### PR TITLE
[InstCombine] Fold zext-add/sub-min/max-trunc to uadd.sat or usub.sat

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineCasts.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCasts.cpp
@@ -1086,6 +1086,28 @@ Instruction *InstCombinerImpl::visitTrunc(TruncInst &Trunc) {
 
   Value *A, *B;
   Constant *C;
+
+  // trunc(u/smin(zext(a) + zext(b), MAX)) --> uadd.sat(a, b)
+  if (match(Src,
+            m_OneUse(m_CombineOr(
+                m_UMin(m_OneUse(m_Add(m_ZExt(m_Value(A)), m_ZExt(m_Value(B)))),
+                       m_SpecificInt(APInt::getMaxValue(DestWidth))),
+                m_SMin(m_OneUse(m_Add(m_ZExt(m_Value(A)), m_ZExt(m_Value(B)))),
+                       m_SpecificInt(APInt::getMaxValue(DestWidth)))))) &&
+      A->getType() == DestTy && B->getType() == DestTy) {
+    return replaceInstUsesWith(
+        Trunc, Builder.CreateBinaryIntrinsic(Intrinsic::uadd_sat, A, B));
+  }
+
+  // trunc(smax(zext(a) - zext(b), 0)) --> usub.sat(a, b)
+  if (match(Src, m_OneUse(m_SMax(
+                     m_OneUse(m_Sub(m_ZExt(m_Value(A)), m_ZExt(m_Value(B)))),
+                     m_Zero()))) &&
+      A->getType() == DestTy && B->getType() == DestTy) {
+    return replaceInstUsesWith(
+        Trunc, Builder.CreateBinaryIntrinsic(Intrinsic::usub_sat, A, B));
+  }
+
   if (match(Src, m_LShr(m_SExt(m_Value(A)), m_Constant(C)))) {
     unsigned AWidth = A->getType()->getScalarSizeInBits();
     unsigned MaxShiftAmt = SrcWidth - std::max(DestWidth, AWidth);

--- a/llvm/test/Transforms/InstCombine/saturating-add-sub.ll
+++ b/llvm/test/Transforms/InstCombine/saturating-add-sub.ll
@@ -2902,8 +2902,8 @@ define i8 @fold_umin_to_uadd_sat_with_commuted_operations(i8 %a, i8 %b) {
 }
 
 ; Multi-use test: zext-add-umin-trunc, but add has multi use
-define i8 @no_fold_umin_to_uadd_sat_if_has_multi_use(i8 %a, i8 %b) {
-; CHECK-LABEL: @no_fold_umin_to_uadd_sat_if_has_multi_use(
+define i8 @no_fold_umin_to_uadd_sat_if_has_multi_use_for_add(i8 %a, i8 %b) {
+; CHECK-LABEL: @no_fold_umin_to_uadd_sat_if_has_multi_use_for_add(
 ; CHECK-NEXT:    [[ZA:%.*]] = zext i8 [[A:%.*]] to i16
 ; CHECK-NEXT:    [[ZB:%.*]] = zext i8 [[B:%.*]] to i16
 ; CHECK-NEXT:    [[ADD:%.*]] = add nuw nsw i16 [[ZB]], [[ZA]]
@@ -2916,6 +2916,43 @@ define i8 @no_fold_umin_to_uadd_sat_if_has_multi_use(i8 %a, i8 %b) {
   %zb = zext i8 %b to i16
   %add = add nuw nsw i16 %zb, %za
   call void @usei16(i16 %add)
+  %cmp = call i16 @llvm.umin.i16(i16 %add, i16 255)
+  %r = trunc nuw i16 %cmp to i8
+  ret i8 %r
+}
+
+; Multi-use test: zext-add-umin-trunc, but umin has multi use
+define i8 @no_fold_umin_to_uadd_sat_if_has_multi_use_for_umin(i8 %a, i8 %b) {
+; CHECK-LABEL: @no_fold_umin_to_uadd_sat_if_has_multi_use_for_umin(
+; CHECK-NEXT:    [[ZA:%.*]] = zext i8 [[A:%.*]] to i16
+; CHECK-NEXT:    [[ZB:%.*]] = zext i8 [[B:%.*]] to i16
+; CHECK-NEXT:    [[ADD:%.*]] = add nuw nsw i16 [[ZB]], [[ZA]]
+; CHECK-NEXT:    [[CMP:%.*]] = call i16 @llvm.umin.i16(i16 [[ADD]], i16 255)
+; CHECK-NEXT:    [[R:%.*]] = trunc nuw i16 [[CMP]] to i8
+; CHECK-NEXT:    call void @usei16(i16 [[CMP]])
+; CHECK-NEXT:    ret i8 [[R]]
+;
+  %za = zext i8 %a to i16
+  %zb = zext i8 %b to i16
+  %add = add nuw nsw i16 %zb, %za
+  %cmp = call i16 @llvm.umin.i16(i16 %add, i16 255)
+  %r = trunc nuw i16 %cmp to i8
+  call void @usei16(i16 %cmp)
+  ret i8 %r
+}
+
+; Multi-use test: zext-add-umin-trunc, and zext has multi use
+define i8 @fold_umin_to_uadd_sat_if_has_multi_use_for_zext(i8 %a, i8 %b) {
+; CHECK-LABEL: @fold_umin_to_uadd_sat_if_has_multi_use_for_zext(
+; CHECK-NEXT:    [[ZA:%.*]] = zext i8 [[A:%.*]] to i16
+; CHECK-NEXT:    call void @usei16(i16 [[ZA]])
+; CHECK-NEXT:    [[R:%.*]] = call i8 @llvm.uadd.sat.i8(i8 [[B:%.*]], i8 [[A]])
+; CHECK-NEXT:    ret i8 [[R]]
+;
+  %za = zext i8 %a to i16
+  %zb = zext i8 %b to i16
+  %add = add nuw nsw i16 %zb, %za
+  call void @usei16(i16 %za)
   %cmp = call i16 @llvm.umin.i16(i16 %add, i16 255)
   %r = trunc nuw i16 %cmp to i8
   ret i8 %r

--- a/llvm/test/Transforms/InstCombine/saturating-add-sub.ll
+++ b/llvm/test/Transforms/InstCombine/saturating-add-sub.ll
@@ -2862,11 +2862,7 @@ entry:
 ; Fold zext-add-umin-trunc to uadd.sat
 define i8 @fold_umin_to_uadd_sat(i8 %a, i8 %b) {
 ; CHECK-LABEL: @fold_umin_to_uadd_sat(
-; CHECK-NEXT:    [[ZA:%.*]] = zext i8 [[A:%.*]] to i16
-; CHECK-NEXT:    [[ZB:%.*]] = zext i8 [[B:%.*]] to i16
-; CHECK-NEXT:    [[ZSUM:%.*]] = add nuw nsw i16 [[ZB]], [[ZA]]
-; CHECK-NEXT:    [[CMP:%.*]] = call i16 @llvm.umin.i16(i16 [[ZSUM]], i16 255)
-; CHECK-NEXT:    [[R:%.*]] = trunc nuw i16 [[CMP]] to i8
+; CHECK-NEXT:    [[R:%.*]] = call i8 @llvm.uadd.sat.i8(i8 [[B:%.*]], i8 [[A:%.*]])
 ; CHECK-NEXT:    ret i8 [[R]]
 ;
   %za = zext i8 %a to i16
@@ -2880,11 +2876,7 @@ define i8 @fold_umin_to_uadd_sat(i8 %a, i8 %b) {
 ; Fold zext-add-umin-trunc to uadd.sat with illegal type
 define i3 @fold_umin_to_uadd_sat_with_illegal_type(i3 %a, i3 %b) {
 ; CHECK-LABEL: @fold_umin_to_uadd_sat_with_illegal_type(
-; CHECK-NEXT:    [[ZA:%.*]] = zext i3 [[A:%.*]] to i11
-; CHECK-NEXT:    [[ZB:%.*]] = zext i3 [[B:%.*]] to i11
-; CHECK-NEXT:    [[ZSUM:%.*]] = add nuw nsw i11 [[ZB]], [[ZA]]
-; CHECK-NEXT:    [[CMP:%.*]] = call i11 @llvm.umin.i11(i11 [[ZSUM]], i11 7)
-; CHECK-NEXT:    [[R:%.*]] = trunc nuw i11 [[CMP]] to i3
+; CHECK-NEXT:    [[R:%.*]] = call i3 @llvm.uadd.sat.i3(i3 [[B:%.*]], i3 [[A:%.*]])
 ; CHECK-NEXT:    ret i3 [[R]]
 ;
   %za = zext i3 %a to i11
@@ -2898,11 +2890,7 @@ define i3 @fold_umin_to_uadd_sat_with_illegal_type(i3 %a, i3 %b) {
 ; Fold zext-add-umin-trunc to uadd.sat with commuted operations
 define i8 @fold_umin_to_uadd_sat_with_commuted_operations(i8 %a, i8 %b) {
 ; CHECK-LABEL: @fold_umin_to_uadd_sat_with_commuted_operations(
-; CHECK-NEXT:    [[ZA:%.*]] = zext i8 [[A:%.*]] to i16
-; CHECK-NEXT:    [[ZB:%.*]] = zext i8 [[B:%.*]] to i16
-; CHECK-NEXT:    [[ZSUM:%.*]] = add nuw nsw i16 [[ZA]], [[ZB]]
-; CHECK-NEXT:    [[CMP:%.*]] = call i16 @llvm.umin.i16(i16 [[ZSUM]], i16 255)
-; CHECK-NEXT:    [[R:%.*]] = trunc nuw i16 [[CMP]] to i8
+; CHECK-NEXT:    [[R:%.*]] = call i8 @llvm.uadd.sat.i8(i8 [[A:%.*]], i8 [[B:%.*]])
 ; CHECK-NEXT:    ret i8 [[R]]
 ;
   %za = zext i8 %a to i16
@@ -2938,11 +2926,7 @@ declare void @usei16(i16)
 ; Fold zext-add-smin-trunc to uadd.sat
 define i8 @fold_smin_to_uadd_sat(i8 %a, i8 %b) {
 ; CHECK-LABEL: @fold_smin_to_uadd_sat(
-; CHECK-NEXT:    [[ZA:%.*]] = zext i8 [[A:%.*]] to i16
-; CHECK-NEXT:    [[ZB:%.*]] = zext i8 [[B:%.*]] to i16
-; CHECK-NEXT:    [[ZSUM:%.*]] = add nuw nsw i16 [[ZB]], [[ZA]]
-; CHECK-NEXT:    [[CMP:%.*]] = call i16 @llvm.smin.i16(i16 [[ZSUM]], i16 255)
-; CHECK-NEXT:    [[R:%.*]] = trunc nuw i16 [[CMP]] to i8
+; CHECK-NEXT:    [[R:%.*]] = call i8 @llvm.uadd.sat.i8(i8 [[B:%.*]], i8 [[A:%.*]])
 ; CHECK-NEXT:    ret i8 [[R]]
 ;
   %za = zext i8 %a to i16
@@ -2956,11 +2940,7 @@ define i8 @fold_smin_to_uadd_sat(i8 %a, i8 %b) {
 ; Vector version of fold zext-add-umin-trunc to uadd.sat
 define <2 x i8> @fold_umin_to_uadd_sat_vec(<2 x i8> %a, <2 x i8> %b) {
 ; CHECK-LABEL: @fold_umin_to_uadd_sat_vec(
-; CHECK-NEXT:    [[ZA:%.*]] = zext <2 x i8> [[A:%.*]] to <2 x i16>
-; CHECK-NEXT:    [[ZB:%.*]] = zext <2 x i8> [[B:%.*]] to <2 x i16>
-; CHECK-NEXT:    [[ZSUM:%.*]] = add nuw nsw <2 x i16> [[ZB]], [[ZA]]
-; CHECK-NEXT:    [[CMP:%.*]] = call <2 x i16> @llvm.umin.v2i16(<2 x i16> [[ZSUM]], <2 x i16> splat (i16 255))
-; CHECK-NEXT:    [[R:%.*]] = trunc nuw <2 x i16> [[CMP]] to <2 x i8>
+; CHECK-NEXT:    [[R:%.*]] = call <2 x i8> @llvm.uadd.sat.v2i8(<2 x i8> [[B:%.*]], <2 x i8> [[A:%.*]])
 ; CHECK-NEXT:    ret <2 x i8> [[R]]
 ;
   %za = zext <2 x i8> %a to <2 x i16>
@@ -3010,11 +2990,7 @@ define i8 @no_fold_umin_to_uadd_sat_if_not_boundary(i8 %a, i8 %b) {
 ; Fold zext-sub-smax-trunc to usub.sat
 define i8 @fold_smax_to_usub_sat(i8 %a, i8 %b) {
 ; CHECK-LABEL: @fold_smax_to_usub_sat(
-; CHECK-NEXT:    [[ZA:%.*]] = zext i8 [[A:%.*]] to i16
-; CHECK-NEXT:    [[ZB:%.*]] = zext i8 [[B:%.*]] to i16
-; CHECK-NEXT:    [[ZSUB:%.*]] = sub nsw i16 [[ZA]], [[ZB]]
-; CHECK-NEXT:    [[CMP:%.*]] = call i16 @llvm.smax.i16(i16 [[ZSUB]], i16 0)
-; CHECK-NEXT:    [[R:%.*]] = trunc nuw i16 [[CMP]] to i8
+; CHECK-NEXT:    [[R:%.*]] = call i8 @llvm.usub.sat.i8(i8 [[A:%.*]], i8 [[B:%.*]])
 ; CHECK-NEXT:    ret i8 [[R]]
 ;
   %za = zext i8 %a to i16
@@ -3028,11 +3004,7 @@ define i8 @fold_smax_to_usub_sat(i8 %a, i8 %b) {
 ; Vector version of fold zext-sub-smax-trunc to usub.sat
 define <2 x i8> @fold_smax_to_usub_sat_vec(<2 x i8> %a, <2 x i8> %b) {
 ; CHECK-LABEL: @fold_smax_to_usub_sat_vec(
-; CHECK-NEXT:    [[ZA:%.*]] = zext <2 x i8> [[A:%.*]] to <2 x i16>
-; CHECK-NEXT:    [[ZB:%.*]] = zext <2 x i8> [[B:%.*]] to <2 x i16>
-; CHECK-NEXT:    [[ZSUB:%.*]] = sub nsw <2 x i16> [[ZA]], [[ZB]]
-; CHECK-NEXT:    [[CMP:%.*]] = call <2 x i16> @llvm.smax.v2i16(<2 x i16> [[ZSUB]], <2 x i16> zeroinitializer)
-; CHECK-NEXT:    [[R:%.*]] = trunc nuw <2 x i16> [[CMP]] to <2 x i8>
+; CHECK-NEXT:    [[R:%.*]] = call <2 x i8> @llvm.usub.sat.v2i8(<2 x i8> [[A:%.*]], <2 x i8> [[B:%.*]])
 ; CHECK-NEXT:    ret <2 x i8> [[R]]
 ;
   %za = zext <2 x i8> %a to <2 x i16>

--- a/llvm/test/Transforms/InstCombine/saturating-add-sub.ll
+++ b/llvm/test/Transforms/InstCombine/saturating-add-sub.ll
@@ -2858,3 +2858,223 @@ entry:
   %res = select i1 %cmp, i32 %add, i32 2147483647
   ret i32 %res
 }
+
+; Fold zext-add-umin-trunc to uadd.sat
+define i8 @fold_umin_to_uadd_sat(i8 %a, i8 %b) {
+; CHECK-LABEL: @fold_umin_to_uadd_sat(
+; CHECK-NEXT:    [[ZA:%.*]] = zext i8 [[A:%.*]] to i16
+; CHECK-NEXT:    [[ZB:%.*]] = zext i8 [[B:%.*]] to i16
+; CHECK-NEXT:    [[ZSUM:%.*]] = add nuw nsw i16 [[ZB]], [[ZA]]
+; CHECK-NEXT:    [[CMP:%.*]] = call i16 @llvm.umin.i16(i16 [[ZSUM]], i16 255)
+; CHECK-NEXT:    [[R:%.*]] = trunc nuw i16 [[CMP]] to i8
+; CHECK-NEXT:    ret i8 [[R]]
+;
+  %za = zext i8 %a to i16
+  %zb = zext i8 %b to i16
+  %zsum = add nuw nsw i16 %zb, %za
+  %cmp = call i16 @llvm.umin.i16(i16 %zsum, i16 255)
+  %r = trunc nuw i16 %cmp to i8
+  ret i8 %r
+}
+
+; Fold zext-add-umin-trunc to uadd.sat with illegal type
+define i3 @fold_umin_to_uadd_sat_with_illegal_type(i3 %a, i3 %b) {
+; CHECK-LABEL: @fold_umin_to_uadd_sat_with_illegal_type(
+; CHECK-NEXT:    [[ZA:%.*]] = zext i3 [[A:%.*]] to i11
+; CHECK-NEXT:    [[ZB:%.*]] = zext i3 [[B:%.*]] to i11
+; CHECK-NEXT:    [[ZSUM:%.*]] = add nuw nsw i11 [[ZB]], [[ZA]]
+; CHECK-NEXT:    [[CMP:%.*]] = call i11 @llvm.umin.i11(i11 [[ZSUM]], i11 7)
+; CHECK-NEXT:    [[R:%.*]] = trunc nuw i11 [[CMP]] to i3
+; CHECK-NEXT:    ret i3 [[R]]
+;
+  %za = zext i3 %a to i11
+  %zb = zext i3 %b to i11
+  %zsum = add nuw nsw i11 %zb, %za
+  %cmp = call i11 @llvm.umin.i11(i11 %zsum, i11 7)
+  %r = trunc nuw i11 %cmp to i3
+  ret i3 %r
+}
+
+; Fold zext-add-umin-trunc to uadd.sat with commuted operations
+define i8 @fold_umin_to_uadd_sat_with_commuted_operations(i8 %a, i8 %b) {
+; CHECK-LABEL: @fold_umin_to_uadd_sat_with_commuted_operations(
+; CHECK-NEXT:    [[ZA:%.*]] = zext i8 [[A:%.*]] to i16
+; CHECK-NEXT:    [[ZB:%.*]] = zext i8 [[B:%.*]] to i16
+; CHECK-NEXT:    [[ZSUM:%.*]] = add nuw nsw i16 [[ZA]], [[ZB]]
+; CHECK-NEXT:    [[CMP:%.*]] = call i16 @llvm.umin.i16(i16 [[ZSUM]], i16 255)
+; CHECK-NEXT:    [[R:%.*]] = trunc nuw i16 [[CMP]] to i8
+; CHECK-NEXT:    ret i8 [[R]]
+;
+  %za = zext i8 %a to i16
+  %zb = zext i8 %b to i16
+  %zsum = add nuw nsw i16 %za, %zb
+  %cmp = call i16 @llvm.umin.i16(i16 %zsum, i16 255)
+  %r = trunc nuw i16 %cmp to i8
+  ret i8 %r
+}
+
+; Multi-use test: zext-add-umin-trunc, but add has multi use
+define i8 @no_fold_umin_to_uadd_sat_if_has_multi_use(i8 %a, i8 %b) {
+; CHECK-LABEL: @no_fold_umin_to_uadd_sat_if_has_multi_use(
+; CHECK-NEXT:    [[ZA:%.*]] = zext i8 [[A:%.*]] to i16
+; CHECK-NEXT:    [[ZB:%.*]] = zext i8 [[B:%.*]] to i16
+; CHECK-NEXT:    [[ADD:%.*]] = add nuw nsw i16 [[ZB]], [[ZA]]
+; CHECK-NEXT:    call void @usei16(i16 [[ADD]])
+; CHECK-NEXT:    [[CMP:%.*]] = call i16 @llvm.umin.i16(i16 [[ADD]], i16 255)
+; CHECK-NEXT:    [[R:%.*]] = trunc nuw i16 [[CMP]] to i8
+; CHECK-NEXT:    ret i8 [[R]]
+;
+  %za = zext i8 %a to i16
+  %zb = zext i8 %b to i16
+  %add = add nuw nsw i16 %zb, %za
+  call void @usei16(i16 %add)
+  %cmp = call i16 @llvm.umin.i16(i16 %add, i16 255)
+  %r = trunc nuw i16 %cmp to i8
+  ret i8 %r
+}
+
+declare void @usei16(i16)
+
+; Fold zext-add-smin-trunc to uadd.sat
+define i8 @fold_smin_to_uadd_sat(i8 %a, i8 %b) {
+; CHECK-LABEL: @fold_smin_to_uadd_sat(
+; CHECK-NEXT:    [[ZA:%.*]] = zext i8 [[A:%.*]] to i16
+; CHECK-NEXT:    [[ZB:%.*]] = zext i8 [[B:%.*]] to i16
+; CHECK-NEXT:    [[ZSUM:%.*]] = add nuw nsw i16 [[ZB]], [[ZA]]
+; CHECK-NEXT:    [[CMP:%.*]] = call i16 @llvm.smin.i16(i16 [[ZSUM]], i16 255)
+; CHECK-NEXT:    [[R:%.*]] = trunc nuw i16 [[CMP]] to i8
+; CHECK-NEXT:    ret i8 [[R]]
+;
+  %za = zext i8 %a to i16
+  %zb = zext i8 %b to i16
+  %zsum = add nuw nsw i16 %zb, %za
+  %cmp = call i16 @llvm.smin.i16(i16 %zsum, i16 255)
+  %r = trunc nuw i16 %cmp to i8
+  ret i8 %r
+}
+
+; Vector version of fold zext-add-umin-trunc to uadd.sat
+define <2 x i8> @fold_umin_to_uadd_sat_vec(<2 x i8> %a, <2 x i8> %b) {
+; CHECK-LABEL: @fold_umin_to_uadd_sat_vec(
+; CHECK-NEXT:    [[ZA:%.*]] = zext <2 x i8> [[A:%.*]] to <2 x i16>
+; CHECK-NEXT:    [[ZB:%.*]] = zext <2 x i8> [[B:%.*]] to <2 x i16>
+; CHECK-NEXT:    [[ZSUM:%.*]] = add nuw nsw <2 x i16> [[ZB]], [[ZA]]
+; CHECK-NEXT:    [[CMP:%.*]] = call <2 x i16> @llvm.umin.v2i16(<2 x i16> [[ZSUM]], <2 x i16> splat (i16 255))
+; CHECK-NEXT:    [[R:%.*]] = trunc nuw <2 x i16> [[CMP]] to <2 x i8>
+; CHECK-NEXT:    ret <2 x i8> [[R]]
+;
+  %za = zext <2 x i8> %a to <2 x i16>
+  %zb = zext <2 x i8> %b to <2 x i16>
+  %zsum = add nuw nsw <2 x i16> %zb, %za
+  %cmp = call <2 x i16> @llvm.umin.v2i16(<2 x i16> %zsum, <2 x i16> splat (i16 255))
+  %r = trunc nuw <2 x i16> %cmp to <2 x i8>
+  ret <2 x i8> %r
+}
+
+; Negative test: operands type inconsistency.
+define i16 @no_fold_umin_to_uadd_sat_if_different_type(i8 %a, i16 %b) {
+; CHECK-LABEL: @no_fold_umin_to_uadd_sat_if_different_type(
+; CHECK-NEXT:    [[ZA:%.*]] = zext i8 [[A:%.*]] to i32
+; CHECK-NEXT:    [[ZB:%.*]] = zext i16 [[B:%.*]] to i32
+; CHECK-NEXT:    [[ZSUM:%.*]] = add nuw nsw i32 [[ZB]], [[ZA]]
+; CHECK-NEXT:    [[CMP:%.*]] = call i32 @llvm.umin.i32(i32 [[ZSUM]], i32 65535)
+; CHECK-NEXT:    [[R:%.*]] = trunc nuw i32 [[CMP]] to i16
+; CHECK-NEXT:    ret i16 [[R]]
+;
+  %za = zext i8 %a to i32
+  %zb = zext i16 %b to i32
+  %zsum = add nuw nsw i32 %zb, %za
+  %cmp = call i32 @llvm.umin.i32(i32 %zsum, i32 65535)
+  %r = trunc nuw i32 %cmp to i16
+  ret i16 %r
+}
+
+; Negative test: umin constant is not the maximum value of the target bitwidth.
+define i8 @no_fold_umin_to_uadd_sat_if_not_boundary(i8 %a, i8 %b) {
+; CHECK-LABEL: @no_fold_umin_to_uadd_sat_if_not_boundary(
+; CHECK-NEXT:    [[ZA:%.*]] = zext i8 [[A:%.*]] to i16
+; CHECK-NEXT:    [[ZB:%.*]] = zext i8 [[B:%.*]] to i16
+; CHECK-NEXT:    [[ZSUM:%.*]] = add nuw nsw i16 [[ZB]], [[ZA]]
+; CHECK-NEXT:    [[CMP:%.*]] = call i16 @llvm.umin.i16(i16 [[ZSUM]], i16 121)
+; CHECK-NEXT:    [[R:%.*]] = trunc nuw nsw i16 [[CMP]] to i8
+; CHECK-NEXT:    ret i8 [[R]]
+;
+  %za = zext i8 %a to i16
+  %zb = zext i8 %b to i16
+  %zsum = add nuw nsw i16 %zb, %za
+  %cmp = call i16 @llvm.umin.i16(i16 %zsum, i16 121)
+  %r = trunc nuw nsw i16 %cmp to i8
+  ret i8 %r
+}
+
+; Fold zext-sub-smax-trunc to usub.sat
+define i8 @fold_smax_to_usub_sat(i8 %a, i8 %b) {
+; CHECK-LABEL: @fold_smax_to_usub_sat(
+; CHECK-NEXT:    [[ZA:%.*]] = zext i8 [[A:%.*]] to i16
+; CHECK-NEXT:    [[ZB:%.*]] = zext i8 [[B:%.*]] to i16
+; CHECK-NEXT:    [[ZSUB:%.*]] = sub nsw i16 [[ZA]], [[ZB]]
+; CHECK-NEXT:    [[CMP:%.*]] = call i16 @llvm.smax.i16(i16 [[ZSUB]], i16 0)
+; CHECK-NEXT:    [[R:%.*]] = trunc nuw i16 [[CMP]] to i8
+; CHECK-NEXT:    ret i8 [[R]]
+;
+  %za = zext i8 %a to i16
+  %zb = zext i8 %b to i16
+  %zsub = sub nsw i16 %za, %zb
+  %cmp = call i16 @llvm.smax.i16(i16 %zsub, i16 0)
+  %r = trunc nuw i16 %cmp to i8
+  ret i8 %r
+}
+
+; Vector version of fold zext-sub-smax-trunc to usub.sat
+define <2 x i8> @fold_smax_to_usub_sat_vec(<2 x i8> %a, <2 x i8> %b) {
+; CHECK-LABEL: @fold_smax_to_usub_sat_vec(
+; CHECK-NEXT:    [[ZA:%.*]] = zext <2 x i8> [[A:%.*]] to <2 x i16>
+; CHECK-NEXT:    [[ZB:%.*]] = zext <2 x i8> [[B:%.*]] to <2 x i16>
+; CHECK-NEXT:    [[ZSUB:%.*]] = sub nsw <2 x i16> [[ZA]], [[ZB]]
+; CHECK-NEXT:    [[CMP:%.*]] = call <2 x i16> @llvm.smax.v2i16(<2 x i16> [[ZSUB]], <2 x i16> zeroinitializer)
+; CHECK-NEXT:    [[R:%.*]] = trunc nuw <2 x i16> [[CMP]] to <2 x i8>
+; CHECK-NEXT:    ret <2 x i8> [[R]]
+;
+  %za = zext <2 x i8> %a to <2 x i16>
+  %zb = zext <2 x i8> %b to <2 x i16>
+  %zsub = sub nsw <2 x i16> %za, %zb
+  %cmp = call <2 x i16> @llvm.smax.v2i16(<2 x i16> %zsub, <2 x i16> splat (i16 0))
+  %r = trunc nuw <2 x i16> %cmp to <2 x i8>
+  ret <2 x i8> %r
+}
+
+; Negative test: operands type inconsistency.
+define i8 @no_fold_smax_to_usub_sat_if_different_type(i8 %a, i16 %b) {
+; CHECK-LABEL: @no_fold_smax_to_usub_sat_if_different_type(
+; CHECK-NEXT:    [[ZA:%.*]] = zext i8 [[A:%.*]] to i32
+; CHECK-NEXT:    [[ZB:%.*]] = zext i16 [[B:%.*]] to i32
+; CHECK-NEXT:    [[ZSUB:%.*]] = sub nsw i32 [[ZA]], [[ZB]]
+; CHECK-NEXT:    [[CMP:%.*]] = call i32 @llvm.smax.i32(i32 [[ZSUB]], i32 0)
+; CHECK-NEXT:    [[R:%.*]] = trunc i32 [[CMP]] to i8
+; CHECK-NEXT:    ret i8 [[R]]
+;
+  %za = zext i8 %a to i32
+  %zb = zext i16 %b to i32
+  %zsub = sub nsw i32 %za, %zb
+  %cmp = call i32 @llvm.smax.i32(i32 %zsub, i32 0)
+  %r = trunc i32 %cmp to i8
+  ret i8 %r
+}
+
+; Negative test: smax constant is not zero.
+define i8 @no_fold_umin_to_uadd_sat_if_not_zero(i8 %a, i8 %b) {
+; CHECK-LABEL: @no_fold_umin_to_uadd_sat_if_not_zero(
+; CHECK-NEXT:    [[ZA:%.*]] = zext i8 [[A:%.*]] to i16
+; CHECK-NEXT:    [[ZB:%.*]] = zext i8 [[B:%.*]] to i16
+; CHECK-NEXT:    [[ZSUB:%.*]] = sub nsw i16 [[ZA]], [[ZB]]
+; CHECK-NEXT:    [[CMP:%.*]] = call i16 @llvm.smax.i16(i16 [[ZSUB]], i16 2)
+; CHECK-NEXT:    [[R:%.*]] = trunc nuw i16 [[CMP]] to i8
+; CHECK-NEXT:    ret i8 [[R]]
+;
+  %za = zext i8 %a to i16
+  %zb = zext i8 %b to i16
+  %zsub = sub nsw i16 %za, %zb
+  %cmp = call i16 @llvm.smax.i16(i16 %zsub, i16 2)
+  %r = trunc nuw i16 %cmp to i8
+  ret i8 %r
+}


### PR DESCRIPTION
Fixes #185244

## sumary

```
trunc(umin(zext(a) + zext(b), MAX)) -> uadd.sat(a, b)
trunc(smin(zext(a) + zext(b), MAX)) -> uadd.sat(a, b)
trunc(smax(zext(a) - zext(b), 0)) --> usub.sat(a, b)
```

Proof: https://alive2.llvm.org/ce/z/K6wszu

## body

```c
uint16_t sum = (uint16_t)a + (uint16_t)b;
return (sum > 255) ? 255 : (uint8_t)sum;
```

The code above will compile into the following LLVM IR:

```llvm
%3 = zext i8 %0 to i16
%4 = zext i8 %1 to i16
%5 = add nuw nsw i16 %4, %3
%6 = tail call i16 @llvm.umin.i16(i16 %5, i16 255)
%7 = trunc nuw i16 %6 to i8
ret i8 %7
```

The above is a common way to write saturated add. Similarly, we also have the following LLVM IR:

```llvm
%3 = zext i8 %0 to i16
%4 = zext i8 %1 to i16
%5 = sub nsw i16 %3, %4
%6 = tail call i16 @llvm.smax.i16(i16 %5, i16 0)
%7 = trunc nuw i16 %6 to i8
ret i8 %7
```

However, we can actually use `llvm.uadd.sat` and `llvm.usub.sat` directly, which will facilitate subsequent optimizations.

I'm quite skeptical about whether the subtraction optimization here will have any effect, because it seems to me that such LLVM IR won't occur. I could achieve a similar effect using `(a > b) ? (a - b) : 0`, while LLVM could optimize this expression to `usub.sat`.

Regarding addition, I considered the case of `smin` based on @sweiglbosker  suggestion. In my opinion, `umin` and `smin` shouldn't have any impact, because I matched `zext` instead of `sext`.

I'm a beginner with LLVM, so there might be some issues with symbol naming or not using the most appropriate API. Please point them to help me, thanks. :)

## local testing:

```bash
$ cmake --build build/ -t check-llvm-transforms-instcombine
[12/13] Running lit suite /home/suoyuan/git_repo/llvm-project/llvm/test/Transforms/InstCombine

Testing Time: 4.39s

Total Discovered Tests: 1792
  Unsupported:  110 (6.14%)
  Passed     : 1682 (93.86%)

$ cmake --build build/ -t check-llvm
[348/349] Running the LLVM regression tests

Testing Time: 866.65s

Total Discovered Tests: 72412
  Skipped          :   409 (0.56%)
  Unsupported      : 30594 (42.25%)
  Passed           : 41341 (57.09%)
  Expectedly Failed:    68 (0.09%)
```