### PR TITLE
[support][blake3][nfc]Expose init_keyed to BLAKE3 llvm wrapper.

### DIFF
--- a/llvm/include/llvm/Support/BLAKE3.h
+++ b/llvm/include/llvm/Support/BLAKE3.h
@@ -42,6 +42,12 @@ public:
   /// Reinitialize the internal state
   void init() { llvm_blake3_hasher_init(&Hasher); }
 
+  /// Reinitialize the internal state with the given key.
+  void init_keyed(ArrayRef<uint8_t> Key) {
+    // TODO: maybe assert on the size of the key?
+    llvm_blake3_hasher_init_keyed(&Hasher, Key.data());
+  }
+
   /// Digest more data.
   void update(ArrayRef<uint8_t> Data) {
     llvm_blake3_hasher_update(&Hasher, Data.data(), Data.size());

--- a/llvm/unittests/Support/BLAKE3Test.cpp
+++ b/llvm/unittests/Support/BLAKE3Test.cpp
@@ -92,4 +92,35 @@ TEST(BLAKE3Test, SmallerHashSize) {
   EXPECT_EQ(hashStr1, toHex(hash4));
 }
 
+TEST(BLAKE3Test, InitKeyed) {
+  const char *InputStr = "abc";
+  ArrayRef<uint8_t> Input(reinterpret_cast<const uint8_t *>(InputStr),
+                          strlen(InputStr));
+  BLAKE3 Hash1;
+  uint8_t key1[32] = {0};
+  key1[0] = 'a';
+  key1[1] = 'b';
+  key1[2] = 'c';
+  key1[3] = 'd';
+  Hash1.init_keyed(key1);
+  Hash1.update(Input);
+  auto hash1 = Hash1.final<16>();
+  auto hashStr1 = toHex(hash1);
+
+  BLAKE3 Hash2;
+  uint8_t key2[32] = {0};
+  key2[0] = 'x';
+  key2[1] = 'y';
+  key2[2] = 'z';
+  key2[3] = 't';
+  Hash2.init_keyed(key2);
+  Hash2.update(Input);
+  auto hash2 = Hash2.final<16>();
+  auto hashStr2 = toHex(hash2);
+
+  ASSERT_NE(hashStr1, hashStr2);
+  EXPECT_EQ(hashStr1, "667DB3821E1AAABA03ADFE1F4F803DF7");
+  EXPECT_EQ(hashStr2, "B683D7EB0B441AC11FCAC1199B911053");
+}
+
 } // namespace


### PR DESCRIPTION
Our use case requires making two (or more) hashes for the same input but with different keys.
The library already supports this - we just need to expose the API