### PR TITLE
[WebAssembly] Do not form minnum/maxnum

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
@@ -13802,7 +13802,7 @@ SDValue DAGCombiner::visitVSELECT(SDNode *N) {
   // vselect (not Cond), N1, N2 -> vselect Cond, N2, N1
   if (!TLI.isTargetCanonicalSelect(N))
     if (SDValue F = extractBooleanFlip(N0, DAG, TLI, false))
-      return DAG.getSelect(DL, VT, F, N2, N1);
+      return DAG.getSelect(DL, VT, F, N2, N1, N->getFlags());
 
   // select (sext m), (add X, C), X --> (add X, (and C, (sext m))))
   if (N1.getOpcode() == ISD::ADD && N1.getOperand(0) == N2 && N1->hasOneUse() &&

--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.cpp
@@ -3875,6 +3875,9 @@ void SelectionDAGBuilder::visitSelect(const User &I) {
     case SPF_SMAX:    Opc = ISD::SMAX; break;
     case SPF_SMIN:    Opc = ISD::SMIN; break;
     case SPF_FMINNUM:
+      if (!TLI.isProfitableToCombineMinNumMaxNum(VT))
+        break;
+
       switch (SPR.NaNBehavior) {
       case SPNB_NA: llvm_unreachable("No NaN behavior for FP op?");
       case SPNB_RETURNS_NAN: break;
@@ -3891,6 +3894,9 @@ void SelectionDAGBuilder::visitSelect(const User &I) {
       }
       break;
     case SPF_FMAXNUM:
+      if (!TLI.isProfitableToCombineMinNumMaxNum(VT))
+        break;
+
       switch (SPR.NaNBehavior) {
       case SPNB_NA: llvm_unreachable("No NaN behavior for FP op?");
       case SPNB_RETURNS_NAN: break;

--- a/llvm/lib/Target/WebAssembly/WebAssemblyISelLowering.h
+++ b/llvm/lib/Target/WebAssembly/WebAssemblyISelLowering.h
@@ -75,6 +75,12 @@ private:
   bool isFMAFasterThanFMulAndFAdd(const MachineFunction &MF,
                                   EVT VT) const override;
 
+  bool isProfitableToCombineMinNumMaxNum(EVT VT) const override {
+    // Prefer leaving cmp + select alone to form pmin/pmax,
+    // or relaxed_fmin/relaxed_fmax with appropriate FMF.
+    return false;
+  }
+
   SDValue LowerCall(CallLoweringInfo &CLI,
                     SmallVectorImpl<SDValue> &InVals) const override;
   bool CanLowerReturn(CallingConv::ID CallConv, MachineFunction &MF,

--- a/llvm/test/CodeGen/WebAssembly/simd-relaxed-fmax.ll
+++ b/llvm/test/CodeGen/WebAssembly/simd-relaxed-fmax.ll
@@ -359,29 +359,8 @@ define <4 x float> @pmax_v4f32_fast_olt(<4 x float> %x, <4 x float> %y) {
 ; CHECK:         .functype pmax_v4f32_fast_olt (v128, v128) -> (v128)
 ; CHECK-NEXT:  # %bb.0:
 ; CHECK-NEXT:    local.get 0
-; CHECK-NEXT:    f32x4.extract_lane 0
 ; CHECK-NEXT:    local.get 1
-; CHECK-NEXT:    f32x4.extract_lane 0
-; CHECK-NEXT:    call fmaxf
-; CHECK-NEXT:    f32x4.splat
-; CHECK-NEXT:    local.get 0
-; CHECK-NEXT:    f32x4.extract_lane 1
-; CHECK-NEXT:    local.get 1
-; CHECK-NEXT:    f32x4.extract_lane 1
-; CHECK-NEXT:    call fmaxf
-; CHECK-NEXT:    f32x4.replace_lane 1
-; CHECK-NEXT:    local.get 0
-; CHECK-NEXT:    f32x4.extract_lane 2
-; CHECK-NEXT:    local.get 1
-; CHECK-NEXT:    f32x4.extract_lane 2
-; CHECK-NEXT:    call fmaxf
-; CHECK-NEXT:    f32x4.replace_lane 2
-; CHECK-NEXT:    local.get 0
-; CHECK-NEXT:    f32x4.extract_lane 3
-; CHECK-NEXT:    local.get 1
-; CHECK-NEXT:    f32x4.extract_lane 3
-; CHECK-NEXT:    call fmaxf
-; CHECK-NEXT:    f32x4.replace_lane 3
+; CHECK-NEXT:    f32x4.pmax
 ; CHECK-NEXT:    # fallthrough-return
   %c = fcmp fast olt <4 x float> %x, %y
   %a = select <4 x i1> %c, <4 x float> %y, <4 x float> %x
@@ -408,29 +387,8 @@ define <4 x float> @test_pmax_v4f32_fast_ogt(<4 x float> %x, <4 x float> %y) {
 ; CHECK:         .functype test_pmax_v4f32_fast_ogt (v128, v128) -> (v128)
 ; CHECK-NEXT:  # %bb.0:
 ; CHECK-NEXT:    local.get 0
-; CHECK-NEXT:    f32x4.extract_lane 0
 ; CHECK-NEXT:    local.get 1
-; CHECK-NEXT:    f32x4.extract_lane 0
-; CHECK-NEXT:    call fmaxf
-; CHECK-NEXT:    f32x4.splat
-; CHECK-NEXT:    local.get 0
-; CHECK-NEXT:    f32x4.extract_lane 1
-; CHECK-NEXT:    local.get 1
-; CHECK-NEXT:    f32x4.extract_lane 1
-; CHECK-NEXT:    call fmaxf
-; CHECK-NEXT:    f32x4.replace_lane 1
-; CHECK-NEXT:    local.get 0
-; CHECK-NEXT:    f32x4.extract_lane 2
-; CHECK-NEXT:    local.get 1
-; CHECK-NEXT:    f32x4.extract_lane 2
-; CHECK-NEXT:    call fmaxf
-; CHECK-NEXT:    f32x4.replace_lane 2
-; CHECK-NEXT:    local.get 0
-; CHECK-NEXT:    f32x4.extract_lane 3
-; CHECK-NEXT:    local.get 1
-; CHECK-NEXT:    f32x4.extract_lane 3
-; CHECK-NEXT:    call fmaxf
-; CHECK-NEXT:    f32x4.replace_lane 3
+; CHECK-NEXT:    f32x4.pmax
 ; CHECK-NEXT:    # fallthrough-return
   %c = fcmp fast ogt <4 x float> %x, %y
   %a = select <4 x i1> %c, <4 x float> %x, <4 x float> %y
@@ -523,17 +481,8 @@ define <2 x double> @pmax_v2f64_fast_olt(<2 x double> %x, <2 x double> %y) {
 ; CHECK:         .functype pmax_v2f64_fast_olt (v128, v128) -> (v128)
 ; CHECK-NEXT:  # %bb.0:
 ; CHECK-NEXT:    local.get 0
-; CHECK-NEXT:    f64x2.extract_lane 0
 ; CHECK-NEXT:    local.get 1
-; CHECK-NEXT:    f64x2.extract_lane 0
-; CHECK-NEXT:    call fmax
-; CHECK-NEXT:    f64x2.splat
-; CHECK-NEXT:    local.get 0
-; CHECK-NEXT:    f64x2.extract_lane 1
-; CHECK-NEXT:    local.get 1
-; CHECK-NEXT:    f64x2.extract_lane 1
-; CHECK-NEXT:    call fmax
-; CHECK-NEXT:    f64x2.replace_lane 1
+; CHECK-NEXT:    f64x2.pmax
 ; CHECK-NEXT:    # fallthrough-return
   %c = fcmp fast olt <2 x double> %x, %y
   %a = select <2 x i1> %c, <2 x double> %y, <2 x double> %x
@@ -559,17 +508,8 @@ define <2 x double> @test_pmax_v2f64_fast_ogt(<2 x double> %x, <2 x double> %y) 
 ; CHECK:         .functype test_pmax_v2f64_fast_ogt (v128, v128) -> (v128)
 ; CHECK-NEXT:  # %bb.0:
 ; CHECK-NEXT:    local.get 0
-; CHECK-NEXT:    f64x2.extract_lane 0
 ; CHECK-NEXT:    local.get 1
-; CHECK-NEXT:    f64x2.extract_lane 0
-; CHECK-NEXT:    call fmax
-; CHECK-NEXT:    f64x2.splat
-; CHECK-NEXT:    local.get 0
-; CHECK-NEXT:    f64x2.extract_lane 1
-; CHECK-NEXT:    local.get 1
-; CHECK-NEXT:    f64x2.extract_lane 1
-; CHECK-NEXT:    call fmax
-; CHECK-NEXT:    f64x2.replace_lane 1
+; CHECK-NEXT:    f64x2.pmax
 ; CHECK-NEXT:    # fallthrough-return
   %c = fcmp fast ogt <2 x double> %x, %y
   %a = select <2 x i1> %c, <2 x double> %x, <2 x double> %y
@@ -663,29 +603,8 @@ define <4 x float> @pmax_v4f32_fast_ult(<4 x float> %x, <4 x float> %y) {
 ; CHECK:         .functype pmax_v4f32_fast_ult (v128, v128) -> (v128)
 ; CHECK-NEXT:  # %bb.0:
 ; CHECK-NEXT:    local.get 0
-; CHECK-NEXT:    f32x4.extract_lane 0
 ; CHECK-NEXT:    local.get 1
-; CHECK-NEXT:    f32x4.extract_lane 0
-; CHECK-NEXT:    call fmaxf
-; CHECK-NEXT:    f32x4.splat
-; CHECK-NEXT:    local.get 0
-; CHECK-NEXT:    f32x4.extract_lane 1
-; CHECK-NEXT:    local.get 1
-; CHECK-NEXT:    f32x4.extract_lane 1
-; CHECK-NEXT:    call fmaxf
-; CHECK-NEXT:    f32x4.replace_lane 1
-; CHECK-NEXT:    local.get 0
-; CHECK-NEXT:    f32x4.extract_lane 2
-; CHECK-NEXT:    local.get 1
-; CHECK-NEXT:    f32x4.extract_lane 2
-; CHECK-NEXT:    call fmaxf
-; CHECK-NEXT:    f32x4.replace_lane 2
-; CHECK-NEXT:    local.get 0
-; CHECK-NEXT:    f32x4.extract_lane 3
-; CHECK-NEXT:    local.get 1
-; CHECK-NEXT:    f32x4.extract_lane 3
-; CHECK-NEXT:    call fmaxf
-; CHECK-NEXT:    f32x4.replace_lane 3
+; CHECK-NEXT:    f32x4.pmax
 ; CHECK-NEXT:    # fallthrough-return
   %c = fcmp fast ult <4 x float> %x, %y
   %a = select <4 x i1> %c, <4 x float> %y, <4 x float> %x
@@ -712,29 +631,8 @@ define <4 x float> @test_pmax_v4f32_fast_ugt(<4 x float> %x, <4 x float> %y) {
 ; CHECK:         .functype test_pmax_v4f32_fast_ugt (v128, v128) -> (v128)
 ; CHECK-NEXT:  # %bb.0:
 ; CHECK-NEXT:    local.get 0
-; CHECK-NEXT:    f32x4.extract_lane 0
 ; CHECK-NEXT:    local.get 1
-; CHECK-NEXT:    f32x4.extract_lane 0
-; CHECK-NEXT:    call fmaxf
-; CHECK-NEXT:    f32x4.splat
-; CHECK-NEXT:    local.get 0
-; CHECK-NEXT:    f32x4.extract_lane 1
-; CHECK-NEXT:    local.get 1
-; CHECK-NEXT:    f32x4.extract_lane 1
-; CHECK-NEXT:    call fmaxf
-; CHECK-NEXT:    f32x4.replace_lane 1
-; CHECK-NEXT:    local.get 0
-; CHECK-NEXT:    f32x4.extract_lane 2
-; CHECK-NEXT:    local.get 1
-; CHECK-NEXT:    f32x4.extract_lane 2
-; CHECK-NEXT:    call fmaxf
-; CHECK-NEXT:    f32x4.replace_lane 2
-; CHECK-NEXT:    local.get 0
-; CHECK-NEXT:    f32x4.extract_lane 3
-; CHECK-NEXT:    local.get 1
-; CHECK-NEXT:    f32x4.extract_lane 3
-; CHECK-NEXT:    call fmaxf
-; CHECK-NEXT:    f32x4.replace_lane 3
+; CHECK-NEXT:    f32x4.pmax
 ; CHECK-NEXT:    # fallthrough-return
   %c = fcmp fast ugt <4 x float> %x, %y
   %a = select <4 x i1> %c, <4 x float> %x, <4 x float> %y
@@ -831,17 +729,8 @@ define <2 x double> @pmax_v2f64_fast_ult(<2 x double> %x, <2 x double> %y) {
 ; CHECK:         .functype pmax_v2f64_fast_ult (v128, v128) -> (v128)
 ; CHECK-NEXT:  # %bb.0:
 ; CHECK-NEXT:    local.get 0
-; CHECK-NEXT:    f64x2.extract_lane 0
 ; CHECK-NEXT:    local.get 1
-; CHECK-NEXT:    f64x2.extract_lane 0
-; CHECK-NEXT:    call fmax
-; CHECK-NEXT:    f64x2.splat
-; CHECK-NEXT:    local.get 0
-; CHECK-NEXT:    f64x2.extract_lane 1
-; CHECK-NEXT:    local.get 1
-; CHECK-NEXT:    f64x2.extract_lane 1
-; CHECK-NEXT:    call fmax
-; CHECK-NEXT:    f64x2.replace_lane 1
+; CHECK-NEXT:    f64x2.pmax
 ; CHECK-NEXT:    # fallthrough-return
   %c = fcmp fast ult <2 x double> %x, %y
   %a = select <2 x i1> %c, <2 x double> %y, <2 x double> %x
@@ -867,17 +756,8 @@ define <2 x double> @test_pmax_v2f64_fast_ugt(<2 x double> %x, <2 x double> %y) 
 ; CHECK:         .functype test_pmax_v2f64_fast_ugt (v128, v128) -> (v128)
 ; CHECK-NEXT:  # %bb.0:
 ; CHECK-NEXT:    local.get 0
-; CHECK-NEXT:    f64x2.extract_lane 0
 ; CHECK-NEXT:    local.get 1
-; CHECK-NEXT:    f64x2.extract_lane 0
-; CHECK-NEXT:    call fmax
-; CHECK-NEXT:    f64x2.splat
-; CHECK-NEXT:    local.get 0
-; CHECK-NEXT:    f64x2.extract_lane 1
-; CHECK-NEXT:    local.get 1
-; CHECK-NEXT:    f64x2.extract_lane 1
-; CHECK-NEXT:    call fmax
-; CHECK-NEXT:    f64x2.replace_lane 1
+; CHECK-NEXT:    f64x2.pmax
 ; CHECK-NEXT:    # fallthrough-return
   %c = fcmp fast ugt <2 x double> %x, %y
   %a = select <2 x i1> %c, <2 x double> %x, <2 x double> %y
@@ -946,8 +826,8 @@ define <4 x float> @test_pmax_v4f32_ogt_nsz_nnan(<4 x float> %x, <4 x float> %y)
 ; CHECK-LABEL: test_pmax_v4f32_ogt_nsz_nnan:
 ; CHECK:         .functype test_pmax_v4f32_ogt_nsz_nnan (v128, v128) -> (v128)
 ; CHECK-NEXT:  # %bb.0:
-; CHECK-NEXT:    local.get 1
 ; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    local.get 1
 ; CHECK-NEXT:    f32x4.relaxed_max
 ; CHECK-NEXT:    # fallthrough-return
   %c = fcmp ogt <4 x float> %y, %x
@@ -959,8 +839,8 @@ define <4 x float> @test_pmax_v4f32_oge_nsz_nnan(<4 x float> %x, <4 x float> %y)
 ; CHECK-LABEL: test_pmax_v4f32_oge_nsz_nnan:
 ; CHECK:         .functype test_pmax_v4f32_oge_nsz_nnan (v128, v128) -> (v128)
 ; CHECK-NEXT:  # %bb.0:
-; CHECK-NEXT:    local.get 1
 ; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    local.get 1
 ; CHECK-NEXT:    f32x4.relaxed_max
 ; CHECK-NEXT:    # fallthrough-return
   %c = fcmp oge <4 x float> %y, %x
@@ -1083,8 +963,8 @@ define <4 x float> @test_pmax_v4f32_ult_nsz_nnan(<4 x float> %x, <4 x float> %y)
 ; CHECK-LABEL: test_pmax_v4f32_ult_nsz_nnan:
 ; CHECK:         .functype test_pmax_v4f32_ult_nsz_nnan (v128, v128) -> (v128)
 ; CHECK-NEXT:  # %bb.0:
-; CHECK-NEXT:    local.get 0
 ; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    local.get 0
 ; CHECK-NEXT:    f32x4.relaxed_max
 ; CHECK-NEXT:    # fallthrough-return
   %c = fcmp ult <4 x float> %x, %y
@@ -1096,8 +976,8 @@ define <4 x float> @test_pmax_v4f32_ule_nsz_nnan(<4 x float> %x, <4 x float> %y)
 ; CHECK-LABEL: test_pmax_v4f32_ule_nsz_nnan:
 ; CHECK:         .functype test_pmax_v4f32_ule_nsz_nnan (v128, v128) -> (v128)
 ; CHECK-NEXT:  # %bb.0:
-; CHECK-NEXT:    local.get 0
 ; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    local.get 0
 ; CHECK-NEXT:    f32x4.relaxed_max
 ; CHECK-NEXT:    # fallthrough-return
   %c = fcmp ule <4 x float> %x, %y

--- a/llvm/test/CodeGen/WebAssembly/simd-relaxed-fmin.ll
+++ b/llvm/test/CodeGen/WebAssembly/simd-relaxed-fmin.ll
@@ -356,29 +356,8 @@ define <4 x float> @pmin_v4f32_fast_olt(<4 x float> %x, <4 x float> %y) {
 ; CHECK:         .functype pmin_v4f32_fast_olt (v128, v128) -> (v128)
 ; CHECK-NEXT:  # %bb.0:
 ; CHECK-NEXT:    local.get 1
-; CHECK-NEXT:    f32x4.extract_lane 0
 ; CHECK-NEXT:    local.get 0
-; CHECK-NEXT:    f32x4.extract_lane 0
-; CHECK-NEXT:    call fminf
-; CHECK-NEXT:    f32x4.splat
-; CHECK-NEXT:    local.get 1
-; CHECK-NEXT:    f32x4.extract_lane 1
-; CHECK-NEXT:    local.get 0
-; CHECK-NEXT:    f32x4.extract_lane 1
-; CHECK-NEXT:    call fminf
-; CHECK-NEXT:    f32x4.replace_lane 1
-; CHECK-NEXT:    local.get 1
-; CHECK-NEXT:    f32x4.extract_lane 2
-; CHECK-NEXT:    local.get 0
-; CHECK-NEXT:    f32x4.extract_lane 2
-; CHECK-NEXT:    call fminf
-; CHECK-NEXT:    f32x4.replace_lane 2
-; CHECK-NEXT:    local.get 1
-; CHECK-NEXT:    f32x4.extract_lane 3
-; CHECK-NEXT:    local.get 0
-; CHECK-NEXT:    f32x4.extract_lane 3
-; CHECK-NEXT:    call fminf
-; CHECK-NEXT:    f32x4.replace_lane 3
+; CHECK-NEXT:    f32x4.pmin
 ; CHECK-NEXT:    # fallthrough-return
   %c = fcmp fast olt <4 x float> %y, %x
   %a = select <4 x i1> %c, <4 x float> %y, <4 x float> %x
@@ -405,29 +384,8 @@ define <4 x float> @test_pmin_v4f32_fast_ogt(<4 x float> %x, <4 x float> %y) {
 ; CHECK:         .functype test_pmin_v4f32_fast_ogt (v128, v128) -> (v128)
 ; CHECK-NEXT:  # %bb.0:
 ; CHECK-NEXT:    local.get 0
-; CHECK-NEXT:    f32x4.extract_lane 0
 ; CHECK-NEXT:    local.get 1
-; CHECK-NEXT:    f32x4.extract_lane 0
-; CHECK-NEXT:    call fminf
-; CHECK-NEXT:    f32x4.splat
-; CHECK-NEXT:    local.get 0
-; CHECK-NEXT:    f32x4.extract_lane 1
-; CHECK-NEXT:    local.get 1
-; CHECK-NEXT:    f32x4.extract_lane 1
-; CHECK-NEXT:    call fminf
-; CHECK-NEXT:    f32x4.replace_lane 1
-; CHECK-NEXT:    local.get 0
-; CHECK-NEXT:    f32x4.extract_lane 2
-; CHECK-NEXT:    local.get 1
-; CHECK-NEXT:    f32x4.extract_lane 2
-; CHECK-NEXT:    call fminf
-; CHECK-NEXT:    f32x4.replace_lane 2
-; CHECK-NEXT:    local.get 0
-; CHECK-NEXT:    f32x4.extract_lane 3
-; CHECK-NEXT:    local.get 1
-; CHECK-NEXT:    f32x4.extract_lane 3
-; CHECK-NEXT:    call fminf
-; CHECK-NEXT:    f32x4.replace_lane 3
+; CHECK-NEXT:    f32x4.pmin
 ; CHECK-NEXT:    # fallthrough-return
   %c = fcmp fast ogt <4 x float> %x, %y
   %a = select <4 x i1> %c, <4 x float> %y, <4 x float> %x
@@ -521,17 +479,8 @@ define <2 x double> @pmin_v2f64_fast_olt(<2 x double> %x, <2 x double> %y) {
 ; CHECK:         .functype pmin_v2f64_fast_olt (v128, v128) -> (v128)
 ; CHECK-NEXT:  # %bb.0:
 ; CHECK-NEXT:    local.get 1
-; CHECK-NEXT:    f64x2.extract_lane 0
 ; CHECK-NEXT:    local.get 0
-; CHECK-NEXT:    f64x2.extract_lane 0
-; CHECK-NEXT:    call fmin
-; CHECK-NEXT:    f64x2.splat
-; CHECK-NEXT:    local.get 1
-; CHECK-NEXT:    f64x2.extract_lane 1
-; CHECK-NEXT:    local.get 0
-; CHECK-NEXT:    f64x2.extract_lane 1
-; CHECK-NEXT:    call fmin
-; CHECK-NEXT:    f64x2.replace_lane 1
+; CHECK-NEXT:    f64x2.pmin
 ; CHECK-NEXT:    # fallthrough-return
   %c = fcmp fast olt <2 x double> %y, %x
   %a = select <2 x i1> %c, <2 x double> %y, <2 x double> %x
@@ -558,17 +507,8 @@ define <2 x double> @test_pmin_v2f64_fast_ogt(<2 x double> %x, <2 x double> %y) 
 ; CHECK:         .functype test_pmin_v2f64_fast_ogt (v128, v128) -> (v128)
 ; CHECK-NEXT:  # %bb.0:
 ; CHECK-NEXT:    local.get 0
-; CHECK-NEXT:    f64x2.extract_lane 0
 ; CHECK-NEXT:    local.get 1
-; CHECK-NEXT:    f64x2.extract_lane 0
-; CHECK-NEXT:    call fmin
-; CHECK-NEXT:    f64x2.splat
-; CHECK-NEXT:    local.get 0
-; CHECK-NEXT:    f64x2.extract_lane 1
-; CHECK-NEXT:    local.get 1
-; CHECK-NEXT:    f64x2.extract_lane 1
-; CHECK-NEXT:    call fmin
-; CHECK-NEXT:    f64x2.replace_lane 1
+; CHECK-NEXT:    f64x2.pmin
 ; CHECK-NEXT:    # fallthrough-return
   %c = fcmp fast ogt <2 x double> %x, %y
   %a = select <2 x i1> %c, <2 x double> %y, <2 x double> %x
@@ -662,29 +602,8 @@ define <4 x float> @pmin_v4f32_fast_ult(<4 x float> %x, <4 x float> %y) {
 ; CHECK:         .functype pmin_v4f32_fast_ult (v128, v128) -> (v128)
 ; CHECK-NEXT:  # %bb.0:
 ; CHECK-NEXT:    local.get 1
-; CHECK-NEXT:    f32x4.extract_lane 0
 ; CHECK-NEXT:    local.get 0
-; CHECK-NEXT:    f32x4.extract_lane 0
-; CHECK-NEXT:    call fminf
-; CHECK-NEXT:    f32x4.splat
-; CHECK-NEXT:    local.get 1
-; CHECK-NEXT:    f32x4.extract_lane 1
-; CHECK-NEXT:    local.get 0
-; CHECK-NEXT:    f32x4.extract_lane 1
-; CHECK-NEXT:    call fminf
-; CHECK-NEXT:    f32x4.replace_lane 1
-; CHECK-NEXT:    local.get 1
-; CHECK-NEXT:    f32x4.extract_lane 2
-; CHECK-NEXT:    local.get 0
-; CHECK-NEXT:    f32x4.extract_lane 2
-; CHECK-NEXT:    call fminf
-; CHECK-NEXT:    f32x4.replace_lane 2
-; CHECK-NEXT:    local.get 1
-; CHECK-NEXT:    f32x4.extract_lane 3
-; CHECK-NEXT:    local.get 0
-; CHECK-NEXT:    f32x4.extract_lane 3
-; CHECK-NEXT:    call fminf
-; CHECK-NEXT:    f32x4.replace_lane 3
+; CHECK-NEXT:    f32x4.pmin
 ; CHECK-NEXT:    # fallthrough-return
   %c = fcmp fast ult <4 x float> %y, %x
   %a = select <4 x i1> %c, <4 x float> %y, <4 x float> %x
@@ -711,29 +630,8 @@ define <4 x float> @test_pmin_v4f32_fast_ugt(<4 x float> %x, <4 x float> %y) {
 ; CHECK:         .functype test_pmin_v4f32_fast_ugt (v128, v128) -> (v128)
 ; CHECK-NEXT:  # %bb.0:
 ; CHECK-NEXT:    local.get 0
-; CHECK-NEXT:    f32x4.extract_lane 0
 ; CHECK-NEXT:    local.get 1
-; CHECK-NEXT:    f32x4.extract_lane 0
-; CHECK-NEXT:    call fminf
-; CHECK-NEXT:    f32x4.splat
-; CHECK-NEXT:    local.get 0
-; CHECK-NEXT:    f32x4.extract_lane 1
-; CHECK-NEXT:    local.get 1
-; CHECK-NEXT:    f32x4.extract_lane 1
-; CHECK-NEXT:    call fminf
-; CHECK-NEXT:    f32x4.replace_lane 1
-; CHECK-NEXT:    local.get 0
-; CHECK-NEXT:    f32x4.extract_lane 2
-; CHECK-NEXT:    local.get 1
-; CHECK-NEXT:    f32x4.extract_lane 2
-; CHECK-NEXT:    call fminf
-; CHECK-NEXT:    f32x4.replace_lane 2
-; CHECK-NEXT:    local.get 0
-; CHECK-NEXT:    f32x4.extract_lane 3
-; CHECK-NEXT:    local.get 1
-; CHECK-NEXT:    f32x4.extract_lane 3
-; CHECK-NEXT:    call fminf
-; CHECK-NEXT:    f32x4.replace_lane 3
+; CHECK-NEXT:    f32x4.pmin
 ; CHECK-NEXT:    # fallthrough-return
   %c = fcmp fast ugt <4 x float> %x, %y
   %a = select <4 x i1> %c, <4 x float> %y, <4 x float> %x
@@ -830,17 +728,8 @@ define <2 x double> @pmin_v2f64_fast_ult(<2 x double> %x, <2 x double> %y) {
 ; CHECK:         .functype pmin_v2f64_fast_ult (v128, v128) -> (v128)
 ; CHECK-NEXT:  # %bb.0:
 ; CHECK-NEXT:    local.get 1
-; CHECK-NEXT:    f64x2.extract_lane 0
 ; CHECK-NEXT:    local.get 0
-; CHECK-NEXT:    f64x2.extract_lane 0
-; CHECK-NEXT:    call fmin
-; CHECK-NEXT:    f64x2.splat
-; CHECK-NEXT:    local.get 1
-; CHECK-NEXT:    f64x2.extract_lane 1
-; CHECK-NEXT:    local.get 0
-; CHECK-NEXT:    f64x2.extract_lane 1
-; CHECK-NEXT:    call fmin
-; CHECK-NEXT:    f64x2.replace_lane 1
+; CHECK-NEXT:    f64x2.pmin
 ; CHECK-NEXT:    # fallthrough-return
   %c = fcmp fast ult <2 x double> %y, %x
   %a = select <2 x i1> %c, <2 x double> %y, <2 x double> %x
@@ -867,17 +756,8 @@ define <2 x double> @test_pmin_v2f64_fast_ugt(<2 x double> %x, <2 x double> %y) 
 ; CHECK:         .functype test_pmin_v2f64_fast_ugt (v128, v128) -> (v128)
 ; CHECK-NEXT:  # %bb.0:
 ; CHECK-NEXT:    local.get 0
-; CHECK-NEXT:    f64x2.extract_lane 0
 ; CHECK-NEXT:    local.get 1
-; CHECK-NEXT:    f64x2.extract_lane 0
-; CHECK-NEXT:    call fmin
-; CHECK-NEXT:    f64x2.splat
-; CHECK-NEXT:    local.get 0
-; CHECK-NEXT:    f64x2.extract_lane 1
-; CHECK-NEXT:    local.get 1
-; CHECK-NEXT:    f64x2.extract_lane 1
-; CHECK-NEXT:    call fmin
-; CHECK-NEXT:    f64x2.replace_lane 1
+; CHECK-NEXT:    f64x2.pmin
 ; CHECK-NEXT:    # fallthrough-return
   %c = fcmp fast ugt <2 x double> %x, %y
   %a = select <2 x i1> %c, <2 x double> %y, <2 x double> %x
@@ -946,8 +826,8 @@ define <4 x float> @test_pmin_v4f32_ugt_nsz_nnan(<4 x float> %x, <4 x float> %y)
 ; CHECK-LABEL: test_pmin_v4f32_ugt_nsz_nnan:
 ; CHECK:         .functype test_pmin_v4f32_ugt_nsz_nnan (v128, v128) -> (v128)
 ; CHECK-NEXT:  # %bb.0:
-; CHECK-NEXT:    local.get 0
 ; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    local.get 0
 ; CHECK-NEXT:    f32x4.relaxed_min
 ; CHECK-NEXT:    # fallthrough-return
   %c = fcmp ugt <4 x float> %x, %y
@@ -959,8 +839,8 @@ define <4 x float> @test_pmin_v4f32_uge_nsz_nnan(<4 x float> %x, <4 x float> %y)
 ; CHECK-LABEL: test_pmin_v4f32_uge_nsz_nnan:
 ; CHECK:         .functype test_pmin_v4f32_uge_nsz_nnan (v128, v128) -> (v128)
 ; CHECK-NEXT:  # %bb.0:
-; CHECK-NEXT:    local.get 0
 ; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    local.get 0
 ; CHECK-NEXT:    f32x4.relaxed_min
 ; CHECK-NEXT:    # fallthrough-return
   %c = fcmp uge <4 x float> %x, %y
@@ -1054,8 +934,8 @@ define <2 x double> @test_pmin_v2f64_ugt_nsz_nnan(<2 x double> %x, <2 x double> 
 ; CHECK-LABEL: test_pmin_v2f64_ugt_nsz_nnan:
 ; CHECK:         .functype test_pmin_v2f64_ugt_nsz_nnan (v128, v128) -> (v128)
 ; CHECK-NEXT:  # %bb.0:
-; CHECK-NEXT:    local.get 0
 ; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    local.get 0
 ; CHECK-NEXT:    f64x2.relaxed_min
 ; CHECK-NEXT:    # fallthrough-return
   %c = fcmp ugt <2 x double> %x, %y
@@ -1067,8 +947,8 @@ define <2 x double> @test_pmin_v2f64_uge_nsz_nnan(<2 x double> %x, <2 x double> 
 ; CHECK-LABEL: test_pmin_v2f64_uge_nsz_nnan:
 ; CHECK:         .functype test_pmin_v2f64_uge_nsz_nnan (v128, v128) -> (v128)
 ; CHECK-NEXT:  # %bb.0:
-; CHECK-NEXT:    local.get 0
 ; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    local.get 0
 ; CHECK-NEXT:    f64x2.relaxed_min
 ; CHECK-NEXT:    # fallthrough-return
   %c = fcmp uge <2 x double> %x, %y


### PR DESCRIPTION
For wasm, forming minnum/maxnum style ISD nodes is non-profitable, because (in cases where any float min/max support exists at all), it has pmin/pmax instructions that correspond to the fcmp+select semantics, or relaxed_fmin/relaxed_fmax (for the nnan+nsz case) with even loser semantics.

As such, return false from isProfitableToCombineMinNumMaxNum(), and also respect that hook in the SDAGBuilder.