### PR TITLE
AMDGPU: Clean up print handling of AMDGPUTargetID

### DIFF
--- a/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUTargetStreamer.cpp
+++ b/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUTargetStreamer.cpp
@@ -247,7 +247,7 @@ void AMDGPUTargetAsmStreamer::finish() {
 }
 
 void AMDGPUTargetAsmStreamer::EmitDirectiveAMDGCNTarget() {
-  OS << "\t.amdgcn_target \"" << getTargetID()->toString() << "\"\n";
+  OS << "\t.amdgcn_target \"" << *getTargetID() << "\"\n";
 }
 
 void AMDGPUTargetAsmStreamer::EmitDirectiveAMDHSACodeObjectVersion(
@@ -327,7 +327,7 @@ void AMDGPUTargetAsmStreamer::EmitMCResourceMaximums(
 }
 
 bool AMDGPUTargetAsmStreamer::EmitISAVersion() {
-  OS << "\t.amd_amdgpu_isa \"" << getTargetID()->toString() << "\"\n";
+  OS << "\t.amd_amdgpu_isa \"" << getTargetID() << "\"\n";
   return true;
 }
 
@@ -930,7 +930,12 @@ bool AMDGPUTargetELFStreamer::EmitISAVersion() {
   EmitNote(ElfNote::NoteNameV2, DescSZ, ELF::NT_AMD_HSA_ISA_NAME,
            [&](MCELFStreamer &OS) {
              OS.emitLabel(DescBegin);
-             OS.emitBytes(getTargetID()->toString());
+
+             SmallString<32> Str;
+             raw_svector_ostream StrOS(Str);
+             StrOS << *getTargetID();
+
+             OS.emitBytes(StrOS.str());
              OS.emitLabel(DescEnd);
            });
   return true;

--- a/llvm/lib/Target/AMDGPU/Utils/AMDGPUBaseInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/Utils/AMDGPUBaseInfo.cpp
@@ -1131,10 +1131,7 @@ void AMDGPUTargetID::setTargetIDFromTargetIDStream(StringRef TargetID) {
   }
 }
 
-std::string AMDGPUTargetID::toString() const {
-  std::string StringRep;
-  raw_string_ostream StreamRep(StringRep);
-
+void AMDGPUTargetID::print(raw_ostream &StreamRep) const {
   const Triple &TargetTriple = STI.getTargetTriple();
   auto Version = getIsaVersion(STI.getCPU());
 
@@ -1168,8 +1165,13 @@ std::string AMDGPUTargetID::toString() const {
   }
 
   StreamRep << Processor << Features;
+}
 
-  return StringRep;
+std::string AMDGPUTargetID::toString() const {
+  std::string Str;
+  raw_string_ostream OS(Str);
+  OS << *this;
+  return Str;
 }
 
 unsigned getWavefrontSize(const MCSubtargetInfo *STI) {

--- a/llvm/lib/Target/AMDGPU/Utils/AMDGPUBaseInfo.h
+++ b/llvm/lib/Target/AMDGPU/Utils/AMDGPUBaseInfo.h
@@ -217,9 +217,18 @@ public:
   void setTargetIDFromFeaturesString(StringRef FS);
   void setTargetIDFromTargetIDStream(StringRef TargetID);
 
+  /// Write string representation to \p OS
+  void print(raw_ostream &OS) const;
+
   /// \returns String representation of an object.
   std::string toString() const;
 };
+
+inline raw_ostream &operator<<(raw_ostream &OS,
+                               const AMDGPUTargetID &TargetID) {
+  TargetID.print(OS);
+  return OS;
+}
 
 /// \returns Wavefront size for given subtarget \p STI.
 unsigned getWavefrontSize(const MCSubtargetInfo *STI);


### PR DESCRIPTION
Provide print to raw_ostream method and use it where applicable.