### PR TITLE
[SPIRV] Fix return value of runOnModule for SPIRVPrepareFunctions

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVPrepareFunctions.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVPrepareFunctions.cpp
@@ -666,6 +666,7 @@ bool SPIRVPrepareFunctions::runOnModule(Module &M) {
       .getMutableSubtargetImpl()
       ->resolveEnvFromModule(M);
 
+  bool Changed = false;
   if (M.functions().empty()) {
     // If there are no functions, insert a service
     // function so that the global/constant tracking intrinsics
@@ -675,9 +676,9 @@ bool SPIRVPrepareFunctions::runOnModule(Module &M) {
     BasicBlock *BB = BasicBlock::Create(M.getContext(), "entry", SF);
     IRBuilder<> IRB(BB);
     IRB.CreateRetVoid();
+    Changed = true;
   }
 
-  bool Changed = false;
   for (Function &F : M) {
     Changed |= substituteIntrinsicCalls(&F);
     Changed |= sortBlocks(F);


### PR DESCRIPTION
We need to return `true` if the module is changed by the pass, and we forgot to do that in this new case.

This fixes a buildbot [fail](https://lab.llvm.org/buildbot/#/builders/187/builds/17475).