### PR TITLE
[libc++] Install build-essential in the CI docker container

### DIFF
--- a/libcxx/utils/ci/docker/linux-builder-base.dockerfile
+++ b/libcxx/utils/ci/docker/linux-builder-base.dockerfile
@@ -51,6 +51,7 @@ RUN sudo apt-get update \
 RUN sudo apt-get update \
     && sudo apt-get install -y \
         bash \
+        build-essential \
         bzip2 \
         ccache \
         curl \


### PR DESCRIPTION
We don't install a compiler via `apt` anymore, so we need to explicitly install the utilities required to build stuff.
