### PR TITLE
[lldb] Use llvm::SmallVector in the PluginManager (NFC)

### DIFF
--- a/lldb/include/lldb/Core/PluginManager.h
+++ b/lldb/include/lldb/Core/PluginManager.h
@@ -20,6 +20,7 @@
 #include "lldb/lldb-forward.h"
 #include "lldb/lldb-private-interfaces.h"
 #include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/JSON.h"
 
@@ -74,7 +75,7 @@ struct RegisteredPluginInfo {
 //
 // The plugin namespace here is used so we can operate on all the plugins
 // of a given type so it is easy to enable or disable them as a group.
-using GetPluginInfo = std::function<std::vector<RegisteredPluginInfo>()>;
+using GetPluginInfo = std::function<llvm::SmallVector<RegisteredPluginInfo>()>;
 using SetPluginEnabled = std::function<bool(llvm::StringRef, bool)>;
 struct PluginNamespace {
   llvm::StringRef name;
@@ -170,7 +171,7 @@ public:
 
   static bool UnregisterPlugin(ABICreateInstance create_callback);
 
-  static std::vector<ABICreateInstance> GetABICreateCallbacks();
+  static llvm::SmallVector<ABICreateInstance> GetABICreateCallbacks();
 
   // Architecture
   static void RegisterPlugin(llvm::StringRef name, llvm::StringRef description,
@@ -187,7 +188,7 @@ public:
 
   static bool UnregisterPlugin(DisassemblerCreateInstance create_callback);
 
-  static std::vector<DisassemblerCreateInstance>
+  static llvm::SmallVector<DisassemblerCreateInstance>
   GetDisassemblerCreateCallbacks();
 
   static DisassemblerCreateInstance
@@ -201,7 +202,7 @@ public:
 
   static bool UnregisterPlugin(DynamicLoaderCreateInstance create_callback);
 
-  static std::vector<DynamicLoaderCreateInstance>
+  static llvm::SmallVector<DynamicLoaderCreateInstance>
   GetDynamicLoaderCreateCallbacks();
 
   static DynamicLoaderCreateInstance
@@ -215,7 +216,8 @@ public:
 
   static bool UnregisterPlugin(JITLoaderCreateInstance create_callback);
 
-  static std::vector<JITLoaderCreateInstance> GetJITLoaderCreateCallbacks();
+  static llvm::SmallVector<JITLoaderCreateInstance>
+  GetJITLoaderCreateCallbacks();
 
   // EmulateInstruction
   static bool RegisterPlugin(llvm::StringRef name, llvm::StringRef description,
@@ -224,7 +226,7 @@ public:
   static bool
   UnregisterPlugin(EmulateInstructionCreateInstance create_callback);
 
-  static std::vector<EmulateInstructionCreateInstance>
+  static llvm::SmallVector<EmulateInstructionCreateInstance>
   GetEmulateInstructionCreateCallbacks();
 
   static EmulateInstructionCreateInstance
@@ -237,7 +239,7 @@ public:
 
   static bool UnregisterPlugin(OperatingSystemCreateInstance create_callback);
 
-  static std::vector<OperatingSystemCreateInstance>
+  static llvm::SmallVector<OperatingSystemCreateInstance>
   GetOperatingSystemCreateCallbacks();
 
   static OperatingSystemCreateInstance
@@ -251,7 +253,7 @@ public:
 
   static bool UnregisterPlugin(LanguageCreateInstance create_callback);
 
-  static std::vector<LanguageCreateInstance> GetLanguageCreateCallbacks();
+  static llvm::SmallVector<LanguageCreateInstance> GetLanguageCreateCallbacks();
 
   // LanguageRuntime
   static bool RegisterPlugin(
@@ -262,7 +264,8 @@ public:
 
   static bool UnregisterPlugin(LanguageRuntimeCreateInstance create_callback);
 
-  static std::vector<LanguageRuntimeCallbacks> GetLanguageRuntimeCallbacks();
+  static llvm::SmallVector<LanguageRuntimeCallbacks>
+  GetLanguageRuntimeCallbacks();
 
   // SystemRuntime
   static bool RegisterPlugin(llvm::StringRef name, llvm::StringRef description,
@@ -270,7 +273,7 @@ public:
 
   static bool UnregisterPlugin(SystemRuntimeCreateInstance create_callback);
 
-  static std::vector<SystemRuntimeCreateInstance>
+  static llvm::SmallVector<SystemRuntimeCreateInstance>
   GetSystemRuntimeCreateCallbacks();
 
   // ObjectFile
@@ -286,14 +289,14 @@ public:
 
   static bool IsRegisteredObjectFilePluginName(llvm::StringRef name);
 
-  static std::vector<ObjectFileCallbacks> GetObjectFileCallbacks();
+  static llvm::SmallVector<ObjectFileCallbacks> GetObjectFileCallbacks();
 
   static ObjectFileCreateMemoryInstance
   GetObjectFileCreateMemoryCallbackForPluginName(llvm::StringRef name);
 
   static Status SaveCore(lldb_private::SaveCoreOptions &core_options);
 
-  static std::vector<llvm::StringRef> GetSaveCorePluginNames();
+  static llvm::SmallVector<llvm::StringRef> GetSaveCorePluginNames();
 
   // ObjectContainer
   static bool RegisterPlugin(
@@ -304,7 +307,8 @@ public:
 
   static bool UnregisterPlugin(ObjectContainerCreateInstance create_callback);
 
-  static std::vector<ObjectContainerCallbacks> GetObjectContainerCallbacks();
+  static llvm::SmallVector<ObjectContainerCallbacks>
+  GetObjectContainerCallbacks();
 
   // Platform
   static bool
@@ -314,7 +318,7 @@ public:
 
   static bool UnregisterPlugin(PlatformCreateInstance create_callback);
 
-  static std::vector<PlatformCreateInstance> GetPlatformCreateCallbacks();
+  static llvm::SmallVector<PlatformCreateInstance> GetPlatformCreateCallbacks();
 
   static PlatformCreateInstance
   GetPlatformCreateCallbackForPluginName(llvm::StringRef name);
@@ -333,7 +337,7 @@ public:
 
   static bool UnregisterPlugin(ProcessCreateInstance create_callback);
 
-  static std::vector<ProcessCreateInstance> GetProcessCreateCallbacks();
+  static llvm::SmallVector<ProcessCreateInstance> GetProcessCreateCallbacks();
 
   static ProcessCreateInstance
   GetProcessCreateCallbackForPluginName(llvm::StringRef name);
@@ -374,7 +378,7 @@ public:
 
   static bool UnregisterPlugin(ScriptInterpreterCreateInstance create_callback);
 
-  static std::vector<ScriptInterpreterCreateInstance>
+  static llvm::SmallVector<ScriptInterpreterCreateInstance>
   GetScriptInterpreterCreateCallbacks();
 
   static lldb::ScriptInterpreterSP
@@ -399,7 +403,7 @@ public:
   static SyntheticFrameProviderCreateInstance
   GetSyntheticFrameProviderCreateCallbackForPluginName(llvm::StringRef name);
 
-  static std::vector<ScriptedFrameProviderCreateInstance>
+  static llvm::SmallVector<ScriptedFrameProviderCreateInstance>
   GetScriptedFrameProviderCreateCallbacks();
 
   // StructuredDataPlugin
@@ -445,7 +449,7 @@ public:
   static bool
   UnregisterPlugin(StructuredDataPluginCreateInstance create_callback);
 
-  static std::vector<StructuredDataPluginCallbacks>
+  static llvm::SmallVector<StructuredDataPluginCallbacks>
   GetStructuredDataPluginCallbacks();
 
   // SymbolFile
@@ -456,7 +460,8 @@ public:
 
   static bool UnregisterPlugin(SymbolFileCreateInstance create_callback);
 
-  static std::vector<SymbolFileCreateInstance> GetSymbolFileCreateCallbacks();
+  static llvm::SmallVector<SymbolFileCreateInstance>
+  GetSymbolFileCreateCallbacks();
 
   // SymbolVendor
   static bool RegisterPlugin(llvm::StringRef name, llvm::StringRef description,
@@ -464,7 +469,7 @@ public:
 
   static bool UnregisterPlugin(SymbolVendorCreateInstance create_callback);
 
-  static std::vector<SymbolVendorCreateInstance>
+  static llvm::SmallVector<SymbolVendorCreateInstance>
   GetSymbolVendorCreateCallbacks();
 
   // SymbolLocator
@@ -482,7 +487,7 @@ public:
 
   static bool UnregisterPlugin(SymbolLocatorCreateInstance create_callback);
 
-  static std::vector<SymbolLocatorCreateInstance>
+  static llvm::SmallVector<SymbolLocatorCreateInstance>
   GetSymbolLocatorCreateCallbacks();
 
   static ModuleSpec LocateExecutableObjectFile(const ModuleSpec &module_spec,
@@ -555,7 +560,7 @@ public:
 
   static bool UnregisterPlugin(TraceExporterCreateInstance create_callback);
 
-  static std::vector<TraceExporterCallbacks> GetTraceExporterCallbacks();
+  static llvm::SmallVector<TraceExporterCallbacks> GetTraceExporterCallbacks();
 
   // UnwindAssembly
   static bool RegisterPlugin(llvm::StringRef name, llvm::StringRef description,
@@ -563,7 +568,7 @@ public:
 
   static bool UnregisterPlugin(UnwindAssemblyCreateInstance create_callback);
 
-  static std::vector<UnwindAssemblyCreateInstance>
+  static llvm::SmallVector<UnwindAssemblyCreateInstance>
   GetUnwindAssemblyCreateCallbacks();
 
   // MemoryHistory
@@ -572,7 +577,7 @@ public:
 
   static bool UnregisterPlugin(MemoryHistoryCreateInstance create_callback);
 
-  static std::vector<MemoryHistoryCreateInstance>
+  static llvm::SmallVector<MemoryHistoryCreateInstance>
   GetMemoryHistoryCreateCallbacks();
 
   // InstrumentationRuntime
@@ -584,7 +589,7 @@ public:
   static bool
   UnregisterPlugin(InstrumentationRuntimeCreateInstance create_callback);
 
-  static std::vector<InstrumentationRuntimeCallbacks>
+  static llvm::SmallVector<InstrumentationRuntimeCallbacks>
   GetInstrumentationRuntimeCallbacks();
 
   // TypeSystem
@@ -595,7 +600,8 @@ public:
 
   static bool UnregisterPlugin(TypeSystemCreateInstance create_callback);
 
-  static std::vector<TypeSystemCreateInstance> GetTypeSystemCreateCallbacks();
+  static llvm::SmallVector<TypeSystemCreateInstance>
+  GetTypeSystemCreateCallbacks();
 
   static LanguageSet GetAllTypeSystemSupportedLanguagesForTypes();
 
@@ -627,7 +633,7 @@ public:
 
   static bool UnregisterPlugin(REPLCreateInstance create_callback);
 
-  static std::vector<REPLCallbacks> GetREPLCallbacks();
+  static llvm::SmallVector<REPLCallbacks> GetREPLCallbacks();
 
   static LanguageSet GetREPLAllTypeSystemSupportedLanguages();
 
@@ -637,7 +643,8 @@ public:
 
   static bool UnregisterPlugin(HighlighterCreateInstance create_callback);
 
-  static std::vector<HighlighterCreateInstance> GetHighlighterCreateCallbacks();
+  static llvm::SmallVector<HighlighterCreateInstance>
+  GetHighlighterCreateCallbacks();
 
   // Some plug-ins might register a DebuggerInitializeCallback callback when
   // registering the plug-in. After a new Debugger instance is created, this
@@ -731,97 +738,101 @@ public:
   //
   // Plugin Info+Enable Declarations
   //
-  static std::vector<RegisteredPluginInfo> GetABIPluginInfo();
+  static llvm::SmallVector<RegisteredPluginInfo> GetABIPluginInfo();
   static bool SetABIPluginEnabled(llvm::StringRef name, bool enable);
 
-  static std::vector<RegisteredPluginInfo> GetArchitecturePluginInfo();
+  static llvm::SmallVector<RegisteredPluginInfo> GetArchitecturePluginInfo();
   static bool SetArchitecturePluginEnabled(llvm::StringRef name, bool enable);
 
-  static std::vector<RegisteredPluginInfo> GetDisassemblerPluginInfo();
+  static llvm::SmallVector<RegisteredPluginInfo> GetDisassemblerPluginInfo();
   static bool SetDisassemblerPluginEnabled(llvm::StringRef name, bool enable);
 
-  static std::vector<RegisteredPluginInfo> GetDynamicLoaderPluginInfo();
+  static llvm::SmallVector<RegisteredPluginInfo> GetDynamicLoaderPluginInfo();
   static bool SetDynamicLoaderPluginEnabled(llvm::StringRef name, bool enable);
 
-  static std::vector<RegisteredPluginInfo> GetEmulateInstructionPluginInfo();
+  static llvm::SmallVector<RegisteredPluginInfo>
+  GetEmulateInstructionPluginInfo();
   static bool SetEmulateInstructionPluginEnabled(llvm::StringRef name,
                                                  bool enable);
 
-  static std::vector<RegisteredPluginInfo>
+  static llvm::SmallVector<RegisteredPluginInfo>
   GetInstrumentationRuntimePluginInfo();
   static bool SetInstrumentationRuntimePluginEnabled(llvm::StringRef name,
                                                      bool enable);
 
-  static std::vector<RegisteredPluginInfo> GetJITLoaderPluginInfo();
+  static llvm::SmallVector<RegisteredPluginInfo> GetJITLoaderPluginInfo();
   static bool SetJITLoaderPluginEnabled(llvm::StringRef name, bool enable);
 
-  static std::vector<RegisteredPluginInfo> GetLanguagePluginInfo();
+  static llvm::SmallVector<RegisteredPluginInfo> GetLanguagePluginInfo();
   static bool SetLanguagePluginEnabled(llvm::StringRef name, bool enable);
 
-  static std::vector<RegisteredPluginInfo> GetLanguageRuntimePluginInfo();
+  static llvm::SmallVector<RegisteredPluginInfo> GetLanguageRuntimePluginInfo();
   static bool SetLanguageRuntimePluginEnabled(llvm::StringRef name,
                                               bool enable);
 
-  static std::vector<RegisteredPluginInfo> GetMemoryHistoryPluginInfo();
+  static llvm::SmallVector<RegisteredPluginInfo> GetMemoryHistoryPluginInfo();
   static bool SetMemoryHistoryPluginEnabled(llvm::StringRef name, bool enable);
 
-  static std::vector<RegisteredPluginInfo> GetObjectContainerPluginInfo();
+  static llvm::SmallVector<RegisteredPluginInfo> GetObjectContainerPluginInfo();
   static bool SetObjectContainerPluginEnabled(llvm::StringRef name,
                                               bool enable);
 
-  static std::vector<RegisteredPluginInfo> GetObjectFilePluginInfo();
+  static llvm::SmallVector<RegisteredPluginInfo> GetObjectFilePluginInfo();
   static bool SetObjectFilePluginEnabled(llvm::StringRef name, bool enable);
 
-  static std::vector<RegisteredPluginInfo> GetOperatingSystemPluginInfo();
+  static llvm::SmallVector<RegisteredPluginInfo> GetOperatingSystemPluginInfo();
   static bool SetOperatingSystemPluginEnabled(llvm::StringRef name,
                                               bool enable);
 
-  static std::vector<RegisteredPluginInfo> GetPlatformPluginInfo();
+  static llvm::SmallVector<RegisteredPluginInfo> GetPlatformPluginInfo();
   static bool SetPlatformPluginEnabled(llvm::StringRef name, bool enable);
 
-  static std::vector<RegisteredPluginInfo> GetProcessPluginInfo();
+  static llvm::SmallVector<RegisteredPluginInfo> GetProcessPluginInfo();
   static bool SetProcessPluginEnabled(llvm::StringRef name, bool enable);
 
-  static std::vector<RegisteredPluginInfo> GetREPLPluginInfo();
+  static llvm::SmallVector<RegisteredPluginInfo> GetREPLPluginInfo();
   static bool SetREPLPluginEnabled(llvm::StringRef name, bool enable);
 
-  static std::vector<RegisteredPluginInfo> GetRegisterTypeBuilderPluginInfo();
+  static llvm::SmallVector<RegisteredPluginInfo>
+  GetRegisterTypeBuilderPluginInfo();
   static bool SetRegisterTypeBuilderPluginEnabled(llvm::StringRef name,
                                                   bool enable);
 
-  static std::vector<RegisteredPluginInfo> GetScriptInterpreterPluginInfo();
+  static llvm::SmallVector<RegisteredPluginInfo>
+  GetScriptInterpreterPluginInfo();
   static bool SetScriptInterpreterPluginEnabled(llvm::StringRef name,
                                                 bool enable);
 
-  static std::vector<RegisteredPluginInfo> GetScriptedInterfacePluginInfo();
+  static llvm::SmallVector<RegisteredPluginInfo>
+  GetScriptedInterfacePluginInfo();
   static bool SetScriptedInterfacePluginEnabled(llvm::StringRef name,
                                                 bool enable);
 
-  static std::vector<RegisteredPluginInfo> GetStructuredDataPluginInfo();
+  static llvm::SmallVector<RegisteredPluginInfo> GetStructuredDataPluginInfo();
   static bool SetStructuredDataPluginEnabled(llvm::StringRef name, bool enable);
 
-  static std::vector<RegisteredPluginInfo> GetSymbolFilePluginInfo();
+  static llvm::SmallVector<RegisteredPluginInfo> GetSymbolFilePluginInfo();
   static bool SetSymbolFilePluginEnabled(llvm::StringRef name, bool enable);
 
-  static std::vector<RegisteredPluginInfo> GetSymbolLocatorPluginInfo();
+  static llvm::SmallVector<RegisteredPluginInfo> GetSymbolLocatorPluginInfo();
   static bool SetSymbolLocatorPluginEnabled(llvm::StringRef name, bool enable);
 
-  static std::vector<RegisteredPluginInfo> GetSymbolVendorPluginInfo();
+  static llvm::SmallVector<RegisteredPluginInfo> GetSymbolVendorPluginInfo();
   static bool SetSymbolVendorPluginEnabled(llvm::StringRef name, bool enable);
 
-  static std::vector<RegisteredPluginInfo> GetSystemRuntimePluginInfo();
+  static llvm::SmallVector<RegisteredPluginInfo> GetSystemRuntimePluginInfo();
   static bool SetSystemRuntimePluginEnabled(llvm::StringRef name, bool enable);
 
-  static std::vector<RegisteredPluginInfo> GetTracePluginInfo();
+  static llvm::SmallVector<RegisteredPluginInfo> GetTracePluginInfo();
   static bool SetTracePluginEnabled(llvm::StringRef name, bool enable);
 
-  static std::vector<RegisteredPluginInfo> GetTraceExporterPluginInfo();
+  static llvm::SmallVector<RegisteredPluginInfo> GetTraceExporterPluginInfo();
   static bool SetTraceExporterPluginEnabled(llvm::StringRef name, bool enable);
 
-  static std::vector<RegisteredPluginInfo> GetTypeSystemPluginInfo();
+  static llvm::SmallVector<RegisteredPluginInfo> GetTypeSystemPluginInfo();
   static bool SetTypeSystemPluginEnabled(llvm::StringRef name, bool enable);
 
-  static std::vector<RegisteredPluginInfo> GetUnwindAssemblyPluginInfo();
+  static llvm::SmallVector<RegisteredPluginInfo> GetUnwindAssemblyPluginInfo();
   static bool SetUnwindAssemblyPluginEnabled(llvm::StringRef name, bool enable);
 
   static void AutoCompletePluginName(llvm::StringRef partial_name,

--- a/lldb/source/Commands/CommandObjectProcess.cpp
+++ b/lldb/source/Commands/CommandObjectProcess.cpp
@@ -1301,7 +1301,7 @@ public:
         if (opt_name != "plugin-name")
           continue;
 
-        std::vector<llvm::StringRef> plugin_names =
+        llvm::SmallVector<llvm::StringRef> plugin_names =
             PluginManager::GetSaveCorePluginNames();
         m_plugin_enums.resize(plugin_names.size());
         for (auto [num, val] : llvm::zip(plugin_names, m_plugin_enums)) {

--- a/lldb/source/Core/PluginManager.cpp
+++ b/lldb/source/Core/PluginManager.cpp
@@ -24,12 +24,10 @@
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/raw_ostream.h"
 #include <cassert>
-#include <map>
 #include <memory>
 #include <mutex>
 #include <string>
 #include <utility>
-#include <vector>
 #if defined(_WIN32)
 #include "lldb/Host/windows/PosixApi.h"
 #endif
@@ -532,9 +530,9 @@ public:
     return nullptr;
   }
 
-  std::vector<typename Instance::CallbackType> GetCreateCallbacks() {
-    std::vector<Instance> snapshot = GetSnapshot();
-    std::vector<typename Instance::CallbackType> result;
+  llvm::SmallVector<typename Instance::CallbackType> GetCreateCallbacks() {
+    llvm::SmallVector<Instance> snapshot = GetSnapshot();
+    llvm::SmallVector<typename Instance::CallbackType> result;
     result.reserve(snapshot.size());
     for (const auto &instance : snapshot)
       result.push_back(instance.create_callback);
@@ -552,10 +550,10 @@ public:
   // Note that this is a copy of the internal state so modifications
   // to the returned instances will not be reflected back to instances
   // stored by the PluginInstances object.
-  std::vector<Instance> GetSnapshot() const {
+  llvm::SmallVector<Instance> GetSnapshot() const {
     std::lock_guard<std::mutex> guard(m_mutex);
 
-    std::vector<Instance> enabled_instances;
+    llvm::SmallVector<Instance> enabled_instances;
     enabled_instances.reserve(m_instances.size());
     for (const auto &instance : m_instances) {
       if (instance.enabled)
@@ -592,11 +590,11 @@ public:
   // enabled and disabled instances. The instances are listed in the order they
   // were registered which is the order they would be queried if they were all
   // enabled.
-  std::vector<RegisteredPluginInfo> GetPluginInfoForAllInstances() {
+  llvm::SmallVector<RegisteredPluginInfo> GetPluginInfoForAllInstances() {
     std::lock_guard<std::mutex> guard(m_mutex);
 
     // Lookup the plugin info for each instance in the sorted order.
-    std::vector<RegisteredPluginInfo> plugin_infos;
+    llvm::SmallVector<RegisteredPluginInfo> plugin_infos;
     plugin_infos.reserve(m_instances.size());
 
     for (const Instance &instance : m_instances)
@@ -621,7 +619,7 @@ public:
 
 private:
   mutable std::mutex m_mutex;
-  std::vector<Instance> m_instances;
+  llvm::SmallVector<Instance> m_instances;
 };
 
 #pragma mark ABI
@@ -644,7 +642,7 @@ bool PluginManager::UnregisterPlugin(ABICreateInstance create_callback) {
   return GetABIInstances().UnregisterPlugin(create_callback);
 }
 
-std::vector<ABICreateInstance> PluginManager::GetABICreateCallbacks() {
+llvm::SmallVector<ABICreateInstance> PluginManager::GetABICreateCallbacks() {
   return GetABIInstances().GetCreateCallbacks();
 }
 
@@ -701,7 +699,7 @@ bool PluginManager::UnregisterPlugin(
   return GetDisassemblerInstances().UnregisterPlugin(create_callback);
 }
 
-std::vector<DisassemblerCreateInstance>
+llvm::SmallVector<DisassemblerCreateInstance>
 PluginManager::GetDisassemblerCreateCallbacks() {
   return GetDisassemblerInstances().GetCreateCallbacks();
 }
@@ -735,7 +733,7 @@ bool PluginManager::UnregisterPlugin(
   return GetDynamicLoaderInstances().UnregisterPlugin(create_callback);
 }
 
-std::vector<DynamicLoaderCreateInstance>
+llvm::SmallVector<DynamicLoaderCreateInstance>
 PluginManager::GetDynamicLoaderCreateCallbacks() {
   return GetDynamicLoaderInstances().GetCreateCallbacks();
 }
@@ -768,7 +766,7 @@ bool PluginManager::UnregisterPlugin(JITLoaderCreateInstance create_callback) {
   return GetJITLoaderInstances().UnregisterPlugin(create_callback);
 }
 
-std::vector<JITLoaderCreateInstance>
+llvm::SmallVector<JITLoaderCreateInstance>
 PluginManager::GetJITLoaderCreateCallbacks() {
   return GetJITLoaderInstances().GetCreateCallbacks();
 }
@@ -796,7 +794,7 @@ bool PluginManager::UnregisterPlugin(
   return GetEmulateInstructionInstances().UnregisterPlugin(create_callback);
 }
 
-std::vector<EmulateInstructionCreateInstance>
+llvm::SmallVector<EmulateInstructionCreateInstance>
 PluginManager::GetEmulateInstructionCreateCallbacks() {
   return GetEmulateInstructionInstances().GetCreateCallbacks();
 }
@@ -830,7 +828,7 @@ bool PluginManager::UnregisterPlugin(
   return GetOperatingSystemInstances().UnregisterPlugin(create_callback);
 }
 
-std::vector<OperatingSystemCreateInstance>
+llvm::SmallVector<OperatingSystemCreateInstance>
 PluginManager::GetOperatingSystemCreateCallbacks() {
   return GetOperatingSystemInstances().GetCreateCallbacks();
 }
@@ -863,7 +861,7 @@ bool PluginManager::UnregisterPlugin(LanguageCreateInstance create_callback) {
   return GetLanguageInstances().UnregisterPlugin(create_callback);
 }
 
-std::vector<LanguageCreateInstance>
+llvm::SmallVector<LanguageCreateInstance>
 PluginManager::GetLanguageCreateCallbacks() {
   return GetLanguageInstances().GetCreateCallbacks();
 }
@@ -909,10 +907,10 @@ bool PluginManager::UnregisterPlugin(
   return GetLanguageRuntimeInstances().UnregisterPlugin(create_callback);
 }
 
-std::vector<LanguageRuntimeCallbacks>
+llvm::SmallVector<LanguageRuntimeCallbacks>
 PluginManager::GetLanguageRuntimeCallbacks() {
   auto instances = GetLanguageRuntimeInstances().GetSnapshot();
-  std::vector<LanguageRuntimeCallbacks> result;
+  llvm::SmallVector<LanguageRuntimeCallbacks> result;
   result.reserve(instances.size());
   for (auto &instance : instances)
     result.push_back({instance.create_callback, instance.command_callback,
@@ -942,7 +940,7 @@ bool PluginManager::UnregisterPlugin(
   return GetSystemRuntimeInstances().UnregisterPlugin(create_callback);
 }
 
-std::vector<SystemRuntimeCreateInstance>
+llvm::SmallVector<SystemRuntimeCreateInstance>
 PluginManager::GetSystemRuntimeCreateCallbacks() {
   return GetSystemRuntimeInstances().GetCreateCallbacks();
 }
@@ -997,9 +995,9 @@ bool PluginManager::UnregisterPlugin(ObjectFileCreateInstance create_callback) {
   return GetObjectFileInstances().UnregisterPlugin(create_callback);
 }
 
-std::vector<ObjectFileCallbacks> PluginManager::GetObjectFileCallbacks() {
+llvm::SmallVector<ObjectFileCallbacks> PluginManager::GetObjectFileCallbacks() {
   auto instances = GetObjectFileInstances().GetSnapshot();
-  std::vector<ObjectFileCallbacks> result;
+  llvm::SmallVector<ObjectFileCallbacks> result;
   result.reserve(instances.size());
   for (auto &instance : instances)
     result.push_back({instance.create_callback, instance.create_memory_callback,
@@ -1069,8 +1067,8 @@ Status PluginManager::SaveCore(lldb_private::SaveCoreOptions &options) {
       "no ObjectFile plugins were able to save a core for this process");
 }
 
-std::vector<llvm::StringRef> PluginManager::GetSaveCorePluginNames() {
-  std::vector<llvm::StringRef> plugin_names;
+llvm::SmallVector<llvm::StringRef> PluginManager::GetSaveCorePluginNames() {
+  llvm::SmallVector<llvm::StringRef> plugin_names;
   auto instances = GetObjectFileInstances().GetSnapshot();
   for (auto &instance : instances) {
     if (instance.save_core)
@@ -1118,10 +1116,10 @@ bool PluginManager::UnregisterPlugin(
   return GetObjectContainerInstances().UnregisterPlugin(create_callback);
 }
 
-std::vector<ObjectContainerCallbacks>
+llvm::SmallVector<ObjectContainerCallbacks>
 PluginManager::GetObjectContainerCallbacks() {
   auto instances = GetObjectContainerInstances().GetSnapshot();
-  std::vector<ObjectContainerCallbacks> result;
+  llvm::SmallVector<ObjectContainerCallbacks> result;
   result.reserve(instances.size());
   for (auto &instance : instances)
     result.push_back({instance.create_callback, instance.create_memory_callback,
@@ -1165,7 +1163,7 @@ PluginManager::GetPlatformCreateCallbackForPluginName(llvm::StringRef name) {
   return GetPlatformInstances().GetCallbackForName(name);
 }
 
-std::vector<PlatformCreateInstance>
+llvm::SmallVector<PlatformCreateInstance>
 PluginManager::GetPlatformCreateCallbacks() {
   return GetPlatformInstances().GetCreateCallbacks();
 }
@@ -1214,7 +1212,8 @@ PluginManager::GetProcessCreateCallbackForPluginName(llvm::StringRef name) {
   return GetProcessInstances().GetCallbackForName(name);
 }
 
-std::vector<ProcessCreateInstance> PluginManager::GetProcessCreateCallbacks() {
+llvm::SmallVector<ProcessCreateInstance>
+PluginManager::GetProcessCreateCallbacks() {
   return GetProcessInstances().GetCreateCallbacks();
 }
 
@@ -1334,7 +1333,7 @@ bool PluginManager::UnregisterPlugin(
   return GetScriptInterpreterInstances().UnregisterPlugin(create_callback);
 }
 
-std::vector<ScriptInterpreterCreateInstance>
+llvm::SmallVector<ScriptInterpreterCreateInstance>
 PluginManager::GetScriptInterpreterCreateCallbacks() {
   return GetScriptInterpreterInstances().GetCreateCallbacks();
 }
@@ -1417,7 +1416,7 @@ PluginManager::GetSyntheticFrameProviderCreateCallbackForPluginName(
   return GetSyntheticFrameProviderInstances().GetCallbackForName(name);
 }
 
-std::vector<ScriptedFrameProviderCreateInstance>
+llvm::SmallVector<ScriptedFrameProviderCreateInstance>
 PluginManager::GetScriptedFrameProviderCreateCallbacks() {
   return GetScriptedFrameProviderInstances().GetCreateCallbacks();
 }
@@ -1461,10 +1460,10 @@ bool PluginManager::UnregisterPlugin(
   return GetStructuredDataPluginInstances().UnregisterPlugin(create_callback);
 }
 
-std::vector<StructuredDataPluginCallbacks>
+llvm::SmallVector<StructuredDataPluginCallbacks>
 PluginManager::GetStructuredDataPluginCallbacks() {
   auto instances = GetStructuredDataPluginInstances().GetSnapshot();
-  std::vector<StructuredDataPluginCallbacks> result;
+  llvm::SmallVector<StructuredDataPluginCallbacks> result;
   result.reserve(instances.size());
   for (auto &instance : instances)
     result.push_back({instance.create_callback, instance.filter_callback});
@@ -1493,7 +1492,7 @@ bool PluginManager::UnregisterPlugin(SymbolFileCreateInstance create_callback) {
   return GetSymbolFileInstances().UnregisterPlugin(create_callback);
 }
 
-std::vector<SymbolFileCreateInstance>
+llvm::SmallVector<SymbolFileCreateInstance>
 PluginManager::GetSymbolFileCreateCallbacks() {
   return GetSymbolFileInstances().GetCreateCallbacks();
 }
@@ -1520,7 +1519,7 @@ bool PluginManager::UnregisterPlugin(
   return GetSymbolVendorInstances().UnregisterPlugin(create_callback);
 }
 
-std::vector<SymbolVendorCreateInstance>
+llvm::SmallVector<SymbolVendorCreateInstance>
 PluginManager::GetSymbolVendorCreateCallbacks() {
   return GetSymbolVendorInstances().GetCreateCallbacks();
 }
@@ -1575,7 +1574,7 @@ bool PluginManager::UnregisterPlugin(
   return GetSymbolLocatorInstances().UnregisterPlugin(create_callback);
 }
 
-std::vector<SymbolLocatorCreateInstance>
+llvm::SmallVector<SymbolLocatorCreateInstance>
 PluginManager::GetSymbolLocatorCreateCallbacks() {
   return GetSymbolLocatorInstances().GetCreateCallbacks();
 }
@@ -1759,9 +1758,10 @@ bool PluginManager::UnregisterPlugin(
   return GetTraceExporterInstances().UnregisterPlugin(create_callback);
 }
 
-std::vector<TraceExporterCallbacks> PluginManager::GetTraceExporterCallbacks() {
+llvm::SmallVector<TraceExporterCallbacks>
+PluginManager::GetTraceExporterCallbacks() {
   auto instances = GetTraceExporterInstances().GetSnapshot();
-  std::vector<TraceExporterCallbacks> result;
+  llvm::SmallVector<TraceExporterCallbacks> result;
   result.reserve(instances.size());
   for (auto &instance : instances)
     result.push_back({instance.name, instance.create_callback,
@@ -1791,7 +1791,7 @@ bool PluginManager::UnregisterPlugin(
   return GetUnwindAssemblyInstances().UnregisterPlugin(create_callback);
 }
 
-std::vector<UnwindAssemblyCreateInstance>
+llvm::SmallVector<UnwindAssemblyCreateInstance>
 PluginManager::GetUnwindAssemblyCreateCallbacks() {
   return GetUnwindAssemblyInstances().GetCreateCallbacks();
 }
@@ -1818,7 +1818,7 @@ bool PluginManager::UnregisterPlugin(
   return GetMemoryHistoryInstances().UnregisterPlugin(create_callback);
 }
 
-std::vector<MemoryHistoryCreateInstance>
+llvm::SmallVector<MemoryHistoryCreateInstance>
 PluginManager::GetMemoryHistoryCreateCallbacks() {
   return GetMemoryHistoryInstances().GetCreateCallbacks();
 }
@@ -1859,10 +1859,10 @@ bool PluginManager::UnregisterPlugin(
   return GetInstrumentationRuntimeInstances().UnregisterPlugin(create_callback);
 }
 
-std::vector<InstrumentationRuntimeCallbacks>
+llvm::SmallVector<InstrumentationRuntimeCallbacks>
 PluginManager::GetInstrumentationRuntimeCallbacks() {
   auto instances = GetInstrumentationRuntimeInstances().GetSnapshot();
-  std::vector<InstrumentationRuntimeCallbacks> result;
+  llvm::SmallVector<InstrumentationRuntimeCallbacks> result;
   result.reserve(instances.size());
   for (auto &instance : instances)
     result.push_back({instance.create_callback, instance.get_type_callback});
@@ -1907,7 +1907,7 @@ bool PluginManager::UnregisterPlugin(TypeSystemCreateInstance create_callback) {
   return GetTypeSystemInstances().UnregisterPlugin(create_callback);
 }
 
-std::vector<TypeSystemCreateInstance>
+llvm::SmallVector<TypeSystemCreateInstance>
 PluginManager::GetTypeSystemCreateCallbacks() {
   return GetTypeSystemInstances().GetCreateCallbacks();
 }
@@ -2021,9 +2021,9 @@ bool PluginManager::UnregisterPlugin(REPLCreateInstance create_callback) {
   return GetREPLInstances().UnregisterPlugin(create_callback);
 }
 
-std::vector<REPLCallbacks> PluginManager::GetREPLCallbacks() {
+llvm::SmallVector<REPLCallbacks> PluginManager::GetREPLCallbacks() {
   auto instances = GetREPLInstances().GetSnapshot();
-  std::vector<REPLCallbacks> result;
+  llvm::SmallVector<REPLCallbacks> result;
   result.reserve(instances.size());
   for (auto &instance : instances)
     result.push_back({instance.create_callback, instance.supported_languages});
@@ -2066,7 +2066,7 @@ bool PluginManager::UnregisterPlugin(
   return GetHighlighterInstances().UnregisterPlugin(create_callback);
 }
 
-std::vector<HighlighterCreateInstance>
+llvm::SmallVector<HighlighterCreateInstance>
 PluginManager::GetHighlighterCreateCallbacks() {
   return GetHighlighterInstances().GetCreateCallbacks();
 }
@@ -2394,14 +2394,15 @@ bool PluginManager::CreateSettingForCPlusPlusLanguagePlugin(
 //
 // Plugin Info+Enable Implementations
 //
-std::vector<RegisteredPluginInfo> PluginManager::GetABIPluginInfo() {
+llvm::SmallVector<RegisteredPluginInfo> PluginManager::GetABIPluginInfo() {
   return GetABIInstances().GetPluginInfoForAllInstances();
 }
 bool PluginManager::SetABIPluginEnabled(llvm::StringRef name, bool enable) {
   return GetABIInstances().SetInstanceEnabled(name, enable);
 }
 
-std::vector<RegisteredPluginInfo> PluginManager::GetArchitecturePluginInfo() {
+llvm::SmallVector<RegisteredPluginInfo>
+PluginManager::GetArchitecturePluginInfo() {
   return GetArchitectureInstances().GetPluginInfoForAllInstances();
 }
 bool PluginManager::SetArchitecturePluginEnabled(llvm::StringRef name,
@@ -2409,7 +2410,8 @@ bool PluginManager::SetArchitecturePluginEnabled(llvm::StringRef name,
   return GetArchitectureInstances().SetInstanceEnabled(name, enable);
 }
 
-std::vector<RegisteredPluginInfo> PluginManager::GetDisassemblerPluginInfo() {
+llvm::SmallVector<RegisteredPluginInfo>
+PluginManager::GetDisassemblerPluginInfo() {
   return GetDisassemblerInstances().GetPluginInfoForAllInstances();
 }
 bool PluginManager::SetDisassemblerPluginEnabled(llvm::StringRef name,
@@ -2417,7 +2419,8 @@ bool PluginManager::SetDisassemblerPluginEnabled(llvm::StringRef name,
   return GetDisassemblerInstances().SetInstanceEnabled(name, enable);
 }
 
-std::vector<RegisteredPluginInfo> PluginManager::GetDynamicLoaderPluginInfo() {
+llvm::SmallVector<RegisteredPluginInfo>
+PluginManager::GetDynamicLoaderPluginInfo() {
   return GetDynamicLoaderInstances().GetPluginInfoForAllInstances();
 }
 bool PluginManager::SetDynamicLoaderPluginEnabled(llvm::StringRef name,
@@ -2425,7 +2428,7 @@ bool PluginManager::SetDynamicLoaderPluginEnabled(llvm::StringRef name,
   return GetDynamicLoaderInstances().SetInstanceEnabled(name, enable);
 }
 
-std::vector<RegisteredPluginInfo>
+llvm::SmallVector<RegisteredPluginInfo>
 PluginManager::GetEmulateInstructionPluginInfo() {
   return GetEmulateInstructionInstances().GetPluginInfoForAllInstances();
 }
@@ -2434,7 +2437,7 @@ bool PluginManager::SetEmulateInstructionPluginEnabled(llvm::StringRef name,
   return GetEmulateInstructionInstances().SetInstanceEnabled(name, enable);
 }
 
-std::vector<RegisteredPluginInfo>
+llvm::SmallVector<RegisteredPluginInfo>
 PluginManager::GetInstrumentationRuntimePluginInfo() {
   return GetInstrumentationRuntimeInstances().GetPluginInfoForAllInstances();
 }
@@ -2443,7 +2446,8 @@ bool PluginManager::SetInstrumentationRuntimePluginEnabled(llvm::StringRef name,
   return GetInstrumentationRuntimeInstances().SetInstanceEnabled(name, enable);
 }
 
-std::vector<RegisteredPluginInfo> PluginManager::GetJITLoaderPluginInfo() {
+llvm::SmallVector<RegisteredPluginInfo>
+PluginManager::GetJITLoaderPluginInfo() {
   return GetJITLoaderInstances().GetPluginInfoForAllInstances();
 }
 bool PluginManager::SetJITLoaderPluginEnabled(llvm::StringRef name,
@@ -2451,7 +2455,7 @@ bool PluginManager::SetJITLoaderPluginEnabled(llvm::StringRef name,
   return GetJITLoaderInstances().SetInstanceEnabled(name, enable);
 }
 
-std::vector<RegisteredPluginInfo> PluginManager::GetLanguagePluginInfo() {
+llvm::SmallVector<RegisteredPluginInfo> PluginManager::GetLanguagePluginInfo() {
   return GetLanguageInstances().GetPluginInfoForAllInstances();
 }
 bool PluginManager::SetLanguagePluginEnabled(llvm::StringRef name,
@@ -2459,7 +2463,7 @@ bool PluginManager::SetLanguagePluginEnabled(llvm::StringRef name,
   return GetLanguageInstances().SetInstanceEnabled(name, enable);
 }
 
-std::vector<RegisteredPluginInfo>
+llvm::SmallVector<RegisteredPluginInfo>
 PluginManager::GetLanguageRuntimePluginInfo() {
   return GetLanguageRuntimeInstances().GetPluginInfoForAllInstances();
 }
@@ -2468,7 +2472,8 @@ bool PluginManager::SetLanguageRuntimePluginEnabled(llvm::StringRef name,
   return GetLanguageRuntimeInstances().SetInstanceEnabled(name, enable);
 }
 
-std::vector<RegisteredPluginInfo> PluginManager::GetMemoryHistoryPluginInfo() {
+llvm::SmallVector<RegisteredPluginInfo>
+PluginManager::GetMemoryHistoryPluginInfo() {
   return GetMemoryHistoryInstances().GetPluginInfoForAllInstances();
 }
 bool PluginManager::SetMemoryHistoryPluginEnabled(llvm::StringRef name,
@@ -2476,7 +2481,7 @@ bool PluginManager::SetMemoryHistoryPluginEnabled(llvm::StringRef name,
   return GetMemoryHistoryInstances().SetInstanceEnabled(name, enable);
 }
 
-std::vector<RegisteredPluginInfo>
+llvm::SmallVector<RegisteredPluginInfo>
 PluginManager::GetObjectContainerPluginInfo() {
   return GetObjectContainerInstances().GetPluginInfoForAllInstances();
 }
@@ -2485,7 +2490,8 @@ bool PluginManager::SetObjectContainerPluginEnabled(llvm::StringRef name,
   return GetObjectContainerInstances().SetInstanceEnabled(name, enable);
 }
 
-std::vector<RegisteredPluginInfo> PluginManager::GetObjectFilePluginInfo() {
+llvm::SmallVector<RegisteredPluginInfo>
+PluginManager::GetObjectFilePluginInfo() {
   return GetObjectFileInstances().GetPluginInfoForAllInstances();
 }
 bool PluginManager::SetObjectFilePluginEnabled(llvm::StringRef name,
@@ -2493,7 +2499,7 @@ bool PluginManager::SetObjectFilePluginEnabled(llvm::StringRef name,
   return GetObjectFileInstances().SetInstanceEnabled(name, enable);
 }
 
-std::vector<RegisteredPluginInfo>
+llvm::SmallVector<RegisteredPluginInfo>
 PluginManager::GetOperatingSystemPluginInfo() {
   return GetOperatingSystemInstances().GetPluginInfoForAllInstances();
 }
@@ -2502,7 +2508,7 @@ bool PluginManager::SetOperatingSystemPluginEnabled(llvm::StringRef name,
   return GetOperatingSystemInstances().SetInstanceEnabled(name, enable);
 }
 
-std::vector<RegisteredPluginInfo> PluginManager::GetPlatformPluginInfo() {
+llvm::SmallVector<RegisteredPluginInfo> PluginManager::GetPlatformPluginInfo() {
   return GetPlatformInstances().GetPluginInfoForAllInstances();
 }
 bool PluginManager::SetPlatformPluginEnabled(llvm::StringRef name,
@@ -2510,21 +2516,21 @@ bool PluginManager::SetPlatformPluginEnabled(llvm::StringRef name,
   return GetPlatformInstances().SetInstanceEnabled(name, enable);
 }
 
-std::vector<RegisteredPluginInfo> PluginManager::GetProcessPluginInfo() {
+llvm::SmallVector<RegisteredPluginInfo> PluginManager::GetProcessPluginInfo() {
   return GetProcessInstances().GetPluginInfoForAllInstances();
 }
 bool PluginManager::SetProcessPluginEnabled(llvm::StringRef name, bool enable) {
   return GetProcessInstances().SetInstanceEnabled(name, enable);
 }
 
-std::vector<RegisteredPluginInfo> PluginManager::GetREPLPluginInfo() {
+llvm::SmallVector<RegisteredPluginInfo> PluginManager::GetREPLPluginInfo() {
   return GetREPLInstances().GetPluginInfoForAllInstances();
 }
 bool PluginManager::SetREPLPluginEnabled(llvm::StringRef name, bool enable) {
   return GetREPLInstances().SetInstanceEnabled(name, enable);
 }
 
-std::vector<RegisteredPluginInfo>
+llvm::SmallVector<RegisteredPluginInfo>
 PluginManager::GetRegisterTypeBuilderPluginInfo() {
   return GetRegisterTypeBuilderInstances().GetPluginInfoForAllInstances();
 }
@@ -2533,7 +2539,7 @@ bool PluginManager::SetRegisterTypeBuilderPluginEnabled(llvm::StringRef name,
   return GetRegisterTypeBuilderInstances().SetInstanceEnabled(name, enable);
 }
 
-std::vector<RegisteredPluginInfo>
+llvm::SmallVector<RegisteredPluginInfo>
 PluginManager::GetScriptInterpreterPluginInfo() {
   return GetScriptInterpreterInstances().GetPluginInfoForAllInstances();
 }
@@ -2542,7 +2548,7 @@ bool PluginManager::SetScriptInterpreterPluginEnabled(llvm::StringRef name,
   return GetScriptInterpreterInstances().SetInstanceEnabled(name, enable);
 }
 
-std::vector<RegisteredPluginInfo>
+llvm::SmallVector<RegisteredPluginInfo>
 PluginManager::GetScriptedInterfacePluginInfo() {
   return GetScriptedInterfaceInstances().GetPluginInfoForAllInstances();
 }
@@ -2551,7 +2557,8 @@ bool PluginManager::SetScriptedInterfacePluginEnabled(llvm::StringRef name,
   return GetScriptedInterfaceInstances().SetInstanceEnabled(name, enable);
 }
 
-std::vector<RegisteredPluginInfo> PluginManager::GetStructuredDataPluginInfo() {
+llvm::SmallVector<RegisteredPluginInfo>
+PluginManager::GetStructuredDataPluginInfo() {
   return GetStructuredDataPluginInstances().GetPluginInfoForAllInstances();
 }
 bool PluginManager::SetStructuredDataPluginEnabled(llvm::StringRef name,
@@ -2559,7 +2566,8 @@ bool PluginManager::SetStructuredDataPluginEnabled(llvm::StringRef name,
   return GetStructuredDataPluginInstances().SetInstanceEnabled(name, enable);
 }
 
-std::vector<RegisteredPluginInfo> PluginManager::GetSymbolFilePluginInfo() {
+llvm::SmallVector<RegisteredPluginInfo>
+PluginManager::GetSymbolFilePluginInfo() {
   return GetSymbolFileInstances().GetPluginInfoForAllInstances();
 }
 bool PluginManager::SetSymbolFilePluginEnabled(llvm::StringRef name,
@@ -2567,7 +2575,8 @@ bool PluginManager::SetSymbolFilePluginEnabled(llvm::StringRef name,
   return GetSymbolFileInstances().SetInstanceEnabled(name, enable);
 }
 
-std::vector<RegisteredPluginInfo> PluginManager::GetSymbolLocatorPluginInfo() {
+llvm::SmallVector<RegisteredPluginInfo>
+PluginManager::GetSymbolLocatorPluginInfo() {
   return GetSymbolLocatorInstances().GetPluginInfoForAllInstances();
 }
 bool PluginManager::SetSymbolLocatorPluginEnabled(llvm::StringRef name,
@@ -2575,7 +2584,8 @@ bool PluginManager::SetSymbolLocatorPluginEnabled(llvm::StringRef name,
   return GetSymbolLocatorInstances().SetInstanceEnabled(name, enable);
 }
 
-std::vector<RegisteredPluginInfo> PluginManager::GetSymbolVendorPluginInfo() {
+llvm::SmallVector<RegisteredPluginInfo>
+PluginManager::GetSymbolVendorPluginInfo() {
   return GetSymbolVendorInstances().GetPluginInfoForAllInstances();
 }
 bool PluginManager::SetSymbolVendorPluginEnabled(llvm::StringRef name,
@@ -2583,7 +2593,8 @@ bool PluginManager::SetSymbolVendorPluginEnabled(llvm::StringRef name,
   return GetSymbolVendorInstances().SetInstanceEnabled(name, enable);
 }
 
-std::vector<RegisteredPluginInfo> PluginManager::GetSystemRuntimePluginInfo() {
+llvm::SmallVector<RegisteredPluginInfo>
+PluginManager::GetSystemRuntimePluginInfo() {
   return GetSystemRuntimeInstances().GetPluginInfoForAllInstances();
 }
 bool PluginManager::SetSystemRuntimePluginEnabled(llvm::StringRef name,
@@ -2591,14 +2602,15 @@ bool PluginManager::SetSystemRuntimePluginEnabled(llvm::StringRef name,
   return GetSystemRuntimeInstances().SetInstanceEnabled(name, enable);
 }
 
-std::vector<RegisteredPluginInfo> PluginManager::GetTracePluginInfo() {
+llvm::SmallVector<RegisteredPluginInfo> PluginManager::GetTracePluginInfo() {
   return GetTracePluginInstances().GetPluginInfoForAllInstances();
 }
 bool PluginManager::SetTracePluginEnabled(llvm::StringRef name, bool enable) {
   return GetTracePluginInstances().SetInstanceEnabled(name, enable);
 }
 
-std::vector<RegisteredPluginInfo> PluginManager::GetTraceExporterPluginInfo() {
+llvm::SmallVector<RegisteredPluginInfo>
+PluginManager::GetTraceExporterPluginInfo() {
   return GetTraceExporterInstances().GetPluginInfoForAllInstances();
 }
 bool PluginManager::SetTraceExporterPluginEnabled(llvm::StringRef name,
@@ -2606,7 +2618,8 @@ bool PluginManager::SetTraceExporterPluginEnabled(llvm::StringRef name,
   return GetTraceExporterInstances().SetInstanceEnabled(name, enable);
 }
 
-std::vector<RegisteredPluginInfo> PluginManager::GetTypeSystemPluginInfo() {
+llvm::SmallVector<RegisteredPluginInfo>
+PluginManager::GetTypeSystemPluginInfo() {
   return GetTypeSystemInstances().GetPluginInfoForAllInstances();
 }
 bool PluginManager::SetTypeSystemPluginEnabled(llvm::StringRef name,
@@ -2614,7 +2627,8 @@ bool PluginManager::SetTypeSystemPluginEnabled(llvm::StringRef name,
   return GetTypeSystemInstances().SetInstanceEnabled(name, enable);
 }
 
-std::vector<RegisteredPluginInfo> PluginManager::GetUnwindAssemblyPluginInfo() {
+llvm::SmallVector<RegisteredPluginInfo>
+PluginManager::GetUnwindAssemblyPluginInfo() {
   return GetUnwindAssemblyInstances().GetPluginInfoForAllInstances();
 }
 bool PluginManager::SetUnwindAssemblyPluginEnabled(llvm::StringRef name,

--- a/lldb/source/Symbol/SaveCoreOptions.cpp
+++ b/lldb/source/Symbol/SaveCoreOptions.cpp
@@ -21,7 +21,7 @@ Status SaveCoreOptions::SetPluginName(const char *name) {
     return error;
   }
 
-  std::vector<llvm::StringRef> plugin_names =
+  llvm::SmallVector<llvm::StringRef> plugin_names =
       PluginManager::GetSaveCorePluginNames();
   if (!llvm::is_contained(plugin_names, name)) {
     StreamString stream;

--- a/lldb/unittests/Core/PluginManagerTest.cpp
+++ b/lldb/unittests/Core/PluginManagerTest.cpp
@@ -52,7 +52,7 @@ public:
   }
 
 protected:
-  std::vector<SystemRuntimeCreateInstance> m_system_runtime_plugins;
+  llvm::SmallVector<SystemRuntimeCreateInstance> m_system_runtime_plugins;
 
   static void RemoveAllRegisteredSystemRuntimePlugins() {
     // Enable all currently registered plugins so we can get a handle to
@@ -65,7 +65,7 @@ protected:
     }
 
     // Get a handle to the create call backs for all the registered plugins.
-    std::vector<SystemRuntimeCreateInstance> registered_plugin_callbacks =
+    llvm::SmallVector<SystemRuntimeCreateInstance> registered_plugin_callbacks =
         PluginManager::GetSystemRuntimeCreateCallbacks();
 
     // Remove all currently registered plugins.
@@ -103,7 +103,7 @@ TEST_F(PluginManagerTest, UnRegisterSystemRuntimePlugin) {
 TEST_F(PluginManagerTest, SystemRuntimePluginInfo) {
   RegisterMockSystemRuntimePlugins();
 
-  std::vector<RegisteredPluginInfo> plugin_info =
+  llvm::SmallVector<RegisteredPluginInfo> plugin_info =
       PluginManager::GetSystemRuntimePluginInfo();
   ASSERT_EQ(plugin_info.size(), 3u);
   ASSERT_EQ(plugin_info[0].name, "a");
@@ -122,7 +122,7 @@ TEST_F(PluginManagerTest, UnRegisterSystemRuntimePluginInfo) {
   RegisterMockSystemRuntimePlugins();
 
   // Initial plugin info has all three registered plugins.
-  std::vector<RegisteredPluginInfo> plugin_info =
+  llvm::SmallVector<RegisteredPluginInfo> plugin_info =
       PluginManager::GetSystemRuntimePluginInfo();
   ASSERT_EQ(plugin_info.size(), 3u);
 
@@ -145,7 +145,7 @@ TEST_F(PluginManagerTest, SystemRuntimePluginDisable) {
   ASSERT_TRUE(PluginManager::SetSystemRuntimePluginEnabled("b", false));
 
   // Disabling a plugin does not remove it from plugin info.
-  std::vector<RegisteredPluginInfo> plugin_info =
+  llvm::SmallVector<RegisteredPluginInfo> plugin_info =
       PluginManager::GetSystemRuntimePluginInfo();
   ASSERT_EQ(plugin_info.size(), 3u);
   ASSERT_EQ(plugin_info[0].name, "a");
@@ -193,7 +193,7 @@ TEST_F(PluginManagerTest, SystemRuntimePluginDisableThenEnable) {
   }
 
   // And show up in the plugin info correctly.
-  std::vector<RegisteredPluginInfo> plugin_info =
+  llvm::SmallVector<RegisteredPluginInfo> plugin_info =
       PluginManager::GetSystemRuntimePluginInfo();
   ASSERT_EQ(plugin_info.size(), 3u);
   ASSERT_EQ(plugin_info[0].name, "a");
@@ -255,7 +255,7 @@ TEST_F(PluginManagerTest, SystemRuntimePluginDisableAll) {
   ASSERT_EQ(PluginManager::GetSystemRuntimeCreateCallbacks().size(), 0u);
 
   // And show up in the plugin info correctly.
-  std::vector<RegisteredPluginInfo> plugin_info =
+  llvm::SmallVector<RegisteredPluginInfo> plugin_info =
       PluginManager::GetSystemRuntimePluginInfo();
   ASSERT_EQ(plugin_info.size(), 3u);
   ASSERT_EQ(plugin_info[0].name, "a");
@@ -297,7 +297,7 @@ TEST_F(PluginManagerTest, UnRegisterDisabledSystemRuntimePlugin) {
   RegisterMockSystemRuntimePlugins();
 
   // Initial plugin info has all three registered plugins.
-  std::vector<RegisteredPluginInfo> plugin_info =
+  llvm::SmallVector<RegisteredPluginInfo> plugin_info =
       PluginManager::GetSystemRuntimePluginInfo();
   ASSERT_EQ(plugin_info.size(), 3u);
 
@@ -319,7 +319,7 @@ TEST_F(PluginManagerTest, UnRegisterDisabledSystemRuntimePlugin) {
 TEST_F(PluginManagerTest, UnRegisterSystemRuntimePluginChangesOrder) {
   RegisterMockSystemRuntimePlugins();
 
-  std::vector<RegisteredPluginInfo> plugin_info =
+  llvm::SmallVector<RegisteredPluginInfo> plugin_info =
       PluginManager::GetSystemRuntimePluginInfo();
   {
     auto callbacks = PluginManager::GetSystemRuntimeCreateCallbacks();


### PR DESCRIPTION
Most of the plugins have only a small number of instances. Use `llvm::SmallVector` instead of `std::vector`.

Depends on https://github.com/llvm/llvm-project/pull/184837