### PR TITLE
[bazel] Fix building lldb with zlib disabled

### DIFF
--- a/utils/bazel/llvm-project-overlay/third-party/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/third-party/BUILD.bazel
@@ -49,7 +49,9 @@ cc_library_wrapper(
         ":llvm_zlib_enabled": [
             "LLVM_ENABLE_ZLIB=1",
         ],
-        "//conditions:default": [],
+        "//conditions:default": [
+            "LLVM_ENABLE_ZLIB=0",
+        ],
     }),
     deps = select({
         ":llvm_zlib_enabled": [

--- a/utils/bazel/third_party_build/zlib-ng.BUILD
+++ b/utils/bazel/third_party_build/zlib-ng.BUILD
@@ -89,7 +89,9 @@ cc_library(
         "@llvm-project//third-party:llvm_zlib_enabled": [
             "LLVM_ENABLE_ZLIB=1",
         ],
-        "//conditions:default": [],
+        "//conditions:default": [
+            "LLVM_ENABLE_ZLIB=0",
+        ],
     }),
     # Clang includes zlib with angled instead of quoted includes, so we need
     # strip_include_prefix here.


### PR DESCRIPTION
In cmake this value is set in llvm-config.h, we're not really handling
that the same way in bazel so we can just allow all targets to inherit
this disabled, otherwise it fails since lldb assumes it is always
something
