### PR TITLE
[SPIRV] Lower load/store atomic to OpAtomicLoad/OpAtomicStore

### DIFF
--- a/llvm/include/llvm/IR/IntrinsicsSPIRV.td
+++ b/llvm/include/llvm/IR/IntrinsicsSPIRV.td
@@ -24,8 +24,8 @@ let TargetPrefix = "spv" in {
   def int_spv_unref_global : Intrinsic<[], [llvm_any_ty]>;
 
   def int_spv_gep : Intrinsic<[llvm_any_ty], [llvm_i1_ty, llvm_any_ty, llvm_vararg_ty], [ImmArg<ArgIndex<0>>]>;
-  def int_spv_load : Intrinsic<[llvm_i32_ty], [llvm_anyptr_ty, llvm_i16_ty, llvm_i32_ty], [ImmArg<ArgIndex<1>>, ImmArg<ArgIndex<2>>]>;
-  def int_spv_store : Intrinsic<[], [llvm_any_ty, llvm_anyptr_ty, llvm_i16_ty, llvm_i32_ty], [ImmArg<ArgIndex<2>>, ImmArg<ArgIndex<3>>]>;
+  def int_spv_load : Intrinsic<[llvm_i32_ty], [llvm_anyptr_ty, llvm_i16_ty, llvm_i32_ty, llvm_i8_ty], [ImmArg<ArgIndex<1>>, ImmArg<ArgIndex<2>>, ImmArg<ArgIndex<3>>]>;
+  def int_spv_store : Intrinsic<[], [llvm_any_ty, llvm_anyptr_ty, llvm_i16_ty, llvm_i32_ty, llvm_i8_ty], [ImmArg<ArgIndex<2>>, ImmArg<ArgIndex<3>>, ImmArg<ArgIndex<4>>]>;
   def int_spv_extractv : Intrinsic<[llvm_any_ty], [llvm_i32_ty, llvm_vararg_ty]>;
   def int_spv_insertv : Intrinsic<[llvm_i32_ty], [llvm_i32_ty, llvm_any_ty, llvm_vararg_ty]>;
   def int_spv_extractelt : Intrinsic<[llvm_any_ty], [llvm_any_ty, llvm_anyint_ty]>;

--- a/llvm/include/llvm/IR/IntrinsicsSPIRV.td
+++ b/llvm/include/llvm/IR/IntrinsicsSPIRV.td
@@ -24,8 +24,10 @@ let TargetPrefix = "spv" in {
   def int_spv_unref_global : Intrinsic<[], [llvm_any_ty]>;
 
   def int_spv_gep : Intrinsic<[llvm_any_ty], [llvm_i1_ty, llvm_any_ty, llvm_vararg_ty], [ImmArg<ArgIndex<0>>]>;
-  def int_spv_load : Intrinsic<[llvm_i32_ty], [llvm_anyptr_ty, llvm_i16_ty, llvm_i32_ty, llvm_i8_ty], [ImmArg<ArgIndex<1>>, ImmArg<ArgIndex<2>>, ImmArg<ArgIndex<3>>]>;
-  def int_spv_store : Intrinsic<[], [llvm_any_ty, llvm_anyptr_ty, llvm_i16_ty, llvm_i32_ty, llvm_i8_ty], [ImmArg<ArgIndex<2>>, ImmArg<ArgIndex<3>>, ImmArg<ArgIndex<4>>]>;
+  def int_spv_load : Intrinsic<[llvm_i32_ty], [llvm_anyptr_ty, llvm_i16_ty, llvm_i32_ty], [ImmArg<ArgIndex<1>>, ImmArg<ArgIndex<2>>]>;
+  def int_spv_atomic_load : Intrinsic<[llvm_i32_ty], [llvm_anyptr_ty, llvm_i16_ty, llvm_i8_ty], [ImmArg<ArgIndex<1>>, ImmArg<ArgIndex<2>>]>;
+  def int_spv_store : Intrinsic<[], [llvm_any_ty, llvm_anyptr_ty, llvm_i16_ty, llvm_i32_ty], [ImmArg<ArgIndex<2>>, ImmArg<ArgIndex<3>>]>;
+  def int_spv_atomic_store : Intrinsic<[], [llvm_any_ty, llvm_anyptr_ty, llvm_i16_ty, llvm_i8_ty], [ImmArg<ArgIndex<2>>, ImmArg<ArgIndex<3>>]>;
   def int_spv_extractv : Intrinsic<[llvm_any_ty], [llvm_i32_ty, llvm_vararg_ty]>;
   def int_spv_insertv : Intrinsic<[llvm_i32_ty], [llvm_i32_ty, llvm_any_ty, llvm_vararg_ty]>;
   def int_spv_extractelt : Intrinsic<[llvm_any_ty], [llvm_any_ty, llvm_anyint_ty]>;

--- a/llvm/lib/Target/SPIRV/SPIRVEmitIntrinsics.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVEmitIntrinsics.cpp
@@ -2574,14 +2574,8 @@ bool SPIRVEmitIntrinsics::shouldTryToAddMemAliasingDecoration(
   // Add aliasing decorations to internal load and store intrinsics
   // and atomic instructions, skipping atomic store as it won't have ID to
   // attach the decoration.
-  if (match(Inst, m_AnyIntrinsic<Intrinsic::spv_load, Intrinsic::spv_store,
-                                 Intrinsic::spv_atomic_load>()))
+  if (match(Inst, m_AnyIntrinsic<Intrinsic::spv_load, Intrinsic::spv_store>()))
     return true;
-
-  if (LoadInst *L = dyn_cast<LoadInst>(Inst)) {
-    if (L->isAtomic())
-      return true;
-  }
 
   auto *CI = dyn_cast<CallInst>(Inst);
   if (!CI)

--- a/llvm/lib/Target/SPIRV/SPIRVEmitIntrinsics.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVEmitIntrinsics.cpp
@@ -2239,7 +2239,8 @@ Instruction *SPIRVEmitIntrinsics::visitLoadInst(LoadInst &I) {
   auto *NewI =
       B.CreateIntrinsic(Intrinsic::spv_load, {I.getOperand(0)->getType()},
                         {I.getPointerOperand(), B.getInt16(Flags),
-                         B.getInt32(I.getAlign().value())});
+                         B.getInt32(I.getAlign().value()),
+                         B.getInt8(static_cast<uint8_t>(I.getOrdering()))});
   replaceMemInstrUses(&I, NewI, B);
   return NewI;
 }
@@ -2270,7 +2271,8 @@ Instruction *SPIRVEmitIntrinsics::visitStoreInst(StoreInst &I) {
   auto *NewI = B.CreateIntrinsic(
       Intrinsic::spv_store, {I.getValueOperand()->getType(), PtrOp->getType()},
       {I.getValueOperand(), PtrOp, B.getInt16(Flags),
-       B.getInt32(I.getAlign().value())});
+       B.getInt32(I.getAlign().value()),
+       B.getInt8(static_cast<uint8_t>(I.getOrdering()))});
   NewI->copyMetadata(I);
   I.eraseFromParent();
   return NewI;

--- a/llvm/lib/Target/SPIRV/SPIRVEmitIntrinsics.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVEmitIntrinsics.cpp
@@ -2575,9 +2575,14 @@ bool SPIRVEmitIntrinsics::shouldTryToAddMemAliasingDecoration(
   // and atomic instructions, skipping atomic store as it won't have ID to
   // attach the decoration.
   if (match(Inst, m_AnyIntrinsic<Intrinsic::spv_load, Intrinsic::spv_store,
-                                 Intrinsic::spv_atomic_load,
-                                 Intrinsic::spv_atomic_store>()))
+                                 Intrinsic::spv_atomic_load>()))
     return true;
+
+  if (LoadInst *L = dyn_cast<LoadInst>(Inst)) {
+    if (L->isAtomic())
+      return true;
+  }
+
   auto *CI = dyn_cast<CallInst>(Inst);
   if (!CI)
     return false;

--- a/llvm/lib/Target/SPIRV/SPIRVEmitIntrinsics.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVEmitIntrinsics.cpp
@@ -2576,7 +2576,6 @@ bool SPIRVEmitIntrinsics::shouldTryToAddMemAliasingDecoration(
   // attach the decoration.
   if (match(Inst, m_AnyIntrinsic<Intrinsic::spv_load, Intrinsic::spv_store>()))
     return true;
-
   auto *CI = dyn_cast<CallInst>(Inst);
   if (!CI)
     return false;

--- a/llvm/lib/Target/SPIRV/SPIRVEmitIntrinsics.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVEmitIntrinsics.cpp
@@ -2236,11 +2236,19 @@ Instruction *SPIRVEmitIntrinsics::visitLoadInst(LoadInst &I) {
   const auto *TLI = TM.getSubtargetImpl()->getTargetLowering();
   MachineMemOperand::Flags Flags =
       TLI->getLoadMemOperandFlags(I, CurrF->getDataLayout());
-  auto *NewI =
-      B.CreateIntrinsic(Intrinsic::spv_load, {I.getOperand(0)->getType()},
-                        {I.getPointerOperand(), B.getInt16(Flags),
-                         B.getInt32(I.getAlign().value()),
-                         B.getInt8(static_cast<uint8_t>(I.getOrdering()))});
+
+  unsigned IntrinsicId;
+  SmallVector<Value *, 4> Args = {I.getPointerOperand(), B.getInt16(Flags)};
+  if (!I.isAtomic()) {
+    IntrinsicId = Intrinsic::spv_load;
+    Args.push_back(B.getInt32(I.getAlign().value()));
+  } else {
+    IntrinsicId = Intrinsic::spv_atomic_load;
+    Args.push_back(B.getInt8(static_cast<uint8_t>(I.getOrdering())));
+  }
+  CallInst *NewI =
+      B.CreateIntrinsic(IntrinsicId, {I.getOperand(0)->getType()}, Args);
+
   replaceMemInstrUses(&I, NewI, B);
   return NewI;
 }
@@ -2268,11 +2276,18 @@ Instruction *SPIRVEmitIntrinsics::visitStoreInst(StoreInst &I) {
     CB->mutateType(B.getInt32Ty());
   }
 
+  unsigned IntrinsicId;
+  SmallVector<Value *, 4> Args = {I.getValueOperand(), PtrOp,
+                                  B.getInt16(Flags)};
+  if (!I.isAtomic()) {
+    IntrinsicId = Intrinsic::spv_store;
+    Args.push_back(B.getInt32(I.getAlign().value()));
+  } else {
+    IntrinsicId = Intrinsic::spv_atomic_store;
+    Args.push_back(B.getInt8(static_cast<uint8_t>(I.getOrdering())));
+  }
   auto *NewI = B.CreateIntrinsic(
-      Intrinsic::spv_store, {I.getValueOperand()->getType(), PtrOp->getType()},
-      {I.getValueOperand(), PtrOp, B.getInt16(Flags),
-       B.getInt32(I.getAlign().value()),
-       B.getInt8(static_cast<uint8_t>(I.getOrdering()))});
+      IntrinsicId, {I.getValueOperand()->getType(), PtrOp->getType()}, Args);
   NewI->copyMetadata(I);
   I.eraseFromParent();
   return NewI;
@@ -2559,7 +2574,9 @@ bool SPIRVEmitIntrinsics::shouldTryToAddMemAliasingDecoration(
   // Add aliasing decorations to internal load and store intrinsics
   // and atomic instructions, skipping atomic store as it won't have ID to
   // attach the decoration.
-  if (match(Inst, m_AnyIntrinsic<Intrinsic::spv_load, Intrinsic::spv_store>()))
+  if (match(Inst, m_AnyIntrinsic<Intrinsic::spv_load, Intrinsic::spv_store,
+                                 Intrinsic::spv_atomic_load,
+                                 Intrinsic::spv_atomic_store>()))
     return true;
   auto *CI = dyn_cast<CallInst>(Inst);
   if (!CI)

--- a/llvm/lib/Target/SPIRV/SPIRVISelLowering.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVISelLowering.cpp
@@ -115,15 +115,15 @@ void SPIRVTargetLowering::getTgtMemIntrinsic(
     AlignIdx = 2;
     [[fallthrough]];
   case Intrinsic::spv_store: {
-    if (I.getNumOperands() >= AlignIdx + 1) {
-      auto *AlignOp = cast<ConstantInt>(I.getOperand(AlignIdx));
-      Info.align = Align(AlignOp->getZExtValue());
-    }
+    auto *AlignOp = cast<ConstantInt>(I.getOperand(AlignIdx));
+    Info.align = Align(AlignOp->getZExtValue());
     Info.flags = static_cast<MachineMemOperand::Flags>(
         cast<ConstantInt>(I.getOperand(AlignIdx - 1))->getZExtValue());
     Info.memVT = MVT::i64;
     // TODO: take into account opaque pointers (don't use getElementType).
     // MVT::getVT(PtrTy->getElementType());
+    Info.order = static_cast<AtomicOrdering>(
+        cast<ConstantInt>(I.getOperand(AlignIdx + 1))->getZExtValue());
     Infos.push_back(Info);
     return;
   }

--- a/llvm/lib/Target/SPIRV/SPIRVISelLowering.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVISelLowering.cpp
@@ -110,8 +110,8 @@ void SPIRVTargetLowering::getTgtMemIntrinsic(
     MachineFunction &MF, unsigned Intrinsic) const {
   IntrinsicInfo Info;
 
-  unsigned AlignIdx = -1;
-  unsigned OrderingIdx = -1;
+  unsigned AlignIdx = 0;
+  unsigned OrderingIdx = 0;
   unsigned FlagsIdx;
 
   switch (Intrinsic) {
@@ -141,12 +141,12 @@ void SPIRVTargetLowering::getTgtMemIntrinsic(
   // TODO: take into account opaque pointers (don't use getElementType).
   // MVT::getVT(PtrTy->getElementType());
 
-  if (AlignIdx != -1) {
+  if (AlignIdx) {
     auto *AlignOp = cast<ConstantInt>(I.getOperand(AlignIdx));
     Info.align = Align(AlignOp->getZExtValue());
   }
 
-  if (OrderingIdx != -1) {
+  if (OrderingIdx) {
     Info.order = static_cast<AtomicOrdering>(
         cast<ConstantInt>(I.getOperand(OrderingIdx))->getZExtValue());
   }

--- a/llvm/lib/Target/SPIRV/SPIRVISelLowering.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVISelLowering.cpp
@@ -109,27 +109,48 @@ void SPIRVTargetLowering::getTgtMemIntrinsic(
     SmallVectorImpl<IntrinsicInfo> &Infos, const CallBase &I,
     MachineFunction &MF, unsigned Intrinsic) const {
   IntrinsicInfo Info;
-  unsigned AlignIdx = 3;
+
+  unsigned AlignIdx = -1;
+  unsigned OrderingIdx = -1;
+  unsigned FlagsIdx;
+
   switch (Intrinsic) {
   case Intrinsic::spv_load:
+    FlagsIdx = 1;
     AlignIdx = 2;
-    [[fallthrough]];
-  case Intrinsic::spv_store: {
-    auto *AlignOp = cast<ConstantInt>(I.getOperand(AlignIdx));
-    Info.align = Align(AlignOp->getZExtValue());
-    Info.flags = static_cast<MachineMemOperand::Flags>(
-        cast<ConstantInt>(I.getOperand(AlignIdx - 1))->getZExtValue());
-    Info.memVT = MVT::i64;
-    // TODO: take into account opaque pointers (don't use getElementType).
-    // MVT::getVT(PtrTy->getElementType());
-    Info.order = static_cast<AtomicOrdering>(
-        cast<ConstantInt>(I.getOperand(AlignIdx + 1))->getZExtValue());
-    Infos.push_back(Info);
+    break;
+  case Intrinsic::spv_store:
+    FlagsIdx = 2;
+    AlignIdx = 3;
+    break;
+  case Intrinsic::spv_atomic_load:
+    FlagsIdx = 1;
+    OrderingIdx = 2;
+    break;
+  case Intrinsic::spv_atomic_store:
+    FlagsIdx = 2;
+    OrderingIdx = 3;
+    break;
+  default:
     return;
   }
-  default:
-    break;
+
+  Info.flags = static_cast<MachineMemOperand::Flags>(
+      cast<ConstantInt>(I.getOperand(FlagsIdx))->getZExtValue());
+  Info.memVT = MVT::i64;
+  // TODO: take into account opaque pointers (don't use getElementType).
+  // MVT::getVT(PtrTy->getElementType());
+
+  if (AlignIdx != -1) {
+    auto *AlignOp = cast<ConstantInt>(I.getOperand(AlignIdx));
+    Info.align = Align(AlignOp->getZExtValue());
   }
+
+  if (OrderingIdx != -1) {
+    Info.order = static_cast<AtomicOrdering>(
+        cast<ConstantInt>(I.getOperand(OrderingIdx))->getZExtValue());
+  }
+  Infos.push_back(Info);
 }
 
 TargetLowering::ConstraintType

--- a/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
@@ -1938,6 +1938,7 @@ bool SPIRVInstructionSelector::selectAtomicLoad(Register ResVReg,
                                "Lowering to SPIR-V of atomic load is only "
                                "allowed for integer or floating point types");
 
+  assert(I.getNumMemOperands());
   const MachineMemOperand &MemOp = **I.memoperands_begin();
   assert(MemOp.isAtomic());
   // TODO: This must be relaxed since the volatile attribute on atomic load is

--- a/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
@@ -1934,16 +1934,17 @@ bool SPIRVInstructionSelector::selectAtomicLoad(Register ResVReg,
   Register Ptr = I.getOperand(1 + OpOffset).getReg();
 
   if (!ResType.isTypeIntOrFloat())
-    return diagnoseUnsupported(
-        I, "atomic load is only allowed for integer or floating point types");
+    return diagnoseUnsupported(I,
+                               "Lowering to SPIR-V of atomic load is only "
+                               "allowed for integer or floating point types");
 
   const MachineMemOperand &MemOp = **I.memoperands_begin();
   assert(MemOp.isAtomic());
-  // This could be relaxed since the volatile attribute on atomic load is
+  // TODO: This must be relaxed since the volatile attribute on atomic load is
   // supported with the VulkanMemoryModelKHR capability.
   if (MemOp.isVolatile())
-    return diagnoseUnsupported(
-        I, "atomic load of volatile memory is not supported");
+    return diagnoseUnsupported(I, "Lowering to SPIR-V of atomic load of "
+                                  "volatile memory is not supported");
 
   uint32_t Scope =
       static_cast<uint32_t>(getMemScope(Context, MemOp.getSyncScopeID()));
@@ -2029,17 +2030,18 @@ bool SPIRVInstructionSelector::selectAtomicStore(MachineInstr &I) const {
   SPIRVTypeInst PtrType = GR.getSPIRVTypeForVReg(Ptr);
   SPIRVTypeInst PointeeType = GR.getPointeeType(PtrType);
   if (!PointeeType.isTypeIntOrFloat())
-    return diagnoseUnsupported(
-        I, "atomic store is only allowed for integer or floating point types");
+    return diagnoseUnsupported(I,
+                               "Lowering to SPIR-V of atomic store is only "
+                               "allowed for integer or floating point types");
 
   const MachineMemOperand &MemOp = **I.memoperands_begin();
   assert(MemOp.isAtomic());
 
-  // This could be relaxed since the volatile attribute on atomic store is
+  // TODO: This must be relaxed since the volatile attribute on atomic store is
   // supported with the VulkanMemoryModelKHR capability.
   if (MemOp.isVolatile())
-    return diagnoseUnsupported(
-        I, "atomic store of volatile memory is not supported");
+    return diagnoseUnsupported(I, "Lowering to SPIR-V of atomic store of "
+                                  "volatile memory is not supported");
 
   uint32_t Scope =
       static_cast<uint32_t>(getMemScope(Context, MemOp.getSyncScopeID()));

--- a/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
@@ -1952,8 +1952,10 @@ bool SPIRVInstructionSelector::selectAtomicLoad(Register ResVReg,
   Register ScopeReg = buildI32Constant(Scope, I);
 
   AtomicOrdering AO = MemOp.getSuccessOrdering();
+  uint32_t StorageClass = static_cast<uint32_t>(getMemSemanticsForStorageClass(
+      addressSpaceToStorageClass(MemOp.getAddrSpace(), STI)));
   uint32_t MemSem = static_cast<uint32_t>(getMemSemantics(AO));
-  Register MemSemReg = buildI32Constant(MemSem, I);
+  Register MemSemReg = buildI32Constant(MemSem | StorageClass, I);
 
   MachineIRBuilder MIRBuilder(I);
   auto AtomicLoad = MIRBuilder.buildInstr(SPIRV::OpAtomicLoad)
@@ -2050,8 +2052,10 @@ bool SPIRVInstructionSelector::selectAtomicStore(MachineInstr &I) const {
   Register ScopeReg = buildI32Constant(Scope, I);
 
   AtomicOrdering AO = MemOp.getSuccessOrdering();
+  uint32_t StorageClass = static_cast<uint32_t>(getMemSemanticsForStorageClass(
+      addressSpaceToStorageClass(MemOp.getAddrSpace(), STI)));
   uint32_t MemSem = static_cast<uint32_t>(getMemSemantics(AO));
-  Register MemSemReg = buildI32Constant(MemSem, I);
+  Register MemSemReg = buildI32Constant(MemSem | StorageClass, I);
 
   MachineIRBuilder MIRBuilder(I);
   auto AtomicStore = MIRBuilder.buildInstr(SPIRV::OpAtomicStore)

--- a/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
@@ -160,7 +160,13 @@ private:
 
   bool selectLoad(Register ResVReg, SPIRVTypeInst ResType,
                   MachineInstr &I) const;
+  bool selectAtomicLoad(Register ResVReg, SPIRVTypeInst ResType, Register Ptr,
+                        const MachineMemOperand &MemOp,
+                        MachineIRBuilder &MIRBuilder, MachineInstr &L) const;
   bool selectStore(MachineInstr &I) const;
+  bool selectAtomicStore(Register StoreVal, Register Ptr,
+                         const MachineMemOperand &MemOp,
+                         MachineIRBuilder &MIRBuilder, MachineInstr &S) const;
 
   bool selectStackSave(Register ResVReg, SPIRVTypeInst ResType,
                        MachineInstr &I) const;
@@ -1898,7 +1904,15 @@ bool SPIRVInstructionSelector::selectLoad(Register ResVReg,
     }
   }
 
-  auto MIB = BuildMI(*I.getParent(), I, I.getDebugLoc(), TII.get(SPIRV::OpLoad))
+  MachineIRBuilder MIRBuilder(I);
+
+  if (I.getNumMemOperands()) {
+    const MachineMemOperand *MemOp = *I.memoperands_begin();
+    if (MemOp->isAtomic())
+      return selectAtomicLoad(ResVReg, ResType, Ptr, *MemOp, MIRBuilder, I);
+  }
+
+  auto MIB = MIRBuilder.buildInstr(SPIRV::OpLoad)
                  .addDef(ResVReg)
                  .addUse(GR.getSPIRVTypeID(ResType))
                  .addUse(Ptr);
@@ -1908,10 +1922,45 @@ bool SPIRVInstructionSelector::selectLoad(Register ResVReg,
                TargetOpcode::G_INTRINSIC_CONVERGENT_W_SIDE_EFFECTS);
     addMemoryOperands(I.getOperand(2 + OpOffset).getImm(), MIB);
   } else {
-    MachineIRBuilder MIRBuilder(I);
     addMemoryOperands(*I.memoperands_begin(), MIB, MIRBuilder, GR);
   }
   MIB.constrainAllUses(TII, TRI, RBI);
+  return true;
+}
+
+bool SPIRVInstructionSelector::selectAtomicLoad(Register ResVReg,
+                                                SPIRVTypeInst ResType,
+                                                Register Ptr,
+                                                const MachineMemOperand &MemOp,
+                                                MachineIRBuilder &MIRBuilder,
+                                                MachineInstr &L) const {
+  LLVMContext &Context = L.getMF()->getFunction().getContext();
+
+  if (!ResType.isTypeIntOrFloat())
+    return diagnoseUnsupported(
+        L, "atomic load is only allowed for integer or floating point types");
+
+  // This could be relaxed since the volatile attribute on atomic load is
+  // supported with the VulkanMemoryModelKHR capability.
+  if (MemOp.isVolatile())
+    return diagnoseUnsupported(
+        L, "atomic load of volatile memory is not supported");
+
+  uint32_t Scope =
+      static_cast<uint32_t>(getMemScope(Context, MemOp.getSyncScopeID()));
+  Register ScopeReg = buildI32Constant(Scope, L);
+
+  AtomicOrdering AO = MemOp.getSuccessOrdering();
+  uint32_t MemSem = static_cast<uint32_t>(getMemSemantics(AO));
+  Register MemSemReg = buildI32Constant(MemSem, L);
+
+  auto AtomicLoad = MIRBuilder.buildInstr(SPIRV::OpAtomicLoad)
+                        .addDef(ResVReg)
+                        .addUse(GR.getSPIRVTypeID(ResType))
+                        .addUse(Ptr)
+                        .addUse(ScopeReg)
+                        .addUse(MemSemReg);
+  AtomicLoad.constrainAllUses(TII, TRI, RBI);
   return true;
 }
 
@@ -1950,20 +1999,60 @@ bool SPIRVInstructionSelector::selectStore(MachineInstr &I) const {
     }
   }
 
-  MachineBasicBlock &BB = *I.getParent();
-  auto MIB = BuildMI(BB, I, I.getDebugLoc(), TII.get(SPIRV::OpStore))
-                 .addUse(Ptr)
-                 .addUse(StoreVal);
+  MachineIRBuilder MIRBuilder(I);
+
+  if (I.getNumMemOperands()) {
+    const MachineMemOperand *MemOp = *I.memoperands_begin();
+    if (MemOp->isAtomic())
+      return selectAtomicStore(StoreVal, Ptr, *MemOp, MIRBuilder, I);
+  }
+
+  auto MIB = MIRBuilder.buildInstr(SPIRV::OpStore).addUse(Ptr).addUse(StoreVal);
   if (!I.getNumMemOperands()) {
     assert(I.getOpcode() == TargetOpcode::G_INTRINSIC_W_SIDE_EFFECTS ||
            I.getOpcode() ==
                TargetOpcode::G_INTRINSIC_CONVERGENT_W_SIDE_EFFECTS);
     addMemoryOperands(I.getOperand(2 + OpOffset).getImm(), MIB);
   } else {
-    MachineIRBuilder MIRBuilder(I);
     addMemoryOperands(*I.memoperands_begin(), MIB, MIRBuilder, GR);
   }
   MIB.constrainAllUses(TII, TRI, RBI);
+  return true;
+}
+
+bool SPIRVInstructionSelector::selectAtomicStore(Register StoreVal,
+                                                 Register Ptr,
+                                                 const MachineMemOperand &MemOp,
+                                                 MachineIRBuilder &MIRBuilder,
+                                                 MachineInstr &S) const {
+  LLVMContext &Context = S.getMF()->getFunction().getContext();
+
+  SPIRVTypeInst PtrType = GR.getSPIRVTypeForVReg(Ptr);
+  SPIRVTypeInst PointeeType = GR.getPointeeType(PtrType);
+  if (!PointeeType.isTypeIntOrFloat())
+    return diagnoseUnsupported(
+        S, "atomic store is only allowed for integer or floating point types");
+
+  // This could be relaxed since the volatile attribute on atomic store is
+  // supported with the VulkanMemoryModelKHR capability.
+  if (MemOp.isVolatile())
+    return diagnoseUnsupported(
+        S, "atomic store of volatile memory is not supported");
+
+  uint32_t Scope =
+      static_cast<uint32_t>(getMemScope(Context, MemOp.getSyncScopeID()));
+  Register ScopeReg = buildI32Constant(Scope, S);
+
+  AtomicOrdering AO = MemOp.getSuccessOrdering();
+  uint32_t MemSem = static_cast<uint32_t>(getMemSemantics(AO));
+  Register MemSemReg = buildI32Constant(MemSem, S);
+
+  auto AtomicStore = MIRBuilder.buildInstr(SPIRV::OpAtomicStore)
+                         .addUse(Ptr)
+                         .addUse(ScopeReg)
+                         .addUse(MemSemReg)
+                         .addUse(StoreVal);
+  AtomicStore.constrainAllUses(TII, TRI, RBI);
   return true;
 }
 

--- a/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
@@ -160,13 +160,10 @@ private:
 
   bool selectLoad(Register ResVReg, SPIRVTypeInst ResType,
                   MachineInstr &I) const;
-  bool selectAtomicLoad(Register ResVReg, SPIRVTypeInst ResType, Register Ptr,
-                        const MachineMemOperand &MemOp,
-                        MachineIRBuilder &MIRBuilder, MachineInstr &L) const;
+  bool selectAtomicLoad(Register ResVReg, SPIRVTypeInst ResType,
+                        MachineInstr &I) const;
   bool selectStore(MachineInstr &I) const;
-  bool selectAtomicStore(Register StoreVal, Register Ptr,
-                         const MachineMemOperand &MemOp,
-                         MachineIRBuilder &MIRBuilder, MachineInstr &S) const;
+  bool selectAtomicStore(MachineInstr &I) const;
 
   bool selectStackSave(Register ResVReg, SPIRVTypeInst ResType,
                        MachineInstr &I) const;
@@ -1909,7 +1906,7 @@ bool SPIRVInstructionSelector::selectLoad(Register ResVReg,
   if (I.getNumMemOperands()) {
     const MachineMemOperand *MemOp = *I.memoperands_begin();
     if (MemOp->isAtomic())
-      return selectAtomicLoad(ResVReg, ResType, Ptr, *MemOp, MIRBuilder, I);
+      return selectAtomicLoad(ResVReg, ResType, I);
   }
 
   auto MIB = MIRBuilder.buildInstr(SPIRV::OpLoad)
@@ -1930,30 +1927,33 @@ bool SPIRVInstructionSelector::selectLoad(Register ResVReg,
 
 bool SPIRVInstructionSelector::selectAtomicLoad(Register ResVReg,
                                                 SPIRVTypeInst ResType,
-                                                Register Ptr,
-                                                const MachineMemOperand &MemOp,
-                                                MachineIRBuilder &MIRBuilder,
-                                                MachineInstr &L) const {
-  LLVMContext &Context = L.getMF()->getFunction().getContext();
+                                                MachineInstr &I) const {
+  LLVMContext &Context = I.getMF()->getFunction().getContext();
+
+  unsigned OpOffset = isa<GIntrinsic>(I) ? 1 : 0;
+  Register Ptr = I.getOperand(1 + OpOffset).getReg();
 
   if (!ResType.isTypeIntOrFloat())
     return diagnoseUnsupported(
-        L, "atomic load is only allowed for integer or floating point types");
+        I, "atomic load is only allowed for integer or floating point types");
 
+  const MachineMemOperand &MemOp = **I.memoperands_begin();
+  assert(MemOp.isAtomic());
   // This could be relaxed since the volatile attribute on atomic load is
   // supported with the VulkanMemoryModelKHR capability.
   if (MemOp.isVolatile())
     return diagnoseUnsupported(
-        L, "atomic load of volatile memory is not supported");
+        I, "atomic load of volatile memory is not supported");
 
   uint32_t Scope =
       static_cast<uint32_t>(getMemScope(Context, MemOp.getSyncScopeID()));
-  Register ScopeReg = buildI32Constant(Scope, L);
+  Register ScopeReg = buildI32Constant(Scope, I);
 
   AtomicOrdering AO = MemOp.getSuccessOrdering();
   uint32_t MemSem = static_cast<uint32_t>(getMemSemantics(AO));
-  Register MemSemReg = buildI32Constant(MemSem, L);
+  Register MemSemReg = buildI32Constant(MemSem, I);
 
+  MachineIRBuilder MIRBuilder(I);
   auto AtomicLoad = MIRBuilder.buildInstr(SPIRV::OpAtomicLoad)
                         .addDef(ResVReg)
                         .addUse(GR.getSPIRVTypeID(ResType))
@@ -1999,14 +1999,13 @@ bool SPIRVInstructionSelector::selectStore(MachineInstr &I) const {
     }
   }
 
-  MachineIRBuilder MIRBuilder(I);
-
   if (I.getNumMemOperands()) {
     const MachineMemOperand *MemOp = *I.memoperands_begin();
     if (MemOp->isAtomic())
-      return selectAtomicStore(StoreVal, Ptr, *MemOp, MIRBuilder, I);
+      return selectAtomicStore(I);
   }
 
+  MachineIRBuilder MIRBuilder(I);
   auto MIB = MIRBuilder.buildInstr(SPIRV::OpStore).addUse(Ptr).addUse(StoreVal);
   if (!I.getNumMemOperands()) {
     assert(I.getOpcode() == TargetOpcode::G_INTRINSIC_W_SIDE_EFFECTS ||
@@ -2020,33 +2019,37 @@ bool SPIRVInstructionSelector::selectStore(MachineInstr &I) const {
   return true;
 }
 
-bool SPIRVInstructionSelector::selectAtomicStore(Register StoreVal,
-                                                 Register Ptr,
-                                                 const MachineMemOperand &MemOp,
-                                                 MachineIRBuilder &MIRBuilder,
-                                                 MachineInstr &S) const {
-  LLVMContext &Context = S.getMF()->getFunction().getContext();
+bool SPIRVInstructionSelector::selectAtomicStore(MachineInstr &I) const {
+  LLVMContext &Context = I.getMF()->getFunction().getContext();
+
+  unsigned OpOffset = isa<GIntrinsic>(I) ? 1 : 0;
+  Register StoreVal = I.getOperand(0 + OpOffset).getReg();
+  Register Ptr = I.getOperand(1 + OpOffset).getReg();
 
   SPIRVTypeInst PtrType = GR.getSPIRVTypeForVReg(Ptr);
   SPIRVTypeInst PointeeType = GR.getPointeeType(PtrType);
   if (!PointeeType.isTypeIntOrFloat())
     return diagnoseUnsupported(
-        S, "atomic store is only allowed for integer or floating point types");
+        I, "atomic store is only allowed for integer or floating point types");
+
+  const MachineMemOperand &MemOp = **I.memoperands_begin();
+  assert(MemOp.isAtomic());
 
   // This could be relaxed since the volatile attribute on atomic store is
   // supported with the VulkanMemoryModelKHR capability.
   if (MemOp.isVolatile())
     return diagnoseUnsupported(
-        S, "atomic store of volatile memory is not supported");
+        I, "atomic store of volatile memory is not supported");
 
   uint32_t Scope =
       static_cast<uint32_t>(getMemScope(Context, MemOp.getSyncScopeID()));
-  Register ScopeReg = buildI32Constant(Scope, S);
+  Register ScopeReg = buildI32Constant(Scope, I);
 
   AtomicOrdering AO = MemOp.getSuccessOrdering();
   uint32_t MemSem = static_cast<uint32_t>(getMemSemantics(AO));
-  Register MemSemReg = buildI32Constant(MemSem, S);
+  Register MemSemReg = buildI32Constant(MemSem, I);
 
+  MachineIRBuilder MIRBuilder(I);
   auto AtomicStore = MIRBuilder.buildInstr(SPIRV::OpAtomicStore)
                          .addUse(Ptr)
                          .addUse(ScopeReg)
@@ -4514,8 +4517,12 @@ bool SPIRVInstructionSelector::selectIntrinsic(Register ResVReg,
   switch (IID) {
   case Intrinsic::spv_load:
     return selectLoad(ResVReg, ResType, I);
+  case Intrinsic::spv_atomic_load:
+    return selectAtomicLoad(ResVReg, ResType, I);
   case Intrinsic::spv_store:
     return selectStore(I);
+  case Intrinsic::spv_atomic_store:
+    return selectAtomicStore(I);
   case Intrinsic::spv_extractv:
     return selectExtractVal(ResVReg, ResType, I);
   case Intrinsic::spv_insertv:

--- a/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
@@ -2035,6 +2035,7 @@ bool SPIRVInstructionSelector::selectAtomicStore(MachineInstr &I) const {
                                "Lowering to SPIR-V of atomic store is only "
                                "allowed for integer or floating point types");
 
+  assert(I.getNumMemOperands());
   const MachineMemOperand &MemOp = **I.memoperands_begin();
   assert(MemOp.isAtomic());
 

--- a/llvm/lib/Target/SPIRV/SPIRVTypeInst.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVTypeInst.cpp
@@ -14,6 +14,8 @@
 #include "MCTargetDesc/SPIRVMCTargetDesc.h"
 #include "SPIRVInstrInfo.h"
 
+#include "SPIRV.h"
+
 namespace llvm {
 [[maybe_unused]] static bool definesATypeRegister(const MachineInstr &MI) {
   const MachineRegisterInfo &MRI = MI.getMF()->getRegInfo();
@@ -30,6 +32,22 @@ bool SPIRVTypeInst::isTypeIntN(unsigned N) const {
     return false;
   if (N)
     return MI->getOperand(1).getImm() == N;
+  return true;
+}
+
+bool SPIRVTypeInst::isTypeFloat(unsigned Width,
+                                std::optional<unsigned> Encoding) const {
+  if (MI->getOpcode() != SPIRV::OpTypeFloat)
+    return false;
+  if (Width)
+    return MI->getOperand(1).getImm() == Width;
+  if (Encoding) {
+    if (MI->getNumOperands() < 3)
+      return false;
+    const MachineOperand &EO = MI->getOperand(2);
+    assert(EO.isImm() && "Encoding operand must be an immediate");
+    return EO.getImm() == *Encoding;
+  }
   return true;
 }
 } // namespace llvm

--- a/llvm/lib/Target/SPIRV/SPIRVTypeInst.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVTypeInst.cpp
@@ -35,19 +35,7 @@ bool SPIRVTypeInst::isTypeIntN(unsigned N) const {
   return true;
 }
 
-bool SPIRVTypeInst::isTypeFloat(unsigned Width,
-                                std::optional<unsigned> Encoding) const {
-  if (MI->getOpcode() != SPIRV::OpTypeFloat)
-    return false;
-  if (Width)
-    return MI->getOperand(1).getImm() == Width;
-  if (Encoding) {
-    if (MI->getNumOperands() < 3)
-      return false;
-    const MachineOperand &EO = MI->getOperand(2);
-    assert(EO.isImm() && "Encoding operand must be an immediate");
-    return EO.getImm() == *Encoding;
-  }
-  return true;
+bool SPIRVTypeInst::isAnyTypeFloat() const {
+  return MI->getOpcode() == SPIRV::OpTypeFloat;
 }
 } // namespace llvm

--- a/llvm/lib/Target/SPIRV/SPIRVTypeInst.h
+++ b/llvm/lib/Target/SPIRV/SPIRVTypeInst.h
@@ -51,6 +51,14 @@ public:
   // Returns true if this is an OpTypeInt instruction.
   // If N is non-zero, also checks that the bit width matches N.
   bool isTypeIntN(unsigned N = 0) const;
+  // Returns true if this is an OpTypeFloat instruction.
+  // If Width is non-zero, also checks that the bit width matches Width.
+  // If Encoding is set, also checks that the optional
+  // encoding.
+  bool isTypeFloat(unsigned Width = 0,
+                   std::optional<unsigned> Encoding = std::nullopt) const;
+  // Returns true if this is an OpTypeInt or OpTypeFloat instruction.
+  bool isTypeIntOrFloat() const { return isTypeIntN() || isTypeFloat(); }
 
   friend struct DenseMapInfo<SPIRVTypeInst>;
 };

--- a/llvm/lib/Target/SPIRV/SPIRVTypeInst.h
+++ b/llvm/lib/Target/SPIRV/SPIRVTypeInst.h
@@ -52,13 +52,9 @@ public:
   // If N is non-zero, also checks that the bit width matches N.
   bool isTypeIntN(unsigned N = 0) const;
   // Returns true if this is an OpTypeFloat instruction.
-  // If Width is non-zero, also checks that the bit width matches Width.
-  // If Encoding is set, also checks that the optional
-  // encoding.
-  bool isTypeFloat(unsigned Width = 0,
-                   std::optional<unsigned> Encoding = std::nullopt) const;
+  bool isAnyTypeFloat() const;
   // Returns true if this is an OpTypeInt or OpTypeFloat instruction.
-  bool isTypeIntOrFloat() const { return isTypeIntN() || isTypeFloat(); }
+  bool isTypeIntOrFloat() const { return isTypeIntN() || isAnyTypeFloat(); }
 
   friend struct DenseMapInfo<SPIRVTypeInst>;
 };

--- a/llvm/test/CodeGen/SPIRV/extensions/SPV_INTEL_memory_access_aliasing/alias-load-store-atomic.ll
+++ b/llvm/test/CodeGen/SPIRV/extensions/SPV_INTEL_memory_access_aliasing/alias-load-store-atomic.ll
@@ -1,4 +1,5 @@
-; Check aliasing information translation on atomic load and store
+; Check aliasing information translation on atomic load and store.
+; For stores, the decoration is not generated since the store opcodes do not have an id.
 
 ; RUN: llc -O0 -mtriple=spirv64-unknown-unknown -verify-machineinstrs --spirv-ext=+SPV_INTEL_memory_access_aliasing %s -o - | FileCheck %s
 ; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv64-unknown-unknown --spirv-ext=+SPV_INTEL_memory_access_aliasing %s -o - -filetype=obj | spirv-val %}
@@ -8,23 +9,42 @@
 ; CHECK: %[[#Domain1:]] = OpAliasDomainDeclINTEL
 ; CHECK: %[[#Scope1:]] = OpAliasScopeDeclINTEL %[[#Domain1]]
 ; CHECK: %[[#List1:]] = OpAliasScopeListDeclINTEL %[[#Scope1]]
-; CHECK: OpDecorateId %[[#Load:]] NoAliasINTEL %[[#List1]]
-; CHECK: %[[#Load:]] = OpAtomicLoad
+; CHECK: %[[#Domain2:]] = OpAliasDomainDeclINTEL
+; CHECK: %[[#Scope2:]] = OpAliasScopeDeclINTEL %[[#Domain2]]
+; CHECK: %[[#List2:]] = OpAliasScopeListDeclINTEL %[[#Scope2]]
+; CHECK: OpDecorateId %[[#LoadFun:]] NoAliasINTEL %[[#List1]]
+; CHECK: OpDecorateId %[[#LoadInst:]] NoAliasINTEL %[[#List2]]
+; CHECK-NOT: OpDecorateId
+; CHECK: %[[#LoadFun:]] = OpAtomicLoad
+; CHECK: OpAtomicStore
+; CHECK: %[[#LoadInst:]] = OpAtomicLoad
+; CHECK: OpAtomicStore
 
-define spir_func i32 @test_load(ptr addrspace(4) %object) #0 {
+define spir_func i32 @test_load_call(ptr addrspace(4) %object) #0 {
 entry:
   %0 = call spir_func i32 @_Z18__spirv_AtomicLoadPU3AS4iii(ptr addrspace(4) %object, i32 1, i32 16), !noalias !1
   ret i32 %0
 }
 
-declare spir_func i32 @_Z18__spirv_AtomicLoadPU3AS4iii(ptr addrspace(4), i32, i32)
-
-define spir_func void @test_store(ptr addrspace(4) %object, ptr addrspace(4) %expected, i32 %desired) {
+define spir_func void @test_store_call(ptr addrspace(4) %object, i32 %desired) {
 entry:
   call spir_func void @_Z19__spirv_AtomicStorePU3AS4iiii(ptr addrspace(4) %object, i32 1, i32 16, i32 %desired), !noalias !4
   ret void
 }
 
+define spir_func i32 @test_load_instr(ptr addrspace(4) %object) #0 {
+entry:
+  %0 = load atomic i32, ptr addrspace(4) %object syncscope("singlethread") acquire, align 4, !noalias !7
+  ret i32 %0
+}
+
+define spir_func void @test_store_instr(ptr addrspace(4) %object, i32 %desired) {
+entry:
+  store atomic i32 %desired, ptr addrspace(4) %object syncscope("singlethread") release, align 4, !noalias !10
+  ret void
+}
+
+declare spir_func i32 @_Z18__spirv_AtomicLoadPU3AS4iii(ptr addrspace(4), i32, i32)
 declare spir_func void @_Z19__spirv_AtomicStorePU3AS4iiii(ptr addrspace(4), i32, i32, i32)
 
 !1 = !{!2}
@@ -33,3 +53,9 @@ declare spir_func void @_Z19__spirv_AtomicStorePU3AS4iiii(ptr addrspace(4), i32,
 !4 = !{!5}
 !5 = distinct !{!5, !6}
 !6 = distinct !{!6}
+!7 = !{!8}
+!8 = distinct !{!8, !9}
+!9 = distinct !{!9}
+!10 = !{!11}
+!11 = distinct !{!11, !12}
+!12 = distinct !{!12}

--- a/llvm/test/CodeGen/SPIRV/extensions/SPV_INTEL_memory_access_aliasing/alias-load-store-atomic.ll
+++ b/llvm/test/CodeGen/SPIRV/extensions/SPV_INTEL_memory_access_aliasing/alias-load-store-atomic.ll
@@ -1,5 +1,6 @@
 ; Check aliasing information translation on atomic load and store.
 ; For stores, the decoration is not generated since the store opcodes do not have an id.
+; For `load atomic`, the decoration is not generated because we're dropping the extension on atomics.
 
 ; RUN: llc -O0 -mtriple=spirv64-unknown-unknown -verify-machineinstrs --spirv-ext=+SPV_INTEL_memory_access_aliasing %s -o - | FileCheck %s
 ; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv64-unknown-unknown --spirv-ext=+SPV_INTEL_memory_access_aliasing %s -o - -filetype=obj | spirv-val %}
@@ -9,11 +10,7 @@
 ; CHECK: %[[#Domain1:]] = OpAliasDomainDeclINTEL
 ; CHECK: %[[#Scope1:]] = OpAliasScopeDeclINTEL %[[#Domain1]]
 ; CHECK: %[[#List1:]] = OpAliasScopeListDeclINTEL %[[#Scope1]]
-; CHECK: %[[#Domain2:]] = OpAliasDomainDeclINTEL
-; CHECK: %[[#Scope2:]] = OpAliasScopeDeclINTEL %[[#Domain2]]
-; CHECK: %[[#List2:]] = OpAliasScopeListDeclINTEL %[[#Scope2]]
 ; CHECK: OpDecorateId %[[#LoadFun:]] NoAliasINTEL %[[#List1]]
-; CHECK: OpDecorateId %[[#LoadInst:]] NoAliasINTEL %[[#List2]]
 ; CHECK-NOT: OpDecorateId
 ; CHECK: %[[#LoadFun:]] = OpAtomicLoad
 ; CHECK: OpAtomicStore

--- a/llvm/test/CodeGen/SPIRV/transcoding/atomic-load-store-unsupported.ll
+++ b/llvm/test/CodeGen/SPIRV/transcoding/atomic-load-store-unsupported.ll
@@ -1,0 +1,41 @@
+; Verify that atomic load/store of vectors and volatile atomic load/store
+; correctly fail to select.
+
+; RUN: split-file %s %t
+
+; RUN: not llc -O0 -mtriple=spirv64-- %t/load-vector.ll -o /dev/null 2>&1 | FileCheck --check-prefix=FAIL-LOAD-VEC %s
+
+; RUN: not llc -O0 -mtriple=spirv64-- %t/load-volatile.ll -o /dev/null 2>&1 | FileCheck --check-prefix=FAIL-LOAD-VOL %s
+
+; RUN: not llc -O0 -mtriple=spirv64-- %t/store-vector.ll -o /dev/null 2>&1 | FileCheck --check-prefix=FAIL-STORE-VEC %s
+
+; RUN: not llc -O0 -mtriple=spirv64-- %t/store-volatile.ll -o /dev/null 2>&1 | FileCheck --check-prefix=FAIL-STORE-VOL %s
+
+; FAIL-LOAD-VEC: error:{{.*}}atomic load is only allowed for integer or floating point types
+; FAIL-LOAD-VOL: error:{{.*}}atomic load of volatile memory is not supported
+; FAIL-STORE-VEC: error:{{.*}}atomic store is only allowed for integer or floating point types
+; FAIL-STORE-VOL: error:{{.*}}atomic store of volatile memory is not supported
+
+;--- load-vector.ll
+define <2 x i32> @load_vector_acquire(ptr addrspace(1) %ptr) {
+  %val = load atomic <2 x i32>, ptr addrspace(1) %ptr acquire, align 8
+  ret <2 x i32> %val
+}
+
+;--- load-volatile.ll
+define i32 @load_i32_acquire_device_volatile(ptr addrspace(1) %ptr) {
+  %val = load atomic volatile i32, ptr addrspace(1) %ptr syncscope("device") acquire, align 4
+  ret i32 %val
+}
+
+;--- store-vector.ll
+define void @store_vector_release(ptr addrspace(1) %ptr, <2 x i32> %val) {
+  store atomic <2 x i32> %val, ptr addrspace(1) %ptr release, align 8
+  ret void
+}
+
+;--- store-volatile.ll
+define void @store_i32_release_device_volatile(ptr addrspace(1) %ptr, i32 %val) {
+  store atomic volatile i32 %val, ptr addrspace(1) %ptr syncscope("device") release, align 4
+  ret void
+}

--- a/llvm/test/CodeGen/SPIRV/transcoding/load-atomic.ll
+++ b/llvm/test/CodeGen/SPIRV/transcoding/load-atomic.ll
@@ -4,19 +4,24 @@
 ; RUN: llc -O0 -mtriple=spirv32-- %s -o - | FileCheck %s
 ; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv32-- %s -o - -filetype=obj | spirv-val %}
 
-;; Check that 'load atomic' LLVM IR instructions are lowered.
-;; NOTE: The current lowering is incorrect: 'load atomic' should produce
-;; OpAtomicLoad but currently produces OpLoad, silently dropping the atomic
-;; ordering. This test documents the broken behaviour so it can be fixed.
+; Check that 'load atomic' LLVM IR instructions are lowered correctly to
+; OpAtomicLoad with the right Scope and Memory Semantics operands.
+;
+; unordered and monotonic are currently mapped to Memory Semantics `None (Relaxed)` 0x0
 
 ; CHECK-DAG: %[[#Int32:]] = OpTypeInt 32 0
 ; CHECK-DAG: %[[#Float:]] = OpTypeFloat 32
-; CHECK-DAG: %[[#Int32Vec:]] = OpTypeVector %[[#Int32]] 2
+; CHECK-DAG: %[[#Const0:]] = OpConstantNull %[[#Int32]]
+; CHECK-DAG: %[[#Const1:]] = OpConstant %[[#Int32]] 1{{$}}
+; CHECK-DAG: %[[#Const2:]] = OpConstant %[[#Int32]] 2{{$}}
+; CHECK-DAG: %[[#Const3:]] = OpConstant %[[#Int32]] 3{{$}}
+; CHECK-DAG: %[[#Const4:]] = OpConstant %[[#Int32]] 4{{$}}
+; CHECK-DAG: %[[#Const16:]] = OpConstant %[[#Int32]] 16{{$}}
 
 define i32 @load_i32_unordered(ptr addrspace(1) %ptr) {
 ; CHECK-LABEL: OpFunction %[[#]]
 ; CHECK:       %[[#ptr:]] = OpFunctionParameter %[[#]]
-; CHECK:       %[[#]] = OpLoad %[[#Int32]] %[[#ptr]] Aligned 4
+; CHECK:       %[[#]] = OpAtomicLoad %[[#Int32]] %[[#ptr]] %[[#Const0]] %[[#Const0]]
 ; CHECK:       OpReturnValue
   %val = load atomic i32, ptr addrspace(1) %ptr unordered, align 4
   ret i32 %val
@@ -25,7 +30,7 @@ define i32 @load_i32_unordered(ptr addrspace(1) %ptr) {
 define i32 @load_i32_monotonic(ptr addrspace(1) %ptr) {
 ; CHECK-LABEL: OpFunction %[[#]]
 ; CHECK:       %[[#ptr:]] = OpFunctionParameter %[[#]]
-; CHECK:       %[[#]] = OpLoad %[[#Int32]] %[[#ptr]] Aligned 4
+; CHECK:       %[[#]] = OpAtomicLoad %[[#Int32]] %[[#ptr]] %[[#Const0]] %[[#Const0]]
 ; CHECK:       OpReturnValue
   %val = load atomic i32, ptr addrspace(1) %ptr monotonic, align 4
   ret i32 %val
@@ -34,7 +39,7 @@ define i32 @load_i32_monotonic(ptr addrspace(1) %ptr) {
 define i32 @load_i32_acquire(ptr addrspace(1) %ptr) {
 ; CHECK-LABEL: OpFunction %[[#]]
 ; CHECK:       %[[#ptr:]] = OpFunctionParameter %[[#]]
-; CHECK:       %[[#]] = OpLoad %[[#Int32]] %[[#ptr]] Aligned 4
+; CHECK:       %[[#]] = OpAtomicLoad %[[#Int32]] %[[#ptr]] %[[#Const0]] %[[#Const2]]
 ; CHECK:       OpReturnValue
   %val = load atomic i32, ptr addrspace(1) %ptr acquire, align 4
   ret i32 %val
@@ -43,7 +48,7 @@ define i32 @load_i32_acquire(ptr addrspace(1) %ptr) {
 define i32 @load_i32_seq_cst(ptr addrspace(1) %ptr) {
 ; CHECK-LABEL: OpFunction %[[#]]
 ; CHECK:       %[[#ptr:]] = OpFunctionParameter %[[#]]
-; CHECK:       %[[#]] = OpLoad %[[#Int32]] %[[#ptr]] Aligned 4
+; CHECK:       %[[#]] = OpAtomicLoad %[[#Int32]] %[[#ptr]] %[[#Const0]] %[[#Const16]]
 ; CHECK:       OpReturnValue
   %val = load atomic i32, ptr addrspace(1) %ptr seq_cst, align 4
   ret i32 %val
@@ -54,7 +59,7 @@ define i32 @load_i32_seq_cst(ptr addrspace(1) %ptr) {
 define i32 @load_i32_acquire_singlethread(ptr addrspace(1) %ptr) {
 ; CHECK-LABEL: OpFunction %[[#]]
 ; CHECK:       %[[#ptr:]] = OpFunctionParameter %[[#]]
-; CHECK:       %[[#]] = OpLoad %[[#Int32]] %[[#ptr]] Aligned 4
+; CHECK:       %[[#]] = OpAtomicLoad %[[#Int32]] %[[#ptr]] %[[#Const4]] %[[#Const2]]
 ; CHECK:       OpReturnValue
   %val = load atomic i32, ptr addrspace(1) %ptr syncscope("singlethread") acquire, align 4
   ret i32 %val
@@ -63,7 +68,7 @@ define i32 @load_i32_acquire_singlethread(ptr addrspace(1) %ptr) {
 define i32 @load_i32_acquire_subgroup(ptr addrspace(1) %ptr) {
 ; CHECK-LABEL: OpFunction %[[#]]
 ; CHECK:       %[[#ptr:]] = OpFunctionParameter %[[#]]
-; CHECK:       %[[#]] = OpLoad %[[#Int32]] %[[#ptr]] Aligned 4
+; CHECK:       %[[#]] = OpAtomicLoad %[[#Int32]] %[[#ptr]] %[[#Const3]] %[[#Const2]]
 ; CHECK:       OpReturnValue
   %val = load atomic i32, ptr addrspace(1) %ptr syncscope("subgroup") acquire, align 4
   ret i32 %val
@@ -72,7 +77,7 @@ define i32 @load_i32_acquire_subgroup(ptr addrspace(1) %ptr) {
 define i32 @load_i32_acquire_workgroup(ptr addrspace(1) %ptr) {
 ; CHECK-LABEL: OpFunction %[[#]]
 ; CHECK:       %[[#ptr:]] = OpFunctionParameter %[[#]]
-; CHECK:       %[[#]] = OpLoad %[[#Int32]] %[[#ptr]] Aligned 4
+; CHECK:       %[[#]] = OpAtomicLoad %[[#Int32]] %[[#ptr]] %[[#Const2]] %[[#Const2]]
 ; CHECK:       OpReturnValue
   %val = load atomic i32, ptr addrspace(1) %ptr syncscope("workgroup") acquire, align 4
   ret i32 %val
@@ -81,7 +86,7 @@ define i32 @load_i32_acquire_workgroup(ptr addrspace(1) %ptr) {
 define i32 @load_i32_acquire_device(ptr addrspace(1) %ptr) {
 ; CHECK-LABEL: OpFunction %[[#]]
 ; CHECK:       %[[#ptr:]] = OpFunctionParameter %[[#]]
-; CHECK:       %[[#]] = OpLoad %[[#Int32]] %[[#ptr]] Aligned 4
+; CHECK:       %[[#]] = OpAtomicLoad %[[#Int32]] %[[#ptr]] %[[#Const1]] %[[#Const2]]
 ; CHECK:       OpReturnValue
   %val = load atomic i32, ptr addrspace(1) %ptr syncscope("device") acquire, align 4
   ret i32 %val
@@ -92,20 +97,9 @@ define i32 @load_i32_acquire_device(ptr addrspace(1) %ptr) {
 define float @load_float_acquire(ptr addrspace(1) %ptr) {
 ; CHECK-LABEL: OpFunction %[[#]]
 ; CHECK:       %[[#ptr:]] = OpFunctionParameter %[[#]]
-; CHECK:       %[[#load:]] = OpLoad %[[#Int32]] %[[#ptr]] Aligned 8
+; CHECK:       %[[#load:]] = OpAtomicLoad %[[#Int32]] %[[#ptr]] %[[#Const0]] %[[#Const2]]
 ; CHECK:       %[[#val:]] = OpBitcast %[[#Float]] %[[#load]]
 ; CHECK:       OpReturnValue %[[#val]]
   %val = load atomic float, ptr addrspace(1) %ptr acquire, align 8
   ret float %val
-}
-
-; -- test with a vector type
-
-define <2 x i32> @load_vector_acquire(ptr addrspace(1) %ptr) {
-; CHECK-LABEL: OpFunction %[[#]]
-; CHECK:       %[[#ptr:]] = OpFunctionParameter %[[#]]
-; CHECK:       %[[#]] = OpLoad %[[#Int32Vec]] %[[#ptr]] Aligned 8
-; CHECK:       OpReturnValue
-  %val = load atomic <2 x i32>, ptr addrspace(1) %ptr acquire, align 8
-  ret <2 x i32> %val
 }

--- a/llvm/test/CodeGen/SPIRV/transcoding/load-atomic.ll
+++ b/llvm/test/CodeGen/SPIRV/transcoding/load-atomic.ll
@@ -7,7 +7,8 @@
 ; Check that 'load atomic' LLVM IR instructions are lowered correctly to
 ; OpAtomicLoad with the right Scope and Memory Semantics operands.
 ;
-; unordered and monotonic are currently mapped to Memory Semantics `None (Relaxed)` 0x0
+; Ordering bits are combined with storage-class semantics (e.g. CrossWorkgroupMemory
+; 0x200 for ptr addrspace(1), WorkgroupMemory 0x100 for ptr addrspace(3)).
 
 ; CHECK-DAG: %[[#Int32:]] = OpTypeInt 32 0
 ; CHECK-DAG: %[[#Float:]] = OpTypeFloat 32
@@ -16,12 +17,15 @@
 ; CHECK-DAG: %[[#Const2:]] = OpConstant %[[#Int32]] 2{{$}}
 ; CHECK-DAG: %[[#Const3:]] = OpConstant %[[#Int32]] 3{{$}}
 ; CHECK-DAG: %[[#Const4:]] = OpConstant %[[#Int32]] 4{{$}}
-; CHECK-DAG: %[[#Const16:]] = OpConstant %[[#Int32]] 16{{$}}
+; CHECK-DAG: %[[#Const258:]] = OpConstant %[[#Int32]] 258{{$}}
+; CHECK-DAG: %[[#Const512:]] = OpConstant %[[#Int32]] 512{{$}}
+; CHECK-DAG: %[[#Const514:]] = OpConstant %[[#Int32]] 514{{$}}
+; CHECK-DAG: %[[#Const528:]] = OpConstant %[[#Int32]] 528{{$}}
 
 define i32 @load_i32_unordered(ptr addrspace(1) %ptr) {
 ; CHECK-LABEL: OpFunction %[[#]]
 ; CHECK:       %[[#ptr:]] = OpFunctionParameter %[[#]]
-; CHECK:       %[[#]] = OpAtomicLoad %[[#Int32]] %[[#ptr]] %[[#Const0]] %[[#Const0]]
+; CHECK:       %[[#]] = OpAtomicLoad %[[#Int32]] %[[#ptr]] %[[#Const0]] %[[#Const512]]
 ; CHECK:       OpReturnValue
   %val = load atomic i32, ptr addrspace(1) %ptr unordered, align 4
   ret i32 %val
@@ -30,7 +34,7 @@ define i32 @load_i32_unordered(ptr addrspace(1) %ptr) {
 define i32 @load_i32_monotonic(ptr addrspace(1) %ptr) {
 ; CHECK-LABEL: OpFunction %[[#]]
 ; CHECK:       %[[#ptr:]] = OpFunctionParameter %[[#]]
-; CHECK:       %[[#]] = OpAtomicLoad %[[#Int32]] %[[#ptr]] %[[#Const0]] %[[#Const0]]
+; CHECK:       %[[#]] = OpAtomicLoad %[[#Int32]] %[[#ptr]] %[[#Const0]] %[[#Const512]]
 ; CHECK:       OpReturnValue
   %val = load atomic i32, ptr addrspace(1) %ptr monotonic, align 4
   ret i32 %val
@@ -39,7 +43,7 @@ define i32 @load_i32_monotonic(ptr addrspace(1) %ptr) {
 define i32 @load_i32_acquire(ptr addrspace(1) %ptr) {
 ; CHECK-LABEL: OpFunction %[[#]]
 ; CHECK:       %[[#ptr:]] = OpFunctionParameter %[[#]]
-; CHECK:       %[[#]] = OpAtomicLoad %[[#Int32]] %[[#ptr]] %[[#Const0]] %[[#Const2]]
+; CHECK:       %[[#]] = OpAtomicLoad %[[#Int32]] %[[#ptr]] %[[#Const0]] %[[#Const514]]
 ; CHECK:       OpReturnValue
   %val = load atomic i32, ptr addrspace(1) %ptr acquire, align 4
   ret i32 %val
@@ -48,7 +52,7 @@ define i32 @load_i32_acquire(ptr addrspace(1) %ptr) {
 define i32 @load_i32_seq_cst(ptr addrspace(1) %ptr) {
 ; CHECK-LABEL: OpFunction %[[#]]
 ; CHECK:       %[[#ptr:]] = OpFunctionParameter %[[#]]
-; CHECK:       %[[#]] = OpAtomicLoad %[[#Int32]] %[[#ptr]] %[[#Const0]] %[[#Const16]]
+; CHECK:       %[[#]] = OpAtomicLoad %[[#Int32]] %[[#ptr]] %[[#Const0]] %[[#Const528]]
 ; CHECK:       OpReturnValue
   %val = load atomic i32, ptr addrspace(1) %ptr seq_cst, align 4
   ret i32 %val
@@ -59,7 +63,7 @@ define i32 @load_i32_seq_cst(ptr addrspace(1) %ptr) {
 define i32 @load_i32_acquire_singlethread(ptr addrspace(1) %ptr) {
 ; CHECK-LABEL: OpFunction %[[#]]
 ; CHECK:       %[[#ptr:]] = OpFunctionParameter %[[#]]
-; CHECK:       %[[#]] = OpAtomicLoad %[[#Int32]] %[[#ptr]] %[[#Const4]] %[[#Const2]]
+; CHECK:       %[[#]] = OpAtomicLoad %[[#Int32]] %[[#ptr]] %[[#Const4]] %[[#Const514]]
 ; CHECK:       OpReturnValue
   %val = load atomic i32, ptr addrspace(1) %ptr syncscope("singlethread") acquire, align 4
   ret i32 %val
@@ -68,7 +72,7 @@ define i32 @load_i32_acquire_singlethread(ptr addrspace(1) %ptr) {
 define i32 @load_i32_acquire_subgroup(ptr addrspace(1) %ptr) {
 ; CHECK-LABEL: OpFunction %[[#]]
 ; CHECK:       %[[#ptr:]] = OpFunctionParameter %[[#]]
-; CHECK:       %[[#]] = OpAtomicLoad %[[#Int32]] %[[#ptr]] %[[#Const3]] %[[#Const2]]
+; CHECK:       %[[#]] = OpAtomicLoad %[[#Int32]] %[[#ptr]] %[[#Const3]] %[[#Const514]]
 ; CHECK:       OpReturnValue
   %val = load atomic i32, ptr addrspace(1) %ptr syncscope("subgroup") acquire, align 4
   ret i32 %val
@@ -77,7 +81,7 @@ define i32 @load_i32_acquire_subgroup(ptr addrspace(1) %ptr) {
 define i32 @load_i32_acquire_workgroup(ptr addrspace(1) %ptr) {
 ; CHECK-LABEL: OpFunction %[[#]]
 ; CHECK:       %[[#ptr:]] = OpFunctionParameter %[[#]]
-; CHECK:       %[[#]] = OpAtomicLoad %[[#Int32]] %[[#ptr]] %[[#Const2]] %[[#Const2]]
+; CHECK:       %[[#]] = OpAtomicLoad %[[#Int32]] %[[#ptr]] %[[#Const2]] %[[#Const514]]
 ; CHECK:       OpReturnValue
   %val = load atomic i32, ptr addrspace(1) %ptr syncscope("workgroup") acquire, align 4
   ret i32 %val
@@ -86,7 +90,7 @@ define i32 @load_i32_acquire_workgroup(ptr addrspace(1) %ptr) {
 define i32 @load_i32_acquire_device(ptr addrspace(1) %ptr) {
 ; CHECK-LABEL: OpFunction %[[#]]
 ; CHECK:       %[[#ptr:]] = OpFunctionParameter %[[#]]
-; CHECK:       %[[#]] = OpAtomicLoad %[[#Int32]] %[[#ptr]] %[[#Const1]] %[[#Const2]]
+; CHECK:       %[[#]] = OpAtomicLoad %[[#Int32]] %[[#ptr]] %[[#Const1]] %[[#Const514]]
 ; CHECK:       OpReturnValue
   %val = load atomic i32, ptr addrspace(1) %ptr syncscope("device") acquire, align 4
   ret i32 %val
@@ -97,9 +101,20 @@ define i32 @load_i32_acquire_device(ptr addrspace(1) %ptr) {
 define float @load_float_acquire(ptr addrspace(1) %ptr) {
 ; CHECK-LABEL: OpFunction %[[#]]
 ; CHECK:       %[[#ptr:]] = OpFunctionParameter %[[#]]
-; CHECK:       %[[#load:]] = OpAtomicLoad %[[#Int32]] %[[#ptr]] %[[#Const0]] %[[#Const2]]
+; CHECK:       %[[#load:]] = OpAtomicLoad %[[#Int32]] %[[#ptr]] %[[#Const0]] %[[#Const514]]
 ; CHECK:       %[[#val:]] = OpBitcast %[[#Float]] %[[#load]]
 ; CHECK:       OpReturnValue %[[#val]]
   %val = load atomic float, ptr addrspace(1) %ptr acquire, align 8
   ret float %val
+}
+
+; -- test with a different addrspace
+
+define i32 @load_i32_acquire_device_workgroup(ptr addrspace(3) %ptr) {
+; CHECK-LABEL: OpFunction %[[#]]
+; CHECK:       %[[#ptr:]] = OpFunctionParameter %[[#]]
+; CHECK:       %[[#]] = OpAtomicLoad %[[#Int32]] %[[#ptr]] %[[#Const1]] %[[#Const258]]
+; CHECK:       OpReturnValue
+  %val = load atomic i32, ptr addrspace(3) %ptr syncscope("device") acquire, align 4
+  ret i32 %val
 }

--- a/llvm/test/CodeGen/SPIRV/transcoding/store-atomic.ll
+++ b/llvm/test/CodeGen/SPIRV/transcoding/store-atomic.ll
@@ -4,20 +4,25 @@
 ; RUN: llc -O0 -mtriple=spirv32-- %s -o - | FileCheck %s
 ; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv32-- %s -o - -filetype=obj | spirv-val %}
 
-;; Check that 'store atomic' LLVM IR instructions are lowered.
-;; NOTE: The current lowering is incorrect: 'store atomic' should produce
-;; OpAtomicStore but currently produces OpStore, silently dropping the atomic
-;; ordering. This test documents the broken behaviour so it can be fixed.
+; Check that 'store atomic' LLVM IR instructions are lowered correctly to
+; OpAtomicStore with the right Scope and Memory Semantics operands.
+;
+; unordered and monotonic are currently mapped to Memory Semantics `None (Relaxed)` 0x0
 
 ; CHECK-DAG: %[[#Int32:]] = OpTypeInt 32 0
 ; CHECK-DAG: %[[#Float:]] = OpTypeFloat 32
-; CHECK-DAG: %[[#Int32Vec:]] = OpTypeVector %[[#Int32]] 2
+; CHECK-DAG: %[[#Const0:]] = OpConstantNull %[[#Int32]]
+; CHECK-DAG: %[[#Const1:]] = OpConstant %[[#Int32]] 1{{$}}
+; CHECK-DAG: %[[#Const2:]] = OpConstant %[[#Int32]] 2{{$}}
+; CHECK-DAG: %[[#Const3:]] = OpConstant %[[#Int32]] 3{{$}}
+; CHECK-DAG: %[[#Const4:]] = OpConstant %[[#Int32]] 4{{$}}
+; CHECK-DAG: %[[#Const16:]] = OpConstant %[[#Int32]] 16{{$}}
 
 define void @store_i32_unordered(ptr addrspace(1) %ptr, i32 %val) {
 ; CHECK-LABEL: OpFunction %[[#]]
 ; CHECK:       %[[#ptr:]] = OpFunctionParameter %[[#]]
 ; CHECK:       %[[#val:]] = OpFunctionParameter %[[#Int32]]
-; CHECK:       OpStore %[[#ptr]] %[[#val]] Aligned 4
+; CHECK:       OpAtomicStore %[[#ptr]] %[[#Const0]] %[[#Const0]] %[[#val]]
 ; CHECK:       OpReturn
   store atomic i32 %val, ptr addrspace(1) %ptr unordered, align 4
   ret void
@@ -27,7 +32,7 @@ define void @store_i32_monotonic(ptr addrspace(1) %ptr, i32 %val) {
 ; CHECK-LABEL: OpFunction %[[#]]
 ; CHECK:       %[[#ptr:]] = OpFunctionParameter %[[#]]
 ; CHECK:       %[[#val:]] = OpFunctionParameter %[[#Int32]]
-; CHECK:       OpStore %[[#ptr]] %[[#val]] Aligned 4
+; CHECK:       OpAtomicStore %[[#ptr]] %[[#Const0]] %[[#Const0]] %[[#val]]
 ; CHECK:       OpReturn
   store atomic i32 %val, ptr addrspace(1) %ptr monotonic, align 4
   ret void
@@ -37,7 +42,7 @@ define void @store_i32_release(ptr addrspace(1) %ptr, i32 %val) {
 ; CHECK-LABEL: OpFunction %[[#]]
 ; CHECK:       %[[#ptr:]] = OpFunctionParameter %[[#]]
 ; CHECK:       %[[#val:]] = OpFunctionParameter %[[#Int32]]
-; CHECK:       OpStore %[[#ptr]] %[[#val]] Aligned 4
+; CHECK:       OpAtomicStore %[[#ptr]] %[[#Const0]] %[[#Const4]] %[[#val]]
 ; CHECK:       OpReturn
   store atomic i32 %val, ptr addrspace(1) %ptr release, align 4
   ret void
@@ -47,7 +52,7 @@ define void @store_i32_seq_cst(ptr addrspace(1) %ptr, i32 %val) {
 ; CHECK-LABEL: OpFunction %[[#]]
 ; CHECK:       %[[#ptr:]] = OpFunctionParameter %[[#]]
 ; CHECK:       %[[#val:]] = OpFunctionParameter %[[#Int32]]
-; CHECK:       OpStore %[[#ptr]] %[[#val]] Aligned 4
+; CHECK:       OpAtomicStore %[[#ptr]] %[[#Const0]] %[[#Const16]] %[[#val]]
 ; CHECK:       OpReturn
   store atomic i32 %val, ptr addrspace(1) %ptr seq_cst, align 4
   ret void
@@ -59,7 +64,7 @@ define void @store_i32_release_singlethread(ptr addrspace(1) %ptr, i32 %val) {
 ; CHECK-LABEL: OpFunction %[[#]]
 ; CHECK:       %[[#ptr:]] = OpFunctionParameter %[[#]]
 ; CHECK:       %[[#val:]] = OpFunctionParameter %[[#Int32]]
-; CHECK:       OpStore %[[#ptr]] %[[#val]] Aligned 4
+; CHECK:       OpAtomicStore %[[#ptr]] %[[#Const4]] %[[#Const4]] %[[#val]]
 ; CHECK:       OpReturn
   store atomic i32 %val, ptr addrspace(1) %ptr syncscope("singlethread") release, align 4
   ret void
@@ -69,7 +74,7 @@ define void @store_i32_release_subgroup(ptr addrspace(1) %ptr, i32 %val) {
 ; CHECK-LABEL: OpFunction %[[#]]
 ; CHECK:       %[[#ptr:]] = OpFunctionParameter %[[#]]
 ; CHECK:       %[[#val:]] = OpFunctionParameter %[[#Int32]]
-; CHECK:       OpStore %[[#ptr]] %[[#val]] Aligned 4
+; CHECK:       OpAtomicStore %[[#ptr]] %[[#Const3]] %[[#Const4]] %[[#val]]
 ; CHECK:       OpReturn
   store atomic i32 %val, ptr addrspace(1) %ptr syncscope("subgroup") release, align 4
   ret void
@@ -79,7 +84,7 @@ define void @store_i32_release_workgroup(ptr addrspace(1) %ptr, i32 %val) {
 ; CHECK-LABEL: OpFunction %[[#]]
 ; CHECK:       %[[#ptr:]] = OpFunctionParameter %[[#]]
 ; CHECK:       %[[#val:]] = OpFunctionParameter %[[#Int32]]
-; CHECK:       OpStore %[[#ptr]] %[[#val]] Aligned 4
+; CHECK:       OpAtomicStore %[[#ptr]] %[[#Const2]] %[[#Const4]] %[[#val]]
 ; CHECK:       OpReturn
   store atomic i32 %val, ptr addrspace(1) %ptr syncscope("workgroup") release, align 4
   ret void
@@ -89,7 +94,7 @@ define void @store_i32_release_device(ptr addrspace(1) %ptr, i32 %val) {
 ; CHECK-LABEL: OpFunction %[[#]]
 ; CHECK:       %[[#ptr:]] = OpFunctionParameter %[[#]]
 ; CHECK:       %[[#val:]] = OpFunctionParameter %[[#Int32]]
-; CHECK:       OpStore %[[#ptr]] %[[#val]] Aligned 4
+; CHECK:       OpAtomicStore %[[#ptr]] %[[#Const1]] %[[#Const4]] %[[#val]]
 ; CHECK:       OpReturn
   store atomic i32 %val, ptr addrspace(1) %ptr syncscope("device") release, align 4
   ret void
@@ -102,20 +107,8 @@ define void @store_float_release(ptr addrspace(1) %ptr, float %val) {
 ; CHECK:       %[[#ptr:]] = OpFunctionParameter %[[#]]
 ; CHECK:       %[[#val:]] = OpFunctionParameter %[[#Float]]
 ; CHECK:       %[[#cast:]] = OpBitcast %[[#Int32]] %[[#val]]
-; CHECK:       OpStore %[[#ptr]] %[[#cast]] Aligned 8
+; CHECK:       OpAtomicStore %[[#ptr]] %[[#Const0]] %[[#Const4]] %[[#cast]]
 ; CHECK:       OpReturn
   store atomic float %val, ptr addrspace(1) %ptr release, align 8
-  ret void
-}
-
-; -- test with a vector type
-
-define void @store_vector_release(ptr addrspace(1) %ptr, <2 x i32> %val) {
-; CHECK-LABEL: OpFunction %[[#]]
-; CHECK:       %[[#ptr:]] = OpFunctionParameter %[[#]]
-; CHECK:       %[[#val:]] = OpFunctionParameter %[[#Int32Vec]]
-; CHECK:       OpStore %[[#ptr]] %[[#val]] Aligned 8
-; CHECK:       OpReturn
-  store atomic <2 x i32> %val, ptr addrspace(1) %ptr release, align 8
   ret void
 }

--- a/llvm/test/CodeGen/SPIRV/transcoding/store-atomic.ll
+++ b/llvm/test/CodeGen/SPIRV/transcoding/store-atomic.ll
@@ -7,7 +7,8 @@
 ; Check that 'store atomic' LLVM IR instructions are lowered correctly to
 ; OpAtomicStore with the right Scope and Memory Semantics operands.
 ;
-; unordered and monotonic are currently mapped to Memory Semantics `None (Relaxed)` 0x0
+; Ordering bits are combined with storage-class semantics (e.g. CrossWorkgroupMemory
+; 0x200 for ptr addrspace(1), WorkgroupMemory 0x100 for ptr addrspace(3)).
 
 ; CHECK-DAG: %[[#Int32:]] = OpTypeInt 32 0
 ; CHECK-DAG: %[[#Float:]] = OpTypeFloat 32
@@ -16,13 +17,16 @@
 ; CHECK-DAG: %[[#Const2:]] = OpConstant %[[#Int32]] 2{{$}}
 ; CHECK-DAG: %[[#Const3:]] = OpConstant %[[#Int32]] 3{{$}}
 ; CHECK-DAG: %[[#Const4:]] = OpConstant %[[#Int32]] 4{{$}}
-; CHECK-DAG: %[[#Const16:]] = OpConstant %[[#Int32]] 16{{$}}
+; CHECK-DAG: %[[#Const260:]] = OpConstant %[[#Int32]] 260{{$}}
+; CHECK-DAG: %[[#Const512:]] = OpConstant %[[#Int32]] 512{{$}}
+; CHECK-DAG: %[[#Const516:]] = OpConstant %[[#Int32]] 516{{$}}
+; CHECK-DAG: %[[#Const528:]] = OpConstant %[[#Int32]] 528{{$}}
 
 define void @store_i32_unordered(ptr addrspace(1) %ptr, i32 %val) {
 ; CHECK-LABEL: OpFunction %[[#]]
 ; CHECK:       %[[#ptr:]] = OpFunctionParameter %[[#]]
 ; CHECK:       %[[#val:]] = OpFunctionParameter %[[#Int32]]
-; CHECK:       OpAtomicStore %[[#ptr]] %[[#Const0]] %[[#Const0]] %[[#val]]
+; CHECK:       OpAtomicStore %[[#ptr]] %[[#Const0]] %[[#Const512]] %[[#val]]
 ; CHECK:       OpReturn
   store atomic i32 %val, ptr addrspace(1) %ptr unordered, align 4
   ret void
@@ -32,7 +36,7 @@ define void @store_i32_monotonic(ptr addrspace(1) %ptr, i32 %val) {
 ; CHECK-LABEL: OpFunction %[[#]]
 ; CHECK:       %[[#ptr:]] = OpFunctionParameter %[[#]]
 ; CHECK:       %[[#val:]] = OpFunctionParameter %[[#Int32]]
-; CHECK:       OpAtomicStore %[[#ptr]] %[[#Const0]] %[[#Const0]] %[[#val]]
+; CHECK:       OpAtomicStore %[[#ptr]] %[[#Const0]] %[[#Const512]] %[[#val]]
 ; CHECK:       OpReturn
   store atomic i32 %val, ptr addrspace(1) %ptr monotonic, align 4
   ret void
@@ -42,7 +46,7 @@ define void @store_i32_release(ptr addrspace(1) %ptr, i32 %val) {
 ; CHECK-LABEL: OpFunction %[[#]]
 ; CHECK:       %[[#ptr:]] = OpFunctionParameter %[[#]]
 ; CHECK:       %[[#val:]] = OpFunctionParameter %[[#Int32]]
-; CHECK:       OpAtomicStore %[[#ptr]] %[[#Const0]] %[[#Const4]] %[[#val]]
+; CHECK:       OpAtomicStore %[[#ptr]] %[[#Const0]] %[[#Const516]] %[[#val]]
 ; CHECK:       OpReturn
   store atomic i32 %val, ptr addrspace(1) %ptr release, align 4
   ret void
@@ -52,7 +56,7 @@ define void @store_i32_seq_cst(ptr addrspace(1) %ptr, i32 %val) {
 ; CHECK-LABEL: OpFunction %[[#]]
 ; CHECK:       %[[#ptr:]] = OpFunctionParameter %[[#]]
 ; CHECK:       %[[#val:]] = OpFunctionParameter %[[#Int32]]
-; CHECK:       OpAtomicStore %[[#ptr]] %[[#Const0]] %[[#Const16]] %[[#val]]
+; CHECK:       OpAtomicStore %[[#ptr]] %[[#Const0]] %[[#Const528]] %[[#val]]
 ; CHECK:       OpReturn
   store atomic i32 %val, ptr addrspace(1) %ptr seq_cst, align 4
   ret void
@@ -64,7 +68,7 @@ define void @store_i32_release_singlethread(ptr addrspace(1) %ptr, i32 %val) {
 ; CHECK-LABEL: OpFunction %[[#]]
 ; CHECK:       %[[#ptr:]] = OpFunctionParameter %[[#]]
 ; CHECK:       %[[#val:]] = OpFunctionParameter %[[#Int32]]
-; CHECK:       OpAtomicStore %[[#ptr]] %[[#Const4]] %[[#Const4]] %[[#val]]
+; CHECK:       OpAtomicStore %[[#ptr]] %[[#Const4]] %[[#Const516]] %[[#val]]
 ; CHECK:       OpReturn
   store atomic i32 %val, ptr addrspace(1) %ptr syncscope("singlethread") release, align 4
   ret void
@@ -74,7 +78,7 @@ define void @store_i32_release_subgroup(ptr addrspace(1) %ptr, i32 %val) {
 ; CHECK-LABEL: OpFunction %[[#]]
 ; CHECK:       %[[#ptr:]] = OpFunctionParameter %[[#]]
 ; CHECK:       %[[#val:]] = OpFunctionParameter %[[#Int32]]
-; CHECK:       OpAtomicStore %[[#ptr]] %[[#Const3]] %[[#Const4]] %[[#val]]
+; CHECK:       OpAtomicStore %[[#ptr]] %[[#Const3]] %[[#Const516]] %[[#val]]
 ; CHECK:       OpReturn
   store atomic i32 %val, ptr addrspace(1) %ptr syncscope("subgroup") release, align 4
   ret void
@@ -84,7 +88,7 @@ define void @store_i32_release_workgroup(ptr addrspace(1) %ptr, i32 %val) {
 ; CHECK-LABEL: OpFunction %[[#]]
 ; CHECK:       %[[#ptr:]] = OpFunctionParameter %[[#]]
 ; CHECK:       %[[#val:]] = OpFunctionParameter %[[#Int32]]
-; CHECK:       OpAtomicStore %[[#ptr]] %[[#Const2]] %[[#Const4]] %[[#val]]
+; CHECK:       OpAtomicStore %[[#ptr]] %[[#Const2]] %[[#Const516]] %[[#val]]
 ; CHECK:       OpReturn
   store atomic i32 %val, ptr addrspace(1) %ptr syncscope("workgroup") release, align 4
   ret void
@@ -94,7 +98,7 @@ define void @store_i32_release_device(ptr addrspace(1) %ptr, i32 %val) {
 ; CHECK-LABEL: OpFunction %[[#]]
 ; CHECK:       %[[#ptr:]] = OpFunctionParameter %[[#]]
 ; CHECK:       %[[#val:]] = OpFunctionParameter %[[#Int32]]
-; CHECK:       OpAtomicStore %[[#ptr]] %[[#Const1]] %[[#Const4]] %[[#val]]
+; CHECK:       OpAtomicStore %[[#ptr]] %[[#Const1]] %[[#Const516]] %[[#val]]
 ; CHECK:       OpReturn
   store atomic i32 %val, ptr addrspace(1) %ptr syncscope("device") release, align 4
   ret void
@@ -107,8 +111,20 @@ define void @store_float_release(ptr addrspace(1) %ptr, float %val) {
 ; CHECK:       %[[#ptr:]] = OpFunctionParameter %[[#]]
 ; CHECK:       %[[#val:]] = OpFunctionParameter %[[#Float]]
 ; CHECK:       %[[#cast:]] = OpBitcast %[[#Int32]] %[[#val]]
-; CHECK:       OpAtomicStore %[[#ptr]] %[[#Const0]] %[[#Const4]] %[[#cast]]
+; CHECK:       OpAtomicStore %[[#ptr]] %[[#Const0]] %[[#Const516]] %[[#cast]]
 ; CHECK:       OpReturn
   store atomic float %val, ptr addrspace(1) %ptr release, align 8
+  ret void
+}
+
+; -- test with a different addrspace
+
+define void @store_i32_release_device_workgroup(ptr addrspace(3) %ptr, i32 %val) {
+; CHECK-LABEL: OpFunction %[[#]]
+; CHECK:       %[[#ptr:]] = OpFunctionParameter %[[#]]
+; CHECK:       %[[#val:]] = OpFunctionParameter %[[#Int32]]
+; CHECK:       OpAtomicStore %[[#ptr]] %[[#Const1]] %[[#Const260]] %[[#val]]
+; CHECK:       OpReturn
+  store atomic i32 %val, ptr addrspace(3) %ptr syncscope("device") release, align 4
   ret void
 }


### PR DESCRIPTION
Lower LLVM's `load atomic` `store atomic` as `OpAtomicStore` and `OpAtomicLoad`.

Closes #185629 