### PR TITLE
[RISCV][P-ext] Fix cannot select error for shlsat with i8 vector argument.

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
@@ -573,11 +573,13 @@ RISCVTargetLowering::RISCVTargetLowering(const TargetMachine &TM,
     setOperationAction(ISD::SADDSAT, VTs, Legal);
     setOperationAction(ISD::USUBSAT, VTs, Legal);
     setOperationAction(ISD::SSUBSAT, VTs, Legal);
-    setOperationAction(ISD::SSHLSAT, VTs, Legal);
     setOperationAction({ISD::AVGFLOORS, ISD::AVGFLOORU}, VTs, Legal);
-    for (MVT VT : VTs)
+    for (MVT VT : VTs) {
       if (VT != MVT::v2i32)
         setOperationAction({ISD::ABDS, ISD::ABDU}, VT, Legal);
+      if (VT.getVectorElementType() != MVT::i8)
+        setOperationAction(ISD::SSHLSAT, VT, Legal);
+    }
     setOperationAction(ISD::SPLAT_VECTOR, VTs, Legal);
     setOperationAction(ISD::BUILD_VECTOR, VTs, Legal);
     setOperationAction(ISD::SCALAR_TO_VECTOR, VTs, Legal);

--- a/llvm/test/CodeGen/RISCV/rvp-ext-rv32.ll
+++ b/llvm/test/CodeGen/RISCV/rvp-ext-rv32.ll
@@ -644,6 +644,25 @@ define <2 x i16> @test_psslai_h(<2 x i16> %a) {
   ret <2 x i16> %res
 }
 
+; Test arithmetic saturation shift left immediate for v4i8
+define <4 x i8> @test_psslai_b(<4 x i8> %a) {
+; CHECK-LABEL: test_psslai_b:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    pli.b a1, 0
+; CHECK-NEXT:    li a2, 128
+; CHECK-NEXT:    pli.b a3, 127
+; CHECK-NEXT:    pmslt.b a1, a0, a1
+; CHECK-NEXT:    padd.bs a2, zero, a2
+; CHECK-NEXT:    merge a1, a3, a2
+; CHECK-NEXT:    pslli.b a2, a0, 2
+; CHECK-NEXT:    psrai.b a3, a2, 2
+; CHECK-NEXT:    pmseq.b a0, a0, a3
+; CHECK-NEXT:    merge a0, a1, a2
+; CHECK-NEXT:    ret
+  %res = call <4 x i8> @llvm.sshl.sat.v4i8(<4 x i8> %a, <4 x i8> splat(i8 2))
+  ret <4 x i8> %res
+}
+
 ; Test logical shift right immediate
 define <2 x i16> @test_psrli_h(<2 x i16> %a) {
 ; CHECK-LABEL: test_psrli_h:
@@ -1699,10 +1718,10 @@ define <2 x i16> @test_select_v2i16(i1 %cond, <2 x i16> %a, <2 x i16> %b) {
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    andi a3, a0, 1
 ; CHECK-NEXT:    mv a0, a1
-; CHECK-NEXT:    bnez a3, .LBB119_2
+; CHECK-NEXT:    bnez a3, .LBB120_2
 ; CHECK-NEXT:  # %bb.1:
 ; CHECK-NEXT:    mv a0, a2
-; CHECK-NEXT:  .LBB119_2:
+; CHECK-NEXT:  .LBB120_2:
 ; CHECK-NEXT:    ret
   %res = select i1 %cond, <2 x i16> %a, <2 x i16> %b
   ret <2 x i16> %res
@@ -1713,10 +1732,10 @@ define <4 x i8> @test_select_v4i8(i1 %cond, <4 x i8> %a, <4 x i8> %b) {
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    andi a3, a0, 1
 ; CHECK-NEXT:    mv a0, a1
-; CHECK-NEXT:    bnez a3, .LBB120_2
+; CHECK-NEXT:    bnez a3, .LBB121_2
 ; CHECK-NEXT:  # %bb.1:
 ; CHECK-NEXT:    mv a0, a2
-; CHECK-NEXT:  .LBB120_2:
+; CHECK-NEXT:  .LBB121_2:
 ; CHECK-NEXT:    ret
   %res = select i1 %cond, <4 x i8> %a, <4 x i8> %b
   ret <4 x i8> %res

--- a/llvm/test/CodeGen/RISCV/rvp-ext-rv64.ll
+++ b/llvm/test/CodeGen/RISCV/rvp-ext-rv64.ll
@@ -898,7 +898,6 @@ define <8 x i8> @test_psrai_b(<8 x i8> %a) {
   ret <8 x i8> %res
 }
 
-
 ; Test arithmetic saturation shift left immediate for v2i32
 define <2 x i32> @test_psslai_w(<2 x i32> %a) {
 ; CHECK-LABEL: test_psslai_w:
@@ -907,6 +906,35 @@ define <2 x i32> @test_psslai_w(<2 x i32> %a) {
 ; CHECK-NEXT:    ret
   %res = call <2 x i32> @llvm.sshl.sat.v2i32(<2 x i32> %a, <2 x i32> splat(i32 2))
   ret <2 x i32> %res
+}
+
+; Test arithmetic saturation shift left immediate for v4i16
+define <4 x i16> @test_psslai_h(<4 x i16> %a) {
+; CHECK-LABEL: test_psslai_h:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    psslai.h a0, a0, 2
+; CHECK-NEXT:    ret
+  %res = call <4 x i16> @llvm.sshl.sat.v4i16(<4 x i16> %a, <4 x i16> splat(i16 2))
+  ret <4 x i16> %res
+}
+
+; Test arithmetic saturation shift left immediate for v8i8
+define <8 x i8> @test_psslai_b(<8 x i8> %a) {
+; CHECK-LABEL: test_psslai_b:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    pli.b a1, 0
+; CHECK-NEXT:    li a2, 128
+; CHECK-NEXT:    pli.b a3, 127
+; CHECK-NEXT:    pmslt.b a1, a0, a1
+; CHECK-NEXT:    padd.bs a2, zero, a2
+; CHECK-NEXT:    merge a1, a3, a2
+; CHECK-NEXT:    pslli.b a2, a0, 2
+; CHECK-NEXT:    psrai.b a3, a2, 2
+; CHECK-NEXT:    pmseq.b a0, a0, a3
+; CHECK-NEXT:    merge a0, a1, a2
+; CHECK-NEXT:    ret
+  %res = call <8 x i8> @llvm.sshl.sat.v8i8(<8 x i8> %a, <8 x i8> splat(i8 2))
+  ret <8 x i8> %res
 }
 
 ; Test logical shift left(scalar shamt)
@@ -2035,10 +2063,10 @@ define <4 x i16> @test_select_v4i16(i1 %cond, <4 x i16> %a, <4 x i16> %b) {
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    andi a3, a0, 1
 ; CHECK-NEXT:    mv a0, a1
-; CHECK-NEXT:    bnez a3, .LBB163_2
+; CHECK-NEXT:    bnez a3, .LBB165_2
 ; CHECK-NEXT:  # %bb.1:
 ; CHECK-NEXT:    mv a0, a2
-; CHECK-NEXT:  .LBB163_2:
+; CHECK-NEXT:  .LBB165_2:
 ; CHECK-NEXT:    ret
   %res = select i1 %cond, <4 x i16> %a, <4 x i16> %b
   ret <4 x i16> %res
@@ -2049,10 +2077,10 @@ define <8 x i8> @test_select_v8i8(i1 %cond, <8 x i8> %a, <8 x i8> %b) {
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    andi a3, a0, 1
 ; CHECK-NEXT:    mv a0, a1
-; CHECK-NEXT:    bnez a3, .LBB164_2
+; CHECK-NEXT:    bnez a3, .LBB166_2
 ; CHECK-NEXT:  # %bb.1:
 ; CHECK-NEXT:    mv a0, a2
-; CHECK-NEXT:  .LBB164_2:
+; CHECK-NEXT:  .LBB166_2:
 ; CHECK-NEXT:    ret
   %res = select i1 %cond, <8 x i8> %a, <8 x i8> %b
   ret <8 x i8> %res
@@ -2063,10 +2091,10 @@ define <2 x i32> @test_select_v2i32(i1 %cond, <2 x i32> %a, <2 x i32> %b) {
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    andi a3, a0, 1
 ; CHECK-NEXT:    mv a0, a1
-; CHECK-NEXT:    bnez a3, .LBB165_2
+; CHECK-NEXT:    bnez a3, .LBB167_2
 ; CHECK-NEXT:  # %bb.1:
 ; CHECK-NEXT:    mv a0, a2
-; CHECK-NEXT:  .LBB165_2:
+; CHECK-NEXT:  .LBB167_2:
 ; CHECK-NEXT:    ret
   %res = select i1 %cond, <2 x i32> %a, <2 x i32> %b
   ret <2 x i32> %res


### PR DESCRIPTION
We don't have instructions for an i8 sshlat.