### PR TITLE
[LLDB] Allow symbols added by linker scripts to be examined.

### DIFF
--- a/lldb/source/Plugins/ObjectFile/ELF/ObjectFileELF.cpp
+++ b/lldb/source/Plugins/ObjectFile/ELF/ObjectFileELF.cpp
@@ -2434,7 +2434,10 @@ ObjectFileELF::ParseSymbols(Symtab *symtab, user_id_t start_id,
                    sect_name == rodata1_section_name ||
                    sect_name == bss_section_name) {
           symbol_type = eSymbolTypeData;
-        }
+        } else if (symbol_section_sp->Get() & SHF_ALLOC)
+          // Check for symbols from custom sections (e.g. added by linker
+          // scripts) with SHF_ALLOC in their flags.
+          symbol_type = eSymbolTypeData;
       }
     }
 

--- a/lldb/source/Plugins/ObjectFile/ELF/ObjectFileELF.cpp
+++ b/lldb/source/Plugins/ObjectFile/ELF/ObjectFileELF.cpp
@@ -2436,7 +2436,8 @@ ObjectFileELF::ParseSymbols(Symtab *symtab, user_id_t start_id,
           symbol_type = eSymbolTypeData;
         } else if (symbol_section_sp->Get() & SHF_ALLOC)
           // Check for symbols from custom sections (e.g. added by linker
-          // scripts) with SHF_ALLOC in their flags.
+          // scripts) with SHF_ALLOC (i.e. occupies memory during process
+          // execution) in their flags.
           symbol_type = eSymbolTypeData;
       }
     }

--- a/lldb/test/API/linux/linker-symbols/Makefile
+++ b/lldb/test/API/linux/linker-symbols/Makefile
@@ -1,0 +1,5 @@
+CXX_SOURCES := main.cpp
+
+CXXFLAGS_EXTRAS=-nostdlib -static
+
+include Makefile.rules

--- a/lldb/test/API/linux/linker-symbols/TestLinkerSymbols.py
+++ b/lldb/test/API/linux/linker-symbols/TestLinkerSymbols.py
@@ -15,9 +15,7 @@ class TestLinkerSymbols(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 
     def test_linker_symbols(self):
-        build_dict = dict(
-            LD_EXTRAS="-Wl,-T," + self.getSourcePath("linker.script")
-        )
+        build_dict = dict(LD_EXTRAS="-Wl,-T," + self.getSourcePath("linker.script"))
         self.build(dictionary=build_dict)
         exe = self.getBuildArtifact("a.out")
         target = self.dbg.CreateTarget(exe)

--- a/lldb/test/API/linux/linker-symbols/TestLinkerSymbols.py
+++ b/lldb/test/API/linux/linker-symbols/TestLinkerSymbols.py
@@ -1,0 +1,38 @@
+"""
+Test that LLDB can find symbols added by a linker script.
+"""
+
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+from lldbsuite.test import lldbutil
+
+
+class TestLinkerSymbols(TestBase):
+    # If your test case doesn't stress debug info, then
+    # set this to true.  That way it won't be run once for
+    # each debug info format.
+    NO_DEBUG_INFO_TESTCASE = True
+
+    def test_linker_symbols(self):
+        build_dict = dict(
+            LD_EXTRAS="-Wl,-T," + self.getSourcePath("linker.script")
+        )
+        self.build(dictionary=build_dict)
+        exe = self.getBuildArtifact("a.out")
+        target = self.dbg.CreateTarget(exe)
+
+        # Check for data symbols
+        self.expect_expr("&bss_symbol", result_type="void **")
+        self.expect_expr("&bss_var", result_type="int *")
+        self.expect_expr("&data_symbol", result_type="void **")
+        self.expect_expr("&data_var", result_type="int *")
+        self.expect_expr("&pseudo_bss_var", result_type="int *")
+        self.expect_expr("&pseudo_bss_symbol", result_type="void **")
+        self.expect_expr("&pseudo_data_symbol", result_type="void **")
+
+        # Check for text symbols
+        self.expect_expr("(int(*)())&absolute_symbol", result_type="int (*)()")
+        self.expect_expr("(int(*)())&pseudo_text_func", result_type="int (*)()")
+        self.expect_expr("(int(*)())&text_func", result_type="int (*)()")
+        self.expect_expr("(int(*)())&text_symbol", result_type="int (*)()")

--- a/lldb/test/API/linux/linker-symbols/linker.script
+++ b/lldb/test/API/linux/linker-symbols/linker.script
@@ -1,0 +1,37 @@
+SECTIONS {
+  . = 0x10000;
+
+  absolute_symbol = .;
+
+  .text : {
+    text_symbol = .;
+    *(.text)
+  }
+
+  pseudo_text : {
+    pseudo_text_symbol = .;
+    *(.pseudo_text)
+  }
+
+  .data : {
+    data_symbol = .;
+    *(.data)
+  }
+
+  pseudo_data : {
+    pseudo_data_symbol = .;
+    *(.pseudo_data)
+  }
+
+  .bss : {
+    bss_symbol = .;
+    *(.bss)
+  }
+
+  pseudo_bss : {
+    pseudo_bss_symbol = .;
+    *(.pseudo_bss)
+  }
+}
+
+ENTRY(text_func)

--- a/lldb/test/API/linux/linker-symbols/main.cpp
+++ b/lldb/test/API/linux/linker-symbols/main.cpp
@@ -1,0 +1,20 @@
+extern "C" {
+
+extern void text_func() {}
+[[gnu::section("pseudo_text")]] extern void pseudo_text_func() {}
+
+extern int data_var;
+int data_var = 1;
+extern int pseudo_data_var;
+[[gnu::section("pseudo_data")]] int pseudo_data_var = 1;
+
+extern int bss_var;
+int bss_var;
+extern int pseudo_bss_var;
+[[gnu::section("pseudo_bss")]] int pseudo_bss_var;
+
+}
+
+int main(int argc, char **argv) {
+  return 0; // Set a breakpoint here
+}

--- a/lldb/test/API/linux/linker-symbols/main.cpp
+++ b/lldb/test/API/linux/linker-symbols/main.cpp
@@ -12,7 +12,6 @@ extern int bss_var;
 int bss_var;
 extern int pseudo_bss_var;
 [[gnu::section("pseudo_bss")]] int pseudo_bss_var;
-
 }
 
 int main(int argc, char **argv) {


### PR DESCRIPTION
Symbols added by linker scripts do not have debug information or types, but they do have addresses. Sometimes users need to see the addresses of these symbols. Currently these symbols end up being assigned 'eSymbolTypeInvalid', so any attempt to look at them fails. This fixes that issue.