### PR TITLE
[clang-doc] Introduce abstractions for pointer operations

### DIFF
--- a/clang-tools-extra/clang-doc/BitcodeReader.cpp
+++ b/clang-tools-extra/clang-doc/BitcodeReader.cpp
@@ -507,8 +507,8 @@ template <> llvm::Expected<CommentInfo *> getCommentInfo(EnumValueInfo *I) {
 }
 
 template <> llvm::Expected<CommentInfo *> getCommentInfo(CommentInfo *I) {
-  I->Children.emplace_back(std::make_unique<CommentInfo>());
-  return I->Children.back().get();
+  I->Children.emplace_back(allocatePtr<CommentInfo>());
+  return getPtr(I->Children.back());
 }
 
 template <> llvm::Expected<CommentInfo *> getCommentInfo(ConceptInfo *I) {
@@ -1078,8 +1078,8 @@ llvm::Error ClangDocBitcodeReader::readBlockInfoBlock() {
 template <typename T>
 llvm::Expected<OwnedPtr<Info>> ClangDocBitcodeReader::createInfo(unsigned ID) {
   llvm::TimeTraceScope("Reducing infos", "createInfo");
-  OwnedPtr<Info> I = std::make_unique<T>();
-  if (auto Err = readBlock(ID, static_cast<T *>(I.get())))
+  OwnedPtr<Info> I = doc::allocatePtr<T>();
+  if (auto Err = readBlock(ID, static_cast<T *>(getPtr(I))))
     return std::move(Err);
   return OwnedPtr<Info>{std::move(I)};
 }

--- a/clang-tools-extra/clang-doc/JSONGenerator.cpp
+++ b/clang-tools-extra/clang-doc/JSONGenerator.cpp
@@ -927,7 +927,7 @@ Error JSONGenerator::generateDocumentation(
   StringSet<> CreatedDirs;
   StringMap<std::vector<doc::Info *>> FileToInfos;
   for (const auto &Group : Infos) {
-    Info *Info = Group.getValue().get();
+    Info *Info = getPtr(Group.getValue());
 
     SmallString<128> Path;
     auto RootDirStr = RootDir.str() + "/json";

--- a/clang-tools-extra/clang-doc/MDGenerator.cpp
+++ b/clang-tools-extra/clang-doc/MDGenerator.cpp
@@ -423,7 +423,7 @@ llvm::Error MDGenerator::generateDocumentation(
   // Collect all output by file name and create the necessary directories.
   llvm::StringMap<std::vector<doc::Info *>> FileToInfos;
   for (const auto &Group : Infos) {
-    doc::Info *Info = Group.getValue().get();
+    doc::Info *Info = getPtr(Group.getValue());
 
     llvm::SmallString<128> Path;
     llvm::sys::path::native(RootDir, Path);

--- a/clang-tools-extra/clang-doc/Representation.cpp
+++ b/clang-tools-extra/clang-doc/Representation.cpp
@@ -89,10 +89,10 @@ static llvm::Expected<OwnedPtr<Info>> reduce(OwningPtrArray<Info> &Values) {
   if (Values.empty() || !Values[0])
     return llvm::createStringError(llvm::inconvertibleErrorCode(),
                                    "no value to reduce");
-  OwnedPtr<Info> Merged = std::make_unique<T>(Values[0]->USR);
-  T *Tmp = static_cast<T *>(Merged.get());
+  OwnedPtr<Info> Merged = allocatePtr<T>(Values[0]->USR);
+  T *Tmp = static_cast<T *>(getPtr(Merged));
   for (auto &I : Values)
-    Tmp->merge(std::move(*static_cast<T *>(I.get())));
+    Tmp->merge(std::move(*static_cast<T *>(getPtr(I))));
   return std::move(Merged);
 }
 

--- a/clang-tools-extra/clang-doc/Representation.h
+++ b/clang-tools-extra/clang-doc/Representation.h
@@ -48,6 +48,17 @@ template <typename T> using OwningPtrVec = std::vector<OwnedPtr<T>>;
 // To be eventually transitioned to arena-allocated arrays of bare pointers.
 template <typename T> using OwningPtrArray = std::vector<OwnedPtr<T>>;
 
+// A helper function to create an owned pointer, abstracting away the memory
+// allocation mechanism.
+template <typename T, typename... Args>
+OwnedPtr<T> allocatePtr(Args &&...args) {
+  return std::make_unique<T>(std::forward<Args>(args)...);
+}
+
+// A helper function to access the underlying pointer from an owned pointer,
+// abstracting away the pointer dereferencing mechanism.
+template <typename T> T *getPtr(const OwnedPtr<T> &O) { return O.get(); }
+
 // SHA1'd hash of a USR.
 using SymbolID = std::array<uint8_t, 20>;
 

--- a/clang-tools-extra/clang-doc/Serialize.cpp
+++ b/clang-tools-extra/clang-doc/Serialize.cpp
@@ -241,7 +241,7 @@ void ClangDocCommentVisitor::parseComment(const comments::Comment *C) {
   ConstCommentVisitor<ClangDocCommentVisitor>::visit(C);
   for (comments::Comment *Child :
        llvm::make_range(C->child_begin(), C->child_end())) {
-    CurrentCI.Children.emplace_back(std::make_unique<CommentInfo>());
+    CurrentCI.Children.emplace_back(allocatePtr<CommentInfo>());
     ClangDocCommentVisitor Visitor(*CurrentCI.Children.back());
     Visitor.parseComment(Child);
   }
@@ -349,17 +349,17 @@ static std::string serialize(T &I, DiagnosticsEngine &Diags) {
 std::string serialize(OwnedPtr<Info> &I, DiagnosticsEngine &Diags) {
   switch (I->IT) {
   case InfoType::IT_namespace:
-    return serialize(*static_cast<NamespaceInfo *>(I.get()), Diags);
+    return serialize(*static_cast<NamespaceInfo *>(getPtr(I)), Diags);
   case InfoType::IT_record:
-    return serialize(*static_cast<RecordInfo *>(I.get()), Diags);
+    return serialize(*static_cast<RecordInfo *>(getPtr(I)), Diags);
   case InfoType::IT_enum:
-    return serialize(*static_cast<EnumInfo *>(I.get()), Diags);
+    return serialize(*static_cast<EnumInfo *>(getPtr(I)), Diags);
   case InfoType::IT_function:
-    return serialize(*static_cast<FunctionInfo *>(I.get()), Diags);
+    return serialize(*static_cast<FunctionInfo *>(getPtr(I)), Diags);
   case InfoType::IT_concept:
-    return serialize(*static_cast<ConceptInfo *>(I.get()), Diags);
+    return serialize(*static_cast<ConceptInfo *>(getPtr(I)), Diags);
   case InfoType::IT_variable:
-    return serialize(*static_cast<VarInfo *>(I.get()), Diags);
+    return serialize(*static_cast<VarInfo *>(getPtr(I)), Diags);
   case InfoType::IT_friend:
   case InfoType::IT_typedef:
   case InfoType::IT_default:
@@ -491,20 +491,20 @@ template <typename ChildType>
 static OwnedPtr<Info> makeAndInsertIntoParent(ChildType Child) {
   if (Child.Namespace.empty()) {
     // Insert into unnamed parent namespace.
-    auto ParentNS = std::make_unique<NamespaceInfo>();
+    auto ParentNS = allocatePtr<NamespaceInfo>();
     InsertChild(ParentNS->Children, std::forward<ChildType>(Child));
     return ParentNS;
   }
 
   switch (Child.Namespace[0].RefType) {
   case InfoType::IT_namespace: {
-    auto ParentNS = std::make_unique<NamespaceInfo>();
+    auto ParentNS = allocatePtr<NamespaceInfo>();
     ParentNS->USR = Child.Namespace[0].USR;
     InsertChild(ParentNS->Children, std::forward<ChildType>(Child));
     return ParentNS;
   }
   case InfoType::IT_record: {
-    auto ParentRec = std::make_unique<RecordInfo>();
+    auto ParentRec = allocatePtr<RecordInfo>();
     ParentRec->USR = Child.Namespace[0].USR;
     InsertChild(ParentRec->Children, std::forward<ChildType>(Child));
     return ParentRec;
@@ -944,7 +944,7 @@ std::pair<OwnedPtr<Info>, OwnedPtr<Info>> emitInfo(const NamespaceDecl *D,
                                                    const FullComment *FC,
                                                    Location Loc,
                                                    bool PublicOnly) {
-  auto NSI = std::make_unique<NamespaceInfo>();
+  auto NSI = allocatePtr<NamespaceInfo>();
   bool IsInAnonymousNamespace = false;
   populateInfo(*NSI, D, FC, IsInAnonymousNamespace);
   if (!shouldSerializeInfo(PublicOnly, IsInAnonymousNamespace, D))
@@ -1017,7 +1017,7 @@ std::pair<OwnedPtr<Info>, OwnedPtr<Info>> emitInfo(const RecordDecl *D,
                                                    Location Loc,
                                                    bool PublicOnly) {
 
-  auto RI = std::make_unique<RecordInfo>();
+  auto RI = allocatePtr<RecordInfo>();
   bool IsInAnonymousNamespace = false;
 
   populateSymbolInfo(*RI, D, FC, Loc, IsInAnonymousNamespace);

--- a/clang-tools-extra/clang-doc/YAMLGenerator.cpp
+++ b/clang-tools-extra/clang-doc/YAMLGenerator.cpp
@@ -357,7 +357,7 @@ llvm::Error YAMLGenerator::generateDocumentation(
     StringRef RootDir, llvm::StringMap<doc::OwnedPtr<doc::Info>> Infos,
     const ClangDocContext &CDCtx, std::string DirName) {
   for (const auto &Group : Infos) {
-    doc::Info *Info = Group.getValue().get();
+    doc::Info *Info = getPtr(Group.getValue());
 
     // Output file names according to the USR except the global namesapce.
     // Anonymous namespaces are taken care of in serialization, so here we can

--- a/clang-tools-extra/clang-doc/benchmarks/ClangDocBenchmark.cpp
+++ b/clang-tools-extra/clang-doc/benchmarks/ClangDocBenchmark.cpp
@@ -91,7 +91,7 @@ BENCHMARK(BM_Mapper_Scale)->Range(10, 10000);
 // --- Reducer Benchmarks ---
 
 static void BM_SerializeFunctionInfo(benchmark::State &State) {
-  auto I = std::make_unique<FunctionInfo>();
+  auto I = allocatePtr<FunctionInfo>();
   I->Name = "f";
   I->DefLoc = Location(0, 0, "test.cpp");
   I->ReturnType = TypeInfo("void");
@@ -119,7 +119,7 @@ static void BM_MergeInfos_Scale(benchmark::State &State) {
     OwningPtrArray<Info> Input;
     Input.reserve(State.range(0));
     for (int i = 0; i < State.range(0); ++i) {
-      auto I = std::make_unique<FunctionInfo>();
+      auto I = allocatePtr<FunctionInfo>();
       I->Name = "f";
       I->USR = USR;
       I->DefLoc = Location(10, i, "test.cpp");
@@ -181,7 +181,7 @@ static void BM_JSONGenerator_Scale(benchmark::State &State) {
   }
 
   int NumRecords = State.range(0);
-  auto NI = std::make_unique<NamespaceInfo>();
+  auto NI = allocatePtr<NamespaceInfo>();
   NI->Name = "GlobalNamespace";
   for (int i = 0; i < NumRecords; ++i) {
     NI->Children.Records.emplace_back(SymbolID{(uint8_t)(i & 0xFF)},
@@ -200,7 +200,7 @@ static void BM_JSONGenerator_Scale(benchmark::State &State) {
 
   for (auto _ : State) {
     Output.clear();
-    auto Err = (*G)->generateDocForInfo(NI.get(), OS, CDCtx);
+    auto Err = (*G)->generateDocForInfo(getPtr(NI), OS, CDCtx);
     if (Err) {
       State.SkipWithError("generateDocForInfo failed");
       llvm::consumeError(std::move(Err));

--- a/clang-tools-extra/clang-doc/tool/ClangDocMain.cpp
+++ b/clang-tools-extra/clang-doc/tool/ClangDocMain.cpp
@@ -228,11 +228,11 @@ sortUsrToInfo(llvm::StringMap<doc::OwnedPtr<doc::Info>> &USRToInfo) {
   for (auto &I : USRToInfo) {
     auto &Info = I.second;
     if (Info->IT == doc::InfoType::IT_namespace) {
-      auto *Namespace = static_cast<clang::doc::NamespaceInfo *>(Info.get());
+      auto *Namespace = static_cast<clang::doc::NamespaceInfo *>(getPtr(Info));
       Namespace->Children.sort();
     }
     if (Info->IT == doc::InfoType::IT_record) {
-      auto *Record = static_cast<clang::doc::RecordInfo *>(Info.get());
+      auto *Record = static_cast<clang::doc::RecordInfo *>(getPtr(Info));
       Record->Children.sort();
     }
   }
@@ -400,7 +400,7 @@ Example usage for a project using a compile commands database:
           {
             llvm::TimeTraceScope Merge("addInfoToIndex");
             std::lock_guard<llvm::sys::Mutex> Guard(IndexMutex);
-            clang::doc::Generator::addInfoToIndex(CDCtx.Idx, Reduced.get());
+            clang::doc::Generator::addInfoToIndex(CDCtx.Idx, getPtr(Reduced));
           }
           // Save in the result map (needs a lock due to threaded access).
           {

--- a/clang-tools-extra/unittests/clang-doc/BitcodeTest.cpp
+++ b/clang-tools-extra/unittests/clang-doc/BitcodeTest.cpp
@@ -105,10 +105,10 @@ TEST_F(BitcodeTest, emitRecordInfoBitcode) {
   // Documentation for the data member.
   CommentInfo TopComment;
   TopComment.Kind = CommentKind::CK_FullComment;
-  TopComment.Children.emplace_back(std::make_unique<CommentInfo>());
+  TopComment.Children.emplace_back(allocatePtr<CommentInfo>());
   CommentInfo *Brief = TopComment.Children.back().get();
   Brief->Kind = CommentKind::CK_ParagraphComment;
-  Brief->Children.emplace_back(std::make_unique<CommentInfo>());
+  Brief->Children.emplace_back(allocatePtr<CommentInfo>());
   Brief->Children.back()->Kind = CommentKind::CK_TextComment;
   Brief->Children.back()->Name = "ParagraphComment";
   Brief->Children.back()->Text = "Value of the thing.";
@@ -197,10 +197,10 @@ TEST_F(BitcodeTest, emitTypedefInfoBitcode) {
   CommentInfo Top;
   Top.Kind = CommentKind::CK_FullComment;
 
-  Top.Children.emplace_back(std::make_unique<CommentInfo>());
+  Top.Children.emplace_back(allocatePtr<CommentInfo>());
   CommentInfo *BlankLine = Top.Children.back().get();
   BlankLine->Kind = CommentKind::CK_ParagraphComment;
-  BlankLine->Children.emplace_back(std::make_unique<CommentInfo>());
+  BlankLine->Children.emplace_back(allocatePtr<CommentInfo>());
   BlankLine->Children.back()->Kind = CommentKind::CK_TextComment;
 
   I.Description.emplace_back(std::move(Top));
@@ -233,102 +233,102 @@ TEST_F(BitcodeTest, emitInfoWithCommentBitcode) {
   CommentInfo Top;
   Top.Kind = CommentKind::CK_FullComment;
 
-  Top.Children.emplace_back(std::make_unique<CommentInfo>());
+  Top.Children.emplace_back(allocatePtr<CommentInfo>());
   CommentInfo *BlankLine = Top.Children.back().get();
   BlankLine->Kind = CommentKind::CK_ParagraphComment;
-  BlankLine->Children.emplace_back(std::make_unique<CommentInfo>());
+  BlankLine->Children.emplace_back(allocatePtr<CommentInfo>());
   BlankLine->Children.back()->Kind = CommentKind::CK_TextComment;
 
-  Top.Children.emplace_back(std::make_unique<CommentInfo>());
+  Top.Children.emplace_back(allocatePtr<CommentInfo>());
   CommentInfo *Brief = Top.Children.back().get();
   Brief->Kind = CommentKind::CK_ParagraphComment;
-  Brief->Children.emplace_back(std::make_unique<CommentInfo>());
+  Brief->Children.emplace_back(allocatePtr<CommentInfo>());
   Brief->Children.back()->Kind = CommentKind::CK_TextComment;
   Brief->Children.back()->Name = "ParagraphComment";
   Brief->Children.back()->Text = " Brief description.";
 
-  Top.Children.emplace_back(std::make_unique<CommentInfo>());
+  Top.Children.emplace_back(allocatePtr<CommentInfo>());
   CommentInfo *Extended = Top.Children.back().get();
   Extended->Kind = CommentKind::CK_ParagraphComment;
-  Extended->Children.emplace_back(std::make_unique<CommentInfo>());
+  Extended->Children.emplace_back(allocatePtr<CommentInfo>());
   Extended->Children.back()->Kind = CommentKind::CK_TextComment;
   Extended->Children.back()->Text = " Extended description that";
-  Extended->Children.emplace_back(std::make_unique<CommentInfo>());
+  Extended->Children.emplace_back(allocatePtr<CommentInfo>());
   Extended->Children.back()->Kind = CommentKind::CK_TextComment;
   Extended->Children.back()->Text = " continues onto the next line.";
 
-  Top.Children.emplace_back(std::make_unique<CommentInfo>());
+  Top.Children.emplace_back(allocatePtr<CommentInfo>());
   CommentInfo *HTML = Top.Children.back().get();
   HTML->Kind = CommentKind::CK_ParagraphComment;
-  HTML->Children.emplace_back(std::make_unique<CommentInfo>());
+  HTML->Children.emplace_back(allocatePtr<CommentInfo>());
   HTML->Children.back()->Kind = CommentKind::CK_TextComment;
-  HTML->Children.emplace_back(std::make_unique<CommentInfo>());
+  HTML->Children.emplace_back(allocatePtr<CommentInfo>());
   HTML->Children.back()->Kind = CommentKind::CK_HTMLStartTagComment;
   HTML->Children.back()->Name = "ul";
   HTML->Children.back()->AttrKeys.emplace_back("class");
   HTML->Children.back()->AttrValues.emplace_back("test");
-  HTML->Children.emplace_back(std::make_unique<CommentInfo>());
+  HTML->Children.emplace_back(allocatePtr<CommentInfo>());
   HTML->Children.back()->Kind = CommentKind::CK_HTMLStartTagComment;
   HTML->Children.back()->Name = "li";
-  HTML->Children.emplace_back(std::make_unique<CommentInfo>());
+  HTML->Children.emplace_back(allocatePtr<CommentInfo>());
   HTML->Children.back()->Kind = CommentKind::CK_TextComment;
   HTML->Children.back()->Text = " Testing.";
-  HTML->Children.emplace_back(std::make_unique<CommentInfo>());
+  HTML->Children.emplace_back(allocatePtr<CommentInfo>());
   HTML->Children.back()->Kind = CommentKind::CK_HTMLEndTagComment;
   HTML->Children.back()->Name = "ul";
   HTML->Children.back()->SelfClosing = true;
 
-  Top.Children.emplace_back(std::make_unique<CommentInfo>());
+  Top.Children.emplace_back(allocatePtr<CommentInfo>());
   CommentInfo *Verbatim = Top.Children.back().get();
   Verbatim->Kind = CommentKind::CK_VerbatimBlockComment;
   Verbatim->Name = "verbatim";
   Verbatim->CloseName = "endverbatim";
-  Verbatim->Children.emplace_back(std::make_unique<CommentInfo>());
+  Verbatim->Children.emplace_back(allocatePtr<CommentInfo>());
   Verbatim->Children.back()->Kind = CommentKind::CK_VerbatimBlockLineComment;
   Verbatim->Children.back()->Text = " The description continues.";
 
-  Top.Children.emplace_back(std::make_unique<CommentInfo>());
+  Top.Children.emplace_back(allocatePtr<CommentInfo>());
   CommentInfo *ParamOut = Top.Children.back().get();
   ParamOut->Kind = CommentKind::CK_ParamCommandComment;
   ParamOut->Direction = "[out]";
   ParamOut->ParamName = "I";
   ParamOut->Explicit = true;
-  ParamOut->Children.emplace_back(std::make_unique<CommentInfo>());
+  ParamOut->Children.emplace_back(allocatePtr<CommentInfo>());
   ParamOut->Children.back()->Kind = CommentKind::CK_ParagraphComment;
   ParamOut->Children.back()->Children.emplace_back(
-      std::make_unique<CommentInfo>());
+      allocatePtr<CommentInfo>());
   ParamOut->Children.back()->Children.back()->Kind =
       CommentKind::CK_TextComment;
   ParamOut->Children.back()->Children.emplace_back(
-      std::make_unique<CommentInfo>());
+      allocatePtr<CommentInfo>());
   ParamOut->Children.back()->Children.back()->Kind =
       CommentKind::CK_TextComment;
   ParamOut->Children.back()->Children.back()->Text = " is a parameter.";
 
-  Top.Children.emplace_back(std::make_unique<CommentInfo>());
+  Top.Children.emplace_back(allocatePtr<CommentInfo>());
   CommentInfo *ParamIn = Top.Children.back().get();
   ParamIn->Kind = CommentKind::CK_ParamCommandComment;
   ParamIn->Direction = "[in]";
   ParamIn->ParamName = "J";
-  ParamIn->Children.emplace_back(std::make_unique<CommentInfo>());
+  ParamIn->Children.emplace_back(allocatePtr<CommentInfo>());
   ParamIn->Children.back()->Kind = CommentKind::CK_ParagraphComment;
   ParamIn->Children.back()->Children.emplace_back(
-      std::make_unique<CommentInfo>());
+      allocatePtr<CommentInfo>());
   ParamIn->Children.back()->Children.back()->Kind = CommentKind::CK_TextComment;
   ParamIn->Children.back()->Children.back()->Text = " is a parameter.";
   ParamIn->Children.back()->Children.emplace_back(
-      std::make_unique<CommentInfo>());
+      allocatePtr<CommentInfo>());
   ParamIn->Children.back()->Children.back()->Kind = CommentKind::CK_TextComment;
 
-  Top.Children.emplace_back(std::make_unique<CommentInfo>());
+  Top.Children.emplace_back(allocatePtr<CommentInfo>());
   CommentInfo *Return = Top.Children.back().get();
   Return->Kind = CommentKind::CK_BlockCommandComment;
   Return->Name = "return";
   Return->Explicit = true;
-  Return->Children.emplace_back(std::make_unique<CommentInfo>());
+  Return->Children.emplace_back(allocatePtr<CommentInfo>());
   Return->Children.back()->Kind = CommentKind::CK_ParagraphComment;
   Return->Children.back()->Children.emplace_back(
-      std::make_unique<CommentInfo>());
+      allocatePtr<CommentInfo>());
   Return->Children.back()->Children.back()->Kind = CommentKind::CK_TextComment;
   Return->Children.back()->Children.back()->Text = "void";
 

--- a/clang-tools-extra/unittests/clang-doc/BitcodeTest.cpp
+++ b/clang-tools-extra/unittests/clang-doc/BitcodeTest.cpp
@@ -295,12 +295,10 @@ TEST_F(BitcodeTest, emitInfoWithCommentBitcode) {
   ParamOut->Explicit = true;
   ParamOut->Children.emplace_back(allocatePtr<CommentInfo>());
   ParamOut->Children.back()->Kind = CommentKind::CK_ParagraphComment;
-  ParamOut->Children.back()->Children.emplace_back(
-      allocatePtr<CommentInfo>());
+  ParamOut->Children.back()->Children.emplace_back(allocatePtr<CommentInfo>());
   ParamOut->Children.back()->Children.back()->Kind =
       CommentKind::CK_TextComment;
-  ParamOut->Children.back()->Children.emplace_back(
-      allocatePtr<CommentInfo>());
+  ParamOut->Children.back()->Children.emplace_back(allocatePtr<CommentInfo>());
   ParamOut->Children.back()->Children.back()->Kind =
       CommentKind::CK_TextComment;
   ParamOut->Children.back()->Children.back()->Text = " is a parameter.";
@@ -312,12 +310,10 @@ TEST_F(BitcodeTest, emitInfoWithCommentBitcode) {
   ParamIn->ParamName = "J";
   ParamIn->Children.emplace_back(allocatePtr<CommentInfo>());
   ParamIn->Children.back()->Kind = CommentKind::CK_ParagraphComment;
-  ParamIn->Children.back()->Children.emplace_back(
-      allocatePtr<CommentInfo>());
+  ParamIn->Children.back()->Children.emplace_back(allocatePtr<CommentInfo>());
   ParamIn->Children.back()->Children.back()->Kind = CommentKind::CK_TextComment;
   ParamIn->Children.back()->Children.back()->Text = " is a parameter.";
-  ParamIn->Children.back()->Children.emplace_back(
-      allocatePtr<CommentInfo>());
+  ParamIn->Children.back()->Children.emplace_back(allocatePtr<CommentInfo>());
   ParamIn->Children.back()->Children.back()->Kind = CommentKind::CK_TextComment;
 
   Top.Children.emplace_back(allocatePtr<CommentInfo>());
@@ -327,8 +323,7 @@ TEST_F(BitcodeTest, emitInfoWithCommentBitcode) {
   Return->Explicit = true;
   Return->Children.emplace_back(allocatePtr<CommentInfo>());
   Return->Children.back()->Kind = CommentKind::CK_ParagraphComment;
-  Return->Children.back()->Children.emplace_back(
-      allocatePtr<CommentInfo>());
+  Return->Children.back()->Children.emplace_back(allocatePtr<CommentInfo>());
   Return->Children.back()->Children.back()->Kind = CommentKind::CK_TextComment;
   Return->Children.back()->Children.back()->Text = "void";
 

--- a/clang-tools-extra/unittests/clang-doc/MDGeneratorTest.cpp
+++ b/clang-tools-extra/unittests/clang-doc/MDGeneratorTest.cpp
@@ -284,12 +284,10 @@ TEST_F(MDGeneratorTest, emitCommentMD) {
   ParamOut->Explicit = true;
   ParamOut->Children.emplace_back(allocatePtr<CommentInfo>());
   ParamOut->Children.back()->Kind = CommentKind::CK_ParagraphComment;
-  ParamOut->Children.back()->Children.emplace_back(
-      allocatePtr<CommentInfo>());
+  ParamOut->Children.back()->Children.emplace_back(allocatePtr<CommentInfo>());
   ParamOut->Children.back()->Children.back()->Kind =
       CommentKind::CK_TextComment;
-  ParamOut->Children.back()->Children.emplace_back(
-      allocatePtr<CommentInfo>());
+  ParamOut->Children.back()->Children.emplace_back(allocatePtr<CommentInfo>());
   ParamOut->Children.back()->Children.back()->Kind =
       CommentKind::CK_TextComment;
   ParamOut->Children.back()->Children.back()->Text = " is a parameter.";
@@ -301,12 +299,10 @@ TEST_F(MDGeneratorTest, emitCommentMD) {
   ParamIn->ParamName = "J";
   ParamIn->Children.emplace_back(allocatePtr<CommentInfo>());
   ParamIn->Children.back()->Kind = CommentKind::CK_ParagraphComment;
-  ParamIn->Children.back()->Children.emplace_back(
-      allocatePtr<CommentInfo>());
+  ParamIn->Children.back()->Children.emplace_back(allocatePtr<CommentInfo>());
   ParamIn->Children.back()->Children.back()->Kind = CommentKind::CK_TextComment;
   ParamIn->Children.back()->Children.back()->Text = " is a parameter.";
-  ParamIn->Children.back()->Children.emplace_back(
-      allocatePtr<CommentInfo>());
+  ParamIn->Children.back()->Children.emplace_back(allocatePtr<CommentInfo>());
   ParamIn->Children.back()->Children.back()->Kind = CommentKind::CK_TextComment;
 
   Top.Children.emplace_back(allocatePtr<CommentInfo>());
@@ -316,8 +312,7 @@ TEST_F(MDGeneratorTest, emitCommentMD) {
   Return->Explicit = true;
   Return->Children.emplace_back(allocatePtr<CommentInfo>());
   Return->Children.back()->Kind = CommentKind::CK_ParagraphComment;
-  Return->Children.back()->Children.emplace_back(
-      allocatePtr<CommentInfo>());
+  Return->Children.back()->Children.emplace_back(allocatePtr<CommentInfo>());
   Return->Children.back()->Children.back()->Kind = CommentKind::CK_TextComment;
   Return->Children.back()->Children.back()->Text = "void";
 

--- a/clang-tools-extra/unittests/clang-doc/MDGeneratorTest.cpp
+++ b/clang-tools-extra/unittests/clang-doc/MDGeneratorTest.cpp
@@ -222,102 +222,102 @@ TEST_F(MDGeneratorTest, emitCommentMD) {
   CommentInfo Top;
   Top.Kind = CommentKind::CK_FullComment;
 
-  Top.Children.emplace_back(std::make_unique<CommentInfo>());
+  Top.Children.emplace_back(allocatePtr<CommentInfo>());
   CommentInfo *BlankLine = Top.Children.back().get();
   BlankLine->Kind = CommentKind::CK_ParagraphComment;
-  BlankLine->Children.emplace_back(std::make_unique<CommentInfo>());
+  BlankLine->Children.emplace_back(allocatePtr<CommentInfo>());
   BlankLine->Children.back()->Kind = CommentKind::CK_TextComment;
 
-  Top.Children.emplace_back(std::make_unique<CommentInfo>());
+  Top.Children.emplace_back(allocatePtr<CommentInfo>());
   CommentInfo *Brief = Top.Children.back().get();
   Brief->Kind = CommentKind::CK_ParagraphComment;
-  Brief->Children.emplace_back(std::make_unique<CommentInfo>());
+  Brief->Children.emplace_back(allocatePtr<CommentInfo>());
   Brief->Children.back()->Kind = CommentKind::CK_TextComment;
   Brief->Children.back()->Name = "ParagraphComment";
   Brief->Children.back()->Text = " Brief description.";
 
-  Top.Children.emplace_back(std::make_unique<CommentInfo>());
+  Top.Children.emplace_back(allocatePtr<CommentInfo>());
   CommentInfo *Extended = Top.Children.back().get();
   Extended->Kind = CommentKind::CK_ParagraphComment;
-  Extended->Children.emplace_back(std::make_unique<CommentInfo>());
+  Extended->Children.emplace_back(allocatePtr<CommentInfo>());
   Extended->Children.back()->Kind = CommentKind::CK_TextComment;
   Extended->Children.back()->Text = " Extended description that";
-  Extended->Children.emplace_back(std::make_unique<CommentInfo>());
+  Extended->Children.emplace_back(allocatePtr<CommentInfo>());
   Extended->Children.back()->Kind = CommentKind::CK_TextComment;
   Extended->Children.back()->Text = " continues onto the next line.";
 
-  Top.Children.emplace_back(std::make_unique<CommentInfo>());
+  Top.Children.emplace_back(allocatePtr<CommentInfo>());
   CommentInfo *HTML = Top.Children.back().get();
   HTML->Kind = CommentKind::CK_ParagraphComment;
-  HTML->Children.emplace_back(std::make_unique<CommentInfo>());
+  HTML->Children.emplace_back(allocatePtr<CommentInfo>());
   HTML->Children.back()->Kind = CommentKind::CK_TextComment;
-  HTML->Children.emplace_back(std::make_unique<CommentInfo>());
+  HTML->Children.emplace_back(allocatePtr<CommentInfo>());
   HTML->Children.back()->Kind = CommentKind::CK_HTMLStartTagComment;
   HTML->Children.back()->Name = "ul";
   HTML->Children.back()->AttrKeys.emplace_back("class");
   HTML->Children.back()->AttrValues.emplace_back("test");
-  HTML->Children.emplace_back(std::make_unique<CommentInfo>());
+  HTML->Children.emplace_back(allocatePtr<CommentInfo>());
   HTML->Children.back()->Kind = CommentKind::CK_HTMLStartTagComment;
   HTML->Children.back()->Name = "li";
-  HTML->Children.emplace_back(std::make_unique<CommentInfo>());
+  HTML->Children.emplace_back(allocatePtr<CommentInfo>());
   HTML->Children.back()->Kind = CommentKind::CK_TextComment;
   HTML->Children.back()->Text = " Testing.";
-  HTML->Children.emplace_back(std::make_unique<CommentInfo>());
+  HTML->Children.emplace_back(allocatePtr<CommentInfo>());
   HTML->Children.back()->Kind = CommentKind::CK_HTMLEndTagComment;
   HTML->Children.back()->Name = "ul";
   HTML->Children.back()->SelfClosing = true;
 
-  Top.Children.emplace_back(std::make_unique<CommentInfo>());
+  Top.Children.emplace_back(allocatePtr<CommentInfo>());
   CommentInfo *Verbatim = Top.Children.back().get();
   Verbatim->Kind = CommentKind::CK_VerbatimBlockComment;
   Verbatim->Name = "verbatim";
   Verbatim->CloseName = "endverbatim";
-  Verbatim->Children.emplace_back(std::make_unique<CommentInfo>());
+  Verbatim->Children.emplace_back(allocatePtr<CommentInfo>());
   Verbatim->Children.back()->Kind = CommentKind::CK_VerbatimBlockLineComment;
   Verbatim->Children.back()->Text = " The description continues.";
 
-  Top.Children.emplace_back(std::make_unique<CommentInfo>());
+  Top.Children.emplace_back(allocatePtr<CommentInfo>());
   CommentInfo *ParamOut = Top.Children.back().get();
   ParamOut->Kind = CommentKind::CK_ParamCommandComment;
   ParamOut->Direction = "[out]";
   ParamOut->ParamName = "I";
   ParamOut->Explicit = true;
-  ParamOut->Children.emplace_back(std::make_unique<CommentInfo>());
+  ParamOut->Children.emplace_back(allocatePtr<CommentInfo>());
   ParamOut->Children.back()->Kind = CommentKind::CK_ParagraphComment;
   ParamOut->Children.back()->Children.emplace_back(
-      std::make_unique<CommentInfo>());
+      allocatePtr<CommentInfo>());
   ParamOut->Children.back()->Children.back()->Kind =
       CommentKind::CK_TextComment;
   ParamOut->Children.back()->Children.emplace_back(
-      std::make_unique<CommentInfo>());
+      allocatePtr<CommentInfo>());
   ParamOut->Children.back()->Children.back()->Kind =
       CommentKind::CK_TextComment;
   ParamOut->Children.back()->Children.back()->Text = " is a parameter.";
 
-  Top.Children.emplace_back(std::make_unique<CommentInfo>());
+  Top.Children.emplace_back(allocatePtr<CommentInfo>());
   CommentInfo *ParamIn = Top.Children.back().get();
   ParamIn->Kind = CommentKind::CK_ParamCommandComment;
   ParamIn->Direction = "[in]";
   ParamIn->ParamName = "J";
-  ParamIn->Children.emplace_back(std::make_unique<CommentInfo>());
+  ParamIn->Children.emplace_back(allocatePtr<CommentInfo>());
   ParamIn->Children.back()->Kind = CommentKind::CK_ParagraphComment;
   ParamIn->Children.back()->Children.emplace_back(
-      std::make_unique<CommentInfo>());
+      allocatePtr<CommentInfo>());
   ParamIn->Children.back()->Children.back()->Kind = CommentKind::CK_TextComment;
   ParamIn->Children.back()->Children.back()->Text = " is a parameter.";
   ParamIn->Children.back()->Children.emplace_back(
-      std::make_unique<CommentInfo>());
+      allocatePtr<CommentInfo>());
   ParamIn->Children.back()->Children.back()->Kind = CommentKind::CK_TextComment;
 
-  Top.Children.emplace_back(std::make_unique<CommentInfo>());
+  Top.Children.emplace_back(allocatePtr<CommentInfo>());
   CommentInfo *Return = Top.Children.back().get();
   Return->Kind = CommentKind::CK_BlockCommandComment;
   Return->Name = "return";
   Return->Explicit = true;
-  Return->Children.emplace_back(std::make_unique<CommentInfo>());
+  Return->Children.emplace_back(allocatePtr<CommentInfo>());
   Return->Children.back()->Kind = CommentKind::CK_ParagraphComment;
   Return->Children.back()->Children.emplace_back(
-      std::make_unique<CommentInfo>());
+      allocatePtr<CommentInfo>());
   Return->Children.back()->Children.back()->Kind = CommentKind::CK_TextComment;
   Return->Children.back()->Children.back()->Text = "void";
 

--- a/clang-tools-extra/unittests/clang-doc/MergeTest.cpp
+++ b/clang-tools-extra/unittests/clang-doc/MergeTest.cpp
@@ -45,10 +45,10 @@ TEST_F(MergeTest, mergeNamespaceInfos) {
   Two.Children.Enums.back().Name = "TwoEnum";
 
   OwningPtrVec<Info> Infos;
-  Infos.emplace_back(std::make_unique<NamespaceInfo>(std::move(One)));
-  Infos.emplace_back(std::make_unique<NamespaceInfo>(std::move(Two)));
+  Infos.emplace_back(allocatePtr<NamespaceInfo>(std::move(One)));
+  Infos.emplace_back(allocatePtr<NamespaceInfo>(std::move(Two)));
 
-  auto Expected = std::make_unique<NamespaceInfo>();
+  auto Expected = allocatePtr<NamespaceInfo>();
   Expected->Name = "Namespace";
   Expected->Namespace.emplace_back(EmptySID, "A", InfoType::IT_namespace);
 
@@ -117,10 +117,10 @@ TEST_F(MergeTest, mergeRecordInfos) {
   Two.Children.Enums.back().Name = "TwoEnum";
 
   OwningPtrVec<Info> Infos;
-  Infos.emplace_back(std::make_unique<RecordInfo>(std::move(One)));
-  Infos.emplace_back(std::make_unique<RecordInfo>(std::move(Two)));
+  Infos.emplace_back(allocatePtr<RecordInfo>(std::move(One)));
+  Infos.emplace_back(allocatePtr<RecordInfo>(std::move(Two)));
 
-  auto Expected = std::make_unique<RecordInfo>();
+  auto Expected = allocatePtr<RecordInfo>();
   Expected->Name = "r";
   Expected->IsTypeDef = true;
   Expected->Namespace.emplace_back(EmptySID, "A", InfoType::IT_namespace);
@@ -169,9 +169,9 @@ TEST_F(MergeTest, mergeFunctionInfos) {
   One.Description.emplace_back();
   auto *OneFullComment = &One.Description.back();
   OneFullComment->Kind = CommentKind::CK_FullComment;
-  auto OneParagraphComment = std::make_unique<CommentInfo>();
+  auto OneParagraphComment = allocatePtr<CommentInfo>();
   OneParagraphComment->Kind = CommentKind::CK_ParagraphComment;
-  auto OneTextComment = std::make_unique<CommentInfo>();
+  auto OneTextComment = allocatePtr<CommentInfo>();
   OneTextComment->Kind = CommentKind::CK_TextComment;
   OneTextComment->Text = "This is a text comment.";
   OneParagraphComment->Children.push_back(std::move(OneTextComment));
@@ -189,19 +189,19 @@ TEST_F(MergeTest, mergeFunctionInfos) {
   Two.Description.emplace_back();
   auto *TwoFullComment = &Two.Description.back();
   TwoFullComment->Kind = CommentKind::CK_FullComment;
-  auto TwoParagraphComment = std::make_unique<CommentInfo>();
+  auto TwoParagraphComment = allocatePtr<CommentInfo>();
   TwoParagraphComment->Kind = CommentKind::CK_ParagraphComment;
-  auto TwoTextComment = std::make_unique<CommentInfo>();
+  auto TwoTextComment = allocatePtr<CommentInfo>();
   TwoTextComment->Kind = CommentKind::CK_TextComment;
   TwoTextComment->Text = "This is a text comment.";
   TwoParagraphComment->Children.push_back(std::move(TwoTextComment));
   TwoFullComment->Children.push_back(std::move(TwoParagraphComment));
 
   OwningPtrVec<Info> Infos;
-  Infos.emplace_back(std::make_unique<FunctionInfo>(std::move(One)));
-  Infos.emplace_back(std::make_unique<FunctionInfo>(std::move(Two)));
+  Infos.emplace_back(allocatePtr<FunctionInfo>(std::move(One)));
+  Infos.emplace_back(allocatePtr<FunctionInfo>(std::move(Two)));
 
-  auto Expected = std::make_unique<FunctionInfo>();
+  auto Expected = allocatePtr<FunctionInfo>();
   Expected->Name = "f";
   Expected->Namespace.emplace_back(EmptySID, "A", InfoType::IT_namespace);
 
@@ -216,9 +216,9 @@ TEST_F(MergeTest, mergeFunctionInfos) {
   Expected->Description.emplace_back();
   auto *ExpectedFullComment = &Expected->Description.back();
   ExpectedFullComment->Kind = CommentKind::CK_FullComment;
-  auto ExpectedParagraphComment = std::make_unique<CommentInfo>();
+  auto ExpectedParagraphComment = allocatePtr<CommentInfo>();
   ExpectedParagraphComment->Kind = CommentKind::CK_ParagraphComment;
-  auto ExpectedTextComment = std::make_unique<CommentInfo>();
+  auto ExpectedTextComment = allocatePtr<CommentInfo>();
   ExpectedTextComment->Kind = CommentKind::CK_TextComment;
   ExpectedTextComment->Text = "This is a text comment.";
   ExpectedParagraphComment->Children.push_back(std::move(ExpectedTextComment));
@@ -250,10 +250,10 @@ TEST_F(MergeTest, mergeEnumInfos) {
   Two.Members.emplace_back("Y");
 
   OwningPtrVec<Info> Infos;
-  Infos.emplace_back(std::make_unique<EnumInfo>(std::move(One)));
-  Infos.emplace_back(std::make_unique<EnumInfo>(std::move(Two)));
+  Infos.emplace_back(allocatePtr<EnumInfo>(std::move(One)));
+  Infos.emplace_back(allocatePtr<EnumInfo>(std::move(Two)));
 
-  auto Expected = std::make_unique<EnumInfo>();
+  auto Expected = allocatePtr<EnumInfo>();
   Expected->Name = "e";
   Expected->Namespace.emplace_back(EmptySID, "A", InfoType::IT_namespace);
 

--- a/clang-tools-extra/unittests/clang-doc/SerializeTest.cpp
+++ b/clang-tools-extra/unittests/clang-doc/SerializeTest.cpp
@@ -96,12 +96,12 @@ static void extractInfosFromCodeWithArgs(StringRef Code,
 CommentInfo MakeOneLineCommentInfo(const std::string &Text) {
   CommentInfo TopComment;
   TopComment.Kind = "FullComment";
-  TopComment.Children.emplace_back(std::make_unique<CommentInfo>());
+  TopComment.Children.emplace_back(allocatePtr<CommentInfo>());
 
   CommentInfo *Brief = TopComment.Children.back().get();
   Brief->Kind = "ParagraphComment";
 
-  Brief->Children.emplace_back(std::make_unique<CommentInfo>());
+  Brief->Children.emplace_back(allocatePtr<CommentInfo>());
   Brief->Children.back()->Kind = "TextComment";
   Brief->Children.back()->Name = "ParagraphComment";
   Brief->Children.back()->Text = Text;

--- a/clang-tools-extra/unittests/clang-doc/YAMLGeneratorTest.cpp
+++ b/clang-tools-extra/unittests/clang-doc/YAMLGeneratorTest.cpp
@@ -94,10 +94,10 @@ TEST_F(YAMLGeneratorTest, emitRecordYAML) {
   // Member documentation.
   CommentInfo TopComment;
   TopComment.Kind = CommentKind::CK_FullComment;
-  TopComment.Children.emplace_back(std::make_unique<CommentInfo>());
+  TopComment.Children.emplace_back(allocatePtr<CommentInfo>());
   CommentInfo *Brief = TopComment.Children.back().get();
   Brief->Kind = CommentKind::CK_ParagraphComment;
-  Brief->Children.emplace_back(std::make_unique<CommentInfo>());
+  Brief->Children.emplace_back(allocatePtr<CommentInfo>());
   Brief->Children.back()->Kind = CommentKind::CK_TextComment;
   Brief->Children.back()->Name = "ParagraphComment";
   Brief->Children.back()->Text = "Value of the thing.";
@@ -379,102 +379,102 @@ TEST_F(YAMLGeneratorTest, emitCommentYAML) {
   CommentInfo Top;
   Top.Kind = CommentKind::CK_FullComment;
 
-  Top.Children.emplace_back(std::make_unique<CommentInfo>());
+  Top.Children.emplace_back(allocatePtr<CommentInfo>());
   CommentInfo *BlankLine = Top.Children.back().get();
   BlankLine->Kind = CommentKind::CK_ParagraphComment;
-  BlankLine->Children.emplace_back(std::make_unique<CommentInfo>());
+  BlankLine->Children.emplace_back(allocatePtr<CommentInfo>());
   BlankLine->Children.back()->Kind = CommentKind::CK_TextComment;
 
-  Top.Children.emplace_back(std::make_unique<CommentInfo>());
+  Top.Children.emplace_back(allocatePtr<CommentInfo>());
   CommentInfo *Brief = Top.Children.back().get();
   Brief->Kind = CommentKind::CK_ParagraphComment;
-  Brief->Children.emplace_back(std::make_unique<CommentInfo>());
+  Brief->Children.emplace_back(allocatePtr<CommentInfo>());
   Brief->Children.back()->Kind = CommentKind::CK_TextComment;
   Brief->Children.back()->Name = "ParagraphComment";
   Brief->Children.back()->Text = " Brief description.";
 
-  Top.Children.emplace_back(std::make_unique<CommentInfo>());
+  Top.Children.emplace_back(allocatePtr<CommentInfo>());
   CommentInfo *Extended = Top.Children.back().get();
   Extended->Kind = CommentKind::CK_ParagraphComment;
-  Extended->Children.emplace_back(std::make_unique<CommentInfo>());
+  Extended->Children.emplace_back(allocatePtr<CommentInfo>());
   Extended->Children.back()->Kind = CommentKind::CK_TextComment;
   Extended->Children.back()->Text = " Extended description that";
-  Extended->Children.emplace_back(std::make_unique<CommentInfo>());
+  Extended->Children.emplace_back(allocatePtr<CommentInfo>());
   Extended->Children.back()->Kind = CommentKind::CK_TextComment;
   Extended->Children.back()->Text = " continues onto the next line.";
 
-  Top.Children.emplace_back(std::make_unique<CommentInfo>());
+  Top.Children.emplace_back(allocatePtr<CommentInfo>());
   CommentInfo *HTML = Top.Children.back().get();
   HTML->Kind = CommentKind::CK_ParagraphComment;
-  HTML->Children.emplace_back(std::make_unique<CommentInfo>());
+  HTML->Children.emplace_back(allocatePtr<CommentInfo>());
   HTML->Children.back()->Kind = CommentKind::CK_TextComment;
-  HTML->Children.emplace_back(std::make_unique<CommentInfo>());
+  HTML->Children.emplace_back(allocatePtr<CommentInfo>());
   HTML->Children.back()->Kind = CommentKind::CK_HTMLStartTagComment;
   HTML->Children.back()->Name = "ul";
   HTML->Children.back()->AttrKeys.emplace_back("class");
   HTML->Children.back()->AttrValues.emplace_back("test");
-  HTML->Children.emplace_back(std::make_unique<CommentInfo>());
+  HTML->Children.emplace_back(allocatePtr<CommentInfo>());
   HTML->Children.back()->Kind = CommentKind::CK_HTMLStartTagComment;
   HTML->Children.back()->Name = "li";
-  HTML->Children.emplace_back(std::make_unique<CommentInfo>());
+  HTML->Children.emplace_back(allocatePtr<CommentInfo>());
   HTML->Children.back()->Kind = CommentKind::CK_TextComment;
   HTML->Children.back()->Text = " Testing.";
-  HTML->Children.emplace_back(std::make_unique<CommentInfo>());
+  HTML->Children.emplace_back(allocatePtr<CommentInfo>());
   HTML->Children.back()->Kind = CommentKind::CK_HTMLEndTagComment;
   HTML->Children.back()->Name = "ul";
   HTML->Children.back()->SelfClosing = true;
 
-  Top.Children.emplace_back(std::make_unique<CommentInfo>());
+  Top.Children.emplace_back(allocatePtr<CommentInfo>());
   CommentInfo *Verbatim = Top.Children.back().get();
   Verbatim->Kind = CommentKind::CK_VerbatimBlockComment;
   Verbatim->Name = "verbatim";
   Verbatim->CloseName = "endverbatim";
-  Verbatim->Children.emplace_back(std::make_unique<CommentInfo>());
+  Verbatim->Children.emplace_back(allocatePtr<CommentInfo>());
   Verbatim->Children.back()->Kind = CommentKind::CK_VerbatimBlockLineComment;
   Verbatim->Children.back()->Text = " The description continues.";
 
-  Top.Children.emplace_back(std::make_unique<CommentInfo>());
+  Top.Children.emplace_back(allocatePtr<CommentInfo>());
   CommentInfo *ParamOut = Top.Children.back().get();
   ParamOut->Kind = CommentKind::CK_ParamCommandComment;
   ParamOut->Direction = "[out]";
   ParamOut->ParamName = "I";
   ParamOut->Explicit = true;
-  ParamOut->Children.emplace_back(std::make_unique<CommentInfo>());
+  ParamOut->Children.emplace_back(allocatePtr<CommentInfo>());
   ParamOut->Children.back()->Kind = CommentKind::CK_ParagraphComment;
   ParamOut->Children.back()->Children.emplace_back(
-      std::make_unique<CommentInfo>());
+      allocatePtr<CommentInfo>());
   ParamOut->Children.back()->Children.back()->Kind =
       CommentKind::CK_TextComment;
   ParamOut->Children.back()->Children.emplace_back(
-      std::make_unique<CommentInfo>());
+      allocatePtr<CommentInfo>());
   ParamOut->Children.back()->Children.back()->Kind =
       CommentKind::CK_TextComment;
   ParamOut->Children.back()->Children.back()->Text = " is a parameter.";
 
-  Top.Children.emplace_back(std::make_unique<CommentInfo>());
+  Top.Children.emplace_back(allocatePtr<CommentInfo>());
   CommentInfo *ParamIn = Top.Children.back().get();
   ParamIn->Kind = CommentKind::CK_ParamCommandComment;
   ParamIn->Direction = "[in]";
   ParamIn->ParamName = "J";
-  ParamIn->Children.emplace_back(std::make_unique<CommentInfo>());
+  ParamIn->Children.emplace_back(allocatePtr<CommentInfo>());
   ParamIn->Children.back()->Kind = CommentKind::CK_ParagraphComment;
   ParamIn->Children.back()->Children.emplace_back(
-      std::make_unique<CommentInfo>());
+      allocatePtr<CommentInfo>());
   ParamIn->Children.back()->Children.back()->Kind = CommentKind::CK_TextComment;
   ParamIn->Children.back()->Children.back()->Text = " is a parameter.";
   ParamIn->Children.back()->Children.emplace_back(
-      std::make_unique<CommentInfo>());
+      allocatePtr<CommentInfo>());
   ParamIn->Children.back()->Children.back()->Kind = CommentKind::CK_TextComment;
 
-  Top.Children.emplace_back(std::make_unique<CommentInfo>());
+  Top.Children.emplace_back(allocatePtr<CommentInfo>());
   CommentInfo *Return = Top.Children.back().get();
   Return->Kind = CommentKind::CK_BlockCommandComment;
   Return->Name = "return";
   Return->Explicit = true;
-  Return->Children.emplace_back(std::make_unique<CommentInfo>());
+  Return->Children.emplace_back(allocatePtr<CommentInfo>());
   Return->Children.back()->Kind = CommentKind::CK_ParagraphComment;
   Return->Children.back()->Children.emplace_back(
-      std::make_unique<CommentInfo>());
+      allocatePtr<CommentInfo>());
   Return->Children.back()->Children.back()->Kind = CommentKind::CK_TextComment;
   Return->Children.back()->Children.back()->Text = "void";
 

--- a/clang-tools-extra/unittests/clang-doc/YAMLGeneratorTest.cpp
+++ b/clang-tools-extra/unittests/clang-doc/YAMLGeneratorTest.cpp
@@ -441,12 +441,10 @@ TEST_F(YAMLGeneratorTest, emitCommentYAML) {
   ParamOut->Explicit = true;
   ParamOut->Children.emplace_back(allocatePtr<CommentInfo>());
   ParamOut->Children.back()->Kind = CommentKind::CK_ParagraphComment;
-  ParamOut->Children.back()->Children.emplace_back(
-      allocatePtr<CommentInfo>());
+  ParamOut->Children.back()->Children.emplace_back(allocatePtr<CommentInfo>());
   ParamOut->Children.back()->Children.back()->Kind =
       CommentKind::CK_TextComment;
-  ParamOut->Children.back()->Children.emplace_back(
-      allocatePtr<CommentInfo>());
+  ParamOut->Children.back()->Children.emplace_back(allocatePtr<CommentInfo>());
   ParamOut->Children.back()->Children.back()->Kind =
       CommentKind::CK_TextComment;
   ParamOut->Children.back()->Children.back()->Text = " is a parameter.";
@@ -458,12 +456,10 @@ TEST_F(YAMLGeneratorTest, emitCommentYAML) {
   ParamIn->ParamName = "J";
   ParamIn->Children.emplace_back(allocatePtr<CommentInfo>());
   ParamIn->Children.back()->Kind = CommentKind::CK_ParagraphComment;
-  ParamIn->Children.back()->Children.emplace_back(
-      allocatePtr<CommentInfo>());
+  ParamIn->Children.back()->Children.emplace_back(allocatePtr<CommentInfo>());
   ParamIn->Children.back()->Children.back()->Kind = CommentKind::CK_TextComment;
   ParamIn->Children.back()->Children.back()->Text = " is a parameter.";
-  ParamIn->Children.back()->Children.emplace_back(
-      allocatePtr<CommentInfo>());
+  ParamIn->Children.back()->Children.emplace_back(allocatePtr<CommentInfo>());
   ParamIn->Children.back()->Children.back()->Kind = CommentKind::CK_TextComment;
 
   Top.Children.emplace_back(allocatePtr<CommentInfo>());
@@ -473,8 +469,7 @@ TEST_F(YAMLGeneratorTest, emitCommentYAML) {
   Return->Explicit = true;
   Return->Children.emplace_back(allocatePtr<CommentInfo>());
   Return->Children.back()->Kind = CommentKind::CK_ParagraphComment;
-  Return->Children.back()->Children.emplace_back(
-      allocatePtr<CommentInfo>());
+  Return->Children.back()->Children.emplace_back(allocatePtr<CommentInfo>());
   Return->Children.back()->Children.back()->Kind = CommentKind::CK_TextComment;
   Return->Children.back()->Children.back()->Text = "void";
 


### PR DESCRIPTION
Since we're migrating from std::unique_ptr to raw pointers via
arena allocation, we want to have some interfaces that abstract
these operations away, and can be changed to keep the system working
without introducing a lot of unnecessary chrun in the code.