### PR TITLE
[OpenMP][OMPT] Remove Threads dependency from omptest link interface

### DIFF
--- a/openmp/tools/omptest/CMakeLists.txt
+++ b/openmp/tools/omptest/CMakeLists.txt
@@ -87,9 +87,10 @@ if ((NOT LIBOMPTEST_BUILD_STANDALONE) OR LIBOMPTEST_BUILD_UNITTESTS)
   # available to dependant targets, e.g. for unit tests.
   target_link_libraries(omptest PUBLIC default_gtest)
 
-  # Link against Threads (recommended for GTest).
+  # Link against Threads, which may be required for GTest.
+  # But keep it out of the link interface to avoid transitive dependencies.
   find_package(Threads REQUIRED)
-  target_link_libraries(omptest PUBLIC Threads::Threads)
+  target_link_libraries(omptest PRIVATE Threads::Threads)
 
   # Ensure that embedded GTest symbols are exported from libomptest.so even in
   # builds that default to hidden.


### PR DESCRIPTION
Link against Threads using PRIVATE scope, instead of PUBLIC.
Reason: it imposes a transitive dependency on library users.

If Threads could not be found this could cause a link error.
The issue would manifest, if omptest is used via find_package.

Addresses issues with previous PR https://github.com/llvm/llvm-project/pull/185930