### PR TITLE
make div more assumption aware for better code

### DIFF
--- a/llvm/include/llvm/Transforms/Utils/BypassSlowDivision.h
+++ b/llvm/include/llvm/Transforms/Utils/BypassSlowDivision.h
@@ -19,6 +19,7 @@
 
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/DenseMapInfo.h"
+#include "llvm/Analysis/SimplifyQuery.h"
 #include "llvm/IR/ValueHandle.h"
 #include <cstdint>
 
@@ -70,7 +71,8 @@ template <> struct DenseMapInfo<DivRemMapKey> {
 /// reasons, you shouldn't pass those blocks to bypassSlowDivision.
 bool bypassSlowDivision(BasicBlock *BB,
                         const DenseMap<unsigned int, unsigned int> &BypassWidth,
-                        DomTreeUpdater *DTU = nullptr, LoopInfo *LI = nullptr);
+                        DomTreeUpdater *DTU, LoopInfo *LI,
+                        const SimplifyQuery &SQ);
 
 } // end namespace llvm
 

--- a/llvm/lib/CodeGen/CodeGenPrepare.cpp
+++ b/llvm/lib/CodeGen/CodeGenPrepare.cpp
@@ -22,6 +22,7 @@
 #include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/Statistic.h"
+#include "llvm/Analysis/AssumptionCache.h"
 #include "llvm/Analysis/BlockFrequencyInfo.h"
 #include "llvm/Analysis/BranchProbabilityInfo.h"
 #include "llvm/Analysis/DomTreeUpdater.h"
@@ -319,6 +320,7 @@ class CodeGenPrepare {
   BlockFrequencyInfo *BFI;
   BranchProbabilityInfo *BPI;
   ProfileSummaryInfo *PSI = nullptr;
+  AssumptionCache *AC = nullptr;
 
   /// As we scan instructions optimizing them, this is the next instruction
   /// to optimize. Transforms that can invalidate this should update it.
@@ -487,6 +489,7 @@ public:
   void getAnalysisUsage(AnalysisUsage &AU) const override {
     // FIXME: When we can selectively preserve passes, preserve the domtree.
     AU.addRequired<ProfileSummaryInfoWrapperPass>();
+    AU.addRequired<AssumptionCacheTracker>();
     AU.addRequired<TargetLibraryInfoWrapperPass>();
     AU.addRequired<TargetPassConfig>();
     AU.addRequired<TargetTransformInfoWrapperPass>();
@@ -517,6 +520,7 @@ bool CodeGenPrepareLegacyPass::runOnFunction(Function &F) {
   CGP.BPI = &getAnalysis<BranchProbabilityInfoWrapperPass>().getBPI();
   CGP.BFI = &getAnalysis<BlockFrequencyInfoWrapperPass>().getBFI();
   CGP.PSI = &getAnalysis<ProfileSummaryInfoWrapperPass>().getPSI();
+  CGP.AC = &getAnalysis<AssumptionCacheTracker>().getAssumptionCache(F);
   auto BBSPRWP =
       getAnalysisIfAvailable<BasicBlockSectionsProfileReaderWrapperPass>();
   CGP.BBSectionsProfileReader = BBSPRWP ? &BBSPRWP->getBBSPR() : nullptr;
@@ -534,6 +538,7 @@ INITIALIZE_PASS_DEPENDENCY(BasicBlockSectionsProfileReaderWrapperPass)
 INITIALIZE_PASS_DEPENDENCY(DominatorTreeWrapperPass)
 INITIALIZE_PASS_DEPENDENCY(LoopInfoWrapperPass)
 INITIALIZE_PASS_DEPENDENCY(ProfileSummaryInfoWrapperPass)
+INITIALIZE_PASS_DEPENDENCY(AssumptionCacheTracker)
 INITIALIZE_PASS_DEPENDENCY(TargetLibraryInfoWrapperPass)
 INITIALIZE_PASS_DEPENDENCY(TargetPassConfig)
 INITIALIZE_PASS_DEPENDENCY(TargetTransformInfoWrapperPass)
@@ -570,6 +575,7 @@ bool CodeGenPrepare::run(Function &F, FunctionAnalysisManager &AM) {
   BFI = &AM.getResult<BlockFrequencyAnalysis>(F);
   auto &MAMProxy = AM.getResult<ModuleAnalysisManagerFunctionProxy>(F);
   PSI = MAMProxy.getCachedResult<ProfileSummaryAnalysis>(*F.getParent());
+  AC = &AM.getResult<AssumptionAnalysis>(F);
   BBSectionsProfileReader =
       AM.getCachedResult<BasicBlockSectionsProfileReaderAnalysis>(F);
   DomTreeUpdater DTUpdater(&AM.getResult<DominatorTreeAnalysis>(F),
@@ -615,8 +621,10 @@ bool CodeGenPrepare::_run(Function &F) {
       // bypassSlowDivision may create new BBs, but we don't want to reapply the
       // optimization to those blocks.
       BasicBlock *Next = BB->getNextNode();
-      if (!llvm::shouldOptimizeForSize(BB, PSI, BFI))
-        EverMadeChange |= bypassSlowDivision(BB, BypassWidths, DTU, LI);
+      if (!llvm::shouldOptimizeForSize(BB, PSI, BFI)) {
+        SimplifyQuery SQ(*DL, &DTU->getDomTree(), AC);
+        EverMadeChange |= bypassSlowDivision(BB, BypassWidths, DTU, LI, SQ);
+      }
       BB = Next;
     }
   }

--- a/llvm/lib/Transforms/Utils/BypassSlowDivision.cpp
+++ b/llvm/lib/Transforms/Utils/BypassSlowDivision.cpp
@@ -20,6 +20,7 @@
 #include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/Analysis/DomTreeUpdater.h"
 #include "llvm/Analysis/LoopInfo.h"
+#include "llvm/Analysis/SimplifyQuery.h"
 #include "llvm/Analysis/ValueTracking.h"
 #include "llvm/IR/BasicBlock.h"
 #include "llvm/IR/Constants.h"
@@ -81,6 +82,7 @@ class FastDivInsertionTask {
   BasicBlock *MainBB = nullptr;
   DomTreeUpdater *DTU = nullptr;
   LoopInfo *LI = nullptr;
+  SimplifyQuery SQ;
 
   bool isHashLikeValue(Value *V, VisitedSetTy &Visited);
   ValueRange getValueRange(Value *Op, VisitedSetTy &Visited);
@@ -105,7 +107,8 @@ class FastDivInsertionTask {
 
 public:
   FastDivInsertionTask(Instruction *I, const BypassWidthsTy &BypassWidths,
-                       DomTreeUpdater *DTU, LoopInfo *LI);
+                       DomTreeUpdater *DTU, LoopInfo *LI,
+                       const SimplifyQuery &SQ);
 
   Value *getReplacement(DivCacheTy &Cache);
 };
@@ -114,8 +117,9 @@ public:
 
 FastDivInsertionTask::FastDivInsertionTask(Instruction *I,
                                            const BypassWidthsTy &BypassWidths,
-                                           DomTreeUpdater *DTU, LoopInfo *LI)
-    : DTU(DTU), LI(LI) {
+                                           DomTreeUpdater *DTU, LoopInfo *LI,
+                                           const SimplifyQuery &SQ)
+    : DTU(DTU), LI(LI), SQ(SQ) {
   switch (I->getOpcode()) {
   case Instruction::UDiv:
   case Instruction::SDiv:
@@ -240,10 +244,16 @@ ValueRange FastDivInsertionTask::getValueRange(Value *V,
   assert(LongLen > ShortLen && "Value type must be wider than BypassType");
   unsigned HiBits = LongLen - ShortLen;
 
-  const DataLayout &DL = SlowDivOrRem->getDataLayout();
-  KnownBits Known(LongLen);
+  APInt BypassLimit = APInt::getOneBitSet(LongLen, ShortLen);
+  ConstantRange CR = computeConstantRange(V, /*ForSigned=*/false,
+                                          SQ.getWithInstruction(SlowDivOrRem));
+  if (CR.getUnsignedMax().ult(BypassLimit))
+    return VALRNG_KNOWN_SHORT;
+  if (CR.getUnsignedMin().uge(BypassLimit))
+    return VALRNG_LIKELY_LONG;
 
-  computeKnownBits(V, Known, DL);
+  KnownBits Known(LongLen);
+  computeKnownBits(V, Known, SQ.DL, SQ.AC, SlowDivOrRem);
 
   if (Known.countMinLeadingZeros() >= HiBits)
     return VALRNG_KNOWN_SHORT;
@@ -475,7 +485,8 @@ std::optional<QuotRemPair> FastDivInsertionTask::insertFastDivAndRem() {
 /// profitably bypassed and carried out with a shorter, faster divide.
 bool llvm::bypassSlowDivision(BasicBlock *BB,
                               const BypassWidthsTy &BypassWidths,
-                              DomTreeUpdater *DTU, LoopInfo *LI) {
+                              DomTreeUpdater *DTU, LoopInfo *LI,
+                              const SimplifyQuery &SQ) {
   DivCacheTy PerBBDivCache;
 
   bool MadeChange = false;
@@ -490,7 +501,7 @@ bool llvm::bypassSlowDivision(BasicBlock *BB,
     if (I->use_empty())
       continue;
 
-    FastDivInsertionTask Task(I, BypassWidths, DTU, LI);
+    FastDivInsertionTask Task(I, BypassWidths, DTU, LI, SQ);
     if (Value *Replacement = Task.getReplacement(PerBBDivCache)) {
       I->replaceAllUsesWith(Replacement);
       I->eraseFromParent();

--- a/llvm/test/CodeGen/X86/bypass-slow-division-64.ll
+++ b/llvm/test/CodeGen/X86/bypass-slow-division-64.ll
@@ -386,34 +386,14 @@ define void @PR43514(i32 %x, i32 %y) {
 
 ; dividend > U32_MAX, bypass emits divq only
 define i32 @udiv_i64_i32_assume_dividend_gt_u32_max(i64 %n, i32 %d) {
-; FAST-DIVQ-LABEL: udiv_i64_i32_assume_dividend_gt_u32_max:
-; FAST-DIVQ:       # %bb.0:
-; FAST-DIVQ-NEXT:    movq %rdi, %rax
-; FAST-DIVQ-NEXT:    movl %esi, %ecx
-; FAST-DIVQ-NEXT:    xorl %edx, %edx
-; FAST-DIVQ-NEXT:    divq %rcx
-; FAST-DIVQ-NEXT:    # kill: def $eax killed $eax killed $rax
-; FAST-DIVQ-NEXT:    retq
-;
-; SLOW-DIVQ-LABEL: udiv_i64_i32_assume_dividend_gt_u32_max:
-; SLOW-DIVQ:       # %bb.0:
-; SLOW-DIVQ-DAG:     movq %rdi, %rax
-; SLOW-DIVQ-DAG:     movl %esi, %ecx
-; SLOW-DIVQ-DAG:     movq %rdi, %rdx
-; SLOW-DIVQ-DAG:     shrq $32, %rdx
-; SLOW-DIVQ-NEXT:    je .LBB19_1
-; SLOW-DIVQ-NEXT:  # %bb.2:
-; SLOW-DIVQ-NEXT:    xorl %edx, %edx
-; SLOW-DIVQ-NEXT:    divq %rcx
-; SLOW-DIVQ-NEXT:    # kill: def $eax killed $eax killed $rax
-; SLOW-DIVQ-NEXT:    retq
-; SLOW-DIVQ-NEXT:  .LBB19_1:
-; SLOW-DIVQ-DAG:     # kill: def $eax killed $eax killed $rax
-; SLOW-DIVQ-DAG:     xorl %edx, %edx
-; SLOW-DIVQ-NEXT:    divl %ecx
-; SLOW-DIVQ-NEXT:    # kill: def $eax killed $eax def $rax
-; SLOW-DIVQ-NEXT:    # kill: def $eax killed $eax killed $rax
-; SLOW-DIVQ-NEXT:    retq
+; CHECK-LABEL: udiv_i64_i32_assume_dividend_gt_u32_max:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    movq %rdi, %rax
+; CHECK-NEXT:    movl %esi, %ecx
+; CHECK-NEXT:    xorl %edx, %edx
+; CHECK-NEXT:    divq %rcx
+; CHECK-NEXT:    # kill: def $eax killed $eax killed $rax
+; CHECK-NEXT:    retq
   %cmp = icmp ugt i64 %n, 4294967295
   call void @llvm.assume(i1 %cmp)
   %d.ext = zext i32 %d to i64
@@ -424,36 +404,15 @@ define i32 @udiv_i64_i32_assume_dividend_gt_u32_max(i64 %n, i32 %d) {
 
 ; dividend > U32_MAX, bypass emits divq only
 define i32 @urem_i64_i32_assume_dividend_gt_u32_max(i64 %n, i32 %d) {
-; FAST-DIVQ-LABEL: urem_i64_i32_assume_dividend_gt_u32_max:
-; FAST-DIVQ:       # %bb.0:
-; FAST-DIVQ-NEXT:    movq %rdi, %rax
-; FAST-DIVQ-NEXT:    movl %esi, %ecx
-; FAST-DIVQ-NEXT:    xorl %edx, %edx
-; FAST-DIVQ-NEXT:    divq %rcx
-; FAST-DIVQ-NEXT:    movq %rdx, %rax
-; FAST-DIVQ-NEXT:    # kill: def $eax killed $eax killed $rax
-; FAST-DIVQ-NEXT:    retq
-;
-; SLOW-DIVQ-LABEL: urem_i64_i32_assume_dividend_gt_u32_max:
-; SLOW-DIVQ:       # %bb.0:
-; SLOW-DIVQ-DAG:     movq %rdi, %rax
-; SLOW-DIVQ-DAG:     movl %esi, %ecx
-; SLOW-DIVQ-DAG:     movq %rdi, %rdx
-; SLOW-DIVQ-DAG:     shrq $32, %rdx
-; SLOW-DIVQ-NEXT:    je .LBB20_1
-; SLOW-DIVQ-NEXT:  # %bb.2:
-; SLOW-DIVQ-NEXT:    xorl %edx, %edx
-; SLOW-DIVQ-NEXT:    divq %rcx
-; SLOW-DIVQ-NEXT:    movq %rdx, %rax
-; SLOW-DIVQ-NEXT:    # kill: def $eax killed $eax killed $rax
-; SLOW-DIVQ-NEXT:    retq
-; SLOW-DIVQ-NEXT:  .LBB20_1:
-; SLOW-DIVQ-DAG:     # kill: def $eax killed $eax killed $rax
-; SLOW-DIVQ-DAG:     xorl %edx, %edx
-; SLOW-DIVQ-NEXT:    divl %ecx
-; SLOW-DIVQ-NEXT:    movl %edx, %eax
-; SLOW-DIVQ-NEXT:    # kill: def $eax killed $eax killed $rax
-; SLOW-DIVQ-NEXT:    retq
+; CHECK-LABEL: urem_i64_i32_assume_dividend_gt_u32_max:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    movq %rdi, %rax
+; CHECK-NEXT:    movl %esi, %ecx
+; CHECK-NEXT:    xorl %edx, %edx
+; CHECK-NEXT:    divq %rcx
+; CHECK-NEXT:    movq %rdx, %rax
+; CHECK-NEXT:    # kill: def $eax killed $eax killed $rax
+; CHECK-NEXT:    retq
   %cmp = icmp ugt i64 %n, 4294967295
   call void @llvm.assume(i1 %cmp)
   %d.ext = zext i32 %d to i64
@@ -464,35 +423,14 @@ define i32 @urem_i64_i32_assume_dividend_gt_u32_max(i64 %n, i32 %d) {
 
 ; dividend > U32_MAX, bypass emits idivq only
 define i32 @sdiv_i64_i32_assume_dividend_gt_u32_max(i64 %n, i32 %d) {
-; FAST-DIVQ-LABEL: sdiv_i64_i32_assume_dividend_gt_u32_max:
-; FAST-DIVQ:       # %bb.0:
-; FAST-DIVQ-NEXT:    movq %rdi, %rax
-; FAST-DIVQ-NEXT:    movslq %esi, %rcx
-; FAST-DIVQ-NEXT:    cqto
-; FAST-DIVQ-NEXT:    idivq %rcx
-; FAST-DIVQ-NEXT:    # kill: def $eax killed $eax killed $rax
-; FAST-DIVQ-NEXT:    retq
-;
-; SLOW-DIVQ-LABEL: sdiv_i64_i32_assume_dividend_gt_u32_max:
-; SLOW-DIVQ:       # %bb.0:
-; SLOW-DIVQ-DAG:     movq %rdi, %rax
-; SLOW-DIVQ-DAG:     movslq %esi, %rcx
-; SLOW-DIVQ-DAG:     movq %rdi, %rdx
-; SLOW-DIVQ-DAG:     orq %rcx, %rdx
-; SLOW-DIVQ-DAG:     shrq $32, %rdx
-; SLOW-DIVQ-NEXT:    je .LBB21_1
-; SLOW-DIVQ-NEXT:  # %bb.2:
-; SLOW-DIVQ-NEXT:    cqto
-; SLOW-DIVQ-NEXT:    idivq %rcx
-; SLOW-DIVQ-NEXT:    # kill: def $eax killed $eax killed $rax
-; SLOW-DIVQ-NEXT:    retq
-; SLOW-DIVQ-NEXT:  .LBB21_1:
-; SLOW-DIVQ-DAG:     # kill: def $eax killed $eax killed $rax
-; SLOW-DIVQ-DAG:     xorl %edx, %edx
-; SLOW-DIVQ-NEXT:    divl %esi
-; SLOW-DIVQ-NEXT:    # kill: def $eax killed $eax def $rax
-; SLOW-DIVQ-NEXT:    # kill: def $eax killed $eax killed $rax
-; SLOW-DIVQ-NEXT:    retq
+; CHECK-LABEL: sdiv_i64_i32_assume_dividend_gt_u32_max:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    movq %rdi, %rax
+; CHECK-NEXT:    movslq %esi, %rcx
+; CHECK-NEXT:    cqto
+; CHECK-NEXT:    idivq %rcx
+; CHECK-NEXT:    # kill: def $eax killed $eax killed $rax
+; CHECK-NEXT:    retq
   %cmp = icmp sgt i64 %n, 4294967295
   call void @llvm.assume(i1 %cmp)
   %d.ext = sext i32 %d to i64
@@ -503,37 +441,15 @@ define i32 @sdiv_i64_i32_assume_dividend_gt_u32_max(i64 %n, i32 %d) {
 
 ; dividend > U32_MAX, bypass emits idivq only
 define i32 @srem_i64_i32_assume_dividend_gt_u32_max(i64 %n, i32 %d) {
-; FAST-DIVQ-LABEL: srem_i64_i32_assume_dividend_gt_u32_max:
-; FAST-DIVQ:       # %bb.0:
-; FAST-DIVQ-NEXT:    movq %rdi, %rax
-; FAST-DIVQ-NEXT:    movslq %esi, %rcx
-; FAST-DIVQ-NEXT:    cqto
-; FAST-DIVQ-NEXT:    idivq %rcx
-; FAST-DIVQ-NEXT:    movq %rdx, %rax
-; FAST-DIVQ-NEXT:    # kill: def $eax killed $eax killed $rax
-; FAST-DIVQ-NEXT:    retq
-;
-; SLOW-DIVQ-LABEL: srem_i64_i32_assume_dividend_gt_u32_max:
-; SLOW-DIVQ:       # %bb.0:
-; SLOW-DIVQ-DAG:     movq %rdi, %rax
-; SLOW-DIVQ-DAG:     movslq %esi, %rcx
-; SLOW-DIVQ-DAG:     movq %rdi, %rdx
-; SLOW-DIVQ-DAG:     orq %rcx, %rdx
-; SLOW-DIVQ-DAG:     shrq $32, %rdx
-; SLOW-DIVQ-NEXT:    je .LBB22_1
-; SLOW-DIVQ-NEXT:  # %bb.2:
-; SLOW-DIVQ-NEXT:    cqto
-; SLOW-DIVQ-NEXT:    idivq %rcx
-; SLOW-DIVQ-NEXT:    movq %rdx, %rax
-; SLOW-DIVQ-NEXT:    # kill: def $eax killed $eax killed $rax
-; SLOW-DIVQ-NEXT:    retq
-; SLOW-DIVQ-NEXT:  .LBB22_1:
-; SLOW-DIVQ-DAG:     # kill: def $eax killed $eax killed $rax
-; SLOW-DIVQ-DAG:     xorl %edx, %edx
-; SLOW-DIVQ-NEXT:    divl %esi
-; SLOW-DIVQ-NEXT:    movl %edx, %eax
-; SLOW-DIVQ-NEXT:    # kill: def $eax killed $eax killed $rax
-; SLOW-DIVQ-NEXT:    retq
+; CHECK-LABEL: srem_i64_i32_assume_dividend_gt_u32_max:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    movq %rdi, %rax
+; CHECK-NEXT:    movslq %esi, %rcx
+; CHECK-NEXT:    cqto
+; CHECK-NEXT:    idivq %rcx
+; CHECK-NEXT:    movq %rdx, %rax
+; CHECK-NEXT:    # kill: def $eax killed $eax killed $rax
+; CHECK-NEXT:    retq
   %cmp = icmp sgt i64 %n, 4294967295
   call void @llvm.assume(i1 %cmp)
   %d.ext = sext i32 %d to i64

--- a/llvm/test/CodeGen/X86/bypass-slow-division-64.ll
+++ b/llvm/test/CodeGen/X86/bypass-slow-division-64.ll
@@ -383,3 +383,238 @@ define void @PR43514(i32 %x, i32 %y) {
   %s = srem i64 %z1, %z2
   ret void
 }
+
+; dividend > U32_MAX, bypass emits divq only
+define i32 @udiv_i64_i32_assume_dividend_gt_u32_max(i64 %n, i32 %d) {
+; FAST-DIVQ-LABEL: udiv_i64_i32_assume_dividend_gt_u32_max:
+; FAST-DIVQ:       # %bb.0:
+; FAST-DIVQ-NEXT:    movq %rdi, %rax
+; FAST-DIVQ-NEXT:    movl %esi, %ecx
+; FAST-DIVQ-NEXT:    xorl %edx, %edx
+; FAST-DIVQ-NEXT:    divq %rcx
+; FAST-DIVQ-NEXT:    # kill: def $eax killed $eax killed $rax
+; FAST-DIVQ-NEXT:    retq
+;
+; SLOW-DIVQ-LABEL: udiv_i64_i32_assume_dividend_gt_u32_max:
+; SLOW-DIVQ:       # %bb.0:
+; SLOW-DIVQ-DAG:     movq %rdi, %rax
+; SLOW-DIVQ-DAG:     movl %esi, %ecx
+; SLOW-DIVQ-DAG:     movq %rdi, %rdx
+; SLOW-DIVQ-DAG:     shrq $32, %rdx
+; SLOW-DIVQ-NEXT:    je .LBB19_1
+; SLOW-DIVQ-NEXT:  # %bb.2:
+; SLOW-DIVQ-NEXT:    xorl %edx, %edx
+; SLOW-DIVQ-NEXT:    divq %rcx
+; SLOW-DIVQ-NEXT:    # kill: def $eax killed $eax killed $rax
+; SLOW-DIVQ-NEXT:    retq
+; SLOW-DIVQ-NEXT:  .LBB19_1:
+; SLOW-DIVQ-DAG:     # kill: def $eax killed $eax killed $rax
+; SLOW-DIVQ-DAG:     xorl %edx, %edx
+; SLOW-DIVQ-NEXT:    divl %ecx
+; SLOW-DIVQ-NEXT:    # kill: def $eax killed $eax def $rax
+; SLOW-DIVQ-NEXT:    # kill: def $eax killed $eax killed $rax
+; SLOW-DIVQ-NEXT:    retq
+  %cmp = icmp ugt i64 %n, 4294967295
+  call void @llvm.assume(i1 %cmp)
+  %d.ext = zext i32 %d to i64
+  %q = udiv i64 %n, %d.ext
+  %tr = trunc i64 %q to i32
+  ret i32 %tr
+}
+
+; dividend > U32_MAX, bypass emits divq only
+define i32 @urem_i64_i32_assume_dividend_gt_u32_max(i64 %n, i32 %d) {
+; FAST-DIVQ-LABEL: urem_i64_i32_assume_dividend_gt_u32_max:
+; FAST-DIVQ:       # %bb.0:
+; FAST-DIVQ-NEXT:    movq %rdi, %rax
+; FAST-DIVQ-NEXT:    movl %esi, %ecx
+; FAST-DIVQ-NEXT:    xorl %edx, %edx
+; FAST-DIVQ-NEXT:    divq %rcx
+; FAST-DIVQ-NEXT:    movq %rdx, %rax
+; FAST-DIVQ-NEXT:    # kill: def $eax killed $eax killed $rax
+; FAST-DIVQ-NEXT:    retq
+;
+; SLOW-DIVQ-LABEL: urem_i64_i32_assume_dividend_gt_u32_max:
+; SLOW-DIVQ:       # %bb.0:
+; SLOW-DIVQ-DAG:     movq %rdi, %rax
+; SLOW-DIVQ-DAG:     movl %esi, %ecx
+; SLOW-DIVQ-DAG:     movq %rdi, %rdx
+; SLOW-DIVQ-DAG:     shrq $32, %rdx
+; SLOW-DIVQ-NEXT:    je .LBB20_1
+; SLOW-DIVQ-NEXT:  # %bb.2:
+; SLOW-DIVQ-NEXT:    xorl %edx, %edx
+; SLOW-DIVQ-NEXT:    divq %rcx
+; SLOW-DIVQ-NEXT:    movq %rdx, %rax
+; SLOW-DIVQ-NEXT:    # kill: def $eax killed $eax killed $rax
+; SLOW-DIVQ-NEXT:    retq
+; SLOW-DIVQ-NEXT:  .LBB20_1:
+; SLOW-DIVQ-DAG:     # kill: def $eax killed $eax killed $rax
+; SLOW-DIVQ-DAG:     xorl %edx, %edx
+; SLOW-DIVQ-NEXT:    divl %ecx
+; SLOW-DIVQ-NEXT:    movl %edx, %eax
+; SLOW-DIVQ-NEXT:    # kill: def $eax killed $eax killed $rax
+; SLOW-DIVQ-NEXT:    retq
+  %cmp = icmp ugt i64 %n, 4294967295
+  call void @llvm.assume(i1 %cmp)
+  %d.ext = zext i32 %d to i64
+  %r = urem i64 %n, %d.ext
+  %tr = trunc i64 %r to i32
+  ret i32 %tr
+}
+
+; dividend > U32_MAX, bypass emits idivq only
+define i32 @sdiv_i64_i32_assume_dividend_gt_u32_max(i64 %n, i32 %d) {
+; FAST-DIVQ-LABEL: sdiv_i64_i32_assume_dividend_gt_u32_max:
+; FAST-DIVQ:       # %bb.0:
+; FAST-DIVQ-NEXT:    movq %rdi, %rax
+; FAST-DIVQ-NEXT:    movslq %esi, %rcx
+; FAST-DIVQ-NEXT:    cqto
+; FAST-DIVQ-NEXT:    idivq %rcx
+; FAST-DIVQ-NEXT:    # kill: def $eax killed $eax killed $rax
+; FAST-DIVQ-NEXT:    retq
+;
+; SLOW-DIVQ-LABEL: sdiv_i64_i32_assume_dividend_gt_u32_max:
+; SLOW-DIVQ:       # %bb.0:
+; SLOW-DIVQ-DAG:     movq %rdi, %rax
+; SLOW-DIVQ-DAG:     movslq %esi, %rcx
+; SLOW-DIVQ-DAG:     movq %rdi, %rdx
+; SLOW-DIVQ-DAG:     orq %rcx, %rdx
+; SLOW-DIVQ-DAG:     shrq $32, %rdx
+; SLOW-DIVQ-NEXT:    je .LBB21_1
+; SLOW-DIVQ-NEXT:  # %bb.2:
+; SLOW-DIVQ-NEXT:    cqto
+; SLOW-DIVQ-NEXT:    idivq %rcx
+; SLOW-DIVQ-NEXT:    # kill: def $eax killed $eax killed $rax
+; SLOW-DIVQ-NEXT:    retq
+; SLOW-DIVQ-NEXT:  .LBB21_1:
+; SLOW-DIVQ-DAG:     # kill: def $eax killed $eax killed $rax
+; SLOW-DIVQ-DAG:     xorl %edx, %edx
+; SLOW-DIVQ-NEXT:    divl %esi
+; SLOW-DIVQ-NEXT:    # kill: def $eax killed $eax def $rax
+; SLOW-DIVQ-NEXT:    # kill: def $eax killed $eax killed $rax
+; SLOW-DIVQ-NEXT:    retq
+  %cmp = icmp sgt i64 %n, 4294967295
+  call void @llvm.assume(i1 %cmp)
+  %d.ext = sext i32 %d to i64
+  %q = sdiv i64 %n, %d.ext
+  %tr = trunc i64 %q to i32
+  ret i32 %tr
+}
+
+; dividend > U32_MAX, bypass emits idivq only
+define i32 @srem_i64_i32_assume_dividend_gt_u32_max(i64 %n, i32 %d) {
+; FAST-DIVQ-LABEL: srem_i64_i32_assume_dividend_gt_u32_max:
+; FAST-DIVQ:       # %bb.0:
+; FAST-DIVQ-NEXT:    movq %rdi, %rax
+; FAST-DIVQ-NEXT:    movslq %esi, %rcx
+; FAST-DIVQ-NEXT:    cqto
+; FAST-DIVQ-NEXT:    idivq %rcx
+; FAST-DIVQ-NEXT:    movq %rdx, %rax
+; FAST-DIVQ-NEXT:    # kill: def $eax killed $eax killed $rax
+; FAST-DIVQ-NEXT:    retq
+;
+; SLOW-DIVQ-LABEL: srem_i64_i32_assume_dividend_gt_u32_max:
+; SLOW-DIVQ:       # %bb.0:
+; SLOW-DIVQ-DAG:     movq %rdi, %rax
+; SLOW-DIVQ-DAG:     movslq %esi, %rcx
+; SLOW-DIVQ-DAG:     movq %rdi, %rdx
+; SLOW-DIVQ-DAG:     orq %rcx, %rdx
+; SLOW-DIVQ-DAG:     shrq $32, %rdx
+; SLOW-DIVQ-NEXT:    je .LBB22_1
+; SLOW-DIVQ-NEXT:  # %bb.2:
+; SLOW-DIVQ-NEXT:    cqto
+; SLOW-DIVQ-NEXT:    idivq %rcx
+; SLOW-DIVQ-NEXT:    movq %rdx, %rax
+; SLOW-DIVQ-NEXT:    # kill: def $eax killed $eax killed $rax
+; SLOW-DIVQ-NEXT:    retq
+; SLOW-DIVQ-NEXT:  .LBB22_1:
+; SLOW-DIVQ-DAG:     # kill: def $eax killed $eax killed $rax
+; SLOW-DIVQ-DAG:     xorl %edx, %edx
+; SLOW-DIVQ-NEXT:    divl %esi
+; SLOW-DIVQ-NEXT:    movl %edx, %eax
+; SLOW-DIVQ-NEXT:    # kill: def $eax killed $eax killed $rax
+; SLOW-DIVQ-NEXT:    retq
+  %cmp = icmp sgt i64 %n, 4294967295
+  call void @llvm.assume(i1 %cmp)
+  %d.ext = sext i32 %d to i64
+  %r = srem i64 %n, %d.ext
+  %tr = trunc i64 %r to i32
+  ret i32 %tr
+}
+
+; nonzero-divisor assumption carries no width fact, udiv branch still emitted
+define i32 @udiv_i64_i32_assume_divisor_nonzero_no_width_fact(i64 %n, i32 %d) {
+; FAST-DIVQ-LABEL: udiv_i64_i32_assume_divisor_nonzero_no_width_fact:
+; FAST-DIVQ:       # %bb.0:
+; FAST-DIVQ-NEXT:    movq %rdi, %rax
+; FAST-DIVQ-NEXT:    movl %esi, %ecx
+; FAST-DIVQ-NEXT:    xorl %edx, %edx
+; FAST-DIVQ-NEXT:    divq %rcx
+; FAST-DIVQ-NEXT:    # kill: def $eax killed $eax killed $rax
+; FAST-DIVQ-NEXT:    retq
+;
+; SLOW-DIVQ-LABEL: udiv_i64_i32_assume_divisor_nonzero_no_width_fact:
+; SLOW-DIVQ:       # %bb.0:
+; SLOW-DIVQ-DAG:     movq %rdi, %rax
+; SLOW-DIVQ-DAG:     movl %esi, %ecx
+; SLOW-DIVQ-DAG:     movq %rdi, %rdx
+; SLOW-DIVQ-DAG:     shrq $32, %rdx
+; SLOW-DIVQ-NEXT:    je .LBB23_1
+; SLOW-DIVQ-NEXT:  # %bb.2:
+; SLOW-DIVQ-NEXT:    xorl %edx, %edx
+; SLOW-DIVQ-NEXT:    divq %rcx
+; SLOW-DIVQ-NEXT:    # kill: def $eax killed $eax killed $rax
+; SLOW-DIVQ-NEXT:    retq
+; SLOW-DIVQ-NEXT:  .LBB23_1:
+; SLOW-DIVQ-DAG:     # kill: def $eax killed $eax killed $rax
+; SLOW-DIVQ-DAG:     xorl %edx, %edx
+; SLOW-DIVQ-NEXT:    divl %ecx
+; SLOW-DIVQ-NEXT:    # kill: def $eax killed $eax def $rax
+; SLOW-DIVQ-NEXT:    # kill: def $eax killed $eax killed $rax
+; SLOW-DIVQ-NEXT:    retq
+  %cmp = icmp ne i32 %d, 0
+  call void @llvm.assume(i1 %cmp)
+  %d.ext = zext i32 %d to i64
+  %q = udiv i64 %n, %d.ext
+  %tr = trunc i64 %q to i32
+  ret i32 %tr
+}
+
+; nonzero-divisor assumption carries no width fact, sdiv branch still emitted
+define i32 @sdiv_i64_i32_assume_divisor_nonzero_no_width_fact(i64 %n, i32 %d) {
+; FAST-DIVQ-LABEL: sdiv_i64_i32_assume_divisor_nonzero_no_width_fact:
+; FAST-DIVQ:       # %bb.0:
+; FAST-DIVQ-NEXT:    movq %rdi, %rax
+; FAST-DIVQ-NEXT:    movslq %esi, %rcx
+; FAST-DIVQ-NEXT:    cqto
+; FAST-DIVQ-NEXT:    idivq %rcx
+; FAST-DIVQ-NEXT:    # kill: def $eax killed $eax killed $rax
+; FAST-DIVQ-NEXT:    retq
+;
+; SLOW-DIVQ-LABEL: sdiv_i64_i32_assume_divisor_nonzero_no_width_fact:
+; SLOW-DIVQ:       # %bb.0:
+; SLOW-DIVQ-DAG:     movq %rdi, %rax
+; SLOW-DIVQ-DAG:     movslq %esi, %rcx
+; SLOW-DIVQ-DAG:     movq %rdi, %rdx
+; SLOW-DIVQ-DAG:     orq %rcx, %rdx
+; SLOW-DIVQ-DAG:     shrq $32, %rdx
+; SLOW-DIVQ-NEXT:    je .LBB24_1
+; SLOW-DIVQ-NEXT:  # %bb.2:
+; SLOW-DIVQ-NEXT:    cqto
+; SLOW-DIVQ-NEXT:    idivq %rcx
+; SLOW-DIVQ-NEXT:    # kill: def $eax killed $eax killed $rax
+; SLOW-DIVQ-NEXT:    retq
+; SLOW-DIVQ-NEXT:  .LBB24_1:
+; SLOW-DIVQ-DAG:     # kill: def $eax killed $eax killed $rax
+; SLOW-DIVQ-DAG:     xorl %edx, %edx
+; SLOW-DIVQ-NEXT:    divl %esi
+; SLOW-DIVQ-NEXT:    # kill: def $eax killed $eax def $rax
+; SLOW-DIVQ-NEXT:    # kill: def $eax killed $eax killed $rax
+; SLOW-DIVQ-NEXT:    retq
+  %cmp = icmp ne i32 %d, 0
+  call void @llvm.assume(i1 %cmp)
+  %d.ext = sext i32 %d to i64
+  %q = sdiv i64 %n, %d.ext
+  %tr = trunc i64 %q to i32
+  ret i32 %tr
+}


### PR DESCRIPTION
Related: https://github.com/llvm/llvm-project/issues/115158

The linked issue points out that there are some cases where division and modulo will have enough information to prove that there doesn't need to be a branch of a division (e.g. long / long or long / short division). In which case there shouldn't need to be a branch emitted because the compiler knows which div operation is going to be better and should just emit that code without a runtime branch.

This is just a few of the cases the issue points out, so this just handles some basic cases.