### PR TITLE
[lldb] Add darwin-mte-launcher

### DIFF
--- a/lldb/tools/CMakeLists.txt
+++ b/lldb/tools/CMakeLists.txt
@@ -20,6 +20,7 @@ endif()
 
 if (CMAKE_SYSTEM_NAME MATCHES "Darwin")
   add_lldb_tool_subdirectory(darwin-debug)
+  add_lldb_tool_subdirectory(darwin-mte-launcher)
   if(NOT LLDB_USE_SYSTEM_DEBUGSERVER)
     add_lldb_tool_subdirectory(debugserver)
   endif()

--- a/lldb/tools/darwin-mte-launcher/CMakeLists.txt
+++ b/lldb/tools/darwin-mte-launcher/CMakeLists.txt
@@ -1,0 +1,6 @@
+add_lldb_tool(darwin-mte-launcher
+  darwin-mte-launcher.cpp
+
+  LINK_COMPONENTS
+    Support
+)

--- a/lldb/tools/darwin-mte-launcher/darwin-mte-launcher.cpp
+++ b/lldb/tools/darwin-mte-launcher/darwin-mte-launcher.cpp
@@ -1,0 +1,74 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/Support/WithColor.h"
+#include <dlfcn.h>
+#include <spawn.h>
+#include <string.h>
+#include <vector>
+
+using namespace llvm;
+
+int main(int argc, const char *argv[], const char *envp[]) {
+  const char *program = argv[1];
+  const char **new_args = &argv[1];
+
+  posix_spawnattr_t attr;
+  int ret = posix_spawnattr_init(&attr);
+  if (ret != 0) {
+    WithColor::error() << "posix_spawnattr_init failed\n";
+    return EXIT_FAILURE;
+  }
+
+  typedef int (*posix_spawnattr_set_use_sec_transition_shims_np_t)(
+      posix_spawnattr_t *attr, uint32_t flags);
+  posix_spawnattr_set_use_sec_transition_shims_np_t
+      posix_spawnattr_enable_memory_tagging_fn =
+          (posix_spawnattr_set_use_sec_transition_shims_np_t)dlsym(
+              RTLD_DEFAULT, "posix_spawnattr_set_use_sec_transition_shims_np");
+
+  if (!posix_spawnattr_enable_memory_tagging_fn) {
+    WithColor::error()
+        << "posix_spawnattr_set_use_sec_transition_shims_np not available\n";
+    return EXIT_FAILURE;
+  }
+
+  ret = posix_spawnattr_enable_memory_tagging_fn(&attr, /*unused=*/0);
+  if (ret != 0) {
+    WithColor::error()
+        << "posix_spawnattr_set_use_sec_transition_shims_np failed\n";
+    return EXIT_FAILURE;
+  }
+
+  // Python's allocator (pymalloc) is not aware of Memory Tagging Extension
+  // (MTE) and crashes.
+  // https://bugs.python.org/issue43593
+  std::vector<const char *> new_envp;
+  for (const char **e = envp; *e; ++e)
+    new_envp.push_back(*e);
+  new_envp.push_back("PYTHONMALLOC=malloc");
+  new_envp.push_back(nullptr);
+
+  pid_t pid;
+  ret = posix_spawn(&pid, program, /*file_actions=*/nullptr, &attr,
+                    const_cast<char **>(new_args),
+                    const_cast<char **>(new_envp.data()));
+  if (ret != 0) {
+    WithColor::error() << "posix_spawn failed with error " << ret << "("
+                       << strerror(ret) << ")\n";
+    return EXIT_FAILURE;
+  }
+
+  int status;
+  if (waitpid(pid, &status, 0) == -1) {
+    WithColor::error() << "waitpid failed\n";
+    return EXIT_FAILURE;
+  }
+
+  return WEXITSTATUS(status);
+}


### PR DESCRIPTION
A new tool called `darwin-mte-launcher`. In order to launch a process under MTE, we need to set a posix_spawn flag. We already support this in LLDB when launching with the `--memory-tagging` flag (see #162944).

Python's built-in allocator doesn't play nice with MTE and requires setting PYTHONMALLOC=malloc to use the systme allocator. The launcher takes care of this as well.