### PR TITLE
[lldb] Replace make_error<StringError> with createStringError* (NFC)

### DIFF
--- a/lldb/bindings/lua/lua-wrapper.swig
+++ b/lldb/bindings/lua/lua-wrapper.swig
@@ -26,9 +26,8 @@ lldb_private::lua::SWIGBridge::LLDBSwigLuaBreakpointCallbackFunction(
   // Call into the Lua callback passing 'sb_frame' and 'sb_bp_loc'.
   // Expects a boolean return.
   if (lua_pcall(L, nargs, 1, 0) != LUA_OK) {
-    llvm::Error E = llvm::make_error<llvm::StringError>(
-        llvm::formatv("{0}\n", lua_tostring(L, -1)),
-        llvm::inconvertibleErrorCode());
+    llvm::Error E = llvm::createStringError(
+        llvm::formatv("{0}\n", lua_tostring(L, -1)));
     // Pop error message from the stack.
     lua_pop(L, 1);
     return std::move(E);
@@ -56,9 +55,8 @@ lldb_private::lua::SWIGBridge::LLDBSwigLuaWatchpointCallbackFunction(
   // Call into the Lua callback passing 'sb_frame' and 'sb_wp'.
   // Expects a boolean return.
   if (lua_pcall(L, nargs, 1, 0) != LUA_OK) {
-    llvm::Error E = llvm::make_error<llvm::StringError>(
-        llvm::formatv("{0}\n", lua_tostring(L, -1)),
-        llvm::inconvertibleErrorCode());
+    llvm::Error E = llvm::createStringError(
+        llvm::formatv("{0}\n", lua_tostring(L, -1)));
     // Pop error message from the stack.
     lua_pop(L, 1);
     return std::move(E);

--- a/lldb/bindings/lua/lua-wrapper.swig
+++ b/lldb/bindings/lua/lua-wrapper.swig
@@ -1,4 +1,5 @@
 %header %{
+#include "llvm/Support/ErrorExtras.h"
 
 template <typename T> void PushSBClass(lua_State * L, T * obj);
 
@@ -26,8 +27,7 @@ lldb_private::lua::SWIGBridge::LLDBSwigLuaBreakpointCallbackFunction(
   // Call into the Lua callback passing 'sb_frame' and 'sb_bp_loc'.
   // Expects a boolean return.
   if (lua_pcall(L, nargs, 1, 0) != LUA_OK) {
-    llvm::Error E = llvm::createStringError(
-        llvm::formatv("{0}\n", lua_tostring(L, -1)));
+    llvm::Error E = llvm::createStringErrorV("{0}\n", lua_tostring(L, -1));
     // Pop error message from the stack.
     lua_pop(L, 1);
     return std::move(E);
@@ -55,8 +55,7 @@ lldb_private::lua::SWIGBridge::LLDBSwigLuaWatchpointCallbackFunction(
   // Call into the Lua callback passing 'sb_frame' and 'sb_wp'.
   // Expects a boolean return.
   if (lua_pcall(L, nargs, 1, 0) != LUA_OK) {
-    llvm::Error E = llvm::createStringError(
-        llvm::formatv("{0}\n", lua_tostring(L, -1)));
+    llvm::Error E = llvm::createStringErrorV("{0}\n", lua_tostring(L, -1));
     // Pop error message from the stack.
     lua_pop(L, 1);
     return std::move(E);

--- a/lldb/include/lldb/Target/Process.h
+++ b/lldb/include/lldb/Target/Process.h
@@ -685,8 +685,7 @@ public:
   /// \return
   ///    A status object indicating if the operation was sucessful or not.
   virtual llvm::Error LoadModules() {
-    return llvm::make_error<llvm::StringError>("Not implemented.",
-                                               llvm::inconvertibleErrorCode());
+    return llvm::createStringError("Not implemented.");
   }
 
   /// Query remote GDBServer for a detailed loaded library list

--- a/lldb/source/Interpreter/Options.cpp
+++ b/lldb/source/Interpreter/Options.cpp
@@ -981,7 +981,7 @@ llvm::Expected<Args> Options::ParseAlias(const Args &args,
     // See if the option takes an argument, and see if one was supplied.
     if (long_options_index == -1) {
       return llvm::createStringError(
-          llvm::formatv("Invalid option with value '{0}'.", char(val)).str());
+          llvm::formatv("Invalid option with value '{0}'.", char(val)));
     }
 
     StreamString option_str;

--- a/lldb/source/Interpreter/Options.cpp
+++ b/lldb/source/Interpreter/Options.cpp
@@ -23,6 +23,7 @@
 #include "lldb/Utility/AnsiTerminal.h"
 #include "lldb/Utility/StreamString.h"
 #include "llvm/ADT/STLExtras.h"
+#include "llvm/Support/ErrorExtras.h"
 
 using namespace lldb;
 using namespace lldb_private;
@@ -980,8 +981,8 @@ llvm::Expected<Args> Options::ParseAlias(const Args &args,
 
     // See if the option takes an argument, and see if one was supplied.
     if (long_options_index == -1) {
-      return llvm::createStringError(
-          llvm::formatv("Invalid option with value '{0}'.", char(val)));
+      return llvm::createStringErrorV("Invalid option with value '{0}'.",
+                                      char(val));
     }
 
     StreamString option_str;

--- a/lldb/source/Plugins/Process/AIX/NativeProcessAIX.cpp
+++ b/lldb/source/Plugins/Process/AIX/NativeProcessAIX.cpp
@@ -80,8 +80,7 @@ NativeProcessAIX::Manager::Launch(ProcessLaunchInfo &launch_info,
   if (!WIFSTOPPED(wstatus)) {
     LLDB_LOG(log, "Could not sync with inferior process: wstatus={1}",
              WaitStatus::Decode(wstatus));
-    return llvm::make_error<StringError>("Could not sync with inferior process",
-                                         llvm::inconvertibleErrorCode());
+    return llvm::createStringError("Could not sync with inferior process");
   }
   LLDB_LOG(log, "inferior started, now in stopped state");
 

--- a/lldb/source/Plugins/Process/FreeBSD/NativeProcessFreeBSD.cpp
+++ b/lldb/source/Plugins/Process/FreeBSD/NativeProcessFreeBSD.cpp
@@ -92,15 +92,13 @@ NativeProcessFreeBSD::Manager::Launch(ProcessLaunchInfo &launch_info,
   if (!WIFSTOPPED(wstatus)) {
     LLDB_LOG(log, "Could not sync with inferior process: wstatus={1}",
              WaitStatus::Decode(wstatus));
-    return llvm::make_error<StringError>("Could not sync with inferior process",
-                                         llvm::inconvertibleErrorCode());
+    return llvm::createStringError("Could not sync with inferior process");
   }
   LLDB_LOG(log, "inferior started, now in stopped state");
 
   ProcessInstanceInfo Info;
   if (!Host::GetProcessInfo(pid, Info)) {
-    return llvm::make_error<StringError>("Cannot get process architecture",
-                                         llvm::inconvertibleErrorCode());
+    return llvm::createStringError("Cannot get process architecture");
   }
 
   // Set the architecture to the exe architecture.
@@ -131,8 +129,7 @@ NativeProcessFreeBSD::Manager::Attach(
   // Retrieve the architecture for the running process.
   ProcessInstanceInfo Info;
   if (!Host::GetProcessInfo(pid, Info)) {
-    return llvm::make_error<StringError>("Cannot get process architecture",
-                                         llvm::inconvertibleErrorCode());
+    return llvm::createStringError("Cannot get process architecture");
   }
 
   std::unique_ptr<NativeProcessFreeBSD> process_up(new NativeProcessFreeBSD(

--- a/lldb/source/Plugins/Process/Linux/NativeProcessLinux.cpp
+++ b/lldb/source/Plugins/Process/Linux/NativeProcessLinux.cpp
@@ -287,8 +287,7 @@ NativeProcessLinux::Manager::Launch(ProcessLaunchInfo &launch_info,
   if (!WIFSTOPPED(wstatus)) {
     LLDB_LOG(log, "Could not sync with inferior process: wstatus={1}",
              WaitStatus::Decode(wstatus));
-    return llvm::make_error<StringError>("Could not sync with inferior process",
-                                         llvm::inconvertibleErrorCode());
+    return llvm::createStringError("Could not sync with inferior process");
   }
   LLDB_LOG(log, "inferior started, now in stopped state");
 
@@ -505,8 +504,7 @@ llvm::Expected<std::vector<::pid_t>> NativeProcessLinux::Attach(::pid_t pid) {
 
   size_t tid_count = tids_to_attach.size();
   if (tid_count == 0)
-    return llvm::make_error<StringError>("No such process",
-                                         llvm::inconvertibleErrorCode());
+    return llvm::createStringError("No such process");
 
   std::vector<::pid_t> tids;
   tids.reserve(tid_count);

--- a/lldb/source/Plugins/Process/NetBSD/NativeProcessNetBSD.cpp
+++ b/lldb/source/Plugins/Process/NetBSD/NativeProcessNetBSD.cpp
@@ -78,15 +78,13 @@ NativeProcessNetBSD::Manager::Launch(ProcessLaunchInfo &launch_info,
   if (!WIFSTOPPED(wstatus)) {
     LLDB_LOG(log, "Could not sync with inferior process: wstatus={1}",
              WaitStatus::Decode(wstatus));
-    return llvm::make_error<StringError>("Could not sync with inferior process",
-                                         llvm::inconvertibleErrorCode());
+    return llvm::createStringError("Could not sync with inferior process");
   }
   LLDB_LOG(log, "inferior started, now in stopped state");
 
   ProcessInstanceInfo Info;
   if (!Host::GetProcessInfo(pid, Info)) {
-    return llvm::make_error<StringError>("Cannot get process architecture",
-                                         llvm::inconvertibleErrorCode());
+    return llvm::createStringError("Cannot get process architecture");
   }
 
   // Set the architecture to the exe architecture.
@@ -117,8 +115,7 @@ NativeProcessNetBSD::Manager::Attach(
   // Retrieve the architecture for the running process.
   ProcessInstanceInfo Info;
   if (!Host::GetProcessInfo(pid, Info)) {
-    return llvm::make_error<StringError>("Cannot get process architecture",
-                                         llvm::inconvertibleErrorCode());
+    return llvm::createStringError("Cannot get process architecture");
   }
 
   std::unique_ptr<NativeProcessNetBSD> process_up(new NativeProcessNetBSD(

--- a/lldb/source/Plugins/Process/elf-core/ProcessElfCore.cpp
+++ b/lldb/source/Plugins/Process/elf-core/ProcessElfCore.cpp
@@ -597,15 +597,13 @@ static llvm::Error ParseNetBSDProcInfo(const DataExtractor &data,
 
   uint32_t version = data.GetU32(&offset);
   if (version != 1)
-    return llvm::make_error<llvm::StringError>(
-        "Error parsing NetBSD core(5) notes: Unsupported procinfo version",
-        llvm::inconvertibleErrorCode());
+    return llvm::createStringError(
+        "Error parsing NetBSD core(5) notes: Unsupported procinfo version");
 
   uint32_t cpisize = data.GetU32(&offset);
   if (cpisize != NETBSD::NT_PROCINFO_SIZE)
-    return llvm::make_error<llvm::StringError>(
-        "Error parsing NetBSD core(5) notes: Unsupported procinfo size",
-        llvm::inconvertibleErrorCode());
+    return llvm::createStringError(
+        "Error parsing NetBSD core(5) notes: Unsupported procinfo size");
 
   cpi_signo = data.GetU32(&offset); /* killing signal */
 
@@ -652,8 +650,7 @@ ProcessElfCore::parseSegment(const DataExtractor &segment) {
   while (offset < segment.GetByteSize()) {
     ELFNote note = ELFNote();
     if (!note.Parse(segment, &offset))
-      return llvm::make_error<llvm::StringError>(
-          "Unable to parse note segment", llvm::inconvertibleErrorCode());
+      return llvm::createStringError("Unable to parse note segment");
 
     size_t note_start = offset;
     size_t note_size = llvm::alignTo(note.n_descsz, 4);
@@ -711,9 +708,8 @@ llvm::Error ProcessElfCore::parseFreeBSDNotes(llvm::ArrayRef<CoreNote> notes) {
     }
   }
   if (!have_prstatus) {
-    return llvm::make_error<llvm::StringError>(
-        "Could not find NT_PRSTATUS note in core file.",
-        llvm::inconvertibleErrorCode());
+    return llvm::createStringError(
+        "Could not find NT_PRSTATUS note in core file.");
   }
   m_thread_data.push_back(thread_data);
   return llvm::Error::success();
@@ -768,10 +764,9 @@ llvm::Error ProcessElfCore::parseNetBSDNotes(llvm::ArrayRef<CoreNote> notes) {
     } else if (name.consume_front("NetBSD-CORE@")) {
       lldb::tid_t tid;
       if (name.getAsInteger(10, tid))
-        return llvm::make_error<llvm::StringError>(
+        return llvm::createStringError(
             "Error parsing NetBSD core(5) notes: Cannot convert LWP ID "
-            "to integer",
-            llvm::inconvertibleErrorCode());
+            "to integer");
 
       switch (GetArchitecture().GetMachine()) {
       case llvm::Triple::aarch64: {
@@ -787,16 +782,14 @@ llvm::Error ProcessElfCore::parseNetBSDNotes(llvm::ArrayRef<CoreNote> notes) {
           thread_data.gpregset = note.data;
           thread_data.tid = tid;
           if (thread_data.gpregset.GetByteSize() == 0)
-            return llvm::make_error<llvm::StringError>(
-                "Could not find general purpose registers note in core file.",
-                llvm::inconvertibleErrorCode());
+            return llvm::createStringError(
+                "Could not find general purpose registers note in core file.");
           had_nt_regs = true;
         } else if (note.info.n_type == NETBSD::AARCH64::NT_FPREGS) {
           if (!had_nt_regs || tid != thread_data.tid)
-            return llvm::make_error<llvm::StringError>(
+            return llvm::createStringError(
                 "Error parsing NetBSD core(5) notes: Unexpected order "
-                "of NOTEs PT_GETFPREG before PT_GETREG",
-                llvm::inconvertibleErrorCode());
+                "of NOTEs PT_GETFPREG before PT_GETREG");
           thread_data.notes.push_back(note);
         }
       } break;
@@ -813,16 +806,14 @@ llvm::Error ProcessElfCore::parseNetBSDNotes(llvm::ArrayRef<CoreNote> notes) {
           thread_data.gpregset = note.data;
           thread_data.tid = tid;
           if (thread_data.gpregset.GetByteSize() == 0)
-            return llvm::make_error<llvm::StringError>(
-                "Could not find general purpose registers note in core file.",
-                llvm::inconvertibleErrorCode());
+            return llvm::createStringError(
+                "Could not find general purpose registers note in core file.");
           had_nt_regs = true;
         } else if (note.info.n_type == NETBSD::I386::NT_FPREGS) {
           if (!had_nt_regs || tid != thread_data.tid)
-            return llvm::make_error<llvm::StringError>(
+            return llvm::createStringError(
                 "Error parsing NetBSD core(5) notes: Unexpected order "
-                "of NOTEs PT_GETFPREG before PT_GETREG",
-                llvm::inconvertibleErrorCode());
+                "of NOTEs PT_GETFPREG before PT_GETREG");
           thread_data.notes.push_back(note);
         }
       } break;
@@ -839,16 +830,14 @@ llvm::Error ProcessElfCore::parseNetBSDNotes(llvm::ArrayRef<CoreNote> notes) {
           thread_data.gpregset = note.data;
           thread_data.tid = tid;
           if (thread_data.gpregset.GetByteSize() == 0)
-            return llvm::make_error<llvm::StringError>(
-                "Could not find general purpose registers note in core file.",
-                llvm::inconvertibleErrorCode());
+            return llvm::createStringError(
+                "Could not find general purpose registers note in core file.");
           had_nt_regs = true;
         } else if (note.info.n_type == NETBSD::AMD64::NT_FPREGS) {
           if (!had_nt_regs || tid != thread_data.tid)
-            return llvm::make_error<llvm::StringError>(
+            return llvm::createStringError(
                 "Error parsing NetBSD core(5) notes: Unexpected order "
-                "of NOTEs PT_GETFPREG before PT_GETREG",
-                llvm::inconvertibleErrorCode());
+                "of NOTEs PT_GETFPREG before PT_GETREG");
           thread_data.notes.push_back(note);
         }
       } break;
@@ -863,17 +852,15 @@ llvm::Error ProcessElfCore::parseNetBSDNotes(llvm::ArrayRef<CoreNote> notes) {
     m_thread_data.push_back(thread_data);
 
   if (m_thread_data.empty())
-    return llvm::make_error<llvm::StringError>(
+    return llvm::createStringError(
         "Error parsing NetBSD core(5) notes: No threads information "
-        "specified in notes",
-        llvm::inconvertibleErrorCode());
+        "specified in notes");
 
   if (m_thread_data.size() != nlwps)
-    return llvm::make_error<llvm::StringError>(
+    return llvm::createStringError(
         "Error parsing NetBSD core(5) notes: Mismatch between the number "
         "of LWPs in netbsd_elfcore_procinfo and the number of LWPs specified "
-        "by MD notes",
-        llvm::inconvertibleErrorCode());
+        "by MD notes");
 
   // Signal targeted at the whole process.
   if (siglwp == 0) {
@@ -893,9 +880,8 @@ llvm::Error ProcessElfCore::parseNetBSDNotes(llvm::ArrayRef<CoreNote> notes) {
     }
 
     if (!passed)
-      return llvm::make_error<llvm::StringError>(
-          "Error parsing NetBSD core(5) notes: Signal passed to unknown LWP",
-          llvm::inconvertibleErrorCode());
+      return llvm::createStringError(
+          "Error parsing NetBSD core(5) notes: Signal passed to unknown LWP");
   }
 
   return llvm::Error::success();
@@ -925,9 +911,8 @@ llvm::Error ProcessElfCore::parseOpenBSDNotes(llvm::ArrayRef<CoreNote> notes) {
     }
   }
   if (thread_data.gpregset.GetByteSize() == 0) {
-    return llvm::make_error<llvm::StringError>(
-        "Could not find general purpose registers note in core file.",
-        llvm::inconvertibleErrorCode());
+    return llvm::createStringError(
+        "Could not find general purpose registers note in core file.");
   }
   m_thread_data.push_back(thread_data);
   return llvm::Error::success();
@@ -1051,9 +1036,8 @@ llvm::Error ProcessElfCore::ParseThreadContextsFromNoteSegment(
   case llvm::Triple::OpenBSD:
     return parseOpenBSDNotes(*notes_or_error);
   default:
-    return llvm::make_error<llvm::StringError>(
-        "Don't know how to parse core file. Unsupported OS.",
-        llvm::inconvertibleErrorCode());
+    return llvm::createStringError(
+        "Don't know how to parse core file. Unsupported OS.");
   }
 }
 

--- a/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationServerLLGS.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationServerLLGS.cpp
@@ -2457,7 +2457,8 @@ GDBRemoteCommunicationServerLLGS::Handle_H(StringExtractorGDBRemote &packet) {
   if (pid == StringExtractorGDBRemote::AllProcesses)
     return SendUnimplementedResponse("Selecting all processes not supported");
   if (pid == LLDB_INVALID_PROCESS_ID)
-    return SendErrorResponse(llvm::createStringError("No current process and no PID provided"));
+    return SendErrorResponse(
+        llvm::createStringError("No current process and no PID provided"));
 
   // Check the process ID and find respective process instance.
   auto new_process_it = m_debugged_processes.find(pid);
@@ -4137,7 +4138,8 @@ GDBRemoteCommunicationServerLLGS::Handle_T(StringExtractorGDBRemote &packet) {
   // Technically, this would also be caught by the PID check but let's be more
   // explicit about the error.
   if (pid == LLDB_INVALID_PROCESS_ID)
-    return SendErrorResponse(llvm::createStringError("No current process and no PID provided"));
+    return SendErrorResponse(
+        llvm::createStringError("No current process and no PID provided"));
 
   // Check the process ID and find respective process instance.
   auto new_process_it = m_debugged_processes.find(pid);

--- a/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationServerLLGS.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationServerLLGS.cpp
@@ -800,8 +800,7 @@ GetJSONThreadsInfo(NativeProcessProtocol &process, bool abridged) {
     struct ThreadStopInfo tid_stop_info;
     std::string description;
     if (!thread.GetStopReason(tid_stop_info, description))
-      return llvm::make_error<llvm::StringError>(
-          "failed to get stop reason", llvm::inconvertibleErrorCode());
+      return llvm::createStringError("failed to get stop reason");
 
     const int signum = tid_stop_info.signo;
     if (log) {
@@ -2450,8 +2449,7 @@ GDBRemoteCommunicationServerLLGS::Handle_H(StringExtractorGDBRemote &packet) {
   auto pid_tid = packet.GetPidTid(default_process ? default_process->GetID()
                                                   : LLDB_INVALID_PROCESS_ID);
   if (!pid_tid)
-    return SendErrorResponse(llvm::make_error<StringError>(
-        inconvertibleErrorCode(), "Malformed thread-id"));
+    return SendErrorResponse(llvm::createStringError("Malformed thread-id"));
 
   lldb::pid_t pid = pid_tid->first;
   lldb::tid_t tid = pid_tid->second;
@@ -2459,14 +2457,12 @@ GDBRemoteCommunicationServerLLGS::Handle_H(StringExtractorGDBRemote &packet) {
   if (pid == StringExtractorGDBRemote::AllProcesses)
     return SendUnimplementedResponse("Selecting all processes not supported");
   if (pid == LLDB_INVALID_PROCESS_ID)
-    return SendErrorResponse(llvm::make_error<StringError>(
-        inconvertibleErrorCode(), "No current process and no PID provided"));
+    return SendErrorResponse(llvm::createStringError("No current process and no PID provided"));
 
   // Check the process ID and find respective process instance.
   auto new_process_it = m_debugged_processes.find(pid);
   if (new_process_it == m_debugged_processes.end())
-    return SendErrorResponse(llvm::make_error<StringError>(
-        inconvertibleErrorCode(),
+    return SendErrorResponse(llvm::createStringError(
         llvm::formatv("No process with PID {0} debugged", pid)));
 
   // Ensure we have the given thread when not specifying -1 (all threads) or 0
@@ -4133,8 +4129,7 @@ GDBRemoteCommunicationServerLLGS::Handle_T(StringExtractorGDBRemote &packet) {
   auto pid_tid = packet.GetPidTid(m_current_process ? m_current_process->GetID()
                                                     : LLDB_INVALID_PROCESS_ID);
   if (!pid_tid)
-    return SendErrorResponse(llvm::make_error<StringError>(
-        inconvertibleErrorCode(), "Malformed thread-id"));
+    return SendErrorResponse(llvm::createStringError("Malformed thread-id"));
 
   lldb::pid_t pid = pid_tid->first;
   lldb::tid_t tid = pid_tid->second;
@@ -4142,8 +4137,7 @@ GDBRemoteCommunicationServerLLGS::Handle_T(StringExtractorGDBRemote &packet) {
   // Technically, this would also be caught by the PID check but let's be more
   // explicit about the error.
   if (pid == LLDB_INVALID_PROCESS_ID)
-    return SendErrorResponse(llvm::make_error<StringError>(
-        inconvertibleErrorCode(), "No current process and no PID provided"));
+    return SendErrorResponse(llvm::createStringError("No current process and no PID provided"));
 
   // Check the process ID and find respective process instance.
   auto new_process_it = m_debugged_processes.find(pid);

--- a/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationServerLLGS.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationServerLLGS.cpp
@@ -41,6 +41,7 @@
 #include "lldb/Utility/StreamString.h"
 #include "lldb/Utility/UnimplementedError.h"
 #include "lldb/Utility/UriParser.h"
+#include "llvm/Support/ErrorExtras.h"
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/JSON.h"
 #include "llvm/Support/ScopedPrinter.h"
@@ -2463,8 +2464,8 @@ GDBRemoteCommunicationServerLLGS::Handle_H(StringExtractorGDBRemote &packet) {
   // Check the process ID and find respective process instance.
   auto new_process_it = m_debugged_processes.find(pid);
   if (new_process_it == m_debugged_processes.end())
-    return SendErrorResponse(llvm::createStringError(
-        llvm::formatv("No process with PID {0} debugged", pid)));
+    return SendErrorResponse(
+        llvm::createStringErrorV("No process with PID {0} debugged", pid));
 
   // Ensure we have the given thread when not specifying -1 (all threads) or 0
   // (any thread).

--- a/lldb/source/Plugins/Protocol/MCP/Resource.cpp
+++ b/lldb/source/Plugins/Protocol/MCP/Resource.cpp
@@ -58,7 +58,7 @@ static constexpr llvm::StringLiteral kMimeTypeJSON = "application/json";
 template <typename... Args>
 static llvm::Error createStringError(const char *format, Args &&...args) {
   return llvm::createStringError(
-      llvm::formatv(format, std::forward<Args>(args)...).str());
+      llvm::formatv(format, std::forward<Args>(args)...));
 }
 
 static llvm::Error createUnsupportedURIError(llvm::StringRef uri) {

--- a/lldb/source/Plugins/Protocol/MCP/Resource.cpp
+++ b/lldb/source/Plugins/Protocol/MCP/Resource.cpp
@@ -56,12 +56,6 @@ llvm::json::Value toJSON(const TargetResource &TR) {
 
 static constexpr llvm::StringLiteral kMimeTypeJSON = "application/json";
 
-template <typename... Args>
-static llvm::Error createStringError(const char *format, Args &&...args) {
-  return llvm::createStringError(
-      llvm::formatv(format, std::forward<Args>(args)...));
-}
-
 static llvm::Error createUnsupportedURIError(llvm::StringRef uri) {
   return llvm::make_error<UnsupportedURI>(uri.str());
 }
@@ -143,8 +137,8 @@ DebuggerResourceProvider::ReadResource(llvm::StringRef uri) const {
 
   size_t debugger_idx;
   if (components[1].getAsInteger(0, debugger_idx))
-    return createStringError("invalid debugger id '{0}': {1}", components[1],
-                             path);
+    return llvm::createStringErrorV("invalid debugger id '{0}': {1}",
+                                    components[1], path);
 
   if (components.size() > 3) {
     if (components[2] != "target")
@@ -152,8 +146,8 @@ DebuggerResourceProvider::ReadResource(llvm::StringRef uri) const {
 
     size_t target_idx;
     if (components[3].getAsInteger(0, target_idx))
-      return createStringError("invalid target id '{0}': {1}", components[3],
-                               path);
+      return llvm::createStringErrorV("invalid target id '{0}': {1}",
+                                      components[3], path);
 
     return ReadTargetResource(uri, debugger_idx, target_idx);
   }
@@ -166,7 +160,7 @@ DebuggerResourceProvider::ReadDebuggerResource(llvm::StringRef uri,
                                                lldb::user_id_t debugger_id) {
   lldb::DebuggerSP debugger_sp = Debugger::FindDebuggerWithID(debugger_id);
   if (!debugger_sp)
-    return createStringError("invalid debugger id: {0}", debugger_id);
+    return llvm::createStringErrorV("invalid debugger id: {0}", debugger_id);
 
   DebuggerResource debugger_resource;
   debugger_resource.debugger_id = debugger_id;
@@ -190,12 +184,12 @@ DebuggerResourceProvider::ReadTargetResource(llvm::StringRef uri,
 
   lldb::DebuggerSP debugger_sp = Debugger::FindDebuggerWithID(debugger_id);
   if (!debugger_sp)
-    return createStringError("invalid debugger id: {0}", debugger_id);
+    return llvm::createStringErrorV("invalid debugger id: {0}", debugger_id);
 
   TargetList &target_list = debugger_sp->GetTargetList();
   lldb::TargetSP target_sp = target_list.GetTargetAtIndex(target_idx);
   if (!target_sp)
-    return createStringError("invalid target idx: {0}", target_idx);
+    return llvm::createStringErrorV("invalid target idx: {0}", target_idx);
 
   TargetResource target_resource;
   target_resource.debugger_id = debugger_id;

--- a/lldb/source/Plugins/Protocol/MCP/Resource.cpp
+++ b/lldb/source/Plugins/Protocol/MCP/Resource.cpp
@@ -5,10 +5,10 @@
 //===----------------------------------------------------------------------===//
 
 #include "Resource.h"
-#include "llvm/Support/ErrorExtras.h"
 #include "lldb/Core/Debugger.h"
 #include "lldb/Core/Module.h"
 #include "lldb/Protocol/MCP/MCPError.h"
+#include "llvm/Support/ErrorExtras.h"
 
 using namespace lldb_private;
 using namespace lldb_private::mcp;

--- a/lldb/source/Plugins/Protocol/MCP/Resource.cpp
+++ b/lldb/source/Plugins/Protocol/MCP/Resource.cpp
@@ -5,6 +5,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "Resource.h"
+#include "llvm/Support/ErrorExtras.h"
 #include "lldb/Core/Debugger.h"
 #include "lldb/Core/Module.h"
 #include "lldb/Protocol/MCP/MCPError.h"

--- a/lldb/source/Plugins/ScriptInterpreter/Lua/LuaState.cpp
+++ b/lldb/source/Plugins/ScriptInterpreter/Lua/LuaState.cpp
@@ -51,9 +51,8 @@ llvm::Error LuaState::Run(llvm::StringRef buffer) {
   if (error == LUA_OK)
     return llvm::Error::success();
 
-  llvm::Error e = llvm::make_error<llvm::StringError>(
-      llvm::formatv("{0}\n", lua_tostring(m_lua_state, -1)),
-      llvm::inconvertibleErrorCode());
+  llvm::Error e = llvm::createStringError(
+      llvm::formatv("{0}\n", lua_tostring(m_lua_state, -1)));
   // Pop error message from the stack.
   lua_pop(m_lua_state, 1);
   return e;
@@ -65,9 +64,8 @@ llvm::Error LuaState::RegisterBreakpointCallback(void *baton,
   const char *fmt_str = "return function(frame, bp_loc, ...) {0} end";
   std::string func_str = llvm::formatv(fmt_str, body).str();
   if (luaL_dostring(m_lua_state, func_str.c_str()) != LUA_OK) {
-    llvm::Error e = llvm::make_error<llvm::StringError>(
-        llvm::formatv("{0}", lua_tostring(m_lua_state, -1)),
-        llvm::inconvertibleErrorCode());
+    llvm::Error e = llvm::createStringError(
+        llvm::formatv("{0}", lua_tostring(m_lua_state, -1)));
     // Pop error message from the stack.
     lua_pop(m_lua_state, 2);
     return e;
@@ -94,9 +92,8 @@ llvm::Error LuaState::RegisterWatchpointCallback(void *baton,
   const char *fmt_str = "return function(frame, wp, ...) {0} end";
   std::string func_str = llvm::formatv(fmt_str, body).str();
   if (luaL_dostring(m_lua_state, func_str.c_str()) != LUA_OK) {
-    llvm::Error e = llvm::make_error<llvm::StringError>(
-        llvm::formatv("{0}", lua_tostring(m_lua_state, -1)),
-        llvm::inconvertibleErrorCode());
+    llvm::Error e = llvm::createStringError(
+        llvm::formatv("{0}", lua_tostring(m_lua_state, -1)));
     // Pop error message from the stack.
     lua_pop(m_lua_state, 2);
     return e;
@@ -124,9 +121,8 @@ llvm::Error LuaState::CheckSyntax(llvm::StringRef buffer) {
     return llvm::Error::success();
   }
 
-  llvm::Error e = llvm::make_error<llvm::StringError>(
-      llvm::formatv("{0}\n", lua_tostring(m_lua_state, -1)),
-      llvm::inconvertibleErrorCode());
+  llvm::Error e = llvm::createStringError(
+      llvm::formatv("{0}\n", lua_tostring(m_lua_state, -1)));
   // Pop error message from the stack.
   lua_pop(m_lua_state, 1);
   return e;
@@ -135,21 +131,18 @@ llvm::Error LuaState::CheckSyntax(llvm::StringRef buffer) {
 llvm::Error LuaState::LoadModule(llvm::StringRef filename) {
   const FileSpec file(filename);
   if (!FileSystem::Instance().Exists(file)) {
-    return llvm::make_error<llvm::StringError>("invalid path",
-                                               llvm::inconvertibleErrorCode());
+    return llvm::createStringError("invalid path");
   }
 
   if (file.GetFileNameExtension() != ".lua") {
-    return llvm::make_error<llvm::StringError>("invalid extension",
-                                               llvm::inconvertibleErrorCode());
+    return llvm::createStringError("invalid extension");
   }
 
   int error = luaL_loadfile(m_lua_state, filename.data()) ||
               lua_pcall(m_lua_state, 0, 1, 0);
   if (error != LUA_OK) {
-    llvm::Error e = llvm::make_error<llvm::StringError>(
-        llvm::formatv("{0}\n", lua_tostring(m_lua_state, -1)),
-        llvm::inconvertibleErrorCode());
+    llvm::Error e = llvm::createStringError(
+        llvm::formatv("{0}\n", lua_tostring(m_lua_state, -1)));
     // Pop error message from the stack.
     lua_pop(m_lua_state, 1);
     return e;
@@ -173,8 +166,7 @@ llvm::Error LuaState::ChangeIO(FILE *out, FILE *err) {
     lua_pop(m_lua_state, 1);
   } else {
     lua_pop(m_lua_state, 2);
-    return llvm::make_error<llvm::StringError>("could not get stdout",
-                                               llvm::inconvertibleErrorCode());
+    return llvm::createStringError("could not get stdout");
   }
 
   lua_getfield(m_lua_state, -1, "stderr");
@@ -184,8 +176,7 @@ llvm::Error LuaState::ChangeIO(FILE *out, FILE *err) {
     lua_pop(m_lua_state, 1);
   } else {
     lua_pop(m_lua_state, 2);
-    return llvm::make_error<llvm::StringError>("could not get stderr",
-                                               llvm::inconvertibleErrorCode());
+    return llvm::createStringError("could not get stderr");
   }
 
   lua_pop(m_lua_state, 1);

--- a/lldb/source/Plugins/ScriptInterpreter/Lua/LuaState.cpp
+++ b/lldb/source/Plugins/ScriptInterpreter/Lua/LuaState.cpp
@@ -11,6 +11,7 @@
 #include "lldb/Host/FileSystem.h"
 #include "lldb/Utility/FileSpec.h"
 #include "llvm/Support/Error.h"
+#include "llvm/Support/ErrorExtras.h"
 #include "llvm/Support/FormatVariadic.h"
 
 using namespace lldb_private;
@@ -51,8 +52,7 @@ llvm::Error LuaState::Run(llvm::StringRef buffer) {
   if (error == LUA_OK)
     return llvm::Error::success();
 
-  llvm::Error e = llvm::createStringError(
-      llvm::formatv("{0}\n", lua_tostring(m_lua_state, -1)));
+  llvm::Error e = llvm::createStringErrorV("{0}\n", lua_tostring(m_lua_state, -1));
   // Pop error message from the stack.
   lua_pop(m_lua_state, 1);
   return e;
@@ -64,8 +64,7 @@ llvm::Error LuaState::RegisterBreakpointCallback(void *baton,
   const char *fmt_str = "return function(frame, bp_loc, ...) {0} end";
   std::string func_str = llvm::formatv(fmt_str, body).str();
   if (luaL_dostring(m_lua_state, func_str.c_str()) != LUA_OK) {
-    llvm::Error e = llvm::createStringError(
-        llvm::formatv("{0}", lua_tostring(m_lua_state, -1)));
+    llvm::Error e = llvm::createStringErrorV("{0}", lua_tostring(m_lua_state, -1));
     // Pop error message from the stack.
     lua_pop(m_lua_state, 2);
     return e;
@@ -92,8 +91,7 @@ llvm::Error LuaState::RegisterWatchpointCallback(void *baton,
   const char *fmt_str = "return function(frame, wp, ...) {0} end";
   std::string func_str = llvm::formatv(fmt_str, body).str();
   if (luaL_dostring(m_lua_state, func_str.c_str()) != LUA_OK) {
-    llvm::Error e = llvm::createStringError(
-        llvm::formatv("{0}", lua_tostring(m_lua_state, -1)));
+    llvm::Error e = llvm::createStringErrorV("{0}", lua_tostring(m_lua_state, -1));
     // Pop error message from the stack.
     lua_pop(m_lua_state, 2);
     return e;
@@ -121,8 +119,7 @@ llvm::Error LuaState::CheckSyntax(llvm::StringRef buffer) {
     return llvm::Error::success();
   }
 
-  llvm::Error e = llvm::createStringError(
-      llvm::formatv("{0}\n", lua_tostring(m_lua_state, -1)));
+  llvm::Error e = llvm::createStringErrorV("{0}\n", lua_tostring(m_lua_state, -1));
   // Pop error message from the stack.
   lua_pop(m_lua_state, 1);
   return e;
@@ -141,8 +138,7 @@ llvm::Error LuaState::LoadModule(llvm::StringRef filename) {
   int error = luaL_loadfile(m_lua_state, filename.data()) ||
               lua_pcall(m_lua_state, 0, 1, 0);
   if (error != LUA_OK) {
-    llvm::Error e = llvm::createStringError(
-        llvm::formatv("{0}\n", lua_tostring(m_lua_state, -1)));
+    llvm::Error e = llvm::createStringErrorV("{0}\n", lua_tostring(m_lua_state, -1));
     // Pop error message from the stack.
     lua_pop(m_lua_state, 1);
     return e;

--- a/lldb/source/Plugins/ScriptInterpreter/Lua/LuaState.cpp
+++ b/lldb/source/Plugins/ScriptInterpreter/Lua/LuaState.cpp
@@ -52,7 +52,8 @@ llvm::Error LuaState::Run(llvm::StringRef buffer) {
   if (error == LUA_OK)
     return llvm::Error::success();
 
-  llvm::Error e = llvm::createStringErrorV("{0}\n", lua_tostring(m_lua_state, -1));
+  llvm::Error e =
+      llvm::createStringErrorV("{0}\n", lua_tostring(m_lua_state, -1));
   // Pop error message from the stack.
   lua_pop(m_lua_state, 1);
   return e;
@@ -64,7 +65,8 @@ llvm::Error LuaState::RegisterBreakpointCallback(void *baton,
   const char *fmt_str = "return function(frame, bp_loc, ...) {0} end";
   std::string func_str = llvm::formatv(fmt_str, body).str();
   if (luaL_dostring(m_lua_state, func_str.c_str()) != LUA_OK) {
-    llvm::Error e = llvm::createStringErrorV("{0}", lua_tostring(m_lua_state, -1));
+    llvm::Error e =
+        llvm::createStringErrorV("{0}", lua_tostring(m_lua_state, -1));
     // Pop error message from the stack.
     lua_pop(m_lua_state, 2);
     return e;
@@ -91,7 +93,8 @@ llvm::Error LuaState::RegisterWatchpointCallback(void *baton,
   const char *fmt_str = "return function(frame, wp, ...) {0} end";
   std::string func_str = llvm::formatv(fmt_str, body).str();
   if (luaL_dostring(m_lua_state, func_str.c_str()) != LUA_OK) {
-    llvm::Error e = llvm::createStringErrorV("{0}", lua_tostring(m_lua_state, -1));
+    llvm::Error e =
+        llvm::createStringErrorV("{0}", lua_tostring(m_lua_state, -1));
     // Pop error message from the stack.
     lua_pop(m_lua_state, 2);
     return e;
@@ -119,7 +122,8 @@ llvm::Error LuaState::CheckSyntax(llvm::StringRef buffer) {
     return llvm::Error::success();
   }
 
-  llvm::Error e = llvm::createStringErrorV("{0}\n", lua_tostring(m_lua_state, -1));
+  llvm::Error e =
+      llvm::createStringErrorV("{0}\n", lua_tostring(m_lua_state, -1));
   // Pop error message from the stack.
   lua_pop(m_lua_state, 1);
   return e;
@@ -138,7 +142,8 @@ llvm::Error LuaState::LoadModule(llvm::StringRef filename) {
   int error = luaL_loadfile(m_lua_state, filename.data()) ||
               lua_pcall(m_lua_state, 0, 1, 0);
   if (error != LUA_OK) {
-    llvm::Error e = llvm::createStringErrorV("{0}\n", lua_tostring(m_lua_state, -1));
+    llvm::Error e =
+        llvm::createStringErrorV("{0}\n", lua_tostring(m_lua_state, -1));
     // Pop error message from the stack.
     lua_pop(m_lua_state, 1);
     return e;

--- a/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/ScriptedPythonInterface.h
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/ScriptedPythonInterface.h
@@ -462,8 +462,7 @@ public:
 
     // Call the static method.
     llvm::Expected<PythonObject> expected_return_object =
-        llvm::make_error<llvm::StringError>("Not initialized.",
-                                            llvm::inconvertibleErrorCode());
+        llvm::createStringError("Not initialized.");
     std::apply(
         [&method, &expected_return_object](auto &&...args) {
           llvm::consumeError(expected_return_object.takeError());
@@ -526,8 +525,7 @@ protected:
     auto transformed_args = TransformArgs(original_args);
 
     llvm::Expected<PythonObject> expected_return_object =
-        llvm::make_error<llvm::StringError>("Not initialized.",
-                                            llvm::inconvertibleErrorCode());
+        llvm::createStringError("Not initialized.");
     std::apply(
         [&implementor, &method_name, &expected_return_object](auto &&...args) {
           llvm::consumeError(expected_return_object.takeError());

--- a/lldb/source/Plugins/SymbolFile/CTF/SymbolFileCTF.cpp
+++ b/lldb/source/Plugins/SymbolFile/CTF/SymbolFileCTF.cpp
@@ -346,21 +346,18 @@ SymbolFileCTF::CreateInteger(const CTFInteger &ctf_integer) {
     // Make sure the type we got is an integer type.
     bool compiler_type_is_signed = false;
     if (!compiler_type.IsIntegerType(compiler_type_is_signed))
-      return llvm::createStringError(
-          llvm::formatv(
-              "Found compiler type for '{0}' but it's not an integer type: {1}",
-              ctf_integer.name,
-              compiler_type.GetDisplayTypeName().GetStringRef()));
+      return llvm::createStringError(llvm::formatv(
+          "Found compiler type for '{0}' but it's not an integer type: {1}",
+          ctf_integer.name, compiler_type.GetDisplayTypeName().GetStringRef()));
 
     // Make sure the signing matches between the CTF and the compiler type.
     const bool type_is_signed = (ctf_integer.encoding & IntEncoding::eSigned);
     if (compiler_type_is_signed != type_is_signed)
-      return llvm::createStringError(
-          llvm::formatv("Found integer compiler type for {0} but compiler type "
-                        "is {1} and {0} is {2}",
-                        ctf_integer.name,
-                        compiler_type_is_signed ? "signed" : "unsigned",
-                        type_is_signed ? "signed" : "unsigned"));
+      return llvm::createStringError(llvm::formatv(
+          "Found integer compiler type for {0} but compiler type is {1} and "
+          "{0} is {2}",
+          ctf_integer.name, compiler_type_is_signed ? "signed" : "unsigned",
+          type_is_signed ? "signed" : "unsigned"));
   }
 
   Declaration decl;
@@ -393,9 +390,8 @@ SymbolFileCTF::CreateModifier(const CTFModifier &ctf_modifier) {
     compiler_type = ref_type->GetFullCompilerType().AddRestrictModifier();
     break;
   default:
-    return llvm::createStringError(
-        llvm::formatv("ParseModifier called with unsupported kind: {0}",
-                      ctf_modifier.kind));
+    return llvm::createStringError(llvm::formatv(
+        "ParseModifier called with unsupported kind: {0}", ctf_modifier.kind));
   }
 
   Declaration decl;
@@ -408,9 +404,8 @@ llvm::Expected<lldb::TypeSP>
 SymbolFileCTF::CreateTypedef(const CTFTypedef &ctf_typedef) {
   Type *underlying_type = ResolveTypeUID(ctf_typedef.type);
   if (!underlying_type)
-    return llvm::createStringError(
-        llvm::formatv("Could not find typedef underlying type: {0}",
-                      ctf_typedef.type));
+    return llvm::createStringError(llvm::formatv(
+        "Could not find typedef underlying type: {0}", ctf_typedef.type));
 
   CompilerType target_ast_type = underlying_type->GetFullCompilerType();
   clang::DeclContext *decl_ctx = m_ast->GetTranslationUnitDecl();
@@ -427,8 +422,8 @@ llvm::Expected<lldb::TypeSP>
 SymbolFileCTF::CreateArray(const CTFArray &ctf_array) {
   Type *element_type = ResolveTypeUID(ctf_array.type);
   if (!element_type)
-    return llvm::createStringError(
-        llvm::formatv("Could not find array element type: {0}", ctf_array.type));
+    return llvm::createStringError(llvm::formatv(
+        "Could not find array element type: {0}", ctf_array.type));
 
   auto element_size_or_err = element_type->GetByteSize(nullptr);
   if (!element_size_or_err)
@@ -476,9 +471,8 @@ SymbolFileCTF::CreateFunction(const CTFFunction &ctf_function) {
 
   Type *ret_type = ResolveTypeUID(ctf_function.return_type);
   if (!ret_type)
-    return llvm::createStringError(
-        llvm::formatv("Could not find function return type: {0}",
-                      ctf_function.return_type));
+    return llvm::createStringError(llvm::formatv(
+        "Could not find function return type: {0}", ctf_function.return_type));
 
   CompilerType func_type = m_ast->CreateFunctionType(
       ret_type->GetFullCompilerType(), arg_types, ctf_function.variadic, 0,

--- a/lldb/source/Plugins/SymbolFile/CTF/SymbolFileCTF.cpp
+++ b/lldb/source/Plugins/SymbolFile/CTF/SymbolFileCTF.cpp
@@ -335,11 +335,10 @@ SymbolFileCTF::CreateInteger(const CTFInteger &ctf_integer) {
   lldb::BasicType basic_type =
       TypeSystemClang::GetBasicTypeEnumeration(ctf_integer.name);
   if (basic_type == eBasicTypeInvalid)
-    return llvm::make_error<llvm::StringError>(
+    return llvm::createStringError(
         llvm::formatv("unsupported integer type: no corresponding basic clang "
                       "type for '{0}'",
-                      ctf_integer.name),
-        llvm::inconvertibleErrorCode());
+                      ctf_integer.name));
 
   CompilerType compiler_type = m_ast->GetBasicType(basic_type);
 
@@ -347,23 +346,21 @@ SymbolFileCTF::CreateInteger(const CTFInteger &ctf_integer) {
     // Make sure the type we got is an integer type.
     bool compiler_type_is_signed = false;
     if (!compiler_type.IsIntegerType(compiler_type_is_signed))
-      return llvm::make_error<llvm::StringError>(
+      return llvm::createStringError(
           llvm::formatv(
               "Found compiler type for '{0}' but it's not an integer type: {1}",
               ctf_integer.name,
-              compiler_type.GetDisplayTypeName().GetStringRef()),
-          llvm::inconvertibleErrorCode());
+              compiler_type.GetDisplayTypeName().GetStringRef()));
 
     // Make sure the signing matches between the CTF and the compiler type.
     const bool type_is_signed = (ctf_integer.encoding & IntEncoding::eSigned);
     if (compiler_type_is_signed != type_is_signed)
-      return llvm::make_error<llvm::StringError>(
+      return llvm::createStringError(
           llvm::formatv("Found integer compiler type for {0} but compiler type "
                         "is {1} and {0} is {2}",
                         ctf_integer.name,
                         compiler_type_is_signed ? "signed" : "unsigned",
-                        type_is_signed ? "signed" : "unsigned"),
-          llvm::inconvertibleErrorCode());
+                        type_is_signed ? "signed" : "unsigned"));
   }
 
   Declaration decl;
@@ -377,9 +374,8 @@ llvm::Expected<lldb::TypeSP>
 SymbolFileCTF::CreateModifier(const CTFModifier &ctf_modifier) {
   Type *ref_type = ResolveTypeUID(ctf_modifier.type);
   if (!ref_type)
-    return llvm::make_error<llvm::StringError>(
-        llvm::formatv("Could not find modified type: {0}", ctf_modifier.type),
-        llvm::inconvertibleErrorCode());
+    return llvm::createStringError(
+        llvm::formatv("Could not find modified type: {0}", ctf_modifier.type));
 
   CompilerType compiler_type;
 
@@ -397,10 +393,9 @@ SymbolFileCTF::CreateModifier(const CTFModifier &ctf_modifier) {
     compiler_type = ref_type->GetFullCompilerType().AddRestrictModifier();
     break;
   default:
-    return llvm::make_error<llvm::StringError>(
+    return llvm::createStringError(
         llvm::formatv("ParseModifier called with unsupported kind: {0}",
-                      ctf_modifier.kind),
-        llvm::inconvertibleErrorCode());
+                      ctf_modifier.kind));
   }
 
   Declaration decl;
@@ -413,10 +408,9 @@ llvm::Expected<lldb::TypeSP>
 SymbolFileCTF::CreateTypedef(const CTFTypedef &ctf_typedef) {
   Type *underlying_type = ResolveTypeUID(ctf_typedef.type);
   if (!underlying_type)
-    return llvm::make_error<llvm::StringError>(
+    return llvm::createStringError(
         llvm::formatv("Could not find typedef underlying type: {0}",
-                      ctf_typedef.type),
-        llvm::inconvertibleErrorCode());
+                      ctf_typedef.type));
 
   CompilerType target_ast_type = underlying_type->GetFullCompilerType();
   clang::DeclContext *decl_ctx = m_ast->GetTranslationUnitDecl();
@@ -433,9 +427,8 @@ llvm::Expected<lldb::TypeSP>
 SymbolFileCTF::CreateArray(const CTFArray &ctf_array) {
   Type *element_type = ResolveTypeUID(ctf_array.type);
   if (!element_type)
-    return llvm::make_error<llvm::StringError>(
-        llvm::formatv("Could not find array element type: {0}", ctf_array.type),
-        llvm::inconvertibleErrorCode());
+    return llvm::createStringError(
+        llvm::formatv("Could not find array element type: {0}", ctf_array.type));
 
   auto element_size_or_err = element_type->GetByteSize(nullptr);
   if (!element_size_or_err)
@@ -483,10 +476,9 @@ SymbolFileCTF::CreateFunction(const CTFFunction &ctf_function) {
 
   Type *ret_type = ResolveTypeUID(ctf_function.return_type);
   if (!ret_type)
-    return llvm::make_error<llvm::StringError>(
+    return llvm::createStringError(
         llvm::formatv("Could not find function return type: {0}",
-                      ctf_function.return_type),
-        llvm::inconvertibleErrorCode());
+                      ctf_function.return_type));
 
   CompilerType func_type = m_ast->CreateFunctionType(
       ret_type->GetFullCompilerType(), arg_types, ctf_function.variadic, 0,
@@ -570,8 +562,7 @@ SymbolFileCTF::CreateForward(const CTFForward &ctf_forward) {
 
 llvm::Expected<TypeSP> SymbolFileCTF::CreateType(CTFType *ctf_type) {
   if (!ctf_type)
-    return llvm::make_error<llvm::StringError>(
-        "cannot create type for unparsed type", llvm::inconvertibleErrorCode());
+    return llvm::createStringError("cannot create type for unparsed type");
 
   switch (ctf_type->kind) {
   case CTFType::Kind::eInteger:
@@ -597,10 +588,9 @@ llvm::Expected<TypeSP> SymbolFileCTF::CreateType(CTFType *ctf_type) {
   case CTFType::Kind::eUnknown:
   case CTFType::Kind::eFloat:
   case CTFType::Kind::eSlice:
-    return llvm::make_error<llvm::StringError>(
+    return llvm::createStringError(
         llvm::formatv("unsupported type (uid = {0}, name = {1}, kind = {2})",
-                      ctf_type->uid, ctf_type->name, ctf_type->kind),
-        llvm::inconvertibleErrorCode());
+                      ctf_type->uid, ctf_type->name, ctf_type->kind));
   }
   llvm_unreachable("Unexpected CTF type kind");
 }
@@ -700,10 +690,9 @@ SymbolFileCTF::ParseType(lldb::offset_t &offset, lldb::user_id_t uid) {
     break;
   }
 
-  return llvm::make_error<llvm::StringError>(
+  return llvm::createStringError(
       llvm::formatv("unsupported type (name = {0}, kind = {1}, vlength = {2})",
-                    name, kind, variable_length),
-      llvm::inconvertibleErrorCode());
+                    name, kind, variable_length));
 }
 
 size_t SymbolFileCTF::ParseTypes(CompileUnit &cu) {

--- a/lldb/source/Plugins/SymbolFile/CTF/SymbolFileCTF.cpp
+++ b/lldb/source/Plugins/SymbolFile/CTF/SymbolFileCTF.cpp
@@ -29,6 +29,7 @@
 #include "lldb/Utility/StreamString.h"
 #include "lldb/Utility/Timer.h"
 #include "llvm/Config/llvm-config.h" // for LLVM_ENABLE_ZLIB
+#include "llvm/Support/ErrorExtras.h"
 #include "llvm/Support/MemoryBuffer.h"
 
 #include "Plugins/ExpressionParser/Clang/ClangASTMetadata.h"
@@ -335,10 +336,10 @@ SymbolFileCTF::CreateInteger(const CTFInteger &ctf_integer) {
   lldb::BasicType basic_type =
       TypeSystemClang::GetBasicTypeEnumeration(ctf_integer.name);
   if (basic_type == eBasicTypeInvalid)
-    return llvm::createStringError(
-        llvm::formatv("unsupported integer type: no corresponding basic clang "
-                      "type for '{0}'",
-                      ctf_integer.name));
+    return llvm::createStringErrorV(
+        "unsupported integer type: no corresponding basic clang "
+        "type for '{0}'",
+        ctf_integer.name);
 
   CompilerType compiler_type = m_ast->GetBasicType(basic_type);
 
@@ -346,18 +347,18 @@ SymbolFileCTF::CreateInteger(const CTFInteger &ctf_integer) {
     // Make sure the type we got is an integer type.
     bool compiler_type_is_signed = false;
     if (!compiler_type.IsIntegerType(compiler_type_is_signed))
-      return llvm::createStringError(llvm::formatv(
+      return llvm::createStringErrorV(
           "Found compiler type for '{0}' but it's not an integer type: {1}",
-          ctf_integer.name, compiler_type.GetDisplayTypeName().GetStringRef()));
+          ctf_integer.name, compiler_type.GetDisplayTypeName().GetStringRef());
 
     // Make sure the signing matches between the CTF and the compiler type.
     const bool type_is_signed = (ctf_integer.encoding & IntEncoding::eSigned);
     if (compiler_type_is_signed != type_is_signed)
-      return llvm::createStringError(llvm::formatv(
+      return llvm::createStringErrorV(
           "Found integer compiler type for {0} but compiler type is {1} and "
           "{0} is {2}",
           ctf_integer.name, compiler_type_is_signed ? "signed" : "unsigned",
-          type_is_signed ? "signed" : "unsigned"));
+          type_is_signed ? "signed" : "unsigned");
   }
 
   Declaration decl;
@@ -371,8 +372,8 @@ llvm::Expected<lldb::TypeSP>
 SymbolFileCTF::CreateModifier(const CTFModifier &ctf_modifier) {
   Type *ref_type = ResolveTypeUID(ctf_modifier.type);
   if (!ref_type)
-    return llvm::createStringError(
-        llvm::formatv("Could not find modified type: {0}", ctf_modifier.type));
+    return llvm::createStringErrorV("Could not find modified type: {0}",
+                                    ctf_modifier.type);
 
   CompilerType compiler_type;
 
@@ -390,8 +391,8 @@ SymbolFileCTF::CreateModifier(const CTFModifier &ctf_modifier) {
     compiler_type = ref_type->GetFullCompilerType().AddRestrictModifier();
     break;
   default:
-    return llvm::createStringError(llvm::formatv(
-        "ParseModifier called with unsupported kind: {0}", ctf_modifier.kind));
+    return llvm::createStringErrorV(
+        "ParseModifier called with unsupported kind: {0}", ctf_modifier.kind);
   }
 
   Declaration decl;
@@ -404,8 +405,8 @@ llvm::Expected<lldb::TypeSP>
 SymbolFileCTF::CreateTypedef(const CTFTypedef &ctf_typedef) {
   Type *underlying_type = ResolveTypeUID(ctf_typedef.type);
   if (!underlying_type)
-    return llvm::createStringError(llvm::formatv(
-        "Could not find typedef underlying type: {0}", ctf_typedef.type));
+    return llvm::createStringErrorV(
+        "Could not find typedef underlying type: {0}", ctf_typedef.type);
 
   CompilerType target_ast_type = underlying_type->GetFullCompilerType();
   clang::DeclContext *decl_ctx = m_ast->GetTranslationUnitDecl();
@@ -422,8 +423,8 @@ llvm::Expected<lldb::TypeSP>
 SymbolFileCTF::CreateArray(const CTFArray &ctf_array) {
   Type *element_type = ResolveTypeUID(ctf_array.type);
   if (!element_type)
-    return llvm::createStringError(llvm::formatv(
-        "Could not find array element type: {0}", ctf_array.type));
+    return llvm::createStringErrorV("Could not find array element type: {0}",
+                                    ctf_array.type);
 
   auto element_size_or_err = element_type->GetByteSize(nullptr);
   if (!element_size_or_err)
@@ -471,8 +472,8 @@ SymbolFileCTF::CreateFunction(const CTFFunction &ctf_function) {
 
   Type *ret_type = ResolveTypeUID(ctf_function.return_type);
   if (!ret_type)
-    return llvm::createStringError(llvm::formatv(
-        "Could not find function return type: {0}", ctf_function.return_type));
+    return llvm::createStringErrorV("Could not find function return type: {0}",
+                                    ctf_function.return_type);
 
   CompilerType func_type = m_ast->CreateFunctionType(
       ret_type->GetFullCompilerType(), arg_types, ctf_function.variadic, 0,
@@ -582,9 +583,9 @@ llvm::Expected<TypeSP> SymbolFileCTF::CreateType(CTFType *ctf_type) {
   case CTFType::Kind::eUnknown:
   case CTFType::Kind::eFloat:
   case CTFType::Kind::eSlice:
-    return llvm::createStringError(
-        llvm::formatv("unsupported type (uid = {0}, name = {1}, kind = {2})",
-                      ctf_type->uid, ctf_type->name, ctf_type->kind));
+    return llvm::createStringErrorV(
+        "unsupported type (uid = {0}, name = {1}, kind = {2})",
+        ctf_type->uid, ctf_type->name, ctf_type->kind);
   }
   llvm_unreachable("Unexpected CTF type kind");
 }
@@ -684,9 +685,9 @@ SymbolFileCTF::ParseType(lldb::offset_t &offset, lldb::user_id_t uid) {
     break;
   }
 
-  return llvm::createStringError(
-      llvm::formatv("unsupported type (name = {0}, kind = {1}, vlength = {2})",
-                    name, kind, variable_length));
+  return llvm::createStringErrorV(
+      "unsupported type (name = {0}, kind = {1}, vlength = {2})",
+      name, kind, variable_length);
 }
 
 size_t SymbolFileCTF::ParseTypes(CompileUnit &cu) {

--- a/lldb/source/Plugins/SymbolFile/CTF/SymbolFileCTF.cpp
+++ b/lldb/source/Plugins/SymbolFile/CTF/SymbolFileCTF.cpp
@@ -584,8 +584,8 @@ llvm::Expected<TypeSP> SymbolFileCTF::CreateType(CTFType *ctf_type) {
   case CTFType::Kind::eFloat:
   case CTFType::Kind::eSlice:
     return llvm::createStringErrorV(
-        "unsupported type (uid = {0}, name = {1}, kind = {2})",
-        ctf_type->uid, ctf_type->name, ctf_type->kind);
+        "unsupported type (uid = {0}, name = {1}, kind = {2})", ctf_type->uid,
+        ctf_type->name, ctf_type->kind);
   }
   llvm_unreachable("Unexpected CTF type kind");
 }
@@ -686,8 +686,8 @@ SymbolFileCTF::ParseType(lldb::offset_t &offset, lldb::user_id_t uid) {
   }
 
   return llvm::createStringErrorV(
-      "unsupported type (name = {0}, kind = {1}, vlength = {2})",
-      name, kind, variable_length);
+      "unsupported type (name = {0}, kind = {1}, vlength = {2})", name, kind,
+      variable_length);
 }
 
 size_t SymbolFileCTF::ParseTypes(CompileUnit &cu) {

--- a/lldb/source/Plugins/TraceExporter/common/TraceHTR.cpp
+++ b/lldb/source/Plugins/TraceExporter/common/TraceHTR.cpp
@@ -234,14 +234,16 @@ llvm::Error TraceHTR::Export(std::string outfile) {
   std::error_code ec;
   llvm::raw_fd_ostream os(outfile, ec, llvm::sys::fs::OF_Text);
   if (ec) {
-    return llvm::make_error<llvm::StringError>(
-        "unable to open destination file: " + outfile, os.error());
+    return llvm::createStringError(os.error(),
+                                    "unable to open destination file: " +
+                                        outfile);
   } else {
     os << toJSON(*this);
     os.close();
     if (os.has_error()) {
-      return llvm::make_error<llvm::StringError>(
-          "unable to write to destination file: " + outfile, os.error());
+      return llvm::createStringError(os.error(),
+                                     "unable to write to destination file: " +
+                                         outfile);
     }
   }
   return llvm::Error::success();

--- a/lldb/source/Plugins/TraceExporter/common/TraceHTR.cpp
+++ b/lldb/source/Plugins/TraceExporter/common/TraceHTR.cpp
@@ -234,16 +234,14 @@ llvm::Error TraceHTR::Export(std::string outfile) {
   std::error_code ec;
   llvm::raw_fd_ostream os(outfile, ec, llvm::sys::fs::OF_Text);
   if (ec) {
-    return llvm::createStringError(os.error(),
-                                    "unable to open destination file: " +
-                                        outfile);
+    return llvm::createStringError(
+        os.error(), "unable to open destination file: " + outfile);
   } else {
     os << toJSON(*this);
     os.close();
     if (os.has_error()) {
-      return llvm::createStringError(os.error(),
-                                     "unable to write to destination file: " +
-                                         outfile);
+      return llvm::createStringError(
+          os.error(), "unable to write to destination file: " + outfile);
     }
   }
   return llvm::Error::success();

--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -2823,11 +2823,8 @@ llvm::Error Target::SetLabel(llvm::StringRef label) {
   for (size_t i = 0; i < targets.GetNumTargets(); i++) {
     TargetSP target_sp = targets.GetTargetAtIndex(i);
     if (target_sp && target_sp->GetLabel() == label) {
-        return llvm::make_error<llvm::StringError>(
-            llvm::formatv(
-                "Cannot use label '{0}' since it's set in target #{1}.", label,
-                i),
-            llvm::inconvertibleErrorCode());
+      return llvm::createStringError(llvm::formatv(
+          "Cannot use label '{0}' since it's set in target #{1}.", label, i));
     }
   }
 

--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -2823,8 +2823,8 @@ llvm::Error Target::SetLabel(llvm::StringRef label) {
   for (size_t i = 0; i < targets.GetNumTargets(); i++) {
     TargetSP target_sp = targets.GetTargetAtIndex(i);
     if (target_sp && target_sp->GetLabel() == label) {
-      return llvm::createStringError(llvm::formatv(
-          "Cannot use label '{0}' since it's set in target #{1}.", label, i));
+      return llvm::createStringErrorV(
+          "Cannot use label '{0}' since it's set in target #{1}.", label, i);
     }
   }
 

--- a/lldb/source/Utility/RegularExpression.cpp
+++ b/lldb/source/Utility/RegularExpression.cpp
@@ -36,7 +36,6 @@ llvm::StringRef RegularExpression::GetText() const { return m_regex_text; }
 llvm::Error RegularExpression::GetError() const {
   std::string error;
   if (!m_regex.isValid(error))
-    return llvm::make_error<llvm::StringError>(error,
-                                               llvm::inconvertibleErrorCode());
+    return llvm::createStringError(error);
   return llvm::Error::success();
 }

--- a/lldb/source/Utility/Status.cpp
+++ b/lldb/source/Utility/Status.cpp
@@ -125,8 +125,7 @@ static llvm::Error CloneError(const llvm::Error &error) {
       return llvm::Error(static_cast<const CloneableError &>(e).Clone());
     if (e.isA<llvm::ECError>())
       return llvm::errorCodeToError(e.convertToErrorCode());
-    return llvm::make_error<llvm::StringError>(e.message(),
-                                               e.convertToErrorCode(), true);
+    return llvm::createStringError(e.message(), e.convertToErrorCode());
   };
   llvm::visitErrors(error, [&](const llvm::ErrorInfoBase &e) {
     result = joinErrors(std::move(result), clone(e));

--- a/lldb/source/ValueObject/ValueObject.cpp
+++ b/lldb/source/ValueObject/ValueObject.cpp
@@ -1166,8 +1166,7 @@ llvm::Expected<llvm::APSInt> ValueObject::GetValueAsAPSInt() {
       return scalar.GetAPSInt();
   }
 
-  return llvm::createStringError(
-      "error occurred; unable to convert to APSInt");
+  return llvm::createStringError("error occurred; unable to convert to APSInt");
 }
 
 llvm::Expected<llvm::APFloat> ValueObject::GetValueAsAPFloat() {

--- a/lldb/source/ValueObject/ValueObject.cpp
+++ b/lldb/source/ValueObject/ValueObject.cpp
@@ -1158,8 +1158,7 @@ llvm::Expected<llvm::APSInt> ValueObject::GetValueAsAPSInt() {
       !GetCompilerType().IsPointerType() &&
       !GetCompilerType().IsNullPtrType() &&
       !GetCompilerType().IsReferenceType() && !GetCompilerType().IsBoolean())
-    return llvm::make_error<llvm::StringError>(
-        "type cannot be converted to APSInt", llvm::inconvertibleErrorCode());
+    return llvm::createStringError("type cannot be converted to APSInt");
 
   if (CanProvideValue()) {
     Scalar scalar;
@@ -1167,15 +1166,13 @@ llvm::Expected<llvm::APSInt> ValueObject::GetValueAsAPSInt() {
       return scalar.GetAPSInt();
   }
 
-  return llvm::make_error<llvm::StringError>(
-      "error occurred; unable to convert to APSInt",
-      llvm::inconvertibleErrorCode());
+  return llvm::createStringError(
+      "error occurred; unable to convert to APSInt");
 }
 
 llvm::Expected<llvm::APFloat> ValueObject::GetValueAsAPFloat() {
   if (!HasFloatingRepresentation(GetCompilerType()))
-    return llvm::make_error<llvm::StringError>(
-        "type cannot be converted to APFloat", llvm::inconvertibleErrorCode());
+    return llvm::createStringError("type cannot be converted to APFloat");
 
   if (CanProvideValue()) {
     Scalar scalar;
@@ -1183,9 +1180,8 @@ llvm::Expected<llvm::APFloat> ValueObject::GetValueAsAPFloat() {
       return scalar.GetAPFloat();
   }
 
-  return llvm::make_error<llvm::StringError>(
-      "error occurred; unable to convert to APFloat",
-      llvm::inconvertibleErrorCode());
+  return llvm::createStringError(
+      "error occurred; unable to convert to APFloat");
 }
 
 llvm::Expected<bool> ValueObject::GetValueAsBool() {
@@ -1204,8 +1200,7 @@ llvm::Expected<bool> ValueObject::GetValueAsBool() {
   if (val_type.IsArrayType())
     return GetAddressOf().address != 0;
 
-  return llvm::make_error<llvm::StringError>("type cannot be converted to bool",
-                                             llvm::inconvertibleErrorCode());
+  return llvm::createStringError("type cannot be converted to bool");
 }
 
 void ValueObject::SetValueFromInteger(const llvm::APInt &value, Status &error) {
@@ -3016,9 +3011,8 @@ llvm::Expected<lldb::ValueObjectSP> ValueObject::CastDerivedToBaseType(
   // type of cast; otherwise return the shared pointer to the original
   // (unchanged) ValueObject.
   if (!type.IsPointerType() && !type.IsReferenceType())
-    return llvm::make_error<llvm::StringError>(
-        "Invalid target type: should be a pointer or a reference",
-        llvm::inconvertibleErrorCode());
+    return llvm::createStringError(
+        "Invalid target type: should be a pointer or a reference");
 
   CompilerType start_type = GetCompilerType();
   if (start_type.IsReferenceType())
@@ -3030,18 +3024,15 @@ llvm::Expected<lldb::ValueObjectSP> ValueObject::CastDerivedToBaseType(
       start_type.IsPointerType() ? start_type.GetPointeeType() : start_type;
 
   if (!target_record_type.IsRecordType() || !start_record_type.IsRecordType())
-    return llvm::make_error<llvm::StringError>(
-        "Underlying start & target types should be record types",
-        llvm::inconvertibleErrorCode());
+    return llvm::createStringError(
+        "Underlying start & target types should be record types");
 
   if (target_record_type.CompareTypes(start_record_type))
-    return llvm::make_error<llvm::StringError>(
-        "Underlying start & target types should be different",
-        llvm::inconvertibleErrorCode());
+    return llvm::createStringError(
+        "Underlying start & target types should be different");
 
   if (base_type_indices.empty())
-    return llvm::make_error<llvm::StringError>(
-        "Children sequence must be non-empty", llvm::inconvertibleErrorCode());
+    return llvm::createStringError("Children sequence must be non-empty");
 
   // Both the starting & target types are valid for the cast, and the list of
   // base class indices is non-empty, so we can proceed with the cast.
@@ -3060,9 +3051,8 @@ llvm::Expected<lldb::ValueObjectSP> ValueObject::CastDerivedToBaseType(
   CompilerType inner_value_type = inner_value->GetCompilerType();
   if (type.IsPointerType()) {
     if (!inner_value_type.CompareTypes(type.GetPointeeType()))
-      return llvm::make_error<llvm::StringError>(
-          "casted value doesn't match the desired type",
-          llvm::inconvertibleErrorCode());
+      return llvm::createStringError(
+          "casted value doesn't match the desired type");
 
     uintptr_t addr = inner_value->GetLoadAddress();
     llvm::StringRef name = "";
@@ -3073,9 +3063,8 @@ llvm::Expected<lldb::ValueObjectSP> ValueObject::CastDerivedToBaseType(
 
   // At this point the target type should be a reference.
   if (!inner_value_type.CompareTypes(type.GetNonReferenceType()))
-    return llvm::make_error<llvm::StringError>(
-        "casted value doesn't match the desired type",
-        llvm::inconvertibleErrorCode());
+    return llvm::createStringError(
+        "casted value doesn't match the desired type");
 
   return lldb::ValueObjectSP(inner_value->Cast(type.GetNonReferenceType()));
 }
@@ -3086,9 +3075,8 @@ ValueObject::CastBaseToDerivedType(CompilerType type, uint64_t offset) {
   // type of cast; otherwise return the shared pointer to the original
   // (unchanged) ValueObject.
   if (!type.IsPointerType() && !type.IsReferenceType())
-    return llvm::make_error<llvm::StringError>(
-        "Invalid target type: should be a pointer or a reference",
-        llvm::inconvertibleErrorCode());
+    return llvm::createStringError(
+        "Invalid target type: should be a pointer or a reference");
 
   CompilerType start_type = GetCompilerType();
   if (start_type.IsReferenceType())
@@ -3100,25 +3088,22 @@ ValueObject::CastBaseToDerivedType(CompilerType type, uint64_t offset) {
       start_type.IsPointerType() ? start_type.GetPointeeType() : start_type;
 
   if (!target_record_type.IsRecordType() || !start_record_type.IsRecordType())
-    return llvm::make_error<llvm::StringError>(
-        "Underlying start & target types should be record types",
-        llvm::inconvertibleErrorCode());
+    return llvm::createStringError(
+        "Underlying start & target types should be record types");
 
   if (target_record_type.CompareTypes(start_record_type))
-    return llvm::make_error<llvm::StringError>(
-        "Underlying start & target types should be different",
-        llvm::inconvertibleErrorCode());
+    return llvm::createStringError(
+        "Underlying start & target types should be different");
 
   CompilerType virtual_base;
   if (target_record_type.IsVirtualBase(start_record_type, &virtual_base)) {
     if (!virtual_base.IsValid())
-      return llvm::make_error<llvm::StringError>(
-          "virtual base should be valid", llvm::inconvertibleErrorCode());
-    return llvm::make_error<llvm::StringError>(
+      return llvm::createStringError("virtual base should be valid");
+    return llvm::createStringError(
         llvm::Twine("cannot cast " + start_type.TypeDescription() + " to " +
                     type.TypeDescription() + " via virtual base " +
-                    virtual_base.TypeDescription()),
-        llvm::inconvertibleErrorCode());
+                    virtual_base.TypeDescription())
+            .str());
   }
 
   // Both the starting & target types are valid for the cast,  so we can

--- a/lldb/source/ValueObject/ValueObjectVariable.cpp
+++ b/lldb/source/ValueObject/ValueObjectVariable.cpp
@@ -99,8 +99,7 @@ ValueObjectVariable::CalculateNumChildren(uint32_t max) {
   CompilerType type(GetCompilerType());
 
   if (!type.IsValid())
-    return llvm::make_error<llvm::StringError>("invalid type",
-                                               llvm::inconvertibleErrorCode());
+    return llvm::createStringError("invalid type");
 
   ExecutionContext exe_ctx(GetExecutionContextRef());
   const bool omit_empty_base_classes = true;

--- a/lldb/tools/lldb-dap/DAPSessionManager.cpp
+++ b/lldb/tools/lldb-dap/DAPSessionManager.cpp
@@ -85,8 +85,7 @@ llvm::Error DAPSessionManager::WaitForAllSessionsToDisconnect() {
 
   // Check if any disconnection failed and return appropriate error.
   if (m_client_failed)
-    return llvm::make_error<llvm::StringError>(
-        "disconnecting all clients failed", llvm::inconvertibleErrorCode());
+    return llvm::createStringError("disconnecting all clients failed");
 
   return llvm::Error::success();
 }

--- a/lldb/unittests/TestingSupport/Host/SocketTestUtilities.cpp
+++ b/lldb/unittests/TestingSupport/Host/SocketTestUtilities.cpp
@@ -143,7 +143,6 @@ llvm::Expected<std::string> lldb_private::GetLocalhostIP() {
     return "127.0.0.1";
   if (HostSupportsIPv6())
     return "[::1]";
-  return llvm::make_error<llvm::StringError>(
-      "Neither IPv4 nor IPv6 appear to be supported",
-      llvm::inconvertibleErrorCode());
+  return llvm::createStringError(
+      "Neither IPv4 nor IPv6 appear to be supported");
 }

--- a/lldb/unittests/Utility/LogTest.cpp
+++ b/lldb/unittests/Utility/LogTest.cpp
@@ -340,15 +340,13 @@ TEST_F(LogChannelEnabledTest, LLDB_LOG_ERROR) {
   ASSERT_EQ("", takeOutput());
 
   LLDB_LOG_ERROR(getLog(),
-                 llvm::make_error<llvm::StringError>(
-                     "My Error", llvm::inconvertibleErrorCode()),
+                 llvm::createStringError("My Error"),
                  "Foo failed: {0}");
   ASSERT_EQ("Foo failed: My Error\n", takeOutput());
 
   // Doesn't log, but doesn't assert either
   LLDB_LOG_ERROR(nullptr,
-                 llvm::make_error<llvm::StringError>(
-                     "My Error", llvm::inconvertibleErrorCode()),
+                 llvm::createStringError("My Error"),
                  "Foo failed: {0}");
 }
 

--- a/lldb/unittests/Utility/LogTest.cpp
+++ b/lldb/unittests/Utility/LogTest.cpp
@@ -339,14 +339,12 @@ TEST_F(LogChannelEnabledTest, LLDB_LOG_ERROR) {
   LLDB_LOG_ERROR(getLog(), llvm::Error::success(), "Foo failed: {0}");
   ASSERT_EQ("", takeOutput());
 
-  LLDB_LOG_ERROR(getLog(),
-                 llvm::createStringError("My Error"),
+  LLDB_LOG_ERROR(getLog(), llvm::createStringError("My Error"),
                  "Foo failed: {0}");
   ASSERT_EQ("Foo failed: My Error\n", takeOutput());
 
   // Doesn't log, but doesn't assert either
-  LLDB_LOG_ERROR(nullptr,
-                 llvm::createStringError("My Error"),
+  LLDB_LOG_ERROR(nullptr, llvm::createStringError("My Error"),
                  "Foo failed: {0}");
 }
 

--- a/lldb/unittests/Utility/SubsystemRAIITest.cpp
+++ b/lldb/unittests/Utility/SubsystemRAIITest.cpp
@@ -59,8 +59,7 @@ struct TestSubsystemWithError {
     assert(state == SystemState::Start);
     state = SystemState::Initialized;
     if (will_fail)
-      return llvm::make_error<llvm::StringError>(
-          SubsystemErrorString, llvm::inconvertibleErrorCode());
+      return llvm::createStringError(SubsystemErrorString);
     return llvm::Error::success();
   }
   static void Terminate() {

--- a/lldb/unittests/tools/lldb-server/tests/MessageObjects.h
+++ b/lldb/unittests/tools/lldb-server/tests/MessageObjects.h
@@ -173,8 +173,7 @@ llvm::Error make_parsing_error(llvm::StringRef format, Args &&... args) {
   std::string error =
       "Unable to parse " +
       llvm::formatv(format.data(), std::forward<Args>(args)...).str();
-  return llvm::make_error<llvm::StringError>(error,
-                                             llvm::inconvertibleErrorCode());
+  return llvm::createStringError(error);
 }
 
 } // namespace llgs_tests

--- a/lldb/unittests/tools/lldb-server/tests/TestClient.cpp
+++ b/lldb/unittests/tools/lldb-server/tests/TestClient.cpp
@@ -44,8 +44,7 @@ TestClient::~TestClient() {
 
 Error TestClient::initializeConnection() {
   if (SendAck() == 0)
-    return make_error<StringError>("Sending initial ACK failed.",
-                                   inconvertibleErrorCode());
+    return createStringError("Sending initial ACK failed.");
 
   if (Error E = SendMessage("QStartNoAckMode"))
     return E;
@@ -142,8 +141,7 @@ TestClient::launchCustom(StringRef Log, bool disable_stdio,
 
 Error TestClient::SetInferior(llvm::ArrayRef<std::string> inferior_args) {
   if (SendEnvironment(Host::GetEnvironment()) != 0) {
-    return make_error<StringError>("Failed to set launch environment",
-                                   inconvertibleErrorCode());
+    return createStringError("Failed to set launch environment");
   }
   std::stringstream command;
   command << "A";
@@ -212,9 +210,8 @@ Error TestClient::SendMessage(StringRef message, std::string &response_string,
   response.GetEscapedBinaryData(response_string);
   GTEST_LOG_(INFO) << "Read Packet: " << response_string;
   if (result != expected_result)
-    return make_error<StringError>(
-        formatv("Error sending message `{0}`: {1}", message, result).str(),
-        inconvertibleErrorCode());
+    return createStringError(
+        formatv("Error sending message `{0}`: {1}", message, result));
 
   return Error::success();
 }
@@ -279,12 +276,10 @@ Error TestClient::Continue(StringRef message) {
     StringExtractorGDBRemote R;
     PacketResult result = ReadPacket(R, GetPacketTimeout(), false);
     if (result != PacketResult::ErrorDisconnected) {
-      return make_error<StringError>(
+      return createStringError(
           formatv("Expected connection close after sending {0}. Got {1}/{2} "
                   "instead.",
-                  message, result, R.GetStringRef())
-              .str(),
-          inconvertibleErrorCode());
+                  message, result, R.GetStringRef()));
     }
   }
   return Error::success();

--- a/lldb/unittests/tools/lldb-server/tests/TestClient.cpp
+++ b/lldb/unittests/tools/lldb-server/tests/TestClient.cpp
@@ -14,6 +14,7 @@
 #include "lldb/Utility/Args.h"
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/Support/Path.h"
+#include "llvm/Support/ErrorExtras.h"
 #include "llvm/Testing/Support/Error.h"
 #include "gtest/gtest.h"
 #include <cstdlib>
@@ -210,8 +211,8 @@ Error TestClient::SendMessage(StringRef message, std::string &response_string,
   response.GetEscapedBinaryData(response_string);
   GTEST_LOG_(INFO) << "Read Packet: " << response_string;
   if (result != expected_result)
-    return createStringError(
-        formatv("Error sending message `{0}`: {1}", message, result));
+    return createStringErrorV("Error sending message `{0}`: {1}", message,
+                              result);
 
   return Error::success();
 }
@@ -276,10 +277,9 @@ Error TestClient::Continue(StringRef message) {
     StringExtractorGDBRemote R;
     PacketResult result = ReadPacket(R, GetPacketTimeout(), false);
     if (result != PacketResult::ErrorDisconnected) {
-      return createStringError(
-          formatv("Expected connection close after sending {0}. Got {1}/{2} "
-                  "instead.",
-                  message, result, R.GetStringRef()));
+      return createStringErrorV("Expected connection close after sending {0}. "
+                                "Got {1}/{2} instead.",
+                                message, result, R.GetStringRef());
     }
   }
   return Error::success();

--- a/lldb/unittests/tools/lldb-server/tests/TestClient.cpp
+++ b/lldb/unittests/tools/lldb-server/tests/TestClient.cpp
@@ -13,8 +13,8 @@
 #include "lldb/Host/posix/ConnectionFileDescriptorPosix.h"
 #include "lldb/Utility/Args.h"
 #include "llvm/ADT/StringExtras.h"
-#include "llvm/Support/Path.h"
 #include "llvm/Support/ErrorExtras.h"
+#include "llvm/Support/Path.h"
 #include "llvm/Testing/Support/Error.h"
 #include "gtest/gtest.h"
 #include <cstdlib>

--- a/lldb/unittests/tools/lldb-server/tests/TestClient.h
+++ b/lldb/unittests/tools/lldb-server/tests/TestClient.h
@@ -69,9 +69,8 @@ public:
     assert(m_stop_reply);
     if (const auto *Reply = llvm::dyn_cast<T>(m_stop_reply.get()))
       return *Reply;
-    return llvm::make_error<llvm::StringError>(
-        llvm::formatv("Unexpected Stop Reply {0}", m_stop_reply->getKind()),
-        llvm::inconvertibleErrorCode());
+    return llvm::createStringError(
+        llvm::formatv("Unexpected Stop Reply {0}", m_stop_reply->getKind()));
   }
   llvm::Error SendMessage(llvm::StringRef message);
   llvm::Error SendMessage(llvm::StringRef message,

--- a/lldb/unittests/tools/lldb-server/tests/TestClient.h
+++ b/lldb/unittests/tools/lldb-server/tests/TestClient.h
@@ -15,6 +15,7 @@
 #include "lldb/Utility/ArchSpec.h"
 #include "lldb/Utility/Connection.h"
 #include "llvm/Support/Casting.h"
+#include "llvm/Support/ErrorExtras.h"
 #include "llvm/Support/FormatVariadic.h"
 #include <memory>
 #include <optional>
@@ -69,8 +70,8 @@ public:
     assert(m_stop_reply);
     if (const auto *Reply = llvm::dyn_cast<T>(m_stop_reply.get()))
       return *Reply;
-    return llvm::createStringError(
-        llvm::formatv("Unexpected Stop Reply {0}", m_stop_reply->getKind()));
+    return llvm::createStringErrorV("Unexpected Stop Reply {0}",
+                                    m_stop_reply->getKind());
   }
   llvm::Error SendMessage(llvm::StringRef message);
   llvm::Error SendMessage(llvm::StringRef message,


### PR DESCRIPTION
This makes the constructions of string errors more concise and more consistent, mainly by removing the `inconvertibleErrorCode()`. Additional changes replace `createStringError(formatv(...), ...)` with `createStringErrorV(...)`.

Assisted-by: Claude