### PR TITLE
[RISCV] Use PatGprImm for riscv_psslai. NFC

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVInstrInfo.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfo.td
@@ -1375,7 +1375,7 @@ class PatGpr<SDPatternOperator OpNode, RVInst Inst, ValueType vt = XLenVT>
 class PatGprGpr<SDPatternOperator OpNode, RVInst Inst, ValueType vt = XLenVT>
     : Pat<(vt (OpNode (vt GPR:$rs1), (vt GPR:$rs2))), (Inst GPR:$rs1, GPR:$rs2)>;
 
-class PatGprImm<SDPatternOperator OpNode, RVInst Inst, ImmLeaf ImmType,
+class PatGprImm<SDPatternOperator OpNode, RVInst Inst, SDPatternOperator ImmType,
                 ValueType vt = XLenVT>
     : Pat<(vt (OpNode (vt GPR:$rs1), ImmType:$imm)),
           (Inst GPR:$rs1, ImmType:$imm)>;

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoP.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoP.td
@@ -1797,8 +1797,7 @@ let Predicates = [HasStdExtP] in {
   def : PatGprImm<riscv_psra, PSRAI_H, uimm4, XLenVecI16VT>;
 
   // 16-bit signed saturation shift left patterns
-  def : Pat<(XLenVecI16VT (riscv_psslai GPR:$rs1, timm:$shamt)),
-            (PSSLAI_H GPR:$rs1, timm:$shamt)>;
+  def : PatGprImm<riscv_psslai, PSSLAI_H, timm, XLenVecI16VT>;
 
   // 8-bit logical shift left/right
   def : Pat<(XLenVecI8VT (riscv_pshl GPR:$rs1, GPR:$rs2)),
@@ -1972,8 +1971,7 @@ let Predicates = [HasStdExtP, IsRV64] in {
   def : PatGprImm<riscv_psra, PSRAI_W, uimm5, v2i32>;
 
   // 32-bit signed saturation shift left patterns
-  def : Pat<(v2i32 (riscv_psslai GPR:$rs1, timm:$shamt)),
-            (PSSLAI_W GPR:$rs1, timm:$shamt)>;
+  def : PatGprImm<riscv_psslai, PSSLAI_W, timm, v2i32>;
 
   // 32-bit logical shift left/right
   def : Pat<(v2i32 (riscv_pshl GPR:$rs1, GPR:$rs2)),


### PR DESCRIPTION
Relax PatGprImm to allow any SDPatternOperator insead of ImmLeaf.