### PR TITLE
Add sancov support for large AArch64 binaries.

### DIFF
--- a/llvm/tools/sancov/sancov.cpp
+++ b/llvm/tools/sancov/sancov.cpp
@@ -628,7 +628,12 @@ static bool isCoveragePointSymbol(StringRef Name) {
          // Mac has '___' prefix
          Name == "___sanitizer_cov" || Name == "___sanitizer_cov_with_check" ||
          Name == "___sanitizer_cov_trace_func_enter" ||
-         Name == "___sanitizer_cov_trace_pc_guard";
+         Name == "___sanitizer_cov_trace_pc_guard" ||
+         // Large Aarch64 binaries use thunks
+         Name == "__AArch64ADRPThunk___sanitizer_cov" ||
+         Name == "__AArch64ADRPThunk___sanitizer_cov_with_check" ||
+         Name == "__AArch64ADRPThunk___sanitizer_cov_trace_func_enter" ||
+         Name == "__AArch64ADRPThunk___sanitizer_cov_trace_pc_guard";
 }
 
 // Locate __sanitizer_cov* function addresses inside the stubs table on MachO.


### PR DESCRIPTION
In AArch64 calls have a +/-128MB range
(https://developer.arm.com/documentation/ddi0602/2025-12/Base-Instructions/BL--Branch-with-link-). In cases where the .text is larger than that, the linker adds functions that just jumps to the sanitizer functions and places them to some code location where the rest of the binary can call it. These functions have the prefix __AArch64ADRPThunk__.
This commit marks calls to this function as coverage points.