### PR TITLE
[MLIR] Update DIDerivedType To Support File, Line And Scope

### DIFF
--- a/flang/lib/Optimizer/Transforms/DebugTypeGenerator.cpp
+++ b/flang/lib/Optimizer/Transforms/DebugTypeGenerator.cpp
@@ -436,8 +436,9 @@ mlir::LLVM::DITypeAttr DebugTypeGenerator::convertRecordType(
     offset = llvm::alignTo(offset, byteAlign);
     mlir::LLVM::DIDerivedTypeAttr tyAttr = mlir::LLVM::DIDerivedTypeAttr::get(
         context, llvm::dwarf::DW_TAG_member,
-        mlir::StringAttr::get(context, fieldName), elemTy, byteSize * 8,
-        byteAlign * 8, offset * 8, /*optional<address space>=*/std::nullopt,
+        mlir::StringAttr::get(context, fieldName), /*file=*/nullptr, /*line=*/0,
+        /*scope=*/nullptr, elemTy, byteSize * 8, byteAlign * 8, offset * 8,
+        /*optional<address space>=*/std::nullopt,
         /*flags=*/mlir::LLVM::DIFlags::Zero,
         /*extra data=*/nullptr);
     elements.push_back(tyAttr);
@@ -479,7 +480,8 @@ mlir::LLVM::DITypeAttr DebugTypeGenerator::convertTupleType(
     offset = llvm::alignTo(offset, byteAlign);
     mlir::LLVM::DIDerivedTypeAttr tyAttr = mlir::LLVM::DIDerivedTypeAttr::get(
         context, llvm::dwarf::DW_TAG_member, mlir::StringAttr::get(context, ""),
-        elemTy, byteSize * 8, byteAlign * 8, offset * 8,
+        /*file=*/nullptr, /*line=*/0, /*scope=*/nullptr, elemTy, byteSize * 8,
+        byteAlign * 8, offset * 8,
         /*optional<address space>=*/std::nullopt,
         /*flags=*/mlir::LLVM::DIFlags::Zero,
         /*extra data=*/nullptr);
@@ -673,7 +675,8 @@ mlir::LLVM::DITypeAttr DebugTypeGenerator::convertPointerLikeType(
 
   return mlir::LLVM::DIDerivedTypeAttr::get(
       context, llvm::dwarf::DW_TAG_pointer_type,
-      mlir::StringAttr::get(context, ""), elTyAttr, /*sizeInBits=*/ptrSize * 8,
+      mlir::StringAttr::get(context, ""), /*file=*/nullptr, /*line=*/0,
+      /*scope=*/nullptr, elTyAttr, /*sizeInBits=*/ptrSize * 8,
       /*alignInBits=*/0, /*offset=*/0,
       /*optional<address space>=*/std::nullopt,
       /*flags=*/mlir::LLVM::DIFlags::Zero, /*extra data=*/nullptr);
@@ -743,7 +746,8 @@ DebugTypeGenerator::convertType(mlir::Type Ty, mlir::LLVM::DIFileAttr fileAttr,
 
     return mlir::LLVM::DIDerivedTypeAttr::get(
         context, llvm::dwarf::DW_TAG_pointer_type,
-        mlir::StringAttr::get(context, ""), subroutineTy,
+        mlir::StringAttr::get(context, ""), /*file=*/nullptr, /*line=*/0,
+        /*scope=*/nullptr, subroutineTy,
         /*sizeInBits=*/ptrSize * 8, /*alignInBits=*/0, /*offset=*/0,
         /*optional<address space>=*/std::nullopt,
         /*flags=*/mlir::LLVM::DIFlags::Zero, /*extra data=*/nullptr);

--- a/mlir/include/mlir-c/Dialect/LLVM.h
+++ b/mlir/include/mlir-c/Dialect/LLVM.h
@@ -294,10 +294,10 @@ MLIR_CAPI_EXPORTED MlirStringRef mlirLLVMDICompositeTypeAttrGetName(void);
 /// optional field, where `MLIR_CAPI_DWARF_ADDRESS_SPACE_NULL` indicates null
 /// and non-negative values indicate a value present.
 MLIR_CAPI_EXPORTED MlirAttribute mlirLLVMDIDerivedTypeAttrGet(
-    MlirContext ctx, unsigned int tag, MlirAttribute name,
-    MlirAttribute baseType, uint64_t sizeInBits, uint32_t alignInBits,
-    uint64_t offsetInBits, int64_t dwarfAddressSpace, int64_t flags,
-    MlirAttribute extraData);
+    MlirContext ctx, unsigned int tag, MlirAttribute name, MlirAttribute file,
+    uint32_t line, MlirAttribute scope, MlirAttribute baseType,
+    uint64_t sizeInBits, uint32_t alignInBits, uint64_t offsetInBits,
+    int64_t dwarfAddressSpace, int64_t flags, MlirAttribute extraData);
 
 MLIR_CAPI_EXPORTED MlirStringRef mlirLLVMDIDerivedTypeAttrGetName(void);
 

--- a/mlir/include/mlir/Dialect/LLVMIR/LLVMAttrDefs.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/LLVMAttrDefs.td
@@ -512,17 +512,18 @@ def LLVM_DICompositeTypeAttr : LLVM_Attr<"DICompositeType", "di_composite_type",
 
 def LLVM_DIDerivedTypeAttr : LLVM_Attr<"DIDerivedType", "di_derived_type",
                                        /*traits=*/[], "DITypeAttr"> {
-  let parameters = (ins
-    LLVM_DITagParameter:$tag,
-    OptionalParameter<"StringAttr">:$name,
-    OptionalParameter<"DITypeAttr">:$baseType,
-    OptionalParameter<"uint64_t">:$sizeInBits,
-    OptionalParameter<"uint32_t">:$alignInBits,
-    OptionalParameter<"uint64_t">:$offsetInBits,
-    OptionalParameter<"std::optional<unsigned>">:$dwarfAddressSpace,
-    OptionalParameter<"DIFlags", "DIFlags::Zero">:$flags,
-    OptionalParameter<"DINodeAttr">:$extraData
-  );
+  let parameters = (ins LLVM_DITagParameter:$tag,
+      OptionalParameter<"StringAttr">:$name,
+      OptionalParameter<"DIFileAttr">:$file,
+      OptionalParameter<"uint32_t">:$line,
+      OptionalParameter<"DIScopeAttr">:$scope,
+      OptionalParameter<"DITypeAttr">:$baseType,
+      OptionalParameter<"uint64_t">:$sizeInBits,
+      OptionalParameter<"uint32_t">:$alignInBits,
+      OptionalParameter<"uint64_t">:$offsetInBits,
+      OptionalParameter<"std::optional<unsigned>">:$dwarfAddressSpace,
+      OptionalParameter<"DIFlags", "DIFlags::Zero">:$flags,
+      OptionalParameter<"DINodeAttr">:$extraData);
   let assemblyFormat = "`<` struct(params) `>`";
 
   // Generate mnemonic alias for the attribute.

--- a/mlir/include/mlir/Dialect/LLVMIR/LLVMAttrDefs.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/LLVMAttrDefs.td
@@ -512,18 +512,20 @@ def LLVM_DICompositeTypeAttr : LLVM_Attr<"DICompositeType", "di_composite_type",
 
 def LLVM_DIDerivedTypeAttr : LLVM_Attr<"DIDerivedType", "di_derived_type",
                                        /*traits=*/[], "DITypeAttr"> {
-  let parameters = (ins LLVM_DITagParameter:$tag,
-      OptionalParameter<"StringAttr">:$name,
-      OptionalParameter<"DIFileAttr">:$file,
-      OptionalParameter<"uint32_t">:$line,
-      OptionalParameter<"DIScopeAttr">:$scope,
-      OptionalParameter<"DITypeAttr">:$baseType,
-      OptionalParameter<"uint64_t">:$sizeInBits,
-      OptionalParameter<"uint32_t">:$alignInBits,
-      OptionalParameter<"uint64_t">:$offsetInBits,
-      OptionalParameter<"std::optional<unsigned>">:$dwarfAddressSpace,
-      OptionalParameter<"DIFlags", "DIFlags::Zero">:$flags,
-      OptionalParameter<"DINodeAttr">:$extraData);
+  let parameters = (ins
+    LLVM_DITagParameter:$tag,
+    OptionalParameter<"StringAttr">:$name,
+    OptionalParameter<"DIFileAttr">:$file,
+    OptionalParameter<"uint32_t">:$line,
+    OptionalParameter<"DIScopeAttr">:$scope,
+    OptionalParameter<"DITypeAttr">:$baseType,
+    OptionalParameter<"uint64_t">:$sizeInBits,
+    OptionalParameter<"uint32_t">:$alignInBits,
+    OptionalParameter<"uint64_t">:$offsetInBits,
+    OptionalParameter<"std::optional<unsigned>">:$dwarfAddressSpace,
+    OptionalParameter<"DIFlags", "DIFlags::Zero">:$flags,
+    OptionalParameter<"DINodeAttr">:$extraData
+  );
   let assemblyFormat = "`<` struct(params) `>`";
 
   // Generate mnemonic alias for the attribute.

--- a/mlir/include/mlir/Dialect/LLVMIR/LLVMDialectBytecode.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/LLVMDialectBytecode.td
@@ -191,18 +191,16 @@ def DICompositeTypeAttr : DialectAttribute<(attr
 // DIDerivedTypeAttr
 //===----------------------------------------------------------------------===//
 
-def DIDerivedTypeAttr : DialectAttribute<(attr
-  VarInt:$tag,
-  OptionalAttribute<"StringAttr">:$name,
-  OptionalAttribute<"DITypeAttr">:$baseType,
-  VarInt:$sizeInBits,
-  VarInt:$alignInBits,
-  VarInt:$offsetInBits,
-  OptionalInt<"unsigned">:$dwarfAddressSpace,
-  EnumClassFlag<"DIFlags", "getFlags()">:$_rawflags,
-  LocalVar<"DIFlags", "(DIFlags)_rawflags">:$flags,
-  OptionalAttribute<"DINodeAttr">:$extraData
-)>;
+def DIDerivedTypeAttr
+    : DialectAttribute<(attr VarInt:$tag, OptionalAttribute<"StringAttr">:$name,
+          OptionalAttribute<"DIFileAttr">:$file, VarInt:$line,
+          OptionalAttribute<"DIScopeAttr">:$scope,
+          OptionalAttribute<"DITypeAttr">:$baseType, VarInt:$sizeInBits,
+          VarInt:$alignInBits, VarInt:$offsetInBits,
+          OptionalInt<"unsigned">:$dwarfAddressSpace,
+          EnumClassFlag<"DIFlags", "getFlags()">:$_rawflags,
+          LocalVar<"DIFlags", "(DIFlags)_rawflags">:$flags,
+          OptionalAttribute<"DINodeAttr">:$extraData)>;
 
 //===----------------------------------------------------------------------===//
 // DIImportedEntityAttr

--- a/mlir/include/mlir/Dialect/LLVMIR/LLVMDialectBytecode.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/LLVMDialectBytecode.td
@@ -191,16 +191,19 @@ def DICompositeTypeAttr : DialectAttribute<(attr
 // DIDerivedTypeAttr
 //===----------------------------------------------------------------------===//
 
-def DIDerivedTypeAttr
-    : DialectAttribute<(attr VarInt:$tag, OptionalAttribute<"StringAttr">:$name,
-          OptionalAttribute<"DIFileAttr">:$file, VarInt:$line,
-          OptionalAttribute<"DIScopeAttr">:$scope,
-          OptionalAttribute<"DITypeAttr">:$baseType, VarInt:$sizeInBits,
-          VarInt:$alignInBits, VarInt:$offsetInBits,
-          OptionalInt<"unsigned">:$dwarfAddressSpace,
-          EnumClassFlag<"DIFlags", "getFlags()">:$_rawflags,
-          LocalVar<"DIFlags", "(DIFlags)_rawflags">:$flags,
-          OptionalAttribute<"DINodeAttr">:$extraData)>;
+def DIDerivedTypeAttr : DialectAttribute<(attr
+  VarInt:$tag, OptionalAttribute<"StringAttr">:$name,
+  OptionalAttribute<"DIFileAttr">:$file,
+  VarInt:$line,
+  OptionalAttribute<"DIScopeAttr">:$scope,
+  OptionalAttribute<"DITypeAttr">:$baseType,
+  VarInt:$sizeInBits,
+  VarInt:$alignInBits, VarInt:$offsetInBits,
+  OptionalInt<"unsigned">:$dwarfAddressSpace,
+  EnumClassFlag<"DIFlags", "getFlags()">:$_rawflags,
+  LocalVar<"DIFlags", "(DIFlags)_rawflags">:$flags,
+  OptionalAttribute<"DINodeAttr">:$extraData
+)>;
 
 //===----------------------------------------------------------------------===//
 // DIImportedEntityAttr

--- a/mlir/include/mlir/Dialect/LLVMIR/LLVMDialectBytecode.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/LLVMDialectBytecode.td
@@ -192,13 +192,15 @@ def DICompositeTypeAttr : DialectAttribute<(attr
 //===----------------------------------------------------------------------===//
 
 def DIDerivedTypeAttr : DialectAttribute<(attr
-  VarInt:$tag, OptionalAttribute<"StringAttr">:$name,
+  VarInt:$tag,
+  OptionalAttribute<"StringAttr">:$name,
   OptionalAttribute<"DIFileAttr">:$file,
   VarInt:$line,
   OptionalAttribute<"DIScopeAttr">:$scope,
   OptionalAttribute<"DITypeAttr">:$baseType,
   VarInt:$sizeInBits,
-  VarInt:$alignInBits, VarInt:$offsetInBits,
+  VarInt:$alignInBits,
+  VarInt:$offsetInBits,
   OptionalInt<"unsigned">:$dwarfAddressSpace,
   EnumClassFlag<"DIFlags", "getFlags()">:$_rawflags,
   LocalVar<"DIFlags", "(DIFlags)_rawflags">:$flags,

--- a/mlir/lib/CAPI/Dialect/LLVM.cpp
+++ b/mlir/lib/CAPI/Dialect/LLVM.cpp
@@ -250,17 +250,17 @@ MlirStringRef mlirLLVMDICompositeTypeAttrGetName(void) {
   return wrap(DICompositeTypeAttr::name);
 }
 
-MlirAttribute
-mlirLLVMDIDerivedTypeAttrGet(MlirContext ctx, unsigned int tag,
-                             MlirAttribute name, MlirAttribute baseType,
-                             uint64_t sizeInBits, uint32_t alignInBits,
-                             uint64_t offsetInBits, int64_t dwarfAddressSpace,
-                             int64_t flags, MlirAttribute extraData) {
+MlirAttribute mlirLLVMDIDerivedTypeAttrGet(
+    MlirContext ctx, unsigned int tag, MlirAttribute name, MlirAttribute file,
+    uint32_t line, MlirAttribute scope, MlirAttribute baseType,
+    uint64_t sizeInBits, uint32_t alignInBits, uint64_t offsetInBits,
+    int64_t dwarfAddressSpace, int64_t flags, MlirAttribute extraData) {
   std::optional<unsigned> addressSpace = std::nullopt;
   if (dwarfAddressSpace >= 0)
     addressSpace = (unsigned)dwarfAddressSpace;
   return wrap(DIDerivedTypeAttr::get(
       unwrap(ctx), tag, cast<StringAttr>(unwrap(name)),
+      cast<DIFileAttr>(unwrap(file)), line, cast<DIScopeAttr>(unwrap(scope)),
       cast<DITypeAttr>(unwrap(baseType)), sizeInBits, alignInBits, offsetInBits,
       addressSpace, DIFlags(flags), cast<DINodeAttr>(unwrap(extraData))));
 }

--- a/mlir/lib/Target/LLVMIR/DebugImporter.cpp
+++ b/mlir/lib/Target/LLVMIR/DebugImporter.cpp
@@ -104,6 +104,7 @@ DIDerivedTypeAttr DebugImporter::translateImpl(llvm::DIDerivedType *node) {
       translate(dyn_cast_or_null<llvm::DINode>(node->getExtraData()));
   return DIDerivedTypeAttr::get(
       context, node->getTag(), getStringAttrOrNull(node->getRawName()),
+      translate(node->getFile()), node->getLine(), translate(node->getScope()),
       baseType, node->getSizeInBits(), node->getAlignInBits(),
       node->getOffsetInBits(), node->getDWARFAddressSpace(),
       symbolizeDIFlags(node->getFlags()).value_or(DIFlags::Zero), extraData);

--- a/mlir/lib/Target/LLVMIR/DebugTranslation.cpp
+++ b/mlir/lib/Target/LLVMIR/DebugTranslation.cpp
@@ -200,8 +200,8 @@ DebugTranslation::translateImpl(DICompositeTypeAttr attr) {
 llvm::DIDerivedType *DebugTranslation::translateImpl(DIDerivedTypeAttr attr) {
   return llvm::DIDerivedType::get(
       llvmCtx, attr.getTag(), getMDStringOrNull(attr.getName()),
-      /*File=*/nullptr, /*Line=*/0,
-      /*Scope=*/nullptr, translate(attr.getBaseType()), attr.getSizeInBits(),
+      translate(attr.getFile()), attr.getLine(), translate(attr.getScope()),
+      translate(attr.getBaseType()), attr.getSizeInBits(),
       attr.getAlignInBits(), attr.getOffsetInBits(),
       attr.getDwarfAddressSpace(), /*PtrAuthData=*/std::nullopt,
       /*Flags=*/static_cast<llvm::DINode::DIFlags>(attr.getFlags()),

--- a/mlir/test/CAPI/llvm.c
+++ b/mlir/test/CAPI/llvm.c
@@ -303,12 +303,12 @@ static void testDebugInfoAttributes(MlirContext ctx) {
   // CHECK: #llvm.di_derived_type<{{.*}}>
   // CHECK-NOT: dwarfAddressSpace
   mlirAttributeDump(mlirLLVMDIDerivedTypeAttrGet(
-      ctx, 0, bar, di_type, 64, 8, 0, MLIR_CAPI_DWARF_ADDRESS_SPACE_NULL, 0,
-      di_type));
+      ctx, 0, bar, file, 1, compile_unit, di_type, 64, 8, 0,
+      MLIR_CAPI_DWARF_ADDRESS_SPACE_NULL, 0, di_type));
 
   // CHECK: #llvm.di_derived_type<{{.*}} dwarfAddressSpace = 3{{.*}}>
-  mlirAttributeDump(mlirLLVMDIDerivedTypeAttrGet(ctx, 0, bar, di_type, 64, 8, 0,
-                                                 3, 0, di_type));
+  mlirAttributeDump(mlirLLVMDIDerivedTypeAttrGet(
+      ctx, 0, bar, file, 1, compile_unit, di_type, 64, 8, 0, 3, 0, di_type));
 
   MlirAttribute subroutine_type =
       mlirLLVMDISubroutineTypeAttrGet(ctx, 0x0, 1, &di_type);

--- a/mlir/test/Target/LLVMIR/Import/debug-info.ll
+++ b/mlir/test/Target/LLVMIR/Import/debug-info.ll
@@ -136,9 +136,10 @@ define void @basic_type() !dbg !3 {
 
 ; // -----
 
+; CHECK-DAG: #[[FILE:.+]] = #llvm.di_file<"debug-info.ll" in "/">
 ; CHECK: #[[INT:.+]] = #llvm.di_basic_type<tag = DW_TAG_base_type, name = "int">
 ; CHECK: #[[PTR1:.+]] = #llvm.di_derived_type<tag = DW_TAG_pointer_type, baseType = #[[INT]]>
-; CHECK: #[[PTR2:.+]] = #llvm.di_derived_type<tag = DW_TAG_pointer_type, name = "mypointer", baseType = #[[INT]], sizeInBits = 64, alignInBits = 32, offsetInBits = 4, extraData = #[[INT]]>
+; CHECK: #[[PTR2:.+]] = #llvm.di_derived_type<tag = DW_TAG_pointer_type, name = "mypointer", file = #[[FILE]], line = 42, scope = #[[FILE]], baseType = #[[INT]], sizeInBits = 64, alignInBits = 32, offsetInBits = 4, extraData = #[[INT]]>
 ; CHECK: #[[PTR3:.+]] = #llvm.di_derived_type<tag = DW_TAG_pointer_type, baseType = #[[INT]], dwarfAddressSpace = 3>
 ; CHECK: #llvm.di_subroutine_type<types = #[[PTR1]], #[[PTR2]], #[[PTR3]]>
 
@@ -156,7 +157,7 @@ define void @derived_type() !dbg !3 {
 !5 = !{!7, !8, !9}
 !6 = !DIBasicType(name: "int")
 !7 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !6)
-!8 = !DIDerivedType(name: "mypointer", tag: DW_TAG_pointer_type, baseType: !6, size: 64, align: 32, offset: 4, extraData: !6)
+!8 = !DIDerivedType(name: "mypointer", tag: DW_TAG_pointer_type, file: !2, line: 42, scope: !2, baseType: !6, size: 64, align: 32, offset: 4, extraData: !6)
 !9 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !6, dwarfAddressSpace: 3)
 
 ; // -----
@@ -341,7 +342,7 @@ define void @class_method() {
 ; Verify the cyclic composite type is handled correctly.
 ; CHECK-DAG: #[[COMP_SELF:.+]] = #llvm.di_composite_type<recId = [[REC_ID:.+]], isRecSelf = true>
 ; CHECK-DAG: #[[COMP_PTR_INNER:.+]] = #llvm.di_derived_type<tag = DW_TAG_pointer_type, baseType = #[[COMP_SELF]], flags = "Artificial|ObjectPointer">
-; CHECK-DAG: #[[FIELD:.+]] = #llvm.di_derived_type<tag = DW_TAG_member, name = "call_field", baseType = #[[COMP_PTR_INNER]]>
+; CHECK-DAG: #[[FIELD:.+]] = #llvm.di_derived_type<tag = DW_TAG_member, name = "call_field", file = #{{.*}}, baseType = #[[COMP_PTR_INNER]]>
 ; CHECK-DAG: #[[COMP:.+]] = #llvm.di_composite_type<recId = [[REC_ID]], tag = DW_TAG_class_type, name = "class_field", file = #{{.*}}, line = 42, flags = "TypePassByReference|NonTrivial", elements = #[[FIELD]]>
 ; CHECK-DAG: #[[COMP_PTR_OUTER:.+]] = #llvm.di_derived_type<tag = DW_TAG_pointer_type, baseType = #[[COMP]], flags = "Artificial|ObjectPointer">
 ; CHECK-DAG: #[[VAR0:.+]] = #llvm.di_local_variable<scope = #{{.*}}, name = "class_field", file = #{{.*}}, type = #[[COMP_PTR_OUTER]]>
@@ -636,12 +637,12 @@ declare !dbg !1 void @declaration()
 ; +--> B:B2 ----+
 ; This should result in only one B instance.
 
-; CHECK-DAG: #[[B1_INNER:.+]] = #llvm.di_derived_type<{{.*}}name = "B:B1", baseType = #[[B_SELF:.+]]>
-; CHECK-DAG: #[[B2_INNER:.+]] = #llvm.di_derived_type<{{.*}}name = "B:B2", baseType = #[[B_SELF]]>
+; CHECK-DAG: #[[B1_INNER:.+]] = #llvm.di_derived_type<{{.*}}name = "B:B1", file = #{{.*}}, baseType = #[[B_SELF:.+]]>
+; CHECK-DAG: #[[B2_INNER:.+]] = #llvm.di_derived_type<{{.*}}name = "B:B2", file = #{{.*}}, baseType = #[[B_SELF]]>
 ; CHECK-DAG: #[[B_INNER:.+]] = #llvm.di_composite_type<recId = [[B_RECID:.+]], tag = DW_TAG_class_type, name = "B", {{.*}}elements = #[[B1_INNER]], #[[B2_INNER]]
 
-; CHECK-DAG: #[[B1_OUTER:.+]] = #llvm.di_derived_type<{{.*}}name = "B:B1", baseType = #[[B_INNER]]>
-; CHECK-DAG: #[[B2_OUTER:.+]] = #llvm.di_derived_type<{{.*}}name = "B:B2", baseType = #[[B_INNER]]>
+; CHECK-DAG: #[[B1_OUTER:.+]] = #llvm.di_derived_type<{{.*}}name = "B:B1", file = #{{.*}}, baseType = #[[B_INNER]]>
+; CHECK-DAG: #[[B2_OUTER:.+]] = #llvm.di_derived_type<{{.*}}name = "B:B2", file = #{{.*}}, baseType = #[[B_INNER]]>
 ; CHECK-DAG: #[[A_OUTER:.+]] = #llvm.di_composite_type<recId = [[A_RECID:.+]], tag = DW_TAG_class_type, name = "A", {{.*}}elements = #[[B1_OUTER]], #[[B2_OUTER]]
 
 ; CHECK-DAG: #[[A_SELF:.+]] = #llvm.di_composite_type<recId = [[A_RECID]]

--- a/mlir/test/Target/LLVMIR/llvmir-debug.mlir
+++ b/mlir/test/Target/LLVMIR/llvmir-debug.mlir
@@ -40,6 +40,10 @@ llvm.func @func_no_debug() {
   sizeInBits = 64, alignInBits = 32, offsetInBits = 8,
   dwarfAddressSpace = 3
 >
+#ptrWithFileLine = #llvm.di_derived_type<
+  tag = DW_TAG_pointer_type, baseType = #si32, file = #file,
+  line = 42
+>
 #flags = #llvm.di_derived_type<
   tag = DW_TAG_pointer_type, baseType = #si32,
   sizeInBits = 64, flags = "Artificial|ObjectPointer"
@@ -60,7 +64,7 @@ llvm.func @func_no_debug() {
   elements = #llvm.di_subrange<lowerBound = 0, upperBound = 4, stride = 1>
 >
 #null = #llvm.di_null_type
-#spType0 = #llvm.di_subroutine_type<callingConvention = DW_CC_normal, types = #null, #si64, #ptr, #named, #ptrWithAddressSpace, #flags, #composite, #vector>
+#spType0 = #llvm.di_subroutine_type<callingConvention = DW_CC_normal, types = #null, #si64, #ptr, #named, #ptrWithAddressSpace, #ptrWithFileLine, #flags, #composite, #vector>
 #toplevel_namespace = #llvm.di_namespace<
   name = "toplevel", exportSymbols = true
 >
@@ -151,12 +155,13 @@ llvm.func @empty_types() {
 // CHECK: ![[NESTED_NAMESPACE]] = !DINamespace(name: "nested", scope: ![[TOPLEVEL_NAMESPACE:.*]])
 // CHECK: ![[TOPLEVEL_NAMESPACE]] = !DINamespace(name: "toplevel", scope: null, exportSymbols: true)
 // CHECK: ![[FUNC_TYPE]] = !DISubroutineType(cc: DW_CC_normal, types: ![[FUNC_ARGS:.*]])
-// CHECK: ![[FUNC_ARGS]] = !{null, ![[ARG_TYPE:.*]], ![[PTR_TYPE:.*]], ![[NAMED_TYPE:.*]], ![[PTR_WITH_ADDR_SPACE:.*]], ![[FLAGS:.*]], ![[COMPOSITE_TYPE:.*]], ![[VECTOR_TYPE:.*]]}
+// CHECK: ![[FUNC_ARGS]] = !{null, ![[ARG_TYPE:.*]], ![[PTR_TYPE:.*]], ![[NAMED_TYPE:.*]], ![[PTR_WITH_ADDR_SPACE:.*]], ![[PTR_WITH_FILE_LINE:.*]], ![[FLAGS:.*]], ![[COMPOSITE_TYPE:.*]], ![[VECTOR_TYPE:.*]]}
 // CHECK: ![[ARG_TYPE]] = !DIBasicType()
 // CHECK: ![[PTR_TYPE]] = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: ![[BASE_TYPE:.*]], size: 64, align: 32, offset: 8, extraData: ![[BASE_TYPE]])
 // CHECK: ![[BASE_TYPE]] = !DIBasicType(name: "si32", size: 32, encoding: DW_ATE_signed)
 // CHECK: ![[NAMED_TYPE]] = !DIDerivedType(tag: DW_TAG_pointer_type, name: "named", baseType: ![[BASE_TYPE:.*]])
 // CHECK: ![[PTR_WITH_ADDR_SPACE]] = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: ![[BASE_TYPE:.*]], size: 64, align: 32, offset: 8, dwarfAddressSpace: 3)
+// CHECK: ![[PTR_WITH_FILE_LINE]] = !DIDerivedType(tag: DW_TAG_pointer_type, file: ![[CU_FILE_LOC]], line: 42, baseType: ![[BASE_TYPE:.*]])
 // CHECK: ![[FLAGS]] = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: ![[BASE_TYPE:.*]], size: 64, flags: DIFlagArtificial | DIFlagObjectPointer)
 // CHECK: ![[COMPOSITE_TYPE]] = distinct !DICompositeType(tag: DW_TAG_structure_type, name: "composite", file: ![[CU_FILE_LOC]], line: 42, size: 64, align: 32, elements: ![[COMPOSITE_ELEMENTS:.*]])
 // CHECK: ![[COMPOSITE_ELEMENTS]] = !{![[COMPOSITE_ELEMENT:.*]]}

--- a/mlir/test/Target/LLVMIR/llvmir-debug.mlir
+++ b/mlir/test/Target/LLVMIR/llvmir-debug.mlir
@@ -42,7 +42,7 @@ llvm.func @func_no_debug() {
 >
 #ptrWithFileLine = #llvm.di_derived_type<
   tag = DW_TAG_pointer_type, baseType = #si32, file = #file,
-  line = 42
+  line = 42, scope = #file
 >
 #flags = #llvm.di_derived_type<
   tag = DW_TAG_pointer_type, baseType = #si32,
@@ -155,13 +155,13 @@ llvm.func @empty_types() {
 // CHECK: ![[NESTED_NAMESPACE]] = !DINamespace(name: "nested", scope: ![[TOPLEVEL_NAMESPACE:.*]])
 // CHECK: ![[TOPLEVEL_NAMESPACE]] = !DINamespace(name: "toplevel", scope: null, exportSymbols: true)
 // CHECK: ![[FUNC_TYPE]] = !DISubroutineType(cc: DW_CC_normal, types: ![[FUNC_ARGS:.*]])
-// CHECK: ![[FUNC_ARGS]] = !{null, ![[ARG_TYPE:.*]], ![[PTR_TYPE:.*]], ![[NAMED_TYPE:.*]], ![[PTR_WITH_ADDR_SPACE:.*]], ![[PTR_WITH_FILE_LINE:.*]], ![[FLAGS:.*]], ![[COMPOSITE_TYPE:.*]], ![[VECTOR_TYPE:.*]]}
+// CHECK: ![[FUNC_ARGS]] = !{null, ![[ARG_TYPE:.*]], ![[PTR_TYPE:.*]], ![[NAMED_TYPE:.*]], ![[PTR_WITH_ADDR_SPACE:.*]], ![[PTR_WITH_FILE_LINE_SCOPE:.*]], ![[FLAGS:.*]], ![[COMPOSITE_TYPE:.*]], ![[VECTOR_TYPE:.*]]}
 // CHECK: ![[ARG_TYPE]] = !DIBasicType()
 // CHECK: ![[PTR_TYPE]] = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: ![[BASE_TYPE:.*]], size: 64, align: 32, offset: 8, extraData: ![[BASE_TYPE]])
 // CHECK: ![[BASE_TYPE]] = !DIBasicType(name: "si32", size: 32, encoding: DW_ATE_signed)
 // CHECK: ![[NAMED_TYPE]] = !DIDerivedType(tag: DW_TAG_pointer_type, name: "named", baseType: ![[BASE_TYPE:.*]])
 // CHECK: ![[PTR_WITH_ADDR_SPACE]] = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: ![[BASE_TYPE:.*]], size: 64, align: 32, offset: 8, dwarfAddressSpace: 3)
-// CHECK: ![[PTR_WITH_FILE_LINE]] = !DIDerivedType(tag: DW_TAG_pointer_type, file: ![[CU_FILE_LOC]], line: 42, baseType: ![[BASE_TYPE:.*]])
+// CHECK: ![[PTR_WITH_FILE_LINE_SCOPE]] = !DIDerivedType(tag: DW_TAG_pointer_type, scope: ![[CU_FILE_LOC:.*]], file: ![[CU_FILE_LOC]], line: 42, baseType: ![[BASE_TYPE:.*]])
 // CHECK: ![[FLAGS]] = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: ![[BASE_TYPE:.*]], size: 64, flags: DIFlagArtificial | DIFlagObjectPointer)
 // CHECK: ![[COMPOSITE_TYPE]] = distinct !DICompositeType(tag: DW_TAG_structure_type, name: "composite", file: ![[CU_FILE_LOC]], line: 42, size: 64, align: 32, elements: ![[COMPOSITE_ELEMENTS:.*]])
 // CHECK: ![[COMPOSITE_ELEMENTS]] = !{![[COMPOSITE_ELEMENT:.*]]}


### PR DESCRIPTION
This PR updates `DIDerivedTypeAttr` to support optional file, line and scope parameters in the same way as `DICompositeTypeAttr`. These parameters are already supported in the `llvm::DIDerivedType` constructor and were hardcoded to nullptr/0, they are now accessible from MLIR.

The existing `llvmir-debug.mlir` test has been updated to test these changes.