### PR TITLE
[CIR] Fix try_call replacement for indirect calls

### DIFF
--- a/clang/lib/CIR/Dialect/Transforms/FlattenCFG.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/FlattenCFG.cpp
@@ -648,12 +648,22 @@ static void replaceCallWithTryCall(cir::CallOp callOp, mlir::Block *unwindDest,
 
   // Build the try_call to replace the original call.
   rewriter.setInsertionPoint(callOp);
-  mlir::Type resType = callOp->getNumResults() > 0
-                           ? callOp->getResult(0).getType()
-                           : mlir::Type();
-  auto tryCallOp =
-      cir::TryCallOp::create(rewriter, loc, callOp.getCalleeAttr(), resType,
-                             normalDest, unwindDest, callOp.getArgOperands());
+  cir::TryCallOp tryCallOp;
+  if (callOp.isIndirect()) {
+    mlir::Value indTarget = callOp.getIndirectCall();
+    auto ptrTy = mlir::cast<cir::PointerType>(indTarget.getType());
+    auto resTy = mlir::cast<cir::FuncType>(ptrTy.getPointee());
+    tryCallOp =
+        cir::TryCallOp::create(rewriter, loc, indTarget, resTy, normalDest,
+                               unwindDest, callOp.getArgOperands());
+  } else {
+    mlir::Type resType = callOp->getNumResults() > 0
+                             ? callOp->getResult(0).getType()
+                             : mlir::Type();
+    tryCallOp =
+        cir::TryCallOp::create(rewriter, loc, callOp.getCalleeAttr(), resType,
+                               normalDest, unwindDest, callOp.getArgOperands());
+  }
 
   // Replace uses of the call result with the try_call result.
   if (callOp->getNumResults() > 0)

--- a/clang/lib/CIR/Dialect/Transforms/FlattenCFG.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/FlattenCFG.cpp
@@ -647,6 +647,7 @@ static void replaceCallWithTryCall(cir::CallOp callOp, mlir::Block *unwindDest,
       rewriter.splitBlock(callBlock, std::next(callOp->getIterator()));
 
   // Build the try_call to replace the original call.
+  // TODO(cir): Preserve function and argument attributes.
   rewriter.setInsertionPoint(callOp);
   cir::TryCallOp tryCallOp;
   if (callOp.isIndirect()) {

--- a/clang/test/CIR/CodeGen/virtual-fn-calls-eh.cpp
+++ b/clang/test/CIR/CodeGen/virtual-fn-calls-eh.cpp
@@ -1,0 +1,124 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -mconstructor-aliases -fcxx-exceptions -fexceptions -fclangir -emit-cir %s -o %t.cir
+// RUN: FileCheck --check-prefix=CIR --input-file=%t.cir %s
+// RUN: cir-opt --cir-flatten-cfg %t.cir -o %t-flat.cir
+// RUN: FileCheck --input-file=%t-flat.cir %s --check-prefix=CIR-FLAT
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -mconstructor-aliases -fcxx-exceptions -fexceptions -fclangir -emit-llvm %s -o %t-cir.ll
+// RUN: FileCheck --input-file=%t-cir.ll %s -check-prefix=LLVM
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -mconstructor-aliases -fcxx-exceptions -fexceptions -emit-llvm %s -o %t.ll
+// RUN: FileCheck --input-file=%t.ll %s -check-prefix=OGCG
+
+struct B {
+  ~B();
+  virtual void f(char);
+};
+
+void call_virtual_fn_in_cleanup_scope() {
+  B b;
+  b.f('c');
+}
+
+// CIR: cir.func {{.*}} @_Z32call_virtual_fn_in_cleanup_scopev()
+// CIR:   %[[B:.*]] = cir.alloca !rec_B, !cir.ptr<!rec_B>, ["b", init]
+// CIR:   cir.call @_ZN1BC2Ev(%[[B]])
+// CIR:   cir.cleanup.scope {
+// CIR:     %[[C_LITERAL:.*]] = cir.const #cir.int<99> : !s8i
+// CIR:     %[[VPTR_ADDR:.*]] = cir.vtable.get_vptr %[[B]] : !cir.ptr<!rec_B> -> !cir.ptr<!cir.vptr>
+// CIR:     %[[VPTR:.*]] = cir.load{{.*}} %[[VPTR_ADDR]]
+// CIR:     %[[FN_PTR_ADDR:.*]] = cir.vtable.get_virtual_fn_addr %[[VPTR]][0] : !cir.vptr -> !cir.ptr<!cir.ptr<!cir.func<(!cir.ptr<!rec_B>, !s8i)>>>
+// CIR:     %[[FN_PTR:.*]] = cir.load{{.*}} %[[FN_PTR_ADDR:.*]] : !cir.ptr<!cir.ptr<!cir.func<(!cir.ptr<!rec_B>, !s8i)>>>, !cir.ptr<!cir.func<(!cir.ptr<!rec_B>, !s8i)>>
+// CIR:     cir.call %[[FN_PTR]](%[[B]], %[[C_LITERAL]]) : (!cir.ptr<!cir.func<(!cir.ptr<!rec_B>, !s8i)>>, !cir.ptr<!rec_B> {{.*}}, !s8i {{.*}}) -> ()
+// CIR:     cir.yield
+// CIR:   } cleanup  all {
+// CIR:     cir.call @_ZN1BD1Ev(%[[B]]) nothrow : (!cir.ptr<!rec_B> {{.*}}) -> ()
+// CIR:     cir.yield
+// CIR:   }
+
+// CIR-FLAT: cir.func {{.*}} @_Z32call_virtual_fn_in_cleanup_scopev()
+// CIR-FLAT:   %[[B:.*]] = cir.alloca !rec_B, !cir.ptr<!rec_B>, ["b", init]
+// CIR-FLAT:   cir.call @_ZN1BC2Ev(%[[B]]) nothrow : (!cir.ptr<!rec_B> {{.*}}) -> ()
+// CIR-FLAT:   cir.br ^[[CLEANUP_SCOPE:bb[0-9]+]]
+// CIR-FLAT: ^[[CLEANUP_SCOPE]]:
+// CIR-FLAT:   %[[C_LITERAL:.*]] = cir.const #cir.int<99> : !s8i
+// CIR-FLAT:   %[[VPTR_ADDR:.*]] = cir.vtable.get_vptr %[[B]] : !cir.ptr<!rec_B> -> !cir.ptr<!cir.vptr>
+// CIR-FLAT:   %[[VPTR:.*]] = cir.load{{.*}} %[[VPTR_ADDR]]
+// CIR-FLAT:   %[[FN_PTR_ADDR:.*]] = cir.vtable.get_virtual_fn_addr %[[VPTR]][0] : !cir.vptr -> !cir.ptr<!cir.ptr<!cir.func<(!cir.ptr<!rec_B>, !s8i)>>>
+// CIR-FLAT:   %[[FN_PTR:.*]] = cir.load{{.*}} %[[FN_PTR_ADDR:.*]] : !cir.ptr<!cir.ptr<!cir.func<(!cir.ptr<!rec_B>, !s8i)>>>, !cir.ptr<!cir.func<(!cir.ptr<!rec_B>, !s8i)>>
+// CIR-FLAT:   cir.try_call %[[FN_PTR]](%[[B]], %[[C_LITERAL]]) ^[[NORMAL:bb[0-9]+]], ^[[UNWIND:bb[0-9]+]] : (!cir.ptr<!cir.func<(!cir.ptr<!rec_B>, !s8i)>>, !cir.ptr<!rec_B>, !s8i) -> ()
+// CIR-FLAT: ^[[NORMAL]]:  // pred: ^bb1
+// CIR-FLAT:   cir.br ^[[NORMAL_CLEANUP:bb[0-9]+]]
+// CIR-FLAT: ^[[NORMAL_CLEANUP]]:
+// CIR-FLAT:   cir.call @_ZN1BD1Ev(%[[B]]) nothrow : (!cir.ptr<!rec_B> {{.*}}) -> ()
+// CIR-FLAT:   cir.br ^[[NORMAL_CONTINUE:bb[0-9]+]]
+// CIR-FLAT: ^[[NORMAL_CONTINUE]]:
+// CIR-FLAT:   cir.br ^[[TRY_CONTINUE:bb[0-9]+]]
+// CIR-FLAT: ^[[UNWIND]]:  // pred: ^bb1
+// CIR-FLAT:   %[[EH_TOKEN:.*]] = cir.eh.initiate cleanup : !cir.eh_token
+// CIR-FLAT:   cir.br ^[[EH_CLEANUP:bb[0-9]+]](%[[EH_TOKEN]] : !cir.eh_token)
+// CIR-FLAT: ^[[EH_CLEANUP]](%[[EH_TOKEN:.*]]: !cir.eh_token):
+// CIR-FLAT:   %[[CT:.*]] = cir.begin_cleanup %[[EH_TOKEN]] : !cir.eh_token -> !cir.cleanup_token
+// CIR-FLAT:   cir.call @_ZN1BD1Ev(%[[B]]) nothrow : (!cir.ptr<!rec_B> {{.*}}) -> ()
+// CIR-FLAT:   cir.end_cleanup %[[CT]] : !cir.cleanup_token
+// CIR-FLAT:   cir.resume %[[EH_TOKEN]] : !cir.eh_token
+// CIR-FLAT: ^[[TRY_CONTINUE]]:
+// CIR-FLAT:   cir.return
+
+// LLVM: define {{.*}} void @_Z32call_virtual_fn_in_cleanup_scopev()
+// LLVM:   %[[B:.*]] = alloca %struct.B
+// LLVM:   call void @_ZN1BC2Ev(ptr {{.*}} %[[B]])
+// LLVM:   br label %[[CLEANUP_SCOPE:.*]]
+// LLVM: [[CLEANUP_SCOPE]]:
+// LLVM:   %[[B_VPTR:.*]] = load ptr, ptr %[[B]]
+// LLVM:   %[[FN_PTR_ADDR:.*]] = getelementptr inbounds ptr, ptr %[[B_VPTR]], i32 0
+// LLVM:   %[[FN_PTR:.*]] = load ptr, ptr %[[FN_PTR_ADDR]]
+// LLVM:   invoke void %[[FN_PTR]](ptr %[[B]], i8 99)
+// LLVM:           to label %[[NORMAL_CONTINUE:.*]] unwind label %[[UNWIND:.*]]
+// LLVM: [[NORMAL_CONTINUE]]
+// LLVM:   br label %[[NORMAL_CLEANUP:.*]]
+// LLVM: [[NORMAL_CLEANUP]]:
+// LLVM:   call void @_ZN1BD1Ev(ptr {{.*}} %[[B]])
+// LLVM:   br label %[[EXIT_CLEANUP_SCOPE:.*]]
+// LLVM: [[EXIT_CLEANUP_SCOPE]]:
+// LLVM:   br label %[[DONE:.*]]
+// LLVM: [[UNWIND]]:
+// LLVM:   %[[EXN:.*]] = landingpad { ptr, i32 }
+// LLVM:                   cleanup
+// LLVM:   %[[EXN_PTR:.*]] = extractvalue { ptr, i32 } %[[EXN]], 0
+// LLVM:   %[[TYPEID:.*]] = extractvalue { ptr, i32 } %[[EXN]], 1
+// LLVM:   br label %[[EH_CLEANUP:.*]]
+// LLVM: [[EH_CLEANUP]]:
+// LLVM:   %[[EXN_PTR_PHI:.*]] = phi ptr [ %[[EXN_PTR]], %[[UNWIND]] ]
+// LLVM:   %[[TYPEID_PHI:.*]] = phi i32 [ %[[TYPEID]], %[[UNWIND]] ]
+// LLVM:   call void @_ZN1BD1Ev(ptr {{.*}} %[[B]])
+// LLVM:   %[[EXN_INSERT:.*]] = insertvalue { ptr, i32 } poison, ptr %[[EXN_PTR_PHI]], 0
+// LLVM:   %[[EXN_INSERT_2:.*]] = insertvalue { ptr, i32 } %[[EXN_INSERT]], i32 %[[TYPEID_PHI]], 1
+// LLVM:   resume { ptr, i32 } %[[EXN_INSERT_2]]
+// LLVM: [[DONE]]:
+// LLVM:   ret void
+
+// Note: OGCG devirtualizes the call. We don't do that yet in CIR.
+// OGCG: define {{.*}} void @_Z32call_virtual_fn_in_cleanup_scopev()
+// OGCG:   %[[B:.*]] = alloca %struct.B, align 8
+// OGCG:   %[[EXN_SLOT:.*]] = alloca ptr
+// OGCG:   %[[EHSELECTOR_SLOT:.*]] = alloca i32
+// OGCG:   call void @_ZN1BC2Ev(ptr {{.*}} %[[B]])
+// OGCG:   invoke void @_ZN1B1fEc(ptr {{.*}} %[[B]], i8 {{.*}} 99)
+// OGCG:           to label %[[INVOKE_CONT:.*]] unwind label %[[UNWIND:.*]]
+// OGCG: [[INVOKE_CONT]]:
+// OGCG:   call void @_ZN1BD1Ev(ptr {{.*}} %[[B]])
+// OGCG:   ret void
+// OGCG: [[UNWIND]]:
+// OGCG:   %[[EXN:.*]] = landingpad { ptr, i32 }
+// OGCG:           cleanup
+// OGCG:   %[[EXN_PTR:.*]] = extractvalue { ptr, i32 } %[[EXN]], 0
+// OGCG:   store ptr %[[EXN_PTR]], ptr %[[EXN_SLOT]]
+// OGCG:   %[[TYPEID:.*]] = extractvalue { ptr, i32 } %[[EXN]], 1
+// OGCG:   store i32 %[[TYPEID]], ptr %[[EHSELECTOR_SLOT]]
+// OGCG:   call void @_ZN1BD1Ev(ptr {{.*}} %[[B]])
+// OGCG:   br label %[[EH_RESUME:.*]]
+// OGCG: [[EH_RESUME]]:
+// OGCG:   %[[EXN:.*]] = load ptr, ptr %[[EXN_SLOT]]
+// OGCG:   %[[SEL:.*]] = load i32, ptr %[[EHSELECTOR_SLOT]]
+// OGCG:   %[[LPAD_VAL:.*]] = insertvalue { ptr, i32 } poison, ptr %[[EXN]], 0
+// OGCG:   %[[LPAD_VAL_1:.*]] = insertvalue { ptr, i32 } %[[LPAD_VAL]], i32 %[[SEL]], 1
+// OGCG:   resume { ptr, i32 } %[[LPAD_VAL_1]]
+  

--- a/clang/test/CIR/CodeGen/virtual-function-calls.cpp
+++ b/clang/test/CIR/CodeGen/virtual-function-calls.cpp
@@ -79,3 +79,50 @@ void f1(A *a) {
 // OGCG:   %[[FN_PTR_PTR:.*]] = getelementptr inbounds ptr, ptr %[[VPTR]], i64 0
 // OGCG:   %[[FN_PTR:.*]] = load ptr, ptr %[[FN_PTR_PTR]]
 // OGCG:   call void %[[FN_PTR]](ptr {{.*}} %[[A]], i8 {{.*}} 99)
+
+struct B {
+  ~B();
+  virtual void f(char);
+};
+
+void call_virtual_fn_in_cleanup_scope() {
+  B b;
+  b.f('c');
+}
+
+// CIR: cir.func {{.*}} @_Z32call_virtual_fn_in_cleanup_scopev()
+// CIR:   %[[B:.*]] = cir.alloca !rec_B, !cir.ptr<!rec_B>, ["b", init]
+// CIR:   cir.call @_ZN1BC2Ev(%[[B]])
+// CIR:   cir.cleanup.scope {
+// CIR:    %[[C_LITERAL:.*]] = cir.const #cir.int<99> : !s8i
+// CIR:    %[[VPTR_ADDR:.*]] = cir.vtable.get_vptr %[[B]] : !cir.ptr<!rec_B> -> !cir.ptr<!cir.vptr>
+// CIR:    %[[VPTR:.*]] = cir.load{{.*}} %[[VPTR_ADDR]]
+// CIR:    %[[FN_PTR_ADDR:.*]] = cir.vtable.get_virtual_fn_addr %[[VPTR]][0] : !cir.vptr -> !cir.ptr<!cir.ptr<!cir.func<(!cir.ptr<!rec_B>, !s8i)>>>
+// CIR:    %[[FN_PTR:.*]] = cir.load{{.*}} %[[FN_PTR_ADDR:.*]] : !cir.ptr<!cir.ptr<!cir.func<(!cir.ptr<!rec_B>, !s8i)>>>, !cir.ptr<!cir.func<(!cir.ptr<!rec_B>, !s8i)>>
+// CIR:    cir.call %[[FN_PTR]](%[[B]], %[[C_LITERAL]]) : (!cir.ptr<!cir.func<(!cir.ptr<!rec_B>, !s8i)>>, !cir.ptr<!rec_B> {{.*}}, !s8i {{.*}}) -> ()
+// CIR:    cir.yield
+// CIR:   } cleanup  normal {
+// CIR:    cir.call @_ZN1BD1Ev(%[[B]]) nothrow : (!cir.ptr<!rec_B> {{.*}}) -> ()
+// CIR:    cir.yield
+// CIR:   }
+
+// LLVM: define {{.*}} void @_Z32call_virtual_fn_in_cleanup_scopev()
+// LLVM:   %[[B:.*]] = alloca %struct.B
+// LLVM:   call void @_ZN1BC2Ev(ptr {{.*}} %[[B]])
+// LLVM:   br label %[[CLEANUP_SCOPE:.*]]
+// LLVM: [[CLEANUP_SCOPE]]:
+// LLVM:    %[[B_VPTR:.*]] = load ptr, ptr %[[B]]
+// LLVM:    %[[FN_PTR_ADDR:.*]] = getelementptr inbounds ptr, ptr %[[B_VPTR]], i32 0
+// LLVM:    %[[FN_PTR:.*]] = load ptr, ptr %[[FN_PTR_ADDR]]
+// LLVM:    call void %[[FN_PTR]](ptr {{.*}} %[[B]], i8 noundef 99)
+// LLVM:    br label %[[NORMAL_CLEANUP:.*]]
+// LLVM: [[NORMAL_CLEANUP]]:
+// LLVM:    call void @_ZN1BD1Ev(ptr {{.*}} %[[B]])
+
+// Note: OGCG devirtualizes the call. We don't do that yet in CIR.
+// OGCG: define {{.*}} void @_Z32call_virtual_fn_in_cleanup_scopev()
+// OGCG:   %[[B:.*]] = alloca %struct.B, align 8
+// OGCG:   call void @_ZN1BC2Ev(ptr {{.*}} %[[B]])
+// OGCG:   call void @_ZN1B1fEc(ptr {{.*}} %[[B]], i8 noundef signext 99)
+// OGCG:   call void @_ZN1BD1Ev(ptr {{.*}} %[[B]])
+  

--- a/clang/test/CIR/Transforms/flatten-try-op.cir
+++ b/clang/test/CIR/Transforms/flatten-try-op.cir
@@ -723,6 +723,55 @@ cir.func @test_try_multiple_typed_and_catch_all() {
 // CHECK:       ^[[RETURN]]:
 // CHECK:         cir.return
 
+// Test try-catch with an indirect (virtual) call in the try body.
+// The indirect call should become an indirect try_call.
+cir.func @test_try_indirect_call(%arg0 : !cir.ptr<!cir.func<(!cir.ptr<!rec_SomeClass>)>>,
+                                  %arg1 : !cir.ptr<!rec_SomeClass>) {
+  cir.scope {
+    cir.try {
+      cir.call %arg0(%arg1) : (!cir.ptr<!cir.func<(!cir.ptr<!rec_SomeClass>)>>, !cir.ptr<!rec_SomeClass>) -> ()
+      cir.yield
+    } catch all (%eh_token : !cir.eh_token) {
+      %catch_token, %exn_ptr = cir.begin_catch %eh_token : !cir.eh_token -> (!cir.catch_token, !cir.ptr<!cir.void>)
+      cir.end_catch %catch_token : !cir.catch_token
+      cir.yield
+    }
+  }
+  cir.return
+}
+
+// CHECK-LABEL: cir.func @test_try_indirect_call
+// CHECK-SAME:    (%[[FPTR:.*]]: !cir.ptr<!cir.func<(!cir.ptr<!rec_SomeClass>)>>, %[[OBJ:.*]]: !cir.ptr<!rec_SomeClass>)
+// CHECK:         cir.br ^[[SCOPE:bb[0-9]+]]
+//
+// CHECK:       ^[[SCOPE]]:
+// CHECK:         cir.br ^[[TRY_BODY:bb[0-9]+]]
+//
+// CHECK:       ^[[TRY_BODY]]:
+// CHECK:         cir.try_call %[[FPTR]](%[[OBJ]]) ^[[NORMAL:bb[0-9]+]], ^[[UNWIND:bb[0-9]+]] : (!cir.ptr<!cir.func<(!cir.ptr<!rec_SomeClass>)>>, !cir.ptr<!rec_SomeClass>) -> ()
+//
+// CHECK:       ^[[NORMAL]]:
+// CHECK:         cir.br ^[[CONTINUE:bb[0-9]+]]
+//
+// CHECK:       ^[[UNWIND]]:
+// CHECK:         %[[EH_TOK:.*]] = cir.eh.initiate : !cir.eh_token
+// CHECK:         cir.br ^[[DISPATCH:bb[0-9]+]](%[[EH_TOK]] : !cir.eh_token)
+//
+// CHECK:       ^[[DISPATCH]](%[[DISP_ET:.*]]: !cir.eh_token):
+// CHECK:         cir.eh.dispatch %[[DISP_ET]] : !cir.eh_token [
+// CHECK:           catch_all : ^[[CATCH_ALL:bb[0-9]+]]
+// CHECK:         ]
+//
+// CHECK:       ^[[CATCH_ALL]](%[[ET:.*]]: !cir.eh_token):
+// CHECK:         %{{.*}}, %{{.*}} = cir.begin_catch %[[ET]] : !cir.eh_token -> (!cir.catch_token, !cir.ptr<!void>)
+// CHECK:         cir.end_catch
+// CHECK:         cir.br ^[[CONTINUE]]
+//
+// CHECK:       ^[[CONTINUE]]:
+// CHECK:         cir.br ^[[SCOPE_EXIT:bb[0-9]+]]
+// CHECK:       ^[[SCOPE_EXIT]]:
+// CHECK:         cir.return
+
 cir.func private @mayThrow()
 cir.func private @ctor(!cir.ptr<!rec_SomeClass>)
 cir.func private @dtor(!cir.ptr<!rec_SomeClass>) attributes {nothrow}


### PR DESCRIPTION
We had a bug in the FlattenCFG pass where if an indirect call occurred within a cleanup scope that required exception handling, the indirect callee was not being preserved in the cir.try_call. This fixes that.