### PR TITLE
[lldb] Catch missing calls to SystemLifetimeManager::Initialize

### DIFF
--- a/lldb/include/lldb/Initialization/SystemLifetimeManager.h
+++ b/lldb/include/lldb/Initialization/SystemLifetimeManager.h
@@ -10,7 +10,6 @@
 #define LLDB_INITIALIZATION_SYSTEMLIFETIMEMANAGER_H
 
 #include "lldb/Initialization/SystemInitializer.h"
-#include "lldb/lldb-private-types.h"
 #include "llvm/Support/Error.h"
 
 #include <memory>
@@ -29,7 +28,8 @@ public:
 private:
   std::recursive_mutex m_mutex;
   std::unique_ptr<SystemInitializer> m_initializer;
-  bool m_initialized = false;
+  uint8_t m_initialized = 0;
+  uint8_t m_terminated = 0;
 
   // Noncopyable.
   SystemLifetimeManager(const SystemLifetimeManager &other) = delete;

--- a/lldb/source/Initialization/SystemLifetimeManager.cpp
+++ b/lldb/source/Initialization/SystemLifetimeManager.cpp
@@ -17,18 +17,17 @@ using namespace lldb_private;
 SystemLifetimeManager::SystemLifetimeManager() : m_mutex() {}
 
 SystemLifetimeManager::~SystemLifetimeManager() {
-  assert(!m_initialized &&
+  assert(m_initialized != 0 &&
+         "SystemLifetimeManager destroyed without calling Initialize!");
+  assert(m_initialized == m_terminated &&
          "SystemLifetimeManager destroyed without calling Terminate!");
 }
 
 llvm::Error SystemLifetimeManager::Initialize(
     std::unique_ptr<SystemInitializer> initializer) {
   std::lock_guard<std::recursive_mutex> guard(m_mutex);
-  if (!m_initialized) {
-    assert(!m_initializer && "Attempting to call "
-                             "SystemLifetimeManager::Initialize() when it is "
-                             "already initialized");
-    m_initialized = true;
+  if (!m_initializer) {
+    m_initialized++;
     m_initializer = std::move(initializer);
 
     if (auto e = m_initializer->Initialize())
@@ -41,10 +40,9 @@ llvm::Error SystemLifetimeManager::Initialize(
 void SystemLifetimeManager::Terminate() {
   std::lock_guard<std::recursive_mutex> guard(m_mutex);
 
-  if (m_initialized) {
+  if (m_initializer) {
     m_initializer->Terminate();
-
     m_initializer.reset();
-    m_initialized = false;
+    m_terminated++;
   }
 }


### PR DESCRIPTION
We already catch missing calls to SystemLifetimeManager::Terminate, but not for Initialize. This adds the missing assert and also makes sure it behaves correctly when initializing and terminating more than once, which is now supported.