### PR TITLE
[DWARFVerifier] rewrite DieRangeInfo::insert to remove O(N^2) loop 

### DIFF
--- a/llvm/benchmarks/CMakeLists.txt
+++ b/llvm/benchmarks/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(LLVM_LINK_COMPONENTS
   AsmParser
   Core
+  DebugInfoDWARF
   SandboxIR
   Support)
 
@@ -12,6 +13,7 @@ add_benchmark(GetIntrinsicInfoTableEntriesBM GetIntrinsicInfoTableEntriesBM.cpp 
 add_benchmark(SandboxIRBench SandboxIRBench.cpp PARTIAL_SOURCES_INTENDED)
 add_benchmark(MustacheBench Mustache.cpp PARTIAL_SOURCES_INTENDED)
 add_benchmark(SpecialCaseListBM SpecialCaseListBM.cpp PARTIAL_SOURCES_INTENDED)
+add_benchmark(DWARFVerifierBM DWARFVerifierBM.cpp PARTIAL_SOURCES_INTENDED)
 
 add_benchmark(RuntimeLibcallsBench RuntimeLibcalls.cpp PARTIAL_SOURCES_INTENDED)
 

--- a/llvm/benchmarks/DWARFVerifierBM.cpp
+++ b/llvm/benchmarks/DWARFVerifierBM.cpp
@@ -1,0 +1,105 @@
+//===- DWARFVerifierBM.cpp - DieRangeInfo::insert benchmark ---------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "benchmark/benchmark.h"
+#include "llvm/DebugInfo/DWARF/DWARFVerifier.h"
+#include <algorithm>
+#include <random>
+#include <vector>
+
+using namespace llvm;
+using DieRangeInfo = DWARFVerifier::DieRangeInfo;
+
+static DieRangeInfo makeRI(uint64_t Lo, uint64_t Hi) {
+  return DieRangeInfo({{Lo, Hi}});
+}
+
+// Insert N non-overlapping ranges in forward address order.
+static void BM_DieRangeInfoInsertForward(benchmark::State &State) {
+  const unsigned N = State.range(0);
+  for (auto _ : State) {
+    DieRangeInfo Parent;
+    for (unsigned I = 0; I < N; ++I) {
+      uint64_t Lo = I * 100;
+      uint64_t Hi = Lo + 50;
+      Parent.insert(makeRI(Lo, Hi));
+    }
+    benchmark::DoNotOptimize(Parent);
+  }
+}
+BENCHMARK(BM_DieRangeInfoInsertForward)
+    ->Arg(1000)
+    ->Arg(10000)
+    ->Arg(100000);
+
+// Insert N non-overlapping ranges in reverse address order.
+static void BM_DieRangeInfoInsertReverse(benchmark::State &State) {
+  const unsigned N = State.range(0);
+  for (auto _ : State) {
+    DieRangeInfo Parent;
+    for (unsigned I = N; I > 0; --I) {
+      uint64_t Lo = I * 100;
+      uint64_t Hi = Lo + 50;
+      Parent.insert(makeRI(Lo, Hi));
+    }
+    benchmark::DoNotOptimize(Parent);
+  }
+}
+BENCHMARK(BM_DieRangeInfoInsertReverse)
+    ->Arg(1000)
+    ->Arg(10000)
+    ->Arg(100000);
+
+// Insert N non-overlapping ranges in random order.
+static void BM_DieRangeInfoInsertRandom(benchmark::State &State) {
+  const unsigned N = State.range(0);
+
+  std::vector<std::pair<uint64_t, uint64_t>> Ranges;
+  Ranges.reserve(N);
+  for (unsigned I = 0; I < N; ++I)
+    Ranges.push_back({I * 100, I * 100 + 50});
+  std::mt19937 RNG(42);
+  std::shuffle(Ranges.begin(), Ranges.end(), RNG);
+
+  for (auto _ : State) {
+    DieRangeInfo Parent;
+    for (const auto &[Lo, Hi] : Ranges)
+      Parent.insert(makeRI(Lo, Hi));
+    benchmark::DoNotOptimize(Parent);
+  }
+}
+BENCHMARK(BM_DieRangeInfoInsertRandom)
+    ->Arg(1000)
+    ->Arg(10000)
+    ->Arg(100000);
+
+// Measure single overlap detection after N-1 insertions.
+static void BM_DieRangeInfoOverlapDetection(benchmark::State &State) {
+  const unsigned N = State.range(0);
+
+  // Pre-build the parent with N-1 non-overlapping ranges.
+  DieRangeInfo Base;
+  for (unsigned I = 0; I < N - 1; ++I) {
+    uint64_t Lo = I * 100;
+    uint64_t Hi = Lo + 50;
+    Base.insert(makeRI(Lo, Hi));
+  }
+
+  uint64_t Mid = (N / 2) * 100;
+  for (auto _ : State) {
+    DieRangeInfo Parent = Base;
+    auto It = Parent.insert(makeRI(Mid + 10, Mid + 60));
+    benchmark::DoNotOptimize(It);
+  }
+}
+BENCHMARK(BM_DieRangeInfoOverlapDetection)
+    ->Arg(1000)
+    ->Arg(10000)
+    ->Arg(100000);
+
+BENCHMARK_MAIN();

--- a/llvm/benchmarks/DWARFVerifierBM.cpp
+++ b/llvm/benchmarks/DWARFVerifierBM.cpp
@@ -32,10 +32,7 @@ static void BM_DieRangeInfoInsertForward(benchmark::State &State) {
     benchmark::DoNotOptimize(Parent);
   }
 }
-BENCHMARK(BM_DieRangeInfoInsertForward)
-    ->Arg(1000)
-    ->Arg(10000)
-    ->Arg(100000);
+BENCHMARK(BM_DieRangeInfoInsertForward)->Arg(1000)->Arg(10000)->Arg(100000);
 
 // Insert N non-overlapping ranges in reverse address order.
 static void BM_DieRangeInfoInsertReverse(benchmark::State &State) {
@@ -50,10 +47,7 @@ static void BM_DieRangeInfoInsertReverse(benchmark::State &State) {
     benchmark::DoNotOptimize(Parent);
   }
 }
-BENCHMARK(BM_DieRangeInfoInsertReverse)
-    ->Arg(1000)
-    ->Arg(10000)
-    ->Arg(100000);
+BENCHMARK(BM_DieRangeInfoInsertReverse)->Arg(1000)->Arg(10000)->Arg(100000);
 
 // Insert N non-overlapping ranges in random order.
 static void BM_DieRangeInfoInsertRandom(benchmark::State &State) {
@@ -73,10 +67,7 @@ static void BM_DieRangeInfoInsertRandom(benchmark::State &State) {
     benchmark::DoNotOptimize(Parent);
   }
 }
-BENCHMARK(BM_DieRangeInfoInsertRandom)
-    ->Arg(1000)
-    ->Arg(10000)
-    ->Arg(100000);
+BENCHMARK(BM_DieRangeInfoInsertRandom)->Arg(1000)->Arg(10000)->Arg(100000);
 
 // Measure single overlap detection after N-1 insertions.
 static void BM_DieRangeInfoOverlapDetection(benchmark::State &State) {
@@ -97,9 +88,6 @@ static void BM_DieRangeInfoOverlapDetection(benchmark::State &State) {
     benchmark::DoNotOptimize(It);
   }
 }
-BENCHMARK(BM_DieRangeInfoOverlapDetection)
-    ->Arg(1000)
-    ->Arg(10000)
-    ->Arg(100000);
+BENCHMARK(BM_DieRangeInfoOverlapDetection)->Arg(1000)->Arg(10000)->Arg(100000);
 
 BENCHMARK_MAIN();

--- a/llvm/lib/DebugInfo/DWARF/DWARFVerifier.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFVerifier.cpp
@@ -88,13 +88,6 @@ DWARFVerifier::DieRangeInfo::insert(const DieRangeInfo &RI) {
   // verified to be non-overlapping as they are inserted, only adjacent entries
   // in the sorted set can intersect with a newly inserted entry.
   //
-  // Proof: all existing children are pairwise non-overlapping (checked on each
-  // prior insertion). For single-range children sorted by LowPC, if child
-  // C < P < RI in sorted order and C, P are non-overlapping, then
-  // C.HighPC <= P.LowPC. If P also doesn't intersect RI (P.HighPC <= RI.LowPC),
-  // then C.HighPC <= P.LowPC <= RI.LowPC, so C can't intersect RI either.
-  // The same argument applies symmetrically in the successor direction.
-
   // Check immediate predecessor.
   if (It != Children.begin()) {
     auto Prev = std::prev(It);

--- a/llvm/lib/DebugInfo/DWARF/DWARFVerifier.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFVerifier.cpp
@@ -87,6 +87,7 @@ DWARFVerifier::DieRangeInfo::insert(const DieRangeInfo &RI) {
   // Check only the immediate neighbors for intersection. Since children are
   // verified to be non-overlapping as they are inserted, only adjacent entries
   // in the sorted set can intersect with a newly inserted entry.
+
   // Check immediate predecessor.
   if (It != Children.begin()) {
     auto Prev = std::prev(It);

--- a/llvm/lib/DebugInfo/DWARF/DWARFVerifier.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFVerifier.cpp
@@ -80,35 +80,34 @@ DWARFVerifier::DieRangeInfo::insert(const DieRangeInfo &RI) {
   if (RI.Ranges.empty())
     return Children.end();
 
-  auto [It, Inserted] = Children.insert(RI);
-  if (!Inserted)
-    return Children.end(); // Exact duplicate, allowed.
+  // Use lower_bound to find the insertion point in O(log N), then check
+  // only the immediate neighbors for overlap. Since children are verified
+  // to be non-overlapping as they are inserted, only adjacent entries in
+  // the sorted set can intersect with a newly inserted entry.
+  auto It = Children.lower_bound(RI);
 
-  // Check only the immediate neighbors for intersection. Since children are
-  // verified to be non-overlapping as they are inserted, only adjacent entries
-  // in the sorted set can intersect with a newly inserted entry.
-
-  // Check immediate predecessor.
+  // Check the predecessor for overlap.
   if (It != Children.begin()) {
     auto Prev = std::prev(It);
-    if (Prev->intersects(RI)) {
-      Children.erase(It);
+    if (Prev->intersects(RI))
       return Prev;
-    }
   }
 
-  // Check immediate successor.
-  auto Next = std::next(It);
-  if (Next != Children.end()) {
-    if (Next->intersects(RI)) {
-      Children.erase(It);
-      return Next;
-    }
+  // Check the element at the lower_bound position for overlap or duplicate.
+  if (It != Children.end()) {
+    // We only override "smaller than", so "not smaller than" (RI >= It) plus the semantics
+    // of `lower_bound` (It >= RI) says this is exact duplicate (equivalent key), which is
+    // allowed and doesn't need reinsertion.
+    if (!(RI < *It))
+      return Children.end();
+    if (It->intersects(RI))
+      return It;
   }
 
+  // No overlap — insert with hint for O(1) amortized insertion.
+  Children.insert(It, RI);
   return Children.end();
 }
-
 bool DWARFVerifier::DieRangeInfo::contains(const DieRangeInfo &RHS) const {
   auto I1 = Ranges.begin(), E1 = Ranges.end();
   auto I2 = RHS.Ranges.begin(), E2 = RHS.Ranges.end();

--- a/llvm/lib/DebugInfo/DWARF/DWARFVerifier.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFVerifier.cpp
@@ -87,7 +87,6 @@ DWARFVerifier::DieRangeInfo::insert(const DieRangeInfo &RI) {
   // Check only the immediate neighbors for intersection. Since children are
   // verified to be non-overlapping as they are inserted, only adjacent entries
   // in the sorted set can intersect with a newly inserted entry.
-  //
   // Check immediate predecessor.
   if (It != Children.begin()) {
     auto Prev = std::prev(It);

--- a/llvm/lib/DebugInfo/DWARF/DWARFVerifier.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFVerifier.cpp
@@ -80,14 +80,39 @@ DWARFVerifier::DieRangeInfo::insert(const DieRangeInfo &RI) {
   if (RI.Ranges.empty())
     return Children.end();
 
-  auto End = Children.end();
-  auto Iter = Children.begin();
-  while (Iter != End) {
-    if (Iter->intersects(RI))
-      return Iter;
-    ++Iter;
+  auto [It, Inserted] = Children.insert(RI);
+  if (!Inserted)
+    return Children.end(); // Exact duplicate, allowed.
+
+  // Check only the immediate neighbors for intersection. Since children are
+  // verified to be non-overlapping as they are inserted, only adjacent entries
+  // in the sorted set can intersect with a newly inserted entry.
+  //
+  // Proof: all existing children are pairwise non-overlapping (checked on each
+  // prior insertion). For single-range children sorted by LowPC, if child
+  // C < P < RI in sorted order and C, P are non-overlapping, then
+  // C.HighPC <= P.LowPC. If P also doesn't intersect RI (P.HighPC <= RI.LowPC),
+  // then C.HighPC <= P.LowPC <= RI.LowPC, so C can't intersect RI either.
+  // The same argument applies symmetrically in the successor direction.
+
+  // Check immediate predecessor.
+  if (It != Children.begin()) {
+    auto Prev = std::prev(It);
+    if (Prev->intersects(RI)) {
+      Children.erase(It);
+      return Prev;
+    }
   }
-  Children.insert(RI);
+
+  // Check immediate successor.
+  auto Next = std::next(It);
+  if (Next != Children.end()) {
+    if (Next->intersects(RI)) {
+      Children.erase(It);
+      return Next;
+    }
+  }
+
   return Children.end();
 }
 

--- a/llvm/lib/DebugInfo/DWARF/DWARFVerifier.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFVerifier.cpp
@@ -95,9 +95,9 @@ DWARFVerifier::DieRangeInfo::insert(const DieRangeInfo &RI) {
 
   // Check the element at the lower_bound position for overlap or duplicate.
   if (It != Children.end()) {
-    // We only override "smaller than", so "not smaller than" (RI >= It) plus the semantics
-    // of `lower_bound` (It >= RI) says this is exact duplicate (equivalent key), which is
-    // allowed and doesn't need reinsertion.
+    // We only override "smaller than", so "not smaller than" (RI >= It) plus
+    // the semantics of `lower_bound` (It >= RI) says this is exact duplicate
+    // (equivalent key), which is allowed and doesn't need reinsertion.
     if (!(RI < *It))
       return Children.end();
     if (It->intersects(RI))
@@ -172,11 +172,13 @@ bool DWARFVerifier::verifyUnitHeader(const DWARFDataExtractor DebugInfoData,
   if (Version >= 5) {
     UnitType = DebugInfoData.getU8(Offset);
     AddrSize = DebugInfoData.getU8(Offset);
-    AbbrOffset = isUnitDWARF64 ? DebugInfoData.getU64(Offset) : DebugInfoData.getU32(Offset);
+    AbbrOffset = isUnitDWARF64 ? DebugInfoData.getU64(Offset)
+                               : DebugInfoData.getU32(Offset);
     ValidType = dwarf::isUnitType(UnitType);
   } else {
     UnitType = 0;
-    AbbrOffset = isUnitDWARF64 ? DebugInfoData.getU64(Offset) : DebugInfoData.getU32(Offset);
+    AbbrOffset = isUnitDWARF64 ? DebugInfoData.getU64(Offset)
+                               : DebugInfoData.getU32(Offset);
     AddrSize = DebugInfoData.getU8(Offset);
   }
 
@@ -439,7 +441,7 @@ unsigned DWARFVerifier::verifyUnits(const DWARFUnitVector &Units) {
 
   for (const auto &Unit : Units) {
     OS << formatv("Verifying unit: {0} / {1}", Index, Units.getNumUnits());
-    if (const char* Name = Unit->getUnitDIE(true).getShortName())
+    if (const char *Name = Unit->getUnitDIE(true).getShortName())
       OS << formatv(", \"{0}\"", Name);
     OS << '\n';
     OS.flush();
@@ -554,14 +556,12 @@ bool DWARFVerifier::handleDebugInfo() {
   unsigned NumErrors = 0;
 
   OS << "Verifying .debug_info Unit Header Chain...\n";
-  DObj.forEachInfoSections([&](const DWARFSection &S) {
-    NumErrors += verifyUnitSection(S);
-  });
+  DObj.forEachInfoSections(
+      [&](const DWARFSection &S) { NumErrors += verifyUnitSection(S); });
 
   OS << "Verifying .debug_types Unit Header Chain...\n";
-  DObj.forEachTypesSections([&](const DWARFSection &S) {
-    NumErrors += verifyUnitSection(S);
-  });
+  DObj.forEachTypesSections(
+      [&](const DWARFSection &S) { NumErrors += verifyUnitSection(S); });
 
   OS << "Verifying non-dwo Units...\n";
   NumErrors += verifyUnits(DCtx.getNormalUnitsVector());
@@ -1043,8 +1043,7 @@ unsigned DWARFVerifier::verifyDebugInfoReferences(
     return DWARFDie();
   };
   unsigned NumErrors = 0;
-  for (const std::pair<const uint64_t, std::set<uint64_t>> &Pair :
-       References) {
+  for (const std::pair<const uint64_t, std::set<uint64_t>> &Pair : References) {
     if (GetDIEForOffset(Pair.first))
       continue;
     ++NumErrors;
@@ -2294,7 +2293,8 @@ bool DWARFVerifier::verifyDebugStrOffsets(
       });
       Success = false;
     }
-    for (uint64_t Index = 0; C && C.tell() + OffsetByteSize <= NextUnit; ++Index) {
+    for (uint64_t Index = 0; C && C.tell() + OffsetByteSize <= NextUnit;
+         ++Index) {
       uint64_t OffOff = C.tell();
       uint64_t StrOff = DA.getAddress(C);
       // check StrOff refers to the start of a string

--- a/llvm/unittests/DebugInfo/DWARF/CMakeLists.txt
+++ b/llvm/unittests/DebugInfo/DWARF/CMakeLists.txt
@@ -29,6 +29,7 @@ add_llvm_unittest(DebugInfoDWARFTests
   DWARFFormValueTest.cpp
   DWARFListTableTest.cpp
   DWARFLocationExpressionTest.cpp
+  DWARFVerifierTest.cpp
   )
 
 target_link_libraries(DebugInfoDWARFTests PRIVATE LLVMTestingSupport)

--- a/llvm/unittests/DebugInfo/DWARF/DWARFVerifierTest.cpp
+++ b/llvm/unittests/DebugInfo/DWARF/DWARFVerifierTest.cpp
@@ -150,9 +150,8 @@ TEST(DWARFVerifierTest, InsertPerformanceForwardOrder) {
   EXPECT_EQ(Parent.Children.size(), (size_t)N);
   // Should complete well within 10 seconds. The old O(N^2) implementation
   // would take minutes for N=100000.
-  EXPECT_LT(ElapsedMs, 10000)
-      << "Insert took " << ElapsedMs
-      << "ms; likely O(N^2) regression for N=" << N;
+  EXPECT_LT(ElapsedMs, 10000) << "Insert took " << ElapsedMs
+                              << "ms; likely O(N^2) regression for N=" << N;
 }
 
 TEST(DWARFVerifierTest, InsertPerformanceReverseOrder) {
@@ -172,9 +171,8 @@ TEST(DWARFVerifierTest, InsertPerformanceReverseOrder) {
           .count();
 
   EXPECT_EQ(Parent.Children.size(), (size_t)N);
-  EXPECT_LT(ElapsedMs, 10000)
-      << "Insert took " << ElapsedMs
-      << "ms; likely O(N^2) regression for N=" << N;
+  EXPECT_LT(ElapsedMs, 10000) << "Insert took " << ElapsedMs
+                              << "ms; likely O(N^2) regression for N=" << N;
 }
 
 TEST(DWARFVerifierTest, InsertPerformanceRandomOrder) {
@@ -200,9 +198,8 @@ TEST(DWARFVerifierTest, InsertPerformanceRandomOrder) {
           .count();
 
   EXPECT_EQ(Parent.Children.size(), (size_t)N);
-  EXPECT_LT(ElapsedMs, 10000)
-      << "Insert took " << ElapsedMs
-      << "ms; likely O(N^2) regression for N=" << N;
+  EXPECT_LT(ElapsedMs, 10000) << "Insert took " << ElapsedMs
+                              << "ms; likely O(N^2) regression for N=" << N;
 }
 
 TEST(DWARFVerifierTest, InsertPerformanceWithOverlapDetection) {
@@ -227,8 +224,8 @@ TEST(DWARFVerifierTest, InsertPerformanceWithOverlapDetection) {
           .count();
 
   EXPECT_NE(It, Parent.Children.end()) << "Overlap should be detected";
-  EXPECT_LT(ElapsedMs, 100)
-      << "Single overlap detection took " << ElapsedMs << "ms; should be O(log N)";
+  EXPECT_LT(ElapsedMs, 100) << "Single overlap detection took " << ElapsedMs
+                            << "ms; should be O(log N)";
 }
 
 } // namespace

--- a/llvm/unittests/DebugInfo/DWARF/DWARFVerifierTest.cpp
+++ b/llvm/unittests/DebugInfo/DWARF/DWARFVerifierTest.cpp
@@ -1,0 +1,234 @@
+//===- DWARFVerifierTest.cpp ----------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/DebugInfo/DWARF/DWARFVerifier.h"
+#include "llvm/DebugInfo/DWARF/DWARFAddressRange.h"
+#include "gtest/gtest.h"
+#include <chrono>
+#include <random>
+
+using namespace llvm;
+
+namespace {
+
+using DieRangeInfo = DWARFVerifier::DieRangeInfo;
+
+// Helper to create a DieRangeInfo with a single range [Lo, Hi).
+DieRangeInfo makeRI(uint64_t Lo, uint64_t Hi) {
+  return DieRangeInfo({{Lo, Hi}});
+}
+
+//===----------------------------------------------------------------------===//
+// Correctness tests
+//===----------------------------------------------------------------------===//
+
+TEST(DWARFVerifierTest, InsertNoOverlap) {
+  DieRangeInfo Parent;
+  // Insert three non-overlapping ranges.
+  EXPECT_EQ(Parent.insert(makeRI(100, 200)), Parent.Children.end());
+  EXPECT_EQ(Parent.insert(makeRI(300, 400)), Parent.Children.end());
+  EXPECT_EQ(Parent.insert(makeRI(500, 600)), Parent.Children.end());
+  EXPECT_EQ(Parent.Children.size(), 3u);
+}
+
+TEST(DWARFVerifierTest, InsertOverlapWithPredecessor) {
+  DieRangeInfo Parent;
+  EXPECT_EQ(Parent.insert(makeRI(100, 300)), Parent.Children.end());
+  // Overlaps with [100, 300).
+  auto It = Parent.insert(makeRI(200, 400));
+  EXPECT_NE(It, Parent.Children.end());
+  // The conflicting child should be the first one.
+  EXPECT_EQ(It->Ranges.front().LowPC, 100u);
+}
+
+TEST(DWARFVerifierTest, InsertOverlapWithSuccessor) {
+  DieRangeInfo Parent;
+  EXPECT_EQ(Parent.insert(makeRI(300, 500)), Parent.Children.end());
+  // Insert before, overlapping with [300, 500).
+  auto It = Parent.insert(makeRI(100, 400));
+  EXPECT_NE(It, Parent.Children.end());
+  EXPECT_EQ(It->Ranges.front().LowPC, 300u);
+}
+
+TEST(DWARFVerifierTest, InsertEmptyRange) {
+  DieRangeInfo Parent;
+  DieRangeInfo Empty;
+  EXPECT_EQ(Parent.insert(Empty), Parent.Children.end());
+  EXPECT_EQ(Parent.Children.size(), 0u);
+}
+
+TEST(DWARFVerifierTest, InsertAdjacentRanges) {
+  DieRangeInfo Parent;
+  // Adjacent but not overlapping: [100,200) and [200,300).
+  EXPECT_EQ(Parent.insert(makeRI(100, 200)), Parent.Children.end());
+  EXPECT_EQ(Parent.insert(makeRI(200, 300)), Parent.Children.end());
+  EXPECT_EQ(Parent.Children.size(), 2u);
+}
+
+TEST(DWARFVerifierTest, InsertLongRangeOverlapsSuccessor) {
+  DieRangeInfo Parent;
+  EXPECT_EQ(Parent.insert(makeRI(100, 200)), Parent.Children.end());
+  EXPECT_EQ(Parent.insert(makeRI(300, 400)), Parent.Children.end());
+  EXPECT_EQ(Parent.insert(makeRI(500, 600)), Parent.Children.end());
+  // Insert a long range that overlaps multiple children.
+  auto It = Parent.insert(makeRI(150, 550));
+  EXPECT_NE(It, Parent.Children.end());
+}
+
+TEST(DWARFVerifierTest, InsertBetweenNonOverlapping) {
+  DieRangeInfo Parent;
+  EXPECT_EQ(Parent.insert(makeRI(100, 200)), Parent.Children.end());
+  EXPECT_EQ(Parent.insert(makeRI(500, 600)), Parent.Children.end());
+  // Fits in the gap.
+  EXPECT_EQ(Parent.insert(makeRI(300, 400)), Parent.Children.end());
+  EXPECT_EQ(Parent.Children.size(), 3u);
+}
+
+TEST(DWARFVerifierTest, InsertOverlapByOneAddress) {
+  DieRangeInfo Parent;
+  EXPECT_EQ(Parent.insert(makeRI(100, 200)), Parent.Children.end());
+  // Overlaps by a single address.
+  auto It = Parent.insert(makeRI(199, 300));
+  EXPECT_NE(It, Parent.Children.end());
+}
+
+TEST(DWARFVerifierTest, InsertReverseOrder) {
+  DieRangeInfo Parent;
+  // Insert in reverse address order.
+  EXPECT_EQ(Parent.insert(makeRI(500, 600)), Parent.Children.end());
+  EXPECT_EQ(Parent.insert(makeRI(300, 400)), Parent.Children.end());
+  EXPECT_EQ(Parent.insert(makeRI(100, 200)), Parent.Children.end());
+  EXPECT_EQ(Parent.Children.size(), 3u);
+}
+
+TEST(DWARFVerifierTest, InsertReverseOrderWithOverlap) {
+  DieRangeInfo Parent;
+  EXPECT_EQ(Parent.insert(makeRI(500, 600)), Parent.Children.end());
+  EXPECT_EQ(Parent.insert(makeRI(300, 400)), Parent.Children.end());
+  // Overlaps with [300, 400).
+  auto It = Parent.insert(makeRI(350, 450));
+  EXPECT_NE(It, Parent.Children.end());
+}
+
+TEST(DWARFVerifierTest, InsertRandomOrderNoOverlap) {
+  DieRangeInfo Parent;
+  // Insert in shuffled order.
+  EXPECT_EQ(Parent.insert(makeRI(500, 600)), Parent.Children.end());
+  EXPECT_EQ(Parent.insert(makeRI(100, 200)), Parent.Children.end());
+  EXPECT_EQ(Parent.insert(makeRI(700, 800)), Parent.Children.end());
+  EXPECT_EQ(Parent.insert(makeRI(300, 400)), Parent.Children.end());
+  EXPECT_EQ(Parent.Children.size(), 4u);
+}
+
+//===----------------------------------------------------------------------===//
+// Stress test: O(N^2) -> O(N log N) performance regression test
+//===----------------------------------------------------------------------===//
+
+TEST(DWARFVerifierTest, InsertPerformanceForwardOrder) {
+  // Insert N non-overlapping ranges in forward address order.
+  // With O(N^2): N=100000 would take ~minutes.
+  // With O(N log N): should complete in < 1 second.
+  const unsigned N = 100000;
+  DieRangeInfo Parent;
+
+  auto Start = std::chrono::steady_clock::now();
+  for (unsigned I = 0; I < N; ++I) {
+    uint64_t Lo = I * 100;
+    uint64_t Hi = Lo + 50;
+    ASSERT_EQ(Parent.insert(makeRI(Lo, Hi)), Parent.Children.end());
+  }
+  auto End = std::chrono::steady_clock::now();
+  auto ElapsedMs =
+      std::chrono::duration_cast<std::chrono::milliseconds>(End - Start)
+          .count();
+
+  EXPECT_EQ(Parent.Children.size(), (size_t)N);
+  // Should complete well within 10 seconds. The old O(N^2) implementation
+  // would take minutes for N=100000.
+  EXPECT_LT(ElapsedMs, 10000)
+      << "Insert took " << ElapsedMs
+      << "ms; likely O(N^2) regression for N=" << N;
+}
+
+TEST(DWARFVerifierTest, InsertPerformanceReverseOrder) {
+  // Insert in reverse order — exercises different code paths.
+  const unsigned N = 100000;
+  DieRangeInfo Parent;
+
+  auto Start = std::chrono::steady_clock::now();
+  for (unsigned I = N; I > 0; --I) {
+    uint64_t Lo = I * 100;
+    uint64_t Hi = Lo + 50;
+    ASSERT_EQ(Parent.insert(makeRI(Lo, Hi)), Parent.Children.end());
+  }
+  auto End = std::chrono::steady_clock::now();
+  auto ElapsedMs =
+      std::chrono::duration_cast<std::chrono::milliseconds>(End - Start)
+          .count();
+
+  EXPECT_EQ(Parent.Children.size(), (size_t)N);
+  EXPECT_LT(ElapsedMs, 10000)
+      << "Insert took " << ElapsedMs
+      << "ms; likely O(N^2) regression for N=" << N;
+}
+
+TEST(DWARFVerifierTest, InsertPerformanceRandomOrder) {
+  // Insert in random order — most realistic scenario.
+  const unsigned N = 100000;
+  DieRangeInfo Parent;
+
+  // Generate N non-overlapping ranges, then shuffle.
+  std::vector<std::pair<uint64_t, uint64_t>> Ranges;
+  Ranges.reserve(N);
+  for (unsigned I = 0; I < N; ++I)
+    Ranges.push_back({I * 100, I * 100 + 50});
+
+  std::mt19937 RNG(42); // Fixed seed for reproducibility.
+  std::shuffle(Ranges.begin(), Ranges.end(), RNG);
+
+  auto Start = std::chrono::steady_clock::now();
+  for (const auto &[Lo, Hi] : Ranges)
+    ASSERT_EQ(Parent.insert(makeRI(Lo, Hi)), Parent.Children.end());
+  auto End = std::chrono::steady_clock::now();
+  auto ElapsedMs =
+      std::chrono::duration_cast<std::chrono::milliseconds>(End - Start)
+          .count();
+
+  EXPECT_EQ(Parent.Children.size(), (size_t)N);
+  EXPECT_LT(ElapsedMs, 10000)
+      << "Insert took " << ElapsedMs
+      << "ms; likely O(N^2) regression for N=" << N;
+}
+
+TEST(DWARFVerifierTest, InsertPerformanceWithOverlapDetection) {
+  // Insert N-1 non-overlapping ranges, then insert one that overlaps.
+  // Verify the overlap is detected quickly.
+  const unsigned N = 100000;
+  DieRangeInfo Parent;
+
+  for (unsigned I = 0; I < N - 1; ++I) {
+    uint64_t Lo = I * 100;
+    uint64_t Hi = Lo + 50;
+    ASSERT_EQ(Parent.insert(makeRI(Lo, Hi)), Parent.Children.end());
+  }
+
+  // Insert an overlapping range in the middle.
+  auto Start = std::chrono::steady_clock::now();
+  uint64_t Mid = (N / 2) * 100;
+  auto It = Parent.insert(makeRI(Mid + 10, Mid + 60));
+  auto End = std::chrono::steady_clock::now();
+  auto ElapsedMs =
+      std::chrono::duration_cast<std::chrono::milliseconds>(End - Start)
+          .count();
+
+  EXPECT_NE(It, Parent.Children.end()) << "Overlap should be detected";
+  EXPECT_LT(ElapsedMs, 100)
+      << "Single overlap detection took " << ElapsedMs << "ms; should be O(log N)";
+}
+
+} // namespace

--- a/llvm/unittests/DebugInfo/DWARF/DWARFVerifierTest.cpp
+++ b/llvm/unittests/DebugInfo/DWARF/DWARFVerifierTest.cpp
@@ -9,8 +9,6 @@
 #include "llvm/DebugInfo/DWARF/DWARFVerifier.h"
 #include "llvm/DebugInfo/DWARF/DWARFAddressRange.h"
 #include "gtest/gtest.h"
-#include <chrono>
-#include <random>
 
 using namespace llvm;
 
@@ -22,10 +20,6 @@ using DieRangeInfo = DWARFVerifier::DieRangeInfo;
 DieRangeInfo makeRI(uint64_t Lo, uint64_t Hi) {
   return DieRangeInfo({{Lo, Hi}});
 }
-
-//===----------------------------------------------------------------------===//
-// Correctness tests
-//===----------------------------------------------------------------------===//
 
 TEST(DWARFVerifierTest, InsertNoOverlap) {
   DieRangeInfo Parent;
@@ -123,109 +117,6 @@ TEST(DWARFVerifierTest, InsertRandomOrderNoOverlap) {
   EXPECT_EQ(Parent.insert(makeRI(700, 800)), Parent.Children.end());
   EXPECT_EQ(Parent.insert(makeRI(300, 400)), Parent.Children.end());
   EXPECT_EQ(Parent.Children.size(), 4u);
-}
-
-//===----------------------------------------------------------------------===//
-// Stress test: O(N^2) -> O(N log N) performance regression test
-//===----------------------------------------------------------------------===//
-
-TEST(DWARFVerifierTest, InsertPerformanceForwardOrder) {
-  // Insert N non-overlapping ranges in forward address order.
-  // With O(N^2): N=100000 would take ~minutes.
-  // With O(N log N): should complete in < 1 second.
-  const unsigned N = 100000;
-  DieRangeInfo Parent;
-
-  auto Start = std::chrono::steady_clock::now();
-  for (unsigned I = 0; I < N; ++I) {
-    uint64_t Lo = I * 100;
-    uint64_t Hi = Lo + 50;
-    ASSERT_EQ(Parent.insert(makeRI(Lo, Hi)), Parent.Children.end());
-  }
-  auto End = std::chrono::steady_clock::now();
-  auto ElapsedMs =
-      std::chrono::duration_cast<std::chrono::milliseconds>(End - Start)
-          .count();
-
-  EXPECT_EQ(Parent.Children.size(), (size_t)N);
-  // Should complete well within 10 seconds. The old O(N^2) implementation
-  // would take minutes for N=100000.
-  EXPECT_LT(ElapsedMs, 10000) << "Insert took " << ElapsedMs
-                              << "ms; likely O(N^2) regression for N=" << N;
-}
-
-TEST(DWARFVerifierTest, InsertPerformanceReverseOrder) {
-  // Insert in reverse order — exercises different code paths.
-  const unsigned N = 100000;
-  DieRangeInfo Parent;
-
-  auto Start = std::chrono::steady_clock::now();
-  for (unsigned I = N; I > 0; --I) {
-    uint64_t Lo = I * 100;
-    uint64_t Hi = Lo + 50;
-    ASSERT_EQ(Parent.insert(makeRI(Lo, Hi)), Parent.Children.end());
-  }
-  auto End = std::chrono::steady_clock::now();
-  auto ElapsedMs =
-      std::chrono::duration_cast<std::chrono::milliseconds>(End - Start)
-          .count();
-
-  EXPECT_EQ(Parent.Children.size(), (size_t)N);
-  EXPECT_LT(ElapsedMs, 10000) << "Insert took " << ElapsedMs
-                              << "ms; likely O(N^2) regression for N=" << N;
-}
-
-TEST(DWARFVerifierTest, InsertPerformanceRandomOrder) {
-  // Insert in random order — most realistic scenario.
-  const unsigned N = 100000;
-  DieRangeInfo Parent;
-
-  // Generate N non-overlapping ranges, then shuffle.
-  std::vector<std::pair<uint64_t, uint64_t>> Ranges;
-  Ranges.reserve(N);
-  for (unsigned I = 0; I < N; ++I)
-    Ranges.push_back({I * 100, I * 100 + 50});
-
-  std::mt19937 RNG(42); // Fixed seed for reproducibility.
-  std::shuffle(Ranges.begin(), Ranges.end(), RNG);
-
-  auto Start = std::chrono::steady_clock::now();
-  for (const auto &[Lo, Hi] : Ranges)
-    ASSERT_EQ(Parent.insert(makeRI(Lo, Hi)), Parent.Children.end());
-  auto End = std::chrono::steady_clock::now();
-  auto ElapsedMs =
-      std::chrono::duration_cast<std::chrono::milliseconds>(End - Start)
-          .count();
-
-  EXPECT_EQ(Parent.Children.size(), (size_t)N);
-  EXPECT_LT(ElapsedMs, 10000) << "Insert took " << ElapsedMs
-                              << "ms; likely O(N^2) regression for N=" << N;
-}
-
-TEST(DWARFVerifierTest, InsertPerformanceWithOverlapDetection) {
-  // Insert N-1 non-overlapping ranges, then insert one that overlaps.
-  // Verify the overlap is detected quickly.
-  const unsigned N = 100000;
-  DieRangeInfo Parent;
-
-  for (unsigned I = 0; I < N - 1; ++I) {
-    uint64_t Lo = I * 100;
-    uint64_t Hi = Lo + 50;
-    ASSERT_EQ(Parent.insert(makeRI(Lo, Hi)), Parent.Children.end());
-  }
-
-  // Insert an overlapping range in the middle.
-  auto Start = std::chrono::steady_clock::now();
-  uint64_t Mid = (N / 2) * 100;
-  auto It = Parent.insert(makeRI(Mid + 10, Mid + 60));
-  auto End = std::chrono::steady_clock::now();
-  auto ElapsedMs =
-      std::chrono::duration_cast<std::chrono::milliseconds>(End - Start)
-          .count();
-
-  EXPECT_NE(It, Parent.Children.end()) << "Overlap should be detected";
-  EXPECT_LT(ElapsedMs, 100) << "Single overlap detection took " << ElapsedMs
-                            << "ms; should be O(log N)";
 }
 
 } // namespace


### PR DESCRIPTION
We have a dSYM that is ~5.6 GB and has 69,840 compile units that took 3+ hours to verify (`dsymutil --verify-dwarf=auto`). This severely slowed our build time. So I investigated by `perf record` for a few minutes and found that `DWARFVerifier::DieRangeInfo::insert(const DieRangeInfo &RI)` was consuming 83% of CPU time — 48% in `_Rb_tree_increment` (iterator traversal) and 36% in the `insert` function itself.

It turns out the function was linearly scanning all children in a std::set to check for range overlaps, when it could leverage the sorted property of the set and check only the immediate neighbors after a O(log N) insertion. The worst compile unit had ~189K DIEs, making this O(N²) scan take over 4 minutes for a single unit.

The fix: insert into the sorted set first (O(log N)), then check only the predecessor and successor for intersection. Since children are verified non-overlapping as they are inserted incrementally, if the immediate neighbors don't intersect, no other child can either.

Results:
- Full verification: 181 minutes → 3.5 minutes (~52x speedup)
- Worst single compile unit: 245 seconds → 1.7 seconds (146x)
- Unit test with N=100,000 inserts (old → new):
    - Forward order: 262s → 33ms
    - Reverse order: 288s → 18ms
    - Random order: 369s → 59ms
