### PR TITLE
[libc] Add missing const qualifiers to a few functions in <time.h>

### DIFF
--- a/libc/include/time.yaml
+++ b/libc/include/time.yaml
@@ -26,7 +26,7 @@ functions:
       - stdc
     return_type: char *
     arguments:
-      - type: struct tm *
+      - type: const struct tm *
       - type: char *
   - name: ctime
     standard:
@@ -93,13 +93,13 @@ functions:
       - stdc
     return_type: struct tm *
     arguments:
-      - type: time_t *
+      - type: const time_t *
   - name: gmtime_r
     standard:
       - stdc
     return_type: struct tm *
     arguments:
-      - type: time_t *
+      - type: const time_t *
       - type: struct tm *
   - name: mktime
     standard:


### PR DESCRIPTION
`asctime_r`, `gmtime`, and `gmtime_r` were missing const-qualifiers for a first function argument. Add them to fix generated `<time.h>` header.

Implementation headers / source files are declaring arguments correctly.