### PR TITLE
[clang-repl] fix vtable symbol duplication error (closes #141039)

### DIFF
--- a/clang/lib/CodeGen/CGVTables.cpp
+++ b/clang/lib/CodeGen/CGVTables.cpp
@@ -1210,6 +1210,7 @@ CodeGenModule::getVTableLinkage(const CXXRecordDecl *RD) {
 /// emits them as-needed.
 void CodeGenModule::EmitVTable(CXXRecordDecl *theClass) {
   VTables.GenerateClassData(theClass);
+  EmittedVTables.insert(theClass);
 }
 
 void
@@ -1292,11 +1293,18 @@ void CodeGenModule::EmitDeferredVTables() {
   size_t savedSize = DeferredVTables.size();
 #endif
 
-  for (const CXXRecordDecl *RD : DeferredVTables)
+  for (const CXXRecordDecl *RD : DeferredVTables) {
+    // if a table has been emitted in an earlier PTU, but was also marked
+    // deferred, we should skip if the linkage is external
+    if (EmittedVTables.count(RD) &&
+        getVTableLinkage(RD) == llvm::GlobalValue::ExternalLinkage)
+      continue;
+
     if (shouldEmitVTableAtEndOfTranslationUnit(*this, RD))
       VTables.GenerateClassData(RD);
     else if (shouldOpportunisticallyEmitVTables())
       OpportunisticVTables.push_back(RD);
+  }
 
   assert(savedSize == DeferredVTables.size() &&
          "deferred extra vtables during vtable emission?");

--- a/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/clang/lib/CodeGen/CodeGenModule.cpp
@@ -8696,6 +8696,10 @@ void CodeGenModule::moveLazyEmissionStates(CodeGenModule *NewBuilder) {
          "Newly created module should not have deferred vtables");
   NewBuilder->DeferredVTables = std::move(DeferredVTables);
 
+  assert(NewBuilder->EmittedVTables.empty() &&
+         "Newly created module should not have defined vtables");
+  NewBuilder->EmittedVTables = std::move(EmittedVTables);
+
   assert(NewBuilder->MangledDeclNames.empty() &&
          "Newly created module should not have mangled decl names");
   assert(NewBuilder->Manglings.empty() &&

--- a/clang/lib/CodeGen/CodeGenModule.h
+++ b/clang/lib/CodeGen/CodeGenModule.h
@@ -478,6 +478,11 @@ private:
   /// A queue of (optional) vtables to consider emitting.
   std::vector<const CXXRecordDecl*> DeferredVTables;
 
+  /// In incremental compilation, the set of vtable classes whose vtable
+  /// definitions were emitted into a previous PTU's module. Carried forward
+  /// by moveLazyEmissionStates() so later PTUs skip re-defining them.
+  llvm::SmallPtrSet<const CXXRecordDecl *, 8> EmittedVTables;
+
   /// A queue of (optional) vtables that may be emitted opportunistically.
   std::vector<const CXXRecordDecl *> OpportunisticVTables;
 

--- a/clang/test/Interpreter/virtualdef-outside.cpp
+++ b/clang/test/Interpreter/virtualdef-outside.cpp
@@ -1,0 +1,40 @@
+// REQUIRES: host-supports-jit
+// RUN: cat %s | clang-repl | FileCheck %s
+// virtual functions defined outside of class had duplicate symbols:
+//     duplicate definition of symbol '__ZTV3Two' (i.e., vtable for Two)
+// see https://github.com/llvm/llvm-project/issues/141039.
+// fixed in PR #185648
+
+extern "C" int printf(const char *, ...);
+
+struct X1 { virtual void vi() { printf("1vi\n"); } };
+X1().vi();
+// CHECK: 1vi
+
+struct X2 { virtual void vo(); };
+void X2::vo() { printf("2vo\n"); }
+X2().vo();
+// CHECK: 2vo
+
+struct X3 { \
+  void ni() { printf("3ni\n"); } \
+  void no(); \
+  virtual void vi() { printf("3vi\n"); } \
+  virtual void vo(); \
+  virtual ~X3() { printf("3d\n"); } \
+};
+void X3::no() { printf("3no\n"); }
+void X3::vo() { printf("3vo\n"); }
+auto x3 = new X3;
+x3->ni();
+// CHECK: 3ni
+x3->no();
+// CHECK: 3no
+x3->vi();
+// CHECK: 3vi
+x3->vo();
+// CHECK: 3vo
+delete x3;
+// CHECK: 3d
+
+%quit


### PR DESCRIPTION
In incremental mode, emit by ExternalLinkage causes duplicate symbol error. A single targeted change in getVTableLinkage() fixes the issue by returning LinkOnceODRLinkage when IncrementalExtensions is active. The JIT linker then keeps the first definition a silently discards subsequent ones.

closes issue #141039