### PR TITLE
[flang][OpenMP] Prevent attaching implicit mapper to data motion clause

### DIFF
--- a/flang/lib/Lower/OpenMP/ClauseProcessor.cpp
+++ b/flang/lib/Lower/OpenMP/ClauseProcessor.cpp
@@ -1770,10 +1770,11 @@ bool ClauseProcessor::processMap(
     // For data-motion directives we avoid auto-attaching implicit default
     // mappers. Deep recursive mapping there can conflict with explicit
     // component enter/exit maps users commonly spell out.
-    std::string mapperIdName = "__implicit_mapper";
-    if (directive == llvm::omp::Directive::OMPD_target_enter_data ||
-        directive == llvm::omp::Directive::OMPD_target_exit_data ||
-        directive == llvm::omp::Directive::OMPD_target_update)
+    std::string mapperIdName = getMapperIdentifier(converter, mappers);
+    if ((directive == llvm::omp::Directive::OMPD_target_enter_data ||
+         directive == llvm::omp::Directive::OMPD_target_exit_data ||
+         directive == llvm::omp::Directive::OMPD_target_update) &&
+        mapperIdName == "__implicit_mapper")
       mapperIdName.clear();
     // If the map type is specified, then process it else set the appropriate
     // default value
@@ -1821,8 +1822,6 @@ bool ClauseProcessor::processMap(
       TODO(currentLocation,
            "Support for iterator modifiers is not implemented yet");
     }
-    mapperIdName = getMapperIdentifier(converter, mappers);
-
     processMapObjects(stmtCtx, clauseLocation,
                       std::get<omp::ObjectList>(clause.t), mapTypeBits,
                       parentMemberIndices, result.mapVars, *ptrMapSyms,
@@ -1854,6 +1853,8 @@ bool ClauseProcessor::processMotionClauses(lower::StatementContext &stmtCtx,
 
     // Support motion modifiers: mapper, iterator.
     std::string mapperIdName = getMapperIdentifier(converter, mapper);
+    if (mapperIdName == "__implicit_mapper")
+      mapperIdName.clear();
     if (iterator) {
       TODO(clauseLocation, "Iterator modifier is not supported yet");
     }

--- a/flang/test/Lower/OpenMP/target-motion-skip-implicit-mapper.f90
+++ b/flang/test/Lower/OpenMP/target-motion-skip-implicit-mapper.f90
@@ -1,0 +1,30 @@
+! RUN: bbc -emit-hlfir -fopenmp -fopenmp-version=52 %s -o - | FileCheck %s
+
+module m
+  type :: t
+    integer :: a
+  end type
+  !$omp declare mapper(t :: v) map(v%a)
+contains
+  subroutine test_motion(x)
+    type(t) :: x
+
+    !$omp target enter data map(to: x)
+    !$omp target update to(x)
+    !$omp target update from(x)
+    !$omp target update to(mapper(default): x)
+    !$omp target exit data map(from: x)
+  end subroutine test_motion
+end module m
+
+! CHECK-LABEL: func.func @_QMmPtest_motion(
+! CHECK: %[[ENTER:.*]] = omp.map.info {{.*}} map_clauses(to) capture(ByRef) -> {{.*}} {name = "x"}
+! CHECK: omp.target_enter_data map_entries(%[[ENTER]]
+! CHECK: %[[UPTO:.*]] = omp.map.info {{.*}} map_clauses(to) capture(ByRef) -> {{.*}} {name = "x"}
+! CHECK: omp.target_update map_entries(%[[UPTO]]
+! CHECK: %[[UPFROM:.*]] = omp.map.info {{.*}} map_clauses(from) capture(ByRef) -> {{.*}} {name = "x"}
+! CHECK: omp.target_update map_entries(%[[UPFROM]]
+! CHECK: %[[UPDEFAULT:.*]] = omp.map.info {{.*}} map_clauses(to) capture(ByRef) mapper(@{{.*}}t_omp_default_mapper) -> {{.*}} {name = "x"}
+! CHECK: omp.target_update map_entries(%[[UPDEFAULT]]
+! CHECK: %[[EXIT:.*]] = omp.map.info {{.*}} map_clauses(from) capture(ByRef) -> {{.*}} {name = "x"}
+! CHECK: omp.target_exit_data map_entries(%[[EXIT]]


### PR DESCRIPTION
Further prevent corner cases of implicit declare mapper getting attached to data motion clauses like target enter/exit data.