### PR TITLE
[OpenMP] Add definitions of FLATTEN and SPLIT to OMP.td

### DIFF
--- a/llvm/include/llvm/Frontend/OpenMP/OMP.td
+++ b/llvm/include/llvm/Frontend/OpenMP/OMP.td
@@ -929,6 +929,16 @@ def OMP_Error : Directive<[Spelling<"error">]> {
   let association = AS_None;
   let category = CA_Utility;
 }
+def OMP_Flatten : Directive<[Spelling<"flatten">]> {
+  let allowedClauses = [
+    VersionedClause<OMPC_Apply, 60>,
+  ];
+  let allowedOnceClauses = [
+    VersionedClause<OMPC_Depth, 61>,
+  ];
+  let association = AS_LoopNest;
+  let category = CA_Executable;
+}
 def OMP_Flush : Directive<[Spelling<"flush">]> {
   let allowedOnceClauses = [
     VersionedClause<OMPC_AcqRel, 50>,
@@ -1191,6 +1201,16 @@ def OMP_EndSingle : Directive<[Spelling<"end single">]> {
   let association = OMP_Single.association;
   let category = OMP_Single.category;
   let languages = [L_Fortran];
+}
+def OMP_Split : Directive<[Spelling<"split">]> {
+  let allowedClauses = [
+    VersionedClause<OMPC_Apply, 60>,
+  ];
+  let allowedOnceClauses = [
+    VersionedClause<OMPC_Counts, 60>,
+  ];
+  let association = AS_LoopNest;
+  let category = CA_Executable;
 }
 def OMP_Target : Directive<[Spelling<"target">]> {
   let allowedClauses = [


### PR DESCRIPTION
Add the definitions of the "flatten" and the "split" constructs to the OMP.td file. This will allow the implementation efforts in clang and flang to proceed independently.

There is no other functionality added in this patch.

The "flatten" construct is defined in the OpenMP Technical Report 14:
https://www.openmp.org/wp-content/uploads/openmp-TR14.pdf