### PR TITLE
[LLDB] Remove C++ language runtime dependency of Clang expression parser

### DIFF
--- a/lldb/source/Plugins/ExpressionParser/Clang/CMakeLists.txt
+++ b/lldb/source/Plugins/ExpressionParser/Clang/CMakeLists.txt
@@ -45,7 +45,6 @@ add_lldb_library(lldbPluginExpressionParserClang
     lldbUtility
     lldbValueObject
     lldbPluginCPlusPlusLanguage
-    lldbPluginCPPRuntime
     lldbPluginObjCRuntime
     lldbPluginTypeSystemClang
   CLANG_LIBS

--- a/lldb/source/Plugins/ExpressionParser/Clang/ClangExpressionDeclMap.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ClangExpressionDeclMap.cpp
@@ -58,7 +58,6 @@
 #include "clang/AST/DeclarationName.h"
 #include "clang/AST/RecursiveASTVisitor.h"
 
-#include "Plugins/LanguageRuntime/CPlusPlus/CPPLanguageRuntime.h"
 #include "Plugins/LanguageRuntime/ObjC/ObjCLanguageRuntime.h"
 
 using namespace lldb;


### PR DESCRIPTION
From https://github.com/llvm/llvm-project/pull/169225#issuecomment-4024377289: There was a dependency cycle involving the C++ language runtime:
```
  //lldb/source/Plugins/TypeSystem/Clang:Clang ->
  //lldb/source/Plugins/ExpressionParser/Clang:Clang ->
  //lldb/source/Plugins/LanguageRuntime/CPlusPlus:CPlusPlus ->
  //lldb/source/Plugins/TypeSystem/Clang:Clang
```

`ExpressionParserClang` doesn't need to depend on the C++ language runtime. It only included a file, but didn't use it. This PR removes that dependency.