### PR TITLE
[Clang][Sema] Fix crash in CheckNonTypeTemplateParameterType with invalid type

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -327,6 +327,7 @@ Bug Fixes in This Version
 - Fixed a bug with multiple-include optimization (MIOpt) state not being preserved in some cases during lexing, which could suppress header-guard mismatch diagnostics and interfere with include-guard optimization. (#GH180155)
 - Fixed a crash when normalizing constraints involving concept template parameters whose index coincided with non-concept template parameters in the same parameter mapping.
 - Fixed a crash caused by accessing dependent diagnostics of a non-dependent context.
+- Fixed a crash when substituting into a non-type template parameter that has a type containing an undeduced placeholder type.
 
 Bug Fixes to Compiler Builtins
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/lib/Sema/SemaTemplate.cpp
+++ b/clang/lib/Sema/SemaTemplate.cpp
@@ -1342,7 +1342,10 @@ QualType Sema::CheckNonTypeTemplateParameterType(TypeSourceInfo *&TSI,
     //    - an identifier associated by name lookup with a non-type
     //      template-parameter declared with a type that contains a
     //      placeholder type (7.1.7.4),
-    TSI = SubstAutoTypeSourceInfoDependent(TSI);
+    TypeSourceInfo *NewTSI = SubstAutoTypeSourceInfoDependent(TSI);
+    if (!NewTSI)
+      return QualType();
+    TSI = NewTSI;
   }
 
   return CheckNonTypeTemplateParameterType(TSI->getType(), Loc);

--- a/clang/test/SemaTemplate/deduction-crash.cpp
+++ b/clang/test/SemaTemplate/deduction-crash.cpp
@@ -172,3 +172,8 @@ namespace PR51872_part1 {
   // expected-error@-1 {{no viable constructor or deduction guide for deduction of template arguments of 'T1'}}
   // expected-note@-7  {{candidate template ignored: could not match 'PR51872_part1::T1<value-parameter-0-0>' against 'int'}}
 }
+
+namespace GH177545 {
+  template<decltype(auto)()() volatile throw() -> char> // expected-error {{'decltype(auto)' can only be used as a return type in a function declaration}}
+  struct T2;                                            // expected-error@-1 {{function cannot return function type 'auto () volatile throw() -> decltype(auto)'}}
+}

--- a/clang/test/SemaTemplate/deduction-crash.cpp
+++ b/clang/test/SemaTemplate/deduction-crash.cpp
@@ -175,5 +175,5 @@ namespace PR51872_part1 {
 
 namespace GH177545 {
   template<decltype(auto)()() volatile throw() -> char> // expected-error {{'decltype(auto)' can only be used as a return type in a function declaration}}
-  struct T2;                                            // expected-error@-1 {{function cannot return function type 'auto () volatile throw() -> decltype(auto)'}}
+  struct T2;                                            // expected-error@* {{function cannot return function type 'auto () volatile throw() -> decltype(auto)'}}
 }


### PR DESCRIPTION
When a non-type template parameter has a type containing an undeduced placeholder type that is invalid (e.g., a function returning a function), `SubstAutoTypeSourceInfoDependent` can return null if the type is invalid. `CheckNonTypeTemplateParameterType` was not handling this case and would dereference the null pointer.

Fixes #177545