### PR TITLE
[PPC64][Linux] Watchpoint configuration for PPC64

### DIFF
--- a/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationServerCommon.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationServerCommon.cpp
@@ -234,7 +234,7 @@ GDBRemoteCommunicationServerCommon::Handle_qHostInfo(
       host_arch.GetMachine() == llvm::Triple::aarch64_be ||
       host_arch.GetMachine() == llvm::Triple::arm ||
       host_arch.GetMachine() == llvm::Triple::armeb || host_arch.IsMIPS() ||
-      host_arch.GetTriple().isLoongArch())
+      host_arch.GetTriple().isPPC64() || host_arch.GetTriple().isLoongArch())
     response.Printf("watchpoint_exceptions_received:before;");
   else
     response.Printf("watchpoint_exceptions_received:after;");


### PR DESCRIPTION
On PPC64, SIGTRAP is delivered before the triggering instruction completes. The previous implementation wrongly assumed that the instruction gets executed and due to that qHostInfo has the wrong info, causing the SingleStep being avoided on Linux for PPC64, and the execution being stuck at the store instruction.
This patch corrects this, making watchpoint work.