### PR TITLE
[LLVM][CodeGen][SVE] insert_subvector(undef, splat(C), 0) -> splat(C).

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
@@ -21998,11 +21998,16 @@ performInsertSubvectorCombine(SDNode *N, TargetLowering::DAGCombinerInfo &DCI,
   EVT VecVT = Vec.getValueType();
   EVT SubVT = SubVec.getValueType();
 
-  // Promote fixed length vector zeros.
+  // Promote fixed length vector constants.
   if (VecVT.isScalableVector() && SubVT.isFixedLengthVector() &&
-      Vec.isUndef() && isZerosVector(SubVec.getNode()))
-    return VecVT.isInteger() ? DAG.getConstant(0, DL, VecVT)
-                             : DAG.getConstantFP(0, DL, VecVT);
+      Vec.isUndef()) {
+    SDValue SplatVal = DAG.getSplatValue(SubVec);
+    if (auto C = dyn_cast_or_null<ConstantSDNode>(SplatVal))
+      return DAG.getConstant(C->getAPIntValue(), DL, VecVT);
+
+    if (auto C = dyn_cast_or_null<ConstantFPSDNode>(SplatVal))
+      return DAG.getConstantFP(C->getValueAPF(), DL, VecVT);
+  }
 
   // Only do this for legal fixed vector types.
   if (!VecVT.isFixedLengthVector() ||

--- a/llvm/test/CodeGen/AArch64/imm-splat-ops.ll
+++ b/llvm/test/CodeGen/AArch64/imm-splat-ops.ll
@@ -235,10 +235,8 @@ define <2 x i64> @mul_v2i64(<2 x i64> %a) {
 ;
 ; CHECK-SVE-LABEL: mul_v2i64:
 ; CHECK-SVE:       // %bb.0: // %entry
-; CHECK-SVE-NEXT:    mov z1.d, #123 // =0x7b
-; CHECK-SVE-NEXT:    ptrue p0.d, vl2
 ; CHECK-SVE-NEXT:    // kill: def $q0 killed $q0 def $z0
-; CHECK-SVE-NEXT:    mul z0.d, p0/m, z0.d, z1.d
+; CHECK-SVE-NEXT:    mul z0.d, z0.d, #123
 ; CHECK-SVE-NEXT:    // kill: def $q0 killed $q0 killed $z0
 ; CHECK-SVE-NEXT:    ret
 entry:

--- a/llvm/test/CodeGen/AArch64/sve-asrd.ll
+++ b/llvm/test/CodeGen/AArch64/sve-asrd.ll
@@ -7,23 +7,18 @@ target triple = "aarch64-unknown-linux-gnu"
 define <16 x i16> @sdiv_by_one_v16i16(<16 x i16> %a) vscale_range(2,2) {
 ; CHECK-LABEL: sdiv_by_one_v16i16:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    ptrue p0.h
-; CHECK-NEXT:    adrp x8, .LCPI0_0
-; CHECK-NEXT:    add x8, x8, :lo12:.LCPI0_0
+; CHECK-NEXT:    mov z2.h, #1 // =0x1
 ; CHECK-NEXT:    // kill: def $q1 killed $q1 def $z1
 ; CHECK-NEXT:    // kill: def $q0 killed $q0 def $z0
-; CHECK-NEXT:    ld1h { z2.h }, p0/z, [x8]
-; CHECK-NEXT:    sunpklo z0.s, z0.h
-; CHECK-NEXT:    sunpklo z1.s, z1.h
 ; CHECK-NEXT:    ptrue p0.s
-; CHECK-NEXT:    sunpklo z3.s, z2.h
-; CHECK-NEXT:    ext z2.b, z2.b, z2.b, #16
+; CHECK-NEXT:    sunpklo z1.s, z1.h
+; CHECK-NEXT:    sunpklo z0.s, z0.h
 ; CHECK-NEXT:    sunpklo z2.s, z2.h
-; CHECK-NEXT:    sdiv z0.s, p0/m, z0.s, z3.s
 ; CHECK-NEXT:    sdiv z1.s, p0/m, z1.s, z2.s
+; CHECK-NEXT:    sdiv z0.s, p0/m, z0.s, z2.s
 ; CHECK-NEXT:    ptrue p0.h, vl8
-; CHECK-NEXT:    uzp1 z0.h, z0.h, z0.h
 ; CHECK-NEXT:    uzp1 z1.h, z1.h, z1.h
+; CHECK-NEXT:    uzp1 z0.h, z0.h, z0.h
 ; CHECK-NEXT:    splice z0.h, p0, z0.h, z1.h
 ; CHECK-NEXT:    movprfx z1, z0
 ; CHECK-NEXT:    ext z1.b, z1.b, z0.b, #16

--- a/llvm/test/CodeGen/AArch64/sve-fixed-length-no-vscale-range.ll
+++ b/llvm/test/CodeGen/AArch64/sve-fixed-length-no-vscale-range.ll
@@ -19,10 +19,8 @@ define <2 x i64> @mul_v2i64(<2 x i64> %op1, <2 x i64> %op2) #0 {
 define <2 x i64> @mul_imm_v2i64(<2 x i64> %op1) #0 {
 ; CHECK-LABEL: mul_imm_v2i64:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    mov z1.d, #123 // =0x7b
-; CHECK-NEXT:    ptrue p0.d, vl2
 ; CHECK-NEXT:    // kill: def $q0 killed $q0 def $z0
-; CHECK-NEXT:    mul z0.d, p0/m, z0.d, z1.d
+; CHECK-NEXT:    mul z0.d, z0.d, #123
 ; CHECK-NEXT:    // kill: def $q0 killed $q0 killed $z0
 ; CHECK-NEXT:    ret
   %res = mul <2 x i64> %op1, splat (i64 123)

--- a/llvm/test/CodeGen/AArch64/sve-fixed-length-no-vscale-range.ll
+++ b/llvm/test/CodeGen/AArch64/sve-fixed-length-no-vscale-range.ll
@@ -16,6 +16,19 @@ define <2 x i64> @mul_v2i64(<2 x i64> %op1, <2 x i64> %op2) #0 {
   ret <2 x i64> %res
 }
 
+define <2 x i64> @mul_imm_v2i64(<2 x i64> %op1) #0 {
+; CHECK-LABEL: mul_imm_v2i64:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    mov z1.d, #123 // =0x7b
+; CHECK-NEXT:    ptrue p0.d, vl2
+; CHECK-NEXT:    // kill: def $q0 killed $q0 def $z0
+; CHECK-NEXT:    mul z0.d, p0/m, z0.d, z1.d
+; CHECK-NEXT:    // kill: def $q0 killed $q0 killed $z0
+; CHECK-NEXT:    ret
+  %res = mul <2 x i64> %op1, splat (i64 123)
+  ret <2 x i64> %res
+}
+
 define <4 x i32> @sdiv_v4i32(<4 x i32> %op1, <4 x i32> %op2) #0 {
 ; CHECK-LABEL: sdiv_v4i32:
 ; CHECK:       // %bb.0:

--- a/llvm/test/CodeGen/AArch64/sve-partial-reduce-dot-product.ll
+++ b/llvm/test/CodeGen/AArch64/sve-partial-reduce-dot-product.ll
@@ -1303,8 +1303,8 @@ entry:
 define <2 x i32> @udot_v16i8tov2i32(<2 x i32> %acc, <16 x i8> %input) "target-features"="+dotprod" {
 ; CHECK-SVE2-LABEL: udot_v16i8tov2i32:
 ; CHECK-SVE2:       // %bb.0: // %entry
-; CHECK-SVE2-NEXT:    movi v2.16b, #1
 ; CHECK-SVE2-NEXT:    fmov d0, d0
+; CHECK-SVE2-NEXT:    mov z2.b, #1 // =0x1
 ; CHECK-SVE2-NEXT:    // kill: def $q1 killed $q1 def $z1
 ; CHECK-SVE2-NEXT:    udot z0.s, z1.b, z2.b
 ; CHECK-SVE2-NEXT:    addp v0.4s, v0.4s, v0.4s
@@ -1313,8 +1313,8 @@ define <2 x i32> @udot_v16i8tov2i32(<2 x i32> %acc, <16 x i8> %input) "target-fe
 ;
 ; CHECK-SVE2-I8MM-LABEL: udot_v16i8tov2i32:
 ; CHECK-SVE2-I8MM:       // %bb.0: // %entry
-; CHECK-SVE2-I8MM-NEXT:    movi v2.16b, #1
 ; CHECK-SVE2-I8MM-NEXT:    fmov d0, d0
+; CHECK-SVE2-I8MM-NEXT:    mov z2.b, #1 // =0x1
 ; CHECK-SVE2-I8MM-NEXT:    // kill: def $q1 killed $q1 def $z1
 ; CHECK-SVE2-I8MM-NEXT:    udot z0.s, z1.b, z2.b
 ; CHECK-SVE2-I8MM-NEXT:    addp v0.4s, v0.4s, v0.4s

--- a/llvm/test/CodeGen/AArch64/vecreduce-add.ll
+++ b/llvm/test/CodeGen/AArch64/vecreduce-add.ll
@@ -4778,7 +4778,7 @@ entry:
 define i64 @extract_scalable(<2 x i32> %0) "target-features"="+sve2" {
 ; CHECK-SD-LABEL: extract_scalable:
 ; CHECK-SD:       // %bb.0:
-; CHECK-SD-NEXT:    movi v1.2s, #1
+; CHECK-SD-NEXT:    mov z1.s, #1 // =0x1
 ; CHECK-SD-NEXT:    ptrue p0.s, vl2
 ; CHECK-SD-NEXT:    // kill: def $d0 killed $d0 def $z0
 ; CHECK-SD-NEXT:    sdivr z0.s, p0/m, z0.s, z1.s


### PR DESCRIPTION
When converting a fixed-length constant splats to scalable vector we can simply regenerate the splat using the target type.