### PR TITLE
[lldb] Fix lldb-x86_64-win bot after 454eb8bc0ac

### DIFF
--- a/lldb/test/API/symstore/Makefile
+++ b/lldb/test/API/symstore/Makefile
@@ -1,4 +1,2 @@
-MAKE_PDB := YES
-
 C_SOURCES := main.c
 include Makefile.rules

--- a/lldb/test/API/symstore/TestSymStoreLocal.py
+++ b/lldb/test/API/symstore/TestSymStoreLocal.py
@@ -71,12 +71,11 @@ class SymStoreLocalTests(TestBase):
     TEST_WITH_PDB_DEBUG_INFO = True
 
     def build_inferior(self):
+        if self.getDebugInfo() != "pdb":
+            self.skipTest("Non-PDB debug info variants not yet supported")
         self.build()
         exe_file = "a.out"
-        if self.getDebugInfo() == "pdb":
-            sym_file = "a.pdb"
-        else:
-            self.skipTest("Non-PDB debug info variants not yet supported")
+        sym_file = "a.pdb"
         self.assertTrue(os.path.isfile(self.getBuildArtifact(exe_file)))
         self.assertTrue(os.path.isfile(self.getBuildArtifact(sym_file)))
         return exe_file, sym_file


### PR DESCRIPTION
Attempt to fix forward a test failure after https://github.com/llvm/llvm-project/pull/183302, which seems to be caused by reusing build directories for test inferiors in LLDB API tests.