### PR TITLE
[ci][github][analyzer] Enable Z3 for Clang Static Analyzer on Linux

### DIFF
--- a/.ci/compute_projects.py
+++ b/.ci/compute_projects.py
@@ -20,6 +20,7 @@ PROJECT_DEPENDENCIES = {
     "llvm": set(),
     "clang": {"llvm"},
     "CIR": {"clang", "mlir"},
+    "Z3": {"clang"},
     "bolt": {"clang", "lld", "llvm"},
     "clang-tools-extra": {"clang", "llvm"},
     "compiler-rt": {"clang", "lld"},
@@ -57,6 +58,7 @@ DEPENDENTS_TO_TEST = {
         "llvm",
         "clang",
         "CIR",
+        "Z3",
         "lld",
         "lldb",
         "bolt",
@@ -107,6 +109,7 @@ EXCLUDE_WINDOWS = {
     "libcxxabi",
     "libunwind",
     "flang-rt",
+    "Z3",
 }
 
 # These are projects that we should test if the project itself is changed but
@@ -128,6 +131,7 @@ EXCLUDE_MAC = {
     "libcxx",
     "libcxxabi",
     "libunwind",
+    "Z3",
 }
 
 PROJECT_CHECK_TARGETS = {
@@ -141,6 +145,7 @@ PROJECT_CHECK_TARGETS = {
     "llvm": "check-llvm",
     "clang": "check-clang",
     "CIR": "check-clang-cir",
+    "Z3": "check-clang",
     "bolt": "check-bolt",
     "lld": "check-lld",
     "flang": "check-flang",
@@ -164,6 +169,9 @@ META_PROJECTS = {
     ("clang", "lib", "CIR"): "CIR",
     ("clang", "test", "CIR"): "CIR",
     ("clang", "include", "clang", "CIR"): "CIR",
+    ("clang", "lib", "StaticAnalyzer"): "Z3",
+    ("clang", "test", "Analysis"): "Z3",
+    ("clang", "include", "clang", "StaticAnalyzer"): "Z3",
     ("*", "docs"): "docs",
     ("llvm", "utils", "gn"): "gn",
     (".github", "workflows", "premerge.yaml"): ".ci",
@@ -172,7 +180,7 @@ META_PROJECTS = {
 }
 
 # Projects that should run tests but cannot be explicitly built.
-SKIP_BUILD_PROJECTS = ["CIR", "lit"]
+SKIP_BUILD_PROJECTS = ["Z3", "CIR", "lit"]
 
 # Projects that should not run any tests. These need to be metaprojects.
 SKIP_PROJECTS = ["docs", "gn"]
@@ -321,6 +329,8 @@ def get_env_variables(modified_files: list[str], platform: str) -> Set[str]:
     # clang build, but it requires an explicit option to enable. We set that
     # option here, and remove it from the projects_to_build list.
     enable_cir = "ON" if "CIR" in projects_to_build else "OFF"
+    # Z3 is used as a pseudo-project like CIR to enable building with Z3.
+    enable_z3 = "ON" if "Z3" in projects_to_build else "OFF"
     # Remove any metaprojects from the list of projects to build.
     for project in SKIP_BUILD_PROJECTS:
         projects_to_build.discard(project)
@@ -338,6 +348,7 @@ def get_env_variables(modified_files: list[str], platform: str) -> Set[str]:
             sorted(runtimes_check_targets_needs_reconfig)
         ),
         "enable_cir": enable_cir,
+        "enable_z3": enable_z3,
     }
 
 

--- a/.ci/compute_projects_test.py
+++ b/.ci/compute_projects_test.py
@@ -32,6 +32,7 @@ class TestComputeProjects(unittest.TestCase):
             env_variables["runtimes_check_targets_needs_reconfig"],
             "check-cxx check-cxxabi check-unwind",
         )
+        self.assertEqual(env_variables["enable_z3"], "OFF")
 
     def test_llvm_windows(self):
         env_variables = compute_projects.get_env_variables(
@@ -54,6 +55,7 @@ class TestComputeProjects(unittest.TestCase):
             env_variables["runtimes_check_targets_needs_reconfig"],
             "",
         )
+        self.assertEqual(env_variables["enable_z3"], "OFF")
 
     def test_llvm_mac(self):
         env_variables = compute_projects.get_env_variables(
@@ -76,6 +78,7 @@ class TestComputeProjects(unittest.TestCase):
             env_variables["runtimes_check_targets_needs_reconfig"],
             "",
         )
+        self.assertEqual(env_variables["enable_z3"], "OFF")
 
     def test_clang(self):
         env_variables = compute_projects.get_env_variables(
@@ -104,6 +107,7 @@ class TestComputeProjects(unittest.TestCase):
             env_variables["enable_cir"],
             "OFF",
         )
+        self.assertEqual(env_variables["enable_z3"], "OFF")
 
     def test_clang_windows(self):
         env_variables = compute_projects.get_env_variables(
@@ -125,6 +129,7 @@ class TestComputeProjects(unittest.TestCase):
             "",
         )
         self.assertEqual(env_variables["enable_cir"], "OFF")
+        self.assertEqual(env_variables["enable_z3"], "OFF")
 
     def test_compiler_rt(self):
         env_variables = compute_projects.get_env_variables(
@@ -151,6 +156,7 @@ class TestComputeProjects(unittest.TestCase):
             env_variables["enable_cir"],
             "OFF",
         )
+        self.assertEqual(env_variables["enable_z3"], "OFF")
 
     def test_cir(self):
         env_variables = compute_projects.get_env_variables(
@@ -176,6 +182,45 @@ class TestComputeProjects(unittest.TestCase):
             "check-cxx check-cxxabi check-unwind",
         )
         self.assertEqual(env_variables["enable_cir"], "ON")
+        self.assertEqual(env_variables["enable_z3"], "OFF")
+
+    def test_z3(self):
+        env_variables = compute_projects.get_env_variables(
+            ["clang/lib/StaticAnalyzer/CMakeLists.txt"], "Linux"
+        )
+        self.assertEqual(
+            env_variables["projects_to_build"],
+            "clang;clang-tools-extra;lld;lldb;llvm",
+        )
+        self.assertEqual(
+            env_variables["project_check_targets"],
+            "check-clang check-clang-tools check-lldb",
+        )
+        self.assertEqual(
+            env_variables["runtimes_to_build"], "compiler-rt;libcxx;libcxxabi;libunwind"
+        )
+        self.assertEqual(
+            env_variables["runtimes_check_targets"],
+            "check-compiler-rt",
+        )
+        self.assertEqual(
+            env_variables["runtimes_check_targets_needs_reconfig"],
+            "check-cxx check-cxxabi check-unwind",
+        )
+        self.assertEqual(env_variables["enable_cir"], "OFF")
+        self.assertEqual(env_variables["enable_z3"], "ON")
+
+    def test_z3_windows(self):
+        env_variables = compute_projects.get_env_variables(
+            ["clang/lib/StaticAnalyzer/CMakeLists.txt"], "Windows"
+        )
+        self.assertEqual(env_variables["enable_z3"], "OFF")
+
+    def test_z3_mac(self):
+        env_variables = compute_projects.get_env_variables(
+            ["clang/lib/StaticAnalyzer/CMakeLists.txt"], "Darwin"
+        )
+        self.assertEqual(env_variables["enable_z3"], "OFF")
 
     def test_bolt(self):
         env_variables = compute_projects.get_env_variables(
@@ -186,6 +231,7 @@ class TestComputeProjects(unittest.TestCase):
         self.assertEqual(env_variables["runtimes_to_build"], "")
         self.assertEqual(env_variables["runtimes_check_targets"], "")
         self.assertEqual(env_variables["runtimes_check_targets_needs_reconfig"], "")
+        self.assertEqual(env_variables["enable_z3"], "OFF")
 
     def test_lldb(self):
         env_variables = compute_projects.get_env_variables(
@@ -196,6 +242,7 @@ class TestComputeProjects(unittest.TestCase):
         self.assertEqual(env_variables["runtimes_to_build"], "")
         self.assertEqual(env_variables["runtimes_check_targets"], "")
         self.assertEqual(env_variables["runtimes_check_targets_needs_reconfig"], "")
+        self.assertEqual(env_variables["enable_z3"], "OFF")
 
     def test_mlir(self):
         env_variables = compute_projects.get_env_variables(
@@ -209,6 +256,7 @@ class TestComputeProjects(unittest.TestCase):
         self.assertEqual(env_variables["runtimes_check_targets"], "")
         self.assertEqual(env_variables["runtimes_check_targets_needs_reconfig"], "")
         self.assertEqual(env_variables["enable_cir"], "OFF")
+        self.assertEqual(env_variables["enable_z3"], "OFF")
 
     def test_flang(self):
         env_variables = compute_projects.get_env_variables(
@@ -220,6 +268,7 @@ class TestComputeProjects(unittest.TestCase):
         self.assertEqual(env_variables["runtimes_check_targets"], "check-flang-rt")
         self.assertEqual(env_variables["runtimes_check_targets_needs_reconfig"], "")
         self.assertEqual(env_variables["enable_cir"], "OFF")
+        self.assertEqual(env_variables["enable_z3"], "OFF")
 
     def test_invalid_subproject(self):
         env_variables = compute_projects.get_env_variables(
@@ -230,6 +279,7 @@ class TestComputeProjects(unittest.TestCase):
         self.assertEqual(env_variables["runtimes_to_build"], "")
         self.assertEqual(env_variables["runtimes_check_targets"], "")
         self.assertEqual(env_variables["runtimes_check_targets_needs_reconfig"], "")
+        self.assertEqual(env_variables["enable_z3"], "OFF")
 
     def test_top_level_file(self):
         env_variables = compute_projects.get_env_variables(["README.md"], "Linux")
@@ -238,6 +288,7 @@ class TestComputeProjects(unittest.TestCase):
         self.assertEqual(env_variables["runtimes_to_build"], "")
         self.assertEqual(env_variables["runtimes_check_targets"], "")
         self.assertEqual(env_variables["runtimes_check_targets_needs_reconfig"], "")
+        self.assertEqual(env_variables["enable_z3"], "OFF")
 
     def test_exclude_libcxx_in_projects(self):
         env_variables = compute_projects.get_env_variables(
@@ -248,6 +299,7 @@ class TestComputeProjects(unittest.TestCase):
         self.assertEqual(env_variables["runtimes_to_build"], "")
         self.assertEqual(env_variables["runtimes_check_targets"], "")
         self.assertEqual(env_variables["runtimes_check_targets_needs_reconfig"], "")
+        self.assertEqual(env_variables["enable_z3"], "OFF")
 
     def test_include_libc_in_runtimes(self):
         env_variables = compute_projects.get_env_variables(
@@ -258,6 +310,7 @@ class TestComputeProjects(unittest.TestCase):
         self.assertEqual(env_variables["runtimes_to_build"], "libc")
         self.assertEqual(env_variables["runtimes_check_targets"], "check-libc")
         self.assertEqual(env_variables["runtimes_check_targets_needs_reconfig"], "")
+        self.assertEqual(env_variables["enable_z3"], "OFF")
 
     def test_exclude_docs(self):
         env_variables = compute_projects.get_env_variables(
@@ -268,6 +321,7 @@ class TestComputeProjects(unittest.TestCase):
         self.assertEqual(env_variables["runtimes_to_build"], "")
         self.assertEqual(env_variables["runtimes_check_targets"], "")
         self.assertEqual(env_variables["runtimes_check_targets_needs_reconfig"], "")
+        self.assertEqual(env_variables["enable_z3"], "OFF")
 
     def test_exclude_gn(self):
         env_variables = compute_projects.get_env_variables(
@@ -278,6 +332,7 @@ class TestComputeProjects(unittest.TestCase):
         self.assertEqual(env_variables["runtimes_to_build"], "")
         self.assertEqual(env_variables["runtimes_check_targets"], "")
         self.assertEqual(env_variables["runtimes_check_targets_needs_reconfig"], "")
+        self.assertEqual(env_variables["enable_z3"], "OFF")
 
     def test_ci(self):
         env_variables = compute_projects.get_env_variables(
@@ -303,6 +358,7 @@ class TestComputeProjects(unittest.TestCase):
             env_variables["runtimes_check_targets_needs_reconfig"],
             "check-cxx check-cxxabi check-unwind",
         )
+        self.assertEqual(env_variables["enable_z3"], "ON")
 
     def test_windows_ci(self):
         env_variables = compute_projects.get_env_variables(
@@ -328,6 +384,7 @@ class TestComputeProjects(unittest.TestCase):
             env_variables["runtimes_check_targets_needs_reconfig"],
             "",
         )
+        self.assertEqual(env_variables["enable_z3"], "OFF")
 
     def test_lldb(self):
         env_variables = compute_projects.get_env_variables(
@@ -340,6 +397,7 @@ class TestComputeProjects(unittest.TestCase):
         )
         self.assertEqual(env_variables["runtimes_check_targets"], "")
         self.assertEqual(env_variables["runtimes_check_targets_needs_reconfig"], "")
+        self.assertEqual(env_variables["enable_z3"], "OFF")
 
     def test_clang_tools_extra(self):
         env_variables = compute_projects.get_env_variables(
@@ -352,6 +410,7 @@ class TestComputeProjects(unittest.TestCase):
         self.assertEqual(env_variables["runtimes_to_build"], "libc")
         self.assertEqual(env_variables["runtimes_check_targets"], "check-libc")
         self.assertEqual(env_variables["runtimes_check_targets_needs_reconfig"], "")
+        self.assertEqual(env_variables["enable_z3"], "OFF")
 
     def test_premerge_workflow(self):
         env_variables = compute_projects.get_env_variables(
@@ -377,6 +436,7 @@ class TestComputeProjects(unittest.TestCase):
             env_variables["runtimes_check_targets_needs_reconfig"],
             "check-cxx check-cxxabi check-unwind",
         )
+        self.assertEqual(env_variables["enable_z3"], "ON")
 
     def test_other_github_workflow(self):
         env_variables = compute_projects.get_env_variables(
@@ -387,6 +447,7 @@ class TestComputeProjects(unittest.TestCase):
         self.assertEqual(env_variables["runtimes_to_build"], "")
         self.assertEqual(env_variables["runtimes_check_targets"], "")
         self.assertEqual(env_variables["runtimes_check_targets_needs_reconfig"], "")
+        self.assertEqual(env_variables["enable_z3"], "OFF")
 
     def test_third_party_benchmark(self):
         env_variables = compute_projects.get_env_variables(
@@ -412,6 +473,7 @@ class TestComputeProjects(unittest.TestCase):
             env_variables["runtimes_check_targets_needs_reconfig"],
             "check-cxx check-cxxabi check-unwind",
         )
+        self.assertEqual(env_variables["enable_z3"], "ON")
 
     def test_lit(self):
         env_variables = compute_projects.get_env_variables(
@@ -436,6 +498,7 @@ class TestComputeProjects(unittest.TestCase):
             env_variables["runtimes_check_targets_needs_reconfig"],
             "check-cxx check-cxxabi check-unwind",
         )
+        self.assertEqual(env_variables["enable_z3"], "OFF")
 
 
 if __name__ == "__main__":

--- a/.ci/monolithic-linux.sh
+++ b/.ci/monolithic-linux.sh
@@ -28,6 +28,7 @@ runtimes="${3}"
 runtime_targets="${4}"
 runtime_targets_needs_reconfig="${5}"
 enable_cir="${6}"
+enable_z3="${7}"
 
 lit_args="-v --xunit-xml-output ${BUILD_DIR}/test-results.xml --use-unique-output-file-name --timeout=1200 --time-tests --succinct"
 
@@ -46,6 +47,7 @@ cmake -S "${MONOREPO_ROOT}"/llvm -B "${BUILD_DIR}" \
       -D CMAKE_PREFIX_PATH="${HOME}/.local" \
       -D CMAKE_BUILD_TYPE=Release \
       -D CLANG_ENABLE_CIR=${enable_cir} \
+      -D LLVM_ENABLE_Z3_SOLVER="${enable_z3}" \
       -D LLVM_ENABLE_ASSERTIONS=ON \
       -D LLVM_BUILD_EXAMPLES=ON \
       -D COMPILER_RT_BUILD_LIBFUZZER=OFF \

--- a/.github/workflows/containers/github-action-ci/Dockerfile
+++ b/.github/workflows/containers/github-action-ci/Dockerfile
@@ -54,6 +54,7 @@ RUN apt-get update && \
     git \
     libstdc++-11-dev \
     ninja-build \
+    libz3-dev \
     nodejs \
     perl-modules \
     python3-psutil \

--- a/.github/workflows/premerge.yaml
+++ b/.github/workflows/premerge.yaml
@@ -104,7 +104,7 @@ jobs:
           mkdir artifacts
           SCCACHE_LOG=info SCCACHE_ERROR_LOG=$(pwd)/artifacts/sccache.log sccache --start-server
 
-          ./.ci/monolithic-linux.sh "${projects_to_build}" "${project_check_targets}" "${runtimes_to_build}" "${runtimes_check_targets}" "${runtimes_check_targets_needs_reconfig}" "${enable_cir}"
+          ./.ci/monolithic-linux.sh "${projects_to_build}" "${project_check_targets}" "${runtimes_to_build}" "${runtimes_check_targets}" "${runtimes_check_targets_needs_reconfig}" "${enable_cir}" "${enable_z3}"
       - name: Upload Artifacts
         # In some cases, Github will fail to upload the artifact. We want to
         # continue anyways as a failed artifact upload is an infra failure, not


### PR DESCRIPTION
Addressing the discussions in #181581

Adding a pseudo-project 'Z3' to build Clang with Z3 support on Linux when the code or tests of the Clang Static Analyzer are changed. This enables the test cases depending on Z3.