### PR TITLE
Don't crash when given an empty input filename.

### DIFF
--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -3082,7 +3082,7 @@ void Driver::BuildInputs(const ToolChain &TC, DerivedArgList &Args,
           InputTypeArg->claim();
 
         // stdin must be handled specially.
-        if (memcmp(Value, "-", 2) == 0) {
+        if (strcmp(Value, "-") == 0) {
           if (IsFlangMode()) {
             Ty = types::TY_Fortran;
           } else if (IsDXCMode()) {

--- a/clang/test/Driver/empty_arg.c
+++ b/clang/test/Driver/empty_arg.c
@@ -1,0 +1,2 @@
+// RUN: not %clang -- "" 2>&1 | FileCheck %s
+// CHECK: error: no such file or directory: ''

--- a/llvm/lib/Option/OptTable.cpp
+++ b/llvm/lib/Option/OptTable.cpp
@@ -264,8 +264,6 @@ unsigned OptTable::internalFindNearest(
     StringRef Option, std::string &NearestString, unsigned MinimumLength,
     unsigned MaximumDistance,
     std::function<bool(const Info &)> ExcludeOption) const {
-  assert(!Option.empty());
-
   // Consider each [option prefix + option name] pair as a candidate, finding
   // the closest match.
   unsigned BestDistance =


### PR DESCRIPTION
Commands such as `clang -- ''` hit two different crash bugs: a buffer overflow caused by using a `memcmp` that might be larger than the input, and a bogus assert in the option parser when attempting typo correction.