### PR TITLE
[LoopUnrollPass] Remove unecessary `!TripCount` checks (NFC)

### DIFF
--- a/llvm/lib/Transforms/Scalar/LoopUnrollPass.cpp
+++ b/llvm/lib/Transforms/Scalar/LoopUnrollPass.cpp
@@ -836,7 +836,7 @@ shouldPragmaUnroll(Loop *L, const PragmaInfo &PInfo,
     return TripCount;
   }
 
-  if (PInfo.PragmaEnableUnroll && !TripCount && MaxTripCount &&
+  if (PInfo.PragmaEnableUnroll && MaxTripCount &&
       MaxTripCount <= UP.MaxUpperBound)
     return MaxTripCount;
 
@@ -1015,7 +1015,7 @@ bool llvm::computeUnrollCount(Loop *L, const TargetTransformInfo &TTI,
   // Note that the cost of bounded unrolling is always strictly greater than
   // cost of exact full unrolling.  As such, if we have an exact count and
   // found it unprofitable, we'll never chose to bounded unroll.
-  if (!TripCount && MaxTripCount && (UP.UpperBound || MaxOrZero) &&
+  if ((UP.UpperBound || MaxOrZero) && MaxTripCount &&
       MaxTripCount <= UP.MaxUpperBound) {
     UP.Count = MaxTripCount;
     if (auto UnrollFactor = shouldFullUnroll(L, TTI, DT, SE, EphValues,


### PR DESCRIPTION
If `MaxTripCount` is non-zero, then `TripCount` must equal `0` ([source](https://github.com/llvm/llvm-project/blob/5b1eed6278de1fffa195978b017039add70a94e3/llvm/lib/Transforms/Scalar/LoopUnrollPass.cpp#L1298)). 