### PR TITLE
[clang-doc] Add individual target for unit tests

### DIFF
--- a/clang-tools-extra/test/CMakeLists.txt
+++ b/clang-tools-extra/test/CMakeLists.txt
@@ -90,4 +90,10 @@ add_lit_testsuites(CLANG-EXTRA ${CMAKE_CURRENT_SOURCE_DIR}
    SKIP "^clang-doc"
   )
 
+add_lit_testsuite(check-clang-doc-unit "Running clang-doc unit tests"
+  ${CMAKE_CURRENT_BINARY_DIR}/Unit
+  EXCLUDE_FROM_CHECK_ALL
+  ARGS --filter=ClangDocTests
+  )
+
 add_subdirectory(clang-doc)

--- a/clang-tools-extra/test/CMakeLists.txt
+++ b/clang-tools-extra/test/CMakeLists.txt
@@ -21,13 +21,6 @@ configure_lit_site_cfg(
   ${CMAKE_CURRENT_SOURCE_DIR}/lit.cfg.py
   )
 
-configure_lit_site_cfg(
-  ${CMAKE_CURRENT_SOURCE_DIR}/Unit/lit.site.cfg.py.in
-  ${CMAKE_CURRENT_BINARY_DIR}/Unit/lit.site.cfg.py
-  MAIN_CONFIG
-  ${CMAKE_CURRENT_SOURCE_DIR}/Unit/lit.cfg.py
-  )
-
 set(CLANG_TOOLS_TEST_DEPS
   # For the clang-doc tests that emit bitcode files.
   llvm-bcanalyzer
@@ -90,10 +83,5 @@ add_lit_testsuites(CLANG-EXTRA ${CMAKE_CURRENT_SOURCE_DIR}
    SKIP "^clang-doc"
   )
 
-add_lit_testsuite(check-clang-doc-unit "Running clang-doc unit tests"
-  ${CMAKE_CURRENT_BINARY_DIR}/Unit
-  EXCLUDE_FROM_CHECK_ALL
-  ARGS --filter=ClangDocTests
-  )
-
 add_subdirectory(clang-doc)
+add_subdirectory(Unit)

--- a/clang-tools-extra/test/Unit/CMakeLists.txt
+++ b/clang-tools-extra/test/Unit/CMakeLists.txt
@@ -1,0 +1,12 @@
+configure_lit_site_cfg(
+  ${CMAKE_CURRENT_SOURCE_DIR}/lit.site.cfg.py.in
+  ${CMAKE_CURRENT_BINARY_DIR}/lit.site.cfg.py
+  MAIN_CONFIG
+  ${CMAKE_CURRENT_SOURCE_DIR}/lit.cfg.py
+  )
+
+add_lit_testsuite(check-clang-doc-unit "Running clang-doc unit tests"
+  ${CMAKE_CURRENT_BINARY_DIR}
+  EXCLUDE_FROM_CHECK_ALL
+  ARGS --filter=ClangDocTests
+  )


### PR DESCRIPTION
clang-doc unit tests are packaged in a target that contains all other
tools' unit tests so filter to only run clang-doc tests
