### PR TITLE
[dsymutil] Use DebugMapFilter when parsing --allow/--disallow YAML input

### DIFF
--- a/llvm/tools/dsymutil/DebugMap.cpp
+++ b/llvm/tools/dsymutil/DebugMap.cpp
@@ -265,7 +265,7 @@ void MappingTraits<dsymutil::DebugMap>::mapping(IO &io,
   io.mapOptional("binary-path", DM.BinaryPath);
   if (void *Ctxt = io.getContext())
     reinterpret_cast<YAMLContext *>(Ctxt)->BinaryTriple = DM.BinaryTriple;
-  io.mapOptional("objects", DM.Objects);
+  io.mapOptional("objects", DM.getObjects());
 }
 
 void MappingTraits<std::unique_ptr<dsymutil::DebugMap>>::mapping(
@@ -276,7 +276,7 @@ void MappingTraits<std::unique_ptr<dsymutil::DebugMap>>::mapping(
   io.mapOptional("binary-path", DM->BinaryPath);
   if (void *Ctxt = io.getContext())
     reinterpret_cast<YAMLContext *>(Ctxt)->BinaryTriple = DM->BinaryTriple;
-  io.mapOptional("objects", DM->Objects);
+  io.mapOptional("objects", DM->getObjects());
 }
 
 MappingTraits<dsymutil::DebugMapObject>::YamlDMO::YamlDMO(

--- a/llvm/tools/dsymutil/DebugMap.cpp
+++ b/llvm/tools/dsymutil/DebugMap.cpp
@@ -230,17 +230,33 @@ SequenceTraits<std::vector<std::unique_ptr<dsymutil::DebugMapObjectFilter>>>::
   return seq.size();
 }
 
-dsymutil::DebugMapObject &
+dsymutil::DebugMapObjectFilter &
 SequenceTraits<std::vector<std::unique_ptr<dsymutil::DebugMapObjectFilter>>>::
     element(IO &io,
             std::vector<std::unique_ptr<dsymutil::DebugMapObjectFilter>> &seq,
             size_t index) {
-  auto &Objects = reinterpret_cast<
-      std::vector<std::unique_ptr<dsymutil::DebugMapObject>> &>(seq);
-  return SequenceTraits<
-      std::vector<std::unique_ptr<dsymutil::DebugMapObject>>>::element(io,
-                                                                       Objects,
-                                                                       index);
+  if (index >= seq.size()) {
+    seq.resize(index + 1);
+    seq[index].reset(new dsymutil::DebugMapObjectFilter);
+  }
+  return *seq[index];
+}
+
+void MappingTraits<dsymutil::DebugMapObjectFilter>::mapping(
+    IO &io, dsymutil::DebugMapObjectFilter &DMOF) {
+  io.mapRequired("filename", DMOF.Filename);
+}
+
+void MappingTraits<dsymutil::DebugMapFilter>::mapping(
+    IO &io, dsymutil::DebugMapFilter &DMF) {
+  io.mapRequired("objects", DMF.Objects);
+}
+
+void MappingTraits<std::unique_ptr<dsymutil::DebugMapFilter>>::mapping(
+    IO &io, std::unique_ptr<dsymutil::DebugMapFilter> &DMF) {
+  if (!DMF)
+    DMF.reset(new DebugMapFilter());
+  io.mapRequired("objects", DMF->Objects);
 }
 
 void MappingTraits<dsymutil::DebugMap>::mapping(IO &io,

--- a/llvm/tools/dsymutil/DebugMap.h
+++ b/llvm/tools/dsymutil/DebugMap.h
@@ -51,8 +51,37 @@ class DebugMapObject;
 class DebugMapObjectFilter;
 
 class DebugMapFilter {
+  using ObjectContainer = std::vector<std::unique_ptr<DebugMapObjectFilter>>;
+
+public:
+  virtual ~DebugMapFilter() = default;
+  using const_iterator = ObjectContainer::const_iterator;
+
+  iterator_range<const_iterator> objects() const {
+    return make_range(begin(), end());
+  }
+
+  const_iterator begin() const { return Objects.begin(); }
+
+  const_iterator end() const { return Objects.end(); }
+
 protected:
   std::vector<std::unique_ptr<DebugMapObjectFilter>> Objects;
+
+private:
+  friend class DebugMap;
+
+  /// For YAML IO support.
+  ///@{
+  friend yaml::MappingTraits<std::unique_ptr<DebugMapFilter>>;
+  friend yaml::MappingTraits<DebugMapFilter>;
+
+  DebugMapFilter() = default;
+
+public:
+  DebugMapFilter(DebugMapFilter &&) = default;
+  DebugMapFilter &operator=(DebugMapFilter &&) = default;
+  ///@}
 };
 
 /// The DebugMap object stores the list of object files to query for debug
@@ -278,13 +307,17 @@ struct SequenceTraits<std::vector<std::unique_ptr<dsymutil::DebugMapObject>>> {
           size_t index);
 };
 
+template <> struct MappingTraits<dsymutil::DebugMapObjectFilter> {
+  static void mapping(IO &io, dsymutil::DebugMapObjectFilter &DMO);
+};
+
 template <>
 struct SequenceTraits<
     std::vector<std::unique_ptr<dsymutil::DebugMapObjectFilter>>> {
   static size_t
   size(IO &io,
        std::vector<std::unique_ptr<dsymutil::DebugMapObjectFilter>> &seq);
-  static dsymutil::DebugMapObject &
+  static dsymutil::DebugMapObjectFilter &
   element(IO &,
           std::vector<std::unique_ptr<dsymutil::DebugMapObjectFilter>> &seq,
           size_t index);
@@ -296,6 +329,14 @@ template <> struct MappingTraits<dsymutil::DebugMap> {
 
 template <> struct MappingTraits<std::unique_ptr<dsymutil::DebugMap>> {
   static void mapping(IO &io, std::unique_ptr<dsymutil::DebugMap> &DM);
+};
+
+template <> struct MappingTraits<dsymutil::DebugMapFilter> {
+  static void mapping(IO &io, dsymutil::DebugMapFilter &DMF);
+};
+
+template <> struct MappingTraits<std::unique_ptr<dsymutil::DebugMapFilter>> {
+  static void mapping(IO &io, std::unique_ptr<dsymutil::DebugMapFilter> &DMF);
 };
 
 } // end namespace yaml

--- a/llvm/tools/dsymutil/dsymutil.cpp
+++ b/llvm/tools/dsymutil/dsymutil.cpp
@@ -59,33 +59,6 @@ using namespace llvm::dsymutil;
 using namespace object;
 using namespace llvm::dwarf_linker;
 
-/// YAML structure for --allow / --disallow object list files.
-struct ObjectFileEntry {
-  std::string Filename;
-};
-
-struct ObjectFileList {
-  std::vector<ObjectFileEntry> Objects;
-};
-
-LLVM_YAML_IS_SEQUENCE_VECTOR(ObjectFileEntry)
-
-namespace llvm {
-namespace yaml {
-template <> struct MappingTraits<ObjectFileEntry> {
-  static void mapping(IO &IO, ObjectFileEntry &Entry) {
-    IO.mapRequired("filename", Entry.Filename);
-  }
-};
-
-template <> struct MappingTraits<ObjectFileList> {
-  static void mapping(IO &IO, ObjectFileList &List) {
-    IO.mapOptional("objects", List.Objects);
-  }
-};
-} // namespace yaml
-} // namespace llvm
-
 namespace {
 enum ID {
   OPT_INVALID = 0, // This is not an option ID.
@@ -754,15 +727,15 @@ int dsymutil_main(int argc, char **argv, const llvm::ToolContext &) {
       StringRef Content = (*BufOrErr)->getBuffer();
       if (!Content.trim().empty()) {
         yaml::Input YAMLIn(Content);
-        ObjectFileList ObjList;
-        YAMLIn >> ObjList;
+        std::unique_ptr<DebugMapFilter> DebugMapFilter;
+        YAMLIn >> DebugMapFilter;
         if (YAMLIn.error())
           return make_error<StringError>(
               Twine("cannot parse allow/disallow file '") + FilePath + "'",
               YAMLIn.error());
-        for (const auto &Entry : ObjList.Objects) {
+        for (const auto &Entry : *DebugMapFilter) {
           SmallString<80> Path(Options.LinkOpts.PrependPath);
-          sys::path::append(Path, Entry.Filename);
+          sys::path::append(Path, Entry->getObjectFilename());
           Result.insert(Path);
         }
       }


### PR DESCRIPTION
# Change

PR https://github.com/llvm/llvm-project/pull/182083 forgot to switch over to use the newly added `DebugMapFilter` when parsing `--allow/--disallow` YAML input. It was still using `ObjectFileList`/`ObjectFileEntry`, which was added initially in the same PR and was later intended to be replaced by `DebugMapFilter`.

This patch switches over to use `DebugMapFilter`, adds necessary YAML traits, and removes `ObjectFileList`/`ObjectFileEntry`.

# Test

```
% ninja dsymutil test-depends && bin/llvm-lit -v \
  ../llvm-project/llvm/test/tools/dsymutil/*/*.test
...
Testing Time: 4.79s

Total Discovered Tests: 92
  Passed: 92 (100.00%)
```