### PR TITLE
[libc] Make standard streams entrypoints

### DIFF
--- a/libc/config/baremetal/aarch64/entrypoints.txt
+++ b/libc/config/baremetal/aarch64/entrypoints.txt
@@ -144,6 +144,9 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.stdio.snprintf
     libc.src.stdio.sprintf
     libc.src.stdio.sscanf
+    libc.src.stdio.stderr
+    libc.src.stdio.stdin
+    libc.src.stdio.stdout
     libc.src.stdio.vasprintf
     libc.src.stdio.vfprintf
     libc.src.stdio.vfscanf

--- a/libc/config/baremetal/arm/entrypoints.txt
+++ b/libc/config/baremetal/arm/entrypoints.txt
@@ -144,6 +144,9 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.stdio.snprintf
     libc.src.stdio.sprintf
     libc.src.stdio.sscanf
+    libc.src.stdio.stderr
+    libc.src.stdio.stdin
+    libc.src.stdio.stdout
     libc.src.stdio.vasprintf
     libc.src.stdio.vfprintf
     libc.src.stdio.vfscanf

--- a/libc/config/baremetal/riscv/entrypoints.txt
+++ b/libc/config/baremetal/riscv/entrypoints.txt
@@ -144,6 +144,9 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.stdio.snprintf
     libc.src.stdio.sprintf
     libc.src.stdio.sscanf
+    libc.src.stdio.stderr
+    libc.src.stdio.stdin
+    libc.src.stdio.stdout
     libc.src.stdio.vasprintf
     libc.src.stdio.vfprintf
     libc.src.stdio.vfscanf

--- a/libc/config/linux/aarch64/entrypoints.txt
+++ b/libc/config/linux/aarch64/entrypoints.txt
@@ -228,6 +228,9 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.stdio.sprintf
     libc.src.stdio.asprintf
     libc.src.stdio.sscanf
+    libc.src.stdio.stderr
+    libc.src.stdio.stdin
+    libc.src.stdio.stdout
     libc.src.stdio.vsscanf
     libc.src.stdio.vfprintf
     libc.src.stdio.vprintf

--- a/libc/config/linux/riscv/entrypoints.txt
+++ b/libc/config/linux/riscv/entrypoints.txt
@@ -229,6 +229,9 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.stdio.sprintf
     libc.src.stdio.asprintf
     libc.src.stdio.sscanf
+    libc.src.stdio.stderr
+    libc.src.stdio.stdin
+    libc.src.stdio.stdout
     libc.src.stdio.vsscanf
     libc.src.stdio.vfprintf
     libc.src.stdio.vprintf

--- a/libc/config/linux/x86_64/entrypoints.txt
+++ b/libc/config/linux/x86_64/entrypoints.txt
@@ -231,6 +231,9 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.stdio.sprintf
     libc.src.stdio.asprintf
     libc.src.stdio.sscanf
+    libc.src.stdio.stderr
+    libc.src.stdio.stdin
+    libc.src.stdio.stdout
     libc.src.stdio.vsscanf
     libc.src.stdio.vfprintf
     libc.src.stdio.vprintf

--- a/libc/src/__support/File/CMakeLists.txt
+++ b/libc/src/__support/File/CMakeLists.txt
@@ -42,24 +42,14 @@ endif()
 add_subdirectory(${LIBC_TARGET_OS})
 
 set(target_file libc.src.__support.File.${LIBC_TARGET_OS}.file)
-set(target_stdout libc.src.__support.File.${LIBC_TARGET_OS}.stdout)
-set(target_stderr libc.src.__support.File.${LIBC_TARGET_OS}.stderr)
-set(target_stdin libc.src.__support.File.${LIBC_TARGET_OS}.stdin)
 
-set(file_targets "${target_file};${target_stdout};${target_stdin};${target_stderr}")
-set(file_aliases "platform_file;platform_stdout;platform_stdin;platform_stderr")
-
-foreach(alias target IN ZIP_LISTS file_aliases file_targets)
-  if(TARGET ${target})
-    add_object_library(
-      ${alias}
-      ALIAS
-        ${target}
-      DEPENDS
-        ${target}
-    )
-  endif()
-endforeach()
+add_object_library(
+  platform_file
+  ALIAS
+    ${target_file}
+  DEPENDS
+    ${target_file}
+)
 
 set(target_dir libc.src.__support.File.${LIBC_TARGET_OS}.${LIBC_TARGET_OS}_dir)
 if(NOT TARGET ${target_dir})

--- a/libc/src/__support/File/file.h
+++ b/libc/src/__support/File/file.h
@@ -323,10 +323,6 @@ ErrorOr<File *> openfile(const char *path, const char *mode);
 // platform.
 int get_fileno(File *f);
 
-extern File *stdin;
-extern File *stdout;
-extern File *stderr;
-
 } // namespace LIBC_NAMESPACE_DECL
 
 #endif // LLVM_LIBC_SRC___SUPPORT_FILE_FILE_H

--- a/libc/src/__support/File/linux/CMakeLists.txt
+++ b/libc/src/__support/File/linux/CMakeLists.txt
@@ -22,36 +22,6 @@ add_object_library(
 )
 
 add_object_library(
-  stdout
-  SRCS
-    stdout.cpp
-  DEPENDS
-    .file
-    libc.hdr.types.FILE
-    libc.hdr.stdio_macros
-)
-
-add_object_library(
-  stdin
-  SRCS
-    stdin.cpp
-  DEPENDS
-    .file
-    libc.hdr.types.FILE
-    libc.hdr.stdio_macros
-)
-
-add_object_library(
-  stderr
-  SRCS
-    stderr.cpp
-  DEPENDS
-    .file
-    libc.hdr.types.FILE
-    libc.hdr.stdio_macros
-)
-
-add_object_library(
   linux_dir
   SRCS
     dir.cpp

--- a/libc/src/__support/OSUtil/baremetal/io.cpp
+++ b/libc/src/__support/OSUtil/baremetal/io.cpp
@@ -14,19 +14,7 @@
 
 namespace LIBC_NAMESPACE_DECL {
 
-extern "C" FILE *stdin = reinterpret_cast<FILE *>(&__llvm_libc_stdin_cookie);
-extern "C" FILE *stdout = reinterpret_cast<FILE *>(&__llvm_libc_stdout_cookie);
-extern "C" FILE *stderr = reinterpret_cast<FILE *>(&__llvm_libc_stderr_cookie);
-
-ssize_t read_from_stdin(char *buf, size_t size) {
-  return __llvm_libc_stdio_read(static_cast<void *>(&__llvm_libc_stdin_cookie),
-                                buf, size);
-}
-
-void write_to_stdout(cpp::string_view msg) {
-  __llvm_libc_stdio_write(static_cast<void *>(&__llvm_libc_stdout_cookie),
-                          msg.data(), msg.size());
-}
+extern "C" struct __llvm_libc_stdio_cookie __llvm_libc_stderr_cookie;
 
 void write_to_stderr(cpp::string_view msg) {
   __llvm_libc_stdio_write(static_cast<void *>(&__llvm_libc_stderr_cookie),

--- a/libc/src/__support/OSUtil/baremetal/io.h
+++ b/libc/src/__support/OSUtil/baremetal/io.h
@@ -47,17 +47,11 @@ namespace LIBC_NAMESPACE_DECL {
 
 struct __llvm_libc_stdio_cookie;
 
-extern "C" struct __llvm_libc_stdio_cookie __llvm_libc_stdin_cookie;
-extern "C" struct __llvm_libc_stdio_cookie __llvm_libc_stdout_cookie;
-extern "C" struct __llvm_libc_stdio_cookie __llvm_libc_stderr_cookie;
-
 extern "C" ssize_t __llvm_libc_stdio_read(void *cookie, char *buf, size_t size);
 extern "C" ssize_t __llvm_libc_stdio_write(void *cookie, const char *buf,
                                            size_t size);
 
-ssize_t read_from_stdin(char *buf, size_t size);
 void write_to_stderr(cpp::string_view msg);
-void write_to_stdout(cpp::string_view msg);
 
 } // namespace LIBC_NAMESPACE_DECL
 

--- a/libc/src/__support/common.h
+++ b/libc/src/__support/common.h
@@ -22,6 +22,10 @@
 #define LLVM_LIBC_FUNCTION_ATTR
 #endif
 
+#ifndef LLVM_LIBC_VARIABLE_ATTR
+#define LLVM_LIBC_VARIABLE_ATTR
+#endif
+
 // clang-format off
 // Allow each function `func` to have extra attributes specified by defining:
 // `LLVM_LIBC_FUNCTION_ATTR_func` macro, which should always start with
@@ -63,6 +67,31 @@
 // This extra layer of macro allows `name` to be a macro to rename a function.
 #define LLVM_LIBC_FUNCTION(type, name, arglist)                                \
   LLVM_LIBC_FUNCTION_IMPL(type, name, arglist)
+
+// At the moment, [[gnu::alias()]] is not supported on MacOS, and it is needed
+// to cleanly export and alias the C++ symbol `LIBC_NAMESPACE::func` with the C
+// symbol `func`.  So for public packaging on MacOS, we will only export the C
+// symbol.  Moreover, a C symbol `func` in macOS is mangled as `_func`.
+#if defined(LIBC_COPT_PUBLIC_PACKAGING) && !defined(LIBC_COMPILER_IS_MSVC)
+#ifndef __APPLE__
+#define LLVM_LIBC_VARIABLE_IMPL(type, name)                                    \
+  LLVM_LIBC_ATTR(name)                                                         \
+  extern LLVM_LIBC_VARIABLE_ATTR decltype(LIBC_NAMESPACE::name)                \
+      __##name##_impl__ asm(#name);                                            \
+  extern decltype(LIBC_NAMESPACE::name) name [[gnu::alias(#name)]];            \
+  type __##name##_impl__
+#else // __APPLE__
+#define LLVM_LIBC_VARIABLE_IMPL(type, name)                                    \
+  LLVM_LIBC_ATTR(name)                                                         \
+  extern LLVM_LIBC_VARIABLE_ATTR decltype(LIBC_NAMESPACE::name) name asm(      \
+      "_" #name);                                                              \
+  type name
+#endif // __APPLE__
+#else  // LIBC_COPT_PUBLIC_PACKAGING
+#define LLVM_LIBC_VARIABLE_IMPL(type, name) type name
+#endif // LIBC_COPT_PUBLIC_PACKAGING
+
+#define LLVM_LIBC_VARIABLE(type, name) LLVM_LIBC_VARIABLE_IMPL(type, name)
 
 namespace LIBC_NAMESPACE_DECL {
 namespace internal {

--- a/libc/src/stdio/baremetal/CMakeLists.txt
+++ b/libc/src/stdio/baremetal/CMakeLists.txt
@@ -172,6 +172,7 @@ add_entrypoint_object(
     ../getchar.h
   DEPENDS
     .file_internal
+    .stdin
     libc.hdr.types.FILE
     libc.src.errno.errno
 )
@@ -193,8 +194,8 @@ add_entrypoint_object(
   HDRS
     ../printf.h
   DEPENDS
+    .stdout
     .vfprintf_internal
-    libc.hdr.stdio_macros
     libc.src.__support.arg_list
 )
 
@@ -206,6 +207,7 @@ add_entrypoint_object(
     ../putchar.h
   DEPENDS
     .file_internal
+    .stdout
     libc.hdr.stdio_macros
     libc.src.errno.errno
 )
@@ -218,6 +220,7 @@ add_entrypoint_object(
     ../putc.h
   DEPENDS
     .file_internal
+    .stdout
     libc.hdr.stdio_macros
     libc.hdr.types.FILE
     libc.src.errno.errno
@@ -231,6 +234,7 @@ add_entrypoint_object(
     ../puts.h
   DEPENDS
     .file_internal
+    .stdout
     libc.hdr.stdio_macros
     libc.src.errno.errno
 )
@@ -242,10 +246,41 @@ add_entrypoint_object(
   HDRS
     ../scanf.h
   DEPENDS
+    .stdin
     .vfscanf_internal
     libc.hdr.types.FILE
     libc.hdr.stdio_macros
     libc.src.__support.arg_list
+)
+
+add_entrypoint_object(
+  stdin
+  SRCS
+    stdin.cpp
+  HDRS
+    ../stdin.h
+  DEPENDS
+    libc.hdr.types.FILE
+)
+
+add_entrypoint_object(
+  stdout
+  SRCS
+    stdout.cpp
+  HDRS
+    ../stdout.h
+  DEPENDS
+    libc.hdr.types.FILE
+)
+
+add_entrypoint_object(
+  stderr
+  SRCS
+    stderr.cpp
+  HDRS
+    ../stderr.h
+  DEPENDS
+    libc.hdr.types.FILE
 )
 
 add_entrypoint_object(
@@ -281,6 +316,7 @@ add_entrypoint_object(
   HDRS
     ../vprintf.h
   DEPENDS
+    .stdout
     .vfprintf_internal
     libc.hdr.stdio_macros
     libc.src.__support.arg_list
@@ -293,6 +329,7 @@ add_entrypoint_object(
   HDRS
     ../vscanf.h
   DEPENDS
+    .stdin
     .vfscanf_internal
     libc.hdr.stdio_macros
     libc.src.__support.arg_list

--- a/libc/src/stdio/baremetal/getchar.cpp
+++ b/libc/src/stdio/baremetal/getchar.cpp
@@ -13,6 +13,7 @@
 #include "src/__support/libc_errno.h"
 #include "src/__support/macros/config.h"
 #include "src/stdio/baremetal/file_internal.h"
+#include "src/stdio/stdout.h"
 
 namespace LIBC_NAMESPACE_DECL {
 

--- a/libc/src/stdio/baremetal/printf.cpp
+++ b/libc/src/stdio/baremetal/printf.cpp
@@ -8,11 +8,11 @@
 
 #include "src/stdio/printf.h"
 
-#include "hdr/stdio_macros.h"
 #include "src/__support/arg_list.h"
 #include "src/__support/common.h"
 #include "src/__support/macros/config.h"
 #include "src/stdio/baremetal/vfprintf_internal.h"
+#include "src/stdio/stdout.h"
 
 #include <stdarg.h>
 

--- a/libc/src/stdio/baremetal/putc.cpp
+++ b/libc/src/stdio/baremetal/putc.cpp
@@ -14,6 +14,7 @@
 #include "src/__support/libc_errno.h"
 #include "src/__support/macros/config.h"
 #include "src/stdio/baremetal/file_internal.h"
+#include "src/stdio/stdout.h"
 
 namespace LIBC_NAMESPACE_DECL {
 

--- a/libc/src/stdio/baremetal/putchar.cpp
+++ b/libc/src/stdio/baremetal/putchar.cpp
@@ -13,6 +13,7 @@
 #include "src/__support/libc_errno.h"
 #include "src/__support/macros/config.h"
 #include "src/stdio/baremetal/file_internal.h"
+#include "src/stdio/stdout.h"
 
 namespace LIBC_NAMESPACE_DECL {
 

--- a/libc/src/stdio/baremetal/puts.cpp
+++ b/libc/src/stdio/baremetal/puts.cpp
@@ -13,6 +13,7 @@
 #include "src/__support/libc_errno.h"
 #include "src/__support/macros/config.h"
 #include "src/stdio/baremetal/file_internal.h"
+#include "src/stdio/stdout.h"
 
 namespace LIBC_NAMESPACE_DECL {
 

--- a/libc/src/stdio/baremetal/scanf.cpp
+++ b/libc/src/stdio/baremetal/scanf.cpp
@@ -8,10 +8,10 @@
 
 #include "src/stdio/scanf.h"
 
-#include "hdr/stdio_macros.h"
 #include "src/__support/arg_list.h"
 #include "src/__support/macros/config.h"
 #include "src/stdio/baremetal/vfscanf_internal.h"
+#include "src/stdio/stdout.h"
 
 #include <stdarg.h>
 

--- a/libc/src/stdio/baremetal/stderr.cpp
+++ b/libc/src/stdio/baremetal/stderr.cpp
@@ -1,4 +1,4 @@
-//===-- Definition of the global stderr object ----------------------------===//
+//===--- Definition of baremetal stderr -----------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -6,17 +6,18 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "src/stdio/stdin.h"
+#include "src/stdio/stderr.h"
 
 #include "hdr/types/FILE.h"
+#include "src/__support/OSUtil/baremetal/io.h"
 #include "src/__support/common.h"
 #include "src/__support/macros/config.h"
 
 namespace LIBC_NAMESPACE_DECL {
 
-static struct {
-} stub;
+extern "C" struct __llvm_libc_stdio_cookie __llvm_libc_stderr_cookie;
 
-LLVM_LIBC_VARIABLE(FILE *, stderr) = reinterpret_cast<FILE *>(&stub);
+LLVM_LIBC_VARIABLE(FILE *, stderr) =
+    reinterpret_cast<FILE *>(&__llvm_libc_stderr_cookie);
 
 } // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/stdio/baremetal/stdin.cpp
+++ b/libc/src/stdio/baremetal/stdin.cpp
@@ -1,4 +1,4 @@
-//===-- Definition of the global stderr object ----------------------------===//
+//===--- Definition of baremetal stdin ------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -9,14 +9,15 @@
 #include "src/stdio/stdin.h"
 
 #include "hdr/types/FILE.h"
+#include "src/__support/OSUtil/baremetal/io.h"
 #include "src/__support/common.h"
 #include "src/__support/macros/config.h"
 
 namespace LIBC_NAMESPACE_DECL {
 
-static struct {
-} stub;
+extern "C" struct __llvm_libc_stdio_cookie __llvm_libc_stdin_cookie;
 
-LLVM_LIBC_VARIABLE(FILE *, stderr) = reinterpret_cast<FILE *>(&stub);
+LLVM_LIBC_VARIABLE(FILE *,
+                   stdin) = reinterpret_cast<FILE *>(&__llvm_libc_stdin_cookie);
 
 } // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/stdio/baremetal/stdout.cpp
+++ b/libc/src/stdio/baremetal/stdout.cpp
@@ -1,4 +1,4 @@
-//===-- Definition of the global stderr object ----------------------------===//
+//===--- Definition of baremetal stdout -----------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -6,17 +6,18 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "src/stdio/stdin.h"
+#include "src/stdio/stdout.h"
 
 #include "hdr/types/FILE.h"
+#include "src/__support/OSUtil/baremetal/io.h"
 #include "src/__support/common.h"
 #include "src/__support/macros/config.h"
 
 namespace LIBC_NAMESPACE_DECL {
 
-static struct {
-} stub;
+extern "C" struct __llvm_libc_stdio_cookie __llvm_libc_stdout_cookie;
 
-LLVM_LIBC_VARIABLE(FILE *, stderr) = reinterpret_cast<FILE *>(&stub);
+LLVM_LIBC_VARIABLE(FILE *, stdout) =
+    reinterpret_cast<FILE *>(&__llvm_libc_stdout_cookie);
 
 } // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/stdio/baremetal/vprintf.cpp
+++ b/libc/src/stdio/baremetal/vprintf.cpp
@@ -8,11 +8,11 @@
 
 #include "src/stdio/vprintf.h"
 
-#include "hdr/stdio_macros.h"
 #include "src/__support/arg_list.h"
 #include "src/__support/common.h"
 #include "src/__support/macros/config.h"
 #include "src/stdio/baremetal/vfprintf_internal.h"
+#include "src/stdio/stdout.h"
 
 #include <stdarg.h>
 

--- a/libc/src/stdio/baremetal/vscanf.cpp
+++ b/libc/src/stdio/baremetal/vscanf.cpp
@@ -8,10 +8,10 @@
 
 #include "src/stdio/vscanf.h"
 
-#include "hdr/stdio_macros.h"
 #include "src/__support/arg_list.h"
 #include "src/__support/macros/config.h"
 #include "src/stdio/baremetal/vfscanf_internal.h"
+#include "src/stdio/stdout.h"
 
 #include <stdarg.h>
 

--- a/libc/src/stdio/generic/CMakeLists.txt
+++ b/libc/src/stdio/generic/CMakeLists.txt
@@ -218,7 +218,7 @@ add_generic_entrypoint_object(
     libc.src.__support.CPP.string_view
     libc.src.__support.File.file
     libc.src.__support.File.platform_file
-    libc.src.__support.File.platform_stderr
+    libc.src.stdio.stderr
 )
 
 add_generic_entrypoint_object(
@@ -244,7 +244,7 @@ add_generic_entrypoint_object(
     libc.src.errno.errno
     libc.hdr.types.FILE
     libc.src.__support.File.file
-    libc.src.__support.File.platform_stdout
+    libc.src.stdio.stdout
 )
 
 add_generic_entrypoint_object(
@@ -412,7 +412,7 @@ set(printf_deps ${fprintf_deps})
 
 if(LLVM_LIBC_FULL_BUILD)
   list(APPEND printf_deps
-      libc.src.__support.File.platform_stdout
+      libc.src.stdio.stdout
   )
 endif()
 
@@ -466,7 +466,7 @@ if(LLVM_LIBC_FULL_BUILD AND NOT LIBC_TARGET_OS_IS_GPU)
   list(APPEND scanf_deps
       libc.src.__support.File.file
       libc.src.__support.File.platform_file
-      libc.src.__support.File.platform_stdin
+      libc.src.stdio.stdin
   )
 endif()
 
@@ -544,7 +544,7 @@ add_generic_entrypoint_object(
   DEPENDS
     libc.hdr.types.FILE
     libc.src.__support.File.file
-    libc.src.__support.File.platform_stdin
+    libc.src.stdio.stdin
 )
 
 add_generic_entrypoint_object(
@@ -556,7 +556,7 @@ add_generic_entrypoint_object(
   DEPENDS
     libc.hdr.types.FILE
     libc.src.__support.File.file
-    libc.src.__support.File.platform_stdout
+    libc.src.stdio.stdout
 )
 
 add_generic_entrypoint_object(
@@ -568,5 +568,5 @@ add_generic_entrypoint_object(
   DEPENDS
     libc.hdr.types.FILE
     libc.src.__support.File.file
-    libc.src.__support.File.platform_stderr
+    libc.src.stdio.stderr
 )

--- a/libc/src/stdio/generic/getchar.cpp
+++ b/libc/src/stdio/generic/getchar.cpp
@@ -12,12 +12,14 @@
 #include "hdr/types/FILE.h"
 #include "src/__support/libc_errno.h"
 #include "src/__support/macros/config.h"
+#include "src/stdio/stdin.h"
 
 namespace LIBC_NAMESPACE_DECL {
 
 LLVM_LIBC_FUNCTION(int, getchar, ()) {
   unsigned char c;
-  auto result = stdin->read(&c, 1);
+  auto result = reinterpret_cast<LIBC_NAMESPACE::File *>(LIBC_NAMESPACE::stdin)
+                    ->read(&c, 1);
   if (result.has_error())
     libc_errno = result.error;
 

--- a/libc/src/stdio/generic/getchar_unlocked.cpp
+++ b/libc/src/stdio/generic/getchar_unlocked.cpp
@@ -12,12 +12,14 @@
 #include "hdr/types/FILE.h"
 #include "src/__support/libc_errno.h"
 #include "src/__support/macros/config.h"
+#include "src/stdio/stdin.h"
 
 namespace LIBC_NAMESPACE_DECL {
 
 LLVM_LIBC_FUNCTION(int, getchar_unlocked, ()) {
   unsigned char c;
-  auto result = stdin->read_unlocked(&c, 1);
+  auto result = reinterpret_cast<LIBC_NAMESPACE::File *>(LIBC_NAMESPACE::stdin)
+                    ->read_unlocked(&c, 1);
   if (result.has_error())
     libc_errno = result.error;
 

--- a/libc/src/stdio/generic/perror.cpp
+++ b/libc/src/stdio/generic/perror.cpp
@@ -12,12 +12,16 @@
 #include "src/__support/StringUtil/error_to_string.h"
 #include "src/__support/libc_errno.h"
 #include "src/__support/macros/config.h"
+#include "src/stdio/stderr.h"
+
+#include "hdr/types/FILE.h"
 
 namespace LIBC_NAMESPACE_DECL {
 
-static int write_out(cpp::string_view str_view, File *f) {
+static int write_out(cpp::string_view str_view, ::FILE *f) {
   if (str_view.size() > 0) {
-    auto result = f->write_unlocked(str_view.data(), str_view.size());
+    auto result = reinterpret_cast<LIBC_NAMESPACE::File *>(f)->write_unlocked(
+        str_view.data(), str_view.size());
     if (result.has_error())
       return result.error;
   }
@@ -73,9 +77,10 @@ LLVM_LIBC_FUNCTION(void, perror, (const char *str)) {
   cpp::string_view err_str = get_error_string(libc_errno);
 
   // We need to lock the stream to ensure the newline is always appended.
-  LIBC_NAMESPACE::stderr->lock();
+  LIBC_NAMESPACE::File *file = reinterpret_cast<File *>(stderr);
+  file->lock();
   write_sequence(str_view, err_str);
-  LIBC_NAMESPACE::stderr->unlock();
+  file->unlock();
 }
 
 } // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/stdio/generic/printf.cpp
+++ b/libc/src/stdio/generic/printf.cpp
@@ -15,6 +15,7 @@
 #include "src/stdio/printf_core/core_structs.h"
 #include "src/stdio/printf_core/error_mapper.h"
 #include "src/stdio/printf_core/vfprintf_internal.h"
+#include "src/stdio/stdout.h"
 
 #include "hdr/types/FILE.h"
 #include <stdarg.h>

--- a/libc/src/stdio/generic/putchar.cpp
+++ b/libc/src/stdio/generic/putchar.cpp
@@ -12,6 +12,7 @@
 #include "hdr/types/FILE.h"
 #include "src/__support/libc_errno.h"
 #include "src/__support/macros/config.h"
+#include "src/stdio/stdout.h"
 #include <stddef.h>
 
 namespace LIBC_NAMESPACE_DECL {
@@ -19,7 +20,8 @@ namespace LIBC_NAMESPACE_DECL {
 LLVM_LIBC_FUNCTION(int, putchar, (int c)) {
   unsigned char uc = static_cast<unsigned char>(c);
 
-  auto result = LIBC_NAMESPACE::stdout->write(&uc, 1);
+  auto result = reinterpret_cast<LIBC_NAMESPACE::File *>(LIBC_NAMESPACE::stdout)
+                    ->write(&uc, 1);
   if (result.has_error())
     libc_errno = result.error;
   size_t written = result.value;

--- a/libc/src/stdio/generic/puts.cpp
+++ b/libc/src/stdio/generic/puts.cpp
@@ -13,6 +13,7 @@
 #include "hdr/types/FILE.h"
 #include "src/__support/libc_errno.h"
 #include "src/__support/macros/config.h"
+#include "src/stdio/stdout.h"
 #include <stddef.h>
 
 namespace LIBC_NAMESPACE_DECL {
@@ -33,10 +34,11 @@ private:
 LLVM_LIBC_FUNCTION(int, puts, (const char *__restrict str)) {
   cpp::string_view str_view(str);
 
+  LIBC_NAMESPACE::File *file = reinterpret_cast<File *>(stdout);
   // We need to lock the stream to ensure the newline is always appended.
-  ScopedLock lock(LIBC_NAMESPACE::stdout);
+  ScopedLock lock(file);
 
-  auto result = LIBC_NAMESPACE::stdout->write_unlocked(str, str_view.size());
+  auto result = file->write_unlocked(str, str_view.size());
   if (result.has_error())
     libc_errno = result.error;
   size_t written = result.value;
@@ -44,7 +46,7 @@ LLVM_LIBC_FUNCTION(int, puts, (const char *__restrict str)) {
     // The stream should be in an error state in this case.
     return EOF;
   }
-  result = LIBC_NAMESPACE::stdout->write_unlocked("\n", 1);
+  result = file->write_unlocked("\n", 1);
   if (result.has_error())
     libc_errno = result.error;
   written = result.value;

--- a/libc/src/stdio/generic/scanf.cpp
+++ b/libc/src/stdio/generic/scanf.cpp
@@ -12,6 +12,7 @@
 #include "src/__support/arg_list.h"
 #include "src/__support/macros/config.h"
 #include "src/stdio/scanf_core/vfscanf_internal.h"
+#include "src/stdio/stdin.h"
 
 #include "hdr/types/FILE.h"
 #include <stdarg.h>

--- a/libc/src/stdio/generic/vprintf.cpp
+++ b/libc/src/stdio/generic/vprintf.cpp
@@ -15,6 +15,7 @@
 #include "src/stdio/printf_core/core_structs.h"
 #include "src/stdio/printf_core/error_mapper.h"
 #include "src/stdio/printf_core/vfprintf_internal.h"
+#include "src/stdio/stdout.h"
 
 #include "hdr/types/FILE.h"
 #include <stdarg.h>

--- a/libc/src/stdio/generic/vscanf.cpp
+++ b/libc/src/stdio/generic/vscanf.cpp
@@ -12,6 +12,7 @@
 #include "src/__support/arg_list.h"
 #include "src/__support/macros/config.h"
 #include "src/stdio/scanf_core/vfscanf_internal.h"
+#include "src/stdio/stdin.h"
 
 #include "hdr/types/FILE.h"
 #include <stdarg.h>

--- a/libc/src/stdio/gpu/stdin.cpp
+++ b/libc/src/stdio/gpu/stdin.cpp
@@ -6,12 +6,17 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "src/stdio/stdin.h"
+
 #include "hdr/types/FILE.h"
 #include "src/__support/common.h"
+#include "src/__support/macros/config.h"
 
 namespace LIBC_NAMESPACE_DECL {
+
 static struct {
 } stub;
-FILE *stdin = reinterpret_cast<FILE *>(&stub);
+
+LLVM_LIBC_VARIABLE(FILE *, stdin) = reinterpret_cast<FILE *>(&stub);
+
 } // namespace LIBC_NAMESPACE_DECL
-extern "C" FILE *stdin = reinterpret_cast<FILE *>(&LIBC_NAMESPACE::stub);

--- a/libc/src/stdio/gpu/stdout.cpp
+++ b/libc/src/stdio/gpu/stdout.cpp
@@ -6,12 +6,17 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "src/stdio/stdout.h"
+
 #include "hdr/types/FILE.h"
 #include "src/__support/common.h"
+#include "src/__support/macros/config.h"
 
 namespace LIBC_NAMESPACE_DECL {
+
 static struct {
 } stub;
-FILE *stdout = reinterpret_cast<FILE *>(&stub);
+
+LLVM_LIBC_VARIABLE(FILE *, stdout) = reinterpret_cast<FILE *>(&stub);
+
 } // namespace LIBC_NAMESPACE_DECL
-extern "C" FILE *stdout = reinterpret_cast<FILE *>(&LIBC_NAMESPACE::stub);

--- a/libc/src/stdio/linux/CMakeLists.txt
+++ b/libc/src/stdio/linux/CMakeLists.txt
@@ -35,3 +35,33 @@ add_entrypoint_object(
     libc.src.__support.File.file
     libc.src.__support.File.platform_file
 )
+
+add_entrypoint_object(
+  stdin
+  SRCS
+    stdin.cpp
+  HDRS
+    ../stdin.h
+  DEPENDS
+    libc.hdr.types.FILE
+)
+
+add_entrypoint_object(
+  stdout
+  SRCS
+    stdout.cpp
+  HDRS
+    ../stdout.h
+  DEPENDS
+    libc.hdr.types.FILE
+)
+
+add_entrypoint_object(
+  stderr
+  SRCS
+    stderr.cpp
+  HDRS
+    ../stderr.h
+  DEPENDS
+    libc.hdr.types.FILE
+)

--- a/libc/src/stdio/linux/CMakeLists.txt
+++ b/libc/src/stdio/linux/CMakeLists.txt
@@ -44,6 +44,7 @@ add_entrypoint_object(
     ../stdin.h
   DEPENDS
     libc.hdr.types.FILE
+    libc.src.__support.File.platform_file
 )
 
 add_entrypoint_object(
@@ -54,6 +55,7 @@ add_entrypoint_object(
     ../stdout.h
   DEPENDS
     libc.hdr.types.FILE
+    libc.src.__support.File.platform_file
 )
 
 add_entrypoint_object(
@@ -64,4 +66,5 @@ add_entrypoint_object(
     ../stderr.h
   DEPENDS
     libc.hdr.types.FILE
+    libc.src.__support.File.platform_file
 )

--- a/libc/src/stdio/linux/stderr.cpp
+++ b/libc/src/stdio/linux/stderr.cpp
@@ -1,4 +1,4 @@
-//===--- Definition of Linux stdout ---------------------------------------===//
+//===--- Definition of Linux stderr ---------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -6,21 +6,19 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "file.h"
-#include "hdr/stdio_macros.h"
+#include "src/stdio/stderr.h"
+
 #include "hdr/types/FILE.h"
+#include "src/__support/File/linux/file.h"
+#include "src/__support/common.h"
 #include "src/__support/macros/config.h"
 
 namespace LIBC_NAMESPACE_DECL {
 
-constexpr size_t STDOUT_BUFFER_SIZE = 1024;
-uint8_t stdout_buffer[STDOUT_BUFFER_SIZE];
-static LinuxFile StdOut(1, stdout_buffer, STDOUT_BUFFER_SIZE, _IOLBF, false,
+constexpr size_t STDERR_BUFFER_SIZE = 0;
+static LinuxFile StdErr(2, nullptr, STDERR_BUFFER_SIZE, _IONBF, false,
                         File::ModeFlags(File::OpenMode::APPEND));
-File *stdout = &StdOut;
+
+LLVM_LIBC_VARIABLE(FILE *, stderr) = reinterpret_cast<FILE *>(&StdErr);
 
 } // namespace LIBC_NAMESPACE_DECL
-
-extern "C" {
-FILE *stdout = reinterpret_cast<FILE *>(&LIBC_NAMESPACE::StdOut);
-} // extern "C"

--- a/libc/src/stdio/linux/stdin.cpp
+++ b/libc/src/stdio/linux/stdin.cpp
@@ -6,9 +6,11 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "file.h"
-#include "hdr/stdio_macros.h"
+#include "src/stdio/stdin.h"
+
 #include "hdr/types/FILE.h"
+#include "src/__support/File/linux/file.h"
+#include "src/__support/common.h"
 #include "src/__support/macros/config.h"
 
 namespace LIBC_NAMESPACE_DECL {
@@ -17,10 +19,7 @@ constexpr size_t STDIN_BUFFER_SIZE = 512;
 uint8_t stdin_buffer[STDIN_BUFFER_SIZE];
 static LinuxFile StdIn(0, stdin_buffer, STDIN_BUFFER_SIZE, _IOFBF, false,
                        File::ModeFlags(File::OpenMode::READ));
-File *stdin = &StdIn;
+
+LLVM_LIBC_VARIABLE(FILE *, stdin) = reinterpret_cast<FILE *>(&StdIn);
 
 } // namespace LIBC_NAMESPACE_DECL
-
-extern "C" {
-FILE *stdin = reinterpret_cast<FILE *>(&LIBC_NAMESPACE::StdIn);
-} // extern "C"

--- a/libc/src/stdio/linux/stdout.cpp
+++ b/libc/src/stdio/linux/stdout.cpp
@@ -1,4 +1,4 @@
-//===--- Definition of Linux stderr ---------------------------------------===//
+//===--- Definition of Linux stdout ---------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -6,20 +6,20 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "file.h"
-#include "hdr/stdio_macros.h"
+#include "src/stdio/stdout.h"
+
 #include "hdr/types/FILE.h"
+#include "src/__support/File/linux/file.h"
+#include "src/__support/common.h"
 #include "src/__support/macros/config.h"
 
 namespace LIBC_NAMESPACE_DECL {
 
-constexpr size_t STDERR_BUFFER_SIZE = 0;
-static LinuxFile StdErr(2, nullptr, STDERR_BUFFER_SIZE, _IONBF, false,
+constexpr size_t STDOUT_BUFFER_SIZE = 1024;
+uint8_t stdout_buffer[STDOUT_BUFFER_SIZE];
+static LinuxFile StdOut(1, stdout_buffer, STDOUT_BUFFER_SIZE, _IOLBF, false,
                         File::ModeFlags(File::OpenMode::APPEND));
-File *stderr = &StdErr;
+
+LLVM_LIBC_VARIABLE(FILE *, stdout) = reinterpret_cast<FILE *>(&StdOut);
 
 } // namespace LIBC_NAMESPACE_DECL
-
-extern "C" {
-FILE *stderr = reinterpret_cast<FILE *>(&LIBC_NAMESPACE::StdErr);
-}

--- a/libc/src/stdio/stderr.h
+++ b/libc/src/stdio/stderr.h
@@ -1,4 +1,4 @@
-//===------------------------------------------------------------*- C++ -*-===//
+//===--- Implementation header for stderr -----------------------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -6,4 +6,16 @@
 //
 //===----------------------------------------------------------------------===//
 
-#error "Do not include this file. Instead include __support/File/file.h."
+#ifndef LLVM_LIBC_SRC_STDIO_STDERR_H
+#define LLVM_LIBC_SRC_STDIO_STDERR_H
+
+#include "hdr/types/FILE.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+extern FILE *stderr;
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_STDIO_STDERR_H

--- a/libc/src/stdio/stdin.h
+++ b/libc/src/stdio/stdin.h
@@ -1,4 +1,4 @@
-//===------------------------------------------------------------*- C++ -*-===//
+//===--- Implementation header for stdin ------------------------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -6,4 +6,16 @@
 //
 //===----------------------------------------------------------------------===//
 
-#error "Do not include this file. Instead include __support/File/file.h."
+#ifndef LLVM_LIBC_SRC_STDIO_STDIN_H
+#define LLVM_LIBC_SRC_STDIO_STDIN_H
+
+#include "hdr/types/FILE.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+extern FILE *stdin;
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_STDIO_STDIN_H

--- a/libc/src/stdio/stdout.h
+++ b/libc/src/stdio/stdout.h
@@ -1,4 +1,4 @@
-//===------------------------------------------------------------*- C++ -*-===//
+//===--- Implementation header for stdout -----------------------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -6,4 +6,16 @@
 //
 //===----------------------------------------------------------------------===//
 
-#error "Do not include this file. Instead include __support/File/file.h."
+#ifndef LLVM_LIBC_SRC_STDIO_STDOUT_H
+#define LLVM_LIBC_SRC_STDIO_STDOUT_H
+
+#include "hdr/types/FILE.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+extern FILE *stdout;
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_STDIO_STDOUT_H

--- a/libc/src/unistd/CMakeLists.txt
+++ b/libc/src/unistd/CMakeLists.txt
@@ -362,8 +362,8 @@ add_entrypoint_object(
     libc.src.__support.CPP.optional
     libc.src.__support.CPP.string_view
     libc.src.__support.File.file
-    libc.src.__support.File.platform_stderr
     libc.src.stdio.fprintf
+    libc.src.stdio.stderr
 )
 
 add_entrypoint_object(

--- a/libc/src/unistd/getopt.cpp
+++ b/libc/src/unistd/getopt.cpp
@@ -13,6 +13,7 @@
 #include "src/__support/common.h"
 #include "src/__support/macros/config.h"
 #include "src/stdio/fprintf.h"
+#include "src/stdio/stderr.h"
 
 #include "hdr/types/FILE.h"
 

--- a/libc/test/src/stdio/fputc_test.cpp
+++ b/libc/test/src/stdio/fputc_test.cpp
@@ -9,6 +9,7 @@
 #include "src/__support/File/file.h"
 #include "src/stdio/fputc.h"
 #include "src/stdio/putchar.h"
+#include "src/stdio/stderr.h"
 
 #include "test/UnitTest/Test.h"
 

--- a/libc/test/src/stdio/fputs_test.cpp
+++ b/libc/test/src/stdio/fputs_test.cpp
@@ -8,6 +8,8 @@
 
 #include "src/__support/File/file.h"
 #include "src/stdio/fputs.h"
+#include "src/stdio/stderr.h"
+#include "src/stdio/stdout.h"
 
 #include "test/UnitTest/Test.h"
 


### PR DESCRIPTION
The standard streams should be defined the same as other public symbols, even though they're variables rather than functions: we should have public and private symbol which are aliases, and all internal uses should use the private symbol to avoid GOT relocations.

This change introduces a new macro `LLVM_LIBC_VARIABLE` which is the equivalent of `LLVM_LIBC_FUNCTION` and it refactors the existing definitions of standard streams for BareMetal, Linux and GPU to use this macro.