### PR TITLE
[Dexter] Add missing calls to SBDebugger::{Initialize,Terminate}

### DIFF
--- a/cross-project-tests/debuginfo-tests/dexter/dex/debugger/lldb/LLDB.py
+++ b/cross-project-tests/debuginfo-tests/dexter/dex/debugger/lldb/LLDB.py
@@ -32,6 +32,10 @@ class LLDB(DebuggerBase):
         # condition. See get_triggered_breakpoint_ids usage for more info.
         self._breakpoint_conditions = {}
         super(LLDB, self).__init__(context, *args)
+        self._interface.SBDebugger.Initialize()
+
+    def __del__(self):
+        self._interface.SBDebugger.Terminate()
 
     def _custom_init(self):
         self._debugger = self._interface.SBDebugger.Create()
@@ -49,8 +53,10 @@ class LLDB(DebuggerBase):
     def _custom_exit(self):
         if getattr(self, "_process", None):
             self._process.Kill()
-        if getattr(self, "_debugger", None) and getattr(self, "_target", None):
-            self._debugger.DeleteTarget(self._target)
+        if getattr(self, "_debugger", None):
+            if getattr(self, "_target", None):
+                self._debugger.DeleteTarget(self._target)
+            self._interface.SBDebugger.Destroy(self._debugger)
 
     def _translate_stop_reason(self, reason):
         if reason == self._interface.eStopReasonNone:

--- a/cross-project-tests/debuginfo-tests/dexter/dex/debugger/lldb/LLDB.py
+++ b/cross-project-tests/debuginfo-tests/dexter/dex/debugger/lldb/LLDB.py
@@ -32,10 +32,12 @@ class LLDB(DebuggerBase):
         # condition. See get_triggered_breakpoint_ids usage for more info.
         self._breakpoint_conditions = {}
         super(LLDB, self).__init__(context, *args)
-        self._interface.SBDebugger.Initialize()
+        if self.has_loaded:
+            self._interface.SBDebugger.Initialize()
 
     def __del__(self):
-        self._interface.SBDebugger.Terminate()
+        if self.has_loaded:
+            self._interface.SBDebugger.Terminate()
 
     def _custom_init(self):
         self._debugger = self._interface.SBDebugger.Create()


### PR DESCRIPTION
When using LLDB, the first and last call should be SBDebugger::Initialize and SBDebugger::Terminate respectively.

While we're resilient against mistakes, I'm adding an assert (#185162) to debug builds to catch those mistakes in-tree as they have the potential to leak resources. The assert was tripped by Dexter.

This PR adds the missing calls to SBDebugger::{Initialize,Terminate}, and while I was at it, I also added a missing call to SBDebugger::Destroy. With that, the Dexter tests pass locally with the assert enabled.