### PR TITLE
Revert "[CFI] Expand test to include minimal runtime"

### DIFF
--- a/compiler-rt/test/cfi/icall/bad-signature.c
+++ b/compiler-rt/test/cfi/icall/bad-signature.c
@@ -7,9 +7,6 @@
 // RUN: %clang_cfi_diag -g -o %t3 %s
 // RUN: %t3 2>&1 | FileCheck --check-prefix=CFI-DIAG %s
 
-// RUN: %clang_cfi -fno-sanitize-trap=cfi -fsanitize-recover=cfi -fsanitize-minimal-runtime -o %t4 %s
-// RUN: %t4 2>&1 | FileCheck --check-prefix=CFI-MINIMAL %s
-
 #include <stdio.h>
 
 void f() {
@@ -18,16 +15,13 @@ void f() {
 int main() {
   // CFI: 1
   // NCFI: 1
-  // CFI-MINIMAL: 1
   fprintf(stderr, "1\n");
 
   // CFI-DIAG: runtime error: control flow integrity check for type 'void (int)' failed during indirect function call
   // CFI-DIAG: f defined here
-  // CFI-MINIMAL: ubsan: cfi-check-fail by 0x
   ((void (*)(int))f)(42); // UB here
 
   // CFI-NOT: 2
   // NCFI: 2
-  // CFI-MINIMAL: 2
   fprintf(stderr, "2\n");
 }


### PR DESCRIPTION
Reverts llvm/llvm-project#183646

Breaks tests if ubsan_minimal runtime isn't built, see:
https://github.com/llvm/llvm-project/pull/183646#issuecomment-3994252478