### PR TITLE
[SystemZ] Drop assertion against preg-def in definesCmp0Src().

### DIFF
--- a/llvm/lib/Target/SystemZ/SystemZMachineScheduler.cpp
+++ b/llvm/lib/Target/SystemZ/SystemZMachineScheduler.cpp
@@ -77,7 +77,6 @@ bool SystemZPreRASchedStrategy::definesCmp0Src(const MachineInstr *MI,
   if (Cmp0SrcReg != SystemZ::NoRegister && MI->getNumOperands() &&
       (MI->getDesc().hasImplicitDefOfPhysReg(SystemZ::CC) || !CCDef)) {
     const MachineOperand &MO0 = MI->getOperand(0);
-    assert(!isPhysRegDef(MO0) && "Did not expect physreg def!");
     if (isRegDef(MO0) && MO0.getReg() == Cmp0SrcReg)
       return true;
   }


### PR DESCRIPTION
This assertion was some kind of sanity check that there are no physreg defining instructions between a compare with zero and the instruction defining the compared value. This is the expected generally with calls as they clobber CC and their outgoing preg definitions should always end up just above the call, below any compare with zero.

However, with an inline asm that does not clobber CC this could actually happen. As biasPhysRegExtra() will now handle any such preg def of MO0, it seems this assertion isn't that useful anymore.