### PR TITLE
[OpenMP][AIX] Add libpthreads for -fopenmp

### DIFF
--- a/clang/lib/Driver/ToolChains/AIX.cpp
+++ b/clang/lib/Driver/ToolChains/AIX.cpp
@@ -310,6 +310,8 @@ void aix::Linker::ConstructJob(Compilation &C, const JobAction &JA,
           // Already diagnosed.
           break;
         }
+        // libpthreads is required for -fopenmp.
+        CmdArgs.push_back("-lpthreads");
       }
 
       // Support POSIX threads if "-pthreads" or "-pthread" is present.


### PR DESCRIPTION
The compiler uses TLS for OpenMP thread‑private data, which results in references to symbols such as `__tls_get_addr` in `libpthreads`. Therefore, this PR adds `libpthreads` to the link command when `-fopenmp` is specified.