### PR TITLE
[libc] 185136 - added iswlower entry point

### DIFF
--- a/libc/config/baremetal/arm/entrypoints.txt
+++ b/libc/config/baremetal/arm/entrypoints.txt
@@ -300,6 +300,7 @@ set(TARGET_LIBC_ENTRYPOINTS
     # wctype.h entrypoints
     libc.src.wctype.iswalpha
     libc.src.wctype.iswdigit
+    libc.src.wctype.iswlower
 
     # internal entrypoints
     libc.startup.baremetal.init

--- a/libc/config/baremetal/riscv/entrypoints.txt
+++ b/libc/config/baremetal/riscv/entrypoints.txt
@@ -297,6 +297,7 @@ set(TARGET_LIBC_ENTRYPOINTS
     # wctype.h entrypoints
     libc.src.wctype.iswalpha
     libc.src.wctype.iswdigit
+    libc.src.wctype.iswlower
 
     # internal entrypoints
     libc.startup.baremetal.init

--- a/libc/config/darwin/aarch64/entrypoints.txt
+++ b/libc/config/darwin/aarch64/entrypoints.txt
@@ -103,6 +103,7 @@ set(TARGET_LIBC_ENTRYPOINTS
     # wctype.h entrypoints
     libc.src.wctype.iswalpha
     libc.src.wctype.iswdigit
+    libc.src.wctype.iswlower
 )
 
 if(LLVM_LIBC_FULL_BUILD)

--- a/libc/config/linux/aarch64/entrypoints.txt
+++ b/libc/config/linux/aarch64/entrypoints.txt
@@ -370,6 +370,7 @@ set(TARGET_LIBC_ENTRYPOINTS
     # wctype.h entrypoints
     libc.src.wctype.iswalpha
     libc.src.wctype.iswdigit
+    libc.src.wctype.iswlower
 
     # sys/uio.h entrypoints
     libc.src.sys.uio.writev

--- a/libc/config/linux/arm/entrypoints.txt
+++ b/libc/config/linux/arm/entrypoints.txt
@@ -195,6 +195,7 @@ set(TARGET_LIBC_ENTRYPOINTS
     # wctype.h entrypoints
     libc.src.wctype.iswalpha
     libc.src.wctype.iswdigit
+    libc.src.wctype.iswlower
 )
 
 if(LLVM_LIBC_FULL_BUILD)

--- a/libc/config/linux/riscv/entrypoints.txt
+++ b/libc/config/linux/riscv/entrypoints.txt
@@ -374,6 +374,7 @@ set(TARGET_LIBC_ENTRYPOINTS
     # wctype.h entrypoints
     libc.src.wctype.iswalpha
     libc.src.wctype.iswdigit
+    libc.src.wctype.iswlower
 
     # sys/uio.h entrypoints
     libc.src.sys.uio.writev

--- a/libc/config/linux/x86_64/entrypoints.txt
+++ b/libc/config/linux/x86_64/entrypoints.txt
@@ -419,6 +419,7 @@ set(TARGET_LIBC_ENTRYPOINTS
     # wctype.h entrypoints
     libc.src.wctype.iswalpha
     libc.src.wctype.iswdigit
+    libc.src.wctype.iswlower
 
     # sys/uio.h entrypoints
     libc.src.sys.uio.writev

--- a/libc/config/windows/entrypoints.txt
+++ b/libc/config/windows/entrypoints.txt
@@ -108,6 +108,7 @@ set(TARGET_LIBC_ENTRYPOINTS
 
     # wctype.h entrypoints
     libc.src.wctype.iswalpha
+    libc.src.wctype.iswlower
 )
 
 set(TARGET_LIBM_ENTRYPOINTS

--- a/libc/include/wctype.yaml
+++ b/libc/include/wctype.yaml
@@ -8,3 +8,9 @@ functions:
     return_type: int
     arguments:
       - type: wint_t
+  - name: iswlower
+    standards:
+      - stdc
+    return_type: int
+    arguments:
+      - type: wint_t

--- a/libc/src/wctype/CMakeLists.txt
+++ b/libc/src/wctype/CMakeLists.txt
@@ -17,3 +17,13 @@ add_entrypoint_object(
   DEPENDS
     libc.src.__support.wctype_utils    
 )
+
+add_entrypoint_object(
+  iswlower
+  SRCS
+    iswlower.cpp
+  HDRS
+    iswlower.h
+  DEPENDS
+    libc.src.__support.wctype_utils
+)

--- a/libc/src/wctype/CMakeLists.txt
+++ b/libc/src/wctype/CMakeLists.txt
@@ -26,4 +26,5 @@ add_entrypoint_object(
     iswlower.h
   DEPENDS
     libc.src.__support.wctype_utils
+    libc.hdr.types.wint_t
 )

--- a/libc/src/wctype/iswlower.cpp
+++ b/libc/src/wctype/iswlower.cpp
@@ -1,0 +1,21 @@
+//===-- Implementation of iswlower ----------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/wctype/iswlower.h"
+#include "src/__support/common.h"
+#include "src/__support/wctype_utils.h"
+
+#include "hdr/types/wint_t.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(int, iswlower, (wint_t c)) {
+  return internal::islower(static_cast<wchar_t>(c));
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/wctype/iswlower.h
+++ b/libc/src/wctype/iswlower.h
@@ -1,0 +1,21 @@
+//===-- Implementation header for iswalpha ----------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_WCTYPE_ISLOWER_H
+#define LLVM_LIBC_SRC_WCTYPE_ISLOWER_H
+
+#include "hdr/types/wint_t.h"
+#include "src/__support/common.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+int iswlower(wint_t c);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_WCTYPE_ISLOWER_H

--- a/libc/src/wctype/iswlower.h
+++ b/libc/src/wctype/iswlower.h
@@ -1,4 +1,4 @@
-//===-- Implementation header for iswalpha ----------------------*- C++ -*-===//
+//===-- Implementation header for iswlower ----------------------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/libc/test/src/wctype/CMakeLists.txt
+++ b/libc/test/src/wctype/CMakeLists.txt
@@ -21,3 +21,13 @@ add_libc_test(
     libc.src.wctype.iswdigit
     libc.src.__support.wctype_utils
 )
+
+add_libc_test(
+  iswlower_test
+  SUITE
+    libc_wctype_unittests
+  SRCS
+    iswlower_test.cpp
+  DEPENDS
+    libc.src.wctype.iswlower
+)

--- a/libc/test/src/wctype/iswlower_test.cpp
+++ b/libc/test/src/wctype/iswlower_test.cpp
@@ -1,0 +1,22 @@
+//===-- Unittests for iswlower --------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/__support/CPP/span.h"
+#include "src/wctype/iswlower.h"
+
+#include "test/UnitTest/Test.h"
+
+TEST(LlvmLibciswlower, SimpleTest) {
+  EXPECT_NE(LIBC_NAMESPACE::iswlower('a'), 0);
+  EXPECT_NE(LIBC_NAMESPACE::iswlower('b'), 0);
+  EXPECT_NE(LIBC_NAMESPACE::iswlower('z'), 0);
+
+  EXPECT_EQ(LIBC_NAMESPACE::iswlower('A'), 0);
+  EXPECT_EQ(LIBC_NAMESPACE::iswlower('B'), 0);
+  EXPECT_EQ(LIBC_NAMESPACE::iswlower('Z'), 0);
+}

--- a/libc/test/src/wctype/iswlower_test.cpp
+++ b/libc/test/src/wctype/iswlower_test.cpp
@@ -6,9 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "src/__support/CPP/span.h"
 #include "src/wctype/iswlower.h"
-
 #include "test/UnitTest/Test.h"
 
 TEST(LlvmLibciswlower, SimpleTest) {


### PR DESCRIPTION
Changes include:
- Added iswlower entrypoint in wctype.yaml to expose the function
- Created iswlower.h header and iswlower.cpp implementation
- Added CMake entrypoint object for iswlower
- Created unit test in iswlower_test.cpp
- Added test entry to wctype CMakeLists.txt

this PR helps in exposing iswlower which internally calls islower on wide character

built using :  ninja -C build libc 
tested using : ninja libc_wctype_unittests and all the 3 tests passed 

resolves issue #185136 