### PR TITLE
[libc++][test] Use loop with compare_exchange_weak calls

### DIFF
--- a/libcxx/test/std/atomics/atomics.ref/compare_exchange_weak.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.ref/compare_exchange_weak.pass.cpp
@@ -33,11 +33,10 @@ struct TestCompareExchangeWeak {
       std::atomic_ref<T> const a(x);
 
       T t(T(1));
-      std::same_as<bool> decltype(auto) y = a.compare_exchange_weak(t, T(2));
-      assert(y == true);
+      while(!a.compare_exchange_weak(t, T(2)));
       assert(a == T(2));
       assert(t == T(1));
-      y = a.compare_exchange_weak(t, T(3));
+      std::same_as<bool> decltype(auto) y = a.compare_exchange_weak(t, T(3));
       assert(y == false);
       assert(a == T(2));
       assert(t == T(2));
@@ -49,11 +48,10 @@ struct TestCompareExchangeWeak {
       std::atomic_ref<T> const a(x);
 
       T t(T(1));
-      std::same_as<bool> decltype(auto) y = a.compare_exchange_weak(t, T(2), std::memory_order_seq_cst);
-      assert(y == true);
+      while(!a.compare_exchange_weak(t, T(2), std::memory_order_seq_cst));
       assert(a == T(2));
       assert(t == T(1));
-      y = a.compare_exchange_weak(t, T(3), std::memory_order_seq_cst);
+      std::same_as<bool> decltype(auto) y = a.compare_exchange_weak(t, T(3), std::memory_order_seq_cst);
       assert(y == false);
       assert(a == T(2));
       assert(t == T(2));
@@ -65,12 +63,11 @@ struct TestCompareExchangeWeak {
       std::atomic_ref<T> const a(x);
 
       T t(T(1));
-      std::same_as<bool> decltype(auto) y =
-          a.compare_exchange_weak(t, T(2), std::memory_order_release, std::memory_order_relaxed);
-      assert(y == true);
+      while(!a.compare_exchange_weak(t, T(2), std::memory_order_release, std::memory_order_relaxed));
       assert(a == T(2));
       assert(t == T(1));
-      y = a.compare_exchange_weak(t, T(3), std::memory_order_release, std::memory_order_relaxed);
+      std::same_as<bool> decltype(auto) y = 
+          a.compare_exchange_weak(t, T(3), std::memory_order_release, std::memory_order_relaxed);
       assert(y == false);
       assert(a == T(2));
       assert(t == T(2));

--- a/libcxx/test/std/atomics/atomics.ref/compare_exchange_weak.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.ref/compare_exchange_weak.pass.cpp
@@ -33,7 +33,7 @@ struct TestCompareExchangeWeak {
       std::atomic_ref<T> const a(x);
 
       T t(T(1));
-      while(!a.compare_exchange_weak(t, T(2)));
+      while(!a.compare_exchange_weak(t, T(2))) {}
       assert(a == T(2));
       assert(t == T(1));
       std::same_as<bool> decltype(auto) y = a.compare_exchange_weak(t, T(3));
@@ -48,7 +48,7 @@ struct TestCompareExchangeWeak {
       std::atomic_ref<T> const a(x);
 
       T t(T(1));
-      while(!a.compare_exchange_weak(t, T(2), std::memory_order_seq_cst));
+      while(!a.compare_exchange_weak(t, T(2), std::memory_order_seq_cst)) {}
       assert(a == T(2));
       assert(t == T(1));
       std::same_as<bool> decltype(auto) y = a.compare_exchange_weak(t, T(3), std::memory_order_seq_cst);
@@ -63,7 +63,8 @@ struct TestCompareExchangeWeak {
       std::atomic_ref<T> const a(x);
 
       T t(T(1));
-      while(!a.compare_exchange_weak(t, T(2), std::memory_order_release, std::memory_order_relaxed));
+      while(!a.compare_exchange_weak(t, T(2), std::memory_order_release, std::memory_order_relaxed))
+        {}
       assert(a == T(2));
       assert(t == T(1));
       std::same_as<bool> decltype(auto) y = 

--- a/libcxx/test/std/atomics/atomics.ref/compare_exchange_weak.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.ref/compare_exchange_weak.pass.cpp
@@ -33,7 +33,8 @@ struct TestCompareExchangeWeak {
       std::atomic_ref<T> const a(x);
 
       T t(T(1));
-      while(!a.compare_exchange_weak(t, T(2))) {}
+      while (!a.compare_exchange_weak(t, T(2))) {
+      }
       assert(a == T(2));
       assert(t == T(1));
       std::same_as<bool> decltype(auto) y = a.compare_exchange_weak(t, T(3));
@@ -48,7 +49,8 @@ struct TestCompareExchangeWeak {
       std::atomic_ref<T> const a(x);
 
       T t(T(1));
-      while(!a.compare_exchange_weak(t, T(2), std::memory_order_seq_cst)) {}
+      while (!a.compare_exchange_weak(t, T(2), std::memory_order_seq_cst)) {
+      }
       assert(a == T(2));
       assert(t == T(1));
       std::same_as<bool> decltype(auto) y = a.compare_exchange_weak(t, T(3), std::memory_order_seq_cst);
@@ -63,11 +65,11 @@ struct TestCompareExchangeWeak {
       std::atomic_ref<T> const a(x);
 
       T t(T(1));
-      while(!a.compare_exchange_weak(t, T(2), std::memory_order_release, std::memory_order_relaxed))
-        {}
+      while (!a.compare_exchange_weak(t, T(2), std::memory_order_release, std::memory_order_relaxed)) {
+      }
       assert(a == T(2));
       assert(t == T(1));
-      std::same_as<bool> decltype(auto) y = 
+      std::same_as<bool> decltype(auto) y =
           a.compare_exchange_weak(t, T(3), std::memory_order_release, std::memory_order_relaxed);
       assert(y == false);
       assert(a == T(2));


### PR DESCRIPTION
On AIX, this test sometimes fails with error `Assertion failed: y == true`. The test assumes `compare_exchange_weak` should succeed on a single call, however according to the standard:

> A weak compare-and-exchange operation may fail spuriously. That is, even when the contents of memory referred to by expected and ptr are equal, it may return false and store back to expected the same memory contents that were originally there.
This spurious failure enables implementation of compare-and-exchange on a broader class of machines, e.g., load-locked store-conditional machines. A consequence of spurious failure is that nearly all uses of weak compare-and-exchange will be in a loop.

[atomics.ref.ops]/27