### PR TITLE
[flang][openacc] Relax semantic check on cache directive

### DIFF
--- a/flang/lib/Semantics/check-acc-structure.cpp
+++ b/flang/lib/Semantics/check-acc-structure.cpp
@@ -688,13 +688,7 @@ void AccStructureChecker::Enter(const parser::OpenACCCacheConstruct &x) {
                     if (const auto *triplet =
                             std::get_if<parser::SubscriptTriplet>(
                                 &subscript.u)) {
-                      const auto &lower{std::get<0>(triplet->t)};
-                      const auto &upper{std::get<1>(triplet->t)};
                       const auto &stride{std::get<2>(triplet->t)};
-                      if (!lower && !upper) {
-                        context_.Say(designator.source,
-                            "The CACHE directive requires at least one of the bounds in the array section subscript triplet to be specified"_err_en_US);
-                      }
                       if (stride) {
                         if (auto strideVal{GetIntValue(*stride)}) {
                           if (*strideVal != 1) {

--- a/flang/test/Lower/OpenACC/acc-cache.f90
+++ b/flang/test/Lower/OpenACC/acc-cache.f90
@@ -767,3 +767,19 @@ subroutine test_cache_temp_in_designator(data, a)
 ! CHECK: hlfir.designate %[[DECL]]#0
 ! CHECK: acc.yield
 end subroutine
+
+
+subroutine full_array_cache()
+  integer :: k, j , kd, jd,y, x
+  real(8) :: tile(0:8,0:8)
+
+  !$acc parallel loop gang collapse(2)
+  do k = 1, kd
+    do j = 1, jd
+      !$acc cache(tile(:,:))
+    end do
+  end do
+end subroutine
+
+! CHECK-LABEL: func.func @_QPfull_array_cache()
+! CHECK: acc.cache var(%{{.*}}) bounds(%{{.*}})

--- a/flang/test/Semantics/OpenACC/acc-cache-validity.f90
+++ b/flang/test/Semantics/OpenACC/acc-cache-validity.f90
@@ -38,11 +38,9 @@ program openacc_cache_validity
   !ERROR: Only array element or subarray are allowed in CACHE directive
   !$acc cache(/i/)
 
-  !ERROR: The CACHE directive requires at least one of the bounds in the array section subscript triplet to be specified
-  !$acc cache(a(:))
+  !$acc cache(a(:)) ! ok
 
-  !ERROR: The CACHE directive requires at least one of the bounds in the array section subscript triplet to be specified
-  !$acc cache(aa(:,:))
+  !$acc cache(aa(:,:)) ! ok
 
   !ERROR: The CACHE directive does not support strided array sections
   !$acc cache(a(1:10:2))


### PR DESCRIPTION
The specification doesn't really forbid the colon notation to be used to specify the full array. Reference compiler accepts this and our lowering can already handle it. 