### PR TITLE
libclc: Use frexp builtins to implement frexp for amdgpu

### DIFF
--- a/libclc/clc/lib/amdgpu/CMakeLists.txt
+++ b/libclc/clc/lib/amdgpu/CMakeLists.txt
@@ -4,6 +4,7 @@ libclc_configure_source_list(CLC_AMDGPU_SOURCES
   math/clc_exp.cl
   math/clc_exp2.cl
   math/clc_exp10.cl
+  math/clc_frexp.cl
   math/clc_half_exp.cl
   math/clc_half_exp2.cl
   math/clc_half_exp10.cl

--- a/libclc/clc/lib/amdgpu/math/clc_frexp.cl
+++ b/libclc/clc/lib/amdgpu/math/clc_frexp.cl
@@ -1,0 +1,43 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include <clc/internal/clc.h>
+#include <clc/math/clc_frexp.h>
+
+#define __CLC_BODY <clc_frexp_builtin.inc>
+#define __CLC_ADDRESS_SPACE private
+#define __CLC_PRIVATE
+#include <clc/math/gentype.inc>
+#undef __CLC_ADDRESS_SPACE
+#undef __CLC_PRIVATE
+
+#define __CLC_BODY <clc_frexp_builtin.inc>
+#define __CLC_ADDRESS_SPACE global
+#include <clc/math/gentype.inc>
+#undef __CLC_ADDRESS_SPACE
+
+#define __CLC_BODY <clc_frexp_builtin.inc>
+#define __CLC_ADDRESS_SPACE local
+#include <clc/math/gentype.inc>
+#undef __CLC_ADDRESS_SPACE
+
+#if _CLC_DISTINCT_GENERIC_AS_SUPPORTED
+#define __CLC_BODY <clc_frexp_builtin.inc>
+#define __CLC_ADDRESS_SPACE generic
+#include <clc/math/gentype.inc>
+#undef __CLC_ADDRESS_SPACE
+#endif
+
+#define __CLC_FUNCTION __clc_frexp
+#define __CLC_ARG2_TYPE int
+#define __CLC_ADDRSPACE private
+#define __CLC_BODY <clc/shared/unary_def_with_ptr_scalarize.inc>
+#include <clc/math/gentype.inc>
+#undef __CLC_ADDRSPACE
+#undef __CLC_ARG2_TYPE
+#undef __CLC_FUNCTION

--- a/libclc/clc/lib/generic/math/clc_frexp_builtin.inc
+++ b/libclc/clc/lib/generic/math/clc_frexp_builtin.inc
@@ -1,0 +1,47 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#if defined(__CLC_PRIVATE) && defined(__CLC_SCALAR)
+
+#if __CLC_FPSIZE == 16
+
+_CLC_OVERLOAD _CLC_DEF __CLC_GENTYPE __clc_frexp(__CLC_GENTYPE x,
+                                                 private __CLC_INTN *ep) {
+  return __builtin_frexpf16(x, ep);
+}
+
+#elif __CLC_FPSIZE == 32
+
+_CLC_OVERLOAD _CLC_DEF __CLC_GENTYPE __clc_frexp(__CLC_GENTYPE x,
+                                                 private __CLC_INTN *ep) {
+  return __builtin_frexpf(x, ep);
+}
+
+#elif __CLC_FPSIZE == 64
+
+_CLC_OVERLOAD _CLC_DEF __CLC_GENTYPE __clc_frexp(__CLC_GENTYPE x,
+                                                 private __CLC_INTN *ep) {
+  return __builtin_frexp(x, ep);
+}
+
+#else
+#error "unhandled fpsize"
+#endif
+
+#elif !defined(__CLC_PRIVATE)
+
+_CLC_OVERLOAD _CLC_DEF __CLC_GENTYPE
+__clc_frexp(__CLC_GENTYPE x, __CLC_ADDRESS_SPACE __CLC_INTN *ep) {
+private
+  __CLC_INTN e;
+  __CLC_GENTYPE result = __clc_frexp(x, &e);
+  *ep = e;
+  return result;
+}
+
+#endif

--- a/libclc/clc/lib/generic/math/clc_frexp_builtin.inc
+++ b/libclc/clc/lib/generic/math/clc_frexp_builtin.inc
@@ -37,7 +37,6 @@ _CLC_OVERLOAD _CLC_DEF __CLC_GENTYPE __clc_frexp(__CLC_GENTYPE x,
 
 _CLC_OVERLOAD _CLC_DEF __CLC_GENTYPE
 __clc_frexp(__CLC_GENTYPE x, __CLC_ADDRESS_SPACE __CLC_INTN *ep) {
-private
   __CLC_INTN e;
   __CLC_GENTYPE result = __clc_frexp(x, &e);
   *ep = e;


### PR DESCRIPTION
This should really be the default implementation.