### PR TITLE
[JSON] Consistently reset moved-from object

### DIFF
--- a/llvm/lib/Support/JSON.cpp
+++ b/llvm/lib/Support/JSON.cpp
@@ -145,6 +145,8 @@ void Value::moveFrom(const Value &&M) {
     create<json::Array>(std::move(M.as<json::Array>()));
     break;
   }
+  const_cast<Value&>(M).destroy();
+  M.Type = T_Null;
 }
 
 void Value::destroy() {

--- a/llvm/lib/Support/JSON.cpp
+++ b/llvm/lib/Support/JSON.cpp
@@ -137,15 +137,12 @@ void Value::moveFrom(const Value &&M) {
     break;
   case T_String:
     create<std::string>(std::move(M.as<std::string>()));
-    M.Type = T_Null;
     break;
   case T_Object:
     create<json::Object>(std::move(M.as<json::Object>()));
-    M.Type = T_Null;
     break;
   case T_Array:
     create<json::Array>(std::move(M.as<json::Array>()));
-    M.Type = T_Null;
     break;
   }
 }

--- a/llvm/lib/Support/JSON.cpp
+++ b/llvm/lib/Support/JSON.cpp
@@ -145,7 +145,7 @@ void Value::moveFrom(const Value &&M) {
     create<json::Array>(std::move(M.as<json::Array>()));
     break;
   }
-  const_cast<Value&>(M).destroy();
+  const_cast<Value &>(M).destroy();
   M.Type = T_Null;
 }
 

--- a/llvm/unittests/Support/JSONTest.cpp
+++ b/llvm/unittests/Support/JSONTest.cpp
@@ -12,6 +12,7 @@
 
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
+#include <utility>
 
 namespace llvm {
 namespace json {
@@ -50,6 +51,18 @@ TEST(JSONTest, Constructors) {
   EXPECT_EQ("2.5", s(std::optional<double>(2.5)));
   EXPECT_EQ("[[2.5,null]]", s(std::vector<std::vector<std::optional<double>>>{
                                 {2.5, std::nullopt}}));
+}
+
+TEST(JSONTest, Move) {
+  std::string S = "Hello";
+  Value CopyS = S;
+  EXPECT_EQ(R"("Hello")", s(Value(std::move(CopyS))));
+  EXPECT_EQ("null", s(CopyS));
+
+  int N = 5;
+  Value CopyN = N;
+  EXPECT_EQ("5", s(Value(std::move(CopyN))));
+  EXPECT_EQ("null", s(CopyN));
 }
 
 TEST(JSONTest, StringOwnership) {


### PR DESCRIPTION
Before the patch moved from object was in consistent state.
For some types it resets contents and switch to T_Null, for others
it preserves type and value.

So make sure to set T_Null for all.

When we set T_Null we need to destroy the value.
It's important for particular types, like std::string. With
Asan it must unpoison SSO buffer.

Fixes false container overflows after #184693:
https://lab.llvm.org/buildbot/#/builders/169/builds/20655/steps/11/logs/stdio