### PR TITLE
[lldb] Use raw address in "memory history" command

### DIFF
--- a/lldb/source/Commands/CommandObjectMemory.cpp
+++ b/lldb/source/Commands/CommandObjectMemory.cpp
@@ -1567,7 +1567,7 @@ protected:
     }
 
     Status error;
-    lldb::addr_t addr = OptionArgParser::ToAddress(
+    lldb::addr_t addr = OptionArgParser::ToRawAddress(
         &m_exe_ctx, command[0].ref(), LLDB_INVALID_ADDRESS, &error);
 
     if (addr == LLDB_INVALID_ADDRESS) {


### PR DESCRIPTION
The `memory history` command was using `ToAddress` for its  address argument, which strips non-addressable bits (including MTE tag bits) via `FixAnyAddress`. This caused us to pass a stripped address to `__asan_get_alloc_stack`/`__asan_get_free_stack`, which is incorrect. Switch to `ToRawAddress` to preserve the complete address, including the MTE tag, so we can look up the correct address.