### PR TITLE
[TableGen] Do not order register classes based on heap addresses

### DIFF
--- a/llvm/utils/TableGen/Common/CodeGenRegisters.cpp
+++ b/llvm/utils/TableGen/Common/CodeGenRegisters.cpp
@@ -844,24 +844,21 @@ unsigned CodeGenRegisterClass::getWeight(const CodeGenRegBank &RegBank) const {
 bool CodeGenRegisterClass::Key::operator<(
     const CodeGenRegisterClass::Key &B) const {
   assert(Members && B.Members);
-  if (!IgnoreArtificialMembers)
-    return std::tie(*Members, RSI) < std::tie(*B.Members, B.RSI);
 
-  // Do the same lexicographical comparison, but ignoring
-  // artificial registers.
+  // Lexicographical comparison. Ignores artificial registers when asked.
   auto IA = Members->begin(), EA = Members->end();
   auto IB = B.Members->begin(), EB = B.Members->end();
   for (;;) {
-    while (IA != EA && (*IA)->Artificial)
+    while (IgnoreArtificialMembers && IA != EA && (*IA)->Artificial)
       ++IA;
-    while (IB != EB && (*IB)->Artificial)
+    while (IgnoreArtificialMembers && IB != EB && (*IB)->Artificial)
       ++IB;
     if (IA == EA && IB == EB)
       break;
     if (IA == EA || IB == EB)
       return IA == EA;
-    if (*IA != *IB)
-      return *IA < *IB;
+    if (**IA != **IB)
+      return **IA < **IB;
     ++IA;
     ++IB;
   }

--- a/llvm/utils/TableGen/Common/CodeGenRegisters.h
+++ b/llvm/utils/TableGen/Common/CodeGenRegisters.h
@@ -318,6 +318,10 @@ inline bool operator==(const CodeGenRegister &A, const CodeGenRegister &B) {
   return A.EnumValue == B.EnumValue;
 }
 
+inline bool operator!=(const CodeGenRegister &A, const CodeGenRegister &B) {
+  return !(A == B);
+}
+
 class CodeGenRegisterClass {
   CodeGenRegister::Vec Members;
   // Bit mask of members, indexed by getRegIndex.


### PR DESCRIPTION
Compare registers using their enum values instead, which I suspect was the intention in the first place, since we already have lexicographical ordering defined for CodeGenRegisters.

This does not cause any changes in .inc files and is likely NFC, but it's still best to have it be deterministic.