### PR TITLE
[lldb] Assert & fix missing calls to UnregisterPlugin

### DIFF
--- a/lldb/source/Core/PluginManager.cpp
+++ b/lldb/source/Core/PluginManager.cpp
@@ -493,6 +493,10 @@ template <typename Callback> struct PluginInstance {
 
 template <typename Instance> class PluginInstances {
 public:
+  ~PluginInstances() {
+    assert(m_instances.empty() && "forgot to unregister plugin?");
+  }
+
   template <typename... Args>
   bool RegisterPlugin(llvm::StringRef name, llvm::StringRef description,
                       typename Instance::CallbackType callback,

--- a/lldb/source/Plugins/DynamicLoader/Hexagon-DYLD/DynamicLoaderHexagonDYLD.cpp
+++ b/lldb/source/Plugins/DynamicLoader/Hexagon-DYLD/DynamicLoaderHexagonDYLD.cpp
@@ -77,7 +77,9 @@ void DynamicLoaderHexagonDYLD::Initialize() {
                                 GetPluginDescriptionStatic(), CreateInstance);
 }
 
-void DynamicLoaderHexagonDYLD::Terminate() {}
+void DynamicLoaderHexagonDYLD::Terminate() {
+  PluginManager::UnregisterPlugin(CreateInstance);
+}
 
 llvm::StringRef DynamicLoaderHexagonDYLD::GetPluginDescriptionStatic() {
   return "Dynamic loader plug-in that watches for shared library "

--- a/lldb/source/Plugins/DynamicLoader/POSIX-DYLD/DynamicLoaderPOSIXDYLD.cpp
+++ b/lldb/source/Plugins/DynamicLoader/POSIX-DYLD/DynamicLoaderPOSIXDYLD.cpp
@@ -42,7 +42,9 @@ void DynamicLoaderPOSIXDYLD::Initialize() {
                                 GetPluginDescriptionStatic(), CreateInstance);
 }
 
-void DynamicLoaderPOSIXDYLD::Terminate() {}
+void DynamicLoaderPOSIXDYLD::Terminate() {
+  PluginManager::UnregisterPlugin(CreateInstance);
+}
 
 llvm::StringRef DynamicLoaderPOSIXDYLD::GetPluginDescriptionStatic() {
   return "Dynamic loader plug-in that watches for shared library "

--- a/lldb/source/Plugins/DynamicLoader/Windows-DYLD/DynamicLoaderWindowsDYLD.cpp
+++ b/lldb/source/Plugins/DynamicLoader/Windows-DYLD/DynamicLoaderWindowsDYLD.cpp
@@ -36,7 +36,9 @@ void DynamicLoaderWindowsDYLD::Initialize() {
                                 GetPluginDescriptionStatic(), CreateInstance);
 }
 
-void DynamicLoaderWindowsDYLD::Terminate() {}
+void DynamicLoaderWindowsDYLD::Terminate() {
+  PluginManager::UnregisterPlugin(CreateInstance);
+}
 
 llvm::StringRef DynamicLoaderWindowsDYLD::GetPluginDescriptionStatic() {
   return "Dynamic loader plug-in that watches for shared library "

--- a/lldb/source/Plugins/DynamicLoader/wasm-DYLD/DynamicLoaderWasmDYLD.cpp
+++ b/lldb/source/Plugins/DynamicLoader/wasm-DYLD/DynamicLoaderWasmDYLD.cpp
@@ -31,6 +31,10 @@ void DynamicLoaderWasmDYLD::Initialize() {
                                 GetPluginDescriptionStatic(), CreateInstance);
 }
 
+void DynamicLoaderWasmDYLD::Terminate() {
+  PluginManager::UnregisterPlugin(CreateInstance);
+}
+
 llvm::StringRef DynamicLoaderWasmDYLD::GetPluginDescriptionStatic() {
   return "Dynamic loader plug-in that watches for shared library "
          "loads/unloads in WebAssembly engines.";

--- a/lldb/source/Plugins/DynamicLoader/wasm-DYLD/DynamicLoaderWasmDYLD.h
+++ b/lldb/source/Plugins/DynamicLoader/wasm-DYLD/DynamicLoaderWasmDYLD.h
@@ -19,7 +19,7 @@ public:
   DynamicLoaderWasmDYLD(Process *process);
 
   static void Initialize();
-  static void Terminate() {}
+  static void Terminate();
 
   static llvm::StringRef GetPluginNameStatic() { return "wasm-dyld"; }
   static llvm::StringRef GetPluginDescriptionStatic();

--- a/lldb/source/Plugins/Platform/MacOSX/PlatformDarwin.cpp
+++ b/lldb/source/Plugins/Platform/MacOSX/PlatformDarwin.cpp
@@ -90,8 +90,6 @@ PlatformDarwin::~PlatformDarwin() = default;
 static uint32_t g_initialize_count = 0;
 
 void PlatformDarwin::Initialize() {
-  Platform::Initialize();
-
   if (g_initialize_count++ == 0) {
     PluginManager::RegisterPlugin(PlatformDarwin::GetPluginNameStatic(),
                                   PlatformDarwin::GetDescriptionStatic(),
@@ -106,8 +104,6 @@ void PlatformDarwin::Terminate() {
       PluginManager::UnregisterPlugin(PlatformDarwin::CreateInstance);
     }
   }
-
-  Platform::Terminate();
 }
 
 llvm::StringRef PlatformDarwin::GetDescriptionStatic() {

--- a/lldb/source/Plugins/Platform/MacOSX/PlatformMacOSX.cpp
+++ b/lldb/source/Plugins/Platform/MacOSX/PlatformMacOSX.cpp
@@ -84,7 +84,7 @@ void PlatformMacOSX::Terminate() {
   PlatformDarwinKernel::Terminate();
   PlatformAppleSimulator::Terminate();
 #endif
-  PlatformRemoteMacOSX::Initialize();
+  PlatformRemoteMacOSX::Terminate();
   PlatformRemoteiOS::Terminate();
   PlatformDarwin::Terminate();
 }

--- a/lldb/source/Plugins/Platform/MacOSX/PlatformRemoteMacOSX.cpp
+++ b/lldb/source/Plugins/Platform/MacOSX/PlatformRemoteMacOSX.cpp
@@ -38,8 +38,6 @@ static uint32_t g_initialize_count = 0;
 
 // Static Functions
 void PlatformRemoteMacOSX::Initialize() {
-  PlatformDarwin::Initialize();
-
   if (g_initialize_count++ == 0) {
     PluginManager::RegisterPlugin(PlatformRemoteMacOSX::GetPluginNameStatic(),
                                   PlatformRemoteMacOSX::GetDescriptionStatic(),
@@ -53,8 +51,6 @@ void PlatformRemoteMacOSX::Terminate() {
       PluginManager::UnregisterPlugin(PlatformRemoteMacOSX::CreateInstance);
     }
   }
-
-  PlatformDarwin::Terminate();
 }
 
 PlatformSP PlatformRemoteMacOSX::CreateInstance(bool force,

--- a/lldb/source/Plugins/Process/Windows/Common/ProcessWindows.cpp
+++ b/lldb/source/Plugins/Process/Windows/Common/ProcessWindows.cpp
@@ -107,7 +107,10 @@ void ProcessWindows::Initialize() {
   }
 }
 
-void ProcessWindows::Terminate() {}
+void ProcessWindows::Terminate() {
+  if (!ShouldUseLLDBServer())
+    PluginManager::UnregisterPlugin(CreateInstance);
+}
 
 llvm::StringRef ProcessWindows::GetPluginDescriptionStatic() {
   return "Process plugin for Windows";

--- a/lldb/source/Plugins/RegisterTypeBuilder/RegisterTypeBuilderClang.cpp
+++ b/lldb/source/Plugins/RegisterTypeBuilder/RegisterTypeBuilderClang.cpp
@@ -23,7 +23,9 @@ void RegisterTypeBuilderClang::Initialize() {
                                 GetPluginDescriptionStatic(), CreateInstance);
 }
 
-void RegisterTypeBuilderClang::Terminate() {}
+void RegisterTypeBuilderClang::Terminate() {
+  PluginManager::UnregisterPlugin(CreateInstance);
+}
 
 lldb::RegisterTypeBuilderSP
 RegisterTypeBuilderClang::CreateInstance(Target &target) {

--- a/lldb/source/Plugins/ScriptInterpreter/Lua/ScriptInterpreterLua.cpp
+++ b/lldb/source/Plugins/ScriptInterpreter/Lua/ScriptInterpreterLua.cpp
@@ -245,7 +245,9 @@ void ScriptInterpreterLua::Initialize() {
                                 lldb::eScriptLanguageLua, CreateInstance);
 }
 
-void ScriptInterpreterLua::Terminate() {}
+void ScriptInterpreterLua::Terminate() {
+  PluginManager::UnregisterPlugin(CreateInstance);
+}
 
 llvm::Error ScriptInterpreterLua::EnterSession(user_id_t debugger_id) {
   if (m_session_is_active)

--- a/lldb/source/Plugins/ScriptInterpreter/None/ScriptInterpreterNone.cpp
+++ b/lldb/source/Plugins/ScriptInterpreter/None/ScriptInterpreterNone.cpp
@@ -43,7 +43,9 @@ void ScriptInterpreterNone::Initialize() {
                                 lldb::eScriptLanguageNone, CreateInstance);
 }
 
-void ScriptInterpreterNone::Terminate() {}
+void ScriptInterpreterNone::Terminate() {
+  PluginManager::UnregisterPlugin(CreateInstance);
+}
 
 lldb::ScriptInterpreterSP
 ScriptInterpreterNone::CreateInstance(Debugger &debugger) {

--- a/lldb/source/Plugins/ScriptInterpreter/Python/ScriptInterpreterPython.cpp
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/ScriptInterpreterPython.cpp
@@ -301,6 +301,7 @@ void ScriptInterpreterPython::Initialize() {
 
 void ScriptInterpreterPython::Terminate() {
   ScriptInterpreterPythonInterfaces::Terminate();
+  PluginManager::UnregisterPlugin(ScriptInterpreterPythonImpl::CreateInstance);
 }
 
 ScriptInterpreterPythonImpl::Locker::Locker(

--- a/lldb/test/API/api/command-return-object/main.cpp
+++ b/lldb/test/API/api/command-return-object/main.cpp
@@ -30,4 +30,5 @@ int main() {
   interp.AddCommand("crasher", &crasher, nullptr /*help*/);
   SBCommandReturnObject Result;
   dbg.GetCommandInterpreter().HandleCommand("crasher", Result);
+  SBDebugger::Terminate();
 }

--- a/lldb/test/API/api/multithreaded/driver.cpp.template
+++ b/lldb/test/API/api/multithreaded/driver.cpp.template
@@ -47,5 +47,6 @@ int main(int argc, char** argv) {
   }
 
   SBDebugger::Destroy(dbg);
+  SBDebugger::Terminate();
   return code;
 }

--- a/lldb/tools/lldb-test/SystemInitializerTest.cpp
+++ b/lldb/tools/lldb-test/SystemInitializerTest.cpp
@@ -69,7 +69,7 @@ void SystemInitializerTest::Terminate() {
 
   // We ignored all the script interpreter earlier, so terminate
   // ScriptInterpreterNone explicitly.
-  LLDB_PLUGIN_INITIALIZE(ScriptInterpreterNone);
+  LLDB_PLUGIN_TERMINATE(ScriptInterpreterNone);
 
   // Now shutdown the common parts, in reverse order.
   SystemInitializerCommon::Terminate();

--- a/lldb/unittests/Platform/PlatformDarwinTest.cpp
+++ b/lldb/unittests/Platform/PlatformDarwinTest.cpp
@@ -49,7 +49,7 @@ public:
                                   lldb::eScriptLanguagePython, CreateInstance);
   }
 
-  static void Terminate() {}
+  static void Terminate() { PluginManager::UnregisterPlugin(CreateInstance); }
 
   static lldb::ScriptInterpreterSP CreateInstance(Debugger &debugger) {
     return std::make_shared<MockScriptInterpreterPython>(debugger);

--- a/lldb/unittests/Process/ProcessTraceTest.cpp
+++ b/lldb/unittests/Process/ProcessTraceTest.cpp
@@ -26,7 +26,7 @@ public:
     PlatformLinux::Initialize();
   }
   void TearDown() override {
-    PlatformLinux::Initialize();
+    PlatformLinux::Terminate();
     HostInfo::Terminate();
     FileSystem::Terminate();
     ProcessTrace::Terminate();

--- a/lldb/unittests/Target/LocateModuleCallbackTest.cpp
+++ b/lldb/unittests/Target/LocateModuleCallbackTest.cpp
@@ -224,6 +224,9 @@ public:
     // Create MockProcess.
     PluginManager::RegisterPlugin(k_process_plugin, "",
                                   MockProcessCreateInstance);
+    auto unregister_plugin = llvm::scope_exit(
+        [&]() { PluginManager::UnregisterPlugin(MockProcessCreateInstance); });
+
     m_process_sp =
         m_target_sp->CreateProcess(Listener::MakeListener("test-listener"),
                                    k_process_plugin, /*crash_file=*/nullptr,


### PR DESCRIPTION
Fix missing calls to UnregisterPlugin and add an assert in the PluginManager that ensures all plugins have been unregistered by the time the plugin manager is destroyed.