### PR TITLE
[HLSL][Matrix] Add `half` type overloads to `mul` and exercise them

### DIFF
--- a/clang/lib/Headers/hlsl/hlsl_alias_intrinsics.h
+++ b/clang/lib/Headers/hlsl/hlsl_alias_intrinsics.h
@@ -1810,16 +1810,31 @@ double4 min(double4, double4);
 // directly to HLSL.
 
 // Case 6: vector * matrix -> vector
+template <int R, int C>
+_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_BUILTIN_ALIAS(__builtin_hlsl_mul) vector<half, C> mul(vector<half, R>,
+                                                            matrix<half, R, C>);
+
 template <typename T, int R, int C>
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_mul)
 vector<T, C> mul(vector<T, R>, matrix<T, R, C>);
 
 // Case 8: matrix * vector -> vector
+template <int R, int C>
+_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_BUILTIN_ALIAS(__builtin_hlsl_mul) vector<half, R> mul(matrix<half, R, C>,
+                                                            vector<half, C>);
+
 template <typename T, int R, int C>
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_mul)
 vector<T, R> mul(matrix<T, R, C>, vector<T, C>);
 
 // Case 9: matrix * matrix -> matrix
+template <int R, int K, int C>
+_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_BUILTIN_ALIAS(__builtin_hlsl_mul) matrix<half, R, C> mul(
+    matrix<half, R, K>, matrix<half, K, C>);
+
 template <typename T, int R, int K, int C>
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_mul)
 matrix<T, R, C> mul(matrix<T, R, K>, matrix<T, K, C>);

--- a/clang/lib/Headers/hlsl/hlsl_intrinsics.h
+++ b/clang/lib/Headers/hlsl/hlsl_intrinsics.h
@@ -826,33 +826,72 @@ fwidth(__detail::HLSL_FIXED_VECTOR<float, N> input) {
 
 // Case 1: scalar * scalar -> scalar
 template <typename T>
-constexpr __detail::enable_if_t<__detail::is_arithmetic<T>::Value, T> mul(T x,
-                                                                          T y) {
+_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+constexpr __detail::enable_if_t<__detail::is_arithmetic<T>::Value &&
+                                    __detail::is_same<half, T>::value,
+                                T> mul(T x, T y) {
+  return x * y;
+}
+
+template <typename T>
+constexpr __detail::enable_if_t<
+    __detail::is_arithmetic<T>::Value && !__detail::is_same<half, T>::value, T>
+mul(T x, T y) {
   return x * y;
 }
 
 // Case 2: scalar * vector -> vector
+template <int N>
+_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+constexpr vector<half, N> mul(half x, vector<half, N> y) {
+  return x * y;
+}
+
 template <typename T, int N> constexpr vector<T, N> mul(T x, vector<T, N> y) {
   return x * y;
 }
 
 // Case 3: scalar * matrix -> matrix
+template <int R, int C>
+_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+constexpr matrix<half, R, C> mul(half x, matrix<half, R, C> y) {
+  return x * y;
+}
+
 template <typename T, int R, int C>
 constexpr matrix<T, R, C> mul(T x, matrix<T, R, C> y) {
   return x * y;
 }
 
 // Case 4: vector * scalar -> vector
+template <int N>
+_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+constexpr vector<half, N> mul(vector<half, N> x, half y) {
+  return x * y;
+}
+
 template <typename T, int N> constexpr vector<T, N> mul(vector<T, N> x, T y) {
   return x * y;
 }
 
 // Case 5: vector * vector -> scalar (dot product)
+template <int N>
+_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+half mul(vector<half, N> x, vector<half, N> y) {
+  return __detail::mul_vec_impl(x, y);
+}
+
 template <typename T, int N> T mul(vector<T, N> x, vector<T, N> y) {
   return __detail::mul_vec_impl(x, y);
 }
 
 // Case 7: matrix * scalar -> matrix
+template <int R, int C>
+_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+constexpr matrix<half, R, C> mul(matrix<half, R, C> x, half y) {
+  return x * y;
+}
+
 template <typename T, int R, int C>
 constexpr matrix<T, R, C> mul(matrix<T, R, C> x, T y) {
   return x * y;

--- a/clang/test/CodeGenHLSL/builtins/mul.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/mul.hlsl
@@ -1,5 +1,5 @@
-// RUN: %clang_cc1 -finclude-default-header -O1 -triple dxil-pc-shadermodel6.3-library -emit-llvm -o - %s | FileCheck %s --check-prefixes=CHECK,DXIL
-// RUN: %clang_cc1 -finclude-default-header -O1 -triple spirv-unknown-vulkan1.3-library -emit-llvm -o - %s | FileCheck %s --check-prefixes=CHECK,SPIRV
+// RUN: %clang_cc1 -finclude-default-header -O1 -triple dxil-pc-shadermodel6.3-library -fnative-half-type -emit-llvm -o - %s | FileCheck %s --check-prefixes=CHECK,DXIL
+// RUN: %clang_cc1 -finclude-default-header -O1 -triple spirv-unknown-vulkan1.3-library -fnative-half-type -emit-llvm -o - %s | FileCheck %s --check-prefixes=CHECK,SPIRV
 
 // -- Case 1: scalar * scalar -> scalar --
 
@@ -107,3 +107,59 @@ export float2x4 test_mat_mat_mul(float2x3 a, float3x4 b) { return mul(a, b); }
 // CHECK: %hlsl.mul = {{.*}} call <8 x i32> @llvm.matrix.multiply.v8i32.v6i32.v12i32(<6 x i32> %a, <12 x i32> %b, i32 2, i32 3, i32 4)
 // CHECK: ret <8 x i32> %hlsl.mul
 export int2x4 test_mat_mat_muli(int2x3 a, int3x4 b) { return mul(a, b); }
+
+// -- Half-type overloads (native half) --
+
+// CHECK-LABEL: test_scalar_mulh
+// CHECK: %mul.i = fmul {{.*}} half %b, %a
+// CHECK: ret half %mul.i
+export half test_scalar_mulh(half a, half b) { return mul(a, b); }
+
+// CHECK-LABEL: test_scalar_vec_mulh
+// CHECK: %splat.splatinsert.i = insertelement <3 x half> poison, half %a, i64 0
+// CHECK: %splat.splat.i = shufflevector <3 x half> %splat.splatinsert.i, <3 x half> poison, <3 x i32> zeroinitializer
+// CHECK: %mul.i = fmul {{.*}} <3 x half> %splat.splat.i, %b
+// CHECK: ret <3 x half> %mul.i
+export half3 test_scalar_vec_mulh(half a, half3 b) { return mul(a, b); }
+
+// CHECK-LABEL: test_scalar_mat_mulh
+// CHECK: %scalar.splat.splatinsert.i = insertelement <6 x half> poison, half %a, i64 0
+// CHECK: %scalar.splat.splat.i = shufflevector <6 x half> %scalar.splat.splatinsert.i, <6 x half> poison, <6 x i32> zeroinitializer
+// CHECK: [[MUL:%.*]] = fmul {{.*}} <6 x half> %scalar.splat.splat.i, %b
+// CHECK: ret <6 x half> [[MUL]]
+export half2x3 test_scalar_mat_mulh(half a, half2x3 b) { return mul(a, b); }
+
+// CHECK-LABEL: test_vec_scalar_mulh
+// CHECK: %splat.splatinsert.i = insertelement <3 x half> poison, half %b, i64 0
+// CHECK: %splat.splat.i = shufflevector <3 x half> %splat.splatinsert.i, <3 x half> poison, <3 x i32> zeroinitializer
+// CHECK: %mul.i = fmul {{.*}} <3 x half> %splat.splat.i, %a
+// CHECK: ret <3 x half> %mul.i
+export half3 test_vec_scalar_mulh(half3 a, half b) { return mul(a, b); }
+
+// CHECK-LABEL: test_vec_vec_mulh
+// DXIL: %hlsl.dot.i = {{.*}}call {{.*}} half @llvm.dx.fdot.v3f16(<3 x half> {{.*}} %a, <3 x half> {{.*}} %b)
+// SPIRV: %hlsl.dot.i = {{.*}}call {{.*}} half @llvm.spv.fdot.v3f16(<3 x half> {{.*}} %a, <3 x half> {{.*}} %b)
+// CHECK: ret half %hlsl.dot.i
+export half test_vec_vec_mulh(half3 a, half3 b) { return mul(a, b); }
+
+// CHECK-LABEL: test_mat_scalar_mulh
+// CHECK: %scalar.splat.splatinsert.i = insertelement <6 x half> poison, half %b, i64 0
+// CHECK: %scalar.splat.splat.i = shufflevector <6 x half> %scalar.splat.splatinsert.i, <6 x half> poison, <6 x i32> zeroinitializer
+// CHECK: [[MUL:%.*]] = fmul {{.*}} <6 x half> %scalar.splat.splat.i, %a
+// CHECK: ret <6 x half> [[MUL]]
+export half2x3 test_mat_scalar_mulh(half2x3 a, half b) { return mul(a, b); }
+
+// CHECK-LABEL: test_vec_mat_mulh
+// CHECK: %hlsl.mul = {{.*}}call {{.*}} <3 x half> @llvm.matrix.multiply.v3f16.v2f16.v6f16(<2 x half> %v, <6 x half> %m, i32 1, i32 2, i32 3)
+// CHECK: ret <3 x half> %hlsl.mul
+export half3 test_vec_mat_mulh(half2 v, half2x3 m) { return mul(v, m); }
+
+// CHECK-LABEL: test_mat_vec_mulh
+// CHECK: %hlsl.mul = {{.*}}call {{.*}} <2 x half> @llvm.matrix.multiply.v2f16.v6f16.v3f16(<6 x half> %m, <3 x half> %v, i32 2, i32 3, i32 1)
+// CHECK: ret <2 x half> %hlsl.mul
+export half2 test_mat_vec_mulh(half2x3 m, half3 v) { return mul(m, v); }
+
+// CHECK-LABEL: test_mat_mat_mulh
+// CHECK: %hlsl.mul = {{.*}}call {{.*}} <8 x half> @llvm.matrix.multiply.v8f16.v6f16.v12f16(<6 x half> %a, <12 x half> %b, i32 2, i32 3, i32 4)
+// CHECK: ret <8 x half> %hlsl.mul
+export half2x4 test_mat_mat_mulh(half2x3 a, half3x4 b) { return mul(a, b); }

--- a/clang/test/SemaHLSL/BuiltIns/mul-errors.hlsl
+++ b/clang/test/SemaHLSL/BuiltIns/mul-errors.hlsl
@@ -1,6 +1,6 @@
 // RUN: %clang_cc1 -finclude-default-header -triple dxil-pc-shadermodel6.3-library %s -verify
 
-// expected-note@*:* 54 {{candidate template ignored}}
+// expected-note@*:* 108 {{candidate template ignored}}
 
 // Test mul error cases via template overload resolution
 

--- a/llvm/test/CodeGen/DirectX/matrix-multiply.ll
+++ b/llvm/test/CodeGen/DirectX/matrix-multiply.ll
@@ -13,6 +13,9 @@ declare <4 x double> @llvm.matrix.multiply.v4f64.v4f64.v4f64(<4 x double>, <4 x 
 declare <2 x double> @llvm.matrix.multiply.v2f64.v4f64.v2f64(<4 x double>, <2 x double>, i32, i32, i32)
 declare <6 x float> @llvm.matrix.multiply.v6f32.v2f32.v3f32(<2 x float>, <3 x float>, i32, i32, i32)
 declare <6 x i32> @llvm.matrix.multiply.v6i32.v2i32.v3i32(<2 x i32>, <3 x i32>, i32, i32, i32)
+declare <4 x half> @llvm.matrix.multiply.v4f16.v4f16.v4f16(<4 x half>, <4 x half>, i32, i32, i32)
+declare <2 x half> @llvm.matrix.multiply.v2f16.v6f16.v3f16(<6 x half>, <3 x half>, i32, i32, i32)
+declare <6 x half> @llvm.matrix.multiply.v6f16.v2f16.v3f16(<2 x half>, <3 x half>, i32, i32, i32)
 
 ; 2x2 float: 4 dot2 calls.
 define <4 x float> @test_float_2x2(<4 x float> %a, <4 x float> %b) {
@@ -306,6 +309,82 @@ define <6 x float> @test_k1_outer_product(<2 x float> %a, <3 x float> %b) {
 ;
   %r = call <6 x float> @llvm.matrix.multiply.v6f32.v2f32.v3f32(<2 x float> %a, <3 x float> %b, i32 2, i32 1, i32 3)
   ret <6 x float> %r
+}
+
+; 2x2 half: 4 dot2 calls.
+define <4 x half> @test_half_2x2(<4 x half> %a, <4 x half> %b) {
+; CHECK-LABEL: define <4 x half> @test_half_2x2(
+; CHECK-SAME: <4 x half> [[A:%.*]], <4 x half> [[B:%.*]]) {
+; CHECK-NEXT:    [[TMP1:%.*]] = extractelement <4 x half> [[A]], i64 0
+; CHECK-NEXT:    [[TMP2:%.*]] = extractelement <4 x half> [[A]], i64 1
+; CHECK-NEXT:    [[TMP3:%.*]] = extractelement <4 x half> [[A]], i64 2
+; CHECK-NEXT:    [[TMP4:%.*]] = extractelement <4 x half> [[A]], i64 3
+; CHECK-NEXT:    [[TMP5:%.*]] = extractelement <4 x half> [[B]], i64 0
+; CHECK-NEXT:    [[TMP6:%.*]] = extractelement <4 x half> [[B]], i64 1
+; CHECK-NEXT:    [[TMP7:%.*]] = extractelement <4 x half> [[B]], i64 2
+; CHECK-NEXT:    [[TMP8:%.*]] = extractelement <4 x half> [[B]], i64 3
+; CHECK-NEXT:    [[TMP9:%.*]] = call half @llvm.dx.dot2.f16(half [[TMP1]], half [[TMP3]], half [[TMP5]], half [[TMP6]])
+; CHECK-NEXT:    [[TMP10:%.*]] = insertelement <4 x half> poison, half [[TMP9]], i64 0
+; CHECK-NEXT:    [[TMP11:%.*]] = call half @llvm.dx.dot2.f16(half [[TMP2]], half [[TMP4]], half [[TMP5]], half [[TMP6]])
+; CHECK-NEXT:    [[TMP12:%.*]] = insertelement <4 x half> [[TMP10]], half [[TMP11]], i64 1
+; CHECK-NEXT:    [[TMP13:%.*]] = call half @llvm.dx.dot2.f16(half [[TMP1]], half [[TMP3]], half [[TMP7]], half [[TMP8]])
+; CHECK-NEXT:    [[TMP14:%.*]] = insertelement <4 x half> [[TMP12]], half [[TMP13]], i64 2
+; CHECK-NEXT:    [[TMP15:%.*]] = call half @llvm.dx.dot2.f16(half [[TMP2]], half [[TMP4]], half [[TMP7]], half [[TMP8]])
+; CHECK-NEXT:    [[TMP16:%.*]] = insertelement <4 x half> [[TMP14]], half [[TMP15]], i64 3
+; CHECK-NEXT:    ret <4 x half> [[TMP16]]
+;
+  %r = call <4 x half> @llvm.matrix.multiply.v4f16.v4f16.v4f16(<4 x half> %a, <4 x half> %b, i32 2, i32 2, i32 2)
+  ret <4 x half> %r
+}
+
+; 2x3 half * 3x1 half: 2 dot3 calls.
+define <2 x half> @test_half_mat_vec(<6 x half> %m, <3 x half> %v) {
+; CHECK-LABEL: define <2 x half> @test_half_mat_vec(
+; CHECK-SAME: <6 x half> [[M:%.*]], <3 x half> [[V:%.*]]) {
+; CHECK-NEXT:    [[TMP1:%.*]] = extractelement <6 x half> [[M]], i64 0
+; CHECK-NEXT:    [[TMP2:%.*]] = extractelement <6 x half> [[M]], i64 1
+; CHECK-NEXT:    [[TMP3:%.*]] = extractelement <6 x half> [[M]], i64 2
+; CHECK-NEXT:    [[TMP4:%.*]] = extractelement <6 x half> [[M]], i64 3
+; CHECK-NEXT:    [[TMP5:%.*]] = extractelement <6 x half> [[M]], i64 4
+; CHECK-NEXT:    [[TMP6:%.*]] = extractelement <6 x half> [[M]], i64 5
+; CHECK-NEXT:    [[TMP7:%.*]] = extractelement <3 x half> [[V]], i64 0
+; CHECK-NEXT:    [[TMP8:%.*]] = extractelement <3 x half> [[V]], i64 1
+; CHECK-NEXT:    [[TMP9:%.*]] = extractelement <3 x half> [[V]], i64 2
+; CHECK-NEXT:    [[TMP10:%.*]] = call half @llvm.dx.dot3.f16(half [[TMP1]], half [[TMP3]], half [[TMP5]], half [[TMP7]], half [[TMP8]], half [[TMP9]])
+; CHECK-NEXT:    [[TMP11:%.*]] = insertelement <2 x half> poison, half [[TMP10]], i64 0
+; CHECK-NEXT:    [[TMP12:%.*]] = call half @llvm.dx.dot3.f16(half [[TMP2]], half [[TMP4]], half [[TMP6]], half [[TMP7]], half [[TMP8]], half [[TMP9]])
+; CHECK-NEXT:    [[TMP13:%.*]] = insertelement <2 x half> [[TMP11]], half [[TMP12]], i64 1
+; CHECK-NEXT:    ret <2 x half> [[TMP13]]
+;
+  %r = call <2 x half> @llvm.matrix.multiply.v2f16.v6f16.v3f16(<6 x half> %m, <3 x half> %v, i32 2, i32 3, i32 1)
+  ret <2 x half> %r
+}
+
+; K=1 half outer product (2x1 * 1x3 = 2x3): each element is a single fmul.
+define <6 x half> @test_k1_half_outer_product(<2 x half> %a, <3 x half> %b) {
+; CHECK-LABEL: define <6 x half> @test_k1_half_outer_product(
+; CHECK-SAME: <2 x half> [[A:%.*]], <3 x half> [[B:%.*]]) {
+; CHECK-NEXT:    [[TMP1:%.*]] = extractelement <2 x half> [[A]], i64 0
+; CHECK-NEXT:    [[TMP2:%.*]] = extractelement <2 x half> [[A]], i64 1
+; CHECK-NEXT:    [[TMP3:%.*]] = extractelement <3 x half> [[B]], i64 0
+; CHECK-NEXT:    [[TMP4:%.*]] = extractelement <3 x half> [[B]], i64 1
+; CHECK-NEXT:    [[TMP5:%.*]] = extractelement <3 x half> [[B]], i64 2
+; CHECK-NEXT:    [[TMP6:%.*]] = fmul half [[TMP1]], [[TMP3]]
+; CHECK-NEXT:    [[TMP7:%.*]] = insertelement <6 x half> poison, half [[TMP6]], i64 0
+; CHECK-NEXT:    [[TMP8:%.*]] = fmul half [[TMP2]], [[TMP3]]
+; CHECK-NEXT:    [[TMP9:%.*]] = insertelement <6 x half> [[TMP7]], half [[TMP8]], i64 1
+; CHECK-NEXT:    [[TMP10:%.*]] = fmul half [[TMP1]], [[TMP4]]
+; CHECK-NEXT:    [[TMP11:%.*]] = insertelement <6 x half> [[TMP9]], half [[TMP10]], i64 2
+; CHECK-NEXT:    [[TMP12:%.*]] = fmul half [[TMP2]], [[TMP4]]
+; CHECK-NEXT:    [[TMP13:%.*]] = insertelement <6 x half> [[TMP11]], half [[TMP12]], i64 3
+; CHECK-NEXT:    [[TMP14:%.*]] = fmul half [[TMP1]], [[TMP5]]
+; CHECK-NEXT:    [[TMP15:%.*]] = insertelement <6 x half> [[TMP13]], half [[TMP14]], i64 4
+; CHECK-NEXT:    [[TMP16:%.*]] = fmul half [[TMP2]], [[TMP5]]
+; CHECK-NEXT:    [[TMP17:%.*]] = insertelement <6 x half> [[TMP15]], half [[TMP16]], i64 5
+; CHECK-NEXT:    ret <6 x half> [[TMP17]]
+;
+  %r = call <6 x half> @llvm.matrix.multiply.v6f16.v2f16.v3f16(<2 x half> %a, <3 x half> %b, i32 2, i32 1, i32 3)
+  ret <6 x half> %r
 }
 
 ; K=1 integer outer product (2x1 * 1x3 = 2x3): each element is a single mul.


### PR DESCRIPTION
PR #184882 was missing `half` type-specific overloads for `mul`. 
This PR introduces `half` type-specific overloads for `mul` and additional codegen tests for the half type.
Also added f16 tests for the lowering of llvm.matrix.multiply.

The offload test suite already has a `mul.fp16` test for exercising half types at runtime, so no change is needed there.

Assisted-by: claude-opus-4.6