### PR TITLE
[llvm-debuginfo-analyzer] Refactor type assignment for locals

### DIFF
--- a/llvm/include/llvm/DebugInfo/LogicalView/Readers/LVCodeViewVisitor.h
+++ b/llvm/include/llvm/DebugInfo/LogicalView/Readers/LVCodeViewVisitor.h
@@ -175,6 +175,8 @@ class LVSymbolVisitor final : public SymbolVisitorCallbacks {
     Symbol->setIsVariable();
   }
 
+  void setLocalVariableType(LVSymbol *Symbol, TypeIndex TI);
+
 public:
   LVSymbolVisitor(LVCodeViewReader *Reader, ScopedPrinter &W,
                   LVLogicalVisitor *LogicalVisitor,

--- a/llvm/lib/DebugInfo/LogicalView/Readers/LVCodeViewVisitor.cpp
+++ b/llvm/lib/DebugInfo/LogicalView/Readers/LVCodeViewVisitor.cpp
@@ -834,23 +834,7 @@ Error LVSymbolVisitor::visitKnownRecord(CVSymbol &Record,
     if (Symbol->getIsParameter())
       Symbol->setTag(dwarf::DW_TAG_formal_parameter);
 
-    LVElement *Element = LogicalVisitor->getElement(StreamTPI, Local.Type);
-    if (Element && Element->getIsScoped()) {
-      // We have a local type. Find its parent function.
-      LVScope *Parent = Symbol->getFunctionParent();
-      // The element representing the type has been already finalized. If
-      // the type is an aggregate type, its members have been already added.
-      // As the type is local, its level will be changed.
-
-      // FIXME: Currently the algorithm used to scope lambda functions is
-      // incorrect. Before we allocate the type at this scope, check if is
-      // already allocated in other scope.
-      if (!Element->getParentScope()) {
-        Parent->addElement(Element);
-        Element->updateLevel(Parent);
-      }
-    }
-    Symbol->setType(Element);
+    setLocalVariableType(Symbol, Local.Type);
   }
 
   return Error::success();
@@ -884,23 +868,7 @@ Error LVSymbolVisitor::visitKnownRecord(CVSymbol &Record,
     if (Symbol->getIsParameter())
       Symbol->setTag(dwarf::DW_TAG_formal_parameter);
 
-    LVElement *Element = LogicalVisitor->getElement(StreamTPI, Local.Type);
-    if (Element && Element->getIsScoped()) {
-      // We have a local type. Find its parent function.
-      LVScope *Parent = Symbol->getFunctionParent();
-      // The element representing the type has been already finalized. If
-      // the type is an aggregate type, its members have been already added.
-      // As the type is local, its level will be changed.
-
-      // FIXME: Currently the algorithm used to scope lambda functions is
-      // incorrect. Before we allocate the type at this scope, check if is
-      // already allocated in other scope.
-      if (!Element->getParentScope()) {
-        Parent->addElement(Element);
-        Element->updateLevel(Parent);
-      }
-    }
-    Symbol->setType(Element);
+    setLocalVariableType(Symbol, Local.Type);
   }
 
   return Error::success();
@@ -935,23 +903,7 @@ Error LVSymbolVisitor::visitKnownRecord(CVSymbol &Record,
     if (Symbol->getIsParameter())
       Symbol->setTag(dwarf::DW_TAG_formal_parameter);
 
-    LVElement *Element = LogicalVisitor->getElement(StreamTPI, Local.Type);
-    if (Element && Element->getIsScoped()) {
-      // We have a local type. Find its parent function.
-      LVScope *Parent = Symbol->getFunctionParent();
-      // The element representing the type has been already finalized. If
-      // the type is an aggregate type, its members have been already added.
-      // As the type is local, its level will be changed.
-
-      // FIXME: Currently the algorithm used to scope lambda functions is
-      // incorrect. Before we allocate the type at this scope, check if is
-      // already allocated in other scope.
-      if (!Element->getParentScope()) {
-        Parent->addElement(Element);
-        Element->updateLevel(Parent);
-      }
-    }
-    Symbol->setType(Element);
+    setLocalVariableType(Symbol, Local.Type);
   }
 
   return Error::success();
@@ -1485,17 +1437,7 @@ Error LVSymbolVisitor::visitKnownRecord(CVSymbol &Record, LocalSym &Local) {
     if (Symbol->getIsParameter())
       Symbol->setTag(dwarf::DW_TAG_formal_parameter);
 
-    LVElement *Element = LogicalVisitor->getElement(StreamTPI, Local.Type);
-    if (Element && Element->getIsScoped()) {
-      // We have a local type. Find its parent function.
-      LVScope *Parent = Symbol->getFunctionParent();
-      // The element representing the type has been already finalized. If
-      // the type is an aggregate type, its members have been already added.
-      // As the type is local, its level will be changed.
-      Parent->addElement(Element);
-      Element->updateLevel(Parent);
-    }
-    Symbol->setType(Element);
+    setLocalVariableType(Symbol, Local.Type);
 
     // The CodeView records (S_DEFFRAME_*) describing debug location for
     // this symbol, do not have any direct reference to it. Those records
@@ -1769,6 +1711,26 @@ Error LVSymbolVisitor::visitKnownRecord(CVSymbol &Record, CallerSym &Caller) {
     }
   });
   return Error::success();
+}
+
+void LVSymbolVisitor::setLocalVariableType(LVSymbol *Symbol, TypeIndex TI) {
+  LVElement *Element = LogicalVisitor->getElement(StreamTPI, TI);
+  if (Element && Element->getIsScoped()) {
+    // We have a local type. Find its parent function.
+    LVScope *Parent = Symbol->getFunctionParent();
+    // The element representing the type has been already finalized. If
+    // the type is an aggregate type, its members have been already added.
+    // As the type is local, its level will be changed.
+
+    // FIXME: Currently the algorithm used to scope lambda functions is
+    // incorrect. Before we allocate the type at this scope, check if is
+    // already allocated in other scope.
+    if (!Element->getParentScope()) {
+      Parent->addElement(Element);
+      Element->updateLevel(Parent);
+    }
+  }
+  Symbol->setType(Element);
 }
 
 #undef DEBUG_TYPE


### PR DESCRIPTION
From https://github.com/llvm/llvm-project/pull/183172#discussion_r2918524548: Assigning and scoping the type of a local variable was duplicated in `S_BPREL32`, `S_REGREL32` (and now) `S_REGREL32_INDIR`. I moved these into a separate method in this PR.

`S_LOCAL` shares a similar part, but not the exact one. There, it's not checked if the type element has a parent scope (`Element->getParentScope()`). As all these records represent a local variable (or a parameter/this), I figured this was an oversight.