### PR TITLE
[lld][Hexagon] Add "hexagonlinux" emulation alias

### DIFF
--- a/lld/ELF/Driver.cpp
+++ b/lld/ELF/Driver.cpp
@@ -180,7 +180,7 @@ static std::tuple<ELFKind, uint16_t, uint8_t> parseEmulation(Ctx &ctx,
           .Case("elf64_amdgpu", {ELF64LEKind, EM_AMDGPU})
           .Case("elf64loongarch", {ELF64LEKind, EM_LOONGARCH})
           .Case("elf64_s390", {ELF64BEKind, EM_S390})
-          .Case("hexagonelf", {ELF32LEKind, EM_HEXAGON})
+          .Cases({"hexagonelf", "hexagonlinux"}, {ELF32LEKind, EM_HEXAGON})
           .Default({ELFNoneKind, EM_NONE});
 
   if (ret.first == ELFNoneKind)

--- a/lld/test/ELF/emulation-hexagon.s
+++ b/lld/test/ELF/emulation-hexagon.s
@@ -4,6 +4,8 @@
 # RUN: llvm-readelf --file-headers %t | FileCheck --check-prefix=CHECK %s
 # RUN: ld.lld -m hexagonelf %t.o -o %t
 # RUN: llvm-readelf --file-headers %t | FileCheck --check-prefix=CHECK %s
+# RUN: ld.lld -m hexagonlinux %t.o -o %t
+# RUN: llvm-readelf --file-headers %t | FileCheck --check-prefix=CHECK %s
 
 # RUN: echo 'OUTPUT_FORMAT(elf32-littlehexagon)' > %t.script
 # RUN: ld.lld %t.script %t.o -o %t


### PR DESCRIPTION
Map the "hexagonlinux" emulation to the same ELF32 little-endian Hexagon target as the existing "hexagonelf" emulation.