### PR TITLE
[cmake] use target names instead of legacy variables

### DIFF
--- a/llvm/cmake/config-ix.cmake
+++ b/llvm/cmake/config-ix.cmake
@@ -172,8 +172,7 @@ if(LLVM_ENABLE_ZLIB)
     # Check if zlib we found is usable; for example, we may have found a 32-bit
     # library on a 64-bit system which would result in a link-time failure.
     cmake_push_check_state()
-    list(APPEND CMAKE_REQUIRED_INCLUDES ${ZLIB_INCLUDE_DIRS})
-    list(APPEND CMAKE_REQUIRED_LIBRARIES ${ZLIB_LIBRARY})
+    list(APPEND CMAKE_REQUIRED_LIBRARIES ZLIB::ZLIB)
     check_symbol_exists(compress2 zlib.h HAVE_ZLIB)
     cmake_pop_check_state()
     if(LLVM_ENABLE_ZLIB STREQUAL FORCE_ON AND NOT HAVE_ZLIB)
@@ -219,9 +218,7 @@ if(LLVM_ENABLE_LIBXML2)
     # Check if libxml2 we found is usable; for example, we may have found a 32-bit
     # library on a 64-bit system which would result in a link-time failure.
     cmake_push_check_state()
-    list(APPEND CMAKE_REQUIRED_INCLUDES ${LIBXML2_INCLUDE_DIRS})
-    list(APPEND CMAKE_REQUIRED_LIBRARIES ${LIBXML2_LIBRARIES})
-    list(APPEND CMAKE_REQUIRED_DEFINITIONS ${LIBXML2_DEFINITIONS})
+    list(APPEND CMAKE_REQUIRED_LIBRARIES LibXml2::LibXml2)
     check_symbol_exists(xmlReadMemory libxml/xmlreader.h HAVE_LIBXML2)
     cmake_pop_check_state()
     if(LLVM_ENABLE_LIBXML2 STREQUAL FORCE_ON AND NOT HAVE_LIBXML2)


### PR DESCRIPTION
Use the [name of the imported targets](https://cmake.org/cmake/help/latest/module/CheckSymbolExists.html) when testing the libraries during cmake configuration. This removes the need  to also set `CMAKE_REQUIRED_INCLUDES` and `CMAKE_REQUIRED_DEFINITIONS` and reflects more modern CMake usage where targets are preferred over variables.

This is already the case when checking libcurl in the same file.