### PR TITLE
[clang-doc] Sort index and avoid non-determinism

### DIFF
--- a/clang-tools-extra/clang-doc/JSONGenerator.cpp
+++ b/clang-tools-extra/clang-doc/JSONGenerator.cpp
@@ -838,6 +838,7 @@ static std::vector<Index> preprocessCDCtxIndex(Index CDCtxIndex) {
     Processed.push_back(Entry.second);
   }
 
+  llvm::sort(Processed);
   return Processed;
 }
 

--- a/clang-tools-extra/clang-doc/JSONGenerator.cpp
+++ b/clang-tools-extra/clang-doc/JSONGenerator.cpp
@@ -829,16 +829,16 @@ static std::vector<Index> preprocessCDCtxIndex(Index CDCtxIndex) {
   CDCtxIndex.sort();
   std::vector<Index> Processed;
   Processed.reserve(CDCtxIndex.Children.size());
-  for (auto &Entry : CDCtxIndex.Children) {
-    auto NewPath = Entry.second.getRelativeFilePath("");
+  for (const auto *Idx : CDCtxIndex.getSortedChildren()) {
+    Index NewIdx = *Idx;
+    auto NewPath = NewIdx.getRelativeFilePath("");
     sys::path::native(NewPath, sys::path::Style::posix);
     sys::path::append(NewPath, sys::path::Style::posix,
-                      Entry.second.getFileBaseName() + ".md");
-    Entry.second.Path = NewPath;
-    Processed.push_back(Entry.second);
+                      NewIdx.getFileBaseName() + ".md");
+    NewIdx.Path = NewPath;
+    Processed.push_back(NewIdx);
   }
 
-  llvm::sort(Processed);
   return Processed;
 }
 
@@ -885,11 +885,7 @@ static Error serializeIndex(const ClangDocContext &CDCtx, StringRef RootDir,
     IndexArrayRef.reserve(CDCtx.Idx.Children.size());
   }
 
-  llvm::SmallVector<const Index *> Children;
-  Children.reserve(IndexCopy.Children.size());
-  for (const auto &[_, Idx] : IndexCopy.Children)
-    Children.push_back(&Idx);
-  llvm::sort(Children, [](const Index *A, const Index *B) { return *A < *B; });
+  auto Children = IndexCopy.getSortedChildren();
 
   for (const auto *Idx : Children) {
     if (Idx->Children.empty())

--- a/clang-tools-extra/clang-doc/MDGenerator.cpp
+++ b/clang-tools-extra/clang-doc/MDGenerator.cpp
@@ -339,12 +339,7 @@ static llvm::Error serializeIndex(ClangDocContext &CDCtx) {
     OS << " for " << CDCtx.ProjectName;
   OS << "\n\n";
 
-  std::vector<const Index *> Children;
-  Children.reserve(CDCtx.Idx.Children.size());
-  for (const auto &[_, C] : CDCtx.Idx.Children)
-    Children.push_back(&C);
-  llvm::sort(Children, [](const Index *A, const Index *B) { return *A < *B; });
-
+  std::vector<const Index *> Children = CDCtx.Idx.getSortedChildren();
   for (const auto *C : Children)
     serializeReference(OS, *C, 0);
 
@@ -363,11 +358,7 @@ static llvm::Error genIndex(ClangDocContext &CDCtx) {
                                        FileErr.message());
   CDCtx.Idx.sort();
   OS << "# " << CDCtx.ProjectName << " C/C++ Reference\n\n";
-  std::vector<const Index *> Children;
-  Children.reserve(CDCtx.Idx.Children.size());
-  for (const auto &[_, C] : CDCtx.Idx.Children)
-    Children.push_back(&C);
-  llvm::sort(Children, [](const Index *A, const Index *B) { return *A < *B; });
+  std::vector<const Index *> Children = CDCtx.Idx.getSortedChildren();
   for (const auto *C : Children) {
     if (!C->Children.empty()) {
       const char *Type;

--- a/clang-tools-extra/clang-doc/Representation.cpp
+++ b/clang-tools-extra/clang-doc/Representation.cpp
@@ -472,6 +472,16 @@ bool Index::operator<(const Index &Other) const {
   return Name.size() < Other.Name.size();
 }
 
+std::vector<const Index *> Index::getSortedChildren() const {
+  std::vector<const Index *> SortedChildren;
+  SortedChildren.reserve(Children.size());
+  for (const auto &[_, C] : Children)
+    SortedChildren.push_back(&C);
+  llvm::sort(SortedChildren,
+             [](const Index *A, const Index *B) { return *A < *B; });
+  return SortedChildren;
+}
+
 void Index::sort() {
   for (auto &[_, C] : Children)
     C.sort();

--- a/clang-tools-extra/clang-doc/Representation.h
+++ b/clang-tools-extra/clang-doc/Representation.h
@@ -616,6 +616,7 @@ struct Index : public Reference {
   std::optional<SmallString<16>> JumpToSection;
   llvm::StringMap<Index> Children;
 
+  std::vector<const Index *> getSortedChildren() const;
   void sort();
 };
 

--- a/clang-tools-extra/test/clang-doc/namespace.cpp
+++ b/clang-tools-extra/test/clang-doc/namespace.cpp
@@ -363,12 +363,11 @@ class ClassInAnotherNamespace {};
 // MD-ALL-FILES: ## [GlobalNamespace](GlobalNamespace{{[\/]}}index.md)
 // MD-ALL-FILES: ## [PrimaryNamespace](PrimaryNamespace{{[\/]}}index.md)
 
-// COM: FIXME: The output from the sorted index should be deterministic.
 // MD-MUSTACHE-ALL-FILES: # All Files
-// MD-MUSTACHE-ALL-FILES-DAG: ## [GlobalNamespace](GlobalNamespace{{[\/]}}index.md)
-// MD-MUSTACHE-ALL-FILES-DAG: ## [PrimaryNamespace](PrimaryNamespace{{[\/]}}index.md)
-// MD-MUSTACHE-ALL-FILES-DAG: ## [@nonymous_namespace](@nonymous_namespace{{[\/]}}index.md)
-// MD-MUSTACHE-ALL-FILES-DAG: ## [AnotherNamespace](AnotherNamespace{{[\/]}}index.md)
+// MD-MUSTACHE-ALL-FILES: ## [@nonymous_namespace](@nonymous_namespace{{[\/]}}index.md)
+// MD-MUSTACHE-ALL-FILES: ## [AnotherNamespace](AnotherNamespace{{[\/]}}index.md)
+// MD-MUSTACHE-ALL-FILES: ## [GlobalNamespace](GlobalNamespace{{[\/]}}index.md)
+// MD-MUSTACHE-ALL-FILES: ## [PrimaryNamespace](PrimaryNamespace{{[\/]}}index.md)
 
 // MD-INDEX: #  C/C++ Reference
 // MD-INDEX: * Namespace: [@nonymous_namespace](@nonymous_namespace)


### PR DESCRIPTION
Consolidate logic to get sorted children from  StringMap. 
Using the new API makes it more natural to not miss cases,
where we missed sorting the children directly.

This also allows us to remove -DAG checks from tests and have
deterministic ordering. 
