### PR TITLE
[libclc] Remove unused and incorrect pkgconf file

### DIFF
--- a/libclc/CMakeLists.txt
+++ b/libclc/CMakeLists.txt
@@ -139,10 +139,6 @@ add_custom_target( libclc ALL )
 add_custom_target( libclc-opencl-builtins COMMENT "Build libclc OpenCL builtins" )
 add_dependencies( libclc libclc-opencl-builtins )
 
-configure_file( libclc.pc.in libclc.pc @ONLY )
-install( FILES ${CMAKE_CURRENT_BINARY_DIR}/libclc.pc
-  DESTINATION "${CMAKE_INSTALL_DATADIR}/pkgconfig" )
-
 enable_testing()
 
 foreach( t ${LIBCLC_TARGETS_TO_BUILD} )

--- a/libclc/libclc.pc.in
+++ b/libclc/libclc.pc.in
@@ -1,6 +1,0 @@
-libexecdir=@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_DATADIR@/clc
-
-Name: libclc
-Description: Library requirements of the OpenCL C programming language
-Version: @PROJECT_VERSION@
-Libs: -L${libexecdir}


### PR DESCRIPTION
Summary:
All this file does is pass `-L` to an incorrect location. These files
are installed as part of the resource directory which is always included
anyway, so I think this is vestigial and can be removed.
