### PR TITLE
[MSF] Fix max PDB file size when using /pdbpagesize

### DIFF
--- a/llvm/include/llvm/DebugInfo/MSF/MSFCommon.h
+++ b/llvm/include/llvm/DebugInfo/MSF/MSFCommon.h
@@ -114,9 +114,9 @@ inline uint64_t getMaxFileSizeFromBlockSize(uint32_t Size) {
   case 8192:
     return (uint64_t)UINT32_MAX * 2ULL;
   case 16384:
-    return (uint64_t)UINT32_MAX * 3ULL;
-  case 32768:
     return (uint64_t)UINT32_MAX * 4ULL;
+  case 32768:
+    return (uint64_t)UINT32_MAX * 8ULL;
   default:
     return (uint64_t)UINT32_MAX;
   }

--- a/llvm/include/llvm/DebugInfo/MSF/MSFCommon.h
+++ b/llvm/include/llvm/DebugInfo/MSF/MSFCommon.h
@@ -112,13 +112,13 @@ inline bool isValidBlockSize(uint32_t Size) {
 inline uint64_t getMaxFileSizeFromBlockSize(uint32_t Size) {
   switch (Size) {
   case 8192:
-    return (uint64_t)UINT32_MAX * 2ULL;
+    return (uint64_t)1 << 33; // 8 GiB
   case 16384:
-    return (uint64_t)UINT32_MAX * 4ULL;
+    return (uint64_t)1 << 34; // 16 GiB
   case 32768:
-    return (uint64_t)UINT32_MAX * 8ULL;
+    return (uint64_t)1 << 35; // 32 GiB
   default:
-    return (uint64_t)UINT32_MAX;
+    return (uint64_t)1 << 32; // 4 GiB
   }
 }
 


### PR DESCRIPTION
This PR updates the logic in the `getMaxFileSizeFromBlockSize` function to correct the maximum file size values for certain block sizes (a.k.a `/pdbpagesize`).

As stated in the function comment, the correct maximum file size should be 4/8/16/32 GiB, rather than of 4/8/12/16 GiB.

Additionally (after reading <https://github.com/microsoft/microsoft-pdb/blob/master/PDB/msf/msf.cpp>), I've noticed that files precisely 4GiB in size appear to be valid. Can anyone verify this?