### PR TITLE
[MLIR][Python] Add get_parent_of_type helper

### DIFF
--- a/mlir/python/mlir/ir.py
+++ b/mlir/python/mlir/ir.py
@@ -21,9 +21,7 @@ from ._mlir_libs import (
 )
 
 
-def get_parent_of_type(
-    op: OpView | Operation, op_class: type[OpView]
-) -> OpView | None:
+def get_parent_of_type(op: OpView | Operation, op_class: type[OpView]) -> OpView | None:
     """Return the closest enclosing parent operation of the given type.
 
     Walks the parent chain of *op* and returns the first ancestor that is an instance of *op_class*.

--- a/mlir/python/mlir/ir.py
+++ b/mlir/python/mlir/ir.py
@@ -21,6 +21,33 @@ from ._mlir_libs import (
 )
 
 
+def get_parent_of_type(
+    op: "OpView | Operation", op_class: "type[OpView]"
+) -> "OpView | None":
+    """Return the closest enclosing parent operation of the given type.
+
+    Walks the parent chain of *op* and returns the first ancestor that is an instance of *op_class*.
+    Returns ``None`` if no matching parent is found.
+
+    Args:
+      op: The starting operation.
+      op_class: The OpView subclass to search for (e.g. ``func.FuncOp``).
+
+    """
+    if not (isinstance(op_class, type) and issubclass(op_class, OpView)):
+        raise TypeError(f"op_class must be an OpView subclass, got {op_class!r}")
+    try:
+        parent = op.operation.parent
+    except ValueError:
+        return None  # No parent chain.
+    while parent is not None:
+        opview = parent.opview
+        if isinstance(opview, op_class):
+            return opview
+        parent = parent.parent
+    return None
+
+
 @contextmanager
 def loc_tracebacks(*, max_depth: int | None = None) -> Generator[None]:
     """Enables automatic traceback-based locations for MLIR operations.

--- a/mlir/python/mlir/ir.py
+++ b/mlir/python/mlir/ir.py
@@ -37,14 +37,13 @@ def get_parent_of_type(
     if not (isinstance(op_class, type) and issubclass(op_class, OpView)):
         raise TypeError(f"op_class must be an OpView subclass, got {op_class!r}")
     try:
-        parent = op.operation.parent
+        op = op.parent
     except ValueError:
         return None  # No parent chain.
-    while parent is not None:
-        opview = parent.opview
-        if isinstance(opview, op_class):
-            return opview
-        parent = parent.parent
+    while op is not None:
+        if isinstance(op.opview, op_class):
+            return op.opview
+        op = op.parent
     return None
 
 

--- a/mlir/python/mlir/ir.py
+++ b/mlir/python/mlir/ir.py
@@ -22,8 +22,8 @@ from ._mlir_libs import (
 
 
 def get_parent_of_type(
-    op: "OpView | Operation", op_class: "type[OpView]"
-) -> "OpView | None":
+    op: OpView | Operation, op_class: type[OpView]
+) -> OpView | None:
     """Return the closest enclosing parent operation of the given type.
 
     Walks the parent chain of *op* and returns the first ancestor that is an instance of *op_class*.

--- a/mlir/test/python/ir/operation.py
+++ b/mlir/test/python/ir/operation.py
@@ -1410,7 +1410,8 @@ def testGetParentOfType():
                 base_op = Operation.create("custom.base_op")
                 scf.YieldOp([])
             func.ReturnOp([])
-            
+
+
         # CHECK: get_parent_of_type detached->func.func: None
         detached = Operation.create("custom.detached")
         res = get_parent_of_type(detached, func.FuncOp)

--- a/mlir/test/python/ir/operation.py
+++ b/mlir/test/python/ir/operation.py
@@ -4,7 +4,6 @@ import gc
 import io
 from tempfile import NamedTemporaryFile
 from mlir.ir import *
-from mlir.ir import get_parent_of_type
 from mlir.dialects.builtin import ModuleOp
 from mlir.dialects import arith, func, scf, shape
 from mlir.dialects._ods_common import _cext

--- a/mlir/test/python/ir/operation.py
+++ b/mlir/test/python/ir/operation.py
@@ -1400,19 +1400,19 @@ def testGetParentOfType():
         ctx.allow_unregistered_dialects = True
         idx = IndexType.get()
         # Build: func.func -> scf.for -> custom.base_op
-        func_op = func.FuncOp("test_fn", ([], []))
+        func_op: func.FuncOp = func.FuncOp("test_fn", ([], []))
         with InsertionPoint(func_op.add_entry_block()):
             lower_bound = arith.ConstantOp(idx, 0)
             upper_bound = arith.ConstantOp(idx, 10)
             step = arith.ConstantOp(idx, 1)
-            for_op = scf.ForOp(lower_bound, upper_bound, step)
+            for_op: scf.ForOp = scf.ForOp(lower_bound, upper_bound, step)
             with InsertionPoint(for_op.body):
-                base_op = Operation.create("custom.base_op")
+                base_op: Operation = Operation.create("custom.base_op")
                 scf.YieldOp([])
             func.ReturnOp([])
 
         # CHECK: get_parent_of_type detached->func.func: None
-        detached = Operation.create("custom.detached")
+        detached: Operation = Operation.create("custom.detached")
         res = get_parent_of_type(detached, func.FuncOp)
         print(f"get_parent_of_type detached->func.func: {res}")
         assert res is None

--- a/mlir/test/python/ir/operation.py
+++ b/mlir/test/python/ir/operation.py
@@ -4,6 +4,7 @@ import gc
 import io
 from tempfile import NamedTemporaryFile
 from mlir.ir import *
+from mlir.ir import get_parent_of_type
 from mlir.dialects.builtin import ModuleOp
 from mlir.dialects import arith, func, scf, shape
 from mlir.dialects._ods_common import _cext
@@ -1391,3 +1392,43 @@ def testIndexSwitch():
                 assert len([i for i in switch_op.caseRegions]) == 3
                 assert len(switch_op.caseRegions[1:]) == 2
                 assert len([i for i in switch_op.caseRegions[1:]]) == 2
+
+
+# CHECK-LABEL: TEST: testGetParentOfType
+@run
+def testGetParentOfType():
+    with Context() as ctx, Location.unknown():
+        ctx.allow_unregistered_dialects = True
+        idx = IndexType.get()
+        # Build: func.func -> scf.for -> custom.base_op
+        func_op = func.FuncOp("test_fn", ([], []))
+        with InsertionPoint(func_op.add_entry_block()):
+            lower_bound = arith.ConstantOp(idx, 0)
+            upper_bound = arith.ConstantOp(idx, 10)
+            step = arith.ConstantOp(idx, 1)
+            for_op = scf.ForOp(lower_bound, upper_bound, step)
+            with InsertionPoint(for_op.body):
+                base_op = Operation.create("custom.base_op")
+                scf.YieldOp([])
+            func.ReturnOp([])
+
+        # CHECK: get_parent_of_type base_op->func.func: func.func
+        res = get_parent_of_type(base_op, func.FuncOp)
+        print(f"get_parent_of_type base_op->func.func: {res.operation.name}")
+        assert isinstance(res, func.FuncOp)
+
+        # CHECK: get_parent_of_type func_op->func.func: None
+        res = get_parent_of_type(func_op, func.FuncOp)
+        print(f"get_parent_of_type func_op->func.func: {res}")
+        assert res is None
+
+        # CHECK: get_parent_of_type base_op->scf.if: None
+        res = get_parent_of_type(base_op, scf.IfOp)
+        print(f"get_parent_of_type base_op->scf.if: {res}")
+        assert res is None
+
+        try:
+            get_parent_of_type(base_op, int)
+            assert False, "expected TypeError"
+        except TypeError:
+            pass

--- a/mlir/test/python/ir/operation.py
+++ b/mlir/test/python/ir/operation.py
@@ -1410,6 +1410,12 @@ def testGetParentOfType():
                 base_op = Operation.create("custom.base_op")
                 scf.YieldOp([])
             func.ReturnOp([])
+            
+        # CHECK: get_parent_of_type detached->func.func: None
+        detached = Operation.create("custom.detached")
+        res = get_parent_of_type(detached, func.FuncOp)
+        print(f"get_parent_of_type detached->func.func: {res}")
+        assert res is None
 
         # CHECK: get_parent_of_type base_op->func.func: func.func
         res = get_parent_of_type(base_op, func.FuncOp)

--- a/mlir/test/python/ir/operation.py
+++ b/mlir/test/python/ir/operation.py
@@ -1411,7 +1411,6 @@ def testGetParentOfType():
                 scf.YieldOp([])
             func.ReturnOp([])
 
-
         # CHECK: get_parent_of_type detached->func.func: None
         detached = Operation.create("custom.detached")
         res = get_parent_of_type(detached, func.FuncOp)


### PR DESCRIPTION
The `op.parent` only returns the immediate parent, in which case downstream users have to traverse the operation by themselves to find a specific type op.
This PR adds a python function `get_parent_of_type()` to mlir.ir to provide an API to do so.

The function mirrors the implementation here:
https://github.com/llvm/llvm-project/blob/main/mlir/include/mlir/IR/Operation.h#L257-L273. Instead of creating a new binding, reimplement it in python using `isinstance()` is simpler.