### PR TITLE
[clang-tidy][NFC] Fix various clang-tidy finding

### DIFF
--- a/clang-tools-extra/clang-tidy/ClangTidy.cpp
+++ b/clang-tools-extra/clang-tidy/ClangTidy.cpp
@@ -446,7 +446,7 @@ ClangTidyASTConsumerFactory::createASTConsumer(
   if (!Context.getOptions().SystemHeaders.value_or(false))
     FinderOptions.IgnoreSystemHeaders = true;
 
-  std::unique_ptr<ast_matchers::MatchFinder> Finder =
+  auto Finder =
       std::make_unique<ast_matchers::MatchFinder>(std::move(FinderOptions));
 
   Preprocessor *PP = &Compiler.getPreprocessor();

--- a/clang-tools-extra/clang-tidy/ClangTidy.cpp
+++ b/clang-tools-extra/clang-tidy/ClangTidy.cpp
@@ -37,6 +37,7 @@
 #include "clang/Tooling/Refactoring.h"
 #include "clang/Tooling/Tooling.h"
 #include "llvm/Support/Process.h"
+#include <memory>
 #include <utility>
 
 #if CLANG_TIDY_ENABLE_STATIC_ANALYZER
@@ -445,8 +446,8 @@ ClangTidyASTConsumerFactory::createASTConsumer(
   if (!Context.getOptions().SystemHeaders.value_or(false))
     FinderOptions.IgnoreSystemHeaders = true;
 
-  std::unique_ptr<ast_matchers::MatchFinder> Finder(
-      new ast_matchers::MatchFinder(std::move(FinderOptions)));
+  std::unique_ptr<ast_matchers::MatchFinder> Finder =
+      std::make_unique<ast_matchers::MatchFinder>(std::move(FinderOptions));
 
   Preprocessor *PP = &Compiler.getPreprocessor();
   Preprocessor *ModuleExpanderPP = PP;

--- a/clang-tools-extra/clang-tidy/altera/IdDependentBackwardBranchCheck.cpp
+++ b/clang-tools-extra/clang-tidy/altera/IdDependentBackwardBranchCheck.cpp
@@ -142,7 +142,7 @@ void IdDependentBackwardBranchCheck::saveIdDepVarFromReference(
     const DeclRefExpr *RefExpr, const MemberExpr *MemExpr,
     const VarDecl *PotentialVar) {
   // If the variable is already in IdDepVarsMap, ignore it.
-  if (IdDepVarsMap.find(PotentialVar) != IdDepVarsMap.end())
+  if (IdDepVarsMap.contains(PotentialVar))
     return;
   std::string Message;
   llvm::raw_string_ostream StringStream(Message);
@@ -151,13 +151,13 @@ void IdDependentBackwardBranchCheck::saveIdDepVarFromReference(
   if (RefExpr) {
     const auto *RefVar = dyn_cast<VarDecl>(RefExpr->getDecl());
     // If variable isn't ID-dependent, but RefVar is.
-    if (IdDepVarsMap.find(RefVar) != IdDepVarsMap.end())
+    if (IdDepVarsMap.contains(RefVar))
       StringStream << "variable " << RefVar->getNameAsString();
   }
   if (MemExpr) {
     const auto *RefField = dyn_cast<FieldDecl>(MemExpr->getMemberDecl());
     // If variable isn't ID-dependent, but RefField is.
-    if (IdDepFieldsMap.find(RefField) != IdDepFieldsMap.end())
+    if (IdDepFieldsMap.contains(RefField))
       StringStream << "member " << RefField->getNameAsString();
   }
   IdDepVarsMap[PotentialVar] =
@@ -168,7 +168,7 @@ void IdDependentBackwardBranchCheck::saveIdDepFieldFromReference(
     const DeclRefExpr *RefExpr, const MemberExpr *MemExpr,
     const FieldDecl *PotentialField) {
   // If the field is already in IdDepFieldsMap, ignore it.
-  if (IdDepFieldsMap.find(PotentialField) != IdDepFieldsMap.end())
+  if (IdDepFieldsMap.contains(PotentialField))
     return;
   std::string Message;
   llvm::raw_string_ostream StringStream(Message);
@@ -177,12 +177,12 @@ void IdDependentBackwardBranchCheck::saveIdDepFieldFromReference(
   if (RefExpr) {
     const auto *RefVar = dyn_cast<VarDecl>(RefExpr->getDecl());
     // If field isn't ID-dependent, but RefVar is.
-    if (IdDepVarsMap.find(RefVar) != IdDepVarsMap.end())
+    if (IdDepVarsMap.contains(RefVar))
       StringStream << "variable " << RefVar->getNameAsString();
   }
   if (MemExpr) {
     const auto *RefField = dyn_cast<FieldDecl>(MemExpr->getMemberDecl());
-    if (IdDepFieldsMap.find(RefField) != IdDepFieldsMap.end())
+    if (IdDepFieldsMap.contains(RefField))
       StringStream << "member " << RefField->getNameAsString();
   }
   IdDepFieldsMap[PotentialField] = IdDependencyRecord(

--- a/clang-tools-extra/clang-tidy/bugprone/ParentVirtualCallCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/ParentVirtualCallCheck.cpp
@@ -12,7 +12,6 @@
 #include "clang/Tooling/FixIt.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallVector.h"
-#include <cctype>
 
 using namespace clang::ast_matchers;
 

--- a/clang-tools-extra/clang-tidy/bugprone/UnsafeFunctionsCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/UnsafeFunctionsCheck.cpp
@@ -11,7 +11,6 @@
 #include "clang/AST/ASTContext.h"
 #include "clang/ASTMatchers/ASTMatchFinder.h"
 #include "clang/Analysis/AnnexKDetection.h"
-#include "clang/Lex/PPCallbacks.h"
 #include "clang/Lex/Preprocessor.h"
 #include <cassert>
 

--- a/clang-tools-extra/clang-tidy/cppcoreguidelines/MacroUsageCheck.cpp
+++ b/clang-tools-extra/clang-tidy/cppcoreguidelines/MacroUsageCheck.cpp
@@ -82,14 +82,12 @@ void MacroUsageCheck::registerPPCallbacks(const SourceManager &SM,
 void MacroUsageCheck::warnMacro(const MacroDirective *MD, StringRef MacroName) {
   const MacroInfo *Info = MD->getMacroInfo();
   StringRef Message;
-  bool MacroBodyExpressionLike;
+  bool MacroBodyExpressionLike = true;
   if (Info->getNumTokens() > 0) {
     const Token &Tok = Info->getReplacementToken(0);
     // Now notice that keywords like `__attribute` cannot be a leading
     // token in an expression.
     MacroBodyExpressionLike = !Tok.is(tok::kw___attribute);
-  } else {
-    MacroBodyExpressionLike = true;
   }
 
   if (llvm::all_of(Info->tokens(), std::mem_fn(&Token::isLiteral)))

--- a/clang-tools-extra/clang-tidy/llvm/IncludeOrderCheck.cpp
+++ b/clang-tools-extra/clang-tidy/llvm/IncludeOrderCheck.cpp
@@ -12,8 +12,6 @@
 #include "clang/Lex/Preprocessor.h"
 #include "llvm/ADT/STLExtras.h"
 
-#include <map>
-
 namespace clang::tidy::llvm_check {
 
 namespace {

--- a/clang-tools-extra/clang-tidy/modernize/RawStringLiteralCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/RawStringLiteralCheck.cpp
@@ -63,9 +63,8 @@ static bool containsEscapedCharacters(const MatchFinder::MatchResult &Result,
 }
 
 static bool containsDelimiter(StringRef Bytes, const std::string &Delimiter) {
-  return Bytes.find(Delimiter.empty()
-                        ? std::string(R"lit()")lit")
-                        : (")" + Delimiter + R"(")")) != StringRef::npos;
+  return Bytes.contains(Delimiter.empty() ? std::string(R"lit()")lit")
+                                          : (")" + Delimiter + R"(")"));
 }
 
 RawStringLiteralCheck::RawStringLiteralCheck(StringRef Name,

--- a/clang-tools-extra/clang-tidy/modernize/UseOverrideCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/UseOverrideCheck.cpp
@@ -139,7 +139,7 @@ void UseOverrideCheck::check(const MatchFinder::MatchResult &Result) {
 
   // FIXME: Instead of re-lexing and looking for the 'virtual' token,
   // store the location of 'virtual' in each FunctionDecl.
-  SmallVector<Token, 16> Tokens = parseTokens(FileRange, Result);
+  const SmallVector<Token, 16> Tokens = parseTokens(FileRange, Result);
 
   // Add 'override' on inline declarations that don't already have it.
   if (!HasFinal && !HasOverride) {

--- a/clang-tools-extra/clang-tidy/modernize/UseStdPrintCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/UseStdPrintCheck.cpp
@@ -22,7 +22,7 @@ AST_MATCHER(StringLiteral, isOrdinary) { return Node.isOrdinary(); }
 } // namespace
 
 UseStdPrintCheck::UseStdPrintCheck(StringRef Name, ClangTidyContext *Context)
-    : ClangTidyCheck(Name, Context), PP(nullptr),
+    : ClangTidyCheck(Name, Context),
       StrictMode(Options.get("StrictMode", false)),
       PrintfLikeFunctions(utils::options::parseStringList(
           Options.get("PrintfLikeFunctions", ""))),

--- a/clang-tools-extra/clang-tidy/modernize/UseTrailingReturnTypeCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/UseTrailingReturnTypeCheck.cpp
@@ -14,7 +14,6 @@
 #include "clang/Tooling/FixIt.h"
 #include "llvm/ADT/StringExtras.h"
 
-#include <cctype>
 #include <optional>
 
 namespace clang::tidy {

--- a/clang-tools-extra/clang-tidy/readability/ContainerDataPointerCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/ContainerDataPointerCheck.cpp
@@ -11,7 +11,6 @@
 #include "../utils/Matchers.h"
 #include "../utils/OptionsUtils.h"
 #include "clang/Lex/Lexer.h"
-#include "llvm/ADT/StringRef.h"
 
 using namespace clang::ast_matchers;
 

--- a/clang-tools-extra/clang-tidy/readability/SuspiciousCallArgumentCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/SuspiciousCallArgumentCheck.cpp
@@ -204,7 +204,7 @@ static bool applyLevenshteinHeuristic(StringRef Arg, StringRef Param,
                                       int8_t Threshold) {
   const std::size_t LongerLength = std::max(Arg.size(), Param.size());
   double Dist = Arg.edit_distance(Param);
-  Dist = (1.0 - Dist / LongerLength) * 100.0;
+  Dist = (1.0 - (Dist / LongerLength)) * 100.0;
   return Dist > Threshold;
 }
 

--- a/clang-tools-extra/clang-tidy/tool/ClangTidyMain.cpp
+++ b/clang-tools-extra/clang-tidy/tool/ClangTidyMain.cpp
@@ -18,7 +18,6 @@
 #include "../ClangTidy.h"
 #include "../ClangTidyForceLinker.h" // IWYU pragma: keep
 #include "../GlobList.h"
-#include "../utils/OptionsUtils.h"
 #include "clang/Tooling/CommonOptionsParser.h"
 #include "llvm/ADT/StringSet.h"
 #include "llvm/Support/CommandLine.h"

--- a/clang-tools-extra/clang-tidy/utils/IncludeSorter.cpp
+++ b/clang-tools-extra/clang-tidy/utils/IncludeSorter.cpp
@@ -9,7 +9,6 @@
 #include "IncludeSorter.h"
 #include "clang/Basic/SourceManager.h"
 #include "clang/Lex/Lexer.h"
-#include <algorithm>
 #include <optional>
 
 namespace clang::tidy {

--- a/clang-tools-extra/clang-tidy/utils/UseRangesCheck.cpp
+++ b/clang-tools-extra/clang-tidy/utils/UseRangesCheck.cpp
@@ -123,7 +123,7 @@ void UseRangesCheck::registerMatchers(MatchFinder *Finder) {
     Replacers.push_back(Replacer);
     assert(!Replacer->getReplacementSignatures().empty() &&
            llvm::all_of(Replacer->getReplacementSignatures(),
-                        [](auto Index) { return !Index.empty(); }));
+                        [](const Signature &Index) { return !Index.empty(); }));
     std::vector<StringRef> Names(1, I->getKey());
     for (auto J = std::next(I); J != E; ++J)
       if (J->getValue() == Replacer)


### PR DESCRIPTION
I suspect many of them must slipped under the radar in CI because they were absent in diff (like redundant includes).

Other cases must be some fixed FN in existing checks.