### PR TITLE
[CIR] Fix convertSideEffectForCall header/definition signature mismatch

### DIFF
--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.h
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.h
@@ -33,7 +33,7 @@ mlir::LLVM::Linkage convertLinkage(cir::GlobalLinkageKind linkage);
 void convertSideEffectForCall(mlir::Operation *callOp, bool isNothrow,
                               cir::SideEffect sideEffect,
                               mlir::LLVM::MemoryEffectsAttr &memoryEffect,
-                              bool &noUnwind, bool &willReturn);
+                              bool &noUnwind, bool &willReturn, bool &noReturn);
 
 struct LLVMBlockAddressInfo {
   // Get the next tag index


### PR DESCRIPTION
Add missing bool &noReturn parameter to the declaration in
LowerToLLVM.h to match the definition in LowerToLLVM.cpp.