### PR TITLE
[MemProf] Add stack IDs to MemProfUse optimization remarks

### DIFF
--- a/llvm/lib/Transforms/Instrumentation/MemProfUse.cpp
+++ b/llvm/lib/Transforms/Instrumentation/MemProfUse.cpp
@@ -603,11 +603,15 @@ static void handleCallSite(Instruction &I, const Function *CalledFunction,
           append_range(CallStack, InlinedCallStack);
           MatchedCallSites.insert(std::move(CallStack));
         }
-        ORE.emit(OptimizationRemark(DEBUG_TYPE, "MemProfUse", &I)
-                 << ore::NV("CallSite", &I) << " in function "
-                 << ore::NV("Caller", I.getFunction())
-                 << " matched callsite with frame count "
-                 << ore::NV("Frames", InlinedCallStack.size()));
+        OptimizationRemark Remark(DEBUG_TYPE, "MemProfUse", &I);
+        Remark << ore::NV("CallSite", &I) << " in function "
+               << ore::NV("Caller", I.getFunction())
+               << " matched callsite with frame count "
+               << ore::NV("Frames", InlinedCallStack.size())
+               << " and stack ids";
+        for (uint64_t StackId : InlinedCallStack)
+          Remark << " " << ore::NV("StackId", StackId);
+        ORE.emit(Remark);
 
         // If this is a direct call, we're done.
         if (CalledFunction)

--- a/llvm/test/Transforms/PGOProfile/memprof-dump-matched-call-sites.ll
+++ b/llvm/test/Transforms/PGOProfile/memprof-dump-matched-call-sites.ll
@@ -73,8 +73,8 @@ HeapProfileRecords:
 ;--- memprof-dump-matched-call-site.ll
 
 ;; From -pass-remarks=memprof
-; CHECK: remark: match.cc:18:3: call in function main matched callsite with frame count 1
-; CHECK: remark: match.cc:13:28: call in function _ZL2f1v matched callsite with frame count 2
+; CHECK: remark: match.cc:18:3: call in function main matched callsite with frame count 1 and stack ids 5401059281181789382
+; CHECK: remark: match.cc:13:28: call in function _ZL2f1v matched callsite with frame count 2 and stack ids 4745611964195289084 10616861955219347331
 
 ;; From -memprof-print-match-info
 ; CHECK: MemProf notcold context with id 3894143216621363392 has total profiled size 4 is matched with 1 frames


### PR DESCRIPTION
This makes the remarks more equivalent for analysis to what we emit to
stderr under -memprof-print-match-info.
