### PR TITLE
[TableGen] Fix MUL case in DAG default operands test

### DIFF
--- a/llvm/test/TableGen/DAGDefaultOps.td
+++ b/llvm/test/TableGen/DAGDefaultOps.td
@@ -3,6 +3,7 @@
 // RUN: FileCheck --check-prefix=ADDINT %s < %t
 // RUN: FileCheck --check-prefix=SUB %s < %t
 // RUN: FileCheck --check-prefix=MULINT %s < %t
+// RUN: FileCheck --check-prefix=MUL %s < %t
 
 include "llvm/Target/Target.td"
 
@@ -102,7 +103,7 @@ def MulIRRPat : Pat<(mul i32:$x, i32:$y), (MulIRR Reg:$x, Reg:$y)>;
 // MULINT-NEXT: OPC_MorphNodeTo1Chain, TARGET_VAL(::MulRRI)
 
 // MUL: SwitchOpcode{{.*}}TARGET_VAL(ISD::MUL)
-// MUL-NEXT: OPC_EmitIntegerI32, 0
 // MUL-NEXT: OPC_RecordChild0
 // MUL-NEXT: OPC_RecordChild1
-// MUL-NEXT: OPC_MorphNodeTo1Chain, TARGET_VAL(::MulRRI)
+// MUL-NEXT: OPC_EmitIntegerI32, 0
+// MUL-NEXT: OPC_MorphNodeTo1None, TARGET_VAL(::MulIRR)


### PR DESCRIPTION
The checks have been unused forever. This was an oversight in the patch that introduced this test: https://reviews.llvm.org/D63814

Also fix the checks to match the actual output. This looks like another oversight in the original patch, presumably because the checks were never actually tested.