### PR TITLE
[Hexagon] Disable system include paths

### DIFF
--- a/clang/lib/Lex/InitHeaderSearch.cpp
+++ b/clang/lib/Lex/InitHeaderSearch.cpp
@@ -249,6 +249,10 @@ bool InitHeaderSearch::ShouldAddDefaultIncludePaths(
   if (triple.isOSDarwin())
     return false;
 
+  // On hexagon, include paths are managed by the driver.
+  if (triple.getArch() == llvm::Triple::hexagon)
+    return false;
+
   return true; // Everything else uses AddDefaultIncludePaths().
 }
 


### PR DESCRIPTION
Hexagon toolchains are almost always cross-compiling and using system include paths is vrtually always an error. In general, adding implicit paths is confusing and a comment in `InitHeaderSearch::AddDefaultIncludePaths()` suggests that "this code path is going away" and the proper place for path selection is in the driver. The current logic is to use system paths by default but it looks like almost all majors OSes are explictly excluded.

Disable implicit system include paths for Hexagon targets.