### PR TITLE
[SYCL] Correct emission status reporting for function templates declared with SYCL attributes.

### DIFF
--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -21086,16 +21086,14 @@ Sema::FunctionEmissionStatus Sema::getEmissionStatus(const FunctionDecl *FD,
                                                      bool Final) {
   assert(FD && "Expected non-null FunctionDecl");
 
-  // SYCL functions can be template, so we check if they have appropriate
-  // attribute prior to checking if it is a template.
+  // Templates are emitted when they're instantiated.
+  if (FD->isDependentContext())
+    return FunctionEmissionStatus::TemplateDiscarded;
+
   if (LangOpts.SYCLIsDevice && (FD->hasAttr<SYCLKernelAttr>() ||
                                 FD->hasAttr<SYCLKernelEntryPointAttr>() ||
                                 FD->hasAttr<SYCLExternalAttr>()))
     return FunctionEmissionStatus::Emitted;
-
-  // Templates are emitted when they're instantiated.
-  if (FD->isDependentContext())
-    return FunctionEmissionStatus::TemplateDiscarded;
 
   // Check whether this function is an externally visible definition.
   auto IsEmittedForExternalSymbol = [this, FD]() {


### PR DESCRIPTION
Commit cf6cc662eeee2b1416430f517850be9032788e39 ([OpenMP][SYCL] Improve diagnosing of unsupported types usage) customized `Sema::getEmissionStatus()` to return `Emitted` for a function declared with the `sycl_kernel` attribute during device compilation. That change is appropriate, but was inserted before a check for a dependent context and resulted in `Emitted` being returned instead of `TemplateDiscarded` for templated functions declared with the attribute. That appears to be incorrect; templated functions are still discarded.

The customization was extended to include the `sycl_kernel_entry_point` and `sycl_external` attributes in commit 23e4fe040b67e2dd419652830a87093a93ea1a97 ([SYCL] SYCL host kernel launch support for the sycl_kernel_entry_point attribute). Those additions are appropriate, but the effect on templated functions (as opposed to their instantiations) resulted in the incorrect status being observed in a downstream fork of Clang.

This change corrects `Sema::getEmissionStatus()` to once again unconditionally return `TemplateDiscarded` for templated functions.