### PR TITLE
[flang][openacc] Attach IndirectGlobalAccessModel to fir.use_stmt

### DIFF
--- a/flang/lib/Optimizer/OpenACC/Support/FIROpenACCOpsInterfaces.cpp
+++ b/flang/lib/Optimizer/OpenACC/Support/FIROpenACCOpsInterfaces.cpp
@@ -216,6 +216,23 @@ void IndirectGlobalAccessModel<fir::TypeDescOp>::getReferencedSymbols(
 }
 
 template <>
+void IndirectGlobalAccessModel<fir::UseStmtOp>::getReferencedSymbols(
+    mlir::Operation *op, llvm::SmallVectorImpl<mlir::SymbolRefAttr> &symbols,
+    mlir::SymbolTable *symbolTable) const {
+  auto useStmtOp = mlir::cast<fir::UseStmtOp>(op);
+  if (auto onlySymbols = useStmtOp.getOnlySymbols()) {
+    for (auto attr : *onlySymbols)
+      if (auto symRef = mlir::dyn_cast<mlir::SymbolRefAttr>(attr))
+        symbols.push_back(symRef);
+  }
+  if (auto renames = useStmtOp.getRenames()) {
+    for (auto attr : *renames)
+      if (auto renameAttr = mlir::dyn_cast<fir::UseRenameAttr>(attr))
+        symbols.push_back(renameAttr.getSymbol());
+  }
+}
+
+template <>
 bool OperationMoveModel<mlir::acc::LoopOp>::canMoveFromDescendant(
     mlir::Operation *op, mlir::Operation *descendant,
     mlir::Operation *candidate) const {

--- a/flang/lib/Optimizer/OpenACC/Support/RegisterOpenACCExtensions.cpp
+++ b/flang/lib/Optimizer/OpenACC/Support/RegisterOpenACCExtensions.cpp
@@ -65,6 +65,8 @@ void registerOpenACCExtensions(mlir::DialectRegistry &registry) {
         *ctx);
     fir::TypeDescOp::attachInterface<
         IndirectGlobalAccessModel<fir::TypeDescOp>>(*ctx);
+    fir::UseStmtOp::attachInterface<IndirectGlobalAccessModel<fir::UseStmtOp>>(
+        *ctx);
 
     // Attach OutlineRematerializationOpInterface to FIR operations that
     // produce synthetic types (shapes, field indices) which cannot be passed

--- a/flang/test/Transforms/OpenACC/offload-target-verifier.fir
+++ b/flang/test/Transforms/OpenACC/offload-target-verifier.fir
@@ -311,3 +311,37 @@ func.func @test_fir_embox() {
   }
   return
 }
+
+// -----
+
+// Test fir.use_stmt inside offload region referencing undeclared global
+fir.global @_QMmod1Evar1 : f32 {
+  %0 = arith.constant 0.0 : f32
+  fir.has_value %0 : f32
+}
+
+func.func @test_use_stmt_no_declare() {
+  // expected-warning @below {{illegal symbol(s): _QMmod1Evar1}}
+  acc.serial {
+    fir.use_stmt "mod1" only_symbols[[@_QMmod1Evar1]]
+    acc.yield
+  }
+  return
+}
+
+// -----
+
+// Test fir.use_stmt inside offload region referencing declared global
+fir.global @_QMmod2Evar2 {acc.declare = #acc.declare<dataClause = acc_create>} : f32 {
+  %0 = arith.constant 0.0 : f32
+  fir.has_value %0 : f32
+}
+
+func.func @test_use_stmt_with_declare() {
+  // expected-remark @below {{passed validity check}}
+  acc.serial {
+    fir.use_stmt "mod2" only_symbols[[@_QMmod2Evar2]]
+    acc.yield
+  }
+  return
+}


### PR DESCRIPTION
In some cases, `fir.use_stmt` operation can end up in offload region like in acc routine for example. Make sure we can validate the symbols associated with the `fir.use_stmt` operation. 