### PR TITLE
[mlir][docs] Add LLVM target passes to the docs

### DIFF
--- a/mlir/docs/Passes.md
+++ b/mlir/docs/Passes.md
@@ -64,6 +64,10 @@ This document describes the available MLIR passes and their contracts.
 
 [include "LLVMPasses.md"]
 
+## 'llvm' Target Passes
+
+[include "TargetLLVMIRTransforms.md"]
+
 ## 'math' Dialect Passes
 
 [include "MathPasses.md"]


### PR DESCRIPTION
These passes are useful for translating between LLVM proper and the LLVM dialect and have so far been missing in the documentation.