### PR TITLE
[SandboxVec][DAG] Mark UnscheduledSuccs as invalid when vectorized

### DIFF
--- a/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/DependencyGraph.h
+++ b/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/DependencyGraph.h
@@ -289,7 +289,7 @@ public:
     PredN->MemSuccs.insert(this);
     if (!Scheduled) {
       if (!PredN->Scheduled)
-        ++*PredN->UnscheduledSuccs;
+        PredN->incrUnscheduledSuccs();
     }
   }
   /// Removes the memory dependency PredN->this. This also updates the

--- a/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/DependencyGraph.h
+++ b/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/DependencyGraph.h
@@ -121,7 +121,10 @@ public:
   DGNode(const DGNode &Other) = delete;
   virtual ~DGNode();
   /// \Returns the number of unscheduled successors.
-  unsigned getNumUnscheduledSuccs() const { return *UnscheduledSuccs; }
+  unsigned getNumUnscheduledSuccs() const {
+    assert((bool)UnscheduledSuccs && "Invalid UnscheduledSuccs!");
+    return *UnscheduledSuccs;
+  }
 #ifndef NDEBUG
   /// \returns true unscheduled successors contains valid data (for testing).
   bool validUnscheduledSuccs() const { return (bool)UnscheduledSuccs; }

--- a/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/DependencyGraph.h
+++ b/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/DependencyGraph.h
@@ -98,9 +98,9 @@ protected:
   // TODO: Use a PointerIntPair for SubclassID and I.
   /// For isa/dyn_cast etc.
   DGNodeID SubclassID;
-  /// The number of unscheduled successors. This is meaningless after a node
-  /// gets scheduled.
-  unsigned UnscheduledSuccs = 0;
+  /// The number of unscheduled successors. Optional represents whether the
+  /// value is meaningless, e.g., after a node gets scheduled.
+  std::optional<unsigned> UnscheduledSuccs = 0;
   /// This is true if this node has been scheduled.
   bool Scheduled = false;
   /// The scheduler bundle that this node belongs to.
@@ -121,13 +121,17 @@ public:
   DGNode(const DGNode &Other) = delete;
   virtual ~DGNode();
   /// \Returns the number of unscheduled successors.
-  unsigned getNumUnscheduledSuccs() const { return UnscheduledSuccs; }
+  unsigned getNumUnscheduledSuccs() const { return *UnscheduledSuccs; }
+#ifndef NDEBUG
+  /// \returns true unscheduled successors contains valid data (for testing).
+  bool validUnscheduledSuccs() const { return (bool)UnscheduledSuccs; }
+#endif
   // TODO: Make this private?
   void decrUnscheduledSuccs() {
-    assert(UnscheduledSuccs > 0 && "Counting error!");
-    --UnscheduledSuccs;
+    assert(*UnscheduledSuccs > 0 && "Counting error!");
+    --*UnscheduledSuccs;
   }
-  void incrUnscheduledSuccs() { ++UnscheduledSuccs; }
+  void incrUnscheduledSuccs() { ++*UnscheduledSuccs; }
   void resetScheduleState() {
     UnscheduledSuccs = 0;
     Scheduled = false;
@@ -136,7 +140,12 @@ public:
   bool ready() const { return UnscheduledSuccs == 0; }
   /// \Returns true if this node has been scheduled.
   bool scheduled() const { return Scheduled; }
-  void setScheduled(bool NewVal) { Scheduled = NewVal; }
+  void setScheduled(bool NewVal) {
+    Scheduled = NewVal;
+    if (Scheduled)
+      // UnscheduledSuccs is meaningless from this point on, so prohibit its use
+      UnscheduledSuccs = std::nullopt;
+  }
   /// \Returns the scheduling bundle that this node belongs to, or nullptr.
   SchedBundle *getSchedBundle() const { return SB; }
   /// \Returns true if this is before \p Other in program order.
@@ -279,7 +288,8 @@ public:
     assert(PredN != this && "Trying to add a dependency to self!");
     PredN->MemSuccs.insert(this);
     if (!Scheduled) {
-      ++PredN->UnscheduledSuccs;
+      if (!PredN->Scheduled)
+        ++*PredN->UnscheduledSuccs;
     }
   }
   /// Removes the memory dependency PredN->this. This also updates the
@@ -288,7 +298,8 @@ public:
     MemPreds.erase(PredN);
     PredN->MemSuccs.erase(this);
     if (!Scheduled) {
-      PredN->decrUnscheduledSuccs();
+      if (!PredN->Scheduled)
+        PredN->decrUnscheduledSuccs();
     }
   }
   /// \Returns true if there is a memory dependency N->this.

--- a/llvm/lib/Transforms/Vectorize/SandboxVectorizer/DependencyGraph.cpp
+++ b/llvm/lib/Transforms/Vectorize/SandboxVectorizer/DependencyGraph.cpp
@@ -260,7 +260,7 @@ void DependencyGraph::setDefUseUnscheduledSuccs(
       auto *OpN = getNode(OpI);
       if (OpN == nullptr)
         continue;
-      ++OpN->UnscheduledSuccs;
+      ++*OpN->UnscheduledSuccs;
     }
   }
 
@@ -292,7 +292,7 @@ void DependencyGraph::setDefUseUnscheduledSuccs(
         continue;
       if (!TopInterval.contains(OpI))
         continue;
-      ++OpN->UnscheduledSuccs;
+      ++*OpN->UnscheduledSuccs;
     }
   }
 }
@@ -546,7 +546,7 @@ void DependencyGraph::notifySetUse(const Use &U, Value *NewSrc) {
     if (auto *NewSrcN = getNode(NewSrcI)) {
       // If CurrSrcN is scheduled there is no point in updating UnscheduleSuccs.
       if (!NewSrcN->scheduled())
-        ++NewSrcN->UnscheduledSuccs;
+        ++*NewSrcN->UnscheduledSuccs;
     }
   }
 }

--- a/llvm/lib/Transforms/Vectorize/SandboxVectorizer/DependencyGraph.cpp
+++ b/llvm/lib/Transforms/Vectorize/SandboxVectorizer/DependencyGraph.cpp
@@ -260,7 +260,7 @@ void DependencyGraph::setDefUseUnscheduledSuccs(
       auto *OpN = getNode(OpI);
       if (OpN == nullptr)
         continue;
-      ++*OpN->UnscheduledSuccs;
+      OpN->incrUnscheduledSuccs();
     }
   }
 
@@ -292,7 +292,7 @@ void DependencyGraph::setDefUseUnscheduledSuccs(
         continue;
       if (!TopInterval.contains(OpI))
         continue;
-      ++*OpN->UnscheduledSuccs;
+      OpN->incrUnscheduledSuccs();
     }
   }
 }
@@ -546,7 +546,7 @@ void DependencyGraph::notifySetUse(const Use &U, Value *NewSrc) {
     if (auto *NewSrcN = getNode(NewSrcI)) {
       // If CurrSrcN is scheduled there is no point in updating UnscheduleSuccs.
       if (!NewSrcN->scheduled())
-        ++*NewSrcN->UnscheduledSuccs;
+        NewSrcN->incrUnscheduledSuccs();
     }
   }
 }

--- a/llvm/unittests/Transforms/Vectorize/SandboxVectorizer/DependencyGraphTest.cpp
+++ b/llvm/unittests/Transforms/Vectorize/SandboxVectorizer/DependencyGraphTest.cpp
@@ -1256,14 +1256,31 @@ define void @foo(i8 %v0) {
   auto *Add0N = DAG.getNode(Add0);
   auto *Add1N = DAG.getNode(Add1);
   // Mark Add0N and Add1N as scheduled.
+#ifndef NDEBUG
+  EXPECT_TRUE(Add0N->validUnscheduledSuccs());
+#endif
   Add0N->setScheduled(true);
+#ifndef NDEBUG
+  EXPECT_FALSE(Add0N->validUnscheduledSuccs());
+  EXPECT_DEATH(Add0N->getNumUnscheduledSuccs(), ".*");
+#endif
+
+#ifndef NDEBUG
+  EXPECT_TRUE(Add1N->validUnscheduledSuccs());
+#endif
   Add1N->setScheduled(true);
-  EXPECT_EQ(Add0N->getNumUnscheduledSuccs(), 1u);
-  EXPECT_EQ(Add1N->getNumUnscheduledSuccs(), 0u);
+#ifndef NDEBUG
+  EXPECT_FALSE(Add1N->validUnscheduledSuccs());
+  EXPECT_DEATH(Add1N->getNumUnscheduledSuccs(), ".*");
+#endif
 
   // Change Modify's operand and make sure we won't update Add0N's or Add1N's
   // unscheduled succs.
   Modify->setOperand(0, Add1);
-  EXPECT_EQ(Add0N->getNumUnscheduledSuccs(), 1u);
-  EXPECT_EQ(Add1N->getNumUnscheduledSuccs(), 0u);
+#ifndef NDEBUG
+  EXPECT_FALSE(Add0N->validUnscheduledSuccs());
+  EXPECT_DEATH(Add0N->getNumUnscheduledSuccs(), ".*");
+  EXPECT_FALSE(Add1N->validUnscheduledSuccs());
+  EXPECT_DEATH(Add1N->getNumUnscheduledSuccs(), ".*");
+#endif
 }


### PR DESCRIPTION
When a DAG node gets scheduled, it's UnscheduledSuccs variable becomes invalid. Up until now we had no way in the code of expressing this.

This patch converts UnscheduledSuccs to an std::optional in order to protect its use when not valid.