### PR TITLE
[bazel] Add -Wno-vla-cxx-extension to macOS lldb srcs

### DIFF
--- a/utils/bazel/llvm-project-overlay/lldb/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/lldb/BUILD.bazel
@@ -979,6 +979,9 @@ cc_library(
         ["tools/debugserver/source/**/*.cpp"],
         exclude = ["tools/debugserver/source/debugserver.cpp"],
     ),
+    copts = [
+        "-Wno-vla-cxx-extension",
+    ],
     local_defines = ["LLDB_USE_OS_LOG"],
     tags = ["nobuildkite"],
     deps = [
@@ -1021,6 +1024,9 @@ cc_binary(
         "tools/debugserver/source/debugserver.cpp",
         ":debugserver_version_gen",
         ":mach_gen",
+    ],
+    copts = [
+        "-Wno-vla-cxx-extension",
     ],
     tags = ["nobuildkite"],
     target_compatible_with = select({

--- a/utils/bazel/llvm-project-overlay/lldb/source/Plugins/plugin_config.bzl
+++ b/utils/bazel/llvm-project-overlay/lldb/source/Plugins/plugin_config.bzl
@@ -103,4 +103,5 @@ OBJCPP_COPTS = [
     "-std=c++{}".format(CMAKE_CXX_STANDARD),
     "-fno-objc-exceptions",
     "-Wno-shorten-64-to-32",
+    "-Wno-vla-cxx-extension",
 ]


### PR DESCRIPTION
```
lldb/tools/debugserver/source/MacOSX/MachVMMemory.cpp:88:20: warning: variable length arrays in C++ are a Clang extension [-Wvla-cxx-extension]
   88 |   int dispositions[dispositions_size];
      |                    ^~~~~~~~~~~~~~~~~
```

This code contains objc++ which can only be compiled with clang anyways.
