### PR TITLE
[OFFLOAD] Add interface to extend image validation

### DIFF
--- a/offload/plugins-nextgen/common/include/PluginInterface.h
+++ b/offload/plugins-nextgen/common/include/PluginInterface.h
@@ -1371,7 +1371,7 @@ struct GenericPluginTy {
     return false;
   }
 
-  /// Indicate if an imaget is compatible with the plugin devices. This is
+  /// Indicate if an image is compatible with the plugin devices. This is
   /// called if the image is not recognized as compatible by the common layer.
   /// This gives the plugin a chance to inspect the image and decide if it is
   /// compatible. Notice that this function may be called before actually

--- a/offload/plugins-nextgen/common/include/PluginInterface.h
+++ b/offload/plugins-nextgen/common/include/PluginInterface.h
@@ -1364,6 +1364,24 @@ struct GenericPluginTy {
   virtual Expected<bool> isELFCompatible(uint32_t DeviceID,
                                          StringRef Image) const = 0;
 
+  /// Indicate if an image is compatible with the plugin. This is called if
+  /// the image is not recognized as compatible by the common layer. This gives
+  /// the plugin a chance to inspect the image and decide if it is compatible.
+  virtual Expected<bool> isCompatibleImage(StringRef Image) const {
+    return false;
+  }
+
+  /// Indicate if an imaget is compatible with the plugin devices. This is
+  /// called if the image is not recognized as compatible by the common layer.
+  /// This gives the plugin a chance to inspect the image and decide if it is
+  /// compatible. Notice that this function may be called before actually
+  /// initializing the devices. So we could not move this function into
+  /// GenericDeviceTy.
+  virtual Expected<bool> isCompatibleImage(uint32_t DeviceID,
+                                           StringRef Image) const {
+    return isCompatibleImage(Image);
+  }
+
   virtual Error flushQueueImpl(omp_interop_val_t *Interop) {
     return Plugin::success();
   }

--- a/offload/plugins-nextgen/common/include/PluginInterface.h
+++ b/offload/plugins-nextgen/common/include/PluginInterface.h
@@ -1367,7 +1367,7 @@ struct GenericPluginTy {
   /// Indicate if an image is compatible with the plugin. This is called if
   /// the image is not recognized as compatible by the common layer. This gives
   /// the plugin a chance to inspect the image and decide if it is compatible.
-  virtual Expected<bool> isCompatibleImage(StringRef Image) const {
+  virtual Expected<bool> isImageCompatible(StringRef Image) const {
     return false;
   }
 
@@ -1377,9 +1377,9 @@ struct GenericPluginTy {
   /// compatible. Notice that this function may be called before actually
   /// initializing the devices. So we could not move this function into
   /// GenericDeviceTy.
-  virtual Expected<bool> isCompatibleImage(uint32_t DeviceID,
+  virtual Expected<bool> isImageCompatible(uint32_t DeviceID,
                                            StringRef Image) const {
-    return isCompatibleImage(Image);
+    return isImageCompatible(Image);
   }
 
   virtual Error flushQueueImpl(omp_interop_val_t *Interop) {

--- a/offload/plugins-nextgen/common/src/PluginInterface.cpp
+++ b/offload/plugins-nextgen/common/src/PluginInterface.cpp
@@ -1652,7 +1652,10 @@ int32_t GenericPluginTy::isPluginCompatible(StringRef Image) {
     return *MatchOrErr;
   }
   default:
-    return false;
+    auto MatchOrErr = isCompatibleImage(Image);
+    if (Error Err = MatchOrErr.takeError())
+      return HandleError(std::move(Err));
+    return *MatchOrErr;
   }
 }
 
@@ -1689,7 +1692,10 @@ int32_t GenericPluginTy::isDeviceCompatible(int32_t DeviceId, StringRef Image) {
     return *MatchOrErr;
   }
   default:
-    return false;
+    auto MatchOrErr = isCompatibleImage(DeviceId, Image);
+    if (Error Err = MatchOrErr.takeError())
+      return HandleError(std::move(Err));
+    return *MatchOrErr;
   }
 }
 

--- a/offload/plugins-nextgen/common/src/PluginInterface.cpp
+++ b/offload/plugins-nextgen/common/src/PluginInterface.cpp
@@ -1652,7 +1652,7 @@ int32_t GenericPluginTy::isPluginCompatible(StringRef Image) {
     return *MatchOrErr;
   }
   default:
-    auto MatchOrErr = isCompatibleImage(Image);
+    auto MatchOrErr = isImageCompatible(Image);
     if (Error Err = MatchOrErr.takeError())
       return HandleError(std::move(Err));
     return *MatchOrErr;
@@ -1692,7 +1692,7 @@ int32_t GenericPluginTy::isDeviceCompatible(int32_t DeviceId, StringRef Image) {
     return *MatchOrErr;
   }
   default:
-    auto MatchOrErr = isCompatibleImage(DeviceId, Image);
+    auto MatchOrErr = isImageCompatible(DeviceId, Image);
     if (Error Err = MatchOrErr.takeError())
       return HandleError(std::move(Err));
     return *MatchOrErr;

--- a/offload/plugins-nextgen/level_zero/include/L0Plugin.h
+++ b/offload/plugins-nextgen/level_zero/include/L0Plugin.h
@@ -107,6 +107,8 @@ public:
   Error flushQueueImpl(omp_interop_val_t *Interop) override;
   Error syncBarrierImpl(omp_interop_val_t *Interop) override;
   Error asyncBarrierImpl(omp_interop_val_t *Interop) override;
+
+  Expected<bool> isCompatibleImage(StringRef Image) const override;
 };
 
 } // namespace llvm::omp::target::plugin

--- a/offload/plugins-nextgen/level_zero/include/L0Plugin.h
+++ b/offload/plugins-nextgen/level_zero/include/L0Plugin.h
@@ -108,7 +108,7 @@ public:
   Error syncBarrierImpl(omp_interop_val_t *Interop) override;
   Error asyncBarrierImpl(omp_interop_val_t *Interop) override;
 
-  Expected<bool> isCompatibleImage(StringRef Image) const override;
+  Expected<bool> isImageCompatible(StringRef Image) const override;
 };
 
 } // namespace llvm::omp::target::plugin

--- a/offload/plugins-nextgen/level_zero/src/L0Plugin.cpp
+++ b/offload/plugins-nextgen/level_zero/src/L0Plugin.cpp
@@ -233,6 +233,13 @@ Error LevelZeroPluginTy::asyncBarrierImpl(omp_interop_val_t *Interop) {
   return Plugin::success();
 }
 
+// We only need to check for formats other than ELF here
+Expected<bool> LevelZeroPluginTy::isCompatibleImage(StringRef Image) const {
+  if (identify_magic(Image) == file_magic::spirv_object)
+    return true;
+  return false; 
+}
+
 } // namespace llvm::omp::target::plugin
 
 extern "C" {

--- a/offload/plugins-nextgen/level_zero/src/L0Plugin.cpp
+++ b/offload/plugins-nextgen/level_zero/src/L0Plugin.cpp
@@ -235,9 +235,7 @@ Error LevelZeroPluginTy::asyncBarrierImpl(omp_interop_val_t *Interop) {
 
 // We only need to check for formats other than ELF here
 Expected<bool> LevelZeroPluginTy::isImageCompatible(StringRef Image) const {
-  if (identify_magic(Image) == file_magic::spirv_object)
-    return true;
-  return false;
+  return identify_magic(Image) == file_magic::spirv_object;
 }
 
 } // namespace llvm::omp::target::plugin

--- a/offload/plugins-nextgen/level_zero/src/L0Plugin.cpp
+++ b/offload/plugins-nextgen/level_zero/src/L0Plugin.cpp
@@ -237,7 +237,7 @@ Error LevelZeroPluginTy::asyncBarrierImpl(omp_interop_val_t *Interop) {
 Expected<bool> LevelZeroPluginTy::isCompatibleImage(StringRef Image) const {
   if (identify_magic(Image) == file_magic::spirv_object)
     return true;
-  return false; 
+  return false;
 }
 
 } // namespace llvm::omp::target::plugin

--- a/offload/plugins-nextgen/level_zero/src/L0Plugin.cpp
+++ b/offload/plugins-nextgen/level_zero/src/L0Plugin.cpp
@@ -234,7 +234,7 @@ Error LevelZeroPluginTy::asyncBarrierImpl(omp_interop_val_t *Interop) {
 }
 
 // We only need to check for formats other than ELF here
-Expected<bool> LevelZeroPluginTy::isCompatibleImage(StringRef Image) const {
+Expected<bool> LevelZeroPluginTy::isImageCompatible(StringRef Image) const {
   if (identify_magic(Image) == file_magic::spirv_object)
     return true;
   return false;


### PR DESCRIPTION
As discussed in #185404 we might want to provide a way for plugins to validate images not recognized by the common layer.

This PR adds such extension and uses to validate pure SPIRV images by the Level Zero plugin.