### PR TITLE
[libc++] Drop the unrepresentative search_n benchmark

### DIFF
--- a/libcxx/test/benchmarks/algorithms/nonmodifying/search_n.bench.cpp
+++ b/libcxx/test/benchmarks/algorithms/nonmodifying/search_n.bench.cpp
@@ -31,42 +31,6 @@ int main(int argc, char** argv) {
     });
   };
 
-  // Benchmark {std,ranges}::search_n where the needle is never found (worst case).
-  {
-    auto bm = []<class Container>(std::string name, auto search_n) {
-      benchmark::RegisterBenchmark(
-          name,
-          [search_n](auto& st) {
-            std::size_t const size = st.range(0);
-            using ValueType        = typename Container::value_type;
-            ValueType x            = Generate<ValueType>::random();
-            ValueType y            = random_different_from({x});
-            Container haystack(size, x);
-            std::size_t n = size / 10; // needle size is 10% of the haystack
-
-            for ([[maybe_unused]] auto _ : st) {
-              benchmark::DoNotOptimize(haystack);
-              benchmark::DoNotOptimize(n);
-              benchmark::DoNotOptimize(y);
-              auto result = search_n(haystack.begin(), haystack.end(), n, y);
-              benchmark::DoNotOptimize(result);
-            }
-          })
-          ->Arg(32)
-          ->Arg(1024)
-          ->Arg(8192);
-    };
-    // {std,ranges}::search_n
-    bm.operator()<std::vector<int>>("std::search_n(vector<int>) (no match)", std_search_n);
-    bm.operator()<std::deque<int>>("std::search_n(deque<int>) (no match)", std_search_n);
-    bm.operator()<std::list<int>>("std::search_n(list<int>) (no match)", std_search_n);
-
-    // {std,ranges}::search_n(pred)
-    bm.operator()<std::vector<int>>("std::search_n(vector<int>, pred) (no match)", std_search_n_pred);
-    bm.operator()<std::deque<int>>("std::search_n(deque<int>, pred) (no match)", std_search_n_pred);
-    bm.operator()<std::list<int>>("std::search_n(list<int>, pred) (no match)", std_search_n_pred);
-  }
-
   // Benchmark {std,ranges}::search_n where the needle almost matches a lot.
   {
     auto bm = []<class Container>(std::string name, auto search_n) {


### PR DESCRIPTION
This benchmark isn't very good at benchmarking `search_n`, since a good `search_n` implementation can go through it in ~10 perfectly predictable steps. We can drop it to avoid spending unnecessary resources. This also fixes that the two benchmark sets have identical names.

Fixes #183832
