### PR TITLE
[mlir][Pass] Report error when passing options to pipelines via shorthand syntax

### DIFF
--- a/mlir/lib/Pass/PassRegistry.cpp
+++ b/mlir/lib/Pass/PassRegistry.cpp
@@ -1022,7 +1022,9 @@ LogicalResult PassPipelineCLParser::addToPipeline(
   for (auto &passIt : impl->passList) {
     if (failed(passIt.registryEntry->addToPipeline(pm, passIt.options,
                                                    errorHandler)))
-      return failure();
+      return errorHandler("failed to add `" +
+                          passIt.registryEntry->getPassArgument() +
+                          "` with options `" + passIt.options + "`");
   }
   return success();
 }

--- a/mlir/test/Pass/invalid-pass.mlir
+++ b/mlir/test/Pass/invalid-pass.mlir
@@ -1,9 +1,11 @@
 // RUN: not mlir-opt %s -pass-pipeline='builtin.module(builtin.module(test-module-pass{test-option=a}))' 2>&1 | FileCheck %s
 // RUN: not mlir-opt %s -mlir-print-ir-module-scope -mlir-print-ir-before=cse 2>&1 | FileCheck -check-prefix=PRINT_MODULE_IR_WITH_MULTITHREAD %s
+// RUN: not mlir-opt %s --tosa-to-linalg-pipeline=foo 2>&1 | FileCheck -check-prefix=SHORTHAND %s
 
 // CHECK: <Pass-Options-Parser>: no such option test-option
 // CHECK: failed to add `test-module-pass` with options `test-option=a`
 // CHECK: failed to add `builtin.module` with options `` to inner pipeline
+// SHORTHAND: failed to add `tosa-to-linalg-pipeline` with options `foo`
 module {}
 
 // PRINT_MODULE_IR_WITH_MULTITHREAD: IR print for module scope can't be setup on a pass-manager without disabling multi-threading first.


### PR DESCRIPTION
When passing options to a pass pipeline that doesn't accept options, mlir-opt exits with error code 1, but prints no error message when using shorthand CLI syntax:

```
# Silent failure (no error message):
$ mlir-opt --tosa-to-linalg-pipeline=foo /dev/null
$ echo $?
1

# Same pipeline via --pass-pipeline syntax reports error:
$ mlir-opt --pass-pipeline='builtin.module(tosa-to-linalg-pipeline{foo})' /dev/null
<unknown>:0: error: failed to add `tosa-to-linalg-pipeline` with options `foo`
```

This PR adds replaces the silent call to `failure` with `errorHandler` in `PassPipelineCLParser::addToPipeline`, matching the existing pattern in `TextualPipeline::addToPipeline`.