### PR TITLE
[ConstantFolding] Don't fold constrained fsub/fadd to zero with round.dynamic

### DIFF
--- a/llvm/lib/Analysis/ConstantFolding.cpp
+++ b/llvm/lib/Analysis/ConstantFolding.cpp
@@ -2316,15 +2316,22 @@ static bool getConstIntOrUndef(Value *Op, const APInt *&C) {
 ///
 /// \param CI Constrained intrinsic call.
 /// \param St Exception flags raised during constant evaluation.
-static bool mayFoldConstrained(ConstrainedFPIntrinsic *CI,
-                               APFloat::opStatus St) {
+/// \param Res Result of constant evaluation (if available).
+static bool mayFoldConstrained(const ConstrainedFPIntrinsic *CI,
+                               APFloat::opStatus St,
+                               std::optional<APFloat> Res = std::nullopt) {
   std::optional<RoundingMode> ORM = CI->getRoundingMode();
   std::optional<fp::ExceptionBehavior> EB = CI->getExceptionBehavior();
 
   // If the operation does not change exception status flags, it is safe
-  // to fold.
-  if (St == APFloat::opStatus::opOK)
+  // to fold. However, if the result is zero and the rounding mode is dynamic,
+  // the sign of zero depends on the rounding mode (IEEE 754, section 6.3),
+  // so we cannot fold.
+  if (St == APFloat::opStatus::opOK) {
+    if (Res && Res->isZero() && ORM == RoundingMode::Dynamic)
+      return false;
     return true;
+  }
 
   // If evaluation raised FP exception, the result can depend on rounding
   // mode. If the latter is unknown, folding is not possible.
@@ -3170,7 +3177,7 @@ static Constant *evaluateCompare(const APFloat &Op1, const APFloat &Op2,
       St = APFloat::opInvalidOp;
   }
   bool Result = FCmpInst::compare(Op1, Op2, Cond);
-  if (mayFoldConstrained(const_cast<ConstrainedFPCmpIntrinsic *>(FCmp), St))
+  if (mayFoldConstrained(FCmp, St))
     return ConstantInt::get(Call->getType()->getScalarType(), Result);
   return nullptr;
 }
@@ -3337,8 +3344,7 @@ static Constant *ConstantFoldIntrinsicCall2(Intrinsic::ID IntrinsicID, Type *Ty,
         case Intrinsic::experimental_constrained_fcmps:
           return evaluateCompare(Op1V, Op2V, ConstrIntr);
         }
-        if (mayFoldConstrained(const_cast<ConstrainedFPIntrinsic *>(ConstrIntr),
-                               St))
+        if (mayFoldConstrained(ConstrIntr, St, Res))
           return ConstantFP::get(Ty, Res);
         return nullptr;
       }
@@ -3917,8 +3923,7 @@ static Constant *ConstantFoldScalarCall3(StringRef Name,
             St = Res.fusedMultiplyAdd(C2, C3, RM);
             break;
           }
-          if (mayFoldConstrained(
-                  const_cast<ConstrainedFPIntrinsic *>(ConstrIntr), St))
+          if (mayFoldConstrained(ConstrIntr, St))
             return ConstantFP::get(Ty, Res);
           return nullptr;
         }

--- a/llvm/lib/Analysis/ConstantFolding.cpp
+++ b/llvm/lib/Analysis/ConstantFolding.cpp
@@ -2316,22 +2316,15 @@ static bool getConstIntOrUndef(Value *Op, const APInt *&C) {
 ///
 /// \param CI Constrained intrinsic call.
 /// \param St Exception flags raised during constant evaluation.
-/// \param Res Result of constant evaluation (if available).
 static bool mayFoldConstrained(const ConstrainedFPIntrinsic *CI,
-                               APFloat::opStatus St,
-                               std::optional<APFloat> Res = std::nullopt) {
+                               APFloat::opStatus St) {
   std::optional<RoundingMode> ORM = CI->getRoundingMode();
   std::optional<fp::ExceptionBehavior> EB = CI->getExceptionBehavior();
 
   // If the operation does not change exception status flags, it is safe
-  // to fold. However, if the result is zero and the rounding mode is dynamic,
-  // the sign of zero depends on the rounding mode (IEEE 754, section 6.3),
-  // so we cannot fold.
-  if (St == APFloat::opStatus::opOK) {
-    if (Res && Res->isZero() && ORM == RoundingMode::Dynamic)
-      return false;
+  // to fold.
+  if (St == APFloat::opStatus::opOK)
     return true;
-  }
 
   // If evaluation raised FP exception, the result can depend on rounding
   // mode. If the latter is unknown, folding is not possible.
@@ -2346,6 +2339,19 @@ static bool mayFoldConstrained(const ConstrainedFPIntrinsic *CI,
   // Leave the calculation for runtime so that exception flags be correctly set
   // in hardware.
   return false;
+}
+
+/// Like mayFoldConstrained, but also checks that the sign of a zero result is
+/// not rounding-mode-dependent (IEEE 754, section 6.3).
+static bool mayFoldConstrained(const ConstrainedFPIntrinsic *CI,
+                               APFloat::opStatus St, const APFloat &Res) {
+  if (St == APFloat::opStatus::opOK) {
+    std::optional<RoundingMode> ORM = CI->getRoundingMode();
+    if (Res.isZero() && ORM == RoundingMode::Dynamic)
+      return false;
+    return true;
+  }
+  return mayFoldConstrained(CI, St);
 }
 
 /// Returns the rounding mode that should be used for constant evaluation.
@@ -3923,7 +3929,7 @@ static Constant *ConstantFoldScalarCall3(StringRef Name,
             St = Res.fusedMultiplyAdd(C2, C3, RM);
             break;
           }
-          if (mayFoldConstrained(ConstrIntr, St))
+          if (mayFoldConstrained(ConstrIntr, St, Res))
             return ConstantFP::get(Ty, Res);
           return nullptr;
         }

--- a/llvm/test/Transforms/InstSimplify/constfold-constrained.ll
+++ b/llvm/test/Transforms/InstSimplify/constfold-constrained.ll
@@ -535,6 +535,43 @@ entry:
 }
 
 
+; The sign of 0.0 - 0.0 depends on the rounding mode (IEEE 754, section 6.3).
+; With round.dynamic, this must not be folded.
+define double @fsub_zero_zero_dynamic() #0 {
+; CHECK-LABEL: @fsub_zero_zero_dynamic(
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    [[RESULT:%.*]] = call double @llvm.experimental.constrained.fsub.f64(double 0.000000e+00, double 0.000000e+00, metadata !"round.dynamic", metadata !"fpexcept.strict") #[[ATTR0]]
+; CHECK-NEXT:    ret double [[RESULT]]
+;
+entry:
+  %result = call double @llvm.experimental.constrained.fsub.f64(double 0.0, double 0.0, metadata !"round.dynamic", metadata !"fpexcept.strict") #0
+  ret double %result
+}
+
+; With a known rounding mode, 0.0 - 0.0 can be folded.
+define double @fsub_zero_zero_tonearest() #0 {
+; CHECK-LABEL: @fsub_zero_zero_tonearest(
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    [[RESULT:%.*]] = call double @llvm.experimental.constrained.fsub.f64(double 0.000000e+00, double 0.000000e+00, metadata !"round.tonearest", metadata !"fpexcept.strict") #[[ATTR0]]
+; CHECK-NEXT:    ret double 0.000000e+00
+;
+entry:
+  %result = call double @llvm.experimental.constrained.fsub.f64(double 0.0, double 0.0, metadata !"round.tonearest", metadata !"fpexcept.strict") #0
+  ret double %result
+}
+
+; 1.0 + 1.0 = 2.0 exactly, no sign-of-zero issue, safe to fold even with round.dynamic.
+define double @fadd_one_one_dynamic() #0 {
+; CHECK-LABEL: @fadd_one_one_dynamic(
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    [[RESULT:%.*]] = call double @llvm.experimental.constrained.fadd.f64(double 1.000000e+00, double 1.000000e+00, metadata !"round.dynamic", metadata !"fpexcept.strict") #[[ATTR0]]
+; CHECK-NEXT:    ret double 2.000000e+00
+;
+entry:
+  %result = call double @llvm.experimental.constrained.fadd.f64(double 1.0, double 1.0, metadata !"round.dynamic", metadata !"fpexcept.strict") #0
+  ret double %result
+}
+
 attributes #0 = { strictfp }
 
 declare double @llvm.experimental.constrained.nearbyint.f64(double, metadata, metadata)

--- a/llvm/test/Transforms/InstSimplify/constfold-constrained.ll
+++ b/llvm/test/Transforms/InstSimplify/constfold-constrained.ll
@@ -540,11 +540,11 @@ entry:
 define double @fsub_zero_zero_dynamic() #0 {
 ; CHECK-LABEL: @fsub_zero_zero_dynamic(
 ; CHECK-NEXT:  entry:
-; CHECK-NEXT:    [[RESULT:%.*]] = call double @llvm.experimental.constrained.fsub.f64(double 0.000000e+00, double 0.000000e+00, metadata !"round.dynamic", metadata !"fpexcept.strict") #[[ATTR0]]
+; CHECK-NEXT:    [[RESULT:%.*]] = call double @llvm.experimental.constrained.fsub.f64(double 0.000000e+00, double 0.000000e+00, metadata !"round.dynamic", metadata !"fpexcept.strict")
 ; CHECK-NEXT:    ret double [[RESULT]]
 ;
 entry:
-  %result = call double @llvm.experimental.constrained.fsub.f64(double 0.0, double 0.0, metadata !"round.dynamic", metadata !"fpexcept.strict") #0
+  %result = call double @llvm.experimental.constrained.fsub.f64(double 0.0, double 0.0, metadata !"round.dynamic", metadata !"fpexcept.strict")
   ret double %result
 }
 
@@ -552,11 +552,11 @@ entry:
 define double @fsub_zero_zero_tonearest() #0 {
 ; CHECK-LABEL: @fsub_zero_zero_tonearest(
 ; CHECK-NEXT:  entry:
-; CHECK-NEXT:    [[RESULT:%.*]] = call double @llvm.experimental.constrained.fsub.f64(double 0.000000e+00, double 0.000000e+00, metadata !"round.tonearest", metadata !"fpexcept.strict") #[[ATTR0]]
+; CHECK-NEXT:    [[RESULT:%.*]] = call double @llvm.experimental.constrained.fsub.f64(double 0.000000e+00, double 0.000000e+00, metadata !"round.tonearest", metadata !"fpexcept.strict")
 ; CHECK-NEXT:    ret double 0.000000e+00
 ;
 entry:
-  %result = call double @llvm.experimental.constrained.fsub.f64(double 0.0, double 0.0, metadata !"round.tonearest", metadata !"fpexcept.strict") #0
+  %result = call double @llvm.experimental.constrained.fsub.f64(double 0.0, double 0.0, metadata !"round.tonearest", metadata !"fpexcept.strict")
   ret double %result
 }
 
@@ -564,11 +564,11 @@ entry:
 define double @fadd_one_one_dynamic() #0 {
 ; CHECK-LABEL: @fadd_one_one_dynamic(
 ; CHECK-NEXT:  entry:
-; CHECK-NEXT:    [[RESULT:%.*]] = call double @llvm.experimental.constrained.fadd.f64(double 1.000000e+00, double 1.000000e+00, metadata !"round.dynamic", metadata !"fpexcept.strict") #[[ATTR0]]
+; CHECK-NEXT:    [[RESULT:%.*]] = call double @llvm.experimental.constrained.fadd.f64(double 1.000000e+00, double 1.000000e+00, metadata !"round.dynamic", metadata !"fpexcept.strict")
 ; CHECK-NEXT:    ret double 2.000000e+00
 ;
 entry:
-  %result = call double @llvm.experimental.constrained.fadd.f64(double 1.0, double 1.0, metadata !"round.dynamic", metadata !"fpexcept.strict") #0
+  %result = call double @llvm.experimental.constrained.fadd.f64(double 1.0, double 1.0, metadata !"round.dynamic", metadata !"fpexcept.strict")
   ret double %result
 }
 


### PR DESCRIPTION
## Summary

The sign of an exact zero result from `fadd`/`fsub` depends on the rounding mode (IEEE 754, section 6.3). The constant folder was incorrectly folding constrained `fsub`/`fadd` operations when the rounding mode is `round.dynamic`, because `opOK` was interpreted as "result is rounding-mode-independent" — which is true for the magnitude but not for the sign of zero.

For example, `0.0 - 0.0` with `round.dynamic` was being folded to `+0.0`, but under `roundTowardNegative` the correct result is `-0.0`.

## Changes

- Added a `mayFoldConstrained` overload that takes a `const APFloat &Res` parameter and returns `false` when `St == opOK`, the result is zero, and the rounding mode is dynamic
- Float-result call sites (`ConstantFoldIntrinsicCall2`, `ConstantFoldScalarCall3`) now use the new overload, removing the unnecessary `const_cast`
- Added three new tests to `constfold-constrained.ll`: `fsub` with `round.dynamic` (must not fold), `fsub` with `round.tonearest` (can fold), and `fadd` with non-zero result and `round.dynamic` (can fold)

Fixes https://github.com/llvm/llvm-project/issues/177467