### PR TITLE
[clang][modules] -Wmodule-import-in-extern-c should not be an error by default

### DIFF
--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -12722,8 +12722,7 @@ def note_unreachable_entity : Note<
   "is not %select{visible|reachable|reachable|reachable|reachable|reachable}0">;
 def ext_module_import_in_extern_c : ExtWarn<
   "import of C++ module '%0' appears within extern \"C\" language linkage "
-  "specification">, DefaultError,
-  InGroup<DiagGroup<"module-import-in-extern-c">>;
+  "specification">, InGroup<DiagGroup<"module-import-in-extern-c">>;
 def err_module_import_not_at_top_level_fatal : Error<
   "import of module '%0' appears within %1">, DefaultFatal;
 def ext_module_import_not_at_top_level_noop : ExtWarn<

--- a/clang/test/Modules/auto-module-import.m
+++ b/clang/test/Modules/auto-module-import.m
@@ -96,6 +96,6 @@ namespace NS { // expected-note {{begins here}}
 }
 extern "C" { // expected-note {{begins here}}
 #include <NoUmbrella/A.h> // expected-remark {{treating #include as an import}} \
-                             expected-error {{import of C++ module 'NoUmbrella.A' appears within extern "C"}}
+                             expected-warning {{import of C++ module 'NoUmbrella.A' appears within extern "C"}}
 }
 #endif

--- a/clang/test/Modules/extern_c.cpp
+++ b/clang/test/Modules/extern_c.cpp
@@ -42,7 +42,7 @@ extern "C++" {
 // expected-error-re@-3 {{import of module '{{c_library.inner|cxx_library}}' appears within namespace 'M'}}
 // expected-note@-21 {{namespace 'M' begins here}}
 #elif defined(EXTERN_C) && !defined(EXTERN_CXX) && defined(CXX_HEADER) && !defined(NO_EXTERN_C_ERROR)
-// expected-error@-6 {{import of C++ module 'cxx_library' appears within extern "C" language linkage specification}}
+// expected-warning@-6 {{import of C++ module 'cxx_library' appears within extern "C" language linkage specification}}
 // expected-note@-20 {{extern "C" language linkage specification begins here}}
 #endif
 


### PR DESCRIPTION
Importing a module inside of an `extern "C" {...}` section doesn't have any effect, i.e. the imported module is not treated as `extern "C"`, it's built independent of the includer state. The warning is akin to `-Wconfig-macros`, it's trying to say that the behavior will be different (and unexpected) when compiling with modules. That doesn't need to be an error, a warning is enough. As an error, it makes it difficult to support and test modules in C++ mode while dependencies still have includes in `extern "C" {...}`.

 rdar://171677028