### PR TITLE
[InstCombine] Fold `fptrunc(x) ord/uno [ C | fptrunc(y) ]` to `x ord/uno [ C | y ]`

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineCompares.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCompares.cpp
@@ -8919,7 +8919,7 @@ Instruction *InstCombinerImpl::visitFCmpInst(FCmpInst &I) {
 
   // fcmp ord/uno (fptrunc X), (fptrunc Y) -> fcmp ord/uno X, Y
   if ((Pred == FCmpInst::FCMP_ORD || Pred == FCmpInst::FCMP_UNO) &&
-      match(Op0, m_Trunc(m_Value(X))) && match(Op0, m_Trunc(m_Value(Y))) &&
+      match(Op0, m_Trunc(m_Value(X))) && match(Op1, m_Trunc(m_Value(Y))) &&
       X->getType() == Y->getType())
     return new FCmpInst(Pred, X, Y, "", &I);
 

--- a/llvm/lib/Transforms/InstCombine/InstCombineCompares.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCompares.cpp
@@ -8919,7 +8919,7 @@ Instruction *InstCombinerImpl::visitFCmpInst(FCmpInst &I) {
 
   // fcmp ord/uno (fptrunc X), (fptrunc Y) -> fcmp ord/uno X, Y
   if ((Pred == FCmpInst::FCMP_ORD || Pred == FCmpInst::FCMP_UNO) &&
-      match(Op0, m_Trunc(m_Value(X))) && match(Op1, m_Trunc(m_Value(Y))) &&
+      match(Op0, m_FPTrunc(m_Value(X))) && match(Op1, m_FPTrunc(m_Value(Y))) &&
       X->getType() == Y->getType())
     return new FCmpInst(Pred, X, Y, "", &I);
 

--- a/llvm/lib/Transforms/InstCombine/InstCombineCompares.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCompares.cpp
@@ -26,6 +26,7 @@
 #include "llvm/IR/Constants.h"
 #include "llvm/IR/DataLayout.h"
 #include "llvm/IR/InstrTypes.h"
+#include "llvm/IR/Instruction.h"
 #include "llvm/IR/Instructions.h"
 #include "llvm/IR/IntrinsicInst.h"
 #include "llvm/IR/PatternMatch.h"
@@ -8295,38 +8296,27 @@ static Instruction *foldFCmpReciprocalAndZero(FCmpInst &I, Instruction *LHSI,
 //    fptrunc(x) >  C                -->  x >  ext(C)
 //    fptrunc(x) >= C                -->  x >= ext(C)
 //    fptrunc(x) ord/uno C           -->  x ord/uno 0
-//    fptrunc(x) ord/uno fptrunc(y)  -->  x ord/uno y
 // where 'ext(C)' is the extension of 'C' to the type of 'x' with a small bias
 // due to precision loss.
 static Instruction *foldFCmpFpTrunc(FCmpInst &I, const Instruction &FPTrunc,
-                                    const Value &CmpRHS) {
+                                    const Constant &C) {
   FCmpInst::Predicate Pred = I.getPredicate();
   Type *DestType = FPTrunc.getOperand(0)->getType();
 
-  // Handle ord/uno [C | fptrunc(y)]
-  if (Pred == FCmpInst::FCMP_ORD || Pred == FCmpInst::FCMP_UNO) {
-    Value *RHS;
-    const APFloat *CValue;
-    if (match(&CmpRHS, m_FPTrunc(m_Value(RHS)))) {
-      if (DestType != RHS->getType())
-        return nullptr;
-    } else if (match(&CmpRHS, m_APFloat(CValue))) {
-      assert(!CValue->isNaN() &&
-             "NaN RHS should be folded away by simplifyFCmpInst()");
-      RHS = ConstantFP::getZero(DestType);
-    } else {
-      return nullptr;
-    }
+  const APFloat *CValue;
+  // TODO: support vec
+  if (!match(&C, m_APFloat(CValue)))
+    return nullptr;
 
-    return new FCmpInst(Pred, FPTrunc.getOperand(0), RHS, "", &I);
+  // Handle ord/uno
+  if (Pred == FCmpInst::FCMP_ORD || Pred == FCmpInst::FCMP_UNO) {
+    assert(!CValue->isNaN() &&
+           "X ord/uno NaN should be folded away by simplifyFCmpInst()");
+    return new FCmpInst(Pred, FPTrunc.getOperand(0),
+                        ConstantFP::getZero(DestType), "", &I);
   }
 
   // Handle <, >, <=, >=
-  const APFloat *CValue;
-  // TODO: support vec
-  if (!match(&CmpRHS, m_APFloat(CValue)))
-    return nullptr;
-
   bool RoundDown = false;
 
   if (Pred == FCmpInst::FCMP_OGE || Pred == FCmpInst::FCMP_UGE ||
@@ -8377,7 +8367,7 @@ static Instruction *foldFCmpFpTrunc(FCmpInst &I, const Instruction &FPTrunc,
       scalbn(ExtCValue + ExtNextCValue, -1, APFloat::rmNearestTiesToEven);
 
   const fltSemantics &SrcFltSema =
-      CmpRHS.getType()->getScalarType()->getFltSemantics();
+      C.getType()->getScalarType()->getFltSemantics();
 
   // 'MidValue' might be rounded to 'NextCValue'. Correct it here.
   APFloat MidValue = ConvertFltSema(ExtMidValue, SrcFltSema);
@@ -8858,16 +8848,10 @@ Instruction *InstCombinerImpl::visitFCmpInst(FCmpInst &I) {
     }
   }
 
-  Instruction *LHSI;
-  // Handle fcmp with fptrunc LHS
-  if (match(Op0, m_Instruction(LHSI)) &&
-      LHSI->getOpcode() == Instruction::FPTrunc)
-    if (Instruction *NV = foldFCmpFpTrunc(I, *LHSI, *Op1))
-      return NV;
-
   // Handle fcmp with instruction LHS and constant RHS.
+  Instruction *LHSI;
   Constant *RHSC;
-  if (LHSI && match(Op1, m_Constant(RHSC))) {
+  if (match(Op0, m_Instruction(LHSI)) && match(Op1, m_Constant(RHSC))) {
     switch (LHSI->getOpcode()) {
     case Instruction::Select:
       // fcmp eq (cond ? x : -x), 0 --> fcmp eq x, 0
@@ -8901,6 +8885,10 @@ Instruction *InstCombinerImpl::visitFCmpInst(FCmpInst &I) {
                 foldCmpLoadFromIndexedGlobal(cast<LoadInst>(LHSI), GEP, I))
           return Res;
       break;
+    case Instruction::FPTrunc:
+      if (Instruction *NV = foldFCmpFpTrunc(I, *LHSI, *RHSC))
+        return NV;
+      break;
     }
   }
 
@@ -8928,6 +8916,12 @@ Instruction *InstCombinerImpl::visitFCmpInst(FCmpInst &I) {
   // fcmp X, (fadd Y, 0.0) --> fcmp X, Y
   if (match(Op1, m_FAdd(m_Value(Y), m_AnyZeroFP())))
     return new FCmpInst(Pred, Op0, Y, "", &I);
+
+  // fcmp ord/uno (fptrunc X), (fptrunc Y) -> fcmp ord/uno X, Y
+  if ((Pred == FCmpInst::FCMP_ORD || Pred == FCmpInst::FCMP_UNO) &&
+      match(Op0, m_Trunc(m_Value(X))) && match(Op0, m_Trunc(m_Value(Y))) &&
+      X->getType() == Y->getType())
+    return new FCmpInst(Pred, X, Y, "", &I);
 
   if (match(Op0, m_FPExt(m_Value(X)))) {
     // fcmp (fpext X), (fpext Y) -> fcmp X, Y

--- a/llvm/lib/Transforms/InstCombine/InstCombineCompares.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCompares.cpp
@@ -8291,11 +8291,11 @@ static Instruction *foldFCmpReciprocalAndZero(FCmpInst &I, Instruction *LHSI,
 
 // Transform 'fptrunc(x) cmp C' to 'x cmp ext(C)' if possible.
 // Patterns include:
-//    fptrunc(x) <  C                -->  x <  ext(C)
-//    fptrunc(x) <= C                -->  x <= ext(C)
-//    fptrunc(x) >  C                -->  x >  ext(C)
-//    fptrunc(x) >= C                -->  x >= ext(C)
-//    fptrunc(x) ord/uno C           -->  x ord/uno 0
+//    fptrunc(x) <  C       -->  x <  ext(C)
+//    fptrunc(x) <= C       -->  x <= ext(C)
+//    fptrunc(x) >  C       -->  x >  ext(C)
+//    fptrunc(x) >= C       -->  x >= ext(C)
+//    fptrunc(x) ord/uno C  -->  x ord/uno 0
 // where 'ext(C)' is the extension of 'C' to the type of 'x' with a small bias
 // due to precision loss.
 static Instruction *foldFCmpFpTrunc(FCmpInst &I, const Instruction &FPTrunc,

--- a/llvm/lib/Transforms/InstCombine/InstCombineCompares.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCompares.cpp
@@ -8290,15 +8290,43 @@ static Instruction *foldFCmpReciprocalAndZero(FCmpInst &I, Instruction *LHSI,
 
 // Transform 'fptrunc(x) cmp C' to 'x cmp ext(C)' if possible.
 // Patterns include:
-//    fptrunc(x) <  C  -->  x <  ext(C)
-//    fptrunc(x) <= C  -->  x <= ext(C)
-//    fptrunc(x) >  C  -->  x >  ext(C)
-//    fptrunc(x) >= C  -->  x >= ext(C)
+//    fptrunc(x) <  C                -->  x <  ext(C)
+//    fptrunc(x) <= C                -->  x <= ext(C)
+//    fptrunc(x) >  C                -->  x >  ext(C)
+//    fptrunc(x) >= C                -->  x >= ext(C)
+//    fptrunc(x) ord/uno C           -->  x ord/uno 0
+//    fptrunc(x) ord/uno fptrunc(y)  -->  x ord/uno y
 // where 'ext(C)' is the extension of 'C' to the type of 'x' with a small bias
 // due to precision loss.
 static Instruction *foldFCmpFpTrunc(FCmpInst &I, const Instruction &FPTrunc,
-                                    const Constant &C) {
+                                    const Value &CmpRHS) {
   FCmpInst::Predicate Pred = I.getPredicate();
+  Type *DestType = FPTrunc.getOperand(0)->getType();
+
+  // Handle ord/uno [C | fptrunc(y)]
+  if (Pred == FCmpInst::FCMP_ORD || Pred == FCmpInst::FCMP_UNO) {
+    Value *RHS;
+    const APFloat *CValue;
+    if (match(&CmpRHS, m_FPTrunc(m_Value(RHS)))) {
+      if (DestType != RHS->getType())
+        return nullptr;
+    } else if (match(&CmpRHS, m_APFloat(CValue))) {
+      assert(!CValue->isNaN() &&
+             "NaN RHS should be folded away by simplifyFCmpInst()");
+      RHS = ConstantFP::getZero(DestType);
+    } else {
+      return nullptr;
+    }
+
+    return new FCmpInst(Pred, FPTrunc.getOperand(0), RHS, "", &I);
+  }
+
+  // Handle <, >, <=, >=
+  const APFloat *CValue;
+  // TODO: support vec
+  if (!match(&CmpRHS, m_APFloat(CValue)))
+    return nullptr;
+
   bool RoundDown = false;
 
   if (Pred == FCmpInst::FCMP_OGE || Pred == FCmpInst::FCMP_UGE ||
@@ -8308,10 +8336,6 @@ static Instruction *foldFCmpFpTrunc(FCmpInst &I, const Instruction &FPTrunc,
            Pred == FCmpInst::FCMP_OLE || Pred == FCmpInst::FCMP_ULE)
     RoundDown = false;
   else
-    return nullptr;
-
-  const APFloat *CValue;
-  if (!match(&C, m_APFloat(CValue)))
     return nullptr;
 
   if (CValue->isNaN() || CValue->isInfinity())
@@ -8332,7 +8356,6 @@ static Instruction *foldFCmpFpTrunc(FCmpInst &I, const Instruction &FPTrunc,
 
   APFloat NextCValue = NextValue(*CValue, RoundDown);
 
-  Type *DestType = FPTrunc.getOperand(0)->getType();
   const fltSemantics &DestFltSema =
       DestType->getScalarType()->getFltSemantics();
 
@@ -8354,7 +8377,7 @@ static Instruction *foldFCmpFpTrunc(FCmpInst &I, const Instruction &FPTrunc,
       scalbn(ExtCValue + ExtNextCValue, -1, APFloat::rmNearestTiesToEven);
 
   const fltSemantics &SrcFltSema =
-      C.getType()->getScalarType()->getFltSemantics();
+      CmpRHS.getType()->getScalarType()->getFltSemantics();
 
   // 'MidValue' might be rounded to 'NextCValue'. Correct it here.
   APFloat MidValue = ConvertFltSema(ExtMidValue, SrcFltSema);
@@ -8835,10 +8858,16 @@ Instruction *InstCombinerImpl::visitFCmpInst(FCmpInst &I) {
     }
   }
 
-  // Handle fcmp with instruction LHS and constant RHS.
   Instruction *LHSI;
+  // Handle fcmp with fptrunc LHS
+  if (match(Op0, m_Instruction(LHSI)) &&
+      LHSI->getOpcode() == Instruction::FPTrunc)
+    if (Instruction *NV = foldFCmpFpTrunc(I, *LHSI, *Op1))
+      return NV;
+
+  // Handle fcmp with instruction LHS and constant RHS.
   Constant *RHSC;
-  if (match(Op0, m_Instruction(LHSI)) && match(Op1, m_Constant(RHSC))) {
+  if (LHSI && match(Op1, m_Constant(RHSC))) {
     switch (LHSI->getOpcode()) {
     case Instruction::Select:
       // fcmp eq (cond ? x : -x), 0 --> fcmp eq x, 0
@@ -8871,10 +8900,6 @@ Instruction *InstCombinerImpl::visitFCmpInst(FCmpInst &I) {
         if (Instruction *Res =
                 foldCmpLoadFromIndexedGlobal(cast<LoadInst>(LHSI), GEP, I))
           return Res;
-      break;
-    case Instruction::FPTrunc:
-      if (Instruction *NV = foldFCmpFpTrunc(I, *LHSI, *RHSC))
-        return NV;
       break;
     }
   }

--- a/llvm/test/Transforms/InstCombine/fold-fcmp-trunc.ll
+++ b/llvm/test/Transforms/InstCombine/fold-fcmp-trunc.ll
@@ -716,3 +716,4 @@ define i1 @fcmp_trunc_mn_ppc_fp128(ppc_fp128 %0) {
   %result = fcmp uge float %trunc, 0xC7EFFFFF00000000
   ret i1 %result
 }
+

--- a/llvm/test/Transforms/InstCombine/fold-fcmp-trunc.ll
+++ b/llvm/test/Transforms/InstCombine/fold-fcmp-trunc.ll
@@ -60,8 +60,7 @@ define i1 @fcmp_trunc_zero(double %0) {
 define i1 @fcmp_trunc_uno(double %0) {
 ; CHECK-LABEL: define i1 @fcmp_trunc_uno(
 ; CHECK-SAME: double [[TMP0:%.*]]) {
-; CHECK-NEXT:    [[TRUNC:%.*]] = fptrunc double [[TMP0]] to float
-; CHECK-NEXT:    [[RESULT:%.*]] = fcmp uno float [[TRUNC]], 0.000000e+00
+; CHECK-NEXT:    [[RESULT:%.*]] = fcmp uno double [[TMP0]], 0.000000e+00
 ; CHECK-NEXT:    ret i1 [[RESULT]]
 ;
   %trunc = fptrunc double %0 to float
@@ -72,8 +71,7 @@ define i1 @fcmp_trunc_uno(double %0) {
 define i1 @fcmp_trunc_ord_inf(double %0) {
 ; CHECK-LABEL: define i1 @fcmp_trunc_ord_inf(
 ; CHECK-SAME: double [[TMP0:%.*]]) {
-; CHECK-NEXT:    [[TRUNC:%.*]] = fptrunc double [[TMP0]] to float
-; CHECK-NEXT:    [[RESULT:%.*]] = fcmp ord float [[TRUNC]], 0.000000e+00
+; CHECK-NEXT:    [[RESULT:%.*]] = fcmp ord double [[TMP0]], 0.000000e+00
 ; CHECK-NEXT:    ret i1 [[RESULT]]
 ;
   %trunc = fptrunc double %0 to float
@@ -84,9 +82,7 @@ define i1 @fcmp_trunc_ord_inf(double %0) {
 define i1 @fcmp_trunc_pair_uno(double %x, double %y) {
 ; CHECK-LABEL: define i1 @fcmp_trunc_pair_uno(
 ; CHECK-SAME: double [[X:%.*]], double [[Y:%.*]]) {
-; CHECK-NEXT:    [[TX:%.*]] = fptrunc double [[X]] to float
-; CHECK-NEXT:    [[TY:%.*]] = fptrunc double [[Y]] to float
-; CHECK-NEXT:    [[RESULT:%.*]] = fcmp uno float [[TX]], [[TY]]
+; CHECK-NEXT:    [[RESULT:%.*]] = fcmp uno double [[X]], [[Y]]
 ; CHECK-NEXT:    ret i1 [[RESULT]]
 ;
   %tx = fptrunc double %x to float
@@ -98,9 +94,7 @@ define i1 @fcmp_trunc_pair_uno(double %x, double %y) {
 define i1 @fcmp_trunc_pair_ord(double %x, double %y) {
 ; CHECK-LABEL: define i1 @fcmp_trunc_pair_ord(
 ; CHECK-SAME: double [[X:%.*]], double [[Y:%.*]]) {
-; CHECK-NEXT:    [[TX:%.*]] = fptrunc double [[X]] to float
-; CHECK-NEXT:    [[TY:%.*]] = fptrunc double [[Y]] to float
-; CHECK-NEXT:    [[RESULT:%.*]] = fcmp ord float [[TX]], [[TY]]
+; CHECK-NEXT:    [[RESULT:%.*]] = fcmp ord double [[X]], [[Y]]
 ; CHECK-NEXT:    ret i1 [[RESULT]]
 ;
   %tx = fptrunc double %x to float
@@ -379,8 +373,7 @@ define i1 @fcmp_trunc_literal_positive_inf(double %0) {
 define i1 @fcmp_trunc_literal_negative_inf(double %0) {
 ; CHECK-LABEL: define i1 @fcmp_trunc_literal_negative_inf(
 ; CHECK-SAME: double [[TMP0:%.*]]) {
-; CHECK-NEXT:    [[TRUNC:%.*]] = fptrunc double [[TMP0]] to float
-; CHECK-NEXT:    [[RESULT:%.*]] = fcmp uno float [[TRUNC]], 0.000000e+00
+; CHECK-NEXT:    [[RESULT:%.*]] = fcmp uno double [[TMP0]], 0.000000e+00
 ; CHECK-NEXT:    ret i1 [[RESULT]]
 ;
   %trunc = fptrunc double %0 to float
@@ -723,4 +716,3 @@ define i1 @fcmp_trunc_mn_ppc_fp128(ppc_fp128 %0) {
   %result = fcmp uge float %trunc, 0xC7EFFFFF00000000
   ret i1 %result
 }
-

--- a/llvm/test/Transforms/InstCombine/fold-fcmp-trunc.ll
+++ b/llvm/test/Transforms/InstCombine/fold-fcmp-trunc.ll
@@ -57,6 +57,58 @@ define i1 @fcmp_trunc_zero(double %0) {
   ret i1 %result
 }
 
+define i1 @fcmp_trunc_uno(double %0) {
+; CHECK-LABEL: define i1 @fcmp_trunc_uno(
+; CHECK-SAME: double [[TMP0:%.*]]) {
+; CHECK-NEXT:    [[TRUNC:%.*]] = fptrunc double [[TMP0]] to float
+; CHECK-NEXT:    [[RESULT:%.*]] = fcmp uno float [[TRUNC]], 0.000000e+00
+; CHECK-NEXT:    ret i1 [[RESULT]]
+;
+  %trunc = fptrunc double %0 to float
+  %result = fcmp uno float %trunc, 0.000000e+00
+  ret i1 %result
+}
+
+define i1 @fcmp_trunc_ord_inf(double %0) {
+; CHECK-LABEL: define i1 @fcmp_trunc_ord_inf(
+; CHECK-SAME: double [[TMP0:%.*]]) {
+; CHECK-NEXT:    [[TRUNC:%.*]] = fptrunc double [[TMP0]] to float
+; CHECK-NEXT:    [[RESULT:%.*]] = fcmp ord float [[TRUNC]], 0.000000e+00
+; CHECK-NEXT:    ret i1 [[RESULT]]
+;
+  %trunc = fptrunc double %0 to float
+  %result = fcmp ord float %trunc, 0x7FF0000000000000
+  ret i1 %result
+}
+
+define i1 @fcmp_trunc_pair_uno(double %x, double %y) {
+; CHECK-LABEL: define i1 @fcmp_trunc_pair_uno(
+; CHECK-SAME: double [[X:%.*]], double [[Y:%.*]]) {
+; CHECK-NEXT:    [[TX:%.*]] = fptrunc double [[X]] to float
+; CHECK-NEXT:    [[TY:%.*]] = fptrunc double [[Y]] to float
+; CHECK-NEXT:    [[RESULT:%.*]] = fcmp uno float [[TX]], [[TY]]
+; CHECK-NEXT:    ret i1 [[RESULT]]
+;
+  %tx = fptrunc double %x to float
+  %ty = fptrunc double %y to float
+  %result = fcmp uno float %tx, %ty
+  ret i1 %result
+}
+
+define i1 @fcmp_trunc_pair_ord(double %x, double %y) {
+; CHECK-LABEL: define i1 @fcmp_trunc_pair_ord(
+; CHECK-SAME: double [[X:%.*]], double [[Y:%.*]]) {
+; CHECK-NEXT:    [[TX:%.*]] = fptrunc double [[X]] to float
+; CHECK-NEXT:    [[TY:%.*]] = fptrunc double [[Y]] to float
+; CHECK-NEXT:    [[RESULT:%.*]] = fcmp ord float [[TX]], [[TY]]
+; CHECK-NEXT:    ret i1 [[RESULT]]
+;
+  %tx = fptrunc double %x to float
+  %ty = fptrunc double %y to float
+  %result = fcmp ord float %tx, %ty
+  ret i1 %result
+}
+
 define i1 @fcmp_trunc_with_nnan(double %0) {
 ; CHECK-LABEL: define i1 @fcmp_trunc_with_nnan(
 ; CHECK-SAME: double [[TMP0:%.*]]) {
@@ -104,7 +156,7 @@ define i1 @fcmp_trunc_with_reassoc(double %0) {
 define i1 @fcmp_trunc_with_fast(double %0) {
 ; CHECK-LABEL: define i1 @fcmp_trunc_with_fast(
 ; CHECK-SAME: double [[TMP0:%.*]]) {
-; CHECK-NEXT:    [[RESULT:%.*]] = fcmp fast oge double [[TMP0]], 0x4058FFFFF0000000 
+; CHECK-NEXT:    [[RESULT:%.*]] = fcmp fast oge double [[TMP0]], 0x4058FFFFF0000000
 ; CHECK-NEXT:    ret i1 [[RESULT]]
 ;
   %trunc = fptrunc double %0 to float

--- a/llvm/test/Transforms/InstCombine/known-never-nan.ll
+++ b/llvm/test/Transforms/InstCombine/known-never-nan.ll
@@ -150,8 +150,7 @@ define i1 @fpext_maybe_nan(float %arg0) {
 
 define i1 @fptrunc_maybe_nan(double %arg0) {
 ; CHECK-LABEL: @fptrunc_maybe_nan(
-; CHECK-NEXT:    [[OP:%.*]] = fptrunc double [[ARG0:%.*]] to float
-; CHECK-NEXT:    [[TMP:%.*]] = fcmp ord float [[OP]], 0.000000e+00
+; CHECK-NEXT:    [[TMP:%.*]] = fcmp ord double [[ARG0:%.*]], 0.000000e+00
 ; CHECK-NEXT:    ret i1 [[TMP]]
 ;
   %op = fptrunc double %arg0 to float


### PR DESCRIPTION
Recognize TWO new patterns and fold them as follows:
```
fptrunc(x) ord/uno C           -->  x ord/uno 0
fptrunc(x) ord/uno fptrunc(y)  -->  x ord/uno y
```

Fixes #185698
Alive2: https://alive2.llvm.org/ce/z/YvXnBJ
IR diff: https://github.com/dtcxzyw/llvm-opt-benchmark/pull/3551
CompTime impact: https://github.com/dtcxzyw/llvm-opt-benchmark/pull/3552