### PR TITLE
[SelectionDAG] Second SimplifyDemandedBits pass for AND RHS using LHS known zeros (scalar only)

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/TargetLowering.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/TargetLowering.cpp
@@ -1513,13 +1513,12 @@ bool TargetLowering::SimplifyDemandedBits(
                              Known2, TLO, Depth + 1))
       return true;
 
-    // FIXME: Pretty much all these extra conditions are to avoid regressions in
-    // x86 and AMDGPU.
+    // FIXME: Op1Opc checks are to avoid regressions in
+    // x86 codegen.
     unsigned Op1Opc = Op1.getOpcode();
     if (!VT.isVector() &&
         (Op1Opc == ISD::ZERO_EXTEND || Op1Opc == ISD::SIGN_EXTEND ||
          Op1Opc == ISD::ANY_EXTEND || Op1Opc == ISD::TRUNCATE) &&
-        Op1.getOperand(0).getValueType().getScalarType() != MVT::i1 &&
         (~Known2.Zero & DemandedBits) != DemandedBits) {
       Known2 = TLO.DAG.computeKnownBits(Op0, DemandedElts, Depth + 1);
       if (SimplifyDemandedBits(Op1, ~Known2.Zero & DemandedBits, DemandedElts,

--- a/llvm/lib/CodeGen/SelectionDAG/TargetLowering.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/TargetLowering.cpp
@@ -1513,6 +1513,20 @@ bool TargetLowering::SimplifyDemandedBits(
                              Known2, TLO, Depth + 1))
       return true;
 
+    // FIXME: Pretty much all these extra conditions are to avoid regressions in
+    // x86 and AMDGPU.
+    unsigned Op1Opc = Op1.getOpcode();
+    if (!VT.isVector() &&
+        (Op1Opc == ISD::ZERO_EXTEND || Op1Opc == ISD::SIGN_EXTEND ||
+         Op1Opc == ISD::ANY_EXTEND || Op1Opc == ISD::TRUNCATE) &&
+        Op1.getOperand(0).getValueType().getScalarType() != MVT::i1 &&
+        (~Known2.Zero & DemandedBits) != DemandedBits) {
+      Known2 = TLO.DAG.computeKnownBits(Op0, DemandedElts, Depth + 1);
+      if (SimplifyDemandedBits(Op1, ~Known2.Zero & DemandedBits, DemandedElts,
+                               Known, TLO, Depth + 1))
+        return true;
+    }
+
     // If all of the demanded bits are known one on one side, return the other.
     // These bits cannot contribute to the result of the 'and'.
     if (DemandedBits.isSubsetOf(Known2.Zero | Known.One))

--- a/llvm/lib/Target/AMDGPU/SIISelLowering.cpp
+++ b/llvm/lib/Target/AMDGPU/SIISelLowering.cpp
@@ -13821,9 +13821,12 @@ SDValue SITargetLowering::performAndCombine(SDNode *N,
   }
 
   if (VT == MVT::i32 && (RHS.getOpcode() == ISD::SIGN_EXTEND ||
-                         LHS.getOpcode() == ISD::SIGN_EXTEND)) {
-    // and x, (sext cc from i1) => select cc, x, 0
-    if (RHS.getOpcode() != ISD::SIGN_EXTEND)
+                         RHS.getOpcode() == ISD::ANY_EXTEND ||
+                         LHS.getOpcode() == ISD::SIGN_EXTEND ||
+                         LHS.getOpcode() == ISD::ANY_EXTEND)) {
+    // and x, (sext/anyext cc from i1) => select cc, x, 0
+    if (RHS.getOpcode() != ISD::SIGN_EXTEND &&
+        RHS.getOpcode() != ISD::ANY_EXTEND)
       std::swap(LHS, RHS);
     if (isBoolSGPR(RHS.getOperand(0)))
       return DAG.getSelect(SDLoc(N), MVT::i32, RHS.getOperand(0), LHS,

--- a/llvm/test/CodeGen/AArch64/reduce-and.ll
+++ b/llvm/test/CodeGen/AArch64/reduce-and.ll
@@ -263,9 +263,9 @@ define i8 @test_redand_v8i8(<8 x i8> %a) {
 ; CHECK:       // %bb.0:
 ; CHECK-NEXT:    fmov x8, d0
 ; CHECK-NEXT:    and x8, x8, x8, lsr #32
-; CHECK-NEXT:    and x8, x8, x8, lsr #16
-; CHECK-NEXT:    lsr x9, x8, #8
-; CHECK-NEXT:    and w0, w8, w9
+; CHECK-NEXT:    lsr x9, x8, #16
+; CHECK-NEXT:    and w8, w8, w9
+; CHECK-NEXT:    and w0, w8, w8, lsr #8
 ; CHECK-NEXT:    ret
 ;
 ; GISEL-LABEL: test_redand_v8i8:
@@ -298,9 +298,9 @@ define i8 @test_redand_v16i8(<16 x i8> %a) {
 ; CHECK-NEXT:    and v0.8b, v0.8b, v1.8b
 ; CHECK-NEXT:    fmov x8, d0
 ; CHECK-NEXT:    and x8, x8, x8, lsr #32
-; CHECK-NEXT:    and x8, x8, x8, lsr #16
-; CHECK-NEXT:    lsr x9, x8, #8
-; CHECK-NEXT:    and w0, w8, w9
+; CHECK-NEXT:    lsr x9, x8, #16
+; CHECK-NEXT:    and w8, w8, w9
+; CHECK-NEXT:    and w0, w8, w8, lsr #8
 ; CHECK-NEXT:    ret
 ;
 ; GISEL-LABEL: test_redand_v16i8:
@@ -335,9 +335,9 @@ define i8 @test_redand_v32i8(<32 x i8> %a) {
 ; CHECK-NEXT:    and v0.8b, v0.8b, v1.8b
 ; CHECK-NEXT:    fmov x8, d0
 ; CHECK-NEXT:    and x8, x8, x8, lsr #32
-; CHECK-NEXT:    and x8, x8, x8, lsr #16
-; CHECK-NEXT:    lsr x9, x8, #8
-; CHECK-NEXT:    and w0, w8, w9
+; CHECK-NEXT:    lsr x9, x8, #16
+; CHECK-NEXT:    and w8, w8, w9
+; CHECK-NEXT:    and w0, w8, w8, lsr #8
 ; CHECK-NEXT:    ret
 ;
 ; GISEL-LABEL: test_redand_v32i8:

--- a/llvm/test/CodeGen/AArch64/vecreduce-and-legalization.ll
+++ b/llvm/test/CodeGen/AArch64/vecreduce-and-legalization.ll
@@ -107,9 +107,9 @@ define i8 @test_v9i8(<9 x i8> %a) nounwind {
 ; CHECK-NEXT:    and v0.8b, v0.8b, v1.8b
 ; CHECK-NEXT:    fmov x8, d0
 ; CHECK-NEXT:    and x8, x8, x8, lsr #32
-; CHECK-NEXT:    and x8, x8, x8, lsr #16
-; CHECK-NEXT:    lsr x9, x8, #8
-; CHECK-NEXT:    and w0, w8, w9
+; CHECK-NEXT:    lsr x9, x8, #16
+; CHECK-NEXT:    and w8, w8, w9
+; CHECK-NEXT:    and w0, w8, w8, lsr #8
 ; CHECK-NEXT:    ret
   %b = call i8 @llvm.vector.reduce.and.v9i8(<9 x i8> %a)
   ret i8 %b

--- a/llvm/test/CodeGen/X86/atomic-rm-bit-test.ll
+++ b/llvm/test/CodeGen/X86/atomic-rm-bit-test.ll
@@ -1286,11 +1286,10 @@ define zeroext i16 @atomic_shl1_mask01_xor_16_gpr_valz(ptr %v, i16 zeroext %c) n
 ; X86-NEXT:    # kill: def $ax killed $ax def $eax
 ; X86-NEXT:    jne .LBB22_1
 ; X86-NEXT:  # %bb.2: # %atomicrmw.end
-; X86-NEXT:    movzwl %ax, %ecx
-; X86-NEXT:    xorl %eax, %eax
-; X86-NEXT:    testl %ecx, %esi
-; X86-NEXT:    sete %al
-; X86-NEXT:    # kill: def $ax killed $ax killed $eax
+; X86-NEXT:    xorl %ecx, %ecx
+; X86-NEXT:    testl %eax, %esi
+; X86-NEXT:    sete %cl
+; X86-NEXT:    movl %ecx, %eax
 ; X86-NEXT:    popl %esi
 ; X86-NEXT:    retl
 ;
@@ -1312,11 +1311,10 @@ define zeroext i16 @atomic_shl1_mask01_xor_16_gpr_valz(ptr %v, i16 zeroext %c) n
 ; X64-NEXT:    # kill: def $ax killed $ax def $eax
 ; X64-NEXT:    jne .LBB22_1
 ; X64-NEXT:  # %bb.2: # %atomicrmw.end
-; X64-NEXT:    movzwl %ax, %ecx
-; X64-NEXT:    xorl %eax, %eax
-; X64-NEXT:    testl %ecx, %edx
-; X64-NEXT:    sete %al
-; X64-NEXT:    # kill: def $ax killed $ax killed $eax
+; X64-NEXT:    xorl %ecx, %ecx
+; X64-NEXT:    testl %eax, %edx
+; X64-NEXT:    sete %cl
+; X64-NEXT:    movl %ecx, %eax
 ; X64-NEXT:    retq
 entry:
   %0 = and i16 %c, 15
@@ -1335,51 +1333,49 @@ define zeroext i16 @atomic_blsi_xor_16_gpr_valz(ptr %v, i16 zeroext %c) nounwind
 ; X86-LABEL: atomic_blsi_xor_16_gpr_valz:
 ; X86:       # %bb.0: # %entry
 ; X86-NEXT:    pushl %esi
-; X86-NEXT:    movl {{[0-9]+}}(%esp), %edx
+; X86-NEXT:    movl {{[0-9]+}}(%esp), %ecx
 ; X86-NEXT:    movzwl {{[0-9]+}}(%esp), %eax
-; X86-NEXT:    movl %eax, %ecx
-; X86-NEXT:    negl %ecx
-; X86-NEXT:    andl %eax, %ecx
-; X86-NEXT:    movzwl (%edx), %eax
+; X86-NEXT:    movl %eax, %edx
+; X86-NEXT:    negl %edx
+; X86-NEXT:    andl %eax, %edx
+; X86-NEXT:    movzwl (%ecx), %eax
 ; X86-NEXT:    .p2align 4
 ; X86-NEXT:  .LBB23_1: # %atomicrmw.start
 ; X86-NEXT:    # =>This Inner Loop Header: Depth=1
 ; X86-NEXT:    movl %eax, %esi
-; X86-NEXT:    xorl %ecx, %esi
+; X86-NEXT:    xorl %edx, %esi
 ; X86-NEXT:    # kill: def $ax killed $ax killed $eax
-; X86-NEXT:    lock cmpxchgw %si, (%edx)
+; X86-NEXT:    lock cmpxchgw %si, (%ecx)
 ; X86-NEXT:    # kill: def $ax killed $ax def $eax
 ; X86-NEXT:    jne .LBB23_1
 ; X86-NEXT:  # %bb.2: # %atomicrmw.end
-; X86-NEXT:    movzwl %ax, %edx
-; X86-NEXT:    xorl %eax, %eax
-; X86-NEXT:    testl %edx, %ecx
-; X86-NEXT:    sete %al
-; X86-NEXT:    # kill: def $ax killed $ax killed $eax
+; X86-NEXT:    xorl %ecx, %ecx
+; X86-NEXT:    testl %eax, %edx
+; X86-NEXT:    sete %cl
+; X86-NEXT:    movl %ecx, %eax
 ; X86-NEXT:    popl %esi
 ; X86-NEXT:    retl
 ;
 ; X64-LABEL: atomic_blsi_xor_16_gpr_valz:
 ; X64:       # %bb.0: # %entry
-; X64-NEXT:    movl %esi, %ecx
-; X64-NEXT:    negl %ecx
-; X64-NEXT:    andl %esi, %ecx
+; X64-NEXT:    movl %esi, %edx
+; X64-NEXT:    negl %edx
+; X64-NEXT:    andl %esi, %edx
 ; X64-NEXT:    movzwl (%rdi), %eax
 ; X64-NEXT:    .p2align 4
 ; X64-NEXT:  .LBB23_1: # %atomicrmw.start
 ; X64-NEXT:    # =>This Inner Loop Header: Depth=1
-; X64-NEXT:    movl %eax, %edx
-; X64-NEXT:    xorl %ecx, %edx
+; X64-NEXT:    movl %eax, %ecx
+; X64-NEXT:    xorl %edx, %ecx
 ; X64-NEXT:    # kill: def $ax killed $ax killed $eax
-; X64-NEXT:    lock cmpxchgw %dx, (%rdi)
+; X64-NEXT:    lock cmpxchgw %cx, (%rdi)
 ; X64-NEXT:    # kill: def $ax killed $ax def $eax
 ; X64-NEXT:    jne .LBB23_1
 ; X64-NEXT:  # %bb.2: # %atomicrmw.end
-; X64-NEXT:    movzwl %ax, %edx
-; X64-NEXT:    xorl %eax, %eax
-; X64-NEXT:    testl %edx, %ecx
-; X64-NEXT:    sete %al
-; X64-NEXT:    # kill: def $ax killed $ax killed $eax
+; X64-NEXT:    xorl %ecx, %ecx
+; X64-NEXT:    testl %eax, %edx
+; X64-NEXT:    sete %cl
+; X64-NEXT:    movl %ecx, %eax
 ; X64-NEXT:    retq
 entry:
   %conv = zext i16 %c to i32
@@ -1679,11 +1675,10 @@ define zeroext i16 @atomic_shl1_mask01_xor_16_gpr_valnz(ptr %v, i16 zeroext %c) 
 ; X86-NEXT:    # kill: def $ax killed $ax def $eax
 ; X86-NEXT:    jne .LBB28_1
 ; X86-NEXT:  # %bb.2: # %atomicrmw.end
-; X86-NEXT:    movzwl %ax, %ecx
-; X86-NEXT:    xorl %eax, %eax
-; X86-NEXT:    testl %ecx, %esi
-; X86-NEXT:    setne %al
-; X86-NEXT:    # kill: def $ax killed $ax killed $eax
+; X86-NEXT:    xorl %ecx, %ecx
+; X86-NEXT:    testl %eax, %esi
+; X86-NEXT:    setne %cl
+; X86-NEXT:    movl %ecx, %eax
 ; X86-NEXT:    popl %esi
 ; X86-NEXT:    retl
 ;
@@ -1705,11 +1700,10 @@ define zeroext i16 @atomic_shl1_mask01_xor_16_gpr_valnz(ptr %v, i16 zeroext %c) 
 ; X64-NEXT:    # kill: def $ax killed $ax def $eax
 ; X64-NEXT:    jne .LBB28_1
 ; X64-NEXT:  # %bb.2: # %atomicrmw.end
-; X64-NEXT:    movzwl %ax, %ecx
-; X64-NEXT:    xorl %eax, %eax
-; X64-NEXT:    testl %ecx, %edx
-; X64-NEXT:    setne %al
-; X64-NEXT:    # kill: def $ax killed $ax killed $eax
+; X64-NEXT:    xorl %ecx, %ecx
+; X64-NEXT:    testl %eax, %edx
+; X64-NEXT:    setne %cl
+; X64-NEXT:    movl %ecx, %eax
 ; X64-NEXT:    retq
 entry:
   %0 = and i16 %c, 15
@@ -1728,51 +1722,49 @@ define zeroext i16 @atomic_blsi_xor_16_gpr_valnz(ptr %v, i16 zeroext %c) nounwin
 ; X86-LABEL: atomic_blsi_xor_16_gpr_valnz:
 ; X86:       # %bb.0: # %entry
 ; X86-NEXT:    pushl %esi
-; X86-NEXT:    movl {{[0-9]+}}(%esp), %edx
+; X86-NEXT:    movl {{[0-9]+}}(%esp), %ecx
 ; X86-NEXT:    movzwl {{[0-9]+}}(%esp), %eax
-; X86-NEXT:    movl %eax, %ecx
-; X86-NEXT:    negl %ecx
-; X86-NEXT:    andl %eax, %ecx
-; X86-NEXT:    movzwl (%edx), %eax
+; X86-NEXT:    movl %eax, %edx
+; X86-NEXT:    negl %edx
+; X86-NEXT:    andl %eax, %edx
+; X86-NEXT:    movzwl (%ecx), %eax
 ; X86-NEXT:    .p2align 4
 ; X86-NEXT:  .LBB29_1: # %atomicrmw.start
 ; X86-NEXT:    # =>This Inner Loop Header: Depth=1
 ; X86-NEXT:    movl %eax, %esi
-; X86-NEXT:    xorl %ecx, %esi
+; X86-NEXT:    xorl %edx, %esi
 ; X86-NEXT:    # kill: def $ax killed $ax killed $eax
-; X86-NEXT:    lock cmpxchgw %si, (%edx)
+; X86-NEXT:    lock cmpxchgw %si, (%ecx)
 ; X86-NEXT:    # kill: def $ax killed $ax def $eax
 ; X86-NEXT:    jne .LBB29_1
 ; X86-NEXT:  # %bb.2: # %atomicrmw.end
-; X86-NEXT:    movzwl %ax, %edx
-; X86-NEXT:    xorl %eax, %eax
-; X86-NEXT:    testl %edx, %ecx
-; X86-NEXT:    setne %al
-; X86-NEXT:    # kill: def $ax killed $ax killed $eax
+; X86-NEXT:    xorl %ecx, %ecx
+; X86-NEXT:    testl %eax, %edx
+; X86-NEXT:    setne %cl
+; X86-NEXT:    movl %ecx, %eax
 ; X86-NEXT:    popl %esi
 ; X86-NEXT:    retl
 ;
 ; X64-LABEL: atomic_blsi_xor_16_gpr_valnz:
 ; X64:       # %bb.0: # %entry
-; X64-NEXT:    movl %esi, %ecx
-; X64-NEXT:    negl %ecx
-; X64-NEXT:    andl %esi, %ecx
+; X64-NEXT:    movl %esi, %edx
+; X64-NEXT:    negl %edx
+; X64-NEXT:    andl %esi, %edx
 ; X64-NEXT:    movzwl (%rdi), %eax
 ; X64-NEXT:    .p2align 4
 ; X64-NEXT:  .LBB29_1: # %atomicrmw.start
 ; X64-NEXT:    # =>This Inner Loop Header: Depth=1
-; X64-NEXT:    movl %eax, %edx
-; X64-NEXT:    xorl %ecx, %edx
+; X64-NEXT:    movl %eax, %ecx
+; X64-NEXT:    xorl %edx, %ecx
 ; X64-NEXT:    # kill: def $ax killed $ax killed $eax
-; X64-NEXT:    lock cmpxchgw %dx, (%rdi)
+; X64-NEXT:    lock cmpxchgw %cx, (%rdi)
 ; X64-NEXT:    # kill: def $ax killed $ax def $eax
 ; X64-NEXT:    jne .LBB29_1
 ; X64-NEXT:  # %bb.2: # %atomicrmw.end
-; X64-NEXT:    movzwl %ax, %edx
-; X64-NEXT:    xorl %eax, %eax
-; X64-NEXT:    testl %edx, %ecx
-; X64-NEXT:    setne %al
-; X64-NEXT:    # kill: def $ax killed $ax killed $eax
+; X64-NEXT:    xorl %ecx, %ecx
+; X64-NEXT:    testl %eax, %edx
+; X64-NEXT:    setne %cl
+; X64-NEXT:    movl %ecx, %eax
 ; X64-NEXT:    retq
 entry:
   %conv = zext i16 %c to i32
@@ -2141,14 +2133,14 @@ define zeroext i16 @atomic_shl1_mask01_xor_16_gpr_brz(ptr %v, i16 zeroext %c) no
 ; X86-NEXT:    # kill: def $ax killed $ax def $eax
 ; X86-NEXT:    jne .LBB34_1
 ; X86-NEXT:  # %bb.2: # %atomicrmw.end
-; X86-NEXT:    movzwl %ax, %ecx
-; X86-NEXT:    movw $123, %ax
-; X86-NEXT:    testl %ecx, %esi
+; X86-NEXT:    movw $123, %cx
+; X86-NEXT:    testl %eax, %esi
 ; X86-NEXT:    jne .LBB34_4
 ; X86-NEXT:  # %bb.3: # %if.then
 ; X86-NEXT:    movzwl %bx, %eax
-; X86-NEXT:    movzwl (%edx,%eax,2), %eax
+; X86-NEXT:    movzwl (%edx,%eax,2), %ecx
 ; X86-NEXT:  .LBB34_4: # %return
+; X86-NEXT:    movl %ecx, %eax
 ; X86-NEXT:    popl %esi
 ; X86-NEXT:    popl %ebx
 ; X86-NEXT:    retl
@@ -2172,15 +2164,16 @@ define zeroext i16 @atomic_shl1_mask01_xor_16_gpr_brz(ptr %v, i16 zeroext %c) no
 ; X64-NEXT:    # kill: def $ax killed $ax def $eax
 ; X64-NEXT:    jne .LBB34_1
 ; X64-NEXT:  # %bb.2: # %atomicrmw.end
-; X64-NEXT:    movzwl %ax, %ecx
-; X64-NEXT:    movw $123, %ax
-; X64-NEXT:    testl %ecx, %esi
+; X64-NEXT:    movw $123, %cx
+; X64-NEXT:    testl %eax, %esi
 ; X64-NEXT:    je .LBB34_3
 ; X64-NEXT:  # %bb.4: # %return
+; X64-NEXT:    movl %ecx, %eax
 ; X64-NEXT:    retq
 ; X64-NEXT:  .LBB34_3: # %if.then
 ; X64-NEXT:    movzwl %dx, %eax
-; X64-NEXT:    movzwl (%rdi,%rax,2), %eax
+; X64-NEXT:    movzwl (%rdi,%rax,2), %ecx
+; X64-NEXT:    movl %ecx, %eax
 ; X64-NEXT:    retq
 entry:
   %0 = and i16 %c, 15
@@ -2209,59 +2202,60 @@ define zeroext i16 @atomic_blsi_xor_16_gpr_brz(ptr %v, i16 zeroext %c) nounwind 
 ; X86:       # %bb.0: # %entry
 ; X86-NEXT:    pushl %edi
 ; X86-NEXT:    pushl %esi
-; X86-NEXT:    movzwl {{[0-9]+}}(%esp), %ecx
-; X86-NEXT:    movl {{[0-9]+}}(%esp), %edx
-; X86-NEXT:    movl %ecx, %esi
-; X86-NEXT:    negl %esi
-; X86-NEXT:    andl %ecx, %esi
-; X86-NEXT:    movzwl (%edx), %eax
+; X86-NEXT:    movzwl {{[0-9]+}}(%esp), %edx
+; X86-NEXT:    movl {{[0-9]+}}(%esp), %esi
+; X86-NEXT:    movl %edx, %edi
+; X86-NEXT:    negl %edi
+; X86-NEXT:    andl %edx, %edi
+; X86-NEXT:    movzwl (%esi), %eax
 ; X86-NEXT:    .p2align 4
 ; X86-NEXT:  .LBB35_1: # %atomicrmw.start
 ; X86-NEXT:    # =>This Inner Loop Header: Depth=1
-; X86-NEXT:    movl %eax, %edi
-; X86-NEXT:    xorl %esi, %edi
+; X86-NEXT:    movl %eax, %ecx
+; X86-NEXT:    xorl %edi, %ecx
 ; X86-NEXT:    # kill: def $ax killed $ax killed $eax
-; X86-NEXT:    lock cmpxchgw %di, (%edx)
+; X86-NEXT:    lock cmpxchgw %cx, (%esi)
 ; X86-NEXT:    # kill: def $ax killed $ax def $eax
 ; X86-NEXT:    jne .LBB35_1
 ; X86-NEXT:  # %bb.2: # %atomicrmw.end
-; X86-NEXT:    movzwl %ax, %edi
-; X86-NEXT:    movw $123, %ax
-; X86-NEXT:    testl %edi, %esi
+; X86-NEXT:    movw $123, %cx
+; X86-NEXT:    testl %eax, %edi
 ; X86-NEXT:    jne .LBB35_4
 ; X86-NEXT:  # %bb.3: # %if.then
-; X86-NEXT:    movzwl %cx, %eax
-; X86-NEXT:    movzwl (%edx,%eax,2), %eax
+; X86-NEXT:    movzwl %dx, %eax
+; X86-NEXT:    movzwl (%esi,%eax,2), %ecx
 ; X86-NEXT:  .LBB35_4: # %return
+; X86-NEXT:    movl %ecx, %eax
 ; X86-NEXT:    popl %esi
 ; X86-NEXT:    popl %edi
 ; X86-NEXT:    retl
 ;
 ; X64-LABEL: atomic_blsi_xor_16_gpr_brz:
 ; X64:       # %bb.0: # %entry
-; X64-NEXT:    movl %esi, %ecx
-; X64-NEXT:    negl %ecx
-; X64-NEXT:    andl %esi, %ecx
+; X64-NEXT:    movl %esi, %edx
+; X64-NEXT:    negl %edx
+; X64-NEXT:    andl %esi, %edx
 ; X64-NEXT:    movzwl (%rdi), %eax
 ; X64-NEXT:    .p2align 4
 ; X64-NEXT:  .LBB35_1: # %atomicrmw.start
 ; X64-NEXT:    # =>This Inner Loop Header: Depth=1
-; X64-NEXT:    movl %eax, %edx
-; X64-NEXT:    xorl %ecx, %edx
+; X64-NEXT:    movl %eax, %ecx
+; X64-NEXT:    xorl %edx, %ecx
 ; X64-NEXT:    # kill: def $ax killed $ax killed $eax
-; X64-NEXT:    lock cmpxchgw %dx, (%rdi)
+; X64-NEXT:    lock cmpxchgw %cx, (%rdi)
 ; X64-NEXT:    # kill: def $ax killed $ax def $eax
 ; X64-NEXT:    jne .LBB35_1
 ; X64-NEXT:  # %bb.2: # %atomicrmw.end
-; X64-NEXT:    movzwl %ax, %edx
-; X64-NEXT:    movw $123, %ax
-; X64-NEXT:    testl %edx, %ecx
+; X64-NEXT:    movw $123, %cx
+; X64-NEXT:    testl %eax, %edx
 ; X64-NEXT:    je .LBB35_3
 ; X64-NEXT:  # %bb.4: # %return
+; X64-NEXT:    movl %ecx, %eax
 ; X64-NEXT:    retq
 ; X64-NEXT:  .LBB35_3: # %if.then
 ; X64-NEXT:    movzwl %si, %eax
-; X64-NEXT:    movzwl (%rdi,%rax,2), %eax
+; X64-NEXT:    movzwl (%rdi,%rax,2), %ecx
+; X64-NEXT:    movl %ecx, %eax
 ; X64-NEXT:    retq
 entry:
   %conv = zext i16 %c to i32
@@ -2893,11 +2887,10 @@ define zeroext i16 @atomic_shl1_mask01_and_16_gpr_valnz(ptr %v, i16 zeroext %c) 
 ; X86-NEXT:    # kill: def $ax killed $ax def $eax
 ; X86-NEXT:    jne .LBB46_1
 ; X86-NEXT:  # %bb.2: # %atomicrmw.end
-; X86-NEXT:    movzwl %ax, %ecx
-; X86-NEXT:    xorl %eax, %eax
-; X86-NEXT:    testl %ecx, %esi
-; X86-NEXT:    setne %al
-; X86-NEXT:    # kill: def $ax killed $ax killed $eax
+; X86-NEXT:    xorl %ecx, %ecx
+; X86-NEXT:    testl %eax, %esi
+; X86-NEXT:    setne %cl
+; X86-NEXT:    movl %ecx, %eax
 ; X86-NEXT:    popl %esi
 ; X86-NEXT:    popl %edi
 ; X86-NEXT:    retl
@@ -2922,11 +2915,10 @@ define zeroext i16 @atomic_shl1_mask01_and_16_gpr_valnz(ptr %v, i16 zeroext %c) 
 ; X64-NEXT:    # kill: def $ax killed $ax def $eax
 ; X64-NEXT:    jne .LBB46_1
 ; X64-NEXT:  # %bb.2: # %atomicrmw.end
-; X64-NEXT:    movzwl %ax, %ecx
-; X64-NEXT:    xorl %eax, %eax
-; X64-NEXT:    testl %ecx, %edx
-; X64-NEXT:    setne %al
-; X64-NEXT:    # kill: def $ax killed $ax killed $eax
+; X64-NEXT:    xorl %ecx, %ecx
+; X64-NEXT:    testl %eax, %edx
+; X64-NEXT:    setne %cl
+; X64-NEXT:    movl %ecx, %eax
 ; X64-NEXT:    retq
 entry:
   %0 = and i16 %c, 15
@@ -2947,56 +2939,54 @@ define zeroext i16 @atomic_blsi_and_16_gpr_valnz(ptr %v, i16 zeroext %c) nounwin
 ; X86:       # %bb.0: # %entry
 ; X86-NEXT:    pushl %edi
 ; X86-NEXT:    pushl %esi
-; X86-NEXT:    movl {{[0-9]+}}(%esp), %edx
+; X86-NEXT:    movl {{[0-9]+}}(%esp), %ecx
 ; X86-NEXT:    movzwl {{[0-9]+}}(%esp), %eax
-; X86-NEXT:    movl %eax, %ecx
-; X86-NEXT:    negl %ecx
-; X86-NEXT:    andl %eax, %ecx
-; X86-NEXT:    movl %ecx, %esi
+; X86-NEXT:    movl %eax, %edx
+; X86-NEXT:    negl %edx
+; X86-NEXT:    andl %eax, %edx
+; X86-NEXT:    movl %edx, %esi
 ; X86-NEXT:    notl %esi
-; X86-NEXT:    movzwl (%edx), %eax
+; X86-NEXT:    movzwl (%ecx), %eax
 ; X86-NEXT:    .p2align 4
 ; X86-NEXT:  .LBB47_1: # %atomicrmw.start
 ; X86-NEXT:    # =>This Inner Loop Header: Depth=1
 ; X86-NEXT:    movl %eax, %edi
 ; X86-NEXT:    andl %esi, %edi
 ; X86-NEXT:    # kill: def $ax killed $ax killed $eax
-; X86-NEXT:    lock cmpxchgw %di, (%edx)
+; X86-NEXT:    lock cmpxchgw %di, (%ecx)
 ; X86-NEXT:    # kill: def $ax killed $ax def $eax
 ; X86-NEXT:    jne .LBB47_1
 ; X86-NEXT:  # %bb.2: # %atomicrmw.end
-; X86-NEXT:    movzwl %ax, %edx
-; X86-NEXT:    xorl %eax, %eax
-; X86-NEXT:    testl %edx, %ecx
-; X86-NEXT:    setne %al
-; X86-NEXT:    # kill: def $ax killed $ax killed $eax
+; X86-NEXT:    xorl %ecx, %ecx
+; X86-NEXT:    testl %eax, %edx
+; X86-NEXT:    setne %cl
+; X86-NEXT:    movl %ecx, %eax
 ; X86-NEXT:    popl %esi
 ; X86-NEXT:    popl %edi
 ; X86-NEXT:    retl
 ;
 ; X64-LABEL: atomic_blsi_and_16_gpr_valnz:
 ; X64:       # %bb.0: # %entry
-; X64-NEXT:    movl %esi, %ecx
-; X64-NEXT:    negl %ecx
-; X64-NEXT:    andl %esi, %ecx
-; X64-NEXT:    movl %ecx, %edx
-; X64-NEXT:    notl %edx
+; X64-NEXT:    movl %esi, %edx
+; X64-NEXT:    negl %edx
+; X64-NEXT:    andl %esi, %edx
+; X64-NEXT:    movl %edx, %ecx
+; X64-NEXT:    notl %ecx
 ; X64-NEXT:    movzwl (%rdi), %eax
 ; X64-NEXT:    .p2align 4
 ; X64-NEXT:  .LBB47_1: # %atomicrmw.start
 ; X64-NEXT:    # =>This Inner Loop Header: Depth=1
 ; X64-NEXT:    movl %eax, %esi
-; X64-NEXT:    andl %edx, %esi
+; X64-NEXT:    andl %ecx, %esi
 ; X64-NEXT:    # kill: def $ax killed $ax killed $eax
 ; X64-NEXT:    lock cmpxchgw %si, (%rdi)
 ; X64-NEXT:    # kill: def $ax killed $ax def $eax
 ; X64-NEXT:    jne .LBB47_1
 ; X64-NEXT:  # %bb.2: # %atomicrmw.end
-; X64-NEXT:    movzwl %ax, %edx
-; X64-NEXT:    xorl %eax, %eax
-; X64-NEXT:    testl %edx, %ecx
-; X64-NEXT:    setne %al
-; X64-NEXT:    # kill: def $ax killed $ax killed $eax
+; X64-NEXT:    xorl %ecx, %ecx
+; X64-NEXT:    testl %eax, %edx
+; X64-NEXT:    setne %cl
+; X64-NEXT:    movl %ecx, %eax
 ; X64-NEXT:    retq
 entry:
   %conv = zext i16 %c to i32
@@ -3382,7 +3372,6 @@ define zeroext i16 @atomic_shl1_mask01_and_16_gpr_brnz(ptr %v, i16 zeroext %c) n
 ; X86-NEXT:    # kill: def $ax killed $ax def $eax
 ; X86-NEXT:    jne .LBB52_1
 ; X86-NEXT:  # %bb.2: # %atomicrmw.end
-; X86-NEXT:    movzwl %ax, %eax
 ; X86-NEXT:    testl %eax, %esi
 ; X86-NEXT:    je .LBB52_3
 ; X86-NEXT:  # %bb.4: # %if.then
@@ -3418,7 +3407,6 @@ define zeroext i16 @atomic_shl1_mask01_and_16_gpr_brnz(ptr %v, i16 zeroext %c) n
 ; X64-NEXT:    # kill: def $ax killed $ax def $eax
 ; X64-NEXT:    jne .LBB52_1
 ; X64-NEXT:  # %bb.2: # %atomicrmw.end
-; X64-NEXT:    movzwl %ax, %eax
 ; X64-NEXT:    testl %eax, %esi
 ; X64-NEXT:    je .LBB52_3
 ; X64-NEXT:  # %bb.4: # %if.then
@@ -3475,7 +3463,6 @@ define zeroext i16 @atomic_blsi_and_16_gpr_brnz(ptr %v, i16 zeroext %c) nounwind
 ; X86-NEXT:    # kill: def $ax killed $ax def $eax
 ; X86-NEXT:    jne .LBB53_1
 ; X86-NEXT:  # %bb.2: # %atomicrmw.end
-; X86-NEXT:    movzwl %ax, %eax
 ; X86-NEXT:    testl %eax, %esi
 ; X86-NEXT:    je .LBB53_3
 ; X86-NEXT:  # %bb.4: # %if.then
@@ -3508,7 +3495,6 @@ define zeroext i16 @atomic_blsi_and_16_gpr_brnz(ptr %v, i16 zeroext %c) nounwind
 ; X64-NEXT:    # kill: def $ax killed $ax def $eax
 ; X64-NEXT:    jne .LBB53_1
 ; X64-NEXT:  # %bb.2: # %atomicrmw.end
-; X64-NEXT:    movzwl %ax, %eax
 ; X64-NEXT:    testl %eax, %ecx
 ; X64-NEXT:    je .LBB53_3
 ; X64-NEXT:  # %bb.4: # %if.then

--- a/llvm/test/CodeGen/X86/movmsk-cmp.ll
+++ b/llvm/test/CodeGen/X86/movmsk-cmp.ll
@@ -3713,8 +3713,6 @@ define i1 @movmsk_v16i8(<16 x i8> %x, <16 x i8> %y) {
 ; SSE-NEXT:    shrl $15, %ecx
 ; SSE-NEXT:    movl %eax, %edx
 ; SSE-NEXT:    shrl $8, %edx
-; SSE-NEXT:    andl $1, %edx
-; SSE-NEXT:    andl $8, %eax
 ; SSE-NEXT:    shrl $3, %eax
 ; SSE-NEXT:    xorl %edx, %eax
 ; SSE-NEXT:    andl %ecx, %eax
@@ -3729,8 +3727,6 @@ define i1 @movmsk_v16i8(<16 x i8> %x, <16 x i8> %y) {
 ; AVX1OR2-NEXT:    shrl $15, %ecx
 ; AVX1OR2-NEXT:    movl %eax, %edx
 ; AVX1OR2-NEXT:    shrl $8, %edx
-; AVX1OR2-NEXT:    andl $1, %edx
-; AVX1OR2-NEXT:    andl $8, %eax
 ; AVX1OR2-NEXT:    shrl $3, %eax
 ; AVX1OR2-NEXT:    xorl %edx, %eax
 ; AVX1OR2-NEXT:    andl %ecx, %eax

--- a/llvm/test/CodeGen/X86/pr34137.ll
+++ b/llvm/test/CodeGen/X86/pr34137.ll
@@ -15,10 +15,10 @@ define void @pr34127() {
 ; CHECK-NEXT:    movl %ecx, -{{[0-9]+}}(%rsp)
 ; CHECK-NEXT:    movzwl var_3(%rip), %ecx
 ; CHECK-NEXT:    xorl %edx, %edx
-; CHECK-NEXT:    testl %eax, %ecx
+; CHECK-NEXT:    testw %ax, %cx
 ; CHECK-NEXT:    sete %dl
-; CHECK-NEXT:    andl %ecx, %edx
-; CHECK-NEXT:    movq %rdx, var_212(%rip)
+; CHECK-NEXT:    andl %edx, %ecx
+; CHECK-NEXT:    movq %rcx, var_212(%rip)
 ; CHECK-NEXT:    movw $0, (%rax)
 ; CHECK-NEXT:    retq
 entry:


### PR DESCRIPTION
Add a second SimplifyDemandedBits pass for the RHS of an AND in `TargetLowering::SimplifyDemandedBits`. We already simplify the LHS (Op0) with a mask narrowed by the RHS’s known zeros (`~Known.Zero & DemandedBits`). This change also simplifies the RHS (Op1) with a mask narrowed by the LHS’s known zeros (`~Known2.Zero & DemandedBits`), so both sides get the same kind of simplification (e.g. both `~X & Y` and `X & ~Y` can benefit).