### PR TITLE
[CIR] Add abstract array delete operation with expansion during CXXABILowering

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIRAttrs.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRAttrs.td
@@ -1397,6 +1397,14 @@ def CIR_ASTVarDeclAttr : CIR_AST<"VarDecl", "var.decl", [
   ASTVarDeclInterface
 ]>;
 
+def CIR_ASTFunctionDeclAttr : CIR_AST<"FunctionDecl", "function.decl", [
+  ASTFunctionDeclInterface
+]>;
+
+def CIR_ASTCXXDeleteExprAttr : CIR_AST<"CXXDeleteExpr", "cxx_delete.expr", [
+  ASTCXXDeleteExprInterface
+]>;
+
 include "clang/CIR/Dialect/IR/CIRCUDAAttrs.td"
 
 #endif // CLANG_CIR_DIALECT_IR_CIRATTRS_TD

--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -3590,6 +3590,45 @@ def CIR_LLVMIntrinsicCallOp : CIR_Op<"call_llvm_intrinsic"> {
 }
 
 //===----------------------------------------------------------------------===//
+// DeleteArrayOp
+//===----------------------------------------------------------------------===//
+
+def CIR_DeleteArrayOp : CIR_Op<"delete_array"> {
+  let summary = "Delete address representing an array";
+  let description = [{
+    `cir.delete_array` operation deletes an array. For example, `delete[] ptr;`
+    will be translated to `cir.delete_array %ptr`.
+
+    When present, the AST attribute provides the CXXDeleteExpr for generating
+    the delete call during CXXABILowering. The callee attribute specifies the
+    operator delete function to call.
+  }];
+
+  let arguments = (ins CIR_PointerType:$address,
+                       OptionalAttr<ASTCXXDeleteExprInterface>:$ast,
+                       OptionalAttr<FlatSymbolRefAttr>:$callee);
+
+  let assemblyFormat = [{
+    $address `:` qualified(type($address)) attr-dict
+  }];
+
+  let builders = [
+    OpBuilder<(ins "mlir::Value":$address,
+                   CArg<"mlir::Attribute", "{}">:$ast,
+                   CArg<"mlir::FlatSymbolRefAttr", "{}">:$callee), [{
+        $_state.addOperands(ValueRange{address});
+        if (ast)
+          $_state.addAttribute("ast", ast);
+        if (callee)
+          $_state.addAttribute("callee", callee);
+    }]>
+  ];
+
+  let hasLLVMLowering = false;
+  let hasCXXABILowering = true;
+}
+
+//===----------------------------------------------------------------------===//
 // CallOp and TryCallOp
 //===----------------------------------------------------------------------===//
 

--- a/clang/include/clang/CIR/Interfaces/ASTAttrInterfaces.h
+++ b/clang/include/clang/CIR/Interfaces/ASTAttrInterfaces.h
@@ -12,7 +12,16 @@
 #include "mlir/IR/Attributes.h"
 
 #include "clang/AST/Attr.h"
+#include "clang/AST/Decl.h"
 #include "clang/AST/DeclTemplate.h"
+#include "clang/AST/ExprCXX.h"
+
+namespace cir {
+
+mlir::Attribute makeFuncDeclAttr(const clang::FunctionDecl *decl,
+                                 mlir::MLIRContext *ctx);
+
+} // namespace cir
 
 /// Include the generated interface declarations.
 #include "clang/CIR/Interfaces/ASTAttrInterfaces.h.inc"

--- a/clang/include/clang/CIR/Interfaces/ASTAttrInterfaces.td
+++ b/clang/include/clang/CIR/Interfaces/ASTAttrInterfaces.td
@@ -34,6 +34,61 @@ let cppNamespace = "::cir" in {
       }]>
     ];
   }
+
+  def ASTFunctionDeclInterface : AttrInterface<"ASTFunctionDeclInterface"> {
+    let methods = [
+      InterfaceMethod<"", "bool", "hasSizeParameter", (ins), [{}],
+                      /*defaultImplementation=*/[{
+        const clang::FunctionDecl *FD = $_attr.getAst();
+        return FD && FD->getUsualDeleteParams().Size;
+      }]>,
+      InterfaceMethod<"", "bool", "hasTypeAwareDelete", (ins), [{}],
+                      /*defaultImplementation=*/[{
+        const clang::FunctionDecl *FD = $_attr.getAst();
+        return FD && ::clang::isTypeAwareAllocation(
+            FD->getUsualDeleteParams().TypeAwareDelete);
+      }]>,
+      InterfaceMethod<"", "bool", "hasDestroyingDelete", (ins), [{}],
+                      /*defaultImplementation=*/[{
+        const clang::FunctionDecl *FD = $_attr.getAst();
+        return FD && FD->getUsualDeleteParams().DestroyingDelete;
+      }]>,
+      InterfaceMethod<"", "bool", "hasAlignmentParameter", (ins), [{}],
+                      /*defaultImplementation=*/[{
+        const clang::FunctionDecl *FD = $_attr.getAst();
+        return FD && ::clang::isAlignedAllocation(
+            FD->getUsualDeleteParams().Alignment);
+      }]>,
+    ];
+  }
+
+  def ASTCXXDeleteExprInterface : AttrInterface<"ASTCXXDeleteExprInterface"> {
+    let methods = [
+      InterfaceMethod<"", "cir::ASTFunctionDeclInterface", "getOperatorDelete",
+                      (ins), [{}],
+                      /*defaultImplementation=*/[{
+        const clang::CXXDeleteExpr *E = $_attr.getAst();
+        if (!E || !E->getOperatorDelete())
+          return {};
+        return mlir::cast<cir::ASTFunctionDeclInterface>(
+            makeFuncDeclAttr(E->getOperatorDelete(), $_attr.getContext()));
+      }]>,
+      InterfaceMethod<"", "bool", "doesUsualArrayDeleteWantSize", (ins), [{}],
+                      /*defaultImplementation=*/[{
+        const clang::CXXDeleteExpr *E = $_attr.getAst();
+        return E && E->doesUsualArrayDeleteWantSize();
+      }]>,
+      InterfaceMethod<"", "bool", "isElementDestructedType", (ins), [{}],
+                      /*defaultImplementation=*/[{
+        const clang::CXXDeleteExpr *E = $_attr.getAst();
+        if (!E) return false;
+        clang::QualType eltTy = E->getOperatorDelete()->getASTContext()
+            .getBaseElementType(E->getDestroyedType());
+        return eltTy.isDestructedType();
+      }]>,
+    ];
+  }
+
 } // namespace cir
 
 #endif // MLIR_CIR_INTERFACES_ASTATTRINTERFACES_TD

--- a/clang/lib/CIR/CodeGen/CIRGenExprCXX.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprCXX.cpp
@@ -1222,9 +1222,20 @@ void CIRGenFunction::emitCXXDeleteExpr(const CXXDeleteExpr *e) {
   }
 
   if (e->isArrayForm()) {
-    assert(!cir::MissingFeatures::deleteArray());
-    cgm.errorNYI(e->getSourceRange(), "emitCXXDeleteExpr: array delete");
-    return;
+    // To handle this for cases that require array cookie, we will need to
+    // add target-specific handling during the lowering of delete_array in
+    // CXXABILowering, but we can emit a better diagnostic here.
+    if (e->doesUsualArrayDeleteWantSize() || deleteTy.isDestructedType()) {
+      cgm.errorNYI(e->getSourceRange(),
+                   "emitCXXDeleteExpr: array delete requires cookies");
+    }
+    cir::FuncOp operatorDeleteFn =
+        cgm.getAddrOfFunction(e->getOperatorDelete());
+    mlir::FlatSymbolRefAttr callee = mlir::FlatSymbolRefAttr::get(
+        builder.getContext(), operatorDeleteFn.getSymNameAttr());
+    cir::DeleteArrayOp::create(
+        builder, ptr.getPointer().getLoc(), ptr.getPointer(),
+        cir::ASTCXXDeleteExprAttr::get(builder.getContext(), e), callee);
   } else {
     emitObjectDelete(*this, e, ptr, deleteTy);
   }

--- a/clang/lib/CIR/Dialect/IR/CIRAttrs.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRAttrs.cpp
@@ -11,7 +11,9 @@
 //===----------------------------------------------------------------------===//
 
 #include "mlir/Dialect/Ptr/IR/MemorySpaceInterfaces.h"
+#include "clang/AST/Decl.h"
 #include "clang/CIR/Dialect/IR/CIRDialect.h"
+#include "clang/CIR/Interfaces/ASTAttrInterfaces.h"
 
 #include "mlir/IR/DialectImplementation.h"
 #include "llvm/ADT/TypeSwitch.h"
@@ -74,6 +76,21 @@ static void printConstPtr(mlir::AsmPrinter &p, mlir::IntegerAttr value);
 
 using namespace mlir;
 using namespace cir;
+
+//===----------------------------------------------------------------------===//
+// CIR AST Attr helpers
+//===----------------------------------------------------------------------===//
+
+namespace cir {
+
+mlir::Attribute makeFuncDeclAttr(const clang::FunctionDecl *decl,
+                                 mlir::MLIRContext *ctx) {
+  if (!decl)
+    return {};
+  return cir::ASTFunctionDeclAttr::get(ctx, decl);
+}
+
+} // namespace cir
 
 //===----------------------------------------------------------------------===//
 // MemorySpaceAttrInterface implementations for Lang and Target address space

--- a/clang/lib/CIR/Dialect/Transforms/CXXABILowering.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/CXXABILowering.cpp
@@ -19,6 +19,7 @@
 #include "clang/CIR/Dialect/IR/CIRDialect.h"
 #include "clang/CIR/Dialect/IR/CIROpsEnums.h"
 #include "clang/CIR/Dialect/Passes.h"
+#include "clang/CIR/Interfaces/ASTAttrInterfaces.h"
 #include "clang/CIR/MissingFeatures.h"
 
 using namespace mlir;
@@ -58,7 +59,7 @@ public:
                   mlir::ConversionPatternRewriter &rewriter) const override {
     // Do not match on operations that have dedicated ABI lowering rewrite rules
     if (llvm::isa<cir::AllocaOp, cir::BaseDataMemberOp, cir::BaseMethodOp,
-                  cir::CastOp, cir::CmpOp, cir::ConstantOp,
+                  cir::CastOp, cir::CmpOp, cir::ConstantOp, cir::DeleteArrayOp,
                   cir::DerivedDataMemberOp, cir::DerivedMethodOp, cir::FuncOp,
                   cir::GetMethodOp, cir::GetRuntimeMemberOp, cir::GlobalOp>(op))
       return mlir::failure();
@@ -320,6 +321,50 @@ mlir::LogicalResult CIRBaseMethodOpABILowering::matchAndRewrite(
   return mlir::success();
 }
 
+mlir::LogicalResult CIRDeleteArrayOpABILowering::matchAndRewrite(
+    cir::DeleteArrayOp op, OpAdaptor adaptor,
+    mlir::ConversionPatternRewriter &rewriter) const {
+  std::optional<cir::ASTCXXDeleteExprInterface> ast = op.getAst();
+  if (!ast)
+    return rewriter.notifyMatchFailure(
+        op, "Unable to lower cir.delete_array  without an AST attribute");
+
+  mlir::FlatSymbolRefAttr callee = op.getCalleeAttr();
+  if (!callee)
+    return rewriter.notifyMatchFailure(op, "requires callee attribute");
+
+  mlir::Location loc = op->getLoc();
+  mlir::Value loweredAddress = adaptor.getAddress();
+  auto voidPtrTy =
+      cir::PointerType::get(cir::VoidType::get(rewriter.getContext()));
+  mlir::Value deletePtr = cir::CastOp::create(
+      rewriter, loc, voidPtrTy, cir::CastKind::bitcast, loweredAddress);
+
+  llvm::SmallVector<mlir::Value> callArgs{deletePtr};
+
+  if (cir::ASTFunctionDeclInterface opDelete = ast->getOperatorDelete()) {
+    if (opDelete.hasSizeParameter()) {
+      auto ptrTy = mlir::cast<cir::PointerType>(loweredAddress.getType());
+      mlir::Type eltTy = ptrTy.getPointee();
+      mlir::DataLayout dataLayout(op->getParentOfType<mlir::ModuleOp>());
+      uint64_t sizeBytes = dataLayout.getTypeSizeInBits(eltTy) / 8;
+      mlir::Type sizeTy =
+          cir::IntType::get(rewriter.getContext(), 64, /*isSigned=*/false);
+      mlir::Value sizeConst = cir::ConstantOp::create(
+          rewriter, loc, cir::IntAttr::get(sizeTy, sizeBytes));
+      callArgs.push_back(sizeConst);
+    }
+    if (opDelete.hasTypeAwareDelete() || opDelete.hasDestroyingDelete() ||
+        opDelete.hasAlignmentParameter())
+      return rewriter.notifyMatchFailure(
+          op, "type-aware, destroying, or aligned delete not yet supported");
+  }
+
+  cir::CallOp::create(rewriter, loc, callee, cir::VoidType(), callArgs);
+  rewriter.eraseOp(op);
+  return mlir::success();
+}
+
 mlir::LogicalResult CIRDerivedDataMemberOpABILowering::matchAndRewrite(
     cir::DerivedDataMemberOp op, OpAdaptor adaptor,
     mlir::ConversionPatternRewriter &rewriter) const {
@@ -454,6 +499,9 @@ populateCXXABIConversionTarget(mlir::ConversionTarget &target,
       [&typeConverter](cir::GlobalOp op) {
         return typeConverter.isLegal(op.getSymType());
       });
+  // Operations that do not use any special types must be explicitly marked as
+  // illegal to trigger processing here.
+  target.addIllegalOp<cir::DeleteArrayOp>();
   target.addIllegalOp<cir::DynamicCastOp>();
   target.addIllegalOp<cir::VTableGetTypeInfoOp>();
 }

--- a/clang/test/CIR/CodeGen/delete-array.cpp
+++ b/clang/test/CIR/CodeGen/delete-array.cpp
@@ -1,0 +1,64 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -std=c++20 -fclangir -emit-cir -mmlir -mlir-print-ir-before=cir-cxxabi-lowering %s -o %t.cir 2> %t-before.cir
+// RUN: FileCheck --input-file=%t-before.cir -check-prefix=CIR-BEFORE %s
+// RUN: FileCheck --input-file=%t.cir --check-prefix=CIR %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -std=c++20 -fclangir -emit-llvm %s -o %t-cir.ll
+// RUN: FileCheck --input-file=%t-cir.ll --check-prefix=LLVM %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -std=c++20 -emit-llvm %s -o %t.ll
+// RUN: FileCheck --input-file=%t.ll --check-prefix=OGCG %s
+
+void test_delete_array(int *ptr) {
+  delete[] ptr;
+}
+
+// CIR-BEFORE: cir.func {{.*}} @_Z17test_delete_arrayPi
+// CIR-BEFORE:   %[[PTR:.*]] = cir.load{{.*}} %{{.*}}
+// CIR-BEFORE:   cir.delete_array %[[PTR]] : !cir.ptr<!s32i>
+
+// CIR: cir.func {{.*}} @_Z17test_delete_arrayPi
+// CIR:   %[[PTR:.*]] = cir.load{{.*}} %{{.*}}
+// CIR:   %[[VOID_PTR:.*]] = cir.cast bitcast %[[PTR]] : !cir.ptr<!s32i> -> !cir.ptr<!void>
+// CIR:   cir.call @_ZdaPv(%[[VOID_PTR]])
+
+// LLVM: define {{.*}} void @_Z17test_delete_arrayPi
+// LLVM:   %[[PTR:.*]] = load ptr, ptr %{{.*}}
+// LLVM:   call void @_ZdaPv(ptr %[[PTR]])
+
+// OGCG: define {{.*}} void @_Z17test_delete_arrayPi
+// OGCG:   %[[PTR:.*]] = load ptr, ptr %{{.*}}
+// OGCG:   %[[IS_NULL:.*]] = icmp eq ptr %[[PTR]], null
+// OGCG:   br i1 %[[IS_NULL]], label %[[DELETE_END:.*]], label %[[DELETE_NOT_NULL:.*]]
+// OGCG: [[DELETE_NOT_NULL]]:
+// OGCG:   call void @_ZdaPv(ptr {{.*}} %[[PTR]])
+// OGCG:   br label %[[DELETE_END]]
+// OGCG: [[DELETE_END]]:
+// OGCG:   ret void
+
+struct SimpleArrDelete {
+  void operator delete[](void *);
+  int member;
+};
+void test_simple_delete_array(SimpleArrDelete *ptr) {
+  delete[] ptr;
+}
+
+// CIR-BEFORE: cir.func {{.*}} @_Z24test_simple_delete_arrayP15SimpleArrDelete
+// CIR-BEFORE:   %[[PTR:.*]] = cir.load{{.*}} %{{.*}}
+// CIR-BEFORE:   cir.delete_array %[[PTR]] : !cir.ptr<!rec_SimpleArrDelete> {{.*}} callee = @_ZN15SimpleArrDeletedaEPv
+
+// CIR: cir.func {{.*}} @_Z24test_simple_delete_arrayP15SimpleArrDelete
+// CIR:   %[[PTR:.*]] = cir.load{{.*}} %{{.*}}
+// CIR:   %[[VOID_PTR:.*]] = cir.cast bitcast %[[PTR]] : !cir.ptr<!rec_SimpleArrDelete> -> !cir.ptr<!void>
+// CIR:   cir.call @_ZN15SimpleArrDeletedaEPv(%[[VOID_PTR]])
+
+// LLVM: define {{.*}} void @_Z24test_simple_delete_arrayP15SimpleArrDelete
+// LLVM:   %[[PTR:.*]] = load ptr, ptr %{{.*}}
+// LLVM:   call void @_ZN15SimpleArrDeletedaEPv(ptr %[[PTR]])
+
+// OGCG: define {{.*}} void @_Z24test_simple_delete_arrayP15SimpleArrDelete
+// OGCG:   %[[PTR:.*]] = load ptr, ptr %{{.*}}
+// OGCG:   %[[IS_NULL:.*]] = icmp eq ptr %[[PTR]], null
+// OGCG:   br i1 %[[IS_NULL]], label %[[ARR_DELETE_END:.*]], label %[[ARR_DELETE_NOT_NULL:.*]]
+// OGCG: [[ARR_DELETE_NOT_NULL]]:
+// OGCG:   call void @_ZN15SimpleArrDeletedaEPv(ptr {{.*}} %[[PTR]])
+// OGCG:   br label %[[ARR_DELETE_END]]
+// OGCG: [[ARR_DELETE_END]]:


### PR DESCRIPTION
This introduces the cir.delete_array operation, adds code to emit that operation during CIR codegen, and adds lowering of the operation to the CXXABILowering pass.

In order to handle possible variations in the delete representation, we add AST interfaces and attach an attribute to the cir.delete_array op with a pointer to the CXXDeleteExpr for the operation and a flat symbol reference to the delete function to be called.

During the CXXABILoweringPass, the cir.delete_array operation is expanded to call the delete function. This will be expanded in a future change to handle reading the array cookie, if required, and calling element destructors.