### PR TITLE
[bazel] Fix more parse_headers cases in lldb

### DIFF
--- a/utils/bazel/llvm-project-overlay/lldb/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/lldb/BUILD.bazel
@@ -361,25 +361,32 @@ gentbl_cc_library(
 cc_library(
     name = "APIHeaders",
     hdrs = glob(["include/lldb/API/**/*.h"]),
+    features = ["-parse_headers"],  # Would otherwise have circular dependencies
     includes = ["include"],
 )
 
 cc_library(
     name = "InterpreterHeaders",
     hdrs = glob(["include/lldb/Interpreter/**/*.h"]),
+    features = ["-parse_headers"],  # Would otherwise have circular dependencies
     includes = ["include"],
-    deps = [":APIHeaders"],
+    deps = [
+        ":APIHeaders",
+        ":Headers",
+    ],
 )
 
 cc_library(
     name = "BreakpointHeaders",
     hdrs = glob(["include/lldb/Breakpoint/**/*.h"]),
+    features = ["-parse_headers"],  # Would otherwise have circular dependencies
     includes = ["include"],
 )
 
 cc_library(
     name = "ExpressionHeaders",
     hdrs = glob(["include/lldb/Expression/**/*.h"]) + [":lldb-sbapi-dwarf-enums"],
+    features = ["-parse_headers"],  # Would otherwise have circular dependencies
     includes = ["include"],
     deps = ["//llvm:ExecutionEngine"],
 )
@@ -387,8 +394,12 @@ cc_library(
 cc_library(
     name = "DataFormattersHeaders",
     hdrs = glob(["include/lldb/DataFormatters/**/*.h"]),
+    features = ["-parse_headers"],  # Would otherwise have circular dependencies
     includes = ["include"],
     textual_hdrs = glob(["include/lldb/DataFormatters/**/*.def"]),
+    deps = [
+        ":Headers",
+    ],
 )
 
 cc_library(
@@ -455,6 +466,7 @@ cc_library(
 cc_library(
     name = "SymbolHeaders",
     hdrs = glob(["include/lldb/Symbol/**/*.h"]),
+    features = ["-parse_headers"],  # Would otherwise have circular dependencies
     includes = ["include"],
 )
 
@@ -485,6 +497,7 @@ cc_library(
         "include/lldb/Host/macosx/*.h",
         "include/lldb/Host/posix/*.h",
     ]),
+    features = ["-parse_headers"],  # Would otherwise have circular dependencies
     includes = ["include"],
     deps = [":UtilityHeaders"],
 )
@@ -632,20 +645,24 @@ cc_library(
         "include/lldb/Core/**/*.h",
         "include/lldb/ValueObject/**/*.h",  # This should be its own library.
     ]),
+    features = ["-parse_headers"],  # Would otherwise have circular dependencies
     includes = ["include"],
     deps = [
         ":BreakpointHeaders",
         ":CoreProperties",
         ":DataFormattersHeaders",
         ":ExpressionHeaders",
+        ":Headers",
         ":Host",
         ":InterpreterHeaders",
         ":SymbolHeaders",
         ":TargetHeaders",
+        ":UtilityHeaders",
         "//clang:driver",
         "//llvm:Demangle",
         "//llvm:Support",
         "//llvm:TargetParser",
+        "//llvm:Telemetry",
     ],
 )
 
@@ -710,6 +727,7 @@ cc_library(
 cc_library(
     name = "TargetHeaders",
     hdrs = glob(["include/lldb/Target/**/*.h"]),
+    features = ["-parse_headers"],  # Would otherwise have circular dependencies
     includes = ["include"],
     deps = [
         ":AppleArm64ExceptionClass",
@@ -746,12 +764,17 @@ cc_library(
     hdrs = glob(["include/lldb/lldb-*.h"]) + [
         "include/lldb/Symbol/SaveCoreOptions.h",
     ],
+    features = ["-parse_headers"],  # Would otherwise have circular dependencies
     includes = ["include"],
+    deps = [
+        "//llvm:Support",
+    ],
 )
 
 cc_library(
     name = "UtilityPrivateHeaders",
     hdrs = glob(["source/Utility/**/*.h"]),
+    features = ["-parse_headers"],  # Would otherwise have circular dependencies
     includes = ["source"],
     deps = [":Headers"],
 )
@@ -759,12 +782,17 @@ cc_library(
 cc_library(
     name = "UtilityHeaders",
     hdrs = glob(["include/lldb/Utility/**/*.h"]),
+    features = ["-parse_headers"],  # Would otherwise have circular dependencies
     includes = ["include"],
+    deps = [
+        ":Headers",
+    ],
 )
 
 cc_library(
     name = "ProtocolHeaders",
     hdrs = glob(["include/lldb/Protocol/**/*.h"]),
+    features = ["-parse_headers"],  # Would otherwise have circular dependencies
     includes = ["include"],
     deps = [
         ":Headers",
@@ -899,12 +927,22 @@ cc_library(
     name = "DebugServerCommonMacOSXHeaders",
     hdrs = glob(["tools/debugserver/source/MacOSX/**/*.h"]),
     strip_include_prefix = "tools/debugserver/source/MacOSX",
+    tags = ["nobuildkite"],
+    target_compatible_with = select({
+        "@platforms//os:macos": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }),
 )
 
 cc_library(
     name = "DebugServerCommonHeaders",
     hdrs = glob(["tools/debugserver/source/**/*.h"]),
     strip_include_prefix = "tools/debugserver/source",
+    tags = ["nobuildkite"],
+    target_compatible_with = select({
+        "@platforms//os:macos": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }),
     deps = [":DebugServerCommonMacOSXHeaders"],
 )
 

--- a/utils/bazel/llvm-project-overlay/lldb/source/Plugins/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/lldb/source/Plugins/BUILD.bazel
@@ -43,6 +43,7 @@ cc_library(
 cc_library(
     name = "PluginObjCLanguageHeaders",
     hdrs = glob(["Language/ObjC/*.h"]),
+    features = ["-parse_headers"],  # Would otherwise have circular dependencies
     includes = [".."],
     deps = [
         ":PluginExpressionParserClangHeaders",
@@ -80,8 +81,16 @@ cc_library(
     includes = [".."],
     deps = [
         ":PluginExpressionParserClangHeaders",
+        "//clang:ast",
+        "//clang:basic",
         "//clang:frontend",
         "//lldb:CoreHeaders",
+        "//lldb:ExpressionHeaders",
+        "//lldb:Headers",
+        "//lldb:SymbolHeaders",
+        "//lldb:TargetHeaders",
+        "//lldb:UtilityHeaders",
+        "//llvm:Support",
     ],
 )
 
@@ -192,6 +201,7 @@ cc_library(
 cc_library(
     name = "PluginExpressionParserClangHeaders",
     hdrs = glob(["ExpressionParser/Clang/*.h"]),
+    features = ["-parse_headers"],  # Would otherwise have circular dependencies
     includes = [".."],
     deps = [
         "//lldb:CoreHeaders",
@@ -295,6 +305,7 @@ cc_library(
                "//conditions:default": [],
            }),
     hdrs = glob(["Platform/MacOSX/*.h"]),
+    features = ["-parse_headers"],  # TODO: Attempt to fix in a way that works cross platform
     includes = [".."],
     tags = ["nobuildkite"],
     deps = [
@@ -338,6 +349,7 @@ gentbl_cc_library(
 cc_library(
     name = "PluginSymbolFileDWARFHeaders",
     hdrs = glob(["SymbolFile/DWARF/*.h"]),
+    features = ["-parse_headers"],  # Would otherwise have circular dependencies
     includes = [".."],
     deps = [
         ":PluginTypeSystemClangHeaders",
@@ -413,7 +425,18 @@ cc_library(
     name = "PluginSymbolFileNativePDBHeaders",
     hdrs = glob(["SymbolFile/NativePDB/*.h"]),
     includes = [".."],
-    deps = ["//lldb:Core"],
+    deps = [
+        ":PluginExpressionParserClangHeaders",
+        "//lldb:Core",
+        "//lldb:ExpressionHeaders",
+        "//lldb:Headers",
+        "//lldb:SymbolHeaders",
+        "//lldb:UtilityHeaders",
+        "//llvm:DebugInfoCodeView",
+        "//llvm:DebugInfoPDB",
+        "//llvm:Support",
+        "//llvm:TargetParser",
+    ],
 )
 
 cc_library(
@@ -446,7 +469,16 @@ cc_library(
     name = "PluginSymbolFilePDBHeaders",
     hdrs = glob(["SymbolFile/PDB/*.h"]),
     includes = [".."],
-    deps = ["//lldb:Core"],
+    deps = [
+        ":PluginExpressionParserClangHeaders",
+        "//lldb:Core",
+        "//lldb:Headers",
+        "//lldb:SymbolHeaders",
+        "//lldb:TargetHeaders",
+        "//lldb:UtilityHeaders",
+        "//llvm:DebugInfoPDB",
+        "//llvm:Support",
+    ],
 )
 
 gentbl_cc_library(
@@ -907,7 +939,13 @@ cc_library(
     deps = [
         ":PluginExpressionParserClangHeaders",
         ":PluginHighlighterClang",
+        "//clang:lex",
         "//lldb:CoreHeaders",
+        "//lldb:DataFormatters",
+        "//lldb:Headers",
+        "//lldb:TargetHeaders",
+        "//lldb:UtilityHeaders",
+        "//llvm:Support",
     ],
 )
 
@@ -1177,6 +1215,7 @@ cc_library(
 cc_library(
     name = "PluginDynamicLoaderPosixDYLDHeaders",
     hdrs = glob(["DynamicLoader/POSIX-DYLD/*.h"]),
+    features = ["-parse_headers"],  # Would otherwise have circular dependencies
     includes = [".."],
 )
 
@@ -1301,6 +1340,7 @@ gentbl_cc_library(
 cc_library(
     name = "PluginDynamicLoaderDarwinKernelHeaders",
     hdrs = glob(["DynamicLoader/Darwin-Kernel/*.h"]),
+    features = ["-parse_headers"],  # Would otherwise have circular dependencies
     includes = [".."],
 )
 


### PR DESCRIPTION
CI doesn't have a toolchain that supports this so we don't validate this
there, but locally this fixes some issues if you're using a toolchain
that does. Mostly since lldb has a bunch of circular deps we just have
to disable it for the header only targets we create to avoid those
circular deps.
