### PR TITLE
[AArch64] Add sanitazation when custom lowering fp partial reduce

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
@@ -3591,7 +3591,8 @@ MachineBasicBlock *AArch64TargetLowering::EmitInstrWithCustomInserter(
 
 // Forward declarations of SVE fixed length lowering helpers
 static EVT getContainerForFixedLengthVector(SelectionDAG &DAG, EVT VT);
-static SDValue convertToScalableVector(SelectionDAG &DAG, EVT VT, SDValue V);
+static SDValue convertToScalableVector(SelectionDAG &DAG, EVT VT, SDValue V,
+                                       bool clearUnused = false);
 static SDValue convertFromScalableVector(SelectionDAG &DAG, EVT VT, SDValue V);
 static SDValue convertFixedMaskToScalableVector(SDValue Mask,
                                                 SelectionDAG &DAG);
@@ -31416,14 +31417,18 @@ static SDValue getPredicateForVector(SelectionDAG &DAG, SDLoc &DL, EVT VT) {
 }
 
 // Grow V to consume an entire SVE register.
-static SDValue convertToScalableVector(SelectionDAG &DAG, EVT VT, SDValue V) {
+static SDValue convertToScalableVector(SelectionDAG &DAG, EVT VT, SDValue V,
+                                       bool clearUnused) {
   assert(VT.isScalableVector() &&
          "Expected to convert into a scalable vector!");
   assert(V.getValueType().isFixedLengthVector() &&
          "Expected a fixed length vector operand!");
   SDLoc DL(V);
   SDValue Zero = DAG.getConstant(0, DL, MVT::i64);
-  return DAG.getNode(ISD::INSERT_SUBVECTOR, DL, VT, DAG.getPOISON(VT), V, Zero);
+  SDValue ZeroVec = VT.isFloatingPoint() ? DAG.getConstantFP(0, DL, VT)
+                                         : DAG.getConstant(0, DL, VT);
+  return DAG.getNode(ISD::INSERT_SUBVECTOR, DL, VT,
+                     clearUnused ? ZeroVec : DAG.getPOISON(VT), V, Zero);
 }
 
 // Shrink V so it's just big enough to maintain a VT's worth of data.
@@ -32590,9 +32595,10 @@ AArch64TargetLowering::LowerPARTIAL_REDUCE_MLA(SDValue Op,
   if (ConvertToScalable) {
     ResultVT = getContainerForFixedLengthVector(DAG, ResultVT);
     OpVT = getContainerForFixedLengthVector(DAG, LHS.getValueType());
-    Acc = convertToScalableVector(DAG, ResultVT, Acc);
-    LHS = convertToScalableVector(DAG, OpVT, LHS);
-    RHS = convertToScalableVector(DAG, OpVT, RHS);
+    Acc =
+        convertToScalableVector(DAG, ResultVT, Acc, ResultVT.isFloatingPoint());
+    LHS = convertToScalableVector(DAG, OpVT, LHS, OpVT.isFloatingPoint());
+    RHS = convertToScalableVector(DAG, OpVT, RHS, OpVT.isFloatingPoint());
     Op = DAG.getNode(Op.getOpcode(), DL, ResultVT, {Acc, LHS, RHS});
   }
 

--- a/llvm/test/CodeGen/AArch64/clmul-fixed.ll
+++ b/llvm/test/CodeGen/AArch64/clmul-fixed.ll
@@ -1728,21 +1728,21 @@ define <1 x i128> @clmul_v1i128_neon(<1 x i128> %x, <1 x i128> %y) {
 ; CHECK-AES:       // %bb.0:
 ; CHECK-AES-NEXT:    rbit x8, x2
 ; CHECK-AES-NEXT:    rbit x9, x0
-; CHECK-AES-NEXT:    fmov d0, x2
-; CHECK-AES-NEXT:    fmov d1, x1
-; CHECK-AES-NEXT:    fmov d2, x3
+; CHECK-AES-NEXT:    fmov d0, x3
+; CHECK-AES-NEXT:    fmov d1, x0
+; CHECK-AES-NEXT:    fmov d2, x2
 ; CHECK-AES-NEXT:    fmov d3, x8
 ; CHECK-AES-NEXT:    fmov d4, x9
-; CHECK-AES-NEXT:    pmull v1.1q, v1.1d, v0.1d
+; CHECK-AES-NEXT:    pmull v0.1q, v1.1d, v0.1d
 ; CHECK-AES-NEXT:    pmull v3.1q, v4.1d, v3.1d
-; CHECK-AES-NEXT:    fmov d4, x0
-; CHECK-AES-NEXT:    pmull v2.1q, v4.1d, v2.1d
-; CHECK-AES-NEXT:    fmov x9, d1
+; CHECK-AES-NEXT:    fmov d4, x1
+; CHECK-AES-NEXT:    pmull v1.1q, v1.1d, v2.1d
+; CHECK-AES-NEXT:    pmull v4.1q, v4.1d, v2.1d
+; CHECK-AES-NEXT:    fmov x10, d0
 ; CHECK-AES-NEXT:    fmov x8, d3
-; CHECK-AES-NEXT:    pmull v0.1q, v4.1d, v0.1d
-; CHECK-AES-NEXT:    fmov x10, d2
+; CHECK-AES-NEXT:    fmov x0, d1
+; CHECK-AES-NEXT:    fmov x9, d4
 ; CHECK-AES-NEXT:    rbit x8, x8
-; CHECK-AES-NEXT:    fmov x0, d0
 ; CHECK-AES-NEXT:    eor x9, x10, x9
 ; CHECK-AES-NEXT:    eor x1, x9, x8, lsr #1
 ; CHECK-AES-NEXT:    ret

--- a/llvm/test/CodeGen/AArch64/clmul.ll
+++ b/llvm/test/CodeGen/AArch64/clmul.ll
@@ -179,9 +179,9 @@ define i32 @clmul_i32(i32 %x, i32 %y) {
 ;
 ; CHECK-AES-LABEL: clmul_i32:
 ; CHECK-AES:       // %bb.0:
-; CHECK-AES-NEXT:    fmov s0, w1
-; CHECK-AES-NEXT:    fmov s1, w0
-; CHECK-AES-NEXT:    pmull v0.1q, v1.1d, v0.1d
+; CHECK-AES-NEXT:    fmov s0, w0
+; CHECK-AES-NEXT:    fmov s1, w1
+; CHECK-AES-NEXT:    pmull v0.1q, v0.1d, v1.1d
 ; CHECK-AES-NEXT:    fmov w0, s0
 ; CHECK-AES-NEXT:    ret
   %a = call i32 @llvm.clmul.i32(i32 %x, i32 %y)
@@ -573,9 +573,9 @@ define i32 @clmul_i32_zext(i16 %x, i16 %y) {
 ; CHECK-AES:       // %bb.0:
 ; CHECK-AES-NEXT:    and w8, w0, #0xffff
 ; CHECK-AES-NEXT:    and w9, w1, #0xffff
-; CHECK-AES-NEXT:    fmov s0, w9
-; CHECK-AES-NEXT:    fmov s1, w8
-; CHECK-AES-NEXT:    pmull v0.1q, v1.1d, v0.1d
+; CHECK-AES-NEXT:    fmov s0, w8
+; CHECK-AES-NEXT:    fmov s1, w9
+; CHECK-AES-NEXT:    pmull v0.1q, v0.1d, v1.1d
 ; CHECK-AES-NEXT:    fmov w0, s0
 ; CHECK-AES-NEXT:    ret
   %zextx = zext i16 %x to i32
@@ -689,9 +689,9 @@ define i64 @clmul_i64_zext(i32 %x, i32 %y) {
 ; CHECK-AES:       // %bb.0:
 ; CHECK-AES-NEXT:    mov w8, w0
 ; CHECK-AES-NEXT:    mov w9, w1
-; CHECK-AES-NEXT:    fmov d0, x9
-; CHECK-AES-NEXT:    fmov d1, x8
-; CHECK-AES-NEXT:    pmull v0.1q, v1.1d, v0.1d
+; CHECK-AES-NEXT:    fmov d0, x8
+; CHECK-AES-NEXT:    fmov d1, x9
+; CHECK-AES-NEXT:    pmull v0.1q, v0.1d, v1.1d
 ; CHECK-AES-NEXT:    fmov x0, d0
 ; CHECK-AES-NEXT:    ret
   %zextx = zext i32 %x to i64

--- a/llvm/test/CodeGen/AArch64/partial-reduction-add-predicated.ll
+++ b/llvm/test/CodeGen/AArch64/partial-reduction-add-predicated.ll
@@ -92,11 +92,17 @@ define <4 x float> @predicated_fdot_fixed_length(<4 x float> %acc, <8 x i1> %p, 
 ; CHECK-LABEL: predicated_fdot_fixed_length:
 ; CHECK:       // %bb.0:
 ; CHECK-NEXT:    ushll v1.8h, v1.8b, #0
-; CHECK-NEXT:    // kill: def $q0 killed $q0 def $z0
+; CHECK-NEXT:    movi v4.2d, #0000000000000000
 ; CHECK-NEXT:    // kill: def $q2 killed $q2 def $z2
+; CHECK-NEXT:    // kill: def $q0 killed $q0 def $z0
+; CHECK-NEXT:    ptrue p0.h, vl8
+; CHECK-NEXT:    ptrue p1.s, vl4
 ; CHECK-NEXT:    shl v1.8h, v1.8h, #15
+; CHECK-NEXT:    sel z2.h, p0, z2.h, z4.h
+; CHECK-NEXT:    sel z0.s, p1, z0.s, z4.s
 ; CHECK-NEXT:    cmlt v1.8h, v1.8h, #0
 ; CHECK-NEXT:    and v1.16b, v1.16b, v3.16b
+; CHECK-NEXT:    sel z1.h, p0, z1.h, z4.h
 ; CHECK-NEXT:    fdot z0.s, z2.h, z1.h
 ; CHECK-NEXT:    // kill: def $q0 killed $q0 killed $z0
 ; CHECK-NEXT:    ret
@@ -128,11 +134,17 @@ define <4 x float> @predicated_fpext_fmul_fixed_length(<4 x float> %acc, <8 x i1
 ; CHECK:       // %bb.0:
 ; CHECK-NEXT:    ushll v1.8h, v1.8b, #0
 ; CHECK-NEXT:    movi v3.8h, #60, lsl #8
-; CHECK-NEXT:    // kill: def $q0 killed $q0 def $z0
 ; CHECK-NEXT:    // kill: def $q2 killed $q2 def $z2
+; CHECK-NEXT:    // kill: def $q0 killed $q0 def $z0
+; CHECK-NEXT:    movi v4.2d, #0000000000000000
+; CHECK-NEXT:    ptrue p0.h, vl8
+; CHECK-NEXT:    ptrue p1.s, vl4
 ; CHECK-NEXT:    shl v1.8h, v1.8h, #15
+; CHECK-NEXT:    sel z2.h, p0, z2.h, z4.h
+; CHECK-NEXT:    sel z0.s, p1, z0.s, z4.s
 ; CHECK-NEXT:    cmlt v1.8h, v1.8h, #0
 ; CHECK-NEXT:    and v1.16b, v1.16b, v3.16b
+; CHECK-NEXT:    sel z1.h, p0, z1.h, z4.h
 ; CHECK-NEXT:    fdot z0.s, z2.h, z1.h
 ; CHECK-NEXT:    // kill: def $q0 killed $q0 killed $z0
 ; CHECK-NEXT:    ret

--- a/llvm/test/CodeGen/AArch64/sve-fixed-length-frame-offests.ll
+++ b/llvm/test/CodeGen/AArch64/sve-fixed-length-frame-offests.ll
@@ -12,12 +12,12 @@ define void @foo(ptr %a) #0 {
 ; CHECK:       SelectionDAG has 13 nodes:
 ; CHECK-NEXT:    t0: ch,glue = EntryToken
 ; CHECK-NEXT:    t2: i64,ch = CopyFromReg t0, Register:i64 %0
-; CHECK-NEXT:    t22: nxv2i64,ch = LDR_ZXI<Mem:(volatile load (<vscale x 1 x s128>) from %ir.a, align 64)> t2, TargetConstant:i64<0>, t0
+; CHECK-NEXT:    t23: nxv2i64,ch = LDR_ZXI<Mem:(volatile load (<vscale x 1 x s128>) from %ir.a, align 64)> t2, TargetConstant:i64<0>, t0
 ; CHECK-NEXT:    t8: i64 = ADDXri TargetFrameIndex:i64<1>, TargetConstant:i32<0>, TargetConstant:i32<0>
 ; CHECK-NEXT:    t6: i64 = ADDXri TargetFrameIndex:i64<0>, TargetConstant:i32<0>, TargetConstant:i32<0>
-; CHECK-NEXT:    t23: ch = STR_ZXI<Mem:(volatile store (<vscale x 1 x s128>) into %ir.r0, align 64)> t22, t6, TargetConstant:i64<0>, t22:1
-; CHECK-NEXT:    t24: ch = STR_ZXI<Mem:(volatile store (<vscale x 1 x s128>) into %ir.r1, align 64)> t22, t8, TargetConstant:i64<0>, t23
-; CHECK-NEXT:    t10: ch = RET_ReallyLR t24
+; CHECK-NEXT:    t24: ch = STR_ZXI<Mem:(volatile store (<vscale x 1 x s128>) into %ir.r0, align 64)> t23, t6, TargetConstant:i64<0>, t23:1
+; CHECK-NEXT:    t25: ch = STR_ZXI<Mem:(volatile store (<vscale x 1 x s128>) into %ir.r1, align 64)> t23, t8, TargetConstant:i64<0>, t24
+; CHECK-NEXT:    t10: ch = RET_ReallyLR t25
 ; CHECK-EMPTY:
 entry:
   %r0 = alloca <8 x i64>

--- a/llvm/test/CodeGen/AArch64/sve2p1-fixed-length-fdot.ll
+++ b/llvm/test/CodeGen/AArch64/sve2p1-fixed-length-fdot.ll
@@ -23,11 +23,17 @@ define void @fdot_v4f32(ptr %accptr, ptr %aptr, ptr %bptr) {
 ;
 ; SVE2P1-LABEL: fdot_v4f32:
 ; SVE2P1:       // %bb.0: // %entry
-; SVE2P1-NEXT:    ldr q0, [x0]
-; SVE2P1-NEXT:    ldr q1, [x1]
-; SVE2P1-NEXT:    ldr q2, [x2]
-; SVE2P1-NEXT:    fdot z0.s, z1.h, z2.h
-; SVE2P1-NEXT:    str q0, [x0]
+; SVE2P1-NEXT:    movi v0.2d, #0000000000000000
+; SVE2P1-NEXT:    ldr q1, [x0]
+; SVE2P1-NEXT:    ptrue p0.s, vl4
+; SVE2P1-NEXT:    ldr q2, [x1]
+; SVE2P1-NEXT:    ptrue p1.h, vl8
+; SVE2P1-NEXT:    ldr q3, [x2]
+; SVE2P1-NEXT:    sel z1.s, p0, z1.s, z0.s
+; SVE2P1-NEXT:    sel z2.h, p1, z2.h, z0.h
+; SVE2P1-NEXT:    mov z0.h, p1/m, z3.h
+; SVE2P1-NEXT:    fdot z1.s, z2.h, z0.h
+; SVE2P1-NEXT:    str q1, [x0]
 ; SVE2P1-NEXT:    ret
 entry:
   %acc = load <4 x float>, ptr %accptr
@@ -65,12 +71,16 @@ define void @fdot_wide_v8f32(ptr %accptr, ptr %aptr, ptr %bptr) vscale_range(2,0
 ; SVE2P1-LABEL: fdot_wide_v8f32:
 ; SVE2P1:       // %bb.0: // %entry
 ; SVE2P1-NEXT:    ptrue p0.s, vl8
+; SVE2P1-NEXT:    movi v0.2d, #0000000000000000
 ; SVE2P1-NEXT:    ptrue p1.h, vl16
-; SVE2P1-NEXT:    ld1w { z0.s }, p0/z, [x0]
-; SVE2P1-NEXT:    ld1h { z1.h }, p1/z, [x1]
-; SVE2P1-NEXT:    ld1h { z2.h }, p1/z, [x2]
-; SVE2P1-NEXT:    fdot z0.s, z1.h, z2.h
-; SVE2P1-NEXT:    st1w { z0.s }, p0, [x0]
+; SVE2P1-NEXT:    ld1w { z1.s }, p0/z, [x0]
+; SVE2P1-NEXT:    ld1h { z2.h }, p1/z, [x1]
+; SVE2P1-NEXT:    ld1h { z3.h }, p1/z, [x2]
+; SVE2P1-NEXT:    sel z1.s, p0, z1.s, z0.s
+; SVE2P1-NEXT:    sel z2.h, p1, z2.h, z0.h
+; SVE2P1-NEXT:    mov z0.h, p1/m, z3.h
+; SVE2P1-NEXT:    fdot z1.s, z2.h, z0.h
+; SVE2P1-NEXT:    st1w { z1.s }, p0, [x0]
 ; SVE2P1-NEXT:    ret
 entry:
   %acc = load <8 x float>, ptr %accptr
@@ -108,12 +118,16 @@ define void @fdot_wide_v16f32(ptr %accptr, ptr %aptr, ptr %bptr) vscale_range(4,
 ; SVE2P1-LABEL: fdot_wide_v16f32:
 ; SVE2P1:       // %bb.0: // %entry
 ; SVE2P1-NEXT:    ptrue p0.s, vl16
+; SVE2P1-NEXT:    movi v0.2d, #0000000000000000
 ; SVE2P1-NEXT:    ptrue p1.h, vl32
-; SVE2P1-NEXT:    ld1w { z0.s }, p0/z, [x0]
-; SVE2P1-NEXT:    ld1h { z1.h }, p1/z, [x1]
-; SVE2P1-NEXT:    ld1h { z2.h }, p1/z, [x2]
-; SVE2P1-NEXT:    fdot z0.s, z1.h, z2.h
-; SVE2P1-NEXT:    st1w { z0.s }, p0, [x0]
+; SVE2P1-NEXT:    ld1w { z1.s }, p0/z, [x0]
+; SVE2P1-NEXT:    ld1h { z2.h }, p1/z, [x1]
+; SVE2P1-NEXT:    ld1h { z3.h }, p1/z, [x2]
+; SVE2P1-NEXT:    sel z1.s, p0, z1.s, z0.s
+; SVE2P1-NEXT:    sel z2.h, p1, z2.h, z0.h
+; SVE2P1-NEXT:    mov z0.h, p1/m, z3.h
+; SVE2P1-NEXT:    fdot z1.s, z2.h, z0.h
+; SVE2P1-NEXT:    st1w { z1.s }, p0, [x0]
 ; SVE2P1-NEXT:    ret
 entry:
   %acc = load <16 x float>, ptr %accptr
@@ -151,12 +165,16 @@ define void @fdot_wide_v32f32(ptr %accptr, ptr %aptr, ptr %bptr) vscale_range(8,
 ; SVE2P1-LABEL: fdot_wide_v32f32:
 ; SVE2P1:       // %bb.0: // %entry
 ; SVE2P1-NEXT:    ptrue p0.s, vl32
+; SVE2P1-NEXT:    movi v0.2d, #0000000000000000
 ; SVE2P1-NEXT:    ptrue p1.h, vl64
-; SVE2P1-NEXT:    ld1w { z0.s }, p0/z, [x0]
-; SVE2P1-NEXT:    ld1h { z1.h }, p1/z, [x1]
-; SVE2P1-NEXT:    ld1h { z2.h }, p1/z, [x2]
-; SVE2P1-NEXT:    fdot z0.s, z1.h, z2.h
-; SVE2P1-NEXT:    st1w { z0.s }, p0, [x0]
+; SVE2P1-NEXT:    ld1w { z1.s }, p0/z, [x0]
+; SVE2P1-NEXT:    ld1h { z2.h }, p1/z, [x1]
+; SVE2P1-NEXT:    ld1h { z3.h }, p1/z, [x2]
+; SVE2P1-NEXT:    sel z1.s, p0, z1.s, z0.s
+; SVE2P1-NEXT:    sel z2.h, p1, z2.h, z0.h
+; SVE2P1-NEXT:    mov z0.h, p1/m, z3.h
+; SVE2P1-NEXT:    fdot z1.s, z2.h, z0.h
+; SVE2P1-NEXT:    st1w { z1.s }, p0, [x0]
 ; SVE2P1-NEXT:    ret
 entry:
   %acc = load <32 x float>, ptr %accptr
@@ -194,12 +212,16 @@ define void @fdot_wide_v64f32(ptr %accptr, ptr %aptr, ptr %bptr) vscale_range(16
 ; SVE2P1-LABEL: fdot_wide_v64f32:
 ; SVE2P1:       // %bb.0: // %entry
 ; SVE2P1-NEXT:    ptrue p0.s, vl64
+; SVE2P1-NEXT:    movi v0.2d, #0000000000000000
 ; SVE2P1-NEXT:    ptrue p1.h, vl128
-; SVE2P1-NEXT:    ld1w { z0.s }, p0/z, [x0]
-; SVE2P1-NEXT:    ld1h { z1.h }, p1/z, [x1]
-; SVE2P1-NEXT:    ld1h { z2.h }, p1/z, [x2]
-; SVE2P1-NEXT:    fdot z0.s, z1.h, z2.h
-; SVE2P1-NEXT:    st1w { z0.s }, p0, [x0]
+; SVE2P1-NEXT:    ld1w { z1.s }, p0/z, [x0]
+; SVE2P1-NEXT:    ld1h { z2.h }, p1/z, [x1]
+; SVE2P1-NEXT:    ld1h { z3.h }, p1/z, [x2]
+; SVE2P1-NEXT:    sel z1.s, p0, z1.s, z0.s
+; SVE2P1-NEXT:    sel z2.h, p1, z2.h, z0.h
+; SVE2P1-NEXT:    mov z0.h, p1/m, z3.h
+; SVE2P1-NEXT:    fdot z1.s, z2.h, z0.h
+; SVE2P1-NEXT:    st1w { z1.s }, p0, [x0]
 ; SVE2P1-NEXT:    ret
 entry:
   %acc = load <64 x float>, ptr %accptr
@@ -228,9 +250,15 @@ define <4 x float> @fixed_fdot_wide(<4 x float> %acc, <8 x half> %a, <8 x half> 
 ;
 ; SVE2P1-LABEL: fixed_fdot_wide:
 ; SVE2P1:       // %bb.0: // %entry
-; SVE2P1-NEXT:    // kill: def $q0 killed $q0 def $z0
+; SVE2P1-NEXT:    movi v3.2d, #0000000000000000
+; SVE2P1-NEXT:    ptrue p0.h, vl8
 ; SVE2P1-NEXT:    // kill: def $q2 killed $q2 def $z2
 ; SVE2P1-NEXT:    // kill: def $q1 killed $q1 def $z1
+; SVE2P1-NEXT:    // kill: def $q0 killed $q0 def $z0
+; SVE2P1-NEXT:    ptrue p1.s, vl4
+; SVE2P1-NEXT:    sel z2.h, p0, z2.h, z3.h
+; SVE2P1-NEXT:    sel z1.h, p0, z1.h, z3.h
+; SVE2P1-NEXT:    sel z0.s, p1, z0.s, z3.s
 ; SVE2P1-NEXT:    fdot z0.s, z1.h, z2.h
 ; SVE2P1-NEXT:    // kill: def $q0 killed $q0 killed $z0
 ; SVE2P1-NEXT:    ret
@@ -240,6 +268,33 @@ entry:
   %mult = fmul <8 x float> %a.wide, %b.wide
   %partial.reduce = call <4 x float> @llvm.vector.partial.reduce.fadd(<4 x float> %acc, <8 x float> %mult)
   ret <4 x float> %partial.reduce
+}
+
+define <2 x float> @fixed_fdot(<2 x float> %acc, <4 x half> %a, <4 x half> %b) {
+; SVE2-LABEL: fixed_fdot:
+; SVE2:       // %bb.0: // %entry
+; SVE2-NEXT:    fcvtl v1.4s, v1.4h
+; SVE2-NEXT:    fcvtl v2.4s, v2.4h
+; SVE2-NEXT:    fmul v1.4s, v1.4s, v2.4s
+; SVE2-NEXT:    fadd v0.2s, v0.2s, v1.2s
+; SVE2-NEXT:    ext v1.16b, v1.16b, v1.16b, #8
+; SVE2-NEXT:    fadd v0.2s, v1.2s, v0.2s
+; SVE2-NEXT:    ret
+;
+; SVE2P1-LABEL: fixed_fdot:
+; SVE2P1:       // %bb.0: // %entry
+; SVE2P1-NEXT:    // kill: def $d0 killed $d0 def $z0
+; SVE2P1-NEXT:    // kill: def $d2 killed $d2 def $z2
+; SVE2P1-NEXT:    // kill: def $d1 killed $d1 def $z1
+; SVE2P1-NEXT:    fdot z0.s, z1.h, z2.h
+; SVE2P1-NEXT:    // kill: def $d0 killed $d0 killed $z0
+; SVE2P1-NEXT:    ret
+entry:
+  %a.wide = fpext <4 x half> %a to <4 x float>
+  %b.wide = fpext <4 x half> %b to <4 x float>
+  %mult = fmul <4 x float> %a.wide, %b.wide
+  %partial.reduce = call <2 x float> @llvm.vector.partial.reduce.fadd(<2 x float> %acc, <4 x float> %mult)
+  ret <2 x float> %partial.reduce
 }
 
 define <8 x half> @partial_reduce_half(<8 x half> %acc, <16 x half> %a) {

--- a/llvm/test/CodeGen/AArch64/sve2p1-fixed-length-fdot.ll
+++ b/llvm/test/CodeGen/AArch64/sve2p1-fixed-length-fdot.ll
@@ -270,33 +270,6 @@ entry:
   ret <4 x float> %partial.reduce
 }
 
-define <2 x float> @fixed_fdot(<2 x float> %acc, <4 x half> %a, <4 x half> %b) {
-; SVE2-LABEL: fixed_fdot:
-; SVE2:       // %bb.0: // %entry
-; SVE2-NEXT:    fcvtl v1.4s, v1.4h
-; SVE2-NEXT:    fcvtl v2.4s, v2.4h
-; SVE2-NEXT:    fmul v1.4s, v1.4s, v2.4s
-; SVE2-NEXT:    fadd v0.2s, v0.2s, v1.2s
-; SVE2-NEXT:    ext v1.16b, v1.16b, v1.16b, #8
-; SVE2-NEXT:    fadd v0.2s, v1.2s, v0.2s
-; SVE2-NEXT:    ret
-;
-; SVE2P1-LABEL: fixed_fdot:
-; SVE2P1:       // %bb.0: // %entry
-; SVE2P1-NEXT:    // kill: def $d0 killed $d0 def $z0
-; SVE2P1-NEXT:    // kill: def $d2 killed $d2 def $z2
-; SVE2P1-NEXT:    // kill: def $d1 killed $d1 def $z1
-; SVE2P1-NEXT:    fdot z0.s, z1.h, z2.h
-; SVE2P1-NEXT:    // kill: def $d0 killed $d0 killed $z0
-; SVE2P1-NEXT:    ret
-entry:
-  %a.wide = fpext <4 x half> %a to <4 x float>
-  %b.wide = fpext <4 x half> %b to <4 x float>
-  %mult = fmul <4 x float> %a.wide, %b.wide
-  %partial.reduce = call <2 x float> @llvm.vector.partial.reduce.fadd(<2 x float> %acc, <4 x float> %mult)
-  ret <2 x float> %partial.reduce
-}
-
 define <8 x half> @partial_reduce_half(<8 x half> %acc, <16 x half> %a) {
 ; CHECK-LABEL: partial_reduce_half:
 ; CHECK:       // %bb.0: // %entry


### PR DESCRIPTION
This patch adds sanitization of input vectors when converting from using fixed vectors into using scalable vectors for fp partial reduce. This is done to preserve behaviour correctness and avoid triggering fp exceptions on extra sve lanes. The performance with this sanitazation is still better than trying to do it in neon using fmul + fadd, at least in simple cases. 