### PR TITLE
[MLIR] Fix crash when parsing typed attribute via parseOptionalAttribute

### DIFF
--- a/mlir/include/mlir/IR/OpImplementation.h
+++ b/mlir/include/mlir/IR/OpImplementation.h
@@ -1142,6 +1142,26 @@ public:
   virtual OptionalParseResult parseOptionalAttribute(SymbolRefAttr &result,
                                                      Type type = {}) = 0;
 
+  /// Parse an optional attribute of a specific typed result. This overload
+  /// handles concrete attribute types (e.g. FloatAttr) that are not covered by
+  /// a dedicated virtual overload. It parses any attribute and then validates
+  /// that the result is of the expected type, emitting an error if not.
+  template <typename AttrType>
+  std::enable_if_t<!llvm::is_one_of<AttrType, Attribute, ArrayAttr, StringAttr,
+                                    SymbolRefAttr>::value,
+                   OptionalParseResult>
+  parseOptionalAttribute(AttrType &result, Type type = {}) {
+    Attribute attr;
+    OptionalParseResult parseResult = parseOptionalAttribute(attr, type);
+    if (!parseResult.has_value() || failed(*parseResult))
+      return parseResult;
+    result = dyn_cast<AttrType>(attr);
+    if (!result)
+      return emitError(getCurrentLocation())
+             << "expected attribute of a different type";
+    return success();
+  }
+
   /// Parse an optional attribute of a specific type and add it to the list with
   /// the specified name.
   template <typename AttrType>

--- a/mlir/test/IR/invalid-custom-print-parse.mlir
+++ b/mlir/test/IR/invalid-custom-print-parse.mlir
@@ -25,4 +25,11 @@ test.optional_custom_attr foo
 // expected-error @below {{unknown key '"foo"' when parsing properties dictionary}}
 test.op_with_enum_prop_attr_form <{value = 0 : i32, foo}>
 
+// -----
+
+// Test that an integer literal cannot be used where an APFloat is expected.
+// parseOptionalAttribute(FloatAttr &) should reject a non-float attribute.
+// expected-error@+2 {{expected attribute of a different type}}
+// expected-error@+1 {{failed to parse TestTypeAPFloat parameter}}
+func.func private @test_ap_float_wrong_attr_type() -> !test.ap_float<5U0>
 


### PR DESCRIPTION
When calling `parseOptionalAttribute(result, type)` with a typed result (e.g. `FloatAttr`), the call resolved to the generic `parseOptionalAttribute(Attribute&, Type)` overload via implicit conversion. This overload accepted any attribute, including ones that don't match the expected concrete type. The caller would then invoke type-specific methods (e.g. `FloatAttr::getValue()`) on storage that belongs to a different attribute kind (e.g. `IntegerAttr`), causing a type-confusion crash.

The fix adds a non-virtual template overload of `parseOptionalAttribute` in `AsmParser` that intercepts calls for concrete attribute types not covered by the dedicated virtual overloads (`Attribute`, `ArrayAttr`, `StringAttr`, `SymbolRefAttr`). It parses the attribute generically and then validates the result type via `dyn_cast`, emitting an error if the parsed attribute is of the wrong kind.

Fixes #108135

Assisted-by: Claude Code