### PR TITLE
[clang-doc] Introduce type alias for OwningPtrVec/Array

### DIFF
--- a/clang-tools-extra/clang-doc/BitcodeReader.cpp
+++ b/clang-tools-extra/clang-doc/BitcodeReader.cpp
@@ -1111,9 +1111,8 @@ ClangDocBitcodeReader::readBlockToInfo(unsigned ID) {
 }
 
 // Entry point
-llvm::Expected<std::vector<OwnedPtr<Info>>>
-ClangDocBitcodeReader::readBitcode() {
-  std::vector<OwnedPtr<Info>> Infos;
+llvm::Expected<OwningPtrArray<Info>> ClangDocBitcodeReader::readBitcode() {
+  OwningPtrArray<Info> Infos;
   if (auto Err = validateStream())
     return std::move(Err);
 

--- a/clang-tools-extra/clang-doc/BitcodeReader.h
+++ b/clang-tools-extra/clang-doc/BitcodeReader.h
@@ -31,7 +31,7 @@ public:
       : Stream(Stream), Diags(Diags) {}
 
   // Main entry point, calls readBlock to read each block in the given stream.
-  llvm::Expected<std::vector<OwnedPtr<Info>>> readBitcode();
+  llvm::Expected<OwningPtrArray<Info>> readBitcode();
 
 private:
   enum class Cursor { BadBlock = 1, Record, BlockEnd, BlockBegin };

--- a/clang-tools-extra/clang-doc/Representation.cpp
+++ b/clang-tools-extra/clang-doc/Representation.cpp
@@ -85,8 +85,7 @@ llvm::StringRef commentKindToString(CommentKind Kind) {
 const SymbolID EmptySID = SymbolID();
 
 template <typename T>
-static llvm::Expected<OwnedPtr<Info>>
-reduce(std::vector<OwnedPtr<Info>> &Values) {
+static llvm::Expected<OwnedPtr<Info>> reduce(OwningPtrArray<Info> &Values) {
   if (Values.empty() || !Values[0])
     return llvm::createStringError(llvm::inconvertibleErrorCode(),
                                    "no value to reduce");
@@ -122,7 +121,7 @@ static void reduceChildren(OwningVec<T> &Children,
 }
 
 // Dispatch function.
-llvm::Expected<OwnedPtr<Info>> mergeInfos(std::vector<OwnedPtr<Info>> &Values) {
+llvm::Expected<OwnedPtr<Info>> mergeInfos(OwningPtrArray<Info> &Values) {
   if (Values.empty() || !Values[0])
     return llvm::createStringError(llvm::inconvertibleErrorCode(),
                                    "no info values to merge");

--- a/clang-tools-extra/clang-doc/Representation.h
+++ b/clang-tools-extra/clang-doc/Representation.h
@@ -40,6 +40,14 @@ template <typename T> using OwningArray = std::vector<T>;
 // To be eventually transitioned to llvm::simple_ilist.
 template <typename T> using OwningVec = std::vector<T>;
 
+// An abstraction for dynamic lists of owned pointers.
+// To be eventually transitioned to llvm::simple_ilist<T*> or similar.
+template <typename T> using OwningPtrVec = std::vector<OwnedPtr<T>>;
+
+// An abstraction for arrays of owned pointers.
+// To be eventually transitioned to arena-allocated arrays of bare pointers.
+template <typename T> using OwningPtrArray = std::vector<OwnedPtr<T>>;
+
 // SHA1'd hash of a USR.
 using SymbolID = std::array<uint8_t, 20>;
 
@@ -102,7 +110,7 @@ struct CommentInfo {
   // the vector.
   bool operator<(const CommentInfo &Other) const;
 
-  OwningVec<OwnedPtr<CommentInfo>>
+  OwningPtrVec<CommentInfo>
       Children;              // List of child comments for this CommentInfo.
   SmallString<8> Direction;  // Parameter direction (for (T)ParamCommand).
   SmallString<16> Name;      // Name of the comment (for Verbatim and HTML).
@@ -637,7 +645,7 @@ struct Index : public Reference {
 // A standalone function to call to merge a vector of infos into one.
 // This assumes that all infos in the vector are of the same type, and will fail
 // if they are different.
-llvm::Expected<OwnedPtr<Info>> mergeInfos(std::vector<OwnedPtr<Info>> &Values);
+llvm::Expected<OwnedPtr<Info>> mergeInfos(OwningPtrArray<Info> &Values);
 
 struct ClangDocContext {
   ClangDocContext(tooling::ExecutionContext *ECtx, StringRef ProjectName,

--- a/clang-tools-extra/clang-doc/benchmarks/ClangDocBenchmark.cpp
+++ b/clang-tools-extra/clang-doc/benchmarks/ClangDocBenchmark.cpp
@@ -116,7 +116,7 @@ static void BM_MergeInfos_Scale(benchmark::State &State) {
 
   for (auto _ : State) {
     State.PauseTiming();
-    std::vector<OwnedPtr<Info>> Input;
+    OwningPtrArray<Info> Input;
     Input.reserve(State.range(0));
     for (int i = 0; i < State.range(0); ++i) {
       auto I = std::make_unique<FunctionInfo>();

--- a/clang-tools-extra/clang-doc/tool/ClangDocMain.cpp
+++ b/clang-tools-extra/clang-doc/tool/ClangDocMain.cpp
@@ -361,7 +361,7 @@ Example usage for a project using a compile commands database:
           if (FTimeTrace)
             llvm::timeTraceProfilerInitialize(200, "clang-doc");
 
-          std::vector<doc::OwnedPtr<doc::Info>> Infos;
+          doc::OwningPtrVec<doc::Info> Infos;
           {
             llvm::TimeTraceScope Red("decoding bitcode");
             for (auto &Bitcode : Group.getValue()) {

--- a/clang-tools-extra/unittests/clang-doc/BitcodeTest.cpp
+++ b/clang-tools-extra/unittests/clang-doc/BitcodeTest.cpp
@@ -51,8 +51,8 @@ static std::string writeInfo(Info *I, DiagnosticsEngine &Diags) {
   }
 }
 
-static std::vector<OwnedPtr<Info>> readInfo(StringRef Bitcode, size_t NumInfos,
-                                            DiagnosticsEngine &Diags) {
+static OwningPtrVec<Info> readInfo(StringRef Bitcode, size_t NumInfos,
+                                   DiagnosticsEngine &Diags) {
   llvm::BitstreamCursor Stream(Bitcode);
   doc::ClangDocBitcodeReader Reader(Stream, Diags);
   auto Infos = Reader.readBitcode();
@@ -78,8 +78,7 @@ TEST_F(BitcodeTest, emitNamespaceInfoBitcode) {
 
   std::string WriteResult = writeInfo(&I, this->Diags);
   EXPECT_TRUE(WriteResult.size() > 0);
-  OwningPtrVec<Info> ReadResults =
-      readInfo(WriteResult, 1, this->Diags);
+  OwningPtrVec<Info> ReadResults = readInfo(WriteResult, 1, this->Diags);
 
   CheckNamespaceInfo(&I, InfoAsNamespace(ReadResults[0].get()));
 }
@@ -121,8 +120,7 @@ TEST_F(BitcodeTest, emitRecordInfoBitcode) {
 
   std::string WriteResult = writeInfo(&I, this->Diags);
   EXPECT_TRUE(WriteResult.size() > 0);
-  OwningPtrVec<Info> ReadResults =
-      readInfo(WriteResult, 1, this->Diags);
+  OwningPtrVec<Info> ReadResults = readInfo(WriteResult, 1, this->Diags);
 
   CheckRecordInfo(&I, InfoAsRecord(ReadResults[0].get()));
 }
@@ -142,8 +140,7 @@ TEST_F(BitcodeTest, emitFunctionInfoBitcode) {
 
   std::string WriteResult = writeInfo(&I, this->Diags);
   EXPECT_TRUE(WriteResult.size() > 0);
-  OwningPtrVec<Info> ReadResults =
-      readInfo(WriteResult, 1, this->Diags);
+  OwningPtrVec<Info> ReadResults = readInfo(WriteResult, 1, this->Diags);
 
   CheckFunctionInfo(&I, InfoAsFunction(ReadResults[0].get()));
 }
@@ -165,8 +162,7 @@ TEST_F(BitcodeTest, emitMethodInfoBitcode) {
 
   std::string WriteResult = writeInfo(&I, this->Diags);
   EXPECT_TRUE(WriteResult.size() > 0);
-  OwningPtrVec<Info> ReadResults =
-      readInfo(WriteResult, 1, this->Diags);
+  OwningPtrVec<Info> ReadResults = readInfo(WriteResult, 1, this->Diags);
 
   CheckFunctionInfo(&I, InfoAsFunction(ReadResults[0].get()));
 }
@@ -184,8 +180,7 @@ TEST_F(BitcodeTest, emitEnumInfoBitcode) {
 
   std::string WriteResult = writeInfo(&I, this->Diags);
   EXPECT_TRUE(WriteResult.size() > 0);
-  OwningPtrVec<Info> ReadResults =
-      readInfo(WriteResult, 1, this->Diags);
+  OwningPtrVec<Info> ReadResults = readInfo(WriteResult, 1, this->Diags);
 
   CheckEnumInfo(&I, InfoAsEnum(ReadResults[0].get()));
 }
@@ -212,8 +207,7 @@ TEST_F(BitcodeTest, emitTypedefInfoBitcode) {
 
   std::string WriteResult = writeInfo(&I, this->Diags);
   EXPECT_TRUE(WriteResult.size() > 0);
-  OwningPtrVec<Info> ReadResults =
-      readInfo(WriteResult, 1, this->Diags);
+  OwningPtrVec<Info> ReadResults = readInfo(WriteResult, 1, this->Diags);
 
   CheckTypedefInfo(&I, InfoAsTypedef(ReadResults[0].get()));
 
@@ -342,8 +336,7 @@ TEST_F(BitcodeTest, emitInfoWithCommentBitcode) {
 
   std::string WriteResult = writeInfo(&F, this->Diags);
   EXPECT_TRUE(WriteResult.size() > 0);
-  OwningPtrVec<Info> ReadResults =
-      readInfo(WriteResult, 1, this->Diags);
+  OwningPtrVec<Info> ReadResults = readInfo(WriteResult, 1, this->Diags);
 
   CheckFunctionInfo(&F, InfoAsFunction(ReadResults[0].get()));
 }

--- a/clang-tools-extra/unittests/clang-doc/BitcodeTest.cpp
+++ b/clang-tools-extra/unittests/clang-doc/BitcodeTest.cpp
@@ -78,7 +78,7 @@ TEST_F(BitcodeTest, emitNamespaceInfoBitcode) {
 
   std::string WriteResult = writeInfo(&I, this->Diags);
   EXPECT_TRUE(WriteResult.size() > 0);
-  std::vector<OwnedPtr<Info>> ReadResults =
+  OwningPtrVec<Info> ReadResults =
       readInfo(WriteResult, 1, this->Diags);
 
   CheckNamespaceInfo(&I, InfoAsNamespace(ReadResults[0].get()));
@@ -121,7 +121,7 @@ TEST_F(BitcodeTest, emitRecordInfoBitcode) {
 
   std::string WriteResult = writeInfo(&I, this->Diags);
   EXPECT_TRUE(WriteResult.size() > 0);
-  std::vector<OwnedPtr<Info>> ReadResults =
+  OwningPtrVec<Info> ReadResults =
       readInfo(WriteResult, 1, this->Diags);
 
   CheckRecordInfo(&I, InfoAsRecord(ReadResults[0].get()));
@@ -142,7 +142,7 @@ TEST_F(BitcodeTest, emitFunctionInfoBitcode) {
 
   std::string WriteResult = writeInfo(&I, this->Diags);
   EXPECT_TRUE(WriteResult.size() > 0);
-  std::vector<OwnedPtr<Info>> ReadResults =
+  OwningPtrVec<Info> ReadResults =
       readInfo(WriteResult, 1, this->Diags);
 
   CheckFunctionInfo(&I, InfoAsFunction(ReadResults[0].get()));
@@ -165,7 +165,7 @@ TEST_F(BitcodeTest, emitMethodInfoBitcode) {
 
   std::string WriteResult = writeInfo(&I, this->Diags);
   EXPECT_TRUE(WriteResult.size() > 0);
-  std::vector<OwnedPtr<Info>> ReadResults =
+  OwningPtrVec<Info> ReadResults =
       readInfo(WriteResult, 1, this->Diags);
 
   CheckFunctionInfo(&I, InfoAsFunction(ReadResults[0].get()));
@@ -184,7 +184,7 @@ TEST_F(BitcodeTest, emitEnumInfoBitcode) {
 
   std::string WriteResult = writeInfo(&I, this->Diags);
   EXPECT_TRUE(WriteResult.size() > 0);
-  std::vector<OwnedPtr<Info>> ReadResults =
+  OwningPtrVec<Info> ReadResults =
       readInfo(WriteResult, 1, this->Diags);
 
   CheckEnumInfo(&I, InfoAsEnum(ReadResults[0].get()));
@@ -212,7 +212,7 @@ TEST_F(BitcodeTest, emitTypedefInfoBitcode) {
 
   std::string WriteResult = writeInfo(&I, this->Diags);
   EXPECT_TRUE(WriteResult.size() > 0);
-  std::vector<OwnedPtr<Info>> ReadResults =
+  OwningPtrVec<Info> ReadResults =
       readInfo(WriteResult, 1, this->Diags);
 
   CheckTypedefInfo(&I, InfoAsTypedef(ReadResults[0].get()));
@@ -342,7 +342,7 @@ TEST_F(BitcodeTest, emitInfoWithCommentBitcode) {
 
   std::string WriteResult = writeInfo(&F, this->Diags);
   EXPECT_TRUE(WriteResult.size() > 0);
-  std::vector<OwnedPtr<Info>> ReadResults =
+  OwningPtrVec<Info> ReadResults =
       readInfo(WriteResult, 1, this->Diags);
 
   CheckFunctionInfo(&F, InfoAsFunction(ReadResults[0].get()));

--- a/clang-tools-extra/unittests/clang-doc/ClangDocTest.h
+++ b/clang-tools-extra/unittests/clang-doc/ClangDocTest.h
@@ -19,7 +19,7 @@
 namespace clang {
 namespace doc {
 
-using EmittedInfoList = std::vector<OwnedPtr<Info>>;
+using EmittedInfoList = OwningPtrVec<Info>;
 
 static const SymbolID EmptySID = SymbolID();
 static const SymbolID NonEmptySID =

--- a/clang-tools-extra/unittests/clang-doc/MergeTest.cpp
+++ b/clang-tools-extra/unittests/clang-doc/MergeTest.cpp
@@ -44,7 +44,7 @@ TEST_F(MergeTest, mergeNamespaceInfos) {
   Two.Children.Enums.emplace_back();
   Two.Children.Enums.back().Name = "TwoEnum";
 
-  std::vector<OwnedPtr<Info>> Infos;
+  OwningPtrVec<Info> Infos;
   Infos.emplace_back(std::make_unique<NamespaceInfo>(std::move(One)));
   Infos.emplace_back(std::make_unique<NamespaceInfo>(std::move(Two)));
 
@@ -116,7 +116,7 @@ TEST_F(MergeTest, mergeRecordInfos) {
   Two.Children.Enums.emplace_back();
   Two.Children.Enums.back().Name = "TwoEnum";
 
-  std::vector<OwnedPtr<Info>> Infos;
+  OwningPtrVec<Info> Infos;
   Infos.emplace_back(std::make_unique<RecordInfo>(std::move(One)));
   Infos.emplace_back(std::make_unique<RecordInfo>(std::move(Two)));
 
@@ -197,7 +197,7 @@ TEST_F(MergeTest, mergeFunctionInfos) {
   TwoParagraphComment->Children.push_back(std::move(TwoTextComment));
   TwoFullComment->Children.push_back(std::move(TwoParagraphComment));
 
-  std::vector<OwnedPtr<Info>> Infos;
+  OwningPtrVec<Info> Infos;
   Infos.emplace_back(std::make_unique<FunctionInfo>(std::move(One)));
   Infos.emplace_back(std::make_unique<FunctionInfo>(std::move(Two)));
 
@@ -249,7 +249,7 @@ TEST_F(MergeTest, mergeEnumInfos) {
   Two.Members.emplace_back("X");
   Two.Members.emplace_back("Y");
 
-  std::vector<OwnedPtr<Info>> Infos;
+  OwningPtrVec<Info> Infos;
   Infos.emplace_back(std::make_unique<EnumInfo>(std::move(One)));
   Infos.emplace_back(std::make_unique<EnumInfo>(std::move(Two)));
 


### PR DESCRIPTION
We commonly have vectors/arrays of owned pointers. This should simplify
future refactoring when switching to arena allocation.