### PR TITLE
[llvm-otool] Fix -arch flag for universal binary slice selection

### DIFF
--- a/llvm/test/tools/llvm-objdump/MachO/otool-arch-flag.test
+++ b/llvm/test/tools/llvm-objdump/MachO/otool-arch-flag.test
@@ -1,0 +1,10 @@
+# Test that llvm-otool -arch selects the correct slice from a universal binary.
+
+RUN: llvm-otool -h -arch x86_64 %p/Inputs/macho-universal.x86_64.i386 \
+RUN: | FileCheck %s --check-prefix=X86_64
+
+RUN: llvm-otool -h -arch i386 %p/Inputs/macho-universal.x86_64.i386 \
+RUN: | FileCheck %s --check-prefix=I386
+
+X86_64: 0xfeedfacf
+I386:   0xfeedface

--- a/llvm/tools/llvm-objdump/MachODump.cpp
+++ b/llvm/tools/llvm-objdump/MachODump.cpp
@@ -82,7 +82,7 @@ bool objdump::ObjcMetaData;
 std::string objdump::DisSymName;
 bool objdump::IsOtool;
 bool objdump::SymbolicOperands;
-static std::vector<std::string> ArchFlags;
+std::vector<std::string> objdump::ArchFlags;
 
 static bool ArchAll = false;
 static std::string ThumbTripleName;

--- a/llvm/tools/llvm-objdump/MachODump.h
+++ b/llvm/tools/llvm-objdump/MachODump.h
@@ -61,6 +61,7 @@ extern bool SymbolicOperands;
 extern bool UniversalHeaders;
 extern bool Verbose;
 extern bool WeakBind;
+extern std::vector<std::string> ArchFlags;
 
 Error getMachORelocationValueString(const object::MachOObjectFile *Obj,
                                     const object::RelocationRef &RelRef,

--- a/llvm/tools/llvm-objdump/llvm-objdump.cpp
+++ b/llvm/tools/llvm-objdump/llvm-objdump.cpp
@@ -3658,6 +3658,8 @@ static void parseOtoolOptions(const llvm::opt::InputArgList &InputArgs) {
   PrintImmHex = true;
 
   ArchName = InputArgs.getLastArgValue(OTOOL_arch).str();
+  if (!ArchName.empty())
+    ArchFlags.push_back(ArchName);
   LinkOptHints = InputArgs.hasArg(OTOOL_C);
   if (InputArgs.hasArg(OTOOL_d))
     FilterSections.push_back("__DATA,__data");


### PR DESCRIPTION
In otool mode, -arch was only used for disassembler target selection but not for picking the right slice from a universal binary.