### PR TITLE
[SPIRV] Replace `removeFromParent` with `eraseFromParent` for `ASSING_TYPE`

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
@@ -822,7 +822,7 @@ bool SPIRVInstructionSelector::select(MachineInstr &I) {
       MRI->setRegClass(SrcReg, MRI->getRegClass(DstReg));
       MRI->replaceRegWith(SrcReg, DstReg);
       GR.invalidateMachineInstr(&I);
-      I.removeFromParent();
+      I.eraseFromParent();
       return true;
     } else if (I.getNumDefs() == 1) {
       // Make all vregs 64 bits (for SPIR-V IDs).


### PR DESCRIPTION
The `ASSIGN_TYPE` instruction should not be referenced anymore at this point. So we can free its memory.

Follow up of https://github.com/llvm/llvm-project/pull/182330