### PR TITLE
[mlir][arith] Fix crash in IntRangeOptimizations due to stale solver state

### DIFF
--- a/mlir/lib/Dialect/Arith/Transforms/IntRangeOptimizations.cpp
+++ b/mlir/lib/Dialect/Arith/Transforms/IntRangeOptimizations.cpp
@@ -676,9 +676,14 @@ struct IntRangeOptimizationsPass final
     RewritePatternSet patterns(ctx);
     populateIntRangeOptimizationsPatterns(patterns, solver);
 
+    // Disable folding to avoid potential control-flow folding that would break
+    // the solver state: this happens for example when a block argument is
+    // folded and other block arguments inherit from the address of the folded
+    // block argument. Further queries to the remaining block arguments would
+    // then return the solver state associated to the original block argument.
     if (failed(applyPatternsGreedily(
             op, std::move(patterns),
-            GreedyRewriteConfig().setListener(&listener))))
+            GreedyRewriteConfig().enableFolding(false).setListener(&listener))))
       signalPassFailure();
   }
 };


### PR DESCRIPTION
When the IntRangeOptimizationsPass runs applyPatternsGreedily with constant folding enabled, constant folding can restructure blocks — for example by removing a block argument. The integer range solver, which pre-computed range information for the original block arguments, is now out of sync: subsequent range queries about the new (reused) argument positions return stale information computed for the old arguments, causing crashes.

Fix by passing enableConstantFolding(false) in GreedyRewriteConfig so that the solver's state remains consistent with the IR throughout the rewrite.

Fixes #122076

Assisted-by: Claude Code