### PR TITLE
[lldb][FreeBSDKernelCore] Do not include <cstddef>

### DIFF
--- a/lldb/source/Plugins/Process/FreeBSD-Kernel-Core/RegisterContextFreeBSDKernelCore_arm.cpp
+++ b/lldb/source/Plugins/Process/FreeBSD-Kernel-Core/RegisterContextFreeBSDKernelCore_arm.cpp
@@ -15,7 +15,6 @@
 #include "llvm/Support/Endian.h"
 
 #if defined(__FreeBSD__) && defined(__arm__)
-#include <cstddef>
 #include <machine/frame.h>
 #endif
 

--- a/lldb/source/Plugins/Process/FreeBSD-Kernel-Core/RegisterContextFreeBSDKernelCore_arm64.cpp
+++ b/lldb/source/Plugins/Process/FreeBSD-Kernel-Core/RegisterContextFreeBSDKernelCore_arm64.cpp
@@ -19,7 +19,6 @@
 #include "llvm/Support/Endian.h"
 
 #if defined(__FreeBSD__) && defined(__aarch64__)
-#include <cstddef>
 #include <machine/pcb.h>
 #include <sys/param.h>
 #endif

--- a/lldb/source/Plugins/Process/FreeBSD-Kernel-Core/RegisterContextFreeBSDKernelCore_i386.cpp
+++ b/lldb/source/Plugins/Process/FreeBSD-Kernel-Core/RegisterContextFreeBSDKernelCore_i386.cpp
@@ -14,7 +14,6 @@
 #include "llvm/Support/Endian.h"
 
 #if defined(__FreeBSD__) && defined(__i386__)
-#include <cstddef>
 #include <machine/pcb.h>
 #endif
 

--- a/lldb/source/Plugins/Process/FreeBSD-Kernel-Core/RegisterContextFreeBSDKernelCore_ppc64le.cpp
+++ b/lldb/source/Plugins/Process/FreeBSD-Kernel-Core/RegisterContextFreeBSDKernelCore_ppc64le.cpp
@@ -14,7 +14,6 @@
 #include "llvm/Support/Endian.h"
 
 #if defined(__FreeBSD__) && defined(__powerpc64__) && defined(__LITTLE_ENDIAN__)
-#include <cstddef>
 #include <machine/pcb.h>
 #endif
 

--- a/lldb/source/Plugins/Process/FreeBSD-Kernel-Core/RegisterContextFreeBSDKernelCore_riscv64.cpp
+++ b/lldb/source/Plugins/Process/FreeBSD-Kernel-Core/RegisterContextFreeBSDKernelCore_riscv64.cpp
@@ -14,7 +14,6 @@
 #include "llvm/Support/Endian.h"
 
 #if defined(__FreeBSD__) && defined(__riscv) && __riscv_xlen == 64
-#include <cstddef>
 #include <machine/pcb.h>
 #endif
 

--- a/lldb/source/Plugins/Process/FreeBSD-Kernel-Core/RegisterContextFreeBSDKernelCore_x86_64.cpp
+++ b/lldb/source/Plugins/Process/FreeBSD-Kernel-Core/RegisterContextFreeBSDKernelCore_x86_64.cpp
@@ -14,7 +14,6 @@
 #include "llvm/Support/Endian.h"
 
 #if defined(__FreeBSD__) && defined(__amd64__)
-#include <cstddef>
 #include <machine/pcb.h>
 #endif
 


### PR DESCRIPTION
`<cstddef>` was included for static assertion using `offsetof()`, but it turns out that the header is already included before. Thus remove `<cstddef>` includes from `RegisterContextFreeBSDKernelCore_<arch>.cpp` files.

Fixes 3f65a03e8abb3e6fb3372cf4c254d6c9f090e2e0 (#183969)