### PR TITLE
[X86] Reject 'p' constraint without 'a' modifier in inline asm

### DIFF
--- a/llvm/lib/Target/X86/X86AsmPrinter.cpp
+++ b/llvm/lib/Target/X86/X86AsmPrinter.cpp
@@ -899,6 +899,11 @@ bool X86AsmPrinter::PrintAsmMemoryOperand(const MachineInstr *MI, unsigned OpNo,
       }
       return false;
     }
+  } else {
+    // Constraint 'p' requires modifier 'a'.
+    const InlineAsm::Flag Flags(MI->getOperand(OpNo - 1).getImm());
+    if (Flags.getMemoryConstraintID() == InlineAsm::ConstraintCode::p)
+      return true;
   }
   if (MI->getInlineAsmDialect() == InlineAsm::AD_Intel) {
     PrintIntelMemReference(MI, OpNo, O);

--- a/llvm/test/CodeGen/X86/asm-modifier-error.ll
+++ b/llvm/test/CodeGen/X86/asm-modifier-error.ll
@@ -7,6 +7,12 @@ entry:
   ret void
 }
 
+; CHECK: error: invalid operand in inline asm: '#TEST $0'
+define void @test_p_no_modifier(ptr %p) {
+  call void asm sideeffect "#TEST $0", "p,~{dirflag},~{fpsr},~{flags}"(ptr %p)
+  ret void
+}
+
 ; CHECK: error: invalid operand in inline asm: '#TEST ${0:a}'
 define void @test_a_m(ptr %p) {
   call void asm sideeffect "#TEST ${0:a}", "*m,~{dirflag},~{fpsr},~{flags}"(ptr elementtype(i32) %p)

--- a/llvm/test/CodeGen/X86/inline-asm-p-constraint.ll
+++ b/llvm/test/CodeGen/X86/inline-asm-p-constraint.ll
@@ -7,7 +7,7 @@ define ptr @foo(ptr %Ptr) {
   %Ptr.addr = alloca ptr, align 8
   store ptr %Ptr, ptr %Ptr.addr, align 8
 ; CHECK: movq    %rdi, -8(%rsp)
-  %1 = tail call ptr asm "mov $1, $0\0A\09lea $2, $0", "=r,p,*m,~{dirflag},~{fpsr},~{flags}"(ptr %Ptr, ptr elementtype(ptr) %Ptr.addr)
+  %1 = tail call ptr asm "mov ${1:a}, $0\0A\09lea $2, $0", "=r,p,*m,~{dirflag},~{fpsr},~{flags}"(ptr %Ptr, ptr elementtype(ptr) %Ptr.addr)
 ; CHECK-NEXT: #APP
 ; CHECK-NEXT: mov (%rdi), %rax
 ; CHECK-NEXT: lea -8(%rsp), %rax
@@ -17,10 +17,9 @@ define ptr @foo(ptr %Ptr) {
 }
 
 define void @intptr() {
-; Don't assert on a non-ptr operand, existing code & gcc accept these.
 entry:
 ; CHECK-LABEL: intptr:
 ; CHECK: ud1l 49150(%eax), %eax
-  call void asm "ud1l $0(%eax), %eax", "p,~{dirflag},~{fpsr},~{flags}"(i32 49150)
+  call void asm "ud1l ${0:a}(%eax), %eax", "p,~{dirflag},~{fpsr},~{flags}"(i32 49150)
   unreachable
 }


### PR DESCRIPTION
The 'p' constraint produces an address operand that should only be
printed with the 'a' modifier (e.g., %a0). Without it, GCC and Clang
produce different and arguably incorrect output
https://github.com/llvm/llvm-project/issues/185343#issuecomment-4029670370
Reject the combination to catch misuse early.
