### PR TITLE
[lldb/test] Add generic test variant infrastructure

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/decorators.py
+++ b/lldb/packages/Python/lldbsuite/test/decorators.py
@@ -172,12 +172,28 @@ def skipTestIfFn(expected_fn, bugnumber=None):
         return skipTestIfFn_impl
 
 
-def _xfailForDebugInfo(expected_fn, bugnumber=None):
+def _xfailForVariant(variant_name, expected_fn, bugnumber=None):
+    """Mark a test method as expected-failure for a specific variant dimension.
+
+    Adds *expected_fn* to the decorated function's `__variant_xfail__`
+    dictionary under the key *variant_name*.  When the `LLDBTestCaseFactory`
+    metaclass expands the test method, it looks up *variant_name* in this
+    dictionary and calls the corresponding function with the concrete variant
+    value.  If the function returns a reason string, the expanded test method
+    is marked as expected failure via `unittest.expectedFailure`.
+
+    Args:
+        variant_name: The variant dimension name (e.g. `"debug_info"`).
+        expected_fn: Callable `(**{variant_name: value}) -> reason | None`.
+        bugnumber: Optional bug reference or the decorated function itself
+            (when the decorator is used without parentheses).
+    """
     def expectedFailure_impl(func):
         if isinstance(func, type) and issubclass(func, unittest.TestCase):
             raise Exception("Decorator can only be used to decorate a test method")
-
-        func.__xfail_for_debug_info_cat_fn__ = expected_fn
+        xfail_dict = getattr(func, "__variant_xfail__", {})
+        xfail_dict[variant_name] = expected_fn
+        func.__variant_xfail__ = xfail_dict
         return func
 
     if callable(bugnumber):
@@ -186,12 +202,28 @@ def _xfailForDebugInfo(expected_fn, bugnumber=None):
         return expectedFailure_impl
 
 
-def _skipForDebugInfo(expected_fn, bugnumber=None):
+def _skipForVariant(variant_name, expected_fn, bugnumber=None):
+    """Mark a test method as skipped for a specific variant dimension.
+
+    Adds *expected_fn* to the decorated function's `__variant_skip__`
+    dictionary under the key *variant_name*.  When the `LLDBTestCaseFactory`
+    metaclass expands the test method, it looks up *variant_name* in this
+    dictionary and calls the corresponding function with the concrete variant
+    value.  If the function returns a reason string, the expanded test method
+    is skipped via `unittest.skip(reason)`.
+
+    Args:
+        variant_name: The variant dimension name (e.g. `"debug_info"`).
+        expected_fn: Callable `(**{variant_name: value}) -> reason | None`.
+        bugnumber: Optional bug reference or the decorated function itself
+            (when the decorator is used without parentheses).
+    """
     def skipImpl(func):
         if isinstance(func, type) and issubclass(func, unittest.TestCase):
             raise Exception("Decorator can only be used to decorate a test method")
-
-        func.__skip_for_debug_info_cat_fn__ = expected_fn
+        skip_dict = getattr(func, "__variant_skip__", {})
+        skip_dict[variant_name] = expected_fn
+        func.__variant_skip__ = skip_dict
         return func
 
     if callable(bugnumber):
@@ -218,7 +250,7 @@ def _decorateTest(
     setting=None,
     asan=None,
 ):
-    def fn(actual_debug_info=None):
+    def fn(**actual_variants):
         skip_for_os = _match_decorator_property(
             lldbplatform.translate(oslist), lldbplatformutil.getPlatform()
         )
@@ -231,7 +263,9 @@ def _decorateTest(
         skip_for_arch = _match_decorator_property(
             archs, lldbplatformutil.getArchitecture()
         )
-        skip_for_debug_info = _match_decorator_property(debug_info, actual_debug_info)
+        skip_for_debug_info = _match_decorator_property(
+            debug_info, actual_variants.get("debug_info")
+        )
         skip_for_triple = _match_decorator_property(
             triple, lldb.selected_platform.GetTriple()
         )
@@ -311,11 +345,11 @@ def _decorateTest(
 
     if mode == DecorateMode.Skip:
         if debug_info:
-            return _skipForDebugInfo(fn, bugnumber)
+            return _skipForVariant("debug_info", fn, bugnumber)
         return skipTestIfFn(fn, bugnumber)
     elif mode == DecorateMode.Xfail:
         if debug_info:
-            return _xfailForDebugInfo(fn, bugnumber)
+            return _xfailForVariant("debug_info", fn, bugnumber)
         return expectedFailureIf(fn(), bugnumber)
     else:
         return None

--- a/lldb/packages/Python/lldbsuite/test/lldbtest.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbtest.py
@@ -1514,9 +1514,12 @@ class Base(unittest.TestCase):
             option_str += " -C " + comp
         return option_str
 
-    def getDebugInfo(self):
+    def getVariant(self, variant_name):
         method = getattr(self, self.testMethodName)
-        return getattr(method, "debug_info", None)
+        return getattr(method, variant_name, None)
+
+    def getDebugInfo(self):
+        return self.getVariant("debug_info")
 
     def build(
         self,
@@ -1804,12 +1807,160 @@ class Base(unittest.TestCase):
 # level by using the decorator @no_debug_info_test.
 
 
+class TestVariant:
+    """Describes a test variant dimension for test method expansion.
+
+    Test variants add extra dimensions to the test matrix. When a variant is
+    registered in `_test_variants`, the `LLDBTestCaseFactory` metaclass
+    iterates over every `test*` method and, for each method that matches the
+    variant's predicate, replaces it with one copy per enabled value.
+
+    For example, a variant with values `{"a": True, "b": True}` turns
+    `test_foo` into `test_foo_a` and `test_foo_b`.  If multiple variants
+    match, the expansion is applied sequentially, producing the cross product
+    (e.g. `test_foo_dwarf_a`, `test_foo_dwarf_b`, ...).
+
+    Variant-aware `@expectedFailureAll` / `@skipIf` decorators use
+    `_xfailForVariant` / `_skipForVariant` in `decorators.py` to store
+    predicate functions in the `__variant_xfail__` / `__variant_skip__`
+    dictionaries on the **original** test method, keyed by variant name.
+    During expansion the metaclass looks up the predicate for each variant,
+    evaluates it for each value, and wraps the copy with
+    `unittest.expectedFailure` or `unittest.skip` accordingly.
+
+    At test run-time, `TestBase.setUp` calls `apply_settings` for every
+    registered variant so the test process is configured for the value that
+    the current method was expanded into.
+    """
+
+    def __init__(
+        self, name, values, predicate=None, setup_fn=None, attrs_to_preserve=()
+    ):
+        """Create a new test variant dimension.
+
+        Args:
+            name: Attribute name set on each expanded method to record which
+                value it was created for (e.g. `"debug_info"`).  Used to
+                look up xfail/skip predicates in the `__variant_xfail__`
+                / `__variant_skip__` dictionaries on the test method.
+            values: `dict[str, bool]` mapping variant value names to whether
+                they should be enabled.  Values with a `False` entry
+                are present in the dict for documentation but are skipped
+                during expansion.
+            predicate: Optional callable `(test_method) -> bool`.  When
+                given, only methods for which the predicate returns `True`
+                are expanded.  `None` means *every* test method is expanded.
+            setup_fn: Optional callable `(test_instance, variant_value)`
+                invoked from `TestBase.setUp` to apply run-time
+                configuration for the given variant value.
+            attrs_to_preserve: Tuple of attribute names that should be copied
+                from the source method to each expanded copy (e.g.
+                `("debug_info",)` so that a second-pass variant preserves
+                the debug-info value set by the first pass).
+        """
+        self.name = name
+        self.values = values
+        self.predicate = predicate
+        self.setup_fn = setup_fn
+        self.attrs_to_preserve = attrs_to_preserve
+
+    def should_expand(self, test_method):
+        """Return True if *test_method* should be expanded by this variant."""
+        if self.predicate is None:
+            return True
+        return self.predicate(test_method)
+
+    def get_enabled_values(self):
+        """Return the list of value names whose entry is True."""
+        return [n for n, enabled in self.values.items() if enabled]
+
+    def apply_settings(self, test_instance, variant_value):
+        """Configure *test_instance* for *variant_value* via the setup_fn."""
+        if self.setup_fn:
+            self.setup_fn(test_instance, variant_value)
+
+
+def _expand_test_variants(attrname, methods, variant, xfail_fns, skip_fns):
+    """Expand test methods in *methods* along the given *variant* dimension.
+
+    Only methods whose name equals *attrname* or starts with `attrname + "_"`
+    are expanded (this keeps methods from other `test*` functions untouched
+    when multiple test methods coexist in the same `newattrs` dict).
+
+    For each matching method and each enabled value in *variant*, a new
+    wrapper method is created with the value name appended
+    (`method_name + "_" + value_name`).  The wrapper delegates to the original
+    method, carries the variant attribute, and is optionally wrapped with
+    `unittest.expectedFailure` or `unittest.skip` based on predicates
+    found in *xfail_fns* / *skip_fns*.
+
+    Args:
+        attrname: The original test method name being processed by the
+            metaclass (e.g. `"test_foo"`).
+        methods: `dict[str, callable]` of accumulated methods (`newattrs`).
+        variant: The `TestVariant` to expand along.
+        xfail_fns: `__variant_xfail__` dict from the original test method.
+        skip_fns: `__variant_skip__` dict from the original test method.
+
+    Returns:
+        A new dict with the original matching methods replaced by their
+        per-value copies.  Non-matching entries are passed through.
+    """
+    no_reason = lambda *args, **kwargs: None
+    xfail_fn = xfail_fns.get(variant.name, no_reason)
+    skip_fn = skip_fns.get(variant.name, no_reason)
+    expanded = {}
+    for method_name, method in methods.items():
+        if not method_name.startswith("test"):
+            expanded[method_name] = method
+            continue
+        if method_name != attrname and not method_name.startswith(attrname + "_"):
+            expanded[method_name] = method
+            continue
+        for value_name in variant.get_enabled_values():
+            new_name = method_name + "_" + value_name
+
+            @decorators.add_test_categories([value_name])
+            @wraps(method)
+            def variant_method(self, method=method):
+                return method(self)
+
+            variant_method.__name__ = new_name
+            setattr(variant_method, variant.name, value_name)
+
+            for attr in variant.attrs_to_preserve:
+                if hasattr(method, attr):
+                    setattr(variant_method, attr, getattr(method, attr))
+
+            xfail_reason = xfail_fn(**{variant.name: value_name})
+            if xfail_reason:
+                variant_method = unittest.expectedFailure(variant_method)
+
+            skip_reason = skip_fn(**{variant.name: value_name})
+            if skip_reason:
+                variant_method = unittest.skip(skip_reason)(variant_method)
+
+            expanded[new_name] = variant_method
+    return expanded
+
+
+_test_variants = []
+
+
 class LLDBTestCaseFactory(type):
     def __new__(cls, name, bases, attrs):
         original_testcase = super(LLDBTestCaseFactory, cls).__new__(
             cls, name, bases, attrs
         )
-        if original_testcase.NO_DEBUG_INFO_TESTCASE:
+
+        # Check if any test methods need variant expansion
+        has_variant_tests = any(
+            attrname.startswith("test")
+            and any(v.should_expand(attrvalue) for v in _test_variants)
+            for attrname, attrvalue in attrs.items()
+        )
+
+        if original_testcase.NO_DEBUG_INFO_TESTCASE and not has_variant_tests:
             return original_testcase
 
         if original_testcase.TEST_WITH_PDB_DEBUG_INFO:
@@ -1817,7 +1968,7 @@ class LLDBTestCaseFactory(type):
 
         # Default implementation for skip/xfail reason based on the debug category,
         # where "None" means to run the test as usual.
-        def no_reason(_):
+        def no_reason(*args, **kwargs):
             return None
 
         newattrs = {}
@@ -1825,52 +1976,71 @@ class LLDBTestCaseFactory(type):
             if attrname.startswith("test") and not getattr(
                 attrvalue, "__no_debug_info_test__", False
             ):
-                # If any debug info categories were explicitly tagged, assume that list to be
-                # authoritative.  If none were specified, try with all debug info formats.
-                test_method_categories = set(getattr(attrvalue, "categories", []))
-                all_dbginfo_categories = set(
-                    test_categories.debug_info_categories.keys()
-                )
-                dbginfo_categories = test_method_categories & all_dbginfo_categories
-                other_categories = list(test_method_categories - all_dbginfo_categories)
-                if not dbginfo_categories:
-                    dbginfo_categories = [
-                        category
-                        for category, can_replicate in test_categories.debug_info_categories.items()
-                        if can_replicate
-                    ]
+                # Create debug info variants unless NO_DEBUG_INFO_TESTCASE
+                if not original_testcase.NO_DEBUG_INFO_TESTCASE:
+                    # If any debug info categories were explicitly tagged, assume that list to be
+                    # authoritative.  If none were specified, try with all debug info formats.
+                    test_method_categories = set(getattr(attrvalue, "categories", []))
+                    all_dbginfo_categories = set(
+                        test_categories.debug_info_categories.keys()
+                    )
+                    dbginfo_categories = test_method_categories & all_dbginfo_categories
+                    other_categories = list(
+                        test_method_categories - all_dbginfo_categories
+                    )
+                    if not dbginfo_categories:
+                        dbginfo_categories = [
+                            category
+                            for category, enabled in test_categories.debug_info_categories.items()
+                            if enabled
+                        ]
 
                     # PDB is off by default, because it has a lot of failures right now.
                     # See llvm.org/pr149498
                     if original_testcase.TEST_WITH_PDB_DEBUG_INFO:
                         dbginfo_categories.append("pdb")
 
-                xfail_for_debug_info_cat_fn = getattr(
-                    attrvalue, "__xfail_for_debug_info_cat_fn__", no_reason
-                )
-                skip_for_debug_info_cat_fn = getattr(
-                    attrvalue, "__skip_for_debug_info_cat_fn__", no_reason
-                )
-                for cat in dbginfo_categories:
+                    xfail_fns = getattr(attrvalue, "__variant_xfail__", {})
+                    skip_fns = getattr(attrvalue, "__variant_skip__", {})
+                    xfail_for_debug_info_cat_fn = xfail_fns.get("debug_info", no_reason)
+                    skip_for_debug_info_cat_fn = skip_fns.get("debug_info", no_reason)
+                    for cat in dbginfo_categories:
 
-                    @wraps(attrvalue)
-                    def test_method(self, attrvalue=attrvalue):
-                        return attrvalue(self)
+                        @decorators.add_test_categories([cat])
+                        @wraps(attrvalue)
+                        def test_method(self, attrvalue=attrvalue):
+                            return attrvalue(self)
 
-                    method_name = attrname + "_" + cat
-                    test_method.__name__ = method_name
-                    test_method.debug_info = cat
-                    test_method.categories = other_categories + [cat]
+                        method_name = attrname + "_" + cat
+                        test_method.__name__ = method_name
+                        test_method.debug_info = cat
+                        test_method.categories = other_categories + [cat]
 
-                    xfail_reason = xfail_for_debug_info_cat_fn(cat)
-                    if xfail_reason:
-                        test_method = unittest.expectedFailure(test_method)
+                        xfail_reason = xfail_for_debug_info_cat_fn(debug_info=cat)
+                        if xfail_reason:
+                            test_method = unittest.expectedFailure(test_method)
 
-                    skip_reason = skip_for_debug_info_cat_fn(cat)
-                    if skip_reason:
-                        test_method = unittest.skip(skip_reason)(test_method)
+                        skip_reason = skip_for_debug_info_cat_fn(debug_info=cat)
+                        if skip_reason:
+                            test_method = unittest.skip(skip_reason)(test_method)
 
-                    newattrs[method_name] = test_method
+                        newattrs[method_name] = test_method
+                else:
+                    # NO_DEBUG_INFO_TESTCASE — put method in newattrs for variant expansion
+                    newattrs[attrname] = attrvalue
+
+                # Expand test variants (e.g. additional variant dimensions)
+                for variant in _test_variants:
+                    if variant.should_expand(attrvalue):
+                        xfail_fns = getattr(attrvalue, "__variant_xfail__", {})
+                        skip_fns = getattr(attrvalue, "__variant_skip__", {})
+                        newattrs = _expand_test_variants(
+                            attrname,
+                            newattrs,
+                            variant,
+                            xfail_fns=xfail_fns,
+                            skip_fns=skip_fns,
+                        )
 
             else:
                 newattrs[attrname] = attrvalue
@@ -1989,6 +2159,12 @@ class TestBase(Base, metaclass=LLDBTestCaseFactory):
 
         # And the result object.
         self.res = lldb.SBCommandReturnObject()
+
+        # Apply variant-specific settings.
+        for variant in _test_variants:
+            variant_value = self.getVariant(variant.name)
+            if variant_value is not None:
+                variant.apply_settings(self, variant_value)
 
     def registerSharedLibrariesWithTarget(self, target, shlibs):
         """If we are remotely running the test suite, register the shared libraries with the target so they get uploaded, otherwise do nothing


### PR DESCRIPTION
Add a generic `TestVariant` class and `_expand_test_variants` function that can be used to create new test variant dimensions (similar to the existing debug_info variant expansion).

Each TestVariant describes a dimension that multiplies test methods by different configurations. The infrastructure handles method expansion, xfail/skip decorator support, and setUp-time configuration.

This also generalizes `_xfailForDebugInfo`/`_skipForDebugInfo` into `_xfailForVariant`/`_skipForVariant`, and changes the decorator's inner fn() to accept **kwargs so variant values can be passed by name.

The `_test_variants` list is currently empty — downstream forks (i.e. swift) can register their own variants without modifying the metaclass logic.