### PR TITLE
[lldb-dap] Allow expressions in setVariable request

### DIFF
--- a/lldb/test/API/tools/lldb-dap/variables/TestDAP_variables.py
+++ b/lldb/test/API/tools/lldb-dap/variables/TestDAP_variables.py
@@ -332,7 +332,7 @@ class TestDAP_variables(lldbdap_testcase.DAPTestCaseBase):
         # Set a variable value whose name is a real child value, like "pt.x"
         # and verify the value by reading it
         varRef = varref_dict["pt"]
-        self.set_variable(varRef, "x", 111)
+        self.set_variable(varRef, "x", "g_global - 12")
         response = self.dap_server.request_variables(varRef, start=0, count=1)
         value = response["body"]["variables"][0]["value"]
         self.assertEqual(

--- a/lldb/tools/lldb-dap/Handler/SetVariableRequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/SetVariableRequestHandler.cpp
@@ -18,6 +18,18 @@ using namespace lldb_dap::protocol;
 
 namespace lldb_dap {
 
+static lldb::SBValue EvaluateExpression(lldb::SBTarget &target,
+                                        lldb::SBFrame &frame,
+                                        const std::string &expression) {
+  const char *expression_cstr = expression.c_str();
+
+  if (frame)
+    return frame.EvaluateExpression(expression_cstr);
+
+  // Evaluate expression in global scope.
+  return target.EvaluateExpression(expression_cstr);
+}
+
 /// Set the variable with the given name in the variable container to a new
 /// value. Clients should only call this request if the corresponding capability
 /// `supportsSetVariable` is true.
@@ -49,8 +61,13 @@ SetVariableRequestHandler::Run(const SetVariableArguments &args) const {
   if (!variable.IsValid())
     return llvm::make_error<DAPError>("could not find variable in scope");
 
+  lldb::SBFrame frame = variable.GetFrame();
+  std::string expression = llvm::StringRef(args.value).trim().str();
+  lldb::SBValue result = EvaluateExpression(dap.target, frame, expression);
+  const char *value = result.IsValid() ? result.GetValue() : expression.c_str();
+
   lldb::SBError error;
-  const bool success = variable.SetValueFromCString(args.value.c_str(), error);
+  const bool success = variable.SetValueFromCString(value, error);
   if (!success)
     return llvm::make_error<DAPError>(error.GetCString());
 


### PR DESCRIPTION
This paths allows expressions in `setVariable` request. It is small extension of original  semantics from DAP specification. DAP has `setExpression` request to this purpose, but it is too general. So I prefer to keep this simple solution.