### PR TITLE
[lldb] Temporarily remove the assert to unblock the bots

### DIFF
--- a/lldb/source/Core/PluginManager.cpp
+++ b/lldb/source/Core/PluginManager.cpp
@@ -493,9 +493,7 @@ template <typename Callback> struct PluginInstance {
 
 template <typename Instance> class PluginInstances {
 public:
-  ~PluginInstances() {
-    assert(m_instances.empty() && "forgot to unregister plugin?");
-  }
+  ~PluginInstances() {}
 
   template <typename... Args>
   bool RegisterPlugin(llvm::StringRef name, llvm::StringRef description,


### PR DESCRIPTION
The assert is triggering from Dexter in the cross-project-test. This temporarily removes the assert while I address the issue.