### PR TITLE
[NFC] Don't replicate hasKernelCallingConv.

### DIFF
--- a/clang/tools/clang-sycl-linker/ClangSYCLLinker.cpp
+++ b/clang/tools/clang-sycl-linker/ClangSYCLLinker.cpp
@@ -462,14 +462,6 @@ static Error runAOTCompile(StringRef InputFile, StringRef OutputFile,
   return createStringError(inconvertibleErrorCode(), "Unsupported arch");
 }
 
-// TODO: Consider using LLVM-IR metadata to identify globals of interest
-bool isKernel(const Function &F) {
-  const llvm::CallingConv::ID CC = F.getCallingConv();
-  return CC == llvm::CallingConv::SPIR_KERNEL ||
-         CC == llvm::CallingConv::AMDGPU_KERNEL ||
-         CC == llvm::CallingConv::PTX_Kernel;
-}
-
 /// Performs the following steps:
 /// 1. Link input device code (user code and SYCL device library code).
 /// 2. Run SPIR-V code generation.
@@ -500,7 +492,8 @@ Error runSYCLLink(ArrayRef<std::string> Files, const ArgList &Args) {
 
     SmallString<0> SymbolData;
     for (Function &F : **ModOrErr) {
-      if (isKernel(F)) {
+      // TODO: Consider using LLVM-IR metadata to identify globals of interest
+      if (F.hasKernelCallingConv()) {
         SymbolData.append(F.getName());
         SymbolData.push_back('\0');
       }

--- a/llvm/lib/Transforms/Utils/SplitModuleByCategory.cpp
+++ b/llvm/lib/Transforms/Utils/SplitModuleByCategory.cpp
@@ -87,12 +87,6 @@ public:
 #endif
 };
 
-bool isKernel(const Function &F) {
-  return F.getCallingConv() == CallingConv::SPIR_KERNEL ||
-         F.getCallingConv() == CallingConv::AMDGPU_KERNEL ||
-         F.getCallingConv() == CallingConv::PTX_Kernel;
-}
-
 // Represents "dependency" or "use" graph of global objects (functions and
 // global variables) in a module. It is used during code split to
 // understand which global variables and functions (other than entry points)
@@ -125,7 +119,7 @@ public:
         FuncTypeToFuncsMap;
     for (const Function &F : M.functions()) {
       // Kernels can't be called (either directly or indirectly).
-      if (isKernel(F))
+      if (F.hasKernelCallingConv())
         continue;
 
       FuncTypeToFuncsMap[F.getFunctionType()].insert(&F);

--- a/llvm/tools/llvm-split/llvm-split.cpp
+++ b/llvm/tools/llvm-split/llvm-split.cpp
@@ -160,9 +160,7 @@ private:
     if (F.isDeclaration())
       return false;
 
-    return F.getCallingConv() == CallingConv::SPIR_KERNEL ||
-           F.getCallingConv() == CallingConv::AMDGPU_KERNEL ||
-           F.getCallingConv() == CallingConv::PTX_Kernel;
+    return F.hasKernelCallingConv();
   }
 
   static SmallString<0> computeFunctionCategory(SplitByCategoryType Type,


### PR DESCRIPTION
isKernel function duplicates llvm::Function::hasKernelCallingConv
method.