### PR TITLE
[libc][test] FIX: made RoundingModUtils.cpp and .h hermetic

### DIFF
--- a/libc/test/UnitTest/CMakeLists.txt
+++ b/libc/test/UnitTest/CMakeLists.txt
@@ -133,6 +133,7 @@ add_unittest_framework_library(
     libc.src.__support.FPUtil.fpbits_str
     libc.src.__support.FPUtil.fenv_impl
     libc.src.__support.FPUtil.rounding_mode
+    libc.include.llvm-libc-macros.fenv_macros
 )
 
 add_unittest_framework_library(

--- a/libc/test/UnitTest/RoundingModeUtils.cpp
+++ b/libc/test/UnitTest/RoundingModeUtils.cpp
@@ -12,7 +12,8 @@
 #include "src/__support/FPUtil/FEnvImpl.h"
 #include "src/__support/FPUtil/rounding_mode.h"
 
-#include "hdr/fenv_macros.h"
+#include "include/llvm-libc-macros/fenv-macros.h"
+
 #include "src/__support/macros/config.h"
 
 namespace LIBC_NAMESPACE_DECL {

--- a/libc/test/UnitTest/RoundingModeUtils.h
+++ b/libc/test/UnitTest/RoundingModeUtils.h
@@ -9,8 +9,8 @@
 #ifndef LLVM_LIBC_TEST_UNITTEST_ROUNDINGMODEUTILS_H
 #define LLVM_LIBC_TEST_UNITTEST_ROUNDINGMODEUTILS_H
 
-#include <stdint.h>
 #include "src/__support/macros/config.h"
+#include <stdint.h>
 
 namespace LIBC_NAMESPACE_DECL {
 namespace fputil {

--- a/libc/test/UnitTest/RoundingModeUtils.h
+++ b/libc/test/UnitTest/RoundingModeUtils.h
@@ -9,7 +9,7 @@
 #ifndef LLVM_LIBC_TEST_UNITTEST_ROUNDINGMODEUTILS_H
 #define LLVM_LIBC_TEST_UNITTEST_ROUNDINGMODEUTILS_H
 
-#include "hdr/stdint_proxy.h"
+#include <stdint.h>
 #include "src/__support/macros/config.h"
 
 namespace LIBC_NAMESPACE_DECL {


### PR DESCRIPTION
Fixes #135211

Changed Files:
`libc/test/UnitTest/CMakeLists.txt`
`libc/test/UnitTest/RoundingModeUtils.cpp`
`libc/test/UnitTest/RoundingModeUtils.h`

Made the RoundingModeUtils.cpp and .h hermetic.