### PR TITLE
[RISCV] Make selectShiftMask32/selectShiftMask64 a template function. NFC

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVISelDAGToDAG.h
+++ b/llvm/lib/Target/RISCV/RISCVISelDAGToDAG.h
@@ -87,8 +87,7 @@ public:
   bool selectShiftMaskXLen(SDValue N, SDValue &ShAmt) {
     return selectShiftMask(N, Subtarget->getXLen(), ShAmt);
   }
-  template <unsigned Size>
-  bool selectShiftMask(SDValue N, SDValue &ShAmt) {
+  template <unsigned Size> bool selectShiftMask(SDValue N, SDValue &ShAmt) {
     return selectShiftMask(N, Size, ShAmt);
   }
 

--- a/llvm/lib/Target/RISCV/RISCVISelDAGToDAG.h
+++ b/llvm/lib/Target/RISCV/RISCVISelDAGToDAG.h
@@ -87,11 +87,9 @@ public:
   bool selectShiftMaskXLen(SDValue N, SDValue &ShAmt) {
     return selectShiftMask(N, Subtarget->getXLen(), ShAmt);
   }
-  bool selectShiftMask32(SDValue N, SDValue &ShAmt) {
-    return selectShiftMask(N, 32, ShAmt);
-  }
-  bool selectShiftMask64(SDValue N, SDValue &ShAmt) {
-    return selectShiftMask(N, 64, ShAmt);
+  template <unsigned Size>
+  bool selectShiftMask(SDValue N, SDValue &ShAmt) {
+    return selectShiftMask(N, Size, ShAmt);
   }
 
   bool selectSETCC(SDValue N, ISD::CondCode ExpectedCCVal, SDValue &Val);

--- a/llvm/lib/Target/RISCV/RISCVInstrInfo.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfo.td
@@ -1503,7 +1503,7 @@ def : Pat<(XLenVT (and GPR:$rs, immop_oneuse<TrailingOnesMask>:$mask)),
 // zero-extends it). For RISC-V, the mask is unnecessary as shifts in the base
 // ISA only read the least significant 5 bits (RV32I) or 6 bits (RV64I).
 def shiftMaskXLen : ComplexPattern<XLenVT, 1, "selectShiftMaskXLen", [], [], 0>;
-def shiftMask32   : ComplexPattern<i64, 1, "selectShiftMask32", [], [], 0>;
+def shiftMask32   : ComplexPattern<i64, 1, "selectShiftMask<32>", [], [], 0>;
 // FIXME: This is labelled as handling 's32', however the ComplexPattern it
 // refers to handles both i32 and i64 based on the HwMode. Currently this LLT
 // parameter appears to be ignored so this pattern works for both, however we

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoP.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoP.td
@@ -1650,7 +1650,7 @@ def riscv_nsrl : RVSDNode<"NSRL", SDT_RISCVNarrowingShift>;
 def riscv_nsra : RVSDNode<"NSRA", SDT_RISCVNarrowingShift>;
 
 // ComplexPattern for 64-bit shift mask (NSRL/NSRA only read 6 bits).
-def shiftMask64 : ComplexPattern<i32, 1, "selectShiftMask64", [], [], 0>;
+def shiftMask64 : ComplexPattern<i32, 1, "selectShiftMask<64>", [], [], 0>;
 
 // Build a GPRPair from two GPR registers for narrowing shift instructions.
 def BuildGPRPair : OutPatFrag<(ops node:$lo, node:$hi),


### PR DESCRIPTION
I may need selectShiftMask16 and selectShiftMask8 for P extension shift instructions.