### PR TITLE
[DA] Fix test case for the Weak Zero SIV tests (NFC)

### DIFF
--- a/llvm/test/Analysis/DependenceAnalysis/weak-zero-siv-overflow.ll
+++ b/llvm/test/Analysis/DependenceAnalysis/weak-zero-siv-overflow.ll
@@ -92,7 +92,7 @@ entry:
 
 loop.header:
   %i = phi i64 [ 0, %entry ], [ %i.inc, %loop.latch ]
-  %offset = phi i64 [ -2, %entry ], [ %offset.next, %loop.latch ]
+  %offset = phi i64 [ -1, %entry ], [ %offset.next, %loop.latch ]
   %ec = icmp eq i64 %i, %n
   br i1 %ec, label %exit, label %loop.body
 


### PR DESCRIPTION
The IR does not match the pseudo code. The pseudo code is intentional, so update the IR accordingly.