### PR TITLE
[mlir][DataFlow] Fix crash in TestLastModifiedPass for unreachable private functions

### DIFF
--- a/mlir/test/Analysis/DataFlow/test-last-modified.mlir
+++ b/mlir/test/Analysis/DataFlow/test-last-modified.mlir
@@ -348,3 +348,14 @@ func.func @store_with_a_loop_region_after_containing_a_store(%arg0: memref<f32>)
   memref.store %1, %arg0[] {tag_name = "post"} : memref<f32>
   return {tag = "return"} %arg0 : memref<f32>
 }
+
+// Regression test for https://github.com/llvm/llvm-project/issues/128333:
+// In interprocedural analysis mode, private functions that are never called
+// should not cause an assertion failure when querying the dense lattice.
+// Instead, the pass should gracefully report "<not computed>".
+// CHECK-LABEL: test_tag: tag_in_unreachable_private
+// CHECK-NEXT:   - <not computed>
+func.func private @unreachable_private(%arg0: i32) {
+  %cond = arith.index_cast %arg0 {tag = "tag_in_unreachable_private"} : i32 to index
+  return
+}

--- a/mlir/test/lib/Analysis/DataFlow/TestDenseForwardDataFlowAnalysis.cpp
+++ b/mlir/test/lib/Analysis/DataFlow/TestDenseForwardDataFlowAnalysis.cpp
@@ -256,7 +256,13 @@ struct TestLastModifiedPass
       os << "test_tag: " << tag.getValue() << ":\n";
       const LastModification *lastMods =
           solver.lookupState<LastModification>(solver.getProgramPointAfter(op));
-      assert(lastMods && "expected a dense lattice");
+      if (!lastMods) {
+        // The lattice may not be computed for operations in unreachable code
+        // (e.g., private functions not called from anywhere in interprocedural
+        // analysis mode).
+        os << " - <not computed>\n";
+        return;
+      }
       for (auto [index, operand] : llvm::enumerate(op->getOperands())) {
         os << " operand #" << index << "\n";
         std::optional<Value> underlyingValue =


### PR DESCRIPTION
TestLastModifiedPass asserted that a dense lattice state is always present after running the data flow solver. However, in interprocedural analysis mode (the default), private functions that are never called from any callee in the module are not analyzed, so no lattice state is computed for their program points.

Replace the assertion with a null check that prints "<not computed>" when the lattice state is absent. This matches the expected behavior: unreachable code in interprocedural mode simply has no computed analysis result.

Add a regression test for the case where a tagged op is inside an unreachable private function.

Fixes #128333

Assisted-by: Claude Code