### PR TITLE
[SPIR] Do not warn on 64-bit atomics

### DIFF
--- a/clang/lib/Basic/Targets/SPIR.h
+++ b/clang/lib/Basic/Targets/SPIR.h
@@ -276,7 +276,7 @@ public:
     PtrDiffType = IntPtrType = TargetInfo::SignedInt;
     // SPIR32 has support for atomic ops if atomic extension is enabled.
     // Take the maximum because it's possible the Host supports wider types.
-    MaxAtomicInlineWidth = std::max<unsigned char>(MaxAtomicInlineWidth, 32);
+    MaxAtomicInlineWidth = std::max<unsigned char>(MaxAtomicInlineWidth, 64);
     resetDataLayout("e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-"
                     "v96:128-v192:256-v256:256-v512:512-v1024:1024-G1");
   }
@@ -372,7 +372,7 @@ public:
     PtrDiffType = IntPtrType = TargetInfo::SignedInt;
     // SPIR-V has core support for atomic ops, and Int32 is always available;
     // we take the maximum because it's possible the Host supports wider types.
-    MaxAtomicInlineWidth = std::max<unsigned char>(MaxAtomicInlineWidth, 32);
+    MaxAtomicInlineWidth = std::max<unsigned char>(MaxAtomicInlineWidth, 64);
     resetDataLayout();
   }
 

--- a/clang/test/Sema/scoped-atomic-ops.c
+++ b/clang/test/Sema/scoped-atomic-ops.c
@@ -1,6 +1,7 @@
 // RUN: %clang_cc1 -x c -triple=amdgcn-amd-amdhsa -verify -fsyntax-only %s
 // RUN: %clang_cc1 -x c -triple=x86_64-pc-linux-gnu -verify -fsyntax-only %s
 // RUN: %clang_cc1 -x c -triple=spirv64-unknown-unknown -verify -fsyntax-only %s
+// RUN: %clang_cc1 -x c -triple=spir -verify -fsyntax-only %s
 
 int fi1a(int *i) {
   int v;
@@ -142,4 +143,8 @@ float ff3a(float *c, float *d) {
 float ff4a(_Bool *c) {
   return __scoped_atomic_exchange_n(c, 1, __ATOMIC_RELAXED,
                                     __MEMORY_SCOPE_SYSTEM);
+}
+
+void fi8a(long long *p) {
+  __scoped_atomic_store_n(p, 1, __ATOMIC_RELAXED, __MEMORY_SCOPE_SYSTEM);
 }


### PR DESCRIPTION
Summary:
SPIR-V's Int64Atomics capability is not dependent on its addressing mode
as far as I am aware. These 32-bit SPIR targets already claim to support
the cl_khr_int64 atomics and we already emit 64-bit atomics in the
backend. Additionally, this is already accepted as a hack due to the
fact that the host will increase it in offloading usage. I do not see a
reason to keep these at 32, which causes numerous warnings inside of the
`libclc` build.
