### PR TITLE
[LLDB][Windows] Initialize `read_result`

### DIFF
--- a/lldb/source/Host/windows/ConnectionGenericFileWindows.cpp
+++ b/lldb/source/Host/windows/ConnectionGenericFileWindows.cpp
@@ -160,8 +160,8 @@ size_t ConnectionGenericFile::Read(void *dst, size_t dst_len,
   if (!IsConnected())
     return finish(0, eConnectionStatusNoConnection, ERROR_INVALID_HANDLE);
 
-  BOOL read_result;
-  DWORD read_error;
+  BOOL read_result = FALSE;
+  DWORD read_error = ERROR_SUCCESS;
   if (!m_read_pending) {
     m_overlapped.hEvent = m_event_handles[kBytesAvailableEvent];
     read_result = ::ReadFile(m_file, dst, dst_len, NULL, &m_overlapped);


### PR DESCRIPTION
When I ran `lldb -o "b main" -o r`, the process crashed at `if (!read_result || m_read_pending)`, because `read_result` was uninitialized.

As a sidenote: MSVC inserts calls to `_RTC_UninitUse` which causes a pretty error message when debugging with VS:
> Exception has occurred: The variable 'read_result' is being used without being initialized.
> Run-Time Check Failure [#]3 - The variable 'read_result' is being used without being initialized.

With LLDB, you get
```
(lldb) r
Process 12344 stopped
* thread #9, stop reason = Exception 0x80000003 encountered at address 0x7ff96516c96a
       frame #0: 0x00007ff96516c96b liblldb.dll`failwithmessage(retaddr=0x00007ff95742cb02, crttype=1, errnum=3, msg="The variable 'read_result' is being used without being initialized.") at error.cpp:210
```

We could improve on the stop reason that's displayed.
