### PR TITLE
[CIR] Add optnone, minsize, noduplicate, cold/hot definition attrs

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIRDialect.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRDialect.td
@@ -54,6 +54,7 @@ def CIR_Dialect : Dialect {
     static llvm::StringRef getNoCallerSavedRegsAttrName() { return "no_caller_saved_registers"; }
     static llvm::StringRef getNoCallbackAttrName() { return "nocallback"; }
     static llvm::StringRef getAllocSizeAttrName() { return "allocsize"; }
+    static llvm::StringRef getOptimizeNoneAttrName() { return "optimize_none"; }
     static llvm::StringRef getOptimizeForSizeAttrName() { return "optsize"; }
     static llvm::StringRef getMinSizeAttrName() { return "minsize"; }
     // Note: we have to name this with the underscore instead of the dash like

--- a/clang/include/clang/CIR/MissingFeatures.h
+++ b/clang/include/clang/CIR/MissingFeatures.h
@@ -72,19 +72,16 @@ struct MissingFeatures {
   static bool opFuncArmStreamingAttr() { return false; }
   static bool opFuncAstDeclAttr() { return false; }
   static bool opFuncCallingConv() { return false; }
-  static bool opFuncColdHotAttr() { return false; }
   static bool opFuncCPUAndFeaturesAttributes() { return false; }
   static bool opFuncExceptions() { return false; }
   static bool opFuncExtraAttrs() { return false; }
   static bool opFuncMaybeHandleStaticInExternC() { return false; }
-  static bool opFuncMinSizeAttr() { return false; }
   static bool opFuncMultipleReturnVals() { return false; }
   static bool opFuncNakedAttr() { return false; }
-  static bool opFuncNoDuplicateAttr() { return false; }
+  static bool opFuncNoOutlineAttr() { return false; }
   static bool opFuncNoUnwind() { return false; }
   static bool opFuncOpenCLKernelMetadata() { return false; }
   static bool opFuncOperandBundles() { return false; }
-  static bool opFuncOptNoneAttr() { return false; }
   static bool opFuncParameterAttributes() { return false; }
   static bool opFuncReadOnly() { return false; }
   static bool opFuncSection() { return false; }

--- a/clang/lib/CIR/CodeGen/CIRGenModule.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.cpp
@@ -2371,14 +2371,34 @@ void CIRGenModule::setCIRFunctionAttributesForDefinition(
 
   assert(!cir::MissingFeatures::opFuncArmStreamingAttr());
   assert(!cir::MissingFeatures::opFuncArmNewAttr());
-  assert(!cir::MissingFeatures::opFuncOptNoneAttr());
-  assert(!cir::MissingFeatures::opFuncMinSizeAttr());
   assert(!cir::MissingFeatures::opFuncNakedAttr());
-  assert(!cir::MissingFeatures::opFuncNoDuplicateAttr());
   assert(!cir::MissingFeatures::hlsl());
 
-  // Handle inline attributes
-  if (decl->hasAttr<NoInlineAttr>() && !isAlwaysInline) {
+  // Track whether we need to add the optnone attribute, starting with the
+  // default for this optimization level.
+  bool shouldAddOptNone =
+      !codeGenOpts.DisableO0ImplyOptNone && codeGenOpts.OptimizationLevel == 0;
+  // We can't add optnone in the following cases, it won't pass the verifier.
+  shouldAddOptNone &= !decl->hasAttr<MinSizeAttr>();
+  shouldAddOptNone &= !decl->hasAttr<AlwaysInlineAttr>();
+
+  if ((shouldAddOptNone || decl->hasAttr<OptimizeNoneAttr>()) &&
+      !isAlwaysInline) {
+    // Add optnone, but do so only if the function isn't always_inline.
+    f->setAttr(cir::CIRDialect::getOptimizeNoneAttrName(),
+               mlir::UnitAttr::get(&getMLIRContext()));
+
+    // OptimizeNone implies noinline; we should not be inlining such functions.
+    f.setInlineKind(cir::InlineKind::NoInline);
+
+    // OptimizeNone wins over OptimizeForSize and MinSize.
+    f->removeAttr(cir::CIRDialect::getOptimizeForSizeAttrName());
+    f->removeAttr(cir::CIRDialect::getMinSizeAttrName());
+  } else if (decl->hasAttr<NoDuplicateAttr>()) {
+    // NoDuplicate is already set as a discardable attr by
+    // constructAttributeList. No additional action needed here beyond
+    // occupying the correct position in the precedence chain.
+  } else if (decl->hasAttr<NoInlineAttr>() && !isAlwaysInline) {
     // Add noinline if the function isn't always_inline.
     f.setInlineKind(cir::InlineKind::NoInline);
   } else if (decl->hasAttr<AlwaysInlineAttr>() && !isNoInline) {
@@ -2419,7 +2439,22 @@ void CIRGenModule::setCIRFunctionAttributesForDefinition(
     }
   }
 
-  assert(!cir::MissingFeatures::opFuncColdHotAttr());
+  // Add other optimization-related attributes if we are optimizing this
+  // function (i.e. OptimizeNone is not present).
+  if (!decl->hasAttr<OptimizeNoneAttr>()) {
+    if (decl->hasAttr<ColdAttr>()) {
+      // ColdAttr implies OptimizeForSize, but not if we're already adding
+      // optnone (which would remove it anyway).
+      if (!shouldAddOptNone)
+        f->setAttr(cir::CIRDialect::getOptimizeForSizeAttrName(),
+                   mlir::UnitAttr::get(&getMLIRContext()));
+    }
+    if (decl->hasAttr<MinSizeAttr>())
+      f->setAttr(cir::CIRDialect::getMinSizeAttrName(),
+                 mlir::UnitAttr::get(&getMLIRContext()));
+  }
+
+  assert(!cir::MissingFeatures::opFuncNoOutlineAttr());
 }
 
 cir::FuncOp CIRGenModule::getOrCreateCIRFunction(

--- a/clang/test/CIR/CodeGen/arg-attrs.cpp
+++ b/clang/test/CIR/CodeGen/arg-attrs.cpp
@@ -15,10 +15,10 @@ struct Struct {
 };
 
 void Struct::this_func(){}
-  // CIR: cir.func {{.*}}@_ZN6Struct9this_funcEv(%{{.*}}: !cir.ptr<!rec_Struct> {llvm.align = 4 : i64, llvm.dereferenceable = 20 : i64, llvm.nonnull, llvm.noundef} {{.*}}) {
+  // CIR: cir.func {{.*}}@_ZN6Struct9this_funcEv(%{{.*}}: !cir.ptr<!rec_Struct> {llvm.align = 4 : i64, llvm.dereferenceable = 20 : i64, llvm.nonnull, llvm.noundef} {{.*}}){{.*}}{
   // BOTH: define {{.*}}void @_ZN6Struct9this_funcEv(ptr noundef nonnull align 4 dereferenceable(20) %{{.*}})
 void Struct::arg_attr(Struct s, int &i, Incomplete &j){}
-  // CIR: cir.func {{.*}}@_ZN6Struct8arg_attrES_RiR10Incomplete(%{{.*}}: !cir.ptr<!rec_Struct> {llvm.align = 4 : i64, llvm.dereferenceable = 20 : i64, llvm.nonnull, llvm.noundef} {{.*}}, %{{.*}}: !rec_Struct {{.*}}, %{{.*}}: !cir.ptr<!s32i> {llvm.align = 8 : i64, llvm.dereferenceable = 4 : i64, llvm.nonnull, llvm.noundef} {{.*}}, %arg3: !cir.ptr<!rec_Incomplete> {llvm.align = 8 : i64, llvm.nonnull, llvm.noundef} {{.*}}) {
+  // CIR: cir.func {{.*}}@_ZN6Struct8arg_attrES_RiR10Incomplete(%{{.*}}: !cir.ptr<!rec_Struct> {llvm.align = 4 : i64, llvm.dereferenceable = 20 : i64, llvm.nonnull, llvm.noundef} {{.*}}, %{{.*}}: !rec_Struct {{.*}}, %{{.*}}: !cir.ptr<!s32i> {llvm.align = 8 : i64, llvm.dereferenceable = 4 : i64, llvm.nonnull, llvm.noundef} {{.*}}, %arg3: !cir.ptr<!rec_Incomplete> {llvm.align = 8 : i64, llvm.nonnull, llvm.noundef} {{.*}}){{.*}}{
   // LLVM: define {{.*}}void @_ZN6Struct8arg_attrES_RiR10Incomplete(ptr noundef nonnull align 4 dereferenceable(20) %{{.*}}, %struct.Struct %{{.*}}, ptr noundef nonnull align 8 dereferenceable(4) %{{.*}}, ptr noundef nonnull align 8 %{{.*}})
   // OGCG: define {{.*}}void @_ZN6Struct8arg_attrES_RiR10Incomplete(ptr noundef nonnull align 4 dereferenceable(20) %{{.*}}, ptr noundef byval(%struct.Struct) align 8 %{{.*}}, ptr noundef nonnull align 4 dereferenceable(4) %{{.*}}, ptr noundef nonnull align 1 %{{.*}})
 

--- a/clang/test/CIR/CodeGen/dtors.cpp
+++ b/clang/test/CIR/CodeGen/dtors.cpp
@@ -340,7 +340,7 @@ int test_temp_in_condition(G &obj) {
   return 0;
 }
 
-// CIR: cir.func {{.*}} @_Z22test_temp_in_conditionR1G(%[[ARG0:.*]]: !cir.ptr<!rec_G> {{.*}}) -> (!s32i {{.*}}) {
+// CIR: cir.func {{.*}} @_Z22test_temp_in_conditionR1G(%[[ARG0:.*]]: !cir.ptr<!rec_G> {{.*}}) -> (!s32i {{.*}}){{.*}}{
 // CIR:   %[[OBJ:.*]] = cir.alloca !cir.ptr<!rec_G>, !cir.ptr<!cir.ptr<!rec_G>>, ["obj", init, const]
 // CIR:   %[[RET_ADDR:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["__retval"]
 // CIR:   cir.store %[[ARG0]], %[[OBJ]]

--- a/clang/test/CIR/CodeGen/func-attrs.cpp
+++ b/clang/test/CIR/CodeGen/func-attrs.cpp
@@ -1,0 +1,121 @@
+// RUN: %clang_cc1 -std=c++11 -triple x86_64-unknown-linux-gnu -O1 -fclangir -emit-cir %s -o %t.cir
+// RUN: FileCheck --check-prefix=CIR --input-file=%t.cir %s
+// RUN: %clang_cc1 -std=c++11 -triple x86_64-unknown-linux-gnu -O1 -fclangir -emit-llvm %s -o %t.ll
+// RUN: FileCheck --check-prefix=LLVM --input-file=%t.ll %s
+// RUN: %clang_cc1 -std=c++11 -triple x86_64-unknown-linux-gnu -O1 -emit-llvm %s -o %t.ll
+// RUN: FileCheck --check-prefix=OGCG --input-file=%t.ll %s
+//
+// Test -O0 implicit optnone:
+// RUN: %clang_cc1 -std=c++11 -triple x86_64-unknown-linux-gnu -O0 -fclangir -emit-cir %s -o %t-o0.cir
+// RUN: FileCheck --check-prefix=O0CIR --input-file=%t-o0.cir %s
+// RUN: %clang_cc1 -std=c++11 -triple x86_64-unknown-linux-gnu -O0 -fclangir -emit-llvm %s -o %t-o0.ll
+// RUN: FileCheck --check-prefix=O0LLVM --input-file=%t-o0.ll %s
+// RUN: %clang_cc1 -std=c++11 -triple x86_64-unknown-linux-gnu -O0 -emit-llvm %s -o %t-o0-ogcg.ll
+// RUN: FileCheck --check-prefix=O0OGCG --input-file=%t-o0-ogcg.ll %s
+
+extern "C" {
+
+// CIR: cir.func no_inline dso_local @optnone_func()
+// CIR-SAME: attributes {optimize_none}
+// LLVM: define dso_local void @optnone_func() {{.*}}#[[OPTNONE_ATTR:[0-9]+]]
+// OGCG: define dso_local void @optnone_func() {{.*}}#[[OPTNONE_ATTR:[0-9]+]]
+__attribute__((optnone))
+void optnone_func() {}
+
+// CIR: cir.func dso_local @cold_func()
+// CIR-SAME: attributes {cold, optsize}
+// LLVM: define dso_local void @cold_func() {{.*}}#[[COLD_ATTR:[0-9]+]]
+// OGCG: define dso_local void @cold_func() {{.*}}#[[COLD_ATTR:[0-9]+]]
+__attribute__((cold))
+void cold_func() {}
+
+// CIR: cir.func dso_local @hot_func()
+// CIR-SAME: attributes {hot}
+// LLVM: define dso_local void @hot_func() {{.*}}#[[HOT_ATTR:[0-9]+]]
+// OGCG: define dso_local void @hot_func() {{.*}}#[[HOT_ATTR:[0-9]+]]
+__attribute__((hot))
+void hot_func() {}
+
+// CIR: cir.func dso_local @noduplicate_func()
+// CIR-SAME: attributes {noduplicate}
+// LLVM: define dso_local void @noduplicate_func() {{.*}}#[[ND_ATTR:[0-9]+]]
+// OGCG: define dso_local void @noduplicate_func() {{.*}}#[[ND_ATTR:[0-9]+]]
+__attribute__((noduplicate))
+void noduplicate_func() {}
+
+// CIR: cir.func dso_local @minsize_func()
+// CIR-SAME: attributes {minsize}
+// LLVM: define dso_local void @minsize_func() {{.*}}#[[MINSIZE_ATTR:[0-9]+]]
+// OGCG: define dso_local void @minsize_func() {{.*}}#[[MINSIZE_ATTR:[0-9]+]]
+__attribute__((minsize))
+void minsize_func() {}
+
+// optnone + cold: optnone wins, cold stays but optsize must NOT be added.
+// CIR: cir.func no_inline dso_local @optnone_cold_func()
+// CIR-SAME: attributes {cold, optimize_none}
+// CIR-NOT: optsize
+// LLVM: define dso_local void @optnone_cold_func() {{.*}}#[[OPTNONE_COLD_ATTR:[0-9]+]]
+// OGCG: define dso_local void @optnone_cold_func() {{.*}}#[[OPTNONE_COLD_ATTR:[0-9]+]]
+__attribute__((optnone, cold))
+void optnone_cold_func() {}
+
+// optnone + hot: hot stays (set by constructAttributeList), optnone+noinline added.
+// CIR: cir.func no_inline dso_local @optnone_hot_func()
+// CIR-SAME: attributes {hot, optimize_none}
+// LLVM: define dso_local void @optnone_hot_func() {{.*}}#[[OPTNONE_HOT_ATTR:[0-9]+]]
+// OGCG: define dso_local void @optnone_hot_func() {{.*}}#[[OPTNONE_HOT_ATTR:[0-9]+]]
+__attribute__((optnone, hot))
+void optnone_hot_func() {}
+
+// always_inline: gets alwaysinline, no optnone even at -O0.
+// CIR: cir.func always_inline dso_local @always_inline_func() {
+// LLVM: define dso_local void @always_inline_func() {{.*}}#[[AI_ATTR:[0-9]+]]
+// OGCG: define dso_local void @always_inline_func() {{.*}}#[[AI_ATTR:[0-9]+]]
+__attribute__((always_inline))
+void always_inline_func() {}
+
+// -O0 implicit optnone: normal functions get optimize_none + noinline.
+// O0CIR: cir.func no_inline dso_local @optnone_func()
+// O0CIR-SAME: optimize_none
+// O0CIR: cir.func no_inline dso_local @cold_func()
+// O0CIR-SAME: optimize_none
+// -O0 with hot: optnone takes precedence, hot stays.
+// O0CIR: cir.func no_inline dso_local @hot_func()
+// O0CIR-SAME: optimize_none
+// -O0 with noduplicate: optnone takes precedence, noduplicate stays.
+// O0CIR: cir.func no_inline dso_local @noduplicate_func()
+// O0CIR-SAME: optimize_none
+// minsize suppresses implicit optnone at -O0.
+// O0CIR: cir.func no_inline dso_local @minsize_func() attributes {minsize} {
+// always_inline suppresses implicit optnone at -O0.
+// O0CIR: cir.func always_inline dso_local @always_inline_func() {
+//
+// O0LLVM: define dso_local void @optnone_func() {{.*}}#[[O0_OPTNONE:[0-9]+]]
+// O0LLVM: define dso_local void @always_inline_func() {{.*}}#[[O0_AI:[0-9]+]]
+// O0LLVM-DAG: attributes #[[O0_OPTNONE]] = {{{.*}}noinline{{.*}}optnone{{.*}}}
+// O0LLVM-DAG: attributes #[[O0_AI]] = {{{.*}}alwaysinline{{.*}}}
+//
+// O0OGCG: define dso_local void @optnone_func() {{.*}}#[[O0_OPTNONE:[0-9]+]]
+// O0OGCG: define dso_local void @always_inline_func() {{.*}}#[[O0_AI:[0-9]+]]
+// O0OGCG-DAG: attributes #[[O0_OPTNONE]] = {{{.*}}noinline{{.*}}optnone{{.*}}}
+// O0OGCG-DAG: attributes #[[O0_AI]] = {{{.*}}alwaysinline{{.*}}}
+
+}
+
+// LLVM-DAG: attributes #[[OPTNONE_ATTR]] = {{{.*}}noinline{{.*}}optnone{{.*}}}
+// LLVM-DAG: attributes #[[COLD_ATTR]] = {{{.*}}cold{{.*}}optsize{{.*}}}
+// LLVM-DAG: attributes #[[HOT_ATTR]] = {{{.*}}hot{{.*}}}
+// LLVM-DAG: attributes #[[ND_ATTR]] = {{{.*}}noduplicate{{.*}}}
+// LLVM-DAG: attributes #[[MINSIZE_ATTR]] = {{{.*}}minsize{{.*}}}
+// LLVM-DAG: attributes #[[OPTNONE_COLD_ATTR]] = {{{.*}}cold{{.*}}noinline{{.*}}optnone{{.*}}}
+// LLVM-DAG: attributes #[[OPTNONE_HOT_ATTR]] = {{{.*}}hot{{.*}}noinline{{.*}}optnone{{.*}}}
+// LLVM-DAG: attributes #[[AI_ATTR]] = {{{.*}}alwaysinline{{.*}}}
+
+// OGCG-DAG: attributes #[[OPTNONE_ATTR]] = {{{.*}}noinline{{.*}}optnone{{.*}}}
+// OGCG-DAG: attributes #[[COLD_ATTR]] = {{{.*}}cold{{.*}}optsize{{.*}}}
+// OGCG-DAG: attributes #[[HOT_ATTR]] = {{{.*}}hot{{.*}}}
+// OGCG-DAG: attributes #[[ND_ATTR]] = {{{.*}}noduplicate{{.*}}}
+// OGCG-DAG: attributes #[[MINSIZE_ATTR]] = {{{.*}}minsize{{.*}}}
+// OGCG-DAG: attributes #[[OPTNONE_COLD_ATTR]] = {{{.*}}cold{{.*}}noinline{{.*}}optnone{{.*}}}
+// OGCG-DAG: attributes #[[OPTNONE_HOT_ATTR]] = {{{.*}}hot{{.*}}noinline{{.*}}optnone{{.*}}}
+// OGCG-DAG: attributes #[[AI_ATTR]] = {{{.*}}alwaysinline{{.*}}}

--- a/clang/test/CIR/CodeGen/lambda-static-invoker.cpp
+++ b/clang/test/CIR/CodeGen/lambda-static-invoker.cpp
@@ -66,7 +66,7 @@ int g3() {
 // In OGCG, the _ZZ2g3vENK3$_0clERKi function is emitted after _ZZ2g3vEN3$_08__invokeERKi, see below.
 
 // lambda invoker
-// CIR: cir.func no_inline internal private dso_local @_ZZ2g3vEN3$_08__invokeERKi(%[[REF_I_ARG:.*]]: !cir.ptr<!s32i> {{.*}}) -> (!s32i{{.*}}) {
+// CIR: cir.func no_inline internal private dso_local @_ZZ2g3vEN3$_08__invokeERKi(%[[REF_I_ARG:.*]]: !cir.ptr<!s32i> {{.*}}) -> (!s32i{{.*}}){{.*}}{
 // CIR:   %[[REF_I_ALLOCA:.*]] = cir.alloca {{.*}} ["i", init, const]
 // CIR:   %[[RETVAL:.*]] = cir.alloca {{.*}} ["__retval"]
 // CIR:   %[[LAM_ALLOCA:.*]] = cir.alloca ![[REC_LAM_G3]], !cir.ptr<![[REC_LAM_G3]]>, ["unused.capture"]

--- a/clang/test/CIR/CodeGen/lambda.cpp
+++ b/clang/test/CIR/CodeGen/lambda.cpp
@@ -157,7 +157,7 @@ auto g() {
   };
 }
 
-// CIR: cir.func {{.*}} @_Z1gv() -> ![[REC_LAM_G:.*]] {
+// CIR: cir.func {{.*}} @_Z1gv() -> ![[REC_LAM_G:[^ ]*]]{{.*}}{
 // CIR:   %[[RETVAL:.*]] = cir.alloca ![[REC_LAM_G]], !cir.ptr<![[REC_LAM_G]]>, ["__retval"]
 // CIR:   %[[I_ADDR:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["i", init]
 // CIR:   %[[TWELVE:.*]] = cir.const #cir.int<12> : !s32i
@@ -199,7 +199,7 @@ auto g2() {
 }
 
 // Should be same as above because of NRVO
-// CIR: cir.func {{.*}} @_Z2g2v() -> ![[REC_LAM_G2:.*]] {
+// CIR: cir.func {{.*}} @_Z2g2v() -> ![[REC_LAM_G2:[^ ]*]]{{.*}}{
 // CIR:   %[[RETVAL:.*]] = cir.alloca ![[REC_LAM_G2]], !cir.ptr<![[REC_LAM_G2]]>, ["__retval", init]
 // CIR:   %[[I_ADDR:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["i", init]
 // CIR:   %[[TWELVE:.*]] = cir.const #cir.int<12> : !s32i

--- a/clang/test/CIR/CodeGen/misc-attrs.cpp
+++ b/clang/test/CIR/CodeGen/misc-attrs.cpp
@@ -6,47 +6,47 @@
 // RUN: FileCheck --input-file=%t.ll %s -check-prefix=LLVM
 
 extern "C" {
-  // CIR: cir.func{{.*}}@returns_twice() attributes {returns_twice} {
+  // CIR: cir.func{{.*}}@returns_twice() attributes {{{.*}}returns_twice{{.*}}} {
   // LLVM: Function Attrs:{{.*}}returns_twice
   // LLVM-NEXT: define{{.*}}@returns_twice() #[[RT_ATTR:.*]] {
   __attribute__((returns_twice))
   void returns_twice() {}
-  // CIR: cir.func{{.*}}@cold() attributes {cold} {
+  // CIR: cir.func{{.*}}@cold() attributes {{{.*}}cold{{.*}}} {
   // LLVM: Function Attrs:{{.*}}cold
   // LLVM-NEXT: define{{.*}}@cold() #[[COLD_ATTR:.*]] {
   __attribute__((cold))
   void cold() {}
-  // CIR: cir.func{{.*}}@hot() attributes {hot} {
+  // CIR: cir.func{{.*}}@hot() attributes {{{.*}}hot{{.*}}} {
   // LLVM: Function Attrs:{{.*}}hot
   // LLVM-NEXT: define{{.*}}@hot() #[[HOT_ATTR:.*]] {
   __attribute__((hot))
   void hot() {}
-  // CIR: cir.func{{.*}}@nodupes() attributes {noduplicate} {
+  // CIR: cir.func{{.*}}@nodupes() attributes {{{.*}}noduplicate{{.*}}} {
   // LLVM: Function Attrs:{{.*}}noduplicate
   // LLVM-NEXT: define{{.*}}@nodupes() #[[ND_ATTR:.*]] {
   __attribute__((noduplicate))
   void nodupes() {}
-  // CIR: cir.func{{.*}}@convergent() attributes {convergent} {
+  // CIR: cir.func{{.*}}@convergent() attributes {{{.*}}convergent{{.*}}} {
   // LLVM: Function Attrs:{{.*}}convergent
   // LLVM-NEXT: define{{.*}}@convergent() #[[CONV_ATTR:.*]] {
   __attribute__((convergent))
   void convergent() {}
 
-  // CIR: cir.func{{.*}}@no_caller_saved_registers() attributes {no_caller_saved_registers} {
+  // CIR: cir.func{{.*}}@no_caller_saved_registers() attributes {{{.*}}no_caller_saved_registers{{.*}}} {
   // LLVM: Function Attrs:
   // LLVM-NOT: no_caller_saved_registers
   // LLVM-NEXT: define{{.*}}@no_caller_saved_registers() #[[NCSR_ATTR:.*]] {
   __attribute__((no_caller_saved_registers))
   void no_caller_saved_registers() {}
 
-  // CIR: cir.func{{.*}}@leaf() attributes {nocallback} {
+  // CIR: cir.func{{.*}}@leaf() attributes {{{.*}}nocallback{{.*}}} {
   // LLVM: Function Attrs:
   // LLVM-NOT: leaf
   // LLVM-NEXT: define{{.*}}@leaf() #[[LEAF_ATTR:.*]] {
   __attribute__((leaf))
   void leaf() {}
 
-  // CIR: cir.func{{.*}}@modular_format({{.*}}) attributes {modular_format = "kprintf,1,2,someIdent,someStr,aspect,aspect2"} {
+  // CIR: cir.func{{.*}}@modular_format({{.*}}) attributes {{{.*}}modular_format = "kprintf,1,2,someIdent,someStr,aspect,aspect2"{{.*}}} {
   // LLVM: Function Attrs:
   // LLVM-NOT:modular_format
   // LLVM-NEXT: define{{.*}}@modular_format({{.*}}) #[[MOD_FORMAT_ATTR:.*]] {

--- a/clang/test/CIR/CodeGen/new-delete.cpp
+++ b/clang/test/CIR/CodeGen/new-delete.cpp
@@ -12,7 +12,7 @@ A *a() {
   return new A(5);
 }
 
-// CIR: cir.func {{.*}} @_Z1av() -> !cir.ptr<!rec_A> {
+// CIR: cir.func {{.*}} @_Z1av() -> !cir.ptr<!rec_A>{{.*}}{
 // CIR:   %[[RETVAL:.*]] = cir.alloca !cir.ptr<!rec_A>, !cir.ptr<!cir.ptr<!rec_A>>, ["__retval"]
 // CIR:   %[[NEW_RESULT:.*]] = cir.alloca !cir.ptr<!rec_A>, !cir.ptr<!cir.ptr<!rec_A>>, ["__new_result"]
 // CIR:   %[[ALLOC_SIZE:.*]] = cir.const #cir.int<8> : !u64i
@@ -87,7 +87,7 @@ A *b() {
   return new A(foo());
 }
 
-// CIR: cir.func {{.*}} @_Z1bv() -> !cir.ptr<!rec_A> {
+// CIR: cir.func {{.*}} @_Z1bv() -> !cir.ptr<!rec_A>{{.*}}{
 // CIR:   %[[RETVAL:.*]] = cir.alloca !cir.ptr<!rec_A>, !cir.ptr<!cir.ptr<!rec_A>>, ["__retval"]
 // CIR:   %[[NEW_RESULT:.*]] = cir.alloca !cir.ptr<!rec_A>, !cir.ptr<!cir.ptr<!rec_A>>, ["__new_result"]
 // CIR:   %[[ALLOC_SIZE:.*]] = cir.const #cir.int<8> : !u64i

--- a/clang/test/CIR/CodeGen/noreturn.cpp
+++ b/clang/test/CIR/CodeGen/noreturn.cpp
@@ -6,7 +6,7 @@
 // RUN: FileCheck --input-file=%t.ll %s -check-prefixes=LLVM,OGCG
 
 extern "C" {
-// CIR: cir.func {{.*}} @bar() -> !s32i attributes {noreturn} {
+// CIR: cir.func {{.*}} @bar() -> !s32i attributes {{{.*}}noreturn{{.*}}} {
 // LLVM: Function Attrs:{{.*}} noreturn
 // LLVM-NEXT: define {{.*}} i32 @bar() #[[BAR_FOO_ATTR:.*]] {
 __attribute((noreturn))
@@ -17,7 +17,7 @@ int bar() { }
 // lowering puts the trap decl at the end, so it isn't here to worry about.
 // OGCG: declare void @llvm.trap
 
-// CIR: cir.func {{.*}} @foo() -> !s32i attributes {noreturn} {
+// CIR: cir.func {{.*}} @foo() -> !s32i attributes {{{.*}}noreturn{{.*}}} {
 // LLVM: Function Attrs:{{.*}} noreturn
 // LLVM-NEXT: define {{.*}} i32 @foo() #[[BAR_FOO_ATTR]] {
 [[noreturn]]

--- a/clang/test/CIR/CodeGen/optsize-func-attr.cpp
+++ b/clang/test/CIR/CodeGen/optsize-func-attr.cpp
@@ -40,7 +40,7 @@ extern "C" {
     // CIR: cir.call{{.*}}@optnone()
     // CIR-NOT: optsize
     // CIR-NOT: minsize
-    // LLVM: call void @optnone() #[[OPTNONE_ATTR]]
+    // LLVM: call void @optnone() #[[OPTNONE_CALL_ATTR:.*]]
     // OGCG: call void @optnone() #[[OPTNONE_CALL_ATTR:.*]]
 
     // CIR: cir.return
@@ -58,10 +58,13 @@ extern "C" {
 // attributes for caller, to block the 'NOT'.
 // BOTH: attributes
 //
-// CIR doesn't have sufficiently different 'attributes' implemented for the
-// caller and the callee to be different when doing -O settings (as 'optnone'
-// is the only difference).  So the below call attributes are only necessary
-// for classic codegen.
+// Call-site attributes differ from definition attributes because optnone,
+// noinline, etc. are definition-only. Verify the call attrs separately.
+// LLVM: attributes #[[OPTNONE_CALL_ATTR]]
+// LLVM-NOT: optsize
+// LLVM-NOT: minsize
+// LLVM: !llvm.
+//
 // OGCG: attributes #[[NORMAL_CALL_ATTR]]
 // OGCGOZ-SAME: minsize
 // OGCG-SAME: optsize
@@ -71,4 +74,4 @@ extern "C" {
 // OGCG-NOT: minsize
 //
 // to block the 'NOT'.
-// BOTH: !llvm.
+// OGCG: !llvm.

--- a/clang/test/CIR/CodeGen/pointer-to-data-member.cpp
+++ b/clang/test/CIR/CodeGen/pointer-to-data-member.cpp
@@ -46,14 +46,14 @@ int Point::*pt_member_nested_region = test1();
 
 // Checks for test1()
 
-// CIR-BEFORE: cir.func {{.*}} @_Z5test1v() -> !cir.data_member<!s32i in !rec_Point> {
+// CIR-BEFORE: cir.func {{.*}} @_Z5test1v() -> !cir.data_member<!s32i in !rec_Point>{{.*}}{
 // CIR-BEFORE:   %[[RETVAL:.*]] = cir.alloca !cir.data_member<!s32i in !rec_Point>, !cir.ptr<!cir.data_member<!s32i in !rec_Point>>, ["__retval"]
 // CIR-BEFORE:   %[[MEMBER:.*]] = cir.const #cir.data_member<1> : !cir.data_member<!s32i in !rec_Point>
 // CIR-BEFORE:   cir.store %[[MEMBER]], %[[RETVAL]] : !cir.data_member<!s32i in !rec_Point>, !cir.ptr<!cir.data_member<!s32i in !rec_Point>>
 // CIR-BEFORE:   %[[RET:.*]] = cir.load %[[RETVAL]] : !cir.ptr<!cir.data_member<!s32i in !rec_Point>>, !cir.data_member<!s32i in !rec_Point>
 // CIR-BEFORE:   cir.return %[[RET]] : !cir.data_member<!s32i in !rec_Point>
 
-// CIR-AFTER: cir.func {{.*}} @_Z5test1v() -> !s64i {
+// CIR-AFTER: cir.func {{.*}} @_Z5test1v() -> !s64i{{.*}}{
 // CIR-AFTER:   %[[RETVAL:.*]] = cir.alloca !s64i, !cir.ptr<!s64i>, ["__retval"]
 // CIR-AFTER:   %[[OFFSET:.*]] = cir.const #cir.int<4> : !s64i
 // CIR-AFTER:   cir.store %[[OFFSET]], %[[RETVAL]] : !s64i, !cir.ptr<!s64i>

--- a/clang/test/CIR/CodeGen/pointer-to-member-func.cpp
+++ b/clang/test/CIR/CodeGen/pointer-to-member-func.cpp
@@ -45,7 +45,7 @@ auto make_non_virtual() -> void (Foo::*)(int) {
 // CIR-BEFORE:   %[[RET:.*]] = cir.load %[[RETVAL]]
 // CIR-BEFORE:   cir.return %[[RET]] : !cir.method<!cir.func<(!cir.ptr<!rec_Foo>, !s32i)> in !rec_Foo>
 
-// CIR-AFTER: cir.func {{.*}} @_Z16make_non_virtualv() -> !rec_anon_struct {
+// CIR-AFTER: cir.func {{.*}} @_Z16make_non_virtualv() -> !rec_anon_struct{{.*}}{
 // CIR-AFTER:   %[[RETVAL:.*]] = cir.alloca !rec_anon_struct, !cir.ptr<!rec_anon_struct>, ["__retval"]
 // CIR-AFTER:   %[[METHOD_PTR:.*]] = cir.get_global @[[NONVIRT_RET]] : !cir.ptr<!rec_anon_struct>
 // CIR-AFTER:   cir.copy %[[METHOD_PTR]] to %[[RETVAL]] : !cir.ptr<!rec_anon_struct>

--- a/clang/test/CIR/CodeGen/ret-attrs.cpp
+++ b/clang/test/CIR/CodeGen/ret-attrs.cpp
@@ -16,7 +16,7 @@ struct Struct{};
 using MemPtrTy = void (Struct::*)();
 
 MemPtrTy not_noundef_memptr(MemPtrTy t){}
-// CIR: cir.func no_inline dso_local @_Z18not_noundef_memptrM6StructFvvE({{.*}}) -> !rec_anon_struct {
+// CIR: cir.func no_inline dso_local @_Z18not_noundef_memptrM6StructFvvE({{.*}}) -> !rec_anon_struct{{.*}}{
 // LLVM: define dso_local { i64, i64 } @_Z18not_noundef_memptrM6StructFvvE({{.*}})
 
 void not_noundef_void(){}

--- a/clang/test/CIR/CodeGen/side-effect.cpp
+++ b/clang/test/CIR/CodeGen/side-effect.cpp
@@ -8,7 +8,7 @@ extern "C" {
 
 // FIXME: We should figure out how to better print this on functions in the
 // future.
-// CIR: cir.func{{.*}}@pure_func() -> !s32i side_effect(pure) {
+// CIR: cir.func{{.*}}@pure_func() -> !s32i side_effect(pure){{.*}}{
 // LLVM: Function Attrs: {{.*}}nounwind{{.*}}willreturn{{.*}}memory(read)
 // LLVM: define{{.*}} @pure_func() #{{.*}} {
 // OGCG: Function Attrs: {{.*}}nounwind{{.*}}willreturn{{.*}}memory(read)
@@ -16,7 +16,7 @@ extern "C" {
 __attribute__((pure))
 int pure_func() { return 2;}
 
-// CIR: cir.func{{.*}}@const_func() -> !s32i side_effect(const) {
+// CIR: cir.func{{.*}}@const_func() -> !s32i side_effect(const){{.*}}{
 // LLVM: Function Attrs: {{.*}}nounwind{{.*}}willreturn{{.*}}memory(none)
 // LLVM: define{{.*}} @const_func() #{{.*}} {
 // OGCG: Function Attrs: {{.*}}nounwind{{.*}}willreturn{{.*}}memory(none)

--- a/clang/test/CIR/CodeGen/ternary.cpp
+++ b/clang/test/CIR/CodeGen/ternary.cpp
@@ -10,7 +10,7 @@ int x(int y) {
 }
 
 // CIR-LABEL: cir.func{{.*}} @_Z1xi(
-// CIR-SAME: %[[ARG0:.*]]: !s32i {{.*}}) -> (!s32i{{.*}}) {
+// CIR-SAME: %[[ARG0:.*]]: !s32i {{.*}}) -> (!s32i{{.*}}){{.*}}{
 // CIR: [[Y:%.+]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["y", init]
 // CIR: [[RETVAL:%.+]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["__retval"]
 // CIR: cir.store %[[ARG0]], [[Y]] : !s32i, !cir.ptr<!s32i>
@@ -52,7 +52,7 @@ int foo(int a, int b) {
 }
 
 // CIR-LABEL: cir.func{{.*}} @_Z3fooii(
-// CIR-SAME: %[[ARG0:.*]]: !s32i {{.*}}, %[[ARG1:.*]]: !s32i {{.*}}) -> (!s32i{{.*}}) {
+// CIR-SAME: %[[ARG0:.*]]: !s32i {{.*}}, %[[ARG1:.*]]: !s32i {{.*}}) -> (!s32i{{.*}}){{.*}}{
 // CIR: [[A:%.+]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["a", init]
 // CIR: [[B:%.+]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["b", init]
 // CIR: [[RETVAL:%.+]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["__retval"]

--- a/clang/test/CIR/CodeGen/try-catch-tmp.cpp
+++ b/clang/test/CIR/CodeGen/try-catch-tmp.cpp
@@ -596,7 +596,7 @@ void cleanup_inside_try_body() {
   }
 }
 
-// CIR: cir.func {{.*}} @_Z23cleanup_inside_try_bodyv(){{.*}} personality(@__gxx_personality_v0) {
+// CIR: cir.func {{.*}} @_Z23cleanup_inside_try_bodyv(){{.*}} personality(@__gxx_personality_v0){{.*}}{
 // CIR: cir.scope {
 // CIR:   %[[S:.*]] = cir.alloca !rec_S, !cir.ptr<!rec_S>, ["s"]
 // CIR:   cir.try {

--- a/clang/test/CIR/CodeGenBuiltins/builtin-fcmp-sse.c
+++ b/clang/test/CIR/CodeGenBuiltins/builtin-fcmp-sse.c
@@ -10,7 +10,7 @@ typedef double __m128d __attribute__((__vector_size__(16), __aligned__(16)));
 
 __m128 test_cmpnleps(__m128 A, __m128 B) {
   // CIR-LABEL:   cir.func no_inline dso_local @test_cmpnleps(
-  // CIR:           %[[ARG0:.*]]: !cir.vector<4 x !cir.float> {{.*}}, %[[ARG1:.*]]: !cir.vector<4 x !cir.float> {{.*}}) -> !cir.vector<4 x !cir.float> {
+  // CIR:           %[[ARG0:.*]]: !cir.vector<4 x !cir.float> {{.*}}, %[[ARG1:.*]]: !cir.vector<4 x !cir.float> {{.*}}) -> !cir.vector<4 x !cir.float>{{.*}}{
   // CIR:           %[[ALLOCA_0:.*]] = cir.alloca !cir.vector<4 x !cir.float>, !cir.ptr<!cir.vector<4 x !cir.float>>, ["A", init] {alignment = 16 : i64}
   // CIR:           %[[ALLOCA_1:.*]] = cir.alloca !cir.vector<4 x !cir.float>, !cir.ptr<!cir.vector<4 x !cir.float>>, ["B", init] {alignment = 16 : i64}
   // CIR:           %[[ALLOCA_2:.*]] = cir.alloca !cir.vector<4 x !cir.float>, !cir.ptr<!cir.vector<4 x !cir.float>>, ["__retval"] {alignment = 16 : i64}
@@ -61,7 +61,7 @@ __m128 test_cmpnleps(__m128 A, __m128 B) {
 
 __m128d test_cmpnlepd(__m128d A, __m128d B) {
   // CIR-LABEL:   cir.func no_inline dso_local @test_cmpnlepd(
-  // CIR:           %[[ARG0:.*]]: !cir.vector<2 x !cir.double> {{.*}}, %[[ARG1:.*]]: !cir.vector<2 x !cir.double> {{.*}}) -> !cir.vector<2 x !cir.double> {
+  // CIR:           %[[ARG0:.*]]: !cir.vector<2 x !cir.double> {{.*}}, %[[ARG1:.*]]: !cir.vector<2 x !cir.double> {{.*}}) -> !cir.vector<2 x !cir.double>{{.*}}{
   // CIR:           %[[ALLOCA_0:.*]] = cir.alloca !cir.vector<2 x !cir.double>, !cir.ptr<!cir.vector<2 x !cir.double>>, ["A", init] {alignment = 16 : i64} 
   // CIR:           %[[ALLOCA_1:.*]] = cir.alloca !cir.vector<2 x !cir.double>, !cir.ptr<!cir.vector<2 x !cir.double>>, ["B", init] {alignment = 16 : i64} 
   // CIR:           %[[ALLOCA_2:.*]] = cir.alloca !cir.vector<2 x !cir.double>, !cir.ptr<!cir.vector<2 x !cir.double>>, ["__retval"] {alignment = 16 : i64} 
@@ -112,7 +112,7 @@ __m128d test_cmpnlepd(__m128d A, __m128d B) {
 
 __m128 test_cmpnltps(__m128 A, __m128 B) {
   // CIR-LABEL:   cir.func no_inline dso_local @test_cmpnltps(
-  // CIR:           %[[ARG0:.*]]: !cir.vector<4 x !cir.float> {{.*}}, %[[ARG1:.*]]: !cir.vector<4 x !cir.float> {{.*}}) -> !cir.vector<4 x !cir.float> {
+  // CIR:           %[[ARG0:.*]]: !cir.vector<4 x !cir.float> {{.*}}, %[[ARG1:.*]]: !cir.vector<4 x !cir.float> {{.*}}) -> !cir.vector<4 x !cir.float>{{.*}}{
   // CIR:           %[[ALLOCA_0:.*]] = cir.alloca !cir.vector<4 x !cir.float>, !cir.ptr<!cir.vector<4 x !cir.float>>, ["A", init] {alignment = 16 : i64} 
   // CIR:           %[[ALLOCA_1:.*]] = cir.alloca !cir.vector<4 x !cir.float>, !cir.ptr<!cir.vector<4 x !cir.float>>, ["B", init] {alignment = 16 : i64} 
   // CIR:           %[[ALLOCA_2:.*]] = cir.alloca !cir.vector<4 x !cir.float>, !cir.ptr<!cir.vector<4 x !cir.float>>, ["__retval"] {alignment = 16 : i64} 
@@ -163,7 +163,7 @@ __m128 test_cmpnltps(__m128 A, __m128 B) {
 
 __m128d test_cmpnltpd(__m128d A, __m128d B) {
   // CIR-LABEL:   cir.func no_inline dso_local @test_cmpnltpd(
-  // CIR:           %[[ARG0:.*]]: !cir.vector<2 x !cir.double> {{.*}}, %[[ARG1:.*]]: !cir.vector<2 x !cir.double> {{.*}}) -> !cir.vector<2 x !cir.double> {
+  // CIR:           %[[ARG0:.*]]: !cir.vector<2 x !cir.double> {{.*}}, %[[ARG1:.*]]: !cir.vector<2 x !cir.double> {{.*}}) -> !cir.vector<2 x !cir.double>{{.*}}{
   // CIR:           %[[ALLOCA_0:.*]] = cir.alloca !cir.vector<2 x !cir.double>, !cir.ptr<!cir.vector<2 x !cir.double>>, ["A", init] {alignment = 16 : i64} 
   // CIR:           %[[ALLOCA_1:.*]] = cir.alloca !cir.vector<2 x !cir.double>, !cir.ptr<!cir.vector<2 x !cir.double>>, ["B", init] {alignment = 16 : i64} 
   // CIR:           %[[ALLOCA_2:.*]] = cir.alloca !cir.vector<2 x !cir.double>, !cir.ptr<!cir.vector<2 x !cir.double>>, ["__retval"] {alignment = 16 : i64} 

--- a/clang/test/CIR/CodeGenCUDA/kernel-stub-name.cu
+++ b/clang/test/CIR/CodeGenCUDA/kernel-stub-name.cu
@@ -6,17 +6,17 @@
 
 #include "Inputs/cuda.h"
 
-// CHECK: cir.func {{.*}} @[[CSTUB:__device_stub__ckernel]]() attributes {cu.kernel_name = #cir.cu.kernel_name<ckernel>}
+// CHECK: cir.func {{.*}} @[[CSTUB:__device_stub__ckernel]]() attributes {{{.*}}cu.kernel_name = #cir.cu.kernel_name<ckernel>{{.*}}}
 // CHECK: cir.return
 // CHECK-NEXT: }
 extern "C" __global__ void ckernel() {}
 
-// CHECK: cir.func {{.*}} @_ZN2ns23__device_stub__nskernelEv() attributes {cu.kernel_name = #cir.cu.kernel_name<_ZN2ns8nskernelEv>}
+// CHECK: cir.func {{.*}} @_ZN2ns23__device_stub__nskernelEv() attributes {{{.*}}cu.kernel_name = #cir.cu.kernel_name<_ZN2ns8nskernelEv>{{.*}}}
 namespace ns {
 __global__ void nskernel() {}
 } // namespace ns
 
-// CHECK: cir.func {{.*}} @_Z25__device_stub__kernelfuncIiEvv() attributes {cu.kernel_name = #cir.cu.kernel_name<_Z10kernelfuncIiEvv>}
+// CHECK: cir.func {{.*}} @_Z25__device_stub__kernelfuncIiEvv() attributes {{{.*}}cu.kernel_name = #cir.cu.kernel_name<_Z10kernelfuncIiEvv>{{.*}}}
 template <class T>
 __global__ void kernelfunc() {}
 template __global__ void kernelfunc<int>();

--- a/clang/test/CIR/CodeGenCXX/global-refs.cpp
+++ b/clang/test/CIR/CodeGenCXX/global-refs.cpp
@@ -51,7 +51,7 @@ WithCtor withCtor{};
 // CIR-BEFORE-NEXT:    cir.call @_ZN8WithCtorC1Ev(%[[GET_GLOB]]) : (!cir.ptr<!rec_WithCtor>{{.*}}) -> ()
 // CIR-BEFORE-NEXT:  } {alignment = 1 : i64, ast = #cir.var.decl.ast}
 // CIR-AFTER: cir.global external @withCtor = #cir.zero : !rec_WithCtor {alignment = 1 : i64, ast = #cir.var.decl.ast}
-// CIR-AFTER-NEXT: cir.func internal private @__cxx_global_var_init{{.*}}() {
+// CIR-AFTER-NEXT: cir.func internal private @__cxx_global_var_init{{.*}}(){{.*}}{
 // CIR-AFTER-NEXT:   %[[GET_GLOB:.*]] = cir.get_global @withCtor : !cir.ptr<!rec_WithCtor>
 // CIR-AFTER-NEXT:   cir.call @_ZN8WithCtorC1Ev(%[[GET_GLOB]]) : (!cir.ptr<!rec_WithCtor>{{.*}}) -> ()
 // CIR-AFTER-NEXT:   cir.return
@@ -70,7 +70,7 @@ const WithCtor &constWithCtorRef{};
 // CIR-BEFORE-NEXT:   cir.store align(8) %[[GET_GLOB_OBJ]], %[[GET_GLOB]] : !cir.ptr<!rec_WithCtor>, !cir.ptr<!cir.ptr<!rec_WithCtor>>
 // CIR-BEFORE-NEXT: } {alignment = 8 : i64, ast = #cir.var.decl.ast}
 // CIR-AFTER: cir.global external @constWithCtorRef = #cir.ptr<null> : !cir.ptr<!rec_WithCtor> {alignment = 8 : i64, ast = #cir.var.decl.ast}
-// CIR-AFTER-NEXT: cir.func internal private @__cxx_global_var_init{{.*}}() {
+// CIR-AFTER-NEXT: cir.func internal private @__cxx_global_var_init{{.*}}(){{.*}}{
 // CIR-AFTER-NEXT:   %[[GET_GLOB:.*]] = cir.get_global @constWithCtorRef : !cir.ptr<!cir.ptr<!rec_WithCtor>>
 // CIR-AFTER-NEXT:   %[[GET_GLOB_OBJ:.*]] = cir.get_global @_ZGR16constWithCtorRef_ : !cir.ptr<!rec_WithCtor>
 // CIR-AFTER-NEXT:   cir.call @_ZN8WithCtorC1Ev(%[[GET_GLOB_OBJ]]) : (!cir.ptr<!rec_WithCtor>{{.*}}) -> ()
@@ -88,7 +88,7 @@ const WithCtor &constWithCtorRef2{5};
 // CIR-BEFORE-NEXT:   cir.store align(8) %[[GET_GLOB_OBJ]], %[[GET_GLOB]] : !cir.ptr<!rec_WithCtor>, !cir.ptr<!cir.ptr<!rec_WithCtor>>
 // CIR-BEFORE-NEXT: } {alignment = 8 : i64, ast = #cir.var.decl.ast}
 // CIR-AFTER: cir.global external @constWithCtorRef2 = #cir.ptr<null> : !cir.ptr<!rec_WithCtor> {alignment = 8 : i64, ast = #cir.var.decl.ast}
-// CIR-AFTER-NEXT: cir.func internal private @__cxx_global_var_init{{.*}}() {
+// CIR-AFTER-NEXT: cir.func internal private @__cxx_global_var_init{{.*}}(){{.*}}{
 // CIR-AFTER-NEXT:   %[[GET_GLOB:.*]] = cir.get_global @constWithCtorRef2 : !cir.ptr<!cir.ptr<!rec_WithCtor>>
 // CIR-AFTER-NEXT:   %[[GET_GLOB_OBJ:.*]] = cir.get_global @_ZGR17constWithCtorRef2_ : !cir.ptr<!rec_WithCtor>
 // CIR-AFTER-NEXT:   %[[FIVE:.*]] = cir.const #cir.int<5> : !s32i
@@ -107,7 +107,7 @@ WithCtorDtor withCtorDtor{};
 // CIR-BEFORE-NEXT:   cir.call @_ZN12WithCtorDtorD1Ev(%[[GET_GLOB]]) : (!cir.ptr<!rec_WithCtorDtor>{{.*}}) -> ()
 // CIR-BEFORE-NEXT: } {alignment = 1 : i64, ast = #cir.var.decl.ast}
 // CIR-AFTER: cir.global external @withCtorDtor = #cir.zero : !rec_WithCtorDtor {alignment = 1 : i64, ast = #cir.var.decl.ast}
-// CIR-AFTER: cir.func internal private @__cxx_global_var_init{{.*}}() {
+// CIR-AFTER: cir.func internal private @__cxx_global_var_init{{.*}}(){{.*}}{
 // CIR-AFTER-NEXT:   %[[GET_GLOB:.*]] = cir.get_global @withCtorDtor : !cir.ptr<!rec_WithCtorDtor>
 // CIR-AFTER-NEXT:   cir.call @_ZN12WithCtorDtorC1Ev(%[[GET_GLOB]]) : (!cir.ptr<!rec_WithCtorDtor>{{.*}}) -> ()
 // CIR-AFTER-NEXT:   %[[GET_GLOB:.*]] = cir.get_global @withCtorDtor : !cir.ptr<!rec_WithCtorDtor> 

--- a/clang/test/CIR/CodeGenCXX/simple-reinterpret-const-cast.cpp
+++ b/clang/test/CIR/CodeGenCXX/simple-reinterpret-const-cast.cpp
@@ -7,7 +7,7 @@ struct S { void do_thing(); };
 void test_const_cast(const S &s) {
   const_cast<S&>(s).do_thing();
 }
-// CIR: cir.func {{.*}}@_Z15test_const_castRK1S(%[[ARG:.*]]: !cir.ptr<!rec_S>{{.*}}) {
+// CIR: cir.func {{.*}}@_Z15test_const_castRK1S(%[[ARG:.*]]: !cir.ptr<!rec_S>{{.*}}){{.*}}{
 // CIR-NEXT:   %[[ARG_ALLOCA:.*]] = cir.alloca !cir.ptr<!rec_S>, !cir.ptr<!cir.ptr<!rec_S>>, ["s", init, const]
 // CIR-NEXT:   cir.store %[[ARG]], %[[ARG_ALLOCA]] : !cir.ptr<!rec_S>, !cir.ptr<!cir.ptr<!rec_S>>
 // CIR-NEXT:   %[[ARG_LOAD:.*]] = cir.load %[[ARG_ALLOCA]] : !cir.ptr<!cir.ptr<!rec_S>>, !cir.ptr<!rec_S>
@@ -25,7 +25,7 @@ void test_reinterpet_cast(void *&data) {
   call_with_ri_cast(reinterpret_cast<S*&>(data));
   call_with_ri_cast(reinterpret_cast<int*&>(data));
 }
-// CIR: cir.func {{.*}}@_Z20test_reinterpet_castRPv(%[[ARG:.*]]: !cir.ptr<!cir.ptr<!void>>{{.*}}) {
+// CIR: cir.func {{.*}}@_Z20test_reinterpet_castRPv(%[[ARG:.*]]: !cir.ptr<!cir.ptr<!void>>{{.*}}){{.*}}{
 // CIR-NEXT:   %[[ARG_ALLOCA:.*]] = cir.alloca !cir.ptr<!cir.ptr<!void>>, !cir.ptr<!cir.ptr<!cir.ptr<!void>>>, ["data", init, const]
 // CIR-NEXT:   cir.store %[[ARG]], %[[ARG_ALLOCA]] : !cir.ptr<!cir.ptr<!void>>, !cir.ptr<!cir.ptr<!cir.ptr<!void>>>
 // CIR-NEXT:   %[[ARG_LOAD:.*]] = cir.load %[[ARG_ALLOCA]] : !cir.ptr<!cir.ptr<!cir.ptr<!void>>>, !cir.ptr<!cir.ptr<!void>>

--- a/clang/test/CIR/CodeGenOpenACC/atomic-capture.cpp
+++ b/clang/test/CIR/CodeGenOpenACC/atomic-capture.cpp
@@ -8,7 +8,7 @@ struct HasOps {
 };
 
 void use(int x, int v, float f, HasOps ops) {
-  // CHECK: cir.func{{.*}}(%[[X_ARG:.*]]: !s32i{{.*}}, %[[V_ARG:.*]]: !s32i{{.*}}, %[[F_ARG:.*]]: !cir.float{{.*}}){{.*}}, %[[OPS_ARG:.*]]: !rec_HasOps{{.*}}) {
+  // CHECK: cir.func{{.*}}(%[[X_ARG:.*]]: !s32i{{.*}}, %[[V_ARG:.*]]: !s32i{{.*}}, %[[F_ARG:.*]]: !cir.float{{.*}}){{.*}}, %[[OPS_ARG:.*]]: !rec_HasOps{{.*}}){{.*}}{
   // CHECK-NEXT: %[[X_ALLOCA:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["x", init]
   // CHECK-NEXT: %[[V_ALLOCA:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["v", init]
   // CHECK-NEXT: %[[F_ALLOCA:.*]] = cir.alloca !cir.float, !cir.ptr<!cir.float>, ["f", init]

--- a/clang/test/CIR/CodeGenOpenACC/atomic-update.cpp
+++ b/clang/test/CIR/CodeGenOpenACC/atomic-update.cpp
@@ -6,7 +6,7 @@ struct HasOps {
 };
 
 void use(int x, unsigned int y, float f, HasOps ops) {
-  // CHECK: cir.func{{.*}}(%[[X_ARG:.*]]: !s32i{{.*}}, %[[Y_ARG:.*]]: !u32i{{.*}}, %[[F_ARG:.*]]: !cir.float{{.*}}){{.*}}, %[[OPS_ARG:.*]]: !rec_HasOps{{.*}}) {
+  // CHECK: cir.func{{.*}}(%[[X_ARG:.*]]: !s32i{{.*}}, %[[Y_ARG:.*]]: !u32i{{.*}}, %[[F_ARG:.*]]: !cir.float{{.*}}){{.*}}, %[[OPS_ARG:.*]]: !rec_HasOps{{.*}}){{.*}}{
   // CHECK-NEXT: %[[X_ALLOCA:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["x", init]
   // CHECK-NEXT: %[[Y_ALLOCA:.*]] = cir.alloca !u32i, !cir.ptr<!u32i>, ["y", init]
   // CHECK-NEXT: %[[F_ALLOCA:.*]] = cir.alloca !cir.float, !cir.ptr<!cir.float>, ["f", init]

--- a/clang/test/CIR/CodeGenOpenACC/atomic-write.cpp
+++ b/clang/test/CIR/CodeGenOpenACC/atomic-write.cpp
@@ -8,7 +8,7 @@ struct ConvertsToScalar {
 };
 
 void use(int x, unsigned int y, float f, ConvertsToScalar cts) {
-  // CHECK: cir.func{{.*}}(%[[X_ARG:.*]]: !s32i{{.*}}, %[[Y_ARG:.*]]: !u32i{{.*}}, %[[F_ARG:.*]]: !cir.float{{.*}}){{.*}}, %[[CTS_ARG:.*]]: !rec_ConvertsToScalar{{.*}}) {
+  // CHECK: cir.func{{.*}}(%[[X_ARG:.*]]: !s32i{{.*}}, %[[Y_ARG:.*]]: !u32i{{.*}}, %[[F_ARG:.*]]: !cir.float{{.*}}){{.*}}, %[[CTS_ARG:.*]]: !rec_ConvertsToScalar{{.*}}){{.*}}{
   // CHECK-NEXT: %[[X_ALLOC:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["x", init]
   // CHECK-NEXT: %[[Y_ALLOC:.*]] = cir.alloca !u32i, !cir.ptr<!u32i>, ["y", init]
   // CHECK-NEXT: %[[F_ALLOC:.*]] = cir.alloca !cir.float, !cir.ptr<!cir.float>, ["f", init]

--- a/clang/test/CIR/CodeGenOpenACC/combined-copyin-copyout-create.c
+++ b/clang/test/CIR/CodeGenOpenACC/combined-copyin-copyout-create.c
@@ -1,7 +1,7 @@
 // RUN: %clang_cc1 -fopenacc -Wno-openacc-self-if-potential-conflict -emit-cir -fclangir %s -o - | FileCheck %s
 
 void acc_combined(int parmVar) {
-  // CHECK: cir.func{{.*}} @acc_combined(%[[ARG:.*]]: !s32i{{.*}}) {
+  // CHECK: cir.func{{.*}} @acc_combined(%[[ARG:.*]]: !s32i{{.*}}){{.*}}{
   // CHECK-NEXT: %[[PARM:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["parmVar", init]
 
   int localVar1;

--- a/clang/test/CIR/CodeGenOpenACC/combined.cpp
+++ b/clang/test/CIR/CodeGenOpenACC/combined.cpp
@@ -1,7 +1,7 @@
 // RUN: %clang_cc1 -fopenacc -Wno-openacc-self-if-potential-conflict -emit-cir -fclangir %s -o - | FileCheck %s
 
 extern "C" void acc_combined(int N, int cond) {
-  // CHECK: cir.func{{.*}} @acc_combined(%[[ARG_N:.*]]: !s32i {{.*}}, %[[ARG_COND:.*]]: !s32i {{.*}}) {
+  // CHECK: cir.func{{.*}} @acc_combined(%[[ARG_N:.*]]: !s32i {{.*}}, %[[ARG_COND:.*]]: !s32i {{.*}}){{.*}}{
   // CHECK-NEXT: %[[ALLOCA_N:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["N", init]
   // CHECK-NEXT: %[[COND:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["cond", init]
   // CHECK-NEXT: cir.store %[[ARG_N]], %[[ALLOCA_N]] : !s32i, !cir.ptr<!s32i>
@@ -1012,7 +1012,7 @@ extern "C" void acc_combined(int N, int cond) {
   // CHECK-NEXT: } loc
 }
 extern "C" void acc_combined_data_clauses(int *arg1, int *arg2) {
-  // CHECK: cir.func{{.*}} @acc_combined_data_clauses(%[[ARG1_PARAM:.*]]: !cir.ptr<!s32i>{{.*}}, %[[ARG2_PARAM:.*]]: !cir.ptr<!s32i>{{.*}}) {
+  // CHECK: cir.func{{.*}} @acc_combined_data_clauses(%[[ARG1_PARAM:.*]]: !cir.ptr<!s32i>{{.*}}, %[[ARG2_PARAM:.*]]: !cir.ptr<!s32i>{{.*}}){{.*}}{
   // CHECK-NEXT: %[[ARG1:.*]] = cir.alloca !cir.ptr<!s32i>, !cir.ptr<!cir.ptr<!s32i>>, ["arg1", init]
   // CHECK-NEXT: %[[ARG2:.*]] = cir.alloca !cir.ptr<!s32i>, !cir.ptr<!cir.ptr<!s32i>>, ["arg2", init]
   // CHECK-NEXT: cir.store %[[ARG1_PARAM]], %[[ARG1]] : !cir.ptr<!s32i>, !cir.ptr<!cir.ptr<!s32i>>

--- a/clang/test/CIR/CodeGenOpenACC/compute-copyin-copyout-create.c
+++ b/clang/test/CIR/CodeGenOpenACC/compute-copyin-copyout-create.c
@@ -1,7 +1,7 @@
 // RUN: %clang_cc1 -fopenacc -Wno-openacc-self-if-potential-conflict -emit-cir -fclangir %s -o - | FileCheck %s
 
 void acc_compute(int parmVar) {
-  // CHECK: cir.func{{.*}} @acc_compute(%[[ARG:.*]]: !s32i{{.*}}) {
+  // CHECK: cir.func{{.*}} @acc_compute(%[[ARG:.*]]: !s32i{{.*}}){{.*}}{
   // CHECK-NEXT: %[[PARM:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["parmVar", init]
 
   int localVar1;

--- a/clang/test/CIR/CodeGenOpenACC/compute-firstprivate-clause-templates.cpp
+++ b/clang/test/CIR/CodeGenOpenACC/compute-firstprivate-clause-templates.cpp
@@ -61,7 +61,7 @@ struct HasDtor {
 
 template<typename T, typename U, typename V, typename W>
 void dependent_version(const T &cc, const U &ndc, const V &dtor, const W &someInt) {
-  // CHECK: cir.func {{.*}}@_Z17dependent_versionI13CopyConstruct14NonDefaultCtor7HasDtoriEvRKT_RKT0_RKT1_RKT2_(%[[ARG0:.*]]: !cir.ptr<!rec_CopyConstruct> {{.*}}, %[[ARG1:.*]]: !cir.ptr<!rec_NonDefaultCtor> {{.*}}, %[[ARG2:.*]]: !cir.ptr<!rec_HasDtor> {{.*}}, %[[ARG3:.*]]: !cir.ptr<!s32i> {{.*}}) {
+  // CHECK: cir.func {{.*}}@_Z17dependent_versionI13CopyConstruct14NonDefaultCtor7HasDtoriEvRKT_RKT0_RKT1_RKT2_(%[[ARG0:.*]]: !cir.ptr<!rec_CopyConstruct> {{.*}}, %[[ARG1:.*]]: !cir.ptr<!rec_NonDefaultCtor> {{.*}}, %[[ARG2:.*]]: !cir.ptr<!rec_HasDtor> {{.*}}, %[[ARG3:.*]]: !cir.ptr<!s32i> {{.*}}){{.*}}{
   // CHECK-NEXT: %[[CC:.*]] = cir.alloca !cir.ptr<!rec_CopyConstruct>, !cir.ptr<!cir.ptr<!rec_CopyConstruct>>, ["cc", init, const]
   // CHECK-NEXT: %[[NDC:.*]] = cir.alloca !cir.ptr<!rec_NonDefaultCtor>, !cir.ptr<!cir.ptr<!rec_NonDefaultCtor>>, ["ndc", init, const]
   // CHECK-NEXT: %[[DTOR:.*]] = cir.alloca !cir.ptr<!rec_HasDtor>, !cir.ptr<!cir.ptr<!rec_HasDtor>>, ["dtor", init, const]

--- a/clang/test/CIR/CodeGenOpenACC/compute-private-clause-templates.cpp
+++ b/clang/test/CIR/CodeGenOpenACC/compute-private-clause-templates.cpp
@@ -44,7 +44,7 @@ struct HasDtor {
 
 template<typename T, typename U, typename V, typename W>
 void dependent_version(const T &cc, const U &ndc, const V &dtor, const W &someInt) {
-  // CHECK: cir.func {{.*}}@_Z17dependent_versionI13CopyConstruct14NonDefaultCtor7HasDtoriEvRKT_RKT0_RKT1_RKT2_(%[[ARG0:.*]]: !cir.ptr<!rec_CopyConstruct> {{.*}}, %[[ARG1:.*]]: !cir.ptr<!rec_NonDefaultCtor> {{.*}}, %[[ARG2:.*]]: !cir.ptr<!rec_HasDtor> {{.*}}, %[[ARG3:.*]]: !cir.ptr<!s32i> {{.*}}) {
+  // CHECK: cir.func {{.*}}@_Z17dependent_versionI13CopyConstruct14NonDefaultCtor7HasDtoriEvRKT_RKT0_RKT1_RKT2_(%[[ARG0:.*]]: !cir.ptr<!rec_CopyConstruct> {{.*}}, %[[ARG1:.*]]: !cir.ptr<!rec_NonDefaultCtor> {{.*}}, %[[ARG2:.*]]: !cir.ptr<!rec_HasDtor> {{.*}}, %[[ARG3:.*]]: !cir.ptr<!s32i> {{.*}}){{.*}}{
   // CHECK-NEXT: %[[CC:.*]] = cir.alloca !cir.ptr<!rec_CopyConstruct>, !cir.ptr<!cir.ptr<!rec_CopyConstruct>>, ["cc", init, const]
   // CHECK-NEXT: %[[NDC:.*]] = cir.alloca !cir.ptr<!rec_NonDefaultCtor>, !cir.ptr<!cir.ptr<!rec_NonDefaultCtor>>, ["ndc", init, const]
   // CHECK-NEXT: %[[DTOR:.*]] = cir.alloca !cir.ptr<!rec_HasDtor>, !cir.ptr<!cir.ptr<!rec_HasDtor>>, ["dtor", init, const]

--- a/clang/test/CIR/CodeGenOpenACC/data-copy-copyin-copyout-create.c
+++ b/clang/test/CIR/CodeGenOpenACC/data-copy-copyin-copyout-create.c
@@ -1,7 +1,7 @@
 // RUN: %clang_cc1 -fopenacc -Wno-openacc-self-if-potential-conflict -emit-cir -fclangir %s -o - | FileCheck %s
 
 void acc_data(int parmVar) {
-  // CHECK: cir.func{{.*}} @acc_data(%[[ARG:.*]]: !s32i{{.*}}) {
+  // CHECK: cir.func{{.*}} @acc_data(%[[ARG:.*]]: !s32i{{.*}}){{.*}}{
   // CHECK-NEXT: %[[PARM:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["parmVar", init]
   int localVar1;
   // CHECK-NEXT: %[[LV1:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["localVar1"]

--- a/clang/test/CIR/CodeGenOpenACC/data.c
+++ b/clang/test/CIR/CodeGenOpenACC/data.c
@@ -1,7 +1,7 @@
 // RUN: %clang_cc1 -fopenacc -emit-cir -fclangir %s -o - | FileCheck %s
 
 void acc_data(int cond) {
-  // CHECK: cir.func{{.*}} @acc_data(%[[ARG:.*]]: !s32i{{.*}}) {
+  // CHECK: cir.func{{.*}} @acc_data(%[[ARG:.*]]: !s32i{{.*}}){{.*}}{
   // CHECK-NEXT: %[[COND:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["cond", init]
 
   int *ptr;

--- a/clang/test/CIR/CodeGenOpenACC/declare-link.cpp
+++ b/clang/test/CIR/CodeGenOpenACC/declare-link.cpp
@@ -117,7 +117,7 @@ int AnonNSInt1;
 struct Struct {
 
   void MemFunc1() {
-    // CHECK: cir.func {{.*}}MemFunc1{{.*}}({{.*}}) {
+    // CHECK: cir.func {{.*}}MemFunc1{{.*}}({{.*}}){{.*}}{
     // CHECK-NEXT: cir.alloca{{.*}}["this"
     // CHECK-NEXT: cir.store
     // CHECK-NEXT: cir.load
@@ -160,7 +160,7 @@ void use() {
 }
 
 void Struct::MemFunc2() {
-    // CHECK: cir.func {{.*}}MemFunc2{{.*}}({{.*}}) {
+    // CHECK: cir.func {{.*}}MemFunc2{{.*}}({{.*}}){{.*}}{
     // CHECK-NEXT: cir.alloca{{.*}}["this"
     // CHECK-NEXT: cir.store
     // CHECK-NEXT: cir.load

--- a/clang/test/CIR/CodeGenOpenACC/enter-data.c
+++ b/clang/test/CIR/CodeGenOpenACC/enter-data.c
@@ -1,6 +1,6 @@
 // RUN: %clang_cc1 -fopenacc -Wno-openacc-self-if-potential-conflict -emit-cir -fclangir %s -o - | FileCheck %s
 void acc_data(int parmVar, int *ptrParmVar) {
-  // CHECK: cir.func{{.*}} @acc_data(%[[ARG:.*]]: !s32i{{.*}}, %[[PTRARG:.*]]: !cir.ptr<!s32i>{{.*}}) {
+  // CHECK: cir.func{{.*}} @acc_data(%[[ARG:.*]]: !s32i{{.*}}, %[[PTRARG:.*]]: !cir.ptr<!s32i>{{.*}}){{.*}}{
   // CHECK-NEXT: %[[PARM:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["parmVar", init]
   // CHECK-NEXT: %[[PTRPARM:.*]] = cir.alloca !cir.ptr<!s32i>, !cir.ptr<!cir.ptr<!s32i>>, ["ptrParmVar", init]
   // CHECK-NEXT: cir.store %[[ARG]], %[[PARM]] : !s32i, !cir.ptr<!s32i>

--- a/clang/test/CIR/CodeGenOpenACC/exit-data.c
+++ b/clang/test/CIR/CodeGenOpenACC/exit-data.c
@@ -1,6 +1,6 @@
 // RUN: %clang_cc1 -fopenacc -Wno-openacc-self-if-potential-conflict -emit-cir -fclangir %s -o - | FileCheck %s
 void acc_data(int parmVar, int *ptrParmVar) {
-  // CHECK: cir.func{{.*}} @acc_data(%[[ARG:.*]]: !s32i{{.*}}, %[[PTRARG:.*]]: !cir.ptr<!s32i>{{.*}}) {
+  // CHECK: cir.func{{.*}} @acc_data(%[[ARG:.*]]: !s32i{{.*}}, %[[PTRARG:.*]]: !cir.ptr<!s32i>{{.*}}){{.*}}{
   // CHECK-NEXT: %[[PARM:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["parmVar", init]
   // CHECK-NEXT: %[[PTRPARM:.*]] = cir.alloca !cir.ptr<!s32i>, !cir.ptr<!cir.ptr<!s32i>>, ["ptrParmVar", init]
   // CHECK-NEXT: cir.store %[[ARG]], %[[PARM]] : !s32i, !cir.ptr<!s32i>

--- a/clang/test/CIR/CodeGenOpenACC/host_data.c
+++ b/clang/test/CIR/CodeGenOpenACC/host_data.c
@@ -1,7 +1,7 @@
 // RUN: %clang_cc1 -fopenacc -Wno-openacc-self-if-potential-conflict -emit-cir -fclangir %s -o - | FileCheck %s
 
 void acc_host_data(int cond, int var1, int var2, int *arr) {
-  // CHECK: cir.func{{.*}} @acc_host_data(%[[ARG_COND:.*]]: !s32i {{.*}}, %[[ARG_V1:.*]]: !s32i {{.*}}, %[[ARG_V2:.*]]: !s32i {{.*}}, %[[ARG_ARR:.*]]: !cir.ptr<!s32i> {{.*}}) {
+  // CHECK: cir.func{{.*}} @acc_host_data(%[[ARG_COND:.*]]: !s32i {{.*}}, %[[ARG_V1:.*]]: !s32i {{.*}}, %[[ARG_V2:.*]]: !s32i {{.*}}, %[[ARG_ARR:.*]]: !cir.ptr<!s32i> {{.*}}){{.*}}{
   // CHECK-NEXT: %[[COND:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["cond", init]
   // CHECK-NEXT: %[[V1:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["var1", init]
   // CHECK-NEXT: %[[V2:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["var2", init]

--- a/clang/test/CIR/CodeGenOpenACC/init.c
+++ b/clang/test/CIR/CodeGenOpenACC/init.c
@@ -1,7 +1,7 @@
 // RUN: %clang_cc1 -fopenacc -emit-cir -fclangir %s -o - | FileCheck %s
 
 void acc_init(int cond) {
-  // CHECK: cir.func{{.*}} @acc_init(%[[ARG:.*]]: !s32i{{.*}}) {
+  // CHECK: cir.func{{.*}} @acc_init(%[[ARG:.*]]: !s32i{{.*}}){{.*}}{
   // CHECK-NEXT: %[[COND:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["cond", init]
   // CHECK-NEXT: cir.store %[[ARG]], %[[COND]] : !s32i, !cir.ptr<!s32i>
 #pragma acc init

--- a/clang/test/CIR/CodeGenOpenACC/kernels.c
+++ b/clang/test/CIR/CodeGenOpenACC/kernels.c
@@ -1,7 +1,7 @@
 // RUN: %clang_cc1 -fopenacc -Wno-openacc-self-if-potential-conflict -emit-cir -fclangir %s -o - | FileCheck %s
 
 void acc_kernels(int cond) {
-  // CHECK: cir.func{{.*}} @acc_kernels(%[[ARG:.*]]: !s32i{{.*}}) {
+  // CHECK: cir.func{{.*}} @acc_kernels(%[[ARG:.*]]: !s32i{{.*}}){{.*}}{
   // CHECK-NEXT: %[[COND:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["cond", init]
   // CHECK-NEXT: cir.store %[[ARG]], %[[COND]] : !s32i, !cir.ptr<!s32i>
 #pragma acc kernels
@@ -418,7 +418,7 @@ void acc_kernels(int cond) {
 }
 
 void acc_kernels_data_clauses(int *arg1, int *arg2) {
-  // CHECK: cir.func{{.*}} @acc_kernels_data_clauses(%[[ARG1_PARAM:.*]]: !cir.ptr<!s32i>{{.*}}, %[[ARG2_PARAM:.*]]: !cir.ptr<!s32i>{{.*}}) {
+  // CHECK: cir.func{{.*}} @acc_kernels_data_clauses(%[[ARG1_PARAM:.*]]: !cir.ptr<!s32i>{{.*}}, %[[ARG2_PARAM:.*]]: !cir.ptr<!s32i>{{.*}}){{.*}}{
   // CHECK-NEXT: %[[ARG1:.*]] = cir.alloca !cir.ptr<!s32i>, !cir.ptr<!cir.ptr<!s32i>>, ["arg1", init]
   // CHECK-NEXT: %[[ARG2:.*]] = cir.alloca !cir.ptr<!s32i>, !cir.ptr<!cir.ptr<!s32i>>, ["arg2", init]
   // CHECK-NEXT: cir.store %[[ARG1_PARAM]], %[[ARG1]] : !cir.ptr<!s32i>, !cir.ptr<!cir.ptr<!s32i>>

--- a/clang/test/CIR/CodeGenOpenACC/loop.cpp
+++ b/clang/test/CIR/CodeGenOpenACC/loop.cpp
@@ -1,7 +1,7 @@
 // RUN: %clang_cc1 -fopenacc -Wno-openacc-self-if-potential-conflict -emit-cir -fclangir %s -o - | FileCheck %s
 
 extern "C" void acc_loop(int *A, int *B, int *C, int N) {
-  // CHECK: cir.func{{.*}} @acc_loop(%[[ARG_A:.*]]: !cir.ptr<!s32i> {{.*}}, %[[ARG_B:.*]]: !cir.ptr<!s32i> {{.*}}, %[[ARG_C:.*]]: !cir.ptr<!s32i> {{.*}}, %[[ARG_N:.*]]: !s32i {{.*}}) {
+  // CHECK: cir.func{{.*}} @acc_loop(%[[ARG_A:.*]]: !cir.ptr<!s32i> {{.*}}, %[[ARG_B:.*]]: !cir.ptr<!s32i> {{.*}}, %[[ARG_C:.*]]: !cir.ptr<!s32i> {{.*}}, %[[ARG_N:.*]]: !s32i {{.*}}){{.*}}{
   // CHECK-NEXT: %[[ALLOCA_A:.*]] = cir.alloca !cir.ptr<!s32i>, !cir.ptr<!cir.ptr<!s32i>>, ["A", init]
   // CHECK-NEXT: %[[ALLOCA_B:.*]] = cir.alloca !cir.ptr<!s32i>, !cir.ptr<!cir.ptr<!s32i>>, ["B", init]
   // CHECK-NEXT: %[[ALLOCA_C:.*]] = cir.alloca !cir.ptr<!s32i>, !cir.ptr<!cir.ptr<!s32i>>, ["C", init]

--- a/clang/test/CIR/CodeGenOpenACC/parallel.c
+++ b/clang/test/CIR/CodeGenOpenACC/parallel.c
@@ -1,7 +1,7 @@
 // RUN: %clang_cc1 -fopenacc -Wno-openacc-self-if-potential-conflict -emit-cir -fclangir %s -o - | FileCheck %s
 
 void acc_parallel(int cond) {
-  // CHECK: cir.func{{.*}} @acc_parallel(%[[ARG:.*]]: !s32i{{.*}}) {
+  // CHECK: cir.func{{.*}} @acc_parallel(%[[ARG:.*]]: !s32i{{.*}}){{.*}}{
   // CHECK-NEXT: %[[COND:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["cond", init]
   // CHECK-NEXT: cir.store %[[ARG]], %[[COND]] : !s32i, !cir.ptr<!s32i>
 #pragma acc parallel
@@ -445,7 +445,7 @@ void acc_parallel(int cond) {
 }
 
 void acc_parallel_data_clauses(int *arg1, int *arg2) {
-  // CHECK: cir.func{{.*}} @acc_parallel_data_clauses(%[[ARG1_PARAM:.*]]: !cir.ptr<!s32i>{{.*}}, %[[ARG2_PARAM:.*]]: !cir.ptr<!s32i>{{.*}}) {
+  // CHECK: cir.func{{.*}} @acc_parallel_data_clauses(%[[ARG1_PARAM:.*]]: !cir.ptr<!s32i>{{.*}}, %[[ARG2_PARAM:.*]]: !cir.ptr<!s32i>{{.*}}){{.*}}{
   // CHECK-NEXT: %[[ARG1:.*]] = cir.alloca !cir.ptr<!s32i>, !cir.ptr<!cir.ptr<!s32i>>, ["arg1", init]
   // CHECK-NEXT: %[[ARG2:.*]] = cir.alloca !cir.ptr<!s32i>, !cir.ptr<!cir.ptr<!s32i>>, ["arg2", init]
   // CHECK-NEXT: cir.store %[[ARG1_PARAM]], %[[ARG1]] : !cir.ptr<!s32i>, !cir.ptr<!cir.ptr<!s32i>>

--- a/clang/test/CIR/CodeGenOpenACC/routine-anon-ns.cpp
+++ b/clang/test/CIR/CodeGenOpenACC/routine-anon-ns.cpp
@@ -17,9 +17,9 @@ void force_emit() {
   Lambda2();
 }
 
-// CHECK: cir.func{{.*}} @[[F1_NAME:[^\(]*]]({{.*}}){{.*}} attributes {acc.routine_info = #acc.routine_info<[@[[F1_R_NAME:.*]], @[[F1_R2_NAME:.*]]]>}
-// CHECK: cir.func {{.*}}lambda{{.*}} @[[L1_NAME:[^\(]*]]({{.*}}){{.*}} attributes {acc.routine_info = #acc.routine_info<[@[[L1_R_NAME:.*]]]>}
-// CHECK: cir.func {{.*}}lambda{{.*}} @[[L2_NAME:[^\(]*]]({{.*}}){{.*}} attributes {acc.routine_info = #acc.routine_info<[@[[L2_R_NAME:.*]]]>}
+// CHECK: cir.func{{.*}} @[[F1_NAME:[^\(]*]]({{.*}}){{.*}} attributes {{{.*}}acc.routine_info = #acc.routine_info<[@[[F1_R_NAME:.*]], @[[F1_R2_NAME:.*]]]>{{.*}}}
+// CHECK: cir.func {{.*}}lambda{{.*}} @[[L1_NAME:[^\(]*]]({{.*}}){{.*}} attributes {{{.*}}acc.routine_info = #acc.routine_info<[@[[L1_R_NAME:.*]]]>{{.*}}}
+// CHECK: cir.func {{.*}}lambda{{.*}} @[[L2_NAME:[^\(]*]]({{.*}}){{.*}} attributes {{{.*}}acc.routine_info = #acc.routine_info<[@[[L2_R_NAME:.*]]]>{{.*}}}
 //
 // CHECK: acc.routine @[[F1_R_NAME]] func(@[[F1_NAME]]) seq
 // CHECK: acc.routine @[[L1_R_NAME]] func(@[[L1_NAME]]) seq

--- a/clang/test/CIR/CodeGenOpenACC/routine-bind.c
+++ b/clang/test/CIR/CodeGenOpenACC/routine-bind.c
@@ -41,35 +41,35 @@ void Func11(struct U* u, struct V v, int i){}
 int Func12(struct U u, struct V v, int i){ return 0; }
 #pragma acc routine(Func12) seq device_type(radeon) bind(BIND12_R) device_type(multicore, host) bind(BIND12_MCH)
 
-// CHECK: cir.func{{.*}} @[[F1_NAME:.*Func1[^\(]*]]({{.*}}){{.*}} attributes {acc.routine_info = #acc.routine_info<[@[[F1_R_NAME:.*]]]>}
+// CHECK: cir.func{{.*}} @[[F1_NAME:.*Func1[^\(]*]]({{.*}}){{.*}} attributes {{{.*}}acc.routine_info = #acc.routine_info<[@[[F1_R_NAME:.*]]]>{{.*}}}
 // CHECK: acc.routine @[[F1_R_NAME]] func(@[[F1_NAME]]) bind("BIND1") seq
 //
-// CHECK: cir.func{{.*}} @[[F2_NAME:.*Func2[^\(]*]]({{.*}}){{.*}} attributes {acc.routine_info = #acc.routine_info<[@[[F2_R_NAME:.*]]]>}
+// CHECK: cir.func{{.*}} @[[F2_NAME:.*Func2[^\(]*]]({{.*}}){{.*}} attributes {{{.*}}acc.routine_info = #acc.routine_info<[@[[F2_R_NAME:.*]]]>{{.*}}}
 //
-// CHECK: cir.func{{.*}} @[[F3_NAME:.*Func3[^\(]*]]({{.*}}){{.*}} attributes {acc.routine_info = #acc.routine_info<[@[[F3_R_NAME:.*]]]>}
+// CHECK: cir.func{{.*}} @[[F3_NAME:.*Func3[^\(]*]]({{.*}}){{.*}} attributes {{{.*}}acc.routine_info = #acc.routine_info<[@[[F3_R_NAME:.*]]]>{{.*}}}
 // CHECK: acc.routine @[[F3_R_NAME]] func(@[[F3_NAME]]) bind("BIND3" [#acc.device_type<nvidia>]) seq
 //
-// CHECK: cir.func{{.*}} @[[F4_NAME:.*Func4[^\(]*]]({{.*}}){{.*}} attributes {acc.routine_info = #acc.routine_info<[@[[F4_R_NAME:.*]]]>}
+// CHECK: cir.func{{.*}} @[[F4_NAME:.*Func4[^\(]*]]({{.*}}){{.*}} attributes {{{.*}}acc.routine_info = #acc.routine_info<[@[[F4_R_NAME:.*]]]>{{.*}}}
 //
-// CHECK: cir.func{{.*}} @[[F5_NAME:.*Func5[^\(]*]]({{.*}}){{.*}} attributes {acc.routine_info = #acc.routine_info<[@[[F5_R_NAME:.*]]]>}
+// CHECK: cir.func{{.*}} @[[F5_NAME:.*Func5[^\(]*]]({{.*}}){{.*}} attributes {{{.*}}acc.routine_info = #acc.routine_info<[@[[F5_R_NAME:.*]]]>{{.*}}}
 // CHECK: acc.routine @[[F5_R_NAME]] func(@[[F5_NAME]]) bind("BIND5_N" [#acc.device_type<nvidia>], "BIND5_N" [#acc.device_type<host>], "BIND5_M" [#acc.device_type<multicore>]) seq
 //
-// CHECK: cir.func{{.*}} @[[F6_NAME:.*Func6[^\(]*]]({{.*}}){{.*}} attributes {acc.routine_info = #acc.routine_info<[@[[F6_R_NAME:.*]]]>}
+// CHECK: cir.func{{.*}} @[[F6_NAME:.*Func6[^\(]*]]({{.*}}){{.*}} attributes {{{.*}}acc.routine_info = #acc.routine_info<[@[[F6_R_NAME:.*]]]>{{.*}}}
 //
-// CHECK: cir.func{{.*}} @[[F7_NAME:.*Func7[^\(]*]]({{.*}}){{.*}} attributes {acc.routine_info = #acc.routine_info<[@[[F7_R_NAME:.*]]]>}
+// CHECK: cir.func{{.*}} @[[F7_NAME:.*Func7[^\(]*]]({{.*}}){{.*}} attributes {{{.*}}acc.routine_info = #acc.routine_info<[@[[F7_R_NAME:.*]]]>{{.*}}}
 // CHECK: acc.routine @[[F7_R_NAME]] func(@[[F7_NAME]]) bind(@BIND7) seq
 //
-// CHECK: cir.func{{.*}} @[[F8_NAME:.*Func8[^\(]*]]({{.*}}){{.*}} attributes {acc.routine_info = #acc.routine_info<[@[[F8_R_NAME:.*]]]>}
+// CHECK: cir.func{{.*}} @[[F8_NAME:.*Func8[^\(]*]]({{.*}}){{.*}} attributes {{{.*}}acc.routine_info = #acc.routine_info<[@[[F8_R_NAME:.*]]]>{{.*}}}
 //
-// CHECK: cir.func{{.*}} @[[F9_NAME:.*Func9[^\(]*]]({{.*}}){{.*}} attributes {acc.routine_info = #acc.routine_info<[@[[F9_R_NAME:.*]]]>}
+// CHECK: cir.func{{.*}} @[[F9_NAME:.*Func9[^\(]*]]({{.*}}){{.*}} attributes {{{.*}}acc.routine_info = #acc.routine_info<[@[[F9_R_NAME:.*]]]>{{.*}}}
 // CHECK: acc.routine @[[F9_R_NAME]] func(@[[F9_NAME]]) bind(@BIND9 [#acc.device_type<nvidia>]) seq
 //
-// CHECK: cir.func{{.*}} @[[F10_NAME:.*Func10[^\(]*]]({{.*}}){{.*}} attributes {acc.routine_info = #acc.routine_info<[@[[F10_R_NAME:.*]]]>}
+// CHECK: cir.func{{.*}} @[[F10_NAME:.*Func10[^\(]*]]({{.*}}){{.*}} attributes {{{.*}}acc.routine_info = #acc.routine_info<[@[[F10_R_NAME:.*]]]>{{.*}}}
 //
-// CHECK: cir.func{{.*}} @[[F11_NAME:.*Func11[^\(]*]]({{.*}}){{.*}} attributes {acc.routine_info = #acc.routine_info<[@[[F11_R_NAME:.*]]]>}
+// CHECK: cir.func{{.*}} @[[F11_NAME:.*Func11[^\(]*]]({{.*}}){{.*}} attributes {{{.*}}acc.routine_info = #acc.routine_info<[@[[F11_R_NAME:.*]]]>{{.*}}}
 // CHECK: acc.routine @[[F11_R_NAME]] func(@[[F11_NAME]]) bind(@BIND11_NVH [#acc.device_type<nvidia>], @BIND11_NVH [#acc.device_type<host>], @BIND11_MC [#acc.device_type<multicore>])
 //
-// CHECK: cir.func{{.*}} @[[F12_NAME:.*Func12[^\(]*]]({{.*}}){{.*}} attributes {acc.routine_info = #acc.routine_info<[@[[F12_R_NAME:.*]]]>}
+// CHECK: cir.func{{.*}} @[[F12_NAME:.*Func12[^\(]*]]({{.*}}){{.*}} attributes {{{.*}}acc.routine_info = #acc.routine_info<[@[[F12_R_NAME:.*]]]>{{.*}}}
 //
 // CHECK: acc.routine @[[F2_R_NAME]] func(@[[F2_NAME]]) bind("BIND2") seq
 // CHECK: acc.routine @[[F4_R_NAME]] func(@[[F4_NAME]]) bind("BIND4" [#acc.device_type<radeon>]) seq

--- a/clang/test/CIR/CodeGenOpenACC/routine-bind.cpp
+++ b/clang/test/CIR/CodeGenOpenACC/routine-bind.cpp
@@ -72,49 +72,49 @@ void hasLambdas() {
   Lambda2(1, 2, 3);
 }
 
-// CHECK: cir.func{{.*}} @_Z5Func1v({{.*}}){{.*}} attributes {acc.routine_info = #acc.routine_info<[@[[F1_R_NAME:.*]]]>}
+// CHECK: cir.func{{.*}} @_Z5Func1v({{.*}}){{.*}} attributes {{{.*}}acc.routine_info = #acc.routine_info<[@[[F1_R_NAME:.*]]]>{{.*}}}
 // CHECK: acc.routine @[[F1_R_NAME]] func(@_Z5Func1v) bind("BIND1") seq
 //
-// CHECK: cir.func{{.*}} @_Z5Func2v({{.*}}){{.*}} attributes {acc.routine_info = #acc.routine_info<[@[[F2_R_NAME:.*]]]>}
+// CHECK: cir.func{{.*}} @_Z5Func2v({{.*}}){{.*}} attributes {{{.*}}acc.routine_info = #acc.routine_info<[@[[F2_R_NAME:.*]]]>{{.*}}}
 //
-// CHECK: cir.func{{.*}} @_Z5Func3v({{.*}}){{.*}} attributes {acc.routine_info = #acc.routine_info<[@[[F3_R_NAME:.*]]]>}
+// CHECK: cir.func{{.*}} @_Z5Func3v({{.*}}){{.*}} attributes {{{.*}}acc.routine_info = #acc.routine_info<[@[[F3_R_NAME:.*]]]>{{.*}}}
 // CHECK: acc.routine @[[F3_R_NAME]] func(@_Z5Func3v) bind("BIND3" [#acc.device_type<nvidia>]) seq
 //
-// CHECK: cir.func{{.*}} @_Z5Func4v({{.*}}){{.*}} attributes {acc.routine_info = #acc.routine_info<[@[[F4_R_NAME:.*]]]>}
+// CHECK: cir.func{{.*}} @_Z5Func4v({{.*}}){{.*}} attributes {{{.*}}acc.routine_info = #acc.routine_info<[@[[F4_R_NAME:.*]]]>{{.*}}}
 //
-// CHECK: cir.func{{.*}} @_Z5Func5v({{.*}}){{.*}} attributes {acc.routine_info = #acc.routine_info<[@[[F5_R_NAME:.*]]]>}
+// CHECK: cir.func{{.*}} @_Z5Func5v({{.*}}){{.*}} attributes {{{.*}}acc.routine_info = #acc.routine_info<[@[[F5_R_NAME:.*]]]>{{.*}}}
 // CHECK: acc.routine @[[F5_R_NAME]] func(@_Z5Func5v) bind("BIND5_N" [#acc.device_type<nvidia>], "BIND5_N" [#acc.device_type<host>], "BIND5_M" [#acc.device_type<multicore>]) seq
 //
-// CHECK: cir.func{{.*}} @_Z5Func6v({{.*}}){{.*}} attributes {acc.routine_info = #acc.routine_info<[@[[F6_R_NAME:.*]]]>}
+// CHECK: cir.func{{.*}} @_Z5Func6v({{.*}}){{.*}} attributes {{{.*}}acc.routine_info = #acc.routine_info<[@[[F6_R_NAME:.*]]]>{{.*}}}
 //
-// CHECK: cir.func{{.*}} @_Z5Func7i({{.*}}){{.*}} attributes {acc.routine_info = #acc.routine_info<[@[[F7_R_NAME:.*]]]>}
+// CHECK: cir.func{{.*}} @_Z5Func7i({{.*}}){{.*}} attributes {{{.*}}acc.routine_info = #acc.routine_info<[@[[F7_R_NAME:.*]]]>{{.*}}}
 // CHECK: acc.routine @[[F7_R_NAME]] func(@_Z5Func7i) bind(@_Z5BIND7i) seq
 //
-// CHECK: cir.func{{.*}} @_Z5Func8f({{.*}}){{.*}} attributes {acc.routine_info = #acc.routine_info<[@[[F8_R_NAME:.*]]]>}
+// CHECK: cir.func{{.*}} @_Z5Func8f({{.*}}){{.*}} attributes {{{.*}}acc.routine_info = #acc.routine_info<[@[[F8_R_NAME:.*]]]>{{.*}}}
 //
-// CHECK: cir.func{{.*}} @_Z5Func9ifs({{.*}}){{.*}} attributes {acc.routine_info = #acc.routine_info<[@[[F9_R_NAME:.*]]]>}
+// CHECK: cir.func{{.*}} @_Z5Func9ifs({{.*}}){{.*}} attributes {{{.*}}acc.routine_info = #acc.routine_info<[@[[F9_R_NAME:.*]]]>{{.*}}}
 // CHECK: acc.routine @[[F9_R_NAME]] func(@_Z5Func9ifs) bind(@_Z5BIND9ifs [#acc.device_type<nvidia>]) seq
 
-// CHECK: cir.func{{.*}} @_Z6Func101S({{.*}}){{.*}} attributes {acc.routine_info = #acc.routine_info<[@[[F10_R_NAME:.*]]]>}
+// CHECK: cir.func{{.*}} @_Z6Func101S({{.*}}){{.*}} attributes {{{.*}}acc.routine_info = #acc.routine_info<[@[[F10_R_NAME:.*]]]>{{.*}}}
 //
-// CHECK: cir.func{{.*}} @_Z6Func11P1UR1Vi({{.*}}){{.*}} attributes {acc.routine_info = #acc.routine_info<[@[[F11_R_NAME:.*]]]>}
+// CHECK: cir.func{{.*}} @_Z6Func11P1UR1Vi({{.*}}){{.*}} attributes {{{.*}}acc.routine_info = #acc.routine_info<[@[[F11_R_NAME:.*]]]>{{.*}}}
 // CHECK: acc.routine @[[F11_R_NAME]] func(@_Z6Func11P1UR1Vi) bind(@_Z10BIND11_NVHP1UR1Vi [#acc.device_type<nvidia>], @_Z10BIND11_NVHP1UR1Vi [#acc.device_type<host>], @_Z9BIND11_MCP1UR1Vi [#acc.device_type<multicore>]) seq
 //
-// CHECK: cir.func{{.*}} @_Z6Func121U1Vi({{.*}}){{.*}} attributes {acc.routine_info = #acc.routine_info<[@[[F12_R_NAME:.*]]]>}
+// CHECK: cir.func{{.*}} @_Z6Func121U1Vi({{.*}}){{.*}} attributes {{{.*}}acc.routine_info = #acc.routine_info<[@[[F12_R_NAME:.*]]]>{{.*}}}
 //
-// CHECK: cir.func{{.*}} @_ZN8HasFuncs7MemFuncEidRS_1S({{.*}}){{.*}} attributes {acc.routine_info = #acc.routine_info<[@[[MEMFUNC_R_NAME:.*]]]>}
+// CHECK: cir.func{{.*}} @_ZN8HasFuncs7MemFuncEidRS_1S({{.*}}){{.*}} attributes {{{.*}}acc.routine_info = #acc.routine_info<[@[[MEMFUNC_R_NAME:.*]]]>{{.*}}}
 //
-// CHECK: cir.func{{.*}} @_ZNK8HasFuncs12ConstMemFuncEidRS_1S({{.*}}){{.*}} attributes {acc.routine_info = #acc.routine_info<[@[[CONSTMEMFUNC_R_NAME:.*]]]>}
+// CHECK: cir.func{{.*}} @_ZNK8HasFuncs12ConstMemFuncEidRS_1S({{.*}}){{.*}} attributes {{{.*}}acc.routine_info = #acc.routine_info<[@[[CONSTMEMFUNC_R_NAME:.*]]]>{{.*}}}
 //
-// CHECK: cir.func{{.*}} @_ZNVK8HasFuncs15VolatileMemFuncEidRS_1S({{.*}}){{.*}} attributes {acc.routine_info = #acc.routine_info<[@[[VOLATILEMEMFUNC_R_NAME:.*]]]>}
+// CHECK: cir.func{{.*}} @_ZNVK8HasFuncs15VolatileMemFuncEidRS_1S({{.*}}){{.*}} attributes {{{.*}}acc.routine_info = #acc.routine_info<[@[[VOLATILEMEMFUNC_R_NAME:.*]]]>{{.*}}}
 //
-// CHECK: cir.func{{.*}} @_ZNKO8HasFuncs10RefMemFuncEidRS_1S({{.*}}){{.*}} attributes {acc.routine_info = #acc.routine_info<[@[[REFMEMFUNC_R_NAME:.*]]]>}
+// CHECK: cir.func{{.*}} @_ZNKO8HasFuncs10RefMemFuncEidRS_1S({{.*}}){{.*}} attributes {{{.*}}acc.routine_info = #acc.routine_info<[@[[REFMEMFUNC_R_NAME:.*]]]>{{.*}}}
 //
-// CHECK: cir.func{{.*}} @_ZN8HasFuncs13StaticMemFuncEidRS_P1U({{.*}}){{.*}} attributes {acc.routine_info = #acc.routine_info<[@[[STATICFUNC_R_NAME:.*]]]>}
+// CHECK: cir.func{{.*}} @_ZN8HasFuncs13StaticMemFuncEidRS_P1U({{.*}}){{.*}} attributes {{{.*}}acc.routine_info = #acc.routine_info<[@[[STATICFUNC_R_NAME:.*]]]>{{.*}}}
 //
-// CHECK: cir.func{{.*}} lambda{{.*}} @_ZZ10hasLambdasvENK3$_0clEifd({{.*}}){{.*}} attributes {acc.routine_info = #acc.routine_info<[@[[LAMBDA1_R_NAME:.*]]]>}
+// CHECK: cir.func{{.*}} lambda{{.*}} @_ZZ10hasLambdasvENK3$_0clEifd({{.*}}){{.*}} attributes {{{.*}}acc.routine_info = #acc.routine_info<[@[[LAMBDA1_R_NAME:.*]]]>{{.*}}}
 //
-// CHECK: cir.func{{.*}} lambda{{.*}} @_ZZ10hasLambdasvENK3$_1clEifd({{.*}}){{.*}} attributes {acc.routine_info = #acc.routine_info<[@[[LAMBDA2_R_NAME:.*]]]>}
+// CHECK: cir.func{{.*}} lambda{{.*}} @_ZZ10hasLambdasvENK3$_1clEifd({{.*}}){{.*}} attributes {{{.*}}acc.routine_info = #acc.routine_info<[@[[LAMBDA2_R_NAME:.*]]]>{{.*}}}
 //
 // CHECK:  acc.routine @[[MEMFUNC_R_NAME]] func(@_ZN8HasFuncs7MemFuncEidRS_1S) bind(@_Z3MEMP8HasFuncsidRS_1S) seq
 // CHECK:  acc.routine @[[CONSTMEMFUNC_R_NAME]] func(@_ZNK8HasFuncs12ConstMemFuncEidRS_1S) bind(@_Z3MEMPK8HasFuncsidRS_1S) seq

--- a/clang/test/CIR/CodeGenOpenACC/routine-clauses.cpp
+++ b/clang/test/CIR/CodeGenOpenACC/routine-clauses.cpp
@@ -39,35 +39,35 @@ void Func11() {}
 void Func12() {}
 #pragma acc routine(Func12) nohost gang(dim:Value)
 
-// CHECK: cir.func{{.*}} @[[F1_NAME:.*Func1[^\(]*]]({{.*}}){{.*}} attributes {acc.routine_info = #acc.routine_info<[@[[F1_R_NAME:.*]]]>}
+// CHECK: cir.func{{.*}} @[[F1_NAME:.*Func1[^\(]*]]({{.*}}){{.*}} attributes {{{.*}}acc.routine_info = #acc.routine_info<[@[[F1_R_NAME:.*]]]>{{.*}}}
 // CHECK: acc.routine @[[F1_R_NAME]] func(@[[F1_NAME]]) seq nohost
 
-// CHECK: cir.func{{.*}} @[[F2_NAME:.*Func2[^\(]*]]({{.*}}){{.*}} attributes {acc.routine_info = #acc.routine_info<[@[[F2_R_NAME:.*]]]>}
+// CHECK: cir.func{{.*}} @[[F2_NAME:.*Func2[^\(]*]]({{.*}}){{.*}} attributes {{{.*}}acc.routine_info = #acc.routine_info<[@[[F2_R_NAME:.*]]]>{{.*}}}
 
-// CHECK: cir.func{{.*}} @[[F3_NAME:.*Func3[^\(]*]]({{.*}}){{.*}} attributes {acc.routine_info = #acc.routine_info<[@[[F3_R_NAME:.*]]]>}
+// CHECK: cir.func{{.*}} @[[F3_NAME:.*Func3[^\(]*]]({{.*}}){{.*}} attributes {{{.*}}acc.routine_info = #acc.routine_info<[@[[F3_R_NAME:.*]]]>{{.*}}}
 // CHECK: acc.routine @[[F3_R_NAME]] func(@[[F3_NAME]]) worker
 
-// CHECK: cir.func{{.*}} @[[F4_NAME:.*Func4[^\(]*]]({{.*}}){{.*}} attributes {acc.routine_info = #acc.routine_info<[@[[F4_R_NAME:.*]]]>}
+// CHECK: cir.func{{.*}} @[[F4_NAME:.*Func4[^\(]*]]({{.*}}){{.*}} attributes {{{.*}}acc.routine_info = #acc.routine_info<[@[[F4_R_NAME:.*]]]>{{.*}}}
 
-// CHECK: cir.func{{.*}} @[[F5_NAME:.*Func5[^\(]*]]({{.*}}){{.*}} attributes {acc.routine_info = #acc.routine_info<[@[[F5_R_NAME:.*]]]>}
+// CHECK: cir.func{{.*}} @[[F5_NAME:.*Func5[^\(]*]]({{.*}}){{.*}} attributes {{{.*}}acc.routine_info = #acc.routine_info<[@[[F5_R_NAME:.*]]]>{{.*}}}
 // CHECK: acc.routine @[[F5_R_NAME]] func(@[[F5_NAME]]) vector
 
-// CHECK: cir.func{{.*}} @[[F6_NAME:.*Func6[^\(]*]]({{.*}}){{.*}} attributes {acc.routine_info = #acc.routine_info<[@[[F6_R_NAME:.*]]]>}
+// CHECK: cir.func{{.*}} @[[F6_NAME:.*Func6[^\(]*]]({{.*}}){{.*}} attributes {{{.*}}acc.routine_info = #acc.routine_info<[@[[F6_R_NAME:.*]]]>{{.*}}}
 //
-// CHECK: cir.func{{.*}} @[[F7_NAME:.*Func7[^\(]*]]({{.*}}){{.*}} attributes {acc.routine_info = #acc.routine_info<[@[[F7_R_NAME:.*]]]>}
+// CHECK: cir.func{{.*}} @[[F7_NAME:.*Func7[^\(]*]]({{.*}}){{.*}} attributes {{{.*}}acc.routine_info = #acc.routine_info<[@[[F7_R_NAME:.*]]]>{{.*}}}
 // CHECK: acc.routine @[[F7_R_NAME]] func(@[[F7_NAME]]) gang
 //
-// CHECK: cir.func{{.*}} @[[F8_NAME:.*Func8[^\(]*]]({{.*}}){{.*}} attributes {acc.routine_info = #acc.routine_info<[@[[F8_R_NAME:.*]]]>}
+// CHECK: cir.func{{.*}} @[[F8_NAME:.*Func8[^\(]*]]({{.*}}){{.*}} attributes {{{.*}}acc.routine_info = #acc.routine_info<[@[[F8_R_NAME:.*]]]>{{.*}}}
 //
-// CHECK: cir.func{{.*}} @[[F9_NAME:.*Func9[^\(]*]]({{.*}}){{.*}} attributes {acc.routine_info = #acc.routine_info<[@[[F9_R_NAME:.*]]]>}
+// CHECK: cir.func{{.*}} @[[F9_NAME:.*Func9[^\(]*]]({{.*}}){{.*}} attributes {{{.*}}acc.routine_info = #acc.routine_info<[@[[F9_R_NAME:.*]]]>{{.*}}}
 // CHECK: acc.routine @[[F9_R_NAME]] func(@[[F9_NAME]]) gang(dim: 1 : i64)
 //
-// CHECK: cir.func{{.*}} @[[F10_NAME:.*Func10[^\(]*]]({{.*}}){{.*}} attributes {acc.routine_info = #acc.routine_info<[@[[F10_R_NAME:.*]]]>}
+// CHECK: cir.func{{.*}} @[[F10_NAME:.*Func10[^\(]*]]({{.*}}){{.*}} attributes {{{.*}}acc.routine_info = #acc.routine_info<[@[[F10_R_NAME:.*]]]>{{.*}}}
 
-// CHECK: cir.func{{.*}} @[[F11_NAME:.*Func11[^\(]*]]({{.*}}){{.*}} attributes {acc.routine_info = #acc.routine_info<[@[[F11_R_NAME:.*]]]>}
+// CHECK: cir.func{{.*}} @[[F11_NAME:.*Func11[^\(]*]]({{.*}}){{.*}} attributes {{{.*}}acc.routine_info = #acc.routine_info<[@[[F11_R_NAME:.*]]]>{{.*}}}
 // CHECK: acc.routine @[[F11_R_NAME]] func(@[[F11_NAME]]) gang(dim: 2 : i64)
 //
-// CHECK: cir.func{{.*}} @[[F12_NAME:.*Func12[^\(]*]]({{.*}}){{.*}} attributes {acc.routine_info = #acc.routine_info<[@[[F12_R_NAME:.*]]]>}
+// CHECK: cir.func{{.*}} @[[F12_NAME:.*Func12[^\(]*]]({{.*}}){{.*}} attributes {{{.*}}acc.routine_info = #acc.routine_info<[@[[F12_R_NAME:.*]]]>{{.*}}}
 
 // CHECK: acc.routine @[[F2_R_NAME]] func(@[[F2_NAME]]) seq
 // CHECK: acc.routine @[[F4_R_NAME]] func(@[[F4_NAME]]) worker nohost

--- a/clang/test/CIR/CodeGenOpenACC/routine-device_type.cpp
+++ b/clang/test/CIR/CodeGenOpenACC/routine-device_type.cpp
@@ -35,40 +35,40 @@ void Func13() {}
 void Func14() {}
 #pragma acc routine(Func14) device_type(nvidia) gang(dim:2) device_type(radeon) gang
 
-// CHECK: cir.func{{.*}} @[[F1_NAME:.*Func1[^\(]*]]({{.*}}){{.*}} attributes {acc.routine_info = #acc.routine_info<[@[[F1_R_NAME:.*]]]>}
+// CHECK: cir.func{{.*}} @[[F1_NAME:.*Func1[^\(]*]]({{.*}}){{.*}} attributes {{{.*}}acc.routine_info = #acc.routine_info<[@[[F1_R_NAME:.*]]]>{{.*}}}
 // CHECK: acc.routine @[[F1_R_NAME]] func(@[[F1_NAME]]) seq ([#acc.device_type<nvidia>, #acc.device_type<radeon>]) nohost
 
-// CHECK: cir.func{{.*}} @[[F2_NAME:.*Func2[^\(]*]]({{.*}}){{.*}} attributes {acc.routine_info = #acc.routine_info<[@[[F2_R_NAME:.*]]]>}
+// CHECK: cir.func{{.*}} @[[F2_NAME:.*Func2[^\(]*]]({{.*}}){{.*}} attributes {{{.*}}acc.routine_info = #acc.routine_info<[@[[F2_R_NAME:.*]]]>{{.*}}}
 
-// CHECK: cir.func{{.*}} @[[F3_NAME:.*Func3[^\(]*]]({{.*}}){{.*}} attributes {acc.routine_info = #acc.routine_info<[@[[F3_R_NAME:.*]]]>}
+// CHECK: cir.func{{.*}} @[[F3_NAME:.*Func3[^\(]*]]({{.*}}){{.*}} attributes {{{.*}}acc.routine_info = #acc.routine_info<[@[[F3_R_NAME:.*]]]>{{.*}}}
 // CHECK: acc.routine @[[F3_R_NAME]] func(@[[F3_NAME]]) worker ([#acc.device_type<multicore>]) seq ([#acc.device_type<nvidia>, #acc.device_type<radeon>])
 
-// CHECK: cir.func{{.*}} @[[F4_NAME:.*Func4[^\(]*]]({{.*}}){{.*}} attributes {acc.routine_info = #acc.routine_info<[@[[F4_R_NAME:.*]]]>}
+// CHECK: cir.func{{.*}} @[[F4_NAME:.*Func4[^\(]*]]({{.*}}){{.*}} attributes {{{.*}}acc.routine_info = #acc.routine_info<[@[[F4_R_NAME:.*]]]>{{.*}}}
 
-// CHECK: cir.func{{.*}} @[[F5_NAME:.*Func5[^\(]*]]({{.*}}){{.*}} attributes {acc.routine_info = #acc.routine_info<[@[[F5_R_NAME:.*]]]>}
+// CHECK: cir.func{{.*}} @[[F5_NAME:.*Func5[^\(]*]]({{.*}}){{.*}} attributes {{{.*}}acc.routine_info = #acc.routine_info<[@[[F5_R_NAME:.*]]]>{{.*}}}
 // CHECK: acc.routine @[[F5_R_NAME]] func(@[[F5_NAME]]) gang([#acc.device_type<multicore>, #acc.device_type<nvidia>, #acc.device_type<radeon>])
 
-// CHECK: cir.func{{.*}} @[[F6_NAME:.*Func6[^\(]*]]({{.*}}){{.*}} attributes {acc.routine_info = #acc.routine_info<[@[[F6_R_NAME:.*]]]>}
+// CHECK: cir.func{{.*}} @[[F6_NAME:.*Func6[^\(]*]]({{.*}}){{.*}} attributes {{{.*}}acc.routine_info = #acc.routine_info<[@[[F6_R_NAME:.*]]]>{{.*}}}
 //
-// CHECK: cir.func{{.*}} @[[F7_NAME:.*Func7[^\(]*]]({{.*}}){{.*}} attributes {acc.routine_info = #acc.routine_info<[@[[F7_R_NAME:.*]]]>}
+// CHECK: cir.func{{.*}} @[[F7_NAME:.*Func7[^\(]*]]({{.*}}){{.*}} attributes {{{.*}}acc.routine_info = #acc.routine_info<[@[[F7_R_NAME:.*]]]>{{.*}}}
 // CHECK: acc.routine @[[F7_R_NAME]] func(@[[F7_NAME]]) gang([#acc.device_type<host>], dim: 1 : i64 [#acc.device_type<nvidia>], dim: 1 : i64 [#acc.device_type<radeon>])
 
-// CHECK: cir.func{{.*}} @[[F8_NAME:.*Func8[^\(]*]]({{.*}}){{.*}} attributes {acc.routine_info = #acc.routine_info<[@[[F8_R_NAME:.*]]]>}
+// CHECK: cir.func{{.*}} @[[F8_NAME:.*Func8[^\(]*]]({{.*}}){{.*}} attributes {{{.*}}acc.routine_info = #acc.routine_info<[@[[F8_R_NAME:.*]]]>{{.*}}}
 //
-// CHECK: cir.func{{.*}} @[[F9_NAME:.*Func9[^\(]*]]({{.*}}){{.*}} attributes {acc.routine_info = #acc.routine_info<[@[[F9_R_NAME:.*]]]>}
+// CHECK: cir.func{{.*}} @[[F9_NAME:.*Func9[^\(]*]]({{.*}}){{.*}} attributes {{{.*}}acc.routine_info = #acc.routine_info<[@[[F9_R_NAME:.*]]]>{{.*}}}
 // CHECK: acc.routine @[[F9_R_NAME]] func(@[[F9_NAME]]) gang(dim: 2 : i64 [#acc.device_type<nvidia>], dim: 3 : i64 [#acc.device_type<radeon>])
 //
-// CHECK: cir.func{{.*}} @[[F10_NAME:.*Func10[^\(]*]]({{.*}}){{.*}} attributes {acc.routine_info = #acc.routine_info<[@[[F10_R_NAME:.*]]]>}
+// CHECK: cir.func{{.*}} @[[F10_NAME:.*Func10[^\(]*]]({{.*}}){{.*}} attributes {{{.*}}acc.routine_info = #acc.routine_info<[@[[F10_R_NAME:.*]]]>{{.*}}}
 
-// CHECK: cir.func{{.*}} @[[F11_NAME:.*Func11[^\(]*]]({{.*}}){{.*}} attributes {acc.routine_info = #acc.routine_info<[@[[F11_R_NAME:.*]]]>}
+// CHECK: cir.func{{.*}} @[[F11_NAME:.*Func11[^\(]*]]({{.*}}){{.*}} attributes {{{.*}}acc.routine_info = #acc.routine_info<[@[[F11_R_NAME:.*]]]>{{.*}}}
 // CHECK: acc.routine @[[F11_R_NAME]] func(@[[F11_NAME]]) gang([#acc.device_type<multicore>], dim: 2 : i64 [#acc.device_type<nvidia>], dim: 3 : i64 [#acc.device_type<radeon>])
 //
-// CHECK: cir.func{{.*}} @[[F12_NAME:.*Func12[^\(]*]]({{.*}}){{.*}} attributes {acc.routine_info = #acc.routine_info<[@[[F12_R_NAME:.*]]]>}
+// CHECK: cir.func{{.*}} @[[F12_NAME:.*Func12[^\(]*]]({{.*}}){{.*}} attributes {{{.*}}acc.routine_info = #acc.routine_info<[@[[F12_R_NAME:.*]]]>{{.*}}}
 //
-// CHECK: cir.func{{.*}} @[[F13_NAME:.*Func13[^\(]*]]({{.*}}){{.*}} attributes {acc.routine_info = #acc.routine_info<[@[[F13_R_NAME:.*]]]>}
+// CHECK: cir.func{{.*}} @[[F13_NAME:.*Func13[^\(]*]]({{.*}}){{.*}} attributes {{{.*}}acc.routine_info = #acc.routine_info<[@[[F13_R_NAME:.*]]]>{{.*}}}
 // CHECK: acc.routine @[[F13_R_NAME]] func(@[[F13_NAME]]) gang([#acc.device_type<radeon>], dim: 2 : i64 [#acc.device_type<nvidia>])
 //
-// CHECK: cir.func{{.*}} @[[F14_NAME:.*Func14[^\(]*]]({{.*}}){{.*}} attributes {acc.routine_info = #acc.routine_info<[@[[F14_R_NAME:.*]]]>}
+// CHECK: cir.func{{.*}} @[[F14_NAME:.*Func14[^\(]*]]({{.*}}){{.*}} attributes {{{.*}}acc.routine_info = #acc.routine_info<[@[[F14_R_NAME:.*]]]>{{.*}}}
 
 // CHECK: acc.routine @[[F2_R_NAME]] func(@[[F2_NAME]]) seq ([#acc.device_type<radeon>]) 
 // CHECK: acc.routine @[[F4_R_NAME]] func(@[[F4_NAME]]) vector ([#acc.device_type<radeon>]) seq ([#acc.device_type<nvidia>])

--- a/clang/test/CIR/CodeGenOpenACC/routine-globals.cpp
+++ b/clang/test/CIR/CodeGenOpenACC/routine-globals.cpp
@@ -21,11 +21,11 @@ void force_emit() {
   GlobalFunc2();
 }
 
-// CHECK: cir.func {{.*}}lambda{{.*}} @[[L1_NAME:[^\(]*]]({{.*}}){{.*}} attributes {acc.routine_info = #acc.routine_info<[@[[L1_R_NAME:.*]]]>}
-// CHECK: cir.func {{.*}}lambda{{.*}} @[[L2_NAME:[^\(]*]]({{.*}}){{.*}} attributes {acc.routine_info = #acc.routine_info<[@[[L2_R_NAME:.*]], @[[L2_R2_NAME:.*]]]>}
+// CHECK: cir.func {{.*}}lambda{{.*}} @[[L1_NAME:[^\(]*]]({{.*}}){{.*}} attributes {{{.*}}acc.routine_info = #acc.routine_info<[@[[L1_R_NAME:.*]]]>{{.*}}}
+// CHECK: cir.func {{.*}}lambda{{.*}} @[[L2_NAME:[^\(]*]]({{.*}}){{.*}} attributes {{{.*}}acc.routine_info = #acc.routine_info<[@[[L2_R_NAME:.*]], @[[L2_R2_NAME:.*]]]>{{.*}}}
 //
-// CHECK: cir.func{{.*}} @[[G1_NAME:[^\(]*]]({{.*}}){{.*}} attributes {acc.routine_info = #acc.routine_info<[@[[G1_R_NAME:.*]], @[[G1_R2_NAME:.*]]]>}
-// CHECK: cir.func{{.*}} @[[G2_NAME:[^\(]*]]({{.*}}){{.*}} attributes {acc.routine_info = #acc.routine_info<[@[[G2_R_NAME:.*]]]>}
+// CHECK: cir.func{{.*}} @[[G1_NAME:[^\(]*]]({{.*}}){{.*}} attributes {{{.*}}acc.routine_info = #acc.routine_info<[@[[G1_R_NAME:.*]], @[[G1_R2_NAME:.*]]]>{{.*}}}
+// CHECK: cir.func{{.*}} @[[G2_NAME:[^\(]*]]({{.*}}){{.*}} attributes {{{.*}}acc.routine_info = #acc.routine_info<[@[[G2_R_NAME:.*]]]>{{.*}}}
 
 // CHECK: acc.routine @[[L1_R_NAME]] func(@[[L1_NAME]]) seq
 // CHECK: acc.routine @[[G1_R_NAME]] func(@[[G1_NAME]]) seq

--- a/clang/test/CIR/CodeGenOpenACC/routine-globals2.cpp
+++ b/clang/test/CIR/CodeGenOpenACC/routine-globals2.cpp
@@ -25,11 +25,11 @@ void force_emit() {
   GlobalFunc7();
 }
 
-// CHECK: cir.func{{.*}} @[[G6_NAME:[^\(]*]]({{.*}}){{.*}} attributes {acc.routine_info = #acc.routine_info<[@[[G6_R_NAME:.*]]]>}
-// CHECK: cir.func{{.*}} @[[G7_NAME:[^\(]*]]({{.*}}){{.*}} attributes {acc.routine_info = #acc.routine_info<[@[[G7_R_NAME:.*]]]>}
+// CHECK: cir.func{{.*}} @[[G6_NAME:[^\(]*]]({{.*}}){{.*}} attributes {{{.*}}acc.routine_info = #acc.routine_info<[@[[G6_R_NAME:.*]]]>{{.*}}}
+// CHECK: cir.func{{.*}} @[[G7_NAME:[^\(]*]]({{.*}}){{.*}} attributes {{{.*}}acc.routine_info = #acc.routine_info<[@[[G7_R_NAME:.*]]]>{{.*}}}
 
-// CHECK: cir.func{{.*}} @[[G4_NAME:[^\(]*]]({{.*}}){{.*}} attributes {acc.routine_info = #acc.routine_info<[@[[G4_R_NAME:.*]], @[[G4_R2_NAME:.*]]]>}
-// CHECK: cir.func{{.*}} @[[G5_NAME:[^\(]*]]({{.*}}){{.*}} attributes {acc.routine_info = #acc.routine_info<[@[[G5_R_NAME:.*]], @[[G5_R1_NAME:.*]], @[[G5_R2_NAME:.*]], @[[G5_R3_NAME:.*]]]>}
+// CHECK: cir.func{{.*}} @[[G4_NAME:[^\(]*]]({{.*}}){{.*}} attributes {{{.*}}acc.routine_info = #acc.routine_info<[@[[G4_R_NAME:.*]], @[[G4_R2_NAME:.*]]]>{{.*}}}
+// CHECK: cir.func{{.*}} @[[G5_NAME:[^\(]*]]({{.*}}){{.*}} attributes {{{.*}}acc.routine_info = #acc.routine_info<[@[[G5_R_NAME:.*]], @[[G5_R1_NAME:.*]], @[[G5_R2_NAME:.*]], @[[G5_R3_NAME:.*]]]>{{.*}}}
 
 // CHECK: acc.routine @[[G4_R_NAME]] func(@[[G4_NAME]]) seq
 // CHECK: acc.routine @[[G5_R_NAME]] func(@[[G5_NAME]]) seq

--- a/clang/test/CIR/CodeGenOpenACC/routine-locals.cpp
+++ b/clang/test/CIR/CodeGenOpenACC/routine-locals.cpp
@@ -15,9 +15,9 @@ void InFunc() {
   Lambda2();
 };
 
-// CHECK: cir.func{{.*}} @[[G1_NAME:[^\(]*]]({{.*}}){{.*}} attributes {acc.routine_info = #acc.routine_info<[@[[G1_R_NAME:.*]]]>}
-// CHECK: cir.func {{.*}}lambda{{.*}} @[[L1_NAME:[^\(]*]]({{.*}}){{.*}} attributes {acc.routine_info = #acc.routine_info<[@[[L1_R_NAME:.*]]]>}
-// CHECK: cir.func {{.*}}lambda{{.*}} @[[L2_NAME:[^\(]*]]({{.*}}){{.*}} attributes {acc.routine_info = #acc.routine_info<[@[[L2_R_NAME:.*]]]>}
+// CHECK: cir.func{{.*}} @[[G1_NAME:[^\(]*]]({{.*}}){{.*}} attributes {{{.*}}acc.routine_info = #acc.routine_info<[@[[G1_R_NAME:.*]]]>{{.*}}}
+// CHECK: cir.func {{.*}}lambda{{.*}} @[[L1_NAME:[^\(]*]]({{.*}}){{.*}} attributes {{{.*}}acc.routine_info = #acc.routine_info<[@[[L1_R_NAME:.*]]]>{{.*}}}
+// CHECK: cir.func {{.*}}lambda{{.*}} @[[L2_NAME:[^\(]*]]({{.*}}){{.*}} attributes {{{.*}}acc.routine_info = #acc.routine_info<[@[[L2_R_NAME:.*]]]>{{.*}}}
 
 // CHECK: acc.routine @[[L1_R_NAME]] func(@[[L1_NAME]]) seq
 // CHECK: acc.routine @[[G1_R_NAME]] func(@[[G1_NAME]]) seq

--- a/clang/test/CIR/CodeGenOpenACC/routine-members.cpp
+++ b/clang/test/CIR/CodeGenOpenACC/routine-members.cpp
@@ -33,16 +33,16 @@ void force_emit() {
   S::StaticLambda2();
 }
 
-// CHECK: cir.func{{.*}} @[[MEM1_NAME:[^\(]*]]({{.*}}){{.*}} attributes {acc.routine_info = #acc.routine_info<[@[[MEM1_R_NAME:.*]]]>}
-// CHECK: cir.func{{.*}} @[[MEM2_NAME:[^\(]*]]({{.*}}){{.*}} attributes {acc.routine_info = #acc.routine_info<[@[[MEM2_R_NAME:.*]], @[[MEM2_R2_NAME:.*]]]>}
-// CHECK: cir.func{{.*}} @[[MEM3_NAME:[^\(]*]]({{.*}}){{.*}} attributes {acc.routine_info = #acc.routine_info<[@[[MEM3_R_NAME:.*]]]>}
+// CHECK: cir.func{{.*}} @[[MEM1_NAME:[^\(]*]]({{.*}}){{.*}} attributes {{{.*}}acc.routine_info = #acc.routine_info<[@[[MEM1_R_NAME:.*]]]>{{.*}}}
+// CHECK: cir.func{{.*}} @[[MEM2_NAME:[^\(]*]]({{.*}}){{.*}} attributes {{{.*}}acc.routine_info = #acc.routine_info<[@[[MEM2_R_NAME:.*]], @[[MEM2_R2_NAME:.*]]]>{{.*}}}
+// CHECK: cir.func{{.*}} @[[MEM3_NAME:[^\(]*]]({{.*}}){{.*}} attributes {{{.*}}acc.routine_info = #acc.routine_info<[@[[MEM3_R_NAME:.*]]]>{{.*}}}
 //
-// CHECK: cir.func{{.*}} @[[STATICMEM1_NAME:[^\(]*]]({{.*}}){{.*}} attributes {acc.routine_info = #acc.routine_info<[@[[STATICMEM1_R_NAME:.*]]]>}
-// CHECK: cir.func{{.*}} @[[STATICMEM2_NAME:[^\(]*]]({{.*}}){{.*}} attributes {acc.routine_info = #acc.routine_info<[@[[STATICMEM2_R_NAME:.*]]]>}
-// CHECK: cir.func{{.*}} @[[STATICMEM3_NAME:[^\(]*]]({{.*}}){{.*}} attributes {acc.routine_info = #acc.routine_info<[@[[STATICMEM3_R_NAME:.*]]]>}
+// CHECK: cir.func{{.*}} @[[STATICMEM1_NAME:[^\(]*]]({{.*}}){{.*}} attributes {{{.*}}acc.routine_info = #acc.routine_info<[@[[STATICMEM1_R_NAME:.*]]]>{{.*}}}
+// CHECK: cir.func{{.*}} @[[STATICMEM2_NAME:[^\(]*]]({{.*}}){{.*}} attributes {{{.*}}acc.routine_info = #acc.routine_info<[@[[STATICMEM2_R_NAME:.*]]]>{{.*}}}
+// CHECK: cir.func{{.*}} @[[STATICMEM3_NAME:[^\(]*]]({{.*}}){{.*}} attributes {{{.*}}acc.routine_info = #acc.routine_info<[@[[STATICMEM3_R_NAME:.*]]]>{{.*}}}
 //
-// CHECK: cir.func {{.*}}lambda{{.*}} @[[L1_NAME:[^\(]*]]({{.*}}){{.*}} attributes {acc.routine_info = #acc.routine_info<[@[[L1_R_NAME:.*]]]>}
-// CHECK: cir.func {{.*}}lambda{{.*}} @[[L2_NAME:[^\(]*]]({{.*}}){{.*}} attributes {acc.routine_info = #acc.routine_info<[@[[L2_R_NAME:.*]]]>}
+// CHECK: cir.func {{.*}}lambda{{.*}} @[[L1_NAME:[^\(]*]]({{.*}}){{.*}} attributes {{{.*}}acc.routine_info = #acc.routine_info<[@[[L1_R_NAME:.*]]]>{{.*}}}
+// CHECK: cir.func {{.*}}lambda{{.*}} @[[L2_NAME:[^\(]*]]({{.*}}){{.*}} attributes {{{.*}}acc.routine_info = #acc.routine_info<[@[[L2_R_NAME:.*]]]>{{.*}}}
 //
 // CHECK: acc.routine @[[MEM1_R_NAME]] func(@[[MEM1_NAME]]) seq
 // CHECK: acc.routine @[[STATICMEM1_R_NAME]] func(@[[STATICMEM1_NAME]]) seq

--- a/clang/test/CIR/CodeGenOpenACC/routine-ns.cpp
+++ b/clang/test/CIR/CodeGenOpenACC/routine-ns.cpp
@@ -18,9 +18,9 @@ void force_emit() {
   NS1::Lambda2();
 }
 
-// CHECK: cir.func{{.*}} @[[F1_NAME:[^\(]*]]({{.*}}){{.*}} attributes {acc.routine_info = #acc.routine_info<[@[[F1_R_NAME:.*]], @[[F1_R2_NAME:.*]]]>}
-// CHECK: cir.func {{.*}}lambda{{.*}} @[[L1_NAME:[^\(]*]]({{.*}}){{.*}} attributes {acc.routine_info = #acc.routine_info<[@[[L1_R_NAME:.*]]]>}
-// CHECK: cir.func {{.*}}lambda{{.*}} @[[L2_NAME:[^\(]*]]({{.*}}){{.*}} attributes {acc.routine_info = #acc.routine_info<[@[[L2_R_NAME:.*]]]>}
+// CHECK: cir.func{{.*}} @[[F1_NAME:[^\(]*]]({{.*}}){{.*}} attributes {{{.*}}acc.routine_info = #acc.routine_info<[@[[F1_R_NAME:.*]], @[[F1_R2_NAME:.*]]]>{{.*}}}
+// CHECK: cir.func {{.*}}lambda{{.*}} @[[L1_NAME:[^\(]*]]({{.*}}){{.*}} attributes {{{.*}}acc.routine_info = #acc.routine_info<[@[[L1_R_NAME:.*]]]>{{.*}}}
+// CHECK: cir.func {{.*}}lambda{{.*}} @[[L2_NAME:[^\(]*]]({{.*}}){{.*}} attributes {{{.*}}acc.routine_info = #acc.routine_info<[@[[L2_R_NAME:.*]]]>{{.*}}}
 //
 // CHECK: acc.routine @[[F1_R_NAME]] func(@[[F1_NAME]]) seq 
 // CHECK: acc.routine @[[L1_R_NAME]] func(@[[L1_NAME]]) seq 

--- a/clang/test/CIR/CodeGenOpenACC/routine-templ.cpp
+++ b/clang/test/CIR/CodeGenOpenACC/routine-templ.cpp
@@ -9,8 +9,8 @@ void use() {
   func<float>();
 }
 
-// CHECK: cir.func{{.*}} @[[T1_NAME:[^\(]*]]({{.*}}){{.*}} attributes {acc.routine_info = #acc.routine_info<[@[[T1_R_NAME:.*]]]>}
-// CHECK: cir.func{{.*}} @[[T2_NAME:[^\(]*]]({{.*}}){{.*}} attributes {acc.routine_info = #acc.routine_info<[@[[T2_R_NAME:.*]]]>}
+// CHECK: cir.func{{.*}} @[[T1_NAME:[^\(]*]]({{.*}}){{.*}} attributes {{{.*}}acc.routine_info = #acc.routine_info<[@[[T1_R_NAME:.*]]]>{{.*}}}
+// CHECK: cir.func{{.*}} @[[T2_NAME:[^\(]*]]({{.*}}){{.*}} attributes {{{.*}}acc.routine_info = #acc.routine_info<[@[[T2_R_NAME:.*]]]>{{.*}}}
 //
 // CHECK: acc.routine @[[T1_R_NAME]] func(@[[T1_NAME]]) seq
 // CHECK: acc.routine @[[T2_R_NAME]] func(@[[T2_NAME]]) seq

--- a/clang/test/CIR/CodeGenOpenACC/serial.c
+++ b/clang/test/CIR/CodeGenOpenACC/serial.c
@@ -1,7 +1,7 @@
 // RUN: %clang_cc1 -fopenacc -Wno-openacc-self-if-potential-conflict -emit-cir -fclangir %s -o - | FileCheck %s
 
 void acc_serial(int cond) {
-  // CHECK: cir.func{{.*}} @acc_serial(%[[ARG:.*]]: !s32i{{.*}}) {
+  // CHECK: cir.func{{.*}} @acc_serial(%[[ARG:.*]]: !s32i{{.*}}){{.*}}{
   // CHECK-NEXT: %[[COND:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["cond", init]
   // CHECK-NEXT: cir.store %[[ARG]], %[[COND]] : !s32i, !cir.ptr<!s32i>
 #pragma acc serial
@@ -268,7 +268,7 @@ void acc_serial(int cond) {
 }
 
 void acc_serial_data_clauses(int *arg1, int *arg2) {
-  // CHECK: cir.func{{.*}} @acc_serial_data_clauses(%[[ARG1_PARAM:.*]]: !cir.ptr<!s32i>{{.*}}, %[[ARG2_PARAM:.*]]: !cir.ptr<!s32i>{{.*}}) {
+  // CHECK: cir.func{{.*}} @acc_serial_data_clauses(%[[ARG1_PARAM:.*]]: !cir.ptr<!s32i>{{.*}}, %[[ARG2_PARAM:.*]]: !cir.ptr<!s32i>{{.*}}){{.*}}{
   // CHECK-NEXT: %[[ARG1:.*]] = cir.alloca !cir.ptr<!s32i>, !cir.ptr<!cir.ptr<!s32i>>, ["arg1", init]
   // CHECK-NEXT: %[[ARG2:.*]] = cir.alloca !cir.ptr<!s32i>, !cir.ptr<!cir.ptr<!s32i>>, ["arg2", init]
   // CHECK-NEXT: cir.store %[[ARG1_PARAM]], %[[ARG1]] : !cir.ptr<!s32i>, !cir.ptr<!cir.ptr<!s32i>>

--- a/clang/test/CIR/CodeGenOpenACC/set.c
+++ b/clang/test/CIR/CodeGenOpenACC/set.c
@@ -1,7 +1,7 @@
 // RUN: %clang_cc1 -fopenacc -emit-cir -fclangir %s -o - | FileCheck %s
 
 void acc_set(int cond) {
-  // CHECK: cir.func{{.*}} @acc_set(%[[ARG:.*]]: !s32i{{.*}}) {
+  // CHECK: cir.func{{.*}} @acc_set(%[[ARG:.*]]: !s32i{{.*}}){{.*}}{
   // CHECK-NEXT: %[[COND:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["cond", init]
   // CHECK-NEXT: cir.store %[[ARG]], %[[COND]] : !s32i, !cir.ptr<!s32i>
 

--- a/clang/test/CIR/CodeGenOpenACC/shutdown.c
+++ b/clang/test/CIR/CodeGenOpenACC/shutdown.c
@@ -1,7 +1,7 @@
 // RUN: %clang_cc1 -fopenacc -emit-cir -fclangir %s -o - | FileCheck %s
 
 void acc_shutdown(int cond) {
-  // CHECK: cir.func{{.*}} @acc_shutdown(%[[ARG:.*]]: !s32i{{.*}}) {
+  // CHECK: cir.func{{.*}} @acc_shutdown(%[[ARG:.*]]: !s32i{{.*}}){{.*}}{
   // CHECK-NEXT: %[[COND:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["cond", init]
   // CHECK-NEXT: cir.store %[[ARG]], %[[COND]] : !s32i, !cir.ptr<!s32i>
 #pragma acc shutdown

--- a/clang/test/CIR/CodeGenOpenACC/update.c
+++ b/clang/test/CIR/CodeGenOpenACC/update.c
@@ -1,7 +1,7 @@
 // RUN: %clang_cc1 -fopenacc -Wno-openacc-self-if-potential-conflict -emit-cir -fclangir %s -o - | FileCheck %s
 
 void acc_update(int parmVar, int *ptrParmVar) {
-  // CHECK: cir.func{{.*}} @acc_update(%[[ARG:.*]]: !s32i{{.*}}, %[[PTRARG:.*]]: !cir.ptr<!s32i>{{.*}}) {
+  // CHECK: cir.func{{.*}} @acc_update(%[[ARG:.*]]: !s32i{{.*}}, %[[PTRARG:.*]]: !cir.ptr<!s32i>{{.*}}){{.*}}{
   // CHECK-NEXT: %[[PARM:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["parmVar", init]
   // CHECK-NEXT: %[[PTRPARM:.*]] = cir.alloca !cir.ptr<!s32i>, !cir.ptr<!cir.ptr<!s32i>>, ["ptrParmVar", init]
   // CHECK-NEXT: cir.store %[[ARG]], %[[PARM]] : !s32i, !cir.ptr<!s32i>

--- a/clang/test/CIR/CodeGenOpenACC/wait.c
+++ b/clang/test/CIR/CodeGenOpenACC/wait.c
@@ -1,7 +1,7 @@
 // RUN: %clang_cc1 -fopenacc -emit-cir -fclangir %s -o - | FileCheck %s
 
 void acc_wait(int cond) {
-  // CHECK: cir.func{{.*}} @acc_wait(%[[ARG:.*]]: !s32i{{.*}}) {
+  // CHECK: cir.func{{.*}} @acc_wait(%[[ARG:.*]]: !s32i{{.*}}){{.*}}{
   // CHECK-NEXT: %[[COND:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["cond", init]
   // CHECK-NEXT: cir.store %[[ARG]], %[[COND]] : !s32i, !cir.ptr<!s32i>
 

--- a/clang/test/CIR/CodeGenOpenMP/omp-llvmir.c
+++ b/clang/test/CIR/CodeGenOpenMP/omp-llvmir.c
@@ -5,7 +5,7 @@
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fopenmp -emit-llvm %s -o %t.ll
 // RUN: FileCheck --input-file=%t.ll %s --check-prefix=OGCG
 
-// CIR-LABEL: cir.func no_inline no_proto dso_local @main() -> !s32i {
+// CIR-LABEL: cir.func no_inline no_proto dso_local @main() -> !s32i{{.*}}{
 // CIR: [[RETVAL:%.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["__retval"] {alignment = 4 : i64}
 // CIR: [[J:%.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["j"] {alignment = 4 : i64}
 // CIR:   omp.parallel {

--- a/clang/test/CIR/Lowering/func-attrs.cir
+++ b/clang/test/CIR/Lowering/func-attrs.cir
@@ -1,0 +1,35 @@
+// RUN: cir-opt %s --cir-to-llvm -o - | FileCheck %s
+
+module {
+  // CHECK: llvm.func @optimize_none_func() attributes {no_inline, optimize_none}
+  cir.func no_inline @optimize_none_func() attributes {optimize_none} {
+    cir.return
+  }
+
+  // CHECK: llvm.func @cold_func() attributes {cold, optsize}
+  cir.func @cold_func() attributes {cold, optsize} {
+    cir.return
+  }
+
+  // CHECK: llvm.func @hot_func() attributes {hot}
+  cir.func @hot_func() attributes {hot} {
+    cir.return
+  }
+
+  // CHECK: llvm.func @noduplicate_func() attributes {noduplicate}
+  cir.func @noduplicate_func() attributes {noduplicate} {
+    cir.return
+  }
+
+  // CHECK: llvm.func @minsize_func() attributes {minsize}
+  cir.func @minsize_func() attributes {minsize} {
+    cir.return
+  }
+
+  // optnone + cold: optimize_none is set, cold is preserved, but no optsize.
+  // CHECK: llvm.func @optnone_cold_func() attributes {cold, no_inline, optimize_none}
+  // CHECK-NOT: optsize
+  cir.func no_inline @optnone_cold_func() attributes {cold, optimize_none} {
+    cir.return
+  }
+}


### PR DESCRIPTION
Implement the definition-time precedence logic in
setCIRFunctionAttributesForDefinition(). This fills the gap where constructAttributeList() already sets cold/hot/noduplicate as discardable attrs, but the definition-time precedence for optnone (and its interactions with optsize/minsize) was missing.