### PR TITLE
[green dragon] skip trigger on release branch stage1 RA jobs

### DIFF
--- a/.ci/green-dragon/clang-stage1-RA.groovy
+++ b/.ci/green-dragon/clang-stage1-RA.groovy
@@ -18,7 +18,8 @@ clangPipeline(
         projects: 'clang;clang-tools-extra',
         runtimes: 'compiler-rt',
         timeout: 120,
-        incremental: false
+        incremental: false,
+        skipTrigger: env.BRANCH_NAME?.startsWith('release/') ?: false
     ],
     testConfig: [
         test_type: 'testlong',


### PR DESCRIPTION
* This will allow us to setup clang-stage1-RA jobs as multi branch pipelines for release branches without setting up all the downstream jobs.

I will need to cherry-pick the jenkinsfile to the release/22.x branch which I will do after this lands