### PR TITLE
[LLDB] Fix null pointer dereference.

### DIFF
--- a/lldb/source/ValueObject/ValueObject.cpp
+++ b/lldb/source/ValueObject/ValueObject.cpp
@@ -1239,10 +1239,9 @@ void ValueObject::SetValueFromInteger(const llvm::APInt &value, Status &error) {
     return;
   }
 
-  lldb::DataExtractorSP data_sp;
-  data_sp->SetData(value.getRawData(), byte_size,
-                   target->GetArchitecture().GetByteOrder());
-  data_sp->SetAddressByteSize(
+  lldb::DataExtractorSP data_sp = std::make_shared<DataExtractor>(
+      reinterpret_cast<const void *>(value.getRawData()), byte_size,
+      target->GetArchitecture().GetByteOrder(),
       static_cast<uint8_t>(target->GetArchitecture().GetAddressByteSize()));
   SetData(*data_sp, error);
 }


### PR DESCRIPTION
The code was declaring a shared poiner and then immediately trying to dereference it to initialize it's contents, but the dereference was giving a seg fault. This fixes that issue.