### PR TITLE
[LoopUnroll] Remove `computeUnrollCount()`'s return value 

### DIFF
--- a/llvm/include/llvm/Transforms/Utils/UnrollLoop.h
+++ b/llvm/include/llvm/Transforms/Utils/UnrollLoop.h
@@ -124,19 +124,15 @@ LLVM_ABI MDNode *GetUnrollMetadata(MDNode *LoopID, StringRef Name);
 // returned.
 LLVM_ABI MDNode *getUnrollMetadataForLoop(const Loop *L, StringRef Name);
 
-// Returns true if the loop has an unroll(full) pragma.
-LLVM_ABI bool hasUnrollFullPragma(const Loop *L);
-
-// Returns true if the loop has an unroll(enable) pragma. This metadata is used
-// for both "#pragma unroll" and "#pragma clang loop unroll(enable)" directives.
-LLVM_ABI bool hasUnrollEnablePragma(const Loop *L);
-
-// Returns true if the loop has an runtime unroll(disable) pragma.
-LLVM_ABI bool hasRuntimeUnrollDisablePragma(const Loop *L);
-
-// If loop has an unroll_count pragma return the (necessarily
-// positive) value from the pragma.  Otherwise return 0.
-LLVM_ABI unsigned unrollCountPragmaValue(const Loop *L);
+struct UnrollPragmaInfo {
+  UnrollPragmaInfo(const Loop *L);
+  const bool UserUnrollCount;
+  const bool PragmaFullUnroll;
+  const unsigned PragmaCount;
+  const bool PragmaEnableUnroll;
+  const bool PragmaRuntimeUnrollDisable;
+  const bool ExplicitUnroll;
+};
 
 LLVM_ABI TargetTransformInfo::UnrollingPreferences gatherUnrollingPreferences(
     Loop *L, ScalarEvolution &SE, const TargetTransformInfo &TTI,

--- a/llvm/include/llvm/Transforms/Utils/UnrollLoop.h
+++ b/llvm/include/llvm/Transforms/Utils/UnrollLoop.h
@@ -176,7 +176,7 @@ public:
                       unsigned CountOverwrite = 0) const;
 };
 
-LLVM_ABI bool
+LLVM_ABI void
 computeUnrollCount(Loop *L, const TargetTransformInfo &TTI, DominatorTree &DT,
                    LoopInfo *LI, AssumptionCache *AC, ScalarEvolution &SE,
                    const SmallPtrSetImpl<const Value *> &EphValues,

--- a/llvm/lib/Target/AMDGPU/AMDGPUTargetTransformInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUTargetTransformInfo.cpp
@@ -269,11 +269,10 @@ void AMDGPUTTIImpl::getUnrollingPreferences(
     if (L->isInnermost() && BB->size() < UnrollMaxBlockToAnalyze)
       UP.MaxIterationsCountToAnalyze = 32;
   }
-  const unsigned PragmaCount = unrollCountPragmaValue(L);
-  const bool PragmaEnableUnroll = hasUnrollEnablePragma(L);
   // If a user provided an explicit unroll pragma (with or without count),
   // override expensive trip count checks
-  if (PragmaEnableUnroll || PragmaCount > 0)
+  UnrollPragmaInfo PInfo(L);
+  if (PInfo.PragmaEnableUnroll || PInfo.PragmaCount > 0)
     UP.AllowExpensiveTripCount = true;
 }
 

--- a/llvm/lib/Transforms/Scalar/LoopUnrollAndJamPass.cpp
+++ b/llvm/lib/Transforms/Scalar/LoopUnrollAndJamPass.cpp
@@ -153,18 +153,9 @@ static bool computeUnrollAndJamCount(
   // unrolling we leave to the unroller. This uses UP.Threshold /
   // UP.PartialThreshold / UP.MaxCount to come up with sensible loop values.
   // We have already checked that the loop has no unroll.* pragmas.
-  bool ExplicitUnroll =
-      computeUnrollCount(L, TTI, DT, LI, AC, SE, EphValues, ORE, OuterTripCount,
-                         /*MaxTripCount*/ 0, /*MaxOrZero*/ false,
-                         OuterTripMultiple, OuterUCE, UP, PP);
-  if (ExplicitUnroll) {
-    // If the user explicitly set the loop as unrolled, dont UnJ it. Leave it
-    // for the unroller instead.
-    LLVM_DEBUG(dbgs() << "Won't unroll-and-jam; explicit count set by "
-                         "computeUnrollCount\n");
-    UP.Count = 0;
-    return false;
-  }
+  computeUnrollCount(L, TTI, DT, LI, AC, SE, EphValues, ORE, OuterTripCount,
+                     /*MaxTripCount*/ 0, /*MaxOrZero*/ false, OuterTripMultiple,
+                     OuterUCE, UP, PP);
 
   // Override with any explicit Count from the "unroll-and-jam-count" option.
   bool UserUnrollCount = UnrollAndJamCount.getNumOccurrences() > 0;

--- a/llvm/lib/Transforms/Scalar/LoopUnrollPass.cpp
+++ b/llvm/lib/Transforms/Scalar/LoopUnrollPass.cpp
@@ -330,13 +330,12 @@ struct EstimatedUnrollCost {
 };
 
 struct PragmaInfo {
-  PragmaInfo(bool UUC, bool PFU, unsigned PC, bool PEU)
-      : UserUnrollCount(UUC), PragmaFullUnroll(PFU), PragmaCount(PC),
-        PragmaEnableUnroll(PEU) {}
+  PragmaInfo(Loop *L);
   const bool UserUnrollCount;
   const bool PragmaFullUnroll;
   const unsigned PragmaCount;
   const bool PragmaEnableUnroll;
+  const bool ExplicitUnroll;
 };
 
 } // end anonymous namespace
@@ -753,6 +752,54 @@ uint64_t UnrollCostEstimator::getUnrolledLoopSize(
     return static_cast<uint64_t>(LS - UP.BEInsns) * UP.Count + UP.BEInsns;
 }
 
+// Returns the loop hint metadata node with the given name (for example,
+// "llvm.loop.unroll.count").  If no such metadata node exists, then nullptr is
+// returned.
+static MDNode *getUnrollMetadataForLoop(const Loop *L, StringRef Name) {
+  if (MDNode *LoopID = L->getLoopID())
+    return GetUnrollMetadata(LoopID, Name);
+  return nullptr;
+}
+
+// Returns true if the loop has an unroll(full) pragma.
+static bool hasUnrollFullPragma(const Loop *L) {
+  return getUnrollMetadataForLoop(L, "llvm.loop.unroll.full");
+}
+
+// Returns true if the loop has an unroll(enable) pragma. This metadata is used
+// for both "#pragma unroll" and "#pragma clang loop unroll(enable)" directives.
+static bool hasUnrollEnablePragma(const Loop *L) {
+  return getUnrollMetadataForLoop(L, "llvm.loop.unroll.enable");
+}
+
+// Returns true if the loop has an runtime unroll(disable) pragma.
+static bool hasRuntimeUnrollDisablePragma(const Loop *L) {
+  return getUnrollMetadataForLoop(L, "llvm.loop.unroll.runtime.disable");
+}
+
+// If loop has an unroll_count pragma return the (necessarily
+// positive) value from the pragma.  Otherwise return 0.
+static unsigned unrollCountPragmaValue(const Loop *L) {
+  MDNode *MD = getUnrollMetadataForLoop(L, "llvm.loop.unroll.count");
+  if (MD) {
+    assert(MD->getNumOperands() == 2 &&
+           "Unroll count hint metadata should have two operands.");
+    unsigned Count =
+        mdconst::extract<ConstantInt>(MD->getOperand(1))->getZExtValue();
+    assert(Count >= 1 && "Unroll count must be positive.");
+    return Count;
+  }
+  return 0;
+}
+
+PragmaInfo::PragmaInfo(Loop *L)
+    : UserUnrollCount(UnrollCount.getNumOccurrences() > 0),
+      PragmaFullUnroll(hasUnrollFullPragma(L)),
+      PragmaCount(unrollCountPragmaValue(L)),
+      PragmaEnableUnroll(hasUnrollEnablePragma(L)),
+      ExplicitUnroll(PragmaCount > 0 || PragmaFullUnroll ||
+                     PragmaEnableUnroll || UserUnrollCount) {}
+
 // Computes the boosting factor for complete unrolling.
 // If fully unrolling the loop would save a lot of RolledDynamicCost, it would
 // be beneficial to fully unroll the loop even if unrolledcost is large. We
@@ -943,7 +990,6 @@ shouldPartialUnroll(const unsigned LoopSize, const unsigned TripCount,
 
   return count;
 }
-// Returns true if unroll count was set explicitly.
 // Calculates unroll count and writes it to UP.Count.
 // Unless IgnoreUser is true, will also use metadata and command-line options
 // that are specific to the LoopUnroll pass (which, for instance, are
@@ -951,7 +997,7 @@ shouldPartialUnroll(const unsigned LoopSize, const unsigned TripCount,
 // FIXME: This function is used by LoopUnroll and LoopUnrollAndJam, but consumes
 // many LoopUnroll-specific options. The shared functionality should be
 // refactored into it own function.
-bool llvm::computeUnrollCount(Loop *L, const TargetTransformInfo &TTI,
+void llvm::computeUnrollCount(Loop *L, const TargetTransformInfo &TTI,
                               DominatorTree &DT, LoopInfo *LI,
                               AssumptionCache *AC, ScalarEvolution &SE,
                               const SmallPtrSetImpl<const Value *> &EphValues,
@@ -970,31 +1016,22 @@ bool llvm::computeUnrollCount(Loop *L, const TargetTransformInfo &TTI,
                               << (MaxOrZero ? " (MaxOrZero)" : "")
                               << ", TripMultiple=" << TripMultiple << "\n");
 
-  const bool UserUnrollCount = UnrollCount.getNumOccurrences() > 0;
-  const bool PragmaFullUnroll = hasUnrollFullPragma(L);
-  const unsigned PragmaCount = unrollCountPragmaValue(L);
-  const bool PragmaEnableUnroll = hasUnrollEnablePragma(L);
-
-  const bool ExplicitUnroll = PragmaCount > 0 || PragmaFullUnroll ||
-                              PragmaEnableUnroll || UserUnrollCount;
-
+  PragmaInfo PInfo(L);
   LLVM_DEBUG({
-    if (ExplicitUnroll) {
+    if (PInfo.ExplicitUnroll) {
       dbgs().indent(1) << "Explicit unroll requested:";
-      if (UserUnrollCount)
+      if (PInfo.UserUnrollCount)
         dbgs() << " user-count";
-      if (PragmaFullUnroll)
+      if (PInfo.PragmaFullUnroll)
         dbgs() << " pragma-full";
-      if (PragmaCount > 0)
-        dbgs() << " pragma-count(" << PragmaCount << ")";
-      if (PragmaEnableUnroll)
+      if (PInfo.PragmaCount > 0)
+        dbgs() << " pragma-count(" << PInfo.PragmaCount << ")";
+      if (PInfo.PragmaEnableUnroll)
         dbgs() << " pragma-enable";
       dbgs() << "\n";
     }
   });
 
-  PragmaInfo PInfo(UserUnrollCount, PragmaFullUnroll, PragmaCount,
-                   PragmaEnableUnroll);
   // Use an explicit peel count that has been specified for testing. In this
   // case it's not permitted to also specify an explicit unroll count.
   if (PP.PeelCount) {
@@ -1006,7 +1043,7 @@ bool llvm::computeUnrollCount(Loop *L, const TargetTransformInfo &TTI,
                << "Using explicit peel count: " << PP.PeelCount << ".\n");
     UP.Count = 1;
     UP.Runtime = false;
-    return true;
+    return;
   }
   // Check for explicit Count.
   // 1st priority is unroll count set by "unroll-count" option.
@@ -1016,14 +1053,14 @@ bool llvm::computeUnrollCount(Loop *L, const TargetTransformInfo &TTI,
                                              MaxTripCount, UCE, UP)) {
     UP.Count = *UnrollFactor;
 
-    if (UserUnrollCount || (PragmaCount > 0)) {
+    if (PInfo.UserUnrollCount || (PInfo.PragmaCount > 0)) {
       UP.AllowExpensiveTripCount = true;
       UP.Force = true;
     }
-    UP.Runtime |= (PragmaCount > 0);
-    return ExplicitUnroll;
+    UP.Runtime |= (PInfo.PragmaCount > 0);
+    return;
   } else {
-    if (ExplicitUnroll && TripCount != 0) {
+    if (PInfo.ExplicitUnroll && TripCount != 0) {
       // If the loop has an unrolling pragma, we want to be more aggressive with
       // unrolling limits. Set thresholds to at least the PragmaUnrollThreshold
       // value which is larger than the default limits.
@@ -1042,7 +1079,7 @@ bool llvm::computeUnrollCount(Loop *L, const TargetTransformInfo &TTI,
     if (auto UnrollFactor = shouldFullUnroll(L, TTI, DT, SE, EphValues,
                                              TripCount, UCE, UP)) {
       UP.Count = *UnrollFactor;
-      return ExplicitUnroll;
+      return;
     }
   }
 
@@ -1065,7 +1102,7 @@ bool llvm::computeUnrollCount(Loop *L, const TargetTransformInfo &TTI,
     if (auto UnrollFactor = shouldFullUnroll(L, TTI, DT, SE, EphValues,
                                              MaxTripCount, UCE, UP)) {
       UP.Count = *UnrollFactor;
-      return ExplicitUnroll;
+      return;
     }
   }
 
@@ -1077,13 +1114,13 @@ bool llvm::computeUnrollCount(Loop *L, const TargetTransformInfo &TTI,
                << "Peeling with count: " << PP.PeelCount << ".\n");
     UP.Runtime = false;
     UP.Count = 1;
-    return ExplicitUnroll;
+    return;
   }
 
   // Before starting partial unrolling, set up.partial to true,
   // if user explicitly asked  for unrolling
   if (TripCount)
-    UP.Partial |= ExplicitUnroll;
+    UP.Partial |= PInfo.ExplicitUnroll;
 
   // 6th priority is partial unrolling.
   // Try partial unroll only when TripCount could be statically calculated.
@@ -1091,7 +1128,7 @@ bool llvm::computeUnrollCount(Loop *L, const TargetTransformInfo &TTI,
   if (auto UnrollFactor = shouldPartialUnroll(LoopSize, TripCount, UCE, UP)) {
     UP.Count = *UnrollFactor;
 
-    if ((PragmaFullUnroll || PragmaEnableUnroll) && TripCount &&
+    if ((PInfo.PragmaFullUnroll || PInfo.PragmaEnableUnroll) && TripCount &&
         UP.Count != TripCount)
       ORE->emit([&]() {
         return OptimizationRemarkMissed(DEBUG_TYPE,
@@ -1103,7 +1140,7 @@ bool llvm::computeUnrollCount(Loop *L, const TargetTransformInfo &TTI,
 
     if (UP.PartialThreshold != NoThreshold) {
       if (UP.Count == 0) {
-        if (PragmaEnableUnroll)
+        if (PInfo.PragmaEnableUnroll)
           ORE->emit([&]() {
             return OptimizationRemarkMissed(DEBUG_TYPE,
                                             "UnrollAsDirectedTooLarge",
@@ -1114,11 +1151,11 @@ bool llvm::computeUnrollCount(Loop *L, const TargetTransformInfo &TTI,
           });
       }
     }
-    return ExplicitUnroll;
+    return;
   }
   assert(TripCount == 0 &&
          "All cases when TripCount is constant should be covered here.");
-  if (PragmaFullUnroll)
+  if (PInfo.PragmaFullUnroll)
     ORE->emit([&]() {
       return OptimizationRemarkMissed(
                  DEBUG_TYPE, "CantFullUnrollAsDirectedRuntimeTripCount",
@@ -1135,7 +1172,7 @@ bool llvm::computeUnrollCount(Loop *L, const TargetTransformInfo &TTI,
     LLVM_DEBUG(dbgs().indent(2)
                << "Not runtime unrolling: disabled by pragma.\n");
     UP.Count = 0;
-    return false;
+    return;
   }
 
   // Don't unroll a small upper bound loop unless user or TTI asked to do so.
@@ -1144,25 +1181,26 @@ bool llvm::computeUnrollCount(Loop *L, const TargetTransformInfo &TTI,
                << "Not runtime unrolling: max trip count " << MaxTripCount
                << " is small (< " << UP.MaxUpperBound << ") and not forced.\n");
     UP.Count = 0;
-    return false;
+    return;
   }
 
   // Check if the runtime trip count is too small when profile is available.
   if (L->getHeader()->getParent()->hasProfileData()) {
     if (auto ProfileTripCount = getLoopEstimatedTripCount(L)) {
       if (*ProfileTripCount < FlatLoopTripCountThreshold)
-        return false;
+        return;
       else
         UP.AllowExpensiveTripCount = true;
     }
   }
-  UP.Runtime |= PragmaEnableUnroll || PragmaCount > 0 || UserUnrollCount;
+  UP.Runtime |= PInfo.PragmaEnableUnroll || PInfo.PragmaCount > 0 ||
+                PInfo.UserUnrollCount;
   if (!UP.Runtime) {
     LLVM_DEBUG(dbgs().indent(2)
                << "Will not try to unroll loop with runtime trip count "
                << "because -unroll-runtime not given\n");
     UP.Count = 0;
-    return false;
+    return;
   }
   if (UP.Count == 0)
     UP.Count = UP.DefaultUnrollRuntimeCount;
@@ -1190,7 +1228,7 @@ bool llvm::computeUnrollCount(Loop *L, const TargetTransformInfo &TTI,
 
     using namespace ore;
 
-    if (PragmaCount > 0 && !UP.AllowRemainder)
+    if (PInfo.PragmaCount > 0 && !UP.AllowRemainder)
       ORE->emit([&]() {
         return OptimizationRemarkMissed(DEBUG_TYPE,
                                         "DifferentUnrollCountFromDirected",
@@ -1215,7 +1253,7 @@ bool llvm::computeUnrollCount(Loop *L, const TargetTransformInfo &TTI,
              << "Runtime unrolling with count: " << UP.Count << "\n");
   if (UP.Count < 2)
     UP.Count = 0;
-  return ExplicitUnroll;
+  return;
 }
 
 static LoopUnrollResult
@@ -1366,9 +1404,8 @@ tryToUnrollLoop(Loop *L, DominatorTree &DT, LoopInfo *LI, ScalarEvolution &SE,
 
   // computeUnrollCount() decides whether it is beneficial to use upper bound to
   // fully unroll the loop.
-  bool IsCountSetExplicitly =
-      computeUnrollCount(L, TTI, DT, LI, &AC, SE, EphValues, &ORE, TripCount,
-                         MaxTripCount, MaxOrZero, TripMultiple, UCE, UP, PP);
+  computeUnrollCount(L, TTI, DT, LI, &AC, SE, EphValues, &ORE, TripCount,
+                     MaxTripCount, MaxOrZero, TripMultiple, UCE, UP, PP);
   if (!UP.Count) {
     LLVM_DEBUG(dbgs().indent(1)
                << "Not unrolling: no viable strategy found.\n");
@@ -1458,7 +1495,8 @@ tryToUnrollLoop(Loop *L, DominatorTree &DT, LoopInfo *LI, ScalarEvolution &SE,
 
   // If loop has an unroll count pragma or unrolled by explicitly set count
   // mark loop as unrolled to prevent unrolling beyond that requested.
-  if (UnrollResult != LoopUnrollResult::FullyUnrolled && IsCountSetExplicitly)
+  if (UnrollResult != LoopUnrollResult::FullyUnrolled &&
+      PragmaInfo(L).ExplicitUnroll)
     L->setLoopAlreadyUnrolled();
 
   return UnrollResult;

--- a/llvm/lib/Transforms/Scalar/LoopUnrollPass.cpp
+++ b/llvm/lib/Transforms/Scalar/LoopUnrollPass.cpp
@@ -330,7 +330,7 @@ struct EstimatedUnrollCost {
 };
 
 struct PragmaInfo {
-  PragmaInfo(Loop *L);
+  PragmaInfo(const Loop *L);
   const bool UserUnrollCount;
   const bool PragmaFullUnroll;
   const unsigned PragmaCount;
@@ -792,7 +792,7 @@ static unsigned unrollCountPragmaValue(const Loop *L) {
   return 0;
 }
 
-PragmaInfo::PragmaInfo(Loop *L)
+PragmaInfo::PragmaInfo(const Loop *L)
     : UserUnrollCount(UnrollCount.getNumOccurrences() > 0),
       PragmaFullUnroll(hasUnrollFullPragma(L)),
       PragmaCount(unrollCountPragmaValue(L)),

--- a/llvm/lib/Transforms/Scalar/LoopUnrollPass.cpp
+++ b/llvm/lib/Transforms/Scalar/LoopUnrollPass.cpp
@@ -329,15 +329,6 @@ struct EstimatedUnrollCost {
   unsigned RolledDynamicCost;
 };
 
-struct PragmaInfo {
-  PragmaInfo(const Loop *L);
-  const bool UserUnrollCount;
-  const bool PragmaFullUnroll;
-  const unsigned PragmaCount;
-  const bool PragmaEnableUnroll;
-  const bool ExplicitUnroll;
-};
-
 } // end anonymous namespace
 
 /// Figure out if the loop is worth full unrolling.
@@ -752,15 +743,6 @@ uint64_t UnrollCostEstimator::getUnrolledLoopSize(
     return static_cast<uint64_t>(LS - UP.BEInsns) * UP.Count + UP.BEInsns;
 }
 
-// Returns the loop hint metadata node with the given name (for example,
-// "llvm.loop.unroll.count").  If no such metadata node exists, then nullptr is
-// returned.
-static MDNode *getUnrollMetadataForLoop(const Loop *L, StringRef Name) {
-  if (MDNode *LoopID = L->getLoopID())
-    return GetUnrollMetadata(LoopID, Name);
-  return nullptr;
-}
-
 // Returns true if the loop has an unroll(full) pragma.
 static bool hasUnrollFullPragma(const Loop *L) {
   return getUnrollMetadataForLoop(L, "llvm.loop.unroll.full");
@@ -792,11 +774,12 @@ static unsigned unrollCountPragmaValue(const Loop *L) {
   return 0;
 }
 
-PragmaInfo::PragmaInfo(const Loop *L)
+UnrollPragmaInfo::UnrollPragmaInfo(const Loop *L)
     : UserUnrollCount(UnrollCount.getNumOccurrences() > 0),
       PragmaFullUnroll(hasUnrollFullPragma(L)),
       PragmaCount(unrollCountPragmaValue(L)),
       PragmaEnableUnroll(hasUnrollEnablePragma(L)),
+      PragmaRuntimeUnrollDisable(hasRuntimeUnrollDisablePragma(L)),
       ExplicitUnroll(PragmaCount > 0 || PragmaFullUnroll ||
                      PragmaEnableUnroll || UserUnrollCount) {}
 
@@ -818,7 +801,7 @@ static unsigned getFullUnrollBoostingFactor(const EstimatedUnrollCost &Cost,
 }
 
 static std::optional<unsigned>
-shouldPragmaUnroll(Loop *L, const PragmaInfo &PInfo,
+shouldPragmaUnroll(Loop *L, const UnrollPragmaInfo &PInfo,
                    const unsigned TripMultiple, const unsigned TripCount,
                    unsigned MaxTripCount, const UnrollCostEstimator UCE,
                    const TargetTransformInfo::UnrollingPreferences &UP) {
@@ -1016,7 +999,7 @@ void llvm::computeUnrollCount(Loop *L, const TargetTransformInfo &TTI,
                               << (MaxOrZero ? " (MaxOrZero)" : "")
                               << ", TripMultiple=" << TripMultiple << "\n");
 
-  PragmaInfo PInfo(L);
+  UnrollPragmaInfo PInfo(L);
   LLVM_DEBUG({
     if (PInfo.ExplicitUnroll) {
       dbgs().indent(1) << "Explicit unroll requested:";
@@ -1168,7 +1151,7 @@ void llvm::computeUnrollCount(Loop *L, const TargetTransformInfo &TTI,
   // 7th priority is runtime unrolling.
   LLVM_DEBUG(dbgs().indent(1) << "Trying runtime unroll...\n");
   // Don't unroll a runtime trip count loop when it is disabled.
-  if (hasRuntimeUnrollDisablePragma(L)) {
+  if (PInfo.PragmaRuntimeUnrollDisable) {
     LLVM_DEBUG(dbgs().indent(2)
                << "Not runtime unrolling: disabled by pragma.\n");
     UP.Count = 0;
@@ -1496,7 +1479,7 @@ tryToUnrollLoop(Loop *L, DominatorTree &DT, LoopInfo *LI, ScalarEvolution &SE,
   // If loop has an unroll count pragma or unrolled by explicitly set count
   // mark loop as unrolled to prevent unrolling beyond that requested.
   if (UnrollResult != LoopUnrollResult::FullyUnrolled &&
-      PragmaInfo(L).ExplicitUnroll)
+      UnrollPragmaInfo(L).ExplicitUnroll)
     L->setLoopAlreadyUnrolled();
 
   return UnrollResult;

--- a/llvm/lib/Transforms/Utils/LoopUnroll.cpp
+++ b/llvm/lib/Transforms/Utils/LoopUnroll.cpp
@@ -1261,37 +1261,6 @@ MDNode *llvm::getUnrollMetadataForLoop(const Loop *L, StringRef Name) {
   return nullptr;
 }
 
-// Returns true if the loop has an unroll(full) pragma.
-bool llvm::hasUnrollFullPragma(const Loop *L) {
-  return getUnrollMetadataForLoop(L, "llvm.loop.unroll.full");
-}
-
-// Returns true if the loop has an unroll(enable) pragma. This metadata is used
-// for both "#pragma unroll" and "#pragma clang loop unroll(enable)" directives.
-bool llvm::hasUnrollEnablePragma(const Loop *L) {
-  return getUnrollMetadataForLoop(L, "llvm.loop.unroll.enable");
-}
-
-// Returns true if the loop has an runtime unroll(disable) pragma.
-bool llvm::hasRuntimeUnrollDisablePragma(const Loop *L) {
-  return getUnrollMetadataForLoop(L, "llvm.loop.unroll.runtime.disable");
-}
-
-// If loop has an unroll_count pragma return the (necessarily
-// positive) value from the pragma.  Otherwise return 0.
-unsigned llvm::unrollCountPragmaValue(const Loop *L) {
-  MDNode *MD = getUnrollMetadataForLoop(L, "llvm.loop.unroll.count");
-  if (MD) {
-    assert(MD->getNumOperands() == 2 &&
-           "Unroll count hint metadata should have two operands.");
-    unsigned Count =
-        mdconst::extract<ConstantInt>(MD->getOperand(1))->getZExtValue();
-    assert(Count >= 1 && "Unroll count must be positive.");
-    return Count;
-  }
-  return 0;
-}
-
 std::optional<RecurrenceDescriptor>
 llvm::canParallelizeReductionWhenUnrolling(PHINode &Phi, Loop *L,
                                            ScalarEvolution *SE) {


### PR DESCRIPTION
`computeUnrollCount()`'s return value is used to communicate whether unrolling was explicitly requested. However, each of `computeUnrollCount()`'s two callers can compute this directly:

 - `LoopUnrollAndJamPass` already checks for loop unrolling metadata [before calling `computeUnrollCount()`](https://github.com/llvm/llvm-project/blob/43dbcdea98f5bb04ae967bdd81ece2d2144f4661/llvm/lib/Transforms/Scalar/LoopUnrollAndJamPass.cpp#L308). The return value only added handling for `-unroll-count`, a testing flag with no UnrollAndJam test coverage.

 - `tryToUnrollLoop()` can use `PragmaInfo(L).ExplicitUnroll` directly at the `setLoopAlreadyUnrolled()` call site. 
   - In all but one case where `computeUnrollCount()` explicitly `return`s `false` instead of `ExplicitUnroll`, `UP.Count = 0` is set. This causes `tryToUnrollLoop()` to early-exit before reaching `setLoopAlreadyUnrolled`. 
   - The remaining case that `return`s false, but does not set `UP.Count = 0` [seems to be a bug](https://github.com/llvm/llvm-project/pull/184529#discussion_r2893041263). I'm in the process of addressing that with #185979.
   - On all remaining paths, the return value is equivalent to `UnrollPragmaInfo(L).ExplicitUnroll`.

IMHO, this is a small step toward simplifying the loop-unrolling heuristics by making `computeUnrollCount()` slightly easier to read. 