### PR TITLE
[CodeGen] Simplify EVT::operator!=. NFCI.

### DIFF
--- a/llvm/include/llvm/CodeGen/ValueTypes.h
+++ b/llvm/include/llvm/CodeGen/ValueTypes.h
@@ -46,11 +46,7 @@ namespace llvm {
       return !(*this != VT);
     }
     bool operator!=(EVT VT) const {
-      if (V.SimpleTy != VT.V.SimpleTy)
-        return true;
-      if (V.SimpleTy == MVT::INVALID_SIMPLE_VALUE_TYPE)
-        return LLVMTy != VT.LLVMTy;
-      return false;
+      return V.SimpleTy != VT.V.SimpleTy || LLVMTy != VT.LLVMTy;
     }
 
     /// Returns the EVT that represents a floating-point type with the given


### PR DESCRIPTION
This is based on the assumption that LLVMTy should be nullptr if and
only if the EVT is simple.
