### PR TITLE
[OpenMP][OMPT] Add missing `error` entry to device tracing record union

### DIFF
--- a/openmp/runtime/src/include/omp-tools.h.var
+++ b/openmp/runtime/src/include/omp-tools.h.var
@@ -1402,6 +1402,7 @@ typedef struct ompt_record_ompt_t {
     ompt_record_target_map_t target_map;
     ompt_record_target_kernel_t target_kernel;
     ompt_record_control_tool_t control_tool;
+    ompt_record_error_t error;
   } record;
 } ompt_record_ompt_t;
 


### PR DESCRIPTION
While `omp-tools.h` already includes the `ompt_record_error_t` struct, the corresponding union entry was missing from `ompt_record_ompt_t`. This commit adds the missing entry.

Note that this does not enable any functionality for device tracing records.
This only aligns the struct with OpenMP v5.1 and newer. OpenMP v5.0 did not contain the `error` directive.

CC: @jprotze 