### PR TITLE
[clang][deps] Move-construct optional to fix a bot

### DIFF
--- a/clang/lib/Tooling/DependencyScanningTool.cpp
+++ b/clang/lib/Tooling/DependencyScanningTool.cpp
@@ -333,7 +333,7 @@ CompilerInstanceWithContext::initializeFromCommandline(
     if (!CIWithContext.initialize(std::move(DiagEngineWithCmdAndOpts),
                                   OverlayFS))
       return std::nullopt;
-    return CIWithContext;
+    return std::move(CIWithContext);
   }
 
   // The input command line is either a driver-style command line, or
@@ -350,7 +350,7 @@ CompilerInstanceWithContext::initializeFromCommandline(
                                             std::move(CC1CommandLine));
   if (!CIWithContext.initialize(std::move(DiagEngineWithCmdAndOpts), OverlayFS))
     return std::nullopt;
-  return CIWithContext;
+  return std::move(CIWithContext);
 }
 
 llvm::Expected<CompilerInstanceWithContext>


### PR DESCRIPTION
This is a speculative fix for the openmp-offload-sles-build-only build bot that fails after #184376 with:

```
clang/lib/Tooling/DependencyScanningTool.cpp:336:12: error: could not convert ‘CIWithContext’ from ‘clang::tooling::CompilerInstanceWithContext’ to ‘std::optional<clang::tooling::CompilerInstanceWithContext>’
     return CIWithContext;
            ^~~~~~~~~~~~~
```