### PR TITLE
[WebAssembly] Clang support for exception-based lookup paths

### DIFF
--- a/clang/lib/Driver/ToolChains/WebAssembly.cpp
+++ b/clang/lib/Driver/ToolChains/WebAssembly.cpp
@@ -34,6 +34,15 @@ std::string WebAssembly::getMultiarchTriple(const Driver &D,
             TargetTriple.getOSAndEnvironmentName()).str();
 }
 
+/// Returns a directory name in which separate objects compile with/without
+/// exceptions may lie. This is used both for `#include` paths as well as lib
+/// paths.
+static std::string GetCXXExceptionsDir(const ArgList &DriverArgs) {
+  if (DriverArgs.getLastArg(options::OPT_fwasm_exceptions))
+    return "eh";
+  return "noeh";
+}
+
 std::string wasm::Linker::getLinkerPath(const ArgList &Args) const {
   const ToolChain &ToolChain = getToolChain();
   if (const Arg* A = Args.getLastArg(options::OPT_fuse_ld_EQ)) {
@@ -230,12 +239,16 @@ void wasm::Linker::ConstructJob(Compilation &C, const JobAction &JA,
   }
 }
 
-/// Given a base library directory, append path components to form the
-/// LTO directory.
-static std::string AppendLTOLibDir(const std::string &Dir) {
+/// Append `Dir` to `Paths`, but also include the LTO directories before that if
+/// LTO is eanbled.
+static void AppendLibDirAndLTODir(ToolChain::path_list &Paths, const Driver &D,
+                                  const std::string &Dir) {
+  if (D.isUsingLTO()) {
     // The version allows the path to be keyed to the specific version of
     // LLVM in used, as the bitcode format is not stable.
-    return Dir + "/llvm-lto/" LLVM_VERSION_STRING;
+    Paths.push_back(Dir + "/llvm-lto/" LLVM_VERSION_STRING);
+  }
+  Paths.push_back(Dir);
 }
 
 WebAssembly::WebAssembly(const Driver &D, const llvm::Triple &Triple,
@@ -256,14 +269,15 @@ WebAssembly::WebAssembly(const Driver &D, const llvm::Triple &Triple,
   } else {
     const std::string MultiarchTriple =
         getMultiarchTriple(getDriver(), Triple, SysRoot);
-    if (D.isUsingLTO()) {
-      // For LTO, enable use of lto-enabled sysroot libraries too, if available.
-      // Note that the directory is keyed to the LLVM revision, as LLVM's
-      // bitcode format is not stable.
-      auto Dir = AppendLTOLibDir(SysRoot + "/lib/" + MultiarchTriple);
-      getFilePaths().push_back(Dir);
-    }
-    getFilePaths().push_back(SysRoot + "/lib/" + MultiarchTriple);
+    std::string TripleLibDir = SysRoot + "/lib/" + MultiarchTriple;
+    // Allow sysroots to segregate objects based on whether exceptions are
+    // enabled or not. This is intended to assist with distribution of pre-built
+    // sysroots that contain libraries that are capable of producing binaries
+    // entirely without exception-handling instructions but also with if
+    // exceptions are enabled, for example.
+    AppendLibDirAndLTODir(getFilePaths(), D,
+                          TripleLibDir + "/" + GetCXXExceptionsDir(Args));
+    AppendLibDirAndLTODir(getFilePaths(), D, TripleLibDir);
   }
 
   if (getTriple().getOS() == llvm::Triple::WASI) {
@@ -580,13 +594,18 @@ void WebAssembly::addLibCxxIncludePaths(
   if (Version.empty())
     return;
 
-  // First add the per-target include path if the OS is known.
+  // First add the per-target-per-exception-handling include path if the
+  // OS is known,  then second add the per-target include path.
   if (IsKnownOs) {
-    std::string TargetDir = LibPath + "/" + MultiarchTriple + "/c++/" + Version;
-    addSystemInclude(DriverArgs, CC1Args, TargetDir);
+    std::string TargetDir = LibPath + "/" + MultiarchTriple;
+    std::string Suffix = "/c++/" + Version;
+    addSystemInclude(DriverArgs, CC1Args,
+                     TargetDir + "/" + GetCXXExceptionsDir(DriverArgs) +
+                         Suffix);
+    addSystemInclude(DriverArgs, CC1Args, TargetDir + Suffix);
   }
 
-  // Second add the generic one.
+  // Third add the generic one.
   addSystemInclude(DriverArgs, CC1Args, LibPath + "/c++/" + Version);
 }
 

--- a/clang/test/Driver/wasm-toolchain.cpp
+++ b/clang/test/Driver/wasm-toolchain.cpp
@@ -111,3 +111,38 @@
 // COMPILE_WALI_STDCXX: "-internal-isystem" "[[RESOURCE_DIR]]{{(/|\\\\)}}include"
 // COMPILE_WALI_STDCXX: "-internal-isystem" "[[SYSROOT:[^"]+]]/include/wasm32-linux-muslwali"
 // COMPILE_WALI_STDCXX: "-internal-isystem" "[[SYSROOT:[^"]+]]/include"
+
+// With a known OS "eh" and "noeh" directories are added to enable segregating
+// object built with/without exception-handling
+
+// RUN: %clangxx -### --target=wasm32-wasi --stdlib=libc++ %s 2>&1 \
+// RUN:     --sysroot=%S/Inputs/basic_linux_libcxx_tree/usr \
+// RUN:   | FileCheck -check-prefix=EH_OFF %s
+// EH_OFF: "-cc1"
+// EH_OFF: "-isysroot" "[[SYSROOT:[^"]+]]"
+// EH_OFF: "-internal-isystem" "[[SYSROOT:[^"]+]]/include/wasm32-wasi/noeh/c++/v1"
+// EH_OFF-NOT: "-internal-isystem" "[[SYSROOT:[^"]+]]/include/wasm32-wasi/eh/c++/v1"
+// EH_OFF: "-internal-isystem" "[[SYSROOT:[^"]+]]/include/wasm32-wasi/c++/v1"
+// EH_OFF: "-internal-isystem" "[[SYSROOT:[^"]+]]/include/c++/v1"
+// EH_OFF: "-internal-isystem" "[[SYSROOT:[^"]+]]/include/wasm32-wasi"
+// EH_OFF: "-internal-isystem" "[[SYSROOT:[^"]+]]/include"
+
+// RUN: %clangxx -### --target=wasm32-wasi -fwasm-exceptions --stdlib=libc++ %s 2>&1 \
+// RUN:     --sysroot=%S/Inputs/basic_linux_libcxx_tree/usr \
+// RUN:   | FileCheck -check-prefix=EH_ON %s
+// EH_ON: "-cc1"
+// EH_ON: "-isysroot" "[[SYSROOT:[^"]+]]"
+// EH_ON: "-internal-isystem" "[[SYSROOT:[^"]+]]/include/wasm32-wasi/eh/c++/v1"
+// EH_ON-NOT: "-internal-isystem" "[[SYSROOT:[^"]+]]/include/wasm32-wasi/noeh/c++/v1"
+// EH_ON: "-internal-isystem" "[[SYSROOT:[^"]+]]/include/wasm32-wasi/c++/v1"
+// EH_ON: "-internal-isystem" "[[SYSROOT:[^"]+]]/include/c++/v1"
+// EH_ON: "-internal-isystem" "[[SYSROOT:[^"]+]]/include/wasm32-wasi"
+// EH_ON: "-internal-isystem" "[[SYSROOT:[^"]+]]/include"
+//
+// RUN: %clangxx -### --target=wasm32-wasi --sysroot=/foo --stdlib=libc++ %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=EH_OFF_LINK %s
+// EH_OFF_LINK: wasm-ld{{.*}}" "-L/foo/lib/wasm32-wasi/noeh" "-L/foo/lib/wasm32-wasi"
+//
+// RUN: %clangxx -### --target=wasm32-wasi -fwasm-exceptions --sysroot=/foo --stdlib=libc++ %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=EH_ON_LINK %s
+// EH_ON_LINK: wasm-ld{{.*}}" "-L/foo/lib/wasm32-wasi/eh" "-L/foo/lib/wasm32-wasi"


### PR DESCRIPTION
This commit is an attempt to make progress on WebAssembly/wasi-sdk#565 where with wasi-sdk I'd like to ship a single toolchain which is capable of building binaries both with C++ exceptions and without. This means that there can't be a single set of precompiled libraries that are used because one set of libraries is wrong for the other mode. The support added here is to use `-fwasm-exceptions` to automatically select a lookup path in the sysroot. The intention is then that wasi-sdk will ship both a "eh" set of C++ libraries as well as a "noeh" set of C++ libraries too. Clang will automatically select the correct one based on compilation flags which means that the final distribution will be able to build both binaries with exceptions and without.