### PR TITLE
Reapply "[llvm][clang] Enable IO sandbox for assert builds"

### DIFF
--- a/llvm/CMakeLists.txt
+++ b/llvm/CMakeLists.txt
@@ -700,7 +700,7 @@ else()
   option(LLVM_ENABLE_ASSERTIONS "Enable assertions" ON)
 endif()
 
-option(LLVM_ENABLE_IO_SANDBOX "Enable IO sandboxing in supported tools" OFF)
+option(LLVM_ENABLE_IO_SANDBOX "Enable IO sandboxing in supported tools" ${LLVM_ENABLE_ASSERTIONS})
 option(LLVM_ENABLE_EXPENSIVE_CHECKS "Enable expensive checks" OFF)
 
 set(LLVM_ABI_BREAKING_CHECKS "WITH_ASSERTS" CACHE STRING


### PR DESCRIPTION
This reverts #173074 and essentially reapplies #171935. The main reason for the revert was an omission where we were not sandboxing direct clang -cc1 invocations in our test suite, leading to sandbox violations reported by Clang users. This was rectified in #174653 after a number of patches fixing found sandbox violations.

RFC: https://discourse.llvm.org/t/rfc-file-system-sandboxing-in-clang-llvm/88791