### PR TITLE
clang/AMDGPU: Ensure more macros are defined for dummy target

### DIFF
--- a/clang/lib/Basic/Targets/AMDGPU.cpp
+++ b/clang/lib/Basic/Targets/AMDGPU.cpp
@@ -289,6 +289,21 @@ void AMDGPUTargetInfo::getTargetDefines(const LangOptions &Opts,
   else
     Builder.defineMacro("__R600__");
 
+  // TODO: __HAS_FMAF__, __HAS_LDEXPF__, __HAS_FP64__ are deprecated and will be
+  // removed in the near future.
+  if (hasFMAF())
+    Builder.defineMacro("__HAS_FMAF__");
+  if (hasFastFMAF())
+    Builder.defineMacro("FP_FAST_FMAF");
+  if (hasLDEXPF())
+    Builder.defineMacro("__HAS_LDEXPF__");
+  if (hasFP64())
+    Builder.defineMacro("__HAS_FP64__");
+  if (hasFastFMA())
+    Builder.defineMacro("FP_FAST_FMA");
+
+  Builder.defineMacro("__AMDGCN_CUMODE__", Twine(CUMode));
+
   // Legacy HIP host code relies on these default attributes to be defined.
   bool IsHIPHost = Opts.HIP && !Opts.CUDAIsDevice;
   if (GPUKind == llvm::AMDGPU::GK_NONE && !IsHIPHost)
@@ -331,21 +346,6 @@ void AMDGPUTargetInfo::getTargetDefines(const LangOptions &Opts,
 
   if (Opts.AtomicIgnoreDenormalMode)
     Builder.defineMacro("__AMDGCN_UNSAFE_FP_ATOMICS__");
-
-  // TODO: __HAS_FMAF__, __HAS_LDEXPF__, __HAS_FP64__ are deprecated and will be
-  // removed in the near future.
-  if (hasFMAF())
-    Builder.defineMacro("__HAS_FMAF__");
-  if (hasFastFMAF())
-    Builder.defineMacro("FP_FAST_FMAF");
-  if (hasLDEXPF())
-    Builder.defineMacro("__HAS_LDEXPF__");
-  if (hasFP64())
-    Builder.defineMacro("__HAS_FP64__");
-  if (hasFastFMA())
-    Builder.defineMacro("FP_FAST_FMA");
-
-  Builder.defineMacro("__AMDGCN_CUMODE__", Twine(CUMode));
 }
 
 void AMDGPUTargetInfo::setAuxTarget(const TargetInfo *Aux) {

--- a/clang/test/Driver/amdgpu-macros.cl
+++ b/clang/test/Driver/amdgpu-macros.cl
@@ -66,6 +66,7 @@
 // AMDGCN-based processors.
 //
 
+// RUN: %clang -E -dM -target amdgcn %s 2>&1 | FileCheck --check-prefixes=DUMMY,SLOW_FMAF -DWAVEFRONT_SIZE=64 %s
 // RUN: %clang -E -dM -target amdgcn -mcpu=gfx600 %s 2>&1 | FileCheck --check-prefixes=ARCH-GCN,FAST_FMAF %s -DWAVEFRONT_SIZE=64 -DCPU=gfx600 -DFAMILY=GFX6
 // RUN: %clang -E -dM -target amdgcn -mcpu=tahiti %s 2>&1 | FileCheck --check-prefixes=ARCH-GCN,FAST_FMAF %s -DWAVEFRONT_SIZE=64 -DCPU=gfx600 -DFAMILY=GFX6
 // RUN: %clang -E -dM -target amdgcn -mcpu=gfx601 %s 2>&1 | FileCheck --check-prefixes=ARCH-GCN,SLOW_FMAF %s -DWAVEFRONT_SIZE=64 -DCPU=gfx601 -DFAMILY=GFX6
@@ -160,6 +161,15 @@
 // ARCH-GCN-DAG: #define __GCC_DESTRUCTIVE_SIZE 128
 // ARCH-GCN-DAG: #define __GCC_CONSTRUCTIVE_SIZE 128
 // UNSAFEFPATOMIC-DAG: #define __AMDGCN_UNSAFE_FP_ATOMICS__ 1
+
+
+// DUMMY-DAG: #define __AMDGCN__ 1
+// DUMMY-DAG: #define __AMDGPU__ 1
+// DUMMY-DAG: #define __AMD__ 1
+// DUMMY-DAG: #define __HAS_FMAF__ 1
+// DUMMY-DAG: #define __HAS_FP64__ 1
+// DUMMY-DAG: #define __HAS_LDEXPF__ 1
+
 
 // RUN: %clang -E -dM -target amdgcn -mcpu=gfx906 \
 // RUN:   %s 2>&1 | FileCheck --check-prefix=CUMODE-ON %s

--- a/clang/test/Preprocessor/predefined-arch-macros.c
+++ b/clang/test/Preprocessor/predefined-arch-macros.c
@@ -4607,19 +4607,19 @@
 
 // Begin amdgcn tests ----------------
 
-// RUN: %clang -mcpu=gfx803 -E -dM %s -o - 2>&1 \
+// RUN: %clang -mcpu=gfx900 -E -dM %s -o - 2>&1 \
 // RUN:     -target amdgcn-unknown-unknown \
-// RUN:   | FileCheck -match-full-lines %s -check-prefixes=CHECK_AMDGCN,CHECK_AMDGCN_803
+// RUN:   | FileCheck -match-full-lines %s -check-prefixes=CHECK_AMDGCN,CHECK_AMDGCN_900
 // RUN: %clang -E -dM %s -o - 2>&1 \
 // RUN:     -target amdgcn-unknown-unknown \
 // RUN:   | FileCheck -match-full-lines %s -check-prefixes=CHECK_AMDGCN,CHECK_AMDGCN_NONE
+// CHECK_AMDGCN: #define FP_FAST_FMA 1
+// CHECK_AMDGCN_900: #define FP_FAST_FMAF 1
+// CHECK_AMDGCN_NONE-NOT: FP_FAST_FMAF
 // CHECK_AMDGCN: #define __AMDGCN__ 1
-// CHECK_AMDGCN_803: #define __HAS_FMAF__ 1
-// CHECK_AMDGCN_803: #define __HAS_FP64__ 1
-// CHECK_AMDGCN_803: #define __HAS_LDEXPF__ 1
-// CHECK_AMDGCN_NONE-NOT: #define __HAS_FMAF__
-// CHECK_AMDGCN_NONE-NOT: #define __HAS_FP64__
-// CHECK_AMDGCN_NONE-NOT: #define __HAS_LDEXPF__
+// CHECK_AMDGCN: #define __HAS_FMAF__ 1
+// CHECK_AMDGCN: #define __HAS_FP64__ 1
+// CHECK_AMDGCN: #define __HAS_LDEXPF__ 1
 
 // Begin r600 tests ----------------
 


### PR DESCRIPTION
FP_FAST_FMA should be unconditionally true.