### PR TITLE
[Inliner] Fix return attribute propagation across multiple return sites

### DIFF
--- a/llvm/lib/Transforms/Utils/InlineFunction.cpp
+++ b/llvm/lib/Transforms/Utils/InlineFunction.cpp
@@ -1550,9 +1550,9 @@ static AttrBuilder IdentifyValidPoisonGeneratingAttributes(CallBase &CB) {
 
 static void AddReturnAttributes(CallBase &CB, ValueToValueMapTy &VMap,
                                 ClonedCodeInfo &InlinedFunctionInfo) {
-  AttrBuilder ValidUB = IdentifyValidUBGeneratingAttributes(CB);
-  AttrBuilder ValidPG = IdentifyValidPoisonGeneratingAttributes(CB);
-  if (!ValidUB.hasAttributes() && !ValidPG.hasAttributes())
+  AttrBuilder CallSiteValidUB = IdentifyValidUBGeneratingAttributes(CB);
+  AttrBuilder CallSiteValidPG = IdentifyValidPoisonGeneratingAttributes(CB);
+  if (!CallSiteValidUB.hasAttributes() && !CallSiteValidPG.hasAttributes())
     return;
   auto *CalledFunction = CB.getCalledFunction();
   auto &Context = CalledFunction->getContext();
@@ -1600,6 +1600,8 @@ static void AddReturnAttributes(CallBase &CB, ValueToValueMapTy &VMap,
     // with a differing value, the AttributeList's merge API honours the already
     // existing attribute value (i.e. attributes such as dereferenceable,
     // dereferenceable_or_null etc). See AttrBuilder::merge for more details.
+    AttrBuilder ValidUB = IdentifyValidUBGeneratingAttributes(CB);
+    AttrBuilder ValidPG = IdentifyValidPoisonGeneratingAttributes(CB);
     AttributeList AL = NewRetVal->getAttributes();
     if (ValidUB.getDereferenceableBytes() < AL.getRetDereferenceableBytes())
       ValidUB.removeAttribute(Attribute::Dereferenceable);

--- a/llvm/test/Transforms/Inline/ret_attr_align_and_noundef.ll
+++ b/llvm/test/Transforms/Inline/ret_attr_align_and_noundef.ll
@@ -421,6 +421,43 @@ define i8 @caller16_not_intersecting_ranges() {
   ret i8 %r
 }
 
+define i8 @callee_range_multi_ret(i1 %c) {
+; CHECK-LABEL: define i8 @callee_range_multi_ret(i1 %c) {
+; CHECK-NEXT:    br i1 %c, label %bb1, label %bb2
+; CHECK:       bb1:
+; CHECK-NEXT:    [[R1:%.*]] = call range(i8 0, 20) i8 @val8()
+; CHECK-NEXT:    ret i8 [[R1]]
+; CHECK:       bb2:
+; CHECK-NEXT:    [[R2:%.*]] = call range(i8 10, 30) i8 @val8()
+; CHECK-NEXT:    ret i8 [[R2]]
+;
+  br i1 %c, label %bb1, label %bb2
+
+bb1:
+  %r1 = call range(i8 0, 20) i8 @val8()
+  ret i8 %r1
+
+bb2:
+  %r2 = call range(i8 10, 30) i8 @val8()
+  ret i8 %r2
+}
+
+define i8 @caller_range_multi_ret_okay_intersect(i1 %c) {
+; CHECK-LABEL: define i8 @caller_range_multi_ret_okay_intersect(i1 %c) {
+; CHECK-NEXT:    br i1 %c, label %bb1.i, label %bb2.i
+; CHECK:       bb1.i:
+; CHECK-NEXT:    [[R1_I:%.*]] = call range(i8 5, 20) i8 @val8()
+; CHECK-NEXT:    br label %callee_range_multi_ret.exit
+; CHECK:       bb2.i:
+; CHECK-NEXT:    [[R2_I:%.*]] = call range(i8 10, 25) i8 @val8()
+; CHECK-NEXT:    br label %callee_range_multi_ret.exit
+; CHECK:       callee_range_multi_ret.exit:
+; CHECK-NEXT:    [[R_I:%.*]] = phi i8 [ [[R1_I]], %bb1.i ], [ [[R2_I]], %bb2.i ]
+; CHECK-NEXT:    ret i8 [[R_I]]
+;
+  %r = call range(i8 5, 25) i8 @callee_range_multi_ret(i1 %c)
+  ret i8 %r
+}
 
 define ptr @caller_bad_ret_prop(ptr %p1, ptr %p2, i64 %x, ptr %other) {
 ; CHECK-LABEL: define ptr @caller_bad_ret_prop

--- a/llvm/test/Transforms/Inline/ret_attr_nofpclass.ll
+++ b/llvm/test/Transforms/Inline/ret_attr_nofpclass.ll
@@ -55,3 +55,42 @@ define float @caller_not_intersecting_nofpclass() {
   ret float %r
 }
 
+define float @callee_nofpclass_inf_nan_multi_ret(i1 %c) {
+; CHECK-LABEL: define float @callee_nofpclass_inf_nan_multi_ret(i1 %c) {
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    br i1 %c, label %bb1, label %bb2
+; CHECK:       bb1:
+; CHECK-NEXT:    [[R1:%.*]] = call nofpclass(nan) float @use.val(float 1.000000e+00)
+; CHECK-NEXT:    ret float [[R1]]
+; CHECK:       bb2:
+; CHECK-NEXT:    [[R2:%.*]] = call nofpclass(inf) float @use.val(float 2.000000e+00)
+; CHECK-NEXT:    ret float [[R2]]
+;
+entry:
+  br i1 %c, label %bb1, label %bb2
+
+bb1:
+  %r1 = call nofpclass(nan) float @use.val(float 1.0)
+  ret float %r1
+
+bb2:
+  %r2 = call nofpclass(inf) float @use.val(float 2.0)
+  ret float %r2
+}
+
+define float @caller_okay_intersect_nofpclass_multi_ret(i1 %c) {
+; CHECK-LABEL: define float @caller_okay_intersect_nofpclass_multi_ret(
+; CHECK-NEXT:    br i1 %c, label %bb1.i, label %bb2.i
+; CHECK:       bb1.i:
+; CHECK-NEXT:    [[R1_I:%.*]] = call nofpclass(nan zero) float @use.val(float 1.000000e+00)
+; CHECK-NEXT:    br label %callee_nofpclass_inf_nan_multi_ret.exit
+; CHECK:       bb2.i:
+; CHECK-NEXT:    [[R2_I:%.*]] = call nofpclass(inf zero) float @use.val(float 2.000000e+00)
+; CHECK-NEXT:    br label %callee_nofpclass_inf_nan_multi_ret.exit
+; CHECK:       callee_nofpclass_inf_nan_multi_ret.exit:
+; CHECK-NEXT:    [[R:%.*]] = phi float [ [[R1_I]], %bb1.i ], [ [[R2_I]], %bb2.i ]
+; CHECK-NEXT:    ret float [[R]]
+;
+  %r = call nofpclass(zero) float @callee_nofpclass_inf_nan_multi_ret(i1 %c)
+  ret float %r
+}


### PR DESCRIPTION
Fixes #185159 

This patch fixes a bug in `AddReturnAttributes()` where propagated return attributes could incorrectly leak across multiple return sites in the callee being inlined.

`AddReturnAttributes()` walks the callee's return instructions and tries to backward-propagate return attributes from the callsite to the returned call when the callee directly returns a call result. However, the propagated attribute builders were updated in-place while iterating over return sites. As a result, attributes refined for one return site could be reused when
processing a later return site. This is incorrect because each return site should be handled independently, starting from the original callsite attributes.

This patch ensures that propagated return attributes are reinitialized for each return site, so propagation is computed independently per returned call. 