### PR TITLE
[mlir][bytecode] Add builtin dialect version

### DIFF
--- a/mlir/include/mlir/Bytecode/BytecodeImplementation.h
+++ b/mlir/include/mlir/Bytecode/BytecodeImplementation.h
@@ -50,6 +50,9 @@ public:
   /// Emit an error to the reader.
   virtual InFlightDiagnostic emitError(const Twine &msg = {}) const = 0;
 
+  /// Emit a warning to the reader.
+  virtual InFlightDiagnostic emitWarning(const Twine &msg = {}) const = 0;
+
   /// Retrieve the dialect version by name if available.
   virtual FailureOr<const DialectVersion *>
   getDialectVersion(StringRef dialectName) const = 0;

--- a/mlir/include/mlir/IR/BuiltinDialect.h
+++ b/mlir/include/mlir/IR/BuiltinDialect.h
@@ -14,7 +14,27 @@
 #ifndef MLIR_IR_BUILTINDIALECT_H_
 #define MLIR_IR_BUILTINDIALECT_H_
 
+#include "mlir/Bytecode/BytecodeImplementation.h"
 #include "mlir/IR/Dialect.h"
+
+//===----------------------------------------------------------------------===//
+// BuiltinDialectVersion
+//===----------------------------------------------------------------------===//
+
+struct BuiltinDialectVersion : public mlir::DialectVersion {
+  BuiltinDialectVersion(int64_t version) : version(version) {}
+
+  int64_t getVersion() const { return version; }
+
+  static BuiltinDialectVersion getCurrentVersion() { return {0}; }
+
+  bool operator<(const BuiltinDialectVersion &other) const {
+    return version < other.version;
+  }
+
+private:
+  int64_t version;
+};
 
 //===----------------------------------------------------------------------===//
 // Dialect

--- a/mlir/include/mlir/IR/BuiltinDialect.td
+++ b/mlir/include/mlir/IR/BuiltinDialect.td
@@ -24,6 +24,9 @@ def Builtin_Dialect : Dialect {
   let useDefaultAttributePrinterParser = 0;
   let useDefaultTypePrinterParser = 0;
   let extraClassDeclaration = [{
+    std::optional<BuiltinDialectVersion> getVersion() const { return version; }
+    void setVersion(std::optional<BuiltinDialectVersion> v) { version = v; }
+
   private:
     // Register the builtin Attributes.
     void registerAttributes();
@@ -32,7 +35,7 @@ def Builtin_Dialect : Dialect {
     // Register the builtin Types.
     void registerTypes();
 
-  public:
+    std::optional<BuiltinDialectVersion> version;
   }];
 
 }

--- a/mlir/lib/Bytecode/Reader/BytecodeReader.cpp
+++ b/mlir/lib/Bytecode/Reader/BytecodeReader.cpp
@@ -144,6 +144,13 @@ public:
   }
   InFlightDiagnostic emitError() const { return ::emitError(fileLoc); }
 
+  /// Emit a warning using the given arguments.
+  template <typename... Args>
+  InFlightDiagnostic emitWarning(Args &&...args) const {
+    return ::emitWarning(fileLoc).append(std::forward<Args>(args)...);
+  }
+  InFlightDiagnostic emitWarning() const { return ::emitWarning(fileLoc); }
+
   /// Parse a single byte from the stream.
   template <typename T>
   LogicalResult parseByte(T &value) {
@@ -1034,6 +1041,10 @@ public:
 
   InFlightDiagnostic emitError(const Twine &msg) const override {
     return reader.emitError(msg);
+  }
+
+  InFlightDiagnostic emitWarning(const Twine &msg) const override {
+    return reader.emitWarning(msg);
   }
 
   FailureOr<const DialectVersion *>

--- a/mlir/lib/IR/BuiltinDialectBytecode.cpp
+++ b/mlir/lib/IR/BuiltinDialectBytecode.cpp
@@ -239,6 +239,41 @@ struct BuiltinDialectBytecodeInterface : public BytecodeDialectInterface {
                           DialectBytecodeWriter &writer) const override {
     return ::writeType(type, writer);
   }
+
+  //===--------------------------------------------------------------------===//
+  // Version
+
+  void writeVersion(DialectBytecodeWriter &writer) const override {
+    auto configVersion = writer.getDialectVersion(getDialect()->getNamespace());
+    // Write version set in config.
+    if (succeeded(configVersion)) {
+      auto *version =
+          static_cast<const BuiltinDialectVersion *>(*configVersion);
+      writer.writeVarInt(static_cast<uint64_t>(version->getVersion()));
+      return;
+    }
+    // Else, write current set version version if not 0.
+    if (auto version = cast<BuiltinDialect>(getDialect())->getVersion();
+        version && version->getVersion() > 0) {
+      writer.writeVarInt(static_cast<uint64_t>(version->getVersion()));
+    }
+  }
+
+  std::unique_ptr<DialectVersion>
+  readVersion(DialectBytecodeReader &reader) const override {
+    uint64_t version;
+    if (failed(reader.readVarInt(version)))
+      return nullptr;
+
+    auto dialectVersion = std::make_unique<BuiltinDialectVersion>(version);
+    if (BuiltinDialectVersion::getCurrentVersion() < *dialectVersion) {
+      reader.emitWarning()
+          << "reading newer builtin dialect version than supported";
+      return nullptr;
+    }
+
+    return dialectVersion;
+  }
 };
 } // namespace
 

--- a/mlir/lib/IR/BuiltinDialectBytecode.cpp
+++ b/mlir/lib/IR/BuiltinDialectBytecode.cpp
@@ -267,7 +267,7 @@ struct BuiltinDialectBytecodeInterface : public BytecodeDialectInterface {
 
     auto dialectVersion = std::make_unique<BuiltinDialectVersion>(version);
     if (BuiltinDialectVersion::getCurrentVersion() < *dialectVersion) {
-      reader.emitWarning()
+      reader.emitError()
           << "reading newer builtin dialect version than supported";
       return nullptr;
     }

--- a/mlir/unittests/IR/BuiltinDialectVersionTest.cpp
+++ b/mlir/unittests/IR/BuiltinDialectVersionTest.cpp
@@ -1,0 +1,56 @@
+//===- BuiltinDialectVersionTest.cpp - Test builtin dialect versioning ----===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "gtest/gtest.h"
+
+#include "mlir/Bytecode/BytecodeWriter.h"
+#include "mlir/IR/BuiltinDialect.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/Diagnostics.h"
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/Parser/Parser.h"
+
+using namespace mlir;
+
+TEST(BuiltinDialectVersionTest, RejectFutureVersion) {
+  MLIRContext ctx;
+  auto module = ModuleOp::create(UnknownLoc::get(&ctx));
+
+  auto writeBytecode = [&](std::string &out,
+                           std::optional<int64_t> version =
+                               std::nullopt) -> LogicalResult {
+    BytecodeWriterConfig config;
+    if (version)
+      config.setDialectVersion<BuiltinDialect>(
+          std::make_unique<BuiltinDialectVersion>(*version));
+    llvm::raw_string_ostream os(out);
+    return writeBytecodeToFile(module, os, config);
+  };
+
+  std::string bytecode;
+  ASSERT_TRUE(succeeded(writeBytecode(bytecode)));
+  std::string bytecodeWithFutureVersion;
+  ASSERT_TRUE(succeeded(writeBytecode(bytecodeWithFutureVersion, 99)));
+
+  EXPECT_NE(bytecode, bytecodeWithFutureVersion);
+
+  std::string warning;
+  ScopedDiagnosticHandler handler(&ctx, [&](Diagnostic &diag) {
+    if (diag.getSeverity() == DiagnosticSeverity::Warning)
+      warning = diag.str();
+    return success();
+  });
+
+  auto parsed =
+      parseSourceString(StringRef(bytecodeWithFutureVersion),
+                        ParserConfig(&ctx, /*verifyAfterParse=*/true));
+  EXPECT_TRUE(warning.find("reading newer builtin dialect version") !=
+              std::string::npos);
+
+  module->erase();
+}

--- a/mlir/unittests/IR/BuiltinDialectVersionTest.cpp
+++ b/mlir/unittests/IR/BuiltinDialectVersionTest.cpp
@@ -39,17 +39,17 @@ TEST(BuiltinDialectVersionTest, RejectFutureVersion) {
 
   EXPECT_NE(bytecode, bytecodeWithFutureVersion);
 
-  std::string warning;
+  std::string error;
   ScopedDiagnosticHandler handler(&ctx, [&](Diagnostic &diag) {
-    if (diag.getSeverity() == DiagnosticSeverity::Warning)
-      warning = diag.str();
+    if (diag.getSeverity() == DiagnosticSeverity::Error)
+      error = diag.str();
     return success();
   });
 
   auto parsed =
       parseSourceString(StringRef(bytecodeWithFutureVersion),
                         ParserConfig(&ctx, /*verifyAfterParse=*/true));
-  EXPECT_TRUE(warning.find("reading newer builtin dialect version") !=
+  EXPECT_TRUE(error.find("reading newer builtin dialect version") !=
               std::string::npos);
 
   module->erase();

--- a/mlir/unittests/IR/CMakeLists.txt
+++ b/mlir/unittests/IR/CMakeLists.txt
@@ -29,5 +29,6 @@ add_mlir_unittest(MLIRIRTests
 )
 target_include_directories(MLIRIRTests PRIVATE "${MLIR_BINARY_DIR}/test/lib/Dialect/Test")
 mlir_target_link_libraries(MLIRIRTests PRIVATE MLIRIR)
+target_link_libraries(MLIRIRTests PRIVATE MLIRBytecodeWriter)
 target_link_libraries(MLIRIRTests PRIVATE MLIRTestDialect)
 target_link_libraries(MLIRIRTests PRIVATE MLIRRemarkStreamer)

--- a/mlir/unittests/IR/CMakeLists.txt
+++ b/mlir/unittests/IR/CMakeLists.txt
@@ -4,6 +4,7 @@ add_mlir_unittest(MLIRIRTests
   AffineMapTest.cpp
   AttributeTest.cpp
   AttrTypeReplacerTest.cpp
+  BuiltinDialectVersionTest.cpp
   Diagnostic.cpp
   DialectTest.cpp
   DistinctAttributeAllocatorTest.cpp

--- a/utils/bazel/llvm-project-overlay/mlir/unittests/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/mlir/unittests/BUILD.bazel
@@ -41,6 +41,7 @@ cc_test(
         "//llvm:Remarks",
         "//llvm:Support",
         "//mlir:BytecodeReader",
+        "//mlir:BytecodeWriter",
         "//mlir:CallOpInterfaces",
         "//mlir:FunctionInterfaces",
         "//mlir:IR",


### PR DESCRIPTION
This adds a singular Builtin dialect version for use with bytecode serialization. This version is not currently print unless set and not 0 (not planned a bump until next LLVM version). Created a unit test as this was easiest way to track.

Additionally add emitWarning virtual method to DialectBytecodeReader, mirroring emitError.

Tested on old mlir-opt reader, and could read, so should be non-breaking change.