### PR TITLE
[mlir][LLVM] Add support for `ptrtoaddr`

### DIFF
--- a/mlir/include/mlir/Dialect/LLVMIR/LLVMOps.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/LLVMOps.td
@@ -629,6 +629,14 @@ def LLVM_IntToPtrOp : LLVM_DereferenceableCastOp<"inttoptr", "IntToPtr",
 def LLVM_PtrToIntOp : LLVM_CastOp<"ptrtoint", "PtrToInt",
                                   LLVM_ScalarOrVectorOf<LLVM_AnyPointer>,
                                   LLVM_ScalarOrVectorOf<AnySignlessInteger>>;
+
+def LLVM_PtrToAddrOp : LLVM_CastOp<"ptrtoaddr", "PtrToAddr",
+                                  LLVM_ScalarOrVectorOf<LLVM_AnyPointer>,
+                                  LLVM_ScalarOrVectorOf<AnySignlessInteger>> {
+  let llvmBuilder = "$res = builder.CreatePtrToAddr($arg);";
+  let hasVerifier = 1;
+}
+
 def LLVM_SExtOp : LLVM_CastOp<"sext", "SExt",
                               LLVM_ScalarOrVectorOf<AnySignlessInteger>,
                               LLVM_ScalarOrVectorOf<AnySignlessInteger>> {

--- a/mlir/include/mlir/Dialect/LLVMIR/LLVMOps.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/LLVMOps.td
@@ -640,10 +640,15 @@ def LLVM_PtrToAddrOp : LLVM_CastOp<"ptrtoaddr", "PtrToAddr",
     Operation mirroring LLVM's `ptrtoaddr` operation.
 
     This operation casts a pointer (or a vector of pointers) to an integer
-    (or a vector of integers).
+    (or a vector of integers) without capturing the provenance of the pointer.
+    Therefore, an integer returned or derived from `llvm.ptrtoaddr` does not
+    create a legal-to-access pointer when used in `llvm.inttoptr`.
+    Code that only care about the address value of a pointer
+    (e.g. pointer subtraction) should prefer `llvm.ptrtoaddr` over
+    `llvm.ptrtoint`.
+
     The integer type used as the result type is required to be equal in width
     to the pointer type as specified in the data layout.
-
     Use the `llvm-target-to-data-layout` pass to derive an MLIR datalayout from
     an LLVM datalayout.
 

--- a/mlir/include/mlir/Dialect/LLVMIR/LLVMOps.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/LLVMOps.td
@@ -635,6 +635,35 @@ def LLVM_PtrToAddrOp : LLVM_CastOp<"ptrtoaddr", "PtrToAddr",
                                   LLVM_ScalarOrVectorOf<AnySignlessInteger>> {
   let llvmBuilder = "$res = builder.CreatePtrToAddr($arg);";
   let hasVerifier = 1;
+
+  let description = [{
+    Operation mirroring LLVM's `ptrtoaddr` operation.
+
+    This operation casts a pointer (or a vector of pointers) to an integer
+    (or a vector of integers).
+    The integer type used as the result type is required to be equal in width
+    to the pointer type as specified in the data layout.
+
+    Use the `llvm-target-to-data-layout` pass to derive an MLIR datalayout from
+    an LLVM datalayout.
+
+    Examples:
+    ```
+    llvm.func @default_64_bit_ptrtoaddr(%arg0 : !llvm.ptr) -> i64 {
+      %0 = llvm.ptrtoaddr %arg0 : !llvm.ptr to i64
+      llvm.return i64
+    }
+
+    module attributes { dlti.dl_spec = #dlti.dl_spec<
+      #dlti.dl_entry<!llvm.ptr, dense<[/*size=*/32, 32, 64]> : vector<3xi64>>
+    >} {
+      llvm.func @datalayout_32_bit(%arg0 : !llvm.ptr) -> i32 {
+        %0 = llvm.ptrtoaddr %arg0 : !llvm.ptr to i32
+        llvm.return %0 : i32
+      }
+    }
+    ```
+  }];
 }
 
 def LLVM_SExtOp : LLVM_CastOp<"sext", "SExt",

--- a/mlir/include/mlir/Dialect/LLVMIR/LLVMOps.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/LLVMOps.td
@@ -633,6 +633,8 @@ def LLVM_PtrToIntOp : LLVM_CastOp<"ptrtoint", "PtrToInt",
 def LLVM_PtrToAddrOp : LLVM_CastOp<"ptrtoaddr", "PtrToAddr",
                                   LLVM_ScalarOrVectorOf<LLVM_AnyPointer>,
                                   LLVM_ScalarOrVectorOf<AnySignlessInteger>> {
+  // Overwrite the base class llvmBuilder since the instruction doesn't take a
+  // destination type argument.
   let llvmBuilder = "$res = builder.CreatePtrToAddr($arg);";
   let hasVerifier = 1;
 
@@ -643,7 +645,7 @@ def LLVM_PtrToAddrOp : LLVM_CastOp<"ptrtoaddr", "PtrToAddr",
     (or a vector of integers) without capturing the provenance of the pointer.
     Therefore, an integer returned or derived from `llvm.ptrtoaddr` does not
     create a legal-to-access pointer when used in `llvm.inttoptr`.
-    Code that only care about the address value of a pointer
+    Code that only cares about the address value of a pointer
     (e.g. pointer subtraction) should prefer `llvm.ptrtoaddr` over
     `llvm.ptrtoint`.
 

--- a/mlir/lib/Dialect/LLVMIR/IR/LLVMDialect.cpp
+++ b/mlir/lib/Dialect/LLVMIR/IR/LLVMDialect.cpp
@@ -3854,6 +3854,21 @@ LogicalResult LLVM::BitcastOp::verify() {
   return success();
 }
 
+LogicalResult LLVM::PtrToAddrOp::verify() {
+  auto pointerType =
+      cast<LLVM::LLVMPointerType>(extractVectorElementType(getArg().getType()));
+  auto integerType = cast<IntegerType>(extractVectorElementType(getType()));
+
+  auto dataLayout = DataLayout::closest(*this);
+  unsigned width = dataLayout.getTypeSizeInBits(pointerType);
+  if (width != integerType.getWidth())
+    return emitOpError("bit-width of integer result type ")
+           << integerType << " must match the pointer bitwidth (" << width
+           << ") specified in the datalayout";
+
+  return success();
+}
+
 //===----------------------------------------------------------------------===//
 // Folder for LLVM::AddrSpaceCastOp
 //===----------------------------------------------------------------------===//

--- a/mlir/lib/Dialect/LLVMIR/IR/LLVMDialect.cpp
+++ b/mlir/lib/Dialect/LLVMIR/IR/LLVMDialect.cpp
@@ -3860,10 +3860,11 @@ LogicalResult LLVM::PtrToAddrOp::verify() {
   auto integerType = cast<IntegerType>(extractVectorElementType(getType()));
 
   auto dataLayout = DataLayout::closest(*this);
-  unsigned width = dataLayout.getTypeSizeInBits(pointerType);
+  std::optional<unsigned> width = dataLayout.getTypeIndexBitwidth(pointerType);
+  assert(width && "pointers always return an index bitwidth");
   if (width != integerType.getWidth())
     return emitOpError("bit-width of integer result type ")
-           << integerType << " must match the pointer bitwidth (" << width
+           << integerType << " must match the pointer bitwidth (" << *width
            << ") specified in the datalayout";
 
   return success();

--- a/mlir/test/Dialect/LLVMIR/invalid.mlir
+++ b/mlir/test/Dialect/LLVMIR/invalid.mlir
@@ -2072,3 +2072,21 @@ module {
   // expected-error@+1 {{'llvm.blockaddress' op expects an existing block label target in the referenced function}}
   %0 = llvm.blockaddress <function = @missing_func, tag = <id = 1>> : !llvm.ptr
 }
+
+// -----
+
+llvm.func @too_narrow_ptr_to_addr(%arg0 : !llvm.ptr) -> () {
+  // expected-error@+1 {{'llvm.ptrtoaddr' op bit-width of integer result type 'i32' must match the pointer bitwidth (64) specified in the datalayout}}
+  %0 = llvm.ptrtoaddr %arg0 : !llvm.ptr to i32
+}
+
+// -----
+
+module attributes { dlti.dl_spec = #dlti.dl_spec<
+  #dlti.dl_entry<!llvm.ptr, dense<[32, 32, 64]> : vector<3xi64>>
+>} {
+  llvm.func @too_narrow_ptr_to_addr(%arg0 : !llvm.ptr) -> () {
+    // expected-error@+1 {{'llvm.ptrtoaddr' op bit-width of integer result type 'i64' must match the pointer bitwidth (32) specified in the datalayout}}
+    %0 = llvm.ptrtoaddr %arg0 : !llvm.ptr to i64
+  }
+}

--- a/mlir/test/Dialect/LLVMIR/roundtrip.mlir
+++ b/mlir/test/Dialect/LLVMIR/roundtrip.mlir
@@ -243,8 +243,10 @@ func.func @ops(%arg0: i32, %arg1: f32,
 //
 // CHECK: %[[PTR:.*]] = llvm.inttoptr %[[I32]] : i32 to !llvm.ptr
 // CHECK: %{{.*}} = llvm.ptrtoint %[[PTR]] : !llvm.ptr to i32
+// CHECK: %{{.*}} = llvm.ptrtoaddr %[[PTR]] : !llvm.ptr to i64
   %25 = llvm.inttoptr %arg0 : i32 to !llvm.ptr
   %26 = llvm.ptrtoint %25 : !llvm.ptr to i32
+  %a26 = llvm.ptrtoaddr %25 : !llvm.ptr to i64
 
 // Extended and Quad floating point
 //

--- a/mlir/test/Dialect/LLVMIR/roundtrip.mlir
+++ b/mlir/test/Dialect/LLVMIR/roundtrip.mlir
@@ -247,6 +247,8 @@ func.func @ops(%arg0: i32, %arg1: f32,
   %25 = llvm.inttoptr %arg0 : i32 to !llvm.ptr
   %26 = llvm.ptrtoint %25 : !llvm.ptr to i32
   %a26 = llvm.ptrtoaddr %25 : !llvm.ptr to i64
+  %vp = llvm.mlir.poison : vector<3 x !llvm.ptr>
+  %va26 = llvm.ptrtoaddr %vp : vector<3 x !llvm.ptr> to vector<3 x i64>
 
 // Extended and Quad floating point
 //

--- a/mlir/test/Target/LLVMIR/Import/instructions.ll
+++ b/mlir/test/Target/LLVMIR/Import/instructions.ll
@@ -184,10 +184,12 @@ define void @integer_extension_and_truncation(i32 %arg1) {
 define ptr @pointer_casts(ptr %arg1, i64 %arg2) {
   ; CHECK:  %[[NULL:[0-9]+]] = llvm.mlir.zero : !llvm.ptr
   ; CHECK:  llvm.ptrtoint %[[ARG1]] : !llvm.ptr to i64
+  ; CHECK:  llvm.ptrtoaddr %[[ARG1]] : !llvm.ptr to i64
   ; CHECK:  llvm.inttoptr %[[ARG2]] : i64 to !llvm.ptr
   ; CHECK:  llvm.bitcast %[[ARG1]] : !llvm.ptr to !llvm.ptr
   ; CHECK:  llvm.return %[[NULL]] : !llvm.ptr
   %1 = ptrtoint ptr %arg1 to i64
+  %p = ptrtoaddr ptr %arg1 to i64
   %2 = inttoptr i64 %arg2 to ptr
   %3 = bitcast ptr %arg1 to ptr
   ret ptr null

--- a/mlir/test/Target/LLVMIR/Import/instructions.ll
+++ b/mlir/test/Target/LLVMIR/Import/instructions.ll
@@ -181,15 +181,18 @@ define void @integer_extension_and_truncation(i32 %arg1) {
 ; CHECK-LABEL: @pointer_casts
 ; CHECK-SAME:  %[[ARG1:[a-zA-Z0-9]+]]
 ; CHECK-SAME:  %[[ARG2:[a-zA-Z0-9]+]]
-define ptr @pointer_casts(ptr %arg1, i64 %arg2) {
+; CHECK-SAME:  %[[ARG3:[a-zA-Z0-9]+]]
+define ptr @pointer_casts(ptr %arg1, i64 %arg2, <3 x ptr> %arg3) {
   ; CHECK:  %[[NULL:[0-9]+]] = llvm.mlir.zero : !llvm.ptr
   ; CHECK:  llvm.ptrtoint %[[ARG1]] : !llvm.ptr to i64
   ; CHECK:  llvm.ptrtoaddr %[[ARG1]] : !llvm.ptr to i64
+  ; CHECK:  llvm.ptrtoaddr %[[ARG3]] : vector<3x!llvm.ptr> to vector<3xi64>
   ; CHECK:  llvm.inttoptr %[[ARG2]] : i64 to !llvm.ptr
   ; CHECK:  llvm.bitcast %[[ARG1]] : !llvm.ptr to !llvm.ptr
   ; CHECK:  llvm.return %[[NULL]] : !llvm.ptr
   %1 = ptrtoint ptr %arg1 to i64
   %p = ptrtoaddr ptr %arg1 to i64
+  %vp = ptrtoaddr <3 x ptr> %arg3 to <3 x i64>
   %2 = inttoptr i64 %arg2 to ptr
   %3 = bitcast ptr %arg1 to ptr
   ret ptr null

--- a/mlir/test/Target/LLVMIR/llvmir.mlir
+++ b/mlir/test/Target/LLVMIR/llvmir.mlir
@@ -1283,6 +1283,15 @@ llvm.func @intpointerconversion(%arg0 : i32) -> i32 {
   llvm.return %2 : i32
 }
 
+// CHECK-LABEL: @addrpointerconversion
+// CHECK-SAME: %[[ARG0:[[:alnum:]]+]]
+llvm.func @addrpointerconversion(%arg0 : !llvm.ptr) -> i64 {
+  // CHECK: %[[PTR:.*]] = ptrtoaddr ptr %[[ARG0]] to i64
+  // CHECK-NEXT: ret i64 %[[PTR]]
+  %1 = llvm.ptrtoaddr %arg0 : !llvm.ptr to i64
+  llvm.return %1 : i64
+}
+
 llvm.func @fpconversion(%arg0 : i32) -> i32 {
 // CHECK:      %2 = sitofp i32 %0 to float
 // CHECK-NEXT: %3 = fptosi float %2 to i32

--- a/mlir/test/Target/LLVMIR/llvmir.mlir
+++ b/mlir/test/Target/LLVMIR/llvmir.mlir
@@ -1283,13 +1283,22 @@ llvm.func @intpointerconversion(%arg0 : i32) -> i32 {
   llvm.return %2 : i32
 }
 
-// CHECK-LABEL: @addrpointerconversion
+// CHECK-LABEL: @addrpointerconversion_scalar
 // CHECK-SAME: %[[ARG0:[[:alnum:]]+]]
-llvm.func @addrpointerconversion(%arg0 : !llvm.ptr) -> i64 {
+llvm.func @addrpointerconversion_scalar(%arg0 : !llvm.ptr) -> i64 {
   // CHECK: %[[PTR:.*]] = ptrtoaddr ptr %[[ARG0]] to i64
   // CHECK-NEXT: ret i64 %[[PTR]]
   %1 = llvm.ptrtoaddr %arg0 : !llvm.ptr to i64
   llvm.return %1 : i64
+}
+
+// CHECK-LABEL: @addrpointerconversion_vector
+// CHECK-SAME: %[[ARG0:[[:alnum:]]+]]
+llvm.func @addrpointerconversion_vector(%arg0 : vector<3x!llvm.ptr>) -> vector<3x i64> {
+  // CHECK: %[[PTR:.*]] = ptrtoaddr <3 x ptr> %[[ARG0]] to <3 x i64>
+  // CHECK-NEXT: ret <3 x i64> %[[PTR]]
+  %1 = llvm.ptrtoaddr %arg0 : vector<3x!llvm.ptr> to vector<3x i64>
+  llvm.return %1 : vector<3x i64>
 }
 
 llvm.func @fpconversion(%arg0 : i32) -> i32 {

--- a/mlir/test/Target/LLVMIR/llvmir.mlir
+++ b/mlir/test/Target/LLVMIR/llvmir.mlir
@@ -1286,8 +1286,8 @@ llvm.func @intpointerconversion(%arg0 : i32) -> i32 {
 // CHECK-LABEL: @addrpointerconversion_scalar
 // CHECK-SAME: %[[ARG0:[[:alnum:]]+]]
 llvm.func @addrpointerconversion_scalar(%arg0 : !llvm.ptr) -> i64 {
-  // CHECK: %[[PTR:.*]] = ptrtoaddr ptr %[[ARG0]] to i64
-  // CHECK-NEXT: ret i64 %[[PTR]]
+// CHECK:      %[[PTR:.*]] = ptrtoaddr ptr %[[ARG0]] to i64
+// CHECK-NEXT: ret i64 %[[PTR]]
   %1 = llvm.ptrtoaddr %arg0 : !llvm.ptr to i64
   llvm.return %1 : i64
 }
@@ -1295,8 +1295,8 @@ llvm.func @addrpointerconversion_scalar(%arg0 : !llvm.ptr) -> i64 {
 // CHECK-LABEL: @addrpointerconversion_vector
 // CHECK-SAME: %[[ARG0:[[:alnum:]]+]]
 llvm.func @addrpointerconversion_vector(%arg0 : vector<3x!llvm.ptr>) -> vector<3x i64> {
-  // CHECK: %[[PTR:.*]] = ptrtoaddr <3 x ptr> %[[ARG0]] to <3 x i64>
-  // CHECK-NEXT: ret <3 x i64> %[[PTR]]
+// CHECK:      %[[PTR:.*]] = ptrtoaddr <3 x ptr> %[[ARG0]] to <3 x i64>
+// CHECK-NEXT: ret <3 x i64> %[[PTR]]
   %1 = llvm.ptrtoaddr %arg0 : vector<3x!llvm.ptr> to vector<3x i64>
   llvm.return %1 : vector<3x i64>
 }


### PR DESCRIPTION
The `ptrtoaddr` op is akin to `ptrtoint` with some important differences:
* It does not capture the provenance of the pointer, meaning a pointer does not escape and subsequent `inttoptr` don't make a legal pointer. LLVM can then assume the pointer never escaped, which helps alias analysis.
* It does not support arbitrary integer types, but only exactly the integer type that is equal in width to the pointer type as specified by the data layout.

This PR adds the op the MLIR dialect and adds the corresponding verification for the datalayout property.