### PR TITLE
[CIR][RISCV][NFC] Add CIRGenBuiltinRISCV file to support RISCV builtins codegen

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenBuiltin.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuiltin.cpp
@@ -2384,11 +2384,12 @@ emitTargetArchBuiltinExpr(CIRGenFunction *cgf, unsigned builtinID,
   case llvm::Triple::wasm32:
   case llvm::Triple::wasm64:
   case llvm::Triple::hexagon:
-  case llvm::Triple::riscv32:
-  case llvm::Triple::riscv64:
     // These are actually NYI, but that will be reported by emitBuiltinExpr.
     // At this point, we don't even know that the builtin is target-specific.
     return std::nullopt;
+  case llvm::Triple::riscv32:
+  case llvm::Triple::riscv64:
+    return cgf->emitRISCVBuiltinExpr(builtinID, e);
   default:
     return std::nullopt;
   }

--- a/clang/lib/CIR/CodeGen/CIRGenBuiltinRISCV.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuiltinRISCV.cpp
@@ -19,22 +19,21 @@ using namespace clang::CIRGen;
 
 std::optional<mlir::Value>
 CIRGenFunction::emitRISCVBuiltinExpr(unsigned builtinID, const CallExpr *e) {
+  if (builtinID == Builtin::BI__builtin_cpu_supports ||
+      builtinID == Builtin::BI__builtin_cpu_init ||
+      builtinID == Builtin::BI__builtin_cpu_is) {
+    cgm.errorNYI(e->getSourceRange(),
+                 std::string("unimplemented RISC-V builtin call: ") +
+                     getContext().BuiltinInfo.getName(builtinID));
+    return mlir::Value{};
+  }
   switch (builtinID) {
   default:
-    return std::nullopt;
+    llvm_unreachable("unexpected builtin ID");
 
-  // Zihintpause
-  case RISCV::BI__builtin_riscv_pause:
-  // Zihintntl
-  case RISCV::BI__builtin_riscv_ntl_load:
-  case RISCV::BI__builtin_riscv_ntl_store:
   // Zbb
   case RISCV::BI__builtin_riscv_orc_b_32:
   case RISCV::BI__builtin_riscv_orc_b_64:
-  case RISCV::BI__builtin_riscv_clz_32:
-  case RISCV::BI__builtin_riscv_clz_64:
-  case RISCV::BI__builtin_riscv_ctz_32:
-  case RISCV::BI__builtin_riscv_ctz_64:
   // Zbc
   case RISCV::BI__builtin_riscv_clmul_32:
   case RISCV::BI__builtin_riscv_clmul_64:
@@ -42,16 +41,16 @@ CIRGenFunction::emitRISCVBuiltinExpr(unsigned builtinID, const CallExpr *e) {
   case RISCV::BI__builtin_riscv_clmulh_64:
   case RISCV::BI__builtin_riscv_clmulr_32:
   case RISCV::BI__builtin_riscv_clmulr_64:
-  // Zbkb
-  case RISCV::BI__builtin_riscv_brev8_32:
-  case RISCV::BI__builtin_riscv_brev8_64:
-  case RISCV::BI__builtin_riscv_zip_32:
-  case RISCV::BI__builtin_riscv_unzip_32:
   // Zbkx
   case RISCV::BI__builtin_riscv_xperm4_32:
   case RISCV::BI__builtin_riscv_xperm4_64:
   case RISCV::BI__builtin_riscv_xperm8_32:
   case RISCV::BI__builtin_riscv_xperm8_64:
+  // Zbkb
+  case RISCV::BI__builtin_riscv_brev8_32:
+  case RISCV::BI__builtin_riscv_brev8_64:
+  case RISCV::BI__builtin_riscv_zip_32:
+  case RISCV::BI__builtin_riscv_unzip_32:
   // Zknh
   case RISCV::BI__builtin_riscv_sha256sig0:
   case RISCV::BI__builtin_riscv_sha256sig1:
@@ -63,6 +62,16 @@ CIRGenFunction::emitRISCVBuiltinExpr(unsigned builtinID, const CallExpr *e) {
   // Zksh
   case RISCV::BI__builtin_riscv_sm3p0:
   case RISCV::BI__builtin_riscv_sm3p1:
+  // Zbb
+  case RISCV::BI__builtin_riscv_clz_32:
+  case RISCV::BI__builtin_riscv_clz_64:
+  case RISCV::BI__builtin_riscv_ctz_32:
+  case RISCV::BI__builtin_riscv_ctz_64:
+  // Zihintntl
+  case RISCV::BI__builtin_riscv_ntl_load:
+  case RISCV::BI__builtin_riscv_ntl_store:
+  // Zihintpause
+  case RISCV::BI__builtin_riscv_pause:
   // XCValu
   case RISCV::BI__builtin_riscv_cv_alu_addN:
   case RISCV::BI__builtin_riscv_cv_alu_addRN:

--- a/clang/lib/CIR/CodeGen/CIRGenBuiltinRISCV.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuiltinRISCV.cpp
@@ -1,0 +1,103 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This contains code to emit RISC-V Builtin calls as CIR or a function call
+// to be later resolved.
+//
+//===----------------------------------------------------------------------===//
+
+#include "CIRGenFunction.h"
+#include "clang/Basic/TargetBuiltins.h"
+
+using namespace clang;
+using namespace clang::CIRGen;
+
+std::optional<mlir::Value>
+CIRGenFunction::emitRISCVBuiltinExpr(unsigned builtinID, const CallExpr *e) {
+  switch (builtinID) {
+  default:
+    return std::nullopt;
+
+  // Zihintpause
+  case RISCV::BI__builtin_riscv_pause:
+  // Zihintntl
+  case RISCV::BI__builtin_riscv_ntl_load:
+  case RISCV::BI__builtin_riscv_ntl_store:
+  // Zbb
+  case RISCV::BI__builtin_riscv_orc_b_32:
+  case RISCV::BI__builtin_riscv_orc_b_64:
+  case RISCV::BI__builtin_riscv_clz_32:
+  case RISCV::BI__builtin_riscv_clz_64:
+  case RISCV::BI__builtin_riscv_ctz_32:
+  case RISCV::BI__builtin_riscv_ctz_64:
+  // Zbc
+  case RISCV::BI__builtin_riscv_clmul_32:
+  case RISCV::BI__builtin_riscv_clmul_64:
+  case RISCV::BI__builtin_riscv_clmulh_32:
+  case RISCV::BI__builtin_riscv_clmulh_64:
+  case RISCV::BI__builtin_riscv_clmulr_32:
+  case RISCV::BI__builtin_riscv_clmulr_64:
+  // Zbkb
+  case RISCV::BI__builtin_riscv_brev8_32:
+  case RISCV::BI__builtin_riscv_brev8_64:
+  case RISCV::BI__builtin_riscv_zip_32:
+  case RISCV::BI__builtin_riscv_unzip_32:
+  // Zbkx
+  case RISCV::BI__builtin_riscv_xperm4_32:
+  case RISCV::BI__builtin_riscv_xperm4_64:
+  case RISCV::BI__builtin_riscv_xperm8_32:
+  case RISCV::BI__builtin_riscv_xperm8_64:
+  // Zknh
+  case RISCV::BI__builtin_riscv_sha256sig0:
+  case RISCV::BI__builtin_riscv_sha256sig1:
+  case RISCV::BI__builtin_riscv_sha256sum0:
+  case RISCV::BI__builtin_riscv_sha256sum1:
+  // Zksed
+  case RISCV::BI__builtin_riscv_sm4ks:
+  case RISCV::BI__builtin_riscv_sm4ed:
+  // Zksh
+  case RISCV::BI__builtin_riscv_sm3p0:
+  case RISCV::BI__builtin_riscv_sm3p1:
+  // XCValu
+  case RISCV::BI__builtin_riscv_cv_alu_addN:
+  case RISCV::BI__builtin_riscv_cv_alu_addRN:
+  case RISCV::BI__builtin_riscv_cv_alu_adduN:
+  case RISCV::BI__builtin_riscv_cv_alu_adduRN:
+  case RISCV::BI__builtin_riscv_cv_alu_clip:
+  case RISCV::BI__builtin_riscv_cv_alu_clipu:
+  case RISCV::BI__builtin_riscv_cv_alu_extbs:
+  case RISCV::BI__builtin_riscv_cv_alu_extbz:
+  case RISCV::BI__builtin_riscv_cv_alu_exths:
+  case RISCV::BI__builtin_riscv_cv_alu_exthz:
+  case RISCV::BI__builtin_riscv_cv_alu_sle:
+  case RISCV::BI__builtin_riscv_cv_alu_sleu:
+  case RISCV::BI__builtin_riscv_cv_alu_subN:
+  case RISCV::BI__builtin_riscv_cv_alu_subRN:
+  case RISCV::BI__builtin_riscv_cv_alu_subuN:
+  case RISCV::BI__builtin_riscv_cv_alu_subuRN:
+  // XAndesPerf
+  case RISCV::BI__builtin_riscv_nds_ffb_32:
+  case RISCV::BI__builtin_riscv_nds_ffb_64:
+  case RISCV::BI__builtin_riscv_nds_ffzmism_32:
+  case RISCV::BI__builtin_riscv_nds_ffzmism_64:
+  case RISCV::BI__builtin_riscv_nds_ffmism_32:
+  case RISCV::BI__builtin_riscv_nds_ffmism_64:
+  case RISCV::BI__builtin_riscv_nds_flmism_32:
+  case RISCV::BI__builtin_riscv_nds_flmism_64:
+  // XAndesBFHCvt
+  case RISCV::BI__builtin_riscv_nds_fcvt_s_bf16:
+  case RISCV::BI__builtin_riscv_nds_fcvt_bf16_s: {
+    cgm.errorNYI(e->getSourceRange(),
+                 std::string("unimplemented RISC-V builtin call: ") +
+                     getContext().BuiltinInfo.getName(builtinID));
+    return mlir::Value{};
+  }
+
+    // TODO: Handle vector builtins in tablegen.
+  }
+}

--- a/clang/lib/CIR/CodeGen/CIRGenFunction.h
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.h
@@ -1939,6 +1939,9 @@ public:
 
   mlir::LogicalResult emitWhileStmt(const clang::WhileStmt &s);
 
+  std::optional<mlir::Value> emitRISCVBuiltinExpr(unsigned builtinID,
+                                                  const CallExpr *expr);
+
   std::optional<mlir::Value> emitX86BuiltinExpr(unsigned builtinID,
                                                 const CallExpr *expr);
 

--- a/clang/lib/CIR/CodeGen/CMakeLists.txt
+++ b/clang/lib/CIR/CodeGen/CMakeLists.txt
@@ -15,6 +15,7 @@ add_clang_library(clangCIR
   CIRGenBuiltinAArch64.cpp
   CIRGenBuiltinAMDGPU.cpp
   CIRGenAMDGPU.cpp
+  CIRGenBuiltinRISCV.cpp
   CIRGenBuiltinX86.cpp
   CIRGenCall.cpp
   CIRGenClass.cpp


### PR DESCRIPTION
This PR adds CIRGenBuiltinRISCV.cpp file for RISCV specific builtins codegen support.
List all builtins except vector builtins which need tablegen, and mark them as "NYI".