### PR TITLE
[mlir][IR] Rename `DenseIntOrFPElementsAttr` to `DenseTypedElementsAttr`

### DIFF
--- a/cross-project-tests/debuginfo-tests/llvm-prettyprinters/gdb/mlir-support.gdb
+++ b/cross-project-tests/debuginfo-tests/llvm-prettyprinters/gdb/mlir-support.gdb
@@ -143,5 +143,5 @@ print StringAttr
 
 # CHECK-LABEL: +print ElementsAttr
 print ElementsAttr
-# CHECK: typeID = mlir::TypeID::get<mlir::DenseIntOrFPElementsAttr>()
-# CHECK: members of mlir::detail::DenseIntOrFPElementsAttrStorage
+# CHECK: typeID = mlir::TypeID::get<mlir::DenseTypedElementsAttr>()
+# CHECK: members of mlir::detail::DenseTypedElementsAttrStorage

--- a/flang/lib/Optimizer/CodeGen/CodeGen.cpp
+++ b/flang/lib/Optimizer/CodeGen/CodeGen.cpp
@@ -3276,7 +3276,7 @@ static inline bool attributeTypeIsCompatible(mlir::MLIRContext *ctx,
   // Get attr's LLVM element type.
   if (!attr)
     return true;
-  auto intOrFpEleAttr = mlir::dyn_cast<mlir::DenseIntOrFPElementsAttr>(attr);
+  auto intOrFpEleAttr = mlir::dyn_cast<mlir::DenseTypedElementsAttr>(attr);
   if (!intOrFpEleAttr)
     return true;
   auto tensorTy = mlir::dyn_cast<mlir::TensorType>(intOrFpEleAttr.getType());

--- a/mlir/docs/Tutorials/Toy/Ch-2.md
+++ b/mlir/docs/Tutorials/Toy/Ch-2.md
@@ -241,7 +241,7 @@ operation. This operation will represent a constant value in the Toy language.
 ```
 
 This operation takes zero operands, a
-[dense elements](../../Dialects/Builtin.md/#denseintorfpelementsattr) attribute named
+[dense elements](../../Dialects/Builtin.md/#densetypedelementsattr) attribute named
 `value` to represent the constant value, and returns a single result of
 [RankedTensorType](../../Dialects/Builtin.md/#rankedtensortype). An operation class
 inherits from the [CRTP](https://en.wikipedia.org/wiki/Curiously_recurring_template_pattern)

--- a/mlir/include/mlir-c/BuiltinAttributes.h
+++ b/mlir/include/mlir-c/BuiltinAttributes.h
@@ -468,7 +468,9 @@ MLIR_CAPI_EXPORTED bool mlirAttributeIsADenseElements(MlirAttribute attr);
 MLIR_CAPI_EXPORTED bool mlirAttributeIsADenseIntElements(MlirAttribute attr);
 MLIR_CAPI_EXPORTED bool mlirAttributeIsADenseFPElements(MlirAttribute attr);
 
-/// Returns the typeID of an DenseIntOrFPElements attribute.
+/// Returns the typeID of a DenseTypedElements attribute.
+MLIR_CAPI_EXPORTED MlirTypeID mlirDenseTypedElementsAttrGetTypeID(void);
+/// Deprecated API. Will be removed in the future.
 MLIR_CAPI_EXPORTED MlirTypeID mlirDenseIntOrFPElementsAttrGetTypeID(void);
 
 /// Creates a dense elements attribute with the given Shaped type and elements

--- a/mlir/include/mlir/IR/BuiltinAttributes.h
+++ b/mlir/include/mlir/IR/BuiltinAttributes.h
@@ -32,7 +32,7 @@ class Operation;
 class RankedTensorType;
 
 namespace detail {
-struct DenseIntOrFPElementsAttrStorage;
+struct DenseTypedElementsAttrStorage;
 struct DenseStringElementsAttrStorage;
 struct StringAttrStorage;
 } // namespace detail
@@ -702,6 +702,12 @@ using DenseResourceElementsHandle = DialectResourceBlobHandle<BuiltinDialect>;
 //===----------------------------------------------------------------------===//
 
 namespace mlir {
+/// DenseIntOrFPElementsAttr was renamed to DenseTypedElementsAttr. This alias
+/// is provided for backwards compatibility. It will be removed in the future.
+using DenseIntOrFPElementsAttr [[deprecated(
+    "DenseIntOrFPElementsAttr has been renamed to DenseTypedElementsAttr")]] =
+    DenseTypedElementsAttr;
+
 //===----------------------------------------------------------------------===//
 // DenseArrayAttr
 //===----------------------------------------------------------------------===//
@@ -897,11 +903,11 @@ private:
 
 /// An attribute that represents a reference to a dense float vector or tensor
 /// object. Each element is stored as a double.
-class DenseFPElementsAttr : public DenseIntOrFPElementsAttr {
+class DenseFPElementsAttr : public DenseTypedElementsAttr {
 public:
   using iterator = DenseElementsAttr::FloatElementIterator;
 
-  using DenseIntOrFPElementsAttr::DenseIntOrFPElementsAttr;
+  using DenseTypedElementsAttr::DenseTypedElementsAttr;
 
   /// Get an instance of a DenseFPElementsAttr with the given arguments. This
   /// simply wraps the DenseElementsAttr::get calls.
@@ -936,13 +942,13 @@ public:
 
 /// An attribute that represents a reference to a dense integer vector or tensor
 /// object.
-class DenseIntElementsAttr : public DenseIntOrFPElementsAttr {
+class DenseIntElementsAttr : public DenseTypedElementsAttr {
 public:
   /// DenseIntElementsAttr iterates on APInt, so we can use the raw element
   /// iterator directly.
   using iterator = DenseElementsAttr::IntElementIterator;
 
-  using DenseIntOrFPElementsAttr::DenseIntOrFPElementsAttr;
+  using DenseTypedElementsAttr::DenseTypedElementsAttr;
 
   /// Get an instance of a DenseIntElementsAttr with the given arguments. This
   /// simply wraps the DenseElementsAttr::get calls.

--- a/mlir/include/mlir/IR/BuiltinAttributes.td
+++ b/mlir/include/mlir/IR/BuiltinAttributes.td
@@ -169,7 +169,7 @@ def Builtin_DenseArray : Builtin_Attr<"DenseArray", "dense_array",
   let summary = "A dense array of integer or floating point elements.";
   let description = [{
     A dense array attribute is an attribute that represents a dense array of
-    primitive element types. Contrary to DenseIntOrFPElementsAttr this is a
+    primitive element types. Contrary to DenseTypedElementsAttr this is a
     flat unidimensional array which does not have a storage optimization for
     splat. This allows to expose the raw array through a C++ API as
     `ArrayRef<T>` for compatible types. The element type must be bool or an
@@ -231,11 +231,11 @@ def Builtin_DenseArray : Builtin_Attr<"DenseArray", "dense_array",
 }
 
 //===----------------------------------------------------------------------===//
-// DenseIntOrFPElementsAttr
+// DenseTypedElementsAttr
 //===----------------------------------------------------------------------===//
 
-def Builtin_DenseIntOrFPElementsAttr : Builtin_Attr<
-    "DenseIntOrFPElements", "dense_int_or_fp_elements", [ElementsAttrInterface],
+def Builtin_DenseTypedElementsAttr : Builtin_Attr<
+    "DenseTypedElements", "dense_typed_elements", [ElementsAttrInterface],
     "DenseElementsAttr"
   > {
   let summary = "An Attribute containing a dense multi-dimensional array of "
@@ -257,9 +257,6 @@ def Builtin_DenseIntOrFPElementsAttr : Builtin_Attr<
     Storage format: Given an element bitwidth "w", element "i" starts at byte
     offset "i * ceildiv(w, 8)". In other words, each element starts at a full
     byte offset.
-
-    TODO: The name `DenseIntOrFPElements` is no longer accurate. The attribute
-    will be renamed in the future.
 
     Examples:
 

--- a/mlir/include/mlir/IR/BuiltinDialectBytecode.td
+++ b/mlir/include/mlir/IR/BuiltinDialectBytecode.td
@@ -173,12 +173,12 @@ def DenseArrayAttr : DialectAttribute<(attr
 )>;
 
 def DenseElementsAttr : WithType<"DenseElementsAttr", Attribute>;
-def DenseIntOrFPElementsAttr : DialectAttribute<(attr
+def DenseTypedElementsAttr : DialectAttribute<(attr
   ShapedType:$type,
   WithBuilder<"$_args",
     WithType<"SmallVector<char>",
-    WithParser<"succeeded(readDenseIntOrFPElementsAttr($_reader, type, $_var))",
-    WithPrinter<"writeDenseIntOrFPElementsAttr($_writer, $_name)">>>>:$rawData
+    WithParser<"succeeded(readDenseTypedElementsAttr($_reader, type, $_var))",
+    WithPrinter<"writeDenseTypedElementsAttr($_writer, $_name)">>>>:$rawData
 )>;
 
 def DenseStringElementsAttr : DialectAttribute<(attr
@@ -334,7 +334,7 @@ def BuiltinDialectAttributes : DialectAttributes<"Builtin"> {
     UnknownLoc,
     DenseResourceElementsAttr,
     DenseArrayAttr,
-    DenseIntOrFPElementsAttr,
+    DenseTypedElementsAttr,
     DenseStringElementsAttr,
     SparseElementsAttr,
     DistinctAttr,

--- a/mlir/lib/AsmParser/AttributeParser.cpp
+++ b/mlir/lib/AsmParser/AttributeParser.cpp
@@ -732,7 +732,7 @@ DenseElementsAttr TensorLiteralParser::getHexAttr(SMLoc loc, ShapedType type) {
     // machines.
     SmallVector<char, 64> outDataVec(rawData.size());
     MutableArrayRef<char> convRawData(outDataVec);
-    DenseIntOrFPElementsAttr::convertEndianOfArrayRefForBEmachine(
+    DenseTypedElementsAttr::convertEndianOfArrayRefForBEmachine(
         rawData, convRawData, type);
     return DenseElementsAttr::getFromRawBuffer(type, convRawData);
   }

--- a/mlir/lib/Bindings/Python/IRAttributes.cpp
+++ b/mlir/lib/Bindings/Python/IRAttributes.cpp
@@ -1329,14 +1329,13 @@ nb::object denseArrayAttributeCaster(PyAttribute &pyAttribute) {
   throw nb::type_error(msg.c_str());
 }
 
-nb::object denseIntOrFPElementsAttributeCaster(PyAttribute &pyAttribute) {
+nb::object denseTypedElementsAttributeCaster(PyAttribute &pyAttribute) {
   if (PyDenseFPElementsAttribute::isaFunction(pyAttribute))
     return nb::cast(PyDenseFPElementsAttribute(pyAttribute));
   if (PyDenseIntElementsAttribute::isaFunction(pyAttribute))
     return nb::cast(PyDenseIntElementsAttribute(pyAttribute));
   std::string msg =
-      std::string(
-          "Can't cast unknown element type DenseIntOrFPElementsAttr (") +
+      std::string("Can't cast unknown element type DenseTypedElementsAttr (") +
       nb::cast<std::string>(nb::repr(nb::cast(pyAttribute))) + ")";
   throw nb::type_error(msg.c_str());
 }
@@ -1512,10 +1511,9 @@ void populateIRAttributes(nb::module_ &m) {
   PyDenseElementsAttribute::bind(m, PyDenseElementsAttribute::slots);
   PyDenseFPElementsAttribute::bind(m);
   PyDenseIntElementsAttribute::bind(m);
-  PyGlobals::get().registerTypeCaster(
-      mlirDenseIntOrFPElementsAttrGetTypeID(),
-      nb::cast<nb::callable>(
-          nb::cpp_function(denseIntOrFPElementsAttributeCaster)));
+  PyGlobals::get().registerTypeCaster(mlirDenseTypedElementsAttrGetTypeID(),
+                                      nb::cast<nb::callable>(nb::cpp_function(
+                                          denseTypedElementsAttributeCaster)));
   PyDenseResourceElementsAttribute::bind(m);
 
   PyDictAttribute::bind(m);

--- a/mlir/lib/CAPI/IR/BuiltinAttributes.cpp
+++ b/mlir/lib/CAPI/IR/BuiltinAttributes.cpp
@@ -559,8 +559,13 @@ bool mlirAttributeIsADenseFPElements(MlirAttribute attr) {
   return llvm::isa<DenseFPElementsAttr>(unwrap(attr));
 }
 
+MlirTypeID mlirDenseTypedElementsAttrGetTypeID(void) {
+  return wrap(DenseTypedElementsAttr::getTypeID());
+}
+
+// Deprecated API. Will be removed in the future.
 MlirTypeID mlirDenseIntOrFPElementsAttrGetTypeID(void) {
-  return wrap(DenseIntOrFPElementsAttr::getTypeID());
+  return mlirDenseTypedElementsAttrGetTypeID();
 }
 
 //===----------------------------------------------------------------------===//

--- a/mlir/lib/Dialect/Arith/Transforms/ShardingInterfaceImpl.cpp
+++ b/mlir/lib/Dialect/Arith/Transforms/ShardingInterfaceImpl.cpp
@@ -73,7 +73,7 @@ struct ConstantShardingInterface
                           SymbolTableCollection &symbolTable,
                           OpBuilder &builder) const {
     auto cOp = cast<ConstantOp>(op);
-    if (auto value = dyn_cast<DenseIntOrFPElementsAttr>(cOp.getValue())) {
+    if (auto value = dyn_cast<DenseTypedElementsAttr>(cOp.getValue())) {
       if (!value.isSplat() || !resultShardings[0]) {
         // Currently non-splat constants are not supported.
         return failure();

--- a/mlir/lib/Dialect/Linalg/Transforms/ConstantFold.cpp
+++ b/mlir/lib/Dialect/Linalg/Transforms/ConstantFold.cpp
@@ -115,7 +115,7 @@ public:
 
     // All inputs should be constants.
     int numInputs = linalgOp.getNumDpsInputs();
-    SmallVector<DenseIntOrFPElementsAttr> inputValues(numInputs);
+    SmallVector<DenseTypedElementsAttr> inputValues(numInputs);
     for (const auto &en : llvm::enumerate(linalgOp.getDpsInputOperands())) {
       if (!matchPattern(en.value()->get(),
                         m_Constant(&inputValues[en.index()])))

--- a/mlir/lib/Dialect/SPIRV/IR/SPIRVOps.cpp
+++ b/mlir/lib/Dialect/SPIRV/IR/SPIRVOps.cpp
@@ -575,7 +575,7 @@ static LogicalResult verifyConstantType(spirv::ConstantOp op, Attribute value,
              << opType << ") does not match value type (" << valueType << ")";
     return success();
   }
-  if (isa<DenseIntOrFPElementsAttr, SparseElementsAttr>(value)) {
+  if (isa<DenseTypedElementsAttr, SparseElementsAttr>(value)) {
     auto valueType = cast<TypedAttr>(value).getType();
     if (valueType == opType)
       return success();

--- a/mlir/lib/IR/AsmPrinter.cpp
+++ b/mlir/lib/IR/AsmPrinter.cpp
@@ -510,8 +510,7 @@ protected:
   /// Print a dense elements attribute in the literal-first syntax. If
   /// 'allowHex' is true, a hex string is used instead of individual elements
   /// when the elements attr is large.
-  void printDenseIntOrFPElementsAttr(DenseIntOrFPElementsAttr attr,
-                                     bool allowHex);
+  void printDenseTypedElementsAttr(DenseTypedElementsAttr attr, bool allowHex);
 
   /// Print a dense elements attribute using the type-first syntax and the
   /// DenseElementTypeInterface, which provides the attribute printer for each
@@ -2509,7 +2508,7 @@ void AsmPrinter::Impl::printAttributeImpl(Attribute attr,
     }
 
   } else if (auto intOrFpEltAttr =
-                 llvm::dyn_cast<DenseIntOrFPElementsAttr>(attr)) {
+                 llvm::dyn_cast<DenseTypedElementsAttr>(attr)) {
     if (printerFlags.shouldElideElementsAttr(intOrFpEltAttr)) {
       printElidedElementsAttr(os);
     } else {
@@ -2519,7 +2518,7 @@ void AsmPrinter::Impl::printAttributeImpl(Attribute attr,
       // the existing printing format for backwards compatibility.
       Type eltType = intOrFpEltAttr.getElementType();
       if (isa<FloatType, IntegerType, IndexType, ComplexType>(eltType)) {
-        printDenseIntOrFPElementsAttr(intOrFpEltAttr, /*allowHex=*/true);
+        printDenseTypedElementsAttr(intOrFpEltAttr, /*allowHex=*/true);
       } else {
         printTypeFirstDenseElementsAttr(intOrFpEltAttr,
                                         cast<DenseElementType>(eltType));
@@ -2545,7 +2544,7 @@ void AsmPrinter::Impl::printAttributeImpl(Attribute attr,
       os << "sparse<";
       DenseIntElementsAttr indices = sparseEltAttr.getIndices();
       if (indices.getNumElements() != 0) {
-        printDenseIntOrFPElementsAttr(indices, /*allowHex=*/false);
+        printDenseTypedElementsAttr(indices, /*allowHex=*/false);
         os << ", ";
         printDenseElementsAttr(sparseEltAttr.getValues(), /*allowHex=*/true);
       }
@@ -2648,12 +2647,12 @@ void AsmPrinter::Impl::printDenseElementsAttr(DenseElementsAttr attr,
   if (auto stringAttr = llvm::dyn_cast<DenseStringElementsAttr>(attr))
     return printDenseStringElementsAttr(stringAttr);
 
-  printDenseIntOrFPElementsAttr(llvm::cast<DenseIntOrFPElementsAttr>(attr),
-                                allowHex);
+  printDenseTypedElementsAttr(llvm::cast<DenseTypedElementsAttr>(attr),
+                              allowHex);
 }
 
-void AsmPrinter::Impl::printDenseIntOrFPElementsAttr(
-    DenseIntOrFPElementsAttr attr, bool allowHex) {
+void AsmPrinter::Impl::printDenseTypedElementsAttr(DenseTypedElementsAttr attr,
+                                                   bool allowHex) {
   auto type = attr.getType();
   auto elementType = type.getElementType();
 
@@ -2665,7 +2664,7 @@ void AsmPrinter::Impl::printDenseIntOrFPElementsAttr(
       // machines. It is converted here to print in LE format.
       SmallVector<char, 64> outDataVec(rawData.size());
       MutableArrayRef<char> convRawData(outDataVec);
-      DenseIntOrFPElementsAttr::convertEndianOfArrayRefForBEmachine(
+      DenseTypedElementsAttr::convertEndianOfArrayRefForBEmachine(
           rawData, convRawData, type);
       printHexString(convRawData);
     } else {

--- a/mlir/lib/IR/AttributeDetail.h
+++ b/mlir/lib/IR/AttributeDetail.h
@@ -47,8 +47,8 @@ public:
 };
 
 /// An attribute representing a reference to a dense vector or tensor object.
-struct DenseIntOrFPElementsAttrStorage : public DenseElementsAttributeStorage {
-  DenseIntOrFPElementsAttrStorage(ShapedType ty, ArrayRef<char> data)
+struct DenseTypedElementsAttrStorage : public DenseElementsAttributeStorage {
+  DenseTypedElementsAttrStorage(ShapedType ty, ArrayRef<char> data)
       : DenseElementsAttributeStorage(ty), data(data) {}
 
   struct KeyTy {
@@ -108,7 +108,7 @@ struct DenseIntOrFPElementsAttrStorage : public DenseElementsAttributeStorage {
   }
 
   /// Construct a new storage instance.
-  static DenseIntOrFPElementsAttrStorage *
+  static DenseTypedElementsAttrStorage *
   construct(AttributeStorageAllocator &allocator, KeyTy key) {
     // If the data buffer is non-empty, we copy it into the allocator with a
     // 64-bit alignment.
@@ -120,8 +120,8 @@ struct DenseIntOrFPElementsAttrStorage : public DenseElementsAttributeStorage {
       copy = ArrayRef<char>(rawData, data.size());
     }
 
-    return new (allocator.allocate<DenseIntOrFPElementsAttrStorage>())
-        DenseIntOrFPElementsAttrStorage(key.type, copy);
+    return new (allocator.allocate<DenseTypedElementsAttrStorage>())
+        DenseTypedElementsAttrStorage(key.type, copy);
   }
 
   ArrayRef<char> data;

--- a/mlir/lib/IR/BuiltinAttributes.cpp
+++ b/mlir/lib/IR/BuiltinAttributes.cpp
@@ -481,13 +481,13 @@ static void copyAPIntToArrayForBEmachine(APInt value, size_t numBytes,
   // ex. last word of `value` (BE): |------ij|  ==> `valueLE` (LE): |ji------|
   size_t lastWordPos = numFilledWords;
   SmallVector<char, 8> valueLE(APInt::APINT_WORD_SIZE);
-  DenseIntOrFPElementsAttr::convertEndianOfCharForBEmachine(
+  DenseTypedElementsAttr::convertEndianOfCharForBEmachine(
       reinterpret_cast<const char *>(value.getRawData()) + lastWordPos,
       valueLE.begin(), APInt::APINT_BITS_PER_WORD, 1);
   // Extract actual APInt data from `valueLE`, convert endianness to BE format,
   // and store it in `result`.
   // ex. `valueLE` (LE): |ji------|  ==> `result` (BE): |abcdefgh|ij|
-  DenseIntOrFPElementsAttr::convertEndianOfCharForBEmachine(
+  DenseTypedElementsAttr::convertEndianOfCharForBEmachine(
       valueLE.begin(), result + lastWordPos,
       (numBytes - lastWordPos) * CHAR_BIT, 1);
 }
@@ -514,13 +514,13 @@ static void copyArrayToAPIntForBEmachine(const char *inArray, size_t numBytes,
   // ex. `inArray` (last two bytes, BE): |ij|  ==> `inArrayLE` (LE): |ji------|
   size_t lastWordPos = numFilledWords;
   SmallVector<char, 8> inArrayLE(APInt::APINT_WORD_SIZE);
-  DenseIntOrFPElementsAttr::convertEndianOfCharForBEmachine(
+  DenseTypedElementsAttr::convertEndianOfCharForBEmachine(
       inArray + lastWordPos, inArrayLE.begin(),
       (numBytes - lastWordPos) * CHAR_BIT, 1);
 
   // Convert `inArrayLE` to BE format, and store it in last word of `result`.
   // ex. `inArrayLE` (LE): |ji------|  ==> `result` (BE): |abcdefgh|------ij|
-  DenseIntOrFPElementsAttr::convertEndianOfCharForBEmachine(
+  DenseTypedElementsAttr::convertEndianOfCharForBEmachine(
       inArrayLE.begin(),
       const_cast<char *>(reinterpret_cast<const char *>(result.getRawData())) +
           lastWordPos,
@@ -864,7 +864,7 @@ template class DenseArrayAttrImpl<double>;
 
 /// Method for support type inquiry through isa, cast and dyn_cast.
 bool DenseElementsAttr::classof(Attribute attr) {
-  return llvm::isa<DenseIntOrFPElementsAttr, DenseStringElementsAttr>(attr);
+  return llvm::isa<DenseTypedElementsAttr, DenseStringElementsAttr>(attr);
 }
 
 DenseElementsAttr DenseElementsAttr::get(ShapedType type,
@@ -894,14 +894,14 @@ DenseElementsAttr DenseElementsAttr::get(ShapedType type,
     if (failed(result))
       return {};
   }
-  return DenseIntOrFPElementsAttr::getRaw(type, data);
+  return DenseTypedElementsAttr::getRaw(type, data);
 }
 
 DenseElementsAttr DenseElementsAttr::get(ShapedType type,
                                          ArrayRef<bool> values) {
   assert(hasSameNumElementsOrSplat(type, values));
   assert(type.getElementType().isInteger(1));
-  return DenseIntOrFPElementsAttr::getRaw(
+  return DenseTypedElementsAttr::getRaw(
       type, ArrayRef<char>(reinterpret_cast<const char *>(values.data()),
                            values.size()));
 }
@@ -920,7 +920,7 @@ DenseElementsAttr DenseElementsAttr::get(ShapedType type,
   assert(type.getElementType().isIntOrIndex());
   assert(hasSameNumElementsOrSplat(type, values));
   size_t storageBitWidth = getDenseElementStorageWidth(type.getElementType());
-  return DenseIntOrFPElementsAttr::getRaw(type, storageBitWidth, values);
+  return DenseTypedElementsAttr::getRaw(type, storageBitWidth, values);
 }
 DenseElementsAttr DenseElementsAttr::get(ShapedType type,
                                          ArrayRef<std::complex<APInt>> values) {
@@ -930,7 +930,7 @@ DenseElementsAttr DenseElementsAttr::get(ShapedType type,
   size_t storageBitWidth = getDenseElementStorageWidth(complex) / 2;
   ArrayRef<APInt> intVals(reinterpret_cast<const APInt *>(values.data()),
                           values.size() * 2);
-  return DenseIntOrFPElementsAttr::getRaw(type, storageBitWidth, intVals);
+  return DenseTypedElementsAttr::getRaw(type, storageBitWidth, intVals);
 }
 
 // Constructs a dense float elements attribute from an array of APFloat
@@ -941,7 +941,7 @@ DenseElementsAttr DenseElementsAttr::get(ShapedType type,
   assert(llvm::isa<FloatType>(type.getElementType()));
   assert(hasSameNumElementsOrSplat(type, values));
   size_t storageBitWidth = getDenseElementStorageWidth(type.getElementType());
-  return DenseIntOrFPElementsAttr::getRaw(type, storageBitWidth, values);
+  return DenseTypedElementsAttr::getRaw(type, storageBitWidth, values);
 }
 DenseElementsAttr
 DenseElementsAttr::get(ShapedType type,
@@ -952,7 +952,7 @@ DenseElementsAttr::get(ShapedType type,
   ArrayRef<APFloat> apVals(reinterpret_cast<const APFloat *>(values.data()),
                            values.size() * 2);
   size_t storageBitWidth = getDenseElementStorageWidth(complex) / 2;
-  return DenseIntOrFPElementsAttr::getRaw(type, storageBitWidth, apVals);
+  return DenseTypedElementsAttr::getRaw(type, storageBitWidth, apVals);
 }
 
 /// Construct a dense elements attribute from a raw buffer representing the
@@ -960,7 +960,7 @@ DenseElementsAttr::get(ShapedType type,
 /// the expected buffer format may not be a form the user expects.
 DenseElementsAttr
 DenseElementsAttr::getFromRawBuffer(ShapedType type, ArrayRef<char> rawBuffer) {
-  return DenseIntOrFPElementsAttr::getRaw(type, rawBuffer);
+  return DenseTypedElementsAttr::getRaw(type, rawBuffer);
 }
 
 /// Returns true if the given buffer is a valid raw buffer for the given type.
@@ -1021,16 +1021,16 @@ DenseElementsAttr DenseElementsAttr::getRawComplex(ShapedType type,
                                                    ArrayRef<char> data,
                                                    int64_t dataEltSize,
                                                    bool isInt, bool isSigned) {
-  return DenseIntOrFPElementsAttr::getRawComplex(type, data, dataEltSize, isInt,
-                                                 isSigned);
+  return DenseTypedElementsAttr::getRawComplex(type, data, dataEltSize, isInt,
+                                               isSigned);
 }
 DenseElementsAttr DenseElementsAttr::getRawIntOrFloat(ShapedType type,
                                                       ArrayRef<char> data,
                                                       int64_t dataEltSize,
                                                       bool isInt,
                                                       bool isSigned) {
-  return DenseIntOrFPElementsAttr::getRawIntOrFloat(type, data, dataEltSize,
-                                                    isInt, isSigned);
+  return DenseTypedElementsAttr::getRawIntOrFloat(type, data, dataEltSize,
+                                                  isInt, isSigned);
 }
 
 bool DenseElementsAttr::isValidIntOrFloat(int64_t dataEltSize, bool isInt,
@@ -1097,7 +1097,7 @@ auto DenseElementsAttr::tryGetComplexFloatValues() const
 
 /// Return the raw storage data held by this attribute.
 ArrayRef<char> DenseElementsAttr::getRawData() const {
-  return static_cast<DenseIntOrFPElementsAttrStorage *>(impl)->data;
+  return static_cast<DenseTypedElementsAttrStorage *>(impl)->data;
 }
 
 ArrayRef<StringRef> DenseElementsAttr::getRawStringData() const {
@@ -1116,7 +1116,7 @@ DenseElementsAttr DenseElementsAttr::reshape(ShapedType newType) {
          "expected the same element type");
   assert(newType.getNumElements() == curType.getNumElements() &&
          "expected the same number of elements");
-  return DenseIntOrFPElementsAttr::getRaw(newType, getRawData());
+  return DenseTypedElementsAttr::getRaw(newType, getRawData());
 }
 
 DenseElementsAttr DenseElementsAttr::resizeSplat(ShapedType newType) {
@@ -1128,7 +1128,7 @@ DenseElementsAttr DenseElementsAttr::resizeSplat(ShapedType newType) {
 
   assert(newType.getElementType() == curType.getElementType() &&
          "expected the same element type");
-  return DenseIntOrFPElementsAttr::getRaw(newType, getRawData());
+  return DenseTypedElementsAttr::getRaw(newType, getRawData());
 }
 
 /// Return a new DenseElementsAttr that has the same data as the current
@@ -1144,8 +1144,7 @@ DenseElementsAttr DenseElementsAttr::bitcast(Type newElType) {
   assert(getDenseElementBitWidth(newElType) ==
              getDenseElementBitWidth(curElType) &&
          "expected element types with the same bitwidth");
-  return DenseIntOrFPElementsAttr::getRaw(curType.clone(newElType),
-                                          getRawData());
+  return DenseTypedElementsAttr::getRaw(curType.clone(newElType), getRawData());
 }
 
 DenseElementsAttr
@@ -1174,7 +1173,7 @@ int64_t DenseElementsAttr::getNumElements() const {
 }
 
 //===----------------------------------------------------------------------===//
-// DenseIntOrFPElementsAttr
+// DenseTypedElementsAttr
 //===----------------------------------------------------------------------===//
 
 /// Utility method to write a range of APInt values to a buffer.
@@ -1195,28 +1194,28 @@ static void writeAPIntsToBuffer(size_t storageWidth,
 /// Constructs a dense elements attribute from an array of raw APFloat values.
 /// Each APFloat value is expected to have the same bitwidth as the element
 /// type of 'type'. 'type' must be a vector or tensor with static shape.
-DenseElementsAttr DenseIntOrFPElementsAttr::getRaw(ShapedType type,
-                                                   size_t storageWidth,
-                                                   ArrayRef<APFloat> values) {
+DenseElementsAttr DenseTypedElementsAttr::getRaw(ShapedType type,
+                                                 size_t storageWidth,
+                                                 ArrayRef<APFloat> values) {
   SmallVector<char> data;
   auto unwrapFloat = [](const APFloat &val) { return val.bitcastToAPInt(); };
   writeAPIntsToBuffer(storageWidth, data, llvm::map_range(values, unwrapFloat));
-  return DenseIntOrFPElementsAttr::getRaw(type, data);
+  return DenseTypedElementsAttr::getRaw(type, data);
 }
 
 /// Constructs a dense elements attribute from an array of raw APInt values.
 /// Each APInt value is expected to have the same bitwidth as the element type
 /// of 'type'.
-DenseElementsAttr DenseIntOrFPElementsAttr::getRaw(ShapedType type,
-                                                   size_t storageWidth,
-                                                   ArrayRef<APInt> values) {
+DenseElementsAttr DenseTypedElementsAttr::getRaw(ShapedType type,
+                                                 size_t storageWidth,
+                                                 ArrayRef<APInt> values) {
   SmallVector<char> data;
   writeAPIntsToBuffer(storageWidth, data, values);
-  return DenseIntOrFPElementsAttr::getRaw(type, data);
+  return DenseTypedElementsAttr::getRaw(type, data);
 }
 
-DenseElementsAttr DenseIntOrFPElementsAttr::getRaw(ShapedType type,
-                                                   ArrayRef<char> data) {
+DenseElementsAttr DenseTypedElementsAttr::getRaw(ShapedType type,
+                                                 ArrayRef<char> data) {
   assert(type.hasStaticShape() && "type must have static shape");
   assert(isValidRawBuffer(type, data));
   return Base::get(type.getContext(), type, data);
@@ -1225,11 +1224,11 @@ DenseElementsAttr DenseIntOrFPElementsAttr::getRaw(ShapedType type,
 /// Overload of the raw 'get' method that asserts that the given type is of
 /// complex type. This method is used to verify type invariants that the
 /// templatized 'get' method cannot.
-DenseElementsAttr DenseIntOrFPElementsAttr::getRawComplex(ShapedType type,
-                                                          ArrayRef<char> data,
-                                                          int64_t dataEltSize,
-                                                          bool isInt,
-                                                          bool isSigned) {
+DenseElementsAttr DenseTypedElementsAttr::getRawComplex(ShapedType type,
+                                                        ArrayRef<char> data,
+                                                        int64_t dataEltSize,
+                                                        bool isInt,
+                                                        bool isSigned) {
   assert(::isValidIntOrFloat(
              llvm::cast<ComplexType>(type.getElementType()).getElementType(),
              dataEltSize / 2, isInt, isSigned) &&
@@ -1244,10 +1243,11 @@ DenseElementsAttr DenseIntOrFPElementsAttr::getRawComplex(ShapedType type,
 /// Overload of the 'getRaw' method that asserts that the given type is of
 /// integer type. This method is used to verify type invariants that the
 /// templatized 'get' method cannot.
-DenseElementsAttr
-DenseIntOrFPElementsAttr::getRawIntOrFloat(ShapedType type, ArrayRef<char> data,
-                                           int64_t dataEltSize, bool isInt,
-                                           bool isSigned) {
+DenseElementsAttr DenseTypedElementsAttr::getRawIntOrFloat(ShapedType type,
+                                                           ArrayRef<char> data,
+                                                           int64_t dataEltSize,
+                                                           bool isInt,
+                                                           bool isSigned) {
   assert(::isValidIntOrFloat(type.getElementType(), dataEltSize, isInt,
                              isSigned) &&
          "Try re-running with -debug-only=builtinattributes");
@@ -1258,7 +1258,7 @@ DenseIntOrFPElementsAttr::getRawIntOrFloat(ShapedType type, ArrayRef<char> data,
   return getRaw(type, data);
 }
 
-void DenseIntOrFPElementsAttr::convertEndianOfCharForBEmachine(
+void DenseTypedElementsAttr::convertEndianOfCharForBEmachine(
     const char *inRawData, char *outRawData, size_t elementBitWidth,
     size_t numElements) {
   using llvm::support::ulittle16_t;
@@ -1300,7 +1300,7 @@ void DenseIntOrFPElementsAttr::convertEndianOfCharForBEmachine(
   }
 }
 
-void DenseIntOrFPElementsAttr::convertEndianOfArrayRefForBEmachine(
+void DenseTypedElementsAttr::convertEndianOfArrayRefForBEmachine(
     ArrayRef<char> inRawData, MutableArrayRef<char> outRawData,
     ShapedType type) {
   size_t numElements = type.getNumElements();

--- a/mlir/lib/IR/BuiltinDialectBytecode.cpp
+++ b/mlir/lib/IR/BuiltinDialectBytecode.cpp
@@ -149,16 +149,15 @@ static void writeFileLineColRangeLocs(DialectBytecodeWriter &writer,
 }
 
 static LogicalResult
-readDenseIntOrFPElementsAttr(DialectBytecodeReader &reader, ShapedType type,
-                             SmallVectorImpl<char> &rawData) {
+readDenseTypedElementsAttr(DialectBytecodeReader &reader, ShapedType type,
+                           SmallVectorImpl<char> &rawData) {
   // Validate that the element type implements DenseElementTypeInterface.
   // Without this check, downstream code unconditionally calls
   // getDenseElementBitWidth() which asserts on unsupported types.
   if (!llvm::isa<DenseElementType>(type.getElementType())) {
-    reader.emitError()
-        << "DenseIntOrFPElementsAttr element type must implement "
-           "DenseElementTypeInterface, but got: "
-        << type.getElementType();
+    reader.emitError() << "DenseTypedElementsAttr element type must implement "
+                          "DenseElementTypeInterface, but got: "
+                       << type.getElementType();
     return failure();
   }
 
@@ -191,8 +190,8 @@ readDenseIntOrFPElementsAttr(DialectBytecodeReader &reader, ShapedType type,
   return success();
 }
 
-static void writeDenseIntOrFPElementsAttr(DialectBytecodeWriter &writer,
-                                          DenseIntOrFPElementsAttr attr) {
+static void writeDenseTypedElementsAttr(DialectBytecodeWriter &writer,
+                                        DenseTypedElementsAttr attr) {
   // Check to see if this is an i1 dense attribute.
   if (attr.getElementType().isInteger(1)) {
     // Pack the data.

--- a/mlir/lib/Rewrite/ByteCode.cpp
+++ b/mlir/lib/Rewrite/ByteCode.cpp
@@ -2075,7 +2075,7 @@ void ByteCodeExecutor::executeSwitchAttribute() {
 void ByteCodeExecutor::executeSwitchOperandCount() {
   LDBG() << "Executing SwitchOperandCount:";
   Operation *op = read<Operation *>();
-  auto cases = read<DenseIntOrFPElementsAttr>().getValues<uint32_t>();
+  auto cases = read<DenseTypedElementsAttr>().getValues<uint32_t>();
 
   LDBG() << "  * Operation: " << *op;
   handleSwitch(op->getNumOperands(), cases);
@@ -2112,7 +2112,7 @@ void ByteCodeExecutor::executeSwitchOperationName() {
 void ByteCodeExecutor::executeSwitchResultCount() {
   LDBG() << "Executing SwitchResultCount:";
   Operation *op = read<Operation *>();
-  auto cases = read<DenseIntOrFPElementsAttr>().getValues<uint32_t>();
+  auto cases = read<DenseTypedElementsAttr>().getValues<uint32_t>();
 
   LDBG() << "  * Operation: " << *op;
   handleSwitch(op->getNumResults(), cases);

--- a/mlir/test/Bytecode/invalid/invalid-dense-elem-type-interface.mlir
+++ b/mlir/test/Bytecode/invalid/invalid-dense-elem-type-interface.mlir
@@ -2,9 +2,9 @@
 
 // Regression test: test-kind=2 replaces i32 with !test.i32 (a type that does
 // not implement DenseElementTypeInterface). This should produce a proper error
-// instead of an assertion failure when deserializing DenseIntOrFPElementsAttr.
+// instead of an assertion failure when deserializing DenseTypedElementsAttr.
 
-// CHECK: DenseIntOrFPElementsAttr element type must implement DenseElementTypeInterface, but got: '!test.i32'
+// CHECK: DenseTypedElementsAttr element type must implement DenseElementTypeInterface, but got: '!test.i32'
 // CHECK: failed to read bytecode
 
 module {

--- a/mlir/test/Dialect/Builtin/Bytecode/attrs.mlir
+++ b/mlir/test/Dialect/Builtin/Bytecode/attrs.mlir
@@ -25,14 +25,14 @@ module @TestDenseArray attributes {
 } {}
 
 //===----------------------------------------------------------------------===//
-// DenseIntOfFPElementsAttr
+// DenseTypedElementsAttr
 //===----------------------------------------------------------------------===//
 
-// CHECK-LABEL: @TestDenseIntOrFPElements
+// CHECK-LABEL: @TestDenseTypedElements
 // CHECK: bytecode.test1 = dense<true> : tensor<256xi1>
 // CHECK: bytecode.test2 = dense<[10, 32, -1]> : tensor<3xi8>
 // CHECK: bytecode.test3 = dense<[1.{{.*}}e+01, 3.2{{.*}}e+01, 1.809{{.*}}e+03]> : tensor<3xf64>
-module @TestDenseIntOrFPElements attributes {
+module @TestDenseTypedElements attributes {
   bytecode.test1 = dense<true> : tensor<256xi1>,
   bytecode.test2 = dense<[10, 32, 255]> : tensor<3xi8>,
   bytecode.test3 = dense<[10.0, 32.0, 1809.0]> : tensor<3xf64>

--- a/mlir/utils/gdb-scripts/prettyprinters.py
+++ b/mlir/utils/gdb-scripts/prettyprinters.py
@@ -159,7 +159,7 @@ for name in [
     "TypeAttr",
     "UnitAttr",
     "DenseStringElementsAttr",
-    "DenseIntOrFPElementsAttr",
+    "DenseTypedElementsAttr",
     "SparseElementsAttr",
     # mlir/IR/BuiltinTypes.h
     "ComplexType",


### PR DESCRIPTION
`DenseIntOrFPElementsAttr` was recently generalized to accept any type that implement the `DenseElementType` interface. The name `DenseIntOrFPElementsAttr` does not make sense anymore. This commit renames the attribute to `DenseTypedElementsAttr`. An alias is kept for migration purposes. The alias will be removed after some time.
