### PR TITLE
[flang][OpenMP] Loop IVs inside TEAMS are predetermined private in 5.2+

### DIFF
--- a/flang/lib/Semantics/resolve-directives.cpp
+++ b/flang/lib/Semantics/resolve-directives.cpp
@@ -2041,6 +2041,7 @@ bool OmpAttributeVisitor::Pre(const parser::OpenMPLoopConstruct &x) {
 
 void OmpAttributeVisitor::ResolveSeqLoopIndexInParallelOrTaskConstruct(
     const parser::Name &iv) {
+  unsigned version{context_.langOptions().OpenMPVersion};
   // Find the parallel or task generating construct enclosing the
   // sequential loop.
   auto targetIt{dirContext_.rbegin()};
@@ -2051,6 +2052,11 @@ void OmpAttributeVisitor::ResolveSeqLoopIndexInParallelOrTaskConstruct(
     if (llvm::omp::allParallelSet.test(targetIt->directive) ||
         llvm::omp::taskGeneratingSet.test(targetIt->directive)) {
       break;
+    }
+    if (version >= 52) {
+      if (llvm::omp::allTeamsSet.test(targetIt->directive)) {
+        break;
+      }
     }
   }
   if (IsLocalInsideScope(*iv.symbol, targetIt->scope)) {

--- a/flang/lib/Semantics/resolve-directives.cpp
+++ b/flang/lib/Semantics/resolve-directives.cpp
@@ -2042,7 +2042,7 @@ bool OmpAttributeVisitor::Pre(const parser::OpenMPLoopConstruct &x) {
 void OmpAttributeVisitor::ResolveSeqLoopIndexInParallelOrTaskConstruct(
     const parser::Name &iv) {
   unsigned version{context_.langOptions().OpenMPVersion};
-  // Find the parallel or task generating construct enclosing the
+  // Find the parallel, teams or task generating construct enclosing the
   // sequential loop.
   auto targetIt{dirContext_.rbegin()};
   for (;; ++targetIt) {

--- a/flang/test/Semantics/OpenMP/resolve07.f90
+++ b/flang/test/Semantics/OpenMP/resolve07.f90
@@ -1,41 +1,41 @@
-! RUN: %python %S/../test_errors.py %s %flang -fopenmp -fopenmp-version=52
+!RUN: %python %S/../test_symbols.py %s %flang_fc1 -fopenmp -fopenmp-version=52
 
+!DEF: /f00 (Subroutine) Subprogram
 subroutine f00
   implicit none
 
+!DEF: /f00/n PARAMETER ObjectEntity INTEGER(4)
   integer, parameter :: n = 1024
-  integer :: i, j, k, array(n, n, n)
+ !DEF: /f00/i ObjectEntity INTEGER(4)
+ !DEF: /f00/j ObjectEntity INTEGER(4)
+ !DEF: /f00/k ObjectEntity INTEGER(4)
+ !DEF: /f00/array ObjectEntity INTEGER(4)
+ !REF: /f00/n
+  integer i, j, k, array(n, n, n)
 
   !The i and j are predetermined private as loop induction variables nested
   !in a teams construct.
   !$omp target teams distribute default(none) shared(array)
+!DEF: /f00/OtherConstruct1/i (OmpPrivate, OmpPreDetermined) HostAssoc INTEGER(4)
+!REF: /f00/n
   do i = 1, n
+!DEF: /f00/OtherConstruct1/j (OmpPrivate, OmpPreDetermined) HostAssoc INTEGER(4)
+!REF: /f00/n
     do j = 1, n
       !i and j are shared in parallel
       !$omp parallel do shared(array)
+!DEF: /f00/OtherConstruct1/OtherConstruct1/k (OmpPrivate, OmpPreDetermined) HostAssoc INTEGER(4)
+!REF: /f00/n
       do k = 1, n
+!DEF: /f00/OtherConstruct1/OtherConstruct1/array (OmpShared, OmpExplicit) HostAssoc INTEGER(4)
+!DEF: /f00/OtherConstruct1/OtherConstruct1/i (OmpShared) HostAssoc INTEGER(4)
+!DEF: /f00/OtherConstruct1/OtherConstruct1/j (OmpShared) HostAssoc INTEGER(4)
+!REF: /f00/OtherConstruct1/OtherConstruct1/k
         array(i, j, k) = i + j + k
       enddo
     enddo
   enddo
-end
+end subroutine
 
-subroutine f01
-  implicit none
 
-  integer, parameter :: n = 1024
-  integer :: i, j, k, array(n, n, n)
-
-  !$omp target teams distribute default(none) shared(array)
-  do i = 1, n
-    do j = 1, n
-      !$omp parallel do default(none) shared(array)
-      do k = 1, n
-        !ERROR: The DEFAULT(NONE) clause requires that 'i' must be listed in a data-sharing attribute clause
-        !ERROR: The DEFAULT(NONE) clause requires that 'j' must be listed in a data-sharing attribute clause
-        array(i, j, k) = i + j + k
-      enddo
-    enddo
-  enddo
-end
 

--- a/flang/test/Semantics/OpenMP/resolve07.f90
+++ b/flang/test/Semantics/OpenMP/resolve07.f90
@@ -6,7 +6,7 @@ subroutine f00
   integer, parameter :: n = 1024
   integer :: i, j, k, array(n, n, n)
 
-  !The i and j are predermined private as loop induction variables nested
+  !The i and j are predetermined private as loop induction variables nested
   !in a teams construct.
   !$omp target teams distribute default(none) shared(array)
   do i = 1, n

--- a/flang/test/Semantics/OpenMP/resolve07.f90
+++ b/flang/test/Semantics/OpenMP/resolve07.f90
@@ -1,0 +1,41 @@
+! RUN: %python %S/../test_errors.py %s %flang -fopenmp -fopenmp-version=52
+
+subroutine f00
+  implicit none
+
+  integer, parameter :: n = 1024
+  integer :: i, j, k, array(n, n, n)
+
+  !The i and j are predermined private as loop induction variables nested
+  !in a teams construct.
+  !$omp target teams distribute default(none) shared(array)
+  do i = 1, n
+    do j = 1, n
+      !i and j are shared in parallel
+      !$omp parallel do shared(array)
+      do k = 1, n
+        array(i, j, k) = i + j + k
+      enddo
+    enddo
+  enddo
+end
+
+subroutine f01
+  implicit none
+
+  integer, parameter :: n = 1024
+  integer :: i, j, k, array(n, n, n)
+
+  !$omp target teams distribute default(none) shared(array)
+  do i = 1, n
+    do j = 1, n
+      !$omp parallel do default(none) shared(array)
+      do k = 1, n
+        !ERROR: The DEFAULT(NONE) clause requires that 'i' must be listed in a data-sharing attribute clause
+        !ERROR: The DEFAULT(NONE) clause requires that 'j' must be listed in a data-sharing attribute clause
+        array(i, j, k) = i + j + k
+      enddo
+    enddo
+  enddo
+end
+


### PR DESCRIPTION
Mark the induction variables of loops in a TEAMS construct as predetermined private when OpenMP version is 5.2 or later.