### PR TITLE
[lldb] Wrap LLDBLog Initialize/Terminate in a class (NFC)

### DIFF
--- a/lldb/include/lldb/Utility/LLDBLog.h
+++ b/lldb/include/lldb/Utility/LLDBLog.h
@@ -56,8 +56,11 @@ enum class LLDBLog : Log::MaskType {
 
 LLVM_ENABLE_BITMASK_ENUMS_IN_NAMESPACE();
 
-void InitializeLLDBChannel();
-void TerminateLLDBChannel();
+class LLDBLogChannel {
+public:
+  static void Initialize();
+  static void Terminate();
+};
 
 template <> Log::Channel &LogChannelFor<LLDBLog>();
 } // namespace lldb_private

--- a/lldb/source/Initialization/SystemInitializerCommon.cpp
+++ b/lldb/source/Initialization/SystemInitializerCommon.cpp
@@ -62,8 +62,7 @@ llvm::Error SystemInitializerCommon::Initialize() {
   }
 #endif
 
-  InitializeLLDBChannel();
-
+  LLDBLogChannel::Initialize();
   Diagnostics::Initialize();
   FileSystem::Initialize();
   HostInfo::Initialize();
@@ -99,6 +98,5 @@ void SystemInitializerCommon::Terminate() {
   Log::DisableAllLogChannels();
   FileSystem::Terminate();
   Diagnostics::Terminate();
-
-  TerminateLLDBChannel();
+  LLDBLogChannel::Terminate();
 }

--- a/lldb/source/Utility/LLDBLog.cpp
+++ b/lldb/source/Utility/LLDBLog.cpp
@@ -84,8 +84,6 @@ template <> Log::Channel &lldb_private::LogChannelFor<LLDBLog>() {
   return g_log_channel;
 }
 
-void lldb_private::InitializeLLDBChannel() {
-  Log::Register("lldb", g_log_channel);
-}
+void LLDBLogChannel::Initialize() { Log::Register("lldb", g_log_channel); }
 
-void lldb_private::TerminateLLDBChannel() { Log::Unregister("lldb"); }
+void LLDBLogChannel::Terminate() { Log::Unregister("lldb"); }


### PR DESCRIPTION
This matches what we do for all the other log channels (GDB Remote, POSIX, Windows, KDP, etc).