### PR TITLE
libclc: Improve fdim handling

### DIFF
--- a/libclc/clc/lib/generic/math/clc_fdim.cl
+++ b/libclc/clc/lib/generic/math/clc_fdim.cl
@@ -6,13 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <clc/clc_convert.h>
-#include <clc/float/definitions.h>
-#include <clc/internal/clc.h>
-#include <clc/math/clc_fmax.h>
-#include <clc/math/math.h>
-#include <clc/relational/clc_isnan.h>
-#include <clc/relational/clc_select.h>
+#include "clc/relational/clc_isunordered.h"
 
 #define __CLC_BODY <clc_fdim.inc>
-#include <clc/math/gentype.inc>
+#include "clc/math/gentype.inc"

--- a/libclc/clc/lib/generic/math/clc_fdim.inc
+++ b/libclc/clc/lib/generic/math/clc_fdim.inc
@@ -8,7 +8,5 @@
 
 _CLC_OVERLOAD _CLC_DEF __CLC_GENTYPE __clc_fdim(__CLC_GENTYPE x,
                                                 __CLC_GENTYPE y) {
-  return __clc_select(__builtin_elementwise_maxnum(x - y, __CLC_FP_LIT(0.0)),
-                      __CLC_GENTYPE_NAN,
-                      __CLC_CONVERT_BIT_INTN(__clc_isnan(x) || __clc_isnan(y)));
+  return (x <= y && !__clc_isunordered(x, y)) ? __CLC_FP_LIT(0.0) : (x - y);
 }


### PR DESCRIPTION
The maxnum is somewhat overconstraining. This gives slightly
better codegen and avoids the noise from the select and convert,
and saves the cost of materializing the nan literal.