### PR TITLE
[TableGen] Let -register-info-debug dump the Artificial flag

### DIFF
--- a/llvm/test/TableGen/ArtificialRegs.td
+++ b/llvm/test/TableGen/ArtificialRegs.td
@@ -52,5 +52,12 @@ def DA : RegisterClass<"D", [i64], 64, (add D0, A)>;
 // CHECK-NEXT: BaseClassOrder:
 // CHECK-NEXT: Regs: A D0{{$}}
 // CHECK-NEXT: SubClasses: DA{{$}}
+//
+// CHECK-LABEL: Register A:
+// CHECK-NEXT: CostPerUse: 0
+// CHECK-NEXT: CoveredBySubregs: 0
+// CHECK-NEXT: HasDisjunctSubRegs: 0
+// CHECK-NEXT: RegUnit 0
+// CHECK-NEXT: Artificial: 1
 
 def TestTarget : Target;

--- a/llvm/test/TableGen/ArtificialSubregs.td
+++ b/llvm/test/TableGen/ArtificialSubregs.td
@@ -129,6 +129,7 @@ def TestTarget : Target;
 // CHECK-NEXT: 	LaneMask: 0000000000000120
 // CHECK-LABEL: SubRegIndex dsub_hi:
 // CHECK-NEXT: 	LaneMask: 0000000000000001
+// CHECK:       Artificial: 1
 // CHECK-LABEL: SubRegIndex ssub:
 // CHECK-NEXT: 	LaneMask: 0000000000000004
 // CHECK-LABEL: SubRegIndex ssub0:
@@ -139,10 +140,13 @@ def TestTarget : Target;
 // CHECK-NEXT: 	LaneMask: 0000000000000020
 // CHECK-LABEL: SubRegIndex ssub_hi:
 // CHECK-NEXT: 	LaneMask: 0000000000000040
+// CHECK:       Artificial: 1
 // CHECK-LABEL: SubRegIndex dsub1_then_ssub_hi:
 // CHECK-NEXT: 	LaneMask: 0000000000000080
+// CHECK:       Artificial: 1
 // CHECK-LABEL: SubRegIndex dsub2_then_ssub_hi:
 // CHECK-NEXT: 	LaneMask: 0000000000000100
+// CHECK:       Artificial: 1
 // CHECK-LABEL: SubRegIndex ssub_ssub1:
 // CHECK-NEXT: 	LaneMask: 0000000000000014
 // CHECK-LABEL: SubRegIndex dsub0_dsub1:
@@ -173,6 +177,12 @@ def TestTarget : Target;
 // CHECK-LABEL: Register S0:
 // CHECK: 	CoveredBySubregs: 0
 // CHECK: 	HasDisjunctSubRegs: 0
+//
+// CHECK-LABEL: Register D0_HI:
+// CHECK:       Artificial: 1
+//
+// CHECK-LABEL: Register S0_HI:
+// CHECK:       Artificial: 1
 //
 // CHECK-LABEL: Register D0_D1:
 // CHECK: 	CoveredBySubregs: 1

--- a/llvm/utils/TableGen/RegisterInfoEmitter.cpp
+++ b/llvm/utils/TableGen/RegisterInfoEmitter.cpp
@@ -1990,6 +1990,8 @@ void RegisterInfoEmitter::debugDump(raw_ostream &OS) {
       OS << " " << SRC->getName();
     }
     OS << '\n';
+    if (RC.Artificial)
+      OS << "\tArtificial: 1\n";
   }
 
   for (const CodeGenSubRegIndex &SRI : RegBank.getSubRegIndices()) {
@@ -2002,6 +2004,8 @@ void RegisterInfoEmitter::debugDump(raw_ostream &OS) {
     OS << "\tSize: " << printByHwMode(SRI.Range, [](const SubRegRange &Info) {
       return Info.Size;
     }) << '\n';
+    if (SRI.Artificial)
+      OS << "\tArtificial: 1\n";
   }
 
   for (const CodeGenRegister &R : RegBank.getRegisters()) {
@@ -2018,6 +2022,8 @@ void RegisterInfoEmitter::debugDump(raw_ostream &OS) {
     }
     for (unsigned U : R.getNativeRegUnits())
       OS << "\tRegUnit " << U << '\n';
+    if (R.Artificial)
+      OS << "\tArtificial: 1\n";
   }
 }
 


### PR DESCRIPTION
Dump the Artificial flag for RegisterClasses, SubRegIndices and
Registers. To avoid clutter it is only dumped when the flag is set (has
value 1).
