### PR TITLE
[Analysis] Require explict updates to BFI

### DIFF
--- a/llvm/include/llvm/Analysis/BlockFrequencyInfo.h
+++ b/llvm/include/llvm/Analysis/BlockFrequencyInfo.h
@@ -92,6 +92,9 @@ public:
   setBlockFreqAndScale(const BasicBlock *ReferenceBB, BlockFrequency Freq,
                        SmallPtrSetImpl<BasicBlock *> &BlocksToScale);
 
+  /// Remove basic block from analysis.
+  LLVM_ABI void eraseBlock(const BasicBlock *BB);
+
   /// calculate - compute block frequency info for the given function.
   LLVM_ABI void calculate(const Function &F, const BranchProbabilityInfo &BPI,
                           const LoopInfo &LI);

--- a/llvm/include/llvm/Analysis/BlockFrequencyInfoImpl.h
+++ b/llvm/include/llvm/Analysis/BlockFrequencyInfoImpl.h
@@ -26,7 +26,6 @@
 #include "llvm/ADT/iterator_range.h"
 #include "llvm/IR/BasicBlock.h"
 #include "llvm/IR/Function.h"
-#include "llvm/IR/ValueHandle.h"
 #include "llvm/Support/BlockFrequency.h"
 #include "llvm/Support/BranchProbability.h"
 #include "llvm/Support/CommandLine.h"
@@ -541,7 +540,6 @@ namespace bfi_detail {
 template <class BlockT> struct TypeMap {};
 template <> struct TypeMap<BasicBlock> {
   using BlockT = BasicBlock;
-  using BlockKeyT = AssertingVH<const BasicBlock>;
   using FunctionT = Function;
   using BranchProbabilityInfoT = BranchProbabilityInfo;
   using LoopT = Loop;
@@ -549,15 +547,11 @@ template <> struct TypeMap<BasicBlock> {
 };
 template <> struct TypeMap<MachineBasicBlock> {
   using BlockT = MachineBasicBlock;
-  using BlockKeyT = const MachineBasicBlock *;
   using FunctionT = MachineFunction;
   using BranchProbabilityInfoT = MachineBranchProbabilityInfo;
   using LoopT = MachineLoop;
   using LoopInfoT = MachineLoopInfo;
 };
-
-template <class BlockT, class BFIImplT>
-class BFICallbackVH;
 
 /// Get the name of a MachineBasicBlock.
 ///
@@ -841,7 +835,6 @@ void IrreducibleGraph::addEdges(const BlockNode &Node,
 ///         series by simulation.)
 template <class BT> class BlockFrequencyInfoImpl : BlockFrequencyInfoImplBase {
   using BlockT = typename bfi_detail::TypeMap<BT>::BlockT;
-  using BlockKeyT = typename bfi_detail::TypeMap<BT>::BlockKeyT;
   using FunctionT = typename bfi_detail::TypeMap<BT>::FunctionT;
   using BranchProbabilityInfoT =
       typename bfi_detail::TypeMap<BT>::BranchProbabilityInfoT;
@@ -849,18 +842,27 @@ template <class BT> class BlockFrequencyInfoImpl : BlockFrequencyInfoImplBase {
   using LoopInfoT = typename bfi_detail::TypeMap<BT>::LoopInfoT;
   using Successor = GraphTraits<const BlockT *>;
   using Predecessor = GraphTraits<Inverse<const BlockT *>>;
-  using BFICallbackVH =
-      bfi_detail::BFICallbackVH<BlockT, BlockFrequencyInfoImpl>;
 
   const BranchProbabilityInfoT *BPI = nullptr;
   const LoopInfoT *LI = nullptr;
   const FunctionT *F = nullptr;
 
   // All blocks in reverse postorder.
-  std::vector<BFICallbackVH> RPOT;
+  std::vector<const BlockT *> RPOT;
   DenseMap<const BlockT *, BlockNode> Nodes;
 
-  BlockNode getNode(const BlockT *BB) const { return Nodes.lookup(BB); }
+  BlockNode getNode(const BlockT *BB) const {
+#ifdef EXPENSIVE_CHECKS
+    // Try to catch cases where blocks were deleted (use-after-free can be
+    // caught by ASan) or moved to a different function, but the BFI was not
+    // updated. This is an asymptotically expensive check.
+    for (auto Node : RPOT)
+      assert((!Node || Node->getParent() == F) &&
+             "BFI stores basic block outside of function, missing update!");
+#endif
+    assert(BB->getParent() == F && "block must be in same function");
+    return Nodes.lookup(BB);
+  }
 
   const BlockT *getBlock(const BlockNode &Node) const {
     assert(Node.Index < RPOT.size());
@@ -1020,14 +1022,15 @@ public:
 
   void setBlockFreq(const BlockT *BB, BlockFrequency Freq);
 
-  void forgetBlock(const BlockT *BB) {
+  void eraseBlock(const BlockT *BB) {
+    assert(BB->getParent() == F && "block must be in same function");
     // We don't erase corresponding items from `Freqs`, `RPOT` and other to
     // avoid invalidating indices. Doing so would have saved some memory, but
     // it's not worth it.
-    auto It = Nodes.find(BB);
-    assert(It != Nodes.end() && "cannot forget block that was never seen");
-    RPOT[It->second.Index] = {}; // Clear value handle.
-    Nodes.erase(It);
+    if (auto It = Nodes.find(BB); It != Nodes.end()) {
+      RPOT[It->second.Index] = nullptr;
+      Nodes.erase(It);
+    }
   }
 
   Scaled64 getFloatingBlockFreq(const BlockT *BB) const {
@@ -1053,45 +1056,6 @@ public:
 
   void verifyMatch(BlockFrequencyInfoImpl<BT> &Other) const;
 };
-
-namespace bfi_detail {
-
-template <class BFIImplT>
-class BFICallbackVH<BasicBlock, BFIImplT> : public CallbackVH {
-  BFIImplT *BFIImpl;
-
-public:
-  BFICallbackVH() = default;
-
-  BFICallbackVH(const BasicBlock *BB, BFIImplT *BFIImpl)
-      : CallbackVH(BB), BFIImpl(BFIImpl) {}
-
-  virtual ~BFICallbackVH() = default;
-
-  void deleted() override {
-    BFIImpl->forgetBlock(cast<BasicBlock>(getValPtr()));
-  }
-
-  operator const BasicBlock *() const {
-    Value *V = *static_cast<const CallbackVH *>(this);
-    return cast<BasicBlock>(V);
-  }
-};
-
-/// Dummy implementation since MachineBasicBlocks aren't Values, so ValueHandles
-/// don't apply to them.
-template <class BFIImplT>
-class BFICallbackVH<MachineBasicBlock, BFIImplT> {
-  const MachineBasicBlock *MBB;
-
-public:
-  BFICallbackVH() = default;
-  BFICallbackVH(const MachineBasicBlock *MBB, BFIImplT *) : MBB(MBB) {}
-
-  operator const MachineBasicBlock *() const { return MBB; }
-};
-
-} // end namespace bfi_detail
 
 template <class BT>
 void BlockFrequencyInfoImpl<BT>::calculate(const FunctionT &F,
@@ -1148,7 +1112,7 @@ void BlockFrequencyInfoImpl<BT>::setBlockFreq(const BlockT *BB,
     BlockNode NewNode(Freqs.size());
     It->second = NewNode;
     Freqs.emplace_back();
-    RPOT.emplace_back(BB, this);
+    RPOT.emplace_back(BB);
     BlockFrequencyInfoImplBase::setBlockFreq(NewNode, Freq);
   }
 }
@@ -1157,7 +1121,7 @@ template <class BT> void BlockFrequencyInfoImpl<BT>::initializeRPOT() {
   const BlockT *Entry = &F->front();
   RPOT.reserve(F->size());
   for (const BlockT *BB : post_order(Entry))
-    RPOT.emplace_back(BB, this);
+    RPOT.emplace_back(BB);
   std::reverse(RPOT.begin(), RPOT.end());
 
   assert(RPOT.size() - 1 <= BlockNode::getMaxIndex() &&

--- a/llvm/include/llvm/CodeGen/MBFIWrapper.h
+++ b/llvm/include/llvm/CodeGen/MBFIWrapper.h
@@ -24,20 +24,22 @@ class MachineBasicBlock;
 class MachineBlockFrequencyInfo;
 
 class MBFIWrapper {
- public:
-  MBFIWrapper(const MachineBlockFrequencyInfo &I) : MBFI(I) {}
+public:
+  MBFIWrapper(MachineBlockFrequencyInfo &I) : MBFI(I) {}
 
   BlockFrequency getBlockFreq(const MachineBasicBlock *MBB) const;
   void setBlockFreq(const MachineBasicBlock *MBB, BlockFrequency F);
   std::optional<uint64_t>
   getBlockProfileCount(const MachineBasicBlock *MBB) const;
 
+  void eraseBlock(const MachineBasicBlock *MBB);
+
   void view(const Twine &Name, bool isSimple = true);
   BlockFrequency getEntryFreq() const;
   const MachineBlockFrequencyInfo &getMBFI() const { return MBFI; }
 
 private:
-  const MachineBlockFrequencyInfo &MBFI;
+  MachineBlockFrequencyInfo &MBFI;
   DenseMap<const MachineBasicBlock *, BlockFrequency> MergedBBFreq;
 };
 

--- a/llvm/include/llvm/CodeGen/MachineBlockFrequencyInfo.h
+++ b/llvm/include/llvm/CodeGen/MachineBlockFrequencyInfo.h
@@ -80,6 +80,8 @@ public:
   LLVM_ABI std::optional<uint64_t>
   getProfileCountFromFreq(BlockFrequency Freq) const;
 
+  LLVM_ABI void eraseBlock(const MachineBasicBlock *MBB);
+
   LLVM_ABI bool isIrrLoopHeader(const MachineBasicBlock *MBB) const;
 
   /// incrementally calculate block frequencies when we split edges, to avoid

--- a/llvm/lib/Analysis/BlockFrequencyInfo.cpp
+++ b/llvm/lib/Analysis/BlockFrequencyInfo.cpp
@@ -250,6 +250,10 @@ void BlockFrequencyInfo::setBlockFreqAndScale(
   BFI->setBlockFreq(ReferenceBB, Freq);
 }
 
+void BlockFrequencyInfo::eraseBlock(const BasicBlock *BB) {
+  BFI->eraseBlock(BB);
+}
+
 /// Pop up a ghostview window with the current block frequency propagation
 /// rendered using dot.
 void BlockFrequencyInfo::view(StringRef title) const {

--- a/llvm/lib/CodeGen/BranchFolding.cpp
+++ b/llvm/lib/CodeGen/BranchFolding.cpp
@@ -204,6 +204,8 @@ void BranchFolder::RemoveDeadBlock(MachineBasicBlock *MBB) {
     if (MI.shouldUpdateAdditionalCallInfo())
       MF->eraseAdditionalCallInfo(&MI);
 
+  MBBFreqInfo.eraseBlock(MBB);
+
   // Remove the block.
   MF->erase(MBB);
   EHScopeMembership.erase(MBB);

--- a/llvm/lib/CodeGen/CodeGenPrepare.cpp
+++ b/llvm/lib/CodeGen/CodeGenPrepare.cpp
@@ -1134,6 +1134,7 @@ void CodeGenPrepare::eliminateMostlyEmptyBlock(BasicBlock *BB) {
       assert(SinglePred == BB &&
              "Single predecessor not the same as predecessor");
       // Merge DestBB into SinglePred/BB and delete it.
+      BFI->eraseBlock(DestBB);
       MergeBlockIntoPredecessor(DestBB);
       // Note: BB(=SinglePred) will not be deleted on this path.
       // DestBB(=its single successor) is the one that was deleted.
@@ -1184,6 +1185,7 @@ void CodeGenPrepare::eliminateMostlyEmptyBlock(BasicBlock *BB) {
   // The PHIs are now updated, change everything that refers to BB to use
   // DestBB and remove BB.
   BB->replaceAllUsesWith(DestBB);
+  BFI->eraseBlock(BB);
   BB->eraseFromParent();
   ++NumBlocksElim;
 

--- a/llvm/lib/CodeGen/MBFIWrapper.cpp
+++ b/llvm/lib/CodeGen/MBFIWrapper.cpp
@@ -43,6 +43,12 @@ MBFIWrapper::getBlockProfileCount(const MachineBasicBlock *MBB) const {
   return MBFI.getBlockProfileCount(MBB);
 }
 
+void MBFIWrapper::eraseBlock(const MachineBasicBlock *MBB) {
+  if (auto I = MergedBBFreq.find(MBB); I != MergedBBFreq.end())
+    MergedBBFreq.erase(I);
+  MBFI.eraseBlock(MBB);
+}
+
 void MBFIWrapper::view(const Twine &Name, bool isSimple) {
   MBFI.view(Name, isSimple);
 }

--- a/llvm/lib/CodeGen/MachineBlockFrequencyInfo.cpp
+++ b/llvm/lib/CodeGen/MachineBlockFrequencyInfo.cpp
@@ -309,6 +309,11 @@ BlockFrequency MachineBlockFrequencyInfo::getEntryFreq() const {
   return MBFI ? MBFI->getEntryFreq() : BlockFrequency(0);
 }
 
+void MachineBlockFrequencyInfo::eraseBlock(const MachineBasicBlock *MBB) {
+  if (MBFI)
+    MBFI->eraseBlock(MBB);
+}
+
 Printable llvm::printBlockFreq(const MachineBlockFrequencyInfo &MBFI,
                                BlockFrequency Freq) {
   return Printable([&MBFI, Freq](raw_ostream &OS) {

--- a/llvm/lib/CodeGen/TailDuplicator.cpp
+++ b/llvm/lib/CodeGen/TailDuplicator.cpp
@@ -19,6 +19,7 @@
 #include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/Statistic.h"
+#include "llvm/CodeGen/MBFIWrapper.h"
 #include "llvm/CodeGen/MachineBasicBlock.h"
 #include "llvm/CodeGen/MachineBranchProbabilityInfo.h"
 #include "llvm/CodeGen/MachineFunction.h"
@@ -193,6 +194,8 @@ bool TailDuplicator::tailDuplicateAndUpdate(
   // If it is dead, remove it.
   if (isDead) {
     NumTailDupRemoved += MBB->size();
+    if (MBFI)
+      MBFI->eraseBlock(MBB);
     removeDeadBlock(MBB, RemovalCallback);
     ++NumDeadBlocks;
   }

--- a/llvm/lib/Transforms/Utils/CodeExtractor.cpp
+++ b/llvm/lib/Transforms/Utils/CodeExtractor.cpp
@@ -1154,6 +1154,8 @@ void CodeExtractor::moveCodeToFunction(Function *newFunction) {
   auto newFuncIt = newFunction->begin();
   for (BasicBlock *Block : Blocks) {
     // Delete the basic block from the old function, and the list of blocks
+    if (BFI)
+      BFI->eraseBlock(Block);
     Block->removeFromParent();
 
     // Insert this basic block into the new function

--- a/llvm/lib/Transforms/Utils/InlineFunction.cpp
+++ b/llvm/lib/Transforms/Utils/InlineFunction.cpp
@@ -3230,6 +3230,8 @@ void llvm::InlineFunctionImpl(CallBase &CB, InlineFunctionInfo &IFI,
     // Move all of the instructions right before the call.
     OrigBB->splice(CB.getIterator(), &*FirstNewBlock, FirstNewBlock->begin(),
                    FirstNewBlock->end());
+    if (IFI.UpdateProfile && IFI.CallerBFI)
+      IFI.CallerBFI->eraseBlock(&Caller->back());
     // Remove the cloned basic block.
     Caller->back().eraseFromParent();
 
@@ -3375,6 +3377,8 @@ void llvm::InlineFunctionImpl(CallBase &CB, InlineFunctionInfo &IFI,
 
     // Delete the return instruction now and empty ReturnBB now.
     Returns[0]->eraseFromParent();
+    if (IFI.CallerBFI)
+      IFI.CallerBFI->eraseBlock(ReturnBB);
     ReturnBB->eraseFromParent();
   } else if (!CB.use_empty()) {
     // In this case there are no returns to use, so there is no clear source
@@ -3410,6 +3414,8 @@ void llvm::InlineFunctionImpl(CallBase &CB, InlineFunctionInfo &IFI,
   Br->eraseFromParent();
 
   // Now we can remove the CalleeEntry block, which is now empty.
+  if (IFI.CallerBFI)
+    IFI.CallerBFI->eraseBlock(CalleeEntry);
   CalleeEntry->eraseFromParent();
 
   // If we inserted a phi node, check to see if it has a single value (e.g. all


### PR DESCRIPTION
Value handles are not cheap and registering a value handle for every basic block just in case it gets removed adds some cost. As the number of places that remove/erase blocks and continue to use the BFI afterwards is low (IR: Inliner, PartialInliner (CodeExtractor), CodeGenPrepare; Machine IR: BranchFolder, TailDuplicator), change these passes to update the BFI explicitly when blocks are removed.

Verification of integrity is not easy and there is no good place for such logic. Therefore, when building with EXPENSIVE_CHECKS, verify the parent of all stored nodes on every access. This will result in use-after-frees for erased blocks, which can be caught with ASan, Valgrind, or MALLOC_PERTURB_.

This is preliminary work to use block numbers instead of a DenseMap.

---

http://llvm-compile-time-tracker.com/compare.php?from=534d6e887ff815cdba5f9e2784b6b432faac25c1&to=368b367083ab417b35cb85bcdf415aa47a64c6c5&stat=instructions:u