### PR TITLE
[libc] Add hdrgen tests to the main libc test target

### DIFF
--- a/libc/test/CMakeLists.txt
+++ b/libc/test/CMakeLists.txt
@@ -3,6 +3,10 @@ add_custom_target(libc-unit-tests)
 add_custom_target(libc-hermetic-tests)
 add_dependencies(check-libc libc-unit-tests libc-hermetic-tests)
 
+if (TARGET check-hdrgen)
+  add_dependencies(check-libc check-hdrgen)
+endif()
+
 add_custom_target(exhaustive-check-libc)
 add_custom_target(libc-long-running-tests)
 


### PR DESCRIPTION
The hdrgen tests are small and quick to run, so there's little harm in running them under the main test target `check-libc`. Consequently they will be run by the CI jobs.