### PR TITLE
libclc: Add sqrt_cr utility

### DIFF
--- a/libclc/clc/include/clc/math/clc_sqrt_cr.h
+++ b/libclc/clc/include/clc/math/clc_sqrt_cr.h
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef __CLC_MATH_SQRT_CR_H__
+#define __CLC_MATH_SQRT_CR_H__
+
+// Declare overloads of __clc_sqrt_cr. This is a wrapper around the
+// floating-point / operator. This is a utilty to deal with the language default
+// sqrt not being correctly rounded, and requires the
+// -cl-fp32-correctly-rounded-divide-sqrt flag. This will just be the operator
+// compiled with that option. Ideally clang would expose a direct way to get the
+// correctly rounded and opencl precision versions.
+
+#define __CLC_FUNCTION __clc_sqrt_cr
+#define __CLC_BODY <clc/shared/unary_decl.inc>
+
+#include <clc/math/gentype.inc>
+
+#undef __CLC_FUNCTION
+
+#endif // __CLC_MATH_SQRT_CR_H__

--- a/libclc/clc/lib/generic/CMakeLists.txt
+++ b/libclc/clc/lib/generic/CMakeLists.txt
@@ -149,6 +149,7 @@ libclc_configure_source_list(CLC_GENERIC_SOURCES
   math/clc_sinh.cl
   math/clc_sinpi.cl
   math/clc_sqrt.cl
+  math/clc_sqrt_cr.cl
   math/clc_tables.cl
   math/clc_tan.cl
   math/clc_tanh.cl
@@ -209,4 +210,5 @@ libclc_configure_source_options(${CMAKE_CURRENT_SOURCE_DIR} -fapprox-func
 )
 
 libclc_configure_source_options(${CMAKE_CURRENT_SOURCE_DIR} -cl-fp32-correctly-rounded-divide-sqrt
-  math/clc_div_cr.cl)
+  math/clc_div_cr.cl
+  math/clc_sqrt_cr.cl)

--- a/libclc/clc/lib/generic/math/clc_sqrt_cr.cl
+++ b/libclc/clc/lib/generic/math/clc_sqrt_cr.cl
@@ -1,0 +1,11 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "clc/math/clc_sqrt_cr.h"
+#define __CLC_BODY <clc_sqrt_cr.inc>
+#include <clc/math/gentype.inc>

--- a/libclc/clc/lib/generic/math/clc_sqrt_cr.inc
+++ b/libclc/clc/lib/generic/math/clc_sqrt_cr.inc
@@ -1,0 +1,11 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+_CLC_OVERLOAD _CLC_DEF __CLC_GENTYPE __clc_sqrt_cr(__CLC_GENTYPE val) {
+  return __builtin_elementwise_sqrt(val);
+}


### PR DESCRIPTION
Same as the div case, add a backdoor to use the correctly
rounded sqrt builtin.