### PR TITLE
[SPIR-V] Add overload of getConstraintType for inline asm lowering

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVISelLowering.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVISelLowering.cpp
@@ -132,6 +132,15 @@ void SPIRVTargetLowering::getTgtMemIntrinsic(
   }
 }
 
+TargetLowering::ConstraintType
+SPIRVTargetLowering::getConstraintType(StringRef Constraint) const {
+  // SPIR-V represents inline assembly via OpAsmINTEL where constraints are
+  // passed through as literals defined by client API. Return C_RegisterClass
+  // for any constraint since SPIR-V does not distinguish between register,
+  // immediate, or memory operands at this level.
+  return C_RegisterClass;
+}
+
 std::pair<unsigned, const TargetRegisterClass *>
 SPIRVTargetLowering::getRegForInlineAsmConstraint(const TargetRegisterInfo *TRI,
                                                   StringRef Constraint,

--- a/llvm/lib/Target/SPIRV/SPIRVISelLowering.h
+++ b/llvm/lib/Target/SPIRV/SPIRVISelLowering.h
@@ -52,6 +52,8 @@ public:
                           const CallBase &I, MachineFunction &MF,
                           unsigned Intrinsic) const override;
 
+  ConstraintType getConstraintType(StringRef Constraint) const override;
+
   std::pair<unsigned, const TargetRegisterClass *>
   getRegForInlineAsmConstraint(const TargetRegisterInfo *TRI,
                                StringRef Constraint, MVT VT) const override;

--- a/llvm/test/CodeGen/SPIRV/extensions/SPV_INTEL_inline_assembly/inline_asm_target_constraints.ll
+++ b/llvm/test/CodeGen/SPIRV/extensions/SPV_INTEL_inline_assembly/inline_asm_target_constraints.ll
@@ -1,0 +1,21 @@
+; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv64-amd-amdhsa %s --spirv-ext=+SPV_INTEL_inline_assembly -o - | FileCheck %s
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv64-unknown-unknown %s -o - -filetype=obj | spirv-val %}
+
+; Test that SPIR-V backend handles target-specific inline asm constraints
+; (e.g., AMDGPU's "v" for VGPR) without crashing.
+
+; CHECK-DAG: OpCapability AsmINTEL
+; CHECK-DAG: OpExtension "SPV_INTEL_inline_assembly"
+; CHECK-DAG: %[[#Int32Ty:]] = OpTypeInt 32 0
+; CHECK-DAG: %[[#Int64Ty:]] = OpTypeInt 64 0
+; CHECK-DAG: %[[#Fun:]] = OpTypeFunction %[[#Int64Ty]] %[[#Int32Ty]]
+; CHECK-DAG: %[[#Dialect:]] = OpAsmTargetINTEL "spirv64-amd-amdhsa"
+; CHECK-DAG: %[[#Asm:]] = OpAsmINTEL %[[#Int64Ty]] %[[#Fun]] %[[#Dialect]] "v_mov_b32 $0, $1" "=v,v"
+
+; CHECK: OpFunction
+; CHECK: OpAsmCallINTEL %[[#Int64Ty]] %[[#Asm]] %[[#]]
+
+define i64 @test_vgpr_constraint(i32 %x) {
+  %res = call i64 asm sideeffect "v_mov_b32 $0, $1", "=v,v"(i32 %x)
+  ret i64 %res
+}

--- a/llvm/test/CodeGen/SPIRV/extensions/SPV_INTEL_inline_assembly/inline_asm_target_constraints.ll
+++ b/llvm/test/CodeGen/SPIRV/extensions/SPV_INTEL_inline_assembly/inline_asm_target_constraints.ll
@@ -1,5 +1,5 @@
 ; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv64-amd-amdhsa %s --spirv-ext=+SPV_INTEL_inline_assembly -o - | FileCheck %s
-; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv64-unknown-unknown %s -o - -filetype=obj | spirv-val %}
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv64-unknown-unknown %s --spirv-ext=+SPV_INTEL_inline_assembly -o - -filetype=obj | spirv-val %}
 
 ; Test that SPIR-V backend handles target-specific inline asm constraints
 ; (e.g., AMDGPU's "v" for VGPR) without crashing.


### PR DESCRIPTION
Without the overload constrain lowering would go with a default path which would later result in a crash in case if for example AMDGPU asm is inlined (for example v_ would be Unknown).

Overload sets ConstraintType to be always RegClass for SPIR-V.