### PR TITLE
fix ppc64le builds without IEEE double long

### DIFF
--- a/libc/src/__support/RPC/rpc_server.h
+++ b/libc/src/__support/RPC/rpc_server.h
@@ -36,6 +36,7 @@
 #define LIBC_COPT_PRINTF_DISABLE_WRITE_INT
 #define LIBC_COPT_PRINTF_DISABLE_INDEX_MODE
 #define LIBC_COPT_PRINTF_DISABLE_STRERROR
+#define LIBC_COPT_PRINTF_DISABLE_FLOAT
 
 // TODO: Remove this check once UTF-16 is supported. It may be necessary to add
 // additional targets for other systems that use UTF-16.

--- a/libc/src/stdio/printf_core/core_structs.h
+++ b/libc/src/stdio/printf_core/core_structs.h
@@ -13,6 +13,9 @@
 
 #include "src/__support/CPP/string_view.h"
 #include "src/__support/CPP/type_traits.h"
+#ifdef LIBC_TYPES_LONG_DOUBLE_IS_DOUBLE_DOUBLE
+#include "src/__support/uint128.h"
+#endif // LIBC_TYPES_LONG_DOUBLE_IS_DOUBLE_DOUBLE
 #include "src/__support/FPUtil/FPBits.h"
 #include "src/stdio/printf_core/printf_config.h"
 

--- a/libc/src/stdio/printf_core/parser.h
+++ b/libc/src/stdio/printf_core/parser.h
@@ -41,7 +41,11 @@ template <> struct int_type_of<double> {
   using type = fputil::FPBits<double>::StorageType;
 };
 template <> struct int_type_of<long double> {
+#ifdef LIBC_TYPES_LONG_DOUBLE_IS_DOUBLE_DOUBLE
+  using type = UInt128;
+#else
   using type = fputil::FPBits<long double>::StorageType;
+#endif // LIBC_TYPES_LONG_DOUBLE_IS_DOUBLE_DOUBLE
 };
 
 #ifdef LIBC_INTERNAL_PRINTF_HAS_FIXED_POINT


### PR DESCRIPTION
I don't know a lot about LLVM internals, but these at least make a build pass on ppc64le without `-DPPC_LINUX_DEFAULT_IEEELONGDOUBLE=ON` and might serve as a starting point ;)