### PR TITLE
[NFC][analyzer] Eliminate NodeBuilder::getContext()

### DIFF
--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/CheckerContext.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/CheckerContext.h
@@ -89,9 +89,7 @@ public:
 
   /// Returns the number of times the current block has been visited
   /// along the analyzed path.
-  unsigned blockCount() const {
-    return NB.getContext().blockCount();
-  }
+  unsigned blockCount() const { return Eng.getNumVisitedCurrent(); }
 
   ASTContext &getASTContext() {
     return Eng.getContext();
@@ -155,9 +153,7 @@ public:
   }
 
   /// Get the blockID.
-  unsigned getBlockID() const {
-    return NB.getContext().getBlock()->getBlockID();
-  }
+  unsigned getBlockID() const { return Eng.getCurrBlock()->getBlockID(); }
 
   /// If the given node corresponds to a PostStore program point,
   /// retrieve the location region as it was uttered in the code.

--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/CoreEngine.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/CoreEngine.h
@@ -306,7 +306,6 @@ public:
 
   const ExplodedNodeSet &getResults() const { return Frontier; }
 
-  const NodeBuilderContext &getContext() const { return C; }
   bool hasGeneratedNodes() const { return HasGeneratedNodes; }
 
   void takeNodes(const ExplodedNodeSet &S) {

--- a/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
@@ -2562,7 +2562,7 @@ void ExprEngine::processCFGBlockEntrance(const BlockEdge &L,
   // other constraints) then consider completely unrolling it.
   if(AMgr.options.ShouldUnrollLoops) {
     unsigned maxBlockVisitOnPath = AMgr.options.maxBlockVisitOnPath;
-    const Stmt *Term = Builder.getContext().getBlock()->getTerminatorStmt();
+    const Stmt *Term = getCurrBlock()->getTerminatorStmt();
     if (Term) {
       ProgramStateRef NewState = updateLoopStack(Term, AMgr.getASTContext(),
                                                  Pred, maxBlockVisitOnPath);
@@ -2580,10 +2580,10 @@ void ExprEngine::processCFGBlockEntrance(const BlockEdge &L,
 
   // If this block is terminated by a loop and it has already been visited the
   // maximum number of times, widen the loop.
-  unsigned int BlockCount = Builder.getContext().blockCount();
+  unsigned int BlockCount = getNumVisitedCurrent();
   if (BlockCount == AMgr.options.maxBlockVisitOnPath - 1 &&
       AMgr.options.ShouldWidenLoops) {
-    const Stmt *Term = Builder.getContext().getBlock()->getTerminatorStmt();
+    const Stmt *Term = getCurrBlock()->getTerminatorStmt();
     if (!isa_and_nonnull<ForStmt, WhileStmt, DoStmt, CXXForRangeStmt>(Term))
       return;
 
@@ -2596,9 +2596,8 @@ void ExprEngine::processCFGBlockEntrance(const BlockEdge &L,
     // would be stale.  Ideally, we should pass on the terminator of the CFG
     // block, but the terminator cannot be referred as a CFG element.
     // Here we just pass the the first CFG element in the block.
-    ProgramStateRef WidenedState =
-        getWidenedLoopState(Pred->getState(), LCtx, BlockCount,
-                            *Builder.getContext().getBlock()->ref_begin());
+    ProgramStateRef WidenedState = getWidenedLoopState(
+        Pred->getState(), LCtx, BlockCount, *getCurrBlock()->ref_begin());
     Builder.generateNode(BE, WidenedState, Pred);
     return;
   }


### PR DESCRIPTION
This is a step towards the removal of the type `NodeBuilderContext`.

The few remaining locations that used `NodeBuilder::getContext()` were changed to use the methods `getCurrBlock()` and `getNumVisitedCurrent()` of `ExprEngine`.

The new code is equivalent to the old one because the `NodeBuilder`s were constructed with `ExprEngine::currBldrCtx` as their context, which is currently the "backend" behind `getCurrBlock()` and `getNumVisitedCurrent()` -- but these methods will remain valid after the removal of `NodeBuilderContext` and `currBldrCtx`.