### PR TITLE
[mlir] Fix assert in TestWrittenToPass for unreachable private functions

### DIFF
--- a/mlir/test/Analysis/DataFlow/test-written-to.mlir
+++ b/mlir/test/Analysis/DataFlow/test-written-to.mlir
@@ -364,3 +364,18 @@ func.func @test_external_callee(%arg0: i32, %m0: memref<i32>) {
   memref.store %1, %m0[] {tag_name = "a"} : memref<i32>
   return
 }
+
+// -----
+
+// Regression test for https://github.com/llvm/llvm-project/issues/128339
+// A private function that is never called should not crash the analysis —
+// its lattice state is simply not computed.
+
+// CHECK-LABEL: test_tag: in_private2
+// CHECK-NEXT:   operand #0: <not computed>
+// CHECK-NEXT:   result #0: <not computed>
+
+func.func private @private2(%arg0: i32) {
+  %0 = arith.index_cast %arg0 {tag = "in_private2"} : i32 to index
+  return
+}

--- a/mlir/test/lib/Analysis/DataFlow/TestSparseBackwardDataFlowAnalysis.cpp
+++ b/mlir/test/lib/Analysis/DataFlow/TestSparseBackwardDataFlowAnalysis.cpp
@@ -198,14 +198,23 @@ struct TestWrittenToPass
       os << "test_tag: " << tag.getValue() << ":\n";
       for (auto [index, operand] : llvm::enumerate(op->getOperands())) {
         const WrittenTo *writtenTo = solver.lookupState<WrittenTo>(operand);
-        assert(writtenTo && "expected a sparse lattice");
+        if (!writtenTo) {
+          // The lattice may not be computed for values in unreachable code
+          // (e.g., private functions not called from anywhere in
+          // interprocedural analysis mode).
+          os << " operand #" << index << ": <not computed>\n";
+          continue;
+        }
         os << " operand #" << index << ": ";
         writtenTo->print(os);
         os << "\n";
       }
       for (auto [index, operand] : llvm::enumerate(op->getResults())) {
         const WrittenTo *writtenTo = solver.lookupState<WrittenTo>(operand);
-        assert(writtenTo && "expected a sparse lattice");
+        if (!writtenTo) {
+          os << " result #" << index << ": <not computed>\n";
+          continue;
+        }
         os << " result #" << index << ": ";
         writtenTo->print(os);
         os << "\n";


### PR DESCRIPTION
TestSparseBackwardDataFlowAnalysis::TestWrittenToPass asserted that the WrittenTo sparse lattice was always computed for tagged operands and results. This assertion fires when analyzing a private function that is never called from anywhere: in interprocedural mode the backward data flow solver does not visit such dead code, leaving the lattice state uninitialized.

Replace the assertions with null checks that print "<not computed>" instead, matching the approach used in TestDenseForwardDataFlowAnalysis for the analogous dense forward case.

Fixes #128339

Assisted-by: Claude Code