### PR TITLE
build: adjust LLDB and clang library naming on Windows

### DIFF
--- a/clang/tools/libclang/CMakeLists.txt
+++ b/clang/tools/libclang/CMakeLists.txt
@@ -120,7 +120,7 @@ if (MSVC AND ENABLE_SHARED AND ENABLE_STATIC)
   unset(ENABLE_STATIC)
 endif()
 
-if(MSVC)
+if(WIN32 AND NOT MINGW)
   set(output_name "libclang")
 else()
   set(output_name "clang")

--- a/lldb/source/API/CMakeLists.txt
+++ b/lldb/source/API/CMakeLists.txt
@@ -216,7 +216,7 @@ elseif (LLDB_EXPORT_ALL_SYMBOLS)
   add_llvm_symbol_exports(liblldb ${exported_symbol_file})
 endif()
 
-if (NOT MSVC)
+if(NOT WIN32 OR MINGW)
   set_target_properties(liblldb
     PROPERTIES
     OUTPUT_NAME lldb


### PR DESCRIPTION
Ensure that use of the GNU driver does not change the library name on Windows. We would check the build tools being MSVC rather than targeting Windows to select the output name.