### PR TITLE
[Clang] Check sanitizer ignorelist for divrem overflow

### DIFF
--- a/clang/lib/CodeGen/CGExprScalar.cpp
+++ b/clang/lib/CodeGen/CGExprScalar.cpp
@@ -4193,7 +4193,9 @@ void ScalarExprEmitter::EmitUndefinedBehaviorIntegerDivAndRemCheck(
   if (CGF.SanOpts.has(SanitizerKind::SignedIntegerOverflow) &&
       Ops.Ty->hasSignedIntegerRepresentation() &&
       !IsWidenedIntegerOp(CGF.getContext(), BO->getLHS()) &&
-      Ops.mayHaveIntegerOverflow() && !Ops.Ty.isWrapType()) {
+      Ops.mayHaveIntegerOverflow() && !Ops.Ty.isWrapType() &&
+      !CGF.getContext().isTypeIgnoredBySanitizer(
+          SanitizerKind::SignedIntegerOverflow, Ops.Ty)) {
     llvm::IntegerType *Ty = cast<llvm::IntegerType>(Zero->getType());
 
     llvm::Value *IntMin =

--- a/clang/test/CodeGen/ubsan-type-ignorelist-category.test
+++ b/clang/test/CodeGen/ubsan-type-ignorelist-category.test
@@ -83,6 +83,24 @@ void truncation(char A, int B, unsigned char C, short D) {
 }
 
 
+// INT-LABEL: ignore_int_divrem
+void ignore_int_divrem(int A, int B, unsigned C, unsigned D, long E, long F) {
+// INT-NOT: handler.divrem_overflow
+  (void)(A/B);
+// INT-NOT: handler.divrem_overflow
+  (void)(A%B);
+// INT: handler.divrem_overflow
+  (void)(E/F);
+}
+
+// MYTY-LABEL: ignore_all_except_myty_divrem
+void ignore_all_except_myty_divrem(int A, int B, myty C, myty D) {
+// MYTY-NOT: handler.divrem_overflow
+  (void)(A/B);
+// MYTY-NOT: handler.divrem_overflow
+  (void)(A%B);
+}
+
 // Matches the example from clang/docs/SanitizerSpecialCaseList.rst
 typedef char T;
 typedef char U;


### PR DESCRIPTION
Instrumentation emitted for overflow by division was not checking with the sanitizer case list's type entries.

The original type-based ignorelist support (#107332) added `isTypeIgnoredBySanitizer` calls to `CanElideOverflowCheck`, which covers `+`, `-`, `*`, `++`, `--`. However, division and remainder have a separate code path in `EmitUndefinedBehaviorIntegerDivAndRemCheck` that never calls `CanElideOverflowCheck` or checks the ignorelist directly.

Add a check so that the SCL is honored for the div/rem case.

