### PR TITLE
[mlir][shape] Fix crash when shape.lib array references undefined symbol

### DIFF
--- a/mlir/lib/Dialect/Shape/IR/Shape.cpp
+++ b/mlir/lib/Dialect/Shape/IR/Shape.cpp
@@ -193,7 +193,7 @@ LogicalResult ShapeDialect::verifyOperationAttribute(Operation *op,
           return op->emitError(
               "only SymbolRefAttr allowed in shape.lib attribute array");
 
-        auto shapeFnLib = dyn_cast<shape::FunctionLibraryOp>(
+        auto shapeFnLib = dyn_cast_or_null<shape::FunctionLibraryOp>(
             SymbolTable::lookupSymbolIn(op, llvm::cast<SymbolRefAttr>(it)));
         if (!shapeFnLib)
           return op->emitError()

--- a/mlir/test/Dialect/Shape/invalid.mlir
+++ b/mlir/test/Dialect/Shape/invalid.mlir
@@ -258,6 +258,14 @@ module attributes {shape.lib = @fn} { }
 
 // -----
 
+// Test that shape function library array entry is defined (regression test for
+// github.com/llvm/llvm-project/issues/159653: dyn_cast crash on missing symbol).
+
+// expected-error@+1 {{@missing does not refer to FunctionLibraryOp}}
+module attributes {shape.lib = [@missing]} { }
+
+// -----
+
 func.func @fn(%arg: !shape.shape) -> !shape.witness {
   // expected-error@+1 {{required at least 2 input shapes}}
   %0 = shape.cstr_broadcastable %arg : !shape.shape


### PR DESCRIPTION
In verifyOperationAttribute(), the single-symbol path for shape.lib used SymbolTable::lookupSymbolIn() followed by an explicit null check. The array path at line 196-197 used dyn_cast<FunctionLibraryOp>() directly on the lookup result, which asserts when the symbol is not found (null pointer).

Fix: use dyn_cast_or_null<> instead of dyn_cast<> so that a missing symbol falls through to the existing "does not refer to FunctionLibraryOp" error diagnostic instead of asserting.

Fixes #159653