### PR TITLE
libclc: Remove old mesa amdgcn targets

### DIFF
--- a/libclc/CMakeLists.txt
+++ b/libclc/CMakeLists.txt
@@ -32,9 +32,7 @@ option(
 
 # List of all supported targets.
 set( LIBCLC_TARGETS_ALL
-  amdgcn--
   amdgcn-amd-amdhsa-llvm
-  amdgcn-mesa-mesa3d
   clspv--
   clspv64--
   nvptx64--


### PR DESCRIPTION
amdgcn-- was probably dead when clover was being maintained, since
it switched to using amdgcn-mesa-mesa3d. Also remove amdgcn-mesa-mesa3d,
since clover is no longer in mesa.