### PR TITLE
[lldb] Use AppendMessageWithFormatv instead of AppendMessageWithFormat

### DIFF
--- a/lldb/source/Commands/CommandObjectBreakpoint.cpp
+++ b/lldb/source/Commands/CommandObjectBreakpoint.cpp
@@ -2146,9 +2146,8 @@ protected:
     if (command.empty()) {
       // No breakpoint selected; enable all currently set breakpoints.
       target.EnableAllowedBreakpoints();
-      result.AppendMessageWithFormat("All breakpoints enabled. (%" PRIu64
-                                     " breakpoints)\n",
-                                     (uint64_t)num_breakpoints);
+      result.AppendMessageWithFormatv(
+          "All breakpoints enabled. ({0} breakpoints)", num_breakpoints);
       result.SetStatus(eReturnStatusSuccessFinishNoResult);
     } else {
       // Particular breakpoint selected; enable that breakpoint.
@@ -2183,8 +2182,8 @@ protected:
             }
           }
         }
-        result.AppendMessageWithFormat("%d breakpoints enabled.\n",
-                                       enable_count + loc_count);
+        result.AppendMessageWithFormatv("{0} breakpoints enabled.",
+                                        enable_count + loc_count);
         result.SetStatus(eReturnStatusSuccessFinishNoResult);
       }
     }
@@ -2254,9 +2253,8 @@ protected:
     if (command.empty()) {
       // No breakpoint selected; disable all currently set breakpoints.
       target.DisableAllowedBreakpoints();
-      result.AppendMessageWithFormat("All breakpoints disabled. (%" PRIu64
-                                     " breakpoints)\n",
-                                     (uint64_t)num_breakpoints);
+      result.AppendMessageWithFormatv(
+          "All breakpoints disabled. ({0} breakpoints)\n", num_breakpoints);
       result.SetStatus(eReturnStatusSuccessFinishNoResult);
     } else {
       // Particular breakpoint selected; disable that breakpoint.
@@ -2292,8 +2290,8 @@ protected:
             }
           }
         }
-        result.AppendMessageWithFormat("%d breakpoints disabled.\n",
-                                       disable_count + loc_count);
+        result.AppendMessageWithFormatv("{0} breakpoints disabled.",
+                                        disable_count + loc_count);
         result.SetStatus(eReturnStatusSuccessFinishNoResult);
       }
     }
@@ -2669,9 +2667,9 @@ protected:
         result.AppendMessage("Operation cancelled...");
       } else {
         target.RemoveAllowedBreakpoints();
-        result.AppendMessageWithFormat(
-            "All breakpoints removed. (%" PRIu64 " breakpoint%s)\n",
-            (uint64_t)num_breakpoints, num_breakpoints > 1 ? "s" : "");
+        result.AppendMessageWithFormatv(
+            "All breakpoints removed. ({0} breakpoint{1})", num_breakpoints,
+            num_breakpoints > 1 ? "s" : "");
       }
       result.SetStatus(eReturnStatusSuccessFinishNoResult);
       return;
@@ -2739,8 +2737,8 @@ protected:
         }
       }
     }
-    result.AppendMessageWithFormat(
-        "%d breakpoints deleted; %d breakpoint locations disabled.\n",
+    result.AppendMessageWithFormatv(
+        "{0} breakpoints deleted; {1} breakpoint locations disabled.",
         delete_count, disable_count);
     result.SetStatus(eReturnStatusSuccessFinishNoResult);
   }
@@ -3156,7 +3154,7 @@ protected:
             target.FindBreakpointName(ConstString(name), false, error);
         if (bp_name) {
           StreamString s;
-          result.AppendMessageWithFormat("Name: %s\n", name);
+          result.AppendMessageWithFormatv("Name: {0}", name);
           if (bp_name->GetDescription(&s, eDescriptionLevelFull)) {
             result.AppendMessage(s.GetString());
           }
@@ -3178,7 +3176,7 @@ protected:
           if (!any_set)
             result.AppendMessage("No breakpoints using this name.");
         } else {
-          result.AppendMessageWithFormat("Name: %s not found.\n", name);
+          result.AppendMessageWithFormatv("Name: {0} not found.", name);
         }
       }
     }

--- a/lldb/source/Commands/CommandObjectMemory.cpp
+++ b/lldb/source/Commands/CommandObjectMemory.cpp
@@ -1110,8 +1110,8 @@ protected:
           result.AppendMessage("no more matches within the range.\n");
         break;
       }
-      result.AppendMessageWithFormat("data found at location: 0x%" PRIx64 "\n",
-                                     found_location);
+      result.AppendMessageWithFormatv("data found at location: {0:x}",
+                                      found_location);
 
       DataBufferHeap dumpbuffer(32, 0);
       process->ReadMemory(
@@ -1699,8 +1699,8 @@ protected:
         range_info.GetDirtyPageList();
     if (dirty_page_list) {
       const size_t page_count = dirty_page_list->size();
-      result.AppendMessageWithFormat(
-          "Modified memory (dirty) page list provided, %zu entries.\n",
+      result.AppendMessageWithFormatv(
+          "Modified memory (dirty) page list provided, {0} entries.",
           page_count);
       if (page_count > 0) {
         bool print_comma = false;
@@ -1712,7 +1712,7 @@ protected:
             print_comma = true;
           result.AppendMessageWithFormat("0x%" PRIx64, (*dirty_page_list)[i]);
         }
-        result.AppendMessageWithFormat(".\n");
+        result.AppendMessage(".");
       }
     }
   }

--- a/lldb/source/Commands/CommandObjectProcess.cpp
+++ b/lldb/source/Commands/CommandObjectProcess.cpp
@@ -264,8 +264,8 @@ protected:
 
           const char *archname =
               exe_module_sp->GetArchitecture().GetArchitectureName();
-          result.AppendMessageWithFormat(
-              "Process %" PRIu64 " launched: '%s' (%s)\n", process_sp->GetID(),
+          result.AppendMessageWithFormatv(
+              "Process {0} launched: '{1}' ({2})", process_sp->GetID(),
               exe_module_sp->GetFileSpec().GetPath().c_str(), archname);
         }
         result.SetStatus(eReturnStatusSuccessFinishResult);
@@ -383,8 +383,8 @@ protected:
     if (!old_exec_module_sp) {
       // We might not have a module if we attached to a raw pid...
       if (new_exec_module_sp) {
-        result.AppendMessageWithFormat(
-            "Executable binary set to \"%s\".\n",
+        result.AppendMessageWithFormatv(
+            "Executable binary set to \"{0}\".",
             new_exec_module_sp->GetFileSpec().GetPath().c_str());
       }
     } else if (!new_exec_module_sp) {
@@ -399,8 +399,8 @@ protected:
     }
 
     if (!old_arch_spec.IsValid()) {
-      result.AppendMessageWithFormat(
-          "Architecture set to: %s.\n",
+      result.AppendMessageWithFormatv(
+          "Architecture set to: {0}.",
           target->GetArchitecture().GetTriple().getTriple().c_str());
     } else if (!old_arch_spec.IsExactMatch(target->GetArchitecture())) {
       result.AppendWarningWithFormat(
@@ -719,8 +719,8 @@ protected:
         // PushProcessIOHandler().
         process->SyncIOHandler(iohandler_id, std::chrono::seconds(2));
 
-        result.AppendMessageWithFormat("Process %" PRIu64 " resuming\n",
-                                       process->GetID());
+        result.AppendMessageWithFormatv("Process {0} resuming",
+                                        process->GetID());
         if (synchronous_execution) {
           // If any state changed events had anything to say, add that to the
           // result
@@ -1122,8 +1122,8 @@ protected:
         Status error(process->GetTarget().GetPlatform()->UnloadImage(
             process, image_token));
         if (error.Success()) {
-          result.AppendMessageWithFormat(
-              "Unloading shared library with index %u...ok\n", image_token);
+          result.AppendMessageWithFormatv(
+              "Unloading shared library with index {0}...ok", image_token);
           result.SetStatus(eReturnStatusSuccessFinishResult);
         } else {
           result.AppendErrorWithFormat("failed to unload image: %s",
@@ -1468,12 +1468,12 @@ protected:
       addr_t data_mask = process->GetDataAddressMask();
       if (code_mask != LLDB_INVALID_ADDRESS_MASK) {
         int bits = std::bitset<64>(~code_mask).count();
-        result.AppendMessageWithFormat(
-            "Addressable code address mask: 0x%" PRIx64 "\n", code_mask);
-        result.AppendMessageWithFormat(
-            "Addressable data address mask: 0x%" PRIx64 "\n", data_mask);
-        result.AppendMessageWithFormat(
-            "Number of bits used in addressing (code): %d\n", bits);
+        result.AppendMessageWithFormatv("Addressable code address mask: {0:x}",
+                                        code_mask);
+        result.AppendMessageWithFormatv("Addressable data address mask: {0:x}",
+                                        data_mask);
+        result.AppendMessageWithFormatv(
+            "Number of bits used in addressing (code): {0}", bits);
       }
 
       PlatformSP platform_sp = process->GetTarget().GetPlatform();

--- a/lldb/source/Commands/CommandObjectTarget.cpp
+++ b/lldb/source/Commands/CommandObjectTarget.cpp
@@ -441,8 +441,8 @@ protected:
                                         core_file.GetPath());
         }
       } else {
-        result.AppendMessageWithFormat(
-            "Current executable set to '%s' (%s).\n",
+        result.AppendMessageWithFormatv(
+            "Current executable set to '{0}' ({1}).",
             file_spec.GetPath().c_str(),
             target_sp->GetArchitecture().GetArchitectureName());
         result.SetStatus(eReturnStatusSuccessFinishNoResult);
@@ -3016,9 +3016,9 @@ protected:
                           if (target.SetSectionLoadAddress(section_sp,
                                                            load_addr))
                             changed = true;
-                          result.AppendMessageWithFormat(
-                              "section '%s' loaded at 0x%" PRIx64 "\n",
-                              sect_name, load_addr);
+                          result.AppendMessageWithFormatv(
+                              "section '{0}' loaded at {1:x}", sect_name,
+                              load_addr);
                         }
                       } else {
                         result.AppendErrorWithFormat("no section found that "
@@ -3120,7 +3120,7 @@ protected:
             if (matching_modules.GetModulePointerAtIndex(i)
                     ->GetFileSpec()
                     .GetPath(path, sizeof(path)))
-              result.AppendMessageWithFormat("%s\n", path);
+              result.AppendMessageWithFormatv("{0}", path);
           }
         } else {
           result.AppendErrorWithFormat(
@@ -4389,8 +4389,8 @@ protected:
         if (object_file && object_file->GetFileSpec() == symbol_fspec) {
           // Provide feedback that the symfile has been successfully added.
           const FileSpec &module_fs = module_sp->GetFileSpec();
-          result.AppendMessageWithFormat(
-              "symbol file '%s' has been added to '%s'\n", symfile_path,
+          result.AppendMessageWithFormatv(
+              "symbol file '{0}' has been added to '{1}'", symfile_path,
               module_fs.GetPath().c_str());
 
           // Let clients know something changed in the module if it is
@@ -5078,8 +5078,8 @@ protected:
       Target::StopHookCommandLine *hook_ptr =
           static_cast<Target::StopHookCommandLine *>(new_hook_sp.get());
       hook_ptr->SetActionFromStrings(m_options.m_one_liner);
-      result.AppendMessageWithFormat("Stop hook #%" PRIu64 " added.\n",
-                                     new_hook_sp->GetID());
+      result.AppendMessageWithFormatv("Stop hook #{0} added.",
+                                      new_hook_sp->GetID());
     } else if (!m_python_class_options.GetName().empty()) {
       // This is a scripted stop hook:
       Target::StopHookScripted *hook_ptr =
@@ -5088,8 +5088,8 @@ protected:
           m_python_class_options.GetName(),
           m_python_class_options.GetStructuredData());
       if (error.Success())
-        result.AppendMessageWithFormat("Stop hook #%" PRIu64 " added.\n",
-                                       new_hook_sp->GetID());
+        result.AppendMessageWithFormatv("Stop hook #{0} added.",
+                                        new_hook_sp->GetID());
       else {
         // FIXME: Set the stop hook ID counter back.
         result.AppendErrorWithFormat("Couldn't add stop hook: %s",
@@ -5457,8 +5457,8 @@ protected:
       return;
     }
 
-    result.AppendMessageWithFormat(
-        "successfully registered scripted frame provider '%s' for target\n",
+    result.AppendMessageWithFormatv(
+        "successfully registered scripted frame provider '{0}' for target",
         m_class_options.GetName().c_str());
   }
 
@@ -5563,8 +5563,8 @@ protected:
     }
 
     if (size_t num_removed_providers = removed_provider_ids.size()) {
-      result.AppendMessageWithFormat(
-          "Successfully removed %zu frame-providers.\n", num_removed_providers);
+      result.AppendMessageWithFormatv(
+          "Successfully removed {0} frame-providers.", num_removed_providers);
       result.SetStatus(eReturnStatusSuccessFinishNoResult);
     } else {
       result.AppendError("0 frame providers removed.\n");


### PR DESCRIPTION
When the message ends with a newline. ...WithFormatv adds a newline automatically.

Note that the ":x" style is lower case hex with 0x prefix. (see llvm/include/llvm/Support/FormatProviders.h)

This change does not change uses where multiple chunks are emitted to one line, or the message has embedded newlines. I want to deal with these more complex cases later.

This is round 3 of N doing this, converting a few files at a time.