### PR TITLE
[mlir][spirv] Add first 7 elementwise unary ops in TOSA Ext Inst Set

### DIFF
--- a/mlir/include/mlir/Dialect/SPIRV/IR/SPIRVTosaOps.td
+++ b/mlir/include/mlir/Dialect/SPIRV/IR/SPIRVTosaOps.td
@@ -62,6 +62,34 @@ class SPIRV_TosaOpWithComplexResult<string mnemonic, int opcode, list<Trait> tra
   }];
 }
 
+class SPIRV_TosaElementwiseUnaryOp<string mnemonic, int opcode, list<Trait> traits = []> :
+  SPIRV_TosaOpWithResult<mnemonic, opcode, !listconcat(traits,
+    [AllTypesMatch<["input1", "output"]>])> {
+
+  let extraClassDeclaration = extraBaseClassDeclaration#[{
+    ::mlir::spirv::TensorArmType getInput1Type() {
+      return cast<::mlir::spirv::TensorArmType>(getInput1().getType());
+    }
+  }];
+}
+
+class SPIRV_TosaFloatElementwiseUnaryOp<string mnemonic, int opcode, list<Trait> traits = []> :
+  SPIRV_TosaElementwiseUnaryOp<mnemonic, opcode, !listconcat(traits, [Pure])> {
+
+  let arguments = (ins
+    SPIRV_TosaFloat_TensorArm: $input1
+  );
+
+  let results = (outs
+    SPIRV_TosaFloat_TensorArm: $output
+  );
+
+  let assemblyFormat = [{
+    $input1
+    attr-dict `:` type(operands) `->` type(results)
+  }];
+}
+
 class SPIRV_TosaBinaryOp<string mnemonic, int opcode, list<Trait> traits = []> :
   SPIRV_TosaOpWithResult<mnemonic, opcode, !listconcat(traits, [
     AllElementTypesMatch<["input1", "input2"]>,
@@ -1479,6 +1507,174 @@ def SPIRV_TosaTableOp : SPIRV_TosaOpWithResult<"Table", 30, [NoMemoryEffect,
     ::mlir::spirv::TensorArmType getInput1Type() {
       return cast<::mlir::spirv::TensorArmType>(getInput1().getType());
     }
+  }];
+}
+
+
+def SPIRV_TosaAbsOp : SPIRV_TosaElementwiseUnaryOp<"Abs", 31, [NoMemoryEffect]> {
+  let summary = "Absolute value operation.";
+
+  let description = [{
+    Elementwise Absolute value operation. Input and Output types must match.
+    Integer element types are always interpreted as signed. The behaviour is
+    undefined if the input value is min_value<si32>.
+
+    References:
+      * https://github.khronos.org/SPIRV-Registry/extended/TOSA.001000.1.html#_abs
+      * https://www.mlplatform.org/tosa/tosa_spec_1_0_1.html#_abs
+
+    #### Example:
+    ```mlir
+    %0 = spirv.Tosa.Abs %arg0 : !spirv.arm.tensor<5x1x4x4xi32> -> !spirv.arm.tensor<5x1x4x4xi32>
+    %0 = spirv.Tosa.Abs %arg0 : !spirv.arm.tensor<3x6x14x8xf16> -> !spirv.arm.tensor<3x6x14x8xf16>
+    ```
+  }];
+
+  let arguments = (ins
+    SPIRV_TosaNumerical_TensorArm: $input1
+  );
+
+  let results = (outs
+    SPIRV_TosaNumerical_TensorArm: $output
+  );
+
+  let assemblyFormat = [{
+    $input1
+    attr-dict `:` type(operands) `->` type(results)
+  }];
+}
+
+
+def SPIRV_TosaBitwiseNotOp : SPIRV_TosaElementwiseUnaryOp<"BitwiseNot", 32, [Pure]> {
+  let summary = "Bitwise NOT operator.";
+
+  let description = [{
+    Elementwise Bitwise NOT of input tensor. Input and Output types must match.
+
+    References:
+      * https://github.khronos.org/SPIRV-Registry/extended/TOSA.001000.1.html#_bitwise_not
+      * https://www.mlplatform.org/tosa/tosa_spec_1_0_1.html#_bitwise_not
+
+    #### Example:
+    ```mlir
+    %0 = spirv.Tosa.BitwiseNot %arg0 : !spirv.arm.tensor<12x56x50xi32> -> !spirv.arm.tensor<12x56x50xi32>
+    ```
+  }];
+
+  let arguments = (ins
+    SPIRV_TosaInteger_TensorArm: $input1
+  );
+
+  let results = (outs
+    SPIRV_TosaInteger_TensorArm: $output
+  );
+
+  let assemblyFormat = [{
+    $input1
+    attr-dict `:` type(operands) `->` type(results)
+  }];
+}
+
+
+def SPIRV_TosaCeilOp : SPIRV_TosaFloatElementwiseUnaryOp<"Ceil", 33> {
+  let summary = "Ceil operator.";
+
+  let description = [{
+    Elementwise Ceiling operation. Input and Output types must match.
+
+    References:
+      * https://github.khronos.org/SPIRV-Registry/extended/TOSA.001000.1.html#_ceil
+      * https://www.mlplatform.org/tosa/tosa_spec_1_0_1.html#_ceil
+
+    #### Example:
+    ```mlir
+    %0 = spirv.Tosa.Ceil %arg0 : !spirv.arm.tensor<46x55x53xf16> -> !spirv.arm.tensor<46x55x53xf16>
+    ```
+  }];
+}
+
+
+def SPIRV_TosaClzOp : SPIRV_TosaElementwiseUnaryOp<"Clz", 34, [Pure]> {
+  let summary = "Count Leading Zero operator.";
+
+  let description = [{
+    Elementwise Count Leading Zeros operation. Input and Output types must match.
+
+    References:
+      * https://github.khronos.org/SPIRV-Registry/extended/TOSA.001000.1.html#_clz
+      * https://www.mlplatform.org/tosa/tosa_spec_1_0_1.html#_clz
+
+    #### Example:
+    ```mlir
+    %0 = spirv.Tosa.Clz %arg0 : !spirv.arm.tensor<14x10x7x5xi32> -> !spirv.arm.tensor<14x10x7x5xi32>
+    ```
+  }];
+
+  let arguments = (ins
+    SPIRV_Int32_TensorArm: $input1
+  );
+
+  let results = (outs
+    SPIRV_Int32_TensorArm: $output
+  );
+
+  let assemblyFormat = [{
+    $input1
+    attr-dict `:` type(operands) `->` type(results)
+  }];
+}
+
+
+def SPIRV_TosaCosOp : SPIRV_TosaFloatElementwiseUnaryOp<"Cos", 35> {
+  let summary = "Cosine operator.";
+
+  let description = [{
+    Elementwise Cosine operation for values given in radians. Input and Output types must match.
+
+    References:
+      * https://github.khronos.org/SPIRV-Registry/extended/TOSA.001000.1.html#_cos
+      * https://www.mlplatform.org/tosa/tosa_spec_1_0_1.html#_cos
+
+    #### Example:
+    ```mlir
+    %0 = spirv.Tosa.Cos %arg0 : !spirv.arm.tensor<44x49x51xf32> -> !spirv.arm.tensor<44x49x51xf32>
+    ```
+  }];
+}
+
+
+def SPIRV_TosaExpOp : SPIRV_TosaFloatElementwiseUnaryOp<"Exp", 36> {
+  let summary = "Exp operator.";
+
+  let description = [{
+    Elementwise e to the power of x operation. Input and Output types must match.
+
+    References:
+      * https://github.khronos.org/SPIRV-Registry/extended/TOSA.001000.1.html#_exp
+      * https://www.mlplatform.org/tosa/tosa_spec_1_0_1.html#_exp
+
+    #### Example:
+    ```mlir
+    %0 = spirv.Tosa.Exp %arg0 : !spirv.arm.tensor<37x53x47xf32> -> !spirv.arm.tensor<37x53x47xf32>
+    ```
+  }];
+}
+
+
+def SPIRV_TosaFloorOp : SPIRV_TosaFloatElementwiseUnaryOp<"Floor", 37> {
+  let summary = "Floor operator.";
+
+  let description = [{
+    Elementwise Floor operation. Input and Output types must match.
+
+    References:
+      * https://github.khronos.org/SPIRV-Registry/extended/TOSA.001000.1.html#_floor
+      * https://www.mlplatform.org/tosa/tosa_spec_1_0_1.html#_floor
+
+    #### Example:
+    ```mlir
+    %0 = spirv.Tosa.Floor %arg0 : !spirv.arm.tensor<40x52x42xf32> -> !spirv.arm.tensor<40x52x42xf32>
+    ```
   }];
 }
 

--- a/mlir/test/Dialect/SPIRV/IR/tosa-ops-verification.mlir
+++ b/mlir/test/Dialect/SPIRV/IR/tosa-ops-verification.mlir
@@ -1206,3 +1206,109 @@ spirv.ARM.Graph @table_input_with_element_type_i16_requires_an_output_with_eleme
   %1 = spirv.Tosa.Table %arg0, %0 : !spirv.arm.tensor<3x2x15x7xi16>, !spirv.arm.tensor<513xi16> -> !spirv.arm.tensor<3x2x15x7xi16>
   spirv.ARM.GraphOutputs %1 : !spirv.arm.tensor<3x2x15x7xi16>
 }
+
+//===----------------------------------------------------------------------===//
+// spirv.TOSA.Abs
+//===----------------------------------------------------------------------===//
+
+spirv.ARM.Graph @abs_input_output_element_types_not_matching(%arg0: !spirv.arm.tensor<3x6x14x8xf16>) -> (!spirv.arm.tensor<3x6x14x8xf32>) {
+  // expected-error @+1 {{op failed to verify that all of {input1, output} have same type}}
+  %0 = spirv.Tosa.Abs %arg0 : !spirv.arm.tensor<3x6x14x8xf16> -> !spirv.arm.tensor<3x6x14x8xf32>
+  spirv.ARM.GraphOutputs %0 : !spirv.arm.tensor<3x6x14x8xf32>
+}
+
+spirv.ARM.Graph @abs_input_output_shapes_not_matching(%arg0: !spirv.arm.tensor<3x6x14x8xf16>) -> (!spirv.arm.tensor<3x6x14x9xf16>) {
+  // expected-error @+1 {{op failed to verify that all of {input1, output} have same type}}
+  %0 = spirv.Tosa.Abs %arg0 : !spirv.arm.tensor<3x6x14x8xf16> -> !spirv.arm.tensor<3x6x14x9xf16>
+  spirv.ARM.GraphOutputs %0 : !spirv.arm.tensor<3x6x14x9xf16>
+}
+
+//===----------------------------------------------------------------------===//
+// spirv.TOSA.BitwiseNot
+//===----------------------------------------------------------------------===//
+
+spirv.ARM.Graph @bitwise_not_input_output_element_types_not_matching(%arg0: !spirv.arm.tensor<12x56x50xi16>) -> (!spirv.arm.tensor<12x56x50xi32>) {
+  // expected-error @+1 {{op failed to verify that all of {input1, output} have same type}}
+  %0 = spirv.Tosa.BitwiseNot %arg0 : !spirv.arm.tensor<12x56x50xi16> -> !spirv.arm.tensor<12x56x50xi32>
+  spirv.ARM.GraphOutputs %0 : !spirv.arm.tensor<12x56x50xi32>
+}
+
+spirv.ARM.Graph @bitwise_not_input_output_shapes_not_matching(%arg0: !spirv.arm.tensor<12x56x50xi16>) -> (!spirv.arm.tensor<12x56x51xi16>) {
+  // expected-error @+1 {{op failed to verify that all of {input1, output} have same type}}
+  %0 = spirv.Tosa.BitwiseNot %arg0 : !spirv.arm.tensor<12x56x50xi16> -> !spirv.arm.tensor<12x56x51xi16>
+  spirv.ARM.GraphOutputs %0 : !spirv.arm.tensor<12x56x51xi16>
+}
+
+//===----------------------------------------------------------------------===//
+// spirv.TOSA.Ceil
+//===----------------------------------------------------------------------===//
+
+spirv.ARM.Graph @ceil_input_output_element_types_not_matching(%arg0: !spirv.arm.tensor<46x55x53xf16>) -> (!spirv.arm.tensor<46x55x53xf32>) {
+  // expected-error @+1 {{op failed to verify that all of {input1, output} have same type}}
+  %0 = spirv.Tosa.Ceil %arg0 : !spirv.arm.tensor<46x55x53xf16> -> !spirv.arm.tensor<46x55x53xf32>
+  spirv.ARM.GraphOutputs %0 : !spirv.arm.tensor<46x55x53xf32>
+}
+
+spirv.ARM.Graph @ceil_input_output_shapes_not_matching(%arg0: !spirv.arm.tensor<46x55x53xf16>) -> (!spirv.arm.tensor<46x55x54xf16>) {
+  // expected-error @+1 {{op failed to verify that all of {input1, output} have same type}}
+  %0 = spirv.Tosa.Ceil %arg0 : !spirv.arm.tensor<46x55x53xf16> -> !spirv.arm.tensor<46x55x54xf16>
+  spirv.ARM.GraphOutputs %0 : !spirv.arm.tensor<46x55x54xf16>
+}
+
+//===----------------------------------------------------------------------===//
+// spirv.TOSA.Clz
+//===----------------------------------------------------------------------===//
+
+spirv.ARM.Graph @clz_input_output_shapes_not_matching(%arg0: !spirv.arm.tensor<14x10x7x5xi32>) -> (!spirv.arm.tensor<14x10x7x6xi32>) {
+  // expected-error @+1 {{op failed to verify that all of {input1, output} have same type}}
+  %0 = spirv.Tosa.Clz %arg0 : !spirv.arm.tensor<14x10x7x5xi32> -> !spirv.arm.tensor<14x10x7x6xi32>
+  spirv.ARM.GraphOutputs %0 : !spirv.arm.tensor<14x10x7x6xi32>
+}
+
+//===----------------------------------------------------------------------===//
+// spirv.TOSA.Cos
+//===----------------------------------------------------------------------===//
+
+spirv.ARM.Graph @cos_input_output_element_types_not_matching(%arg0: !spirv.arm.tensor<44x49x51xf16>) -> (!spirv.arm.tensor<44x49x51xf32>) {
+  // expected-error @+1 {{op failed to verify that all of {input1, output} have same type}}
+  %0 = spirv.Tosa.Cos %arg0 : !spirv.arm.tensor<44x49x51xf16> -> !spirv.arm.tensor<44x49x51xf32>
+  spirv.ARM.GraphOutputs %0 : !spirv.arm.tensor<44x49x51xf32>
+}
+
+spirv.ARM.Graph @cos_input_output_shapes_not_matching(%arg0: !spirv.arm.tensor<44x49x51xf16>) -> (!spirv.arm.tensor<44x49x52xf16>) {
+  // expected-error @+1 {{op failed to verify that all of {input1, output} have same type}}
+  %0 = spirv.Tosa.Cos %arg0 : !spirv.arm.tensor<44x49x51xf16> -> !spirv.arm.tensor<44x49x52xf16>
+  spirv.ARM.GraphOutputs %0 : !spirv.arm.tensor<44x49x52xf16>
+}
+
+//===----------------------------------------------------------------------===//
+// spirv.TOSA.Exp
+//===----------------------------------------------------------------------===//
+
+spirv.ARM.Graph @exp_input_output_element_types_not_matching(%arg0: !spirv.arm.tensor<37x53x47xf16>) -> (!spirv.arm.tensor<37x53x47xf32>) {
+  // expected-error @+1 {{op failed to verify that all of {input1, output} have same type}}
+  %0 = spirv.Tosa.Exp %arg0 : !spirv.arm.tensor<37x53x47xf16> -> !spirv.arm.tensor<37x53x47xf32>
+  spirv.ARM.GraphOutputs %0 : !spirv.arm.tensor<37x53x47xf32>
+}
+
+spirv.ARM.Graph @exp_input_output_shapes_not_matching(%arg0: !spirv.arm.tensor<37x53x47xf16>) -> (!spirv.arm.tensor<37x53x48xf16>) {
+  // expected-error @+1 {{op failed to verify that all of {input1, output} have same type}}
+  %0 = spirv.Tosa.Exp %arg0 : !spirv.arm.tensor<37x53x47xf16> -> !spirv.arm.tensor<37x53x48xf16>
+  spirv.ARM.GraphOutputs %0 : !spirv.arm.tensor<37x53x48xf16>
+}
+
+//===----------------------------------------------------------------------===//
+// spirv.TOSA.Floor
+//===----------------------------------------------------------------------===//
+
+spirv.ARM.Graph @floor_input_output_element_types_not_matching(%arg0: !spirv.arm.tensor<40x52x42xf16>) -> (!spirv.arm.tensor<40x52x42xf32>) {
+  // expected-error @+1 {{op failed to verify that all of {input1, output} have same type}}
+  %0 = spirv.Tosa.Floor %arg0 : !spirv.arm.tensor<40x52x42xf16> -> !spirv.arm.tensor<40x52x42xf32>
+  spirv.ARM.GraphOutputs %0 : !spirv.arm.tensor<40x52x42xf32>
+}
+
+spirv.ARM.Graph @floor_input_output_shapes_not_matching(%arg0: !spirv.arm.tensor<40x52x42xf16>) -> (!spirv.arm.tensor<40x52x43xf16>) {
+  // expected-error @+1 {{op failed to verify that all of {input1, output} have same type}}
+  %0 = spirv.Tosa.Floor %arg0 : !spirv.arm.tensor<40x52x42xf16> -> !spirv.arm.tensor<40x52x43xf16>
+  spirv.ARM.GraphOutputs %0 : !spirv.arm.tensor<40x52x43xf16>
+}

--- a/mlir/test/Dialect/SPIRV/IR/tosa-ops.mlir
+++ b/mlir/test/Dialect/SPIRV/IR/tosa-ops.mlir
@@ -529,3 +529,91 @@ spirv.ARM.Graph @table_int(%arg0: !spirv.arm.tensor<3x2x15x7xi8>) -> (!spirv.arm
   // CHECK: spirv.ARM.GraphOutputs {{%.*}} : !spirv.arm.tensor<3x2x15x7xi8>
   spirv.ARM.GraphOutputs %1 : !spirv.arm.tensor<3x2x15x7xi8>
 }
+
+//===----------------------------------------------------------------------===//
+// spirv.TOSA.Abs - PRO-INT
+//===----------------------------------------------------------------------===//
+
+spirv.ARM.Graph @abs_int(%arg0: !spirv.arm.tensor<5x1x4x4xi32>) -> (!spirv.arm.tensor<5x1x4x4xi32>) {
+  // CHECK: {{%.*}} = spirv.Tosa.Abs %arg0 : !spirv.arm.tensor<5x1x4x4xi32> -> !spirv.arm.tensor<5x1x4x4xi32>
+  %0 = spirv.Tosa.Abs %arg0 : !spirv.arm.tensor<5x1x4x4xi32> -> !spirv.arm.tensor<5x1x4x4xi32>
+  // CHECK: spirv.ARM.GraphOutputs {{%.*}} : !spirv.arm.tensor<5x1x4x4xi32>
+  spirv.ARM.GraphOutputs %0 : !spirv.arm.tensor<5x1x4x4xi32>
+}
+
+//===----------------------------------------------------------------------===//
+// spirv.TOSA.Abs - PRO-FP
+//===----------------------------------------------------------------------===//
+
+spirv.ARM.Graph @abs_fp(%arg0: !spirv.arm.tensor<3x6x14x8xf16>) -> (!spirv.arm.tensor<3x6x14x8xf16>) {
+  // CHECK: {{%.*}} = spirv.Tosa.Abs %arg0 : !spirv.arm.tensor<3x6x14x8xf16> -> !spirv.arm.tensor<3x6x14x8xf16>
+  %0 = spirv.Tosa.Abs %arg0 : !spirv.arm.tensor<3x6x14x8xf16> -> !spirv.arm.tensor<3x6x14x8xf16>
+  // CHECK: spirv.ARM.GraphOutputs {{%.*}} : !spirv.arm.tensor<3x6x14x8xf16>
+  spirv.ARM.GraphOutputs %0 : !spirv.arm.tensor<3x6x14x8xf16>
+}
+
+//===----------------------------------------------------------------------===//
+// spirv.TOSA.BitwiseNot - PRO-INT
+//===----------------------------------------------------------------------===//
+
+spirv.ARM.Graph @bitwisenot_int(%arg0: !spirv.arm.tensor<12x56x50xi32>) -> (!spirv.arm.tensor<12x56x50xi32>) {
+  // CHECK: {{%.*}} = spirv.Tosa.BitwiseNot %arg0 : !spirv.arm.tensor<12x56x50xi32> -> !spirv.arm.tensor<12x56x50xi32>
+  %0 = spirv.Tosa.BitwiseNot %arg0 : !spirv.arm.tensor<12x56x50xi32> -> !spirv.arm.tensor<12x56x50xi32>
+  // CHECK: spirv.ARM.GraphOutputs {{%.*}} : !spirv.arm.tensor<12x56x50xi32>
+  spirv.ARM.GraphOutputs %0 : !spirv.arm.tensor<12x56x50xi32>
+}
+
+//===----------------------------------------------------------------------===//
+// spirv.TOSA.Ceil - PRO-FP
+//===----------------------------------------------------------------------===//
+
+spirv.ARM.Graph @ceil_fp(%arg0: !spirv.arm.tensor<46x55x53xf16>) -> (!spirv.arm.tensor<46x55x53xf16>) {
+  // CHECK: {{%.*}} = spirv.Tosa.Ceil %arg0 : !spirv.arm.tensor<46x55x53xf16> -> !spirv.arm.tensor<46x55x53xf16>
+  %0 = spirv.Tosa.Ceil %arg0 : !spirv.arm.tensor<46x55x53xf16> -> !spirv.arm.tensor<46x55x53xf16>
+  // CHECK: spirv.ARM.GraphOutputs {{%.*}} : !spirv.arm.tensor<46x55x53xf16>
+  spirv.ARM.GraphOutputs %0 : !spirv.arm.tensor<46x55x53xf16>
+}
+
+//===----------------------------------------------------------------------===//
+// spirv.TOSA.Clz - PRO-INT
+//===----------------------------------------------------------------------===//
+
+spirv.ARM.Graph @clz_int(%arg0: !spirv.arm.tensor<14x10x7x5xi32>) -> (!spirv.arm.tensor<14x10x7x5xi32>) {
+  // CHECK: {{%.*}} = spirv.Tosa.Clz %arg0 : !spirv.arm.tensor<14x10x7x5xi32> -> !spirv.arm.tensor<14x10x7x5xi32>
+  %0 = spirv.Tosa.Clz %arg0 : !spirv.arm.tensor<14x10x7x5xi32> -> !spirv.arm.tensor<14x10x7x5xi32>
+  // CHECK: spirv.ARM.GraphOutputs {{%.*}} : !spirv.arm.tensor<14x10x7x5xi32>
+  spirv.ARM.GraphOutputs %0 : !spirv.arm.tensor<14x10x7x5xi32>
+}
+
+//===----------------------------------------------------------------------===//
+// spirv.TOSA.Cos - PRO-FP
+//===----------------------------------------------------------------------===//
+
+spirv.ARM.Graph @cos_fp(%arg0: !spirv.arm.tensor<44x49x51xf32>) -> (!spirv.arm.tensor<44x49x51xf32>) {
+  // CHECK: {{%.*}} = spirv.Tosa.Cos %arg0 : !spirv.arm.tensor<44x49x51xf32> -> !spirv.arm.tensor<44x49x51xf32>
+  %0 = spirv.Tosa.Cos %arg0 : !spirv.arm.tensor<44x49x51xf32> -> !spirv.arm.tensor<44x49x51xf32>
+  // CHECK: spirv.ARM.GraphOutputs {{%.*}} : !spirv.arm.tensor<44x49x51xf32>
+  spirv.ARM.GraphOutputs %0 : !spirv.arm.tensor<44x49x51xf32>
+}
+
+//===----------------------------------------------------------------------===//
+// spirv.TOSA.Exp - PRO-FP
+//===----------------------------------------------------------------------===//
+
+spirv.ARM.Graph @exp_fp(%arg0: !spirv.arm.tensor<37x53x47xf32>) -> (!spirv.arm.tensor<37x53x47xf32>) {
+  // CHECK: {{%.*}} = spirv.Tosa.Exp %arg0 : !spirv.arm.tensor<37x53x47xf32> -> !spirv.arm.tensor<37x53x47xf32>
+  %0 = spirv.Tosa.Exp %arg0 : !spirv.arm.tensor<37x53x47xf32> -> !spirv.arm.tensor<37x53x47xf32>
+  // CHECK: spirv.ARM.GraphOutputs {{%.*}} : !spirv.arm.tensor<37x53x47xf32>
+  spirv.ARM.GraphOutputs %0 : !spirv.arm.tensor<37x53x47xf32>
+}
+
+//===----------------------------------------------------------------------===//
+// spirv.TOSA.Floor - PRO-FP
+//===----------------------------------------------------------------------===//
+
+spirv.ARM.Graph @floor_fp(%arg0: !spirv.arm.tensor<40x52x42xf32>) -> (!spirv.arm.tensor<40x52x42xf32>) {
+  // CHECK: {{%.*}} = spirv.Tosa.Floor %arg0 : !spirv.arm.tensor<40x52x42xf32> -> !spirv.arm.tensor<40x52x42xf32>
+  %0 = spirv.Tosa.Floor %arg0 : !spirv.arm.tensor<40x52x42xf32> -> !spirv.arm.tensor<40x52x42xf32>
+  // CHECK: spirv.ARM.GraphOutputs {{%.*}} : !spirv.arm.tensor<40x52x42xf32>
+  spirv.ARM.GraphOutputs %0 : !spirv.arm.tensor<40x52x42xf32>
+}

--- a/mlir/test/Target/SPIRV/tosa-ops.mlir
+++ b/mlir/test/Target/SPIRV/tosa-ops.mlir
@@ -933,3 +933,155 @@ spirv.module Logical Vulkan requires #spirv.vce<v1.3, [VulkanMemoryModel, Shader
     spirv.ARM.GraphOutputs %1 : !spirv.arm.tensor<3x2x15x7xi8>
   }
 }
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// spirv.TOSA.Abs - PRO-INT
+//===----------------------------------------------------------------------===//
+
+// CHECK: spirv.module Logical Vulkan requires #spirv.vce<v1.3, [VulkanMemoryModel, Shader, Int8, Int16, Int64, Float16, TensorsARM, GraphARM], [SPV_ARM_tensors, SPV_ARM_graph, SPV_KHR_vulkan_memory_model]>
+spirv.module Logical Vulkan requires #spirv.vce<v1.3, [VulkanMemoryModel, Shader, Int8, Int16, Int64, Float16, TensorsARM, GraphARM], [SPV_ARM_tensors, SPV_ARM_graph, SPV_KHR_vulkan_memory_model]> {
+  spirv.GlobalVariable @abs_int_arg_0 bind(0, 0) : !spirv.ptr<!spirv.arm.tensor<5x1x4x4xi32>, UniformConstant>
+  spirv.GlobalVariable @abs_int_res_0 bind(1, 0) : !spirv.ptr<!spirv.arm.tensor<5x1x4x4xi32>, UniformConstant>
+  spirv.ARM.GraphEntryPoint @abs_int, @abs_int_arg_0, @abs_int_res_0
+  spirv.ARM.Graph @abs_int(%arg0: !spirv.arm.tensor<5x1x4x4xi32>) -> (!spirv.arm.tensor<5x1x4x4xi32>) {
+    // CHECK: {{%.*}} = spirv.Tosa.Abs %arg0 : !spirv.arm.tensor<5x1x4x4xi32> -> !spirv.arm.tensor<5x1x4x4xi32>
+    %0 = spirv.Tosa.Abs %arg0 : !spirv.arm.tensor<5x1x4x4xi32> -> !spirv.arm.tensor<5x1x4x4xi32>
+    // CHECK: spirv.ARM.GraphOutputs {{%.*}} : !spirv.arm.tensor<5x1x4x4xi32>
+    spirv.ARM.GraphOutputs %0 : !spirv.arm.tensor<5x1x4x4xi32>
+  }
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// spirv.TOSA.Abs - PRO-FP
+//===----------------------------------------------------------------------===//
+
+// CHECK: spirv.module Logical Vulkan requires #spirv.vce<v1.3, [VulkanMemoryModel, Shader, Int8, Int16, Int64, Float16, TensorsARM, GraphARM], [SPV_ARM_tensors, SPV_ARM_graph, SPV_KHR_vulkan_memory_model]>
+spirv.module Logical Vulkan requires #spirv.vce<v1.3, [VulkanMemoryModel, Shader, Int8, Int16, Int64, Float16, TensorsARM, GraphARM], [SPV_ARM_tensors, SPV_ARM_graph, SPV_KHR_vulkan_memory_model]> {
+  spirv.GlobalVariable @abs_fp_arg_0 bind(0, 0) : !spirv.ptr<!spirv.arm.tensor<3x6x14x8xf16>, UniformConstant>
+  spirv.GlobalVariable @abs_fp_res_0 bind(1, 0) : !spirv.ptr<!spirv.arm.tensor<3x6x14x8xf16>, UniformConstant>
+  spirv.ARM.GraphEntryPoint @abs_fp, @abs_fp_arg_0, @abs_fp_res_0
+  spirv.ARM.Graph @abs_fp(%arg0: !spirv.arm.tensor<3x6x14x8xf16>) -> (!spirv.arm.tensor<3x6x14x8xf16>) {
+    // CHECK: {{%.*}} = spirv.Tosa.Abs %arg0 : !spirv.arm.tensor<3x6x14x8xf16> -> !spirv.arm.tensor<3x6x14x8xf16>
+    %0 = spirv.Tosa.Abs %arg0 : !spirv.arm.tensor<3x6x14x8xf16> -> !spirv.arm.tensor<3x6x14x8xf16>
+    // CHECK: spirv.ARM.GraphOutputs {{%.*}} : !spirv.arm.tensor<3x6x14x8xf16>
+    spirv.ARM.GraphOutputs %0 : !spirv.arm.tensor<3x6x14x8xf16>
+  }
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// spirv.TOSA.BitwiseNot - PRO-INT
+//===----------------------------------------------------------------------===//
+
+// CHECK: spirv.module Logical Vulkan requires #spirv.vce<v1.3, [VulkanMemoryModel, Shader, Int8, Int16, Int64, Float16, TensorsARM, GraphARM], [SPV_ARM_tensors, SPV_ARM_graph, SPV_KHR_vulkan_memory_model]>
+spirv.module Logical Vulkan requires #spirv.vce<v1.3, [VulkanMemoryModel, Shader, Int8, Int16, Int64, Float16, TensorsARM, GraphARM], [SPV_ARM_tensors, SPV_ARM_graph, SPV_KHR_vulkan_memory_model]> {
+  spirv.GlobalVariable @bitwisenot_int_arg_0 bind(0, 0) : !spirv.ptr<!spirv.arm.tensor<12x56x50xi32>, UniformConstant>
+  spirv.GlobalVariable @bitwisenot_int_res_0 bind(1, 0) : !spirv.ptr<!spirv.arm.tensor<12x56x50xi32>, UniformConstant>
+  spirv.ARM.GraphEntryPoint @bitwisenot_int, @bitwisenot_int_arg_0, @bitwisenot_int_res_0
+  spirv.ARM.Graph @bitwisenot_int(%arg0: !spirv.arm.tensor<12x56x50xi32>) -> (!spirv.arm.tensor<12x56x50xi32>) {
+    // CHECK: {{%.*}} = spirv.Tosa.BitwiseNot %arg0 : !spirv.arm.tensor<12x56x50xi32> -> !spirv.arm.tensor<12x56x50xi32>
+    %0 = spirv.Tosa.BitwiseNot %arg0 : !spirv.arm.tensor<12x56x50xi32> -> !spirv.arm.tensor<12x56x50xi32>
+    // CHECK: spirv.ARM.GraphOutputs {{%.*}} : !spirv.arm.tensor<12x56x50xi32>
+    spirv.ARM.GraphOutputs %0 : !spirv.arm.tensor<12x56x50xi32>
+  }
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// spirv.TOSA.Ceil - PRO-FP
+//===----------------------------------------------------------------------===//
+
+// CHECK: spirv.module Logical Vulkan requires #spirv.vce<v1.3, [VulkanMemoryModel, Shader, Int8, Int16, Int64, Float16, TensorsARM, GraphARM], [SPV_ARM_tensors, SPV_ARM_graph, SPV_KHR_vulkan_memory_model]>
+spirv.module Logical Vulkan requires #spirv.vce<v1.3, [VulkanMemoryModel, Shader, Int8, Int16, Int64, Float16, TensorsARM, GraphARM], [SPV_ARM_tensors, SPV_ARM_graph, SPV_KHR_vulkan_memory_model]> {
+  spirv.GlobalVariable @ceil_fp_arg_0 bind(0, 0) : !spirv.ptr<!spirv.arm.tensor<46x55x53xf16>, UniformConstant>
+  spirv.GlobalVariable @ceil_fp_res_0 bind(1, 0) : !spirv.ptr<!spirv.arm.tensor<46x55x53xf16>, UniformConstant>
+  spirv.ARM.GraphEntryPoint @ceil_fp, @ceil_fp_arg_0, @ceil_fp_res_0
+  spirv.ARM.Graph @ceil_fp(%arg0: !spirv.arm.tensor<46x55x53xf16>) -> (!spirv.arm.tensor<46x55x53xf16>) {
+    // CHECK: {{%.*}} = spirv.Tosa.Ceil %arg0 : !spirv.arm.tensor<46x55x53xf16> -> !spirv.arm.tensor<46x55x53xf16>
+    %0 = spirv.Tosa.Ceil %arg0 : !spirv.arm.tensor<46x55x53xf16> -> !spirv.arm.tensor<46x55x53xf16>
+    // CHECK: spirv.ARM.GraphOutputs {{%.*}} : !spirv.arm.tensor<46x55x53xf16>
+    spirv.ARM.GraphOutputs %0 : !spirv.arm.tensor<46x55x53xf16>
+  }
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// spirv.TOSA.Clz - PRO-INT
+//===----------------------------------------------------------------------===//
+
+// CHECK: spirv.module Logical Vulkan requires #spirv.vce<v1.3, [VulkanMemoryModel, Shader, Int8, Int16, Int64, Float16, TensorsARM, GraphARM], [SPV_ARM_tensors, SPV_ARM_graph, SPV_KHR_vulkan_memory_model]>
+spirv.module Logical Vulkan requires #spirv.vce<v1.3, [VulkanMemoryModel, Shader, Int8, Int16, Int64, Float16, TensorsARM, GraphARM], [SPV_ARM_tensors, SPV_ARM_graph, SPV_KHR_vulkan_memory_model]> {
+  spirv.GlobalVariable @clz_int_arg_0 bind(0, 0) : !spirv.ptr<!spirv.arm.tensor<14x10x7x5xi32>, UniformConstant>
+  spirv.GlobalVariable @clz_int_res_0 bind(1, 0) : !spirv.ptr<!spirv.arm.tensor<14x10x7x5xi32>, UniformConstant>
+  spirv.ARM.GraphEntryPoint @clz_int, @clz_int_arg_0, @clz_int_res_0
+  spirv.ARM.Graph @clz_int(%arg0: !spirv.arm.tensor<14x10x7x5xi32>) -> (!spirv.arm.tensor<14x10x7x5xi32>) {
+    // CHECK: {{%.*}} = spirv.Tosa.Clz %arg0 : !spirv.arm.tensor<14x10x7x5xi32> -> !spirv.arm.tensor<14x10x7x5xi32>
+    %0 = spirv.Tosa.Clz %arg0 : !spirv.arm.tensor<14x10x7x5xi32> -> !spirv.arm.tensor<14x10x7x5xi32>
+    // CHECK: spirv.ARM.GraphOutputs {{%.*}} : !spirv.arm.tensor<14x10x7x5xi32>
+    spirv.ARM.GraphOutputs %0 : !spirv.arm.tensor<14x10x7x5xi32>
+  }
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// spirv.TOSA.Cos - PRO-FP
+//===----------------------------------------------------------------------===//
+
+// CHECK: spirv.module Logical Vulkan requires #spirv.vce<v1.3, [VulkanMemoryModel, Shader, Int8, Int16, Int64, Float16, TensorsARM, GraphARM], [SPV_ARM_tensors, SPV_ARM_graph, SPV_KHR_vulkan_memory_model]>
+spirv.module Logical Vulkan requires #spirv.vce<v1.3, [VulkanMemoryModel, Shader, Int8, Int16, Int64, Float16, TensorsARM, GraphARM], [SPV_ARM_tensors, SPV_ARM_graph, SPV_KHR_vulkan_memory_model]> {
+  spirv.GlobalVariable @cos_fp_arg_0 bind(0, 0) : !spirv.ptr<!spirv.arm.tensor<44x49x51xf32>, UniformConstant>
+  spirv.GlobalVariable @cos_fp_res_0 bind(1, 0) : !spirv.ptr<!spirv.arm.tensor<44x49x51xf32>, UniformConstant>
+  spirv.ARM.GraphEntryPoint @cos_fp, @cos_fp_arg_0, @cos_fp_res_0
+  spirv.ARM.Graph @cos_fp(%arg0: !spirv.arm.tensor<44x49x51xf32>) -> (!spirv.arm.tensor<44x49x51xf32>) {
+    // CHECK: {{%.*}} = spirv.Tosa.Cos %arg0 : !spirv.arm.tensor<44x49x51xf32> -> !spirv.arm.tensor<44x49x51xf32>
+    %0 = spirv.Tosa.Cos %arg0 : !spirv.arm.tensor<44x49x51xf32> -> !spirv.arm.tensor<44x49x51xf32>
+    // CHECK: spirv.ARM.GraphOutputs {{%.*}} : !spirv.arm.tensor<44x49x51xf32>
+    spirv.ARM.GraphOutputs %0 : !spirv.arm.tensor<44x49x51xf32>
+  }
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// spirv.TOSA.Exp - PRO-FP
+//===----------------------------------------------------------------------===//
+
+// CHECK: spirv.module Logical Vulkan requires #spirv.vce<v1.3, [VulkanMemoryModel, Shader, Int8, Int16, Int64, Float16, TensorsARM, GraphARM], [SPV_ARM_tensors, SPV_ARM_graph, SPV_KHR_vulkan_memory_model]>
+spirv.module Logical Vulkan requires #spirv.vce<v1.3, [VulkanMemoryModel, Shader, Int8, Int16, Int64, Float16, TensorsARM, GraphARM], [SPV_ARM_tensors, SPV_ARM_graph, SPV_KHR_vulkan_memory_model]> {
+  spirv.GlobalVariable @exp_fp_arg_0 bind(0, 0) : !spirv.ptr<!spirv.arm.tensor<37x53x47xf32>, UniformConstant>
+  spirv.GlobalVariable @exp_fp_res_0 bind(1, 0) : !spirv.ptr<!spirv.arm.tensor<37x53x47xf32>, UniformConstant>
+  spirv.ARM.GraphEntryPoint @exp_fp, @exp_fp_arg_0, @exp_fp_res_0
+  spirv.ARM.Graph @exp_fp(%arg0: !spirv.arm.tensor<37x53x47xf32>) -> (!spirv.arm.tensor<37x53x47xf32>) {
+    // CHECK: {{%.*}} = spirv.Tosa.Exp %arg0 : !spirv.arm.tensor<37x53x47xf32> -> !spirv.arm.tensor<37x53x47xf32>
+    %0 = spirv.Tosa.Exp %arg0 : !spirv.arm.tensor<37x53x47xf32> -> !spirv.arm.tensor<37x53x47xf32>
+    // CHECK: spirv.ARM.GraphOutputs {{%.*}} : !spirv.arm.tensor<37x53x47xf32>
+    spirv.ARM.GraphOutputs %0 : !spirv.arm.tensor<37x53x47xf32>
+  }
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// spirv.TOSA.Floor - PRO-FP
+//===----------------------------------------------------------------------===//
+
+// CHECK: spirv.module Logical Vulkan requires #spirv.vce<v1.3, [VulkanMemoryModel, Shader, Int8, Int16, Int64, Float16, TensorsARM, GraphARM], [SPV_ARM_tensors, SPV_ARM_graph, SPV_KHR_vulkan_memory_model]>
+spirv.module Logical Vulkan requires #spirv.vce<v1.3, [VulkanMemoryModel, Shader, Int8, Int16, Int64, Float16, TensorsARM, GraphARM], [SPV_ARM_tensors, SPV_ARM_graph, SPV_KHR_vulkan_memory_model]> {
+  spirv.GlobalVariable @floor_fp_arg_0 bind(0, 0) : !spirv.ptr<!spirv.arm.tensor<40x52x42xf32>, UniformConstant>
+  spirv.GlobalVariable @floor_fp_res_0 bind(1, 0) : !spirv.ptr<!spirv.arm.tensor<40x52x42xf32>, UniformConstant>
+  spirv.ARM.GraphEntryPoint @floor_fp, @floor_fp_arg_0, @floor_fp_res_0
+  spirv.ARM.Graph @floor_fp(%arg0: !spirv.arm.tensor<40x52x42xf32>) -> (!spirv.arm.tensor<40x52x42xf32>) {
+    // CHECK: {{%.*}} = spirv.Tosa.Floor %arg0 : !spirv.arm.tensor<40x52x42xf32> -> !spirv.arm.tensor<40x52x42xf32>
+    %0 = spirv.Tosa.Floor %arg0 : !spirv.arm.tensor<40x52x42xf32> -> !spirv.arm.tensor<40x52x42xf32>
+    // CHECK: spirv.ARM.GraphOutputs {{%.*}} : !spirv.arm.tensor<40x52x42xf32>
+    spirv.ARM.GraphOutputs %0 : !spirv.arm.tensor<40x52x42xf32>
+  }
+}


### PR DESCRIPTION
This patch introduces the following elementwise unary operators:

    spirv.Tosa.Abs
    spirv.Tosa.BitwiseNot
    spirv.Tosa.Ceil
    spirv.Tosa.Clz
    spirv.Tosa.Cos
    spirv.Tosa.Exp
    spirv.Tosa.Floor

Also dialect and serialization round-trip tests have been added.