### PR TITLE
[clang][NFC] Clean up InitializedEntity booleans.

### DIFF
--- a/clang/include/clang/Sema/Initialization.h
+++ b/clang/include/clang/Sema/Initialization.h
@@ -136,14 +136,19 @@ public:
     // that diagnostic text needs to be updated as well.
   };
 
-  enum class NRVOKind { Forbidden, Allowed };
+  enum class NRVOKind : uint8_t { Forbidden, Allowed };
 
-  enum class NewArrayKind {
+  enum class NewArrayKind : uint8_t {
     KnownLength,
     UnknownLength,
   };
 
-  enum class FieldInitKind { Normal, ImplicitField, DefaultMember, ParenAgg };
+  enum class FieldInitKind : uint8_t {
+    Normal,
+    ImplicitField,
+    DefaultMember,
+    ParenAgg
+  };
 
 private:
   /// The kind of entity being initialized.
@@ -250,8 +255,8 @@ private:
   /// Create the initialization entity for a member subobject.
   InitializedEntity(FieldDecl *Member, const InitializedEntity *Parent,
                     FieldInitKind FieldKind)
-      : Kind(Kind == FieldInitKind::ParenAgg ? EK_ParenAggInitMember
-                                             : EK_Member),
+      : Kind(FieldKind == FieldInitKind::ParenAgg ? EK_ParenAggInitMember
+                                                  : EK_Member),
         Parent(Parent), Type(Member->getType()), Variable{Member, FieldKind} {}
 
   /// Create the initialization entity for an array element.

--- a/clang/include/clang/Sema/Initialization.h
+++ b/clang/include/clang/Sema/Initialization.h
@@ -143,11 +143,7 @@ public:
     UnknownLength,
   };
 
-  enum class ImplicitFieldInitKind { No, Yes };
-
-  enum class DefaultMemberInitKind { No, Yes };
-
-  enum class ParenAggInitKind { No, Yes };
+  enum class FieldInitKind { Normal, ImplicitField, DefaultMember, ParenAgg };
 
 private:
   /// The kind of entity being initialized.
@@ -184,14 +180,14 @@ private:
     /// initialized.
     NamedDecl *VariableOrMember;
 
-    /// When Kind == EK_Member, whether this is an implicit member
-    /// initialization in a copy or move constructor. These can perform array
-    /// copies.
-    ImplicitFieldInitKind IsImplicitFieldInit;
-
-    /// When Kind == EK_Member, whether this is the initial initialization
-    /// check for a default member initializer.
-    DefaultMemberInitKind IsDefaultMemberInit;
+    /// When Kind == EK_Member or EK_ParenAggInitMember, whether this is:
+    /// - ImplicitField: an implicit member initialization in a copy or move
+    ///   constructor. These can perform array copies.
+    /// - DefaultMember: the initial initialization check for a default member
+    ///   initialize.
+    /// - ParenAgg: aggregate initialization with a parenthesized list.
+    /// - Normal: simple member initialization.
+    FieldInitKind FieldKind;
   };
 
   struct C {
@@ -238,8 +234,7 @@ private:
 
   /// Create the initialization entity for a variable.
   InitializedEntity(VarDecl *Var, EntityKind EK = EK_Variable)
-      : Kind(EK), Type(Var->getType()),
-        Variable{Var, ImplicitFieldInitKind::No, DefaultMemberInitKind::No} {}
+      : Kind(EK), Type(Var->getType()), Variable{Var, FieldInitKind::Normal} {}
 
   /// Create the initialization entity for the result of a
   /// function, throwing an object, performing an explicit cast, or
@@ -254,13 +249,10 @@ private:
 
   /// Create the initialization entity for a member subobject.
   InitializedEntity(FieldDecl *Member, const InitializedEntity *Parent,
-                    ImplicitFieldInitKind Implicit,
-                    DefaultMemberInitKind DefaultMemberInit,
-                    ParenAggInitKind IsParenAggInit)
-      : Kind(IsParenAggInit == ParenAggInitKind::Yes ? EK_ParenAggInitMember
-                                                     : EK_Member),
-        Parent(Parent), Type(Member->getType()),
-        Variable{Member, Implicit, DefaultMemberInit} {}
+                    FieldInitKind FieldKind)
+      : Kind(Kind == FieldInitKind::ParenAgg ? EK_ParenAggInitMember
+                                             : EK_Member),
+        Parent(Parent), Type(Member->getType()), Variable{Member, FieldKind} {}
 
   /// Create the initialization entity for an array element.
   InitializedEntity(ASTContext &Context, unsigned Index,
@@ -320,8 +312,7 @@ public:
     Entity.Kind = EK_TemplateParameter;
     Entity.Type = T;
     Entity.Parent = nullptr;
-    Entity.Variable = {Param, ImplicitFieldInitKind::No,
-                       DefaultMemberInitKind::No};
+    Entity.Variable = {Param, FieldInitKind::Normal};
     return Entity;
   }
 
@@ -407,34 +398,44 @@ public:
 
   /// Create the initialization entity for a member subobject.
   static InitializedEntity
-  InitializeMember(FieldDecl *Member, const InitializedEntity *Parent = nullptr,
-                   ImplicitFieldInitKind Implicit = ImplicitFieldInitKind::No) {
-    return InitializedEntity(Member, Parent, Implicit,
-                             DefaultMemberInitKind::No, ParenAggInitKind::No);
+  InitializeMember(FieldDecl *Member,
+                   const InitializedEntity *Parent = nullptr) {
+    return InitializedEntity(Member, Parent, FieldInitKind::Normal);
   }
 
   /// Create the initialization entity for a member subobject.
   static InitializedEntity
   InitializeMember(IndirectFieldDecl *Member,
-                   const InitializedEntity *Parent = nullptr,
-                   ImplicitFieldInitKind Implicit = ImplicitFieldInitKind::No) {
-    return InitializedEntity(Member->getAnonField(), Parent, Implicit,
-                             DefaultMemberInitKind::No, ParenAggInitKind::No);
+                   const InitializedEntity *Parent = nullptr) {
+    return InitializedEntity(Member->getAnonField(), Parent,
+                             FieldInitKind::Normal);
+  }
+
+  /// Create the initialization entity for a member subobject with implicit
+  /// field initializer.
+  static InitializedEntity InitializeMemberImplicit(FieldDecl *Member) {
+    return InitializedEntity(Member, /*Parent=*/nullptr,
+                             FieldInitKind::ImplicitField);
+  }
+
+  /// Create the initialization entity for a member subobject with implicit
+  /// field initializer.
+  static InitializedEntity InitializeMemberImplicit(IndirectFieldDecl *Member) {
+    return InitializedEntity(Member->getAnonField(), /*Parent=*/nullptr,
+                             FieldInitKind::ImplicitField);
   }
 
   /// Create the initialization entity for a member subobject initialized via
   /// parenthesized aggregate init.
   static InitializedEntity InitializeMemberFromParenAggInit(FieldDecl *Member) {
     return InitializedEntity(Member, /*Parent=*/nullptr,
-                             ImplicitFieldInitKind::No,
-                             DefaultMemberInitKind::No, ParenAggInitKind::Yes);
+                             FieldInitKind::ParenAgg);
   }
 
   /// Create the initialization entity for a default member initializer.
   static InitializedEntity
   InitializeMemberFromDefaultMemberInitializer(FieldDecl *Member) {
-    return InitializedEntity(Member, nullptr, ImplicitFieldInitKind::No,
-                             DefaultMemberInitKind::Yes, ParenAggInitKind::No);
+    return InitializedEntity(Member, nullptr, FieldInitKind::DefaultMember);
   }
 
   /// Create the initialization entity for an array element.
@@ -538,14 +539,14 @@ public:
   /// a defaulted constructor?
   bool isImplicitMemberInitializer() const {
     return getKind() == EK_Member &&
-           Variable.IsImplicitFieldInit == ImplicitFieldInitKind::Yes;
+           Variable.FieldKind == FieldInitKind::ImplicitField;
   }
 
   /// Is this the default member initializer of a member (specified inside
   /// the class definition)?
   bool isDefaultMemberInitializer() const {
     return getKind() == EK_Member &&
-           Variable.IsDefaultMemberInit == DefaultMemberInitKind::Yes;
+           Variable.FieldKind == FieldInitKind::DefaultMember;
   }
 
   /// Determine the location of the 'return' keyword when initializing

--- a/clang/include/clang/Sema/Initialization.h
+++ b/clang/include/clang/Sema/Initialization.h
@@ -136,18 +136,18 @@ public:
     // that diagnostic text needs to be updated as well.
   };
 
-  enum NRVOKind { NoNRVO, NRVOAllowed };
+  enum class NRVOKind { Forbidden, Allowed };
 
-  enum NewArrayKind {
-    KnownLengthNewArray,
-    UnknownLengthNewArray,
+  enum class NewArrayKind {
+    KnownLength,
+    UnknownLength,
   };
 
-  enum ImplicitFieldInitKind { NotImplicitFieldInit, ImplicitFieldInit };
+  enum class ImplicitFieldInitKind { No, Yes };
 
-  enum DefaultMemberInitKind { NotDefaultMemberInit, DefaultMemberInit };
+  enum class DefaultMemberInitKind { No, Yes };
 
-  enum ParenAggInitKind { NotParenAggInit, ParenAggInit };
+  enum class ParenAggInitKind { No, Yes };
 
 private:
   /// The kind of entity being initialized.
@@ -172,7 +172,7 @@ private:
 
     /// Whether the entity being initialized may end up using the
     /// named return value optimization (NRVO).
-    NRVOKind IsNRVO;
+    NRVOKind NRVO;
 
     /// When Kind == EK_New, whether this is initializing an array of runtime
     /// size (which needs an array filler).
@@ -239,16 +239,17 @@ private:
   /// Create the initialization entity for a variable.
   InitializedEntity(VarDecl *Var, EntityKind EK = EK_Variable)
       : Kind(EK), Type(Var->getType()),
-        Variable{Var, NotImplicitFieldInit, NotDefaultMemberInit} {}
+        Variable{Var, ImplicitFieldInitKind::No, DefaultMemberInitKind::No} {}
 
   /// Create the initialization entity for the result of a
   /// function, throwing an object, performing an explicit cast, or
   /// initializing a parameter for which there is no declaration.
-  InitializedEntity(EntityKind Kind, SourceLocation Loc, QualType Type,
-                    NRVOKind IsNRVO = NoNRVO,
-                    NewArrayKind VariableLengthArrayNew = KnownLengthNewArray)
+  InitializedEntity(
+      EntityKind Kind, SourceLocation Loc, QualType Type,
+      NRVOKind NRVO = NRVOKind::Forbidden,
+      NewArrayKind VariableLengthArrayNew = NewArrayKind::KnownLength)
       : Kind(Kind), Type(Type) {
-    new (&LocAndNRVO) LN{Loc, IsNRVO, VariableLengthArrayNew};
+    new (&LocAndNRVO) LN{Loc, NRVO, VariableLengthArrayNew};
   }
 
   /// Create the initialization entity for a member subobject.
@@ -256,7 +257,8 @@ private:
                     ImplicitFieldInitKind Implicit,
                     DefaultMemberInitKind DefaultMemberInit,
                     ParenAggInitKind IsParenAggInit)
-      : Kind(IsParenAggInit ? EK_ParenAggInitMember : EK_Member),
+      : Kind(IsParenAggInit == ParenAggInitKind::Yes ? EK_ParenAggInitMember
+                                                     : EK_Member),
         Parent(Parent), Type(Member->getType()),
         Variable{Member, Implicit, DefaultMemberInit} {}
 
@@ -318,7 +320,8 @@ public:
     Entity.Kind = EK_TemplateParameter;
     Entity.Type = T;
     Entity.Parent = nullptr;
-    Entity.Variable = {Param, NotImplicitFieldInit, NotDefaultMemberInit};
+    Entity.Variable = {Param, ImplicitFieldInitKind::No,
+                       DefaultMemberInitKind::No};
     return Entity;
   }
 
@@ -354,7 +357,7 @@ public:
   static InitializedEntity
   InitializeNew(SourceLocation NewLoc, QualType Type,
                 NewArrayKind IsVariableLengthArrayNew) {
-    return InitializedEntity(EK_New, NewLoc, Type, NoNRVO,
+    return InitializedEntity(EK_New, NewLoc, Type, NRVOKind::Forbidden,
                              IsVariableLengthArrayNew);
   }
 
@@ -405,32 +408,33 @@ public:
   /// Create the initialization entity for a member subobject.
   static InitializedEntity
   InitializeMember(FieldDecl *Member, const InitializedEntity *Parent = nullptr,
-                   ImplicitFieldInitKind Implicit = NotImplicitFieldInit) {
-    return InitializedEntity(Member, Parent, Implicit, NotDefaultMemberInit,
-                             NotParenAggInit);
+                   ImplicitFieldInitKind Implicit = ImplicitFieldInitKind::No) {
+    return InitializedEntity(Member, Parent, Implicit,
+                             DefaultMemberInitKind::No, ParenAggInitKind::No);
   }
 
   /// Create the initialization entity for a member subobject.
   static InitializedEntity
   InitializeMember(IndirectFieldDecl *Member,
                    const InitializedEntity *Parent = nullptr,
-                   ImplicitFieldInitKind Implicit = NotImplicitFieldInit) {
+                   ImplicitFieldInitKind Implicit = ImplicitFieldInitKind::No) {
     return InitializedEntity(Member->getAnonField(), Parent, Implicit,
-                             NotDefaultMemberInit, NotParenAggInit);
+                             DefaultMemberInitKind::No, ParenAggInitKind::No);
   }
 
   /// Create the initialization entity for a member subobject initialized via
   /// parenthesized aggregate init.
   static InitializedEntity InitializeMemberFromParenAggInit(FieldDecl *Member) {
-    return InitializedEntity(Member, /*Parent=*/nullptr, NotImplicitFieldInit,
-                             NotDefaultMemberInit, NotParenAggInit);
+    return InitializedEntity(Member, /*Parent=*/nullptr,
+                             ImplicitFieldInitKind::No,
+                             DefaultMemberInitKind::No, ParenAggInitKind::Yes);
   }
 
   /// Create the initialization entity for a default member initializer.
   static InitializedEntity
   InitializeMemberFromDefaultMemberInitializer(FieldDecl *Member) {
-    return InitializedEntity(Member, nullptr, NotImplicitFieldInit,
-                             DefaultMemberInit, NotParenAggInit);
+    return InitializedEntity(Member, nullptr, ImplicitFieldInitKind::No,
+                             DefaultMemberInitKind::Yes, ParenAggInitKind::No);
   }
 
   /// Create the initialization entity for an array element.
@@ -526,19 +530,22 @@ public:
 
   /// Determine whether this is an array new with an unknown bound.
   bool isVariableLengthArrayNew() const {
-    return getKind() == EK_New && LocAndNRVO.IsVariableLengthArrayNew;
+    return getKind() == EK_New &&
+           LocAndNRVO.IsVariableLengthArrayNew == NewArrayKind::UnknownLength;
   }
 
   /// Is this the implicit initialization of a member of a class from
   /// a defaulted constructor?
   bool isImplicitMemberInitializer() const {
-    return getKind() == EK_Member && Variable.IsImplicitFieldInit;
+    return getKind() == EK_Member &&
+           Variable.IsImplicitFieldInit == ImplicitFieldInitKind::Yes;
   }
 
   /// Is this the default member initializer of a member (specified inside
   /// the class definition)?
   bool isDefaultMemberInitializer() const {
-    return getKind() == EK_Member && Variable.IsDefaultMemberInit;
+    return getKind() == EK_Member &&
+           Variable.IsDefaultMemberInit == DefaultMemberInitKind::Yes;
   }
 
   /// Determine the location of the 'return' keyword when initializing

--- a/clang/include/clang/Sema/Initialization.h
+++ b/clang/include/clang/Sema/Initialization.h
@@ -136,6 +136,19 @@ public:
     // that diagnostic text needs to be updated as well.
   };
 
+  enum NRVOKind { NoNRVO, NRVOAllowed };
+
+  enum NewArrayKind {
+    KnownLengthNewArray,
+    UnknownLengthNewArray,
+  };
+
+  enum ImplicitFieldInitKind { NotImplicitFieldInit, ImplicitFieldInit };
+
+  enum DefaultMemberInitKind { NotDefaultMemberInit, DefaultMemberInit };
+
+  enum ParenAggInitKind { NotParenAggInit, ParenAggInit };
+
 private:
   /// The kind of entity being initialized.
   EntityKind Kind;
@@ -159,11 +172,11 @@ private:
 
     /// Whether the entity being initialized may end up using the
     /// named return value optimization (NRVO).
-    bool NRVO;
+    NRVOKind IsNRVO;
 
     /// When Kind == EK_New, whether this is initializing an array of runtime
     /// size (which needs an array filler).
-    bool VariableLengthArrayNew;
+    NewArrayKind IsVariableLengthArrayNew;
   };
 
   struct VD {
@@ -174,11 +187,11 @@ private:
     /// When Kind == EK_Member, whether this is an implicit member
     /// initialization in a copy or move constructor. These can perform array
     /// copies.
-    bool IsImplicitFieldInit;
+    ImplicitFieldInitKind IsImplicitFieldInit;
 
     /// When Kind == EK_Member, whether this is the initial initialization
     /// check for a default member initializer.
-    bool IsDefaultMemberInit;
+    DefaultMemberInitKind IsDefaultMemberInit;
   };
 
   struct C {
@@ -225,24 +238,24 @@ private:
 
   /// Create the initialization entity for a variable.
   InitializedEntity(VarDecl *Var, EntityKind EK = EK_Variable)
-      : Kind(EK), Type(Var->getType()), Variable{Var, false, false} {}
+      : Kind(EK), Type(Var->getType()),
+        Variable{Var, NotImplicitFieldInit, NotDefaultMemberInit} {}
 
   /// Create the initialization entity for the result of a
   /// function, throwing an object, performing an explicit cast, or
   /// initializing a parameter for which there is no declaration.
   InitializedEntity(EntityKind Kind, SourceLocation Loc, QualType Type,
-                    bool NRVO = false, bool VariableLengthArrayNew = false)
+                    NRVOKind IsNRVO = NoNRVO,
+                    NewArrayKind VariableLengthArrayNew = KnownLengthNewArray)
       : Kind(Kind), Type(Type) {
-    new (&LocAndNRVO) LN;
-    LocAndNRVO.Location = Loc;
-    LocAndNRVO.NRVO = NRVO;
-    LocAndNRVO.VariableLengthArrayNew = VariableLengthArrayNew;
+    new (&LocAndNRVO) LN{Loc, IsNRVO, VariableLengthArrayNew};
   }
 
   /// Create the initialization entity for a member subobject.
   InitializedEntity(FieldDecl *Member, const InitializedEntity *Parent,
-                    bool Implicit, bool DefaultMemberInit,
-                    bool IsParenAggInit = false)
+                    ImplicitFieldInitKind Implicit,
+                    DefaultMemberInitKind DefaultMemberInit,
+                    ParenAggInitKind IsParenAggInit)
       : Kind(IsParenAggInit ? EK_ParenAggInitMember : EK_Member),
         Parent(Parent), Type(Member->getType()),
         Variable{Member, Implicit, DefaultMemberInit} {}
@@ -254,9 +267,7 @@ private:
   /// Create the initialization entity for a lambda capture.
   InitializedEntity(IdentifierInfo *VarID, QualType FieldType, SourceLocation Loc)
       : Kind(EK_LambdaCapture), Type(FieldType) {
-    new (&Capture) C;
-    Capture.VarID = VarID;
-    Capture.Location = Loc;
+    new (&Capture) C{VarID, Loc};
   }
 
 public:
@@ -307,7 +318,7 @@ public:
     Entity.Kind = EK_TemplateParameter;
     Entity.Type = T;
     Entity.Parent = nullptr;
-    Entity.Variable = {Param, false, false};
+    Entity.Variable = {Param, NotImplicitFieldInit, NotDefaultMemberInit};
     return Entity;
   }
 
@@ -340,10 +351,11 @@ public:
   }
 
   /// Create the initialization entity for an object allocated via new.
-  static InitializedEntity InitializeNew(SourceLocation NewLoc, QualType Type,
-                                         bool VariableLengthArrayNew) {
-    return InitializedEntity(EK_New, NewLoc, Type, /*NRVO=*/false,
-                             VariableLengthArrayNew);
+  static InitializedEntity
+  InitializeNew(SourceLocation NewLoc, QualType Type,
+                NewArrayKind IsVariableLengthArrayNew) {
+    return InitializedEntity(EK_New, NewLoc, Type, NoNRVO,
+                             IsVariableLengthArrayNew);
   }
 
   /// Create the initialization entity for a temporary.
@@ -392,32 +404,33 @@ public:
 
   /// Create the initialization entity for a member subobject.
   static InitializedEntity
-  InitializeMember(FieldDecl *Member,
-                   const InitializedEntity *Parent = nullptr,
-                   bool Implicit = false) {
-    return InitializedEntity(Member, Parent, Implicit, false);
+  InitializeMember(FieldDecl *Member, const InitializedEntity *Parent = nullptr,
+                   ImplicitFieldInitKind Implicit = NotImplicitFieldInit) {
+    return InitializedEntity(Member, Parent, Implicit, NotDefaultMemberInit,
+                             NotParenAggInit);
   }
 
   /// Create the initialization entity for a member subobject.
   static InitializedEntity
   InitializeMember(IndirectFieldDecl *Member,
                    const InitializedEntity *Parent = nullptr,
-                   bool Implicit = false) {
-    return InitializedEntity(Member->getAnonField(), Parent, Implicit, false);
+                   ImplicitFieldInitKind Implicit = NotImplicitFieldInit) {
+    return InitializedEntity(Member->getAnonField(), Parent, Implicit,
+                             NotDefaultMemberInit, NotParenAggInit);
   }
 
   /// Create the initialization entity for a member subobject initialized via
   /// parenthesized aggregate init.
   static InitializedEntity InitializeMemberFromParenAggInit(FieldDecl *Member) {
-    return InitializedEntity(Member, /*Parent=*/nullptr, /*Implicit=*/false,
-                             /*DefaultMemberInit=*/false,
-                             /*IsParenAggInit=*/true);
+    return InitializedEntity(Member, /*Parent=*/nullptr, NotImplicitFieldInit,
+                             NotDefaultMemberInit, NotParenAggInit);
   }
 
   /// Create the initialization entity for a default member initializer.
   static InitializedEntity
   InitializeMemberFromDefaultMemberInitializer(FieldDecl *Member) {
-    return InitializedEntity(Member, nullptr, false, true);
+    return InitializedEntity(Member, nullptr, NotImplicitFieldInit,
+                             DefaultMemberInit, NotParenAggInit);
   }
 
   /// Create the initialization entity for an array element.
@@ -513,7 +526,7 @@ public:
 
   /// Determine whether this is an array new with an unknown bound.
   bool isVariableLengthArrayNew() const {
-    return getKind() == EK_New && LocAndNRVO.VariableLengthArrayNew;
+    return getKind() == EK_New && LocAndNRVO.IsVariableLengthArrayNew;
   }
 
   /// Is this the implicit initialization of a member of a class from

--- a/clang/lib/Sema/SemaDeclCXX.cpp
+++ b/clang/lib/Sema/SemaDeclCXX.cpp
@@ -5044,12 +5044,8 @@ BuildImplicitMemberInitializer(Sema &SemaRef, CXXConstructorDecl *Constructor,
     }
 
     InitializedEntity Entity =
-        Indirect ? InitializedEntity::InitializeMember(
-                       Indirect, nullptr,
-                       InitializedEntity::ImplicitFieldInitKind::Yes)
-                 : InitializedEntity::InitializeMember(
-                       Field, nullptr,
-                       InitializedEntity::ImplicitFieldInitKind::Yes);
+        Indirect ? InitializedEntity::InitializeMemberImplicit(Indirect)
+                 : InitializedEntity::InitializeMemberImplicit(Field);
 
     // Direct-initialize to use the copy constructor.
     InitializationKind InitKind =
@@ -5080,12 +5076,8 @@ BuildImplicitMemberInitializer(Sema &SemaRef, CXXConstructorDecl *Constructor,
 
   if (FieldBaseElementType->isRecordType()) {
     InitializedEntity InitEntity =
-        Indirect ? InitializedEntity::InitializeMember(
-                       Indirect, nullptr,
-                       InitializedEntity::ImplicitFieldInitKind::Yes)
-                 : InitializedEntity::InitializeMember(
-                       Field, nullptr,
-                       InitializedEntity::ImplicitFieldInitKind::Yes);
+        Indirect ? InitializedEntity::InitializeMemberImplicit(Indirect)
+                 : InitializedEntity::InitializeMemberImplicit(Field);
     InitializationKind InitKind =
       InitializationKind::CreateDefault(Loc);
 
@@ -5286,8 +5278,7 @@ static bool CollectFieldInitializer(Sema &SemaRef, BaseAndFieldInfo &Info,
     if (DIE.isInvalid())
       return true;
 
-    auto Entity = InitializedEntity::InitializeMember(
-        Field, nullptr, InitializedEntity::ImplicitFieldInitKind::Yes);
+    auto Entity = InitializedEntity::InitializeMemberImplicit(Field);
     SemaRef.checkInitializerLifetime(Entity, DIE.get());
 
     CXXCtorInitializer *Init;

--- a/clang/lib/Sema/SemaDeclCXX.cpp
+++ b/clang/lib/Sema/SemaDeclCXX.cpp
@@ -5044,10 +5044,10 @@ BuildImplicitMemberInitializer(Sema &SemaRef, CXXConstructorDecl *Constructor,
     }
 
     InitializedEntity Entity =
-        Indirect ? InitializedEntity::InitializeMember(Indirect, nullptr,
-                                                       /*Implicit*/ true)
-                 : InitializedEntity::InitializeMember(Field, nullptr,
-                                                       /*Implicit*/ true);
+        Indirect ? InitializedEntity::InitializeMember(
+                       Indirect, nullptr, InitializedEntity::ImplicitFieldInit)
+                 : InitializedEntity::InitializeMember(
+                       Field, nullptr, InitializedEntity::ImplicitFieldInit);
 
     // Direct-initialize to use the copy constructor.
     InitializationKind InitKind =
@@ -5078,10 +5078,10 @@ BuildImplicitMemberInitializer(Sema &SemaRef, CXXConstructorDecl *Constructor,
 
   if (FieldBaseElementType->isRecordType()) {
     InitializedEntity InitEntity =
-        Indirect ? InitializedEntity::InitializeMember(Indirect, nullptr,
-                                                       /*Implicit*/ true)
-                 : InitializedEntity::InitializeMember(Field, nullptr,
-                                                       /*Implicit*/ true);
+        Indirect ? InitializedEntity::InitializeMember(
+                       Indirect, nullptr, InitializedEntity::ImplicitFieldInit)
+                 : InitializedEntity::InitializeMember(
+                       Field, nullptr, InitializedEntity::ImplicitFieldInit);
     InitializationKind InitKind =
       InitializationKind::CreateDefault(Loc);
 
@@ -5282,7 +5282,8 @@ static bool CollectFieldInitializer(Sema &SemaRef, BaseAndFieldInfo &Info,
     if (DIE.isInvalid())
       return true;
 
-    auto Entity = InitializedEntity::InitializeMember(Field, nullptr, true);
+    auto Entity = InitializedEntity::InitializeMember(
+        Field, nullptr, InitializedEntity::ImplicitFieldInit);
     SemaRef.checkInitializerLifetime(Entity, DIE.get());
 
     CXXCtorInitializer *Init;

--- a/clang/lib/Sema/SemaDeclCXX.cpp
+++ b/clang/lib/Sema/SemaDeclCXX.cpp
@@ -5045,9 +5045,11 @@ BuildImplicitMemberInitializer(Sema &SemaRef, CXXConstructorDecl *Constructor,
 
     InitializedEntity Entity =
         Indirect ? InitializedEntity::InitializeMember(
-                       Indirect, nullptr, InitializedEntity::ImplicitFieldInit)
+                       Indirect, nullptr,
+                       InitializedEntity::ImplicitFieldInitKind::Yes)
                  : InitializedEntity::InitializeMember(
-                       Field, nullptr, InitializedEntity::ImplicitFieldInit);
+                       Field, nullptr,
+                       InitializedEntity::ImplicitFieldInitKind::Yes);
 
     // Direct-initialize to use the copy constructor.
     InitializationKind InitKind =
@@ -5079,9 +5081,11 @@ BuildImplicitMemberInitializer(Sema &SemaRef, CXXConstructorDecl *Constructor,
   if (FieldBaseElementType->isRecordType()) {
     InitializedEntity InitEntity =
         Indirect ? InitializedEntity::InitializeMember(
-                       Indirect, nullptr, InitializedEntity::ImplicitFieldInit)
+                       Indirect, nullptr,
+                       InitializedEntity::ImplicitFieldInitKind::Yes)
                  : InitializedEntity::InitializeMember(
-                       Field, nullptr, InitializedEntity::ImplicitFieldInit);
+                       Field, nullptr,
+                       InitializedEntity::ImplicitFieldInitKind::Yes);
     InitializationKind InitKind =
       InitializationKind::CreateDefault(Loc);
 
@@ -5283,7 +5287,7 @@ static bool CollectFieldInitializer(Sema &SemaRef, BaseAndFieldInfo &Info,
       return true;
 
     auto Entity = InitializedEntity::InitializeMember(
-        Field, nullptr, InitializedEntity::ImplicitFieldInit);
+        Field, nullptr, InitializedEntity::ImplicitFieldInitKind::Yes);
     SemaRef.checkInitializerLifetime(Entity, DIE.get());
 
     CXXCtorInitializer *Init;

--- a/clang/lib/Sema/SemaExprCXX.cpp
+++ b/clang/lib/Sema/SemaExprCXX.cpp
@@ -2207,7 +2207,7 @@ ExprResult Sema::BuildCXXNew(SourceRange Range, bool UseGlobal,
           << (*ArraySize ? (*ArraySize)->getSourceRange() : TypeRange));
 
     InitializedEntity Entity = InitializedEntity::InitializeNew(
-        StartLoc, AllocType, InitializedEntity::KnownLengthNewArray);
+        StartLoc, AllocType, InitializedEntity::NewArrayKind::KnownLength);
     AllocType = DeduceTemplateSpecializationFromInitializer(
         AllocTypeInfo, Entity, Kind, Exprs);
     if (AllocType.isNull())
@@ -2592,8 +2592,8 @@ ExprResult Sema::BuildCXXNew(SourceRange Range, bool UseGlobal,
     bool VariableLengthArrayNew = ArraySize && *ArraySize && !KnownArraySize;
     InitializedEntity Entity = InitializedEntity::InitializeNew(
         StartLoc, InitType,
-        VariableLengthArrayNew ? InitializedEntity::UnknownLengthNewArray
-                               : InitializedEntity::KnownLengthNewArray);
+        VariableLengthArrayNew ? InitializedEntity::NewArrayKind::UnknownLength
+                               : InitializedEntity::NewArrayKind::KnownLength);
     InitializationSequence InitSeq(*this, Entity, Kind, Exprs);
     ExprResult FullInit = InitSeq.Perform(*this, Entity, Kind, Exprs);
     if (FullInit.isInvalid())

--- a/clang/lib/Sema/SemaExprCXX.cpp
+++ b/clang/lib/Sema/SemaExprCXX.cpp
@@ -2206,9 +2206,8 @@ ExprResult Sema::BuildCXXNew(SourceRange Range, bool UseGlobal,
           << /*array*/ 2
           << (*ArraySize ? (*ArraySize)->getSourceRange() : TypeRange));
 
-    InitializedEntity Entity =
-        InitializedEntity::InitializeNew(StartLoc, AllocType,
-                                         /*VariableLengthArrayNew=*/false);
+    InitializedEntity Entity = InitializedEntity::InitializeNew(
+        StartLoc, AllocType, InitializedEntity::KnownLengthNewArray);
     AllocType = DeduceTemplateSpecializationFromInitializer(
         AllocTypeInfo, Entity, Kind, Exprs);
     if (AllocType.isNull())
@@ -2592,7 +2591,9 @@ ExprResult Sema::BuildCXXNew(SourceRange Range, bool UseGlobal,
 
     bool VariableLengthArrayNew = ArraySize && *ArraySize && !KnownArraySize;
     InitializedEntity Entity = InitializedEntity::InitializeNew(
-        StartLoc, InitType, VariableLengthArrayNew);
+        StartLoc, InitType,
+        VariableLengthArrayNew ? InitializedEntity::UnknownLengthNewArray
+                               : InitializedEntity::KnownLengthNewArray);
     InitializationSequence InitSeq(*this, Entity, Kind, Exprs);
     ExprResult FullInit = InitSeq.Perform(*this, Entity, Kind, Exprs);
     if (FullInit.isInvalid())

--- a/clang/lib/Sema/SemaInit.cpp
+++ b/clang/lib/Sema/SemaInit.cpp
@@ -3847,7 +3847,7 @@ bool InitializedEntity::allowsNRVO() const {
   switch (getKind()) {
   case EK_Result:
   case EK_Exception:
-    return LocAndNRVO.IsNRVO;
+    return LocAndNRVO.NRVO == NRVOKind::Allowed;
 
   case EK_StmtExprResult:
   case EK_Variable:

--- a/clang/lib/Sema/SemaInit.cpp
+++ b/clang/lib/Sema/SemaInit.cpp
@@ -3847,7 +3847,7 @@ bool InitializedEntity::allowsNRVO() const {
   switch (getKind()) {
   case EK_Result:
   case EK_Exception:
-    return LocAndNRVO.NRVO;
+    return LocAndNRVO.IsNRVO;
 
   case EK_StmtExprResult:
   case EK_Variable:


### PR DESCRIPTION
As discussed in #182203, use enums instead.

I tried to name/use them appropriately, but I'm not sure sure I'm really happy with the results; suggestions welcome.