### PR TITLE
[NFC] Fix typo in CAPI

### DIFF
--- a/mlir/include/mlir-c/BuiltinAttributes.h
+++ b/mlir/include/mlir-c/BuiltinAttributes.h
@@ -319,9 +319,9 @@ mlirSymbolRefAttrGetNestedReference(MlirAttribute attr, intptr_t pos);
 /// Returns the typeID of an SymbolRef attribute.
 MLIR_CAPI_EXPORTED MlirTypeID mlirSymbolRefAttrGetTypeID(void);
 
-/// Creates a DisctinctAttr with the referenced attribute.
+/// Creates a DistinctAttr with the referenced attribute.
 MLIR_CAPI_EXPORTED MlirAttribute
-mlirDisctinctAttrCreate(MlirAttribute referencedAttr);
+mlirDistinctAttrCreate(MlirAttribute referencedAttr);
 
 //===----------------------------------------------------------------------===//
 // Flat SymbolRef attribute.

--- a/mlir/lib/CAPI/IR/BuiltinAttributes.cpp
+++ b/mlir/lib/CAPI/IR/BuiltinAttributes.cpp
@@ -347,7 +347,7 @@ MlirTypeID mlirSymbolRefAttrGetTypeID(void) {
   return wrap(SymbolRefAttr::getTypeID());
 }
 
-MlirAttribute mlirDisctinctAttrCreate(MlirAttribute referencedAttr) {
+MlirAttribute mlirDistinctAttrCreate(MlirAttribute referencedAttr) {
   return wrap(mlir::DistinctAttr::create(unwrap(referencedAttr)));
 }
 

--- a/mlir/test/CAPI/ir.c
+++ b/mlir/test/CAPI/ir.c
@@ -1495,7 +1495,7 @@ int printAffineMap(MlirContext ctx) {
   // CHECK: (d0, d1, d2) -> (d2)
 
   // CHECK: distinct[0]<"foo">
-  mlirAttributeDump(mlirDisctinctAttrCreate(
+  mlirAttributeDump(mlirDistinctAttrCreate(
       mlirStringAttrGet(ctx, mlirStringRefCreateFromCString("foo"))));
 
   return 0;

--- a/mlir/test/CAPI/llvm.c
+++ b/mlir/test/CAPI/llvm.c
@@ -250,9 +250,9 @@ static void testDebugInfoAttributes(MlirContext ctx) {
       mlirStringAttrGet(ctx, mlirStringRefCreateFromCString("bar"));
 
   MlirAttribute none = mlirUnitAttrGet(ctx);
-  MlirAttribute id = mlirDisctinctAttrCreate(none);
-  MlirAttribute recId0 = mlirDisctinctAttrCreate(none);
-  MlirAttribute recId1 = mlirDisctinctAttrCreate(none);
+  MlirAttribute id = mlirDistinctAttrCreate(none);
+  MlirAttribute recId0 = mlirDistinctAttrCreate(none);
+  MlirAttribute recId1 = mlirDistinctAttrCreate(none);
 
   // CHECK: #llvm.di_null_type
   mlirAttributeDump(mlirLLVMDINullTypeAttrGet(ctx));


### PR DESCRIPTION
Fixed typo in https://github.com/llvm/llvm-project/pull/83992
Changed function names `Disctinct` -> `Distinct`