### PR TITLE
[Hexagon] Fix B0 macro conflict between hexagon_types.h and termios.h

### DIFF
--- a/clang/lib/Headers/hexagon_types.h
+++ b/clang/lib/Headers/hexagon_types.h
@@ -11,6 +11,11 @@
 
 #include <hexagon_protos.h>
 
+// Save and undefine B0 to avoid conflicts with POSIX termios.h which
+// defines B0 as a macro for baud rate 0.
+#pragma push_macro("B0")
+#undef B0
+
 /* Hexagon names */
 #define HEXAGON_Vect HEXAGON_Vect64
 #define HEXAGON_V_GET_D HEXAGON_V64_GET_D
@@ -697,9 +702,8 @@ public:
   };
 
   // Extract byte methods
-  signed char B0(void) {
-    return HEXAGON_V64_GET_B0(data);
-  };
+  signed char b0(void) { return HEXAGON_V64_GET_B0(data); };
+  signed char B0(void) { return b0(); };
   signed char B1(void) {
     return HEXAGON_V64_GET_B1(data);
   };
@@ -776,9 +780,10 @@ public:
   };
 
   // Set byte methods
-  HEXAGON_Vect64C B0(signed char b) {
+  HEXAGON_Vect64C b0(signed char b) {
     return HEXAGON_Vect64C(HEXAGON_V64_PUT_B0(data, b));
   };
+  HEXAGON_Vect64C B0(signed char b) { return b0(b); };
   HEXAGON_Vect64C B1(signed char b) {
     return HEXAGON_Vect64C(HEXAGON_V64_PUT_B1(data, b));
   };
@@ -1121,9 +1126,8 @@ public:
   };
 
   // Extract byte methods
-  signed char B0(void) {
-    return HEXAGON_V32_GET_B0(data);
-  };
+  signed char b0(void) { return HEXAGON_V32_GET_B0(data); };
+  signed char B0(void) { return b0(); };
   signed char B1(void) {
     return HEXAGON_V32_GET_B1(data);
   };
@@ -1162,9 +1166,10 @@ public:
   };
 
   // Set byte methods
-  HEXAGON_Vect32C B0(signed char b) {
+  HEXAGON_Vect32C b0(signed char b) {
     return HEXAGON_Vect32C(HEXAGON_V32_PUT_B0(data, b));
   };
+  HEXAGON_Vect32C B0(signed char b) { return b0(b); };
   HEXAGON_Vect32C B1(signed char b) {
     return HEXAGON_Vect32C(HEXAGON_V32_PUT_B1(data, b));
   };
@@ -1924,9 +1929,8 @@ public:
   };
 
   // Extract byte methods
-  signed char B0(void) {
-    return Q6V64_GET_B0(data);
-  };
+  signed char b0(void) { return Q6V64_GET_B0(data); };
+  signed char B0(void) { return b0(); };
   signed char B1(void) {
     return Q6V64_GET_B1(data);
   };
@@ -2003,9 +2007,8 @@ public:
   };
 
   // Set byte methods
-  Q6Vect64C B0(signed char b) {
-    return Q6Vect64C(Q6V64_PUT_B0(data, b));
-  };
+  Q6Vect64C b0(signed char b) { return Q6Vect64C(Q6V64_PUT_B0(data, b)); };
+  Q6Vect64C B0(signed char b) { return b0(b); };
   Q6Vect64C B1(signed char b) {
     return Q6Vect64C(Q6V64_PUT_B1(data, b));
   };
@@ -2348,9 +2351,8 @@ public:
   };
 
   // Extract byte methods
-  signed char B0(void) {
-    return Q6V32_GET_B0(data);
-  };
+  signed char b0(void) { return Q6V32_GET_B0(data); };
+  signed char B0(void) { return b0(); };
   signed char B1(void) {
     return Q6V32_GET_B1(data);
   };
@@ -2389,9 +2391,8 @@ public:
   };
 
   // Set byte methods
-  Q6Vect32C B0(signed char b) {
-    return Q6Vect32C(Q6V32_PUT_B0(data, b));
-  };
+  Q6Vect32C b0(signed char b) { return Q6Vect32C(Q6V32_PUT_B0(data, b)); };
+  Q6Vect32C B0(signed char b) { return b0(b); };
   Q6Vect32C B1(signed char b) {
     return Q6Vect32C(Q6V32_PUT_B1(data, b));
   };
@@ -2621,5 +2622,7 @@ typedef struct hexagon_udma_descriptor_type1_s
     unsigned int srcwidthoffset:16;
     unsigned int dstwidthoffset:16;
 } hexagon_udma_descriptor_type1_t;
+
+#pragma pop_macro("B0")
 
 #endif /* !HEXAGON_TYPES_H */

--- a/clang/test/Headers/hexagon-types-b0-conflict.c
+++ b/clang/test/Headers/hexagon-types-b0-conflict.c
@@ -1,0 +1,38 @@
+// REQUIRES: hexagon-registered-target
+
+// Verify that hexagon_types.h can be included after a B0 macro definition
+// without conflicts, that B0 is restored afterward, and that the
+// lowercase b0() alias is usable even while B0 is still a macro.
+
+// RUN: %clang_cc1 -fsyntax-only -internal-isystem %S/../../lib/Headers/ \
+// RUN:   -target-cpu hexagonv68 -triple hexagon-unknown-linux-musl \
+// RUN:   -verify %s
+
+// RUN: %clang_cc1 -fsyntax-only -internal-isystem %S/../../lib/Headers/ \
+// RUN:   -target-cpu hexagonv68 -triple hexagon-unknown-linux-musl \
+// RUN:   -x c++ -verify %s
+
+// expected-no-diagnostics
+
+// Simulate the POSIX termios.h B0 macro definition.
+#define B0 0000000
+
+#include <hexagon_types.h>
+
+// Verify B0 is restored after including hexagon_types.h.
+#ifndef B0
+#error "B0 should be defined after including hexagon_types.h"
+#endif
+
+_Static_assert(B0 == 0, "B0 should still be 0 after including hexagon_types.h");
+
+// In C++ mode, verify the lowercase b0() alias works even with B0 defined.
+#ifdef __cplusplus
+void test_b0_alias(void) {
+  HEXAGON_Vect64C v(0x0807060504030201LL);
+  signed char got = v.b0();
+  (void)got;
+  HEXAGON_Vect64C v2 = v.b0(0x42);
+  (void)v2;
+}
+#endif


### PR DESCRIPTION
POSIX termios.h defines `#define B0 0000000` for baud rate 0. This conflicts with the B0() member functions in hexagon_types.h vector classes, causing compilation failures when both headers are included.

Use #pragma push_macro/pop_macro to save, undefine, and restore B0 around the class definitions so the header is safe to use alongside termios.h without losing the macro afterward.

Fixes #183815