### PR TITLE
[StaticAnalyzer] Fix InnerPointerBRVisitor to avoid repeated map scans

### DIFF
--- a/clang/lib/StaticAnalyzer/Checkers/AllocationState.h
+++ b/clang/lib/StaticAnalyzer/Checkers/AllocationState.h
@@ -23,7 +23,8 @@ ProgramStateRef markReleased(ProgramStateRef State, SymbolRef Sym,
 /// This function provides an additional visitor that augments the bug report
 /// with information relevant to memory errors caused by the misuse of
 /// AF_InnerBuffer symbols.
-std::unique_ptr<BugReporterVisitor> getInnerPointerBRVisitor(SymbolRef Sym);
+std::unique_ptr<BugReporterVisitor>
+getInnerPointerBRVisitor(SymbolRef Sym, ProgramStateRef State);
 
 /// 'Sym' represents a pointer to the inner buffer of a container object.
 /// This function looks up the memory region of that object in

--- a/clang/lib/StaticAnalyzer/Checkers/InnerPointerChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/InnerPointerChecker.cpp
@@ -59,9 +59,11 @@ class InnerPointerChecker
 public:
   class InnerPointerBRVisitor : public BugReporterVisitor {
     SymbolRef PtrToBuf;
+    const MemRegion *const ContainerRegion;
 
   public:
-    InnerPointerBRVisitor(SymbolRef Sym) : PtrToBuf(Sym) {}
+    InnerPointerBRVisitor(SymbolRef Sym, ProgramStateRef State)
+        : PtrToBuf(Sym), ContainerRegion(getContainerRegion(Sym, State)) {}
 
     static void *getTag() {
       static int Tag = 0;
@@ -76,15 +78,18 @@ public:
                                      BugReporterContext &BRC,
                                      PathSensitiveBugReport &BR) override;
 
-    // FIXME: Scan the map once in the visitor's constructor and do a direct
-    // lookup by region.
-    bool isSymbolTracked(ProgramStateRef State, SymbolRef Sym) {
-      RawPtrMapTy Map = State->get<RawPtrMap>();
-      for (const auto &Entry : Map) {
-        if (Entry.second.contains(Sym))
-          return true;
+    static const MemRegion *getContainerRegion(SymbolRef Sym,
+                                               ProgramStateRef State) {
+      for (auto [R, Ptrs] : State->get<RawPtrMap>()) {
+        if (Ptrs.contains(Sym))
+          return R;
       }
-      return false;
+      return nullptr;
+    }
+
+    bool isSymbolTracked(ProgramStateRef State, SymbolRef Sym) {
+      const PtrSet *PS = State->get<RawPtrMap>(ContainerRegion);
+      return PS && PS->contains(Sym);
     }
   };
 
@@ -275,8 +280,10 @@ namespace clang {
 namespace ento {
 namespace allocation_state {
 
-std::unique_ptr<BugReporterVisitor> getInnerPointerBRVisitor(SymbolRef Sym) {
-  return std::make_unique<InnerPointerChecker::InnerPointerBRVisitor>(Sym);
+std::unique_ptr<BugReporterVisitor>
+getInnerPointerBRVisitor(SymbolRef Sym, ProgramStateRef State) {
+  return std::make_unique<InnerPointerChecker::InnerPointerBRVisitor>(Sym,
+                                                                      State);
 }
 
 const MemRegion *getContainerObjRegion(ProgramStateRef State, SymbolRef Sym) {

--- a/clang/lib/StaticAnalyzer/Checkers/MallocChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/MallocChecker.cpp
@@ -2757,7 +2757,8 @@ void MallocChecker::HandleUseAfterFree(CheckerContext &C, SourceRange Range,
     R->addVisitor<MallocBugVisitor>(Sym);
 
     if (AF.Kind == AF_InnerBuffer)
-      R->addVisitor(allocation_state::getInnerPointerBRVisitor(Sym));
+      R->addVisitor(
+          allocation_state::getInnerPointerBRVisitor(Sym, C.getState()));
 
     C.emitReport(std::move(R));
   }


### PR DESCRIPTION
`InnerPointerBRVisitor::isSymbolTracked()` previously scanned the whole `RawPtrMap` on each call which caused O(n) lookup to check if a symbol was tracked or not.

This patch resolves the FIXME by caching the `ContainerRegion` into the constructor that uses a single map scan, so it performs a single O(1) lookup instead of the previous O(n) lookup.