### PR TITLE
[libc] Fix build failures in fuzzing tests

### DIFF
--- a/libc/fuzzing/__support/freelist_heap_fuzz.cpp
+++ b/libc/fuzzing/__support/freelist_heap_fuzz.cpp
@@ -135,6 +135,7 @@ optional<size_t> choose_alloc_idx(const AllocVec &allocs, const uint8_t *&data,
   TYPE NAME = *maybe_##NAME
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t remainder) {
+  using LIBC_NAMESPACE::Block;
   LIBC_NAMESPACE::FreeListHeapBuffer<heap_size> heap;
   AllocVec allocs(heap);
 

--- a/libc/fuzzing/__support/freelist_heap_fuzz.cpp
+++ b/libc/fuzzing/__support/freelist_heap_fuzz.cpp
@@ -26,6 +26,7 @@ _end:
 __llvm_libc_heap_limit:
 )");
 
+using LIBC_NAMESPACE::Block;
 using LIBC_NAMESPACE::FreeListHeap;
 using LIBC_NAMESPACE::inline_memset;
 using LIBC_NAMESPACE::cpp::nullopt;
@@ -135,7 +136,6 @@ optional<size_t> choose_alloc_idx(const AllocVec &allocs, const uint8_t *&data,
   TYPE NAME = *maybe_##NAME
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t remainder) {
-  using LIBC_NAMESPACE::Block;
   LIBC_NAMESPACE::FreeListHeapBuffer<heap_size> heap;
   AllocVec allocs(heap);
 

--- a/libc/fuzzing/string/strlen_fuzz.cpp
+++ b/libc/fuzzing/string/strlen_fuzz.cpp
@@ -11,8 +11,8 @@
 //===----------------------------------------------------------------------===//
 
 #include "src/string/strlen.h"
-#include <cstdint>
-#include <cstring>
+#include <stdint.h>
+#include <string.h>
 
 // always null terminate the data
 extern "C" size_t LLVMFuzzerMutate(uint8_t *data, size_t size, size_t max_size);


### PR DESCRIPTION
The tests:
 - __support/freelist_heap_fuzz.cpp
 - fuzzing/string/strlen_fuzz.cpp

had build failures for different reasons. This patch fixes these failures.

freelist_heap_fuzz.cpp had this error:

```
llvm-project/libc/fuzzing/__support/freelist_heap_fuzz.cpp:150:26: error: use of undeclared identifier 'Block'; did you mean '__llvm_libc_23_0_0_git::Block'?
  150 |       size_t alignment = Block::MIN_ALIGN;
      |                          ^~~~~
      |                          __llvm_libc_23_0_0_git::Block
```

The issue stems from the fact that Block was not available in scope. It needs to be referenced via LIBC_NAMESPACE.

strlen_fuzz.cpp had this error:

```
In file included from Workspace/llvm-project/libc/fuzzing/string/strlen_fuzz.cpp:14:
In file included from /usr/lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/cstdint:38:
In file included from /usr/lib/gcc/x86_64-linux-gnu/13/../../../../include/x86_64-linux-gnu/c++/13/bits/c++config.h:679:
/usr/lib/gcc/x86_64-linux-gnu/13/../../../../include/x86_64-linux-gnu/c++/13/bits/os_defines.h:44:5: error: function-like macro '__GLIBC_PREREQ' is not defined
   44 | #if __GLIBC_PREREQ(2,15) && defined(_GNU_SOURCE)

```

This issue is more cryptic to me, but I managed to fix it by changing the includes from cstdint and cstring to stdint.h and string.h.