### PR TITLE
[third-party] Fix benchmark build error with Clang 22

### DIFF
--- a/third-party/benchmark/include/benchmark/benchmark.h
+++ b/third-party/benchmark/include/benchmark/benchmark.h
@@ -1495,6 +1495,7 @@ BENCHMARK_RESTORE_PEDANTIC_WARNING
   BaseClass##_##Method##_Benchmark
 
 #define BENCHMARK_PRIVATE_DECLARE(n)                                 \
+  BENCHMARK_DISABLE_PEDANTIC_WARNING                                 \
   static ::benchmark::internal::Benchmark* BENCHMARK_PRIVATE_NAME(n) \
       BENCHMARK_UNUSED
 
@@ -1503,12 +1504,14 @@ BENCHMARK_RESTORE_PEDANTIC_WARNING
   BENCHMARK_PRIVATE_DECLARE(_benchmark_) =                           \
       (::benchmark::internal::RegisterBenchmarkInternal(             \
           new ::benchmark::internal::FunctionBenchmark(#__VA_ARGS__, \
-                                                       __VA_ARGS__)))
+                                                       __VA_ARGS__))) \
+  BENCHMARK_RESTORE_PEDANTIC_WARNING
 #else
 #define BENCHMARK(n)                                     \
   BENCHMARK_PRIVATE_DECLARE(n) =                         \
       (::benchmark::internal::RegisterBenchmarkInternal( \
-          new ::benchmark::internal::FunctionBenchmark(#n, n)))
+          new ::benchmark::internal::FunctionBenchmark(#n, n))) \
+  BENCHMARK_RESTORE_PEDANTIC_WARNING
 #endif  // BENCHMARK_HAS_CXX11
 
 // Old-style macros


### PR DESCRIPTION
While running CI, I noticed a build failure:

```log
llvm-project/clang-tools-extra/clangd/benchmarks/IndexBenchmark.cpp:92:1: error: '__COUNTER__' is a C2y extension [-Werror,-Wc2y-extensions]
```

Related link: https://github.com/llvm/llvm-project/pull/184015#issuecomment-3994435400

While `benchmark.h` already had some suppression logic, it didn't cover the macro expansion at call sites.
This patch ensures `IndexBenchmark.cpp` build successfully when compiled with `-pedantic` and `-Werror`.