### PR TITLE
[libc] Add more macro/type declarations to Elf headers.

### DIFF
--- a/libc/hdr/CMakeLists.txt
+++ b/libc/hdr/CMakeLists.txt
@@ -313,6 +313,7 @@ add_gen_header(
     libc.include.llvm-libc-types.Elf32_Versym
     libc.include.llvm-libc-types.Elf32_Word
     libc.include.llvm-libc-types.Elf32_Xword
+    libc.include.llvm-libc-types.Elf32_auxv_t
     libc.include.llvm-libc-types.Elf64_Addr
     libc.include.llvm-libc-types.Elf64_Chdr
     libc.include.llvm-libc-types.Elf64_Dyn
@@ -335,6 +336,7 @@ add_gen_header(
     libc.include.llvm-libc-types.Elf64_Versym
     libc.include.llvm-libc-types.Elf64_Word
     libc.include.llvm-libc-types.Elf64_Xword
+    libc.include.llvm-libc-types.Elf64_auxv_t
   PROXY
 )
 

--- a/libc/hdr/types/CMakeLists.txt
+++ b/libc/hdr/types/CMakeLists.txt
@@ -675,6 +675,14 @@ add_proxy_header_library(
 )
 
 add_proxy_header_library(
+  Elf32_auxv_t
+  HDRS
+  Elf32_auxv_t.h
+  FULL_BUILD_DEPENDS
+    libc.include.llvm-libc-types.Elf32_auxv_t
+)
+
+add_proxy_header_library(
   Elf64_Addr
   HDRS
     Elf64_Addr.h
@@ -808,6 +816,14 @@ add_proxy_header_library(
     Elf64_Xword.h
   FULL_BUILD_DEPENDS
     libc.include.llvm-libc-types.Elf64_Xword
+)
+
+add_proxy_header_library(
+  Elf64_auxv_t
+  HDRS
+  Elf64_auxv_t.h
+  FULL_BUILD_DEPENDS
+    libc.include.llvm-libc-types.Elf64_auxv_t
 )
 
 add_proxy_header_library(

--- a/libc/hdr/types/Elf32_auxv_t.h
+++ b/libc/hdr/types/Elf32_auxv_t.h
@@ -1,0 +1,22 @@
+//===-- Proxy for Elf32_auxv_t --------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_HDR_TYPES_ELF32_AUXV_T_H
+#define LLVM_LIBC_HDR_TYPES_ELF32_AUXV_T_H
+
+#ifdef LIBC_FULL_BUILD
+
+#include "include/llvm-libc-types/Elf32_auxv_t.h"
+
+#else // Overlay mode
+
+#include <elf.h>
+
+#endif // LLVM_LIBC_FULL_BUILD
+
+#endif // LLVM_LIBC_HDR_TYPES_ELF32_AUXV_T_H

--- a/libc/hdr/types/Elf64_auxv_t.h
+++ b/libc/hdr/types/Elf64_auxv_t.h
@@ -1,0 +1,22 @@
+//===-- Proxy for Elf64_auxv_t --------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_HDR_TYPES_ELF64_AUXV_T_H
+#define LLVM_LIBC_HDR_TYPES_ELF64_AUXV_T_H
+
+#ifdef LIBC_FULL_BUILD
+
+#include "include/llvm-libc-types/Elf64_auxv_t.h"
+
+#else // Overlay mode
+
+#include <elf.h>
+
+#endif // LLVM_LIBC_FULL_BUILD
+
+#endif // LLVM_LIBC_HDR_TYPES_ELF64_AUXV_T_H

--- a/libc/include/CMakeLists.txt
+++ b/libc/include/CMakeLists.txt
@@ -498,6 +498,7 @@ add_header_macro(
     .llvm-libc-types.Elf32_Versym
     .llvm-libc-types.Elf32_Word
     .llvm-libc-types.Elf32_Xword
+    .llvm-libc-types.Elf32_auxv_t
     .llvm-libc-types.Elf64_Addr
     .llvm-libc-types.Elf64_Chdr
     .llvm-libc-types.Elf64_Dyn
@@ -520,6 +521,7 @@ add_header_macro(
     .llvm-libc-types.Elf64_Versym
     .llvm-libc-types.Elf64_Word
     .llvm-libc-types.Elf64_Xword
+    .llvm-libc-types.Elf64_auxv_t
 )
 
 # TODO: Not all platforms will have a include/sys directory. Add the sys

--- a/libc/include/elf.yaml
+++ b/libc/include/elf.yaml
@@ -358,6 +358,42 @@ macros:
     macro_value: '0x70000000'
   - macro_name: DT_HIPROC
     macro_value: '0x7fffffff'
+  - macro_name: DT_ADDRRNGLO
+    macro_value: '0x6ffffe00'
+  - macro_name: DT_GNU_HASH
+    macro_value: '0x6ffffef5'
+    standards:
+      - gnu
+  - macro_name: DT_TLSDESC_PLT
+    macro_value: '0x6ffffef6'
+    standards:
+      - gnu
+  - macro_name: DT_TLSDESC_GOT
+    macro_value: '0x6ffffef7'
+    standards:
+      - gnu
+  - macro_name: DT_GNU_CONFLICT
+    macro_value: '0x6ffffef8'
+    standards:
+      - gnu
+  - macro_name: DT_GNU_LIBLIST
+    macro_value: '0x6ffffef9'
+    standards:
+      - gnu
+  - macro_name: DT_CONFIG
+    macro_value: '0x6ffffefa'
+  - macro_name: DT_DEPAUDIT
+    macro_value: '0x6ffffefb'
+  - macro_name: DT_AUDIT
+    macro_value: '0x6ffffefc'
+  - macro_name: DT_PLTPAD
+    macro_value: '0x6ffffefd'
+  - macro_name: DT_MOVETAB
+    macro_value: '0x6ffffefe'
+  - macro_name: DT_SYMINFO
+    macro_value: '0x6ffffeff'
+  - macro_name: DT_ADDRRNGHI
+    macro_value: '0x6ffffeff'
   - macro_name: DT_VERSYM
     macro_value: '0x6ffffff0'
   - macro_name: DT_RELACOUNT
@@ -471,6 +507,7 @@ types:
   - type_name: Elf32_Versym
   - type_name: Elf32_Word
   - type_name: Elf32_Xword
+  - type_name: Elf32_auxv_t
   - type_name: Elf64_Addr
   - type_name: Elf64_Chdr
   - type_name: Elf64_Dyn
@@ -493,6 +530,7 @@ types:
   - type_name: Elf64_Versym
   - type_name: Elf64_Word
   - type_name: Elf64_Xword
+  - type_name: Elf64_auxv_t
 enums: []
 objects: []
 functions: []

--- a/libc/include/llvm-libc-macros/link-macros.h
+++ b/libc/include/llvm-libc-macros/link-macros.h
@@ -25,6 +25,7 @@
 #include "../llvm-libc-types/Elf32_Sym.h"
 #include "../llvm-libc-types/Elf32_Word.h"
 #include "../llvm-libc-types/Elf32_Xword.h"
+#include "../llvm-libc-types/Elf32_auxv_t.h"
 #include "../llvm-libc-types/Elf64_Addr.h"
 #include "../llvm-libc-types/Elf64_Chdr.h"
 #include "../llvm-libc-types/Elf64_Dyn.h"
@@ -42,6 +43,7 @@
 #include "../llvm-libc-types/Elf64_Sym.h"
 #include "../llvm-libc-types/Elf64_Word.h"
 #include "../llvm-libc-types/Elf64_Xword.h"
+#include "../llvm-libc-types/Elf64_auxv_t.h"
 
 #ifdef __LP64__
 #define ElfW(type) Elf64_##type

--- a/libc/include/llvm-libc-macros/sys-auxv-macros.h
+++ b/libc/include/llvm-libc-macros/sys-auxv-macros.h
@@ -33,8 +33,12 @@
 #define AT_BASE_PLATFORM 24
 #define AT_RANDOM 25
 #define AT_HWCAP2 26
+#define AT_HWCAP3 29
+#define AT_HWCAP4 30
 
 #define AT_EXECFN 31
+#define AT_SYSINFO 32
+#define AT_SYSINFO_EHDR 33
 
 #ifndef AT_MINSIGSTKSZ
 #define AT_MINSIGSTKSZ 51

--- a/libc/include/llvm-libc-types/CMakeLists.txt
+++ b/libc/include/llvm-libc-types/CMakeLists.txt
@@ -205,6 +205,7 @@ add_header(Elf32_Off HDR Elf32_Off.h DEPENDS libc.include.llvm-libc-macros.stdin
 add_header(Elf32_Sword HDR Elf32_Sword.h DEPENDS libc.include.llvm-libc-macros.stdint_macros)
 add_header(Elf32_Word HDR Elf32_Word.h DEPENDS libc.include.llvm-libc-macros.stdint_macros)
 add_header(Elf32_Xword HDR Elf32_Xword.h DEPENDS libc.include.llvm-libc-macros.stdint_macros)
+add_header(Elf32_auxv_t HDR Elf32_auxv_t.h DEPENDS libc.include.llvm-libc-macros.stdint_macros)
 add_header(
   Elf32_Chdr
   HDR
@@ -323,6 +324,7 @@ add_header(Elf64_Sword HDR Elf64_Sword.h DEPENDS libc.include.llvm-libc-macros.s
 add_header(Elf64_Sxword HDR Elf64_Sxword.h DEPENDS libc.include.llvm-libc-macros.stdint_macros)
 add_header(Elf64_Word HDR Elf64_Word.h DEPENDS libc.include.llvm-libc-macros.stdint_macros)
 add_header(Elf64_Xword HDR Elf64_Xword.h DEPENDS libc.include.llvm-libc-macros.stdint_macros)
+add_header(Elf64_auxv_t HDR Elf64_auxv_t.h DEPENDS libc.include.llvm-libc-macros.stdint_macros)
 add_header(
   Elf64_Chdr
   HDR

--- a/libc/include/llvm-libc-types/Elf32_auxv_t.h
+++ b/libc/include/llvm-libc-types/Elf32_auxv_t.h
@@ -1,0 +1,21 @@
+//===-- Definition of Elf32_auxv_t type -----------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_TYPES_ELF32_AUXV_T_H
+#define LLVM_LIBC_TYPES_ELF32_AUXV_T_H
+
+#include "../llvm-libc-macros/stdint-macros.h"
+
+typedef struct {
+  uint32_t a_type;
+  union {
+    uint32_t a_val;
+  } a_un;
+} Elf32_auxv_t;
+
+#endif // LLVM_LIBC_TYPES_ELF32_AUXV_T_H

--- a/libc/include/llvm-libc-types/Elf64_auxv_t.h
+++ b/libc/include/llvm-libc-types/Elf64_auxv_t.h
@@ -1,0 +1,21 @@
+//===-- Definition of Elf64_auxv_t type -----------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_TYPES_ELF64_AUXV_T_H
+#define LLVM_LIBC_TYPES_ELF64_AUXV_T_H
+
+#include "../llvm-libc-macros/stdint-macros.h"
+
+typedef struct {
+  uint64_t a_type;
+  union {
+    uint64_t a_val;
+  } a_un;
+} Elf64_auxv_t;
+
+#endif // LLVM_LIBC_TYPES_ELF64_AUXV_T_H

--- a/libc/src/__support/OSUtil/linux/CMakeLists.txt
+++ b/libc/src/__support/OSUtil/linux/CMakeLists.txt
@@ -30,6 +30,7 @@ add_header_library(
     auxv.h
   DEPENDS
     libc.hdr.fcntl_macros
+    libc.hdr.sys_auxv_macros
     libc.src.__support.OSUtil.osutil
     libc.src.__support.common
     libc.src.__support.CPP.optional

--- a/libc/src/__support/OSUtil/linux/auxv.h
+++ b/libc/src/__support/OSUtil/linux/auxv.h
@@ -10,11 +10,11 @@
 #define LLVM_LIBC_SRC___SUPPORT_OSUTIL_LINUX_AUXV_H
 
 #include "hdr/fcntl_macros.h" // For open flags
+#include "hdr/sys_auxv_macros.h" // For AT_ macros
 #include "src/__support/OSUtil/syscall.h"
 #include "src/__support/common.h"
 #include "src/__support/threads/callonce.h"
 
-#include <linux/auxvec.h> // For AT_ macros
 #include <linux/mman.h>   // For mmap flags
 #include <linux/param.h>  // For EXEC_PAGESIZE
 #include <linux/prctl.h>  // For prctl


### PR DESCRIPTION
* Add several `AT_` macro values from `<sys/auxv.h>`. In particular, this allows to make internal Linux auxv header parsing more hermetic by removing one of Linux header includes.
* Add constants between `DT_ADDRNGLO` and `DT_ADDRNGHI`, in particular `DT_GNU_HASH`, which is de-facto standard on many platforms.
* Add `Elf32_auxv_t` and `Elf64_auxv_t` types which define the auxv entries and can be used by VDSO parsing code. Note that this PR doesn't yet update libc's own Linux auxv header support (in `src/__support/OSUtil/linux/auxv.h`).

This fixes some of the missing definitions when building code working with Elf files, such as Abseil's debugging support in
https://github.com/abseil/abseil-cpp/tree/master/absl/debugging/internal.