### PR TITLE
[lldb] Update test diff invocation for portability

### DIFF
--- a/lldb/test/Shell/ScriptInterpreter/Python/python-bytecode.test
+++ b/lldb/test/Shell/ScriptInterpreter/Python/python-bytecode.test
@@ -1,6 +1,6 @@
 # RUN: mkdir -p %t
 # RUN: %python %S/../../../../examples/python/formatter_bytecode.py --compile %s --format c --type-name RigidArray --output %t/output.txt
-# RUN: diff -u %S/Inputs/FormatterBytecode/RigidArrayLLDBFormatter.txt %t/output.txt
+# RUN: diff -u --strip-trailing-cr %S/Inputs/FormatterBytecode/RigidArrayLLDBFormatter.txt %t/output.txt
 import lldb
 
 


### PR DESCRIPTION
Use --strip-trailing-cr to ignore line ending differences. Fixes failures on windows.
