### PR TITLE
[libclc][CMake] Append target_name to external-funcs test target name

### DIFF
--- a/libclc/cmake/modules/AddLibclc.cmake
+++ b/libclc/cmake/modules/AddLibclc.cmake
@@ -180,7 +180,7 @@ function(add_libclc_library target_name)
   if(NOT ARG_ARCH MATCHES "^(nvptx|clspv)(64)?$" AND
      NOT ARG_ARCH MATCHES "^spirv(64)?$")
     set(builtins_file $<TARGET_PROPERTY:${target_name},TARGET_FILE>)
-    add_test(NAME external-funcs-${ARG_TARGET_TRIPLE}
+    add_test(NAME external-funcs-${target_name}
       COMMAND ./check_external_funcs.sh
               ${builtins_file} ${LLVM_TOOLS_BINARY_DIR}
       WORKING_DIRECTORY ${LIBCLC_SOURCE_DIR})


### PR DESCRIPTION
Avoid name conflicts when multiple libararies use the same target triple.