### PR TITLE
[flang] Improve error message for missing primary expression

### DIFF
--- a/flang/lib/Parser/expr-parsers.cpp
+++ b/flang/lib/Parser/expr-parsers.cpp
@@ -80,10 +80,13 @@ constexpr auto primary{instrumented("primary"_en_US,
         // PGI/XLF extension: COMPLEX constructor (x,y)
         construct<Expr>(parenthesized(
             construct<Expr::ComplexConstructor>(expr, "," >> expr))),
-        extension<LanguageFeature::PercentLOC>(
-            "nonstandard usage: %LOC"_port_en_US,
-            construct<Expr>("%LOC" >> parenthesized(construct<Expr::PercentLoc>(
-                                          indirect(variable)))))))};
+        // prevent confusing error on missing primary expression
+        lookAhead("%LOC"_tok) >>
+            extension<LanguageFeature::PercentLOC>(
+                "nonstandard usage: %LOC"_port_en_US,
+                construct<Expr>("%LOC" >>
+                    parenthesized(
+                        construct<Expr::PercentLoc>(indirect(variable)))))))};
 
 // R1002 level-1-expr -> [defined-unary-op] primary
 // TODO: Reasonable extension: permit multiple defined-unary-ops

--- a/flang/test/Parser/bug2364.f90
+++ b/flang/test/Parser/bug2364.f90
@@ -1,0 +1,8 @@
+!RUN: not %flang_fc1 -fsyntax-only %s 2>&1 | FileCheck %s
+logical b
+a = 0.
+!CHECK: error: expected '('
+!CHECK-NOT: error: expected '%LOC'
+b = .t.
+c = 0.
+end


### PR DESCRIPTION
Don't mention the possible expectation that the extension %LOC() could appear when emitting the error messages for a completely missing primary expression; it's just confusing.