### PR TITLE
[lldb] Reinstate ~PluginInstances assertion

### DIFF
--- a/lldb/source/Core/PluginManager.cpp
+++ b/lldb/source/Core/PluginManager.cpp
@@ -493,7 +493,15 @@ template <typename Callback> struct PluginInstance {
 
 template <typename Instance> class PluginInstances {
 public:
-  ~PluginInstances() {}
+  ~PluginInstances() {
+#ifndef NDEBUG
+    for (const auto &instance : m_instances)
+      llvm::errs() << llvm::formatv("Use `image lookup -va {0:x}` to find out "
+                                    "which callback was not removed\n",
+                                    instance.create_callback);
+#endif
+    assert(m_instances.empty() && "forgot to unregister plugin?");
+  }
 
   template <typename... Args>
   bool RegisterPlugin(llvm::StringRef name, llvm::StringRef description,


### PR DESCRIPTION
This re-enables the assertion in the PluginInstances destructor that catches plugins that were not unregistered in their Terminate method. It also adds a helpful message to quickly identify the plugin.