### PR TITLE
[DebugInfo] Don't specify target triple for cross-cu-linkonce-distinct.ll

### DIFF
--- a/llvm/test/DebugInfo/Generic/cross-cu-linkonce-distinct.ll
+++ b/llvm/test/DebugInfo/Generic/cross-cu-linkonce-distinct.ll
@@ -38,7 +38,6 @@
 ; CHECK:     DW_AT_name ("func")
 
 source_filename = "test/DebugInfo/Generic/cross-cu-linkonce-distinct.ll"
-target triple = "x86_64-unknown-linux-gnu"
 
 @x = global ptr @_Z4funci, align 8, !dbg !0
 @y = global ptr @_Z4funci, align 8, !dbg !7


### PR DESCRIPTION
Fixes buildbot failures after #184219.
Target triple line was added to this test in https://reviews.llvm.org/D144007, but it's needless.