### PR TITLE
[AMDGPU] Add stalls for DS FIFO buffer to coexec sched

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUCoExecSchedStrategy.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUCoExecSchedStrategy.cpp
@@ -729,10 +729,11 @@ bool AMDGPUCoExecSchedStrategy::tryEffectiveStall(SchedCandidate &Cand,
   LLVM_DEBUG(if (TryCosts.Effective || CandCosts.Effective) {
     dbgs() << "Effective stalls: try=" << TryCosts.Effective
            << " (ready=" << TryCosts.Ready << ", struct=" << TryCosts.Structural
-           << ", lat=" << TryCosts.Latency << ", buffer=" << TryCosts.Buffer << ") cand=" << CandCosts.Effective
-           << " (ready=" << CandCosts.Ready
+           << ", lat=" << TryCosts.Latency << ", buffer=" << TryCosts.Buffer
+           << ") cand=" << CandCosts.Effective << " (ready=" << CandCosts.Ready
            << ", struct=" << CandCosts.Structural
-           << ", lat=" << CandCosts.Latency << ", buffer=" << CandCosts.Buffer < ")\n";
+           << ", lat=" << CandCosts.Latency << ", buffer=" << CandCosts.Buffer
+           << ")\n";
   });
 
   return tryLess(TryCosts.Effective, CandCosts.Effective, TryCand, Cand, Stall);

--- a/llvm/lib/Target/AMDGPU/AMDGPUCoExecSchedStrategy.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUCoExecSchedStrategy.cpp
@@ -137,10 +137,12 @@ void HardwareUnitInfo::markScheduled(SUnit *SU, unsigned BlockingCycles) {
   if (TotalCycles == 0)
     return;
 
+  ScheduledSUs.push_back(SU);
   AllSUs.remove(SU);
   PrioritySUs.remove(SU);
 
-  TotalCycles -= BlockingCycles;
+  if (BufferSize <= 1 || (ScheduledSUs.size() % BufferSize == 0))
+    TotalCycles -= BlockingCycles;
 
   if (AllSUs.empty())
     return;
@@ -165,6 +167,14 @@ void HardwareUnitInfo::markScheduled(SUnit *SU, unsigned BlockingCycles) {
       PrioritySUs.insert(SU);
     }
   }
+}
+
+void HardwareUnitInfo::finalizeCycles() {
+  if (BufferSize <= 1 || !AllSUs.size())
+    return;
+
+  BufferCycles = TotalCycles / AllSUs.size();
+  TotalCycles /= BufferSize;
 }
 
 HardwareUnitInfo *
@@ -216,6 +226,7 @@ void CandidateHeuristics::initialize(ScheduleDAGMI *SchedDAG,
   HWUInfo[(int)InstructionFlavor::WMMA].setProducesCoexecWindow(true);
   HWUInfo[(int)InstructionFlavor::MultiCycleVALU].setProducesCoexecWindow(true);
   HWUInfo[(int)InstructionFlavor::TRANS].setProducesCoexecWindow(true);
+  HWUInfo[(int)InstructionFlavor::DS].setBufferSize(DefaultBufferSizes::DS);
 
   collectHWUIPressure();
 }
@@ -227,6 +238,10 @@ void CandidateHeuristics::collectHWUIPressure() {
   for (auto &SU : DAG->SUnits) {
     const InstructionFlavor Flavor = classifyFlavor(*SU.getInstr(), *SII);
     HWUInfo[(int)(Flavor)].insert(&SU, getHWUICyclesForInst(&SU));
+  }
+
+  for (auto &HWUI : HWUInfo) {
+    HWUI.finalizeCycles();
   }
 
   LLVM_DEBUG(dumpRegionSummary());
@@ -666,7 +681,26 @@ bool AMDGPUCoExecSchedStrategy::tryCandidateCoexec(SchedCandidate &Cand,
 
 bool AMDGPUCoExecSchedStrategy::tryEffectiveStall(SchedCandidate &Cand,
                                                   SchedCandidate &TryCand,
-                                                  SchedBoundary &Zone) const {
+                                                  SchedBoundary &Zone) {
+  auto getBufferFullStalls = [this,
+                              &Zone](SUnit *SU) -> unsigned {
+    InstructionFlavor Flavor = classifyFlavor(
+        *SU->getInstr(), *static_cast<const SIInstrInfo *>(DAG->TII));
+    HardwareUnitInfo *HWUI = Heurs.getHWUIFromFlavor(Flavor);
+
+    if (HWUI->getBufferSize() <= 1)
+      return 0;
+
+    // getBufferAvailableCycle assumes top-down scheduling.
+    assert(Zone.isTop());
+    unsigned CurrCycle = Zone.getCurrCycle();
+    unsigned BufferReadyCycle = HWUI->getBufferAvailableCycle(CurrCycle);
+    if (BufferReadyCycle <= CurrCycle)
+      return 0;
+
+    return BufferReadyCycle - CurrCycle;
+  };
+
   // Treat structural and latency stalls as a single scheduling cost for the
   // current cycle.
   struct StallCosts {
@@ -674,6 +708,7 @@ bool AMDGPUCoExecSchedStrategy::tryEffectiveStall(SchedCandidate &Cand,
     unsigned Structural = 0;
     unsigned Latency = 0;
     unsigned Effective = 0;
+    unsigned Buffer = 0;
   };
 
   unsigned CurrCycle = Zone.getCurrCycle();
@@ -683,7 +718,8 @@ bool AMDGPUCoExecSchedStrategy::tryEffectiveStall(SchedCandidate &Cand,
     Costs.Ready = ReadyCycle > CurrCycle ? ReadyCycle - CurrCycle : 0;
     Costs.Structural = getStructuralStallCycles(Zone, SU);
     Costs.Latency = Zone.getLatencyStallCycles(SU);
-    Costs.Effective = std::max({Costs.Ready, Costs.Structural, Costs.Latency});
+    Costs.Buffer = getBufferFullStalls(SU);
+    Costs.Effective = std::max({Costs.Ready, Costs.Structural, Costs.Latency, Costs.Buffer});
     return Costs;
   };
 
@@ -693,10 +729,10 @@ bool AMDGPUCoExecSchedStrategy::tryEffectiveStall(SchedCandidate &Cand,
   LLVM_DEBUG(if (TryCosts.Effective || CandCosts.Effective) {
     dbgs() << "Effective stalls: try=" << TryCosts.Effective
            << " (ready=" << TryCosts.Ready << ", struct=" << TryCosts.Structural
-           << ", lat=" << TryCosts.Latency << ") cand=" << CandCosts.Effective
+           << ", lat=" << TryCosts.Latency << ", buffer=" << TryCosts.Buffer << ") cand=" << CandCosts.Effective
            << " (ready=" << CandCosts.Ready
            << ", struct=" << CandCosts.Structural
-           << ", lat=" << CandCosts.Latency << ")\n";
+           << ", lat=" << CandCosts.Latency << ", buffer=" << CandCosts.Buffer < ")\n";
   });
 
   return tryLess(TryCosts.Effective, CandCosts.Effective, TryCand, Cand, Stall);

--- a/llvm/lib/Target/AMDGPU/AMDGPUCoExecSchedStrategy.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUCoExecSchedStrategy.cpp
@@ -80,7 +80,7 @@ InstructionFlavor llvm::AMDGPU::classifyFlavor(const MachineInstr &MI,
 }
 
 SUnit *HardwareUnitInfo::getNextTargetSU(bool LookDeep) const {
-  for (auto *PrioritySU : PrioritySUs) {
+  for (SUnit *PrioritySU : PrioritySUs) {
     if (!PrioritySU->isTopReady())
       return PrioritySU;
   }
@@ -106,12 +106,8 @@ SUnit *HardwareUnitInfo::getNextTargetSU(bool LookDeep) const {
 }
 
 void HardwareUnitInfo::insert(SUnit *SU, unsigned BlockingCycles) {
-#ifndef NDEBUG
-  bool Inserted = AllSUs.insert(SU);
-  assert(Inserted);
-#else
-  AllSUs.insert(SU);
-#endif
+  if (!AllSUs.insert(SU))
+    llvm_unreachable("HardwareUnit already contains SU!");
 
   TotalCycles += BlockingCycles;
 
@@ -173,7 +169,7 @@ void HardwareUnitInfo::markScheduled(SUnit *SU, unsigned BlockingCycles) {
 
 HardwareUnitInfo *
 CandidateHeuristics::getHWUIFromFlavor(InstructionFlavor Flavor) {
-  for (auto &HWUICand : HWUInfo) {
+  for (HardwareUnitInfo &HWUICand : HWUInfo) {
     if (HWUICand.getType() == Flavor) {
       return &HWUICand;
     }
@@ -269,7 +265,8 @@ void CandidateHeuristics::sortHWUIResources() {
       return A.size() < B.size();
 
     // Default to Flavor order
-    return (unsigned)A.getType() < (unsigned)B.getType();
+    return static_cast<unsigned>(A.getType()) <
+           static_cast<unsigned>(B.getType());
   });
 }
 

--- a/llvm/lib/Target/AMDGPU/AMDGPUCoExecSchedStrategy.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUCoExecSchedStrategy.cpp
@@ -170,10 +170,24 @@ void HardwareUnitInfo::markScheduled(SUnit *SU, unsigned BlockingCycles) {
 }
 
 void HardwareUnitInfo::finalizeCycles() {
-  if (BufferSize <= 1 || !AllSUs.size())
+  if (BufferSize <= 1 || AllSUs.empty())
     return;
 
+  // We estimate the amount of cycles it takes to free up a slot in the buffer
+  // as the average cycles per SU.
   BufferCycles = TotalCycles / AllSUs.size();
+  // The TotalCycles is normalized against the BufferSize.
+  // This provides an estimate of the TotalCycles which is not always accurate
+  // -- particularly in cases where we have fewer instructions than the
+  // BufferSize. For example, if we have 2 instructions which each take 50
+  // cycles and a BufferSize of 16, then a TotalCycles of 51 cycles would be
+  // somewhat accurate. This normalization calculates TotalCycles as 6. However,
+  // if we have 64 of these instructions, our normalized estimate of 200 is more
+  // reasonable, given the more accurate measure is 264. Having a completely
+  // accurate measure is not very important, since this metric is mainly used to
+  // compare the relative demand per HardwareUnit across the region. The simpler
+  // estimate makes managing the metric incrementally during scheduling much
+  // simpler.
   TotalCycles /= BufferSize;
 }
 

--- a/llvm/lib/Target/AMDGPU/AMDGPUCoExecSchedStrategy.h
+++ b/llvm/lib/Target/AMDGPU/AMDGPUCoExecSchedStrategy.h
@@ -20,6 +20,9 @@
 namespace llvm {
 
 namespace AMDGPU {
+namespace DefaultBufferSizes {
+constexpr unsigned DS = 16;
+} // namespace DefaultBufferSizes
 
 //===----------------------------------------------------------------------===//
 // Instruction Flavor Classification
@@ -163,6 +166,8 @@ private:
   SmallSetVector<SUnit *, 16> PrioritySUs;
   /// All the SUs in the region that consume this resource.
   SmallSetVector<SUnit *, 16> AllSUs;
+  /// All the SUs for this HardwareUnit that have already been scheduled.
+  SmallVector<SUnit *, 16> ScheduledSUs;
   /// The total number of busy cycles for this HardwareUnit for a given region.
   unsigned TotalCycles = 0;
   /// InstructionFlavor mapping.
@@ -172,6 +177,11 @@ private:
   /// / MFMA instructions may take multiple cycles, which may be overlapped with
   /// instructions on other HardwareUnits.
   bool ProducesCoexecWindow = false;
+  /// How many instructons can be held simultaneously for this HardwareUnit.
+  /// A value of 0 or 1 means that there is no buffer.
+  unsigned BufferSize = 0;
+  /// How many cycles it takes for an instruction to clear the buffer.
+  unsigned BufferCycles = 0;
 
 public:
   HardwareUnitInfo() {}
@@ -192,6 +202,24 @@ public:
   void setProducesCoexecWindow(bool Val) { ProducesCoexecWindow = Val; }
 
   bool contains(SUnit *SU) const { return AllSUs.contains(SU); }
+
+  void setBufferSize(unsigned Size) { BufferSize = Size; }
+
+  unsigned getBufferSize() { return BufferSize; }
+
+  /// \returns the next cycle where there is space in the buffer.
+  unsigned getBufferAvailableCycle(unsigned CurrCycle) {
+    // There is no buffer.
+    if (BufferSize <= 1)
+      return CurrCycle;
+
+    // Buffer is available now.
+    if (ScheduledSUs.size() < BufferSize)
+      return CurrCycle;
+
+    return BufferCycles +
+           ScheduledSUs[ScheduledSUs.size() - BufferSize]->TopReadyCycle;
+  }
 
   /// \returns the SUnit with higher priority or nullptr if they are the same.
   /// This method looks through the PrioritySUs to determine if one SU is more
@@ -214,6 +242,8 @@ public:
     TotalCycles = 0;
     Type = AMDGPU::InstructionFlavor::Other;
     ProducesCoexecWindow = false;
+    BufferSize = 0;
+    BufferCycles = 0;
   }
 
   /// \returns the next SU in PrioritySUs that is not ready. If \p LookDeep is
@@ -233,6 +263,11 @@ public:
   /// and reducing its \p BlockingCycles from the TotalCycles. This maintains
   /// the list of PrioritySUs.
   void markScheduled(SUnit *SU, unsigned BlockingCycles);
+  /// After we've collected all the region pressure for this HWUI, correct for
+  /// any specifics of the behavior of this resource. For example, if we the
+  /// HardwareUnit can hold N instructions simultaneously, then there is no
+  /// penalty for scheduling N instructions back to back.
+  void finalizeCycles();
 };
 
 //===----------------------------------------------------------------------===//
@@ -257,10 +292,6 @@ protected:
   /// SU.
   unsigned getHWUICyclesForInst(SUnit *SU);
 
-  /// Given a \p Flavor , find the corresponding HardwareUnit. \returns the
-  /// mapped HardwareUnit.
-  HardwareUnitInfo *getHWUIFromFlavor(AMDGPU::InstructionFlavor Flavor);
-
 public:
   CandidateHeuristics() = default;
 
@@ -270,7 +301,11 @@ public:
   /// Update the state to reflect that \p SU is going to be scheduled.
   void updateForScheduling(SUnit *SU);
 
-  /// Sort the HWUInfo vector. After sorting, the HardwareUnits that are highest
+  /// Given a \p Flavor , find the corresponding HardwareUnit. \returns the
+  /// mapped HardwareUnit.
+  HardwareUnitInfo *getHWUIFromFlavor(AMDGPU::InstructionFlavor Flavor);
+
+  /// Sort the HardwarUnitInfo vector. After sorting, the HWUI that are highest
   /// priority are first. Priority is determined by maximizing coexecution and
   /// keeping the critical HardwareUnit busy.
   void sortHWUIResources();
@@ -299,7 +334,7 @@ public:
 class AMDGPUCoExecSchedStrategy final : public GCNSchedStrategy {
 protected:
   bool tryEffectiveStall(SchedCandidate &Cand, SchedCandidate &TryCand,
-                         SchedBoundary &Zone) const;
+                         SchedBoundary &Zone);
   AMDGPU::AMDGPUSchedReason LastAMDGPUReason = AMDGPU::AMDGPUSchedReason::None;
   CandidateHeuristics Heurs;
 

--- a/llvm/lib/Target/AMDGPU/AMDGPUCoExecSchedStrategy.h
+++ b/llvm/lib/Target/AMDGPU/AMDGPUCoExecSchedStrategy.h
@@ -177,7 +177,7 @@ private:
   /// / MFMA instructions may take multiple cycles, which may be overlapped with
   /// instructions on other HardwareUnits.
   bool ProducesCoexecWindow = false;
-  /// How many instructons can be held simultaneously for this HardwareUnit.
+  /// How many instructions can be held simultaneously for this HardwareUnit.
   /// A value of 0 or 1 means that there is no buffer.
   unsigned BufferSize = 0;
   /// How many cycles it takes for an instruction to clear the buffer.

--- a/llvm/lib/Target/AMDGPU/AMDGPUCoExecSchedStrategy.h
+++ b/llvm/lib/Target/AMDGPU/AMDGPUCoExecSchedStrategy.h
@@ -39,7 +39,7 @@ enum class InstructionFlavor : uint8_t {
   NUM_FLAVORS
 };
 
-inline StringRef getFlavorName(InstructionFlavor F) {
+constexpr StringRef getFlavorName(InstructionFlavor F) {
   switch (F) {
   case InstructionFlavor::WMMA:
     return "WMMA";
@@ -62,12 +62,12 @@ inline StringRef getFlavorName(InstructionFlavor F) {
   case InstructionFlavor::Other:
     return "Other";
   case InstructionFlavor::NUM_FLAVORS:
-    return "???";
+    llvm_unreachable("Unknown InstructionFlavor");
   }
   llvm_unreachable("Unknown InstructionFlavor");
 }
 
-inline StringRef getFlavorShortName(InstructionFlavor F) {
+constexpr StringRef getFlavorShortName(InstructionFlavor F) {
   switch (F) {
   case InstructionFlavor::WMMA:
     return "W";
@@ -90,7 +90,7 @@ inline StringRef getFlavorShortName(InstructionFlavor F) {
   case InstructionFlavor::Other:
     return "O";
   case InstructionFlavor::NUM_FLAVORS:
-    return "?";
+    llvm_unreachable("Unknown InstructionFlavor");
   }
   llvm_unreachable("Unknown InstructionFlavor");
 }
@@ -128,7 +128,7 @@ enum class AMDGPUSchedReason : uint8_t {
   NUM_REASONS
 };
 
-inline StringRef getReasonName(AMDGPUSchedReason R) {
+constexpr StringRef getReasonName(AMDGPUSchedReason R) {
   switch (R) {
   case AMDGPUSchedReason::None:
     return "None";
@@ -137,7 +137,7 @@ inline StringRef getReasonName(AMDGPUSchedReason R) {
   case AMDGPUSchedReason::CritResourceDep:
     return "CritResourceDep";
   case AMDGPUSchedReason::NUM_REASONS:
-    return "???";
+    llvm_unreachable("Unknown AMDGPUSchedReason");
   }
   llvm_unreachable("Unknown AMDGPUSchedReason");
 }
@@ -161,16 +161,16 @@ private:
   /// more regular HardwareUnit access patterns. SUs are prioritized based on
   /// depth for top-down scheduling.
   SmallSetVector<SUnit *, 16> PrioritySUs;
-  /// All the SUs in the region that consume this resource
+  /// All the SUs in the region that consume this resource.
   SmallSetVector<SUnit *, 16> AllSUs;
   /// The total number of busy cycles for this HardwareUnit for a given region.
   unsigned TotalCycles = 0;
-  // InstructionFlavor mapping
+  /// InstructionFlavor mapping.
   AMDGPU::InstructionFlavor Type;
-  // Whether or not instructions on this HardwareUnit may produce a window in
-  // which instructions in other HardwareUnits can coexecute. For example, WMMA
-  // / MFMA instructions may take multiple cycles, which may be overlapped with
-  // instructions on other HardwareUnits
+  /// Whether or not instructions on this HardwareUnit may produce a window in
+  /// which instructions in other HardwareUnits can coexecute. For example, WMMA
+  /// / MFMA instructions may take multiple cycles, which may be overlapped with
+  /// instructions on other HardwareUnits.
   bool ProducesCoexecWindow = false;
 
 public:
@@ -193,13 +193,12 @@ public:
 
   bool contains(SUnit *SU) const { return AllSUs.contains(SU); }
 
-  /// \returns true if there is a difference in priority between \p SU and \p
-  /// Other. If so, \returns the SUnit with higher priority. This
-  /// method looks through the PrioritySUs to determine if one SU is more
+  /// \returns the SUnit with higher priority or nullptr if they are the same.
+  /// This method looks through the PrioritySUs to determine if one SU is more
   /// prioritized than the other. If neither are in the PrioritySUs list, then
   /// neither have priority over each other.
   SUnit *getHigherPriority(SUnit *SU, SUnit *Other) const {
-    for (auto *SUOrder : PrioritySUs) {
+    for (SUnit *SUOrder : PrioritySUs) {
       if (SUOrder == SU)
         return SU;
 
@@ -227,12 +226,12 @@ public:
   /// long latency (e.g. memory instructions). If we have many long latency
   /// dependencies, it is beneficial to enable SUs multiple levels ahead.
   SUnit *getNextTargetSU(bool LookDeep = false) const;
-  /// Insert the \p SU into the AllSUs and account its \p BlockingCycles into
+  /// Insert the \p SU into AllSUs and account its \p BlockingCycles into
   /// the TotalCycles. This maintains the list of PrioritySUs.
   void insert(SUnit *SU, unsigned BlockingCycles);
-  /// Update the state for \p SU being scheduled by removing it from the AllSus
+  /// Update the state for \p SU being scheduled by removing it from the AllSUs
   /// and reducing its \p BlockingCycles from the TotalCycles. This maintains
-  /// the list of PrioritySUS.
+  /// the list of PrioritySUs.
   void markScheduled(SUnit *SU, unsigned BlockingCycles);
 };
 
@@ -251,11 +250,11 @@ protected:
   const TargetSchedModel *SchedModel;
   SmallVector<HardwareUnitInfo, 8> HWUInfo;
 
-  /// Walk over the region and collect total usage per HardwareUnit
+  /// Walk over the region and collect total usage per HardwareUnit.
   void collectHWUIPressure();
 
   /// Compute the blocking cycles for the appropriate HardwareUnit given an \p
-  /// SU
+  /// SU.
   unsigned getHWUICyclesForInst(SUnit *SU);
 
   /// Given a \p Flavor , find the corresponding HardwareUnit. \returns the

--- a/llvm/lib/Target/AMDGPU/AMDGPUCoExecSchedStrategy.h
+++ b/llvm/lib/Target/AMDGPU/AMDGPUCoExecSchedStrategy.h
@@ -239,6 +239,7 @@ public:
   void reset() {
     AllSUs.clear();
     PrioritySUs.clear();
+    ScheduledSUs.clear();
     TotalCycles = 0;
     Type = AMDGPU::InstructionFlavor::Other;
     ProducesCoexecWindow = false;

--- a/llvm/test/CodeGen/AMDGPU/coexec-scheduler.ll
+++ b/llvm/test/CodeGen/AMDGPU/coexec-scheduler.ll
@@ -287,11 +287,6 @@ define amdgpu_kernel void @ds_wmma_permute(ptr addrspace(3) %base, ptr addrspace
 ; COEXEC-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; COEXEC-NEXT:    s_add_co_i32 s7, s2, s6
 ; COEXEC-NEXT:    s_add_co_i32 s8, s3, s6
-; COEXEC-NEXT:    v_nop
-; COEXEC-NEXT:    v_nop
-; COEXEC-NEXT:    v_nop
-; COEXEC-NEXT:    v_nop
-; COEXEC-NEXT:    v_dual_mov_b32 v92, s7 :: v_dual_mov_b32 v108, s8
 ; COEXEC-NEXT:    s_add_co_i32 s6, s6, s1
 ; COEXEC-NEXT:    v_nop
 ; COEXEC-NEXT:    v_nop
@@ -299,65 +294,63 @@ define amdgpu_kernel void @ds_wmma_permute(ptr addrspace(3) %base, ptr addrspace
 ; COEXEC-NEXT:    v_nop
 ; COEXEC-NEXT:    v_mov_b32_e32 v124, s7
 ; COEXEC-NEXT:    s_and_b32 vcc_lo, exec_lo, s0
-; COEXEC-NEXT:    ds_load_tr16_b128 v[32:35], v92
-; COEXEC-NEXT:    ds_load_tr16_b128 v[40:43], v108
-; COEXEC-NEXT:    ds_load_tr16_b128 v[36:39], v92 offset:64
-; COEXEC-NEXT:    ds_load_tr16_b128 v[44:47], v108 offset:64
-; COEXEC-NEXT:    ds_load_tr16_b128 v[48:51], v108 offset:256
-; COEXEC-NEXT:    ds_load_tr16_b128 v[56:59], v92 offset:256
-; COEXEC-NEXT:    ds_load_tr16_b128 v[52:55], v108 offset:320
-; COEXEC-NEXT:    ds_load_tr16_b128 v[60:63], v92 offset:320
-; COEXEC-NEXT:    ds_load_tr16_b128 v[64:67], v92 offset:512
-; COEXEC-NEXT:    ds_load_tr16_b128 v[72:75], v108 offset:512
-; COEXEC-NEXT:    ds_load_tr16_b128 v[68:71], v92 offset:576
-; COEXEC-NEXT:    ds_load_tr16_b128 v[76:79], v108 offset:576
-; COEXEC-NEXT:    ds_load_tr16_b128 v[80:83], v92 offset:768
-; COEXEC-NEXT:    s_wait_dscnt 0x9
+; COEXEC-NEXT:    v_mov_b32_e32 v156, s8
+; COEXEC-NEXT:    ds_load_tr16_b128 v[32:35], v124
+; COEXEC-NEXT:    ds_load_tr16_b128 v[36:39], v124 offset:64
+; COEXEC-NEXT:    ds_load_tr16_b128 v[40:43], v156
+; COEXEC-NEXT:    ds_load_tr16_b128 v[44:47], v156 offset:64
+; COEXEC-NEXT:    ds_load_tr16_b128 v[48:51], v124 offset:256
+; COEXEC-NEXT:    ds_load_tr16_b128 v[56:59], v156 offset:256
+; COEXEC-NEXT:    ds_load_tr16_b128 v[52:55], v124 offset:320
+; COEXEC-NEXT:    ds_load_tr16_b128 v[60:63], v156 offset:320
+; COEXEC-NEXT:    ds_load_tr16_b128 v[64:67], v124 offset:512
+; COEXEC-NEXT:    ds_load_tr16_b128 v[72:75], v156 offset:512
+; COEXEC-NEXT:    ds_load_tr16_b128 v[68:71], v124 offset:576
+; COEXEC-NEXT:    ds_load_tr16_b128 v[76:79], v156 offset:576
+; COEXEC-NEXT:    ds_load_tr16_b128 v[80:83], v124 offset:768
+; COEXEC-NEXT:    ds_load_tr16_b128 v[88:91], v156 offset:768
+; COEXEC-NEXT:    ds_load_tr16_b128 v[84:87], v124 offset:832
+; COEXEC-NEXT:    ds_load_tr16_b128 v[92:95], v156 offset:832
+; COEXEC-NEXT:    ds_load_tr16_b128 v[96:99], v124 offset:128
+; COEXEC-NEXT:    ds_load_tr16_b128 v[104:107], v124 offset:384
+; COEXEC-NEXT:    ds_load_tr16_b128 v[112:115], v124 offset:640
+; COEXEC-NEXT:    ds_load_tr16_b128 v[120:123], v124 offset:896
+; COEXEC-NEXT:    ds_load_tr16_b128 v[128:131], v156 offset:128
+; COEXEC-NEXT:    ds_load_tr16_b128 v[136:139], v156 offset:384
+; COEXEC-NEXT:    ds_load_tr16_b128 v[144:147], v156 offset:640
+; COEXEC-NEXT:    s_wait_dscnt 0x13
 ; COEXEC-NEXT:    v_wmma_f32_16x16x32_f16 v[24:31], v[32:39], v[40:47], v[24:31]
-; COEXEC-NEXT:    s_wait_dscnt 0x5
-; COEXEC-NEXT:    v_wmma_f32_16x16x32_f16 v[16:23], v[56:63], v[48:55], v[16:23]
-; COEXEC-NEXT:    s_wait_dscnt 0x1
+; COEXEC-NEXT:    ds_load_tr16_b128 v[152:155], v156 offset:896
+; COEXEC-NEXT:    ds_load_tr16_b128 v[100:103], v124 offset:192
+; COEXEC-NEXT:    ds_load_tr16_b128 v[108:111], v124 offset:448
+; COEXEC-NEXT:    ds_load_tr16_b128 v[116:119], v124 offset:704
+; COEXEC-NEXT:    ds_load_tr16_b128 v[124:127], v124 offset:960
+; COEXEC-NEXT:    ds_load_tr16_b128 v[132:135], v156 offset:192
+; COEXEC-NEXT:    ds_load_tr16_b128 v[140:143], v156 offset:448
+; COEXEC-NEXT:    s_wait_dscnt 0x16
+; COEXEC-NEXT:    v_wmma_f32_16x16x32_f16 v[16:23], v[48:55], v[56:63], v[16:23]
+; COEXEC-NEXT:    ds_load_tr16_b128 v[148:151], v156 offset:704
+; COEXEC-NEXT:    ds_load_tr16_b128 v[156:159], v156 offset:960
+; COEXEC-NEXT:    s_wait_dscnt 0x14
 ; COEXEC-NEXT:    v_wmma_f32_16x16x32_f16 v[8:15], v[64:71], v[72:79], v[8:15]
-; COEXEC-NEXT:    s_delay_alu instid0(TRANS32_DEP_3) | instskip(NEXT) | instid1(TRANS32_DEP_3)
-; COEXEC-NEXT:    v_wmma_f32_16x16x32_f16 v[24:31], v[32:39], v[40:47], v[24:31]
-; COEXEC-NEXT:    v_wmma_f32_16x16x32_f16 v[16:23], v[56:63], v[48:55], v[16:23]
-; COEXEC-NEXT:    s_delay_alu instid0(TRANS32_DEP_3)
-; COEXEC-NEXT:    v_wmma_f32_16x16x32_f16 v[8:15], v[64:71], v[72:79], v[8:15]
-; COEXEC-NEXT:    ds_load_tr16_b128 v[84:87], v92 offset:832
-; COEXEC-NEXT:    ds_load_tr16_b128 v[32:35], v108 offset:768
-; COEXEC-NEXT:    ds_load_tr16_b128 v[36:39], v108 offset:832
-; COEXEC-NEXT:    ds_load_tr16_b128 v[40:43], v92 offset:128
-; COEXEC-NEXT:    ds_load_tr16_b128 v[48:51], v92 offset:384
-; COEXEC-NEXT:    ds_load_tr16_b128 v[56:59], v92 offset:640
-; COEXEC-NEXT:    ds_load_tr16_b128 v[64:67], v92 offset:896
-; COEXEC-NEXT:    ds_load_tr16_b128 v[72:75], v108 offset:128
-; COEXEC-NEXT:    ds_load_tr16_b128 v[88:91], v108 offset:384
-; COEXEC-NEXT:    ds_load_tr16_b128 v[96:99], v108 offset:640
-; COEXEC-NEXT:    ds_load_tr16_b128 v[104:107], v108 offset:896
-; COEXEC-NEXT:    ds_load_tr16_b128 v[44:47], v92 offset:192
-; COEXEC-NEXT:    ds_load_tr16_b128 v[52:55], v92 offset:448
-; COEXEC-NEXT:    ds_load_tr16_b128 v[60:63], v92 offset:704
-; COEXEC-NEXT:    ds_load_tr16_b128 v[68:71], v92 offset:960
-; COEXEC-NEXT:    ds_load_tr16_b128 v[76:79], v108 offset:192
-; COEXEC-NEXT:    ds_load_tr16_b128 v[92:95], v108 offset:448
-; COEXEC-NEXT:    ds_load_tr16_b128 v[100:103], v108 offset:704
-; COEXEC-NEXT:    ds_load_tr16_b128 v[108:111], v108 offset:960
 ; COEXEC-NEXT:    s_wait_dscnt 0x10
-; COEXEC-NEXT:    v_wmma_f32_16x16x32_f16 v[0:7], v[80:87], v[32:39], v[0:7]
-; COEXEC-NEXT:    s_delay_alu instid0(TRANS32_DEP_1)
-; COEXEC-NEXT:    v_wmma_f32_16x16x32_f16 v[0:7], v[80:87], v[32:39], v[0:7]
+; COEXEC-NEXT:    v_wmma_f32_16x16x32_f16 v[0:7], v[80:87], v[88:95], v[0:7]
+; COEXEC-NEXT:    v_wmma_f32_16x16x32_f16 v[24:31], v[32:39], v[40:47], v[24:31]
+; COEXEC-NEXT:    v_wmma_f32_16x16x32_f16 v[16:23], v[48:55], v[56:63], v[16:23]
+; COEXEC-NEXT:    v_wmma_f32_16x16x32_f16 v[8:15], v[64:71], v[72:79], v[8:15]
+; COEXEC-NEXT:    v_wmma_f32_16x16x32_f16 v[0:7], v[80:87], v[88:95], v[0:7]
 ; COEXEC-NEXT:    s_wait_dscnt 0x3
-; COEXEC-NEXT:    v_wmma_f32_16x16x32_f16 v[24:31], v[40:47], v[72:79], v[24:31]
+; COEXEC-NEXT:    v_wmma_f32_16x16x32_f16 v[24:31], v[96:103], v[128:135], v[24:31]
 ; COEXEC-NEXT:    s_wait_dscnt 0x2
-; COEXEC-NEXT:    v_wmma_f32_16x16x32_f16 v[16:23], v[48:55], v[88:95], v[16:23]
+; COEXEC-NEXT:    v_wmma_f32_16x16x32_f16 v[16:23], v[104:111], v[136:143], v[16:23]
 ; COEXEC-NEXT:    s_wait_dscnt 0x1
-; COEXEC-NEXT:    v_wmma_f32_16x16x32_f16 v[8:15], v[56:63], v[96:103], v[8:15]
+; COEXEC-NEXT:    v_wmma_f32_16x16x32_f16 v[8:15], v[112:119], v[144:151], v[8:15]
 ; COEXEC-NEXT:    s_wait_dscnt 0x0
-; COEXEC-NEXT:    v_wmma_f32_16x16x32_f16 v[0:7], v[64:71], v[104:111], v[0:7]
-; COEXEC-NEXT:    v_wmma_f32_16x16x32_f16 v[24:31], v[40:47], v[72:79], v[24:31]
-; COEXEC-NEXT:    v_wmma_f32_16x16x32_f16 v[16:23], v[48:55], v[88:95], v[16:23]
-; COEXEC-NEXT:    v_wmma_f32_16x16x32_f16 v[8:15], v[56:63], v[96:103], v[8:15]
-; COEXEC-NEXT:    v_wmma_f32_16x16x32_f16 v[0:7], v[64:71], v[104:111], v[0:7]
+; COEXEC-NEXT:    v_wmma_f32_16x16x32_f16 v[0:7], v[120:127], v[152:159], v[0:7]
+; COEXEC-NEXT:    v_wmma_f32_16x16x32_f16 v[24:31], v[96:103], v[128:135], v[24:31]
+; COEXEC-NEXT:    v_wmma_f32_16x16x32_f16 v[16:23], v[104:111], v[136:143], v[16:23]
+; COEXEC-NEXT:    v_wmma_f32_16x16x32_f16 v[8:15], v[112:119], v[144:151], v[8:15]
+; COEXEC-NEXT:    v_wmma_f32_16x16x32_f16 v[0:7], v[120:127], v[152:159], v[0:7]
 ; COEXEC-NEXT:    s_cbranch_vccnz .LBB1_1
 ; COEXEC-NEXT:  ; %bb.2: ; %end
 ; COEXEC-NEXT:    v_mov_b32_e32 v32, 0

--- a/llvm/test/CodeGen/AMDGPU/coexec-scheduler.ll
+++ b/llvm/test/CodeGen/AMDGPU/coexec-scheduler.ll
@@ -287,6 +287,11 @@ define amdgpu_kernel void @ds_wmma_permute(ptr addrspace(3) %base, ptr addrspace
 ; COEXEC-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; COEXEC-NEXT:    s_add_co_i32 s7, s2, s6
 ; COEXEC-NEXT:    s_add_co_i32 s8, s3, s6
+; COEXEC-NEXT:    v_nop
+; COEXEC-NEXT:    v_nop
+; COEXEC-NEXT:    v_nop
+; COEXEC-NEXT:    v_nop
+; COEXEC-NEXT:    v_dual_mov_b32 v92, s7 :: v_dual_mov_b32 v108, s8
 ; COEXEC-NEXT:    s_add_co_i32 s6, s6, s1
 ; COEXEC-NEXT:    v_nop
 ; COEXEC-NEXT:    v_nop
@@ -294,63 +299,65 @@ define amdgpu_kernel void @ds_wmma_permute(ptr addrspace(3) %base, ptr addrspace
 ; COEXEC-NEXT:    v_nop
 ; COEXEC-NEXT:    v_mov_b32_e32 v124, s7
 ; COEXEC-NEXT:    s_and_b32 vcc_lo, exec_lo, s0
-; COEXEC-NEXT:    v_mov_b32_e32 v156, s8
-; COEXEC-NEXT:    ds_load_tr16_b128 v[32:35], v124
-; COEXEC-NEXT:    ds_load_tr16_b128 v[36:39], v124 offset:64
-; COEXEC-NEXT:    ds_load_tr16_b128 v[40:43], v156
-; COEXEC-NEXT:    ds_load_tr16_b128 v[44:47], v156 offset:64
-; COEXEC-NEXT:    ds_load_tr16_b128 v[48:51], v124 offset:256
-; COEXEC-NEXT:    ds_load_tr16_b128 v[56:59], v156 offset:256
-; COEXEC-NEXT:    ds_load_tr16_b128 v[52:55], v124 offset:320
-; COEXEC-NEXT:    ds_load_tr16_b128 v[60:63], v156 offset:320
-; COEXEC-NEXT:    ds_load_tr16_b128 v[64:67], v124 offset:512
-; COEXEC-NEXT:    ds_load_tr16_b128 v[72:75], v156 offset:512
-; COEXEC-NEXT:    ds_load_tr16_b128 v[68:71], v124 offset:576
-; COEXEC-NEXT:    ds_load_tr16_b128 v[76:79], v156 offset:576
-; COEXEC-NEXT:    ds_load_tr16_b128 v[80:83], v124 offset:768
-; COEXEC-NEXT:    ds_load_tr16_b128 v[88:91], v156 offset:768
-; COEXEC-NEXT:    ds_load_tr16_b128 v[84:87], v124 offset:832
-; COEXEC-NEXT:    ds_load_tr16_b128 v[92:95], v156 offset:832
-; COEXEC-NEXT:    ds_load_tr16_b128 v[96:99], v124 offset:128
-; COEXEC-NEXT:    ds_load_tr16_b128 v[104:107], v124 offset:384
-; COEXEC-NEXT:    ds_load_tr16_b128 v[112:115], v124 offset:640
-; COEXEC-NEXT:    ds_load_tr16_b128 v[120:123], v124 offset:896
-; COEXEC-NEXT:    ds_load_tr16_b128 v[128:131], v156 offset:128
-; COEXEC-NEXT:    ds_load_tr16_b128 v[136:139], v156 offset:384
-; COEXEC-NEXT:    ds_load_tr16_b128 v[144:147], v156 offset:640
-; COEXEC-NEXT:    s_wait_dscnt 0x13
+; COEXEC-NEXT:    ds_load_tr16_b128 v[32:35], v92
+; COEXEC-NEXT:    ds_load_tr16_b128 v[40:43], v108
+; COEXEC-NEXT:    ds_load_tr16_b128 v[36:39], v92 offset:64
+; COEXEC-NEXT:    ds_load_tr16_b128 v[44:47], v108 offset:64
+; COEXEC-NEXT:    ds_load_tr16_b128 v[48:51], v108 offset:256
+; COEXEC-NEXT:    ds_load_tr16_b128 v[56:59], v92 offset:256
+; COEXEC-NEXT:    ds_load_tr16_b128 v[52:55], v108 offset:320
+; COEXEC-NEXT:    ds_load_tr16_b128 v[60:63], v92 offset:320
+; COEXEC-NEXT:    ds_load_tr16_b128 v[64:67], v92 offset:512
+; COEXEC-NEXT:    ds_load_tr16_b128 v[72:75], v108 offset:512
+; COEXEC-NEXT:    ds_load_tr16_b128 v[68:71], v92 offset:576
+; COEXEC-NEXT:    ds_load_tr16_b128 v[76:79], v108 offset:576
+; COEXEC-NEXT:    ds_load_tr16_b128 v[80:83], v92 offset:768
+; COEXEC-NEXT:    s_wait_dscnt 0x9
 ; COEXEC-NEXT:    v_wmma_f32_16x16x32_f16 v[24:31], v[32:39], v[40:47], v[24:31]
-; COEXEC-NEXT:    ds_load_tr16_b128 v[152:155], v156 offset:896
-; COEXEC-NEXT:    ds_load_tr16_b128 v[100:103], v124 offset:192
-; COEXEC-NEXT:    ds_load_tr16_b128 v[108:111], v124 offset:448
-; COEXEC-NEXT:    ds_load_tr16_b128 v[116:119], v124 offset:704
-; COEXEC-NEXT:    ds_load_tr16_b128 v[124:127], v124 offset:960
-; COEXEC-NEXT:    ds_load_tr16_b128 v[132:135], v156 offset:192
-; COEXEC-NEXT:    ds_load_tr16_b128 v[140:143], v156 offset:448
-; COEXEC-NEXT:    s_wait_dscnt 0x16
-; COEXEC-NEXT:    v_wmma_f32_16x16x32_f16 v[16:23], v[48:55], v[56:63], v[16:23]
-; COEXEC-NEXT:    ds_load_tr16_b128 v[148:151], v156 offset:704
-; COEXEC-NEXT:    ds_load_tr16_b128 v[156:159], v156 offset:960
-; COEXEC-NEXT:    s_wait_dscnt 0x14
-; COEXEC-NEXT:    v_wmma_f32_16x16x32_f16 v[8:15], v[64:71], v[72:79], v[8:15]
-; COEXEC-NEXT:    s_wait_dscnt 0x10
-; COEXEC-NEXT:    v_wmma_f32_16x16x32_f16 v[0:7], v[80:87], v[88:95], v[0:7]
-; COEXEC-NEXT:    v_wmma_f32_16x16x32_f16 v[24:31], v[32:39], v[40:47], v[24:31]
-; COEXEC-NEXT:    v_wmma_f32_16x16x32_f16 v[16:23], v[48:55], v[56:63], v[16:23]
-; COEXEC-NEXT:    v_wmma_f32_16x16x32_f16 v[8:15], v[64:71], v[72:79], v[8:15]
-; COEXEC-NEXT:    v_wmma_f32_16x16x32_f16 v[0:7], v[80:87], v[88:95], v[0:7]
-; COEXEC-NEXT:    s_wait_dscnt 0x3
-; COEXEC-NEXT:    v_wmma_f32_16x16x32_f16 v[24:31], v[96:103], v[128:135], v[24:31]
-; COEXEC-NEXT:    s_wait_dscnt 0x2
-; COEXEC-NEXT:    v_wmma_f32_16x16x32_f16 v[16:23], v[104:111], v[136:143], v[16:23]
+; COEXEC-NEXT:    s_wait_dscnt 0x5
+; COEXEC-NEXT:    v_wmma_f32_16x16x32_f16 v[16:23], v[56:63], v[48:55], v[16:23]
 ; COEXEC-NEXT:    s_wait_dscnt 0x1
-; COEXEC-NEXT:    v_wmma_f32_16x16x32_f16 v[8:15], v[112:119], v[144:151], v[8:15]
+; COEXEC-NEXT:    v_wmma_f32_16x16x32_f16 v[8:15], v[64:71], v[72:79], v[8:15]
+; COEXEC-NEXT:    s_delay_alu instid0(TRANS32_DEP_3) | instskip(NEXT) | instid1(TRANS32_DEP_3)
+; COEXEC-NEXT:    v_wmma_f32_16x16x32_f16 v[24:31], v[32:39], v[40:47], v[24:31]
+; COEXEC-NEXT:    v_wmma_f32_16x16x32_f16 v[16:23], v[56:63], v[48:55], v[16:23]
+; COEXEC-NEXT:    s_delay_alu instid0(TRANS32_DEP_3)
+; COEXEC-NEXT:    v_wmma_f32_16x16x32_f16 v[8:15], v[64:71], v[72:79], v[8:15]
+; COEXEC-NEXT:    ds_load_tr16_b128 v[84:87], v92 offset:832
+; COEXEC-NEXT:    ds_load_tr16_b128 v[32:35], v108 offset:768
+; COEXEC-NEXT:    ds_load_tr16_b128 v[36:39], v108 offset:832
+; COEXEC-NEXT:    ds_load_tr16_b128 v[40:43], v92 offset:128
+; COEXEC-NEXT:    ds_load_tr16_b128 v[48:51], v92 offset:384
+; COEXEC-NEXT:    ds_load_tr16_b128 v[56:59], v92 offset:640
+; COEXEC-NEXT:    ds_load_tr16_b128 v[64:67], v92 offset:896
+; COEXEC-NEXT:    ds_load_tr16_b128 v[72:75], v108 offset:128
+; COEXEC-NEXT:    ds_load_tr16_b128 v[88:91], v108 offset:384
+; COEXEC-NEXT:    ds_load_tr16_b128 v[96:99], v108 offset:640
+; COEXEC-NEXT:    ds_load_tr16_b128 v[104:107], v108 offset:896
+; COEXEC-NEXT:    ds_load_tr16_b128 v[44:47], v92 offset:192
+; COEXEC-NEXT:    ds_load_tr16_b128 v[52:55], v92 offset:448
+; COEXEC-NEXT:    ds_load_tr16_b128 v[60:63], v92 offset:704
+; COEXEC-NEXT:    ds_load_tr16_b128 v[68:71], v92 offset:960
+; COEXEC-NEXT:    ds_load_tr16_b128 v[76:79], v108 offset:192
+; COEXEC-NEXT:    ds_load_tr16_b128 v[92:95], v108 offset:448
+; COEXEC-NEXT:    ds_load_tr16_b128 v[100:103], v108 offset:704
+; COEXEC-NEXT:    ds_load_tr16_b128 v[108:111], v108 offset:960
+; COEXEC-NEXT:    s_wait_dscnt 0x10
+; COEXEC-NEXT:    v_wmma_f32_16x16x32_f16 v[0:7], v[80:87], v[32:39], v[0:7]
+; COEXEC-NEXT:    s_delay_alu instid0(TRANS32_DEP_1)
+; COEXEC-NEXT:    v_wmma_f32_16x16x32_f16 v[0:7], v[80:87], v[32:39], v[0:7]
+; COEXEC-NEXT:    s_wait_dscnt 0x3
+; COEXEC-NEXT:    v_wmma_f32_16x16x32_f16 v[24:31], v[40:47], v[72:79], v[24:31]
+; COEXEC-NEXT:    s_wait_dscnt 0x2
+; COEXEC-NEXT:    v_wmma_f32_16x16x32_f16 v[16:23], v[48:55], v[88:95], v[16:23]
+; COEXEC-NEXT:    s_wait_dscnt 0x1
+; COEXEC-NEXT:    v_wmma_f32_16x16x32_f16 v[8:15], v[56:63], v[96:103], v[8:15]
 ; COEXEC-NEXT:    s_wait_dscnt 0x0
-; COEXEC-NEXT:    v_wmma_f32_16x16x32_f16 v[0:7], v[120:127], v[152:159], v[0:7]
-; COEXEC-NEXT:    v_wmma_f32_16x16x32_f16 v[24:31], v[96:103], v[128:135], v[24:31]
-; COEXEC-NEXT:    v_wmma_f32_16x16x32_f16 v[16:23], v[104:111], v[136:143], v[16:23]
-; COEXEC-NEXT:    v_wmma_f32_16x16x32_f16 v[8:15], v[112:119], v[144:151], v[8:15]
-; COEXEC-NEXT:    v_wmma_f32_16x16x32_f16 v[0:7], v[120:127], v[152:159], v[0:7]
+; COEXEC-NEXT:    v_wmma_f32_16x16x32_f16 v[0:7], v[64:71], v[104:111], v[0:7]
+; COEXEC-NEXT:    v_wmma_f32_16x16x32_f16 v[24:31], v[40:47], v[72:79], v[24:31]
+; COEXEC-NEXT:    v_wmma_f32_16x16x32_f16 v[16:23], v[48:55], v[88:95], v[16:23]
+; COEXEC-NEXT:    v_wmma_f32_16x16x32_f16 v[8:15], v[56:63], v[96:103], v[8:15]
+; COEXEC-NEXT:    v_wmma_f32_16x16x32_f16 v[0:7], v[64:71], v[104:111], v[0:7]
 ; COEXEC-NEXT:    s_cbranch_vccnz .LBB1_1
 ; COEXEC-NEXT:  ; %bb.2: ; %end
 ; COEXEC-NEXT:    v_mov_b32_e32 v32, 0


### PR DESCRIPTION
This PR adds modeling for the LDS FIFO, and adds support for modelling other types of buffers with similar characteristics.

The LDS unit has a FIFO which allows us to issue multiple LDS instructions while the first is still executing. However, the FIFO is sized, and, if we exceed the capacity, we will need to wait for a spot in the FIFO before we can issue the instruction. This adds modeling for this feature, which has impacts on: 1. the stall cycle calculations, and 2. the total usage of the HardwareUnit. The reason why this impacts 2. is because previously we just summed the cycle count for each LDS instruction for the total cycle. But, we can actually run N LDS instructions in N + SingleInstructionCycle * N / BufferSize cycles. So, if we scheduled 2 DS_LOAD instructions back to back, with SingleInstructionCycle of 20 and BufferSize of 16, it would take 21 cycles to execute them instead of 40.

The SchedModel doesn't really have any good way to express this. It has BufferSize property for ProcResource, but this is mainly used for OOO scheduling, and it doesn't have any impact on stalling behavior. We can replicate the LDS ProcResource N times, but this is hacking the SchedModel to get the desired stall behavior while misrepresenting the hardware. In this modelling, if we ever need to understand that two DS instructions actually use the same ProcResource, we will need to write custom C++ on top of the SchedModel.

Manually managed stack:

[AMDGPU] Add stalls for DS FIFO buffer https://github.com/llvm/llvm-project/pull/185726 👈
[AMDGPU] Add HWUI pressure heuristics to coexec strategy https://github.com/llvm/llvm-project/pull/184929 
