### PR TITLE
[RISCV] Don't make ISD::ABDS/ABDU legal for v2i32 with P extension.

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
@@ -575,7 +575,9 @@ RISCVTargetLowering::RISCVTargetLowering(const TargetMachine &TM,
     setOperationAction(ISD::SSUBSAT, VTs, Legal);
     setOperationAction(ISD::SSHLSAT, VTs, Legal);
     setOperationAction({ISD::AVGFLOORS, ISD::AVGFLOORU}, VTs, Legal);
-    setOperationAction({ISD::ABDS, ISD::ABDU}, VTs, Legal);
+    for (MVT VT : VTs)
+      if (VT != MVT::v2i32)
+        setOperationAction({ISD::ABDS, ISD::ABDU}, VT, Legal);
     setOperationAction(ISD::SPLAT_VECTOR, VTs, Legal);
     setOperationAction(ISD::BUILD_VECTOR, VTs, Legal);
     setOperationAction(ISD::SCALAR_TO_VECTOR, VTs, Legal);

--- a/llvm/test/CodeGen/RISCV/rvp-ext-rv64.ll
+++ b/llvm/test/CodeGen/RISCV/rvp-ext-rv64.ll
@@ -374,6 +374,36 @@ define <8 x i8> @test_paaddu_b(<8 x i8> %a, <8 x i8> %b) {
   ret <8 x i8> %res
 }
 
+; Test absolute difference signed for v2i32
+; abds pattern: sub(smax(a,b), smin(a,b))
+define <2 x i32> @test_pdif_w(<2 x i32> %a, <2 x i32> %b) {
+; CHECK-LABEL: test_pdif_w:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    pmin.w a2, a0, a1
+; CHECK-NEXT:    pmax.w a0, a0, a1
+; CHECK-NEXT:    psub.w a0, a0, a2
+; CHECK-NEXT:    ret
+  %min = call <2 x i32> @llvm.smin.v2i32(<2 x i32> %a, <2 x i32> %b)
+  %max = call <2 x i32> @llvm.smax.v2i32(<2 x i32> %a, <2 x i32> %b)
+  %res = sub <2 x i32> %max, %min
+  ret <2 x i32> %res
+}
+
+; Test absolute difference unsigned for v2i32
+; abdu pattern: sub(umax(a,b), umin(a,b))
+define <2 x i32> @test_pdifu_w(<2 x i32> %a, <2 x i32> %b) {
+; CHECK-LABEL: test_pdifu_w:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    pminu.w a2, a0, a1
+; CHECK-NEXT:    pmaxu.w a0, a0, a1
+; CHECK-NEXT:    psub.w a0, a0, a2
+; CHECK-NEXT:    ret
+  %min = call <2 x i32> @llvm.umin.v2i32(<2 x i32> %a, <2 x i32> %b)
+  %max = call <2 x i32> @llvm.umax.v2i32(<2 x i32> %a, <2 x i32> %b)
+  %res = sub <2 x i32> %max, %min
+  ret <2 x i32> %res
+}
+
 ; Test absolute difference signed for v4i16
 ; abds pattern: sub(smax(a,b), smin(a,b))
 define <4 x i16> @test_pdif_h(<4 x i16> %a, <4 x i16> %b) {
@@ -2005,10 +2035,10 @@ define <4 x i16> @test_select_v4i16(i1 %cond, <4 x i16> %a, <4 x i16> %b) {
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    andi a3, a0, 1
 ; CHECK-NEXT:    mv a0, a1
-; CHECK-NEXT:    bnez a3, .LBB161_2
+; CHECK-NEXT:    bnez a3, .LBB163_2
 ; CHECK-NEXT:  # %bb.1:
 ; CHECK-NEXT:    mv a0, a2
-; CHECK-NEXT:  .LBB161_2:
+; CHECK-NEXT:  .LBB163_2:
 ; CHECK-NEXT:    ret
   %res = select i1 %cond, <4 x i16> %a, <4 x i16> %b
   ret <4 x i16> %res
@@ -2019,10 +2049,10 @@ define <8 x i8> @test_select_v8i8(i1 %cond, <8 x i8> %a, <8 x i8> %b) {
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    andi a3, a0, 1
 ; CHECK-NEXT:    mv a0, a1
-; CHECK-NEXT:    bnez a3, .LBB162_2
+; CHECK-NEXT:    bnez a3, .LBB164_2
 ; CHECK-NEXT:  # %bb.1:
 ; CHECK-NEXT:    mv a0, a2
-; CHECK-NEXT:  .LBB162_2:
+; CHECK-NEXT:  .LBB164_2:
 ; CHECK-NEXT:    ret
   %res = select i1 %cond, <8 x i8> %a, <8 x i8> %b
   ret <8 x i8> %res
@@ -2033,10 +2063,10 @@ define <2 x i32> @test_select_v2i32(i1 %cond, <2 x i32> %a, <2 x i32> %b) {
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    andi a3, a0, 1
 ; CHECK-NEXT:    mv a0, a1
-; CHECK-NEXT:    bnez a3, .LBB163_2
+; CHECK-NEXT:    bnez a3, .LBB165_2
 ; CHECK-NEXT:  # %bb.1:
 ; CHECK-NEXT:    mv a0, a2
-; CHECK-NEXT:  .LBB163_2:
+; CHECK-NEXT:  .LBB165_2:
 ; CHECK-NEXT:    ret
   %res = select i1 %cond, <2 x i32> %a, <2 x i32> %b
   ret <2 x i32> %res


### PR DESCRIPTION
We don't have the instructions for this so it causes a cannot select error.