### PR TITLE
[CI] Install binutils-dev in pre-merge container

### DIFF
--- a/.github/workflows/containers/github-action-ci/Dockerfile
+++ b/.github/workflows/containers/github-action-ci/Dockerfile
@@ -45,9 +45,10 @@ COPY --from=stage1-toolchain $LLVM_SYSROOT $LLVM_SYSROOT
 # Need nodejs for some of the GitHub actions.
 # Need perl-modules for clang analyzer tests.
 # Need git for SPIRV-Tools tests.
+# Need binutils-dev instead of binutils to build the linker LTO plugin.
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y \
-    binutils \
+    binutils-dev \
     cmake \
     curl \
     git \


### PR DESCRIPTION
This is to get the plugin-api.h file, to allow running tests for the gold plugin.