### PR TITLE
[AArch64][llvm] Ensure `tlbip` instructions aren't gated by `+tlb-rmi`

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64SystemOperands.td
+++ b/llvm/lib/Target/AArch64/AArch64SystemOperands.td
@@ -900,11 +900,11 @@ multiclass TLBI<string name, bit hasTLBIP, bits<3> op1, bits<4> crn, bits<4> crm
              bits<3> op2, bit needsreg = 1, bit optionalreg = 0,
              list<string> tlbirequires = []> {
   def : TLBIEntry<name, op1, crn, crm, op2, needsreg, optionalreg> {
-    let ExtraRequires = tlbirequires;
+    let Requires = tlbirequires;
   }
   def : TLBIEntry<!strconcat(name, "nXS"), op1, crn, crm, op2, needsreg, optionalreg> {
     let Encoding{7} = 1;
-    let ExtraRequires = tlbirequires # ["AArch64::FeatureXS"];
+    let ExtraRequires = ["AArch64::FeatureXS"];
   }
   if !eq(hasTLBIP, true) then {
     def : TLBIPEntry<name, op1, crn, crm, op2, needsreg, optionalreg> {

--- a/llvm/lib/Target/AArch64/AArch64SystemOperands.td
+++ b/llvm/lib/Target/AArch64/AArch64SystemOperands.td
@@ -897,11 +897,14 @@ defm TLBI  : TLBITableBase;
 defm TLBIP : TLBITableBase;
 
 multiclass TLBI<string name, bit hasTLBIP, bits<3> op1, bits<4> crn, bits<4> crm,
-             bits<3> op2, bit needsreg = 1, bit optionalreg = 0> {
-  def : TLBIEntry<name, op1, crn, crm, op2, needsreg, optionalreg>;
+             bits<3> op2, bit needsreg = 1, bit optionalreg = 0,
+             list<string> tlbirequires = []> {
+  def : TLBIEntry<name, op1, crn, crm, op2, needsreg, optionalreg> {
+    let ExtraRequires = tlbirequires;
+  }
   def : TLBIEntry<!strconcat(name, "nXS"), op1, crn, crm, op2, needsreg, optionalreg> {
     let Encoding{7} = 1;
-    let ExtraRequires = ["AArch64::FeatureXS"];
+    let ExtraRequires = tlbirequires # ["AArch64::FeatureXS"];
   }
   if !eq(hasTLBIP, true) then {
     def : TLBIPEntry<name, op1, crn, crm, op2, needsreg, optionalreg> {
@@ -913,6 +916,13 @@ multiclass TLBI<string name, bit hasTLBIP, bits<3> op1, bits<4> crn, bits<4> crm
     }
   }
 }
+
+// Some TLBI instructions require tlb-rmi; TLBIP isns do not
+multiclass TLBIRMI<string name, bit hasTLBIP, bits<3> op1, bits<4> crn,
+                   bits<4> crm, bits<3> op2, bit needsreg = 1,
+                   bit optionalreg = 0>
+    : TLBI<name, hasTLBIP, op1, crn, crm, op2, needsreg, optionalreg,
+           ["AArch64::FeatureTLB_RMI"]>;
 
 //                   hasTLBIP  op1    CRn     CRm     op2    needsreg, optreg
 defm : TLBI<"IPAS2E1IS",    1, 0b100, 0b1000, 0b0000, 0b001>;
@@ -949,59 +959,57 @@ defm : TLBI<"VMALLS12E1",   0, 0b100, 0b1000, 0b0111, 0b110, 0, 0>;
 defm : TLBI<"VAALE1",       1, 0b000, 0b1000, 0b0111, 0b111>;
 
 // Armv8.4-A Translation Lookaside Buffer Instructions (TLBI)
-let Requires = ["AArch64::FeatureTLB_RMI"] in {
 // Armv8.4-A Outer Sharable TLB Maintenance instructions:
 //                   hasTLBIP  op1    CRn     CRm     op2    needsreg, optreg
-defm : TLBI<"VMALLE1OS",    0, 0b000, 0b1000, 0b0001, 0b000, 0, 1>;
-defm : TLBI<"VAE1OS",       1, 0b000, 0b1000, 0b0001, 0b001>;
-defm : TLBI<"ASIDE1OS",     0, 0b000, 0b1000, 0b0001, 0b010>;
-defm : TLBI<"VAAE1OS",      1, 0b000, 0b1000, 0b0001, 0b011>;
-defm : TLBI<"VALE1OS",      1, 0b000, 0b1000, 0b0001, 0b101>;
-defm : TLBI<"VAALE1OS",     1, 0b000, 0b1000, 0b0001, 0b111>;
-defm : TLBI<"IPAS2E1OS",    1, 0b100, 0b1000, 0b0100, 0b000>;
-defm : TLBI<"IPAS2LE1OS",   1, 0b100, 0b1000, 0b0100, 0b100>;
-defm : TLBI<"VAE2OS",       1, 0b100, 0b1000, 0b0001, 0b001>;
-defm : TLBI<"VALE2OS",      1, 0b100, 0b1000, 0b0001, 0b101>;
-defm : TLBI<"VMALLS12E1OS", 0, 0b100, 0b1000, 0b0001, 0b110, 0, 1>;
-defm : TLBI<"VAE3OS",       1, 0b110, 0b1000, 0b0001, 0b001>;
-defm : TLBI<"VALE3OS",      1, 0b110, 0b1000, 0b0001, 0b101>;
-defm : TLBI<"ALLE2OS",      0, 0b100, 0b1000, 0b0001, 0b000, 0, 1>;
-defm : TLBI<"ALLE1OS",      0, 0b100, 0b1000, 0b0001, 0b100, 0, 1>;
-defm : TLBI<"ALLE3OS",      0, 0b110, 0b1000, 0b0001, 0b000, 0, 1>;
+defm : TLBIRMI<"VMALLE1OS",    0, 0b000, 0b1000, 0b0001, 0b000, 0, 1>;
+defm : TLBIRMI<"VAE1OS",       1, 0b000, 0b1000, 0b0001, 0b001>;
+defm : TLBIRMI<"ASIDE1OS",     0, 0b000, 0b1000, 0b0001, 0b010>;
+defm : TLBIRMI<"VAAE1OS",      1, 0b000, 0b1000, 0b0001, 0b011>;
+defm : TLBIRMI<"VALE1OS",      1, 0b000, 0b1000, 0b0001, 0b101>;
+defm : TLBIRMI<"VAALE1OS",     1, 0b000, 0b1000, 0b0001, 0b111>;
+defm : TLBIRMI<"IPAS2E1OS",    1, 0b100, 0b1000, 0b0100, 0b000>;
+defm : TLBIRMI<"IPAS2LE1OS",   1, 0b100, 0b1000, 0b0100, 0b100>;
+defm : TLBIRMI<"VAE2OS",       1, 0b100, 0b1000, 0b0001, 0b001>;
+defm : TLBIRMI<"VALE2OS",      1, 0b100, 0b1000, 0b0001, 0b101>;
+defm : TLBIRMI<"VMALLS12E1OS", 0, 0b100, 0b1000, 0b0001, 0b110, 0, 1>;
+defm : TLBIRMI<"VAE3OS",       1, 0b110, 0b1000, 0b0001, 0b001>;
+defm : TLBIRMI<"VALE3OS",      1, 0b110, 0b1000, 0b0001, 0b101>;
+defm : TLBIRMI<"ALLE2OS",      0, 0b100, 0b1000, 0b0001, 0b000, 0, 1>;
+defm : TLBIRMI<"ALLE1OS",      0, 0b100, 0b1000, 0b0001, 0b100, 0, 1>;
+defm : TLBIRMI<"ALLE3OS",      0, 0b110, 0b1000, 0b0001, 0b000, 0, 1>;
 
 // Armv8.4-A TLB Range Maintenance instructions:
 //                   hasTLBIP  op1    CRn     CRm     op2
-defm : TLBI<"RVAE1",        1, 0b000, 0b1000, 0b0110, 0b001>;
-defm : TLBI<"RVAAE1",       1, 0b000, 0b1000, 0b0110, 0b011>;
-defm : TLBI<"RVALE1",       1, 0b000, 0b1000, 0b0110, 0b101>;
-defm : TLBI<"RVAALE1",      1, 0b000, 0b1000, 0b0110, 0b111>;
-defm : TLBI<"RVAE1IS",      1, 0b000, 0b1000, 0b0010, 0b001>;
-defm : TLBI<"RVAAE1IS",     1, 0b000, 0b1000, 0b0010, 0b011>;
-defm : TLBI<"RVALE1IS",     1, 0b000, 0b1000, 0b0010, 0b101>;
-defm : TLBI<"RVAALE1IS",    1, 0b000, 0b1000, 0b0010, 0b111>;
-defm : TLBI<"RVAE1OS",      1, 0b000, 0b1000, 0b0101, 0b001>;
-defm : TLBI<"RVAAE1OS",     1, 0b000, 0b1000, 0b0101, 0b011>;
-defm : TLBI<"RVALE1OS",     1, 0b000, 0b1000, 0b0101, 0b101>;
-defm : TLBI<"RVAALE1OS",    1, 0b000, 0b1000, 0b0101, 0b111>;
-defm : TLBI<"RIPAS2E1IS",   1, 0b100, 0b1000, 0b0000, 0b010>;
-defm : TLBI<"RIPAS2LE1IS",  1, 0b100, 0b1000, 0b0000, 0b110>;
-defm : TLBI<"RIPAS2E1",     1, 0b100, 0b1000, 0b0100, 0b010>;
-defm : TLBI<"RIPAS2LE1",    1, 0b100, 0b1000, 0b0100, 0b110>;
-defm : TLBI<"RIPAS2E1OS",   1, 0b100, 0b1000, 0b0100, 0b011>;
-defm : TLBI<"RIPAS2LE1OS",  1, 0b100, 0b1000, 0b0100, 0b111>;
-defm : TLBI<"RVAE2",        1, 0b100, 0b1000, 0b0110, 0b001>;
-defm : TLBI<"RVALE2",       1, 0b100, 0b1000, 0b0110, 0b101>;
-defm : TLBI<"RVAE2IS",      1, 0b100, 0b1000, 0b0010, 0b001>;
-defm : TLBI<"RVALE2IS",     1, 0b100, 0b1000, 0b0010, 0b101>;
-defm : TLBI<"RVAE2OS",      1, 0b100, 0b1000, 0b0101, 0b001>;
-defm : TLBI<"RVALE2OS",     1, 0b100, 0b1000, 0b0101, 0b101>;
-defm : TLBI<"RVAE3",        1, 0b110, 0b1000, 0b0110, 0b001>;
-defm : TLBI<"RVALE3",       1, 0b110, 0b1000, 0b0110, 0b101>;
-defm : TLBI<"RVAE3IS",      1, 0b110, 0b1000, 0b0010, 0b001>;
-defm : TLBI<"RVALE3IS",     1, 0b110, 0b1000, 0b0010, 0b101>;
-defm : TLBI<"RVAE3OS",      1, 0b110, 0b1000, 0b0101, 0b001>;
-defm : TLBI<"RVALE3OS",     1, 0b110, 0b1000, 0b0101, 0b101>;
-} //FeatureTLB_RMI
+defm : TLBIRMI<"RVAE1",        1, 0b000, 0b1000, 0b0110, 0b001>;
+defm : TLBIRMI<"RVAAE1",       1, 0b000, 0b1000, 0b0110, 0b011>;
+defm : TLBIRMI<"RVALE1",       1, 0b000, 0b1000, 0b0110, 0b101>;
+defm : TLBIRMI<"RVAALE1",      1, 0b000, 0b1000, 0b0110, 0b111>;
+defm : TLBIRMI<"RVAE1IS",      1, 0b000, 0b1000, 0b0010, 0b001>;
+defm : TLBIRMI<"RVAAE1IS",     1, 0b000, 0b1000, 0b0010, 0b011>;
+defm : TLBIRMI<"RVALE1IS",     1, 0b000, 0b1000, 0b0010, 0b101>;
+defm : TLBIRMI<"RVAALE1IS",    1, 0b000, 0b1000, 0b0010, 0b111>;
+defm : TLBIRMI<"RVAE1OS",      1, 0b000, 0b1000, 0b0101, 0b001>;
+defm : TLBIRMI<"RVAAE1OS",     1, 0b000, 0b1000, 0b0101, 0b011>;
+defm : TLBIRMI<"RVALE1OS",     1, 0b000, 0b1000, 0b0101, 0b101>;
+defm : TLBIRMI<"RVAALE1OS",    1, 0b000, 0b1000, 0b0101, 0b111>;
+defm : TLBIRMI<"RIPAS2E1IS",   1, 0b100, 0b1000, 0b0000, 0b010>;
+defm : TLBIRMI<"RIPAS2LE1IS",  1, 0b100, 0b1000, 0b0000, 0b110>;
+defm : TLBIRMI<"RIPAS2E1",     1, 0b100, 0b1000, 0b0100, 0b010>;
+defm : TLBIRMI<"RIPAS2LE1",    1, 0b100, 0b1000, 0b0100, 0b110>;
+defm : TLBIRMI<"RIPAS2E1OS",   1, 0b100, 0b1000, 0b0100, 0b011>;
+defm : TLBIRMI<"RIPAS2LE1OS",  1, 0b100, 0b1000, 0b0100, 0b111>;
+defm : TLBIRMI<"RVAE2",        1, 0b100, 0b1000, 0b0110, 0b001>;
+defm : TLBIRMI<"RVALE2",       1, 0b100, 0b1000, 0b0110, 0b101>;
+defm : TLBIRMI<"RVAE2IS",      1, 0b100, 0b1000, 0b0010, 0b001>;
+defm : TLBIRMI<"RVALE2IS",     1, 0b100, 0b1000, 0b0010, 0b101>;
+defm : TLBIRMI<"RVAE2OS",      1, 0b100, 0b1000, 0b0101, 0b001>;
+defm : TLBIRMI<"RVALE2OS",     1, 0b100, 0b1000, 0b0101, 0b101>;
+defm : TLBIRMI<"RVAE3",        1, 0b110, 0b1000, 0b0110, 0b001>;
+defm : TLBIRMI<"RVALE3",       1, 0b110, 0b1000, 0b0110, 0b101>;
+defm : TLBIRMI<"RVAE3IS",      1, 0b110, 0b1000, 0b0010, 0b001>;
+defm : TLBIRMI<"RVALE3IS",     1, 0b110, 0b1000, 0b0010, 0b101>;
+defm : TLBIRMI<"RVAE3OS",      1, 0b110, 0b1000, 0b0101, 0b001>;
+defm : TLBIRMI<"RVALE3OS",     1, 0b110, 0b1000, 0b0101, 0b101>;
 
 // Armv9-A Realm Management Extension TLBI Instructions
 let Requires = ["AArch64::FeatureRME"] in {

--- a/llvm/test/MC/AArch64/armv9-sysp-diagnostics.s
+++ b/llvm/test/MC/AArch64/armv9-sysp-diagnostics.s
@@ -1,7 +1,7 @@
-// +tbl-rmi required for RIPA*/RVA*
+// +d128 required for tlbip
 // +xs required for *NXS
 
-// RUN: not llvm-mc -triple aarch64 -mattr=+d128,+tlb-rmi,+xs -show-encoding %s -o - 2>&1 | FileCheck %s --check-prefix=ERRORS
+// RUN: not llvm-mc -triple aarch64 -mattr=+d128,+xs -show-encoding %s -o - 2>&1 | FileCheck %s --check-prefix=ERRORS
 
 // sysp #<op1>, <Cn>, <Cm>, #<op2>{, <Xt1>, <Xt2>}
 // registers with 128-bit formats (op0, op1, Cn, Cm, op2)

--- a/llvm/test/MC/AArch64/armv9a-tlbip.s
+++ b/llvm/test/MC/AArch64/armv9a-tlbip.s
@@ -1,19 +1,18 @@
-// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+d128,+tlb-rmi < %s \
+// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+d128 < %s \
 // RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 // RUN: not llvm-mc -triple=aarch64 -show-encoding -mattr=+tlb-rmi < %s 2>&1 \
 // RUN:        | FileCheck %s --check-prefixes=CHECK-ERROR
-// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+d128,+tlb-rmi < %s \
-// RUN:        | llvm-objdump -d --mattr=+d128,+tlb-rmi --no-print-imm-hex - | FileCheck %s --check-prefix=CHECK-INST
-// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+d128,+tlb-rmi < %s \
-// RUN:        | llvm-objdump -d --mattr=-d128,-tlb-rmi --no-print-imm-hex - | FileCheck %s --check-prefix=CHECK-UNKNOWN
+// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+d128 < %s \
+// RUN:        | llvm-objdump -d --mattr=+d128 --no-print-imm-hex - | FileCheck %s --check-prefix=CHECK-INST
+// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+d128 < %s \
+// RUN:        | llvm-objdump -d --mattr=-d128 --no-print-imm-hex - | FileCheck %s --check-prefix=CHECK-UNKNOWN
 // Disassemble encoding and check the re-encoding (-show-encoding) matches.
-// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+d128,+tlb-rmi < %s \
+// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+d128 < %s \
 // RUN:        | sed '/.text/d' | sed 's/.*encoding: //g' \
-// RUN:        | llvm-mc -triple=aarch64 -mattr=+d128,+tlb-rmi -disassemble -show-encoding \
+// RUN:        | llvm-mc -triple=aarch64 -mattr=+d128 -disassemble -show-encoding \
 // RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 
 // +d128 required for tlbip
-// +tbl-rmi required for RIPA*/RVA*
 
 tlbip IPAS2E1, x4, x5
 // CHECK-INST: tlbip ipas2e1, x4, x5


### PR DESCRIPTION
Prior to change 2690bb6db, `tlbi` and `tlbip` instructions were
(wrongly) unified, and everything was defined for both of them.
I split them apart in that change, to avoid invalid instructions
being defined.

However, I didn't realise that `+tlb-rmi` was only applicable
to `tlbi` instructions, and `tlbip` instructions should not use
this feature gate.

Remove gating for `tlbip` instructions (requires defining another
multiclass) and adjust testcases accordingly.

Pre-requisite for PR #179813.