### PR TITLE
[libclc][NFC] Add clang-tidy config and standardize header guards

### DIFF
--- a/libclc/.clang-tidy
+++ b/libclc/.clang-tidy
@@ -1,0 +1,7 @@
+InheritParentConfig: true
+# Disable bugprone-reserved-identifier and bugprone-macro-parentheses as libclc,
+# uses reserved identifiers (__prefix) for internal macros/functions.
+# Disable readability-identifier-naming to preserve existing naming (LOG2_HEAD, etc).
+Checks: 'bugprone-*,-bugprone-reserved-identifier,-bugprone-macro-parentheses,performance-*,llvm-header-guard,-readability-identifier-naming'
+WarningsAsErrors: 'bugprone-*'
+HeaderFilterRegex: 'libclc/.*'

--- a/libclc/.clang-tidy
+++ b/libclc/.clang-tidy
@@ -1,5 +1,5 @@
 InheritParentConfig: true
-# Disable bugprone-reserved-identifier and bugprone-macro-parentheses as libclc,
+# Disable bugprone-reserved-identifier and bugprone-macro-parentheses as libclc
 # uses reserved identifiers (__prefix) for internal macros/functions.
 # Disable readability-identifier-naming to preserve existing naming (LOG2_HEAD, etc).
 Checks: 'bugprone-*,-bugprone-reserved-identifier,-bugprone-macro-parentheses,performance-*,llvm-header-guard,-readability-identifier-naming'

--- a/libclc/clc/include/clc/async/clc_prefetch.h
+++ b/libclc/clc/include/clc/async/clc_prefetch.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_ASYNC_CLC_PREFETCH_H__
-#define __CLC_ASYNC_CLC_PREFETCH_H__
+#ifndef CLC_ASYNC_CLC_PREFETCH_H
+#define CLC_ASYNC_CLC_PREFETCH_H
 
 #define __CLC_BODY <clc/async/clc_prefetch.inc>
 #include <clc/integer/gentype.inc>
@@ -15,4 +15,4 @@
 #define __CLC_BODY <clc/async/clc_prefetch.inc>
 #include <clc/math/gentype.inc>
 
-#endif // __CLC_ASYNC_CLC_PREFETCH_H__
+#endif // CLC_ASYNC_CLC_PREFETCH_H

--- a/libclc/clc/include/clc/atomic/clc_atomic_compare_exchange.h
+++ b/libclc/clc/include/clc/atomic/clc_atomic_compare_exchange.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_ATOMIC_CLC_ATOMIC_COMPARE_EXCHANGE_H__
-#define __CLC_ATOMIC_CLC_ATOMIC_COMPARE_EXCHANGE_H__
+#ifndef CLC_ATOMIC_CLC_ATOMIC_COMPARE_EXCHANGE_H
+#define CLC_ATOMIC_CLC_ATOMIC_COMPARE_EXCHANGE_H
 
 #include <clc/internal/clc.h>
 
@@ -23,4 +23,4 @@
 #undef __CLC_COMPARE_EXCHANGE
 #undef __CLC_FUNCTION
 
-#endif // __CLC_ATOMIC_CLC_ATOMIC_COMPARE_EXCHANGE_H__
+#endif // CLC_ATOMIC_CLC_ATOMIC_COMPARE_EXCHANGE_H

--- a/libclc/clc/include/clc/atomic/clc_atomic_dec.h
+++ b/libclc/clc/include/clc/atomic/clc_atomic_dec.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_ATOMIC_CLC_ATOMIC_DEC_H__
-#define __CLC_ATOMIC_CLC_ATOMIC_DEC_H__
+#ifndef CLC_ATOMIC_CLC_ATOMIC_DEC_H
+#define CLC_ATOMIC_CLC_ATOMIC_DEC_H
 
 #include <clc/internal/clc.h>
 
@@ -20,4 +20,4 @@
 #undef __CLC_NO_VALUE_ARG
 #undef __CLC_FUNCTION
 
-#endif // __CLC_ATOMIC_CLC_ATOMIC_DEC_H__
+#endif // CLC_ATOMIC_CLC_ATOMIC_DEC_H

--- a/libclc/clc/include/clc/atomic/clc_atomic_exchange.h
+++ b/libclc/clc/include/clc/atomic/clc_atomic_exchange.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_ATOMIC_CLC_ATOMIC_EXCHANGE_H__
-#define __CLC_ATOMIC_CLC_ATOMIC_EXCHANGE_H__
+#ifndef CLC_ATOMIC_CLC_ATOMIC_EXCHANGE_H
+#define CLC_ATOMIC_CLC_ATOMIC_EXCHANGE_H
 
 #include <clc/internal/clc.h>
 
@@ -21,4 +21,4 @@
 
 #undef __CLC_FUNCTION
 
-#endif // __CLC_ATOMIC_CLC_ATOMIC_EXCHANGE_H__
+#endif // CLC_ATOMIC_CLC_ATOMIC_EXCHANGE_H

--- a/libclc/clc/include/clc/atomic/clc_atomic_fetch_add.h
+++ b/libclc/clc/include/clc/atomic/clc_atomic_fetch_add.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_ATOMIC_CLC_ATOMIC_FETCH_ADD_H__
-#define __CLC_ATOMIC_CLC_ATOMIC_FETCH_ADD_H__
+#ifndef CLC_ATOMIC_CLC_ATOMIC_FETCH_ADD_H
+#define CLC_ATOMIC_CLC_ATOMIC_FETCH_ADD_H
 
 #include <clc/internal/clc.h>
 
@@ -21,4 +21,4 @@
 
 #undef __CLC_FUNCTION
 
-#endif // __CLC_ATOMIC_CLC_ATOMIC_FETCH_ADD_H__
+#endif // CLC_ATOMIC_CLC_ATOMIC_FETCH_ADD_H

--- a/libclc/clc/include/clc/atomic/clc_atomic_fetch_and.h
+++ b/libclc/clc/include/clc/atomic/clc_atomic_fetch_and.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_ATOMIC_CLC_ATOMIC_FETCH_AND_H__
-#define __CLC_ATOMIC_CLC_ATOMIC_FETCH_AND_H__
+#ifndef CLC_ATOMIC_CLC_ATOMIC_FETCH_AND_H
+#define CLC_ATOMIC_CLC_ATOMIC_FETCH_AND_H
 
 #include <clc/internal/clc.h>
 
@@ -18,4 +18,4 @@
 
 #undef __CLC_FUNCTION
 
-#endif // __CLC_ATOMIC_CLC_ATOMIC_FETCH_AND_H__
+#endif // CLC_ATOMIC_CLC_ATOMIC_FETCH_AND_H

--- a/libclc/clc/include/clc/atomic/clc_atomic_fetch_max.h
+++ b/libclc/clc/include/clc/atomic/clc_atomic_fetch_max.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_ATOMIC_CLC_ATOMIC_FETCH_MAX_H__
-#define __CLC_ATOMIC_CLC_ATOMIC_FETCH_MAX_H__
+#ifndef CLC_ATOMIC_CLC_ATOMIC_FETCH_MAX_H
+#define CLC_ATOMIC_CLC_ATOMIC_FETCH_MAX_H
 
 #include <clc/internal/clc.h>
 
@@ -21,4 +21,4 @@
 
 #undef __CLC_FUNCTION
 
-#endif // __CLC_ATOMIC_CLC_ATOMIC_FETCH_MAX_H__
+#endif // CLC_ATOMIC_CLC_ATOMIC_FETCH_MAX_H

--- a/libclc/clc/include/clc/atomic/clc_atomic_fetch_min.h
+++ b/libclc/clc/include/clc/atomic/clc_atomic_fetch_min.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_ATOMIC_CLC_ATOMIC_FETCH_MIN_H__
-#define __CLC_ATOMIC_CLC_ATOMIC_FETCH_MIN_H__
+#ifndef CLC_ATOMIC_CLC_ATOMIC_FETCH_MIN_H
+#define CLC_ATOMIC_CLC_ATOMIC_FETCH_MIN_H
 
 #include <clc/internal/clc.h>
 
@@ -21,4 +21,4 @@
 
 #undef __CLC_FUNCTION
 
-#endif // __CLC_ATOMIC_CLC_ATOMIC_FETCH_MIN_H__
+#endif // CLC_ATOMIC_CLC_ATOMIC_FETCH_MIN_H

--- a/libclc/clc/include/clc/atomic/clc_atomic_fetch_or.h
+++ b/libclc/clc/include/clc/atomic/clc_atomic_fetch_or.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_ATOMIC_CLC_ATOMIC_FETCH_OR_H__
-#define __CLC_ATOMIC_CLC_ATOMIC_FETCH_OR_H__
+#ifndef CLC_ATOMIC_CLC_ATOMIC_FETCH_OR_H
+#define CLC_ATOMIC_CLC_ATOMIC_FETCH_OR_H
 
 #include <clc/internal/clc.h>
 
@@ -18,4 +18,4 @@
 
 #undef __CLC_FUNCTION
 
-#endif // __CLC_ATOMIC_CLC_ATOMIC_FETCH_OR_H__
+#endif // CLC_ATOMIC_CLC_ATOMIC_FETCH_OR_H

--- a/libclc/clc/include/clc/atomic/clc_atomic_fetch_sub.h
+++ b/libclc/clc/include/clc/atomic/clc_atomic_fetch_sub.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_ATOMIC_CLC_ATOMIC_FETCH_SUB_H__
-#define __CLC_ATOMIC_CLC_ATOMIC_FETCH_SUB_H__
+#ifndef CLC_ATOMIC_CLC_ATOMIC_FETCH_SUB_H
+#define CLC_ATOMIC_CLC_ATOMIC_FETCH_SUB_H
 
 #include <clc/internal/clc.h>
 
@@ -21,4 +21,4 @@
 
 #undef __CLC_FUNCTION
 
-#endif // __CLC_ATOMIC_CLC_ATOMIC_FETCH_SUB_H__
+#endif // CLC_ATOMIC_CLC_ATOMIC_FETCH_SUB_H

--- a/libclc/clc/include/clc/atomic/clc_atomic_fetch_xor.h
+++ b/libclc/clc/include/clc/atomic/clc_atomic_fetch_xor.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_ATOMIC_CLC_ATOMIC_FETCH_XOR_H__
-#define __CLC_ATOMIC_CLC_ATOMIC_FETCH_XOR_H__
+#ifndef CLC_ATOMIC_CLC_ATOMIC_FETCH_XOR_H
+#define CLC_ATOMIC_CLC_ATOMIC_FETCH_XOR_H
 
 #include <clc/internal/clc.h>
 
@@ -18,4 +18,4 @@
 
 #undef __CLC_FUNCTION
 
-#endif // __CLC_ATOMIC_CLC_ATOMIC_FETCH_XOR_H__
+#endif // CLC_ATOMIC_CLC_ATOMIC_FETCH_XOR_H

--- a/libclc/clc/include/clc/atomic/clc_atomic_flag_clear.h
+++ b/libclc/clc/include/clc/atomic/clc_atomic_flag_clear.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_ATOMIC_CLC_ATOMIC_FLAG_CLEAR_H__
-#define __CLC_ATOMIC_CLC_ATOMIC_FLAG_CLEAR_H__
+#ifndef CLC_ATOMIC_CLC_ATOMIC_FLAG_CLEAR_H
+#define CLC_ATOMIC_CLC_ATOMIC_FLAG_CLEAR_H
 
 #include <clc/internal/clc.h>
 
@@ -21,4 +21,4 @@ __CLC_DECLARE_ATOMIC_FLAG_CLEAR(local)
 __CLC_DECLARE_ATOMIC_FLAG_CLEAR()
 #endif
 
-#endif // __CLC_ATOMIC_CLC_ATOMIC_FLAG_CLEAR_H__
+#endif // CLC_ATOMIC_CLC_ATOMIC_FLAG_CLEAR_H

--- a/libclc/clc/include/clc/atomic/clc_atomic_flag_test_and_set.h
+++ b/libclc/clc/include/clc/atomic/clc_atomic_flag_test_and_set.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_ATOMIC_CLC_ATOMIC_FLAG_TEST_AND_SET_H__
-#define __CLC_ATOMIC_CLC_ATOMIC_FLAG_TEST_AND_SET_H__
+#ifndef CLC_ATOMIC_CLC_ATOMIC_FLAG_TEST_AND_SET_H
+#define CLC_ATOMIC_CLC_ATOMIC_FLAG_TEST_AND_SET_H
 
 #include <clc/internal/clc.h>
 
@@ -21,4 +21,4 @@ __CLC_DECLARE_ATOMIC_FLAG_TEST_AND_SET(local)
 __CLC_DECLARE_ATOMIC_FLAG_TEST_AND_SET()
 #endif
 
-#endif // __CLC_ATOMIC_CLC_ATOMIC_FLAG_TEST_AND_SET_H__
+#endif // CLC_ATOMIC_CLC_ATOMIC_FLAG_TEST_AND_SET_H

--- a/libclc/clc/include/clc/atomic/clc_atomic_inc.h
+++ b/libclc/clc/include/clc/atomic/clc_atomic_inc.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_ATOMIC_CLC_ATOMIC_INC_H__
-#define __CLC_ATOMIC_CLC_ATOMIC_INC_H__
+#ifndef CLC_ATOMIC_CLC_ATOMIC_INC_H
+#define CLC_ATOMIC_CLC_ATOMIC_INC_H
 
 #include <clc/internal/clc.h>
 
@@ -20,4 +20,4 @@
 #undef __CLC_NO_VALUE_ARG
 #undef __CLC_FUNCTION
 
-#endif // __CLC_ATOMIC_CLC_ATOMIC_INC_H__
+#endif // CLC_ATOMIC_CLC_ATOMIC_INC_H

--- a/libclc/clc/include/clc/atomic/clc_atomic_load.h
+++ b/libclc/clc/include/clc/atomic/clc_atomic_load.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_ATOMIC_CLC_ATOMIC_LOAD_H__
-#define __CLC_ATOMIC_CLC_ATOMIC_LOAD_H__
+#ifndef CLC_ATOMIC_CLC_ATOMIC_LOAD_H
+#define CLC_ATOMIC_CLC_ATOMIC_LOAD_H
 
 #include <clc/internal/clc.h>
 
@@ -23,4 +23,4 @@
 #undef __CLC_NO_VALUE_ARG
 #undef __CLC_FUNCTION
 
-#endif // __CLC_ATOMIC_CLC_ATOMIC_LOAD_H__
+#endif // CLC_ATOMIC_CLC_ATOMIC_LOAD_H

--- a/libclc/clc/include/clc/atomic/clc_atomic_store.h
+++ b/libclc/clc/include/clc/atomic/clc_atomic_store.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_ATOMIC_CLC_ATOMIC_STORE_H__
-#define __CLC_ATOMIC_CLC_ATOMIC_STORE_H__
+#ifndef CLC_ATOMIC_CLC_ATOMIC_STORE_H
+#define CLC_ATOMIC_CLC_ATOMIC_STORE_H
 
 #include <clc/internal/clc.h>
 
@@ -23,4 +23,4 @@
 #undef __CLC_RETURN_VOID
 #undef __CLC_FUNCTION
 
-#endif // __CLC_ATOMIC_CLC_ATOMIC_STORE_H__
+#endif // CLC_ATOMIC_CLC_ATOMIC_STORE_H

--- a/libclc/clc/include/clc/clc_as_type.h
+++ b/libclc/clc/include/clc/clc_as_type.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_CLC_AS_TYPE_H__
-#define __CLC_CLC_AS_TYPE_H__
+#ifndef CLC_CLC_AS_TYPE_H
+#define CLC_CLC_AS_TYPE_H
 
 #define __clc_as_char(x) __builtin_astype(x, char)
 #define __clc_as_uchar(x) __builtin_astype(x, uchar)
@@ -87,4 +87,4 @@
 #define __clc_as_half16(x) __builtin_astype(x, half16)
 #endif
 
-#endif // __CLC_CLC_AS_TYPE_H__
+#endif // CLC_CLC_AS_TYPE_H

--- a/libclc/clc/include/clc/clc_convert.h
+++ b/libclc/clc/include/clc/clc_convert.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_CLC_CONVERT_H__
-#define __CLC_CLC_CONVERT_H__
+#ifndef CLC_CLC_CONVERT_H
+#define CLC_CLC_CONVERT_H
 
 #include <clc/internal/clc.h>
 
@@ -105,4 +105,4 @@ _CLC_VECTOR_CONVERT_TO_SUFFIX()
 #undef _CLC_VECTOR_CONVERT_DECL
 #undef _CLC_CONVERT_DECL
 
-#endif // __CLC_CLC_CONVERT_H__
+#endif // CLC_CLC_CONVERT_H

--- a/libclc/clc/include/clc/clcfunc.h
+++ b/libclc/clc/include/clc/clcfunc.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_CLCFUNC_H_
-#define __CLC_CLCFUNC_H_
+#ifndef CLC_CLCFUNC_H
+#define CLC_CLCFUNC_H
 
 #define _CLC_OVERLOAD __attribute__((overloadable))
 #define _CLC_DECL
@@ -34,4 +34,4 @@
 #define _CLC_DISTINCT_GENERIC_AS_SUPPORTED 0
 #endif
 
-#endif // __CLC_CLCFUNC_H_
+#endif // CLC_CLCFUNC_H

--- a/libclc/clc/include/clc/common/clc_degrees.h
+++ b/libclc/clc/include/clc/common/clc_degrees.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_COMMON_CLC_DEGREES_H__
-#define __CLC_COMMON_CLC_DEGREES_H__
+#ifndef CLC_COMMON_CLC_DEGREES_H
+#define CLC_COMMON_CLC_DEGREES_H
 
 #define __CLC_BODY <clc/math/unary_decl.inc>
 #define __CLC_FUNCTION __clc_degrees
@@ -16,4 +16,4 @@
 
 #undef __CLC_FUNCTION
 
-#endif // __CLC_COMMON_CLC_DEGREES_H__
+#endif // CLC_COMMON_CLC_DEGREES_H

--- a/libclc/clc/include/clc/common/clc_radians.h
+++ b/libclc/clc/include/clc/common/clc_radians.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_COMMON_CLC_RADIANS_H__
-#define __CLC_COMMON_CLC_RADIANS_H__
+#ifndef CLC_COMMON_CLC_RADIANS_H
+#define CLC_COMMON_CLC_RADIANS_H
 
 #define __CLC_BODY <clc/math/unary_decl.inc>
 #define __CLC_FUNCTION __clc_radians
@@ -16,4 +16,4 @@
 
 #undef __CLC_FUNCTION
 
-#endif // __CLC_COMMON_CLC_RADIANS_H__
+#endif // CLC_COMMON_CLC_RADIANS_H

--- a/libclc/clc/include/clc/common/clc_sign.h
+++ b/libclc/clc/include/clc/common/clc_sign.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_COMMON_CLC_SIGN_H__
-#define __CLC_COMMON_CLC_SIGN_H__
+#ifndef CLC_COMMON_CLC_SIGN_H
+#define CLC_COMMON_CLC_SIGN_H
 
 #define __CLC_FUNCTION __clc_sign
 #define __CLC_BODY <clc/math/unary_decl.inc>
@@ -16,4 +16,4 @@
 
 #undef __CLC_FUNCTION
 
-#endif // __CLC_COMMON_CLC_SIGN_H__
+#endif // CLC_COMMON_CLC_SIGN_H

--- a/libclc/clc/include/clc/common/clc_smoothstep.h
+++ b/libclc/clc/include/clc/common/clc_smoothstep.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_COMMON_CLC_SMOOTHSTEP_H__
-#define __CLC_COMMON_CLC_SMOOTHSTEP_H__
+#ifndef CLC_COMMON_CLC_SMOOTHSTEP_H
+#define CLC_COMMON_CLC_SMOOTHSTEP_H
 
 // note: Unlike OpenCL __clc_smoothstep is only defined for three matching
 // argument types.
@@ -15,4 +15,4 @@
 #define __CLC_BODY <clc/common/clc_smoothstep.inc>
 #include <clc/math/gentype.inc>
 
-#endif // __CLC_COMMON_CLC_SMOOTHSTEP_H__
+#endif // CLC_COMMON_CLC_SMOOTHSTEP_H

--- a/libclc/clc/include/clc/common/clc_step.h
+++ b/libclc/clc/include/clc/common/clc_step.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_COMMON_CLC_STEP_H__
-#define __CLC_COMMON_CLC_STEP_H__
+#ifndef CLC_COMMON_CLC_STEP_H
+#define CLC_COMMON_CLC_STEP_H
 
 #define __CLC_FUNCTION __clc_step
 #define __CLC_BODY <clc/shared/binary_decl.inc>
@@ -16,4 +16,4 @@
 
 #undef __CLC_FUNCTION
 
-#endif // __CLC_COMMON_CLC_STEP_H__
+#endif // CLC_COMMON_CLC_STEP_H

--- a/libclc/clc/include/clc/float/definitions.h
+++ b/libclc/clc/include/clc/float/definitions.h
@@ -1,6 +1,3 @@
-#ifndef CLC_FLOAT_DEFINITIONS_H
-#define CLC_FLOAT_DEFINITIONS_H
-
 //===----------------------------------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
@@ -8,6 +5,9 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
+
+#ifndef CLC_FLOAT_DEFINITIONS_H
+#define CLC_FLOAT_DEFINITIONS_H
 
 #define FLT_DIG 6
 #define FLT_MANT_DIG 24

--- a/libclc/clc/include/clc/float/definitions.h
+++ b/libclc/clc/include/clc/float/definitions.h
@@ -1,3 +1,6 @@
+#ifndef CLC_FLOAT_DEFINITIONS_H
+#define CLC_FLOAT_DEFINITIONS_H
+
 //===----------------------------------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
@@ -58,5 +61,7 @@
 #define HALF_MIN_EXP -13
 #define HALF_RADIX 2
 #define HALF_NAN __builtin_nanf16("")
+
+#endif
 
 #endif

--- a/libclc/clc/include/clc/float/definitions.h
+++ b/libclc/clc/include/clc/float/definitions.h
@@ -64,4 +64,4 @@
 
 #endif
 
-#endif
+#endif // CLC_FLOAT_DEFINITIONS_H

--- a/libclc/clc/include/clc/geometric/clc_cross.h
+++ b/libclc/clc/include/clc/geometric/clc_cross.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_GEOMETRIC_CLC_CROSS_H__
-#define __CLC_GEOMETRIC_CLC_CROSS_H__
+#ifndef CLC_GEOMETRIC_CLC_CROSS_H
+#define CLC_GEOMETRIC_CLC_CROSS_H
 
 #include <clc/internal/clc.h>
 
@@ -30,4 +30,4 @@ _CLC_OVERLOAD _CLC_CONST _CLC_DECL half4 __clc_cross(half4 p0, half4 p1);
 
 #endif
 
-#endif // __CLC_GEOMETRIC_CLC_CROSS_H__
+#endif // CLC_GEOMETRIC_CLC_CROSS_H

--- a/libclc/clc/include/clc/geometric/clc_distance.h
+++ b/libclc/clc/include/clc/geometric/clc_distance.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_GEOMETRIC_CLC_DISTANCE_H__
-#define __CLC_GEOMETRIC_CLC_DISTANCE_H__
+#ifndef CLC_GEOMETRIC_CLC_DISTANCE_H
+#define CLC_GEOMETRIC_CLC_DISTANCE_H
 
 #define __CLC_FUNCTION __clc_distance
 #define __CLC_BODY <clc/geometric/binary_decl.inc>
@@ -16,4 +16,4 @@
 
 #undef __CLC_FUNCTION
 
-#endif // __CLC_GEOMETRIC_CLC_DISTANCE_H__
+#endif // CLC_GEOMETRIC_CLC_DISTANCE_H

--- a/libclc/clc/include/clc/geometric/clc_dot.h
+++ b/libclc/clc/include/clc/geometric/clc_dot.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_GEOMETRIC_CLC_DOT_H__
-#define __CLC_GEOMETRIC_CLC_DOT_H__
+#ifndef CLC_GEOMETRIC_CLC_DOT_H
+#define CLC_GEOMETRIC_CLC_DOT_H
 
 #define __CLC_FUNCTION __clc_dot
 #define __CLC_BODY <clc/geometric/binary_decl.inc>
@@ -16,4 +16,4 @@
 
 #undef __CLC_FUNCTION
 
-#endif // __CLC_GEOMETRIC_CLC_DOT_H__
+#endif // CLC_GEOMETRIC_CLC_DOT_H

--- a/libclc/clc/include/clc/geometric/clc_fast_distance.h
+++ b/libclc/clc/include/clc/geometric/clc_fast_distance.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_GEOMETRIC_CLC_FAST_DISTANCE_H__
-#define __CLC_GEOMETRIC_CLC_FAST_DISTANCE_H__
+#ifndef CLC_GEOMETRIC_CLC_FAST_DISTANCE_H
+#define CLC_GEOMETRIC_CLC_FAST_DISTANCE_H
 
 #define __CLC_FLOAT_ONLY
 #define __CLC_FUNCTION __clc_fast_distance
@@ -17,4 +17,4 @@
 
 #undef __CLC_FUNCTION
 
-#endif // __CLC_GEOMETRIC_CLC_FAST_DISTANCE_H__
+#endif // CLC_GEOMETRIC_CLC_FAST_DISTANCE_H

--- a/libclc/clc/include/clc/geometric/clc_fast_length.h
+++ b/libclc/clc/include/clc/geometric/clc_fast_length.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_GEOMETRIC_CLC_FAST_LENGTH_H__
-#define __CLC_GEOMETRIC_CLC_FAST_LENGTH_H__
+#ifndef CLC_GEOMETRIC_CLC_FAST_LENGTH_H
+#define CLC_GEOMETRIC_CLC_FAST_LENGTH_H
 
 #define __CLC_FLOAT_ONLY
 #define __CLC_FUNCTION __clc_fast_length
@@ -17,4 +17,4 @@
 
 #undef __CLC_FUNCTION
 
-#endif // __CLC_GEOMETRIC_CLC_FAST_LENGTH_H__
+#endif // CLC_GEOMETRIC_CLC_FAST_LENGTH_H

--- a/libclc/clc/include/clc/geometric/clc_fast_normalize.h
+++ b/libclc/clc/include/clc/geometric/clc_fast_normalize.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_GEOMETRIC_CLC_FAST_NORMALIZE_H__
-#define __CLC_GEOMETRIC_CLC_FAST_NORMALIZE_H__
+#ifndef CLC_GEOMETRIC_CLC_FAST_NORMALIZE_H
+#define CLC_GEOMETRIC_CLC_FAST_NORMALIZE_H
 
 #define __CLC_FLOAT_ONLY
 #define __CLC_GEOMETRIC_RET_GENTYPE
@@ -18,4 +18,4 @@
 #undef __CLC_FUNCTION
 #undef __CLC_GEOMETRIC_RET_GENTYPE
 
-#endif // __CLC_GEOMETRIC_CLC_FAST_NORMALIZE_H__
+#endif // CLC_GEOMETRIC_CLC_FAST_NORMALIZE_H

--- a/libclc/clc/include/clc/geometric/clc_length.h
+++ b/libclc/clc/include/clc/geometric/clc_length.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_GEOMETRIC_CLC_LENGTH_H__
-#define __CLC_GEOMETRIC_CLC_LENGTH_H__
+#ifndef CLC_GEOMETRIC_CLC_LENGTH_H
+#define CLC_GEOMETRIC_CLC_LENGTH_H
 
 #define __CLC_FUNCTION __clc_length
 #define __CLC_BODY <clc/geometric/unary_decl.inc>
@@ -16,4 +16,4 @@
 
 #undef __CLC_FUNCTION
 
-#endif // __CLC_GEOMETRIC_CLC_LENGTH_H__
+#endif // CLC_GEOMETRIC_CLC_LENGTH_H

--- a/libclc/clc/include/clc/geometric/clc_normalize.h
+++ b/libclc/clc/include/clc/geometric/clc_normalize.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_GEOMETRIC_CLC_NORMALIZE_H__
-#define __CLC_GEOMETRIC_CLC_NORMALIZE_H__
+#ifndef CLC_GEOMETRIC_CLC_NORMALIZE_H
+#define CLC_GEOMETRIC_CLC_NORMALIZE_H
 
 #define __CLC_GEOMETRIC_RET_GENTYPE
 #define __CLC_FUNCTION __clc_normalize
@@ -17,4 +17,4 @@
 #undef __CLC_FUNCTION
 #undef __CLC_GEOMETRIC_RET_GENTYPE
 
-#endif // __CLC_GEOMETRIC_CLC_NORMALIZE_H__
+#endif // CLC_GEOMETRIC_CLC_NORMALIZE_H

--- a/libclc/clc/include/clc/integer/clc_abs.h
+++ b/libclc/clc/include/clc/integer/clc_abs.h
@@ -6,10 +6,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_INTEGER_CLC_ABS_H__
-#define __CLC_INTEGER_CLC_ABS_H__
+#ifndef CLC_INTEGER_CLC_ABS_H
+#define CLC_INTEGER_CLC_ABS_H
 
 #define __CLC_BODY <clc/integer/clc_abs.inc>
 #include <clc/integer/gentype.inc>
 
-#endif // __CLC_INTEGER_CLC_ABS_H__
+#endif // CLC_INTEGER_CLC_ABS_H

--- a/libclc/clc/include/clc/integer/clc_abs_diff.h
+++ b/libclc/clc/include/clc/integer/clc_abs_diff.h
@@ -6,10 +6,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_INTEGER_CLC_ABS_DIFF_H__
-#define __CLC_INTEGER_CLC_ABS_DIFF_H__
+#ifndef CLC_INTEGER_CLC_ABS_DIFF_H
+#define CLC_INTEGER_CLC_ABS_DIFF_H
 
 #define __CLC_BODY <clc/integer/clc_abs_diff.inc>
 #include <clc/integer/gentype.inc>
 
-#endif // __CLC_INTEGER_CLC_ABS_DIFF_H__
+#endif // CLC_INTEGER_CLC_ABS_DIFF_H

--- a/libclc/clc/include/clc/integer/clc_add_sat.h
+++ b/libclc/clc/include/clc/integer/clc_add_sat.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_INTEGER_CLC_ADD_SAT_H__
-#define __CLC_INTEGER_CLC_ADD_SAT_H__
+#ifndef CLC_INTEGER_CLC_ADD_SAT_H
+#define CLC_INTEGER_CLC_ADD_SAT_H
 
 #define __CLC_FUNCTION __clc_add_sat
 #define __CLC_BODY <clc/shared/binary_decl.inc>
@@ -16,4 +16,4 @@
 
 #undef __CLC_FUNCTION
 
-#endif // __CLC_INTEGER_CLC_ADD_SAT_H__
+#endif // CLC_INTEGER_CLC_ADD_SAT_H

--- a/libclc/clc/include/clc/integer/clc_bit_reverse.h
+++ b/libclc/clc/include/clc/integer/clc_bit_reverse.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_INTEGER_CLC_BIT_REVERSE_H__
-#define __CLC_INTEGER_CLC_BIT_REVERSE_H__
+#ifndef CLC_INTEGER_CLC_BIT_REVERSE_H
+#define CLC_INTEGER_CLC_BIT_REVERSE_H
 
 #define __CLC_FUNCTION __clc_bit_reverse
 #define __CLC_BODY <clc/shared/unary_decl.inc>
@@ -16,4 +16,4 @@
 
 #undef __CLC_FUNCTION
 
-#endif // __CLC_INTEGER_CLC_BIT_REVERSE_H__
+#endif // CLC_INTEGER_CLC_BIT_REVERSE_H

--- a/libclc/clc/include/clc/integer/clc_bitfield_extract_signed.h
+++ b/libclc/clc/include/clc/integer/clc_bitfield_extract_signed.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_INTEGER_CLC_BITFIELD_EXTRACT_SIGNED_H__
-#define __CLC_INTEGER_CLC_BITFIELD_EXTRACT_SIGNED_H__
+#ifndef CLC_INTEGER_CLC_BITFIELD_EXTRACT_SIGNED_H
+#define CLC_INTEGER_CLC_BITFIELD_EXTRACT_SIGNED_H
 
 #include <clc/internal/clc.h>
 
@@ -20,4 +20,4 @@
 #undef __CLC_RETTYPE
 #undef __CLC_FUNCTION
 
-#endif // __CLC_INTEGER_CLC_BITFIELD_EXTRACT_SIGNED_H__
+#endif // CLC_INTEGER_CLC_BITFIELD_EXTRACT_SIGNED_H

--- a/libclc/clc/include/clc/integer/clc_bitfield_extract_unsigned.h
+++ b/libclc/clc/include/clc/integer/clc_bitfield_extract_unsigned.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_INTEGER_CLC_BITFIELD_EXTRACT_SIGNED_H__
-#define __CLC_INTEGER_CLC_BITFIELD_EXTRACT_SIGNED_H__
+#ifndef CLC_INTEGER_CLC_BITFIELD_EXTRACT_UNSIGNED_H
+#define CLC_INTEGER_CLC_BITFIELD_EXTRACT_UNSIGNED_H
 
 #include <clc/internal/clc.h>
 
@@ -20,4 +20,4 @@
 #undef __CLC_RETTYPE
 #undef __CLC_FUNCTION
 
-#endif // __CLC_INTEGER_CLC_BITFIELD_EXTRACT_SIGNED_H__
+#endif // CLC_INTEGER_CLC_BITFIELD_EXTRACT_UNSIGNED_H

--- a/libclc/clc/include/clc/integer/clc_bitfield_insert.h
+++ b/libclc/clc/include/clc/integer/clc_bitfield_insert.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_INTEGER_CLC_BITFIELD_INSERT_H__
-#define __CLC_INTEGER_CLC_BITFIELD_INSERT_H__
+#ifndef CLC_INTEGER_CLC_BITFIELD_INSERT_H
+#define CLC_INTEGER_CLC_BITFIELD_INSERT_H
 
 #include <clc/internal/clc.h>
 
@@ -15,4 +15,4 @@
 #define __CLC_BODY <clc/integer/clc_bitfield_insert.inc>
 #include <clc/integer/gentype.inc>
 
-#endif // __CLC_INTEGER_CLC_BITFIELD_INSERT_H__
+#endif // CLC_INTEGER_CLC_BITFIELD_INSERT_H

--- a/libclc/clc/include/clc/integer/clc_clz.h
+++ b/libclc/clc/include/clc/integer/clc_clz.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_INTEGER_CLC_CLZ_H__
-#define __CLC_INTEGER_CLC_CLZ_H__
+#ifndef CLC_INTEGER_CLC_CLZ_H
+#define CLC_INTEGER_CLC_CLZ_H
 
 #define __CLC_FUNCTION __clc_clz
 #define __CLC_BODY <clc/shared/unary_decl.inc>
@@ -16,4 +16,4 @@
 
 #undef __CLC_FUNCTION
 
-#endif // __CLC_INTEGER_CLC_CLZ_H__
+#endif // CLC_INTEGER_CLC_CLZ_H

--- a/libclc/clc/include/clc/integer/clc_ctz.h
+++ b/libclc/clc/include/clc/integer/clc_ctz.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_INTEGER_CLC_CTZ_H__
-#define __CLC_INTEGER_CLC_CTZ_H__
+#ifndef CLC_INTEGER_CLC_CTZ_H
+#define CLC_INTEGER_CLC_CTZ_H
 
 #define __CLC_FUNCTION __clc_ctz
 #define __CLC_BODY <clc/shared/unary_decl.inc>
@@ -16,4 +16,4 @@
 
 #undef __CLC_FUNCTION
 
-#endif // __CLC_INTEGER_CLC_CTZ_H__
+#endif // CLC_INTEGER_CLC_CTZ_H

--- a/libclc/clc/include/clc/integer/clc_hadd.h
+++ b/libclc/clc/include/clc/integer/clc_hadd.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_INTEGER_CLC_HADD_H__
-#define __CLC_INTEGER_CLC_HADD_H__
+#ifndef CLC_INTEGER_CLC_HADD_H
+#define CLC_INTEGER_CLC_HADD_H
 
 #define __CLC_FUNCTION __clc_hadd
 #define __CLC_BODY <clc/shared/binary_decl.inc>
@@ -16,4 +16,4 @@
 
 #undef __CLC_FUNCTION
 
-#endif // __CLC_INTEGER_CLC_HADD_H__
+#endif // CLC_INTEGER_CLC_HADD_H

--- a/libclc/clc/include/clc/integer/clc_mad24.h
+++ b/libclc/clc/include/clc/integer/clc_mad24.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_INTEGER_CLC_MAD24_H__
-#define __CLC_INTEGER_CLC_MAD24_H__
+#ifndef CLC_INTEGER_CLC_MAD24_H
+#define CLC_INTEGER_CLC_MAD24_H
 
 #define __CLC_FUNCTION __clc_mad24
 #define __CLC_BODY <clc/shared/ternary_decl.inc>
@@ -16,4 +16,4 @@
 
 #undef __CLC_FUNCTION
 
-#endif // __CLC_INTEGER_CLC_MAD24_H__
+#endif // CLC_INTEGER_CLC_MAD24_H

--- a/libclc/clc/include/clc/integer/clc_mad_hi.h
+++ b/libclc/clc/include/clc/integer/clc_mad_hi.h
@@ -6,11 +6,11 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_INTEGER_CLC_MAD_HI_H__
-#define __CLC_INTEGER_CLC_MAD_HI_H__
+#ifndef CLC_INTEGER_CLC_MAD_HI_H
+#define CLC_INTEGER_CLC_MAD_HI_H
 
 #include <clc/integer/clc_mul_hi.h>
 
 #define __clc_mad_hi(a, b, c) (__clc_mul_hi((a), (b)) + (c))
 
-#endif // __CLC_INTEGER_CLC_MAD_HI_H__
+#endif // CLC_INTEGER_CLC_MAD_HI_H

--- a/libclc/clc/include/clc/integer/clc_mad_sat.h
+++ b/libclc/clc/include/clc/integer/clc_mad_sat.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_INTEGER_CLC_MAD_SAT_H__
-#define __CLC_INTEGER_CLC_MAD_SAT_H__
+#ifndef CLC_INTEGER_CLC_MAD_SAT_H
+#define CLC_INTEGER_CLC_MAD_SAT_H
 
 #define __CLC_FUNCTION __clc_mad_sat
 #define __CLC_BODY <clc/shared/ternary_decl.inc>
@@ -16,4 +16,4 @@
 
 #undef __CLC_FUNCTION
 
-#endif // __CLC_INTEGER_CLC_MAD_SAT_H__
+#endif // CLC_INTEGER_CLC_MAD_SAT_H

--- a/libclc/clc/include/clc/integer/clc_mul24.h
+++ b/libclc/clc/include/clc/integer/clc_mul24.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_INTEGER_CLC_MUL24_H__
-#define __CLC_INTEGER_CLC_MUL24_H__
+#ifndef CLC_INTEGER_CLC_MUL24_H
+#define CLC_INTEGER_CLC_MUL24_H
 
 #define __CLC_FUNCTION __clc_mul24
 #define __CLC_BODY <clc/shared/binary_decl.inc>
@@ -16,4 +16,4 @@
 
 #undef __CLC_FUNCTION
 
-#endif // __CLC_INTEGER_CLC_MUL24_H__
+#endif // CLC_INTEGER_CLC_MUL24_H

--- a/libclc/clc/include/clc/integer/clc_mul_hi.h
+++ b/libclc/clc/include/clc/integer/clc_mul_hi.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_INTEGER_CLC_MUL_HI_H__
-#define __CLC_INTEGER_CLC_MUL_HI_H__
+#ifndef CLC_INTEGER_CLC_MUL_HI_H
+#define CLC_INTEGER_CLC_MUL_HI_H
 
 #define __CLC_FUNCTION __clc_mul_hi
 #define __CLC_BODY <clc/shared/binary_decl.inc>
@@ -16,4 +16,4 @@
 
 #undef __CLC_FUNCTION
 
-#endif // __CLC_INTEGER_CLC_MUL_HI_H__
+#endif // CLC_INTEGER_CLC_MUL_HI_H

--- a/libclc/clc/include/clc/integer/clc_popcount.h
+++ b/libclc/clc/include/clc/integer/clc_popcount.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_INTEGER_CLC_POPCOUNT_H__
-#define __CLC_INTEGER_CLC_POPCOUNT_H__
+#ifndef CLC_INTEGER_CLC_POPCOUNT_H
+#define CLC_INTEGER_CLC_POPCOUNT_H
 
 #define __CLC_FUNCTION __clc_popcount
 #define __CLC_BODY <clc/shared/unary_decl.inc>
@@ -17,4 +17,4 @@
 #undef __CLC_INTRINSIC
 #undef __CLC_FUNCTION
 
-#endif // __CLC_INTEGER_CLC_POPCOUNT_H__
+#endif // CLC_INTEGER_CLC_POPCOUNT_H

--- a/libclc/clc/include/clc/integer/clc_rhadd.h
+++ b/libclc/clc/include/clc/integer/clc_rhadd.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_INTEGER_CLC_RHADD_H__
-#define __CLC_INTEGER_CLC_RHADD_H__
+#ifndef CLC_INTEGER_CLC_RHADD_H
+#define CLC_INTEGER_CLC_RHADD_H
 
 #define __CLC_FUNCTION __clc_rhadd
 #define __CLC_BODY <clc/shared/binary_decl.inc>
@@ -16,4 +16,4 @@
 
 #undef __CLC_FUNCTION
 
-#endif // __CLC_INTEGER_CLC_RHADD_H__
+#endif // CLC_INTEGER_CLC_RHADD_H

--- a/libclc/clc/include/clc/integer/clc_rotate.h
+++ b/libclc/clc/include/clc/integer/clc_rotate.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_INTEGER_CLC_ROTATE_H__
-#define __CLC_INTEGER_CLC_ROTATE_H__
+#ifndef CLC_INTEGER_CLC_ROTATE_H
+#define CLC_INTEGER_CLC_ROTATE_H
 
 #define __CLC_FUNCTION __clc_rotate
 #define __CLC_BODY <clc/shared/binary_decl.inc>
@@ -16,4 +16,4 @@
 
 #undef __CLC_FUNCTION
 
-#endif // __CLC_INTEGER_CLC_ROTATE_H__
+#endif // CLC_INTEGER_CLC_ROTATE_H

--- a/libclc/clc/include/clc/integer/clc_sub_sat.h
+++ b/libclc/clc/include/clc/integer/clc_sub_sat.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_INTEGER_CLC_SUB_SAT_H__
-#define __CLC_INTEGER_CLC_SUB_SAT_H__
+#ifndef CLC_INTEGER_CLC_SUB_SAT_H
+#define CLC_INTEGER_CLC_SUB_SAT_H
 
 #define __CLC_FUNCTION __clc_sub_sat
 #define __CLC_BODY <clc/shared/binary_decl.inc>
@@ -16,4 +16,4 @@
 
 #undef __CLC_FUNCTION
 
-#endif // __CLC_INTEGER_CLC_SUB_SAT_H__
+#endif // CLC_INTEGER_CLC_SUB_SAT_H

--- a/libclc/clc/include/clc/integer/clc_upsample.h
+++ b/libclc/clc/include/clc/integer/clc_upsample.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_INTEGER_CLC_UPSAMPLE_H__
-#define __CLC_INTEGER_CLC_UPSAMPLE_H__
+#ifndef CLC_INTEGER_CLC_UPSAMPLE_H
+#define CLC_INTEGER_CLC_UPSAMPLE_H
 
 #include <clc/clcfunc.h>
 
@@ -36,4 +36,4 @@ __CLC_UPSAMPLE_TYPES()
 #undef __CLC_UPSAMPLE_DECL
 #undef __CLC_UPSAMPLE_VEC
 
-#endif // __CLC_INTEGER_CLC_UPSAMPLE_H__
+#endif // CLC_INTEGER_CLC_UPSAMPLE_H

--- a/libclc/clc/include/clc/integer/definitions.h
+++ b/libclc/clc/include/clc/integer/definitions.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_INTEGER_DEFINITIONS_H__
-#define __CLC_INTEGER_DEFINITIONS_H__
+#ifndef CLC_INTEGER_DEFINITIONS_H
+#define CLC_INTEGER_DEFINITIONS_H
 
 #define CHAR_BIT 8
 #define INT_MAX 2147483647
@@ -25,4 +25,4 @@
 #define ULONG_MAX 0xffffffffffffffffUL
 #define ULONG_MIN 0UL
 
-#endif // __CLC_INTEGER_DEFINITIONS_H__
+#endif // CLC_INTEGER_DEFINITIONS_H

--- a/libclc/clc/include/clc/internal/clc.h
+++ b/libclc/clc/include/clc/internal/clc.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_INTERNAL_CLC_H_
-#define __CLC_INTERNAL_CLC_H_
+#ifndef CLC_INTERNAL_CLC_H
+#define CLC_INTERNAL_CLC_H
 
 #ifndef cl_clang_storage_class_specifiers
 #error Implementation requires cl_clang_storage_class_specifiers extension!
@@ -33,4 +33,4 @@
 
 #pragma OPENCL EXTENSION all : disable
 
-#endif // __CLC_INTERNAL_CLC_H_
+#endif // CLC_INTERNAL_CLC_H

--- a/libclc/clc/include/clc/internal/math/clc_sw_fma.h
+++ b/libclc/clc/include/clc/internal/math/clc_sw_fma.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_INTERNAL_MATH_CLC_SW_FMA_H__
-#define __CLC_INTERNAL_MATH_CLC_SW_FMA_H__
+#ifndef CLC_INTERNAL_MATH_CLC_SW_FMA_H
+#define CLC_INTERNAL_MATH_CLC_SW_FMA_H
 
 #define __CLC_FUNCTION __clc_sw_fma
 #define __CLC_FLOAT_ONLY
@@ -17,4 +17,4 @@
 
 #undef __CLC_FUNCTION
 
-#endif // __CLC_INTERNAL_MATH_CLC_SW_FMA_H__
+#endif // CLC_INTERNAL_MATH_CLC_SW_FMA_H

--- a/libclc/clc/include/clc/math/clc_acos.h
+++ b/libclc/clc/include/clc/math/clc_acos.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_MATH_CLC_ACOS_H__
-#define __CLC_MATH_CLC_ACOS_H__
+#ifndef CLC_MATH_CLC_ACOS_H
+#define CLC_MATH_CLC_ACOS_H
 
 #define __CLC_BODY <clc/math/unary_decl.inc>
 #define __CLC_FUNCTION __clc_acos
@@ -16,4 +16,4 @@
 
 #undef __CLC_FUNCTION
 
-#endif // __CLC_MATH_CLC_ACOS_H__
+#endif // CLC_MATH_CLC_ACOS_H

--- a/libclc/clc/include/clc/math/clc_acosh.h
+++ b/libclc/clc/include/clc/math/clc_acosh.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_MATH_CLC_ACOSH_H__
-#define __CLC_MATH_CLC_ACOSH_H__
+#ifndef CLC_MATH_CLC_ACOSH_H
+#define CLC_MATH_CLC_ACOSH_H
 
 #define __CLC_BODY <clc/math/unary_decl.inc>
 #define __CLC_FUNCTION __clc_acosh
@@ -16,4 +16,4 @@
 
 #undef __CLC_FUNCTION
 
-#endif // __CLC_MATH_CLC_ACOSH_H__
+#endif // CLC_MATH_CLC_ACOSH_H

--- a/libclc/clc/include/clc/math/clc_acospi.h
+++ b/libclc/clc/include/clc/math/clc_acospi.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_MATH_CLC_ACOSPI_H__
-#define __CLC_MATH_CLC_ACOSPI_H__
+#ifndef CLC_MATH_CLC_ACOSPI_H
+#define CLC_MATH_CLC_ACOSPI_H
 
 #define __CLC_BODY <clc/math/unary_decl.inc>
 #define __CLC_FUNCTION __clc_acospi
@@ -16,4 +16,4 @@
 
 #undef __CLC_FUNCTION
 
-#endif // __CLC_MATH_CLC_ACOSPI_H__
+#endif // CLC_MATH_CLC_ACOSPI_H

--- a/libclc/clc/include/clc/math/clc_asin.h
+++ b/libclc/clc/include/clc/math/clc_asin.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_MATH_CLC_ASIN_H__
-#define __CLC_MATH_CLC_ASIN_H__
+#ifndef CLC_MATH_CLC_ASIN_H
+#define CLC_MATH_CLC_ASIN_H
 
 #define __CLC_BODY <clc/math/unary_decl.inc>
 #define __CLC_FUNCTION __clc_asin
@@ -16,4 +16,4 @@
 
 #undef __CLC_FUNCTION
 
-#endif // __CLC_MATH_CLC_ASIN_H__
+#endif // CLC_MATH_CLC_ASIN_H

--- a/libclc/clc/include/clc/math/clc_asinh.h
+++ b/libclc/clc/include/clc/math/clc_asinh.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_MATH_CLC_ASINH_H__
-#define __CLC_MATH_CLC_ASINH_H__
+#ifndef CLC_MATH_CLC_ASINH_H
+#define CLC_MATH_CLC_ASINH_H
 
 #define __CLC_BODY <clc/math/unary_decl.inc>
 #define __CLC_FUNCTION __clc_asinh
@@ -16,4 +16,4 @@
 
 #undef __CLC_FUNCTION
 
-#endif // __CLC_MATH_CLC_ASINH_H__
+#endif // CLC_MATH_CLC_ASINH_H

--- a/libclc/clc/include/clc/math/clc_asinpi.h
+++ b/libclc/clc/include/clc/math/clc_asinpi.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_MATH_CLC_ASINPI_H__
-#define __CLC_MATH_CLC_ASINPI_H__
+#ifndef CLC_MATH_CLC_ASINPI_H
+#define CLC_MATH_CLC_ASINPI_H
 
 #define __CLC_BODY <clc/math/unary_decl.inc>
 #define __CLC_FUNCTION __clc_asinpi
@@ -16,4 +16,4 @@
 
 #undef __CLC_FUNCTION
 
-#endif // __CLC_MATH_CLC_ASINPI_H__
+#endif // CLC_MATH_CLC_ASINPI_H

--- a/libclc/clc/include/clc/math/clc_atan.h
+++ b/libclc/clc/include/clc/math/clc_atan.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_MATH_CLC_ATAN_H__
-#define __CLC_MATH_CLC_ATAN_H__
+#ifndef CLC_MATH_CLC_ATAN_H
+#define CLC_MATH_CLC_ATAN_H
 
 #define __CLC_BODY <clc/math/unary_decl.inc>
 #define __CLC_FUNCTION __clc_atan
@@ -16,4 +16,4 @@
 
 #undef __CLC_FUNCTION
 
-#endif // __CLC_MATH_CLC_ATAN_H__
+#endif // CLC_MATH_CLC_ATAN_H

--- a/libclc/clc/include/clc/math/clc_atan2.h
+++ b/libclc/clc/include/clc/math/clc_atan2.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_MATH_CLC_ATAN2_H__
-#define __CLC_MATH_CLC_ATAN2_H__
+#ifndef CLC_MATH_CLC_ATAN2_H
+#define CLC_MATH_CLC_ATAN2_H
 
 #define __CLC_BODY <clc/shared/binary_decl.inc>
 #define __CLC_FUNCTION __clc_atan2
@@ -16,4 +16,4 @@
 
 #undef __CLC_FUNCTION
 
-#endif // __CLC_MATH_CLC_ATAN2_H__
+#endif // CLC_MATH_CLC_ATAN2_H

--- a/libclc/clc/include/clc/math/clc_atan2pi.h
+++ b/libclc/clc/include/clc/math/clc_atan2pi.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_MATH_CLC_ATAN2PI_H__
-#define __CLC_MATH_CLC_ATAN2PI_H__
+#ifndef CLC_MATH_CLC_ATAN2PI_H
+#define CLC_MATH_CLC_ATAN2PI_H
 
 #define __CLC_BODY <clc/shared/binary_decl.inc>
 #define __CLC_FUNCTION __clc_atan2pi
@@ -16,4 +16,4 @@
 
 #undef __CLC_FUNCTION
 
-#endif // __CLC_MATH_CLC_ATAN2PI_H__
+#endif // CLC_MATH_CLC_ATAN2PI_H

--- a/libclc/clc/include/clc/math/clc_atanh.h
+++ b/libclc/clc/include/clc/math/clc_atanh.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_MATH_CLC_ATANH_H__
-#define __CLC_MATH_CLC_ATANH_H__
+#ifndef CLC_MATH_CLC_ATANH_H
+#define CLC_MATH_CLC_ATANH_H
 
 #define __CLC_BODY <clc/math/unary_decl.inc>
 #define __CLC_FUNCTION __clc_atanh
@@ -16,4 +16,4 @@
 
 #undef __CLC_FUNCTION
 
-#endif // __CLC_MATH_CLC_ATANH_H__
+#endif // CLC_MATH_CLC_ATANH_H

--- a/libclc/clc/include/clc/math/clc_atanpi.h
+++ b/libclc/clc/include/clc/math/clc_atanpi.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_MATH_CLC_ATANPI_H__
-#define __CLC_MATH_CLC_ATANPI_H__
+#ifndef CLC_MATH_CLC_ATANPI_H
+#define CLC_MATH_CLC_ATANPI_H
 
 #define __CLC_BODY <clc/math/unary_decl.inc>
 #define __CLC_FUNCTION __clc_atanpi
@@ -16,4 +16,4 @@
 
 #undef __CLC_FUNCTION
 
-#endif // __CLC_MATH_CLC_ATANPI_H__
+#endif // CLC_MATH_CLC_ATANPI_H

--- a/libclc/clc/include/clc/math/clc_cbrt.h
+++ b/libclc/clc/include/clc/math/clc_cbrt.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_MATH_CLC_CBRT_H__
-#define __CLC_MATH_CLC_CBRT_H__
+#ifndef CLC_MATH_CLC_CBRT_H
+#define CLC_MATH_CLC_CBRT_H
 
 #define __CLC_BODY <clc/math/unary_decl.inc>
 #define __CLC_FUNCTION __clc_cbrt
@@ -16,4 +16,4 @@
 
 #undef __CLC_FUNCTION
 
-#endif // __CLC_MATH_CLC_CBRT_H__
+#endif // CLC_MATH_CLC_CBRT_H

--- a/libclc/clc/include/clc/math/clc_ceil.h
+++ b/libclc/clc/include/clc/math/clc_ceil.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_MATH_CLC_CEIL_H__
-#define __CLC_MATH_CLC_CEIL_H__
+#ifndef CLC_MATH_CLC_CEIL_H
+#define CLC_MATH_CLC_CEIL_H
 
 #define __CLC_BODY <clc/math/unary_decl.inc>
 #define __CLC_FUNCTION __clc_ceil
@@ -16,4 +16,4 @@
 
 #undef __CLC_FUNCTION
 
-#endif // __CLC_MATH_CLC_CEIL_H__
+#endif // CLC_MATH_CLC_CEIL_H

--- a/libclc/clc/include/clc/math/clc_copysign.h
+++ b/libclc/clc/include/clc/math/clc_copysign.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_MATH_CLC_COPYSIGN_H__
-#define __CLC_MATH_CLC_COPYSIGN_H__
+#ifndef CLC_MATH_CLC_COPYSIGN_H
+#define CLC_MATH_CLC_COPYSIGN_H
 
 #define __CLC_BODY <clc/shared/binary_decl.inc>
 #define __CLC_FUNCTION __clc_copysign
@@ -16,4 +16,4 @@
 
 #undef __CLC_FUNCTION
 
-#endif // __CLC_MATH_CLC_COPYSIGN_H__
+#endif // CLC_MATH_CLC_COPYSIGN_H

--- a/libclc/clc/include/clc/math/clc_cos.h
+++ b/libclc/clc/include/clc/math/clc_cos.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_MATH_CLC_COS_H__
-#define __CLC_MATH_CLC_COS_H__
+#ifndef CLC_MATH_CLC_COS_H
+#define CLC_MATH_CLC_COS_H
 
 #define __CLC_BODY <clc/math/unary_decl.inc>
 #define __CLC_FUNCTION __clc_cos
@@ -16,4 +16,4 @@
 
 #undef __CLC_FUNCTION
 
-#endif // __CLC_MATH_CLC_COS_H__
+#endif // CLC_MATH_CLC_COS_H

--- a/libclc/clc/include/clc/math/clc_cosh.h
+++ b/libclc/clc/include/clc/math/clc_cosh.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_MATH_CLC_COSH_H__
-#define __CLC_MATH_CLC_COSH_H__
+#ifndef CLC_MATH_CLC_COSH_H
+#define CLC_MATH_CLC_COSH_H
 
 #define __CLC_BODY <clc/math/unary_decl.inc>
 #define __CLC_FUNCTION __clc_cosh
@@ -16,4 +16,4 @@
 
 #undef __CLC_FUNCTION
 
-#endif // __CLC_MATH_CLC_COSH_H__
+#endif // CLC_MATH_CLC_COSH_H

--- a/libclc/clc/include/clc/math/clc_cospi.h
+++ b/libclc/clc/include/clc/math/clc_cospi.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_MATH_CLC_COSPI_H__
-#define __CLC_MATH_CLC_COSPI_H__
+#ifndef CLC_MATH_CLC_COSPI_H
+#define CLC_MATH_CLC_COSPI_H
 
 #define __CLC_BODY <clc/math/unary_decl.inc>
 #define __CLC_FUNCTION __clc_cospi
@@ -16,4 +16,4 @@
 
 #undef __CLC_FUNCTION
 
-#endif // __CLC_MATH_CLC_COSPI_H__
+#endif // CLC_MATH_CLC_COSPI_H

--- a/libclc/clc/include/clc/math/clc_ep_log.h
+++ b/libclc/clc/include/clc/math/clc_ep_log.h
@@ -6,10 +6,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_MATH_CLC_EP_LOG_H__
-#define __CLC_MATH_CLC_EP_LOG_H__
+#ifndef CLC_MATH_CLC_EP_LOG_H
+#define CLC_MATH_CLC_EP_LOG_H
 
 #define __CLC_BODY <clc/math/clc_ep_log.inc>
 #include <clc/math/gentype.inc>
 
-#endif // __CLC_MATH_CLC_EP_LOG_H__
+#endif // CLC_MATH_CLC_EP_LOG_H

--- a/libclc/clc/include/clc/math/clc_erf.h
+++ b/libclc/clc/include/clc/math/clc_erf.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_MATH_CLC_ERF_H__
-#define __CLC_MATH_CLC_ERF_H__
+#ifndef CLC_MATH_CLC_ERF_H
+#define CLC_MATH_CLC_ERF_H
 
 #define __CLC_BODY <clc/math/unary_decl.inc>
 #define __CLC_FUNCTION __clc_erf
@@ -16,4 +16,4 @@
 
 #undef __CLC_FUNCTION
 
-#endif // __CLC_MATH_CLC_ERF_H__
+#endif // CLC_MATH_CLC_ERF_H

--- a/libclc/clc/include/clc/math/clc_erfc.h
+++ b/libclc/clc/include/clc/math/clc_erfc.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_MATH_CLC_ERFC_H__
-#define __CLC_MATH_CLC_ERFC_H__
+#ifndef CLC_MATH_CLC_ERFC_H
+#define CLC_MATH_CLC_ERFC_H
 
 #define __CLC_BODY <clc/math/unary_decl.inc>
 #define __CLC_FUNCTION __clc_erfc
@@ -16,4 +16,4 @@
 
 #undef __CLC_FUNCTION
 
-#endif // __CLC_MATH_CLC_ERFC_H__
+#endif // CLC_MATH_CLC_ERFC_H

--- a/libclc/clc/include/clc/math/clc_exp.h
+++ b/libclc/clc/include/clc/math/clc_exp.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_MATH_CLC_EXP_H__
-#define __CLC_MATH_CLC_EXP_H__
+#ifndef CLC_MATH_CLC_EXP_H
+#define CLC_MATH_CLC_EXP_H
 
 #define __CLC_BODY <clc/math/unary_decl.inc>
 #define __CLC_FUNCTION __clc_exp
@@ -16,4 +16,4 @@
 
 #undef __CLC_FUNCTION
 
-#endif // __CLC_MATH_CLC_EXP_H__
+#endif // CLC_MATH_CLC_EXP_H

--- a/libclc/clc/include/clc/math/clc_exp10.h
+++ b/libclc/clc/include/clc/math/clc_exp10.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_MATH_CLC_EXP10_H__
-#define __CLC_MATH_CLC_EXP10_H__
+#ifndef CLC_MATH_CLC_EXP10_H
+#define CLC_MATH_CLC_EXP10_H
 
 #define __CLC_BODY <clc/math/unary_decl.inc>
 #define __CLC_FUNCTION __clc_exp10
@@ -16,4 +16,4 @@
 
 #undef __CLC_FUNCTION
 
-#endif // __CLC_MATH_CLC_EXP10_H__
+#endif // CLC_MATH_CLC_EXP10_H

--- a/libclc/clc/include/clc/math/clc_exp2.h
+++ b/libclc/clc/include/clc/math/clc_exp2.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_MATH_CLC_EXP2_H__
-#define __CLC_MATH_CLC_EXP2_H__
+#ifndef CLC_MATH_CLC_EXP2_H
+#define CLC_MATH_CLC_EXP2_H
 
 #define __CLC_BODY <clc/math/unary_decl.inc>
 #define __CLC_FUNCTION __clc_exp2
@@ -16,4 +16,4 @@
 
 #undef __CLC_FUNCTION
 
-#endif // __CLC_MATH_CLC_EXP2_H__
+#endif // CLC_MATH_CLC_EXP2_H

--- a/libclc/clc/include/clc/math/clc_exp_helper.h
+++ b/libclc/clc/include/clc/math/clc_exp_helper.h
@@ -6,12 +6,12 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_MATH_CLC_EXP_HELPER
-#define __CLC_MATH_CLC_EXP_HELPER
+#ifndef CLC_MATH_CLC_EXP_HELPER_H
+#define CLC_MATH_CLC_EXP_HELPER_H
 
 #define __CLC_DOUBLE_ONLY
 #define __CLC_BODY <clc/math/clc_exp_helper.inc>
 
 #include <clc/math/gentype.inc>
 
-#endif // __CLC_MATH_CLC_EXP_HELPER
+#endif // CLC_MATH_CLC_EXP_HELPER_H

--- a/libclc/clc/include/clc/math/clc_expm1.h
+++ b/libclc/clc/include/clc/math/clc_expm1.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_MATH_CLC_EXPM1_H__
-#define __CLC_MATH_CLC_EXPM1_H__
+#ifndef CLC_MATH_CLC_EXPM1_H
+#define CLC_MATH_CLC_EXPM1_H
 
 #define __CLC_BODY <clc/math/unary_decl.inc>
 #define __CLC_FUNCTION __clc_expm1
@@ -16,4 +16,4 @@
 
 #undef __CLC_FUNCTION
 
-#endif // __CLC_MATH_CLC_EXPM1_H__
+#endif // CLC_MATH_CLC_EXPM1_H

--- a/libclc/clc/include/clc/math/clc_fabs.h
+++ b/libclc/clc/include/clc/math/clc_fabs.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_MATH_CLC_FABS_H__
-#define __CLC_MATH_CLC_FABS_H__
+#ifndef CLC_MATH_CLC_FABS_H
+#define CLC_MATH_CLC_FABS_H
 
 #define __CLC_BODY <clc/math/unary_decl.inc>
 #define __CLC_FUNCTION __clc_fabs
@@ -16,4 +16,4 @@
 
 #undef __CLC_FUNCTION
 
-#endif // __CLC_MATH_CLC_FABS_H__
+#endif // CLC_MATH_CLC_FABS_H

--- a/libclc/clc/include/clc/math/clc_fdim.h
+++ b/libclc/clc/include/clc/math/clc_fdim.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_MATH_CLC_FDIM_H__
-#define __CLC_MATH_CLC_FDIM_H__
+#ifndef CLC_MATH_CLC_FDIM_H
+#define CLC_MATH_CLC_FDIM_H
 
 #define __CLC_BODY <clc/shared/binary_decl.inc>
 #define __CLC_FUNCTION __clc_fdim
@@ -16,4 +16,4 @@
 
 #undef __CLC_FUNCTION
 
-#endif // __CLC_MATH_CLC_FDIM_H__
+#endif // CLC_MATH_CLC_FDIM_H

--- a/libclc/clc/include/clc/math/clc_floor.h
+++ b/libclc/clc/include/clc/math/clc_floor.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_MATH_CLC_FLOOR_H__
-#define __CLC_MATH_CLC_FLOOR_H__
+#ifndef CLC_MATH_CLC_FLOOR_H
+#define CLC_MATH_CLC_FLOOR_H
 
 #define __CLC_BODY <clc/math/unary_decl.inc>
 #define __CLC_FUNCTION __clc_floor
@@ -16,4 +16,4 @@
 
 #undef __CLC_FUNCTION
 
-#endif // __CLC_MATH_CLC_FLOOR_H__
+#endif // CLC_MATH_CLC_FLOOR_H

--- a/libclc/clc/include/clc/math/clc_fma.h
+++ b/libclc/clc/include/clc/math/clc_fma.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_MATH_CLC_FMA_H__
-#define __CLC_MATH_CLC_FMA_H__
+#ifndef CLC_MATH_CLC_FMA_H
+#define CLC_MATH_CLC_FMA_H
 
 #define __CLC_FUNCTION __clc_fma
 #define __CLC_BODY <clc/shared/ternary_decl.inc>
@@ -16,4 +16,4 @@
 
 #undef __CLC_FUNCTION
 
-#endif // __CLC_MATH_CLC_FMA_H__
+#endif // CLC_MATH_CLC_FMA_H

--- a/libclc/clc/include/clc/math/clc_fmax.h
+++ b/libclc/clc/include/clc/math/clc_fmax.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_MATH_CLC_FMAX_H__
-#define __CLC_MATH_CLC_FMAX_H__
+#ifndef CLC_MATH_CLC_FMAX_H
+#define CLC_MATH_CLC_FMAX_H
 
 #define __CLC_FUNCTION __clc_fmax
 #define __CLC_BODY <clc/shared/binary_decl.inc>
@@ -16,4 +16,4 @@
 
 #undef __CLC_FUNCTION
 
-#endif // __CLC_MATH_CLC_FMAX_H__
+#endif // CLC_MATH_CLC_FMAX_H

--- a/libclc/clc/include/clc/math/clc_fmin.h
+++ b/libclc/clc/include/clc/math/clc_fmin.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_MATH_CLC_FMIN_H__
-#define __CLC_MATH_CLC_FMIN_H__
+#ifndef CLC_MATH_CLC_FMIN_H
+#define CLC_MATH_CLC_FMIN_H
 
 #define __CLC_FUNCTION __clc_fmin
 #define __CLC_BODY <clc/shared/binary_decl.inc>
@@ -16,4 +16,4 @@
 
 #undef __CLC_FUNCTION
 
-#endif // __CLC_MATH_CLC_FMIN_H__
+#endif // CLC_MATH_CLC_FMIN_H

--- a/libclc/clc/include/clc/math/clc_fmod.h
+++ b/libclc/clc/include/clc/math/clc_fmod.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_MATH_CLC_FMOD_H__
-#define __CLC_MATH_CLC_FMOD_H__
+#ifndef CLC_MATH_CLC_FMOD_H
+#define CLC_MATH_CLC_FMOD_H
 
 #define __CLC_FUNCTION __clc_fmod
 #define __CLC_BODY <clc/shared/binary_decl.inc>
@@ -16,4 +16,4 @@
 
 #undef __CLC_FUNCTION
 
-#endif // __CLC_MATH_CLC_FMOD_H__
+#endif // CLC_MATH_CLC_FMOD_H

--- a/libclc/clc/include/clc/math/clc_fract.h
+++ b/libclc/clc/include/clc/math/clc_fract.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_MATH_CLC_FRACT_H__
-#define __CLC_MATH_CLC_FRACT_H__
+#ifndef CLC_MATH_CLC_FRACT_H
+#define CLC_MATH_CLC_FRACT_H
 
 #define __CLC_FUNCTION __clc_fract
 #define __CLC_BODY <clc/math/unary_decl_with_ptr.inc>
@@ -16,4 +16,4 @@
 
 #undef __CLC_FUNCTION
 
-#endif // __CLC_MATH_CLC_FRACT_H__
+#endif // CLC_MATH_CLC_FRACT_H

--- a/libclc/clc/include/clc/math/clc_frexp.h
+++ b/libclc/clc/include/clc/math/clc_frexp.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_MATH_CLC_FREXP_H__
-#define __CLC_MATH_CLC_FREXP_H__
+#ifndef CLC_MATH_CLC_FREXP_H
+#define CLC_MATH_CLC_FREXP_H
 
 #define __CLC_FUNCTION __clc_frexp
 #define __CLC_BODY <clc/math/unary_decl_with_int_ptr.inc>
@@ -15,4 +15,4 @@
 
 #undef __CLC_FUNCTION
 
-#endif // __CLC_MATH_CLC_FREXP_H__
+#endif // CLC_MATH_CLC_FREXP_H

--- a/libclc/clc/include/clc/math/clc_half_cos.h
+++ b/libclc/clc/include/clc/math/clc_half_cos.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_MATH_CLC_HALF_COS_H__
-#define __CLC_MATH_CLC_HALF_COS_H__
+#ifndef CLC_MATH_CLC_HALF_COS_H
+#define CLC_MATH_CLC_HALF_COS_H
 
 #define __CLC_FLOAT_ONLY
 #define __CLC_FUNCTION __clc_half_cos
@@ -17,4 +17,4 @@
 
 #undef __CLC_FUNCTION
 
-#endif // __CLC_MATH_CLC_HALF_COS_H__
+#endif // CLC_MATH_CLC_HALF_COS_H

--- a/libclc/clc/include/clc/math/clc_half_divide.h
+++ b/libclc/clc/include/clc/math/clc_half_divide.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_MATH_CLC_HALF_DIVIDE_H__
-#define __CLC_MATH_CLC_HALF_DIVIDE_H__
+#ifndef CLC_MATH_CLC_HALF_DIVIDE_H
+#define CLC_MATH_CLC_HALF_DIVIDE_H
 
 #define __CLC_FLOAT_ONLY
 #define __CLC_FUNCTION __clc_half_divide
@@ -17,4 +17,4 @@
 
 #undef __CLC_FUNCTION
 
-#endif // __CLC_MATH_CLC_HALF_DIVIDE_H__
+#endif // CLC_MATH_CLC_HALF_DIVIDE_H

--- a/libclc/clc/include/clc/math/clc_half_exp.h
+++ b/libclc/clc/include/clc/math/clc_half_exp.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_MATH_CLC_HALF_EXP_H__
-#define __CLC_MATH_CLC_HALF_EXP_H__
+#ifndef CLC_MATH_CLC_HALF_EXP_H
+#define CLC_MATH_CLC_HALF_EXP_H
 
 #define __CLC_FLOAT_ONLY
 #define __CLC_FUNCTION __clc_half_exp
@@ -17,4 +17,4 @@
 
 #undef __CLC_FUNCTION
 
-#endif // __CLC_MATH_CLC_HALF_EXP_H__
+#endif // CLC_MATH_CLC_HALF_EXP_H

--- a/libclc/clc/include/clc/math/clc_half_exp10.h
+++ b/libclc/clc/include/clc/math/clc_half_exp10.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_MATH_CLC_HALF_EXP10_H__
-#define __CLC_MATH_CLC_HALF_EXP10_H__
+#ifndef CLC_MATH_CLC_HALF_EXP10_H
+#define CLC_MATH_CLC_HALF_EXP10_H
 
 #define __CLC_FLOAT_ONLY
 #define __CLC_FUNCTION __clc_half_exp10
@@ -17,4 +17,4 @@
 
 #undef __CLC_FUNCTION
 
-#endif // __CLC_MATH_CLC_HALF_EXP10_H__
+#endif // CLC_MATH_CLC_HALF_EXP10_H

--- a/libclc/clc/include/clc/math/clc_half_exp2.h
+++ b/libclc/clc/include/clc/math/clc_half_exp2.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_MATH_CLC_HALF_EXP2_H__
-#define __CLC_MATH_CLC_HALF_EXP2_H__
+#ifndef CLC_MATH_CLC_HALF_EXP2_H
+#define CLC_MATH_CLC_HALF_EXP2_H
 
 #define __CLC_FLOAT_ONLY
 #define __CLC_FUNCTION __clc_half_exp2
@@ -17,4 +17,4 @@
 
 #undef __CLC_FUNCTION
 
-#endif // __CLC_MATH_CLC_HALF_EXP2_H__
+#endif // CLC_MATH_CLC_HALF_EXP2_H

--- a/libclc/clc/include/clc/math/clc_half_log.h
+++ b/libclc/clc/include/clc/math/clc_half_log.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_MATH_CLC_HALF_LOG_H__
-#define __CLC_MATH_CLC_HALF_LOG_H__
+#ifndef CLC_MATH_CLC_HALF_LOG_H
+#define CLC_MATH_CLC_HALF_LOG_H
 
 #define __CLC_FLOAT_ONLY
 #define __CLC_FUNCTION __clc_half_log
@@ -17,4 +17,4 @@
 
 #undef __CLC_FUNCTION
 
-#endif // __CLC_MATH_CLC_HALF_LOG_H__
+#endif // CLC_MATH_CLC_HALF_LOG_H

--- a/libclc/clc/include/clc/math/clc_half_log10.h
+++ b/libclc/clc/include/clc/math/clc_half_log10.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_MATH_CLC_HALF_LOG10_H__
-#define __CLC_MATH_CLC_HALF_LOG10_H__
+#ifndef CLC_MATH_CLC_HALF_LOG10_H
+#define CLC_MATH_CLC_HALF_LOG10_H
 
 #define __CLC_FLOAT_ONLY
 #define __CLC_FUNCTION __clc_half_log10
@@ -17,4 +17,4 @@
 
 #undef __CLC_FUNCTION
 
-#endif // __CLC_MATH_CLC_HALF_LOG10_H__
+#endif // CLC_MATH_CLC_HALF_LOG10_H

--- a/libclc/clc/include/clc/math/clc_half_log2.h
+++ b/libclc/clc/include/clc/math/clc_half_log2.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_MATH_CLC_HALF_LOG2_H__
-#define __CLC_MATH_CLC_HALF_LOG2_H__
+#ifndef CLC_MATH_CLC_HALF_LOG2_H
+#define CLC_MATH_CLC_HALF_LOG2_H
 
 #define __CLC_FLOAT_ONLY
 #define __CLC_FUNCTION __clc_half_log2
@@ -17,4 +17,4 @@
 
 #undef __CLC_FUNCTION
 
-#endif // __CLC_MATH_CLC_HALF_LOG2_H__
+#endif // CLC_MATH_CLC_HALF_LOG2_H

--- a/libclc/clc/include/clc/math/clc_half_powr.h
+++ b/libclc/clc/include/clc/math/clc_half_powr.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_MATH_CLC_HALF_POWR_H__
-#define __CLC_MATH_CLC_HALF_POWR_H__
+#ifndef CLC_MATH_CLC_HALF_POWR_H
+#define CLC_MATH_CLC_HALF_POWR_H
 
 #define __CLC_FLOAT_ONLY
 #define __CLC_FUNCTION __clc_half_powr
@@ -17,4 +17,4 @@
 
 #undef __CLC_FUNCTION
 
-#endif // __CLC_MATH_CLC_HALF_POWR_H__
+#endif // CLC_MATH_CLC_HALF_POWR_H

--- a/libclc/clc/include/clc/math/clc_half_recip.h
+++ b/libclc/clc/include/clc/math/clc_half_recip.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_MATH_CLC_HALF_RECIP_H__
-#define __CLC_MATH_CLC_HALF_RECIP_H__
+#ifndef CLC_MATH_CLC_HALF_RECIP_H
+#define CLC_MATH_CLC_HALF_RECIP_H
 
 #define __CLC_FLOAT_ONLY
 #define __CLC_FUNCTION __clc_half_recip
@@ -17,4 +17,4 @@
 
 #undef __CLC_FUNCTION
 
-#endif // __CLC_MATH_CLC_HALF_RECIP_H__
+#endif // CLC_MATH_CLC_HALF_RECIP_H

--- a/libclc/clc/include/clc/math/clc_half_rsqrt.h
+++ b/libclc/clc/include/clc/math/clc_half_rsqrt.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_MATH_CLC_HALF_RSQRT_H__
-#define __CLC_MATH_CLC_HALF_RSQRT_H__
+#ifndef CLC_MATH_CLC_HALF_RSQRT_H
+#define CLC_MATH_CLC_HALF_RSQRT_H
 
 #define __CLC_FLOAT_ONLY
 #define __CLC_FUNCTION __clc_half_rsqrt
@@ -17,4 +17,4 @@
 
 #undef __CLC_FUNCTION
 
-#endif // __CLC_MATH_CLC_HALF_RSQRT_H__
+#endif // CLC_MATH_CLC_HALF_RSQRT_H

--- a/libclc/clc/include/clc/math/clc_half_sin.h
+++ b/libclc/clc/include/clc/math/clc_half_sin.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_MATH_CLC_HALF_SIN_H__
-#define __CLC_MATH_CLC_HALF_SIN_H__
+#ifndef CLC_MATH_CLC_HALF_SIN_H
+#define CLC_MATH_CLC_HALF_SIN_H
 
 #define __CLC_FLOAT_ONLY
 #define __CLC_FUNCTION __clc_half_sin
@@ -17,4 +17,4 @@
 
 #undef __CLC_FUNCTION
 
-#endif // __CLC_MATH_CLC_HALF_SIN_H__
+#endif // CLC_MATH_CLC_HALF_SIN_H

--- a/libclc/clc/include/clc/math/clc_half_sqrt.h
+++ b/libclc/clc/include/clc/math/clc_half_sqrt.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_MATH_CLC_HALF_SQRT_H__
-#define __CLC_MATH_CLC_HALF_SQRT_H__
+#ifndef CLC_MATH_CLC_HALF_SQRT_H
+#define CLC_MATH_CLC_HALF_SQRT_H
 
 #define __CLC_FLOAT_ONLY
 #define __CLC_FUNCTION __clc_half_sqrt
@@ -17,4 +17,4 @@
 
 #undef __CLC_FUNCTION
 
-#endif // __CLC_MATH_CLC_HALF_SQRT_H__
+#endif // CLC_MATH_CLC_HALF_SQRT_H

--- a/libclc/clc/include/clc/math/clc_half_tan.h
+++ b/libclc/clc/include/clc/math/clc_half_tan.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_MATH_CLC_HALF_TAN_H__
-#define __CLC_MATH_CLC_HALF_TAN_H__
+#ifndef CLC_MATH_CLC_HALF_TAN_H
+#define CLC_MATH_CLC_HALF_TAN_H
 
 #define __CLC_FLOAT_ONLY
 #define __CLC_FUNCTION __clc_half_tan
@@ -17,4 +17,4 @@
 
 #undef __CLC_FUNCTION
 
-#endif // __CLC_MATH_CLC_HALF_TAN_H__
+#endif // CLC_MATH_CLC_HALF_TAN_H

--- a/libclc/clc/include/clc/math/clc_hypot.h
+++ b/libclc/clc/include/clc/math/clc_hypot.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_MATH_CLC_HYPOT_H__
-#define __CLC_MATH_CLC_HYPOT_H__
+#ifndef CLC_MATH_CLC_HYPOT_H
+#define CLC_MATH_CLC_HYPOT_H
 
 #define __CLC_BODY <clc/shared/binary_decl.inc>
 #define __CLC_FUNCTION __clc_hypot
@@ -16,4 +16,4 @@
 
 #undef __CLC_FUNCTION
 
-#endif // __CLC_MATH_CLC_HYPOT_H__
+#endif // CLC_MATH_CLC_HYPOT_H

--- a/libclc/clc/include/clc/math/clc_ilogb.h
+++ b/libclc/clc/include/clc/math/clc_ilogb.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_MATH_CLC_ILOGB_H__
-#define __CLC_MATH_CLC_ILOGB_H__
+#ifndef CLC_MATH_CLC_ILOGB_H
+#define CLC_MATH_CLC_ILOGB_H
 
 #define __CLC_FUNCTION __clc_ilogb
 #define __CLC_BODY <clc/math/unary_decl_with_int_return.inc>
@@ -15,4 +15,4 @@
 
 #undef __CLC_FUNCTION
 
-#endif // __CLC_MATH_CLC_ILOGB_H__
+#endif // CLC_MATH_CLC_ILOGB_H

--- a/libclc/clc/include/clc/math/clc_ldexp.h
+++ b/libclc/clc/include/clc/math/clc_ldexp.h
@@ -6,10 +6,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_MATH_CLC_LDEXP_H__
-#define __CLC_MATH_CLC_LDEXP_H__
+#ifndef CLC_MATH_CLC_LDEXP_H
+#define CLC_MATH_CLC_LDEXP_H
 
 #define __CLC_BODY <clc/math/clc_ldexp.inc>
 #include <clc/math/gentype.inc>
 
-#endif // __CLC_MATH_CLC_LDEXP_H__
+#endif // CLC_MATH_CLC_LDEXP_H

--- a/libclc/clc/include/clc/math/clc_lgamma.h
+++ b/libclc/clc/include/clc/math/clc_lgamma.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_MATH_CLC_LGAMMA_H__
-#define __CLC_MATH_CLC_LGAMMA_H__
+#ifndef CLC_MATH_CLC_LGAMMA_H
+#define CLC_MATH_CLC_LGAMMA_H
 
 #define __CLC_BODY <clc/math/unary_decl.inc>
 #define __CLC_FUNCTION __clc_lgamma
@@ -16,4 +16,4 @@
 
 #undef __CLC_FUNCTION
 
-#endif // __CLC_MATH_CLC_LGAMMA_H__
+#endif // CLC_MATH_CLC_LGAMMA_H

--- a/libclc/clc/include/clc/math/clc_lgamma_r.h
+++ b/libclc/clc/include/clc/math/clc_lgamma_r.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_MATH_CLC_LGAMMA_R_H__
-#define __CLC_MATH_CLC_LGAMMA_R_H__
+#ifndef CLC_MATH_CLC_LGAMMA_R_H
+#define CLC_MATH_CLC_LGAMMA_R_H
 
 #define __CLC_FUNCTION __clc_lgamma_r
 #define __CLC_BODY <clc/math/unary_decl_with_int_ptr.inc>
@@ -16,4 +16,4 @@
 
 #undef __CLC_FUNCTION
 
-#endif // __CLC_MATH_CLC_LGAMMA_R_H__
+#endif // CLC_MATH_CLC_LGAMMA_R_H

--- a/libclc/clc/include/clc/math/clc_log.h
+++ b/libclc/clc/include/clc/math/clc_log.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_MATH_CLC_LOG_H__
-#define __CLC_MATH_CLC_LOG_H__
+#ifndef CLC_MATH_CLC_LOG_H
+#define CLC_MATH_CLC_LOG_H
 
 #define __CLC_FUNCTION __clc_log
 #define __CLC_BODY <clc/shared/unary_decl.inc>
@@ -16,4 +16,4 @@
 
 #undef __CLC_FUNCTION
 
-#endif // __CLC_MATH_CLC_LOG_H__
+#endif // CLC_MATH_CLC_LOG_H

--- a/libclc/clc/include/clc/math/clc_log10.h
+++ b/libclc/clc/include/clc/math/clc_log10.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_MATH_CLC_LOG10_H__
-#define __CLC_MATH_CLC_LOG10_H__
+#ifndef CLC_MATH_CLC_LOG10_H
+#define CLC_MATH_CLC_LOG10_H
 
 #define __CLC_FUNCTION __clc_log10
 #define __CLC_BODY <clc/shared/unary_decl.inc>
@@ -16,4 +16,4 @@
 
 #undef __CLC_FUNCTION
 
-#endif // __CLC_MATH_CLC_LOG10_H__
+#endif // CLC_MATH_CLC_LOG10_H

--- a/libclc/clc/include/clc/math/clc_log1p.h
+++ b/libclc/clc/include/clc/math/clc_log1p.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_MATH_CLC_LOG1P_H__
-#define __CLC_MATH_CLC_LOG1P_H__
+#ifndef CLC_MATH_CLC_LOG1P_H
+#define CLC_MATH_CLC_LOG1P_H
 
 #define __CLC_BODY <clc/math/unary_decl.inc>
 #define __CLC_FUNCTION __clc_log1p
@@ -16,4 +16,4 @@
 
 #undef __CLC_FUNCTION
 
-#endif // __CLC_MATH_CLC_LOG1P_H__
+#endif // CLC_MATH_CLC_LOG1P_H

--- a/libclc/clc/include/clc/math/clc_log2.h
+++ b/libclc/clc/include/clc/math/clc_log2.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_MATH_CLC_LOG2_H__
-#define __CLC_MATH_CLC_LOG2_H__
+#ifndef CLC_MATH_CLC_LOG2_H
+#define CLC_MATH_CLC_LOG2_H
 
 #define __CLC_FUNCTION __clc_log2
 #define __CLC_BODY <clc/shared/unary_decl.inc>
@@ -16,4 +16,4 @@
 
 #undef __CLC_FUNCTION
 
-#endif // __CLC_MATH_CLC_LOG2_H__
+#endif // CLC_MATH_CLC_LOG2_H

--- a/libclc/clc/include/clc/math/clc_logb.h
+++ b/libclc/clc/include/clc/math/clc_logb.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_MATH_CLC_LOGB_H__
-#define __CLC_MATH_CLC_LOGB_H__
+#ifndef CLC_MATH_CLC_LOGB_H
+#define CLC_MATH_CLC_LOGB_H
 
 #define __CLC_FUNCTION __clc_logb
 #define __CLC_BODY <clc/shared/unary_decl.inc>
@@ -15,4 +15,4 @@
 
 #undef __CLC_FUNCTION
 
-#endif // __CLC_MATH_CLC_LOGB_H__
+#endif // CLC_MATH_CLC_LOGB_H

--- a/libclc/clc/include/clc/math/clc_mad.h
+++ b/libclc/clc/include/clc/math/clc_mad.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_MATH_CLC_MAD_H__
-#define __CLC_MATH_CLC_MAD_H__
+#ifndef CLC_MATH_CLC_MAD_H
+#define CLC_MATH_CLC_MAD_H
 
 #define __CLC_BODY <clc/shared/ternary_decl.inc>
 #define __CLC_FUNCTION __clc_mad
@@ -16,4 +16,4 @@
 
 #undef __CLC_FUNCTION
 
-#endif // __CLC_MATH_CLC_MAD_H__
+#endif // CLC_MATH_CLC_MAD_H

--- a/libclc/clc/include/clc/math/clc_maxmag.h
+++ b/libclc/clc/include/clc/math/clc_maxmag.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_MATH_CLC_MAXMAG_H__
-#define __CLC_MATH_CLC_MAXMAG_H__
+#ifndef CLC_MATH_CLC_MAXMAG_H
+#define CLC_MATH_CLC_MAXMAG_H
 
 #define __CLC_BODY <clc/shared/binary_decl.inc>
 #define __CLC_FUNCTION __clc_maxmag
@@ -16,4 +16,4 @@
 
 #undef __CLC_FUNCTION
 
-#endif // __CLC_MATH_CLC_MAXMAG_H__
+#endif // CLC_MATH_CLC_MAXMAG_H

--- a/libclc/clc/include/clc/math/clc_minmag.h
+++ b/libclc/clc/include/clc/math/clc_minmag.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_MATH_CLC_MINMAG_H__
-#define __CLC_MATH_CLC_MINMAG_H__
+#ifndef CLC_MATH_CLC_MINMAG_H
+#define CLC_MATH_CLC_MINMAG_H
 
 #define __CLC_BODY <clc/shared/binary_decl.inc>
 #define __CLC_FUNCTION __clc_minmag
@@ -16,4 +16,4 @@
 
 #undef __CLC_FUNCTION
 
-#endif // __CLC_MATH_CLC_MINMAG_H__
+#endif // CLC_MATH_CLC_MINMAG_H

--- a/libclc/clc/include/clc/math/clc_modf.h
+++ b/libclc/clc/include/clc/math/clc_modf.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_MATH_CLC_MODF_H__
-#define __CLC_MATH_CLC_MODF_H__
+#ifndef CLC_MATH_CLC_MODF_H
+#define CLC_MATH_CLC_MODF_H
 
 #define __CLC_FUNCTION __clc_modf
 #define __CLC_BODY <clc/math/unary_decl_with_ptr.inc>
@@ -15,4 +15,4 @@
 
 #undef __CLC_FUNCTION
 
-#endif // __CLC_MATH_CLC_MODF_H__
+#endif // CLC_MATH_CLC_MODF_H

--- a/libclc/clc/include/clc/math/clc_nan.h
+++ b/libclc/clc/include/clc/math/clc_nan.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_MATH_CLC_NAN_H__
-#define __CLC_MATH_CLC_NAN_H__
+#ifndef CLC_MATH_CLC_NAN_H
+#define CLC_MATH_CLC_NAN_H
 
 #define __CLC_FUNCTION __clc_nan
 #define __CLC_BODY <clc/math/clc_nan.inc>
@@ -16,4 +16,4 @@
 
 #undef __CLC_FUNCTION
 
-#endif // __CLC_MATH_CLC_NAN_H__
+#endif // CLC_MATH_CLC_NAN_H

--- a/libclc/clc/include/clc/math/clc_native_cos.h
+++ b/libclc/clc/include/clc/math/clc_native_cos.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_MATH_CLC_NATIVE_COS_H__
-#define __CLC_MATH_CLC_NATIVE_COS_H__
+#ifndef CLC_MATH_CLC_NATIVE_COS_H
+#define CLC_MATH_CLC_NATIVE_COS_H
 
 #define __CLC_FLOAT_ONLY
 #define __CLC_FUNCTION __clc_native_cos
@@ -17,4 +17,4 @@
 
 #undef __CLC_FUNCTION
 
-#endif // __CLC_MATH_CLC_NATIVE_COS_H__
+#endif // CLC_MATH_CLC_NATIVE_COS_H

--- a/libclc/clc/include/clc/math/clc_native_divide.h
+++ b/libclc/clc/include/clc/math/clc_native_divide.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_MATH_CLC_NATIVE_DIVIDE_H__
-#define __CLC_MATH_CLC_NATIVE_DIVIDE_H__
+#ifndef CLC_MATH_CLC_NATIVE_DIVIDE_H
+#define CLC_MATH_CLC_NATIVE_DIVIDE_H
 
 #define __CLC_FLOAT_ONLY
 #define __CLC_FUNCTION __clc_native_divide
@@ -17,4 +17,4 @@
 
 #undef __CLC_FUNCTION
 
-#endif // __CLC_MATH_CLC_NATIVE_DIVIDE_H__
+#endif // CLC_MATH_CLC_NATIVE_DIVIDE_H

--- a/libclc/clc/include/clc/math/clc_native_exp.h
+++ b/libclc/clc/include/clc/math/clc_native_exp.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_MATH_CLC_NATIVE_EXP_H__
-#define __CLC_MATH_CLC_NATIVE_EXP_H__
+#ifndef CLC_MATH_CLC_NATIVE_EXP_H
+#define CLC_MATH_CLC_NATIVE_EXP_H
 
 #define __CLC_FLOAT_ONLY
 #define __CLC_FUNCTION __clc_native_exp
@@ -17,4 +17,4 @@
 
 #undef __CLC_FUNCTION
 
-#endif // __CLC_MATH_CLC_NATIVE_EXP_H__
+#endif // CLC_MATH_CLC_NATIVE_EXP_H

--- a/libclc/clc/include/clc/math/clc_native_exp10.h
+++ b/libclc/clc/include/clc/math/clc_native_exp10.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_MATH_CLC_NATIVE_EXP10_H__
-#define __CLC_MATH_CLC_NATIVE_EXP10_H__
+#ifndef CLC_MATH_CLC_NATIVE_EXP10_H
+#define CLC_MATH_CLC_NATIVE_EXP10_H
 
 #define __CLC_FLOAT_ONLY
 #define __CLC_FUNCTION __clc_native_exp10
@@ -17,4 +17,4 @@
 
 #undef __CLC_FUNCTION
 
-#endif // __CLC_MATH_CLC_NATIVE_EXP10_H__
+#endif // CLC_MATH_CLC_NATIVE_EXP10_H

--- a/libclc/clc/include/clc/math/clc_native_exp2.h
+++ b/libclc/clc/include/clc/math/clc_native_exp2.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_MATH_CLC_NATIVE_EXP2_H__
-#define __CLC_MATH_CLC_NATIVE_EXP2_H__
+#ifndef CLC_MATH_CLC_NATIVE_EXP2_H
+#define CLC_MATH_CLC_NATIVE_EXP2_H
 
 #define __CLC_FLOAT_ONLY
 #define __CLC_FUNCTION __clc_native_exp2
@@ -17,4 +17,4 @@
 
 #undef __CLC_FUNCTION
 
-#endif // __CLC_MATH_CLC_NATIVE_EXP2_H__
+#endif // CLC_MATH_CLC_NATIVE_EXP2_H

--- a/libclc/clc/include/clc/math/clc_native_log.h
+++ b/libclc/clc/include/clc/math/clc_native_log.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_MATH_CLC_NATIVE_LOG_H__
-#define __CLC_MATH_CLC_NATIVE_LOG_H__
+#ifndef CLC_MATH_CLC_NATIVE_LOG_H
+#define CLC_MATH_CLC_NATIVE_LOG_H
 
 #define __CLC_FLOAT_ONLY
 #define __CLC_FUNCTION __clc_native_log
@@ -17,4 +17,4 @@
 
 #undef __CLC_FUNCTION
 
-#endif // __CLC_MATH_CLC_NATIVE_LOG_H__
+#endif // CLC_MATH_CLC_NATIVE_LOG_H

--- a/libclc/clc/include/clc/math/clc_native_log10.h
+++ b/libclc/clc/include/clc/math/clc_native_log10.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_MATH_CLC_NATIVE_LOG10_H__
-#define __CLC_MATH_CLC_NATIVE_LOG10_H__
+#ifndef CLC_MATH_CLC_NATIVE_LOG10_H
+#define CLC_MATH_CLC_NATIVE_LOG10_H
 
 #define __CLC_FLOAT_ONLY
 #define __CLC_FUNCTION __clc_native_log10
@@ -17,4 +17,4 @@
 
 #undef __CLC_FUNCTION
 
-#endif // __CLC_MATH_CLC_NATIVE_LOG10_H__
+#endif // CLC_MATH_CLC_NATIVE_LOG10_H

--- a/libclc/clc/include/clc/math/clc_native_log2.h
+++ b/libclc/clc/include/clc/math/clc_native_log2.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_MATH_CLC_NATIVE_LOG2_H__
-#define __CLC_MATH_CLC_NATIVE_LOG2_H__
+#ifndef CLC_MATH_CLC_NATIVE_LOG2_H
+#define CLC_MATH_CLC_NATIVE_LOG2_H
 
 #define __CLC_FLOAT_ONLY
 #define __CLC_FUNCTION __clc_native_log2
@@ -17,4 +17,4 @@
 
 #undef __CLC_FUNCTION
 
-#endif // __CLC_MATH_CLC_NATIVE_LOG2_H__
+#endif // CLC_MATH_CLC_NATIVE_LOG2_H

--- a/libclc/clc/include/clc/math/clc_native_powr.h
+++ b/libclc/clc/include/clc/math/clc_native_powr.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_MATH_CLC_NATIVE_POWR_H__
-#define __CLC_MATH_CLC_NATIVE_POWR_H__
+#ifndef CLC_MATH_CLC_NATIVE_POWR_H
+#define CLC_MATH_CLC_NATIVE_POWR_H
 
 #define __CLC_FLOAT_ONLY
 #define __CLC_FUNCTION __clc_native_powr
@@ -17,4 +17,4 @@
 
 #undef __CLC_FUNCTION
 
-#endif // __CLC_MATH_CLC_NATIVE_POWR_H__
+#endif // CLC_MATH_CLC_NATIVE_POWR_H

--- a/libclc/clc/include/clc/math/clc_native_recip.h
+++ b/libclc/clc/include/clc/math/clc_native_recip.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_MATH_CLC_NATIVE_RECIP_H__
-#define __CLC_MATH_CLC_NATIVE_RECIP_H__
+#ifndef CLC_MATH_CLC_NATIVE_RECIP_H
+#define CLC_MATH_CLC_NATIVE_RECIP_H
 
 #define __CLC_FLOAT_ONLY
 #define __CLC_FUNCTION __clc_native_recip
@@ -17,4 +17,4 @@
 
 #undef __CLC_FUNCTION
 
-#endif // __CLC_MATH_CLC_NATIVE_RECIP_H__
+#endif // CLC_MATH_CLC_NATIVE_RECIP_H

--- a/libclc/clc/include/clc/math/clc_native_rsqrt.h
+++ b/libclc/clc/include/clc/math/clc_native_rsqrt.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_MATH_CLC_NATIVE_RSQRT_H__
-#define __CLC_MATH_CLC_NATIVE_RSQRT_H__
+#ifndef CLC_MATH_CLC_NATIVE_RSQRT_H
+#define CLC_MATH_CLC_NATIVE_RSQRT_H
 
 #define __CLC_FLOAT_ONLY
 #define __CLC_FUNCTION __clc_native_rsqrt
@@ -17,4 +17,4 @@
 
 #undef __CLC_FUNCTION
 
-#endif // __CLC_MATH_CLC_NATIVE_RSQRT_H__
+#endif // CLC_MATH_CLC_NATIVE_RSQRT_H

--- a/libclc/clc/include/clc/math/clc_native_sin.h
+++ b/libclc/clc/include/clc/math/clc_native_sin.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_MATH_CLC_NATIVE_SIN_H__
-#define __CLC_MATH_CLC_NATIVE_SIN_H__
+#ifndef CLC_MATH_CLC_NATIVE_SIN_H
+#define CLC_MATH_CLC_NATIVE_SIN_H
 
 #define __CLC_FLOAT_ONLY
 #define __CLC_FUNCTION __clc_native_sin
@@ -17,4 +17,4 @@
 
 #undef __CLC_FUNCTION
 
-#endif // __CLC_MATH_CLC_NATIVE_SIN_H__
+#endif // CLC_MATH_CLC_NATIVE_SIN_H

--- a/libclc/clc/include/clc/math/clc_native_sqrt.h
+++ b/libclc/clc/include/clc/math/clc_native_sqrt.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_MATH_CLC_NATIVE_SQRT_H__
-#define __CLC_MATH_CLC_NATIVE_SQRT_H__
+#ifndef CLC_MATH_CLC_NATIVE_SQRT_H
+#define CLC_MATH_CLC_NATIVE_SQRT_H
 
 #define __CLC_FLOAT_ONLY
 #define __CLC_FUNCTION __clc_native_sqrt
@@ -17,4 +17,4 @@
 
 #undef __CLC_FUNCTION
 
-#endif // __CLC_MATH_CLC_NATIVE_SQRT_H__
+#endif // CLC_MATH_CLC_NATIVE_SQRT_H

--- a/libclc/clc/include/clc/math/clc_native_tan.h
+++ b/libclc/clc/include/clc/math/clc_native_tan.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_MATH_CLC_NATIVE_TAN_H__
-#define __CLC_MATH_CLC_NATIVE_TAN_H__
+#ifndef CLC_MATH_CLC_NATIVE_TAN_H
+#define CLC_MATH_CLC_NATIVE_TAN_H
 
 #define __CLC_FLOAT_ONLY
 #define __CLC_FUNCTION __clc_native_tan
@@ -17,4 +17,4 @@
 
 #undef __CLC_FUNCTION
 
-#endif // __CLC_MATH_CLC_NATIVE_TAN_H__
+#endif // CLC_MATH_CLC_NATIVE_TAN_H

--- a/libclc/clc/include/clc/math/clc_nextafter.h
+++ b/libclc/clc/include/clc/math/clc_nextafter.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_MATH_CLC_NEXTAFTER_H__
-#define __CLC_MATH_CLC_NEXTAFTER_H__
+#ifndef CLC_MATH_CLC_NEXTAFTER_H
+#define CLC_MATH_CLC_NEXTAFTER_H
 
 #define __CLC_BODY <clc/shared/binary_decl.inc>
 #define __CLC_FUNCTION __clc_nextafter
@@ -16,4 +16,4 @@
 
 #undef __CLC_FUNCTION
 
-#endif // __CLC_MATH_CLC_NEXTAFTER_H__
+#endif // CLC_MATH_CLC_NEXTAFTER_H

--- a/libclc/clc/include/clc/math/clc_pow.h
+++ b/libclc/clc/include/clc/math/clc_pow.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_MATH_CLC_POW_H__
-#define __CLC_MATH_CLC_POW_H__
+#ifndef CLC_MATH_CLC_POW_H
+#define CLC_MATH_CLC_POW_H
 
 #define __CLC_BODY <clc/shared/binary_decl.inc>
 #define __CLC_FUNCTION __clc_pow
@@ -16,4 +16,4 @@
 
 #undef __CLC_FUNCTION
 
-#endif // __CLC_MATH_CLC_POW_H__
+#endif // CLC_MATH_CLC_POW_H

--- a/libclc/clc/include/clc/math/clc_pown.h
+++ b/libclc/clc/include/clc/math/clc_pown.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_MATH_CLC_POWN_H__
-#define __CLC_MATH_CLC_POWN_H__
+#ifndef CLC_MATH_CLC_POWN_H
+#define CLC_MATH_CLC_POWN_H
 
 #define __CLC_BODY <clc/shared/binary_decl_with_int_second_arg.inc>
 #define __CLC_FUNCTION __clc_pown
@@ -16,4 +16,4 @@
 
 #undef __CLC_FUNCTION
 
-#endif // __CLC_MATH_CLC_POWN_H__
+#endif // CLC_MATH_CLC_POWN_H

--- a/libclc/clc/include/clc/math/clc_powr.h
+++ b/libclc/clc/include/clc/math/clc_powr.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_MATH_CLC_POWR_H__
-#define __CLC_MATH_CLC_POWR_H__
+#ifndef CLC_MATH_CLC_POWR_H
+#define CLC_MATH_CLC_POWR_H
 
 #define __CLC_BODY <clc/shared/binary_decl.inc>
 #define __CLC_FUNCTION __clc_powr
@@ -16,4 +16,4 @@
 
 #undef __CLC_FUNCTION
 
-#endif // __CLC_MATH_CLC_POWR_H__
+#endif // CLC_MATH_CLC_POWR_H

--- a/libclc/clc/include/clc/math/clc_remainder.h
+++ b/libclc/clc/include/clc/math/clc_remainder.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_MATH_CLC_REMAINDER_H__
-#define __CLC_MATH_CLC_REMAINDER_H__
+#ifndef CLC_MATH_CLC_REMAINDER_H
+#define CLC_MATH_CLC_REMAINDER_H
 
 #define __CLC_FUNCTION __clc_remainder
 #define __CLC_BODY <clc/shared/binary_decl.inc>
@@ -16,4 +16,4 @@
 
 #undef __CLC_FUNCTION
 
-#endif // __CLC_MATH_CLC_REMAINDER_H__
+#endif // CLC_MATH_CLC_REMAINDER_H

--- a/libclc/clc/include/clc/math/clc_remquo.h
+++ b/libclc/clc/include/clc/math/clc_remquo.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_MATH_CLC_REMQUO_H__
-#define __CLC_MATH_CLC_REMQUO_H__
+#ifndef CLC_MATH_CLC_REMQUO_H
+#define CLC_MATH_CLC_REMQUO_H
 
 #define __CLC_FUNCTION __clc_remquo
 #define __CLC_BODY <clc/math/remquo_decl.inc>
@@ -16,4 +16,4 @@
 
 #undef __CLC_FUNCTION
 
-#endif // __CLC_MATH_CLC_REMQUO_H__
+#endif // CLC_MATH_CLC_REMQUO_H

--- a/libclc/clc/include/clc/math/clc_rint.h
+++ b/libclc/clc/include/clc/math/clc_rint.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_MATH_CLC_RINT_H__
-#define __CLC_MATH_CLC_RINT_H__
+#ifndef CLC_MATH_CLC_RINT_H
+#define CLC_MATH_CLC_RINT_H
 
 #define __CLC_BODY <clc/math/unary_decl.inc>
 #define __CLC_FUNCTION __clc_rint
@@ -16,4 +16,4 @@
 
 #undef __CLC_FUNCTION
 
-#endif // __CLC_MATH_CLC_RINT_H__
+#endif // CLC_MATH_CLC_RINT_H

--- a/libclc/clc/include/clc/math/clc_rootn.h
+++ b/libclc/clc/include/clc/math/clc_rootn.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_MATH_CLC_ROOTN_H__
-#define __CLC_MATH_CLC_ROOTN_H__
+#ifndef CLC_MATH_CLC_ROOTN_H
+#define CLC_MATH_CLC_ROOTN_H
 
 #define __CLC_BODY <clc/shared/binary_decl_with_int_second_arg.inc>
 #define __CLC_FUNCTION __clc_rootn
@@ -16,4 +16,4 @@
 
 #undef __CLC_FUNCTION
 
-#endif // __CLC_MATH_CLC_ROOTN_H__
+#endif // CLC_MATH_CLC_ROOTN_H

--- a/libclc/clc/include/clc/math/clc_round.h
+++ b/libclc/clc/include/clc/math/clc_round.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_MATH_CLC_ROUND_H__
-#define __CLC_MATH_CLC_ROUND_H__
+#ifndef CLC_MATH_CLC_ROUND_H
+#define CLC_MATH_CLC_ROUND_H
 
 #define __CLC_BODY <clc/math/unary_decl.inc>
 #define __CLC_FUNCTION __clc_round
@@ -16,4 +16,4 @@
 
 #undef __CLC_FUNCTION
 
-#endif // __CLC_MATH_CLC_ROUND_H__
+#endif // CLC_MATH_CLC_ROUND_H

--- a/libclc/clc/include/clc/math/clc_rsqrt.h
+++ b/libclc/clc/include/clc/math/clc_rsqrt.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_MATH_CLC_RSQRT_H__
-#define __CLC_MATH_CLC_RSQRT_H__
+#ifndef CLC_MATH_CLC_RSQRT_H
+#define CLC_MATH_CLC_RSQRT_H
 
 #define __CLC_BODY <clc/math/unary_decl.inc>
 #define __CLC_FUNCTION __clc_rsqrt
@@ -16,4 +16,4 @@
 
 #undef __CLC_FUNCTION
 
-#endif // __CLC_MATH_CLC_RSQRT_H__
+#endif // CLC_MATH_CLC_RSQRT_H

--- a/libclc/clc/include/clc/math/clc_sin.h
+++ b/libclc/clc/include/clc/math/clc_sin.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_MATH_CLC_SIN_H__
-#define __CLC_MATH_CLC_SIN_H__
+#ifndef CLC_MATH_CLC_SIN_H
+#define CLC_MATH_CLC_SIN_H
 
 #define __CLC_BODY <clc/math/unary_decl.inc>
 #define __CLC_FUNCTION __clc_sin
@@ -16,4 +16,4 @@
 
 #undef __CLC_FUNCTION
 
-#endif // __CLC_MATH_CLC_SIN_H__
+#endif // CLC_MATH_CLC_SIN_H

--- a/libclc/clc/include/clc/math/clc_sincos.h
+++ b/libclc/clc/include/clc/math/clc_sincos.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_MATH_CLC_SINCOS_H__
-#define __CLC_MATH_CLC_SINCOS_H__
+#ifndef CLC_MATH_CLC_SINCOS_H
+#define CLC_MATH_CLC_SINCOS_H
 
 #define __CLC_BODY <clc/math/unary_decl_with_ptr.inc>
 #define __CLC_FUNCTION __clc_sincos
@@ -16,4 +16,4 @@
 
 #undef __CLC_FUNCTION
 
-#endif // __CLC_MATH_CLC_SINCOS_H__
+#endif // CLC_MATH_CLC_SINCOS_H

--- a/libclc/clc/include/clc/math/clc_sincos_helpers.h
+++ b/libclc/clc/include/clc/math/clc_sincos_helpers.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_MATH_CLC_SINCOS_HELPERS_H__
-#define __CLC_MATH_CLC_SINCOS_HELPERS_H__
+#ifndef CLC_MATH_CLC_SINCOS_HELPERS_H
+#define CLC_MATH_CLC_SINCOS_HELPERS_H
 
 #define __CLC_FLOAT_ONLY
 #define __CLC_BODY <clc/math/clc_sincos_helpers.inc>
@@ -19,4 +19,4 @@
 
 #include <clc/math/gentype.inc>
 
-#endif // __CLC_MATH_CLC_SINCOS_HELPERS_H__
+#endif // CLC_MATH_CLC_SINCOS_HELPERS_H

--- a/libclc/clc/include/clc/math/clc_sinh.h
+++ b/libclc/clc/include/clc/math/clc_sinh.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_MATH_CLC_SINH_H__
-#define __CLC_MATH_CLC_SINH_H__
+#ifndef CLC_MATH_CLC_SINH_H
+#define CLC_MATH_CLC_SINH_H
 
 #define __CLC_BODY <clc/math/unary_decl.inc>
 #define __CLC_FUNCTION __clc_sinh
@@ -16,4 +16,4 @@
 
 #undef __CLC_FUNCTION
 
-#endif // __CLC_MATH_CLC_SINH_H__
+#endif // CLC_MATH_CLC_SINH_H

--- a/libclc/clc/include/clc/math/clc_sinpi.h
+++ b/libclc/clc/include/clc/math/clc_sinpi.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_MATH_CLC_SINPI_H__
-#define __CLC_MATH_CLC_SINPI_H__
+#ifndef CLC_MATH_CLC_SINPI_H
+#define CLC_MATH_CLC_SINPI_H
 
 #define __CLC_BODY <clc/math/unary_decl.inc>
 #define __CLC_FUNCTION __clc_sinpi
@@ -16,4 +16,4 @@
 
 #undef __CLC_FUNCTION
 
-#endif // __CLC_MATH_CLC_SINPI_H__
+#endif // CLC_MATH_CLC_SINPI_H

--- a/libclc/clc/include/clc/math/clc_sqrt.h
+++ b/libclc/clc/include/clc/math/clc_sqrt.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_MATH_CLC_SQRT_H__
-#define __CLC_MATH_CLC_SQRT_H__
+#ifndef CLC_MATH_CLC_SQRT_H
+#define CLC_MATH_CLC_SQRT_H
 
 #define __CLC_BODY <clc/math/unary_decl.inc>
 #define __CLC_FUNCTION __clc_sqrt
@@ -16,4 +16,4 @@
 
 #undef __CLC_FUNCTION
 
-#endif // __CLC_MATH_CLC_SQRT_H__
+#endif // CLC_MATH_CLC_SQRT_H

--- a/libclc/clc/include/clc/math/clc_subnormal_config.h
+++ b/libclc/clc/include/clc/math/clc_subnormal_config.h
@@ -5,8 +5,8 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-#ifndef __CLC_MATH_CLC_SUBNORMAL_CONFIG_H__
-#define __CLC_MATH_CLC_SUBNORMAL_CONFIG_H__
+#ifndef CLC_MATH_CLC_SUBNORMAL_CONFIG_H
+#define CLC_MATH_CLC_SUBNORMAL_CONFIG_H
 
 #include <clc/clcfunc.h>
 
@@ -15,4 +15,4 @@ _CLC_DECL bool __clc_fp16_subnormals_supported();
 _CLC_DECL bool __clc_fp32_subnormals_supported();
 _CLC_DECL bool __clc_fp64_subnormals_supported();
 
-#endif // __CLC_MATH_CLC_SUBNORMAL_CONFIG_H__
+#endif // CLC_MATH_CLC_SUBNORMAL_CONFIG_H

--- a/libclc/clc/include/clc/math/clc_tan.h
+++ b/libclc/clc/include/clc/math/clc_tan.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_MATH_CLC_TAN_H__
-#define __CLC_MATH_CLC_TAN_H__
+#ifndef CLC_MATH_CLC_TAN_H
+#define CLC_MATH_CLC_TAN_H
 
 #define __CLC_BODY <clc/math/unary_decl.inc>
 #define __CLC_FUNCTION __clc_tan
@@ -16,4 +16,4 @@
 
 #undef __CLC_FUNCTION
 
-#endif // __CLC_MATH_CLC_TAN_H__
+#endif // CLC_MATH_CLC_TAN_H

--- a/libclc/clc/include/clc/math/clc_tanh.h
+++ b/libclc/clc/include/clc/math/clc_tanh.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_MATH_CLC_TANH_H__
-#define __CLC_MATH_CLC_TANH_H__
+#ifndef CLC_MATH_CLC_TANH_H
+#define CLC_MATH_CLC_TANH_H
 
 #define __CLC_BODY <clc/math/unary_decl.inc>
 #define __CLC_FUNCTION __clc_tanh
@@ -16,4 +16,4 @@
 
 #undef __CLC_FUNCTION
 
-#endif // __CLC_MATH_CLC_TANH_H__
+#endif // CLC_MATH_CLC_TANH_H

--- a/libclc/clc/include/clc/math/clc_tanpi.h
+++ b/libclc/clc/include/clc/math/clc_tanpi.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_MATH_CLC_TANPI_H__
-#define __CLC_MATH_CLC_TANPI_H__
+#ifndef CLC_MATH_CLC_TANPI_H
+#define CLC_MATH_CLC_TANPI_H
 
 #define __CLC_BODY <clc/math/unary_decl.inc>
 #define __CLC_FUNCTION __clc_tanpi
@@ -16,4 +16,4 @@
 
 #undef __CLC_FUNCTION
 
-#endif // __CLC_MATH_CLC_TANPI_H__
+#endif // CLC_MATH_CLC_TANPI_H

--- a/libclc/clc/include/clc/math/clc_tgamma.h
+++ b/libclc/clc/include/clc/math/clc_tgamma.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_MATH_CLC_TGAMMA_H__
-#define __CLC_MATH_CLC_TGAMMA_H__
+#ifndef CLC_MATH_CLC_TGAMMA_H
+#define CLC_MATH_CLC_TGAMMA_H
 
 #define __CLC_BODY <clc/math/unary_decl.inc>
 #define __CLC_FUNCTION __clc_tgamma
@@ -16,4 +16,4 @@
 
 #undef __CLC_FUNCTION
 
-#endif // __CLC_MATH_CLC_TGAMMA_H__
+#endif // CLC_MATH_CLC_TGAMMA_H

--- a/libclc/clc/include/clc/math/clc_trunc.h
+++ b/libclc/clc/include/clc/math/clc_trunc.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_MATH_CLC_TRUNC_H__
-#define __CLC_MATH_CLC_TRUNC_H__
+#ifndef CLC_MATH_CLC_TRUNC_H
+#define CLC_MATH_CLC_TRUNC_H
 
 #define __CLC_BODY <clc/math/unary_decl.inc>
 #define __CLC_FUNCTION __clc_trunc
@@ -16,4 +16,4 @@
 
 #undef __CLC_FUNCTION
 
-#endif // __CLC_MATH_CLC_TRUNC_H__
+#endif // CLC_MATH_CLC_TRUNC_H

--- a/libclc/clc/include/clc/math/math.h
+++ b/libclc/clc/include/clc/math/math.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_MATH_MATH_H__
-#define __CLC_MATH_MATH_H__
+#ifndef CLC_MATH_MATH_H
+#define CLC_MATH_MATH_H
 
 #include <clc/clc_as_type.h>
 #include <clc/clcfunc.h>
@@ -113,4 +113,4 @@ _CLC_OVERLOAD _CLC_INLINE float __clc_flush_denormal_if_not_supported(float x) {
 
 #endif // cl_khr_fp16
 
-#endif // __CLC_MATH_MATH_H__
+#endif // CLC_MATH_MATH_H

--- a/libclc/clc/include/clc/math/tables.h
+++ b/libclc/clc/include/clc/math/tables.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_MATH_TABLES_H__
-#define __CLC_MATH_TABLES_H__
+#ifndef CLC_MATH_TABLES_H
+#define CLC_MATH_TABLES_H
 
 #define __CLC_TABLE_SPACE __constant
 
@@ -102,4 +102,4 @@ __CLC_TABLE_FUNCTION_DECL_VEC(double, log_f_inv_tbl_tail);
 
 #endif // cl_khr_fp64
 
-#endif // __CLC_MATH_TABLES_H__
+#endif // CLC_MATH_TABLES_H

--- a/libclc/clc/include/clc/mem_fence/clc_mem_fence.h
+++ b/libclc/clc/include/clc/mem_fence/clc_mem_fence.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_MEM_FENCE_CLC_MEM_FENCE_H__
-#define __CLC_MEM_FENCE_CLC_MEM_FENCE_H__
+#ifndef CLC_MEM_FENCE_CLC_MEM_FENCE_H
+#define CLC_MEM_FENCE_CLC_MEM_FENCE_H
 
 #include <clc/internal/clc.h>
 #include <clc/mem_fence/clc_mem_semantic.h>
@@ -16,4 +16,4 @@ _CLC_OVERLOAD _CLC_DECL void
 __clc_mem_fence(int memory_scope, int memory_order,
                 __CLC_MemorySemantics memory_semantics);
 
-#endif // __CLC_MEM_FENCE_CLC_MEM_FENCE_H__
+#endif // CLC_MEM_FENCE_CLC_MEM_FENCE_H

--- a/libclc/clc/include/clc/mem_fence/clc_mem_semantic.h
+++ b/libclc/clc/include/clc/mem_fence/clc_mem_semantic.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_MEM_FENCE_CLC_MEM_SEMANTIC_H__
-#define __CLC_MEM_FENCE_CLC_MEM_SEMANTIC_H__
+#ifndef CLC_MEM_FENCE_CLC_MEM_SEMANTIC_H
+#define CLC_MEM_FENCE_CLC_MEM_SEMANTIC_H
 
 // The memory or address space to which the memory ordering is applied.
 typedef enum __CLC_MemorySemantics {
@@ -18,4 +18,4 @@ typedef enum __CLC_MemorySemantics {
   __CLC_MEMORY_GENERIC = 1 << 4,
 } __CLC_MemorySemantics;
 
-#endif // __CLC_MEM_FENCE_CLC_MEM_SEMANTIC_H__
+#endif // CLC_MEM_FENCE_CLC_MEM_SEMANTIC_H

--- a/libclc/clc/include/clc/misc/clc_shuffle.h
+++ b/libclc/clc/include/clc/misc/clc_shuffle.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_MISC_CLC_SHUFFLE_H__
-#define __CLC_MISC_CLC_SHUFFLE_H__
+#ifndef CLC_MISC_CLC_SHUFFLE_H
+#define CLC_MISC_CLC_SHUFFLE_H
 
 #define __CLC_FUNCTION __clc_shuffle
 
@@ -21,4 +21,4 @@
 
 #undef __CLC_FUNCTION
 
-#endif // __CLC_MISC_CLC_SHUFFLE_H__
+#endif // CLC_MISC_CLC_SHUFFLE_H

--- a/libclc/clc/include/clc/misc/clc_shuffle2.h
+++ b/libclc/clc/include/clc/misc/clc_shuffle2.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_MISC_CLC_SHUFFLE2_H__
-#define __CLC_MISC_CLC_SHUFFLE2_H__
+#ifndef CLC_MISC_CLC_SHUFFLE2_H
+#define CLC_MISC_CLC_SHUFFLE2_H
 
 #define __CLC_FUNCTION __clc_shuffle2
 
@@ -21,4 +21,4 @@
 
 #undef __CLC_FUNCTION
 
-#endif // __CLC_MISC_CLC_SHUFFLE2_H__
+#endif // CLC_MISC_CLC_SHUFFLE2_H

--- a/libclc/clc/include/clc/relational/clc_all.h
+++ b/libclc/clc/include/clc/relational/clc_all.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_RELATIONAL_CLC_ALL_H__
-#define __CLC_RELATIONAL_CLC_ALL_H__
+#ifndef CLC_RELATIONAL_CLC_ALL_H
+#define CLC_RELATIONAL_CLC_ALL_H
 
 #include <clc/clcfunc.h>
 
@@ -30,4 +30,4 @@ _CLC_VECTOR_ALL_DECL(long)
 #undef _CLC_ALL_DECL
 #undef _CLC_VECTOR_ALL_DECL
 
-#endif // __CLC_RELATIONAL_CLC_ALL_H__
+#endif // CLC_RELATIONAL_CLC_ALL_H

--- a/libclc/clc/include/clc/relational/clc_any.h
+++ b/libclc/clc/include/clc/relational/clc_any.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_RELATIONAL_CLC_ANY_H__
-#define __CLC_RELATIONAL_CLC_ANY_H__
+#ifndef CLC_RELATIONAL_CLC_ANY_H
+#define CLC_RELATIONAL_CLC_ANY_H
 
 #include <clc/clcfunc.h>
 
@@ -30,4 +30,4 @@ _CLC_VECTOR_ANY_DECL(long)
 #undef _CLC_ANY_DECL
 #undef _CLC_VECTOR_ANY_DECL
 
-#endif // __CLC_RELATIONAL_CLC_ANY_H__
+#endif // CLC_RELATIONAL_CLC_ANY_H

--- a/libclc/clc/include/clc/relational/clc_bitselect.h
+++ b/libclc/clc/include/clc/relational/clc_bitselect.h
@@ -6,12 +6,12 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_RELATIONAL_CLC_BITSELECT_H__
-#define __CLC_RELATIONAL_CLC_BITSELECT_H__
+#ifndef CLC_RELATIONAL_CLC_BITSELECT_H
+#define CLC_RELATIONAL_CLC_BITSELECT_H
 
 #define __CLC_BODY <clc/relational/clc_bitselect.inc>
 #include <clc/math/gentype.inc>
 #define __CLC_BODY <clc/relational/clc_bitselect.inc>
 #include <clc/integer/gentype.inc>
 
-#endif // __CLC_RELATIONAL_CLC_BITSELECT_H__
+#endif // CLC_RELATIONAL_CLC_BITSELECT_H

--- a/libclc/clc/include/clc/relational/clc_isequal.h
+++ b/libclc/clc/include/clc/relational/clc_isequal.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_RELATIONAL_CLC_ISEQUAL_H__
-#define __CLC_RELATIONAL_CLC_ISEQUAL_H__
+#ifndef CLC_RELATIONAL_CLC_ISEQUAL_H
+#define CLC_RELATIONAL_CLC_ISEQUAL_H
 
 #include <clc/clcfunc.h>
 
@@ -39,4 +39,4 @@ _CLC_VECTOR_ISEQUAL_DECL(half, short)
 #undef _CLC_ISEQUAL_DECL
 #undef _CLC_VECTOR_ISEQUAL_DECL
 
-#endif //  __CLC_RELATIONAL_CLC_ISEQUAL_H__
+#endif // CLC_RELATIONAL_CLC_ISEQUAL_H

--- a/libclc/clc/include/clc/relational/clc_isfinite.h
+++ b/libclc/clc/include/clc/relational/clc_isfinite.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_RELATIONAL_CLC_ISFINITE_H__
-#define __CLC_RELATIONAL_CLC_ISFINITE_H__
+#ifndef CLC_RELATIONAL_CLC_ISFINITE_H
+#define CLC_RELATIONAL_CLC_ISFINITE_H
 
 #define __CLC_FUNCTION __clc_isfinite
 #define __CLC_BODY <clc/relational/unary_decl.inc>
@@ -16,4 +16,4 @@
 
 #undef __CLC_FUNCTION
 
-#endif // __CLC_RELATIONAL_CLC_ISFINITE_H__
+#endif // CLC_RELATIONAL_CLC_ISFINITE_H

--- a/libclc/clc/include/clc/relational/clc_isgreater.h
+++ b/libclc/clc/include/clc/relational/clc_isgreater.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_RELATIONAL_CLC_ISGREATER_H__
-#define __CLC_RELATIONAL_CLC_ISGREATER_H__
+#ifndef CLC_RELATIONAL_CLC_ISGREATER_H
+#define CLC_RELATIONAL_CLC_ISGREATER_H
 
 #define __CLC_FUNCTION __clc_isgreater
 #define __CLC_BODY <clc/relational/binary_decl.inc>
@@ -16,4 +16,4 @@
 
 #undef __CLC_FUNCTION
 
-#endif // __CLC_RELATIONAL_CLC_ISGREATER_H__
+#endif // CLC_RELATIONAL_CLC_ISGREATER_H

--- a/libclc/clc/include/clc/relational/clc_isgreaterequal.h
+++ b/libclc/clc/include/clc/relational/clc_isgreaterequal.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_RELATIONAL_CLC_ISGREATEREQUAL_H__
-#define __CLC_RELATIONAL_CLC_ISGREATEREQUAL_H__
+#ifndef CLC_RELATIONAL_CLC_ISGREATEREQUAL_H
+#define CLC_RELATIONAL_CLC_ISGREATEREQUAL_H
 
 #define __CLC_FUNCTION __clc_isgreaterequal
 #define __CLC_BODY <clc/relational/binary_decl.inc>
@@ -16,4 +16,4 @@
 
 #undef __CLC_FUNCTION
 
-#endif // __CLC_RELATIONAL_CLC_ISGREATEREQUAL_H__
+#endif // CLC_RELATIONAL_CLC_ISGREATEREQUAL_H

--- a/libclc/clc/include/clc/relational/clc_isinf.h
+++ b/libclc/clc/include/clc/relational/clc_isinf.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_RELATIONAL_CLC_ISINF_H__
-#define __CLC_RELATIONAL_CLC_ISINF_H__
+#ifndef CLC_RELATIONAL_CLC_ISINF_H
+#define CLC_RELATIONAL_CLC_ISINF_H
 
 #include <clc/clcfunc.h>
 
@@ -39,4 +39,4 @@ _CLC_VECTOR_ISINF_DECL(short, half)
 #undef _CLC_ISINF_DECL
 #undef _CLC_VECTOR_ISINF_DECL
 
-#endif // __CLC_RELATIONAL_CLC_ISINF_H__
+#endif // CLC_RELATIONAL_CLC_ISINF_H

--- a/libclc/clc/include/clc/relational/clc_isless.h
+++ b/libclc/clc/include/clc/relational/clc_isless.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_RELATIONAL_CLC_ISLESS_H__
-#define __CLC_RELATIONAL_CLC_ISLESS_H__
+#ifndef CLC_RELATIONAL_CLC_ISLESS_H
+#define CLC_RELATIONAL_CLC_ISLESS_H
 
 #define __CLC_FUNCTION __clc_isless
 #define __CLC_BODY <clc/relational/binary_decl.inc>
@@ -16,4 +16,4 @@
 
 #undef __CLC_FUNCTION
 
-#endif // __CLC_RELATIONAL_CLC_ISLESS_H__
+#endif // CLC_RELATIONAL_CLC_ISLESS_H

--- a/libclc/clc/include/clc/relational/clc_islessequal.h
+++ b/libclc/clc/include/clc/relational/clc_islessequal.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_RELATIONAL_CLC_ISLESSEQUAL_H__
-#define __CLC_RELATIONAL_CLC_ISLESSEQUAL_H__
+#ifndef CLC_RELATIONAL_CLC_ISLESSEQUAL_H
+#define CLC_RELATIONAL_CLC_ISLESSEQUAL_H
 
 #define __CLC_FUNCTION __clc_islessequal
 #define __CLC_BODY <clc/relational/binary_decl.inc>
@@ -16,4 +16,4 @@
 
 #undef __CLC_FUNCTION
 
-#endif // __CLC_RELATIONAL_CLC_ISLESSEQUAL_H__
+#endif // CLC_RELATIONAL_CLC_ISLESSEQUAL_H

--- a/libclc/clc/include/clc/relational/clc_islessgreater.h
+++ b/libclc/clc/include/clc/relational/clc_islessgreater.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_RELATIONAL_CLC_ISLESSGREATER_H__
-#define __CLC_RELATIONAL_CLC_ISLESSGREATER_H__
+#ifndef CLC_RELATIONAL_CLC_ISLESSGREATER_H
+#define CLC_RELATIONAL_CLC_ISLESSGREATER_H
 
 #define __CLC_FUNCTION __clc_islessgreater
 #define __CLC_BODY <clc/relational/binary_decl.inc>
@@ -16,4 +16,4 @@
 
 #undef __CLC_FUNCTION
 
-#endif // __CLC_RELATIONAL_CLC_ISLESSGREATER_H__
+#endif // CLC_RELATIONAL_CLC_ISLESSGREATER_H

--- a/libclc/clc/include/clc/relational/clc_isnan.h
+++ b/libclc/clc/include/clc/relational/clc_isnan.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_RELATIONAL_CLC_ISNAN_H__
-#define __CLC_RELATIONAL_CLC_ISNAN_H__
+#ifndef CLC_RELATIONAL_CLC_ISNAN_H
+#define CLC_RELATIONAL_CLC_ISNAN_H
 
 #include <clc/clcfunc.h>
 
@@ -39,4 +39,4 @@ _CLC_VECTOR_ISNAN_DECL(short, half)
 #undef _CLC_ISNAN_DECL
 #undef _CLC_VECTOR_ISNAN_DECL
 
-#endif // __CLC_RELATIONAL_CLC_ISNAN_H__
+#endif // CLC_RELATIONAL_CLC_ISNAN_H

--- a/libclc/clc/include/clc/relational/clc_isnormal.h
+++ b/libclc/clc/include/clc/relational/clc_isnormal.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_RELATIONAL_CLC_ISNORMAL_H__
-#define __CLC_RELATIONAL_CLC_ISNORMAL_H__
+#ifndef CLC_RELATIONAL_CLC_ISNORMAL_H
+#define CLC_RELATIONAL_CLC_ISNORMAL_H
 
 #define __CLC_FUNCTION __clc_isnormal
 #define __CLC_BODY <clc/relational/unary_decl.inc>
@@ -16,4 +16,4 @@
 
 #undef __CLC_FUNCTION
 
-#endif // __CLC_RELATIONAL_CLC_ISNORMAL_H__
+#endif // CLC_RELATIONAL_CLC_ISNORMAL_H

--- a/libclc/clc/include/clc/relational/clc_isnotequal.h
+++ b/libclc/clc/include/clc/relational/clc_isnotequal.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_RELATIONAL_CLC_ISNOTEQUAL_H__
-#define __CLC_RELATIONAL_CLC_ISNOTEQUAL_H__
+#ifndef CLC_RELATIONAL_CLC_ISNOTEQUAL_H
+#define CLC_RELATIONAL_CLC_ISNOTEQUAL_H
 
 #define __CLC_FUNCTION __clc_isnotequal
 #define __CLC_BODY <clc/relational/binary_decl.inc>
@@ -16,4 +16,4 @@
 
 #undef __CLC_FUNCTION
 
-#endif // __CLC_RELATIONAL_CLC_ISNOTEQUAL_H__
+#endif // CLC_RELATIONAL_CLC_ISNOTEQUAL_H

--- a/libclc/clc/include/clc/relational/clc_isordered.h
+++ b/libclc/clc/include/clc/relational/clc_isordered.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_RELATIONAL_CLC_ISORDERED_H__
-#define __CLC_RELATIONAL_CLC_ISORDERED_H__
+#ifndef CLC_RELATIONAL_CLC_ISORDERED_H
+#define CLC_RELATIONAL_CLC_ISORDERED_H
 
 #define __CLC_FUNCTION __clc_isordered
 #define __CLC_BODY <clc/relational/binary_decl.inc>
@@ -16,4 +16,4 @@
 
 #undef __CLC_FUNCTION
 
-#endif // __CLC_RELATIONAL_CLC_ISORDERED_H__
+#endif // CLC_RELATIONAL_CLC_ISORDERED_H

--- a/libclc/clc/include/clc/relational/clc_issubnormal.h
+++ b/libclc/clc/include/clc/relational/clc_issubnormal.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_RELATIONAL_CLC_ISSUBNORMAL_H__
-#define __CLC_RELATIONAL_CLC_ISSUBNORMAL_H__
+#ifndef CLC_RELATIONAL_CLC_ISSUBNORMAL_H
+#define CLC_RELATIONAL_CLC_ISSUBNORMAL_H
 
 #include <clc/clcfunc.h>
 
@@ -39,4 +39,4 @@ _CLC_VECTOR_ISSUBNORMAL_DECL(short, half)
 #undef _CLC_ISSUBNORMAL_DECL
 #undef _CLC_VECTOR_ISSUBNORMAL_DECL
 
-#endif // __CLC_RELATIONAL_CLC_ISSUBNORMAL_H__
+#endif // CLC_RELATIONAL_CLC_ISSUBNORMAL_H

--- a/libclc/clc/include/clc/relational/clc_isunordered.h
+++ b/libclc/clc/include/clc/relational/clc_isunordered.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_RELATIONAL_CLC_ISUNORDERED_H__
-#define __CLC_RELATIONAL_CLC_ISUNORDERED_H__
+#ifndef CLC_RELATIONAL_CLC_ISUNORDERED_H
+#define CLC_RELATIONAL_CLC_ISUNORDERED_H
 
 #define __CLC_FUNCTION __clc_isunordered
 #define __CLC_BODY <clc/relational/binary_decl.inc>
@@ -16,4 +16,4 @@
 
 #undef __CLC_FUNCTION
 
-#endif // __CLC_RELATIONAL_CLC_ISUNORDERED_H__
+#endif // CLC_RELATIONAL_CLC_ISUNORDERED_H

--- a/libclc/clc/include/clc/relational/clc_select.h
+++ b/libclc/clc/include/clc/relational/clc_select.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_RELATIONAL_CLC_SELECT_H__
-#define __CLC_RELATIONAL_CLC_SELECT_H__
+#ifndef CLC_RELATIONAL_CLC_SELECT_H
+#define CLC_RELATIONAL_CLC_SELECT_H
 
 #include <clc/utils.h>
 
@@ -20,4 +20,4 @@
 
 #undef __CLC_SELECT_FN
 
-#endif // __CLC_RELATIONAL_CLC_SELECT_H__
+#endif // CLC_RELATIONAL_CLC_SELECT_H

--- a/libclc/clc/include/clc/relational/clc_signbit.h
+++ b/libclc/clc/include/clc/relational/clc_signbit.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_RELATIONAL_CLC_SIGNBIT_H__
-#define __CLC_RELATIONAL_CLC_SIGNBIT_H__
+#ifndef CLC_RELATIONAL_CLC_SIGNBIT_H
+#define CLC_RELATIONAL_CLC_SIGNBIT_H
 
 #define __CLC_FUNCTION __clc_signbit
 #define __CLC_BODY <clc/relational/unary_decl.inc>
@@ -16,4 +16,4 @@
 
 #undef __CLC_FUNCTION
 
-#endif // __CLC_RELATIONAL_CLC_SIGNBIT_H__
+#endif // CLC_RELATIONAL_CLC_SIGNBIT_H

--- a/libclc/clc/include/clc/relational/relational.h
+++ b/libclc/clc/include/clc/relational/relational.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_RELATIONAL_RELATIONAL_H__
-#define __CLC_RELATIONAL_RELATIONAL_H__
+#ifndef CLC_RELATIONAL_RELATIONAL_H
+#define CLC_RELATIONAL_RELATIONAL_H
 
 /*
  * Contains relational macros that have to return 1 for scalar and -1 for vector
@@ -71,4 +71,4 @@
   _CLC_DEFINE_ISFPCLASS_VEC(VEC_RET_TYPE##16, __CLC_FUNCTION, MASK,            \
                             ARG_TYPE##16)
 
-#endif // __CLC_RELATIONAL_RELATIONAL_H__
+#endif // CLC_RELATIONAL_RELATIONAL_H

--- a/libclc/clc/include/clc/shared/clc_clamp.h
+++ b/libclc/clc/include/clc/shared/clc_clamp.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_SHARED_CLC_CLAMP_H__
-#define __CLC_SHARED_CLC_CLAMP_H__
+#ifndef CLC_SHARED_CLC_CLAMP_H
+#define CLC_SHARED_CLC_CLAMP_H
 
 #define __CLC_BODY <clc/shared/clc_clamp.inc>
 #include <clc/integer/gentype.inc>
@@ -15,4 +15,4 @@
 #define __CLC_BODY <clc/shared/clc_clamp.inc>
 #include <clc/math/gentype.inc>
 
-#endif // __CLC_SHARED_CLC_CLAMP_H__
+#endif // CLC_SHARED_CLC_CLAMP_H

--- a/libclc/clc/include/clc/shared/clc_less_aligned_types.h
+++ b/libclc/clc/include/clc/shared/clc_less_aligned_types.h
@@ -11,8 +11,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_SHARED_CLC_LESS_ALIGNED_TYPES_H__
-#define __CLC_SHARED_CLC_LESS_ALIGNED_TYPES_H__
+#ifndef CLC_SHARED_CLC_LESS_ALIGNED_TYPES_H
+#define CLC_SHARED_CLC_LESS_ALIGNED_TYPES_H
 
 #define __CLC_BODY <clc/shared/clc_less_aligned_types.inc>
 #include <clc/integer/gentype.inc>
@@ -20,4 +20,4 @@
 #define __CLC_BODY <clc/shared/clc_less_aligned_types.inc>
 #include <clc/math/gentype.inc>
 
-#endif // __CLC_SHARED_CLC_LESS_ALIGNED_TYPES_H__
+#endif // CLC_SHARED_CLC_LESS_ALIGNED_TYPES_H

--- a/libclc/clc/include/clc/shared/clc_max.h
+++ b/libclc/clc/include/clc/shared/clc_max.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_SHARED_CLC_MAX_H__
-#define __CLC_SHARED_CLC_MAX_H__
+#ifndef CLC_SHARED_CLC_MAX_H
+#define CLC_SHARED_CLC_MAX_H
 
 #define __CLC_BODY <clc/shared/clc_max.inc>
 #include <clc/integer/gentype.inc>
@@ -15,4 +15,4 @@
 #define __CLC_BODY <clc/shared/clc_max.inc>
 #include <clc/math/gentype.inc>
 
-#endif // __CLC_SHARED_CLC_MAX_H__
+#endif // CLC_SHARED_CLC_MAX_H

--- a/libclc/clc/include/clc/shared/clc_min.h
+++ b/libclc/clc/include/clc/shared/clc_min.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_SHARED_CLC_MIN_H__
-#define __CLC_SHARED_CLC_MIN_H__
+#ifndef CLC_SHARED_CLC_MIN_H
+#define CLC_SHARED_CLC_MIN_H
 
 #define __CLC_BODY <clc/shared/clc_min.inc>
 #include <clc/integer/gentype.inc>
@@ -15,4 +15,4 @@
 #define __CLC_BODY <clc/shared/clc_min.inc>
 #include <clc/math/gentype.inc>
 
-#endif // __CLC_SHARED_CLC_MIN_H__
+#endif // CLC_SHARED_CLC_MIN_H

--- a/libclc/clc/include/clc/shared/clc_vload.h
+++ b/libclc/clc/include/clc/shared/clc_vload.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_SHARED_CLC_VLOAD_H__
-#define __CLC_SHARED_CLC_VLOAD_H__
+#ifndef CLC_SHARED_CLC_VLOAD_H
+#define CLC_SHARED_CLC_VLOAD_H
 
 #include <clc/shared/clc_less_aligned_types.h>
 
@@ -17,4 +17,4 @@
 #define __CLC_BODY <clc/shared/clc_vload.inc>
 #include <clc/math/gentype.inc>
 
-#endif // __CLC_SHARED_CLC_VLOAD_H__
+#endif // CLC_SHARED_CLC_VLOAD_H

--- a/libclc/clc/include/clc/shared/clc_vstore.h
+++ b/libclc/clc/include/clc/shared/clc_vstore.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_SHARED_CLC_VSTORE_H__
-#define __CLC_SHARED_CLC_VSTORE_H__
+#ifndef CLC_SHARED_CLC_VSTORE_H
+#define CLC_SHARED_CLC_VSTORE_H
 
 #include <clc/shared/clc_less_aligned_types.h>
 
@@ -17,4 +17,4 @@
 #define __CLC_BODY <clc/shared/clc_vstore.inc>
 #include <clc/math/gentype.inc>
 
-#endif // __CLC_SHARED_CLC_VSTORE_H__
+#endif // CLC_SHARED_CLC_VSTORE_H

--- a/libclc/clc/include/clc/synchronization/clc_work_group_barrier.h
+++ b/libclc/clc/include/clc/synchronization/clc_work_group_barrier.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_SYNCHRONIZATION_CLC_WORK_GROUP_BARRIER_H__
-#define __CLC_SYNCHRONIZATION_CLC_WORK_GROUP_BARRIER_H__
+#ifndef CLC_SYNCHRONIZATION_CLC_WORK_GROUP_BARRIER_H
+#define CLC_SYNCHRONIZATION_CLC_WORK_GROUP_BARRIER_H
 
 #include <clc/internal/clc.h>
 #include <clc/mem_fence/clc_mem_semantic.h>
@@ -16,4 +16,4 @@ _CLC_OVERLOAD _CLC_DECL void
 __clc_work_group_barrier(int memory_scope, int memory_order,
                          __CLC_MemorySemantics memory_semantics);
 
-#endif // __CLC_SYNCHRONIZATION_CLC_WORK_GROUP_BARRIER_H__
+#endif // CLC_SYNCHRONIZATION_CLC_WORK_GROUP_BARRIER_H

--- a/libclc/clc/include/clc/utils.h
+++ b/libclc/clc/include/clc/utils.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_UTILS_H__
-#define __CLC_UTILS_H__
+#ifndef CLC_UTILS_H
+#define CLC_UTILS_H
 
 #define __CLC_CONCAT(x, y) x##y
 #define __CLC_XCONCAT(x, y) __CLC_CONCAT(x, y)
@@ -15,4 +15,4 @@
 #define __CLC_STR(x) #x
 #define __CLC_XSTR(x) __CLC_STR(x)
 
-#endif // __CLC_UTILS_H__
+#endif // CLC_UTILS_H

--- a/libclc/clc/include/clc/workitem/clc_get_global_id.h
+++ b/libclc/clc/include/clc/workitem/clc_get_global_id.h
@@ -6,11 +6,11 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_WORKITEM_CLC_GET_GLOBAL_ID_H__
-#define __CLC_WORKITEM_CLC_GET_GLOBAL_ID_H__
+#ifndef CLC_WORKITEM_CLC_GET_GLOBAL_ID_H
+#define CLC_WORKITEM_CLC_GET_GLOBAL_ID_H
 
 #include <clc/internal/clc.h>
 
 _CLC_OVERLOAD _CLC_CONST _CLC_DECL size_t __clc_get_global_id(uint dim);
 
-#endif // __CLC_WORKITEM_CLC_GET_GLOBAL_ID_H__
+#endif // CLC_WORKITEM_CLC_GET_GLOBAL_ID_H

--- a/libclc/clc/include/clc/workitem/clc_get_global_offset.h
+++ b/libclc/clc/include/clc/workitem/clc_get_global_offset.h
@@ -6,11 +6,11 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_WORKITEM_CLC_GET_GLOBAL_OFFSET_H__
-#define __CLC_WORKITEM_CLC_GET_GLOBAL_OFFSET_H__
+#ifndef CLC_WORKITEM_CLC_GET_GLOBAL_OFFSET_H
+#define CLC_WORKITEM_CLC_GET_GLOBAL_OFFSET_H
 
 #include <clc/internal/clc.h>
 
 _CLC_OVERLOAD _CLC_CONST _CLC_DECL size_t __clc_get_global_offset(uint dim);
 
-#endif // __CLC_WORKITEM_CLC_GET_GLOBAL_OFFSET_H__
+#endif // CLC_WORKITEM_CLC_GET_GLOBAL_OFFSET_H

--- a/libclc/clc/include/clc/workitem/clc_get_global_size.h
+++ b/libclc/clc/include/clc/workitem/clc_get_global_size.h
@@ -6,11 +6,11 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_WORKITEM_CLC_GET_GLOBAL_SIZE_H__
-#define __CLC_WORKITEM_CLC_GET_GLOBAL_SIZE_H__
+#ifndef CLC_WORKITEM_CLC_GET_GLOBAL_SIZE_H
+#define CLC_WORKITEM_CLC_GET_GLOBAL_SIZE_H
 
 #include <clc/internal/clc.h>
 
 _CLC_OVERLOAD _CLC_CONST _CLC_DECL size_t __clc_get_global_size(uint dim);
 
-#endif // __CLC_WORKITEM_CLC_GET_GLOBAL_SIZE_H__
+#endif // CLC_WORKITEM_CLC_GET_GLOBAL_SIZE_H

--- a/libclc/clc/include/clc/workitem/clc_get_group_id.h
+++ b/libclc/clc/include/clc/workitem/clc_get_group_id.h
@@ -6,11 +6,11 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_WORKITEM_CLC_GET_GROUP_ID_H__
-#define __CLC_WORKITEM_CLC_GET_GROUP_ID_H__
+#ifndef CLC_WORKITEM_CLC_GET_GROUP_ID_H
+#define CLC_WORKITEM_CLC_GET_GROUP_ID_H
 
 #include <clc/internal/clc.h>
 
 _CLC_OVERLOAD _CLC_CONST _CLC_DECL size_t __clc_get_group_id(uint dim);
 
-#endif // __CLC_WORKITEM_CLC_GET_GROUP_ID_H__
+#endif // CLC_WORKITEM_CLC_GET_GROUP_ID_H

--- a/libclc/clc/include/clc/workitem/clc_get_local_id.h
+++ b/libclc/clc/include/clc/workitem/clc_get_local_id.h
@@ -6,11 +6,11 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_WORKITEM_CLC_GET_LOCAL_ID_H__
-#define __CLC_WORKITEM_CLC_GET_LOCAL_ID_H__
+#ifndef CLC_WORKITEM_CLC_GET_LOCAL_ID_H
+#define CLC_WORKITEM_CLC_GET_LOCAL_ID_H
 
 #include <clc/internal/clc.h>
 
 _CLC_OVERLOAD _CLC_CONST _CLC_DECL size_t __clc_get_local_id(uint dim);
 
-#endif // __CLC_WORKITEM_CLC_GET_LOCAL_ID_H__
+#endif // CLC_WORKITEM_CLC_GET_LOCAL_ID_H

--- a/libclc/clc/include/clc/workitem/clc_get_local_linear_id.h
+++ b/libclc/clc/include/clc/workitem/clc_get_local_linear_id.h
@@ -6,11 +6,11 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_WORKITEM_CLC_GET_LOCAL_LINEAR_ID_H__
-#define __CLC_WORKITEM_CLC_GET_LOCAL_LINEAR_ID_H__
+#ifndef CLC_WORKITEM_CLC_GET_LOCAL_LINEAR_ID_H
+#define CLC_WORKITEM_CLC_GET_LOCAL_LINEAR_ID_H
 
 #include <clc/internal/clc.h>
 
 _CLC_OVERLOAD _CLC_CONST _CLC_DECL size_t __clc_get_local_linear_id();
 
-#endif // __CLC_WORKITEM_CLC_GET_LOCAL_LINEAR_ID_H__
+#endif // CLC_WORKITEM_CLC_GET_LOCAL_LINEAR_ID_H

--- a/libclc/clc/include/clc/workitem/clc_get_local_size.h
+++ b/libclc/clc/include/clc/workitem/clc_get_local_size.h
@@ -6,11 +6,11 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_WORKITEM_CLC_GET_LOCAL_SIZE_H__
-#define __CLC_WORKITEM_CLC_GET_LOCAL_SIZE_H__
+#ifndef CLC_WORKITEM_CLC_GET_LOCAL_SIZE_H
+#define CLC_WORKITEM_CLC_GET_LOCAL_SIZE_H
 
 #include <clc/internal/clc.h>
 
 _CLC_OVERLOAD _CLC_CONST _CLC_DECL size_t __clc_get_local_size(uint dim);
 
-#endif // __CLC_WORKITEM_CLC_GET_LOCAL_SIZE_H__
+#endif // CLC_WORKITEM_CLC_GET_LOCAL_SIZE_H

--- a/libclc/clc/include/clc/workitem/clc_get_max_sub_group_size.h
+++ b/libclc/clc/include/clc/workitem/clc_get_max_sub_group_size.h
@@ -6,11 +6,11 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_WORKITEM_CLC_GET_MAX_SUB_GROUP_SIZE_H__
-#define __CLC_WORKITEM_CLC_GET_MAX_SUB_GROUP_SIZE_H__
+#ifndef CLC_WORKITEM_CLC_GET_MAX_SUB_GROUP_SIZE_H
+#define CLC_WORKITEM_CLC_GET_MAX_SUB_GROUP_SIZE_H
 
 #include <clc/internal/clc.h>
 
 _CLC_OVERLOAD _CLC_CONST _CLC_DECL uint __clc_get_max_sub_group_size();
 
-#endif // __CLC_WORKITEM_CLC_GET_MAX_SUB_GROUP_SIZE_H__
+#endif // CLC_WORKITEM_CLC_GET_MAX_SUB_GROUP_SIZE_H

--- a/libclc/clc/include/clc/workitem/clc_get_num_groups.h
+++ b/libclc/clc/include/clc/workitem/clc_get_num_groups.h
@@ -6,11 +6,11 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_WORKITEM_CLC_GET_NUM_GROUPS_H__
-#define __CLC_WORKITEM_CLC_GET_NUM_GROUPS_H__
+#ifndef CLC_WORKITEM_CLC_GET_NUM_GROUPS_H
+#define CLC_WORKITEM_CLC_GET_NUM_GROUPS_H
 
 #include <clc/internal/clc.h>
 
 _CLC_OVERLOAD _CLC_CONST _CLC_DECL size_t __clc_get_num_groups(uint dim);
 
-#endif // __CLC_WORKITEM_CLC_GET_NUM_GROUPS_H__
+#endif // CLC_WORKITEM_CLC_GET_NUM_GROUPS_H

--- a/libclc/clc/include/clc/workitem/clc_get_num_sub_groups.h
+++ b/libclc/clc/include/clc/workitem/clc_get_num_sub_groups.h
@@ -6,11 +6,11 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_WORKITEM_CLC_GET_NUM_SUB_GROUPS_H__
-#define __CLC_WORKITEM_CLC_GET_NUM_SUB_GROUPS_H__
+#ifndef CLC_WORKITEM_CLC_GET_NUM_SUB_GROUPS_H
+#define CLC_WORKITEM_CLC_GET_NUM_SUB_GROUPS_H
 
 #include <clc/internal/clc.h>
 
 _CLC_OVERLOAD _CLC_CONST _CLC_DECL uint __clc_get_num_sub_groups();
 
-#endif // __CLC_WORKITEM_CLC_GET_NUM_SUB_GROUPS_H__
+#endif // CLC_WORKITEM_CLC_GET_NUM_SUB_GROUPS_H

--- a/libclc/clc/include/clc/workitem/clc_get_sub_group_id.h
+++ b/libclc/clc/include/clc/workitem/clc_get_sub_group_id.h
@@ -6,11 +6,11 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_WORKITEM_CLC_GET_SUB_GROUP_ID_H__
-#define __CLC_WORKITEM_CLC_GET_SUB_GROUP_ID_H__
+#ifndef CLC_WORKITEM_CLC_GET_SUB_GROUP_ID_H
+#define CLC_WORKITEM_CLC_GET_SUB_GROUP_ID_H
 
 #include <clc/internal/clc.h>
 
 _CLC_OVERLOAD _CLC_CONST _CLC_DECL uint __clc_get_sub_group_id();
 
-#endif // __CLC_WORKITEM_CLC_GET_SUB_GROUP_ID_H__
+#endif // CLC_WORKITEM_CLC_GET_SUB_GROUP_ID_H

--- a/libclc/clc/include/clc/workitem/clc_get_sub_group_local_id.h
+++ b/libclc/clc/include/clc/workitem/clc_get_sub_group_local_id.h
@@ -6,11 +6,11 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_WORKITEM_CLC_GET_SUB_GROUP_LOCAL_ID_H__
-#define __CLC_WORKITEM_CLC_GET_SUB_GROUP_LOCAL_ID_H__
+#ifndef CLC_WORKITEM_CLC_GET_SUB_GROUP_LOCAL_ID_H
+#define CLC_WORKITEM_CLC_GET_SUB_GROUP_LOCAL_ID_H
 
 #include <clc/internal/clc.h>
 
 _CLC_OVERLOAD _CLC_CONST _CLC_DECL uint __clc_get_sub_group_local_id();
 
-#endif // __CLC_WORKITEM_CLC_GET_SUB_GROUP_LOCAL_ID_H__
+#endif // CLC_WORKITEM_CLC_GET_SUB_GROUP_LOCAL_ID_H

--- a/libclc/clc/include/clc/workitem/clc_get_sub_group_size.h
+++ b/libclc/clc/include/clc/workitem/clc_get_sub_group_size.h
@@ -6,11 +6,11 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_WORKITEM_CLC_GET_SUB_GROUP_SIZE_H__
-#define __CLC_WORKITEM_CLC_GET_SUB_GROUP_SIZE_H__
+#ifndef CLC_WORKITEM_CLC_GET_SUB_GROUP_SIZE_H
+#define CLC_WORKITEM_CLC_GET_SUB_GROUP_SIZE_H
 
 #include <clc/internal/clc.h>
 
 _CLC_OVERLOAD _CLC_CONST _CLC_DECL uint __clc_get_sub_group_size();
 
-#endif // __CLC_WORKITEM_CLC_GET_SUB_GROUP_SIZE_H__
+#endif // CLC_WORKITEM_CLC_GET_SUB_GROUP_SIZE_H

--- a/libclc/clc/include/clc/workitem/clc_get_work_dim.h
+++ b/libclc/clc/include/clc/workitem/clc_get_work_dim.h
@@ -6,11 +6,11 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_WORKITEM_CLC_GET_WORK_DIM_H__
-#define __CLC_WORKITEM_CLC_GET_WORK_DIM_H__
+#ifndef CLC_WORKITEM_CLC_GET_WORK_DIM_H
+#define CLC_WORKITEM_CLC_GET_WORK_DIM_H
 
 #include <clc/internal/clc.h>
 
 _CLC_OVERLOAD _CLC_CONST _CLC_DECL uint __clc_get_work_dim();
 
-#endif // __CLC_WORKITEM_CLC_GET_WORK_DIM_H__
+#endif // CLC_WORKITEM_CLC_GET_WORK_DIM_H

--- a/libclc/clc/lib/generic/integer/clc_mad24.cl
+++ b/libclc/clc/lib/generic/integer/clc_mad24.cl
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <clc/internal/clc.h>
 #include <clc/integer/clc_mul24.h>
+#include <clc/internal/clc.h>
 
 #define __CLC_BODY <clc_mad24.inc>
 #include <clc/integer/gentype24.inc>

--- a/libclc/clc/lib/generic/math/clc_log_base.h
+++ b/libclc/clc/lib/generic/math/clc_log_base.h
@@ -1,6 +1,3 @@
-#ifndef CLC_LIB_GENERIC_MATH_CLC_LOG_BASE_H
-#define CLC_LIB_GENERIC_MATH_CLC_LOG_BASE_H
-
 //===----------------------------------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
@@ -8,6 +5,9 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
+
+#ifndef CLC_LIB_GENERIC_MATH_CLC_LOG_BASE_H
+#define CLC_LIB_GENERIC_MATH_CLC_LOG_BASE_H
 
 #include <clc/math/clc_fabs.h>
 #include <clc/math/clc_fma.h>

--- a/libclc/clc/lib/generic/math/clc_log_base.h
+++ b/libclc/clc/lib/generic/math/clc_log_base.h
@@ -1,3 +1,6 @@
+#ifndef LLVM_LIBCLC_CLC_LIB_GENERIC_MATH_CLC_LOG_BASE_H
+#define LLVM_LIBCLC_CLC_LIB_GENERIC_MATH_CLC_LOG_BASE_H
+
 //===----------------------------------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
@@ -322,3 +325,5 @@ __clc_log(half x) {
 #endif
 
 #endif // cl_khr_fp16
+
+#endif

--- a/libclc/clc/lib/generic/math/clc_log_base.h
+++ b/libclc/clc/lib/generic/math/clc_log_base.h
@@ -1,5 +1,5 @@
-#ifndef LLVM_LIBCLC_CLC_LIB_GENERIC_MATH_CLC_LOG_BASE_H
-#define LLVM_LIBCLC_CLC_LIB_GENERIC_MATH_CLC_LOG_BASE_H
+#ifndef CLC_LIB_GENERIC_MATH_CLC_LOG_BASE_H
+#define CLC_LIB_GENERIC_MATH_CLC_LOG_BASE_H
 
 //===----------------------------------------------------------------------===//
 //
@@ -326,4 +326,4 @@ __clc_log(half x) {
 
 #endif // cl_khr_fp16
 
-#endif
+#endif // CLC_LIB_GENERIC_MATH_CLC_LOG_BASE_H

--- a/libclc/clc/lib/generic/math/clc_sincos_helpers.inc
+++ b/libclc/clc/lib/generic/math/clc_sincos_helpers.inc
@@ -347,8 +347,7 @@ _CLC_DEF _CLC_OVERLOAD __CLC_INTN __clc_argReductionS(private __CLC_FLOATN *r,
 #ifdef __CLC_SCALAR
   if (is_small)
     return __clc_argReductionSmallS(r, rr, x);
-  else
-    return __clc_argReductionLargeS(r, rr, x);
+  return __clc_argReductionLargeS(r, rr, x);
 #else
   __CLC_FLOATN r1, rr1, r2, rr2;
   __CLC_INTN ret1 = __clc_argReductionSmallS(&r1, &rr1, x);


### PR DESCRIPTION
Our downstream clang-tidy CI reports warning:
header guard does not follow preferred style [llvm-header-guard]

Changes:
- Add libclc/.clang-tidy configuration file that:
  * Disables bugprone-reserved-identifier to allow `__` prefix for internal macros (__CLC_FUNCTION, __CLC_BODY, etc.) avoiding namespace conflicts
  * Disables bugprone-macro-parentheses for include macros like `#define __CLC_BODY <file.inc>`
  * Enables llvm-header-guard check to standardize header guards
  * Disables readability-identifier-naming to preserve existing constant naming conventions (LOG2_HEAD, LOG2_TAIL, etc.)
- Update all header guards from `__CLC_*_H__` to `CLC_*_H` format
- Remove unnecessary else after return in clc_sincos_helpers.inc
- Change the include reordering in clc_mad24.cl