### PR TITLE
[clang][test] Add missing FileCheck pipe in cxx20-module-directive.cpp

### DIFF
--- a/clang/test/Lexer/cxx20-module-directive.cpp
+++ b/clang/test/Lexer/cxx20-module-directive.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -E -std=c++20 %s
+// RUN: %clang_cc1 -E -std=c++20 %s | FileCheck %s
 
 // CHECK: export __preprocessed_module M;
 // CHECK-NEXT: export __preprocessed_import K;


### PR DESCRIPTION
The test had CHECK directives that were never executed because the RUN line did not pipe output to FileCheck.