### PR TITLE
[AMDGPU] Address post-commit review of #177343

### DIFF
--- a/clang/lib/CodeGen/Targets/AMDGPU.cpp
+++ b/clang/lib/CodeGen/Targets/AMDGPU.cpp
@@ -511,7 +511,8 @@ StringRef AMDGPUTargetCodeGenInfo::getLLVMSyncScopeStr(
     return IsOneAs ? "wavefront-one-as" : "wavefront";
   case SyncScope::HIPCluster:
   case SyncScope::ClusterScope:
-    return IsOneAs ? "cluster-one-as" : "cluster";
+    assert(!IsOneAs && "OpenCL does not have cluster scope");
+    return "cluster";
   case SyncScope::HIPWorkgroup:
   case SyncScope::OpenCLWorkGroup:
   case SyncScope::WorkgroupScope:


### PR DESCRIPTION
- OpenCL has no cluster scope so "cluster-one-as" does not exist and cannot be emitted.