### PR TITLE
[bazel] Explicitly disable pfm shared lib

### DIFF
--- a/utils/bazel/third_party_build/pfm.BUILD
+++ b/utils/bazel/third_party_build/pfm.BUILD
@@ -13,6 +13,9 @@ filegroup(
 make_variant(
     name = "pfm",
     copts = ["-w"],
+    env = {
+        "CONFIG_PFMLIB_SHARED": "n",
+    },
     lib_name = "libpfm",
     lib_source = ":sources",
     target_compatible_with = select({


### PR DESCRIPTION
We don't consume this but it was getting built behind the scenes. This
can matter if you use a custom toolchain that isn't compatible with
producing this.
