### PR TITLE
[CIR][NFC] Add missing enum element added to CIRGenStmt

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenStmt.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenStmt.cpp
@@ -152,6 +152,7 @@ mlir::LogicalResult CIRGenFunction::emitStmt(const Stmt *s,
   case Stmt::SEHExceptStmtClass:
   case Stmt::SEHFinallyStmtClass:
   case Stmt::MSDependentExistsStmtClass:
+  case Stmt::UnresolvedSYCLKernelCallStmtClass:
     llvm_unreachable("invalid statement class to emit generically");
   case Stmt::BreakStmtClass:
   case Stmt::NullStmtClass:


### PR DESCRIPTION
The unresolved SYCL kernel call stmt class was added in a different patch that didn't deal with CIR.  This patch adds it to the list in teh correct spot, which is an unreachable anyway.