### PR TITLE
[lldb] change how unsupported tests are aggregated

### DIFF
--- a/lldb/test/API/lldbtest.py
+++ b/lldb/test/API/lldbtest.py
@@ -129,23 +129,18 @@ class LLDBTest(TestFormat):
         passes = num_ran - non_pass
 
         if exitCode:
-            # Mark this test as FAIL if at least one test failed.
+            # Aggregate the tests results with the following precedence:
+            # UNRESOLVED > FAIL > XPASS
+            if errors > 0:
+                return lit.Test.UNRESOLVED, output
             if failures > 0:
                 return lit.Test.FAIL, output
-            lit_results = [
-                (failures, lit.Test.FAIL),
-                (errors, lit.Test.UNRESOLVED),
-                (unexpected_successes, lit.Test.XPASS),
-            ]
+            return lit.Test.XPASS, output
         else:
-            # Only mark the test as unsupported if they are all unsupported.
-            if passes == 0 and expected_failures == 0:
-                return lit.Test.UNSUPPORTED
-            lit_results = [
-                (passes, lit.Test.PASS),
-                (expected_failures, lit.Test.XFAIL),
-            ]
-
-        # Return the lit result code with the maximum occurrence. Only look at
-        # the first element and rely on the original order to break ties.
-        return max(lit_results, key=operator.itemgetter(0))[1], output
+            # Aggregate the tests results with the following precedence:
+            # PASS > XFAIL > UNSUPPORTED
+            if passes > 0:
+                return lit.Test.PASS, output
+            if expected_failures > 0:
+                return lit.Test.XFAIL, output
+            return lit.Test.UNSUPPORTED, output

--- a/lldb/test/API/lldbtest.py
+++ b/lldb/test/API/lldbtest.py
@@ -138,12 +138,11 @@ class LLDBTest(TestFormat):
                 (unexpected_successes, lit.Test.XPASS),
             ]
         else:
-            # Mark this test as PASS if at least one test passed.
-            if passes > 0:
-                return lit.Test.PASS, output
+            # Only mark the test as unsupported if they are all unsupported.
+            if passes == 0 and expected_failures == 0:
+                return lit.Test.UNSUPPORTED
             lit_results = [
                 (passes, lit.Test.PASS),
-                (skipped, lit.Test.UNSUPPORTED),
                 (expected_failures, lit.Test.XFAIL),
             ]
 


### PR DESCRIPTION
Change how the results of multiple tests are aggregated into one result.

Currently if 2 tests are UNSUPPORTED and 1 test is XFAIL, the aggregated result will be UNSUPPORTED. If any test is PASS, the aggregated result will be PASS.

This is confusing on Windows because a lot of API tests try to run `dwo`, `dsym` and `dwarf` variants, whereas we only run the `dwarf` variant on Windows. In swiftlang/llvm-project, we are seeing results like the following when running the lldb-swift target:

```
Total Discovered Tests: 2548
  Excluded         : 2009 (78.85%)
  Unsupported      :  462 (18.13%)
  Passed           :    6 (0.24%)
  Expectedly Failed:   19 (0.75%)
  Unresolved       :    6 (0.24%)
  Failed           :   46 (1.81%)
```

With this patch, precedence is introduced to aggregate the test results:
If the tests are failing: `UNRESOLVED > FAIL > XPASS`
If the tests are passing: `PASS > XFAIL > UNSUPPORTED`

The results become:

```
Total Discovered Tests: 2548
  Excluded         : 2009 (78.85%)
  Unsupported      :  257 (10.09%)
  Passed           :    6 (0.24%)
  Expectedly Failed:  224 (8.79%)
  Unresolved       :    6 (0.24%)
  Failed           :   46 (1.81%)
```