### PR TITLE
[libc] Fix hdrgen test test_small_proxy.h

### DIFF
--- a/libc/utils/hdrgen/tests/expected_output/test_small_proxy.h
+++ b/libc/utils/hdrgen/tests/expected_output/test_small_proxy.h
@@ -18,6 +18,12 @@
 #include "llvm-libc-types/type_a.h"
 #include "llvm-libc-types/type_b.h"
 
+#define MACRO_A 1
+
+#define MACRO_B 2
+
+#define MACRO_C
+
 #else // Overlay mode
 
 #include <test_small.h>


### PR DESCRIPTION
The expected output was outdated as it did not contain the macro definitions.

This patch fixes the issue.