### PR TITLE
[WebAssembly] Fold any/alltrue SIMD boolean reductions with eqz

### DIFF
--- a/llvm/lib/Target/WebAssembly/WebAssemblyInstrSIMD.td
+++ b/llvm/lib/Target/WebAssembly/WebAssemblyInstrSIMD.td
@@ -999,7 +999,9 @@ defvar inst = !cast<NI>(reduction[1]);
 defvar vec = !cast<Vec>(reduction[2]);
 def : Pat<(i32 (and (i32 (intrinsic (vec.vt V128:$x))), (i32 1))), (inst $x)>;
 def : Pat<(i32 (setne (i32 (intrinsic (vec.vt V128:$x))), (i32 0))), (inst $x)>;
+def : Pat<(i32 (setne (i32 (intrinsic (vec.vt V128:$x))), (i32 1))), (i32 (EQZ_I32 (inst $x)))>;
 def : Pat<(i32 (seteq (i32 (intrinsic (vec.vt V128:$x))), (i32 1))), (inst $x)>;
+def : Pat<(i32 (seteq (i32 (intrinsic (vec.vt V128:$x))), (i32 0))), (i32 (EQZ_I32 (inst $x)))>;
 }
 
 multiclass SIMDBitmask<Vec vec, bits<32> simdop> {

--- a/llvm/test/CodeGen/WebAssembly/simd-memcmp.ll
+++ b/llvm/test/CodeGen/WebAssembly/simd-memcmp.ll
@@ -17,8 +17,7 @@ define i1 @memcmp_zero(ptr %d) {
 ; CHECK-NEXT:    i32.const 0
 ; CHECK-NEXT:    v128.load 0:p2align=0
 ; CHECK-NEXT:    v128.any_true
-; CHECK-NEXT:    i32.const 1
-; CHECK-NEXT:    i32.ne
+; CHECK-NEXT:    i32.eqz
 ; CHECK-NEXT:    # fallthrough-return
 entry:
   call void @llvm.memset.p0.i32(ptr %d, i8 0, i32 16, i1 false)

--- a/llvm/test/CodeGen/WebAssembly/simd-reductions.ll
+++ b/llvm/test/CodeGen/WebAssembly/simd-reductions.ll
@@ -44,6 +44,30 @@ define i32 @any_v16i8_eq(<16 x i8> %x) {
   ret i32 %c
 }
 
+; CHECK-LABEL: any_v16i8_eq_0:
+; CHECK-NEXT: .functype any_v16i8_eq_0 (v128) -> (i32){{$}}
+; CHECK-NEXT: v128.any_true $push[[T:[0-9]+]]=, $0{{$}}
+; CHECK-NEXT: i32.eqz $push[[R:[0-9]+]]=, $pop[[T]]{{$}}
+; CHECK-NEXT: return $pop[[R]]{{$}}
+define i32 @any_v16i8_eq_0(<16 x i8> %x) {
+  %a = call i32 @llvm.wasm.anytrue.v16i8(<16 x i8> %x)
+  %b = icmp eq i32 %a, 0
+  %c = zext i1 %b to i32
+  ret i32 %c
+}
+
+; CHECK-LABEL: any_v16i8_ne_1:
+; CHECK-NEXT: .functype any_v16i8_ne_1 (v128) -> (i32){{$}}
+; CHECK-NEXT: v128.any_true $push[[T:[0-9]+]]=, $0{{$}}
+; CHECK-NEXT: i32.eqz $push[[R:[0-9]+]]=, $pop[[T]]{{$}}
+; CHECK-NEXT: return $pop[[R]]{{$}}
+define i32 @any_v16i8_ne_1(<16 x i8> %x) {
+  %a = call i32 @llvm.wasm.anytrue.v16i8(<16 x i8> %x)
+  %b = icmp ne i32 %a, 1
+  %c = zext i1 %b to i32
+  ret i32 %c
+}
+
 ; CHECK-LABEL: all_v16i8_trunc:
 ; CHECK-NEXT: .functype all_v16i8_trunc (v128) -> (i32){{$}}
 ; CHECK-NEXT: i8x16.all_true $push[[R:[0-9]+]]=, $0{{$}}
@@ -73,6 +97,30 @@ define i32 @all_v16i8_ne(<16 x i8> %x) {
 define i32 @all_v16i8_eq(<16 x i8> %x) {
   %a = call i32 @llvm.wasm.alltrue.v16i8(<16 x i8> %x)
   %b = icmp eq i32 %a, 1
+  %c = zext i1 %b to i32
+  ret i32 %c
+}
+
+; CHECK-LABEL: all_v16i8_eq_0:
+; CHECK-NEXT: .functype all_v16i8_eq_0 (v128) -> (i32){{$}}
+; CHECK-NEXT: i8x16.all_true $push[[T:[0-9]+]]=, $0{{$}}
+; CHECK-NEXT: i32.eqz $push[[R:[0-9]+]]=, $pop[[T]]{{$}}
+; CHECK-NEXT: return $pop[[R]]{{$}}
+define i32 @all_v16i8_eq_0(<16 x i8> %x) {
+  %a = call i32 @llvm.wasm.alltrue.v16i8(<16 x i8> %x)
+  %b = icmp eq i32 %a, 0
+  %c = zext i1 %b to i32
+  ret i32 %c
+}
+
+; CHECK-LABEL: all_v16i8_ne_1:
+; CHECK-NEXT: .functype all_v16i8_ne_1 (v128) -> (i32){{$}}
+; CHECK-NEXT: i8x16.all_true $push[[T:[0-9]+]]=, $0{{$}}
+; CHECK-NEXT: i32.eqz $push[[R:[0-9]+]]=, $pop[[T]]{{$}}
+; CHECK-NEXT: return $pop[[R]]{{$}}
+define i32 @all_v16i8_ne_1(<16 x i8> %x) {
+  %a = call i32 @llvm.wasm.alltrue.v16i8(<16 x i8> %x)
+  %b = icmp ne i32 %a, 1
   %c = zext i1 %b to i32
   ret i32 %c
 }
@@ -116,6 +164,30 @@ define i32 @any_v8i16_eq(<8 x i16> %x) {
   ret i32 %c
 }
 
+; CHECK-LABEL: any_v8i16_eq_0:
+; CHECK-NEXT: .functype any_v8i16_eq_0 (v128) -> (i32){{$}}
+; CHECK-NEXT: v128.any_true $push[[T:[0-9]+]]=, $0{{$}}
+; CHECK-NEXT: i32.eqz $push[[R:[0-9]+]]=, $pop[[T]]{{$}}
+; CHECK-NEXT: return $pop[[R]]{{$}}
+define i32 @any_v8i16_eq_0(<8 x i16> %x) {
+  %a = call i32 @llvm.wasm.anytrue.v8i16(<8 x i16> %x)
+  %b = icmp eq i32 %a, 0
+  %c = zext i1 %b to i32
+  ret i32 %c
+}
+
+; CHECK-LABEL: any_v8i16_ne_1:
+; CHECK-NEXT: .functype any_v8i16_ne_1 (v128) -> (i32){{$}}
+; CHECK-NEXT: v128.any_true $push[[T:[0-9]+]]=, $0{{$}}
+; CHECK-NEXT: i32.eqz $push[[R:[0-9]+]]=, $pop[[T]]{{$}}
+; CHECK-NEXT: return $pop[[R]]{{$}}
+define i32 @any_v8i16_ne_1(<8 x i16> %x) {
+  %a = call i32 @llvm.wasm.anytrue.v8i16(<8 x i16> %x)
+  %b = icmp ne i32 %a, 1
+  %c = zext i1 %b to i32
+  ret i32 %c
+}
+
 ; CHECK-LABEL: all_v8i16_trunc:
 ; CHECK-NEXT: .functype all_v8i16_trunc (v128) -> (i32){{$}}
 ; CHECK-NEXT: i16x8.all_true $push[[R:[0-9]+]]=, $0{{$}}
@@ -145,6 +217,30 @@ define i32 @all_v8i16_ne(<8 x i16> %x) {
 define i32 @all_v8i16_eq(<8 x i16> %x) {
   %a = call i32 @llvm.wasm.alltrue.v8i16(<8 x i16> %x)
   %b = icmp eq i32 %a, 1
+  %c = zext i1 %b to i32
+  ret i32 %c
+}
+
+; CHECK-LABEL: all_v8i16_eq_0:
+; CHECK-NEXT: .functype all_v8i16_eq_0 (v128) -> (i32){{$}}
+; CHECK-NEXT: i16x8.all_true $push[[T:[0-9]+]]=, $0{{$}}
+; CHECK-NEXT: i32.eqz $push[[R:[0-9]+]]=, $pop[[T]]{{$}}
+; CHECK-NEXT: return $pop[[R]]{{$}}
+define i32 @all_v8i16_eq_0(<8 x i16> %x) {
+  %a = call i32 @llvm.wasm.alltrue.v8i16(<8 x i16> %x)
+  %b = icmp eq i32 %a, 0
+  %c = zext i1 %b to i32
+  ret i32 %c
+}
+
+; CHECK-LABEL: all_v8i16_ne_1:
+; CHECK-NEXT: .functype all_v8i16_ne_1 (v128) -> (i32){{$}}
+; CHECK-NEXT: i16x8.all_true $push[[T:[0-9]+]]=, $0{{$}}
+; CHECK-NEXT: i32.eqz $push[[R:[0-9]+]]=, $pop[[T]]{{$}}
+; CHECK-NEXT: return $pop[[R]]{{$}}
+define i32 @all_v8i16_ne_1(<8 x i16> %x) {
+  %a = call i32 @llvm.wasm.alltrue.v8i16(<8 x i16> %x)
+  %b = icmp ne i32 %a, 1
   %c = zext i1 %b to i32
   ret i32 %c
 }
@@ -188,6 +284,30 @@ define i32 @any_v4i32_eq(<4 x i32> %x) {
   ret i32 %c
 }
 
+; CHECK-LABEL: any_v4i32_eq_0:
+; CHECK-NEXT: .functype any_v4i32_eq_0 (v128) -> (i32){{$}}
+; CHECK-NEXT: v128.any_true $push[[T:[0-9]+]]=, $0{{$}}
+; CHECK-NEXT: i32.eqz $push[[R:[0-9]+]]=, $pop[[T]]{{$}}
+; CHECK-NEXT: return $pop[[R]]{{$}}
+define i32 @any_v4i32_eq_0(<4 x i32> %x) {
+  %a = call i32 @llvm.wasm.anytrue.v4i32(<4 x i32> %x)
+  %b = icmp eq i32 %a, 0
+  %c = zext i1 %b to i32
+  ret i32 %c
+}
+
+; CHECK-LABEL: any_v4i32_ne_1:
+; CHECK-NEXT: .functype any_v4i32_ne_1 (v128) -> (i32){{$}}
+; CHECK-NEXT: v128.any_true $push[[T:[0-9]+]]=, $0{{$}}
+; CHECK-NEXT: i32.eqz $push[[R:[0-9]+]]=, $pop[[T]]{{$}}
+; CHECK-NEXT: return $pop[[R]]{{$}}
+define i32 @any_v4i32_ne_1(<4 x i32> %x) {
+  %a = call i32 @llvm.wasm.anytrue.v4i32(<4 x i32> %x)
+  %b = icmp ne i32 %a, 1
+  %c = zext i1 %b to i32
+  ret i32 %c
+}
+
 ; CHECK-LABEL: all_v4i32_trunc:
 ; CHECK-NEXT: .functype all_v4i32_trunc (v128) -> (i32){{$}}
 ; CHECK-NEXT: i32x4.all_true $push[[R:[0-9]+]]=, $0{{$}}
@@ -217,6 +337,30 @@ define i32 @all_v4i32_ne(<4 x i32> %x) {
 define i32 @all_v4i32_eq(<4 x i32> %x) {
   %a = call i32 @llvm.wasm.alltrue.v4i32(<4 x i32> %x)
   %b = icmp eq i32 %a, 1
+  %c = zext i1 %b to i32
+  ret i32 %c
+}
+
+; CHECK-LABEL: all_v4i32_eq_0:
+; CHECK-NEXT: .functype all_v4i32_eq_0 (v128) -> (i32){{$}}
+; CHECK-NEXT: i32x4.all_true $push[[T:[0-9]+]]=, $0{{$}}
+; CHECK-NEXT: i32.eqz $push[[R:[0-9]+]]=, $pop[[T]]{{$}}
+; CHECK-NEXT: return $pop[[R]]{{$}}
+define i32 @all_v4i32_eq_0(<4 x i32> %x) {
+  %a = call i32 @llvm.wasm.alltrue.v4i32(<4 x i32> %x)
+  %b = icmp eq i32 %a, 0
+  %c = zext i1 %b to i32
+  ret i32 %c
+}
+
+; CHECK-LABEL: all_v4i32_ne_1:
+; CHECK-NEXT: .functype all_v4i32_ne_1 (v128) -> (i32){{$}}
+; CHECK-NEXT: i32x4.all_true $push[[T:[0-9]+]]=, $0{{$}}
+; CHECK-NEXT: i32.eqz $push[[R:[0-9]+]]=, $pop[[T]]{{$}}
+; CHECK-NEXT: return $pop[[R]]{{$}}
+define i32 @all_v4i32_ne_1(<4 x i32> %x) {
+  %a = call i32 @llvm.wasm.alltrue.v4i32(<4 x i32> %x)
+  %b = icmp ne i32 %a, 1
   %c = zext i1 %b to i32
   ret i32 %c
 }
@@ -260,6 +404,30 @@ define i32 @any_v2i64_eq(<2 x i64> %x) {
   ret i32 %c
 }
 
+; CHECK-LABEL: any_v2i64_eq_0:
+; CHECK-NEXT: .functype any_v2i64_eq_0 (v128) -> (i32){{$}}
+; CHECK-NEXT: v128.any_true $push[[T:[0-9]+]]=, $0{{$}}
+; CHECK-NEXT: i32.eqz $push[[R:[0-9]+]]=, $pop[[T]]{{$}}
+; CHECK-NEXT: return $pop[[R]]{{$}}
+define i32 @any_v2i64_eq_0(<2 x i64> %x) {
+  %a = call i32 @llvm.wasm.anytrue.v2i64(<2 x i64> %x)
+  %b = icmp eq i32 %a, 0
+  %c = zext i1 %b to i32
+  ret i32 %c
+}
+
+; CHECK-LABEL: any_v2i64_ne_1:
+; CHECK-NEXT: .functype any_v2i64_ne_1 (v128) -> (i32){{$}}
+; CHECK-NEXT: v128.any_true $push[[T:[0-9]+]]=, $0{{$}}
+; CHECK-NEXT: i32.eqz $push[[R:[0-9]+]]=, $pop[[T]]{{$}}
+; CHECK-NEXT: return $pop[[R]]{{$}}
+define i32 @any_v2i64_ne_1(<2 x i64> %x) {
+  %a = call i32 @llvm.wasm.anytrue.v2i64(<2 x i64> %x)
+  %b = icmp ne i32 %a, 1
+  %c = zext i1 %b to i32
+  ret i32 %c
+}
+
 ; CHECK-LABEL: all_v2i64_trunc:
 ; CHECK-NEXT: .functype all_v2i64_trunc (v128) -> (i32){{$}}
 ; CHECK-NEXT: i64x2.all_true $push[[R:[0-9]+]]=, $0{{$}}
@@ -289,6 +457,30 @@ define i32 @all_v2i64_ne(<2 x i64> %x) {
 define i32 @all_v2i64_eq(<2 x i64> %x) {
   %a = call i32 @llvm.wasm.alltrue.v2i64(<2 x i64> %x)
   %b = icmp eq i32 %a, 1
+  %c = zext i1 %b to i32
+  ret i32 %c
+}
+
+; CHECK-LABEL: all_v2i64_eq_0:
+; CHECK-NEXT: .functype all_v2i64_eq_0 (v128) -> (i32){{$}}
+; CHECK-NEXT: i64x2.all_true $push[[T:[0-9]+]]=, $0{{$}}
+; CHECK-NEXT: i32.eqz $push[[R:[0-9]+]]=, $pop[[T]]{{$}}
+; CHECK-NEXT: return $pop[[R]]{{$}}
+define i32 @all_v2i64_eq_0(<2 x i64> %x) {
+  %a = call i32 @llvm.wasm.alltrue.v2i64(<2 x i64> %x)
+  %b = icmp eq i32 %a, 0
+  %c = zext i1 %b to i32
+  ret i32 %c
+}
+
+; CHECK-LABEL: all_v2i64_ne_1:
+; CHECK-NEXT: .functype all_v2i64_ne_1 (v128) -> (i32){{$}}
+; CHECK-NEXT: i64x2.all_true $push[[T:[0-9]+]]=, $0{{$}}
+; CHECK-NEXT: i32.eqz $push[[R:[0-9]+]]=, $pop[[T]]{{$}}
+; CHECK-NEXT: return $pop[[R]]{{$}}
+define i32 @all_v2i64_ne_1(<2 x i64> %x) {
+  %a = call i32 @llvm.wasm.alltrue.v2i64(<2 x i64> %x)
+  %b = icmp ne i32 %a, 1
   %c = zext i1 %b to i32
   ret i32 %c
 }

--- a/llvm/test/CodeGen/WebAssembly/simd-reductions.ll
+++ b/llvm/test/CodeGen/WebAssembly/simd-reductions.ll
@@ -22,36 +22,13 @@ define i32 @any_v16i8_trunc(<16 x i8> %x) {
   ret i32 %c
 }
 
-; CHECK-LABEL: any_v16i8_ne:
-; CHECK-NEXT: .functype any_v16i8_ne (v128) -> (i32){{$}}
+; CHECK-LABEL: any_v16i8_ne_0:
+; CHECK-NEXT: .functype any_v16i8_ne_0 (v128) -> (i32){{$}}
 ; CHECK-NEXT: v128.any_true $push[[R:[0-9]+]]=, $0{{$}}
 ; CHECK-NEXT: return $pop[[R]]{{$}}
-define i32 @any_v16i8_ne(<16 x i8> %x) {
+define i32 @any_v16i8_ne_0(<16 x i8> %x) {
   %a = call i32 @llvm.wasm.anytrue.v16i8(<16 x i8> %x)
   %b = icmp ne i32 %a, 0
-  %c = zext i1 %b to i32
-  ret i32 %c
-}
-
-; CHECK-LABEL: any_v16i8_eq:
-; CHECK-NEXT: .functype any_v16i8_eq (v128) -> (i32){{$}}
-; CHECK-NEXT: v128.any_true $push[[R:[0-9]+]]=, $0{{$}}
-; CHECK-NEXT: return $pop[[R]]{{$}}
-define i32 @any_v16i8_eq(<16 x i8> %x) {
-  %a = call i32 @llvm.wasm.anytrue.v16i8(<16 x i8> %x)
-  %b = icmp eq i32 %a, 1
-  %c = zext i1 %b to i32
-  ret i32 %c
-}
-
-; CHECK-LABEL: any_v16i8_eq_0:
-; CHECK-NEXT: .functype any_v16i8_eq_0 (v128) -> (i32){{$}}
-; CHECK-NEXT: v128.any_true $push[[T:[0-9]+]]=, $0{{$}}
-; CHECK-NEXT: i32.eqz $push[[R:[0-9]+]]=, $pop[[T]]{{$}}
-; CHECK-NEXT: return $pop[[R]]{{$}}
-define i32 @any_v16i8_eq_0(<16 x i8> %x) {
-  %a = call i32 @llvm.wasm.anytrue.v16i8(<16 x i8> %x)
-  %b = icmp eq i32 %a, 0
   %c = zext i1 %b to i32
   ret i32 %c
 }
@@ -68,6 +45,29 @@ define i32 @any_v16i8_ne_1(<16 x i8> %x) {
   ret i32 %c
 }
 
+; CHECK-LABEL: any_v16i8_eq_0:
+; CHECK-NEXT: .functype any_v16i8_eq_0 (v128) -> (i32){{$}}
+; CHECK-NEXT: v128.any_true $push[[T:[0-9]+]]=, $0{{$}}
+; CHECK-NEXT: i32.eqz $push[[R:[0-9]+]]=, $pop[[T]]{{$}}
+; CHECK-NEXT: return $pop[[R]]{{$}}
+define i32 @any_v16i8_eq_0(<16 x i8> %x) {
+  %a = call i32 @llvm.wasm.anytrue.v16i8(<16 x i8> %x)
+  %b = icmp eq i32 %a, 0
+  %c = zext i1 %b to i32
+  ret i32 %c
+}
+
+; CHECK-LABEL: any_v16i8_eq_1:
+; CHECK-NEXT: .functype any_v16i8_eq_1 (v128) -> (i32){{$}}
+; CHECK-NEXT: v128.any_true $push[[R:[0-9]+]]=, $0{{$}}
+; CHECK-NEXT: return $pop[[R]]{{$}}
+define i32 @any_v16i8_eq_1(<16 x i8> %x) {
+  %a = call i32 @llvm.wasm.anytrue.v16i8(<16 x i8> %x)
+  %b = icmp eq i32 %a, 1
+  %c = zext i1 %b to i32
+  ret i32 %c
+}
+
 ; CHECK-LABEL: all_v16i8_trunc:
 ; CHECK-NEXT: .functype all_v16i8_trunc (v128) -> (i32){{$}}
 ; CHECK-NEXT: i8x16.all_true $push[[R:[0-9]+]]=, $0{{$}}
@@ -79,24 +79,25 @@ define i32 @all_v16i8_trunc(<16 x i8> %x) {
   ret i32 %c
 }
 
-; CHECK-LABEL: all_v16i8_ne:
-; CHECK-NEXT: .functype all_v16i8_ne (v128) -> (i32){{$}}
+; CHECK-LABEL: all_v16i8_ne_0:
+; CHECK-NEXT: .functype all_v16i8_ne_0 (v128) -> (i32){{$}}
 ; CHECK-NEXT: i8x16.all_true $push[[R:[0-9]+]]=, $0{{$}}
 ; CHECK-NEXT: return $pop[[R]]{{$}}
-define i32 @all_v16i8_ne(<16 x i8> %x) {
+define i32 @all_v16i8_ne_0(<16 x i8> %x) {
   %a = call i32 @llvm.wasm.alltrue.v16i8(<16 x i8> %x)
   %b = icmp ne i32 %a, 0
   %c = zext i1 %b to i32
   ret i32 %c
 }
 
-; CHECK-LABEL: all_v16i8_eq:
-; CHECK-NEXT: .functype all_v16i8_eq (v128) -> (i32){{$}}
-; CHECK-NEXT: i8x16.all_true $push[[R:[0-9]+]]=, $0{{$}}
+; CHECK-LABEL: all_v16i8_ne_1:
+; CHECK-NEXT: .functype all_v16i8_ne_1 (v128) -> (i32){{$}}
+; CHECK-NEXT: i8x16.all_true $push[[T:[0-9]+]]=, $0{{$}}
+; CHECK-NEXT: i32.eqz $push[[R:[0-9]+]]=, $pop[[T]]{{$}}
 ; CHECK-NEXT: return $pop[[R]]{{$}}
-define i32 @all_v16i8_eq(<16 x i8> %x) {
+define i32 @all_v16i8_ne_1(<16 x i8> %x) {
   %a = call i32 @llvm.wasm.alltrue.v16i8(<16 x i8> %x)
-  %b = icmp eq i32 %a, 1
+  %b = icmp ne i32 %a, 1
   %c = zext i1 %b to i32
   ret i32 %c
 }
@@ -113,17 +114,17 @@ define i32 @all_v16i8_eq_0(<16 x i8> %x) {
   ret i32 %c
 }
 
-; CHECK-LABEL: all_v16i8_ne_1:
-; CHECK-NEXT: .functype all_v16i8_ne_1 (v128) -> (i32){{$}}
-; CHECK-NEXT: i8x16.all_true $push[[T:[0-9]+]]=, $0{{$}}
-; CHECK-NEXT: i32.eqz $push[[R:[0-9]+]]=, $pop[[T]]{{$}}
+; CHECK-LABEL: all_v16i8_eq_1:
+; CHECK-NEXT: .functype all_v16i8_eq_1 (v128) -> (i32){{$}}
+; CHECK-NEXT: i8x16.all_true $push[[R:[0-9]+]]=, $0{{$}}
 ; CHECK-NEXT: return $pop[[R]]{{$}}
-define i32 @all_v16i8_ne_1(<16 x i8> %x) {
+define i32 @all_v16i8_eq_1(<16 x i8> %x) {
   %a = call i32 @llvm.wasm.alltrue.v16i8(<16 x i8> %x)
-  %b = icmp ne i32 %a, 1
+  %b = icmp eq i32 %a, 1
   %c = zext i1 %b to i32
   ret i32 %c
 }
+
 
 ; ==============================================================================
 ; 8 x i16
@@ -142,36 +143,13 @@ define i32 @any_v8i16_trunc(<8 x i16> %x) {
   ret i32 %c
 }
 
-; CHECK-LABEL: any_v8i16_ne:
-; CHECK-NEXT: .functype any_v8i16_ne (v128) -> (i32){{$}}
+; CHECK-LABEL: any_v8i16_ne_0:
+; CHECK-NEXT: .functype any_v8i16_ne_0 (v128) -> (i32){{$}}
 ; CHECK-NEXT: v128.any_true $push[[R:[0-9]+]]=, $0{{$}}
 ; CHECK-NEXT: return $pop[[R]]{{$}}
-define i32 @any_v8i16_ne(<8 x i16> %x) {
+define i32 @any_v8i16_ne_0(<8 x i16> %x) {
   %a = call i32 @llvm.wasm.anytrue.v8i16(<8 x i16> %x)
   %b = icmp ne i32 %a, 0
-  %c = zext i1 %b to i32
-  ret i32 %c
-}
-
-; CHECK-LABEL: any_v8i16_eq:
-; CHECK-NEXT: .functype any_v8i16_eq (v128) -> (i32){{$}}
-; CHECK-NEXT: v128.any_true $push[[R:[0-9]+]]=, $0{{$}}
-; CHECK-NEXT: return $pop[[R]]{{$}}
-define i32 @any_v8i16_eq(<8 x i16> %x) {
-  %a = call i32 @llvm.wasm.anytrue.v8i16(<8 x i16> %x)
-  %b = icmp eq i32 %a, 1
-  %c = zext i1 %b to i32
-  ret i32 %c
-}
-
-; CHECK-LABEL: any_v8i16_eq_0:
-; CHECK-NEXT: .functype any_v8i16_eq_0 (v128) -> (i32){{$}}
-; CHECK-NEXT: v128.any_true $push[[T:[0-9]+]]=, $0{{$}}
-; CHECK-NEXT: i32.eqz $push[[R:[0-9]+]]=, $pop[[T]]{{$}}
-; CHECK-NEXT: return $pop[[R]]{{$}}
-define i32 @any_v8i16_eq_0(<8 x i16> %x) {
-  %a = call i32 @llvm.wasm.anytrue.v8i16(<8 x i16> %x)
-  %b = icmp eq i32 %a, 0
   %c = zext i1 %b to i32
   ret i32 %c
 }
@@ -188,6 +166,29 @@ define i32 @any_v8i16_ne_1(<8 x i16> %x) {
   ret i32 %c
 }
 
+; CHECK-LABEL: any_v8i16_eq_0:
+; CHECK-NEXT: .functype any_v8i16_eq_0 (v128) -> (i32){{$}}
+; CHECK-NEXT: v128.any_true $push[[T:[0-9]+]]=, $0{{$}}
+; CHECK-NEXT: i32.eqz $push[[R:[0-9]+]]=, $pop[[T]]{{$}}
+; CHECK-NEXT: return $pop[[R]]{{$}}
+define i32 @any_v8i16_eq_0(<8 x i16> %x) {
+  %a = call i32 @llvm.wasm.anytrue.v8i16(<8 x i16> %x)
+  %b = icmp eq i32 %a, 0
+  %c = zext i1 %b to i32
+  ret i32 %c
+}
+
+; CHECK-LABEL: any_v8i16_eq_1:
+; CHECK-NEXT: .functype any_v8i16_eq_1 (v128) -> (i32){{$}}
+; CHECK-NEXT: v128.any_true $push[[R:[0-9]+]]=, $0{{$}}
+; CHECK-NEXT: return $pop[[R]]{{$}}
+define i32 @any_v8i16_eq_1(<8 x i16> %x) {
+  %a = call i32 @llvm.wasm.anytrue.v8i16(<8 x i16> %x)
+  %b = icmp eq i32 %a, 1
+  %c = zext i1 %b to i32
+  ret i32 %c
+}
+
 ; CHECK-LABEL: all_v8i16_trunc:
 ; CHECK-NEXT: .functype all_v8i16_trunc (v128) -> (i32){{$}}
 ; CHECK-NEXT: i16x8.all_true $push[[R:[0-9]+]]=, $0{{$}}
@@ -199,24 +200,25 @@ define i32 @all_v8i16_trunc(<8 x i16> %x) {
   ret i32 %c
 }
 
-; CHECK-LABEL: all_v8i16_ne:
-; CHECK-NEXT: .functype all_v8i16_ne (v128) -> (i32){{$}}
+; CHECK-LABEL: all_v8i16_ne_0:
+; CHECK-NEXT: .functype all_v8i16_ne_0 (v128) -> (i32){{$}}
 ; CHECK-NEXT: i16x8.all_true $push[[R:[0-9]+]]=, $0{{$}}
 ; CHECK-NEXT: return $pop[[R]]{{$}}
-define i32 @all_v8i16_ne(<8 x i16> %x) {
+define i32 @all_v8i16_ne_0(<8 x i16> %x) {
   %a = call i32 @llvm.wasm.alltrue.v8i16(<8 x i16> %x)
   %b = icmp ne i32 %a, 0
   %c = zext i1 %b to i32
   ret i32 %c
 }
 
-; CHECK-LABEL: all_v8i16_eq:
-; CHECK-NEXT: .functype all_v8i16_eq (v128) -> (i32){{$}}
-; CHECK-NEXT: i16x8.all_true $push[[R:[0-9]+]]=, $0{{$}}
+; CHECK-LABEL: all_v8i16_ne_1:
+; CHECK-NEXT: .functype all_v8i16_ne_1 (v128) -> (i32){{$}}
+; CHECK-NEXT: i16x8.all_true $push[[T:[0-9]+]]=, $0{{$}}
+; CHECK-NEXT: i32.eqz $push[[R:[0-9]+]]=, $pop[[T]]{{$}}
 ; CHECK-NEXT: return $pop[[R]]{{$}}
-define i32 @all_v8i16_eq(<8 x i16> %x) {
+define i32 @all_v8i16_ne_1(<8 x i16> %x) {
   %a = call i32 @llvm.wasm.alltrue.v8i16(<8 x i16> %x)
-  %b = icmp eq i32 %a, 1
+  %b = icmp ne i32 %a, 1
   %c = zext i1 %b to i32
   ret i32 %c
 }
@@ -233,17 +235,17 @@ define i32 @all_v8i16_eq_0(<8 x i16> %x) {
   ret i32 %c
 }
 
-; CHECK-LABEL: all_v8i16_ne_1:
-; CHECK-NEXT: .functype all_v8i16_ne_1 (v128) -> (i32){{$}}
-; CHECK-NEXT: i16x8.all_true $push[[T:[0-9]+]]=, $0{{$}}
-; CHECK-NEXT: i32.eqz $push[[R:[0-9]+]]=, $pop[[T]]{{$}}
+; CHECK-LABEL: all_v8i16_eq_1:
+; CHECK-NEXT: .functype all_v8i16_eq_1 (v128) -> (i32){{$}}
+; CHECK-NEXT: i16x8.all_true $push[[R:[0-9]+]]=, $0{{$}}
 ; CHECK-NEXT: return $pop[[R]]{{$}}
-define i32 @all_v8i16_ne_1(<8 x i16> %x) {
+define i32 @all_v8i16_eq_1(<8 x i16> %x) {
   %a = call i32 @llvm.wasm.alltrue.v8i16(<8 x i16> %x)
-  %b = icmp ne i32 %a, 1
+  %b = icmp eq i32 %a, 1
   %c = zext i1 %b to i32
   ret i32 %c
 }
+
 
 ; ==============================================================================
 ; 4 x i32
@@ -262,36 +264,13 @@ define i32 @any_v4i32_trunc(<4 x i32> %x) {
   ret i32 %c
 }
 
-; CHECK-LABEL: any_v4i32_ne:
-; CHECK-NEXT: .functype any_v4i32_ne (v128) -> (i32){{$}}
+; CHECK-LABEL: any_v4i32_ne_0:
+; CHECK-NEXT: .functype any_v4i32_ne_0 (v128) -> (i32){{$}}
 ; CHECK-NEXT: v128.any_true $push[[R:[0-9]+]]=, $0{{$}}
 ; CHECK-NEXT: return $pop[[R]]{{$}}
-define i32 @any_v4i32_ne(<4 x i32> %x) {
+define i32 @any_v4i32_ne_0(<4 x i32> %x) {
   %a = call i32 @llvm.wasm.anytrue.v4i32(<4 x i32> %x)
   %b = icmp ne i32 %a, 0
-  %c = zext i1 %b to i32
-  ret i32 %c
-}
-
-; CHECK-LABEL: any_v4i32_eq:
-; CHECK-NEXT: .functype any_v4i32_eq (v128) -> (i32){{$}}
-; CHECK-NEXT: v128.any_true $push[[R:[0-9]+]]=, $0{{$}}
-; CHECK-NEXT: return $pop[[R]]{{$}}
-define i32 @any_v4i32_eq(<4 x i32> %x) {
-  %a = call i32 @llvm.wasm.anytrue.v4i32(<4 x i32> %x)
-  %b = icmp eq i32 %a, 1
-  %c = zext i1 %b to i32
-  ret i32 %c
-}
-
-; CHECK-LABEL: any_v4i32_eq_0:
-; CHECK-NEXT: .functype any_v4i32_eq_0 (v128) -> (i32){{$}}
-; CHECK-NEXT: v128.any_true $push[[T:[0-9]+]]=, $0{{$}}
-; CHECK-NEXT: i32.eqz $push[[R:[0-9]+]]=, $pop[[T]]{{$}}
-; CHECK-NEXT: return $pop[[R]]{{$}}
-define i32 @any_v4i32_eq_0(<4 x i32> %x) {
-  %a = call i32 @llvm.wasm.anytrue.v4i32(<4 x i32> %x)
-  %b = icmp eq i32 %a, 0
   %c = zext i1 %b to i32
   ret i32 %c
 }
@@ -308,6 +287,29 @@ define i32 @any_v4i32_ne_1(<4 x i32> %x) {
   ret i32 %c
 }
 
+; CHECK-LABEL: any_v4i32_eq_0:
+; CHECK-NEXT: .functype any_v4i32_eq_0 (v128) -> (i32){{$}}
+; CHECK-NEXT: v128.any_true $push[[T:[0-9]+]]=, $0{{$}}
+; CHECK-NEXT: i32.eqz $push[[R:[0-9]+]]=, $pop[[T]]{{$}}
+; CHECK-NEXT: return $pop[[R]]{{$}}
+define i32 @any_v4i32_eq_0(<4 x i32> %x) {
+  %a = call i32 @llvm.wasm.anytrue.v4i32(<4 x i32> %x)
+  %b = icmp eq i32 %a, 0
+  %c = zext i1 %b to i32
+  ret i32 %c
+}
+
+; CHECK-LABEL: any_v4i32_eq_1:
+; CHECK-NEXT: .functype any_v4i32_eq_1 (v128) -> (i32){{$}}
+; CHECK-NEXT: v128.any_true $push[[R:[0-9]+]]=, $0{{$}}
+; CHECK-NEXT: return $pop[[R]]{{$}}
+define i32 @any_v4i32_eq_1(<4 x i32> %x) {
+  %a = call i32 @llvm.wasm.anytrue.v4i32(<4 x i32> %x)
+  %b = icmp eq i32 %a, 1
+  %c = zext i1 %b to i32
+  ret i32 %c
+}
+
 ; CHECK-LABEL: all_v4i32_trunc:
 ; CHECK-NEXT: .functype all_v4i32_trunc (v128) -> (i32){{$}}
 ; CHECK-NEXT: i32x4.all_true $push[[R:[0-9]+]]=, $0{{$}}
@@ -319,24 +321,25 @@ define i32 @all_v4i32_trunc(<4 x i32> %x) {
   ret i32 %c
 }
 
-; CHECK-LABEL: all_v4i32_ne:
-; CHECK-NEXT: .functype all_v4i32_ne (v128) -> (i32){{$}}
+; CHECK-LABEL: all_v4i32_ne_0:
+; CHECK-NEXT: .functype all_v4i32_ne_0 (v128) -> (i32){{$}}
 ; CHECK-NEXT: i32x4.all_true $push[[R:[0-9]+]]=, $0{{$}}
 ; CHECK-NEXT: return $pop[[R]]{{$}}
-define i32 @all_v4i32_ne(<4 x i32> %x) {
+define i32 @all_v4i32_ne_0(<4 x i32> %x) {
   %a = call i32 @llvm.wasm.alltrue.v4i32(<4 x i32> %x)
   %b = icmp ne i32 %a, 0
   %c = zext i1 %b to i32
   ret i32 %c
 }
 
-; CHECK-LABEL: all_v4i32_eq:
-; CHECK-NEXT: .functype all_v4i32_eq (v128) -> (i32){{$}}
-; CHECK-NEXT: i32x4.all_true $push[[R:[0-9]+]]=, $0{{$}}
+; CHECK-LABEL: all_v4i32_ne_1:
+; CHECK-NEXT: .functype all_v4i32_ne_1 (v128) -> (i32){{$}}
+; CHECK-NEXT: i32x4.all_true $push[[T:[0-9]+]]=, $0{{$}}
+; CHECK-NEXT: i32.eqz $push[[R:[0-9]+]]=, $pop[[T]]{{$}}
 ; CHECK-NEXT: return $pop[[R]]{{$}}
-define i32 @all_v4i32_eq(<4 x i32> %x) {
+define i32 @all_v4i32_ne_1(<4 x i32> %x) {
   %a = call i32 @llvm.wasm.alltrue.v4i32(<4 x i32> %x)
-  %b = icmp eq i32 %a, 1
+  %b = icmp ne i32 %a, 1
   %c = zext i1 %b to i32
   ret i32 %c
 }
@@ -353,17 +356,17 @@ define i32 @all_v4i32_eq_0(<4 x i32> %x) {
   ret i32 %c
 }
 
-; CHECK-LABEL: all_v4i32_ne_1:
-; CHECK-NEXT: .functype all_v4i32_ne_1 (v128) -> (i32){{$}}
-; CHECK-NEXT: i32x4.all_true $push[[T:[0-9]+]]=, $0{{$}}
-; CHECK-NEXT: i32.eqz $push[[R:[0-9]+]]=, $pop[[T]]{{$}}
+; CHECK-LABEL: all_v4i32_eq_1:
+; CHECK-NEXT: .functype all_v4i32_eq_1 (v128) -> (i32){{$}}
+; CHECK-NEXT: i32x4.all_true $push[[R:[0-9]+]]=, $0{{$}}
 ; CHECK-NEXT: return $pop[[R]]{{$}}
-define i32 @all_v4i32_ne_1(<4 x i32> %x) {
+define i32 @all_v4i32_eq_1(<4 x i32> %x) {
   %a = call i32 @llvm.wasm.alltrue.v4i32(<4 x i32> %x)
-  %b = icmp ne i32 %a, 1
+  %b = icmp eq i32 %a, 1
   %c = zext i1 %b to i32
   ret i32 %c
 }
+
 
 ; ==============================================================================
 ; 2 x i64
@@ -382,36 +385,13 @@ define i32 @any_v2i64_trunc(<2 x i64> %x) {
   ret i32 %c
 }
 
-; CHECK-LABEL: any_v2i64_ne:
-; CHECK-NEXT: .functype any_v2i64_ne (v128) -> (i32){{$}}
+; CHECK-LABEL: any_v2i64_ne_0:
+; CHECK-NEXT: .functype any_v2i64_ne_0 (v128) -> (i32){{$}}
 ; CHECK-NEXT: v128.any_true $push[[R:[0-9]+]]=, $0{{$}}
 ; CHECK-NEXT: return $pop[[R]]{{$}}
-define i32 @any_v2i64_ne(<2 x i64> %x) {
+define i32 @any_v2i64_ne_0(<2 x i64> %x) {
   %a = call i32 @llvm.wasm.anytrue.v2i64(<2 x i64> %x)
   %b = icmp ne i32 %a, 0
-  %c = zext i1 %b to i32
-  ret i32 %c
-}
-
-; CHECK-LABEL: any_v2i64_eq:
-; CHECK-NEXT: .functype any_v2i64_eq (v128) -> (i32){{$}}
-; CHECK-NEXT: v128.any_true $push[[R:[0-9]+]]=, $0{{$}}
-; CHECK-NEXT: return $pop[[R]]{{$}}
-define i32 @any_v2i64_eq(<2 x i64> %x) {
-  %a = call i32 @llvm.wasm.anytrue.v2i64(<2 x i64> %x)
-  %b = icmp eq i32 %a, 1
-  %c = zext i1 %b to i32
-  ret i32 %c
-}
-
-; CHECK-LABEL: any_v2i64_eq_0:
-; CHECK-NEXT: .functype any_v2i64_eq_0 (v128) -> (i32){{$}}
-; CHECK-NEXT: v128.any_true $push[[T:[0-9]+]]=, $0{{$}}
-; CHECK-NEXT: i32.eqz $push[[R:[0-9]+]]=, $pop[[T]]{{$}}
-; CHECK-NEXT: return $pop[[R]]{{$}}
-define i32 @any_v2i64_eq_0(<2 x i64> %x) {
-  %a = call i32 @llvm.wasm.anytrue.v2i64(<2 x i64> %x)
-  %b = icmp eq i32 %a, 0
   %c = zext i1 %b to i32
   ret i32 %c
 }
@@ -428,6 +408,29 @@ define i32 @any_v2i64_ne_1(<2 x i64> %x) {
   ret i32 %c
 }
 
+; CHECK-LABEL: any_v2i64_eq_0:
+; CHECK-NEXT: .functype any_v2i64_eq_0 (v128) -> (i32){{$}}
+; CHECK-NEXT: v128.any_true $push[[T:[0-9]+]]=, $0{{$}}
+; CHECK-NEXT: i32.eqz $push[[R:[0-9]+]]=, $pop[[T]]{{$}}
+; CHECK-NEXT: return $pop[[R]]{{$}}
+define i32 @any_v2i64_eq_0(<2 x i64> %x) {
+  %a = call i32 @llvm.wasm.anytrue.v2i64(<2 x i64> %x)
+  %b = icmp eq i32 %a, 0
+  %c = zext i1 %b to i32
+  ret i32 %c
+}
+
+; CHECK-LABEL: any_v2i64_eq_1:
+; CHECK-NEXT: .functype any_v2i64_eq_1 (v128) -> (i32){{$}}
+; CHECK-NEXT: v128.any_true $push[[R:[0-9]+]]=, $0{{$}}
+; CHECK-NEXT: return $pop[[R]]{{$}}
+define i32 @any_v2i64_eq_1(<2 x i64> %x) {
+  %a = call i32 @llvm.wasm.anytrue.v2i64(<2 x i64> %x)
+  %b = icmp eq i32 %a, 1
+  %c = zext i1 %b to i32
+  ret i32 %c
+}
+
 ; CHECK-LABEL: all_v2i64_trunc:
 ; CHECK-NEXT: .functype all_v2i64_trunc (v128) -> (i32){{$}}
 ; CHECK-NEXT: i64x2.all_true $push[[R:[0-9]+]]=, $0{{$}}
@@ -439,24 +442,25 @@ define i32 @all_v2i64_trunc(<2 x i64> %x) {
   ret i32 %c
 }
 
-; CHECK-LABEL: all_v2i64_ne:
-; CHECK-NEXT: .functype all_v2i64_ne (v128) -> (i32){{$}}
+; CHECK-LABEL: all_v2i64_ne_0:
+; CHECK-NEXT: .functype all_v2i64_ne_0 (v128) -> (i32){{$}}
 ; CHECK-NEXT: i64x2.all_true $push[[R:[0-9]+]]=, $0{{$}}
 ; CHECK-NEXT: return $pop[[R]]{{$}}
-define i32 @all_v2i64_ne(<2 x i64> %x) {
+define i32 @all_v2i64_ne_0(<2 x i64> %x) {
   %a = call i32 @llvm.wasm.alltrue.v2i64(<2 x i64> %x)
   %b = icmp ne i32 %a, 0
   %c = zext i1 %b to i32
   ret i32 %c
 }
 
-; CHECK-LABEL: all_v2i64_eq:
-; CHECK-NEXT: .functype all_v2i64_eq (v128) -> (i32){{$}}
-; CHECK-NEXT: i64x2.all_true $push[[R:[0-9]+]]=, $0{{$}}
+; CHECK-LABEL: all_v2i64_ne_1:
+; CHECK-NEXT: .functype all_v2i64_ne_1 (v128) -> (i32){{$}}
+; CHECK-NEXT: i64x2.all_true $push[[T:[0-9]+]]=, $0{{$}}
+; CHECK-NEXT: i32.eqz $push[[R:[0-9]+]]=, $pop[[T]]{{$}}
 ; CHECK-NEXT: return $pop[[R]]{{$}}
-define i32 @all_v2i64_eq(<2 x i64> %x) {
+define i32 @all_v2i64_ne_1(<2 x i64> %x) {
   %a = call i32 @llvm.wasm.alltrue.v2i64(<2 x i64> %x)
-  %b = icmp eq i32 %a, 1
+  %b = icmp ne i32 %a, 1
   %c = zext i1 %b to i32
   ret i32 %c
 }
@@ -473,14 +477,13 @@ define i32 @all_v2i64_eq_0(<2 x i64> %x) {
   ret i32 %c
 }
 
-; CHECK-LABEL: all_v2i64_ne_1:
-; CHECK-NEXT: .functype all_v2i64_ne_1 (v128) -> (i32){{$}}
-; CHECK-NEXT: i64x2.all_true $push[[T:[0-9]+]]=, $0{{$}}
-; CHECK-NEXT: i32.eqz $push[[R:[0-9]+]]=, $pop[[T]]{{$}}
+; CHECK-LABEL: all_v2i64_eq_1:
+; CHECK-NEXT: .functype all_v2i64_eq_1 (v128) -> (i32){{$}}
+; CHECK-NEXT: i64x2.all_true $push[[R:[0-9]+]]=, $0{{$}}
 ; CHECK-NEXT: return $pop[[R]]{{$}}
-define i32 @all_v2i64_ne_1(<2 x i64> %x) {
+define i32 @all_v2i64_eq_1(<2 x i64> %x) {
   %a = call i32 @llvm.wasm.alltrue.v2i64(<2 x i64> %x)
-  %b = icmp ne i32 %a, 1
+  %b = icmp eq i32 %a, 1
   %c = zext i1 %b to i32
   ret i32 %c
 }


### PR DESCRIPTION
Existing ISel patterns match setne/seteq following SIMD boolean reductions
any_true and all_true, and drop the ones that are redundant (because the
reductions always return 1 or 0). This adds patterns to also produce eqz
instructions instead of a comparison with a const.
