### PR TITLE
libclc: Add frexp_exp utility function

### DIFF
--- a/libclc/clc/include/clc/math/clc_frexp_exp.h
+++ b/libclc/clc/include/clc/math/clc_frexp_exp.h
@@ -1,0 +1,22 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Convenience function which returns the out argument value of frexp.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef __CLC_MATH_CLC_FREXP_EXP_H__
+#define __CLC_MATH_CLC_FREXP_EXP_H__
+
+#define __CLC_FUNCTION __clc_frexp_exp
+#define __CLC_BODY "clc/math/unary_decl_with_int_return.inc"
+#include "clc/math/gentype.inc"
+
+#undef __CLC_FUNCTION
+
+#endif // __CLC_MATH_CLC_FREXP_EXP_H__

--- a/libclc/clc/include/clc/shared/unary_decl_with_int_return.inc
+++ b/libclc/clc/include/clc/shared/unary_decl_with_int_return.inc
@@ -1,0 +1,9 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+_CLC_OVERLOAD _CLC_CONST _CLC_DECL __CLC_INTN __CLC_FUNCTION(__CLC_GENTYPE x);

--- a/libclc/clc/lib/generic/CMakeLists.txt
+++ b/libclc/clc/lib/generic/CMakeLists.txt
@@ -91,6 +91,7 @@ libclc_configure_source_list(CLC_GENERIC_SOURCES
   math/clc_fmod.cl
   math/clc_fract.cl
   math/clc_frexp.cl
+  math/clc_frexp_exp.cl
   math/clc_half_cos.cl
   math/clc_half_divide.cl
   math/clc_half_exp.cl

--- a/libclc/clc/lib/generic/math/clc_frexp_exp.cl
+++ b/libclc/clc/lib/generic/math/clc_frexp_exp.cl
@@ -1,0 +1,13 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "clc/math/clc_frexp.h"
+#include "clc/math/clc_frexp_exp.h"
+
+#define __CLC_BODY "clc_frexp_exp.inc"
+#include "clc/math/gentype.inc"

--- a/libclc/clc/lib/generic/math/clc_frexp_exp.inc
+++ b/libclc/clc/lib/generic/math/clc_frexp_exp.inc
@@ -1,0 +1,13 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+_CLC_DEF _CLC_OVERLOAD __CLC_INTN __clc_frexp_exp(__CLC_GENTYPE x) {
+  __CLC_INTN e;
+  (void)__clc_frexp(x, &e);
+  return e;
+}


### PR DESCRIPTION
Many functions want to extract the exponent and
currently rely on bithacking to do it. These can be
better handled with frexp. AMDGPU has a dedicated
instruction for each of the frexp return values. Other
targets could override this to do the bithacking (though
they would be better off teaching codegen to optimize
frexp with a discarded output).