### PR TITLE
[SampleProfile] Add per-function optimization remarks for stale profile matching

### DIFF
--- a/llvm/include/llvm/Transforms/IPO/SampleProfileMatcher.h
+++ b/llvm/include/llvm/Transforms/IPO/SampleProfileMatcher.h
@@ -15,6 +15,7 @@
 #define LLVM_TRANSFORMS_IPO_SAMPLEPROFILEMATCHER_H
 
 #include "llvm/ADT/StringSet.h"
+#include "llvm/Analysis/OptimizationRemarkEmitter.h"
 #include "llvm/Transforms/Utils/SampleProfileLoaderBaseImpl.h"
 
 #include <unordered_set>
@@ -238,6 +239,8 @@ private:
   // which are supposed to be new functions. We use them as the targets for
   // call graph matching.
   void findFunctionsWithoutProfile();
+  // Emit optimization remarks for per-function profile matching status.
+  void emitMatchingRemarks();
   void reportOrPersistProfileStats();
 };
 } // end namespace llvm

--- a/llvm/lib/Transforms/IPO/SampleProfileMatcher.cpp
+++ b/llvm/lib/Transforms/IPO/SampleProfileMatcher.cpp
@@ -907,6 +907,82 @@ void SampleProfileMatcher::runOnModule() {
     distributeIRToProfileLocationMap();
 
   computeAndReportProfileStaleness();
+  emitMatchingRemarks();
+}
+
+void SampleProfileMatcher::emitMatchingRemarks() {
+  LLVMContext &Ctx = M.getContext();
+  if (!OptimizationRemarkEmitter::allowExtraAnalysis(Ctx, DEBUG_TYPE))
+    return;
+
+  for (auto &F : M) {
+    if (F.isDeclaration() || skipProfileForFunction(F))
+      continue;
+    if (GlobalValue::isAvailableExternallyLinkage(F.getLinkage()))
+      continue;
+
+    auto CGIt = FuncToProfileNameMap.find(const_cast<Function *>(&F));
+    const auto *FS = Reader.getSamplesFor(F);
+
+    if (CGIt != FuncToProfileNameMap.end()) {
+      // CG-recovered match — function was renamed but recovered via
+      // call-graph matching.
+      uint64_t Samples = FS ? FS->getTotalSamples() : 0;
+      Ctx.diagnose(
+          OptimizationRemark(DEBUG_TYPE, "SampleProfileRecovered", &F)
+          << "sample profile recovered for "
+          << ore::NV("Function", &F)
+          << " matched to profile '"
+          << ore::NV("ProfileName", CGIt->second.stringRef())
+          << "' with " << ore::NV("TotalSamples", Samples)
+          << " total samples (method: call-graph matching)");
+    } else if (FS) {
+      bool IsHashMismatch = false;
+      if (FunctionSamples::ProfileIsProbeBased) {
+        const auto *FuncDesc = ProbeManager->getDesc(FS->getGUID());
+        if (FuncDesc &&
+            ProbeManager->profileIsHashMismatched(*FuncDesc, *FS))
+          IsHashMismatch = true;
+      }
+      if (IsHashMismatch) {
+        // Matched by name but profile body is stale (checksum mismatch).
+        // Function still gets samples but they may be inaccurate.
+        Ctx.diagnose(
+            OptimizationRemarkAnalysis(DEBUG_TYPE,
+                                       "SampleProfileHashMismatch", &F)
+            << "sample profile matched for "
+            << ore::NV("Function", &F)
+            << " but profile is stale (hash mismatch); "
+            << ore::NV("TotalSamples", FS->getTotalSamples())
+            << " samples potentially affected");
+      } else {
+        // Clean match by name, no staleness.
+        Ctx.diagnose(
+            OptimizationRemark(DEBUG_TYPE, "SampleProfileMatched", &F)
+            << "sample profile matched for "
+            << ore::NV("Function", &F)
+            << " with " << ore::NV("TotalSamples", FS->getTotalSamples())
+            << " total samples");
+      }
+    }
+  }
+
+  // Unmatched orphan functions — in FunctionsWithoutProfile and not
+  // CG-recovered. These are functions not in the profile NameTable (truly
+  // new or renamed without recovery).
+  for (const auto &I : FunctionsWithoutProfile) {
+    Function *F = I.second;
+    if (!F || F->isDeclaration())
+      continue;
+    if (GlobalValue::isAvailableExternallyLinkage(F->getLinkage()))
+      continue;
+    if (FuncToProfileNameMap.count(F))
+      continue;
+    Ctx.diagnose(
+        OptimizationRemarkMissed(DEBUG_TYPE, "SampleProfileNotMatched", F)
+        << "no sample profile matched for "
+        << ore::NV("Function", F));
+  }
 }
 
 void SampleProfileMatcher::distributeIRToProfileLocationMap(

--- a/llvm/test/Transforms/SampleProfile/pseudo-probe-stale-profile-matching-remarks.ll
+++ b/llvm/test/Transforms/SampleProfile/pseudo-probe-stale-profile-matching-remarks.ll
@@ -1,0 +1,44 @@
+; REQUIRES: x86_64-linux
+
+; Test that each remark category can be enabled independently.
+
+; -Rpass-missed: only unmatched functions
+; RUN: opt < %S/pseudo-probe-stale-profile-renaming.ll -passes=sample-profile \
+; RUN:   -sample-profile-file=%S/Inputs/pseudo-probe-stale-profile-renaming.prof \
+; RUN:   --salvage-stale-profile --salvage-unused-profile \
+; RUN:   -pass-remarks-missed=sample-profile-matcher \
+; RUN:   --min-call-count-for-cg-matching=0 --min-func-count-for-cg-matching=0 \
+; RUN:   --func-profile-similarity-threshold=70 -S -o /dev/null 2>&1 | FileCheck %s --check-prefix=MISSED --allow-empty
+
+; MISSED-NOT: sample profile matched
+; MISSED-NOT: sample profile recovered
+
+; -Rpass: matched and recovered functions
+; RUN: opt < %S/pseudo-probe-stale-profile-renaming.ll -passes=sample-profile \
+; RUN:   -sample-profile-file=%S/Inputs/pseudo-probe-stale-profile-renaming.prof \
+; RUN:   --salvage-stale-profile --salvage-unused-profile \
+; RUN:   -pass-remarks=sample-profile-matcher \
+; RUN:   --min-call-count-for-cg-matching=0 --min-func-count-for-cg-matching=0 \
+; RUN:   --func-profile-similarity-threshold=70 -S -o /dev/null 2>&1 | FileCheck %s --check-prefix=PASS
+
+; PASS-DAG: remark: {{.*}}: sample profile recovered for new_foo matched to profile 'foo'
+; PASS-DAG: remark: {{.*}}: sample profile recovered for new_block_only matched to profile 'block_only'
+; PASS-DAG: remark: {{.*}}: sample profile matched for main with {{[0-9]+}} total samples
+; PASS-DAG: remark: {{.*}}: sample profile matched for bar with {{[0-9]+}} total samples
+; PASS-NOT: no sample profile matched
+
+; All categories together
+; RUN: opt < %S/pseudo-probe-stale-profile-renaming.ll -passes=sample-profile \
+; RUN:   -sample-profile-file=%S/Inputs/pseudo-probe-stale-profile-renaming.prof \
+; RUN:   --salvage-stale-profile --salvage-unused-profile \
+; RUN:   -pass-remarks=sample-profile-matcher -pass-remarks-missed=sample-profile-matcher \
+; RUN:   -pass-remarks-analysis=sample-profile-matcher \
+; RUN:   --min-call-count-for-cg-matching=0 --min-func-count-for-cg-matching=0 \
+; RUN:   --func-profile-similarity-threshold=70 -S -o /dev/null 2>&1 | FileCheck %s --check-prefix=ALL
+
+; ALL-DAG: remark: {{.*}}: sample profile recovered for new_foo matched to profile 'foo'
+; ALL-DAG: remark: {{.*}}: sample profile recovered for new_block_only matched to profile 'block_only'
+; ALL-DAG: remark: {{.*}}: sample profile matched for main with {{[0-9]+}} total samples
+; ALL-DAG: remark: {{.*}}: sample profile matched for bar with {{[0-9]+}} total samples
+; ALL-NOT: no sample profile matched for new_foo
+; ALL-NOT: no sample profile matched for new_block_only


### PR DESCRIPTION
Emit per-function optimization remarks reporting profile match/mismatch status. 

Four remark categories are emitted, each gated by a different -R flag:

`-Rpass=sample-profile-matcher`:
    `SampleProfileMatched`   - function matched by name directly.
    `SampleProfileRecovered` - renamed function recovered via CG matching.

`-Rpass-analysis=sample-profile-matcher`:
    `SampleProfileHashMismatch` - matched by name but profile body is stale.

`-Rpass-missed=sample-profile-matcher`:
    `SampleProfileNotMatched` - no profile found