### PR TITLE
[libc++] Update the docker base image version

### DIFF
--- a/libcxx/utils/ci/docker/docker-compose.yml
+++ b/libcxx/utils/ci/docker/docker-compose.yml
@@ -23,7 +23,7 @@ services:
       context: ../../../.. # monorepo root
       dockerfile: libcxx/utils/ci/docker/linux-builder.dockerfile
       args:
-        BASE_IMAGE_VERSION: 825943e06f840710177e5514c4f61c9e73660c44
+        BASE_IMAGE_VERSION: 9b04a3cd393c24dfe14cf72f2130a17a9b2020b3
         GITHUB_RUNNER_VERSION: 2.331.0
 
   libcxx-android-builder:
@@ -32,7 +32,7 @@ services:
       context: ../../../.. # monorepo root
       dockerfile: libcxx/utils/ci/docker/android-builder.dockerfile
       args:
-        BASE_IMAGE_VERSION: 825943e06f840710177e5514c4f61c9e73660c44
+        BASE_IMAGE_VERSION: 9b04a3cd393c24dfe14cf72f2130a17a9b2020b3
         ANDROID_CLANG_VERSION: r563880
         ANDROID_CLANG_PREBUILTS_COMMIT: 6ae4184bb8706f9731569b9a0a82be3fcdcb951c
         ANDROID_SYSROOT_COMMIT: f8b85cc5262c6e5cbc9a92c1bab2b18b32a4c63f


### PR DESCRIPTION
This updates the base image version so we can update our compilers.
