### PR TITLE
libclc: Add uintptr_t overloads of atomic_fetch_add and sub

### DIFF
--- a/libclc/opencl/lib/generic/atomic/atomic_fetch_add.cl
+++ b/libclc/opencl/lib/generic/atomic/atomic_fetch_add.cl
@@ -17,3 +17,31 @@
 
 #define __CLC_BODY <atomic_def.inc>
 #include <clc/math/gentype.inc>
+
+#if defined(__opencl_c_atomic_order_seq_cst) &&                                \
+    defined(__opencl_c_atomic_scope_device)
+
+_CLC_OVERLOAD _CLC_DEF uintptr_t
+atomic_fetch_add(volatile __local atomic_uintptr_t *p, ptrdiff_t v) {
+  return __opencl_atomic_fetch_add(p, v, memory_order_seq_cst,
+                                   memory_scope_device);
+}
+
+_CLC_OVERLOAD _CLC_DEF uintptr_t
+atomic_fetch_add(volatile __global atomic_uintptr_t *p, ptrdiff_t v) {
+  return __opencl_atomic_fetch_add(p, v, memory_order_seq_cst,
+                                   memory_scope_device);
+}
+
+#if _CLC_GENERIC_AS_SUPPORTED
+
+_CLC_OVERLOAD _CLC_DEF uintptr_t atomic_fetch_add(volatile atomic_uintptr_t *p,
+                                                  ptrdiff_t v) {
+  return __opencl_atomic_fetch_add(p, v, memory_order_seq_cst,
+                                   memory_scope_device);
+}
+
+#endif // _CLC_GENERIC_AS_SUPPORTED
+
+#endif // defined(__opencl_c_atomic_order_seq_cst) &&
+       // defined(__opencl_c_atomic_scope_device)

--- a/libclc/opencl/lib/generic/atomic/atomic_fetch_sub.cl
+++ b/libclc/opencl/lib/generic/atomic/atomic_fetch_sub.cl
@@ -17,3 +17,31 @@
 
 #define __CLC_BODY <atomic_def.inc>
 #include <clc/math/gentype.inc>
+
+#if defined(__opencl_c_atomic_order_seq_cst) &&                                \
+    defined(__opencl_c_atomic_scope_device)
+
+_CLC_OVERLOAD _CLC_DEF uintptr_t
+atomic_fetch_sub(volatile __local atomic_uintptr_t *p, ptrdiff_t v) {
+  return __opencl_atomic_fetch_sub(p, v, memory_order_seq_cst,
+                                   memory_scope_device);
+}
+
+_CLC_OVERLOAD _CLC_DEF uintptr_t
+atomic_fetch_sub(volatile __global atomic_uintptr_t *p, ptrdiff_t v) {
+  return __opencl_atomic_fetch_sub(p, v, memory_order_seq_cst,
+                                   memory_scope_device);
+}
+
+#if _CLC_GENERIC_AS_SUPPORTED
+
+_CLC_OVERLOAD _CLC_DEF uintptr_t atomic_fetch_sub(volatile atomic_uintptr_t *p,
+                                                  ptrdiff_t v) {
+  return __opencl_atomic_fetch_sub(p, v, memory_order_seq_cst,
+                                   memory_scope_device);
+}
+
+#endif // _CLC_GENERIC_AS_SUPPORTED
+
+#endif // defined(__opencl_c_atomic_order_seq_cst) &&
+       // defined(__opencl_c_atomic_scope_device)


### PR DESCRIPTION
This is a special case because the pointee type is unsigned, but the
input value is signed. Directly use the opencl builtins, because these
work correctly without any ugly casting required, and it's not worth
putting a wrapper in clc.