### PR TITLE
[lldb] Fix Windows build by adding missing link dependencies

### DIFF
--- a/lldb/unittests/TestingSupport/CMakeLists.txt
+++ b/lldb/unittests/TestingSupport/CMakeLists.txt
@@ -6,8 +6,10 @@ add_lldb_library(lldbUtilityHelpers
   LINK_COMPONENTS
     Support
     ObjectYAML
+    TestingSupport
   LINK_LIBS
     lldbUtility
+    liblldb
     llvm_gtest
   )
 


### PR DESCRIPTION
PR #184656 (08cef699c4bb) moved LoadCore and DebuggerSupportsLLVMTarget into TestUtilities.cpp but did not update CMakeLists.txt to add the new link dependencies.

This fixes the broken lldb unit test build on Windows because lld was throwing unresolved external symbol errors on Windows and required all symbols to be resolved explicitly.