### PR TITLE
[Bazel] Fix af7c352fa38d49096888df6c99d010d274362aa6

### DIFF
--- a/utils/bazel/llvm-project-overlay/clang/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/clang/BUILD.bazel
@@ -1876,6 +1876,7 @@ cc_library(
         ":sema",
         ":serialization",
         ":type_nodes_gen",
+        "//llvm:ABI",
         "//llvm:AllTargetsAsmParsers",
         "//llvm:Analysis",
         "//llvm:BinaryFormat",

--- a/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel
@@ -1321,6 +1321,20 @@ cc_library(
 )
 
 cc_library(
+    name = "ABI",
+    srcs = glob(
+        ["lib/ABI/*.cpp"],
+    ),
+    hdrs = glob(
+        ["include/llvm/ABI/*.h"],
+    ),
+    copts = llvm_copts,
+    deps = [
+        ":Support",
+    ],
+)
+
+cc_library(
     name = "Analysis",
     srcs = glob(
         ["lib/Analysis/*.cpp"],


### PR DESCRIPTION
This added a user of the ABI library into clang. We did not have the ABI library set up as a build target yet. This patch does that and also adds the relevant use in clang.