### PR TITLE
[LLDB] Allow one-line summaries in the presence of synthetic child providers

### DIFF
--- a/lldb/source/DataFormatters/FormatManager.cpp
+++ b/lldb/source/DataFormatters/FormatManager.cpp
@@ -526,7 +526,7 @@ bool FormatManager::ShouldPrintAsOneLiner(ValueObject &valobj) {
       if (!synth_sp->MightHaveChildren() &&
           synth_sp->DoesProvideSyntheticValue())
         is_synth_val = true;
-      else
+      else if (synth_sp->MightHaveChildren())
         return false;
     }
 

--- a/lldb/test/API/functionalities/data-formatter/synth_oneline_summaries/Makefile
+++ b/lldb/test/API/functionalities/data-formatter/synth_oneline_summaries/Makefile
@@ -1,0 +1,3 @@
+C_SOURCES := main.c
+
+include Makefile.rules

--- a/lldb/test/API/functionalities/data-formatter/synth_oneline_summaries/MyStringFormatter.py
+++ b/lldb/test/API/functionalities/data-formatter/synth_oneline_summaries/MyStringFormatter.py
@@ -1,0 +1,12 @@
+import lldb
+
+
+class MyStringSynthProvider:
+    def __init__(self, valobj, dict):
+        self.valobj = valobj
+
+    def num_children(self, max_num_children):
+        return 0
+
+    def has_children(self):
+        return False

--- a/lldb/test/API/functionalities/data-formatter/synth_oneline_summaries/TestSyntheticOneLineSummaries.py
+++ b/lldb/test/API/functionalities/data-formatter/synth_oneline_summaries/TestSyntheticOneLineSummaries.py
@@ -1,0 +1,21 @@
+import lldb
+from lldbsuite.test.decorators import *
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test import lldbutil
+
+
+class SyntheticOneLineSummariesTestCase(TestBase):
+    def test(self):
+        """Test that the presence of a synthetic child provider doesn't prevent one-line-summaries."""
+        self.build()
+        lldbutil.run_to_source_breakpoint(self, "break here", lldb.SBFileSpec("main.c"))
+
+        # set up the synthetic children provider
+        self.runCmd("script from MyStringFormatter import *")
+        self.runCmd("type synth add -l MyStringSynthProvider MyString")
+        self.runCmd('type summary add --summary-string "${var.guts}" MyString')
+
+        self.expect(
+            "frame variable s",
+            substrs=['a = "hello", b = "world"'],
+        )

--- a/lldb/test/API/functionalities/data-formatter/synth_oneline_summaries/main.c
+++ b/lldb/test/API/functionalities/data-formatter/synth_oneline_summaries/main.c
@@ -1,0 +1,16 @@
+struct MyString {
+  const char *guts;
+};
+
+struct S {
+  struct MyString a;
+  struct MyString b;
+};
+void stop() {}
+int main() {
+  struct S s;
+  s.a.guts = "hello";
+  s.b.guts = "world";
+  stop(); // break here
+  return 0;
+}


### PR DESCRIPTION
This is driven by the Swift language. In Swift many data types such as Int, and String are structs, and LLDB provides summary formatters and synthetic child providers for them. For String, for example, a summary formatter pulls out the string data from the implementation, while a synthetic child provider hides the implementation details from users, so strings don't expand their children.

rdar://171646109