### PR TITLE
[mlir][python] Avoid needless std::string copies in properties. NFC.

### DIFF
--- a/mlir/lib/Bindings/Python/DialectLLVM.cpp
+++ b/mlir/lib/Bindings/Python/DialectLLVM.cpp
@@ -128,14 +128,13 @@ struct StructType : PyConcreteType<StructType> {
         "name"_a, "elements"_a, nb::kw_only(), "packed"_a = false,
         "context"_a = nb::none());
 
-    c.def_prop_ro(
-        "name", [](const StructType &type) -> std::optional<std::string> {
-          if (mlirLLVMStructTypeIsLiteral(type))
-            return std::nullopt;
+    c.def_prop_ro("name",
+                  [](const StructType &type) -> std::optional<MlirStringRef> {
+                    if (mlirLLVMStructTypeIsLiteral(type))
+                      return std::nullopt;
 
-          MlirStringRef stringRef = mlirLLVMStructTypeGetIdentifier(type);
-          return std::string(stringRef.data, stringRef.length);
-        });
+                    return mlirLLVMStructTypeGetIdentifier(type);
+                  });
 
     c.def_prop_ro("body", [](const StructType &type) -> nb::object {
       // Don't crash in absence of a body.

--- a/mlir/lib/Bindings/Python/IRAttributes.cpp
+++ b/mlir/lib/Bindings/Python/IRAttributes.cpp
@@ -511,10 +511,11 @@ void PySymbolRefAttribute::bindDerived(ClassTy &c) {
   c.def_prop_ro(
       "value",
       [](PySymbolRefAttribute &self) {
-        std::vector<MlirStringRef> symbols = {
-            mlirSymbolRefAttrGetRootReference(self)};
-        for (int i = 0; i < mlirSymbolRefAttrGetNumNestedReferences(self);
-             ++i) {
+        intptr_t numNested = mlirSymbolRefAttrGetNumNestedReferences(self);
+        std::vector<MlirStringRef> symbols;
+        symbols.reserve(numNested + 1);
+        symbols.push_back(mlirSymbolRefAttrGetRootReference(self));
+        for (intptr_t i = 0; i < numNested; ++i) {
           symbols.push_back(mlirSymbolRefAttrGetRootReference(
               mlirSymbolRefAttrGetNestedReference(self, i)));
         }

--- a/mlir/lib/Bindings/Python/IRAttributes.cpp
+++ b/mlir/lib/Bindings/Python/IRAttributes.cpp
@@ -511,14 +511,12 @@ void PySymbolRefAttribute::bindDerived(ClassTy &c) {
   c.def_prop_ro(
       "value",
       [](PySymbolRefAttribute &self) {
-        MlirStringRef rootRef = mlirSymbolRefAttrGetRootReference(self);
-        std::vector<std::string> symbols = {
-            std::string(rootRef.data, rootRef.length)};
+        std::vector<MlirStringRef> symbols = {
+            mlirSymbolRefAttrGetRootReference(self)};
         for (int i = 0; i < mlirSymbolRefAttrGetNumNestedReferences(self);
              ++i) {
-          MlirStringRef nestedRef = mlirSymbolRefAttrGetRootReference(
-              mlirSymbolRefAttrGetNestedReference(self, i));
-          symbols.push_back(std::string(nestedRef.data, nestedRef.length));
+          symbols.push_back(mlirSymbolRefAttrGetRootReference(
+              mlirSymbolRefAttrGetNestedReference(self, i)));
         }
         return symbols;
       },


### PR DESCRIPTION
MlirStringRef is copied into a Python str by nanobind's type_caster anyway, so the intermediate std::string was a redundant allocation.