### PR TITLE
Add hybrid function ordering support

### DIFF
--- a/bolt/include/bolt/Passes/ReorderFunctions.h
+++ b/bolt/include/bolt/Passes/ReorderFunctions.h
@@ -11,6 +11,7 @@
 
 #include "bolt/Core/BinaryFunctionCallGraph.h"
 #include "bolt/Passes/BinaryPasses.h"
+#include "llvm/ADT/DenseSet.h"
 
 namespace llvm {
 namespace bolt {
@@ -21,7 +22,18 @@ class ReorderFunctions : public BinaryFunctionPass {
   BinaryFunctionCallGraph Cg;
 
   void reorder(BinaryContext &BC, std::vector<Cluster> &&Clusters,
-               std::map<uint64_t, BinaryFunction> &BFs);
+               std::map<uint64_t, BinaryFunction> &BFs,
+               uint32_t StartIndex = 0);
+
+  /// Read the function order file and assign indices to listed functions.
+  /// \p StartIndex is the first index to assign.
+  /// \p OrderedFuncs if non-null, will be populated with the set of functions
+  ///    that were assigned indices from the order file.
+  /// \returns the next available index after all assigned functions, or an
+  ///    error if the order file cannot be read.
+  Expected<uint32_t> assignFunctionOrder(
+      BinaryContext &BC, std::map<uint64_t, BinaryFunction> &BFs,
+      uint32_t StartIndex, DenseSet<const BinaryFunction *> *OrderedFuncs);
 
   void printStats(BinaryContext &BC, const std::vector<Cluster> &Clusters,
                   const std::vector<uint64_t> &FuncAddr);

--- a/bolt/lib/Passes/ReorderFunctions.cpp
+++ b/bolt/lib/Passes/ReorderFunctions.cpp
@@ -70,7 +70,7 @@ static cl::opt<bool> ReorderFunctionsUseHotSize(
 static cl::opt<std::string> FunctionOrderFile(
     "function-order",
     cl::desc("file containing an ordered list of functions to use for function "
-             "reordering"),
+             "reordering; can be combined with --reorder-functions algorithms"),
     cl::cat(BoltOptCategory));
 
 static cl::opt<std::string> GenerateFunctionOrderFile(
@@ -351,9 +351,49 @@ Expected<uint32_t> ReorderFunctions::assignFunctionOrder(
 Error ReorderFunctions::runOnFunctions(BinaryContext &BC) {
   auto &BFs = BC.getBinaryFunctions();
 
+  // If a function order file is provided but no reorder algorithm was
+  // explicitly specified, default to RT_USER.
+  if (!opts::FunctionOrderFile.empty()) {
+    if (opts::ReorderFunctions.getNumOccurrences() == 0) {
+      opts::ReorderFunctions = RT_USER;
+      BC.outs()
+          << "BOLT-INFO: --function-order specified without "
+          << "--reorder-functions, defaulting to --reorder-functions=user\n";
+    } else if (opts::ReorderFunctions == RT_NONE) {
+      BC.errs() << "BOLT-WARNING: --reorder-functions=none is incompatible "
+                << "with --function-order, resetting to "
+                << "--reorder-functions=user\n";
+      opts::ReorderFunctions = RT_USER;
+    } else if (opts::ReorderFunctions != RT_USER) {
+      StringRef AlgName;
+      switch (opts::ReorderFunctions) {
+      case RT_EXEC_COUNT:
+        AlgName = "exec-count";
+        break;
+      case RT_HFSORT:
+        AlgName = "hfsort";
+        break;
+      case RT_CDSORT:
+        AlgName = "cdsort";
+        break;
+      case RT_PETTIS_HANSEN:
+        AlgName = "pettis-hansen";
+        break;
+      case RT_RANDOM:
+        AlgName = "random";
+        break;
+      default:
+        llvm_unreachable("unexpected reorder type in hybrid mode");
+      }
+      BC.outs() << "BOLT-INFO: hybrid mode: functions from order file will be "
+                << "pinned first, remaining functions ordered by " << AlgName
+                << "\n";
+    }
+  }
+
   // Process order file if provided. Assign indices 0..N-1 to listed functions.
   // For algorithmic modes, the algorithm orders remaining functions starting
-  // at index N. For RT_NONE/RT_USER, remaining functions keep original order.
+  // at index N. For RT_USER, remaining functions keep original order.
   // UserFileEndIndex tracks the number of functions pinned by the order file.
   uint32_t UserFileEndIndex = 0;
   DenseSet<const BinaryFunction *> UserOrderedFuncs;

--- a/bolt/lib/Passes/ReorderFunctions.cpp
+++ b/bolt/lib/Passes/ReorderFunctions.cpp
@@ -14,6 +14,7 @@
 #include "bolt/Passes/HFSort.h"
 #include "bolt/Utils/Utils.h"
 #include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/StringMap.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Transforms/Utils/CodeLayout.h"
 #include <fstream>
@@ -117,10 +118,11 @@ using Node = CallGraph::Node;
 
 void ReorderFunctions::reorder(BinaryContext &BC,
                                std::vector<Cluster> &&Clusters,
-                               std::map<uint64_t, BinaryFunction> &BFs) {
+                               std::map<uint64_t, BinaryFunction> &BFs,
+                               uint32_t StartIndex) {
   std::vector<uint64_t> FuncAddr(Cg.numNodes()); // Just for computing stats
   uint64_t TotalSize = 0;
-  uint32_t Index = 0;
+  uint32_t Index = StartIndex;
 
   // Set order of hot functions based on clusters.
   for (const Cluster &Cluster : Clusters) {
@@ -269,17 +271,118 @@ Error ReorderFunctions::readFunctionOrderFile(
   return Error::success();
 }
 
+Expected<uint32_t> ReorderFunctions::assignFunctionOrder(
+    BinaryContext &BC, std::map<uint64_t, BinaryFunction> &BFs,
+    uint32_t StartIndex, DenseSet<const BinaryFunction *> *OrderedFuncs) {
+  // Build LTOCommonNameMap for name resolution.
+  StringMap<std::vector<uint64_t>> LTOCommonNameMap;
+  for (const BinaryFunction &BF : llvm::make_second_range(BFs))
+    for (StringRef Name : BF.getNames())
+      if (std::optional<StringRef> LTOCommonName = getLTOCommonName(Name))
+        LTOCommonNameMap[*LTOCommonName].push_back(BF.getAddress());
+
+  uint32_t Index = StartIndex;
+  uint32_t InvalidEntries = 0;
+  std::vector<std::string> FunctionNames;
+  if (Error E = readFunctionOrderFile(FunctionNames))
+    return std::move(E);
+
+  for (const std::string &Function : FunctionNames) {
+    std::vector<uint64_t> FuncAddrs;
+
+    BinaryData *BD = BC.getBinaryDataByName(Function);
+    if (!BD) {
+      // If we can't find the main symbol name, look for alternates.
+      uint32_t LocalID = 1;
+      while (true) {
+        const std::string FuncName = Function + "/" + std::to_string(LocalID);
+        BD = BC.getBinaryDataByName(FuncName);
+        if (BD)
+          FuncAddrs.push_back(BD->getAddress());
+        else
+          break;
+        LocalID++;
+      }
+      // Strip LTO suffixes.
+      if (std::optional<StringRef> CommonName = getLTOCommonName(Function))
+        if (LTOCommonNameMap.contains(*CommonName))
+          llvm::append_range(FuncAddrs, LTOCommonNameMap[*CommonName]);
+    } else {
+      FuncAddrs.push_back(BD->getAddress());
+    }
+
+    if (FuncAddrs.empty()) {
+      if (opts::Verbosity >= 1)
+        BC.errs() << "BOLT-WARNING: Reorder functions: can't find function "
+                  << "for " << Function << "\n";
+      ++InvalidEntries;
+      continue;
+    }
+
+    for (const uint64_t FuncAddr : FuncAddrs) {
+      const BinaryData *FuncBD = BC.getBinaryDataAtAddress(FuncAddr);
+      assert(FuncBD);
+
+      BinaryFunction *BF = BC.getFunctionForSymbol(FuncBD->getSymbol());
+      if (!BF) {
+        if (opts::Verbosity >= 1)
+          BC.errs() << "BOLT-WARNING: Reorder functions: can't find function "
+                    << "for " << Function << "\n";
+        ++InvalidEntries;
+        break;
+      }
+      if (!BF->hasValidIndex()) {
+        BF->setIndex(Index++);
+        if (OrderedFuncs)
+          OrderedFuncs->insert(BF);
+      } else if (opts::Verbosity > 0) {
+        BC.errs() << "BOLT-WARNING: Duplicate reorder entry for " << Function
+                  << "\n";
+      }
+    }
+  }
+  if (InvalidEntries)
+    BC.errs() << "BOLT-WARNING: Reorder functions: can't find functions for "
+              << InvalidEntries << " entries in -function-order list\n";
+
+  return Index;
+}
+
 Error ReorderFunctions::runOnFunctions(BinaryContext &BC) {
   auto &BFs = BC.getBinaryFunctions();
+
+  // Process order file if provided. Assign indices 0..N-1 to listed functions.
+  // For algorithmic modes, the algorithm orders remaining functions starting
+  // at index N. For RT_NONE/RT_USER, remaining functions keep original order.
+  // UserFileEndIndex tracks the number of functions pinned by the order file.
+  uint32_t UserFileEndIndex = 0;
+  DenseSet<const BinaryFunction *> UserOrderedFuncs;
+
+  if (!opts::FunctionOrderFile.empty()) {
+    Expected<uint32_t> NextIndexOrErr =
+        assignFunctionOrder(BC, BFs, 0, &UserOrderedFuncs);
+    if (!NextIndexOrErr)
+      return NextIndexOrErr.takeError();
+    UserFileEndIndex = *NextIndexOrErr;
+
+    BC.outs() << "BOLT-INFO: " << UserFileEndIndex
+              << " functions pinned by order file, remaining functions will be "
+              << "ordered by algorithm\n";
+  }
+
+  // Build call graph (needed for clustering algorithms).
+  // Exclude functions already ordered by the user order file.
   if (opts::ReorderFunctions != RT_NONE &&
       opts::ReorderFunctions != RT_EXEC_COUNT &&
       opts::ReorderFunctions != RT_USER) {
     Cg = buildCallGraph(
         BC,
-        [](const BinaryFunction &BF) {
+        [&UserOrderedFuncs](const BinaryFunction &BF) {
           if (!BF.hasProfile())
             return true;
           if (BF.getState() != BinaryFunction::State::CFG)
+            return true;
+          if (UserOrderedFuncs.contains(&BF))
             return true;
           return false;
         },
@@ -290,6 +393,7 @@ Error ReorderFunctions::runOnFunctions(BinaryContext &BC) {
     Cg.normalizeArcWeights();
   }
 
+  // Run selected algorithm on remaining functions.
   std::vector<Cluster> Clusters;
 
   switch (opts::ReorderFunctions) {
@@ -299,31 +403,31 @@ Error ReorderFunctions::runOnFunctions(BinaryContext &BC) {
     BinaryFunctionListType SortedFunctions(BFs.size());
     llvm::transform(llvm::make_second_range(BFs), SortedFunctions.begin(),
                     [](BinaryFunction &BF) { return &BF; });
-    llvm::stable_sort(SortedFunctions,
-                      [&](const BinaryFunction *A, const BinaryFunction *B) {
-                        if (A->isIgnored())
-                          return false;
-                        if (B->isIgnored())
-                          return true;
-                        const size_t PadA = opts::padFunctionBefore(*A) +
-                                            opts::padFunctionAfter(*A);
-                        const size_t PadB = opts::padFunctionBefore(*B) +
-                                            opts::padFunctionAfter(*B);
-                        if (!PadA || !PadB) {
-                          if (PadA)
-                            return true;
-                          if (PadB)
-                            return false;
-                        }
-                        if (!A->hasProfile())
-                          return false;
-                        if (!B->hasProfile())
-                          return true;
-                        return A->getExecutionCount() > B->getExecutionCount();
-                      });
-    uint32_t Index = 0;
+    llvm::stable_sort(
+        SortedFunctions, [&](const BinaryFunction *A, const BinaryFunction *B) {
+          if (A->isIgnored())
+            return false;
+          if (B->isIgnored())
+            return true;
+          const size_t PadA =
+              opts::padFunctionBefore(*A) + opts::padFunctionAfter(*A);
+          const size_t PadB =
+              opts::padFunctionBefore(*B) + opts::padFunctionAfter(*B);
+          if (!PadA || !PadB) {
+            if (PadA)
+              return true;
+            if (PadB)
+              return false;
+          }
+          if (!A->hasProfile())
+            return false;
+          if (!B->hasProfile())
+            return true;
+          return A->getExecutionCount() > B->getExecutionCount();
+        });
+    uint32_t Index = UserFileEndIndex;
     for (BinaryFunction *BF : SortedFunctions)
-      if (BF->hasProfile()) {
+      if (BF->hasProfile() && !BF->hasValidIndex()) {
         BF->setIndex(Index++);
         LLVM_DEBUG(if (opts::Verbosity > 1) {
           dbgs() << "BOLT-INFO: hot func " << BF->getPrintName() << " ("
@@ -370,81 +474,14 @@ Error ReorderFunctions::runOnFunctions(BinaryContext &BC) {
     std::srand(opts::RandomSeed);
     Clusters = randomClusters(Cg);
     break;
-  case RT_USER: {
-    // Build LTOCommonNameMap
-    StringMap<std::vector<uint64_t>> LTOCommonNameMap;
-    for (const BinaryFunction &BF : llvm::make_second_range(BFs))
-      for (StringRef Name : BF.getNames())
-        if (std::optional<StringRef> LTOCommonName = getLTOCommonName(Name))
-          LTOCommonNameMap[*LTOCommonName].push_back(BF.getAddress());
-
-    uint32_t Index = 0;
-    uint32_t InvalidEntries = 0;
-    std::vector<std::string> FunctionNames;
-    if (Error E = readFunctionOrderFile(FunctionNames))
-      return Error(std::move(E));
-
-    for (const std::string &Function : FunctionNames) {
-      std::vector<uint64_t> FuncAddrs;
-
-      BinaryData *BD = BC.getBinaryDataByName(Function);
-      if (!BD) {
-        // If we can't find the main symbol name, look for alternates.
-        uint32_t LocalID = 1;
-        while (true) {
-          const std::string FuncName = Function + "/" + std::to_string(LocalID);
-          BD = BC.getBinaryDataByName(FuncName);
-          if (BD)
-            FuncAddrs.push_back(BD->getAddress());
-          else
-            break;
-          LocalID++;
-        }
-        // Strip LTO suffixes
-        if (std::optional<StringRef> CommonName = getLTOCommonName(Function))
-          if (LTOCommonNameMap.contains(*CommonName))
-            llvm::append_range(FuncAddrs, LTOCommonNameMap[*CommonName]);
-      } else {
-        FuncAddrs.push_back(BD->getAddress());
-      }
-
-      if (FuncAddrs.empty()) {
-        if (opts::Verbosity >= 1)
-          BC.errs() << "BOLT-WARNING: Reorder functions: can't find function "
-                    << "for " << Function << "\n";
-        ++InvalidEntries;
-        continue;
-      }
-
-      for (const uint64_t FuncAddr : FuncAddrs) {
-        const BinaryData *FuncBD = BC.getBinaryDataAtAddress(FuncAddr);
-        assert(FuncBD);
-
-        BinaryFunction *BF = BC.getFunctionForSymbol(FuncBD->getSymbol());
-        if (!BF) {
-          if (opts::Verbosity >= 1)
-            BC.errs() << "BOLT-WARNING: Reorder functions: can't find function "
-                      << "for " << Function << "\n";
-          ++InvalidEntries;
-          break;
-        }
-        if (!BF->hasValidIndex())
-          BF->setIndex(Index++);
-        else if (opts::Verbosity > 0)
-          BC.errs() << "BOLT-WARNING: Duplicate reorder entry for " << Function
-                    << "\n";
-      }
-    }
-    if (InvalidEntries)
-      BC.errs() << "BOLT-WARNING: Reorder functions: can't find functions for "
-                << InvalidEntries << " entries in -function-order list\n";
-  } break;
-
+  case RT_USER:
+    // Order file already processed above; nothing more to do.
+    break;
   default:
     llvm_unreachable("unexpected layout type");
   }
 
-  reorder(BC, std::move(Clusters), BFs);
+  reorder(BC, std::move(Clusters), BFs, UserFileEndIndex);
 
   BC.HasFinalizedFunctionOrder = true;
 

--- a/bolt/test/AArch64/function-order-hybrid.s
+++ b/bolt/test/AArch64/function-order-hybrid.s
@@ -1,0 +1,131 @@
+## Check that --function-order can be combined with
+## --reorder-functions algorithms to pin specific functions first
+## while remaining functions are ordered by the selected algorithm.
+
+# REQUIRES: system-linux
+
+# RUN: llvm-mc -filetype=obj -triple aarch64-unknown-unknown %s -o %t.o
+# RUN: link_fdata %s %t.o %t.fdata
+# RUN: %clang %cflags --target=aarch64-unknown-linux %t.o -o %t.exe -Wl,-q
+
+## Create order file pinning func_b first, then func_a.
+# RUN: echo "func_b" > %t.order
+# RUN: echo "func_a" >> %t.order
+
+## Test 1: Hybrid exec-count + order file.
+## Order-file functions come first (func_b, func_a), then remaining sorted by
+## execution count descending (func_c=100, func_d=50).
+# RUN: llvm-bolt %t.exe --data %t.fdata --reorder-functions=exec-count \
+# RUN:   --function-order=%t.order --generate-function-order=%t.genorder1 \
+# RUN:   -o %t.null 2>&1 | FileCheck %s --check-prefix=CHECK-HYBRID
+# RUN: FileCheck %s --input-file %t.genorder1 --check-prefix=CHECK-HYBRID-ORDER
+
+# CHECK-HYBRID: BOLT-INFO: 2 functions pinned by order file
+
+# CHECK-HYBRID-ORDER:      func_b
+# CHECK-HYBRID-ORDER-NEXT: func_a
+# CHECK-HYBRID-ORDER-NEXT: func_c
+# CHECK-HYBRID-ORDER-NEXT: func_d
+
+## Test 2: Default (none) + order file.
+## Order-file functions come first, then remaining in original address order
+## (func_d before func_c in the binary).
+# RUN: llvm-bolt %t.exe --data %t.fdata \
+# RUN:   --function-order=%t.order --generate-function-order=%t.genorder2 \
+# RUN:   -o %t.null 2>&1 | FileCheck %s --check-prefix=CHECK-NONE
+# RUN: FileCheck %s --input-file %t.genorder2 --check-prefix=CHECK-NONE-ORDER
+
+# CHECK-NONE: BOLT-INFO: 2 functions pinned by order file
+
+# CHECK-NONE-ORDER:      func_b
+# CHECK-NONE-ORDER-NEXT: func_a
+# CHECK-NONE-ORDER-NEXT: func_d
+# CHECK-NONE-ORDER-NEXT: func_c
+
+## Test 3: User mode + order file. Same result as none + order file since
+## RT_USER delegates entirely to the order file.
+# RUN: llvm-bolt %t.exe --data %t.fdata --reorder-functions=user \
+# RUN:   --function-order=%t.order --generate-function-order=%t.genorder3 \
+# RUN:   -o %t.null 2>&1 | FileCheck %s --check-prefix=CHECK-USER
+# RUN: FileCheck %s --input-file %t.genorder3 --check-prefix=CHECK-USER-ORDER
+
+# CHECK-USER: BOLT-INFO: 2 functions pinned by order file
+
+# CHECK-USER-ORDER:      func_b
+# CHECK-USER-ORDER-NEXT: func_a
+# CHECK-USER-ORDER-NEXT: func_d
+# CHECK-USER-ORDER-NEXT: func_c
+
+## Test 4: Order file with a missing function.
+## The nonexistent function is skipped with a warning, valid functions are still
+## pinned correctly.
+# RUN: echo "func_b" > %t.order_missing
+# RUN: echo "nonexist" >> %t.order_missing
+# RUN: echo "func_a" >> %t.order_missing
+# RUN: llvm-bolt %t.exe --data %t.fdata --reorder-functions=exec-count \
+# RUN:   --function-order=%t.order_missing \
+# RUN:   --generate-function-order=%t.genorder4 -v=1 \
+# RUN:   -o %t.null 2>&1 | FileCheck %s --check-prefix=CHECK-MISS
+# RUN: FileCheck %s --input-file %t.genorder4 \
+# RUN:   --check-prefix=CHECK-MISS-ORDER
+
+# CHECK-MISS-DAG: can't find function for nonexist
+# CHECK-MISS-DAG: can't find functions for 1 entries
+# CHECK-MISS-DAG: 2 functions pinned by order file
+
+# CHECK-MISS-ORDER:      func_b
+# CHECK-MISS-ORDER-NEXT: func_a
+# CHECK-MISS-ORDER-NEXT: func_c
+# CHECK-MISS-ORDER-NEXT: func_d
+
+  .text
+  .align 4
+  .globl main
+  .type main, %function
+main:
+	.cfi_startproc
+	bl func_a
+	ret
+	.cfi_endproc
+.size main, .-main
+
+  .globl func_a
+  .type func_a, %function
+func_a:
+# FDATA: 0 [unknown] 0 1 func_a 0 0 10
+	.cfi_startproc
+	ret
+	.cfi_endproc
+.size func_a, .-func_a
+
+  .globl func_b
+  .type func_b, %function
+func_b:
+# FDATA: 0 [unknown] 0 1 func_b 0 0 5
+	.cfi_startproc
+	ret
+	.cfi_endproc
+.size func_b, .-func_b
+
+## func_d is placed before func_c in the assembly to distinguish address-order
+## results (func_d, func_c) from exec-count results (func_c, func_d).
+  .globl func_d
+  .type func_d, %function
+func_d:
+# FDATA: 0 [unknown] 0 1 func_d 0 0 50
+	.cfi_startproc
+	ret
+	.cfi_endproc
+.size func_d, .-func_d
+
+  .globl func_c
+  .type func_c, %function
+func_c:
+# FDATA: 0 [unknown] 0 1 func_c 0 0 100
+	.cfi_startproc
+	ret
+	.cfi_endproc
+.size func_c, .-func_c
+
+## Force relocation mode.
+.reloc 0, R_AARCH64_NONE

--- a/bolt/test/AArch64/function-order-hybrid.s
+++ b/bolt/test/AArch64/function-order-hybrid.s
@@ -20,6 +20,9 @@
 # RUN:   -o %t.null 2>&1 | FileCheck %s --check-prefix=CHECK-HYBRID
 # RUN: FileCheck %s --input-file %t.genorder1 --check-prefix=CHECK-HYBRID-ORDER
 
+# CHECK-HYBRID: BOLT-INFO: hybrid mode: functions from
+# CHECK-HYBRID-SAME: order file will be pinned first,
+# CHECK-HYBRID-SAME: remaining functions ordered by exec-count
 # CHECK-HYBRID: BOLT-INFO: 2 functions pinned by order file
 
 # CHECK-HYBRID-ORDER:      func_b
@@ -27,20 +30,25 @@
 # CHECK-HYBRID-ORDER-NEXT: func_c
 # CHECK-HYBRID-ORDER-NEXT: func_d
 
-## Test 2: Default (none) + order file.
+## Test 2: Standalone order file (no --reorder-functions).
+## Should auto-default to --reorder-functions=user.
 ## Order-file functions come first, then remaining in original address order
 ## (func_d before func_c in the binary).
 # RUN: llvm-bolt %t.exe --data %t.fdata \
 # RUN:   --function-order=%t.order --generate-function-order=%t.genorder2 \
-# RUN:   -o %t.null 2>&1 | FileCheck %s --check-prefix=CHECK-NONE
-# RUN: FileCheck %s --input-file %t.genorder2 --check-prefix=CHECK-NONE-ORDER
+# RUN:   -o %t.null 2>&1 | FileCheck %s --check-prefix=CHECK-STANDALONE
+# RUN: FileCheck %s --input-file %t.genorder2 \
+# RUN:   --check-prefix=CHECK-STANDALONE-ORDER
 
-# CHECK-NONE: BOLT-INFO: 2 functions pinned by order file
+# CHECK-STANDALONE: BOLT-INFO: --function-order specified
+# CHECK-STANDALONE-SAME: without --reorder-functions,
+# CHECK-STANDALONE-SAME: defaulting to --reorder-functions=user
+# CHECK-STANDALONE: BOLT-INFO: 2 functions pinned by order file
 
-# CHECK-NONE-ORDER:      func_b
-# CHECK-NONE-ORDER-NEXT: func_a
-# CHECK-NONE-ORDER-NEXT: func_d
-# CHECK-NONE-ORDER-NEXT: func_c
+# CHECK-STANDALONE-ORDER:      func_b
+# CHECK-STANDALONE-ORDER-NEXT: func_a
+# CHECK-STANDALONE-ORDER-NEXT: func_d
+# CHECK-STANDALONE-ORDER-NEXT: func_c
 
 ## Test 3: User mode + order file. Same result as none + order file since
 ## RT_USER delegates entirely to the order file.
@@ -56,7 +64,24 @@
 # CHECK-USER-ORDER-NEXT: func_d
 # CHECK-USER-ORDER-NEXT: func_c
 
-## Test 4: Order file with a missing function.
+## Test 4: Explicit --reorder-functions=none + order file.
+## Should warn and reset to --reorder-functions=user.
+# RUN: llvm-bolt %t.exe --data %t.fdata --reorder-functions=none \
+# RUN:   --function-order=%t.order --generate-function-order=%t.genorder4 \
+# RUN:   -o %t.null 2>&1 | FileCheck %s --check-prefix=CHECK-RESET
+# RUN: FileCheck %s --input-file %t.genorder4 --check-prefix=CHECK-RESET-ORDER
+
+# CHECK-RESET: BOLT-WARNING: --reorder-functions=none
+# CHECK-RESET-SAME: is incompatible with --function-order,
+# CHECK-RESET-SAME: resetting to --reorder-functions=user
+# CHECK-RESET: BOLT-INFO: 2 functions pinned by order file
+
+# CHECK-RESET-ORDER:      func_b
+# CHECK-RESET-ORDER-NEXT: func_a
+# CHECK-RESET-ORDER-NEXT: func_d
+# CHECK-RESET-ORDER-NEXT: func_c
+
+## Test 5: Order file with a missing function.
 ## The nonexistent function is skipped with a warning, valid functions are still
 ## pinned correctly.
 # RUN: echo "func_b" > %t.order_missing
@@ -64,9 +89,9 @@
 # RUN: echo "func_a" >> %t.order_missing
 # RUN: llvm-bolt %t.exe --data %t.fdata --reorder-functions=exec-count \
 # RUN:   --function-order=%t.order_missing \
-# RUN:   --generate-function-order=%t.genorder4 -v=1 \
+# RUN:   --generate-function-order=%t.genorder5 -v=1 \
 # RUN:   -o %t.null 2>&1 | FileCheck %s --check-prefix=CHECK-MISS
-# RUN: FileCheck %s --input-file %t.genorder4 \
+# RUN: FileCheck %s --input-file %t.genorder5 \
 # RUN:   --check-prefix=CHECK-MISS-ORDER
 
 # CHECK-MISS-DAG: can't find function for nonexist


### PR DESCRIPTION
Allow `--function-order` to be combined with `--reorder-functions` algorithms.
Functions listed in the order file are pinned first (indices 0..N-1), then the
selected algorithm orders remaining functions starting at index N.