### PR TITLE
[lldb] Update TestProcessCrashInfo for MTE

### DIFF
--- a/lldb/test/API/functionalities/process_crash_info/TestProcessCrashInfo.py
+++ b/lldb/test/API/functionalities/process_crash_info/TestProcessCrashInfo.py
@@ -26,6 +26,7 @@ class PlatformProcessCrashInfoTestCase(TestBase):
         for error in [
             "pointer being freed was not allocated",
             "not an allocated block",
+            "MTE tag mismatch",
         ]:
             if error in output:
                 return True


### PR DESCRIPTION
With MTE, the issue is caught by hardware and libmalloc records a different message: "BUG IN CLIENT OF LIBMALLOC: MTE tag mismatch (probable double-free)". Update the test accordingly.