### PR TITLE
[libc] Add support for chown on platforms that don't define SYS_chown

### DIFF
--- a/libc/config/linux/riscv/entrypoints.txt
+++ b/libc/config/linux/riscv/entrypoints.txt
@@ -324,6 +324,7 @@ set(TARGET_LIBC_ENTRYPOINTS
     # unistd.h entrypoints
     libc.src.unistd.access
     libc.src.unistd.chdir
+    libc.src.unistd.chown
     libc.src.unistd.close
     libc.src.unistd.dup
     libc.src.unistd.dup2

--- a/libc/src/unistd/linux/CMakeLists.txt
+++ b/libc/src/unistd/linux/CMakeLists.txt
@@ -32,6 +32,7 @@ add_entrypoint_object(
   HDRS
     ../chown.h
   DEPENDS
+    libc.hdr.fcntl_macros
     libc.hdr.types.uid_t
     libc.hdr.types.gid_t
     libc.include.sys_syscall

--- a/libc/src/unistd/linux/chown.cpp
+++ b/libc/src/unistd/linux/chown.cpp
@@ -11,6 +11,7 @@
 #include "src/__support/OSUtil/syscall.h" // For internal syscall function.
 #include "src/__support/common.h"
 
+#include "hdr/fcntl_macros.h"
 #include "src/__support/libc_errno.h"
 #include "src/__support/macros/config.h"
 #include <sys/syscall.h> // For syscall numbers.
@@ -18,7 +19,15 @@
 namespace LIBC_NAMESPACE_DECL {
 
 LLVM_LIBC_FUNCTION(int, chown, (const char *path, uid_t owner, gid_t group)) {
+#ifdef SYS_chown
   int ret = LIBC_NAMESPACE::syscall_impl<int>(SYS_chown, path, owner, group);
+#elif defined(SYS_fchownat)
+  int ret = LIBC_NAMESPACE::syscall_impl<int>(SYS_fchownat, AT_FDCWD, path,
+                                              owner, group, 0);
+#else
+#error "chown and fchownat syscalls not available."
+#endif
+
   if (ret < 0) {
     libc_errno = -ret;
     return -1;


### PR DESCRIPTION
Some platforms don't define SYS_chown (like risc-v), so this PR adds a fallback to calling SYS_fchownat.