### PR TITLE
build: add `LINKER:` modifier to `/DELAYLOAD:` options

### DIFF
--- a/lldb/cmake/modules/AddLLDB.cmake
+++ b/lldb/cmake/modules/AddLLDB.cmake
@@ -171,7 +171,8 @@ function(add_lldb_executable name)
     list(FIND ARG_LINK_LIBS liblldb LIBLLDB_INDEX)
     if(NOT LIBLLDB_INDEX EQUAL -1)
       if (MSVC)
-        target_link_options(${name} PRIVATE "/DELAYLOAD:$<TARGET_FILE_NAME:liblldb>")
+        target_link_options(${name} PRIVATE
+          "LINKER:/DELAYLOAD:$<TARGET_FILE_NAME:liblldb>")
         target_link_libraries(${name} PRIVATE delayimp)
       elseif (MINGW AND LINKER_IS_LLD)
         # LLD can delay load just by passing a --delayload flag, as long as the import


### PR DESCRIPTION
When building with the GNU driver, we would pass in `/DELAYLOAD:...` without indicating that this is a linker flag. `clang` does not implictly forward non-consumed options to the linker like `cl` does, and this would cause the build to fail.