### PR TITLE
[Linker] Do not warn on data layout mismatch when the source module has none

### DIFF
--- a/llvm/lib/Linker/IRMover.cpp
+++ b/llvm/lib/Linker/IRMover.cpp
@@ -1500,7 +1500,11 @@ Error IRLinker::run() {
     EnableDLWarning = !(SrcHasLibDeviceTriple && SrcHasLibDeviceDL);
   }
 
-  if (EnableDLWarning && (SrcM->getDataLayout() != DstM.getDataLayout())) {
+  // A source module without a data layout has made no ABI commitments, so
+  // there is nothing to conflict with; the destination's layout simply
+  // applies, matching how an empty source target triple is treated below.
+  if (EnableDLWarning && !SrcM->getDataLayoutStr().empty() &&
+      (SrcM->getDataLayout() != DstM.getDataLayout())) {
     emitWarning("Linking two modules of different data layouts: '" +
                 SrcM->getModuleIdentifier() + "' is '" +
                 SrcM->getDataLayoutStr() + "' whereas '" +

--- a/llvm/test/Linker/Inputs/datalayout-empty.ll
+++ b/llvm/test/Linker/Inputs/datalayout-empty.ll
@@ -1,0 +1,3 @@
+define void @from_empty_layout_module() {
+  ret void
+}

--- a/llvm/test/Linker/datalayout.ll
+++ b/llvm/test/Linker/datalayout.ll
@@ -6,9 +6,19 @@
 ; RUN: llvm-link %s %S/Inputs/datalayout-b.ll -S -o - 2>%t.b.err
 ; RUN: cat %t.b.err | FileCheck --check-prefix=WARN-B %s
 
+; A module with no data layout has made no ABI commitments, so linking it
+; into a module that has one should not warn, matching how an empty source
+; target triple is treated.
+;   Ensure t.c.err is non-empty.
+; RUN: echo foo > %t.c.err
+; RUN: llvm-link %S/Inputs/datalayout-b.ll %S/Inputs/datalayout-empty.ll -S -o - 2>>%t.c.err
+; RUN: FileCheck --check-prefix=WARN-C %s < %t.c.err
+
 target datalayout = "e"
 
 
 ; WARN-A-NOT: warning
 
 ; WARN-B: warning: Linking two modules of different data layouts:
+
+; WARN-C-NOT: warning

--- a/llvm/test/tools/llvm-link/archive-non-bitcode.test
+++ b/llvm/test/tools/llvm-link/archive-non-bitcode.test
@@ -3,7 +3,7 @@
 # RUN: echo "This is not a bitcode file" > %t.not_bitcode.txt
 # RUN: llvm-ar cr %t.a %t.f.bc %t.not_bitcode.txt %t.g.bc
 # RUN: llvm-ar cr --format=gnu %t.empty.lib
-# RUN: llvm-link -ignore-non-bitcode %t.a %t.empty.lib -o %t.linked.bc 2>&1 | FileCheck --check-prefix CHECK_IGNORE_NON_BITCODE %s
+# RUN: llvm-link -ignore-non-bitcode %t.a %t.empty.lib -o %t.linked.bc 2>&1 | FileCheck --allow-empty --check-prefix CHECK_IGNORE_NON_BITCODE %s
 # RUN: not llvm-link %t.a %t.empty.lib -o %t.linked2.bc 2>&1 | FileCheck --check-prefix CHECK_ERROR_BITCODE %s
 
 # CHECK_ERROR_BITCODE: error: member of archive is not a bitcode file


### PR DESCRIPTION
When a source module declares no data layout, linking it into a module that has one emits "Linking two modules of different data layouts". A module with no data layout has made no ABI commitments, so there is nothing to conflict with. The empty target triple case is already handled this way, and an empty destination layout already silently inherits from the source.

This shows up in practice when linking archives whose members are empty modules, for example the empty device bitcode that clang's static device library handling extracts from host-only archives during HIP -fgpu-rdc links (CHIP-SPV/chipStar#525).

Skip the warning when the source module's data layout string is empty, matching the existing empty-triple behavior.
