### PR TITLE
[ClangIncludeCleaner] Disable PCH

### DIFF
--- a/clang-tools-extra/include-cleaner/lib/CMakeLists.txt
+++ b/clang-tools-extra/include-cleaner/lib/CMakeLists.txt
@@ -12,6 +12,9 @@ add_clang_library(clangIncludeCleaner STATIC
 
   DEPENDS
   ClangDriverOptions
+
+  # Workaround for Clang bug: https://github.com/llvm/llvm-project/issues/184559
+  DISABLE_PCH_REUSE
   )
 
 clang_target_link_libraries(clangIncludeCleaner


### PR DESCRIPTION
Workaround a Clang bug w.r.t. instantiation of inline functions.

See: https://github.com/llvm/llvm-project/issues/184559.