### PR TITLE
[lldb] Use AppendMessageWithFormatv instead of AppendMessageWithFormat

### DIFF
--- a/lldb/source/Commands/CommandObjectPlugin.cpp
+++ b/lldb/source/Commands/CommandObjectPlugin.cpp
@@ -96,9 +96,9 @@ int SetEnableOnMatchingPlugins(const llvm::StringRef &pattern,
             continue;
           }
 
-          result.AppendMessageWithFormat(
-              "  %s %-30s %s\n", enabled ? "[+]" : "[-]", plugin.name.data(),
-              plugin.description.data());
+          result.AppendMessageWithFormatv("  {0} {1, -30} {2}",
+                                          enabled ? "[+]" : "[-]", plugin.name,
+                                          plugin.description);
         }
       });
 }
@@ -253,9 +253,9 @@ private:
                        const std::vector<RegisteredPluginInfo> &plugins) {
             result.AppendMessage(plugin_namespace.name);
             for (auto &plugin : plugins) {
-              result.AppendMessageWithFormat(
-                  "  %s %-30s %s\n", plugin.enabled ? "[+]" : "[-]",
-                  plugin.name.data(), plugin.description.data());
+              result.AppendMessageWithFormatv("  {0} {1, -30} {2}",
+                                              plugin.enabled ? "[+]" : "[-]",
+                                              plugin.name, plugin.description);
             }
           });
       if (num_matching == 0) {

--- a/lldb/source/Commands/CommandObjectProcess.cpp
+++ b/lldb/source/Commands/CommandObjectProcess.cpp
@@ -1057,8 +1057,8 @@ protected:
       }
 
       if (image_token != LLDB_INVALID_IMAGE_TOKEN) {
-        result.AppendMessageWithFormat(
-            "Loading \"%s\"...ok\nImage %u loaded.\n", image_path.str().c_str(),
+        result.AppendMessageWithFormatv(
+            "Loading \"{0}\"...ok\nImage {1} loaded.", image_path.str().c_str(),
             image_token);
         result.SetStatus(eReturnStatusSuccessFinishResult);
       } else {
@@ -1362,7 +1362,7 @@ protected:
                   SaveCoreStyle::eSaveCoreDirtyOnly ||
               core_dump_options.GetStyle() ==
                   SaveCoreStyle::eSaveCoreStackOnly) {
-            result.AppendMessageWithFormat(
+            result.AppendMessage(
                 "\nModified-memory or stack-memory only corefile "
                 "created.  This corefile may \n"
                 "not show library/framework/app binaries "
@@ -1370,7 +1370,7 @@ protected:
                 "those binaries have "
                 "been updated/modified. Copies are not included\n"
                 "in this corefile.  Use --style full to include all "
-                "process memory.\n");
+                "process memory.");
           }
           result.SetStatus(eReturnStatusSuccessFinishResult);
         } else {

--- a/lldb/source/Commands/CommandObjectThread.cpp
+++ b/lldb/source/Commands/CommandObjectThread.cpp
@@ -718,8 +718,7 @@ public:
               thread->SetResumeState(eStateSuspended);
             }
           }
-          result.AppendMessageWithFormat("in process %" PRIu64 "\n",
-                                         process->GetID());
+          result.AppendMessageWithFormatv("in process {0}", process->GetID());
         }
       } else {
         // These two lines appear at the beginning of both blocks in this
@@ -740,6 +739,9 @@ public:
             result.AppendMessageWithFormat("Resuming thread 0x%4.4" PRIx64
                                            " in process %" PRIu64 "\n",
                                            thread->GetID(), process->GetID());
+            result.AppendMessageWithFormatv(
+                "Resuming thread {0:x4} in process {1}", thread->GetID(),
+                process->GetID());
             const bool override_suspend = true;
             thread->SetResumeState(eStateRunning, override_suspend);
           } else {
@@ -757,8 +759,8 @@ public:
 
       // We should not be holding the thread list lock when we do this.
       if (error.Success()) {
-        result.AppendMessageWithFormat("Process %" PRIu64 " resuming\n",
-                                       process->GetID());
+        result.AppendMessageWithFormatv("Process {0} resuming",
+                                        process->GetID());
         if (synchronous_execution) {
           // If any state changed events had anything to say, add that to the
           // result
@@ -1062,8 +1064,8 @@ protected:
         error = process->Resume();
 
       if (error.Success()) {
-        result.AppendMessageWithFormat("Process %" PRIu64 " resuming\n",
-                                       process->GetID());
+        result.AppendMessageWithFormatv("Process {0} resuming",
+                                        process->GetID());
         if (synchronous_execution) {
           // If any state changed events had anything to say, add that to the
           // result

--- a/lldb/source/Commands/CommandObjectThread.cpp
+++ b/lldb/source/Commands/CommandObjectThread.cpp
@@ -736,9 +736,6 @@ public:
         for (uint32_t idx = 0; idx < num_threads; ++idx) {
           Thread *thread = process->GetThreadList().GetThreadAtIndex(idx).get();
           if (thread == current_thread) {
-            result.AppendMessageWithFormat("Resuming thread 0x%4.4" PRIx64
-                                           " in process %" PRIu64 "\n",
-                                           thread->GetID(), process->GetID());
             result.AppendMessageWithFormatv(
                 "Resuming thread {0:x4} in process {1}", thread->GetID(),
                 process->GetID());

--- a/lldb/source/Interpreter/CommandInterpreter.cpp
+++ b/lldb/source/Interpreter/CommandInterpreter.cpp
@@ -1641,9 +1641,9 @@ void CommandInterpreter::GetHelp(CommandReturnObject &result,
 
   if (!m_alias_dict.empty() &&
       ((cmd_types & eCommandTypesAliases) == eCommandTypesAliases)) {
-    result.AppendMessageWithFormat(
+    result.AppendMessageWithFormatv(
         "Current command abbreviations "
-        "(type '%shelp command alias' for more info):\n",
+        "(type '{0}help command alias' for more info):",
         GetCommandPrefix());
     result.AppendMessage("");
     max_len = FindLongestCommandWord(m_alias_dict);
@@ -1680,8 +1680,8 @@ void CommandInterpreter::GetHelp(CommandReturnObject &result,
     result.AppendMessage("");
   }
 
-  result.AppendMessageWithFormat(
-      "For more information on any command, type '%shelp <command-name>'.\n",
+  result.AppendMessageWithFormatv(
+      "For more information on any command, type '{0}help <command-name>'.",
       GetCommandPrefix());
 }
 
@@ -2830,8 +2830,8 @@ void CommandInterpreter::HandleCommands(
 
     if (options.GetEchoCommands()) {
       // TODO: Add Stream support.
-      result.AppendMessageWithFormat("%s %s\n",
-                                     m_debugger.GetPrompt().str().c_str(), cmd);
+      result.AppendMessageWithFormatv(
+          "{0} {1}", m_debugger.GetPrompt().str().c_str(), cmd);
     }
 
     CommandReturnObject tmp_result(m_debugger.GetUseColor());
@@ -2892,9 +2892,9 @@ void CommandInterpreter::HandleCommands(
               ": '%s' continued the target.\n",
               (uint64_t)idx + 1, cmd);
         else
-          result.AppendMessageWithFormat("Command #%" PRIu64
-                                         " '%s' continued the target.\n",
-                                         (uint64_t)idx + 1, cmd);
+          result.AppendMessageWithFormatv(
+              "Command #{0} '{1}' continued the target.", (uint64_t)idx + 1,
+              cmd);
 
         result.SetStatus(tmp_result.GetStatus());
         m_debugger.SetAsyncExecution(old_async_execution);
@@ -2912,8 +2912,8 @@ void CommandInterpreter::HandleCommands(
             ": '%s' stopped with a signal or exception.\n",
             (uint64_t)idx + 1, cmd);
       else
-        result.AppendMessageWithFormat(
-            "Command #%" PRIu64 " '%s' stopped with a signal or exception.\n",
+        result.AppendMessageWithFormatv(
+            "Command #{0} '{1}' stopped with a signal or exception.",
             (uint64_t)idx + 1, cmd);
 
       result.SetStatus(tmp_result.GetStatus());
@@ -3552,8 +3552,8 @@ bool CommandInterpreter::SaveTranscript(
                      "Bytes written do not match transcript size.");
 
   result.SetStatus(eReturnStatusSuccessFinishNoResult);
-  result.AppendMessageWithFormat("Session's transcripts saved to %s\n",
-                                 output_file->c_str());
+  result.AppendMessageWithFormatv("Session's transcripts saved to {0}",
+                                  output_file->c_str());
   if (!GetSaveTranscript())
     result.AppendError(
         "Note: the setting interpreter.save-transcript is set to false, so the "


### PR DESCRIPTION
Part 4. This converts all the remaining simple uses (the ones that ended with a newline).

What remains in tree are the outliers that expect multiple ending newlines, or are building a message in pieces.