### PR TITLE
[AArch64][SVE] Add unpacked fp ISel patterns for clastb

### DIFF
--- a/llvm/lib/Target/AArch64/SVEInstrFormats.td
+++ b/llvm/lib/Target/AArch64/SVEInstrFormats.td
@@ -7514,6 +7514,20 @@ multiclass sve_int_perm_clast_vz<bit ab, string asm, SDPatternOperator op> {
   def : SVE_3_Op_Pat<f64, op, nxv2i1, f64, nxv2f64, !cast<Instruction>(NAME # _D)>;
 
   def : SVE_3_Op_Pat<bf16, op, nxv8i1, bf16, nxv8bf16, !cast<Instruction>(NAME # _H)>;
+
+  // Unpacked variants must use container types to ensure that stray bits in
+  // the incoming predicate don't affect the result. We need some extra
+  // insert/extract subreg ops to handle the scalar types correctly.
+  def : Pat<(f16 (op nxv4i1:$Pg, f16:$default, nxv4f16:$vec)),
+            (EXTRACT_SUBREG (!cast<Instruction>(NAME # _S) $Pg, (INSERT_SUBREG (IMPLICIT_DEF), $default, hsub), $vec), hsub)>;
+  def : Pat<(f16 (op nxv2i1:$Pg, f16:$default, nxv2f16:$vec)),
+            (EXTRACT_SUBREG (!cast<Instruction>(NAME # _D) $Pg, (INSERT_SUBREG (IMPLICIT_DEF), $default, hsub), $vec), hsub)>;
+  def : Pat<(bf16 (op nxv4i1:$Pg, bf16:$default, nxv4bf16:$vec)),
+            (EXTRACT_SUBREG (!cast<Instruction>(NAME # _S) $Pg, (INSERT_SUBREG (IMPLICIT_DEF), $default, hsub), $vec), hsub)>;
+  def : Pat<(bf16 (op nxv2i1:$Pg, bf16:$default, nxv2bf16:$vec)),
+            (EXTRACT_SUBREG (!cast<Instruction>(NAME # _D) $Pg, (INSERT_SUBREG (IMPLICIT_DEF), $default, hsub), $vec), hsub)>;
+  def : Pat<(f32 (op nxv2i1:$Pg, f32:$default, nxv2f32:$vec)),
+            (EXTRACT_SUBREG (!cast<Instruction>(NAME # _D) $Pg, (f64 (INSERT_SUBREG (IMPLICIT_DEF), $default, ssub)), $vec), ssub)>;            
 }
 
 class sve_int_perm_clast_zz<bits<2> sz8_64, bit ab, string asm,

--- a/llvm/test/CodeGen/AArch64/vector-extract-last-active.ll
+++ b/llvm/test/CodeGen/AArch64/vector-extract-last-active.ll
@@ -577,4 +577,59 @@ define i8 @extract_last_active_split(<vscale x 32 x i8> %data, <vscale x 32 x i1
   ret i8 %res
 }
 
+define half @extract_last_active_unpacked_fp_nxv4f16(<vscale x 4 x half> %0, <vscale x 4 x i1> %mask, half %passthru) #0 {
+; CHECK-LABEL: extract_last_active_unpacked_fp_nxv4f16:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    // kill: def $h1 killed $h1 def $s1
+; CHECK-NEXT:    clastb s1, p0, s1, z0.s
+; CHECK-NEXT:    fmov s0, s1
+; CHECK-NEXT:    ret
+  %res = call half @llvm.experimental.vector.extract.last.active.nxv4f16(<vscale x 4 x half> %0, <vscale x 4 x i1> %mask, half %passthru)
+  ret half %res
+}
+
+define half @extract_last_active_unpacked_fp_nxv2f16(<vscale x 2 x half> %0, <vscale x 2 x i1> %mask, half %passthru) #0 {
+; CHECK-LABEL: extract_last_active_unpacked_fp_nxv2f16:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    // kill: def $h1 killed $h1 def $d1
+; CHECK-NEXT:    clastb d1, p0, d1, z0.d
+; CHECK-NEXT:    fmov s0, s1
+; CHECK-NEXT:    ret
+  %res = call half @llvm.experimental.vector.extract.last.active.nxv2f16(<vscale x 2 x half> %0, <vscale x 2 x i1> %mask, half %passthru)
+  ret half %res
+}
+
+define bfloat @extract_last_active_unpacked_fp_nxv4bf16(<vscale x 4 x bfloat> %0, <vscale x 4 x i1> %mask, bfloat %passthru) #0 {
+; CHECK-LABEL: extract_last_active_unpacked_fp_nxv4bf16:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    // kill: def $h1 killed $h1 def $s1
+; CHECK-NEXT:    clastb s1, p0, s1, z0.s
+; CHECK-NEXT:    fmov s0, s1
+; CHECK-NEXT:    ret
+  %res = call bfloat @llvm.experimental.vector.extract.last.active.nxv4bf16(<vscale x 4 x bfloat> %0, <vscale x 4 x i1> %mask, bfloat %passthru)
+  ret bfloat %res
+}
+
+define bfloat @extract_last_active_unpacked_fp_nxv2bf16(<vscale x 2 x bfloat> %0, <vscale x 2 x i1> %mask, bfloat %passthru) #0 {
+; CHECK-LABEL: extract_last_active_unpacked_fp_nxv2bf16:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    // kill: def $h1 killed $h1 def $d1
+; CHECK-NEXT:    clastb d1, p0, d1, z0.d
+; CHECK-NEXT:    fmov s0, s1
+; CHECK-NEXT:    ret
+  %res = call bfloat @llvm.experimental.vector.extract.last.active.nxv2bf16(<vscale x 2 x bfloat> %0, <vscale x 2 x i1> %mask, bfloat %passthru)
+  ret bfloat %res
+}
+
+define float @extract_last_active_unpacked_fp_nxv2f32(<vscale x 2 x float> %0, <vscale x 2 x i1> %mask, float %passthru) #0 {
+; CHECK-LABEL: extract_last_active_unpacked_fp_nxv2f32:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    // kill: def $s1 killed $s1 def $d1
+; CHECK-NEXT:    clastb d1, p0, d1, z0.d
+; CHECK-NEXT:    fmov s0, s1
+; CHECK-NEXT:    ret
+  %res = call float @llvm.experimental.vector.extract.last.active.nxv2f32(<vscale x 2 x float> %0, <vscale x 2 x i1> %mask, float %passthru)
+  ret float %res
+}
+
 attributes #0 = { nounwind "target-features"="+sve" vscale_range(1, 16) }


### PR DESCRIPTION
Add support for selecting clastb for unpacked float, half, and
bfloat vectors.

Fixes #185670.
