### PR TITLE
[MLIR][Func] Return nullptr for empty ResultAttrs

### DIFF
--- a/mlir/include/mlir/Interfaces/FunctionInterfaces.td
+++ b/mlir/include/mlir/Interfaces/FunctionInterfaces.td
@@ -490,8 +490,11 @@ def FunctionOpInterface : OpInterface<"FunctionOpInterface", [
     }
 
     /// Return an ArrayAttr containing all result attribute dictionaries of this
-    /// function, or nullptr if no result have attributes.
-    ::mlir::ArrayAttr getAllResultAttrs() { return $_op.getResAttrsAttr(); }
+    /// function, or nullptr if no results have attributes.
+    ::mlir::ArrayAttr getAllResultAttrs() {
+      auto attrs = $_op.getResAttrsAttr();
+      return attrs && !attrs.empty() ? attrs : nullptr;
+    }
 
     /// Return all result attributes of this function.
     void getAllResultAttrs(::llvm::SmallVectorImpl<::mlir::DictionaryAttr> &result) {

--- a/mlir/test/Conversion/FuncToLLVM/convert-funcs.mlir
+++ b/mlir/test/Conversion/FuncToLLVM/convert-funcs.mlir
@@ -96,3 +96,10 @@ func.func private @badllvmlinkage(i32) attributes { "llvm.linkage" = 3 : i64 } /
 func.func @variadic_func(%arg0: i32) attributes { "func.varargs" = true, "llvm.emit_c_interface" } {
   return
 }
+
+// -----
+
+// CHECK-LABEL: llvm.func @empty_res_attrs()
+func.func @empty_res_attrs() attributes {res_attrs = []} {
+  return
+}


### PR DESCRIPTION
Fixes #185156

When an empty res_attrs is passed manually, we should still return nullptr to indicate that no results have attributes.