### PR TITLE
Revert "[mlir][arith] Add `exact` to `index_cast{,ui}` (#183395)"

### DIFF
--- a/mlir/include/mlir/Dialect/Arith/IR/ArithOps.td
+++ b/mlir/include/mlir/Dialect/Arith/IR/ArithOps.td
@@ -168,8 +168,7 @@ class Arith_IntBinaryOpWithOverflowFlags<string mnemonic, list<Trait> traits = [
 
 class Arith_IntBinaryOpWithExactFlag<string mnemonic, list<Trait> traits = []> :
     Arith_BinaryOp<mnemonic, traits #
-      [DeclareOpInterfaceMethods<InferIntRangeInterface, ["inferResultRanges"]>,
-       DeclareOpInterfaceMethods<ArithExactFlagInterface>]>,
+      [DeclareOpInterfaceMethods<InferIntRangeInterface, ["inferResultRanges"]>]>,
     Arguments<(ins Arith_SignlessIntegerOrIndexLike:$lhs,
                Arith_SignlessIntegerOrIndexLike:$rhs,
                UnitAttr:$isExact)>,
@@ -1588,34 +1587,15 @@ def IndexCastTypeConstraint : TypeConstraint<Or<[
 
 def Arith_IndexCastOp
   : Arith_CastOp<"index_cast", IndexCastTypeConstraint, IndexCastTypeConstraint,
-                 [DeclareOpInterfaceMethods<InferIntRangeInterface, ["inferResultRanges"]>,
-                  DeclareOpInterfaceMethods<ArithExactFlagInterface>]> {
+                 [DeclareOpInterfaceMethods<InferIntRangeInterface, ["inferResultRanges"]>]> {
   let summary = "cast between index and integer types";
   let description = [{
     Casts between scalar or vector integers and corresponding 'index' scalar or
     vectors. Index is an integer of platform-specific bit width. If casting to
     a wider integer, the value is sign-extended. If casting to a narrower
     integer, the value is truncated.
-
-    If the `exact` attribute is present, it is assumed that the operand
-    contains a value that fits in the destination's representation, therefore
-    the cast does not lose any information. When this assumption is violated,
-    the result is poison.
-
-    Example:
-
-    ```mlir
-      %0 = arith.index_cast %a : index to i64
-      %1 = arith.index_cast %a exact : index to i64
-      %2 = arith.index_cast %b exact : i32 to index
-    ```
   }];
 
-  let arguments = (ins IndexCastTypeConstraint:$in, UnitAttr:$isExact);
-  let results = (outs IndexCastTypeConstraint:$out);
-  let assemblyFormat = [{
-    $in (`exact` $isExact^)? attr-dict `:` type($in) `to` type($out)
-  }];
   let hasFolder = 1;
   let hasCanonicalizer = 1;
 }
@@ -1627,8 +1607,7 @@ def Arith_IndexCastOp
 def Arith_IndexCastUIOp
   : Arith_CastOp<"index_castui", IndexCastTypeConstraint, IndexCastTypeConstraint,
                  [DeclareOpInterfaceMethods<InferIntRangeInterface, ["inferResultRanges"]>,
-                  DeclareOpInterfaceMethods<ArithNonNegFlagInterface>,
-                  DeclareOpInterfaceMethods<ArithExactFlagInterface>]> {
+                  DeclareOpInterfaceMethods<ArithNonNegFlagInterface>]> {
   let summary = "unsigned cast between index and integer types";
   let description = [{
     Casts between scalar or vector integers and corresponding 'index' scalar or
@@ -1641,27 +1620,19 @@ def Arith_IndexCastUIOp
     is equivalent to sign extension. When this assumption is violated,
     the result is poison.
 
-    If the `exact` attribute is present, it is assumed that the operand
-    contains a value that fits in the destination's representation, therefore
-    the cast does not lose any information. When this assumption is violated,
-    the result is poison.
-
     Example:
 
     ```mlir
       %0 = arith.index_castui %a : i32 to index
       %1 = arith.index_castui %a nneg : i32 to index
       %2 = arith.index_castui %b nneg : index to i64
-      %3 = arith.index_castui %a nneg exact : i64 to index
     ```
   }];
 
-  let arguments = (ins IndexCastTypeConstraint:$in, UnitAttr:$nonNeg,
-                       UnitAttr:$isExact);
+  let arguments = (ins IndexCastTypeConstraint:$in, UnitAttr:$nonNeg);
   let results = (outs IndexCastTypeConstraint:$out);
   let assemblyFormat = [{
-    $in oilist(`exact` $isExact | `nneg` $nonNeg) attr-dict
-        `:` type($in) `to` type($out)
+    $in (`nneg` $nonNeg^)? attr-dict `:` type($in) `to` type($out)
   }];
   let hasFolder = 1;
   let hasCanonicalizer = 1;

--- a/mlir/include/mlir/Dialect/Arith/IR/ArithOpsInterfaces.td
+++ b/mlir/include/mlir/Dialect/Arith/IR/ArithOpsInterfaces.td
@@ -153,53 +153,6 @@ def ArithNonNegFlagInterface : OpInterface<"ArithNonNegFlagInterface"> {
   ];
 }
 
-def ArithExactFlagInterface : OpInterface<"ArithExactFlagInterface"> {
-  let description = [{
-    Access to op exact flag.
-  }];
-
-  let cppNamespace = "::mlir::arith";
-
-  let methods = [
-    InterfaceMethod<
-      /*desc=*/        "Returns whether the operation has the exact flag set",
-      /*returnType=*/  "bool",
-      /*methodName=*/  "getExact",
-      /*args=*/        (ins),
-      /*methodBody=*/  [{}],
-      /*defaultImpl=*/ [{
-        auto op = cast<ConcreteOp>(this->getOperation());
-        return op.getIsExactAttr() != nullptr;
-      }]
-      >,
-    InterfaceMethod<
-      /*desc=*/        "Set the exact flag for the operation",
-      /*returnType=*/  "void",
-      /*methodName=*/  "setExact",
-      /*args=*/        (ins "bool":$isExact),
-      /*methodBody=*/  [{}],
-      /*defaultImpl=*/ [{
-        auto op = cast<ConcreteOp>(this->getOperation());
-        if (isExact)
-          op.setIsExactAttr(UnitAttr::get(op->getContext()));
-        else
-          op.removeIsExactAttr();
-      }]
-      >,
-    StaticInterfaceMethod<
-      /*desc=*/        [{Returns the name of the exact flag attribute for
-                         the operation}],
-      /*returnType=*/  "StringRef",
-      /*methodName=*/  "getExactFlagAttrName",
-      /*args=*/        (ins),
-      /*methodBody=*/  [{}],
-      /*defaultImpl=*/ [{
-        return "isExact";
-      }]
-      >
-  ];
-}
-
 def ArithRoundingModeInterface : OpInterface<"ArithRoundingModeInterface"> {
   let description = [{
     Access to op rounding mode.

--- a/mlir/lib/Conversion/ArithToLLVM/ArithToLLVM.cpp
+++ b/mlir/lib/Conversion/ArithToLLVM/ArithToLLVM.cpp
@@ -311,32 +311,13 @@ LogicalResult IndexCastOpLowering<OpTy, ExtCastTy>::matchAndRewrite(
   if constexpr (std::is_same_v<ExtCastTy, LLVM::ZExtOp>)
     isNonNeg = op.getNonNeg();
 
-  bool isExact = op.getExact();
-
-  // Map exact to the appropriate overflow flag(s) for truncation:
-  //   index_cast (signed) exact    -> trunc nsw
-  //   index_castui (unsigned) exact -> trunc nuw
-  //   index_castui nneg exact       -> trunc nuw nsw
-  LLVM::IntegerOverflowFlags truncOverflow = LLVM::IntegerOverflowFlags::none;
-  if (isExact) {
-    if constexpr (std::is_same_v<ExtCastTy, LLVM::SExtOp>) {
-      truncOverflow = LLVM::IntegerOverflowFlags::nsw;
-    } else {
-      truncOverflow = LLVM::IntegerOverflowFlags::nuw;
-      if (isNonNeg)
-        truncOverflow |= LLVM::IntegerOverflowFlags::nsw;
-    }
-  }
-
   // Handle the scalar and 1D vector cases.
   Type operandType = adaptor.getIn().getType();
   if (!isa<LLVM::LLVMArrayType>(operandType)) {
     Type targetType = this->typeConverter->convertType(resultType);
     if (targetBits < sourceBits) {
-      auto truncOp = rewriter.replaceOpWithNewOp<LLVM::TruncOp>(
-          op, targetType, adaptor.getIn());
-      if (isExact)
-        truncOp.setOverflowFlags(truncOverflow);
+      rewriter.replaceOpWithNewOp<LLVM::TruncOp>(op, targetType,
+                                                 adaptor.getIn());
     } else {
       auto extOp = rewriter.replaceOpWithNewOp<ExtCastTy>(op, targetType,
                                                           adaptor.getIn());
@@ -354,16 +335,15 @@ LogicalResult IndexCastOpLowering<OpTy, ExtCastTy>::matchAndRewrite(
       [&](Type llvm1DVectorTy, ValueRange operands) -> Value {
         typename OpTy::Adaptor adaptor(operands);
         if (targetBits < sourceBits) {
-          auto truncOp = LLVM::TruncOp::create(rewriter, op.getLoc(),
-                                               llvm1DVectorTy, adaptor.getIn());
-          if (isExact)
-            truncOp.setOverflowFlags(truncOverflow);
-          return truncOp;
+          return LLVM::TruncOp::create(rewriter, op.getLoc(), llvm1DVectorTy,
+                                       adaptor.getIn());
         }
         auto extOp = ExtCastTy::create(rewriter, op.getLoc(), llvm1DVectorTy,
                                        adaptor.getIn());
-        if constexpr (std::is_same_v<ExtCastTy, LLVM::ZExtOp>)
-          extOp.setNonNeg(isNonNeg);
+        if constexpr (std::is_same_v<ExtCastTy, LLVM::ZExtOp>) {
+          if (isNonNeg)
+            extOp.setNonNeg(true);
+        }
         return extOp;
       },
       rewriter);

--- a/mlir/lib/Dialect/Arith/IR/ArithCanonicalization.td
+++ b/mlir/lib/Dialect/Arith/IR/ArithCanonicalization.td
@@ -288,38 +288,31 @@ def SelectI1ToNot :
 // IndexCastOp
 //===----------------------------------------------------------------------===//
 
-// index_cast(index_cast(x, exact)) -> x, if dstType == srcType.
-// The inner exact guarantees the iN -> index conversion is lossless,
-// so the roundtrip through index preserves the value.
+// index_cast(index_cast(x)) -> x, if dstType == srcType.
 def IndexCastOfIndexCast :
-    Pat<(Arith_IndexCastOp:$res (Arith_IndexCastOp $x, $exact1), $exact2),
+    Pat<(Arith_IndexCastOp:$res (Arith_IndexCastOp $x)),
         (replaceWithValue $x),
-        [(Constraint<CPred<"$0.getType() == $1.getType()">> $res, $x),
-         (Constraint<CPred<"(bool)$0">> $exact1)]>;
+        [(Constraint<CPred<"$0.getType() == $1.getType()">> $res, $x)]>;
 
 // index_cast(extsi(x)) -> index_cast(x)
 def IndexCastOfExtSI :
-    Pat<(Arith_IndexCastOp (Arith_ExtSIOp $x), $exact),
-        (Arith_IndexCastOp $x, $exact)>;
+    Pat<(Arith_IndexCastOp (Arith_ExtSIOp $x)), (Arith_IndexCastOp $x)>;
 
 //===----------------------------------------------------------------------===//
 // IndexCastUIOp
 //===----------------------------------------------------------------------===//
 
-// index_castui(index_castui(x, exact)) -> x, if dstType == srcType.
-// The inner exact guarantees the iN -> index conversion is lossless,
-// so the roundtrip through index preserves the value.
+// index_castui(index_castui(x)) -> x, if dstType == srcType.
 def IndexCastUIOfIndexCastUI :
-    Pat<(Arith_IndexCastUIOp:$res
-          (Arith_IndexCastUIOp $x, $nneg1, $exact1), $nneg2, $exact2),
+    Pat<(Arith_IndexCastUIOp:$res (Arith_IndexCastUIOp $x, $nneg1), $nneg2),
         (replaceWithValue $x),
-        [(Constraint<CPred<"$0.getType() == $1.getType()">> $res, $x),
-         (Constraint<CPred<"static_cast<bool>($0)">> $exact1)]>;
+        [(Constraint<CPred<"$0.getType() == $1.getType()">> $res, $x)]>;
 
 // index_castui(extui(x)) -> index_castui(x)
 def IndexCastUIOfExtUI :
-    Pat<(Arith_IndexCastUIOp (Arith_ExtUIOp $x, $nneg1), $nneg2, $exact),
-        (Arith_IndexCastUIOp $x, $nneg1, $exact)>;
+    Pat<(Arith_IndexCastUIOp (Arith_ExtUIOp $x, $nneg1), $nneg2),
+        (Arith_IndexCastUIOp $x, $nneg1)>;
+
 
 //===----------------------------------------------------------------------===//
 // BitcastOp

--- a/mlir/test/Conversion/ArithToLLVM/arith-to-llvm.mlir
+++ b/mlir/test/Conversion/ArithToLLVM/arith-to-llvm.mlir
@@ -160,58 +160,6 @@ func.func @index_castui_nneg_not_set(%arg0: i1) {
 
 // -----
 
-// index_cast exact on truncation lowers to trunc nsw (signed semantics).
-// CHECK-LABEL: @index_cast_exact_trunc
-func.func @index_cast_exact_trunc(%arg0: index) {
-// CHECK: llvm.trunc %{{.*}} overflow<nsw> : i{{.*}} to i1
-  %0 = arith.index_cast %arg0 exact : index to i1
-  return
-}
-
-// -----
-
-// index_cast exact on widening: exact is vacuously true, sext has no flag.
-// CHECK-LABEL: @index_cast_exact_ext
-func.func @index_cast_exact_ext(%arg0: i1) {
-// CHECK: llvm.sext %{{.*}} : i1 to i{{.*}}
-// CHECK-NOT: nsw
-  %0 = arith.index_cast %arg0 exact : i1 to index
-  return
-}
-
-// -----
-
-// index_castui exact on truncation lowers to trunc nuw (unsigned semantics).
-// CHECK-LABEL: @index_castui_exact_trunc
-func.func @index_castui_exact_trunc(%arg0: index) {
-// CHECK: llvm.trunc %{{.*}} overflow<nuw> : i{{.*}} to i1
-  %0 = arith.index_castui %arg0 exact : index to i1
-  return
-}
-
-// -----
-
-// index_castui nneg exact on truncation lowers to trunc nuw nsw.
-// CHECK-LABEL: @index_castui_nneg_exact_trunc
-func.func @index_castui_nneg_exact_trunc(%arg0: index) {
-// CHECK: llvm.trunc %{{.*}} overflow<nsw, nuw> : i{{.*}} to i1
-  %0 = arith.index_castui %arg0 nneg exact : index to i1
-  return
-}
-
-// -----
-
-// index_castui exact on widening: exact is vacuously true, zext has no flag.
-// CHECK-LABEL: @index_castui_exact_ext
-func.func @index_castui_exact_ext(%arg0: i1) {
-// CHECK: llvm.zext %{{.*}} : i1 to i{{.*}}
-// CHECK-NOT: nuw
-  %0 = arith.index_castui %arg0 exact : i1 to index
-  return
-}
-
-// -----
-
 // Checking conversion of signed integer types to floating point.
 // CHECK-LABEL: @sitofp
 func.func @sitofp(%arg0 : i32, %arg1 : i64) {

--- a/mlir/test/Dialect/Arith/canonicalize.mlir
+++ b/mlir/test/Dialect/Arith/canonicalize.mlir
@@ -588,15 +588,6 @@ func.func @indexCastOfSignExtend(%arg0: i8) -> index {
   return %idx : index
 }
 
-// CHECK-LABEL: @indexCastOfSignExtend_exact
-//       CHECK:   %[[res:.+]] = arith.index_cast %arg0 exact : i8 to index
-//       CHECK:   return %[[res]]
-func.func @indexCastOfSignExtend_exact(%arg0: i8) -> index {
-  %ext = arith.extsi %arg0 : i8 to i16
-  %idx = arith.index_cast %ext exact : i16 to index
-  return %idx : index
-}
-
 // CHECK-LABEL: @indexCastUIOfUnsignedExtend
 //       CHECK:   %[[res:.+]] = arith.index_castui %arg0 : i8 to index
 //       CHECK:   return %[[res]]
@@ -623,61 +614,6 @@ func.func @indexCastUIOfUnsignedExtend_nneg_on_castui(%arg0: i8) -> index {
   %ext = arith.extui %arg0 : i8 to i16
   %idx = arith.index_castui %ext nneg : i16 to index
   return %idx : index
-}
-
-// CHECK-LABEL: @indexCastUIOfUnsignedExtend_exact
-//       CHECK:   %[[res:.+]] = arith.index_castui %arg0 exact : i8 to index
-//       CHECK:   return %[[res]]
-func.func @indexCastUIOfUnsignedExtend_exact(%arg0: i8) -> index {
-  %ext = arith.extui %arg0 : i8 to i16
-  %idx = arith.index_castui %ext exact : i16 to index
-  return %idx : index
-}
-
-// CHECK-LABEL: @indexCastUIOfUnsignedExtend_nneg_exact
-//       CHECK:   %[[res:.+]] = arith.index_castui %arg0 exact nneg : i8 to index
-//       CHECK:   return %[[res]]
-func.func @indexCastUIOfUnsignedExtend_nneg_exact(%arg0: i8) -> index {
-  %ext = arith.extui %arg0 nneg : i8 to i16
-  %idx = arith.index_castui %ext exact : i16 to index
-  return %idx : index
-}
-
-// index_castui(index_castui(x)) -> x only when exact is on the inner cast.
-// CHECK-LABEL: @indexCastUIOfIndexCastUI_no_exact
-//       CHECK:   arith.index_castui
-//       CHECK:   arith.index_castui
-func.func @indexCastUIOfIndexCastUI_no_exact(%arg0: i32) -> i32 {
-  %idx = arith.index_castui %arg0 : i32 to index
-  %res = arith.index_castui %idx : index to i32
-  return %res : i32
-}
-
-// CHECK-LABEL: @indexCastUIOfIndexCastUI_exact_inner
-//       CHECK:   return %arg0 : i32
-func.func @indexCastUIOfIndexCastUI_exact_inner(%arg0: i32) -> i32 {
-  %idx = arith.index_castui %arg0 exact : i32 to index
-  %res = arith.index_castui %idx : index to i32
-  return %res : i32
-}
-
-// exact on outer only does NOT trigger the fold (outer exact on widening
-// is vacuously true and does not guarantee the inner truncation is lossless).
-// CHECK-LABEL: @indexCastUIOfIndexCastUI_exact_outer
-//       CHECK:   arith.index_castui
-//       CHECK:   arith.index_castui
-func.func @indexCastUIOfIndexCastUI_exact_outer(%arg0: i32) -> i32 {
-  %idx = arith.index_castui %arg0 : i32 to index
-  %res = arith.index_castui %idx exact : index to i32
-  return %res : i32
-}
-
-// CHECK-LABEL: @indexCastUIOfIndexCastUI_exact_both
-//       CHECK:   return %arg0 : i32
-func.func @indexCastUIOfIndexCastUI_exact_both(%arg0: i32) -> i32 {
-  %idx = arith.index_castui %arg0 exact : i32 to index
-  %res = arith.index_castui %idx exact : index to i32
-  return %res : i32
 }
 
 // CHECK-LABEL: @indexCastFold

--- a/mlir/test/Dialect/Arith/ops.mlir
+++ b/mlir/test/Dialect/Arith/ops.mlir
@@ -909,20 +909,6 @@ func.func @test_index_cast_scalable_vector1(%arg0 : vector<[8]xindex>) -> vector
   return %0 : vector<[8]xi64>
 }
 
-// CHECK-LABEL: test_index_cast_exact
-// CHECK: arith.index_cast %{{.*}} exact : i32 to index
-func.func @test_index_cast_exact(%arg0 : i32) -> index {
-  %0 = arith.index_cast %arg0 exact : i32 to index
-  return %0 : index
-}
-
-// CHECK-LABEL: test_index_cast_exact_vector
-// CHECK: arith.index_cast %{{.*}} exact : vector<8xi32> to vector<8xindex>
-func.func @test_index_cast_exact_vector(%arg0 : vector<8xi32>) -> vector<8xindex> {
-  %0 = arith.index_cast %arg0 exact : vector<8xi32> to vector<8xindex>
-  return %0 : vector<8xindex>
-}
-
 // CHECK-LABEL: test_index_castui0
 func.func @test_index_castui0(%arg0 : i32) -> index {
   %0 = arith.index_castui %arg0 : i32 to index
@@ -983,20 +969,6 @@ func.func @test_index_castui_nneg(%arg0 : i32) -> index {
 func.func @test_index_castui_nneg_vector(%arg0 : vector<8xi32>) -> vector<8xindex> {
   %0 = arith.index_castui %arg0 nneg : vector<8xi32> to vector<8xindex>
   return %0 : vector<8xindex>
-}
-
-// CHECK-LABEL: test_index_castui_exact
-// CHECK: arith.index_castui %{{.*}} exact : i32 to index
-func.func @test_index_castui_exact(%arg0 : i32) -> index {
-  %0 = arith.index_castui %arg0 exact : i32 to index
-  return %0 : index
-}
-
-// CHECK-LABEL: test_index_castui_nneg_exact
-// CHECK: arith.index_castui %{{.*}} exact nneg : i32 to index
-func.func @test_index_castui_nneg_exact(%arg0 : i32) -> index {
-  %0 = arith.index_castui %arg0 nneg exact : i32 to index
-  return %0 : index
 }
 
 // CHECK-LABEL: test_bitcast0

--- a/mlir/test/Transforms/canonicalize.mlir
+++ b/mlir/test/Transforms/canonicalize.mlir
@@ -895,7 +895,7 @@ func.func @subview(%arg0 : index, %arg1 : index) -> (index, index) {
 // CHECK-LABEL: func @index_cast
 // CHECK-SAME: %[[ARG_0:arg[0-9]+]]: i16
 func.func @index_cast(%arg0: i16) -> (i16) {
-  %11 = arith.index_cast %arg0 exact : i16 to index
+  %11 = arith.index_cast %arg0 : i16 to index
   %12 = arith.index_cast %11 : index to i16
   // CHECK: return %[[ARG_0]] : i16
   return %12 : i16


### PR DESCRIPTION
This reverts commit 7ad2c6db54a0e77249f2edb3c589ccf4c930d455.

PR #183395 introduced the `exact` flag to `index_cast` and `index_castui` and updated some canonicalization patterns.
These canonicalization patterns were found to be unsound. For example:

* `index_cast(index_cast(x)) -> x`
* where one first truncates and then widens x

the rewrite is unsound because information is lost on the first cast as it **may** truncate the value of x, therefore losing information. The `exact` flag was made to make this transformation sound. Its semantics are that when the `exact` flag is present, then it is assumed that the operand to index_cast does not lose information (i.e., fits perfectly in the destination type).

In PR #183395, the canonicalization rule was rewritten such that would only match where the inner index_cast had the `exact` flag set.

* `index_cast(index_cast(x, exact)) -> x`
* where source type and destination type are the same

A post-merge review [highlighted](https://github.com/llvm/llvm-project/pull/183395#discussion_r2880422529) that the pattern above also disallows the following correct pattern:

* `index_cast(index_cast(x)) -> x`
* when the first index widens and the second one truncates.

Unfortunately the semantics of `index` are such that its bitwidth is target specific. Attempts were made in https://github.com/llvm/llvm-project/pull/184631 to automatically add annotations were possible but no agreement was reached on the best way to do this. Adding to the disagreement are the following points:

* [there are other unsound patterns that assume index is 64](https://github.com/llvm/llvm-project/pull/184631/changes#r2885181291)
* [The semantics of index is contested](https://discourse.llvm.org/t/index-type-and-assumption-about-bitwidth/88287)

This lead to the belief that a reversal and an RFC would be a good approach to get some consensus from the community before proceeding further.