### PR TITLE
[clang-doc][NFC] Introduce OwnedPtr abstraction

### DIFF
--- a/clang-tools-extra/clang-doc/BitcodeReader.cpp
+++ b/clang-tools-extra/clang-doc/BitcodeReader.cpp
@@ -1076,16 +1076,15 @@ llvm::Error ClangDocBitcodeReader::readBlockInfoBlock() {
 }
 
 template <typename T>
-llvm::Expected<std::unique_ptr<Info>>
-ClangDocBitcodeReader::createInfo(unsigned ID) {
+llvm::Expected<OwnedPtr<Info>> ClangDocBitcodeReader::createInfo(unsigned ID) {
   llvm::TimeTraceScope("Reducing infos", "createInfo");
-  std::unique_ptr<Info> I = std::make_unique<T>();
+  OwnedPtr<Info> I = std::make_unique<T>();
   if (auto Err = readBlock(ID, static_cast<T *>(I.get())))
     return std::move(Err);
-  return std::unique_ptr<Info>{std::move(I)};
+  return OwnedPtr<Info>{std::move(I)};
 }
 
-llvm::Expected<std::unique_ptr<Info>>
+llvm::Expected<OwnedPtr<Info>>
 ClangDocBitcodeReader::readBlockToInfo(unsigned ID) {
   llvm::TimeTraceScope("Reducing infos", "readBlockToInfo");
   switch (ID) {
@@ -1112,9 +1111,9 @@ ClangDocBitcodeReader::readBlockToInfo(unsigned ID) {
 }
 
 // Entry point
-llvm::Expected<std::vector<std::unique_ptr<Info>>>
+llvm::Expected<std::vector<OwnedPtr<Info>>>
 ClangDocBitcodeReader::readBitcode() {
-  std::vector<std::unique_ptr<Info>> Infos;
+  std::vector<OwnedPtr<Info>> Infos;
   if (auto Err = validateStream())
     return std::move(Err);
 

--- a/clang-tools-extra/clang-doc/BitcodeReader.h
+++ b/clang-tools-extra/clang-doc/BitcodeReader.h
@@ -31,7 +31,7 @@ public:
       : Stream(Stream), Diags(Diags) {}
 
   // Main entry point, calls readBlock to read each block in the given stream.
-  llvm::Expected<std::vector<std::unique_ptr<Info>>> readBitcode();
+  llvm::Expected<std::vector<OwnedPtr<Info>>> readBitcode();
 
 private:
   enum class Cursor { BadBlock = 1, Record, BlockEnd, BlockBegin };
@@ -53,15 +53,14 @@ private:
   template <typename T> llvm::Error readRecord(unsigned ID, T I);
 
   // Allocate the relevant type of info and add read data to the object.
-  template <typename T>
-  llvm::Expected<std::unique_ptr<Info>> createInfo(unsigned ID);
+  template <typename T> llvm::Expected<OwnedPtr<Info>> createInfo(unsigned ID);
 
   // Helper function to step through blocks to find and dispatch the next record
   // or block to be read.
   llvm::Expected<Cursor> skipUntilRecordOrBlock(unsigned &BlockOrRecordID);
 
   // Helper function to set up the appropriate type of Info.
-  llvm::Expected<std::unique_ptr<Info>> readBlockToInfo(unsigned ID);
+  llvm::Expected<OwnedPtr<Info>> readBlockToInfo(unsigned ID);
 
   template <typename InfoType, typename T, typename CallbackFunction>
   llvm::Error handleSubBlock(unsigned ID, T Parent, CallbackFunction Function);

--- a/clang-tools-extra/clang-doc/ClangDoc.cpp
+++ b/clang-tools-extra/clang-doc/ClangDoc.cpp
@@ -25,18 +25,18 @@ namespace doc {
 class MapperActionFactory : public tooling::FrontendActionFactory {
 public:
   MapperActionFactory(ClangDocContext CDCtx) : CDCtx(CDCtx) {}
-  std::unique_ptr<FrontendAction> create() override;
+  OwnedPtr<FrontendAction> create() override;
 
 private:
   ClangDocContext CDCtx;
 };
 
-std::unique_ptr<FrontendAction> MapperActionFactory::create() {
+OwnedPtr<FrontendAction> MapperActionFactory::create() {
   class ClangDocAction : public clang::ASTFrontendAction {
   public:
     ClangDocAction(ClangDocContext CDCtx) : CDCtx(CDCtx) {}
 
-    std::unique_ptr<clang::ASTConsumer>
+    OwnedPtr<clang::ASTConsumer>
     CreateASTConsumer(clang::CompilerInstance &Compiler,
                       llvm::StringRef InFile) override {
       return std::make_unique<MapASTVisitor>(&Compiler.getASTContext(), CDCtx);
@@ -48,7 +48,7 @@ std::unique_ptr<FrontendAction> MapperActionFactory::create() {
   return std::make_unique<ClangDocAction>(CDCtx);
 }
 
-std::unique_ptr<tooling::FrontendActionFactory>
+OwnedPtr<tooling::FrontendActionFactory>
 newMapperActionFactory(ClangDocContext CDCtx) {
   return std::make_unique<MapperActionFactory>(CDCtx);
 }

--- a/clang-tools-extra/clang-doc/ClangDoc.h
+++ b/clang-tools-extra/clang-doc/ClangDoc.h
@@ -22,7 +22,7 @@
 namespace clang {
 namespace doc {
 
-std::unique_ptr<tooling::FrontendActionFactory>
+OwnedPtr<tooling::FrontendActionFactory>
 newMapperActionFactory(ClangDocContext CDCtx);
 
 } // namespace doc

--- a/clang-tools-extra/clang-doc/Generators.cpp
+++ b/clang-tools-extra/clang-doc/Generators.cpp
@@ -66,7 +66,7 @@ Error MustacheGenerator::setupTemplate(
 }
 
 Error MustacheGenerator::generateDocumentation(
-    StringRef RootDir, StringMap<std::unique_ptr<doc::Info>> Infos,
+    StringRef RootDir, StringMap<doc::OwnedPtr<doc::Info>> Infos,
     const clang::doc::ClangDocContext &CDCtx, std::string DirName) {
   {
     llvm::TimeTraceScope TS("Setup Templates");

--- a/clang-tools-extra/clang-doc/Generators.cpp
+++ b/clang-tools-extra/clang-doc/Generators.cpp
@@ -19,7 +19,7 @@ using namespace llvm::mustache;
 namespace clang {
 namespace doc {
 
-llvm::Expected<OwnedPtr<Generator>>
+llvm::Expected<std::unique_ptr<Generator>>
 findGeneratorByName(llvm::StringRef Format) {
   for (const auto &Generator : GeneratorRegistry::entries()) {
     if (Generator.getName() != Format)

--- a/clang-tools-extra/clang-doc/Generators.cpp
+++ b/clang-tools-extra/clang-doc/Generators.cpp
@@ -19,7 +19,7 @@ using namespace llvm::mustache;
 namespace clang {
 namespace doc {
 
-llvm::Expected<std::unique_ptr<Generator>>
+llvm::Expected<OwnedPtr<Generator>>
 findGeneratorByName(llvm::StringRef Format) {
   for (const auto &Generator : GeneratorRegistry::entries()) {
     if (Generator.getName() != Format)
@@ -53,7 +53,7 @@ Error createFileOpenError(StringRef FileName, std::error_code EC) {
 }
 
 Error MustacheGenerator::setupTemplate(
-    std::unique_ptr<MustacheTemplateFile> &Template, StringRef TemplatePath,
+    OwnedPtr<MustacheTemplateFile> &Template, StringRef TemplatePath,
     std::vector<std::pair<StringRef, StringRef>> Partials) {
   auto T = MustacheTemplateFile::createMustacheFile(TemplatePath);
   if (Error Err = T.takeError())

--- a/clang-tools-extra/clang-doc/Generators.h
+++ b/clang-tools-extra/clang-doc/Generators.h
@@ -30,7 +30,7 @@ public:
   // Write out the decl info for the objects in the given map in the specified
   // format.
   virtual llvm::Error generateDocumentation(
-      StringRef RootDir, llvm::StringMap<std::unique_ptr<doc::Info>> Infos,
+      StringRef RootDir, llvm::StringMap<doc::OwnedPtr<doc::Info>> Infos,
       const ClangDocContext &CDCtx, std::string DirName = "") = 0;
 
   // This function writes a file with the index previously constructed.
@@ -132,7 +132,7 @@ struct MustacheGenerator : public Generator {
   /// JSON, and calls generateDocForJSON for each file.
   /// 4. A file of the desired format is created.
   llvm::Error generateDocumentation(
-      StringRef RootDir, llvm::StringMap<std::unique_ptr<doc::Info>> Infos,
+      StringRef RootDir, llvm::StringMap<doc::OwnedPtr<doc::Info>> Infos,
       const clang::doc::ClangDocContext &CDCtx, std::string DirName) override;
 };
 

--- a/clang-tools-extra/clang-doc/Generators.h
+++ b/clang-tools-extra/clang-doc/Generators.h
@@ -48,7 +48,7 @@ public:
 
 typedef llvm::Registry<Generator> GeneratorRegistry;
 
-llvm::Expected<OwnedPtr<Generator>> findGeneratorByName(llvm::StringRef Format);
+llvm::Expected<std::unique_ptr<Generator>> findGeneratorByName(llvm::StringRef Format);
 
 llvm::StringRef getTagType(TagTypeKind AS);
 

--- a/clang-tools-extra/clang-doc/Generators.h
+++ b/clang-tools-extra/clang-doc/Generators.h
@@ -48,8 +48,7 @@ public:
 
 typedef llvm::Registry<Generator> GeneratorRegistry;
 
-llvm::Expected<std::unique_ptr<Generator>>
-findGeneratorByName(llvm::StringRef Format);
+llvm::Expected<OwnedPtr<Generator>> findGeneratorByName(llvm::StringRef Format);
 
 llvm::StringRef getTagType(TagTypeKind AS);
 
@@ -60,12 +59,12 @@ class MustacheTemplateFile {
   llvm::StringSaver Saver;
   llvm::mustache::MustacheContext Ctx;
   llvm::mustache::Template T;
-  std::unique_ptr<llvm::MemoryBuffer> Buffer;
+  OwnedPtr<llvm::MemoryBuffer> Buffer;
 
 public:
-  static Expected<std::unique_ptr<MustacheTemplateFile>>
+  static Expected<OwnedPtr<MustacheTemplateFile>>
   createMustacheFile(StringRef FileName) {
-    llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>> BufferOrError =
+    llvm::ErrorOr<OwnedPtr<llvm::MemoryBuffer>> BufferOrError =
         llvm::MemoryBuffer::getFile(FileName);
     if (auto EC = BufferOrError.getError())
       return createFileOpenError(FileName, EC);
@@ -74,12 +73,12 @@ public:
   }
 
   llvm::Error registerPartialFile(StringRef Name, StringRef FileName) {
-    llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>> BufferOrError =
+    llvm::ErrorOr<OwnedPtr<llvm::MemoryBuffer>> BufferOrError =
         llvm::MemoryBuffer::getFile(FileName);
     if (auto EC = BufferOrError.getError())
       return createFileOpenError(FileName, EC);
 
-    std::unique_ptr<llvm::MemoryBuffer> Buffer = std::move(BufferOrError.get());
+    OwnedPtr<llvm::MemoryBuffer> Buffer = std::move(BufferOrError.get());
     StringRef FileContent = Buffer->getBuffer();
     T.registerPartial(Name.str(), FileContent.str());
     return llvm::Error::success();
@@ -91,7 +90,7 @@ public:
     T.overrideEscapeCharacters(Characters);
   }
 
-  MustacheTemplateFile(std::unique_ptr<llvm::MemoryBuffer> &&B)
+  MustacheTemplateFile(OwnedPtr<llvm::MemoryBuffer> &&B)
       : Saver(Allocator), Ctx(Allocator, Saver), T(B->getBuffer(), Ctx),
         Buffer(std::move(B)) {}
 };
@@ -120,7 +119,7 @@ struct MustacheGenerator : public Generator {
 
   /// Registers partials to templates.
   llvm::Error
-  setupTemplate(std::unique_ptr<MustacheTemplateFile> &Template,
+  setupTemplate(OwnedPtr<MustacheTemplateFile> &Template,
                 StringRef TemplatePath,
                 std::vector<std::pair<StringRef, StringRef>> Partials);
 

--- a/clang-tools-extra/clang-doc/Generators.h
+++ b/clang-tools-extra/clang-doc/Generators.h
@@ -48,7 +48,8 @@ public:
 
 typedef llvm::Registry<Generator> GeneratorRegistry;
 
-llvm::Expected<std::unique_ptr<Generator>> findGeneratorByName(llvm::StringRef Format);
+llvm::Expected<std::unique_ptr<Generator>>
+findGeneratorByName(llvm::StringRef Format);
 
 llvm::StringRef getTagType(TagTypeKind AS);
 

--- a/clang-tools-extra/clang-doc/HTMLGenerator.cpp
+++ b/clang-tools-extra/clang-doc/HTMLGenerator.cpp
@@ -25,11 +25,11 @@ using namespace llvm::mustache;
 namespace clang {
 namespace doc {
 
-static std::unique_ptr<MustacheTemplateFile> NamespaceTemplate = nullptr;
+static OwnedPtr<MustacheTemplateFile> NamespaceTemplate = nullptr;
 
-static std::unique_ptr<MustacheTemplateFile> RecordTemplate = nullptr;
+static OwnedPtr<MustacheTemplateFile> RecordTemplate = nullptr;
 
-static std::unique_ptr<MustacheTemplateFile> IndexTemplate = nullptr;
+static OwnedPtr<MustacheTemplateFile> IndexTemplate = nullptr;
 
 class HTMLGenerator : public MustacheGenerator {
 public:

--- a/clang-tools-extra/clang-doc/HTMLGenerator.cpp
+++ b/clang-tools-extra/clang-doc/HTMLGenerator.cpp
@@ -45,7 +45,7 @@ public:
   Error setupTemplateResources(const ClangDocContext &CDCtx, json::Value &V,
                                SmallString<128> RelativeRootPath);
   llvm::Error generateDocumentation(
-      StringRef RootDir, llvm::StringMap<std::unique_ptr<doc::Info>> Infos,
+      StringRef RootDir, llvm::StringMap<doc::OwnedPtr<doc::Info>> Infos,
       const ClangDocContext &CDCtx, std::string DirName) override;
 };
 
@@ -183,7 +183,7 @@ Error HTMLGenerator::createResources(ClangDocContext &CDCtx) {
 }
 
 Error HTMLGenerator::generateDocumentation(
-    StringRef RootDir, llvm::StringMap<std::unique_ptr<doc::Info>> Infos,
+    StringRef RootDir, llvm::StringMap<doc::OwnedPtr<doc::Info>> Infos,
     const ClangDocContext &CDCtx, std::string DirName) {
   return MustacheGenerator::generateDocumentation(RootDir, std::move(Infos),
                                                   CDCtx, "html");

--- a/clang-tools-extra/clang-doc/JSONGenerator.cpp
+++ b/clang-tools-extra/clang-doc/JSONGenerator.cpp
@@ -8,32 +8,6 @@ using namespace llvm::json;
 namespace clang {
 namespace doc {
 
-// FIXME: These static methods should be refactored into methods for
-// `JSONGenerator`. It's cumbersome to pass around important properties from
-// ClangDocContext using these static methods.
-class JSONGenerator : public Generator {
-public:
-  static const char *Format;
-  bool Markdown = false;
-
-  Error generateDocumentation(StringRef RootDir,
-                              llvm::StringMap<doc::OwnedPtr<doc::Info>> Infos,
-                              const ClangDocContext &CDCtx,
-                              std::string DirName) override;
-  Error createResources(ClangDocContext &CDCtx) override;
-  Error generateDocForInfo(Info *I, llvm::raw_ostream &OS,
-                           const ClangDocContext &CDCtx) override;
-};
-
-const char *JSONGenerator::Format = "json";
-
-static void serializeInfo(const ConstraintInfo &I, Object &Obj);
-static void serializeInfo(const RecordInfo &I, Object &Obj,
-                          const std::optional<StringRef> &RepositoryUrl,
-                          const std::optional<StringRef> &RepositoryLinePrefix);
-
-static void serializeReference(const Reference &Ref, Object &ReferenceObj);
-
 template <typename Container, typename SerializationFunc>
 static void serializeArray(
     const Container &Records, Object &Obj, const StringRef Key,
@@ -92,7 +66,7 @@ public:
   bool Markdown;
 
   Error generateDocumentation(StringRef RootDir,
-                              llvm::StringMap<std::unique_ptr<doc::Info>> Infos,
+                              llvm::StringMap<OwnedPtr<doc::Info>> Infos,
                               const ClangDocContext &CDCtx,
                               std::string DirName) override;
   Error createResources(ClangDocContext &CDCtx) override;

--- a/clang-tools-extra/clang-doc/JSONGenerator.cpp
+++ b/clang-tools-extra/clang-doc/JSONGenerator.cpp
@@ -924,8 +924,7 @@ Error JSONGenerator::serializeIndex(StringRef RootDir) {
   return Error::success();
 }
 
-static void serializeContexts(Info *I,
-                              StringMap<OwnedPtr<Info>> &Infos) {
+static void serializeContexts(Info *I, StringMap<OwnedPtr<Info>> &Infos) {
   if (I->USR == GlobalNamespaceID)
     return;
   auto ParentUSR = I->ParentUSR;

--- a/clang-tools-extra/clang-doc/JSONGenerator.cpp
+++ b/clang-tools-extra/clang-doc/JSONGenerator.cpp
@@ -8,6 +8,32 @@ using namespace llvm::json;
 namespace clang {
 namespace doc {
 
+// FIXME: These static methods should be refactored into methods for
+// `JSONGenerator`. It's cumbersome to pass around important properties from
+// ClangDocContext using these static methods.
+class JSONGenerator : public Generator {
+public:
+  static const char *Format;
+  bool Markdown = false;
+
+  Error generateDocumentation(StringRef RootDir,
+                              llvm::StringMap<doc::OwnedPtr<doc::Info>> Infos,
+                              const ClangDocContext &CDCtx,
+                              std::string DirName) override;
+  Error createResources(ClangDocContext &CDCtx) override;
+  Error generateDocForInfo(Info *I, llvm::raw_ostream &OS,
+                           const ClangDocContext &CDCtx) override;
+};
+
+const char *JSONGenerator::Format = "json";
+
+static void serializeInfo(const ConstraintInfo &I, Object &Obj);
+static void serializeInfo(const RecordInfo &I, Object &Obj,
+                          const std::optional<StringRef> &RepositoryUrl,
+                          const std::optional<StringRef> &RepositoryLinePrefix);
+
+static void serializeReference(const Reference &Ref, Object &ReferenceObj);
+
 template <typename Container, typename SerializationFunc>
 static void serializeArray(
     const Container &Records, Object &Obj, const StringRef Key,
@@ -899,7 +925,7 @@ Error JSONGenerator::serializeIndex(StringRef RootDir) {
 }
 
 static void serializeContexts(Info *I,
-                              StringMap<std::unique_ptr<Info>> &Infos) {
+                              StringMap<OwnedPtr<Info>> &Infos) {
   if (I->USR == GlobalNamespaceID)
     return;
   auto ParentUSR = I->ParentUSR;
@@ -922,7 +948,7 @@ static void serializeContexts(Info *I,
 }
 
 Error JSONGenerator::generateDocumentation(
-    StringRef RootDir, llvm::StringMap<std::unique_ptr<doc::Info>> Infos,
+    StringRef RootDir, llvm::StringMap<doc::OwnedPtr<doc::Info>> Infos,
     const ClangDocContext &CDCtx, std::string DirName) {
   this->CDCtx = &CDCtx;
   StringSet<> CreatedDirs;

--- a/clang-tools-extra/clang-doc/MDGenerator.cpp
+++ b/clang-tools-extra/clang-doc/MDGenerator.cpp
@@ -405,7 +405,7 @@ public:
   static const char *Format;
 
   llvm::Error generateDocumentation(
-      StringRef RootDir, llvm::StringMap<std::unique_ptr<doc::Info>> Infos,
+      StringRef RootDir, llvm::StringMap<doc::OwnedPtr<doc::Info>> Infos,
       const ClangDocContext &CDCtx, std::string DirName) override;
   llvm::Error createResources(ClangDocContext &CDCtx) override;
   llvm::Error generateDocForInfo(Info *I, llvm::raw_ostream &OS,
@@ -415,7 +415,7 @@ public:
 const char *MDGenerator::Format = "md";
 
 llvm::Error MDGenerator::generateDocumentation(
-    StringRef RootDir, llvm::StringMap<std::unique_ptr<doc::Info>> Infos,
+    StringRef RootDir, llvm::StringMap<doc::OwnedPtr<doc::Info>> Infos,
     const ClangDocContext &CDCtx, std::string DirName) {
   // Track which directories we already tried to create.
   llvm::StringSet<> CreatedDirs;

--- a/clang-tools-extra/clang-doc/MDMustacheGenerator.cpp
+++ b/clang-tools-extra/clang-doc/MDMustacheGenerator.cpp
@@ -27,7 +27,7 @@ static std::unique_ptr<MustacheTemplateFile> IndexTemplate = nullptr;
 struct MDMustacheGenerator : public MustacheGenerator {
   static const char *Format;
   Error generateDocumentation(StringRef RootDir,
-                              StringMap<std::unique_ptr<doc::Info>> Infos,
+                              StringMap<doc::OwnedPtr<doc::Info>> Infos,
                               const ClangDocContext &CDCtx,
                               std::string DirName) override;
   Error setupTemplateFiles(const ClangDocContext &CDCtx) override;
@@ -72,7 +72,7 @@ Error MDMustacheGenerator::setupTemplateFiles(const ClangDocContext &CDCtx) {
 }
 
 Error MDMustacheGenerator::generateDocumentation(
-    StringRef RootDir, StringMap<std::unique_ptr<doc::Info>> Infos,
+    StringRef RootDir, StringMap<doc::OwnedPtr<doc::Info>> Infos,
     const clang::doc::ClangDocContext &CDCtx, std::string Dirname) {
   return MustacheGenerator::generateDocumentation(RootDir, std::move(Infos),
                                                   CDCtx, "md");

--- a/clang-tools-extra/clang-doc/MDMustacheGenerator.cpp
+++ b/clang-tools-extra/clang-doc/MDMustacheGenerator.cpp
@@ -16,13 +16,13 @@
 namespace clang {
 using namespace llvm;
 namespace doc {
-static std::unique_ptr<MustacheTemplateFile> RecordTemplate = nullptr;
+static OwnedPtr<MustacheTemplateFile> RecordTemplate = nullptr;
 
-static std::unique_ptr<MustacheTemplateFile> NamespaceTemplate = nullptr;
+static OwnedPtr<MustacheTemplateFile> NamespaceTemplate = nullptr;
 
-static std::unique_ptr<MustacheTemplateFile> AllFilesTemplate = nullptr;
+static OwnedPtr<MustacheTemplateFile> AllFilesTemplate = nullptr;
 
-static std::unique_ptr<MustacheTemplateFile> IndexTemplate = nullptr;
+static OwnedPtr<MustacheTemplateFile> IndexTemplate = nullptr;
 
 struct MDMustacheGenerator : public MustacheGenerator {
   static const char *Format;

--- a/clang-tools-extra/clang-doc/Mapper.cpp
+++ b/clang-tools-extra/clang-doc/Mapper.cpp
@@ -62,7 +62,7 @@ bool MapASTVisitor::mapDecl(const T *D, bool IsDefinition) {
       return true;
   }
 
-  std::pair<std::unique_ptr<Info>, std::unique_ptr<Info>> CP;
+  std::pair<OwnedPtr<Info>, OwnedPtr<Info>> CP;
 
   {
     llvm::TimeTraceScope TS("emit info from astnode");

--- a/clang-tools-extra/clang-doc/Representation.cpp
+++ b/clang-tools-extra/clang-doc/Representation.cpp
@@ -85,12 +85,12 @@ llvm::StringRef commentKindToString(CommentKind Kind) {
 const SymbolID EmptySID = SymbolID();
 
 template <typename T>
-static llvm::Expected<std::unique_ptr<Info>>
-reduce(std::vector<std::unique_ptr<Info>> &Values) {
+static llvm::Expected<OwnedPtr<Info>>
+reduce(std::vector<OwnedPtr<Info>> &Values) {
   if (Values.empty() || !Values[0])
     return llvm::createStringError(llvm::inconvertibleErrorCode(),
                                    "no value to reduce");
-  std::unique_ptr<Info> Merged = std::make_unique<T>(Values[0]->USR);
+  OwnedPtr<Info> Merged = std::make_unique<T>(Values[0]->USR);
   T *Tmp = static_cast<T *>(Merged.get());
   for (auto &I : Values)
     Tmp->merge(std::move(*static_cast<T *>(I.get())));
@@ -122,8 +122,7 @@ static void reduceChildren(std::vector<T> &Children,
 }
 
 // Dispatch function.
-llvm::Expected<std::unique_ptr<Info>>
-mergeInfos(std::vector<std::unique_ptr<Info>> &Values) {
+llvm::Expected<OwnedPtr<Info>> mergeInfos(std::vector<OwnedPtr<Info>> &Values) {
   if (Values.empty() || !Values[0])
     return llvm::createStringError(llvm::inconvertibleErrorCode(),
                                    "no info values to merge");

--- a/clang-tools-extra/clang-doc/Representation.h
+++ b/clang-tools-extra/clang-doc/Representation.h
@@ -21,11 +21,16 @@
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/SmallVector.h"
 #include <array>
+#include <memory>
 #include <optional>
 #include <string>
 
 namespace clang {
 namespace doc {
+
+// An abstraction for owned pointers. Initially mapped to std::unique_ptr,
+// to be eventually transitioned to bare pointers in an arena.
+template <typename T> using OwnedPtr = std::unique_ptr<T>;
 
 // SHA1'd hash of a USR.
 using SymbolID = std::array<uint8_t, 20>;
@@ -89,7 +94,7 @@ struct CommentInfo {
   // the vector.
   bool operator<(const CommentInfo &Other) const;
 
-  std::vector<std::unique_ptr<CommentInfo>>
+  std::vector<OwnedPtr<CommentInfo>>
       Children;              // List of child comments for this CommentInfo.
   SmallString<8> Direction;  // Parameter direction (for (T)ParamCommand).
   SmallString<16> Name;      // Name of the comment (for Verbatim and HTML).
@@ -625,8 +630,7 @@ struct Index : public Reference {
 // A standalone function to call to merge a vector of infos into one.
 // This assumes that all infos in the vector are of the same type, and will fail
 // if they are different.
-llvm::Expected<std::unique_ptr<Info>>
-mergeInfos(std::vector<std::unique_ptr<Info>> &Values);
+llvm::Expected<OwnedPtr<Info>> mergeInfos(std::vector<OwnedPtr<Info>> &Values);
 
 struct ClangDocContext {
   ClangDocContext(tooling::ExecutionContext *ECtx, StringRef ProjectName,

--- a/clang-tools-extra/clang-doc/Representation.h
+++ b/clang-tools-extra/clang-doc/Representation.h
@@ -28,7 +28,7 @@
 namespace clang {
 namespace doc {
 
-// An abstraction for owned pointers. Initially mapped to std::unique_ptr,
+// An abstraction for owned pointers. Initially mapped to OwnedPtr,
 // to be eventually transitioned to bare pointers in an arena.
 template <typename T> using OwnedPtr = std::unique_ptr<T>;
 

--- a/clang-tools-extra/clang-doc/Serialize.cpp
+++ b/clang-tools-extra/clang-doc/Serialize.cpp
@@ -346,7 +346,7 @@ static std::string serialize(T &I, DiagnosticsEngine &Diags) {
   return Buffer.str().str();
 }
 
-std::string serialize(std::unique_ptr<Info> &I, DiagnosticsEngine &Diags) {
+std::string serialize(OwnedPtr<Info> &I, DiagnosticsEngine &Diags) {
   switch (I->IT) {
   case InfoType::IT_namespace:
     return serialize(*static_cast<NamespaceInfo *>(I.get()), Diags);
@@ -488,7 +488,7 @@ static void InsertChild(ScopeChildren &Scope, VarInfo Info) {
 // parameter. Since each variant is used once, it's not worth having a more
 // elaborate system to automatically deduce this information.
 template <typename ChildType>
-static std::unique_ptr<Info> makeAndInsertIntoParent(ChildType Child) {
+static OwnedPtr<Info> makeAndInsertIntoParent(ChildType Child) {
   if (Child.Namespace.empty()) {
     // Insert into unnamed parent namespace.
     auto ParentNS = std::make_unique<NamespaceInfo>();
@@ -940,9 +940,10 @@ parseBases(RecordInfo &I, const CXXRecordDecl *D, bool IsFileInRootDir,
   }
 }
 
-std::pair<std::unique_ptr<Info>, std::unique_ptr<Info>>
-emitInfo(const NamespaceDecl *D, const FullComment *FC, Location Loc,
-         bool PublicOnly) {
+std::pair<OwnedPtr<Info>, OwnedPtr<Info>> emitInfo(const NamespaceDecl *D,
+                                                   const FullComment *FC,
+                                                   Location Loc,
+                                                   bool PublicOnly) {
   auto NSI = std::make_unique<NamespaceInfo>();
   bool IsInAnonymousNamespace = false;
   populateInfo(*NSI, D, FC, IsInAnonymousNamespace);
@@ -954,7 +955,7 @@ emitInfo(const NamespaceDecl *D, const FullComment *FC, Location Loc,
                   : NSI->Name;
   NSI->Path = getInfoRelativePath(NSI->Namespace);
   if (NSI->Namespace.empty() && NSI->USR == SymbolID())
-    return {std::unique_ptr<Info>{std::move(NSI)}, nullptr};
+    return {OwnedPtr<Info>{std::move(NSI)}, nullptr};
 
   // Namespaces are inserted into the parent by reference, so we need to return
   // both the parent and the record itself.
@@ -1011,9 +1012,10 @@ static void parseFriends(RecordInfo &RI, const CXXRecordDecl *D) {
   }
 }
 
-std::pair<std::unique_ptr<Info>, std::unique_ptr<Info>>
-emitInfo(const RecordDecl *D, const FullComment *FC, Location Loc,
-         bool PublicOnly) {
+std::pair<OwnedPtr<Info>, OwnedPtr<Info>> emitInfo(const RecordDecl *D,
+                                                   const FullComment *FC,
+                                                   Location Loc,
+                                                   bool PublicOnly) {
 
   auto RI = std::make_unique<RecordInfo>();
   bool IsInAnonymousNamespace = false;
@@ -1083,9 +1085,10 @@ emitInfo(const RecordDecl *D, const FullComment *FC, Location Loc,
   return {std::move(RI), std::move(Parent)};
 }
 
-std::pair<std::unique_ptr<Info>, std::unique_ptr<Info>>
-emitInfo(const FunctionDecl *D, const FullComment *FC, Location Loc,
-         bool PublicOnly) {
+std::pair<OwnedPtr<Info>, OwnedPtr<Info>> emitInfo(const FunctionDecl *D,
+                                                   const FullComment *FC,
+                                                   Location Loc,
+                                                   bool PublicOnly) {
   FunctionInfo Func;
   bool IsInAnonymousNamespace = false;
   populateFunctionInfo(Func, D, FC, Loc, IsInAnonymousNamespace);
@@ -1097,9 +1100,10 @@ emitInfo(const FunctionDecl *D, const FullComment *FC, Location Loc,
   return {nullptr, makeAndInsertIntoParent<FunctionInfo &&>(std::move(Func))};
 }
 
-std::pair<std::unique_ptr<Info>, std::unique_ptr<Info>>
-emitInfo(const CXXMethodDecl *D, const FullComment *FC, Location Loc,
-         bool PublicOnly) {
+std::pair<OwnedPtr<Info>, OwnedPtr<Info>> emitInfo(const CXXMethodDecl *D,
+                                                   const FullComment *FC,
+                                                   Location Loc,
+                                                   bool PublicOnly) {
   FunctionInfo Func;
   bool IsInAnonymousNamespace = false;
   populateFunctionInfo(Func, D, FC, Loc, IsInAnonymousNamespace);
@@ -1140,9 +1144,10 @@ static void extractCommentFromDecl(const Decl *D, TypedefInfo &Info) {
   }
 }
 
-std::pair<std::unique_ptr<Info>, std::unique_ptr<Info>>
-emitInfo(const TypedefDecl *D, const FullComment *FC, Location Loc,
-         bool PublicOnly) {
+std::pair<OwnedPtr<Info>, OwnedPtr<Info>> emitInfo(const TypedefDecl *D,
+                                                   const FullComment *FC,
+                                                   Location Loc,
+                                                   bool PublicOnly) {
   TypedefInfo Info;
   bool IsInAnonymousNamespace = false;
   populateInfo(Info, D, FC, IsInAnonymousNamespace);
@@ -1172,9 +1177,10 @@ emitInfo(const TypedefDecl *D, const FullComment *FC, Location Loc,
 
 // A type alias is a C++ "using" declaration for a type. It gets mapped to a
 // TypedefInfo with the IsUsing flag set.
-std::pair<std::unique_ptr<Info>, std::unique_ptr<Info>>
-emitInfo(const TypeAliasDecl *D, const FullComment *FC, Location Loc,
-         bool PublicOnly) {
+std::pair<OwnedPtr<Info>, OwnedPtr<Info>> emitInfo(const TypeAliasDecl *D,
+                                                   const FullComment *FC,
+                                                   Location Loc,
+                                                   bool PublicOnly) {
   TypedefInfo Info;
   bool IsInAnonymousNamespace = false;
   populateInfo(Info, D, FC, IsInAnonymousNamespace);
@@ -1196,9 +1202,10 @@ emitInfo(const TypeAliasDecl *D, const FullComment *FC, Location Loc,
   return {nullptr, makeAndInsertIntoParent<TypedefInfo &&>(std::move(Info))};
 }
 
-std::pair<std::unique_ptr<Info>, std::unique_ptr<Info>>
-emitInfo(const EnumDecl *D, const FullComment *FC, Location Loc,
-         bool PublicOnly) {
+std::pair<OwnedPtr<Info>, OwnedPtr<Info>> emitInfo(const EnumDecl *D,
+                                                   const FullComment *FC,
+                                                   Location Loc,
+                                                   bool PublicOnly) {
   EnumInfo Enum;
   bool IsInAnonymousNamespace = false;
   populateSymbolInfo(Enum, D, FC, Loc, IsInAnonymousNamespace);
@@ -1217,9 +1224,10 @@ emitInfo(const EnumDecl *D, const FullComment *FC, Location Loc,
   return {nullptr, makeAndInsertIntoParent<EnumInfo &&>(std::move(Enum))};
 }
 
-std::pair<std::unique_ptr<Info>, std::unique_ptr<Info>>
-emitInfo(const ConceptDecl *D, const FullComment *FC, const Location &Loc,
-         bool PublicOnly) {
+std::pair<OwnedPtr<Info>, OwnedPtr<Info>> emitInfo(const ConceptDecl *D,
+                                                   const FullComment *FC,
+                                                   const Location &Loc,
+                                                   bool PublicOnly) {
   ConceptInfo Concept;
 
   bool IsInAnonymousNamespace = false;
@@ -1241,9 +1249,10 @@ emitInfo(const ConceptDecl *D, const FullComment *FC, const Location &Loc,
   return {nullptr, makeAndInsertIntoParent<ConceptInfo &&>(std::move(Concept))};
 }
 
-std::pair<std::unique_ptr<Info>, std::unique_ptr<Info>>
-emitInfo(const VarDecl *D, const FullComment *FC, const Location &Loc,
-         bool PublicOnly) {
+std::pair<OwnedPtr<Info>, OwnedPtr<Info>> emitInfo(const VarDecl *D,
+                                                   const FullComment *FC,
+                                                   const Location &Loc,
+                                                   bool PublicOnly) {
   VarInfo Var;
   bool IsInAnonymousNamespace = false;
   populateSymbolInfo(Var, D, FC, Loc, IsInAnonymousNamespace);

--- a/clang-tools-extra/clang-doc/Serialize.h
+++ b/clang-tools-extra/clang-doc/Serialize.h
@@ -33,45 +33,54 @@ namespace serialize {
 // EnumDecl, FunctionDecl and CXXMethodDecl; they are only returned wrapped in
 // its parent scope. For NamespaceDecl and RecordDecl both elements are not
 // nullptr.
-std::pair<std::unique_ptr<Info>, std::unique_ptr<Info>>
-emitInfo(const NamespaceDecl *D, const FullComment *FC, Location Loc,
-         bool PublicOnly);
+std::pair<OwnedPtr<Info>, OwnedPtr<Info>> emitInfo(const NamespaceDecl *D,
+                                                   const FullComment *FC,
+                                                   Location Loc,
+                                                   bool PublicOnly);
 
-std::pair<std::unique_ptr<Info>, std::unique_ptr<Info>>
-emitInfo(const RecordDecl *D, const FullComment *FC, Location Loc,
-         bool PublicOnly);
+std::pair<OwnedPtr<Info>, OwnedPtr<Info>> emitInfo(const RecordDecl *D,
+                                                   const FullComment *FC,
+                                                   Location Loc,
+                                                   bool PublicOnly);
 
-std::pair<std::unique_ptr<Info>, std::unique_ptr<Info>>
-emitInfo(const EnumDecl *D, const FullComment *FC, Location Loc,
-         bool PublicOnly);
+std::pair<OwnedPtr<Info>, OwnedPtr<Info>> emitInfo(const EnumDecl *D,
+                                                   const FullComment *FC,
+                                                   Location Loc,
+                                                   bool PublicOnly);
 
-std::pair<std::unique_ptr<Info>, std::unique_ptr<Info>>
-emitInfo(const FunctionDecl *D, const FullComment *FC, Location Loc,
-         bool PublicOnly);
+std::pair<OwnedPtr<Info>, OwnedPtr<Info>> emitInfo(const FunctionDecl *D,
+                                                   const FullComment *FC,
+                                                   Location Loc,
+                                                   bool PublicOnly);
 
-std::pair<std::unique_ptr<Info>, std::unique_ptr<Info>>
+std::pair<OwnedPtr<Info>, OwnedPtr<Info>>
 emitInfo(const VarDecl *D, const FullComment *FC, int LineNumber,
          StringRef File, bool IsFileInRootDir, bool PublicOnly);
 
-std::pair<std::unique_ptr<Info>, std::unique_ptr<Info>>
-emitInfo(const CXXMethodDecl *D, const FullComment *FC, Location Loc,
-         bool PublicOnly);
+std::pair<OwnedPtr<Info>, OwnedPtr<Info>> emitInfo(const CXXMethodDecl *D,
+                                                   const FullComment *FC,
+                                                   Location Loc,
+                                                   bool PublicOnly);
 
-std::pair<std::unique_ptr<Info>, std::unique_ptr<Info>>
-emitInfo(const TypedefDecl *D, const FullComment *FC, Location Loc,
-         bool PublicOnly);
+std::pair<OwnedPtr<Info>, OwnedPtr<Info>> emitInfo(const TypedefDecl *D,
+                                                   const FullComment *FC,
+                                                   Location Loc,
+                                                   bool PublicOnly);
 
-std::pair<std::unique_ptr<Info>, std::unique_ptr<Info>>
-emitInfo(const TypeAliasDecl *D, const FullComment *FC, Location Loc,
-         bool PublicOnly);
+std::pair<OwnedPtr<Info>, OwnedPtr<Info>> emitInfo(const TypeAliasDecl *D,
+                                                   const FullComment *FC,
+                                                   Location Loc,
+                                                   bool PublicOnly);
 
-std::pair<std::unique_ptr<Info>, std::unique_ptr<Info>>
-emitInfo(const ConceptDecl *D, const FullComment *FC, const Location &Loc,
-         bool PublicOnly);
+std::pair<OwnedPtr<Info>, OwnedPtr<Info>> emitInfo(const ConceptDecl *D,
+                                                   const FullComment *FC,
+                                                   const Location &Loc,
+                                                   bool PublicOnly);
 
-std::pair<std::unique_ptr<Info>, std::unique_ptr<Info>>
-emitInfo(const VarDecl *D, const FullComment *FC, const Location &Loc,
-         bool PublicOnly);
+std::pair<OwnedPtr<Info>, OwnedPtr<Info>> emitInfo(const VarDecl *D,
+                                                   const FullComment *FC,
+                                                   const Location &Loc,
+                                                   bool PublicOnly);
 
 // Function to hash a given USR value for storage.
 // As USRs (Unified Symbol Resolution) could be large, especially for functions
@@ -80,7 +89,7 @@ emitInfo(const VarDecl *D, const FullComment *FC, const Location &Loc,
 // memory (vs storing USRs directly).
 SymbolID hashUSR(llvm::StringRef USR);
 
-std::string serialize(std::unique_ptr<Info> &I, DiagnosticsEngine &Diags);
+std::string serialize(OwnedPtr<Info> &I, DiagnosticsEngine &Diags);
 
 } // namespace serialize
 } // namespace doc

--- a/clang-tools-extra/clang-doc/YAMLGenerator.cpp
+++ b/clang-tools-extra/clang-doc/YAMLGenerator.cpp
@@ -346,7 +346,7 @@ public:
   static const char *Format;
 
   llvm::Error generateDocumentation(
-      StringRef RootDir, llvm::StringMap<std::unique_ptr<doc::Info>> Infos,
+      StringRef RootDir, llvm::StringMap<doc::OwnedPtr<doc::Info>> Infos,
       const ClangDocContext &CDCtx, std::string DirName) override;
   llvm::Error generateDocForInfo(Info *I, llvm::raw_ostream &OS,
                                  const ClangDocContext &CDCtx) override;
@@ -355,7 +355,7 @@ public:
 const char *YAMLGenerator::Format = "yaml";
 
 llvm::Error YAMLGenerator::generateDocumentation(
-    StringRef RootDir, llvm::StringMap<std::unique_ptr<doc::Info>> Infos,
+    StringRef RootDir, llvm::StringMap<doc::OwnedPtr<doc::Info>> Infos,
     const ClangDocContext &CDCtx, std::string DirName) {
   for (const auto &Group : Infos) {
     doc::Info *Info = Group.getValue().get();

--- a/clang-tools-extra/clang-doc/YAMLGenerator.cpp
+++ b/clang-tools-extra/clang-doc/YAMLGenerator.cpp
@@ -28,7 +28,7 @@ LLVM_YAML_IS_SEQUENCE_VECTOR(EnumValueInfo)
 LLVM_YAML_IS_SEQUENCE_VECTOR(TemplateParamInfo)
 LLVM_YAML_IS_SEQUENCE_VECTOR(TypedefInfo)
 LLVM_YAML_IS_SEQUENCE_VECTOR(BaseRecordInfo)
-LLVM_YAML_IS_SEQUENCE_VECTOR(std::unique_ptr<CommentInfo>)
+LLVM_YAML_IS_SEQUENCE_VECTOR(OwnedPtr<CommentInfo>)
 LLVM_YAML_IS_SEQUENCE_VECTOR(llvm::SmallString<16>)
 
 namespace llvm {
@@ -327,8 +327,8 @@ template <> struct MappingTraits<CommentInfo> {
   static void mapping(IO &IO, CommentInfo &I) { commentInfoMapping(IO, I); }
 };
 
-template <> struct MappingTraits<std::unique_ptr<CommentInfo>> {
-  static void mapping(IO &IO, std::unique_ptr<CommentInfo> &I) {
+template <> struct MappingTraits<OwnedPtr<CommentInfo>> {
+  static void mapping(IO &IO, OwnedPtr<CommentInfo> &I) {
     if (I)
       commentInfoMapping(IO, *I);
   }

--- a/clang-tools-extra/clang-doc/benchmarks/ClangDocBenchmark.cpp
+++ b/clang-tools-extra/clang-doc/benchmarks/ClangDocBenchmark.cpp
@@ -50,7 +50,7 @@ private:
 
 static void BM_EmitInfoFunction(benchmark::State &State) {
   std::string Code = "void f() {}";
-  std::unique_ptr<clang::ASTUnit> AST = clang::tooling::buildASTFromCode(Code);
+  OwnedPtr<clang::ASTUnit> AST = clang::tooling::buildASTFromCode(Code);
   const FunctionDecl *Func = nullptr;
   BenchmarkVisitor Visitor(Func);
   Visitor.TraverseDecl(AST->getASTContext().getTranslationUnitDecl());
@@ -82,7 +82,7 @@ static void BM_Mapper_Scale(benchmark::State &State) {
     ClangDocContext CDCtx(&ECtx, "test-project", false, "", "", "", "", "", {},
                           Diags, OutputFormatTy::json, false);
     auto ActionFactory = doc::newMapperActionFactory(CDCtx);
-    std::unique_ptr<FrontendAction> Action = ActionFactory->create();
+    OwnedPtr<FrontendAction> Action = ActionFactory->create();
     tooling::runToolOnCode(std::move(Action), Code, "test.cpp");
   }
 }
@@ -101,7 +101,7 @@ static void BM_SerializeFunctionInfo(benchmark::State &State) {
   DiagnosticOptions DiagOpts;
   DiagnosticsEngine Diags(DiagID, DiagOpts, new IgnoringDiagConsumer());
 
-  std::unique_ptr<Info> InfoPtr = std::move(I);
+  OwnedPtr<Info> InfoPtr = std::move(I);
 
   for (auto _ : State) {
     auto Result = serialize::serialize(InfoPtr, Diags);
@@ -116,7 +116,7 @@ static void BM_MergeInfos_Scale(benchmark::State &State) {
 
   for (auto _ : State) {
     State.PauseTiming();
-    std::vector<std::unique_ptr<Info>> Input;
+    std::vector<OwnedPtr<Info>> Input;
     Input.reserve(State.range(0));
     for (int i = 0; i < State.range(0); ++i) {
       auto I = std::make_unique<FunctionInfo>();

--- a/clang-tools-extra/clang-doc/tool/ClangDocMain.cpp
+++ b/clang-tools-extra/clang-doc/tool/ClangDocMain.cpp
@@ -224,7 +224,7 @@ static llvm::Error getMdFiles(const char *Argv0,
 /// Make the output of clang-doc deterministic by sorting the children of
 /// namespaces and records.
 static void
-sortUsrToInfo(llvm::StringMap<std::unique_ptr<doc::Info>> &USRToInfo) {
+sortUsrToInfo(llvm::StringMap<doc::OwnedPtr<doc::Info>> &USRToInfo) {
   for (auto &I : USRToInfo) {
     auto &Info = I.second;
     if (Info->IT == doc::InfoType::IT_namespace) {
@@ -339,7 +339,7 @@ Example usage for a project using a compile commands database:
     // Collects all Infos according to their unique USR value. This map is added
     // to from the thread pool below and is protected by the USRToInfoMutex.
     llvm::sys::Mutex USRToInfoMutex;
-    llvm::StringMap<std::unique_ptr<doc::Info>> USRToInfo;
+    llvm::StringMap<doc::OwnedPtr<doc::Info>> USRToInfo;
 
     // First reducing phase (reduce all decls into one info per decl).
     llvm::outs() << "Reducing " << USRToBitcode.size() << " infos...\n";
@@ -381,7 +381,7 @@ Example usage for a project using a compile commands database:
             }
           } // time trace decoding bitcode
 
-          std::unique_ptr<doc::Info> Reduced;
+          doc::OwnedPtr<doc::Info> Reduced;
 
           {
             llvm::TimeTraceScope Merge("merging bitcode");

--- a/clang-tools-extra/clang-doc/tool/ClangDocMain.cpp
+++ b/clang-tools-extra/clang-doc/tool/ClangDocMain.cpp
@@ -361,7 +361,7 @@ Example usage for a project using a compile commands database:
           if (FTimeTrace)
             llvm::timeTraceProfilerInitialize(200, "clang-doc");
 
-          std::vector<std::unique_ptr<doc::Info>> Infos;
+          std::vector<doc::OwnedPtr<doc::Info>> Infos;
           {
             llvm::TimeTraceScope Red("decoding bitcode");
             for (auto &Bitcode : Group.getValue()) {

--- a/clang-tools-extra/unittests/clang-doc/BitcodeTest.cpp
+++ b/clang-tools-extra/unittests/clang-doc/BitcodeTest.cpp
@@ -51,8 +51,8 @@ static std::string writeInfo(Info *I, DiagnosticsEngine &Diags) {
   }
 }
 
-static std::vector<OwnedPtr<Info>>
-readInfo(StringRef Bitcode, size_t NumInfos, DiagnosticsEngine &Diags) {
+static std::vector<OwnedPtr<Info>> readInfo(StringRef Bitcode, size_t NumInfos,
+                                            DiagnosticsEngine &Diags) {
   llvm::BitstreamCursor Stream(Bitcode);
   doc::ClangDocBitcodeReader Reader(Stream, Diags);
   auto Infos = Reader.readBitcode();

--- a/clang-tools-extra/unittests/clang-doc/BitcodeTest.cpp
+++ b/clang-tools-extra/unittests/clang-doc/BitcodeTest.cpp
@@ -51,7 +51,7 @@ static std::string writeInfo(Info *I, DiagnosticsEngine &Diags) {
   }
 }
 
-static std::vector<std::unique_ptr<Info>>
+static std::vector<OwnedPtr<Info>>
 readInfo(StringRef Bitcode, size_t NumInfos, DiagnosticsEngine &Diags) {
   llvm::BitstreamCursor Stream(Bitcode);
   doc::ClangDocBitcodeReader Reader(Stream, Diags);
@@ -78,7 +78,7 @@ TEST_F(BitcodeTest, emitNamespaceInfoBitcode) {
 
   std::string WriteResult = writeInfo(&I, this->Diags);
   EXPECT_TRUE(WriteResult.size() > 0);
-  std::vector<std::unique_ptr<Info>> ReadResults =
+  std::vector<OwnedPtr<Info>> ReadResults =
       readInfo(WriteResult, 1, this->Diags);
 
   CheckNamespaceInfo(&I, InfoAsNamespace(ReadResults[0].get()));
@@ -121,7 +121,7 @@ TEST_F(BitcodeTest, emitRecordInfoBitcode) {
 
   std::string WriteResult = writeInfo(&I, this->Diags);
   EXPECT_TRUE(WriteResult.size() > 0);
-  std::vector<std::unique_ptr<Info>> ReadResults =
+  std::vector<OwnedPtr<Info>> ReadResults =
       readInfo(WriteResult, 1, this->Diags);
 
   CheckRecordInfo(&I, InfoAsRecord(ReadResults[0].get()));
@@ -142,7 +142,7 @@ TEST_F(BitcodeTest, emitFunctionInfoBitcode) {
 
   std::string WriteResult = writeInfo(&I, this->Diags);
   EXPECT_TRUE(WriteResult.size() > 0);
-  std::vector<std::unique_ptr<Info>> ReadResults =
+  std::vector<OwnedPtr<Info>> ReadResults =
       readInfo(WriteResult, 1, this->Diags);
 
   CheckFunctionInfo(&I, InfoAsFunction(ReadResults[0].get()));
@@ -165,7 +165,7 @@ TEST_F(BitcodeTest, emitMethodInfoBitcode) {
 
   std::string WriteResult = writeInfo(&I, this->Diags);
   EXPECT_TRUE(WriteResult.size() > 0);
-  std::vector<std::unique_ptr<Info>> ReadResults =
+  std::vector<OwnedPtr<Info>> ReadResults =
       readInfo(WriteResult, 1, this->Diags);
 
   CheckFunctionInfo(&I, InfoAsFunction(ReadResults[0].get()));
@@ -184,7 +184,7 @@ TEST_F(BitcodeTest, emitEnumInfoBitcode) {
 
   std::string WriteResult = writeInfo(&I, this->Diags);
   EXPECT_TRUE(WriteResult.size() > 0);
-  std::vector<std::unique_ptr<Info>> ReadResults =
+  std::vector<OwnedPtr<Info>> ReadResults =
       readInfo(WriteResult, 1, this->Diags);
 
   CheckEnumInfo(&I, InfoAsEnum(ReadResults[0].get()));
@@ -212,7 +212,7 @@ TEST_F(BitcodeTest, emitTypedefInfoBitcode) {
 
   std::string WriteResult = writeInfo(&I, this->Diags);
   EXPECT_TRUE(WriteResult.size() > 0);
-  std::vector<std::unique_ptr<Info>> ReadResults =
+  std::vector<OwnedPtr<Info>> ReadResults =
       readInfo(WriteResult, 1, this->Diags);
 
   CheckTypedefInfo(&I, InfoAsTypedef(ReadResults[0].get()));
@@ -342,7 +342,7 @@ TEST_F(BitcodeTest, emitInfoWithCommentBitcode) {
 
   std::string WriteResult = writeInfo(&F, this->Diags);
   EXPECT_TRUE(WriteResult.size() > 0);
-  std::vector<std::unique_ptr<Info>> ReadResults =
+  std::vector<OwnedPtr<Info>> ReadResults =
       readInfo(WriteResult, 1, this->Diags);
 
   CheckFunctionInfo(&F, InfoAsFunction(ReadResults[0].get()));

--- a/clang-tools-extra/unittests/clang-doc/ClangDocTest.cpp
+++ b/clang-tools-extra/unittests/clang-doc/ClangDocTest.cpp
@@ -56,8 +56,8 @@ TypedefInfo *InfoAsTypedef(Info *I) {
 
 void CheckCommentInfo(const std::vector<CommentInfo> &Expected,
                       const std::vector<CommentInfo> &Actual);
-void CheckCommentInfo(const std::vector<std::unique_ptr<CommentInfo>> &Expected,
-                      const std::vector<std::unique_ptr<CommentInfo>> &Actual);
+void CheckCommentInfo(const std::vector<OwnedPtr<CommentInfo>> &Expected,
+                      const std::vector<OwnedPtr<CommentInfo>> &Actual);
 
 void CheckCommentInfo(const CommentInfo &Expected, const CommentInfo &Actual) {
   EXPECT_EQ(Expected.Kind, Actual.Kind);
@@ -91,8 +91,8 @@ void CheckCommentInfo(const std::vector<CommentInfo> &Expected,
     CheckCommentInfo(Expected[Idx], Actual[Idx]);
 }
 
-void CheckCommentInfo(const std::vector<std::unique_ptr<CommentInfo>> &Expected,
-                      const std::vector<std::unique_ptr<CommentInfo>> &Actual) {
+void CheckCommentInfo(const std::vector<OwnedPtr<CommentInfo>> &Expected,
+                      const std::vector<OwnedPtr<CommentInfo>> &Actual) {
   ASSERT_EQ(Expected.size(), Actual.size());
   for (size_t Idx = 0; Idx < Actual.size(); ++Idx)
     CheckCommentInfo(*Expected[Idx], *Actual[Idx]);

--- a/clang-tools-extra/unittests/clang-doc/ClangDocTest.h
+++ b/clang-tools-extra/unittests/clang-doc/ClangDocTest.h
@@ -19,7 +19,7 @@
 namespace clang {
 namespace doc {
 
-using EmittedInfoList = std::vector<std::unique_ptr<Info>>;
+using EmittedInfoList = std::vector<OwnedPtr<Info>>;
 
 static const SymbolID EmptySID = SymbolID();
 static const SymbolID NonEmptySID =

--- a/clang-tools-extra/unittests/clang-doc/MergeTest.cpp
+++ b/clang-tools-extra/unittests/clang-doc/MergeTest.cpp
@@ -44,7 +44,7 @@ TEST_F(MergeTest, mergeNamespaceInfos) {
   Two.Children.Enums.emplace_back();
   Two.Children.Enums.back().Name = "TwoEnum";
 
-  std::vector<std::unique_ptr<Info>> Infos;
+  std::vector<OwnedPtr<Info>> Infos;
   Infos.emplace_back(std::make_unique<NamespaceInfo>(std::move(One)));
   Infos.emplace_back(std::make_unique<NamespaceInfo>(std::move(Two)));
 
@@ -116,7 +116,7 @@ TEST_F(MergeTest, mergeRecordInfos) {
   Two.Children.Enums.emplace_back();
   Two.Children.Enums.back().Name = "TwoEnum";
 
-  std::vector<std::unique_ptr<Info>> Infos;
+  std::vector<OwnedPtr<Info>> Infos;
   Infos.emplace_back(std::make_unique<RecordInfo>(std::move(One)));
   Infos.emplace_back(std::make_unique<RecordInfo>(std::move(Two)));
 
@@ -197,7 +197,7 @@ TEST_F(MergeTest, mergeFunctionInfos) {
   TwoParagraphComment->Children.push_back(std::move(TwoTextComment));
   TwoFullComment->Children.push_back(std::move(TwoParagraphComment));
 
-  std::vector<std::unique_ptr<Info>> Infos;
+  std::vector<OwnedPtr<Info>> Infos;
   Infos.emplace_back(std::make_unique<FunctionInfo>(std::move(One)));
   Infos.emplace_back(std::make_unique<FunctionInfo>(std::move(Two)));
 
@@ -249,7 +249,7 @@ TEST_F(MergeTest, mergeEnumInfos) {
   Two.Members.emplace_back("X");
   Two.Members.emplace_back("Y");
 
-  std::vector<std::unique_ptr<Info>> Infos;
+  std::vector<OwnedPtr<Info>> Infos;
   Infos.emplace_back(std::make_unique<EnumInfo>(std::move(One)));
   Infos.emplace_back(std::make_unique<EnumInfo>(std::move(Two)));
 


### PR DESCRIPTION
Eventually, we want clang-doc to support arena allocation, but the
widespread use of owning pointers in the data types prevents this.
Rather than have wide scale refactoring, we can introduce a type alias
that can be swapped out atomically to switch from smart pointers to raw
pointers. This is the first of several refactorings that are intended to
make the transition simpler.