### PR TITLE
[CIR][NFC] Add 'matrix' type to CIRGenExprConstant.cpp switch

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenExprConstant.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprConstant.cpp
@@ -1950,6 +1950,9 @@ mlir::Attribute ConstantEmitter::tryEmitPrivate(const APValue &value,
     cgm.errorNYI(
         "ConstExprEmitter::tryEmitPrivate fixed point, addr label diff");
     return {};
+  case APValue::Matrix:
+    cgm.errorNYI("ConstExprEmitter::tryEmitPrivate matrix");
+    return {};
   }
   llvm_unreachable("Unknown APValue kind");
 }


### PR DESCRIPTION
This just adds this as an NYI, but this will suppress the Wswitch warning.