### PR TITLE
[Clang] Add __ob_trap support for implicit integer sign change

### DIFF
--- a/clang/lib/CodeGen/CGExprScalar.cpp
+++ b/clang/lib/CodeGen/CGExprScalar.cpp
@@ -405,7 +405,8 @@ public:
   /// the sign of the value. It is not UB, so we use the value after conversion.
   /// NOTE: Src and Dst may be the exact same value! (point to the same thing)
   void EmitIntegerSignChangeCheck(Value *Src, QualType SrcType, Value *Dst,
-                                  QualType DstType, SourceLocation Loc);
+                                  QualType DstType, SourceLocation Loc,
+                                  bool OBTrapInvolved = false);
 
   /// Emit a conversion from the specified type to the specified destination
   /// type, both of which are LLVM scalar types.
@@ -1303,8 +1304,10 @@ EmitIntegerSignChangeCheckHelper(Value *Src, QualType SrcType, Value *Dst,
 
 void ScalarExprEmitter::EmitIntegerSignChangeCheck(Value *Src, QualType SrcType,
                                                    Value *Dst, QualType DstType,
-                                                   SourceLocation Loc) {
-  if (!CGF.SanOpts.has(SanitizerKind::SO_ImplicitIntegerSignChange))
+                                                   SourceLocation Loc,
+                                                   bool OBTrapInvolved) {
+  if (!CGF.SanOpts.has(SanitizerKind::SO_ImplicitIntegerSignChange) &&
+      !OBTrapInvolved)
     return;
 
   llvm::Type *SrcTy = Src->getType();
@@ -1389,6 +1392,16 @@ void ScalarExprEmitter::EmitIntegerSignChangeCheck(Value *Src, QualType SrcType,
     CheckKind = ICCK_SignedIntegerTruncationOrSignChange;
     Checks.emplace_back(Check.second);
     // If the comparison result is 'i1 false', then the truncation was lossy.
+  }
+
+  if (!CGF.SanOpts.has(SanitizerKind::SO_ImplicitIntegerSignChange)) {
+    if (OBTrapInvolved) {
+      llvm::Value *Combined = Check.second.first;
+      for (const auto &C : Checks)
+        Combined = Builder.CreateAnd(Combined, C.first);
+      CGF.EmitTrapCheck(Combined, CheckHandler);
+    }
+    return;
   }
 
   llvm::Constant *StaticArgs[] = {
@@ -1828,9 +1841,10 @@ Value *ScalarExprEmitter::EmitScalarConversion(Value *Src, QualType SrcType,
     EmitIntegerTruncationCheck(Src, NoncanonicalSrcType, Res,
                                NoncanonicalDstType, Loc, OBTrapInvolved);
 
-  if (Opts.EmitImplicitIntegerSignChangeChecks)
+  if (Opts.EmitImplicitIntegerSignChangeChecks ||
+      (OBTrapInvolved && !OBWrapInvolved))
     EmitIntegerSignChangeCheck(Src, NoncanonicalSrcType, Res,
-                               NoncanonicalDstType, Loc);
+                               NoncanonicalDstType, Loc, OBTrapInvolved);
 
   return Res;
 }

--- a/clang/test/CodeGen/overflow-behavior-types.c
+++ b/clang/test/CodeGen/overflow-behavior-types.c
@@ -1,9 +1,9 @@
 // RUN: %clang_cc1 -triple x86_64-linux-gnu -fexperimental-overflow-behavior-types %s \
-// RUN: -fsanitize=signed-integer-overflow,unsigned-integer-overflow,implicit-signed-integer-truncation,implicit-unsigned-integer-truncation \
+// RUN: -fsanitize=signed-integer-overflow,unsigned-integer-overflow,implicit-signed-integer-truncation,implicit-unsigned-integer-truncation,implicit-integer-sign-change \
 // RUN: -emit-llvm -o - | FileCheck %s --check-prefix=DEFAULT
 
 // RUN: %clang_cc1 -triple x86_64-linux-gnu -fexperimental-overflow-behavior-types %s -ftrapv \
-// RUN: -fsanitize=signed-integer-overflow,unsigned-integer-overflow,implicit-signed-integer-truncation,implicit-unsigned-integer-truncation \
+// RUN: -fsanitize=signed-integer-overflow,unsigned-integer-overflow,implicit-signed-integer-truncation,implicit-unsigned-integer-truncation,implicit-integer-sign-change \
 // RUN: -emit-llvm -o - | FileCheck %s --check-prefix=DEFAULT
 
 // RUN: %clang_cc1 -triple x86_64-linux-gnu -fexperimental-overflow-behavior-types %s \
@@ -11,12 +11,12 @@
 // RUN: -emit-llvm -o - | FileCheck %s --check-prefix=TRAPV-HANDLER
 
 // RUN: %clang_cc1 -triple x86_64-linux-gnu -fexperimental-overflow-behavior-types %s -fwrapv \
-// RUN: -fsanitize=signed-integer-overflow,unsigned-integer-overflow,implicit-signed-integer-truncation,implicit-unsigned-integer-truncation \
+// RUN: -fsanitize=signed-integer-overflow,unsigned-integer-overflow,implicit-signed-integer-truncation,implicit-unsigned-integer-truncation,implicit-integer-sign-change \
 // RUN: -emit-llvm -o - | FileCheck %s --check-prefix=DEFAULT
 
 // RUN: %clang_cc1 -triple x86_64-linux-gnu -fexperimental-overflow-behavior-types %s \
 // RUN: -fsanitize-undefined-ignore-overflow-pattern=all \
-// RUN: -fsanitize=signed-integer-overflow,unsigned-integer-overflow,implicit-signed-integer-truncation,implicit-unsigned-integer-truncation \
+// RUN: -fsanitize=signed-integer-overflow,unsigned-integer-overflow,implicit-signed-integer-truncation,implicit-unsigned-integer-truncation,implicit-integer-sign-change \
 // RUN: -emit-llvm -o - | FileCheck %s --check-prefix=EXCL
 
 // RUN: %clang_cc1 -triple x86_64-linux-gnu -fexperimental-overflow-behavior-types %s \
@@ -173,4 +173,24 @@ int explicit_truncation_cast(__ob_trap unsigned long long result) {
   // NOSAN: trap:
   // NOSAN: call void @llvm.ubsantrap(i8 7)
   return (int)result;
+}
+
+// Make sure __ob_trap types warn on sign change with
+// -fsanitize=implicit-integer-sign-change or trap otherwise.
+// DEFAULT-LABEL: define {{.*}} @unsigned_to_signed_cast
+void unsigned_to_signed_cast(__ob_trap unsigned long long a) {
+  // DEFAULT: %[[T0:.*]] = load i64, ptr %a.addr
+  // DEFAULT-NEXT: %[[CONV0:.*]] = trunc i64 %[[T0]] to i8
+  // DEFAULT-NEXT: %[[NEG:.*]] = icmp slt i8 %[[CONV0]], 0
+  // DEFAULT-NEXT: %[[SIGN0:.*]] = icmp eq i1 false, %[[NEG]]
+  // DEFAULT: %[[T1:.*]] = and i1 %[[SIGN0]]
+  // DEFUALT-NEXT: br i1 %[[T1]], {{.*}}, label %handler.implicit_conversion
+
+  // NOSAN: %[[T0:.*]] = load i64, ptr %a.addr
+  // NOSAN-NEXT: %[[CONV0:.*]] = trunc i64 %[[T0]] to i8
+  // NOSAN: %[[NEG:.*]] = icmp slt i8 %[[CONV0]], 0
+  // NOSAN-NEXT: %[[SIGN0:.*]] = icmp eq i1 false, %[[NEG]]
+  // NOSAN: %[[T1:.*]] = and i1 %[[SIGN0]]
+  // NOSAN-NEXT: br i1 %[[T1]], {{.*}}, label %trap
+  (signed char)(a);
 }


### PR DESCRIPTION
The `__ob_trap` type specifier can be used to trap (or warn with sanitizers) when overflow or truncation occurs on the specified type.

There was a gap in coverage for this with the `-fsanitize=implicit-integer-sign-change` sanitizer. Fix this by carrying around `__ob_trap` information through `EmitIntegerSignChange()` which allows us to properly trap or warn in the following example:

```
$ cat test.c
int main(__ob_trap unsigned long long a) {
  (signed char)(a);
}

$ clang test.c -Xclang -fexperimental-overflow-behavior-types -o test

$ ./test
[1]    1065345 illegal hardware instruction (core dumped)  ./test
```

... and with runtime sanitizers:
```
$ clang test.c -Xclang -fexperimental-overflow-behavior-types -fsanitize=implicit-integer-sign-change -o test

$ ./test
test.c:9:3: runtime error: implicit conversion from type '__ob_trap unsigned int' of value 4294967295 (32-bit, unsigned) to type 'signed char' changed the value to -1 (8-bit, signed)
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior test.c:9:3 

```

If such a cast is desirable, make your intentions *explicit*:

```c
int main() {
  __ob_trap unsigned int a = 4294967295;
  (__ob_wrap signed char)a;
}
```

---

IIUC, the reason this didn't trap before is because `UINT_MAX` is representable as `-1` as a signed char. This means there was no data loss (truncation) as the bits are technically preserved, only the representation differs. For `__ob_trap` we care about this representation change too. By including the `__ob_wrap` specifiers in our explicit cast we have chosen an overflow behavior which allows for this representation change.