### PR TITLE
[libclc] Replace last of `opencl` atomics with `__scoped_` versions

### DIFF
--- a/libclc/opencl/lib/amdgcn/printf/__printf_alloc.cl
+++ b/libclc/opencl/lib/amdgcn/printf/__printf_alloc.cl
@@ -19,16 +19,16 @@ __global char *__printf_alloc(uint bytes) {
   __global char *ptr = (__global char *)args->printf_buffer;
 
   uint size = ((__global uint *)ptr)[1];
-  uint offset = __opencl_atomic_load((__global atomic_uint *)ptr,
-                                     memory_order_relaxed, memory_scope_device);
+  uint offset = __scoped_atomic_load_n((__global uint *)ptr, __ATOMIC_RELAXED,
+                                       __MEMORY_SCOPE_DEVICE);
 
   for (;;) {
     if (OFFSET + offset + bytes > size)
       return NULL;
 
-    if (__opencl_atomic_compare_exchange_strong(
-            (__global atomic_uint *)ptr, &offset, offset + bytes,
-            memory_order_relaxed, memory_order_relaxed, memory_scope_device))
+    if (__scoped_atomic_compare_exchange_n(
+            (__global uint *)ptr, &offset, offset + bytes, false,
+            __ATOMIC_RELAXED, __ATOMIC_RELAXED, __MEMORY_SCOPE_DEVICE))
       break;
   }
 

--- a/libclc/opencl/lib/generic/atomic/atomic_fetch_add.cl
+++ b/libclc/opencl/lib/generic/atomic/atomic_fetch_add.cl
@@ -23,22 +23,22 @@
 
 _CLC_OVERLOAD _CLC_DEF uintptr_t
 atomic_fetch_add(volatile __local atomic_uintptr_t *p, ptrdiff_t v) {
-  return __opencl_atomic_fetch_add(p, v, memory_order_seq_cst,
-                                   memory_scope_device);
+  return __scoped_atomic_fetch_add((volatile __local uintptr_t *)p, v,
+                                   __ATOMIC_SEQ_CST, __MEMORY_SCOPE_DEVICE);
 }
 
 _CLC_OVERLOAD _CLC_DEF uintptr_t
 atomic_fetch_add(volatile __global atomic_uintptr_t *p, ptrdiff_t v) {
-  return __opencl_atomic_fetch_add(p, v, memory_order_seq_cst,
-                                   memory_scope_device);
+  return __scoped_atomic_fetch_add((volatile __global uintptr_t *)p, v,
+                                   __ATOMIC_SEQ_CST, __MEMORY_SCOPE_DEVICE);
 }
 
 #if _CLC_GENERIC_AS_SUPPORTED
 
 _CLC_OVERLOAD _CLC_DEF uintptr_t atomic_fetch_add(volatile atomic_uintptr_t *p,
                                                   ptrdiff_t v) {
-  return __opencl_atomic_fetch_add(p, v, memory_order_seq_cst,
-                                   memory_scope_device);
+  return __scoped_atomic_fetch_add((volatile uintptr_t *)p, v, __ATOMIC_SEQ_CST,
+                                   __MEMORY_SCOPE_DEVICE);
 }
 
 #endif // _CLC_GENERIC_AS_SUPPORTED

--- a/libclc/opencl/lib/generic/atomic/atomic_fetch_sub.cl
+++ b/libclc/opencl/lib/generic/atomic/atomic_fetch_sub.cl
@@ -23,22 +23,22 @@
 
 _CLC_OVERLOAD _CLC_DEF uintptr_t
 atomic_fetch_sub(volatile __local atomic_uintptr_t *p, ptrdiff_t v) {
-  return __opencl_atomic_fetch_sub(p, v, memory_order_seq_cst,
-                                   memory_scope_device);
+  return __scoped_atomic_fetch_sub((volatile __local uintptr_t *)p, v,
+                                   __ATOMIC_SEQ_CST, __MEMORY_SCOPE_DEVICE);
 }
 
 _CLC_OVERLOAD _CLC_DEF uintptr_t
 atomic_fetch_sub(volatile __global atomic_uintptr_t *p, ptrdiff_t v) {
-  return __opencl_atomic_fetch_sub(p, v, memory_order_seq_cst,
-                                   memory_scope_device);
+  return __scoped_atomic_fetch_sub((volatile __global uintptr_t *)p, v,
+                                   __ATOMIC_SEQ_CST, __MEMORY_SCOPE_DEVICE);
 }
 
 #if _CLC_GENERIC_AS_SUPPORTED
 
 _CLC_OVERLOAD _CLC_DEF uintptr_t atomic_fetch_sub(volatile atomic_uintptr_t *p,
                                                   ptrdiff_t v) {
-  return __opencl_atomic_fetch_sub(p, v, memory_order_seq_cst,
-                                   memory_scope_device);
+  return __scoped_atomic_fetch_sub((volatile uintptr_t *)p, v, __ATOMIC_SEQ_CST,
+                                   __MEMORY_SCOPE_DEVICE);
 }
 
 #endif // _CLC_GENERIC_AS_SUPPORTED


### PR DESCRIPTION
Summary:
These were the only uses of the old atomics. The old definition guards
stay as those prevent us from compiling the unsupported uintptr_t atomic
type on nvptx which does not define it. Could probably be improved
later.
