### PR TITLE
[clang] Fix alias declaration fix-it location for token-split '>>'

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -276,6 +276,10 @@ Improvements to Clang's diagnostics
 - Added a missing space to the FixIt for the ``implicit-int`` group of diagnostics and 
   made sure that only one such diagnostic and FixIt is emitted per declaration group. (#GH179354)
 
+- Fixed the Fix-It insertion point for ``expected ';' after alias declaration``
+  when parsing alias declarations involving a token-split ``>>`` sequence
+  (for example, ``using A = X<int>>;``). (#GH184425)
+
 - The ``-Wloop-analysis`` warning has been extended to catch more cases of
   variable modification inside lambda expressions (#GH132038).
 

--- a/clang/lib/Lex/Lexer.cpp
+++ b/clang/lib/Lex/Lexer.cpp
@@ -862,8 +862,17 @@ SourceLocation Lexer::getLocForEndOfToken(SourceLocation Loc, unsigned Offset,
     return {};
 
   if (Loc.isMacroID()) {
+    // Token-split expansion ranges (for example, when splitting '>>' into two
+    // '>' tokens while parsing templates) are character ranges, so the
+    // expansion end location already points just past the split token.
+    const bool IsTokenSplitRange =
+        !SM.getSLocEntry(SM.getFileID(Loc))
+             .getExpansion()
+             .isExpansionTokenRange();
     if (Offset > 0 || !isAtEndOfMacroExpansion(Loc, SM, LangOpts, &Loc))
       return {}; // Points inside the macro expansion.
+    if (IsTokenSplitRange)
+      return Loc;
   }
 
   unsigned Len = Lexer::MeasureTokenLength(Loc, SM, LangOpts);

--- a/clang/lib/Lex/Lexer.cpp
+++ b/clang/lib/Lex/Lexer.cpp
@@ -865,13 +865,10 @@ SourceLocation Lexer::getLocForEndOfToken(SourceLocation Loc, unsigned Offset,
     // Token-split expansion ranges (for example, when splitting '>>' into two
     // '>' tokens while parsing templates) are character ranges, so the
     // expansion end location already points just past the split token.
-    const bool IsTokenSplitRange =
-        !SM.getSLocEntry(SM.getFileID(Loc))
-             .getExpansion()
-             .isExpansionTokenRange();
+    const FileID LocFileID = SM.getFileID(Loc);
     if (Offset > 0 || !isAtEndOfMacroExpansion(Loc, SM, LangOpts, &Loc))
       return {}; // Points inside the macro expansion.
-    if (IsTokenSplitRange)
+    if (!SM.getSLocEntry(LocFileID).getExpansion().isExpansionTokenRange())
       return Loc;
   }
 

--- a/clang/lib/Lex/Lexer.cpp
+++ b/clang/lib/Lex/Lexer.cpp
@@ -862,9 +862,11 @@ SourceLocation Lexer::getLocForEndOfToken(SourceLocation Loc, unsigned Offset,
     return {};
 
   if (Loc.isMacroID()) {
-    // Token-split expansion ranges (for example, when splitting '>>' into two
-    // '>' tokens while parsing templates) are character ranges, so the
-    // expansion end location already points just past the split token.
+    // Token split (for example, splitting '>>' into two '>' tokens) is
+    // represented in SourceManager as an ExpansionInfo (see
+    // createForTokenSplit), so these locations are MacroIDs even when no user
+    // macro is involved. For split expansions, the expansion end is already
+    // the correct insertion point.
     const FileID LocFileID = SM.getFileID(Loc);
     if (Offset > 0 || !isAtEndOfMacroExpansion(Loc, SM, LangOpts, &Loc))
       return {}; // Points inside the macro expansion.

--- a/clang/test/Parser/cxx-alias-decl-split-angle-fixit.cpp
+++ b/clang/test/Parser/cxx-alias-decl-split-angle-fixit.cpp
@@ -1,0 +1,7 @@
+// RUN: not %clang_cc1 -fsyntax-only -std=c++11 -fdiagnostics-parseable-fixits %s 2>&1 | FileCheck %s
+
+template <typename> struct X {};
+using A = X<int>>;
+
+// CHECK: error: expected ';' after alias declaration
+// CHECK: fix-it:"{{.*}}":{4:17-4:17}:";"

--- a/clang/test/Parser/cxx0x-decl.cpp
+++ b/clang/test/Parser/cxx0x-decl.cpp
@@ -190,8 +190,6 @@ namespace AliasDeclEndLocation {
     ;
   using D = AliasDeclEndLocation::A<int
     > // expected-error {{expected ';' after alias declaration}}
-  // FIXME: After splitting this >> into two > tokens, we incorrectly determine
-  // the end of the template-id to be after the *second* '>'.
   using E = AliasDeclEndLocation::A<int>>;
 #define GGG >>>
   using F = AliasDeclEndLocation::A<int GGG;


### PR DESCRIPTION
Fixes #184425

When parsing an alias declaration like:

```c++
using A = X<int>>;
```

clang splits `>>` into two `>` tokens while parsing templates. In this token-split case, `Lexer::getLocForEndOfToken` was advancing past the already-correct expansion end location, which moved the fix-it insertion point too far right (at `;` instead of before the second `>`).

This patch detects token-split expansion ranges and returns the expansion end location directly after `isAtEndOfMacroExpansion`, avoiding the extra token-length advance.

Also adds a regression test in `clang/test/Parser/cxx-alias-decl-split-angle-fixit.cpp` that checks the fix-it insertion location is `{4:17-4:17}` for the example above.

Local validation:
- `tools/clang/lib/Lex/CMakeFiles/obj.clangLex.dir/Lexer.cpp.o` builds successfully
- full `clang` build/test still in progress
