### PR TITLE
[ELF] Move ArmCmseSGSection into Arch/ARM.cpp

### DIFF
--- a/lld/ELF/Arch/ARM.cpp
+++ b/lld/ELF/Arch/ARM.cpp
@@ -25,6 +25,11 @@ using namespace lld;
 using namespace lld::elf;
 using namespace llvm::object;
 
+// Cortex-M Security Extensions. Prefix for functions that should be exported
+// for the non-secure world.
+constexpr char ACLESESYM_PREFIX[] = "__acle_se_";
+constexpr int ACLESESYM_SIZE = 8;
+
 namespace {
 class ARM final : public TargetInfo {
 public:
@@ -65,6 +70,33 @@ private:
                       int group, bool check) const;
 };
 enum class CodeState { Data = 0, Thumb = 2, Arm = 4 };
+
+struct CmseSGVeneer {
+  CmseSGVeneer(Symbol *sym, Symbol *acleSeSym,
+               std::optional<uint64_t> addr = std::nullopt)
+      : sym(sym), acleSeSym(acleSeSym), entAddr{addr} {}
+  static const size_t size{ACLESESYM_SIZE};
+  std::optional<uint64_t> getAddr() const { return entAddr; };
+
+  Symbol *sym;
+  Symbol *acleSeSym;
+  uint64_t offset = 0;
+  const std::optional<uint64_t> entAddr;
+};
+
+struct ArmCmseSGSection : SyntheticSection {
+  ArmCmseSGSection(Ctx &ctx);
+  bool isNeeded() const override { return !entries.empty(); }
+  size_t getSize() const override;
+  void writeTo(uint8_t *buf) override;
+  void addSGVeneer(Symbol *sym, Symbol *ext_sym);
+  void addMappingSymbol();
+  void finalizeContents() override;
+  uint64_t impLibMaxAddr = 0;
+  SmallVector<std::pair<Symbol *, Symbol *>, 0> entries;
+  SmallVector<std::unique_ptr<CmseSGVeneer>, 0> sgVeneers;
+  uint64_t newEntries = 0;
+};
 } // namespace
 
 ARM::ARM(Ctx &ctx) : TargetInfo(ctx) {
@@ -1450,20 +1482,20 @@ void ArmCmseSGSection::addSGVeneer(Symbol *acleSeSym, Symbol *sym) {
     return;
   // Only secure symbols with values equal to that of it's non-secure
   // counterpart needs to be in the .gnu.sgstubs section.
-  std::unique_ptr<ArmCmseSGVeneer> ss;
+  std::unique_ptr<CmseSGVeneer> ss;
   auto it = ctx.symtab->cmseImportLib.find(sym->getName());
   if (it != ctx.symtab->cmseImportLib.end()) {
     Defined *impSym = it->second;
-    ss = std::make_unique<ArmCmseSGVeneer>(sym, acleSeSym, impSym->value);
+    ss = std::make_unique<CmseSGVeneer>(sym, acleSeSym, impSym->value);
   } else {
-    ss = std::make_unique<ArmCmseSGVeneer>(sym, acleSeSym);
+    ss = std::make_unique<CmseSGVeneer>(sym, acleSeSym);
     ++newEntries;
   }
   sgVeneers.emplace_back(std::move(ss));
 }
 
 void ArmCmseSGSection::writeTo(uint8_t *buf) {
-  for (std::unique_ptr<ArmCmseSGVeneer> &s : sgVeneers) {
+  for (std::unique_ptr<CmseSGVeneer> &s : sgVeneers) {
     uint8_t *p = buf + s->offset;
     write16(ctx, p + 0, 0xe97f); // SG
     write16(ctx, p + 2, 0xe97f);

--- a/lld/ELF/SyntheticSections.h
+++ b/lld/ELF/SyntheticSections.h
@@ -1245,45 +1245,6 @@ private:
   size_t size = 0;
 };
 
-// Cortex-M Security Extensions. Prefix for functions that should be exported
-// for the non-secure world.
-const char ACLESESYM_PREFIX[] = "__acle_se_";
-const int ACLESESYM_SIZE = 8;
-
-class ArmCmseSGVeneer {
-public:
-  ArmCmseSGVeneer(Symbol *sym, Symbol *acleSeSym,
-                  std::optional<uint64_t> addr = std::nullopt)
-      : sym(sym), acleSeSym(acleSeSym), entAddr{addr} {}
-  static const size_t size{ACLESESYM_SIZE};
-  std::optional<uint64_t> getAddr() const { return entAddr; };
-
-  Symbol *sym;
-  Symbol *acleSeSym;
-  uint64_t offset = 0;
-
-private:
-  const std::optional<uint64_t> entAddr;
-};
-
-class ArmCmseSGSection final : public SyntheticSection {
-public:
-  ArmCmseSGSection(Ctx &ctx);
-  bool isNeeded() const override { return !entries.empty(); }
-  size_t getSize() const override;
-  void writeTo(uint8_t *buf) override;
-  void addSGVeneer(Symbol *sym, Symbol *ext_sym);
-  void addMappingSymbol();
-  void finalizeContents() override;
-  void exportEntries(SymbolTableBaseSection *symTab);
-  uint64_t impLibMaxAddr = 0;
-
-private:
-  SmallVector<std::pair<Symbol *, Symbol *>, 0> entries;
-  SmallVector<std::unique_ptr<ArmCmseSGVeneer>, 0> sgVeneers;
-  uint64_t newEntries = 0;
-};
-
 // This section is used to store the addresses of functions that are called
 // in range-extending thunks on PowerPC64. When producing position dependent
 // code the addresses are link-time constants and the table is written out to


### PR DESCRIPTION
Move the ArmCmseSGVeneer and ArmCmseSGSection class definitions from
SyntheticSections.h into the anonymous namespace in Arch/ARM.cpp, where
the implementations already reside. Rename ArmCmseSGVeneer to
CmseSGVeneer as it no longer needs the Arm prefix for disambiguation.