### PR TITLE
[lldb] Implement PluginInfo move constructor

### DIFF
--- a/lldb/source/Core/PluginManager.cpp
+++ b/lldb/source/Core/PluginManager.cpp
@@ -46,8 +46,19 @@ struct PluginInfo {
   PluginInfo(const PluginInfo &) = delete;
   PluginInfo &operator=(const PluginInfo &) = delete;
 
-  PluginInfo(PluginInfo &&) = default;
-  PluginInfo &operator=(PluginInfo &&) = default;
+  PluginInfo(PluginInfo &&other)
+      : library(std::move(other.library)),
+        plugin_init_callback(
+            std::exchange(other.plugin_init_callback, nullptr)),
+        plugin_term_callback(
+            std::exchange(other.plugin_term_callback, nullptr)) {}
+
+  PluginInfo &operator=(PluginInfo &&other) {
+    library = std::move(other.library);
+    plugin_init_callback = std::exchange(other.plugin_init_callback, nullptr);
+    plugin_term_callback = std::exchange(other.plugin_term_callback, nullptr);
+    return *this;
+  }
 
   ~PluginInfo() {
     if (!library.isValid())


### PR DESCRIPTION
The default move constructor wasn't nulling out the callbacks. Combined with the fact that llvm::sys::DynamicLibrary  has no explicit move constructor and hence library.isValid() still returned true after having moved-from, we would end up calling plugin_term_callback() when destroying the moved-from PluginInfo, calling it prematurely.