### PR TITLE
[NFC] Add template disambiguation for dependent call to getAttr.

### DIFF
--- a/clang/lib/Sema/TreeTransform.h
+++ b/clang/lib/Sema/TreeTransform.h
@@ -13080,7 +13080,7 @@ template <typename Derived>
 StmtResult TreeTransform<Derived>::TransformUnresolvedSYCLKernelCallStmt(
     UnresolvedSYCLKernelCallStmt *S) {
   auto *FD = cast<FunctionDecl>(SemaRef.CurContext);
-  const auto *SKEPAttr = FD->getAttr<SYCLKernelEntryPointAttr>();
+  const auto *SKEPAttr = FD->template getAttr<SYCLKernelEntryPointAttr>();
   if (!SKEPAttr || SKEPAttr->isInvalidAttr())
     return StmtError();
 


### PR DESCRIPTION
This fixes buildbot failures for darwin targets triggered by #152403. 
- https://lab.llvm.org/buildbot/#/builders/190/builds/37864
- https://lab.llvm.org/buildbot/#/builders/23/builds/18339