### PR TITLE
workflows/release-task: Add job for publishing to winget

### DIFF
--- a/.github/workflows/release-tasks.yml
+++ b/.github/workflows/release-tasks.yml
@@ -146,6 +146,44 @@ jobs:
     secrets:
       RELEASE_TASKS_USER_TOKEN: ${{ secrets.RELEASE_TASKS_USER_TOKEN }}
 
+  publish-winget:
+    name: Submit to WinGet repository
+    # winget-create is only supported on Windows
+    runs-on: windows-latest
+    permissions:
+      contents: read
+    needs:
+      - validate-tag
+      - release-binaries
+    # Only submit stable releases
+    if: >-
+      github.repository == 'llvm/llvm-project' &&
+      !contains(needs.validate-tag.outputs.release-version, '-rc')
+    env:
+      # winget-create will read the following environment variable to access the GitHub token needed for submitting a PR
+      # See https://aka.ms/winget-create-token
+      WINGET_CREATE_GITHUB_TOKEN: ${{ secrets.WINGET_CREATE_GITHUB_TOKEN }}
+      GITHUB_TOKEN: ${{ github.token }}
+
+    steps:
+      - name: Submit package using wingetcreate
+        shell: pwsh
+        run: |
+          # Get installer URLs from GitHub API
+          $releaseVersion = '${{ needs.validate-tag.outputs.release-version }}'
+          $releaseTag = "llvmorg-$releaseVersion"
+          $releaseApi = "https://api.github.com/repos/llvm/llvm-project/releases/tags/$releaseTag"
+          $assets = Invoke-RestMethod -Uri $releaseApi | Select-Object -ExpandProperty assets
+          $x64InstallerUrl = $assets | Where-Object -Property name -match 'LLVM.*win64.exe$' | Select -ExpandProperty browser_download_url
+          $arm64InstallerUrl = $assets | Where-Object -Property name -match 'LLVM.*woa64.exe$' | Select -ExpandProperty browser_download_url
+
+          # Update package using wingetcreate
+          curl.exe -JLO https://aka.ms/wingetcreate/latest
+          .\wingetcreate.exe update LLVM.LLVM `
+            --version $releaseVersion `
+            --urls "$x64InstallerUrl|x64" "$arm64InstallerUrl|arm64" `
+            --submit
+
   release-sources:
     name: Package Release Sources
     permissions:


### PR DESCRIPTION
PR creates a GitHub action workflow to trigger after all binaries are published on a stable release & submit a PR to WinGet repository ([microsoft/winget-pkgs](https://github.com/microsoft/winget-pkgs)). [microsoft/winget-create](https://github.com/microsoft/winget-create) is the tool used for creating and submitting the manifest

- Resolves https://github.com/llvm/llvm-project/issues/162901

One can see examples of other similar actions in the following repositories (I've linked their workflows)
- [Microsoft PowerToys](https://github.com/microsoft/PowerToys/blob/main/.github/workflows/package-submissions.yml)
- [Microsoft Terminal](https://github.com/microsoft/terminal/blob/main/.github/workflows/winget.yml)
- [Microsoft Copilot CLI](https://github.com/github/copilot-cli/blob/v0.0.368-2/.github/workflows/winget.yml)
- [Microsoft Edit](https://github.com/microsoft/edit/blob/main/.github/workflows/winget.yml)
- [WinGet Studio](https://github.com/microsoft/winget-studio/blob/main/.github/workflows/winget.yml)
- [Oh-My-Posh](https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/.github/workflows/release.yml)


## Steps needed from maintainers

- Add a repository secret named `WINGET_CREATE_GITHUB_TOKEN` that's a [public access token (classic)](https://github.com/microsoft/winget-create?tab=readme-ov-file#github-personal-access-token-classic-permissions) with [`public_repo`](https://raw.githubusercontent.com/microsoft/winget-create/main/doc/images/tokenscope-publicrepo.png) scope from the user account where the winget-pkgs fork will exist for submitting a PR. Recommend using a bot account for this purpose. Maybe we could use @llvm-ci or @llvmbot ?

## Test run

While I would need a bit of guidance if I put the workflow in the correct location with the correct variables, one can verify the `wingetcreate` submission flow of it easily with:

To validate one can just run the same powershell commands listed in the workflow job, but omit the `--submit` flag to prevent opening an actual PR.

```powershell
curl.exe -JLO https://aka.ms/wingetcreate/latest
.\wingetcreate.exe update LLVM.LLVM `
  --version 10.0.0 `
  --urls "https://github.com/llvm/llvm-project/releases/download/llvmorg-22.1.1/LLVM-22.1.1-woa64.exe|arm64" "https://github.com/llvm/llvm-project/releases/download/llvmorg-22.1.1/LLVM-22.1.1-win64.exe|x64"
```