### PR TITLE
[bazel] Disable parse_headers on gtest headers

### DIFF
--- a/utils/bazel/llvm-project-overlay/third-party/unittest/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/third-party/unittest/BUILD.bazel
@@ -67,6 +67,7 @@ cc_library(
         "@platforms//os:windows": ["GTEST_USE_OWN_TR1_TUPLE=0"],
         "//conditions:default": ["GTEST_USE_OWN_TR1_TUPLE=1"],
     }),
+    features = ["-parse_headers"],
     includes = [
         "googletest/include",
         "include",


### PR DESCRIPTION
One of the headers has a circular dependency issue that makes it not
isolated

```
.../googletest/include/gtest/internal/custom/gtest-printers.h:53:12: error: no member named 'testing' in the global namespace
   53 |   *OS << ::testing::PrintToString(S.str());
      |          ~~^
```
