### PR TITLE
[libclc][CMake] Use per-source include flags instead of target-level includes

### DIFF
--- a/libclc/cmake/modules/AddLibclc.cmake
+++ b/libclc/cmake/modules/AddLibclc.cmake
@@ -1,8 +1,23 @@
 # Converts a list of relative source paths to absolute paths and exports
-# it to the parent scope.
+# it to the parent scope. Also adds each source file's parent directory
+# as an include path to support .inc files in the same directory.
 macro(libclc_configure_source_list variable path)
   set(${variable} ${ARGN})
   list(TRANSFORM ${variable} PREPEND "${path}/")
+
+  # Add each source file's parent directory as an include path
+  foreach(_src ${${variable}})
+    cmake_path(GET _src PARENT_PATH _parent_dir)
+    get_property(_existing SOURCE ${_src}
+      DIRECTORY ${LIBCLC_SOURCE_DIR}
+      PROPERTY COMPILE_OPTIONS)
+    if(NOT "-I${_parent_dir}" IN_LIST _existing)
+      set_property(SOURCE ${_src}
+        DIRECTORY ${LIBCLC_SOURCE_DIR}
+        APPEND PROPERTY COMPILE_OPTIONS "-I${_parent_dir}")
+    endif()
+  endforeach()
+
   set(${variable} ${${variable}} PARENT_SCOPE)
 endmacro()
 
@@ -49,16 +64,6 @@ function(add_libclc_builtin_library target_name)
     "SOURCES;COMPILE_OPTIONS;INCLUDE_DIRS;COMPILE_DEFINITIONS"
     ${ARGN}
   )
-
-  # Append each source's parent directory as an include path to COMPILE_OPTIONS.
-  foreach(f ${ARG_SOURCES})
-    cmake_path(GET f PARENT_PATH parent_dir)
-    get_property(_existing SOURCE "${f}" DIRECTORY ${LIBCLC_SOURCE_DIR} PROPERTY COMPILE_OPTIONS)
-    if(NOT "-I${parent_dir}" IN_LIST _existing)
-      set_property(SOURCE "${f}" DIRECTORY ${LIBCLC_SOURCE_DIR}
-        APPEND PROPERTY COMPILE_OPTIONS "-I${parent_dir}")
-    endif()
-  endforeach()
 
   add_library(${target_name} STATIC ${ARG_SOURCES})
   target_compile_options(${target_name} PRIVATE ${ARG_COMPILE_OPTIONS})

--- a/libclc/cmake/modules/AddLibclc.cmake
+++ b/libclc/cmake/modules/AddLibclc.cmake
@@ -50,17 +50,20 @@ function(add_libclc_builtin_library target_name)
     ${ARGN}
   )
 
-  set(_inc_dirs)
+  # Append each source's parent directory as an include path to COMPILE_OPTIONS.
   foreach(f ${ARG_SOURCES})
-    get_filename_component(dir ${f} DIRECTORY)
-    list(APPEND _inc_dirs ${dir})
+    cmake_path(GET f PARENT_PATH parent_dir)
+    get_property(_existing SOURCE "${f}" DIRECTORY ${LIBCLC_SOURCE_DIR} PROPERTY COMPILE_OPTIONS)
+    if(NOT "-I${parent_dir}" IN_LIST _existing)
+      set_property(SOURCE "${f}" DIRECTORY ${LIBCLC_SOURCE_DIR}
+        APPEND PROPERTY COMPILE_OPTIONS "-I${parent_dir}")
+    endif()
   endforeach()
-  list(REMOVE_DUPLICATES _inc_dirs)
 
   add_library(${target_name} STATIC ${ARG_SOURCES})
   target_compile_options(${target_name} PRIVATE ${ARG_COMPILE_OPTIONS})
   target_include_directories(${target_name} PRIVATE
-    ${ARG_INCLUDE_DIRS} ${_inc_dirs}
+    ${ARG_INCLUDE_DIRS}
   )
   target_compile_definitions(${target_name} PRIVATE ${ARG_COMPILE_DEFINITIONS})
   set_target_properties(${target_name} PROPERTIES


### PR DESCRIPTION
Previously, add_libclc_builtin_library added all source files' parent directories to include directories, resulting in many unnecessary -I flags.

Some source files include .inc files from their own directory, so adding only the source file's parent directory as an include path is sufficient.

Add deduplication check because different targets can share the same file.