### PR TITLE
[mlir][spirv] Add OpOuterProduct operation

### DIFF
--- a/mlir/include/mlir/Dialect/SPIRV/IR/SPIRVBase.td
+++ b/mlir/include/mlir/Dialect/SPIRV/IR/SPIRVBase.td
@@ -4492,6 +4492,7 @@ def SPIRV_OC_OpMatrixTimesScalar              : I32EnumAttrCase<"OpMatrixTimesSc
 def SPIRV_OC_OpVectorTimesMatrix              : I32EnumAttrCase<"OpVectorTimesMatrix", 144>;
 def SPIRV_OC_OpMatrixTimesVector              : I32EnumAttrCase<"OpMatrixTimesVector", 145>;
 def SPIRV_OC_OpMatrixTimesMatrix              : I32EnumAttrCase<"OpMatrixTimesMatrix", 146>;
+def SPIRV_OC_OpOuterProduct                   : I32EnumAttrCase<"OpOuterProduct", 147>;
 def SPIRV_OC_OpDot                            : I32EnumAttrCase<"OpDot", 148>;
 def SPIRV_OC_OpIAddCarry                      : I32EnumAttrCase<"OpIAddCarry", 149>;
 def SPIRV_OC_OpISubBorrow                     : I32EnumAttrCase<"OpISubBorrow", 150>;
@@ -4690,7 +4691,8 @@ def SPIRV_OpcodeAttr :
       SPIRV_OC_OpSMod, SPIRV_OC_OpFRem, SPIRV_OC_OpFMod,
       SPIRV_OC_OpVectorTimesScalar, SPIRV_OC_OpMatrixTimesScalar,
       SPIRV_OC_OpVectorTimesMatrix, SPIRV_OC_OpMatrixTimesVector,
-      SPIRV_OC_OpMatrixTimesMatrix, SPIRV_OC_OpDot, SPIRV_OC_OpIAddCarry,
+      SPIRV_OC_OpMatrixTimesMatrix, SPIRV_OC_OpOuterProduct, SPIRV_OC_OpDot,
+      SPIRV_OC_OpIAddCarry,
       SPIRV_OC_OpISubBorrow, SPIRV_OC_OpUMulExtended, SPIRV_OC_OpSMulExtended,
       SPIRV_OC_OpIsNan, SPIRV_OC_OpIsInf, SPIRV_OC_OpIsFinite,
       SPIRV_OC_OpOrdered, SPIRV_OC_OpUnordered,

--- a/mlir/include/mlir/Dialect/SPIRV/IR/SPIRVMatrixOps.td
+++ b/mlir/include/mlir/Dialect/SPIRV/IR/SPIRVMatrixOps.td
@@ -93,6 +93,57 @@ def SPIRV_MatrixTimesMatrixOp : SPIRV_Op<"MatrixTimesMatrix", [
 
 // -----
 
+def SPIRV_OuterProductOp : SPIRV_Op<"OuterProduct", [
+    Pure,
+    AllElementTypesMatch<["vector1", "vector2", "result"]>,
+    SPIRV_MatrixVectorDimMatch<"result", "rows", "vector1">,
+    SPIRV_MatrixVectorDimMatch<"result", "columns", "vector2">
+  ]> {
+  let summary = "Linear-algebraic outer product of vector1 and vector2.";
+
+  let description = [{
+    Result Type must be a Matrix Type whose Column Type is a vector of
+    floating-point type.
+
+    Vector1 must have the same type as the Column Type in Result Type.
+
+    Vector2 must be a vector with the same Component Type as the Component
+    Type in Result Type. Its number of components must equal the number of
+    columns in Result Type.
+
+    #### Example:
+
+    ```mlir
+    %0 = spirv.OuterProduct %vector1, %vector2 :
+        vector<3xf32>, vector<2xf32> -> !spirv.matrix<2 x vector<3xf32>>
+    ```
+  }];
+
+  let availability = [
+    MinVersion<SPIRV_V_1_0>,
+    MaxVersion<SPIRV_V_1_6>,
+    Extension<[]>,
+    Capability<[SPIRV_C_Matrix]>
+  ];
+
+  let arguments = (ins
+    SPIRV_VectorOf<SPIRV_Float>:$vector1,
+    SPIRV_VectorOf<SPIRV_Float>:$vector2
+  );
+
+  let results = (outs
+    SPIRV_MatrixOf<SPIRV_Float>:$result
+  );
+
+  let assemblyFormat = [{
+    operands attr-dict `:` type($vector1) `,` type($vector2) `->` type($result)
+  }];
+
+  let hasVerifier = 0;
+}
+
+// -----
+
 def SPIRV_MatrixTimesScalarOp : SPIRV_Op<"MatrixTimesScalar", [
     Pure,
     AllTypesMatch<["matrix", "result"]>,

--- a/mlir/test/Dialect/SPIRV/IR/matrix-ops.mlir
+++ b/mlir/test/Dialect/SPIRV/IR/matrix-ops.mlir
@@ -43,6 +43,13 @@ spirv.module Logical GLSL450 requires #spirv.vce<v1.0, [Shader], []> {
     spirv.ReturnValue %result : vector<4xf32>
   }
 
+  // CHECK-LABEL: @outer_product_1
+  spirv.func @outer_product_1(%arg0: vector<3xf32>, %arg1: vector<2xf32>) -> !spirv.matrix<2 x vector<3xf32>> "None" {
+    // CHECK: {{%.*}} = spirv.OuterProduct {{%.*}}, {{%.*}} : vector<3xf32>, vector<2xf32> -> !spirv.matrix<2 x vector<3xf32>>
+    %result = spirv.OuterProduct %arg0, %arg1 : vector<3xf32>, vector<2xf32> -> !spirv.matrix<2 x vector<3xf32>>
+    spirv.ReturnValue %result : !spirv.matrix<2 x vector<3xf32>>
+  }
+
   // CHECK-LABEL: @matrix_times_matrix_1
   spirv.func @matrix_times_matrix_1(%arg0: !spirv.matrix<3 x vector<3xf32>>, %arg1: !spirv.matrix<3 x vector<3xf32>>) -> !spirv.matrix<3 x vector<3xf32>> "None"{
     // CHECK: {{%.*}} = spirv.MatrixTimesMatrix {{%.*}}, {{%.*}} : !spirv.matrix<3 x vector<3xf32>>, !spirv.matrix<3 x vector<3xf32>> -> !spirv.matrix<3 x vector<3xf32>>
@@ -199,5 +206,29 @@ func.func @vector_times_matrix_vector_type_mismatch(%arg0: vector<3xf16>, %arg1:
 func.func @vector_times_matrix_matrix_type_mismatch(%arg0: vector<3xf32>, %arg1: !spirv.matrix<4 x vector<3xf16>>) {
   // expected-error @+1 {{op failed to verify that all of {matrix, result} have same element type}}
   %result = spirv.VectorTimesMatrix %arg0, %arg1 : vector<3xf32>, !spirv.matrix<4 x vector<3xf16>> -> vector<4xf32>
+  return
+}
+
+// -----
+
+func.func @outer_product_element_type_mismatch(%arg0: vector<3xf16>, %arg1: vector<2xf16>) {
+  // expected-error @+1 {{op failed to verify that all of {vector1, vector2, result} have same element type}}
+  %result = spirv.OuterProduct %arg0, %arg1 : vector<3xf16>, vector<2xf16> -> !spirv.matrix<2 x vector<3xf32>>
+  return
+}
+
+// -----
+
+func.func @outer_product_vector1_result_row_mismatch(%arg0: vector<3xf32>, %arg1: vector<2xf32>) {
+  // expected-error @+1 {{op failed to verify that result rows count matches vector1 elements count}}
+  %result = spirv.OuterProduct %arg0, %arg1 : vector<3xf32>, vector<2xf32> -> !spirv.matrix<2 x vector<4xf32>>
+  return
+}
+
+// -----
+
+func.func @outer_product_vector2_result_column_mismatch(%arg0: vector<3xf32>, %arg1: vector<2xf32>) {
+  // expected-error @+1 {{op failed to verify that result columns count matches vector2 elements count}}
+  %result = spirv.OuterProduct %arg0, %arg1 : vector<3xf32>, vector<2xf32> -> !spirv.matrix<3 x vector<3xf32>>
   return
 }

--- a/mlir/test/Target/SPIRV/matrix.mlir
+++ b/mlir/test/Target/SPIRV/matrix.mlir
@@ -54,6 +54,13 @@ spirv.module Physical64 Vulkan requires #spirv.vce<v1.3, [Shader, Linkage, Coope
     %result = spirv.VectorTimesMatrix %arg0, %arg1 : vector<3xf32>, !spirv.matrix<4 x vector<3xf32>> -> vector<4xf32>
     spirv.ReturnValue %result : vector<4xf32>
   }
+
+  // CHECK-LABEL: @outer_product_1
+  spirv.func @outer_product_1(%arg0: vector<3xf32>, %arg1: vector<2xf32>) -> !spirv.matrix<2 x vector<3xf32>> "None" {
+    // CHECK: {{%.*}} = spirv.OuterProduct {{%.*}}, {{%.*}} : vector<3xf32>, vector<2xf32> -> !spirv.matrix<2 x vector<3xf32>>
+    %result = spirv.OuterProduct %arg0, %arg1 : vector<3xf32>, vector<2xf32> -> !spirv.matrix<2 x vector<3xf32>>
+    spirv.ReturnValue %result : !spirv.matrix<2 x vector<3xf32>>
+  }
   
   // CHECK-LABEL: @matrix_times_matrix_1
   spirv.func @matrix_times_matrix_1(%arg0: !spirv.matrix<3 x vector<3xf32>>, %arg1: !spirv.matrix<3 x vector<3xf32>>) -> !spirv.matrix<3 x vector<3xf32>> "None"{


### PR DESCRIPTION
This should be the last operation enabled by the `Matrix` capability.

Assisted-by: Codex