### PR TITLE
[CIR][AMDGPU] Add module flags for AMDGPU target using amendOperation of CIRDialectLLVMIRTranslationInterface

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIRDialect.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRDialect.td
@@ -76,6 +76,9 @@ def CIR_Dialect : Dialect {
     static llvm::StringRef getResAttrsAttrName() { return "res_attrs"; }
     static llvm::StringRef getArgAttrsAttrName() { return "arg_attrs"; }
 
+    static llvm::StringRef getAMDGPUCodeObjectVersionAttrName() { return "cir.amdhsa_code_object_version"; }
+    static llvm::StringRef getAMDGPUPrintfKindAttrName() { return "cir.amdgpu_printf_kind"; }
+
     void registerAttributes();
     void registerTypes();
 

--- a/clang/lib/CIR/CodeGen/CIRGenAMDGPU.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenAMDGPU.cpp
@@ -1,0 +1,41 @@
+//===- CIRGenAMDGPU.cpp - AMDGPU-specific logic for CIR generation --------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This contains code dealing with AMDGPU-specific logic of CIR generation.
+//
+//===----------------------------------------------------------------------===//
+
+#include "CIRGenModule.h"
+
+#include "clang/Basic/TargetOptions.h"
+#include "clang/CIR/Dialect/IR/CIRDialect.h"
+#include "llvm/TargetParser/Triple.h"
+
+using namespace clang;
+using namespace clang::CIRGen;
+
+void CIRGenModule::emitAMDGPUMetadata() {
+  // Emit code object version module flag.
+  if (target.getTargetOpts().CodeObjectVersion !=
+      llvm::CodeObjectVersionKind::COV_None) {
+    theModule->setAttr(
+        cir::CIRDialect::getAMDGPUCodeObjectVersionAttrName(),
+        builder.getI32IntegerAttr(target.getTargetOpts().CodeObjectVersion));
+  }
+
+  // Emit printf kind module flag for HIP.
+  if (langOpts.HIP) {
+    llvm::StringRef printfKind =
+        target.getTargetOpts().AMDGPUPrintfKindVal ==
+                TargetOptions::AMDGPUPrintfKind::Hostcall
+            ? "hostcall"
+            : "buffered";
+    theModule->setAttr(cir::CIRDialect::getAMDGPUPrintfKindAttrName(),
+                       builder.getStringAttr(printfKind));
+  }
+}

--- a/clang/lib/CIR/CodeGen/CIRGenModule.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.cpp
@@ -2878,6 +2878,9 @@ void CIRGenModule::release() {
   theModule->setAttr(cir::CIRDialect::getModuleLevelAsmAttrName(),
                      builder.getArrayAttr(globalScopeAsm));
 
+  if (getTriple().isAMDGPU())
+    emitAMDGPUMetadata();
+
   // There's a lot of code that is not implemented yet.
   assert(!cir::MissingFeatures::cgmRelease());
 }

--- a/clang/lib/CIR/CodeGen/CIRGenModule.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.cpp
@@ -2878,7 +2878,8 @@ void CIRGenModule::release() {
   theModule->setAttr(cir::CIRDialect::getModuleLevelAsmAttrName(),
                      builder.getArrayAttr(globalScopeAsm));
 
-  if (getTriple().isAMDGPU())
+  if (getTriple().isAMDGPU() ||
+      (getTriple().isSPIRV() && getTriple().getVendor() == llvm::Triple::AMD))
     emitAMDGPUMetadata();
 
   // There's a lot of code that is not implemented yet.

--- a/clang/lib/CIR/CodeGen/CIRGenModule.h
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.h
@@ -778,6 +778,9 @@ public:
   /// Print out an error that codegen doesn't support the specified decl yet.
   void errorUnsupported(const Decl *d, llvm::StringRef type);
 
+  /// Emits AMDGPU specific Metadata.
+  void emitAMDGPUMetadata();
+
 private:
   // An ordered map of canonical GlobalDecls to their mangled names.
   llvm::MapVector<clang::GlobalDecl, llvm::StringRef> mangledDeclNames;

--- a/clang/lib/CIR/CodeGen/CMakeLists.txt
+++ b/clang/lib/CIR/CodeGen/CMakeLists.txt
@@ -14,6 +14,7 @@ add_clang_library(clangCIR
   CIRGenBuiltin.cpp
   CIRGenBuiltinAArch64.cpp
   CIRGenBuiltinAMDGPU.cpp
+  CIRGenAMDGPU.cpp
   CIRGenBuiltinX86.cpp
   CIRGenCall.cpp
   CIRGenClass.cpp

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVMIR.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVMIR.cpp
@@ -74,7 +74,28 @@ private:
   // Translate CIR's module attributes to LLVM's module metadata
   void amendModule(mlir::ModuleOp mod, mlir::NamedAttribute attribute,
                    mlir::LLVM::ModuleTranslation &moduleTranslation) const {
-    // TODO(cir): Implement this
+    llvm::Module *llvmModule = moduleTranslation.getLLVMModule();
+    llvm::LLVMContext &llvmContext = llvmModule->getContext();
+
+    // AMDGPU module flags
+    if (attribute.getName() == "cir.amdhsa_code_object_version") {
+      if (auto intAttr =
+              mlir::dyn_cast<mlir::IntegerAttr>(attribute.getValue())) {
+        llvmModule->addModuleFlag(llvm::Module::Error,
+                                  "amdhsa_code_object_version",
+                                  static_cast<uint32_t>(intAttr.getInt()));
+      }
+    }
+
+    if (attribute.getName() == "cir.amdgpu_printf_kind") {
+      if (auto strAttr =
+              mlir::dyn_cast<mlir::StringAttr>(attribute.getValue())) {
+        llvm::MDString *mdStr =
+            llvm::MDString::get(llvmContext, strAttr.getValue());
+        llvmModule->addModuleFlag(llvm::Module::Error, "amdgpu_printf_kind",
+                                  mdStr);
+      }
+    }
   }
 };
 

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVMIR.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVMIR.cpp
@@ -47,6 +47,35 @@ public:
 
     return mlir::success();
   }
+
+  /// Any named attribute in the CIR dialect, i.e, with name started with
+  /// "cir.", will be handled here.
+  virtual mlir::LogicalResult amendOperation(
+      mlir::Operation *op, llvm::ArrayRef<llvm::Instruction *> instructions,
+      mlir::NamedAttribute attribute,
+      mlir::LLVM::ModuleTranslation &moduleTranslation) const override {
+    if (auto func = dyn_cast<mlir::LLVM::LLVMFuncOp>(op)) {
+      amendFunction(func, instructions, attribute, moduleTranslation);
+    } else if (auto mod = dyn_cast<mlir::ModuleOp>(op)) {
+      amendModule(mod, attribute, moduleTranslation);
+    }
+    return mlir::success();
+  }
+
+private:
+  // Translate CIR's extra function attributes to LLVM's function attributes.
+  void amendFunction(mlir::LLVM::LLVMFuncOp func,
+                     llvm::ArrayRef<llvm::Instruction *> instructions,
+                     mlir::NamedAttribute attribute,
+                     mlir::LLVM::ModuleTranslation &moduleTranslation) const {
+    // TODO(cir): Implement this
+  }
+
+  // Translate CIR's module attributes to LLVM's module metadata
+  void amendModule(mlir::ModuleOp mod, mlir::NamedAttribute attribute,
+                   mlir::LLVM::ModuleTranslation &moduleTranslation) const {
+    // TODO(cir): Implement this
+  }
 };
 
 void registerCIRDialectTranslation(mlir::DialectRegistry &registry) {

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVMIR.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVMIR.cpp
@@ -55,35 +55,41 @@ public:
       mlir::NamedAttribute attribute,
       mlir::LLVM::ModuleTranslation &moduleTranslation) const override {
     if (auto func = dyn_cast<mlir::LLVM::LLVMFuncOp>(op)) {
-      amendFunction(func, instructions, attribute, moduleTranslation);
+      if (mlir::failed(
+              amendFunction(func, instructions, attribute, moduleTranslation)))
+        return mlir::failure();
     } else if (auto mod = dyn_cast<mlir::ModuleOp>(op)) {
-      amendModule(mod, attribute, moduleTranslation);
+      if (mlir::failed(amendModule(mod, attribute, moduleTranslation)))
+        return mlir::failure();
     }
     return mlir::success();
   }
 
 private:
   // Translate CIR's extra function attributes to LLVM's function attributes.
-  void amendFunction(mlir::LLVM::LLVMFuncOp func,
-                     llvm::ArrayRef<llvm::Instruction *> instructions,
-                     mlir::NamedAttribute attribute,
-                     mlir::LLVM::ModuleTranslation &moduleTranslation) const {
-    // TODO(cir): Implement this
+  mlir::LogicalResult
+  amendFunction(mlir::LLVM::LLVMFuncOp func,
+                llvm::ArrayRef<llvm::Instruction *> instructions,
+                mlir::NamedAttribute attribute,
+                mlir::LLVM::ModuleTranslation &moduleTranslation) const {
+    // TODO(CIR): process extra function attributes.
+    return mlir::success();
   }
 
   // Translate CIR's module attributes to LLVM's module metadata
-  void amendModule(mlir::ModuleOp mod, mlir::NamedAttribute attribute,
-                   mlir::LLVM::ModuleTranslation &moduleTranslation) const {
+  mlir::LogicalResult
+  amendModule(mlir::ModuleOp mod, mlir::NamedAttribute attribute,
+              mlir::LLVM::ModuleTranslation &moduleTranslation) const {
     llvm::Module *llvmModule = moduleTranslation.getLLVMModule();
     llvm::LLVMContext &llvmContext = llvmModule->getContext();
 
-    // AMDGPU module flags
     if (attribute.getName() == "cir.amdhsa_code_object_version") {
       if (auto intAttr =
               mlir::dyn_cast<mlir::IntegerAttr>(attribute.getValue())) {
         llvmModule->addModuleFlag(llvm::Module::Error,
                                   "amdhsa_code_object_version",
                                   static_cast<uint32_t>(intAttr.getInt()));
+        return mlir::success();
       }
     }
 
@@ -94,8 +100,11 @@ private:
             llvm::MDString::get(llvmContext, strAttr.getValue());
         llvmModule->addModuleFlag(llvm::Module::Error, "amdgpu_printf_kind",
                                   mdStr);
+        return mlir::success();
       }
     }
+
+    return mlir::success();
   }
 };
 

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVMIR.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVMIR.cpp
@@ -89,7 +89,6 @@ private:
         llvmModule->addModuleFlag(llvm::Module::Error,
                                   "amdhsa_code_object_version",
                                   static_cast<uint32_t>(intAttr.getInt()));
-        return mlir::success();
       }
     }
 
@@ -100,7 +99,6 @@ private:
             llvm::MDString::get(llvmContext, strAttr.getValue());
         llvmModule->addModuleFlag(llvm::Module::Error, "amdgpu_printf_kind",
                                   mdStr);
-        return mlir::success();
       }
     }
 

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVMIR.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVMIR.cpp
@@ -54,11 +54,7 @@ public:
       mlir::Operation *op, llvm::ArrayRef<llvm::Instruction *> instructions,
       mlir::NamedAttribute attribute,
       mlir::LLVM::ModuleTranslation &moduleTranslation) const override {
-    if (auto func = dyn_cast<mlir::LLVM::LLVMFuncOp>(op)) {
-      if (mlir::failed(
-              amendFunction(func, instructions, attribute, moduleTranslation)))
-        return mlir::failure();
-    } else if (auto mod = dyn_cast<mlir::ModuleOp>(op)) {
+    if (auto mod = dyn_cast<mlir::ModuleOp>(op)) {
       if (mlir::failed(amendModule(mod, attribute, moduleTranslation)))
         return mlir::failure();
     }
@@ -66,16 +62,6 @@ public:
   }
 
 private:
-  // Translate CIR's extra function attributes to LLVM's function attributes.
-  mlir::LogicalResult
-  amendFunction(mlir::LLVM::LLVMFuncOp func,
-                llvm::ArrayRef<llvm::Instruction *> instructions,
-                mlir::NamedAttribute attribute,
-                mlir::LLVM::ModuleTranslation &moduleTranslation) const {
-    // TODO(CIR): process extra function attributes.
-    return mlir::success();
-  }
-
   // Translate CIR's module attributes to LLVM's module metadata
   mlir::LogicalResult
   amendModule(mlir::ModuleOp mod, mlir::NamedAttribute attribute,

--- a/clang/test/CIR/CodeGenHIP/amdgpu-module-flags.hip
+++ b/clang/test/CIR/CodeGenHIP/amdgpu-module-flags.hip
@@ -1,0 +1,30 @@
+#include "../CodeGenCUDA/Inputs/cuda.h"
+
+// REQUIRES: amdgpu-registered-target
+// RUN: %clang_cc1 -triple=amdgcn-amd-amdhsa -x hip -fclangir \
+// RUN:            -fcuda-is-device -emit-cir %s -o %t.cir
+// RUN: FileCheck --check-prefix=CIR %s --input-file=%t.cir
+
+// RUN: %clang_cc1 -triple=amdgcn-amd-amdhsa -x hip -fclangir \
+// RUN:            -fcuda-is-device -emit-llvm %s -o %t.cir.ll
+// RUN: FileCheck --check-prefix=LLVM %s --input-file=%t.cir.ll
+
+// RUN: %clang_cc1 -triple=amdgcn-amd-amdhsa -x hip \
+// RUN:            -fcuda-is-device -emit-llvm %s -o %t.ogcg.ll
+// RUN: FileCheck --check-prefix=OGCG %s --input-file=%t.ogcg.ll
+
+// Test that AMDGPU module flags are emitted correctly.
+
+// CIR: module {{.*}} attributes {
+// CIR-SAME: cir.amdgpu_printf_kind = "hostcall"
+// CIR-SAME: cir.amdhsa_code_object_version = 600
+
+// LLVM: !llvm.module.flags = !{
+// LLVM-DAG: !{i32 1, !"amdhsa_code_object_version", i32 600}
+// LLVM-DAG: !{i32 1, !"amdgpu_printf_kind", !"hostcall"}
+
+// OGCG: !llvm.module.flags = !{
+// OGCG-DAG: !{i32 1, !"amdhsa_code_object_version", i32 600}
+// OGCG-DAG: !{i32 1, !"amdgpu_printf_kind", !"hostcall"}
+
+__global__ void kernel() {}

--- a/clang/test/CIR/CodeGenHIP/amdgpu-module-flags.hip
+++ b/clang/test/CIR/CodeGenHIP/amdgpu-module-flags.hip
@@ -11,7 +11,7 @@
 
 // RUN: %clang_cc1 -triple=amdgcn-amd-amdhsa -x hip \
 // RUN:            -fcuda-is-device -emit-llvm %s -o %t.ogcg.ll
-// RUN: FileCheck --check-prefix=OGCG %s --input-file=%t.ogcg.ll
+// RUN: FileCheck --check-prefix=LLVM %s --input-file=%t.ogcg.ll
 
 // Test that AMDGPU module flags are emitted correctly.
 
@@ -22,9 +22,5 @@
 // LLVM: !llvm.module.flags = !{
 // LLVM-DAG: !{i32 1, !"amdhsa_code_object_version", i32 600}
 // LLVM-DAG: !{i32 1, !"amdgpu_printf_kind", !"hostcall"}
-
-// OGCG: !llvm.module.flags = !{
-// OGCG-DAG: !{i32 1, !"amdhsa_code_object_version", i32 600}
-// OGCG-DAG: !{i32 1, !"amdgpu_printf_kind", !"hostcall"}
 
 __global__ void kernel() {}


### PR DESCRIPTION
Add the amendOperation override to handle CIR dialect attributes during MLIR-to-LLVM IR translation. This dispatches to amendFunction for LLVMFuncOp and amendModule for ModuleOp, enabling future translation of CIR-specific attributes to LLVM function attributes and module metadata.

This PR also adds support to emit AMDGPU-specific module flags amdhsa_code_object_version and amdgpu_printf_kind to match OGCG behavior.

In CIRGenModule, the flags are stored as CIR module attributes:

cir.amdhsa_code_object_version (integer)
cir.amdgpu_printf_kind (string: "hostcall" or "buffered")
During lowering to LLVM IR (in LowerToLLVMIR.cpp), these attributes are converted to LLVM module flags.

Upstreaming basic changes from clangIR PRs: 
https://github.com/llvm/clangir/commit/61e9ebd9f80393a0d6d792142642e8edddbe1adc
https://github.com/llvm/clangir/pull/768
https://github.com/llvm/clangir/pull/773
https://github.com/llvm/clangir/pull/2100
