### PR TITLE
[flang] Fix extra "./" prefix in source file paths

### DIFF
--- a/flang/lib/Parser/source.cpp
+++ b/flang/lib/Parser/source.cpp
@@ -63,21 +63,16 @@ std::optional<std::string> LocateSourceFile(
   if (name == "-" || llvm::sys::path::is_absolute(name)) {
     return name;
   }
-  // Check if file exists at original path to preserve user's format.
-  bool isDir{false};
-  const auto er = llvm::sys::fs::is_directory(name, isDir);
-  if (!er && !isDir) {
-    return name;
-  }
-  // Normalize: strip leading "./" to avoid "././file" with "." search paths.
-  llvm::StringRef nameRef(name);
-  if (nameRef.starts_with("./")) {
-    nameRef = nameRef.substr(2);
-  }
-  std::string normalizedName = nameRef.str();
   for (const std::string &dir : searchPath) {
-    llvm::SmallString<128> path{dir};
-    llvm::sys::path::append(path, normalizedName);
+    llvm::SmallString<128> path;
+    // If the file is found in the current directory, don't append the
+    // directory path. This preserves the user's format.
+    if (dir == ".") {
+      path = name;
+    } else {
+      path = dir;
+      llvm::sys::path::append(path, name);
+    }
     bool isDir{false};
     auto er = llvm::sys::fs::is_directory(path, isDir);
     if (!er && !isDir) {
@@ -93,15 +88,16 @@ std::vector<std::string> LocateSourceFileAll(
     return {name};
   }
   std::vector<std::string> result;
-  // Normalize: strip leading "./" to avoid "././file" with "." search paths.
-  llvm::StringRef nameRef(name);
-  if (nameRef.starts_with("./")) {
-    nameRef = nameRef.substr(2);
-  }
-  std::string normalizedName = nameRef.str();
   for (const std::string &dir : searchPath) {
-    llvm::SmallString<128> path{dir};
-    llvm::sys::path::append(path, normalizedName);
+    llvm::SmallString<128> path;
+    // If the file is found in the current directory, don't append the
+    // directory path. This preserves the user's format.
+    if (dir == ".") {
+      path = name;
+    } else {
+      path = dir;
+      llvm::sys::path::append(path, name);
+    }
     bool isDir{false};
     auto er = llvm::sys::fs::is_directory(path, isDir);
     if (!er && !isDir) {

--- a/flang/lib/Parser/source.cpp
+++ b/flang/lib/Parser/source.cpp
@@ -63,9 +63,21 @@ std::optional<std::string> LocateSourceFile(
   if (name == "-" || llvm::sys::path::is_absolute(name)) {
     return name;
   }
+  // Check if file exists at original path to preserve user's format.
+  bool isDir{false};
+  const auto er = llvm::sys::fs::is_directory(name, isDir);
+  if (!er && !isDir) {
+    return name;
+  }
+  // Normalize: strip leading "./" to avoid "././file" with "." search paths.
+  llvm::StringRef nameRef(name);
+  if (nameRef.starts_with("./")) {
+    nameRef = nameRef.substr(2);
+  }
+  std::string normalizedName = nameRef.str();
   for (const std::string &dir : searchPath) {
     llvm::SmallString<128> path{dir};
-    llvm::sys::path::append(path, name);
+    llvm::sys::path::append(path, normalizedName);
     bool isDir{false};
     auto er = llvm::sys::fs::is_directory(path, isDir);
     if (!er && !isDir) {
@@ -81,9 +93,15 @@ std::vector<std::string> LocateSourceFileAll(
     return {name};
   }
   std::vector<std::string> result;
+  // Normalize: strip leading "./" to avoid "././file" with "." search paths.
+  llvm::StringRef nameRef(name);
+  if (nameRef.starts_with("./")) {
+    nameRef = nameRef.substr(2);
+  }
+  std::string normalizedName = nameRef.str();
   for (const std::string &dir : searchPath) {
     llvm::SmallString<128> path{dir};
-    llvm::sys::path::append(path, name);
+    llvm::sys::path::append(path, normalizedName);
     bool isDir{false};
     auto er = llvm::sys::fs::is_directory(path, isDir);
     if (!er && !isDir) {

--- a/flang/test/Semantics/getsymbols02.f90
+++ b/flang/test/Semantics/getsymbols02.f90
@@ -10,5 +10,5 @@ ENDPROGRAM
 ! RUN: %flang_fc1 -fsyntax-only %S/Inputs/getsymbols02-a.f90
 ! RUN: %flang_fc1 -fsyntax-only %S/Inputs/getsymbols02-b.f90
 ! RUN: %flang_fc1 -fget-symbols-sources %s 2>&1 | FileCheck %s
-! CHECK: callget5: .{{[/\\]}}mm2b.mod,
-! CHECK: get5: .{{[/\\]}}.{{[/\\]}}mm2a.mod,
+! CHECK: callget5: mm2b.mod,
+! CHECK: get5: .{{[/\\]}}mm2a.mod,

--- a/flang/test/Semantics/getsymbols02.f90
+++ b/flang/test/Semantics/getsymbols02.f90
@@ -11,4 +11,4 @@ ENDPROGRAM
 ! RUN: %flang_fc1 -fsyntax-only %S/Inputs/getsymbols02-b.f90
 ! RUN: %flang_fc1 -fget-symbols-sources %s 2>&1 | FileCheck %s
 ! CHECK: callget5: mm2b.mod,
-! CHECK: get5: .{{[/\\]}}mm2a.mod,
+! CHECK: get5: mm2a.mod,


### PR DESCRIPTION
When a relative file search path in the current working directory was passed to LocateSourceFile, an extra `./` was appended, producing paths like "././test.F90". This caused the `__FILE__` macro to expand incorrectly and did not match the behavior of other Fortran compilers such as gfortran. This caused failures when running an external test suites that parses `__FILE__`  to generate test log filenames.

### Reproducer
```
> cat test.F90
program test
  print *, __FILE__
end program

> flang test.F90 -o test
> ./test
./test.F90      # WRONG! expected: test.F90
> flang ./test.F90 -o test
> ./test
././test.F90.   # WRONG! expected: ./test.F90
```

### Fix
In LocateSourceFile and LocateSourceFileAll: do not append the search path if it is the current working directory (`.`). In all other cases, append the search path to the file name (original behavior).

### Tests
- The test expectation in getsymbols02.f90 is updated because the old CHECK patterns matched the buggy "././" output.
- The flang lit tests (with update) and llvm-test-suite pass with this commit.