### PR TITLE
[lldb][PlatformDarwin][NFC] Use formatv-style format string in LocateExecutableScriptingResourcesFromDSYM

### DIFF
--- a/lldb/source/Plugins/Platform/MacOSX/PlatformDarwin.cpp
+++ b/lldb/source/Plugins/Platform/MacOSX/PlatformDarwin.cpp
@@ -229,12 +229,13 @@ FileSpecList PlatformDarwin::LocateExecutableScriptingResourcesFromDSYM(
     // .dSYM/Contents/Resources/DWARF/<basename> let us go to
     // .dSYM/Contents/Resources/Python/<basename>.py and see if the
     // file exists
-    path_string.Printf("%s/../Python/%s.py",
-                       symfile_spec.GetDirectory().GetCString(),
-                       module_basename.c_str());
-    original_path_string.Printf("%s/../Python/%s.py",
-                                symfile_spec.GetDirectory().GetCString(),
-                                original_module_basename.c_str());
+    path_string.Format("{0}/../Python/{1}.py",
+                       symfile_spec.GetDirectory().GetStringRef(),
+                       module_basename);
+    original_path_string.Format("{0}/../Python/{1}.py",
+                                symfile_spec.GetDirectory().GetStringRef(),
+                                original_module_basename);
+
     FileSpec script_fspec(path_string.GetString());
     FileSystem::Instance().Resolve(script_fspec);
     FileSpec orig_script_fspec(original_path_string.GetString());


### PR DESCRIPTION
About to make changes in this area and using `formatv` instead of `printf` style format specifiers makes those easier to follow.