### PR TITLE
[flang][cuda] Emit CUDA attributes in type declarations in mod files

### DIFF
--- a/flang/lib/Semantics/mod-file.cpp
+++ b/flang/lib/Semantics/mod-file.cpp
@@ -1042,10 +1042,6 @@ void ModFileWriter::PutObjectEntity(
     });
     os << ") " << symbol.name() << '\n';
   }
-  if (auto attr{details.cudaDataAttr()}) {
-    PutLower(os << "attributes(", common::EnumToString(*attr))
-        << ") " << symbol.name() << '\n';
-  }
   if (symbol.test(Fortran::semantics::Symbol::Flag::CrayPointer)) {
     for (const auto &[pointee, pointer] : symbol.owner().crayPointers()) {
       if (pointer == symbol) {
@@ -1168,6 +1164,11 @@ void ModFileWriter::PutEntity(llvm::raw_ostream &os, const Symbol &symbol,
     std::function<void()> writeType, Attrs attrs) {
   writeType();
   PutAttrs(os, attrs, symbol.GetBindName(), symbol.GetIsExplicitBindName());
+  if (const auto *details{symbol.detailsIf<ObjectEntityDetails>()}) {
+    if (auto attr{details->cudaDataAttr()}) {
+      PutLower(os << ',', common::EnumToString(*attr));
+    }
+  }
   if (symbol.owner().kind() == Scope::Kind::DerivedType &&
       context_.IsTempName(symbol.name().ToString())) {
     os << "::%FILL";

--- a/flang/test/Semantics/modfile55.cuf
+++ b/flang/test/Semantics/modfile55.cuf
@@ -5,6 +5,9 @@ module m
   real, managed, allocatable :: md
   real, pinned, allocatable :: mp
   attributes(constant) cd
+  type dt
+    real, device, pointer :: dp
+  end type
  contains
   attributes(global) subroutine globsub(x,y,z)
     real, value :: x
@@ -22,27 +25,24 @@ end
 
 !Expect: m.mod
 !module m
-!real(4)::dd
-!attributes(device) dd
-!real(4),allocatable::md
-!attributes(managed) md
-!real(4),allocatable::mp
-!attributes(pinned) mp
-!real(4)::cd
-!attributes(constant) cd
+!real(4),device::dd
+!real(4),allocatable,managed::md
+!real(4),allocatable,pinned::mp
+!real(4),constant::cd
+!type::dt
+!real(4),pointer,device::dp
+!end type
 !contains
 !attributes(global) subroutine globsub(x,y,z)
 !real(4),value::x
-!real(4)::y
-!attributes(device) y
-!real(4)::z
-!attributes(managed) z
+!real(4),device::y
+!real(4),managed::z
 !end
 !attributes(host,device) function foo(x)
 !real(4)::x
 !real(4)::foo
 !end
-attributes(host)subroutinehostsub(a)
-integer(4),intent(out)::a(1_8:14_8)
-end
+!attributes(host)subroutinehostsub(a)
+!integer(4),intent(out)::a(1_8:14_8)
+!end
 !end


### PR DESCRIPTION
The compiler implements CUDA object entity attributes in module files by emitting "attributes()" statements after the type declaration statement for the object.  This works fine for variables, but not at all for derived type components -- the "attributes()" statement is not allowed in a derived type definition, and the module file isn't readable later when USE'd.  The fix is to emit the attribute as part of the type declaration statement or component declaration statement instead.