### PR TITLE
[AMDGPU] Add scheduling strategy for critical resource in remainder

### DIFF
--- a/llvm/include/llvm/CodeGen/MachineScheduler.h
+++ b/llvm/include/llvm/CodeGen/MachineScheduler.h
@@ -1089,6 +1089,13 @@ public:
   /// Dump the state of the information that tracks resource usage.
   LLVM_ABI void dumpReservedCycles() const;
   LLVM_ABI void dumpScheduledState() const;
+
+  /// Count nodes in the Available + Pending queues that satisfy \p P.
+  /// Hides the underlying queue storage from callers.
+  template <typename Predicate> unsigned countReadyNodes(Predicate P) {
+    return llvm::count_if(Available.elements(), P) +
+           llvm::count_if(Pending.elements(), P);
+  }
 };
 
 /// Base class for GenericScheduler. This class maintains information about

--- a/llvm/lib/Target/AMDGPU/AMDGPUCacheCapacityHazardRecognizer.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUCacheCapacityHazardRecognizer.cpp
@@ -1,0 +1,234 @@
+//===-- AMDGPUCacheCapacityHazardRecognizer.cpp ----------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements a hazard recognizer for modeling L1 data cache capacity
+// pressure during instruction scheduling on AMDGPU processors.
+//
+//===----------------------------------------------------------------------===//
+
+#include "AMDGPUCacheCapacityHazardRecognizer.h"
+#include "AMDGPUWaitcntUtils.h"
+#include "SIInstrInfo.h"
+#include "llvm/Support/Debug.h"
+
+#include <algorithm>
+#include <numeric>
+#include <optional>
+
+#define DEBUG_TYPE "amdgpu-l1-hazard"
+
+namespace llvm {
+namespace AMDGPU {
+
+/// Cap on the user-controlled L1 latency. The internal IssueHistory ring
+/// buffer is sized in cycles, so an unclamped cl::opt could request a
+/// pathologically large allocation per scheduling region.
+static constexpr unsigned MaxLatencyClamp = 10000;
+
+namespace {
+unsigned getEffectiveCacheBytes(MachineInstr *MI) {
+  unsigned Res = 0;
+  for (auto *MMO : MI->memoperands()) {
+    auto AS = MMO->getAddrSpace();
+    if (AS == AMDGPUAS::FLAT_ADDRESS || AS == AMDGPUAS::GLOBAL_ADDRESS ||
+        AS == AMDGPUAS::BUFFER_RESOURCE) {
+      auto MMOSize = MMO->getSize();
+      if (MMOSize.hasValue() && MMOSize.isPrecise() && !MMOSize.isScalable())
+        Res += (unsigned)MMOSize.getValue().getFixedValue();
+    }
+  }
+  return Res;
+}
+std::optional<unsigned> getInstrVMCNT(MachineInstr *MI, AMDGPU::IsaVersion IV) {
+  unsigned Opcode = SIInstrInfo::getNonSoftWaitcntOpcode(MI->getOpcode());
+  if (Opcode == AMDGPU::S_WAITCNT) {
+    unsigned IEnc = MI->getOperand(0).getImm();
+    AMDGPU::Waitcnt Waitcnt = AMDGPU::decodeWaitcnt(IV, IEnc);
+    return Waitcnt.get(InstCounterType::LOAD_CNT);
+  }
+  return std::nullopt;
+}
+} // namespace
+
+CacheCapacityHazardRecognizer::CacheCapacityHazardRecognizer(
+    unsigned CapacityBytes, BytesPerCycle DrainRate, unsigned LatencyIn,
+    AMDGPU::IsaVersion IsaVer)
+    : IsaVer(IsaVer), Latency(std::min(LatencyIn, MaxLatencyClamp)) {
+  if (LatencyIn > MaxLatencyClamp)
+    LLVM_DEBUG(dbgs() << "L1Hazard: clamping latency from " << LatencyIn
+                      << " to " << MaxLatencyClamp << "\n");
+  assert(DrainRate.Dividend > 0 && DrainRate.Divisor > 0 &&
+         "BytesPerCycle dividend and divisor must be positive");
+  unsigned GCD = std::gcd(DrainRate.Dividend, DrainRate.Divisor);
+  ScaledDrainPerCycle = DrainRate.Dividend / GCD;
+  BytesScaleFactor = DrainRate.Divisor / GCD;
+  ScaledCapacityBytes = CapacityBytes * BytesScaleFactor;
+  unsigned MaxCycles =
+      Latency +
+      (ScaledCapacityBytes + ScaledDrainPerCycle - 1) / ScaledDrainPerCycle;
+  // Buffer must accommodate both the time horizon (MaxCycles) and the worst-
+  // case slot count: with multi-issue and small per-load footprints, up to
+  // ScaledCapacityBytes entries can pile up before the byte cap blocks further
+  // issues. Sizing only by MaxCycles undercounts when ScaledDrainPerCycle > 1.
+  IssueHistory.resize(std::max(MaxCycles, ScaledCapacityBytes) + 1);
+  MaxLookAhead = MaxCycles;
+}
+
+void CacheCapacityHazardRecognizer::Reset() {
+  ScaledUsedBytes = 0;
+  CurrentCycle = 0;
+  IssueHead = IssueTail = 0;
+}
+
+void CacheCapacityHazardRecognizer::waitLessThanInstr(unsigned InstrCount) {
+  while (historySize() > InstrCount) {
+    AdvanceCycle();
+  }
+}
+
+void CacheCapacityHazardRecognizer::issueBytes(unsigned Bytes) {
+  if (Bytes == 0) {
+    return;
+  }
+  unsigned ScaledBytes = Bytes * BytesScaleFactor;
+  // Clamp to ScaledCapacityBytes so an instruction whose footprint exceeds the
+  // modeled cache cannot make the drain loop below spin forever. Real-world
+  // load groups larger than capacity will still drain the FIFO between issues.
+  if (ScaledBytes > ScaledCapacityBytes) {
+    LLVM_DEBUG(dbgs() << "L1Hazard: clamping issue footprint from " << Bytes
+                      << " to capacity ("
+                      << ScaledCapacityBytes / BytesScaleFactor
+                      << ") bytes\n");
+    ScaledBytes = ScaledCapacityBytes;
+  }
+  while (ScaledUsedBytes + ScaledBytes > ScaledCapacityBytes) {
+    AdvanceCycle();
+  }
+  ScaledUsedBytes += ScaledBytes;
+  IssueHistory[IssueHead] = {ScaledBytes, CurrentCycle};
+  IssueHead += 1;
+  if (IssueHead == IssueHistory.size())
+    IssueHead = 0;
+  assert(IssueHead != IssueTail && "Circular buffer overflow");
+}
+
+bool CacheCapacityHazardRecognizer::canWaitLessThanInstr(unsigned InstrCount,
+                                                         int Stalls) const {
+  unsigned RemBytesScaled, RemInstrs;
+  simulateAdvanceCycles(Stalls, RemBytesScaled, RemInstrs);
+  return RemInstrs <= InstrCount;
+}
+
+bool CacheCapacityHazardRecognizer::canIssueBytes(unsigned Bytes,
+                                                  int Stalls) const {
+  // Scale incoming bytes to match the internal scaled representation.
+  unsigned ScaledBytes = Bytes * BytesScaleFactor;
+  // Clamp to ScaledCapacityBytes. Without this, an instruction whose footprint
+  // exceeds the cache would report a hazard that can never be resolved.
+  if (ScaledBytes > ScaledCapacityBytes) {
+    LLVM_DEBUG(dbgs() << "L1Hazard: clamping probe footprint from " << Bytes
+                      << " to capacity ("
+                      << ScaledCapacityBytes / BytesScaleFactor
+                      << ") bytes\n");
+    ScaledBytes = ScaledCapacityBytes;
+  }
+  unsigned RemBytesScaled, RemInstrs;
+  simulateAdvanceCycles(Stalls, RemBytesScaled, RemInstrs);
+  return RemBytesScaled + ScaledBytes <= ScaledCapacityBytes;
+}
+
+ScheduleHazardRecognizer::HazardType
+CacheCapacityHazardRecognizer::getHazardType(MachineInstr *MI, int Stalls) {
+  assert(Stalls >= 0 && "Only top-down is implemented");
+  if (SIInstrInfo::isWaitcnt(MI->getOpcode())) {
+    auto VMCNT = getInstrVMCNT(MI, IsaVer);
+    return !VMCNT || canWaitLessThanInstr(*VMCNT, Stalls) ? NoHazard
+                                                          : NoopHazard;
+  }
+  unsigned CacheBytes = getEffectiveCacheBytes(MI);
+  return canIssueBytes(CacheBytes, Stalls) ? NoHazard : NoopHazard;
+}
+
+ScheduleHazardRecognizer::HazardType
+CacheCapacityHazardRecognizer::getHazardType(SUnit *SU, int Stalls) {
+  return getHazardType(SU->getInstr(), Stalls);
+}
+
+void CacheCapacityHazardRecognizer::EmitInstruction(SUnit *SU) {
+  return EmitInstruction(SU->getInstr());
+}
+
+void CacheCapacityHazardRecognizer::EmitInstruction(MachineInstr *MI) {
+  if (SIInstrInfo::isWaitcnt(MI->getOpcode())) {
+    auto VMCNT = getInstrVMCNT(MI, IsaVer);
+    if (VMCNT)
+      waitLessThanInstr(*VMCNT);
+    return;
+  }
+  return issueBytes(getEffectiveCacheBytes(MI));
+}
+
+void CacheCapacityHazardRecognizer::drainOneCycle(
+    unsigned ScaledDrainPerCycle, unsigned CurrCycle, unsigned Latency,
+    unsigned &Tail, unsigned Head, ArrayRef<IssueEntry> History,
+    unsigned &UsedBytes, unsigned &Remain) {
+  unsigned Budget = ScaledDrainPerCycle;
+  while (Budget && Tail != Head) {
+    // Only drain entries that have matured (age >= Latency).
+    if (CurrCycle - History[Tail].Cycle < Latency)
+      break;
+    unsigned Finished = std::min(Budget, Remain);
+    Budget -= Finished;
+    assert(UsedBytes >= Finished && "ScaledUsedBytes underflow");
+    UsedBytes -= Finished;
+    if (Finished == Remain) {
+      if (++Tail == History.size())
+        Tail = 0;
+      Remain = Tail != Head ? History[Tail].ScaledBytes : 0;
+    } else {
+      Remain -= Finished;
+      break;
+    }
+  }
+}
+
+void CacheCapacityHazardRecognizer::simulateAdvanceCycles(
+    int Stalls, unsigned &RemBytesScaled, unsigned &RemInstrs) const {
+  unsigned SimHead = IssueHead, SimTail = IssueTail;
+  unsigned SimUsed = ScaledUsedBytes;
+  unsigned SimCycle = CurrentCycle;
+  unsigned Remain = SimTail != SimHead ? IssueHistory[SimTail].ScaledBytes : 0;
+  while (Stalls > 0 && SimTail != SimHead) {
+    drainOneCycle(ScaledDrainPerCycle, SimCycle, Latency, SimTail, SimHead,
+                  IssueHistory, SimUsed, Remain);
+    ++SimCycle;
+    --Stalls;
+  }
+  RemBytesScaled = SimUsed;
+  RemInstrs = circularDistance(SimHead, SimTail, IssueHistory.size());
+}
+
+void CacheCapacityHazardRecognizer::AdvanceCycle() {
+  // Each cycle drains exactly ScaledDrainPerCycle scaled-units.
+  // Unused drain capacity does not carry over to future cycles.
+  unsigned Remain =
+      IssueTail != IssueHead ? IssueHistory[IssueTail].ScaledBytes : 0;
+  drainOneCycle(ScaledDrainPerCycle, CurrentCycle, Latency, IssueTail,
+                IssueHead, IssueHistory, ScaledUsedBytes, Remain);
+  // Persist any partial drain on the entry we stopped at.
+  if (IssueTail != IssueHead)
+    IssueHistory[IssueTail].ScaledBytes = Remain;
+  ++CurrentCycle;
+}
+
+void CacheCapacityHazardRecognizer::RecedeCycle() {
+  llvm_unreachable("Bottom-Up scheduling not implemented");
+}
+
+} // namespace AMDGPU
+} // namespace llvm

--- a/llvm/lib/Target/AMDGPU/AMDGPUCacheCapacityHazardRecognizer.h
+++ b/llvm/lib/Target/AMDGPU/AMDGPUCacheCapacityHazardRecognizer.h
@@ -1,0 +1,108 @@
+//===-- AMDGPUCacheCapacityHazardRecognizer.h --------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines a hazard recognizer for modeling L1 data cache capacity
+// pressure during instruction scheduling on AMDGPU processors.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIB_TARGET_AMDGPU_AMDGPUCACHECAPACITYHAZARDRECOGNIZER_H
+#define LLVM_LIB_TARGET_AMDGPU_AMDGPUCACHECAPACITYHAZARDRECOGNIZER_H
+
+#include "llvm/CodeGen/ScheduleHazardRecognizer.h"
+#include "llvm/TargetParser/TargetParser.h"
+
+#include <utility>
+#include <vector>
+
+namespace llvm {
+namespace AMDGPU {
+
+/// Per-thread effective L1 drain rate as a fraction of bytes per cycle.
+/// Named fields prevent dividend/divisor argument swaps at call sites.
+struct BytesPerCycle {
+  unsigned Dividend;
+  unsigned Divisor;
+};
+
+class CacheCapacityHazardRecognizer : public ScheduleHazardRecognizer {
+  AMDGPU::IsaVersion IsaVer;
+  /// All byte quantities below are in "scaled" units (real bytes *
+  /// BytesScaleFactor) so that the per-cycle drain rate is an integer.
+  unsigned ScaledCapacityBytes;
+  unsigned ScaledUsedBytes = 0;
+  unsigned ScaledDrainPerCycle;
+  unsigned BytesScaleFactor;
+  unsigned Latency;
+  unsigned CurrentCycle = 0;
+  struct IssueEntry {
+    unsigned ScaledBytes;
+    unsigned Cycle;
+  };
+
+  std::vector<IssueEntry> IssueHistory;
+  /// Valid entries: [IssueTail, IssueHead), with wrap-around.
+  unsigned IssueHead = 0;
+  unsigned IssueTail = 0;
+
+  /// Number of in-flight entries between Tail and Head in a circular buffer
+  /// of capacity BufferSize.
+  static unsigned circularDistance(unsigned Head, unsigned Tail,
+                                   unsigned BufferSize) {
+    return Head >= Tail ? Head - Tail : Head + BufferSize - Tail;
+  }
+
+  unsigned historySize() const {
+    return circularDistance(IssueHead, IssueTail, IssueHistory.size());
+  }
+
+  /// Drain up to ScaledDrainPerCycle units from the head of the FIFO at
+  /// CurrCycle, advancing Tail and updating UsedBytes / Remain in place. On
+  /// exit, Remain holds the bytes left in the tail entry the loop stopped at
+  /// (or 0 if the FIFO drained empty). The caller must write Remain back to
+  /// History[Tail].ScaledBytes when it owns the storage and wants the partial
+  /// drain to persist.
+  static void drainOneCycle(unsigned ScaledDrainPerCycle, unsigned CurrCycle,
+                            unsigned Latency, unsigned &Tail, unsigned Head,
+                            ArrayRef<IssueEntry> History, unsigned &UsedBytes,
+                            unsigned &Remain);
+
+  void simulateAdvanceCycles(int Stalls, unsigned &RemBytesScaled,
+                             unsigned &RemInstrs) const;
+
+  bool canIssueBytes(unsigned Bytes, int Stalls) const;
+
+  bool canWaitLessThanInstr(unsigned InstrCount, int Stalls) const;
+
+  void issueBytes(unsigned Bytes);
+
+  void waitLessThanInstr(unsigned InstrCount);
+
+  HazardType getHazardType(MachineInstr *MI, int Stalls);
+
+public:
+  CacheCapacityHazardRecognizer(unsigned CapacityBytes, BytesPerCycle DrainRate,
+                                unsigned Latency, AMDGPU::IsaVersion IsaVer);
+
+  void Reset() override;
+
+  void EmitInstruction(SUnit *) override;
+
+  void EmitInstruction(MachineInstr *) override;
+
+  HazardType getHazardType(SUnit *SU, int Stalls) override;
+
+  void AdvanceCycle() override;
+
+  void RecedeCycle() override;
+};
+
+} // namespace AMDGPU
+} // namespace llvm
+
+#endif // LLVM_LIB_TARGET_AMDGPU_AMDGPUCACHECAPACITYHAZARDRECOGNIZER_H

--- a/llvm/lib/Target/AMDGPU/AMDGPUResourceDistanceMap.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUResourceDistanceMap.cpp
@@ -1,0 +1,278 @@
+//===-- AMDGPUResourceDistanceMap.cpp -------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "AMDGPUResourceDistanceMap.h"
+
+#include "llvm/ADT/GraphTraits.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/CodeGen/ScheduleDAGInstrs.h"
+
+#include <deque>
+#include <limits>
+
+namespace llvm {
+namespace AMDGPU {
+// TODO: Support BottomUp
+class ResourceDistanceMapBuilder {
+  DenseMap<SUnit *, unsigned> SuccsLeft;
+  ResourceDistanceMaps::DistMapTy DistMap;
+  ResourceDistanceMaps::RootInfosTy RootInfos;
+
+  ScheduleDAGInstrs *DAG;
+  unsigned ResourceID;
+
+  bool isRoot(const SUnit *SU) const { return RootInfos.contains(SU); }
+
+  static bool shouldPruneEdge(const SDep &Edge) {
+    return Edge.isArtificial() || Edge.isWeak();
+  }
+
+  void getReachableNodes() {
+    auto *SchedModel = DAG->getSchedModel();
+    SmallVector<SUnit *> WorkList;
+    for (auto *SU : nodes(static_cast<ScheduleDAG *>(DAG)))
+      if (auto *SC = DAG->getSchedClass(SU))
+        for (auto &ProcRes : make_range(SchedModel->getWriteProcResBegin(SC),
+                                        SchedModel->getWriteProcResEnd(SC)))
+          if (ProcRes.ProcResourceIdx == ResourceID) {
+            RootInfos.try_emplace(SU, ResourceDistanceMaps::ResourceRootInfo{});
+            WorkList.push_back(SU);
+            break;
+          }
+    while (!WorkList.empty()) {
+      auto *SU = WorkList.pop_back_val();
+      for (auto &Pred : SU->Preds) {
+        if (shouldPruneEdge(Pred)) {
+          continue;
+        }
+        auto *PredSU = Pred.getSUnit();
+        auto [Iter, Inserted] = SuccsLeft.try_emplace(PredSU, 0);
+        if (Inserted && !isRoot(PredSU))
+          WorkList.push_back(PredSU);
+        Iter->second += 1;
+      }
+    }
+  }
+
+  void buildDistanceMap() {
+    std::deque<SUnit *> WorkList;
+    for (auto &[Root, _] : RootInfos) {
+      WorkList.push_back(Root);
+    }
+    while (!WorkList.empty()) {
+      auto *SU = WorkList.front();
+      WorkList.pop_front();
+      for (auto &Pred : SU->Preds) {
+        if (shouldPruneEdge(Pred)) {
+          continue;
+        }
+        auto *PredSU = Pred.getSUnit();
+        if (--SuccsLeft[PredSU] == 0) {
+          buildDistanceMapForNode(PredSU);
+          WorkList.push_back(PredSU);
+        }
+      }
+    }
+  }
+
+  void buildDistanceMapForNode(SUnit *SU) {
+    auto &SUDists = DistMap[SU];
+    for (auto &Succ : SU->Succs) {
+      if (shouldPruneEdge(Succ)) {
+        continue;
+      }
+      auto *SuccSU = Succ.getSUnit();
+      if (isRoot(SuccSU)) {
+        // Don't populate second-order roots.
+        auto &CurrDist = SUDists[SuccSU];
+        CurrDist = std::max(Succ.getLatency(), CurrDist);
+      } else {
+        // Don't trigger a re-hash.
+        if (auto SuccDists = DistMap.find(SuccSU); SuccDists != DistMap.end())
+          for (auto [SuccRoot, RootDist] : SuccDists->second) {
+            auto &CurrDist = SUDists[SuccRoot];
+            CurrDist = std::max(Succ.getLatency() + RootDist, CurrDist);
+          }
+      }
+    }
+  }
+
+  void initializeRoots() {
+    for (auto &[RootSU, _] : RootInfos) {
+      auto Iter = DistMap.find(RootSU);
+      if (Iter == DistMap.end())
+        continue;
+      for (auto [SuccRoot, _] : Iter->second)
+        // Won't trigger a re-hash
+        ++RootInfos[SuccRoot].PredRootsLeft;
+    }
+  }
+
+public:
+  ResourceDistanceMapBuilder(ScheduleDAGInstrs *DAG, unsigned ResourceID)
+      : DAG(DAG), ResourceID(ResourceID) {}
+
+  ResourceDistanceMaps::ResourceInfo build() {
+    getReachableNodes();
+    buildDistanceMap();
+    initializeRoots();
+    ResourceDistanceMaps::ResourceInfo Res(DAG);
+    Res.init(std::move(DistMap), std::move(RootInfos));
+    return Res;
+  }
+};
+ResourceDistanceMaps::ResourceInfo
+ResourceDistanceMaps::build(ScheduleDAGInstrs *DAG, unsigned ResourceID) {
+  return ResourceDistanceMapBuilder(DAG, ResourceID).build();
+}
+
+void ResourceDistanceMaps::ResourceInfo::init(DistMapTy &&DistMap_,
+                                              RootInfosTy &&RootInfos_) {
+  DistMap = std::move(DistMap_);
+  RootInfos = std::move(RootInfos_);
+  for (const auto &KV : DistMap) {
+    if (isRoot(KV.first)) {
+      continue;
+    }
+    for (const auto &KV1 : KV.second) {
+      RootInfos[KV1.first].NonRootPredLatency.push(KV1.second);
+    }
+  }
+  for (auto &KV : RootInfos) {
+    if (KV.second.PredRootsLeft == 0) {
+      CurrentRoots.insert(&KV);
+    }
+  }
+  sortRoots();
+}
+
+unsigned
+ResourceDistanceMaps::ResourceInfo::getOrderForRoot(SUnit *Root) const {
+  auto Iter = RootInfos.find(Root);
+  assert(Iter != RootInfos.end());
+  return Iter->second.Order;
+}
+
+void ResourceDistanceMaps::ResourceInfo::sortRoots() {
+  int Order = 0;
+  bool Changed = false;
+  for (auto Root : CurrentRoots) {
+    if (Root->second.Order != Order) {
+      Changed = true;
+    }
+    Root->second.Order = Order++;
+  }
+  if (Changed) {
+    SURankCache.clear();
+  }
+}
+
+void ResourceDistanceMaps::ResourceInfo::schedNode(SUnit *SU,
+                                                   unsigned CurrCycle) {
+  // CurrCycle is part of the public schedNode contract for future use; no
+  // current ResourceInfo bookkeeping depends on it.
+  (void)CurrCycle;
+  bool IsRoot = isRoot(SU);
+  if (IsRoot) {
+    for (auto Iter = CurrentRoots.begin(), End = CurrentRoots.end();
+         Iter != End; ++Iter) {
+      if ((*Iter)->first == SU) {
+        (*Iter)->second.Order = std::numeric_limits<int>::max() - 1;
+        CurrentRoots.erase(Iter);
+        break;
+      }
+    }
+  }
+  auto Iter = DistMap.find(SU);
+  if (Iter == DistMap.end()) {
+    if (IsRoot)
+      sortRoots();
+    return;
+  }
+  if (IsRoot) {
+    for (auto [RootSU, Dist] : Iter->second) {
+      auto &RootInfo = RootInfos[RootSU];
+      --RootInfo.PredRootsLeft;
+      if (RootInfo.PredRootsLeft == 0) {
+        CurrentRoots.insert(&*RootInfos.find(RootSU));
+      }
+    }
+  } else {
+    for (auto [RootSU, Dist] : Iter->second) {
+      auto RootIter = RootInfos.find(RootSU);
+      auto &RootInfo = RootIter->second;
+      // Erase from set before mutating sort key, then re-insert to avoid UB.
+      auto SetIter = CurrentRoots.find(&*RootIter);
+      bool WasInSet = SetIter != CurrentRoots.end();
+      if (WasInSet)
+        CurrentRoots.erase(SetIter);
+      RootInfo.NonRootPredLatency.pop();
+      if (WasInSet)
+        CurrentRoots.insert(&*RootIter);
+    }
+  }
+  sortRoots();
+}
+
+ResourceDistanceMaps::SUDistRank
+ResourceDistanceMaps::ResourceInfo::getSURank(SUnit *SU) {
+  auto Iter = SURankCache.find(SU);
+  if (Iter != SURankCache.end()) {
+    return Iter->second;
+  }
+  auto Res = getSURankImpl(SU);
+  SURankCache.try_emplace(SU, Res);
+  return Res;
+}
+
+ResourceDistanceMaps::SUDistRank
+ResourceDistanceMaps::ResourceInfo::getSURankImpl(SUnit *SU) {
+  // Prefer roots.
+  if (isRoot(SU)) {
+    return {-1};
+  }
+
+  SUDistRank Res{std::numeric_limits<int>::max()};
+  // Prefer nodes leading to roots.
+  auto Iter = DistMap.find(SU);
+  if (Iter == DistMap.end()) {
+    return Res;
+  }
+
+  // Prefer nodes leading to closer roots.
+  for (auto [Root, Dist] : Iter->second) {
+    auto &RootInfo = RootInfos[Root];
+    if (RootInfo.PredRootsLeft == 0) {
+      SUDistRank NewRes{RootInfo.Order, Dist};
+      if (NewRes < Res)
+        Res = NewRes;
+    }
+  }
+  return Res;
+}
+
+ResourceDistanceMaps::ResourceInfo &
+ResourceDistanceMaps::ensureResDistMap(unsigned ResourceID) const {
+  auto Iter = Maps.find(ResourceID);
+  if (Iter != Maps.end())
+    return Iter->second;
+  return Maps.try_emplace(ResourceID, build(DAG, ResourceID)).first->second;
+}
+
+ResourceDistanceMaps::SUDistRank
+ResourceDistanceMaps::getSUnitRankForRes(SUnit *SU, unsigned ResourceID) const {
+  return ensureResDistMap(ResourceID).getSURank(SU);
+}
+
+void ResourceDistanceMaps::schedNode(SUnit *SU, unsigned CurrCycle) {
+  for (auto &[_, ResInfo] : Maps)
+    ResInfo.schedNode(SU, CurrCycle);
+}
+
+} // namespace AMDGPU
+} // namespace llvm

--- a/llvm/lib/Target/AMDGPU/AMDGPUResourceDistanceMap.h
+++ b/llvm/lib/Target/AMDGPU/AMDGPUResourceDistanceMap.h
@@ -1,0 +1,125 @@
+//===-- AMDGPUResourceDistanceMap.h - SU-to-resource-root distances --*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+/// \file
+/// Per-resource DAG analysis: for each processor resource, compute the
+/// distance from each SUnit to the nearest "root" SUnit that consumes that
+/// resource. Used by GCNPreRA/PostRACriticalResource to bias scheduling
+/// toward instructions closer to a critical-resource consumer.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIB_TARGET_AMDGPU_AMDGPURESOURCEDISTANCEMAP_H
+#define LLVM_LIB_TARGET_AMDGPU_AMDGPURESOURCEDISTANCEMAP_H
+
+#include "llvm/ADT/DenseMap.h"
+
+#include <functional>
+#include <limits>
+#include <queue>
+#include <set>
+
+namespace llvm {
+
+class ScheduleDAGInstrs;
+
+namespace AMDGPU {
+
+class ResourceDistanceMaps {
+public:
+  struct SUDistRank {
+    int OrderOfRoot;
+    unsigned DistToRoot;
+    SUDistRank(int OrderOfRoot,
+               unsigned DistToRoot = std::numeric_limits<unsigned>::max())
+        : OrderOfRoot(OrderOfRoot), DistToRoot(DistToRoot) {}
+    bool operator<(const SUDistRank &Other) const {
+      if (OrderOfRoot != Other.OrderOfRoot) {
+        return OrderOfRoot < Other.OrderOfRoot;
+      }
+      return DistToRoot > Other.DistToRoot;
+    }
+    bool operator>(const SUDistRank &Other) const { return Other < *this; }
+  };
+
+private:
+  using DistMapTy = DenseMap<SUnit *, DenseMap<SUnit *, unsigned>>;
+  struct ResourceRootInfo {
+    /// Number of root SU that is predecessor of this root.
+    unsigned PredRootsLeft = 0;
+
+    /// Sorted set of preds latency to this root.
+    std::priority_queue<unsigned> NonRootPredLatency;
+
+    /// Order relative to other roots, lower is more prioritized.
+    int Order = std::numeric_limits<int>::max();
+
+    unsigned getMaxLatency() const {
+      if (NonRootPredLatency.empty()) {
+        return 0;
+      }
+      return NonRootPredLatency.top();
+    }
+  };
+  using RootInfosTy = DenseMap<SUnit *, ResourceRootInfo>;
+  using RootInfosKV = RootInfosTy::value_type;
+  struct RootInfoCompare {
+    bool operator()(const RootInfosKV *LHS, const RootInfosKV *RHS) const {
+      auto LHSLatency = LHS->second.getMaxLatency();
+      auto RHSLatency = RHS->second.getMaxLatency();
+      if (LHSLatency != RHSLatency) {
+        return LHSLatency < RHSLatency;
+      }
+      return LHS->first->NodeNum < RHS->first->NodeNum;
+    }
+  };
+
+  struct ResourceInfo {
+    ScheduleDAGInstrs *DAG;
+    DistMapTy DistMap;
+    RootInfosTy RootInfos;
+    std::set<RootInfosKV *, RootInfoCompare> CurrentRoots;
+    DenseMap<SUnit *, SUDistRank> SURankCache;
+
+    unsigned getOrderForRoot(SUnit *Root) const;
+    void sortRoots();
+    void schedNode(SUnit *SU, unsigned CurrCycle);
+    SUDistRank getSURank(SUnit *SU);
+    SUDistRank getSURankImpl(SUnit *SU);
+    bool isRoot(SUnit *SU) const { return RootInfos.contains(SU); }
+
+    ResourceInfo(ScheduleDAGInstrs *DAG) : DAG(DAG) {}
+    void init(DistMapTy &&DistMap_, RootInfosTy &&RootInfos_);
+  };
+
+  mutable DenseMap<unsigned, ResourceInfo> Maps;
+  friend class ResourceDistanceMapBuilder;
+  static ResourceInfo build(ScheduleDAGInstrs *DAG, unsigned ResourceID);
+
+  ResourceInfo &ensureResDistMap(unsigned ResourceID) const;
+
+  ScheduleDAGInstrs *DAG = nullptr;
+
+public:
+  ResourceDistanceMaps() {}
+  void initialize(ScheduleDAGInstrs *DAG) {
+    this->DAG = DAG;
+    Maps.clear();
+  }
+  SUDistRank getSUnitRankForRes(SUnit *SU, unsigned ResourceID) const;
+  void schedNode(SUnit *SU, unsigned CurrCycle);
+  bool isRoot(SUnit *SU) const {
+    return llvm::any_of(Maps,
+                        [SU](const auto &KV) { return KV.second.isRoot(SU); });
+  }
+};
+
+} // namespace AMDGPU
+} // namespace llvm
+
+#endif // LLVM_LIB_TARGET_AMDGPU_AMDGPURESOURCEDISTANCEMAP_H

--- a/llvm/lib/Target/AMDGPU/AMDGPUTargetMachine.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUTargetMachine.cpp
@@ -608,11 +608,23 @@ diagnoseUnsupportedCoExecSchedulerSelection(const Function &F,
       DiagnosticLocation(), DS_Warning));
 }
 
-static bool useNoopPostScheduler(const Function &F) {
+static cl::opt<std::string> AMDGPUPostSchedStrategy(
+    "amdgpu-post-sched-strategy",
+    cl::desc("Select custom AMDGPU post scheduling strategy."), cl::Hidden,
+    cl::init(""));
+
+// Post-RA scheduler selection. Mirrors getSchedStrategy: function attribute
+// takes priority over the global -amdgpu-post-sched-strategy cl::opt.
+StringRef llvm::AMDGPU::getPostSchedStrategy(const Function &F) {
   Attribute PostSchedStrategyAttr =
       F.getFnAttribute("amdgpu-post-sched-strategy");
-  return PostSchedStrategyAttr.isValid() &&
-         PostSchedStrategyAttr.getValueAsString() == "nop";
+  if (PostSchedStrategyAttr.isValid())
+    return PostSchedStrategyAttr.getValueAsString();
+
+  if (!AMDGPUPostSchedStrategy.empty())
+    return AMDGPUPostSchedStrategy;
+
+  return "";
 }
 
 static cl::opt<bool> EnableRewritePartialRegUses(
@@ -746,11 +758,10 @@ static ScheduleDAGInstrs *createSIMachineScheduler(MachineSchedContext *C) {
   return new SIScheduleDAGMI(C);
 }
 
-static ScheduleDAGInstrs *
-createGCNMaxOccupancyMachineScheduler(MachineSchedContext *C) {
+static ScheduleDAGInstrs *createGCNMaxOccupancyMachineSchedulerImpl(
+    MachineSchedContext *C, std::unique_ptr<GCNSchedStrategy> Scheduler) {
   const GCNSubtarget &ST = C->MF->getSubtarget<GCNSubtarget>();
-  ScheduleDAGMILive *DAG =
-    new GCNScheduleDAGMILive(C, std::make_unique<GCNMaxOccupancySchedStrategy>(C));
+  ScheduleDAGMILive *DAG = new GCNScheduleDAGMILive(C, std::move(Scheduler));
   DAG->addMutation(createLoadClusterDAGMutation(DAG->TII, DAG->TRI));
   if (ST.shouldClusterStores())
     DAG->addMutation(createStoreClusterDAGMutation(DAG->TII, DAG->TRI));
@@ -760,6 +771,18 @@ createGCNMaxOccupancyMachineScheduler(MachineSchedContext *C) {
   DAG->addMutation(createAMDGPUBarrierLatencyDAGMutation(C->MF));
   DAG->addMutation(createAMDGPUHazardLatencyDAGMutation(C->MF));
   return DAG;
+}
+
+static ScheduleDAGInstrs *
+createGCNMaxOccupancyMachineScheduler(MachineSchedContext *C) {
+  return createGCNMaxOccupancyMachineSchedulerImpl(
+      C, std::make_unique<GCNMaxOccupancySchedStrategy>(C));
+}
+
+static ScheduleDAGInstrs *
+createPreRACriticalResourceMachineScheduler(MachineSchedContext *C) {
+  return createGCNMaxOccupancyMachineSchedulerImpl(
+      C, std::make_unique<GCNPreRACriticalResource>(C));
 }
 
 static ScheduleDAGInstrs *
@@ -846,6 +869,10 @@ static MachineSchedRegistry GCNILPSchedRegistry(
     "gcn-iterative-ilp",
     "Run GCN iterative scheduler for ILP scheduling (experimental)",
     createIterativeILPMachineScheduler);
+
+static MachineSchedRegistry GCNCriticalResourceSchedRegistry(
+    "gcn-resource", "Run GCN scheduler to minimize resource bubbles",
+    createPreRACriticalResourceMachineScheduler);
 
 LLVM_READNONE
 static StringRef getGPUOrDefault(const Triple &TT, StringRef GPU) {
@@ -1308,25 +1335,24 @@ GCNTargetMachine::createMachineScheduler(MachineSchedContext *C) const {
     diagnoseUnsupportedCoExecSchedulerSelection(C->MF->getFunction(), ST);
     return createGCNCoExecMachineScheduler(C);
   }
+  if (SchedStrategy == "resource")
+    return createPreRACriticalResourceMachineScheduler(C);
 
   return createGCNMaxOccupancyMachineScheduler(C);
 }
 
-ScheduleDAGInstrs *
-GCNTargetMachine::createPostMachineScheduler(MachineSchedContext *C) const {
-  if (useNoopPostScheduler(C->MF->getFunction()))
-    return createGCNNoopPostMachineScheduler(C);
-
-  ScheduleDAGMI *DAG =
-      new GCNPostScheduleDAGMILive(C, std::make_unique<PostGenericScheduler>(C),
-                                   /*RemoveKillFlags=*/true);
+static ScheduleDAGInstrs *
+createPostMachineSchedulerImpl(MachineSchedContext *C,
+                               std::unique_ptr<PostGenericScheduler> Scheduler,
+                               CodeGenOptLevel OptLevel) {
+  ScheduleDAGMI *DAG = new GCNPostScheduleDAGMILive(C, std::move(Scheduler),
+                                                    /*RemoveKillFlags=*/true);
   const GCNSubtarget &ST = C->MF->getSubtarget<GCNSubtarget>();
   DAG->addMutation(createLoadClusterDAGMutation(DAG->TII, DAG->TRI));
   if (ST.shouldClusterStores())
     DAG->addMutation(createStoreClusterDAGMutation(DAG->TII, DAG->TRI));
   DAG->addMutation(createIGroupLPDAGMutation(AMDGPU::SchedulingPhase::PostRA));
-  if ((EnableVOPD.getNumOccurrences() ||
-       getOptLevel() >= CodeGenOptLevel::Less) &&
+  if ((EnableVOPD.getNumOccurrences() || OptLevel >= CodeGenOptLevel::Less) &&
       EnableVOPD)
     DAG->addMutation(createVOPDPairingMutation());
   DAG->addMutation(createAMDGPUExportClusteringDAGMutation());
@@ -1334,6 +1360,34 @@ GCNTargetMachine::createPostMachineScheduler(MachineSchedContext *C) const {
   DAG->addMutation(createAMDGPUHazardLatencyDAGMutation(C->MF));
   return DAG;
 }
+
+static ScheduleDAGInstrs *
+createPostMachineSchedulerDefault(MachineSchedContext *C,
+                                  CodeGenOptLevel OptLevel) {
+  return createPostMachineSchedulerImpl(
+      C, std::make_unique<PostGenericScheduler>(C), OptLevel);
+}
+
+static ScheduleDAGInstrs *
+createPostMachineSchedulerResource(MachineSchedContext *C,
+                                   CodeGenOptLevel OptLevel) {
+  return createPostMachineSchedulerImpl(
+      C, std::make_unique<GCNPostRACriticalResource>(C), OptLevel);
+}
+
+ScheduleDAGInstrs *
+GCNTargetMachine::createPostMachineScheduler(MachineSchedContext *C) const {
+  StringRef SchedStrategy = AMDGPU::getPostSchedStrategy(C->MF->getFunction());
+
+  if (SchedStrategy == "nop")
+    return createGCNNoopPostMachineScheduler(C);
+
+  if (SchedStrategy == "resource")
+    return createPostMachineSchedulerResource(C, getOptLevel());
+
+  return createPostMachineSchedulerDefault(C, getOptLevel());
+}
+
 //===----------------------------------------------------------------------===//
 // AMDGPU Legacy Pass Setup
 //===----------------------------------------------------------------------===//

--- a/llvm/lib/Target/AMDGPU/AMDGPUTargetMachine.h
+++ b/llvm/lib/Target/AMDGPU/AMDGPUTargetMachine.h
@@ -29,6 +29,7 @@ namespace llvm {
 
 namespace AMDGPU {
 StringRef getSchedStrategy(const Function &F);
+StringRef getPostSchedStrategy(const Function &F);
 }
 
 class AMDGPUTargetMachine : public CodeGenTargetMachineImpl {

--- a/llvm/lib/Target/AMDGPU/CMakeLists.txt
+++ b/llvm/lib/Target/AMDGPU/CMakeLists.txt
@@ -109,6 +109,7 @@ add_llvm_target(AMDGPUCodeGen
   AMDGPURegisterBankInfo.cpp
   AMDGPURemoveIncompatibleFunctions.cpp
   AMDGPUReserveWWMRegs.cpp
+  AMDGPUResourceDistanceMap.cpp
   AMDGPUResourceUsageAnalysis.cpp
   AMDGPURewriteAGPRCopyMFMA.cpp
   AMDGPURewriteOutArguments.cpp

--- a/llvm/lib/Target/AMDGPU/CMakeLists.txt
+++ b/llvm/lib/Target/AMDGPU/CMakeLists.txt
@@ -50,6 +50,7 @@ add_llvm_target(AMDGPUCodeGen
   AMDGPUAtomicOptimizer.cpp
   AMDGPUAttributor.cpp
   AMDGPUBarrierLatency.cpp
+  AMDGPUCacheCapacityHazardRecognizer.cpp
   AMDGPUCallLowering.cpp
   AMDGPUCodeGenPrepare.cpp
   AMDGPUCombinerHelper.cpp

--- a/llvm/lib/Target/AMDGPU/GCNSchedStrategy.cpp
+++ b/llvm/lib/Target/AMDGPU/GCNSchedStrategy.cpp
@@ -660,6 +660,34 @@ SUnit *GCNSchedStrategy::pickNode(bool &IsTopNode) {
   return SU;
 }
 
+static unsigned
+countCriticalResourceInRemainder(const SchedRemainder &Rem,
+                                 const TargetSchedModel *SchedModel) {
+  if (!SchedModel || !SchedModel->hasInstrSchedModel())
+    return 0;
+  unsigned CriticalResIdx = 0;
+  unsigned CriticalResCount = 0;
+  for (unsigned I = 1, E = SchedModel->getNumProcResourceKinds(); I < E; ++I) {
+    if (SchedModel->getResourceBufferSize(I) != 0)
+      continue;
+    // RemainingCounts is pre-scaled by ResourceFactor (set up by
+    // SchedRemainder::init) so it's in the same units as LatencyPath *
+    // LatencyFactor used below.
+    unsigned ResCount = Rem.RemainingCounts[I];
+    if (ResCount > CriticalResCount) {
+      CriticalResIdx = I;
+      CriticalResCount = ResCount;
+    }
+  }
+  if (CriticalResIdx) {
+    unsigned LatencyPath =
+        Rem.IsAcyclicLatencyLimited ? Rem.CriticalPath : Rem.CyclicCritPath;
+    if (LatencyPath * SchedModel->getLatencyFactor() < CriticalResCount)
+      return CriticalResIdx;
+  }
+  return 0;
+}
+
 void GCNSchedStrategy::schedNode(SUnit *SU, bool IsTopNode) {
   if (useGCNTrackers()) {
     MachineInstr *MI = SU->getInstr();
@@ -747,6 +775,166 @@ GCNMaxOccupancySchedStrategy::GCNMaxOccupancySchedStrategy(
   SchedStages.push_back(GCNSchedStageID::PreRARematerialize);
   if (IsLegacyScheduler)
     GCNTrackersOverride = std::nullopt;
+}
+
+/// Like SchedBoundary::getLatencyStallCycles, but also considers reserved
+/// resources (BufferSize == 0) in addition to unbuffered ones.
+static unsigned getLatencyStallCycles(const SchedBoundary &Zone, SUnit *SU) {
+  if (!SU->isUnbuffered && !SU->hasReservedResource)
+    return 0;
+  unsigned ReadyCycle = Zone.isTop() ? SU->TopReadyCycle : SU->BotReadyCycle;
+  if (ReadyCycle > Zone.getCurrCycle())
+    return ReadyCycle - Zone.getCurrCycle();
+  return 0;
+}
+
+static unsigned getResourceUseCount(unsigned ResId, const MCSchedClassDesc *SC,
+                                    const TargetSchedModel *SchedModel) {
+  if (!SC)
+    return 0;
+  unsigned Count = 0;
+  for (const MCWriteProcResEntry &PRE :
+       make_range(SchedModel->getWriteProcResBegin(SC),
+                  SchedModel->getWriteProcResEnd(SC))) {
+    if (PRE.ProcResourceIdx == ResId)
+      Count += PRE.ReleaseAtCycle - PRE.AcquireAtCycle;
+  }
+  return Count;
+}
+
+void GCNPreRACriticalResource::initialize(ScheduleDAGMI *DAG) {
+  GCNMaxOccupancySchedStrategy::initialize(DAG);
+  // TrackRemCriticalRes is set per-region by GCNSchedStage::initGCNRegion
+  // before this initialize() runs.
+  updateRemainderCriticalRes();
+}
+
+void GCNPreRACriticalResource::updateRemainderCriticalRes() {
+  RemCriticalRes = TrackRemCriticalRes
+                       ? countCriticalResourceInRemainder(Rem, SchedModel)
+                       : 0;
+}
+
+void GCNPreRACriticalResource::schedNode(SUnit *SU, bool IsTopNode) {
+  GCNSchedStrategy::schedNode(SU, IsTopNode);
+  updateRemainderCriticalRes();
+}
+
+bool GCNPreRACriticalResource::tryCandidate(SchedCandidate &Cand,
+                                            SchedCandidate &TryCand,
+                                            SchedBoundary *Zone) const {
+  // Initialize the candidate if needed.
+  if (!Cand.isValid()) {
+    TryCand.Reason = FirstValid;
+    return true;
+  }
+
+  // Bias PhysReg Defs and copies to their uses and defined respectively.
+  if (tryGreater(biasPhysReg(TryCand.SU, TryCand.AtTop),
+                 biasPhysReg(Cand.SU, Cand.AtTop), TryCand, Cand, PhysReg))
+    return TryCand.Reason != NoCand;
+
+  // Avoid exceeding the target's limit.
+  if (DAG->isTrackingPressure() &&
+      tryPressure(TryCand.RPDelta.Excess, Cand.RPDelta.Excess, TryCand, Cand,
+                  RegExcess, TRI, DAG->MF))
+    return TryCand.Reason != NoCand;
+
+  // Avoid increasing the max critical pressure in the scheduled region.
+  if (DAG->isTrackingPressure() &&
+      tryPressure(TryCand.RPDelta.CriticalMax, Cand.RPDelta.CriticalMax,
+                  TryCand, Cand, RegCritical, TRI, DAG->MF))
+    return TryCand.Reason != NoCand;
+
+  // We only compare a subset of features when comparing nodes between
+  // Top and Bottom boundary. Some properties are simply incomparable, in many
+  // other instances we should only override the other boundary if something
+  // is a clear good pick on one boundary. Skip heuristics that are more
+  // "tie-breaking" in nature.
+  bool SameBoundary = Zone != nullptr;
+  if (SameBoundary) {
+    // For loops that are acyclic path limited, aggressively schedule for
+    // latency. Within an single cycle, whenever CurrMOps > 0, allow normal
+    // heuristics to take precedence.
+    if (Rem.IsAcyclicLatencyLimited && !Zone->getCurrMOps() &&
+        tryLatency(TryCand, Cand, *Zone))
+      return TryCand.Reason != NoCand;
+
+    // Prioritize instructions that read unbuffered or reserved resources by
+    // stall cycles.
+    if (tryLess(getLatencyStallCycles(*Zone, TryCand.SU),
+                getLatencyStallCycles(*Zone, Cand.SU), TryCand, Cand, Stall))
+      return TryCand.Reason != NoCand;
+  }
+
+  if (RemCriticalRes) {
+
+    // Prioritize instructions that use critical resource
+    if (tryGreater(getResourceUseCount(RemCriticalRes,
+                                       DAG->getSchedClass(TryCand.SU),
+                                       SchedModel),
+                   getResourceUseCount(RemCriticalRes,
+                                       DAG->getSchedClass(Cand.SU), SchedModel),
+                   TryCand, Cand, ResourceDemand))
+      return TryCand.Reason != NoCand;
+  }
+
+  // Keep clustered nodes together to encourage downstream peephole
+  // optimizations which may reduce resource requirements.
+  //
+  // This is a best effort to set things up for a post-RA pass. Optimizations
+  // like generating loads of multiple registers should ideally be done within
+  // the scheduler pass by combining the loads during DAG postprocessing.
+  unsigned CandZoneCluster = Cand.AtTop ? TopClusterID : BotClusterID;
+  unsigned TryCandZoneCluster = TryCand.AtTop ? TopClusterID : BotClusterID;
+  bool CandIsClusterSucc =
+      isTheSameCluster(CandZoneCluster, Cand.SU->ParentClusterIdx);
+  bool TryCandIsClusterSucc =
+      isTheSameCluster(TryCandZoneCluster, TryCand.SU->ParentClusterIdx);
+
+  if (tryGreater(TryCandIsClusterSucc, CandIsClusterSucc, TryCand, Cand,
+                 Cluster))
+    return TryCand.Reason != NoCand;
+
+  if (SameBoundary) {
+    // Weak edges are for clustering and other constraints.
+    if (tryLess(getWeakLeft(TryCand.SU, TryCand.AtTop),
+                getWeakLeft(Cand.SU, Cand.AtTop), TryCand, Cand, Weak))
+      return TryCand.Reason != NoCand;
+  }
+
+  // Avoid increasing the max pressure of the entire region.
+  if (DAG->isTrackingPressure() &&
+      tryPressure(TryCand.RPDelta.CurrentMax, Cand.RPDelta.CurrentMax, TryCand,
+                  Cand, RegMax, TRI, DAG->MF))
+    return TryCand.Reason != NoCand;
+
+  if (SameBoundary) {
+    // Avoid critical resource consumption and balance the schedule.
+    TryCand.initResourceDelta(DAG, SchedModel);
+    if (tryLess(TryCand.ResDelta.CritResources, Cand.ResDelta.CritResources,
+                TryCand, Cand, ResourceReduce))
+      return TryCand.Reason != NoCand;
+    if (tryGreater(TryCand.ResDelta.DemandedResources,
+                   Cand.ResDelta.DemandedResources, TryCand, Cand,
+                   ResourceDemand))
+      return TryCand.Reason != NoCand;
+
+    // Avoid serializing long latency dependence chains.
+    // For acyclic path limited loops, latency was already checked above.
+    if (!RegionPolicy.DisableLatencyHeuristic && TryCand.Policy.ReduceLatency &&
+        !Rem.IsAcyclicLatencyLimited && tryLatency(TryCand, Cand, *Zone))
+      return TryCand.Reason != NoCand;
+
+    // Fall through to original instruction order.
+    if ((Zone->isTop() && TryCand.SU->NodeNum < Cand.SU->NodeNum) ||
+        (!Zone->isTop() && TryCand.SU->NodeNum > Cand.SU->NodeNum)) {
+      TryCand.Reason = NodeOrder;
+      return true;
+    }
+  }
+
+  return false;
 }
 
 GCNMaxILPSchedStrategy::GCNMaxILPSchedStrategy(const MachineSchedContext *C)
@@ -972,6 +1160,89 @@ bool GCNMaxMemoryClauseSchedStrategy::tryCandidate(SchedCandidate &Cand,
   }
 
   return false;
+}
+
+void GCNPostRACriticalResource::updateRemainderCriticalRes() {
+  RemCriticalRes = TrackRemCriticalRes
+                       ? countCriticalResourceInRemainder(Rem, SchedModel)
+                       : 0;
+}
+
+bool GCNPostRACriticalResource::tryCandidate(SchedCandidate &Cand,
+                                             SchedCandidate &TryCand) {
+  // Initialize the candidate if needed.
+  if (!Cand.isValid()) {
+    TryCand.Reason = FirstValid;
+    return true;
+  }
+
+  // Prioritize instructions that read unbuffered or reserved resources by
+  // stall cycles.
+  if (tryLess(getLatencyStallCycles(Top, TryCand.SU),
+              getLatencyStallCycles(Top, Cand.SU), TryCand, Cand, Stall))
+    return TryCand.Reason != NoCand;
+
+  if (RemCriticalRes) {
+
+    // Prioritize instructions that use critical resource
+    if (tryGreater(getResourceUseCount(RemCriticalRes,
+                                       DAG->getSchedClass(TryCand.SU),
+                                       SchedModel),
+                   getResourceUseCount(RemCriticalRes,
+                                       DAG->getSchedClass(Cand.SU), SchedModel),
+                   TryCand, Cand, ResourceDemand))
+      return TryCand.Reason != NoCand;
+  }
+
+  // Keep clustered nodes together.
+  unsigned CandZoneCluster = Cand.AtTop ? TopClusterID : BotClusterID;
+  unsigned TryCandZoneCluster = TryCand.AtTop ? TopClusterID : BotClusterID;
+  bool CandIsClusterSucc =
+      isTheSameCluster(CandZoneCluster, Cand.SU->ParentClusterIdx);
+  bool TryCandIsClusterSucc =
+      isTheSameCluster(TryCandZoneCluster, TryCand.SU->ParentClusterIdx);
+
+  if (tryGreater(TryCandIsClusterSucc, CandIsClusterSucc, TryCand, Cand,
+                 Cluster))
+    return TryCand.Reason != NoCand;
+  // Avoid critical resource consumption and balance the schedule.
+  if (tryLess(TryCand.ResDelta.CritResources, Cand.ResDelta.CritResources,
+              TryCand, Cand, ResourceReduce))
+    return TryCand.Reason != NoCand;
+  if (tryGreater(TryCand.ResDelta.DemandedResources,
+                 Cand.ResDelta.DemandedResources, TryCand, Cand,
+                 ResourceDemand))
+    return TryCand.Reason != NoCand;
+
+  // We only compare a subset of features when comparing nodes between
+  // Top and Bottom boundary.
+  if (Cand.AtTop == TryCand.AtTop) {
+    // Avoid serializing long latency dependence chains.
+    if (Cand.Policy.ReduceLatency &&
+        tryLatency(TryCand, Cand, Cand.AtTop ? Top : Bot))
+      return TryCand.Reason != NoCand;
+  }
+
+  // Fall through to original instruction order.
+  if (TryCand.SU->NodeNum < Cand.SU->NodeNum) {
+    TryCand.Reason = NodeOrder;
+    return true;
+  }
+
+  return false;
+}
+
+void GCNPostRACriticalResource::initialize(ScheduleDAGMI *Dag) {
+  PostGenericScheduler::initialize(Dag);
+  setTrackRemainderCriticalRes(
+      Context->MF->getSubtarget<GCNSubtarget>(),
+      !static_cast<GCNPostScheduleDAGMILive *>(Dag)->hasIGLPInstrs());
+  updateRemainderCriticalRes();
+}
+
+void GCNPostRACriticalResource::schedNode(SUnit *SU, bool IsTopNode) {
+  PostGenericScheduler::schedNode(SU, IsTopNode);
+  updateRemainderCriticalRes();
 }
 
 GCNScheduleDAGMILive::GCNScheduleDAGMILive(
@@ -1735,6 +2006,8 @@ bool GCNSchedStage::initGCNRegion() {
 
   unsigned NumRegionInstrs = std::distance(DAG.begin(), DAG.end());
   DAG.enterRegion(CurrentMBB, DAG.begin(), DAG.end(), NumRegionInstrs);
+  static_cast<GCNSchedStrategy *>(DAG.SchedImpl.get())
+      ->notifyRegionIGLPInstrs(DAG.hasIGLPInstrs(RegionIdx));
 
   // Skip regions with 1 schedulable instruction.
   if (DAG.begin() == std::prev(DAG.end()))
@@ -3267,7 +3540,7 @@ void GCNScheduleDAGMILive::setTargetOccupancy(unsigned TargetOccupancy) {
     MFI.limitOccupancy(MinOccupancy);
 }
 
-static bool hasIGLPInstrs(ScheduleDAGInstrs *DAG) {
+static bool computeHasIGLPInstrs(ScheduleDAGInstrs *DAG) {
   const SIInstrInfo *SII = static_cast<const SIInstrInfo *>(DAG->TII);
   return any_of(*DAG, [SII](MachineBasicBlock::iterator MI) {
     return SII->isIGLPMutationOnly(MI->getOpcode());
@@ -3280,7 +3553,7 @@ GCNPostScheduleDAGMILive::GCNPostScheduleDAGMILive(
     : ScheduleDAGMI(C, std::move(S), RemoveKillFlags) {}
 
 void GCNPostScheduleDAGMILive::schedule() {
-  HasIGLPInstrs = hasIGLPInstrs(this);
+  HasIGLPInstrs = computeHasIGLPInstrs(this);
   if (HasIGLPInstrs) {
     SavedMutations.clear();
     SavedMutations.swap(Mutations);

--- a/llvm/lib/Target/AMDGPU/GCNSchedStrategy.cpp
+++ b/llvm/lib/Target/AMDGPU/GCNSchedStrategy.cpp
@@ -803,7 +803,8 @@ static unsigned getResourceUseCount(unsigned ResId, const MCSchedClassDesc *SC,
 }
 
 void GCNPreRACriticalResource::initialize(ScheduleDAGMI *DAG) {
-  GCNMaxOccupancySchedStrategy::initialize(DAG);
+  GCNSchedStrategy::initialize(DAG);
+  ResDistMap.initialize(DAG);
   // TrackRemCriticalRes is set per-region by GCNSchedStage::initGCNRegion
   // before this initialize() runs.
   updateRemainderCriticalRes();
@@ -818,6 +819,41 @@ void GCNPreRACriticalResource::updateRemainderCriticalRes() {
 void GCNPreRACriticalResource::schedNode(SUnit *SU, bool IsTopNode) {
   GCNSchedStrategy::schedNode(SU, IsTopNode);
   updateRemainderCriticalRes();
+  ResDistMap.schedNode(SU, Top.getCurrCycle());
+  PendingResInstrs.reset();
+}
+
+SUnit *GCNPreRACriticalResource::pickNode(bool &IsTopNode) {
+  if (RemCriticalRes && !PendingResInstrs) {
+    PendingResInstrs = Top.countReadyNodes(
+        [&](SUnit *SU) { return ResDistMap.isRoot(SU); });
+  }
+  return GCNSchedStrategy::pickNode(IsTopNode);
+}
+
+template <typename T>
+static bool tryLessGeneric(const T &TryVal, const T &CandVal,
+                           GenericSchedulerBase::SchedCandidate &TryCand,
+                           GenericSchedulerBase::SchedCandidate &Cand,
+                           GenericSchedulerBase::CandReason Reason) {
+  if (TryVal < CandVal) {
+    TryCand.Reason = Reason;
+    return true;
+  }
+  if (TryVal > CandVal) {
+    if (Cand.Reason > Reason)
+      Cand.Reason = Reason;
+    return true;
+  }
+  return false;
+}
+
+GCNPreRACriticalResource::GCNPreRACriticalResource(const MachineSchedContext *C)
+    : GCNSchedStrategy(C) {
+  SchedStages.push_back(GCNSchedStageID::OccInitialSchedule);
+  if (!DisableRewriteMFMAFormSchedStage)
+    SchedStages.push_back(GCNSchedStageID::RewriteMFMAForm);
+  SchedStages.push_back(GCNSchedStageID::PreRARematerialize);
 }
 
 bool GCNPreRACriticalResource::tryCandidate(SchedCandidate &Cand,
@@ -853,13 +889,6 @@ bool GCNPreRACriticalResource::tryCandidate(SchedCandidate &Cand,
   // "tie-breaking" in nature.
   bool SameBoundary = Zone != nullptr;
   if (SameBoundary) {
-    // For loops that are acyclic path limited, aggressively schedule for
-    // latency. Within an single cycle, whenever CurrMOps > 0, allow normal
-    // heuristics to take precedence.
-    if (Rem.IsAcyclicLatencyLimited && !Zone->getCurrMOps() &&
-        tryLatency(TryCand, Cand, *Zone))
-      return TryCand.Reason != NoCand;
-
     // Prioritize instructions that read unbuffered or reserved resources by
     // stall cycles.
     if (tryLess(getLatencyStallCycles(*Zone, TryCand.SU),
@@ -868,7 +897,6 @@ bool GCNPreRACriticalResource::tryCandidate(SchedCandidate &Cand,
   }
 
   if (RemCriticalRes) {
-
     // Prioritize instructions that use critical resource
     if (tryGreater(getResourceUseCount(RemCriticalRes,
                                        DAG->getSchedClass(TryCand.SU),
@@ -876,6 +904,34 @@ bool GCNPreRACriticalResource::tryCandidate(SchedCandidate &Cand,
                    getResourceUseCount(RemCriticalRes,
                                        DAG->getSchedClass(Cand.SU), SchedModel),
                    TryCand, Cand, ResourceDemand))
+      return TryCand.Reason != NoCand;
+  }
+
+  if (SameBoundary) {
+    // For loops that are acyclic path limited, aggressively schedule for
+    // latency. Within an single cycle, whenever CurrMOps > 0, allow normal
+    // heuristics to take precedence.
+    if ((!PendingResInstrs || *PendingResInstrs >= 2) &&
+        Rem.IsAcyclicLatencyLimited && !Zone->getCurrMOps() &&
+        tryLatency(TryCand, Cand, *Zone))
+      return TryCand.Reason != NoCand;
+  }
+
+  if (RemCriticalRes) {
+    LLVM_DEBUG({
+      dbgs() << "try ResourceReduce\n";
+      DAG->dumpNode(*TryCand.SU);
+      DAG->dumpNode(*Cand.SU);
+      auto r1 = ResDistMap.getSUnitRankForRes(TryCand.SU, RemCriticalRes);
+      auto r2 = ResDistMap.getSUnitRankForRes(Cand.SU, RemCriticalRes);
+      dbgs() << r1.OrderOfRoot << "@" << r1.DistToRoot << " " << r2.OrderOfRoot
+             << "@" << r2.DistToRoot << "\n";
+    });
+    // Prefer nodes closer to critical resource roots.
+    if (tryLessGeneric(
+            ResDistMap.getSUnitRankForRes(TryCand.SU, RemCriticalRes),
+            ResDistMap.getSUnitRankForRes(Cand.SU, RemCriticalRes), TryCand,
+            Cand, ResourceReduce))
       return TryCand.Reason != NoCand;
   }
 
@@ -1183,7 +1239,6 @@ bool GCNPostRACriticalResource::tryCandidate(SchedCandidate &Cand,
     return TryCand.Reason != NoCand;
 
   if (RemCriticalRes) {
-
     // Prioritize instructions that use critical resource
     if (tryGreater(getResourceUseCount(RemCriticalRes,
                                        DAG->getSchedClass(TryCand.SU),
@@ -1191,6 +1246,13 @@ bool GCNPostRACriticalResource::tryCandidate(SchedCandidate &Cand,
                    getResourceUseCount(RemCriticalRes,
                                        DAG->getSchedClass(Cand.SU), SchedModel),
                    TryCand, Cand, ResourceDemand))
+      return TryCand.Reason != NoCand;
+
+    // Prefer nodes closer to critical resource roots.
+    if (tryLessGeneric(
+            ResDistMap.getSUnitRankForRes(TryCand.SU, RemCriticalRes),
+            ResDistMap.getSUnitRankForRes(Cand.SU, RemCriticalRes), TryCand,
+            Cand, ResourceReduce))
       return TryCand.Reason != NoCand;
   }
 
@@ -1234,6 +1296,7 @@ bool GCNPostRACriticalResource::tryCandidate(SchedCandidate &Cand,
 
 void GCNPostRACriticalResource::initialize(ScheduleDAGMI *Dag) {
   PostGenericScheduler::initialize(Dag);
+  ResDistMap.initialize(DAG);
   setTrackRemainderCriticalRes(
       Context->MF->getSubtarget<GCNSubtarget>(),
       !static_cast<GCNPostScheduleDAGMILive *>(Dag)->hasIGLPInstrs());
@@ -1243,6 +1306,7 @@ void GCNPostRACriticalResource::initialize(ScheduleDAGMI *Dag) {
 void GCNPostRACriticalResource::schedNode(SUnit *SU, bool IsTopNode) {
   PostGenericScheduler::schedNode(SU, IsTopNode);
   updateRemainderCriticalRes();
+  ResDistMap.schedNode(SU, Top.getCurrCycle());
 }
 
 GCNScheduleDAGMILive::GCNScheduleDAGMILive(

--- a/llvm/lib/Target/AMDGPU/GCNSchedStrategy.h
+++ b/llvm/lib/Target/AMDGPU/GCNSchedStrategy.h
@@ -13,7 +13,9 @@
 #ifndef LLVM_LIB_TARGET_AMDGPU_GCNSCHEDSTRATEGY_H
 #define LLVM_LIB_TARGET_AMDGPU_GCNSCHEDSTRATEGY_H
 
+#include "AMDGPUResourceDistanceMap.h"
 #include "GCNRegPressure.h"
+
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/CodeGen/MachineBasicBlock.h"
 #include "llvm/CodeGen/MachineBlockFrequencyInfo.h"
@@ -205,11 +207,14 @@ public:
   GCNMaxMemoryClauseSchedStrategy(const MachineSchedContext *C);
 };
 
-class GCNPreRACriticalResource final : public GCNMaxOccupancySchedStrategy {
-private:
+class GCNPreRACriticalResource final : public GCNSchedStrategy {
+  AMDGPU::ResourceDistanceMaps ResDistMap;
+
   bool TrackRemCriticalRes;
 
   unsigned RemCriticalRes;
+
+  std::optional<unsigned> PendingResInstrs;
 
   bool tryCandidate(SchedCandidate &Cand, SchedCandidate &TryCand,
                     SchedBoundary *Zone) const override;
@@ -220,13 +225,14 @@ private:
 
   void schedNode(SUnit *SU, bool IsTopNode) override;
 
+  SUnit *pickNode(bool &IsTopNode) override;
+
   void setTrackRemainderCriticalRes(const GCNSubtarget &ST, bool B) {
     TrackRemCriticalRes = B && ST.hasGFX940Insts();
   }
 
 public:
-  GCNPreRACriticalResource(const MachineSchedContext *C)
-      : GCNMaxOccupancySchedStrategy(C) {}
+  GCNPreRACriticalResource(const MachineSchedContext *C);
 
   void notifyRegionIGLPInstrs(bool HasIGLPInstrs) override {
     setTrackRemainderCriticalRes(
@@ -235,7 +241,8 @@ public:
 };
 
 class GCNPostRACriticalResource final : public PostGenericScheduler {
-private:
+  AMDGPU::ResourceDistanceMaps ResDistMap;
+
   bool TrackRemCriticalRes;
 
   unsigned RemCriticalRes;

--- a/llvm/lib/Target/AMDGPU/GCNSchedStrategy.h
+++ b/llvm/lib/Target/AMDGPU/GCNSchedStrategy.h
@@ -151,6 +151,12 @@ public:
 
   void setTargetOccupancy(unsigned Occ) { TargetOccupancy = Occ; }
 
+  /// Per-region notification from GCNSchedStage about whether the upcoming
+  /// region contains IGLP scheduling instructions (SCHED_GROUP_BARRIER /
+  /// IGLP_OPT). Strategies that need to disable themselves for IGLP-managed
+  /// regions override this; the default is a no-op.
+  virtual void notifyRegionIGLPInstrs(bool HasIGLPInstrs) {}
+
   GCNSchedStageID getCurrentStage();
 
   // Advances stage. Returns true if there are remaining stages.
@@ -171,7 +177,7 @@ public:
 
 /// The goal of this scheduling strategy is to maximize kernel occupancy (i.e.
 /// maximum number of waves per simd).
-class GCNMaxOccupancySchedStrategy final : public GCNSchedStrategy {
+class GCNMaxOccupancySchedStrategy : public GCNSchedStrategy {
 public:
   GCNMaxOccupancySchedStrategy(const MachineSchedContext *C,
                                bool IsLegacyScheduler = false);
@@ -197,6 +203,58 @@ protected:
 
 public:
   GCNMaxMemoryClauseSchedStrategy(const MachineSchedContext *C);
+};
+
+class GCNPreRACriticalResource final : public GCNMaxOccupancySchedStrategy {
+private:
+  bool TrackRemCriticalRes;
+
+  unsigned RemCriticalRes;
+
+  bool tryCandidate(SchedCandidate &Cand, SchedCandidate &TryCand,
+                    SchedBoundary *Zone) const override;
+
+  void updateRemainderCriticalRes();
+
+  void initialize(ScheduleDAGMI *DAG) override;
+
+  void schedNode(SUnit *SU, bool IsTopNode) override;
+
+  void setTrackRemainderCriticalRes(const GCNSubtarget &ST, bool B) {
+    TrackRemCriticalRes = B && ST.hasGFX940Insts();
+  }
+
+public:
+  GCNPreRACriticalResource(const MachineSchedContext *C)
+      : GCNMaxOccupancySchedStrategy(C) {}
+
+  void notifyRegionIGLPInstrs(bool HasIGLPInstrs) override {
+    setTrackRemainderCriticalRes(
+        Context->MF->getSubtarget<GCNSubtarget>(), !HasIGLPInstrs);
+  }
+};
+
+class GCNPostRACriticalResource final : public PostGenericScheduler {
+private:
+  bool TrackRemCriticalRes;
+
+  unsigned RemCriticalRes;
+
+  bool tryCandidate(SchedCandidate &Cand, SchedCandidate &TryCand) override;
+
+  void updateRemainderCriticalRes();
+
+  void initialize(ScheduleDAGMI *Dag) override;
+
+  void schedNode(SUnit *SU, bool IsTopNode) override;
+
+public:
+  GCNPostRACriticalResource(const MachineSchedContext *C)
+      : PostGenericScheduler(C) {}
+
+  void setTrackRemainderCriticalRes(const GCNSubtarget &ST, bool B) {
+    TrackRemCriticalRes = B && ST.hasGFX940Insts();
+  }
 };
 
 class ScheduleMetrics {
@@ -337,6 +395,10 @@ public:
   void schedule() override;
 
   void finalizeSchedule() override;
+
+  bool hasIGLPInstrs(unsigned RegionIdx) const {
+    return RegionsWithIGLPInstrs[RegionIdx];
+  }
 };
 
 // GCNSchedStrategy applies multiple scheduling stages to a function.
@@ -822,6 +884,8 @@ public:
   GCNPostScheduleDAGMILive(MachineSchedContext *C,
                            std::unique_ptr<MachineSchedStrategy> S,
                            bool RemoveKillFlags);
+
+  bool hasIGLPInstrs() const { return HasIGLPInstrs; }
 };
 
 } // End namespace llvm

--- a/llvm/lib/Target/AMDGPU/SIInstrInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/SIInstrInfo.cpp
@@ -13,6 +13,7 @@
 
 #include "SIInstrInfo.h"
 #include "AMDGPU.h"
+#include "AMDGPUCacheCapacityHazardRecognizer.h"
 #include "AMDGPUInstrInfo.h"
 #include "AMDGPULaneMaskUtils.h"
 #include "GCNHazardRecognizer.h"
@@ -28,6 +29,7 @@
 #include "llvm/CodeGen/MachineDominators.h"
 #include "llvm/CodeGen/MachineFrameInfo.h"
 #include "llvm/CodeGen/MachineScheduler.h"
+#include "llvm/CodeGen/MultiHazardRecognizer.h"
 #include "llvm/CodeGen/RegisterScavenging.h"
 #include "llvm/CodeGen/ScheduleDAG.h"
 #include "llvm/IR/DiagnosticInfo.h"
@@ -62,6 +64,48 @@ static cl::opt<bool> Fix16BitCopies(
   cl::desc("Fix copies between 32 and 16 bit registers by extending to 32 bit"),
   cl::init(true),
   cl::ReallyHidden);
+
+static cl::opt<bool>
+    L1Hazard("amdgpu-l1-hazard", cl::init(false),
+             cl::desc("Enable hazard recognizer for L1 data cache."));
+
+static cl::opt<unsigned>
+    L1Bytes("amdgpu-l1-bytes", cl::init(32),
+            cl::desc("Per thread effective byte size of L1 data cache."));
+namespace {
+
+struct L1SpeedParser : public cl::parser<std::pair<unsigned, unsigned>> {
+  L1SpeedParser(cl::Option &O) : cl::parser<std::pair<unsigned, unsigned>>(O) {}
+
+  bool parse(cl::Option &O, StringRef ArgName, StringRef Arg,
+             std::pair<unsigned, unsigned> &Val) {
+    auto [NumStr, DenStr] = Arg.split('/');
+    unsigned Num;
+    if (NumStr.getAsInteger(0, Num))
+      return O.error("'" + Arg + "' invalid for L1 speed (expected N or N/D)");
+    if (DenStr.empty()) {
+      Val = {Num, 1};
+      return false;
+    }
+    unsigned Den;
+    if (DenStr.getAsInteger(0, Den) || Den == 0)
+      return O.error("'" + Arg +
+                     "' invalid for L1 speed (expected N or N/D with D > 0)");
+    Val = {Num, Den};
+    return false;
+  }
+};
+
+} // end anonymous namespace
+
+static cl::opt<std::pair<unsigned, unsigned>, false, L1SpeedParser>
+    L1Speed("amdgpu-l1-speed", cl::init(std::pair<unsigned, unsigned>{1, 1}),
+            cl::desc("Per thread effective bytes per cycle of L1 data cache "
+                     "(integer N or fraction N/D)."));
+static cl::opt<unsigned>
+    L1Latency("amdgpu-l1-latency", cl::init(0),
+              cl::desc("Minimum cycles before an instruction's L1 data cache "
+                       "space can be freed."));
 
 SIInstrInfo::SIInstrInfo(const GCNSubtarget &ST)
     : AMDGPUGenInstrInfo(ST, RI, AMDGPU::ADJCALLSTACKUP,
@@ -10039,12 +10083,30 @@ SIInstrInfo::getSerializableTargetIndices() const {
   return ArrayRef(TargetIndices);
 }
 
+static std::unique_ptr<ScheduleHazardRecognizer>
+maybeCombineL1Hazard(std::unique_ptr<ScheduleHazardRecognizer> HazRec,
+                     const GCNSubtarget &ST) {
+  if (!L1Hazard)
+    return HazRec;
+  auto Res = std::make_unique<MultiHazardRecognizer>();
+  Res->AddHazardRecognizer(std::move(HazRec));
+  Res->AddHazardRecognizer(
+      std::make_unique<AMDGPU::CacheCapacityHazardRecognizer>(
+          L1Bytes,
+          AMDGPU::BytesPerCycle{L1Speed.getValue().first,
+                                L1Speed.getValue().second},
+          L1Latency, AMDGPU::getIsaVersion(ST.getCPU())));
+  return Res;
+}
+
 /// This is used by the post-RA scheduler (SchedulePostRAList.cpp).  The
 /// post-RA version of misched uses CreateTargetMIHazardRecognizer.
 ScheduleHazardRecognizer *
 SIInstrInfo::CreateTargetPostRAHazardRecognizer(const InstrItineraryData *II,
                                             const ScheduleDAG *DAG) const {
-  return new GCNHazardRecognizer(DAG->MF);
+  return maybeCombineL1Hazard(std::make_unique<GCNHazardRecognizer>(DAG->MF),
+                              ST)
+      .release();
 }
 
 /// This is the hazard recognizer used at -O0 by the PostRAHazardRecognizer
@@ -10052,7 +10114,9 @@ SIInstrInfo::CreateTargetPostRAHazardRecognizer(const InstrItineraryData *II,
 ScheduleHazardRecognizer *
 SIInstrInfo::CreateTargetPostRAHazardRecognizer(const MachineFunction &MF,
                                                 MachineLoopInfo *MLI) const {
-  return new GCNHazardRecognizer(MF, MLI);
+  return maybeCombineL1Hazard(std::make_unique<GCNHazardRecognizer>(MF, MLI),
+                              ST)
+      .release();
 }
 
 // Called during:
@@ -10065,8 +10129,14 @@ SIInstrInfo::CreateTargetMIHazardRecognizer(const InstrItineraryData *II,
   // post-RA scheduling; we can tell that we're post-RA because we don't
   // track VRegLiveness.
   if (!DAG->hasVRegLiveness())
-    return new GCNHazardRecognizer(DAG->MF);
-  return TargetInstrInfo::CreateTargetMIHazardRecognizer(II, DAG);
+    return maybeCombineL1Hazard(std::make_unique<GCNHazardRecognizer>(DAG->MF),
+                                ST)
+        .release();
+  return maybeCombineL1Hazard(
+             std::unique_ptr<ScheduleHazardRecognizer>(
+                 TargetInstrInfo::CreateTargetMIHazardRecognizer(II, DAG)),
+             ST)
+      .release();
 }
 
 std::pair<unsigned, unsigned>

--- a/llvm/test/CodeGen/AMDGPU/gcn-post-sched-resource-attr.ll
+++ b/llvm/test/CodeGen/AMDGPU/gcn-post-sched-resource-attr.ll
@@ -1,0 +1,25 @@
+; RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx942 \
+; RUN:     -enable-post-misched=1 < %s | FileCheck -check-prefix=GCN %s
+
+; Smoke test: the "amdgpu-post-sched-strategy"="resource" function attribute
+; selects the GCNPostRACriticalResource post-RA scheduling strategy. The
+; strategy attaches the resource distance map at post-RA scheduling time
+; and must not crash on a function with reserved-resource (MFMA) consumers
+; on multiple paths to the same accumulator.
+
+declare <4 x float> @llvm.amdgcn.mfma.f32.16x16x16f16(<4 x half>, <4 x half>, <4 x float>, i32, i32, i32)
+
+define amdgpu_kernel void @post_resource_strategy(<4 x half> %a, <4 x half> %b,
+                                                  <4 x half> %a2, <4 x half> %b2,
+                                                  <4 x float> %c,
+                                                  ptr addrspace(1) %out) #0 {
+; GCN-LABEL: post_resource_strategy:
+; GCN: v_mfma_f32_16x16x16
+; GCN: v_mfma_f32_16x16x16
+  %r1 = call <4 x float> @llvm.amdgcn.mfma.f32.16x16x16f16(<4 x half> %a, <4 x half> %b, <4 x float> %c, i32 0, i32 0, i32 0)
+  %r2 = call <4 x float> @llvm.amdgcn.mfma.f32.16x16x16f16(<4 x half> %a2, <4 x half> %b2, <4 x float> %r1, i32 0, i32 0, i32 0)
+  store <4 x float> %r2, ptr addrspace(1) %out
+  ret void
+}
+
+attributes #0 = { "amdgpu-post-sched-strategy"="resource" }

--- a/llvm/test/CodeGen/AMDGPU/gcn-resource-distance-map.mir
+++ b/llvm/test/CodeGen/AMDGPU/gcn-resource-distance-map.mir
@@ -1,0 +1,26 @@
+# RUN: llc -mtriple=amdgcn -mcpu=gfx942 -run-pass=machine-scheduler \
+# RUN:   -misched=gcn-resource -verify-misched %s -o - | FileCheck %s
+
+# Smoke test for the resource distance map (ResourceReduce heuristic).
+# Region has two independent producer chains feeding distinct MFMA roots;
+# the analysis must build a per-resource distance map without crashing
+# and the strategy must pick a valid order.
+
+---
+name: two_mfma_roots
+tracksRegLiveness: true
+body: |
+  bb.0:
+    ; CHECK-LABEL: name: two_mfma_roots
+    ; CHECK: V_MFMA_F32_16X16X16F16_e64
+    ; CHECK: V_MFMA_F32_16X16X16F16_e64
+    %0:vreg_64_align2 = IMPLICIT_DEF
+    %1:vreg_64_align2 = IMPLICIT_DEF
+    %2:areg_128_align2 = IMPLICIT_DEF
+    %3:vreg_64_align2 = IMPLICIT_DEF
+    %4:vreg_64_align2 = IMPLICIT_DEF
+    %5:areg_128_align2 = IMPLICIT_DEF
+    %6:areg_128_align2 = V_MFMA_F32_16X16X16F16_e64 %0, %1, %2, 0, 0, 0, implicit $mode, implicit $exec
+    %7:areg_128_align2 = V_MFMA_F32_16X16X16F16_e64 %3, %4, %5, 0, 0, 0, implicit $mode, implicit $exec
+    S_ENDPGM 0
+...

--- a/llvm/test/CodeGen/AMDGPU/gcn-resource-strategy.mir
+++ b/llvm/test/CodeGen/AMDGPU/gcn-resource-strategy.mir
@@ -1,0 +1,25 @@
+# RUN: llc -mtriple=amdgcn -mcpu=gfx942 -run-pass=machine-scheduler \
+# RUN:   -misched=gcn-resource -verify-misched %s -o - | FileCheck %s
+# RUN: llc -mtriple=amdgcn -mcpu=gfx942 -run-pass=machine-scheduler \
+# RUN:   -amdgpu-sched-strategy=resource -verify-misched %s -o - | FileCheck %s
+
+# Smoke test for the gcn-resource pre-RA scheduling strategy. Both the
+# -misched= registry route and the -amdgpu-sched-strategy= cl::opt route
+# should select GCNPreRACriticalResource without crashing on a region
+# containing reserved-resource (MFMA) consumers.
+
+---
+name: mfma_chain
+tracksRegLiveness: true
+body: |
+  bb.0:
+    ; CHECK-LABEL: name: mfma_chain
+    ; CHECK: V_MFMA_F32_16X16X16F16_e64
+    %0:vreg_64_align2 = IMPLICIT_DEF
+    %1:vreg_64_align2 = IMPLICIT_DEF
+    %2:areg_128_align2 = IMPLICIT_DEF
+    %3:areg_128_align2 = V_MFMA_F32_16X16X16F16_e64 %0, %1, %2, 0, 0, 0, implicit $mode, implicit $exec
+    %4:vgpr_32 = V_ADD_U32_e32 1, %0.sub0, implicit $exec
+    %5:vgpr_32 = V_ADD_U32_e32 2, %0.sub1, implicit $exec
+    S_ENDPGM 0
+...

--- a/llvm/test/CodeGen/AMDGPU/gcn-sched-resource-attr.ll
+++ b/llvm/test/CodeGen/AMDGPU/gcn-sched-resource-attr.ll
@@ -1,0 +1,21 @@
+; RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx942 -enable-post-misched=0 \
+; RUN:     < %s | FileCheck -check-prefix=GCN %s
+
+; Smoke test: the "amdgpu-sched-strategy"="resource" function attribute
+; selects the gcn-resource pre-RA scheduling strategy
+; (GCNPreRACriticalResource) without crashing on a function that contains
+; reserved-resource (MFMA) consumers.
+
+declare <4 x float> @llvm.amdgcn.mfma.f32.16x16x16f16(<4 x half>, <4 x half>, <4 x float>, i32, i32, i32)
+
+define amdgpu_kernel void @resource_strategy(<4 x half> %a, <4 x half> %b,
+                                             <4 x float> %c,
+                                             ptr addrspace(1) %out) #0 {
+; GCN-LABEL: resource_strategy:
+; GCN: v_mfma_f32_16x16x16
+  %r = call <4 x float> @llvm.amdgcn.mfma.f32.16x16x16f16(<4 x half> %a, <4 x half> %b, <4 x float> %c, i32 0, i32 0, i32 0)
+  store <4 x float> %r, ptr addrspace(1) %out
+  ret void
+}
+
+attributes #0 = { "amdgpu-sched-strategy"="resource" }

--- a/llvm/test/CodeGen/AMDGPU/l1-cache-capacity-hazard.mir
+++ b/llvm/test/CodeGen/AMDGPU/l1-cache-capacity-hazard.mir
@@ -1,0 +1,395 @@
+# Test the L1 data cache capacity hazard recognizer under different
+# configurations of bandwidth, latency, cache size, and load width.
+#
+# l1_cache_hazard: 4 GLOBAL_LOAD_DWORD (4 B each) + 16 independent VALU,
+# varying bandwidth and latency with l1-bytes=8.
+#
+# l1_cache_size: same loads + VALU, varying l1-bytes (8 vs 12 vs 16) to
+# show the effect of cache capacity.
+#
+# l1_wide_loads: 4 GLOBAL_LOAD_DWORDX2 (8 B each) + 16 VALU with
+# l1-bytes=16, contrasted against the DWORD case to show the effect of
+# wider loads filling the cache faster.
+
+# -- Bandwidth / latency tests (l1-bytes=8, DWORD loads) ------------------
+
+# RUN: llc -mtriple=amdgcn -mcpu=gfx906 -run-pass=postmisched \
+# RUN:   -amdgpu-l1-hazard=false \
+# RUN:   -o - %s | FileCheck -check-prefix=OFF %s
+# RUN: llc -mtriple=amdgcn -mcpu=gfx906 -run-pass=postmisched \
+# RUN:   -amdgpu-l1-hazard=true -amdgpu-l1-bytes=8 -amdgpu-l1-speed=32 \
+# RUN:   -amdgpu-l1-latency=0 \
+# RUN:   -o - %s | FileCheck -check-prefix=FAST %s
+# RUN: llc -mtriple=amdgcn -mcpu=gfx906 -run-pass=postmisched \
+# RUN:   -amdgpu-l1-hazard=true -amdgpu-l1-bytes=8 -amdgpu-l1-speed=1 \
+# RUN:   -amdgpu-l1-latency=0 \
+# RUN:   -o - %s | FileCheck -check-prefix=SLOW %s
+# RUN: llc -mtriple=amdgcn -mcpu=gfx906 -run-pass=postmisched \
+# RUN:   -amdgpu-l1-hazard=true -amdgpu-l1-bytes=8 -amdgpu-l1-speed=32 \
+# RUN:   -amdgpu-l1-latency=8 \
+# RUN:   -o - %s | FileCheck -check-prefix=DELAY %s
+# RUN: llc -mtriple=amdgcn -mcpu=gfx906 -run-pass=postmisched \
+# RUN:   -amdgpu-l1-hazard=true -amdgpu-l1-bytes=8 -amdgpu-l1-speed=1 \
+# RUN:   -amdgpu-l1-latency=8 \
+# RUN:   -o - %s | FileCheck -check-prefix=WORST %s
+
+# -- Fractional bandwidth test (l1-bytes=8, DWORD loads) ------------------
+
+# RUN: llc -mtriple=amdgcn -mcpu=gfx906 -run-pass=postmisched \
+# RUN:   -amdgpu-l1-hazard=true -amdgpu-l1-bytes=8 -amdgpu-l1-speed=3/4 \
+# RUN:   -amdgpu-l1-latency=0 \
+# RUN:   -o - %s | FileCheck -check-prefix=FRAC %s
+
+# -- Cache size tests (DWORD loads, speed=1, latency=0) -------------------
+
+# RUN: llc -mtriple=amdgcn -mcpu=gfx906 -run-pass=postmisched \
+# RUN:   -amdgpu-l1-hazard=true -amdgpu-l1-bytes=2 -amdgpu-l1-speed=1 \
+# RUN:   -amdgpu-l1-latency=0 \
+# RUN:   -o - %s | FileCheck -check-prefix=TINY %s
+# RUN: llc -mtriple=amdgcn -mcpu=gfx906 -run-pass=postmisched \
+# RUN:   -amdgpu-l1-hazard=true -amdgpu-l1-bytes=12 -amdgpu-l1-speed=1 \
+# RUN:   -amdgpu-l1-latency=0 \
+# RUN:   -o - %s | FileCheck -check-prefix=MED %s
+# RUN: llc -mtriple=amdgcn -mcpu=gfx906 -run-pass=postmisched \
+# RUN:   -amdgpu-l1-hazard=true -amdgpu-l1-bytes=16 -amdgpu-l1-speed=1 \
+# RUN:   -amdgpu-l1-latency=0 \
+# RUN:   -o - %s | FileCheck -check-prefix=BIG %s
+
+# -- Load width tests (l1-bytes=16, speed=1, latency=0) -------------------
+
+# RUN: llc -mtriple=amdgcn -mcpu=gfx906 -run-pass=postmisched \
+# RUN:   -amdgpu-l1-hazard=true -amdgpu-l1-bytes=16 -amdgpu-l1-speed=1 \
+# RUN:   -amdgpu-l1-latency=0 \
+# RUN:   -o - %s | FileCheck -check-prefix=NARROW %s
+# RUN: llc -mtriple=amdgcn -mcpu=gfx906 -run-pass=postmisched \
+# RUN:   -amdgpu-l1-hazard=true -amdgpu-l1-bytes=16 -amdgpu-l1-speed=1 \
+# RUN:   -amdgpu-l1-latency=0 \
+# RUN:   -o - %s | FileCheck -check-prefix=WIDE %s
+
+--- |
+  define amdgpu_kernel void @l1_cache_hazard() { ret void }
+  define amdgpu_kernel void @l1_wide_loads() { ret void }
+...
+
+# ===========================================================================
+# l1_cache_hazard: 4 x GLOBAL_LOAD_DWORD (4 B each)
+# ===========================================================================
+---
+name: l1_cache_hazard
+body: |
+  bb.0:
+    liveins: $vgpr0_vgpr1, $vgpr6_vgpr7, $vgpr8_vgpr9, $vgpr40_vgpr41
+
+    ; --- Hazard disabled: all loads first, then all VALU. ---
+    ; OFF-LABEL: name: l1_cache_hazard
+    ; OFF:      $vgpr2 = GLOBAL_LOAD_DWORD killed $vgpr0_vgpr1
+    ; OFF-NEXT: $vgpr3 = GLOBAL_LOAD_DWORD killed $vgpr6_vgpr7
+    ; OFF-NEXT: $vgpr4 = GLOBAL_LOAD_DWORD killed $vgpr8_vgpr9
+    ; OFF-NEXT: $vgpr5 = GLOBAL_LOAD_DWORD killed $vgpr40_vgpr41
+    ; OFF-NEXT: $vgpr10 = V_MOV_B32_e32 1
+    ; OFF-NEXT: $vgpr11 = V_MOV_B32_e32 2
+    ; OFF-NEXT: $vgpr12 = V_MOV_B32_e32 3
+    ; OFF-NEXT: $vgpr13 = V_MOV_B32_e32 4
+    ; OFF-NEXT: $vgpr14 = V_MOV_B32_e32 5
+    ; OFF-NEXT: $vgpr15 = V_MOV_B32_e32 6
+    ; OFF-NEXT: $vgpr16 = V_MOV_B32_e32 7
+    ; OFF-NEXT: $vgpr17 = V_MOV_B32_e32 8
+    ; OFF-NEXT: $vgpr18 = V_MOV_B32_e32 9
+    ; OFF-NEXT: $vgpr19 = V_MOV_B32_e32 10
+    ; OFF-NEXT: $vgpr20 = V_MOV_B32_e32 11
+    ; OFF-NEXT: $vgpr21 = V_MOV_B32_e32 12
+    ; OFF-NEXT: $vgpr22 = V_MOV_B32_e32 13
+    ; OFF-NEXT: $vgpr23 = V_MOV_B32_e32 14
+    ; OFF-NEXT: $vgpr24 = V_MOV_B32_e32 15
+    ; OFF-NEXT: $vgpr25 = V_MOV_B32_e32 16
+    ; OFF-NEXT: S_ENDPGM 0
+
+    ; --- High bandwidth (32 B/cyc), no latency: same as disabled. ---
+    ; FAST-LABEL: name: l1_cache_hazard
+    ; FAST:      $vgpr2 = GLOBAL_LOAD_DWORD killed $vgpr0_vgpr1
+    ; FAST-NEXT: $vgpr3 = GLOBAL_LOAD_DWORD killed $vgpr6_vgpr7
+    ; FAST-NEXT: $vgpr4 = GLOBAL_LOAD_DWORD killed $vgpr8_vgpr9
+    ; FAST-NEXT: $vgpr5 = GLOBAL_LOAD_DWORD killed $vgpr40_vgpr41
+    ; FAST-NEXT: $vgpr10 = V_MOV_B32_e32 1
+    ; FAST-NEXT: $vgpr11 = V_MOV_B32_e32 2
+    ; FAST-NEXT: $vgpr12 = V_MOV_B32_e32 3
+    ; FAST-NEXT: $vgpr13 = V_MOV_B32_e32 4
+    ; FAST-NEXT: $vgpr14 = V_MOV_B32_e32 5
+    ; FAST-NEXT: $vgpr15 = V_MOV_B32_e32 6
+    ; FAST-NEXT: $vgpr16 = V_MOV_B32_e32 7
+    ; FAST-NEXT: $vgpr17 = V_MOV_B32_e32 8
+    ; FAST-NEXT: $vgpr18 = V_MOV_B32_e32 9
+    ; FAST-NEXT: $vgpr19 = V_MOV_B32_e32 10
+    ; FAST-NEXT: $vgpr20 = V_MOV_B32_e32 11
+    ; FAST-NEXT: $vgpr21 = V_MOV_B32_e32 12
+    ; FAST-NEXT: $vgpr22 = V_MOV_B32_e32 13
+    ; FAST-NEXT: $vgpr23 = V_MOV_B32_e32 14
+    ; FAST-NEXT: $vgpr24 = V_MOV_B32_e32 15
+    ; FAST-NEXT: $vgpr25 = V_MOV_B32_e32 16
+    ; FAST-NEXT: S_ENDPGM 0
+
+    ; --- Low bandwidth (1 B/cyc), no latency: 2 VALU before load3, ---
+    ; --- 3 more before load4. ---
+    ; SLOW-LABEL: name: l1_cache_hazard
+    ; SLOW:      $vgpr2 = GLOBAL_LOAD_DWORD killed $vgpr0_vgpr1
+    ; SLOW-NEXT: $vgpr3 = GLOBAL_LOAD_DWORD killed $vgpr6_vgpr7
+    ; SLOW-NEXT: $vgpr10 = V_MOV_B32_e32 1
+    ; SLOW-NEXT: $vgpr11 = V_MOV_B32_e32 2
+    ; SLOW-NEXT: $vgpr4 = GLOBAL_LOAD_DWORD killed $vgpr8_vgpr9
+    ; SLOW-NEXT: $vgpr12 = V_MOV_B32_e32 3
+    ; SLOW-NEXT: $vgpr13 = V_MOV_B32_e32 4
+    ; SLOW-NEXT: $vgpr14 = V_MOV_B32_e32 5
+    ; SLOW-NEXT: $vgpr5 = GLOBAL_LOAD_DWORD killed $vgpr40_vgpr41
+    ; SLOW-NEXT: $vgpr15 = V_MOV_B32_e32 6
+    ; SLOW-NEXT: $vgpr16 = V_MOV_B32_e32 7
+    ; SLOW-NEXT: $vgpr17 = V_MOV_B32_e32 8
+    ; SLOW-NEXT: $vgpr18 = V_MOV_B32_e32 9
+    ; SLOW-NEXT: $vgpr19 = V_MOV_B32_e32 10
+    ; SLOW-NEXT: $vgpr20 = V_MOV_B32_e32 11
+    ; SLOW-NEXT: $vgpr21 = V_MOV_B32_e32 12
+    ; SLOW-NEXT: $vgpr22 = V_MOV_B32_e32 13
+    ; SLOW-NEXT: $vgpr23 = V_MOV_B32_e32 14
+    ; SLOW-NEXT: $vgpr24 = V_MOV_B32_e32 15
+    ; SLOW-NEXT: $vgpr25 = V_MOV_B32_e32 16
+    ; SLOW-NEXT: S_ENDPGM 0
+
+    ; --- High bandwidth (32 B/cyc), latency=8: latency forces 7 VALU ---
+    ; --- before load3; once matured, drains instantly so load4 follows. ---
+    ; DELAY-LABEL: name: l1_cache_hazard
+    ; DELAY:      $vgpr2 = GLOBAL_LOAD_DWORD killed $vgpr0_vgpr1
+    ; DELAY-NEXT: $vgpr3 = GLOBAL_LOAD_DWORD killed $vgpr6_vgpr7
+    ; DELAY-NEXT: $vgpr10 = V_MOV_B32_e32 1
+    ; DELAY-NEXT: $vgpr11 = V_MOV_B32_e32 2
+    ; DELAY-NEXT: $vgpr12 = V_MOV_B32_e32 3
+    ; DELAY-NEXT: $vgpr13 = V_MOV_B32_e32 4
+    ; DELAY-NEXT: $vgpr14 = V_MOV_B32_e32 5
+    ; DELAY-NEXT: $vgpr15 = V_MOV_B32_e32 6
+    ; DELAY-NEXT: $vgpr16 = V_MOV_B32_e32 7
+    ; DELAY-NEXT: $vgpr4 = GLOBAL_LOAD_DWORD killed $vgpr8_vgpr9
+    ; DELAY-NEXT: $vgpr5 = GLOBAL_LOAD_DWORD killed $vgpr40_vgpr41
+    ; DELAY-NEXT: $vgpr17 = V_MOV_B32_e32 8
+    ; DELAY-NEXT: $vgpr18 = V_MOV_B32_e32 9
+    ; DELAY-NEXT: $vgpr19 = V_MOV_B32_e32 10
+    ; DELAY-NEXT: $vgpr20 = V_MOV_B32_e32 11
+    ; DELAY-NEXT: $vgpr21 = V_MOV_B32_e32 12
+    ; DELAY-NEXT: $vgpr22 = V_MOV_B32_e32 13
+    ; DELAY-NEXT: $vgpr23 = V_MOV_B32_e32 14
+    ; DELAY-NEXT: $vgpr24 = V_MOV_B32_e32 15
+    ; DELAY-NEXT: $vgpr25 = V_MOV_B32_e32 16
+    ; DELAY-NEXT: S_ENDPGM 0
+
+    ; --- Low bandwidth (1 B/cyc), latency=8: most constrained; 10 VALU ---
+    ; --- before load3, 3 more before load4. ---
+    ; WORST-LABEL: name: l1_cache_hazard
+    ; WORST:      $vgpr2 = GLOBAL_LOAD_DWORD killed $vgpr0_vgpr1
+    ; WORST-NEXT: $vgpr3 = GLOBAL_LOAD_DWORD killed $vgpr6_vgpr7
+    ; WORST-NEXT: $vgpr10 = V_MOV_B32_e32 1
+    ; WORST-NEXT: $vgpr11 = V_MOV_B32_e32 2
+    ; WORST-NEXT: $vgpr12 = V_MOV_B32_e32 3
+    ; WORST-NEXT: $vgpr13 = V_MOV_B32_e32 4
+    ; WORST-NEXT: $vgpr14 = V_MOV_B32_e32 5
+    ; WORST-NEXT: $vgpr15 = V_MOV_B32_e32 6
+    ; WORST-NEXT: $vgpr16 = V_MOV_B32_e32 7
+    ; WORST-NEXT: $vgpr17 = V_MOV_B32_e32 8
+    ; WORST-NEXT: $vgpr18 = V_MOV_B32_e32 9
+    ; WORST-NEXT: $vgpr19 = V_MOV_B32_e32 10
+    ; WORST-NEXT: $vgpr4 = GLOBAL_LOAD_DWORD killed $vgpr8_vgpr9
+    ; WORST-NEXT: $vgpr20 = V_MOV_B32_e32 11
+    ; WORST-NEXT: $vgpr21 = V_MOV_B32_e32 12
+    ; WORST-NEXT: $vgpr22 = V_MOV_B32_e32 13
+    ; WORST-NEXT: $vgpr5 = GLOBAL_LOAD_DWORD killed $vgpr40_vgpr41
+    ; WORST-NEXT: $vgpr23 = V_MOV_B32_e32 14
+    ; WORST-NEXT: $vgpr24 = V_MOV_B32_e32 15
+    ; WORST-NEXT: $vgpr25 = V_MOV_B32_e32 16
+    ; WORST-NEXT: S_ENDPGM 0
+
+    ; --- Fractional bandwidth (3/4 B/cyc), no latency: slower drain ---
+    ; --- than integer speed=1; 4 VALU before load3, 4 before load4. ---
+    ; FRAC-LABEL: name: l1_cache_hazard
+    ; FRAC:      $vgpr2 = GLOBAL_LOAD_DWORD killed $vgpr0_vgpr1
+    ; FRAC-NEXT: $vgpr3 = GLOBAL_LOAD_DWORD killed $vgpr6_vgpr7
+    ; FRAC-NEXT: $vgpr10 = V_MOV_B32_e32 1
+    ; FRAC-NEXT: $vgpr11 = V_MOV_B32_e32 2
+    ; FRAC-NEXT: $vgpr12 = V_MOV_B32_e32 3
+    ; FRAC-NEXT: $vgpr13 = V_MOV_B32_e32 4
+    ; FRAC-NEXT: $vgpr4 = GLOBAL_LOAD_DWORD killed $vgpr8_vgpr9
+    ; FRAC-NEXT: $vgpr14 = V_MOV_B32_e32 5
+    ; FRAC-NEXT: $vgpr15 = V_MOV_B32_e32 6
+    ; FRAC-NEXT: $vgpr16 = V_MOV_B32_e32 7
+    ; FRAC-NEXT: $vgpr17 = V_MOV_B32_e32 8
+    ; FRAC-NEXT: $vgpr5 = GLOBAL_LOAD_DWORD killed $vgpr40_vgpr41
+    ; FRAC-NEXT: $vgpr18 = V_MOV_B32_e32 9
+    ; FRAC-NEXT: $vgpr19 = V_MOV_B32_e32 10
+    ; FRAC-NEXT: $vgpr20 = V_MOV_B32_e32 11
+    ; FRAC-NEXT: $vgpr21 = V_MOV_B32_e32 12
+    ; FRAC-NEXT: $vgpr22 = V_MOV_B32_e32 13
+    ; FRAC-NEXT: $vgpr23 = V_MOV_B32_e32 14
+    ; FRAC-NEXT: $vgpr24 = V_MOV_B32_e32 15
+    ; FRAC-NEXT: $vgpr25 = V_MOV_B32_e32 16
+    ; FRAC-NEXT: S_ENDPGM 0
+
+    ; --- Cache size: l1-bytes=2 with speed=1; cache is smaller than a ---
+    ; --- single DWORD load (4 B). Each load's footprint is clamped ---
+    ; --- to cache size (2 B), so every load is separated by 1 VALU. ---
+    ; TINY-LABEL: name: l1_cache_hazard
+    ; TINY:      $vgpr2 = GLOBAL_LOAD_DWORD killed $vgpr0_vgpr1
+    ; TINY-NEXT: $vgpr10 = V_MOV_B32_e32 1
+    ; TINY-NEXT: $vgpr3 = GLOBAL_LOAD_DWORD killed $vgpr6_vgpr7
+    ; TINY-NEXT: $vgpr11 = V_MOV_B32_e32 2
+    ; TINY-NEXT: $vgpr4 = GLOBAL_LOAD_DWORD killed $vgpr8_vgpr9
+    ; TINY-NEXT: $vgpr12 = V_MOV_B32_e32 3
+    ; TINY-NEXT: $vgpr5 = GLOBAL_LOAD_DWORD killed $vgpr40_vgpr41
+    ; TINY-NEXT: $vgpr13 = V_MOV_B32_e32 4
+    ; TINY-NEXT: $vgpr14 = V_MOV_B32_e32 5
+    ; TINY-NEXT: $vgpr15 = V_MOV_B32_e32 6
+    ; TINY-NEXT: $vgpr16 = V_MOV_B32_e32 7
+    ; TINY-NEXT: $vgpr17 = V_MOV_B32_e32 8
+    ; TINY-NEXT: $vgpr18 = V_MOV_B32_e32 9
+    ; TINY-NEXT: $vgpr19 = V_MOV_B32_e32 10
+    ; TINY-NEXT: $vgpr20 = V_MOV_B32_e32 11
+    ; TINY-NEXT: $vgpr21 = V_MOV_B32_e32 12
+    ; TINY-NEXT: $vgpr22 = V_MOV_B32_e32 13
+    ; TINY-NEXT: $vgpr23 = V_MOV_B32_e32 14
+    ; TINY-NEXT: $vgpr24 = V_MOV_B32_e32 15
+    ; TINY-NEXT: $vgpr25 = V_MOV_B32_e32 16
+    ; TINY-NEXT: S_ENDPGM 0
+
+    ; --- Cache size: l1-bytes=12 with speed=1; 3 DWORD loads (12 B) ---
+    ; --- fit, only load4 needs 1 VALU gap. ---
+    ; MED-LABEL: name: l1_cache_hazard
+    ; MED:      $vgpr2 = GLOBAL_LOAD_DWORD killed $vgpr0_vgpr1
+    ; MED-NEXT: $vgpr3 = GLOBAL_LOAD_DWORD killed $vgpr6_vgpr7
+    ; MED-NEXT: $vgpr4 = GLOBAL_LOAD_DWORD killed $vgpr8_vgpr9
+    ; MED-NEXT: $vgpr10 = V_MOV_B32_e32 1
+    ; MED-NEXT: $vgpr5 = GLOBAL_LOAD_DWORD killed $vgpr40_vgpr41
+    ; MED-NEXT: $vgpr11 = V_MOV_B32_e32 2
+    ; MED-NEXT: $vgpr12 = V_MOV_B32_e32 3
+    ; MED-NEXT: $vgpr13 = V_MOV_B32_e32 4
+    ; MED-NEXT: $vgpr14 = V_MOV_B32_e32 5
+    ; MED-NEXT: $vgpr15 = V_MOV_B32_e32 6
+    ; MED-NEXT: $vgpr16 = V_MOV_B32_e32 7
+    ; MED-NEXT: $vgpr17 = V_MOV_B32_e32 8
+    ; MED-NEXT: $vgpr18 = V_MOV_B32_e32 9
+    ; MED-NEXT: $vgpr19 = V_MOV_B32_e32 10
+    ; MED-NEXT: $vgpr20 = V_MOV_B32_e32 11
+    ; MED-NEXT: $vgpr21 = V_MOV_B32_e32 12
+    ; MED-NEXT: $vgpr22 = V_MOV_B32_e32 13
+    ; MED-NEXT: $vgpr23 = V_MOV_B32_e32 14
+    ; MED-NEXT: $vgpr24 = V_MOV_B32_e32 15
+    ; MED-NEXT: $vgpr25 = V_MOV_B32_e32 16
+    ; MED-NEXT: S_ENDPGM 0
+
+    ; --- Cache size: l1-bytes=16 with speed=1; all 4 DWORD loads ---
+    ; --- (16 B) fit in the cache, no interleaving needed. ---
+    ; BIG-LABEL: name: l1_cache_hazard
+    ; BIG:      $vgpr2 = GLOBAL_LOAD_DWORD killed $vgpr0_vgpr1
+    ; BIG-NEXT: $vgpr3 = GLOBAL_LOAD_DWORD killed $vgpr6_vgpr7
+    ; BIG-NEXT: $vgpr4 = GLOBAL_LOAD_DWORD killed $vgpr8_vgpr9
+    ; BIG-NEXT: $vgpr5 = GLOBAL_LOAD_DWORD killed $vgpr40_vgpr41
+    ; BIG-NEXT: $vgpr10 = V_MOV_B32_e32 1
+    ; BIG-NEXT: $vgpr11 = V_MOV_B32_e32 2
+    ; BIG-NEXT: $vgpr12 = V_MOV_B32_e32 3
+    ; BIG-NEXT: $vgpr13 = V_MOV_B32_e32 4
+    ; BIG-NEXT: $vgpr14 = V_MOV_B32_e32 5
+    ; BIG-NEXT: $vgpr15 = V_MOV_B32_e32 6
+    ; BIG-NEXT: $vgpr16 = V_MOV_B32_e32 7
+    ; BIG-NEXT: $vgpr17 = V_MOV_B32_e32 8
+    ; BIG-NEXT: $vgpr18 = V_MOV_B32_e32 9
+    ; BIG-NEXT: $vgpr19 = V_MOV_B32_e32 10
+    ; BIG-NEXT: $vgpr20 = V_MOV_B32_e32 11
+    ; BIG-NEXT: $vgpr21 = V_MOV_B32_e32 12
+    ; BIG-NEXT: $vgpr22 = V_MOV_B32_e32 13
+    ; BIG-NEXT: $vgpr23 = V_MOV_B32_e32 14
+    ; BIG-NEXT: $vgpr24 = V_MOV_B32_e32 15
+    ; BIG-NEXT: $vgpr25 = V_MOV_B32_e32 16
+    ; BIG-NEXT: S_ENDPGM 0
+
+    ; --- Load width: DWORD (4 B) with l1-bytes=16; all 4 loads fit ---
+    ; --- (same as BIG, checked on the same function for contrast). ---
+    ; NARROW-LABEL: name: l1_cache_hazard
+    ; NARROW:      $vgpr2 = GLOBAL_LOAD_DWORD killed $vgpr0_vgpr1
+    ; NARROW-NEXT: $vgpr3 = GLOBAL_LOAD_DWORD killed $vgpr6_vgpr7
+    ; NARROW-NEXT: $vgpr4 = GLOBAL_LOAD_DWORD killed $vgpr8_vgpr9
+    ; NARROW-NEXT: $vgpr5 = GLOBAL_LOAD_DWORD killed $vgpr40_vgpr41
+    ; NARROW-NEXT: $vgpr10 = V_MOV_B32_e32 1
+
+    $vgpr2 = GLOBAL_LOAD_DWORD $vgpr0_vgpr1, 0, 0, implicit $exec :: (load (s32), addrspace 1)
+    $vgpr3 = GLOBAL_LOAD_DWORD $vgpr6_vgpr7, 0, 0, implicit $exec :: (load (s32), addrspace 1)
+    $vgpr4 = GLOBAL_LOAD_DWORD $vgpr8_vgpr9, 0, 0, implicit $exec :: (load (s32), addrspace 1)
+    $vgpr5 = GLOBAL_LOAD_DWORD $vgpr40_vgpr41, 0, 0, implicit $exec :: (load (s32), addrspace 1)
+    $vgpr10 = V_MOV_B32_e32 1, implicit $exec
+    $vgpr11 = V_MOV_B32_e32 2, implicit $exec
+    $vgpr12 = V_MOV_B32_e32 3, implicit $exec
+    $vgpr13 = V_MOV_B32_e32 4, implicit $exec
+    $vgpr14 = V_MOV_B32_e32 5, implicit $exec
+    $vgpr15 = V_MOV_B32_e32 6, implicit $exec
+    $vgpr16 = V_MOV_B32_e32 7, implicit $exec
+    $vgpr17 = V_MOV_B32_e32 8, implicit $exec
+    $vgpr18 = V_MOV_B32_e32 9, implicit $exec
+    $vgpr19 = V_MOV_B32_e32 10, implicit $exec
+    $vgpr20 = V_MOV_B32_e32 11, implicit $exec
+    $vgpr21 = V_MOV_B32_e32 12, implicit $exec
+    $vgpr22 = V_MOV_B32_e32 13, implicit $exec
+    $vgpr23 = V_MOV_B32_e32 14, implicit $exec
+    $vgpr24 = V_MOV_B32_e32 15, implicit $exec
+    $vgpr25 = V_MOV_B32_e32 16, implicit $exec
+    S_ENDPGM 0, implicit $vgpr2, implicit $vgpr3, implicit $vgpr4, implicit $vgpr5, implicit $vgpr10, implicit $vgpr11, implicit $vgpr12, implicit $vgpr13, implicit $vgpr14, implicit $vgpr15, implicit $vgpr16, implicit $vgpr17, implicit $vgpr18, implicit $vgpr19, implicit $vgpr20, implicit $vgpr21, implicit $vgpr22, implicit $vgpr23, implicit $vgpr24, implicit $vgpr25
+...
+
+# ===========================================================================
+# l1_wide_loads: 4 x GLOBAL_LOAD_DWORDX2 (8 B each)
+# With l1-bytes=16, speed=1: 2 wide loads (16 B) fill the cache immediately;
+# 6 VALU before load3, 7 more before load4.
+# Contrast with NARROW above where 4 narrow loads all fit in the same cache.
+# ===========================================================================
+---
+name: l1_wide_loads
+body: |
+  bb.0:
+    liveins: $vgpr0_vgpr1, $vgpr6_vgpr7, $vgpr8_vgpr9, $vgpr40_vgpr41
+
+    ; WIDE-LABEL: name: l1_wide_loads
+    ; WIDE:      $vgpr2_vgpr3 = GLOBAL_LOAD_DWORDX2 killed $vgpr0_vgpr1
+    ; WIDE-NEXT: $vgpr4_vgpr5 = GLOBAL_LOAD_DWORDX2 killed $vgpr6_vgpr7
+    ; WIDE-NEXT: $vgpr10 = V_MOV_B32_e32 1
+    ; WIDE-NEXT: $vgpr11 = V_MOV_B32_e32 2
+    ; WIDE-NEXT: $vgpr12 = V_MOV_B32_e32 3
+    ; WIDE-NEXT: $vgpr13 = V_MOV_B32_e32 4
+    ; WIDE-NEXT: $vgpr14 = V_MOV_B32_e32 5
+    ; WIDE-NEXT: $vgpr15 = V_MOV_B32_e32 6
+    ; WIDE-NEXT: $vgpr26_vgpr27 = GLOBAL_LOAD_DWORDX2 killed $vgpr8_vgpr9
+    ; WIDE-NEXT: $vgpr16 = V_MOV_B32_e32 7
+    ; WIDE-NEXT: $vgpr17 = V_MOV_B32_e32 8
+    ; WIDE-NEXT: $vgpr18 = V_MOV_B32_e32 9
+    ; WIDE-NEXT: $vgpr19 = V_MOV_B32_e32 10
+    ; WIDE-NEXT: $vgpr20 = V_MOV_B32_e32 11
+    ; WIDE-NEXT: $vgpr21 = V_MOV_B32_e32 12
+    ; WIDE-NEXT: $vgpr22 = V_MOV_B32_e32 13
+    ; WIDE-NEXT: $vgpr28_vgpr29 = GLOBAL_LOAD_DWORDX2 killed $vgpr40_vgpr41
+    ; WIDE-NEXT: $vgpr23 = V_MOV_B32_e32 14
+    ; WIDE-NEXT: $vgpr24 = V_MOV_B32_e32 15
+    ; WIDE-NEXT: $vgpr25 = V_MOV_B32_e32 16
+    ; WIDE-NEXT: S_ENDPGM 0
+
+    $vgpr2_vgpr3 = GLOBAL_LOAD_DWORDX2 $vgpr0_vgpr1, 0, 0, implicit $exec :: (load (s64), addrspace 1)
+    $vgpr4_vgpr5 = GLOBAL_LOAD_DWORDX2 $vgpr6_vgpr7, 0, 0, implicit $exec :: (load (s64), addrspace 1)
+    $vgpr26_vgpr27 = GLOBAL_LOAD_DWORDX2 $vgpr8_vgpr9, 0, 0, implicit $exec :: (load (s64), addrspace 1)
+    $vgpr28_vgpr29 = GLOBAL_LOAD_DWORDX2 $vgpr40_vgpr41, 0, 0, implicit $exec :: (load (s64), addrspace 1)
+    $vgpr10 = V_MOV_B32_e32 1, implicit $exec
+    $vgpr11 = V_MOV_B32_e32 2, implicit $exec
+    $vgpr12 = V_MOV_B32_e32 3, implicit $exec
+    $vgpr13 = V_MOV_B32_e32 4, implicit $exec
+    $vgpr14 = V_MOV_B32_e32 5, implicit $exec
+    $vgpr15 = V_MOV_B32_e32 6, implicit $exec
+    $vgpr16 = V_MOV_B32_e32 7, implicit $exec
+    $vgpr17 = V_MOV_B32_e32 8, implicit $exec
+    $vgpr18 = V_MOV_B32_e32 9, implicit $exec
+    $vgpr19 = V_MOV_B32_e32 10, implicit $exec
+    $vgpr20 = V_MOV_B32_e32 11, implicit $exec
+    $vgpr21 = V_MOV_B32_e32 12, implicit $exec
+    $vgpr22 = V_MOV_B32_e32 13, implicit $exec
+    $vgpr23 = V_MOV_B32_e32 14, implicit $exec
+    $vgpr24 = V_MOV_B32_e32 15, implicit $exec
+    $vgpr25 = V_MOV_B32_e32 16, implicit $exec
+    S_ENDPGM 0, implicit $vgpr2_vgpr3, implicit $vgpr4_vgpr5, implicit $vgpr26_vgpr27, implicit $vgpr28_vgpr29, implicit $vgpr10, implicit $vgpr11, implicit $vgpr12, implicit $vgpr13, implicit $vgpr14, implicit $vgpr15, implicit $vgpr16, implicit $vgpr17, implicit $vgpr18, implicit $vgpr19, implicit $vgpr20, implicit $vgpr21, implicit $vgpr22, implicit $vgpr23, implicit $vgpr24, implicit $vgpr25
+...


### PR DESCRIPTION
To get high mfma util rate, we want to keep issuing mfma instrs, and co-issue/co-exec other instructions within mfma's co-exec slots. However, when llvm machine scheduler is faced with a bunch of available nodes, it has no reason to pick a mfma node, thus mfma util rate drops.
This commit will count resource usage in schedule remainder, if some resource kind takes more cycles than critical path, it will prioritize nodes using this resource in tryCandidate.