### PR TITLE
[mlir] Fix tests not to depend `llvm-strings` in standalone build

### DIFF
--- a/mlir/test/CMakeLists.txt
+++ b/mlir/test/CMakeLists.txt
@@ -102,7 +102,6 @@ configure_lit_site_cfg(
   )
 
 set(MLIR_TEST_DEPENDS
-  llvm-strings
   mlir-capi-ir-test
   mlir-capi-irdl-test
   mlir-capi-llvm-test
@@ -126,7 +125,14 @@ set(MLIR_TEST_DEPENDS
   tblgen-to-irdl
   )
 if(NOT MLIR_STANDALONE_BUILD)
-  list(APPEND MLIR_TEST_DEPENDS FileCheck count not split-file yaml2obj)
+  list(APPEND MLIR_TEST_DEPENDS
+    FileCheck
+    count
+    llvm-strings
+    not
+    split-file
+    yaml2obj
+    )
 endif()
 # Examples/standalone/test.toy (vis-a-vis the standalone example) depends on these.
 if(LLVM_INCLUDE_EXAMPLES)


### PR DESCRIPTION
Move the `llvm-strings` test dependency into the non-standalone test dependency block, to fix standalone builds after #182846.  While at it, reformat the block to make it more visible.