### PR TITLE
[AMDGPU] Poison invalid globals after emitting error in LowerBufferFatPointers pass

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPULowerBufferFatPointers.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPULowerBufferFatPointers.cpp
@@ -223,6 +223,7 @@
 #include "GCNSubtarget.h"
 #include "SIDefines.h"
 #include "llvm/ADT/SetOperations.h"
+#include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Analysis/InstSimplifyFolder.h"
 #include "llvm/Analysis/TargetTransformInfo.h"
@@ -2467,13 +2468,19 @@ bool AMDGPULowerBufferFatPointers::run(Module &M, const TargetMachine &TM) {
 
   BufferFatPtrToStructTypeMap StructTM(DL);
   BufferFatPtrToIntTypeMap IntTM(DL);
-  SmallVector<GlobalVariable *, 4> InvalidGlobals;
-  for (GlobalVariable &GV : M.globals()) {
+
+  auto EraseInvalidGlobal = [&Changed](GlobalVariable &GV) {
+    GV.replaceAllUsesWith(PoisonValue::get(GV.getType()));
+    GV.eraseFromParent();
+    Changed = true;
+  };
+
+  for (GlobalVariable &GV : make_early_inc_range(M.globals())) {
     if (GV.getAddressSpace() == AMDGPUAS::BUFFER_FAT_POINTER) {
       // FIXME: Use DiagnosticInfo unsupported but it requires a Function
       Ctx.emitError("global variables with a buffer fat pointer address "
                     "space (7) are not supported");
-      InvalidGlobals.push_back(&GV);
+      EraseInvalidGlobal(GV);
       continue;
     }
 
@@ -2483,15 +2490,9 @@ bool AMDGPULowerBufferFatPointers::run(Module &M, const TargetMachine &TM) {
       Ctx.emitError("global variables that contain buffer fat pointers "
                     "(address space 7 pointers) are unsupported. Use "
                     "buffer resource pointers (address space 8) instead");
-      InvalidGlobals.push_back(&GV);
+      EraseInvalidGlobal(GV);
       continue;
     }
-  }
-
-  for (GlobalVariable *GV : InvalidGlobals) {
-    GV->replaceAllUsesWith(PoisonValue::get(GV->getType()));
-    GV->eraseFromParent();
-    Changed = true;
   }
 
   {

--- a/llvm/lib/Target/AMDGPU/AMDGPULowerBufferFatPointers.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPULowerBufferFatPointers.cpp
@@ -223,7 +223,6 @@
 #include "GCNSubtarget.h"
 #include "SIDefines.h"
 #include "llvm/ADT/SetOperations.h"
-#include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Analysis/InstSimplifyFolder.h"
 #include "llvm/Analysis/TargetTransformInfo.h"
@@ -2468,19 +2467,14 @@ bool AMDGPULowerBufferFatPointers::run(Module &M, const TargetMachine &TM) {
 
   BufferFatPtrToStructTypeMap StructTM(DL);
   BufferFatPtrToIntTypeMap IntTM(DL);
-
-  auto EraseInvalidGlobal = [&Changed](GlobalVariable &GV) {
-    GV.replaceAllUsesWith(PoisonValue::get(GV.getType()));
-    GV.eraseFromParent();
-    Changed = true;
-  };
-
   for (GlobalVariable &GV : make_early_inc_range(M.globals())) {
     if (GV.getAddressSpace() == AMDGPUAS::BUFFER_FAT_POINTER) {
       // FIXME: Use DiagnosticInfo unsupported but it requires a Function
       Ctx.emitError("global variables with a buffer fat pointer address "
                     "space (7) are not supported");
-      EraseInvalidGlobal(GV);
+      GV.replaceAllUsesWith(PoisonValue::get(GV.getType()));
+      GV.eraseFromParent();
+      Changed = true;
       continue;
     }
 
@@ -2490,7 +2484,9 @@ bool AMDGPULowerBufferFatPointers::run(Module &M, const TargetMachine &TM) {
       Ctx.emitError("global variables that contain buffer fat pointers "
                     "(address space 7 pointers) are unsupported. Use "
                     "buffer resource pointers (address space 8) instead");
-      EraseInvalidGlobal(GV);
+      GV.replaceAllUsesWith(PoisonValue::get(GV.getType()));
+      GV.eraseFromParent();
+      Changed = true;
       continue;
     }
   }

--- a/llvm/lib/Target/AMDGPU/AMDGPULowerBufferFatPointers.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPULowerBufferFatPointers.cpp
@@ -2467,11 +2467,13 @@ bool AMDGPULowerBufferFatPointers::run(Module &M, const TargetMachine &TM) {
 
   BufferFatPtrToStructTypeMap StructTM(DL);
   BufferFatPtrToIntTypeMap IntTM(DL);
-  for (const GlobalVariable &GV : M.globals()) {
+  SmallVector<GlobalVariable *, 4> InvalidGlobals;
+  for (GlobalVariable &GV : M.globals()) {
     if (GV.getAddressSpace() == AMDGPUAS::BUFFER_FAT_POINTER) {
       // FIXME: Use DiagnosticInfo unsupported but it requires a Function
       Ctx.emitError("global variables with a buffer fat pointer address "
                     "space (7) are not supported");
+      InvalidGlobals.push_back(&GV);
       continue;
     }
 
@@ -2481,8 +2483,15 @@ bool AMDGPULowerBufferFatPointers::run(Module &M, const TargetMachine &TM) {
       Ctx.emitError("global variables that contain buffer fat pointers "
                     "(address space 7 pointers) are unsupported. Use "
                     "buffer resource pointers (address space 8) instead");
+      InvalidGlobals.push_back(&GV);
       continue;
     }
+  }
+
+  for (GlobalVariable *GV : InvalidGlobals) {
+    GV->replaceAllUsesWith(PoisonValue::get(GV->getType()));
+    GV->eraseFromParent();
+    Changed = true;
   }
 
   {

--- a/llvm/test/CodeGen/AMDGPU/buffer-fat-pointer-unsupported-errors.ll
+++ b/llvm/test/CodeGen/AMDGPU/buffer-fat-pointer-unsupported-errors.ll
@@ -3,6 +3,7 @@
 ; RUN: not opt -mtriple=amdgcn-amd-amdhsa -disable-output -passes=amdgpu-lower-buffer-fat-pointers %t/contains-poison-init.ll 2>&1 | FileCheck -check-prefix=ERR1 %s
 ; RUN: not opt -mtriple=amdgcn-amd-amdhsa -disable-output -passes=amdgpu-lower-buffer-fat-pointers %t/defined-gv-type.ll 2>&1 | FileCheck -check-prefix=ERR2 %s
 ; RUN: not opt -mtriple=amdgcn-amd-amdhsa -disable-output -passes=amdgpu-lower-buffer-fat-pointers %t/declared-gv-type.ll 2>&1 | FileCheck -check-prefix=ERR3 %s
+; RUN: not opt -mtriple=amdgcn-amd-amdhsa -disable-output -passes=amdgpu-lower-buffer-fat-pointers %t/used-global-with-p7.ll 2>&1 | FileCheck -check-prefix=ERR4 %s
 
 ;--- contains-null-init.ll
 ; ERR0: error: global variables that contain buffer fat pointers (address space 7 pointers) are unsupported. Use buffer resource pointers (address space 8) instead
@@ -20,3 +21,14 @@
 ; ERR3: error: global variables with a buffer fat pointer address space (7) are not supported
 @extern_gv_is_addrspace_7 = external addrspace(7) global i32
 
+;--- used-global-with-p7.ll
+; ERR4: error: global variables that contain buffer fat pointers (address space 7 pointers) are unsupported. Use buffer resource pointers (address space 8) instead
+; ERR4-NOT: LLVM ERROR
+@G = global ptr addrspace(7) poison
+
+define amdgpu_kernel void @use_global(ptr addrspace(7) %in) {
+  %ptr = load ptr addrspace(7), ptr @G, align 8
+  %v = load i32, ptr addrspace(7) %ptr, align 4
+  store i32 %v, ptr addrspace(7) %in, align 4
+  ret void
+}


### PR DESCRIPTION
After the change from `report_fatal_error` to `Ctx.emitError` in #142014 there is a necessity to remove unsupported globals. Otherwise there is a secondary crash during ISel when processing them

Fixes SWDEV-511241