### PR TITLE
[SPIRV] In G_SELECT selection path: replace `removeFromParent` with `eraseFromParent` and return early 

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
@@ -794,18 +794,20 @@ bool SPIRVInstructionSelector::select(MachineInstr &I) {
       if (isTypeFoldingSupported(Def->getOpcode()) &&
           Def->getOpcode() != TargetOpcode::G_CONSTANT &&
           Def->getOpcode() != TargetOpcode::G_FCONSTANT) {
-        bool Res = false;
         if (Def->getOpcode() == TargetOpcode::G_SELECT) {
           Register SelectDstReg = Def->getOperand(0).getReg();
-          Res = selectSelect(SelectDstReg, GR.getSPIRVTypeForVReg(SelectDstReg),
-                             *Def);
+          bool SuccessToSelectSelect [[maybe_unused]] = selectSelect(
+              SelectDstReg, GR.getSPIRVTypeForVReg(SelectDstReg), *Def);
+          assert(SuccessToSelectSelect);
           GR.invalidateMachineInstr(Def);
-          Def->removeFromParent();
+          Def->eraseFromParent();
           MRI->replaceRegWith(DstReg, SelectDstReg);
           GR.invalidateMachineInstr(&I);
-          I.removeFromParent();
-        } else
-          Res = selectImpl(I, *CoverageInfo);
+          I.eraseFromParent();
+          return true;
+        }
+
+        bool Res = selectImpl(I, *CoverageInfo);
         LLVM_DEBUG({
           if (!Res && Def->getOpcode() != TargetOpcode::G_CONSTANT) {
             dbgs() << "Unexpected pattern in ASSIGN_TYPE.\nInstruction: ";


### PR DESCRIPTION
When selecting an `ASSIGN_TYPE` of a `G_SELECT`, both instructions were removed but not erased.

The code followed on a code path where the replaced G_SELECT would be added to a remove set if it was dead. But the select is not in the function anymore since it is already removed!

Selecting a `selectSelect` always returns `true`. So the assertions/prints below would have never been triggered.

This patch simplifies this code path to avoid falling through the asserts and paths where `selectSelect` could have failed (which trivially doesn't happen).

Guarded `selectSelect` return with an assert in case it changes.

Follow up of https://github.com/llvm/llvm-project/pull/182330