### PR TITLE
[bazel][mlir] Remove non-existent file mlir/run_lit.sh

### DIFF
--- a/utils/bazel/llvm-project-overlay/mlir/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/mlir/BUILD.bazel
@@ -28,7 +28,6 @@ licenses(["notice"])
 
 exports_files([
     "LICENSE.TXT",
-    "run_lit.sh",
     "utils/lldb-scripts/mlirDataFormatters.py",
     "utils/pygments/mlir_lexer.py",
     "utils/textmate/mlir.json",


### PR DESCRIPTION
This file does not exist. Surprisingly, it's not a fatal error to have it in the list, as long as you don't explicitly reference it.