### PR TITLE
[WebAssembly] Remove the `wasm-disable-fix-irreducible-control-flow-pass` switch

### DIFF
--- a/llvm/lib/Target/WebAssembly/WebAssemblyTargetMachine.cpp
+++ b/llvm/lib/Target/WebAssembly/WebAssemblyTargetMachine.cpp
@@ -51,12 +51,6 @@ static cl::opt<bool> WasmDisableExplicitLocals(
              " instruction output for test purposes only."),
     cl::init(false));
 
-static cl::opt<bool> WasmDisableFixIrreducibleControlFlowPass(
-    "wasm-disable-fix-irreducible-control-flow-pass", cl::Hidden,
-    cl::desc("webassembly: disables the fix "
-             " irreducible control flow optimization pass"),
-    cl::init(false));
-
 // Exception handling & setjmp-longjmp handling related options.
 
 // Emscripten's asm.js-style exception handling
@@ -605,8 +599,7 @@ void WebAssemblyPassConfig::addPreEmitPass() {
   addPass(createWebAssemblyNullifyDebugValueLists());
 
   // Eliminate multiple-entry loops.
-  if (!WasmDisableFixIrreducibleControlFlowPass)
-    addPass(createWebAssemblyFixIrreducibleControlFlow());
+  addPass(createWebAssemblyFixIrreducibleControlFlow());
 
   // Do various transformations for exception handling.
   // Every CFG-changing optimizations should come before this.


### PR DESCRIPTION
This removes the `wasm-disable-fix-irreducible-control-flow-pass` switch.

It was originally added in #67715 as a way to avoid the potentially absurd compile times the pass used to bring. However with the successful merge of #184441, the pass itself has been fixed to avoid this issue.

Given that, it is no longer necessary nor desirable to keep this switch.