### PR TITLE
[clang-doc] Fix benchmark not compiling

### DIFF
--- a/clang-tools-extra/clang-doc/benchmarks/CMakeLists.txt
+++ b/clang-tools-extra/clang-doc/benchmarks/CMakeLists.txt
@@ -15,4 +15,6 @@ target_link_libraries(ClangDocBenchmark
   clangTooling
   clangBasic
   clangAST
+  clangFrontend
+  clangSerialization
 )

--- a/clang-tools-extra/clang-doc/benchmarks/ClangDocBenchmark.cpp
+++ b/clang-tools-extra/clang-doc/benchmarks/ClangDocBenchmark.cpp
@@ -80,7 +80,7 @@ static void BM_Mapper_Scale(benchmark::State &State) {
     tooling::InMemoryToolResults Results;
     tooling::ExecutionContext ECtx(&Results);
     ClangDocContext CDCtx(&ECtx, "test-project", false, "", "", "", "", "", {},
-                          Diags, false);
+                          Diags, OutputFormatTy::json, false);
     auto ActionFactory = doc::newMapperActionFactory(CDCtx);
     std::unique_ptr<FrontendAction> Action = ActionFactory->create();
     tooling::runToolOnCode(std::move(Action), Code, "test.cpp");
@@ -193,7 +193,7 @@ static void BM_JSONGenerator_Scale(benchmark::State &State) {
   DiagnosticOptions DiagOpts;
   DiagnosticsEngine Diags(DiagID, DiagOpts, new IgnoringDiagConsumer());
   ClangDocContext CDCtx(nullptr, "test-project", false, "", "", "", "", "", {},
-                        Diags, false);
+                        Diags, OutputFormatTy::json, false);
 
   std::string Output;
   llvm::raw_string_ostream OS(Output);


### PR DESCRIPTION
CI didn't flag that the benchmark was using the outdated Ctx call
when landing the Mustache MD patch since this benchmark isn't tested.
Also added missing libraries in CMake that prevented me from building
the benchmark locally.
