### PR TITLE
[LLVM] Fix assertion when dropping type tests with SelectInst users

### DIFF
--- a/llvm/lib/Transforms/IPO/LowerTypeTests.cpp
+++ b/llvm/lib/Transforms/IPO/LowerTypeTests.cpp
@@ -2002,14 +2002,14 @@ static void dropTypeTests(Module &M, Function &TypeTestFunc,
       if (auto *Assume = dyn_cast<AssumeInst>(CIU.getUser()))
         Assume->eraseFromParent();
     // If the assume was merged with another assume, we might have a use on a
-    // phi (which will feed the assume). Simply replace the use on the phi
-    // with "true" and leave the merged assume.
+    // phi or select (which will feed the assume). Simply replace the use on
+    // the phi/select with "true" and leave the merged assume.
     //
     // If ShouldDropAll is set, then we  we need to update any remaining uses,
     // regardless of the instruction type.
     if (!CI->use_empty()) {
       assert(ShouldDropAll || all_of(CI->users(), [](User *U) -> bool {
-               return isa<PHINode>(U);
+               return isa<PHINode>(U) || isa<SelectInst>(U);
              }));
       CI->replaceAllUsesWith(ConstantInt::getTrue(M.getContext()));
     }

--- a/llvm/test/Transforms/LowerTypeTests/drop_type_test_select.ll
+++ b/llvm/test/Transforms/LowerTypeTests/drop_type_test_select.ll
@@ -1,6 +1,6 @@
-; Test to ensure dropping of type tests can handle a select feeding the assume.
-; This pattern is created by SimplifyCFG when merging two type test + assume
-; sequences from different branches.
+;; Test to ensure dropping of type tests can handle a select feeding the assume.
+;; This pattern is created by SimplifyCFG when merging two type test + assume
+;; sequences from different branches.
 ; RUN: opt -S -passes=lowertypetests -lowertypetests-drop-type-tests=assume %s | FileCheck %s
 
 ; CHECK-LABEL: define void @test

--- a/llvm/test/Transforms/LowerTypeTests/drop_type_test_select.ll
+++ b/llvm/test/Transforms/LowerTypeTests/drop_type_test_select.ll
@@ -1,0 +1,19 @@
+; Test to ensure dropping of type tests can handle a select feeding the assume.
+; This pattern is created by SimplifyCFG when merging two type test + assume
+; sequences from different branches.
+; RUN: opt -S -passes=lowertypetests -lowertypetests-drop-type-tests=assume %s | FileCheck %s
+
+; CHECK-LABEL: define void @test
+define void @test(ptr %p, i1 %cond) {
+  %tt1 = call i1 @llvm.type.test(ptr %p, metadata !"_ZTS4Base")
+  %tt2 = call i1 @llvm.type.test(ptr %p, metadata !"_ZTS7Derived")
+; CHECK-NOT: @llvm.type.test
+  %sel = select i1 %cond, i1 %tt2, i1 %tt1
+  call void @llvm.assume(i1 %sel)
+; CHECK: %sel = select i1 %cond, i1 true, i1 true
+; CHECK: call void @llvm.assume(i1 %sel)
+  ret void
+}
+
+declare i1 @llvm.type.test(ptr, metadata)
+declare void @llvm.assume(i1)


### PR DESCRIPTION
The `dropTypeTests` function assumes that after removing `llvm.assume` users of `llvm.type.test` calls, any remaining users must be PHINodes (from merged assumes). However, SimplifyCFG can also merge two `assume(type.test(...))` sequences into `assume(select(cond, type.test_1, type.test_2))`, leaving SelectInst users that trigger the assertion.

Extend the assertion to also accept SelectInst. The `replaceAllUsesWith(true)` call already handles all user types
correctly — only the assertion was too narrow.