### PR TITLE
[CIR] Add support for size parameter with array delete

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenExprCXX.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprCXX.cpp
@@ -1222,12 +1222,11 @@ void CIRGenFunction::emitCXXDeleteExpr(const CXXDeleteExpr *e) {
   }
 
   if (e->isArrayForm()) {
-    // To handle this for cases that require array cookie, we will need to
-    // add target-specific handling during the lowering of delete_array in
-    // CXXABILowering, but we can emit a better diagnostic here.
-    if (e->doesUsualArrayDeleteWantSize() || deleteTy.isDestructedType()) {
+    // This will be handled in CXXABILowering, but we can emit a better
+    // diagnostic here.
+    if (deleteTy.isDestructedType()) {
       cgm.errorNYI(e->getSourceRange(),
-                   "emitCXXDeleteExpr: array delete requires cookies");
+                   "emitCXXDeleteExpr: array delete of destructed type");
     }
     const FunctionDecl *operatorDelete = e->getOperatorDelete();
     cir::FuncOp operatorDeleteFn = cgm.getAddrOfFunction(operatorDelete);

--- a/clang/lib/CIR/Dialect/Transforms/CXXABILowering.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/CXXABILowering.cpp
@@ -13,7 +13,6 @@
 #include "mlir/Interfaces/DataLayoutInterfaces.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/DialectConversion.h"
-#include "clang/Basic/TargetInfo.h"
 #include "clang/CIR/Dialect/Builder/CIRBaseBuilder.h"
 #include "clang/CIR/Dialect/IR/CIRAttrs.h"
 #include "clang/CIR/Dialect/IR/CIRDialect.h"
@@ -326,19 +325,47 @@ mlir::LogicalResult CIRDeleteArrayOpABILowering::matchAndRewrite(
   mlir::FlatSymbolRefAttr deleteFn = op.getDeleteFnAttr();
   mlir::Location loc = op->getLoc();
   mlir::Value loweredAddress = adaptor.getAddress();
-  auto voidPtrTy =
-      cir::PointerType::get(cir::VoidType::get(rewriter.getContext()));
-  mlir::Value deletePtr = cir::CastOp::create(
-      rewriter, loc, voidPtrTy, cir::CastKind::bitcast, loweredAddress);
 
   cir::UsualDeleteParamsAttr deleteParams = op.getDeleteParams();
-  if (deleteParams.getSize() || deleteParams.getTypeAwareDelete() ||
-      deleteParams.getDestroyingDelete() || deleteParams.getAlignment())
-    return rewriter.notifyMatchFailure(
-        op,
-        "sized, type-aware, destroying, or aligned delete not yet supported");
+  bool sizeNeeded = deleteParams.getSize();
 
-  llvm::SmallVector<mlir::Value> callArgs{deletePtr};
+  if (deleteParams.getTypeAwareDelete() || deleteParams.getDestroyingDelete() ||
+      deleteParams.getAlignment())
+    return rewriter.notifyMatchFailure(
+        op, "type-aware, destroying, or aligned delete not yet supported");
+
+  const CIRCXXABI &cxxABI = lowerModule->getCXXABI();
+  mlir::Value deletePtr;
+  llvm::SmallVector<mlir::Value> callArgs;
+
+  if (sizeNeeded) {
+    mlir::Value numElements;
+    clang::CharUnits cookieSize;
+    auto ptrTy = mlir::cast<cir::PointerType>(loweredAddress.getType());
+    mlir::DataLayout dl(op->getParentOfType<mlir::ModuleOp>());
+
+    cxxABI.readArrayCookie(loc, loweredAddress, dl, rewriter, numElements,
+                           deletePtr, cookieSize);
+    callArgs.push_back(deletePtr);
+    uint64_t eltSizeBytes = dl.getTypeSizeInBits(ptrTy.getPointee()) / 8;
+    cir::IntType sizeTy = cxxABI.getSizeTy();
+
+    mlir::Value eltSizeVal = cir::ConstantOp::create(
+        rewriter, loc, cir::IntAttr::get(sizeTy, eltSizeBytes));
+    mlir::Value allocSize =
+        cir::MulOp::create(rewriter, loc, sizeTy, eltSizeVal, numElements);
+    mlir::Value cookieSizeVal = cir::ConstantOp::create(
+        rewriter, loc,
+        cir::IntAttr::get(sizeTy, cookieSize.getQuantity()));
+    allocSize =
+        cir::AddOp::create(rewriter, loc, sizeTy, allocSize, cookieSizeVal);
+    callArgs.push_back(allocSize);
+  } else {
+    deletePtr = cir::CastOp::create(rewriter, loc, cxxABI.getVoidPtrTy(),
+                                    cir::CastKind::bitcast, loweredAddress);
+    callArgs.push_back(deletePtr);
+  }
+
   cir::CallOp::create(rewriter, loc, deleteFn, cir::VoidType(), callArgs);
   rewriter.eraseOp(op);
   return mlir::success();

--- a/clang/lib/CIR/Dialect/Transforms/CXXABILowering.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/CXXABILowering.cpp
@@ -355,8 +355,7 @@ mlir::LogicalResult CIRDeleteArrayOpABILowering::matchAndRewrite(
     mlir::Value allocSize =
         cir::MulOp::create(rewriter, loc, sizeTy, eltSizeVal, numElements);
     mlir::Value cookieSizeVal = cir::ConstantOp::create(
-        rewriter, loc,
-        cir::IntAttr::get(sizeTy, cookieSize.getQuantity()));
+        rewriter, loc, cir::IntAttr::get(sizeTy, cookieSize.getQuantity()));
     allocSize =
         cir::AddOp::create(rewriter, loc, sizeTy, allocSize, cookieSizeVal);
     callArgs.push_back(allocSize);

--- a/clang/lib/CIR/Dialect/Transforms/CXXABILowering.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/CXXABILowering.cpp
@@ -335,6 +335,7 @@ mlir::LogicalResult CIRDeleteArrayOpABILowering::matchAndRewrite(
         op, "type-aware, destroying, or aligned delete not yet supported");
 
   const CIRCXXABI &cxxABI = lowerModule->getCXXABI();
+  CIRBaseBuilderTy cirBuilder(rewriter);
   mlir::Value deletePtr;
   llvm::SmallVector<mlir::Value> callArgs;
 
@@ -344,11 +345,13 @@ mlir::LogicalResult CIRDeleteArrayOpABILowering::matchAndRewrite(
     auto ptrTy = mlir::cast<cir::PointerType>(loweredAddress.getType());
     mlir::DataLayout dl(op->getParentOfType<mlir::ModuleOp>());
 
-    cxxABI.readArrayCookie(loc, loweredAddress, dl, rewriter, numElements,
+    cxxABI.readArrayCookie(loc, loweredAddress, dl, cirBuilder, numElements,
                            deletePtr, cookieSize);
     callArgs.push_back(deletePtr);
     uint64_t eltSizeBytes = dl.getTypeSizeInBits(ptrTy.getPointee()) / 8;
-    cir::IntType sizeTy = cxxABI.getSizeTy();
+    unsigned ptrWidth =
+        lowerModule->getTarget().getPointerWidth(clang::LangAS::Default);
+    cir::IntType sizeTy = cirBuilder.getUIntNTy(ptrWidth);
 
     mlir::Value eltSizeVal = cir::ConstantOp::create(
         rewriter, loc, cir::IntAttr::get(sizeTy, eltSizeBytes));
@@ -360,7 +363,7 @@ mlir::LogicalResult CIRDeleteArrayOpABILowering::matchAndRewrite(
         cir::AddOp::create(rewriter, loc, sizeTy, allocSize, cookieSizeVal);
     callArgs.push_back(allocSize);
   } else {
-    deletePtr = cir::CastOp::create(rewriter, loc, cxxABI.getVoidPtrTy(),
+    deletePtr = cir::CastOp::create(rewriter, loc, cirBuilder.getVoidPtrTy(),
                                     cir::CastKind::bitcast, loweredAddress);
     callArgs.push_back(deletePtr);
   }

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/CIRCXXABI.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/CIRCXXABI.cpp
@@ -12,9 +12,51 @@
 //===----------------------------------------------------------------------===//
 
 #include "CIRCXXABI.h"
+#include "LowerModule.h"
 
 namespace cir {
 
+CIRCXXABI::CIRCXXABI(LowerModule &lm) : lm(lm) {
+  mlir::MLIRContext *ctx = lm.getMLIRContext();
+  ptrSizeInBits = lm.getTarget().getPointerWidth(clang::LangAS::Default);
+  u8Ty = cir::IntType::get(ctx, 8, /*isSigned=*/false);
+  u8PtrTy = cir::PointerType::get(u8Ty);
+  voidPtrTy = cir::PointerType::get(cir::VoidType::get(ctx));
+  sizeTy = cir::IntType::get(ctx, ptrSizeInBits, /*isSigned=*/false);
+  ptrDiffTy = cir::IntType::get(ctx, ptrSizeInBits, /*isSigned=*/true);
+}
+
 CIRCXXABI::~CIRCXXABI() {}
+
+void CIRCXXABI::readArrayCookie(mlir::Location loc, mlir::Value elementPtr,
+                                const mlir::DataLayout &dataLayout,
+                                mlir::OpBuilder &builder,
+                                mlir::Value &numElements,
+                                mlir::Value &allocPtr,
+                                clang::CharUnits &cookieSize) const {
+  auto ptrTy = mlir::cast<cir::PointerType>(elementPtr.getType());
+  cookieSize = getArrayCookieSizeImpl(ptrTy.getPointee(), dataLayout);
+
+  mlir::Value bytePtr = cir::CastOp::create(builder, loc, u8PtrTy,
+                                             cir::CastKind::bitcast,
+                                             elementPtr);
+
+  mlir::Value negCookieSize = cir::ConstantOp::create(
+      builder, loc,
+      cir::IntAttr::get(ptrDiffTy, -cookieSize.getQuantity()));
+  mlir::Value allocBytePtr = cir::PtrStrideOp::create(builder, loc, u8PtrTy,
+                                                       bytePtr, negCookieSize);
+
+  allocPtr = cir::CastOp::create(builder, loc, voidPtrTy,
+                                 cir::CastKind::bitcast, allocBytePtr);
+
+  // cookieSize is always a multiple of the element ABI alignment (both are
+  // powers of 2 and cookieSize >= elementAlign), so subtracting it preserves
+  // alignment. The cookie alignment therefore equals the element alignment.
+  clang::CharUnits cookieAlignment = clang::CharUnits::fromQuantity(
+      dataLayout.getTypeABIAlignment(ptrTy.getPointee()));
+  numElements = readArrayCookieImpl(loc, allocBytePtr, cookieSize,
+                                    cookieAlignment, dataLayout, builder);
+}
 
 } // namespace cir

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/CIRCXXABI.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/CIRCXXABI.cpp
@@ -31,21 +31,18 @@ CIRCXXABI::~CIRCXXABI() {}
 void CIRCXXABI::readArrayCookie(mlir::Location loc, mlir::Value elementPtr,
                                 const mlir::DataLayout &dataLayout,
                                 mlir::OpBuilder &builder,
-                                mlir::Value &numElements,
-                                mlir::Value &allocPtr,
+                                mlir::Value &numElements, mlir::Value &allocPtr,
                                 clang::CharUnits &cookieSize) const {
   auto ptrTy = mlir::cast<cir::PointerType>(elementPtr.getType());
   cookieSize = getArrayCookieSizeImpl(ptrTy.getPointee(), dataLayout);
 
   mlir::Value bytePtr = cir::CastOp::create(builder, loc, u8PtrTy,
-                                             cir::CastKind::bitcast,
-                                             elementPtr);
+                                            cir::CastKind::bitcast, elementPtr);
 
   mlir::Value negCookieSize = cir::ConstantOp::create(
-      builder, loc,
-      cir::IntAttr::get(ptrDiffTy, -cookieSize.getQuantity()));
-  mlir::Value allocBytePtr = cir::PtrStrideOp::create(builder, loc, u8PtrTy,
-                                                       bytePtr, negCookieSize);
+      builder, loc, cir::IntAttr::get(ptrDiffTy, -cookieSize.getQuantity()));
+  mlir::Value allocBytePtr =
+      cir::PtrStrideOp::create(builder, loc, u8PtrTy, bytePtr, negCookieSize);
 
   allocPtr = cir::CastOp::create(builder, loc, voidPtrTy,
                                  cir::CastKind::bitcast, allocBytePtr);

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/CIRCXXABI.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/CIRCXXABI.cpp
@@ -16,23 +16,21 @@
 
 namespace cir {
 
-CIRCXXABI::CIRCXXABI(LowerModule &lm) : lm(lm) {
-  mlir::MLIRContext *ctx = lm.getMLIRContext();
-  ptrSizeInBits = lm.getTarget().getPointerWidth(clang::LangAS::Default);
-  u8Ty = cir::IntType::get(ctx, 8, /*isSigned=*/false);
-  u8PtrTy = cir::PointerType::get(u8Ty);
-  voidPtrTy = cir::PointerType::get(cir::VoidType::get(ctx));
-  sizeTy = cir::IntType::get(ctx, ptrSizeInBits, /*isSigned=*/false);
-  ptrDiffTy = cir::IntType::get(ctx, ptrSizeInBits, /*isSigned=*/true);
-}
-
 CIRCXXABI::~CIRCXXABI() {}
+
+unsigned CIRCXXABI::getPtrSizeInBits() const {
+  return lm.getTarget().getPointerWidth(clang::LangAS::Default);
+}
 
 void CIRCXXABI::readArrayCookie(mlir::Location loc, mlir::Value elementPtr,
                                 const mlir::DataLayout &dataLayout,
-                                mlir::OpBuilder &builder,
+                                CIRBaseBuilderTy &builder,
                                 mlir::Value &numElements, mlir::Value &allocPtr,
                                 clang::CharUnits &cookieSize) const {
+  auto u8PtrTy = builder.getPointerTo(builder.getUIntNTy(8));
+  auto ptrDiffTy = builder.getSIntNTy(getPtrSizeInBits());
+  auto voidPtrTy = builder.getVoidPtrTy();
+
   auto ptrTy = mlir::cast<cir::PointerType>(elementPtr.getType());
   cookieSize = getArrayCookieSizeImpl(ptrTy.getPointee(), dataLayout);
 

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/CIRCXXABI.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/CIRCXXABI.cpp
@@ -49,7 +49,7 @@ void CIRCXXABI::readArrayCookie(mlir::Location loc, mlir::Value elementPtr,
   // powers of 2 and cookieSize >= elementAlign), so subtracting it preserves
   // alignment. The cookie alignment therefore equals the element alignment.
   clang::CharUnits cookieAlignment = clang::CharUnits::fromQuantity(
-      dataLayout.getTypeABIAlignment(ptrTy.getPointee()));
+      dataLayout.getTypePreferredAlignment(ptrTy.getPointee()));
   numElements = readArrayCookieImpl(loc, allocBytePtr, cookieSize,
                                     cookieAlignment, dataLayout, builder);
 }

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/CIRCXXABI.h
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/CIRCXXABI.h
@@ -15,6 +15,7 @@
 #define CLANG_LIB_CIR_DIALECT_TRANSFORMS_TARGETLOWERING_CIRCXXABI_H
 
 #include "mlir/Transforms/DialectConversion.h"
+#include "clang/AST/CharUnits.h"
 #include "clang/CIR/Dialect/IR/CIRDialect.h"
 #include "clang/CIR/Dialect/IR/CIRTypes.h"
 
@@ -29,10 +30,24 @@ class CIRCXXABI {
 protected:
   LowerModule &lm;
 
-  CIRCXXABI(LowerModule &lm) : lm(lm) {}
+  unsigned ptrSizeInBits;
+  cir::IntType u8Ty;
+  cir::PointerType u8PtrTy;
+  cir::PointerType voidPtrTy;
+  cir::IntType sizeTy;    // unsigned, pointer-width (models size_t)
+  cir::IntType ptrDiffTy; // signed, pointer-width (models ptrdiff_t)
+
+  CIRCXXABI(LowerModule &lm);
 
 public:
   virtual ~CIRCXXABI();
+
+  unsigned getPtrSizeInBits() const { return ptrSizeInBits; }
+  cir::IntType getU8Ty() const { return u8Ty; }
+  cir::PointerType getU8PtrTy() const { return u8PtrTy; }
+  cir::PointerType getVoidPtrTy() const { return voidPtrTy; }
+  cir::IntType getSizeTy() const { return sizeTy; }
+  cir::IntType getPtrDiffTy() const { return ptrDiffTy; }
 
   /// Lower the given data member pointer type to its ABI type. The returned
   /// type is also a CIR type.
@@ -126,6 +141,36 @@ public:
   virtual mlir::Value
   lowerVTableGetTypeInfo(cir::VTableGetTypeInfoOp op,
                          mlir::OpBuilder &builder) const = 0;
+
+  /// Read the array cookie for a dynamically-allocated array whose first
+  /// element is at \p elementPtr. Returns the number of elements, the
+  /// original allocation pointer (before the cookie) as a void*, and the
+  /// cookie size in bytes. Delegates to getArrayCookieSizeImpl and
+  /// readArrayCookieImpl.
+  void readArrayCookie(mlir::Location loc, mlir::Value elementPtr,
+                       const mlir::DataLayout &dataLayout,
+                       mlir::OpBuilder &builder, mlir::Value &numElements,
+                       mlir::Value &allocPtr,
+                       clang::CharUnits &cookieSize) const;
+
+protected:
+  /// Returns the cookie size in bytes for a dynamically-allocated array of
+  /// elements with the given type. Only called when a cookie is required.
+  virtual clang::CharUnits
+  getArrayCookieSizeImpl(mlir::Type elementType,
+                         const mlir::DataLayout &dataLayout) const = 0;
+
+  /// Reads the element count from an array cookie. \p allocPtr is a byte
+  /// pointer to the start of the allocation (the beginning of the cookie).
+  /// \p cookieSize is the value returned by getArrayCookieSizeImpl.
+  /// \p cookieAlignment is the alignment at the cookie start, derived from
+  /// the element type's ABI alignment.
+  virtual mlir::Value
+  readArrayCookieImpl(mlir::Location loc, mlir::Value allocPtr,
+                      clang::CharUnits cookieSize,
+                      clang::CharUnits cookieAlignment,
+                      const mlir::DataLayout &dataLayout,
+                      mlir::OpBuilder &builder) const = 0;
 };
 
 /// Creates an Itanium-family ABI.

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/CIRCXXABI.h
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/CIRCXXABI.h
@@ -165,12 +165,12 @@ protected:
   /// \p cookieSize is the value returned by getArrayCookieSizeImpl.
   /// \p cookieAlignment is the alignment at the cookie start, derived from
   /// the element type's ABI alignment.
-  virtual mlir::Value
-  readArrayCookieImpl(mlir::Location loc, mlir::Value allocPtr,
-                      clang::CharUnits cookieSize,
-                      clang::CharUnits cookieAlignment,
-                      const mlir::DataLayout &dataLayout,
-                      mlir::OpBuilder &builder) const = 0;
+  virtual mlir::Value readArrayCookieImpl(mlir::Location loc,
+                                          mlir::Value allocPtr,
+                                          clang::CharUnits cookieSize,
+                                          clang::CharUnits cookieAlignment,
+                                          const mlir::DataLayout &dataLayout,
+                                          mlir::OpBuilder &builder) const = 0;
 };
 
 /// Creates an Itanium-family ABI.

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/CIRCXXABI.h
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/CIRCXXABI.h
@@ -16,6 +16,7 @@
 
 #include "mlir/Transforms/DialectConversion.h"
 #include "clang/AST/CharUnits.h"
+#include "clang/CIR/Dialect/Builder/CIRBaseBuilder.h"
 #include "clang/CIR/Dialect/IR/CIRDialect.h"
 #include "clang/CIR/Dialect/IR/CIRTypes.h"
 
@@ -30,24 +31,12 @@ class CIRCXXABI {
 protected:
   LowerModule &lm;
 
-  unsigned ptrSizeInBits;
-  cir::IntType u8Ty;
-  cir::PointerType u8PtrTy;
-  cir::PointerType voidPtrTy;
-  cir::IntType sizeTy;    // unsigned, pointer-width (models size_t)
-  cir::IntType ptrDiffTy; // signed, pointer-width (models ptrdiff_t)
+  CIRCXXABI(LowerModule &lm) : lm(lm) {}
 
-  CIRCXXABI(LowerModule &lm);
+  unsigned getPtrSizeInBits() const;
 
 public:
   virtual ~CIRCXXABI();
-
-  unsigned getPtrSizeInBits() const { return ptrSizeInBits; }
-  cir::IntType getU8Ty() const { return u8Ty; }
-  cir::PointerType getU8PtrTy() const { return u8PtrTy; }
-  cir::PointerType getVoidPtrTy() const { return voidPtrTy; }
-  cir::IntType getSizeTy() const { return sizeTy; }
-  cir::IntType getPtrDiffTy() const { return ptrDiffTy; }
 
   /// Lower the given data member pointer type to its ABI type. The returned
   /// type is also a CIR type.
@@ -149,7 +138,7 @@ public:
   /// readArrayCookieImpl.
   void readArrayCookie(mlir::Location loc, mlir::Value elementPtr,
                        const mlir::DataLayout &dataLayout,
-                       mlir::OpBuilder &builder, mlir::Value &numElements,
+                       CIRBaseBuilderTy &builder, mlir::Value &numElements,
                        mlir::Value &allocPtr,
                        clang::CharUnits &cookieSize) const;
 
@@ -170,7 +159,7 @@ protected:
                                           clang::CharUnits cookieSize,
                                           clang::CharUnits cookieAlignment,
                                           const mlir::DataLayout &dataLayout,
-                                          mlir::OpBuilder &builder) const = 0;
+                                          CIRBaseBuilderTy &builder) const = 0;
 };
 
 /// Creates an Itanium-family ABI.

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerItaniumCXXABI.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerItaniumCXXABI.cpp
@@ -108,6 +108,16 @@ public:
                                mlir::OpBuilder &builder) const override;
   mlir::Value lowerVTableGetTypeInfo(cir::VTableGetTypeInfoOp op,
                                      mlir::OpBuilder &builder) const override;
+
+  clang::CharUnits
+  getArrayCookieSizeImpl(mlir::Type elementType,
+                         const mlir::DataLayout &dataLayout) const override;
+
+  mlir::Value readArrayCookieImpl(mlir::Location loc, mlir::Value allocPtr,
+                                  clang::CharUnits cookieSize,
+                                  clang::CharUnits cookieAlignment,
+                                  const mlir::DataLayout &dataLayout,
+                                  mlir::OpBuilder &builder) const override;
 };
 
 } // namespace
@@ -774,6 +784,47 @@ LowerItaniumCXXABI::lowerVTableGetTypeInfo(cir::VTableGetTypeInfoOp op,
   return cir::PtrStrideOp::create(builder, loc, vptrCast.getType(), vptrCast,
                                   offset)
       .getResult();
+}
+
+clang::CharUnits LowerItaniumCXXABI::getArrayCookieSizeImpl(
+    mlir::Type elementType, const mlir::DataLayout &dataLayout) const {
+  // The array cookie is a size_t; pad that up to the element alignment.
+  // The cookie is actually right-justified in that space.
+  clang::CharUnits sizeOfSizeT =
+      clang::CharUnits::fromQuantity(ptrSizeInBits / 8);
+  clang::CharUnits eltAlign =
+      clang::CharUnits::fromQuantity(dataLayout.getTypeABIAlignment(elementType));
+  return std::max(sizeOfSizeT, eltAlign);
+}
+
+mlir::Value LowerItaniumCXXABI::readArrayCookieImpl(
+    mlir::Location loc, mlir::Value allocPtr, clang::CharUnits cookieSize,
+    clang::CharUnits cookieAlignment, const mlir::DataLayout &dataLayout,
+    mlir::OpBuilder &builder) const {
+  // The element count is right-justified in the cookie.
+  clang::CharUnits sizeOfSizeT =
+      clang::CharUnits::fromQuantity(ptrSizeInBits / 8);
+  clang::CharUnits countOffset = cookieSize - sizeOfSizeT;
+
+  mlir::Value countBytePtr = allocPtr;
+  clang::CharUnits countAlignment = cookieAlignment;
+  if (!countOffset.isZero()) {
+    mlir::Value offsetVal = cir::ConstantOp::create(
+        builder, loc,
+        cir::IntAttr::get(ptrDiffTy, countOffset.getQuantity()));
+    countBytePtr =
+        cir::PtrStrideOp::create(builder, loc, u8PtrTy, allocPtr, offsetVal);
+    countAlignment = cookieAlignment.alignmentAtOffset(countOffset);
+  }
+
+  auto countPtrTy = cir::PointerType::get(sizeTy);
+  mlir::Value countPtr = cir::CastOp::create(builder, loc, countPtrTy,
+                                             cir::CastKind::bitcast,
+                                             countBytePtr);
+  return cir::LoadOp::create(
+      builder, loc, countPtr, /*isDeref=*/false, /*isVolatile=*/false,
+      builder.getI64IntegerAttr(countAlignment.getQuantity()),
+      cir::SyncScopeKindAttr(), cir::MemOrderAttr());
 }
 
 } // namespace cir

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerItaniumCXXABI.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerItaniumCXXABI.cpp
@@ -793,7 +793,7 @@ clang::CharUnits LowerItaniumCXXABI::getArrayCookieSizeImpl(
   clang::CharUnits sizeOfSizeT =
       clang::CharUnits::fromQuantity(getPtrSizeInBits() / 8);
   clang::CharUnits eltAlign = clang::CharUnits::fromQuantity(
-      dataLayout.getTypeABIAlignment(elementType));
+      dataLayout.getTypePreferredAlignment(elementType));
   return std::max(sizeOfSizeT, eltAlign);
 }
 

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerItaniumCXXABI.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerItaniumCXXABI.cpp
@@ -117,7 +117,7 @@ public:
                                   clang::CharUnits cookieSize,
                                   clang::CharUnits cookieAlignment,
                                   const mlir::DataLayout &dataLayout,
-                                  mlir::OpBuilder &builder) const override;
+                                  CIRBaseBuilderTy &builder) const override;
 };
 
 } // namespace
@@ -791,7 +791,7 @@ clang::CharUnits LowerItaniumCXXABI::getArrayCookieSizeImpl(
   // The array cookie is a size_t; pad that up to the element alignment.
   // The cookie is actually right-justified in that space.
   clang::CharUnits sizeOfSizeT =
-      clang::CharUnits::fromQuantity(ptrSizeInBits / 8);
+      clang::CharUnits::fromQuantity(getPtrSizeInBits() / 8);
   clang::CharUnits eltAlign = clang::CharUnits::fromQuantity(
       dataLayout.getTypeABIAlignment(elementType));
   return std::max(sizeOfSizeT, eltAlign);
@@ -800,7 +800,12 @@ clang::CharUnits LowerItaniumCXXABI::getArrayCookieSizeImpl(
 mlir::Value LowerItaniumCXXABI::readArrayCookieImpl(
     mlir::Location loc, mlir::Value allocPtr, clang::CharUnits cookieSize,
     clang::CharUnits cookieAlignment, const mlir::DataLayout &dataLayout,
-    mlir::OpBuilder &builder) const {
+    CIRBaseBuilderTy &builder) const {
+  unsigned ptrSizeInBits = getPtrSizeInBits();
+  auto u8PtrTy = builder.getPointerTo(builder.getUIntNTy(8));
+  auto ptrDiffTy = builder.getSIntNTy(ptrSizeInBits);
+  auto sizeTy = builder.getUIntNTy(ptrSizeInBits);
+
   // The element count is right-justified in the cookie.
   clang::CharUnits sizeOfSizeT =
       clang::CharUnits::fromQuantity(ptrSizeInBits / 8);

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerItaniumCXXABI.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerItaniumCXXABI.cpp
@@ -792,8 +792,8 @@ clang::CharUnits LowerItaniumCXXABI::getArrayCookieSizeImpl(
   // The cookie is actually right-justified in that space.
   clang::CharUnits sizeOfSizeT =
       clang::CharUnits::fromQuantity(ptrSizeInBits / 8);
-  clang::CharUnits eltAlign =
-      clang::CharUnits::fromQuantity(dataLayout.getTypeABIAlignment(elementType));
+  clang::CharUnits eltAlign = clang::CharUnits::fromQuantity(
+      dataLayout.getTypeABIAlignment(elementType));
   return std::max(sizeOfSizeT, eltAlign);
 }
 
@@ -810,17 +810,15 @@ mlir::Value LowerItaniumCXXABI::readArrayCookieImpl(
   clang::CharUnits countAlignment = cookieAlignment;
   if (!countOffset.isZero()) {
     mlir::Value offsetVal = cir::ConstantOp::create(
-        builder, loc,
-        cir::IntAttr::get(ptrDiffTy, countOffset.getQuantity()));
+        builder, loc, cir::IntAttr::get(ptrDiffTy, countOffset.getQuantity()));
     countBytePtr =
         cir::PtrStrideOp::create(builder, loc, u8PtrTy, allocPtr, offsetVal);
     countAlignment = cookieAlignment.alignmentAtOffset(countOffset);
   }
 
   auto countPtrTy = cir::PointerType::get(sizeTy);
-  mlir::Value countPtr = cir::CastOp::create(builder, loc, countPtrTy,
-                                             cir::CastKind::bitcast,
-                                             countBytePtr);
+  mlir::Value countPtr = cir::CastOp::create(
+      builder, loc, countPtrTy, cir::CastKind::bitcast, countBytePtr);
   return cir::LoadOp::create(
       builder, loc, countPtr, /*isDeref=*/false, /*isVolatile=*/false,
       builder.getI64IntegerAttr(countAlignment.getQuantity()),

--- a/clang/test/CIR/CodeGen/delete-array.cpp
+++ b/clang/test/CIR/CodeGen/delete-array.cpp
@@ -62,3 +62,52 @@ void test_simple_delete_array(SimpleArrDelete *ptr) {
 // OGCG:   call void @_ZN15SimpleArrDeletedaEPv(ptr {{.*}} %[[PTR]])
 // OGCG:   br label %[[ARR_DELETE_END]]
 // OGCG: [[ARR_DELETE_END]]:
+
+typedef __typeof(sizeof(int)) size_t;
+
+struct SizedArrayDelete {
+  void operator delete[](void *, size_t);
+  int member;
+};
+void test_sized_array_delete(SizedArrayDelete *ptr) {
+  delete[] ptr;
+}
+
+// CIR-BEFORE: cir.func {{.*}} @_Z23test_sized_array_deleteP16SizedArrayDelete
+// CIR-BEFORE:   %[[PTR:.*]] = cir.load{{.*}} %{{.*}}
+// CIR-BEFORE:   cir.delete_array %[[PTR]] : !cir.ptr<!rec_SizedArrayDelete> {delete_fn = @_ZN16SizedArrayDeletedaEPvm, delete_params = #cir.usual_delete_params<size = true>
+
+// CIR: cir.func {{.*}} @_Z23test_sized_array_deleteP16SizedArrayDelete
+// CIR:   %[[PTR:.*]] = cir.load{{.*}} %{{.*}}
+// CIR:   %[[BYTE_PTR:.*]] = cir.cast bitcast %[[PTR]] : !cir.ptr<!rec_SizedArrayDelete> -> !cir.ptr<!u8i>
+// CIR:   %[[NEG_COOKIE:.*]] = cir.const #cir.int<-8> : !s64i
+// CIR:   %[[ALLOC_BYTE_PTR:.*]] = cir.ptr_stride %[[BYTE_PTR]], %[[NEG_COOKIE]] : (!cir.ptr<!u8i>, !s64i) -> !cir.ptr<!u8i>
+// CIR:   %[[VOID_PTR:.*]] = cir.cast bitcast %[[ALLOC_BYTE_PTR]] : !cir.ptr<!u8i> -> !cir.ptr<!void>
+// CIR:   %[[COOKIE_PTR:.*]] = cir.cast bitcast %[[ALLOC_BYTE_PTR]] : !cir.ptr<!u8i> -> !cir.ptr<!u64i>
+// CIR:   %[[NUM_ELEM:.*]] = cir.load align(4) %[[COOKIE_PTR]] : !cir.ptr<!u64i>, !u64i
+// CIR:   %[[ELEM_SIZE:.*]] = cir.const #cir.int<4> : !u64i
+// CIR:   %[[ARRAY_SIZE:.*]] = cir.mul %[[ELEM_SIZE]], %[[NUM_ELEM]] : !u64i
+// CIR:   %[[COOKIE_SIZE:.*]] = cir.const #cir.int<8> : !u64i
+// CIR:   %[[TOTAL_SIZE:.*]] = cir.add %[[ARRAY_SIZE]], %[[COOKIE_SIZE]] : !u64i
+// CIR:   cir.call @_ZN16SizedArrayDeletedaEPvm(%[[VOID_PTR]], %[[TOTAL_SIZE]])
+
+// LLVM: define {{.*}} void @_Z23test_sized_array_deleteP16SizedArrayDelete
+// LLVM:   %[[PTR:.*]] = load ptr, ptr %{{.*}}
+// LLVM:   %[[ALLOC_PTR:.*]] = getelementptr i8, ptr %[[PTR]], i64 -8
+// LLVM:   %[[NUM_ELEM:.*]] = load i64, ptr %[[ALLOC_PTR]], align 4
+// LLVM:   %[[ARRAY_SIZE:.*]] = mul i64 4, %[[NUM_ELEM]]
+// LLVM:   %[[TOTAL_SIZE:.*]] = add i64 %[[ARRAY_SIZE]], 8
+// LLVM:   call void @_ZN16SizedArrayDeletedaEPvm(ptr %[[ALLOC_PTR]], i64 %[[TOTAL_SIZE]])
+
+// OGCG: define {{.*}} void @_Z23test_sized_array_deleteP16SizedArrayDelete
+// OGCG:   %[[PTR:.*]] = load ptr, ptr %{{.*}}
+// OGCG:   %[[IS_NULL:.*]] = icmp eq ptr %[[PTR]], null
+// OGCG:   br i1 %[[IS_NULL]], label %[[DELETE_END:.*]], label %[[DELETE_NOT_NULL:.*]]
+// OGCG: [[DELETE_NOT_NULL]]:
+// OGCG:   %[[ALLOC_PTR:.*]] = getelementptr inbounds i8, ptr %[[PTR]], i64 -8
+// OGCG:   %[[NUM_ELEM:.*]] = load i64, ptr %[[ALLOC_PTR]], align 4
+// OGCG:   %[[ARRAY_SIZE:.*]] = mul i64 4, %[[NUM_ELEM]]
+// OGCG:   %[[TOTAL_SIZE:.*]] = add i64 %[[ARRAY_SIZE]], 8
+// OGCG:   call void @_ZN16SizedArrayDeletedaEPvm(ptr {{.*}} %[[ALLOC_PTR]], i64 {{.*}} %[[TOTAL_SIZE]])
+// OGCG:   br label %[[DELETE_END]]
+// OGCG: [[DELETE_END]]:


### PR DESCRIPTION
This implements reading the array cookie and passing a size parameter to the array delete operator for simple cases that require a size parameter.