### PR TITLE
[clang][AArch64] Do not allow implict conversion from SveFixedLengthData to svbool_t

### DIFF
--- a/clang/lib/Sema/SemaARM.cpp
+++ b/clang/lib/Sema/SemaARM.cpp
@@ -1627,7 +1627,8 @@ bool SemaARM::areCompatibleSveTypes(QualType FirstType, QualType SecondType) {
           return BT->getKind() == BuiltinType::SveBool;
         else if (VT->getVectorKind() == VectorKind::SveFixedLengthData)
           return VT->getElementType().getCanonicalType() ==
-                 FirstType->getSveEltType(Context);
+                     FirstType->getSveEltType(Context) &&
+                 BT->getKind() != BuiltinType::SveBool;
         else if (VT->getVectorKind() == VectorKind::Generic)
           return Context.getTypeSize(SecondType) ==
                      getSVETypeSize(Context, BT, IsStreaming) &&

--- a/clang/test/Sema/attr-arm-sve-vector-bits.c
+++ b/clang/test/Sema/attr-arm-sve-vector-bits.c
@@ -283,6 +283,9 @@ svint32_t badcast(int4 x) { return x; } // expected-error {{returning 'int4' (ve
 // memory representation.
 fixed_bool_t to_fixed_bool_t__from_svuint8_t(svuint8_t x) { return x; } // expected-error-re {{returning 'svuint8_t' (aka '__SVUint8_t') from a function with incompatible result type 'fixed_bool_t' (vector of {{[0-9]+}} 'unsigned char' values)}}
 
+// Do not allow implicit conversion between fixed-length uint8_t vectors and svbool_t.
+svbool_t to_svbool_t_from_fixed_uint8_t(fixed_uint8_t x) { return x; } // expected-error-re {{returning 'fixed_uint8_t' (vector of {{[0-9]+}} 'unsigned char' values) from a function with incompatible result type 'svbool_t' (aka '__SVBool_t')}}
+
 // --------------------------------------------------------------------------//
 // Test the scalable and fixed-length types can be used interchangeably
 


### PR DESCRIPTION
This is diverges from GCC and breaks overload resolution for some SVE builtins. For example, calling `svsel` is ambiguous on Clang (not GCC):

```c
using fixed_bool = svbool_t __attribute__((arm_sve_vector_bits(128)));
using fixed_u8   = svuint8_t __attribute__((arm_sve_vector_bits(128)));

fixed_u8 test(fixed_bool pred, fixed_u8 a, fixed_u8 b) {
  // error: call to 'svsel' is ambiguous
  // note: candidate function: svbool_t svsel(svbool_t, svbool_t, svbool_t);
  // note: candidate function: svuint8_t svsel(svbool_t, svuint8_t, svuint8_t);
  return svsel(pred, a, b);
}
```

See: https://godbolt.org/z/o3r9d5fW4