### PR TITLE
[libc] Use explicit cast to time_t in utimes_test.

### DIFF
--- a/libc/test/src/sys/time/utimes_test.cpp
+++ b/libc/test/src/sys/time/utimes_test.cpp
@@ -50,7 +50,7 @@ TEST_F(LlvmLibcUtimesTest, ChangeTimesSpecific) {
   // seconds
   ASSERT_EQ(statbuf.st_atim.tv_sec, times[0].tv_sec);
   ASSERT_EQ(statbuf.st_mtim.tv_sec, times[1].tv_sec);
-  ASSERT_GT(statbuf.st_ctim.tv_sec, 0L);
+  ASSERT_GT(statbuf.st_ctim.tv_sec, static_cast<time_t>(0));
 
   // microseconds
   ASSERT_EQ(statbuf.st_atim.tv_nsec,
@@ -61,7 +61,7 @@ TEST_F(LlvmLibcUtimesTest, ChangeTimesSpecific) {
   // legacy way to check seconds
   ASSERT_EQ(statbuf.st_atime, times[0].tv_sec);
   ASSERT_EQ(statbuf.st_mtime, times[1].tv_sec);
-  ASSERT_GT(statbuf.st_ctime, 0L);
+  ASSERT_GT(statbuf.st_ctime, static_cast<time_t>(0));
 
   ASSERT_THAT(LIBC_NAMESPACE::remove(TEST_FILE), Succeeds(0));
 }


### PR DESCRIPTION
This fixes an error on RISCV-32 bot, where time_t is "long long" type (64-bit, as required by POSIX), instead of "long".