### PR TITLE
[SPIRV] Emit hidden/local function decls as Import linkage

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVUtils.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVUtils.cpp
@@ -1197,8 +1197,13 @@ Type *reconstitutePeeledArrayType(Type *Ty) {
 
 std::optional<SPIRV::LinkageType::LinkageType>
 getSpirvLinkageTypeFor(const SPIRVSubtarget &ST, const GlobalValue &GV) {
-  if (GV.hasLocalLinkage() || GV.hasHiddenVisibility())
+  if (GV.hasLocalLinkage() || GV.hasHiddenVisibility()) {
+    // Emit local/hidden function decls that are accessed within the module
+    // as Import.
+    if (GV.isDeclarationForLinker() && isa<Function>(GV) && !GV.user_empty())
+      return SPIRV::LinkageType::Import;
     return std::nullopt;
+  }
 
   if (GV.isDeclarationForLinker())
     return SPIRV::LinkageType::Import;

--- a/llvm/test/CodeGen/SPIRV/linkage/hidden-function-decl.ll
+++ b/llvm/test/CodeGen/SPIRV/linkage/hidden-function-decl.ll
@@ -1,0 +1,16 @@
+; RUN: llc -O0 -mtriple=spirv64-unknown-unknown %s -o - | FileCheck %s --check-prefix=CHECK-SPIRV
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv64-unknown-unknown %s -o - -filetype=obj | spirv-val %}
+
+; RUN: llc -O0 -mtriple=spirv64-vulkan1.6-unknown %s -o - | FileCheck %s --check-prefix=CHECK-SPIRV
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv64-vulkan1.6-unknown %s -o - -filetype=obj | spirv-val %}
+
+; CHECK-SPIRV: OpName %[[#FOO:]] "foo"
+; CHECK-SPIRV: OpDecorate %[[#FOO]] LinkageAttributes "foo" Import
+
+define spir_func void @use() {
+entry:
+  call spir_func void @foo()
+  ret void
+}
+
+declare hidden spir_func void @foo()


### PR DESCRIPTION
Right now if we try to compile the below program, we get a backend error:


```c++
namespace [[gnu::visibility("hidden")]] NS { void foo(); }

void use() {
NS::foo();
}

```

```
clang++ -target spirv64 foo.cpp
fatal error: error in backend: Unknown function in:%3:iid = OpFunctionCall %1:type, @_ZN2NS3fooEv

clang++: error: clang frontend command failed with exit code 70 (use -v to see invocation)
clang version 23.0.0git (https://github.com/llvm/llvm-project 291bbef531131d23fa3106e3eb8c04d9a516bae8)
Target: spirv64
Thread model: posix
InstalledDir: /tmp/llvm
Build config: +assertions, +expensive-checks
clang++: note: diagnostic msg: 
********************

PLEASE ATTACH THE FOLLOWING FILES TO THE BUG REPORT:
Preprocessed source(s) and associated run script(s) are located at:
clang++: note: diagnostic msg: /tmp/repro-21d6e1.cpp
clang++: note: diagnostic msg: /tmp/repro-21d6e1.sh
clang++: note: diagnostic msg: 

********************

```

This kind of code is used in the `libc` project, see [here](https://github.com/llvm/llvm-project/blob/main/libc/src/__support/macros/config.h#L62) for example. It works fine for AMDGPU and NVPTX.

Right now we don't emit anything about the function at all because we return `nullopt` in `getSpirvLinkageTypeFor`, causing the backend error about an unknown function.

NVPTX also doesn't natively support `hidden` or `local` and they also just treat it as `extern`.

Do the same for SPIRV.