### PR TITLE
[clang][lit] Fix spirv-tools-err.c when LIT_USE_INTERNAL_SHELL=0

### DIFF
--- a/clang/test/Driver/spirv-tools-err.c
+++ b/clang/test/Driver/spirv-tools-err.c
@@ -5,7 +5,7 @@
 
 // REQUIRES: spirv-registered-target
 
-// RUN: env PATH='' not %clang -o /dev/null --target=spirv64 --save-temps -v %s 2>&1 | FileCheck %s
+// RUN: not env PATH='' %clang -o /dev/null --target=spirv64 --save-temps -v %s 2>&1 | FileCheck %s
 
 // CHECK: error: cannot find SPIR-V Tools binary 'spirv-as'
 // CHECK: error: cannot find SPIR-V Tools binary 'spirv-link'


### PR DESCRIPTION
Only the internal shell parser is able to process an operator in the middle of a command. For the other shells, the operator must appear in the beginning of the line.