### PR TITLE
[clang][CUDA] Define _NV_RSQRT_SPECIFIER for glibc-2.42/cuda-13.2 compatibility

### DIFF
--- a/clang/lib/Headers/__clang_cuda_runtime_wrapper.h
+++ b/clang/lib/Headers/__clang_cuda_runtime_wrapper.h
@@ -47,12 +47,9 @@
 
 // math_functions.h from CUDA 13.2+ defines _NV_RSQRT_SPECIFIER.
 // Clang does not include it, so we need to define it ourselves.
-#if defined(__GNUC__)
-#include <features.h> /* For GLIBC macros */
-#if defined(__GLIBC_PREREQ)
+#if defined(__GNUC__) && defined(__GLIBC_PREREQ)
 #if __GLIBC_PREREQ(2, 42)
 #define _NV_RSQRT_SPECIFIER noexcept(true)
-#endif
 #endif
 #endif
 

--- a/clang/lib/Headers/__clang_cuda_runtime_wrapper.h
+++ b/clang/lib/Headers/__clang_cuda_runtime_wrapper.h
@@ -48,16 +48,16 @@
 // math_functions.h from CUDA 13.2+ defines _NV_RSQRT_SPECIFIER.
 // Clang does not include it, so we need to define it ourselves.
 #if defined(__GNUC__)
-# include <features.h> /* For GLIBC macros */
-# if defined(__GLIBC_PREREQ)
-#  if __GLIBC_PREREQ(2, 42)
-#   define _NV_RSQRT_SPECIFIER noexcept(true)
-#  endif
-# endif
+#include <features.h> /* For GLIBC macros */
+#if defined(__GLIBC_PREREQ)
+#if __GLIBC_PREREQ(2, 42)
+#define _NV_RSQRT_SPECIFIER noexcept(true)
+#endif
+#endif
 #endif
 
 #ifndef _NV_RSQRT_SPECIFIER
-# define _NV_RSQRT_SPECIFIER
+#define _NV_RSQRT_SPECIFIER
 #endif
 
 // Preserve common macros that will be changed below by us or by CUDA

--- a/clang/lib/Headers/__clang_cuda_runtime_wrapper.h
+++ b/clang/lib/Headers/__clang_cuda_runtime_wrapper.h
@@ -45,6 +45,21 @@
 #include <string.h>
 #undef __CUDACC__
 
+// math_functions.h from CUDA 13.2+ defines _NV_RSQRT_SPECIFIER.
+// Clang does not include it, so we need to define it ourselves.
+#if defined(__GNUC__)
+# include <features.h> /* For GLIBC macros */
+# if defined(__GLIBC_PREREQ)
+#  if __GLIBC_PREREQ(2, 42)
+#   define _NV_RSQRT_SPECIFIER noexcept(true)
+#  endif
+# endif
+#endif
+
+#ifndef _NV_RSQRT_SPECIFIER
+# define _NV_RSQRT_SPECIFIER
+#endif
+
 // Preserve common macros that will be changed below by us or by CUDA
 // headers.
 #pragma push_macro("__THROW")


### PR DESCRIPTION
CUDA-13.2 defines _NV_RSQRT_SPECIFIER to make its headers compileable with glibc 2.42+. However, clang does not include the header that defines the macro, and has to define it by itself.