### PR TITLE
[lld][WebAssembly] Restore inactive checks relocatable.ll test. NFC

### DIFF
--- a/lld/test/wasm/relocatable.ll
+++ b/lld/test/wasm/relocatable.ll
@@ -119,176 +119,204 @@ define void @_start() {
 ; CHECK-NEXT:       - Index:         5
 ; CHECK-NEXT:         Locals:
 ; CHECK-NEXT:         Body:          4187808080000B
-; NORMAL-NEXT:  - Type:            DATA
-; NORMAL-NEXT:    Relocations:
-; NORMAL-NEXT:      - Type:            R_WASM_TABLE_INDEX_I32
-; NORMAL-NEXT:        Index:           3
-; NORMAL-NEXT:        Offset:          0x1A
-; NORMAL-NEXT:      - Type:            R_WASM_TABLE_INDEX_I32
-; NORMAL-NEXT:        Index:           4
-; NORMAL-NEXT:        Offset:          0x23
-; NORMAL-NEXT:      - Type:            R_WASM_TABLE_INDEX_I32
-; NORMAL-NEXT:        Index:           5
-; NORMAL-NEXT:        Offset:          0x2C
-; NORMAL-NEXT:      - Type:            R_WASM_MEMORY_ADDR_I32
-; NORMAL-NEXT:        Index:           12
-; NORMAL-NEXT:        Offset:          0x35
-; NORMAL-NEXT:    Segments:
-; NORMAL-NEXT:      - SectionOffset:   6
-; NORMAL-NEXT:        InitFlags:       0
-; NORMAL-NEXT:        Offset:
-; NORMAL-NEXT:          Opcode:          I32_CONST
-; NORMAL-NEXT:          Value:           0
-; NORMAL-NEXT:        Content:         68656C6C6F0A00
-; NORMAL-NEXT:      - SectionOffset:   18
-; NORMAL-NEXT:        InitFlags:       0
-; NORMAL-NEXT:        Offset:
-; NORMAL-NEXT:          Opcode:          I32_CONST
-; NORMAL-NEXT:          Value:           7
-; NORMAL-NEXT:        Content:         '616263'
-; NORMAL-NEXT:      - SectionOffset:   26
-; NORMAL-NEXT:        InitFlags:       0
-; NORMAL-NEXT:        Offset:
-; NORMAL-NEXT:          Opcode:          I32_CONST
-; NORMAL-NEXT:          Value:           12
-; NORMAL-NEXT:        Content:         '01000000'
-; NORMAL-NEXT:      - SectionOffset:   35
-; NORMAL-NEXT:        InitFlags:       0
-; NORMAL-NEXT:        Offset:
-; NORMAL-NEXT:          Opcode:          I32_CONST
-; NORMAL-NEXT:          Value:           16
-; NORMAL-NEXT:        Content:         '02000000'
-; NORMAL-NEXT:      - SectionOffset:   44
-; NORMAL-NEXT:        InitFlags:       0
-; NORMAL-NEXT:        Offset:
-; NORMAL-NEXT:          Opcode:          I32_CONST
-; NORMAL-NEXT:          Value:           20
-; NORMAL-NEXT:        Content:         '03000000'
-; NORMAL-NEXT:      - SectionOffset:   53
-; NORMAL-NEXT:        InitFlags:       0
-; NORMAL-NEXT:        Offset:
-; NORMAL-NEXT:          Opcode:          I32_CONST
-; NORMAL-NEXT:          Value:           24
-; NORMAL-NEXT:        Content:         '00000000'
-; NORMAL-NEXT:  - Type:            CUSTOM
-; NORMAL-NEXT:    Name:            linking
-; NORMAL-NEXT:    Version:         2
-; NORMAL-NEXT:    SymbolTable:
-; NORMAL-NEXT:      - Index:           0
-; NORMAL-NEXT:        Kind:            FUNCTION
-; NORMAL-NEXT:        Name:            hello
-; NORMAL-NEXT:        Flags:           [ VISIBILITY_HIDDEN ]
-; NORMAL-NEXT:        Function:        3
-; NORMAL-NEXT:      - Index:           1
-; NORMAL-NEXT:        Kind:            DATA
-; NORMAL-NEXT:        Name:            hello_str
-; NORMAL-NEXT:        Flags:           [  ]
-; NORMAL-NEXT:        Segment:         0
-; NORMAL-NEXT:        Size:            7
-; NORMAL-NEXT:      - Index:           2
-; NORMAL-NEXT:        Kind:            FUNCTION
-; NORMAL-NEXT:        Name:            puts
-; NORMAL-NEXT:        Flags:           [ UNDEFINED ]
-; NORMAL-NEXT:        Function:        0
-; NORMAL-NEXT:      - Index:           3
-; NORMAL-NEXT:        Kind:            FUNCTION
-; NORMAL-NEXT:        Name:            my_func
-; NORMAL-NEXT:        Flags:           [ VISIBILITY_HIDDEN, NO_STRIP ]
-; NORMAL-NEXT:        Function:        4
-; NORMAL-NEXT:      - Index:           4
-; NORMAL-NEXT:        Kind:            FUNCTION
-; NORMAL-NEXT:        Name:            foo_import
-; NORMAL-NEXT:        Flags:           [ UNDEFINED ]
-; NORMAL-NEXT:        Function:        1
-; NORMAL-NEXT:      - Index:           5
-; NORMAL-NEXT:        Kind:            FUNCTION
-; NORMAL-NEXT:        Name:            bar_import
-; NORMAL-NEXT:        Flags:           [ BINDING_WEAK, UNDEFINED ]
-; NORMAL-NEXT:        Function:        2
-; NORMAL-NEXT:      - Index:           6
-; NORMAL-NEXT:        Kind:            FUNCTION
-; NORMAL-NEXT:        Name:            func_comdat
-; NORMAL-NEXT:        Flags:           [ BINDING_WEAK ]
-; NORMAL-NEXT:        Function:        5
-; NORMAL-NEXT:      - Index:           7
-; NORMAL-NEXT:        Kind:            DATA
-; NORMAL-NEXT:        Name:            data_comdat
-; NORMAL-NEXT:        Flags:           [ BINDING_WEAK ]
-; NORMAL-NEXT:        Segment:         1
-; NORMAL-NEXT:        Size:            3
-; NORMAL-NEXT:      - Index:           8
-; NORMAL-NEXT:        Kind:            DATA
-; NORMAL-NEXT:        Name:            func_addr1
-; NORMAL-NEXT:        Flags:           [ VISIBILITY_HIDDEN ]
-; NORMAL-NEXT:        Segment:         2
-; NORMAL-NEXT:        Size:            4
-; NORMAL-NEXT:      - Index:           9
-; NORMAL-NEXT:        Kind:            DATA
-; NORMAL-NEXT:        Name:            func_addr2
-; NORMAL-NEXT:        Flags:           [ VISIBILITY_HIDDEN ]
-; NORMAL-NEXT:        Segment:         3
-; NORMAL-NEXT:        Size:            4
-; NORMAL-NEXT:      - Index:           10
-; NORMAL-NEXT:        Kind:            DATA
-; NORMAL-NEXT:        Name:            func_addr3
-; NORMAL-NEXT:        Flags:           [ VISIBILITY_HIDDEN ]
-; NORMAL-NEXT:        Segment:         4
-; NORMAL-NEXT:        Size:            4
-; NORMAL-NEXT:      - Index:           11
-; NORMAL-NEXT:        Kind:            DATA
-; NORMAL-NEXT:        Name:            data_addr1
-; NORMAL-NEXT:        Flags:           [ VISIBILITY_HIDDEN ]
-; NORMAL-NEXT:        Segment:         5
-; NORMAL-NEXT:        Size:            4
-; NORMAL-NEXT:      - Index:           12
-; NORMAL-NEXT:        Kind:            DATA
-; NORMAL-NEXT:        Name:            data_import
-; NORMAL-NEXT:        Flags:           [ UNDEFINED ]
-; NORMAL-NEXT:    SegmentInfo:
-; NORMAL-NEXT:      - Index:           0
-; NORMAL-NEXT:        Name:            .rodata.hello_str
-; NORMAL-NEXT:        Alignment:       0
-; NORMAL-NEXT:        Flags:           [  ]
-; NORMAL-NEXT:      - Index:           1
-; NORMAL-NEXT:        Name:            .rodata.data_comdat
-; NORMAL-NEXT:        Alignment:       0
-; NORMAL-NEXT:        Flags:           [  ]
-; NORMAL-NEXT:      - Index:           2
-; NORMAL-NEXT:        Name:            .data.func_addr1
-; NORMAL-NEXT:        Alignment:       2
-; NORMAL-NEXT:        Flags:           [  ]
-; NORMAL-NEXT:      - Index:           3
-; NORMAL-NEXT:        Name:            .data.func_addr2
-; NORMAL-NEXT:        Alignment:       2
-; NORMAL-NEXT:        Flags:           [  ]
-; NORMAL-NEXT:      - Index:           4
-; NORMAL-NEXT:        Name:            .data.func_addr3
-; NORMAL-NEXT:        Alignment:       2
-; NORMAL-NEXT:        Flags:           [  ]
-; NORMAL-NEXT:      - Index:           5
-; NORMAL-NEXT:        Name:            .data.data_addr1
-; NORMAL-NEXT:        Alignment:       3
-; NORMAL-NEXT:        Flags:           [  ]
-; NORMAL-NEXT:    Comdats:
-; NORMAL-NEXT:      - Name:            func_comdat
-; NORMAL-NEXT:        Entries:
-; NORMAL-NEXT:          - Kind:            FUNCTION
-; NORMAL-NEXT:            Index:           5
-; NORMAL-NEXT:          - Kind:            DATA
-; NORMAL-NEXT:            Index:           1
-; NORMAL-NEXT:  - Type:            CUSTOM
-; NORMAL-NEXT:    Name:            name
-; NORMAL-NEXT:    FunctionNames:
-; NORMAL-NEXT:      - Index:           0
-; NORMAL-NEXT:        Name:            puts
-; NORMAL-NEXT:      - Index:           1
-; NORMAL-NEXT:        Name:            foo_import
-; NORMAL-NEXT:      - Index:           2
-; NORMAL-NEXT:        Name:            bar_import
-; NORMAL-NEXT:      - Index:           3
-; NORMAL-NEXT:        Name:            hello
-; NORMAL-NEXT:      - Index:           4
-; NORMAL-NEXT:        Name:            my_func
-; NORMAL-NEXT:      - Index:           5
-; NORMAL-NEXT:        Name:            func_comdat
-; NORMAL-NEXT:...
+; CHECK-NEXT:       - Index:           6
+; CHECK-NEXT:         Locals:          []
+; CHECK-NEXT:         Body:            0B
+; CHECK-NEXT:  - Type:            DATA
+; CHECK-NEXT:    Relocations:
+; CHECK-NEXT:      - Type:            R_WASM_TABLE_INDEX_I32
+; CHECK-NEXT:        Index:           3
+; CHECK-NEXT:        Offset:          0x1A
+; CHECK-NEXT:      - Type:            R_WASM_TABLE_INDEX_I32
+; CHECK-NEXT:        Index:           4
+; CHECK-NEXT:        Offset:          0x23
+; CHECK-NEXT:      - Type:            R_WASM_TABLE_INDEX_I32
+; CHECK-NEXT:        Index:           5
+; CHECK-NEXT:        Offset:          0x2C
+; CHECK-NEXT:      - Type:            R_WASM_MEMORY_ADDR_I32
+; CHECK-NEXT:        Index:           13
+; CHECK-NEXT:        Offset:          0x35
+; CHECK-NEXT:    Segments:
+; CHECK-NEXT:      - SectionOffset:   6
+; CHECK-NEXT:        InitFlags:       0
+; CHECK-NEXT:        Offset:
+; CHECK-NEXT:          Opcode:          I32_CONST
+; CHECK-NEXT:          Value:           0
+; CHECK-NEXT:        Content:         68656C6C6F0A00
+; CHECK-NEXT:      - SectionOffset:   18
+; CHECK-NEXT:        InitFlags:       0
+; CHECK-NEXT:        Offset:
+; CHECK-NEXT:          Opcode:          I32_CONST
+; CHECK-NEXT:          Value:           7
+; CHECK-NEXT:        Content:         '616263'
+; CHECK-NEXT:      - SectionOffset:   26
+; CHECK-NEXT:        InitFlags:       0
+; CHECK-NEXT:        Offset:
+; CHECK-NEXT:          Opcode:          I32_CONST
+; CHECK-NEXT:          Value:           12
+; CHECK-NEXT:        Content:         '01000000'
+; CHECK-NEXT:      - SectionOffset:   35
+; CHECK-NEXT:        InitFlags:       0
+; CHECK-NEXT:        Offset:
+; CHECK-NEXT:          Opcode:          I32_CONST
+; CHECK-NEXT:          Value:           16
+; CHECK-NEXT:        Content:         '02000000'
+; CHECK-NEXT:      - SectionOffset:   44
+; CHECK-NEXT:        InitFlags:       0
+; CHECK-NEXT:        Offset:
+; CHECK-NEXT:          Opcode:          I32_CONST
+; CHECK-NEXT:          Value:           20
+; CHECK-NEXT:        Content:         '03000000'
+; CHECK-NEXT:      - SectionOffset:   53
+; CHECK-NEXT:        InitFlags:       0
+; CHECK-NEXT:        Offset:
+; CHECK-NEXT:          Opcode:          I32_CONST
+; CHECK-NEXT:          Value:           24
+; CHECK-NEXT:        Content:         '00000000'
+; CHECK-NEXT:  - Type:            CUSTOM
+; CHECK-NEXT:    Name:            linking
+; CHECK-NEXT:    Version:         2
+; CHECK-NEXT:    SymbolTable:
+; CHECK-NEXT:      - Index:           0
+; CHECK-NEXT:        Kind:            FUNCTION
+; CHECK-NEXT:        Name:            hello
+; CHECK-NEXT:        Flags:           [  ]
+; CHECK-NEXT:        Function:        3
+; CHECK-NEXT:      - Index:           1
+; CHECK-NEXT:        Kind:            DATA
+; CHECK-NEXT:        Name:            hello_str
+; CHECK-NEXT:        Flags:           [  ]
+; CHECK-NEXT:        Segment:         0
+; CHECK-NEXT:        Size:            7
+; CHECK-NEXT:      - Index:           2
+; CHECK-NEXT:        Kind:            FUNCTION
+; CHECK-NEXT:        Name:            puts
+; CHECK-NEXT:        Flags:           [ UNDEFINED ]
+; CHECK-NEXT:        Function:        0
+; CHECK-NEXT:      - Index:           3
+; CHECK-NEXT:        Kind:            FUNCTION
+; CHECK-NEXT:        Name:            my_func
+; CHECK-NEXT:        Flags:           [ VISIBILITY_HIDDEN, NO_STRIP ]
+; CHECK-NEXT:        Function:        4
+; CHECK-NEXT:      - Index:           4
+; CHECK-NEXT:        Kind:            FUNCTION
+; CHECK-NEXT:        Name:            foo_import
+; CHECK-NEXT:        Flags:           [ UNDEFINED ]
+; CHECK-NEXT:        Function:        1
+; CHECK-NEXT:      - Index:           5
+; CHECK-NEXT:        Kind:            FUNCTION
+; CHECK-NEXT:        Name:            bar_import
+; CHECK-NEXT:        Flags:           [ BINDING_WEAK, UNDEFINED ]
+; CHECK-NEXT:        Function:        2
+; CHECK-NEXT:      - Index:           6
+; CHECK-NEXT:        Kind:            FUNCTION
+; CHECK-NEXT:        Name:            func_comdat
+; CHECK-NEXT:        Flags:           [ BINDING_WEAK ]
+; CHECK-NEXT:        Function:        5
+; CHECK-NEXT:      - Index:           7
+; CHECK-NEXT:        Kind:            DATA
+; CHECK-NEXT:        Name:            data_comdat
+; CHECK-NEXT:        Flags:           [ BINDING_WEAK ]
+; CHECK-NEXT:        Segment:         1
+; CHECK-NEXT:        Size:            3
+; CHECK-NEXT:      - Index:           8
+; CHECK-NEXT:        Kind:            FUNCTION
+; CHECK-NEXT:        Name:            _start
+; CHECK-NEXT:        Flags:           [ ]
+; CHECK-NEXT:        Function:        6
+; CHECK-NEXT:      - Index:           9
+; CHECK-NEXT:        Kind:            DATA
+; CHECK-NEXT:        Name:            func_addr1
+; CHECK-NEXT:        Flags:           [ VISIBILITY_HIDDEN ]
+; CHECK-NEXT:        Segment:         2
+; CHECK-NEXT:        Size:            4
+; CHECK-NEXT:      - Index:           10
+; CHECK-NEXT:        Kind:            DATA
+; CHECK-NEXT:        Name:            func_addr2
+; CHECK-NEXT:        Flags:           [ VISIBILITY_HIDDEN ]
+; CHECK-NEXT:        Segment:         3
+; CHECK-NEXT:        Size:            4
+; CHECK-NEXT:      - Index:           11
+; CHECK-NEXT:        Kind:            DATA
+; CHECK-NEXT:        Name:            func_addr3
+; CHECK-NEXT:        Flags:           [ VISIBILITY_HIDDEN ]
+; CHECK-NEXT:        Segment:         4
+; CHECK-NEXT:        Size:            4
+; CHECK-NEXT:      - Index:           12
+; CHECK-NEXT:        Kind:            DATA
+; CHECK-NEXT:        Name:            data_addr1
+; CHECK-NEXT:        Flags:           [ VISIBILITY_HIDDEN ]
+; CHECK-NEXT:        Segment:         5
+; CHECK-NEXT:        Size:            4
+; CHECK-NEXT:      - Index:           13
+; CHECK-NEXT:        Kind:            DATA
+; CHECK-NEXT:        Name:            data_import
+; CHECK-NEXT:        Flags:           [ UNDEFINED ]
+; CHECK-NEXT:      - Index:           14
+; CHECK-NEXT:        Kind:            TABLE
+; CHECK-NEXT:        Name:            __indirect_function_table
+; CHECK-NEXT:        Flags:           [ UNDEFINED, NO_STRIP ]
+; CHECK-NEXT:        Table:           0
+; CHECK-NEXT:    SegmentInfo:
+; CHECK-NEXT:      - Index:           0
+; CHECK-NEXT:        Name:            .rodata.hello_str
+; CHECK-NEXT:        Alignment:       0
+; CHECK-NEXT:        Flags:           [  ]
+; CHECK-NEXT:      - Index:           1
+; CHECK-NEXT:        Name:            .rodata.data_comdat
+; CHECK-NEXT:        Alignment:       0
+; CHECK-NEXT:        Flags:           [  ]
+; CHECK-NEXT:      - Index:           2
+; CHECK-NEXT:        Name:            .data.func_addr1
+; CHECK-NEXT:        Alignment:       2
+; CHECK-NEXT:        Flags:           [  ]
+; CHECK-NEXT:      - Index:           3
+; CHECK-NEXT:        Name:            .data.func_addr2
+; CHECK-NEXT:        Alignment:       2
+; CHECK-NEXT:        Flags:           [  ]
+; CHECK-NEXT:      - Index:           4
+; CHECK-NEXT:        Name:            .data.func_addr3
+; CHECK-NEXT:        Alignment:       2
+; CHECK-NEXT:        Flags:           [  ]
+; CHECK-NEXT:      - Index:           5
+; CHECK-NEXT:        Name:            .data.data_addr1
+; CHECK-NEXT:        Alignment:       3
+; CHECK-NEXT:        Flags:           [  ]
+; CHECK-NEXT:    Comdats:
+; CHECK-NEXT:      - Name:            func_comdat
+; CHECK-NEXT:        Entries:
+; CHECK-NEXT:          - Kind:            FUNCTION
+; CHECK-NEXT:            Index:           5
+; CHECK-NEXT:          - Kind:            DATA
+; CHECK-NEXT:            Index:           1
+; CHECK-NEXT:  - Type:            CUSTOM
+; CHECK-NEXT:    Name:            name
+; CHECK-NEXT:    FunctionNames:
+; CHECK-NEXT:      - Index:           0
+; CHECK-NEXT:        Name:            puts
+; CHECK-NEXT:      - Index:           1
+; CHECK-NEXT:        Name:            foo_import
+; CHECK-NEXT:      - Index:           2
+; CHECK-NEXT:        Name:            bar_import
+; CHECK-NEXT:      - Index:           3
+; CHECK-NEXT:        Name:            hello
+; CHECK-NEXT:      - Index:           4
+; CHECK-NEXT:        Name:            my_func
+; CHECK-NEXT:      - Index:           5
+; CHECK-NEXT:        Name:            func_comdat
+; CHECK-NEXT:      - Index:           6
+; CHECK-NEXT:        Name:            _start
+; CHECK-NEXT:    DataSegmentNames:
+; CHECK-NEXT:      - Index:           0
+; CHECK-NEXT:        Name:            .rodata.hello_str
+; CHECK-NEXT:      - Index:           1
+; CHECK-NEXT:        Name:            .rodata.data_comdat
+; CHECK-NEXT:      - Index:           2
+; CHECK-NEXT:        Name:            .data.func_addr1
+; CHECK-NEXT:      - Index:           3
+; CHECK-NEXT:        Name:            .data.func_addr2
+; CHECK-NEXT:      - Index:           4
+; CHECK-NEXT:        Name:            .data.func_addr3
+; CHECK-NEXT:      - Index:           5
+; CHECK-NEXT:        Name:            .data.data_addr1
+; CHECK-NEXT:  - Type:            CUSTOM


### PR DESCRIPTION
Back in 6474d1b20 this test was updated, removing the NORMAL vs SHARED distinction in the output checking.  However many of the NORMAL-NEXT lines were left unmodified, making them effectively disabled.

This restores and updates the expectations.