### PR TITLE
[SamplePGO] Add a flag to disable salvage-unused-profile for large modules.

### DIFF
--- a/llvm/lib/Transforms/IPO/SampleProfileMatcher.cpp
+++ b/llvm/lib/Transforms/IPO/SampleProfileMatcher.cpp
@@ -58,6 +58,11 @@ extern cl::opt<bool> SalvageUnusedProfile;
 extern cl::opt<bool> PersistProfileStaleness;
 extern cl::opt<bool> ReportProfileStaleness;
 
+static cl::opt<unsigned> SalvageUnusedProfileMaxFunctions(
+    "salvage-unused-profile-max-functions", cl::Hidden, cl::init(UINT_MAX),
+    cl::desc("The maximum number of functions in a module, above which salvage "
+             "unused profile will be skipped."));
+
 static cl::opt<unsigned> SalvageStaleProfileMaxCallsites(
     "salvage-stale-profile-max-callsites", cl::Hidden, cl::init(UINT_MAX),
     cl::desc("The maximum number of callsites in a function, above which stale "
@@ -999,6 +1004,11 @@ void SampleProfileMatcher::UpdateWithSalvagedProfiles() {
 void SampleProfileMatcher::runOnModule() {
   ProfileConverter::flattenProfile(Reader.getProfiles(), FlattenedProfiles,
                                    FunctionSamples::ProfileIsCS);
+  // Disable SalvageUnusedProfile if the module has an extremely large number of
+  // functions to limit compile time.
+  SalvageUnusedProfile =
+      SalvageUnusedProfile && M.size() < SalvageUnusedProfileMaxFunctions;
+
   if (SalvageUnusedProfile) {
     findFunctionsWithoutProfile();
     matchFunctionsWithoutProfileByBasename();

--- a/llvm/test/Transforms/SampleProfile/pseudo-probe-stale-profile-renaming.ll
+++ b/llvm/test/Transforms/SampleProfile/pseudo-probe-stale-profile-renaming.ll
@@ -1,8 +1,12 @@
 ; REQUIRES: asserts && x86-registered-target
 ; RUN: opt < %s -passes=sample-profile -sample-profile-file=%S/Inputs/pseudo-probe-stale-profile-renaming.prof --salvage-stale-profile --salvage-unused-profile -report-profile-staleness -persist-profile-staleness -S --debug-only=sample-profile,sample-profile-matcher,sample-profile-impl -pass-remarks=inline --min-call-count-for-cg-matching=0 --min-func-count-for-cg-matching=0 --func-profile-similarity-threshold=70 2>&1 | FileCheck %s
 ; RUN: opt < %s -passes=sample-profile -sample-profile-file=%S/Inputs/pseudo-probe-stale-profile-renaming.prof --salvage-stale-profile --salvage-unused-profile -S --debug-only=sample-profile,sample-profile-matcher,sample-profile-impl --min-call-count-for-cg-matching=10 --min-func-count-for-cg-matching=10 2>&1 | FileCheck %s  --check-prefix=TINY-FUNC
+; RUN: opt < %s -passes=sample-profile -sample-profile-file=%S/Inputs/pseudo-probe-stale-profile-renaming.prof --salvage-stale-profile --salvage-unused-profile --salvage-unused-profile-max-functions=1 -S --debug-only=sample-profile-matcher 2>&1 | FileCheck %s --check-prefix=SKIP-SALVAGE
 
 ; Verify find new IR functions.
+; SKIP-SALVAGE: define dso_local i32 @main()
+; SKIP-SALVAGE-NOT: Function new_block_only is not in profile or profile symbol list.
+; SKIP-SALVAGE-NOT: Function new_foo is not in profile or profile symbol list.
 ; CHECK: Function new_block_only is not in profile or profile symbol list.
 ; CHECK: Function new_foo is not in profile or profile symbol list.
 


### PR DESCRIPTION

Added a command-line option, `-salvage-unused-profile-max-functions` to prevents performance degradation during compilation when processing modules with an extremely large number of functions, where salvaging unused profiles becomes prohibitively expensive.