### PR TITLE
libclc: Use elementwise exp for exp functions

### DIFF
--- a/libclc/clc/lib/amdgpu/CMakeLists.txt
+++ b/libclc/clc/lib/amdgpu/CMakeLists.txt
@@ -1,6 +1,9 @@
 libclc_configure_source_list(CLC_AMDGPU_SOURCES
   ${CMAKE_CURRENT_SOURCE_DIR}
   address_space/qualifier.cl
+  math/clc_exp.cl
+  math/clc_exp2.cl
+  math/clc_exp10.cl
   math/clc_half_exp.cl
   math/clc_half_exp2.cl
   math/clc_half_exp10.cl

--- a/libclc/clc/lib/amdgpu/math/clc_exp.cl
+++ b/libclc/clc/lib/amdgpu/math/clc_exp.cl
@@ -1,0 +1,15 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "clc/math/clc_exp.h"
+
+#define __CLC_FUNCTION __clc_exp
+#define __CLC_IMPL_FUNCTION(x) __builtin_elementwise_exp
+#define __CLC_BODY <clc/shared/unary_def.inc>
+
+#include <clc/math/gentype.inc>

--- a/libclc/clc/lib/amdgpu/math/clc_exp10.cl
+++ b/libclc/clc/lib/amdgpu/math/clc_exp10.cl
@@ -1,0 +1,15 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "clc/math/clc_exp10.h"
+
+#define __CLC_FUNCTION __clc_exp10
+#define __CLC_IMPL_FUNCTION(x) __builtin_elementwise_exp10
+#define __CLC_BODY <clc/shared/unary_def.inc>
+
+#include <clc/math/gentype.inc>

--- a/libclc/clc/lib/amdgpu/math/clc_exp2.cl
+++ b/libclc/clc/lib/amdgpu/math/clc_exp2.cl
@@ -1,0 +1,15 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "clc/math/clc_exp2.h"
+
+#define __CLC_FUNCTION __clc_exp2
+#define __CLC_IMPL_FUNCTION(x) __builtin_elementwise_exp2
+#define __CLC_BODY <clc/shared/unary_def.inc>
+
+#include <clc/math/gentype.inc>


### PR DESCRIPTION
For amdgpu use the exp intrinisc. Really, this should be
the default generic implementation. But we're stuck in a
mess where essentially nothing works. All of the exp
intrinsics work for AMDGPU, but aren't really implemented
for spirv or nvptx. Ideally the intrinsic and/or libm call
would be the default implementation.