### PR TITLE
[WebAssembly] Fold vselect(cond, vnot(x), zero) to v128.andnot

### DIFF
--- a/llvm/lib/Target/WebAssembly/WebAssemblyInstrSIMD.td
+++ b/llvm/lib/Target/WebAssembly/WebAssemblyInstrSIMD.td
@@ -911,6 +911,15 @@ def : Pat<(vec.vt (xor (and (xor (vec.vt V128:$v1), (vec.vt V128:$v2)),
                        (vec.vt V128:$v2))),
           (BITSELECT $v2, $v1, $c)>;
 
+// vselect(cond, vnot(X), zero) => andnot(cond, X)
+// DAGCombiner converts and(vnot(X), sext(cmp)) into vselect(cmp, vnot(X), zero)
+// which the generic vselect pattern below lowers to v128.not + v128.bitselect.
+// Match it first and emit a single v128.andnot instead.
+foreach vec = IntVecs in
+def : Pat<(vec.vt (vselect
+            (vec.int_vt V128:$c), (vnot (vec.vt V128:$x)), immAllZerosV)),
+          (ANDNOT $c, $x)>;
+
 // Also implement vselect in terms of bitselect
 foreach vec = StdVecs in
 def : Pat<(vec.vt (vselect

--- a/llvm/test/CodeGen/WebAssembly/simd-select.ll
+++ b/llvm/test/CodeGen/WebAssembly/simd-select.ll
@@ -622,3 +622,82 @@ define <4 x i32> @select_splat_second_zero_cond_input(<4 x i1> %c, <4 x i32> %x)
   ret <4 x i32> %res
 }
 
+; ==============================================================================
+; vselect(cmp, vnot(x), zero) -> v128.andnot
+; ==============================================================================
+
+; Test that and(vnot(x), sext(cmp)) lowers to v128.andnot.
+;
+; DAGCombiner canonicalizes and(x, sext(cmp)) into vselect(cmp, x, zero).
+; When x is vnot(y), this produces vselect(cmp, vnot(y), zero) which the
+; generic vselect-to-bitselect pattern lowers as v128.not + v128.bitselect.
+; A dedicated ISel pattern matches this as a single v128.andnot instead.
+
+define <4 x i32> @andnot_sext_v4i32(<4 x i32> %a, <4 x i32> %b, <4 x i32> %x) {
+; CHECK-LABEL: andnot_sext_v4i32:
+; CHECK:         .functype andnot_sext_v4i32 (v128, v128, v128) -> (v128)
+; CHECK-NEXT:  # %bb.0:
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    i32x4.lt_s
+; CHECK-NEXT:    local.get 2
+; CHECK-NEXT:    v128.andnot
+; CHECK-NEXT:    # fallthrough-return
+  %cmp = icmp slt <4 x i32> %a, %b
+  %sext = sext <4 x i1> %cmp to <4 x i32>
+  %not = xor <4 x i32> %x, splat (i32 -1)
+  %res = and <4 x i32> %not, %sext
+  ret <4 x i32> %res
+}
+
+define <16 x i8> @andnot_sext_v16i8(<16 x i8> %a, <16 x i8> %b, <16 x i8> %x) {
+; CHECK-LABEL: andnot_sext_v16i8:
+; CHECK:         .functype andnot_sext_v16i8 (v128, v128, v128) -> (v128)
+; CHECK-NEXT:  # %bb.0:
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    i8x16.lt_s
+; CHECK-NEXT:    local.get 2
+; CHECK-NEXT:    v128.andnot
+; CHECK-NEXT:    # fallthrough-return
+  %cmp = icmp slt <16 x i8> %a, %b
+  %sext = sext <16 x i1> %cmp to <16 x i8>
+  %not = xor <16 x i8> %x, splat (i8 -1)
+  %res = and <16 x i8> %not, %sext
+  ret <16 x i8> %res
+}
+
+define <8 x i16> @andnot_sext_v8i16(<8 x i16> %a, <8 x i16> %b, <8 x i16> %x) {
+; CHECK-LABEL: andnot_sext_v8i16:
+; CHECK:         .functype andnot_sext_v8i16 (v128, v128, v128) -> (v128)
+; CHECK-NEXT:  # %bb.0:
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    i16x8.lt_s
+; CHECK-NEXT:    local.get 2
+; CHECK-NEXT:    v128.andnot
+; CHECK-NEXT:    # fallthrough-return
+  %cmp = icmp slt <8 x i16> %a, %b
+  %sext = sext <8 x i1> %cmp to <8 x i16>
+  %not = xor <8 x i16> %x, splat (i16 -1)
+  %res = and <8 x i16> %not, %sext
+  ret <8 x i16> %res
+}
+
+define <2 x i64> @andnot_sext_v2i64(<2 x i64> %a, <2 x i64> %b, <2 x i64> %x) {
+; CHECK-LABEL: andnot_sext_v2i64:
+; CHECK:         .functype andnot_sext_v2i64 (v128, v128, v128) -> (v128)
+; CHECK-NEXT:  # %bb.0:
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    i64x2.lt_s
+; CHECK-NEXT:    local.get 2
+; CHECK-NEXT:    v128.andnot
+; CHECK-NEXT:    # fallthrough-return
+  %cmp = icmp slt <2 x i64> %a, %b
+  %sext = sext <2 x i1> %cmp to <2 x i64>
+  %not = xor <2 x i64> %x, splat (i64 -1)
+  %res = and <2 x i64> %not, %sext
+  ret <2 x i64> %res
+}
+


### PR DESCRIPTION
## Summary

DAGCombiner canonicalizes `and(vnot(x), sext(cmp))` into `vselect(cmp, vnot(x), zero)`. Without a dedicated ISel pattern, this falls through to the generic vselect-to-bitselect lowering, producing `v128.not` + `v128.bitselect`. This patch adds a higher-priority pattern that emits a single `v128.andnot` instead, saving two instructions.

### Before (3 instructions)

| Instruction | Description |
|---|---|
| `v128.not %x` | Bitwise NOT: flips every bit in the 128-bit vector |
| `v128.const 0,0,0,0` | Loads a 128-bit constant of all zeros onto the stack |
| `v128.bitselect %vnot, %zero, %mask` | Bitwise select: for each bit, picks from the first operand where the mask bit is 1, and from the second operand where the mask bit is 0 |

Since the second operand is all zeros, `bitselect(vnot(x), 0, mask)` simplifies to `~x & mask`.

### After (1 instruction)

| Instruction | Description |
|---|---|
| `v128.andnot %mask, %x` | Bitwise AND-NOT: computes `mask & ~x` in a single instruction |

### Example

```wat
;; Before
i32x4.lt_s
local.get 2
v128.not
v128.const 0, 0, 0, 0
v128.bitselect

;; After
i32x4.lt_s
local.get 2
v128.andnot
```

The direct `and(vnot(x), y)` pattern is already handled by the existing `andnot` PatFrag. This patch covers the indirect path through DAGCombiner's `and(x, sext(cmp))` → `vselect(cmp, x, zero)` canonicalization, which obscures the `andnot` opportunity when `x` is `vnot(y)`.

Reference: [WebAssembly SIMD spec](https://github.com/WebAssembly/simd/blob/main/proposals/simd/SIMD.md)

## Test plan

- Added `simd-andnot-vselect.ll` with `and(vnot(x), sext(cmp))` tests for all four integer vector types (`v4i32`, `v16i8`, `v8i16`, `v2i64`)

Assisted-by: Claude (Anthropic)