### PR TITLE
[MLIR][Python] Add type filter to walk() binding and add get_ops_of_type() utility

### DIFF
--- a/mlir/include/mlir/Bindings/Python/IRCore.h
+++ b/mlir/include/mlir/Bindings/Python/IRCore.h
@@ -600,8 +600,7 @@ public:
   void walk(std::function<PyWalkResult(MlirOperation)> callback,
             PyWalkOrder walkOrder);
 
-  // Wrap the walk method with a type filter. Works same as op.walk([](OpClass
-  // op) { ... } );
+  // Wrap the walk method with a type filter.
   void walkOfType(nanobind::object opClass,
                   std::function<PyWalkResult(MlirOperation)> callback,
                   PyWalkOrder walkOrder);

--- a/mlir/include/mlir/Bindings/Python/IRCore.h
+++ b/mlir/include/mlir/Bindings/Python/IRCore.h
@@ -600,6 +600,12 @@ public:
   void walk(std::function<PyWalkResult(MlirOperation)> callback,
             PyWalkOrder walkOrder);
 
+  // Wrap the walk method with a type filter. Works same as op.walk([](OpClass
+  // op) { ... } );
+  void walkOfType(nanobind::object opClass,
+                  std::function<PyWalkResult(MlirOperation)> callback,
+                  PyWalkOrder walkOrder);
+
   /// Moves the operation before or after the other operation.
   void moveAfter(PyOperationBase &other);
   void moveBefore(PyOperationBase &other);

--- a/mlir/include/mlir/Bindings/Python/IRCore.h
+++ b/mlir/include/mlir/Bindings/Python/IRCore.h
@@ -600,11 +600,6 @@ public:
   void walk(std::function<PyWalkResult(MlirOperation)> callback,
             PyWalkOrder walkOrder);
 
-  // Wrap the walk method with a type filter.
-  void walkOfType(nanobind::object opClass,
-                  std::function<PyWalkResult(MlirOperation)> callback,
-                  PyWalkOrder walkOrder);
-
   /// Moves the operation before or after the other operation.
   void moveAfter(PyOperationBase &other);
   void moveBefore(PyOperationBase &other);

--- a/mlir/lib/Bindings/Python/IRCore.cpp
+++ b/mlir/lib/Bindings/Python/IRCore.cpp
@@ -1145,20 +1145,6 @@ void PyOperationBase::walk(std::function<PyWalkResult(MlirOperation)> callback,
   }
 }
 
-void PyOperationBase::walkOfType(
-    nb::object opClass, std::function<PyWalkResult(MlirOperation)> callback,
-    PyWalkOrder walkOrder) {
-
-  auto filtered = [&](MlirOperation mlirOp) -> PyWalkResult {
-    nb::object opview = nb::cast(mlirOp).attr("opview");
-    if (nb::isinstance(opview, opClass)) {
-      return callback(mlirOp);
-    };
-    return PyWalkResult::Advance;
-  };
-  walk(filtered, walkOrder);
-}
-
 nb::object PyOperationBase::getAsm(bool binary,
                                    std::optional<int64_t> largeElementsLimit,
                                    std::optional<int64_t> largeResourceLimit,
@@ -3941,32 +3927,39 @@ void populateIRCore(nb::module_ &m) {
 
             Note:
               After erasing, any Python references to the operation become invalid.)")
-      .def("walk", &PyOperationBase::walk, "callback"_a,
-           "walk_order"_a = PyWalkOrder::PostOrder,
-           // clang-format off
-          nb::sig("def walk(self, callback: Callable[[Operation], WalkResult], walk_order: WalkOrder = ...) -> None"),
-           // clang-format on
-           R"(
+      .def(
+          "walk",
+          [](PyOperationBase &self,
+             std::function<PyWalkResult(MlirOperation)> callback,
+             std::optional<nb::object> opClass, PyWalkOrder walkOrder) {
+            if (opClass) {
+              self.walk(
+                  [&](MlirOperation mlirOp) -> PyWalkResult {
+                    nb::object opview = nb::cast(mlirOp).attr("opview");
+                    if (nb::isinstance(opview, *opClass))
+                      return callback(mlirOp);
+                    return PyWalkResult::Advance;
+                  },
+                  walkOrder);
+            } else {
+              self.walk(callback, walkOrder);
+            }
+          },
+          "callback"_a, "op_class"_a = nb::none(),
+          "walk_order"_a = PyWalkOrder::PostOrder,
+          // clang-format off
+           nb::sig("def walk(self, callback: Callable[[Operation], WalkResult], op_class: type[OpView] | None = None, walk_order: WalkOrder = WalkOrder.POST_ORDER) -> None"),
+          // clang-format on
+          R"(
              Walks the operation tree with a callback function.
+
+             If op_class is provided, the callback is only invoked on operations
+             of that type; all other operations are skipped silently.
 
              Args:
                callback: A callable that takes an Operation and returns a WalkResult.
-               walk_order: The order of traversal (PRE_ORDER or POST_ORDER).)")
-      .def("walk_of_type", &PyOperationBase::walkOfType, "op_class"_a,
-           "callback"_a, "walk_order"_a = PyWalkOrder::PostOrder,
-           // clang-format off
-     nb::sig("def walk_of_type(self, op_class: type[OpView], callback: Callable[[Operation], WalkResult], walk_order: WalkOrder) -> None"),
-           // clang-format on
-           R"(
-              Walks the operation tree, invoking the callback only on operations of the specified type.
-
-              Args:
-                op_class: The operation type to match.
-                callback: A callable that takes an Operation and returns a WalkResult.
-                walk_order: The traversal order (PRE_ORDER or POST_ORDER).
-
-              For example, op.walk_of_type(arith.AddIOp, callback) walks the operation tree
-              and invokes callback only on arith.AddIOp operations.)");
+               op_class: If provided, only operations of this type are passed to the callback.
+               walk_order: The order of traversal (PRE_ORDER or POST_ORDER).)");
 
   nb::class_<PyOperation, PyOperationBase>(m, "Operation")
       .def_static(

--- a/mlir/lib/Bindings/Python/IRCore.cpp
+++ b/mlir/lib/Bindings/Python/IRCore.cpp
@@ -3935,7 +3935,9 @@ void populateIRCore(nb::module_ &m) {
             if (opClass) {
               self.walk(
                   [&](MlirOperation mlirOp) -> PyWalkResult {
-                    nb::object opview = nb::cast(mlirOp).attr("opview");
+                     nb::object opview = PyOperation::forOperation(
+                         self.getOperation().getContext(), mlirOp)
+                         ->createOpView();
                     if (nb::isinstance(opview, *opClass))
                       return callback(mlirOp);
                     return PyWalkResult::Advance;

--- a/mlir/lib/Bindings/Python/IRCore.cpp
+++ b/mlir/lib/Bindings/Python/IRCore.cpp
@@ -2721,7 +2721,7 @@ MlirLocation tracebackToLocation(MlirContext ctx) {
     if (!PyGlobals::get().getTracebackLoc().isUserTracebackFilename(fileName))
       continue;
 
-      // co_qualname and PyCode_Addr2Location added in py3.11
+    // co_qualname and PyCode_Addr2Location added in py3.11
 #if PY_VERSION_HEX < 0x030B00F0
     std::string name =
         nb::cast<std::string>(nb::borrow<nb::str>(code->co_name));

--- a/mlir/lib/Bindings/Python/IRCore.cpp
+++ b/mlir/lib/Bindings/Python/IRCore.cpp
@@ -3949,7 +3949,7 @@ void populateIRCore(nb::module_ &m) {
           "callback"_a, "walk_order"_a = PyWalkOrder::PostOrder,
           "op_class"_a = nb::none(),
           // clang-format off
-           nb::sig("def walk(self, callback: Callable[[Operation], WalkResult], walk_order: WalkOrder = WalkOrder.POST_ORDER, op_class: type[OpView] | None = None) -> None"),
+           nb::sig("def walk(self, callback: Callable[[Operation], WalkResult], walk_order: WalkOrder = ..., op_class: type[OpView] | None = None) -> None"),
           // clang-format on
           R"(
              Walks the operation tree with a callback function.

--- a/mlir/lib/Bindings/Python/IRCore.cpp
+++ b/mlir/lib/Bindings/Python/IRCore.cpp
@@ -2721,7 +2721,7 @@ MlirLocation tracebackToLocation(MlirContext ctx) {
     if (!PyGlobals::get().getTracebackLoc().isUserTracebackFilename(fileName))
       continue;
 
-    // co_qualname and PyCode_Addr2Location added in py3.11
+      // co_qualname and PyCode_Addr2Location added in py3.11
 #if PY_VERSION_HEX < 0x030B00F0
     std::string name =
         nb::cast<std::string>(nb::borrow<nb::str>(code->co_name));

--- a/mlir/lib/Bindings/Python/IRCore.cpp
+++ b/mlir/lib/Bindings/Python/IRCore.cpp
@@ -3935,9 +3935,10 @@ void populateIRCore(nb::module_ &m) {
             if (opClass) {
               self.walk(
                   [&](MlirOperation mlirOp) -> PyWalkResult {
-                     nb::object opview = PyOperation::forOperation(
-                         self.getOperation().getContext(), mlirOp)
-                         ->createOpView();
+                    nb::object opview =
+                        PyOperation::forOperation(
+                            self.getOperation().getContext(), mlirOp)
+                            ->createOpView();
                     if (nb::isinstance(opview, *opClass))
                       return callback(mlirOp);
                     return PyWalkResult::Advance;

--- a/mlir/lib/Bindings/Python/IRCore.cpp
+++ b/mlir/lib/Bindings/Python/IRCore.cpp
@@ -3931,27 +3931,25 @@ void populateIRCore(nb::module_ &m) {
           "walk",
           [](PyOperationBase &self,
              std::function<PyWalkResult(MlirOperation)> callback,
-             std::optional<nb::object> opClass, PyWalkOrder walkOrder) {
-            if (opClass) {
-              self.walk(
-                  [&](MlirOperation mlirOp) -> PyWalkResult {
-                    nb::object opview =
-                        PyOperation::forOperation(
-                            self.getOperation().getContext(), mlirOp)
-                            ->createOpView();
-                    if (nb::isinstance(opview, *opClass))
-                      return callback(mlirOp);
-                    return PyWalkResult::Advance;
-                  },
-                  walkOrder);
-            } else {
-              self.walk(callback, walkOrder);
-            }
+             PyWalkOrder walkOrder, std::optional<nb::object> opClass) {
+            if (!opClass)
+              return self.walk(callback, walkOrder);
+            self.walk(
+                [&](MlirOperation mlirOp) -> PyWalkResult {
+                  nb::object opview =
+                      PyOperation::forOperation(
+                          self.getOperation().getContext(), mlirOp)
+                          ->createOpView();
+                  if (nb::isinstance(opview, *opClass))
+                    return callback(mlirOp);
+                  return PyWalkResult::Advance;
+                },
+                walkOrder);
           },
-          "callback"_a, "op_class"_a = nb::none(),
-          "walk_order"_a = PyWalkOrder::PostOrder,
+          "callback"_a, "walk_order"_a = PyWalkOrder::PostOrder,
+          "op_class"_a = nb::none(),
           // clang-format off
-           nb::sig("def walk(self, callback: Callable[[Operation], WalkResult], op_class: type[OpView] | None = None, walk_order: WalkOrder = WalkOrder.POST_ORDER) -> None"),
+           nb::sig("def walk(self, callback: Callable[[Operation], WalkResult], walk_order: WalkOrder = WalkOrder.POST_ORDER, op_class: type[OpView] | None = None) -> None"),
           // clang-format on
           R"(
              Walks the operation tree with a callback function.
@@ -3961,8 +3959,8 @@ void populateIRCore(nb::module_ &m) {
 
              Args:
                callback: A callable that takes an Operation and returns a WalkResult.
-               op_class: If provided, only operations of this type are passed to the callback.
-               walk_order: The order of traversal (PRE_ORDER or POST_ORDER).)");
+               walk_order: The order of traversal (PRE_ORDER or POST_ORDER).
+               op_class: If provided, only operations of this type are passed to the callback.)");
 
   nb::class_<PyOperation, PyOperationBase>(m, "Operation")
       .def_static(

--- a/mlir/lib/Bindings/Python/IRCore.cpp
+++ b/mlir/lib/Bindings/Python/IRCore.cpp
@@ -1145,6 +1145,20 @@ void PyOperationBase::walk(std::function<PyWalkResult(MlirOperation)> callback,
   }
 }
 
+void PyOperationBase::walkOfType(
+    nb::object opClass, std::function<PyWalkResult(MlirOperation)> callback,
+    PyWalkOrder walkOrder) {
+
+  auto filtered = [&](MlirOperation mlirOp) -> PyWalkResult {
+    nb::object opview = nb::cast(mlirOp).attr("opview");
+    if (nb::isinstance(opview, opClass)) {
+      return callback(mlirOp);
+    };
+    return PyWalkResult::Advance;
+  };
+  walk(filtered, walkOrder);
+}
+
 nb::object PyOperationBase::getAsm(bool binary,
                                    std::optional<int64_t> largeElementsLimit,
                                    std::optional<int64_t> largeResourceLimit,
@@ -2707,7 +2721,7 @@ MlirLocation tracebackToLocation(MlirContext ctx) {
     if (!PyGlobals::get().getTracebackLoc().isUserTracebackFilename(fileName))
       continue;
 
-    // co_qualname and PyCode_Addr2Location added in py3.11
+      // co_qualname and PyCode_Addr2Location added in py3.11
 #if PY_VERSION_HEX < 0x030B00F0
     std::string name =
         nb::cast<std::string>(nb::borrow<nb::str>(code->co_name));
@@ -3937,7 +3951,22 @@ void populateIRCore(nb::module_ &m) {
 
              Args:
                callback: A callable that takes an Operation and returns a WalkResult.
-               walk_order: The order of traversal (PRE_ORDER or POST_ORDER).)");
+               walk_order: The order of traversal (PRE_ORDER or POST_ORDER).)")
+      .def("walk_of_type", &PyOperationBase::walkOfType, "op_class"_a,
+           "callback"_a, "walk_order"_a = PyWalkOrder::PostOrder,
+           // clang-format off
+     nb::sig("def walk_of_type(self, op_class: type[OpView], callback: Callable[[Operation], WalkResult], walk_order: WalkOrder) -> None"),
+           // clang-format on
+           R"(
+              Walks the operation tree, invoking the callback only on operations of the specified type.
+
+              Args:
+                op_class: The operation type to match.
+                callback: A callable that takes an Operation and returns a WalkResult.
+                walk_order: The traversal order (PRE_ORDER or POST_ORDER).
+
+              For example, op.walk_of_type(arith.AddIOp, callback) walks the operation tree
+              and invokes callback only on arith.AddIOp operations.)");
 
   nb::class_<PyOperation, PyOperationBase>(m, "Operation")
       .def_static(

--- a/mlir/python/mlir/ir.py
+++ b/mlir/python/mlir/ir.py
@@ -48,7 +48,6 @@ def get_parent_of_type(op: OpView | Operation, op_class: type[OpView]) -> OpView
 def get_ops_of_type(root: OpView | Operation | Module, op_class: type[OpView]) -> list[OpView]:
     """Return all operations of the given type in the operation tree.
 
-
     Args:
       root: The operation or module to start traversing from.
       op_class: The OpView subclass to visit for (e.g. func.FuncOp).

--- a/mlir/python/mlir/ir.py
+++ b/mlir/python/mlir/ir.py
@@ -46,13 +46,14 @@ def get_parent_of_type(op: OpView | Operation, op_class: type[OpView]) -> OpView
 
 
 def get_ops_of_type(
-    root: OpView | Operation | Module, op_class: type[OpView]
+    root: OpView | Operation | Module, op_class: type[OpView] | None = None
 ) -> list[OpView]:
     """Return all operations of the given type in the operation tree.
 
     Args:
       root: The operation or module to start traversing from.
-      op_class: The OpView subclass to visit for (e.g. func.FuncOp).
+      op_class: The OpView subclass to filter by (e.g. func.FuncOp). If None,
+        collects all operations in the tree.
 
     Returns:
       A list of operations of the given type.

--- a/mlir/python/mlir/ir.py
+++ b/mlir/python/mlir/ir.py
@@ -45,6 +45,26 @@ def get_parent_of_type(op: OpView | Operation, op_class: type[OpView]) -> OpView
     return None
 
 
+def get_ops_of_type(root: OpView | Operation | Module, op_class: type[OpView]) -> list[OpView]:
+    """Return all operations of the given type in the operation tree.
+
+
+    Args:
+      root: The operation or module to start traversing from.
+      op_class: The OpView subclass to visit for (e.g. func.FuncOp).
+
+    Returns:
+      A list of operations of the given type.
+    """
+    op = root.operation if isinstance(root, Module) else root
+    ops = []
+    def collect_ops(op: Operation):
+        ops.append(op.opview)
+        return WalkResult.ADVANCE
+    op.walk_of_type(op_class, collect_ops)
+    return ops
+
+
 @contextmanager
 def loc_tracebacks(*, max_depth: int | None = None) -> Generator[None, None, None]:
     """Enables automatic traceback-based locations for MLIR operations.

--- a/mlir/python/mlir/ir.py
+++ b/mlir/python/mlir/ir.py
@@ -64,7 +64,7 @@ def get_ops_of_type(
         ops.append(op.opview)
         return WalkResult.ADVANCE
 
-    op.walk_of_type(op_class, collect_ops)
+    op.walk(collect_ops, op_class=op_class)
     return ops
 
 

--- a/mlir/python/mlir/ir.py
+++ b/mlir/python/mlir/ir.py
@@ -45,7 +45,9 @@ def get_parent_of_type(op: OpView | Operation, op_class: type[OpView]) -> OpView
     return None
 
 
-def get_ops_of_type(root: OpView | Operation | Module, op_class: type[OpView]) -> list[OpView]:
+def get_ops_of_type(
+    root: OpView | Operation | Module, op_class: type[OpView]
+) -> list[OpView]:
     """Return all operations of the given type in the operation tree.
 
     Args:
@@ -57,9 +59,11 @@ def get_ops_of_type(root: OpView | Operation | Module, op_class: type[OpView]) -
     """
     op = root.operation if isinstance(root, Module) else root
     ops = []
+
     def collect_ops(op: Operation):
         ops.append(op.opview)
         return WalkResult.ADVANCE
+
     op.walk_of_type(op_class, collect_ops)
     return ops
 

--- a/mlir/test/python/ir/operation.py
+++ b/mlir/test/python/ir/operation.py
@@ -1284,7 +1284,7 @@ def testOpWalk():
     # CHECK-NEXT:  func.fun
     # CHECK-NEXT:  func.return
     print("Pre-order")
-    module.operation.walk(callback, WalkOrder.PRE_ORDER)
+    module.operation.walk(callback, walk_order=WalkOrder.PRE_ORDER)
 
     # Test interrput.
     # CHECK-NEXT:  Interrupt post-order
@@ -1306,7 +1306,7 @@ def testOpWalk():
         print(op.name)
         return WalkResult.SKIP
 
-    module.operation.walk(callback, WalkOrder.PRE_ORDER)
+    module.operation.walk(callback, walk_order=WalkOrder.PRE_ORDER)
 
     # Test exception.
     # CHECK: Exception
@@ -1323,67 +1323,6 @@ def testOpWalk():
         module.operation.walk(callback)
     except RuntimeError:
         print("Exception raised")
-
-
-# CHECK-LABEL: TEST: testOpWalkOfType
-@run
-def testOpWalkOfType():
-    with Context(), Location.unknown():
-        module = Module.parse("""
-            module {
-                func.func @f() { return }
-                func.func @g() { return }
-                arith.constant dense<0> : tensor<i32>
-            }
-        """)
-
-    # Callback: only visits ops of the requested type.
-    # CHECK: only FuncOp visited: True
-    only_funcs = True
-
-    def check_type(op):
-        nonlocal only_funcs
-        if not isinstance(op.opview, func.FuncOp):
-            only_funcs = False
-        return WalkResult.ADVANCE
-
-    module.operation.walk_of_type(func.FuncOp, check_type)
-    print(f"only FuncOp visited: {only_funcs}")
-
-    # Callback: interrupt after first match.
-    # CHECK: interrupted after: 1
-    seen = []
-
-    def stop_after_first(op):
-        seen.append(op.opview)
-        return WalkResult.INTERRUPT
-
-    module.operation.walk_of_type(func.FuncOp, stop_after_first)
-    print(f"interrupted after: {len(seen)}")
-
-    # Callback: no match, callback never called.
-    # CHECK: never called: True
-    called = False
-
-    def should_not_run(op):
-        nonlocal called
-        called = True
-        return WalkResult.ADVANCE
-
-    module.operation.walk_of_type(scf.ForOp, should_not_run)
-    print(f"never called: {not called}")
-
-    # Callback: collect all matching ops.
-    # CHECK: collected func.FuncOp: ['"f"', '"g"']
-    collected = []
-
-    def collect(op):
-        collected.append(op.opview)
-        return WalkResult.ADVANCE
-
-    module.operation.walk_of_type(func.FuncOp, collect)
-    assert all(isinstance(r, func.FuncOp) for r in collected)
-    print(f"collected func.FuncOp: {[str(r.name) for r in collected]}")
 
 
 # CHECK-LABEL: TEST: testOpReplaceUsesWith

--- a/mlir/test/python/ir/operation.py
+++ b/mlir/test/python/ir/operation.py
@@ -1284,7 +1284,7 @@ def testOpWalk():
     # CHECK-NEXT:  func.fun
     # CHECK-NEXT:  func.return
     print("Pre-order")
-    module.operation.walk(callback, walk_order=WalkOrder.PRE_ORDER)
+    module.operation.walk(callback, WalkOrder.PRE_ORDER)
 
     # Test interrput.
     # CHECK-NEXT:  Interrupt post-order
@@ -1306,7 +1306,7 @@ def testOpWalk():
         print(op.name)
         return WalkResult.SKIP
 
-    module.operation.walk(callback, walk_order=WalkOrder.PRE_ORDER)
+    module.operation.walk(callback, WalkOrder.PRE_ORDER)
 
     # Test exception.
     # CHECK: Exception
@@ -1379,6 +1379,13 @@ def testOpWalk():
     module.operation.walk(collect, op_class=func.FuncOp)
     assert all(isinstance(r, func.FuncOp) for r in collected)
     print(f"collected func.FuncOp: {[str(r.name) for r in collected]}")
+
+    # Test op_class with walk_order: pre-order visits FuncOps in source order.
+    # CHECK-NEXT: pre-order FuncOp names: ['"f"', '"g"']
+    collected.clear()
+    module.operation.walk(collect, WalkOrder.PRE_ORDER, op_class=func.FuncOp)
+    assert all(isinstance(r, func.FuncOp) for r in collected)
+    print(f"pre-order FuncOp names: {[str(r.name) for r in collected]}")
 
 
 # CHECK-LABEL: TEST: testOpReplaceUsesWith

--- a/mlir/test/python/ir/operation.py
+++ b/mlir/test/python/ir/operation.py
@@ -1324,6 +1324,62 @@ def testOpWalk():
     except RuntimeError:
         print("Exception raised")
 
+    # Test op_class filter: only visits ops of the requested type.
+    module = Module.parse(
+        """
+        module {
+            func.func @f() { return }
+            func.func @g() { return }
+            arith.constant dense<0> : tensor<i32>
+        }
+    """,
+        ctx,
+    )
+
+    # CHECK-NEXT: only FuncOp visited: True
+    only_funcs = True
+
+    def check_type(op):
+        nonlocal only_funcs
+        if not isinstance(op.opview, func.FuncOp):
+            only_funcs = False
+        return WalkResult.ADVANCE
+
+    module.operation.walk(check_type, op_class=func.FuncOp)
+    print(f"only FuncOp visited: {only_funcs}")
+
+    # CHECK-NEXT: interrupted after: 1
+    seen = []
+
+    def stop_after_first(op):
+        seen.append(op.opview)
+        return WalkResult.INTERRUPT
+
+    module.operation.walk(stop_after_first, op_class=func.FuncOp)
+    print(f"interrupted after: {len(seen)}")
+
+    # CHECK-NEXT: never called: True
+    called = False
+
+    def should_not_run(op):
+        nonlocal called
+        called = True
+        return WalkResult.ADVANCE
+
+    module.operation.walk(should_not_run, op_class=scf.ForOp)
+    print(f"never called: {not called}")
+
+    # CHECK-NEXT: collected func.FuncOp: ['"f"', '"g"']
+    collected = []
+
+    def collect(op):
+        collected.append(op.opview)
+        return WalkResult.ADVANCE
+
+    module.operation.walk(collect, op_class=func.FuncOp)
+    assert all(isinstance(r, func.FuncOp) for r in collected)
+    print(f"collected func.FuncOp: {[str(r.name) for r in collected]}")
+
 
 # CHECK-LABEL: TEST: testOpReplaceUsesWith
 @run

--- a/mlir/test/python/ir/operation.py
+++ b/mlir/test/python/ir/operation.py
@@ -1323,7 +1323,8 @@ def testOpWalk():
         module.operation.walk(callback)
     except RuntimeError:
         print("Exception raised")
-        
+
+
 # CHECK-LABEL: TEST: testOpWalkOfType
 @run
 def testOpWalkOfType():
@@ -1339,39 +1340,47 @@ def testOpWalkOfType():
     # Callback: only visits ops of the requested type.
     # CHECK: only FuncOp visited: True
     only_funcs = True
+
     def check_type(op):
         nonlocal only_funcs
         if not isinstance(op.opview, func.FuncOp):
             only_funcs = False
         return WalkResult.ADVANCE
+
     module.operation.walk_of_type(func.FuncOp, check_type)
     print(f"only FuncOp visited: {only_funcs}")
 
     # Callback: interrupt after first match.
     # CHECK: interrupted after: 1
     seen = []
+
     def stop_after_first(op):
         seen.append(op.opview)
         return WalkResult.INTERRUPT
+
     module.operation.walk_of_type(func.FuncOp, stop_after_first)
     print(f"interrupted after: {len(seen)}")
 
     # Callback: no match, callback never called.
     # CHECK: never called: True
     called = False
+
     def should_not_run(op):
         nonlocal called
         called = True
         return WalkResult.ADVANCE
+
     module.operation.walk_of_type(scf.ForOp, should_not_run)
     print(f"never called: {not called}")
 
     # Callback: collect all matching ops.
     # CHECK: collected func.FuncOp: ['"f"', '"g"']
     collected = []
+
     def collect(op):
         collected.append(op.opview)
         return WalkResult.ADVANCE
+
     module.operation.walk_of_type(func.FuncOp, collect)
     assert all(isinstance(r, func.FuncOp) for r in collected)
     print(f"collected func.FuncOp: {[str(r.name) for r in collected]}")

--- a/mlir/test/python/ir/operation.py
+++ b/mlir/test/python/ir/operation.py
@@ -1326,13 +1326,17 @@ def testOpWalk():
 
     # Test op_class filter: only visits ops of the requested type.
     module = Module.parse(
-        """
-        module {
-            func.func @f() { return }
-            func.func @g() { return }
-            arith.constant dense<0> : tensor<i32>
-        }
-    """,
+        r"""
+    module {
+      func.func @f() {
+        func.return
+      }
+      func.func @g() {
+        func.return
+      }
+      arith.constant dense<0> : tensor<i32>
+    }
+  """,
         ctx,
     )
 

--- a/mlir/test/python/ir/operation.py
+++ b/mlir/test/python/ir/operation.py
@@ -1499,12 +1499,14 @@ def testGetParentOfType():
 @run
 def test_get_ops_of_type():
     with Context(), Location.unknown():
-        module = Module.parse("""
+        module = Module.parse(
+            """
             module {
                 func.func @f() { return }
                 func.func @g() { return }
             }
-        """)
+        """
+        )
 
         # CHECK: get_ops_of_type func.func count: 2
         results = get_ops_of_type(module, func.FuncOp)

--- a/mlir/test/python/ir/operation.py
+++ b/mlir/test/python/ir/operation.py
@@ -1519,8 +1519,18 @@ def test_get_ops_of_type():
         print(f"get_ops_of_type scf.for count: {len(results)}")
         assert len(results) == 0
 
+        # CHECK: get_ops_of_type func_op->func.ReturnOp count: 1
         # Accepts OpView as root.
         func_op = get_ops_of_type(module, func.FuncOp)[0]
         results = get_ops_of_type(func_op, func.ReturnOp)
+        print(f"get_ops_of_type func_op->func.ReturnOp count: {len(results)}")
         assert len(results) == 1
         assert isinstance(results[0], func.ReturnOp)
+
+        # CHECK: get_ops_of_type no filter count: 5
+        # No op_class collects all ops.
+        results = get_ops_of_type(module)
+        print(f"get_ops_of_type no filter count: {len(results)}")
+        assert len(results) == 5
+        assert any(isinstance(r, func.FuncOp) for r in results)
+        assert any(isinstance(r, func.ReturnOp) for r in results)

--- a/mlir/test/python/ir/operation.py
+++ b/mlir/test/python/ir/operation.py
@@ -1511,12 +1511,16 @@ def testGetParentOfType():
 def test_get_ops_of_type():
     with Context(), Location.unknown():
         module = Module.parse(
-            """
-            module {
-                func.func @f() { return }
-                func.func @g() { return }
-            }
-        """
+            r"""
+    module {
+      func.func @f() {
+        func.return
+      }
+      func.func @g() {
+        func.return
+      }
+    }
+  """
         )
 
         # CHECK: get_ops_of_type func.func count: 2

--- a/mlir/test/python/ir/operation.py
+++ b/mlir/test/python/ir/operation.py
@@ -1489,3 +1489,32 @@ def testGetParentOfType():
             assert False, "expected TypeError"
         except TypeError:
             pass
+
+
+# CHECK-LABEL: TEST: test_get_ops_of_type
+@run
+def test_get_ops_of_type():
+    with Context(), Location.unknown():
+        module = Module.parse("""
+            module {
+                func.func @f() { return }
+                func.func @g() { return }
+            }
+        """)
+
+        # CHECK: get_ops_of_type func.func count: 2
+        results = get_ops_of_type(module, func.FuncOp)
+        print(f"get_ops_of_type func.func count: {len(results)}")
+        assert len(results) == 2
+        assert all(isinstance(r, func.FuncOp) for r in results)
+
+        # CHECK: get_ops_of_type scf.for count: 0
+        results = get_ops_of_type(module, scf.ForOp)
+        print(f"get_ops_of_type scf.for count: {len(results)}")
+        assert len(results) == 0
+
+        # Accepts OpView as root.
+        func_op = get_ops_of_type(module, func.FuncOp)[0]
+        results = get_ops_of_type(func_op, func.ReturnOp)
+        assert len(results) == 1
+        assert isinstance(results[0], func.ReturnOp)

--- a/mlir/test/python/ir/operation.py
+++ b/mlir/test/python/ir/operation.py
@@ -1323,6 +1323,58 @@ def testOpWalk():
         module.operation.walk(callback)
     except RuntimeError:
         print("Exception raised")
+        
+# CHECK-LABEL: TEST: testOpWalkOfType
+@run
+def testOpWalkOfType():
+    with Context(), Location.unknown():
+        module = Module.parse("""
+            module {
+                func.func @f() { return }
+                func.func @g() { return }
+                arith.constant dense<0> : tensor<i32>
+            }
+        """)
+
+    # Callback: only visits ops of the requested type.
+    # CHECK: only FuncOp visited: True
+    only_funcs = True
+    def check_type(op):
+        nonlocal only_funcs
+        if not isinstance(op.opview, func.FuncOp):
+            only_funcs = False
+        return WalkResult.ADVANCE
+    module.operation.walk_of_type(func.FuncOp, check_type)
+    print(f"only FuncOp visited: {only_funcs}")
+
+    # Callback: interrupt after first match.
+    # CHECK: interrupted after: 1
+    seen = []
+    def stop_after_first(op):
+        seen.append(op.opview)
+        return WalkResult.INTERRUPT
+    module.operation.walk_of_type(func.FuncOp, stop_after_first)
+    print(f"interrupted after: {len(seen)}")
+
+    # Callback: no match, callback never called.
+    # CHECK: never called: True
+    called = False
+    def should_not_run(op):
+        nonlocal called
+        called = True
+        return WalkResult.ADVANCE
+    module.operation.walk_of_type(scf.ForOp, should_not_run)
+    print(f"never called: {not called}")
+
+    # Callback: collect all matching ops.
+    # CHECK: collected func.FuncOp: ['"f"', '"g"']
+    collected = []
+    def collect(op):
+        collected.append(op.opview)
+        return WalkResult.ADVANCE
+    module.operation.walk_of_type(func.FuncOp, collect)
+    assert all(isinstance(r, func.FuncOp) for r in collected)
+    print(f"collected func.FuncOp: {[str(r.name) for r in collected]}")
 
 
 # CHECK-LABEL: TEST: testOpReplaceUsesWith


### PR DESCRIPTION
MLIR's C++ `Operation::walk` supports type-filtered traversal (e.g. `op->walk([](arith::AddIOp op) { ... })`), but the Python binding `op.walk()` requires users to manually implement type filtering inside the callback function.

This PR adds type filtering into the python binding `op.walk()`, if users pass `op_class`, walk() will only apply callback to matching ops.

This PR also adds a common use helper in mlir/ir that collects all ops of a given type into a list. Users can just call: `ops = ir.get_ops_of_type(root, op_class)`.