### PR TITLE
[Clang] Fix a concept cache bug on DependentNameType

### DIFF
--- a/clang/lib/Sema/SemaConcept.cpp
+++ b/clang/lib/Sema/SemaConcept.cpp
@@ -381,9 +381,10 @@ public:
     return true;
   }
 
-  bool TraverseTypeLoc(TypeLoc TL, bool TraverseQualifier = true) {
+  bool TraverseTypeLoc(TypeLoc TL, bool /*TraverseQualifier*/ = true) {
     // We don't care about TypeLocs. So traverse Types instead.
-    return TraverseType(TL.getType().getCanonicalType(), TraverseQualifier);
+    return TraverseType(TL.getType().getCanonicalType(),
+                        /*TraverseQualifier=*/true);
   }
 
   bool TraverseTagType(const TagType *T, bool TraverseQualifier) {

--- a/clang/lib/Sema/SemaConcept.cpp
+++ b/clang/lib/Sema/SemaConcept.cpp
@@ -381,10 +381,14 @@ public:
     return true;
   }
 
-  bool TraverseTypeLoc(TypeLoc TL, bool /*TraverseQualifier*/ = true) {
+  bool TraverseTypeLoc(TypeLoc TL, bool TraverseQualifier = true) {
     // We don't care about TypeLocs. So traverse Types instead.
-    return TraverseType(TL.getType().getCanonicalType(),
-                        /*TraverseQualifier=*/true);
+    return TraverseType(TL.getType().getCanonicalType(), TraverseQualifier);
+  }
+
+  bool TraverseDependentNameType(const DependentNameType *T,
+                                 bool /*TraverseQualifier*/) {
+    return TraverseNestedNameSpecifier(T->getQualifier());
   }
 
   bool TraverseTagType(const TagType *T, bool TraverseQualifier) {

--- a/clang/test/SemaTemplate/instantiate-requires-expr.cpp
+++ b/clang/test/SemaTemplate/instantiate-requires-expr.cpp
@@ -278,3 +278,34 @@ namespace sugared_instantiation {
   static_assert(requires { { f() } -> C; });
   static_assert(requires { { f() } -> D; });
 } // namespace sugared_instantiation
+
+namespace GH184562 {
+
+template <typename T>
+struct tid {
+  using type = T;
+};
+template <typename T>
+using tid_t = tid<T>::type;
+
+template <class T, int N = ::tid_t<T>::value>
+concept req = N < 3 || requires { typename T::template as_two<3>; };
+
+struct two {
+  static constexpr int value = 2;
+};
+
+struct three {
+  static constexpr int value = 3;
+  template <int>
+  using as_two = two;
+};
+
+template <req T>
+struct test {
+  using type = test<typename T::template as_two<1>>;
+};
+
+test<three> x;
+
+}

--- a/clang/test/SemaTemplate/instantiate-requires-expr.cpp
+++ b/clang/test/SemaTemplate/instantiate-requires-expr.cpp
@@ -288,7 +288,7 @@ struct tid {
 template <typename T>
 using tid_t = tid<T>::type;
 
-template <class T, int N = ::tid_t<T>::value>
+template <class T, int N = tid_t<T>::value>
 concept req = N < 3 || requires { typename T::template as_two<3>; };
 
 struct two {


### PR DESCRIPTION
The default RAV implementation refuses to traverse NNS's typeloc recursively, and template parameters inside DependentNameType are overlooked inadvertently.

No release note as what regression patches always do.

Endless bug
Fixes https://github.com/llvm/llvm-project/issues/184562
to our poor concept implementation :/

