### PR TITLE
[libc] Use the proper name for the 'llvm-gpu-loader'

### DIFF
--- a/libc/cmake/modules/prepare_libc_gpu_build.cmake
+++ b/libc/cmake/modules/prepare_libc_gpu_build.cmake
@@ -70,20 +70,10 @@ set(LIBC_GPU_TARGET_ARCHITECTURE "${gpu_test_architecture}")
 set(LIBC_GPU_LOADER_EXECUTABLE "" CACHE STRING "Executable for the GPU loader.")
 if(LIBC_GPU_LOADER_EXECUTABLE)
   set(gpu_loader_executable ${LIBC_GPU_LOADER_EXECUTABLE})
-elseif(LIBC_TARGET_ARCHITECTURE_IS_AMDGPU)
-  find_program(LIBC_AMDHSA_LOADER_EXECUTABLE
-               NAMES amdhsa-loader NO_DEFAULT_PATH
+else()
+  find_program(gpu_loader_executable
+               NAMES llvm-gpu-loader NO_DEFAULT_PATH
                PATHS ${LLVM_BINARY_DIR}/bin ${compiler_path})
-  if(LIBC_AMDHSA_LOADER_EXECUTABLE)
-    set(gpu_loader_executable ${LIBC_AMDHSA_LOADER_EXECUTABLE})
-  endif()
-elseif(LIBC_TARGET_ARCHITECTURE_IS_NVPTX)
-  find_program(LIBC_NVPTX_LOADER_EXECUTABLE
-               NAMES nvptx-loader NO_DEFAULT_PATH
-               PATHS ${LLVM_BINARY_DIR}/bin ${compiler_path})
-  if(LIBC_NVPTX_LOADER_EXECUTABLE)
-    set(gpu_loader_executable ${LIBC_NVPTX_LOADER_EXECUTABLE})
-  endif()
 endif()
 if(NOT TARGET libc.utils.gpu.loader AND gpu_loader_executable)
   add_custom_target(libc.utils.gpu.loader)


### PR DESCRIPTION
Summary:
This used to be two separate executables but was merged awhile back. The
LLVM libc code was never updated to use the new tool name and a recent
refactoring unintentionally removed the symlinks. Just look for
`llvm-gpu-loader`.
