### PR TITLE
[Offload] Add CMake alias for CI

### DIFF
--- a/offload/CMakeLists.txt
+++ b/offload/CMakeLists.txt
@@ -403,3 +403,16 @@ if(OFFLOAD_INCLUDE_TESTS)
   add_subdirectory(test)
   add_subdirectory(unittests)
 endif()
+
+# Expose a high-level target to build the offloading runtimes.
+# This is used in pre-commit CI to run a build of the libraries without requiring
+# to invoke the check-* targets.
+add_custom_target(offload
+  COMMENT "Building offloading runtime libraries and plugins"
+)
+if(TARGET omptarget)
+  add_dependencies(offload omptarget)
+endif()
+if(TARGET LLVMOffload)
+  add_dependencies(offload LLVMOffload)
+endif()


### PR DESCRIPTION
In the pre-merge CI we need a top-level visible target that can be used to build offload, i.e., libomptarget and LLVMOffload.

I don't know if this is an acceptable approach, and I am mostly looking for feedback. It seems to do what I intend it to do.

The related PR to include offload into pre-merge CI is here: https://github.com/llvm/llvm-project/pull/174955