### PR TITLE
[AMDGPU][SIInsertWaitcnts][NFC] Simplify logic in GFX12Plus::applyPreexistingWaitcnts

### DIFF
--- a/llvm/lib/Target/AMDGPU/SIInsertWaitcnts.cpp
+++ b/llvm/lib/Target/AMDGPU/SIInsertWaitcnts.cpp
@@ -2013,8 +2013,6 @@ bool WaitcntGeneratorGFX12Plus::applyPreexistingWaitcnt(
       continue;
     }
 
-    MachineInstr **UpdatableInstr;
-
     // Update required wait count. If this is a soft waitcnt (= it was added
     // by an earlier pass), it may be entirely removed.
 
@@ -2034,7 +2032,13 @@ bool WaitcntGeneratorGFX12Plus::applyPreexistingWaitcnt(
         Wait = Wait.combined(OldWait);
       else
         RequiredWait = RequiredWait.combined(OldWait);
-      UpdatableInstr = &CombinedLoadDsCntInstr;
+      // Keep the first wait_loadcnt, erase the rest.
+      if (CombinedLoadDsCntInstr == nullptr) {
+        CombinedLoadDsCntInstr = &II;
+      } else {
+        II.eraseFromParent();
+        Modified = true;
+      }
     } else if (Opcode == AMDGPU::S_WAIT_STORECNT_DSCNT) {
       unsigned OldEnc =
           TII.getNamedOperand(II, AMDGPU::OpName::simm16)->getImm();
@@ -2043,7 +2047,13 @@ bool WaitcntGeneratorGFX12Plus::applyPreexistingWaitcnt(
         Wait = Wait.combined(OldWait);
       else
         RequiredWait = RequiredWait.combined(OldWait);
-      UpdatableInstr = &CombinedStoreDsCntInstr;
+      // Keep the first wait_storecnt, erase the rest.
+      if (CombinedStoreDsCntInstr == nullptr) {
+        CombinedStoreDsCntInstr = &II;
+      } else {
+        II.eraseFromParent();
+        Modified = true;
+      }
     } else if (Opcode == AMDGPU::S_WAITCNT_DEPCTR) {
       unsigned OldEnc =
           TII.getNamedOperand(II, AMDGPU::OpName::simm16)->getImm();
@@ -2053,12 +2063,33 @@ bool WaitcntGeneratorGFX12Plus::applyPreexistingWaitcnt(
       if (TrySimplify)
         ScoreBrackets.simplifyWaitcnt(OldWait);
       Wait = Wait.combined(OldWait);
-      UpdatableInstr = &WaitcntDepctrInstr;
+      if (WaitcntDepctrInstr == nullptr) {
+        WaitcntDepctrInstr = &II;
+      } else {
+        // S_WAITCNT_DEPCTR requires special care. Don't remove a
+        // duplicate if it is waiting on things other than VA_VDST or
+        // VM_VSRC. If that is the case, just make sure the VA_VDST and
+        // VM_VSRC subfields of the operand are set to the "no wait"
+        // values.
+
+        unsigned Enc =
+            TII.getNamedOperand(II, AMDGPU::OpName::simm16)->getImm();
+        Enc = AMDGPU::DepCtr::encodeFieldVmVsrc(Enc, ~0u);
+        Enc = AMDGPU::DepCtr::encodeFieldVaVdst(Enc, ~0u);
+
+        if (Enc != (unsigned)AMDGPU::DepCtr::getDefaultDepCtrEncoding(ST)) {
+          Modified |= updateOperandIfDifferent(II, AMDGPU::OpName::simm16, Enc);
+          Modified |= promoteSoftWaitCnt(&II);
+        } else {
+          II.eraseFromParent();
+          Modified = true;
+        }
+      }
     } else if (Opcode == AMDGPU::S_WAITCNT_lds_direct) {
       // Architectures higher than GFX10 do not have direct loads to
       // LDS, so no work required here yet.
       II.eraseFromParent();
-      continue;
+      Modified = true;
     } else if (Opcode == AMDGPU::WAIT_ASYNCMARK) {
       reportFatalUsageError("WAIT_ASYNCMARK is not ready for GFX12 yet");
     } else {
@@ -2070,33 +2101,13 @@ bool WaitcntGeneratorGFX12Plus::applyPreexistingWaitcnt(
         addWait(Wait, CT.value(), OldCnt);
       else
         addWait(RequiredWait, CT.value(), OldCnt);
-      UpdatableInstr = &WaitInstrs[CT.value()];
-    }
-
-    // Merge consecutive waitcnt of the same type by erasing multiples.
-    if (!*UpdatableInstr) {
-      *UpdatableInstr = &II;
-    } else if (Opcode == AMDGPU::S_WAITCNT_DEPCTR) {
-      // S_WAITCNT_DEPCTR requires special care. Don't remove a
-      // duplicate if it is waiting on things other than VA_VDST or
-      // VM_VSRC. If that is the case, just make sure the VA_VDST and
-      // VM_VSRC subfields of the operand are set to the "no wait"
-      // values.
-
-      unsigned Enc = TII.getNamedOperand(II, AMDGPU::OpName::simm16)->getImm();
-      Enc = AMDGPU::DepCtr::encodeFieldVmVsrc(Enc, ~0u);
-      Enc = AMDGPU::DepCtr::encodeFieldVaVdst(Enc, ~0u);
-
-      if (Enc != (unsigned)AMDGPU::DepCtr::getDefaultDepCtrEncoding(ST)) {
-        Modified |= updateOperandIfDifferent(II, AMDGPU::OpName::simm16, Enc);
-        Modified |= promoteSoftWaitCnt(&II);
+      // Keep the first wait of its kind, erase the rest.
+      if (WaitInstrs[CT.value()] == nullptr) {
+        WaitInstrs[CT.value()] = &II;
       } else {
         II.eraseFromParent();
         Modified = true;
       }
-    } else {
-      II.eraseFromParent();
-      Modified = true;
     }
   }
 


### PR DESCRIPTION
The loop is collecting the first instruction of each waitcnt kind and is erasing the rest, with the exception of DEPCTR which needs more checks. The existing code was factoring out the instruction deletion and the setting of the collected instruction variables. But the special handling for DEPCTR and the in-loop deletion of `S_WAITCNT_lds_direct` was just complicating the logic.