### PR TITLE
[mlir][NVVM] Fix double spaces in tests after ODS printer fix. NFC.

### DIFF
--- a/mlir/test/Conversion/NVVMToLLVM/nvvm-to-llvm.mlir
+++ b/mlir/test/Conversion/NVVMToLLVM/nvvm-to-llvm.mlir
@@ -62,19 +62,19 @@ llvm.func @init_mbarrier_try_wait(%barrier : !llvm.ptr, %ticks : i32, %phase : i
 
 // CHECK-LABEL: @async_cp
 func.func @async_cp(%dst: !llvm.ptr<3>, %src: !llvm.ptr<1>) {
-  // CHECK: nvvm.cp.async.shared.global %{{.*}}, %{{.*}}, 16, cache =  ca : !llvm.ptr<3>, !llvm.ptr<1>
-  nvvm.cp.async.shared.global %dst, %src, 16, cache =  ca : !llvm.ptr<3>, !llvm.ptr<1>
-  // CHECK: nvvm.cp.async.shared.global %{{.*}}, %{{.*}}, 16, cache =  cg : !llvm.ptr<3>, !llvm.ptr<1>
-  nvvm.cp.async.shared.global %dst, %src, 16, cache =  cg : !llvm.ptr<3>, !llvm.ptr<1>
+  // CHECK: nvvm.cp.async.shared.global %{{.*}}, %{{.*}}, 16, cache = ca : !llvm.ptr<3>, !llvm.ptr<1>
+  nvvm.cp.async.shared.global %dst, %src, 16, cache = ca : !llvm.ptr<3>, !llvm.ptr<1>
+  // CHECK: nvvm.cp.async.shared.global %{{.*}}, %{{.*}}, 16, cache = cg : !llvm.ptr<3>, !llvm.ptr<1>
+  nvvm.cp.async.shared.global %dst, %src, 16, cache = cg : !llvm.ptr<3>, !llvm.ptr<1>
   return
 }
 
 // CHECK-LABEL: @async_cp_zfill
 func.func @async_cp_zfill(%dst: !llvm.ptr<3>, %src: !llvm.ptr<1>, %cpSize: i32) {
-  // CHECK: nvvm.cp.async.shared.global %{{.*}}, %{{.*}}, 16, cache =  cg, %{{.*}} : !llvm.ptr<3>, !llvm.ptr<1>, i32
-  nvvm.cp.async.shared.global %dst, %src, 16, cache =  cg, %cpSize : !llvm.ptr<3>, !llvm.ptr<1>, i32
-  // CHECK: nvvm.cp.async.shared.global %{{.*}}, %{{.*}}, 4, cache =  ca, %{{.*}} : !llvm.ptr<3>, !llvm.ptr<1>, i32
-  nvvm.cp.async.shared.global %dst, %src, 4, cache =  ca, %cpSize : !llvm.ptr<3>, !llvm.ptr<1>, i32
+  // CHECK: nvvm.cp.async.shared.global %{{.*}}, %{{.*}}, 16, cache = cg, %{{.*}} : !llvm.ptr<3>, !llvm.ptr<1>, i32
+  nvvm.cp.async.shared.global %dst, %src, 16, cache = cg, %cpSize : !llvm.ptr<3>, !llvm.ptr<1>, i32
+  // CHECK: nvvm.cp.async.shared.global %{{.*}}, %{{.*}}, 4, cache = ca, %{{.*}} : !llvm.ptr<3>, !llvm.ptr<1>, i32
+  nvvm.cp.async.shared.global %dst, %src, 4, cache = ca, %cpSize : !llvm.ptr<3>, !llvm.ptr<1>, i32
   return
 }
 

--- a/mlir/test/Dialect/LLVMIR/nvvm.mlir
+++ b/mlir/test/Dialect/LLVMIR/nvvm.mlir
@@ -356,21 +356,21 @@ llvm.func @cp_async(%arg0: !llvm.ptr<3>, %arg1: !llvm.ptr<1>) {
 
 // CHECK-LABEL: llvm.func @redux_sync
 llvm.func @redux_sync(%value : i32, %offset : i32) -> i32 {
-  // CHECK: nvvm.redux.sync  add %{{.*}}
+  // CHECK: nvvm.redux.sync add %{{.*}}
   %r1 = nvvm.redux.sync add %value, %offset : i32 -> i32
-  // CHECK: nvvm.redux.sync  max %{{.*}}
+  // CHECK: nvvm.redux.sync max %{{.*}}
   %r2 = nvvm.redux.sync max %value, %offset : i32 -> i32
-  // CHECK: nvvm.redux.sync  min %{{.*}}
+  // CHECK: nvvm.redux.sync min %{{.*}}
   %r3 = nvvm.redux.sync min %value, %offset : i32 -> i32
-  // CHECK: nvvm.redux.sync  umax %{{.*}}
+  // CHECK: nvvm.redux.sync umax %{{.*}}
   %r5 = nvvm.redux.sync umax %value, %offset : i32 -> i32
-  // CHECK: nvvm.redux.sync  umin %{{.*}}
+  // CHECK: nvvm.redux.sync umin %{{.*}}
   %r6 = nvvm.redux.sync umin %value, %offset : i32 -> i32
-  // CHECK: nvvm.redux.sync  and %{{.*}}
+  // CHECK: nvvm.redux.sync and %{{.*}}
   %r7 = nvvm.redux.sync and %value, %offset : i32 -> i32
-  // CHECK: nvvm.redux.sync  or %{{.*}}
+  // CHECK: nvvm.redux.sync or %{{.*}}
   %r8 = nvvm.redux.sync or %value, %offset : i32 -> i32
-  // CHECK: nvvm.redux.sync  xor %{{.*}}
+  // CHECK: nvvm.redux.sync xor %{{.*}}
   %r9 = nvvm.redux.sync xor %value, %offset : i32 -> i32
   llvm.return %r1 : i32
 }

--- a/mlir/test/Target/LLVMIR/nvvmir.mlir
+++ b/mlir/test/Target/LLVMIR/nvvmir.mlir
@@ -490,13 +490,13 @@ llvm.func @nvvm_wmma_store_d_f64(%arg0: !llvm.ptr, %arg1 : i32, %arg2 : f64, %ar
 // CHECK-LABEL: @cp_async
 llvm.func @cp_async(%arg0: !llvm.ptr<3>, %arg1: !llvm.ptr<1>) {
   // CHECK: call void @llvm.nvvm.cp.async.ca.shared.global.4(ptr addrspace(3) %{{.*}}, ptr addrspace(1) %{{.*}})
-  nvvm.cp.async.shared.global %arg0, %arg1, 4, cache =  ca : !llvm.ptr<3>, !llvm.ptr<1>
+  nvvm.cp.async.shared.global %arg0, %arg1, 4, cache = ca : !llvm.ptr<3>, !llvm.ptr<1>
   // CHECK: call void @llvm.nvvm.cp.async.ca.shared.global.8(ptr addrspace(3) %{{.*}}, ptr addrspace(1) %{{.*}})
-  nvvm.cp.async.shared.global %arg0, %arg1, 8, cache =  ca : !llvm.ptr<3>, !llvm.ptr<1>
+  nvvm.cp.async.shared.global %arg0, %arg1, 8, cache = ca : !llvm.ptr<3>, !llvm.ptr<1>
   // CHECK: call void @llvm.nvvm.cp.async.ca.shared.global.16(ptr addrspace(3) %{{.*}}, ptr addrspace(1) %{{.*}})
-  nvvm.cp.async.shared.global %arg0, %arg1, 16, cache =  ca : !llvm.ptr<3>, !llvm.ptr<1>
+  nvvm.cp.async.shared.global %arg0, %arg1, 16, cache = ca : !llvm.ptr<3>, !llvm.ptr<1>
   // CHECK: call void @llvm.nvvm.cp.async.cg.shared.global.16(ptr addrspace(3) %{{.*}}, ptr addrspace(1) %{{.*}})
-  nvvm.cp.async.shared.global %arg0, %arg1, 16, cache =  cg : !llvm.ptr<3>, !llvm.ptr<1>
+  nvvm.cp.async.shared.global %arg0, %arg1, 16, cache = cg : !llvm.ptr<3>, !llvm.ptr<1>
 
   // CHECK: call void @llvm.nvvm.cp.async.commit.group()
   nvvm.cp.async.commit.group
@@ -508,13 +508,13 @@ llvm.func @cp_async(%arg0: !llvm.ptr<3>, %arg1: !llvm.ptr<1>) {
 // CHECK-LABEL: @async_cp_zfill
 llvm.func @async_cp_zfill(%dst: !llvm.ptr<3>, %src: !llvm.ptr<1>, %cpSize: i32) {
   // CHECK: call void @llvm.nvvm.cp.async.ca.shared.global.4.s(ptr addrspace(3) %{{.*}}, ptr addrspace(1) %{{.*}}, i32 %{{.*}})
-  nvvm.cp.async.shared.global %dst, %src, 4, cache =  ca, %cpSize : !llvm.ptr<3>, !llvm.ptr<1>, i32
+  nvvm.cp.async.shared.global %dst, %src, 4, cache = ca, %cpSize : !llvm.ptr<3>, !llvm.ptr<1>, i32
   // CHECK: call void @llvm.nvvm.cp.async.ca.shared.global.8.s(ptr addrspace(3) %{{.*}}, ptr addrspace(1) %{{.*}}, i32 %{{.*}})
-  nvvm.cp.async.shared.global %dst, %src, 8, cache =  ca, %cpSize : !llvm.ptr<3>, !llvm.ptr<1>, i32
+  nvvm.cp.async.shared.global %dst, %src, 8, cache = ca, %cpSize : !llvm.ptr<3>, !llvm.ptr<1>, i32
   // CHECK: call void @llvm.nvvm.cp.async.ca.shared.global.16.s(ptr addrspace(3) %{{.*}}, ptr addrspace(1) %{{.*}}, i32 %{{.*}})
-  nvvm.cp.async.shared.global %dst, %src, 16, cache =  ca, %cpSize : !llvm.ptr<3>, !llvm.ptr<1>, i32
+  nvvm.cp.async.shared.global %dst, %src, 16, cache = ca, %cpSize : !llvm.ptr<3>, !llvm.ptr<1>, i32
   // CHECK: call void @llvm.nvvm.cp.async.cg.shared.global.16.s(ptr addrspace(3) %{{.*}}, ptr addrspace(1) %{{.*}}, i32 %{{.*}})
-  nvvm.cp.async.shared.global %dst, %src, 16, cache =  cg, %cpSize : !llvm.ptr<3>, !llvm.ptr<1>, i32
+  nvvm.cp.async.shared.global %dst, %src, 16, cache = cg, %cpSize : !llvm.ptr<3>, !llvm.ptr<1>, i32
   llvm.return
 }
 

--- a/mlir/test/python/dialects/nvvm.py
+++ b/mlir/test/python/dialects/nvvm.py
@@ -183,41 +183,41 @@ def test_reductions():
 
 # CHECK-LABEL:   func.func @reductions(
 # CHECK:           %[[ARG0:.*]]: i32, %[[ARG1:.*]]: i32, %[[ARG2:.*]]: f32) {
-# CHECK:           %[[REDUX_0:.*]] = nvvm.redux.sync  and %[[ARG1]], %[[ARG1]] : i32 -> i32
-# CHECK:           %[[REDUX_1:.*]] = nvvm.redux.sync  max %[[ARG1]], %[[ARG1]] : i32 -> i32
-# CHECK:           %[[REDUX_2:.*]] = nvvm.redux.sync  min %[[ARG1]], %[[ARG1]] : i32 -> i32
-# CHECK:           %[[REDUX_3:.*]] = nvvm.redux.sync  or %[[ARG1]], %[[ARG1]] : i32 -> i32
-# CHECK:           %[[REDUX_4:.*]] = nvvm.redux.sync  umax %[[ARG1]], %[[ARG1]] : i32 -> i32
-# CHECK:           %[[REDUX_5:.*]] = nvvm.redux.sync  umin %[[ARG1]], %[[ARG1]] : i32 -> i32
-# CHECK:           %[[REDUX_6:.*]] = nvvm.redux.sync  xor %[[ARG1]], %[[ARG1]] : i32 -> i32
-# CHECK:           %[[REDUX_7:.*]] = nvvm.redux.sync  fmin %[[ARG2]], %[[ARG1]] {abs = true, nan = true} : f32 -> f32
-# CHECK:           %[[REDUX_8:.*]] = nvvm.redux.sync  fmax %[[ARG2]], %[[ARG1]] {abs = true, nan = true} : f32 -> f32
-# CHECK:           %[[REDUX_9:.*]] = nvvm.redux.sync  and %[[ARG1]], %[[ARG1]] : i32 -> i32
-# CHECK:           %[[REDUX_10:.*]] = nvvm.redux.sync  max %[[ARG1]], %[[ARG1]] : i32 -> i32
-# CHECK:           %[[REDUX_11:.*]] = nvvm.redux.sync  min %[[ARG1]], %[[ARG1]] : i32 -> i32
-# CHECK:           %[[REDUX_12:.*]] = nvvm.redux.sync  or %[[ARG1]], %[[ARG1]] : i32 -> i32
-# CHECK:           %[[REDUX_13:.*]] = nvvm.redux.sync  umax %[[ARG1]], %[[ARG1]] : i32 -> i32
-# CHECK:           %[[REDUX_14:.*]] = nvvm.redux.sync  umin %[[ARG1]], %[[ARG1]] : i32 -> i32
-# CHECK:           %[[REDUX_15:.*]] = nvvm.redux.sync  xor %[[ARG1]], %[[ARG1]] : i32 -> i32
-# CHECK:           %[[REDUX_16:.*]] = nvvm.redux.sync  fmin %[[ARG2]], %[[ARG1]] {abs = true} : f32 -> f32
-# CHECK:           %[[REDUX_17:.*]] = nvvm.redux.sync  fmax %[[ARG2]], %[[ARG1]] {abs = true} : f32 -> f32
-# CHECK:           %[[REDUX_18:.*]] = nvvm.redux.sync  and %[[ARG1]], %[[ARG1]] : i32 -> i32
-# CHECK:           %[[REDUX_19:.*]] = nvvm.redux.sync  max %[[ARG1]], %[[ARG1]] : i32 -> i32
-# CHECK:           %[[REDUX_20:.*]] = nvvm.redux.sync  min %[[ARG1]], %[[ARG1]] : i32 -> i32
-# CHECK:           %[[REDUX_21:.*]] = nvvm.redux.sync  or %[[ARG1]], %[[ARG1]] : i32 -> i32
-# CHECK:           %[[REDUX_22:.*]] = nvvm.redux.sync  umax %[[ARG1]], %[[ARG1]] : i32 -> i32
-# CHECK:           %[[REDUX_23:.*]] = nvvm.redux.sync  umin %[[ARG1]], %[[ARG1]] : i32 -> i32
-# CHECK:           %[[REDUX_24:.*]] = nvvm.redux.sync  xor %[[ARG1]], %[[ARG1]] : i32 -> i32
-# CHECK:           %[[REDUX_25:.*]] = nvvm.redux.sync  fmin %[[ARG2]], %[[ARG1]] {nan = true} : f32 -> f32
-# CHECK:           %[[REDUX_26:.*]] = nvvm.redux.sync  fmax %[[ARG2]], %[[ARG1]] {nan = true} : f32 -> f32
-# CHECK:           %[[REDUX_27:.*]] = nvvm.redux.sync  and %[[ARG1]], %[[ARG1]] : i32 -> i32
-# CHECK:           %[[REDUX_28:.*]] = nvvm.redux.sync  max %[[ARG1]], %[[ARG1]] : i32 -> i32
-# CHECK:           %[[REDUX_29:.*]] = nvvm.redux.sync  min %[[ARG1]], %[[ARG1]] : i32 -> i32
-# CHECK:           %[[REDUX_30:.*]] = nvvm.redux.sync  or %[[ARG1]], %[[ARG1]] : i32 -> i32
-# CHECK:           %[[REDUX_31:.*]] = nvvm.redux.sync  umax %[[ARG1]], %[[ARG1]] : i32 -> i32
-# CHECK:           %[[REDUX_32:.*]] = nvvm.redux.sync  umin %[[ARG1]], %[[ARG1]] : i32 -> i32
-# CHECK:           %[[REDUX_33:.*]] = nvvm.redux.sync  xor %[[ARG1]], %[[ARG1]] : i32 -> i32
-# CHECK:           %[[REDUX_34:.*]] = nvvm.redux.sync  fmin %[[ARG2]], %[[ARG1]] : f32 -> f32
-# CHECK:           %[[REDUX_35:.*]] = nvvm.redux.sync  fmax %[[ARG2]], %[[ARG1]] : f32 -> f32
+# CHECK:           %[[REDUX_0:.*]] = nvvm.redux.sync and %[[ARG1]], %[[ARG1]] : i32 -> i32
+# CHECK:           %[[REDUX_1:.*]] = nvvm.redux.sync max %[[ARG1]], %[[ARG1]] : i32 -> i32
+# CHECK:           %[[REDUX_2:.*]] = nvvm.redux.sync min %[[ARG1]], %[[ARG1]] : i32 -> i32
+# CHECK:           %[[REDUX_3:.*]] = nvvm.redux.sync or %[[ARG1]], %[[ARG1]] : i32 -> i32
+# CHECK:           %[[REDUX_4:.*]] = nvvm.redux.sync umax %[[ARG1]], %[[ARG1]] : i32 -> i32
+# CHECK:           %[[REDUX_5:.*]] = nvvm.redux.sync umin %[[ARG1]], %[[ARG1]] : i32 -> i32
+# CHECK:           %[[REDUX_6:.*]] = nvvm.redux.sync xor %[[ARG1]], %[[ARG1]] : i32 -> i32
+# CHECK:           %[[REDUX_7:.*]] = nvvm.redux.sync fmin %[[ARG2]], %[[ARG1]] {abs = true, nan = true} : f32 -> f32
+# CHECK:           %[[REDUX_8:.*]] = nvvm.redux.sync fmax %[[ARG2]], %[[ARG1]] {abs = true, nan = true} : f32 -> f32
+# CHECK:           %[[REDUX_9:.*]] = nvvm.redux.sync and %[[ARG1]], %[[ARG1]] : i32 -> i32
+# CHECK:           %[[REDUX_10:.*]] = nvvm.redux.sync max %[[ARG1]], %[[ARG1]] : i32 -> i32
+# CHECK:           %[[REDUX_11:.*]] = nvvm.redux.sync min %[[ARG1]], %[[ARG1]] : i32 -> i32
+# CHECK:           %[[REDUX_12:.*]] = nvvm.redux.sync or %[[ARG1]], %[[ARG1]] : i32 -> i32
+# CHECK:           %[[REDUX_13:.*]] = nvvm.redux.sync umax %[[ARG1]], %[[ARG1]] : i32 -> i32
+# CHECK:           %[[REDUX_14:.*]] = nvvm.redux.sync umin %[[ARG1]], %[[ARG1]] : i32 -> i32
+# CHECK:           %[[REDUX_15:.*]] = nvvm.redux.sync xor %[[ARG1]], %[[ARG1]] : i32 -> i32
+# CHECK:           %[[REDUX_16:.*]] = nvvm.redux.sync fmin %[[ARG2]], %[[ARG1]] {abs = true} : f32 -> f32
+# CHECK:           %[[REDUX_17:.*]] = nvvm.redux.sync fmax %[[ARG2]], %[[ARG1]] {abs = true} : f32 -> f32
+# CHECK:           %[[REDUX_18:.*]] = nvvm.redux.sync and %[[ARG1]], %[[ARG1]] : i32 -> i32
+# CHECK:           %[[REDUX_19:.*]] = nvvm.redux.sync max %[[ARG1]], %[[ARG1]] : i32 -> i32
+# CHECK:           %[[REDUX_20:.*]] = nvvm.redux.sync min %[[ARG1]], %[[ARG1]] : i32 -> i32
+# CHECK:           %[[REDUX_21:.*]] = nvvm.redux.sync or %[[ARG1]], %[[ARG1]] : i32 -> i32
+# CHECK:           %[[REDUX_22:.*]] = nvvm.redux.sync umax %[[ARG1]], %[[ARG1]] : i32 -> i32
+# CHECK:           %[[REDUX_23:.*]] = nvvm.redux.sync umin %[[ARG1]], %[[ARG1]] : i32 -> i32
+# CHECK:           %[[REDUX_24:.*]] = nvvm.redux.sync xor %[[ARG1]], %[[ARG1]] : i32 -> i32
+# CHECK:           %[[REDUX_25:.*]] = nvvm.redux.sync fmin %[[ARG2]], %[[ARG1]] {nan = true} : f32 -> f32
+# CHECK:           %[[REDUX_26:.*]] = nvvm.redux.sync fmax %[[ARG2]], %[[ARG1]] {nan = true} : f32 -> f32
+# CHECK:           %[[REDUX_27:.*]] = nvvm.redux.sync and %[[ARG1]], %[[ARG1]] : i32 -> i32
+# CHECK:           %[[REDUX_28:.*]] = nvvm.redux.sync max %[[ARG1]], %[[ARG1]] : i32 -> i32
+# CHECK:           %[[REDUX_29:.*]] = nvvm.redux.sync min %[[ARG1]], %[[ARG1]] : i32 -> i32
+# CHECK:           %[[REDUX_30:.*]] = nvvm.redux.sync or %[[ARG1]], %[[ARG1]] : i32 -> i32
+# CHECK:           %[[REDUX_31:.*]] = nvvm.redux.sync umax %[[ARG1]], %[[ARG1]] : i32 -> i32
+# CHECK:           %[[REDUX_32:.*]] = nvvm.redux.sync umin %[[ARG1]], %[[ARG1]] : i32 -> i32
+# CHECK:           %[[REDUX_33:.*]] = nvvm.redux.sync xor %[[ARG1]], %[[ARG1]] : i32 -> i32
+# CHECK:           %[[REDUX_34:.*]] = nvvm.redux.sync fmin %[[ARG2]], %[[ARG1]] : f32 -> f32
+# CHECK:           %[[REDUX_35:.*]] = nvvm.redux.sync fmax %[[ARG2]], %[[ARG1]] : f32 -> f32
 # CHECK:           return
 # CHECK:         }


### PR DESCRIPTION
Follow-up to #184253. Update tests that checked for the old double-space output of NVVM ops using ReductionKindAttr, ShflKindAttr, and LoadCacheModifierAttr.