### PR TITLE
[ELF] handleTlsGd: support disabling GD-to-IE/LE optimization. NFC

### DIFF
--- a/lld/ELF/Arch/ARM.cpp
+++ b/lld/ELF/Arch/ARM.cpp
@@ -292,8 +292,7 @@ void ARM::scanSectionImpl(InputSectionBase &sec, Relocs<RelTy> rels) {
       rs.handleTlsIe<false>(R_GOT_PC, type, offset, addend, sym);
       continue;
     case R_ARM_TLS_GD32:
-      sym.setFlags(NEEDS_TLSGD);
-      sec.addReloc({R_TLSGD_PC, type, offset, addend, &sym});
+      rs.handleTlsGd(R_TLSGD_PC, R_NONE, R_NONE, type, offset, addend, sym);
       continue;
     case R_ARM_TLS_LDM32:
       ctx.needsTlsLd.store(true, std::memory_order_relaxed);

--- a/lld/ELF/RelocScan.h
+++ b/lld/ELF/RelocScan.h
@@ -137,23 +137,24 @@ public:
   }
 
   // Handle TLS General-Dynamic relocation. Returns true if the __tls_get_addr
-  // call should be skipped (i.e., caller should ++it).
+  // call should be skipped (i.e., caller should ++it). Pass R_NONE for
+  // ieExpr/leExpr to disable GD-to-IE/LE optimization (e.g. ARM, RISC-V).
   bool handleTlsGd(RelExpr sharedExpr, RelExpr ieExpr, RelExpr leExpr,
                    RelType type, uint64_t offset, int64_t addend, Symbol &sym) {
-    if (ctx.arg.shared) {
-      sym.setFlags(NEEDS_TLSGD);
-      sec->addReloc({sharedExpr, type, offset, addend, &sym});
-      return false;
+    if (!ctx.arg.shared && ieExpr != R_NONE) {
+      if (sym.isPreemptible) {
+        // Optimize to Initial Exec.
+        sym.setFlags(NEEDS_TLSIE);
+        sec->addReloc({ieExpr, type, offset, addend, &sym});
+      } else {
+        // Optimize to Local Exec.
+        sec->addReloc({leExpr, type, offset, addend, &sym});
+      }
+      return true;
     }
-    if (sym.isPreemptible) {
-      // Optimize to Initial Exec.
-      sym.setFlags(NEEDS_TLSIE);
-      sec->addReloc({ieExpr, type, offset, addend, &sym});
-    } else {
-      // Optimize to Local Exec.
-      sec->addReloc({leExpr, type, offset, addend, &sym});
-    }
-    return true;
+    sym.setFlags(NEEDS_TLSGD);
+    sec->addReloc({sharedExpr, type, offset, addend, &sym});
+    return false;
   }
 
   // Handle TLSDESC relocation.


### PR DESCRIPTION
Use this in ARM::scanSectionImpl for R_ARM_TLS_GD32 and the upcoming
RISC-V change.