### PR TITLE
[LLDB] Ensure plugins are destroyed at end of fuzz tests

### DIFF
--- a/lldb/tools/lldb-fuzzer/lldb-commandinterpreter-fuzzer/lldb-commandinterpreter-fuzzer.cpp
+++ b/lldb/tools/lldb-fuzzer/lldb-commandinterpreter-fuzzer/lldb-commandinterpreter-fuzzer.cpp
@@ -8,6 +8,8 @@
 
 #include <string>
 
+#include "utils/SBDebuggerContextManager.h"
+
 #include "lldb/API/SBCommandInterpreter.h"
 #include "lldb/API/SBCommandInterpreterRunOptions.h"
 #include "lldb/API/SBCommandReturnObject.h"
@@ -15,13 +17,11 @@
 #include "lldb/API/SBTarget.h"
 
 using namespace lldb;
-
-extern "C" int LLVMFuzzerInitialize(int *argc, char ***argv) {
-  SBDebugger::Initialize();
-  return 0;
-}
+using namespace lldb_fuzzer;
 
 extern "C" int LLVMFuzzerTestOneInput(uint8_t *data, size_t size) {
+  static SBDebuggerContextManager ctx_manager = SBDebuggerContextManager();
+
   // Convert the data into a null-terminated string
   std::string str((char *)data, size);
 

--- a/lldb/tools/lldb-fuzzer/lldb-target-fuzzer/lldb-target-fuzzer.cpp
+++ b/lldb/tools/lldb-fuzzer/lldb-target-fuzzer/lldb-target-fuzzer.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "utils/SBDebuggerContextManager.h"
 #include "utils/TempFile.h"
 
 #include "lldb/API/SBDebugger.h"
@@ -15,12 +16,9 @@ using namespace lldb;
 using namespace lldb_fuzzer;
 using namespace llvm;
 
-extern "C" int LLVMFuzzerInitialize(int *argc, char ***argv) {
-  SBDebugger::Initialize();
-  return 0;
-}
-
 extern "C" int LLVMFuzzerTestOneInput(uint8_t *data, size_t size) {
+  static SBDebuggerContextManager ctx_manager = SBDebuggerContextManager();
+
   std::unique_ptr<TempFile> file = TempFile::Create(data, size);
   if (!file)
     return 1;

--- a/lldb/tools/lldb-fuzzer/utils/SBDebuggerContextManager.h
+++ b/lldb/tools/lldb-fuzzer/utils/SBDebuggerContextManager.h
@@ -1,0 +1,22 @@
+//===------------------------------------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "lldb/API/SBDebugger.h"
+
+using namespace lldb;
+
+namespace lldb_fuzzer {
+
+class SBDebuggerContextManager {
+public:
+  SBDebuggerContextManager() { SBDebugger::Initialize(); }
+
+  ~SBDebuggerContextManager() { SBDebugger::Terminate(); }
+};
+
+} // namespace lldb_fuzzer


### PR DESCRIPTION
With some fuzzing harnesses (at least the one we use inside Google, which is based on centipede/different than libFuzzer), the fuzz test is expected to exit normally, which will end up destroying a PluginManager instance. Given we never call SBDebugger::Terminate(), we hit an assertion after bf2e4585d248af8f9998bff8d252a2cc0bc77a37 due to having registered plugins.