### PR TITLE
[clang][offload] Propagate -v and --cuda-path to linker-wrapper subcommands

### DIFF
--- a/clang/tools/clang-linker-wrapper/ClangLinkerWrapper.cpp
+++ b/clang/tools/clang-linker-wrapper/ClangLinkerWrapper.cpp
@@ -537,6 +537,12 @@ Expected<StringRef> clang(ArrayRef<StringRef> InputFiles, const ArgList &Args,
       Args.MakeArgString("--target=" + Triple.getTriple()),
   };
 
+  if (Verbose)
+    CmdArgs.push_back("-v");
+
+  if (!CudaBinaryPath.empty())
+    CmdArgs.push_back(Args.MakeArgString("--cuda-path=" + CudaBinaryPath));
+
   if (!Arch.empty())
     Triple.isAMDGPU() ? CmdArgs.push_back(Args.MakeArgString("-mcpu=" + Arch))
                       : CmdArgs.push_back(Args.MakeArgString("-march=" + Arch));


### PR DESCRIPTION
Needed for clang-nvlink-wrapper to find nvlink in the CUDA install dir.