### PR TITLE
[lldb][PlatformDarwin][NFC] Move logic to emit warning on invalid/conflicting Python script names into helper function

### DIFF
--- a/lldb/source/Plugins/Platform/MacOSX/PlatformDarwin.cpp
+++ b/lldb/source/Plugins/Platform/MacOSX/PlatformDarwin.cpp
@@ -127,6 +127,40 @@ public:
     return m_conflicting_keyword;
   }
 
+  /// If we did some replacements of reserved characters, and a
+  /// file with the untampered name exists, then warn the user
+  /// that the file as-is shall not be loaded.
+  void WarnIfInvalidUnsanitizedScriptExists(Stream &os,
+                                            const FileSpec &original_fspec,
+                                            const FileSpec &fspec) const {
+    if (!RequiredSanitization())
+      return;
+
+    // Path to unsanitized script name doesn't exist. Nothing to warn about.
+    if (!FileSystem::Instance().Exists(original_fspec))
+      return;
+
+    std::string reason_for_complaint =
+        IsKeyword() ? llvm::formatv("conflicts with the keyword '{0}'",
+                                    GetConflictingKeyword())
+                          .str()
+                    : "contains reserved characters";
+
+    if (FileSystem::Instance().Exists(fspec))
+       os.Format(
+            "debug script '{0}' cannot be loaded because '{1}' {2}. "
+            "Ignoring '{1}' and loading '{3}' instead.\n",
+            original_fspec.GetPath(), original_fspec.GetFilename(),
+            std::move(reason_for_complaint), fspec.GetFilename());
+    else
+      os.Format(
+            "debug script '{0}' cannot be loaded because '{1}' {2}. "
+            "If you intend to have this script loaded, please rename it to "
+            "'{3}' and retry.\n",
+            original_fspec.GetPath(), original_fspec.GetFilename(),
+            std::move(reason_for_complaint), fspec.GetFilename());
+  }
+
 private:
   llvm::StringRef m_original_name;
   std::string m_sanitized_name;
@@ -281,32 +315,8 @@ FileSpecList PlatformDarwin::LocateExecutableScriptingResourcesFromDSYM(
     FileSpec orig_script_fspec(original_path_string.GetString());
     FileSystem::Instance().Resolve(orig_script_fspec);
 
-    // if we did some replacements of reserved characters, and a
-    // file with the untampered name exists, then warn the user
-    // that the file as-is shall not be loaded
-    if (sanitized_name.RequiredSanitization() &&
-        FileSystem::Instance().Exists(orig_script_fspec)) {
-      std::string reason_for_complaint =
-          sanitized_name.IsKeyword()
-              ? llvm::formatv("conflicts with the keyword '{0}'",
-                              sanitized_name.GetConflictingKeyword())
-                    .str()
-              : "contains reserved characters";
-
-      if (FileSystem::Instance().Exists(script_fspec))
-        feedback_stream.Format(
-            "debug script '{0}' cannot be loaded because '{1}' {2}. "
-            "Ignoring '{1}' and loading '{3}' instead.\n",
-            original_path_string.GetString(), orig_script_fspec.GetFilename(),
-            std::move(reason_for_complaint), script_fspec.GetFilename());
-      else
-        feedback_stream.Format(
-            "debug script '{0}' cannot be loaded because '{1}' {2}. "
-            "If you intend to have this script loaded, please rename it to "
-            "'{3}' and retry.\n",
-            original_path_string.GetString(), orig_script_fspec.GetFilename(),
-            std::move(reason_for_complaint), script_fspec.GetFilename());
-    }
+    sanitized_name.WarnIfInvalidUnsanitizedScriptExists(
+        feedback_stream, orig_script_fspec, script_fspec);
 
     if (FileSystem::Instance().Exists(script_fspec)) {
       file_list.Append(script_fspec);

--- a/lldb/unittests/Platform/PlatformDarwinTest.cpp
+++ b/lldb/unittests/Platform/PlatformDarwinTest.cpp
@@ -340,7 +340,8 @@ TEST_F(PlatformDarwinLocateTest,
 
   // Keywords are not permitted in module names.
   // See MockScriptInterpreterPython::IsReservedWord
-  CreateFile("import.py", m_tmp_dsym_python_dir);
+  FileSpec script_fspec(CreateFile("import.py", m_tmp_dsym_python_dir));
+  ASSERT_TRUE(script_fspec);
 
   StreamString ss;
   FileSpecList fspecs =
@@ -349,13 +350,11 @@ TEST_F(PlatformDarwinLocateTest,
               ss, module_fspec, *m_target_sp, dsym_module_fpec);
   EXPECT_EQ(fspecs.GetSize(), 0u);
 
-  std::string orig_script =
-      (m_tmp_dsym_dwarf_dir + "/../Python/import.py").str();
   std::string expected = llvm::formatv(
       "debug script '{0}' cannot be loaded because 'import.py' "
       "conflicts with the keyword 'import'. If you intend to have this script "
       "loaded, please rename it to '_import.py' and retry.\n",
-      orig_script);
+      script_fspec.GetPath());
   EXPECT_EQ(ss.GetString(), expected);
 }
 
@@ -376,7 +375,9 @@ TEST_F(PlatformDarwinLocateTest,
   // Keywords are not permitted in module names.
   // See MockScriptInterpreterPython::IsReservedWord
   CreateFile("_import.py", m_tmp_dsym_python_dir);
-  CreateFile("import.py", m_tmp_dsym_python_dir);
+
+  FileSpec orig_fspec(CreateFile("import.py", m_tmp_dsym_python_dir));
+  ASSERT_TRUE(orig_fspec);
 
   StreamString ss;
   FileSpecList fspecs =
@@ -386,13 +387,11 @@ TEST_F(PlatformDarwinLocateTest,
   EXPECT_EQ(fspecs.GetSize(), 1u);
   EXPECT_EQ(fspecs.GetFileSpecAtIndex(0).GetFilename(), "_import.py");
 
-  std::string orig_script =
-      (m_tmp_dsym_dwarf_dir + "/../Python/import.py").str();
   std::string expected = llvm::formatv(
       "debug script '{0}' cannot be loaded because 'import.py' "
       "conflicts with the keyword 'import'. Ignoring 'import.py' and loading "
       "'_import.py' instead.\n",
-      orig_script);
+      orig_fspec.GetPath());
   EXPECT_EQ(ss.GetString(), expected);
 }
 
@@ -441,7 +440,9 @@ TEST_F(
       CreateFile("TestModule-1.1 1.o", m_tmp_dsym_dwarf_dir));
   ASSERT_TRUE(dsym_module_fpec);
 
-  CreateFile("TestModule-1.1 1.py", m_tmp_dsym_python_dir);
+  FileSpec script_fspec(
+      CreateFile("TestModule-1.1 1.py", m_tmp_dsym_python_dir));
+  ASSERT_TRUE(script_fspec);
 
   StreamString ss;
   FileSpecList fspecs =
@@ -450,13 +451,11 @@ TEST_F(
               ss, module_fspec, *m_target_sp, dsym_module_fpec);
   EXPECT_EQ(fspecs.GetSize(), 0u);
 
-  std::string orig_script =
-      (m_tmp_dsym_dwarf_dir + "/../Python/TestModule-1.1 1.py").str();
   std::string expected = llvm::formatv(
       "debug script '{0}' cannot be loaded because 'TestModule-1.1 1.py' "
       "contains reserved characters. If you intend to have this script "
       "loaded, please rename it to 'TestModule_1_1_1.py' and retry.\n",
-      orig_script);
+      script_fspec.GetPath());
   EXPECT_EQ(ss.GetString(), expected);
 }
 
@@ -477,7 +476,9 @@ TEST_F(
       CreateFile("TestModule-1.1 1.o", m_tmp_dsym_dwarf_dir));
   ASSERT_TRUE(dsym_module_fpec);
 
-  CreateFile("TestModule-1.1 1.py", m_tmp_dsym_python_dir);
+  FileSpec orig_fspec(CreateFile("TestModule-1.1 1.py", m_tmp_dsym_python_dir));
+  ASSERT_TRUE(orig_fspec);
+
   CreateFile("TestModule_1_1_1.py", m_tmp_dsym_python_dir);
 
   StreamString ss;
@@ -488,13 +489,11 @@ TEST_F(
   EXPECT_EQ(fspecs.GetSize(), 1u);
   EXPECT_EQ(fspecs.GetFileSpecAtIndex(0).GetFilename(), "TestModule_1_1_1.py");
 
-  std::string orig_script =
-      (m_tmp_dsym_dwarf_dir + "/../Python/TestModule-1.1 1.py").str();
   std::string expected = llvm::formatv(
       "debug script '{0}' cannot be loaded because"
       " 'TestModule-1.1 1.py' contains reserved characters. Ignoring"
       " 'TestModule-1.1 1.py' and loading 'TestModule_1_1_1.py' instead.\n",
-      orig_script);
+      orig_fspec.GetPath());
   EXPECT_EQ(ss.GetString(), expected);
 }
 


### PR DESCRIPTION
Depends on:
* https://github.com/llvm/llvm-project/pull/185666
* https://github.com/llvm/llvm-project/pull/185627

I'm planning on re-using this logic for a different API. Hence move it into a common helper.