### PR TITLE
[mlir][LLVM] Disallow opaque struct types as function arguments

### DIFF
--- a/mlir/lib/Dialect/LLVMIR/IR/LLVMTypes.cpp
+++ b/mlir/lib/Dialect/LLVMIR/IR/LLVMTypes.cpp
@@ -208,6 +208,9 @@ LLVMArrayType::getPreferredAlignment(const DataLayout &dataLayout,
 //===----------------------------------------------------------------------===//
 
 bool LLVMFunctionType::isValidArgumentType(Type type) {
+  if (auto structType = dyn_cast<LLVMStructType>(type))
+    return !structType.isOpaque();
+
   return !llvm::isa<LLVMVoidType, LLVMFunctionType>(type);
 }
 

--- a/mlir/test/Dialect/LLVMIR/types-invalid.mlir
+++ b/mlir/test/Dialect/LLVMIR/types-invalid.mlir
@@ -14,6 +14,13 @@ func.func @function_returning_function() {
 
 // -----
 
+func.func @function_taking_opaque_struct() {
+  // expected-error @+1 {{invalid function argument type}}
+  "some.op"() : () -> !llvm.func<void(struct<"foo", opaque>)>
+}
+
+// -----
+
 func.func @function_taking_function() {
   // expected-error @+1 {{invalid function argument type}}
   "some.op"() : () -> !llvm.func<void (func<void ()>)>


### PR DESCRIPTION
Function types are only allowed to take first-class values as arguments. The LLVM dialect implemented this correctly so far except for allowing opaque struct types. When translated to LLVM proper, invalid IR would be created with confusing assertion errors.

This PR matches LLVM by disallowing opaque struct types as arguments, allowing users to catch this kind of mistake early while still in the MLIR world.

The corresponding LLVM logic is here: https://github.com/llvm/llvm-project/blob/c4898f3f229027e6cbdf8f9db77b8c14d70f6599/llvm/lib/IR/Type.cpp#L404