### PR TITLE
[mlir] Fix crash in diagnostic verifier for unmatched @unknown expectations

### DIFF
--- a/mlir/lib/IR/Diagnostics.cpp
+++ b/mlir/lib/IR/Diagnostics.cpp
@@ -600,9 +600,17 @@ struct ExpectedDiag {
   /// Emit an error at the location referenced by this diagnostic.
   LogicalResult emitError(raw_ostream &os, llvm::SourceMgr &mgr,
                           const Twine &msg) {
-    SMRange range(fileLoc, SMLoc::getFromPointer(fileLoc.getPointer() +
-                                                 substring.size()));
-    mgr.PrintMessage(os, fileLoc, llvm::SourceMgr::DK_Error, msg, range);
+    // fileLoc may be invalid when the expected diagnostic used an unknown
+    // location specifier (e.g. `// expected-error @unknown {{...}}`). In that
+    // case, skip the source range to avoid a null-pointer dereference and an
+    // assertion in SMRange that both endpoints must have the same validity.
+    if (fileLoc.isValid()) {
+      SMRange range(fileLoc, SMLoc::getFromPointer(fileLoc.getPointer() +
+                                                   substring.size()));
+      mgr.PrintMessage(os, fileLoc, llvm::SourceMgr::DK_Error, msg, range);
+    } else {
+      mgr.PrintMessage(os, fileLoc, llvm::SourceMgr::DK_Error, msg);
+    }
     return failure();
   }
 

--- a/mlir/test/mlir-opt/expected-unknown-loc-unmatched.mlir
+++ b/mlir/test/mlir-opt/expected-unknown-loc-unmatched.mlir
@@ -1,0 +1,9 @@
+// Test that an unmatched `expected-*` directive using the `@unknown` location
+// specifier emits a diagnostic instead of crashing.
+// See https://github.com/llvm/llvm-project/issues/163343
+
+// RUN: not mlir-opt --verify-diagnostics %s 2>&1 | FileCheck %s
+
+// CHECK: expected warning "some warning that is never produced" was not produced
+
+// expected-warning @unknown {{some warning that is never produced}}


### PR DESCRIPTION
When an expected-* directive uses the @unknown location specifier, the associated ExpectedDiag record has an invalid (null) SMLoc as its fileLoc. If the expected diagnostic is never produced, emitError() is called to report the unmatched expectation, but it unconditionally constructs an SMRange from fileLoc, triggering a null-pointer dereference (UBSan) and an assertion failure in SMRange's constructor which requires both endpoints to have equal validity.

Fix by guarding the SMRange construction with a fileLoc.isValid() check. When fileLoc is invalid, call PrintMessage without a source range.

Fixes #163343

Assisted-by: Claude Code