### PR TITLE
[MLIR][LLVM] Add DILocationAttr for debug locations

### DIFF
--- a/mlir/include/mlir/Dialect/LLVMIR/LLVMAttrDefs.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/LLVMAttrDefs.td
@@ -670,6 +670,38 @@ def LLVM_DILexicalBlockFile : LLVM_Attr<"DILexicalBlockFile", "di_lexical_block_
 }
 
 //===----------------------------------------------------------------------===//
+// DILocationAttr
+//===----------------------------------------------------------------------===//
+
+def LLVM_DILocationAttr : LocationAttrDef<LLVM_Dialect, "DILocation"> {
+  let description = [{
+    Represents a debug location combining a source position and a debug info
+    scope for instruction-level and function-level debug locations.
+
+    Inlining is represented using `CallSiteLoc` (LLVM proper's `DILocation`
+    uses the `inlinedAt` field for this).
+
+    Note: Older code represents this with a FusedLoc carrying the debug
+    scope as its metadata and a convention on how to interpret it.
+  }];
+  let mnemonic = "di_location";
+
+  let parameters = (ins
+    "FileLineColLoc":$sourceLoc,
+    "DILocalScopeAttr":$scope
+  );
+  let assemblyFormat = "`<` $sourceLoc `in` $scope `>`";
+
+  let builders = [
+    AttrBuilderWithInferredContext<(ins
+      "FileLineColLoc":$sourceLoc, "DILocalScopeAttr":$scope
+    ), [{
+      return $_get(sourceLoc.getContext(), sourceLoc, scope);
+    }]>,
+  ];
+}
+
+//===----------------------------------------------------------------------===//
 // DILocalVariableAttr
 //===----------------------------------------------------------------------===//
 

--- a/mlir/include/mlir/Dialect/LLVMIR/LLVMAttrDefs.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/LLVMAttrDefs.td
@@ -683,6 +683,15 @@ def LLVM_DILocationAttr : LocationAttrDef<LLVM_Dialect, "DILocation"> {
 
     Note: Older code represents this with a FusedLoc carrying the debug
     scope as its metadata and a convention on how to interpret it.
+
+    Verifier: when the scope chain reaches a `DIFileAttr`, the source
+    filename in `sourceLoc` must equal either the scope's `DIFile.name` or
+    the directory-joined `<DIFile.directory>/<DIFile.name>` rendering. The
+    check is a no-op when the scope chain has no reachable `DIFileAttr`,
+    when the scope file name is empty, or when the source filename is the
+    `-` sentinel (MLIR's placeholder for an empty filename — see
+    `BuiltinLocationAttributes.td`'s `FileLineColRange::get(StringRef, ...)`
+    builder, which substitutes `-` for `""`).
   }];
   let mnemonic = "di_location";
 
@@ -699,6 +708,8 @@ def LLVM_DILocationAttr : LocationAttrDef<LLVM_Dialect, "DILocation"> {
       return $_get(sourceLoc.getContext(), sourceLoc, scope);
     }]>,
   ];
+
+  let genVerifyDecl = 1;
 }
 
 //===----------------------------------------------------------------------===//

--- a/mlir/include/mlir/Dialect/LLVMIR/LLVMAttrDefs.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/LLVMAttrDefs.td
@@ -291,8 +291,8 @@ def LoopAnnotationAttr : LLVM_Attr<"LoopAnnotation", "loop_annotation"> {
     OptionalParameter<"LoopUnswitchAttr">:$unswitch,
     OptionalParameter<"BoolAttr">:$mustProgress,
     OptionalParameter<"BoolAttr">:$isVectorized,
-    OptionalParameter<"FusedLoc">:$startLoc,
-    OptionalParameter<"FusedLoc">:$endLoc,
+    OptionalParameter<"LocationAttr">:$startLoc,
+    OptionalParameter<"LocationAttr">:$endLoc,
     OptionalArrayRefParameter<"AccessGroupAttr">:$parallelAccesses
   );
 

--- a/mlir/include/mlir/Dialect/LLVMIR/LLVMAttrs.h
+++ b/mlir/include/mlir/Dialect/LLVMIR/LLVMAttrs.h
@@ -109,4 +109,14 @@ bool isValidLoadStoreImpl(Type type, ptr::AtomicOrdering ordering,
 #define GET_ATTRDEF_CLASSES
 #include "mlir/Dialect/LLVMIR/LLVMOpsAttrDefs.h.inc"
 
+namespace mlir {
+namespace LLVM {
+
+/// Walk the `getScope()` chain from `scope` and return the first reachable
+/// `DIFileAttr`. Returns null when no scope in the chain carries a file.
+DIFileAttr findFileInScope(DIScopeAttr scope);
+
+} // namespace LLVM
+} // namespace mlir
+
 #endif // MLIR_DIALECT_LLVMIR_LLVMATTRS_H_

--- a/mlir/include/mlir/Dialect/LLVMIR/LLVMAttrs.h
+++ b/mlir/include/mlir/Dialect/LLVMIR/LLVMAttrs.h
@@ -112,6 +112,13 @@ bool isValidLoadStoreImpl(Type type, ptr::AtomicOrdering ordering,
 namespace mlir {
 namespace LLVM {
 
+/// Returns the `DISubprogramAttr` carried by `loc`, looking through
+/// `CallSiteLoc`/`FusedLoc`/`NameLoc` wrappers. Handles both the
+/// `DILocationAttr` shape (scope is the embedded `DILocalScopeAttr`) and the
+/// legacy `FusedLocWith<DISubprogramAttr>` shape. Returns null if neither
+/// shape carries a subprogram.
+DISubprogramAttr findSubprogramInLoc(Location loc);
+
 /// Walk the `getScope()` chain from `scope` and return the first reachable
 /// `DIFileAttr`. Returns null when no scope in the chain carries a file.
 DIFileAttr findFileInScope(DIScopeAttr scope);

--- a/mlir/include/mlir/Dialect/LLVMIR/LLVMDialectBytecode.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/LLVMDialectBytecode.td
@@ -329,8 +329,8 @@ def LoopAnnotationAttr : DialectAttribute<(attr
   OptionalAttribute<"LoopUnswitchAttr">:$unswitch,
   OptionalAttribute<"BoolAttr">:$mustProgress,
   OptionalAttribute<"BoolAttr">:$isVectorized,
-  OptionalAttribute<"FusedLoc">:$startLoc,
-  OptionalAttribute<"FusedLoc">:$endLoc,
+  OptionalAttribute<"LocationAttr">:$startLoc,
+  OptionalAttribute<"LocationAttr">:$endLoc,
   OptionalArrayRef<"AccessGroupAttr">:$parallelAccesses
 )>;
 

--- a/mlir/include/mlir/Dialect/LLVMIR/LLVMDialectBytecode.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/LLVMDialectBytecode.td
@@ -283,6 +283,15 @@ def DILexicalBlockFileAttr : DialectAttribute<(attr
 )>;
 
 //===----------------------------------------------------------------------===//
+// DILocationAttr
+//===----------------------------------------------------------------------===//
+
+def DILocationAttr : DialectAttribute<(attr
+  Attr<"FileLineColLoc">:$sourceLoc,
+  Attr<"DILocalScopeAttr">:$scope
+)>;
+
+//===----------------------------------------------------------------------===//
 // DINamespaceAttr
 //===----------------------------------------------------------------------===//
 
@@ -345,6 +354,7 @@ def LLVMDialectAttributes : DialectAttributes<"LLVM"> {
     DILabelAttr,
     DILexicalBlockAttr,
     DILexicalBlockFileAttr,
+    DILocationAttr,
     DILocalVariableAttr,
     DINamespaceAttr,
     DISubprogramAttr,

--- a/mlir/lib/Dialect/LLVMIR/IR/LLVMAttrs.cpp
+++ b/mlir/lib/Dialect/LLVMIR/IR/LLVMAttrs.cpp
@@ -617,6 +617,18 @@ ModuleFlagAttr::verify(function_ref<InFlightDiagnostic()> emitError,
                      << key << "'";
 }
 
+//===----------------------------------------------------------------------===//
+// Location helpers
+//===----------------------------------------------------------------------===//
+
+DISubprogramAttr LLVM::findSubprogramInLoc(Location loc) {
+  if (auto diLoc = loc->findInstanceOf<DILocationAttr>())
+    return dyn_cast<DISubprogramAttr>(diLoc.getScope());
+  if (auto spLoc = loc->findInstanceOf<FusedLocWith<DISubprogramAttr>>())
+    return spLoc.getMetadata();
+  return nullptr;
+}
+
 DIFileAttr LLVM::findFileInScope(DIScopeAttr scope) {
   while (scope) {
     if (auto file = dyn_cast<DIFileAttr>(scope))

--- a/mlir/lib/Dialect/LLVMIR/IR/LLVMAttrs.cpp
+++ b/mlir/lib/Dialect/LLVMIR/IR/LLVMAttrs.cpp
@@ -20,6 +20,7 @@
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/TypeSwitch.h"
 #include "llvm/BinaryFormat/Dwarf.h"
+#include "llvm/Support/Path.h"
 
 using namespace mlir;
 using namespace mlir::LLVM;
@@ -217,6 +218,39 @@ LogicalResult DIDerivedTypeAttr::verify(
   if (extraData && !llvm::isa<DINodeAttr, IntegerAttr>(extraData))
     return emitError() << "extraData must be a DINodeAttr or an IntegerAttr";
   return success();
+}
+
+//===----------------------------------------------------------------------===//
+// DILocationAttr
+//===----------------------------------------------------------------------===//
+
+LogicalResult
+DILocationAttr::verify(function_ref<InFlightDiagnostic()> emitError,
+                       FileLineColLoc sourceLoc, DILocalScopeAttr scope) {
+  DIFileAttr scopeFile = findFileInScope(scope);
+  if (!scopeFile)
+    return success();
+
+  StringRef sourceName = sourceLoc.getFilename().getValue();
+  StringRef scopeName = scopeFile.getName().getValue();
+  StringRef scopeDir = scopeFile.getDirectory().getValue();
+
+  // Treat the "-" placeholder as the empty/no-source-info sentinel:
+  // `FileLineColRange::get(StringRef, ...)` substitutes "-" for an empty
+  // filename (see BuiltinLocationAttributes.td), so `loc("":0:0)` and the
+  // pass-generated `FileLineColLoc::get(ctx, "", ...)` both land here as "-".
+  if (sourceName.empty() || sourceName == "-" || scopeName.empty())
+    return success();
+
+  SmallString<128> rendered(scopeDir);
+  llvm::sys::path::append(rendered, scopeName);
+
+  if (sourceName == scopeName || sourceName == StringRef(rendered))
+    return success();
+
+  return emitError() << "DILocationAttr source filename '" << sourceName
+                     << "' is inconsistent with scope DIFile '" << rendered
+                     << "'";
 }
 
 //===----------------------------------------------------------------------===//
@@ -581,4 +615,28 @@ ModuleFlagAttr::verify(function_ref<InFlightDiagnostic()> emitError,
   return emitError() << "only integer, string, and string-array values are "
                         "currently supported for unknown key '"
                      << key << "'";
+}
+
+DIFileAttr LLVM::findFileInScope(DIScopeAttr scope) {
+  while (scope) {
+    if (auto file = dyn_cast<DIFileAttr>(scope))
+      return file;
+    DIFileAttr file =
+        TypeSwitch<DIScopeAttr, DIFileAttr>(scope)
+            .Case<DISubprogramAttr, DILexicalBlockAttr, DILexicalBlockFileAttr,
+                  DICompileUnitAttr, DIModuleAttr, DICommonBlockAttr,
+                  DICompositeTypeAttr, DIDerivedTypeAttr>(
+                [](auto s) { return s.getFile(); })
+            .Default(DIFileAttr{});
+    if (file)
+      return file;
+    scope =
+        TypeSwitch<DIScopeAttr, DIScopeAttr>(scope)
+            .Case<DISubprogramAttr, DILexicalBlockAttr, DILexicalBlockFileAttr,
+                  DIModuleAttr, DINamespaceAttr, DICommonBlockAttr,
+                  DICompositeTypeAttr, DIDerivedTypeAttr>(
+                [](auto s) -> DIScopeAttr { return s.getScope(); })
+            .Default(DIScopeAttr{});
+  }
+  return nullptr;
 }

--- a/mlir/lib/Dialect/LLVMIR/IR/LLVMDialect.cpp
+++ b/mlir/lib/Dialect/LLVMIR/IR/LLVMDialect.cpp
@@ -1142,6 +1142,8 @@ static LogicalResult verifyCallOpDebugInfo(CallOp callOp, LLVMFuncOp callee) {
     return success();
 
   auto hasSubprogram = [](Operation *op) {
+    if (auto diLoc = op->getLoc()->findInstanceOf<LLVM::DILocationAttr>())
+      return isa<LLVM::DISubprogramAttr>(diLoc.getScope());
     return op->getLoc()
                ->findInstanceOf<FusedLocWith<LLVM::DISubprogramAttr>>() !=
            nullptr;

--- a/mlir/lib/Dialect/LLVMIR/IR/LLVMDialect.cpp
+++ b/mlir/lib/Dialect/LLVMIR/IR/LLVMDialect.cpp
@@ -1141,14 +1141,8 @@ static LogicalResult verifyCallOpDebugInfo(CallOp callOp, LLVMFuncOp callee) {
   if (!parentFunc)
     return success();
 
-  auto hasSubprogram = [](Operation *op) {
-    if (auto diLoc = op->getLoc()->findInstanceOf<LLVM::DILocationAttr>())
-      return isa<LLVM::DISubprogramAttr>(diLoc.getScope());
-    return op->getLoc()
-               ->findInstanceOf<FusedLocWith<LLVM::DISubprogramAttr>>() !=
-           nullptr;
-  };
-  if (!hasSubprogram(parentFunc) || !hasSubprogram(callee))
+  if (!LLVM::findSubprogramInLoc(parentFunc->getLoc()) ||
+      !LLVM::findSubprogramInLoc(callee->getLoc()))
     return success();
   bool containsLoc = !isa<UnknownLoc>(callOp->getLoc());
   if (!containsLoc)

--- a/mlir/lib/Dialect/LLVMIR/Transforms/DIScopeForLLVMFuncOp.cpp
+++ b/mlir/lib/Dialect/LLVMIR/Transforms/DIScopeForLLVMFuncOp.cpp
@@ -25,6 +25,8 @@ using namespace mlir;
 static FileLineColLoc extractFileLoc(Location loc) {
   if (auto fileLoc = dyn_cast<FileLineColLoc>(loc))
     return fileLoc;
+  if (auto diLoc = dyn_cast<LLVM::DILocationAttr>(loc))
+    return diLoc.getSourceLoc();
   if (auto nameLoc = dyn_cast<NameLoc>(loc))
     return extractFileLoc(nameLoc.getChildLoc());
   if (auto opaqueLoc = dyn_cast<OpaqueLoc>(loc))
@@ -45,10 +47,20 @@ static FileLineColLoc extractFileLoc(Location loc) {
 /// subprogram.
 static void addScopeToFunction(LLVM::LLVMFuncOp llvmFunc,
                                LLVM::DICompileUnitAttr compileUnitAttr) {
-
+  if (auto diLoc = dyn_cast<LLVM::DILocationAttr>(llvmFunc.getLoc()))
+    return; // already has a debug location
   Location loc = llvmFunc.getLoc();
-  if (loc->findInstanceOf<FusedLocWith<LLVM::DISubprogramAttr>>())
+  // Convert legacy FusedLoc<DISubprogramAttr> to DILocationAttr so that
+  // all function locations use a uniform representation after this pass.
+  if (auto fusedLoc =
+          loc->findInstanceOf<FusedLocWith<LLVM::DISubprogramAttr>>()) {
+    auto subprogram = fusedLoc.getMetadata();
+    FileLineColLoc fileLoc = extractFileLoc(loc);
+    if (!fileLoc)
+      fileLoc = FileLineColLoc::get(llvmFunc->getContext(), "", 0, 0);
+    llvmFunc->setLoc(LLVM::DILocationAttr::get(fileLoc, subprogram));
     return;
+  }
 
   MLIRContext *context = llvmFunc->getContext();
 
@@ -87,31 +99,36 @@ static void addScopeToFunction(LLVM::LLVMFuncOp llvmFunc,
       fileAttr,
       /*line=*/line, /*scopeLine=*/line, subprogramFlags, subroutineTypeAttr,
       /*retainedNodes=*/{}, /*annotations=*/{});
-  llvmFunc->setLoc(FusedLoc::get(context, {loc}, subprogramAttr));
+  FileLineColLoc fileLoc = extractFileLoc(loc);
+  if (!fileLoc)
+    fileLoc = FileLineColLoc::get(context, "", line, /*column=*/0);
+  llvmFunc->setLoc(LLVM::DILocationAttr::get(fileLoc, subprogramAttr));
 }
 
-// Get a nested loc for inlined functions.
+// Build a DILocationAttr for an inlined callee. Each recursion level creates a
+// DILexicalBlockFileAttr whose scope chains back through the caller scopes
+// to the enclosing subprogram. The scope nesting is carried by the
+// DILexicalBlockFileAttr hierarchy, not by nesting locations.
 static Location getNestedLoc(Operation *op, LLVM::DIScopeAttr scopeAttr,
                              Location calleeLoc) {
   auto *context = op->getContext();
   LLVM::DIFileAttr calleeFileAttr;
-  if (auto calleeFileLoc = extractFileLoc(calleeLoc)) {
+  FileLineColLoc calleeFileLoc = extractFileLoc(calleeLoc);
+  if (calleeFileLoc) {
     auto calleeFileName = calleeFileLoc.getFilename();
     calleeFileAttr = LLVM::DIFileAttr::get(
         context, llvm::sys::path::filename(calleeFileName),
         llvm::sys::path::parent_path(calleeFileName));
   } else {
     calleeFileAttr = LLVM::DIFileAttr::get(context, "<unknown>", "");
+    calleeFileLoc = FileLineColLoc::get(context, "", 0, 0);
   }
   auto lexicalBlockFileAttr = LLVM::DILexicalBlockFileAttr::get(
       context, scopeAttr, calleeFileAttr, /*discriminator=*/0);
-  Location loc = calleeLoc;
   // Recurse if the callee location is again a call site.
-  if (auto callSiteLoc = dyn_cast<CallSiteLoc>(calleeLoc)) {
-    auto nestedLoc = callSiteLoc.getCallee();
-    loc = getNestedLoc(op, lexicalBlockFileAttr, nestedLoc);
-  }
-  return FusedLoc::get(context, {loc}, lexicalBlockFileAttr);
+  if (auto callSiteLoc = dyn_cast<CallSiteLoc>(calleeLoc))
+    return getNestedLoc(op, lexicalBlockFileAttr, callSiteLoc.getCallee());
+  return LLVM::DILocationAttr::get(calleeFileLoc, lexicalBlockFileAttr);
 }
 
 /// Adds DILexicalBlockFileAttr for operations with CallSiteLoc and operations
@@ -119,27 +136,26 @@ static Location getNestedLoc(Operation *op, LLVM::DIScopeAttr scopeAttr,
 static void setLexicalBlockFileAttr(Operation *op) {
   Location opLoc = op->getLoc();
 
-  if (auto callSiteLoc = dyn_cast<CallSiteLoc>(opLoc)) {
-    auto callerLoc = callSiteLoc.getCaller();
-    auto calleeLoc = callSiteLoc.getCallee();
-    LLVM::DIScopeAttr scopeAttr;
-    // We assemble the full inline stack so the parent of this loc must be a
-    // function
-    if (auto funcOp = op->getParentOfType<LLVM::LLVMFuncOp>()) {
-      if (auto funcOpLoc =
-              llvm::dyn_cast_if_present<FusedLoc>(funcOp.getLoc())) {
-        scopeAttr = cast<LLVM::DISubprogramAttr>(funcOpLoc.getMetadata());
-        op->setLoc(CallSiteLoc::get(getNestedLoc(op, scopeAttr, calleeLoc),
-                                    callerLoc));
-      }
-    }
-
-    return;
-  }
-
   auto funcOp = op->getParentOfType<LLVM::LLVMFuncOp>();
   if (!funcOp)
     return;
+
+  // Extract the subprogram scope from the function's DILocationAttr.
+  // addScopeToFunction guarantees that all function locations are
+  // DILocationAttr by the time this runs (PreOrder walk).
+  auto diLoc = dyn_cast<LLVM::DILocationAttr>(funcOp.getLoc());
+  if (!diLoc)
+    return;
+  auto scopeAttr = dyn_cast<LLVM::DISubprogramAttr>(diLoc.getScope());
+  if (!scopeAttr)
+    return;
+
+  if (auto callSiteLoc = dyn_cast<CallSiteLoc>(opLoc)) {
+    op->setLoc(
+        CallSiteLoc::get(getNestedLoc(op, scopeAttr, callSiteLoc.getCallee()),
+                         callSiteLoc.getCaller()));
+    return;
+  }
 
   FileLineColLoc opFileLoc = extractFileLoc(opLoc);
   if (!opFileLoc)
@@ -155,23 +171,15 @@ static void setLexicalBlockFileAttr(Operation *op) {
   // Handle cross-file operations: add DILexicalBlockFileAttr when the
   // operation's source file differs from its containing function.
   if (opFile != funcFile) {
-    auto funcOpLoc = llvm::dyn_cast_if_present<FusedLoc>(funcOp.getLoc());
-    if (!funcOpLoc)
-      return;
-    auto scopeAttr = dyn_cast<LLVM::DISubprogramAttr>(funcOpLoc.getMetadata());
-    if (!scopeAttr)
-      return;
-
     auto *context = op->getContext();
     LLVM::DIFileAttr opFileAttr =
         LLVM::DIFileAttr::get(context, llvm::sys::path::filename(opFile),
                               llvm::sys::path::parent_path(opFile));
 
-    LLVM::DILexicalBlockFileAttr lexicalBlockFileAttr =
+    auto lexicalBlockFileAttr =
         LLVM::DILexicalBlockFileAttr::get(context, scopeAttr, opFileAttr, 0);
 
-    Location newLoc = FusedLoc::get(context, {opLoc}, lexicalBlockFileAttr);
-    op->setLoc(newLoc);
+    op->setLoc(LLVM::DILocationAttr::get(opFileLoc, lexicalBlockFileAttr));
   }
 }
 

--- a/mlir/lib/Dialect/LLVMIR/Transforms/InlinerInterfaceImpl.cpp
+++ b/mlir/lib/Dialect/LLVMIR/Transforms/InlinerInterfaceImpl.cpp
@@ -491,28 +491,22 @@ handleLoopAnnotations(Operation *call,
   auto func = call->getParentOfType<FunctionOpInterface>();
   if (!func)
     return;
-  LLVM::DISubprogramAttr scope;
-  if (auto diLoc = dyn_cast<LLVM::DILocationAttr>(func->getLoc()))
-    scope = dyn_cast<LLVM::DISubprogramAttr>(diLoc.getScope());
-  else if (auto fusedLoc = dyn_cast<FusedLoc>(func->getLoc()))
-    scope = dyn_cast_if_present<LLVM::DISubprogramAttr>(fusedLoc.getMetadata());
+  LLVM::DISubprogramAttr scope = LLVM::findSubprogramInLoc(func->getLoc());
   if (!scope)
     return;
-
-  // Helper to build a new fused location that reflects the inlining of the loop
+  // Helper to build a new location that reflects the inlining of the loop
   // annotation.
-  auto updateLoc = [&](FusedLoc loc) -> FusedLoc {
+  auto updateLoc = [&](LocationAttr loc) -> LocationAttr {
     if (!loc)
       return {};
-    Location callSiteLoc = CallSiteLoc::get(loc, call->getLoc());
-    return FusedLoc::get(loc.getContext(), callSiteLoc, scope);
+    return CallSiteLoc::get(loc, call->getLoc());
   };
 
   AttrTypeReplacer replacer;
   replacer.addReplacement([&](LLVM::LoopAnnotationAttr loopAnnotation)
                               -> std::pair<Attribute, WalkResult> {
-    FusedLoc newStartLoc = updateLoc(loopAnnotation.getStartLoc());
-    FusedLoc newEndLoc = updateLoc(loopAnnotation.getEndLoc());
+    LocationAttr newStartLoc = updateLoc(loopAnnotation.getStartLoc());
+    LocationAttr newEndLoc = updateLoc(loopAnnotation.getEndLoc());
     if (!newStartLoc && !newEndLoc)
       return {loopAnnotation, WalkResult::advance()};
     auto newLoopAnnotation = LLVM::LoopAnnotationAttr::get(

--- a/mlir/lib/Dialect/LLVMIR/Transforms/InlinerInterfaceImpl.cpp
+++ b/mlir/lib/Dialect/LLVMIR/Transforms/InlinerInterfaceImpl.cpp
@@ -487,16 +487,15 @@ static void handleAccessGroups(Operation *call,
 static void
 handleLoopAnnotations(Operation *call,
                       iterator_range<Region::iterator> inlinedBlocks) {
-  // Attempt to extract a DISubprogram from the callee.
+  // Attempt to extract a DISubprogram from the caller.
   auto func = call->getParentOfType<FunctionOpInterface>();
   if (!func)
     return;
-  LocationAttr funcLoc = func->getLoc();
-  auto fusedLoc = dyn_cast_if_present<FusedLoc>(funcLoc);
-  if (!fusedLoc)
-    return;
-  auto scope =
-      dyn_cast_if_present<LLVM::DISubprogramAttr>(fusedLoc.getMetadata());
+  LLVM::DISubprogramAttr scope;
+  if (auto diLoc = dyn_cast<LLVM::DILocationAttr>(func->getLoc()))
+    scope = dyn_cast<LLVM::DISubprogramAttr>(diLoc.getScope());
+  else if (auto fusedLoc = dyn_cast<FusedLoc>(func->getLoc()))
+    scope = dyn_cast_if_present<LLVM::DISubprogramAttr>(fusedLoc.getMetadata());
   if (!scope)
     return;
 

--- a/mlir/lib/Target/LLVMIR/DebugImporter.cpp
+++ b/mlir/lib/Target/LLVMIR/DebugImporter.cpp
@@ -33,11 +33,19 @@ Location DebugImporter::translateFuncLocation(llvm::Function *func) {
   if (!subprogram)
     return UnknownLoc::get(context);
 
-  // Add a fused location to link the subprogram information.
   StringAttr fileName = StringAttr::get(context, subprogram->getFilename());
-  return FusedLocWith<DISubprogramAttr>::get(
-      {FileLineColLoc::get(fileName, subprogram->getLine(), /*column=*/0)},
-      translate(subprogram), context);
+  auto fileLoc =
+      FileLineColLoc::get(fileName, subprogram->getLine(), /*column=*/0);
+  auto scope = dyn_cast_if_present<DILocalScopeAttr>(translate(subprogram));
+  // DILocationAttr requires a non-null DILocalScopeAttr, but
+  // translateImpl(DISubprogram*) can return null when the subprogram's parent
+  // scope or subroutine type cannot be translated. Preserve the file location
+  // so diagnostics still have source info. This also matches the original
+  // FusedLocWith<DISubprogramAttr> behavior, where a null metadata caused the
+  // location to fail FusedLocWith<DISubprogramAttr> classof checks anyway.
+  if (!scope)
+    return fileLoc;
+  return DILocationAttr::get(fileLoc, scope);
 }
 
 //===----------------------------------------------------------------------===//
@@ -491,16 +499,14 @@ Location DebugImporter::translateLoc(llvm::DILocation *loc) {
   if (!loc)
     return UnknownLoc::get(context);
 
-  // Get the file location of the instruction.
-  Location result = FileLineColLoc::get(context, loc->getFilename(),
-                                        loc->getLine(), loc->getColumn());
-
-  // Add scope information.
-  assert(loc->getScope() && "expected non-null scope");
-  result = FusedLocWith<DIScopeAttr>::get({result}, translate(loc->getScope()),
-                                          context);
-
-  // Add call site information, if available.
+  auto fileLoc = FileLineColLoc::get(context, loc->getFilename(),
+                                     loc->getLine(), loc->getColumn());
+  auto scope =
+      dyn_cast_if_present<DILocalScopeAttr>(translate(loc->getScope()));
+  // DILocationAttr requires a non-null DILocalScopeAttr. When the scope cannot
+  // be translated, preserve the file location for diagnostics.
+  Location result =
+      scope ? Location(DILocationAttr::get(fileLoc, scope)) : Location(fileLoc);
   if (llvm::DILocation *inlinedAt = loc->getInlinedAt())
     result = CallSiteLoc::get(result, translateLoc(inlinedAt));
 

--- a/mlir/lib/Target/LLVMIR/DebugTranslation.cpp
+++ b/mlir/lib/Target/LLVMIR/DebugTranslation.cpp
@@ -63,15 +63,7 @@ void DebugTranslation::translate(LLVMFuncOp func, llvm::Function &llvmFunc) {
   if (!debugEmissionIsEnabled)
     return;
 
-  // Look for a subprogram: check DILocationAttr first, fall back to FusedLoc.
-  LLVM::DISubprogramAttr sp;
-  if (auto diLoc = dyn_cast<LLVM::DILocationAttr>(func.getLoc())) {
-    sp = dyn_cast<LLVM::DISubprogramAttr>(diLoc.getScope());
-  } else if (auto spLoc =
-                 func.getLoc()
-                     ->findInstanceOf<FusedLocWith<LLVM::DISubprogramAttr>>()) {
-    sp = spLoc.getMetadata();
-  }
+  LLVM::DISubprogramAttr sp = LLVM::findSubprogramInLoc(func.getLoc());
   if (!sp)
     return;
   llvmFunc.setSubprogram(translate(sp));

--- a/mlir/lib/Target/LLVMIR/DebugTranslation.cpp
+++ b/mlir/lib/Target/LLVMIR/DebugTranslation.cpp
@@ -63,12 +63,18 @@ void DebugTranslation::translate(LLVMFuncOp func, llvm::Function &llvmFunc) {
   if (!debugEmissionIsEnabled)
     return;
 
-  // Look for a sub program attached to the function.
-  auto spLoc =
-      func.getLoc()->findInstanceOf<FusedLocWith<LLVM::DISubprogramAttr>>();
-  if (!spLoc)
+  // Look for a subprogram: check DILocationAttr first, fall back to FusedLoc.
+  LLVM::DISubprogramAttr sp;
+  if (auto diLoc = dyn_cast<LLVM::DILocationAttr>(func.getLoc())) {
+    sp = dyn_cast<LLVM::DISubprogramAttr>(diLoc.getScope());
+  } else if (auto spLoc =
+                 func.getLoc()
+                     ->findInstanceOf<FusedLocWith<LLVM::DISubprogramAttr>>()) {
+    sp = spLoc.getMetadata();
+  }
+  if (!sp)
     return;
-  llvmFunc.setSubprogram(translate(spLoc.getMetadata()));
+  llvmFunc.setSubprogram(translate(sp));
 }
 
 //===----------------------------------------------------------------------===//
@@ -600,6 +606,17 @@ llvm::DILocation *DebugTranslation::translateLoc(Location loc,
     // Fallback: Ignore callee if it has no debug scope.
     if (!llvmLoc)
       llvmLoc = callerLoc;
+
+  } else if (auto diLoc = dyn_cast<LLVM::DILocationAttr>(loc)) {
+    // Translate the scope from the DILocationAttr.
+    llvm::DILocalScope *diScope = translate(diLoc.getScope());
+    if (!diScope)
+      return nullptr;
+
+    auto sourceLoc = diLoc.getSourceLoc();
+    llvmLoc = llvm::DILocation::get(llvmCtx, sourceLoc.getLine(),
+                                    sourceLoc.getColumn(), diScope,
+                                    const_cast<llvm::DILocation *>(inlinedAt));
 
   } else if (auto fileLoc = dyn_cast<FileLineColLoc>(loc)) {
     // A scope of a DILocation cannot be null.

--- a/mlir/lib/Target/LLVMIR/Dialect/LLVMIR/LLVMToLLVMIRTranslation.cpp
+++ b/mlir/lib/Target/LLVMIR/Dialect/LLVMIR/LLVMToLLVMIRTranslation.cpp
@@ -436,6 +436,10 @@ lookupNonFunctionSymbolCallee(FlatSymbolRefAttr attr, mlir::Type calleeFuncType,
 static llvm::DILocalScope *
 getLocalScopeFromLoc(llvm::IRBuilderBase &builder, Location loc,
                      LLVM::ModuleTranslation &moduleTranslation) {
+  if (auto diLoc = loc->findInstanceOf<LLVM::DILocationAttr>())
+    if (auto *localScope = llvm::dyn_cast<llvm::DILocalScope>(
+            moduleTranslation.translateDebugInfo(diLoc.getScope())))
+      return localScope;
   if (auto scopeLoc =
           loc->findInstanceOf<FusedLocWith<LLVM::DILocalScopeAttr>>())
     if (auto *localScope = llvm::dyn_cast<llvm::DILocalScope>(

--- a/mlir/lib/Target/LLVMIR/LoopAnnotationImporter.cpp
+++ b/mlir/lib/Target/LLVMIR/LoopAnnotationImporter.cpp
@@ -410,10 +410,26 @@ LoopMetadataConversion::convertParallelAccesses() {
   return refs;
 }
 
+/// Convert a translated location to a FusedLoc for loop annotation storage.
+/// translateLoc produces DILocationAttr, but LoopAnnotationAttr stores
+/// locations as FusedLoc<scope>[raw_loc]. Extract the source location and scope
+/// from the DILocationAttr to build the FusedLoc directly, matching the format
+/// expected by LoopAnnotationTranslation on the export side.
+static FusedLoc toFusedLoc(Location loc) {
+  if (auto fused = dyn_cast<FusedLoc>(loc))
+    return fused;
+  if (isa<UnknownLoc>(loc))
+    return {};
+  if (auto diLoc = dyn_cast<LLVM::DILocationAttr>(loc))
+    return dyn_cast<FusedLoc>(FusedLoc::get(
+        {diLoc.getSourceLoc()}, diLoc.getScope(), loc.getContext()));
+  return {};
+}
+
 FusedLoc LoopMetadataConversion::convertStartLoc() {
   if (locations.empty())
     return {};
-  return dyn_cast<FusedLoc>(
+  return toFusedLoc(
       loopAnnotationImporter.moduleImport.translateLoc(locations[0]));
 }
 
@@ -423,7 +439,7 @@ FailureOr<FusedLoc> LoopMetadataConversion::convertEndLoc() {
   if (locations.size() > 2)
     return emitError(loc)
            << "expected loop metadata to have at most two DILocations";
-  return dyn_cast<FusedLoc>(
+  return toFusedLoc(
       loopAnnotationImporter.moduleImport.translateLoc(locations[1]));
 }
 

--- a/mlir/lib/Target/LLVMIR/LoopAnnotationImporter.cpp
+++ b/mlir/lib/Target/LLVMIR/LoopAnnotationImporter.cpp
@@ -54,8 +54,8 @@ struct LoopMetadataConversion {
   FailureOr<LoopPeeledAttr> convertPeeledAttr();
   FailureOr<LoopUnswitchAttr> convertUnswitchAttr();
   FailureOr<SmallVector<AccessGroupAttr>> convertParallelAccesses();
-  FusedLoc convertStartLoc();
-  FailureOr<FusedLoc> convertEndLoc();
+  LocationAttr convertStartLoc();
+  FailureOr<LocationAttr> convertEndLoc();
 
   llvm::SmallVector<llvm::DILocation *, 2> locations;
   llvm::StringMap<const llvm::MDNode *> propertyMap;
@@ -410,37 +410,21 @@ LoopMetadataConversion::convertParallelAccesses() {
   return refs;
 }
 
-/// Convert a translated location to a FusedLoc for loop annotation storage.
-/// translateLoc produces DILocationAttr, but LoopAnnotationAttr stores
-/// locations as FusedLoc<scope>[raw_loc]. Extract the source location and scope
-/// from the DILocationAttr to build the FusedLoc directly, matching the format
-/// expected by LoopAnnotationTranslation on the export side.
-static FusedLoc toFusedLoc(Location loc) {
-  if (auto fused = dyn_cast<FusedLoc>(loc))
-    return fused;
-  if (isa<UnknownLoc>(loc))
-    return {};
-  if (auto diLoc = dyn_cast<LLVM::DILocationAttr>(loc))
-    return dyn_cast<FusedLoc>(FusedLoc::get(
-        {diLoc.getSourceLoc()}, diLoc.getScope(), loc.getContext()));
-  return {};
-}
-
-FusedLoc LoopMetadataConversion::convertStartLoc() {
+LocationAttr LoopMetadataConversion::convertStartLoc() {
   if (locations.empty())
     return {};
-  return toFusedLoc(
-      loopAnnotationImporter.moduleImport.translateLoc(locations[0]));
+  return loopAnnotationImporter.moduleImport.translateLoc(locations[0]);
 }
 
-FailureOr<FusedLoc> LoopMetadataConversion::convertEndLoc() {
+FailureOr<LocationAttr> LoopMetadataConversion::convertEndLoc() {
   if (locations.size() < 2)
-    return FusedLoc();
+    return LocationAttr();
   if (locations.size() > 2)
     return emitError(loc)
            << "expected loop metadata to have at most two DILocations";
-  return toFusedLoc(
-      loopAnnotationImporter.moduleImport.translateLoc(locations[1]));
+  LocationAttr endLoc =
+      loopAnnotationImporter.moduleImport.translateLoc(locations[1]);
+  return endLoc;
 }
 
 LoopAnnotationAttr LoopMetadataConversion::convert() {
@@ -471,8 +455,8 @@ LoopAnnotationAttr LoopMetadataConversion::convert() {
     return {};
   }
 
-  FailureOr<FusedLoc> startLoc = convertStartLoc();
-  FailureOr<FusedLoc> endLoc = convertEndLoc();
+  FailureOr<LocationAttr> startLoc = convertStartLoc();
+  FailureOr<LocationAttr> endLoc = convertEndLoc();
 
   return createIfNonNull<LoopAnnotationAttr>(
       ctx, disableNonForced, vecAttr, interleaveAttr, unrollAttr,

--- a/mlir/lib/Target/LLVMIR/LoopAnnotationTranslation.cpp
+++ b/mlir/lib/Target/LLVMIR/LoopAnnotationTranslation.cpp
@@ -33,7 +33,7 @@ struct LoopAnnotationConversion {
   void convertBoolNode(StringRef name, BoolAttr attr, bool negated = false);
   void convertI32Node(StringRef name, IntegerAttr attr);
   void convertFollowupNode(StringRef name, LoopAnnotationAttr attr);
-  void convertLocation(FusedLoc attr);
+  void convertLocation(LocationAttr attr);
 
   /// Conversion functions for each for each loop annotation sub-attribute.
   void convertLoopOptions(LoopVectorizeAttr options);
@@ -188,14 +188,21 @@ void LoopAnnotationConversion::convertLoopOptions(LoopUnswitchAttr options) {
               options.getPartialDisable());
 }
 
-void LoopAnnotationConversion::convertLocation(FusedLoc location) {
-  auto localScopeAttr =
-      dyn_cast_or_null<DILocalScopeAttr>(location.getMetadata());
-  if (!localScopeAttr)
-    return;
-  auto *localScope = dyn_cast<llvm::DILocalScope>(
-      loopAnnotationTranslation.moduleTranslation.translateDebugInfo(
-          localScopeAttr));
+void LoopAnnotationConversion::convertLocation(LocationAttr location) {
+  // Scope precedence: a DILocationAttr inside the location chain (handles
+  // CallSiteLoc<DILocationAttr> from inlining), then the enclosing function's
+  // DISubprogram so bare FileLineColLoc still emits a !DILocation.
+  llvm::DILocalScope *localScope = nullptr;
+  if (auto diLoc = location.findInstanceOf<LLVM::DILocationAttr>()) {
+    localScope = dyn_cast_or_null<llvm::DILocalScope>(
+        loopAnnotationTranslation.moduleTranslation.translateDebugInfo(
+            diLoc.getScope()));
+  } else if (auto func = op->getParentOfType<FunctionOpInterface>()) {
+    if (auto scope = LLVM::findSubprogramInLoc(func->getLoc()))
+      localScope = dyn_cast_or_null<llvm::DILocalScope>(
+          loopAnnotationTranslation.moduleTranslation.translateDebugInfo(
+              scope));
+  }
   if (!localScope)
     return;
   llvm::Metadata *loc =
@@ -209,10 +216,10 @@ llvm::MDNode *LoopAnnotationConversion::convert() {
   auto dummy = llvm::MDNode::getTemporary(ctx, {});
   metadataNodes.push_back(dummy.get());
 
-  if (FusedLoc startLoc = attr.getStartLoc())
+  if (LocationAttr startLoc = attr.getStartLoc())
     convertLocation(startLoc);
 
-  if (FusedLoc endLoc = attr.getEndLoc())
+  if (LocationAttr endLoc = attr.getEndLoc())
     convertLocation(endLoc);
 
   addUnitNode("llvm.loop.disable_nonforced", attr.getDisableNonforced());

--- a/mlir/test/Dialect/LLVMIR/add-debuginfo-func-scope.mlir
+++ b/mlir/test/Dialect/LLVMIR/add-debuginfo-func-scope.mlir
@@ -6,7 +6,7 @@
 // CHECK: loc(#loc[[LOC:[0-9]+]])
 // CHECK: #di_file = #llvm.di_file<"<unknown>" in "">
 // CHECK: #di_subprogram = #llvm.di_subprogram<id = distinct[{{.*}}]<>, compileUnit = #di_compile_unit, scope = #di_file, name = "func_no_debug", linkageName = "func_no_debug", file = #di_file, line = 1, scopeLine = 1, subprogramFlags = "Definition|Optimized", type = #di_subroutine_type>
-// CHECK: #loc[[LOC]] = loc(fused<#di_subprogram>
+// CHECK: #loc[[LOC]] = #llvm.di_location<{{.*}} in #di_subprogram>
 module {
   llvm.func @func_no_debug() {
     llvm.return loc(unknown)
@@ -31,7 +31,7 @@ module {
 // CHECK: loc(#loc[[LOC:[0-9]+]])
 // CHECK: #di_file = #llvm.di_file<"<unknown>" in "">
 // CHECK: #di_subprogram = #llvm.di_subprogram<id = distinct[{{.*}}]<>, compileUnit = #di_compile_unit, scope = #di_file, name = "func_with_debug", linkageName = "func_with_debug", file = #di_file, line = 42, scopeLine = 42, subprogramFlags = "Definition|Optimized", type = #di_subroutine_type>
-// CHECK: #loc[[LOC]] = loc(fused<#di_subprogram>
+// CHECK: #loc[[LOC]] = #llvm.di_location<{{.*}} in #di_subprogram>
 // CHECK_OTHER_KIND: emissionKind = DebugDirectivesOnly
 module {
   llvm.func @func_with_debug() {
@@ -59,7 +59,7 @@ module {
 // CHECK-DAG: #di_compile_unit = #llvm.di_compile_unit<id = distinct[{{.*}}]<>, sourceLanguage = DW_LANG_C, file = #[[DI_FILE_MODULE]], producer = "MLIR", isOptimized = true, emissionKind = LineTablesOnly>
 // CHECK-DAG: #di_subprogram = #llvm.di_subprogram<id = distinct[{{.*}}]<>, compileUnit = #di_compile_unit, scope = #[[DI_FILE_FUNC]], name = "propagate_compile_unit", linkageName = "propagate_compile_unit", file = #[[DI_FILE_FUNC]], line = 9, scopeLine = 9, subprogramFlags = "Definition|Optimized", type = #di_subroutine_type>
 // CHECK-DAG: #loc[[MODULELOC]] = loc(fused<#di_compile_unit>[#loc])
-// CHECK-DAG: #loc[[FUNCLOC]] = loc(fused<#di_subprogram>[#loc[[FUNCFILELOC]]
+// CHECK-DAG: #loc[[FUNCLOC]] = #llvm.di_location<#loc[[FUNCFILELOC]] in #di_subprogram>
 module {
   llvm.func @propagate_compile_unit() {
     llvm.return loc(unknown)

--- a/mlir/test/Dialect/LLVMIR/bytecode.mlir
+++ b/mlir/test/Dialect/LLVMIR/bytecode.mlir
@@ -5,8 +5,8 @@
 #di_subprogram = #llvm.di_subprogram<recId = distinct[2]<>>
 #loc1 = loc("test.f90":12:14)
 #loc2 = loc("test":4:3)
-#loc6 = loc(fused<#di_subprogram>[#loc1])
-#loc7 = loc(fused<#di_subprogram>[#loc2])
+#loc6 = #llvm.di_location<#loc1 in #di_subprogram>
+#loc7 = #llvm.di_location<#loc2 in #di_subprogram>
 #loop_annotation = #llvm.loop_annotation<disableNonforced = false, mustProgress = true, startLoc = #loc6, endLoc = #loc7, parallelAccesses = #access_group, #access_group1>
 module {
   llvm.func @imp_fn() {

--- a/mlir/test/Dialect/LLVMIR/diloc-attr-invalid.mlir
+++ b/mlir/test/Dialect/LLVMIR/diloc-attr-invalid.mlir
@@ -1,0 +1,61 @@
+// RUN: mlir-opt %s -split-input-file -verify-diagnostics
+
+// Verifier: DILocationAttr source filename must match the scope's DIFile
+// (basename or directory-joined). See LLVMAttrDefs.td DILocationAttr description.
+
+// -----
+
+// Basename differs: source 'wrong.c' vs scope 'source.c'.
+#di_file = #llvm.di_file<"source.c" in "/">
+#di_compile_unit = #llvm.di_compile_unit<id = distinct[0]<>, sourceLanguage = DW_LANG_C, file = #di_file, isOptimized = false, emissionKind = None>
+#di_subprogram = #llvm.di_subprogram<compileUnit = #di_compile_unit, scope = #di_file, name = "f", file = #di_file, subprogramFlags = Definition>
+
+// expected-error @+1 {{DILocationAttr source filename 'wrong.c' is inconsistent with scope DIFile '/source.c'}}
+#bad = #llvm.di_location<loc("wrong.c":1:1) in #di_subprogram>
+
+llvm.func @f() {} loc(#bad)
+
+// -----
+
+// Directory mismatch: source '/build/source.c' vs scope DIFile rendered as
+// '/src/source.c'. Source carries its own directory and it disagrees with
+// the scope's, so neither the basename-equality match ('/build/source.c'
+// != 'source.c') nor the directory-joined match ('/build/source.c' !=
+// '/src/source.c') succeeds.
+#di_file = #llvm.di_file<"source.c" in "/src">
+#di_compile_unit = #llvm.di_compile_unit<id = distinct[0]<>, sourceLanguage = DW_LANG_C, file = #di_file, isOptimized = false, emissionKind = None>
+#di_subprogram = #llvm.di_subprogram<compileUnit = #di_compile_unit, scope = #di_file, name = "f", file = #di_file, subprogramFlags = Definition>
+
+// expected-error @+1 {{DILocationAttr source filename '/build/source.c' is inconsistent with scope DIFile '/src/source.c'}}
+#bad_dir = #llvm.di_location<loc("/build/source.c":1:1) in #di_subprogram>
+
+llvm.func @f_dir_mismatch() {} loc(#bad_dir)
+
+// -----
+
+// Scope chain walks DILexicalBlock -> DISubprogram; bad source name still
+// rejected because the chain reaches a DIFile.
+#di_file = #llvm.di_file<"source.c" in "/">
+#di_compile_unit = #llvm.di_compile_unit<id = distinct[0]<>, sourceLanguage = DW_LANG_C, file = #di_file, isOptimized = false, emissionKind = None>
+#di_subprogram = #llvm.di_subprogram<compileUnit = #di_compile_unit, scope = #di_file, name = "f", file = #di_file, subprogramFlags = Definition>
+#di_lb = #llvm.di_lexical_block<scope = #di_subprogram, line = 5, column = 1>
+
+// expected-error @+1 {{DILocationAttr source filename 'other.c' is inconsistent with scope DIFile '/source.c'}}
+#bad_chain = #llvm.di_location<loc("other.c":6:1) in #di_lb>
+
+llvm.func @f_chain() {} loc(#bad_chain)
+
+// -----
+
+// Type-as-scope chain: DISubprogram (no own $file) -> DICompositeType
+// -> DIFile. Mismatch must still be flagged through the type-as-scope branch
+// of findFileInScope.
+#di_file = #llvm.di_file<"class.cpp" in "/src">
+#di_compile_unit = #llvm.di_compile_unit<id = distinct[0]<>, sourceLanguage = DW_LANG_C_plus_plus_14, file = #di_file, isOptimized = false, emissionKind = None>
+#di_class = #llvm.di_composite_type<tag = DW_TAG_class_type, name = "MyClass", file = #di_file, line = 1, scope = #di_file>
+#di_member = #llvm.di_subprogram<compileUnit = #di_compile_unit, scope = #di_class, name = "foo", subprogramFlags = Definition>
+
+// expected-error @+1 {{DILocationAttr source filename 'other.cpp' is inconsistent with scope DIFile '/src/class.cpp'}}
+#bad_type_chain = #llvm.di_location<loc("other.cpp":42:1) in #di_member>
+
+llvm.func @member_func_bad() {} loc(#bad_type_chain)

--- a/mlir/test/Dialect/LLVMIR/diloc-attr.mlir
+++ b/mlir/test/Dialect/LLVMIR/diloc-attr.mlir
@@ -1,8 +1,12 @@
-// RUN: mlir-opt %s --mlir-print-debuginfo | FileCheck %s
+// RUN: mlir-opt %s --mlir-print-debuginfo -split-input-file | FileCheck %s
 //
-// Basic parse/print test for DILocationAttr (no snapshots).
-// Uses a single source file and exercises two DILocationAttr locations (module and function).
+// Parse/print and verifier coverage for DILocationAttr. The verifier ensures
+// the FileLineColLoc filename is consistent with the scope's DIFile (when
+// reachable).
 
+// -----
+
+// Basename match: source filename equals DIFile.name (directory ignored).
 #di_file = #llvm.di_file<"source.c" in "/">
 #di_compile_unit = #llvm.di_compile_unit<id = distinct[0]<>, sourceLanguage = DW_LANG_C, file = #di_file, isOptimized = false, emissionKind = None>
 #di_subprogram = #llvm.di_subprogram<compileUnit = #di_compile_unit, scope = #di_file, name = "test", file = #di_file, subprogramFlags = Definition>
@@ -15,3 +19,73 @@
 module {
   llvm.func @f() {} loc(#loc_at_func)
 } loc(#loc_at_module)
+
+// -----
+
+// Directory-joined match: source filename equals "<DIFile.directory>/<DIFile.name>".
+#di_file = #llvm.di_file<"source.c" in "/src">
+#di_compile_unit = #llvm.di_compile_unit<id = distinct[0]<>, sourceLanguage = DW_LANG_C, file = #di_file, isOptimized = false, emissionKind = None>
+#di_subprogram = #llvm.di_subprogram<compileUnit = #di_compile_unit, scope = #di_file, name = "test_joined", file = #di_file, subprogramFlags = Definition>
+
+// CHECK: #llvm.di_location<{{.*}} in #di_subprogram>
+#loc_joined = #llvm.di_location<loc("/src/source.c":1:1) in #di_subprogram>
+
+llvm.func @g_joined() {} loc(#loc_joined)
+
+// -----
+
+// Scope chain walks DILexicalBlock -> DILexicalBlock -> DISubprogram to find
+// the DIFile. Inner blocks omit the optional file field.
+#di_file = #llvm.di_file<"source.c" in "/">
+#di_compile_unit = #llvm.di_compile_unit<id = distinct[0]<>, sourceLanguage = DW_LANG_C, file = #di_file, isOptimized = false, emissionKind = None>
+#di_subprogram = #llvm.di_subprogram<compileUnit = #di_compile_unit, scope = #di_file, name = "test_chain", file = #di_file, subprogramFlags = Definition>
+#di_lb_outer = #llvm.di_lexical_block<scope = #di_subprogram, line = 5, column = 1>
+#di_lb_inner = #llvm.di_lexical_block<scope = #di_lb_outer, line = 6, column = 3>
+
+// CHECK: #llvm.di_location<{{.*}} in #di_lexical_block1>
+#loc_in_inner = #llvm.di_location<loc("source.c":7:5) in #di_lb_inner>
+
+llvm.func @h_chain() {} loc(#loc_in_inner)
+
+// -----
+
+// Type-as-scope: scope chain walks DISubprogram (no own $file) -> DICompositeType
+// -> DIFile. Models a C++ member function whose enclosing class carries the file.
+#di_file = #llvm.di_file<"class.cpp" in "/src">
+#di_compile_unit = #llvm.di_compile_unit<id = distinct[0]<>, sourceLanguage = DW_LANG_C_plus_plus_14, file = #di_file, isOptimized = false, emissionKind = None>
+#di_class = #llvm.di_composite_type<tag = DW_TAG_class_type, name = "MyClass", file = #di_file, line = 1, scope = #di_file>
+// Intentionally no $file on the member subprogram, so findFileInScope must
+// walk through #di_class to find the DIFile.
+#di_member = #llvm.di_subprogram<compileUnit = #di_compile_unit, scope = #di_class, name = "foo", subprogramFlags = Definition>
+
+// CHECK: #llvm.di_location<{{.*}} in #di_subprogram>
+#loc_in_member = #llvm.di_location<loc("/src/class.cpp":42:1) in #di_member>
+
+llvm.func @member_func() {} loc(#loc_in_member)
+
+// -----
+
+// "When you have one" — DISubprogram without a file means there's no DIFile
+// reachable in the scope chain, so the source filename is unconstrained.
+#di_subprogram = #llvm.di_subprogram<recId = distinct[0]<>>
+
+// CHECK: #llvm.di_location<{{.*}} in #di_subprogram>
+#loc_no_file_in_scope = #llvm.di_location<loc("anything.c":1:1) in #di_subprogram>
+
+llvm.func @no_file_scope() {} loc(#loc_no_file_in_scope)
+
+// -----
+
+// Empty source filename ("" from text, or programmatic "") is rewritten by
+// MLIR's FileLineColRange builder to the "-" sentinel. The verifier treats
+// "-" as the no-source-info placeholder and skips the consistency check —
+// this covers the pass-generated "<unknown>" / empty-source pair used by
+// DIScopeForLLVMFuncOp for ops with no source info.
+#di_file = #llvm.di_file<"<unknown>" in "">
+#di_compile_unit = #llvm.di_compile_unit<id = distinct[0]<>, sourceLanguage = DW_LANG_C, file = #di_file, isOptimized = false, emissionKind = None>
+#di_subprogram = #llvm.di_subprogram<compileUnit = #di_compile_unit, scope = #di_file, name = "empty_source", file = #di_file, subprogramFlags = Definition>
+
+// CHECK: #llvm.di_location<{{.*}} in #di_subprogram>
+#loc_empty = #llvm.di_location<loc("":0:0) in #di_subprogram>
+
+llvm.func @empty_source_filename() {} loc(#loc_empty)

--- a/mlir/test/Dialect/LLVMIR/diloc-attr.mlir
+++ b/mlir/test/Dialect/LLVMIR/diloc-attr.mlir
@@ -1,0 +1,17 @@
+// RUN: mlir-opt %s --mlir-print-debuginfo | FileCheck %s
+//
+// Basic parse/print test for DILocationAttr (no snapshots).
+// Uses a single source file and exercises two DILocationAttr locations (module and function).
+
+#di_file = #llvm.di_file<"source.c" in "/">
+#di_compile_unit = #llvm.di_compile_unit<id = distinct[0]<>, sourceLanguage = DW_LANG_C, file = #di_file, isOptimized = false, emissionKind = None>
+#di_subprogram = #llvm.di_subprogram<compileUnit = #di_compile_unit, scope = #di_file, name = "test", file = #di_file, subprogramFlags = Definition>
+
+// CHECK-DAG: #llvm.di_location<{{.*}} in #di_subprogram>
+// CHECK-DAG: #llvm.di_location<{{.*}} in #di_subprogram>
+#loc_at_module = #llvm.di_location<loc("source.c":1:1) in #di_subprogram>
+#loc_at_func = #llvm.di_location<loc("source.c":10:2) in #di_subprogram>
+
+module {
+  llvm.func @f() {} loc(#loc_at_func)
+} loc(#loc_at_module)

--- a/mlir/test/Dialect/LLVMIR/inlining-loop-annotation.mlir
+++ b/mlir/test/Dialect/LLVMIR/inlining-loop-annotation.mlir
@@ -2,39 +2,37 @@
 
 #di_file = #llvm.di_file<"test.mlir" in "/">
 
-// CHECK: #[[START_ORIGINAL:.*]] = loc({{.*}}:42
+// CHECK-DAG: #[[START_ORIGINAL:.*]] = loc({{.*}}:42:4)
 #loc1 = loc("test.mlir":42:4)
-// CHECK: #[[END_ORIGINAL:.*]] = loc({{.*}}:52
+// CHECK-DAG: #[[END_ORIGINAL:.*]] = loc({{.*}}:52:4)
 #loc2 = loc("test.mlir":52:4)
 #loc3 = loc("test.mlir":62:4)
-// CHECK: #[[CALL_ORIGINAL:.*]] = loc({{.*}}:72
+// CHECK-DAG: #[[CALL_ORIGINAL:.*]] = loc({{.*}}:72:4)
 #loc4 = loc("test.mlir":72:4)
 
 #di_compile_unit = #llvm.di_compile_unit<id = distinct[0]<>, sourceLanguage = DW_LANG_C, file = #di_file, isOptimized = false, emissionKind = None>
-// CHECK: #[[CALLEE_DI:.*]] = #llvm.di_subprogram<{{.*}}, name = "callee"
+// CHECK-DAG: #[[CALLEE_DI:.*]] = #llvm.di_subprogram<{{.*}}, name = "callee"
 #di_subprogram_callee = #llvm.di_subprogram<compileUnit = #di_compile_unit, scope = #di_file, name = "callee", file = #di_file, subprogramFlags = Definition>
 
-// CHECK: #[[CALLER_DI:.*]] = #llvm.di_subprogram<{{.*}}, name = "caller"
+// CHECK-DAG: #[[CALLER_DI:.*]] = #llvm.di_subprogram<{{.*}}, name = "caller"
 #di_subprogram_caller = #llvm.di_subprogram<compileUnit = #di_compile_unit, scope = #di_file, name = "caller", file = #di_file, subprogramFlags = Definition>
 
-// CHECK: #[[START_FUSED_ORIGINAL:.*]] = loc(fused<#[[CALLEE_DI]]>[#[[START_ORIGINAL]]
-#start_loc_fused = loc(fused<#di_subprogram_callee>[#loc1])
-// CHECK: #[[END_FUSED_ORIGINAL:.*]] = loc(fused<#[[CALLEE_DI]]>[#[[END_ORIGINAL]]
-#end_loc_fused= loc(fused<#di_subprogram_callee>[#loc2])
-#caller_loc= loc(fused<#di_subprogram_caller>[#loc3])
-// CHECK: #[[CALL_FUSED:.*]] = loc(fused<#[[CALLER_DI]]>[#[[CALL_ORIGINAL]]
-#call_loc= loc(fused<#di_subprogram_caller>[#loc4])
+// CHECK-DAG: #[[START_DI:.*]] = #llvm.di_location<#[[START_ORIGINAL]] in #[[CALLEE_DI]]>
+#start_loc = #llvm.di_location<#loc1 in #di_subprogram_callee>
+// CHECK-DAG: #[[END_DI:.*]] = #llvm.di_location<#[[END_ORIGINAL]] in #[[CALLEE_DI]]>
+#end_loc = #llvm.di_location<#loc2 in #di_subprogram_callee>
+#caller_loc = #llvm.di_location<#loc3 in #di_subprogram_caller>
+// CHECK-DAG: #[[CALL_DI:.*]] = #llvm.di_location<#[[CALL_ORIGINAL]] in #[[CALLER_DI]]>
+#call_loc = #llvm.di_location<#loc4 in #di_subprogram_caller>
 
 #loopMD = #llvm.loop_annotation<
-        startLoc = #start_loc_fused,
-        endLoc = #end_loc_fused>
+        startLoc = #start_loc,
+        endLoc = #end_loc>
 
-// CHECK: #[[START_CALLSITE_LOC:.*]] = loc(callsite(#[[START_FUSED_ORIGINAL]] at #[[CALL_FUSED]]
-// CHECK: #[[END_CALLSITE_LOC:.*]] = loc(callsite(#[[END_FUSED_ORIGINAL]] at #[[CALL_FUSED]]
-// CHECK: #[[START_FUSED_LOC:.*]] = loc(fused<#[[CALLER_DI]]>[#[[START_CALLSITE_LOC]]
-// CHECK: #[[END_FUSED_LOC:.*]] = loc(fused<#[[CALLER_DI]]>[
-// CHECK: #[[LOOP_ANNOT:.*]] = #llvm.loop_annotation<
-// CHECK-SAME: startLoc = #[[START_FUSED_LOC]], endLoc = #[[END_FUSED_LOC]]>
+// After inlining, startLoc/endLoc are wrapped in CallSiteLoc.
+// CHECK-DAG: #[[START_CALLSITE:.*]] = loc(callsite(#[[START_DI]] at #[[CALL_DI]]))
+// CHECK-DAG: #[[END_CALLSITE:.*]] = loc(callsite(#[[END_DI]] at #[[CALL_DI]]))
+// CHECK: #[[LOOP_ANNOT:.*]] = #llvm.loop_annotation<startLoc = #[[START_CALLSITE]], endLoc = #[[END_CALLSITE]]>
 
 llvm.func @cond() -> i1
 

--- a/mlir/test/Dialect/LLVMIR/inlining-loop-annotation.mlir
+++ b/mlir/test/Dialect/LLVMIR/inlining-loop-annotation.mlir
@@ -1,6 +1,6 @@
 // RUN: mlir-opt %s -inline -split-input-file | FileCheck %s
 
-#di_file = #llvm.di_file<"file.mlir" in "/">
+#di_file = #llvm.di_file<"test.mlir" in "/">
 
 // CHECK: #[[START_ORIGINAL:.*]] = loc({{.*}}:42
 #loc1 = loc("test.mlir":42:4)

--- a/mlir/test/Dialect/LLVMIR/invalid-call-location.mlir
+++ b/mlir/test/Dialect/LLVMIR/invalid-call-location.mlir
@@ -33,3 +33,36 @@ llvm.func @invalid_call_debug_locs() {
   llvm.call @missing_debug_loc() : () -> () loc(#loc)
   llvm.return
 } loc(#loc4)
+
+// -----
+
+// Test the DILocationAttr path of hasSubprogram.
+
+#di_file2 = #llvm.di_file<"file.cpp" in "/folder/">
+#di_compile_unit2 = #llvm.di_compile_unit<
+  id = distinct[0]<>, sourceLanguage = DW_LANG_C_plus_plus_14,
+  file = #di_file2, isOptimized = true, emissionKind = Full
+>
+#di_sp_callee = #llvm.di_subprogram<
+  compileUnit = #di_compile_unit2, scope = #di_file2,
+  name = "callee_diloc", file = #di_file2,
+  subprogramFlags = "Definition|Optimized"
+>
+#di_sp_caller = #llvm.di_subprogram<
+  compileUnit = #di_compile_unit2, scope = #di_file2,
+  name = "caller_diloc", file = #di_file2,
+  subprogramFlags = "Definition|Optimized"
+>
+#loc_unknown = loc(unknown)
+#loc_callee = #llvm.di_location<loc("file.cpp":10:0) in #di_sp_callee>
+#loc_caller = #llvm.di_location<loc("file.cpp":20:0) in #di_sp_caller>
+
+llvm.func @callee_diloc() {
+  llvm.return
+} loc(#loc_callee)
+
+llvm.func @caller_diloc() {
+// CHECK: <unknown>:0: error: inlinable function call in a function with a DISubprogram location must have a debug location
+  llvm.call @callee_diloc() : () -> () loc(#loc_unknown)
+  llvm.return
+} loc(#loc_caller)

--- a/mlir/test/Dialect/LLVMIR/loop-metadata.mlir
+++ b/mlir/test/Dialect/LLVMIR/loop-metadata.mlir
@@ -83,7 +83,7 @@ llvm.func @loop_annotation() {
 
 // -----
 
-#di_file = #llvm.di_file<"metadata-loop.ll" in "/">
+#di_file = #llvm.di_file<"loop-metadata.mlir" in "/">
 
 // CHECK-DAG: #[[START_LOC:.*]] = loc("loop-metadata.mlir":42:4)
 #loc1 = loc("loop-metadata.mlir":42:4)

--- a/mlir/test/Dialect/LLVMIR/loop-metadata.mlir
+++ b/mlir/test/Dialect/LLVMIR/loop-metadata.mlir
@@ -85,19 +85,19 @@ llvm.func @loop_annotation() {
 
 #di_file = #llvm.di_file<"loop-metadata.mlir" in "/">
 
-// CHECK-DAG: #[[START_LOC:.*]] = loc("loop-metadata.mlir":42:4)
+// CHECK-DAG: #[[START_FILE:.*]] = loc({{.*}}:42:4)
 #loc1 = loc("loop-metadata.mlir":42:4)
-// CHECK-DAG: #[[END_LOC:.*]] = loc("loop-metadata.mlir":52:4)
+// CHECK-DAG: #[[END_FILE:.*]] = loc({{.*}}:52:4)
 #loc2 = loc("loop-metadata.mlir":52:4)
 
 #di_compile_unit = #llvm.di_compile_unit<id = distinct[0]<>, sourceLanguage = DW_LANG_C, file = #di_file, isOptimized = false, emissionKind = None>
 // CHECK-DAG: #[[SUBPROGRAM:.*]] = #llvm.di_subprogram<
 #di_subprogram = #llvm.di_subprogram<compileUnit = #di_compile_unit, scope = #di_file, name = "loop_locs", file = #di_file, subprogramFlags = Definition>
 
-// CHECK-DAG: #[[START_LOC_FUSED:.*]] = loc(fused<#[[SUBPROGRAM]]>[#[[START_LOC]]]
-#start_loc_fused = loc(fused<#di_subprogram>[#loc1])
-// CHECK-DAG: #[[END_LOC_FUSED:.*]] = loc(fused<#[[SUBPROGRAM]]>[#[[END_LOC]]]
-#end_loc_fused= loc(fused<#di_subprogram>[#loc2])
+// CHECK-DAG: #[[START_LOC:.*]] = #llvm.di_location<#[[START_FILE]] in #[[SUBPROGRAM]]>
+#start_loc = #llvm.di_location<#loc1 in #di_subprogram>
+// CHECK-DAG: #[[END_LOC:.*]] = #llvm.di_location<#[[END_FILE]] in #[[SUBPROGRAM]]>
+#end_loc = #llvm.di_location<#loc2 in #di_subprogram>
 
 // CHECK-DAG: #[[GROUP1:.*]] = #llvm.access_group<id = {{.*}}>
 // CHECK-DAG: #[[GROUP2:.*]] = #llvm.access_group<id = {{.*}}>
@@ -106,13 +106,13 @@ llvm.func @loop_annotation() {
 
 // CHECK: #[[LOOP_ANNOT:.*]] = #llvm.loop_annotation<
 // CHECK-DAG: disableNonforced = false
-// CHECK-DAG: startLoc = #[[START_LOC_FUSED]]
-// CHECK-DAG: endLoc = #[[END_LOC_FUSED]]
+// CHECK-DAG: startLoc = #[[START_LOC]]
+// CHECK-DAG: endLoc = #[[END_LOC]]
 // CHECK-DAG: parallelAccesses = #[[GROUP1]], #[[GROUP2]]>
 #loopMD = #llvm.loop_annotation<disableNonforced = false,
         mustProgress = true,
-        startLoc = #start_loc_fused,
-        endLoc = #end_loc_fused,
+        startLoc = #start_loc,
+        endLoc = #end_loc,
         parallelAccesses = #group1, #group2>
 
 // CHECK: llvm.func @loop_annotation_with_locs

--- a/mlir/test/Target/LLVMIR/Import/debug-info.ll
+++ b/mlir/test/Target/LLVMIR/Import/debug-info.ll
@@ -32,11 +32,11 @@ define i32 @instruction_loc(i32 %arg1) {
 ; CHECK-DAG: #[[RAW_FILE_LOC:.+]] = loc("debug-info.ll":1:2)
 ; CHECK-DAG: #[[SP:.+]] =  #llvm.di_subprogram<id = distinct[{{.*}}]<>, compileUnit = #{{.*}}, scope = #{{.*}}, name = "instruction_loc"
 ; CHECK-DAG: #[[CALLEE:.+]] =  #llvm.di_subprogram<id = distinct[{{.*}}]<>, compileUnit = #{{.*}}, scope = #{{.*}}, name = "callee"
-; CHECK-DAG: #[[FILE_LOC]] = loc(fused<#[[SP]]>[#[[RAW_FILE_LOC]]])
+; CHECK-DAG: #[[FILE_LOC]] = #llvm.di_location<#[[RAW_FILE_LOC]] in #[[SP]]>
 ; CHECK-DAG: #[[RAW_CALLEE_LOC:.+]] = loc("debug-info.ll":7:4)
-; CHECK-DAG: #[[CALLEE_LOC:.+]] = loc(fused<#[[CALLEE]]>[#[[RAW_CALLEE_LOC]]])
+; CHECK-DAG: #[[CALLEE_LOC:.+]] = #llvm.di_location<#[[RAW_CALLEE_LOC]] in #[[CALLEE]]>
 ; CHECK-DAG: #[[RAW_CALLER_LOC:.+]] = loc("debug-info.ll":2:2)
-; CHECK-DAG: #[[CALLER_LOC:.+]] = loc(fused<#[[SP]]>[#[[RAW_CALLER_LOC]]])
+; CHECK-DAG: #[[CALLER_LOC:.+]] = #llvm.di_location<#[[RAW_CALLER_LOC]] in #[[SP]]>
 ; CHECK-DAG: #[[CALLSITE_LOC:.+]] = loc(callsite(#[[CALLEE_LOC]] at #[[CALLER_LOC]]))
 
 !llvm.dbg.cu = !{!1}
@@ -68,8 +68,8 @@ define i32 @lexical_block(i32 %arg1) {
 ; CHECK: #[[SP:.+]] = #llvm.di_subprogram<id = distinct[{{.*}}]<>, compileUnit =
 ; CHECK: #[[LB0:.+]] = #llvm.di_lexical_block<scope = #[[SP]]>
 ; CHECK: #[[LB1:.+]] = #llvm.di_lexical_block<scope = #[[SP]], file = #[[FILE]], line = 2, column = 2>
-; CHECK: #[[LOC0]] = loc(fused<#[[LB0]]>[{{.*}}])
-; CHECK: #[[LOC1]] = loc(fused<#[[LB1]]>[{{.*}}])
+; CHECK: #[[LOC0]] = #llvm.di_location<{{.*}} in #[[LB0]]>
+; CHECK: #[[LOC1]] = #llvm.di_location<{{.*}} in #[[LB1]]>
 
 !llvm.dbg.cu = !{!1}
 !llvm.module.flags = !{!0}
@@ -100,8 +100,8 @@ define i32 @lexical_block_file(i32 %arg1) {
 ; CHECK: #[[SP:.+]] = #llvm.di_subprogram<id = distinct[{{.*}}]<>, compileUnit =
 ; CHECK: #[[LB0:.+]] = #llvm.di_lexical_block_file<scope = #[[SP]], discriminator = 0>
 ; CHECK: #[[LB1:.+]] = #llvm.di_lexical_block_file<scope = #[[SP]], file = #[[FILE]], discriminator = 0>
-; CHECK: #[[LOC0]] = loc(fused<#[[LB0]]>[
-; CHECK: #[[LOC1]] = loc(fused<#[[LB1]]>[
+; CHECK: #[[LOC0]] = #llvm.di_location<{{.*}} in #[[LB0]]>
+; CHECK: #[[LOC1]] = #llvm.di_location<{{.*}} in #[[LB1]]>
 
 !llvm.dbg.cu = !{!1}
 !llvm.module.flags = !{!0}
@@ -250,8 +250,7 @@ define void @func_loc() !dbg !3 {
 }
 ; CHECK-DAG: #[[FILE_LOC:.+]] = loc("debug-info.ll":42:0)
 ; CHECK-DAG: #[[SP:.+]] =  #llvm.di_subprogram<id = distinct[{{.*}}]<>, compileUnit = #{{.*}}, scope = #{{.*}}, name = "func_loc", file = #{{.*}}, line = 42, subprogramFlags = Definition, type = #{{.*}}>
-
-; CHECK: loc(fused<#[[SP]]>[#[[FILE_LOC]]]
+; CHECK-DAG: #{{.+}} = #llvm.di_location<#[[FILE_LOC]] in #[[SP]]>
 
 !llvm.dbg.cu = !{!1}
 !llvm.module.flags = !{!0}
@@ -294,8 +293,8 @@ define void @intrinsic(i64 %0, ptr %1) {
   ret void
 }
 
-; CHECK: #[[LOC1]] = loc(fused<#di_subprogram>[{{.*}}])
-; CHECK: #[[LOC0]] = loc(fused<#di_subprogram>[{{.*}}])
+; CHECK: #[[LOC1]] = #llvm.di_location<{{.*}} in #di_subprogram>
+; CHECK: #[[LOC0]] = #llvm.di_location<{{.*}} in #di_subprogram>
 
 declare void @llvm.dbg.value(metadata, metadata, metadata)
 declare void @llvm.dbg.declare(metadata, metadata, metadata)
@@ -331,7 +330,7 @@ define void @class_method() {
 ; CHECK-DAG: #[[COMP_PTR:.+]] = #llvm.di_derived_type<tag = DW_TAG_pointer_type, baseType = #[[COMP]], sizeInBits = 64, flags = "Artificial|ObjectPointer">
 ; CHECK-DAG: #[[SP_TYPE:.+]] = #llvm.di_subroutine_type<types = #{{.*}}, #[[COMP_PTR]]>
 ; CHECK-DAG: #[[SP:.+]] = #llvm.di_subprogram<recId = [[REC_ID]], id = [[SP_ID:.+]], compileUnit = #{{.*}}, scope = #[[COMP]], name = "class_method", file = #{{.*}}, subprogramFlags = Definition, type = #[[SP_TYPE]]>
-; CHECK-DAG: #[[LOC]] = loc(fused<#[[SP]]>
+; CHECK-DAG: #[[LOC]] = #llvm.di_location<{{.*}} in #[[SP]]>
 
 !llvm.dbg.cu = !{!1}
 !llvm.module.flags = !{!0}
@@ -575,7 +574,7 @@ declare void @llvm.dbg.value(metadata, metadata, metadata)
 ; // -----
 
 ; CHECK: #[[SUBPROGRAM:.*]] = #llvm.di_subprogram<id = distinct[{{.*}}]<>, compileUnit = #{{.*}}, scope = #{{.*}}, file = #{{.*}}, subprogramFlags = Definition, type = #{{.*}}>
-; CHECK: #[[FUNC_LOC:.*]] = loc(fused<#[[SUBPROGRAM]]>[{{.*}}])
+; CHECK: #[[FUNC_LOC:.*]] = #llvm.di_location<{{.*}} in #[[SUBPROGRAM]]>
 define void @noname_subprogram(ptr %arg) !dbg !8 {
   ret void
 }
@@ -647,7 +646,8 @@ declare !dbg !1 void @declaration()
 ; CHECK: #[[SP:.+]] = #llvm.di_subprogram<
 ; CHECK-NOT: id = distinct
 ; CHECK-NOT: subprogramFlags =
-; CHECK: loc(fused<#[[SP]]>
+; CHECK-SAME: >
+; CHECK: #{{.+}} = #llvm.di_location<{{.*}} in #[[SP]]>
 
 !llvm.module.flags = !{!0}
 !0 = !{i32 2, !"Debug Info Version", i32 3}

--- a/mlir/test/Target/LLVMIR/Import/metadata-loop.ll
+++ b/mlir/test/Target/LLVMIR/Import/metadata-loop.ll
@@ -342,15 +342,15 @@ end:
 
 ; // -----
 
-; CHECK: #[[start_loc:.*]] = loc("metadata-loop.ll":1:2)
-; CHECK: #[[end_loc:.*]] = loc("metadata-loop.ll":2:2)
+; CHECK: #[[start_file:.*]] = loc({{.*}}:1:2)
+; CHECK: #[[end_file:.*]] = loc({{.*}}:2:2)
 ; CHECK: #[[SUBPROGRAM:.*]] = #llvm.di_subprogram<
-; CHECK: #[[start_loc_fused:.*]] = loc(fused<#[[SUBPROGRAM]]>[#[[start_loc]]])
-; CHECK: #[[end_loc_fused:.*]] = loc(fused<#[[SUBPROGRAM]]>[#[[end_loc]]])
+; CHECK: #[[start_loc:.*]] = #llvm.di_location<#[[start_file]] in #[[SUBPROGRAM]]>
+; CHECK: #[[end_loc:.*]] = #llvm.di_location<#[[end_file]] in #[[SUBPROGRAM]]>
 ; CHECK: #[[$ANNOT_ATTR:.*]] = #llvm.loop_annotation<
 ; CHECK-SAME: mustProgress = true
-; CHECK-SAME: startLoc = #[[start_loc_fused]]
-; CHECK-SAME: endLoc = #[[end_loc_fused]]
+; CHECK-SAME: startLoc = #[[start_loc]]
+; CHECK-SAME: endLoc = #[[end_loc]]
 
 ; CHECK-LABEL: @loop_locs
 define void @loop_locs(i64 %n, ptr %A) {

--- a/mlir/test/Target/LLVMIR/llvmir-debug-fusedloc-no-scope.mlir
+++ b/mlir/test/Target/LLVMIR/llvmir-debug-fusedloc-no-scope.mlir
@@ -1,0 +1,39 @@
+// RUN: mlir-translate -mlir-to-llvmir --split-input-file %s | FileCheck %s
+
+// Verify that a FusedLoc without debug scope metadata does not crash when
+// sub-locations translate to nullptr (no scope available). This pattern is
+// produced by ClangIR which wraps source locations in FusedLoc without
+// attaching a DILocalScopeAttr.
+
+// CHECK-LABEL: define void @fusedloc_no_scope_no_debug()
+// CHECK-NOT: !dbg
+// CHECK: }
+llvm.func @fusedloc_no_scope_no_debug() {
+  llvm.return loc(fused["test.c":1:1, "test.c":2:2])
+}
+
+// -----
+
+// Verify the same situation when the function has a subprogram but the
+// FusedLoc contains UnknownLoc sub-locations (which always translate to
+// nullptr regardless of scope).
+
+#di_file = #llvm.di_file<"test.c" in "/tmp">
+#di_cu = #llvm.di_compile_unit<
+  id = distinct[0]<>, sourceLanguage = DW_LANG_C,
+  file = #di_file, isOptimized = false, emissionKind = Full
+>
+#void_return = #llvm.di_null_type
+#void_type = #llvm.di_subroutine_type<types = #void_return>
+#di_sp = #llvm.di_subprogram<
+  id = distinct[1]<>, compileUnit = #di_cu,
+  scope = #di_file, name = "fusedloc_unknown_sublocs",
+  file = #di_file, subprogramFlags = Definition, type = #void_type
+>
+
+// CHECK-LABEL: define void @fusedloc_unknown_sublocs() !dbg
+// CHECK-NOT: !dbg
+// CHECK: }
+llvm.func @fusedloc_unknown_sublocs() {
+  llvm.return loc(fused[unknown, unknown])
+} loc(fused<#di_sp>["test.c":1:1])

--- a/mlir/test/Target/LLVMIR/loop-metadata.mlir
+++ b/mlir/test/Target/LLVMIR/loop-metadata.mlir
@@ -302,12 +302,12 @@ llvm.func @loopOptions(%arg1 : i32, %arg2 : i32) {
 #void_type = #llvm.di_subroutine_type<types = #void_return>
 #di_subprogram = #llvm.di_subprogram<compileUnit = #di_compile_unit, scope = #di_file, name = "loop_locs", file = #di_file, subprogramFlags = Definition, type = #void_type>
 
-#start_loc_fused = loc(fused<#di_subprogram>[#loc1])
-#end_loc_fused= loc(fused<#di_subprogram>[#loc2])
+#start_loc = #llvm.di_location<#loc1 in #di_subprogram>
+#end_loc = #llvm.di_location<#loc2 in #di_subprogram>
 
 #loopMD = #llvm.loop_annotation<disableNonforced = false,
-        startLoc = #start_loc_fused,
-        endLoc = #end_loc_fused>
+        startLoc = #start_loc,
+        endLoc = #end_loc>
 
 // CHECK-LABEL: @loop_annotation_with_locs
 llvm.func @loop_annotation_with_locs() {
@@ -320,3 +320,38 @@ llvm.func @loop_annotation_with_locs() {
 // CHECK: ![[LOOP_NODE]] = distinct !{![[LOOP_NODE]], ![[START_LOC:.*]], ![[END_LOC:.*]]}
 // CHECK: ![[START_LOC]] = !DILocation(line: 42, column: 4, scope:
 // CHECK: ![[END_LOC]] = !DILocation(line: 52, column: 4, scope:
+
+// -----
+
+// Bare FileLineColLoc startLoc/endLoc fall back to the enclosing function's
+// DISubprogram scope.
+
+#di_file = #llvm.di_file<"metadata-loop.ll" in "/">
+
+#func_file = loc("metadata-loop.ll":1:1)
+#bare_start = loc("loop-metadata.mlir":42:4)
+#bare_end = loc("loop-metadata.mlir":52:4)
+
+#di_compile_unit = #llvm.di_compile_unit<id = distinct[0]<>, sourceLanguage = DW_LANG_C, file = #di_file, isOptimized = false, emissionKind = None>
+#void_return = #llvm.di_null_type
+#void_type = #llvm.di_subroutine_type<types = #void_return>
+#di_subprogram = #llvm.di_subprogram<compileUnit = #di_compile_unit, scope = #di_file, name = "loop_locs_fallback", file = #di_file, subprogramFlags = Definition, type = #void_type>
+
+#func_loc = #llvm.di_location<#func_file in #di_subprogram>
+
+#loopMD = #llvm.loop_annotation<disableNonforced = false,
+        startLoc = #bare_start,
+        endLoc = #bare_end>
+
+// CHECK-LABEL: @loop_annotation_bare_file_loc
+llvm.func @loop_annotation_bare_file_loc() {
+// CHECK: br {{.*}} !llvm.loop ![[LOOP_NODE:[0-9]+]]
+  llvm.br ^bb1 {loop_annotation = #loopMD}
+^bb1:
+  llvm.return
+} loc(#func_loc)
+
+// CHECK: ![[SUBPROGRAM:[0-9]+]] = distinct !DISubprogram(name: "loop_locs_fallback"
+// CHECK: ![[LOOP_NODE]] = distinct !{![[LOOP_NODE]], ![[START_LOC:.*]], ![[END_LOC:.*]]}
+// CHECK-DAG: ![[START_LOC]] = !DILocation(line: 42, column: 4, scope: ![[SUBPROGRAM]])
+// CHECK-DAG: ![[END_LOC]] = !DILocation(line: 52, column: 4, scope: ![[SUBPROGRAM]])

--- a/mlir/test/Target/LLVMIR/loop-metadata.mlir
+++ b/mlir/test/Target/LLVMIR/loop-metadata.mlir
@@ -292,7 +292,7 @@ llvm.func @loopOptions(%arg1 : i32, %arg2 : i32) {
 
 // -----
 
-#di_file = #llvm.di_file<"metadata-loop.ll" in "/">
+#di_file = #llvm.di_file<"loop-metadata.mlir" in "/">
 
 #loc1 = loc("loop-metadata.mlir":42:4)
 #loc2 = loc("loop-metadata.mlir":52:4)


### PR DESCRIPTION
Introduces DILocationAttr, a new MLIR location attribute that pairs a FileLineColLoc with a DIScopeAttr to carry debug scope information directly on locations instead of encoding it as FusedLoc metadata. Replaces FusedLoc-with-metadata patterns across the LLVM dialect transforms.