### PR TITLE
[LV] Fix another invalidated iterator in handleFindLastReductions

### DIFF
--- a/llvm/lib/Transforms/Vectorize/VPlanConstruction.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanConstruction.cpp
@@ -1460,10 +1460,14 @@ bool VPlanTransforms::handleFindLastReductions(VPlan &Plan) {
   //   ...extract-last-active replaces compute-reduction-result.
   //   result = extract-last-active vp<new.data>, vp<new.mask>, ir<default.val>
 
+  SmallVector<VPRecipeBase *, 4> Phis;
+  for (VPRecipeBase &Phi :
+       Plan.getVectorLoopRegion()->getEntryBasicBlock()->phis())
+    Phis.push_back(&Phi);
+
   VPValue *HeaderMask = vputils::findHeaderMask(Plan);
-  for (auto &Phi : make_early_inc_range(
-           Plan.getVectorLoopRegion()->getEntryBasicBlock()->phis())) {
-    auto *PhiR = dyn_cast<VPReductionPHIRecipe>(&Phi);
+  for (VPRecipeBase *Phi : Phis) {
+    auto *PhiR = dyn_cast<VPReductionPHIRecipe>(Phi);
     if (!PhiR || !RecurrenceDescriptor::isFindLastRecurrenceKind(
                      PhiR->getRecurrenceKind()))
       continue;

--- a/llvm/lib/Transforms/Vectorize/VPlanConstruction.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanConstruction.cpp
@@ -1460,27 +1460,26 @@ bool VPlanTransforms::handleFindLastReductions(VPlan &Plan) {
   //   ...extract-last-active replaces compute-reduction-result.
   //   result = extract-last-active vp<new.data>, vp<new.mask>, ir<default.val>
 
-  SmallVector<VPRecipeBase *, 4> Phis;
+  SmallVector<VPReductionPHIRecipe *, 4> Phis;
   for (VPRecipeBase &Phi :
-       Plan.getVectorLoopRegion()->getEntryBasicBlock()->phis())
-    Phis.push_back(&Phi);
+       Plan.getVectorLoopRegion()->getEntryBasicBlock()->phis()) {
+        auto *PhiR = dyn_cast<VPReductionPHIRecipe>(&Phi);
+    if (PhiR && RecurrenceDescriptor::isFindLastRecurrenceKind(
+                     PhiR->getRecurrenceKind()))
+      Phis.push_back(PhiR);
+  }
 
   VPValue *HeaderMask = vputils::findHeaderMask(Plan);
-  for (VPRecipeBase *Phi : Phis) {
-    auto *PhiR = dyn_cast<VPReductionPHIRecipe>(Phi);
-    if (!PhiR || !RecurrenceDescriptor::isFindLastRecurrenceKind(
-                     PhiR->getRecurrenceKind()))
-      continue;
-
+  for (VPReductionPHIRecipe *Phi : Phis) {
     // Find the condition for the select/blend.
-    VPValue *BackedgeSelect = PhiR->getBackedgeValue();
+    VPValue *BackedgeSelect = Phi->getBackedgeValue();
     VPValue *CondSelect = BackedgeSelect;
 
     // If there's a header mask, the backedge select will not be the find-last
     // select.
     if (HeaderMask && !match(BackedgeSelect,
                              m_Select(m_Specific(HeaderMask),
-                                      m_VPValue(CondSelect), m_Specific(PhiR))))
+                                      m_VPValue(CondSelect), m_Specific(Phi))))
       llvm_unreachable("expected header mask select");
 
     VPValue *Cond = nullptr, *Op1 = nullptr, *Op2 = nullptr;
@@ -1496,11 +1495,11 @@ bool VPlanTransforms::handleFindLastReductions(VPlan &Plan) {
       unsigned NumIncomingDataValues = 0;
       for (unsigned I = 0; I < Blend->getNumIncomingValues(); ++I) {
         VPValue *Incoming = Blend->getIncomingValue(I);
-        if (Incoming != PhiR) {
+        if (Incoming != Phi) {
           ++NumIncomingDataValues;
           Cond = Blend->getMask(I);
           Op1 = Incoming;
-          Op2 = PhiR;
+          Op2 = Phi;
         }
       }
       return NumIncomingDataValues == 1;
@@ -1523,20 +1522,20 @@ bool VPlanTransforms::handleFindLastReductions(VPlan &Plan) {
     assert(RdxResult && "Could not find reduction result");
 
     // Add mask phi.
-    VPBuilder Builder = VPBuilder::getToInsertAfter(PhiR);
+    VPBuilder Builder = VPBuilder::getToInsertAfter(Phi);
     auto *MaskPHI = new VPWidenPHIRecipe(nullptr, /*Start=*/Plan.getFalse());
     Builder.insert(MaskPHI);
 
     // Add select for mask.
     Builder.setInsertPoint(SelectR);
 
-    if (Op1 == PhiR) {
+    if (Op1 == Phi) {
       // Normalize to selecting the data operand when the condition is true by
       // swapping operands and negating the condition.
       std::swap(Op1, Op2);
       Cond = Builder.createNot(Cond);
     }
-    assert(Op2 == PhiR && "data value must be selected if Cond is true");
+    assert(Op2 == Phi && "data value must be selected if Cond is true");
 
     if (HeaderMask)
       Cond = Builder.createLogicalAnd(HeaderMask, Cond);
@@ -1549,13 +1548,13 @@ bool VPlanTransforms::handleFindLastReductions(VPlan &Plan) {
     VPValue *DataSelect =
         Builder.createSelect(AnyOf, Op1, Op2, SelectR->getDebugLoc());
     SelectR->replaceAllUsesWith(DataSelect);
-    PhiR->setBackedgeValue(DataSelect);
+    Phi->setBackedgeValue(DataSelect);
     SelectR->eraseFromParent();
 
     Builder.setInsertPoint(RdxResult);
     auto *ExtractLastActive =
         Builder.createNaryOp(VPInstruction::ExtractLastActive,
-                             {PhiR->getStartValue(), DataSelect, MaskSelect},
+                             {Phi->getStartValue(), DataSelect, MaskSelect},
                              RdxResult->getDebugLoc());
     RdxResult->replaceAllUsesWith(ExtractLastActive);
     RdxResult->eraseFromParent();

--- a/llvm/lib/Transforms/Vectorize/VPlanConstruction.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanConstruction.cpp
@@ -1469,17 +1469,20 @@ bool VPlanTransforms::handleFindLastReductions(VPlan &Plan) {
       Phis.push_back(PhiR);
   }
 
+  if (Phis.empty())
+    return true;
+
   VPValue *HeaderMask = vputils::findHeaderMask(Plan);
-  for (VPReductionPHIRecipe *Phi : Phis) {
+  for (VPReductionPHIRecipe *PhiR : Phis) {
     // Find the condition for the select/blend.
-    VPValue *BackedgeSelect = Phi->getBackedgeValue();
+    VPValue *BackedgeSelect = PhiR->getBackedgeValue();
     VPValue *CondSelect = BackedgeSelect;
 
     // If there's a header mask, the backedge select will not be the find-last
     // select.
     if (HeaderMask && !match(BackedgeSelect,
                              m_Select(m_Specific(HeaderMask),
-                                      m_VPValue(CondSelect), m_Specific(Phi))))
+                                      m_VPValue(CondSelect), m_Specific(PhiR))))
       llvm_unreachable("expected header mask select");
 
     VPValue *Cond = nullptr, *Op1 = nullptr, *Op2 = nullptr;
@@ -1495,11 +1498,11 @@ bool VPlanTransforms::handleFindLastReductions(VPlan &Plan) {
       unsigned NumIncomingDataValues = 0;
       for (unsigned I = 0; I < Blend->getNumIncomingValues(); ++I) {
         VPValue *Incoming = Blend->getIncomingValue(I);
-        if (Incoming != Phi) {
+        if (Incoming != PhiR) {
           ++NumIncomingDataValues;
           Cond = Blend->getMask(I);
           Op1 = Incoming;
-          Op2 = Phi;
+          Op2 = PhiR;
         }
       }
       return NumIncomingDataValues == 1;
@@ -1522,20 +1525,20 @@ bool VPlanTransforms::handleFindLastReductions(VPlan &Plan) {
     assert(RdxResult && "Could not find reduction result");
 
     // Add mask phi.
-    VPBuilder Builder = VPBuilder::getToInsertAfter(Phi);
+    VPBuilder Builder = VPBuilder::getToInsertAfter(PhiR);
     auto *MaskPHI = new VPWidenPHIRecipe(nullptr, /*Start=*/Plan.getFalse());
     Builder.insert(MaskPHI);
 
     // Add select for mask.
     Builder.setInsertPoint(SelectR);
 
-    if (Op1 == Phi) {
+    if (Op1 == PhiR) {
       // Normalize to selecting the data operand when the condition is true by
       // swapping operands and negating the condition.
       std::swap(Op1, Op2);
       Cond = Builder.createNot(Cond);
     }
-    assert(Op2 == Phi && "data value must be selected if Cond is true");
+    assert(Op2 == PhiR && "data value must be selected if Cond is true");
 
     if (HeaderMask)
       Cond = Builder.createLogicalAnd(HeaderMask, Cond);
@@ -1548,13 +1551,13 @@ bool VPlanTransforms::handleFindLastReductions(VPlan &Plan) {
     VPValue *DataSelect =
         Builder.createSelect(AnyOf, Op1, Op2, SelectR->getDebugLoc());
     SelectR->replaceAllUsesWith(DataSelect);
-    Phi->setBackedgeValue(DataSelect);
+    PhiR->setBackedgeValue(DataSelect);
     SelectR->eraseFromParent();
 
     Builder.setInsertPoint(RdxResult);
     auto *ExtractLastActive =
         Builder.createNaryOp(VPInstruction::ExtractLastActive,
-                             {Phi->getStartValue(), DataSelect, MaskSelect},
+                             {PhiR->getStartValue(), DataSelect, MaskSelect},
                              RdxResult->getDebugLoc());
     RdxResult->replaceAllUsesWith(ExtractLastActive);
     RdxResult->eraseFromParent();

--- a/llvm/lib/Transforms/Vectorize/VPlanConstruction.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanConstruction.cpp
@@ -1463,9 +1463,9 @@ bool VPlanTransforms::handleFindLastReductions(VPlan &Plan) {
   SmallVector<VPReductionPHIRecipe *, 4> Phis;
   for (VPRecipeBase &Phi :
        Plan.getVectorLoopRegion()->getEntryBasicBlock()->phis()) {
-        auto *PhiR = dyn_cast<VPReductionPHIRecipe>(&Phi);
+    auto *PhiR = dyn_cast<VPReductionPHIRecipe>(&Phi);
     if (PhiR && RecurrenceDescriptor::isFindLastRecurrenceKind(
-                     PhiR->getRecurrenceKind()))
+                    PhiR->getRecurrenceKind()))
       Phis.push_back(PhiR);
   }
 

--- a/llvm/test/Transforms/LoopVectorize/find-last.ll
+++ b/llvm/test/Transforms/LoopVectorize/find-last.ll
@@ -266,3 +266,43 @@ loop:
 exit:
   ret i32 %select
 }
+
+define ptr @loop_inv_select_condition_issue_185682(i32 %a, i32 %b) {
+; CHECK-LABEL: @loop_inv_select_condition_issue_185682(
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    [[INV_COND:%.*]] = icmp eq i32 [[A:%.*]], [[B:%.*]]
+; CHECK-NEXT:    br label [[VECTOR_PH:%.*]]
+; CHECK:       vector.ph:
+; CHECK-NEXT:    [[BROADCAST_SPLATINSERT:%.*]] = insertelement <4 x i1> poison, i1 [[INV_COND]], i64 0
+; CHECK-NEXT:    [[BROADCAST_SPLAT:%.*]] = shufflevector <4 x i1> [[BROADCAST_SPLATINSERT]], <4 x i1> poison, <4 x i32> zeroinitializer
+; CHECK-NEXT:    [[TMP0:%.*]] = xor <4 x i1> [[BROADCAST_SPLAT]], splat (i1 true)
+; CHECK-NEXT:    [[TMP1:%.*]] = freeze <4 x i1> [[TMP0]]
+; CHECK-NEXT:    [[TMP2:%.*]] = call i1 @llvm.vector.reduce.or.v4i1(<4 x i1> [[TMP1]])
+; CHECK-NEXT:    br label [[VECTOR_BODY:%.*]]
+; CHECK:       vector.body:
+; CHECK-NEXT:    [[VEC_PHI:%.*]] = phi <4 x ptr> [ zeroinitializer, [[VECTOR_PH]] ], [ [[TMP5:%.*]], [[VECTOR_BODY]] ]
+; CHECK-NEXT:    [[TMP3:%.*]] = phi <4 x i1> [ zeroinitializer, [[VECTOR_PH]] ], [ [[TMP4:%.*]], [[VECTOR_BODY]] ]
+; CHECK-NEXT:    [[TMP4]] = select i1 [[TMP2]], <4 x i1> [[TMP0]], <4 x i1> [[TMP3]]
+; CHECK-NEXT:    [[TMP5]] = select i1 [[TMP2]], <4 x ptr> zeroinitializer, <4 x ptr> [[VEC_PHI]]
+; CHECK-NEXT:    br i1 true, label [[MIDDLE_BLOCK:%.*]], label [[VECTOR_BODY]], !llvm.loop [[LOOP8:![0-9]+]]
+; CHECK:       middle.block:
+; CHECK-NEXT:    [[TMP6:%.*]] = call ptr @llvm.experimental.vector.extract.last.active.v4p0(<4 x ptr> [[TMP5]], <4 x i1> [[TMP4]], ptr null)
+; CHECK-NEXT:    br label [[EXIT:%.*]]
+; CHECK:       exit:
+; CHECK-NEXT:    ret ptr [[TMP6]]
+;
+entry:
+  %inv.cond = icmp eq i32 %a, %b
+  br label %loop
+
+loop:
+  %rdx = phi ptr [ null, %entry ], [ %select, %loop ]
+  %iv = phi i64 [ 0, %entry ], [ %iv.next, %loop ]
+  %select = select i1 %inv.cond, ptr %rdx, ptr null
+  %iv.next = add i64 %iv, 1
+  %exit.cond = icmp eq i64 %iv.next, 4
+  br i1 %exit.cond, label %exit, label %loop
+
+exit:
+  ret ptr %select
+}


### PR DESCRIPTION
Just collect all the initial phis into a SmallVector first instead
of trying to avoid iterator invalidation in a changing vplan.

Fixes #185682.
