### PR TITLE
[RISCV] Remove outdated TODO in isExtractSubvectorCheap

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
@@ -2702,7 +2702,6 @@ bool RISCVTargetLowering::isExtractSubvectorCheap(EVT ResVT, EVT SrcVT,
   assert(EltVT == SrcVT.getVectorElementType() && "Should hold for node");
 
   // The smallest type we can slide is i8.
-  // TODO: We can extract index 0 from a mask vector without a slide.
   if (EltVT == MVT::i1)
     return false;
 


### PR DESCRIPTION
Index 0 is already handled by an early return, so the TODO comment about extracting index 0 from a mask vector is no longer needed.