### PR TITLE
[NFC][analyzer] Remove orphaned declaration ExprEngine::getStmt()

### DIFF
--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/ExprEngine.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/ExprEngine.h
@@ -221,8 +221,6 @@ public:
     return *currBldrCtx;
   }
 
-  const Stmt *getStmt() const;
-
   const LocationContext *getRootLocationContext() const {
     assert(G.getRoot());
     return G.getRoot()->getLocation().getLocationContext();


### PR DESCRIPTION
Its definition was removed fifteen(!) years ago by commit b1d3d968725baf28a00b12aad760434036cbe704.