### PR TITLE
Remove unneeded cl::ZeroOrMore for cl::opt/cl::list options. NFC

### DIFF
--- a/llvm/lib/Target/Hexagon/HexagonTargetMachine.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonTargetMachine.cpp
@@ -88,7 +88,7 @@ static cl::opt<bool> EnableEarlyIf("hexagon-eif", cl::init(true), cl::Hidden,
                                    cl::desc("Enable early if-conversion"));
 
 static cl::opt<bool> EnableCopyHoist("hexagon-copy-hoist", cl::init(true),
-                                     cl::Hidden, cl::ZeroOrMore,
+                                     cl::Hidden,
                                      cl::desc("Enable Hexagon copy hoisting"));
 
 static cl::opt<bool>

--- a/llvm/lib/Target/SPIRV/SPIRVModuleAnalysis.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVModuleAnalysis.cpp
@@ -42,7 +42,7 @@ static cl::list<SPIRV::Capability::Capability>
     AvoidCapabilities("avoid-spirv-capabilities",
                       cl::desc("SPIR-V capabilities to avoid if there are "
                                "other options enabling a feature"),
-                      cl::ZeroOrMore, cl::Hidden,
+                      cl::Hidden,
                       cl::values(clEnumValN(SPIRV::Capability::Shader, "Shader",
                                             "SPIR-V Shader capability")));
 // Use sets instead of cl::list to check "if contains" condition

--- a/llvm/lib/Transforms/IPO/MemProfContextDisambiguation.cpp
+++ b/llvm/lib/Transforms/IPO/MemProfContextDisambiguation.cpp
@@ -212,8 +212,8 @@ static cl::opt<unsigned> MemProfICPNoInlineThreshold(
 
 namespace llvm {
 cl::opt<bool> EnableMemProfContextDisambiguation(
-    "enable-memprof-context-disambiguation", cl::init(false), cl::Hidden,
-    cl::ZeroOrMore, cl::desc("Enable MemProf context disambiguation"));
+    "enable-memprof-context-disambiguation", cl::Hidden,
+    cl::desc("Enable MemProf context disambiguation"));
 
 // Indicate we are linking with an allocator that supports hot/cold operator
 // new interfaces.

--- a/llvm/lib/Transforms/Instrumentation/AddressSanitizer.cpp
+++ b/llvm/lib/Transforms/Instrumentation/AddressSanitizer.cpp
@@ -446,8 +446,7 @@ static SmallSet<unsigned, 8> SrcAddrSpaces;
 static cl::list<unsigned> ClAddrSpaces(
     "asan-instrument-address-spaces",
     cl::desc("Only instrument variables in the specified address spaces."),
-    cl::Hidden, cl::CommaSeparated, cl::ZeroOrMore,
-    cl::callback([](const unsigned &AddrSpace) {
+    cl::Hidden, cl::CommaSeparated, cl::callback([](const unsigned &AddrSpace) {
       SrcAddrSpaces.insert(AddrSpace);
     }));
 

--- a/llvm/lib/Transforms/Instrumentation/InstrProfiling.cpp
+++ b/llvm/lib/Transforms/Instrumentation/InstrProfiling.cpp
@@ -168,8 +168,7 @@ cl::opt<bool> SkipRetExitBlock(
     "skip-ret-exit-block", cl::init(true),
     cl::desc("Suppress counter promotion if exit blocks contain ret."));
 
-static cl::opt<bool> SampledInstr("sampled-instrumentation", cl::ZeroOrMore,
-                                  cl::init(false),
+static cl::opt<bool> SampledInstr("sampled-instrumentation",
                                   cl::desc("Do PGO instrumentation sampling"));
 
 static cl::opt<unsigned> SampledInstrPeriod(

--- a/llvm/lib/Transforms/Scalar/LoopInterchange.cpp
+++ b/llvm/lib/Transforms/Scalar/LoopInterchange.cpp
@@ -104,8 +104,8 @@ static cl::opt<unsigned int> MaxLoopNestDepth(
 
 // We prefer cache cost to vectorization by default.
 static cl::list<RuleTy> Profitabilities(
-    "loop-interchange-profitabilities", cl::ZeroOrMore,
-    cl::MiscFlags::CommaSeparated, cl::Hidden,
+    "loop-interchange-profitabilities", cl::MiscFlags::CommaSeparated,
+    cl::Hidden,
     cl::desc("List of profitability heuristics to be used. They are applied in "
              "the given order"),
     cl::list_init<RuleTy>({RuleTy::PerLoopCacheAnalysis,

--- a/llvm/tools/llvm-cov/CodeCoverage.cpp
+++ b/llvm/tools/llvm-cov/CodeCoverage.cpp
@@ -690,7 +690,7 @@ int CodeCoverageTool::run(Command Cmd, int argc, const char **argv) {
       "debug-file-directory",
       cl::desc("Directories to search for object files by build ID"));
   cl::opt<bool> Debuginfod(
-      "debuginfod", cl::ZeroOrMore,
+      "debuginfod",
       cl::desc("Use debuginfod to look up object files from profile"),
       cl::init(canUseDebuginfod()));
 

--- a/llvm/tools/llvm-debuginfo-analyzer/Options.cpp
+++ b/llvm/tools/llvm-debuginfo-analyzer/Options.cpp
@@ -44,7 +44,7 @@ LVOptions cmdline::ReaderOptions;
 //===----------------------------------------------------------------------===//
 cl::list<std::string>
     cmdline::InputFilenames(cl::desc("<input object files or .dSYM bundles>"),
-                            cl::Positional, cl::ZeroOrMore);
+                            cl::Positional);
 
 //===----------------------------------------------------------------------===//
 // '--attribute' options
@@ -140,8 +140,7 @@ cl::OptionCategory
 static cl::opt<bool, true>
     CompareContext("compare-context", cl::cat(CompareCategory),
                    cl::desc("Add the view as compare context."), cl::Hidden,
-                   cl::ZeroOrMore, cl::location(ReaderOptions.Compare.Context),
-                   cl::init(false));
+                   cl::location(ReaderOptions.Compare.Context));
 
 // --compare=<value>[,<value>,...]
 cl::list<LVCompareKind> cmdline::CompareElements(
@@ -171,14 +170,14 @@ cl::opt<std::string>
 static cl::opt<std::string, true>
     OutputFolder("output-folder", cl::cat(OutputCategory),
                  cl::desc("Folder name for view splitting."),
-                 cl::value_desc("pathname"), cl::Hidden, cl::ZeroOrMore,
+                 cl::value_desc("pathname"), cl::Hidden,
                  cl::location(ReaderOptions.Output.Folder));
 
 // --output-level=<level>
 static cl::opt<unsigned, true>
     OutputLevel("output-level", cl::cat(OutputCategory),
                 cl::desc("Only print to a depth of N elements."),
-                cl::value_desc("N"), cl::Hidden, cl::ZeroOrMore,
+                cl::value_desc("N"), cl::Hidden,
                 cl::location(ReaderOptions.Output.Level), cl::init(-1U));
 
 // --ouput=<value>[,<value>,...]
@@ -197,7 +196,7 @@ cl::list<LVOutputKind> cmdline::OutputOptions(
 static cl::opt<LVSortMode, true> OutputSort(
     "output-sort", cl::cat(OutputCategory),
     cl::desc("Primary key when ordering logical view (default: line)."),
-    cl::Hidden, cl::ZeroOrMore,
+    cl::Hidden,
     values(clEnumValN(LVSortMode::None, "none",
                       "Unsorted output (i.e. as read from input)."),
            clEnumValN(LVSortMode::ID, "id", "Sort by unique element ID."),
@@ -274,17 +273,14 @@ cl::OptionCategory
 static cl::opt<bool, true>
     SelectIgnoreCase("select-nocase", cl::cat(SelectCategory),
                      cl::desc("Ignore case distinctions when searching."),
-                     cl::Hidden, cl::ZeroOrMore,
-                     cl::location(ReaderOptions.Select.IgnoreCase),
-                     cl::init(false));
+                     cl::Hidden, cl::location(ReaderOptions.Select.IgnoreCase));
 
 // --select-regex
 static cl::opt<bool, true> SelectUseRegex(
     "select-regex", cl::cat(SelectCategory),
     cl::desc("Treat any <pattern> strings as regular expressions when "
              "selecting instead of just as an exact string match."),
-    cl::Hidden, cl::ZeroOrMore, cl::location(ReaderOptions.Select.UseRegex),
-    cl::init(false));
+    cl::Hidden, cl::location(ReaderOptions.Select.UseRegex));
 
 // --select=<pattern>
 cl::list<std::string> cmdline::SelectPatterns(
@@ -297,7 +293,7 @@ OffsetOptionList cmdline::SelectOffsets("select-offsets",
                                         cl::cat(SelectCategory),
                                         cl::desc("Offset element to print."),
                                         cl::Hidden, cl::value_desc("offset"),
-                                        cl::CommaSeparated, cl::ZeroOrMore);
+                                        cl::CommaSeparated);
 
 // --select-elements=<value>[,<value>,...]
 cl::list<LVElementKind> cmdline::SelectElements(

--- a/llvm/tools/llvm-jitlink/llvm-jitlink.cpp
+++ b/llvm/tools/llvm-jitlink/llvm-jitlink.cpp
@@ -87,8 +87,7 @@ using namespace llvm::orc;
 
 static cl::OptionCategory JITLinkCategory("JITLink Options");
 
-static cl::list<std::string> InputFiles(cl::Positional, cl::ZeroOrMore,
-                                        cl::desc("input files"),
+static cl::list<std::string> InputFiles(cl::Positional, cl::desc("input files"),
                                         cl::cat(JITLinkCategory));
 
 static cl::list<bool> LazyLink("lazy",


### PR DESCRIPTION
Similar to commit 557efc9a8b68628c2c944678c6471dac30ed9e8e (2022).

cl::ZeroOrMore is the default for cl::list and is unnecessary for cl::opt
since the "may only occur zero or one times!" error was removed.
Also remove cl::init(false) on modified cl::opt<bool> lines.