### PR TITLE
[MC] Merge fixupNeedsRelaxation and fixupNeedsRelaxationAdvanced. NFC

### DIFF
--- a/llvm/include/llvm/MC/MCAsmBackend.h
+++ b/llvm/include/llvm/MC/MCAsmBackend.h
@@ -143,12 +143,6 @@ public:
                                             const MCValue &, uint64_t,
                                             bool Resolved) const;
 
-  /// Simple predicate for targets where !Resolved implies requiring relaxation
-  virtual bool fixupNeedsRelaxation(const MCFixup &Fixup,
-                                    uint64_t Value) const {
-    llvm_unreachable("Needed if mayNeedRelaxation may return true");
-  }
-
   /// Relax the instruction in the given fragment to the next wider instruction.
   ///
   /// \param [out] Inst The instruction to relax, which is also the relaxed
@@ -156,9 +150,7 @@ public:
   /// \param STI the subtarget information for the associated instruction.
   virtual void relaxInstruction(MCInst &Inst,
                                 const MCSubtargetInfo &STI) const {
-    llvm_unreachable(
-        "Needed if fixupNeedsRelaxation/fixupNeedsRelaxationAdvanced may "
-        "return true");
+    llvm_unreachable("Needed if fixupNeedsRelaxationAdvanced may return true");
   }
 
   // Defined by linker relaxation targets.

--- a/llvm/lib/MC/MCAsmBackend.cpp
+++ b/llvm/lib/MC/MCAsmBackend.cpp
@@ -107,12 +107,10 @@ MCFixupKindInfo MCAsmBackend::getFixupKindInfo(MCFixupKind Kind) const {
 }
 
 bool MCAsmBackend::fixupNeedsRelaxationAdvanced(const MCFragment &,
-                                                const MCFixup &Fixup,
-                                                const MCValue &, uint64_t Value,
+                                                const MCFixup &,
+                                                const MCValue &, uint64_t,
                                                 bool Resolved) const {
-  if (!Resolved)
-    return true;
-  return fixupNeedsRelaxation(Fixup, Value);
+  return !Resolved;
 }
 
 void MCAsmBackend::maybeAddReloc(const MCFragment &F, const MCFixup &Fixup,

--- a/llvm/lib/Target/AArch64/MCTargetDesc/AArch64AsmBackend.cpp
+++ b/llvm/lib/Target/AArch64/MCTargetDesc/AArch64AsmBackend.cpp
@@ -81,8 +81,6 @@ public:
   void applyFixup(const MCFragment &, const MCFixup &, const MCValue &Target,
                   uint8_t *Data, uint64_t Value, bool IsResolved) override;
 
-  bool fixupNeedsRelaxation(const MCFixup &Fixup,
-                            uint64_t Value) const override;
   bool writeNopData(raw_ostream &OS, uint64_t Count,
                     const MCSubtargetInfo *STI) const override;
 
@@ -495,15 +493,6 @@ void AArch64AsmBackend::applyFixup(const MCFragment &F, const MCFixup &Fixup,
     else
       Data[3] |= (1 << 6);
   }
-}
-
-bool AArch64AsmBackend::fixupNeedsRelaxation(const MCFixup &Fixup,
-                                             uint64_t Value) const {
-  // FIXME:  This isn't correct for AArch64. Just moving the "generic" logic
-  // into the targets for now.
-  //
-  // Relax if the value is too big for a (signed) i8.
-  return int64_t(Value) != int64_t(int8_t(Value));
 }
 
 bool AArch64AsmBackend::writeNopData(raw_ostream &OS, uint64_t Count,

--- a/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUAsmBackend.cpp
+++ b/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUAsmBackend.cpp
@@ -34,8 +34,9 @@ public:
 
   void applyFixup(const MCFragment &, const MCFixup &, const MCValue &Target,
                   uint8_t *Data, uint64_t Value, bool IsResolved) override;
-  bool fixupNeedsRelaxation(const MCFixup &Fixup,
-                            uint64_t Value) const override;
+  bool fixupNeedsRelaxationAdvanced(const MCFragment &, const MCFixup &,
+                                    const MCValue &, uint64_t,
+                                    bool) const override;
 
   void relaxInstruction(MCInst &Inst,
                         const MCSubtargetInfo &STI) const override;
@@ -62,8 +63,13 @@ void AMDGPUAsmBackend::relaxInstruction(MCInst &Inst,
   Inst = std::move(Res);
 }
 
-bool AMDGPUAsmBackend::fixupNeedsRelaxation(const MCFixup &Fixup,
-                                            uint64_t Value) const {
+bool AMDGPUAsmBackend::fixupNeedsRelaxationAdvanced(const MCFragment &,
+                                                    const MCFixup &Fixup,
+                                                    const MCValue &,
+                                                    uint64_t Value,
+                                                    bool Resolved) const {
+  if (!Resolved)
+    return true;
   // if the branch target has an offset of x3f this needs to be relaxed to
   // add a s_nop 0 immediately after branch to effectively increment offset
   // for hardware workaround in gfx1010

--- a/llvm/lib/Target/CSKY/MCTargetDesc/CSKYAsmBackend.cpp
+++ b/llvm/lib/Target/CSKY/MCTargetDesc/CSKYAsmBackend.cpp
@@ -276,11 +276,6 @@ bool CSKYAsmBackend::shouldForceRelocation(const MCFixup &Fixup,
   return false;
 }
 
-bool CSKYAsmBackend::fixupNeedsRelaxation(const MCFixup &Fixup,
-                                          uint64_t Value) const {
-  return false;
-}
-
 void CSKYAsmBackend::relaxInstruction(MCInst &Inst,
                                       const MCSubtargetInfo &STI) const {
   MCInst Res;

--- a/llvm/lib/Target/CSKY/MCTargetDesc/CSKYAsmBackend.h
+++ b/llvm/lib/Target/CSKY/MCTargetDesc/CSKYAsmBackend.h
@@ -29,9 +29,6 @@ public:
 
   MCFixupKindInfo getFixupKindInfo(MCFixupKind Kind) const override;
 
-  bool fixupNeedsRelaxation(const MCFixup &Fixup,
-                            uint64_t Value) const override;
-
   bool mayNeedRelaxation(unsigned Opcode, ArrayRef<MCOperand> Operands,
                          const MCSubtargetInfo &STI) const override;
   void relaxInstruction(MCInst &Inst,

--- a/llvm/lib/Target/M68k/MCTargetDesc/M68kAsmBackend.cpp
+++ b/llvm/lib/Target/M68k/MCTargetDesc/M68kAsmBackend.cpp
@@ -58,8 +58,9 @@ public:
   bool mayNeedRelaxation(unsigned Opcode, ArrayRef<MCOperand> Operands,
                          const MCSubtargetInfo &STI) const override;
 
-  bool fixupNeedsRelaxation(const MCFixup &Fixup,
-                            uint64_t Value) const override;
+  bool fixupNeedsRelaxationAdvanced(const MCFragment &, const MCFixup &,
+                                    const MCValue &, uint64_t,
+                                    bool) const override;
 
   void relaxInstruction(MCInst &Inst,
                         const MCSubtargetInfo &STI) const override;
@@ -188,8 +189,13 @@ bool M68kAsmBackend::mayNeedRelaxation(unsigned Opcode, ArrayRef<MCOperand>,
   // NOTE will change for x20 mem
 }
 
-bool M68kAsmBackend::fixupNeedsRelaxation(const MCFixup &Fixup,
-                                          uint64_t UnsignedValue) const {
+bool M68kAsmBackend::fixupNeedsRelaxationAdvanced(const MCFragment &,
+                                                  const MCFixup &Fixup,
+                                                  const MCValue &,
+                                                  uint64_t UnsignedValue,
+                                                  bool Resolved) const {
+  if (!Resolved)
+    return true;
   int64_t Value = static_cast<int64_t>(UnsignedValue);
 
   if (!isInt<32>(Value) || (!Allows32BitBranch && !isInt<16>(Value)))


### PR DESCRIPTION
The two-tier relaxation hook design (fixupNeedsRelaxationAdvanced
delegating to fixupNeedsRelaxation) is confusing and unnecessary.

Only M68k and AMDGPU used fixupNeedsRelaxation (via the default
fixupNeedsRelaxationAdvanced). AArch64 and CSKY had dead overrides:
they don't override mayNeedRelaxation to ever return true.

Merge the two hooks: convert M68k and AMDGPU to override
fixupNeedsRelaxationAdvanced directly, remove dead overrides from
AArch64 and CSKY, and simplify the default implementation to
`return !Resolved`.