### PR TITLE
[clang-format] Fix Macros configuration not working with try/catch expansions

### DIFF
--- a/clang/lib/Format/FormatTokenLexer.cpp
+++ b/clang/lib/Format/FormatTokenLexer.cpp
@@ -163,8 +163,6 @@ void FormatTokenLexer::tryMergePreviousTokens() {
     return;
   if (tryMergeForEach())
     return;
-  if (Style.isCpp() && tryTransformTryUsageForC())
-    return;
 
   if ((Style.Language == FormatStyle::LK_Cpp ||
        Style.Language == FormatStyle::LK_ObjC) &&
@@ -530,26 +528,6 @@ bool FormatTokenLexer::tryMergeForEach() {
                              Each->TokenText.end() - For->TokenText.begin());
   For->ColumnWidth += Each->ColumnWidth;
   Tokens.erase(Tokens.end() - 1);
-  return true;
-}
-
-bool FormatTokenLexer::tryTransformTryUsageForC() {
-  if (Tokens.size() < 2)
-    return false;
-  auto &Try = *(Tokens.end() - 2);
-  if (Try->isNot(tok::kw_try))
-    return false;
-  auto &Next = *(Tokens.end() - 1);
-  if (Next->isOneOf(tok::l_brace, tok::colon, tok::hash, tok::comment))
-    return false;
-
-  if (Tokens.size() > 2) {
-    auto &At = *(Tokens.end() - 3);
-    if (At->is(tok::at))
-      return false;
-  }
-
-  Try->Tok.setKind(tok::identifier);
   return true;
 }
 

--- a/clang/lib/Format/FormatTokenLexer.h
+++ b/clang/lib/Format/FormatTokenLexer.h
@@ -56,7 +56,6 @@ private:
   bool tryMergeNullishCoalescingEqual();
   bool tryTransformCSharpForEach();
   bool tryMergeForEach();
-  bool tryTransformTryUsageForC();
 
   // Merge the most recently lexed tokens into a single token if their kinds are
   // correct.

--- a/clang/unittests/Format/FormatTest.cpp
+++ b/clang/unittests/Format/FormatTest.cpp
@@ -4896,9 +4896,11 @@ TEST_F(FormatTest, FormatTryCatch) {
 }
 
 TEST_F(FormatTest, FormatTryAsAVariable) {
-  verifyFormat("int try;");
-  verifyFormat("int try, size;");
-  verifyFormat("try = foo();");
+  auto Style = getLLVMStyle(FormatStyle::LK_C);
+  verifyFormat("int try;", Style);
+  verifyFormat("int try, size;", Style);
+  verifyFormat("try = foo();", Style);
+
   verifyFormat("if (try < size) {\n  return true;\n}");
 
   verifyFormat("int catch;");
@@ -4906,7 +4908,7 @@ TEST_F(FormatTest, FormatTryAsAVariable) {
   verifyFormat("catch = foo();");
   verifyFormat("if (catch < size) {\n  return true;\n}");
 
-  FormatStyle Style = getLLVMStyle();
+  Style.Language = FormatStyle::LK_Cpp;
   Style.BreakBeforeBraces = FormatStyle::BS_Custom;
   Style.BraceWrapping.AfterFunction = true;
   Style.BraceWrapping.BeforeCatch = true;


### PR DESCRIPTION
This is a superseding followup to my previous PR, https://github.com/llvm/llvm-project/pull/183352.

In my previous PR, I proposed adding TryMacros and CatchMacros configuration options, similar in spirit to IfMacros and ForEachMacros. I did so because I noticed that configuration like `Macros=["TRY_MACRO=try", "CATCH_MACRO(e)=catch(e)]` did not format configured macro(s) as try/catch blocks. @owenca confirmed in my previous PR that this observed behavior is undesired, and we should prefer to fix it rather than introduce new features.

This PR proposes a fix, described in detail in the commit message below the break. In general terms, it deletes a heuristic from the lexing phase, where it interacted poorly with the Macros option, and moves its functionality to the parsing phase instead.

I describe a possibly cleaner fix in [a comment here](https://github.com/llvm/llvm-project/pull/183352#issuecomment-3992773126), but it has the disadvantage of unintended behavior changes for Objective-C code using `try` as an identifier. The fix in this PR avoids that unintended behavior change; the only behavior change is the bugfix itself.

cc @HazardyKnusperkeks as previous reviewer, and @mydeveloperday as the heuristic's original author.

---

The lexer heuristic `tryTransformTryUsageForC()` was intended to allow C code to use `try` as an identifier by demoting `tok::kw_try` to `tok::identifier` when the following token did not look like the start of a try body. However, when `MacroExpander::parseDefinition()` lexed a macro like `"TRY_MACRO=try"`, the `try` token in the expansion body was followed by `eof`, triggering the heuristic. This caused `try` to be demoted to an identifier in the macro definition, so expanded code was never parsed as a try/catch statement.

Delete `tryTransformTryUsageForC()` and instead guard the two `case tok::kw_try:` dispatch sites in
`UnwrappedLineParser::parseStructuralElement()`. The guard is restricted to `Style.isCpp()` (which covers C, C++, and Objective-C) and checks whether the next non-comment token is `{`, `:`, or `#` -- the tokens that can legitimately begin a try body or precede one.

The old heuristic also had to check for a preceding `@` token to avoid demoting `try` in Objective-C `@try` constructs. The parser-level guard does not need this check because `@try` is routed through `case tok::at` and dispatched via `getObjCKeywordID()` to `tok::objc_try`, which calls `parseTryCatch()` directly. The bare `kw_try` token never reaches `case tok::kw_try` when parsing `@try`.

Assisted-by: Claude (anthropic.com)