### PR TITLE
[Clang][NFC] Apply Rule of Three to AttrScopedAttrEquivalenceContext

### DIFF
--- a/clang/include/clang/AST/ASTStructuralEquivalence.h
+++ b/clang/include/clang/AST/ASTStructuralEquivalence.h
@@ -69,6 +69,10 @@ struct StructuralEquivalenceContext {
       Ctx.Complain = false;
     }
     ~AttrScopedAttrEquivalenceContext() { Ctx.Complain = OldComplain; }
+    AttrScopedAttrEquivalenceContext(const AttrScopedAttrEquivalenceContext &) =
+        delete;
+    AttrScopedAttrEquivalenceContext &
+    operator=(const AttrScopedAttrEquivalenceContext &) = delete;
 
     StructuralEquivalenceContext &Ctx;
     bool OldComplain;


### PR DESCRIPTION
Static analysis flagged AttrScopedAttrEquivalenceContext as having a user defined destructor but not having copy ctor or copy assignment. I set them as deleted since they are not needed.