### PR TITLE
[Orc][LibResolver] Fix GNU/Hurd build

### DIFF
--- a/llvm/lib/ExecutionEngine/Orc/TargetProcess/LibraryScanner.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/TargetProcess/LibraryScanner.cpp
@@ -439,11 +439,9 @@ std::optional<std::string> PathResolver::readlinkCached(StringRef Path) {
     return Cache;
 
   // If result not in cache - call system function and cache result
-  char buf[PATH_MAX];
-  ssize_t len;
-  if ((len = readlink(Path.str().c_str(), buf, sizeof(buf))) != -1) {
-    buf[len] = '\0';
-    std::string s(buf);
+  SmallString<128> Buf;
+  if (!sys::fs::readlink(Path, Buf)) {
+    std::string s(Buf.str());
     LibPathCache->insert_link(Path, s);
     return s;
   }


### PR DESCRIPTION
GNU/Hurd does not put a PATH_MAX static constraint on path lengths. We can instead check the symlink length.