### PR TITLE
[X86] Fix wrong RIP-relative relocations for AVX10.2 saturation conversions

### DIFF
--- a/llvm/lib/Target/X86/X86InstrAVX10.td
+++ b/llvm/lib/Target/X86/X86InstrAVX10.td
@@ -249,11 +249,11 @@ multiclass avx10_sat_cvt_base<bits<8> Opc, string OpStr, X86SchedWriteWidths sch
 defm VCVTBF162IBS : avx10_sat_cvt_base<0x69, "vcvtbf162ibs",
                                        SchedWriteVecIMul, X86vcvtp2ibs,
                                        avx512vl_i16_info, avx512vl_bf16_info>,
-                      AVX512XDIi8Base, T_MAP5, EVEX_CD8<16, CD8VF>;
+                      XD, T_MAP5, EVEX_CD8<16, CD8VF>;
 defm VCVTBF162IUBS : avx10_sat_cvt_base<0x6b, "vcvtbf162iubs",
                                         SchedWriteVecIMul, X86vcvtp2iubs,
                                         avx512vl_i16_info, avx512vl_bf16_info>,
-                       AVX512XDIi8Base, T_MAP5, EVEX_CD8<16, CD8VF>;
+                       XD, T_MAP5, EVEX_CD8<16, CD8VF>;
 
 defm VCVTPH2IBS : avx10_sat_cvt_base<0x69, "vcvtph2ibs", SchedWriteVecIMul,
                                      X86vcvtp2ibs, avx512vl_i16_info,
@@ -261,14 +261,14 @@ defm VCVTPH2IBS : avx10_sat_cvt_base<0x69, "vcvtph2ibs", SchedWriteVecIMul,
                   avx10_sat_cvt_rc<0x69, "vcvtph2ibs", SchedWriteVecIMul,
                                    avx512vl_i16_info, avx512vl_f16_info,
                                    X86vcvtp2ibsRnd>,
-                  AVX512PSIi8Base, T_MAP5, EVEX_CD8<16, CD8VF>;
+                  T_MAP5, EVEX_CD8<16, CD8VF>;
 defm VCVTPH2IUBS : avx10_sat_cvt_base<0x6b, "vcvtph2iubs", SchedWriteVecIMul,
                                       X86vcvtp2iubs, avx512vl_i16_info,
                                       avx512vl_f16_info>,
                    avx10_sat_cvt_rc<0x6b, "vcvtph2iubs", SchedWriteVecIMul,
                                     avx512vl_i16_info, avx512vl_f16_info,
                                     X86vcvtp2iubsRnd>,
-                   AVX512PSIi8Base, T_MAP5, EVEX_CD8<16, CD8VF>;
+                   T_MAP5, EVEX_CD8<16, CD8VF>;
 
 defm VCVTPS2IBS : avx10_sat_cvt_base<0x69, "vcvtps2ibs", SchedWriteVecIMul,
                                      X86vcvtp2ibs, avx512vl_i32_info,
@@ -276,23 +276,23 @@ defm VCVTPS2IBS : avx10_sat_cvt_base<0x69, "vcvtps2ibs", SchedWriteVecIMul,
                   avx10_sat_cvt_rc<0x69, "vcvtps2ibs", SchedWriteVecIMul,
                                    avx512vl_i32_info, avx512vl_f32_info,
                                    X86vcvtp2ibsRnd>,
-                  AVX512PDIi8Base, T_MAP5, EVEX_CD8<32, CD8VF>;
+                  PD, T_MAP5, EVEX_CD8<32, CD8VF>;
 defm VCVTPS2IUBS : avx10_sat_cvt_base<0x6b, "vcvtps2iubs", SchedWriteVecIMul,
                                       X86vcvtp2iubs, avx512vl_i32_info,
                                       avx512vl_f32_info>,
                    avx10_sat_cvt_rc<0x6b, "vcvtps2iubs", SchedWriteVecIMul,
                                     avx512vl_i32_info, avx512vl_f32_info,
                                     X86vcvtp2iubsRnd>,
-                   AVX512PDIi8Base, T_MAP5, EVEX_CD8<32, CD8VF>;
+                   PD, T_MAP5, EVEX_CD8<32, CD8VF>;
 
 defm VCVTTBF162IBS : avx10_sat_cvt_base<0x68, "vcvttbf162ibs",
                                         SchedWriteVecIMul, X86vcvttp2ibs,
                                         avx512vl_i16_info, avx512vl_bf16_info>,
-                       AVX512XDIi8Base, T_MAP5, EVEX_CD8<16, CD8VF>;
+                       XD, T_MAP5, EVEX_CD8<16, CD8VF>;
 defm VCVTTBF162IUBS : avx10_sat_cvt_base<0x6a, "vcvttbf162iubs",
                                          SchedWriteVecIMul, X86vcvttp2iubs,
                                          avx512vl_i16_info, avx512vl_bf16_info>,
-                        AVX512XDIi8Base, T_MAP5, EVEX_CD8<16, CD8VF>;
+                        XD, T_MAP5, EVEX_CD8<16, CD8VF>;
 
 defm VCVTTPH2IBS : avx10_sat_cvt_base<0x68, "vcvttph2ibs", SchedWriteVecIMul,
                                       X86vcvttp2ibs, avx512vl_i16_info,
@@ -300,14 +300,14 @@ defm VCVTTPH2IBS : avx10_sat_cvt_base<0x68, "vcvttph2ibs", SchedWriteVecIMul,
                    avx10_sat_cvt_sae<0x68, "vcvttph2ibs", SchedWriteVecIMul,
                                      avx512vl_i16_info, avx512vl_f16_info,
                                      X86vcvttp2ibsSAE>,
-                   AVX512PSIi8Base, T_MAP5, EVEX_CD8<16, CD8VF>;
+                   T_MAP5, EVEX_CD8<16, CD8VF>;
 defm VCVTTPH2IUBS : avx10_sat_cvt_base<0x6a, "vcvttph2iubs", SchedWriteVecIMul,
                                        X86vcvttp2iubs, avx512vl_i16_info,
                                        avx512vl_f16_info>,
                     avx10_sat_cvt_sae<0x6a, "vcvttph2iubs", SchedWriteVecIMul,
                                       avx512vl_i16_info, avx512vl_f16_info,
                                       X86vcvttp2iubsSAE>,
-                    AVX512PSIi8Base, T_MAP5, EVEX_CD8<16, CD8VF>;
+                    T_MAP5, EVEX_CD8<16, CD8VF>;
 
 defm VCVTTPS2IBS : avx10_sat_cvt_base<0x68, "vcvttps2ibs", SchedWriteVecIMul,
                                       X86vcvttp2ibs, avx512vl_i32_info,
@@ -315,14 +315,14 @@ defm VCVTTPS2IBS : avx10_sat_cvt_base<0x68, "vcvttps2ibs", SchedWriteVecIMul,
                    avx10_sat_cvt_sae<0x68, "vcvttps2ibs", SchedWriteVecIMul,
                                      avx512vl_i32_info, avx512vl_f32_info,
                                      X86vcvttp2ibsSAE>,
-                   AVX512PDIi8Base, T_MAP5, EVEX_CD8<32, CD8VF>;
+                   PD, T_MAP5, EVEX_CD8<32, CD8VF>;
 defm VCVTTPS2IUBS : avx10_sat_cvt_base<0x6a, "vcvttps2iubs", SchedWriteVecIMul,
                                        X86vcvttp2iubs, avx512vl_i32_info,
                                        avx512vl_f32_info>,
                     avx10_sat_cvt_sae<0x6a, "vcvttps2iubs", SchedWriteVecIMul,
                                       avx512vl_i32_info, avx512vl_f32_info,
                                       X86vcvttp2iubsSAE>,
-                    AVX512PDIi8Base, T_MAP5, EVEX_CD8<32, CD8VF>;
+                    PD, T_MAP5, EVEX_CD8<32, CD8VF>;
 
 //-------------------------------------------------
 // AVX10 SATCVT-DS instructions

--- a/llvm/lib/Target/X86/X86InstrAVX10.td
+++ b/llvm/lib/Target/X86/X86InstrAVX10.td
@@ -246,6 +246,7 @@ multiclass avx10_sat_cvt_base<bits<8> Opc, string OpStr, X86SchedWriteWidths sch
   }
 }
 
+let ExeDomain = SSEPackedInt in {
 defm VCVTBF162IBS : avx10_sat_cvt_base<0x69, "vcvtbf162ibs",
                                        SchedWriteVecIMul, X86vcvtp2ibs,
                                        avx512vl_i16_info, avx512vl_bf16_info>,
@@ -254,7 +255,9 @@ defm VCVTBF162IUBS : avx10_sat_cvt_base<0x6b, "vcvtbf162iubs",
                                         SchedWriteVecIMul, X86vcvtp2iubs,
                                         avx512vl_i16_info, avx512vl_bf16_info>,
                        XD, T_MAP5, EVEX_CD8<16, CD8VF>;
+}
 
+let ExeDomain = SSEPackedSingle in {
 defm VCVTPH2IBS : avx10_sat_cvt_base<0x69, "vcvtph2ibs", SchedWriteVecIMul,
                                      X86vcvtp2ibs, avx512vl_i16_info,
                                      avx512vl_f16_info>,
@@ -269,7 +272,9 @@ defm VCVTPH2IUBS : avx10_sat_cvt_base<0x6b, "vcvtph2iubs", SchedWriteVecIMul,
                                     avx512vl_i16_info, avx512vl_f16_info,
                                     X86vcvtp2iubsRnd>,
                    T_MAP5, EVEX_CD8<16, CD8VF>;
+}
 
+let ExeDomain = SSEPackedDouble in {
 defm VCVTPS2IBS : avx10_sat_cvt_base<0x69, "vcvtps2ibs", SchedWriteVecIMul,
                                      X86vcvtp2ibs, avx512vl_i32_info,
                                      avx512vl_f32_info>,
@@ -284,7 +289,9 @@ defm VCVTPS2IUBS : avx10_sat_cvt_base<0x6b, "vcvtps2iubs", SchedWriteVecIMul,
                                     avx512vl_i32_info, avx512vl_f32_info,
                                     X86vcvtp2iubsRnd>,
                    PD, T_MAP5, EVEX_CD8<32, CD8VF>;
+}
 
+let ExeDomain = SSEPackedInt in {
 defm VCVTTBF162IBS : avx10_sat_cvt_base<0x68, "vcvttbf162ibs",
                                         SchedWriteVecIMul, X86vcvttp2ibs,
                                         avx512vl_i16_info, avx512vl_bf16_info>,
@@ -293,7 +300,9 @@ defm VCVTTBF162IUBS : avx10_sat_cvt_base<0x6a, "vcvttbf162iubs",
                                          SchedWriteVecIMul, X86vcvttp2iubs,
                                          avx512vl_i16_info, avx512vl_bf16_info>,
                         XD, T_MAP5, EVEX_CD8<16, CD8VF>;
+}
 
+let ExeDomain = SSEPackedSingle in {
 defm VCVTTPH2IBS : avx10_sat_cvt_base<0x68, "vcvttph2ibs", SchedWriteVecIMul,
                                       X86vcvttp2ibs, avx512vl_i16_info,
                                       avx512vl_f16_info>,
@@ -308,7 +317,9 @@ defm VCVTTPH2IUBS : avx10_sat_cvt_base<0x6a, "vcvttph2iubs", SchedWriteVecIMul,
                                       avx512vl_i16_info, avx512vl_f16_info,
                                       X86vcvttp2iubsSAE>,
                     T_MAP5, EVEX_CD8<16, CD8VF>;
+}
 
+let ExeDomain = SSEPackedDouble in {
 defm VCVTTPS2IBS : avx10_sat_cvt_base<0x68, "vcvttps2ibs", SchedWriteVecIMul,
                                       X86vcvttp2ibs, avx512vl_i32_info,
                                       avx512vl_f32_info>,
@@ -323,6 +334,7 @@ defm VCVTTPS2IUBS : avx10_sat_cvt_base<0x6a, "vcvttps2iubs", SchedWriteVecIMul,
                                       avx512vl_i32_info, avx512vl_f32_info,
                                       X86vcvttp2iubsSAE>,
                     PD, T_MAP5, EVEX_CD8<32, CD8VF>;
+}
 
 //-------------------------------------------------
 // AVX10 SATCVT-DS instructions

--- a/llvm/test/MC/X86/Relocations/avx10.2satcvt.s
+++ b/llvm/test/MC/X86/Relocations/avx10.2satcvt.s
@@ -1,0 +1,40 @@
+# RUN: llvm-mc -filetype=obj -triple=x86_64 %s -o %t
+# RUN: llvm-objdump -dr --no-addresses %t | sed 's/#.*//;/^ *$/d' | FileCheck %s
+
+# CHECK:      62 f5 7f 08 69 05 00 00 00 00 vcvtbf162ibs    (%rip), %xmm0
+# CHECK-NEXT:          R_X86_64_PC32   foo-0x4
+# CHECK-NEXT: 62 f5 7f 08 6b 05 00 00 00 00 vcvtbf162iubs   (%rip), %xmm0
+# CHECK-NEXT:          R_X86_64_PC32   foo-0x4
+# CHECK-NEXT: 62 f5 7c 08 69 05 00 00 00 00 vcvtph2ibs      (%rip), %xmm0
+# CHECK-NEXT:          R_X86_64_PC32   foo-0x4
+# CHECK-NEXT: 62 f5 7c 08 6b 05 00 00 00 00 vcvtph2iubs     (%rip), %xmm0
+# CHECK-NEXT:          R_X86_64_PC32   foo-0x4
+# CHECK-NEXT: 62 f5 7d 08 69 05 00 00 00 00 vcvtps2ibs      (%rip), %xmm0
+# CHECK-NEXT:          R_X86_64_PC32   foo-0x4
+# CHECK-NEXT: 62 f5 7d 08 6b 05 00 00 00 00 vcvtps2iubs     (%rip), %xmm0
+# CHECK-NEXT:          R_X86_64_PC32   foo-0x4
+# CHECK-NEXT: 62 f5 7f 08 68 05 00 00 00 00 vcvttbf162ibs   (%rip), %xmm0
+# CHECK-NEXT:          R_X86_64_PC32   foo-0x4
+# CHECK-NEXT: 62 f5 7f 08 6a 05 00 00 00 00 vcvttbf162iubs  (%rip), %xmm0
+# CHECK-NEXT:          R_X86_64_PC32   foo-0x4
+# CHECK-NEXT: 62 f5 7c 08 68 05 00 00 00 00 vcvttph2ibs     (%rip), %xmm0
+# CHECK-NEXT:          R_X86_64_PC32   foo-0x4
+# CHECK-NEXT: 62 f5 7c 08 6a 05 00 00 00 00 vcvttph2iubs    (%rip), %xmm0
+# CHECK-NEXT:          R_X86_64_PC32   foo-0x4
+# CHECK-NEXT: 62 f5 7d 08 68 05 00 00 00 00 vcvttps2ibs     (%rip), %xmm0
+# CHECK-NEXT:          R_X86_64_PC32   foo-0x4
+# CHECK-NEXT: 62 f5 7d 08 6a 05 00 00 00 00 vcvttps2iubs    (%rip), %xmm0
+# CHECK-NEXT:          R_X86_64_PC32   foo-0x4
+
+vcvtbf162ibs foo(%rip), %xmm0
+vcvtbf162iubs foo(%rip), %xmm0
+vcvtph2ibs foo(%rip), %xmm0
+vcvtph2iubs foo(%rip), %xmm0
+vcvtps2ibs foo(%rip), %xmm0
+vcvtps2iubs foo(%rip), %xmm0
+vcvttbf162ibs foo(%rip), %xmm0
+vcvttbf162iubs foo(%rip), %xmm0
+vcvttph2ibs foo(%rip), %xmm0
+vcvttph2iubs foo(%rip), %xmm0
+vcvttps2ibs foo(%rip), %xmm0
+vcvttps2iubs foo(%rip), %xmm0

--- a/llvm/test/MC/X86/Relocations/avx10.2satcvt.s
+++ b/llvm/test/MC/X86/Relocations/avx10.2satcvt.s
@@ -1,5 +1,5 @@
 # RUN: llvm-mc -filetype=obj -triple=x86_64 %s -o %t
-# RUN: llvm-objdump -dr --no-addresses %t | sed 's/#.*//;/^ *$/d' | FileCheck %s
+# RUN: llvm-objdump -dr --no-addresses %t | sed 's/#.*//' | FileCheck %s
 
 # CHECK:      62 f5 7f 08 69 05 00 00 00 00 vcvtbf162ibs    (%rip), %xmm0
 # CHECK-NEXT:          R_X86_64_PC32   foo-0x4


### PR DESCRIPTION
AVX10.2 saturation conversion instructions (VCVT{T}{BF16,PH,PS}2I{U}BS)
incorrectly inherited from AVX512{PS,XD,PD}Ii8Base, which sets
ImmT=Imm8. This caused X86MCCodeEmitter to account for a nonexistent
trailing immediate byte when computing RIP-relative displacement fixups,
producing an addend of -5 instead of the correct -4.

Replace AVX512PSIi8Base/AVX512XDIi8Base/AVX512PDIi8Base with just the
needed prefix classes (PS is default, XD, PD), dropping the bogus
ImmT=Imm8. Preserve the original ExeDomain values (SSEPackedSingle,
SSEPackedDouble, SSEPackedInt; verified with `llvm-tblgen
--print-records ./llvm/lib/Target/X86/X86.td -I./llvm/include/
-I./llvm/lib/Target/X86/`). ExeDomain is not covered by any test.

Fix https://github.com/llvm/llvm-project/issues/184251