### PR TITLE
[BAZEL]Fix MLIR test config for NVPTX and AMDGPU target detection

### DIFF
--- a/utils/bazel/llvm-project-overlay/mlir/test/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/mlir/test/BUILD.bazel
@@ -38,10 +38,10 @@ expand_template(
         "\"@MLIR_BINARY_DIR@\"": "os.environ[\"TEST_UNDECLARED_OUTPUTS_DIR\"]",
         # All disabled, but required to substituted because they are not in quotes.
         "@LLVM_BUILD_EXAMPLES@": "0",
-        "@LLVM_HAS_NVPTX_TARGET@": "0",
+        "@LLVM_HAS_AMDGPU_TARGET@": "1" if (targets.contains("AMDGPU")) else "0",
+        "@LLVM_HAS_NVPTX_TARGET@": "1" if (targets.contains("NVPTX")) else "0",
         "@LLVM_INCLUDE_SPIRV_TOOLS_TESTS@": "0",
         "@MLIR_ENABLE_CUDA_RUNNER@": "0",
-        "@MLIR_ENABLE_ROCM_CONVERSIONS@": "0",
         "@MLIR_ENABLE_ROCM_RUNNER@": "0",
         "@MLIR_ENABLE_SYCL_RUNNER@": "0",
         "@MLIR_ENABLE_LEVELZERO_RUNNER@": "0",


### PR DESCRIPTION
It is a follow-up PR for #182652.
To correctly handle NVPTX and AMDGPU config in MLIR test, while based on configured Bazel targets, instead of
hardcoding them to 0.