### PR TITLE
[llvm][DebugInfo] BTFParser use formatv instead of format

### DIFF
--- a/llvm/lib/DebugInfo/BTF/BTFParser.cpp
+++ b/llvm/lib/DebugInfo/BTF/BTFParser.cpp
@@ -15,6 +15,7 @@
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/Support/Endian.h"
 #include "llvm/Support/Errc.h"
+#include "llvm/Support/FormatVariadic.h"
 
 #define DEBUG_TYPE "debug-info-btf-parser"
 
@@ -679,7 +680,8 @@ void BTFParser::symbolize(const BTF::BPFFieldReloc *Reloc,
     if (SpecStr.empty())
       break;
     if (SpecStr[0] != ':')
-      return Fail(format("unexpected spec string delimiter: '%c'", SpecStr[0]));
+      return Fail(
+          formatv("unexpected spec string delimiter: '{0}'", SpecStr[0]));
     SpecStr = SpecStr.substr(1);
   }
 
@@ -689,7 +691,7 @@ void BTFParser::symbolize(const BTF::BPFFieldReloc *Reloc,
   uint32_t CurId = Reloc->TypeID;
   const BTF::CommonType *Type = findType(CurId);
   if (!Type)
-    return Fail(format("unknown type id: %d", CurId));
+    return Fail(formatv("unknown type id: {0:d}", CurId));
 
   Stream << " [" << CurId << "]";
 
@@ -703,7 +705,7 @@ void BTFParser::symbolize(const BTF::BPFFieldReloc *Reloc,
     CurId = Type->Type;
     const BTF::CommonType *NextType = findType(CurId);
     if (!NextType)
-      return Fail(format("unknown type id: %d in modifiers chain", CurId));
+      return Fail(formatv("unknown type id: {0:d} in modifiers chain", CurId));
     Type = NextType;
   }
   // Print the type name to `Stream`.
@@ -767,19 +769,19 @@ void BTFParser::symbolize(const BTF::BPFFieldReloc *Reloc,
     uint32_t Idx = RawSpec[0];
     if (auto *T = dyn_cast<BTF::EnumType>(Type)) {
       if (T->values().size() <= Idx)
-        return Fail(format("bad value index: %d", Idx));
+        return Fail(formatv("bad value index: {0:d}", Idx));
       const BTF::BTFEnum &E = T->values()[Idx];
       NameOff = E.NameOff;
       Val = E.Val;
     } else if (auto *T = dyn_cast<BTF::Enum64Type>(Type)) {
       if (T->values().size() <= Idx)
-        return Fail(format("bad value index: %d", Idx));
+        return Fail(formatv("bad value index: {0:d}", Idx));
       const BTF::BTFEnum64 &E = T->values()[Idx];
       NameOff = E.NameOff;
       Val = (uint64_t)E.Val_Hi32 << 32u | E.Val_Lo32;
     } else {
-      return Fail(format("unexpected type kind for enum relocation: %d",
-                         Type->getKind()));
+      return Fail(formatv("unexpected type kind for enum relocation: {0:d}",
+                          Type->getKind()));
     }
 
     Stream << StrOrAnon({*this, NameOff, Idx});
@@ -824,9 +826,9 @@ void BTFParser::symbolize(const BTF::BPFFieldReloc *Reloc,
 
       if (auto *T = dyn_cast<BTF::StructType>(Type)) {
         if (T->getVlen() <= Idx)
-          return Fail(
-              format("member index %d for spec sub-string %d is out of range",
-                     Idx, I));
+          return Fail(formatv(
+              "member index {0:d} for spec sub-string {1:d} is out of range",
+              Idx, I));
 
         const BTF::BTFMember &Member = T->members()[Idx];
         if (I != 1 || RawSpec[0] != 0)
@@ -834,18 +836,20 @@ void BTFParser::symbolize(const BTF::BPFFieldReloc *Reloc,
         Stream << StrOrAnon({*this, Member.NameOff, Idx});
         Type = findType(Member.Type);
         if (!Type)
-          return Fail(format("unknown member type id %d for spec sub-string %d",
-                             Member.Type, I));
+          return Fail(
+              formatv("unknown member type id {0:d} for spec sub-string {1:d}",
+                      Member.Type, I));
       } else if (auto *T = dyn_cast<BTF::ArrayType>(Type)) {
         Stream << "[" << Idx << "]";
         Type = findType(T->getArray().ElemType);
         if (!Type)
           return Fail(
-              format("unknown element type id %d for spec sub-string %d",
-                     T->getArray().ElemType, I));
+              formatv("unknown element type id {0:d} for spec sub-string {1:d}",
+                      T->getArray().ElemType, I));
       } else {
-        return Fail(format("unexpected type kind %d for spec sub-string %d",
-                           Type->getKind(), I));
+        return Fail(
+            formatv("unexpected type kind {0:d} for spec sub-string {1:d}",
+                    Type->getKind(), I));
       }
     }
 
@@ -853,5 +857,5 @@ void BTFParser::symbolize(const BTF::BPFFieldReloc *Reloc,
     return;
   }
 
-  return Fail(format("unknown relocation kind: %d", Reloc->RelocKind));
+  return Fail(formatv("unknown relocation kind: {0:d}", Reloc->RelocKind));
 }


### PR DESCRIPTION
This relates to #35980.