### PR TITLE
[LV] Simplify `matchExtendedReductionOperand()` (NFCI)

### DIFF
--- a/llvm/lib/Transforms/Vectorize/VPlanPatternMatch.h
+++ b/llvm/lib/Transforms/Vectorize/VPlanPatternMatch.h
@@ -593,7 +593,7 @@ m_ZExtOrSExt(const Op0_t &Op0) {
   return m_CombineOr(m_ZExt(Op0), m_SExt(Op0));
 }
 
-template <typename Op0_t> inline auto m_IntOrFloatExtend(const Op0_t &Op0) {
+template <typename Op0_t> inline auto m_AnyExtend(const Op0_t &Op0) {
   return m_CombineOr(m_ZExtOrSExt(Op0), m_FPExt(Op0));
 }
 

--- a/llvm/lib/Transforms/Vectorize/VPlanPatternMatch.h
+++ b/llvm/lib/Transforms/Vectorize/VPlanPatternMatch.h
@@ -593,6 +593,10 @@ m_ZExtOrSExt(const Op0_t &Op0) {
   return m_CombineOr(m_ZExt(Op0), m_SExt(Op0));
 }
 
+template <typename Op0_t> inline auto m_IntOrFloatExtend(const Op0_t &Op0) {
+  return m_CombineOr(m_ZExtOrSExt(Op0), m_FPExt(Op0));
+}
+
 template <typename Op0_t>
 inline match_combine_or<AllRecipe_match<Instruction::ZExt, Op0_t>, Op0_t>
 m_ZExtOrSelf(const Op0_t &Op0) {

--- a/llvm/lib/Transforms/Vectorize/VPlanTransforms.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanTransforms.cpp
@@ -6162,8 +6162,8 @@ matchExtendedReductionOperand(VPWidenRecipe *UpdateR, VPValue *Op) {
     if (match(CastSource, m_Mul(m_VPValue(), m_VPValue())) ||
         match(CastSource, m_FMul(m_VPValue(), m_VPValue()))) {
       // Match: ext(mul(...))
-      // Record the outer cast kind and set `Op` to the mul. We can then match
-      // this as a binary operator. Note: We can optimize out the outer extend
+      // Record the outer extend kind and set `Op` to the mul. We can then match
+      // this as a binary operation. Note: We can optimize out the outer extend
       // by widening the inner extends to match it. See
       // optimizeExtendsForPartialReduction.
       Op = CastSource;

--- a/llvm/lib/Transforms/Vectorize/VPlanTransforms.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanTransforms.cpp
@@ -6124,9 +6124,9 @@ static bool isValidPartialReduction(const VPPartialReductionChain &Chain,
 }
 
 static VPWidenRecipe *matchWidenBinaryOperator(VPValue *Value) {
-  if (auto WidenR = dyn_cast<VPWidenRecipe>(Value);
-      WidenR && Instruction::isBinaryOp(WidenR->getOpcode()))
-    return WidenR;
+  if (auto WidenR = dyn_cast<VPWidenRecipe>(Value))
+    if (Instruction::isBinaryOp(WidenR->getOpcode()))
+      return WidenR;
   return nullptr;
 }
 
@@ -6160,7 +6160,8 @@ matchExtendedReductionOperand(VPWidenRecipe *UpdateR, VPValue *Op) {
   // reduction since the inner extends will be widened. We already have oneUse
   // checks on the inner extends so widening them is safe.
   std::optional<TTI::PartialReductionExtendKind> OuterExtKind;
-  if (match(Op, m_IntOrFloatExtend(m_Mul(m_VPValue(), m_VPValue())))) {
+  if (match(Op, m_ZExtOrSExt(m_Mul(m_VPValue(), m_VPValue()))) ||
+      match(Op, m_FPExt(m_FMul(m_VPValue(), m_VPValue())))) {
     auto *CastRecipe = cast<VPWidenCastRecipe>(Op);
     OuterExtKind = getPartialReductionExtendKind(CastRecipe);
     Op = CastRecipe->getOperand(0);
@@ -6169,7 +6170,7 @@ matchExtendedReductionOperand(VPWidenRecipe *UpdateR, VPValue *Op) {
   // Match: UpdateR(PrevValue, ext(...))
   if ((UpdateR->getOpcode() == Instruction::Add ||
        UpdateR->getOpcode() == Instruction::FAdd) &&
-      match(Op, m_IntOrFloatExtend(m_VPValue()))) {
+      match(Op, m_AnyExtend(m_VPValue()))) {
     assert(!OuterExtKind && "Op should be Mul BinOp with OuterExtKind");
     return ExtendedReductionOperand{UpdateR,
                                     {cast<VPWidenCastRecipe>(Op), nullptr}};
@@ -6192,7 +6193,7 @@ matchExtendedReductionOperand(VPWidenRecipe *UpdateR, VPValue *Op) {
   VPValue *RHS = BinOp->getOperand(1);
 
   // The LHS of the operation must always be an extend.
-  if (!match(LHS, m_IntOrFloatExtend(m_VPValue())))
+  if (!match(LHS, m_AnyExtend(m_VPValue())))
     return std::nullopt;
 
   auto *LHSCast = cast<VPWidenCastRecipe>(LHS);
@@ -6200,7 +6201,7 @@ matchExtendedReductionOperand(VPWidenRecipe *UpdateR, VPValue *Op) {
   // The RHS of the operation can be an extend or a constant integer.
   // The constant will be validated in isValidPartialReduction.
   VPWidenCastRecipe *RHSCast = nullptr;
-  if (match(RHS, m_IntOrFloatExtend(m_VPValue())))
+  if (match(RHS, m_AnyExtend(m_VPValue())))
     RHSCast = cast<VPWidenCastRecipe>(RHS);
   else if (!isa<VPConstantInt>(RHS))
     return std::nullopt;

--- a/llvm/lib/Transforms/Vectorize/VPlanTransforms.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanTransforms.cpp
@@ -6123,6 +6123,18 @@ static bool isValidPartialReduction(const VPPartialReductionChain &Chain,
       Range);
 }
 
+static VPWidenRecipe *matchWidenBinaryOperator(VPValue *Value) {
+  if (auto WidenR = dyn_cast<VPWidenRecipe>(Value);
+      WidenR && Instruction::isBinaryOp(WidenR->getOpcode()))
+    return WidenR;
+  return nullptr;
+}
+
+static TTI::PartialReductionExtendKind
+getPartialReductionExtendKind(VPWidenCastRecipe *Cast) {
+  return TTI::getPartialReductionExtendKind(Cast->getOpcode());
+}
+
 /// Checks if \p Op (which is an operand of \p UpdateR) is an extended reduction
 /// operand. This is an operand where the source of the value (e.g. a load) has
 /// been extended (sext, zext, or fpext) before it is used in the reduction.
@@ -6148,79 +6160,59 @@ matchExtendedReductionOperand(VPWidenRecipe *UpdateR, VPValue *Op) {
   // reduction since the inner extends will be widened. We already have oneUse
   // checks on the inner extends so widening them is safe.
   std::optional<TTI::PartialReductionExtendKind> OuterExtKind;
-  if (match(Op, m_ZExtOrSExt(m_Mul(m_VPValue(), m_VPValue()))) ||
-      match(Op, m_FPExt(m_FMul(m_VPValue(), m_VPValue())))) {
-    auto *CastRecipe = dyn_cast<VPWidenCastRecipe>(Op);
-    if (!CastRecipe)
-      return std::nullopt;
-    auto CastOp = static_cast<Instruction::CastOps>(CastRecipe->getOpcode());
-    OuterExtKind = TTI::getPartialReductionExtendKind(CastOp);
+  if (match(Op, m_IntOrFloatExtend(m_Mul(m_VPValue(), m_VPValue())))) {
+    auto *CastRecipe = cast<VPWidenCastRecipe>(Op);
+    OuterExtKind = getPartialReductionExtendKind(CastRecipe);
     Op = CastRecipe->getOperand(0);
   }
 
-  // If the update is a binary op, check both of its operands to see if
-  // they are extends. Otherwise, see if the update comes directly from an
-  // extend.
-  std::array<VPWidenCastRecipe *, 2> CastRecipes = {};
-
-  // Match extends and populate CastRecipes. Returns false if matching fails.
-  auto MatchExtends = [OuterExtKind,
-                       &CastRecipes](ArrayRef<VPValue *> Operands) {
-    assert(Operands.size() <= 2 && "expected at most 2 operands");
-
-    for (const auto &[I, OpVal] : enumerate(Operands)) {
-      // Allow constant as second operand - validation happens in
-      // isValidPartialReduction.
-      const APInt *Unused;
-      if (I > 0 && CastRecipes[0] && match(OpVal, m_APInt(Unused)))
-        continue;
-
-      VPValue *ExtInput;
-      if (!match(OpVal, m_ZExtOrSExt(m_VPValue(ExtInput))) &&
-          !match(OpVal, m_FPExt(m_VPValue(ExtInput))))
-        return false;
-
-      CastRecipes[I] = dyn_cast<VPWidenCastRecipe>(OpVal);
-      if (!CastRecipes[I])
-        return false;
-
-      // The outer extend kind must match the inner extends for folding.
-      if (OuterExtKind) {
-        auto CastOp =
-            static_cast<Instruction::CastOps>(CastRecipes[I]->getOpcode());
-        if (*OuterExtKind != TTI::getPartialReductionExtendKind(CastOp))
-          return false;
-      }
-    }
-    return CastRecipes[0] != nullptr;
-  };
-
-  // If Op is a binary operator, check both of its operands to see if they are
-  // extends. Otherwise, see if the update comes directly from an extend.
-  auto *BinOp = dyn_cast<VPWidenRecipe>(Op);
-  if (BinOp && Instruction::isBinaryOp(BinOp->getOpcode())) {
-    if (!BinOp->hasOneUse())
-      return std::nullopt;
-
-    // Handle neg(binop(ext, ext)) pattern.
-    VPValue *OtherOp = nullptr;
-    if (match(BinOp, m_Sub(m_ZeroInt(), m_VPValue(OtherOp))))
-      BinOp = dyn_cast<VPWidenRecipe>(OtherOp);
-
-    if (!BinOp || !Instruction::isBinaryOp(BinOp->getOpcode()) ||
-        !MatchExtends(BinOp->operands()))
-      return std::nullopt;
-  } else if (match(UpdateR, m_Add(m_VPValue(), m_VPValue())) ||
-             match(UpdateR, m_FAdd(m_VPValue(), m_VPValue()))) {
-    // We already know Op is an operand of UpdateR.
-    if (!MatchExtends({Op}))
-      return std::nullopt;
-    BinOp = UpdateR;
-  } else {
+  // Match: UpdateR(PrevValue, ext(...))
+  VPWidenRecipe *BinOp = matchWidenBinaryOperator(Op);
+  if (!BinOp && (UpdateR->getOpcode() == Instruction::Add ||
+                 UpdateR->getOpcode() == Instruction::FAdd)) {
+    assert(!OuterExtKind && "Op should be Mul BinOp with OuterExtKind");
+    if (match(Op, m_IntOrFloatExtend(m_VPValue())))
+      return ExtendedReductionOperand{UpdateR,
+                                      {cast<VPWidenCastRecipe>(Op), nullptr}};
     return std::nullopt;
   }
 
-  return ExtendedReductionOperand{BinOp, CastRecipes};
+  // The rest of the matching assumes `Op` is a (possibly extended/negated)
+  // binary operation.
+  if (!BinOp || !BinOp->hasOneUse())
+    return std::nullopt;
+
+  // Handle neg(binop(...)) pattern.
+  VPValue *NegatedOp = nullptr;
+  if (match(BinOp, m_Sub(m_ZeroInt(), m_VPValue(NegatedOp)))) {
+    if (!(BinOp = matchWidenBinaryOperator(NegatedOp)))
+      return std::nullopt;
+  }
+
+  VPValue *LHS = BinOp->getOperand(0);
+  VPValue *RHS = BinOp->getOperand(1);
+
+  // The LHS of the operation must always be an extend.
+  if (!match(LHS, m_IntOrFloatExtend(m_VPValue())))
+    return std::nullopt;
+
+  auto *LHSCast = cast<VPWidenCastRecipe>(LHS);
+
+  // The RHS of the operation can be an extend or a constant integer.
+  // The constant will be validated in isValidPartialReduction.
+  VPWidenCastRecipe *RHSCast = nullptr;
+  if (match(RHS, m_IntOrFloatExtend(m_VPValue())))
+    RHSCast = cast<VPWidenCastRecipe>(RHS);
+  else if (!isa<VPConstantInt>(RHS))
+    return std::nullopt;
+
+  // The outer extend kind must match the inner extends for folding.
+  for (VPWidenCastRecipe *Cast : {LHSCast, RHSCast})
+    if (Cast && OuterExtKind &&
+        getPartialReductionExtendKind(Cast) != OuterExtKind)
+      return std::nullopt;
+
+  return ExtendedReductionOperand{BinOp, {LHSCast, RHSCast}};
 }
 
 /// Examines each operation in the reduction chain corresponding to \p RedPhiR,

--- a/llvm/lib/Transforms/Vectorize/VPlanTransforms.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanTransforms.cpp
@@ -6155,40 +6155,42 @@ matchExtendedReductionOperand(VPWidenRecipe *UpdateR, VPValue *Op) {
   assert(is_contained(UpdateR->operands(), Op) &&
          "Op should be operand of UpdateR");
 
-  // If Op is an extend, then it's still a valid partial reduction if the
-  // extended mul fulfills the other requirements.
-  // For example, reduce.add(ext(mul(ext(A), ext(B)))) is still a valid partial
-  // reduction since the inner extends will be widened. We already have oneUse
-  // checks on the inner extends so widening them is safe.
   std::optional<TTI::PartialReductionExtendKind> OuterExtKind;
-  if (match(Op, m_ZExtOrSExt(m_Mul(m_VPValue(), m_VPValue()))) ||
-      match(Op, m_FPExt(m_FMul(m_VPValue(), m_VPValue())))) {
+  if (match(Op, m_AnyExtend(m_VPValue()))) {
     auto *CastRecipe = cast<VPWidenCastRecipe>(Op);
-    OuterExtKind = getPartialReductionExtendKind(CastRecipe);
-    Op = CastRecipe->getOperand(0);
-  }
-
-  // Match: UpdateR(PrevValue, ext(...))
-  if ((UpdateR->getOpcode() == Instruction::Add ||
-       UpdateR->getOpcode() == Instruction::FAdd) &&
-      match(Op, m_AnyExtend(m_VPValue()))) {
-    assert(!OuterExtKind && "Op should be Mul BinOp with OuterExtKind");
-    return ExtendedReductionOperand{UpdateR,
-                                    {cast<VPWidenCastRecipe>(Op), nullptr}};
+    VPValue *CastSource = CastRecipe->getOperand(0);
+    if (match(CastSource, m_Mul(m_VPValue(), m_VPValue())) ||
+        match(CastSource, m_FMul(m_VPValue(), m_VPValue()))) {
+      // Match: ext(mul(...))
+      // Record the outer cast kind and set `Op` to the mul. We can then match
+      // this as a binary operator. Note: We can optimize out the outer extend
+      // by widening the inner extends to match it. See
+      // optimizeExtendsForPartialReduction.
+      Op = CastSource;
+      OuterExtKind = getPartialReductionExtendKind(CastRecipe);
+    } else if (UpdateR->getOpcode() == Instruction::Add ||
+               UpdateR->getOpcode() == Instruction::FAdd) {
+      // Match: UpdateR(PrevValue, ext(...))
+      // TODO: Remove the add/fadd restriction (we should be able to handle this
+      // case for sub reductions too).
+      return ExtendedReductionOperand{UpdateR, {CastRecipe, nullptr}};
+    }
   }
 
   // The rest of the matching assumes `Op` is a (possibly extended/negated)
   // binary operation.
-  VPWidenRecipe *BinOp = matchWidenBinaryOperator(Op);
-  if (!BinOp || !BinOp->hasOneUse())
+
+  if (!Op->hasOneUse())
     return std::nullopt;
 
-  // Handle neg(binop(...)) pattern.
+  // Handle neg(...) pattern (aka sub(0, ...)).
   VPValue *NegatedOp = nullptr;
-  if (match(BinOp, m_Sub(m_ZeroInt(), m_VPValue(NegatedOp)))) {
-    if (!(BinOp = matchWidenBinaryOperator(NegatedOp)))
-      return std::nullopt;
-  }
+  if (match(Op, m_Sub(m_ZeroInt(), m_VPValue(NegatedOp))))
+    Op = NegatedOp;
+
+  VPWidenRecipe *BinOp = matchWidenBinaryOperator(Op);
+  if (!BinOp)
+    return std::nullopt;
 
   VPValue *LHS = BinOp->getOperand(0);
   VPValue *RHS = BinOp->getOperand(1);

--- a/llvm/lib/Transforms/Vectorize/VPlanTransforms.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanTransforms.cpp
@@ -6124,13 +6124,6 @@ static bool isValidPartialReduction(const VPPartialReductionChain &Chain,
       Range);
 }
 
-static VPWidenRecipe *matchWidenBinaryOperator(VPValue *Value) {
-  if (auto WidenR = dyn_cast<VPWidenRecipe>(Value))
-    if (Instruction::isBinaryOp(WidenR->getOpcode()))
-      return WidenR;
-  return nullptr;
-}
-
 static TTI::PartialReductionExtendKind
 getPartialReductionExtendKind(VPWidenCastRecipe *Cast) {
   return TTI::getPartialReductionExtendKind(Cast->getOpcode());
@@ -6177,9 +6170,6 @@ matchExtendedReductionOperand(VPWidenRecipe *UpdateR, VPValue *Op) {
     }
   }
 
-  // The rest of the matching assumes `Op` is a (possibly extended/negated)
-  // binary operation.
-
   if (!Op->hasOneUse())
     return std::nullopt;
 
@@ -6188,9 +6178,12 @@ matchExtendedReductionOperand(VPWidenRecipe *UpdateR, VPValue *Op) {
   if (match(Op, m_Sub(m_ZeroInt(), m_VPValue(NegatedOp))))
     Op = NegatedOp;
 
-  VPWidenRecipe *BinOp = matchWidenBinaryOperator(Op);
-  if (!BinOp)
+  VPWidenRecipe *BinOp = dyn_cast<VPWidenRecipe>(Op);
+  if (!BinOp || !Instruction::isBinaryOp(BinOp->getOpcode()))
     return std::nullopt;
+
+  // The rest of the matching assumes `Op` is a (possibly extended/negated)
+  // binary operation.
 
   VPValue *LHS = BinOp->getOperand(0);
   VPValue *RHS = BinOp->getOperand(1);

--- a/llvm/lib/Transforms/Vectorize/VPlanTransforms.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanTransforms.cpp
@@ -5929,6 +5929,7 @@ optimizeExtendsForPartialReduction(VPSingleDefRecipe *BinOp,
 
   // reduce.add(ext(mul(ext(A), ext(B))))
   // -> reduce.add(mul(wider_ext(A), wider_ext(B)))
+  // TODO: Support this optimization for float types.
   if (match(BinOp, m_ZExtOrSExt(m_Mul(m_ZExtOrSExt(m_VPValue()),
                                       m_ZExtOrSExt(m_VPValue()))))) {
     auto *Ext = cast<VPWidenCastRecipe>(BinOp);

--- a/llvm/lib/Transforms/Vectorize/VPlanTransforms.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanTransforms.cpp
@@ -6167,18 +6167,17 @@ matchExtendedReductionOperand(VPWidenRecipe *UpdateR, VPValue *Op) {
   }
 
   // Match: UpdateR(PrevValue, ext(...))
-  VPWidenRecipe *BinOp = matchWidenBinaryOperator(Op);
-  if (!BinOp && (UpdateR->getOpcode() == Instruction::Add ||
-                 UpdateR->getOpcode() == Instruction::FAdd)) {
+  if ((UpdateR->getOpcode() == Instruction::Add ||
+       UpdateR->getOpcode() == Instruction::FAdd) &&
+      match(Op, m_IntOrFloatExtend(m_VPValue()))) {
     assert(!OuterExtKind && "Op should be Mul BinOp with OuterExtKind");
-    if (match(Op, m_IntOrFloatExtend(m_VPValue())))
-      return ExtendedReductionOperand{UpdateR,
-                                      {cast<VPWidenCastRecipe>(Op), nullptr}};
-    return std::nullopt;
+    return ExtendedReductionOperand{UpdateR,
+                                    {cast<VPWidenCastRecipe>(Op), nullptr}};
   }
 
   // The rest of the matching assumes `Op` is a (possibly extended/negated)
   // binary operation.
+  VPWidenRecipe *BinOp = matchWidenBinaryOperator(Op);
   if (!BinOp || !BinOp->hasOneUse())
     return std::nullopt;
 

--- a/llvm/test/Transforms/LoopVectorize/AArch64/partial-reduce-fdot-product.ll
+++ b/llvm/test/Transforms/LoopVectorize/AArch64/partial-reduce-fdot-product.ll
@@ -943,8 +943,66 @@ exit:
   ret double %add3
 }
 
+define double @ext_fmul_half_to_double(i64 %n, ptr %a, i8 %b) #2 {
+; CHECK-LABEL: define double @ext_fmul_half_to_double(
+; CHECK-SAME: i64 [[N:%.*]], ptr [[A:%.*]], i8 [[B:%.*]]) #[[ATTR2:[0-9]+]] {
+; CHECK-NEXT:  [[ENTRY:.*:]]
+; CHECK-NEXT:    [[TMP0:%.*]] = add i64 [[N]], 1
+; CHECK-NEXT:    [[MIN_ITERS_CHECK:%.*]] = icmp ult i64 [[TMP0]], 16
+; CHECK-NEXT:    br i1 [[MIN_ITERS_CHECK]], label %[[SCALAR_PH:.*]], label %[[VECTOR_PH:.*]]
+; CHECK:       [[VECTOR_PH]]:
+; CHECK-NEXT:    [[N_MOD_VF:%.*]] = urem i64 [[TMP0]], 16
+; CHECK-NEXT:    [[N_VEC:%.*]] = sub i64 [[TMP0]], [[N_MOD_VF]]
+; CHECK-NEXT:    br label %[[VECTOR_BODY:.*]]
+; CHECK:       [[VECTOR_BODY]]:
+; CHECK-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[VECTOR_BODY]] ]
+; CHECK-NEXT:    [[VEC_PHI:%.*]] = phi <2 x double> [ <double 0.000000e+00, double -0.000000e+00>, %[[VECTOR_PH]] ], [ [[PARTIAL_REDUCE:%.*]], %[[VECTOR_BODY]] ]
+; CHECK-NEXT:    [[VEC_PHI1:%.*]] = phi <2 x double> [ splat (double -0.000000e+00), %[[VECTOR_PH]] ], [ [[PARTIAL_REDUCE3:%.*]], %[[VECTOR_BODY]] ]
+; CHECK-NEXT:    [[TMP1:%.*]] = getelementptr half, ptr [[A]], i64 [[INDEX]]
+; CHECK-NEXT:    [[TMP2:%.*]] = getelementptr half, ptr [[TMP1]], i64 8
+; CHECK-NEXT:    [[WIDE_LOAD:%.*]] = load <8 x half>, ptr [[TMP1]], align 2
+; CHECK-NEXT:    [[WIDE_LOAD2:%.*]] = load <8 x half>, ptr [[TMP2]], align 2
+; CHECK-NEXT:    [[TMP3:%.*]] = fpext <8 x half> [[WIDE_LOAD]] to <8 x float>
+; CHECK-NEXT:    [[TMP4:%.*]] = fpext <8 x half> [[WIDE_LOAD2]] to <8 x float>
+; CHECK-NEXT:    [[TMP5:%.*]] = fmul reassoc contract <8 x float> [[TMP3]], [[TMP3]]
+; CHECK-NEXT:    [[TMP6:%.*]] = fmul reassoc contract <8 x float> [[TMP4]], [[TMP4]]
+; CHECK-NEXT:    [[TMP7:%.*]] = fpext <8 x float> [[TMP5]] to <8 x double>
+; CHECK-NEXT:    [[PARTIAL_REDUCE]] = call reassoc contract <2 x double> @llvm.vector.partial.reduce.fadd.v2f64.v8f64(<2 x double> [[VEC_PHI]], <8 x double> [[TMP7]])
+; CHECK-NEXT:    [[TMP8:%.*]] = fpext <8 x float> [[TMP6]] to <8 x double>
+; CHECK-NEXT:    [[PARTIAL_REDUCE3]] = call reassoc contract <2 x double> @llvm.vector.partial.reduce.fadd.v2f64.v8f64(<2 x double> [[VEC_PHI1]], <8 x double> [[TMP8]])
+; CHECK-NEXT:    [[INDEX_NEXT]] = add nuw i64 [[INDEX]], 16
+; CHECK-NEXT:    [[TMP11:%.*]] = icmp eq i64 [[INDEX_NEXT]], [[N_VEC]]
+; CHECK-NEXT:    br i1 [[TMP11]], label %[[MIDDLE_BLOCK:.*]], label %[[VECTOR_BODY]], !llvm.loop [[LOOP30:![0-9]+]]
+; CHECK:       [[MIDDLE_BLOCK]]:
+; CHECK-NEXT:    [[BIN_RDX:%.*]] = fadd reassoc contract <2 x double> [[PARTIAL_REDUCE3]], [[PARTIAL_REDUCE]]
+; CHECK-NEXT:    [[TMP10:%.*]] = call reassoc contract double @llvm.vector.reduce.fadd.v2f64(double -0.000000e+00, <2 x double> [[BIN_RDX]])
+; CHECK-NEXT:    [[CMP_N:%.*]] = icmp eq i64 [[TMP0]], [[N_VEC]]
+; CHECK-NEXT:    br i1 [[CMP_N]], [[EXIT:label %.*]], label %[[SCALAR_PH]]
+; CHECK:       [[SCALAR_PH]]:
+;
+entry:
+  br label %loop
+
+loop:
+  %iv = phi i64 [ 0, %entry ], [ %iv.next, %loop ]
+  %sum = phi double [ 0.0, %entry ], [ %add, %loop ]
+  %a.ptr = getelementptr half, ptr %a, i64 %iv
+  %load.a = load half, ptr %a.ptr, align 2
+  %iv.next = add i64 %iv, 1
+  %ext.a = fpext half %load.a to float
+  %mul = fmul reassoc contract float %ext.a, %ext.a
+  %mul.ext = fpext float %mul to double
+  %add = fadd reassoc contract double %sum, %mul.ext
+  %ec = icmp eq i64 %iv, %n
+  br i1 %ec, label %exit, label %loop
+
+exit:
+  ret double %add
+}
+
 attributes #0 = { "target-features"="+sve2p1,+dotprod" }
 attributes #1 = { "target-features"="+sve" }
+attributes #2 = { "target-features"="+dotprod" }
 
 !0 = distinct !{!0, !1}
 !1 = !{!"llvm.loop.interleave.count", i32 1}


### PR DESCRIPTION
This updates `matchExtendedReductionOperand` so the simple case of `UpdateR(PrevValue, ext(...))` is matched first as an early exit. The binop matching is then flattened to remove the extra layer of the `MatchExtends` lambda.