### PR TITLE
[flang] Add REQUIRES for the trampoline test

### DIFF
--- a/flang/test/Driver/fsafe-trampoline.f90
+++ b/flang/test/Driver/fsafe-trampoline.f90
@@ -1,7 +1,7 @@
 ! Test that -fsafe-trampoline is properly forwarded from driver to
 ! frontend, and that -fno-safe-trampoline (default) works.
 
-! UNSUPPORTED: system-aix
+! REQUIRES: target=aarch64{{.*}} || target=x86{{.*}}
 
 ! RUN: %flang -### -fsafe-trampoline %s 2>&1 | FileCheck %s --check-prefix=ON
 ! RUN: %flang -### -fno-safe-trampoline %s 2>&1 | FileCheck %s --check-prefix=OFF


### PR DESCRIPTION
This patch is to fix build failure in https://lab.llvm.org/buildbot/#/builders/157/builds/45154.

Instead of listing the UNSUPPORTED list, I think it makes sense to have the REQUIRES. The REQUIRES list matches https://github.com/llvm/llvm-project/blob/1fdc16bd426f3db2aa772cc3a8dff33ec8e91e76/clang/lib/Driver/ToolChains/Flang.cpp#L209-L211