### PR TITLE
[clang-tidy] Don't print `Enabled checks:` by default

### DIFF
--- a/clang-tools-extra/clang-tidy/tool/run-clang-tidy.py
+++ b/clang-tools-extra/clang-tidy/tool/run-clang-tidy.py
@@ -664,9 +664,7 @@ async def main() -> None:
         invocation.append("-list-checks")
         invocation.append("-")
         # Even with -quiet we still want to check if we can call clang-tidy.
-        subprocess.check_call(
-            invocation, stdout=subprocess.DEVNULL if args.quiet else None
-        )
+        subprocess.check_call(invocation, stdout=subprocess.DEVNULL)
     except Exception:
         print("Unable to run clang-tidy.", file=sys.stderr)
         sys.exit(1)


### PR DESCRIPTION
`Enabled checks:` by default prints hundreds of lines **polluting output** with moderate amount of enabled checks.
Disable it by default since it's **not human readable** at all.