### PR TITLE
[LLDB] Skip linker symbols test on Windows and MacOS.

### DIFF
--- a/lldb/test/API/linux/linker-symbols/TestLinkerSymbols.py
+++ b/lldb/test/API/linux/linker-symbols/TestLinkerSymbols.py
@@ -14,7 +14,7 @@ class TestLinkerSymbols(TestBase):
     # each debug info format.
     NO_DEBUG_INFO_TESTCASE = True
 
-    @skipIf(oslist=nomatch(["linux"]))
+    @skipIf(oslist=no_match(["linux"]))
     def test_linker_symbols(self):
         build_dict = dict(LD_EXTRAS="-Wl,-T," + self.getSourcePath("linker.script"))
         self.build(dictionary=build_dict)

--- a/lldb/test/API/linux/linker-symbols/TestLinkerSymbols.py
+++ b/lldb/test/API/linux/linker-symbols/TestLinkerSymbols.py
@@ -14,7 +14,7 @@ class TestLinkerSymbols(TestBase):
     # each debug info format.
     NO_DEBUG_INFO_TESTCASE = True
 
-    @skipIf(oslist=no_match(["linux"]))
+    @skipUnlessPlatform(["linux"])
     def test_linker_symbols(self):
         build_dict = dict(LD_EXTRAS="-Wl,-T," + self.getSourcePath("linker.script"))
         self.build(dictionary=build_dict)

--- a/lldb/test/API/linux/linker-symbols/TestLinkerSymbols.py
+++ b/lldb/test/API/linux/linker-symbols/TestLinkerSymbols.py
@@ -14,8 +14,7 @@ class TestLinkerSymbols(TestBase):
     # each debug info format.
     NO_DEBUG_INFO_TESTCASE = True
 
-    @skipIf(oslist=["darwin", "macos"])
-    @skipIfWindows
+    @skipIf(oslist=nomatch(["linux"]))
     def test_linker_symbols(self):
         build_dict = dict(LD_EXTRAS="-Wl,-T," + self.getSourcePath("linker.script"))
         self.build(dictionary=build_dict)

--- a/lldb/test/API/linux/linker-symbols/TestLinkerSymbols.py
+++ b/lldb/test/API/linux/linker-symbols/TestLinkerSymbols.py
@@ -14,6 +14,8 @@ class TestLinkerSymbols(TestBase):
     # each debug info format.
     NO_DEBUG_INFO_TESTCASE = True
 
+    @skipIf(oslist=["darwin", "macos"])
+    @skipIfWindows
     def test_linker_symbols(self):
         build_dict = dict(LD_EXTRAS="-Wl,-T," + self.getSourcePath("linker.script"))
         self.build(dictionary=build_dict)


### PR DESCRIPTION
The test was only intended to run on linux.

Currently it's failing on the lldb-x86_64-win builder: https://lab.llvm.org/buildbot/#/builders/211/builds/6741