### PR TITLE
Revert "[AMDGPU] Enable scheduler mfma rewrite stage by default"

### DIFF
--- a/llvm/lib/Target/AMDGPU/GCNSchedStrategy.cpp
+++ b/llvm/lib/Target/AMDGPU/GCNSchedStrategy.cpp
@@ -101,7 +101,7 @@ static cl::opt<bool> PrintMaxRPRegUsageAfterScheduler(
 
 static cl::opt<bool> DisableRewriteMFMAFormSchedStage(
     "amdgpu-disable-rewrite-mfma-form-sched-stage", cl::Hidden,
-    cl::desc("Disable rewrie mfma rewrite scheduling stage"), cl::init(true));
+    cl::desc("Disable rewrite mfma rewrite scheduling stage"), cl::init(true));
 
 const unsigned ScheduleMetrics::ScaleFactor = 100;
 

--- a/llvm/lib/Target/AMDGPU/GCNSchedStrategy.cpp
+++ b/llvm/lib/Target/AMDGPU/GCNSchedStrategy.cpp
@@ -101,7 +101,7 @@ static cl::opt<bool> PrintMaxRPRegUsageAfterScheduler(
 
 static cl::opt<bool> DisableRewriteMFMAFormSchedStage(
     "amdgpu-disable-rewrite-mfma-form-sched-stage", cl::Hidden,
-    cl::desc("Disable rewrite mfma rewrite scheduling stage"), cl::init(false));
+    cl::desc("Disable rewrie mfma rewrite scheduling stage"), cl::init(true));
 
 const unsigned ScheduleMetrics::ScaleFactor = 100;
 


### PR DESCRIPTION
Reverts llvm/llvm-project#180751

Enabling this pass by default breaks a few tests / use cases downstream. @frederik-h was also looking into the actual implementation of the pass.

For now: Just revert that pass to be on-by-default.