### PR TITLE
In cc1as, re-add call to initSections with NoExecStack parameter

### DIFF
--- a/clang/test/Misc/cc1as-noexecstack.s
+++ b/clang/test/Misc/cc1as-noexecstack.s
@@ -1,0 +1,10 @@
+// REQUIRES: x86-registered-target
+// RUN: %clang -cc1as -triple x86_64-linux-gnu -filetype obj -mnoexecstack -o %t.o %s
+// RUN: llvm-readelf -S %t.o | FileCheck %s
+
+// CHECK: .note.GNU-stack
+
+.text
+.globl foo
+foo:
+    retq

--- a/clang/tools/driver/cc1as_main.cpp
+++ b/clang/tools/driver/cc1as_main.cpp
@@ -602,6 +602,7 @@ static bool ExecuteAssemblerImpl(AssemblerInvocation &Opts,
     Triple T(Opts.Triple);
     Str.reset(TheTarget->createMCObjectStreamer(
         T, Ctx, std::move(MAB), std::move(OW), std::move(CE), *STI));
+    Str->initSections(Opts.NoExecStack, *STI);
     if (T.isOSBinFormatMachO() && T.isOSDarwin()) {
       Triple *TVT = Opts.DarwinTargetVariantTriple
                         ? &*Opts.DarwinTargetVariantTriple


### PR DESCRIPTION
Fixes https://github.com/llvm/llvm-project/issues/186004

913c5b4d1fff removed the `initSections(Opts.NoExecStack, *STI)` call from `cc1as_main.cpp`, assuming it was redundant with the `initSections` call inside `Parser->Run()`. However, `Parser->Run()` calls `initSections(false, ...)`, it does not forward `Opts.NoExecStack`. This causes -`Wa,--noexecstack` / `-cc1as -mnoexecstack` to be parsed but silently ignored, producing objects without `.note.GNU-stack`.

This breaks linking with linkers which errors on missing `.note.GNU-stack` sections by default.

Restore the explicit initSections call with Opts.NoExecStack. Effectively a revert of 913c5b4d1fff.

Add a test to validate the section is present in the output. Existing tests only validated the flag was forwarded from clang.