### PR TITLE
[AMDGPU] Fix missing "---" in MIR test. NFCI.

### DIFF
--- a/llvm/test/CodeGen/AMDGPU/coalesce-copy-to-agpr-to-av-registers.mir
+++ b/llvm/test/CodeGen/AMDGPU/coalesce-copy-to-agpr-to-av-registers.mir
@@ -1137,6 +1137,7 @@ body:             |
 
 ...
 
+---
 name: copy_vgpr32_vgpr64_to_areg96_coalesce_with_av96_shuffle_both_sub
 tracksRegLiveness: true
 body:             |


### PR DESCRIPTION
The only problem this caused was confusing the update script so that it
failed to update checks in the following function.
