### PR TITLE
libclc: Add div_cr utility function

### DIFF
--- a/libclc/clc/include/clc/math/clc_div_cr.h
+++ b/libclc/clc/include/clc/math/clc_div_cr.h
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef __CLC_MATH_DIV_CR_H__
+#define __CLC_MATH_DIV_CR_H__
+
+// Declare overloads of __clc_div_cr. This is a wrapper around the
+// floating-point / operator. This is a utilty to deal with the language default
+// division not being correctly rounded, and requires the
+// -cl-fp32-correctly-rounded-divide-sqrt flag. This will just be the operator
+// compiled with that option. Ideally clang would expose a direct way to get the
+// correctly rounded and opencl precision versions.
+
+#define __CLC_BODY <clc/shared/binary_decl.inc>
+#define __CLC_FUNCTION __clc_div_cr
+
+#include <clc/math/gentype.inc>
+
+#undef __CLC_FUNCTION
+
+#endif // __CLC_MATH_DIV_CR_H__

--- a/libclc/clc/include/clc/math/clc_div_cr.h
+++ b/libclc/clc/include/clc/math/clc_div_cr.h
@@ -16,8 +16,8 @@
 // compiled with that option. Ideally clang would expose a direct way to get the
 // correctly rounded and opencl precision versions.
 
-#define __CLC_BODY <clc/shared/binary_decl.inc>
 #define __CLC_FUNCTION __clc_div_cr
+#define __CLC_BODY <clc/shared/binary_decl.inc>
 
 #include <clc/math/gentype.inc>
 

--- a/libclc/clc/lib/generic/CMakeLists.txt
+++ b/libclc/clc/lib/generic/CMakeLists.txt
@@ -72,6 +72,7 @@ libclc_configure_source_list(CLC_GENERIC_SOURCES
   math/clc_cos.cl
   math/clc_cosh.cl
   math/clc_cospi.cl
+  math/clc_div_cr.cl
   math/clc_ep_log.cl
   math/clc_erf.cl
   math/clc_erfc.cl
@@ -206,3 +207,6 @@ libclc_configure_source_options(${CMAKE_CURRENT_SOURCE_DIR} -fapprox-func
   math/clc_native_sqrt.cl
   math/clc_native_tan.cl
 )
+
+libclc_configure_source_options(${CMAKE_CURRENT_SOURCE_DIR} -cl-fp32-correctly-rounded-divide-sqrt
+  math/clc_div_cr.cl)

--- a/libclc/clc/lib/generic/math/clc_div_cr.cl
+++ b/libclc/clc/lib/generic/math/clc_div_cr.cl
@@ -1,0 +1,11 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "clc/math/clc_div_cr.h"
+#define __CLC_BODY <clc_div_cr.inc>
+#include <clc/math/gentype.inc>

--- a/libclc/clc/lib/generic/math/clc_div_cr.inc
+++ b/libclc/clc/lib/generic/math/clc_div_cr.inc
@@ -1,0 +1,12 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+_CLC_OVERLOAD _CLC_DEF __CLC_GENTYPE __clc_div_cr(__CLC_GENTYPE x,
+                                                  __CLC_GENTYPE y) {
+  return x / y;
+}


### PR DESCRIPTION
This is a workaround for the modal div operator precision. The
OpenCL default is not correctly rounded, so this provides a backdoor
to get a correctly rounded fdiv. Ideally clang would have a builtin
or some other mechanism to control the precision.