### PR TITLE
[SPIR-V] Fix llvm.spv.gep return type for vector-indexed GEPs

### DIFF
--- a/llvm/include/llvm/IR/IntrinsicsSPIRV.td
+++ b/llvm/include/llvm/IR/IntrinsicsSPIRV.td
@@ -23,7 +23,7 @@ let TargetPrefix = "spv" in {
   def int_spv_init_global : Intrinsic<[], [llvm_any_ty, llvm_any_ty]>;
   def int_spv_unref_global : Intrinsic<[], [llvm_any_ty]>;
 
-  def int_spv_gep : Intrinsic<[llvm_anyptr_ty], [llvm_i1_ty, llvm_any_ty, llvm_vararg_ty], [ImmArg<ArgIndex<0>>]>;
+  def int_spv_gep : Intrinsic<[llvm_any_ty], [llvm_i1_ty, llvm_any_ty, llvm_vararg_ty], [ImmArg<ArgIndex<0>>]>;
   def int_spv_load : Intrinsic<[llvm_i32_ty], [llvm_anyptr_ty, llvm_i16_ty, llvm_i32_ty], [ImmArg<ArgIndex<1>>, ImmArg<ArgIndex<2>>]>;
   def int_spv_store : Intrinsic<[], [llvm_any_ty, llvm_anyptr_ty, llvm_i16_ty, llvm_i32_ty], [ImmArg<ArgIndex<2>>, ImmArg<ArgIndex<3>>]>;
   def int_spv_extractv : Intrinsic<[llvm_any_ty], [llvm_i32_ty, llvm_vararg_ty]>;

--- a/llvm/test/CodeGen/SPIRV/pointers/getelementptr-vector-index.ll
+++ b/llvm/test/CodeGen/SPIRV/pointers/getelementptr-vector-index.ll
@@ -1,0 +1,15 @@
+; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv64-unknown-unknown %s -o - | FileCheck %s
+; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv64-amd-amdhsa %s -o - | FileCheck %s
+
+; CHECK-LABEL: Begin function test_vector_gep_with_load
+; CHECK: OpPtrAccessChain
+; CHECK: OpLoad
+; CHECK: OpStore
+; CHECK: OpFunctionEnd
+define spir_kernel void @test_vector_gep_with_load(ptr addrspace(1) %p, ptr addrspace(1) %out) {
+  %gep = getelementptr i32, ptr addrspace(1) %p, <1 x i64> zeroinitializer
+  %elem = extractelement <1 x ptr addrspace(1)> %gep, i32 0
+  %val = load i32, ptr addrspace(1) %elem
+  store i32 %val, ptr addrspace(1) %out
+  ret void
+}

--- a/llvm/test/CodeGen/SPIRV/pointers/getelementptr-vector-index.ll
+++ b/llvm/test/CodeGen/SPIRV/pointers/getelementptr-vector-index.ll
@@ -1,10 +1,18 @@
 ; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv64-unknown-unknown %s -o - | FileCheck %s
-; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv64-amd-amdhsa %s -o - | FileCheck %s
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv64-unknown-unknown %s -o - -filetype=obj | spirv-val %}
 
+; CHECK-DAG: %[[#INT32:]] = OpTypeInt 32 0
+; CHECK-DAG: %[[#PTR_INT32:]] = OpTypePointer CrossWorkgroup %[[#INT32]]
+; CHECK-DAG: %[[#INT8:]] = OpTypeInt 8 0
+; CHECK-DAG: %[[#PTR_INT8:]] = OpTypePointer CrossWorkgroup %[[#INT8]]
+; CHECK-DAG: %[[#INT64:]] = OpTypeInt 64 0
+; CHECK-DAG: %[[#CONST_0:]] = OpConstantNull %[[#INT64]]
 ; CHECK-LABEL: Begin function test_vector_gep_with_load
-; CHECK: OpPtrAccessChain
-; CHECK: OpLoad
-; CHECK: OpStore
+; CHECK: %[[#BC1:]] = OpBitcast %[[#PTR_INT8]] %[[#]]
+; CHECK: %[[#GEP:]] = OpPtrAccessChain %[[#PTR_INT8]] %[[#BC1]] %[[#CONST_0]]
+; CHECK: %[[#BC2:]] = OpBitcast %[[#PTR_INT32]] %[[#GEP]]
+; CHECK: %[[#VAL:]] = OpLoad %[[#INT32]] %[[#BC2]]
+; CHECK: OpStore %[[#]] %[[#VAL]]
 ; CHECK: OpFunctionEnd
 define spir_kernel void @test_vector_gep_with_load(ptr addrspace(1) %p, ptr addrspace(1) %out) {
   %gep = getelementptr i32, ptr addrspace(1) %p, <1 x i64> zeroinitializer


### PR DESCRIPTION
The `int_spv_gep` intrinsic was defined with `llvm_anyptr_ty` which forced it to return a scalar pointer. Change the return type to `llvm_any_ty` to allow the intrinsic to match the actual result type of the original GEP, whether scalar or vector