### PR TITLE
[llvm][tools] Add support to load spirv images to llvm-gpu-loader

### DIFF
--- a/llvm/tools/llvm-gpu-loader/CMakeLists.txt
+++ b/llvm/tools/llvm-gpu-loader/CMakeLists.txt
@@ -4,6 +4,7 @@ set(LLVM_LINK_COMPONENTS
   BinaryFormat
   TargetParser
   Support
+  FrontendOffloading
 )
 
 add_llvm_tool(llvm-gpu-loader

--- a/llvm/tools/llvm-gpu-loader/llvm-gpu-loader.cpp
+++ b/llvm/tools/llvm-gpu-loader/llvm-gpu-loader.cpp
@@ -15,6 +15,7 @@
 #include "llvm-gpu-loader.h"
 
 #include "llvm/BinaryFormat/Magic.h"
+#include "llvm/Frontend/Offloading/Utility.h"
 #include "llvm/Object/ELF.h"
 #include "llvm/Object/ELFObjectFile.h"
 #include "llvm/Support/CommandLine.h"
@@ -215,9 +216,10 @@ int main(int argc, const char **argv, const char **envp) {
       MemoryBuffer::getFileOrSTDIN(File);
   if (std::error_code EC = ImageOrErr.getError())
     handleError(errorCodeToError(EC));
-  MemoryBufferRef Image = **ImageOrErr;
+  std::unique_ptr<MemoryBuffer> ImageBuffer = std::move(*ImageOrErr);
+  MemoryBufferRef Image = *ImageBuffer;
 
-  ol_platform_backend_t Backend;
+  ol_platform_backend_t Backend = OL_PLATFORM_BACKEND_UNKNOWN;
   ol_init_args_t InitArgs = OL_INIT_ARGS_INIT;
 
   file_magic Magic = identify_magic(Image.getBuffer());
@@ -240,8 +242,24 @@ int main(int argc, const char **argv, const char **envp) {
           ELF::convertEMachineToArchName(ElfOrErr->getHeader().e_machine)
               .data()));
     }
-    InitArgs.NumPlatforms = 1;
+  } else if (Magic == file_magic::spirv_object) {
+    // SPIR-V objects are assumed to be for Level Zero for now as that is the
+    // only platform that currently supports them.
+    Backend = OL_PLATFORM_BACKEND_LEVEL_ZERO;
+
+    // llvm-gpu-loader uses images objects which have not been processed
+    // by clang-linker-wrapper therefore we need to containerize the SPIR-V
+    // image before passing to liboffload so it looks like an ELF image.
+    if (auto Err = offloading::intel::containerizeOpenMPSPIRVImage(ImageBuffer))
+      handleError(std::move(Err));
+
+    // Update Image after containerization
+    Image = ImageBuffer->getMemBufferRef();
+  }
+
+  if (Backend != OL_PLATFORM_BACKEND_UNKNOWN) {
     InitArgs.Platforms = &Backend;
+    InitArgs.NumPlatforms = 1;
   }
 
   SmallVector<const char *> NewArgv = {File.c_str()};


### PR DESCRIPTION
The images used when testing libc have only been "compiled" but not "linked" so they're not inside the ELF wrapper that currently the library expects. This invokes the same containerization routine that would be invoked at link time to make the spirv images accepted by liboffload.