### PR TITLE
[RISCV] Update Andes45 vector mask scheduling info

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVSchedAndes45.td
+++ b/llvm/lib/Target/RISCV/RISCVSchedAndes45.td
@@ -1103,13 +1103,26 @@ foreach mx = SchedMxListFWRed in {
 foreach mx = SchedMxList in {
   defvar IsWorstCase = Andes45IsWorstCaseMX<mx, SchedMxList>.c;
 
-  defm "" : LMULWriteResMX<"WriteVMALUV", [Andes45VMASK], mx, IsWorstCase>;
-  defm "" : LMULWriteResMX<"WriteVMPopV", [Andes45VMASK], mx, IsWorstCase>;
-  defm "" : LMULWriteResMX<"WriteVMFFSV", [Andes45VMASK], mx, IsWorstCase>;
-  defm "" : LMULWriteResMX<"WriteVMSFSV", [Andes45VMASK], mx, IsWorstCase>;
+  let Latency = 3, ReleaseAtCycles = [Andes45VLEN_DLEN_RATIO] in {
+    defm "" : LMULWriteResMX<"WriteVMALUV", [Andes45VMASK], mx, IsWorstCase>;
+    defm "" : LMULWriteResMX<"WriteVMSFSV", [Andes45VMASK], mx, IsWorstCase>;
+  }
 
-  defm "" : LMULWriteResMX<"WriteVIotaV", [Andes45VMASK], mx, IsWorstCase>;
-  defm "" : LMULWriteResMX<"WriteVIdxV", [Andes45VMASK], mx, IsWorstCase>;
+  let Latency = !add(3, !ne(Andes45VLEN, Andes45DLEN)),
+      ReleaseAtCycles = [Andes45VLEN_DLEN_RATIO] in {
+    defm "" : LMULWriteResMX<"WriteVMPopV", [Andes45VMASK], mx, IsWorstCase>;
+    defm "" : LMULWriteResMX<"WriteVMFFSV", [Andes45VMASK], mx, IsWorstCase>;
+  }
+
+}
+// TODO: viota and vid have different latency and throughput if VLEN/DLEN=2.
+foreach mx = SchedMxList in {
+  defvar Cycles = Andes45GetCyclesDefault<mx>.c;
+  defvar IsWorstCase = Andes45IsWorstCaseMX<mx, SchedMxList>.c;
+  let Latency = 4, ReleaseAtCycles = [Cycles] in {
+    defm "" : LMULWriteResMX<"WriteVIotaV", [Andes45VMASK], mx, IsWorstCase>;
+    defm "" : LMULWriteResMX<"WriteVIdxV", [Andes45VMASK], mx, IsWorstCase>;
+  }
 }
 
 // 16. Vector Permutation Instructions

--- a/llvm/test/tools/llvm-mca/RISCV/Andes45/rvv-mask.s
+++ b/llvm/test/tools/llvm-mca/RISCV/Andes45/rvv-mask.s
@@ -650,607 +650,607 @@ vfirst.m x8, v8
 
 # CHECK:      [1]    [2]    [3]    [4]    [5]    [6]    [7]    [8]                                        [9]                        Instructions:
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMAND_MM                   vmmv.m	v8, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMAND_MM                   vmmv.m	v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMAND_MM                   vmmv.m	v8, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMAND_MM                   vmmv.m	v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMAND_MM                   vmmv.m	v8, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMAND_MM                   vmmv.m	v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMAND_MM                   vmmv.m	v8, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMAND_MM                   vmmv.m	v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMAND_MM                   vmmv.m	v8, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMAND_MM                   vmmv.m	v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e8, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMAND_MM                   vmmv.m	v8, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMAND_MM                   vmmv.m	v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e8, m8, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMAND_MM                   vmmv.m	v8, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMAND_MM                   vmmv.m	v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMAND_MM                   vmmv.m	v8, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMAND_MM                   vmmv.m	v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMAND_MM                   vmmv.m	v8, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMAND_MM                   vmmv.m	v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMAND_MM                   vmmv.m	v8, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMAND_MM                   vmmv.m	v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMAND_MM                   vmmv.m	v8, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMAND_MM                   vmmv.m	v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e16, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMAND_MM                   vmmv.m	v8, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMAND_MM                   vmmv.m	v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e16, m8, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMAND_MM                   vmmv.m	v8, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMAND_MM                   vmmv.m	v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMAND_MM                   vmmv.m	v8, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMAND_MM                   vmmv.m	v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMAND_MM                   vmmv.m	v8, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMAND_MM                   vmmv.m	v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMAND_MM                   vmmv.m	v8, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMAND_MM                   vmmv.m	v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e32, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMAND_MM                   vmmv.m	v8, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMAND_MM                   vmmv.m	v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e32, m8, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMAND_MM                   vmmv.m	v8, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMAND_MM                   vmmv.m	v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMAND_MM                   vmmv.m	v8, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMAND_MM                   vmmv.m	v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMAND_MM                   vmmv.m	v8, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMAND_MM                   vmmv.m	v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e64, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMAND_MM                   vmmv.m	v8, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMAND_MM                   vmmv.m	v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e64, m8, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMAND_MM                   vmmv.m	v8, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMAND_MM                   vmmv.m	v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMNAND_MM                  vmnot.m	v8, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMNAND_MM                  vmnot.m	v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMNAND_MM                  vmnot.m	v8, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMNAND_MM                  vmnot.m	v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMNAND_MM                  vmnot.m	v8, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMNAND_MM                  vmnot.m	v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMNAND_MM                  vmnot.m	v8, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMNAND_MM                  vmnot.m	v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMNAND_MM                  vmnot.m	v8, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMNAND_MM                  vmnot.m	v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e8, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMNAND_MM                  vmnot.m	v8, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMNAND_MM                  vmnot.m	v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e8, m8, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMNAND_MM                  vmnot.m	v8, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMNAND_MM                  vmnot.m	v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMNAND_MM                  vmnot.m	v8, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMNAND_MM                  vmnot.m	v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMNAND_MM                  vmnot.m	v8, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMNAND_MM                  vmnot.m	v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMNAND_MM                  vmnot.m	v8, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMNAND_MM                  vmnot.m	v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMNAND_MM                  vmnot.m	v8, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMNAND_MM                  vmnot.m	v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e16, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMNAND_MM                  vmnot.m	v8, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMNAND_MM                  vmnot.m	v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e16, m8, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMNAND_MM                  vmnot.m	v8, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMNAND_MM                  vmnot.m	v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMNAND_MM                  vmnot.m	v8, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMNAND_MM                  vmnot.m	v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMNAND_MM                  vmnot.m	v8, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMNAND_MM                  vmnot.m	v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMNAND_MM                  vmnot.m	v8, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMNAND_MM                  vmnot.m	v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e32, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMNAND_MM                  vmnot.m	v8, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMNAND_MM                  vmnot.m	v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e32, m8, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMNAND_MM                  vmnot.m	v8, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMNAND_MM                  vmnot.m	v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMNAND_MM                  vmnot.m	v8, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMNAND_MM                  vmnot.m	v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMNAND_MM                  vmnot.m	v8, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMNAND_MM                  vmnot.m	v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e64, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMNAND_MM                  vmnot.m	v8, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMNAND_MM                  vmnot.m	v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e64, m8, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMNAND_MM                  vmnot.m	v8, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMNAND_MM                  vmnot.m	v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMANDN_MM                  vmandn.mm	v8, v8, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMANDN_MM                  vmandn.mm	v8, v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMANDN_MM                  vmandn.mm	v8, v8, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMANDN_MM                  vmandn.mm	v8, v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMANDN_MM                  vmandn.mm	v8, v8, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMANDN_MM                  vmandn.mm	v8, v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMANDN_MM                  vmandn.mm	v8, v8, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMANDN_MM                  vmandn.mm	v8, v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMANDN_MM                  vmandn.mm	v8, v8, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMANDN_MM                  vmandn.mm	v8, v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e8, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMANDN_MM                  vmandn.mm	v8, v8, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMANDN_MM                  vmandn.mm	v8, v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e8, m8, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMANDN_MM                  vmandn.mm	v8, v8, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMANDN_MM                  vmandn.mm	v8, v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMANDN_MM                  vmandn.mm	v8, v8, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMANDN_MM                  vmandn.mm	v8, v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMANDN_MM                  vmandn.mm	v8, v8, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMANDN_MM                  vmandn.mm	v8, v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMANDN_MM                  vmandn.mm	v8, v8, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMANDN_MM                  vmandn.mm	v8, v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMANDN_MM                  vmandn.mm	v8, v8, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMANDN_MM                  vmandn.mm	v8, v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e16, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMANDN_MM                  vmandn.mm	v8, v8, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMANDN_MM                  vmandn.mm	v8, v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e16, m8, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMANDN_MM                  vmandn.mm	v8, v8, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMANDN_MM                  vmandn.mm	v8, v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMANDN_MM                  vmandn.mm	v8, v8, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMANDN_MM                  vmandn.mm	v8, v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMANDN_MM                  vmandn.mm	v8, v8, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMANDN_MM                  vmandn.mm	v8, v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMANDN_MM                  vmandn.mm	v8, v8, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMANDN_MM                  vmandn.mm	v8, v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e32, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMANDN_MM                  vmandn.mm	v8, v8, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMANDN_MM                  vmandn.mm	v8, v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e32, m8, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMANDN_MM                  vmandn.mm	v8, v8, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMANDN_MM                  vmandn.mm	v8, v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMANDN_MM                  vmandn.mm	v8, v8, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMANDN_MM                  vmandn.mm	v8, v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMANDN_MM                  vmandn.mm	v8, v8, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMANDN_MM                  vmandn.mm	v8, v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e64, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMANDN_MM                  vmandn.mm	v8, v8, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMANDN_MM                  vmandn.mm	v8, v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e64, m8, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMANDN_MM                  vmandn.mm	v8, v8, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMANDN_MM                  vmandn.mm	v8, v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMXOR_MM                   vmclr.m	v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMXOR_MM                   vmclr.m	v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMXOR_MM                   vmclr.m	v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMXOR_MM                   vmclr.m	v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMXOR_MM                   vmclr.m	v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMXOR_MM                   vmclr.m	v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMXOR_MM                   vmclr.m	v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMXOR_MM                   vmclr.m	v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMXOR_MM                   vmclr.m	v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMXOR_MM                   vmclr.m	v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e8, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMXOR_MM                   vmclr.m	v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMXOR_MM                   vmclr.m	v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e8, m8, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMXOR_MM                   vmclr.m	v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMXOR_MM                   vmclr.m	v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMXOR_MM                   vmclr.m	v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMXOR_MM                   vmclr.m	v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMXOR_MM                   vmclr.m	v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMXOR_MM                   vmclr.m	v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMXOR_MM                   vmclr.m	v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMXOR_MM                   vmclr.m	v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMXOR_MM                   vmclr.m	v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMXOR_MM                   vmclr.m	v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e16, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMXOR_MM                   vmclr.m	v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMXOR_MM                   vmclr.m	v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e16, m8, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMXOR_MM                   vmclr.m	v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMXOR_MM                   vmclr.m	v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMXOR_MM                   vmclr.m	v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMXOR_MM                   vmclr.m	v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMXOR_MM                   vmclr.m	v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMXOR_MM                   vmclr.m	v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMXOR_MM                   vmclr.m	v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMXOR_MM                   vmclr.m	v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e32, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMXOR_MM                   vmclr.m	v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMXOR_MM                   vmclr.m	v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e32, m8, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMXOR_MM                   vmclr.m	v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMXOR_MM                   vmclr.m	v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMXOR_MM                   vmclr.m	v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMXOR_MM                   vmclr.m	v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMXOR_MM                   vmclr.m	v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMXOR_MM                   vmclr.m	v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e64, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMXOR_MM                   vmclr.m	v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMXOR_MM                   vmclr.m	v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e64, m8, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMXOR_MM                   vmclr.m	v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMXOR_MM                   vmclr.m	v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMOR_MM                    vmor.mm	v8, v8, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMOR_MM                    vmor.mm	v8, v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMOR_MM                    vmor.mm	v8, v8, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMOR_MM                    vmor.mm	v8, v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMOR_MM                    vmor.mm	v8, v8, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMOR_MM                    vmor.mm	v8, v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMOR_MM                    vmor.mm	v8, v8, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMOR_MM                    vmor.mm	v8, v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMOR_MM                    vmor.mm	v8, v8, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMOR_MM                    vmor.mm	v8, v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e8, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMOR_MM                    vmor.mm	v8, v8, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMOR_MM                    vmor.mm	v8, v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e8, m8, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMOR_MM                    vmor.mm	v8, v8, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMOR_MM                    vmor.mm	v8, v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMOR_MM                    vmor.mm	v8, v8, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMOR_MM                    vmor.mm	v8, v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMOR_MM                    vmor.mm	v8, v8, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMOR_MM                    vmor.mm	v8, v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMOR_MM                    vmor.mm	v8, v8, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMOR_MM                    vmor.mm	v8, v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMOR_MM                    vmor.mm	v8, v8, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMOR_MM                    vmor.mm	v8, v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e16, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMOR_MM                    vmor.mm	v8, v8, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMOR_MM                    vmor.mm	v8, v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e16, m8, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMOR_MM                    vmor.mm	v8, v8, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMOR_MM                    vmor.mm	v8, v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMOR_MM                    vmor.mm	v8, v8, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMOR_MM                    vmor.mm	v8, v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMOR_MM                    vmor.mm	v8, v8, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMOR_MM                    vmor.mm	v8, v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMOR_MM                    vmor.mm	v8, v8, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMOR_MM                    vmor.mm	v8, v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e32, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMOR_MM                    vmor.mm	v8, v8, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMOR_MM                    vmor.mm	v8, v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e32, m8, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMOR_MM                    vmor.mm	v8, v8, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMOR_MM                    vmor.mm	v8, v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMOR_MM                    vmor.mm	v8, v8, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMOR_MM                    vmor.mm	v8, v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMOR_MM                    vmor.mm	v8, v8, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMOR_MM                    vmor.mm	v8, v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e64, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMOR_MM                    vmor.mm	v8, v8, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMOR_MM                    vmor.mm	v8, v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e64, m8, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMOR_MM                    vmor.mm	v8, v8, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMOR_MM                    vmor.mm	v8, v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMNOR_MM                   vmnor.mm	v8, v8, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMNOR_MM                   vmnor.mm	v8, v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMNOR_MM                   vmnor.mm	v8, v8, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMNOR_MM                   vmnor.mm	v8, v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMNOR_MM                   vmnor.mm	v8, v8, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMNOR_MM                   vmnor.mm	v8, v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMNOR_MM                   vmnor.mm	v8, v8, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMNOR_MM                   vmnor.mm	v8, v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMNOR_MM                   vmnor.mm	v8, v8, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMNOR_MM                   vmnor.mm	v8, v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e8, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMNOR_MM                   vmnor.mm	v8, v8, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMNOR_MM                   vmnor.mm	v8, v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e8, m8, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMNOR_MM                   vmnor.mm	v8, v8, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMNOR_MM                   vmnor.mm	v8, v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMNOR_MM                   vmnor.mm	v8, v8, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMNOR_MM                   vmnor.mm	v8, v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMNOR_MM                   vmnor.mm	v8, v8, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMNOR_MM                   vmnor.mm	v8, v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMNOR_MM                   vmnor.mm	v8, v8, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMNOR_MM                   vmnor.mm	v8, v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMNOR_MM                   vmnor.mm	v8, v8, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMNOR_MM                   vmnor.mm	v8, v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e16, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMNOR_MM                   vmnor.mm	v8, v8, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMNOR_MM                   vmnor.mm	v8, v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e16, m8, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMNOR_MM                   vmnor.mm	v8, v8, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMNOR_MM                   vmnor.mm	v8, v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMNOR_MM                   vmnor.mm	v8, v8, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMNOR_MM                   vmnor.mm	v8, v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMNOR_MM                   vmnor.mm	v8, v8, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMNOR_MM                   vmnor.mm	v8, v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMNOR_MM                   vmnor.mm	v8, v8, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMNOR_MM                   vmnor.mm	v8, v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e32, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMNOR_MM                   vmnor.mm	v8, v8, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMNOR_MM                   vmnor.mm	v8, v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e32, m8, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMNOR_MM                   vmnor.mm	v8, v8, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMNOR_MM                   vmnor.mm	v8, v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMNOR_MM                   vmnor.mm	v8, v8, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMNOR_MM                   vmnor.mm	v8, v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMNOR_MM                   vmnor.mm	v8, v8, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMNOR_MM                   vmnor.mm	v8, v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e64, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMNOR_MM                   vmnor.mm	v8, v8, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMNOR_MM                   vmnor.mm	v8, v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e64, m8, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMNOR_MM                   vmnor.mm	v8, v8, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMNOR_MM                   vmnor.mm	v8, v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMORN_MM                   vmorn.mm	v8, v8, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMORN_MM                   vmorn.mm	v8, v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMORN_MM                   vmorn.mm	v8, v8, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMORN_MM                   vmorn.mm	v8, v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMORN_MM                   vmorn.mm	v8, v8, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMORN_MM                   vmorn.mm	v8, v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMORN_MM                   vmorn.mm	v8, v8, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMORN_MM                   vmorn.mm	v8, v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMORN_MM                   vmorn.mm	v8, v8, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMORN_MM                   vmorn.mm	v8, v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e8, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMORN_MM                   vmorn.mm	v8, v8, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMORN_MM                   vmorn.mm	v8, v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e8, m8, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMORN_MM                   vmorn.mm	v8, v8, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMORN_MM                   vmorn.mm	v8, v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMORN_MM                   vmorn.mm	v8, v8, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMORN_MM                   vmorn.mm	v8, v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMORN_MM                   vmorn.mm	v8, v8, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMORN_MM                   vmorn.mm	v8, v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMORN_MM                   vmorn.mm	v8, v8, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMORN_MM                   vmorn.mm	v8, v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMORN_MM                   vmorn.mm	v8, v8, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMORN_MM                   vmorn.mm	v8, v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e16, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMORN_MM                   vmorn.mm	v8, v8, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMORN_MM                   vmorn.mm	v8, v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e16, m8, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMORN_MM                   vmorn.mm	v8, v8, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMORN_MM                   vmorn.mm	v8, v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMORN_MM                   vmorn.mm	v8, v8, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMORN_MM                   vmorn.mm	v8, v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMORN_MM                   vmorn.mm	v8, v8, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMORN_MM                   vmorn.mm	v8, v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMORN_MM                   vmorn.mm	v8, v8, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMORN_MM                   vmorn.mm	v8, v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e32, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMORN_MM                   vmorn.mm	v8, v8, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMORN_MM                   vmorn.mm	v8, v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e32, m8, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMORN_MM                   vmorn.mm	v8, v8, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMORN_MM                   vmorn.mm	v8, v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMORN_MM                   vmorn.mm	v8, v8, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMORN_MM                   vmorn.mm	v8, v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMORN_MM                   vmorn.mm	v8, v8, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMORN_MM                   vmorn.mm	v8, v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e64, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMORN_MM                   vmorn.mm	v8, v8, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMORN_MM                   vmorn.mm	v8, v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e64, m8, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMORN_MM                   vmorn.mm	v8, v8, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMORN_MM                   vmorn.mm	v8, v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMXNOR_MM                  vmset.m	v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMXNOR_MM                  vmset.m	v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMXNOR_MM                  vmset.m	v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMXNOR_MM                  vmset.m	v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMXNOR_MM                  vmset.m	v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMXNOR_MM                  vmset.m	v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMXNOR_MM                  vmset.m	v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMXNOR_MM                  vmset.m	v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMXNOR_MM                  vmset.m	v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMXNOR_MM                  vmset.m	v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e8, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMXNOR_MM                  vmset.m	v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMXNOR_MM                  vmset.m	v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e8, m8, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMXNOR_MM                  vmset.m	v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMXNOR_MM                  vmset.m	v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMXNOR_MM                  vmset.m	v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMXNOR_MM                  vmset.m	v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMXNOR_MM                  vmset.m	v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMXNOR_MM                  vmset.m	v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMXNOR_MM                  vmset.m	v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMXNOR_MM                  vmset.m	v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMXNOR_MM                  vmset.m	v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMXNOR_MM                  vmset.m	v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e16, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMXNOR_MM                  vmset.m	v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMXNOR_MM                  vmset.m	v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e16, m8, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMXNOR_MM                  vmset.m	v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMXNOR_MM                  vmset.m	v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMXNOR_MM                  vmset.m	v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMXNOR_MM                  vmset.m	v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMXNOR_MM                  vmset.m	v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMXNOR_MM                  vmset.m	v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMXNOR_MM                  vmset.m	v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMXNOR_MM                  vmset.m	v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e32, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMXNOR_MM                  vmset.m	v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMXNOR_MM                  vmset.m	v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e32, m8, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMXNOR_MM                  vmset.m	v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMXNOR_MM                  vmset.m	v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMXNOR_MM                  vmset.m	v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMXNOR_MM                  vmset.m	v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMXNOR_MM                  vmset.m	v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMXNOR_MM                  vmset.m	v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e64, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMXNOR_MM                  vmset.m	v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMXNOR_MM                  vmset.m	v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e64, m8, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMXNOR_MM                  vmset.m	v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMXNOR_MM                  vmset.m	v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMSBF_M                    vmsbf.m	v8, v16
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMSBF_M                    vmsbf.m	v8, v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMSBF_M                    vmsbf.m	v8, v16
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMSBF_M                    vmsbf.m	v8, v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMSBF_M                    vmsbf.m	v8, v16
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMSBF_M                    vmsbf.m	v8, v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMSBF_M                    vmsbf.m	v8, v16
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMSBF_M                    vmsbf.m	v8, v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMSBF_M                    vmsbf.m	v8, v16
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMSBF_M                    vmsbf.m	v8, v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e8, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMSBF_M                    vmsbf.m	v8, v16
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMSBF_M                    vmsbf.m	v8, v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e8, m8, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMSBF_M                    vmsbf.m	v8, v16
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMSBF_M                    vmsbf.m	v8, v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMSBF_M                    vmsbf.m	v8, v16
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMSBF_M                    vmsbf.m	v8, v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMSBF_M                    vmsbf.m	v8, v16
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMSBF_M                    vmsbf.m	v8, v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMSBF_M                    vmsbf.m	v8, v16
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMSBF_M                    vmsbf.m	v8, v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMSBF_M                    vmsbf.m	v8, v16
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMSBF_M                    vmsbf.m	v8, v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e16, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMSBF_M                    vmsbf.m	v8, v16
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMSBF_M                    vmsbf.m	v8, v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e16, m8, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMSBF_M                    vmsbf.m	v8, v16
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMSBF_M                    vmsbf.m	v8, v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMSBF_M                    vmsbf.m	v8, v16
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMSBF_M                    vmsbf.m	v8, v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMSBF_M                    vmsbf.m	v8, v16
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMSBF_M                    vmsbf.m	v8, v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMSBF_M                    vmsbf.m	v8, v16
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMSBF_M                    vmsbf.m	v8, v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e32, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMSBF_M                    vmsbf.m	v8, v16
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMSBF_M                    vmsbf.m	v8, v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e32, m8, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMSBF_M                    vmsbf.m	v8, v16
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMSBF_M                    vmsbf.m	v8, v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMSBF_M                    vmsbf.m	v8, v16
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMSBF_M                    vmsbf.m	v8, v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMSBF_M                    vmsbf.m	v8, v16
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMSBF_M                    vmsbf.m	v8, v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e64, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMSBF_M                    vmsbf.m	v8, v16
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMSBF_M                    vmsbf.m	v8, v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e64, m8, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMSBF_M                    vmsbf.m	v8, v16
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMSBF_M                    vmsbf.m	v8, v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMSIF_M                    vmsif.m	v8, v16
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMSIF_M                    vmsif.m	v8, v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMSIF_M                    vmsif.m	v8, v16
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMSIF_M                    vmsif.m	v8, v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMSIF_M                    vmsif.m	v8, v16
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMSIF_M                    vmsif.m	v8, v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMSIF_M                    vmsif.m	v8, v16
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMSIF_M                    vmsif.m	v8, v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMSIF_M                    vmsif.m	v8, v16
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMSIF_M                    vmsif.m	v8, v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e8, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMSIF_M                    vmsif.m	v8, v16
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMSIF_M                    vmsif.m	v8, v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e8, m8, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMSIF_M                    vmsif.m	v8, v16
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMSIF_M                    vmsif.m	v8, v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMSIF_M                    vmsif.m	v8, v16
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMSIF_M                    vmsif.m	v8, v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMSIF_M                    vmsif.m	v8, v16
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMSIF_M                    vmsif.m	v8, v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMSIF_M                    vmsif.m	v8, v16
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMSIF_M                    vmsif.m	v8, v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMSIF_M                    vmsif.m	v8, v16
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMSIF_M                    vmsif.m	v8, v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e16, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMSIF_M                    vmsif.m	v8, v16
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMSIF_M                    vmsif.m	v8, v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e16, m8, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMSIF_M                    vmsif.m	v8, v16
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMSIF_M                    vmsif.m	v8, v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMSIF_M                    vmsif.m	v8, v16
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMSIF_M                    vmsif.m	v8, v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMSIF_M                    vmsif.m	v8, v16
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMSIF_M                    vmsif.m	v8, v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMSIF_M                    vmsif.m	v8, v16
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMSIF_M                    vmsif.m	v8, v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e32, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMSIF_M                    vmsif.m	v8, v16
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMSIF_M                    vmsif.m	v8, v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e32, m8, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMSIF_M                    vmsif.m	v8, v16
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMSIF_M                    vmsif.m	v8, v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMSIF_M                    vmsif.m	v8, v16
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMSIF_M                    vmsif.m	v8, v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMSIF_M                    vmsif.m	v8, v16
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMSIF_M                    vmsif.m	v8, v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e64, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMSIF_M                    vmsif.m	v8, v16
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMSIF_M                    vmsif.m	v8, v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e64, m8, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMSIF_M                    vmsif.m	v8, v16
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMSIF_M                    vmsif.m	v8, v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMSOF_M                    vmsof.m	v8, v16
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMSOF_M                    vmsof.m	v8, v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMSOF_M                    vmsof.m	v8, v16
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMSOF_M                    vmsof.m	v8, v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMSOF_M                    vmsof.m	v8, v16
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMSOF_M                    vmsof.m	v8, v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMSOF_M                    vmsof.m	v8, v16
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMSOF_M                    vmsof.m	v8, v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMSOF_M                    vmsof.m	v8, v16
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMSOF_M                    vmsof.m	v8, v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e8, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMSOF_M                    vmsof.m	v8, v16
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMSOF_M                    vmsof.m	v8, v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e8, m8, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMSOF_M                    vmsof.m	v8, v16
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMSOF_M                    vmsof.m	v8, v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMSOF_M                    vmsof.m	v8, v16
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMSOF_M                    vmsof.m	v8, v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMSOF_M                    vmsof.m	v8, v16
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMSOF_M                    vmsof.m	v8, v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMSOF_M                    vmsof.m	v8, v16
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMSOF_M                    vmsof.m	v8, v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMSOF_M                    vmsof.m	v8, v16
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMSOF_M                    vmsof.m	v8, v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e16, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMSOF_M                    vmsof.m	v8, v16
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMSOF_M                    vmsof.m	v8, v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e16, m8, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMSOF_M                    vmsof.m	v8, v16
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMSOF_M                    vmsof.m	v8, v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMSOF_M                    vmsof.m	v8, v16
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMSOF_M                    vmsof.m	v8, v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMSOF_M                    vmsof.m	v8, v16
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMSOF_M                    vmsof.m	v8, v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMSOF_M                    vmsof.m	v8, v16
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMSOF_M                    vmsof.m	v8, v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e32, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMSOF_M                    vmsof.m	v8, v16
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMSOF_M                    vmsof.m	v8, v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e32, m8, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMSOF_M                    vmsof.m	v8, v16
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMSOF_M                    vmsof.m	v8, v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMSOF_M                    vmsof.m	v8, v16
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMSOF_M                    vmsof.m	v8, v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMSOF_M                    vmsof.m	v8, v16
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMSOF_M                    vmsof.m	v8, v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e64, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMSOF_M                    vmsof.m	v8, v16
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMSOF_M                    vmsof.m	v8, v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e64, m8, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VMSOF_M                    vmsof.m	v8, v16
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VMSOF_M                    vmsof.m	v8, v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VID_V                      vid.v	v8
+# CHECK-NEXT:  1      4     1.00                         4     Andes45VMASK                               VID_V                      vid.v	v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VID_V                      vid.v	v8
+# CHECK-NEXT:  1      4     1.00                         4     Andes45VMASK                               VID_V                      vid.v	v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VID_V                      vid.v	v8
+# CHECK-NEXT:  1      4     1.00                         4     Andes45VMASK                               VID_V                      vid.v	v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VID_V                      vid.v	v8
+# CHECK-NEXT:  1      4     1.00                         4     Andes45VMASK                               VID_V                      vid.v	v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VID_V                      vid.v	v8
+# CHECK-NEXT:  1      4     2.00                         4     Andes45VMASK[2]                            VID_V                      vid.v	v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e8, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VID_V                      vid.v	v8
+# CHECK-NEXT:  1      4     4.00                         4     Andes45VMASK[4]                            VID_V                      vid.v	v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e8, m8, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VID_V                      vid.v	v8
+# CHECK-NEXT:  1      4     8.00                         4     Andes45VMASK[8]                            VID_V                      vid.v	v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VID_V                      vid.v	v8
+# CHECK-NEXT:  1      4     1.00                         4     Andes45VMASK                               VID_V                      vid.v	v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VID_V                      vid.v	v8
+# CHECK-NEXT:  1      4     1.00                         4     Andes45VMASK                               VID_V                      vid.v	v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VID_V                      vid.v	v8
+# CHECK-NEXT:  1      4     1.00                         4     Andes45VMASK                               VID_V                      vid.v	v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VID_V                      vid.v	v8
+# CHECK-NEXT:  1      4     2.00                         4     Andes45VMASK[2]                            VID_V                      vid.v	v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e16, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VID_V                      vid.v	v8
+# CHECK-NEXT:  1      4     4.00                         4     Andes45VMASK[4]                            VID_V                      vid.v	v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e16, m8, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VID_V                      vid.v	v8
+# CHECK-NEXT:  1      4     8.00                         4     Andes45VMASK[8]                            VID_V                      vid.v	v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VID_V                      vid.v	v8
+# CHECK-NEXT:  1      4     1.00                         4     Andes45VMASK                               VID_V                      vid.v	v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VID_V                      vid.v	v8
+# CHECK-NEXT:  1      4     1.00                         4     Andes45VMASK                               VID_V                      vid.v	v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VID_V                      vid.v	v8
+# CHECK-NEXT:  1      4     2.00                         4     Andes45VMASK[2]                            VID_V                      vid.v	v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e32, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VID_V                      vid.v	v8
+# CHECK-NEXT:  1      4     4.00                         4     Andes45VMASK[4]                            VID_V                      vid.v	v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e32, m8, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VID_V                      vid.v	v8
+# CHECK-NEXT:  1      4     8.00                         4     Andes45VMASK[8]                            VID_V                      vid.v	v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VID_V                      vid.v	v8
+# CHECK-NEXT:  1      4     1.00                         4     Andes45VMASK                               VID_V                      vid.v	v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VID_V                      vid.v	v8
+# CHECK-NEXT:  1      4     2.00                         4     Andes45VMASK[2]                            VID_V                      vid.v	v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e64, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VID_V                      vid.v	v8
+# CHECK-NEXT:  1      4     4.00                         4     Andes45VMASK[4]                            VID_V                      vid.v	v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e64, m8, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VID_V                      vid.v	v8
+# CHECK-NEXT:  1      4     8.00                         4     Andes45VMASK[8]                            VID_V                      vid.v	v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VCPOP_M                    vcpop.m	s0, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VCPOP_M                    vcpop.m	s0, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VCPOP_M                    vcpop.m	s0, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VCPOP_M                    vcpop.m	s0, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VCPOP_M                    vcpop.m	s0, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VCPOP_M                    vcpop.m	s0, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VCPOP_M                    vcpop.m	s0, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VCPOP_M                    vcpop.m	s0, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VCPOP_M                    vcpop.m	s0, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VCPOP_M                    vcpop.m	s0, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e8, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VCPOP_M                    vcpop.m	s0, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VCPOP_M                    vcpop.m	s0, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e8, m8, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VCPOP_M                    vcpop.m	s0, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VCPOP_M                    vcpop.m	s0, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VCPOP_M                    vcpop.m	s0, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VCPOP_M                    vcpop.m	s0, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VCPOP_M                    vcpop.m	s0, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VCPOP_M                    vcpop.m	s0, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VCPOP_M                    vcpop.m	s0, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VCPOP_M                    vcpop.m	s0, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VCPOP_M                    vcpop.m	s0, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VCPOP_M                    vcpop.m	s0, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e16, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VCPOP_M                    vcpop.m	s0, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VCPOP_M                    vcpop.m	s0, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e16, m8, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VCPOP_M                    vcpop.m	s0, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VCPOP_M                    vcpop.m	s0, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VCPOP_M                    vcpop.m	s0, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VCPOP_M                    vcpop.m	s0, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VCPOP_M                    vcpop.m	s0, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VCPOP_M                    vcpop.m	s0, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VCPOP_M                    vcpop.m	s0, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VCPOP_M                    vcpop.m	s0, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e32, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VCPOP_M                    vcpop.m	s0, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VCPOP_M                    vcpop.m	s0, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e32, m8, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VCPOP_M                    vcpop.m	s0, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VCPOP_M                    vcpop.m	s0, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VCPOP_M                    vcpop.m	s0, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VCPOP_M                    vcpop.m	s0, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VCPOP_M                    vcpop.m	s0, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VCPOP_M                    vcpop.m	s0, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e64, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VCPOP_M                    vcpop.m	s0, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VCPOP_M                    vcpop.m	s0, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e64, m8, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VCPOP_M                    vcpop.m	s0, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VCPOP_M                    vcpop.m	s0, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VFIRST_M                   vfirst.m	s0, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VFIRST_M                   vfirst.m	s0, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VFIRST_M                   vfirst.m	s0, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VFIRST_M                   vfirst.m	s0, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VFIRST_M                   vfirst.m	s0, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VFIRST_M                   vfirst.m	s0, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VFIRST_M                   vfirst.m	s0, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VFIRST_M                   vfirst.m	s0, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e16, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VFIRST_M                   vfirst.m	s0, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VFIRST_M                   vfirst.m	s0, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e16, m8, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VFIRST_M                   vfirst.m	s0, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VFIRST_M                   vfirst.m	s0, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VFIRST_M                   vfirst.m	s0, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VFIRST_M                   vfirst.m	s0, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VFIRST_M                   vfirst.m	s0, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VFIRST_M                   vfirst.m	s0, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VFIRST_M                   vfirst.m	s0, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VFIRST_M                   vfirst.m	s0, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e32, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VFIRST_M                   vfirst.m	s0, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VFIRST_M                   vfirst.m	s0, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e32, m8, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VFIRST_M                   vfirst.m	s0, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VFIRST_M                   vfirst.m	s0, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VFIRST_M                   vfirst.m	s0, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VFIRST_M                   vfirst.m	s0, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VFIRST_M                   vfirst.m	s0, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VFIRST_M                   vfirst.m	s0, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e64, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VFIRST_M                   vfirst.m	s0, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VFIRST_M                   vfirst.m	s0, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e64, m8, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VFIRST_M                   vfirst.m	s0, v8
+# CHECK-NEXT:  1      3     1.00                         3     Andes45VMASK                               VFIRST_M                   vfirst.m	s0, v8
 
 # CHECK:      Resources:
 # CHECK-NEXT: [0.0] - Andes45ALU
@@ -1273,7 +1273,7 @@ vfirst.m x8, v8
 
 # CHECK:      Resource pressure per iteration:
 # CHECK-NEXT: [0.0]  [0.1]  [1]    [2]    [3]    [4]    [5]    [6]    [7]    [8]    [9]    [10]   [11]   [12]   [13]   [14]   [15]
-# CHECK-NEXT:  -      -     301.00  -      -      -      -      -      -      -      -      -      -      -      -     301.00  -
+# CHECK-NEXT:  -      -     301.00  -      -      -      -      -      -      -      -      -      -      -      -     345.00  -
 
 # CHECK:      Resource pressure by instruction:
 # CHECK-NEXT: [0.0]  [0.1]  [1]    [2]    [3]    [4]    [5]    [6]    [7]    [8]    [9]    [10]   [11]   [12]   [13]   [14]   [15]   Instructions:
@@ -1770,11 +1770,11 @@ vfirst.m x8, v8
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	t3, zero, e8, m1, tu, mu
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -     vid.v	v8
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	t3, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -     vid.v	v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     2.00    -     vid.v	v8
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	t3, zero, e8, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -     vid.v	v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     4.00    -     vid.v	v8
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	t3, zero, e8, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -     vid.v	v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -     vid.v	v8
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	t3, zero, e16, mf2, tu, mu
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -     vid.v	v8
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	t3, zero, e16, mf4, tu, mu
@@ -1782,29 +1782,29 @@ vfirst.m x8, v8
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	t3, zero, e16, m1, tu, mu
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -     vid.v	v8
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	t3, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -     vid.v	v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     2.00    -     vid.v	v8
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	t3, zero, e16, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -     vid.v	v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     4.00    -     vid.v	v8
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	t3, zero, e16, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -     vid.v	v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -     vid.v	v8
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	t3, zero, e32, mf2, tu, mu
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -     vid.v	v8
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	t3, zero, e32, m1, tu, mu
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -     vid.v	v8
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	t3, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -     vid.v	v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     2.00    -     vid.v	v8
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	t3, zero, e32, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -     vid.v	v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     4.00    -     vid.v	v8
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	t3, zero, e32, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -     vid.v	v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -     vid.v	v8
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	t3, zero, e64, m1, tu, mu
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -     vid.v	v8
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	t3, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -     vid.v	v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     2.00    -     vid.v	v8
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	t3, zero, e64, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -     vid.v	v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     4.00    -     vid.v	v8
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	t3, zero, e64, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -     vid.v	v8
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -     vid.v	v8
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	t3, zero, e8, mf2, tu, mu
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -     vcpop.m	s0, v8
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	t3, zero, e8, mf4, tu, mu

--- a/llvm/test/tools/llvm-mca/RISCV/Andes45/rvv-permutation.s
+++ b/llvm/test/tools/llvm-mca/RISCV/Andes45/rvv-permutation.s
@@ -1602,49 +1602,49 @@ vfslide1up.vf v8, v16, ft0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e64, m8, tu, mu
 # CHECK-NEXT:  1      1     1.00                         1     Andes45VPERMUT                             VMV8R_V                    vmv8r.v	v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VIOTA_M                    viota.m	v8, v16
+# CHECK-NEXT:  1      4     1.00                         4     Andes45VMASK                               VIOTA_M                    viota.m	v8, v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VIOTA_M                    viota.m	v8, v16
+# CHECK-NEXT:  1      4     1.00                         4     Andes45VMASK                               VIOTA_M                    viota.m	v8, v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VIOTA_M                    viota.m	v8, v16
+# CHECK-NEXT:  1      4     1.00                         4     Andes45VMASK                               VIOTA_M                    viota.m	v8, v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VIOTA_M                    viota.m	v8, v16
+# CHECK-NEXT:  1      4     1.00                         4     Andes45VMASK                               VIOTA_M                    viota.m	v8, v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VIOTA_M                    viota.m	v8, v16
+# CHECK-NEXT:  1      4     2.00                         4     Andes45VMASK[2]                            VIOTA_M                    viota.m	v8, v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e8, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VIOTA_M                    viota.m	v8, v16
+# CHECK-NEXT:  1      4     4.00                         4     Andes45VMASK[4]                            VIOTA_M                    viota.m	v8, v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e8, m8, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VIOTA_M                    viota.m	v8, v16
+# CHECK-NEXT:  1      4     8.00                         4     Andes45VMASK[8]                            VIOTA_M                    viota.m	v8, v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VIOTA_M                    viota.m	v8, v16
+# CHECK-NEXT:  1      4     1.00                         4     Andes45VMASK                               VIOTA_M                    viota.m	v8, v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VIOTA_M                    viota.m	v8, v16
+# CHECK-NEXT:  1      4     1.00                         4     Andes45VMASK                               VIOTA_M                    viota.m	v8, v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VIOTA_M                    viota.m	v8, v16
+# CHECK-NEXT:  1      4     1.00                         4     Andes45VMASK                               VIOTA_M                    viota.m	v8, v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VIOTA_M                    viota.m	v8, v16
+# CHECK-NEXT:  1      4     2.00                         4     Andes45VMASK[2]                            VIOTA_M                    viota.m	v8, v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e16, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VIOTA_M                    viota.m	v8, v16
+# CHECK-NEXT:  1      4     4.00                         4     Andes45VMASK[4]                            VIOTA_M                    viota.m	v8, v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e16, m8, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VIOTA_M                    viota.m	v8, v16
+# CHECK-NEXT:  1      4     8.00                         4     Andes45VMASK[8]                            VIOTA_M                    viota.m	v8, v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VIOTA_M                    viota.m	v8, v16
+# CHECK-NEXT:  1      4     1.00                         4     Andes45VMASK                               VIOTA_M                    viota.m	v8, v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VIOTA_M                    viota.m	v8, v16
+# CHECK-NEXT:  1      4     1.00                         4     Andes45VMASK                               VIOTA_M                    viota.m	v8, v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VIOTA_M                    viota.m	v8, v16
+# CHECK-NEXT:  1      4     2.00                         4     Andes45VMASK[2]                            VIOTA_M                    viota.m	v8, v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e32, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VIOTA_M                    viota.m	v8, v16
+# CHECK-NEXT:  1      4     4.00                         4     Andes45VMASK[4]                            VIOTA_M                    viota.m	v8, v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e32, m8, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VIOTA_M                    viota.m	v8, v16
+# CHECK-NEXT:  1      4     8.00                         4     Andes45VMASK[8]                            VIOTA_M                    viota.m	v8, v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VIOTA_M                    viota.m	v8, v16
+# CHECK-NEXT:  1      4     1.00                         4     Andes45VMASK                               VIOTA_M                    viota.m	v8, v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VIOTA_M                    viota.m	v8, v16
+# CHECK-NEXT:  1      4     2.00                         4     Andes45VMASK[2]                            VIOTA_M                    viota.m	v8, v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e64, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VIOTA_M                    viota.m	v8, v16
+# CHECK-NEXT:  1      4     4.00                         4     Andes45VMASK[4]                            VIOTA_M                    viota.m	v8, v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e64, m8, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     Andes45VMASK                               VIOTA_M                    viota.m	v8, v16
+# CHECK-NEXT:  1      4     8.00                         4     Andes45VMASK[8]                            VIOTA_M                    viota.m	v8, v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e8, mf2, tu, mu
 # CHECK-NEXT:  1      1     1.00                         1     Andes45VPERMUT                             VCOMPRESS_VM               vcompress.vm	v8, v16, v24
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	t3, zero, e8, mf4, tu, mu
@@ -2371,7 +2371,7 @@ vfslide1up.vf v8, v16, ft0
 
 # CHECK:      Resource pressure per iteration:
 # CHECK-NEXT: [0.0]  [0.1]  [1]    [2]    [3]    [4]    [5]    [6]    [7]    [8]    [9]    [10]   [11]   [12]   [13]   [14]   [15]
-# CHECK-NEXT:  -      -     572.00  -      -      -      -      -      -     396.00  -      -     48.00   -      -     22.00  403.00
+# CHECK-NEXT:  -      -     572.00  -      -      -      -      -      -     396.00  -      -     48.00   -      -     66.00  403.00
 
 # CHECK:      Resource pressure by instruction:
 # CHECK-NEXT: [0.0]  [0.1]  [1]    [2]    [3]    [4]    [5]    [6]    [7]    [8]    [9]    [10]   [11]   [12]   [13]   [14]   [15]   Instructions:
@@ -2780,11 +2780,11 @@ vfslide1up.vf v8, v16, ft0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	t3, zero, e8, m1, tu, mu
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -     viota.m	v8, v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	t3, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -     viota.m	v8, v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     2.00    -     viota.m	v8, v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	t3, zero, e8, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -     viota.m	v8, v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     4.00    -     viota.m	v8, v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	t3, zero, e8, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -     viota.m	v8, v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -     viota.m	v8, v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	t3, zero, e16, mf2, tu, mu
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -     viota.m	v8, v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	t3, zero, e16, mf4, tu, mu
@@ -2792,29 +2792,29 @@ vfslide1up.vf v8, v16, ft0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	t3, zero, e16, m1, tu, mu
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -     viota.m	v8, v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	t3, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -     viota.m	v8, v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     2.00    -     viota.m	v8, v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	t3, zero, e16, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -     viota.m	v8, v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     4.00    -     viota.m	v8, v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	t3, zero, e16, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -     viota.m	v8, v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -     viota.m	v8, v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	t3, zero, e32, mf2, tu, mu
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -     viota.m	v8, v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	t3, zero, e32, m1, tu, mu
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -     viota.m	v8, v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	t3, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -     viota.m	v8, v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     2.00    -     viota.m	v8, v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	t3, zero, e32, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -     viota.m	v8, v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     4.00    -     viota.m	v8, v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	t3, zero, e32, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -     viota.m	v8, v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -     viota.m	v8, v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	t3, zero, e64, m1, tu, mu
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -     viota.m	v8, v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	t3, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -     viota.m	v8, v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     2.00    -     viota.m	v8, v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	t3, zero, e64, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -     viota.m	v8, v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     4.00    -     viota.m	v8, v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	t3, zero, e64, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -     viota.m	v8, v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -     viota.m	v8, v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	t3, zero, e8, mf2, tu, mu
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -      -      -      -     1.00   vcompress.vm	v8, v16, v24
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	t3, zero, e8, mf4, tu, mu


### PR DESCRIPTION
This PR adds latency/throughput for all RVV mask to the andes45 series scheduling model.