### PR TITLE
[ORC] Add WaitingOnGraph record / replay facility and test tool.

### DIFF
--- a/llvm/include/llvm/ExecutionEngine/Orc/Core.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/Core.h
@@ -1408,6 +1408,15 @@ public:
   /// Add a symbol name to the SymbolStringPool and return a pointer to it.
   SymbolStringPtr intern(StringRef SymName) { return EPC->intern(SymName); }
 
+  /// Set a WaitingOnGraph::Recorder to capture WaitingOnGraph operations.
+  ///
+  /// This method can be called at most once. If called, it should be called
+  /// before any symbols are materialized.
+  void setWaitingOnGraphOpRecorder(WaitingOnGraph::OpRecorder &R) {
+    assert(!GOpRecorder && "WaitingOnGraph recorder already set");
+    GOpRecorder = &R;
+  }
+
   /// Set the Platform for this ExecutionSession.
   void setPlatform(std::unique_ptr<Platform> P) { this->P = std::move(P); }
 
@@ -1827,6 +1836,7 @@ private:
 
   std::vector<JITDylibSP> JDs;
   WaitingOnGraph G;
+  WaitingOnGraph::OpRecorder *GOpRecorder = nullptr;
 
   // FIXME: Remove this (and runOutstandingMUs) once the linking layer works
   //        with callbacks from asynchronous queries.

--- a/llvm/include/llvm/ExecutionEngine/Orc/WaitingOnGraph.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/WaitingOnGraph.h
@@ -465,8 +465,21 @@ public:
     ElemToSuperNodeMap ElemToSN;
   };
 
+  class OpRecorder {
+  public:
+    virtual ~OpRecorder() = default;
+    virtual void
+    recordSimplify(const std::vector<std::unique_ptr<SuperNode>> &SNs) = 0;
+    virtual void recordFail(const ContainerElementsMap &Failed) = 0;
+    virtual void recordEnd() = 0;
+  };
+
   /// Preprocess a list of SuperNodes to remove all intra-SN dependencies.
-  static SimplifyResult simplify(std::vector<std::unique_ptr<SuperNode>> SNs) {
+  static SimplifyResult simplify(std::vector<std::unique_ptr<SuperNode>> SNs,
+                                 OpRecorder *Rec = nullptr) {
+    if (Rec)
+      Rec->recordSimplify(SNs);
+
     // Build ElemToSN map.
     ElemToSuperNodeMap ElemToSN;
     for (auto &SN : SNs)
@@ -553,7 +566,10 @@ public:
   /// result, so clients should take whatever actions are needed to mark
   /// this as failed in their external representation.
   std::vector<std::unique_ptr<SuperNode>>
-  fail(const ContainerElementsMap &Failed) {
+  fail(const ContainerElementsMap &Failed, OpRecorder *Rec = nullptr) {
+    if (Rec)
+      Rec->recordFail(Failed);
+
     std::vector<std::unique_ptr<SuperNode>> FailedSNs;
 
     visitWithRemoval(PendingSNs, [&](std::unique_ptr<SuperNode> &SN) {

--- a/llvm/include/llvm/ExecutionEngine/Orc/WaitingOnGraphOpReplay.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/WaitingOnGraphOpReplay.h
@@ -1,0 +1,462 @@
+//===------ WaitingOnGraphOpReplay.h - Record/replay APIs -------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Utilities for capturing and replaying WaitingOnGraph operations.
+//
+//===----------------------------------------------------------------------===//
+#ifndef LLVM_EXECUTIONENGINE_ORC_WAITINGONGRAPHOPREPLAY_H
+#define LLVM_EXECUTIONENGINE_ORC_WAITINGONGRAPHOPREPLAY_H
+
+#include "llvm/ADT/fallible_iterator.h"
+#include "llvm/ExecutionEngine/Orc/WaitingOnGraph.h"
+#include "llvm/Support/Error.h"
+
+#include <mutex>
+#include <optional>
+#include <variant>
+
+namespace llvm::orc::detail {
+
+/// Records WaitingOnGraph operations to a line-oriented text format on a
+/// raw_ostream. The format is a sequence of operations terminated by "end":
+///
+///   simplify-and-emit <num-supernodes>
+///     sn <index>
+///       defs <num-containers>
+///         container <id> <num-elements>
+///           elements <elem-id>...
+///       deps <num-containers>
+///         ...
+///   fail
+///     failed <num-containers>
+///       container <id> <num-elements>
+///         elements <elem-id>...
+///   end
+///
+/// Container and element ids are integers assigned sequentially by the
+/// recorder. Leading/trailing whitespace on each line is ignored.
+template <typename ContainerIdT, typename ElementIdT>
+class WaitingOnGraphOpStreamRecorder
+    : public detail::WaitingOnGraph<ContainerIdT, ElementIdT>::OpRecorder {
+  using WOG = detail::WaitingOnGraph<ContainerIdT, ElementIdT>;
+  using SuperNode = typename WOG::SuperNode;
+  using ContainerId = typename WOG::ContainerId;
+  using ElementId = typename WOG::ElementId;
+  using ContainerElementsMap = typename WOG::ContainerElementsMap;
+  using ElementSet = typename WOG::ElementSet;
+
+public:
+  WaitingOnGraphOpStreamRecorder(raw_ostream &OS) : OS(OS) {}
+
+  void
+  recordSimplify(const std::vector<std::unique_ptr<SuperNode>> &SNs) override {
+    std::scoped_lock<std::mutex> Lock(M);
+    recordSuperNodes("simplify-and-emit", SNs);
+  }
+
+  void recordFail(const ContainerElementsMap &Failed) override {
+    std::scoped_lock<std::mutex> Lock(M);
+    OS << "fail\n";
+    recordContainerElementsMap("  ", "failed", Failed);
+  }
+
+  void recordEnd() override {
+    std::scoped_lock<std::mutex> Lock(M);
+    OS << "end\n";
+  }
+
+  // Should render the container id as a string.
+  virtual void printContainer(const ContainerId &C) {
+    auto I =
+        ContainerIdMap.insert(std::make_pair(C, ContainerIdMap.size())).first;
+    OS << I->second.Id;
+  }
+
+  // Should render the elements of C as a space-separated list (with a space
+  // before the first element).
+  virtual void printElementsIn(const ContainerId &C,
+                               const ElementSet &Elements) {
+    assert(ContainerIdMap.count(C));
+    auto &ElementIdMap = ContainerIdMap[C].ElementIdMap;
+    for (auto &E : Elements) {
+      auto I =
+          ElementIdMap.insert(std::make_pair(E, ElementIdMap.size())).first;
+      OS << " " << I->second;
+    }
+  }
+
+private:
+  struct ContainerIdInfo {
+    ContainerIdInfo() = default;
+    ContainerIdInfo(size_t Id) : Id(Id) {}
+    size_t Id = 0;
+    DenseMap<ElementId, size_t> ElementIdMap;
+  };
+  DenseMap<ContainerId, ContainerIdInfo> ContainerIdMap;
+
+  void recordSuperNodes(StringRef OpName,
+                        const std::vector<std::unique_ptr<SuperNode>> &SNs) {
+    OS << OpName << " " << SNs.size() << "\n";
+    for (size_t I = 0; I != SNs.size(); ++I) {
+      OS << "  sn " << I << "\n";
+      recordContainerElementsMap("    ", "defs", SNs[I]->defs());
+      recordContainerElementsMap("    ", "deps", SNs[I]->deps());
+    }
+  }
+
+  void recordContainerElementsMap(StringRef Indent, StringRef MapName,
+                                  const ContainerElementsMap &M) {
+    OS << Indent << MapName << " " << M.size() << "\n";
+    for (auto &[Container, Elements] : M) {
+      OS << Indent << "  container ";
+      printContainer(Container);
+      OS << " " << Elements.size() << "\n";
+      OS << Indent << "    elements ";
+      printElementsIn(Container, Elements);
+      OS << "\n";
+    }
+  }
+
+  std::mutex M;
+  raw_ostream &OS;
+};
+
+template <typename ContainerIdT, typename ElementIdT>
+class WaitingOnGraphOpReplay {
+public:
+  using Graph = WaitingOnGraph<ContainerIdT, ElementIdT>;
+  using SuperNode = typename Graph::SuperNode;
+  using ContainerId = typename Graph::ContainerId;
+  using ElementId = typename Graph::ElementId;
+  using ContainerElementsMap = typename Graph::ContainerElementsMap;
+  using ExternalState = typename Graph::ExternalState;
+
+  /// A simplify-and-emit operation parsed from the input.
+  struct SimplifyAndEmitOp {
+    SimplifyAndEmitOp() = default;
+    SimplifyAndEmitOp(SimplifyAndEmitOp &&) = default;
+    SimplifyAndEmitOp &operator=(SimplifyAndEmitOp &&) = default;
+    SimplifyAndEmitOp(std::vector<std::unique_ptr<SuperNode>> SNs)
+        : SNs(std::move(SNs)) {}
+    std::vector<std::unique_ptr<SuperNode>> SNs;
+  };
+
+  /// A fail operation parsed from the input.
+  struct FailOp {
+    FailOp() = default;
+    FailOp(FailOp &&) = default;
+    FailOp &operator=(FailOp &&) = default;
+    FailOp(ContainerElementsMap Failed) : Failed(std::move(Failed)) {}
+    ContainerElementsMap Failed;
+  };
+
+  /// A parsed operation -- either a simplify-and-emit or a fail.
+  using Op = std::variant<SimplifyAndEmitOp, FailOp>;
+
+  /// Replay ops on a given graph.
+  struct Replayer {
+    Replayer(Graph &G) : G(G) {}
+
+    void replay(Op O) {
+      if (auto *SimplifyAndEmit = std::get_if<SimplifyAndEmitOp>(&O))
+        replaySimplifyAndEmit(std::move(SimplifyAndEmit->SNs));
+      else if (auto *Fail = std::get_if<FailOp>(&O))
+        replayFail(std::move(Fail->Failed));
+    }
+
+    void replaySimplifyAndEmit(std::vector<std::unique_ptr<SuperNode>> SNs) {
+      auto SR = Graph::simplify(std::move(SNs));
+      auto ER = G.emit(std::move(SR),
+                       [this](ContainerId C, ElementId E) -> ExternalState {
+                         {
+                           auto I = Failed.find(C);
+                           if (I != Failed.end() && I->second.count(E))
+                             return ExternalState::Failed;
+                         }
+                         {
+                           auto I = Ready.find(C);
+                           if (I != Ready.end() && I->second.count(E))
+                             return ExternalState::Ready;
+                         }
+                         return ExternalState::None;
+                       });
+      for (auto &SN : ER.Ready)
+        for (auto &[Container, Elems] : SN->defs())
+          Ready[Container].insert(Elems.begin(), Elems.end());
+      for (auto &SN : ER.Failed)
+        for (auto &[Container, Elems] : SN->defs())
+          Failed[Container].insert(Elems.begin(), Elems.end());
+    }
+
+    void replayFail(ContainerElementsMap NewlyFailed) {
+      for (auto &[Container, Elems] : NewlyFailed)
+        Failed[Container].insert(Elems.begin(), Elems.end());
+
+      auto FailedSNs = G.fail(NewlyFailed);
+      for (auto &SN : FailedSNs)
+        for (auto &[Container, Elems] : SN->defs())
+          Failed[Container].insert(Elems.begin(), Elems.end());
+    }
+
+    Graph &G;
+    ContainerElementsMap Ready;
+    ContainerElementsMap Failed;
+  };
+
+  /// Parser for input buffer.
+  class OpParser {
+  public:
+    using ParseResult = std::pair<std::optional<Op>, StringRef>;
+    virtual ~OpParser() = default;
+    virtual Expected<ParseResult> parseNext(StringRef Input) = 0;
+
+  protected:
+    Expected<ParseResult>
+    parsedSimplifyAndEmit(std::vector<std::unique_ptr<SuperNode>> SNs,
+                          StringRef Input) {
+      return ParseResult(SimplifyAndEmitOp{std::move(SNs)}, Input);
+    }
+
+    Expected<ParseResult> parsedFail(ContainerElementsMap NewlyFailed,
+                                     StringRef Input) {
+      return ParseResult(FailOp{std::move(NewlyFailed)}, Input);
+    }
+
+    Expected<ParseResult> parsedEnd(StringRef Input) {
+      return ParseResult(std::nullopt, Input);
+    }
+  };
+
+  /// Fallible iterator for iterating over WaitingOnGraph ops.
+  class OpIterator {
+  public:
+    /// Default constructed fallible iterator. Serves as end value.
+    OpIterator() = default;
+
+    /// Construct a fallible iterator reading from the given input buffer using
+    /// the given parser.
+    OpIterator(std::shared_ptr<OpParser> P, StringRef Input)
+        : P(std::move(P)), Input(Input), PrevInput(Input) {}
+
+    OpIterator(const OpIterator &Other)
+        : P(Other.P), Input(Other.PrevInput), PrevInput(Other.PrevInput) {
+      // We can't just copy Op, we need to re-parse.
+      if (this->P)
+        cantFail(inc());
+    }
+
+    OpIterator &operator=(const OpIterator &Other) {
+      P = Other.P;
+      Input = PrevInput = Other.PrevInput;
+      if (this->P)
+        cantFail(inc());
+      return *this;
+    }
+
+    OpIterator(OpIterator &&) = default;
+    OpIterator &operator=(OpIterator &&) = default;
+
+    /// Move to next record.
+    Error inc() {
+      PrevInput = Input;
+      auto PR = P->parseNext(Input);
+      if (!PR)
+        return PR.takeError();
+      std::tie(CurOp, Input) = std::move(*PR);
+      if (!CurOp) {
+        P = nullptr;
+        Input = "";
+      }
+      return Error::success();
+    }
+
+    // Dereference. Note: Moves op type.
+    Op &operator*() {
+      assert(CurOp && "Dereferencing end/invalid iterator");
+      return *CurOp;
+    }
+
+    // Dereference. Note: Moves op type.
+    const Op &operator*() const {
+      assert(CurOp && "Dereferencing end/invalid iterator");
+      return *CurOp;
+    }
+
+    /// Compare iterators. End iterators compare equal.
+    friend bool operator==(const OpIterator &LHS, const OpIterator &RHS) {
+      return LHS.P == RHS.P && LHS.Input == RHS.Input;
+    }
+
+    friend bool operator!=(const OpIterator &LHS, const OpIterator &RHS) {
+      return !(LHS == RHS);
+    }
+
+  private:
+    std::shared_ptr<OpParser> P;
+    StringRef Input, PrevInput;
+    std::optional<Op> CurOp;
+  };
+};
+
+/// Returns a fallible iterator range over the operations in the given buffer.
+/// The buffer should contain text in the format produced by
+/// WaitingOnGraphOpStreamRecorder. Parsing errors are reported through Err.
+template <typename ContainerIdT, typename ElementIdT>
+iterator_range<fallible_iterator<
+    typename WaitingOnGraphOpReplay<ContainerIdT, ElementIdT>::OpIterator>>
+readWaitingOnGraphOpsFromBuffer(StringRef InputBuffer, Error &Err) {
+
+  using Replay = WaitingOnGraphOpReplay<ContainerIdT, ElementIdT>;
+
+  class Parser : public Replay::OpParser {
+  public:
+    using ParseResult = typename Replay::OpParser::ParseResult;
+    using SuperNode = typename Replay::SuperNode;
+    using ContainerElementsMap = typename Replay::ContainerElementsMap;
+
+    /// Parse the next operation from Input into CurrentOp.
+    /// Sets IsEnd on "end" keyword. Returns Error on parse failure.
+    Expected<ParseResult> parseNext(StringRef Input) override {
+      auto Line = getNextLine(Input);
+
+      if (Line.empty())
+        return make_error<StringError>(
+            "unexpected end of input (missing 'end')",
+            inconvertibleErrorCode());
+
+      if (Line.consume_front("simplify-and-emit ")) {
+        size_t NumSNs;
+        if (Line.trim().consumeInteger(10, NumSNs))
+          return make_error<StringError>(
+              "expected supernode count after 'simplify-and-emit'",
+              inconvertibleErrorCode());
+        auto SNs = parseSuperNodes(Input, NumSNs);
+        if (!SNs)
+          return SNs.takeError();
+        return this->parsedSimplifyAndEmit(std::move(*SNs), Input);
+      } else if (Line.trim() == "fail") {
+        auto FailElems = parseContainerElementsMap("failed", Input);
+        if (!FailElems)
+          return FailElems.takeError();
+        return this->parsedFail(std::move(*FailElems), Input);
+      } else if (Line.trim() == "end")
+        return this->parsedEnd(Input);
+      else
+        return make_error<StringError>("unexpected line: '" + Line + "'",
+                                       inconvertibleErrorCode());
+    }
+
+  private:
+    static StringRef getNextLine(StringRef &Input) {
+      StringRef Line;
+      // Parse skipping blank lines.
+      do {
+        std::tie(Line, Input) = Input.split('\n');
+        Line = Line.trim();
+      } while (Line.empty() && !Input.empty());
+      return Line;
+    }
+
+    static Expected<std::vector<std::unique_ptr<SuperNode>>>
+    parseSuperNodes(StringRef &Input, size_t NumSNs) {
+      std::vector<std::unique_ptr<SuperNode>> SNs;
+      for (size_t I = 0; I != NumSNs; ++I) {
+        // Parse "sn <index>"
+        StringRef Line = getNextLine(Input);
+        if (!Line.consume_front("sn "))
+          return make_error<StringError>("expected 'sn " + Twine(I) + "'",
+                                         inconvertibleErrorCode());
+
+        auto Defs = parseContainerElementsMap("defs", Input);
+        if (!Defs)
+          return Defs.takeError();
+        auto Deps = parseContainerElementsMap("deps", Input);
+        if (!Deps)
+          return Deps.takeError();
+
+        SNs.push_back(
+            std::make_unique<SuperNode>(std::move(*Defs), std::move(*Deps)));
+      }
+      return SNs;
+    }
+
+    static Expected<ContainerElementsMap>
+    parseContainerElementsMap(StringRef ArgName, StringRef &Input) {
+      // Parse "defs <count>"
+      auto Line = getNextLine(Input);
+      if (!Line.consume_front(ArgName))
+        return make_error<StringError>("expected '" + ArgName + " <count>'",
+                                       inconvertibleErrorCode());
+      size_t NumContainers;
+      if (Line.trim().consumeInteger(10, NumContainers))
+        return make_error<StringError>("expected " + ArgName + " count",
+                                       inconvertibleErrorCode());
+
+      ContainerElementsMap M;
+      for (size_t I = 0; I != NumContainers; ++I) {
+        Line = getNextLine(Input);
+        if (!Line.consume_front("container "))
+          return make_error<StringError>("expected 'container <id> <count>'",
+                                         inconvertibleErrorCode());
+
+        size_t Container;
+        Line = Line.trim();
+        if (Line.consumeInteger(10, Container))
+          return make_error<StringError>("expected container id",
+                                         inconvertibleErrorCode());
+
+        if (M.count(Container))
+          return make_error<StringError>(
+              "expected container id to be unique within " + ArgName,
+              inconvertibleErrorCode());
+
+        size_t NumElements;
+        if (Line.trim().consumeInteger(10, NumElements))
+          return make_error<StringError>("expected elements count",
+                                         inconvertibleErrorCode());
+        if (NumElements == 0)
+          return make_error<StringError>("number of elements for container " +
+                                             Twine(Container) + " must be > 0",
+                                         inconvertibleErrorCode());
+
+        Line = getNextLine(Input);
+        if (!Line.consume_front("elements "))
+          return make_error<StringError>("expected 'elements ...'",
+                                         inconvertibleErrorCode());
+
+        auto &Elements = M[Container];
+        for (size_t J = 0; J != NumElements; ++J) {
+          size_t Elem;
+          Line = Line.trim();
+          if (Line.consumeInteger(10, Elem))
+            return make_error<StringError>("expected element id",
+                                           inconvertibleErrorCode());
+          if (Elements.count(Elem))
+            return make_error<StringError>(
+                "expected element id to be unique within container " +
+                    Twine(Container),
+                inconvertibleErrorCode());
+          Elements.insert(Elem);
+        }
+      }
+
+      return M;
+    }
+  };
+
+  ErrorAsOutParameter _(Err);
+  typename Replay::OpIterator Begin(std::make_shared<Parser>(), InputBuffer);
+  typename Replay::OpIterator End;
+  if ((Err = Begin.inc())) // Parse first operation.
+    Begin = End;
+  return make_fallible_range(std::move(Begin), std::move(End), Err);
+}
+
+} // namespace llvm::orc::detail
+
+#endif // LLVM_EXECUTIONENGINE_ORC_WAITINGONGRAPHOPREPLAY_H

--- a/llvm/lib/ExecutionEngine/Orc/Core.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/Core.cpp
@@ -1590,12 +1590,15 @@ ExecutionSession::~ExecutionSession() {
 Error ExecutionSession::endSession() {
   LLVM_DEBUG(dbgs() << "Ending ExecutionSession " << this << "\n");
 
+  WaitingOnGraph::OpRecorder *GOpRecorderToEnd = nullptr;
   auto JDsToRemove = runSessionLocked([&] {
 
 #ifdef EXPENSIVE_CHECKS
     verifySessionState("Entering ExecutionSession::endSession");
 #endif
 
+    if (SessionOpen)
+      GOpRecorderToEnd = GOpRecorder;
     SessionOpen = false;
     return JDs;
   });
@@ -1605,6 +1608,9 @@ Error ExecutionSession::endSession() {
   auto Err = removeJITDylibs(std::move(JDsToRemove));
 
   Err = joinErrors(std::move(Err), EPC->disconnect());
+
+  if (GOpRecorderToEnd)
+    GOpRecorderToEnd->recordEnd();
 
   return Err;
 }
@@ -2988,7 +2994,7 @@ Error ExecutionSession::OL_notifyEmitted(
           std::move(Residual), WaitingOnGraph::ContainerElementsMap()));
   }
 
-  auto SR = WaitingOnGraph::simplify(std::move(SNs));
+  auto SR = WaitingOnGraph::simplify(std::move(SNs), GOpRecorder);
 
   LLVM_DEBUG({
     dbgs() << "  Simplified dependencies:\n";
@@ -3106,6 +3112,10 @@ ExecutionSession::IL_failSymbols(JITDylib &JD,
   verifySessionState("entering ExecutionSession::IL_failSymbols");
 #endif
 
+  // Early out in the easy case.
+  if (SymbolsToFail.empty())
+    return {};
+
   JITDylib::AsynchronousSymbolQuerySet FailedQueries;
   auto Fail = [&](JITDylib *FailJD, NonOwningSymbolStringPtr FailSym) {
     auto I = FailJD->Symbols.find_as(FailSym);
@@ -3134,7 +3144,7 @@ ExecutionSession::IL_failSymbols(JITDylib &JD,
   for (auto &Sym : SymbolsToFail)
     JDToFail.insert(NonOwningSymbolStringPtr(Sym));
 
-  auto FailedSNs = G.fail(ToFail);
+  auto FailedSNs = G.fail(ToFail, GOpRecorder);
 
   for (auto &SN : FailedSNs) {
     for (auto &[FailJD, Defs] : SN->defs()) {

--- a/llvm/test/ExecutionEngine/JITLink/Generic/waiting-on-graph-capture-replay.test
+++ b/llvm/test/ExecutionEngine/JITLink/Generic/waiting-on-graph-capture-replay.test
@@ -1,0 +1,17 @@
+# Test that -waiting-on-graph-capture and -waiting-on-graph-replay round-trip.
+#
+# Compile a trivial program, run it under llvm-jitlink with
+# -waiting-on-graph-capture to produce a capture file, then replay that file
+# with -waiting-on-graph-replay.
+
+# RUN: rm -rf %t && mkdir %t
+# RUN: llc -filetype=obj -o %t/main.o %S/Inputs/main-ret-0.ll
+# RUN: llvm-jitlink -noexec -waiting-on-graph-capture %t/capture.txt %t/main.o
+# RUN: FileCheck --check-prefix=CAPTURE %s < %t/capture.txt
+# RUN: llvm-jitlink -waiting-on-graph-replay %t/capture.txt \
+# RUN:   | FileCheck --check-prefix=REPLAY %s
+
+# CAPTURE: simplify-and-emit
+# CAPTURE: end
+
+# REPLAY: Replaying WaitingOnGraph operations

--- a/llvm/tools/llvm-jitlink/llvm-jitlink.cpp
+++ b/llvm/tools/llvm-jitlink/llvm-jitlink.cpp
@@ -67,6 +67,7 @@
 #include "llvm/Support/Process.h"
 #include "llvm/Support/TargetSelect.h"
 #include "llvm/Support/Timer.h"
+#include <chrono>
 #include <cstring>
 #include <deque>
 #include <string>
@@ -86,7 +87,7 @@ using namespace llvm::orc;
 
 static cl::OptionCategory JITLinkCategory("JITLink Options");
 
-static cl::list<std::string> InputFiles(cl::Positional, cl::OneOrMore,
+static cl::list<std::string> InputFiles(cl::Positional, cl::ZeroOrMore,
                                         cl::desc("input files"),
                                         cl::cat(JITLinkCategory));
 
@@ -352,6 +353,16 @@ static cl::opt<bool> ForceLoadObjC(
              "Objective-C classes or categories, or Swift structs, "
              "classes or extensions"),
     cl::init(false), cl::cat(JITLinkCategory));
+
+static cl::opt<std::string> WaitingOnGraphCapture(
+    "waiting-on-graph-capture",
+    cl::desc("Record WaitingOnGraph operations to the given file"),
+    cl::init(""), cl::cat(JITLinkCategory));
+
+static cl::opt<std::string> WaitingOnGraphReplay(
+    "waiting-on-graph-replay",
+    cl::desc("Replay WaitingOnGraph operations from the given file"),
+    cl::init(""), cl::cat(JITLinkCategory));
 
 static ExitOnError ExitOnErr;
 
@@ -1214,6 +1225,18 @@ Session::Session(std::unique_ptr<ExecutorProcessControl> EPC, Error &Err)
 
   ES.setErrorReporter(reportLLVMJITLinkError);
 
+  // Attach WaitingOnGraph recorder if requested.
+  if (!WaitingOnGraphCapture.empty()) {
+    if (auto GRecorderOrErr =
+            WaitingOnGraphOpRecorder::Create(WaitingOnGraphCapture)) {
+      GOpRecorder = std::move(*GRecorderOrErr);
+      ES.setWaitingOnGraphOpRecorder(*GOpRecorder);
+    } else {
+      Err = GRecorderOrErr.takeError();
+      return;
+    }
+  }
+
   if (!NoProcessSymbols)
     ExitOnErr(loadProcessSymbols(*this));
 
@@ -1756,6 +1779,15 @@ static std::pair<Triple, SubtargetFeatures> getFirstFileTripleAndFeatures() {
 }
 
 static Error sanitizeArguments(const Triple &TT, const char *ArgV0) {
+
+  if (InputFiles.empty())
+    return make_error<StringError>(
+        "Not enough positional command line arguments specified! (see "
+        "llvm-jitlink --help)",
+        inconvertibleErrorCode());
+
+  // If we're in replay mode we should never get here.
+  assert(WaitingOnGraphReplay.empty());
 
   // -noexec and --args should not be used together.
   if (NoExec && !InputArgv.empty())
@@ -2874,6 +2906,61 @@ static Error symbolicateBacktraces() {
   return Error::success();
 }
 
+static Error waitingOnGraphReplay() {
+  // Warn about ignored options.
+  {
+    bool PrintedHeader = false;
+    for (auto &[OptName, Opt] : cl::getRegisteredOptions()) {
+      if (Opt == &WaitingOnGraphReplay)
+        continue;
+      if (Opt->getNumOccurrences()) {
+        if (!PrintedHeader) {
+          errs() << "Warning: Running in -waiting-on-graph-replay mode. "
+                    "The following options will be ignored:\n";
+          PrintedHeader = true;
+        }
+        errs() << "  " << OptName << "\n";
+      }
+    }
+  }
+
+  // Read the replay buffer file.
+  auto GraphOpsBuffer = getFile(WaitingOnGraphReplay);
+  if (!GraphOpsBuffer)
+    return GraphOpsBuffer.takeError();
+
+  using Replay = orc::detail::WaitingOnGraphOpReplay<uintptr_t, uintptr_t>;
+  using Graph = typename Replay::Graph;
+  using Replayer = typename Replay::Replayer;
+
+  std::vector<typename Replay::Op> RecordedOps;
+
+  // First read the buffer to build the Ops vector. Doing this up-front allows
+  // us to avoid polluting the timings below with the cost of parsing.
+  Error Err = Error::success();
+  for (auto &Op :
+       orc::detail::readWaitingOnGraphOpsFromBuffer<uintptr_t, uintptr_t>(
+           (*GraphOpsBuffer)->getBuffer(), Err))
+    RecordedOps.push_back(std::move(Op));
+  if (Err)
+    return Err;
+
+  // Now replay the Ops:
+  Graph G;
+  Replayer R(G);
+
+  outs() << "Replaying WaitingOnGraph operations from " << WaitingOnGraphReplay
+         << "...\n";
+  auto ReplayStart = std::chrono::high_resolution_clock::now();
+  for (auto &Op : RecordedOps)
+    R.replay(std::move(Op));
+  auto ReplayEnd = std::chrono::high_resolution_clock::now();
+  std::chrono::duration<double> ReplayDiff = ReplayEnd - ReplayStart;
+  outs() << ReplayDiff.count() << "s to replay " << RecordedOps.size()
+         << " ops (wall-clock time)\n";
+  return Error::success();
+}
+
 namespace {
 struct JITLinkTimers {
   TimerGroup JITLinkTG{"llvm-jitlink timers", "timers for llvm-jitlink phases"};
@@ -2893,6 +2980,12 @@ int main(int argc, char *argv[]) {
   cl::HideUnrelatedOptions({&JITLinkCategory, &getColorCategory()});
   cl::ParseCommandLineOptions(argc, argv, "llvm jitlink tool");
   ExitOnErr.setBanner(std::string(argv[0]) + ": ");
+
+  // Check for WaitingOnGraph replay mode.
+  if (!WaitingOnGraphReplay.empty()) {
+    ExitOnErr(waitingOnGraphReplay());
+    return 0;
+  }
 
   /// If timers are enabled, create a JITLinkTimers instance.
   std::unique_ptr<JITLinkTimers> Timers =

--- a/llvm/tools/llvm-jitlink/llvm-jitlink.h
+++ b/llvm/tools/llvm-jitlink/llvm-jitlink.h
@@ -22,6 +22,7 @@
 #include "llvm/ExecutionEngine/Orc/ObjectLinkingLayer.h"
 #include "llvm/ExecutionEngine/Orc/RedirectionManager.h"
 #include "llvm/ExecutionEngine/Orc/SimpleRemoteEPC.h"
+#include "llvm/ExecutionEngine/Orc/WaitingOnGraphOpReplay.h"
 #include "llvm/ExecutionEngine/RuntimeDyldChecker.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/Regex.h"
@@ -32,6 +33,29 @@
 namespace llvm {
 
 struct Session {
+
+  class WaitingOnGraphOpRecorder
+      : public orc::detail::WaitingOnGraphOpStreamRecorder<
+            orc::JITDylib *, orc::NonOwningSymbolStringPtr> {
+  public:
+    static Expected<std::unique_ptr<WaitingOnGraphOpRecorder>>
+    Create(StringRef Path) {
+      std::error_code EC;
+      std::unique_ptr<WaitingOnGraphOpRecorder> Instance(
+          new WaitingOnGraphOpRecorder(Path, EC));
+
+      if (EC)
+        return createFileError(Path, EC);
+      return Instance;
+    }
+
+  private:
+    WaitingOnGraphOpRecorder(StringRef Path, std::error_code EC)
+        : orc::detail::WaitingOnGraphOpStreamRecorder<
+              orc::JITDylib *, orc::NonOwningSymbolStringPtr>(OutStream),
+          OutStream(Path, EC) {}
+    raw_fd_ostream OutStream;
+  };
 
   struct LazyLinkingSupport {
     LazyLinkingSupport(
@@ -143,6 +167,8 @@ struct Session {
 
 private:
   Session(std::unique_ptr<orc::ExecutorProcessControl> EPC, Error &Err);
+
+  std::unique_ptr<WaitingOnGraphOpRecorder> GOpRecorder;
 };
 
 /// Record symbols, GOT entries, stubs, and sections for ELF file.

--- a/llvm/unittests/ExecutionEngine/Orc/WaitingOnGraphTest.cpp
+++ b/llvm/unittests/ExecutionEngine/Orc/WaitingOnGraphTest.cpp
@@ -7,6 +7,8 @@
 //===----------------------------------------------------------------------===//
 
 #include "llvm/ExecutionEngine/Orc/WaitingOnGraph.h"
+#include "llvm/ExecutionEngine/Orc/WaitingOnGraphOpReplay.h"
+#include "llvm/Testing/Support/Error.h"
 #include "gtest/gtest.h"
 
 namespace llvm::orc::detail {
@@ -812,4 +814,46 @@ TEST_F(WaitingOnGraphTest, Fail_ZigZag) {
   auto ER1 = emit(TestGraph::simplify(B.takeSuperNodes()));
   EXPECT_EQ(ER1.Ready.size(), 0U);
   EXPECT_EQ(collapseDefs(ER1.Failed, false), merge(Defs0, Defs1));
+}
+
+TEST_F(WaitingOnGraphTest, RecordAndReplay) {
+  // Record a sequence of operations, then replay them on a fresh graph.
+  std::string RecordBuf;
+  raw_string_ostream RecordOS(RecordBuf);
+  WaitingOnGraphOpStreamRecorder<uintptr_t, uintptr_t> Rec(RecordOS);
+
+  SuperNodeBuilder B;
+
+  // Emit a node with no deps -- becomes Ready immediately.
+  ContainerElementsMap Defs0({{0, {0}}});
+  B.add(Defs0, ContainerElementsMap());
+  auto ER0 = integrate(
+      G.emit(TestGraph::simplify(B.takeSuperNodes(), &Rec), GetExternalState));
+  EXPECT_EQ(collapseDefs(ER0.Ready), Defs0);
+  EXPECT_EQ(ER0.Failed.size(), 0U);
+
+  // Emit a node depending on an external dep -- stays Pending.
+  ContainerElementsMap Defs1({{0, {1}}});
+  ContainerElementsMap Deps1({{1, {0}}});
+  B.add(Defs1, Deps1);
+  auto ER1 = integrate(
+      G.emit(TestGraph::simplify(B.takeSuperNodes(), &Rec), GetExternalState));
+  EXPECT_EQ(ER1.Ready.size(), 0U);
+  EXPECT_EQ(ER1.Failed.size(), 0U);
+
+  // Fail the external dep -- causes the pending node to fail.
+  ContainerElementsMap FailElems({{1, {0}}});
+  auto FailedSNs = G.fail(FailElems, &Rec);
+  EXPECT_EQ(FailedSNs.size(), 1U);
+
+  Rec.recordEnd();
+
+  // Now replay on a fresh graph.
+  TestGraph G2;
+  typename WaitingOnGraphOpReplay<uintptr_t, uintptr_t>::Replayer R(G2);
+  Error Err = Error::success();
+  for (auto &Op :
+       readWaitingOnGraphOpsFromBuffer<uintptr_t, uintptr_t>(RecordBuf, Err))
+    R.replay(std::move(Op));
+  EXPECT_THAT_ERROR(std::move(Err), Succeeded());
 }


### PR DESCRIPTION
This patch adds APIs and a test tool for recording and replaying operations on ORC's WaitingOnGraph data structure.

WaitingOnGraph is critical to the performance of LLVM's JIT (see e.g. https://github.com/llvm/llvm-project/issues/179611), and these facilities will make it easier to capture and investigate test cases, and build a performance regression suite.

WaitingOnGraph::Recorder provides an interface for classes that want to capture the essential WaitingOnGraph operations: simplify, emit, and fail.

WaitingOnGraphStreamRecorder is a WaitingOnGraph::Recorder implementation that writes these operations (using plain ints to encode the containers / elements) to a raw_ostream.

WaitingOnGraphBufferReplay reads a buffer containing WaitingOnGraph operations in the format produced by WaitingOnGraphStreamRecorder, and replays these operations on an instance of WaitingOnGraph.