### PR TITLE
[flang][cuda] Relax host intrinsic semantic check in acc routine

### DIFF
--- a/flang/include/flang/Semantics/tools.h
+++ b/flang/include/flang/Semantics/tools.h
@@ -46,6 +46,7 @@ const Scope *FindModuleOrSubmoduleContaining(const Scope &);
 const Scope *FindModuleFileContaining(const Scope &);
 const Scope *FindPureProcedureContaining(const Scope &);
 const Scope *FindOpenACCConstructContaining(const Scope *);
+bool HasOpenACCRoutineDirective(const Scope *);
 
 const Symbol *FindInterface(const Symbol &);
 const Symbol *FindSubprogram(const Symbol &);

--- a/flang/lib/Semantics/check-call.cpp
+++ b/flang/lib/Semantics/check-call.cpp
@@ -1178,10 +1178,12 @@ static void CheckExplicitDataArg(const characteristics::DummyDataObject &dummy,
           dummyName, toStr(dummyDataAttr), toStr(actualDataAttr));
     }
   }
+
   // Emit an error message if an actual argument passed to a host intrinsic is
   // on the device.
   if (intrinsic && !FindCUDADeviceContext(scope) &&
-      !FindOpenACCConstructContaining(scope)) {
+      !FindOpenACCConstructContaining(scope) &&
+      !HasOpenACCRoutineDirective(scope)) {
     if (!cudaSkippedIntrinsics.contains(intrinsic->name)) {
       std::optional<common::CUDADataAttr> actualDataAttr;
       if (const auto *actualObject{actualLastSymbol

--- a/flang/lib/Semantics/tools.cpp
+++ b/flang/lib/Semantics/tools.cpp
@@ -122,6 +122,19 @@ const Scope *FindOpenACCConstructContaining(const Scope *scope) {
                : nullptr;
 }
 
+bool HasOpenACCRoutineDirective(const Scope *scope) {
+  if (!scope) {
+    return false;
+  }
+  const Scope &progUnit{GetProgramUnitContaining(*scope)};
+  if (const Symbol *symbol{progUnit.symbol()}) {
+    if (const auto *subpDetails{symbol->detailsIf<SubprogramDetails>()}) {
+      return !subpDetails->openACCRoutineInfos().empty();
+    }
+  }
+  return false;
+}
+
 // 7.5.2.4 "same derived type" test -- rely on IsTkCompatibleWith() and its
 // infrastructure to detect and handle comparisons on distinct (but "same")
 // sequence/bind(C) derived types

--- a/flang/test/Semantics/cuf23.cuf
+++ b/flang/test/Semantics/cuf23.cuf
@@ -81,5 +81,24 @@ end subroutine
 subroutine intrinsic_error_skip_show_descriptor(n)
   use flang_debug
   real(8), allocatable, device :: d(:)
-  call show_descriptor(d) ! ok, descriptore in managed memory
+  call show_descriptor(d) ! ok, descriptor in managed memory
 end subroutine
+
+double complex function acc_routine_check(n, x, y)
+  !$acc routine(acc_routine_check) vector
+  implicit none
+  integer :: n, i
+  double complex, device, dimension(*) :: x, y
+  double complex :: temp
+  intrinsic dconjg
+  
+  !$acc loop vector reduction(+:temp)
+  do i = 1, n
+    ! Check that the error message is not not triggered since the subprogram has
+    ! an OpenACC routine directive.
+    !   Actual argument x associated with host intrinsic conjg is on the device
+    temp = temp + dconjg(x(i))*y(i)
+  end do
+  acc_routine_check = temp
+  return
+end function acc_routine_check

--- a/flang/test/Semantics/cuf23.cuf
+++ b/flang/test/Semantics/cuf23.cuf
@@ -94,7 +94,7 @@ double complex function acc_routine_check(n, x, y)
   
   !$acc loop vector reduction(+:temp)
   do i = 1, n
-    ! Check that the error message is not not triggered since the subprogram has
+    ! Check that the error message is not triggered since the subprogram has
     ! an OpenACC routine directive.
     !   Actual argument x associated with host intrinsic conjg is on the device
     temp = temp + dconjg(x(i))*y(i)


### PR DESCRIPTION
Semantic check that checks if any actual argument is on the device doesn't need to be active in acc routine function/subroutine. 