### PR TITLE
[lldb][Debugger] Register 'testing.XXX' settings with Debugger

### DIFF
--- a/lldb/source/Core/Debugger.cpp
+++ b/lldb/source/Core/Debugger.cpp
@@ -1015,6 +1015,12 @@ Debugger::Debugger(lldb::LogOutputCallback log_callback, void *baton)
         "Settings specify to the debugger's command interpreter.", true,
         m_command_interpreter_up->GetValueProperties());
   }
+#ifndef NDEBUG
+  m_collection_sp->AppendProperty(
+      "testing", "Testing-only settings.", /*is_global=*/true,
+      TestingProperties::GetGlobalTestingProperties().GetValueProperties());
+#endif
+
   if (log_callback)
     m_callback_handler_sp =
         std::make_shared<CallbackLogHandler>(log_callback, baton);

--- a/lldb/test/Shell/Settings/TestTestingSettings.test
+++ b/lldb/test/Shell/Settings/TestTestingSettings.test
@@ -1,0 +1,7 @@
+# REQUIRES: asserts
+#
+# Tests that the global 'testing.XXX' settings are available when building with asserts.
+#
+# RUN: %lldb -o 'settings show testing.inject-variable-location-error' -b | FileCheck %s
+#
+# CHECK: testing.inject-variable-location-error (boolean) = false


### PR DESCRIPTION
The `testing.XXX` settings (added in https://github.com/llvm/llvm-project/pull/177279 and currently just `testing.inject-variable-location-error`) are supposed to only exist in asserts builds. However, we never added it as a global property to the `Debugger`, so the setting wasn't actually usable, in any build.

The one test that did use it [skipped the test on error](https://github.com/llvm/llvm-project/blob/230e4656170e3764db28b54d91153a1117290171/lldb/test/API/commands/expression/diagnostics/TestExprDiagnostics.py#L286-L288) as a way to mimick "only run test in asserts mode". However, this just meant the test never ran.

This patch registers the property and adds a test that ensures an asserts-LLDB does allow access to it from the CLI.