### PR TITLE
[libc] Fix implicit lossy conversion warnings in tests (NFC).

### DIFF
--- a/libc/test/src/sys/socket/linux/send_recv_test.cpp
+++ b/libc/test/src/sys/socket/linux/send_recv_test.cpp
@@ -51,12 +51,12 @@ TEST_F(LlvmLibcSendRecvTest, SendFails) {
   const size_t MESSAGE_LEN = sizeof(TEST_MESSAGE);
 
   ASSERT_THAT(LIBC_NAMESPACE::send(-1, TEST_MESSAGE, MESSAGE_LEN, 0),
-              Fails(EBADF));
+              Fails(EBADF, static_cast<ssize_t>(-1)));
 }
 
 TEST_F(LlvmLibcSendRecvTest, RecvFails) {
   char buffer[256];
 
   ASSERT_THAT(LIBC_NAMESPACE::recv(-1, buffer, sizeof(buffer), 0),
-              Fails(EBADF));
+              Fails(EBADF, static_cast<ssize_t>(-1)));
 }

--- a/libc/test/src/sys/socket/linux/sendmsg_recvmsg_test.cpp
+++ b/libc/test/src/sys/socket/linux/sendmsg_recvmsg_test.cpp
@@ -91,7 +91,8 @@ TEST_F(LlvmLibcSendMsgRecvMsgTest, SendFails) {
   send_message.msg_controllen = 0;
   send_message.msg_flags = 0;
 
-  ASSERT_THAT(LIBC_NAMESPACE::sendmsg(-1, &send_message, 0), Fails(EBADF));
+  ASSERT_THAT(LIBC_NAMESPACE::sendmsg(-1, &send_message, 0),
+              Fails(EBADF, static_cast<ssize_t>(-1)));
 }
 
 TEST_F(LlvmLibcSendMsgRecvMsgTest, RecvFails) {
@@ -110,5 +111,6 @@ TEST_F(LlvmLibcSendMsgRecvMsgTest, RecvFails) {
   recv_message.msg_controllen = 0;
   recv_message.msg_flags = 0;
 
-  ASSERT_THAT(LIBC_NAMESPACE::recvmsg(-1, &recv_message, 0), Fails(EBADF));
+  ASSERT_THAT(LIBC_NAMESPACE::recvmsg(-1, &recv_message, 0),
+              Fails(EBADF, static_cast<ssize_t>(-1)));
 }

--- a/libc/test/src/sys/socket/linux/sendto_recvfrom_test.cpp
+++ b/libc/test/src/sys/socket/linux/sendto_recvfrom_test.cpp
@@ -54,7 +54,7 @@ TEST_F(LlvmLibcSendToRecvFromTest, SendToFails) {
 
   ASSERT_THAT(
       LIBC_NAMESPACE::sendto(-1, TEST_MESSAGE, MESSAGE_LEN, 0, nullptr, 0),
-      Fails(EBADF));
+      Fails(EBADF, static_cast<ssize_t>(-1)));
 }
 
 TEST_F(LlvmLibcSendToRecvFromTest, RecvFromFails) {
@@ -62,5 +62,5 @@ TEST_F(LlvmLibcSendToRecvFromTest, RecvFromFails) {
 
   ASSERT_THAT(
       LIBC_NAMESPACE::recvfrom(-1, buffer, sizeof(buffer), 0, nullptr, 0),
-      Fails(EBADF));
+      Fails(EBADF, static_cast<ssize_t>(-1)));
 }

--- a/libc/test/src/time/mktime_test.cpp
+++ b/libc/test/src/time/mktime_test.cpp
@@ -77,7 +77,8 @@ TEST(LlvmLibcMkTime, InvalidSeconds) {
                       .tm_wday = 0,
                       .tm_yday = 0,
                       .tm_isdst = 0};
-    EXPECT_THAT(LIBC_NAMESPACE::mktime(&tm_data), Succeeds(60));
+    EXPECT_THAT(LIBC_NAMESPACE::mktime(&tm_data),
+                Succeeds(static_cast<time_t>(60)));
     EXPECT_TM_EQ((tm{.tm_sec = 0,
                      .tm_min = 1,
                      .tm_hour = 0,


### PR DESCRIPTION
Cast expected error values (-1) to ssize_t for send/recv family of functions.