### PR TITLE
[lldb][PlatformDarwin] Reword warning when locating scripting resources from dSYM

### DIFF
--- a/lldb/source/Plugins/Platform/MacOSX/PlatformDarwin.cpp
+++ b/lldb/source/Plugins/Platform/MacOSX/PlatformDarwin.cpp
@@ -287,23 +287,20 @@ FileSpecList PlatformDarwin::LocateExecutableScriptingResourcesFromDSYM(
                                              : "contains reserved characters";
       if (FileSystem::Instance().Exists(script_fspec))
         feedback_stream.Format(
-            "the symbol file '{0}' contains a debug "
-            "script. However, its name"
-            " '{1}' {2} and as such cannot be loaded. LLDB will"
-            " load '{3}' instead. Consider removing the file with "
-            "the malformed name to"
-            " eliminate this warning.\n",
-            symfile_spec.GetPath(), original_path_string.GetString(),
-            reason_for_complaint, path_string.GetString());
+            "found a debug script '{0}'. However, its name"
+            " {1} and as such cannot be loaded. LLDB will"
+            " load '{2}' instead. Consider removing the file with"
+            " the malformed name to eliminate this warning.\n",
+            original_path_string.GetString(), reason_for_complaint,
+            path_string.GetString());
       else
         feedback_stream.Format(
-            "the symbol file '{0}' contains a debug "
-            "script. However, its name"
+            "found a debug script '{0}'. However, its name"
             " {1} and as such cannot be loaded. If you intend"
-            " to have this script loaded, please rename '{2}' to "
-            "'{3}' and retry.\n",
-            symfile_spec.GetPath(), reason_for_complaint,
-            original_path_string.GetString(), path_string.GetString());
+            " to have this script loaded, please rename it to "
+            "'{2}' and retry.\n",
+            original_path_string.GetString(), reason_for_complaint,
+            path_string.GetString());
     }
 
     if (FileSystem::Instance().Exists(script_fspec)) {

--- a/lldb/source/Plugins/Platform/MacOSX/PlatformDarwin.cpp
+++ b/lldb/source/Plugins/Platform/MacOSX/PlatformDarwin.cpp
@@ -106,14 +106,14 @@ public:
 
     if (script_interpreter &&
         script_interpreter->IsReservedWord(m_sanitized_name.c_str())) {
+      m_conflicting_keyword = m_sanitized_name;
       m_sanitized_name.insert(m_sanitized_name.begin(), '_');
-      m_name_is_keyword = true;
     }
   }
 
   /// Returns \c true if this name is a keyword in the associated scripting
   /// language.
-  bool IsKeyword() const { return m_name_is_keyword; }
+  bool IsKeyword() const { return !m_conflicting_keyword.empty(); }
 
   /// Returns \c true if the original name has been sanitized (i.e., required
   /// changes).
@@ -123,14 +123,18 @@ public:
 
   llvm::StringRef GetSanitizedName() const { return m_sanitized_name; }
   llvm::StringRef GetOriginalName() const { return m_original_name; }
+  llvm::StringRef GetConflictingKeyword() const {
+    return m_conflicting_keyword;
+  }
 
 private:
   llvm::StringRef m_original_name;
   std::string m_sanitized_name;
 
-  /// \c true if m_sanitized_name is a keyword for the ScriptInterpreter
-  /// language associated with this SanitizedScriptingModuleName.
-  bool m_name_is_keyword = false;
+  /// If the m_sanitized_name conflicts with a keyword for the ScriptInterpreter
+  /// language associated with this SanitizedScriptingModuleName, is set to the
+  /// conflicting keyword. Empty otherwise.
+  std::string m_conflicting_keyword;
 };
 } // namespace
 
@@ -282,23 +286,27 @@ FileSpecList PlatformDarwin::LocateExecutableScriptingResourcesFromDSYM(
     // that the file as-is shall not be loaded
     if (sanitized_name.RequiredSanitization() &&
         FileSystem::Instance().Exists(orig_script_fspec)) {
-      const char *reason_for_complaint = sanitized_name.IsKeyword()
-                                             ? "conflicts with a keyword"
-                                             : "contains reserved characters";
+      std::string reason_for_complaint =
+          sanitized_name.IsKeyword()
+              ? llvm::formatv("conflicts with the keyword '{0}'",
+                              sanitized_name.GetConflictingKeyword())
+                    .str()
+              : "contains reserved characters";
+
       if (FileSystem::Instance().Exists(script_fspec))
         feedback_stream.Format(
             "debug script '{0}' cannot be loaded because '{1}' {2}. "
             "Loading '{3}' instead. Consider removing the file with the "
             "malformed name to eliminate this warning.\n",
             original_path_string.GetString(), orig_script_fspec.GetFilename(),
-            reason_for_complaint, script_fspec.GetFilename());
+            std::move(reason_for_complaint), script_fspec.GetFilename());
       else
         feedback_stream.Format(
             "debug script '{0}' cannot be loaded because '{1}' {2}. "
             "If you intend to have this script loaded, please rename it to "
             "'{3}' and retry.\n",
             original_path_string.GetString(), orig_script_fspec.GetFilename(),
-            reason_for_complaint, script_fspec.GetFilename());
+            std::move(reason_for_complaint), script_fspec.GetFilename());
     }
 
     if (FileSystem::Instance().Exists(script_fspec)) {

--- a/lldb/source/Plugins/Platform/MacOSX/PlatformDarwin.cpp
+++ b/lldb/source/Plugins/Platform/MacOSX/PlatformDarwin.cpp
@@ -287,20 +287,18 @@ FileSpecList PlatformDarwin::LocateExecutableScriptingResourcesFromDSYM(
                                              : "contains reserved characters";
       if (FileSystem::Instance().Exists(script_fspec))
         feedback_stream.Format(
-            "found a debug script '{0}'. However, its name"
-            " {1} and as such cannot be loaded. LLDB will"
-            " load '{2}' instead. Consider removing the file with"
-            " the malformed name to eliminate this warning.\n",
-            original_path_string.GetString(), reason_for_complaint,
-            path_string.GetString());
+            "debug script '{0}' cannot be loaded because '{1}' {2}. "
+            "Loading '{3}' instead. Consider removing the file with the "
+            "malformed name to eliminate this warning.\n",
+            original_path_string.GetString(), orig_script_fspec.GetFilename(),
+            reason_for_complaint, script_fspec.GetFilename());
       else
         feedback_stream.Format(
-            "found a debug script '{0}'. However, its name"
-            " {1} and as such cannot be loaded. If you intend"
-            " to have this script loaded, please rename it to "
-            "'{2}' and retry.\n",
-            original_path_string.GetString(), reason_for_complaint,
-            path_string.GetString());
+            "debug script '{0}' cannot be loaded because '{1}' {2}. "
+            "If you intend to have this script loaded, please rename it to "
+            "'{3}' and retry.\n",
+            original_path_string.GetString(), orig_script_fspec.GetFilename(),
+            reason_for_complaint, script_fspec.GetFilename());
     }
 
     if (FileSystem::Instance().Exists(script_fspec)) {

--- a/lldb/source/Plugins/Platform/MacOSX/PlatformDarwin.cpp
+++ b/lldb/source/Plugins/Platform/MacOSX/PlatformDarwin.cpp
@@ -296,8 +296,7 @@ FileSpecList PlatformDarwin::LocateExecutableScriptingResourcesFromDSYM(
       if (FileSystem::Instance().Exists(script_fspec))
         feedback_stream.Format(
             "debug script '{0}' cannot be loaded because '{1}' {2}. "
-            "Loading '{3}' instead. Consider removing the file with the "
-            "malformed name to eliminate this warning.\n",
+            "Ignoring '{1}' and loading '{3}' instead.\n",
             original_path_string.GetString(), orig_script_fspec.GetFilename(),
             std::move(reason_for_complaint), script_fspec.GetFilename());
       else

--- a/lldb/test/Shell/Platform/AutoLoad/Darwin/dsym-python-script-name-warnings.test
+++ b/lldb/test/Shell/Platform/AutoLoad/Darwin/dsym-python-script-name-warnings.test
@@ -14,7 +14,7 @@
 # RUN:   -o 'target create "%t/Test-Module.out"' 2>&1 \
 # RUN:   | FileCheck %s --check-prefix=CHECK-RENAME
 
-# CHECK-RENAME:      warning: the symbol file {{.*}} contains reserved characters
+# CHECK-RENAME:      warning: {{.*}} 'Test-Module.py' contains reserved characters
 # CHECK-RENAME-SAME: If you intend to have this script loaded, please rename
 
 ## Module name contains reserved characters but a script with a corrected
@@ -28,8 +28,8 @@
 # RUN:   -o 'target create "%t/Test-Module2.out"' 2>&1 \
 # RUN:   | FileCheck %s --check-prefix=CHECK-REMOVE
 
-# CHECK-REMOVE:      warning: the symbol file {{.*}} contains reserved characters
-# CHECK-REMOVE-SAME: Consider removing the file with the malformed name to eliminate this warning
+# CHECK-REMOVE:      warning: {{.*}} 'Test-Module2.py' contains reserved characters
+# CHECK-REMOVE-SAME: Ignoring 'Test-Module2.py' and loading 'Test_Module2.py' instead.
 
 ## Also confirm that the warning message about auto-loading scripts is printed afterwards.
 

--- a/lldb/unittests/Platform/PlatformDarwinTest.cpp
+++ b/lldb/unittests/Platform/PlatformDarwinTest.cpp
@@ -354,11 +354,10 @@ TEST_F(PlatformDarwinLocateTest,
   std::string fixed_script =
       (m_tmp_dsym_dwarf_dir + "/../Python/_import.py").str();
   std::string expected = llvm::formatv(
-      "the symbol file '{0}' contains a debug script. However, its "
-      "name conflicts with a keyword and as such cannot be loaded. If you "
-      "intend to have this script loaded, please rename '{1}' to '{2}' and "
-      "retry.\n",
-      dsym_module_fpec.GetPath(), orig_script, fixed_script);
+      "found a debug script '{0}'. However, its name conflicts with a keyword "
+      "and as such cannot be loaded. If you intend to have this script loaded, "
+      "please rename it to '{1}' and retry.\n",
+      orig_script, fixed_script);
   EXPECT_EQ(ss.GetString(), expected);
 }
 
@@ -394,11 +393,10 @@ TEST_F(PlatformDarwinLocateTest,
   std::string fixed_script =
       (m_tmp_dsym_dwarf_dir + "/../Python/_import.py").str();
   std::string expected = llvm::formatv(
-      "the symbol file '{0}' contains a debug script. However, its "
-      "name '{1}' conflicts with a keyword and as such cannot be loaded. LLDB "
-      "will load '{2}' instead. Consider removing the file with the malformed "
-      "name to eliminate this warning.\n",
-      dsym_module_fpec.GetPath(), orig_script, fixed_script);
+      "found a debug script '{0}'. However, its name conflicts with a keyword "
+      "and as such cannot be loaded. LLDB will load '{1}' instead. Consider "
+      "removing the file with the malformed name to eliminate this warning.\n",
+      orig_script, fixed_script);
   EXPECT_EQ(ss.GetString(), expected);
 }
 
@@ -461,11 +459,10 @@ TEST_F(
   std::string fixed_script =
       (m_tmp_dsym_dwarf_dir + "/../Python/TestModule_1_1_1.py").str();
   std::string expected = llvm::formatv(
-      "the symbol file '{0}' contains a debug script. However, its "
-      "name contains reserved characters and as such cannot be loaded. If you "
-      "intend to have this script loaded, please rename '{1}' to '{2}' and "
-      "retry.\n",
-      dsym_module_fpec.GetPath(), orig_script, fixed_script);
+      "found a debug script '{0}'. However, its name contains reserved "
+      "characters and as such cannot be loaded. If you intend to have this "
+      "script loaded, please rename it to '{1}' and retry.\n",
+      orig_script, fixed_script);
   EXPECT_EQ(ss.GetString(), expected);
 }
 
@@ -501,12 +498,12 @@ TEST_F(
       (m_tmp_dsym_dwarf_dir + "/../Python/TestModule-1.1 1.py").str();
   std::string fixed_script =
       (m_tmp_dsym_dwarf_dir + "/../Python/TestModule_1_1_1.py").str();
-  std::string expected = llvm::formatv(
-      "the symbol file '{0}' contains a debug script. However, its "
-      "name '{1}' contains reserved characters and as such cannot be loaded. "
-      "LLDB will load '{2}' instead. Consider removing the file with the "
-      "malformed name to eliminate this warning.\n",
-      dsym_module_fpec.GetPath(), orig_script, fixed_script);
+  std::string expected =
+      llvm::formatv("found a debug script '{0}'. However, its name contains "
+                    "reserved characters and as such cannot be loaded. LLDB "
+                    "will load '{1}' instead. Consider removing the file with "
+                    "the malformed name to eliminate this warning.\n",
+                    orig_script, fixed_script);
   EXPECT_EQ(ss.GetString(), expected);
 }
 

--- a/lldb/unittests/Platform/PlatformDarwinTest.cpp
+++ b/lldb/unittests/Platform/PlatformDarwinTest.cpp
@@ -658,8 +658,7 @@ TEST_P(PlatformDarwinLocateWithSpecialCharsTestFixture,
   EXPECT_EQ(fspecs.GetSize(), 0u);
 
   std::string expected =
-      llvm::formatv("please rename '{0}/../Python/{1}' to '{0}/../Python/{2}'",
-                    m_tmp_dsym_dwarf_dir, script_name, recommended_script_name);
+      llvm::formatv("please rename it to '{0}'", recommended_script_name);
   EXPECT_TRUE(ss.GetString().contains(expected));
 }
 

--- a/lldb/unittests/Platform/PlatformDarwinTest.cpp
+++ b/lldb/unittests/Platform/PlatformDarwinTest.cpp
@@ -351,13 +351,11 @@ TEST_F(PlatformDarwinLocateTest,
 
   std::string orig_script =
       (m_tmp_dsym_dwarf_dir + "/../Python/import.py").str();
-  std::string fixed_script =
-      (m_tmp_dsym_dwarf_dir + "/../Python/_import.py").str();
   std::string expected = llvm::formatv(
-      "found a debug script '{0}'. However, its name conflicts with a keyword "
-      "and as such cannot be loaded. If you intend to have this script loaded, "
-      "please rename it to '{1}' and retry.\n",
-      orig_script, fixed_script);
+      "debug script '{0}' cannot be loaded because 'import.py' "
+      "conflicts with a keyword. If you intend to have this script loaded, "
+      "please rename it to '_import.py' and retry.\n",
+      orig_script);
   EXPECT_EQ(ss.GetString(), expected);
 }
 
@@ -390,13 +388,11 @@ TEST_F(PlatformDarwinLocateTest,
 
   std::string orig_script =
       (m_tmp_dsym_dwarf_dir + "/../Python/import.py").str();
-  std::string fixed_script =
-      (m_tmp_dsym_dwarf_dir + "/../Python/_import.py").str();
   std::string expected = llvm::formatv(
-      "found a debug script '{0}'. However, its name conflicts with a keyword "
-      "and as such cannot be loaded. LLDB will load '{1}' instead. Consider "
+      "debug script '{0}' cannot be loaded because 'import.py' "
+      "conflicts with a keyword. Loading '_import.py' instead. Consider "
       "removing the file with the malformed name to eliminate this warning.\n",
-      orig_script, fixed_script);
+      orig_script);
   EXPECT_EQ(ss.GetString(), expected);
 }
 
@@ -456,13 +452,11 @@ TEST_F(
 
   std::string orig_script =
       (m_tmp_dsym_dwarf_dir + "/../Python/TestModule-1.1 1.py").str();
-  std::string fixed_script =
-      (m_tmp_dsym_dwarf_dir + "/../Python/TestModule_1_1_1.py").str();
   std::string expected = llvm::formatv(
-      "found a debug script '{0}'. However, its name contains reserved "
-      "characters and as such cannot be loaded. If you intend to have this "
-      "script loaded, please rename it to '{1}' and retry.\n",
-      orig_script, fixed_script);
+      "debug script '{0}' cannot be loaded because 'TestModule-1.1 1.py' "
+      "contains reserved characters. If you intend to have this script "
+      "loaded, please rename it to 'TestModule_1_1_1.py' and retry.\n",
+      orig_script);
   EXPECT_EQ(ss.GetString(), expected);
 }
 
@@ -496,14 +490,12 @@ TEST_F(
 
   std::string orig_script =
       (m_tmp_dsym_dwarf_dir + "/../Python/TestModule-1.1 1.py").str();
-  std::string fixed_script =
-      (m_tmp_dsym_dwarf_dir + "/../Python/TestModule_1_1_1.py").str();
-  std::string expected =
-      llvm::formatv("found a debug script '{0}'. However, its name contains "
-                    "reserved characters and as such cannot be loaded. LLDB "
-                    "will load '{1}' instead. Consider removing the file with "
-                    "the malformed name to eliminate this warning.\n",
-                    orig_script, fixed_script);
+  std::string expected = llvm::formatv(
+      "debug script '{0}' cannot be loaded because 'TestModule-1.1 1.py' "
+      "contains reserved characters. Loading 'TestModule_1_1_1.py' "
+      "instead. Consider removing the file with the malformed name to "
+      "eliminate this warning.\n",
+      orig_script);
   EXPECT_EQ(ss.GetString(), expected);
 }
 
@@ -561,8 +553,7 @@ TEST_F(
           ->LocateExecutableScriptingResourcesFromDSYM(
               ss, module_fspec, *m_target_sp, dsym_module_fpec);
   EXPECT_EQ(fspecs.GetSize(), 0u);
-  EXPECT_TRUE(ss.GetString().contains(
-      "its name conflicts with a keyword and as such cannot be loaded"));
+  EXPECT_TRUE(ss.GetString().contains("conflicts with a keyword"));
 }
 
 TEST_F(

--- a/lldb/unittests/Platform/PlatformDarwinTest.cpp
+++ b/lldb/unittests/Platform/PlatformDarwinTest.cpp
@@ -353,8 +353,8 @@ TEST_F(PlatformDarwinLocateTest,
       (m_tmp_dsym_dwarf_dir + "/../Python/import.py").str();
   std::string expected = llvm::formatv(
       "debug script '{0}' cannot be loaded because 'import.py' "
-      "conflicts with a keyword. If you intend to have this script loaded, "
-      "please rename it to '_import.py' and retry.\n",
+      "conflicts with the keyword 'import'. If you intend to have this script "
+      "loaded, please rename it to '_import.py' and retry.\n",
       orig_script);
   EXPECT_EQ(ss.GetString(), expected);
 }
@@ -390,8 +390,9 @@ TEST_F(PlatformDarwinLocateTest,
       (m_tmp_dsym_dwarf_dir + "/../Python/import.py").str();
   std::string expected = llvm::formatv(
       "debug script '{0}' cannot be loaded because 'import.py' "
-      "conflicts with a keyword. Loading '_import.py' instead. Consider "
-      "removing the file with the malformed name to eliminate this warning.\n",
+      "conflicts with the keyword 'import'. Loading '_import.py' instead. "
+      "Consider removing the file with the malformed name to eliminate this "
+      "warning.\n",
       orig_script);
   EXPECT_EQ(ss.GetString(), expected);
 }
@@ -553,7 +554,8 @@ TEST_F(
           ->LocateExecutableScriptingResourcesFromDSYM(
               ss, module_fspec, *m_target_sp, dsym_module_fpec);
   EXPECT_EQ(fspecs.GetSize(), 0u);
-  EXPECT_TRUE(ss.GetString().contains("conflicts with a keyword"));
+  EXPECT_TRUE(
+      ss.GetString().contains("conflicts with the keyword 'mykeyword_1_1_1'"));
 }
 
 TEST_F(

--- a/lldb/unittests/Platform/PlatformDarwinTest.cpp
+++ b/lldb/unittests/Platform/PlatformDarwinTest.cpp
@@ -390,9 +390,8 @@ TEST_F(PlatformDarwinLocateTest,
       (m_tmp_dsym_dwarf_dir + "/../Python/import.py").str();
   std::string expected = llvm::formatv(
       "debug script '{0}' cannot be loaded because 'import.py' "
-      "conflicts with the keyword 'import'. Loading '_import.py' instead. "
-      "Consider removing the file with the malformed name to eliminate this "
-      "warning.\n",
+      "conflicts with the keyword 'import'. Ignoring 'import.py' and loading "
+      "'_import.py' instead.\n",
       orig_script);
   EXPECT_EQ(ss.GetString(), expected);
 }
@@ -492,10 +491,9 @@ TEST_F(
   std::string orig_script =
       (m_tmp_dsym_dwarf_dir + "/../Python/TestModule-1.1 1.py").str();
   std::string expected = llvm::formatv(
-      "debug script '{0}' cannot be loaded because 'TestModule-1.1 1.py' "
-      "contains reserved characters. Loading 'TestModule_1_1_1.py' "
-      "instead. Consider removing the file with the malformed name to "
-      "eliminate this warning.\n",
+      "debug script '{0}' cannot be loaded because"
+      " 'TestModule-1.1 1.py' contains reserved characters. Ignoring"
+      " 'TestModule-1.1 1.py' and loading 'TestModule_1_1_1.py' instead.\n",
       orig_script);
   EXPECT_EQ(ss.GetString(), expected);
 }
@@ -586,9 +584,8 @@ TEST_F(
               ss, module_fspec, *m_target_sp, dsym_module_fpec);
   EXPECT_EQ(fspecs.GetSize(), 1u);
   EXPECT_EQ(fspecs.GetFileSpecAtIndex(0).GetFilename(), "_mykeyword_1_1_1.py");
-  EXPECT_TRUE(
-      ss.GetString().contains("Consider removing the file with the malformed "
-                              "name to eliminate this warning."));
+  EXPECT_TRUE(ss.GetString().contains("Ignoring 'mykeyword-1.1 1.py' and "
+                                      "loading '_mykeyword_1_1_1.py' instead"));
 }
 
 TEST_F(


### PR DESCRIPTION
This patch makes the warning message more concise (in my opinion). We would duplicate the file path multiple times in the message. I'm planning on factoring this logic into a standalone function, and having it rely on fewer parameters helps with that.

Before:
```
warning: the symbol file '/path/to/.dSYM/Contents/Resources/DWARF/import' contains a debug script.
However, its name '/path/to/.dSYM/Contents/Resources/DWARF/../Python/import.py' conflicts with a keyword
and as such cannot be loaded. LLDB will load '/path/to/.dSYM/Contents/Resources/DWARF/../Python/_import.py' instead.
Consider removing the file with the malformed name to eliminate this warning.
```

After:
```
warning: debug script '/path/to/.dSYM/Contents/Resources/DWARF/../Python/import.py' cannot be loaded
because 'import.py' conflicts with the keyword 'import'. Ignoring 'import.py' and loading '_import.py' instead.
```

Before:
```
warning: the symbol file '/path/to/.dSYM/Contents/Resources/DWARF/import' contains a debug script.
However, its name conflicts with a keyword and as such cannot be loaded.
If you intend to have this script loaded, please rename '/path/to/.dSYM/Contents/Resources/DWARF/../Python/import.py'
to '/path/to/.dSYM/Contents/Resources/DWARF/../Python/_import.py' and retry.
```

After:
```
warning: debug script '/path/to/.dSYM/Contents/Resources/DWARF/../Python/import.py' cannot be loaded
because 'import.py' conflicts with the keyword 'import'. If you intend to have this script loaded, please rename
it to '_import.py' and retry.
```