### PR TITLE
[libc] Add missing iswdigit to wctype.yaml and Windows entrypoints

### DIFF
--- a/libc/config/windows/entrypoints.txt
+++ b/libc/config/windows/entrypoints.txt
@@ -110,6 +110,7 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.wctype.iswalpha
     libc.src.wctype.iswgraph
     libc.src.wctype.iswcntrl
+    libc.src.wctype.iswdigit
     libc.src.wctype.iswlower
     libc.src.wctype.iswspace
     libc.src.wctype.iswblank

--- a/libc/include/wctype.yaml
+++ b/libc/include/wctype.yaml
@@ -20,6 +20,12 @@ functions:
     return_type: int
     arguments:
       - type: wint_t
+  - name: iswdigit
+    standards:
+      - stdc
+    return_type: int
+    arguments:
+      - type: wint_t
   - name: iswlower
     standards:
       - stdc


### PR DESCRIPTION
`iswdigit` was implemented (https://github.com/llvm/llvm-project/pull/181635) but not declared in the generated wctype.h (wctype.yaml) and was missing from the Windows config entrypoints. 

This pr declares iswdigit in wctype.h and enables it for the Windows config.

also is part of https://github.com/llvm/llvm-project/issues/185136.