### PR TITLE
[AArch64] Remove dangling function declaration in AArch64PointerAuth

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64PointerAuth.cpp
+++ b/llvm/lib/Target/AArch64/AArch64PointerAuth.cpp
@@ -42,8 +42,6 @@ private:
 
   void authenticateLR(MachineFunction &MF,
                       MachineBasicBlock::iterator MBBI) const;
-
-  bool checkAuthenticatedLR(MachineBasicBlock::iterator TI) const;
 };
 
 } // end anonymous namespace


### PR DESCRIPTION
Function `checkAuthenticatedLR` was declared but not defined anywhere.

This patch removes the dangling declaration.