### PR TITLE
[AMDGPU] Localize resource info symbols

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUAsmPrinter.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUAsmPrinter.cpp
@@ -403,8 +403,8 @@ void AMDGPUAsmPrinter::validateMCResourceInfo(Function &F) {
 
   const uint64_t MaxScratchPerWorkitem =
       STM.getMaxWaveScratchSize() / STM.getWavefrontSize();
-  MCSymbol *ScratchSizeSymbol = RI.getSymbol(
-      FnSym->getName(), RIK::RIK_PrivateSegSize, OutContext);
+  MCSymbol *ScratchSizeSymbol =
+      RI.getSymbol(FnSym->getName(), RIK::RIK_PrivateSegSize, OutContext);
   uint64_t ScratchSize;
   if (ScratchSizeSymbol->isVariable() &&
       TryGetMCExprValue(ScratchSizeSymbol->getVariableValue(), ScratchSize) &&
@@ -435,8 +435,8 @@ void AMDGPUAsmPrinter::validateMCResourceInfo(Function &F) {
 
   MCSymbol *VCCUsedSymbol =
       RI.getSymbol(FnSym->getName(), RIK::RIK_UsesVCC, OutContext);
-  MCSymbol *FlatUsedSymbol = RI.getSymbol(
-      FnSym->getName(), RIK::RIK_UsesFlatScratch, OutContext);
+  MCSymbol *FlatUsedSymbol =
+      RI.getSymbol(FnSym->getName(), RIK::RIK_UsesFlatScratch, OutContext);
   uint64_t VCCUsed, FlatUsed, NumSgpr;
 
   if (NumSGPRSymbol->isVariable() && VCCUsedSymbol->isVariable() &&
@@ -768,11 +768,10 @@ bool AMDGPUAsmPrinter::runOnMachineFunction(MachineFunction &MF) {
       emitCommonFunctionComments(
           RI.getSymbol(CurrentFnSym->getName(), RIK::RIK_NumVGPR, OutContext)
               ->getVariableValue(),
-          STM.hasMAIInsts()
-              ? RI.getSymbol(CurrentFnSym->getName(), RIK::RIK_NumAGPR,
-                             OutContext)
-                    ->getVariableValue()
-              : nullptr,
+          STM.hasMAIInsts() ? RI.getSymbol(CurrentFnSym->getName(),
+                                           RIK::RIK_NumAGPR, OutContext)
+                                  ->getVariableValue()
+                            : nullptr,
           RI.createTotalNumVGPRs(MF, Ctx),
           RI.createTotalNumSGPRs(
               MF,
@@ -1013,8 +1012,7 @@ void AMDGPUAsmPrinter::getSIProgramInfo(SIProgramInfo &ProgInfo,
 
   auto GetSymRefExpr =
       [&](MCResourceInfo::ResourceInfoKind RIK) -> const MCExpr * {
-    MCSymbol *Sym =
-        RI.getSymbol(CurrentFnSym->getName(), RIK, OutContext);
+    MCSymbol *Sym = RI.getSymbol(CurrentFnSym->getName(), RIK, OutContext);
     return MCSymbolRefExpr::create(Sym, Ctx);
   };
 

--- a/llvm/lib/Target/AMDGPU/AMDGPUAsmPrinter.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUAsmPrinter.cpp
@@ -391,7 +391,6 @@ void AMDGPUAsmPrinter::validateMCResourceInfo(Function &F) {
   using RIK = MCResourceInfo::ResourceInfoKind;
   const GCNSubtarget &STM = TM.getSubtarget<GCNSubtarget>(F);
   MCSymbol *FnSym = TM.getSymbol(&F);
-  bool IsLocal = F.hasLocalLinkage();
 
   auto TryGetMCExprValue = [](const MCExpr *Value, uint64_t &Res) -> bool {
     int64_t Val;
@@ -405,7 +404,7 @@ void AMDGPUAsmPrinter::validateMCResourceInfo(Function &F) {
   const uint64_t MaxScratchPerWorkitem =
       STM.getMaxWaveScratchSize() / STM.getWavefrontSize();
   MCSymbol *ScratchSizeSymbol = RI.getSymbol(
-      FnSym->getName(), RIK::RIK_PrivateSegSize, OutContext, IsLocal);
+      FnSym->getName(), RIK::RIK_PrivateSegSize, OutContext);
   uint64_t ScratchSize;
   if (ScratchSizeSymbol->isVariable() &&
       TryGetMCExprValue(ScratchSizeSymbol->getVariableValue(), ScratchSize) &&
@@ -418,7 +417,7 @@ void AMDGPUAsmPrinter::validateMCResourceInfo(Function &F) {
   // Validate addressable scalar registers (i.e., prior to added implicit
   // SGPRs).
   MCSymbol *NumSGPRSymbol =
-      RI.getSymbol(FnSym->getName(), RIK::RIK_NumSGPR, OutContext, IsLocal);
+      RI.getSymbol(FnSym->getName(), RIK::RIK_NumSGPR, OutContext);
   if (STM.getGeneration() >= AMDGPUSubtarget::VOLCANIC_ISLANDS &&
       !STM.hasSGPRInitBug()) {
     unsigned MaxAddressableNumSGPRs = STM.getAddressableNumSGPRs();
@@ -435,9 +434,9 @@ void AMDGPUAsmPrinter::validateMCResourceInfo(Function &F) {
   }
 
   MCSymbol *VCCUsedSymbol =
-      RI.getSymbol(FnSym->getName(), RIK::RIK_UsesVCC, OutContext, IsLocal);
+      RI.getSymbol(FnSym->getName(), RIK::RIK_UsesVCC, OutContext);
   MCSymbol *FlatUsedSymbol = RI.getSymbol(
-      FnSym->getName(), RIK::RIK_UsesFlatScratch, OutContext, IsLocal);
+      FnSym->getName(), RIK::RIK_UsesFlatScratch, OutContext);
   uint64_t VCCUsed, FlatUsed, NumSgpr;
 
   if (NumSGPRSymbol->isVariable() && VCCUsedSymbol->isVariable() &&
@@ -464,9 +463,9 @@ void AMDGPUAsmPrinter::validateMCResourceInfo(Function &F) {
     }
 
     MCSymbol *NumVgprSymbol =
-        RI.getSymbol(FnSym->getName(), RIK::RIK_NumVGPR, OutContext, IsLocal);
+        RI.getSymbol(FnSym->getName(), RIK::RIK_NumVGPR, OutContext);
     MCSymbol *NumAgprSymbol =
-        RI.getSymbol(FnSym->getName(), RIK::RIK_NumAGPR, OutContext, IsLocal);
+        RI.getSymbol(FnSym->getName(), RIK::RIK_NumAGPR, OutContext);
     uint64_t NumVgpr, NumAgpr;
 
     MachineModuleInfo &MMI =
@@ -693,7 +692,6 @@ bool AMDGPUAsmPrinter::runOnMachineFunction(MachineFunction &MF) {
 
   const GCNSubtarget &STM = MF.getSubtarget<GCNSubtarget>();
   MCContext &Context = getObjFileLowering().getContext();
-  bool IsLocal = MF.getFunction().hasLocalLinkage();
   // FIXME: This should be an explicit check for Mesa.
   if (!STM.isAmdHsaOS() && !STM.isAmdPalOS()) {
     MCSectionELF *ConfigSection =
@@ -737,26 +735,22 @@ bool AMDGPUAsmPrinter::runOnMachineFunction(MachineFunction &MF) {
   {
     using RIK = MCResourceInfo::ResourceInfoKind;
     getTargetStreamer()->EmitMCResourceInfo(
-        RI.getSymbol(CurrentFnSym->getName(), RIK::RIK_NumVGPR, OutContext,
-                     IsLocal),
-        RI.getSymbol(CurrentFnSym->getName(), RIK::RIK_NumAGPR, OutContext,
-                     IsLocal),
-        RI.getSymbol(CurrentFnSym->getName(), RIK::RIK_NumSGPR, OutContext,
-                     IsLocal),
+        RI.getSymbol(CurrentFnSym->getName(), RIK::RIK_NumVGPR, OutContext),
+        RI.getSymbol(CurrentFnSym->getName(), RIK::RIK_NumAGPR, OutContext),
+        RI.getSymbol(CurrentFnSym->getName(), RIK::RIK_NumSGPR, OutContext),
         RI.getSymbol(CurrentFnSym->getName(), RIK::RIK_NumNamedBarrier,
-                     OutContext, IsLocal),
+                     OutContext),
         RI.getSymbol(CurrentFnSym->getName(), RIK::RIK_PrivateSegSize,
-                     OutContext, IsLocal),
-        RI.getSymbol(CurrentFnSym->getName(), RIK::RIK_UsesVCC, OutContext,
-                     IsLocal),
+                     OutContext),
+        RI.getSymbol(CurrentFnSym->getName(), RIK::RIK_UsesVCC, OutContext),
         RI.getSymbol(CurrentFnSym->getName(), RIK::RIK_UsesFlatScratch,
-                     OutContext, IsLocal),
+                     OutContext),
         RI.getSymbol(CurrentFnSym->getName(), RIK::RIK_HasDynSizedStack,
-                     OutContext, IsLocal),
-        RI.getSymbol(CurrentFnSym->getName(), RIK::RIK_HasRecursion, OutContext,
-                     IsLocal),
+                     OutContext),
+        RI.getSymbol(CurrentFnSym->getName(), RIK::RIK_HasRecursion,
+                     OutContext),
         RI.getSymbol(CurrentFnSym->getName(), RIK::RIK_HasIndirectCall,
-                     OutContext, IsLocal));
+                     OutContext));
   }
 
   // Emit _dvgpr$ symbol when appropriate.
@@ -772,12 +766,11 @@ bool AMDGPUAsmPrinter::runOnMachineFunction(MachineFunction &MF) {
       OutStreamer->emitRawComment(" Function info:", false);
 
       emitCommonFunctionComments(
-          RI.getSymbol(CurrentFnSym->getName(), RIK::RIK_NumVGPR, OutContext,
-                       IsLocal)
+          RI.getSymbol(CurrentFnSym->getName(), RIK::RIK_NumVGPR, OutContext)
               ->getVariableValue(),
           STM.hasMAIInsts()
               ? RI.getSymbol(CurrentFnSym->getName(), RIK::RIK_NumAGPR,
-                             OutContext, IsLocal)
+                             OutContext)
                     ->getVariableValue()
               : nullptr,
           RI.createTotalNumVGPRs(MF, Ctx),
@@ -786,7 +779,7 @@ bool AMDGPUAsmPrinter::runOnMachineFunction(MachineFunction &MF) {
               MF.getSubtarget<GCNSubtarget>().getTargetID().isXnackOnOrAny(),
               Ctx),
           RI.getSymbol(CurrentFnSym->getName(), RIK::RIK_PrivateSegSize,
-                       OutContext, IsLocal)
+                       OutContext)
               ->getVariableValue(),
           CurrentProgramInfo.getFunctionCodeSize(MF), MFI);
       return false;
@@ -1003,7 +996,6 @@ static const MCExpr *computeAccumOffset(const MCExpr *NumVGPR, MCContext &Ctx) {
 void AMDGPUAsmPrinter::getSIProgramInfo(SIProgramInfo &ProgInfo,
                                         const MachineFunction &MF) {
   const GCNSubtarget &STM = MF.getSubtarget<GCNSubtarget>();
-  bool IsLocal = MF.getFunction().hasLocalLinkage();
   MCContext &Ctx = MF.getContext();
 
   auto CreateExpr = [&Ctx](int64_t Value) {
@@ -1022,7 +1014,7 @@ void AMDGPUAsmPrinter::getSIProgramInfo(SIProgramInfo &ProgInfo,
   auto GetSymRefExpr =
       [&](MCResourceInfo::ResourceInfoKind RIK) -> const MCExpr * {
     MCSymbol *Sym =
-        RI.getSymbol(CurrentFnSym->getName(), RIK, OutContext, IsLocal);
+        RI.getSymbol(CurrentFnSym->getName(), RIK, OutContext);
     return MCSymbolRefExpr::create(Sym, Ctx);
   };
 

--- a/llvm/lib/Target/AMDGPU/AMDGPUMCResourceInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUMCResourceInfo.cpp
@@ -284,8 +284,7 @@ void MCResourceInfo::gatherResourceInfo(
                              FRI.Callees, OutContext);
     } else {
       const MCExpr *SymRef = MCSymbolRefExpr::create(MaxSym, OutContext);
-      MCSymbol *LocalNumSym =
-          getSymbol(FnSym->getName(), RIK, OutContext);
+      MCSymbol *LocalNumSym = getSymbol(FnSym->getName(), RIK, OutContext);
       const MCExpr *MaxWithLocal = AMDGPUMCExpr::createMax(
           {MCConstantExpr::create(numRegs, OutContext), SymRef}, OutContext);
       LocalNumSym->setVariableValue(MaxWithLocal);
@@ -304,8 +303,7 @@ void MCResourceInfo::gatherResourceInfo(
     // The expression for private segment size should be: FRI.PrivateSegmentSize
     // + max(FRI.Callees, FRI.CalleeSegmentSize)
     SmallVector<const MCExpr *, 8> ArgExprs;
-    MCSymbol *Sym =
-        getSymbol(FnSym->getName(), RIK_PrivateSegSize, OutContext);
+    MCSymbol *Sym = getSymbol(FnSym->getName(), RIK_PrivateSegSize, OutContext);
     if (FRI.CalleeSegmentSize) {
       LLVM_DEBUG(dbgs() << "MCResUse:   " << Sym->getName() << ": Adding "
                         << FRI.CalleeSegmentSize
@@ -399,7 +397,7 @@ const MCExpr *MCResourceInfo::createTotalNumSGPRs(const MachineFunction &MF,
       getSymRefExpr(FnSym->getName(), RIK_NumSGPR, Ctx),
       AMDGPUMCExpr::createExtraSGPRs(
           getSymRefExpr(FnSym->getName(), RIK_UsesVCC, Ctx),
-          getSymRefExpr(FnSym->getName(), RIK_UsesFlatScratch, Ctx),
-          hasXnack, Ctx),
+          getSymRefExpr(FnSym->getName(), RIK_UsesFlatScratch, Ctx), hasXnack,
+          Ctx),
       Ctx);
 }

--- a/llvm/lib/Target/AMDGPU/AMDGPUMCResourceInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUMCResourceInfo.cpp
@@ -18,23 +18,16 @@
 #include "llvm/MC/MCAsmInfo.h"
 #include "llvm/MC/MCContext.h"
 #include "llvm/MC/MCSymbol.h"
-#include "llvm/Support/CommandLine.h"
 #include "llvm/Target/TargetMachine.h"
 
 #define DEBUG_TYPE "amdgpu-mc-resource-usage"
 
 using namespace llvm;
 
-static cl::opt<bool> LocalizeResourceSymbols(
-    "amdgpu-localize-resource-symbols", cl::Hidden,
-    cl::desc("Localize all resource information symbols."), cl::init(true));
-
 MCSymbol *MCResourceInfo::getSymbol(StringRef FuncName, ResourceInfoKind RIK,
-                                    MCContext &OutContext, bool IsLocal) {
-  auto GOCS = [FuncName, &OutContext, IsLocal](StringRef Suffix) {
-    StringRef Prefix = LocalizeResourceSymbols || IsLocal
-                           ? OutContext.getAsmInfo()->getInternalSymbolPrefix()
-                           : "";
+                                    MCContext &OutContext) {
+  auto GOCS = [FuncName, &OutContext](StringRef Suffix) {
+    StringRef Prefix = OutContext.getAsmInfo()->getInternalSymbolPrefix();
     return OutContext.getOrCreateSymbol(Twine(Prefix) + FuncName +
                                         Twine(Suffix));
   };
@@ -65,8 +58,8 @@ MCSymbol *MCResourceInfo::getSymbol(StringRef FuncName, ResourceInfoKind RIK,
 
 const MCExpr *MCResourceInfo::getSymRefExpr(StringRef FuncName,
                                             ResourceInfoKind RIK,
-                                            MCContext &Ctx, bool IsLocal) {
-  return MCSymbolRefExpr::create(getSymbol(FuncName, RIK, Ctx, IsLocal), Ctx);
+                                            MCContext &Ctx) {
+  return MCSymbolRefExpr::create(getSymbol(FuncName, RIK, Ctx), Ctx);
 }
 
 void MCResourceInfo::assignMaxRegs(MCContext &OutContext) {
@@ -196,12 +189,11 @@ void MCResourceInfo::assignResourceInfoExpr(
     const MachineFunction &MF, const SmallVectorImpl<const Function *> &Callees,
     MCContext &OutContext) {
   const TargetMachine &TM = MF.getTarget();
-  bool IsLocal = MF.getFunction().hasLocalLinkage();
   MCSymbol *FnSym = TM.getSymbol(&MF.getFunction());
   const MCConstantExpr *LocalConstExpr =
       MCConstantExpr::create(LocalValue, OutContext);
   const MCExpr *SymVal = LocalConstExpr;
-  MCSymbol *Sym = getSymbol(FnSym->getName(), RIK, OutContext, IsLocal);
+  MCSymbol *Sym = getSymbol(FnSym->getName(), RIK, OutContext);
   LLVM_DEBUG(dbgs() << "MCResUse:   " << Sym->getName() << ": Adding "
                     << LocalValue << " as function local usage\n");
   if (!Callees.empty()) {
@@ -213,10 +205,9 @@ void MCResourceInfo::assignResourceInfoExpr(
       if (!Seen.insert(Callee).second)
         continue;
 
-      bool IsCalleeLocal = Callee->hasLocalLinkage();
       MCSymbol *CalleeFnSym = TM.getSymbol(&Callee->getFunction());
       MCSymbol *CalleeValSym =
-          getSymbol(CalleeFnSym->getName(), RIK, OutContext, IsCalleeLocal);
+          getSymbol(CalleeFnSym->getName(), RIK, OutContext);
 
       // Avoid constructing recursive definitions by detecting whether `Sym` is
       // found transitively within any of its `CalleeValSym`.
@@ -262,7 +253,6 @@ void MCResourceInfo::gatherResourceInfo(
   MCSymbol *MaxVGPRSym = getMaxVGPRSymbol(OutContext);
   MCSymbol *MaxAGPRSym = getMaxAGPRSymbol(OutContext);
   MCSymbol *MaxSGPRSym = getMaxSGPRSymbol(OutContext);
-  bool IsLocal = MF.getFunction().hasLocalLinkage();
   MCSymbol *MaxNamedBarrierSym = getMaxNamedBarrierSymbol(OutContext);
 
   if (!AMDGPU::isEntryFunctionCC(MF.getFunction().getCallingConv())) {
@@ -295,7 +285,7 @@ void MCResourceInfo::gatherResourceInfo(
     } else {
       const MCExpr *SymRef = MCSymbolRefExpr::create(MaxSym, OutContext);
       MCSymbol *LocalNumSym =
-          getSymbol(FnSym->getName(), RIK, OutContext, IsLocal);
+          getSymbol(FnSym->getName(), RIK, OutContext);
       const MCExpr *MaxWithLocal = AMDGPUMCExpr::createMax(
           {MCConstantExpr::create(numRegs, OutContext), SymRef}, OutContext);
       LocalNumSym->setVariableValue(MaxWithLocal);
@@ -315,7 +305,7 @@ void MCResourceInfo::gatherResourceInfo(
     // + max(FRI.Callees, FRI.CalleeSegmentSize)
     SmallVector<const MCExpr *, 8> ArgExprs;
     MCSymbol *Sym =
-        getSymbol(FnSym->getName(), RIK_PrivateSegSize, OutContext, IsLocal);
+        getSymbol(FnSym->getName(), RIK_PrivateSegSize, OutContext);
     if (FRI.CalleeSegmentSize) {
       LLVM_DEBUG(dbgs() << "MCResUse:   " << Sym->getName() << ": Adding "
                         << FRI.CalleeSegmentSize
@@ -330,11 +320,9 @@ void MCResourceInfo::gatherResourceInfo(
       if (!Seen.insert(Callee).second)
         continue;
       if (!Callee->isDeclaration()) {
-        bool IsCalleeLocal = Callee->hasLocalLinkage();
         MCSymbol *CalleeFnSym = TM.getSymbol(&Callee->getFunction());
         MCSymbol *CalleeValSym =
-            getSymbol(CalleeFnSym->getName(), RIK_PrivateSegSize, OutContext,
-                      IsCalleeLocal);
+            getSymbol(CalleeFnSym->getName(), RIK_PrivateSegSize, OutContext);
 
         // Avoid constructing recursive definitions by detecting whether `Sym`
         // is found transitively within any of its `CalleeValSym`.
@@ -362,7 +350,7 @@ void MCResourceInfo::gatherResourceInfo(
   }
 
   auto SetToLocal = [&](int64_t LocalValue, ResourceInfoKind RIK) {
-    MCSymbol *Sym = getSymbol(FnSym->getName(), RIK, OutContext, IsLocal);
+    MCSymbol *Sym = getSymbol(FnSym->getName(), RIK, OutContext);
     LLVM_DEBUG(
         dbgs() << "MCResUse:   " << Sym->getName() << ": Adding " << LocalValue
                << ", no further propagation as indirect callee found within\n");
@@ -397,10 +385,9 @@ const MCExpr *MCResourceInfo::createTotalNumVGPRs(const MachineFunction &MF,
                                                   MCContext &Ctx) {
   const TargetMachine &TM = MF.getTarget();
   MCSymbol *FnSym = TM.getSymbol(&MF.getFunction());
-  bool IsLocal = MF.getFunction().hasLocalLinkage();
   return AMDGPUMCExpr::createTotalNumVGPR(
-      getSymRefExpr(FnSym->getName(), RIK_NumAGPR, Ctx, IsLocal),
-      getSymRefExpr(FnSym->getName(), RIK_NumVGPR, Ctx, IsLocal), Ctx);
+      getSymRefExpr(FnSym->getName(), RIK_NumAGPR, Ctx),
+      getSymRefExpr(FnSym->getName(), RIK_NumVGPR, Ctx), Ctx);
 }
 
 const MCExpr *MCResourceInfo::createTotalNumSGPRs(const MachineFunction &MF,
@@ -408,12 +395,11 @@ const MCExpr *MCResourceInfo::createTotalNumSGPRs(const MachineFunction &MF,
                                                   MCContext &Ctx) {
   const TargetMachine &TM = MF.getTarget();
   MCSymbol *FnSym = TM.getSymbol(&MF.getFunction());
-  bool IsLocal = MF.getFunction().hasLocalLinkage();
   return MCBinaryExpr::createAdd(
-      getSymRefExpr(FnSym->getName(), RIK_NumSGPR, Ctx, IsLocal),
+      getSymRefExpr(FnSym->getName(), RIK_NumSGPR, Ctx),
       AMDGPUMCExpr::createExtraSGPRs(
-          getSymRefExpr(FnSym->getName(), RIK_UsesVCC, Ctx, IsLocal),
-          getSymRefExpr(FnSym->getName(), RIK_UsesFlatScratch, Ctx, IsLocal),
+          getSymRefExpr(FnSym->getName(), RIK_UsesVCC, Ctx),
+          getSymRefExpr(FnSym->getName(), RIK_UsesFlatScratch, Ctx),
           hasXnack, Ctx),
       Ctx);
 }

--- a/llvm/lib/Target/AMDGPU/AMDGPUMCResourceInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUMCResourceInfo.cpp
@@ -18,17 +18,23 @@
 #include "llvm/MC/MCAsmInfo.h"
 #include "llvm/MC/MCContext.h"
 #include "llvm/MC/MCSymbol.h"
+#include "llvm/Support/CommandLine.h"
 #include "llvm/Target/TargetMachine.h"
 
 #define DEBUG_TYPE "amdgpu-mc-resource-usage"
 
 using namespace llvm;
 
+static cl::opt<bool> LocalizeResourceSymbols(
+    "amdgpu-localize-resource-symbols", cl::Hidden,
+    cl::desc("Localize all resource information symbols."), cl::init(true));
+
 MCSymbol *MCResourceInfo::getSymbol(StringRef FuncName, ResourceInfoKind RIK,
                                     MCContext &OutContext, bool IsLocal) {
   auto GOCS = [FuncName, &OutContext, IsLocal](StringRef Suffix) {
-    StringRef Prefix =
-        IsLocal ? OutContext.getAsmInfo()->getInternalSymbolPrefix() : "";
+    StringRef Prefix = LocalizeResourceSymbols || IsLocal
+                           ? OutContext.getAsmInfo()->getInternalSymbolPrefix()
+                           : "";
     return OutContext.getOrCreateSymbol(Twine(Prefix) + FuncName +
                                         Twine(Suffix));
   };

--- a/llvm/lib/Target/AMDGPU/AMDGPUMCResourceInfo.h
+++ b/llvm/lib/Target/AMDGPU/AMDGPUMCResourceInfo.h
@@ -82,9 +82,9 @@ public:
   }
 
   MCSymbol *getSymbol(StringRef FuncName, ResourceInfoKind RIK,
-                      MCContext &OutContext, bool IsLocal);
+                      MCContext &OutContext);
   const MCExpr *getSymRefExpr(StringRef FuncName, ResourceInfoKind RIK,
-                              MCContext &Ctx, bool IsLocal);
+                              MCContext &Ctx);
 
   void reset();
 

--- a/llvm/test/CodeGen/AMDGPU/agpr-register-count.ll
+++ b/llvm/test/CodeGen/AMDGPU/agpr-register-count.ll
@@ -1,5 +1,5 @@
-; RUN: llc -mtriple=amdgcn--amdhsa -amdgpu-localize-resource-symbols=false -mcpu=gfx908 < %s | FileCheck -check-prefixes=GCN,GFX908 %s
-; RUN: llc -mtriple=amdgcn--amdhsa -amdgpu-localize-resource-symbols=false -mcpu=gfx90a < %s | FileCheck -check-prefixes=GCN,GFX90A %s
+; RUN: llc -mtriple=amdgcn--amdhsa -mcpu=gfx908 < %s | FileCheck -check-prefixes=GCN,GFX908 %s
+; RUN: llc -mtriple=amdgcn--amdhsa -mcpu=gfx90a < %s | FileCheck -check-prefixes=GCN,GFX90A %s
 
 ; GCN-LABEL: {{^}}kernel_32_agprs:
 ; GFX908: .amdhsa_next_free_vgpr 32
@@ -154,20 +154,20 @@ bb:
 declare void @undef_func()
 
 ; GCN-LABEL: {{^}}kernel_call_undef_func:
-; GCN:    .amdhsa_next_free_vgpr max(totalnumvgprs(kernel_call_undef_func.num_agpr, kernel_call_undef_func.num_vgpr), 1, 0)
-; GFX90A: .amdhsa_accum_offset (((((alignto(max(1, kernel_call_undef_func.num_vgpr), 4)/4)-1)&~65536)&63)+1)*4
-; GCN:    .set kernel_call_undef_func.num_vgpr, max(32, amdgpu.max_num_vgpr)
-; GCN:    .set kernel_call_undef_func.num_agpr, max(0, amdgpu.max_num_agpr)
-; GCN:    NumVgprs: kernel_call_undef_func.num_vgpr
-; GCN:    NumAgprs: kernel_call_undef_func.num_agpr
-; GCN:    TotalNumVgprs: totalnumvgprs(kernel_call_undef_func.num_agpr, kernel_call_undef_func.num_vgpr)
-; GFX908: VGPRBlocks: (alignto(max(max(totalnumvgprs(kernel_call_undef_func.num_agpr, kernel_call_undef_func.num_vgpr), 1, 0), 1), 4)/4)-1
-; GFX90A: VGPRBlocks: (alignto(max(max(totalnumvgprs(kernel_call_undef_func.num_agpr, kernel_call_undef_func.num_vgpr), 1, 0), 1), 8)/8)-1
-; GCN:    NumVGPRsForWavesPerEU: max(totalnumvgprs(kernel_call_undef_func.num_agpr, kernel_call_undef_func.num_vgpr), 1, 0)
-; GFX90A: AccumOffset: ((alignto(max(1, kernel_call_undef_func.num_vgpr), 4)/4)-1+1)*4
-; GFX908: Occupancy: occupancy(10, 4, 256, 8, 10, max(kernel_call_undef_func.numbered_sgpr+extrasgprs(kernel_call_undef_func.uses_vcc, kernel_call_undef_func.uses_flat_scratch, 1), 1, 0), max(totalnumvgprs(kernel_call_undef_func.num_agpr, kernel_call_undef_func.num_vgpr), 1, 0))
-; GFX90A: Occupancy: occupancy(8, 8, 512, 8, 8, max(kernel_call_undef_func.numbered_sgpr+extrasgprs(kernel_call_undef_func.uses_vcc, kernel_call_undef_func.uses_flat_scratch, 1), 1, 0), max(totalnumvgprs(kernel_call_undef_func.num_agpr, kernel_call_undef_func.num_vgpr), 1, 0))
-; GFX90A: COMPUTE_PGM_RSRC3_GFX90A:ACCUM_OFFSET: (((alignto(max(1, kernel_call_undef_func.num_vgpr), 4)/4)-1)&~65536)&63
+; GCN:    .amdhsa_next_free_vgpr max(totalnumvgprs(.Lkernel_call_undef_func.num_agpr, .Lkernel_call_undef_func.num_vgpr), 1, 0)
+; GFX90A: .amdhsa_accum_offset (((((alignto(max(1, .Lkernel_call_undef_func.num_vgpr), 4)/4)-1)&~65536)&63)+1)*4
+; GCN:    .set .Lkernel_call_undef_func.num_vgpr, max(32, amdgpu.max_num_vgpr)
+; GCN:    .set .Lkernel_call_undef_func.num_agpr, max(0, amdgpu.max_num_agpr)
+; GCN:    NumVgprs: .Lkernel_call_undef_func.num_vgpr
+; GCN:    NumAgprs: .Lkernel_call_undef_func.num_agpr
+; GCN:    TotalNumVgprs: totalnumvgprs(.Lkernel_call_undef_func.num_agpr, .Lkernel_call_undef_func.num_vgpr)
+; GFX908: VGPRBlocks: (alignto(max(max(totalnumvgprs(.Lkernel_call_undef_func.num_agpr, .Lkernel_call_undef_func.num_vgpr), 1, 0), 1), 4)/4)-1
+; GFX90A: VGPRBlocks: (alignto(max(max(totalnumvgprs(.Lkernel_call_undef_func.num_agpr, .Lkernel_call_undef_func.num_vgpr), 1, 0), 1), 8)/8)-1
+; GCN:    NumVGPRsForWavesPerEU: max(totalnumvgprs(.Lkernel_call_undef_func.num_agpr, .Lkernel_call_undef_func.num_vgpr), 1, 0)
+; GFX90A: AccumOffset: ((alignto(max(1, .Lkernel_call_undef_func.num_vgpr), 4)/4)-1+1)*4
+; GFX908: Occupancy: occupancy(10, 4, 256, 8, 10, max(.Lkernel_call_undef_func.numbered_sgpr+extrasgprs(.Lkernel_call_undef_func.uses_vcc, .Lkernel_call_undef_func.uses_flat_scratch, 1), 1, 0), max(totalnumvgprs(.Lkernel_call_undef_func.num_agpr, .Lkernel_call_undef_func.num_vgpr), 1, 0))
+; GFX90A: Occupancy: occupancy(8, 8, 512, 8, 8, max(.Lkernel_call_undef_func.numbered_sgpr+extrasgprs(.Lkernel_call_undef_func.uses_vcc, .Lkernel_call_undef_func.uses_flat_scratch, 1), 1, 0), max(totalnumvgprs(.Lkernel_call_undef_func.num_agpr, .Lkernel_call_undef_func.num_vgpr), 1, 0))
+; GFX90A: COMPUTE_PGM_RSRC3_GFX90A:ACCUM_OFFSET: (((alignto(max(1, .Lkernel_call_undef_func.num_vgpr), 4)/4)-1)&~65536)&63
 define amdgpu_kernel void @kernel_call_undef_func() #0 {
 bb:
   call void @undef_func()

--- a/llvm/test/CodeGen/AMDGPU/agpr-register-count.ll
+++ b/llvm/test/CodeGen/AMDGPU/agpr-register-count.ll
@@ -1,5 +1,5 @@
-; RUN: llc -mtriple=amdgcn--amdhsa -mcpu=gfx908 < %s | FileCheck -check-prefixes=GCN,GFX908 %s
-; RUN: llc -mtriple=amdgcn--amdhsa -mcpu=gfx90a < %s | FileCheck -check-prefixes=GCN,GFX90A %s
+; RUN: llc -mtriple=amdgcn--amdhsa -amdgpu-localize-resource-symbols=false -mcpu=gfx908 < %s | FileCheck -check-prefixes=GCN,GFX908 %s
+; RUN: llc -mtriple=amdgcn--amdhsa -amdgpu-localize-resource-symbols=false -mcpu=gfx90a < %s | FileCheck -check-prefixes=GCN,GFX90A %s
 
 ; GCN-LABEL: {{^}}kernel_32_agprs:
 ; GFX908: .amdhsa_next_free_vgpr 32

--- a/llvm/test/CodeGen/AMDGPU/amdpal-metadata-agpr-register-count.ll
+++ b/llvm/test/CodeGen/AMDGPU/amdpal-metadata-agpr-register-count.ll
@@ -1,5 +1,5 @@
-; RUN: llc -mtriple=amdgcn--amdpal -mcpu=gfx90a < %s | FileCheck -check-prefixes=CHECK,GFX90A %s
-; RUN: llc -mtriple=amdgcn--amdpal -mcpu=gfx908 < %s | FileCheck -check-prefixes=CHECK,GFX908 %s
+; RUN: llc -mtriple=amdgcn--amdpal -amdgpu-localize-resource-symbols=false -mcpu=gfx90a < %s | FileCheck -check-prefixes=CHECK,GFX90A %s
+; RUN: llc -mtriple=amdgcn--amdpal -amdgpu-localize-resource-symbols=false -mcpu=gfx908 < %s | FileCheck -check-prefixes=CHECK,GFX908 %s
 
 ; COM: Adapted from agpr-register-count.ll
 ; COM: GFX900 and below should not have .agpr_count present in the metadata

--- a/llvm/test/CodeGen/AMDGPU/amdpal-metadata-agpr-register-count.ll
+++ b/llvm/test/CodeGen/AMDGPU/amdpal-metadata-agpr-register-count.ll
@@ -1,5 +1,5 @@
-; RUN: llc -mtriple=amdgcn--amdpal -amdgpu-localize-resource-symbols=false -mcpu=gfx90a < %s | FileCheck -check-prefixes=CHECK,GFX90A %s
-; RUN: llc -mtriple=amdgcn--amdpal -amdgpu-localize-resource-symbols=false -mcpu=gfx908 < %s | FileCheck -check-prefixes=CHECK,GFX908 %s
+; RUN: llc -mtriple=amdgcn--amdpal -mcpu=gfx90a < %s | FileCheck -check-prefixes=CHECK,GFX90A %s
+; RUN: llc -mtriple=amdgcn--amdpal -mcpu=gfx908 < %s | FileCheck -check-prefixes=CHECK,GFX908 %s
 
 ; COM: Adapted from agpr-register-count.ll
 ; COM: GFX900 and below should not have .agpr_count present in the metadata
@@ -60,8 +60,8 @@ bb:
 declare void @undef_func()
 
 ; CHECK:      .type          kernel_call_undef_func
-; CHECK:      .set kernel_call_undef_func.num_agpr, max(0, amdgpu.max_num_agpr)
-; CHECK:      NumAgprs: kernel_call_undef_func.num_agpr
+; CHECK:      .set .Lkernel_call_undef_func.num_agpr, max(0, amdgpu.max_num_agpr)
+; CHECK:      NumAgprs: .Lkernel_call_undef_func.num_agpr
 ; CHECK:      .set amdgpu.max_num_agpr, 32
 define amdgpu_kernel void @kernel_call_undef_func() #0 {
 bb:

--- a/llvm/test/CodeGen/AMDGPU/attr-amdgpu-flat-work-group-size-vgpr-limit.ll
+++ b/llvm/test/CodeGen/AMDGPU/attr-amdgpu-flat-work-group-size-vgpr-limit.ll
@@ -1,15 +1,15 @@
 ; -enable-misched=false makes the register usage more predictable
 ; -regalloc=fast just makes the test run faster
-; RUN: llc -mtriple=amdgcn -mcpu=gfx900 -amdgpu-localize-resource-symbols=false -amdgpu-function-calls=false -enable-misched=false -sgpr-regalloc=fast -vgpr-regalloc=fast -wwm-regalloc=fast < %s | FileCheck %s --check-prefixes=GCN,GFX9
-; RUN: llc -mtriple=amdgcn -mcpu=gfx90a -amdgpu-localize-resource-symbols=false -amdgpu-function-calls=false -enable-misched=false -sgpr-regalloc=fast -vgpr-regalloc=fast -wwm-regalloc=fast < %s | FileCheck %s --check-prefixes=GCN,GFX90A
-; RUN: llc -mtriple=amdgcn -mcpu=gfx1010 -amdgpu-localize-resource-symbols=false -amdgpu-function-calls=false -enable-misched=false -sgpr-regalloc=fast -vgpr-regalloc=fast -wwm-regalloc=fast < %s | FileCheck %s --check-prefixes=GCN,GFX10WGP-WAVE32
-; RUN: llc -mtriple=amdgcn -mcpu=gfx1010 -amdgpu-localize-resource-symbols=false -mattr=+wavefrontsize64 -amdgpu-function-calls=false -enable-misched=false -sgpr-regalloc=fast -vgpr-regalloc=fast -wwm-regalloc=fast < %s | FileCheck %s --check-prefixes=GCN,GFX10WGP-WAVE64
-; RUN: llc -mtriple=amdgcn -mcpu=gfx1010 -amdgpu-localize-resource-symbols=false -mattr=+cumode -amdgpu-function-calls=false -enable-misched=false -sgpr-regalloc=fast -vgpr-regalloc=fast -wwm-regalloc=fast < %s | FileCheck %s --check-prefixes=GCN,GFX10CU-WAVE32
-; RUN: llc -mtriple=amdgcn -mcpu=gfx1010 -amdgpu-localize-resource-symbols=false -mattr=+cumode,+wavefrontsize64 -amdgpu-function-calls=false -enable-misched=false -sgpr-regalloc=fast -vgpr-regalloc=fast -wwm-regalloc=fast < %s | FileCheck %s --check-prefixes=GCN,GFX10CU-WAVE64
-; RUN: llc -mtriple=amdgcn -mcpu=gfx1100 -amdgpu-localize-resource-symbols=false -amdgpu-function-calls=false -enable-misched=false -sgpr-regalloc=fast -vgpr-regalloc=fast -wwm-regalloc=fast < %s | FileCheck %s --check-prefixes=GCN,GFX11WGP-WAVE32
-; RUN: llc -mtriple=amdgcn -mcpu=gfx1100 -amdgpu-localize-resource-symbols=false -mattr=+wavefrontsize64 -amdgpu-function-calls=false -enable-misched=false -sgpr-regalloc=fast -vgpr-regalloc=fast -wwm-regalloc=fast < %s | FileCheck %s --check-prefixes=GCN,GFX11WGP-WAVE64
-; RUN: llc -mtriple=amdgcn -mcpu=gfx1100 -amdgpu-localize-resource-symbols=false -mattr=+cumode -amdgpu-function-calls=false -enable-misched=false -sgpr-regalloc=fast -vgpr-regalloc=fast -wwm-regalloc=fast < %s | FileCheck %s --check-prefixes=GCN,GFX11CU-WAVE32
-; RUN: llc -mtriple=amdgcn -mcpu=gfx1100 -amdgpu-localize-resource-symbols=false -mattr=+cumode,+wavefrontsize64 -amdgpu-function-calls=false -enable-misched=false -sgpr-regalloc=fast -vgpr-regalloc=fast -wwm-regalloc=fast < %s | FileCheck %s --check-prefixes=GCN,GFX11CU-WAVE64
+; RUN: llc -mtriple=amdgcn -mcpu=gfx900 -amdgpu-function-calls=false -enable-misched=false -sgpr-regalloc=fast -vgpr-regalloc=fast -wwm-regalloc=fast < %s | FileCheck %s --check-prefixes=GCN,GFX9
+; RUN: llc -mtriple=amdgcn -mcpu=gfx90a -amdgpu-function-calls=false -enable-misched=false -sgpr-regalloc=fast -vgpr-regalloc=fast -wwm-regalloc=fast < %s | FileCheck %s --check-prefixes=GCN,GFX90A
+; RUN: llc -mtriple=amdgcn -mcpu=gfx1010 -amdgpu-function-calls=false -enable-misched=false -sgpr-regalloc=fast -vgpr-regalloc=fast -wwm-regalloc=fast < %s | FileCheck %s --check-prefixes=GCN,GFX10WGP-WAVE32
+; RUN: llc -mtriple=amdgcn -mcpu=gfx1010 -mattr=+wavefrontsize64 -amdgpu-function-calls=false -enable-misched=false -sgpr-regalloc=fast -vgpr-regalloc=fast -wwm-regalloc=fast < %s | FileCheck %s --check-prefixes=GCN,GFX10WGP-WAVE64
+; RUN: llc -mtriple=amdgcn -mcpu=gfx1010 -mattr=+cumode -amdgpu-function-calls=false -enable-misched=false -sgpr-regalloc=fast -vgpr-regalloc=fast -wwm-regalloc=fast < %s | FileCheck %s --check-prefixes=GCN,GFX10CU-WAVE32
+; RUN: llc -mtriple=amdgcn -mcpu=gfx1010 -mattr=+cumode,+wavefrontsize64 -amdgpu-function-calls=false -enable-misched=false -sgpr-regalloc=fast -vgpr-regalloc=fast -wwm-regalloc=fast < %s | FileCheck %s --check-prefixes=GCN,GFX10CU-WAVE64
+; RUN: llc -mtriple=amdgcn -mcpu=gfx1100 -amdgpu-function-calls=false -enable-misched=false -sgpr-regalloc=fast -vgpr-regalloc=fast -wwm-regalloc=fast < %s | FileCheck %s --check-prefixes=GCN,GFX11WGP-WAVE32
+; RUN: llc -mtriple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize64 -amdgpu-function-calls=false -enable-misched=false -sgpr-regalloc=fast -vgpr-regalloc=fast -wwm-regalloc=fast < %s | FileCheck %s --check-prefixes=GCN,GFX11WGP-WAVE64
+; RUN: llc -mtriple=amdgcn -mcpu=gfx1100 -mattr=+cumode -amdgpu-function-calls=false -enable-misched=false -sgpr-regalloc=fast -vgpr-regalloc=fast -wwm-regalloc=fast < %s | FileCheck %s --check-prefixes=GCN,GFX11CU-WAVE32
+; RUN: llc -mtriple=amdgcn -mcpu=gfx1100 -mattr=+cumode,+wavefrontsize64 -amdgpu-function-calls=false -enable-misched=false -sgpr-regalloc=fast -vgpr-regalloc=fast -wwm-regalloc=fast < %s | FileCheck %s --check-prefixes=GCN,GFX11CU-WAVE64
 
 define internal void @use256vgprs() {
   %v0 = call i32 asm sideeffect "; def $0", "=v"()
@@ -547,20 +547,20 @@ define amdgpu_kernel void @f256() #256 {
 attributes #256 = { nounwind "amdgpu-flat-work-group-size"="256,256" }
 
 ; GCN-LABEL: {{^}}f512:
-; GFX9:             .set f512.num_vgpr, max(128, amdgpu.max_num_vgpr)
-; GFX90A:           .set f512.num_vgpr, max(128, amdgpu.max_num_vgpr)
-; GFX90A:           .set f512.num_agpr, max(128, amdgpu.max_num_agpr)
-; GFX10WGP-WAVE32:  .set f512.num_vgpr, max(256, amdgpu.max_num_vgpr)
-; GFX10WGP-WAVE64:  .set f512.num_vgpr, max(256, amdgpu.max_num_vgpr)
-; GFX10CU-WAVE32:   .set f512.num_vgpr, max(128, amdgpu.max_num_vgpr)
-; GFX10CU-WAVE64:   .set f512.num_vgpr, max(128, amdgpu.max_num_vgpr)
-; GFX11WGP-WAVE32:  .set f512.num_vgpr, max(256, amdgpu.max_num_vgpr)
-; GFX11WGP-WAVE64:  .set f512.num_vgpr, max(256, amdgpu.max_num_vgpr)
-; GFX11CU-WAVE32:   .set f512.num_vgpr, max(192, amdgpu.max_num_vgpr)
-; GFX11CU-WAVE64:   .set f512.num_vgpr, max(192, amdgpu.max_num_vgpr)
-; GCN:              NumVgprs: f512.num_vgpr
-; GFX90A:           NumAgprs: f512.num_agpr
-; GFX90A:           TotalNumVgprs: totalnumvgprs(f512.num_agpr, f512.num_vgpr)
+; GFX9:             .set .Lf512.num_vgpr, max(128, amdgpu.max_num_vgpr)
+; GFX90A:           .set .Lf512.num_vgpr, max(128, amdgpu.max_num_vgpr)
+; GFX90A:           .set .Lf512.num_agpr, max(128, amdgpu.max_num_agpr)
+; GFX10WGP-WAVE32:  .set .Lf512.num_vgpr, max(256, amdgpu.max_num_vgpr)
+; GFX10WGP-WAVE64:  .set .Lf512.num_vgpr, max(256, amdgpu.max_num_vgpr)
+; GFX10CU-WAVE32:   .set .Lf512.num_vgpr, max(128, amdgpu.max_num_vgpr)
+; GFX10CU-WAVE64:   .set .Lf512.num_vgpr, max(128, amdgpu.max_num_vgpr)
+; GFX11WGP-WAVE32:  .set .Lf512.num_vgpr, max(256, amdgpu.max_num_vgpr)
+; GFX11WGP-WAVE64:  .set .Lf512.num_vgpr, max(256, amdgpu.max_num_vgpr)
+; GFX11CU-WAVE32:   .set .Lf512.num_vgpr, max(192, amdgpu.max_num_vgpr)
+; GFX11CU-WAVE64:   .set .Lf512.num_vgpr, max(192, amdgpu.max_num_vgpr)
+; GCN:              NumVgprs: .Lf512.num_vgpr
+; GFX90A:           NumAgprs: .Lf512.num_agpr
+; GFX90A:           TotalNumVgprs: totalnumvgprs(.Lf512.num_agpr, .Lf512.num_vgpr)
 define amdgpu_kernel void @f512() #512 {
   call void @foo()
   call void @use256vgprs()
@@ -569,20 +569,20 @@ define amdgpu_kernel void @f512() #512 {
 attributes #512 = { nounwind "amdgpu-flat-work-group-size"="512,512" }
 
 ; GCN-LABEL: {{^}}f1024:
-; GFX9:             .set f1024.num_vgpr, max(64, amdgpu.max_num_vgpr)
-; GFX90A:           .set f1024.num_vgpr, max(64, amdgpu.max_num_vgpr)
-; GFX90A:           .set f1024.num_agpr, max(64, amdgpu.max_num_agpr)
-; GFX10WGP-WAVE32:  .set f1024.num_vgpr, max(128, amdgpu.max_num_vgpr)
-; GFX10WGP-WAVE64:  .set f1024.num_vgpr, max(128, amdgpu.max_num_vgpr)
-; GFX10CU-WAVE32:   .set f1024.num_vgpr, max(64, amdgpu.max_num_vgpr)
-; GFX10CU-WAVE64:   .set f1024.num_vgpr, max(64, amdgpu.max_num_vgpr)
-; GFX11WGP-WAVE32:  .set f1024.num_vgpr, max(192, amdgpu.max_num_vgpr)
-; GFX11WGP-WAVE64:  .set f1024.num_vgpr, max(192, amdgpu.max_num_vgpr)
-; GFX11CU-WAVE32:   .set f1024.num_vgpr, max(96, amdgpu.max_num_vgpr)
-; GFX11CU-WAVE64:   .set f1024.num_vgpr, max(96, amdgpu.max_num_vgpr)
-; GCN:              NumVgprs: f1024.num_vgpr
-; GFX90A:           NumAgprs: f1024.num_agpr
-; GFX90A:           TotalNumVgprs: totalnumvgprs(f1024.num_agpr, f1024.num_vgpr)
+; GFX9:             .set .Lf1024.num_vgpr, max(64, amdgpu.max_num_vgpr)
+; GFX90A:           .set .Lf1024.num_vgpr, max(64, amdgpu.max_num_vgpr)
+; GFX90A:           .set .Lf1024.num_agpr, max(64, amdgpu.max_num_agpr)
+; GFX10WGP-WAVE32:  .set .Lf1024.num_vgpr, max(128, amdgpu.max_num_vgpr)
+; GFX10WGP-WAVE64:  .set .Lf1024.num_vgpr, max(128, amdgpu.max_num_vgpr)
+; GFX10CU-WAVE32:   .set .Lf1024.num_vgpr, max(64, amdgpu.max_num_vgpr)
+; GFX10CU-WAVE64:   .set .Lf1024.num_vgpr, max(64, amdgpu.max_num_vgpr)
+; GFX11WGP-WAVE32:  .set .Lf1024.num_vgpr, max(192, amdgpu.max_num_vgpr)
+; GFX11WGP-WAVE64:  .set .Lf1024.num_vgpr, max(192, amdgpu.max_num_vgpr)
+; GFX11CU-WAVE32:   .set .Lf1024.num_vgpr, max(96, amdgpu.max_num_vgpr)
+; GFX11CU-WAVE64:   .set .Lf1024.num_vgpr, max(96, amdgpu.max_num_vgpr)
+; GCN:              NumVgprs: .Lf1024.num_vgpr
+; GFX90A:           NumAgprs: .Lf1024.num_agpr
+; GFX90A:           TotalNumVgprs: totalnumvgprs(.Lf1024.num_agpr, .Lf1024.num_vgpr)
 define amdgpu_kernel void @f1024() #1024 {
   call void @foo()
   call void @use256vgprs()

--- a/llvm/test/CodeGen/AMDGPU/attr-amdgpu-flat-work-group-size-vgpr-limit.ll
+++ b/llvm/test/CodeGen/AMDGPU/attr-amdgpu-flat-work-group-size-vgpr-limit.ll
@@ -1,15 +1,15 @@
 ; -enable-misched=false makes the register usage more predictable
 ; -regalloc=fast just makes the test run faster
-; RUN: llc -mtriple=amdgcn -mcpu=gfx900 -amdgpu-function-calls=false -enable-misched=false -sgpr-regalloc=fast -vgpr-regalloc=fast -wwm-regalloc=fast < %s | FileCheck %s --check-prefixes=GCN,GFX9
-; RUN: llc -mtriple=amdgcn -mcpu=gfx90a -amdgpu-function-calls=false -enable-misched=false -sgpr-regalloc=fast -vgpr-regalloc=fast -wwm-regalloc=fast < %s | FileCheck %s --check-prefixes=GCN,GFX90A
-; RUN: llc -mtriple=amdgcn -mcpu=gfx1010 -amdgpu-function-calls=false -enable-misched=false -sgpr-regalloc=fast -vgpr-regalloc=fast -wwm-regalloc=fast < %s | FileCheck %s --check-prefixes=GCN,GFX10WGP-WAVE32
-; RUN: llc -mtriple=amdgcn -mcpu=gfx1010 -mattr=+wavefrontsize64 -amdgpu-function-calls=false -enable-misched=false -sgpr-regalloc=fast -vgpr-regalloc=fast -wwm-regalloc=fast < %s | FileCheck %s --check-prefixes=GCN,GFX10WGP-WAVE64
-; RUN: llc -mtriple=amdgcn -mcpu=gfx1010 -mattr=+cumode -amdgpu-function-calls=false -enable-misched=false -sgpr-regalloc=fast -vgpr-regalloc=fast -wwm-regalloc=fast < %s | FileCheck %s --check-prefixes=GCN,GFX10CU-WAVE32
-; RUN: llc -mtriple=amdgcn -mcpu=gfx1010 -mattr=+cumode,+wavefrontsize64 -amdgpu-function-calls=false -enable-misched=false -sgpr-regalloc=fast -vgpr-regalloc=fast -wwm-regalloc=fast < %s | FileCheck %s --check-prefixes=GCN,GFX10CU-WAVE64
-; RUN: llc -mtriple=amdgcn -mcpu=gfx1100 -amdgpu-function-calls=false -enable-misched=false -sgpr-regalloc=fast -vgpr-regalloc=fast -wwm-regalloc=fast < %s | FileCheck %s --check-prefixes=GCN,GFX11WGP-WAVE32
-; RUN: llc -mtriple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize64 -amdgpu-function-calls=false -enable-misched=false -sgpr-regalloc=fast -vgpr-regalloc=fast -wwm-regalloc=fast < %s | FileCheck %s --check-prefixes=GCN,GFX11WGP-WAVE64
-; RUN: llc -mtriple=amdgcn -mcpu=gfx1100 -mattr=+cumode -amdgpu-function-calls=false -enable-misched=false -sgpr-regalloc=fast -vgpr-regalloc=fast -wwm-regalloc=fast < %s | FileCheck %s --check-prefixes=GCN,GFX11CU-WAVE32
-; RUN: llc -mtriple=amdgcn -mcpu=gfx1100 -mattr=+cumode,+wavefrontsize64 -amdgpu-function-calls=false -enable-misched=false -sgpr-regalloc=fast -vgpr-regalloc=fast -wwm-regalloc=fast < %s | FileCheck %s --check-prefixes=GCN,GFX11CU-WAVE64
+; RUN: llc -mtriple=amdgcn -mcpu=gfx900 -amdgpu-localize-resource-symbols=false -amdgpu-function-calls=false -enable-misched=false -sgpr-regalloc=fast -vgpr-regalloc=fast -wwm-regalloc=fast < %s | FileCheck %s --check-prefixes=GCN,GFX9
+; RUN: llc -mtriple=amdgcn -mcpu=gfx90a -amdgpu-localize-resource-symbols=false -amdgpu-function-calls=false -enable-misched=false -sgpr-regalloc=fast -vgpr-regalloc=fast -wwm-regalloc=fast < %s | FileCheck %s --check-prefixes=GCN,GFX90A
+; RUN: llc -mtriple=amdgcn -mcpu=gfx1010 -amdgpu-localize-resource-symbols=false -amdgpu-function-calls=false -enable-misched=false -sgpr-regalloc=fast -vgpr-regalloc=fast -wwm-regalloc=fast < %s | FileCheck %s --check-prefixes=GCN,GFX10WGP-WAVE32
+; RUN: llc -mtriple=amdgcn -mcpu=gfx1010 -amdgpu-localize-resource-symbols=false -mattr=+wavefrontsize64 -amdgpu-function-calls=false -enable-misched=false -sgpr-regalloc=fast -vgpr-regalloc=fast -wwm-regalloc=fast < %s | FileCheck %s --check-prefixes=GCN,GFX10WGP-WAVE64
+; RUN: llc -mtriple=amdgcn -mcpu=gfx1010 -amdgpu-localize-resource-symbols=false -mattr=+cumode -amdgpu-function-calls=false -enable-misched=false -sgpr-regalloc=fast -vgpr-regalloc=fast -wwm-regalloc=fast < %s | FileCheck %s --check-prefixes=GCN,GFX10CU-WAVE32
+; RUN: llc -mtriple=amdgcn -mcpu=gfx1010 -amdgpu-localize-resource-symbols=false -mattr=+cumode,+wavefrontsize64 -amdgpu-function-calls=false -enable-misched=false -sgpr-regalloc=fast -vgpr-regalloc=fast -wwm-regalloc=fast < %s | FileCheck %s --check-prefixes=GCN,GFX10CU-WAVE64
+; RUN: llc -mtriple=amdgcn -mcpu=gfx1100 -amdgpu-localize-resource-symbols=false -amdgpu-function-calls=false -enable-misched=false -sgpr-regalloc=fast -vgpr-regalloc=fast -wwm-regalloc=fast < %s | FileCheck %s --check-prefixes=GCN,GFX11WGP-WAVE32
+; RUN: llc -mtriple=amdgcn -mcpu=gfx1100 -amdgpu-localize-resource-symbols=false -mattr=+wavefrontsize64 -amdgpu-function-calls=false -enable-misched=false -sgpr-regalloc=fast -vgpr-regalloc=fast -wwm-regalloc=fast < %s | FileCheck %s --check-prefixes=GCN,GFX11WGP-WAVE64
+; RUN: llc -mtriple=amdgcn -mcpu=gfx1100 -amdgpu-localize-resource-symbols=false -mattr=+cumode -amdgpu-function-calls=false -enable-misched=false -sgpr-regalloc=fast -vgpr-regalloc=fast -wwm-regalloc=fast < %s | FileCheck %s --check-prefixes=GCN,GFX11CU-WAVE32
+; RUN: llc -mtriple=amdgcn -mcpu=gfx1100 -amdgpu-localize-resource-symbols=false -mattr=+cumode,+wavefrontsize64 -amdgpu-function-calls=false -enable-misched=false -sgpr-regalloc=fast -vgpr-regalloc=fast -wwm-regalloc=fast < %s | FileCheck %s --check-prefixes=GCN,GFX11CU-WAVE64
 
 define internal void @use256vgprs() {
   %v0 = call i32 asm sideeffect "; def $0", "=v"()

--- a/llvm/test/CodeGen/AMDGPU/call-alias-register-usage-agpr.ll
+++ b/llvm/test/CodeGen/AMDGPU/call-alias-register-usage-agpr.ll
@@ -1,5 +1,5 @@
-; RUN: llc -O0 -mtriple=amdgcn-amd-amdhsa -mcpu=gfx908 -amdgpu-localize-resource-symbols=false < %s | FileCheck -check-prefix=ALL %s
-; RUN: llc -O0 -mtriple=amdgcn-amd-amdhsa -mcpu=gfx90a -amdgpu-localize-resource-symbols=false < %s | FileCheck -check-prefixes=ALL,GFX90A %s
+; RUN: llc -O0 -mtriple=amdgcn-amd-amdhsa -mcpu=gfx908 < %s | FileCheck -check-prefix=ALL %s
+; RUN: llc -O0 -mtriple=amdgcn-amd-amdhsa -mcpu=gfx90a < %s | FileCheck -check-prefixes=ALL,GFX90A %s
 
 ; CallGraphAnalysis, which CodeGenSCC order depends on, does not look
 ; through aliases. If GlobalOpt is never run, we do not see direct
@@ -8,13 +8,13 @@
 @alias = hidden alias void (), ptr @aliasee_default
 
 ; ALL-LABEL: {{^}}kernel:
-; ALL:          .amdhsa_next_free_vgpr max(totalnumvgprs(kernel.num_agpr, kernel.num_vgpr), 1, 0)
-; ALL-NEXT:     .amdhsa_next_free_sgpr max(kernel.numbered_sgpr+extrasgprs(kernel.uses_vcc, kernel.uses_flat_scratch, 1), 1, 0)-extrasgprs(kernel.uses_vcc, kernel.uses_flat_scratch, 1)
-; GFX90A-NEXT:  .amdhsa_accum_offset (((((alignto(max(1, kernel.num_vgpr), 4)/4)-1)&~65536)&63)+1)*4
+; ALL:          .amdhsa_next_free_vgpr max(totalnumvgprs(.Lkernel.num_agpr, .Lkernel.num_vgpr), 1, 0)
+; ALL-NEXT:     .amdhsa_next_free_sgpr max(.Lkernel.numbered_sgpr+extrasgprs(.Lkernel.uses_vcc, .Lkernel.uses_flat_scratch, 1), 1, 0)-extrasgprs(.Lkernel.uses_vcc, .Lkernel.uses_flat_scratch, 1)
+; GFX90A-NEXT:  .amdhsa_accum_offset (((((alignto(max(1, .Lkernel.num_vgpr), 4)/4)-1)&~65536)&63)+1)*4
 
-; ALL:       .set kernel.num_vgpr, max(41, .Laliasee_default.num_vgpr)
-; ALL-NEXT:  .set kernel.num_agpr, max(0, .Laliasee_default.num_agpr)
-; ALL-NEXT:  .set kernel.numbered_sgpr, max(33, .Laliasee_default.numbered_sgpr)
+; ALL:       .set .Lkernel.num_vgpr, max(41, .Laliasee_default.num_vgpr)
+; ALL-NEXT:  .set .Lkernel.num_agpr, max(0, .Laliasee_default.num_agpr)
+; ALL-NEXT:  .set .Lkernel.numbered_sgpr, max(33, .Laliasee_default.numbered_sgpr)
 define amdgpu_kernel void @kernel() #0 {
 bb:
   call void @alias() #2

--- a/llvm/test/CodeGen/AMDGPU/call-alias-register-usage-agpr.ll
+++ b/llvm/test/CodeGen/AMDGPU/call-alias-register-usage-agpr.ll
@@ -1,5 +1,5 @@
-; RUN: llc -O0 -mtriple=amdgcn-amd-amdhsa -mcpu=gfx908 < %s | FileCheck -check-prefix=ALL %s
-; RUN: llc -O0 -mtriple=amdgcn-amd-amdhsa -mcpu=gfx90a < %s | FileCheck -check-prefixes=ALL,GFX90A %s
+; RUN: llc -O0 -mtriple=amdgcn-amd-amdhsa -mcpu=gfx908 -amdgpu-localize-resource-symbols=false < %s | FileCheck -check-prefix=ALL %s
+; RUN: llc -O0 -mtriple=amdgcn-amd-amdhsa -mcpu=gfx90a -amdgpu-localize-resource-symbols=false < %s | FileCheck -check-prefixes=ALL,GFX90A %s
 
 ; CallGraphAnalysis, which CodeGenSCC order depends on, does not look
 ; through aliases. If GlobalOpt is never run, we do not see direct

--- a/llvm/test/CodeGen/AMDGPU/call-alias-register-usage0.ll
+++ b/llvm/test/CodeGen/AMDGPU/call-alias-register-usage0.ll
@@ -1,4 +1,4 @@
-; RUN: llc -O0 -mtriple=amdgcn-amd-amdhsa -mcpu=gfx900 < %s | FileCheck %s
+; RUN: llc -O0 -mtriple=amdgcn-amd-amdhsa -mcpu=gfx900 -amdgpu-localize-resource-symbols=false < %s | FileCheck %s
 
 ; CallGraphAnalysis, which CodeGenSCC order depends on, does not look
 ; through aliases. If GlobalOpt is never run, we do not see direct

--- a/llvm/test/CodeGen/AMDGPU/call-alias-register-usage0.ll
+++ b/llvm/test/CodeGen/AMDGPU/call-alias-register-usage0.ll
@@ -1,4 +1,4 @@
-; RUN: llc -O0 -mtriple=amdgcn-amd-amdhsa -mcpu=gfx900 -amdgpu-localize-resource-symbols=false < %s | FileCheck %s
+; RUN: llc -O0 -mtriple=amdgcn-amd-amdhsa -mcpu=gfx900 < %s | FileCheck %s
 
 ; CallGraphAnalysis, which CodeGenSCC order depends on, does not look
 ; through aliases. If GlobalOpt is never run, we do not see direct
@@ -7,9 +7,9 @@
 @alias0 = hidden alias void (), ptr @aliasee_default_vgpr64_sgpr102
 
 ; CHECK-LABEL: {{^}}kernel0:
-; CHECK:      .set kernel0.num_vgpr, max(41, .Laliasee_default_vgpr64_sgpr102.num_vgpr)
-; CHECK-NEXT: .set kernel0.num_agpr, max(0, .Laliasee_default_vgpr64_sgpr102.num_agpr)
-; CHECK-NEXT: .set kernel0.numbered_sgpr, max(33, .Laliasee_default_vgpr64_sgpr102.numbered_sgpr)
+; CHECK:      .set .Lkernel0.num_vgpr, max(41, .Laliasee_default_vgpr64_sgpr102.num_vgpr)
+; CHECK-NEXT: .set .Lkernel0.num_agpr, max(0, .Laliasee_default_vgpr64_sgpr102.num_agpr)
+; CHECK-NEXT: .set .Lkernel0.numbered_sgpr, max(33, .Laliasee_default_vgpr64_sgpr102.numbered_sgpr)
 define amdgpu_kernel void @kernel0() #0 {
 bb:
   call void @alias0() #2

--- a/llvm/test/CodeGen/AMDGPU/call-alias-register-usage1.ll
+++ b/llvm/test/CodeGen/AMDGPU/call-alias-register-usage1.ll
@@ -1,4 +1,4 @@
-; RUN: llc -O0 -mtriple=amdgcn-amd-amdhsa -mcpu=gfx900 < %s | FileCheck %s
+; RUN: llc -O0 -mtriple=amdgcn-amd-amdhsa -mcpu=gfx900 -amdgpu-localize-resource-symbols=false < %s | FileCheck %s
 
 ; CallGraphAnalysis, which CodeGenSCC order depends on, does not look
 ; through aliases. If GlobalOpt is never run, we do not see direct

--- a/llvm/test/CodeGen/AMDGPU/call-alias-register-usage1.ll
+++ b/llvm/test/CodeGen/AMDGPU/call-alias-register-usage1.ll
@@ -1,4 +1,4 @@
-; RUN: llc -O0 -mtriple=amdgcn-amd-amdhsa -mcpu=gfx900 -amdgpu-localize-resource-symbols=false < %s | FileCheck %s
+; RUN: llc -O0 -mtriple=amdgcn-amd-amdhsa -mcpu=gfx900 < %s | FileCheck %s
 
 ; CallGraphAnalysis, which CodeGenSCC order depends on, does not look
 ; through aliases. If GlobalOpt is never run, we do not see direct
@@ -9,12 +9,12 @@
 ; The parent kernel has a higher VGPR usage than the possible callees.
 
 ; CHECK-LABEL: {{^}}kernel1:
-; CHECK:      .amdhsa_next_free_vgpr max(totalnumvgprs(kernel1.num_agpr, kernel1.num_vgpr), 1, 0)
-; CHECK-NEXT: .amdhsa_next_free_sgpr max(kernel1.numbered_sgpr+extrasgprs(kernel1.uses_vcc, kernel1.uses_flat_scratch, 1), 1, 0)-extrasgprs(kernel1.uses_vcc, kernel1.uses_flat_scratch, 1)
+; CHECK:      .amdhsa_next_free_vgpr max(totalnumvgprs(.Lkernel1.num_agpr, .Lkernel1.num_vgpr), 1, 0)
+; CHECK-NEXT: .amdhsa_next_free_sgpr max(.Lkernel1.numbered_sgpr+extrasgprs(.Lkernel1.uses_vcc, .Lkernel1.uses_flat_scratch, 1), 1, 0)-extrasgprs(.Lkernel1.uses_vcc, .Lkernel1.uses_flat_scratch, 1)
 
-; CHECK:      .set kernel1.num_vgpr, max(42, .Laliasee_vgpr32_sgpr76.num_vgpr)
-; CHECK-NEXT: .set kernel1.num_agpr, max(0, .Laliasee_vgpr32_sgpr76.num_agpr)
-; CHECK-NEXT: .set kernel1.numbered_sgpr, max(33, .Laliasee_vgpr32_sgpr76.numbered_sgpr)
+; CHECK:      .set .Lkernel1.num_vgpr, max(42, .Laliasee_vgpr32_sgpr76.num_vgpr)
+; CHECK-NEXT: .set .Lkernel1.num_agpr, max(0, .Laliasee_vgpr32_sgpr76.num_agpr)
+; CHECK-NEXT: .set .Lkernel1.numbered_sgpr, max(33, .Laliasee_vgpr32_sgpr76.numbered_sgpr)
 define amdgpu_kernel void @kernel1() #0 {
 bb:
   call void asm sideeffect "; clobber v40 ", "~{v40}"()

--- a/llvm/test/CodeGen/AMDGPU/call-alias-register-usage2.ll
+++ b/llvm/test/CodeGen/AMDGPU/call-alias-register-usage2.ll
@@ -1,4 +1,4 @@
-; RUN: llc -O0 -mtriple=amdgcn-amd-amdhsa -mcpu=gfx900 < %s | FileCheck %s
+; RUN: llc -O0 -mtriple=amdgcn-amd-amdhsa -mcpu=gfx900 -amdgpu-localize-resource-symbols=false < %s | FileCheck %s
 
 ; CallGraphAnalysis, which CodeGenSCC order depends on, does not look
 ; through aliases. If GlobalOpt is never run, we do not see direct

--- a/llvm/test/CodeGen/AMDGPU/call-alias-register-usage2.ll
+++ b/llvm/test/CodeGen/AMDGPU/call-alias-register-usage2.ll
@@ -1,4 +1,4 @@
-; RUN: llc -O0 -mtriple=amdgcn-amd-amdhsa -mcpu=gfx900 -amdgpu-localize-resource-symbols=false < %s | FileCheck %s
+; RUN: llc -O0 -mtriple=amdgcn-amd-amdhsa -mcpu=gfx900 < %s | FileCheck %s
 
 ; CallGraphAnalysis, which CodeGenSCC order depends on, does not look
 ; through aliases. If GlobalOpt is never run, we do not see direct
@@ -7,12 +7,12 @@
 @alias2 = hidden alias void (), ptr @aliasee_vgpr64_sgpr102
 
 ; CHECK-LABEL: {{^}}kernel2:
-; CHECK:      .amdhsa_next_free_vgpr max(totalnumvgprs(kernel2.num_agpr, kernel2.num_vgpr), 1, 0)
-; CHECK-NEXT: .amdhsa_next_free_sgpr max(kernel2.numbered_sgpr+extrasgprs(kernel2.uses_vcc, kernel2.uses_flat_scratch, 1), 1, 0)-extrasgprs(kernel2.uses_vcc, kernel2.uses_flat_scratch, 1)
+; CHECK:      .amdhsa_next_free_vgpr max(totalnumvgprs(.Lkernel2.num_agpr, .Lkernel2.num_vgpr), 1, 0)
+; CHECK-NEXT: .amdhsa_next_free_sgpr max(.Lkernel2.numbered_sgpr+extrasgprs(.Lkernel2.uses_vcc, .Lkernel2.uses_flat_scratch, 1), 1, 0)-extrasgprs(.Lkernel2.uses_vcc, .Lkernel2.uses_flat_scratch, 1)
 
-; CHECK:      .set kernel2.num_vgpr, max(41, .Laliasee_vgpr64_sgpr102.num_vgpr)
-; CHECK-NEXT: .set kernel2.num_agpr, max(0, .Laliasee_vgpr64_sgpr102.num_agpr)
-; CHECK-NEXT: .set kernel2.numbered_sgpr, max(33, .Laliasee_vgpr64_sgpr102.numbered_sgpr)
+; CHECK:      .set .Lkernel2.num_vgpr, max(41, .Laliasee_vgpr64_sgpr102.num_vgpr)
+; CHECK-NEXT: .set .Lkernel2.num_agpr, max(0, .Laliasee_vgpr64_sgpr102.num_agpr)
+; CHECK-NEXT: .set .Lkernel2.numbered_sgpr, max(33, .Laliasee_vgpr64_sgpr102.numbered_sgpr)
 define amdgpu_kernel void @kernel2() #0 {
 bb:
   call void @alias2() #2

--- a/llvm/test/CodeGen/AMDGPU/call-alias-register-usage3.ll
+++ b/llvm/test/CodeGen/AMDGPU/call-alias-register-usage3.ll
@@ -1,4 +1,4 @@
-; RUN: llc -O0 -mtriple=amdgcn-amd-amdhsa -mcpu=gfx900 -amdgpu-localize-resource-symbols=false < %s | FileCheck %s
+; RUN: llc -O0 -mtriple=amdgcn-amd-amdhsa -mcpu=gfx900 < %s | FileCheck %s
 
 ; CallGraphAnalysis, which CodeGenSCC order depends on, does not look
 ; through aliases. If GlobalOpt is never run, we do not see direct
@@ -7,12 +7,12 @@
 @alias3 = hidden alias void (), ptr @aliasee_vgpr256_sgpr102
 
 ; CHECK-LABEL: {{^}}kernel3:
-; CHECK:      .amdhsa_next_free_vgpr max(totalnumvgprs(kernel3.num_agpr, kernel3.num_vgpr), 1, 0)
-; CHECK-NEXT: .amdhsa_next_free_sgpr max(kernel3.numbered_sgpr+extrasgprs(kernel3.uses_vcc, kernel3.uses_flat_scratch, 1), 1, 0)-extrasgprs(kernel3.uses_vcc, kernel3.uses_flat_scratch, 1)
+; CHECK:      .amdhsa_next_free_vgpr max(totalnumvgprs(.Lkernel3.num_agpr, .Lkernel3.num_vgpr), 1, 0)
+; CHECK-NEXT: .amdhsa_next_free_sgpr max(.Lkernel3.numbered_sgpr+extrasgprs(.Lkernel3.uses_vcc, .Lkernel3.uses_flat_scratch, 1), 1, 0)-extrasgprs(.Lkernel3.uses_vcc, .Lkernel3.uses_flat_scratch, 1)
 
-; CHECK:      .set kernel3.num_vgpr, max(41, .Laliasee_vgpr256_sgpr102.num_vgpr)
-; CHECK-NEXT: .set kernel3.num_agpr, max(0, .Laliasee_vgpr256_sgpr102.num_agpr)
-; CHECK-NEXT: .set kernel3.numbered_sgpr, max(33, .Laliasee_vgpr256_sgpr102.numbered_sgpr)
+; CHECK:      .set .Lkernel3.num_vgpr, max(41, .Laliasee_vgpr256_sgpr102.num_vgpr)
+; CHECK-NEXT: .set .Lkernel3.num_agpr, max(0, .Laliasee_vgpr256_sgpr102.num_agpr)
+; CHECK-NEXT: .set .Lkernel3.numbered_sgpr, max(33, .Laliasee_vgpr256_sgpr102.numbered_sgpr)
 define amdgpu_kernel void @kernel3() #0 {
 bb:
   call void @alias3() #2

--- a/llvm/test/CodeGen/AMDGPU/call-alias-register-usage3.ll
+++ b/llvm/test/CodeGen/AMDGPU/call-alias-register-usage3.ll
@@ -1,4 +1,4 @@
-; RUN: llc -O0 -mtriple=amdgcn-amd-amdhsa -mcpu=gfx900 < %s | FileCheck %s
+; RUN: llc -O0 -mtriple=amdgcn-amd-amdhsa -mcpu=gfx900 -amdgpu-localize-resource-symbols=false < %s | FileCheck %s
 
 ; CallGraphAnalysis, which CodeGenSCC order depends on, does not look
 ; through aliases. If GlobalOpt is never run, we do not see direct

--- a/llvm/test/CodeGen/AMDGPU/call-graph-register-usage.ll
+++ b/llvm/test/CodeGen/AMDGPU/call-graph-register-usage.ll
@@ -1,13 +1,13 @@
-; RUN: sed 's/CODE_OBJECT_VERSION/400/g' %s | llc -global-isel=0 -mtriple=amdgcn-amd-amdhsa -amdgpu-localize-resource-symbols=false -enable-ipra=0 | FileCheck -check-prefixes=GCN,CI %s
-; RUN: sed 's/CODE_OBJECT_VERSION/500/g' %s | llc -global-isel=0 -mtriple=amdgcn-amd-amdhsa -amdgpu-localize-resource-symbols=false -enable-ipra=0 | FileCheck -check-prefixes=GCN-V5 %s
-; RUN: sed 's/CODE_OBJECT_VERSION/600/g' %s | llc -global-isel=0 -mtriple=amdgcn-amd-amdhsa -amdgpu-localize-resource-symbols=false -enable-ipra=0 | FileCheck -check-prefixes=GCN-V5 %s
-; RUN: sed 's/CODE_OBJECT_VERSION/400/g' %s | llc -global-isel=0 -mtriple=amdgcn-amd-amdhsa -amdgpu-localize-resource-symbols=false -mcpu=fiji -enable-ipra=0 | FileCheck -check-prefixes=GCN,VI,VI-NOBUG %s
-; RUN: sed 's/CODE_OBJECT_VERSION/400/g' %s | llc -global-isel=0 -mtriple=amdgcn-amd-amdhsa -amdgpu-localize-resource-symbols=false -mcpu=iceland -enable-ipra=0 | FileCheck -check-prefixes=GCN,VI,VI-BUG %s
-; RUN: sed 's/CODE_OBJECT_VERSION/400/g' %s | llc -global-isel=1 -mtriple=amdgcn-amd-amdhsa -amdgpu-localize-resource-symbols=false -enable-ipra=0 | FileCheck -check-prefixes=GCN,CI %s
-; RUN: sed 's/CODE_OBJECT_VERSION/500/g' %s | llc -global-isel=1 -mtriple=amdgcn-amd-amdhsa -amdgpu-localize-resource-symbols=false -enable-ipra=0 | FileCheck -check-prefixes=GCN-V5 %s
-; RUN: sed 's/CODE_OBJECT_VERSION/600/g' %s | llc -global-isel=1 -mtriple=amdgcn-amd-amdhsa -amdgpu-localize-resource-symbols=false -enable-ipra=0 | FileCheck -check-prefixes=GCN-V5 %s
-; RUN: sed 's/CODE_OBJECT_VERSION/400/g' %s | llc -global-isel=1 -mtriple=amdgcn-amd-amdhsa -amdgpu-localize-resource-symbols=false -mcpu=fiji -enable-ipra=0 | FileCheck -check-prefixes=GCN,VI,VI-NOBUG %s
-; RUN: sed 's/CODE_OBJECT_VERSION/400/g' %s | llc -global-isel=1 -mtriple=amdgcn-amd-amdhsa -amdgpu-localize-resource-symbols=false -mcpu=iceland -enable-ipra=0 | FileCheck -check-prefixes=GCN,VI,VI-BUG %s
+; RUN: sed 's/CODE_OBJECT_VERSION/400/g' %s | llc -global-isel=0 -mtriple=amdgcn-amd-amdhsa -enable-ipra=0 | FileCheck -check-prefixes=GCN,CI %s
+; RUN: sed 's/CODE_OBJECT_VERSION/500/g' %s | llc -global-isel=0 -mtriple=amdgcn-amd-amdhsa -enable-ipra=0 | FileCheck -check-prefixes=GCN-V5 %s
+; RUN: sed 's/CODE_OBJECT_VERSION/600/g' %s | llc -global-isel=0 -mtriple=amdgcn-amd-amdhsa -enable-ipra=0 | FileCheck -check-prefixes=GCN-V5 %s
+; RUN: sed 's/CODE_OBJECT_VERSION/400/g' %s | llc -global-isel=0 -mtriple=amdgcn-amd-amdhsa -mcpu=fiji -enable-ipra=0 | FileCheck -check-prefixes=GCN,VI,VI-NOBUG %s
+; RUN: sed 's/CODE_OBJECT_VERSION/400/g' %s | llc -global-isel=0 -mtriple=amdgcn-amd-amdhsa -mcpu=iceland -enable-ipra=0 | FileCheck -check-prefixes=GCN,VI,VI-BUG %s
+; RUN: sed 's/CODE_OBJECT_VERSION/400/g' %s | llc -global-isel=1 -mtriple=amdgcn-amd-amdhsa -enable-ipra=0 | FileCheck -check-prefixes=GCN,CI %s
+; RUN: sed 's/CODE_OBJECT_VERSION/500/g' %s | llc -global-isel=1 -mtriple=amdgcn-amd-amdhsa -enable-ipra=0 | FileCheck -check-prefixes=GCN-V5 %s
+; RUN: sed 's/CODE_OBJECT_VERSION/600/g' %s | llc -global-isel=1 -mtriple=amdgcn-amd-amdhsa -enable-ipra=0 | FileCheck -check-prefixes=GCN-V5 %s
+; RUN: sed 's/CODE_OBJECT_VERSION/400/g' %s | llc -global-isel=1 -mtriple=amdgcn-amd-amdhsa -mcpu=fiji -enable-ipra=0 | FileCheck -check-prefixes=GCN,VI,VI-NOBUG %s
+; RUN: sed 's/CODE_OBJECT_VERSION/400/g' %s | llc -global-isel=1 -mtriple=amdgcn-amd-amdhsa -mcpu=iceland -enable-ipra=0 | FileCheck -check-prefixes=GCN,VI,VI-BUG %s
 
 ; Make sure to run a GPU with the SGPR allocation bug.
 
@@ -239,11 +239,11 @@ define amdgpu_kernel void @usage_direct_recursion(i32 %n) #0 {
 ; Make sure there's no assert when a sgpr96 is used.
 ; GCN-LABEL: {{^}}count_use_sgpr96_external_call
 ; GCN: ; sgpr96 s[{{[0-9]+}}:{{[0-9]+}}]
-; GCN: .set count_use_sgpr96_external_call.num_vgpr, max(0, amdgpu.max_num_vgpr)
-; GCN: .set count_use_sgpr96_external_call.numbered_sgpr, max(33, amdgpu.max_num_sgpr)
-; CI: TotalNumSgprs: count_use_sgpr96_external_call.numbered_sgpr+4
+; GCN: .set .Lcount_use_sgpr96_external_call.num_vgpr, max(0, amdgpu.max_num_vgpr)
+; GCN: .set .Lcount_use_sgpr96_external_call.numbered_sgpr, max(33, amdgpu.max_num_sgpr)
+; CI: TotalNumSgprs: .Lcount_use_sgpr96_external_call.numbered_sgpr+4
 ; VI-BUG: TotalNumSgprs: 96
-; GCN: NumVgprs: count_use_sgpr96_external_call.num_vgpr
+; GCN: NumVgprs: .Lcount_use_sgpr96_external_call.num_vgpr
 define amdgpu_kernel void @count_use_sgpr96_external_call()  {
 entry:
   tail call void asm sideeffect "; sgpr96 $0", "s"(<3 x i32> <i32 10, i32 11, i32 12>) #1
@@ -254,11 +254,11 @@ entry:
 ; Make sure there's no assert when a sgpr160 is used.
 ; GCN-LABEL: {{^}}count_use_sgpr160_external_call
 ; GCN: ; sgpr160 s[{{[0-9]+}}:{{[0-9]+}}]
-; GCN: .set count_use_sgpr160_external_call.num_vgpr, max(0, amdgpu.max_num_vgpr)
-; GCN: .set count_use_sgpr160_external_call.numbered_sgpr, max(33, amdgpu.max_num_sgpr)
-; CI: TotalNumSgprs: count_use_sgpr160_external_call.numbered_sgpr+4
+; GCN: .set .Lcount_use_sgpr160_external_call.num_vgpr, max(0, amdgpu.max_num_vgpr)
+; GCN: .set .Lcount_use_sgpr160_external_call.numbered_sgpr, max(33, amdgpu.max_num_sgpr)
+; CI: TotalNumSgprs: .Lcount_use_sgpr160_external_call.numbered_sgpr+4
 ; VI-BUG: TotalNumSgprs: 96
-; GCN: NumVgprs: count_use_sgpr160_external_call.num_vgpr
+; GCN: NumVgprs: .Lcount_use_sgpr160_external_call.num_vgpr
 define amdgpu_kernel void @count_use_sgpr160_external_call()  {
 entry:
   tail call void asm sideeffect "; sgpr160 $0", "s"(<5 x i32> <i32 10, i32 11, i32 12, i32 13, i32 14>) #1
@@ -269,11 +269,11 @@ entry:
 ; Make sure there's no assert when a vgpr160 is used.
 ; GCN-LABEL: {{^}}count_use_vgpr160_external_call
 ; GCN: ; vgpr160 v[{{[0-9]+}}:{{[0-9]+}}]
-; GCN: .set count_use_vgpr160_external_call.num_vgpr, max(5, amdgpu.max_num_vgpr)
-; GCN: .set count_use_vgpr160_external_call.numbered_sgpr, max(33, amdgpu.max_num_sgpr)
-; CI: TotalNumSgprs: count_use_vgpr160_external_call.numbered_sgpr+4
+; GCN: .set .Lcount_use_vgpr160_external_call.num_vgpr, max(5, amdgpu.max_num_vgpr)
+; GCN: .set .Lcount_use_vgpr160_external_call.numbered_sgpr, max(33, amdgpu.max_num_sgpr)
+; CI: TotalNumSgprs: .Lcount_use_vgpr160_external_call.numbered_sgpr+4
 ; VI-BUG: TotalNumSgprs: 96
-; GCN: NumVgprs: count_use_vgpr160_external_call.num_vgpr
+; GCN: NumVgprs: .Lcount_use_vgpr160_external_call.num_vgpr
 define amdgpu_kernel void @count_use_vgpr160_external_call()  {
 entry:
   tail call void asm sideeffect "; vgpr160 $0", "v"(<5 x i32> <i32 10, i32 11, i32 12, i32 13, i32 14>) #1

--- a/llvm/test/CodeGen/AMDGPU/call-graph-register-usage.ll
+++ b/llvm/test/CodeGen/AMDGPU/call-graph-register-usage.ll
@@ -1,13 +1,13 @@
-; RUN: sed 's/CODE_OBJECT_VERSION/400/g' %s | llc -global-isel=0 -mtriple=amdgcn-amd-amdhsa -enable-ipra=0 | FileCheck -check-prefixes=GCN,CI %s
-; RUN: sed 's/CODE_OBJECT_VERSION/500/g' %s | llc -global-isel=0 -mtriple=amdgcn-amd-amdhsa -enable-ipra=0 | FileCheck -check-prefixes=GCN-V5 %s
-; RUN: sed 's/CODE_OBJECT_VERSION/600/g' %s | llc -global-isel=0 -mtriple=amdgcn-amd-amdhsa -enable-ipra=0 | FileCheck -check-prefixes=GCN-V5 %s
-; RUN: sed 's/CODE_OBJECT_VERSION/400/g' %s | llc -global-isel=0 -mtriple=amdgcn-amd-amdhsa -mcpu=fiji -enable-ipra=0 | FileCheck -check-prefixes=GCN,VI,VI-NOBUG %s
-; RUN: sed 's/CODE_OBJECT_VERSION/400/g' %s | llc -global-isel=0 -mtriple=amdgcn-amd-amdhsa -mcpu=iceland -enable-ipra=0 | FileCheck -check-prefixes=GCN,VI,VI-BUG %s
-; RUN: sed 's/CODE_OBJECT_VERSION/400/g' %s | llc -global-isel=1 -mtriple=amdgcn-amd-amdhsa -enable-ipra=0 | FileCheck -check-prefixes=GCN,CI %s
-; RUN: sed 's/CODE_OBJECT_VERSION/500/g' %s | llc -global-isel=1 -mtriple=amdgcn-amd-amdhsa -enable-ipra=0 | FileCheck -check-prefixes=GCN-V5 %s
-; RUN: sed 's/CODE_OBJECT_VERSION/600/g' %s | llc -global-isel=1 -mtriple=amdgcn-amd-amdhsa -enable-ipra=0 | FileCheck -check-prefixes=GCN-V5 %s
-; RUN: sed 's/CODE_OBJECT_VERSION/400/g' %s | llc -global-isel=1 -mtriple=amdgcn-amd-amdhsa -mcpu=fiji -enable-ipra=0 | FileCheck -check-prefixes=GCN,VI,VI-NOBUG %s
-; RUN: sed 's/CODE_OBJECT_VERSION/400/g' %s | llc -global-isel=1 -mtriple=amdgcn-amd-amdhsa -mcpu=iceland -enable-ipra=0 | FileCheck -check-prefixes=GCN,VI,VI-BUG %s
+; RUN: sed 's/CODE_OBJECT_VERSION/400/g' %s | llc -global-isel=0 -mtriple=amdgcn-amd-amdhsa -amdgpu-localize-resource-symbols=false -enable-ipra=0 | FileCheck -check-prefixes=GCN,CI %s
+; RUN: sed 's/CODE_OBJECT_VERSION/500/g' %s | llc -global-isel=0 -mtriple=amdgcn-amd-amdhsa -amdgpu-localize-resource-symbols=false -enable-ipra=0 | FileCheck -check-prefixes=GCN-V5 %s
+; RUN: sed 's/CODE_OBJECT_VERSION/600/g' %s | llc -global-isel=0 -mtriple=amdgcn-amd-amdhsa -amdgpu-localize-resource-symbols=false -enable-ipra=0 | FileCheck -check-prefixes=GCN-V5 %s
+; RUN: sed 's/CODE_OBJECT_VERSION/400/g' %s | llc -global-isel=0 -mtriple=amdgcn-amd-amdhsa -amdgpu-localize-resource-symbols=false -mcpu=fiji -enable-ipra=0 | FileCheck -check-prefixes=GCN,VI,VI-NOBUG %s
+; RUN: sed 's/CODE_OBJECT_VERSION/400/g' %s | llc -global-isel=0 -mtriple=amdgcn-amd-amdhsa -amdgpu-localize-resource-symbols=false -mcpu=iceland -enable-ipra=0 | FileCheck -check-prefixes=GCN,VI,VI-BUG %s
+; RUN: sed 's/CODE_OBJECT_VERSION/400/g' %s | llc -global-isel=1 -mtriple=amdgcn-amd-amdhsa -amdgpu-localize-resource-symbols=false -enable-ipra=0 | FileCheck -check-prefixes=GCN,CI %s
+; RUN: sed 's/CODE_OBJECT_VERSION/500/g' %s | llc -global-isel=1 -mtriple=amdgcn-amd-amdhsa -amdgpu-localize-resource-symbols=false -enable-ipra=0 | FileCheck -check-prefixes=GCN-V5 %s
+; RUN: sed 's/CODE_OBJECT_VERSION/600/g' %s | llc -global-isel=1 -mtriple=amdgcn-amd-amdhsa -amdgpu-localize-resource-symbols=false -enable-ipra=0 | FileCheck -check-prefixes=GCN-V5 %s
+; RUN: sed 's/CODE_OBJECT_VERSION/400/g' %s | llc -global-isel=1 -mtriple=amdgcn-amd-amdhsa -amdgpu-localize-resource-symbols=false -mcpu=fiji -enable-ipra=0 | FileCheck -check-prefixes=GCN,VI,VI-NOBUG %s
+; RUN: sed 's/CODE_OBJECT_VERSION/400/g' %s | llc -global-isel=1 -mtriple=amdgcn-amd-amdhsa -amdgpu-localize-resource-symbols=false -mcpu=iceland -enable-ipra=0 | FileCheck -check-prefixes=GCN,VI,VI-BUG %s
 
 ; Make sure to run a GPU with the SGPR allocation bug.
 

--- a/llvm/test/CodeGen/AMDGPU/dvgpr_sym.ll
+++ b/llvm/test/CodeGen/AMDGPU/dvgpr_sym.ll
@@ -1,6 +1,6 @@
 ; Test generation of _dvgpr$ symbol for an amdgpu_cs_chain function with dynamic vgprs.
 
-; RUN: llc -mtriple=amdgcn-amd-amdpal -mcpu=gfx1200 < %s | FileCheck -check-prefixes=DVGPR %s
+; RUN: llc -mtriple=amdgcn-amd-amdpal -mcpu=gfx1200 -amdgpu-localize-resource-symbols=false < %s | FileCheck -check-prefixes=DVGPR %s
 
 ; Function with 0 VGPRs, which counts as 1 block.
 ;

--- a/llvm/test/CodeGen/AMDGPU/dvgpr_sym.ll
+++ b/llvm/test/CodeGen/AMDGPU/dvgpr_sym.ll
@@ -1,6 +1,6 @@
 ; Test generation of _dvgpr$ symbol for an amdgpu_cs_chain function with dynamic vgprs.
 
-; RUN: llc -mtriple=amdgcn-amd-amdpal -mcpu=gfx1200 -amdgpu-localize-resource-symbols=false < %s | FileCheck -check-prefixes=DVGPR %s
+; RUN: llc -mtriple=amdgcn-amd-amdpal -mcpu=gfx1200 < %s | FileCheck -check-prefixes=DVGPR %s
 
 ; Function with 0 VGPRs, which counts as 1 block.
 ;
@@ -14,7 +14,7 @@ define amdgpu_cs_chain void @func0() #0 {
 ; Function with 21 VGPRs, which is 2 blocks.
 ;
 ; DVGPR-LABEL: func21:
-; DVGPR: .set func21.num_vgpr, 21
+; DVGPR: .set .Lfunc21.num_vgpr, 21
 ; DVGPR: .set _dvgpr$func21, func21+8
 ;
 define amdgpu_cs_chain void @func21(<13 x float> %arg) #0 {
@@ -25,7 +25,7 @@ define amdgpu_cs_chain void @func21(<13 x float> %arg) #0 {
 ; Anonymous function with 87 VGPRs, which is 6 blocks.
 ;
 ; DVGPR: [[FUNC87:__unnamed[^:]*]]:
-; DVGPR: .set [[FUNC87]].num_vgpr, 87
+; DVGPR: .set .L[[FUNC87]].num_vgpr, 87
 ; DVGPR: .set _dvgpr$[[FUNC87]], [[FUNC87]]+40
 ;
 define amdgpu_cs_chain void @0(<79 x float> %arg) #0 {
@@ -36,7 +36,7 @@ define amdgpu_cs_chain void @0(<79 x float> %arg) #0 {
 ; Function with 128 VGPRs, which is 8 blocks.
 ;
 ; DVGPR-LABEL: func128:
-; DVGPR: .set func128.num_vgpr, 128
+; DVGPR: .set .Lfunc128.num_vgpr, 128
 ; DVGPR: .set _dvgpr$func128, func128+56
 ;
 define amdgpu_cs_chain void @func128(<120 x float> %arg) #0 {
@@ -47,7 +47,7 @@ define amdgpu_cs_chain void @func128(<120 x float> %arg) #0 {
 ; Function with 79 VGPRs, which is 3 blocks with a block size of 32.
 ;
 ; DVGPR-LABEL: func79:
-; DVGPR: .set func79.num_vgpr, 79
+; DVGPR: .set .Lfunc79.num_vgpr, 79
 ; DVGPR: .set _dvgpr$func79, func79+16
 ;
 define amdgpu_cs_chain void @func79(<71 x float> %arg) #1 {
@@ -58,7 +58,7 @@ define amdgpu_cs_chain void @func79(<71 x float> %arg) #1 {
 ; Function with 225 VGPRs, which is 8 blocks with a block size of 32.
 ;
 ; DVGPR-LABEL: func225:
-; DVGPR: .set func225.num_vgpr, 225
+; DVGPR: .set .Lfunc225.num_vgpr, 225
 ; DVGPR: .set _dvgpr$func225, func225+56
 ;
 define amdgpu_cs_chain void @func225(<217 x float> %arg) #1 {

--- a/llvm/test/CodeGen/AMDGPU/dvgpr_sym_fail_too_many_block_size_16.ll
+++ b/llvm/test/CodeGen/AMDGPU/dvgpr_sym_fail_too_many_block_size_16.ll
@@ -1,10 +1,10 @@
 ; Test failure to generate the _dvgpr$ symbol for an amdgpu_cs_chain function with dynamic vgprs.
 
-; RUN: not llc -mtriple=amdgcn-amd-amdpal -mcpu=gfx1200 -amdgpu-localize-resource-symbols=false < %s 2>&1 | FileCheck -check-prefixes=ERR %s
+; RUN: not llc -mtriple=amdgcn-amd-amdpal -mcpu=gfx1200 < %s 2>&1 | FileCheck -check-prefixes=ERR %s
 
 ; Function with 129 VGPRs, which is too many with a block size of 16.
 ;
-; ERR-DAG: .set func129.num_vgpr, 129
+; ERR-DAG: .set .Lfunc129.num_vgpr, 129
 ; ERR-DAG: too many DVGPR blocks for _dvgpr$ symbol for 'func129'
 ;
 define amdgpu_cs_chain void @func129(<121 x float> %arg) #0 {

--- a/llvm/test/CodeGen/AMDGPU/dvgpr_sym_fail_too_many_block_size_16.ll
+++ b/llvm/test/CodeGen/AMDGPU/dvgpr_sym_fail_too_many_block_size_16.ll
@@ -1,6 +1,6 @@
 ; Test failure to generate the _dvgpr$ symbol for an amdgpu_cs_chain function with dynamic vgprs.
 
-; RUN: not llc -mtriple=amdgcn-amd-amdpal -mcpu=gfx1200 < %s 2>&1 | FileCheck -check-prefixes=ERR %s
+; RUN: not llc -mtriple=amdgcn-amd-amdpal -mcpu=gfx1200 -amdgpu-localize-resource-symbols=false < %s 2>&1 | FileCheck -check-prefixes=ERR %s
 
 ; Function with 129 VGPRs, which is too many with a block size of 16.
 ;

--- a/llvm/test/CodeGen/AMDGPU/dvgpr_sym_fail_too_many_block_size_16_anon.ll
+++ b/llvm/test/CodeGen/AMDGPU/dvgpr_sym_fail_too_many_block_size_16_anon.ll
@@ -1,6 +1,6 @@
 ; Test failure to generate the _dvgpr$ symbol for an anonymous amdgpu_cs_chain function with dynamic vgprs.
 
-; RUN: not llc -mtriple=amdgcn-amd-amdpal -mcpu=gfx1200 < %s 2>&1 | FileCheck -check-prefixes=ERR %s
+; RUN: not llc -mtriple=amdgcn-amd-amdpal -mcpu=gfx1200 -amdgpu-localize-resource-symbols=false < %s 2>&1 | FileCheck -check-prefixes=ERR %s
 
 ; Anonymous function with 129 VGPRs, which is too many with a block size of 16.
 ;

--- a/llvm/test/CodeGen/AMDGPU/dvgpr_sym_fail_too_many_block_size_16_anon.ll
+++ b/llvm/test/CodeGen/AMDGPU/dvgpr_sym_fail_too_many_block_size_16_anon.ll
@@ -1,10 +1,10 @@
 ; Test failure to generate the _dvgpr$ symbol for an anonymous amdgpu_cs_chain function with dynamic vgprs.
 
-; RUN: not llc -mtriple=amdgcn-amd-amdpal -mcpu=gfx1200 -amdgpu-localize-resource-symbols=false < %s 2>&1 | FileCheck -check-prefixes=ERR %s
+; RUN: not llc -mtriple=amdgcn-amd-amdpal -mcpu=gfx1200 < %s 2>&1 | FileCheck -check-prefixes=ERR %s
 
 ; Anonymous function with 129 VGPRs, which is too many with a block size of 16.
 ;
-; ERR-DAG: .set __unnamed_1.num_vgpr, 129
+; ERR-DAG: .set .L__unnamed_1.num_vgpr, 129
 ; ERR-DAG: too many DVGPR blocks for _dvgpr$ symbol for '__unnamed_1'
 ;
 define amdgpu_cs_chain void @0(<121 x float> %arg) #0 {

--- a/llvm/test/CodeGen/AMDGPU/function-resource-usage.ll
+++ b/llvm/test/CodeGen/AMDGPU/function-resource-usage.ll
@@ -1,17 +1,18 @@
+; RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx900 -enable-ipra=0 -amdgpu-localize-resource-symbols=false < %s | FileCheck -check-prefix=GCN %s
 ; RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx900 -enable-ipra=0 < %s | FileCheck -check-prefix=GCN %s
 
 ; Functions that don't make calls should have constants as its resource usage as no resource information has to be propagated.
 
 ; GCN-LABEL: {{^}}use_vcc:
-; GCN: .set use_vcc.num_vgpr, 0
-; GCN: .set use_vcc.num_agpr, 0
-; GCN: .set use_vcc.numbered_sgpr, 32
-; GCN: .set use_vcc.private_seg_size, 0
-; GCN: .set use_vcc.uses_vcc, 1
-; GCN: .set use_vcc.uses_flat_scratch, 0
-; GCN: .set use_vcc.has_dyn_sized_stack, 0
-; GCN: .set use_vcc.has_recursion, 0
-; GCN: .set use_vcc.has_indirect_call, 0
+; GCN: .set {{(\.L)?}}use_vcc.num_vgpr, 0
+; GCN: .set {{(\.L)?}}use_vcc.num_agpr, 0
+; GCN: .set {{(\.L)?}}use_vcc.numbered_sgpr, 32
+; GCN: .set {{(\.L)?}}use_vcc.private_seg_size, 0
+; GCN: .set {{(\.L)?}}use_vcc.uses_vcc, 1
+; GCN: .set {{(\.L)?}}use_vcc.uses_flat_scratch, 0
+; GCN: .set {{(\.L)?}}use_vcc.has_dyn_sized_stack, 0
+; GCN: .set {{(\.L)?}}use_vcc.has_recursion, 0
+; GCN: .set {{(\.L)?}}use_vcc.has_indirect_call, 0
 ; GCN: TotalNumSgprs: 36
 ; GCN: NumVgprs: 0
 ; GCN: ScratchSize: 0
@@ -21,15 +22,15 @@ define void @use_vcc() #1 {
 }
 
 ; GCN-LABEL: {{^}}indirect_use_vcc:
-; GCN: .set indirect_use_vcc.num_vgpr, max(41, use_vcc.num_vgpr)
-; GCN: .set indirect_use_vcc.num_agpr, max(0, use_vcc.num_agpr)
-; GCN: .set indirect_use_vcc.numbered_sgpr, max(34, use_vcc.numbered_sgpr)
-; GCN: .set indirect_use_vcc.private_seg_size, 16+max(use_vcc.private_seg_size)
-; GCN: .set indirect_use_vcc.uses_vcc, or(1, use_vcc.uses_vcc)
-; GCN: .set indirect_use_vcc.uses_flat_scratch, or(0, use_vcc.uses_flat_scratch)
-; GCN: .set indirect_use_vcc.has_dyn_sized_stack, or(0, use_vcc.has_dyn_sized_stack)
-; GCN: .set indirect_use_vcc.has_recursion, or(0, use_vcc.has_recursion)
-; GCN: .set indirect_use_vcc.has_indirect_call, or(0, use_vcc.has_indirect_call)
+; GCN: .set {{(\.L)?}}indirect_use_vcc.num_vgpr, max(41, {{(\.L)?}}use_vcc.num_vgpr)
+; GCN: .set {{(\.L)?}}indirect_use_vcc.num_agpr, max(0, {{(\.L)?}}use_vcc.num_agpr)
+; GCN: .set {{(\.L)?}}indirect_use_vcc.numbered_sgpr, max(34, {{(\.L)?}}use_vcc.numbered_sgpr)
+; GCN: .set {{(\.L)?}}indirect_use_vcc.private_seg_size, 16+max({{(\.L)?}}use_vcc.private_seg_size)
+; GCN: .set {{(\.L)?}}indirect_use_vcc.uses_vcc, or(1, {{(\.L)?}}use_vcc.uses_vcc)
+; GCN: .set {{(\.L)?}}indirect_use_vcc.uses_flat_scratch, or(0, {{(\.L)?}}use_vcc.uses_flat_scratch)
+; GCN: .set {{(\.L)?}}indirect_use_vcc.has_dyn_sized_stack, or(0, {{(\.L)?}}use_vcc.has_dyn_sized_stack)
+; GCN: .set {{(\.L)?}}indirect_use_vcc.has_recursion, or(0, {{(\.L)?}}use_vcc.has_recursion)
+; GCN: .set {{(\.L)?}}indirect_use_vcc.has_indirect_call, or(0, {{(\.L)?}}use_vcc.has_indirect_call)
 ; GCN: TotalNumSgprs: 38
 ; GCN: NumVgprs: 41
 ; GCN: ScratchSize: 16
@@ -39,15 +40,15 @@ define void @indirect_use_vcc() #1 {
 }
 
 ; GCN-LABEL: {{^}}indirect_2level_use_vcc_kernel:
-; GCN: .set indirect_2level_use_vcc_kernel.num_vgpr, max(32, indirect_use_vcc.num_vgpr)
-; GCN: .set indirect_2level_use_vcc_kernel.num_agpr, max(0, indirect_use_vcc.num_agpr)
-; GCN: .set indirect_2level_use_vcc_kernel.numbered_sgpr, max(33, indirect_use_vcc.numbered_sgpr)
-; GCN: .set indirect_2level_use_vcc_kernel.private_seg_size, 0+max(indirect_use_vcc.private_seg_size)
-; GCN: .set indirect_2level_use_vcc_kernel.uses_vcc, or(1, indirect_use_vcc.uses_vcc)
-; GCN: .set indirect_2level_use_vcc_kernel.uses_flat_scratch, or(1, indirect_use_vcc.uses_flat_scratch)
-; GCN: .set indirect_2level_use_vcc_kernel.has_dyn_sized_stack, or(0, indirect_use_vcc.has_dyn_sized_stack)
-; GCN: .set indirect_2level_use_vcc_kernel.has_recursion, or(0, indirect_use_vcc.has_recursion)
-; GCN: .set indirect_2level_use_vcc_kernel.has_indirect_call, or(0, indirect_use_vcc.has_indirect_call)
+; GCN: .set {{(\.L)?}}indirect_2level_use_vcc_kernel.num_vgpr, max(32, {{(\.L)?}}indirect_use_vcc.num_vgpr)
+; GCN: .set {{(\.L)?}}indirect_2level_use_vcc_kernel.num_agpr, max(0, {{(\.L)?}}indirect_use_vcc.num_agpr)
+; GCN: .set {{(\.L)?}}indirect_2level_use_vcc_kernel.numbered_sgpr, max(33, {{(\.L)?}}indirect_use_vcc.numbered_sgpr)
+; GCN: .set {{(\.L)?}}indirect_2level_use_vcc_kernel.private_seg_size, 0+max({{(\.L)?}}indirect_use_vcc.private_seg_size)
+; GCN: .set {{(\.L)?}}indirect_2level_use_vcc_kernel.uses_vcc, or(1, {{(\.L)?}}indirect_use_vcc.uses_vcc)
+; GCN: .set {{(\.L)?}}indirect_2level_use_vcc_kernel.uses_flat_scratch, or(1, {{(\.L)?}}indirect_use_vcc.uses_flat_scratch)
+; GCN: .set {{(\.L)?}}indirect_2level_use_vcc_kernel.has_dyn_sized_stack, or(0, {{(\.L)?}}indirect_use_vcc.has_dyn_sized_stack)
+; GCN: .set {{(\.L)?}}indirect_2level_use_vcc_kernel.has_recursion, or(0, {{(\.L)?}}indirect_use_vcc.has_recursion)
+; GCN: .set {{(\.L)?}}indirect_2level_use_vcc_kernel.has_indirect_call, or(0, {{(\.L)?}}indirect_use_vcc.has_indirect_call)
 ; GCN: TotalNumSgprs: 40
 ; GCN: NumVgprs: 41
 ; GCN: ScratchSize: 16
@@ -57,15 +58,15 @@ define amdgpu_kernel void @indirect_2level_use_vcc_kernel(ptr addrspace(1) %out)
 }
 
 ; GCN-LABEL: {{^}}use_flat_scratch:
-; GCN: .set use_flat_scratch.num_vgpr, 0
-; GCN: .set use_flat_scratch.num_agpr, 0
-; GCN: .set use_flat_scratch.numbered_sgpr, 32
-; GCN: .set use_flat_scratch.private_seg_size, 0
-; GCN: .set use_flat_scratch.uses_vcc, 0
-; GCN: .set use_flat_scratch.uses_flat_scratch, 1
-; GCN: .set use_flat_scratch.has_dyn_sized_stack, 0
-; GCN: .set use_flat_scratch.has_recursion, 0
-; GCN: .set use_flat_scratch.has_indirect_call, 0
+; GCN: .set {{(\.L)?}}use_flat_scratch.num_vgpr, 0
+; GCN: .set {{(\.L)?}}use_flat_scratch.num_agpr, 0
+; GCN: .set {{(\.L)?}}use_flat_scratch.numbered_sgpr, 32
+; GCN: .set {{(\.L)?}}use_flat_scratch.private_seg_size, 0
+; GCN: .set {{(\.L)?}}use_flat_scratch.uses_vcc, 0
+; GCN: .set {{(\.L)?}}use_flat_scratch.uses_flat_scratch, 1
+; GCN: .set {{(\.L)?}}use_flat_scratch.has_dyn_sized_stack, 0
+; GCN: .set {{(\.L)?}}use_flat_scratch.has_recursion, 0
+; GCN: .set {{(\.L)?}}use_flat_scratch.has_indirect_call, 0
 ; GCN: TotalNumSgprs: 38
 ; GCN: NumVgprs: 0
 ; GCN: ScratchSize: 0
@@ -75,15 +76,15 @@ define void @use_flat_scratch() #1 {
 }
 
 ; GCN-LABEL: {{^}}indirect_use_flat_scratch:
-; GCN: .set indirect_use_flat_scratch.num_vgpr, max(41, use_flat_scratch.num_vgpr)
-; GCN: .set indirect_use_flat_scratch.num_agpr, max(0, use_flat_scratch.num_agpr)
-; GCN: .set indirect_use_flat_scratch.numbered_sgpr, max(34, use_flat_scratch.numbered_sgpr)
-; GCN: .set indirect_use_flat_scratch.private_seg_size, 16+max(use_flat_scratch.private_seg_size)
-; GCN: .set indirect_use_flat_scratch.uses_vcc, or(1, use_flat_scratch.uses_vcc)
-; GCN: .set indirect_use_flat_scratch.uses_flat_scratch, or(0, use_flat_scratch.uses_flat_scratch)
-; GCN: .set indirect_use_flat_scratch.has_dyn_sized_stack, or(0, use_flat_scratch.has_dyn_sized_stack)
-; GCN: .set indirect_use_flat_scratch.has_recursion, or(0, use_flat_scratch.has_recursion)
-; GCN: .set indirect_use_flat_scratch.has_indirect_call, or(0, use_flat_scratch.has_indirect_call)
+; GCN: .set {{(\.L)?}}indirect_use_flat_scratch.num_vgpr, max(41, {{(.L)?}}use_flat_scratch.num_vgpr)
+; GCN: .set {{(\.L)?}}indirect_use_flat_scratch.num_agpr, max(0, {{(.L)?}}use_flat_scratch.num_agpr)
+; GCN: .set {{(\.L)?}}indirect_use_flat_scratch.numbered_sgpr, max(34, {{(.L)?}}use_flat_scratch.numbered_sgpr)
+; GCN: .set {{(\.L)?}}indirect_use_flat_scratch.private_seg_size, 16+max({{(\.L)?}}use_flat_scratch.private_seg_size)
+; GCN: .set {{(\.L)?}}indirect_use_flat_scratch.uses_vcc, or(1, {{(.L)?}}use_flat_scratch.uses_vcc)
+; GCN: .set {{(\.L)?}}indirect_use_flat_scratch.uses_flat_scratch, or(0, {{(.L)?}}use_flat_scratch.uses_flat_scratch)
+; GCN: .set {{(\.L)?}}indirect_use_flat_scratch.has_dyn_sized_stack, or(0, {{(.L)?}}use_flat_scratch.has_dyn_sized_stack)
+; GCN: .set {{(\.L)?}}indirect_use_flat_scratch.has_recursion, or(0, {{(.L)?}}use_flat_scratch.has_recursion)
+; GCN: .set {{(\.L)?}}indirect_use_flat_scratch.has_indirect_call, or(0, {{(.L)?}}use_flat_scratch.has_indirect_call)
 ; GCN: TotalNumSgprs: 40
 ; GCN: NumVgprs: 41
 ; GCN: ScratchSize: 16
@@ -93,15 +94,15 @@ define void @indirect_use_flat_scratch() #1 {
 }
 
 ; GCN-LABEL: {{^}}indirect_2level_use_flat_scratch_kernel:
-; GCN: .set indirect_2level_use_flat_scratch_kernel.num_vgpr, max(32, indirect_use_flat_scratch.num_vgpr)
-; GCN: .set indirect_2level_use_flat_scratch_kernel.num_agpr, max(0, indirect_use_flat_scratch.num_agpr)
-; GCN: .set indirect_2level_use_flat_scratch_kernel.numbered_sgpr, max(33, indirect_use_flat_scratch.numbered_sgpr)
-; GCN: .set indirect_2level_use_flat_scratch_kernel.private_seg_size, 0+max(indirect_use_flat_scratch.private_seg_size)
-; GCN: .set indirect_2level_use_flat_scratch_kernel.uses_vcc, or(1, indirect_use_flat_scratch.uses_vcc)
-; GCN: .set indirect_2level_use_flat_scratch_kernel.uses_flat_scratch, or(1, indirect_use_flat_scratch.uses_flat_scratch)
-; GCN: .set indirect_2level_use_flat_scratch_kernel.has_dyn_sized_stack, or(0, indirect_use_flat_scratch.has_dyn_sized_stack)
-; GCN: .set indirect_2level_use_flat_scratch_kernel.has_recursion, or(0, indirect_use_flat_scratch.has_recursion)
-; GCN: .set indirect_2level_use_flat_scratch_kernel.has_indirect_call, or(0, indirect_use_flat_scratch.has_indirect_call)
+; GCN: .set {{(\.L)?}}indirect_2level_use_flat_scratch_kernel.num_vgpr, max(32, {{(.L)?}}indirect_use_flat_scratch.num_vgpr)
+; GCN: .set {{(\.L)?}}indirect_2level_use_flat_scratch_kernel.num_agpr, max(0, {{(.L)?}}indirect_use_flat_scratch.num_agpr)
+; GCN: .set {{(\.L)?}}indirect_2level_use_flat_scratch_kernel.numbered_sgpr, max(33, {{(.L)?}}indirect_use_flat_scratch.numbered_sgpr)
+; GCN: .set {{(\.L)?}}indirect_2level_use_flat_scratch_kernel.private_seg_size, 0+max({{(\.L)?}}indirect_use_flat_scratch.private_seg_size)
+; GCN: .set {{(\.L)?}}indirect_2level_use_flat_scratch_kernel.uses_vcc, or(1, {{(.L)?}}indirect_use_flat_scratch.uses_vcc)
+; GCN: .set {{(\.L)?}}indirect_2level_use_flat_scratch_kernel.uses_flat_scratch, or(1, {{(.L)?}}indirect_use_flat_scratch.uses_flat_scratch)
+; GCN: .set {{(\.L)?}}indirect_2level_use_flat_scratch_kernel.has_dyn_sized_stack, or(0, {{(.L)?}}indirect_use_flat_scratch.has_dyn_sized_stack)
+; GCN: .set {{(\.L)?}}indirect_2level_use_flat_scratch_kernel.has_recursion, or(0, {{(.L)?}}indirect_use_flat_scratch.has_recursion)
+; GCN: .set {{(\.L)?}}indirect_2level_use_flat_scratch_kernel.has_indirect_call, or(0, {{(.L)?}}indirect_use_flat_scratch.has_indirect_call)
 ; GCN: TotalNumSgprs: 40
 ; GCN: NumVgprs: 41
 ; GCN: ScratchSize: 16
@@ -111,15 +112,15 @@ define amdgpu_kernel void @indirect_2level_use_flat_scratch_kernel(ptr addrspace
 }
 
 ; GCN-LABEL: {{^}}use_10_vgpr:
-; GCN: .set use_10_vgpr.num_vgpr, 10
-; GCN: .set use_10_vgpr.num_agpr, 0
-; GCN: .set use_10_vgpr.numbered_sgpr, 32
-; GCN: .set use_10_vgpr.private_seg_size, 0
-; GCN: .set use_10_vgpr.uses_vcc, 0
-; GCN: .set use_10_vgpr.uses_flat_scratch, 0
-; GCN: .set use_10_vgpr.has_dyn_sized_stack, 0
-; GCN: .set use_10_vgpr.has_recursion, 0
-; GCN: .set use_10_vgpr.has_indirect_call, 0
+; GCN: .set {{(\.L)?}}use_10_vgpr.num_vgpr, 10
+; GCN: .set {{(\.L)?}}use_10_vgpr.num_agpr, 0
+; GCN: .set {{(\.L)?}}use_10_vgpr.numbered_sgpr, 32
+; GCN: .set {{(\.L)?}}use_10_vgpr.private_seg_size, 0
+; GCN: .set {{(\.L)?}}use_10_vgpr.uses_vcc, 0
+; GCN: .set {{(\.L)?}}use_10_vgpr.uses_flat_scratch, 0
+; GCN: .set {{(\.L)?}}use_10_vgpr.has_dyn_sized_stack, 0
+; GCN: .set {{(\.L)?}}use_10_vgpr.has_recursion, 0
+; GCN: .set {{(\.L)?}}use_10_vgpr.has_indirect_call, 0
 ; GCN: TotalNumSgprs: 36
 ; GCN: NumVgprs: 10
 ; GCN: ScratchSize: 0
@@ -130,15 +131,15 @@ define void @use_10_vgpr() #1 {
 }
 
 ; GCN-LABEL: {{^}}indirect_use_10_vgpr:
-; GCN: .set indirect_use_10_vgpr.num_vgpr, max(41, use_10_vgpr.num_vgpr)
-; GCN: .set indirect_use_10_vgpr.num_agpr, max(0, use_10_vgpr.num_agpr)
-; GCN: .set indirect_use_10_vgpr.numbered_sgpr, max(34, use_10_vgpr.numbered_sgpr)
-; GCN: .set indirect_use_10_vgpr.private_seg_size, 16+max(use_10_vgpr.private_seg_size)
-; GCN: .set indirect_use_10_vgpr.uses_vcc, or(1, use_10_vgpr.uses_vcc)
-; GCN: .set indirect_use_10_vgpr.uses_flat_scratch, or(0, use_10_vgpr.uses_flat_scratch)
-; GCN: .set indirect_use_10_vgpr.has_dyn_sized_stack, or(0, use_10_vgpr.has_dyn_sized_stack)
-; GCN: .set indirect_use_10_vgpr.has_recursion, or(0, use_10_vgpr.has_recursion)
-; GCN: .set indirect_use_10_vgpr.has_indirect_call, or(0, use_10_vgpr.has_indirect_call)
+; GCN: .set {{(\.L)?}}indirect_use_10_vgpr.num_vgpr, max(41, {{(.L)?}}use_10_vgpr.num_vgpr)
+; GCN: .set {{(\.L)?}}indirect_use_10_vgpr.num_agpr, max(0, {{(.L)?}}use_10_vgpr.num_agpr)
+; GCN: .set {{(\.L)?}}indirect_use_10_vgpr.numbered_sgpr, max(34, {{(.L)?}}use_10_vgpr.numbered_sgpr)
+; GCN: .set {{(\.L)?}}indirect_use_10_vgpr.private_seg_size, 16+max({{(\.L)?}}use_10_vgpr.private_seg_size)
+; GCN: .set {{(\.L)?}}indirect_use_10_vgpr.uses_vcc, or(1, {{(.L)?}}use_10_vgpr.uses_vcc)
+; GCN: .set {{(\.L)?}}indirect_use_10_vgpr.uses_flat_scratch, or(0, {{(.L)?}}use_10_vgpr.uses_flat_scratch)
+; GCN: .set {{(\.L)?}}indirect_use_10_vgpr.has_dyn_sized_stack, or(0, {{(.L)?}}use_10_vgpr.has_dyn_sized_stack)
+; GCN: .set {{(\.L)?}}indirect_use_10_vgpr.has_recursion, or(0, {{(.L)?}}use_10_vgpr.has_recursion)
+; GCN: .set {{(\.L)?}}indirect_use_10_vgpr.has_indirect_call, or(0, {{(.L)?}}use_10_vgpr.has_indirect_call)
 ; GCN: TotalNumSgprs: 38
 ; GCN: NumVgprs: 41
 ; GCN: ScratchSize: 16
@@ -148,15 +149,15 @@ define void @indirect_use_10_vgpr() #0 {
 }
 
 ; GCN-LABEL: {{^}}indirect_2_level_use_10_vgpr:
-; GCN:	.set indirect_2_level_use_10_vgpr.num_vgpr, max(32, indirect_use_10_vgpr.num_vgpr)
-; GCN:	.set indirect_2_level_use_10_vgpr.num_agpr, max(0, indirect_use_10_vgpr.num_agpr)
-; GCN:	.set indirect_2_level_use_10_vgpr.numbered_sgpr, max(33, indirect_use_10_vgpr.numbered_sgpr)
-; GCN:	.set indirect_2_level_use_10_vgpr.private_seg_size, 0+max(indirect_use_10_vgpr.private_seg_size)
-; GCN:	.set indirect_2_level_use_10_vgpr.uses_vcc, or(1, indirect_use_10_vgpr.uses_vcc)
-; GCN:	.set indirect_2_level_use_10_vgpr.uses_flat_scratch, or(1, indirect_use_10_vgpr.uses_flat_scratch)
-; GCN:	.set indirect_2_level_use_10_vgpr.has_dyn_sized_stack, or(0, indirect_use_10_vgpr.has_dyn_sized_stack)
-; GCN:	.set indirect_2_level_use_10_vgpr.has_recursion, or(0, indirect_use_10_vgpr.has_recursion)
-; GCN:	.set indirect_2_level_use_10_vgpr.has_indirect_call, or(0, indirect_use_10_vgpr.has_indirect_call)
+; GCN:	.set {{(\.L)?}}indirect_2_level_use_10_vgpr.num_vgpr, max(32, {{(.L)?}}indirect_use_10_vgpr.num_vgpr)
+; GCN:	.set {{(\.L)?}}indirect_2_level_use_10_vgpr.num_agpr, max(0, {{(.L)?}}indirect_use_10_vgpr.num_agpr)
+; GCN:	.set {{(\.L)?}}indirect_2_level_use_10_vgpr.numbered_sgpr, max(33, {{(.L)?}}indirect_use_10_vgpr.numbered_sgpr)
+; GCN:	.set {{(\.L)?}}indirect_2_level_use_10_vgpr.private_seg_size, 0+max({{(\.L)?}}indirect_use_10_vgpr.private_seg_size)
+; GCN:	.set {{(\.L)?}}indirect_2_level_use_10_vgpr.uses_vcc, or(1, {{(.L)?}}indirect_use_10_vgpr.uses_vcc)
+; GCN:	.set {{(\.L)?}}indirect_2_level_use_10_vgpr.uses_flat_scratch, or(1, {{(.L)?}}indirect_use_10_vgpr.uses_flat_scratch)
+; GCN:	.set {{(\.L)?}}indirect_2_level_use_10_vgpr.has_dyn_sized_stack, or(0, {{(.L)?}}indirect_use_10_vgpr.has_dyn_sized_stack)
+; GCN:	.set {{(\.L)?}}indirect_2_level_use_10_vgpr.has_recursion, or(0, {{(.L)?}}indirect_use_10_vgpr.has_recursion)
+; GCN:	.set {{(\.L)?}}indirect_2_level_use_10_vgpr.has_indirect_call, or(0, {{(.L)?}}indirect_use_10_vgpr.has_indirect_call)
 ; GCN: TotalNumSgprs: 40
 ; GCN: NumVgprs: 41
 ; GCN: ScratchSize: 16
@@ -166,15 +167,15 @@ define amdgpu_kernel void @indirect_2_level_use_10_vgpr() #0 {
 }
 
 ; GCN-LABEL: {{^}}use_50_vgpr:
-; GCN:	.set use_50_vgpr.num_vgpr, 50
-; GCN:	.set use_50_vgpr.num_agpr, 0
-; GCN:	.set use_50_vgpr.numbered_sgpr, 32
-; GCN:	.set use_50_vgpr.private_seg_size, 0
-; GCN:	.set use_50_vgpr.uses_vcc, 0
-; GCN:	.set use_50_vgpr.uses_flat_scratch, 0
-; GCN:	.set use_50_vgpr.has_dyn_sized_stack, 0
-; GCN:	.set use_50_vgpr.has_recursion, 0
-; GCN:	.set use_50_vgpr.has_indirect_call, 0
+; GCN:	.set {{(\.L)?}}use_50_vgpr.num_vgpr, 50
+; GCN:	.set {{(\.L)?}}use_50_vgpr.num_agpr, 0
+; GCN:	.set {{(\.L)?}}use_50_vgpr.numbered_sgpr, 32
+; GCN:	.set {{(\.L)?}}use_50_vgpr.private_seg_size, 0
+; GCN:	.set {{(\.L)?}}use_50_vgpr.uses_vcc, 0
+; GCN:	.set {{(\.L)?}}use_50_vgpr.uses_flat_scratch, 0
+; GCN:	.set {{(\.L)?}}use_50_vgpr.has_dyn_sized_stack, 0
+; GCN:	.set {{(\.L)?}}use_50_vgpr.has_recursion, 0
+; GCN:	.set {{(\.L)?}}use_50_vgpr.has_indirect_call, 0
 ; GCN: TotalNumSgprs: 36
 ; GCN: NumVgprs: 50
 ; GCN: ScratchSize: 0
@@ -184,15 +185,15 @@ define void @use_50_vgpr() #1 {
 }
 
 ; GCN-LABEL: {{^}}indirect_use_50_vgpr:
-; GCN:	.set indirect_use_50_vgpr.num_vgpr, max(41, use_50_vgpr.num_vgpr)
-; GCN:	.set indirect_use_50_vgpr.num_agpr, max(0, use_50_vgpr.num_agpr)
-; GCN:	.set indirect_use_50_vgpr.numbered_sgpr, max(34, use_50_vgpr.numbered_sgpr)
-; GCN:	.set indirect_use_50_vgpr.private_seg_size, 16+max(use_50_vgpr.private_seg_size)
-; GCN:	.set indirect_use_50_vgpr.uses_vcc, or(1, use_50_vgpr.uses_vcc)
-; GCN:	.set indirect_use_50_vgpr.uses_flat_scratch, or(0, use_50_vgpr.uses_flat_scratch)
-; GCN:	.set indirect_use_50_vgpr.has_dyn_sized_stack, or(0, use_50_vgpr.has_dyn_sized_stack)
-; GCN:	.set indirect_use_50_vgpr.has_recursion, or(0, use_50_vgpr.has_recursion)
-; GCN:	.set indirect_use_50_vgpr.has_indirect_call, or(0, use_50_vgpr.has_indirect_call)
+; GCN:	.set {{(\.L)?}}indirect_use_50_vgpr.num_vgpr, max(41, {{(.L)?}}use_50_vgpr.num_vgpr)
+; GCN:	.set {{(\.L)?}}indirect_use_50_vgpr.num_agpr, max(0, {{(.L)?}}use_50_vgpr.num_agpr)
+; GCN:	.set {{(\.L)?}}indirect_use_50_vgpr.numbered_sgpr, max(34, {{(.L)?}}use_50_vgpr.numbered_sgpr)
+; GCN:	.set {{(\.L)?}}indirect_use_50_vgpr.private_seg_size, 16+max({{(\.L)?}}use_50_vgpr.private_seg_size)
+; GCN:	.set {{(\.L)?}}indirect_use_50_vgpr.uses_vcc, or(1, {{(.L)?}}use_50_vgpr.uses_vcc)
+; GCN:	.set {{(\.L)?}}indirect_use_50_vgpr.uses_flat_scratch, or(0, {{(.L)?}}use_50_vgpr.uses_flat_scratch)
+; GCN:	.set {{(\.L)?}}indirect_use_50_vgpr.has_dyn_sized_stack, or(0, {{(.L)?}}use_50_vgpr.has_dyn_sized_stack)
+; GCN:	.set {{(\.L)?}}indirect_use_50_vgpr.has_recursion, or(0, {{(.L)?}}use_50_vgpr.has_recursion)
+; GCN:	.set {{(\.L)?}}indirect_use_50_vgpr.has_indirect_call, or(0, {{(.L)?}}use_50_vgpr.has_indirect_call)
 ; GCN: TotalNumSgprs: 38
 ; GCN: NumVgprs: 50
 ; GCN: ScratchSize: 16
@@ -202,15 +203,15 @@ define void @indirect_use_50_vgpr() #0 {
 }
 
 ; GCN-LABEL: {{^}}use_80_sgpr:
-; GCN:	.set use_80_sgpr.num_vgpr, 0
-; GCN:	.set use_80_sgpr.num_agpr, 0
-; GCN:	.set use_80_sgpr.numbered_sgpr, 80
-; GCN:	.set use_80_sgpr.private_seg_size, 0
-; GCN:	.set use_80_sgpr.uses_vcc, 0
-; GCN:	.set use_80_sgpr.uses_flat_scratch, 0
-; GCN:	.set use_80_sgpr.has_dyn_sized_stack, 0
-; GCN:	.set use_80_sgpr.has_recursion, 0
-; GCN:	.set use_80_sgpr.has_indirect_call, 0
+; GCN:	.set {{(\.L)?}}use_80_sgpr.num_vgpr, 0
+; GCN:	.set {{(\.L)?}}use_80_sgpr.num_agpr, 0
+; GCN:	.set {{(\.L)?}}use_80_sgpr.numbered_sgpr, 80
+; GCN:	.set {{(\.L)?}}use_80_sgpr.private_seg_size, 0
+; GCN:	.set {{(\.L)?}}use_80_sgpr.uses_vcc, 0
+; GCN:	.set {{(\.L)?}}use_80_sgpr.uses_flat_scratch, 0
+; GCN:	.set {{(\.L)?}}use_80_sgpr.has_dyn_sized_stack, 0
+; GCN:	.set {{(\.L)?}}use_80_sgpr.has_recursion, 0
+; GCN:	.set {{(\.L)?}}use_80_sgpr.has_indirect_call, 0
 ; GCN: TotalNumSgprs: 84
 ; GCN: NumVgprs: 0
 ; GCN: ScratchSize: 0
@@ -220,15 +221,15 @@ define void @use_80_sgpr() #1 {
 }
 
 ; GCN-LABEL: {{^}}indirect_use_80_sgpr:
-; GCN:	.set indirect_use_80_sgpr.num_vgpr, max(41, use_80_sgpr.num_vgpr)
-; GCN:	.set indirect_use_80_sgpr.num_agpr, max(0, use_80_sgpr.num_agpr)
-; GCN:	.set indirect_use_80_sgpr.numbered_sgpr, max(34, use_80_sgpr.numbered_sgpr)
-; GCN:	.set indirect_use_80_sgpr.private_seg_size, 16+max(use_80_sgpr.private_seg_size)
-; GCN:	.set indirect_use_80_sgpr.uses_vcc, or(1, use_80_sgpr.uses_vcc)
-; GCN:	.set indirect_use_80_sgpr.uses_flat_scratch, or(0, use_80_sgpr.uses_flat_scratch)
-; GCN:	.set indirect_use_80_sgpr.has_dyn_sized_stack, or(0, use_80_sgpr.has_dyn_sized_stack)
-; GCN:	.set indirect_use_80_sgpr.has_recursion, or(0, use_80_sgpr.has_recursion)
-; GCN:	.set indirect_use_80_sgpr.has_indirect_call, or(0, use_80_sgpr.has_indirect_call)
+; GCN:	.set {{(\.L)?}}indirect_use_80_sgpr.num_vgpr, max(41, {{(.L)?}}use_80_sgpr.num_vgpr)
+; GCN:	.set {{(\.L)?}}indirect_use_80_sgpr.num_agpr, max(0, {{(.L)?}}use_80_sgpr.num_agpr)
+; GCN:	.set {{(\.L)?}}indirect_use_80_sgpr.numbered_sgpr, max(34, {{(.L)?}}use_80_sgpr.numbered_sgpr)
+; GCN:	.set {{(\.L)?}}indirect_use_80_sgpr.private_seg_size, 16+max({{(\.L)?}}use_80_sgpr.private_seg_size)
+; GCN:	.set {{(\.L)?}}indirect_use_80_sgpr.uses_vcc, or(1, {{(.L)?}}use_80_sgpr.uses_vcc)
+; GCN:	.set {{(\.L)?}}indirect_use_80_sgpr.uses_flat_scratch, or(0, {{(.L)?}}use_80_sgpr.uses_flat_scratch)
+; GCN:	.set {{(\.L)?}}indirect_use_80_sgpr.has_dyn_sized_stack, or(0, {{(.L)?}}use_80_sgpr.has_dyn_sized_stack)
+; GCN:	.set {{(\.L)?}}indirect_use_80_sgpr.has_recursion, or(0, {{(.L)?}}use_80_sgpr.has_recursion)
+; GCN:	.set {{(\.L)?}}indirect_use_80_sgpr.has_indirect_call, or(0, {{(.L)?}}use_80_sgpr.has_indirect_call)
 ; GCN: TotalNumSgprs: 84
 ; GCN: NumVgprs: 41
 ; GCN: ScratchSize: 16
@@ -238,15 +239,15 @@ define void @indirect_use_80_sgpr() #1 {
 }
 
 ; GCN-LABEL: {{^}}indirect_2_level_use_80_sgpr:
-; GCN:	.set indirect_2_level_use_80_sgpr.num_vgpr, max(32, indirect_use_80_sgpr.num_vgpr)
-; GCN:	.set indirect_2_level_use_80_sgpr.num_agpr, max(0, indirect_use_80_sgpr.num_agpr)
-; GCN:	.set indirect_2_level_use_80_sgpr.numbered_sgpr, max(33, indirect_use_80_sgpr.numbered_sgpr)
-; GCN:	.set indirect_2_level_use_80_sgpr.private_seg_size, 0+max(indirect_use_80_sgpr.private_seg_size)
-; GCN:	.set indirect_2_level_use_80_sgpr.uses_vcc, or(1, indirect_use_80_sgpr.uses_vcc)
-; GCN:	.set indirect_2_level_use_80_sgpr.uses_flat_scratch, or(1, indirect_use_80_sgpr.uses_flat_scratch)
-; GCN:	.set indirect_2_level_use_80_sgpr.has_dyn_sized_stack, or(0, indirect_use_80_sgpr.has_dyn_sized_stack)
-; GCN:	.set indirect_2_level_use_80_sgpr.has_recursion, or(0, indirect_use_80_sgpr.has_recursion)
-; GCN:	.set indirect_2_level_use_80_sgpr.has_indirect_call, or(0, indirect_use_80_sgpr.has_indirect_call)
+; GCN:	.set {{(\.L)?}}indirect_2_level_use_80_sgpr.num_vgpr, max(32, {{(.L)?}}indirect_use_80_sgpr.num_vgpr)
+; GCN:	.set {{(\.L)?}}indirect_2_level_use_80_sgpr.num_agpr, max(0, {{(.L)?}}indirect_use_80_sgpr.num_agpr)
+; GCN:	.set {{(\.L)?}}indirect_2_level_use_80_sgpr.numbered_sgpr, max(33, {{(.L)?}}indirect_use_80_sgpr.numbered_sgpr)
+; GCN:	.set {{(\.L)?}}indirect_2_level_use_80_sgpr.private_seg_size, 0+max({{(\.L)?}}indirect_use_80_sgpr.private_seg_size)
+; GCN:	.set {{(\.L)?}}indirect_2_level_use_80_sgpr.uses_vcc, or(1, {{(.L)?}}indirect_use_80_sgpr.uses_vcc)
+; GCN:	.set {{(\.L)?}}indirect_2_level_use_80_sgpr.uses_flat_scratch, or(1, {{(.L)?}}indirect_use_80_sgpr.uses_flat_scratch)
+; GCN:	.set {{(\.L)?}}indirect_2_level_use_80_sgpr.has_dyn_sized_stack, or(0, {{(.L)?}}indirect_use_80_sgpr.has_dyn_sized_stack)
+; GCN:	.set {{(\.L)?}}indirect_2_level_use_80_sgpr.has_recursion, or(0, {{(.L)?}}indirect_use_80_sgpr.has_recursion)
+; GCN:	.set {{(\.L)?}}indirect_2_level_use_80_sgpr.has_indirect_call, or(0, {{(.L)?}}indirect_use_80_sgpr.has_indirect_call)
 ; GCN: TotalNumSgprs: 86
 ; GCN: NumVgprs: 41
 ; GCN: ScratchSize: 16
@@ -256,15 +257,15 @@ define amdgpu_kernel void @indirect_2_level_use_80_sgpr() #0 {
 }
 
 ; GCN-LABEL: {{^}}use_stack0:
-; GCN:	.set use_stack0.num_vgpr, 1
-; GCN:	.set use_stack0.num_agpr, 0
-; GCN:	.set use_stack0.numbered_sgpr, 33
-; GCN:	.set use_stack0.private_seg_size, 2052
-; GCN:	.set use_stack0.uses_vcc, 0
-; GCN:	.set use_stack0.uses_flat_scratch, 0
-; GCN:	.set use_stack0.has_dyn_sized_stack, 0
-; GCN:	.set use_stack0.has_recursion, 0
-; GCN:	.set use_stack0.has_indirect_call, 0
+; GCN:	.set {{(\.L)?}}use_stack0.num_vgpr, 1
+; GCN:	.set {{(\.L)?}}use_stack0.num_agpr, 0
+; GCN:	.set {{(\.L)?}}use_stack0.numbered_sgpr, 33
+; GCN:	.set {{(\.L)?}}use_stack0.private_seg_size, 2052
+; GCN:	.set {{(\.L)?}}use_stack0.uses_vcc, 0
+; GCN:	.set {{(\.L)?}}use_stack0.uses_flat_scratch, 0
+; GCN:	.set {{(\.L)?}}use_stack0.has_dyn_sized_stack, 0
+; GCN:	.set {{(\.L)?}}use_stack0.has_recursion, 0
+; GCN:	.set {{(\.L)?}}use_stack0.has_indirect_call, 0
 ; GCN: TotalNumSgprs: 37
 ; GCN: NumVgprs: 1
 ; GCN: ScratchSize: 2052
@@ -275,15 +276,15 @@ define void @use_stack0() #1 {
 }
 
 ; GCN-LABEL: {{^}}use_stack1:
-; GCN:	.set use_stack1.num_vgpr, 1
-; GCN:	.set use_stack1.num_agpr, 0
-; GCN:	.set use_stack1.numbered_sgpr, 33
-; GCN:	.set use_stack1.private_seg_size, 404
-; GCN:	.set use_stack1.uses_vcc, 0
-; GCN:	.set use_stack1.uses_flat_scratch, 0
-; GCN:	.set use_stack1.has_dyn_sized_stack, 0
-; GCN:	.set use_stack1.has_recursion, 0
-; GCN:	.set use_stack1.has_indirect_call, 0
+; GCN:	.set {{(\.L)?}}use_stack1.num_vgpr, 1
+; GCN:	.set {{(\.L)?}}use_stack1.num_agpr, 0
+; GCN:	.set {{(\.L)?}}use_stack1.numbered_sgpr, 33
+; GCN:	.set {{(\.L)?}}use_stack1.private_seg_size, 404
+; GCN:	.set {{(\.L)?}}use_stack1.uses_vcc, 0
+; GCN:	.set {{(\.L)?}}use_stack1.uses_flat_scratch, 0
+; GCN:	.set {{(\.L)?}}use_stack1.has_dyn_sized_stack, 0
+; GCN:	.set {{(\.L)?}}use_stack1.has_recursion, 0
+; GCN:	.set {{(\.L)?}}use_stack1.has_indirect_call, 0
 ; GCN: TotalNumSgprs: 37
 ; GCN: NumVgprs: 1
 ; GCN: ScratchSize: 404
@@ -294,15 +295,15 @@ define void @use_stack1() #1 {
 }
 
 ; GCN-LABEL: {{^}}indirect_use_stack:
-; GCN:	.set indirect_use_stack.num_vgpr, max(41, use_stack0.num_vgpr)
-; GCN:	.set indirect_use_stack.num_agpr, max(0, use_stack0.num_agpr)
-; GCN:	.set indirect_use_stack.numbered_sgpr, max(34, use_stack0.numbered_sgpr)
-; GCN:	.set indirect_use_stack.private_seg_size, 80+max(use_stack0.private_seg_size)
-; GCN:	.set indirect_use_stack.uses_vcc, or(1, use_stack0.uses_vcc)
-; GCN:	.set indirect_use_stack.uses_flat_scratch, or(0, use_stack0.uses_flat_scratch)
-; GCN:	.set indirect_use_stack.has_dyn_sized_stack, or(0, use_stack0.has_dyn_sized_stack)
-; GCN:	.set indirect_use_stack.has_recursion, or(0, use_stack0.has_recursion)
-; GCN:	.set indirect_use_stack.has_indirect_call, or(0, use_stack0.has_indirect_call)
+; GCN:	.set {{(\.L)?}}indirect_use_stack.num_vgpr, max(41, {{(.L)?}}use_stack0.num_vgpr)
+; GCN:	.set {{(\.L)?}}indirect_use_stack.num_agpr, max(0, {{(.L)?}}use_stack0.num_agpr)
+; GCN:	.set {{(\.L)?}}indirect_use_stack.numbered_sgpr, max(34, {{(.L)?}}use_stack0.numbered_sgpr)
+; GCN:	.set {{(\.L)?}}indirect_use_stack.private_seg_size, 80+max({{(\.L)?}}use_stack0.private_seg_size)
+; GCN:	.set {{(\.L)?}}indirect_use_stack.uses_vcc, or(1, {{(.L)?}}use_stack0.uses_vcc)
+; GCN:	.set {{(\.L)?}}indirect_use_stack.uses_flat_scratch, or(0, {{(.L)?}}use_stack0.uses_flat_scratch)
+; GCN:	.set {{(\.L)?}}indirect_use_stack.has_dyn_sized_stack, or(0, {{(.L)?}}use_stack0.has_dyn_sized_stack)
+; GCN:	.set {{(\.L)?}}indirect_use_stack.has_recursion, or(0, {{(.L)?}}use_stack0.has_recursion)
+; GCN:	.set {{(\.L)?}}indirect_use_stack.has_indirect_call, or(0, {{(.L)?}}use_stack0.has_indirect_call)
 ; GCN: TotalNumSgprs: 38
 ; GCN: NumVgprs: 41
 ; GCN: ScratchSize: 2132
@@ -314,15 +315,15 @@ define void @indirect_use_stack() #1 {
 }
 
 ; GCN-LABEL: {{^}}indirect_2_level_use_stack:
-; GCN:	.set indirect_2_level_use_stack.num_vgpr, max(32, indirect_use_stack.num_vgpr)
-; GCN:	.set indirect_2_level_use_stack.num_agpr, max(0, indirect_use_stack.num_agpr)
-; GCN:	.set indirect_2_level_use_stack.numbered_sgpr, max(33, indirect_use_stack.numbered_sgpr)
-; GCN:	.set indirect_2_level_use_stack.private_seg_size, 0+max(indirect_use_stack.private_seg_size)
-; GCN:	.set indirect_2_level_use_stack.uses_vcc, or(1, indirect_use_stack.uses_vcc)
-; GCN:	.set indirect_2_level_use_stack.uses_flat_scratch, or(1, indirect_use_stack.uses_flat_scratch)
-; GCN:	.set indirect_2_level_use_stack.has_dyn_sized_stack, or(0, indirect_use_stack.has_dyn_sized_stack)
-; GCN:	.set indirect_2_level_use_stack.has_recursion, or(0, indirect_use_stack.has_recursion)
-; GCN:	.set indirect_2_level_use_stack.has_indirect_call, or(0, indirect_use_stack.has_indirect_call)
+; GCN:	.set {{(\.L)?}}indirect_2_level_use_stack.num_vgpr, max(32, {{(.L)?}}indirect_use_stack.num_vgpr)
+; GCN:	.set {{(\.L)?}}indirect_2_level_use_stack.num_agpr, max(0, {{(.L)?}}indirect_use_stack.num_agpr)
+; GCN:	.set {{(\.L)?}}indirect_2_level_use_stack.numbered_sgpr, max(33, {{(.L)?}}indirect_use_stack.numbered_sgpr)
+; GCN:	.set {{(\.L)?}}indirect_2_level_use_stack.private_seg_size, 0+max({{(\.L)?}}indirect_use_stack.private_seg_size)
+; GCN:	.set {{(\.L)?}}indirect_2_level_use_stack.uses_vcc, or(1, {{(.L)?}}indirect_use_stack.uses_vcc)
+; GCN:	.set {{(\.L)?}}indirect_2_level_use_stack.uses_flat_scratch, or(1, {{(.L)?}}indirect_use_stack.uses_flat_scratch)
+; GCN:	.set {{(\.L)?}}indirect_2_level_use_stack.has_dyn_sized_stack, or(0, {{(.L)?}}indirect_use_stack.has_dyn_sized_stack)
+; GCN:	.set {{(\.L)?}}indirect_2_level_use_stack.has_recursion, or(0, {{(.L)?}}indirect_use_stack.has_recursion)
+; GCN:	.set {{(\.L)?}}indirect_2_level_use_stack.has_indirect_call, or(0, {{(.L)?}}indirect_use_stack.has_indirect_call)
 ; GCN: TotalNumSgprs: 40
 ; GCN: NumVgprs: 41
 ; GCN: ScratchSize: 2132
@@ -334,15 +335,15 @@ define amdgpu_kernel void @indirect_2_level_use_stack() #0 {
 
 ; Should be maximum of callee usage
 ; GCN-LABEL: {{^}}multi_call_use_use_stack:
-; GCN:	.set multi_call_use_use_stack.num_vgpr, max(41, use_stack0.num_vgpr, use_stack1.num_vgpr)
-; GCN:	.set multi_call_use_use_stack.num_agpr, max(0, use_stack0.num_agpr, use_stack1.num_agpr)
-; GCN:	.set multi_call_use_use_stack.numbered_sgpr, max(52, use_stack0.numbered_sgpr, use_stack1.numbered_sgpr)
-; GCN:	.set multi_call_use_use_stack.private_seg_size, 0+max(use_stack0.private_seg_size, use_stack1.private_seg_size)
-; GCN:	.set multi_call_use_use_stack.uses_vcc, or(1, use_stack0.uses_vcc, use_stack1.uses_vcc)
-; GCN:	.set multi_call_use_use_stack.uses_flat_scratch, or(1, use_stack0.uses_flat_scratch, use_stack1.uses_flat_scratch)
-; GCN:	.set multi_call_use_use_stack.has_dyn_sized_stack, or(0, use_stack0.has_dyn_sized_stack, use_stack1.has_dyn_sized_stack)
-; GCN:	.set multi_call_use_use_stack.has_recursion, or(0, use_stack0.has_recursion, use_stack1.has_recursion)
-; GCN:	.set multi_call_use_use_stack.has_indirect_call, or(0, use_stack0.has_indirect_call, use_stack1.has_indirect_call)
+; GCN:	.set {{(\.L)?}}multi_call_use_use_stack.num_vgpr, max(41, {{(.L)?}}use_stack0.num_vgpr, {{(.L)?}}use_stack1.num_vgpr)
+; GCN:	.set {{(\.L)?}}multi_call_use_use_stack.num_agpr, max(0, {{(.L)?}}use_stack0.num_agpr, {{(.L)?}}use_stack1.num_agpr)
+; GCN:	.set {{(\.L)?}}multi_call_use_use_stack.numbered_sgpr, max(52, {{(.L)?}}use_stack0.numbered_sgpr, {{(.L)?}}use_stack1.numbered_sgpr)
+; GCN:	.set {{(\.L)?}}multi_call_use_use_stack.private_seg_size, 0+max({{(\.L)?}}use_stack0.private_seg_size, {{(.L)?}}use_stack1.private_seg_size)
+; GCN:	.set {{(\.L)?}}multi_call_use_use_stack.uses_vcc, or(1, {{(.L)?}}use_stack0.uses_vcc, {{(.L)?}}use_stack1.uses_vcc)
+; GCN:	.set {{(\.L)?}}multi_call_use_use_stack.uses_flat_scratch, or(1, {{(.L)?}}use_stack0.uses_flat_scratch, {{(.L)?}}use_stack1.uses_flat_scratch)
+; GCN:	.set {{(\.L)?}}multi_call_use_use_stack.has_dyn_sized_stack, or(0, {{(.L)?}}use_stack0.has_dyn_sized_stack, {{(.L)?}}use_stack1.has_dyn_sized_stack)
+; GCN:	.set {{(\.L)?}}multi_call_use_use_stack.has_recursion, or(0, {{(.L)?}}use_stack0.has_recursion, {{(.L)?}}use_stack1.has_recursion)
+; GCN:	.set {{(\.L)?}}multi_call_use_use_stack.has_indirect_call, or(0, {{(.L)?}}use_stack0.has_indirect_call, {{(.L)?}}use_stack1.has_indirect_call)
 ; GCN: TotalNumSgprs: 58
 ; GCN: NumVgprs: 41
 ; GCN: ScratchSize: 2052
@@ -355,17 +356,17 @@ define amdgpu_kernel void @multi_call_use_use_stack() #0 {
 declare void @external() #0
 
 ; GCN-LABEL: {{^}}multi_call_with_external:
-; GCN:	.set multi_call_with_external.num_vgpr, max(41, amdgpu.max_num_vgpr)
-; GCN:	.set multi_call_with_external.num_agpr, max(0, amdgpu.max_num_agpr)
-; GCN:	.set multi_call_with_external.numbered_sgpr, max(52, amdgpu.max_num_sgpr)
-; GCN:	.set multi_call_with_external.private_seg_size, 0+max(use_stack0.private_seg_size, use_stack1.private_seg_size)
-; GCN:	.set multi_call_with_external.uses_vcc, 1
-; GCN:	.set multi_call_with_external.uses_flat_scratch, 1
-; GCN:	.set multi_call_with_external.has_dyn_sized_stack, 1
-; GCN:	.set multi_call_with_external.has_recursion, 0
-; GCN:	.set multi_call_with_external.has_indirect_call, 1
-; GCN: TotalNumSgprs: multi_call_with_external.numbered_sgpr+6
-; GCN: NumVgprs: multi_call_with_external.num_vgpr
+; GCN:	.set {{(\.L)?}}multi_call_with_external.num_vgpr, max(41, amdgpu.max_num_vgpr)
+; GCN:	.set {{(\.L)?}}multi_call_with_external.num_agpr, max(0, amdgpu.max_num_agpr)
+; GCN:	.set {{(\.L)?}}multi_call_with_external.numbered_sgpr, max(52, amdgpu.max_num_sgpr)
+; GCN:	.set {{(\.L)?}}multi_call_with_external.private_seg_size, 0+max({{(\.L)?}}use_stack0.private_seg_size, {{(.L)?}}use_stack1.private_seg_size)
+; GCN:	.set {{(\.L)?}}multi_call_with_external.uses_vcc, 1
+; GCN:	.set {{(\.L)?}}multi_call_with_external.uses_flat_scratch, 1
+; GCN:	.set {{(\.L)?}}multi_call_with_external.has_dyn_sized_stack, 1
+; GCN:	.set {{(\.L)?}}multi_call_with_external.has_recursion, 0
+; GCN:	.set {{(\.L)?}}multi_call_with_external.has_indirect_call, 1
+; GCN: TotalNumSgprs: {{(\.L)?}}multi_call_with_external.numbered_sgpr+6
+; GCN: NumVgprs: {{(\.L)?}}multi_call_with_external.num_vgpr
 ; GCN: ScratchSize: 2052
 define amdgpu_kernel void @multi_call_with_external() #0 {
   call void @use_stack0()
@@ -375,17 +376,17 @@ define amdgpu_kernel void @multi_call_with_external() #0 {
 }
 
 ; GCN-LABEL: {{^}}multi_call_with_external_and_duplicates:
-; GCN:	.set multi_call_with_external_and_duplicates.num_vgpr, max(41, amdgpu.max_num_vgpr)
-; GCN:	.set multi_call_with_external_and_duplicates.num_agpr, max(0, amdgpu.max_num_agpr)
-; GCN:	.set multi_call_with_external_and_duplicates.numbered_sgpr, max(54, amdgpu.max_num_sgpr)
-; GCN:	.set multi_call_with_external_and_duplicates.private_seg_size, 0+max(use_stack0.private_seg_size, use_stack1.private_seg_size)
-; GCN:	.set multi_call_with_external_and_duplicates.uses_vcc, 1
-; GCN:	.set multi_call_with_external_and_duplicates.uses_flat_scratch, 1
-; GCN:	.set multi_call_with_external_and_duplicates.has_dyn_sized_stack, 1
-; GCN:	.set multi_call_with_external_and_duplicates.has_recursion, 0
-; GCN:	.set multi_call_with_external_and_duplicates.has_indirect_call, 1
-; GCN: TotalNumSgprs: multi_call_with_external_and_duplicates.numbered_sgpr+6
-; GCN: NumVgprs: multi_call_with_external_and_duplicates.num_vgpr
+; GCN:	.set {{(\.L)?}}multi_call_with_external_and_duplicates.num_vgpr, max(41, amdgpu.max_num_vgpr)
+; GCN:	.set {{(\.L)?}}multi_call_with_external_and_duplicates.num_agpr, max(0, amdgpu.max_num_agpr)
+; GCN:	.set {{(\.L)?}}multi_call_with_external_and_duplicates.numbered_sgpr, max(54, amdgpu.max_num_sgpr)
+; GCN:	.set {{(\.L)?}}multi_call_with_external_and_duplicates.private_seg_size, 0+max({{(\.L)?}}use_stack0.private_seg_size, {{(.L)?}}use_stack1.private_seg_size)
+; GCN:	.set {{(\.L)?}}multi_call_with_external_and_duplicates.uses_vcc, 1
+; GCN:	.set {{(\.L)?}}multi_call_with_external_and_duplicates.uses_flat_scratch, 1
+; GCN:	.set {{(\.L)?}}multi_call_with_external_and_duplicates.has_dyn_sized_stack, 1
+; GCN:	.set {{(\.L)?}}multi_call_with_external_and_duplicates.has_recursion, 0
+; GCN:	.set {{(\.L)?}}multi_call_with_external_and_duplicates.has_indirect_call, 1
+; GCN: TotalNumSgprs: {{(\.L)?}}multi_call_with_external_and_duplicates.numbered_sgpr+6
+; GCN: NumVgprs: {{(\.L)?}}multi_call_with_external_and_duplicates.num_vgpr
 ; GCN: ScratchSize: 2052
 define amdgpu_kernel void @multi_call_with_external_and_duplicates() #0 {
   call void @use_stack0()
@@ -398,17 +399,17 @@ define amdgpu_kernel void @multi_call_with_external_and_duplicates() #0 {
 }
 
 ; GCN-LABEL: {{^}}usage_external:
-; GCN:	.set usage_external.num_vgpr, max(32, amdgpu.max_num_vgpr)
-; GCN:	.set usage_external.num_agpr, max(0, amdgpu.max_num_agpr)
-; GCN:	.set usage_external.numbered_sgpr, max(33, amdgpu.max_num_sgpr)
-; GCN:	.set usage_external.private_seg_size, 0
-; GCN:	.set usage_external.uses_vcc, 1
-; GCN:	.set usage_external.uses_flat_scratch, 1
-; GCN:	.set usage_external.has_dyn_sized_stack, 1
-; GCN:	.set usage_external.has_recursion, 0
-; GCN:	.set usage_external.has_indirect_call, 1
-; GCN: TotalNumSgprs: usage_external.numbered_sgpr+6
-; GCN: NumVgprs: usage_external.num_vgpr
+; GCN:	.set {{(\.L)?}}usage_external.num_vgpr, max(32, amdgpu.max_num_vgpr)
+; GCN:	.set {{(\.L)?}}usage_external.num_agpr, max(0, amdgpu.max_num_agpr)
+; GCN:	.set {{(\.L)?}}usage_external.numbered_sgpr, max(33, amdgpu.max_num_sgpr)
+; GCN:	.set {{(\.L)?}}usage_external.private_seg_size, 0
+; GCN:	.set {{(\.L)?}}usage_external.uses_vcc, 1
+; GCN:	.set {{(\.L)?}}usage_external.uses_flat_scratch, 1
+; GCN:	.set {{(\.L)?}}usage_external.has_dyn_sized_stack, 1
+; GCN:	.set {{(\.L)?}}usage_external.has_recursion, 0
+; GCN:	.set {{(\.L)?}}usage_external.has_indirect_call, 1
+; GCN: TotalNumSgprs: {{(\.L)?}}usage_external.numbered_sgpr+6
+; GCN: NumVgprs: {{(\.L)?}}usage_external.num_vgpr
 ; GCN: ScratchSize: 0
 define amdgpu_kernel void @usage_external() #0 {
   call void @external()
@@ -418,17 +419,17 @@ define amdgpu_kernel void @usage_external() #0 {
 declare void @external_recurse() #2
 
 ; GCN-LABEL: {{^}}usage_external_recurse:
-; GCN:	.set usage_external_recurse.num_vgpr, max(32, amdgpu.max_num_vgpr)
-; GCN:	.set usage_external_recurse.num_agpr, max(0, amdgpu.max_num_agpr)
-; GCN:	.set usage_external_recurse.numbered_sgpr, max(33, amdgpu.max_num_sgpr)
-; GCN:	.set usage_external_recurse.private_seg_size, 0
-; GCN:	.set usage_external_recurse.uses_vcc, 1
-; GCN:	.set usage_external_recurse.uses_flat_scratch, 1
-; GCN:	.set usage_external_recurse.has_dyn_sized_stack, 1
-; GCN:	.set usage_external_recurse.has_recursion, 1
-; GCN:	.set usage_external_recurse.has_indirect_call, 1
-; GCN: TotalNumSgprs: usage_external_recurse.numbered_sgpr+6
-; GCN: NumVgprs: usage_external_recurse.num_vgpr
+; GCN:	.set {{(\.L)?}}usage_external_recurse.num_vgpr, max(32, amdgpu.max_num_vgpr)
+; GCN:	.set {{(\.L)?}}usage_external_recurse.num_agpr, max(0, amdgpu.max_num_agpr)
+; GCN:	.set {{(\.L)?}}usage_external_recurse.numbered_sgpr, max(33, amdgpu.max_num_sgpr)
+; GCN:	.set {{(\.L)?}}usage_external_recurse.private_seg_size, 0
+; GCN:	.set {{(\.L)?}}usage_external_recurse.uses_vcc, 1
+; GCN:	.set {{(\.L)?}}usage_external_recurse.uses_flat_scratch, 1
+; GCN:	.set {{(\.L)?}}usage_external_recurse.has_dyn_sized_stack, 1
+; GCN:	.set {{(\.L)?}}usage_external_recurse.has_recursion, 1
+; GCN:	.set {{(\.L)?}}usage_external_recurse.has_indirect_call, 1
+; GCN: TotalNumSgprs: {{(\.L)?}}usage_external_recurse.numbered_sgpr+6
+; GCN: NumVgprs: {{(\.L)?}}usage_external_recurse.num_vgpr
 ; GCN: ScratchSize: 0
 define amdgpu_kernel void @usage_external_recurse() #0 {
   call void @external_recurse()
@@ -436,15 +437,15 @@ define amdgpu_kernel void @usage_external_recurse() #0 {
 }
 
 ; GCN-LABEL: {{^}}direct_recursion_use_stack:
-; GCN: .set direct_recursion_use_stack.num_vgpr, 41
-; GCN: .set direct_recursion_use_stack.num_agpr, 0
-; GCN: .set direct_recursion_use_stack.numbered_sgpr, 36
-; GCN: .set direct_recursion_use_stack.private_seg_size, 2064
-; GCN: .set direct_recursion_use_stack.uses_vcc, 1
-; GCN: .set direct_recursion_use_stack.uses_flat_scratch, 0
-; GCN: .set direct_recursion_use_stack.has_dyn_sized_stack, 0
-; GCN: .set direct_recursion_use_stack.has_recursion, 1
-; GCN: .set direct_recursion_use_stack.has_indirect_call, 0
+; GCN: .set {{(\.L)?}}direct_recursion_use_stack.num_vgpr, 41
+; GCN: .set {{(\.L)?}}direct_recursion_use_stack.num_agpr, 0
+; GCN: .set {{(\.L)?}}direct_recursion_use_stack.numbered_sgpr, 36
+; GCN: .set {{(\.L)?}}direct_recursion_use_stack.private_seg_size, 2064
+; GCN: .set {{(\.L)?}}direct_recursion_use_stack.uses_vcc, 1
+; GCN: .set {{(\.L)?}}direct_recursion_use_stack.uses_flat_scratch, 0
+; GCN: .set {{(\.L)?}}direct_recursion_use_stack.has_dyn_sized_stack, 0
+; GCN: .set {{(\.L)?}}direct_recursion_use_stack.has_recursion, 1
+; GCN: .set {{(\.L)?}}direct_recursion_use_stack.has_indirect_call, 0
 ; GCN: TotalNumSgprs: 40
 ; GCN: NumVgprs: 41
 ; GCN: ScratchSize: 2064
@@ -464,15 +465,15 @@ ret:
 }
 
 ; GCN-LABEL: {{^}}usage_direct_recursion:
-; GCN:  .set usage_direct_recursion.num_vgpr, max(32, direct_recursion_use_stack.num_vgpr)
-; GCN:  .set usage_direct_recursion.num_agpr, max(0, direct_recursion_use_stack.num_agpr)
-; GCN:  .set usage_direct_recursion.numbered_sgpr, max(33, direct_recursion_use_stack.numbered_sgpr)
-; GCN:  .set usage_direct_recursion.private_seg_size, 0+max(direct_recursion_use_stack.private_seg_size)
-; GCN:  .set usage_direct_recursion.uses_vcc, or(1, direct_recursion_use_stack.uses_vcc)
-; GCN:  .set usage_direct_recursion.uses_flat_scratch, or(1, direct_recursion_use_stack.uses_flat_scratch)
-; GCN:  .set usage_direct_recursion.has_dyn_sized_stack, or(0, direct_recursion_use_stack.has_dyn_sized_stack)
-; GCN:  .set usage_direct_recursion.has_recursion, or(1, direct_recursion_use_stack.has_recursion)
-; GCN:  .set usage_direct_recursion.has_indirect_call, or(0, direct_recursion_use_stack.has_indirect_call)
+; GCN:  .set {{(\.L)?}}usage_direct_recursion.num_vgpr, max(32, {{(.L)?}}direct_recursion_use_stack.num_vgpr)
+; GCN:  .set {{(\.L)?}}usage_direct_recursion.num_agpr, max(0, {{(.L)?}}direct_recursion_use_stack.num_agpr)
+; GCN:  .set {{(\.L)?}}usage_direct_recursion.numbered_sgpr, max(33, {{(.L)?}}direct_recursion_use_stack.numbered_sgpr)
+; GCN:  .set {{(\.L)?}}usage_direct_recursion.private_seg_size, 0+max({{(\.L)?}}direct_recursion_use_stack.private_seg_size)
+; GCN:  .set {{(\.L)?}}usage_direct_recursion.uses_vcc, or(1, {{(.L)?}}direct_recursion_use_stack.uses_vcc)
+; GCN:  .set {{(\.L)?}}usage_direct_recursion.uses_flat_scratch, or(1, {{(.L)?}}direct_recursion_use_stack.uses_flat_scratch)
+; GCN:  .set {{(\.L)?}}usage_direct_recursion.has_dyn_sized_stack, or(0, {{(.L)?}}direct_recursion_use_stack.has_dyn_sized_stack)
+; GCN:  .set {{(\.L)?}}usage_direct_recursion.has_recursion, or(1, {{(.L)?}}direct_recursion_use_stack.has_recursion)
+; GCN:  .set {{(\.L)?}}usage_direct_recursion.has_indirect_call, or(0, {{(.L)?}}direct_recursion_use_stack.has_indirect_call)
 ; GCN: TotalNumSgprs: 42
 ; GCN: NumVgprs: 41
 ; GCN: ScratchSize: 2064
@@ -482,28 +483,28 @@ define amdgpu_kernel void @usage_direct_recursion(i32 %n) #0 {
 }
 
 ; GCN-LABEL: {{^}}multi_stage_recurse2:
-; GCN: .set multi_stage_recurse2.num_vgpr, max(43, multi_stage_recurse1.num_vgpr)
-; GCN: .set multi_stage_recurse2.num_agpr, max(0, multi_stage_recurse1.num_agpr)
-; GCN: .set multi_stage_recurse2.numbered_sgpr, max(34, multi_stage_recurse1.numbered_sgpr)
-; GCN: .set multi_stage_recurse2.private_seg_size, 16+max(multi_stage_recurse1.private_seg_size)
-; GCN: .set multi_stage_recurse2.uses_vcc, or(1, multi_stage_recurse1.uses_vcc)
-; GCN: .set multi_stage_recurse2.uses_flat_scratch, or(0, multi_stage_recurse1.uses_flat_scratch)
-; GCN: .set multi_stage_recurse2.has_dyn_sized_stack, or(0, multi_stage_recurse1.has_dyn_sized_stack)
-; GCN: .set multi_stage_recurse2.has_recursion, or(1, multi_stage_recurse1.has_recursion)
-; GCN: .set multi_stage_recurse2.has_indirect_call, or(0, multi_stage_recurse1.has_indirect_call)
-; GCN: TotalNumSgprs: multi_stage_recurse2.numbered_sgpr+extrasgprs(multi_stage_recurse2.uses_vcc, multi_stage_recurse2.uses_flat_scratch, 1)
-; GCN: NumVgprs: max(43, multi_stage_recurse1.num_vgpr)
-; GCN: ScratchSize: 16+max(multi_stage_recurse1.private_seg_size)
+; GCN: .set {{(\.L)?}}multi_stage_recurse2.num_vgpr, max(43, {{(.L)?}}multi_stage_recurse1.num_vgpr)
+; GCN: .set {{(\.L)?}}multi_stage_recurse2.num_agpr, max(0, {{(.L)?}}multi_stage_recurse1.num_agpr)
+; GCN: .set {{(\.L)?}}multi_stage_recurse2.numbered_sgpr, max(34, {{(.L)?}}multi_stage_recurse1.numbered_sgpr)
+; GCN: .set {{(\.L)?}}multi_stage_recurse2.private_seg_size, 16+max({{(\.L)?}}multi_stage_recurse1.private_seg_size)
+; GCN: .set {{(\.L)?}}multi_stage_recurse2.uses_vcc, or(1, {{(.L)?}}multi_stage_recurse1.uses_vcc)
+; GCN: .set {{(\.L)?}}multi_stage_recurse2.uses_flat_scratch, or(0, {{(.L)?}}multi_stage_recurse1.uses_flat_scratch)
+; GCN: .set {{(\.L)?}}multi_stage_recurse2.has_dyn_sized_stack, or(0, {{(.L)?}}multi_stage_recurse1.has_dyn_sized_stack)
+; GCN: .set {{(\.L)?}}multi_stage_recurse2.has_recursion, or(1, {{(.L)?}}multi_stage_recurse1.has_recursion)
+; GCN: .set {{(\.L)?}}multi_stage_recurse2.has_indirect_call, or(0, {{(.L)?}}multi_stage_recurse1.has_indirect_call)
+; GCN: TotalNumSgprs: {{(\.L)?}}multi_stage_recurse2.numbered_sgpr+extrasgprs({{(\.L)?}}multi_stage_recurse2.uses_vcc, {{(.L)?}}multi_stage_recurse2.uses_flat_scratch, 1)
+; GCN: NumVgprs: max(43, {{(\.L)?}}multi_stage_recurse1.num_vgpr)
+; GCN: ScratchSize: 16+max({{(\.L)?}}multi_stage_recurse1.private_seg_size)
 ; GCN-LABEL: {{^}}multi_stage_recurse1:
-; GCN: .set multi_stage_recurse1.num_vgpr, max(48, 43)
-; GCN: .set multi_stage_recurse1.num_agpr, max(0, 0)
-; GCN: .set multi_stage_recurse1.numbered_sgpr, max(34, 34)
-; GCN: .set multi_stage_recurse1.private_seg_size, 16
-; GCN: .set multi_stage_recurse1.uses_vcc, 1
-; GCN: .set multi_stage_recurse1.uses_flat_scratch, 0
-; GCN: .set multi_stage_recurse1.has_dyn_sized_stack, 0
-; GCN: .set multi_stage_recurse1.has_recursion, 1
-; GCN: .set multi_stage_recurse1.has_indirect_call, 0
+; GCN: .set {{(\.L)?}}multi_stage_recurse1.num_vgpr, max(48, 43)
+; GCN: .set {{(\.L)?}}multi_stage_recurse1.num_agpr, max(0, 0)
+; GCN: .set {{(\.L)?}}multi_stage_recurse1.numbered_sgpr, max(34, 34)
+; GCN: .set {{(\.L)?}}multi_stage_recurse1.private_seg_size, 16
+; GCN: .set {{(\.L)?}}multi_stage_recurse1.uses_vcc, 1
+; GCN: .set {{(\.L)?}}multi_stage_recurse1.uses_flat_scratch, 0
+; GCN: .set {{(\.L)?}}multi_stage_recurse1.has_dyn_sized_stack, 0
+; GCN: .set {{(\.L)?}}multi_stage_recurse1.has_recursion, 1
+; GCN: .set {{(\.L)?}}multi_stage_recurse1.has_indirect_call, 0
 ; GCN: TotalNumSgprs: 38
 ; GCN: NumVgprs: 48
 ; GCN: ScratchSize: 16
@@ -519,15 +520,15 @@ define void @multi_stage_recurse2(i32 %val) #2 {
 }
 
 ; GCN-LABEL: {{^}}usage_multi_stage_recurse:
-; GCN: .set usage_multi_stage_recurse.num_vgpr, max(32, multi_stage_recurse1.num_vgpr)
-; GCN: .set usage_multi_stage_recurse.num_agpr, max(0, multi_stage_recurse1.num_agpr)
-; GCN: .set usage_multi_stage_recurse.numbered_sgpr, max(33, multi_stage_recurse1.numbered_sgpr)
-; GCN: .set usage_multi_stage_recurse.private_seg_size, 0+max(multi_stage_recurse1.private_seg_size)
-; GCN: .set usage_multi_stage_recurse.uses_vcc, or(1, multi_stage_recurse1.uses_vcc)
-; GCN: .set usage_multi_stage_recurse.uses_flat_scratch, or(1, multi_stage_recurse1.uses_flat_scratch)
-; GCN: .set usage_multi_stage_recurse.has_dyn_sized_stack, or(0, multi_stage_recurse1.has_dyn_sized_stack)
-; GCN: .set usage_multi_stage_recurse.has_recursion, or(1, multi_stage_recurse1.has_recursion)
-; GCN: .set usage_multi_stage_recurse.has_indirect_call, or(0, multi_stage_recurse1.has_indirect_call)
+; GCN: .set {{(\.L)?}}usage_multi_stage_recurse.num_vgpr, max(32, {{(.L)?}}multi_stage_recurse1.num_vgpr)
+; GCN: .set {{(\.L)?}}usage_multi_stage_recurse.num_agpr, max(0, {{(.L)?}}multi_stage_recurse1.num_agpr)
+; GCN: .set {{(\.L)?}}usage_multi_stage_recurse.numbered_sgpr, max(33, {{(.L)?}}multi_stage_recurse1.numbered_sgpr)
+; GCN: .set {{(\.L)?}}usage_multi_stage_recurse.private_seg_size, 0+max({{(\.L)?}}multi_stage_recurse1.private_seg_size)
+; GCN: .set {{(\.L)?}}usage_multi_stage_recurse.uses_vcc, or(1, {{(.L)?}}multi_stage_recurse1.uses_vcc)
+; GCN: .set {{(\.L)?}}usage_multi_stage_recurse.uses_flat_scratch, or(1, {{(.L)?}}multi_stage_recurse1.uses_flat_scratch)
+; GCN: .set {{(\.L)?}}usage_multi_stage_recurse.has_dyn_sized_stack, or(0, {{(.L)?}}multi_stage_recurse1.has_dyn_sized_stack)
+; GCN: .set {{(\.L)?}}usage_multi_stage_recurse.has_recursion, or(1, {{(.L)?}}multi_stage_recurse1.has_recursion)
+; GCN: .set {{(\.L)?}}usage_multi_stage_recurse.has_indirect_call, or(0, {{(.L)?}}multi_stage_recurse1.has_indirect_call)
 ; GCN: TotalNumSgprs: 40
 ; GCN: NumVgprs: 48
 ; GCN: ScratchSize: 16
@@ -537,28 +538,28 @@ define amdgpu_kernel void @usage_multi_stage_recurse(i32 %n) #0 {
 }
 
 ; GCN-LABEL: {{^}}multi_stage_recurse_noattr2:
-; GCN: .set multi_stage_recurse_noattr2.num_vgpr, max(41, multi_stage_recurse_noattr1.num_vgpr)
-; GCN: .set multi_stage_recurse_noattr2.num_agpr, max(0, multi_stage_recurse_noattr1.num_agpr)
-; GCN: .set multi_stage_recurse_noattr2.numbered_sgpr, max(54, multi_stage_recurse_noattr1.numbered_sgpr)
-; GCN: .set multi_stage_recurse_noattr2.private_seg_size, 16+max(multi_stage_recurse_noattr1.private_seg_size)
-; GCN: .set multi_stage_recurse_noattr2.uses_vcc, or(1, multi_stage_recurse_noattr1.uses_vcc)
-; GCN: .set multi_stage_recurse_noattr2.uses_flat_scratch, or(0, multi_stage_recurse_noattr1.uses_flat_scratch)
-; GCN: .set multi_stage_recurse_noattr2.has_dyn_sized_stack, or(0, multi_stage_recurse_noattr1.has_dyn_sized_stack)
-; GCN: .set multi_stage_recurse_noattr2.has_recursion, or(0, multi_stage_recurse_noattr1.has_recursion)
-; GCN: .set multi_stage_recurse_noattr2.has_indirect_call, or(0, multi_stage_recurse_noattr1.has_indirect_call)
-; GCN: TotalNumSgprs: multi_stage_recurse_noattr2.numbered_sgpr+extrasgprs(multi_stage_recurse_noattr2.uses_vcc, multi_stage_recurse_noattr2.uses_flat_scratch, 1)
-; GCN: NumVgprs: max(41, multi_stage_recurse_noattr1.num_vgpr)
-; GCN: ScratchSize: 16+max(multi_stage_recurse_noattr1.private_seg_size)
+; GCN: .set {{(\.L)?}}multi_stage_recurse_noattr2.num_vgpr, max(41, {{(.L)?}}multi_stage_recurse_noattr1.num_vgpr)
+; GCN: .set {{(\.L)?}}multi_stage_recurse_noattr2.num_agpr, max(0, {{(.L)?}}multi_stage_recurse_noattr1.num_agpr)
+; GCN: .set {{(\.L)?}}multi_stage_recurse_noattr2.numbered_sgpr, max(54, {{(.L)?}}multi_stage_recurse_noattr1.numbered_sgpr)
+; GCN: .set {{(\.L)?}}multi_stage_recurse_noattr2.private_seg_size, 16+max({{(\.L)?}}multi_stage_recurse_noattr1.private_seg_size)
+; GCN: .set {{(\.L)?}}multi_stage_recurse_noattr2.uses_vcc, or(1, {{(.L)?}}multi_stage_recurse_noattr1.uses_vcc)
+; GCN: .set {{(\.L)?}}multi_stage_recurse_noattr2.uses_flat_scratch, or(0, {{(.L)?}}multi_stage_recurse_noattr1.uses_flat_scratch)
+; GCN: .set {{(\.L)?}}multi_stage_recurse_noattr2.has_dyn_sized_stack, or(0, {{(.L)?}}multi_stage_recurse_noattr1.has_dyn_sized_stack)
+; GCN: .set {{(\.L)?}}multi_stage_recurse_noattr2.has_recursion, or(0, {{(.L)?}}multi_stage_recurse_noattr1.has_recursion)
+; GCN: .set {{(\.L)?}}multi_stage_recurse_noattr2.has_indirect_call, or(0, {{(.L)?}}multi_stage_recurse_noattr1.has_indirect_call)
+; GCN: TotalNumSgprs: {{(\.L)?}}multi_stage_recurse_noattr2.numbered_sgpr+extrasgprs({{(\.L)?}}multi_stage_recurse_noattr2.uses_vcc, {{(.L)?}}multi_stage_recurse_noattr2.uses_flat_scratch, 1)
+; GCN: NumVgprs: max(41, {{(\.L)?}}multi_stage_recurse_noattr1.num_vgpr)
+; GCN: ScratchSize: 16+max({{(\.L)?}}multi_stage_recurse_noattr1.private_seg_size)
 ; GCN-LABEL: {{^}}multi_stage_recurse_noattr1:
-; GCN: .set multi_stage_recurse_noattr1.num_vgpr, max(41, 41)
-; GCN: .set multi_stage_recurse_noattr1.num_agpr, max(0, 0)
-; GCN: .set multi_stage_recurse_noattr1.numbered_sgpr, max(57, 54)
-; GCN: .set multi_stage_recurse_noattr1.private_seg_size, 16
-; GCN: .set multi_stage_recurse_noattr1.uses_vcc, 1
-; GCN: .set multi_stage_recurse_noattr1.uses_flat_scratch, 0
-; GCN: .set multi_stage_recurse_noattr1.has_dyn_sized_stack, 0
-; GCN: .set multi_stage_recurse_noattr1.has_recursion, 0
-; GCN: .set multi_stage_recurse_noattr1.has_indirect_call, 0
+; GCN: .set {{(\.L)?}}multi_stage_recurse_noattr1.num_vgpr, max(41, 41)
+; GCN: .set {{(\.L)?}}multi_stage_recurse_noattr1.num_agpr, max(0, 0)
+; GCN: .set {{(\.L)?}}multi_stage_recurse_noattr1.numbered_sgpr, max(57, 54)
+; GCN: .set {{(\.L)?}}multi_stage_recurse_noattr1.private_seg_size, 16
+; GCN: .set {{(\.L)?}}multi_stage_recurse_noattr1.uses_vcc, 1
+; GCN: .set {{(\.L)?}}multi_stage_recurse_noattr1.uses_flat_scratch, 0
+; GCN: .set {{(\.L)?}}multi_stage_recurse_noattr1.has_dyn_sized_stack, 0
+; GCN: .set {{(\.L)?}}multi_stage_recurse_noattr1.has_recursion, 0
+; GCN: .set {{(\.L)?}}multi_stage_recurse_noattr1.has_indirect_call, 0
 ; GCN: TotalNumSgprs: 61
 ; GCN: NumVgprs: 41
 ; GCN: ScratchSize: 16
@@ -574,15 +575,15 @@ define void @multi_stage_recurse_noattr2(i32 %val) #0 {
 }
 
 ; GCN-LABEL: {{^}}usage_multi_stage_recurse_noattrs:
-; GCN: .set usage_multi_stage_recurse_noattrs.num_vgpr, max(32, multi_stage_recurse_noattr1.num_vgpr)
-; GCN: .set usage_multi_stage_recurse_noattrs.num_agpr, max(0, multi_stage_recurse_noattr1.num_agpr)
-; GCN: .set usage_multi_stage_recurse_noattrs.numbered_sgpr, max(33, multi_stage_recurse_noattr1.numbered_sgpr)
-; GCN: .set usage_multi_stage_recurse_noattrs.private_seg_size, 0+max(multi_stage_recurse_noattr1.private_seg_size)
-; GCN: .set usage_multi_stage_recurse_noattrs.uses_vcc, or(1, multi_stage_recurse_noattr1.uses_vcc)
-; GCN: .set usage_multi_stage_recurse_noattrs.uses_flat_scratch, or(1, multi_stage_recurse_noattr1.uses_flat_scratch)
-; GCN: .set usage_multi_stage_recurse_noattrs.has_dyn_sized_stack, or(0, multi_stage_recurse_noattr1.has_dyn_sized_stack)
-; GCN: .set usage_multi_stage_recurse_noattrs.has_recursion, or(0, multi_stage_recurse_noattr1.has_recursion)
-; GCN: .set usage_multi_stage_recurse_noattrs.has_indirect_call, or(0, multi_stage_recurse_noattr1.has_indirect_call)
+; GCN: .set {{(\.L)?}}usage_multi_stage_recurse_noattrs.num_vgpr, max(32, {{(.L)?}}multi_stage_recurse_noattr1.num_vgpr)
+; GCN: .set {{(\.L)?}}usage_multi_stage_recurse_noattrs.num_agpr, max(0, {{(.L)?}}multi_stage_recurse_noattr1.num_agpr)
+; GCN: .set {{(\.L)?}}usage_multi_stage_recurse_noattrs.numbered_sgpr, max(33, {{(.L)?}}multi_stage_recurse_noattr1.numbered_sgpr)
+; GCN: .set {{(\.L)?}}usage_multi_stage_recurse_noattrs.private_seg_size, 0+max({{(\.L)?}}multi_stage_recurse_noattr1.private_seg_size)
+; GCN: .set {{(\.L)?}}usage_multi_stage_recurse_noattrs.uses_vcc, or(1, {{(.L)?}}multi_stage_recurse_noattr1.uses_vcc)
+; GCN: .set {{(\.L)?}}usage_multi_stage_recurse_noattrs.uses_flat_scratch, or(1, {{(.L)?}}multi_stage_recurse_noattr1.uses_flat_scratch)
+; GCN: .set {{(\.L)?}}usage_multi_stage_recurse_noattrs.has_dyn_sized_stack, or(0, {{(.L)?}}multi_stage_recurse_noattr1.has_dyn_sized_stack)
+; GCN: .set {{(\.L)?}}usage_multi_stage_recurse_noattrs.has_recursion, or(0, {{(.L)?}}multi_stage_recurse_noattr1.has_recursion)
+; GCN: .set {{(\.L)?}}usage_multi_stage_recurse_noattrs.has_indirect_call, or(0, {{(.L)?}}multi_stage_recurse_noattr1.has_indirect_call)
 ; GCN: TotalNumSgprs: 63
 ; GCN: NumVgprs: 41
 ; GCN: ScratchSize: 16
@@ -592,15 +593,15 @@ define amdgpu_kernel void @usage_multi_stage_recurse_noattrs(i32 %n) #0 {
 }
 
 ; GCN-LABEL: {{^}}multi_call_with_multi_stage_recurse:
-; GCN:  .set multi_call_with_multi_stage_recurse.num_vgpr, max(41, use_stack0.num_vgpr, use_stack1.num_vgpr, multi_stage_recurse1.num_vgpr)
-; GCN:  .set multi_call_with_multi_stage_recurse.num_agpr, max(0, use_stack0.num_agpr, use_stack1.num_agpr, multi_stage_recurse1.num_agpr)
-; GCN:  .set multi_call_with_multi_stage_recurse.numbered_sgpr, max(53, use_stack0.numbered_sgpr, use_stack1.numbered_sgpr, multi_stage_recurse1.numbered_sgpr)
-; GCN:  .set multi_call_with_multi_stage_recurse.private_seg_size, 0+max(use_stack0.private_seg_size, use_stack1.private_seg_size, multi_stage_recurse1.private_seg_size)
-; GCN:  .set multi_call_with_multi_stage_recurse.uses_vcc, or(1, use_stack0.uses_vcc, use_stack1.uses_vcc, multi_stage_recurse1.uses_vcc)
-; GCN:  .set multi_call_with_multi_stage_recurse.uses_flat_scratch, or(1, use_stack0.uses_flat_scratch, use_stack1.uses_flat_scratch, multi_stage_recurse1.uses_flat_scratch)
-; GCN:  .set multi_call_with_multi_stage_recurse.has_dyn_sized_stack, or(0, use_stack0.has_dyn_sized_stack, use_stack1.has_dyn_sized_stack, multi_stage_recurse1.has_dyn_sized_stack)
-; GCN:  .set multi_call_with_multi_stage_recurse.has_recursion, or(1, use_stack0.has_recursion, use_stack1.has_recursion, multi_stage_recurse1.has_recursion)
-; GCN:  .set multi_call_with_multi_stage_recurse.has_indirect_call, or(0, use_stack0.has_indirect_call, use_stack1.has_indirect_call, multi_stage_recurse1.has_indirect_call)
+; GCN:  .set {{(\.L)?}}multi_call_with_multi_stage_recurse.num_vgpr, max(41, {{(.L)?}}use_stack0.num_vgpr, {{(.L)?}}use_stack1.num_vgpr, {{(\.L)?}}multi_stage_recurse1.num_vgpr)
+; GCN:  .set {{(\.L)?}}multi_call_with_multi_stage_recurse.num_agpr, max(0, {{(.L)?}}use_stack0.num_agpr, {{(.L)?}}use_stack1.num_agpr, {{(\.L)?}}multi_stage_recurse1.num_agpr)
+; GCN:  .set {{(\.L)?}}multi_call_with_multi_stage_recurse.numbered_sgpr, max(53, {{(.L)?}}use_stack0.numbered_sgpr, {{(.L)?}}use_stack1.numbered_sgpr, {{(\.L)?}}multi_stage_recurse1.numbered_sgpr)
+; GCN:  .set {{(\.L)?}}multi_call_with_multi_stage_recurse.private_seg_size, 0+max({{(\.L)?}}use_stack0.private_seg_size, {{(.L)?}}use_stack1.private_seg_size, {{(\.L)?}}multi_stage_recurse1.private_seg_size)
+; GCN:  .set {{(\.L)?}}multi_call_with_multi_stage_recurse.uses_vcc, or(1, {{(.L)?}}use_stack0.uses_vcc, {{(.L)?}}use_stack1.uses_vcc, {{(\.L)?}}multi_stage_recurse1.uses_vcc)
+; GCN:  .set {{(\.L)?}}multi_call_with_multi_stage_recurse.uses_flat_scratch, or(1, {{(.L)?}}use_stack0.uses_flat_scratch, {{(.L)?}}use_stack1.uses_flat_scratch, {{(\.L)?}}multi_stage_recurse1.uses_flat_scratch)
+; GCN:  .set {{(\.L)?}}multi_call_with_multi_stage_recurse.has_dyn_sized_stack, or(0, {{(.L)?}}use_stack0.has_dyn_sized_stack, {{(.L)?}}use_stack1.has_dyn_sized_stack, {{(\.L)?}}multi_stage_recurse1.has_dyn_sized_stack)
+; GCN:  .set {{(\.L)?}}multi_call_with_multi_stage_recurse.has_recursion, or(1, {{(.L)?}}use_stack0.has_recursion, {{(.L)?}}use_stack1.has_recursion, {{(\.L)?}}multi_stage_recurse1.has_recursion)
+; GCN:  .set {{(\.L)?}}multi_call_with_multi_stage_recurse.has_indirect_call, or(0, {{(.L)?}}use_stack0.has_indirect_call, {{(.L)?}}use_stack1.has_indirect_call, {{(\.L)?}}multi_stage_recurse1.has_indirect_call)
 ; GCN: TotalNumSgprs: 59
 ; GCN: NumVgprs:  48
 ; GCN: ScratchSize: 2052
@@ -613,17 +614,17 @@ define amdgpu_kernel void @multi_call_with_multi_stage_recurse(i32 %n) #0 {
 
 ; Make sure there's no assert when a sgpr96 is used.
 ; GCN-LABEL: {{^}}count_use_sgpr96_external_call
-; GCN:	.set count_use_sgpr96_external_call.num_vgpr, max(32, amdgpu.max_num_vgpr)
-; GCN:	.set count_use_sgpr96_external_call.num_agpr, max(0, amdgpu.max_num_agpr)
-; GCN:	.set count_use_sgpr96_external_call.numbered_sgpr, max(33, amdgpu.max_num_sgpr)
-; GCN:	.set count_use_sgpr96_external_call.private_seg_size, 0
-; GCN:	.set count_use_sgpr96_external_call.uses_vcc, 1
-; GCN:	.set count_use_sgpr96_external_call.uses_flat_scratch, 1
-; GCN:	.set count_use_sgpr96_external_call.has_dyn_sized_stack, 1
-; GCN:	.set count_use_sgpr96_external_call.has_recursion, 0
-; GCN:	.set count_use_sgpr96_external_call.has_indirect_call, 1
-; GCN: TotalNumSgprs: count_use_sgpr96_external_call.numbered_sgpr+6
-; GCN: NumVgprs: count_use_sgpr96_external_call.num_vgpr
+; GCN:	.set {{(\.L)?}}count_use_sgpr96_external_call.num_vgpr, max(32, amdgpu.max_num_vgpr)
+; GCN:	.set {{(\.L)?}}count_use_sgpr96_external_call.num_agpr, max(0, amdgpu.max_num_agpr)
+; GCN:	.set {{(\.L)?}}count_use_sgpr96_external_call.numbered_sgpr, max(33, amdgpu.max_num_sgpr)
+; GCN:	.set {{(\.L)?}}count_use_sgpr96_external_call.private_seg_size, 0
+; GCN:	.set {{(\.L)?}}count_use_sgpr96_external_call.uses_vcc, 1
+; GCN:	.set {{(\.L)?}}count_use_sgpr96_external_call.uses_flat_scratch, 1
+; GCN:	.set {{(\.L)?}}count_use_sgpr96_external_call.has_dyn_sized_stack, 1
+; GCN:	.set {{(\.L)?}}count_use_sgpr96_external_call.has_recursion, 0
+; GCN:	.set {{(\.L)?}}count_use_sgpr96_external_call.has_indirect_call, 1
+; GCN: TotalNumSgprs: {{(\.L)?}}count_use_sgpr96_external_call.numbered_sgpr+6
+; GCN: NumVgprs: {{(\.L)?}}count_use_sgpr96_external_call.num_vgpr
 ; GCN: ScratchSize: 0
 define amdgpu_kernel void @count_use_sgpr96_external_call()  {
 entry:
@@ -634,17 +635,17 @@ entry:
 
 ; Make sure there's no assert when a sgpr160 is used.
 ; GCN-LABEL: {{^}}count_use_sgpr160_external_call
-; GCN:	.set count_use_sgpr160_external_call.num_vgpr, max(32, amdgpu.max_num_vgpr)
-; GCN:	.set count_use_sgpr160_external_call.num_agpr, max(0, amdgpu.max_num_agpr)
-; GCN:	.set count_use_sgpr160_external_call.numbered_sgpr, max(33, amdgpu.max_num_sgpr)
-; GCN:	.set count_use_sgpr160_external_call.private_seg_size, 0
-; GCN:	.set count_use_sgpr160_external_call.uses_vcc, 1
-; GCN:	.set count_use_sgpr160_external_call.uses_flat_scratch, 1
-; GCN:	.set count_use_sgpr160_external_call.has_dyn_sized_stack, 1
-; GCN:	.set count_use_sgpr160_external_call.has_recursion, 0
-; GCN:	.set count_use_sgpr160_external_call.has_indirect_call, 1
-; GCN: TotalNumSgprs: count_use_sgpr160_external_call.numbered_sgpr+6
-; GCN: NumVgprs: count_use_sgpr160_external_call.num_vgpr
+; GCN:	.set {{(\.L)?}}count_use_sgpr160_external_call.num_vgpr, max(32, amdgpu.max_num_vgpr)
+; GCN:	.set {{(\.L)?}}count_use_sgpr160_external_call.num_agpr, max(0, amdgpu.max_num_agpr)
+; GCN:	.set {{(\.L)?}}count_use_sgpr160_external_call.numbered_sgpr, max(33, amdgpu.max_num_sgpr)
+; GCN:	.set {{(\.L)?}}count_use_sgpr160_external_call.private_seg_size, 0
+; GCN:	.set {{(\.L)?}}count_use_sgpr160_external_call.uses_vcc, 1
+; GCN:	.set {{(\.L)?}}count_use_sgpr160_external_call.uses_flat_scratch, 1
+; GCN:	.set {{(\.L)?}}count_use_sgpr160_external_call.has_dyn_sized_stack, 1
+; GCN:	.set {{(\.L)?}}count_use_sgpr160_external_call.has_recursion, 0
+; GCN:	.set {{(\.L)?}}count_use_sgpr160_external_call.has_indirect_call, 1
+; GCN: TotalNumSgprs: {{(\.L)?}}count_use_sgpr160_external_call.numbered_sgpr+6
+; GCN: NumVgprs: {{(\.L)?}}count_use_sgpr160_external_call.num_vgpr
 ; GCN: ScratchSize: 0
 define amdgpu_kernel void @count_use_sgpr160_external_call()  {
 entry:
@@ -655,17 +656,17 @@ entry:
 
 ; Make sure there's no assert when a vgpr160 is used.
 ; GCN-LABEL: {{^}}count_use_vgpr160_external_call
-; GCN:	.set count_use_vgpr160_external_call.num_vgpr, max(32, amdgpu.max_num_vgpr)
-; GCN:	.set count_use_vgpr160_external_call.num_agpr, max(0, amdgpu.max_num_agpr)
-; GCN:	.set count_use_vgpr160_external_call.numbered_sgpr, max(33, amdgpu.max_num_sgpr)
-; GCN:	.set count_use_vgpr160_external_call.private_seg_size, 0
-; GCN:	.set count_use_vgpr160_external_call.uses_vcc, 1
-; GCN:	.set count_use_vgpr160_external_call.uses_flat_scratch, 1
-; GCN:	.set count_use_vgpr160_external_call.has_dyn_sized_stack, 1
-; GCN:	.set count_use_vgpr160_external_call.has_recursion, 0
-; GCN:	.set count_use_vgpr160_external_call.has_indirect_call, 1
-; GCN: TotalNumSgprs: count_use_vgpr160_external_call.numbered_sgpr+6
-; GCN: NumVgprs: count_use_vgpr160_external_call.num_vgpr
+; GCN:	.set {{(\.L)?}}count_use_vgpr160_external_call.num_vgpr, max(32, amdgpu.max_num_vgpr)
+; GCN:	.set {{(\.L)?}}count_use_vgpr160_external_call.num_agpr, max(0, amdgpu.max_num_agpr)
+; GCN:	.set {{(\.L)?}}count_use_vgpr160_external_call.numbered_sgpr, max(33, amdgpu.max_num_sgpr)
+; GCN:	.set {{(\.L)?}}count_use_vgpr160_external_call.private_seg_size, 0
+; GCN:	.set {{(\.L)?}}count_use_vgpr160_external_call.uses_vcc, 1
+; GCN:	.set {{(\.L)?}}count_use_vgpr160_external_call.uses_flat_scratch, 1
+; GCN:	.set {{(\.L)?}}count_use_vgpr160_external_call.has_dyn_sized_stack, 1
+; GCN:	.set {{(\.L)?}}count_use_vgpr160_external_call.has_recursion, 0
+; GCN:	.set {{(\.L)?}}count_use_vgpr160_external_call.has_indirect_call, 1
+; GCN: TotalNumSgprs: {{(\.L)?}}count_use_vgpr160_external_call.numbered_sgpr+6
+; GCN: NumVgprs: {{(\.L)?}}count_use_vgpr160_external_call.num_vgpr
 ; GCN: ScratchSize: 0
 define amdgpu_kernel void @count_use_vgpr160_external_call()  {
 entry:
@@ -676,7 +677,7 @@ entry:
 
 ; Test that amdgcn.device.init correctly references amdgpu.max_num_named_barrier
 ; GCN-LABEL: {{^}}amdgcn.device.init:
-; GCN: .set amdgcn.device.init.num_named_barrier, max(0, amdgpu.max_num_named_barrier)
+; GCN: .set {{(\.L)?}}amdgcn.device.init.num_named_barrier, max(0, amdgpu.max_num_named_barrier)
 
 @llvm.global_ctors = appending addrspace(1) global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 1, ptr @ctor_func, ptr null }]
 

--- a/llvm/test/CodeGen/AMDGPU/function-resource-usage.ll
+++ b/llvm/test/CodeGen/AMDGPU/function-resource-usage.ll
@@ -1,18 +1,18 @@
-; RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx900 -enable-ipra=0 -amdgpu-localize-resource-symbols=false < %s | FileCheck -check-prefix=GCN %s
+; RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx900 -enable-ipra=0 < %s | FileCheck -check-prefix=GCN %s
 ; RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx900 -enable-ipra=0 < %s | FileCheck -check-prefix=GCN %s
 
 ; Functions that don't make calls should have constants as its resource usage as no resource information has to be propagated.
 
 ; GCN-LABEL: {{^}}use_vcc:
-; GCN: .set {{(\.L)?}}use_vcc.num_vgpr, 0
-; GCN: .set {{(\.L)?}}use_vcc.num_agpr, 0
-; GCN: .set {{(\.L)?}}use_vcc.numbered_sgpr, 32
-; GCN: .set {{(\.L)?}}use_vcc.private_seg_size, 0
-; GCN: .set {{(\.L)?}}use_vcc.uses_vcc, 1
-; GCN: .set {{(\.L)?}}use_vcc.uses_flat_scratch, 0
-; GCN: .set {{(\.L)?}}use_vcc.has_dyn_sized_stack, 0
-; GCN: .set {{(\.L)?}}use_vcc.has_recursion, 0
-; GCN: .set {{(\.L)?}}use_vcc.has_indirect_call, 0
+; GCN: .set .Luse_vcc.num_vgpr, 0
+; GCN: .set .Luse_vcc.num_agpr, 0
+; GCN: .set .Luse_vcc.numbered_sgpr, 32
+; GCN: .set .Luse_vcc.private_seg_size, 0
+; GCN: .set .Luse_vcc.uses_vcc, 1
+; GCN: .set .Luse_vcc.uses_flat_scratch, 0
+; GCN: .set .Luse_vcc.has_dyn_sized_stack, 0
+; GCN: .set .Luse_vcc.has_recursion, 0
+; GCN: .set .Luse_vcc.has_indirect_call, 0
 ; GCN: TotalNumSgprs: 36
 ; GCN: NumVgprs: 0
 ; GCN: ScratchSize: 0
@@ -22,15 +22,15 @@ define void @use_vcc() #1 {
 }
 
 ; GCN-LABEL: {{^}}indirect_use_vcc:
-; GCN: .set {{(\.L)?}}indirect_use_vcc.num_vgpr, max(41, {{(\.L)?}}use_vcc.num_vgpr)
-; GCN: .set {{(\.L)?}}indirect_use_vcc.num_agpr, max(0, {{(\.L)?}}use_vcc.num_agpr)
-; GCN: .set {{(\.L)?}}indirect_use_vcc.numbered_sgpr, max(34, {{(\.L)?}}use_vcc.numbered_sgpr)
-; GCN: .set {{(\.L)?}}indirect_use_vcc.private_seg_size, 16+max({{(\.L)?}}use_vcc.private_seg_size)
-; GCN: .set {{(\.L)?}}indirect_use_vcc.uses_vcc, or(1, {{(\.L)?}}use_vcc.uses_vcc)
-; GCN: .set {{(\.L)?}}indirect_use_vcc.uses_flat_scratch, or(0, {{(\.L)?}}use_vcc.uses_flat_scratch)
-; GCN: .set {{(\.L)?}}indirect_use_vcc.has_dyn_sized_stack, or(0, {{(\.L)?}}use_vcc.has_dyn_sized_stack)
-; GCN: .set {{(\.L)?}}indirect_use_vcc.has_recursion, or(0, {{(\.L)?}}use_vcc.has_recursion)
-; GCN: .set {{(\.L)?}}indirect_use_vcc.has_indirect_call, or(0, {{(\.L)?}}use_vcc.has_indirect_call)
+; GCN: .set .Lindirect_use_vcc.num_vgpr, max(41, .Luse_vcc.num_vgpr)
+; GCN: .set .Lindirect_use_vcc.num_agpr, max(0, .Luse_vcc.num_agpr)
+; GCN: .set .Lindirect_use_vcc.numbered_sgpr, max(34, .Luse_vcc.numbered_sgpr)
+; GCN: .set .Lindirect_use_vcc.private_seg_size, 16+max(.Luse_vcc.private_seg_size)
+; GCN: .set .Lindirect_use_vcc.uses_vcc, or(1, .Luse_vcc.uses_vcc)
+; GCN: .set .Lindirect_use_vcc.uses_flat_scratch, or(0, .Luse_vcc.uses_flat_scratch)
+; GCN: .set .Lindirect_use_vcc.has_dyn_sized_stack, or(0, .Luse_vcc.has_dyn_sized_stack)
+; GCN: .set .Lindirect_use_vcc.has_recursion, or(0, .Luse_vcc.has_recursion)
+; GCN: .set .Lindirect_use_vcc.has_indirect_call, or(0, .Luse_vcc.has_indirect_call)
 ; GCN: TotalNumSgprs: 38
 ; GCN: NumVgprs: 41
 ; GCN: ScratchSize: 16
@@ -40,15 +40,15 @@ define void @indirect_use_vcc() #1 {
 }
 
 ; GCN-LABEL: {{^}}indirect_2level_use_vcc_kernel:
-; GCN: .set {{(\.L)?}}indirect_2level_use_vcc_kernel.num_vgpr, max(32, {{(\.L)?}}indirect_use_vcc.num_vgpr)
-; GCN: .set {{(\.L)?}}indirect_2level_use_vcc_kernel.num_agpr, max(0, {{(\.L)?}}indirect_use_vcc.num_agpr)
-; GCN: .set {{(\.L)?}}indirect_2level_use_vcc_kernel.numbered_sgpr, max(33, {{(\.L)?}}indirect_use_vcc.numbered_sgpr)
-; GCN: .set {{(\.L)?}}indirect_2level_use_vcc_kernel.private_seg_size, 0+max({{(\.L)?}}indirect_use_vcc.private_seg_size)
-; GCN: .set {{(\.L)?}}indirect_2level_use_vcc_kernel.uses_vcc, or(1, {{(\.L)?}}indirect_use_vcc.uses_vcc)
-; GCN: .set {{(\.L)?}}indirect_2level_use_vcc_kernel.uses_flat_scratch, or(1, {{(\.L)?}}indirect_use_vcc.uses_flat_scratch)
-; GCN: .set {{(\.L)?}}indirect_2level_use_vcc_kernel.has_dyn_sized_stack, or(0, {{(\.L)?}}indirect_use_vcc.has_dyn_sized_stack)
-; GCN: .set {{(\.L)?}}indirect_2level_use_vcc_kernel.has_recursion, or(0, {{(\.L)?}}indirect_use_vcc.has_recursion)
-; GCN: .set {{(\.L)?}}indirect_2level_use_vcc_kernel.has_indirect_call, or(0, {{(\.L)?}}indirect_use_vcc.has_indirect_call)
+; GCN: .set .Lindirect_2level_use_vcc_kernel.num_vgpr, max(32, .Lindirect_use_vcc.num_vgpr)
+; GCN: .set .Lindirect_2level_use_vcc_kernel.num_agpr, max(0, .Lindirect_use_vcc.num_agpr)
+; GCN: .set .Lindirect_2level_use_vcc_kernel.numbered_sgpr, max(33, .Lindirect_use_vcc.numbered_sgpr)
+; GCN: .set .Lindirect_2level_use_vcc_kernel.private_seg_size, 0+max(.Lindirect_use_vcc.private_seg_size)
+; GCN: .set .Lindirect_2level_use_vcc_kernel.uses_vcc, or(1, .Lindirect_use_vcc.uses_vcc)
+; GCN: .set .Lindirect_2level_use_vcc_kernel.uses_flat_scratch, or(1, .Lindirect_use_vcc.uses_flat_scratch)
+; GCN: .set .Lindirect_2level_use_vcc_kernel.has_dyn_sized_stack, or(0, .Lindirect_use_vcc.has_dyn_sized_stack)
+; GCN: .set .Lindirect_2level_use_vcc_kernel.has_recursion, or(0, .Lindirect_use_vcc.has_recursion)
+; GCN: .set .Lindirect_2level_use_vcc_kernel.has_indirect_call, or(0, .Lindirect_use_vcc.has_indirect_call)
 ; GCN: TotalNumSgprs: 40
 ; GCN: NumVgprs: 41
 ; GCN: ScratchSize: 16
@@ -58,15 +58,15 @@ define amdgpu_kernel void @indirect_2level_use_vcc_kernel(ptr addrspace(1) %out)
 }
 
 ; GCN-LABEL: {{^}}use_flat_scratch:
-; GCN: .set {{(\.L)?}}use_flat_scratch.num_vgpr, 0
-; GCN: .set {{(\.L)?}}use_flat_scratch.num_agpr, 0
-; GCN: .set {{(\.L)?}}use_flat_scratch.numbered_sgpr, 32
-; GCN: .set {{(\.L)?}}use_flat_scratch.private_seg_size, 0
-; GCN: .set {{(\.L)?}}use_flat_scratch.uses_vcc, 0
-; GCN: .set {{(\.L)?}}use_flat_scratch.uses_flat_scratch, 1
-; GCN: .set {{(\.L)?}}use_flat_scratch.has_dyn_sized_stack, 0
-; GCN: .set {{(\.L)?}}use_flat_scratch.has_recursion, 0
-; GCN: .set {{(\.L)?}}use_flat_scratch.has_indirect_call, 0
+; GCN: .set .Luse_flat_scratch.num_vgpr, 0
+; GCN: .set .Luse_flat_scratch.num_agpr, 0
+; GCN: .set .Luse_flat_scratch.numbered_sgpr, 32
+; GCN: .set .Luse_flat_scratch.private_seg_size, 0
+; GCN: .set .Luse_flat_scratch.uses_vcc, 0
+; GCN: .set .Luse_flat_scratch.uses_flat_scratch, 1
+; GCN: .set .Luse_flat_scratch.has_dyn_sized_stack, 0
+; GCN: .set .Luse_flat_scratch.has_recursion, 0
+; GCN: .set .Luse_flat_scratch.has_indirect_call, 0
 ; GCN: TotalNumSgprs: 38
 ; GCN: NumVgprs: 0
 ; GCN: ScratchSize: 0
@@ -76,15 +76,15 @@ define void @use_flat_scratch() #1 {
 }
 
 ; GCN-LABEL: {{^}}indirect_use_flat_scratch:
-; GCN: .set {{(\.L)?}}indirect_use_flat_scratch.num_vgpr, max(41, {{(.L)?}}use_flat_scratch.num_vgpr)
-; GCN: .set {{(\.L)?}}indirect_use_flat_scratch.num_agpr, max(0, {{(.L)?}}use_flat_scratch.num_agpr)
-; GCN: .set {{(\.L)?}}indirect_use_flat_scratch.numbered_sgpr, max(34, {{(.L)?}}use_flat_scratch.numbered_sgpr)
-; GCN: .set {{(\.L)?}}indirect_use_flat_scratch.private_seg_size, 16+max({{(\.L)?}}use_flat_scratch.private_seg_size)
-; GCN: .set {{(\.L)?}}indirect_use_flat_scratch.uses_vcc, or(1, {{(.L)?}}use_flat_scratch.uses_vcc)
-; GCN: .set {{(\.L)?}}indirect_use_flat_scratch.uses_flat_scratch, or(0, {{(.L)?}}use_flat_scratch.uses_flat_scratch)
-; GCN: .set {{(\.L)?}}indirect_use_flat_scratch.has_dyn_sized_stack, or(0, {{(.L)?}}use_flat_scratch.has_dyn_sized_stack)
-; GCN: .set {{(\.L)?}}indirect_use_flat_scratch.has_recursion, or(0, {{(.L)?}}use_flat_scratch.has_recursion)
-; GCN: .set {{(\.L)?}}indirect_use_flat_scratch.has_indirect_call, or(0, {{(.L)?}}use_flat_scratch.has_indirect_call)
+; GCN: .set .Lindirect_use_flat_scratch.num_vgpr, max(41, .Luse_flat_scratch.num_vgpr)
+; GCN: .set .Lindirect_use_flat_scratch.num_agpr, max(0, .Luse_flat_scratch.num_agpr)
+; GCN: .set .Lindirect_use_flat_scratch.numbered_sgpr, max(34, .Luse_flat_scratch.numbered_sgpr)
+; GCN: .set .Lindirect_use_flat_scratch.private_seg_size, 16+max(.Luse_flat_scratch.private_seg_size)
+; GCN: .set .Lindirect_use_flat_scratch.uses_vcc, or(1, .Luse_flat_scratch.uses_vcc)
+; GCN: .set .Lindirect_use_flat_scratch.uses_flat_scratch, or(0, .Luse_flat_scratch.uses_flat_scratch)
+; GCN: .set .Lindirect_use_flat_scratch.has_dyn_sized_stack, or(0, .Luse_flat_scratch.has_dyn_sized_stack)
+; GCN: .set .Lindirect_use_flat_scratch.has_recursion, or(0, .Luse_flat_scratch.has_recursion)
+; GCN: .set .Lindirect_use_flat_scratch.has_indirect_call, or(0, .Luse_flat_scratch.has_indirect_call)
 ; GCN: TotalNumSgprs: 40
 ; GCN: NumVgprs: 41
 ; GCN: ScratchSize: 16
@@ -94,15 +94,15 @@ define void @indirect_use_flat_scratch() #1 {
 }
 
 ; GCN-LABEL: {{^}}indirect_2level_use_flat_scratch_kernel:
-; GCN: .set {{(\.L)?}}indirect_2level_use_flat_scratch_kernel.num_vgpr, max(32, {{(.L)?}}indirect_use_flat_scratch.num_vgpr)
-; GCN: .set {{(\.L)?}}indirect_2level_use_flat_scratch_kernel.num_agpr, max(0, {{(.L)?}}indirect_use_flat_scratch.num_agpr)
-; GCN: .set {{(\.L)?}}indirect_2level_use_flat_scratch_kernel.numbered_sgpr, max(33, {{(.L)?}}indirect_use_flat_scratch.numbered_sgpr)
-; GCN: .set {{(\.L)?}}indirect_2level_use_flat_scratch_kernel.private_seg_size, 0+max({{(\.L)?}}indirect_use_flat_scratch.private_seg_size)
-; GCN: .set {{(\.L)?}}indirect_2level_use_flat_scratch_kernel.uses_vcc, or(1, {{(.L)?}}indirect_use_flat_scratch.uses_vcc)
-; GCN: .set {{(\.L)?}}indirect_2level_use_flat_scratch_kernel.uses_flat_scratch, or(1, {{(.L)?}}indirect_use_flat_scratch.uses_flat_scratch)
-; GCN: .set {{(\.L)?}}indirect_2level_use_flat_scratch_kernel.has_dyn_sized_stack, or(0, {{(.L)?}}indirect_use_flat_scratch.has_dyn_sized_stack)
-; GCN: .set {{(\.L)?}}indirect_2level_use_flat_scratch_kernel.has_recursion, or(0, {{(.L)?}}indirect_use_flat_scratch.has_recursion)
-; GCN: .set {{(\.L)?}}indirect_2level_use_flat_scratch_kernel.has_indirect_call, or(0, {{(.L)?}}indirect_use_flat_scratch.has_indirect_call)
+; GCN: .set .Lindirect_2level_use_flat_scratch_kernel.num_vgpr, max(32, .Lindirect_use_flat_scratch.num_vgpr)
+; GCN: .set .Lindirect_2level_use_flat_scratch_kernel.num_agpr, max(0, .Lindirect_use_flat_scratch.num_agpr)
+; GCN: .set .Lindirect_2level_use_flat_scratch_kernel.numbered_sgpr, max(33, .Lindirect_use_flat_scratch.numbered_sgpr)
+; GCN: .set .Lindirect_2level_use_flat_scratch_kernel.private_seg_size, 0+max(.Lindirect_use_flat_scratch.private_seg_size)
+; GCN: .set .Lindirect_2level_use_flat_scratch_kernel.uses_vcc, or(1, .Lindirect_use_flat_scratch.uses_vcc)
+; GCN: .set .Lindirect_2level_use_flat_scratch_kernel.uses_flat_scratch, or(1, .Lindirect_use_flat_scratch.uses_flat_scratch)
+; GCN: .set .Lindirect_2level_use_flat_scratch_kernel.has_dyn_sized_stack, or(0, .Lindirect_use_flat_scratch.has_dyn_sized_stack)
+; GCN: .set .Lindirect_2level_use_flat_scratch_kernel.has_recursion, or(0, .Lindirect_use_flat_scratch.has_recursion)
+; GCN: .set .Lindirect_2level_use_flat_scratch_kernel.has_indirect_call, or(0, .Lindirect_use_flat_scratch.has_indirect_call)
 ; GCN: TotalNumSgprs: 40
 ; GCN: NumVgprs: 41
 ; GCN: ScratchSize: 16
@@ -112,15 +112,15 @@ define amdgpu_kernel void @indirect_2level_use_flat_scratch_kernel(ptr addrspace
 }
 
 ; GCN-LABEL: {{^}}use_10_vgpr:
-; GCN: .set {{(\.L)?}}use_10_vgpr.num_vgpr, 10
-; GCN: .set {{(\.L)?}}use_10_vgpr.num_agpr, 0
-; GCN: .set {{(\.L)?}}use_10_vgpr.numbered_sgpr, 32
-; GCN: .set {{(\.L)?}}use_10_vgpr.private_seg_size, 0
-; GCN: .set {{(\.L)?}}use_10_vgpr.uses_vcc, 0
-; GCN: .set {{(\.L)?}}use_10_vgpr.uses_flat_scratch, 0
-; GCN: .set {{(\.L)?}}use_10_vgpr.has_dyn_sized_stack, 0
-; GCN: .set {{(\.L)?}}use_10_vgpr.has_recursion, 0
-; GCN: .set {{(\.L)?}}use_10_vgpr.has_indirect_call, 0
+; GCN: .set .Luse_10_vgpr.num_vgpr, 10
+; GCN: .set .Luse_10_vgpr.num_agpr, 0
+; GCN: .set .Luse_10_vgpr.numbered_sgpr, 32
+; GCN: .set .Luse_10_vgpr.private_seg_size, 0
+; GCN: .set .Luse_10_vgpr.uses_vcc, 0
+; GCN: .set .Luse_10_vgpr.uses_flat_scratch, 0
+; GCN: .set .Luse_10_vgpr.has_dyn_sized_stack, 0
+; GCN: .set .Luse_10_vgpr.has_recursion, 0
+; GCN: .set .Luse_10_vgpr.has_indirect_call, 0
 ; GCN: TotalNumSgprs: 36
 ; GCN: NumVgprs: 10
 ; GCN: ScratchSize: 0
@@ -131,15 +131,15 @@ define void @use_10_vgpr() #1 {
 }
 
 ; GCN-LABEL: {{^}}indirect_use_10_vgpr:
-; GCN: .set {{(\.L)?}}indirect_use_10_vgpr.num_vgpr, max(41, {{(.L)?}}use_10_vgpr.num_vgpr)
-; GCN: .set {{(\.L)?}}indirect_use_10_vgpr.num_agpr, max(0, {{(.L)?}}use_10_vgpr.num_agpr)
-; GCN: .set {{(\.L)?}}indirect_use_10_vgpr.numbered_sgpr, max(34, {{(.L)?}}use_10_vgpr.numbered_sgpr)
-; GCN: .set {{(\.L)?}}indirect_use_10_vgpr.private_seg_size, 16+max({{(\.L)?}}use_10_vgpr.private_seg_size)
-; GCN: .set {{(\.L)?}}indirect_use_10_vgpr.uses_vcc, or(1, {{(.L)?}}use_10_vgpr.uses_vcc)
-; GCN: .set {{(\.L)?}}indirect_use_10_vgpr.uses_flat_scratch, or(0, {{(.L)?}}use_10_vgpr.uses_flat_scratch)
-; GCN: .set {{(\.L)?}}indirect_use_10_vgpr.has_dyn_sized_stack, or(0, {{(.L)?}}use_10_vgpr.has_dyn_sized_stack)
-; GCN: .set {{(\.L)?}}indirect_use_10_vgpr.has_recursion, or(0, {{(.L)?}}use_10_vgpr.has_recursion)
-; GCN: .set {{(\.L)?}}indirect_use_10_vgpr.has_indirect_call, or(0, {{(.L)?}}use_10_vgpr.has_indirect_call)
+; GCN: .set .Lindirect_use_10_vgpr.num_vgpr, max(41, .Luse_10_vgpr.num_vgpr)
+; GCN: .set .Lindirect_use_10_vgpr.num_agpr, max(0, .Luse_10_vgpr.num_agpr)
+; GCN: .set .Lindirect_use_10_vgpr.numbered_sgpr, max(34, .Luse_10_vgpr.numbered_sgpr)
+; GCN: .set .Lindirect_use_10_vgpr.private_seg_size, 16+max(.Luse_10_vgpr.private_seg_size)
+; GCN: .set .Lindirect_use_10_vgpr.uses_vcc, or(1, .Luse_10_vgpr.uses_vcc)
+; GCN: .set .Lindirect_use_10_vgpr.uses_flat_scratch, or(0, .Luse_10_vgpr.uses_flat_scratch)
+; GCN: .set .Lindirect_use_10_vgpr.has_dyn_sized_stack, or(0, .Luse_10_vgpr.has_dyn_sized_stack)
+; GCN: .set .Lindirect_use_10_vgpr.has_recursion, or(0, .Luse_10_vgpr.has_recursion)
+; GCN: .set .Lindirect_use_10_vgpr.has_indirect_call, or(0, .Luse_10_vgpr.has_indirect_call)
 ; GCN: TotalNumSgprs: 38
 ; GCN: NumVgprs: 41
 ; GCN: ScratchSize: 16
@@ -149,15 +149,15 @@ define void @indirect_use_10_vgpr() #0 {
 }
 
 ; GCN-LABEL: {{^}}indirect_2_level_use_10_vgpr:
-; GCN:	.set {{(\.L)?}}indirect_2_level_use_10_vgpr.num_vgpr, max(32, {{(.L)?}}indirect_use_10_vgpr.num_vgpr)
-; GCN:	.set {{(\.L)?}}indirect_2_level_use_10_vgpr.num_agpr, max(0, {{(.L)?}}indirect_use_10_vgpr.num_agpr)
-; GCN:	.set {{(\.L)?}}indirect_2_level_use_10_vgpr.numbered_sgpr, max(33, {{(.L)?}}indirect_use_10_vgpr.numbered_sgpr)
-; GCN:	.set {{(\.L)?}}indirect_2_level_use_10_vgpr.private_seg_size, 0+max({{(\.L)?}}indirect_use_10_vgpr.private_seg_size)
-; GCN:	.set {{(\.L)?}}indirect_2_level_use_10_vgpr.uses_vcc, or(1, {{(.L)?}}indirect_use_10_vgpr.uses_vcc)
-; GCN:	.set {{(\.L)?}}indirect_2_level_use_10_vgpr.uses_flat_scratch, or(1, {{(.L)?}}indirect_use_10_vgpr.uses_flat_scratch)
-; GCN:	.set {{(\.L)?}}indirect_2_level_use_10_vgpr.has_dyn_sized_stack, or(0, {{(.L)?}}indirect_use_10_vgpr.has_dyn_sized_stack)
-; GCN:	.set {{(\.L)?}}indirect_2_level_use_10_vgpr.has_recursion, or(0, {{(.L)?}}indirect_use_10_vgpr.has_recursion)
-; GCN:	.set {{(\.L)?}}indirect_2_level_use_10_vgpr.has_indirect_call, or(0, {{(.L)?}}indirect_use_10_vgpr.has_indirect_call)
+; GCN:	.set .Lindirect_2_level_use_10_vgpr.num_vgpr, max(32, .Lindirect_use_10_vgpr.num_vgpr)
+; GCN:	.set .Lindirect_2_level_use_10_vgpr.num_agpr, max(0, .Lindirect_use_10_vgpr.num_agpr)
+; GCN:	.set .Lindirect_2_level_use_10_vgpr.numbered_sgpr, max(33, .Lindirect_use_10_vgpr.numbered_sgpr)
+; GCN:	.set .Lindirect_2_level_use_10_vgpr.private_seg_size, 0+max(.Lindirect_use_10_vgpr.private_seg_size)
+; GCN:	.set .Lindirect_2_level_use_10_vgpr.uses_vcc, or(1, .Lindirect_use_10_vgpr.uses_vcc)
+; GCN:	.set .Lindirect_2_level_use_10_vgpr.uses_flat_scratch, or(1, .Lindirect_use_10_vgpr.uses_flat_scratch)
+; GCN:	.set .Lindirect_2_level_use_10_vgpr.has_dyn_sized_stack, or(0, .Lindirect_use_10_vgpr.has_dyn_sized_stack)
+; GCN:	.set .Lindirect_2_level_use_10_vgpr.has_recursion, or(0, .Lindirect_use_10_vgpr.has_recursion)
+; GCN:	.set .Lindirect_2_level_use_10_vgpr.has_indirect_call, or(0, .Lindirect_use_10_vgpr.has_indirect_call)
 ; GCN: TotalNumSgprs: 40
 ; GCN: NumVgprs: 41
 ; GCN: ScratchSize: 16
@@ -167,15 +167,15 @@ define amdgpu_kernel void @indirect_2_level_use_10_vgpr() #0 {
 }
 
 ; GCN-LABEL: {{^}}use_50_vgpr:
-; GCN:	.set {{(\.L)?}}use_50_vgpr.num_vgpr, 50
-; GCN:	.set {{(\.L)?}}use_50_vgpr.num_agpr, 0
-; GCN:	.set {{(\.L)?}}use_50_vgpr.numbered_sgpr, 32
-; GCN:	.set {{(\.L)?}}use_50_vgpr.private_seg_size, 0
-; GCN:	.set {{(\.L)?}}use_50_vgpr.uses_vcc, 0
-; GCN:	.set {{(\.L)?}}use_50_vgpr.uses_flat_scratch, 0
-; GCN:	.set {{(\.L)?}}use_50_vgpr.has_dyn_sized_stack, 0
-; GCN:	.set {{(\.L)?}}use_50_vgpr.has_recursion, 0
-; GCN:	.set {{(\.L)?}}use_50_vgpr.has_indirect_call, 0
+; GCN:	.set .Luse_50_vgpr.num_vgpr, 50
+; GCN:	.set .Luse_50_vgpr.num_agpr, 0
+; GCN:	.set .Luse_50_vgpr.numbered_sgpr, 32
+; GCN:	.set .Luse_50_vgpr.private_seg_size, 0
+; GCN:	.set .Luse_50_vgpr.uses_vcc, 0
+; GCN:	.set .Luse_50_vgpr.uses_flat_scratch, 0
+; GCN:	.set .Luse_50_vgpr.has_dyn_sized_stack, 0
+; GCN:	.set .Luse_50_vgpr.has_recursion, 0
+; GCN:	.set .Luse_50_vgpr.has_indirect_call, 0
 ; GCN: TotalNumSgprs: 36
 ; GCN: NumVgprs: 50
 ; GCN: ScratchSize: 0
@@ -185,15 +185,15 @@ define void @use_50_vgpr() #1 {
 }
 
 ; GCN-LABEL: {{^}}indirect_use_50_vgpr:
-; GCN:	.set {{(\.L)?}}indirect_use_50_vgpr.num_vgpr, max(41, {{(.L)?}}use_50_vgpr.num_vgpr)
-; GCN:	.set {{(\.L)?}}indirect_use_50_vgpr.num_agpr, max(0, {{(.L)?}}use_50_vgpr.num_agpr)
-; GCN:	.set {{(\.L)?}}indirect_use_50_vgpr.numbered_sgpr, max(34, {{(.L)?}}use_50_vgpr.numbered_sgpr)
-; GCN:	.set {{(\.L)?}}indirect_use_50_vgpr.private_seg_size, 16+max({{(\.L)?}}use_50_vgpr.private_seg_size)
-; GCN:	.set {{(\.L)?}}indirect_use_50_vgpr.uses_vcc, or(1, {{(.L)?}}use_50_vgpr.uses_vcc)
-; GCN:	.set {{(\.L)?}}indirect_use_50_vgpr.uses_flat_scratch, or(0, {{(.L)?}}use_50_vgpr.uses_flat_scratch)
-; GCN:	.set {{(\.L)?}}indirect_use_50_vgpr.has_dyn_sized_stack, or(0, {{(.L)?}}use_50_vgpr.has_dyn_sized_stack)
-; GCN:	.set {{(\.L)?}}indirect_use_50_vgpr.has_recursion, or(0, {{(.L)?}}use_50_vgpr.has_recursion)
-; GCN:	.set {{(\.L)?}}indirect_use_50_vgpr.has_indirect_call, or(0, {{(.L)?}}use_50_vgpr.has_indirect_call)
+; GCN:	.set .Lindirect_use_50_vgpr.num_vgpr, max(41, .Luse_50_vgpr.num_vgpr)
+; GCN:	.set .Lindirect_use_50_vgpr.num_agpr, max(0, .Luse_50_vgpr.num_agpr)
+; GCN:	.set .Lindirect_use_50_vgpr.numbered_sgpr, max(34, .Luse_50_vgpr.numbered_sgpr)
+; GCN:	.set .Lindirect_use_50_vgpr.private_seg_size, 16+max(.Luse_50_vgpr.private_seg_size)
+; GCN:	.set .Lindirect_use_50_vgpr.uses_vcc, or(1, .Luse_50_vgpr.uses_vcc)
+; GCN:	.set .Lindirect_use_50_vgpr.uses_flat_scratch, or(0, .Luse_50_vgpr.uses_flat_scratch)
+; GCN:	.set .Lindirect_use_50_vgpr.has_dyn_sized_stack, or(0, .Luse_50_vgpr.has_dyn_sized_stack)
+; GCN:	.set .Lindirect_use_50_vgpr.has_recursion, or(0, .Luse_50_vgpr.has_recursion)
+; GCN:	.set .Lindirect_use_50_vgpr.has_indirect_call, or(0, .Luse_50_vgpr.has_indirect_call)
 ; GCN: TotalNumSgprs: 38
 ; GCN: NumVgprs: 50
 ; GCN: ScratchSize: 16
@@ -203,15 +203,15 @@ define void @indirect_use_50_vgpr() #0 {
 }
 
 ; GCN-LABEL: {{^}}use_80_sgpr:
-; GCN:	.set {{(\.L)?}}use_80_sgpr.num_vgpr, 0
-; GCN:	.set {{(\.L)?}}use_80_sgpr.num_agpr, 0
-; GCN:	.set {{(\.L)?}}use_80_sgpr.numbered_sgpr, 80
-; GCN:	.set {{(\.L)?}}use_80_sgpr.private_seg_size, 0
-; GCN:	.set {{(\.L)?}}use_80_sgpr.uses_vcc, 0
-; GCN:	.set {{(\.L)?}}use_80_sgpr.uses_flat_scratch, 0
-; GCN:	.set {{(\.L)?}}use_80_sgpr.has_dyn_sized_stack, 0
-; GCN:	.set {{(\.L)?}}use_80_sgpr.has_recursion, 0
-; GCN:	.set {{(\.L)?}}use_80_sgpr.has_indirect_call, 0
+; GCN:	.set .Luse_80_sgpr.num_vgpr, 0
+; GCN:	.set .Luse_80_sgpr.num_agpr, 0
+; GCN:	.set .Luse_80_sgpr.numbered_sgpr, 80
+; GCN:	.set .Luse_80_sgpr.private_seg_size, 0
+; GCN:	.set .Luse_80_sgpr.uses_vcc, 0
+; GCN:	.set .Luse_80_sgpr.uses_flat_scratch, 0
+; GCN:	.set .Luse_80_sgpr.has_dyn_sized_stack, 0
+; GCN:	.set .Luse_80_sgpr.has_recursion, 0
+; GCN:	.set .Luse_80_sgpr.has_indirect_call, 0
 ; GCN: TotalNumSgprs: 84
 ; GCN: NumVgprs: 0
 ; GCN: ScratchSize: 0
@@ -221,15 +221,15 @@ define void @use_80_sgpr() #1 {
 }
 
 ; GCN-LABEL: {{^}}indirect_use_80_sgpr:
-; GCN:	.set {{(\.L)?}}indirect_use_80_sgpr.num_vgpr, max(41, {{(.L)?}}use_80_sgpr.num_vgpr)
-; GCN:	.set {{(\.L)?}}indirect_use_80_sgpr.num_agpr, max(0, {{(.L)?}}use_80_sgpr.num_agpr)
-; GCN:	.set {{(\.L)?}}indirect_use_80_sgpr.numbered_sgpr, max(34, {{(.L)?}}use_80_sgpr.numbered_sgpr)
-; GCN:	.set {{(\.L)?}}indirect_use_80_sgpr.private_seg_size, 16+max({{(\.L)?}}use_80_sgpr.private_seg_size)
-; GCN:	.set {{(\.L)?}}indirect_use_80_sgpr.uses_vcc, or(1, {{(.L)?}}use_80_sgpr.uses_vcc)
-; GCN:	.set {{(\.L)?}}indirect_use_80_sgpr.uses_flat_scratch, or(0, {{(.L)?}}use_80_sgpr.uses_flat_scratch)
-; GCN:	.set {{(\.L)?}}indirect_use_80_sgpr.has_dyn_sized_stack, or(0, {{(.L)?}}use_80_sgpr.has_dyn_sized_stack)
-; GCN:	.set {{(\.L)?}}indirect_use_80_sgpr.has_recursion, or(0, {{(.L)?}}use_80_sgpr.has_recursion)
-; GCN:	.set {{(\.L)?}}indirect_use_80_sgpr.has_indirect_call, or(0, {{(.L)?}}use_80_sgpr.has_indirect_call)
+; GCN:	.set .Lindirect_use_80_sgpr.num_vgpr, max(41, .Luse_80_sgpr.num_vgpr)
+; GCN:	.set .Lindirect_use_80_sgpr.num_agpr, max(0, .Luse_80_sgpr.num_agpr)
+; GCN:	.set .Lindirect_use_80_sgpr.numbered_sgpr, max(34, .Luse_80_sgpr.numbered_sgpr)
+; GCN:	.set .Lindirect_use_80_sgpr.private_seg_size, 16+max(.Luse_80_sgpr.private_seg_size)
+; GCN:	.set .Lindirect_use_80_sgpr.uses_vcc, or(1, .Luse_80_sgpr.uses_vcc)
+; GCN:	.set .Lindirect_use_80_sgpr.uses_flat_scratch, or(0, .Luse_80_sgpr.uses_flat_scratch)
+; GCN:	.set .Lindirect_use_80_sgpr.has_dyn_sized_stack, or(0, .Luse_80_sgpr.has_dyn_sized_stack)
+; GCN:	.set .Lindirect_use_80_sgpr.has_recursion, or(0, .Luse_80_sgpr.has_recursion)
+; GCN:	.set .Lindirect_use_80_sgpr.has_indirect_call, or(0, .Luse_80_sgpr.has_indirect_call)
 ; GCN: TotalNumSgprs: 84
 ; GCN: NumVgprs: 41
 ; GCN: ScratchSize: 16
@@ -239,15 +239,15 @@ define void @indirect_use_80_sgpr() #1 {
 }
 
 ; GCN-LABEL: {{^}}indirect_2_level_use_80_sgpr:
-; GCN:	.set {{(\.L)?}}indirect_2_level_use_80_sgpr.num_vgpr, max(32, {{(.L)?}}indirect_use_80_sgpr.num_vgpr)
-; GCN:	.set {{(\.L)?}}indirect_2_level_use_80_sgpr.num_agpr, max(0, {{(.L)?}}indirect_use_80_sgpr.num_agpr)
-; GCN:	.set {{(\.L)?}}indirect_2_level_use_80_sgpr.numbered_sgpr, max(33, {{(.L)?}}indirect_use_80_sgpr.numbered_sgpr)
-; GCN:	.set {{(\.L)?}}indirect_2_level_use_80_sgpr.private_seg_size, 0+max({{(\.L)?}}indirect_use_80_sgpr.private_seg_size)
-; GCN:	.set {{(\.L)?}}indirect_2_level_use_80_sgpr.uses_vcc, or(1, {{(.L)?}}indirect_use_80_sgpr.uses_vcc)
-; GCN:	.set {{(\.L)?}}indirect_2_level_use_80_sgpr.uses_flat_scratch, or(1, {{(.L)?}}indirect_use_80_sgpr.uses_flat_scratch)
-; GCN:	.set {{(\.L)?}}indirect_2_level_use_80_sgpr.has_dyn_sized_stack, or(0, {{(.L)?}}indirect_use_80_sgpr.has_dyn_sized_stack)
-; GCN:	.set {{(\.L)?}}indirect_2_level_use_80_sgpr.has_recursion, or(0, {{(.L)?}}indirect_use_80_sgpr.has_recursion)
-; GCN:	.set {{(\.L)?}}indirect_2_level_use_80_sgpr.has_indirect_call, or(0, {{(.L)?}}indirect_use_80_sgpr.has_indirect_call)
+; GCN:	.set .Lindirect_2_level_use_80_sgpr.num_vgpr, max(32, .Lindirect_use_80_sgpr.num_vgpr)
+; GCN:	.set .Lindirect_2_level_use_80_sgpr.num_agpr, max(0, .Lindirect_use_80_sgpr.num_agpr)
+; GCN:	.set .Lindirect_2_level_use_80_sgpr.numbered_sgpr, max(33, .Lindirect_use_80_sgpr.numbered_sgpr)
+; GCN:	.set .Lindirect_2_level_use_80_sgpr.private_seg_size, 0+max(.Lindirect_use_80_sgpr.private_seg_size)
+; GCN:	.set .Lindirect_2_level_use_80_sgpr.uses_vcc, or(1, .Lindirect_use_80_sgpr.uses_vcc)
+; GCN:	.set .Lindirect_2_level_use_80_sgpr.uses_flat_scratch, or(1, .Lindirect_use_80_sgpr.uses_flat_scratch)
+; GCN:	.set .Lindirect_2_level_use_80_sgpr.has_dyn_sized_stack, or(0, .Lindirect_use_80_sgpr.has_dyn_sized_stack)
+; GCN:	.set .Lindirect_2_level_use_80_sgpr.has_recursion, or(0, .Lindirect_use_80_sgpr.has_recursion)
+; GCN:	.set .Lindirect_2_level_use_80_sgpr.has_indirect_call, or(0, .Lindirect_use_80_sgpr.has_indirect_call)
 ; GCN: TotalNumSgprs: 86
 ; GCN: NumVgprs: 41
 ; GCN: ScratchSize: 16
@@ -257,15 +257,15 @@ define amdgpu_kernel void @indirect_2_level_use_80_sgpr() #0 {
 }
 
 ; GCN-LABEL: {{^}}use_stack0:
-; GCN:	.set {{(\.L)?}}use_stack0.num_vgpr, 1
-; GCN:	.set {{(\.L)?}}use_stack0.num_agpr, 0
-; GCN:	.set {{(\.L)?}}use_stack0.numbered_sgpr, 33
-; GCN:	.set {{(\.L)?}}use_stack0.private_seg_size, 2052
-; GCN:	.set {{(\.L)?}}use_stack0.uses_vcc, 0
-; GCN:	.set {{(\.L)?}}use_stack0.uses_flat_scratch, 0
-; GCN:	.set {{(\.L)?}}use_stack0.has_dyn_sized_stack, 0
-; GCN:	.set {{(\.L)?}}use_stack0.has_recursion, 0
-; GCN:	.set {{(\.L)?}}use_stack0.has_indirect_call, 0
+; GCN:	.set .Luse_stack0.num_vgpr, 1
+; GCN:	.set .Luse_stack0.num_agpr, 0
+; GCN:	.set .Luse_stack0.numbered_sgpr, 33
+; GCN:	.set .Luse_stack0.private_seg_size, 2052
+; GCN:	.set .Luse_stack0.uses_vcc, 0
+; GCN:	.set .Luse_stack0.uses_flat_scratch, 0
+; GCN:	.set .Luse_stack0.has_dyn_sized_stack, 0
+; GCN:	.set .Luse_stack0.has_recursion, 0
+; GCN:	.set .Luse_stack0.has_indirect_call, 0
 ; GCN: TotalNumSgprs: 37
 ; GCN: NumVgprs: 1
 ; GCN: ScratchSize: 2052
@@ -276,15 +276,15 @@ define void @use_stack0() #1 {
 }
 
 ; GCN-LABEL: {{^}}use_stack1:
-; GCN:	.set {{(\.L)?}}use_stack1.num_vgpr, 1
-; GCN:	.set {{(\.L)?}}use_stack1.num_agpr, 0
-; GCN:	.set {{(\.L)?}}use_stack1.numbered_sgpr, 33
-; GCN:	.set {{(\.L)?}}use_stack1.private_seg_size, 404
-; GCN:	.set {{(\.L)?}}use_stack1.uses_vcc, 0
-; GCN:	.set {{(\.L)?}}use_stack1.uses_flat_scratch, 0
-; GCN:	.set {{(\.L)?}}use_stack1.has_dyn_sized_stack, 0
-; GCN:	.set {{(\.L)?}}use_stack1.has_recursion, 0
-; GCN:	.set {{(\.L)?}}use_stack1.has_indirect_call, 0
+; GCN:	.set .Luse_stack1.num_vgpr, 1
+; GCN:	.set .Luse_stack1.num_agpr, 0
+; GCN:	.set .Luse_stack1.numbered_sgpr, 33
+; GCN:	.set .Luse_stack1.private_seg_size, 404
+; GCN:	.set .Luse_stack1.uses_vcc, 0
+; GCN:	.set .Luse_stack1.uses_flat_scratch, 0
+; GCN:	.set .Luse_stack1.has_dyn_sized_stack, 0
+; GCN:	.set .Luse_stack1.has_recursion, 0
+; GCN:	.set .Luse_stack1.has_indirect_call, 0
 ; GCN: TotalNumSgprs: 37
 ; GCN: NumVgprs: 1
 ; GCN: ScratchSize: 404
@@ -295,15 +295,15 @@ define void @use_stack1() #1 {
 }
 
 ; GCN-LABEL: {{^}}indirect_use_stack:
-; GCN:	.set {{(\.L)?}}indirect_use_stack.num_vgpr, max(41, {{(.L)?}}use_stack0.num_vgpr)
-; GCN:	.set {{(\.L)?}}indirect_use_stack.num_agpr, max(0, {{(.L)?}}use_stack0.num_agpr)
-; GCN:	.set {{(\.L)?}}indirect_use_stack.numbered_sgpr, max(34, {{(.L)?}}use_stack0.numbered_sgpr)
-; GCN:	.set {{(\.L)?}}indirect_use_stack.private_seg_size, 80+max({{(\.L)?}}use_stack0.private_seg_size)
-; GCN:	.set {{(\.L)?}}indirect_use_stack.uses_vcc, or(1, {{(.L)?}}use_stack0.uses_vcc)
-; GCN:	.set {{(\.L)?}}indirect_use_stack.uses_flat_scratch, or(0, {{(.L)?}}use_stack0.uses_flat_scratch)
-; GCN:	.set {{(\.L)?}}indirect_use_stack.has_dyn_sized_stack, or(0, {{(.L)?}}use_stack0.has_dyn_sized_stack)
-; GCN:	.set {{(\.L)?}}indirect_use_stack.has_recursion, or(0, {{(.L)?}}use_stack0.has_recursion)
-; GCN:	.set {{(\.L)?}}indirect_use_stack.has_indirect_call, or(0, {{(.L)?}}use_stack0.has_indirect_call)
+; GCN:	.set .Lindirect_use_stack.num_vgpr, max(41, .Luse_stack0.num_vgpr)
+; GCN:	.set .Lindirect_use_stack.num_agpr, max(0, .Luse_stack0.num_agpr)
+; GCN:	.set .Lindirect_use_stack.numbered_sgpr, max(34, .Luse_stack0.numbered_sgpr)
+; GCN:	.set .Lindirect_use_stack.private_seg_size, 80+max(.Luse_stack0.private_seg_size)
+; GCN:	.set .Lindirect_use_stack.uses_vcc, or(1, .Luse_stack0.uses_vcc)
+; GCN:	.set .Lindirect_use_stack.uses_flat_scratch, or(0, .Luse_stack0.uses_flat_scratch)
+; GCN:	.set .Lindirect_use_stack.has_dyn_sized_stack, or(0, .Luse_stack0.has_dyn_sized_stack)
+; GCN:	.set .Lindirect_use_stack.has_recursion, or(0, .Luse_stack0.has_recursion)
+; GCN:	.set .Lindirect_use_stack.has_indirect_call, or(0, .Luse_stack0.has_indirect_call)
 ; GCN: TotalNumSgprs: 38
 ; GCN: NumVgprs: 41
 ; GCN: ScratchSize: 2132
@@ -315,15 +315,15 @@ define void @indirect_use_stack() #1 {
 }
 
 ; GCN-LABEL: {{^}}indirect_2_level_use_stack:
-; GCN:	.set {{(\.L)?}}indirect_2_level_use_stack.num_vgpr, max(32, {{(.L)?}}indirect_use_stack.num_vgpr)
-; GCN:	.set {{(\.L)?}}indirect_2_level_use_stack.num_agpr, max(0, {{(.L)?}}indirect_use_stack.num_agpr)
-; GCN:	.set {{(\.L)?}}indirect_2_level_use_stack.numbered_sgpr, max(33, {{(.L)?}}indirect_use_stack.numbered_sgpr)
-; GCN:	.set {{(\.L)?}}indirect_2_level_use_stack.private_seg_size, 0+max({{(\.L)?}}indirect_use_stack.private_seg_size)
-; GCN:	.set {{(\.L)?}}indirect_2_level_use_stack.uses_vcc, or(1, {{(.L)?}}indirect_use_stack.uses_vcc)
-; GCN:	.set {{(\.L)?}}indirect_2_level_use_stack.uses_flat_scratch, or(1, {{(.L)?}}indirect_use_stack.uses_flat_scratch)
-; GCN:	.set {{(\.L)?}}indirect_2_level_use_stack.has_dyn_sized_stack, or(0, {{(.L)?}}indirect_use_stack.has_dyn_sized_stack)
-; GCN:	.set {{(\.L)?}}indirect_2_level_use_stack.has_recursion, or(0, {{(.L)?}}indirect_use_stack.has_recursion)
-; GCN:	.set {{(\.L)?}}indirect_2_level_use_stack.has_indirect_call, or(0, {{(.L)?}}indirect_use_stack.has_indirect_call)
+; GCN:	.set .Lindirect_2_level_use_stack.num_vgpr, max(32, .Lindirect_use_stack.num_vgpr)
+; GCN:	.set .Lindirect_2_level_use_stack.num_agpr, max(0, .Lindirect_use_stack.num_agpr)
+; GCN:	.set .Lindirect_2_level_use_stack.numbered_sgpr, max(33, .Lindirect_use_stack.numbered_sgpr)
+; GCN:	.set .Lindirect_2_level_use_stack.private_seg_size, 0+max(.Lindirect_use_stack.private_seg_size)
+; GCN:	.set .Lindirect_2_level_use_stack.uses_vcc, or(1, .Lindirect_use_stack.uses_vcc)
+; GCN:	.set .Lindirect_2_level_use_stack.uses_flat_scratch, or(1, .Lindirect_use_stack.uses_flat_scratch)
+; GCN:	.set .Lindirect_2_level_use_stack.has_dyn_sized_stack, or(0, .Lindirect_use_stack.has_dyn_sized_stack)
+; GCN:	.set .Lindirect_2_level_use_stack.has_recursion, or(0, .Lindirect_use_stack.has_recursion)
+; GCN:	.set .Lindirect_2_level_use_stack.has_indirect_call, or(0, .Lindirect_use_stack.has_indirect_call)
 ; GCN: TotalNumSgprs: 40
 ; GCN: NumVgprs: 41
 ; GCN: ScratchSize: 2132
@@ -335,15 +335,15 @@ define amdgpu_kernel void @indirect_2_level_use_stack() #0 {
 
 ; Should be maximum of callee usage
 ; GCN-LABEL: {{^}}multi_call_use_use_stack:
-; GCN:	.set {{(\.L)?}}multi_call_use_use_stack.num_vgpr, max(41, {{(.L)?}}use_stack0.num_vgpr, {{(.L)?}}use_stack1.num_vgpr)
-; GCN:	.set {{(\.L)?}}multi_call_use_use_stack.num_agpr, max(0, {{(.L)?}}use_stack0.num_agpr, {{(.L)?}}use_stack1.num_agpr)
-; GCN:	.set {{(\.L)?}}multi_call_use_use_stack.numbered_sgpr, max(52, {{(.L)?}}use_stack0.numbered_sgpr, {{(.L)?}}use_stack1.numbered_sgpr)
-; GCN:	.set {{(\.L)?}}multi_call_use_use_stack.private_seg_size, 0+max({{(\.L)?}}use_stack0.private_seg_size, {{(.L)?}}use_stack1.private_seg_size)
-; GCN:	.set {{(\.L)?}}multi_call_use_use_stack.uses_vcc, or(1, {{(.L)?}}use_stack0.uses_vcc, {{(.L)?}}use_stack1.uses_vcc)
-; GCN:	.set {{(\.L)?}}multi_call_use_use_stack.uses_flat_scratch, or(1, {{(.L)?}}use_stack0.uses_flat_scratch, {{(.L)?}}use_stack1.uses_flat_scratch)
-; GCN:	.set {{(\.L)?}}multi_call_use_use_stack.has_dyn_sized_stack, or(0, {{(.L)?}}use_stack0.has_dyn_sized_stack, {{(.L)?}}use_stack1.has_dyn_sized_stack)
-; GCN:	.set {{(\.L)?}}multi_call_use_use_stack.has_recursion, or(0, {{(.L)?}}use_stack0.has_recursion, {{(.L)?}}use_stack1.has_recursion)
-; GCN:	.set {{(\.L)?}}multi_call_use_use_stack.has_indirect_call, or(0, {{(.L)?}}use_stack0.has_indirect_call, {{(.L)?}}use_stack1.has_indirect_call)
+; GCN:	.set .Lmulti_call_use_use_stack.num_vgpr, max(41, .Luse_stack0.num_vgpr, .Luse_stack1.num_vgpr)
+; GCN:	.set .Lmulti_call_use_use_stack.num_agpr, max(0, .Luse_stack0.num_agpr, .Luse_stack1.num_agpr)
+; GCN:	.set .Lmulti_call_use_use_stack.numbered_sgpr, max(52, .Luse_stack0.numbered_sgpr, .Luse_stack1.numbered_sgpr)
+; GCN:	.set .Lmulti_call_use_use_stack.private_seg_size, 0+max(.Luse_stack0.private_seg_size, .Luse_stack1.private_seg_size)
+; GCN:	.set .Lmulti_call_use_use_stack.uses_vcc, or(1, .Luse_stack0.uses_vcc, .Luse_stack1.uses_vcc)
+; GCN:	.set .Lmulti_call_use_use_stack.uses_flat_scratch, or(1, .Luse_stack0.uses_flat_scratch, .Luse_stack1.uses_flat_scratch)
+; GCN:	.set .Lmulti_call_use_use_stack.has_dyn_sized_stack, or(0, .Luse_stack0.has_dyn_sized_stack, .Luse_stack1.has_dyn_sized_stack)
+; GCN:	.set .Lmulti_call_use_use_stack.has_recursion, or(0, .Luse_stack0.has_recursion, .Luse_stack1.has_recursion)
+; GCN:	.set .Lmulti_call_use_use_stack.has_indirect_call, or(0, .Luse_stack0.has_indirect_call, .Luse_stack1.has_indirect_call)
 ; GCN: TotalNumSgprs: 58
 ; GCN: NumVgprs: 41
 ; GCN: ScratchSize: 2052
@@ -356,17 +356,17 @@ define amdgpu_kernel void @multi_call_use_use_stack() #0 {
 declare void @external() #0
 
 ; GCN-LABEL: {{^}}multi_call_with_external:
-; GCN:	.set {{(\.L)?}}multi_call_with_external.num_vgpr, max(41, amdgpu.max_num_vgpr)
-; GCN:	.set {{(\.L)?}}multi_call_with_external.num_agpr, max(0, amdgpu.max_num_agpr)
-; GCN:	.set {{(\.L)?}}multi_call_with_external.numbered_sgpr, max(52, amdgpu.max_num_sgpr)
-; GCN:	.set {{(\.L)?}}multi_call_with_external.private_seg_size, 0+max({{(\.L)?}}use_stack0.private_seg_size, {{(.L)?}}use_stack1.private_seg_size)
-; GCN:	.set {{(\.L)?}}multi_call_with_external.uses_vcc, 1
-; GCN:	.set {{(\.L)?}}multi_call_with_external.uses_flat_scratch, 1
-; GCN:	.set {{(\.L)?}}multi_call_with_external.has_dyn_sized_stack, 1
-; GCN:	.set {{(\.L)?}}multi_call_with_external.has_recursion, 0
-; GCN:	.set {{(\.L)?}}multi_call_with_external.has_indirect_call, 1
-; GCN: TotalNumSgprs: {{(\.L)?}}multi_call_with_external.numbered_sgpr+6
-; GCN: NumVgprs: {{(\.L)?}}multi_call_with_external.num_vgpr
+; GCN:	.set .Lmulti_call_with_external.num_vgpr, max(41, amdgpu.max_num_vgpr)
+; GCN:	.set .Lmulti_call_with_external.num_agpr, max(0, amdgpu.max_num_agpr)
+; GCN:	.set .Lmulti_call_with_external.numbered_sgpr, max(52, amdgpu.max_num_sgpr)
+; GCN:	.set .Lmulti_call_with_external.private_seg_size, 0+max(.Luse_stack0.private_seg_size, .Luse_stack1.private_seg_size)
+; GCN:	.set .Lmulti_call_with_external.uses_vcc, 1
+; GCN:	.set .Lmulti_call_with_external.uses_flat_scratch, 1
+; GCN:	.set .Lmulti_call_with_external.has_dyn_sized_stack, 1
+; GCN:	.set .Lmulti_call_with_external.has_recursion, 0
+; GCN:	.set .Lmulti_call_with_external.has_indirect_call, 1
+; GCN: TotalNumSgprs: .Lmulti_call_with_external.numbered_sgpr+6
+; GCN: NumVgprs: .Lmulti_call_with_external.num_vgpr
 ; GCN: ScratchSize: 2052
 define amdgpu_kernel void @multi_call_with_external() #0 {
   call void @use_stack0()
@@ -376,17 +376,17 @@ define amdgpu_kernel void @multi_call_with_external() #0 {
 }
 
 ; GCN-LABEL: {{^}}multi_call_with_external_and_duplicates:
-; GCN:	.set {{(\.L)?}}multi_call_with_external_and_duplicates.num_vgpr, max(41, amdgpu.max_num_vgpr)
-; GCN:	.set {{(\.L)?}}multi_call_with_external_and_duplicates.num_agpr, max(0, amdgpu.max_num_agpr)
-; GCN:	.set {{(\.L)?}}multi_call_with_external_and_duplicates.numbered_sgpr, max(54, amdgpu.max_num_sgpr)
-; GCN:	.set {{(\.L)?}}multi_call_with_external_and_duplicates.private_seg_size, 0+max({{(\.L)?}}use_stack0.private_seg_size, {{(.L)?}}use_stack1.private_seg_size)
-; GCN:	.set {{(\.L)?}}multi_call_with_external_and_duplicates.uses_vcc, 1
-; GCN:	.set {{(\.L)?}}multi_call_with_external_and_duplicates.uses_flat_scratch, 1
-; GCN:	.set {{(\.L)?}}multi_call_with_external_and_duplicates.has_dyn_sized_stack, 1
-; GCN:	.set {{(\.L)?}}multi_call_with_external_and_duplicates.has_recursion, 0
-; GCN:	.set {{(\.L)?}}multi_call_with_external_and_duplicates.has_indirect_call, 1
-; GCN: TotalNumSgprs: {{(\.L)?}}multi_call_with_external_and_duplicates.numbered_sgpr+6
-; GCN: NumVgprs: {{(\.L)?}}multi_call_with_external_and_duplicates.num_vgpr
+; GCN:	.set .Lmulti_call_with_external_and_duplicates.num_vgpr, max(41, amdgpu.max_num_vgpr)
+; GCN:	.set .Lmulti_call_with_external_and_duplicates.num_agpr, max(0, amdgpu.max_num_agpr)
+; GCN:	.set .Lmulti_call_with_external_and_duplicates.numbered_sgpr, max(54, amdgpu.max_num_sgpr)
+; GCN:	.set .Lmulti_call_with_external_and_duplicates.private_seg_size, 0+max(.Luse_stack0.private_seg_size, .Luse_stack1.private_seg_size)
+; GCN:	.set .Lmulti_call_with_external_and_duplicates.uses_vcc, 1
+; GCN:	.set .Lmulti_call_with_external_and_duplicates.uses_flat_scratch, 1
+; GCN:	.set .Lmulti_call_with_external_and_duplicates.has_dyn_sized_stack, 1
+; GCN:	.set .Lmulti_call_with_external_and_duplicates.has_recursion, 0
+; GCN:	.set .Lmulti_call_with_external_and_duplicates.has_indirect_call, 1
+; GCN: TotalNumSgprs: .Lmulti_call_with_external_and_duplicates.numbered_sgpr+6
+; GCN: NumVgprs: .Lmulti_call_with_external_and_duplicates.num_vgpr
 ; GCN: ScratchSize: 2052
 define amdgpu_kernel void @multi_call_with_external_and_duplicates() #0 {
   call void @use_stack0()
@@ -399,17 +399,17 @@ define amdgpu_kernel void @multi_call_with_external_and_duplicates() #0 {
 }
 
 ; GCN-LABEL: {{^}}usage_external:
-; GCN:	.set {{(\.L)?}}usage_external.num_vgpr, max(32, amdgpu.max_num_vgpr)
-; GCN:	.set {{(\.L)?}}usage_external.num_agpr, max(0, amdgpu.max_num_agpr)
-; GCN:	.set {{(\.L)?}}usage_external.numbered_sgpr, max(33, amdgpu.max_num_sgpr)
-; GCN:	.set {{(\.L)?}}usage_external.private_seg_size, 0
-; GCN:	.set {{(\.L)?}}usage_external.uses_vcc, 1
-; GCN:	.set {{(\.L)?}}usage_external.uses_flat_scratch, 1
-; GCN:	.set {{(\.L)?}}usage_external.has_dyn_sized_stack, 1
-; GCN:	.set {{(\.L)?}}usage_external.has_recursion, 0
-; GCN:	.set {{(\.L)?}}usage_external.has_indirect_call, 1
-; GCN: TotalNumSgprs: {{(\.L)?}}usage_external.numbered_sgpr+6
-; GCN: NumVgprs: {{(\.L)?}}usage_external.num_vgpr
+; GCN:	.set .Lusage_external.num_vgpr, max(32, amdgpu.max_num_vgpr)
+; GCN:	.set .Lusage_external.num_agpr, max(0, amdgpu.max_num_agpr)
+; GCN:	.set .Lusage_external.numbered_sgpr, max(33, amdgpu.max_num_sgpr)
+; GCN:	.set .Lusage_external.private_seg_size, 0
+; GCN:	.set .Lusage_external.uses_vcc, 1
+; GCN:	.set .Lusage_external.uses_flat_scratch, 1
+; GCN:	.set .Lusage_external.has_dyn_sized_stack, 1
+; GCN:	.set .Lusage_external.has_recursion, 0
+; GCN:	.set .Lusage_external.has_indirect_call, 1
+; GCN: TotalNumSgprs: .Lusage_external.numbered_sgpr+6
+; GCN: NumVgprs: .Lusage_external.num_vgpr
 ; GCN: ScratchSize: 0
 define amdgpu_kernel void @usage_external() #0 {
   call void @external()
@@ -419,17 +419,17 @@ define amdgpu_kernel void @usage_external() #0 {
 declare void @external_recurse() #2
 
 ; GCN-LABEL: {{^}}usage_external_recurse:
-; GCN:	.set {{(\.L)?}}usage_external_recurse.num_vgpr, max(32, amdgpu.max_num_vgpr)
-; GCN:	.set {{(\.L)?}}usage_external_recurse.num_agpr, max(0, amdgpu.max_num_agpr)
-; GCN:	.set {{(\.L)?}}usage_external_recurse.numbered_sgpr, max(33, amdgpu.max_num_sgpr)
-; GCN:	.set {{(\.L)?}}usage_external_recurse.private_seg_size, 0
-; GCN:	.set {{(\.L)?}}usage_external_recurse.uses_vcc, 1
-; GCN:	.set {{(\.L)?}}usage_external_recurse.uses_flat_scratch, 1
-; GCN:	.set {{(\.L)?}}usage_external_recurse.has_dyn_sized_stack, 1
-; GCN:	.set {{(\.L)?}}usage_external_recurse.has_recursion, 1
-; GCN:	.set {{(\.L)?}}usage_external_recurse.has_indirect_call, 1
-; GCN: TotalNumSgprs: {{(\.L)?}}usage_external_recurse.numbered_sgpr+6
-; GCN: NumVgprs: {{(\.L)?}}usage_external_recurse.num_vgpr
+; GCN:	.set .Lusage_external_recurse.num_vgpr, max(32, amdgpu.max_num_vgpr)
+; GCN:	.set .Lusage_external_recurse.num_agpr, max(0, amdgpu.max_num_agpr)
+; GCN:	.set .Lusage_external_recurse.numbered_sgpr, max(33, amdgpu.max_num_sgpr)
+; GCN:	.set .Lusage_external_recurse.private_seg_size, 0
+; GCN:	.set .Lusage_external_recurse.uses_vcc, 1
+; GCN:	.set .Lusage_external_recurse.uses_flat_scratch, 1
+; GCN:	.set .Lusage_external_recurse.has_dyn_sized_stack, 1
+; GCN:	.set .Lusage_external_recurse.has_recursion, 1
+; GCN:	.set .Lusage_external_recurse.has_indirect_call, 1
+; GCN: TotalNumSgprs: .Lusage_external_recurse.numbered_sgpr+6
+; GCN: NumVgprs: .Lusage_external_recurse.num_vgpr
 ; GCN: ScratchSize: 0
 define amdgpu_kernel void @usage_external_recurse() #0 {
   call void @external_recurse()
@@ -437,15 +437,15 @@ define amdgpu_kernel void @usage_external_recurse() #0 {
 }
 
 ; GCN-LABEL: {{^}}direct_recursion_use_stack:
-; GCN: .set {{(\.L)?}}direct_recursion_use_stack.num_vgpr, 41
-; GCN: .set {{(\.L)?}}direct_recursion_use_stack.num_agpr, 0
-; GCN: .set {{(\.L)?}}direct_recursion_use_stack.numbered_sgpr, 36
-; GCN: .set {{(\.L)?}}direct_recursion_use_stack.private_seg_size, 2064
-; GCN: .set {{(\.L)?}}direct_recursion_use_stack.uses_vcc, 1
-; GCN: .set {{(\.L)?}}direct_recursion_use_stack.uses_flat_scratch, 0
-; GCN: .set {{(\.L)?}}direct_recursion_use_stack.has_dyn_sized_stack, 0
-; GCN: .set {{(\.L)?}}direct_recursion_use_stack.has_recursion, 1
-; GCN: .set {{(\.L)?}}direct_recursion_use_stack.has_indirect_call, 0
+; GCN: .set .Ldirect_recursion_use_stack.num_vgpr, 41
+; GCN: .set .Ldirect_recursion_use_stack.num_agpr, 0
+; GCN: .set .Ldirect_recursion_use_stack.numbered_sgpr, 36
+; GCN: .set .Ldirect_recursion_use_stack.private_seg_size, 2064
+; GCN: .set .Ldirect_recursion_use_stack.uses_vcc, 1
+; GCN: .set .Ldirect_recursion_use_stack.uses_flat_scratch, 0
+; GCN: .set .Ldirect_recursion_use_stack.has_dyn_sized_stack, 0
+; GCN: .set .Ldirect_recursion_use_stack.has_recursion, 1
+; GCN: .set .Ldirect_recursion_use_stack.has_indirect_call, 0
 ; GCN: TotalNumSgprs: 40
 ; GCN: NumVgprs: 41
 ; GCN: ScratchSize: 2064
@@ -465,15 +465,15 @@ ret:
 }
 
 ; GCN-LABEL: {{^}}usage_direct_recursion:
-; GCN:  .set {{(\.L)?}}usage_direct_recursion.num_vgpr, max(32, {{(.L)?}}direct_recursion_use_stack.num_vgpr)
-; GCN:  .set {{(\.L)?}}usage_direct_recursion.num_agpr, max(0, {{(.L)?}}direct_recursion_use_stack.num_agpr)
-; GCN:  .set {{(\.L)?}}usage_direct_recursion.numbered_sgpr, max(33, {{(.L)?}}direct_recursion_use_stack.numbered_sgpr)
-; GCN:  .set {{(\.L)?}}usage_direct_recursion.private_seg_size, 0+max({{(\.L)?}}direct_recursion_use_stack.private_seg_size)
-; GCN:  .set {{(\.L)?}}usage_direct_recursion.uses_vcc, or(1, {{(.L)?}}direct_recursion_use_stack.uses_vcc)
-; GCN:  .set {{(\.L)?}}usage_direct_recursion.uses_flat_scratch, or(1, {{(.L)?}}direct_recursion_use_stack.uses_flat_scratch)
-; GCN:  .set {{(\.L)?}}usage_direct_recursion.has_dyn_sized_stack, or(0, {{(.L)?}}direct_recursion_use_stack.has_dyn_sized_stack)
-; GCN:  .set {{(\.L)?}}usage_direct_recursion.has_recursion, or(1, {{(.L)?}}direct_recursion_use_stack.has_recursion)
-; GCN:  .set {{(\.L)?}}usage_direct_recursion.has_indirect_call, or(0, {{(.L)?}}direct_recursion_use_stack.has_indirect_call)
+; GCN:  .set .Lusage_direct_recursion.num_vgpr, max(32, .Ldirect_recursion_use_stack.num_vgpr)
+; GCN:  .set .Lusage_direct_recursion.num_agpr, max(0, .Ldirect_recursion_use_stack.num_agpr)
+; GCN:  .set .Lusage_direct_recursion.numbered_sgpr, max(33, .Ldirect_recursion_use_stack.numbered_sgpr)
+; GCN:  .set .Lusage_direct_recursion.private_seg_size, 0+max(.Ldirect_recursion_use_stack.private_seg_size)
+; GCN:  .set .Lusage_direct_recursion.uses_vcc, or(1, .Ldirect_recursion_use_stack.uses_vcc)
+; GCN:  .set .Lusage_direct_recursion.uses_flat_scratch, or(1, .Ldirect_recursion_use_stack.uses_flat_scratch)
+; GCN:  .set .Lusage_direct_recursion.has_dyn_sized_stack, or(0, .Ldirect_recursion_use_stack.has_dyn_sized_stack)
+; GCN:  .set .Lusage_direct_recursion.has_recursion, or(1, .Ldirect_recursion_use_stack.has_recursion)
+; GCN:  .set .Lusage_direct_recursion.has_indirect_call, or(0, .Ldirect_recursion_use_stack.has_indirect_call)
 ; GCN: TotalNumSgprs: 42
 ; GCN: NumVgprs: 41
 ; GCN: ScratchSize: 2064
@@ -483,28 +483,28 @@ define amdgpu_kernel void @usage_direct_recursion(i32 %n) #0 {
 }
 
 ; GCN-LABEL: {{^}}multi_stage_recurse2:
-; GCN: .set {{(\.L)?}}multi_stage_recurse2.num_vgpr, max(43, {{(.L)?}}multi_stage_recurse1.num_vgpr)
-; GCN: .set {{(\.L)?}}multi_stage_recurse2.num_agpr, max(0, {{(.L)?}}multi_stage_recurse1.num_agpr)
-; GCN: .set {{(\.L)?}}multi_stage_recurse2.numbered_sgpr, max(34, {{(.L)?}}multi_stage_recurse1.numbered_sgpr)
-; GCN: .set {{(\.L)?}}multi_stage_recurse2.private_seg_size, 16+max({{(\.L)?}}multi_stage_recurse1.private_seg_size)
-; GCN: .set {{(\.L)?}}multi_stage_recurse2.uses_vcc, or(1, {{(.L)?}}multi_stage_recurse1.uses_vcc)
-; GCN: .set {{(\.L)?}}multi_stage_recurse2.uses_flat_scratch, or(0, {{(.L)?}}multi_stage_recurse1.uses_flat_scratch)
-; GCN: .set {{(\.L)?}}multi_stage_recurse2.has_dyn_sized_stack, or(0, {{(.L)?}}multi_stage_recurse1.has_dyn_sized_stack)
-; GCN: .set {{(\.L)?}}multi_stage_recurse2.has_recursion, or(1, {{(.L)?}}multi_stage_recurse1.has_recursion)
-; GCN: .set {{(\.L)?}}multi_stage_recurse2.has_indirect_call, or(0, {{(.L)?}}multi_stage_recurse1.has_indirect_call)
-; GCN: TotalNumSgprs: {{(\.L)?}}multi_stage_recurse2.numbered_sgpr+extrasgprs({{(\.L)?}}multi_stage_recurse2.uses_vcc, {{(.L)?}}multi_stage_recurse2.uses_flat_scratch, 1)
-; GCN: NumVgprs: max(43, {{(\.L)?}}multi_stage_recurse1.num_vgpr)
-; GCN: ScratchSize: 16+max({{(\.L)?}}multi_stage_recurse1.private_seg_size)
+; GCN: .set .Lmulti_stage_recurse2.num_vgpr, max(43, .Lmulti_stage_recurse1.num_vgpr)
+; GCN: .set .Lmulti_stage_recurse2.num_agpr, max(0, .Lmulti_stage_recurse1.num_agpr)
+; GCN: .set .Lmulti_stage_recurse2.numbered_sgpr, max(34, .Lmulti_stage_recurse1.numbered_sgpr)
+; GCN: .set .Lmulti_stage_recurse2.private_seg_size, 16+max(.Lmulti_stage_recurse1.private_seg_size)
+; GCN: .set .Lmulti_stage_recurse2.uses_vcc, or(1, .Lmulti_stage_recurse1.uses_vcc)
+; GCN: .set .Lmulti_stage_recurse2.uses_flat_scratch, or(0, .Lmulti_stage_recurse1.uses_flat_scratch)
+; GCN: .set .Lmulti_stage_recurse2.has_dyn_sized_stack, or(0, .Lmulti_stage_recurse1.has_dyn_sized_stack)
+; GCN: .set .Lmulti_stage_recurse2.has_recursion, or(1, .Lmulti_stage_recurse1.has_recursion)
+; GCN: .set .Lmulti_stage_recurse2.has_indirect_call, or(0, .Lmulti_stage_recurse1.has_indirect_call)
+; GCN: TotalNumSgprs: .Lmulti_stage_recurse2.numbered_sgpr+extrasgprs(.Lmulti_stage_recurse2.uses_vcc, .Lmulti_stage_recurse2.uses_flat_scratch, 1)
+; GCN: NumVgprs: max(43, .Lmulti_stage_recurse1.num_vgpr)
+; GCN: ScratchSize: 16+max(.Lmulti_stage_recurse1.private_seg_size)
 ; GCN-LABEL: {{^}}multi_stage_recurse1:
-; GCN: .set {{(\.L)?}}multi_stage_recurse1.num_vgpr, max(48, 43)
-; GCN: .set {{(\.L)?}}multi_stage_recurse1.num_agpr, max(0, 0)
-; GCN: .set {{(\.L)?}}multi_stage_recurse1.numbered_sgpr, max(34, 34)
-; GCN: .set {{(\.L)?}}multi_stage_recurse1.private_seg_size, 16
-; GCN: .set {{(\.L)?}}multi_stage_recurse1.uses_vcc, 1
-; GCN: .set {{(\.L)?}}multi_stage_recurse1.uses_flat_scratch, 0
-; GCN: .set {{(\.L)?}}multi_stage_recurse1.has_dyn_sized_stack, 0
-; GCN: .set {{(\.L)?}}multi_stage_recurse1.has_recursion, 1
-; GCN: .set {{(\.L)?}}multi_stage_recurse1.has_indirect_call, 0
+; GCN: .set .Lmulti_stage_recurse1.num_vgpr, max(48, 43)
+; GCN: .set .Lmulti_stage_recurse1.num_agpr, max(0, 0)
+; GCN: .set .Lmulti_stage_recurse1.numbered_sgpr, max(34, 34)
+; GCN: .set .Lmulti_stage_recurse1.private_seg_size, 16
+; GCN: .set .Lmulti_stage_recurse1.uses_vcc, 1
+; GCN: .set .Lmulti_stage_recurse1.uses_flat_scratch, 0
+; GCN: .set .Lmulti_stage_recurse1.has_dyn_sized_stack, 0
+; GCN: .set .Lmulti_stage_recurse1.has_recursion, 1
+; GCN: .set .Lmulti_stage_recurse1.has_indirect_call, 0
 ; GCN: TotalNumSgprs: 38
 ; GCN: NumVgprs: 48
 ; GCN: ScratchSize: 16
@@ -520,15 +520,15 @@ define void @multi_stage_recurse2(i32 %val) #2 {
 }
 
 ; GCN-LABEL: {{^}}usage_multi_stage_recurse:
-; GCN: .set {{(\.L)?}}usage_multi_stage_recurse.num_vgpr, max(32, {{(.L)?}}multi_stage_recurse1.num_vgpr)
-; GCN: .set {{(\.L)?}}usage_multi_stage_recurse.num_agpr, max(0, {{(.L)?}}multi_stage_recurse1.num_agpr)
-; GCN: .set {{(\.L)?}}usage_multi_stage_recurse.numbered_sgpr, max(33, {{(.L)?}}multi_stage_recurse1.numbered_sgpr)
-; GCN: .set {{(\.L)?}}usage_multi_stage_recurse.private_seg_size, 0+max({{(\.L)?}}multi_stage_recurse1.private_seg_size)
-; GCN: .set {{(\.L)?}}usage_multi_stage_recurse.uses_vcc, or(1, {{(.L)?}}multi_stage_recurse1.uses_vcc)
-; GCN: .set {{(\.L)?}}usage_multi_stage_recurse.uses_flat_scratch, or(1, {{(.L)?}}multi_stage_recurse1.uses_flat_scratch)
-; GCN: .set {{(\.L)?}}usage_multi_stage_recurse.has_dyn_sized_stack, or(0, {{(.L)?}}multi_stage_recurse1.has_dyn_sized_stack)
-; GCN: .set {{(\.L)?}}usage_multi_stage_recurse.has_recursion, or(1, {{(.L)?}}multi_stage_recurse1.has_recursion)
-; GCN: .set {{(\.L)?}}usage_multi_stage_recurse.has_indirect_call, or(0, {{(.L)?}}multi_stage_recurse1.has_indirect_call)
+; GCN: .set .Lusage_multi_stage_recurse.num_vgpr, max(32, .Lmulti_stage_recurse1.num_vgpr)
+; GCN: .set .Lusage_multi_stage_recurse.num_agpr, max(0, .Lmulti_stage_recurse1.num_agpr)
+; GCN: .set .Lusage_multi_stage_recurse.numbered_sgpr, max(33, .Lmulti_stage_recurse1.numbered_sgpr)
+; GCN: .set .Lusage_multi_stage_recurse.private_seg_size, 0+max(.Lmulti_stage_recurse1.private_seg_size)
+; GCN: .set .Lusage_multi_stage_recurse.uses_vcc, or(1, .Lmulti_stage_recurse1.uses_vcc)
+; GCN: .set .Lusage_multi_stage_recurse.uses_flat_scratch, or(1, .Lmulti_stage_recurse1.uses_flat_scratch)
+; GCN: .set .Lusage_multi_stage_recurse.has_dyn_sized_stack, or(0, .Lmulti_stage_recurse1.has_dyn_sized_stack)
+; GCN: .set .Lusage_multi_stage_recurse.has_recursion, or(1, .Lmulti_stage_recurse1.has_recursion)
+; GCN: .set .Lusage_multi_stage_recurse.has_indirect_call, or(0, .Lmulti_stage_recurse1.has_indirect_call)
 ; GCN: TotalNumSgprs: 40
 ; GCN: NumVgprs: 48
 ; GCN: ScratchSize: 16
@@ -538,28 +538,28 @@ define amdgpu_kernel void @usage_multi_stage_recurse(i32 %n) #0 {
 }
 
 ; GCN-LABEL: {{^}}multi_stage_recurse_noattr2:
-; GCN: .set {{(\.L)?}}multi_stage_recurse_noattr2.num_vgpr, max(41, {{(.L)?}}multi_stage_recurse_noattr1.num_vgpr)
-; GCN: .set {{(\.L)?}}multi_stage_recurse_noattr2.num_agpr, max(0, {{(.L)?}}multi_stage_recurse_noattr1.num_agpr)
-; GCN: .set {{(\.L)?}}multi_stage_recurse_noattr2.numbered_sgpr, max(54, {{(.L)?}}multi_stage_recurse_noattr1.numbered_sgpr)
-; GCN: .set {{(\.L)?}}multi_stage_recurse_noattr2.private_seg_size, 16+max({{(\.L)?}}multi_stage_recurse_noattr1.private_seg_size)
-; GCN: .set {{(\.L)?}}multi_stage_recurse_noattr2.uses_vcc, or(1, {{(.L)?}}multi_stage_recurse_noattr1.uses_vcc)
-; GCN: .set {{(\.L)?}}multi_stage_recurse_noattr2.uses_flat_scratch, or(0, {{(.L)?}}multi_stage_recurse_noattr1.uses_flat_scratch)
-; GCN: .set {{(\.L)?}}multi_stage_recurse_noattr2.has_dyn_sized_stack, or(0, {{(.L)?}}multi_stage_recurse_noattr1.has_dyn_sized_stack)
-; GCN: .set {{(\.L)?}}multi_stage_recurse_noattr2.has_recursion, or(0, {{(.L)?}}multi_stage_recurse_noattr1.has_recursion)
-; GCN: .set {{(\.L)?}}multi_stage_recurse_noattr2.has_indirect_call, or(0, {{(.L)?}}multi_stage_recurse_noattr1.has_indirect_call)
-; GCN: TotalNumSgprs: {{(\.L)?}}multi_stage_recurse_noattr2.numbered_sgpr+extrasgprs({{(\.L)?}}multi_stage_recurse_noattr2.uses_vcc, {{(.L)?}}multi_stage_recurse_noattr2.uses_flat_scratch, 1)
-; GCN: NumVgprs: max(41, {{(\.L)?}}multi_stage_recurse_noattr1.num_vgpr)
-; GCN: ScratchSize: 16+max({{(\.L)?}}multi_stage_recurse_noattr1.private_seg_size)
+; GCN: .set .Lmulti_stage_recurse_noattr2.num_vgpr, max(41, .Lmulti_stage_recurse_noattr1.num_vgpr)
+; GCN: .set .Lmulti_stage_recurse_noattr2.num_agpr, max(0, .Lmulti_stage_recurse_noattr1.num_agpr)
+; GCN: .set .Lmulti_stage_recurse_noattr2.numbered_sgpr, max(54, .Lmulti_stage_recurse_noattr1.numbered_sgpr)
+; GCN: .set .Lmulti_stage_recurse_noattr2.private_seg_size, 16+max(.Lmulti_stage_recurse_noattr1.private_seg_size)
+; GCN: .set .Lmulti_stage_recurse_noattr2.uses_vcc, or(1, .Lmulti_stage_recurse_noattr1.uses_vcc)
+; GCN: .set .Lmulti_stage_recurse_noattr2.uses_flat_scratch, or(0, .Lmulti_stage_recurse_noattr1.uses_flat_scratch)
+; GCN: .set .Lmulti_stage_recurse_noattr2.has_dyn_sized_stack, or(0, .Lmulti_stage_recurse_noattr1.has_dyn_sized_stack)
+; GCN: .set .Lmulti_stage_recurse_noattr2.has_recursion, or(0, .Lmulti_stage_recurse_noattr1.has_recursion)
+; GCN: .set .Lmulti_stage_recurse_noattr2.has_indirect_call, or(0, .Lmulti_stage_recurse_noattr1.has_indirect_call)
+; GCN: TotalNumSgprs: .Lmulti_stage_recurse_noattr2.numbered_sgpr+extrasgprs(.Lmulti_stage_recurse_noattr2.uses_vcc, .Lmulti_stage_recurse_noattr2.uses_flat_scratch, 1)
+; GCN: NumVgprs: max(41, .Lmulti_stage_recurse_noattr1.num_vgpr)
+; GCN: ScratchSize: 16+max(.Lmulti_stage_recurse_noattr1.private_seg_size)
 ; GCN-LABEL: {{^}}multi_stage_recurse_noattr1:
-; GCN: .set {{(\.L)?}}multi_stage_recurse_noattr1.num_vgpr, max(41, 41)
-; GCN: .set {{(\.L)?}}multi_stage_recurse_noattr1.num_agpr, max(0, 0)
-; GCN: .set {{(\.L)?}}multi_stage_recurse_noattr1.numbered_sgpr, max(57, 54)
-; GCN: .set {{(\.L)?}}multi_stage_recurse_noattr1.private_seg_size, 16
-; GCN: .set {{(\.L)?}}multi_stage_recurse_noattr1.uses_vcc, 1
-; GCN: .set {{(\.L)?}}multi_stage_recurse_noattr1.uses_flat_scratch, 0
-; GCN: .set {{(\.L)?}}multi_stage_recurse_noattr1.has_dyn_sized_stack, 0
-; GCN: .set {{(\.L)?}}multi_stage_recurse_noattr1.has_recursion, 0
-; GCN: .set {{(\.L)?}}multi_stage_recurse_noattr1.has_indirect_call, 0
+; GCN: .set .Lmulti_stage_recurse_noattr1.num_vgpr, max(41, 41)
+; GCN: .set .Lmulti_stage_recurse_noattr1.num_agpr, max(0, 0)
+; GCN: .set .Lmulti_stage_recurse_noattr1.numbered_sgpr, max(57, 54)
+; GCN: .set .Lmulti_stage_recurse_noattr1.private_seg_size, 16
+; GCN: .set .Lmulti_stage_recurse_noattr1.uses_vcc, 1
+; GCN: .set .Lmulti_stage_recurse_noattr1.uses_flat_scratch, 0
+; GCN: .set .Lmulti_stage_recurse_noattr1.has_dyn_sized_stack, 0
+; GCN: .set .Lmulti_stage_recurse_noattr1.has_recursion, 0
+; GCN: .set .Lmulti_stage_recurse_noattr1.has_indirect_call, 0
 ; GCN: TotalNumSgprs: 61
 ; GCN: NumVgprs: 41
 ; GCN: ScratchSize: 16
@@ -575,15 +575,15 @@ define void @multi_stage_recurse_noattr2(i32 %val) #0 {
 }
 
 ; GCN-LABEL: {{^}}usage_multi_stage_recurse_noattrs:
-; GCN: .set {{(\.L)?}}usage_multi_stage_recurse_noattrs.num_vgpr, max(32, {{(.L)?}}multi_stage_recurse_noattr1.num_vgpr)
-; GCN: .set {{(\.L)?}}usage_multi_stage_recurse_noattrs.num_agpr, max(0, {{(.L)?}}multi_stage_recurse_noattr1.num_agpr)
-; GCN: .set {{(\.L)?}}usage_multi_stage_recurse_noattrs.numbered_sgpr, max(33, {{(.L)?}}multi_stage_recurse_noattr1.numbered_sgpr)
-; GCN: .set {{(\.L)?}}usage_multi_stage_recurse_noattrs.private_seg_size, 0+max({{(\.L)?}}multi_stage_recurse_noattr1.private_seg_size)
-; GCN: .set {{(\.L)?}}usage_multi_stage_recurse_noattrs.uses_vcc, or(1, {{(.L)?}}multi_stage_recurse_noattr1.uses_vcc)
-; GCN: .set {{(\.L)?}}usage_multi_stage_recurse_noattrs.uses_flat_scratch, or(1, {{(.L)?}}multi_stage_recurse_noattr1.uses_flat_scratch)
-; GCN: .set {{(\.L)?}}usage_multi_stage_recurse_noattrs.has_dyn_sized_stack, or(0, {{(.L)?}}multi_stage_recurse_noattr1.has_dyn_sized_stack)
-; GCN: .set {{(\.L)?}}usage_multi_stage_recurse_noattrs.has_recursion, or(0, {{(.L)?}}multi_stage_recurse_noattr1.has_recursion)
-; GCN: .set {{(\.L)?}}usage_multi_stage_recurse_noattrs.has_indirect_call, or(0, {{(.L)?}}multi_stage_recurse_noattr1.has_indirect_call)
+; GCN: .set .Lusage_multi_stage_recurse_noattrs.num_vgpr, max(32, .Lmulti_stage_recurse_noattr1.num_vgpr)
+; GCN: .set .Lusage_multi_stage_recurse_noattrs.num_agpr, max(0, .Lmulti_stage_recurse_noattr1.num_agpr)
+; GCN: .set .Lusage_multi_stage_recurse_noattrs.numbered_sgpr, max(33, .Lmulti_stage_recurse_noattr1.numbered_sgpr)
+; GCN: .set .Lusage_multi_stage_recurse_noattrs.private_seg_size, 0+max(.Lmulti_stage_recurse_noattr1.private_seg_size)
+; GCN: .set .Lusage_multi_stage_recurse_noattrs.uses_vcc, or(1, .Lmulti_stage_recurse_noattr1.uses_vcc)
+; GCN: .set .Lusage_multi_stage_recurse_noattrs.uses_flat_scratch, or(1, .Lmulti_stage_recurse_noattr1.uses_flat_scratch)
+; GCN: .set .Lusage_multi_stage_recurse_noattrs.has_dyn_sized_stack, or(0, .Lmulti_stage_recurse_noattr1.has_dyn_sized_stack)
+; GCN: .set .Lusage_multi_stage_recurse_noattrs.has_recursion, or(0, .Lmulti_stage_recurse_noattr1.has_recursion)
+; GCN: .set .Lusage_multi_stage_recurse_noattrs.has_indirect_call, or(0, .Lmulti_stage_recurse_noattr1.has_indirect_call)
 ; GCN: TotalNumSgprs: 63
 ; GCN: NumVgprs: 41
 ; GCN: ScratchSize: 16
@@ -593,15 +593,15 @@ define amdgpu_kernel void @usage_multi_stage_recurse_noattrs(i32 %n) #0 {
 }
 
 ; GCN-LABEL: {{^}}multi_call_with_multi_stage_recurse:
-; GCN:  .set {{(\.L)?}}multi_call_with_multi_stage_recurse.num_vgpr, max(41, {{(.L)?}}use_stack0.num_vgpr, {{(.L)?}}use_stack1.num_vgpr, {{(\.L)?}}multi_stage_recurse1.num_vgpr)
-; GCN:  .set {{(\.L)?}}multi_call_with_multi_stage_recurse.num_agpr, max(0, {{(.L)?}}use_stack0.num_agpr, {{(.L)?}}use_stack1.num_agpr, {{(\.L)?}}multi_stage_recurse1.num_agpr)
-; GCN:  .set {{(\.L)?}}multi_call_with_multi_stage_recurse.numbered_sgpr, max(53, {{(.L)?}}use_stack0.numbered_sgpr, {{(.L)?}}use_stack1.numbered_sgpr, {{(\.L)?}}multi_stage_recurse1.numbered_sgpr)
-; GCN:  .set {{(\.L)?}}multi_call_with_multi_stage_recurse.private_seg_size, 0+max({{(\.L)?}}use_stack0.private_seg_size, {{(.L)?}}use_stack1.private_seg_size, {{(\.L)?}}multi_stage_recurse1.private_seg_size)
-; GCN:  .set {{(\.L)?}}multi_call_with_multi_stage_recurse.uses_vcc, or(1, {{(.L)?}}use_stack0.uses_vcc, {{(.L)?}}use_stack1.uses_vcc, {{(\.L)?}}multi_stage_recurse1.uses_vcc)
-; GCN:  .set {{(\.L)?}}multi_call_with_multi_stage_recurse.uses_flat_scratch, or(1, {{(.L)?}}use_stack0.uses_flat_scratch, {{(.L)?}}use_stack1.uses_flat_scratch, {{(\.L)?}}multi_stage_recurse1.uses_flat_scratch)
-; GCN:  .set {{(\.L)?}}multi_call_with_multi_stage_recurse.has_dyn_sized_stack, or(0, {{(.L)?}}use_stack0.has_dyn_sized_stack, {{(.L)?}}use_stack1.has_dyn_sized_stack, {{(\.L)?}}multi_stage_recurse1.has_dyn_sized_stack)
-; GCN:  .set {{(\.L)?}}multi_call_with_multi_stage_recurse.has_recursion, or(1, {{(.L)?}}use_stack0.has_recursion, {{(.L)?}}use_stack1.has_recursion, {{(\.L)?}}multi_stage_recurse1.has_recursion)
-; GCN:  .set {{(\.L)?}}multi_call_with_multi_stage_recurse.has_indirect_call, or(0, {{(.L)?}}use_stack0.has_indirect_call, {{(.L)?}}use_stack1.has_indirect_call, {{(\.L)?}}multi_stage_recurse1.has_indirect_call)
+; GCN:  .set .Lmulti_call_with_multi_stage_recurse.num_vgpr, max(41, .Luse_stack0.num_vgpr, .Luse_stack1.num_vgpr, .Lmulti_stage_recurse1.num_vgpr)
+; GCN:  .set .Lmulti_call_with_multi_stage_recurse.num_agpr, max(0, .Luse_stack0.num_agpr, .Luse_stack1.num_agpr, .Lmulti_stage_recurse1.num_agpr)
+; GCN:  .set .Lmulti_call_with_multi_stage_recurse.numbered_sgpr, max(53, .Luse_stack0.numbered_sgpr, .Luse_stack1.numbered_sgpr, .Lmulti_stage_recurse1.numbered_sgpr)
+; GCN:  .set .Lmulti_call_with_multi_stage_recurse.private_seg_size, 0+max(.Luse_stack0.private_seg_size, .Luse_stack1.private_seg_size, .Lmulti_stage_recurse1.private_seg_size)
+; GCN:  .set .Lmulti_call_with_multi_stage_recurse.uses_vcc, or(1, .Luse_stack0.uses_vcc, .Luse_stack1.uses_vcc, .Lmulti_stage_recurse1.uses_vcc)
+; GCN:  .set .Lmulti_call_with_multi_stage_recurse.uses_flat_scratch, or(1, .Luse_stack0.uses_flat_scratch, .Luse_stack1.uses_flat_scratch, .Lmulti_stage_recurse1.uses_flat_scratch)
+; GCN:  .set .Lmulti_call_with_multi_stage_recurse.has_dyn_sized_stack, or(0, .Luse_stack0.has_dyn_sized_stack, .Luse_stack1.has_dyn_sized_stack, .Lmulti_stage_recurse1.has_dyn_sized_stack)
+; GCN:  .set .Lmulti_call_with_multi_stage_recurse.has_recursion, or(1, .Luse_stack0.has_recursion, .Luse_stack1.has_recursion, .Lmulti_stage_recurse1.has_recursion)
+; GCN:  .set .Lmulti_call_with_multi_stage_recurse.has_indirect_call, or(0, .Luse_stack0.has_indirect_call, .Luse_stack1.has_indirect_call, .Lmulti_stage_recurse1.has_indirect_call)
 ; GCN: TotalNumSgprs: 59
 ; GCN: NumVgprs:  48
 ; GCN: ScratchSize: 2052
@@ -614,17 +614,17 @@ define amdgpu_kernel void @multi_call_with_multi_stage_recurse(i32 %n) #0 {
 
 ; Make sure there's no assert when a sgpr96 is used.
 ; GCN-LABEL: {{^}}count_use_sgpr96_external_call
-; GCN:	.set {{(\.L)?}}count_use_sgpr96_external_call.num_vgpr, max(32, amdgpu.max_num_vgpr)
-; GCN:	.set {{(\.L)?}}count_use_sgpr96_external_call.num_agpr, max(0, amdgpu.max_num_agpr)
-; GCN:	.set {{(\.L)?}}count_use_sgpr96_external_call.numbered_sgpr, max(33, amdgpu.max_num_sgpr)
-; GCN:	.set {{(\.L)?}}count_use_sgpr96_external_call.private_seg_size, 0
-; GCN:	.set {{(\.L)?}}count_use_sgpr96_external_call.uses_vcc, 1
-; GCN:	.set {{(\.L)?}}count_use_sgpr96_external_call.uses_flat_scratch, 1
-; GCN:	.set {{(\.L)?}}count_use_sgpr96_external_call.has_dyn_sized_stack, 1
-; GCN:	.set {{(\.L)?}}count_use_sgpr96_external_call.has_recursion, 0
-; GCN:	.set {{(\.L)?}}count_use_sgpr96_external_call.has_indirect_call, 1
-; GCN: TotalNumSgprs: {{(\.L)?}}count_use_sgpr96_external_call.numbered_sgpr+6
-; GCN: NumVgprs: {{(\.L)?}}count_use_sgpr96_external_call.num_vgpr
+; GCN:	.set .Lcount_use_sgpr96_external_call.num_vgpr, max(32, amdgpu.max_num_vgpr)
+; GCN:	.set .Lcount_use_sgpr96_external_call.num_agpr, max(0, amdgpu.max_num_agpr)
+; GCN:	.set .Lcount_use_sgpr96_external_call.numbered_sgpr, max(33, amdgpu.max_num_sgpr)
+; GCN:	.set .Lcount_use_sgpr96_external_call.private_seg_size, 0
+; GCN:	.set .Lcount_use_sgpr96_external_call.uses_vcc, 1
+; GCN:	.set .Lcount_use_sgpr96_external_call.uses_flat_scratch, 1
+; GCN:	.set .Lcount_use_sgpr96_external_call.has_dyn_sized_stack, 1
+; GCN:	.set .Lcount_use_sgpr96_external_call.has_recursion, 0
+; GCN:	.set .Lcount_use_sgpr96_external_call.has_indirect_call, 1
+; GCN: TotalNumSgprs: .Lcount_use_sgpr96_external_call.numbered_sgpr+6
+; GCN: NumVgprs: .Lcount_use_sgpr96_external_call.num_vgpr
 ; GCN: ScratchSize: 0
 define amdgpu_kernel void @count_use_sgpr96_external_call()  {
 entry:
@@ -635,17 +635,17 @@ entry:
 
 ; Make sure there's no assert when a sgpr160 is used.
 ; GCN-LABEL: {{^}}count_use_sgpr160_external_call
-; GCN:	.set {{(\.L)?}}count_use_sgpr160_external_call.num_vgpr, max(32, amdgpu.max_num_vgpr)
-; GCN:	.set {{(\.L)?}}count_use_sgpr160_external_call.num_agpr, max(0, amdgpu.max_num_agpr)
-; GCN:	.set {{(\.L)?}}count_use_sgpr160_external_call.numbered_sgpr, max(33, amdgpu.max_num_sgpr)
-; GCN:	.set {{(\.L)?}}count_use_sgpr160_external_call.private_seg_size, 0
-; GCN:	.set {{(\.L)?}}count_use_sgpr160_external_call.uses_vcc, 1
-; GCN:	.set {{(\.L)?}}count_use_sgpr160_external_call.uses_flat_scratch, 1
-; GCN:	.set {{(\.L)?}}count_use_sgpr160_external_call.has_dyn_sized_stack, 1
-; GCN:	.set {{(\.L)?}}count_use_sgpr160_external_call.has_recursion, 0
-; GCN:	.set {{(\.L)?}}count_use_sgpr160_external_call.has_indirect_call, 1
-; GCN: TotalNumSgprs: {{(\.L)?}}count_use_sgpr160_external_call.numbered_sgpr+6
-; GCN: NumVgprs: {{(\.L)?}}count_use_sgpr160_external_call.num_vgpr
+; GCN:	.set .Lcount_use_sgpr160_external_call.num_vgpr, max(32, amdgpu.max_num_vgpr)
+; GCN:	.set .Lcount_use_sgpr160_external_call.num_agpr, max(0, amdgpu.max_num_agpr)
+; GCN:	.set .Lcount_use_sgpr160_external_call.numbered_sgpr, max(33, amdgpu.max_num_sgpr)
+; GCN:	.set .Lcount_use_sgpr160_external_call.private_seg_size, 0
+; GCN:	.set .Lcount_use_sgpr160_external_call.uses_vcc, 1
+; GCN:	.set .Lcount_use_sgpr160_external_call.uses_flat_scratch, 1
+; GCN:	.set .Lcount_use_sgpr160_external_call.has_dyn_sized_stack, 1
+; GCN:	.set .Lcount_use_sgpr160_external_call.has_recursion, 0
+; GCN:	.set .Lcount_use_sgpr160_external_call.has_indirect_call, 1
+; GCN: TotalNumSgprs: .Lcount_use_sgpr160_external_call.numbered_sgpr+6
+; GCN: NumVgprs: .Lcount_use_sgpr160_external_call.num_vgpr
 ; GCN: ScratchSize: 0
 define amdgpu_kernel void @count_use_sgpr160_external_call()  {
 entry:
@@ -656,17 +656,17 @@ entry:
 
 ; Make sure there's no assert when a vgpr160 is used.
 ; GCN-LABEL: {{^}}count_use_vgpr160_external_call
-; GCN:	.set {{(\.L)?}}count_use_vgpr160_external_call.num_vgpr, max(32, amdgpu.max_num_vgpr)
-; GCN:	.set {{(\.L)?}}count_use_vgpr160_external_call.num_agpr, max(0, amdgpu.max_num_agpr)
-; GCN:	.set {{(\.L)?}}count_use_vgpr160_external_call.numbered_sgpr, max(33, amdgpu.max_num_sgpr)
-; GCN:	.set {{(\.L)?}}count_use_vgpr160_external_call.private_seg_size, 0
-; GCN:	.set {{(\.L)?}}count_use_vgpr160_external_call.uses_vcc, 1
-; GCN:	.set {{(\.L)?}}count_use_vgpr160_external_call.uses_flat_scratch, 1
-; GCN:	.set {{(\.L)?}}count_use_vgpr160_external_call.has_dyn_sized_stack, 1
-; GCN:	.set {{(\.L)?}}count_use_vgpr160_external_call.has_recursion, 0
-; GCN:	.set {{(\.L)?}}count_use_vgpr160_external_call.has_indirect_call, 1
-; GCN: TotalNumSgprs: {{(\.L)?}}count_use_vgpr160_external_call.numbered_sgpr+6
-; GCN: NumVgprs: {{(\.L)?}}count_use_vgpr160_external_call.num_vgpr
+; GCN:	.set .Lcount_use_vgpr160_external_call.num_vgpr, max(32, amdgpu.max_num_vgpr)
+; GCN:	.set .Lcount_use_vgpr160_external_call.num_agpr, max(0, amdgpu.max_num_agpr)
+; GCN:	.set .Lcount_use_vgpr160_external_call.numbered_sgpr, max(33, amdgpu.max_num_sgpr)
+; GCN:	.set .Lcount_use_vgpr160_external_call.private_seg_size, 0
+; GCN:	.set .Lcount_use_vgpr160_external_call.uses_vcc, 1
+; GCN:	.set .Lcount_use_vgpr160_external_call.uses_flat_scratch, 1
+; GCN:	.set .Lcount_use_vgpr160_external_call.has_dyn_sized_stack, 1
+; GCN:	.set .Lcount_use_vgpr160_external_call.has_recursion, 0
+; GCN:	.set .Lcount_use_vgpr160_external_call.has_indirect_call, 1
+; GCN: TotalNumSgprs: .Lcount_use_vgpr160_external_call.numbered_sgpr+6
+; GCN: NumVgprs: .Lcount_use_vgpr160_external_call.num_vgpr
 ; GCN: ScratchSize: 0
 define amdgpu_kernel void @count_use_vgpr160_external_call()  {
 entry:
@@ -677,7 +677,7 @@ entry:
 
 ; Test that amdgcn.device.init correctly references amdgpu.max_num_named_barrier
 ; GCN-LABEL: {{^}}amdgcn.device.init:
-; GCN: .set {{(\.L)?}}amdgcn.device.init.num_named_barrier, max(0, amdgpu.max_num_named_barrier)
+; GCN: .set .Lamdgcn.device.init.num_named_barrier, max(0, amdgpu.max_num_named_barrier)
 
 @llvm.global_ctors = appending addrspace(1) global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 1, ptr @ctor_func, ptr null }]
 

--- a/llvm/test/CodeGen/AMDGPU/mcexpr-knownbits-assign-crash-gh-issue-110930.ll
+++ b/llvm/test/CodeGen/AMDGPU/mcexpr-knownbits-assign-crash-gh-issue-110930.ll
@@ -1,4 +1,4 @@
-; RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx1030 < %s | FileCheck %s
+; RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx1030 -amdgpu-localize-resource-symbols=false < %s | FileCheck %s
 
 ; Previously, this would hit an assertion on incompatible comparison between
 ; APInts due to BitWidth differences. This was due to assignment of DenseMap

--- a/llvm/test/CodeGen/AMDGPU/mcexpr-knownbits-assign-crash-gh-issue-110930.ll
+++ b/llvm/test/CodeGen/AMDGPU/mcexpr-knownbits-assign-crash-gh-issue-110930.ll
@@ -1,4 +1,4 @@
-; RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx1030 -amdgpu-localize-resource-symbols=false < %s | FileCheck %s
+; RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx1030 < %s | FileCheck %s
 
 ; Previously, this would hit an assertion on incompatible comparison between
 ; APInts due to BitWidth differences. This was due to assignment of DenseMap
@@ -6,15 +6,15 @@
 ; use-after-free if the assignment operator invokes a DenseMap growth.
 
 ; CHECK-LABEL: I_Quit:
-; CHECK: .set I_Quit.num_vgpr, max(41, amdgpu.max_num_vgpr)
-; CHECK: .set I_Quit.num_agpr, max(0, amdgpu.max_num_agpr)
-; CHECK: .set I_Quit.numbered_sgpr, max(56, amdgpu.max_num_sgpr)
-; CHECK: .set I_Quit.private_seg_size, 16
-; CHECK: .set I_Quit.uses_vcc, 1
-; CHECK: .set I_Quit.uses_flat_scratch, 1
-; CHECK: .set I_Quit.has_dyn_sized_stack, 1
-; CHECK: .set I_Quit.has_recursion, 1
-; CHECK: .set I_Quit.has_indirect_call, 1
+; CHECK: .set .LI_Quit.num_vgpr, max(41, amdgpu.max_num_vgpr)
+; CHECK: .set .LI_Quit.num_agpr, max(0, amdgpu.max_num_agpr)
+; CHECK: .set .LI_Quit.numbered_sgpr, max(56, amdgpu.max_num_sgpr)
+; CHECK: .set .LI_Quit.private_seg_size, 16
+; CHECK: .set .LI_Quit.uses_vcc, 1
+; CHECK: .set .LI_Quit.uses_flat_scratch, 1
+; CHECK: .set .LI_Quit.has_dyn_sized_stack, 1
+; CHECK: .set .LI_Quit.has_recursion, 1
+; CHECK: .set .LI_Quit.has_indirect_call, 1
 define void @I_Quit() {
   %fptr = load ptr, ptr null, align 8
   tail call void %fptr()
@@ -22,71 +22,71 @@ define void @I_Quit() {
 }
 
 ; CHECK-LABEL: P_RemoveMobj:
-; CHECK: .set P_RemoveMobj.num_vgpr, 0
-; CHECK: .set P_RemoveMobj.num_agpr, 0
-; CHECK: .set P_RemoveMobj.numbered_sgpr, 32
-; CHECK: .set P_RemoveMobj.private_seg_size, 0
-; CHECK: .set P_RemoveMobj.uses_vcc, 0
-; CHECK: .set P_RemoveMobj.uses_flat_scratch, 0
-; CHECK: .set P_RemoveMobj.has_dyn_sized_stack, 0
-; CHECK: .set P_RemoveMobj.has_recursion, 0
-; CHECK: .set P_RemoveMobj.has_indirect_call, 0
+; CHECK: .set .LP_RemoveMobj.num_vgpr, 0
+; CHECK: .set .LP_RemoveMobj.num_agpr, 0
+; CHECK: .set .LP_RemoveMobj.numbered_sgpr, 32
+; CHECK: .set .LP_RemoveMobj.private_seg_size, 0
+; CHECK: .set .LP_RemoveMobj.uses_vcc, 0
+; CHECK: .set .LP_RemoveMobj.uses_flat_scratch, 0
+; CHECK: .set .LP_RemoveMobj.has_dyn_sized_stack, 0
+; CHECK: .set .LP_RemoveMobj.has_recursion, 0
+; CHECK: .set .LP_RemoveMobj.has_indirect_call, 0
 define void @P_RemoveMobj() {
   ret void
 }
 
 ; CHECK-LABEL: P_SpawnMobj:
-; CHECK: .set P_SpawnMobj.num_vgpr, 0
-; CHECK: .set P_SpawnMobj.num_agpr, 0
-; CHECK: .set P_SpawnMobj.numbered_sgpr, 32
-; CHECK: .set P_SpawnMobj.private_seg_size, 0
-; CHECK: .set P_SpawnMobj.uses_vcc, 0
-; CHECK: .set P_SpawnMobj.uses_flat_scratch, 0
-; CHECK: .set P_SpawnMobj.has_dyn_sized_stack, 0
-; CHECK: .set P_SpawnMobj.has_recursion, 0
-; CHECK: .set P_SpawnMobj.has_indirect_call, 0
+; CHECK: .set .LP_SpawnMobj.num_vgpr, 0
+; CHECK: .set .LP_SpawnMobj.num_agpr, 0
+; CHECK: .set .LP_SpawnMobj.numbered_sgpr, 32
+; CHECK: .set .LP_SpawnMobj.private_seg_size, 0
+; CHECK: .set .LP_SpawnMobj.uses_vcc, 0
+; CHECK: .set .LP_SpawnMobj.uses_flat_scratch, 0
+; CHECK: .set .LP_SpawnMobj.has_dyn_sized_stack, 0
+; CHECK: .set .LP_SpawnMobj.has_recursion, 0
+; CHECK: .set .LP_SpawnMobj.has_indirect_call, 0
 define void @P_SpawnMobj() {
   ret void
 }
 
 ; CHECK-LABEL: G_PlayerReborn:
-; CHECK: .set G_PlayerReborn.num_vgpr, 0
-; CHECK: .set G_PlayerReborn.num_agpr, 0
-; CHECK: .set G_PlayerReborn.numbered_sgpr, 32
-; CHECK: .set G_PlayerReborn.private_seg_size, 0
-; CHECK: .set G_PlayerReborn.uses_vcc, 0
-; CHECK: .set G_PlayerReborn.uses_flat_scratch, 0
-; CHECK: .set G_PlayerReborn.has_dyn_sized_stack, 0
-; CHECK: .set G_PlayerReborn.has_recursion, 0
-; CHECK: .set G_PlayerReborn.has_indirect_call, 0
+; CHECK: .set .LG_PlayerReborn.num_vgpr, 0
+; CHECK: .set .LG_PlayerReborn.num_agpr, 0
+; CHECK: .set .LG_PlayerReborn.numbered_sgpr, 32
+; CHECK: .set .LG_PlayerReborn.private_seg_size, 0
+; CHECK: .set .LG_PlayerReborn.uses_vcc, 0
+; CHECK: .set .LG_PlayerReborn.uses_flat_scratch, 0
+; CHECK: .set .LG_PlayerReborn.has_dyn_sized_stack, 0
+; CHECK: .set .LG_PlayerReborn.has_recursion, 0
+; CHECK: .set .LG_PlayerReborn.has_indirect_call, 0
 define void @G_PlayerReborn() {
   ret void
 }
 
 ; CHECK-LABEL: P_SetThingPosition:
-; CHECK: .set P_SetThingPosition.num_vgpr, 0
-; CHECK: .set P_SetThingPosition.num_agpr, 0
-; CHECK: .set P_SetThingPosition.numbered_sgpr, 32
-; CHECK: .set P_SetThingPosition.private_seg_size, 0
-; CHECK: .set P_SetThingPosition.uses_vcc, 0
-; CHECK: .set P_SetThingPosition.uses_flat_scratch, 0
-; CHECK: .set P_SetThingPosition.has_dyn_sized_stack, 0
-; CHECK: .set P_SetThingPosition.has_recursion, 0
-; CHECK: .set P_SetThingPosition.has_indirect_call, 0
+; CHECK: .set .LP_SetThingPosition.num_vgpr, 0
+; CHECK: .set .LP_SetThingPosition.num_agpr, 0
+; CHECK: .set .LP_SetThingPosition.numbered_sgpr, 32
+; CHECK: .set .LP_SetThingPosition.private_seg_size, 0
+; CHECK: .set .LP_SetThingPosition.uses_vcc, 0
+; CHECK: .set .LP_SetThingPosition.uses_flat_scratch, 0
+; CHECK: .set .LP_SetThingPosition.has_dyn_sized_stack, 0
+; CHECK: .set .LP_SetThingPosition.has_recursion, 0
+; CHECK: .set .LP_SetThingPosition.has_indirect_call, 0
 define void @P_SetThingPosition() {
   ret void
 }
 
 ; CHECK-LABEL: P_SetupPsprites:
-; CHECK: .set P_SetupPsprites.num_vgpr, max(41, amdgpu.max_num_vgpr)
-; CHECK: .set P_SetupPsprites.num_agpr, max(0, amdgpu.max_num_agpr)
-; CHECK: .set P_SetupPsprites.numbered_sgpr, max(56, amdgpu.max_num_sgpr)
-; CHECK: .set P_SetupPsprites.private_seg_size, 16
-; CHECK: .set P_SetupPsprites.uses_vcc, 1
-; CHECK: .set P_SetupPsprites.uses_flat_scratch, 1
-; CHECK: .set P_SetupPsprites.has_dyn_sized_stack, 1
-; CHECK: .set P_SetupPsprites.has_recursion, 1
-; CHECK: .set P_SetupPsprites.has_indirect_call, 1
+; CHECK: .set .LP_SetupPsprites.num_vgpr, max(41, amdgpu.max_num_vgpr)
+; CHECK: .set .LP_SetupPsprites.num_agpr, max(0, amdgpu.max_num_agpr)
+; CHECK: .set .LP_SetupPsprites.numbered_sgpr, max(56, amdgpu.max_num_sgpr)
+; CHECK: .set .LP_SetupPsprites.private_seg_size, 16
+; CHECK: .set .LP_SetupPsprites.uses_vcc, 1
+; CHECK: .set .LP_SetupPsprites.uses_flat_scratch, 1
+; CHECK: .set .LP_SetupPsprites.has_dyn_sized_stack, 1
+; CHECK: .set .LP_SetupPsprites.has_recursion, 1
+; CHECK: .set .LP_SetupPsprites.has_indirect_call, 1
 define void @P_SetupPsprites(ptr addrspace(1) %i) {
   %fptr = load ptr, ptr addrspace(1) %i, align 8
   tail call void %fptr()
@@ -94,29 +94,29 @@ define void @P_SetupPsprites(ptr addrspace(1) %i) {
 }
 
 ; CHECK-LABEL: HU_Start:
-; CHECK: .set HU_Start.num_vgpr, 0
-; CHECK: .set HU_Start.num_agpr, 0
-; CHECK: .set HU_Start.numbered_sgpr, 32
-; CHECK: .set HU_Start.private_seg_size, 0
-; CHECK: .set HU_Start.uses_vcc, 0
-; CHECK: .set HU_Start.uses_flat_scratch, 0
-; CHECK: .set HU_Start.has_dyn_sized_stack, 0
-; CHECK: .set HU_Start.has_recursion, 0
-; CHECK: .set HU_Start.has_indirect_call, 0
+; CHECK: .set .LHU_Start.num_vgpr, 0
+; CHECK: .set .LHU_Start.num_agpr, 0
+; CHECK: .set .LHU_Start.numbered_sgpr, 32
+; CHECK: .set .LHU_Start.private_seg_size, 0
+; CHECK: .set .LHU_Start.uses_vcc, 0
+; CHECK: .set .LHU_Start.uses_flat_scratch, 0
+; CHECK: .set .LHU_Start.has_dyn_sized_stack, 0
+; CHECK: .set .LHU_Start.has_recursion, 0
+; CHECK: .set .LHU_Start.has_indirect_call, 0
 define void @HU_Start() {
   ret void
 }
 
 ; CHECK-LABEL: P_SpawnPlayer:
-; CHECK: .set P_SpawnPlayer.num_vgpr, max(43, G_PlayerReborn.num_vgpr, P_SetThingPosition.num_vgpr, P_SetupPsprites.num_vgpr, HU_Start.num_vgpr)
-; CHECK: .set P_SpawnPlayer.num_agpr, max(0, G_PlayerReborn.num_agpr, P_SetThingPosition.num_agpr, P_SetupPsprites.num_agpr, HU_Start.num_agpr)
-; CHECK: .set P_SpawnPlayer.numbered_sgpr, max(84, G_PlayerReborn.numbered_sgpr, P_SetThingPosition.numbered_sgpr, P_SetupPsprites.numbered_sgpr, HU_Start.numbered_sgpr)
-; CHECK: .set P_SpawnPlayer.private_seg_size, 16+max(G_PlayerReborn.private_seg_size, P_SetThingPosition.private_seg_size, P_SetupPsprites.private_seg_size, HU_Start.private_seg_size)
-; CHECK: .set P_SpawnPlayer.uses_vcc, or(1, G_PlayerReborn.uses_vcc, P_SetThingPosition.uses_vcc, P_SetupPsprites.uses_vcc, HU_Start.uses_vcc)
-; CHECK: .set P_SpawnPlayer.uses_flat_scratch, or(0, G_PlayerReborn.uses_flat_scratch, P_SetThingPosition.uses_flat_scratch, P_SetupPsprites.uses_flat_scratch, HU_Start.uses_flat_scratch)
-; CHECK: .set P_SpawnPlayer.has_dyn_sized_stack, or(0, G_PlayerReborn.has_dyn_sized_stack, P_SetThingPosition.has_dyn_sized_stack, P_SetupPsprites.has_dyn_sized_stack, HU_Start.has_dyn_sized_stack)
-; CHECK: .set P_SpawnPlayer.has_recursion, or(1, G_PlayerReborn.has_recursion, P_SetThingPosition.has_recursion, P_SetupPsprites.has_recursion, HU_Start.has_recursion)
-; CHECK: .set P_SpawnPlayer.has_indirect_call, or(0, G_PlayerReborn.has_indirect_call, P_SetThingPosition.has_indirect_call, P_SetupPsprites.has_indirect_call, HU_Start.has_indirect_call)
+; CHECK: .set .LP_SpawnPlayer.num_vgpr, max(43, .LG_PlayerReborn.num_vgpr, .LP_SetThingPosition.num_vgpr, .LP_SetupPsprites.num_vgpr, .LHU_Start.num_vgpr)
+; CHECK: .set .LP_SpawnPlayer.num_agpr, max(0, .LG_PlayerReborn.num_agpr, .LP_SetThingPosition.num_agpr, .LP_SetupPsprites.num_agpr, .LHU_Start.num_agpr)
+; CHECK: .set .LP_SpawnPlayer.numbered_sgpr, max(84, .LG_PlayerReborn.numbered_sgpr, .LP_SetThingPosition.numbered_sgpr, .LP_SetupPsprites.numbered_sgpr, .LHU_Start.numbered_sgpr)
+; CHECK: .set .LP_SpawnPlayer.private_seg_size, 16+max(.LG_PlayerReborn.private_seg_size, .LP_SetThingPosition.private_seg_size, .LP_SetupPsprites.private_seg_size, .LHU_Start.private_seg_size)
+; CHECK: .set .LP_SpawnPlayer.uses_vcc, or(1, .LG_PlayerReborn.uses_vcc, .LP_SetThingPosition.uses_vcc, .LP_SetupPsprites.uses_vcc, .LHU_Start.uses_vcc)
+; CHECK: .set .LP_SpawnPlayer.uses_flat_scratch, or(0, .LG_PlayerReborn.uses_flat_scratch, .LP_SetThingPosition.uses_flat_scratch, .LP_SetupPsprites.uses_flat_scratch, .LHU_Start.uses_flat_scratch)
+; CHECK: .set .LP_SpawnPlayer.has_dyn_sized_stack, or(0, .LG_PlayerReborn.has_dyn_sized_stack, .LP_SetThingPosition.has_dyn_sized_stack, .LP_SetupPsprites.has_dyn_sized_stack, .LHU_Start.has_dyn_sized_stack)
+; CHECK: .set .LP_SpawnPlayer.has_recursion, or(1, .LG_PlayerReborn.has_recursion, .LP_SetThingPosition.has_recursion, .LP_SetupPsprites.has_recursion, .LHU_Start.has_recursion)
+; CHECK: .set .LP_SpawnPlayer.has_indirect_call, or(0, .LG_PlayerReborn.has_indirect_call, .LP_SetThingPosition.has_indirect_call, .LP_SetupPsprites.has_indirect_call, .LHU_Start.has_indirect_call)
 define void @P_SpawnPlayer() {
   call void @G_PlayerReborn()
   call void @P_SetThingPosition()
@@ -126,15 +126,15 @@ define void @P_SpawnPlayer() {
 }
 
 ; CHECK-LABEL: I_Error:
-; CHECK: .set I_Error.num_vgpr, max(41, amdgpu.max_num_vgpr)
-; CHECK: .set I_Error.num_agpr, max(0, amdgpu.max_num_agpr)
-; CHECK: .set I_Error.numbered_sgpr, max(56, amdgpu.max_num_sgpr)
-; CHECK: .set I_Error.private_seg_size, 16
-; CHECK: .set I_Error.uses_vcc, 1
-; CHECK: .set I_Error.uses_flat_scratch, 1
-; CHECK: .set I_Error.has_dyn_sized_stack, 1
-; CHECK: .set I_Error.has_recursion, 1
-; CHECK: .set I_Error.has_indirect_call, 1
+; CHECK: .set .LI_Error.num_vgpr, max(41, amdgpu.max_num_vgpr)
+; CHECK: .set .LI_Error.num_agpr, max(0, amdgpu.max_num_agpr)
+; CHECK: .set .LI_Error.numbered_sgpr, max(56, amdgpu.max_num_sgpr)
+; CHECK: .set .LI_Error.private_seg_size, 16
+; CHECK: .set .LI_Error.uses_vcc, 1
+; CHECK: .set .LI_Error.uses_flat_scratch, 1
+; CHECK: .set .LI_Error.has_dyn_sized_stack, 1
+; CHECK: .set .LI_Error.has_recursion, 1
+; CHECK: .set .LI_Error.has_indirect_call, 1
 define void @I_Error(...) {
   %fptr = load ptr, ptr null, align 8
   call void %fptr()
@@ -142,15 +142,15 @@ define void @I_Error(...) {
 }
 
 ; CHECK-LABEL: G_DoReborn:
-; CHECK: .set G_DoReborn.num_vgpr, max(44, P_RemoveMobj.num_vgpr, P_SpawnMobj.num_vgpr, P_SpawnPlayer.num_vgpr, I_Error.num_vgpr)
-; CHECK: .set G_DoReborn.num_agpr, max(0, P_RemoveMobj.num_agpr, P_SpawnMobj.num_agpr, P_SpawnPlayer.num_agpr, I_Error.num_agpr)
-; CHECK: .set G_DoReborn.numbered_sgpr, max(104, P_RemoveMobj.numbered_sgpr, P_SpawnMobj.numbered_sgpr, P_SpawnPlayer.numbered_sgpr, I_Error.numbered_sgpr)
-; CHECK: .set G_DoReborn.private_seg_size, 32+max(P_RemoveMobj.private_seg_size, P_SpawnMobj.private_seg_size, P_SpawnPlayer.private_seg_size, I_Error.private_seg_size)
-; CHECK: .set G_DoReborn.uses_vcc, or(1, P_RemoveMobj.uses_vcc, P_SpawnMobj.uses_vcc, P_SpawnPlayer.uses_vcc, I_Error.uses_vcc)
-; CHECK: .set G_DoReborn.uses_flat_scratch, or(0, P_RemoveMobj.uses_flat_scratch, P_SpawnMobj.uses_flat_scratch, P_SpawnPlayer.uses_flat_scratch, I_Error.uses_flat_scratch)
-; CHECK: .set G_DoReborn.has_dyn_sized_stack, or(0, P_RemoveMobj.has_dyn_sized_stack, P_SpawnMobj.has_dyn_sized_stack, P_SpawnPlayer.has_dyn_sized_stack, I_Error.has_dyn_sized_stack)
-; CHECK: .set G_DoReborn.has_recursion, or(1, P_RemoveMobj.has_recursion, P_SpawnMobj.has_recursion, P_SpawnPlayer.has_recursion, I_Error.has_recursion)
-; CHECK: .set G_DoReborn.has_indirect_call, or(0, P_RemoveMobj.has_indirect_call, P_SpawnMobj.has_indirect_call, P_SpawnPlayer.has_indirect_call, I_Error.has_indirect_call)
+; CHECK: .set .LG_DoReborn.num_vgpr, max(44, .LP_RemoveMobj.num_vgpr, .LP_SpawnMobj.num_vgpr, .LP_SpawnPlayer.num_vgpr, .LI_Error.num_vgpr)
+; CHECK: .set .LG_DoReborn.num_agpr, max(0, .LP_RemoveMobj.num_agpr, .LP_SpawnMobj.num_agpr, .LP_SpawnPlayer.num_agpr, .LI_Error.num_agpr)
+; CHECK: .set .LG_DoReborn.numbered_sgpr, max(104, .LP_RemoveMobj.numbered_sgpr, .LP_SpawnMobj.numbered_sgpr, .LP_SpawnPlayer.numbered_sgpr, .LI_Error.numbered_sgpr)
+; CHECK: .set .LG_DoReborn.private_seg_size, 32+max(.LP_RemoveMobj.private_seg_size, .LP_SpawnMobj.private_seg_size, .LP_SpawnPlayer.private_seg_size, .LI_Error.private_seg_size)
+; CHECK: .set .LG_DoReborn.uses_vcc, or(1, .LP_RemoveMobj.uses_vcc, .LP_SpawnMobj.uses_vcc, .LP_SpawnPlayer.uses_vcc, .LI_Error.uses_vcc)
+; CHECK: .set .LG_DoReborn.uses_flat_scratch, or(0, .LP_RemoveMobj.uses_flat_scratch, .LP_SpawnMobj.uses_flat_scratch, .LP_SpawnPlayer.uses_flat_scratch, .LI_Error.uses_flat_scratch)
+; CHECK: .set .LG_DoReborn.has_dyn_sized_stack, or(0, .LP_RemoveMobj.has_dyn_sized_stack, .LP_SpawnMobj.has_dyn_sized_stack, .LP_SpawnPlayer.has_dyn_sized_stack, .LI_Error.has_dyn_sized_stack)
+; CHECK: .set .LG_DoReborn.has_recursion, or(1, .LP_RemoveMobj.has_recursion, .LP_SpawnMobj.has_recursion, .LP_SpawnPlayer.has_recursion, .LI_Error.has_recursion)
+; CHECK: .set .LG_DoReborn.has_indirect_call, or(0, .LP_RemoveMobj.has_indirect_call, .LP_SpawnMobj.has_indirect_call, .LP_SpawnPlayer.has_indirect_call, .LI_Error.has_indirect_call)
 define void @G_DoReborn() {
   call void @P_RemoveMobj()
   call void @P_SpawnMobj()
@@ -160,71 +160,71 @@ define void @G_DoReborn() {
 }
 
 ; CHECK-LABEL: AM_Stop:
-; CHECK: .set AM_Stop.num_vgpr, 0
-; CHECK: .set AM_Stop.num_agpr, 0
-; CHECK: .set AM_Stop.numbered_sgpr, 32
-; CHECK: .set AM_Stop.private_seg_size, 0
-; CHECK: .set AM_Stop.uses_vcc, 0
-; CHECK: .set AM_Stop.uses_flat_scratch, 0
-; CHECK: .set AM_Stop.has_dyn_sized_stack, 0
-; CHECK: .set AM_Stop.has_recursion, 0
-; CHECK: .set AM_Stop.has_indirect_call, 0
+; CHECK: .set .LAM_Stop.num_vgpr, 0
+; CHECK: .set .LAM_Stop.num_agpr, 0
+; CHECK: .set .LAM_Stop.numbered_sgpr, 32
+; CHECK: .set .LAM_Stop.private_seg_size, 0
+; CHECK: .set .LAM_Stop.uses_vcc, 0
+; CHECK: .set .LAM_Stop.uses_flat_scratch, 0
+; CHECK: .set .LAM_Stop.has_dyn_sized_stack, 0
+; CHECK: .set .LAM_Stop.has_recursion, 0
+; CHECK: .set .LAM_Stop.has_indirect_call, 0
 define void @AM_Stop() {
   ret void
 }
 
 ; CHECK-LABEL: D_AdvanceDemo:
-; CHECK: .set D_AdvanceDemo.num_vgpr, 0
-; CHECK: .set D_AdvanceDemo.num_agpr, 0
-; CHECK: .set D_AdvanceDemo.numbered_sgpr, 32
-; CHECK: .set D_AdvanceDemo.private_seg_size, 0
-; CHECK: .set D_AdvanceDemo.uses_vcc, 0
-; CHECK: .set D_AdvanceDemo.uses_flat_scratch, 0
-; CHECK: .set D_AdvanceDemo.has_dyn_sized_stack, 0
-; CHECK: .set D_AdvanceDemo.has_recursion, 0
-; CHECK: .set D_AdvanceDemo.has_indirect_call, 0
+; CHECK: .set .LD_AdvanceDemo.num_vgpr, 0
+; CHECK: .set .LD_AdvanceDemo.num_agpr, 0
+; CHECK: .set .LD_AdvanceDemo.numbered_sgpr, 32
+; CHECK: .set .LD_AdvanceDemo.private_seg_size, 0
+; CHECK: .set .LD_AdvanceDemo.uses_vcc, 0
+; CHECK: .set .LD_AdvanceDemo.uses_flat_scratch, 0
+; CHECK: .set .LD_AdvanceDemo.has_dyn_sized_stack, 0
+; CHECK: .set .LD_AdvanceDemo.has_recursion, 0
+; CHECK: .set .LD_AdvanceDemo.has_indirect_call, 0
 define void @D_AdvanceDemo() {
   ret void
 }
 
 ; CHECK-LABEL: F_StartFinale:
-; CHECK: .set F_StartFinale.num_vgpr, 0
-; CHECK: .set F_StartFinale.num_agpr, 0
-; CHECK: .set F_StartFinale.numbered_sgpr, 32
-; CHECK: .set F_StartFinale.private_seg_size, 0
-; CHECK: .set F_StartFinale.uses_vcc, 0
-; CHECK: .set F_StartFinale.uses_flat_scratch, 0
-; CHECK: .set F_StartFinale.has_dyn_sized_stack, 0
-; CHECK: .set F_StartFinale.has_recursion, 0
-; CHECK: .set F_StartFinale.has_indirect_call, 0
+; CHECK: .set .LF_StartFinale.num_vgpr, 0
+; CHECK: .set .LF_StartFinale.num_agpr, 0
+; CHECK: .set .LF_StartFinale.numbered_sgpr, 32
+; CHECK: .set .LF_StartFinale.private_seg_size, 0
+; CHECK: .set .LF_StartFinale.uses_vcc, 0
+; CHECK: .set .LF_StartFinale.uses_flat_scratch, 0
+; CHECK: .set .LF_StartFinale.has_dyn_sized_stack, 0
+; CHECK: .set .LF_StartFinale.has_recursion, 0
+; CHECK: .set .LF_StartFinale.has_indirect_call, 0
 define void @F_StartFinale() {
   ret void
 }
 
 ; CHECK-LABEL: F_Ticker:
-; CHECK: .set F_Ticker.num_vgpr, 0
-; CHECK: .set F_Ticker.num_agpr, 0
-; CHECK: .set F_Ticker.numbered_sgpr, 32
-; CHECK: .set F_Ticker.private_seg_size, 0
-; CHECK: .set F_Ticker.uses_vcc, 0
-; CHECK: .set F_Ticker.uses_flat_scratch, 0
-; CHECK: .set F_Ticker.has_dyn_sized_stack, 0
-; CHECK: .set F_Ticker.has_recursion, 0
-; CHECK: .set F_Ticker.has_indirect_call, 0
+; CHECK: .set .LF_Ticker.num_vgpr, 0
+; CHECK: .set .LF_Ticker.num_agpr, 0
+; CHECK: .set .LF_Ticker.numbered_sgpr, 32
+; CHECK: .set .LF_Ticker.private_seg_size, 0
+; CHECK: .set .LF_Ticker.uses_vcc, 0
+; CHECK: .set .LF_Ticker.uses_flat_scratch, 0
+; CHECK: .set .LF_Ticker.has_dyn_sized_stack, 0
+; CHECK: .set .LF_Ticker.has_recursion, 0
+; CHECK: .set .LF_Ticker.has_indirect_call, 0
 define void @F_Ticker() {
   ret void
 }
 
 ; CHECK-LABEL: G_CheckDemoStatus:
-; CHECK: .set G_CheckDemoStatus.num_vgpr, max(43, I_Quit.num_vgpr, D_AdvanceDemo.num_vgpr, I_Error.num_vgpr)
-; CHECK: .set G_CheckDemoStatus.num_agpr, max(0, I_Quit.num_agpr, D_AdvanceDemo.num_agpr, I_Error.num_agpr)
-; CHECK: .set G_CheckDemoStatus.numbered_sgpr, max(84, I_Quit.numbered_sgpr, D_AdvanceDemo.numbered_sgpr, I_Error.numbered_sgpr)
-; CHECK: .set G_CheckDemoStatus.private_seg_size, 32+max(I_Quit.private_seg_size, D_AdvanceDemo.private_seg_size, I_Error.private_seg_size)
-; CHECK: .set G_CheckDemoStatus.uses_vcc, or(1, I_Quit.uses_vcc, D_AdvanceDemo.uses_vcc, I_Error.uses_vcc)
-; CHECK: .set G_CheckDemoStatus.uses_flat_scratch, or(0, I_Quit.uses_flat_scratch, D_AdvanceDemo.uses_flat_scratch, I_Error.uses_flat_scratch)
-; CHECK: .set G_CheckDemoStatus.has_dyn_sized_stack, or(0, I_Quit.has_dyn_sized_stack, D_AdvanceDemo.has_dyn_sized_stack, I_Error.has_dyn_sized_stack)
-; CHECK: .set G_CheckDemoStatus.has_recursion, or(1, I_Quit.has_recursion, D_AdvanceDemo.has_recursion, I_Error.has_recursion)
-; CHECK: .set G_CheckDemoStatus.has_indirect_call, or(0, I_Quit.has_indirect_call, D_AdvanceDemo.has_indirect_call, I_Error.has_indirect_call)
+; CHECK: .set .LG_CheckDemoStatus.num_vgpr, max(43, .LI_Quit.num_vgpr, .LD_AdvanceDemo.num_vgpr, .LI_Error.num_vgpr)
+; CHECK: .set .LG_CheckDemoStatus.num_agpr, max(0, .LI_Quit.num_agpr, .LD_AdvanceDemo.num_agpr, .LI_Error.num_agpr)
+; CHECK: .set .LG_CheckDemoStatus.numbered_sgpr, max(84, .LI_Quit.numbered_sgpr, .LD_AdvanceDemo.numbered_sgpr, .LI_Error.numbered_sgpr)
+; CHECK: .set .LG_CheckDemoStatus.private_seg_size, 32+max(.LI_Quit.private_seg_size, .LD_AdvanceDemo.private_seg_size, .LI_Error.private_seg_size)
+; CHECK: .set .LG_CheckDemoStatus.uses_vcc, or(1, .LI_Quit.uses_vcc, .LD_AdvanceDemo.uses_vcc, .LI_Error.uses_vcc)
+; CHECK: .set .LG_CheckDemoStatus.uses_flat_scratch, or(0, .LI_Quit.uses_flat_scratch, .LD_AdvanceDemo.uses_flat_scratch, .LI_Error.uses_flat_scratch)
+; CHECK: .set .LG_CheckDemoStatus.has_dyn_sized_stack, or(0, .LI_Quit.has_dyn_sized_stack, .LD_AdvanceDemo.has_dyn_sized_stack, .LI_Error.has_dyn_sized_stack)
+; CHECK: .set .LG_CheckDemoStatus.has_recursion, or(1, .LI_Quit.has_recursion, .LD_AdvanceDemo.has_recursion, .LI_Error.has_recursion)
+; CHECK: .set .LG_CheckDemoStatus.has_indirect_call, or(0, .LI_Quit.has_indirect_call, .LD_AdvanceDemo.has_indirect_call, .LI_Error.has_indirect_call)
 define i32 @G_CheckDemoStatus() {
   tail call void @I_Quit()
   tail call void @D_AdvanceDemo()
@@ -234,73 +234,73 @@ define i32 @G_CheckDemoStatus() {
 
 
 ; CHECK-LABEL: P_TempSaveGameFile:
-; CHECK: .set P_TempSaveGameFile.num_vgpr, 2
-; CHECK: .set P_TempSaveGameFile.num_agpr, 0
-; CHECK: .set P_TempSaveGameFile.numbered_sgpr, 32
-; CHECK: .set P_TempSaveGameFile.private_seg_size, 0
-; CHECK: .set P_TempSaveGameFile.uses_vcc, 0
-; CHECK: .set P_TempSaveGameFile.uses_flat_scratch, 0
-; CHECK: .set P_TempSaveGameFile.has_dyn_sized_stack, 0
-; CHECK: .set P_TempSaveGameFile.has_recursion, 0
-; CHECK: .set P_TempSaveGameFile.has_indirect_call, 0
+; CHECK: .set .LP_TempSaveGameFile.num_vgpr, 2
+; CHECK: .set .LP_TempSaveGameFile.num_agpr, 0
+; CHECK: .set .LP_TempSaveGameFile.numbered_sgpr, 32
+; CHECK: .set .LP_TempSaveGameFile.private_seg_size, 0
+; CHECK: .set .LP_TempSaveGameFile.uses_vcc, 0
+; CHECK: .set .LP_TempSaveGameFile.uses_flat_scratch, 0
+; CHECK: .set .LP_TempSaveGameFile.has_dyn_sized_stack, 0
+; CHECK: .set .LP_TempSaveGameFile.has_recursion, 0
+; CHECK: .set .LP_TempSaveGameFile.has_indirect_call, 0
 define ptr @P_TempSaveGameFile() {
   ret ptr null
 }
 
 ; CHECK-LABEL: P_SaveGameFile:
-; CHECK: .set P_SaveGameFile.num_vgpr, 2
-; CHECK: .set P_SaveGameFile.num_agpr, 0
-; CHECK: .set P_SaveGameFile.numbered_sgpr, 32
-; CHECK: .set P_SaveGameFile.private_seg_size, 0
-; CHECK: .set P_SaveGameFile.uses_vcc, 0
-; CHECK: .set P_SaveGameFile.uses_flat_scratch, 0
-; CHECK: .set P_SaveGameFile.has_dyn_sized_stack, 0
-; CHECK: .set P_SaveGameFile.has_recursion, 0
-; CHECK: .set P_SaveGameFile.has_indirect_call, 0
+; CHECK: .set .LP_SaveGameFile.num_vgpr, 2
+; CHECK: .set .LP_SaveGameFile.num_agpr, 0
+; CHECK: .set .LP_SaveGameFile.numbered_sgpr, 32
+; CHECK: .set .LP_SaveGameFile.private_seg_size, 0
+; CHECK: .set .LP_SaveGameFile.uses_vcc, 0
+; CHECK: .set .LP_SaveGameFile.uses_flat_scratch, 0
+; CHECK: .set .LP_SaveGameFile.has_dyn_sized_stack, 0
+; CHECK: .set .LP_SaveGameFile.has_recursion, 0
+; CHECK: .set .LP_SaveGameFile.has_indirect_call, 0
 define ptr @P_SaveGameFile() {
   ret ptr null
 }
 
 ; CHECK-LABEL: R_FlatNumForName:
-; CHECK: .set R_FlatNumForName.num_vgpr, max(42, I_Error.num_vgpr)
-; CHECK: .set R_FlatNumForName.num_agpr, max(0, I_Error.num_agpr)
-; CHECK: .set R_FlatNumForName.numbered_sgpr, max(56, I_Error.numbered_sgpr)
-; CHECK: .set R_FlatNumForName.private_seg_size, 16+max(I_Error.private_seg_size)
-; CHECK: .set R_FlatNumForName.uses_vcc, or(1, I_Error.uses_vcc)
-; CHECK: .set R_FlatNumForName.uses_flat_scratch, or(0, I_Error.uses_flat_scratch)
-; CHECK: .set R_FlatNumForName.has_dyn_sized_stack, or(0, I_Error.has_dyn_sized_stack)
-; CHECK: .set R_FlatNumForName.has_recursion, or(1, I_Error.has_recursion)
-; CHECK: .set R_FlatNumForName.has_indirect_call, or(0, I_Error.has_indirect_call)
+; CHECK: .set .LR_FlatNumForName.num_vgpr, max(42, .LI_Error.num_vgpr)
+; CHECK: .set .LR_FlatNumForName.num_agpr, max(0, .LI_Error.num_agpr)
+; CHECK: .set .LR_FlatNumForName.numbered_sgpr, max(56, .LI_Error.numbered_sgpr)
+; CHECK: .set .LR_FlatNumForName.private_seg_size, 16+max(.LI_Error.private_seg_size)
+; CHECK: .set .LR_FlatNumForName.uses_vcc, or(1, .LI_Error.uses_vcc)
+; CHECK: .set .LR_FlatNumForName.uses_flat_scratch, or(0, .LI_Error.uses_flat_scratch)
+; CHECK: .set .LR_FlatNumForName.has_dyn_sized_stack, or(0, .LI_Error.has_dyn_sized_stack)
+; CHECK: .set .LR_FlatNumForName.has_recursion, or(1, .LI_Error.has_recursion)
+; CHECK: .set .LR_FlatNumForName.has_indirect_call, or(0, .LI_Error.has_indirect_call)
 define i32 @R_FlatNumForName() {
   call void (...) @I_Error()
   unreachable
 }
 
 ; CHECK-LABEL: R_TextureNumForName:
-; CHECK: .set R_TextureNumForName.num_vgpr, max(42, R_FlatNumForName.num_vgpr)
-; CHECK: .set R_TextureNumForName.num_agpr, max(0, R_FlatNumForName.num_agpr)
-; CHECK: .set R_TextureNumForName.numbered_sgpr, max(56, R_FlatNumForName.numbered_sgpr)
-; CHECK: .set R_TextureNumForName.private_seg_size, 16+max(R_FlatNumForName.private_seg_size)
-; CHECK: .set R_TextureNumForName.uses_vcc, or(1, R_FlatNumForName.uses_vcc)
-; CHECK: .set R_TextureNumForName.uses_flat_scratch, or(0, R_FlatNumForName.uses_flat_scratch)
-; CHECK: .set R_TextureNumForName.has_dyn_sized_stack, or(0, R_FlatNumForName.has_dyn_sized_stack)
-; CHECK: .set R_TextureNumForName.has_recursion, or(1, R_FlatNumForName.has_recursion)
-; CHECK: .set R_TextureNumForName.has_indirect_call, or(0, R_FlatNumForName.has_indirect_call)
+; CHECK: .set .LR_TextureNumForName.num_vgpr, max(42, .LR_FlatNumForName.num_vgpr)
+; CHECK: .set .LR_TextureNumForName.num_agpr, max(0, .LR_FlatNumForName.num_agpr)
+; CHECK: .set .LR_TextureNumForName.numbered_sgpr, max(56, .LR_FlatNumForName.numbered_sgpr)
+; CHECK: .set .LR_TextureNumForName.private_seg_size, 16+max(.LR_FlatNumForName.private_seg_size)
+; CHECK: .set .LR_TextureNumForName.uses_vcc, or(1, .LR_FlatNumForName.uses_vcc)
+; CHECK: .set .LR_TextureNumForName.uses_flat_scratch, or(0, .LR_FlatNumForName.uses_flat_scratch)
+; CHECK: .set .LR_TextureNumForName.has_dyn_sized_stack, or(0, .LR_FlatNumForName.has_dyn_sized_stack)
+; CHECK: .set .LR_TextureNumForName.has_recursion, or(1, .LR_FlatNumForName.has_recursion)
+; CHECK: .set .LR_TextureNumForName.has_indirect_call, or(0, .LR_FlatNumForName.has_indirect_call)
 define i32 @R_TextureNumForName() {
   %ret = call i32 @R_FlatNumForName()
   ret i32 0
 }
 
 ; CHECK-LABEL: G_Ticker:
-; CHECK: .set G_Ticker.num_vgpr, max(47, G_DoReborn.num_vgpr, F_Ticker.num_vgpr, AM_Stop.num_vgpr, F_StartFinale.num_vgpr, D_AdvanceDemo.num_vgpr, R_FlatNumForName.num_vgpr, R_TextureNumForName.num_vgpr, P_TempSaveGameFile.num_vgpr, P_SaveGameFile.num_vgpr, I_Error.num_vgpr)
-; CHECK: .set G_Ticker.num_agpr, max(0, G_DoReborn.num_agpr, F_Ticker.num_agpr, AM_Stop.num_agpr, F_StartFinale.num_agpr, D_AdvanceDemo.num_agpr, R_FlatNumForName.num_agpr, R_TextureNumForName.num_agpr, P_TempSaveGameFile.num_agpr, P_SaveGameFile.num_agpr, I_Error.num_agpr)
-; CHECK: .set G_Ticker.numbered_sgpr, max(105, G_DoReborn.numbered_sgpr, F_Ticker.numbered_sgpr, AM_Stop.numbered_sgpr, F_StartFinale.numbered_sgpr, D_AdvanceDemo.numbered_sgpr, R_FlatNumForName.numbered_sgpr, R_TextureNumForName.numbered_sgpr, P_TempSaveGameFile.numbered_sgpr, P_SaveGameFile.numbered_sgpr, I_Error.numbered_sgpr)
-; CHECK: .set G_Ticker.private_seg_size, 48+max(G_DoReborn.private_seg_size, F_Ticker.private_seg_size, AM_Stop.private_seg_size, F_StartFinale.private_seg_size, D_AdvanceDemo.private_seg_size, R_FlatNumForName.private_seg_size, R_TextureNumForName.private_seg_size, P_TempSaveGameFile.private_seg_size, P_SaveGameFile.private_seg_size, I_Error.private_seg_size)
-; CHECK: .set G_Ticker.uses_vcc, or(1, G_DoReborn.uses_vcc, F_Ticker.uses_vcc, AM_Stop.uses_vcc, F_StartFinale.uses_vcc, D_AdvanceDemo.uses_vcc, R_FlatNumForName.uses_vcc, R_TextureNumForName.uses_vcc, P_TempSaveGameFile.uses_vcc, P_SaveGameFile.uses_vcc, I_Error.uses_vcc)
-; CHECK: .set G_Ticker.uses_flat_scratch, or(0, G_DoReborn.uses_flat_scratch, F_Ticker.uses_flat_scratch, AM_Stop.uses_flat_scratch, F_StartFinale.uses_flat_scratch, D_AdvanceDemo.uses_flat_scratch, R_FlatNumForName.uses_flat_scratch, R_TextureNumForName.uses_flat_scratch, P_TempSaveGameFile.uses_flat_scratch, P_SaveGameFile.uses_flat_scratch, I_Error.uses_flat_scratch)
-; CHECK: .set G_Ticker.has_dyn_sized_stack, or(0, G_DoReborn.has_dyn_sized_stack, F_Ticker.has_dyn_sized_stack, AM_Stop.has_dyn_sized_stack, F_StartFinale.has_dyn_sized_stack, D_AdvanceDemo.has_dyn_sized_stack, R_FlatNumForName.has_dyn_sized_stack, R_TextureNumForName.has_dyn_sized_stack, P_TempSaveGameFile.has_dyn_sized_stack, P_SaveGameFile.has_dyn_sized_stack, I_Error.has_dyn_sized_stack)
-; CHECK: .set G_Ticker.has_recursion, or(1, G_DoReborn.has_recursion, F_Ticker.has_recursion, AM_Stop.has_recursion, F_StartFinale.has_recursion, D_AdvanceDemo.has_recursion, R_FlatNumForName.has_recursion, R_TextureNumForName.has_recursion, P_TempSaveGameFile.has_recursion, P_SaveGameFile.has_recursion, I_Error.has_recursion)
-; CHECK: .set G_Ticker.has_indirect_call, or(0, G_DoReborn.has_indirect_call, F_Ticker.has_indirect_call, AM_Stop.has_indirect_call, F_StartFinale.has_indirect_call, D_AdvanceDemo.has_indirect_call, R_FlatNumForName.has_indirect_call, R_TextureNumForName.has_indirect_call, P_TempSaveGameFile.has_indirect_call, P_SaveGameFile.has_indirect_call, I_Error.has_indirect_call)
+; CHECK: .set .LG_Ticker.num_vgpr, max(47, .LG_DoReborn.num_vgpr, .LF_Ticker.num_vgpr, .LAM_Stop.num_vgpr, .LF_StartFinale.num_vgpr, .LD_AdvanceDemo.num_vgpr, .LR_FlatNumForName.num_vgpr, .LR_TextureNumForName.num_vgpr, .LP_TempSaveGameFile.num_vgpr, .LP_SaveGameFile.num_vgpr, .LI_Error.num_vgpr)
+; CHECK: .set .LG_Ticker.num_agpr, max(0, .LG_DoReborn.num_agpr, .LF_Ticker.num_agpr, .LAM_Stop.num_agpr, .LF_StartFinale.num_agpr, .LD_AdvanceDemo.num_agpr, .LR_FlatNumForName.num_agpr, .LR_TextureNumForName.num_agpr, .LP_TempSaveGameFile.num_agpr, .LP_SaveGameFile.num_agpr, .LI_Error.num_agpr)
+; CHECK: .set .LG_Ticker.numbered_sgpr, max(105, .LG_DoReborn.numbered_sgpr, .LF_Ticker.numbered_sgpr, .LAM_Stop.numbered_sgpr, .LF_StartFinale.numbered_sgpr, .LD_AdvanceDemo.numbered_sgpr, .LR_FlatNumForName.numbered_sgpr, .LR_TextureNumForName.numbered_sgpr, .LP_TempSaveGameFile.numbered_sgpr, .LP_SaveGameFile.numbered_sgpr, .LI_Error.numbered_sgpr)
+; CHECK: .set .LG_Ticker.private_seg_size, 48+max(.LG_DoReborn.private_seg_size, .LF_Ticker.private_seg_size, .LAM_Stop.private_seg_size, .LF_StartFinale.private_seg_size, .LD_AdvanceDemo.private_seg_size, .LR_FlatNumForName.private_seg_size, .LR_TextureNumForName.private_seg_size, .LP_TempSaveGameFile.private_seg_size, .LP_SaveGameFile.private_seg_size, .LI_Error.private_seg_size)
+; CHECK: .set .LG_Ticker.uses_vcc, or(1, .LG_DoReborn.uses_vcc, .LF_Ticker.uses_vcc, .LAM_Stop.uses_vcc, .LF_StartFinale.uses_vcc, .LD_AdvanceDemo.uses_vcc, .LR_FlatNumForName.uses_vcc, .LR_TextureNumForName.uses_vcc, .LP_TempSaveGameFile.uses_vcc, .LP_SaveGameFile.uses_vcc, .LI_Error.uses_vcc)
+; CHECK: .set .LG_Ticker.uses_flat_scratch, or(0, .LG_DoReborn.uses_flat_scratch, .LF_Ticker.uses_flat_scratch, .LAM_Stop.uses_flat_scratch, .LF_StartFinale.uses_flat_scratch, .LD_AdvanceDemo.uses_flat_scratch, .LR_FlatNumForName.uses_flat_scratch, .LR_TextureNumForName.uses_flat_scratch, .LP_TempSaveGameFile.uses_flat_scratch, .LP_SaveGameFile.uses_flat_scratch, .LI_Error.uses_flat_scratch)
+; CHECK: .set .LG_Ticker.has_dyn_sized_stack, or(0, .LG_DoReborn.has_dyn_sized_stack, .LF_Ticker.has_dyn_sized_stack, .LAM_Stop.has_dyn_sized_stack, .LF_StartFinale.has_dyn_sized_stack, .LD_AdvanceDemo.has_dyn_sized_stack, .LR_FlatNumForName.has_dyn_sized_stack, .LR_TextureNumForName.has_dyn_sized_stack, .LP_TempSaveGameFile.has_dyn_sized_stack, .LP_SaveGameFile.has_dyn_sized_stack, .LI_Error.has_dyn_sized_stack)
+; CHECK: .set .LG_Ticker.has_recursion, or(1, .LG_DoReborn.has_recursion, .LF_Ticker.has_recursion, .LAM_Stop.has_recursion, .LF_StartFinale.has_recursion, .LD_AdvanceDemo.has_recursion, .LR_FlatNumForName.has_recursion, .LR_TextureNumForName.has_recursion, .LP_TempSaveGameFile.has_recursion, .LP_SaveGameFile.has_recursion, .LI_Error.has_recursion)
+; CHECK: .set .LG_Ticker.has_indirect_call, or(0, .LG_DoReborn.has_indirect_call, .LF_Ticker.has_indirect_call, .LAM_Stop.has_indirect_call, .LF_StartFinale.has_indirect_call, .LD_AdvanceDemo.has_indirect_call, .LR_FlatNumForName.has_indirect_call, .LR_TextureNumForName.has_indirect_call, .LP_TempSaveGameFile.has_indirect_call, .LP_SaveGameFile.has_indirect_call, .LI_Error.has_indirect_call)
 define void @G_Ticker() {
   call void @G_DoReborn()
   tail call void @F_Ticker()
@@ -316,15 +316,15 @@ define void @G_Ticker() {
 }
 
 ; CHECK-LABEL: RunTic:
-; CHECK: .set RunTic.num_vgpr, max(47, G_CheckDemoStatus.num_vgpr, D_AdvanceDemo.num_vgpr, G_Ticker.num_vgpr)
-; CHECK: .set RunTic.num_agpr, max(0, G_CheckDemoStatus.num_agpr, D_AdvanceDemo.num_agpr, G_Ticker.num_agpr)
-; CHECK: .set RunTic.numbered_sgpr, max(105, G_CheckDemoStatus.numbered_sgpr, D_AdvanceDemo.numbered_sgpr, G_Ticker.numbered_sgpr)
-; CHECK: .set RunTic.private_seg_size, 32+max(G_CheckDemoStatus.private_seg_size, D_AdvanceDemo.private_seg_size, G_Ticker.private_seg_size)
-; CHECK: .set RunTic.uses_vcc, or(1, G_CheckDemoStatus.uses_vcc, D_AdvanceDemo.uses_vcc, G_Ticker.uses_vcc)
-; CHECK: .set RunTic.uses_flat_scratch, or(0, G_CheckDemoStatus.uses_flat_scratch, D_AdvanceDemo.uses_flat_scratch, G_Ticker.uses_flat_scratch)
-; CHECK: .set RunTic.has_dyn_sized_stack, or(0, G_CheckDemoStatus.has_dyn_sized_stack, D_AdvanceDemo.has_dyn_sized_stack, G_Ticker.has_dyn_sized_stack)
-; CHECK: .set RunTic.has_recursion, or(1, G_CheckDemoStatus.has_recursion, D_AdvanceDemo.has_recursion, G_Ticker.has_recursion)
-; CHECK: .set RunTic.has_indirect_call, or(0, G_CheckDemoStatus.has_indirect_call, D_AdvanceDemo.has_indirect_call, G_Ticker.has_indirect_call)
+; CHECK: .set .LRunTic.num_vgpr, max(47, .LG_CheckDemoStatus.num_vgpr, .LD_AdvanceDemo.num_vgpr, .LG_Ticker.num_vgpr)
+; CHECK: .set .LRunTic.num_agpr, max(0, .LG_CheckDemoStatus.num_agpr, .LD_AdvanceDemo.num_agpr, .LG_Ticker.num_agpr)
+; CHECK: .set .LRunTic.numbered_sgpr, max(105, .LG_CheckDemoStatus.numbered_sgpr, .LD_AdvanceDemo.numbered_sgpr, .LG_Ticker.numbered_sgpr)
+; CHECK: .set .LRunTic.private_seg_size, 32+max(.LG_CheckDemoStatus.private_seg_size, .LD_AdvanceDemo.private_seg_size, .LG_Ticker.private_seg_size)
+; CHECK: .set .LRunTic.uses_vcc, or(1, .LG_CheckDemoStatus.uses_vcc, .LD_AdvanceDemo.uses_vcc, .LG_Ticker.uses_vcc)
+; CHECK: .set .LRunTic.uses_flat_scratch, or(0, .LG_CheckDemoStatus.uses_flat_scratch, .LD_AdvanceDemo.uses_flat_scratch, .LG_Ticker.uses_flat_scratch)
+; CHECK: .set .LRunTic.has_dyn_sized_stack, or(0, .LG_CheckDemoStatus.has_dyn_sized_stack, .LD_AdvanceDemo.has_dyn_sized_stack, .LG_Ticker.has_dyn_sized_stack)
+; CHECK: .set .LRunTic.has_recursion, or(1, .LG_CheckDemoStatus.has_recursion, .LD_AdvanceDemo.has_recursion, .LG_Ticker.has_recursion)
+; CHECK: .set .LRunTic.has_indirect_call, or(0, .LG_CheckDemoStatus.has_indirect_call, .LD_AdvanceDemo.has_indirect_call, .LG_Ticker.has_indirect_call)
 define void @RunTic() {
   %call5.i1 = call i32 @G_CheckDemoStatus()
   tail call void @D_AdvanceDemo()

--- a/llvm/test/CodeGen/AMDGPU/multi-call-resource-usage-mcexpr.ll
+++ b/llvm/test/CodeGen/AMDGPU/multi-call-resource-usage-mcexpr.ll
@@ -1,4 +1,4 @@
-; RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx90a < %s | FileCheck %s
+; RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx90a -amdgpu-localize-resource-symbols=false < %s | FileCheck %s
 
 ; CHECK-LABEL: {{^}}qux
 ; CHECK: .set qux.num_vgpr, 13

--- a/llvm/test/CodeGen/AMDGPU/multi-call-resource-usage-mcexpr.ll
+++ b/llvm/test/CodeGen/AMDGPU/multi-call-resource-usage-mcexpr.ll
@@ -1,15 +1,15 @@
-; RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx90a -amdgpu-localize-resource-symbols=false < %s | FileCheck %s
+; RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx90a < %s | FileCheck %s
 
 ; CHECK-LABEL: {{^}}qux
-; CHECK: .set qux.num_vgpr, 13
-; CHECK: .set qux.num_agpr, 0
-; CHECK: .set qux.numbered_sgpr, 32
-; CHECK: .set qux.private_seg_size, 0
-; CHECK: .set qux.uses_vcc, 0
-; CHECK: .set qux.uses_flat_scratch, 0
-; CHECK: .set qux.has_dyn_sized_stack, 0
-; CHECK: .set qux.has_recursion, 0
-; CHECK: .set qux.has_indirect_call, 0
+; CHECK: .set .Lqux.num_vgpr, 13
+; CHECK: .set .Lqux.num_agpr, 0
+; CHECK: .set .Lqux.numbered_sgpr, 32
+; CHECK: .set .Lqux.private_seg_size, 0
+; CHECK: .set .Lqux.uses_vcc, 0
+; CHECK: .set .Lqux.uses_flat_scratch, 0
+; CHECK: .set .Lqux.has_dyn_sized_stack, 0
+; CHECK: .set .Lqux.has_recursion, 0
+; CHECK: .set .Lqux.has_indirect_call, 0
 define void @qux() {
 entry:
   call void asm sideeffect "", "~{v12}"()
@@ -17,15 +17,15 @@ entry:
 }
 
 ; CHECK-LABEL: {{^}}baz
-; CHECK: .set baz.num_vgpr, max(49, qux.num_vgpr)
-; CHECK: .set baz.num_agpr, max(0, qux.num_agpr)
-; CHECK: .set baz.numbered_sgpr, max(34, qux.numbered_sgpr)
-; CHECK: .set baz.private_seg_size, 16+max(qux.private_seg_size)
-; CHECK: .set baz.uses_vcc, or(0, qux.uses_vcc)
-; CHECK: .set baz.uses_flat_scratch, or(0, qux.uses_flat_scratch)
-; CHECK: .set baz.has_dyn_sized_stack, or(0, qux.has_dyn_sized_stack)
-; CHECK: .set baz.has_recursion, or(1, qux.has_recursion)
-; CHECK: .set baz.has_indirect_call, or(0, qux.has_indirect_call)
+; CHECK: .set .Lbaz.num_vgpr, max(49, .Lqux.num_vgpr)
+; CHECK: .set .Lbaz.num_agpr, max(0, .Lqux.num_agpr)
+; CHECK: .set .Lbaz.numbered_sgpr, max(34, .Lqux.numbered_sgpr)
+; CHECK: .set .Lbaz.private_seg_size, 16+max(.Lqux.private_seg_size)
+; CHECK: .set .Lbaz.uses_vcc, or(0, .Lqux.uses_vcc)
+; CHECK: .set .Lbaz.uses_flat_scratch, or(0, .Lqux.uses_flat_scratch)
+; CHECK: .set .Lbaz.has_dyn_sized_stack, or(0, .Lqux.has_dyn_sized_stack)
+; CHECK: .set .Lbaz.has_recursion, or(1, .Lqux.has_recursion)
+; CHECK: .set .Lbaz.has_indirect_call, or(0, .Lqux.has_indirect_call)
 define void @baz() {
 entry:
   call void @qux()
@@ -34,15 +34,15 @@ entry:
 }
 
 ; CHECK-LABEL: {{^}}bar
-; CHECK: .set bar.num_vgpr, max(65, baz.num_vgpr, qux.num_vgpr)
-; CHECK: .set bar.num_agpr, max(0, baz.num_agpr, qux.num_agpr)
-; CHECK: .set bar.numbered_sgpr, max(34, baz.numbered_sgpr, qux.numbered_sgpr)
-; CHECK: .set bar.private_seg_size, 16+max(baz.private_seg_size, qux.private_seg_size)
-; CHECK: .set bar.uses_vcc, or(0, baz.uses_vcc, qux.uses_vcc)
-; CHECK: .set bar.uses_flat_scratch, or(0, baz.uses_flat_scratch, qux.uses_flat_scratch)
-; CHECK: .set bar.has_dyn_sized_stack, or(0, baz.has_dyn_sized_stack, qux.has_dyn_sized_stack)
-; CHECK: .set bar.has_recursion, or(1, baz.has_recursion, qux.has_recursion)
-; CHECK: .set bar.has_indirect_call, or(0, baz.has_indirect_call, qux.has_indirect_call)
+; CHECK: .set .Lbar.num_vgpr, max(65, .Lbaz.num_vgpr, .Lqux.num_vgpr)
+; CHECK: .set .Lbar.num_agpr, max(0, .Lbaz.num_agpr, .Lqux.num_agpr)
+; CHECK: .set .Lbar.numbered_sgpr, max(34, .Lbaz.numbered_sgpr, .Lqux.numbered_sgpr)
+; CHECK: .set .Lbar.private_seg_size, 16+max(.Lbaz.private_seg_size, .Lqux.private_seg_size)
+; CHECK: .set .Lbar.uses_vcc, or(0, .Lbaz.uses_vcc, .Lqux.uses_vcc)
+; CHECK: .set .Lbar.uses_flat_scratch, or(0, .Lbaz.uses_flat_scratch, .Lqux.uses_flat_scratch)
+; CHECK: .set .Lbar.has_dyn_sized_stack, or(0, .Lbaz.has_dyn_sized_stack, .Lqux.has_dyn_sized_stack)
+; CHECK: .set .Lbar.has_recursion, or(1, .Lbaz.has_recursion, .Lqux.has_recursion)
+; CHECK: .set .Lbar.has_indirect_call, or(0, .Lbaz.has_indirect_call, .Lqux.has_indirect_call)
 define void @bar() {
 entry:
   call void @baz()
@@ -53,15 +53,15 @@ entry:
 }
 
 ; CHECK-LABEL: {{^}}foo
-; CHECK: .set foo.num_vgpr, max(38, bar.num_vgpr)
-; CHECK: .set foo.num_agpr, max(0, bar.num_agpr)
-; CHECK: .set foo.numbered_sgpr, max(34, bar.numbered_sgpr)
-; CHECK: .set foo.private_seg_size, 16+max(bar.private_seg_size)
-; CHECK: .set foo.uses_vcc, or(0, bar.uses_vcc)
-; CHECK: .set foo.uses_flat_scratch, or(0, bar.uses_flat_scratch)
-; CHECK: .set foo.has_dyn_sized_stack, or(0, bar.has_dyn_sized_stack)
-; CHECK: .set foo.has_recursion, or(1, bar.has_recursion)
-; CHECK: .set foo.has_indirect_call, or(0, bar.has_indirect_call)
+; CHECK: .set .Lfoo.num_vgpr, max(38, .Lbar.num_vgpr)
+; CHECK: .set .Lfoo.num_agpr, max(0, .Lbar.num_agpr)
+; CHECK: .set .Lfoo.numbered_sgpr, max(34, .Lbar.numbered_sgpr)
+; CHECK: .set .Lfoo.private_seg_size, 16+max(.Lbar.private_seg_size)
+; CHECK: .set .Lfoo.uses_vcc, or(0, .Lbar.uses_vcc)
+; CHECK: .set .Lfoo.uses_flat_scratch, or(0, .Lbar.uses_flat_scratch)
+; CHECK: .set .Lfoo.has_dyn_sized_stack, or(0, .Lbar.has_dyn_sized_stack)
+; CHECK: .set .Lfoo.has_recursion, or(1, .Lbar.has_recursion)
+; CHECK: .set .Lfoo.has_indirect_call, or(0, .Lbar.has_indirect_call)
 define void @foo() {
 entry:
   call void @bar()
@@ -70,15 +70,15 @@ entry:
 }
 
 ; CHECK-LABEL: {{^}}usefoo
-; CHECK: .set usefoo.num_vgpr, max(32, foo.num_vgpr)
-; CHECK: .set usefoo.num_agpr, max(0, foo.num_agpr)
-; CHECK: .set usefoo.numbered_sgpr, max(33, foo.numbered_sgpr)
-; CHECK: .set usefoo.private_seg_size, 0+max(foo.private_seg_size)
-; CHECK: .set usefoo.uses_vcc, or(0, foo.uses_vcc)
-; CHECK: .set usefoo.uses_flat_scratch, or(1, foo.uses_flat_scratch)
-; CHECK: .set usefoo.has_dyn_sized_stack, or(0, foo.has_dyn_sized_stack)
-; CHECK: .set usefoo.has_recursion, or(1, foo.has_recursion)
-; CHECK: .set usefoo.has_indirect_call, or(0, foo.has_indirect_call)
+; CHECK: .set .Lusefoo.num_vgpr, max(32, .Lfoo.num_vgpr)
+; CHECK: .set .Lusefoo.num_agpr, max(0, .Lfoo.num_agpr)
+; CHECK: .set .Lusefoo.numbered_sgpr, max(33, .Lfoo.numbered_sgpr)
+; CHECK: .set .Lusefoo.private_seg_size, 0+max(.Lfoo.private_seg_size)
+; CHECK: .set .Lusefoo.uses_vcc, or(0, .Lfoo.uses_vcc)
+; CHECK: .set .Lusefoo.uses_flat_scratch, or(1, .Lfoo.uses_flat_scratch)
+; CHECK: .set .Lusefoo.has_dyn_sized_stack, or(0, .Lfoo.has_dyn_sized_stack)
+; CHECK: .set .Lusefoo.has_recursion, or(1, .Lfoo.has_recursion)
+; CHECK: .set .Lusefoo.has_indirect_call, or(0, .Lfoo.has_indirect_call)
 define amdgpu_kernel void @usefoo() {
   call void @foo()
   ret void

--- a/llvm/test/CodeGen/AMDGPU/recursion.ll
+++ b/llvm/test/CodeGen/AMDGPU/recursion.ll
@@ -1,6 +1,6 @@
-; RUN: sed 's/CODE_OBJECT_VERSION/400/g' %s | llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx900 | FileCheck %s
-; RUN: sed 's/CODE_OBJECT_VERSION/500/g' %s | llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx900 | FileCheck -check-prefixes=V5 %s
-; RUN: sed 's/CODE_OBJECT_VERSION/600/g' %s | llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx900 | FileCheck -check-prefixes=V5 %s
+; RUN: sed 's/CODE_OBJECT_VERSION/400/g' %s | llc -mtriple=amdgcn-amd-amdhsa -amdgpu-localize-resource-symbols=false -mcpu=gfx900 | FileCheck %s
+; RUN: sed 's/CODE_OBJECT_VERSION/500/g' %s | llc -mtriple=amdgcn-amd-amdhsa -amdgpu-localize-resource-symbols=false -mcpu=gfx900 | FileCheck -check-prefixes=V5 %s
+; RUN: sed 's/CODE_OBJECT_VERSION/600/g' %s | llc -mtriple=amdgcn-amd-amdhsa -amdgpu-localize-resource-symbols=false -mcpu=gfx900 | FileCheck -check-prefixes=V5 %s
 
 ; CHECK-LABEL: {{^}}recursive:
 ; CHECK: .set recursive.private_seg_size, 16+max(16384)

--- a/llvm/test/CodeGen/AMDGPU/recursion.ll
+++ b/llvm/test/CodeGen/AMDGPU/recursion.ll
@@ -1,13 +1,13 @@
-; RUN: sed 's/CODE_OBJECT_VERSION/400/g' %s | llc -mtriple=amdgcn-amd-amdhsa -amdgpu-localize-resource-symbols=false -mcpu=gfx900 | FileCheck %s
-; RUN: sed 's/CODE_OBJECT_VERSION/500/g' %s | llc -mtriple=amdgcn-amd-amdhsa -amdgpu-localize-resource-symbols=false -mcpu=gfx900 | FileCheck -check-prefixes=V5 %s
-; RUN: sed 's/CODE_OBJECT_VERSION/600/g' %s | llc -mtriple=amdgcn-amd-amdhsa -amdgpu-localize-resource-symbols=false -mcpu=gfx900 | FileCheck -check-prefixes=V5 %s
+; RUN: sed 's/CODE_OBJECT_VERSION/400/g' %s | llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx900 | FileCheck %s
+; RUN: sed 's/CODE_OBJECT_VERSION/500/g' %s | llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx900 | FileCheck -check-prefixes=V5 %s
+; RUN: sed 's/CODE_OBJECT_VERSION/600/g' %s | llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx900 | FileCheck -check-prefixes=V5 %s
 
 ; CHECK-LABEL: {{^}}recursive:
-; CHECK: .set recursive.private_seg_size, 16+max(16384)
+; CHECK: .set .Lrecursive.private_seg_size, 16+max(16384)
 ; CHECK: ScratchSize: 16
 
 ; V5-LABEL: {{^}}recursive:
-; V5: .set recursive.has_recursion, 1
+; V5: .set .Lrecursive.has_recursion, 1
 define void @recursive() {
   call void @recursive()
   store volatile i32 0, ptr addrspace(1) poison
@@ -15,22 +15,22 @@ define void @recursive() {
 }
 
 ; CHECK-LABEL: {{^}}tail_recursive:
-; CHECK: .set tail_recursive.private_seg_size, 0
+; CHECK: .set .Ltail_recursive.private_seg_size, 0
 ; CHECK: ScratchSize: 0
 define void @tail_recursive() {
   tail call void @tail_recursive()
   ret void
 }
 
-; CHECK: .set calls_tail_recursive.private_seg_size, 0+max(tail_recursive.private_seg_size)
+; CHECK: .set .Lcalls_tail_recursive.private_seg_size, 0+max(.Ltail_recursive.private_seg_size)
 define void @calls_tail_recursive() norecurse {
   tail call void @tail_recursive()
   ret void
 }
 
 ; CHECK-LABEL: {{^}}tail_recursive_with_stack:
-; CHECK: .set tail_recursive_with_stack.private_seg_size, 8
-; CHECK: .set tail_recursive_with_stack.has_recursion, 1
+; CHECK: .set .Ltail_recursive_with_stack.private_seg_size, 8
+; CHECK: .set .Ltail_recursive_with_stack.has_recursion, 1
 define void @tail_recursive_with_stack() {
   %alloca = alloca i32, addrspace(5)
   store volatile i32 0, ptr addrspace(5) %alloca
@@ -41,11 +41,11 @@ define void @tail_recursive_with_stack() {
 ; For an arbitrary recursive call, report a large number for unknown stack
 ; usage for code object v4 and older
 ; CHECK-LABEL: {{^}}calls_recursive:
-; CHECK: .set calls_recursive.private_seg_size, 0+max(16384, recursive.private_seg_size)
+; CHECK: .set .Lcalls_recursive.private_seg_size, 0+max(16384, .Lrecursive.private_seg_size)
 ;
 ; V5-LABEL: {{^}}calls_recursive:
-; V5: .set calls_recursive.private_seg_size, 0+max(recursive.private_seg_size)
-; V5: .set calls_recursive.has_dyn_sized_stack, or(0, recursive.has_dyn_sized_stack)
+; V5: .set .Lcalls_recursive.private_seg_size, 0+max(.Lrecursive.private_seg_size)
+; V5: .set .Lcalls_recursive.has_dyn_sized_stack, or(0, .Lrecursive.has_dyn_sized_stack)
 define amdgpu_kernel void @calls_recursive() {
   call void @recursive()
   ret void
@@ -54,7 +54,7 @@ define amdgpu_kernel void @calls_recursive() {
 ; Make sure we do not report a huge stack size for tail recursive
 ; functions
 ; CHECK-LABEL: {{^}}kernel_indirectly_calls_tail_recursive:
-; CHECK: .set kernel_indirectly_calls_tail_recursive.private_seg_size, 0+max(calls_tail_recursive.private_seg_size)
+; CHECK: .set .Lkernel_indirectly_calls_tail_recursive.private_seg_size, 0+max(.Lcalls_tail_recursive.private_seg_size)
 define amdgpu_kernel void @kernel_indirectly_calls_tail_recursive() {
   call void @calls_tail_recursive()
   ret void
@@ -65,22 +65,22 @@ define amdgpu_kernel void @kernel_indirectly_calls_tail_recursive() {
 ; in the kernel.
 
 ; CHECK-LABEL: {{^}}kernel_calls_tail_recursive:
-; CHECK: .set kernel_calls_tail_recursive.private_seg_size, 0+max(16384, tail_recursive.private_seg_size)
+; CHECK: .set .Lkernel_calls_tail_recursive.private_seg_size, 0+max(16384, .Ltail_recursive.private_seg_size)
 ;
 ; V5-LABEL: {{^}}kernel_calls_tail_recursive:
-; V5: .set kernel_calls_tail_recursive.private_seg_size, 0+max(tail_recursive.private_seg_size)
-; V5: .set kernel_calls_tail_recursive.has_recursion, or(1, tail_recursive.has_recursion)
+; V5: .set .Lkernel_calls_tail_recursive.private_seg_size, 0+max(.Ltail_recursive.private_seg_size)
+; V5: .set .Lkernel_calls_tail_recursive.has_recursion, or(1, .Ltail_recursive.has_recursion)
 define amdgpu_kernel void @kernel_calls_tail_recursive() {
   call void @tail_recursive()
   ret void
 }
 
 ; CHECK-LABEL: {{^}}kernel_calls_tail_recursive_with_stack:
-; CHECK: .set kernel_calls_tail_recursive_with_stack.private_seg_size, 0+max(16384, tail_recursive_with_stack.private_seg_size)
+; CHECK: .set .Lkernel_calls_tail_recursive_with_stack.private_seg_size, 0+max(16384, .Ltail_recursive_with_stack.private_seg_size)
 ;
 ; V5-LABEL: {{^}}kernel_calls_tail_recursive_with_stack:
-; V5: .set kernel_calls_tail_recursive_with_stack.private_seg_size, 0+max(tail_recursive_with_stack.private_seg_size)
-; V5: .set kernel_calls_tail_recursive_with_stack.has_dyn_sized_stack, or(0, tail_recursive_with_stack.has_dyn_sized_stack)
+; V5: .set .Lkernel_calls_tail_recursive_with_stack.private_seg_size, 0+max(.Ltail_recursive_with_stack.private_seg_size)
+; V5: .set .Lkernel_calls_tail_recursive_with_stack.has_dyn_sized_stack, or(0, .Ltail_recursive_with_stack.has_dyn_sized_stack)
 define amdgpu_kernel void @kernel_calls_tail_recursive_with_stack() {
   call void @tail_recursive_with_stack()
   ret void

--- a/llvm/test/CodeGen/AMDGPU/recursive-resource-usage-mcexpr.ll
+++ b/llvm/test/CodeGen/AMDGPU/recursive-resource-usage-mcexpr.ll
@@ -1,50 +1,50 @@
-; RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx90a -amdgpu-localize-resource-symbols=false < %s | FileCheck %s
+; RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx90a < %s | FileCheck %s
 
 ; Recursion: foo -> bar -> baz -> qux -> foo
 
 ; CHECK-LABEL: {{^}}qux
-; CHECK: .set qux.num_vgpr, max(71, foo.num_vgpr)
-; CHECK: .set qux.num_agpr, max(0, foo.num_agpr)
-; CHECK: .set qux.numbered_sgpr, max(46, foo.numbered_sgpr)
-; CHECK: .set qux.private_seg_size, 16
-; CHECK: .set qux.uses_vcc, or(1, foo.uses_vcc)
-; CHECK: .set qux.uses_flat_scratch, or(0, foo.uses_flat_scratch)
-; CHECK: .set qux.has_dyn_sized_stack, or(0, foo.has_dyn_sized_stack)
-; CHECK: .set qux.has_recursion, or(1, foo.has_recursion)
-; CHECK: .set qux.has_indirect_call, or(0, foo.has_indirect_call)
+; CHECK: .set .Lqux.num_vgpr, max(71, .Lfoo.num_vgpr)
+; CHECK: .set .Lqux.num_agpr, max(0, .Lfoo.num_agpr)
+; CHECK: .set .Lqux.numbered_sgpr, max(46, .Lfoo.numbered_sgpr)
+; CHECK: .set .Lqux.private_seg_size, 16
+; CHECK: .set .Lqux.uses_vcc, or(1, .Lfoo.uses_vcc)
+; CHECK: .set .Lqux.uses_flat_scratch, or(0, .Lfoo.uses_flat_scratch)
+; CHECK: .set .Lqux.has_dyn_sized_stack, or(0, .Lfoo.has_dyn_sized_stack)
+; CHECK: .set .Lqux.has_recursion, or(1, .Lfoo.has_recursion)
+; CHECK: .set .Lqux.has_indirect_call, or(0, .Lfoo.has_indirect_call)
 
 ; CHECK-LABEL: {{^}}baz
-; CHECK: .set baz.num_vgpr, max(61, qux.num_vgpr)
-; CHECK: .set baz.num_agpr, max(0, qux.num_agpr)
-; CHECK: .set baz.numbered_sgpr, max(51, qux.numbered_sgpr)
-; CHECK: .set baz.private_seg_size, 16+max(qux.private_seg_size)
-; CHECK: .set baz.uses_vcc, or(1, qux.uses_vcc)
-; CHECK: .set baz.uses_flat_scratch, or(0, qux.uses_flat_scratch)
-; CHECK: .set baz.has_dyn_sized_stack, or(0, qux.has_dyn_sized_stack)
-; CHECK: .set baz.has_recursion, or(1, qux.has_recursion)
-; CHECK: .set baz.has_indirect_call, or(0, qux.has_indirect_call)
+; CHECK: .set .Lbaz.num_vgpr, max(61, .Lqux.num_vgpr)
+; CHECK: .set .Lbaz.num_agpr, max(0, .Lqux.num_agpr)
+; CHECK: .set .Lbaz.numbered_sgpr, max(51, .Lqux.numbered_sgpr)
+; CHECK: .set .Lbaz.private_seg_size, 16+max(.Lqux.private_seg_size)
+; CHECK: .set .Lbaz.uses_vcc, or(1, .Lqux.uses_vcc)
+; CHECK: .set .Lbaz.uses_flat_scratch, or(0, .Lqux.uses_flat_scratch)
+; CHECK: .set .Lbaz.has_dyn_sized_stack, or(0, .Lqux.has_dyn_sized_stack)
+; CHECK: .set .Lbaz.has_recursion, or(1, .Lqux.has_recursion)
+; CHECK: .set .Lbaz.has_indirect_call, or(0, .Lqux.has_indirect_call)
 
 ; CHECK-LABEL: {{^}}bar
-; CHECK: .set bar.num_vgpr, max(51, baz.num_vgpr)
-; CHECK: .set bar.num_agpr, max(0, baz.num_agpr)
-; CHECK: .set bar.numbered_sgpr, max(61, baz.numbered_sgpr)
-; CHECK: .set bar.private_seg_size, 16+max(baz.private_seg_size)
-; CHECK: .set bar.uses_vcc, or(1, baz.uses_vcc)
-; CHECK: .set bar.uses_flat_scratch, or(0, baz.uses_flat_scratch)
-; CHECK: .set bar.has_dyn_sized_stack, or(0, baz.has_dyn_sized_stack)
-; CHECK: .set bar.has_recursion, or(1, baz.has_recursion)
-; CHECK: .set bar.has_indirect_call, or(0, baz.has_indirect_call)
+; CHECK: .set .Lbar.num_vgpr, max(51, .Lbaz.num_vgpr)
+; CHECK: .set .Lbar.num_agpr, max(0, .Lbaz.num_agpr)
+; CHECK: .set .Lbar.numbered_sgpr, max(61, .Lbaz.numbered_sgpr)
+; CHECK: .set .Lbar.private_seg_size, 16+max(.Lbaz.private_seg_size)
+; CHECK: .set .Lbar.uses_vcc, or(1, .Lbaz.uses_vcc)
+; CHECK: .set .Lbar.uses_flat_scratch, or(0, .Lbaz.uses_flat_scratch)
+; CHECK: .set .Lbar.has_dyn_sized_stack, or(0, .Lbaz.has_dyn_sized_stack)
+; CHECK: .set .Lbar.has_recursion, or(1, .Lbaz.has_recursion)
+; CHECK: .set .Lbar.has_indirect_call, or(0, .Lbaz.has_indirect_call)
 
 ; CHECK-LABEL: {{^}}foo
-; CHECK: .set foo.num_vgpr, max(46, 71)
-; CHECK: .set foo.num_agpr, max(0, 0)
-; CHECK: .set foo.numbered_sgpr, max(71, 61)
-; CHECK: .set foo.private_seg_size, 16
-; CHECK: .set foo.uses_vcc, 1
-; CHECK: .set foo.uses_flat_scratch, 0
-; CHECK: .set foo.has_dyn_sized_stack, 0
-; CHECK: .set foo.has_recursion, 1
-; CHECK: .set foo.has_indirect_call, 0
+; CHECK: .set .Lfoo.num_vgpr, max(46, 71)
+; CHECK: .set .Lfoo.num_agpr, max(0, 0)
+; CHECK: .set .Lfoo.numbered_sgpr, max(71, 61)
+; CHECK: .set .Lfoo.private_seg_size, 16
+; CHECK: .set .Lfoo.uses_vcc, 1
+; CHECK: .set .Lfoo.uses_flat_scratch, 0
+; CHECK: .set .Lfoo.has_dyn_sized_stack, 0
+; CHECK: .set .Lfoo.has_recursion, 1
+; CHECK: .set .Lfoo.has_indirect_call, 0
 
 define void @foo() {
 entry:
@@ -79,15 +79,15 @@ entry:
 }
 
 ; CHECK-LABEL: {{^}}usefoo
-; CHECK: .set usefoo.num_vgpr, max(32, foo.num_vgpr)
-; CHECK: .set usefoo.num_agpr, max(0, foo.num_agpr)
-; CHECK: .set usefoo.numbered_sgpr, max(33, foo.numbered_sgpr)
-; CHECK: .set usefoo.private_seg_size, 0+max(foo.private_seg_size)
-; CHECK: .set usefoo.uses_vcc, or(1, foo.uses_vcc)
-; CHECK: .set usefoo.uses_flat_scratch, or(1, foo.uses_flat_scratch)
-; CHECK: .set usefoo.has_dyn_sized_stack, or(0, foo.has_dyn_sized_stack)
-; CHECK: .set usefoo.has_recursion, or(1, foo.has_recursion)
-; CHECK: .set usefoo.has_indirect_call, or(0, foo.has_indirect_call)
+; CHECK: .set .Lusefoo.num_vgpr, max(32, .Lfoo.num_vgpr)
+; CHECK: .set .Lusefoo.num_agpr, max(0, .Lfoo.num_agpr)
+; CHECK: .set .Lusefoo.numbered_sgpr, max(33, .Lfoo.numbered_sgpr)
+; CHECK: .set .Lusefoo.private_seg_size, 0+max(.Lfoo.private_seg_size)
+; CHECK: .set .Lusefoo.uses_vcc, or(1, .Lfoo.uses_vcc)
+; CHECK: .set .Lusefoo.uses_flat_scratch, or(1, .Lfoo.uses_flat_scratch)
+; CHECK: .set .Lusefoo.has_dyn_sized_stack, or(0, .Lfoo.has_dyn_sized_stack)
+; CHECK: .set .Lusefoo.has_recursion, or(1, .Lfoo.has_recursion)
+; CHECK: .set .Lusefoo.has_indirect_call, or(0, .Lfoo.has_indirect_call)
 define amdgpu_kernel void @usefoo() {
   call void @foo()
   ret void
@@ -96,48 +96,48 @@ define amdgpu_kernel void @usefoo() {
 ; Recursion: A -> B -> C -> A && C -> D -> C
 
 ; CHECK-LABEL: {{^}}D
-; CHECK: .set D.num_vgpr, max(71, C.num_vgpr)
-; CHECK: .set D.num_agpr, max(0, C.num_agpr)
-; CHECK: .set D.numbered_sgpr, max(71, C.numbered_sgpr)
-; CHECK: .set D.private_seg_size, 16+max(C.private_seg_size)
-; CHECK: .set D.uses_vcc, or(1, C.uses_vcc)
-; CHECK: .set D.uses_flat_scratch, or(0, C.uses_flat_scratch)
-; CHECK: .set D.has_dyn_sized_stack, or(0, C.has_dyn_sized_stack)
-; CHECK: .set D.has_recursion, or(1, C.has_recursion)
-; CHECK: .set D.has_indirect_call, or(0, C.has_indirect_call)
+; CHECK: .set .LD.num_vgpr, max(71, .LC.num_vgpr)
+; CHECK: .set .LD.num_agpr, max(0, .LC.num_agpr)
+; CHECK: .set .LD.numbered_sgpr, max(71, .LC.numbered_sgpr)
+; CHECK: .set .LD.private_seg_size, 16+max(.LC.private_seg_size)
+; CHECK: .set .LD.uses_vcc, or(1, .LC.uses_vcc)
+; CHECK: .set .LD.uses_flat_scratch, or(0, .LC.uses_flat_scratch)
+; CHECK: .set .LD.has_dyn_sized_stack, or(0, .LC.has_dyn_sized_stack)
+; CHECK: .set .LD.has_recursion, or(1, .LC.has_recursion)
+; CHECK: .set .LD.has_indirect_call, or(0, .LC.has_indirect_call)
 
 ; CHECK-LABEL: {{^}}C
-; CHECK: .set C.num_vgpr, max(42, A.num_vgpr, 71)
-; CHECK: .set C.num_agpr, max(0, A.num_agpr, 0)
-; CHECK: .set C.numbered_sgpr, max(71, A.numbered_sgpr, 71)
-; CHECK: .set C.private_seg_size, 16+max(A.private_seg_size)
-; CHECK: .set C.uses_vcc, or(1, A.uses_vcc)
-; CHECK: .set C.uses_flat_scratch, or(0, A.uses_flat_scratch)
-; CHECK: .set C.has_dyn_sized_stack, or(0, A.has_dyn_sized_stack)
-; CHECK: .set C.has_recursion, or(1, A.has_recursion)
-; CHECK: .set C.has_indirect_call, or(0, A.has_indirect_call)
+; CHECK: .set .LC.num_vgpr, max(42, .LA.num_vgpr, 71)
+; CHECK: .set .LC.num_agpr, max(0, .LA.num_agpr, 0)
+; CHECK: .set .LC.numbered_sgpr, max(71, .LA.numbered_sgpr, 71)
+; CHECK: .set .LC.private_seg_size, 16+max(.LA.private_seg_size)
+; CHECK: .set .LC.uses_vcc, or(1, .LA.uses_vcc)
+; CHECK: .set .LC.uses_flat_scratch, or(0, .LA.uses_flat_scratch)
+; CHECK: .set .LC.has_dyn_sized_stack, or(0, .LA.has_dyn_sized_stack)
+; CHECK: .set .LC.has_recursion, or(1, .LA.has_recursion)
+; CHECK: .set .LC.has_indirect_call, or(0, .LA.has_indirect_call)
 
 ; CHECK-LABEL: {{^}}B
-; CHECK: .set B.num_vgpr, max(42, C.num_vgpr)
-; CHECK: .set B.num_agpr, max(0, C.num_agpr)
-; CHECK: .set B.numbered_sgpr, max(71, C.numbered_sgpr)
-; CHECK: .set B.private_seg_size, 16+max(C.private_seg_size)
-; CHECK: .set B.uses_vcc, or(1, C.uses_vcc)
-; CHECK: .set B.uses_flat_scratch, or(0, C.uses_flat_scratch)
-; CHECK: .set B.has_dyn_sized_stack, or(0, C.has_dyn_sized_stack)
-; CHECK: .set B.has_recursion, or(1, C.has_recursion)
-; CHECK: .set B.has_indirect_call, or(0, C.has_indirect_call)
+; CHECK: .set .LB.num_vgpr, max(42, .LC.num_vgpr)
+; CHECK: .set .LB.num_agpr, max(0, .LC.num_agpr)
+; CHECK: .set .LB.numbered_sgpr, max(71, .LC.numbered_sgpr)
+; CHECK: .set .LB.private_seg_size, 16+max(.LC.private_seg_size)
+; CHECK: .set .LB.uses_vcc, or(1, .LC.uses_vcc)
+; CHECK: .set .LB.uses_flat_scratch, or(0, .LC.uses_flat_scratch)
+; CHECK: .set .LB.has_dyn_sized_stack, or(0, .LC.has_dyn_sized_stack)
+; CHECK: .set .LB.has_recursion, or(1, .LC.has_recursion)
+; CHECK: .set .LB.has_indirect_call, or(0, .LC.has_indirect_call)
 
 ; CHECK-LABEL: {{^}}A
-; CHECK: .set A.num_vgpr, max(42, 71)
-; CHECK: .set A.num_agpr, max(0, 0)
-; CHECK: .set A.numbered_sgpr, max(71, 71)
-; CHECK: .set A.private_seg_size, 16
-; CHECK: .set A.uses_vcc, 1
-; CHECK: .set A.uses_flat_scratch, 0
-; CHECK: .set A.has_dyn_sized_stack, 0
-; CHECK: .set A.has_recursion, 1
-; CHECK: .set A.has_indirect_call, 0
+; CHECK: .set .LA.num_vgpr, max(42, 71)
+; CHECK: .set .LA.num_agpr, max(0, 0)
+; CHECK: .set .LA.numbered_sgpr, max(71, 71)
+; CHECK: .set .LA.private_seg_size, 16
+; CHECK: .set .LA.uses_vcc, 1
+; CHECK: .set .LA.uses_flat_scratch, 0
+; CHECK: .set .LA.has_dyn_sized_stack, 0
+; CHECK: .set .LA.has_recursion, 1
+; CHECK: .set .LA.has_indirect_call, 0
 
 define void @A() {
   call void @B()

--- a/llvm/test/CodeGen/AMDGPU/recursive-resource-usage-mcexpr.ll
+++ b/llvm/test/CodeGen/AMDGPU/recursive-resource-usage-mcexpr.ll
@@ -1,4 +1,4 @@
-; RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx90a < %s | FileCheck %s
+; RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx90a -amdgpu-localize-resource-symbols=false < %s | FileCheck %s
 
 ; Recursion: foo -> bar -> baz -> qux -> foo
 

--- a/llvm/test/CodeGen/AMDGPU/resource-optimization-remarks.ll
+++ b/llvm/test/CodeGen/AMDGPU/resource-optimization-remarks.ll
@@ -1,4 +1,4 @@
-; RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx908 -pass-remarks-output=%t -pass-remarks-analysis=kernel-resource-usage -filetype=null %s 2>&1 | FileCheck -check-prefix=STDERR %s
+; RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx908 -amdgpu-localize-resource-symbols=false -pass-remarks-output=%t -pass-remarks-analysis=kernel-resource-usage -filetype=null %s 2>&1 | FileCheck -check-prefix=STDERR %s
 ; RUN: FileCheck -check-prefix=REMARK %s < %t
 
 ; STDERR: remark: foo.cl:27:0: Function Name: test_kernel

--- a/llvm/test/CodeGen/AMDGPU/resource-optimization-remarks.ll
+++ b/llvm/test/CodeGen/AMDGPU/resource-optimization-remarks.ll
@@ -1,4 +1,4 @@
-; RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx908 -amdgpu-localize-resource-symbols=false -pass-remarks-output=%t -pass-remarks-analysis=kernel-resource-usage -filetype=null %s 2>&1 | FileCheck -check-prefix=STDERR %s
+; RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx908 -pass-remarks-output=%t -pass-remarks-analysis=kernel-resource-usage -filetype=null %s 2>&1 | FileCheck -check-prefix=STDERR %s
 ; RUN: FileCheck -check-prefix=REMARK %s < %t
 
 ; STDERR: remark: foo.cl:27:0: Function Name: test_kernel
@@ -141,12 +141,12 @@ define void @empty_func() !dbg !8 {
 }
 
 ; STDERR: remark: foo.cl:64:0: Function Name: test_indirect_call
-; STDERR-NEXT: remark: foo.cl:64:0:     TotalSGPRs: test_indirect_call.numbered_sgpr+6
-; STDERR-NEXT: remark: foo.cl:64:0:     VGPRs: test_indirect_call.num_vgpr
-; STDERR-NEXT: remark: foo.cl:64:0:     AGPRs: test_indirect_call.num_agpr
+; STDERR-NEXT: remark: foo.cl:64:0:     TotalSGPRs: .Ltest_indirect_call.numbered_sgpr+6
+; STDERR-NEXT: remark: foo.cl:64:0:     VGPRs: .Ltest_indirect_call.num_vgpr
+; STDERR-NEXT: remark: foo.cl:64:0:     AGPRs: .Ltest_indirect_call.num_agpr
 ; STDERR-NEXT: remark: foo.cl:64:0:     ScratchSize [bytes/lane]: 0
 ; STDERR-NEXT: remark: foo.cl:64:0:     Dynamic Stack: True
-; STDERR-NEXT: remark: foo.cl:64:0:     Occupancy [waves/SIMD]: occupancy(10, 4, 256, 8, 10, max(test_indirect_call.numbered_sgpr+extrasgprs(test_indirect_call.uses_vcc, test_indirect_call.uses_flat_scratch, 1), 1, 0), max(totalnumvgprs(test_indirect_call.num_agpr, test_indirect_call.num_vgpr), 1, 0))
+; STDERR-NEXT: remark: foo.cl:64:0:     Occupancy [waves/SIMD]: occupancy(10, 4, 256, 8, 10, max(.Ltest_indirect_call.numbered_sgpr+extrasgprs(.Ltest_indirect_call.uses_vcc, .Ltest_indirect_call.uses_flat_scratch, 1), 1, 0), max(totalnumvgprs(.Ltest_indirect_call.num_agpr, .Ltest_indirect_call.num_vgpr), 1, 0))
 ; STDERR-NEXT: remark: foo.cl:64:0:     SGPRs Spill: 0
 ; STDERR-NEXT: remark: foo.cl:64:0:     VGPRs Spill: 0
 ; STDERR-NEXT: remark: foo.cl:64:0:     LDS Size [bytes/block]: 0
@@ -159,12 +159,12 @@ define amdgpu_kernel void @test_indirect_call() !dbg !9 {
 }
 
 ; STDERR: remark: foo.cl:74:0: Function Name: test_indirect_w_static_stack
-; STDERR-NEXT: remark: foo.cl:74:0:     TotalSGPRs: test_indirect_w_static_stack.numbered_sgpr+6
-; STDERR-NEXT: remark: foo.cl:74:0:     VGPRs: test_indirect_w_static_stack.num_vgpr
-; STDERR-NEXT: remark: foo.cl:74:0:     AGPRs: test_indirect_w_static_stack.num_agpr
+; STDERR-NEXT: remark: foo.cl:74:0:     TotalSGPRs: .Ltest_indirect_w_static_stack.numbered_sgpr+6
+; STDERR-NEXT: remark: foo.cl:74:0:     VGPRs: .Ltest_indirect_w_static_stack.num_vgpr
+; STDERR-NEXT: remark: foo.cl:74:0:     AGPRs: .Ltest_indirect_w_static_stack.num_agpr
 ; STDERR-NEXT: remark: foo.cl:74:0:     ScratchSize [bytes/lane]: 144
 ; STDERR-NEXT: remark: foo.cl:74:0:     Dynamic Stack: True
-; STDERR-NEXT: remark: foo.cl:74:0:     Occupancy [waves/SIMD]: occupancy(10, 4, 256, 8, 10, max(test_indirect_w_static_stack.numbered_sgpr+extrasgprs(test_indirect_w_static_stack.uses_vcc, test_indirect_w_static_stack.uses_flat_scratch, 1), 1, 0), max(totalnumvgprs(test_indirect_w_static_stack.num_agpr, test_indirect_w_static_stack.num_vgpr), 1, 0))
+; STDERR-NEXT: remark: foo.cl:74:0:     Occupancy [waves/SIMD]: occupancy(10, 4, 256, 8, 10, max(.Ltest_indirect_w_static_stack.numbered_sgpr+extrasgprs(.Ltest_indirect_w_static_stack.uses_vcc, .Ltest_indirect_w_static_stack.uses_flat_scratch, 1), 1, 0), max(totalnumvgprs(.Ltest_indirect_w_static_stack.num_agpr, .Ltest_indirect_w_static_stack.num_vgpr), 1, 0))
 ; STDERR-NEXT: remark: foo.cl:74:0:     SGPRs Spill: 0
 ; STDERR-NEXT: remark: foo.cl:74:0:     VGPRs Spill: 0
 ; STDERR-NEXT: remark: foo.cl:74:0:     LDS Size [bytes/block]: 0

--- a/llvm/test/CodeGen/AMDGPU/resource-usage-dead-function.ll
+++ b/llvm/test/CodeGen/AMDGPU/resource-usage-dead-function.ll
@@ -1,6 +1,6 @@
-; RUN: sed 's/CODE_OBJECT_VERSION/400/g' %s | llc -mtriple=amdgcn-amd-amdhsa -amdgpu-localize-resource-symbols=false -mcpu=gfx900 -o - | FileCheck -check-prefixes=GCN,ALL %s
-; RUN: sed 's/CODE_OBJECT_VERSION/500/g' %s | llc -mtriple=amdgcn-amd-amdhsa -amdgpu-localize-resource-symbols=false -mcpu=gfx900 -o - | FileCheck -check-prefixes=GCN-V5,ALL %s
-; RUN: sed 's/CODE_OBJECT_VERSION/600/g' %s | llc -mtriple=amdgcn-amd-amdhsa -amdgpu-localize-resource-symbols=false -mcpu=gfx900 -o - | FileCheck -check-prefixes=GCN-V5,ALL %s
+; RUN: sed 's/CODE_OBJECT_VERSION/400/g' %s | llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx900 -o - | FileCheck -check-prefixes=GCN,ALL %s
+; RUN: sed 's/CODE_OBJECT_VERSION/500/g' %s | llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx900 -o - | FileCheck -check-prefixes=GCN-V5,ALL %s
+; RUN: sed 's/CODE_OBJECT_VERSION/600/g' %s | llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx900 -o - | FileCheck -check-prefixes=GCN-V5,ALL %s
 
 ; Make sure there's no assertion when trying to report the resource
 ; usage for a function which becomes dead during codegen.
@@ -19,8 +19,8 @@ define internal fastcc void @unreachable() {
 
 ; GCN-NOT: .amdhsa_uses_dynamic_stack
 ; GCN-V5: .amdhsa_uses_dynamic_stack
-; ALL: .set entry.private_seg_size, 0
-; ALL: .set entry.has_dyn_sized_stack, 0
+; ALL: .set .Lentry.private_seg_size, 0
+; ALL: .set .Lentry.has_dyn_sized_stack, 0
 define amdgpu_kernel void @entry() {
 bb0:
   br i1 false, label %bb1, label %bb2

--- a/llvm/test/CodeGen/AMDGPU/resource-usage-dead-function.ll
+++ b/llvm/test/CodeGen/AMDGPU/resource-usage-dead-function.ll
@@ -1,6 +1,6 @@
-; RUN: sed 's/CODE_OBJECT_VERSION/400/g' %s | llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx900 -o - | FileCheck -check-prefixes=GCN,ALL %s
-; RUN: sed 's/CODE_OBJECT_VERSION/500/g' %s | llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx900 -o - | FileCheck -check-prefixes=GCN-V5,ALL %s
-; RUN: sed 's/CODE_OBJECT_VERSION/600/g' %s | llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx900 -o - | FileCheck -check-prefixes=GCN-V5,ALL %s
+; RUN: sed 's/CODE_OBJECT_VERSION/400/g' %s | llc -mtriple=amdgcn-amd-amdhsa -amdgpu-localize-resource-symbols=false -mcpu=gfx900 -o - | FileCheck -check-prefixes=GCN,ALL %s
+; RUN: sed 's/CODE_OBJECT_VERSION/500/g' %s | llc -mtriple=amdgcn-amd-amdhsa -amdgpu-localize-resource-symbols=false -mcpu=gfx900 -o - | FileCheck -check-prefixes=GCN-V5,ALL %s
+; RUN: sed 's/CODE_OBJECT_VERSION/600/g' %s | llc -mtriple=amdgcn-amd-amdhsa -amdgpu-localize-resource-symbols=false -mcpu=gfx900 -o - | FileCheck -check-prefixes=GCN-V5,ALL %s
 
 ; Make sure there's no assertion when trying to report the resource
 ; usage for a function which becomes dead during codegen.

--- a/llvm/test/CodeGen/AMDGPU/s-barrier-lowering.ll
+++ b/llvm/test/CodeGen/AMDGPU/s-barrier-lowering.ll
@@ -1,5 +1,5 @@
 ; RUN: opt -S -mtriple=amdgcn-- -passes=amdgpu-lower-exec-sync,amdgpu-lower-module-lds < %s 2>&1 | FileCheck %s
-; RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx1250 -amdgpu-localize-resource-symbols=false -verify-machineinstrs -o - %s | FileCheck -check-prefixes=SOUT %s
+; RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx1250 -verify-machineinstrs -o - %s | FileCheck -check-prefixes=SOUT %s
 
 %class.ExpAmdWorkgroupWaveBarrier = type { target("amdgcn.named.barrier", 0) }
 
@@ -12,7 +12,7 @@
 ; CHECK-NEXT: @bar1 = internal addrspace(3) global [4 x %class.ExpAmdWorkgroupWaveBarrier] poison, !absolute_symbol !2
 ; CHECK-NEXT: @bar1.kernel1 = internal addrspace(3) global [4 x %class.ExpAmdWorkgroupWaveBarrier] poison, !absolute_symbol !2
 
-; SOUT:        .set func1.num_named_barrier, 7
+; SOUT:        .set .Lfunc1.num_named_barrier, 7
 define void @func1() {
     call void @llvm.amdgcn.s.barrier.signal.var(ptr addrspace(3) @bar3, i32 7)
     call void @llvm.amdgcn.s.barrier.join(ptr addrspace(3) @bar3)
@@ -20,7 +20,7 @@ define void @func1() {
     ret void
 }
 
-; SOUT:        .set func2.num_named_barrier, 2
+; SOUT:        .set .Lfunc2.num_named_barrier, 2
 define void @func2() {
     call void @llvm.amdgcn.s.barrier.signal.var(ptr addrspace(3) @bar2, i32 7)
     call void @llvm.amdgcn.s.barrier.join(ptr addrspace(3) @bar2)
@@ -29,7 +29,7 @@ define void @func2() {
 }
 
 ; SOUT:                .amdhsa_named_barrier_count 2
-; SOUT:        .set kernel1.num_named_barrier, max(6, func1.num_named_barrier, func2.num_named_barrier)
+; SOUT:        .set .Lkernel1.num_named_barrier, max(6, .Lfunc1.num_named_barrier, .Lfunc2.num_named_barrier)
 define amdgpu_kernel void @kernel1() #0 {
 ; CHECK-DAG: call void @llvm.amdgcn.s.barrier.signal.var(ptr addrspace(3) @bar1.kernel1, i32 11)
     call void @llvm.amdgcn.s.barrier.signal.var(ptr addrspace(3) @bar1, i32 11)
@@ -43,7 +43,7 @@ define amdgpu_kernel void @kernel1() #0 {
 }
 
 ; SOUT:                .amdhsa_named_barrier_count 2
-; SOUT:        .set kernel2.num_named_barrier, max(6, func2.num_named_barrier)
+; SOUT:        .set .Lkernel2.num_named_barrier, max(6, .Lfunc2.num_named_barrier)
 define amdgpu_kernel void @kernel2() #0 {
 ; CHECK-DAG: call void @llvm.amdgcn.s.barrier.signal.var(ptr addrspace(3) @bar1, i32 9)
     call void @llvm.amdgcn.s.barrier.signal.var(ptr addrspace(3) @bar1, i32 9)

--- a/llvm/test/CodeGen/AMDGPU/s-barrier-lowering.ll
+++ b/llvm/test/CodeGen/AMDGPU/s-barrier-lowering.ll
@@ -1,5 +1,5 @@
 ; RUN: opt -S -mtriple=amdgcn-- -passes=amdgpu-lower-exec-sync,amdgpu-lower-module-lds < %s 2>&1 | FileCheck %s
-; RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx1250 -verify-machineinstrs -o - %s | FileCheck -check-prefixes=SOUT %s
+; RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx1250 -amdgpu-localize-resource-symbols=false -verify-machineinstrs -o - %s | FileCheck -check-prefixes=SOUT %s
 
 %class.ExpAmdWorkgroupWaveBarrier = type { target("amdgcn.named.barrier", 0) }
 

--- a/llvm/test/CodeGen/AMDGPU/unnamed-function-resource-info.ll
+++ b/llvm/test/CodeGen/AMDGPU/unnamed-function-resource-info.ll
@@ -1,4 +1,4 @@
-; RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx906 < %s | FileCheck %s
+; RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx906 -amdgpu-localize-resource-symbols=false < %s | FileCheck %s
 
 ; CHECK-LABEL: __unnamed_1:
 ; CHECK: .set __unnamed_1.num_vgpr, 0

--- a/llvm/test/CodeGen/AMDGPU/unnamed-function-resource-info.ll
+++ b/llvm/test/CodeGen/AMDGPU/unnamed-function-resource-info.ll
@@ -1,30 +1,30 @@
-; RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx906 -amdgpu-localize-resource-symbols=false < %s | FileCheck %s
+; RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx906 < %s | FileCheck %s
 
 ; CHECK-LABEL: __unnamed_1:
-; CHECK: .set __unnamed_1.num_vgpr, 0
-; CHECK: .set __unnamed_1.num_agpr, 0
-; CHECK: .set __unnamed_1.numbered_sgpr, 32
-; CHECK: .set __unnamed_1.private_seg_size, 0
-; CHECK: .set __unnamed_1.uses_vcc, 0
-; CHECK: .set __unnamed_1.uses_flat_scratch, 0
-; CHECK: .set __unnamed_1.has_dyn_sized_stack, 0
-; CHECK: .set __unnamed_1.has_recursion, 0
-; CHECK: .set __unnamed_1.has_indirect_call, 0
+; CHECK: .set .L__unnamed_1.num_vgpr, 0
+; CHECK: .set .L__unnamed_1.num_agpr, 0
+; CHECK: .set .L__unnamed_1.numbered_sgpr, 32
+; CHECK: .set .L__unnamed_1.private_seg_size, 0
+; CHECK: .set .L__unnamed_1.uses_vcc, 0
+; CHECK: .set .L__unnamed_1.uses_flat_scratch, 0
+; CHECK: .set .L__unnamed_1.has_dyn_sized_stack, 0
+; CHECK: .set .L__unnamed_1.has_recursion, 0
+; CHECK: .set .L__unnamed_1.has_indirect_call, 0
 define void @1() {
 entry:
   ret void
 }
 
 ; CHECK-LABEL: __unnamed_2:
-; CHECK: .set __unnamed_2.num_vgpr, max(1, __unnamed_1.num_vgpr)
-; CHECK: .set __unnamed_2.num_agpr, max(0, __unnamed_1.num_agpr)
-; CHECK: .set __unnamed_2.numbered_sgpr, max(34, __unnamed_1.numbered_sgpr)
-; CHECK: .set __unnamed_2.private_seg_size, 16+max(__unnamed_1.private_seg_size)
-; CHECK: .set __unnamed_2.uses_vcc, or(0, __unnamed_1.uses_vcc)
-; CHECK: .set __unnamed_2.uses_flat_scratch, or(0, __unnamed_1.uses_flat_scratch)
-; CHECK: .set __unnamed_2.has_dyn_sized_stack, or(0, __unnamed_1.has_dyn_sized_stack)
-; CHECK: .set __unnamed_2.has_recursion, or(1, __unnamed_1.has_recursion)
-; CHECK: .set __unnamed_2.has_indirect_call, or(0, __unnamed_1.has_indirect_call)
+; CHECK: .set .L__unnamed_2.num_vgpr, max(1, .L__unnamed_1.num_vgpr)
+; CHECK: .set .L__unnamed_2.num_agpr, max(0, .L__unnamed_1.num_agpr)
+; CHECK: .set .L__unnamed_2.numbered_sgpr, max(34, .L__unnamed_1.numbered_sgpr)
+; CHECK: .set .L__unnamed_2.private_seg_size, 16+max(.L__unnamed_1.private_seg_size)
+; CHECK: .set .L__unnamed_2.uses_vcc, or(0, .L__unnamed_1.uses_vcc)
+; CHECK: .set .L__unnamed_2.uses_flat_scratch, or(0, .L__unnamed_1.uses_flat_scratch)
+; CHECK: .set .L__unnamed_2.has_dyn_sized_stack, or(0, .L__unnamed_1.has_dyn_sized_stack)
+; CHECK: .set .L__unnamed_2.has_recursion, or(1, .L__unnamed_1.has_recursion)
+; CHECK: .set .L__unnamed_2.has_indirect_call, or(0, .L__unnamed_1.has_indirect_call)
 define void @2() {
 entry:
   call void @1()
@@ -32,15 +32,15 @@ entry:
 }
 
 ; CHECK-LABEL: {{^}}use
-; CHECK: .set use.num_vgpr, max(32, __unnamed_1.num_vgpr, __unnamed_2.num_vgpr)
-; CHECK: .set use.num_agpr, max(0, __unnamed_1.num_agpr, __unnamed_2.num_agpr)
-; CHECK: .set use.numbered_sgpr, max(33, __unnamed_1.numbered_sgpr, __unnamed_2.numbered_sgpr)
-; CHECK: .set use.private_seg_size, 0+max(__unnamed_1.private_seg_size, __unnamed_2.private_seg_size)
-; CHECK: .set use.uses_vcc, or(0, __unnamed_1.uses_vcc, __unnamed_2.uses_vcc)
-; CHECK: .set use.uses_flat_scratch, or(1, __unnamed_1.uses_flat_scratch, __unnamed_2.uses_flat_scratch)
-; CHECK: .set use.has_dyn_sized_stack, or(0, __unnamed_1.has_dyn_sized_stack, __unnamed_2.has_dyn_sized_stack)
-; CHECK: .set use.has_recursion, or(1, __unnamed_1.has_recursion, __unnamed_2.has_recursion)
-; CHECK: .set use.has_indirect_call, or(0, __unnamed_1.has_indirect_call, __unnamed_2.has_indirect_call)
+; CHECK: .set .Luse.num_vgpr, max(32, .L__unnamed_1.num_vgpr, .L__unnamed_2.num_vgpr)
+; CHECK: .set .Luse.num_agpr, max(0, .L__unnamed_1.num_agpr, .L__unnamed_2.num_agpr)
+; CHECK: .set .Luse.numbered_sgpr, max(33, .L__unnamed_1.numbered_sgpr, .L__unnamed_2.numbered_sgpr)
+; CHECK: .set .Luse.private_seg_size, 0+max(.L__unnamed_1.private_seg_size, .L__unnamed_2.private_seg_size)
+; CHECK: .set .Luse.uses_vcc, or(0, .L__unnamed_1.uses_vcc, .L__unnamed_2.uses_vcc)
+; CHECK: .set .Luse.uses_flat_scratch, or(1, .L__unnamed_1.uses_flat_scratch, .L__unnamed_2.uses_flat_scratch)
+; CHECK: .set .Luse.has_dyn_sized_stack, or(0, .L__unnamed_1.has_dyn_sized_stack, .L__unnamed_2.has_dyn_sized_stack)
+; CHECK: .set .Luse.has_recursion, or(1, .L__unnamed_1.has_recursion, .L__unnamed_2.has_recursion)
+; CHECK: .set .Luse.has_indirect_call, or(0, .L__unnamed_1.has_indirect_call, .L__unnamed_2.has_indirect_call)
 define amdgpu_kernel void @use() {
   call void @1()
   call void @2()


### PR DESCRIPTION
Reduce symbol table size for libraries. Object linking will more than likely divert from using symbols directly.

Fixes ROCM-14907