### PR TITLE
[BOLT] Fix test with -DCLANG_DEFAULT_PIE_ON_LINUX=OFF

### DIFF
--- a/bolt/test/max-funcs.test
+++ b/bolt/test/max-funcs.test
@@ -3,7 +3,7 @@
 
 REQUIRES: system-linux
 
-RUN: %clangxx %p/Inputs/bolt_icf.cpp -g -Wl,-q -o %t.exe
+RUN: %clangxx %p/Inputs/bolt_icf.cpp -g -Wl,-q -fPIC -pie -o %t.exe
 RUN: llvm-bolt %t.exe --relocs -o %t --max-funcs=2
 RUN: llvm-objdump -d -j .text %t | FileCheck %s
 

--- a/bolt/test/max-funcs.test
+++ b/bolt/test/max-funcs.test
@@ -3,7 +3,7 @@
 
 REQUIRES: system-linux
 
-RUN: %clangxx %p/Inputs/bolt_icf.cpp -g -Wl,-q -fPIC -pie -o %t.exe
+RUN: %clangxx %cxxflags %p/Inputs/bolt_icf.cpp -g -Wl,-q -o %t.exe
 RUN: llvm-bolt %t.exe --relocs -o %t --max-funcs=2
 RUN: llvm-objdump -d -j .text %t | FileCheck %s
 


### PR DESCRIPTION
Use `%cxxflags`, so that `-fPIE -pie` get passed in order to ensure the test behavior is the same regardless of cmake configuration. We do similar in many other BOLT tests.