### PR TITLE
[lldb] Make date test handle host-target time difference

### DIFF
--- a/lldb/test/API/functionalities/data-formatter/data-formatter-objc/TestDataFormatterObjCNSDate.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-objc/TestDataFormatterObjCNSDate.py
@@ -40,7 +40,8 @@ class ObjCDataFormatterNSDate(ObjCDataFormatterTestCase):
         self.expect("frame variable date5", substrs=[now_year])
 
         self.expect(
-            "frame variable date1_abs date2_abs", substrs=["1985-04", "2011-01"]
+            "frame variable date1_abs date2_abs",
+            patterns=["1985-04-10|1985-04-11", "2011-01-01|2010-12-31"],
         )
 
         self.expect("frame variable date3_abs", substrs=[now_year])


### PR DESCRIPTION
It seems there may be a formatter bug when there's a time zone difference between the target machine being debugged, and the host the debugger is running on.