### PR TITLE
[clang-doc] Cleanup CMake files and ensure benchmarks build

### DIFF
--- a/clang-tools-extra/clang-doc/CMakeLists.txt
+++ b/clang-tools-extra/clang-doc/CMakeLists.txt
@@ -40,7 +40,7 @@ clang_target_link_libraries(clangDoc
 
 target_link_libraries(clangDoc
   PRIVATE
-  clangDocSupport      
+  clangDocSupport
   )
 
 add_subdirectory(tool)

--- a/clang-tools-extra/clang-doc/benchmarks/CMakeLists.txt
+++ b/clang-tools-extra/clang-doc/benchmarks/CMakeLists.txt
@@ -12,9 +12,4 @@ target_include_directories(ClangDocBenchmark
 target_link_libraries(ClangDocBenchmark
   PRIVATE
   clangDoc
-  clangTooling
-  clangBasic
-  clangAST
-  clangFrontend
-  clangSerialization
 )

--- a/clang-tools-extra/test/clang-doc/CMakeLists.txt
+++ b/clang-tools-extra/test/clang-doc/CMakeLists.txt
@@ -5,3 +5,7 @@ add_lit_testsuite(check-clang-extra-clang-doc "Running clang-doc tests"
   DEPENDS clang-doc
   DEPENDS ${LLVM_UTILS_DEPS}
 )
+
+if (LLVM_INCLUDE_BENCHMARKS)
+   add_dependencies(check-clang-extra-clang-doc ClangDocBenchmark)
+endif()


### PR DESCRIPTION
There's some poor formatting, and ClangDocBenchmark references several
targets that are required, but only because they're required for
clang-doc itself. We can just get those requirements from the clangDoc
target.

Additionally, we can make sure the benchmark builds as part of testing
when LLVM_INCLUDE_BENCHMARKS is set.