### PR TITLE
[lldb][PlatformDarwin] Make LocateExecutableScriptingResourcesFromDSYM a public static

### DIFF
--- a/lldb/source/Plugins/Platform/MacOSX/PlatformDarwin.cpp
+++ b/lldb/source/Plugins/Platform/MacOSX/PlatformDarwin.cpp
@@ -200,7 +200,7 @@ PlatformDarwin::PutFile(const lldb_private::FileSpec &source,
   return PlatformPOSIX::PutFile(source, destination, uid, gid);
 }
 
-static FileSpecList LocateExecutableScriptingResourcesFromDSYM(
+FileSpecList PlatformDarwin::LocateExecutableScriptingResourcesFromDSYM(
     Stream &feedback_stream, FileSpec module_spec, const Target &target,
     const FileSpec &symfile_spec) {
   FileSpecList file_list;

--- a/lldb/source/Plugins/Platform/MacOSX/PlatformDarwin.h
+++ b/lldb/source/Plugins/Platform/MacOSX/PlatformDarwin.h
@@ -133,6 +133,28 @@ public:
   llvm::Expected<std::string>
   ResolveSDKPathFromDebugInfo(CompileUnit &unit) override;
 
+  /// Helper function for \c LocateExecutableScriptingResources
+  /// which gathers FileSpecs for executable scripts (currently
+  /// just Python) from a .dSYM Python directory.
+  ///
+  /// \param[out] feedback_stream Any warnings/errors are printed into this
+  /// stream.
+  ///
+  /// \param[in] module_spec FileSpec of the Module for which to locate
+  /// scripting resources.
+  ///
+  /// \param[in] target Target which owns the ScriptInterpreter which is
+  /// eventually used for loading the scripting resources.
+  ///
+  /// \param[in] symfile_spec FileSpec for the SymbolFile inside the Module's
+  /// dSYM directory. The scripting resources are loaded from the adjacent
+  /// Resources directory in the same dSYM.
+  /// E.g., \c /path/to/.dSYM/Contents/Resources/DWARF/a.out
+  ///
+  static FileSpecList LocateExecutableScriptingResourcesFromDSYM(
+      Stream &feedback_stream, FileSpec module_spec, const Target &target,
+      const FileSpec &symfile_spec);
+
 protected:
   static const char *GetCompatibleArch(ArchSpec::Core core, size_t idx);
 


### PR DESCRIPTION
This will allow us to unit-test it in a follow-up patch. We could test `LocateExecutableScriptingResources` directly, but that requires a valid `Module`/`ObjectFile`/`SymbolFile`. That's a lot of boilerplate/set to ultimately just test the `dSYM` logic. The helper just takes `FileSpec`s, which are much easier to construct in a test.