### PR TITLE
AMDGPU: Document two more in-flight address spaces

### DIFF
--- a/llvm/docs/AMDGPUUsage.rst
+++ b/llvm/docs/AMDGPUUsage.rst
@@ -910,6 +910,8 @@ supported for the ``amdgcn`` target.
      *reserved for future use*             10
      *reserved for future use*             11
      *reserved for downstream use (LLPC)*  12
+     *reserved for future use*             13
+     *reserved for future use*             14
      Streamout Registers                   128             N/A         GS_REGS
      ===================================== =============== =========== ================ ======= ============================
 


### PR DESCRIPTION
There are two more address spaces being worked on internally for
future features. Note this in the documentation now to reduce the risk
of clashes.