### PR TITLE
[clang][AST] Fix assertion in `getFullyQualifiedType` for AutoType

### DIFF
--- a/clang/lib/AST/QualTypeNames.cpp
+++ b/clang/lib/AST/QualTypeNames.cpp
@@ -369,6 +369,11 @@ NestedNameSpecifier createNestedNameSpecifier(const ASTContext &Ctx,
 /// versions of any template parameters.
 QualType getFullyQualifiedType(QualType QT, const ASTContext &Ctx,
                                bool WithGlobalNsPrefix) {
+  // Use the underlying deduced type for AutoType
+  if (const auto *AT = dyn_cast<AutoType>(QT.getTypePtr()))
+    if (AT->isDeduced())
+      QT = AT->getDeducedType();
+
   // In case of myType* we need to strip the pointer first, fully
   // qualify and attach the pointer once again.
   if (isa<PointerType>(QT.getTypePtr())) {

--- a/clang/test/Interpreter/pretty-print.cpp
+++ b/clang/test/Interpreter/pretty-print.cpp
@@ -60,6 +60,15 @@ struct S5 { int foo() { return 42; }};
 &S5::foo
 // CHECK-NEXT: (int (S5::*)()) Function @0x{{[0-9a-f]+}}
 
+// Namespaced types deduced via auto
+namespace Outer { struct Foo {}; }
+auto x = Outer::Foo(); x
+// CHECK-NEXT: (Outer::Foo &) @0x{{[0-9a-f]+}}
+
+namespace Outer { template<class T> struct Bar {}; }
+auto y = Outer::Bar<int>(); y
+// CHECK-NEXT: (Outer::Bar<int> &) @0x{{[0-9a-f]+}}
+
 // int i = 12;
 // int &iref = i;
 // iref


### PR DESCRIPTION
getFullyQualifiedType() asserts "Unhandled type node" when the input QualType is an AutoType.

This was exposed by clang-repl's value printer:
```
clang-repl> namespace N { struct D {}; }
clang-repl> auto x = N::D(); x // asserts
```

Strip AutoType early before the type-specific handling.