### PR TITLE
[llvm-symbolizer] Eagerly flush markup-less line fragments

### DIFF
--- a/llvm/include/llvm/DebugInfo/Symbolize/MarkupFilter.h
+++ b/llvm/include/llvm/DebugInfo/Symbolize/MarkupFilter.h
@@ -35,12 +35,18 @@ public:
   LLVM_ABI MarkupFilter(raw_ostream &OS, LLVMSymbolizer &Symbolizer,
                         std::optional<bool> ColorsEnabled = std::nullopt);
 
-  /// Filters a line containing symbolizer markup and writes the human-readable
-  /// results to the output stream.
+  /// Filters input that may contain symbolizer markup and writes the
+  /// human-readable results to the output stream.
+  ///
+  /// Accepts both complete lines and fragments. Fragments without potential
+  /// markup elements are immediately flushed; otherwise they are buffered until
+  /// a newline is encountered. Eager flushing supports the case where an
+  /// interactive is being piped into llvm-symbolizer: without this, a user
+  /// would not be able to see what they were typing until they pressed enter.
   ///
   /// Invalid or unimplemented markup elements are removed. Some output may be
-  /// deferred until future filter() or finish() call.
-  LLVM_ABI void filter(std::string &&InputLine);
+  /// deferred until a future filter() or finish() call.
+  LLVM_ABI void filter(StringRef Input);
 
   /// Records that the input stream has ended and writes any deferred output.
   LLVM_ABI void finish();
@@ -92,6 +98,7 @@ private:
   void beginModuleInfoLine(const Module *M);
   void endAnyModuleInfoLine();
 
+  void processCompleteLine();
   void filterNode(const MarkupNode &Node);
 
   bool tryPresentation(const MarkupNode &Node);
@@ -142,7 +149,8 @@ private:
 
   MarkupParser Parser;
 
-  // Current line being filtered.
+  // Current line being filtered. Accumulates partial input across filter()
+  // calls until a newline completes it.
   std::string Line;
 
   // A module info line currently being built. This incorporates as much mmap

--- a/llvm/lib/DebugInfo/Symbolize/MarkupFilter.cpp
+++ b/llvm/lib/DebugInfo/Symbolize/MarkupFilter.cpp
@@ -38,8 +38,40 @@ MarkupFilter::MarkupFilter(raw_ostream &OS, LLVMSymbolizer &Symbolizer,
       ColorsEnabled(
           ColorsEnabled.value_or(WithColor::defaultAutoDetectFunction()(OS))) {}
 
-void MarkupFilter::filter(std::string &&InputLine) {
-  Line = std::move(InputLine);
+void MarkupFilter::filter(StringRef Input) {
+  Line.append(Input.data(), Input.size());
+
+  // Process all complete lines (i.e,. those terminated by '\n'), saving any
+  // flush till the end.
+  bool ShouldFlush = false;
+  size_t LineEnd;
+  while ((LineEnd = Line.find('\n')) != std::string::npos) {
+    std::string Rest = Line.substr(LineEnd + 1);
+    Line.resize(LineEnd + 1);
+    processCompleteLine();
+    Line = std::move(Rest);
+    ShouldFlush = true;
+  }
+
+  if (!Line.empty()) {
+    // Anything remaining is a fragment without a newline. Eagerly flush if it
+    // does not contain a potential markup element (i.e., if it contains "{{{"
+    // or ends with "{" or "{{"). Otherwise, buffer it for the next round of
+    // input.
+    StringRef S(Line);
+    if (S.find("{{{") == StringRef::npos && !S.ends_with("{") &&
+        !S.ends_with("{{")) {
+      OS << Line;
+      Line.clear();
+      ShouldFlush = true;
+    }
+  }
+
+  if (ShouldFlush)
+    OS.flush();
+}
+
+void MarkupFilter::processCompleteLine() {
   resetColor();
 
   Parser.parseLine(Line);
@@ -62,11 +94,16 @@ void MarkupFilter::filter(std::string &&InputLine) {
 }
 
 void MarkupFilter::finish() {
+  if (!Line.empty()) {
+    Line += '\n';
+    processCompleteLine();
+  }
   Parser.flush();
   while (std::optional<MarkupNode> Node = Parser.nextNode())
     filterNode(*Node);
   endAnyModuleInfoLine();
   resetColor();
+  OS.flush();
   Modules.clear();
   MMaps.clear();
 }

--- a/llvm/tools/llvm-symbolizer/llvm-symbolizer.cpp
+++ b/llvm/tools/llvm-symbolizer/llvm-symbolizer.cpp
@@ -462,14 +462,31 @@ static object::BuildID parseBuildIDArg(const opt::InputArgList &Args, int ID) {
   return BuildID;
 }
 
-// Symbolize markup from stdin and write the result to stdout.
-static void filterMarkup(const opt::InputArgList &Args, LLVMSymbolizer &Symbolizer) {
-  MarkupFilter Filter(outs(), Symbolizer, parseColorArg(Args));
-  std::string InputString;
-  while (std::getline(std::cin, InputString)) {
-    InputString += '\n';
-    Filter.filter(std::move(InputString));
+// Reads an available chunk from IS: blocks for at least one character, and then
+// drains some immediately available characters without blocking. Returns false
+// on EOF.
+static bool readChunk(std::istream &IS, std::string &Result) {
+  Result.clear();
+  char C;
+  if (!IS.get(C))
+    return false;
+
+  Result += C;
+  if (C != '\n') {
+    char Buf[64];
+    if (std::streamsize N = IS.readsome(Buf, sizeof(Buf)))
+      Result.append(Buf, N);
   }
+  return true;
+}
+
+// Symbolize markup from stdin and write the result to stdout.
+static void filterMarkup(const opt::InputArgList &Args,
+                         LLVMSymbolizer &Symbolizer) {
+  MarkupFilter Filter(outs(), Symbolizer, parseColorArg(Args));
+  std::string Chunk;
+  while (readChunk(std::cin, Chunk))
+    Filter.filter(Chunk);
   Filter.finish();
 }
 

--- a/llvm/unittests/DebugInfo/Symbolizer/MarkupTest.cpp
+++ b/llvm/unittests/DebugInfo/Symbolizer/MarkupTest.cpp
@@ -8,9 +8,12 @@
 //===----------------------------------------------------------------------===//
 
 #include "llvm/DebugInfo/Symbolize/Markup.h"
+#include "llvm/DebugInfo/Symbolize/MarkupFilter.h"
+#include "llvm/DebugInfo/Symbolize/Symbolize.h"
 
 #include "llvm/ADT/Twine.h"
 #include "llvm/Support/FormatVariadic.h"
+#include "llvm/Support/raw_ostream.h"
 
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
@@ -216,6 +219,87 @@ TEST(SymbolizerMarkup, MultilineElements) {
               testing::Optional(isNode("{{{first:\033[0m}}}", "first",
                                        ElementsAre("\033[0m"))));
   EXPECT_THAT(Parser.nextNode(), std::nullopt);
+}
+
+
+// Non-markup fragments are eagerly flushed before any newline arrives.
+TEST(MarkupFilter, EagerFragmentFlush) {
+  std::string Out;
+  raw_string_ostream OS(Out);
+  LLVMSymbolizer Symbolizer;
+  MarkupFilter Filter(OS, Symbolizer, /*ColorsEnabled=*/false);
+
+  Filter.filter("hello ");
+  EXPECT_EQ(Out, "hello ");
+
+  Filter.filter("world");
+  EXPECT_EQ(Out, "hello world");
+
+  // Newline triggers complete-line processing.
+  Filter.filter("\n");
+  EXPECT_EQ(Out, "hello world\n");
+}
+
+// A fragment ending with '{', '{{', or containing '{{{' may be the start of a
+// markup element and is held for more input.
+TEST(MarkupFilter, HoldMarkupFragment) {
+  std::string Out;
+  raw_string_ostream OS(Out);
+  LLVMSymbolizer Symbolizer;
+  MarkupFilter Filter(OS, Symbolizer, /*ColorsEnabled=*/false);
+
+  // Trailing '{' held (could be start of '{{{').
+  Filter.filter("text {");
+  EXPECT_EQ(Out, "");
+
+  // Trailing "{{"" still held.
+  Filter.filter("{");
+  EXPECT_EQ(Out, "");
+
+  // "{{{" present but still no newline. Should still be held.
+  Filter.filter("{unknown:");
+  EXPECT_EQ(Out, "");
+
+  // Completing to a non-special element on a full line flushes everything.
+  Filter.filter("foo}}}\n");
+  EXPECT_EQ(Out, "text {{{unknown:foo}}}\n");
+}
+
+// Multiple complete lines in a single filter() call are all processed.
+TEST(MarkupFilter, MultipleCompleteLines) {
+  std::string Out;
+  raw_string_ostream OS(Out);
+  LLVMSymbolizer Symbolizer;
+  MarkupFilter Filter(OS, Symbolizer, /*ColorsEnabled=*/false);
+
+  Filter.filter("line1\nline2\nline3\n");
+  EXPECT_EQ(Out, "line1\nline2\nline3\n");
+}
+
+// A complete line followed by a non-markup fragment: the line is processed and
+// the fragment is eagerly flushed in the same call.
+TEST(MarkupFilter, CompleteLineThenFragment) {
+  std::string Out;
+  raw_string_ostream OS(Out);
+  LLVMSymbolizer Symbolizer;
+  MarkupFilter Filter(OS, Symbolizer, /*ColorsEnabled=*/false);
+
+  Filter.filter("line1\nfragment");
+  EXPECT_EQ(Out, "line1\nfragment");
+}
+
+// finish() processes a held markup fragment by appending a synthetic newline.
+TEST(MarkupFilter, FinishProcessesHeldFragment) {
+  std::string Out;
+  raw_string_ostream OS(Out);
+  LLVMSymbolizer Symbolizer;
+  MarkupFilter Filter(OS, Symbolizer, /*ColorsEnabled=*/false);
+
+  Filter.filter("pre {{{unknown:foo}}}");
+  EXPECT_EQ(Out, "");
+
+  Filter.finish();
+  EXPECT_EQ(Out, "pre {{{unknown:foo}}}\n");
 }
 
 } // namespace


### PR DESCRIPTION
Previously, llvm-symbolizer's main flushing routine would block until a
complete line was available for processing. This meant that an
interactive shell piped into llvm-symbolizer would have the unpleasant
effect of preventing a user from seeing what they were typing until
they pressed enter. This is a common, everyday use-case/desire in
developing an operating system that emits LLVM symbolizer markup, and
interacting with its console via QEMU.

We update that flushing routine to accept both complete lines and
fragments. Fragments without potential markup elements are immediately
flushed; otherwise they are buffered until a newline is encountered.
