### PR TITLE
[lldb][docs] Restore cut off sentence in GDB command map

### DIFF
--- a/lldb/docs/use/map.rst
+++ b/lldb/docs/use/map.rst
@@ -1416,8 +1416,11 @@ file path instead of the build system's file path.
 
   (lldb) settings set target.source-map /buildbot/path /my/path
 
-Supply a catchall directory to search for source files in.
+Supply a catchall directory to search for source files in
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: shell
 
   (gdb) directory /my/path
+
+There is no equivalent LLDB command, use ``target.source-map`` instead.


### PR DESCRIPTION
Looking back in the history as far as edb874b2310dc, there was a sentence here to say we don't have an equivalent.

Put that sentence back, and make the first line a header as it was in that HTML version.