### PR TITLE
[OpenMP][NFC] Fix stale DeviceRTL header path in OpenMPIRBuilder

### DIFF
--- a/llvm/include/llvm/Frontend/OpenMP/OMPIRBuilder.h
+++ b/llvm/include/llvm/Frontend/OpenMP/OMPIRBuilder.h
@@ -3253,7 +3253,7 @@ public:
   /// The `omp target` interface
   ///
   /// For more information about the usage of this interface,
-  /// \see openmp/libomptarget/deviceRTLs/common/include/target.h
+  /// \see openmp/device/include/Interface.h
   ///
   ///{
 


### PR DESCRIPTION
The `\see` comment in `OpenMPIRBuilder.h` references `openmp/libomptarget/deviceRTLs/common/include/target.h`. This file no longer exists.

This patch updates the comment to point to the current correct header: `openmp/device/include/Interface.h`.