### PR TITLE
[lldb] Turn on OSC 9;4 graphical progress in supported terminals

### DIFF
--- a/lldb/source/Core/CoreProperties.td
+++ b/lldb/source/Core/CoreProperties.td
@@ -184,7 +184,7 @@ let Definition = "debugger", Path = "" in {
   def ShowProgress
       : Property<"show-progress", "Boolean">,
         Global,
-        DefaultFalse,
+        DefaultTrue,
         Desc<"Whether to show progress using Operating System Command (OSC) "
              "Sequences in supporting terminal emulators.">;
   def ShowProgressAnsiPrefix: Property<"show-progress-ansi-prefix", "String">,

--- a/lldb/source/Core/Debugger.cpp
+++ b/lldb/source/Core/Debugger.cpp
@@ -2077,6 +2077,30 @@ void Debugger::CancelForwardEvents(const ListenerSP &listener_sp) {
   m_forward_listener_sp.reset();
 }
 
+/// Conservative heuristic to detect whether OSC 9;4 progress is supported by
+/// the current terminal.
+static bool TerminalSupportsOSCProgress() {
+  static std::once_flag g_once_flag;
+  static bool g_supports_osc_progress = false;
+
+  std::call_once(g_once_flag, []() {
+    std::array<const char *, 4> g_known_env_vars = {
+        "WT_SESSION",            // Windows Terminal
+        "ConEmuPID",             // ConEmu
+        "GHOSTTY_RESOURCES_DIR", // Ghostty
+        "OSC_PROGRESS",          // Override
+    };
+    for (const char *env_var : g_known_env_vars) {
+      if (std::getenv(env_var)) {
+        g_supports_osc_progress = true;
+        return;
+      }
+    }
+  });
+
+  return g_supports_osc_progress;
+}
+
 bool Debugger::IsEscapeCodeCapableTTY() {
   if (lldb::LockableStreamFileSP stream_sp = GetOutputStreamSP()) {
     File &file = stream_sp->GetUnlockedFile();
@@ -2305,7 +2329,8 @@ void Debugger::HandleProgressEvent(const lldb::EventSP &event_sp) {
     }
 
     // Show progress using Operating System Command (OSC) sequences.
-    if (GetShowProgress() && IsEscapeCodeCapableTTY()) {
+    if (GetShowProgress() && IsEscapeCodeCapableTTY() &&
+        TerminalSupportsOSCProgress()) {
       if (lldb::LockableStreamFileSP stream_sp = GetOutputStreamSP()) {
 
         // Clear progress if this was the last progress event.

--- a/lldb/source/Core/Debugger.cpp
+++ b/lldb/source/Core/Debugger.cpp
@@ -2080,17 +2080,32 @@ void Debugger::CancelForwardEvents(const ListenerSP &listener_sp) {
 /// Conservative heuristic to detect whether OSC 9;4 progress is supported by
 /// the current terminal.
 static bool TerminalSupportsOSCProgress() {
+#if defined(_WIN32)
+  // On Windows, we assume that the user is using the Windows Terminal.
+  return true;
+#else
   static std::once_flag g_once_flag;
   static bool g_supports_osc_progress = false;
 
   std::call_once(g_once_flag, []() {
-    std::array<const char *, 4> g_known_env_vars = {
-        "WT_SESSION",            // Windows Terminal
-        "ConEmuPID",             // ConEmu
-        "GHOSTTY_RESOURCES_DIR", // Ghostty
-        "OSC_PROGRESS",          // Override
+    // Check TERM_PROGRAM for known supported terminals. This can lead to false
+    // negatives, for example when using tmux.
+    if (const char *term_program = std::getenv("TERM_PROGRAM")) {
+      llvm::StringRef term_program_str(term_program);
+      if (term_program_str.starts_with("ghostty") ||
+          term_program_str.starts_with("wezterm")) {
+        g_supports_osc_progress = true;
+        return;
+      }
+    }
+
+    // Check other known environment variables.
+    std::array<const char *, 3> known_env_vars = {
+        "ConEmuPID", // https://conemu.github.io/en/ConEmuEnvironment.html
+        "GHOSTTY_RESOURCES_DIR", // https://ghostty.org/docs/features/shell-integration
+        "OSC_PROGRESS",          // LLDB specific override.
     };
-    for (const char *env_var : g_known_env_vars) {
+    for (const char *env_var : known_env_vars) {
       if (std::getenv(env_var)) {
         g_supports_osc_progress = true;
         return;
@@ -2099,6 +2114,7 @@ static bool TerminalSupportsOSCProgress() {
   });
 
   return g_supports_osc_progress;
+#endif
 }
 
 bool Debugger::IsEscapeCodeCapableTTY() {


### PR DESCRIPTION
In #162162, I added support for OSC 9;4 graphical progress. I put it behind the `show-progress` setting because I didn't have a reliable way to detect whether the escape code was supported by the terminal.

Since then, more tools have added support for it, most notably Claude Code and Homebrew. While I still don't have a good way to detect this, there are a handful of known terminals that are easy enough to identify.

This PR toggles the default of `show-progress` to on again and puts showing the progress behind a check for those known terminals (Windows Terminal, ConEmu & Ghostty).

This means that if you're running in one of those, you'll get the visual progress by default unless you set `show-progress` to off. The downside is that if you're on an unrecognized terminal, you can't force it on any longer by setting `show-progress` to on. I think that's a fair trade-off as the setting wasn't really advertised and I doubt many people are using that. As a workaround, they can set `OSC_PROGRESS` to spoof an OSC-supporting terminal.