### PR TITLE
[mlir][quant] Fix u8 storage type parsed as signless instead of unsigned

### DIFF
--- a/mlir/lib/Dialect/Quant/IR/TypeParser.cpp
+++ b/mlir/lib/Dialect/Quant/IR/TypeParser.cpp
@@ -48,7 +48,7 @@ static Type parseStorageType(DialectAsmParser &parser, bool &isSigned) {
         return nullptr;
       }
       isSigned = false;
-      type = parser.getBuilder().getIntegerType(storageTypeWidth);
+      type = parser.getBuilder().getIntegerType(storageTypeWidth, isSigned);
     } else {
       parser.emitError(typeLoc, "illegal storage type prefix");
       return nullptr;

--- a/mlir/test/Dialect/Quant/Bytecode/u8-storage-roundtrip.mlir
+++ b/mlir/test/Dialect/Quant/Bytecode/u8-storage-roundtrip.mlir
@@ -1,0 +1,14 @@
+// Verify that the u8 keyword in quant types creates unsigned (ui8) storage,
+// not signless (i8). The quant printer always outputs "u8" regardless of the
+// underlying IntegerType signedness, so the only way to detect a mismatch is
+// to compare bytecodes: one from the explicit "ui8" syntax (parsed via
+// parseOptionalType, always unsigned) and one from a text roundtrip through
+// the "u8" keyword path.
+
+// RUN: mlir-opt %s -allow-unregistered-dialect --strip-debuginfo -emit-bytecode -o %t.bc
+// RUN: mlir-opt %t.bc -allow-unregistered-dialect | mlir-opt -allow-unregistered-dialect --strip-debuginfo -emit-bytecode -o %t2.bc
+// RUN: cmp %t.bc %t2.bc
+
+module @u8StorageRoundtrip attributes {
+  bytecode.test = !quant.uniform<ui8:f32, 9.987200e-01:127>
+} {}


### PR DESCRIPTION
With this fix quantized `u8` types are parsed as **unsigned** (`ui8`) types instead of **signless** (`i8`).

This was hidden since the quant type printer decides what to print based on `QuantizationFlags`. Additionally, `QuantizedType::verifyInvariants` does not check that flags and type-based signedness are kept in sync. This is not touched in this PR.