### PR TITLE
[lldb] Add missing @skipIfNoIntelPT to commands/trace tests

### DIFF
--- a/lldb/test/API/commands/trace/TestTraceDumpFunctionCalls.py
+++ b/lldb/test/API/commands/trace/TestTraceDumpFunctionCalls.py
@@ -3,6 +3,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test.decorators import *
 
 
+@skipIfNoIntelPT
 class TestTraceDumpInfo(TraceIntelPTTestCaseBase):
     def testDumpSimpleFunctionCalls(self):
         self.expect(
@@ -133,7 +134,6 @@ m.out`bar() + 30 at multi_thread.cpp:19:3 to 20:6  [5, 61831]
             ],
         )
 
-    @skipIfNoIntelPT
     def testInlineFunctionCalls(self):
         self.expect(
             "file " + os.path.join(self.getSourceDir(), "inline-function", "a.out")
@@ -195,7 +195,6 @@ a.out`main + 25 at inline.cpp:16:14 to 16:14  [28, 28]"""
             ],
         )
 
-    @skipIfNoIntelPT
     def testIncompleteInlineFunctionCalls(self):
         self.expect(
             "file " + os.path.join(self.getSourceDir(), "inline-function", "a.out")

--- a/lldb/test/API/commands/trace/TestTraceDumpInfo.py
+++ b/lldb/test/API/commands/trace/TestTraceDumpInfo.py
@@ -38,6 +38,7 @@ class TestTraceDumpInfo(TraceIntelPTTestCaseBase):
             error=True,
         )
 
+    @skipIfNoIntelPT
     def testDumpRawTraceSize(self):
         self.expect(
             "trace load -v "
@@ -67,6 +68,7 @@ class TestTraceDumpInfo(TraceIntelPTTestCaseBase):
             patterns=[r"Decoding instructions: \d.\d\ds"],
         )
 
+    @skipIfNoIntelPT
     def testDumpRawTraceSizeJSON(self):
         self.expect(
             "trace load -v "

--- a/lldb/test/API/commands/trace/TestTraceEvents.py
+++ b/lldb/test/API/commands/trace/TestTraceEvents.py
@@ -5,6 +5,7 @@ from lldbsuite.test import lldbutil
 from lldbsuite.test.decorators import *
 
 
+@skipIfNoIntelPT
 class TestTraceEvents(TraceIntelPTTestCaseBase):
     @testSBAPIAndCommands
     def testCPUEvents(self):
@@ -45,7 +46,6 @@ class TestTraceEvents(TraceIntelPTTestCaseBase):
             ],
         )
 
-    @skipIfNoIntelPT
     @testSBAPIAndCommands
     def testPauseEvents(self):
         """

--- a/lldb/test/API/commands/trace/TestTraceLoad.py
+++ b/lldb/test/API/commands/trace/TestTraceLoad.py
@@ -8,6 +8,7 @@ from lldbsuite.test.decorators import *
 class TestTraceLoad(TraceIntelPTTestCaseBase):
     NO_DEBUG_INFO_TESTCASE = True
 
+    @skipIfNoIntelPT
     @testSBAPIAndCommands
     def testLoadMultiCoreTrace(self):
         src_dir = self.getSourceDir()
@@ -119,6 +120,7 @@ class TestTraceLoad(TraceIntelPTTestCaseBase):
             ],
         )
 
+    @skipIfNoIntelPT
     @testSBAPIAndCommands
     def testLoadCompactMultiCoreTrace(self):
         src_dir = self.getSourceDir()
@@ -178,6 +180,7 @@ class TestTraceLoad(TraceIntelPTTestCaseBase):
         # We clean up for the next run of this test
         self.dbg.DeleteTarget(self.dbg.GetTargetAtIndex(0))
 
+    @skipIfNoIntelPT
     @testSBAPIAndCommands
     def testLoadMultiCoreTraceWithStringNumbers(self):
         src_dir = self.getSourceDir()
@@ -203,6 +206,7 @@ class TestTraceLoad(TraceIntelPTTestCaseBase):
             ],
         )
 
+    @skipIfNoIntelPT
     @testSBAPIAndCommands
     def testLoadMultiCoreTraceWithMissingThreads(self):
         src_dir = self.getSourceDir()
@@ -228,6 +232,7 @@ class TestTraceLoad(TraceIntelPTTestCaseBase):
             ],
         )
 
+    @skipIfNoIntelPT
     @testSBAPIAndCommands
     def testLoadTrace(self):
         src_dir = self.getSourceDir()
@@ -387,6 +392,7 @@ Context:
         )
         self.assertEqual(self.dbg.GetNumTargets(), 0)
 
+    @skipIfNoIntelPT
     def testLoadTraceCursor(self):
         src_dir = self.getSourceDir()
         trace_description_file_path = os.path.join(
@@ -492,6 +498,7 @@ Context:
                 sequentialTraversalCursor, randomAccessCursor
             )
 
+    @skipIfNoIntelPT
     @testSBAPIAndCommands
     def testLoadKernelTrace(self):
         # kernel section without loadAddress (using default loadAddress).

--- a/lldb/test/API/commands/trace/TestTraceSave.py
+++ b/lldb/test/API/commands/trace/TestTraceSave.py
@@ -11,7 +11,6 @@ def find(predicate, seq):
         if predicate(item):
             return item
 
-
 class TestTraceSave(TraceIntelPTTestCaseBase):
     def testErrorMessages(self):
         # We first check the output when there are no targets
@@ -68,6 +67,7 @@ class TestTraceSave(TraceIntelPTTestCaseBase):
             "trace save /", substrs=["error: couldn't write to the file"], error=True
         )
 
+    @skipIfNoIntelPT
     def testSaveWhenNotLiveTrace(self):
         self.expect(
             "trace load -v "
@@ -212,6 +212,7 @@ class TestTraceSave(TraceIntelPTTestCaseBase):
         self.assertTrue(res.Succeeded())
         self.assertEqual(res.GetOutput(), last_ten_instructions)
 
+    @skipIfNoIntelPT
     def testSaveKernelTrace(self):
         original_trace_file = os.path.join(
             self.getSourceDir(), "intelpt-kernel-trace", "trace.json"

--- a/lldb/test/API/commands/trace/TestTraceStartStop.py
+++ b/lldb/test/API/commands/trace/TestTraceStartStop.py
@@ -5,7 +5,6 @@ from lldbsuite.test import lldbutil
 from lldbsuite.test.decorators import *
 
 
-@skipIfNoIntelPT
 class TestTraceStartStop(TraceIntelPTTestCaseBase):
     def expectGenericHelpMessageForStartCommand(self):
         self.expect(
@@ -13,6 +12,7 @@ class TestTraceStartStop(TraceIntelPTTestCaseBase):
             substrs=["Syntax: thread trace start [<trace-options>]"],
         )
 
+    @skipIfNoIntelPT
     @testSBAPIAndCommands
     def testStartStopSessionFileThreads(self):
         # it should fail for processes from json session files
@@ -32,6 +32,7 @@ class TestTraceStartStop(TraceIntelPTTestCaseBase):
     def testStartWithNoProcess(self):
         self.traceStartThread(error=True)
 
+    @skipIfNoIntelPT
     @testSBAPIAndCommands
     def testStartSessionWithWrongSize(self):
         self.expect(
@@ -60,6 +61,7 @@ class TestTraceStartStop(TraceIntelPTTestCaseBase):
 
         self.traceStartThread(iptTraceSize=1048576)
 
+    @skipIfNoIntelPT
     @testSBAPIAndCommands
     def testStartSessionWithSizeDeclarationInUnits(self):
         self.expect(
@@ -156,6 +158,7 @@ class TestTraceStartStop(TraceIntelPTTestCaseBase):
 
         self.traceStartThread(iptTraceSize="1048576")
 
+    @skipIfNoIntelPT
     @skipIf(oslist=no_match(["linux"]), archs=no_match(["i386", "x86_64"]))
     def testSBAPIHelp(self):
         self.expect(
@@ -168,6 +171,7 @@ class TestTraceStartStop(TraceIntelPTTestCaseBase):
         self.assertIn("iptTraceSize", help)
         self.assertIn("processBufferSizeLimit", help)
 
+    @skipIfNoIntelPT
     @skipIf(oslist=no_match(["linux"]), archs=no_match(["i386", "x86_64"]))
     def testStoppingAThread(self):
         self.expect(
@@ -191,6 +195,7 @@ class TestTraceStartStop(TraceIntelPTTestCaseBase):
             "thread trace dump instructions", substrs=["not traced"], error=True
         )
 
+    @skipIfNoIntelPT
     @skipIf(oslist=no_match(["linux"]), archs=no_match(["i386", "x86_64"]))
     def testStartStopLiveThreads(self):
         # The help command should be the generic one if there's no process running


### PR DESCRIPTION
Some tests does not have the @skipIfNoIntelPT decorator, and those tests would fail (time-out) because the required hardware is not present. We add the missing decorators so the unsupported tests will be skipped for machines that intel-pt tracing is unsupported. 