### PR TITLE
[flang-rt] Need to pad the output of execute_command_line(..., CMDMSG)

### DIFF
--- a/flang-rt/lib/runtime/execute.cpp
+++ b/flang-rt/lib/runtime/execute.cpp
@@ -48,20 +48,15 @@ enum CMD_STAT {
   SIGNAL_ERR = 7
 };
 
-// Override CopyCharsToDescriptor in tools.h, pass string directly
-void CopyCharsToDescriptor(const Descriptor &value, const char *rawValue) {
-  CopyAndPad(value.OffsetElement(), rawValue, value.ElementBytes(),
-      std::strlen(rawValue));
-}
-
-void CheckAndCopyCharsToDescriptor(
+static void CheckAndCopyCharsToDescriptor(
     const Descriptor *value, const char *rawValue) {
   if (value) {
-    CopyCharsToDescriptor(*value, rawValue);
+    CopyAndPad(value->OffsetElement(), rawValue, value->ElementBytes(),
+        std::strlen(rawValue));
   }
 }
 
-void CheckAndStoreIntToDescriptor(
+static void CheckAndStoreIntToDescriptor(
     const Descriptor *intVal, std::int64_t value, Terminator &terminator) {
   if (intVal) {
     StoreIntToDescriptor(intVal, value, terminator);

--- a/flang-rt/lib/runtime/execute.cpp
+++ b/flang-rt/lib/runtime/execute.cpp
@@ -50,7 +50,8 @@ enum CMD_STAT {
 
 // Override CopyCharsToDescriptor in tools.h, pass string directly
 void CopyCharsToDescriptor(const Descriptor &value, const char *rawValue) {
-  CopyCharsToDescriptor(value, rawValue, std::strlen(rawValue));
+  CopyAndPad(value.OffsetElement(), rawValue, value.ElementBytes(),
+      std::strlen(rawValue));
 }
 
 void CheckAndCopyCharsToDescriptor(

--- a/flang-rt/unittests/Runtime/CommandTest.cpp
+++ b/flang-rt/unittests/Runtime/CommandTest.cpp
@@ -367,11 +367,13 @@ TEST_F(ZeroArguments, ECLNotExecutedCommandErrorSync) {
 #ifdef _WIN32
   CheckDescriptorEqInt<std::int64_t>(exitStat.get(), 9009);
   CheckDescriptorEqInt<std::int64_t>(cmdStat.get(), 5);
-  CheckDescriptorEqStr(cmdMsg.get(), "Command not found.");
+  CheckDescriptorEqStr(cmdMsg.get(),
+      GetPaddedStr("Command not found.", cmdMsg->ElementBytes()));
 #else
   CheckDescriptorEqInt<std::int64_t>(exitStat.get(), 126);
   CheckDescriptorEqInt<std::int64_t>(cmdStat.get(), 4);
-  CheckDescriptorEqStr(cmdMsg.get(), "Command cannot be execu");
+  CheckDescriptorEqStr(cmdMsg.get(),
+      GetPaddedStr("Command cannot be execu", cmdMsg->ElementBytes()));
   // removing the file only on Linux (file is not created on Win)
   OwningPtr<Descriptor> commandClean{
       CharDescriptor("rm -f NotExecutedCommandFile")};
@@ -396,11 +398,13 @@ TEST_F(ZeroArguments, ECLNotFoundCommandErrorSync) {
 #ifdef _WIN32
   CheckDescriptorEqInt<std::int64_t>(exitStat.get(), 9009);
   CheckDescriptorEqInt<std::int64_t>(cmdStat.get(), 5);
-  CheckDescriptorEqStr(cmdMsg.get(), "Command not found.");
+  CheckDescriptorEqStr(cmdMsg.get(),
+      GetPaddedStr("Command not found.", cmdMsg->ElementBytes()));
 #else
   CheckDescriptorEqInt<std::int64_t>(exitStat.get(), 127);
   CheckDescriptorEqInt<std::int64_t>(cmdStat.get(), 5);
-  CheckDescriptorEqStr(cmdMsg.get(), "Command not found with exit");
+  CheckDescriptorEqStr(cmdMsg.get(),
+      GetPaddedStr("Command not found with exit", cmdMsg->ElementBytes()));
 #endif
 }
 

--- a/flang-rt/unittests/Runtime/CommandTest.cpp
+++ b/flang-rt/unittests/Runtime/CommandTest.cpp
@@ -361,20 +361,22 @@ TEST_F(ZeroArguments, ECLNotExecutedCommandErrorSync) {
   OwningPtr<Descriptor> exitStat{IntDescriptor(404)};
   OwningPtr<Descriptor> cmdStat{IntDescriptor(202)};
   // Use longer character string to check padding
-  OwningPtr<Descriptor> cmdMsg{CharDescriptor("Command cannot be executed with exit code: XXXXXXXXXXX.")};
+  OwningPtr<Descriptor> cmdMsg{CharDescriptor(
+      "Command cannot be executed with exit code: XXXXXXXXXXX.")};
 
   RTNAME(ExecuteCommandLine)
   (*command.get(), wait, exitStat.get(), cmdStat.get(), cmdMsg.get());
 #ifdef _WIN32
   CheckDescriptorEqInt<std::int64_t>(exitStat.get(), 9009);
   CheckDescriptorEqInt<std::int64_t>(cmdStat.get(), 5);
-  CheckDescriptorEqStr(cmdMsg.get(),
-      GetPaddedStr("Command not found.", cmdMsg->ElementBytes()));
+  CheckDescriptorEqStr(
+      cmdMsg.get(), GetPaddedStr("Command not found.", cmdMsg->ElementBytes()));
 #else
   CheckDescriptorEqInt<std::int64_t>(exitStat.get(), 126);
   CheckDescriptorEqInt<std::int64_t>(cmdStat.get(), 4);
   CheckDescriptorEqStr(cmdMsg.get(),
-      GetPaddedStr("Command cannot be executed with exit code: 126.", cmdMsg->ElementBytes()));
+      GetPaddedStr("Command cannot be executed with exit code: 126.",
+          cmdMsg->ElementBytes()));
   // removing the file only on Linux (file is not created on Win)
   OwningPtr<Descriptor> commandClean{
       CharDescriptor("rm -f NotExecutedCommandFile")};
@@ -399,8 +401,8 @@ TEST_F(ZeroArguments, ECLNotFoundCommandErrorSync) {
 #ifdef _WIN32
   CheckDescriptorEqInt<std::int64_t>(exitStat.get(), 9009);
   CheckDescriptorEqInt<std::int64_t>(cmdStat.get(), 5);
-  CheckDescriptorEqStr(cmdMsg.get(),
-      GetPaddedStr("Command not found.", cmdMsg->ElementBytes()));
+  CheckDescriptorEqStr(
+      cmdMsg.get(), GetPaddedStr("Command not found.", cmdMsg->ElementBytes()));
 #else
   CheckDescriptorEqInt<std::int64_t>(exitStat.get(), 127);
   CheckDescriptorEqInt<std::int64_t>(cmdStat.get(), 5);

--- a/flang-rt/unittests/Runtime/CommandTest.cpp
+++ b/flang-rt/unittests/Runtime/CommandTest.cpp
@@ -360,7 +360,8 @@ TEST_F(ZeroArguments, ECLNotExecutedCommandErrorSync) {
   bool wait{true};
   OwningPtr<Descriptor> exitStat{IntDescriptor(404)};
   OwningPtr<Descriptor> cmdStat{IntDescriptor(202)};
-  OwningPtr<Descriptor> cmdMsg{CharDescriptor("cmd msg buffer XXXXXXXX")};
+  // Use longer character string to check padding
+  OwningPtr<Descriptor> cmdMsg{CharDescriptor("Command cannot be executed with exit code: XXXXXXXXXXX.")};
 
   RTNAME(ExecuteCommandLine)
   (*command.get(), wait, exitStat.get(), cmdStat.get(), cmdMsg.get());
@@ -373,7 +374,7 @@ TEST_F(ZeroArguments, ECLNotExecutedCommandErrorSync) {
   CheckDescriptorEqInt<std::int64_t>(exitStat.get(), 126);
   CheckDescriptorEqInt<std::int64_t>(cmdStat.get(), 4);
   CheckDescriptorEqStr(cmdMsg.get(),
-      GetPaddedStr("Command cannot be execu", cmdMsg->ElementBytes()));
+      GetPaddedStr("Command cannot be executed with exit code: 126.", cmdMsg->ElementBytes()));
   // removing the file only on Linux (file is not created on Win)
   OwningPtr<Descriptor> commandClean{
       CharDescriptor("rm -f NotExecutedCommandFile")};


### PR DESCRIPTION
Previously the error message was copied, but not padded for cases where the message was shorter than the passed CMDMSG string. Add the padding and also change the test case to test padding on all platforms.