### PR TITLE
[mlir] Fix crash in TestSymbolUses when erasing functions from nested modules

### DIFF
--- a/mlir/test/IR/test-symbol-uses.mlir
+++ b/mlir/test/IR/test-symbol-uses.mlir
@@ -93,3 +93,18 @@ module {
     return
   }
 }
+
+// -----
+
+// Regression test for https://github.com/llvm/llvm-project/issues/60583:
+// Erasing a dead private function nested inside an inner module must not
+// crash. Previously, SymbolTable was constructed from the outer module and
+// lookup of the inner function asserted because it was in the inner module's
+// symbol table instead.
+// expected-remark@below {{printMemrefF32 function successfully erased}}
+module {
+  module {
+    // expected-remark@below {{symbol has no uses}}
+    func.func private @printMemrefF32(%ptr : memref<*xf32>)
+  }
+}

--- a/mlir/test/lib/IR/TestSymbolUses.cpp
+++ b/mlir/test/lib/IR/TestSymbolUses.cpp
@@ -79,11 +79,15 @@ struct SymbolUsesPass
       return operateOnSymbol(nestedOp, module, deadFunctions);
     });
 
-    SymbolTable table(module);
     for (Operation *op : deadFunctions) {
       // In order to test the SymbolTable::erase method, also erase completely
-      // useless functions.
+      // useless functions. Use the nearest symbol table parent of the function
+      // to handle the case where it is nested inside another symbol table.
       auto name = SymbolTable::getSymbolName(op);
+      Operation *symbolTableOp =
+          SymbolTable::getNearestSymbolTable(op->getParentOp());
+      assert(symbolTableOp && "expected a parent symbol table");
+      SymbolTable table(symbolTableOp);
       assert(table.lookup(name) && "expected no unknown operations");
       table.erase(op);
       assert(!table.lookup(name) &&


### PR DESCRIPTION
SymbolUsesPass collected dead functions via a recursive walk, then tried to erase them using a SymbolTable constructed from the top-level module. When a dead function was nested inside an inner module, the outer module's symbol table did not contain it, causing the assertion "expected no unknown operations" to fail.

Fix by constructing the SymbolTable from the nearest symbol table parent of each dead function instead of from the top-level module, so the lookup and erase operate on the correct scope.

Fixes #60583

Assisted-by: Claude Code