### PR TITLE
[LLD] [ELF] Make -z gcs=always implicitly warn on missing GCS, like force-bti

### DIFF
--- a/lld/ELF/Driver.cpp
+++ b/lld/ELF/Driver.cpp
@@ -3020,6 +3020,13 @@ static void readSecurityNotes(Ctx &ctx) {
                      "GNU_PROPERTY_X86_FEATURE_1_IBT property";
       features |= GNU_PROPERTY_X86_FEATURE_1_IBT;
     }
+    if (ctx.arg.zGcs == GcsPolicy::Always &&
+        !(features & GNU_PROPERTY_AARCH64_FEATURE_1_GCS)) {
+      if (ctx.arg.zGcsReport == ReportPolicy::None)
+        Warn(ctx) << f
+                  << ": -z gcs: file does not have "
+                     "GNU_PROPERTY_AARCH64_FEATURE_1_GCS property";
+    }
     if (ctx.arg.zPacPlt && !(hasValidPauthAbiCoreInfo ||
                              (features & GNU_PROPERTY_AARCH64_FEATURE_1_PAC))) {
       Warn(ctx) << f

--- a/lld/test/ELF/aarch64-feature-gcs.s
+++ b/lld/test/ELF/aarch64-feature-gcs.s
@@ -12,12 +12,21 @@
 
 # RUN: ld.lld f1-s.o f2-s.o f3-s.o -o out --fatal-warnings
 # RUN: llvm-readelf -n out | FileCheck --check-prefix GCS %s
-# RUN: ld.lld f1-s.o f2.o f3-s.o -o out.force -z gcs=always --fatal-warnings
+# RUN: ld.lld f1-s.o f2.o f3-s.o -o out.force -z gcs=always 2>&1 | FileCheck --check-prefix=REPORT-GCS-WARN-F2 %s
 # RUN: llvm-readelf -n out.force | FileCheck --check-prefix GCS %s
-# RUN: ld.lld f2-s.o f3.o --shared -o out.force.so -z gcs=never -z gcs=always --fatal-warnings
+# RUN: ld.lld f2-s.o f3.o --shared -o out.force.so -z gcs=never -z gcs=always 2>&1 | FileCheck --check-prefix=REPORT-GCS-WARN-F3 %s
 # RUN: llvm-readelf -n out.force.so | FileCheck --check-prefix GCS %s
+# RUN: ld.lld --shared f3.o -o out.force-bti -z gcs=always -z force-bti 2>&1 | FileCheck --check-prefix=REPORT-BTI-GCS-WARN-F3 %s
 
 # GCS: Properties:    aarch64 feature: GCS
+
+# REPORT-GCS-WARN-F2: warning: f2.o: -z gcs: file does not have GNU_PROPERTY_AARCH64_FEATURE_1_GCS property
+# REPORT-GCS-WARN-F2-NOT: {{.}}
+# REPORT-GCS-WARN-F3: warning: f3.o: -z gcs: file does not have GNU_PROPERTY_AARCH64_FEATURE_1_GCS property
+# REPORT-GCS-WARN-F3-NOT: {{.}}
+# REPORT-BTI-GCS-WARN-F3: warning: f3.o: -z force-bti: file does not have GNU_PROPERTY_AARCH64_FEATURE_1_BTI property
+# REPORT-BTI-GCS-WARN-F3: warning: f3.o: -z gcs: file does not have GNU_PROPERTY_AARCH64_FEATURE_1_GCS property
+# REPORT-BTI-GCS-WARN-F3-NOT: {{.}}
 
 ## GCS should not be enabled if it's not enabled in at least one input.
 


### PR DESCRIPTION
This matches GNU ld, where gcs=always makes it implicitly warn about missing GCS flags, by matching the existing code pattern used for BTI and IBT.

Also test that warnings can be printed for both missing BTI and GCS for the same object file.

This fixes #186173.