### PR TITLE
[LLDB][NativePDB] Ignore indirect virtual bases

### DIFF
--- a/lldb/source/Plugins/SymbolFile/NativePDB/UdtRecordCompleter.cpp
+++ b/lldb/source/Plugins/SymbolFile/NativePDB/UdtRecordCompleter.cpp
@@ -131,7 +131,7 @@ Error UdtRecordCompleter::visitKnownMember(CVMemberRecord &cvr,
   // one base class C of this class virtually inherits the specified class.
   // We already added that virtual base when creating C. There, it's present as
   // LF_VBCLASS.
-  if (cvr.Kind != LF_IVBCLASS)
+  if (cvr.Kind == LF_VBCLASS)
     AddBaseClassForTypeIndex(base.BaseType, base.getAccess(), base.VTableIndex);
 
   return Error::success();

--- a/lldb/source/Plugins/SymbolFile/NativePDB/UdtRecordCompleter.cpp
+++ b/lldb/source/Plugins/SymbolFile/NativePDB/UdtRecordCompleter.cpp
@@ -127,7 +127,12 @@ Error UdtRecordCompleter::visitKnownMember(CVMemberRecord &cvr,
 
 Error UdtRecordCompleter::visitKnownMember(CVMemberRecord &cvr,
                                            VirtualBaseClassRecord &base) {
-  AddBaseClassForTypeIndex(base.BaseType, base.getAccess(), base.VTableIndex);
+  // Don't create indirect virtual bases. These records indicate that at least
+  // one base class C of this class virtually inherits the specified class.
+  // We already added that virtual base when creating C. There, it's present as
+  // LF_VBCLASS.
+  if (cvr.Kind != LF_IVBCLASS)
+    AddBaseClassForTypeIndex(base.BaseType, base.getAccess(), base.VTableIndex);
 
   return Error::success();
 }

--- a/lldb/test/Shell/SymbolFile/NativePDB/tag-types.cpp
+++ b/lldb/test/Shell/SymbolFile/NativePDB/tag-types.cpp
@@ -247,7 +247,7 @@ int main(int argc, char **argv) {
 // CHECK-NEXT: class DerivedVirtual1 : virtual public Class {
 // CHECK-NEXT: }
 // CHECK-NEXT: (lldb) type lookup -- DerivedVirtual2
-// CHECK-NEXT: class DerivedVirtual2 : public DerivedVirtual1, virtual public Class, virtual public OneMember {
+// CHECK-NEXT: class DerivedVirtual2 : public DerivedVirtual1, virtual public OneMember {
 // CHECK-NEXT: }
 // CHECK-NEXT: (lldb) type lookup -- EnumInt
 // CHECK-NEXT: enum EnumInt {

--- a/lldb/test/Shell/SymbolFile/NativePDB/udt-layout.test
+++ b/lldb/test/Shell/SymbolFile/NativePDB/udt-layout.test
@@ -102,9 +102,6 @@ quit
 # CHECK-NEXT:         _b = 8
 # CHECK-NEXT:         _c = 12
 # CHECK-NEXT:       }
-# CHECK-NEXT:       A = {
-# CHECK-NEXT:         _u = (_u1 = '\x02', _u2 = 2, _u3 = 2)
-# CHECK-NEXT:       }
 # CHECK-NEXT:       B<0> = {
 # CHECK-NEXT:         A = {
 # CHECK-NEXT:           _u = (_u1 = '\x02', _u2 = 2, _u3 = 2)

--- a/lldb/test/Shell/SymbolFile/NativePDB/vbases.test
+++ b/lldb/test/Shell/SymbolFile/NativePDB/vbases.test
@@ -1,6 +1,6 @@
 # Test that LLDB displays indirect virtual bases correctly
 
-# REQUIRES: lld, x86
+# REQUIRES: lld, x86, system-windows
 
 # RUN: split-file %s %t
 

--- a/lldb/test/Shell/SymbolFile/NativePDB/vbases.test
+++ b/lldb/test/Shell/SymbolFile/NativePDB/vbases.test
@@ -1,0 +1,62 @@
+# Test that LLDB displays indirect virtual bases correctly
+
+# REQUIRES: lld, x86
+
+# RUN: split-file %s %t
+
+# RUN: %clang_cl --target=x86_64-windows-msvc -Z7 -c /Fo%t.cv.obj -- %t/main.cpp
+# RUN: %clang_cl --target=x86_64-windows-msvc -Z7 -gdwarf -c /Fo%t.dwarf.obj -- %t/main.cpp
+
+# RUN: lld-link -debug %t.cv.obj -out:%t.cv.exe
+# RUN: lld-link -debug %t.dwarf.obj -out:%t.dwarf.exe
+
+# RUN: %lldb -f %t.cv.exe -s %t/commands.input 2>&1 | FileCheck %s
+# RUN: %lldb -f %t.dwarf.exe -s %t/commands.input 2>&1 | FileCheck %s
+
+#--- main.cpp
+
+struct VBase1 {
+  short member = 1;
+};
+struct VBase2 {
+  short member = 2;
+};
+struct Base1 {
+  short member = 3;
+};
+struct Base2 {
+  short member = 4;
+};
+
+struct User : public virtual VBase1, public virtual VBase2 {
+  short member = 5;
+};
+
+struct UserUser : public Base1, public User, public Base2 {
+  short member = 6;
+};
+
+int main() {
+  UserUser useruser;
+
+  return 0; // break here
+}
+
+#--- commands.input
+
+br set -p "break here"
+r
+v useruser
+exit
+
+# CHECK:      (lldb) v useruser
+# CHECK-NEXT: (UserUser) useruser = {
+# CHECK-NEXT:   Base1 = (member = 3)
+# CHECK-NEXT:   User = {
+# CHECK-NEXT:     VBase1 = (member = 1)
+# CHECK-NEXT:     VBase2 = (member = 2)
+# CHECK-NEXT:     member = 5
+# CHECK-NEXT:   }
+# CHECK-NEXT:   Base2 = (member = 4)
+# CHECK-NEXT:   member = 6
+# CHECK-NEXT: }


### PR DESCRIPTION
When a class indirectly inherits from a class with virtual bases, it will get an `LF_IVBCLASS` record in its fieldlist, even though it doesn't directly inherit that class.

In the following example, `UserUser` inherits from `User`, which virtually inherits from `VBase`:

```cpp
struct User : public virtual VBase {};
struct UserUser : public User {};
```

For this we get
```
  0x1015 | LF_FIELDLIST [size = 72]
           - LF_BCLASS
             type = 0x1002 (-> 0x102A), offset = 0, attrs = public
           - LF_IVBCLASS
             base = 0x1003, vbptr = 0x1005, vbptr offset = 0, vtable index = 1
             attrs = public (...)
  0x1016 | LF_STRUCTURE [size = 48] `UserUser`
           unique name: `.?AUUserUser@@`
           vtable: <no type>, base list: <no type>, field list: 0x1015
           options: has ctor / dtor | has unique name | overloaded operator | overloaded operator=, sizeof 16
  0x1029 | LF_FIELDLIST [size = 56]
           - LF_VBCLASS
             base = 0x1003, vbptr = 0x1005, vbptr offset = 0, vtable index = 1
             attrs = public (...)
  0x102A | LF_STRUCTURE [size = 40] `User`
           unique name: `.?AUUser@@`
           vtable: <no type>, base list: <no type>, field list: 0x1029
           options: has ctor / dtor | has unique name | overloaded operator | overloaded operator=, sizeof 16
```

If I understand correctly, then `LF_IVBCLASS` indicates that if this class (e.g. `UserUser`) is created as the most derived object, it will host the class (e.g. `VBase`).
The VS debugger actually shows this as a separate field. LLDB on the other hand doesn't, so I removed it.

