### PR TITLE
[DebugInfo] Don't match wrong NULL in CHECK lines of dwarf5-debug-info-static-member.ll

### DIFF
--- a/llvm/test/DebugInfo/Generic/dwarf5-debug-info-static-member.ll
+++ b/llvm/test/DebugInfo/Generic/dwarf5-debug-info-static-member.ll
@@ -104,11 +104,10 @@ attributes #1 = { nounwind readnone }
 ; CHECK:      DW_AT_declaration
 ; CHECK:      NULL
 ; CHECK:      DW_TAG_subprogram
-; CHECK:      NULL
 ; CHECK:      DW_TAG_variable
-; CHECK-NEXT: DW_AT_specification {{.*}} "a"
+; CHECK:      DW_AT_specification {{.*}} "a"
 ; CHECK:      DW_TAG_variable
-; CHECK-NEXT: DW_AT_specification {{.*}} "b"
-; CHECK-NEXT: DW_AT_const_value
+; CHECK:      DW_AT_specification {{.*}} "b"
+; CHECK:      DW_AT_const_value
 ; CHECK:      DW_TAG_variable
-; CHECK-NEXT: DW_AT_specification {{.*}} "c"
+; CHECK:      DW_AT_specification {{.*}} "c"


### PR DESCRIPTION
Fixes failure on clang-ppc64le-rhel buildbot (https://lab.llvm.org/buildbot/#/builders/145/builds/13080) after #184219.

On ppc64le, children are not produced for DW_TAG_subprogram "main" in this test. Therefore, dwarfdump doesn't print NULL after this tag. On other platforms (AArch64/X86), DW_TAG_subprogram has DW_TAG_variable "instance_C", which should not be matched by the check lines.

Loosened the check lines (turned CHECK-NEXT into CHECK) to make them work for all mentioned platforms.