### PR TITLE
[BOLT] Spawn buildid-list perf job at perf2bolt start. NFC

### DIFF
--- a/bolt/include/bolt/Profile/DataAggregator.h
+++ b/bolt/include/bolt/Profile/DataAggregator.h
@@ -163,6 +163,7 @@ private:
   };
 
   /// Process info for spawned processes
+  PerfProcessInfo BuildIDProcessInfo;
   PerfProcessInfo MainEventsPPI;
   PerfProcessInfo MemEventsPPI;
   PerfProcessInfo MMapEventsPPI;

--- a/bolt/lib/Profile/DataAggregator.cpp
+++ b/bolt/lib/Profile/DataAggregator.cpp
@@ -233,6 +233,8 @@ void DataAggregator::start() {
 
   launchPerfProcess("task events", TaskEventsPPI,
                     "script --show-task-events --no-itrace");
+
+  launchPerfProcess("buildid list", BuildIDProcessInfo, "buildid-list");
 }
 
 void DataAggregator::abort() {
@@ -303,8 +305,6 @@ void DataAggregator::processFileBuildID(StringRef FileBuildID) {
     errs() << "PERF-ERROR: return code " << ReturnCode << "\n" << ErrBuf;
   };
 
-  PerfProcessInfo BuildIDProcessInfo;
-  launchPerfProcess("buildid list", BuildIDProcessInfo, "buildid-list");
   if (prepareToParse("buildid", BuildIDProcessInfo, WarningCallback))
     return;
 


### PR DESCRIPTION
Launch this perf job with the others at the beginning of the aggregation process.

Extracting buildid-list from perf data is not a costly process, so it can be performed by default. This provides a distinct advantage when this dataset is required in other perf2bolt stages as well.

Please see #171144.