### PR TITLE
[CIR][NFC] ComplexType visitStmt replace NYI with unreachable

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenExprComplex.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprComplex.cpp
@@ -61,8 +61,8 @@ public:
   }
 
   mlir::Value VisitStmt(Stmt *s) {
-    cgf.cgm.errorNYI(s->getBeginLoc(), "ComplexExprEmitter VisitStmt");
-    return {};
+    s->dump(llvm::errs(), cgf.getContext());
+    llvm_unreachable("Stmt can't have complex result type!");
   }
 
   mlir::Value VisitExpr(Expr *e);


### PR DESCRIPTION
Replace errorNYI with llvm_unreachable in ComplexType visitStmt