### PR TITLE
libclc: Add fast version utility functions for div, sqrt and reciprocal

### DIFF
--- a/libclc/clc/include/clc/math/clc_div_fast.h
+++ b/libclc/clc/include/clc/math/clc_div_fast.h
@@ -1,0 +1,19 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef __CLC_MATH_CLC_DIV_FAST_H__
+#define __CLC_MATH_CLC_DIV_FAST_H__
+
+#define __CLC_FUNCTION __clc_div_fast
+#define __CLC_BODY <clc/shared/binary_decl.inc>
+
+#include <clc/math/gentype.inc>
+
+#undef __CLC_FUNCTION
+
+#endif // __CLC_MATH_CLC_DIV_FAST_H__

--- a/libclc/clc/include/clc/math/clc_recip_fast.h
+++ b/libclc/clc/include/clc/math/clc_recip_fast.h
@@ -1,0 +1,19 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef __CLC_MATH_CLC_RECIP_FAST_H__
+#define __CLC_MATH_CLC_RECIP_FAST_H__
+
+#define __CLC_FUNCTION __clc_recip_fast
+#define __CLC_BODY <clc/shared/unary_decl.inc>
+
+#include <clc/math/gentype.inc>
+
+#undef __CLC_FUNCTION
+
+#endif // __CLC_MATH_CLC_RECIP_FAST_H__

--- a/libclc/clc/include/clc/math/clc_sqrt_fast.h
+++ b/libclc/clc/include/clc/math/clc_sqrt_fast.h
@@ -1,0 +1,19 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef __CLC_MATH_CLC_SQRT_FAST_H__
+#define __CLC_MATH_CLC_SQRT_FAST_H__
+
+#define __CLC_FUNCTION __clc_sqrt_fast
+#define __CLC_BODY <clc/shared/unary_decl.inc>
+
+#include <clc/math/gentype.inc>
+
+#undef __CLC_FUNCTION
+
+#endif // __CLC_MATH_CLC_SQRT_FAST_H__

--- a/libclc/clc/lib/generic/CMakeLists.txt
+++ b/libclc/clc/lib/generic/CMakeLists.txt
@@ -73,6 +73,7 @@ libclc_configure_source_list(CLC_GENERIC_SOURCES
   math/clc_cosh.cl
   math/clc_cospi.cl
   math/clc_div_cr.cl
+  math/clc_div_fast.cl
   math/clc_ep_log.cl
   math/clc_erf.cl
   math/clc_erfc.cl
@@ -137,6 +138,7 @@ libclc_configure_source_list(CLC_GENERIC_SOURCES
   math/clc_pow.cl
   math/clc_pown.cl
   math/clc_powr.cl
+  math/clc_recip_fast.cl
   math/clc_remainder.cl
   math/clc_remquo.cl
   math/clc_rint.cl
@@ -150,6 +152,7 @@ libclc_configure_source_list(CLC_GENERIC_SOURCES
   math/clc_sinpi.cl
   math/clc_sqrt.cl
   math/clc_sqrt_cr.cl
+  math/clc_sqrt_fast.cl
   math/clc_tables.cl
   math/clc_tan.cl
   math/clc_tanh.cl
@@ -207,7 +210,9 @@ libclc_configure_source_options(${CMAKE_CURRENT_SOURCE_DIR} -fapprox-func
   math/clc_native_sin.cl
   math/clc_native_sqrt.cl
   math/clc_native_tan.cl
-)
+  math/clc_div_fast.cl
+  math/clc_recip_fast.cl
+  math/clc_sqrt_fast.cl)
 
 libclc_configure_source_options(${CMAKE_CURRENT_SOURCE_DIR} -cl-fp32-correctly-rounded-divide-sqrt
   math/clc_div_cr.cl

--- a/libclc/clc/lib/generic/math/clc_div_fast.cl
+++ b/libclc/clc/lib/generic/math/clc_div_fast.cl
@@ -1,0 +1,13 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "clc/math/clc_div_fast.h"
+
+#define __CLC_FUNCTION __clc_div_fast
+#define __CLC_BODY <clc_div_fast.inc>
+#include <clc/math/gentype.inc>

--- a/libclc/clc/lib/generic/math/clc_div_fast.inc
+++ b/libclc/clc/lib/generic/math/clc_div_fast.inc
@@ -1,0 +1,12 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+_CLC_OVERLOAD _CLC_DEF __CLC_GENTYPE __clc_div_fast(__CLC_GENTYPE x,
+                                                    __CLC_GENTYPE y) {
+  return x / y;
+}

--- a/libclc/clc/lib/generic/math/clc_recip_fast.cl
+++ b/libclc/clc/lib/generic/math/clc_recip_fast.cl
@@ -1,0 +1,14 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include <clc/internal/clc.h>
+
+#define __CLC_FUNCTION __clc_recip_fast
+#define __CLC_BODY <clc_recip_fast.inc>
+
+#include <clc/math/gentype.inc>

--- a/libclc/clc/lib/generic/math/clc_recip_fast.inc
+++ b/libclc/clc/lib/generic/math/clc_recip_fast.inc
@@ -1,0 +1,11 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+_CLC_OVERLOAD _CLC_DEF __CLC_GENTYPE __clc_recip_fast(__CLC_GENTYPE x) {
+  return ((__CLC_GENTYPE)1.0) / x;
+}

--- a/libclc/clc/lib/generic/math/clc_sqrt_fast.cl
+++ b/libclc/clc/lib/generic/math/clc_sqrt_fast.cl
@@ -1,0 +1,15 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include <clc/internal/clc.h>
+
+#define __CLC_FUNCTION __clc_sqrt_fast
+#define __CLC_IMPL_FUNCTION(x) __builtin_elementwise_sqrt
+#define __CLC_BODY <clc/shared/unary_def.inc>
+
+#include <clc/math/gentype.inc>


### PR DESCRIPTION
These are subtly different from the native versions, and should have
tighter requirements. They should handle the special cases correctly,
unlike the native functions from the standard.