### PR TITLE
WIP: [mlir][func] Fix potential crash in `FuncOp::verify`

### DIFF
--- a/mlir/lib/Dialect/Func/IR/FuncOps.cpp
+++ b/mlir/lib/Dialect/Func/IR/FuncOps.cpp
@@ -305,9 +305,12 @@ LogicalResult FuncOp::verify() {
              << " operands, but enclosing function (@" << getName()
              << ") returns " << resultTypes.size();
 
-    for (auto [i, opType] :
-         llvm::enumerate(llvm::zip(returnOp->getOperandTypes(), resultTypes))) {
-      auto [opTy, resTy] = opType;
+    for (auto [i, operand] :
+         llvm::enumerate(llvm::zip(returnOp->getOpOperands(), resultTypes))) {
+      auto [opOperand, resTy] = operand;
+      if (!opOperand.get())
+        return returnOp->emitOpError("null operand at index ") << i;
+      auto opTy = opOperand.get().getType();
       if (opTy != resTy)
         return returnOp->emitError()
                << "type of return operand " << i << " (" << opTy


### PR DESCRIPTION
This PR fixes a potential crash in `FuncOp::verify`. This can happen if one of the operands of the return op inside the verified op is a `<<NULL>>` value, for example, because the original value had all uses dropped. The original implementation used the operands without checking their validity, which could lead to a crash. The fix consists in adding a test and failing verificiation if not all operands exist.