### PR TITLE
[clang] Add a null check when completing member reference

### DIFF
--- a/clang/lib/Sema/SemaCodeComplete.cpp
+++ b/clang/lib/Sema/SemaCodeComplete.cpp
@@ -5866,6 +5866,8 @@ void SemaCodeCompletion::CodeCompleteMemberReferenceExpr(
     return;
   QualType ConvertedBaseType =
       getApproximateType(ConvertedBase.get(), Resolver);
+  if (ConvertedBaseType.isNull())
+    return;
 
   enum CodeCompletionContext::Kind contextKind;
 

--- a/clang/test/CodeCompletion/member-access.cpp
+++ b/clang/test/CodeCompletion/member-access.cpp
@@ -437,3 +437,16 @@ void f(Alias<T> s) {
   // CHECK-TEMPLATE-ALIAS-NESTED: [#int#]b
 }
 }
+
+template <bool>
+struct IntOrChar { using type = int; };
+
+template <>
+struct IntOrChar<false> { using type = char; };
+
+template <bool V>
+void test4(typename IntOrChar<V>::type X) {
+  X.
+  // Make sure this doesn't crash
+  // RUN: %clang_cc1 -fsyntax-only -code-completion-at=%s:%(line-2):5 %s
+}


### PR DESCRIPTION
There used to be a crash on 21.1.8 but it's fixed on the main branch:
<details>
<summary>crash backtrace (preprocessed source is available on the PR branch) </summary>

```log
$ clang++ -cc1 -fsyntax-only -code-completion-at=clang/test/CodeCompletion/member-access.cpp:449:5 clang/test/CodeCompletion/member-access.cpp 
PLEASE submit a bug report to https://github.com/llvm/llvm-project/issues/ and include the crash backtrace, preprocessed source, and associated run script.
Stack dump:
0.      Program arguments: clang++ -cc1 -fsyntax-only -code-completion-at=clang/test/CodeCompletion/member-access.cpp:449:5 clang/test/CodeCompletion/member-access.cpp
1.      <eof> parser at end of file
2.      clang/test/CodeCompletion/member-access.cpp:448:43: parsing function body 'test4'
3.      clang/test/CodeCompletion/member-access.cpp:448:43: in compound statement ('{}')
Stack dump without symbol names (ensure you have llvm-symbolizer in your PATH or set the environment var `LLVM_SYMBOLIZER_PATH` to point to it):
0  libLLVM.so.21.1      0x00007f4b3f3081ed llvm::sys::PrintStackTrace(llvm::raw_ostream&, int) + 61
1  libLLVM.so.21.1      0x00007f4b3f3052c7
2  libc.so.6            0x00007f4b3e44d2d0
3  libclang-cpp.so.21.1 0x00007f4b496b4f8a clang::SemaCodeCompletion::CodeCompleteMemberReferenceExpr(clang::Scope*, clang::Expr*, clang::Expr*, clang::SourceLocation, bool, bool, clang::QualType) + 314
4  libclang-cpp.so.21.1 0x00007f4b489d6da6 clang::Parser::ParsePostfixExpressionSuffix(clang::ActionResult<clang::Expr*, true>) + 4422
5  libclang-cpp.so.21.1 0x00007f4b489b6ea2 clang::Parser::ParseCastExpression(clang::CastParseKind, bool, bool&, clang::TypoCorrectionTypeBehavior, bool, bool*) + 722
6  libclang-cpp.so.21.1 0x00007f4b489b95b5
7  libclang-cpp.so.21.1 0x00007f4b489bab4c
8  libclang-cpp.so.21.1 0x00007f4b489bb225
9  libclang-cpp.so.21.1 0x00007f4b48a437eb clang::Parser::ParseExprStatement(clang::Parser::ParsedStmtContext) + 59
10 libclang-cpp.so.21.1 0x00007f4b48a3e1ad clang::Parser::ParseStatementOrDeclarationAfterAttributes(llvm::SmallVector<clang::Stmt*, 24u>&, clang::Parser::ParsedStmtContext, clang::SourceLocation*, clang::ParsedAttributes&, clang::ParsedAttributes&) + 4413
11 libclang-cpp.so.21.1 0x00007f4b48a3e44e clang::Parser::ParseStatementOrDeclaration(llvm::SmallVector<clang::Stmt*, 24u>&, clang::Parser::ParsedStmtContext, clang::SourceLocation*) + 334
12 libclang-cpp.so.21.1 0x00007f4b48a486ef clang::Parser::ParseCompoundStatementBody(bool) + 1359
13 libclang-cpp.so.21.1 0x00007f4b48a66389 clang::Parser::ParseFunctionStatementBody(clang::Decl*, clang::Parser::ParseScope&) + 201
14 libclang-cpp.so.21.1 0x00007f4b48a70cf4 clang::Parser::ParseFunctionDefinition(clang::ParsingDeclarator&, clang::Parser::ParsedTemplateInfo const&, clang::Parser::LateParsedAttrList*) + 2372
15 libclang-cpp.so.21.1 0x00007f4b48994d44 clang::Parser::ParseDeclGroup(clang::ParsingDeclSpec&, clang::DeclaratorContext, clang::ParsedAttributes&, clang::Parser::ParsedTemplateInfo&, clang::SourceLocation*, clang::Parser::ForRangeInit*) + 4228
16 libclang-cpp.so.21.1 0x00007f4b48a6901a clang::Parser::ParseDeclarationAfterTemplate(clang::DeclaratorContext, clang::Parser::ParsedTemplateInfo&, clang::ParsingDeclRAIIObject&, clang::SourceLocation&, clang::ParsedAttributes&, clang::AccessSpecifier) + 1034
17 libclang-cpp.so.21.1 0x00007f4b48a79f2b clang::Parser::ParseTemplateDeclarationOrSpecialization(clang::DeclaratorContext, clang::SourceLocation&, clang::ParsedAttributes&, clang::AccessSpecifier) + 1291
18 libclang-cpp.so.21.1 0x00007f4b48a7a1fd clang::Parser::ParseDeclarationStartingWithTemplate(clang::DeclaratorContext, clang::SourceLocation&, clang::ParsedAttributes&) + 189
19 libclang-cpp.so.21.1 0x00007f4b48999efd clang::Parser::ParseDeclaration(clang::DeclaratorContext, clang::SourceLocation&, clang::ParsedAttributes&, clang::ParsedAttributes&, clang::SourceLocation*) + 669
20 libclang-cpp.so.21.1 0x00007f4b48a82c2c clang::Parser::ParseExternalDeclaration(clang::ParsedAttributes&, clang::ParsedAttributes&, clang::ParsingDeclSpec*) + 1132
21 libclang-cpp.so.21.1 0x00007f4b48a83adf clang::Parser::ParseTopLevelDecl(clang::OpaquePtr<clang::DeclGroupRef>&, clang::Sema::ModuleImportState&) + 511
22 libclang-cpp.so.21.1 0x00007f4b489716c9 clang::ParseAST(clang::Sema&, bool, bool) + 649
23 libclang-cpp.so.21.1 0x00007f4b4aa4ea9c clang::FrontendAction::Execute() + 44
24 libclang-cpp.so.21.1 0x00007f4b4a9aff0f clang::CompilerInstance::ExecuteAction(clang::FrontendAction&) + 495
25 libclang-cpp.so.21.1 0x00007f4b4aaabcec clang::ExecuteCompilerInvocation(clang::CompilerInstance*) + 588
26 clang++              0x0000557644a3ee9a cc1_main(llvm::ArrayRef<char const*>, char const*, void*) + 11418
27 clang++              0x0000557644a42b61
28 clang++              0x0000557644a44604 clang_main(int, char**, llvm::ToolContext const&) + 6404
29 clang++              0x0000557644a362b0 main + 128
30 libc.so.6            0x00007f4b3e4366c1
31 libc.so.6            0x00007f4b3e4367f9 __libc_start_main + 137
32 clang++              0x0000557644a36315 _start + 37
```
</details>

The crash is no longer reproducible since 91cdd35008e9ab32dffb7e401cdd7313b3461892 (which has a long diff that I haven't yet read through) according to git bisect, so I'm not sure if the change in `CodeCompleteMemberReferenceExpr` is actually necessary, since the regression test in this PR passes without it.

cc: @ojhunt

An LLM was used to identify the source line corresponding to the instruction address in the stacktrace. The code in this PR is not LLM-generated.
