### PR TITLE
[SandboxVec][BottomUpVec] Improve handling of external uses

### DIFF
--- a/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/InstrMaps.h
+++ b/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/InstrMaps.h
@@ -61,6 +61,10 @@ class InstrMaps {
 public:
   InstrMaps() = default;
   ~InstrMaps() = default;
+  /// \Returns true if \p Orig was vectorized
+  bool isVectorized(Value *Orig) const {
+    return OrigToVectorMap.contains(Orig);
+  }
   /// \Returns the vector value that we got from vectorizing \p Orig, or
   /// nullptr if not found.
   Action *getVectorForOrig(Value *Orig) const {

--- a/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/Passes/BottomUpVec.h
+++ b/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/Passes/BottomUpVec.h
@@ -88,6 +88,9 @@ class BottomUpVec final : public RegionPass {
   /// `Actions` vector.
   Action *vectorizeRec(ArrayRef<Value *> Bndl, ArrayRef<Value *> UserBndl,
                        unsigned Depth, LegalityAnalysis &Legality);
+  /// If the values in \p Bndl have external users, then emit unpacks and
+  /// connect them to the users. \p Vec is the vectorized form of \p Bndl.
+  void emitUnpacksForExternalUses(const ArrayRef<Value *> Bndl, Value *Vec);
   /// Generate vector instructions based on `Actions` and return the last vector
   /// created.
   Value *emitVectors();

--- a/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/VecUtils.h
+++ b/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/VecUtils.h
@@ -287,7 +287,7 @@ public:
     }
     // For vector elements we emit a shuffle.
     // For example, extracting lanes 2 and 3 of a <4 x i32> vector %vec:
-    //   %extr0 = shufflevector <4 x i32> %vec, <4 x i32> poison, <2 x i32> <i32 2, i32 3>
+    //  shufflevector <4 x i32> %vec, <4 x i32> poison, <2 x i32> <i32 2, i32 3>
     auto *VecTy = cast<FixedVectorType>(FromVec->getType());
     auto *ExtrVecTy = cast<FixedVectorType>(ExtrTy);
     assert(ExtrVecTy->getElementType() == VecTy->getElementType() &&

--- a/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/VecUtils.h
+++ b/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/VecUtils.h
@@ -283,36 +283,25 @@ public:
       // This may be folded into a Constant if LastInsert is a Constant. In
       // that case we only collect the last constant.
       return ExtractElementInst::create(FromVec, ExtractLaneC, WhereIt, Ctx,
-                                        "UnPack");
+                                        "Unpack");
     }
-    // For vector elements we emit a sequence of Extracts and Inserts.
+    // For vector elements we emit a shuffle.
     // For example, extracting lanes 2 and 3 of a <4 x i32> vector %vec:
-    //   %extr0 = extractelementinst <4 x i32> %vec,   i32 2
-    //   %ins0  = insertelementinst  <2 x i32> poison, i32 %extr0, i32 0
-    //   %extr1 = extractelementisnt <4 x i32> %vec,   i32 3
-    //   %ins1  = insertelementinst  <2 x i32> %ins0,  i32 %extr1, i32 1
+    //   %extr0 = shufflevectorinst <4 x i32> %vec, <4 x i32> poison, <2 x i32> <i32 2, i32 3>
+    auto *VecTy = cast<FixedVectorType>(FromVec->getType());
     auto *ExtrVecTy = cast<FixedVectorType>(ExtrTy);
-    assert(ExtrVecTy->getElementType() ==
-               cast<FixedVectorType>(FromVec->getType())->getElementType() &&
+    assert(ExtrVecTy->getElementType() == VecTy->getElementType() &&
            "Expected same element type!");
-    Value *ExtractedVec = PoisonValue::get(ExtrVecTy);
-    Value *LastIns = nullptr;
+    SmallVector<int, 4> Mask;
     for (unsigned Idx = 0, E = ExtrVecTy->getNumElements(); Idx != E; ++Idx) {
-      assert(Lane + Idx <
+      int MaskLane = Lane + Idx;
+      assert((unsigned)MaskLane <
                  cast<FixedVectorType>(FromVec->getType())->getNumElements() &&
              "Out of bounds!");
-      Constant *ExtractLaneC =
-          ConstantInt::getSigned(Type::getInt32Ty(Ctx), Lane + Idx);
-      auto *Elm = ExtractElementInst::create(FromVec, ExtractLaneC, WhereIt,
-                                             Ctx, "UnPackExt");
-
-      Constant *InsertLaneC =
-          ConstantInt::getSigned(Type::getInt32Ty(Ctx), Idx);
-      LastIns = InsertElementInst::create(ExtractedVec, Elm, InsertLaneC,
-                                          WhereIt, Ctx, "UnPackIns");
-      ExtractedVec = LastIns;
+      Mask.push_back(MaskLane);
     }
-    return LastIns;
+    return ShuffleVectorInst::create(FromVec, PoisonValue::get(VecTy), Mask,
+                                     WhereIt, Ctx, "Unpack");
   }
 
 #ifndef NDEBUG

--- a/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/VecUtils.h
+++ b/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/VecUtils.h
@@ -262,6 +262,59 @@ public:
     return Pack;
   }
 
+  /// Emits the necessary instruction sequence to extract element of type \p
+  /// ExtrTy at \p Lane from \p FromVec. Emits instructions before \p WhereIt.
+  /// Returns the extracted value.
+  /// Note: This handles both vectors and scalars.
+  static Value *unpack(Value *FromVec, Type *ExtrTy, unsigned Lane,
+                       BasicBlock::iterator WhereIt) {
+    assert(isa<FixedVectorType>(FromVec->getType()) && "Expected vector!");
+    auto &Ctx = FromVec->getContext();
+    if (!ExtrTy->isVectorTy()) {
+      // For scalar elements we emit a single ExtractElementInst.
+      assert(Lane <
+                 cast<FixedVectorType>(FromVec->getType())->getNumElements() &&
+             "Out of bounds!");
+      assert(ExtrTy ==
+                 cast<FixedVectorType>(FromVec->getType())->getElementType() &&
+             "Expected same element type!");
+      Constant *ExtractLaneC =
+          ConstantInt::getSigned(Type::getInt32Ty(Ctx), Lane);
+      // This may be folded into a Constant if LastInsert is a Constant. In
+      // that case we only collect the last constant.
+      return ExtractElementInst::create(FromVec, ExtractLaneC, WhereIt, Ctx,
+                                        "UnPack");
+    }
+    // For vector elements we emit a sequence of Extracts and Inserts.
+    // For example, extracting lanes 2 and 3 of a <4 x i32> vector %vec:
+    //   %extr0 = extractelementinst <4 x i32> %vec,   i32 2
+    //   %ins0  = insertelementinst  <2 x i32> poison, i32 %extr0, i32 0
+    //   %extr1 = extractelementisnt <4 x i32> %vec,   i32 3
+    //   %ins1  = insertelementinst  <2 x i32> %ins0,  i32 %extr1, i32 1
+    auto *ExtrVecTy = cast<FixedVectorType>(ExtrTy);
+    assert(ExtrVecTy->getElementType() ==
+               cast<FixedVectorType>(FromVec->getType())->getElementType() &&
+           "Expected same element type!");
+    Value *ExtractedVec = PoisonValue::get(ExtrVecTy);
+    Value *LastIns = nullptr;
+    for (unsigned Idx = 0, E = ExtrVecTy->getNumElements(); Idx != E; ++Idx) {
+      assert(Lane + Idx <
+                 cast<FixedVectorType>(FromVec->getType())->getNumElements() &&
+             "Out of bounds!");
+      Constant *ExtractLaneC =
+          ConstantInt::getSigned(Type::getInt32Ty(Ctx), Lane + Idx);
+      auto *Elm = ExtractElementInst::create(FromVec, ExtractLaneC, WhereIt,
+                                             Ctx, "UnPackExt");
+
+      Constant *InsertLaneC =
+          ConstantInt::getSigned(Type::getInt32Ty(Ctx), Idx);
+      LastIns = InsertElementInst::create(ExtractedVec, Elm, InsertLaneC,
+                                          WhereIt, Ctx, "UnPackIns");
+      ExtractedVec = LastIns;
+    }
+    return LastIns;
+  }
+
 #ifndef NDEBUG
   /// Helper dump function for debugging.
   LLVM_DUMP_METHOD static void dump(ArrayRef<Value *> Bndl);

--- a/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/VecUtils.h
+++ b/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/VecUtils.h
@@ -265,7 +265,8 @@ public:
   /// Emits the necessary instruction sequence to extract element of type \p
   /// ExtrTy at \p Lane from \p FromVec. Emits instructions before \p WhereIt.
   /// Returns the extracted value.
-  /// Note: This handles both vectors and scalars.
+  /// Note: This handles both vectors and scalars. In the vector case it
+  /// extracts an N-wide element (with N dictated by \p ExtrTy).
   static Value *unpack(Value *FromVec, Type *ExtrTy, unsigned Lane,
                        BasicBlock::iterator WhereIt) {
     assert(isa<FixedVectorType>(FromVec->getType()) && "Expected vector!");
@@ -280,14 +281,13 @@ public:
              "Expected same element type!");
       Constant *ExtractLaneC =
           ConstantInt::getSigned(Type::getInt32Ty(Ctx), Lane);
-      // This may be folded into a Constant if LastInsert is a Constant. In
-      // that case we only collect the last constant.
+      // Note: This may be folded into a Constant if FromVec is a Constant.
       return ExtractElementInst::create(FromVec, ExtractLaneC, WhereIt, Ctx,
                                         "Unpack");
     }
     // For vector elements we emit a shuffle.
     // For example, extracting lanes 2 and 3 of a <4 x i32> vector %vec:
-    //   %extr0 = shufflevectorinst <4 x i32> %vec, <4 x i32> poison, <2 x i32> <i32 2, i32 3>
+    //   %extr0 = shufflevector <4 x i32> %vec, <4 x i32> poison, <2 x i32> <i32 2, i32 3>
     auto *VecTy = cast<FixedVectorType>(FromVec->getType());
     auto *ExtrVecTy = cast<FixedVectorType>(ExtrTy);
     assert(ExtrVecTy->getElementType() == VecTy->getElementType() &&

--- a/llvm/lib/Transforms/Vectorize/SandboxVectorizer/Passes/BottomUpVec.cpp
+++ b/llvm/lib/Transforms/Vectorize/SandboxVectorizer/Passes/BottomUpVec.cpp
@@ -360,13 +360,23 @@ void BottomUpVec::emitUnpacksForExternalUses(const ArrayRef<Value *> Bndl,
             : std::next(
                   VecUtils::getLastPHIOrSelf(&*BB->begin())->getIterator());
   }
-  for (auto [Idx, Elm] : enumerate(Bndl)) {
+  unsigned Lane = 0;
+  for (Value *Elm : Bndl) {
     for (User *U : Elm->users()) {
       // Skip users that we just vectorized.
       if (IMaps->isVectorized(U))
         continue;
-      auto *LastUnpackV = VecUtils::unpack(Vec, Elm->getType(), Idx, WhereIt);
+      auto *LastUnpackV = VecUtils::unpack(Vec, Elm->getType(), Lane, WhereIt);
       Elm->replaceAllUsesWith(LastUnpackV);
+    }
+
+    // Increment Lane.
+    auto *ElmTy = Utils::getExpectedType(Elm);
+    if (auto *VecTy = dyn_cast<FixedVectorType>(ElmTy)) {
+      Lane += VecTy->getNumElements();
+    } else {
+      assert(!isa<VectorType>(ElmTy) && "Expected scalar type!");
+      Lane += 1;
     }
   }
 }

--- a/llvm/lib/Transforms/Vectorize/SandboxVectorizer/Passes/BottomUpVec.cpp
+++ b/llvm/lib/Transforms/Vectorize/SandboxVectorizer/Passes/BottomUpVec.cpp
@@ -360,28 +360,13 @@ void BottomUpVec::emitUnpacksForExternalUses(const ArrayRef<Value *> Bndl,
             : std::next(
                   VecUtils::getLastPHIOrSelf(&*BB->begin())->getIterator());
   }
-  Context &Ctx = Bndl[0]->getContext();
   for (auto [Idx, Elm] : enumerate(Bndl)) {
     for (User *U : Elm->users()) {
       // Skip users that we just vectorized.
       if (IMaps->isVectorized(U))
         continue;
-      // An element can be either scalar or vector. We need to generate
-      // different IR for each case.
-      if (Elm->getType()->isVectorTy()) {
-        llvm_unreachable("Unimplemented");
-      } else {
-        Constant *ExtractLaneC =
-            ConstantInt::getSigned(Type::getInt32Ty(Ctx), Idx++);
-        // This may be folded into a Constant if LastInsert is a Constant. In
-        // that case we only collect the last constant.
-        auto *Extract = ExtractElementInst::create(Vec, ExtractLaneC, WhereIt,
-                                                   Ctx, "UnPack");
-        // Move WhereIt to prepare for the next Extract.
-        if (auto *ExtractI = dyn_cast<Instruction>(Extract))
-          WhereIt = std::next(ExtractI->getIterator());
-        Elm->replaceAllUsesWith(Extract);
-      }
+      auto *LastUnpackV = VecUtils::unpack(Vec, Elm->getType(), Idx, WhereIt);
+      Elm->replaceAllUsesWith(LastUnpackV);
     }
   }
 }

--- a/llvm/lib/Transforms/Vectorize/SandboxVectorizer/Passes/BottomUpVec.cpp
+++ b/llvm/lib/Transforms/Vectorize/SandboxVectorizer/Passes/BottomUpVec.cpp
@@ -340,6 +340,51 @@ void BottomUpVec::ActionsVector::print(raw_ostream &OS) const {
 void BottomUpVec::ActionsVector::dump() const { print(dbgs()); }
 #endif // NDEBUG
 
+void BottomUpVec::emitUnpacksForExternalUses(const ArrayRef<Value *> Bndl,
+                                             Value *Vec) {
+  // Find where we should emit the unpacks.
+  BasicBlock::iterator WhereIt;
+  if (auto *VecI = dyn_cast<Instruction>(Vec)) {
+    WhereIt = std::next(VecI->getIterator());
+  } else {
+    // If Vec is a constant then it should be safe to emit the unpacks at the
+    // top of the block.
+    assert(isa<Constant>(Vec) && "Expected constant!");
+    assert(isa<Instruction>(Bndl[0]) &&
+           "A widened Bndl should contain instrs!");
+    BasicBlock *BB = cast<Instruction>(Bndl[0])->getParent();
+    WhereIt =
+        BB->empty()
+            ? BB->begin()
+            : std::next(
+                  VecUtils::getLastPHIOrSelf(&*BB->begin())->getIterator());
+  }
+  Context &Ctx = Bndl[0]->getContext();
+  for (auto [Idx, Elm] : enumerate(Bndl)) {
+    for (User *U : Elm->users()) {
+      // Skip users that we just vectorized.
+      if (IMaps->isVectorized(U))
+        continue;
+      // An element can be either scalar or vector. We need to generate
+      // different IR for each case.
+      if (Elm->getType()->isVectorTy()) {
+        llvm_unreachable("Unimplemented");
+      } else {
+        Constant *ExtractLaneC =
+            ConstantInt::getSigned(Type::getInt32Ty(Ctx), Idx++);
+        // This may be folded into a Constant if LastInsert is a Constant. In
+        // that case we only collect the last constant.
+        auto *Extract = ExtractElementInst::create(Vec, ExtractLaneC, WhereIt,
+                                                   Ctx, "UnPack");
+        // Move WhereIt to prepare for the next Extract.
+        if (auto *ExtractI = dyn_cast<Instruction>(Extract))
+          WhereIt = std::next(ExtractI->getIterator());
+        Elm->replaceAllUsesWith(Extract);
+      }
+    }
+  }
+}
+
 Value *BottomUpVec::emitVectors() {
   Value *NewVec = nullptr;
   for (const auto &ActionPtr : Actions) {
@@ -377,6 +422,9 @@ Value *BottomUpVec::emitVectors() {
       // original scalars and pointer operands of loads/stores.
       if (NewVec != nullptr)
         collectPotentiallyDeadInstrs(Bndl);
+
+      // Emit unpacks for all external uses, if any.
+      emitUnpacksForExternalUses(ActionPtr->Bndl, NewVec);
       break;
     }
     case LegalityResultID::DiamondReuse: {

--- a/llvm/lib/Transforms/Vectorize/SandboxVectorizer/Passes/BottomUpVec.cpp
+++ b/llvm/lib/Transforms/Vectorize/SandboxVectorizer/Passes/BottomUpVec.cpp
@@ -349,6 +349,7 @@ void BottomUpVec::emitUnpacksForExternalUses(const ArrayRef<Value *> Bndl,
   } else {
     // If Vec is a constant then it should be safe to emit the unpacks at the
     // top of the block.
+    // Note: Extracts from constants are usually folded to constants.
     assert(isa<Constant>(Vec) && "Expected constant!");
     assert(isa<Instruction>(Bndl[0]) &&
            "A widened Bndl should contain instrs!");

--- a/llvm/test/Transforms/SandboxVectorizer/bottomup_basic.ll
+++ b/llvm/test/Transforms/SandboxVectorizer/bottomup_basic.ll
@@ -187,10 +187,9 @@ define float @scalars_with_external_uses_not_dead(ptr %ptr) {
 ; CHECK-LABEL: define float @scalars_with_external_uses_not_dead(
 ; CHECK-SAME: ptr [[PTR:%.*]]) {
 ; CHECK-NEXT:    [[PTR0:%.*]] = getelementptr float, ptr [[PTR]], i32 0
-; CHECK-NEXT:    [[PTR1:%.*]] = getelementptr float, ptr [[PTR]], i32 1
-; CHECK-NEXT:    [[LD0:%.*]] = load float, ptr [[PTR0]], align 4
-; CHECK-NEXT:    [[LD1:%.*]] = load float, ptr [[PTR1]], align 4
 ; CHECK-NEXT:    [[VECL:%.*]] = load <2 x float>, ptr [[PTR0]], align 4, !sandboxvec [[META5:![0-9]+]]
+; CHECK-NEXT:    [[LD0:%.*]] = extractelement <2 x float> [[VECL]], i32 0, !sandboxvec [[META5]]
+; CHECK-NEXT:    [[LD1:%.*]] = extractelement <2 x float> [[VECL]], i32 1, !sandboxvec [[META5]]
 ; CHECK-NEXT:    store <2 x float> [[VECL]], ptr [[PTR0]], align 4, !sandboxvec [[META5]]
 ; CHECK-NEXT:    [[USER:%.*]] = fneg float [[LD1]]
 ; CHECK-NEXT:    ret float [[LD0]]
@@ -198,10 +197,10 @@ define float @scalars_with_external_uses_not_dead(ptr %ptr) {
 ; REVERT-LABEL: define float @scalars_with_external_uses_not_dead(
 ; REVERT-SAME: ptr [[PTR:%.*]]) {
 ; REVERT-NEXT:    [[PTR0:%.*]] = getelementptr float, ptr [[PTR]], i32 0
-; REVERT-NEXT:    [[PTR1:%.*]] = getelementptr float, ptr [[PTR]], i32 1
-; REVERT-NEXT:    [[LD0:%.*]] = load float, ptr [[PTR0]], align 4
-; REVERT-NEXT:    [[LD1:%.*]] = load float, ptr [[PTR1]], align 4
-; REVERT-NEXT:    store float [[LD0]], ptr [[PTR0]], align 4, !sandboxvec [[META5:![0-9]+]]
+; REVERT-NEXT:    [[PTR1:%.*]] = getelementptr float, ptr [[PTR]], i32 1, !sandboxvec [[META5:![0-9]+]]
+; REVERT-NEXT:    [[LD0:%.*]] = load float, ptr [[PTR0]], align 4, !sandboxvec [[META5]]
+; REVERT-NEXT:    [[LD1:%.*]] = load float, ptr [[PTR1]], align 4, !sandboxvec [[META5]]
+; REVERT-NEXT:    store float [[LD0]], ptr [[PTR0]], align 4, !sandboxvec [[META5]]
 ; REVERT-NEXT:    store float [[LD1]], ptr [[PTR1]], align 4, !sandboxvec [[META5]]
 ; REVERT-NEXT:    [[USER:%.*]] = fneg float [[LD1]]
 ; REVERT-NEXT:    ret float [[LD0]]
@@ -513,8 +512,8 @@ define void @diamondWithConstantVector(ptr %ptr) {
 ; REVERT-NEXT:    [[GEPA1:%.*]] = getelementptr i32, ptr [[PTR]], i64 1, !sandboxvec [[META14:![0-9]+]]
 ; REVERT-NEXT:    [[GEPB0:%.*]] = getelementptr i32, ptr [[PTR]], i64 10
 ; REVERT-NEXT:    [[GEPB1:%.*]] = getelementptr i32, ptr [[PTR]], i64 11, !sandboxvec [[META15:![0-9]+]]
-; REVERT-NEXT:    [[ZEXT0:%.*]] = zext i16 0 to i32
-; REVERT-NEXT:    [[ZEXT1:%.*]] = zext i16 0 to i32
+; REVERT-NEXT:    [[ZEXT0:%.*]] = zext i16 0 to i32, !sandboxvec [[META14]]
+; REVERT-NEXT:    [[ZEXT1:%.*]] = zext i16 0 to i32, !sandboxvec [[META14]]
 ; REVERT-NEXT:    store i32 [[ZEXT0]], ptr [[GEPA0]], align 4, !sandboxvec [[META14]]
 ; REVERT-NEXT:    store i32 [[ZEXT1]], ptr [[GEPA1]], align 4, !sandboxvec [[META14]]
 ; REVERT-NEXT:    [[ORB0:%.*]] = or i32 0, [[ZEXT0]], !sandboxvec [[META15]]

--- a/llvm/test/Transforms/SandboxVectorizer/external_uses.ll
+++ b/llvm/test/Transforms/SandboxVectorizer/external_uses.ll
@@ -47,7 +47,34 @@ define void @external_user_of_constant(ptr %ptr, ptr %ptrX) {
   ret void
 }
 
+define void @vector_external_users(ptr %ptr) {
+; CHECK-LABEL: define void @vector_external_users(
+; CHECK-SAME: ptr [[PTR:%.*]]) {
+; CHECK-NEXT:    [[PTR0:%.*]] = getelementptr float, ptr [[PTR]], i32 0
+; CHECK-NEXT:    [[VECL:%.*]] = load <3 x float>, ptr [[PTR0]], align 4, !sandboxvec [[META2:![0-9]+]]
+; CHECK-NEXT:    [[VEC:%.*]] = fsub <3 x float> [[VECL]], zeroinitializer, !sandboxvec [[META2]]
+; CHECK-NEXT:    [[UNPACKEXT:%.*]] = extractelement <3 x float> [[VEC]], i32 1, !sandboxvec [[META2]]
+; CHECK-NEXT:    [[UNPACKINS:%.*]] = insertelement <2 x float> poison, float [[UNPACKEXT]], i32 0, !sandboxvec [[META2]]
+; CHECK-NEXT:    [[UNPACKEXT1:%.*]] = extractelement <3 x float> [[VEC]], i32 2, !sandboxvec [[META2]]
+; CHECK-NEXT:    [[UNPACKINS2:%.*]] = insertelement <2 x float> [[UNPACKINS]], float [[UNPACKEXT1]], i32 1, !sandboxvec [[META2]]
+; CHECK-NEXT:    store <3 x float> [[VEC]], ptr [[PTR0]], align 4, !sandboxvec [[META2]]
+; CHECK-NEXT:    [[USER:%.*]] = fneg <2 x float> [[UNPACKINS2]]
+; CHECK-NEXT:    ret void
+;
+  %ptr0 = getelementptr float, ptr %ptr, i32 0
+  %ptr1 = getelementptr float, ptr %ptr, i32 1
+  %ld0 = load float, ptr %ptr0
+  %ld1 = load <2 x float>, ptr %ptr1
+  %sub0 = fsub float %ld0, 0.0
+  %sub1 = fsub <2 x float> %ld1, <float 0.0, float 0.0>
+  store float %sub0, ptr %ptr0
+  store <2 x float> %sub1, ptr %ptr1
+  %user = fneg <2 x float> %sub1
+  ret void
+}
+
 ;.
 ; CHECK: [[META0]] = distinct !{!"sandboxregion"}
 ; CHECK: [[META1]] = distinct !{!"sandboxregion"}
+; CHECK: [[META2]] = distinct !{!"sandboxregion"}
 ;.

--- a/llvm/test/Transforms/SandboxVectorizer/external_uses.ll
+++ b/llvm/test/Transforms/SandboxVectorizer/external_uses.ll
@@ -70,8 +70,32 @@ define void @vector_external_users(ptr %ptr) {
   ret void
 }
 
+define void @vector_external_users_lane_and_index_differ(ptr %ptr) {
+; CHECK-LABEL: define void @vector_external_users_lane_and_index_differ(
+; CHECK-SAME: ptr [[PTR:%.*]]) {
+; CHECK-NEXT:    [[PTR0:%.*]] = getelementptr <2 x float>, ptr [[PTR]], i32 0
+; CHECK-NEXT:    [[VECL:%.*]] = load <4 x float>, ptr [[PTR0]], align 8, !sandboxvec [[META3:![0-9]+]]
+; CHECK-NEXT:    [[VEC:%.*]] = fsub <4 x float> [[VECL]], zeroinitializer, !sandboxvec [[META3]]
+; CHECK-NEXT:    [[UNPACK:%.*]] = shufflevector <4 x float> [[VEC]], <4 x float> poison, <2 x i32> <i32 2, i32 3>, !sandboxvec [[META3]]
+; CHECK-NEXT:    store <4 x float> [[VEC]], ptr [[PTR0]], align 8, !sandboxvec [[META3]]
+; CHECK-NEXT:    [[USER:%.*]] = fneg <2 x float> [[UNPACK]]
+; CHECK-NEXT:    ret void
+;
+  %ptr0 = getelementptr <2 x float>, ptr %ptr, i32 0
+  %ptr1 = getelementptr <2 x float>, ptr %ptr, i32 1
+  %ld0 = load <2 x float>, ptr %ptr0
+  %ld1 = load <2 x float>, ptr %ptr1
+  %sub0 = fsub <2 x float> %ld0, <float 0.0, float 0.0>
+  %sub1 = fsub <2 x float> %ld1, <float 0.0, float 0.0>
+  store <2 x float> %sub0, ptr %ptr0
+  store <2 x float> %sub1, ptr %ptr1
+  %user = fneg <2 x float> %sub1
+  ret void
+}
+
 ;.
 ; CHECK: [[META0]] = distinct !{!"sandboxregion"}
 ; CHECK: [[META1]] = distinct !{!"sandboxregion"}
 ; CHECK: [[META2]] = distinct !{!"sandboxregion"}
+; CHECK: [[META3]] = distinct !{!"sandboxregion"}
 ;.

--- a/llvm/test/Transforms/SandboxVectorizer/external_uses.ll
+++ b/llvm/test/Transforms/SandboxVectorizer/external_uses.ll
@@ -7,10 +7,9 @@ define void @external_users(ptr %ptr) {
 ; CHECK-LABEL: define void @external_users(
 ; CHECK-SAME: ptr [[PTR:%.*]]) {
 ; CHECK-NEXT:    [[PTR0:%.*]] = getelementptr float, ptr [[PTR]], i32 0
-; CHECK-NEXT:    [[LD0:%.*]] = load float, ptr [[PTR0]], align 4
 ; CHECK-NEXT:    [[VECL:%.*]] = load <2 x float>, ptr [[PTR0]], align 4, !sandboxvec [[META0:![0-9]+]]
-; CHECK-NEXT:    [[SUB0:%.*]] = fsub float [[LD0]], 0.000000e+00
 ; CHECK-NEXT:    [[VEC:%.*]] = fsub <2 x float> [[VECL]], zeroinitializer, !sandboxvec [[META0]]
+; CHECK-NEXT:    [[SUB0:%.*]] = extractelement <2 x float> [[VEC]], i32 0, !sandboxvec [[META0]]
 ; CHECK-NEXT:    store <2 x float> [[VEC]], ptr [[PTR0]], align 4, !sandboxvec [[META0]]
 ; CHECK-NEXT:    [[USER:%.*]] = fneg float [[SUB0]]
 ; CHECK-NEXT:    ret void

--- a/llvm/test/Transforms/SandboxVectorizer/external_uses.ll
+++ b/llvm/test/Transforms/SandboxVectorizer/external_uses.ll
@@ -25,6 +25,29 @@ define void @external_users(ptr %ptr) {
   %user = fneg float %sub0
   ret void
 }
+
+; The zexts get vectorized into a constant zero-initializer so the external
+; user is extracting from the constant. Such extracts though get folded.
+define void @external_user_of_constant(ptr %ptr, ptr %ptrX) {
+; CHECK-LABEL: define void @external_user_of_constant(
+; CHECK-SAME: ptr [[PTR:%.*]], ptr [[PTRX:%.*]]) {
+; CHECK-NEXT:    [[PTR0:%.*]] = getelementptr float, ptr [[PTR]], i32 0
+; CHECK-NEXT:    store <2 x i32> zeroinitializer, ptr [[PTR0]], align 4, !sandboxvec [[META1:![0-9]+]]
+; CHECK-NEXT:    store i32 0, ptr [[PTRX]], align 4
+; CHECK-NEXT:    ret void
+;
+  %ptr0 = getelementptr float, ptr %ptr, i32 0
+  %ptr1 = getelementptr float, ptr %ptr, i32 1
+  %zext0 = zext i16 0 to i32
+  %zext1 = zext i16 0 to i32
+  store i32 %zext0, ptr %ptr0
+  store i32 %zext1, ptr %ptr1
+
+  store i32 %zext0, ptr %ptrX   ; External user
+  ret void
+}
+
 ;.
 ; CHECK: [[META0]] = distinct !{!"sandboxregion"}
+; CHECK: [[META1]] = distinct !{!"sandboxregion"}
 ;.

--- a/llvm/test/Transforms/SandboxVectorizer/external_uses.ll
+++ b/llvm/test/Transforms/SandboxVectorizer/external_uses.ll
@@ -53,10 +53,7 @@ define void @vector_external_users(ptr %ptr) {
 ; CHECK-NEXT:    [[PTR0:%.*]] = getelementptr float, ptr [[PTR]], i32 0
 ; CHECK-NEXT:    [[VECL:%.*]] = load <3 x float>, ptr [[PTR0]], align 4, !sandboxvec [[META2:![0-9]+]]
 ; CHECK-NEXT:    [[VEC:%.*]] = fsub <3 x float> [[VECL]], zeroinitializer, !sandboxvec [[META2]]
-; CHECK-NEXT:    [[UNPACKEXT:%.*]] = extractelement <3 x float> [[VEC]], i32 1, !sandboxvec [[META2]]
-; CHECK-NEXT:    [[UNPACKINS:%.*]] = insertelement <2 x float> poison, float [[UNPACKEXT]], i32 0, !sandboxvec [[META2]]
-; CHECK-NEXT:    [[UNPACKEXT1:%.*]] = extractelement <3 x float> [[VEC]], i32 2, !sandboxvec [[META2]]
-; CHECK-NEXT:    [[UNPACKINS2:%.*]] = insertelement <2 x float> [[UNPACKINS]], float [[UNPACKEXT1]], i32 1, !sandboxvec [[META2]]
+; CHECK-NEXT:    [[UNPACKINS2:%.*]] = shufflevector <3 x float> [[VEC]], <3 x float> poison, <2 x i32> <i32 1, i32 2>, !sandboxvec [[META2]]
 ; CHECK-NEXT:    store <3 x float> [[VEC]], ptr [[PTR0]], align 4, !sandboxvec [[META2]]
 ; CHECK-NEXT:    [[USER:%.*]] = fneg <2 x float> [[UNPACKINS2]]
 ; CHECK-NEXT:    ret void

--- a/llvm/test/Transforms/SandboxVectorizer/scheduler.ll
+++ b/llvm/test/Transforms/SandboxVectorizer/scheduler.ll
@@ -57,8 +57,7 @@ define <4 x float> @check_top_of_schedule(ptr %0) {
 ; CHECK-SAME: ptr [[TMP0:%.*]]) {
 ; CHECK-NEXT:    [[INS_1:%.*]] = insertelement <4 x float> zeroinitializer, float poison, i64 0
 ; CHECK-NEXT:    [[GEP_1:%.*]] = getelementptr double, ptr [[TMP0]], i64 1
-; CHECK-NEXT:    [[TRUNC_1:%.*]] = fptrunc double 0.000000e+00 to float
-; CHECK-NEXT:    [[INS_2:%.*]] = insertelement <4 x float> [[INS_1]], float [[TRUNC_1]], i64 0
+; CHECK-NEXT:    [[INS_2:%.*]] = insertelement <4 x float> [[INS_1]], float 0.000000e+00, i64 0
 ; CHECK-NEXT:    store <2 x double> <double 0.000000e+00, double 1.000000e+00>, ptr [[GEP_1]], align 8, !sandboxvec [[META1:![0-9]+]]
 ; CHECK-NEXT:    ret <4 x float> [[INS_2]]
 ;

--- a/llvm/unittests/Transforms/Vectorize/SandboxVectorizer/InstrMapsTest.cpp
+++ b/llvm/unittests/Transforms/Vectorize/SandboxVectorizer/InstrMapsTest.cpp
@@ -59,6 +59,8 @@ define void @foo(i8 %v0, i8 %v1, i8 %v2, i8 %v3, <2 x i8> %vec) {
     sandboxir::Action A(nullptr, {Add0}, {}, 0);
     EXPECT_EQ(IMaps.getVectorForOrig(Add0), nullptr);
     EXPECT_EQ(IMaps.getVectorForOrig(Add1), nullptr);
+    EXPECT_FALSE(IMaps.isVectorized(Add0));
+    EXPECT_FALSE(IMaps.isVectorized(Add1));
     EXPECT_FALSE(IMaps.getOrigLane(&A, Add0));
   }
   {
@@ -68,6 +70,8 @@ define void @foo(i8 %v0, i8 %v1, i8 %v2, i8 %v3, <2 x i8> %vec) {
     IMaps.registerVector({Add0, Add1}, &A);
     EXPECT_EQ(IMaps.getVectorForOrig(Add0), &A);
     EXPECT_EQ(IMaps.getVectorForOrig(Add1), &A);
+    EXPECT_TRUE(IMaps.isVectorized(Add0));
+    EXPECT_TRUE(IMaps.getVectorForOrig(Add1));
     EXPECT_FALSE(IMaps.getOrigLane(&A, VAdd0));     // Bad Orig value
     EXPECT_FALSE(IMaps.getOrigLane(&OtherA, Add0)); // Bad Vector value
     EXPECT_EQ(*IMaps.getOrigLane(&A, Add0), 0U);

--- a/llvm/unittests/Transforms/Vectorize/SandboxVectorizer/VecUtilsTest.cpp
+++ b/llvm/unittests/Transforms/Vectorize/SandboxVectorizer/VecUtilsTest.cpp
@@ -634,7 +634,7 @@ bb0:
   sandboxir::Value *Vec = F.getArg(0);
   sandboxir::Value *Scalar = F.getArg(1);
 
-  auto *Int32Ty = sandboxir::Type::getInt32Ty(Ctx);;
+  auto *Int32Ty = sandboxir::Type::getInt32Ty(Ctx);
 
   // Check unpacking scalars.
   auto WhereIt = It;
@@ -645,20 +645,23 @@ bb0:
     EXPECT_EQ(ExtrI->getOperand(1), sandboxir::ConstantInt::get(Int32Ty, Lane));
     ExtrI->eraseFromParent();
   }
-  // Check assertions.
-  EXPECT_DEBUG_DEATH(sandboxir::VecUtils::unpack(Scalar, Int32Ty, 0, WhereIt),
-                     ".*vector.*");
-  EXPECT_DEBUG_DEATH(sandboxir::VecUtils::unpack(Vec, Int32Ty, 4, WhereIt),
-                     "Out of bounds.*");
   auto *Int8Ty = sandboxir::Type::getInt8Ty(Ctx);
-  EXPECT_DEBUG_DEATH(sandboxir::VecUtils::unpack(Vec, Int8Ty, 0, WhereIt),
-                     ".*element type.*");
+  // Check assertions.
+#ifndef NDEBUG
+  EXPECT_DEATH(sandboxir::VecUtils::unpack(Scalar, Int32Ty, 0, WhereIt),
+               ".*vector.*");
+  EXPECT_DEATH(sandboxir::VecUtils::unpack(Vec, Int32Ty, 4, WhereIt),
+               "Out of bounds.*");
+  EXPECT_DEATH(sandboxir::VecUtils::unpack(Vec, Int8Ty, 0, WhereIt),
+               ".*element type.*");
+#endif // NDEBUG
 
   // Check unpacking vectors.
   auto *ExtrTy = sandboxir::FixedVectorType::get(Int32Ty, 2);
   auto *VecTy = cast<sandboxir::FixedVectorType>(Vec->getType());
   for (unsigned Lane = 0; Lane != 2; ++Lane) {
-    auto *Shuff = cast<sandboxir::ShuffleVectorInst>(sandboxir::VecUtils::unpack(Vec, ExtrTy, Lane, WhereIt));
+    auto *Shuff = cast<sandboxir::ShuffleVectorInst>(
+        sandboxir::VecUtils::unpack(Vec, ExtrTy, Lane, WhereIt));
     EXPECT_EQ(Shuff->getOperand(0), Vec);
     EXPECT_EQ(Shuff->getOperand(1), sandboxir::PoisonValue::get(VecTy));
     auto Mask = Shuff->getShuffleMask();

--- a/llvm/unittests/Transforms/Vectorize/SandboxVectorizer/VecUtilsTest.cpp
+++ b/llvm/unittests/Transforms/Vectorize/SandboxVectorizer/VecUtilsTest.cpp
@@ -656,34 +656,15 @@ bb0:
 
   // Check unpacking vectors.
   auto *ExtrTy = sandboxir::FixedVectorType::get(Int32Ty, 2);
+  auto *VecTy = cast<sandboxir::FixedVectorType>(Vec->getType());
   for (unsigned Lane = 0; Lane != 2; ++Lane) {
-    auto *InsI1 = cast<sandboxir::InsertElementInst>(
-        sandboxir::VecUtils::unpack(Vec, ExtrTy, Lane, WhereIt));
-    auto *ExtrI1 = cast<sandboxir::ExtractElementInst>(InsI1->getPrevNode());
-    auto *InsI0 = cast<sandboxir::InsertElementInst>(ExtrI1->getPrevNode());
-    auto *ExtrI0 = cast<sandboxir::ExtractElementInst>(InsI0->getPrevNode());
+    auto *Shuff = cast<sandboxir::ShuffleVectorInst>(sandboxir::VecUtils::unpack(Vec, ExtrTy, Lane, WhereIt));
+    EXPECT_EQ(Shuff->getOperand(0), Vec);
+    EXPECT_EQ(Shuff->getOperand(1), sandboxir::PoisonValue::get(VecTy));
+    auto Mask = Shuff->getShuffleMask();
+    EXPECT_THAT(Mask, testing::ElementsAre(Lane, Lane + 1));
 
-    EXPECT_EQ(ExtrI0->getOperand(0), Vec);
-    EXPECT_EQ(ExtrI0->getOperand(1), sandboxir::ConstantInt::get(Int32Ty, Lane));
-
-    EXPECT_EQ(InsI0->getOperand(0), sandboxir::PoisonValue::get(ExtrTy));
-    EXPECT_EQ(InsI0->getOperand(1), ExtrI0);
-    EXPECT_EQ(
-        cast<sandboxir::ConstantInt>(InsI0->getOperand(2))->getZExtValue(), 0u);
-
-    EXPECT_EQ(ExtrI1->getOperand(0), Vec);
-    EXPECT_EQ(
-        cast<sandboxir::ConstantInt>(ExtrI1->getOperand(1))->getZExtValue(),
-        Lane + 1u);
-
-    EXPECT_EQ(InsI1->getOperand(0), InsI0);
-    EXPECT_EQ(InsI1->getOperand(1), ExtrI1);
-    EXPECT_EQ(InsI1->getOperand(2), sandboxir::ConstantInt::get(Int32Ty, 1));
-
-    InsI1->eraseFromParent();
-    ExtrI1->eraseFromParent();
-    InsI0->eraseFromParent();
-    ExtrI0->eraseFromParent();
+    Shuff->eraseFromParent();
   }
   // Check out of bounds!.
   auto *Ty2xi32 = sandboxir::FixedVectorType::get(Int32Ty, 2);

--- a/llvm/unittests/Transforms/Vectorize/SandboxVectorizer/VecUtilsTest.cpp
+++ b/llvm/unittests/Transforms/Vectorize/SandboxVectorizer/VecUtilsTest.cpp
@@ -617,3 +617,81 @@ bb1:
       EXPECT_FALSE(sandboxir::VecUtils::matchPack(NotPack));
   }
 }
+
+TEST_F(VecUtilsTest, Unpack) {
+  parseIR(R"IR(
+define void @foo(<4 x i32> %vec, i32 %scalar) {
+bb0:
+  ret void
+}
+)IR");
+  Function &LLVMF = *M->getFunction("foo");
+
+  sandboxir::Context Ctx(C);
+  auto &F = *Ctx.createFunction(&LLVMF);
+  auto &BB = getBasicBlockByName(F, "bb0");
+  auto It = BB.begin();
+  sandboxir::Value *Vec = F.getArg(0);
+  sandboxir::Value *Scalar = F.getArg(1);
+
+  auto *Int32Ty = sandboxir::Type::getInt32Ty(Ctx);;
+
+  // Check unpacking scalars.
+  auto WhereIt = It;
+  for (unsigned Lane = 0; Lane != 4; ++Lane) {
+    auto *ExtrI = cast<sandboxir::ExtractElementInst>(
+        sandboxir::VecUtils::unpack(Vec, Int32Ty, Lane, WhereIt));
+    EXPECT_EQ(ExtrI->getOperand(0), Vec);
+    EXPECT_EQ(ExtrI->getOperand(1), sandboxir::ConstantInt::get(Int32Ty, Lane));
+    ExtrI->eraseFromParent();
+  }
+  // Check assertions.
+  EXPECT_DEBUG_DEATH(sandboxir::VecUtils::unpack(Scalar, Int32Ty, 0, WhereIt),
+                     ".*vector.*");
+  EXPECT_DEBUG_DEATH(sandboxir::VecUtils::unpack(Vec, Int32Ty, 4, WhereIt),
+                     "Out of bounds.*");
+  auto *Int8Ty = sandboxir::Type::getInt8Ty(Ctx);
+  EXPECT_DEBUG_DEATH(sandboxir::VecUtils::unpack(Vec, Int8Ty, 0, WhereIt),
+                     ".*element type.*");
+
+  // Check unpacking vectors.
+  auto *ExtrTy = sandboxir::FixedVectorType::get(Int32Ty, 2);
+  for (unsigned Lane = 0; Lane != 2; ++Lane) {
+    auto *InsI1 = cast<sandboxir::InsertElementInst>(
+        sandboxir::VecUtils::unpack(Vec, ExtrTy, Lane, WhereIt));
+    auto *ExtrI1 = cast<sandboxir::ExtractElementInst>(InsI1->getPrevNode());
+    auto *InsI0 = cast<sandboxir::InsertElementInst>(ExtrI1->getPrevNode());
+    auto *ExtrI0 = cast<sandboxir::ExtractElementInst>(InsI0->getPrevNode());
+
+    EXPECT_EQ(ExtrI0->getOperand(0), Vec);
+    EXPECT_EQ(ExtrI0->getOperand(1), sandboxir::ConstantInt::get(Int32Ty, Lane));
+
+    EXPECT_EQ(InsI0->getOperand(0), sandboxir::PoisonValue::get(ExtrTy));
+    EXPECT_EQ(InsI0->getOperand(1), ExtrI0);
+    EXPECT_EQ(
+        cast<sandboxir::ConstantInt>(InsI0->getOperand(2))->getZExtValue(), 0u);
+
+    EXPECT_EQ(ExtrI1->getOperand(0), Vec);
+    EXPECT_EQ(
+        cast<sandboxir::ConstantInt>(ExtrI1->getOperand(1))->getZExtValue(),
+        Lane + 1u);
+
+    EXPECT_EQ(InsI1->getOperand(0), InsI0);
+    EXPECT_EQ(InsI1->getOperand(1), ExtrI1);
+    EXPECT_EQ(InsI1->getOperand(2), sandboxir::ConstantInt::get(Int32Ty, 1));
+
+    InsI1->eraseFromParent();
+    ExtrI1->eraseFromParent();
+    InsI0->eraseFromParent();
+    ExtrI0->eraseFromParent();
+  }
+  // Check out of bounds!.
+  auto *Ty2xi32 = sandboxir::FixedVectorType::get(Int32Ty, 2);
+  EXPECT_DEBUG_DEATH(sandboxir::VecUtils::unpack(Vec, Ty2xi32, 3, WhereIt),
+                     "Out of bounds.*");
+  EXPECT_DEBUG_DEATH(sandboxir::VecUtils::unpack(Vec, Ty2xi32, 4, WhereIt),
+                     "Out of bounds.*");
+  auto *Ty2xi8 = sandboxir::FixedVectorType::get(Int8Ty, 2);
+  EXPECT_DEBUG_DEATH(sandboxir::VecUtils::unpack(Vec, Ty2xi8, 4, WhereIt),
+                     ".*type.*");
+}


### PR DESCRIPTION
Up until now the bottom-up vectorizer pass would not delete the scalar instructions that have external uses after being vectorized, because it lacked the ability to generate extracts from the vectors.
With the term "external uses", we refer to uses outside the currently vectorized graph.

This patch fixes this. We can now properly handle external uses by extracting from the vectors.

This change relies on the recent changes to the DAG's callbacks because the external user may not be within the current DAG's interval.