### PR TITLE
[ORC] Further simplify ContainerElementsMap::hoistDeps. NFCI.

### DIFF
--- a/llvm/include/llvm/ExecutionEngine/Orc/WaitingOnGraph.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/WaitingOnGraph.h
@@ -280,9 +280,7 @@ public:
     /// Returns true if SuperNodeDeps was changed.
     bool hoistDeps(SuperNodeDepsMap &SuperNodeDeps,
                    ElemToSuperNodeMap &ElemToSN) {
-      bool SuperNodeDepsChanged = false;
-
-      Deps.visit([&](ContainerId &Container, ElementSet &Elements) {
+      return Deps.visit([&](ContainerId &Container, ElementSet &Elements) {
         auto I = ElemToSN.find(Container);
         if (I == ElemToSN.end())
           return false;
@@ -294,15 +292,11 @@ public:
             return false;
 
           auto *DefSN = J->second;
-          if (DefSN != this) {
-            SuperNodeDepsChanged = true;
+          if (DefSN != this)
             SuperNodeDeps[DefSN].insert(this);
-          }
           return true;
         });
       });
-
-      return SuperNodeDepsChanged;
     }
   };
 


### PR DESCRIPTION
At the one call-site where the result of hoistDeps is used, self-dependencies will already have been eliminated. That means we can use the "deps changed" property that we're already computing rather than tracking "deps graph changed" separately.