### PR TITLE
[WebAssembly] Look through freeze nodes when folding vector load + ext

### DIFF
--- a/llvm/lib/Target/WebAssembly/WebAssemblyISelLowering.cpp
+++ b/llvm/lib/Target/WebAssembly/WebAssemblyISelLowering.cpp
@@ -1044,7 +1044,13 @@ bool WebAssemblyTargetLowering::isIntDivCheap(EVT VT,
 
 bool WebAssemblyTargetLowering::isVectorLoadExtDesirable(SDValue ExtVal) const {
   EVT ExtT = ExtVal.getValueType();
-  EVT MemT = cast<LoadSDNode>(ExtVal->getOperand(0))->getValueType(0);
+  SDValue N0 = ExtVal->getOperand(0);
+  if (N0.getOpcode() == ISD::FREEZE)
+    N0 = N0.getOperand(0);
+  auto *Load = dyn_cast<LoadSDNode>(N0);
+  if (!Load)
+    return false;
+  EVT MemT = Load->getValueType(0);
   return (ExtT == MVT::v8i16 && MemT == MVT::v8i8) ||
          (ExtT == MVT::v4i32 && MemT == MVT::v4i16) ||
          (ExtT == MVT::v2i64 && MemT == MVT::v2i32);

--- a/llvm/test/CodeGen/WebAssembly/simd-offset.ll
+++ b/llvm/test/CodeGen/WebAssembly/simd-offset.ll
@@ -3644,3 +3644,19 @@ define void @store_v2f64_to_global_address(<2 x double> %v) {
   store <2 x double> %v , ptr @gv_v2f64
   ret void
 }
+
+; Test that load extends can fold through freeze nodes
+define <4 x i16> @test_freeze_zext(ptr %in) {
+; CHECK-LABEL: test_freeze_zext:
+; CHECK:         .functype test_freeze_zext (i32) -> (v128)
+; CHECK-NEXT:  # %bb.0: # %entry
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    v128.load32_zero 0:p2align=0
+; CHECK-NEXT:    i16x8.extend_low_i8x16_u
+; CHECK-NEXT:    # fallthrough-return
+entry:
+  %t = load <4 x i8>, ptr %in, align 1
+  %t.fr = freeze <4 x i8> %t
+  %w = zext <4 x i8> %t.fr to <4 x i16>
+  ret <4 x i16> %w
+}


### PR DESCRIPTION
When folding loads with extensions, the extension operand can be a freeze node
in addition to a load. We can look through it to do the desirability check.

Fixes #184676