### PR TITLE
[RISCV] Allow unsigned immediates for pli.h, pli.dh, pli.w

### DIFF
--- a/llvm/lib/Target/RISCV/AsmParser/RISCVAsmParser.cpp
+++ b/llvm/lib/Target/RISCV/AsmParser/RISCVAsmParser.cpp
@@ -907,6 +907,17 @@ public:
   bool isSImm8Unsigned() const { return isSImm<8>() || isUImm<8>(); }
   bool isSImm10Unsigned() const { return isSImm<10>() || isUImm<10>(); }
 
+  bool isSImm10PLI_H() const {
+    return isSImm<10>() || isUImmPred([](int64_t Imm) {
+             return isUInt<16>(Imm) && isInt<10>(SignExtend64<16>(Imm));
+           });
+  }
+  bool isSImm10PLI_W() const {
+    return isSImm<10>() || isUImmPred([](int64_t Imm) {
+             return isUInt<32>(Imm) && isInt<10>(SignExtend64<32>(Imm));
+           });
+  }
+
   bool isUImm20LUI() const {
     if (!isExpr())
       return false;
@@ -1577,6 +1588,8 @@ bool RISCVAsmParser::matchAndEmitInstruction(SMLoc IDLoc, unsigned &Opcode,
     return generateImmOutOfRangeError(Operands, ErrorInfo, -(1 << 7),
                                       (1 << 8) - 1);
   case Match_InvalidSImm10:
+  case Match_InvalidSImm10PLI_H:
+  case Match_InvalidSImm10PLI_W:
     return generateImmOutOfRangeError(Operands, ErrorInfo, -(1 << 9),
                                       (1 << 9) - 1);
   case Match_InvalidSImm10Unsigned:

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoP.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoP.td
@@ -67,6 +67,44 @@ def simm10_unsigned : RISCVOp {
   }];
 }
 
+def SImm10PLI_HAsmOperand : SImmAsmOperand<10, "PLI_H"> {
+  let RenderMethod = "addSImm10UnsignedOperands";
+}
+
+def SImm10PLI_WAsmOperand : SImmAsmOperand<10, "PLI_W"> {
+  let RenderMethod = "addSImm10UnsignedOperands";
+}
+
+// A 10-bit signed immediate to be splatted to 16 bit elements allowing range
+// [-512, 511] and [65025,65535] but represented as [-512, 511].
+def simm10_pli_h : RISCVOp {
+  let ParserMatchClass = SImm10PLI_HAsmOperand;
+  let EncoderMethod = "getImmOpValue";
+  let DecoderMethod = "decodeSImmOperand<10>";
+  let OperandType = "OPERAND_SIMM10";
+  let MCOperandPredicate = [{
+    int64_t Imm;
+    if (!MCOp.evaluateAsConstantImm(Imm))
+      return false;
+    return isInt<10>(Imm);
+  }];
+}
+
+// A 10-bit signed immediate to be splatted to 32 bit elements allowing range
+// [-512, 511] and [4294966784,4294967295]
+def simm10_pli_w : RISCVOp {
+  let ParserMatchClass = SImm10PLI_WAsmOperand;
+  let EncoderMethod = "getImmOpValue";
+  let DecoderMethod = "decodeSImmOperand<10>";
+  let OperandType = "OPERAND_SIMM10";
+  let MCOperandPredicate = [{
+    int64_t Imm;
+    if (!MCOp.evaluateAsConstantImm(Imm))
+      return false;
+    return isInt<10>(Imm);
+  }];
+}
+
 //===----------------------------------------------------------------------===//
 // Instruction class templates
 //===----------------------------------------------------------------------===//
@@ -89,8 +127,8 @@ class RVPLoadImm_i<bits<7> funct7, dag ins, string opcodestr,
 }
 
 // Base for pli.h/w.
-class PLI_i<bits<7> funct7, string opcodestr>
-    : RVPLoadImm_i<funct7, (ins simm10:$imm10), opcodestr, "$rd, $imm10"> {
+class PLI_i<bits<7> funct7, string opcodestr, DAGOperand imm>
+    : RVPLoadImm_i<funct7, (ins imm:$imm10), opcodestr, "$rd, $imm10"> {
   bits<10> imm10;
 
   let Inst{24-16} = imm10{8-0};
@@ -517,9 +555,9 @@ let Predicates = [HasStdExtP, IsRV64] in {
 } // Predicates = [HasStdExtP, IsRV64]
 
 let Predicates = [HasStdExtP] in
-def PLI_H : PLI_i<0b1011000, "pli.h">;
+def PLI_H : PLI_i<0b1011000, "pli.h", simm10_pli_h>;
 let Predicates = [HasStdExtP, IsRV64] in
-def PLI_W : PLI_i<0b1011001, "pli.w">;
+def PLI_W : PLI_i<0b1011001, "pli.w", simm10_pli_w>;
 let Predicates = [HasStdExtP] in {
   def PLI_B : RVPLoadImm_i<0b1011010, (ins simm8_unsigned:$imm8), "pli.b",
                            "$rd, $imm8"> {
@@ -1190,7 +1228,7 @@ let Predicates = [HasStdExtP, IsRV64] in {
 } // Predicates = [HasStdExtP, IsRV64]
 
 let Predicates = [HasStdExtP, IsRV32] in {
-  def PLI_DH : RVPPairLoadImm_i<0b0011000, (ins simm10:$imm10), "pli.dh",
+  def PLI_DH : RVPPairLoadImm_i<0b0011000, (ins simm10_pli_h:$imm10), "pli.dh",
                                 "$rd, $imm10"> {
     bits<10> imm10;
 

--- a/llvm/test/MC/RISCV/rv32p-valid.s
+++ b/llvm/test/MC/RISCV/rv32p-valid.s
@@ -37,6 +37,9 @@ sslai a4, a5, 3
 # CHECK-ASM-AND-OBJ: pli.h a5, 16
 # CHECK-ASM: encoding: [0x9b,0x27,0x10,0xb0]
 pli.h a5, 16
+# CHECK-ASM-AND-OBJ: pli.h a5, -512
+# CHECK-ASM: encoding: [0x9b,0xa7,0x00,0xb0]
+pli.h a5, 65024
 # CHECK-ASM-AND-OBJ: pli.b a6, 16
 # CHECK-ASM: encoding: [0x1b,0x28,0x10,0xb4]
 pli.b a6, 16
@@ -660,6 +663,9 @@ wslai t1, a2, 63
 # CHECK-ASM-AND-OBJ: pli.dh a4, 16
 # CHECK-ASM: encoding: [0x1b,0x27,0x10,0x30]
 pli.dh a4, 16
+# CHECK-ASM-AND-OBJ: pli.dh a4, -1
+# CHECK-ASM: encoding: [0x1b,0xa7,0xff,0x31]
+pli.dh a4, 65535
 # CHECK-ASM-AND-OBJ: pli.db a6, 16
 # CHECK-ASM: encoding: [0x1b,0x28,0x10,0x34]
 pli.db a6, 16

--- a/llvm/test/MC/RISCV/rv64p-valid.s
+++ b/llvm/test/MC/RISCV/rv64p-valid.s
@@ -43,9 +43,15 @@ psslai.w a4, a5, 4
 # CHECK-ASM-AND-OBJ: pli.h a5, 5
 # CHECK-ASM: encoding: [0x9b,0x27,0x05,0xb0]
 pli.h a5, 5
+# CHECK-ASM-AND-OBJ: pli.h a5, -215
+# CHECK-ASM: encoding: [0x9b,0xa7,0x29,0xb1]
+pli.h a5, 65321
 # CHECK-ASM-AND-OBJ: pli.w a5, 5
 # CHECK-ASM: encoding: [0x9b,0x27,0x05,0xb2]
 pli.w a5, 5
+# CHECK-ASM-AND-OBJ: pli.w a5, -292
+# CHECK-ASM: encoding: [0x9b,0xa7,0xdc,0xb2]
+pli.w a5, 0xfffffedc
 # CHECK-ASM-AND-OBJ: pli.b a6, 6
 # CHECK-ASM: encoding: [0x1b,0x28,0x06,0xb4]
 pli.b a6, 6


### PR DESCRIPTION
Allow unsigned immediates that look like like simm10 when only considering the lower 16 or 32 bits. For pli.dh and pli.dh this [652024,65535]. For pli.w, this is [4294966784,4294967295].

Since we're only inserting 16 or 32 bits, it makes sense to me that only those 16 or 32 bits matter. This is similar to how we allow `addi a0, a0, 0xffffffff` on RV32.