### PR TITLE
[clang-tidy][NFC] Remove hack that try to avoid including <cstddef> in tests

### DIFF
--- a/clang-tools-extra/test/clang-tidy/checkers/readability/implicit-bool-conversion-cxx98.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/implicit-bool-conversion-cxx98.cpp
@@ -1,9 +1,6 @@
-// RUN: %check_clang_tidy -std=c++98 %s readability-implicit-bool-conversion %t
+// RUN: %check_clang_tidy -std=c++98 %s readability-implicit-bool-conversion %t -- -- -isystem %clang_tidy_headers
 
-// We need NULL macro, but some buildbots don't like including <cstddef> header
-// This is a portable way of getting it to work
-#undef NULL
-#define NULL 0L
+#include <cstddef>
 
 template<typename T>
 void functionTaking(T);

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/implicit-bool-conversion.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/implicit-bool-conversion.cpp
@@ -1,13 +1,10 @@
-// RUN: %check_clang_tidy %s readability-implicit-bool-conversion %t
+// RUN: %check_clang_tidy %s readability-implicit-bool-conversion %t -- -- -isystem %clang_tidy_headers
 // RUN: %check_clang_tidy -check-suffix=UPPER-CASE %s readability-implicit-bool-conversion %t -- \
 // RUN:     -config='{CheckOptions: { \
 // RUN:         readability-implicit-bool-conversion.UseUpperCaseLiteralSuffix: true \
-// RUN:     }}'
+// RUN:     }}' -- -isystem %clang_tidy_headers
 
-// We need NULL macro, but some buildbots don't like including <cstddef> header
-// This is a portable way of getting it to work
-#undef NULL
-#define NULL 0L
+#include <cstddef>
 
 template<typename T>
 void functionTaking(T);


### PR DESCRIPTION
I can't know why exactly these buildbots were failing 10 years ago, but I suspect it's because the tests weren't passing an `-isystem` argument to `%check_clang_tidy`.