### PR TITLE
[lld][MachO] Deduplicate branch-extension thunks for ICF-folded symbols

### DIFF
--- a/lld/MachO/ConcatOutputSection.cpp
+++ b/lld/MachO/ConcatOutputSection.cpp
@@ -112,7 +112,7 @@ void ConcatOutputSection::addInput(ConcatInputSection *input) {
 //   the inputs and thunks vectors (both ordered by ascending address), which
 //   is simple and cheap.
 
-DenseMap<Symbol *, ThunkInfo> lld::macho::thunkMap;
+DenseMap<Symbol *, ThunkInfo, ThunkMapKeyInfo> lld::macho::thunkMap;
 
 // Determine whether we need thunks, which depends on the target arch -- RISC
 // (i.e., ARM) generally does because it has limited-range branch/call

--- a/lld/MachO/ConcatOutputSection.h
+++ b/lld/MachO/ConcatOutputSection.h
@@ -11,13 +11,12 @@
 
 #include "InputSection.h"
 #include "OutputSection.h"
+#include "Symbols.h"
 #include "lld/Common/LLVM.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/MapVector.h"
 
 namespace lld::macho {
-
-class Defined;
 
 // Linking multiple files will inevitably mean resolving sections in different
 // files that are labeled with the same segment and section name. This class
@@ -113,7 +112,32 @@ NamePair maybeRenameSection(NamePair key);
 // of ConcatOutputSection, so must have deterministic iteration order.
 extern llvm::MapVector<NamePair, ConcatOutputSection *> concatOutputSections;
 
-extern llvm::DenseMap<Symbol *, ThunkInfo> thunkMap;
+// After ICF, multiple Defined symbols may point to the same (isec, value) yet
+// remain as distinct Symbol pointers.  Using bare Symbol* as thunkMap keys
+// would create redundant thunks for the same target. This DenseMapInfo
+// canonicalizes Defined symbols by (isec, value) so that ICF-folded copies
+// share a single thunkMap entry.
+struct ThunkMapKeyInfo : llvm::DenseMapInfo<Symbol *> {
+  static unsigned getHashValue(const Symbol *sym) {
+    if (const auto *d = dyn_cast<Defined>(sym))
+      return llvm::hash_combine(d->isec(), d->value);
+    return llvm::DenseMapInfo<Symbol *>::getHashValue(sym);
+  }
+  static bool isEqual(const Symbol *lhs, const Symbol *rhs) {
+    if (lhs == rhs)
+      return true;
+    if (lhs == getEmptyKey() || lhs == getTombstoneKey() ||
+        rhs == getEmptyKey() || rhs == getTombstoneKey())
+      return false;
+    const auto *dl = dyn_cast<Defined>(lhs);
+    const auto *dr = dyn_cast<Defined>(rhs);
+    if (dl && dr)
+      return dl->isec() == dr->isec() && dl->value == dr->value;
+    return false;
+  }
+};
+
+extern llvm::DenseMap<Symbol *, ThunkInfo, ThunkMapKeyInfo> thunkMap;
 
 } // namespace lld::macho
 

--- a/lld/test/MachO/arm64-thunk-icf-body-dedup.s
+++ b/lld/test/MachO/arm64-thunk-icf-body-dedup.s
@@ -1,0 +1,80 @@
+# REQUIRES: aarch64
+
+# RUN: rm -rf %t; mkdir %t
+# RUN: llvm-mc -filetype=obj -triple=arm64-apple-darwin %s -o %t/input.o
+
+## Verify that ICF body-folded symbols share a single branch-extension thunk
+## rather than each getting its own.
+# RUN: %lld -arch arm64 -lSystem -o %t/icf-all %t/input.o --icf=all -map %t/icf-all.map
+# RUN: llvm-objdump --no-print-imm-hex -d --no-show-raw-insn %t/icf-all | FileCheck %s --check-prefix=BODY
+# RUN: FileCheck %s --input-file %t/icf-all.map --check-prefix=BODY-MAP
+
+## Both calls in _main branch to the same thunk address.
+# BODY-LABEL: <_main>:
+# BODY:       bl 0x[[#%x, THUNK:]] <_target_a.thunk.0>
+# BODY-NEXT:  bl 0x[[#%x, THUNK]] <_target_a.thunk.0>
+
+## Only one thunk should be created for the folded functions.
+# BODY-MAP:     .thunk.0
+# BODY-MAP-NOT: .thunk.0
+
+## Verify that safe_thunks ICF still creates separate branch-extension thunks
+## when needed.
+# RUN: %lld -arch arm64 -lSystem -o %t/icf-safe %t/input.o --icf=safe_thunks
+# RUN: llvm-objdump --no-print-imm-hex -d --no-show-raw-insn %t/icf-safe | FileCheck %s --check-prefix=SAFE
+
+## Each call gets its own branch-extension thunk.
+# SAFE-LABEL: <_main>:
+# SAFE:       bl 0x[[#%x, THUNK_A:]] <_target_a.thunk.0>
+# SAFE-NEXT:  bl 0x[[#%x, THUNK_B:]] <_target_b.thunk.0>
+
+.subsections_via_symbols
+
+.addrsig
+.addrsig_sym _target_a
+.addrsig_sym _target_b
+
+.text
+
+## A unique function placed before _target_a so that the assembler's automatic
+## ltmp0 symbol lands here to make the test more readable.
+.globl _unique_func
+.p2align 2
+_unique_func:
+  mov w0, #1
+  ret
+
+.globl _target_a
+.p2align 2
+_target_a:
+  mov w0, #42
+  ret
+
+.globl _target_b
+.p2align 2
+_target_b:
+  mov w0, #42
+  ret
+
+.globl _spacer
+.p2align 2
+_spacer:
+  .space 0x8000000
+  ret
+
+.globl _main
+.p2align 2
+_main:
+  bl _target_a
+  bl _target_b
+  ret
+
+## With safe_thunks, _target_b's ICF thunk is a synthetic section appended
+## after all regular inputs. This spacer pushes it out of branch range from
+## _main so it also needs a branch-extension thunk.
+.globl _spacer2
+.p2align 2
+_spacer2:
+  .space 0x8000000
+  mov w0, #0
+  ret


### PR DESCRIPTION
After ICF, multiple symbols may resolve to the same address but remain as distinct Symbol pointers. When used as keys in thunkMap, this caused redundant branch-extension thunks to be created for the same target. Fix this by providing a custom DenseMapInfo for thunkMap that hashes and compares Defined symbols by (isec, value) instead of pointer identity.