### PR TITLE
[SandboxVec][DAG][NFC] Remove argument from setScheduelued()

### DIFF
--- a/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/DependencyGraph.h
+++ b/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/DependencyGraph.h
@@ -143,11 +143,10 @@ public:
   bool ready() const { return UnscheduledSuccs == 0; }
   /// \Returns true if this node has been scheduled.
   bool scheduled() const { return Scheduled; }
-  void setScheduled(bool NewVal) {
-    Scheduled = NewVal;
-    if (Scheduled)
-      // UnscheduledSuccs is meaningless from this point on, so prohibit its use
-      UnscheduledSuccs = std::nullopt;
+  void setScheduled() {
+    Scheduled = true;
+    // UnscheduledSuccs is meaningless from this point on, so prohibit its use.
+    UnscheduledSuccs = std::nullopt;
   }
   /// \Returns the scheduling bundle that this node belongs to, or nullptr.
   SchedBundle *getSchedBundle() const { return SB; }

--- a/llvm/lib/Transforms/Vectorize/SandboxVectorizer/Scheduler.cpp
+++ b/llvm/lib/Transforms/Vectorize/SandboxVectorizer/Scheduler.cpp
@@ -82,7 +82,7 @@ void Scheduler::scheduleAndUpdateReadyList(SchedBundle &Bndl) {
       if (DepN->ready() && !DepN->scheduled())
         ReadyList.insert(DepN);
     }
-    N->setScheduled(true);
+    N->setScheduled();
   }
 }
 
@@ -99,7 +99,7 @@ void Scheduler::notifyCreateInstr(Instruction *I) {
                      *ScheduleTopItOpt != I->getParent()->end() &&
                      (*ScheduleTopItOpt.value()).comesBefore(I);
   if (IsScheduled)
-    N->setScheduled(true);
+    N->setScheduled();
   // If the new instruction is above the top of schedule we need to remove its
   // dependency predecessors from the ready list and increment their
   // `UnscheduledSuccs` counters.

--- a/llvm/unittests/Transforms/Vectorize/SandboxVectorizer/DependencyGraphTest.cpp
+++ b/llvm/unittests/Transforms/Vectorize/SandboxVectorizer/DependencyGraphTest.cpp
@@ -272,7 +272,7 @@ define void @foo(ptr %ptr, i8 %v0, i8 %v1) {
 
   // Check scheduled(), setScheduled().
   EXPECT_FALSE(N0->scheduled());
-  N0->setScheduled(true);
+  N0->setScheduled();
   EXPECT_TRUE(N0->scheduled());
 }
 
@@ -867,7 +867,7 @@ define void @foo(ptr %ptr, i8 %v1, i8 %v2, i8 %v3, i8 %v4, i8 %v5) {
     sandboxir::DependencyGraph DAG(getAA(*LLVMF), Ctx);
     DAG.extend({S2, S2});
     auto *S2N = cast<sandboxir::MemDGNode>(DAG.getNode(S2));
-    S2N->setScheduled(true);
+    S2N->setScheduled();
 
     DAG.extend({S1, S1});
     auto *S1N = cast<sandboxir::MemDGNode>(DAG.getNode(S1));
@@ -1017,7 +1017,7 @@ define void @foo(ptr %ptr, i8 %v1, i8 %v2, i8 %v3, i8 %v4, i8 %arg) {
   EXPECT_EQ(S1MemN->getNumUnscheduledSuccs(), 1u);
   EXPECT_EQ(S2MemN->getNumUnscheduledSuccs(), 0u);
   // Mark S2 as scheduled and erase it.
-  S2MemN->setScheduled(true);
+  S2MemN->setScheduled();
   S2->eraseFromParent();
   EXPECT_EQ(DAG.getNode(S2), nullptr);
   // Check that we did not update S1's UnscheduledSuccs
@@ -1259,7 +1259,7 @@ define void @foo(i8 %v0) {
 #ifndef NDEBUG
   EXPECT_TRUE(Add0N->validUnscheduledSuccs());
 #endif
-  Add0N->setScheduled(true);
+  Add0N->setScheduled();
 #ifndef NDEBUG
   EXPECT_FALSE(Add0N->validUnscheduledSuccs());
   EXPECT_DEATH(Add0N->getNumUnscheduledSuccs(), ".*");
@@ -1268,7 +1268,7 @@ define void @foo(i8 %v0) {
 #ifndef NDEBUG
   EXPECT_TRUE(Add1N->validUnscheduledSuccs());
 #endif
-  Add1N->setScheduled(true);
+  Add1N->setScheduled();
 #ifndef NDEBUG
   EXPECT_FALSE(Add1N->validUnscheduledSuccs());
   EXPECT_DEATH(Add1N->getNumUnscheduledSuccs(), ".*");


### PR DESCRIPTION
DGNode::setScheduled() is only used to mark a nodes a scheduled, not the reverse. The reverse should only happen with a call to DGNode::resetScheduleState().