### PR TITLE
[clang][bytecode] Check for integral types in evaluateStrlen

### DIFF
--- a/clang/lib/AST/ByteCode/Compiler.cpp
+++ b/clang/lib/AST/ByteCode/Compiler.cpp
@@ -3469,7 +3469,8 @@ bool Compiler<Emitter>::VisitCXXReinterpretCastExpr(
 
     bool Fatal = true;
     if (PointeeToT && PointeeFromT) {
-      if (isIntegralType(*PointeeFromT) && isIntegralType(*PointeeToT))
+      if (isIntegerOrBoolType(*PointeeFromT) &&
+          isIntegerOrBoolType(*PointeeToT))
         Fatal = false;
       else if (E->getCastKind() == CK_LValueBitCast)
         Fatal = false;
@@ -4504,7 +4505,7 @@ bool Compiler<Emitter>::VisitCXXStdInitializerListExpr(
     return false;
 
   PrimType SecondFieldT = classifyPrim(R->getField(1u)->Decl->getType());
-  if (isIntegralType(SecondFieldT)) {
+  if (isIntegerOrBoolType(SecondFieldT)) {
     if (!this->emitConst(ArrayType->getSize(), SecondFieldT, E))
       return false;
     return this->emitInitField(SecondFieldT, R->getField(1u)->Offset, E);
@@ -7043,12 +7044,12 @@ bool Compiler<Emitter>::VisitUnaryOperator(const UnaryOperator *E) {
       if (!this->emitStoreFloat(E))
         return false;
     } else if (SubExpr->refersToBitField()) {
-      assert(isIntegralType(*T));
+      assert(isIntegerOrBoolType(*T));
       if (!this->emitPreIncBitfield(*T, E->canOverflow(), getBitWidth(SubExpr),
                                     E))
         return false;
     } else {
-      assert(isIntegralType(*T));
+      assert(isIntegerOrBoolType(*T));
       if (!this->emitPreInc(*T, E->canOverflow(), E))
         return false;
     }
@@ -7098,12 +7099,12 @@ bool Compiler<Emitter>::VisitUnaryOperator(const UnaryOperator *E) {
       if (!this->emitStoreFloat(E))
         return false;
     } else if (SubExpr->refersToBitField()) {
-      assert(isIntegralType(*T));
+      assert(isIntegerOrBoolType(*T));
       if (!this->emitPreDecBitfield(*T, E->canOverflow(), getBitWidth(SubExpr),
                                     E))
         return false;
     } else {
-      assert(isIntegralType(*T));
+      assert(isIntegerOrBoolType(*T));
       if (!this->emitPreDec(*T, E->canOverflow(), E))
         return false;
     }
@@ -7625,18 +7626,18 @@ bool Compiler<Emitter>::emitPrimCast(PrimType FromT, PrimType ToT,
                                                getFPOptions(E), E);
 
     // Float to integral.
-    if (isIntegralType(ToT) || ToT == PT_Bool)
+    if (isIntegerOrBoolType(ToT) || ToT == PT_Bool)
       return this->emitCastFloatingIntegral(ToT, getFPOptions(E), E);
   }
 
-  if (isIntegralType(FromT) || FromT == PT_Bool) {
+  if (isIntegerOrBoolType(FromT) || FromT == PT_Bool) {
     if (ToT == PT_IntAP)
       return this->emitCastAP(FromT, Ctx.getBitWidth(ToQT), E);
     if (ToT == PT_IntAPS)
       return this->emitCastAPS(FromT, Ctx.getBitWidth(ToQT), E);
 
     // Integral to integral.
-    if (isIntegralType(ToT) || ToT == PT_Bool)
+    if (isIntegerOrBoolType(ToT) || ToT == PT_Bool)
       return FromT != ToT ? this->emitCast(FromT, ToT, E) : true;
 
     if (ToT == PT_Float) {

--- a/clang/lib/AST/ByteCode/Context.cpp
+++ b/clang/lib/AST/ByteCode/Context.cpp
@@ -304,6 +304,10 @@ std::optional<uint64_t> Context::evaluateStrlen(State &Parent, const Expr *E) {
     if (Ptr.isDummy() || Ptr.isUnknownSizeArray() || Ptr.isPastEnd())
       return false;
 
+    PrimType ElemT = FieldDesc->getPrimType();
+    if (!isIntegerType(ElemT))
+      return false;
+
     unsigned N = Ptr.getNumElems();
     if (Ptr.elemSize() == 1) {
       unsigned Size = N - Ptr.getIndex();
@@ -312,7 +316,6 @@ std::optional<uint64_t> Context::evaluateStrlen(State &Parent, const Expr *E) {
       return Result != Size;
     }
 
-    PrimType ElemT = FieldDesc->getPrimType();
     Result = 0;
     for (unsigned I = Ptr.getIndex(); I != N; ++I) {
       INT_TYPE_SWITCH(ElemT, {

--- a/clang/lib/AST/ByteCode/Interp.h
+++ b/clang/lib/AST/ByteCode/Interp.h
@@ -708,7 +708,7 @@ bool Neg(InterpState &S, CodePtr OpPC) {
       return true;
     }
 
-    assert(isIntegralType(Name) &&
+    assert(isIntegerType(Name) &&
            "don't expect other types to fail at constexpr negation");
     S.Stk.push<T>(Result);
 

--- a/clang/lib/AST/ByteCode/InterpBuiltin.cpp
+++ b/clang/lib/AST/ByteCode/InterpBuiltin.cpp
@@ -1193,7 +1193,7 @@ static bool interp__builtin_is_aligned_up_down(InterpState &S, CodePtr OpPC,
   // The first parameter is either an integer or a pointer.
   PrimType FirstArgT = *S.Ctx.classify(Call->getArg(0));
 
-  if (isIntegralType(FirstArgT)) {
+  if (isIntegerType(FirstArgT)) {
     const APSInt &Src = popToAPSInt(S.Stk, FirstArgT);
     APInt AlignMinusOne = Alignment.extOrTrunc(Src.getBitWidth()) - 1;
     if (BuiltinOp == Builtin::BI__builtin_align_up) {

--- a/clang/lib/AST/ByteCode/PrimType.h
+++ b/clang/lib/AST/ByteCode/PrimType.h
@@ -49,6 +49,26 @@ enum PrimType : uint8_t {
   PT_MemberPtr = 14,
 };
 
+constexpr bool isIntegerOrBoolType(PrimType T) { return T <= PT_Bool; }
+constexpr bool isIntegerType(PrimType T) { return T <= PT_IntAPS; }
+
+inline constexpr bool isPtrType(PrimType T) {
+  return T == PT_Ptr || T == PT_MemberPtr;
+}
+
+inline constexpr bool isSignedType(PrimType T) {
+  switch (T) {
+  case PT_Sint8:
+  case PT_Sint16:
+  case PT_Sint32:
+  case PT_Sint64:
+    return true;
+  default:
+    return false;
+  }
+  return false;
+}
+
 // Like std::optional<PrimType>, but only sizeof(PrimType).
 class OptPrimType final {
   static constexpr uint8_t None = 0xFF;
@@ -82,23 +102,6 @@ public:
 };
 static_assert(sizeof(OptPrimType) == sizeof(PrimType));
 
-inline constexpr bool isPtrType(PrimType T) {
-  return T == PT_Ptr || T == PT_MemberPtr;
-}
-
-inline constexpr bool isSignedType(PrimType T) {
-  switch (T) {
-  case PT_Sint8:
-  case PT_Sint16:
-  case PT_Sint32:
-  case PT_Sint64:
-    return true;
-  default:
-    return false;
-  }
-  return false;
-}
-
 enum class CastKind : uint8_t {
   Reinterpret,
   ReinterpretLike,
@@ -125,7 +128,6 @@ inline llvm::raw_ostream &operator<<(llvm::raw_ostream &OS,
   return OS;
 }
 
-constexpr bool isIntegralType(PrimType T) { return T <= PT_FixedPoint; }
 template <typename T> constexpr bool needsAlloc() {
   return std::is_same_v<T, IntegralAP<false>> ||
          std::is_same_v<T, IntegralAP<true>> || std::is_same_v<T, Floating> ||

--- a/clang/test/AST/ByteCode/c.c
+++ b/clang/test/AST/ByteCode/c.c
@@ -439,3 +439,10 @@ char *strcpy(char *restrict s1, const char *restrict s2);
 void strcpy_fn(char *x) {
   strcpy(x, (char*)&strcpy_fn);
 }
+
+/// strcpy on a non-integer pointer.
+void strcpyDouble(void) {
+  char buf[1];
+  const double test_buf[] = {'4', '2'};
+  __builtin_strcpy(buf, test_buf + 1); // all-error {{incompatible pointer types}}
+}


### PR DESCRIPTION
The pointer might point to a primitive array of non-integer type.