### PR TITLE
[libc++] Resolve LWG4366: Heterogeneous comparison of `expected` may be ill-formed 

### DIFF
--- a/libcxx/docs/Status/Cxx26Issues.csv
+++ b/libcxx/docs/Status/Cxx26Issues.csv
@@ -201,7 +201,7 @@
 "`LWG4351 <https://wg21.link/LWG4351>`__","``integral-constant-like`` needs more ``remove_cvref_t``","2025-11 (Kona)","|Complete|","23","`#171359 <https://github.com/llvm/llvm-project/issues/171359>`__",""
 "`LWG4358 <https://wg21.link/LWG4358>`__","§[exec.as.awaitable] is using ""Preconditions:"" when it should probably be described in the constraint","2025-11 (Kona)","","","`#171360 <https://github.com/llvm/llvm-project/issues/171360>`__",""
 "`LWG4360 <https://wg21.link/LWG4360>`__","``awaitable-sender`` concept should qualify use of ``awaitable-receiver`` type","2025-11 (Kona)","","","`#171361 <https://github.com/llvm/llvm-project/issues/171361>`__",""
-"`LWG4366 <https://wg21.link/LWG4366>`__","Heterogeneous comparison of ``expected`` may be ill-formed","2025-11 (Kona)","|Complete|","22","`#171362 <https://github.com/llvm/llvm-project/issues/171362>`__",""
+"`LWG4366 <https://wg21.link/LWG4366>`__","Heterogeneous comparison of ``expected`` may be ill-formed","2025-11 (Kona)","|Complete|","23","`#171362 <https://github.com/llvm/llvm-project/issues/171362>`__",""
 "`LWG4369 <https://wg21.link/LWG4369>`__","``check-types`` function for ``upon_error`` and ``upon_stopped`` is wrong","2025-11 (Kona)","","","`#171363 <https://github.com/llvm/llvm-project/issues/171363>`__",""
 "`LWG4370 <https://wg21.link/LWG4370>`__","Comparison of ``optional<T>`` to ``T`` may be ill-formed","2025-11 (Kona)","|Complete|","22","`#171364 <https://github.com/llvm/llvm-project/issues/171364>`__",""
 "`LWG4372 <https://wg21.link/LWG4372>`__","Weaken *Mandates:* for dynamic padding values in padded layouts","2025-11 (Kona)","","","`#171365 <https://github.com/llvm/llvm-project/issues/171365>`__",""

--- a/libcxx/docs/Status/Cxx26Issues.csv
+++ b/libcxx/docs/Status/Cxx26Issues.csv
@@ -201,7 +201,7 @@
 "`LWG4351 <https://wg21.link/LWG4351>`__","``integral-constant-like`` needs more ``remove_cvref_t``","2025-11 (Kona)","|Complete|","23","`#171359 <https://github.com/llvm/llvm-project/issues/171359>`__",""
 "`LWG4358 <https://wg21.link/LWG4358>`__","§[exec.as.awaitable] is using ""Preconditions:"" when it should probably be described in the constraint","2025-11 (Kona)","","","`#171360 <https://github.com/llvm/llvm-project/issues/171360>`__",""
 "`LWG4360 <https://wg21.link/LWG4360>`__","``awaitable-sender`` concept should qualify use of ``awaitable-receiver`` type","2025-11 (Kona)","","","`#171361 <https://github.com/llvm/llvm-project/issues/171361>`__",""
-"`LWG4366 <https://wg21.link/LWG4366>`__","Heterogeneous comparison of ``expected`` may be ill-formed","2025-11 (Kona)","","","`#171362 <https://github.com/llvm/llvm-project/issues/171362>`__",""
+"`LWG4366 <https://wg21.link/LWG4366>`__","Heterogeneous comparison of ``expected`` may be ill-formed","2025-11 (Kona)","|Complete|","22","`#171362 <https://github.com/llvm/llvm-project/issues/171362>`__",""
 "`LWG4369 <https://wg21.link/LWG4369>`__","``check-types`` function for ``upon_error`` and ``upon_stopped`` is wrong","2025-11 (Kona)","","","`#171363 <https://github.com/llvm/llvm-project/issues/171363>`__",""
 "`LWG4370 <https://wg21.link/LWG4370>`__","Comparison of ``optional<T>`` to ``T`` may be ill-formed","2025-11 (Kona)","|Complete|","22","`#171364 <https://github.com/llvm/llvm-project/issues/171364>`__",""
 "`LWG4372 <https://wg21.link/LWG4372>`__","Weaken *Mandates:* for dynamic padding values in padded layouts","2025-11 (Kona)","","","`#171365 <https://github.com/llvm/llvm-project/issues/171365>`__",""

--- a/libcxx/include/__expected/expected.h
+++ b/libcxx/include/__expected/expected.h
@@ -449,10 +449,7 @@ private:
 // Helper to handle cases for LWG4366 Heterogeneous comparison of ``expected`` may be ill-formed
 // Where the comparison may produce a value that is a type that is not bool, and is implicitly
 // convertible to bool, but not explicitly.
-template <typename _ImplictlyBool>
-constexpr bool __into_bool(_ImplictlyBool&& __b)
-  requires __core_convertible_to<_ImplictlyBool, bool>
-{
+constexpr bool __into_bool(bool __b) noexcept {
   return __b;
 }
 

--- a/libcxx/include/__expected/expected.h
+++ b/libcxx/include/__expected/expected.h
@@ -446,9 +446,8 @@ private:
   _LIBCPP_NO_UNIQUE_ADDRESS __conditional_no_unique_address<__allow_reusing_expected_tail_padding, __repr> __repr_;
 };
 
-// Helper to handle cases for LWG4366 Heterogeneous comparison of ``expected`` may be ill-formed
-// Where the comparison may produce a value that is a type that is not bool, and is implicitly
-// convertible to bool, but not explicitly.
+// Helper to handle comparisons that produce a value whose type is not bool,
+// but allows only implicit (and not explicit) conversions to bool.
 constexpr bool __into_bool(bool __b) noexcept { return __b; }
 
 template <class _Tp, class _Err>

--- a/libcxx/include/__expected/expected.h
+++ b/libcxx/include/__expected/expected.h
@@ -1171,7 +1171,9 @@ public:
     }
 #  endif
   {
-    return __x.__has_val() && static_cast<bool>(__x.__val() == __v);
+    if (__x.__has_val())
+      return __x.__val() == __v;
+    return false;
   }
 
   template <class _E2>
@@ -1182,7 +1184,9 @@ public:
     }
 #  endif
   {
-    return !__x.__has_val() && static_cast<bool>(__x.__unex() == __e.error());
+    if (!__x.__has_val())
+      return __x.__unex() == __e.error();
+    return false;
   }
 };
 
@@ -1883,8 +1887,10 @@ public:
   {
     if (__x.__has_val() != __y.__has_val()) {
       return false;
+    } else if (__x.__has_val()) {
+      return true;
     } else {
-      return __x.__has_val() || static_cast<bool>(__x.__unex() == __y.__unex());
+      return __x.__unex() == __y.__unex();
     }
   }
 
@@ -1896,7 +1902,9 @@ public:
     }
 #  endif
   {
-    return !__x.__has_val() && static_cast<bool>(__x.__unex() == __y.error());
+    if (!__x.__has_val())
+      return __x.__unex() == __y.error();
+    return false;
   }
 };
 

--- a/libcxx/include/__expected/expected.h
+++ b/libcxx/include/__expected/expected.h
@@ -446,6 +446,16 @@ private:
   _LIBCPP_NO_UNIQUE_ADDRESS __conditional_no_unique_address<__allow_reusing_expected_tail_padding, __repr> __repr_;
 };
 
+// Helper to handle cases for LWG4366 Heterogeneous comparison of ``expected`` may be ill-formed
+// Where the comparison may produce a value that is a type that is not bool, and is implicitly
+// convertible to bool, but not explicitly.
+template <typename _ImplictlyBool>
+constexpr bool __into_bool(_ImplictlyBool&& __b)
+  requires __core_convertible_to<_ImplictlyBool, bool>
+{
+  return __b;
+}
+
 template <class _Tp, class _Err>
 class expected : private __expected_base<_Tp, _Err> {
   static_assert(!is_reference_v<_Tp> && !is_function_v<_Tp> && !is_same_v<remove_cv_t<_Tp>, in_place_t> &&
@@ -1171,9 +1181,7 @@ public:
     }
 #  endif
   {
-    if (__x.__has_val())
-      return __x.__val() == __v;
-    return false;
+    return __x.__has_val() && __into_bool(__x.__val() == __v);
   }
 
   template <class _E2>
@@ -1184,9 +1192,7 @@ public:
     }
 #  endif
   {
-    if (!__x.__has_val())
-      return __x.__unex() == __e.error();
-    return false;
+    return !__x.__has_val() && __into_bool(__x.__unex() == __e.error());
   }
 };
 
@@ -1887,10 +1893,8 @@ public:
   {
     if (__x.__has_val() != __y.__has_val()) {
       return false;
-    } else if (__x.__has_val()) {
-      return true;
     } else {
-      return __x.__unex() == __y.__unex();
+      return __x.__has_val() || __into_bool(__x.__unex() == __y.__unex());
     }
   }
 
@@ -1902,9 +1906,7 @@ public:
     }
 #  endif
   {
-    if (!__x.__has_val())
-      return __x.__unex() == __y.error();
-    return false;
+    return !__x.__has_val() && __into_bool(__x.__unex() == __y.error());
   }
 };
 

--- a/libcxx/include/__expected/expected.h
+++ b/libcxx/include/__expected/expected.h
@@ -449,9 +449,7 @@ private:
 // Helper to handle cases for LWG4366 Heterogeneous comparison of ``expected`` may be ill-formed
 // Where the comparison may produce a value that is a type that is not bool, and is implicitly
 // convertible to bool, but not explicitly.
-constexpr bool __into_bool(bool __b) noexcept {
-  return __b;
-}
+constexpr bool __into_bool(bool __b) noexcept { return __b; }
 
 template <class _Tp, class _Err>
 class expected : private __expected_base<_Tp, _Err> {
@@ -1178,7 +1176,7 @@ public:
     }
 #  endif
   {
-    return __x.__has_val() && __into_bool(__x.__val() == __v);
+    return __x.__has_val() && std::__into_bool(__x.__val() == __v);
   }
 
   template <class _E2>
@@ -1189,7 +1187,7 @@ public:
     }
 #  endif
   {
-    return !__x.__has_val() && __into_bool(__x.__unex() == __e.error());
+    return !__x.__has_val() && std::__into_bool(__x.__unex() == __e.error());
   }
 };
 
@@ -1891,7 +1889,7 @@ public:
     if (__x.__has_val() != __y.__has_val()) {
       return false;
     } else {
-      return __x.__has_val() || __into_bool(__x.__unex() == __y.__unex());
+      return __x.__has_val() || std::__into_bool(__x.__unex() == __y.__unex());
     }
   }
 
@@ -1903,7 +1901,7 @@ public:
     }
 #  endif
   {
-    return !__x.__has_val() && __into_bool(__x.__unex() == __y.error());
+    return !__x.__has_val() && std::__into_bool(__x.__unex() == __y.error());
   }
 };
 

--- a/libcxx/test/std/utilities/expected/expected.expected/equality/equality.T2.pass.cpp
+++ b/libcxx/test/std/utilities/expected/expected.expected/equality/equality.T2.pass.cpp
@@ -54,6 +54,18 @@ constexpr bool test() {
     assert(p1 == p2);
   }
 #endif
+  // LWG4366
+  { // x.has_value()
+    const std::expected<ImplicitBool::E1, int> e1(ImplicitBool::E1{1});
+    assert(e1 == ImplicitBool::E2{1});
+    assert(e1 != ImplicitBool::E2{3});
+  }
+
+  { // !x.has_value()
+    const std::expected<ImplicitBool::E1, int> e1(std::unexpect, 1);
+    assert(e1 != ImplicitBool::E2{1});
+    assert(e1 != ImplicitBool::E2{2});
+  }
 
   return true;
 }

--- a/libcxx/test/std/utilities/expected/expected.expected/equality/equality.unexpected.pass.cpp
+++ b/libcxx/test/std/utilities/expected/expected.expected/equality/equality.unexpected.pass.cpp
@@ -45,6 +45,26 @@ constexpr bool test() {
     assert(e1 == un3);
   }
 
+  // LWG4366
+  { // x.has_value()
+    const std::expected<int, ImplicitBool::E1> e1(std::in_place, 1);
+    const std::unexpected<ImplicitBool::E2> u2{ImplicitBool::E2{1}};
+    const std::unexpected<ImplicitBool::E2> u3{ImplicitBool::E2{2}};
+
+    assert(e1 != u2);
+    assert(e1 != u3);
+  }
+
+  { // !x.has_value()
+    const std::unexpected<ImplicitBool::E1> u1{ImplicitBool::E1{1}};
+    const std::unexpected<ImplicitBool::E2> u2{ImplicitBool::E2{1}};
+    const std::unexpected<ImplicitBool::E2> u3{ImplicitBool::E2{2}};
+
+    const std::expected<int, ImplicitBool::E1> e1(u1);
+    assert(e1 == u2);
+    assert(e1 != u3);
+  }
+
   return true;
 }
 

--- a/libcxx/test/support/test_comparisons.h
+++ b/libcxx/test/support/test_comparisons.h
@@ -332,6 +332,23 @@ static_assert(HasOperatorLessThanEqual<ThreeWayComparable>);
 static_assert(HasOperatorNotEqual<ThreeWayComparable>);
 static_assert(HasOperatorSpaceship<ThreeWayComparable>);
 
+// LWG4366: Heterogeneous comparison of expected may be ill-formed
+struct ImplicitBool {
+  bool val;
+  constexpr operator bool() const { return val; };
+  constexpr explicit operator bool() = delete;
+
+  struct E1 {
+    int x;
+  };
+
+  struct E2 {
+    int y;
+  };
+};
+
+constexpr ImplicitBool operator==(ImplicitBool::E1 lhs, ImplicitBool::E2 rhs) { return {lhs.x == rhs.y}; }
+
 #endif // TEST_STD_VER >= 20
 
 #endif // TEST_COMPARISONS_H


### PR DESCRIPTION
Resolves #171362
- Implement proposed resolution
- Refactor `operator==` code to be more in line with the standard as the current way was making an explicit `bool()` conversion in the `x.meow() == y.meow()` cases
- Add test cases
- Update issues paper