### PR TITLE
[llvm][utils] Handle Issue/PR authors having no display name set

### DIFF
--- a/llvm/utils/git/github-automation.py
+++ b/llvm/utils/git/github-automation.py
@@ -61,13 +61,14 @@ def escape_description(str):
 
 
 def format_author(user) -> str:
-    # login is the account name, which everyone has. name is a full name for
-    # example "First Last", which not everyone has set.
+    # user.login is the account name, which everyone has. In theory it can be None,
+    # perhaps for closed accounts. user.name is a longer display name for example
+    # "First Last", which not everyone has set.
     author = "Author: "
     if user.name is not None:
         author += f"{user.name} ({user.login})"
     else:
-        author += user.login
+        author += f"{user.login}"
     return author
 
 

--- a/llvm/utils/git/github-automation.py
+++ b/llvm/utils/git/github-automation.py
@@ -97,11 +97,6 @@ class IssueSubscriber:
             self.issue.create_comment(comment)
 
         body = escape_description(self.issue.body)
-        if self.issue.user.name is not None:
-            author = f"{self.issue.user.name} ({self.issue.user.login})"
-        else:
-            author = f"{self.issue.user.login}"
-
         comment = f"""
 @llvm/{team.slug}
 

--- a/llvm/utils/git/github-automation.py
+++ b/llvm/utils/git/github-automation.py
@@ -195,7 +195,7 @@ class PRSubscriber:
 {self.COMMENT_TAG}
 {team_mention}
 
-{format_author(self.issue.author)}
+{format_author(self.pr.user)}
 
 <details>
 <summary>Changes</summary>

--- a/llvm/utils/git/github-automation.py
+++ b/llvm/utils/git/github-automation.py
@@ -60,6 +60,17 @@ def escape_description(str):
     return str
 
 
+def format_author(user) -> str:
+    # login is the account name, which everyone has. name is a full name for
+    # example "First Last", which not everyone has set.
+    author = "Author: "
+    if user.name is not None:
+        author += f"{user.name} ({user.login})"
+    else:
+        author += user.login
+    return author
+
+
 class IssueSubscriber:
     @property
     def team_name(self) -> str:
@@ -85,10 +96,15 @@ class IssueSubscriber:
             self.issue.create_comment(comment)
 
         body = escape_description(self.issue.body)
+        if self.issue.user.name is not None:
+            author = f"{self.issue.user.name} ({self.issue.user.login})"
+        else:
+            author = f"{self.issue.user.login}"
+
         comment = f"""
 @llvm/{team.slug}
 
-Author: {self.issue.user.name} ({self.issue.user.login})
+{format_author(self.issue.user)}
 
 <details>
 {body}
@@ -183,7 +199,7 @@ class PRSubscriber:
 {self.COMMENT_TAG}
 {team_mention}
 
-Author: {self.pr.user.name} ({self.pr.user.login})
+{format_author(self.issue.author)}
 
 <details>
 <summary>Changes</summary>


### PR DESCRIPTION
user.login is the account name and user.name is an optional display name (often their full name). I got an email generated from a colleague's PR that said: 
```
Author: None (<their username>)
```

As they hadn't set user.name in their account. Which isn't a problem, but it would be neater if we didn't print None.

So I've added a helper function to handle that. If the user has set both, the output is as it was before, if the user has not, we just show the login name.

The login name can apparently be None too. In that case we'll print "None" for it. This does not seem to be a common case though, and I'm not sure printing anything else would be any more useful.