### PR TITLE
[clang][ssaf] Rename `ssaf-format` tool to `clang-ssaf-format`

### DIFF
--- a/clang/test/Analysis/Scalable/ssaf-format/list.test
+++ b/clang/test/Analysis/Scalable/ssaf-format/list.test
@@ -1,4 +1,4 @@
-// Test ssaf-format --list output without any loaded plugins.
+// Test clang-ssaf-format --list output without any loaded plugins.
 
 // RUN: clang-ssaf-format --list \
 // RUN:   | FileCheck %s

--- a/clang/test/Analysis/Scalable/ssaf-format/list.test
+++ b/clang/test/Analysis/Scalable/ssaf-format/list.test
@@ -1,6 +1,6 @@
 // Test ssaf-format --list output without any loaded plugins.
 
-// RUN: ssaf-format --list \
+// RUN: clang-ssaf-format --list \
 // RUN:   | FileCheck %s
 
 // CHECK: Registered serialization formats:

--- a/clang/test/CMakeLists.txt
+++ b/clang/test/CMakeLists.txt
@@ -103,11 +103,11 @@ list(APPEND CLANG_TEST_DEPS
   clang-linker-wrapper
   clang-nvlink-wrapper
   clang-offload-bundler
+  clang-ssaf-format
   clang-ssaf-linker
   clang-sycl-linker
   diagtool
   hmaptool
-  clang-ssaf-format
   )
 
 if(CLANG_ENABLE_CIR)

--- a/clang/test/CMakeLists.txt
+++ b/clang/test/CMakeLists.txt
@@ -107,7 +107,7 @@ list(APPEND CLANG_TEST_DEPS
   clang-sycl-linker
   diagtool
   hmaptool
-  ssaf-format
+  clang-ssaf-format
   )
 
 if(CLANG_ENABLE_CIR)

--- a/clang/test/lit.cfg.py
+++ b/clang/test/lit.cfg.py
@@ -143,7 +143,7 @@ tools = [
         unresolved="ignore",
     ),
     "clang-ssaf-linker",
-    "ssaf-format",
+    "clang-ssaf-format",
 ]
 
 if config.clang_examples:

--- a/clang/tools/ssaf-format/CMakeLists.txt
+++ b/clang/tools/ssaf-format/CMakeLists.txt
@@ -3,11 +3,11 @@ set(LLVM_LINK_COMPONENTS
   Support
   )
 
-add_clang_tool(ssaf-format
+add_clang_tool(clang-ssaf-format
   SSAFFormat.cpp
   )
 
-clang_target_link_libraries(ssaf-format
+clang_target_link_libraries(clang-ssaf-format
   PRIVATE
   clangAnalysisScalable
   clangBasic

--- a/clang/tools/ssaf-format/SSAFFormat.cpp
+++ b/clang/tools/ssaf-format/SSAFFormat.cpp
@@ -51,7 +51,7 @@ enum class SummaryType { TU, LU };
 // Command-Line Options
 //===----------------------------------------------------------------------===//
 
-cl::OptionCategory SsafFormatCategory("ssaf-format options");
+cl::OptionCategory SsafFormatCategory("clang-ssaf-format options");
 
 cl::list<std::string> LoadPlugins("load",
                                   cl::desc("Load a plugin shared library"),


### PR DESCRIPTION
This patch renames the `ssaf-format` tool to `clang-ssaf-format` to decrease the chance of conflicts with binaries from other projects. This issue was brought up in https://github.com/llvm/llvm-project/pull/184713#issuecomment-4030747461