### PR TITLE
[Clang] Address feedback in PR183010

### DIFF
--- a/clang/include/clang/Sema/Template.h
+++ b/clang/include/clang/Sema/Template.h
@@ -185,13 +185,12 @@ enum class TemplateSubstitutionKind : char {
       return !(*this)(Depth, Index).isNull();
     }
 
-    bool isAnyArgInstantiationDependent(const ASTContext &C) const {
+    bool isAnyArgDependent(const ASTContext &C) const {
       for (ArgumentListLevel ListLevel : TemplateArgumentLists)
         for (const TemplateArgument &TA : ListLevel.Args)
           // There might be null template arguments representing unused template
           // parameter mappings in an MLTAL during concept checking.
-          if (!TA.isNull() &&
-              C.getCanonicalTemplateArgument(TA).isInstantiationDependent())
+          if (!TA.isNull() && C.getCanonicalTemplateArgument(TA).isDependent())
             return true;
       return false;
     }

--- a/clang/include/clang/Sema/Template.h
+++ b/clang/include/clang/Sema/Template.h
@@ -185,12 +185,12 @@ enum class TemplateSubstitutionKind : char {
       return !(*this)(Depth, Index).isNull();
     }
 
-    bool isAnyArgDependent(const ASTContext &C) const {
+    bool isAnyArgumentDependent() const {
       for (ArgumentListLevel ListLevel : TemplateArgumentLists)
         for (const TemplateArgument &TA : ListLevel.Args)
           // There might be null template arguments representing unused template
           // parameter mappings in an MLTAL during concept checking.
-          if (!TA.isNull() && C.getCanonicalTemplateArgument(TA).isDependent())
+          if (!TA.isNull() && TA.isDependent())
             return true;
       return false;
     }

--- a/clang/lib/Sema/SemaConcept.cpp
+++ b/clang/lib/Sema/SemaConcept.cpp
@@ -1154,7 +1154,7 @@ static bool CheckConstraintSatisfaction(
     return false;
   }
 
-  if (TemplateArgsLists.isAnyArgInstantiationDependent(S.Context)) {
+  if (TemplateArgsLists.isAnyArgDependent(S.Context)) {
     // No need to check satisfaction for dependent constraint expressions.
     Satisfaction.IsSatisfied = true;
     return false;

--- a/clang/lib/Sema/SemaConcept.cpp
+++ b/clang/lib/Sema/SemaConcept.cpp
@@ -456,7 +456,9 @@ public:
     for (auto &ArgLoc : Mapping) {
       TemplateArgument Canonical =
           SemaRef.Context.getCanonicalTemplateArgument(ArgLoc.getArgument());
-      // We don't want sugars to impede the profile of cache.
+      // We don't want sugars to impede the profile performance of cache.
+      // FIXME: Substituting into type sugars may introduce failures. Ignoring
+      // differences in type sugar might not be feasible.
       UsedTemplateArgs.push_back(Canonical);
       TraverseTemplateArgument(Canonical);
     }
@@ -1154,8 +1156,8 @@ static bool CheckConstraintSatisfaction(
     return false;
   }
 
-  if (TemplateArgsLists.isAnyArgDependent(S.Context)) {
-    // No need to check satisfaction for dependent constraint expressions.
+  if (TemplateArgsLists.isAnyArgumentDependent()) {
+    // No need to check satisfaction for dependent template arguments.
     Satisfaction.IsSatisfied = true;
     return false;
   }

--- a/clang/test/SemaTemplate/concepts-using-decl.cpp
+++ b/clang/test/SemaTemplate/concepts-using-decl.cpp
@@ -197,3 +197,16 @@ struct child : base<int> {
 };
 
 }
+
+// FIXME: The concept cache should consider type sugars in some instantiation-dependent context.
+namespace instantiation_dependent {
+
+template <class T> concept C = sizeof(T) >= 1;
+template <class U> using X = int;
+template <class> concept D = C<X<int>>;
+// D<V> is computed as sizeof(int) >= 1 and it affects the result of both C<X<V&>> and C<X<void&>>,
+// though C<X<void&>> is invalid. We should reject it.
+template <D V> requires C<X<V&>> struct Y {};
+Y<void> y;
+
+}

--- a/clang/test/SemaTemplate/concepts.cpp
+++ b/clang/test/SemaTemplate/concepts.cpp
@@ -1716,10 +1716,24 @@ void f() = delete;
 
 struct Bar {};
 
-template <typename T> using Foo = Bar;
+template <typename> using Foo = Bar;
 
-template <typename T> void use() {
+template <int T>
+  requires true
+void f2() {}
+
+template <int T>
+  requires false
+void f2() = delete;
+
+template <int> constexpr auto Value = 1;
+
+template <template <typename> class> using FooTemp = Bar;
+
+template <typename T, int N, template <typename> class C> void use() {
   f<Foo<T>>();
+  f2<Value<N>>();
+  f<FooTemp<C>>();
 }
 
 }


### PR DESCRIPTION
As discussed in #183010, the name MLTAL::isAnyArgInstantiationDependent became misleading after that patch. For type template arguments, it now checks whether the canonical types are dependent, whereas for expression template arguments, it checks the dependence of the expressions themselves.

We turn to using TA::isDependent now.

One concern is that dependent expressions, such as sizeof(T), may no longer be protected from evaluation. But I think they should have been marked as type dependent by this point since we do not have canonical expressions.

