### PR TITLE
[NFC][MC] Style cleanup in MC-level LFI files

### DIFF
--- a/llvm/lib/MC/MCLFIRewriter.cpp
+++ b/llvm/lib/MC/MCLFIRewriter.cpp
@@ -17,7 +17,7 @@
 #include "llvm/MC/MCInstrInfo.h"
 #include "llvm/MC/MCRegisterInfo.h"
 
-namespace llvm {
+using namespace llvm;
 
 void MCLFIRewriter::error(const MCInst &Inst, const char Msg[]) {
   Ctx.reportError(Inst.getLoc(), Msg);
@@ -51,4 +51,3 @@ bool MCLFIRewriter::mayModifyRegister(const MCInst &Inst,
                                       MCRegister Reg) const {
   return InstInfo->get(Inst.getOpcode()).hasDefOfPhysReg(Inst, Reg, *RegInfo);
 }
-} // namespace llvm

--- a/llvm/lib/MC/MCParser/LFIAsmParser.cpp
+++ b/llvm/lib/MC/MCParser/LFIAsmParser.cpp
@@ -17,6 +17,7 @@
 
 using namespace llvm;
 
+namespace {
 class LFIAsmParser : public MCAsmParserExtension {
   MCLFIRewriter *Rewriter;
   template <bool (LFIAsmParser::*HandlerMethod)(StringRef, SMLoc)>
@@ -62,9 +63,8 @@ public:
     return false;
   }
 };
+} // namespace
 
-namespace llvm {
-MCAsmParserExtension *createLFIAsmParser(MCLFIRewriter *Exp) {
+MCAsmParserExtension *llvm::createLFIAsmParser(MCLFIRewriter *Exp) {
   return new LFIAsmParser(Exp);
 }
-} // namespace llvm


### PR DESCRIPTION
Following https://llvm.org/docs/CodingStandards.html#use-namespace-qualifiers-to-define-previously-declared-symbols and https://llvm.org/docs/CodingStandards.html#restrict-visibility.