### PR TITLE
[MLIR][NVVM] Add family-specific support to NVVMRequiresSM traits

### DIFF
--- a/mlir/include/mlir/Dialect/LLVMIR/NVVMOps.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/NVVMOps.td
@@ -2439,7 +2439,7 @@ def NVVM_ConvertF32x2ToBF16x2Op : NVVM_ConvertF32x2ToFPx2OpBase<"BF16x2", "conve
 // (E4M3x4, E5M2x4, E2M3x4, E3M2x4, E2M1x4)
 // These operations always use RS (stochastic rounding) mode with SATFINITE saturation.
 class NVVM_ConvertF32x4ToFPx4OpBase<string dstFormat, string mnemonic, Type dstType> :
-  NVVM_Op<mnemonic, [Pure, NVVMRequiresSMa<[100, 103]>]>,
+  NVVM_Op<mnemonic, [Pure, NVVMRequiresSMAA<[100, 103]>]>,
   Results<(outs dstType:$dst)>,
   Arguments<(ins VectorOfLengthAndType<[4], [F32]>:$src, I32:$rbits,
                  DefaultValuedAttr<BoolAttr, "false">:$relu,
@@ -4682,7 +4682,7 @@ def NVVM_CpAsyncBulkSharedCTAToGlobalOp :
 // NVVM Wgmma Ops
 //===----------------------------------------------------------------------===//
 
-def NVVM_WgmmaFenceAlignedOp : NVVM_Op<"wgmma.fence.aligned", [NVVMRequiresSMa<[90]>]> {
+def NVVM_WgmmaFenceAlignedOp : NVVM_Op<"wgmma.fence.aligned", [NVVMRequiresSMAA<[90]>]> {
   let arguments = (ins);
   let description = [{
     Enforce an ordering of register accesses between warpgroup level matrix 
@@ -4696,7 +4696,7 @@ def NVVM_WgmmaFenceAlignedOp : NVVM_Op<"wgmma.fence.aligned", [NVVMRequiresSMa<[
   }];
 }
 
-def NVVM_WgmmaGroupSyncAlignedOp : NVVM_Op<"wgmma.commit.group.sync.aligned", [NVVMRequiresSMa<[90]>]> {
+def NVVM_WgmmaGroupSyncAlignedOp : NVVM_Op<"wgmma.commit.group.sync.aligned", [NVVMRequiresSMAA<[90]>]> {
   let assemblyFormat = "attr-dict";
   let description = [{
     Commits all prior uncommitted warpgroup level matrix multiplication operations.
@@ -4708,7 +4708,7 @@ def NVVM_WgmmaGroupSyncAlignedOp : NVVM_Op<"wgmma.commit.group.sync.aligned", [N
   }];
 }
 
-def NVVM_WgmmaWaitGroupSyncOp : NVVM_Op<"wgmma.wait.group.sync.aligned", [NVVMRequiresSMa<[90]>]> {
+def NVVM_WgmmaWaitGroupSyncOp : NVVM_Op<"wgmma.wait.group.sync.aligned", [NVVMRequiresSMAA<[90]>]> {
   let arguments = (ins I64Attr:$group);
   let assemblyFormat = "attr-dict $group";
   let description = [{
@@ -5070,7 +5070,7 @@ def Tcgen05WaitKindAttr :
   let assemblyFormat = "`<` $value `>`";
 }
 
-def NVVM_Tcgen05AllocOp : NVVM_Op<"tcgen05.alloc", [NVVMRequiresSMa<[100, 101]>]> {
+def NVVM_Tcgen05AllocOp : NVVM_Op<"tcgen05.alloc", [NVVMRequiresSMAA<[100, 101]>]> {
   let summary = "Tcgen05 alloc operation";
   let description = [{
     The `tcgen05.alloc` Op allocates tensor core memory for
@@ -5100,7 +5100,7 @@ def NVVM_Tcgen05AllocOp : NVVM_Op<"tcgen05.alloc", [NVVMRequiresSMa<[100, 101]>]
   }];
 }
 
-def NVVM_Tcgen05DeallocOp : NVVM_Op<"tcgen05.dealloc", [NVVMRequiresSMa<[100, 101]>]> {
+def NVVM_Tcgen05DeallocOp : NVVM_Op<"tcgen05.dealloc", [NVVMRequiresSMAA<[100, 101]>]> {
   let summary = "Tcgen05 dealloc operation";
   let description = [{
     The `tcgen05.dealloc` Op de-allocates the tensor core memory
@@ -5128,7 +5128,7 @@ def NVVM_Tcgen05DeallocOp : NVVM_Op<"tcgen05.dealloc", [NVVMRequiresSMa<[100, 10
   }];
 }
 
-def NVVM_Tcgen05RelinquishAllocPermitOp : NVVM_Op<"tcgen05.relinquish_alloc_permit", [NVVMRequiresSMa<[100, 101]>]> {
+def NVVM_Tcgen05RelinquishAllocPermitOp : NVVM_Op<"tcgen05.relinquish_alloc_permit", [NVVMRequiresSMAA<[100, 101]>]> {
   let summary = "Tcgen05 Op to relinquish the right to allocate";
   let description = [{
     The `tcgen05.relinquish_alloc_permit` Op specifies that the CTA
@@ -5151,7 +5151,7 @@ def NVVM_Tcgen05RelinquishAllocPermitOp : NVVM_Op<"tcgen05.relinquish_alloc_perm
   }];
 }
 
-def NVVM_Tcgen05FenceOp : NVVM_Op<"tcgen05.fence", [NVVMRequiresSMa<[100, 101]>]> {
+def NVVM_Tcgen05FenceOp : NVVM_Op<"tcgen05.fence", [NVVMRequiresSMAA<[100, 101]>]> {
   let summary = "Tcgen05 fence operations";
   let description = [{
     The `tcgen05.fence<before>` orders all prior async tcgen05 operations
@@ -5173,7 +5173,7 @@ def NVVM_Tcgen05FenceOp : NVVM_Op<"tcgen05.fence", [NVVMRequiresSMa<[100, 101]>]
   }];
 }
 
-def NVVM_Tcgen05WaitOp : NVVM_Op<"tcgen05.wait", [NVVMRequiresSMa<[100, 101]>]> {
+def NVVM_Tcgen05WaitOp : NVVM_Op<"tcgen05.wait", [NVVMRequiresSMAA<[100, 101]>]> {
   let summary = "Tcgen05 wait operations";
   let description = [{
     The `tcgen05.wait<load>` causes the executing thread to block until
@@ -5195,7 +5195,7 @@ def NVVM_Tcgen05WaitOp : NVVM_Op<"tcgen05.wait", [NVVMRequiresSMa<[100, 101]>]> 
   }];
 }
 
-def NVVM_Tcgen05CommitOp : NVVM_Op<"tcgen05.commit", [NVVMRequiresSMa<[100, 101]>]> {
+def NVVM_Tcgen05CommitOp : NVVM_Op<"tcgen05.commit", [NVVMRequiresSMAA<[100, 101]>]> {
   let summary = "Tcgen05 commit operations";
   let description = [{
     The `tcgen05.commit` makes the *mbarrier object*, specified by
@@ -5233,7 +5233,7 @@ def NVVM_Tcgen05CommitOp : NVVM_Op<"tcgen05.commit", [NVVMRequiresSMa<[100, 101]
   }];
 }
 
-def NVVM_Tcgen05ShiftOp : NVVM_Op<"tcgen05.shift", [NVVMRequiresSMa<[100, 101, 103]>]> {
+def NVVM_Tcgen05ShiftOp : NVVM_Op<"tcgen05.shift", [NVVMRequiresSMAA<[100, 101, 103]>]> {
   let summary = "Tcgen05 shift operation";
   let description = [{
     The `tcgen05.shift` is an asynchronous instruction which initiates
@@ -5299,7 +5299,7 @@ def Tcgen05CpSrcFormatAttr : EnumAttr<NVVM_Dialect, Tcgen05CpSrcFormat, "tcgen05
   let assemblyFormat = "`<` $value `>`";
 }
 
-def NVVM_Tcgen05CpOp : NVVM_Op<"tcgen05.cp", [NVVMRequiresSMa<[100, 101]>]> {
+def NVVM_Tcgen05CpOp : NVVM_Op<"tcgen05.cp", [NVVMRequiresSMAA<[100, 101]>]> {
   let summary = "Tcgen05 copy operation";
   let description = [{
     Instruction tcgen05.cp initiates an asynchronous copy operation from
@@ -5435,7 +5435,7 @@ def Tcgen05LdStShapeAttr: EnumAttr<NVVM_Dialect, Tcgen05LdStShape, "tcgen05_ldst
 // NVVM tcgen05.ld Op
 //===----------------------------------------------------------------------===//
 
-def NVVM_Tcgen05LdOp : NVVM_Op<"tcgen05.ld", [NVVMRequiresSMa<[100, 101]>]> {
+def NVVM_Tcgen05LdOp : NVVM_Op<"tcgen05.ld", [NVVMRequiresSMAA<[100, 101]>]> {
   let summary = "tensor memory load instructions";
   let arguments = (ins
     // Attributes
@@ -5528,7 +5528,7 @@ def NVVM_Tcgen05LdOp : NVVM_Op<"tcgen05.ld", [NVVMRequiresSMa<[100, 101]>]> {
 //===----------------------------------------------------------------------===//
 
 def NVVM_Tcgen05LdRedOp : NVVM_Op<"tcgen05.ld.red",
-                          [NVVMRequiresSMa<[101, 110]>]> {
+                          [NVVMRequiresSMAA<[101, 110]>]> {
   let summary = "Tcgen05 tensor memory load and reduce instructions";
   let arguments = (ins
     Tcgen05LdStShapeAttr:$shape,
@@ -5617,7 +5617,7 @@ def NVVM_Tcgen05LdRedOp : NVVM_Op<"tcgen05.ld.red",
 // NVVM tcgen05.st Op
 //===----------------------------------------------------------------------===//
 
-def NVVM_Tcgen05StOp : NVVM_Op<"tcgen05.st", [NVVMRequiresSMa<[100, 101]>]> {
+def NVVM_Tcgen05StOp : NVVM_Op<"tcgen05.st", [NVVMRequiresSMAA<[100, 101]>]> {
   let summary = "tensor memory store instructions";
   let arguments = (ins
     // Attributes
@@ -5996,7 +5996,7 @@ defvar Tcgen05MMABlockScaleKindAttr =
 
 def NVVM_Tcgen05MMAOp : NVVM_Op<"tcgen05.mma",
                           [AttrSizedOperandSegments,
-                           NVVMRequiresSMa<[100, 110]>]> {
+                           NVVMRequiresSMAA<[100, 110]>]> {
   let summary = "Performs MMA operation on 5th-gen tensor cores";
 
   let description = [{
@@ -6080,7 +6080,7 @@ def NVVM_Tcgen05MMAOp : NVVM_Op<"tcgen05.mma",
 
 def NVVM_Tcgen05MMASparseOp : NVVM_Op<"tcgen05.mma.sp",
                                       [AttrSizedOperandSegments,
-                                       NVVMRequiresSMa<[100, 110]>]> {
+                                       NVVMRequiresSMAA<[100, 110]>]> {
   let summary = "Performs MMA operation with sparse A matrix on 5th-gen tensor cores";
 
   let description = [{
@@ -6161,7 +6161,7 @@ def Tcgen05MMABlockScaleAttr : EnumAttr<NVVM_Dialect, Tcgen05MMABlockScale,
 }
 
 def NVVM_Tcgen05MMABlockScaleOp : NVVM_Op<"tcgen05.mma.block_scale",
-                                          [NVVMRequiresSMa<[100, 110]>]> {
+                                          [NVVMRequiresSMAA<[100, 110]>]> {
   let summary = "Performs block scaled MMA operation on 5th-gen tensor cores";
 
   let description = [{
@@ -6234,7 +6234,7 @@ def NVVM_Tcgen05MMABlockScaleOp : NVVM_Op<"tcgen05.mma.block_scale",
 }
 
 def NVVM_Tcgen05MMASparseBlockScaleOp : NVVM_Op<"tcgen05.mma.sp.block_scale",
-                                                [NVVMRequiresSMa<[100, 110]>]> {
+                                                [NVVMRequiresSMAA<[100, 110]>]> {
   let summary = "Performs block scaled MMA operation with sparse A matrix on 5th-gen tensor cores";
 
   let description = [{
@@ -6316,7 +6316,7 @@ def Tcgen05MMACollectorBBufferAttr : EnumAttr<NVVM_Dialect, Tcgen05MMACollectorB
 }
 
 def NVVM_Tcgen05MMAWsOp : NVVM_Op<"tcgen05.mma.ws",
-                                  [NVVMRequiresSMa<[100, 110]>]> {
+                                  [NVVMRequiresSMAA<[100, 110]>]> {
   let summary = "Performs weight stationary convolution MMA operation on 5th-gen tensor cores";
 
   let description = [{
@@ -6386,7 +6386,7 @@ def NVVM_Tcgen05MMAWsOp : NVVM_Op<"tcgen05.mma.ws",
 }
 
 def NVVM_Tcgen05MMAWsSparseOp : NVVM_Op<"tcgen05.mma.ws.sp",
-                                        [NVVMRequiresSMa<[100, 110]>]> {
+                                        [NVVMRequiresSMAA<[100, 110]>]> {
   let summary = "Performs weight stationary convolution MMA with sparse A matrix on 5th-gen tensor cores";
 
   let description = [{

--- a/mlir/include/mlir/Dialect/LLVMIR/NVVMOps.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/NVVMOps.td
@@ -2439,7 +2439,7 @@ def NVVM_ConvertF32x2ToBF16x2Op : NVVM_ConvertF32x2ToFPx2OpBase<"BF16x2", "conve
 // (E4M3x4, E5M2x4, E2M3x4, E3M2x4, E2M1x4)
 // These operations always use RS (stochastic rounding) mode with SATFINITE saturation.
 class NVVM_ConvertF32x4ToFPx4OpBase<string dstFormat, string mnemonic, Type dstType> :
-  NVVM_Op<mnemonic, [Pure, NVVMRequiresSMAA<[100, 103]>]>,
+  NVVM_Op<mnemonic, [Pure, NVVMRequiresSMa<[100, 103]>]>,
   Results<(outs dstType:$dst)>,
   Arguments<(ins VectorOfLengthAndType<[4], [F32]>:$src, I32:$rbits,
                  DefaultValuedAttr<BoolAttr, "false">:$relu,
@@ -4682,7 +4682,7 @@ def NVVM_CpAsyncBulkSharedCTAToGlobalOp :
 // NVVM Wgmma Ops
 //===----------------------------------------------------------------------===//
 
-def NVVM_WgmmaFenceAlignedOp : NVVM_Op<"wgmma.fence.aligned", [NVVMRequiresSMAA<[90]>]> {
+def NVVM_WgmmaFenceAlignedOp : NVVM_Op<"wgmma.fence.aligned", [NVVMRequiresSMa<[90]>]> {
   let arguments = (ins);
   let description = [{
     Enforce an ordering of register accesses between warpgroup level matrix 
@@ -4696,7 +4696,7 @@ def NVVM_WgmmaFenceAlignedOp : NVVM_Op<"wgmma.fence.aligned", [NVVMRequiresSMAA<
   }];
 }
 
-def NVVM_WgmmaGroupSyncAlignedOp : NVVM_Op<"wgmma.commit.group.sync.aligned", [NVVMRequiresSMAA<[90]>]> {
+def NVVM_WgmmaGroupSyncAlignedOp : NVVM_Op<"wgmma.commit.group.sync.aligned", [NVVMRequiresSMa<[90]>]> {
   let assemblyFormat = "attr-dict";
   let description = [{
     Commits all prior uncommitted warpgroup level matrix multiplication operations.
@@ -4708,7 +4708,7 @@ def NVVM_WgmmaGroupSyncAlignedOp : NVVM_Op<"wgmma.commit.group.sync.aligned", [N
   }];
 }
 
-def NVVM_WgmmaWaitGroupSyncOp : NVVM_Op<"wgmma.wait.group.sync.aligned", [NVVMRequiresSMAA<[90]>]> {
+def NVVM_WgmmaWaitGroupSyncOp : NVVM_Op<"wgmma.wait.group.sync.aligned", [NVVMRequiresSMa<[90]>]> {
   let arguments = (ins I64Attr:$group);
   let assemblyFormat = "attr-dict $group";
   let description = [{
@@ -5070,7 +5070,7 @@ def Tcgen05WaitKindAttr :
   let assemblyFormat = "`<` $value `>`";
 }
 
-def NVVM_Tcgen05AllocOp : NVVM_Op<"tcgen05.alloc", [NVVMRequiresSMAA<[100, 101]>]> {
+def NVVM_Tcgen05AllocOp : NVVM_Op<"tcgen05.alloc", [NVVMRequiresSMa<[100, 101]>]> {
   let summary = "Tcgen05 alloc operation";
   let description = [{
     The `tcgen05.alloc` Op allocates tensor core memory for
@@ -5100,7 +5100,7 @@ def NVVM_Tcgen05AllocOp : NVVM_Op<"tcgen05.alloc", [NVVMRequiresSMAA<[100, 101]>
   }];
 }
 
-def NVVM_Tcgen05DeallocOp : NVVM_Op<"tcgen05.dealloc", [NVVMRequiresSMAA<[100, 101]>]> {
+def NVVM_Tcgen05DeallocOp : NVVM_Op<"tcgen05.dealloc", [NVVMRequiresSMa<[100, 101]>]> {
   let summary = "Tcgen05 dealloc operation";
   let description = [{
     The `tcgen05.dealloc` Op de-allocates the tensor core memory
@@ -5128,7 +5128,7 @@ def NVVM_Tcgen05DeallocOp : NVVM_Op<"tcgen05.dealloc", [NVVMRequiresSMAA<[100, 1
   }];
 }
 
-def NVVM_Tcgen05RelinquishAllocPermitOp : NVVM_Op<"tcgen05.relinquish_alloc_permit", [NVVMRequiresSMAA<[100, 101]>]> {
+def NVVM_Tcgen05RelinquishAllocPermitOp : NVVM_Op<"tcgen05.relinquish_alloc_permit", [NVVMRequiresSMa<[100, 101]>]> {
   let summary = "Tcgen05 Op to relinquish the right to allocate";
   let description = [{
     The `tcgen05.relinquish_alloc_permit` Op specifies that the CTA
@@ -5151,7 +5151,7 @@ def NVVM_Tcgen05RelinquishAllocPermitOp : NVVM_Op<"tcgen05.relinquish_alloc_perm
   }];
 }
 
-def NVVM_Tcgen05FenceOp : NVVM_Op<"tcgen05.fence", [NVVMRequiresSMAA<[100, 101]>]> {
+def NVVM_Tcgen05FenceOp : NVVM_Op<"tcgen05.fence", [NVVMRequiresSMa<[100, 101]>]> {
   let summary = "Tcgen05 fence operations";
   let description = [{
     The `tcgen05.fence<before>` orders all prior async tcgen05 operations
@@ -5173,7 +5173,7 @@ def NVVM_Tcgen05FenceOp : NVVM_Op<"tcgen05.fence", [NVVMRequiresSMAA<[100, 101]>
   }];
 }
 
-def NVVM_Tcgen05WaitOp : NVVM_Op<"tcgen05.wait", [NVVMRequiresSMAA<[100, 101]>]> {
+def NVVM_Tcgen05WaitOp : NVVM_Op<"tcgen05.wait", [NVVMRequiresSMa<[100, 101]>]> {
   let summary = "Tcgen05 wait operations";
   let description = [{
     The `tcgen05.wait<load>` causes the executing thread to block until
@@ -5195,7 +5195,7 @@ def NVVM_Tcgen05WaitOp : NVVM_Op<"tcgen05.wait", [NVVMRequiresSMAA<[100, 101]>]>
   }];
 }
 
-def NVVM_Tcgen05CommitOp : NVVM_Op<"tcgen05.commit", [NVVMRequiresSMAA<[100, 101]>]> {
+def NVVM_Tcgen05CommitOp : NVVM_Op<"tcgen05.commit", [NVVMRequiresSMa<[100, 101]>]> {
   let summary = "Tcgen05 commit operations";
   let description = [{
     The `tcgen05.commit` makes the *mbarrier object*, specified by
@@ -5233,7 +5233,7 @@ def NVVM_Tcgen05CommitOp : NVVM_Op<"tcgen05.commit", [NVVMRequiresSMAA<[100, 101
   }];
 }
 
-def NVVM_Tcgen05ShiftOp : NVVM_Op<"tcgen05.shift", [NVVMRequiresSMAA<[100, 101, 103]>]> {
+def NVVM_Tcgen05ShiftOp : NVVM_Op<"tcgen05.shift", [NVVMRequiresSMa<[100, 101, 103]>]> {
   let summary = "Tcgen05 shift operation";
   let description = [{
     The `tcgen05.shift` is an asynchronous instruction which initiates
@@ -5299,7 +5299,7 @@ def Tcgen05CpSrcFormatAttr : EnumAttr<NVVM_Dialect, Tcgen05CpSrcFormat, "tcgen05
   let assemblyFormat = "`<` $value `>`";
 }
 
-def NVVM_Tcgen05CpOp : NVVM_Op<"tcgen05.cp", [NVVMRequiresSMAA<[100, 101]>]> {
+def NVVM_Tcgen05CpOp : NVVM_Op<"tcgen05.cp", [NVVMRequiresSMa<[100, 101]>]> {
   let summary = "Tcgen05 copy operation";
   let description = [{
     Instruction tcgen05.cp initiates an asynchronous copy operation from
@@ -5435,7 +5435,7 @@ def Tcgen05LdStShapeAttr: EnumAttr<NVVM_Dialect, Tcgen05LdStShape, "tcgen05_ldst
 // NVVM tcgen05.ld Op
 //===----------------------------------------------------------------------===//
 
-def NVVM_Tcgen05LdOp : NVVM_Op<"tcgen05.ld", [NVVMRequiresSMAA<[100, 101]>]> {
+def NVVM_Tcgen05LdOp : NVVM_Op<"tcgen05.ld", [NVVMRequiresSMa<[100, 101]>]> {
   let summary = "tensor memory load instructions";
   let arguments = (ins
     // Attributes
@@ -5528,7 +5528,7 @@ def NVVM_Tcgen05LdOp : NVVM_Op<"tcgen05.ld", [NVVMRequiresSMAA<[100, 101]>]> {
 //===----------------------------------------------------------------------===//
 
 def NVVM_Tcgen05LdRedOp : NVVM_Op<"tcgen05.ld.red",
-                          [NVVMRequiresSMAA<[101, 110]>]> {
+                          [NVVMRequiresSMa<[101, 110]>]> {
   let summary = "Tcgen05 tensor memory load and reduce instructions";
   let arguments = (ins
     Tcgen05LdStShapeAttr:$shape,
@@ -5617,7 +5617,7 @@ def NVVM_Tcgen05LdRedOp : NVVM_Op<"tcgen05.ld.red",
 // NVVM tcgen05.st Op
 //===----------------------------------------------------------------------===//
 
-def NVVM_Tcgen05StOp : NVVM_Op<"tcgen05.st", [NVVMRequiresSMAA<[100, 101]>]> {
+def NVVM_Tcgen05StOp : NVVM_Op<"tcgen05.st", [NVVMRequiresSMa<[100, 101]>]> {
   let summary = "tensor memory store instructions";
   let arguments = (ins
     // Attributes
@@ -5996,7 +5996,7 @@ defvar Tcgen05MMABlockScaleKindAttr =
 
 def NVVM_Tcgen05MMAOp : NVVM_Op<"tcgen05.mma",
                           [AttrSizedOperandSegments,
-                           NVVMRequiresSMAA<[100, 110]>]> {
+                           NVVMRequiresSMa<[100, 110]>]> {
   let summary = "Performs MMA operation on 5th-gen tensor cores";
 
   let description = [{
@@ -6080,7 +6080,7 @@ def NVVM_Tcgen05MMAOp : NVVM_Op<"tcgen05.mma",
 
 def NVVM_Tcgen05MMASparseOp : NVVM_Op<"tcgen05.mma.sp",
                                       [AttrSizedOperandSegments,
-                                       NVVMRequiresSMAA<[100, 110]>]> {
+                                       NVVMRequiresSMa<[100, 110]>]> {
   let summary = "Performs MMA operation with sparse A matrix on 5th-gen tensor cores";
 
   let description = [{
@@ -6161,7 +6161,7 @@ def Tcgen05MMABlockScaleAttr : EnumAttr<NVVM_Dialect, Tcgen05MMABlockScale,
 }
 
 def NVVM_Tcgen05MMABlockScaleOp : NVVM_Op<"tcgen05.mma.block_scale",
-                                          [NVVMRequiresSMAA<[100, 110]>]> {
+                                          [NVVMRequiresSMa<[100, 110]>]> {
   let summary = "Performs block scaled MMA operation on 5th-gen tensor cores";
 
   let description = [{
@@ -6234,7 +6234,7 @@ def NVVM_Tcgen05MMABlockScaleOp : NVVM_Op<"tcgen05.mma.block_scale",
 }
 
 def NVVM_Tcgen05MMASparseBlockScaleOp : NVVM_Op<"tcgen05.mma.sp.block_scale",
-                                                [NVVMRequiresSMAA<[100, 110]>]> {
+                                                [NVVMRequiresSMa<[100, 110]>]> {
   let summary = "Performs block scaled MMA operation with sparse A matrix on 5th-gen tensor cores";
 
   let description = [{
@@ -6316,7 +6316,7 @@ def Tcgen05MMACollectorBBufferAttr : EnumAttr<NVVM_Dialect, Tcgen05MMACollectorB
 }
 
 def NVVM_Tcgen05MMAWsOp : NVVM_Op<"tcgen05.mma.ws",
-                                  [NVVMRequiresSMAA<[100, 110]>]> {
+                                  [NVVMRequiresSMa<[100, 110]>]> {
   let summary = "Performs weight stationary convolution MMA operation on 5th-gen tensor cores";
 
   let description = [{
@@ -6386,7 +6386,7 @@ def NVVM_Tcgen05MMAWsOp : NVVM_Op<"tcgen05.mma.ws",
 }
 
 def NVVM_Tcgen05MMAWsSparseOp : NVVM_Op<"tcgen05.mma.ws.sp",
-                                        [NVVMRequiresSMAA<[100, 110]>]> {
+                                        [NVVMRequiresSMa<[100, 110]>]> {
   let summary = "Performs weight stationary convolution MMA with sparse A matrix on 5th-gen tensor cores";
 
   let description = [{

--- a/mlir/include/mlir/Dialect/LLVMIR/NVVMRequiresSMTraits.h
+++ b/mlir/include/mlir/Dialect/LLVMIR/NVVMRequiresSMTraits.h
@@ -23,55 +23,79 @@ namespace NVVM {
 
 // Struct to store and check compatibility of SM versions.
 struct NVVMCheckSMVersion {
-  // Set to true if the SM version is accelerated (e.g., sm_90a).
-  bool archAccelerated;
+  struct SMVersion {
+    unsigned version;
+    // Set to true if the SM version is accelerated (e.g., sm_90a).
+    bool archAccelerated;
+    // Set to true if the SM version is family-specific (e.g., sm_100f).
+    bool familySpecific;
+
+    unsigned getSmFamilyVersion() const {
+      return version / 10;
+    }
+    
+    bool hasFamilySpecificFeatures() const {
+      return familySpecific || archAccelerated;
+    }
+  };
 
   // List of SM versions.
   // Typically only has one version except for cases where multiple
   // arch-accelerated versions are supported.
   // For example, tcgen05.shift is supported on sm_100a, sm_101a, and sm_103a.
-  llvm::SmallVector<int, 1> smVersionList;
+  llvm::SmallVector<SMVersion, 1> smVersionList;
 
-  template <typename... Ints>
-  NVVMCheckSMVersion(bool archAccelerated, Ints... smVersions)
-      : archAccelerated(archAccelerated), smVersionList({smVersions...}) {
-    assert((archAccelerated || smVersionList.size() == 1) &&
-           "non arch-accelerated SM version list must be a single version!");
+  template <typename... Versions>
+  NVVMCheckSMVersion(bool archAccelerated, bool familySpecific,
+                     Versions... smVersions)
+      : smVersionList({SMVersion{static_cast<unsigned>(smVersions),
+                                 archAccelerated, familySpecific}...}) {
+    assert(
+        !(archAccelerated && familySpecific) &&
+        "archAccelerated and familySpecific cannot be true at the same time!");
   }
 
   bool isCompatibleWith(const NVVMCheckSMVersion &targetSM) const {
     assert(targetSM.smVersionList.size() == 1 &&
            "target SM version list must be a single version!");
 
-    if (archAccelerated) {
-      if (!targetSM.archAccelerated)
-        return false;
+    SMVersion targetSMVersion = targetSM.smVersionList[0];
 
-      for (auto version : smVersionList) {
-        if (version == targetSM.smVersionList[0])
-          return true;
+    return llvm::any_of(smVersionList, [&](const SMVersion &RequiredSMVersion) {
+      if (RequiredSMVersion.archAccelerated) {
+        return targetSMVersion.archAccelerated &&
+               (RequiredSMVersion.version == targetSMVersion.version);
+      } else if (RequiredSMVersion.familySpecific) {
+        return targetSMVersion.hasFamilySpecificFeatures() &&
+               (RequiredSMVersion.getSmFamilyVersion() ==
+                targetSMVersion.getSmFamilyVersion()) &&
+               (targetSMVersion.version >= RequiredSMVersion.version);
+      } else {
+        return targetSMVersion.version >= RequiredSMVersion.version;
       }
-    } else {
-      return targetSM.smVersionList[0] >= smVersionList[0];
-    }
-
-    return false;
+    });
   }
 
-  bool isMinimumSMVersion() const { return smVersionList[0] >= 20; }
+  bool isMinimumSMVersion() const { return smVersionList[0].version >= 20; }
 
   // Parses an SM version string and returns an equivalent NVVMCheckSMVersion
   // object.
-  static const NVVMCheckSMVersion
+  static NVVMCheckSMVersion
   getTargetSMVersionFromStr(StringRef smVersionString) {
     bool isAA = smVersionString.back() == 'a';
+    bool isFS = smVersionString.back() == 'f';
 
     int smVersionInt;
     smVersionString.drop_front(3)
         .take_while([](char c) { return llvm::isDigit(c); })
         .getAsInteger(10, smVersionInt);
 
-    return NVVMCheckSMVersion(isAA, smVersionInt);
+    return NVVMCheckSMVersion(isAA, isFS, smVersionInt);
+  }
+  
+  NVVMCheckSMVersion &append(const NVVMCheckSMVersion &other) {
+    smVersionList.append(other.smVersionList);
+    return *this;
   }
 };
 
@@ -92,8 +116,8 @@ public:
       : public OpTrait::TraitBase<ConcreteOp, NVVMRequiresSM<MinVersion>::Impl>,
         public mlir::NVVM::RequiresSMInterface::Trait<ConcreteOp> {
   public:
-    const NVVM::NVVMCheckSMVersion getRequiredMinSMVersion() const {
-      return NVVM::NVVMCheckSMVersion(false, MinVersion);
+    NVVM::NVVMCheckSMVersion getRequiredMinSMVersion() const {
+      return NVVM::NVVMCheckSMVersion(false, false, MinVersion);
     }
   };
 };
@@ -106,12 +130,49 @@ public:
                                          NVVMRequiresSMa<SMVersions...>::Impl>,
                public mlir::NVVM::RequiresSMInterface::Trait<ConcreteOp> {
   public:
-    const NVVM::NVVMCheckSMVersion getRequiredMinSMVersion() const {
-      return NVVM::NVVMCheckSMVersion(true, SMVersions...);
+    NVVM::NVVMCheckSMVersion getRequiredMinSMVersion() const {
+      return NVVM::NVVMCheckSMVersion(true, false, SMVersions...);
+    }
+  };
+
+  static NVVM::NVVMCheckSMVersion getRequiredMinSMVersion() {
+    return NVVM::NVVMCheckSMVersion(true, false, SMVersions...);
+  }
+};
+
+template <int... SMVersions>
+class NVVMRequiresSMf {
+public:
+  template <typename ConcreteOp>
+  class Impl : public OpTrait::TraitBase<ConcreteOp,
+                                         NVVMRequiresSMf<SMVersions...>::Impl>,
+               public mlir::NVVM::RequiresSMInterface::Trait<ConcreteOp> {
+  public:
+    NVVM::NVVMCheckSMVersion getRequiredMinSMVersion() const {
+      return NVVM::NVVMCheckSMVersion(false, true, SMVersions...);
+    }
+  };
+
+  static NVVM::NVVMCheckSMVersion getRequiredMinSMVersion() {
+    return NVVM::NVVMCheckSMVersion(false, true, SMVersions...);
+  }
+};
+
+template <typename T, typename U>
+class NVVMRequiresSMaOrf {
+public:
+  template <typename ConcreteOp>
+  class Impl
+      : public OpTrait::TraitBase<ConcreteOp, NVVMRequiresSMaOrf<T, U>::Impl>,
+        public mlir::NVVM::RequiresSMInterface::Trait<ConcreteOp> {
+  public:
+    NVVM::NVVMCheckSMVersion getRequiredMinSMVersion() const {
+      auto result = T::getRequiredMinSMVersion();
+      result.append(U::getRequiredMinSMVersion());
+      return result;
     }
   };
 };
-
 } // namespace OpTrait
 } // namespace mlir
 #endif // NVVM_DIALECT_NVVM_IR_NVVMREQUIRESSMTRAITS_H_

--- a/mlir/include/mlir/Dialect/LLVMIR/NVVMRequiresSMTraits.h
+++ b/mlir/include/mlir/Dialect/LLVMIR/NVVMRequiresSMTraits.h
@@ -24,8 +24,9 @@ namespace NVVM {
 // Struct to store and check compatibility of SM versions.
 struct NVVMCheckSMVersion {
   struct SMVersion {
+    // Base SM version (e.g., sm_100)
     unsigned version;
-    // Set to true if the SM version is accelerated (e.g., sm_90a).
+    // Set to true if the SM version is accelerated (e.g., sm_100a).
     bool archAccelerated;
     // Set to true if the SM version is family-specific (e.g., sm_100f).
     bool familySpecific;
@@ -39,9 +40,9 @@ struct NVVMCheckSMVersion {
 
   // List of SM versions.
   // Typically only has one version except for cases where multiple
-  // arch-accelerated versions are supported.
+  // arch-accelerated or family-conditional versions are supported.
   // For example, tcgen05.shift is supported on sm_100a, sm_101a, and sm_103a.
-  llvm::SmallVector<SMVersion, 1> smVersionList;
+  llvm::SmallVector<SMVersion> smVersionList;
 
   template <typename... Versions>
   NVVMCheckSMVersion(bool archAccelerated, bool familySpecific,
@@ -55,22 +56,22 @@ struct NVVMCheckSMVersion {
 
   bool isCompatibleWith(const NVVMCheckSMVersion &targetSM) const {
     assert(targetSM.smVersionList.size() == 1 &&
-           "target SM version list must be a single version!");
+           "target SM version list must have a single version!");
 
     SMVersion targetSMVersion = targetSM.smVersionList[0];
 
     return llvm::any_of(smVersionList, [&](const SMVersion &RequiredSMVersion) {
-      if (RequiredSMVersion.archAccelerated) {
+      if (RequiredSMVersion.archAccelerated)
         return targetSMVersion.archAccelerated &&
                (RequiredSMVersion.version == targetSMVersion.version);
-      } else if (RequiredSMVersion.familySpecific) {
+
+      if (RequiredSMVersion.familySpecific)
         return targetSMVersion.hasFamilySpecificFeatures() &&
                (RequiredSMVersion.getSmFamilyVersion() ==
                 targetSMVersion.getSmFamilyVersion()) &&
                (targetSMVersion.version >= RequiredSMVersion.version);
-      } else {
-        return targetSMVersion.version >= RequiredSMVersion.version;
-      }
+
+      return targetSMVersion.version >= RequiredSMVersion.version;
     });
   }
 
@@ -91,9 +92,8 @@ struct NVVMCheckSMVersion {
     return NVVMCheckSMVersion(isAA, isFS, smVersionInt);
   }
 
-  NVVMCheckSMVersion &append(const NVVMCheckSMVersion &other) {
+  void append(const NVVMCheckSMVersion &other) {
     smVersionList.append(other.smVersionList);
-    return *this;
   }
 };
 
@@ -156,17 +156,18 @@ public:
   }
 };
 
-template <typename T, typename U>
+template <typename SMVersionsA, typename SMVersionsF>
 class NVVMRequiresSMaOrf {
 public:
   template <typename ConcreteOp>
   class Impl
-      : public OpTrait::TraitBase<ConcreteOp, NVVMRequiresSMaOrf<T, U>::Impl>,
+      : public OpTrait::TraitBase<
+            ConcreteOp, NVVMRequiresSMaOrf<SMVersionsA, SMVersionsF>::Impl>,
         public mlir::NVVM::RequiresSMInterface::Trait<ConcreteOp> {
   public:
     NVVM::NVVMCheckSMVersion getRequiredMinSMVersion() const {
-      auto result = T::getRequiredMinSMVersion();
-      result.append(U::getRequiredMinSMVersion());
+      auto result = SMVersionsA::getRequiredMinSMVersion();
+      result.append(SMVersionsF::getRequiredMinSMVersion());
       return result;
     }
   };

--- a/mlir/include/mlir/Dialect/LLVMIR/NVVMRequiresSMTraits.h
+++ b/mlir/include/mlir/Dialect/LLVMIR/NVVMRequiresSMTraits.h
@@ -120,12 +120,14 @@ public:
   };
 };
 
+// SMVersions is a template parameter pack of the supported
+// architecture-accelerated SM versions.
 template <int... SMVersions>
-class NVVMRequiresSMa {
+class NVVMRequiresSMAA {
 public:
   template <typename ConcreteOp>
   class Impl : public OpTrait::TraitBase<ConcreteOp,
-                                         NVVMRequiresSMa<SMVersions...>::Impl>,
+                                         NVVMRequiresSMAA<SMVersions...>::Impl>,
                public mlir::NVVM::RequiresSMInterface::Trait<ConcreteOp> {
   public:
     NVVM::NVVMCheckSMVersion getRequiredMinSMVersion() const {
@@ -138,12 +140,14 @@ public:
   }
 };
 
+// SMVersions is a template parameter pack of the supported family-specific SM
+// versions.
 template <int... SMVersions>
-class NVVMRequiresSMf {
+class NVVMRequiresSMFS {
 public:
   template <typename ConcreteOp>
   class Impl : public OpTrait::TraitBase<ConcreteOp,
-                                         NVVMRequiresSMf<SMVersions...>::Impl>,
+                                         NVVMRequiresSMFS<SMVersions...>::Impl>,
                public mlir::NVVM::RequiresSMInterface::Trait<ConcreteOp> {
   public:
     NVVM::NVVMCheckSMVersion getRequiredMinSMVersion() const {
@@ -156,18 +160,20 @@ public:
   }
 };
 
-template <typename SMVersionsA, typename SMVersionsF>
-class NVVMRequiresSMaOrf {
+// SMVersionsAA (SMVersionsFS) is a template parameter pack of the supported
+// architecture-accelerated (family-specific) SM versions.
+template <typename SMVersionsAA, typename SMVersionsFS>
+class NVVMRequiresSMAAOrFS {
 public:
   template <typename ConcreteOp>
   class Impl
       : public OpTrait::TraitBase<
-            ConcreteOp, NVVMRequiresSMaOrf<SMVersionsA, SMVersionsF>::Impl>,
+            ConcreteOp, NVVMRequiresSMAAOrFS<SMVersionsAA, SMVersionsFS>::Impl>,
         public mlir::NVVM::RequiresSMInterface::Trait<ConcreteOp> {
   public:
     NVVM::NVVMCheckSMVersion getRequiredMinSMVersion() const {
-      auto result = SMVersionsA::getRequiredMinSMVersion();
-      result.append(SMVersionsF::getRequiredMinSMVersion());
+      auto result = SMVersionsAA::getRequiredMinSMVersion();
+      result.append(SMVersionsFS::getRequiredMinSMVersion());
       return result;
     }
   };

--- a/mlir/include/mlir/Dialect/LLVMIR/NVVMRequiresSMTraits.h
+++ b/mlir/include/mlir/Dialect/LLVMIR/NVVMRequiresSMTraits.h
@@ -23,6 +23,9 @@ namespace NVVM {
 
 // Struct to store and check compatibility of SM versions.
 struct NVVMCheckSMVersion {
+  static constexpr char kArchAcceleratedSuffix = 'a';
+  static constexpr char kFamilySpecificSuffix = 'f';
+
   // List of supported full SM versions.
   // This is used to check compatibility with a target SM version.
   // The full SM version is encoded as SM * 10 + ArchSuffixOffset where:
@@ -60,8 +63,8 @@ struct NVVMCheckSMVersion {
   // Parses an SM version string and returns an equivalent full SM version
   // integer.
   static unsigned getTargetFullSmVersionFromStr(StringRef smVersionString) {
-    bool isAA = smVersionString.back() == 'a';
-    bool isFS = smVersionString.back() == 'f';
+    bool isAA = smVersionString.back() == kArchAcceleratedSuffix;
+    bool isFS = smVersionString.back() == kFamilySpecificSuffix;
 
     unsigned smVersion;
     smVersionString.drop_front(3)

--- a/mlir/include/mlir/Dialect/LLVMIR/NVVMRequiresSMTraits.h
+++ b/mlir/include/mlir/Dialect/LLVMIR/NVVMRequiresSMTraits.h
@@ -70,7 +70,7 @@ struct NVVMCheckSMVersion {
 
     return smVersion * 10 + (isAA ? 3 : 0) + (isFS ? 2 : 0);
   }
-  
+
   static bool isMinimumSMVersion(unsigned fullSmVersion) {
     return getSMVersion(fullSmVersion) >= 20;
   }

--- a/mlir/include/mlir/Dialect/LLVMIR/NVVMRequiresSMTraits.h
+++ b/mlir/include/mlir/Dialect/LLVMIR/NVVMRequiresSMTraits.h
@@ -23,77 +23,61 @@ namespace NVVM {
 
 // Struct to store and check compatibility of SM versions.
 struct NVVMCheckSMVersion {
-  struct SMVersion {
-    // Base SM version (e.g., sm_100)
-    unsigned version;
-    // Set to true if the SM version is accelerated (e.g., sm_100a).
-    bool archAccelerated;
-    // Set to true if the SM version is family-specific (e.g., sm_100f).
-    bool familySpecific;
-
-    unsigned getSmFamilyVersion() const { return version / 10; }
-
-    bool hasFamilySpecificFeatures() const {
-      return familySpecific || archAccelerated;
-    }
-  };
-
-  // List of SM versions.
-  // Typically only has one version except for cases where multiple
-  // arch-accelerated or family-conditional versions are supported.
-  // For example, tcgen05.shift is supported on sm_100a, sm_101a, and sm_103a.
-  llvm::SmallVector<SMVersion> smVersionList;
+  // List of supported full SM versions.
+  // This is used to check compatibility with a target SM version.
+  // The full SM version is encoded as SM * 10 + ArchSuffixOffset where:
+  // - SM is the SM version (e.g., 100)
+  // - ArchSuffixOffset is 0 for base, 2 for family-specific, and 3 for
+  //   architecture-accelerated
+  //
+  // For example, sm_100 is encoded as 1000 (100 * 10 + 0), sm_100f is encoded
+  // as 1002 (100 * 10 + 2) and sm_100a is encoded as 1003 (100 * 10 + 3).
+  llvm::SmallVector<unsigned> fullSmVersionList;
 
   template <typename... Versions>
-  NVVMCheckSMVersion(bool archAccelerated, bool familySpecific,
-                     Versions... smVersions)
-      : smVersionList({SMVersion{static_cast<unsigned>(smVersions),
-                                 archAccelerated, familySpecific}...}) {
-    assert(
-        !(archAccelerated && familySpecific) &&
-        "archAccelerated and familySpecific cannot be true at the same time!");
+  NVVMCheckSMVersion(Versions... fullSmVersions)
+      : fullSmVersionList({fullSmVersions...}) {}
+
+  bool isCompatibleWith(const unsigned &targetFullSmVersion) const {
+    return llvm::any_of(
+        fullSmVersionList, [&](const unsigned &requiredFullSmVersion) {
+          if (hasArchAcceleratedFeatures(requiredFullSmVersion))
+            return targetFullSmVersion == requiredFullSmVersion;
+
+          if (hasFamilySpecificFeatures(requiredFullSmVersion))
+            return hasFamilySpecificFeatures(targetFullSmVersion) &&
+                   ((targetFullSmVersion / 100) ==
+                    (requiredFullSmVersion / 100));
+
+          return targetFullSmVersion >= requiredFullSmVersion;
+        });
   }
 
-  bool isCompatibleWith(const NVVMCheckSMVersion &targetSM) const {
-    assert(targetSM.smVersionList.size() == 1 &&
-           "target SM version list must have a single version!");
-
-    SMVersion targetSMVersion = targetSM.smVersionList[0];
-
-    return llvm::any_of(smVersionList, [&](const SMVersion &RequiredSMVersion) {
-      if (RequiredSMVersion.archAccelerated)
-        return targetSMVersion.archAccelerated &&
-               (RequiredSMVersion.version == targetSMVersion.version);
-
-      if (RequiredSMVersion.familySpecific)
-        return targetSMVersion.hasFamilySpecificFeatures() &&
-               (RequiredSMVersion.getSmFamilyVersion() ==
-                targetSMVersion.getSmFamilyVersion()) &&
-               (targetSMVersion.version >= RequiredSMVersion.version);
-
-      return targetSMVersion.version >= RequiredSMVersion.version;
-    });
+  static bool isMinimumSMVersion(unsigned targetFullSmVersion) {
+    return targetFullSmVersion >= 200;
   }
 
-  bool isMinimumSMVersion() const { return smVersionList[0].version >= 20; }
-
-  // Parses an SM version string and returns an equivalent NVVMCheckSMVersion
-  // object.
-  static NVVMCheckSMVersion
-  getTargetSMVersionFromStr(StringRef smVersionString) {
+  // Parses an SM version string and returns an equivalent full SM version
+  // integer.
+  static unsigned getTargetFullSmVersionFromStr(StringRef smVersionString) {
     bool isAA = smVersionString.back() == 'a';
     bool isFS = smVersionString.back() == 'f';
 
-    int smVersionInt;
+    unsigned smVersion;
     smVersionString.drop_front(3)
         .take_while([](char c) { return llvm::isDigit(c); })
-        .getAsInteger(10, smVersionInt);
+        .getAsInteger(10, smVersion);
 
-    return NVVMCheckSMVersion(isAA, isFS, smVersionInt);
+    return smVersion * 10 + (isAA ? 3 : 0) + (isFS ? 2 : 0);
   }
 
-  void append(const NVVMCheckSMVersion &other) {
-    smVersionList.append(other.smVersionList);
+private:
+  bool hasFamilySpecificFeatures(unsigned fullSmVersion) const {
+    return (fullSmVersion % 10) != 0;
+  }
+
+  bool hasArchAcceleratedFeatures(unsigned fullSmVersion) const {
+    return (fullSmVersion % 10) == 3;
   }
 };
 
@@ -106,75 +90,17 @@ namespace mlir {
 
 namespace OpTrait {
 
-template <int MinVersion>
+template <unsigned... FullSMVersions>
 class NVVMRequiresSM {
 public:
   template <typename ConcreteOp>
   class Impl
-      : public OpTrait::TraitBase<ConcreteOp, NVVMRequiresSM<MinVersion>::Impl>,
+      : public OpTrait::TraitBase<ConcreteOp,
+                                  NVVMRequiresSM<FullSMVersions...>::Impl>,
         public mlir::NVVM::RequiresSMInterface::Trait<ConcreteOp> {
   public:
     NVVM::NVVMCheckSMVersion getRequiredMinSMVersion() const {
-      return NVVM::NVVMCheckSMVersion(false, false, MinVersion);
-    }
-  };
-};
-
-// SMVersions is a template parameter pack of the supported
-// architecture-accelerated SM versions.
-template <int... SMVersions>
-class NVVMRequiresSMAA {
-public:
-  template <typename ConcreteOp>
-  class Impl : public OpTrait::TraitBase<ConcreteOp,
-                                         NVVMRequiresSMAA<SMVersions...>::Impl>,
-               public mlir::NVVM::RequiresSMInterface::Trait<ConcreteOp> {
-  public:
-    NVVM::NVVMCheckSMVersion getRequiredMinSMVersion() const {
-      return NVVM::NVVMCheckSMVersion(true, false, SMVersions...);
-    }
-  };
-
-  static NVVM::NVVMCheckSMVersion getRequiredMinSMVersion() {
-    return NVVM::NVVMCheckSMVersion(true, false, SMVersions...);
-  }
-};
-
-// SMVersions is a template parameter pack of the supported family-specific SM
-// versions.
-template <int... SMVersions>
-class NVVMRequiresSMFS {
-public:
-  template <typename ConcreteOp>
-  class Impl : public OpTrait::TraitBase<ConcreteOp,
-                                         NVVMRequiresSMFS<SMVersions...>::Impl>,
-               public mlir::NVVM::RequiresSMInterface::Trait<ConcreteOp> {
-  public:
-    NVVM::NVVMCheckSMVersion getRequiredMinSMVersion() const {
-      return NVVM::NVVMCheckSMVersion(false, true, SMVersions...);
-    }
-  };
-
-  static NVVM::NVVMCheckSMVersion getRequiredMinSMVersion() {
-    return NVVM::NVVMCheckSMVersion(false, true, SMVersions...);
-  }
-};
-
-// SMVersionsAA (SMVersionsFS) is a template parameter pack of the supported
-// architecture-accelerated (family-specific) SM versions.
-template <typename SMVersionsAA, typename SMVersionsFS>
-class NVVMRequiresSMAAOrFS {
-public:
-  template <typename ConcreteOp>
-  class Impl
-      : public OpTrait::TraitBase<
-            ConcreteOp, NVVMRequiresSMAAOrFS<SMVersionsAA, SMVersionsFS>::Impl>,
-        public mlir::NVVM::RequiresSMInterface::Trait<ConcreteOp> {
-  public:
-    NVVM::NVVMCheckSMVersion getRequiredMinSMVersion() const {
-      auto result = SMVersionsAA::getRequiredMinSMVersion();
-      result.append(SMVersionsFS::getRequiredMinSMVersion());
-      return result;
+      return NVVM::NVVMCheckSMVersion(FullSMVersions...);
     }
   };
 };

--- a/mlir/include/mlir/Dialect/LLVMIR/NVVMRequiresSMTraits.h
+++ b/mlir/include/mlir/Dialect/LLVMIR/NVVMRequiresSMTraits.h
@@ -42,7 +42,9 @@ struct NVVMCheckSMVersion {
     return llvm::any_of(
         fullSmVersionList, [&](const unsigned &requiredFullSmVersion) {
           if (hasArchAcceleratedFeatures(requiredFullSmVersion))
-            return targetFullSmVersion == requiredFullSmVersion;
+            return hasArchAcceleratedFeatures(targetFullSmVersion) &&
+                   (getSMVersion(targetFullSmVersion) ==
+                    getSMVersion(requiredFullSmVersion));
 
           if (hasFamilySpecificFeatures(requiredFullSmVersion))
             return hasFamilySpecificFeatures(targetFullSmVersion) &&
@@ -53,14 +55,6 @@ struct NVVMCheckSMVersion {
 
           return targetFullSmVersion >= requiredFullSmVersion;
         });
-  }
-
-  static unsigned getSMVersion(unsigned fullSmVersion) {
-    return fullSmVersion / 10;
-  }
-
-  static unsigned getSMFamily(unsigned fullSmVersion) {
-    return fullSmVersion / 100;
   }
 
   // Parses an SM version string and returns an equivalent full SM version
@@ -76,14 +70,26 @@ struct NVVMCheckSMVersion {
 
     return smVersion * 10 + (isAA ? 3 : 0) + (isFS ? 2 : 0);
   }
-
-private:
-  bool hasFamilySpecificFeatures(unsigned fullSmVersion) const {
-    return (fullSmVersion % 10) != 0;
+  
+  static bool isMinimumSMVersion(unsigned fullSmVersion) {
+    return getSMVersion(fullSmVersion) >= 20;
   }
 
-  bool hasArchAcceleratedFeatures(unsigned fullSmVersion) const {
+private:
+  static bool hasFamilySpecificFeatures(unsigned fullSmVersion) {
+    return (fullSmVersion % 10) >= 2;
+  }
+
+  static bool hasArchAcceleratedFeatures(unsigned fullSmVersion) {
     return (fullSmVersion % 10) == 3;
+  }
+
+  static unsigned getSMVersion(unsigned fullSmVersion) {
+    return fullSmVersion / 10;
+  }
+
+  static unsigned getSMFamily(unsigned fullSmVersion) {
+    return fullSmVersion / 100;
   }
 };
 

--- a/mlir/include/mlir/Dialect/LLVMIR/NVVMRequiresSMTraits.h
+++ b/mlir/include/mlir/Dialect/LLVMIR/NVVMRequiresSMTraits.h
@@ -46,15 +46,21 @@ struct NVVMCheckSMVersion {
 
           if (hasFamilySpecificFeatures(requiredFullSmVersion))
             return hasFamilySpecificFeatures(targetFullSmVersion) &&
-                   ((targetFullSmVersion / 100) ==
-                    (requiredFullSmVersion / 100));
+                   (getSMFamily(targetFullSmVersion) ==
+                    getSMFamily(requiredFullSmVersion)) &&
+                   (getSMVersion(targetFullSmVersion) >=
+                    getSMVersion(requiredFullSmVersion));
 
           return targetFullSmVersion >= requiredFullSmVersion;
         });
   }
 
-  static bool isMinimumSMVersion(unsigned targetFullSmVersion) {
-    return targetFullSmVersion >= 200;
+  static unsigned getSMVersion(unsigned fullSmVersion) {
+    return fullSmVersion / 10;
+  }
+
+  static unsigned getSMFamily(unsigned fullSmVersion) {
+    return fullSmVersion / 100;
   }
 
   // Parses an SM version string and returns an equivalent full SM version

--- a/mlir/include/mlir/Dialect/LLVMIR/NVVMRequiresSMTraits.h
+++ b/mlir/include/mlir/Dialect/LLVMIR/NVVMRequiresSMTraits.h
@@ -30,10 +30,8 @@ struct NVVMCheckSMVersion {
     // Set to true if the SM version is family-specific (e.g., sm_100f).
     bool familySpecific;
 
-    unsigned getSmFamilyVersion() const {
-      return version / 10;
-    }
-    
+    unsigned getSmFamilyVersion() const { return version / 10; }
+
     bool hasFamilySpecificFeatures() const {
       return familySpecific || archAccelerated;
     }
@@ -92,7 +90,7 @@ struct NVVMCheckSMVersion {
 
     return NVVMCheckSMVersion(isAA, isFS, smVersionInt);
   }
-  
+
   NVVMCheckSMVersion &append(const NVVMCheckSMVersion &other) {
     smVersionList.append(other.smVersionList);
     return *this;

--- a/mlir/include/mlir/Dialect/LLVMIR/NVVMRequiresSMTraits.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/NVVMRequiresSMTraits.td
@@ -48,7 +48,7 @@ class NVVMRequiresSMf<list<int> smVersions> :
 class NVVMRequiresSMaOrSMf<list<int> smVersionsA, list<int> smVersionsF> :
   ParamNativeOpTrait<"NVVMRequiresSM",
     !interleave(!foreach(smVersion, smVersionsA, 
-                  !add(!mul(smVersion, 10), 3)), ",") # "," #
-    !interleave(!foreach(smVersion, smVersionsF, 
+                  !add(!mul(smVersion, 10), 3)) #
+                !foreach(smVersion, smVersionsF, 
                   !add(!mul(smVersion, 10), 2)), ",")>;
 #endif //NVVM_REQUIRES_SM_TRAITS

--- a/mlir/include/mlir/Dialect/LLVMIR/NVVMRequiresSMTraits.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/NVVMRequiresSMTraits.td
@@ -22,12 +22,12 @@ def RequiresSMInterface: OpInterface<"RequiresSMInterface"> {
   let methods = [
     InterfaceMethod<
       "Get the SM version required by the op from the trait", 
-      "const mlir::NVVM::NVVMCheckSMVersion", "getRequiredMinSMVersion"
+      "mlir::NVVM::NVVMCheckSMVersion", "getRequiredMinSMVersion"
     >
   ];
 }
 
-// OP requires a specified minimum SM value or higher; 
+// Op requires a specified minimum SM value or higher; 
 // it is not architecture-specific.
 class NVVMRequiresSM<int minVersion> :
   ParamNativeOpTrait<"NVVMRequiresSM", !cast<string>(minVersion)>;
@@ -37,11 +37,23 @@ class StrJoin<string sep, list<string> str_list> {
                !if(!eq(a, ""), b, !if(!eq(b, ""), a, !strconcat(a, sep, b))));
 }
 
-// OP requires an exact SM match along with 
-// architecture acceleration.
+// Op requires an exact SM match along with architecture acceleration.
 class NVVMRequiresSMa<list<int> smVersions> :
   ParamNativeOpTrait<"NVVMRequiresSMa",
                       StrJoin<",", !foreach(vers, smVersions,
                                             !cast<string>(vers))>.ret>;
 
+// Op requires an SM version belonging to the family.
+class NVVMRequiresSMf<list<int> smVersions> :
+  ParamNativeOpTrait<"NVVMRequiresSMf",
+                      StrJoin<",", !foreach(vers, smVersions,
+                                            !cast<string>(vers))>.ret>;
+
+// Op supported on some combination of architecture acceleration and family-specific SM versions.
+class NVVMRequiresSMaOrf<list<int> smVersionsA, list<int> smVersionsF> :
+  ParamNativeOpTrait<"NVVMRequiresSMaOrf",
+    "mlir::OpTrait::NVVMRequiresSMa<" # StrJoin<",",
+      !foreach(vers, smVersionsA, !cast<string>(vers))>.ret # ">" # "," #
+    "mlir::OpTrait::NVVMRequiresSMf<" # StrJoin<",",
+      !foreach(vers, smVersionsF, !cast<string>(vers))>.ret # ">">;
 #endif //NVVM_REQUIRES_SM_TRAITS

--- a/mlir/include/mlir/Dialect/LLVMIR/NVVMRequiresSMTraits.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/NVVMRequiresSMTraits.td
@@ -45,7 +45,7 @@ class NVVMRequiresSMf<list<int> smVersions> :
                   !add(!mul(smVersion, 10), 2)), ",")>;
 
 // Op supported on some combination of architecture acceleration and family-specific SM versions.
-class NVVMRequiresSMaOrf<list<int> smVersionsA, list<int> smVersionsF> :
+class NVVMRequiresSMaOrSMf<list<int> smVersionsA, list<int> smVersionsF> :
   ParamNativeOpTrait<"NVVMRequiresSM",
     !interleave(!foreach(smVersion, smVersionsA, 
                   !add(!mul(smVersion, 10), 3)), ",") # "," #

--- a/mlir/include/mlir/Dialect/LLVMIR/NVVMRequiresSMTraits.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/NVVMRequiresSMTraits.td
@@ -21,7 +21,7 @@ def RequiresSMInterface: OpInterface<"RequiresSMInterface"> {
   let cppNamespace = "::mlir::NVVM";
   let methods = [
     InterfaceMethod<
-      "Get the SM version required by the op from the trait", 
+      "Get the SM version require by the op from the trait", 
       "mlir::NVVM::NVVMCheckSMVersion", "getRequiredMinSMVersion"
     >
   ];
@@ -30,19 +30,25 @@ def RequiresSMInterface: OpInterface<"RequiresSMInterface"> {
 // Op requires a specified minimum SM value or higher; 
 // it is not architecture-specific.
 class NVVMRequiresSM<int minVersion> :
-  ParamNativeOpTrait<"NVVMRequiresSM", !cast<string>(minVersion)>;
+  ParamNativeOpTrait<"NVVMRequiresSM", !cast<string>(minVersion) # "0">;
 
 // Op requires an exact SM match along with architecture acceleration.
-class NVVMRequiresSMAA<list<int> smVersions> :
-  ParamNativeOpTrait<"NVVMRequiresSMAA", !interleave(smVersions, ",")>;
+class NVVMRequiresSMa<list<int> smVersions> :
+  ParamNativeOpTrait<"NVVMRequiresSM",
+    !interleave(!foreach(smVersion, smVersions, 
+                  !add(!mul(smVersion, 10), 3)), ",")>;
 
 // Op requires an SM version belonging to the family.
-class NVVMRequiresSMFS<list<int> smVersions> :
-  ParamNativeOpTrait<"NVVMRequiresSMFS", !interleave(smVersions, ",")>;
+class NVVMRequiresSMf<list<int> smVersions> :
+  ParamNativeOpTrait<"NVVMRequiresSM", 
+    !interleave(!foreach(smVersion, smVersions, 
+                  !add(!mul(smVersion, 10), 2)), ",")>;
 
 // Op supported on some combination of architecture acceleration and family-specific SM versions.
-class NVVMRequiresSMAAOrFS<list<int> smVersionsAA, list<int> smVersionsFS> :
-  ParamNativeOpTrait<"NVVMRequiresSMAAOrFS",
-    "mlir::OpTrait::NVVMRequiresSMAA<" # !interleave(smVersionsAA, ",") # ">" # "," #
-    "mlir::OpTrait::NVVMRequiresSMFS<" # !interleave(smVersionsFS, ",") # ">">;
+class NVVMRequiresSMaOrf<list<int> smVersionsA, list<int> smVersionsF> :
+  ParamNativeOpTrait<"NVVMRequiresSM",
+    !interleave(!foreach(smVersion, smVersionsA, 
+                  !add(!mul(smVersion, 10), 3)), ",") # "," #
+    !interleave(!foreach(smVersion, smVersionsF, 
+                  !add(!mul(smVersion, 10), 2)), ",")>;
 #endif //NVVM_REQUIRES_SM_TRAITS

--- a/mlir/include/mlir/Dialect/LLVMIR/NVVMRequiresSMTraits.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/NVVMRequiresSMTraits.td
@@ -21,7 +21,7 @@ def RequiresSMInterface: OpInterface<"RequiresSMInterface"> {
   let cppNamespace = "::mlir::NVVM";
   let methods = [
     InterfaceMethod<
-      "Get the SM version require by the op from the trait", 
+      "Get the SM version required by the op from the trait", 
       "mlir::NVVM::NVVMCheckSMVersion", "getRequiredMinSMVersion"
     >
   ];

--- a/mlir/include/mlir/Dialect/LLVMIR/NVVMRequiresSMTraits.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/NVVMRequiresSMTraits.td
@@ -33,16 +33,16 @@ class NVVMRequiresSM<int minVersion> :
   ParamNativeOpTrait<"NVVMRequiresSM", !cast<string>(minVersion)>;
 
 // Op requires an exact SM match along with architecture acceleration.
-class NVVMRequiresSMa<list<int> smVersions> :
-  ParamNativeOpTrait<"NVVMRequiresSMa", !interleave(smVersions, ",")>;
+class NVVMRequiresSMAA<list<int> smVersions> :
+  ParamNativeOpTrait<"NVVMRequiresSMAA", !interleave(smVersions, ",")>;
 
 // Op requires an SM version belonging to the family.
-class NVVMRequiresSMf<list<int> smVersions> :
-  ParamNativeOpTrait<"NVVMRequiresSMf", !interleave(smVersions, ",")>;
+class NVVMRequiresSMFS<list<int> smVersions> :
+  ParamNativeOpTrait<"NVVMRequiresSMFS", !interleave(smVersions, ",")>;
 
 // Op supported on some combination of architecture acceleration and family-specific SM versions.
-class NVVMRequiresSMaOrf<list<int> smVersionsA, list<int> smVersionsF> :
-  ParamNativeOpTrait<"NVVMRequiresSMaOrf",
-    "mlir::OpTrait::NVVMRequiresSMa<" # !interleave(smVersionsA, ",") # ">" # "," #
-    "mlir::OpTrait::NVVMRequiresSMf<" # !interleave(smVersionsF, ",") # ">">;
+class NVVMRequiresSMAAOrFS<list<int> smVersionsAA, list<int> smVersionsFS> :
+  ParamNativeOpTrait<"NVVMRequiresSMAAOrFS",
+    "mlir::OpTrait::NVVMRequiresSMAA<" # !interleave(smVersionsAA, ",") # ">" # "," #
+    "mlir::OpTrait::NVVMRequiresSMFS<" # !interleave(smVersionsFS, ",") # ">">;
 #endif //NVVM_REQUIRES_SM_TRAITS

--- a/mlir/include/mlir/Dialect/LLVMIR/NVVMRequiresSMTraits.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/NVVMRequiresSMTraits.td
@@ -32,28 +32,17 @@ def RequiresSMInterface: OpInterface<"RequiresSMInterface"> {
 class NVVMRequiresSM<int minVersion> :
   ParamNativeOpTrait<"NVVMRequiresSM", !cast<string>(minVersion)>;
 
-class StrJoin<string sep, list<string> str_list> {
-  string ret = !foldl("", str_list, a, b,
-               !if(!eq(a, ""), b, !if(!eq(b, ""), a, !strconcat(a, sep, b))));
-}
-
 // Op requires an exact SM match along with architecture acceleration.
 class NVVMRequiresSMa<list<int> smVersions> :
-  ParamNativeOpTrait<"NVVMRequiresSMa",
-                      StrJoin<",", !foreach(vers, smVersions,
-                                            !cast<string>(vers))>.ret>;
+  ParamNativeOpTrait<"NVVMRequiresSMa", !interleave(smVersions, ",")>;
 
 // Op requires an SM version belonging to the family.
 class NVVMRequiresSMf<list<int> smVersions> :
-  ParamNativeOpTrait<"NVVMRequiresSMf",
-                      StrJoin<",", !foreach(vers, smVersions,
-                                            !cast<string>(vers))>.ret>;
+  ParamNativeOpTrait<"NVVMRequiresSMf", !interleave(smVersions, ",")>;
 
 // Op supported on some combination of architecture acceleration and family-specific SM versions.
 class NVVMRequiresSMaOrf<list<int> smVersionsA, list<int> smVersionsF> :
   ParamNativeOpTrait<"NVVMRequiresSMaOrf",
-    "mlir::OpTrait::NVVMRequiresSMa<" # StrJoin<",",
-      !foreach(vers, smVersionsA, !cast<string>(vers))>.ret # ">" # "," #
-    "mlir::OpTrait::NVVMRequiresSMf<" # StrJoin<",",
-      !foreach(vers, smVersionsF, !cast<string>(vers))>.ret # ">">;
+    "mlir::OpTrait::NVVMRequiresSMa<" # !interleave(smVersionsA, ",") # ">" # "," #
+    "mlir::OpTrait::NVVMRequiresSMf<" # !interleave(smVersionsF, ",") # ">">;
 #endif //NVVM_REQUIRES_SM_TRAITS

--- a/mlir/lib/Dialect/LLVMIR/IR/NVVMDialect.cpp
+++ b/mlir/lib/Dialect/LLVMIR/IR/NVVMDialect.cpp
@@ -6053,9 +6053,9 @@ LogicalResult NVVMTargetAttr::verifyTarget(Operation *gpuModule) {
                      "NVVM target attribute must be attached to a GPU module");
   }
 
-  const NVVMCheckSMVersion targetSMVersion =
-      NVVMCheckSMVersion::getTargetSMVersionFromStr(getChip());
-  if (!targetSMVersion.isMinimumSMVersion()) {
+  const unsigned targetFullSmVersion =
+      NVVMCheckSMVersion::getTargetFullSmVersionFromStr(getChip());
+  if (!NVVMCheckSMVersion::isMinimumSMVersion(targetFullSmVersion)) {
     return emitError(gpuModule->getLoc(),
                      "Minimum NVVM target SM version is sm_20");
   }
@@ -6065,7 +6065,7 @@ LogicalResult NVVMTargetAttr::verifyTarget(Operation *gpuModule) {
             if (auto reqOp = llvm::dyn_cast<NVVM::RequiresSMInterface>(op)) {
               const NVVMCheckSMVersion requirement =
                   reqOp.getRequiredMinSMVersion();
-              if (!requirement.isCompatibleWith(targetSMVersion)) {
+              if (!requirement.isCompatibleWith(targetFullSmVersion)) {
                 op->emitOpError() << "is not supported on " << getChip();
                 return WalkResult::interrupt();
               }

--- a/mlir/lib/Dialect/LLVMIR/IR/NVVMDialect.cpp
+++ b/mlir/lib/Dialect/LLVMIR/IR/NVVMDialect.cpp
@@ -6055,7 +6055,7 @@ LogicalResult NVVMTargetAttr::verifyTarget(Operation *gpuModule) {
 
   const unsigned targetFullSmVersion =
       NVVMCheckSMVersion::getTargetFullSmVersionFromStr(getChip());
-  if (!NVVMCheckSMVersion::isMinimumSMVersion(targetFullSmVersion)) {
+  if (NVVMCheckSMVersion::getSMVersion(targetFullSmVersion) < 20) {
     return emitError(gpuModule->getLoc(),
                      "Minimum NVVM target SM version is sm_20");
   }

--- a/mlir/lib/Dialect/LLVMIR/IR/NVVMDialect.cpp
+++ b/mlir/lib/Dialect/LLVMIR/IR/NVVMDialect.cpp
@@ -6055,7 +6055,7 @@ LogicalResult NVVMTargetAttr::verifyTarget(Operation *gpuModule) {
 
   const unsigned targetFullSmVersion =
       NVVMCheckSMVersion::getTargetFullSmVersionFromStr(getChip());
-  if (NVVMCheckSMVersion::getSMVersion(targetFullSmVersion) < 20) {
+  if (!NVVMCheckSMVersion::isMinimumSMVersion(targetFullSmVersion)) {
     return emitError(gpuModule->getLoc(),
                      "Minimum NVVM target SM version is sm_20");
   }

--- a/mlir/test/Dialect/LLVMIR/nvvm-check-targetSM.mlir
+++ b/mlir/test/Dialect/LLVMIR/nvvm-check-targetSM.mlir
@@ -41,6 +41,10 @@ gpu.module @check_valid_SM_family_3 [#nvvm.target<chip = "sm_103a">] {
   test.nvvm_requires_sm_100f
 }
 
+gpu.module @check_valid_SM_family_4[#nvvm.target<chip = "sm_103f">] {
+  test.nvvm_requires_sm_100f
+}
+
 gpu.module @check_valid_SM_family_multi_1 [#nvvm.target<chip = "sm_100f">] {
   test.nvvm_requires_sm_100f_or_sm_120f
 }
@@ -132,6 +136,13 @@ gpu.module @check_invalid_SM_arch_acc_multi_2 [#nvvm.target<chip = "sm_90">] {
 gpu.module @check_invalid_SM_family [#nvvm.target<chip = "sm_110a">] {
   // expected-error @below {{is not supported on sm_110a}}
   test.nvvm_requires_sm_100f
+}
+
+// -----
+
+gpu.module @check_invalid_SM_family_higher [#nvvm.target<chip = "sm_100f">] {
+  // expected-error @below {{is not supported on sm_100f}}
+  test.nvvm_requires_sm_103f
 }
 
 // -----

--- a/mlir/test/Dialect/LLVMIR/nvvm-check-targetSM.mlir
+++ b/mlir/test/Dialect/LLVMIR/nvvm-check-targetSM.mlir
@@ -1,53 +1,53 @@
 // RUN: mlir-opt %s -split-input-file -verify-diagnostics
 
 // Just check these don't emit errors.
-// gpu.module @check_valid_SM_exact [#nvvm.target<chip = "sm_80">] {
-//   test.nvvm_requires_sm_80
-// }
+gpu.module @check_valid_SM_exact [#nvvm.target<chip = "sm_80">] {
+  test.nvvm_requires_sm_80
+}
 
-// gpu.module @check_valid_SM_greater_1 [#nvvm.target<chip = "sm_86">] {
-//   test.nvvm_requires_sm_80
-// }
+gpu.module @check_valid_SM_greater_1 [#nvvm.target<chip = "sm_86">] {
+  test.nvvm_requires_sm_80
+}
 
-// gpu.module @check_valid_SM_greater_2 [#nvvm.target<chip = "sm_90">] {
-//   test.nvvm_requires_sm_80
-// }
+gpu.module @check_valid_SM_greater_2 [#nvvm.target<chip = "sm_90">] {
+  test.nvvm_requires_sm_80
+}
 
-// gpu.module @check_valid_SM_arch_acc_1 [#nvvm.target<chip = "sm_90a">] {
-//   test.nvvm_requires_sm_90a
-// }
+gpu.module @check_valid_SM_arch_acc_1 [#nvvm.target<chip = "sm_90a">] {
+  test.nvvm_requires_sm_90a
+}
 
-// gpu.module @check_valid_SM_arch_acc_2 [#nvvm.target<chip = "sm_90a">] {
-//   test.nvvm_requires_sm_80
-// }
+gpu.module @check_valid_SM_arch_acc_2 [#nvvm.target<chip = "sm_90a">] {
+  test.nvvm_requires_sm_80
+}
 
-// gpu.module @check_valid_SM_arch_acc_multi_1 [#nvvm.target<chip = "sm_90a">] {
-//   test.nvvm_requires_sm_90a_or_sm_100a
-// }
+gpu.module @check_valid_SM_arch_acc_multi_1 [#nvvm.target<chip = "sm_90a">] {
+  test.nvvm_requires_sm_90a_or_sm_100a
+}
 
-// gpu.module @check_valid_SM_arch_acc_multi_2 [#nvvm.target<chip = "sm_100a">] {
-//   test.nvvm_requires_sm_90a_or_sm_100a
-// }
+gpu.module @check_valid_SM_arch_acc_multi_2 [#nvvm.target<chip = "sm_100a">] {
+  test.nvvm_requires_sm_90a_or_sm_100a
+}
 
-// gpu.module @check_valid_SM_family_1 [#nvvm.target<chip = "sm_100f">] {
-//   test.nvvm_requires_sm_100f
-// }
+gpu.module @check_valid_SM_family_1 [#nvvm.target<chip = "sm_100f">] {
+  test.nvvm_requires_sm_100f
+}
 
-// gpu.module @check_valid_SM_family_2 [#nvvm.target<chip = "sm_100a">] {
-//   test.nvvm_requires_sm_100f
-// }
+gpu.module @check_valid_SM_family_2 [#nvvm.target<chip = "sm_100a">] {
+  test.nvvm_requires_sm_100f
+}
 
-// gpu.module @check_valid_SM_family_3 [#nvvm.target<chip = "sm_103a">] {
-//   test.nvvm_requires_sm_100f
-// }
+gpu.module @check_valid_SM_family_3 [#nvvm.target<chip = "sm_103a">] {
+  test.nvvm_requires_sm_100f
+}
 
-// gpu.module @check_valid_SM_family_multi_1 [#nvvm.target<chip = "sm_100f">] {
-//   test.nvvm_requires_sm_100f_or_sm_120f
-// }
+gpu.module @check_valid_SM_family_multi_1 [#nvvm.target<chip = "sm_100f">] {
+  test.nvvm_requires_sm_100f_or_sm_120f
+}
 
-// gpu.module @check_valid_SM_family_multi_2 [#nvvm.target<chip = "sm_120f">] {
-//   test.nvvm_requires_sm_100f_or_sm_120f
-// }
+gpu.module @check_valid_SM_family_multi_2 [#nvvm.target<chip = "sm_120f">] {
+  test.nvvm_requires_sm_100f_or_sm_120f
+}
 
 gpu.module @check_valid_SM_arch_or_family_1 [#nvvm.target<chip = "sm_90a">] {
   test.nvvm_requires_sm_90a_or_sm_100f

--- a/mlir/test/Dialect/LLVMIR/nvvm-check-targetSM.mlir
+++ b/mlir/test/Dialect/LLVMIR/nvvm-check-targetSM.mlir
@@ -29,6 +29,37 @@ gpu.module @check_valid_SM_arch_acc_multi_2 [#nvvm.target<chip = "sm_100a">] {
   test.nvvm_requires_sm_90a_or_sm_100a
 }
 
+gpu.module @check_valid_SM_family_1 [#nvvm.target<chip = "sm_100f">] {
+  test.nvvm_requires_sm_100f
+}
+
+gpu.module @check_valid_SM_family_2 [#nvvm.target<chip = "sm_100a">] {
+  test.nvvm_requires_sm_100f
+}
+
+gpu.module @check_valid_SM_family_3 [#nvvm.target<chip = "sm_103a">] {
+  test.nvvm_requires_sm_100f
+}
+
+gpu.module @check_valid_SM_family_multi_1 [#nvvm.target<chip = "sm_100f">] {
+  test.nvvm_requires_sm_100f_or_sm_120f
+}
+
+gpu.module @check_valid_SM_family_multi_2 [#nvvm.target<chip = "sm_120f">] {
+  test.nvvm_requires_sm_100f_or_sm_120f
+}
+
+gpu.module @check_valid_SM_arch_or_family_1 [#nvvm.target<chip = "sm_90a">] {
+  test.nvvm_requires_sm_90a_or_sm_100f
+}
+
+gpu.module @check_valid_SM_arch_or_family_2 [#nvvm.target<chip = "sm_100f">] {
+  test.nvvm_requires_sm_90a_or_sm_100f
+}
+
+gpu.module @check_valid_SM_arch_or_family_3 [#nvvm.target<chip = "sm_103a">] {
+  test.nvvm_requires_sm_90a_or_sm_100f
+}
 
 gpu.module @disable_verify_target1 [#nvvm.target<chip = "sm_90", verifyTarget = false>] {
   test.nvvm_requires_sm_90a
@@ -40,6 +71,18 @@ gpu.module @disable_verify_target2 [#nvvm.target<chip = "sm_70", verifyTarget = 
 
 gpu.module @disable_verify_target3 [#nvvm.target<chip = "sm_90", verifyTarget = false>] {
   test.nvvm_requires_sm_90a_or_sm_100a
+}
+
+gpu.module @disable_verify_target4 [#nvvm.target<chip = "sm_120f", verifyTarget = false>] {
+  test.nvvm_requires_sm_100f
+}
+
+gpu.module @disable_verify_target5 [#nvvm.target<chip = "sm_100", verifyTarget = false>] {
+  test.nvvm_requires_sm_100f_or_sm_120f
+}
+
+gpu.module @disable_verify_target6 [#nvvm.target<chip = "sm_90", verifyTarget = false>] {
+  test.nvvm_requires_sm_90a_or_sm_100f
 }
 
 // -----
@@ -82,4 +125,25 @@ gpu.module @check_invalid_SM_arch_acc_multi_1 [#nvvm.target<chip = "sm_80">] {
 gpu.module @check_invalid_SM_arch_acc_multi_2 [#nvvm.target<chip = "sm_90">] {
   // expected-error @below {{is not supported on sm_90}}
   test.nvvm_requires_sm_90a_or_sm_100a
+}
+
+// -----
+
+gpu.module @check_invalid_SM_family [#nvvm.target<chip = "sm_110a">] {
+  // expected-error @below {{is not supported on sm_110a}}
+  test.nvvm_requires_sm_100f
+}
+
+// -----
+
+gpu.module @check_invalid_SM_family_multi [#nvvm.target<chip = "sm_110a">] {
+  // expected-error @below {{is not supported on sm_110a}}
+  test.nvvm_requires_sm_100f_or_sm_120f
+}
+
+// -----
+
+gpu.module @check_invalid_SM_arch_or_family [#nvvm.target<chip = "sm_100">] {
+  // expected-error @below {{is not supported on sm_100}}
+  test.nvvm_requires_sm_90a_or_sm_100f
 }

--- a/mlir/test/Dialect/LLVMIR/nvvm-check-targetSM.mlir
+++ b/mlir/test/Dialect/LLVMIR/nvvm-check-targetSM.mlir
@@ -1,53 +1,53 @@
 // RUN: mlir-opt %s -split-input-file -verify-diagnostics
 
 // Just check these don't emit errors.
-gpu.module @check_valid_SM_exact [#nvvm.target<chip = "sm_80">] {
-  test.nvvm_requires_sm_80
-}
+// gpu.module @check_valid_SM_exact [#nvvm.target<chip = "sm_80">] {
+//   test.nvvm_requires_sm_80
+// }
 
-gpu.module @check_valid_SM_greater_1 [#nvvm.target<chip = "sm_86">] {
-  test.nvvm_requires_sm_80
-}
+// gpu.module @check_valid_SM_greater_1 [#nvvm.target<chip = "sm_86">] {
+//   test.nvvm_requires_sm_80
+// }
 
-gpu.module @check_valid_SM_greater_2 [#nvvm.target<chip = "sm_90">] {
-  test.nvvm_requires_sm_80
-}
+// gpu.module @check_valid_SM_greater_2 [#nvvm.target<chip = "sm_90">] {
+//   test.nvvm_requires_sm_80
+// }
 
-gpu.module @check_valid_SM_arch_acc_1 [#nvvm.target<chip = "sm_90a">] {
-  test.nvvm_requires_sm_90a
-}
+// gpu.module @check_valid_SM_arch_acc_1 [#nvvm.target<chip = "sm_90a">] {
+//   test.nvvm_requires_sm_90a
+// }
 
-gpu.module @check_valid_SM_arch_acc_2 [#nvvm.target<chip = "sm_90a">] {
-  test.nvvm_requires_sm_80
-}
+// gpu.module @check_valid_SM_arch_acc_2 [#nvvm.target<chip = "sm_90a">] {
+//   test.nvvm_requires_sm_80
+// }
 
-gpu.module @check_valid_SM_arch_acc_multi_1 [#nvvm.target<chip = "sm_90a">] {
-  test.nvvm_requires_sm_90a_or_sm_100a
-}
+// gpu.module @check_valid_SM_arch_acc_multi_1 [#nvvm.target<chip = "sm_90a">] {
+//   test.nvvm_requires_sm_90a_or_sm_100a
+// }
 
-gpu.module @check_valid_SM_arch_acc_multi_2 [#nvvm.target<chip = "sm_100a">] {
-  test.nvvm_requires_sm_90a_or_sm_100a
-}
+// gpu.module @check_valid_SM_arch_acc_multi_2 [#nvvm.target<chip = "sm_100a">] {
+//   test.nvvm_requires_sm_90a_or_sm_100a
+// }
 
-gpu.module @check_valid_SM_family_1 [#nvvm.target<chip = "sm_100f">] {
-  test.nvvm_requires_sm_100f
-}
+// gpu.module @check_valid_SM_family_1 [#nvvm.target<chip = "sm_100f">] {
+//   test.nvvm_requires_sm_100f
+// }
 
-gpu.module @check_valid_SM_family_2 [#nvvm.target<chip = "sm_100a">] {
-  test.nvvm_requires_sm_100f
-}
+// gpu.module @check_valid_SM_family_2 [#nvvm.target<chip = "sm_100a">] {
+//   test.nvvm_requires_sm_100f
+// }
 
-gpu.module @check_valid_SM_family_3 [#nvvm.target<chip = "sm_103a">] {
-  test.nvvm_requires_sm_100f
-}
+// gpu.module @check_valid_SM_family_3 [#nvvm.target<chip = "sm_103a">] {
+//   test.nvvm_requires_sm_100f
+// }
 
-gpu.module @check_valid_SM_family_multi_1 [#nvvm.target<chip = "sm_100f">] {
-  test.nvvm_requires_sm_100f_or_sm_120f
-}
+// gpu.module @check_valid_SM_family_multi_1 [#nvvm.target<chip = "sm_100f">] {
+//   test.nvvm_requires_sm_100f_or_sm_120f
+// }
 
-gpu.module @check_valid_SM_family_multi_2 [#nvvm.target<chip = "sm_120f">] {
-  test.nvvm_requires_sm_100f_or_sm_120f
-}
+// gpu.module @check_valid_SM_family_multi_2 [#nvvm.target<chip = "sm_120f">] {
+//   test.nvvm_requires_sm_100f_or_sm_120f
+// }
 
 gpu.module @check_valid_SM_arch_or_family_1 [#nvvm.target<chip = "sm_90a">] {
   test.nvvm_requires_sm_90a_or_sm_100f

--- a/mlir/test/lib/Dialect/Test/TestOps.td
+++ b/mlir/test/lib/Dialect/Test/TestOps.td
@@ -3130,7 +3130,7 @@ def TestNVVMRequiresSMFamilyCondMultiOp :
 }
 
 def TestNVVMRequiresSMArchOrFamilyCondOp :
-    TEST_Op<"nvvm_requires_sm_90a_or_sm_100f", [NVVMRequiresSMaOrf<[90], [100]>]> {
+    TEST_Op<"nvvm_requires_sm_90a_or_sm_100f", [NVVMRequiresSMaOrSMf<[90], [100]>]> {
   let arguments = (ins );
   let assemblyFormat = "attr-dict";
 }

--- a/mlir/test/lib/Dialect/Test/TestOps.td
+++ b/mlir/test/lib/Dialect/Test/TestOps.td
@@ -3123,6 +3123,12 @@ def TestNVVMRequiresSMFamilyCondOp :
   let assemblyFormat = "attr-dict";
 }
 
+def TestNVVMRequiresSMFamilyCondHigherOp :
+    TEST_Op<"nvvm_requires_sm_103f", [NVVMRequiresSMf<[103]>]> {
+  let arguments = (ins );
+  let assemblyFormat = "attr-dict";
+}
+
 def TestNVVMRequiresSMFamilyCondMultiOp :
     TEST_Op<"nvvm_requires_sm_100f_or_sm_120f", [NVVMRequiresSMf<[100, 120]>]> {
   let arguments = (ins );

--- a/mlir/test/lib/Dialect/Test/TestOps.td
+++ b/mlir/test/lib/Dialect/Test/TestOps.td
@@ -3117,6 +3117,24 @@ def TestNVVMRequirestSMArchCondMultiOp :
   let assemblyFormat = "attr-dict";
 }
 
+def TestNVVMRequiresSMFamilyCondOp :
+    TEST_Op<"nvvm_requires_sm_100f", [NVVMRequiresSMf<[100]>]> {
+  let arguments = (ins );
+  let assemblyFormat = "attr-dict";
+}
+
+def TestNVVMRequiresSMFamilyCondMultiOp :
+    TEST_Op<"nvvm_requires_sm_100f_or_sm_120f", [NVVMRequiresSMf<[100, 120]>]> {
+  let arguments = (ins );
+  let assemblyFormat = "attr-dict";
+}
+
+def TestNVVMRequiresSMArchOrFamilyCondOp :
+    TEST_Op<"nvvm_requires_sm_90a_or_sm_100f", [NVVMRequiresSMaOrf<[90], [100]>]> {
+  let arguments = (ins );
+  let assemblyFormat = "attr-dict";
+}
+
 //===----------------------------------------------------------------------===//
 // Test Ops with Default-Valued String Attributes
 //===----------------------------------------------------------------------===//

--- a/mlir/test/lib/Dialect/Test/TestOps.td
+++ b/mlir/test/lib/Dialect/Test/TestOps.td
@@ -3106,31 +3106,31 @@ def TestNVVMRequiresSMOp :
 }
 
 def TestNVVMRequiresSMArchCondOp :
-    TEST_Op<"nvvm_requires_sm_90a", [NVVMRequiresSMa<[90]>]> {
+    TEST_Op<"nvvm_requires_sm_90a", [NVVMRequiresSMAA<[90]>]> {
   let arguments = (ins );
   let assemblyFormat = "attr-dict";
 }
 
 def TestNVVMRequirestSMArchCondMultiOp :
-    TEST_Op<"nvvm_requires_sm_90a_or_sm_100a", [NVVMRequiresSMa<[90, 100]>]> {
+    TEST_Op<"nvvm_requires_sm_90a_or_sm_100a", [NVVMRequiresSMAA<[90, 100]>]> {
   let arguments = (ins );
   let assemblyFormat = "attr-dict";
 }
 
 def TestNVVMRequiresSMFamilyCondOp :
-    TEST_Op<"nvvm_requires_sm_100f", [NVVMRequiresSMf<[100]>]> {
+    TEST_Op<"nvvm_requires_sm_100f", [NVVMRequiresSMFS<[100]>]> {
   let arguments = (ins );
   let assemblyFormat = "attr-dict";
 }
 
 def TestNVVMRequiresSMFamilyCondMultiOp :
-    TEST_Op<"nvvm_requires_sm_100f_or_sm_120f", [NVVMRequiresSMf<[100, 120]>]> {
+    TEST_Op<"nvvm_requires_sm_100f_or_sm_120f", [NVVMRequiresSMFS<[100, 120]>]> {
   let arguments = (ins );
   let assemblyFormat = "attr-dict";
 }
 
 def TestNVVMRequiresSMArchOrFamilyCondOp :
-    TEST_Op<"nvvm_requires_sm_90a_or_sm_100f", [NVVMRequiresSMaOrf<[90], [100]>]> {
+    TEST_Op<"nvvm_requires_sm_90a_or_sm_100f", [NVVMRequiresSMAAOrFS<[90], [100]>]> {
   let arguments = (ins );
   let assemblyFormat = "attr-dict";
 }

--- a/mlir/test/lib/Dialect/Test/TestOps.td
+++ b/mlir/test/lib/Dialect/Test/TestOps.td
@@ -3106,31 +3106,31 @@ def TestNVVMRequiresSMOp :
 }
 
 def TestNVVMRequiresSMArchCondOp :
-    TEST_Op<"nvvm_requires_sm_90a", [NVVMRequiresSMAA<[90]>]> {
+    TEST_Op<"nvvm_requires_sm_90a", [NVVMRequiresSMa<[90]>]> {
   let arguments = (ins );
   let assemblyFormat = "attr-dict";
 }
 
 def TestNVVMRequirestSMArchCondMultiOp :
-    TEST_Op<"nvvm_requires_sm_90a_or_sm_100a", [NVVMRequiresSMAA<[90, 100]>]> {
+    TEST_Op<"nvvm_requires_sm_90a_or_sm_100a", [NVVMRequiresSMa<[90, 100]>]> {
   let arguments = (ins );
   let assemblyFormat = "attr-dict";
 }
 
 def TestNVVMRequiresSMFamilyCondOp :
-    TEST_Op<"nvvm_requires_sm_100f", [NVVMRequiresSMFS<[100]>]> {
+    TEST_Op<"nvvm_requires_sm_100f", [NVVMRequiresSMf<[100]>]> {
   let arguments = (ins );
   let assemblyFormat = "attr-dict";
 }
 
 def TestNVVMRequiresSMFamilyCondMultiOp :
-    TEST_Op<"nvvm_requires_sm_100f_or_sm_120f", [NVVMRequiresSMFS<[100, 120]>]> {
+    TEST_Op<"nvvm_requires_sm_100f_or_sm_120f", [NVVMRequiresSMf<[100, 120]>]> {
   let arguments = (ins );
   let assemblyFormat = "attr-dict";
 }
 
 def TestNVVMRequiresSMArchOrFamilyCondOp :
-    TEST_Op<"nvvm_requires_sm_90a_or_sm_100f", [NVVMRequiresSMAAOrFS<[90], [100]>]> {
+    TEST_Op<"nvvm_requires_sm_90a_or_sm_100f", [NVVMRequiresSMaOrf<[90], [100]>]> {
   let arguments = (ins );
   let assemblyFormat = "attr-dict";
 }


### PR DESCRIPTION
This change adds support for family-conditional SM version requirements to the `NVVMRequiresSM` traits. The following new traits are added:
- `NVVMRequiresSMf` - Op requires an SM version belonging to one of the given families.
- `NVVMRequiresSMaOrSMf` - Op requires one of the supported arch-accelerated versions or an SM version belonging to one of the given families.

This also changes the underlying checks to use the `FullSMVersion` instead of booleans to indicate arch-acceleration and family-specific support to simply the checks.