### PR TITLE
[Runtimes] Use order-only deps for runtime external projects

### DIFF
--- a/llvm/cmake/modules/LLVMExternalProjectUtils.cmake
+++ b/llvm/cmake/modules/LLVMExternalProjectUtils.cmake
@@ -59,6 +59,9 @@ endfunction()
 #     Targets for toolchain tools (defaults to clang;lld)
 #   DEPENDS targets...
 #     Targets that this project depends on
+#   ORDER_DEPENDS targets...
+#     Targets that this project depends on for build ordering only without
+#     forcing a reconfigure.
 #   EXTRA_TARGETS targets...
 #     Extra targets in the subproject to generate targets for
 #   PASSTHROUGH_PREFIXES prefix...
@@ -74,7 +77,7 @@ function(llvm_ExternalProject_Add name source_dir)
   cmake_parse_arguments(ARG
     "ENABLE_FORTRAN;USE_TOOLCHAIN;EXCLUDE_FROM_ALL;NO_INSTALL;ALWAYS_CLEAN"
     "SOURCE_DIR;FOLDER"
-    "CMAKE_ARGS;TOOLCHAIN_TOOLS;RUNTIME_LIBRARIES;DEPENDS;EXTRA_TARGETS;PASSTHROUGH_PREFIXES;STRIP_TOOL;TARGET_TRIPLE"
+    "CMAKE_ARGS;TOOLCHAIN_TOOLS;RUNTIME_LIBRARIES;DEPENDS;ORDER_DEPENDS;EXTRA_TARGETS;PASSTHROUGH_PREFIXES;STRIP_TOOL;TARGET_TRIPLE"
     ${ARGN})
   canonicalize_tool_name(${name} nameCanon)
 
@@ -438,6 +441,10 @@ function(llvm_ExternalProject_Add name source_dir)
       PROPERTIES FOLDER "${ARG_FOLDER}"
     )
   endif ()
+
+  if(ARG_ORDER_DEPENDS)
+    add_dependencies(${name}-configure ${ARG_ORDER_DEPENDS})
+  endif()
 
   if(ARG_USE_TOOLCHAIN)
     set(force_deps DEPENDS ${TOOLCHAIN_BINS})

--- a/llvm/runtimes/CMakeLists.txt
+++ b/llvm/runtimes/CMakeLists.txt
@@ -241,7 +241,7 @@ foreach(entry ${runtimes})
 endforeach()
 
 function(runtime_default_target)
-  cmake_parse_arguments(ARG "" "" "DEPENDS;CMAKE_ARGS;PREFIXES;EXTRA_ARGS" ${ARGN})
+  cmake_parse_arguments(ARG "" "" "DEPENDS;ORDER_DEPENDS;CMAKE_ARGS;PREFIXES;EXTRA_ARGS" ${ARGN})
 
   include(${LLVM_BINARY_DIR}/runtimes/Components.cmake OPTIONAL)
   set(SUB_CHECK_TARGETS ${SUB_CHECK_TARGETS} PARENT_SCOPE)
@@ -289,6 +289,7 @@ function(runtime_default_target)
   llvm_ExternalProject_Add(runtimes
                            ${CMAKE_CURRENT_SOURCE_DIR}/../../runtimes
                            DEPENDS ${ARG_DEPENDS}
+                           ORDER_DEPENDS ${ARG_ORDER_DEPENDS}
                            # Builtins were built separately above
                            CMAKE_ARGS -DCOMPILER_RT_BUILD_BUILTINS=Off
                                       -DLLVM_INCLUDE_TESTS=${LLVM_INCLUDE_TESTS}
@@ -323,7 +324,7 @@ endfunction()
 # runtime_register_target(name)
 #   Utility function to register external runtime target.
 function(runtime_register_target name)
-  cmake_parse_arguments(ARG "" "BASE_NAME" "DEPENDS;CMAKE_ARGS;EXTRA_ARGS" ${ARGN})
+  cmake_parse_arguments(ARG "" "BASE_NAME" "DEPENDS;ORDER_DEPENDS;CMAKE_ARGS;EXTRA_ARGS" ${ARGN})
   include(${LLVM_BINARY_DIR}/runtimes/${name}/Components.cmake OPTIONAL)
   set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS ${LLVM_BINARY_DIR}/runtimes/${name}/Components.cmake)
 
@@ -436,6 +437,7 @@ function(runtime_register_target name)
   llvm_ExternalProject_Add(runtimes-${name}
                            ${CMAKE_CURRENT_SOURCE_DIR}/../../runtimes
                            DEPENDS ${ARG_DEPENDS}
+                           ORDER_DEPENDS ${ARG_ORDER_DEPENDS}
                            # Builtins were built separately above
                            CMAKE_ARGS -DCOMPILER_RT_BUILD_BUILTINS=OFF
                                       -DLLVM_INCLUDE_TESTS=${LLVM_INCLUDE_TESTS}
@@ -642,7 +644,8 @@ if(build_runtimes)
 
   if(NOT LLVM_RUNTIME_TARGETS)
     runtime_default_target(
-      DEPENDS ${builtins_dep} ${extra_deps}
+      DEPENDS ${extra_deps}
+      ORDER_DEPENDS ${builtins_dep}
       CMAKE_ARGS ${extra_cmake_args}
       PREFIXES ${prefixes}
       EXTRA_ARGS ${extra_args})
@@ -650,7 +653,8 @@ if(build_runtimes)
   else()
     if("default" IN_LIST LLVM_RUNTIME_TARGETS)
       runtime_default_target(
-        DEPENDS ${builtins_dep} ${extra_deps}
+        DEPENDS ${extra_deps}
+        ORDER_DEPENDS ${builtins_dep}
         CMAKE_ARGS ${extra_cmake_args}
         PREFIXES ${prefixes}
         EXTRA_ARGS ${extra_args})
@@ -709,7 +713,8 @@ if(build_runtimes)
       check_apple_target(${name} runtime)
 
       runtime_register_target(${name}
-        DEPENDS ${builtins_dep_name} ${extra_deps}
+        DEPENDS ${extra_deps}
+        ORDER_DEPENDS ${builtins_dep_name}
         CMAKE_ARGS -DLLVM_DEFAULT_TARGET_TRIPLE=${name} ${extra_cmake_args}
         EXTRA_ARGS TARGET_TRIPLE ${name} ${extra_args})
     endforeach()
@@ -717,7 +722,7 @@ if(build_runtimes)
     foreach(multilib ${LLVM_RUNTIME_MULTILIBS})
       foreach(name ${LLVM_RUNTIME_MULTILIB_${multilib}_TARGETS})
         runtime_register_target(${name}+${multilib}
-          DEPENDS runtimes-${name}
+          ORDER_DEPENDS runtimes-${name}
           CMAKE_ARGS -DLLVM_DEFAULT_TARGET_TRIPLE=${name}
                      -DLLVM_RUNTIMES_PREFIX=${name}/
                      -DLLVM_RUNTIMES_LIBDIR_SUBDIR=${multilib}

--- a/runtimes/CMakeLists.txt
+++ b/runtimes/CMakeLists.txt
@@ -451,19 +451,18 @@ if(SUB_COMPONENTS)
 endif()
 
 # If the user requested 'compile_commands.json' we merge the generated JSON from
-# the created directories.
+# the created directories into the main build's compile_commands.json.
 if(CMAKE_EXPORT_COMPILE_COMMANDS AND NOT ("${LLVM_BINARY_DIR}" STREQUAL "${CMAKE_BINARY_DIR}"))
-  # Make a dependency so that we don't error if the file gets deleted somehow.
-  add_custom_command(OUTPUT ${CMAKE_BINARY_DIR}/compile_commands.json
-                     COMMAND ${CMAKE_COMMAND} -E touch ${CMAKE_BINARY_DIR}/compile_commands.json)
-
   file(TO_NATIVE_PATH "${LLVM_MAIN_SRC_DIR}/utils/merge-json.py" MERGE_JSON_PATH)
-  add_custom_command(OUTPUT ${LLVM_BINARY_DIR}/compile_commands.json
-                     COMMAND ${CMAKE_COMMAND} -E touch ${LLVM_BINARY_DIR}/compile_commands.json
-                     COMMAND ${Python3_EXECUTABLE} ${MERGE_JSON_PATH}
-                             ${LLVM_BINARY_DIR}/compile_commands.json
-                             ${CMAKE_BINARY_DIR}/compile_commands.json
-                             -o ${LLVM_BINARY_DIR}/compile_commands.json
-                     DEPENDS ${CMAKE_BINARY_DIR}/compile_commands.json)
-  add_custom_target(merge_runtime_commands ALL DEPENDS ${LLVM_BINARY_DIR}/compile_commands.json)
+  add_custom_command(
+    OUTPUT ${CMAKE_BINARY_DIR}/merge_compile_commands.stamp
+    COMMAND ${Python3_EXECUTABLE} ${MERGE_JSON_PATH}
+            ${LLVM_BINARY_DIR}/compile_commands.json
+            ${CMAKE_BINARY_DIR}/compile_commands.json
+            -o ${LLVM_BINARY_DIR}/compile_commands.json
+    COMMAND ${CMAKE_COMMAND} -E touch ${CMAKE_BINARY_DIR}/merge_compile_commands.stamp
+    DEPENDS ${CMAKE_BINARY_DIR}/compile_commands.json
+    COMMENT "Merging runtime compile commands")
+  add_custom_target(merge_runtime_commands ALL
+    DEPENDS ${CMAKE_BINARY_DIR}/merge_compile_commands.stamp)
 endif()


### PR DESCRIPTION
Summary:
Introduce an ORDER_DEPENDS parameter to llvm_ExternalProject_Add. These
dependencies are applied via add_dependencies() rather than through
ExternalProject_Add(DEPENDS ...), creating order-only dependencies in
Ninja. This preserves correct build ordering without the stamp file
dependency that triggers reconfiguration.
    
Fixes: https://github.com/llvm/llvm-project/issues/98897