### PR TITLE
[Offload][AMDGPU] Fix RPC server on mixed w32 w64 workloads

### DIFF
--- a/offload/plugins-nextgen/amdgpu/src/rtl.cpp
+++ b/offload/plugins-nextgen/amdgpu/src/rtl.cpp
@@ -503,6 +503,16 @@ struct AMDGPUDeviceImageTy : public DeviceImageTy {
     return It->second;
   }
 
+  /// Return the maximum wavefront size across all known kernels in this image.
+  uint32_t getMaxWavefrontSize() const {
+    uint32_t Max = 0;
+    for (const auto &[Name, Info] : KernelInfoMap)
+      if (Info.WavefrontSize !=
+          offloading::amdgpu::AMDGPUKernelMetaData::KInvalidValue)
+        Max = std::max(Max, Info.WavefrontSize);
+    return Max;
+  }
+
 private:
   /// The executable loaded on the agent.
   hsa_executable_t Executable;
@@ -2352,6 +2362,11 @@ struct AMDGPUDeviceTy : public GenericDeviceTy, AMDGenericDeviceTy {
     return getHardwareParallelism();
   }
 
+  /// In cases of mixed wave32 and wave64 code we need to over-alloacte memory.
+  uint32_t getRPCNumLanes() const override {
+    return MaxWavefrontSize ? MaxWavefrontSize : getWarpSize();
+  }
+
   /// Get the stream of the asynchronous info structure or get a new one.
   Error getStream(AsyncInfoWrapperTy &AsyncInfoWrapper,
                   AMDGPUStreamTy *&Stream) {
@@ -2374,6 +2389,9 @@ struct AMDGPUDeviceTy : public GenericDeviceTy, AMDGenericDeviceTy {
     // Load the HSA executable.
     if (Error Err = AMDImage->loadExecutable(*this))
       return std::move(Err);
+
+    if (uint32_t WFS = AMDImage->getMaxWavefrontSize())
+      MaxWavefrontSize = std::max(MaxWavefrontSize, WFS);
 
     return AMDImage;
   }
@@ -3328,6 +3346,9 @@ private:
 
   /// The total number of concurrent work items that can be running on the GPU.
   uint64_t HardwareParallelism;
+
+  /// The largest wavefront size across all loaded images, used for RPC.
+  uint32_t MaxWavefrontSize = 0;
 
   /// Reference to the host device.
   AMDHostDeviceTy &HostDevice;

--- a/offload/plugins-nextgen/common/include/PluginInterface.h
+++ b/offload/plugins-nextgen/common/include/PluginInterface.h
@@ -984,6 +984,9 @@ struct GenericDeviceTy : public DeviceAllocatorTy {
 
   /// Getters of the grid values.
   uint32_t getWarpSize() const { return GridValues.GV_Warp_Size; }
+
+  /// Get the number of lanes used for the RPC interface.
+  virtual uint32_t getRPCNumLanes() const { return getWarpSize(); }
   uint32_t getThreadLimit() const { return GridValues.GV_Max_WG_Size; }
   uint32_t getBlockLimit() const { return GridValues.GV_Max_Teams; }
   uint32_t getDefaultNumThreads() const {

--- a/offload/plugins-nextgen/common/src/RPC.cpp
+++ b/offload/plugins-nextgen/common/src/RPC.cpp
@@ -95,13 +95,13 @@ runServer(plugin::GenericDeviceTy &Device, void *Buffer,
       std::min(Device.requestedRPCPortCount(), rpc::MAX_PORT_COUNT);
   rpc::Server Server(NumPorts, Buffer);
 
-  auto Port = Server.try_open(Device.getWarpSize());
+  auto Port = Server.try_open(Device.getRPCNumLanes());
   if (!Port)
     return rpc::RPC_SUCCESS;
   ClientInUse = true;
 
   rpc::Status Status = rpc::RPC_UNHANDLED_OPCODE;
-  const uint32_t NumLanes = Device.getWarpSize();
+  const uint32_t NumLanes = Device.getRPCNumLanes();
 
   for (RPCServerTy::RPCServerCallbackTy Callback : Callbacks) {
     Status = static_cast<rpc::Status>(Callback(&*Port, NumLanes));
@@ -214,7 +214,7 @@ Error RPCServerTy::initDevice(plugin::GenericDeviceTy &Device,
   uint64_t NumPorts =
       std::min(Device.requestedRPCPortCount(), rpc::MAX_PORT_COUNT);
   auto RPCBufferOrErr = Device.allocate(
-      rpc::Server::allocation_size(Device.getWarpSize(), NumPorts), nullptr,
+      rpc::Server::allocation_size(Device.getRPCNumLanes(), NumPorts), nullptr,
       TARGET_ALLOC_HOST);
   if (!RPCBufferOrErr)
     return RPCBufferOrErr.takeError();


### PR DESCRIPTION
Summary:
This was a regression from the original LLVM-gpu-loader. We used to
handle `-mwavefrontsize64` correctly in the loader by over-allocating
memory and just leaving the upper 32-bits masked off. In order to handle
this in offload we need to scan loaded kernels to see how much memory we
need to allocate. This should be safe, the protocol is designed to
handle an arbitrary size and worst-case this just wastes space.
