### PR TITLE
[lldb][test] Fix TestLongjmp on Linux

### DIFF
--- a/lldb/test/API/functionalities/longjmp/TestLongjmp.py
+++ b/lldb/test/API/functionalities/longjmp/TestLongjmp.py
@@ -11,7 +11,6 @@ from lldbsuite.test import lldbutil
 
 class LongjmpTestCase(TestBase):
     @skipIfDarwin  # llvm.org/pr16769: LLDB on Mac OS X dies in function ReadRegisterBytes in GDBRemoteRegisterContext.cpp
-    @expectedFailureAll(oslist=["freebsd", "linux"], bugnumber="llvm.org/pr20231")
     @expectedFailureAll(oslist=["windows"], bugnumber="llvm.org/pr24778")
     @expectedFlakeyNetBSD
     def test_step_out(self):
@@ -20,7 +19,6 @@ class LongjmpTestCase(TestBase):
         self.step_out()
 
     @skipIfDarwin  # llvm.org/pr16769: LLDB on Mac OS X dies in function ReadRegisterBytes in GDBRemoteRegisterContext.cpp
-    @expectedFailureAll(oslist=["freebsd", "linux"], bugnumber="llvm.org/pr20231")
     @expectedFailureAll(oslist=["windows"], bugnumber="llvm.org/pr24778")
     @skipIfNetBSD
     def test_step_over(self):
@@ -29,7 +27,6 @@ class LongjmpTestCase(TestBase):
         self.step_over()
 
     @skipIfDarwin  # llvm.org/pr16769: LLDB on Mac OS X dies in function ReadRegisterBytes in GDBRemoteRegisterContext.cpp
-    @expectedFailureAll(oslist=["freebsd", "linux"], bugnumber="llvm.org/pr20231")
     @expectedFailureAll(oslist=["windows"], bugnumber="llvm.org/pr24778")
     @expectedFlakeyNetBSD
     def test_step_back_out(self):

--- a/lldb/test/API/functionalities/longjmp/main.c
+++ b/lldb/test/API/functionalities/longjmp/main.c
@@ -4,20 +4,18 @@
 
 jmp_buf j;
 
-void do_jump(void)
-{
-    // We can't let the compiler know this will always happen or it might make
-    // optimizations that break our test.
-    if (!clock())
-        longjmp(j, 1); // non-local goto
+void do_jump(void) {
+  // We can't let the compiler know this will always happen or it might make
+  // optimizations that break our test.
+  if (clock())
+    longjmp(j, 1); // non-local goto
 }
 
-int main (void)
-{
-    if (setjmp(j) == 0)
-        do_jump();
-    else
-        return 0; // destination of longjmp
+int main(void) {
+  if (setjmp(j) == 0)
+    do_jump();
+  else
+    return 0; // destination of longjmp
 
-    return 1;
+  return 1;
 }


### PR DESCRIPTION
Patch fixes llvm.org/pr20231.
The original test was expecting clock() to return 0 when stepping in
debugger which in reality can never happen.