### PR TITLE
[Hexagon] Pass -m emulation flag to linker from clang driver

### DIFF
--- a/clang/lib/Driver/ToolChains/CommonArgs.cpp
+++ b/clang/lib/Driver/ToolChains/CommonArgs.cpp
@@ -645,6 +645,10 @@ const char *tools::getLDMOption(const llvm::Triple &T, const ArgList &Args) {
     return "elf64ve";
   case llvm::Triple::csky:
     return "cskyelf_linux";
+  case llvm::Triple::hexagon:
+    if (T.isOSLinux())
+      return "hexagonlinux";
+    return "hexagonelf";
   default:
     return nullptr;
   }

--- a/clang/lib/Driver/ToolChains/Hexagon.cpp
+++ b/clang/lib/Driver/ToolChains/Hexagon.cpp
@@ -298,6 +298,12 @@ constructHexagonLinkArgs(Compilation &C, const JobAction &JA,
   Args.ClaimAllArgs(options::OPT_static_libgcc);
 
   CmdArgs.push_back("--eh-frame-hdr");
+
+  if (const char *LDMOption = getLDMOption(HTC.getTriple(), Args)) {
+    CmdArgs.push_back("-m");
+    CmdArgs.push_back(LDMOption);
+  }
+
   //----------------------------------------------------------------------------
   //
   //----------------------------------------------------------------------------

--- a/clang/test/Driver/hexagon-toolchain-elf.c
+++ b/clang/test/Driver/hexagon-toolchain-elf.c
@@ -563,6 +563,7 @@
 // RUN:   -mcpu=hexagonv60 \
 // RUN:   -fuse-ld=lld %s 2>&1 | FileCheck -check-prefix=CHECK382 %s
 // CHECK382:          "--eh-frame-hdr
+// CHECK382:          "-m" "hexagonelf"
 // CHECK382-NOT:      "-march=
 // CHECK382-NOT:      "-mcpu=
 // -----------------------------------------------------------------------------

--- a/clang/test/Driver/hexagon-toolchain-linux.c
+++ b/clang/test/Driver/hexagon-toolchain-linux.c
@@ -9,6 +9,7 @@
 // RUN:   -fuse-ld=lld \
 // RUN:   --sysroot=%S/Inputs/basic_linux_libcxx_tree %s 2>&1 | FileCheck -check-prefix=CHECK000 %s
 // CHECK000-NOT:  {{.*}}basic_linux_libcxx_tree{{/|\\\\}}usr{{/|\\\\}}lib{{/|\\\\}}crti.o
+// CHECK000:      "-m" "hexagonlinux"
 // CHECK000:      "-dynamic-linker={{/|\\\\}}lib{{/|\\\\}}ld-musl-hexagon.so.1"
 // CHECK000:      "{{.*}}basic_linux_libcxx_tree{{/|\\\\}}usr{{/|\\\\}}lib{{/|\\\\}}crt1.o"
 // CHECK000:      "-lc" "-lclang_rt.builtins-hexagon"


### PR DESCRIPTION
Teach the Hexagon clang driver to pass the -m emulation flag when invoking the linker. For Linux targets, pass "hexagonlinux"; for baremetal targets, pass "hexagonelf".