### PR TITLE
[PowerPC] Fix ADJCALLSTACKUP and ADJCALLSTACKDOWN def

### DIFF
--- a/llvm/lib/Target/PowerPC/MCTargetDesc/PPCInstPrinter.cpp
+++ b/llvm/lib/Target/PowerPC/MCTargetDesc/PPCInstPrinter.cpp
@@ -330,7 +330,7 @@ void PPCInstPrinter::printUImmOperand(const MCInst *MI, unsigned OpNo,
                                       const MCSubtargetInfo &STI,
                                       raw_ostream &O) {
   unsigned int Value = MI->getOperand(OpNo).getImm();
-  assert(Value <= ((1U << Width) - 1) && "Invalid uimm argument!");
+  assert(Value <= ((1ULL << Width) - 1) && "Invalid uimm argument!");
   O << (unsigned int)Value;
 }
 

--- a/llvm/lib/Target/PowerPC/PPCInstrInfo.td
+++ b/llvm/lib/Target/PowerPC/PPCInstrInfo.td
@@ -1466,12 +1466,12 @@ multiclass Z22Form_FRTA5_SH6r<bits<6> opcode, bits<9> xo, dag OOL, dag IOL,
 
 let hasCtrlDep = 1 in {
 let Defs = [R1], Uses = [R1] in {
-def ADJCALLSTACKDOWN : PPCEmitTimePseudo<(outs), (ins u16imm:$amt1, u16imm:$amt2),
+def ADJCALLSTACKDOWN : PPCEmitTimePseudo<(outs), (ins u32imm:$amt1, u32imm:$amt2),
                               "#ADJCALLSTACKDOWN $amt1 $amt2",
-                              [(callseq_start timm:$amt1, timm:$amt2)]>;
-def ADJCALLSTACKUP   : PPCEmitTimePseudo<(outs), (ins u16imm:$amt1, u16imm:$amt2),
+                              [(callseq_start u32imm_timm:$amt1, u32imm_timm:$amt2)]>;
+def ADJCALLSTACKUP   : PPCEmitTimePseudo<(outs), (ins u32imm:$amt1, u32imm:$amt2),
                               "#ADJCALLSTACKUP $amt1 $amt2",
-                              [(callseq_end timm:$amt1, timm:$amt2)]>;
+                              [(callseq_end u32imm_timm:$amt1, u32imm_timm:$amt2)]>;
 }
 } // hasCtrlDep
 

--- a/llvm/lib/Target/PowerPC/PPCOperands.td
+++ b/llvm/lib/Target/PowerPC/PPCOperands.td
@@ -116,6 +116,7 @@ def U7Imm : ImmediateAsmOperand<"isUImm<7>">;
 def U8Imm : ImmediateAsmOperand<"isUImm<8>">;
 def U10Imm : ImmediateAsmOperand<"isUImm<10>">;
 def U12Imm : ImmediateAsmOperand<"isUImm<12>">;
+def U32Imm : ImmediateAsmOperand<"isUImm<32>">;
 def S5Imm : ImmediateAsmOperand<"isSImm<5>">;
 
 // Special cases that have custom predicat and/or render method.
@@ -167,6 +168,9 @@ defm u10imm : UnsignedImmediate<i32,
 defm u12imm : UnsignedImmediate<i32,
   [{ return isUInt<12>(Imm); }], NOOP_SDNodeXForm,
   "U12Imm", 12>;
+defm u32imm : UnsignedImmediate<i32,
+  [{ return isUInt<32>(Imm); }], NOOP_SDNodeXForm,
+  "U32Imm", 32>;
 
 defm s5imm : SignedImmediate<i32,
   [{ return isInt<5>(Imm); }], NOOP_SDNodeXForm,


### PR DESCRIPTION
ADJCALLSTACKUP and ADJCALLSTACKDOWN can actually take on values greater then what can be contained in u16imm type.  Update to use u32imm instead.