### PR TITLE
[RISCV][MC] Add support of Zvzip extension

### DIFF
--- a/clang/test/Driver/print-supported-extensions-riscv.c
+++ b/clang/test/Driver/print-supported-extensions-riscv.c
@@ -252,6 +252,7 @@
 // CHECK-NEXT:     zvfbfa               0.1       'Zvfbfa' (Additional BF16 vector compute support)
 // CHECK-NEXT:     zvfofp8min           0.2       'Zvfofp8min' (Vector OFP8 Converts)
 // CHECK-NEXT:     zvkgs                0.7       'Zvkgs' (Vector-Scalar GCM instructions for Cryptography)
+// CHECK-NEXT:     zvzip                0.1       'Zvzip' (Vector Reordering Structured Data)
 // CHECK-NEXT:     smpmpmt              0.6       'Smpmpmt' (PMP-based Memory Types Extension)
 // CHECK-NEXT:     svukte               0.3       'Svukte' (Address-Independent Latency of User-Mode Faults to Supervisor Addresses)
 // CHECK-NEXT:     xrivosvisni          0.1       'XRivosVisni' (Rivos Vector Integer Small New)

--- a/clang/test/Preprocessor/riscv-target-features.c
+++ b/clang/test/Preprocessor/riscv-target-features.c
@@ -1663,6 +1663,14 @@
 // RUN:   -o - | FileCheck --check-prefix=CHECK-ZVDOT4A8I-EXT %s
 // CHECK-ZVDOT4A8I-EXT: __riscv_zvdot4a8i 1000{{$}}
 
+// RUN: %clang --target=riscv32 -menable-experimental-extensions \
+// RUN:   -march=rv32i_zve32x_zvzip0p1 -E -dM %s \
+// RUN:   -o - | FileCheck --check-prefix=CHECK-ZVZVIP-EXT %s
+// RUN: %clang --target=riscv64 -menable-experimental-extensions \
+// RUN:   -march=rv64i_zve32x_zvzip0p1 -E -dM %s \
+// RUN:   -o - | FileCheck --check-prefix=CHECK-ZVZVIP-EXT %s
+// CHECK-ZVZVIP-EXT: __riscv_zvzip 1000{{$}}
+
 // RUN: %clang -target riscv32 -menable-experimental-extensions \
 // RUN:   -march=rv32izicfiss1p0 -E -dM %s \
 // RUN:   -o - | FileCheck --check-prefix=CHECK-ZICFISS-EXT %s

--- a/llvm/docs/RISCVUsage.rst
+++ b/llvm/docs/RISCVUsage.rst
@@ -359,6 +359,9 @@ The primary goal of experimental support is to assist in the process of ratifica
 ``experimental-zvabd``
   LLVM implements the `0.7 draft specification <https://github.com/riscv/integer-vector-absolute-difference/releases/tag/v0.7>`__.
 
+``experimental-zvzip``
+  LLVM implements the `0.1 draft specification <https://github.com/ved-rivos/riscv-isa-manual/blob/zvzip/src/zvzip.adoc>`__.
+
 To use an experimental extension from `clang`, you must add `-menable-experimental-extensions` to the command line, and specify the exact version of the experimental extension you are using.  To use an experimental extension with LLVM's internal developer tools (e.g. `llc`, `llvm-objdump`, `llvm-mc`), you must prefix the extension name with `experimental-`.  Note that you don't need to specify the version with internal tools, and shouldn't include the `experimental-` prefix with `clang`.
 
 Vendor Extensions

--- a/llvm/docs/ReleaseNotes.md
+++ b/llvm/docs/ReleaseNotes.md
@@ -156,6 +156,8 @@ Changes to the RISC-V Backend
 * `-mcpu=spacemit-a100` was added.
 * The opt-in `-riscv-enable-p-ext-simd-codegen` flag has been removed. P extension SIMD code generation is now enabled automatically if the P extension is supported.
 * `-mcpu=xt-c910v2` and `-mcpu=xt-c920v2` were added.
+* Adds experimental assembler support for the 'Zvzip` (RISC-V Vector
+  Reordering Structured Data) extension.
 
 Changes to the WebAssembly Backend
 ----------------------------------

--- a/llvm/lib/Target/RISCV/RISCVFeatures.td
+++ b/llvm/lib/Target/RISCV/RISCVFeatures.td
@@ -883,6 +883,14 @@ def HasStdExtZvdot4a8i : Predicate<"Subtarget->hasStdExtZvdot4a8i()">,
                          AssemblerPredicate<(all_of FeatureStdExtZvdot4a8i),
                          "'Zvdot4a8i' (Vector 4-element Dot Product of packed 8-bit Integers)">;
 
+// Vector Reordering Structured Data
+def FeatureStdExtZvzip
+    : RISCVExperimentalExtension<0, 1, "Vector Reordering Structured Data",
+                                 [FeatureStdExtZve32x]>;
+def HasStdExtZvzip : Predicate<"Subtarget->hasStdExtZvzip()">,
+                     AssemblerPredicate<(all_of FeatureStdExtZvzip),
+                     "'Zvzip' (Vector Reordering Structured Data)">;
+
 // Vector instruction predicates
 
 def HasVInstructions    : Predicate<"Subtarget->hasVInstructions()">,

--- a/llvm/lib/Target/RISCV/RISCVFeatures.td
+++ b/llvm/lib/Target/RISCV/RISCVFeatures.td
@@ -889,7 +889,7 @@ def FeatureStdExtZvzip
                                  [FeatureStdExtZve32x]>;
 def HasStdExtZvzip : Predicate<"Subtarget->hasStdExtZvzip()">,
                      AssemblerPredicate<(all_of FeatureStdExtZvzip),
-                     "'Zvzip' (Vector Reordering Structured Data)">;
+                         "'Zvzip' (Vector Reordering Structured Data)">;
 
 // Vector instruction predicates
 

--- a/llvm/lib/Target/RISCV/RISCVInstrInfo.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfo.td
@@ -2357,6 +2357,7 @@ include "RISCVInstrInfoZvabd.td"
 include "RISCVInstrInfoZvk.td"
 include "RISCVInstrInfoZvdot4a8i.td"
 include "RISCVInstrInfoZvfofp8min.td"
+include "RISCVInstrInfoZvzip.td"
 
 // Packed SIMD
 include "RISCVInstrInfoP.td"

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoZvzip.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoZvzip.td
@@ -1,0 +1,28 @@
+//===---- RISCVInstrInfoZvzip.td - 'Zvzip' instructions ----*- tablegen -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file describes the RISC-V instructions from the Zvzip standard extension
+// for reordering structured data in vector registers.
+//
+//===----------------------------------------------------------------------===//
+
+//===----------------------------------------------------------------------===//
+// Instructions
+//===----------------------------------------------------------------------===//
+
+let Predicates = [HasStdExtZvzip], Constraints = "@earlyclobber $vd" in {
+  let VS1VS2Constraint = WidenV in {
+    def VZIP_VV : VALUVV<0b111110, OPMVV, "vzip.vv">;
+    def VUNZIPE_V : VALUVs2<0b010010, 0b01011, OPMVV, "vunzipe.v">;
+    def VUNZIPO_V : VALUVs2<0b010010, 0b01111, OPMVV, "vunzipo.v">;
+  }
+  let VS1VS2Constraint = Vrgather in {
+    def VPAIRE_VV : VALUVV<0b001111, OPIVV, "vpaire.vv">;
+    def VPAIRO_VV : VALUVV<0b001111, OPMVV, "vpairo.vv">;
+  }
+} // Predicates = [HasStdExtZvzip]

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoZvzip.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoZvzip.td
@@ -16,11 +16,14 @@
 //===----------------------------------------------------------------------===//
 
 let Predicates = [HasStdExtZvzip], Constraints = "@earlyclobber $vd" in {
-  let VS1VS2Constraint = WidenV in {
-    def VZIP_VV : VALUVV<0b111110, OPMVV, "vzip.vv">;
+  let VS1VS2Constraint = WidenV in
+  def VZIP_VV : VALUVV<0b111110, OPMVV, "vzip.vv">;
+
+  let VS1VS2Constraint = VS2Constraint in {
     def VUNZIPE_V : VALUVs2<0b010010, 0b01011, OPMVV, "vunzipe.v">;
     def VUNZIPO_V : VALUVs2<0b010010, 0b01111, OPMVV, "vunzipo.v">;
   }
+
   let VS1VS2Constraint = Vrgather in {
     def VPAIRE_VV : VALUVV<0b001111, OPIVV, "vpaire.vv">;
     def VPAIRO_VV : VALUVV<0b001111, OPMVV, "vpairo.vv">;

--- a/llvm/test/CodeGen/RISCV/attributes.ll
+++ b/llvm/test/CodeGen/RISCV/attributes.ll
@@ -110,6 +110,7 @@
 ; RUN: llc -mtriple=riscv32 -mattr=+zve32x -mattr=+zvksh %s -o - | FileCheck --check-prefix=RV32ZVKSH %s
 ; RUN: llc -mtriple=riscv32 -mattr=+zve32x -mattr=+zvkt %s -o - | FileCheck --check-prefix=RV32ZVKT %s
 ; RUN: llc -mtriple=riscv32 -mattr=+zve32x -mattr=+experimental-zvdot4a8i %s -o - | FileCheck --check-prefix=RV32ZVDOT4A8I %s
+; RUN: llc -mtriple=riscv32 -mattr=+zve32x -mattr=+experimental-zvzip %s -o - | FileCheck --check-prefix=RV32ZVZIP %s
 ; RUN: llc -mtriple=riscv32 -mattr=+zvfh %s -o - | FileCheck --check-prefix=RV32ZVFH %s
 ; RUN: llc -mtriple=riscv32 -mattr=+zve32x -mattr=+experimental-zvabd %s -o - | FileCheck --check-prefix=RV32ZVABD %s
 ; RUN: llc -mtriple=riscv32 -mattr=+zicond %s -o - | FileCheck --check-prefix=RV32ZICOND %s
@@ -265,6 +266,7 @@
 ; RUN: llc -mtriple=riscv64 -mattr=+zve32x -mattr=+zvksh %s -o - | FileCheck --check-prefix=RV64ZVKSH %s
 ; RUN: llc -mtriple=riscv64 -mattr=+zve32x -mattr=+zvkt %s -o - | FileCheck --check-prefix=RV64ZVKT %s
 ; RUN: llc -mtriple=riscv64 -mattr=+zve32x -mattr=+experimental-zvdot4a8i %s -o - | FileCheck --check-prefix=RV64ZVDOT4A8I %s
+; RUN: llc -mtriple=riscv64 -mattr=+zve32x -mattr=+experimental-zvzip %s -o - | FileCheck --check-prefix=RV64ZVZIP %s
 ; RUN: llc -mtriple=riscv64 -mattr=+zvfh %s -o - | FileCheck --check-prefix=RV64ZVFH %s
 ; RUN: llc -mtriple=riscv64 -mattr=+zve32x -mattr=+experimental-zvabd %s -o - | FileCheck --check-prefix=RV64ZVABD %s
 ; RUN: llc -mtriple=riscv64 -mattr=+zicond %s -o - | FileCheck --check-prefix=RV64ZICOND %s
@@ -431,6 +433,7 @@
 ; RV32ZVKSH: .attribute 5, "rv32i2p1_zicsr2p0_zve32x1p0_zvksh1p0_zvl32b1p0"
 ; RV32ZVKT: .attribute 5, "rv32i2p1_zicsr2p0_zve32x1p0_zvkt1p0_zvl32b1p0"
 ; RV32ZVDOT4A8I: .attribute 5, "rv32i2p1_zicsr2p0_zvdot4a8i0p1_zve32x1p0_zvl32b1p0"
+; RV32ZVZIP: .attribute 5, "rv32i2p1_zicsr2p0_zve32x1p0_zvl32b1p0_zvzip0p1"
 ; RV32ZVFH: .attribute 5, "rv32i2p1_f2p2_zicsr2p0_zfhmin1p0_zve32f1p0_zve32x1p0_zvfh1p0_zvfhmin1p0_zvl32b1p0"
 ; RV32ZVABD: .attribute 5, "rv32i2p1_zicsr2p0_zvabd0p7_zve32x1p0_zvl32b1p0"
 ; RV32ZICOND: .attribute 5, "rv32i2p1_zicond1p0"
@@ -584,6 +587,7 @@
 ; RV64ZVKSH: .attribute 5, "rv64i2p1_zicsr2p0_zve32x1p0_zvksh1p0_zvl32b1p0"
 ; RV64ZVKT: .attribute 5, "rv64i2p1_zicsr2p0_zve32x1p0_zvkt1p0_zvl32b1p0"
 ; RV64ZVDOT4A8I: .attribute 5, "rv64i2p1_zicsr2p0_zvdot4a8i0p1_zve32x1p0_zvl32b1p0"
+; RV64ZVZIP: .attribute 5, "rv64i2p1_zicsr2p0_zve32x1p0_zvl32b1p0_zvzip0p1"
 ; RV64ZVFH: .attribute 5, "rv64i2p1_f2p2_zicsr2p0_zfhmin1p0_zve32f1p0_zve32x1p0_zvfh1p0_zvfhmin1p0_zvl32b1p0"
 ; RV64ZVABD: .attribute 5, "rv64i2p1_zicsr2p0_zvabd0p7_zve32x1p0_zvl32b1p0"
 ; RV64ZICOND: .attribute 5, "rv64i2p1_zicond1p0"

--- a/llvm/test/CodeGen/RISCV/features-info.ll
+++ b/llvm/test/CodeGen/RISCV/features-info.ll
@@ -40,6 +40,7 @@
 ; CHECK-NEXT:   experimental-zvfbfa              - 'Zvfbfa' (Additional BF16 vector compute support).
 ; CHECK-NEXT:   experimental-zvfofp8min          - 'Zvfofp8min' (Vector OFP8 Converts).
 ; CHECK-NEXT:   experimental-zvkgs               - 'Zvkgs' (Vector-Scalar GCM instructions for Cryptography).
+; CHECK-NEXT:   experimental-zvzip               - 'Zvzip' (Vector Reordering Structured Data). 
 ; CHECK-NEXT:   f                                - 'F' (Single-Precision Floating-Point).
 ; CHECK-NEXT:   forced-atomics                   - Assume that lock-free native-width atomics are available.
 ; CHECK-NEXT:   fusion-add-load                  - Enable ADD(.UW) + load macrofusion.

--- a/llvm/test/MC/RISCV/attribute-arch.s
+++ b/llvm/test/MC/RISCV/attribute-arch.s
@@ -180,6 +180,9 @@
 .attribute arch, "rv32i_zvdot4a8i0p1"
 # CHECK: attribute      5, "rv32i2p1_zicsr2p0_zvdot4a8i0p1_zve32x1p0_zvl32b1p0"
 
+.attribute arch, "rv32i_zvzip0p1"
+# CHECK: attribute      5, "rv32i2p1_zicsr2p0_zve32x1p0_zvl32b1p0_zvzip0p1"
+
 .attribute arch, "rv32izbs1p0"
 # CHECK: attribute      5, "rv32i2p1_zbs1p0"
 

--- a/llvm/test/MC/RISCV/rvv/zvzip-invalid.s
+++ b/llvm/test/MC/RISCV/rvv/zvzip-invalid.s
@@ -1,0 +1,34 @@
+# RUN: not llvm-mc -triple=riscv64 --mattr=+experimental-zvzip %s 2>&1 \
+# RUN:        | FileCheck %s --check-prefix=CHECK-ERROR
+
+vzip.vv v0, v0, v4
+# CHECK-ERROR: the destination vector register group cannot overlap the source vector register group
+# CHECK-ERROR-LABEL: vzip.vv v0, v0, v4
+
+vpaire.vv v0, v0, v4
+# CHECK-ERROR: the destination vector register group cannot overlap the source vector register group
+# CHECK-ERROR-LABEL: vpaire.vv v0, v0, v4
+
+vpairo.vv v0, v0, v4
+# CHECK-ERROR: the destination vector register group cannot overlap the source vector register group
+# CHECK-ERROR-LABEL: vpairo.vv v0, v0, v4
+
+vunzipe.v v0, v0
+# CHECK-ERROR: the destination vector register group cannot overlap the source vector register group
+# CHECK-ERROR-LABEL: vunzipe.v v0, v0
+
+vunzipo.v v0, v0
+# CHECK-ERROR: the destination vector register group cannot overlap the source vector register group
+# CHECK-ERROR-LABEL: vunzipo.v v0, v0
+
+vzip.vv v0, v2, v4, v0.t
+# CHECK-ERROR: the destination vector register group cannot overlap the mask register
+# CHECK-ERROR-LABEL: vzip.vv v0, v2, v4, v0.t
+
+vpaire.vv v0, v2, v4, v0.t
+# CHECK-ERROR: the destination vector register group cannot overlap the mask register
+# CHECK-ERROR-LABEL: vpaire.vv v0, v2, v4, v0.t
+
+vpairo.vv v0, v2, v4, v0.t
+# CHECK-ERROR: the destination vector register group cannot overlap the mask register
+# CHECK-ERROR-LABEL: vpairo.vv v0, v2, v4, v0.t

--- a/llvm/test/MC/RISCV/rvv/zvzip.s
+++ b/llvm/test/MC/RISCV/rvv/zvzip.s
@@ -1,0 +1,50 @@
+# RUN: llvm-mc %s -triple=riscv32 -mattr=+experimental-zvzip -riscv-no-aliases -show-encoding \
+# RUN:     | FileCheck -check-prefixes=CHECK-ASM,CHECK-ASM-AND-OBJ %s
+# RUN: llvm-mc %s -triple=riscv64 -mattr=+experimental-zvzip -riscv-no-aliases -show-encoding \
+# RUN:     | FileCheck -check-prefixes=CHECK-ASM,CHECK-ASM-AND-OBJ %s
+# RUN: llvm-mc -filetype=obj -triple=riscv32 -mattr=+experimental-zvzip < %s \
+# RUN:     | llvm-objdump --mattr=+experimental-zvzip -M no-aliases -d -r - \
+# RUN:     | FileCheck --check-prefix=CHECK-ASM-AND-OBJ %s
+# RUN: llvm-mc -filetype=obj -triple=riscv64 -mattr=+experimental-zvzip < %s \
+# RUN:     | llvm-objdump --mattr=+experimental-zvzip -M no-aliases -d -r - \
+# RUN:     | FileCheck --check-prefix=CHECK-ASM-AND-OBJ %s
+
+# CHECK-ASM-AND-OBJ: vzip.vv    v1, v2, v3
+# CHECK-ASM: encoding: [0xd7,0xa0,0x21,0xfa]
+vzip.vv    v1, v2, v3
+
+# CHECK-ASM-AND-OBJ: vzip.vv    v1, v2, v3, v0.t
+# CHECK-ASM: encoding: [0xd7,0xa0,0x21,0xf8]
+vzip.vv    v1, v2, v3, v0.t
+
+# CHECK-ASM-AND-OBJ: vpaire.vv  v1, v2, v3
+# CHECK-ASM: encoding: [0xd7,0x80,0x21,0x3e]
+vpaire.vv  v1, v2, v3
+
+# CHECK-ASM-AND-OBJ: vpaire.vv  v1, v2, v3, v0.t
+# CHECK-ASM: encoding: [0xd7,0x80,0x21,0x3c]
+vpaire.vv  v1, v2, v3, v0.t
+
+# CHECK-ASM-AND-OBJ:  vpairo.vv   v1, v2, v3
+# CHECK-ASM: encoding: [0xd7,0xa0,0x21,0x3e]
+vpairo.vv   v1, v2, v3
+
+# CHECK-ASM-AND-OBJ:  vpairo.vv   v1, v2, v3, v0.t
+# CHECK-ASM: encoding: [0xd7,0xa0,0x21,0x3c]
+vpairo.vv   v1, v2, v3, v0.t
+
+# CHECK-ASM-AND-OBJ: vunzipe.v   v1, v2
+# CHECK-ASM: encoding: [0xd7,0xa0,0x25,0x4a]
+vunzipe.v   v1, v2
+
+# CHECK-ASM-AND-OBJ: vunzipe.v   v1, v2, v0.t
+# CHECK-ASM: encoding: [0xd7,0xa0,0x25,0x48]
+vunzipe.v   v1, v2, v0.t
+
+# CHECK-ASM-AND-OBJ: vunzipo.v v1, v2
+# CHECK-ASM: encoding: [0xd7,0xa0,0x27,0x4a]
+vunzipo.v v1, v2
+
+# CHECK-ASM-AND-OBJ: vunzipe.v   v1, v2, v0.t
+# CHECK-ASM: encoding: [0xd7,0xa0,0x25,0x48]
+vunzipe.v   v1, v2, v0.t

--- a/llvm/unittests/TargetParser/RISCVISAInfoTest.cpp
+++ b/llvm/unittests/TargetParser/RISCVISAInfoTest.cpp
@@ -1383,6 +1383,7 @@ Experimental extensions
     zvfbfa               0.1
     zvfofp8min           0.2
     zvkgs                0.7
+    zvzip                0.1
     smpmpmt              0.6
     svukte               0.3
     xrivosvisni          0.1


### PR DESCRIPTION
This adds the initial support of the `Zvzip` standard extension for
reordering structured data in vector registers.

Doc:

* https://github.com/ved-rivos/riscv-isa-manual/blob/zvzip/src/zvzip.adoc
* https://github.com/riscv/riscv-opcodes/blob/master/extensions/unratified/rv_zvzip.

Co-Authored-By: wangboyao <wangboyao@bytedance.com>
