### PR TITLE
[CIR] Add cir.min op and refactor cir.max lowering

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -2400,13 +2400,38 @@ def CIR_MaxOp : CIR_BinaryOp<"max", CIR_AnyIntOrVecOfIntType, [
   let summary = "Integer maximum";
   let description = [{
     The `cir.max` operation computes the maximum of two integer operands.
-    Both operands and the result must have the same integer type.
+    Both operands and the result must have the same integer type or vector of
+    integer type.
 
     Example:
 
     ```mlir
     %0 = cir.max %a, %b : !s32i
     %1 = cir.max %a, %b : !u32i
+    %2 = cir.max %a, %b : !cir.vector<4 x !s32i>
+    ```
+  }];
+}
+
+//===----------------------------------------------------------------------===//
+// MinOp
+//===----------------------------------------------------------------------===//
+
+def CIR_MinOp : CIR_BinaryOp<"min", CIR_AnyIntOrVecOfIntType, [
+  Commutative, Idempotent
+]> {
+  let summary = "Integer minimum";
+  let description = [{
+    The `cir.min` operation computes the minimum of two integer operands.
+    Both operands and the result must have the same integer type or vector of
+    integer type.
+
+    Example:
+
+    ```mlir
+    %0 = cir.min %a, %b : !s32i
+    %1 = cir.min %a, %b : !u32i
+    %2 = cir.min %a, %b : !cir.vector<4 x !s32i>
     ```
   }];
 }

--- a/clang/lib/CIR/Dialect/Transforms/CIRCanonicalize.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/CIRCanonicalize.cpp
@@ -71,11 +71,11 @@ void CIRCanonicalizePass::runOnOperation() {
     // Many operations are here to perform a manual `fold` in
     // applyOpPatternsGreedily.
     if (isa<BrOp, BrCondOp, CastOp, ScopeOp, SwitchOp, SelectOp, UnaryOp, AddOp,
-            MulOp, AndOp, OrOp, XorOp, MaxOp, ComplexCreateOp, ComplexImagOp,
-            ComplexRealOp, VecCmpOp, VecCreateOp, VecExtractOp, VecShuffleOp,
-            VecShuffleDynamicOp, VecTernaryOp, BitClrsbOp, BitClzOp, BitCtzOp,
-            BitFfsOp, BitParityOp, BitPopcountOp, BitReverseOp, ByteSwapOp,
-            RotateOp, ConstantOp>(op))
+            MulOp, AndOp, OrOp, XorOp, MaxOp, MinOp, ComplexCreateOp,
+            ComplexImagOp, ComplexRealOp, VecCmpOp, VecCreateOp, VecExtractOp,
+            VecShuffleOp, VecShuffleDynamicOp, VecTernaryOp, BitClrsbOp,
+            BitClzOp, BitCtzOp, BitFfsOp, BitParityOp, BitPopcountOp,
+            BitReverseOp, ByteSwapOp, RotateOp, ConstantOp>(op))
       ops.push_back(op);
   });
 

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -2998,16 +2998,31 @@ mlir::LogicalResult CIRToLLVMXorOpLowering::matchAndRewrite(
   return mlir::success();
 }
 
-mlir::LogicalResult CIRToLLVMMaxOpLowering::matchAndRewrite(
-    cir::MaxOp op, OpAdaptor adaptor,
-    mlir::ConversionPatternRewriter &rewriter) const {
+template <typename CIROp, typename UIntOp, typename SIntOp>
+static mlir::LogicalResult
+lowerMinMaxOp(CIROp op, typename CIROp::Adaptor adaptor,
+              mlir::ConversionPatternRewriter &rewriter) {
   const mlir::Value lhs = adaptor.getLhs();
   const mlir::Value rhs = adaptor.getRhs();
   if (isIntTypeUnsigned(elementTypeIfVector(op.getRhs().getType())))
-    rewriter.replaceOpWithNewOp<mlir::LLVM::UMaxOp>(op, lhs, rhs);
+    rewriter.replaceOpWithNewOp<UIntOp>(op, lhs, rhs);
   else
-    rewriter.replaceOpWithNewOp<mlir::LLVM::SMaxOp>(op, lhs, rhs);
+    rewriter.replaceOpWithNewOp<SIntOp>(op, lhs, rhs);
   return mlir::success();
+}
+
+mlir::LogicalResult CIRToLLVMMaxOpLowering::matchAndRewrite(
+    cir::MaxOp op, OpAdaptor adaptor,
+    mlir::ConversionPatternRewriter &rewriter) const {
+  return lowerMinMaxOp<cir::MaxOp, mlir::LLVM::UMaxOp, mlir::LLVM::SMaxOp>(
+      op, adaptor, rewriter);
+}
+
+mlir::LogicalResult CIRToLLVMMinOpLowering::matchAndRewrite(
+    cir::MinOp op, OpAdaptor adaptor,
+    mlir::ConversionPatternRewriter &rewriter) const {
+  return lowerMinMaxOp<cir::MinOp, mlir::LLVM::UMinOp, mlir::LLVM::SMinOp>(
+      op, adaptor, rewriter);
 }
 
 /// Convert from a CIR comparison kind to an LLVM IR integral comparison kind.

--- a/clang/test/CIR/Lowering/binop-int-vector.cir
+++ b/clang/test/CIR/Lowering/binop-int-vector.cir
@@ -1,0 +1,24 @@
+// RUN: cir-opt %s -cir-to-llvm -o - | FileCheck %s
+
+!s32i = !cir.int<s, 32>
+!u32i = !cir.int<u, 32>
+
+module {
+  cir.func @signed_vec(%arg0 : !cir.vector<4 x !s32i>,
+                       %arg1 : !cir.vector<4 x !s32i>) {
+    %0 = cir.max %arg0, %arg1 : !cir.vector<4 x !s32i>
+    // CHECK: = llvm.intr.smax
+    %1 = cir.min %arg0, %arg1 : !cir.vector<4 x !s32i>
+    // CHECK: = llvm.intr.smin
+    cir.return
+  }
+
+  cir.func @unsigned_vec(%arg0 : !cir.vector<4 x !u32i>,
+                         %arg1 : !cir.vector<4 x !u32i>) {
+    %0 = cir.max %arg0, %arg1 : !cir.vector<4 x !u32i>
+    // CHECK: = llvm.intr.umax
+    %1 = cir.min %arg0, %arg1 : !cir.vector<4 x !u32i>
+    // CHECK: = llvm.intr.umin
+    cir.return
+  }
+}

--- a/clang/test/CIR/Lowering/binop-signed-int.cir
+++ b/clang/test/CIR/Lowering/binop-signed-int.cir
@@ -55,6 +55,8 @@ module {
     cir.store %34, %2 : !s32i, !cir.ptr<!s32i>
     %37 = cir.max %32, %33 : !s32i
     // CHECK: = llvm.intr.smax
+    %38 = cir.min %32, %33 : !s32i
+    // CHECK: = llvm.intr.smin
     cir.return
   }
 }

--- a/clang/test/CIR/Lowering/binop-unsigned-int.cir
+++ b/clang/test/CIR/Lowering/binop-unsigned-int.cir
@@ -44,6 +44,7 @@ module {
     %35 = cir.add sat %32, %33: !u32i
     %36 = cir.sub sat %32, %33: !u32i  
     %37 = cir.max %32, %33 : !u32i
+    %38 = cir.min %32, %33 : !u32i
     cir.return
   }
 }
@@ -59,6 +60,7 @@ module {
 // MLIR: = llvm.intr.uadd.sat{{.*}}(i32, i32) -> i32
 // MLIR: = llvm.intr.usub.sat{{.*}}(i32, i32) -> i32 
 // MLIR: = llvm.intr.umax
+// MLIR: = llvm.intr.umin
 
 // LLVM: = mul i32
 // LLVM: = udiv i32
@@ -71,3 +73,4 @@ module {
 // LLVM: = call i32 @llvm.uadd.sat.i32
 // LLVM: = call i32 @llvm.usub.sat.i32
 // LLVM: = call i32 @llvm.umax.i32
+// LLVM: = call i32 @llvm.umin.i32

--- a/clang/test/CIR/Transforms/max-min-idempotent.cir
+++ b/clang/test/CIR/Transforms/max-min-idempotent.cir
@@ -1,0 +1,77 @@
+// RUN: cir-opt %s -cir-canonicalize -o - | FileCheck %s
+
+!s32i = !cir.int<s, 32>
+!u32i = !cir.int<u, 32>
+
+// Idempotent: max(x, x) -> x
+// CHECK-LABEL: cir.func @max_idempotent
+// CHECK-NEXT:    cir.return %arg0
+cir.func @max_idempotent(%arg0 : !s32i) -> !s32i {
+  %0 = cir.max %arg0, %arg0 : !s32i
+  cir.return %0 : !s32i
+}
+
+// Idempotent: min(x, x) -> x
+// CHECK-LABEL: cir.func @min_idempotent
+// CHECK-NEXT:    cir.return %arg0
+cir.func @min_idempotent(%arg0 : !s32i) -> !s32i {
+  %0 = cir.min %arg0, %arg0 : !s32i
+  cir.return %0 : !s32i
+}
+
+// Idempotent: max(x, x) -> x (unsigned)
+// CHECK-LABEL: cir.func @max_idempotent_unsigned
+// CHECK-NEXT:    cir.return %arg0
+cir.func @max_idempotent_unsigned(%arg0 : !u32i) -> !u32i {
+  %0 = cir.max %arg0, %arg0 : !u32i
+  cir.return %0 : !u32i
+}
+
+// Idempotent: min(x, x) -> x (unsigned)
+// CHECK-LABEL: cir.func @min_idempotent_unsigned
+// CHECK-NEXT:    cir.return %arg0
+cir.func @min_idempotent_unsigned(%arg0 : !u32i) -> !u32i {
+  %0 = cir.min %arg0, %arg0 : !u32i
+  cir.return %0 : !u32i
+}
+
+// Commutative: max(const, x) -> max(x, const)
+// CHECK-LABEL: cir.func @max_commutative
+// CHECK:         %[[C:.*]] = cir.const #cir.int<42> : !s32i
+// CHECK-NEXT:    %[[R:.*]] = cir.max %arg0, %[[C]] : !s32i
+// CHECK-NEXT:    cir.return %[[R]]
+cir.func @max_commutative(%arg0 : !s32i) -> !s32i {
+  %0 = cir.const #cir.int<42> : !s32i
+  %1 = cir.max %0, %arg0 : !s32i
+  cir.return %1 : !s32i
+}
+
+// Commutative: min(const, x) -> min(x, const)
+// CHECK-LABEL: cir.func @min_commutative
+// CHECK:         %[[C:.*]] = cir.const #cir.int<42> : !s32i
+// CHECK-NEXT:    %[[R:.*]] = cir.min %arg0, %[[C]] : !s32i
+// CHECK-NEXT:    cir.return %[[R]]
+cir.func @min_commutative(%arg0 : !s32i) -> !s32i {
+  %0 = cir.const #cir.int<42> : !s32i
+  %1 = cir.min %0, %arg0 : !s32i
+  cir.return %1 : !s32i
+}
+
+// Idempotent chained: max(max(x, y), max(x, y)) -> max(x, y)
+// CHECK-LABEL: cir.func @max_idempotent_chained
+// CHECK-NEXT:    %[[M:.*]] = cir.max %arg0, %arg1 : !s32i
+// CHECK-NEXT:    cir.return %[[M]]
+cir.func @max_idempotent_chained(%arg0 : !s32i, %arg1 : !s32i) -> !s32i {
+  %0 = cir.max %arg0, %arg1 : !s32i
+  %1 = cir.max %0, %0 : !s32i
+  cir.return %1 : !s32i
+}
+
+// No fold: distinct operands should remain unchanged
+// CHECK-LABEL: cir.func @max_no_fold
+// CHECK-NEXT:    %[[R:.*]] = cir.max %arg0, %arg1 : !s32i
+// CHECK-NEXT:    cir.return %[[R]]
+cir.func @max_no_fold(%arg0 : !s32i, %arg1 : !s32i) -> !s32i {
+  %0 = cir.max %arg0, %arg1 : !s32i
+  cir.return %0 : !s32i
+}


### PR DESCRIPTION
Add cir.min operation for integer minimum computation. Refactor cir.max
lowering into a shared lowerMinMaxOp template reused by both ops.