### PR TITLE
[TableGen] Fix inferring missing sub-classes for various subreg indices

### DIFF
--- a/llvm/utils/TableGen/Common/CodeGenRegisters.cpp
+++ b/llvm/utils/TableGen/Common/CodeGenRegisters.cpp
@@ -2485,9 +2485,9 @@ void CodeGenRegBank::inferMatchingSuperRegClass(
     SubRegs.clear();
     TopoSigs.reset();
     for (const CodeGenRegister *Super : RC->getMembers()) {
-      const CodeGenRegister *Sub = Super->getSubRegs().find(SubIdx)->second;
       if (Super->Artificial)
         continue;
+      const CodeGenRegister *Sub = Super->getSubRegs().find(SubIdx)->second;
       assert(Sub && "Missing sub-register");
       SubRegs.push_back(Sub);
       TopoSigs.set(Sub->getTopoSig());


### PR DESCRIPTION
We should not imply artificial registers have sub-registers for a given index even if the class is known to 'fully support' that index.

Fixes crashes reported in
https://github.com/llvm/llvm-project/pull/183371#discussion_r2905495313