### PR TITLE
[OpenMP][OMPT] Remove Threads dependency from omptest

### DIFF
--- a/openmp/tools/omptest/CMakeLists.txt
+++ b/openmp/tools/omptest/CMakeLists.txt
@@ -87,10 +87,6 @@ if ((NOT LIBOMPTEST_BUILD_STANDALONE) OR LIBOMPTEST_BUILD_UNITTESTS)
   # available to dependant targets, e.g. for unit tests.
   target_link_libraries(omptest PUBLIC default_gtest)
 
-  # Link against Threads (recommended for GTest).
-  find_package(Threads REQUIRED)
-  target_link_libraries(omptest PUBLIC Threads::Threads)
-
   # Ensure that embedded GTest symbols are exported from libomptest.so even in
   # builds that default to hidden.
   set_target_properties(omptest PROPERTIES


### PR DESCRIPTION
Removed link against `Threads`.
Reason: it is potentially problematic and optional.
The issue would manifest, if `omptest` is used via `find_package`.

edit: But `Threads` might not be found and cause a link error.