### PR TITLE
[AMDGPU][MC] Allow the nolds modifier

### DIFF
--- a/llvm/lib/Target/AMDGPU/AsmParser/AMDGPUAsmParser.cpp
+++ b/llvm/lib/Target/AMDGPU/AsmParser/AMDGPUAsmParser.cpp
@@ -10520,7 +10520,7 @@ ParseStatus AMDGPUAsmParser::parseCustomOperand(OperandVector &Operands,
   case MCK_idxen:
     return parseTokenOp("idxen", Operands);
   case MCK_lds:
-    return parseTokenOp("lds", Operands);
+    return parseNamedBit("lds", Operands, AMDGPUOperand::ImmTyLDS, true);
   case MCK_offen:
     return parseTokenOp("offen", Operands);
   case MCK_off:

--- a/llvm/lib/Target/AMDGPU/AsmParser/AMDGPUAsmParser.cpp
+++ b/llvm/lib/Target/AMDGPU/AsmParser/AMDGPUAsmParser.cpp
@@ -10520,7 +10520,8 @@ ParseStatus AMDGPUAsmParser::parseCustomOperand(OperandVector &Operands,
   case MCK_idxen:
     return parseTokenOp("idxen", Operands);
   case MCK_lds:
-    return parseNamedBit("lds", Operands, AMDGPUOperand::ImmTyLDS, true);
+    return parseNamedBit("lds", Operands, AMDGPUOperand::ImmTyLDS,
+                         /*IgnoreNegative=*/true);
   case MCK_offen:
     return parseTokenOp("offen", Operands);
   case MCK_off:

--- a/llvm/lib/Target/AMDGPU/SIInstrInfo.td
+++ b/llvm/lib/Target/AMDGPU/SIInstrInfo.td
@@ -1254,6 +1254,7 @@ def Offset1 : NamedIntOperand<"offset1">;
 }
 
 def gds : NamedBitOperand<"gds", "GDS">;
+def lds : NamedBitOperand<"lds", "LDS", 1>;
 
 def omod : CustomOperand<1, "OModSI">;
 def omod0 : DefaultOperand<omod, 0>;

--- a/llvm/test/MC/AMDGPU/gfx10_asm_mubuf.s
+++ b/llvm/test/MC/AMDGPU/gfx10_asm_mubuf.s
@@ -1107,6 +1107,9 @@ buffer_gl1_inv
 buffer_load_dword v255, off, s[8:11], s3 offset:4095
 // GFX10: buffer_load_dword v255, off, s[8:11], s3 offset:4095 ; encoding: [0xff,0x0f,0x30,0xe0,0x00,0xff,0x02,0x03]
 
+buffer_load_dword v255, off, s[8:11], s3 offset:4095 nolds
+// GFX10: buffer_load_dword v255, off, s[8:11], s3 offset:4095 ; encoding: [0xff,0x0f,0x30,0xe0,0x00,0xff,0x02,0x03]
+
 buffer_load_dword v5, off, s[12:15], s3 offset:4095
 // GFX10: buffer_load_dword v5, off, s[12:15], s3 offset:4095 ; encoding: [0xff,0x0f,0x30,0xe0,0x00,0x05,0x03,0x03]
 
@@ -1338,6 +1341,9 @@ buffer_load_format_d16_xyzw v[1:2], off, s[4:7], s1
 buffer_load_format_x v255, off, s[8:11], s3 offset:4095
 // GFX10: buffer_load_format_x v255, off, s[8:11], s3 offset:4095 ; encoding: [0xff,0x0f,0x00,0xe0,0x00,0xff,0x02,0x03]
 
+buffer_load_format_x v255, off, s[8:11], s3 offset:4095 nolds
+// GFX10: buffer_load_format_x v255, off, s[8:11], s3 offset:4095 ; encoding: [0xff,0x0f,0x00,0xe0,0x00,0xff,0x02,0x03]
+
 buffer_load_format_x v5, off, s[12:15], s3 offset:4095
 // GFX10: buffer_load_format_x v5, off, s[12:15], s3 offset:4095 ; encoding: [0xff,0x0f,0x00,0xe0,0x00,0x05,0x03,0x03]
 
@@ -1554,6 +1560,9 @@ buffer_load_format_xyzw v[5:8], v0, s[8:11], s3 offen offset:4095
 buffer_load_sbyte v255, off, s[8:11], s3 offset:4095
 // GFX10: buffer_load_sbyte v255, off, s[8:11], s3 offset:4095 ; encoding: [0xff,0x0f,0x24,0xe0,0x00,0xff,0x02,0x03]
 
+buffer_load_sbyte v255, off, s[8:11], s3 offset:4095 nolds
+// GFX10: buffer_load_sbyte v255, off, s[8:11], s3 offset:4095 ; encoding: [0xff,0x0f,0x24,0xe0,0x00,0xff,0x02,0x03]
+
 buffer_load_sbyte v5, off, s[12:15], s3 offset:4095
 // GFX10: buffer_load_sbyte v5, off, s[12:15], s3 offset:4095 ; encoding: [0xff,0x0f,0x24,0xe0,0x00,0x05,0x03,0x03]
 
@@ -1606,6 +1615,9 @@ buffer_load_sbyte v5, v0, s[8:11], s3 offen offset:4095
 // GFX10: buffer_load_sbyte v5, v0, s[8:11], s3 offen offset:4095 ; encoding: [0xff,0x1f,0x24,0xe0,0x00,0x05,0x02,0x03]
 
 buffer_load_sshort v255, off, s[8:11], s3 offset:4095
+// GFX10: buffer_load_sshort v255, off, s[8:11], s3 offset:4095 ; encoding: [0xff,0x0f,0x2c,0xe0,0x00,0xff,0x02,0x03]
+
+buffer_load_sshort v255, off, s[8:11], s3 offset:4095 nolds
 // GFX10: buffer_load_sshort v255, off, s[8:11], s3 offset:4095 ; encoding: [0xff,0x0f,0x2c,0xe0,0x00,0xff,0x02,0x03]
 
 buffer_load_sshort v5, off, s[12:15], s3 offset:4095
@@ -1662,6 +1674,9 @@ buffer_load_sshort v5, v0, s[8:11], s3 offen offset:4095
 buffer_load_ubyte v255, off, s[8:11], s3 offset:4095
 // GFX10: buffer_load_ubyte v255, off, s[8:11], s3 offset:4095 ; encoding: [0xff,0x0f,0x20,0xe0,0x00,0xff,0x02,0x03]
 
+buffer_load_ubyte v255, off, s[8:11], s3 offset:4095 nolds
+// GFX10: buffer_load_ubyte v255, off, s[8:11], s3 offset:4095 ; encoding: [0xff,0x0f,0x20,0xe0,0x00,0xff,0x02,0x03]
+
 buffer_load_ubyte v5, off, s[12:15], s3 offset:4095
 // GFX10: buffer_load_ubyte v5, off, s[12:15], s3 offset:4095 ; encoding: [0xff,0x0f,0x20,0xe0,0x00,0x05,0x03,0x03]
 
@@ -1714,6 +1729,9 @@ buffer_load_ubyte v5, v0, s[8:11], s3 offen offset:4095
 // GFX10: buffer_load_ubyte v5, v0, s[8:11], s3 offen offset:4095 ; encoding: [0xff,0x1f,0x20,0xe0,0x00,0x05,0x02,0x03]
 
 buffer_load_ushort v255, off, s[8:11], s3 offset:4095
+// GFX10: buffer_load_ushort v255, off, s[8:11], s3 offset:4095 ; encoding: [0xff,0x0f,0x28,0xe0,0x00,0xff,0x02,0x03]
+
+buffer_load_ushort v255, off, s[8:11], s3 offset:4095 nolds
 // GFX10: buffer_load_ushort v255, off, s[8:11], s3 offset:4095 ; encoding: [0xff,0x0f,0x28,0xe0,0x00,0xff,0x02,0x03]
 
 buffer_load_ushort v5, off, s[12:15], s3 offset:4095

--- a/llvm/test/MC/AMDGPU/gfx7_asm_mubuf.s
+++ b/llvm/test/MC/AMDGPU/gfx7_asm_mubuf.s
@@ -3172,6 +3172,9 @@ buffer_atomic_xor_x2 v[254:255], off, s[12:15], s4 offset:4095
 buffer_load_dword v255, off, s[8:11], s3 offset:4095
 // CHECK: buffer_load_dword v255, off, s[8:11], s3 offset:4095 ; encoding: [0xff,0x0f,0x30,0xe0,0x00,0xff,0x02,0x03]
 
+buffer_load_dword v255, off, s[8:11], s3 offset:4095 nolds
+// CHECK: buffer_load_dword v255, off, s[8:11], s3 offset:4095 ; encoding: [0xff,0x0f,0x30,0xe0,0x00,0xff,0x02,0x03]
+
 buffer_load_dword v5, off, s[100:103], s3 offset:4095
 // CHECK: buffer_load_dword v5, off, s[100:103], s3 offset:4095 ; encoding: [0xff,0x0f,0x30,0xe0,0x00,0x05,0x19,0x03]
 
@@ -3566,6 +3569,9 @@ buffer_load_dwordx4 v[5:8], v[0:1], s[8:11], s3 addr64 offset:4095
 // CHECK: buffer_load_dwordx4 v[5:8], v[0:1], s[8:11], s3 addr64 offset:4095 ; encoding: [0xff,0x8f,0x38,0xe0,0x00,0x05,0x02,0x03]
 
 buffer_load_format_x v255, off, s[8:11], s3 offset:4095
+// CHECK: buffer_load_format_x v255, off, s[8:11], s3 offset:4095 ; encoding: [0xff,0x0f,0x00,0xe0,0x00,0xff,0x02,0x03]
+
+buffer_load_format_x v255, off, s[8:11], s3 offset:4095 nolds
 // CHECK: buffer_load_format_x v255, off, s[8:11], s3 offset:4095 ; encoding: [0xff,0x0f,0x00,0xe0,0x00,0xff,0x02,0x03]
 
 buffer_load_format_x v5, off, s[100:103], s3 offset:4095
@@ -3964,6 +3970,9 @@ buffer_load_format_xyzw v[5:8], v[0:1], s[8:11], s3 addr64 offset:4095
 buffer_load_sbyte v255, off, s[8:11], s3 offset:4095
 // CHECK: buffer_load_sbyte v255, off, s[8:11], s3 offset:4095 ; encoding: [0xff,0x0f,0x24,0xe0,0x00,0xff,0x02,0x03]
 
+buffer_load_sbyte v255, off, s[8:11], s3 offset:4095 nolds
+// CHECK: buffer_load_sbyte v255, off, s[8:11], s3 offset:4095 ; encoding: [0xff,0x0f,0x24,0xe0,0x00,0xff,0x02,0x03]
+
 buffer_load_sbyte v5, off, s[100:103], s3 offset:4095
 // CHECK: buffer_load_sbyte v5, off, s[100:103], s3 offset:4095 ; encoding: [0xff,0x0f,0x24,0xe0,0x00,0x05,0x19,0x03]
 
@@ -4061,6 +4070,9 @@ buffer_load_sbyte v5, v[0:1], s[8:11], s3 addr64 offset:4095
 // CHECK: buffer_load_sbyte v5, v[0:1], s[8:11], s3 addr64 offset:4095 ; encoding: [0xff,0x8f,0x24,0xe0,0x00,0x05,0x02,0x03]
 
 buffer_load_sshort v255, off, s[8:11], s3 offset:4095
+// CHECK: buffer_load_sshort v255, off, s[8:11], s3 offset:4095 ; encoding: [0xff,0x0f,0x2c,0xe0,0x00,0xff,0x02,0x03]
+
+buffer_load_sshort v255, off, s[8:11], s3 offset:4095 nolds
 // CHECK: buffer_load_sshort v255, off, s[8:11], s3 offset:4095 ; encoding: [0xff,0x0f,0x2c,0xe0,0x00,0xff,0x02,0x03]
 
 buffer_load_sshort v5, off, s[100:103], s3 offset:4095
@@ -4162,6 +4174,9 @@ buffer_load_sshort v5, v[0:1], s[8:11], s3 addr64 offset:4095
 buffer_load_ubyte v255, off, s[8:11], s3 offset:4095
 // CHECK: buffer_load_ubyte v255, off, s[8:11], s3 offset:4095 ; encoding: [0xff,0x0f,0x20,0xe0,0x00,0xff,0x02,0x03]
 
+buffer_load_ubyte v255, off, s[8:11], s3 offset:4095 nolds
+// CHECK: buffer_load_ubyte v255, off, s[8:11], s3 offset:4095 ; encoding: [0xff,0x0f,0x20,0xe0,0x00,0xff,0x02,0x03]
+
 buffer_load_ubyte v5, off, s[100:103], s3 offset:4095
 // CHECK: buffer_load_ubyte v5, off, s[100:103], s3 offset:4095 ; encoding: [0xff,0x0f,0x20,0xe0,0x00,0x05,0x19,0x03]
 
@@ -4259,6 +4274,9 @@ buffer_load_ubyte v5, v[0:1], s[8:11], s3 addr64 offset:4095
 // CHECK: buffer_load_ubyte v5, v[0:1], s[8:11], s3 addr64 offset:4095 ; encoding: [0xff,0x8f,0x20,0xe0,0x00,0x05,0x02,0x03]
 
 buffer_load_ushort v255, off, s[8:11], s3 offset:4095
+// CHECK: buffer_load_ushort v255, off, s[8:11], s3 offset:4095 ; encoding: [0xff,0x0f,0x28,0xe0,0x00,0xff,0x02,0x03]
+
+buffer_load_ushort v255, off, s[8:11], s3 offset:4095 nolds
 // CHECK: buffer_load_ushort v255, off, s[8:11], s3 offset:4095 ; encoding: [0xff,0x0f,0x28,0xe0,0x00,0xff,0x02,0x03]
 
 buffer_load_ushort v5, off, s[100:103], s3 offset:4095

--- a/llvm/test/MC/AMDGPU/gfx8_asm_mubuf.s
+++ b/llvm/test/MC/AMDGPU/gfx8_asm_mubuf.s
@@ -2503,6 +2503,9 @@ buffer_load_dword off, s[8:11], s3 offset:4095 lds
 buffer_load_dword v255, off, s[8:11], s3 offset:4095
 // CHECK: buffer_load_dword v255, off, s[8:11], s3 offset:4095 ; encoding: [0xff,0x0f,0x50,0xe0,0x00,0xff,0x02,0x03]
 
+buffer_load_dword v255, off, s[8:11], s3 offset:4095 nolds
+// CHECK: buffer_load_dword v255, off, s[8:11], s3 offset:4095 ; encoding: [0xff,0x0f,0x50,0xe0,0x00,0xff,0x02,0x03]
+
 buffer_load_dword v5, off, s[12:15], s3 offset:4095
 // CHECK: buffer_load_dword v5, off, s[12:15], s3 offset:4095 ; encoding: [0xff,0x0f,0x50,0xe0,0x00,0x05,0x03,0x03]
 
@@ -3274,6 +3277,9 @@ buffer_load_format_x off, s[8:11], s3 offset:4095 lds
 buffer_load_format_x v255, off, s[8:11], s3 offset:4095
 // CHECK: buffer_load_format_x v255, off, s[8:11], s3 offset:4095 ; encoding: [0xff,0x0f,0x00,0xe0,0x00,0xff,0x02,0x03]
 
+buffer_load_format_x v255, off, s[8:11], s3 offset:4095 nolds
+// CHECK: buffer_load_format_x v255, off, s[8:11], s3 offset:4095 ; encoding: [0xff,0x0f,0x00,0xe0,0x00,0xff,0x02,0x03]
+
 buffer_load_format_x v5, off, s[12:15], s3 offset:4095
 // CHECK: buffer_load_format_x v5, off, s[12:15], s3 offset:4095 ; encoding: [0xff,0x0f,0x00,0xe0,0x00,0x05,0x03,0x03]
 
@@ -3661,6 +3667,9 @@ buffer_load_sbyte off, s[8:11], s3 offset:4095 lds
 buffer_load_sbyte v255, off, s[8:11], s3 offset:4095
 // CHECK: buffer_load_sbyte v255, off, s[8:11], s3 offset:4095 ; encoding: [0xff,0x0f,0x44,0xe0,0x00,0xff,0x02,0x03]
 
+buffer_load_sbyte v255, off, s[8:11], s3 offset:4095 nolds
+// CHECK: buffer_load_sbyte v255, off, s[8:11], s3 offset:4095 ; encoding: [0xff,0x0f,0x44,0xe0,0x00,0xff,0x02,0x03]
+
 buffer_load_sbyte v5, off, s[12:15], s3 offset:4095
 // CHECK: buffer_load_sbyte v5, off, s[12:15], s3 offset:4095 ; encoding: [0xff,0x0f,0x44,0xe0,0x00,0x05,0x03,0x03]
 
@@ -3758,6 +3767,9 @@ buffer_load_sshort off, s[8:11], s3 offset:4095 lds
 // CHECK: buffer_load_sshort off, s[8:11], s3 offset:4095 lds ; encoding: [0xff,0x0f,0x4d,0xe0,0x00,0x00,0x02,0x03]
 
 buffer_load_sshort v255, off, s[8:11], s3 offset:4095
+// CHECK: buffer_load_sshort v255, off, s[8:11], s3 offset:4095 ; encoding: [0xff,0x0f,0x4c,0xe0,0x00,0xff,0x02,0x03]
+
+buffer_load_sshort v255, off, s[8:11], s3 offset:4095 nolds
 // CHECK: buffer_load_sshort v255, off, s[8:11], s3 offset:4095 ; encoding: [0xff,0x0f,0x4c,0xe0,0x00,0xff,0x02,0x03]
 
 buffer_load_sshort v5, off, s[12:15], s3 offset:4095
@@ -3859,6 +3871,9 @@ buffer_load_ubyte off, s[8:11], s3 offset:4095 lds
 buffer_load_ubyte v255, off, s[8:11], s3 offset:4095
 // CHECK: buffer_load_ubyte v255, off, s[8:11], s3 offset:4095 ; encoding: [0xff,0x0f,0x40,0xe0,0x00,0xff,0x02,0x03]
 
+buffer_load_ubyte v255, off, s[8:11], s3 offset:4095 nolds
+// CHECK: buffer_load_ubyte v255, off, s[8:11], s3 offset:4095 ; encoding: [0xff,0x0f,0x40,0xe0,0x00,0xff,0x02,0x03]
+
 buffer_load_ubyte v5, off, s[12:15], s3 offset:4095
 // CHECK: buffer_load_ubyte v5, off, s[12:15], s3 offset:4095 ; encoding: [0xff,0x0f,0x40,0xe0,0x00,0x05,0x03,0x03]
 
@@ -3956,6 +3971,9 @@ buffer_load_ushort off, s[8:11], s3 offset:4095 lds
 // CHECK: buffer_load_ushort off, s[8:11], s3 offset:4095 lds ; encoding: [0xff,0x0f,0x49,0xe0,0x00,0x00,0x02,0x03]
 
 buffer_load_ushort v255, off, s[8:11], s3 offset:4095
+// CHECK: buffer_load_ushort v255, off, s[8:11], s3 offset:4095 ; encoding: [0xff,0x0f,0x48,0xe0,0x00,0xff,0x02,0x03]
+
+buffer_load_ushort v255, off, s[8:11], s3 offset:4095 nolds
 // CHECK: buffer_load_ushort v255, off, s[8:11], s3 offset:4095 ; encoding: [0xff,0x0f,0x48,0xe0,0x00,0xff,0x02,0x03]
 
 buffer_load_ushort v5, off, s[12:15], s3 offset:4095

--- a/llvm/test/MC/AMDGPU/gfx9_asm_mubuf.s
+++ b/llvm/test/MC/AMDGPU/gfx9_asm_mubuf.s
@@ -2191,6 +2191,9 @@ buffer_load_dword off, s[8:11], s3 offset:4095 lds
 buffer_load_dword v255, off, s[8:11], s3 offset:4095
 // CHECK: buffer_load_dword v255, off, s[8:11], s3 offset:4095 ; encoding: [0xff,0x0f,0x50,0xe0,0x00,0xff,0x02,0x03]
 
+buffer_load_dword v255, off, s[8:11], s3 offset:4095 nolds
+// CHECK: buffer_load_dword v255, off, s[8:11], s3 offset:4095 ; encoding: [0xff,0x0f,0x50,0xe0,0x00,0xff,0x02,0x03]
+
 buffer_load_dword v5, off, s[12:15], s3 offset:4095
 // CHECK: buffer_load_dword v5, off, s[12:15], s3 offset:4095 ; encoding: [0xff,0x0f,0x50,0xe0,0x00,0x05,0x03,0x03]
 
@@ -2950,6 +2953,9 @@ buffer_load_format_x off, s[8:11], s3 offset:4095 lds
 buffer_load_format_x v255, off, s[8:11], s3 offset:4095
 // CHECK: buffer_load_format_x v255, off, s[8:11], s3 offset:4095 ; encoding: [0xff,0x0f,0x00,0xe0,0x00,0xff,0x02,0x03]
 
+buffer_load_format_x v255, off, s[8:11], s3 offset:4095 nolds
+// CHECK: buffer_load_format_x v255, off, s[8:11], s3 offset:4095 ; encoding: [0xff,0x0f,0x00,0xe0,0x00,0xff,0x02,0x03]
+
 buffer_load_format_x v5, off, s[12:15], s3 offset:4095
 // CHECK: buffer_load_format_x v5, off, s[12:15], s3 offset:4095 ; encoding: [0xff,0x0f,0x00,0xe0,0x00,0x05,0x03,0x03]
 
@@ -3287,6 +3293,9 @@ buffer_load_sbyte off, s[8:11], s3 offset:4095 lds
 // CHECK: buffer_load_sbyte off, s[8:11], s3 offset:4095 lds ; encoding: [0xff,0x0f,0x45,0xe0,0x00,0x00,0x02,0x03]
 
 buffer_load_sbyte v255, off, s[8:11], s3 offset:4095
+// CHECK: buffer_load_sbyte v255, off, s[8:11], s3 offset:4095 ; encoding: [0xff,0x0f,0x44,0xe0,0x00,0xff,0x02,0x03]
+
+buffer_load_sbyte v255, off, s[8:11], s3 offset:4095 nolds
 // CHECK: buffer_load_sbyte v255, off, s[8:11], s3 offset:4095 ; encoding: [0xff,0x0f,0x44,0xe0,0x00,0xff,0x02,0x03]
 
 buffer_load_sbyte v5, off, s[12:15], s3 offset:4095
@@ -3712,6 +3721,9 @@ buffer_load_sshort off, s[8:11], s3 offset:4095 lds
 buffer_load_sshort v255, off, s[8:11], s3 offset:4095
 // CHECK: buffer_load_sshort v255, off, s[8:11], s3 offset:4095 ; encoding: [0xff,0x0f,0x4c,0xe0,0x00,0xff,0x02,0x03]
 
+buffer_load_sshort v255, off, s[8:11], s3 offset:4095 nolds
+// CHECK: buffer_load_sshort v255, off, s[8:11], s3 offset:4095 ; encoding: [0xff,0x0f,0x4c,0xe0,0x00,0xff,0x02,0x03]
+
 buffer_load_sshort v5, off, s[12:15], s3 offset:4095
 // CHECK: buffer_load_sshort v5, off, s[12:15], s3 offset:4095 ; encoding: [0xff,0x0f,0x4c,0xe0,0x00,0x05,0x03,0x03]
 
@@ -3797,6 +3809,9 @@ buffer_load_ubyte off, s[8:11], s3 offset:4095 lds
 // CHECK: buffer_load_ubyte off, s[8:11], s3 offset:4095 lds ; encoding: [0xff,0x0f,0x41,0xe0,0x00,0x00,0x02,0x03]
 
 buffer_load_ubyte v255, off, s[8:11], s3 offset:4095
+// CHECK: buffer_load_ubyte v255, off, s[8:11], s3 offset:4095 ; encoding: [0xff,0x0f,0x40,0xe0,0x00,0xff,0x02,0x03]
+
+buffer_load_ubyte v255, off, s[8:11], s3 offset:4095 nolds
 // CHECK: buffer_load_ubyte v255, off, s[8:11], s3 offset:4095 ; encoding: [0xff,0x0f,0x40,0xe0,0x00,0xff,0x02,0x03]
 
 buffer_load_ubyte v5, off, s[12:15], s3 offset:4095
@@ -4052,6 +4067,9 @@ buffer_load_ushort off, s[8:11], s3 offset:4095 lds
 // CHECK: buffer_load_ushort off, s[8:11], s3 offset:4095 lds ; encoding: [0xff,0x0f,0x49,0xe0,0x00,0x00,0x02,0x03]
 
 buffer_load_ushort v255, off, s[8:11], s3 offset:4095
+// CHECK: buffer_load_ushort v255, off, s[8:11], s3 offset:4095 ; encoding: [0xff,0x0f,0x48,0xe0,0x00,0xff,0x02,0x03]
+
+buffer_load_ushort v255, off, s[8:11], s3 offset:4095 nolds
 // CHECK: buffer_load_ushort v255, off, s[8:11], s3 offset:4095 ; encoding: [0xff,0x0f,0x48,0xe0,0x00,0xff,0x02,0x03]
 
 buffer_load_ushort v5, off, s[12:15], s3 offset:4095


### PR DESCRIPTION
Some pre-GFX11 buffer_load instructions have two variants: one
requires the lds modifier and one does not allow lds. For the latter
allow nolds to be used.
