### PR TITLE
[NFC][SPIRV] New test for untested SPIRVInstructionSelector case

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
@@ -2450,7 +2450,7 @@ static unsigned getPtrCmpOpcode(unsigned Pred) {
 static unsigned getBoolCmpOpcode(unsigned PredNum) {
   auto Pred = static_cast<CmpInst::Predicate>(PredNum);
   switch (Pred) {
-  case CmpInst::ICMP_EQ: 
+  case CmpInst::ICMP_EQ:
     return SPIRV::OpLogicalEqual;
   case CmpInst::ICMP_NE:
     return SPIRV::OpLogicalNotEqual;

--- a/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
@@ -2450,8 +2450,10 @@ static unsigned getPtrCmpOpcode(unsigned Pred) {
 static unsigned getBoolCmpOpcode(unsigned PredNum) {
   auto Pred = static_cast<CmpInst::Predicate>(PredNum);
   switch (Pred) {
-  case CmpInst::ICMP_EQ:
+  case CmpInst::ICMP_EQ: {
+    abort();
     return SPIRV::OpLogicalEqual;
+  }
   case CmpInst::ICMP_NE:
     return SPIRV::OpLogicalNotEqual;
   default:

--- a/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
@@ -2450,10 +2450,8 @@ static unsigned getPtrCmpOpcode(unsigned Pred) {
 static unsigned getBoolCmpOpcode(unsigned PredNum) {
   auto Pred = static_cast<CmpInst::Predicate>(PredNum);
   switch (Pred) {
-  case CmpInst::ICMP_EQ: {
-    abort();
+  case CmpInst::ICMP_EQ: 
     return SPIRV::OpLogicalEqual;
-  }
   case CmpInst::ICMP_NE:
     return SPIRV::OpLogicalNotEqual;
   default:

--- a/llvm/test/CodeGen/SPIRV/instructions/icmp.ll
+++ b/llvm/test/CodeGen/SPIRV/instructions/icmp.ll
@@ -22,8 +22,9 @@
 ; CHECK-DAG: OpName [[v3SGT:%.*]] "test_v3_sgt"
 ; CHECK-DAG: OpName [[v3UGE:%.*]] "test_v3_uge"
 ; CHECK-DAG: OpName [[v3SGE:%.*]] "test_v3_sge"
-; CHECK-DAG: OpName [[v16NE:%.*]] "test_v16_ne"
-; CHECK-DAG: OpName [[v16EQ:%.*]] "test_v16_eq"
+
+; CHECK-DAG: OpName [[v16NE:%.*]] "test_boolean_v16_ne"
+; CHECK-DAG: OpName [[v16EQ:%.*]] "test_boolean_v16_eq"
 
 ; CHECK:      [[EQ]] = OpFunction
 ; CHECK-NEXT: [[A:%.*]] = OpFunctionParameter
@@ -271,7 +272,7 @@ define <3 x i1> @test_v3_sge(<3 x i32> %a, <3 x i32> %b) {
 ; CHECK-NEXT: OpReturnValue [[R]]
 ; CHECK-NEXT: OpFunctionEnd
 
-define spir_func <16 x i1> @test_v16_ne() {
+define spir_func <16 x i1> @test_boolean_v16_ne() {
   %A = icmp ne <16 x i1> zeroinitializer, zeroinitializer
   ret <16 x i1> %A
 }
@@ -281,7 +282,7 @@ define spir_func <16 x i1> @test_v16_ne() {
 ; CHECK-NEXT: [[R:%.*]] = OpLogicalEqual {{%.+}} {{%.*}} {{%.*}}
 ; CHECK-NEXT: OpReturnValue [[R]]
 ; CHECK-NEXT: OpFunctionEnd
-define spir_func <16 x i1> @test_v16_eq() {
+define spir_func <16 x i1> @test_boolean_v16_eq() {
 entry:
   %A = icmp eq <16 x i1> zeroinitializer, zeroinitializer
   ret <16 x i1> %A

--- a/llvm/test/CodeGen/SPIRV/instructions/icmp.ll
+++ b/llvm/test/CodeGen/SPIRV/instructions/icmp.ll
@@ -23,6 +23,7 @@
 ; CHECK-DAG: OpName [[v3UGE:%.*]] "test_v3_uge"
 ; CHECK-DAG: OpName [[v3SGE:%.*]] "test_v3_sge"
 ; CHECK-DAG: OpName [[v16NE:%.*]] "test_v16_ne"
+; CHECK-DAG: OpName [[v16EQ:%.*]] "test_v16_eq"
 
 ; CHECK:      [[EQ]] = OpFunction
 ; CHECK-NEXT: [[A:%.*]] = OpFunctionParameter
@@ -272,5 +273,16 @@ define <3 x i1> @test_v3_sge(<3 x i32> %a, <3 x i32> %b) {
 
 define spir_func <16 x i1> @test_v16_ne() {
   %A = icmp ne <16 x i1> zeroinitializer, zeroinitializer
+  ret <16 x i1> %A
+}
+
+; CHECK:      [[v16EQ]] = OpFunction
+; CHECK-NEXT: OpLabel
+; CHECK-NEXT: [[R:%.*]] = OpLogicalEqual {{%.+}} {{%.*}} {{%.*}}
+; CHECK-NEXT: OpReturnValue [[R]]
+; CHECK-NEXT: OpFunctionEnd
+define spir_func <16 x i1> @test_v16_eq() {
+entry:
+  %A = icmp eq <16 x i1> zeroinitializer, zeroinitializer
   ret <16 x i1> %A
 }

--- a/llvm/test/CodeGen/SPIRV/instructions/icmp.ll
+++ b/llvm/test/CodeGen/SPIRV/instructions/icmp.ll
@@ -26,6 +26,10 @@
 ; CHECK-DAG: OpName [[v16NE:%.*]] "test_boolean_v16_ne"
 ; CHECK-DAG: OpName [[v16EQ:%.*]] "test_boolean_v16_eq"
 
+; CHECK-DAG: [[Bool:%.*]] = OpTypeBool
+; CHECK-DAG: [[v16:%.*]] = OpTypeVector [[Bool]] 16
+; CHECK-DAG: [[Null:%.*]] = OpConstantNull [[v16]]
+
 ; CHECK:      [[EQ]] = OpFunction
 ; CHECK-NEXT: [[A:%.*]] = OpFunctionParameter
 ; CHECK-NEXT: [[B:%.*]] = OpFunctionParameter
@@ -268,10 +272,9 @@ define <3 x i1> @test_v3_sge(<3 x i32> %a, <3 x i32> %b) {
 
 ; CHECK:      [[v16NE]] = OpFunction
 ; CHECK-NEXT: OpLabel
-; CHECK-NEXT: [[R:%.*]] = OpLogicalNotEqual {{%.+}} {{%.*}} {{%.*}}
+; CHECK-NEXT: [[R:%.*]] = OpLogicalNotEqual {{%.+}} [[Null]] [[Null]]
 ; CHECK-NEXT: OpReturnValue [[R]]
 ; CHECK-NEXT: OpFunctionEnd
-
 define spir_func <16 x i1> @test_boolean_v16_ne() {
   %A = icmp ne <16 x i1> zeroinitializer, zeroinitializer
   ret <16 x i1> %A
@@ -279,11 +282,10 @@ define spir_func <16 x i1> @test_boolean_v16_ne() {
 
 ; CHECK:      [[v16EQ]] = OpFunction
 ; CHECK-NEXT: OpLabel
-; CHECK-NEXT: [[R:%.*]] = OpLogicalEqual {{%.+}} {{%.*}} {{%.*}}
+; CHECK-NEXT: [[R:%.*]] = OpLogicalEqual {{%.+}} [[Null]] [[Null]]
 ; CHECK-NEXT: OpReturnValue [[R]]
 ; CHECK-NEXT: OpFunctionEnd
 define spir_func <16 x i1> @test_boolean_v16_eq() {
-entry:
   %A = icmp eq <16 x i1> zeroinitializer, zeroinitializer
   ret <16 x i1> %A
 }


### PR DESCRIPTION
[This line](https://github.com/ambergorzynski/llvm-project/blob/main/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp#L2454) is untested by the existing test suite (checked using coverage and inserting an `abort` at that line).

We propose a new test for the untested logical `eq` case, similarly to the `neq` case added [here](https://github.com/llvm/llvm-project/commit/e45c8b6555c866cd0412b42fce0439e927ca3ba2).