### PR TITLE
[CIR] Remove diagnostic when handling incomplete record types

### DIFF
--- a/clang/include/clang/CIR/MissingFeatures.h
+++ b/clang/include/clang/CIR/MissingFeatures.h
@@ -141,7 +141,6 @@ struct MissingFeatures {
   static bool shouldReverseUnaryCondOnBoolExpr() { return false; }
 
   // RecordType
-  static bool skippedLayout() { return false; }
   static bool astRecordDeclAttr() { return false; }
   static bool zeroSizeRecordMembers() { return false; }
 

--- a/clang/lib/CIR/CodeGen/CIRGenTypes.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenTypes.cpp
@@ -69,14 +69,14 @@ bool CIRGenTypes::isFuncTypeConvertible(const FunctionType *ft) {
 mlir::Type CIRGenTypes::convertFunctionTypeInternal(QualType qft) {
   assert(qft.isCanonical());
   const FunctionType *ft = cast<FunctionType>(qft.getTypePtr());
-  // First, check whether we can build the full function type. If the function
-  // type depends on an incomplete type (e.g. a struct or enum), we cannot lower
-  // the function type.
-  if (!isFuncTypeConvertible(ft)) {
-    cgm.errorNYI(SourceLocation(), "function type involving an incomplete type",
-                 qft);
-    return cir::FuncType::get(SmallVector<mlir::Type, 1>{}, cgm.voidTy);
-  }
+
+  // In classic codegen, if the function type depends on an incomplete type
+  // (e.g. a struct or enum), it cannot lower the function type due to ABI
+  // handling requirements and returns a placeholder. In CIR, ABI handling is
+  // deferred until after codegen, and record types are identified by name, so
+  // incomplete record type references in the function type will automatically
+  // see the complete type once the record is defined. We can always produce a
+  // proper function type here.
 
   const CIRGenFunctionInfo *fi;
   if (const auto *fpt = dyn_cast<FunctionProtoType>(ft)) {
@@ -264,10 +264,6 @@ mlir::Type CIRGenTypes::convertRecordDeclType(const clang::RecordDecl *rd) {
   bool eraseResult = recordsBeingLaidOut.erase(key);
   (void)eraseResult;
   assert(eraseResult && "record not in RecordsBeingLaidOut set?");
-
-  // If this record blocked a FunctionType conversion, then recompute whatever
-  // was derived from that.
-  assert(!cir::MissingFeatures::skippedLayout());
 
   // If we're done converting the outer-most record, then convert any deferred
   // records as well.

--- a/clang/test/CIR/CodeGen/convert-incomplete-type.cpp
+++ b/clang/test/CIR/CodeGen/convert-incomplete-type.cpp
@@ -1,0 +1,36 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o %t.cir
+// RUN: FileCheck --input-file=%t.cir %s -check-prefix=CIR
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o %t-cir.ll
+// RUN: FileCheck --input-file=%t-cir.ll %s -check-prefix=LLVM
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -emit-llvm %s -o %t.ll
+// RUN: FileCheck --input-file=%t.ll %s -check-prefix=OGCG
+
+struct Delayed;
+Delayed (*fp)();
+
+struct Delayed {
+  int x;
+};
+
+void use() {
+  Delayed result = fp();
+}
+
+// CIR: cir.global external @fp = #cir.ptr<null> : !cir.ptr<!cir.func<() -> !rec_Delayed>>
+
+// CIR: cir.func {{.*}} @_Z3usev()
+// CIR:   %[[FP:.*]] = cir.get_global @fp
+// CIR:   %[[LOAD:.*]] = cir.load {{.*}} %[[FP]]
+// CIR:   cir.call %[[LOAD]]() : (!cir.ptr<!cir.func<() -> !rec_Delayed>>) -> !rec_Delayed
+
+// The difference between LLVM and OGCG is due to missing ABI lowering.
+
+// LLVM: @fp = global ptr null
+// LLVM: define {{.*}} void @_Z3usev()
+// LLVM:   %[[FP:.*]] = load ptr, ptr @fp
+// LLVM:   %[[CALL:.*]] = call %struct.Delayed %[[FP]]()
+
+// OGCG: @fp = global ptr null
+// OGCG: define {{.*}} void @_Z3usev()
+// OGCG:   %[[FP:.*]] = load ptr, ptr @fp
+// OGCG:   call i32 %[[FP]]()


### PR DESCRIPTION
Following the example of classic codegen, we were checking for incomplete record types in function signatures and issuing a diagnostic in a place where it appeared that the type conversion needed to be delayed. However, because CIR defers ABI processing until after codegen, we don't actually need special handling for incomplete types.

This change removes the diagnostic and adds a comment explaining the difference in behavior.