### PR TITLE
[Clang][ExprConst] Handle APValue::LValue in BitCast

### DIFF
--- a/clang/lib/AST/ExprConstant.cpp
+++ b/clang/lib/AST/ExprConstant.cpp
@@ -7771,6 +7771,7 @@ class APValueToBufferConverter {
     case APValue::FixedPoint:
       // FIXME: We should support these.
 
+    case APValue::LValue:
     case APValue::Matrix:
     case APValue::Union:
     case APValue::MemberPointer:
@@ -7780,9 +7781,6 @@ class APValueToBufferConverter {
           << Ty;
       return false;
     }
-
-    case APValue::LValue:
-      llvm_unreachable("LValue subobject in bit_cast?");
     }
     llvm_unreachable("Unhandled APValue::ValueKind");
   }

--- a/clang/test/CodeGen/bitcast-based-lvalue.c
+++ b/clang/test/CodeGen/bitcast-based-lvalue.c
@@ -1,0 +1,7 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -emit-llvm -o - %s | FileCheck %s
+
+long fn(void) { return __builtin_bit_cast(long, (long)&fn); }
+
+// CHECK-LABEL: define{{.*}} i64 @fn()
+// CHECK: store i64 ptrtoint (ptr @fn to i64), ptr %ref.tmp, align 8
+// CHECK: ret i64 %{{.*}}


### PR DESCRIPTION
Instead of marking the branch unreachable, emit an unsupported type diagnostic and return false when encountering `APValue::LValue` in `APValueToBufferConverter`.

A good example of this is:
```
long fn() {
  return __builtin_bit_cast(long, (long)&fn);
}
```

Although `&fn` itself is a pointer type, the cast `(long)` converts it to an integer type, which passes `checkBitCastConstexprEligibilityType`. Thus, eventually, we see it in Converter, which does not expect an LValue.

Fixes https://github.com/llvm/llvm-project/issues/44991