### PR TITLE
[clang] Fixes alias declaration fix-it location for token-split '>>'

### DIFF
--- a/clang/lib/Lex/Lexer.cpp
+++ b/clang/lib/Lex/Lexer.cpp
@@ -866,7 +866,8 @@ SourceLocation Lexer::getLocForEndOfToken(SourceLocation Loc, unsigned Offset,
       return {};
 
     // Token-split expansions (e.g., '>>' split into '>') use a char range
-    // whose end is already the correct insertion point; skip MeasureTokenLength.
+    // whose end is already the correct insertion point; skip
+    // MeasureTokenLength.
     CharSourceRange ExpRange = SM.getImmediateExpansionRange(Loc);
     if (!ExpRange.isTokenRange()) {
       SourceLocation End = ExpRange.getEnd();

--- a/clang/lib/Lex/Lexer.cpp
+++ b/clang/lib/Lex/Lexer.cpp
@@ -862,7 +862,18 @@ SourceLocation Lexer::getLocForEndOfToken(SourceLocation Loc, unsigned Offset,
     return {};
 
   if (Loc.isMacroID()) {
-    if (Offset > 0 || !isAtEndOfMacroExpansion(Loc, SM, LangOpts, &Loc))
+    if (Offset > 0)
+      return {};
+
+    // Token-split expansions (e.g., '>>' split into '>') use a char range
+    // whose end is already the correct insertion point; skip MeasureTokenLength.
+    CharSourceRange ExpRange = SM.getImmediateExpansionRange(Loc);
+    if (!ExpRange.isTokenRange()) {
+      SourceLocation End = ExpRange.getEnd();
+      return End.isFileID() ? End : SourceLocation{};
+    }
+
+    if (!isAtEndOfMacroExpansion(Loc, SM, LangOpts, &Loc))
       return {}; // Points inside the macro expansion.
   }
 

--- a/clang/test/Parser/cxx0x-decl.cpp
+++ b/clang/test/Parser/cxx0x-decl.cpp
@@ -190,8 +190,6 @@ namespace AliasDeclEndLocation {
     ;
   using D = AliasDeclEndLocation::A<int
     > // expected-error {{expected ';' after alias declaration}}
-  // FIXME: After splitting this >> into two > tokens, we incorrectly determine
-  // the end of the template-id to be after the *second* '>'.
   using E = AliasDeclEndLocation::A<int>>;
 #define GGG >>>
   using F = AliasDeclEndLocation::A<int GGG;

--- a/clang/test/Parser/cxx11-alias-decl-split-token-fixit.cpp
+++ b/clang/test/Parser/cxx11-alias-decl-split-token-fixit.cpp
@@ -1,0 +1,6 @@
+// RUN: not %clang_cc1 -fsyntax-only -std=c++11 -fdiagnostics-parseable-fixits %s 2>&1 | FileCheck %s
+// RUN: %clang_cc1 -fsyntax-only -std=c++11 -verify %s
+
+template <typename> struct X {};
+using A = X<int>>; // expected-error {{expected ';' after alias declaration}}
+// CHECK: fix-it:"{{.*}}":{[[@LINE-1]]:17-[[@LINE-1]]:17}:";"


### PR DESCRIPTION
Fixes #184425