### PR TITLE
[compiler-rt] Use static buffers in setvbuf/setbuf/setbuffer tests

### DIFF
--- a/compiler-rt/test/sanitizer_common/TestCases/Posix/setvbuf.cpp
+++ b/compiler-rt/test/sanitizer_common/TestCases/Posix/setvbuf.cpp
@@ -14,7 +14,7 @@ void print_one_byte(char *buf) {
 }
 
 void test_setbuf() {
-  char buf[BUFSIZ];
+  static char buf[BUFSIZ];
 
   setbuf(stdout, NULL);
 
@@ -30,7 +30,7 @@ void test_setbuf() {
 }
 
 void test_setbuffer() {
-  char buf[BUFSIZ];
+  static char buf[BUFSIZ];
 
   setbuffer(stdout, NULL, 0);
 
@@ -54,7 +54,7 @@ void test_setlinebuf() {
 }
 
 void test_setvbuf() {
-  char buf[BUFSIZ];
+  static char buf[BUFSIZ];
 
   setvbuf(stdout, NULL, _IONBF, 0);
 


### PR DESCRIPTION
[The buffers passed to `setvbuf`/`setbuf`/`setbuffer` must outlive the stream](https://www.ibm.com/docs/en/zos/3.1.0?topic=functions-setvbuf-control-buffering). Using stack-allocated buffers is undefined behavior if the stream remains open after the function returns. While each test function resets `stdout` to unbuffered before returning, make the buffers static to avoid relying on this ordering.