### PR TITLE
[clangd] Disable PCH for libs that use gRPC

### DIFF
--- a/clang-tools-extra/clangd/index/dex/dexp/CMakeLists.txt
+++ b/clang-tools-extra/clangd/index/dex/dexp/CMakeLists.txt
@@ -5,6 +5,9 @@ set(LLVM_LINK_COMPONENTS
 
 add_clang_executable(dexp
   Dexp.cpp
+
+  # Disable PCH, gRPC adds -pthread.
+  DISABLE_PCH_REUSE
   )
 
 clang_target_link_libraries(dexp

--- a/clang-tools-extra/clangd/index/remote/CMakeLists.txt
+++ b/clang-tools-extra/clangd/index/remote/CMakeLists.txt
@@ -32,6 +32,9 @@ if (CLANGD_ENABLE_REMOTE)
     DEPENDS
     clangdRemoteIndexProto
     clangdRemoteIndexServiceProto
+
+    # Disable PCH, gRPC adds -pthread.
+    DISABLE_PCH_REUSE
     )
 
   clang_target_link_libraries(clangdRemoteIndex

--- a/clang-tools-extra/clangd/index/remote/marshalling/CMakeLists.txt
+++ b/clang-tools-extra/clangd/index/remote/marshalling/CMakeLists.txt
@@ -8,4 +8,7 @@ add_clang_library(clangdRemoteMarshalling STATIC
 
   DEPENDS
   clangdRemoteIndexProto
+
+  # Disable PCH, gRPC adds -pthread.
+  DISABLE_PCH_REUSE
   )

--- a/clang-tools-extra/clangd/index/remote/monitor/CMakeLists.txt
+++ b/clang-tools-extra/clangd/index/remote/monitor/CMakeLists.txt
@@ -6,6 +6,9 @@ add_clang_executable(clangd-index-server-monitor
 
   DEPENDS
   clangdRemoteIndexServiceProto
+
+  # Disable PCH, gRPC adds -pthread.
+  DISABLE_PCH_REUSE
   )
 
 target_link_libraries(clangd-index-server-monitor

--- a/clang-tools-extra/clangd/index/remote/server/CMakeLists.txt
+++ b/clang-tools-extra/clangd/index/remote/server/CMakeLists.txt
@@ -7,6 +7,9 @@ add_clang_executable(clangd-index-server
   DEPENDS
   clangdRemoteIndexProto
   clangdRemoteIndexServiceProto
+
+  # Disable PCH, gRPC adds -pthread.
+  DISABLE_PCH_REUSE
   )
 
 target_link_libraries(clangd-index-server

--- a/clang-tools-extra/clangd/tool/CMakeLists.txt
+++ b/clang-tools-extra/clangd/tool/CMakeLists.txt
@@ -4,6 +4,9 @@ set(LLVM_OPTIONAL_SOURCES ClangdToolMain.cpp)
 add_clang_library(clangdMain STATIC
   ClangdMain.cpp
   Check.cpp
+
+  # Disable PCH, gRPC adds -pthread.
+  DISABLE_PCH_REUSE
   )
 
 add_clang_tool(clangd

--- a/clang/cmake/modules/AddGRPC.cmake
+++ b/clang/cmake/modules/AddGRPC.cmake
@@ -7,5 +7,8 @@ function(generate_clang_protos_library LibraryName ProtoFile)
 
   add_clang_library(${LibraryName} ${ProtoSource}
     PARTIAL_SOURCES_INTENDED
-    LINK_LIBS PUBLIC grpc++ protobuf)
+    LINK_LIBS PUBLIC grpc++ protobuf
+    # Disable PCH, gRPC adds -pthread.
+    DISABLE_PCH_REUSE
+    )
 endfunction()


### PR DESCRIPTION
gRPC adds -pthread, which is incompatible with PCH without it. At some point, we probably should generally switch from -lpthread to -pthread, but until then, disable PCH for affected targets.

Fixes https://github.com/llvm/llvm-project/issues/184759.