### PR TITLE
[mlir][irdl] Fix crash in TypeOp/AttributeOp verify on empty sym_name

### DIFF
--- a/mlir/lib/Dialect/IRDL/IR/IRDL.cpp
+++ b/mlir/lib/Dialect/IRDL/IR/IRDL.cpp
@@ -116,14 +116,14 @@ LogicalResult OperationOp::verify() {
 
 LogicalResult TypeOp::verify() {
   auto symName = getSymName();
-  if (symName.front() == '!')
+  if (!symName.empty() && symName.front() == '!')
     symName = symName.substr(1);
   return isValidName(symName, getOperation(), "type");
 }
 
 LogicalResult AttributeOp::verify() {
   auto symName = getSymName();
-  if (symName.front() == '#')
+  if (!symName.empty() && symName.front() == '#')
     symName = symName.substr(1);
   return isValidName(symName, getOperation(), "attribute");
 }

--- a/mlir/test/Dialect/IRDL/invalid_names.irdl.mlir
+++ b/mlir/test/Dialect/IRDL/invalid_names.irdl.mlir
@@ -92,3 +92,19 @@ irdl.dialect @test_dialect {
 }
 
 // -----
+
+irdl.dialect @test_dialect {
+  // expected-error@+1 {{name of type is empty}}
+  irdl.type @"" {
+    %0 = irdl.any
+  }
+}
+
+// -----
+
+irdl.dialect @test_dialect {
+  // expected-error@+1 {{name of attribute is empty}}
+  irdl.attribute @"" {
+    %0 = irdl.any
+  }
+}


### PR DESCRIPTION
TypeOp::verify() and AttributeOp::verify() called StringRef::front() to check for leading '\!' or '#' sigils before passing the name to isValidName(). When sym_name is empty, front() triggers an assertion failure:
  Assertion `\!empty()' failed.

Fix: guard the front() calls with an emptiness check. An empty sym_name then falls through to isValidName(), which already emits a proper diagnostic:
  error: name of type is empty

Fixes #159949