### PR TITLE
libclc: Update logb implementation

### DIFF
--- a/libclc/clc/lib/generic/math/clc_logb.cl
+++ b/libclc/clc/lib/generic/math/clc_logb.cl
@@ -6,11 +6,15 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <clc/clc_convert.h>
-#include <clc/float/definitions.h>
-#include <clc/integer/clc_clz.h>
-#include <clc/internal/clc.h>
-#include <clc/math/math.h>
+#include "clc/clc_convert.h"
+#include "clc/float/definitions.h"
+#include "clc/integer/clc_clz.h"
+#include "clc/internal/clc.h"
+#include "clc/math/clc_fabs.h"
+#include "clc/math/clc_frexp_exp.h"
+#include "clc/math/math.h"
+#include "clc/relational/clc_isfinite.h"
+#include "clc/relational/clc_select.h"
 
 #define __CLC_BODY <clc_logb.inc>
 #include <clc/math/gentype.inc>

--- a/libclc/clc/lib/generic/math/clc_logb.inc
+++ b/libclc/clc/lib/generic/math/clc_logb.inc
@@ -6,49 +6,15 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if __CLC_FPSIZE == 32
+_CLC_OVERLOAD _CLC_CONST _CLC_DEF __CLC_GENTYPE __clc_logb(__CLC_GENTYPE x) {
+  __CLC_GENTYPE ret = __CLC_CONVERT_GENTYPE(__clc_frexp_exp(x) - (__CLC_INTN)1);
 
-_CLC_OVERLOAD _CLC_DEF __CLC_GENTYPE __clc_logb(__CLC_GENTYPE x) {
-  __CLC_INTN ax = __CLC_AS_INTN(x) & EXSIGNBIT_SP32;
-  __CLC_GENTYPE s = __CLC_CONVERT_GENTYPE(LOG_MAGIC_NUM_SP32 - __clc_clz(ax));
-  __CLC_GENTYPE r =
-      __CLC_CONVERT_GENTYPE((ax >> EXPSHIFTBITS_SP32) - EXPBIAS_SP32);
-  r = ax >= PINFBITPATT_SP32 ? __CLC_AS_GENTYPE(ax) : r;
-  r = ax < 0x00800000 ? s : r;
-  r = ax == 0 ? __CLC_AS_GENTYPE((__CLC_INTN)NINFBITPATT_SP32) : r;
-  return r;
+  __CLC_GENTYPE ax = __clc_fabs(x);
+
+  ret = __clc_select(ax, ret, __CLC_CONVERT_U_GENTYPE(__clc_isfinite(ax)));
+
+  ret = __clc_select(ret, -__CLC_GENTYPE_INF,
+                     __CLC_CONVERT_U_GENTYPE(x == __CLC_FP_LIT(0.0)));
+
+  return ret;
 }
-
-#endif
-
-#if __CLC_FPSIZE == 64
-
-_CLC_OVERLOAD _CLC_DEF __CLC_GENTYPE __clc_logb(__CLC_GENTYPE x) {
-  __CLC_LONGN ax = __CLC_AS_LONGN(x) & EXSIGNBIT_DP64;
-  __CLC_GENTYPE s = __CLC_CONVERT_GENTYPE(LOG_MAGIC_NUM_DP64 - __clc_clz(ax));
-  __CLC_GENTYPE r =
-      __CLC_CONVERT_GENTYPE((ax >> EXPSHIFTBITS_DP64) - EXPBIAS_DP64);
-  r = ax >= PINFBITPATT_DP64 ? __CLC_AS_GENTYPE(ax) : r;
-  r = ax < 0x0010000000000000L ? s : r;
-  r = ax == 0L ? __CLC_AS_GENTYPE((__CLC_LONGN)NINFBITPATT_DP64) : r;
-  return r;
-}
-
-#endif
-
-#if __CLC_FPSIZE == 16
-
-_CLC_OVERLOAD _CLC_DEF __CLC_GENTYPE __clc_logb(__CLC_GENTYPE x) {
-  __CLC_SHORTN ax = __CLC_AS_SHORTN(x) & (__CLC_SHORTN)EXSIGNBIT_FP16;
-  __CLC_GENTYPE s = __CLC_CONVERT_GENTYPE((__CLC_SHORTN)LOG_MAGIC_NUM_FP16 -
-                                          (__CLC_SHORTN)__clc_clz(ax));
-  __CLC_GENTYPE r = __CLC_CONVERT_GENTYPE(
-      (ax >> (__CLC_SHORTN)EXPSHIFTBITS_FP16) - (__CLC_SHORTN)EXPBIAS_FP16);
-  r = ax >= (__CLC_SHORTN)PINFBITPATT_FP16 ? __CLC_AS_GENTYPE(ax) : r;
-  r = ax < (__CLC_SHORTN)0x0400 ? s : r;
-  r = ax == (__CLC_SHORTN)0 ? __CLC_AS_GENTYPE((__CLC_SHORTN)NINFBITPATT_FP16)
-                            : r;
-  return r;
-}
-
-#endif


### PR DESCRIPTION
Similar to the previous logb change, use a common
bithacking free implementation.