### PR TITLE
[lldb] Build debugserver fat for arm64 and arm64e

### DIFF
--- a/lldb/tools/debugserver/source/CMakeLists.txt
+++ b/lldb/tools/debugserver/source/CMakeLists.txt
@@ -102,16 +102,29 @@ check_c_source_compiles(
 )
 
 set(default_arm64e_debugserver OFF)
-if (BUILDING_FOR_ARM64_OSX )
-  execute_process(
-      COMMAND sysctl -n hw.optional.ptrauth
-      OUTPUT_VARIABLE SYSCTL_OUTPUT
-      ERROR_QUIET
-      RESULT_VARIABLE SYSCTL_RESULT
-      OUTPUT_STRIP_TRAILING_WHITESPACE
-  )
-  if(SYSCTL_RESULT EQUAL 0)
-    set(default_arm64e_debugserver ON)
+if (BUILDING_FOR_ARM64_OSX)
+  # As of macOS 26 (Tahoe) you can run arm64e binaries without arm64e_preview_abi.
+  if (CMAKE_OSX_DEPLOYMENT_TARGET VERSION_GREATER_EQUAL "26")
+    set(SUPPORTS_RUNNING_ARM64E ON)
+  elseif (CMAKE_SYSTEM_VERSION VERSION_GREATER_EQUAL "25")
+    # CMAKE_SYSTEM_VERSION reports the kernel version and not the marketing
+    # version, which for macOS Tahoe is 25.
+    set(SUPPORTS_RUNNING_ARM64E ON)
+  else()
+    set(SUPPORTS_RUNNING_ARM64E OFF)
+  endif()
+
+  if (SUPPORTS_RUNNING_ARM64E)
+    execute_process(
+        COMMAND sysctl -n hw.optional.ptrauth
+        OUTPUT_VARIABLE SYSCTL_OUTPUT
+        ERROR_QUIET
+        RESULT_VARIABLE SYSCTL_RESULT
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+    if(SYSCTL_RESULT EQUAL 0)
+      set(default_arm64e_debugserver ON)
+    endif()
   endif()
 endif()
 option(LLDB_ENABLE_ARM64E_DEBUGSERVER "Build debugserver for arm64 and arm64e" ${default_arm64e_debugserver})

--- a/lldb/tools/debugserver/source/CMakeLists.txt
+++ b/lldb/tools/debugserver/source/CMakeLists.txt
@@ -101,9 +101,27 @@ check_c_source_compiles(
     BUILDING_FOR_ARM64_OSX
 )
 
+set(default_arm64e_debugserver OFF)
+if (BUILDING_FOR_ARM64_OSX )
+  execute_process(
+      COMMAND sysctl -n hw.optional.ptrauth
+      OUTPUT_VARIABLE SYSCTL_OUTPUT
+      ERROR_QUIET
+      RESULT_VARIABLE SYSCTL_RESULT
+      OUTPUT_STRIP_TRAILING_WHITESPACE
+  )
+  if(SYSCTL_RESULT EQUAL 0)
+    set(default_arm64e_debugserver ON)
+  endif()
+endif()
+option(LLDB_ENABLE_ARM64E_DEBUGSERVER "Build debugserver for arm64 and arm64e" ${default_arm64e_debugserver})
+
 # You can only debug arm64e processes using an arm64e debugserver.
-option(LLDB_ENABLE_ARM64E_DEBUGSERVER "Build debugserver for arm64 and arm64e" OFF)
+# While on older versions of macOS, you may not be able to run arm64e binaries
+# without arm64e_preview_abi, building it should be harmless which is why we
+# default to ON on capable hardware.
 if (BUILDING_FOR_ARM64_OSX AND LLDB_ENABLE_ARM64E_DEBUGSERVER)
+  message(STATUS "Building debugserver for arm64 and arm64e")
   set(CMAKE_OSX_ARCHITECTURES "arm64;arm64e")
 endif ()
 


### PR DESCRIPTION
Change the default of `LLDB_ENABLE_ARM64E_DEBUGSERVER` so we build debugserver fat for arm64 and arm64e when running on macOS Tahoe (26) or later on ptrauth-capable hardware.