### PR TITLE
[lldb][bytecode] Add swift output to Python->bytecode compiler

### DIFF
--- a/lldb/examples/python/formatter_bytecode.py
+++ b/lldb/examples/python/formatter_bytecode.py
@@ -1221,9 +1221,9 @@ def _main():
         if args.format == "binary":
             with open(args.output, "wb") as output:
                 section.write_binary(output)
-        else:  # args.format == "c"
+        else:
             with open(args.output, "w") as output:
-                section.write_source(output)
+                section.write_source(output, language=args.format)
     elif args.disassemble:
         if args.output:
             with (
@@ -1317,11 +1317,11 @@ if __name__ == "__main__":
                 ],
             )
             out = io.StringIO()
-            section.write_source(out)
+            section.write_source(out, language="c")
             src = out.getvalue()
 
             self.assertIn("__attribute__((used, section(FORMATTER_SECTION)))", src)
-            self.assertIn("unsigned char _Account_synthetic[] =", src)
+            self.assertIn("unsigned char _Account_formatter[] =", src)
             self.assertIn('"\\x01"', src)  # version
             self.assertIn('"\\x15"', src)  # record size (21)
             self.assertIn('"\\x07"', src)  # type name size (7)
@@ -1340,7 +1340,7 @@ if __name__ == "__main__":
 
             # Non-identifier characters in the type name are replaced with '_'.
             out2 = io.StringIO()
-            BytecodeSection("std::vector<int>", 0, []).write_source(out2)
-            self.assertIn("_std__vector_int__synthetic[] =", out2.getvalue())
+            BytecodeSection("std::vector<int>", 0, []).write_source(out2, language="c")
+            self.assertIn("_std__vector_int__formatter[] =", out2.getvalue())
 
     unittest.main(argv=[__file__])

--- a/lldb/examples/python/formatter_bytecode.py
+++ b/lldb/examples/python/formatter_bytecode.py
@@ -226,6 +226,12 @@ class BytecodeSection:
         output.write(_to_uleb(len(bin)))
         output.write(self._to_binary())
 
+    def write_source(self, output: TextIO, language: str) -> None:
+        if language == "c":
+            self.write_c(output)
+        elif language == "swift":
+            self.write_swift(output)
+
     class _CBuilder:
         """Helper class for emitting binary data as a C-string literal."""
 
@@ -248,7 +254,7 @@ class BytecodeSection:
         def add_string(self, string: str, comment: str) -> None:
             self.entries.append((f'"{string}"', comment))
 
-    def write_source(self, output: TextIO) -> None:
+    def write_c(self, output: TextIO) -> None:
         self.validate()
 
         size = len(self._to_binary())
@@ -281,12 +287,81 @@ class BytecodeSection:
             "__attribute__((used, section(FORMATTER_SECTION)))",
             file=output,
         )
-        print(f"unsigned char _{var_name}_synthetic[] =", file=output)
+        print(f"unsigned char _{var_name}_formatter[] =", file=output)
         indent = "    "
         for string, comment in b.entries:
             print(f"{indent}// {comment}", file=output)
             print(f"{indent}{string}", file=output)
         print(";", file=output)
+
+    class _SwiftBuilder:
+        """Helper class for emitting binary data as a Swift tuple literal."""
+
+        entries: list[Tuple[bytes, str]]
+
+        def __init__(self) -> None:
+            self.entries = []
+
+        def add_byte(self, x: int, comment: str) -> None:
+            self.add_bytes(_to_byte(x), comment)
+
+        def add_uleb(self, x: int, comment: str) -> None:
+            self.add_bytes(_to_uleb(x), comment)
+
+        def add_bytes(self, x: bytes, comment: str) -> None:
+            self.entries.append((x, comment))
+
+        def add_string(self, string: str, comment: str) -> None:
+            self.add_bytes(string.encode(), comment)
+
+        @property
+        def type_decl(self):
+            total_bytes = sum((len(bs) for bs, _ in self.entries))
+            element_list = ", ".join(["UInt8"] * total_bytes)
+            return f"({element_list})"
+
+    def write_swift(self, output: TextIO) -> None:
+        self.validate()
+
+        size = len(self._to_binary())
+
+        builder = self._SwiftBuilder()
+        builder.add_byte(BINARY_VERSION, "version")
+        builder.add_uleb(size, "remaining record size")
+        builder.add_uleb(len(self.type_name), "type name size")
+        builder.add_string(self.type_name, f'type name: "{self.type_name}"')
+        builder.add_byte(self.flags, "flags")
+        for sig, bc in self.signatures:
+            builder.add_byte(SIGNATURES[sig], f"sig_{sig}")
+            builder.add_uleb(len(bc), "program size")
+            builder.add_bytes(bc, "program")
+
+        darwin = ("macOS", "iOS", "watchOS", "tvOS", "visionOS")
+        darwin_list = " || ".join(f"os({_os})" for _os in darwin)
+        print(
+            textwrap.dedent(
+                f"""
+                @used
+                #if {darwin_list}
+                @section("__TEXT,__lldbsummaries")
+                #else
+                @section(".lldbsummaries")
+                #endif
+                """
+            ),
+            file=output,
+        )
+        var_name = re.sub(r"\W", "_", self.type_name)
+        print(
+            f"static let _{var_name}_formatter: {builder.type_decl} = (",
+            file=output,
+        )
+        indent = "    "
+        for bs, comment in builder.entries:
+            print(f"{indent}// {comment}", file=output)
+            byte_list = ", ".join(f"0x{b:02x}" for b in bs)
+            print(f"{indent}{byte_list},", file=output)
+        print(")", file=output)
 
 
 def assemble_file(type_name: str, input: TextIO) -> BytecodeSection:
@@ -1110,7 +1185,7 @@ def _main():
     parser.add_argument(
         "-f",
         "--format",
-        choices=("binary", "c"),
+        choices=("binary", "c", "swift"),
         default="binary",
         help="output file format",
     )
@@ -1133,9 +1208,9 @@ def _main():
         if args.format == "binary":
             with open(args.output, "wb") as output:
                 section.write_binary(output)
-        else:  # args.format == "c"
+        else:
             with open(args.output, "w") as output:
-                section.write_source(output)
+                section.write_source(output, language=args.format)
     elif args.assemble:
         if not args.type_name:
             parser.error("--type-name is required with --assemble")

--- a/lldb/examples/python/formatter_bytecode.py
+++ b/lldb/examples/python/formatter_bytecode.py
@@ -338,14 +338,13 @@ class BytecodeSection:
 
         print(
             textwrap.dedent(
-                """
-                @used
+                """\
                 #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS) || os(visionOS)
-                @section("__TEXT,__lldbsummaries")
+                @section("__DATA_CONST,__lldbformatters")
                 #else
-                @section(".lldbsummaries")
+                @section(".lldbformatters")
                 #endif
-                """
+                @used"""
             ),
             file=output,
         )

--- a/lldb/examples/python/formatter_bytecode.py
+++ b/lldb/examples/python/formatter_bytecode.py
@@ -336,13 +336,11 @@ class BytecodeSection:
             builder.add_uleb(len(bc), "program size")
             builder.add_bytes(bc, "program")
 
-        darwin = ("macOS", "iOS", "watchOS", "tvOS", "visionOS")
-        darwin_list = " || ".join(f"os({_os})" for _os in darwin)
         print(
             textwrap.dedent(
-                f"""
+                """
                 @used
-                #if {darwin_list}
+                #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS) || os(visionOS)
                 @section("__TEXT,__lldbsummaries")
                 #else
                 @section(".lldbsummaries")
@@ -353,7 +351,7 @@ class BytecodeSection:
         )
         var_name = re.sub(r"\W", "_", self.type_name)
         print(
-            f"static let _{var_name}_formatter: {builder.type_decl} = (",
+            f"let _{var_name}_formatter: {builder.type_decl} = (",
             file=output,
         )
         indent = "    "

--- a/lldb/examples/python/formatter_bytecode.py
+++ b/lldb/examples/python/formatter_bytecode.py
@@ -240,35 +240,68 @@ class BytecodeSection:
         def __init__(self) -> None:
             self.entries = []
 
-        def add_byte(self, x: int, comment: str) -> None:
-            self.add_bytes(_to_byte(x), comment)
+        def emit_byte(self, x: int, comment: str) -> None:
+            self.emit_bytes(_to_byte(x), comment)
 
-        def add_uleb(self, x: int, comment: str) -> None:
-            self.add_bytes(_to_uleb(x), comment)
+        def emit_uleb(self, x: int, comment: str) -> None:
+            self.emit_bytes(_to_uleb(x), comment)
 
-        def add_bytes(self, x: bytes, comment: str) -> None:
-            # Construct zero padded hex values with length two.
+        def emit_bytes(self, x: bytes, comment: str) -> None:
+            # Construct zero pemited hex values with length two.
             string = "".join(f"\\x{b:02x}" for b in x)
-            self.add_string(string, comment)
+            self.emit_string(string, comment)
 
-        def add_string(self, string: str, comment: str) -> None:
+        def emit_string(self, string: str, comment: str) -> None:
             self.entries.append((f'"{string}"', comment))
+
+    class _SwiftBuilder:
+        """Helper class for emitting binary data as a Swift tuple literal."""
+
+        entries: list[Tuple[bytes, str]]
+
+        def __init__(self) -> None:
+            self.entries = []
+
+        def emit_byte(self, x: int, comment: str) -> None:
+            self.emit_bytes(_to_byte(x), comment)
+
+        def emit_uleb(self, x: int, comment: str) -> None:
+            self.emit_bytes(_to_uleb(x), comment)
+
+        def emit_bytes(self, x: bytes, comment: str) -> None:
+            self.entries.append((x, comment))
+
+        def emit_string(self, string: str, comment: str) -> None:
+            self.emit_bytes(string.encode(), comment)
+
+        @property
+        def type_decl(self):
+            total_bytes = sum((len(bs) for bs, _ in self.entries))
+            element_list = ", ".join(["UInt8"] * total_bytes)
+            return f"({element_list})"
+
+    def _build(self, builder) -> None:
+        size = len(self._to_binary())
+        builder.emit_byte(BINARY_VERSION, "version")
+        builder.emit_uleb(size, "remaining record size")
+        builder.emit_uleb(len(self.type_name), "type name size")
+        builder.emit_string(self.type_name, "type name")
+        builder.emit_byte(self.flags, "flags")
+        for sig, bc in self.signatures:
+            builder.emit_byte(SIGNATURES[sig], f"sig_{sig}")
+            builder.emit_uleb(len(bc), "program size")
+            builder.emit_bytes(bc, "program")
+
+    @property
+    def _var_name(self):
+        var_name = re.sub(r"\W", "_", self.type_name)
+        return f"_{var_name}_formatter"
 
     def write_c(self, output: TextIO) -> None:
         self.validate()
 
-        size = len(self._to_binary())
-
-        b = self._CBuilder()
-        b.add_byte(BINARY_VERSION, "version")
-        b.add_uleb(size, "remaining record size")
-        b.add_uleb(len(self.type_name), "type name size")
-        b.add_string(self.type_name, "type name")
-        b.add_byte(self.flags, "flags")
-        for sig, bc in self.signatures:
-            b.add_byte(SIGNATURES[sig], f"sig_{sig}")
-            b.add_uleb(len(bc), "program size")
-            b.add_bytes(bc, "program")
+        builder = self._CBuilder()
+        self._build(builder)
 
         print(
             textwrap.dedent(
@@ -282,59 +315,22 @@ class BytecodeSection:
             ),
             file=output,
         )
-        var_name = re.sub(r"\W", "_", self.type_name)
         print(
             "__attribute__((used, section(FORMATTER_SECTION)))",
             file=output,
         )
-        print(f"unsigned char _{var_name}_formatter[] =", file=output)
+        print(f"unsigned char {self._var_name}[] =", file=output)
         indent = "    "
-        for string, comment in b.entries:
+        for string, comment in builder.entries:
             print(f"{indent}// {comment}", file=output)
             print(f"{indent}{string}", file=output)
         print(";", file=output)
 
-    class _SwiftBuilder:
-        """Helper class for emitting binary data as a Swift tuple literal."""
-
-        entries: list[Tuple[bytes, str]]
-
-        def __init__(self) -> None:
-            self.entries = []
-
-        def add_byte(self, x: int, comment: str) -> None:
-            self.add_bytes(_to_byte(x), comment)
-
-        def add_uleb(self, x: int, comment: str) -> None:
-            self.add_bytes(_to_uleb(x), comment)
-
-        def add_bytes(self, x: bytes, comment: str) -> None:
-            self.entries.append((x, comment))
-
-        def add_string(self, string: str, comment: str) -> None:
-            self.add_bytes(string.encode(), comment)
-
-        @property
-        def type_decl(self):
-            total_bytes = sum((len(bs) for bs, _ in self.entries))
-            element_list = ", ".join(["UInt8"] * total_bytes)
-            return f"({element_list})"
-
     def write_swift(self, output: TextIO) -> None:
         self.validate()
 
-        size = len(self._to_binary())
-
         builder = self._SwiftBuilder()
-        builder.add_byte(BINARY_VERSION, "version")
-        builder.add_uleb(size, "remaining record size")
-        builder.add_uleb(len(self.type_name), "type name size")
-        builder.add_string(self.type_name, f'type name: "{self.type_name}"')
-        builder.add_byte(self.flags, "flags")
-        for sig, bc in self.signatures:
-            builder.add_byte(SIGNATURES[sig], f"sig_{sig}")
-            builder.add_uleb(len(bc), "program size")
-            builder.add_bytes(bc, "program")
+        self._build(builder)
 
         print(
             textwrap.dedent(
@@ -348,9 +344,8 @@ class BytecodeSection:
             ),
             file=output,
         )
-        var_name = re.sub(r"\W", "_", self.type_name)
         print(
-            f"let _{var_name}_formatter: {builder.type_decl} = (",
+            f"let {self._var_name}: {builder.type_decl} = (",
             file=output,
         )
         indent = "    "

--- a/lldb/test/Shell/ScriptInterpreter/Python/Inputs/FormatterBytecode/RigidArrayLLDBFormatterC.txt
+++ b/lldb/test/Shell/ScriptInterpreter/Python/Inputs/FormatterBytecode/RigidArrayLLDBFormatterC.txt
@@ -6,7 +6,7 @@
 #endif
 
 __attribute__((used, section(FORMATTER_SECTION)))
-unsigned char _RigidArray_synthetic[] =
+unsigned char _RigidArray_formatter[] =
     // version
     "\x01"
     // remaining record size

--- a/lldb/test/Shell/ScriptInterpreter/Python/Inputs/FormatterBytecode/RigidArrayLLDBFormatterSwift.txt
+++ b/lldb/test/Shell/ScriptInterpreter/Python/Inputs/FormatterBytecode/RigidArrayLLDBFormatterSwift.txt
@@ -1,0 +1,38 @@
+
+@used
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS) || os(visionOS)
+@section("__TEXT,__lldbsummaries")
+#else
+@section(".lldbsummaries")
+#endif
+
+static let _RigidArray_formatter: (UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8) = (
+    // version
+    0x01,
+    // remaining record size
+    0x47,
+    // type name size
+    0x0a,
+    // type name: "RigidArray"
+    0x52, 0x69, 0x67, 0x69, 0x64, 0x41, 0x72, 0x72, 0x61, 0x79,
+    // flags
+    0x00,
+    // sig_update
+    0x05,
+    // program size
+    0x27,
+    // program
+    0x21, 0x00, 0x03, 0x22, 0x08, 0x5f, 0x73, 0x74, 0x6f, 0x72, 0x61, 0x67, 0x65, 0x23, 0x12, 0x60, 0x23, 0x18, 0x60, 0x21, 0x00, 0x03, 0x22, 0x06, 0x5f, 0x63, 0x6f, 0x75, 0x6e, 0x74, 0x23, 0x12, 0x60, 0x23, 0x18, 0x60, 0x23, 0x21, 0x60,
+    // sig_get_num_children
+    0x02,
+    // program size
+    0x04,
+    // program
+    0x21, 0x02, 0x03, 0x13,
+    // sig_get_child_at_index
+    0x04,
+    // program size
+    0x0a,
+    // program
+    0x21, 0x01, 0x03, 0x21, 0x04, 0x03, 0x23, 0x11, 0x60, 0x13,
+)

--- a/lldb/test/Shell/ScriptInterpreter/Python/Inputs/FormatterBytecode/RigidArrayLLDBFormatterSwift.txt
+++ b/lldb/test/Shell/ScriptInterpreter/Python/Inputs/FormatterBytecode/RigidArrayLLDBFormatterSwift.txt
@@ -1,12 +1,10 @@
-
-@used
 #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS) || os(visionOS)
-@section("__TEXT,__lldbsummaries")
+@section("__DATA_CONST,__lldbformatters")
 #else
-@section(".lldbsummaries")
+@section(".lldbformatters")
 #endif
-
-static let _RigidArray_formatter: (UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8) = (
+@used
+let _RigidArray_formatter: (UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8) = (
     // version
     0x01,
     // remaining record size

--- a/lldb/test/Shell/ScriptInterpreter/Python/Inputs/FormatterBytecode/RigidArrayLLDBFormatterSwift.txt
+++ b/lldb/test/Shell/ScriptInterpreter/Python/Inputs/FormatterBytecode/RigidArrayLLDBFormatterSwift.txt
@@ -11,7 +11,7 @@ let _RigidArray_formatter: (UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UIn
     0x47,
     // type name size
     0x0a,
-    // type name: "RigidArray"
+    // type name
     0x52, 0x69, 0x67, 0x69, 0x64, 0x41, 0x72, 0x72, 0x61, 0x79,
     // flags
     0x00,

--- a/lldb/test/Shell/ScriptInterpreter/Python/python-bytecode.test
+++ b/lldb/test/Shell/ScriptInterpreter/Python/python-bytecode.test
@@ -1,6 +1,8 @@
 # RUN: mkdir -p %t
-# RUN: %python %S/../../../../examples/python/formatter_bytecode.py --compile %s --format c --type-name RigidArray --output %t/output.txt
-# RUN: diff -u --strip-trailing-cr %S/Inputs/FormatterBytecode/RigidArrayLLDBFormatter.txt %t/output.txt
+# RUN: %python %S/../../../../examples/python/formatter_bytecode.py --compile %s --format c --type-name RigidArray --output %t/c-output.txt
+# RUN: %python %S/../../../../examples/python/formatter_bytecode.py --compile %s --format swift --type-name RigidArray --output %t/swift-output.txt
+# RUN: diff -u --strip-trailing-cr %S/Inputs/FormatterBytecode/RigidArrayLLDBFormatterC.txt %t/c-output.txt
+# RUN: diff -u --strip-trailing-cr %S/Inputs/FormatterBytecode/RigidArrayLLDBFormatterSwift.txt %t/swift-output.txt
 import lldb
 
 


### PR DESCRIPTION
For swift projects using the compiler, having a swift output option will make it easier to integrate bytecode formatters into the build.