### PR TITLE
[NFC] Fix spelling mistakes in emitted string replacing word anaylsis with analysis

### DIFF
--- a/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
@@ -1481,7 +1481,7 @@ getBBAddrMapFeature(const MachineFunction &MF, int NumMBBSectionRanges,
        PgoAnalysisMapFeatures.isSet(PGOMapFeaturesEnum::All)) &&
       popcount(PgoAnalysisMapFeatures.getBits()) != 1) {
     MF.getFunction().getContext().emitError(
-        "-pgo-anaylsis-map can accept only all or none with no additional "
+        "-pgo-analysis-map can accept only all or none with no additional "
         "values.");
   }
 


### PR DESCRIPTION
llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp had spelling mistake in error message string. 
This PR fixes the spelling mistake and replaces 'anaylsis' with 'analysis' 