### PR TITLE
[NFC][Clang][UnsafeBufferUsage] Check optional string before access.

### DIFF
--- a/clang/lib/Analysis/FixitUtil.cpp
+++ b/clang/lib/Analysis/FixitUtil.cpp
@@ -89,8 +89,12 @@ clang::getPointeeTypeText(const DeclaratorDecl *VD, const SourceManager &SM,
     // `PteTy` via source ranges.
     *QualifiersToAppend = PteTy.getQualifiers();
   }
-  return getRangeText({PteTyLoc.getBeginLoc(), PteEndOfTokenLoc}, SM, LangOpts)
-      ->str();
+
+  std::optional<StringRef> RangeText =
+      getRangeText({PteTyLoc.getBeginLoc(), PteEndOfTokenLoc}, SM, LangOpts);
+  if (!RangeText)
+    return std::nullopt;
+  return RangeText->str();
 }
 
 // returns text of pointee to pointee (T*&)

--- a/clang/test/SemaCXX/warn-unsafe-buffer-usage-fixits-parm-unsupported.cpp
+++ b/clang/test/SemaCXX/warn-unsafe-buffer-usage-fixits-parm-unsupported.cpp
@@ -3,6 +3,7 @@
 
 typedef int * TYPEDEF_PTR;
 #define MACRO_PTR int*
+#define MACRO_PTR_TO_CONST const int*
 
 // We CANNOT fix a pointer whose type is defined in a typedef or a
 // macro. Because if the typedef is changed after the fix, the fix
@@ -17,6 +18,13 @@ void typedefPointer(TYPEDEF_PTR p) {  // expected-warning{{'p' is an unsafe poin
 // CHECK-NOT: fix-it:"{{.*}}":{[[@LINE+1]]
 void macroPointer(MACRO_PTR p) {  // expected-warning{{'p' is an unsafe pointer used for buffer access}}
   if (++p) {  // expected-note{{used in pointer arithmetic here}}
+  }
+}
+
+// CHECK-NOT: fix-it:"{{.*}}":{[[@LINE+2]]
+void macroPointer2(const int *p) {
+  MACRO_PTR_TO_CONST *q = &p;  // expected-warning{{'q' is an unsafe pointer used for buffer access}}
+  if (++q) {  // expected-note{{used in pointer arithmetic here}}
   }
 }
 


### PR DESCRIPTION
Without this fix, the new test case results in a crash due to the unchecked optional access.