### PR TITLE
[Clang][layout] Update tests after #182792

### DIFF
--- a/clang/test/Layout/ms-x86-bitfields-overflow.c
+++ b/clang/test/Layout/ms-x86-bitfields-overflow.c
@@ -20,12 +20,12 @@ struct __attribute__((packed, aligned(1))) B {
 // CHECK-LABEL:   0 | struct A{{$}}
 // CHECK-NEXT:0:0-1 |   _BitInt(250) f1
 // CHECK-NEXT:0:2-3 |   _BitInt(250) f2
-// CHECK-NEXT:      | [sizeof=32, align=32]
+// CHECK-NEXT:      | [sizeof=32, align=1]
 
 // CHECK-LABEL:   0 | struct B{{$}}
 // CHECK-NEXT:0:0-1 |   _BitInt(500) f1
 // CHECK-NEXT:0:2-256 |   _BitInt(500) f2
-// CHECK-NEXT:      | [sizeof=64, align=64]
+// CHECK-NEXT:      | [sizeof=64, align=1]
 
 int x[sizeof(struct A)];
 int y[sizeof(struct B)];


### PR DESCRIPTION
\#182792 makes it so that these structs have an alignment of 1. This needs to be fixed in a recently added test (landed after the most recent premerge run of the test).

This test update is expected behavior.