### PR TITLE
[clangd][NFC] Add RefKind::Call into RefKind::All and insertion operator

### DIFF
--- a/clang-tools-extra/clangd/index/Ref.cpp
+++ b/clang-tools-extra/clangd/index/Ref.cpp
@@ -15,8 +15,8 @@ namespace clangd {
 llvm::raw_ostream &operator<<(llvm::raw_ostream &OS, RefKind K) {
   if (K == RefKind::Unknown)
     return OS << "Unknown";
-  static constexpr std::array<const char *, 4> Messages = {"Decl", "Def", "Ref",
-                                                           "Spelled"};
+  static constexpr std::array<const char *, 5> Messages = {"Decl", "Def", "Ref",
+                                                           "Spelled", "Call"};
   bool VisitedOnce = false;
   for (unsigned I = 0; I < Messages.size(); ++I) {
     if (static_cast<uint8_t>(K) & 1u << I) {

--- a/clang-tools-extra/clangd/index/Ref.h
+++ b/clang-tools-extra/clangd/index/Ref.h
@@ -66,7 +66,7 @@ enum class RefKind : uint8_t {
   // A reference which is a call. Used as a filter for which references
   // to store in data structures used for computing outgoing calls.
   Call = 1 << 4,
-  All = Declaration | Definition | Reference | Spelled,
+  All = Declaration | Definition | Reference | Spelled | Call,
 };
 
 inline RefKind operator|(RefKind L, RefKind R) {


### PR DESCRIPTION
Without this patch:
- RefKind output doesn't show RefKind::Call bit.
- RefKind::Call isn't included in RefKind::All.

I don't think these changes require additional tests, as the problems above mainly appear during testing/debugging (e.g. if in tests comparison of two RefKinds fails, `Call` isn't shown in the output even if this bit is set).