### PR TITLE
[RISCV] Disable use of scalable vectors for VLEN=32

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVTargetTransformInfo.h
+++ b/llvm/lib/Target/RISCV/RISCVTargetTransformInfo.h
@@ -113,7 +113,9 @@ public:
 
   bool shouldExpandReduction(const IntrinsicInst *II) const override;
   bool supportsScalableVectors() const override {
-    return ST->hasVInstructions();
+    // VLEN=32 support is incomplete.
+    return ST->hasVInstructions() &&
+           (ST->getRealMinVLen() >= RISCV::RVVBitsPerBlock);
   }
   bool enableOrderedReductions() const override { return true; }
   bool enableScalableVectorization() const override {


### PR DESCRIPTION
This patch prevents the loop vectorizer to choose scalable vector type when target VLEN is less than RVVBitsPerBlock.