### PR TITLE
[libc] Build fuzzing tests in pre-merge CI tests

### DIFF
--- a/.github/workflows/libc-fullbuild-tests.yml
+++ b/.github/workflows/libc-fullbuild-tests.yml
@@ -31,66 +31,77 @@ jobs:
             cpp_compiler: clang++-21
             target: x86_64-unknown-linux-llvm
             include_scudo: ON
+            build_fuzzing_tests: OFF
           - os: ubuntu-24.04
             build_type: Release
             c_compiler: clang-21
             cpp_compiler: clang++-21
             target: x86_64-unknown-linux-llvm
             include_scudo: ON
+            build_fuzzing_tests: ON
           - os: ubuntu-24.04
             build_type: MinSizeRel
             c_compiler: clang-21
             cpp_compiler: clang++-21
             target: x86_64-unknown-linux-llvm
             include_scudo: ON
+            build_fuzzing_tests: OFF
           - os: ubuntu-24.04-arm
             build_type: Debug
             c_compiler: clang-21
             cpp_compiler: clang++-21
             target: aarch64-unknown-linux-llvm
             include_scudo: ON
+            build_fuzzing_tests: ON
           - os: ubuntu-24.04
             build_type: Debug
             c_compiler: clang-21
             cpp_compiler: clang++-21
             target: x86_64-unknown-uefi-llvm
             include_scudo: OFF
+            build_fuzzing_tests: OFF
           - os: ubuntu-24.04
             build_type: MinSizeRel
             c_compiler: clang-21
             cpp_compiler: clang++-21
             target: armv6m-none-eabi
             include_scudo: OFF
+            build_fuzzing_tests: OFF
           - os: ubuntu-24.04
             build_type: MinSizeRel
             c_compiler: clang-21
             cpp_compiler: clang++-21
             target: armv7m-none-eabi
             include_scudo: OFF
+            build_fuzzing_tests: OFF
           - os: ubuntu-24.04
             build_type: MinSizeRel
             c_compiler: clang-21
             cpp_compiler: clang++-21
             target: armv7em-none-eabi
             include_scudo: OFF
+            build_fuzzing_tests: OFF
           - os: ubuntu-24.04
             build_type: MinSizeRel
             c_compiler: clang-21
             cpp_compiler: clang++-21
             target: armv8m.main-none-eabi
             include_scudo: OFF
+            build_fuzzing_tests: OFF
           - os: ubuntu-24.04
             build_type: MinSizeRel
             c_compiler: clang-21
             cpp_compiler: clang++-21
             target: armv8.1m.main-none-eabi
             include_scudo: OFF
+            build_fuzzing_tests: OFF
           - os: ubuntu-24.04
             build_type: MinSizeRel
             c_compiler: clang-21
             cpp_compiler: clang++-21
             target: riscv32-unknown-elf
             include_scudo: OFF
+            build_fuzzing_tests: OFF
           # TODO: add back gcc build when it is fixed
           # - c_compiler: gcc
           #   cpp_compiler: g++
@@ -118,7 +129,6 @@ jobs:
         echo "build-install-dir=/__w/llvm-project/llvm-project/install" >> "$GITHUB_OUTPUT"
     
     # Configure libc fullbuild with scudo.
-    # Use MinSizeRel to reduce the size of the build.
     - name: Configure CMake
       run: |
         export RUNTIMES="libc"
@@ -135,8 +145,11 @@ jobs:
           -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
           -DCMAKE_INSTALL_PREFIX=${{ steps.strings.outputs.build-install-dir }}"
 
-        if [[ ${{ matrix.include_scudo}} == "ON" ]]; then
+        if [[ "${{ matrix.include_scudo }}" == "ON" || "${{ matrix.build_fuzzing_tests }}" == "ON" ]]; then
           export RUNTIMES="$RUNTIMES;compiler-rt"
+        fi
+
+        if [[ "${{ matrix.include_scudo }}" == "ON" ]]; then
           export CMAKE_FLAGS="$CMAKE_FLAGS
             -DLLVM_LIBC_INCLUDE_SCUDO=ON
             -DCOMPILER_RT_BUILD_SCUDO_STANDALONE_WITH_LLVM_LIBC=ON
@@ -158,11 +171,17 @@ jobs:
         esac
 
     - name: Build
-      run: >
-        cmake 
-        --build ${{ steps.strings.outputs.build-output-dir }} 
-        --parallel
-        --target install
+      shell: bash
+      run: |
+        TARGETS="install"
+        if [[ "${{ matrix.build_fuzzing_tests }}" == "ON" ]]; then
+          TARGETS="$TARGETS libc-fuzzer"
+        fi
+
+        cmake \
+          --build ${{ steps.strings.outputs.build-output-dir }} \
+          --parallel \
+          --target $TARGETS
 
     - name: Test
       # Skip UEFI and baremetal tests until we have testing set up.


### PR DESCRIPTION
At the moment, no CI job tests whether the fuzzing tests build correctly.

This patch adds the build of fuzzing tests to the pre-merge CI job.

Only two configurations have it enabled for now. The none-eabi configurations seemingly do not support it because in their cmake configs compiler-rt is not enabled, hence libFuzzer isn't built. I did not dig too much to understand why that is, preferring to just leave it disabled for these configurations. For the remaining ones that seem to support it, I selected one x86 and one aarch64.

In addition, it removes one outdated comment about the build type used and changes the action to run on all branches, not only on PRs that target main.

If we limit it to run only on PRs to the main branch, it will not run on stacked PRs. I believe it is also okay to run it on PRs to release branches. Therefore it is just easier to remove the limit altogether.