### PR TITLE
[SPIRV][Matrix] Add support for Array Vector memory layout

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVLegalizePointerCast.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVLegalizePointerCast.cpp
@@ -192,13 +192,13 @@ class SPIRVLegalizePointerCast : public FunctionPass {
     unsigned ScalarsPerArrayElement = ArrElemVecTy->getNumElements();
     // Load each element of the array.
     SmallVector<Value *, 4> LoadedElements;
+    SmallVector<Type *, 2> Types = {Source->getType(), Source->getType()};
     for (unsigned I = 0; I < TargetType->getNumElements(); ++I) {
       unsigned ArrayIndex = I / ScalarsPerArrayElement;
       unsigned ElementIndexInArrayElem = I % ScalarsPerArrayElement;
       // Create a GEP to access the i-th element of the array.
-      SmallVector<Type *, 2> Types = {Source->getType(), Source->getType()};
       SmallVector<Value *, 4> Args;
-      Args.push_back(B.getInt1(false));
+      Args.push_back(B.getInt1(/*Inbounds=*/false));
       Args.push_back(Source);
       Args.push_back(B.getInt32(0));
       Args.push_back(ConstantInt::get(B.getInt32Ty(), ArrayIndex));
@@ -216,11 +216,11 @@ class SPIRVLegalizePointerCast : public FunctionPass {
                              Value *Source) {
     // Load each element of the array.
     SmallVector<Value *, 4> LoadedElements;
+    SmallVector<Type *, 2> Types = {Source->getType(), Source->getType()};
     for (unsigned I = 0; I < TargetType->getNumElements(); ++I) {
       // Create a GEP to access the i-th element of the array.
-      SmallVector<Type *, 2> Types = {Source->getType(), Source->getType()};
       SmallVector<Value *, 4> Args;
-      Args.push_back(B.getInt1(false));
+      Args.push_back(B.getInt1(/*Inbounds=*/false));
       Args.push_back(Source);
       Args.push_back(B.getInt32(0));
       Args.push_back(ConstantInt::get(B.getInt32Ty(), I));

--- a/llvm/lib/Target/SPIRV/SPIRVLegalizePointerCast.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVLegalizePointerCast.cpp
@@ -165,8 +165,9 @@ class SPIRVLegalizePointerCast : public FunctionPass {
     buildAssignType(B, ElementType, LI);
     return LI;
   }
-  Value *loadVectorFromArrayHelper(IRBuilder<> &B, FixedVectorType *TargetType,
-                                   SmallVector<Value *, 4> &LoadedElements) {
+  Value *
+  buildVectorFromLoadedElements(IRBuilder<> &B, FixedVectorType *TargetType,
+                                SmallVector<Value *, 4> &LoadedElements) {
     // Build the vector from the loaded elements.
     Value *NewVector = PoisonValue::get(TargetType);
     buildAssignType(B, TargetType, NewVector);
@@ -209,7 +210,7 @@ class SPIRVLegalizePointerCast : public FunctionPass {
       LoadedElements.push_back(makeExtractElement(B, TargetElemTy, LoadVec,
                                                   ElementIndexInArrayElem));
     }
-    return loadVectorFromArrayHelper(B, TargetType, LoadedElements);
+    return buildVectorFromLoadedElements(B, TargetType, LoadedElements);
   }
   // Loads elements from an array and constructs a vector.
   Value *loadVectorFromArray(IRBuilder<> &B, FixedVectorType *TargetType,
@@ -232,7 +233,7 @@ class SPIRVLegalizePointerCast : public FunctionPass {
       buildAssignType(B, TargetType->getElementType(), Load);
       LoadedElements.push_back(Load);
     }
-    return loadVectorFromArrayHelper(B, TargetType, LoadedElements);
+    return buildVectorFromLoadedElements(B, TargetType, LoadedElements);
   }
 
   // Stores elements from a vector into an array.

--- a/llvm/lib/Target/SPIRV/SPIRVLegalizePointerCast.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVLegalizePointerCast.cpp
@@ -165,20 +165,65 @@ class SPIRVLegalizePointerCast : public FunctionPass {
     buildAssignType(B, ElementType, LI);
     return LI;
   }
+  Value *loadVectorFromArrayHelper(IRBuilder<> &B, FixedVectorType *TargetType,
+                                   SmallVector<Value *, 4> &LoadedElements) {
+    // Build the vector from the loaded elements.
+    Value *NewVector = PoisonValue::get(TargetType);
+    buildAssignType(B, TargetType, NewVector);
 
-  // Loads elements from an array and constructs a vector.
-  Value *loadVectorFromArray(IRBuilder<> &B, FixedVectorType *TargetType,
-                             Value *Source) {
+    for (unsigned I = 0; I < TargetType->getNumElements(); ++I) {
+      Value *Index = B.getInt32(I);
+      SmallVector<Type *, 4> Types = {TargetType, TargetType,
+                                      TargetType->getElementType(),
+                                      Index->getType()};
+      SmallVector<Value *> Args = {NewVector, LoadedElements[I], Index};
+      NewVector = B.CreateIntrinsic(Intrinsic::spv_insertelt, {Types}, {Args});
+      buildAssignType(B, TargetType, NewVector);
+    }
+    return NewVector;
+  }
+
+  // Loads elements from a matrix with an array of vector memory layout and
+  // constructs a vector.
+  Value *loadVectorFromMatrixArray(IRBuilder<> &B, FixedVectorType *TargetType,
+                                   Value *Source,
+                                   FixedVectorType *ArrElemVecTy) {
+    Type *TargetElemTy = TargetType->getElementType();
+    unsigned ScalarsPerArrayElement = ArrElemVecTy->getNumElements();
     // Load each element of the array.
     SmallVector<Value *, 4> LoadedElements;
-    for (unsigned i = 0; i < TargetType->getNumElements(); ++i) {
+    for (unsigned I = 0; I < TargetType->getNumElements(); ++I) {
+      unsigned ArrayIndex = I / ScalarsPerArrayElement;
+      unsigned ElementIndexInArrayElem = I % ScalarsPerArrayElement;
       // Create a GEP to access the i-th element of the array.
       SmallVector<Type *, 2> Types = {Source->getType(), Source->getType()};
       SmallVector<Value *, 4> Args;
       Args.push_back(B.getInt1(false));
       Args.push_back(Source);
       Args.push_back(B.getInt32(0));
-      Args.push_back(ConstantInt::get(B.getInt32Ty(), i));
+      Args.push_back(ConstantInt::get(B.getInt32Ty(), ArrayIndex));
+      auto *ElementPtr = B.CreateIntrinsic(Intrinsic::spv_gep, {Types}, {Args});
+      GR->buildAssignPtr(B, ArrElemVecTy, ElementPtr);
+      Value *LoadVec = B.CreateLoad(ArrElemVecTy, ElementPtr);
+      buildAssignType(B, ArrElemVecTy, LoadVec);
+      LoadedElements.push_back(makeExtractElement(B, TargetElemTy, LoadVec,
+                                                  ElementIndexInArrayElem));
+    }
+    return loadVectorFromArrayHelper(B, TargetType, LoadedElements);
+  }
+  // Loads elements from an array and constructs a vector.
+  Value *loadVectorFromArray(IRBuilder<> &B, FixedVectorType *TargetType,
+                             Value *Source) {
+    // Load each element of the array.
+    SmallVector<Value *, 4> LoadedElements;
+    for (unsigned I = 0; I < TargetType->getNumElements(); ++I) {
+      // Create a GEP to access the i-th element of the array.
+      SmallVector<Type *, 2> Types = {Source->getType(), Source->getType()};
+      SmallVector<Value *, 4> Args;
+      Args.push_back(B.getInt1(false));
+      Args.push_back(Source);
+      Args.push_back(B.getInt32(0));
+      Args.push_back(ConstantInt::get(B.getInt32Ty(), I));
       auto *ElementPtr = B.CreateIntrinsic(Intrinsic::spv_gep, {Types}, {Args});
       GR->buildAssignPtr(B, TargetType->getElementType(), ElementPtr);
 
@@ -187,21 +232,7 @@ class SPIRVLegalizePointerCast : public FunctionPass {
       buildAssignType(B, TargetType->getElementType(), Load);
       LoadedElements.push_back(Load);
     }
-
-    // Build the vector from the loaded elements.
-    Value *NewVector = PoisonValue::get(TargetType);
-    buildAssignType(B, TargetType, NewVector);
-
-    for (unsigned i = 0; i < TargetType->getNumElements(); ++i) {
-      Value *Index = B.getInt32(i);
-      SmallVector<Type *, 4> Types = {TargetType, TargetType,
-                                      TargetType->getElementType(),
-                                      Index->getType()};
-      SmallVector<Value *> Args = {NewVector, LoadedElements[i], Index};
-      NewVector = B.CreateIntrinsic(Intrinsic::spv_insertelt, {Types}, {Args});
-      buildAssignType(B, TargetType, NewVector);
-    }
-    return NewVector;
+    return loadVectorFromArrayHelper(B, TargetType, LoadedElements);
   }
 
   // Stores elements from a vector into an array.
@@ -256,6 +287,8 @@ class SPIRVLegalizePointerCast : public FunctionPass {
     auto *SAT = dyn_cast<ArrayType>(FromTy);
     auto *SVT = dyn_cast<FixedVectorType>(FromTy);
     auto *DVT = dyn_cast<FixedVectorType>(ToTy);
+    auto *MAT =
+        SAT ? dyn_cast<FixedVectorType>(SAT->getElementType()) : nullptr;
 
     B.SetInsertPoint(LI);
 
@@ -271,6 +304,8 @@ class SPIRVLegalizePointerCast : public FunctionPass {
       Output = loadVectorFromVector(B, SVT, DVT, OriginalOperand);
     else if (SAT && DVT && SAT->getElementType() == DVT->getElementType())
       Output = loadVectorFromArray(B, DVT, OriginalOperand);
+    else if (MAT && DVT && MAT->getElementType() == DVT->getElementType())
+      Output = loadVectorFromMatrixArray(B, DVT, OriginalOperand, MAT);
     else
       llvm_unreachable("Unimplemented implicit down-cast from load.");
 

--- a/llvm/test/CodeGen/SPIRV/pointers/load-vector-from-array-of-vectors.ll
+++ b/llvm/test/CodeGen/SPIRV/pointers/load-vector-from-array-of-vectors.ll
@@ -1,5 +1,6 @@
+; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv-unknown-vulkan %s -stop-after=spirv-legalize-bitcast -o - | FileCheck %s --check-prefix=IRCHECK
 ; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv-unknown-vulkan %s -o - | FileCheck %s
-; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv-unknown-vulkan %s -o - -filetype=obj | spirv-val %}
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv-unknown-vulkan1.3-compute %s -o - -filetype=obj | spirv-val --target-env vulkan1.3 %}
 
 ; CHECK-DAG: [[FLOAT:%[0-9]+]] = OpTypeFloat 32
 ; CHECK-DAG: [[VEC2FLOAT:%[0-9]+]] = OpTypeVector [[FLOAT]] 2
@@ -7,13 +8,40 @@
 ; CHECK: OpCompositeExtract [[FLOAT]]
 ; CHECK: OpCompositeConstruct [[VEC2FLOAT]]
 
+; // M1[0][0]
+; IRCHECK: [[M1ROWZero:%[0-9]+]] = call ptr addrspace(10) (i1, ptr addrspace(10), ...) @llvm.spv.gep.p10.p10(i1 false, ptr addrspace(10) @M1, i32 0, i32 0)
+; IRCHECK: [[M1ROWZeroVec:%[0-9]+]] = load <2 x float>, ptr addrspace(10) [[M1ROWZero]], align 8
+; IRCHECK: [[M1Elem_00:%[0-9]+]] = call float @llvm.spv.extractelt.f32.v2f32.i32(<2 x float> [[M1ROWZeroVec]], i32 0)
+
+;// M1[0][1]
+; IRCHECK: [[M1ROWZero_2:%[0-9]+]] = call ptr addrspace(10) (i1, ptr addrspace(10), ...) @llvm.spv.gep.p10.p10(i1 false, ptr addrspace(10) @M1, i32 0, i32 0)
+; IRCHECK: [[M1ROWZeroVec_2:%[0-9]+]] = load <2 x float>, ptr addrspace(10) [[M1ROWZero_2]], align 8
+; IRCHECK: [[M1Elem_01:%[0-9]+]] = call float @llvm.spv.extractelt.f32.v2f32.i32(<2 x float> [[M1ROWZeroVec_2]], i32 1)
+
+; // M1[1][0]
+; IRCHECK: [[M1ROWOne:%[0-9]+]] = call ptr addrspace(10) (i1, ptr addrspace(10), ...) @llvm.spv.gep.p10.p10(i1 false, ptr addrspace(10) @M1, i32 0, i32 1)
+; IRCHECK: [[M1ROWOneVec:%[0-9]+]] = load <2 x float>, ptr addrspace(10) [[M1ROWOne]], align 8
+; IRCHECK: [[M1Elem_10:%[0-9]+]] = call float @llvm.spv.extractelt.f32.v2f32.i32(<2 x float> [[M1ROWOneVec]], i32 0)
+
+; // M1[1][1]
+; IRCHECK: [[M1ROWOne_2:%[0-9]+]] = call ptr addrspace(10) (i1, ptr addrspace(10), ...) @llvm.spv.gep.p10.p10(i1 false, ptr addrspace(10) @M1, i32 0, i32 1)
+; IRCHECK: [[M1ROWOneVec_2:%[0-9]+]] = load <2 x float>, ptr addrspace(10) [[M1ROWOne_2]], align 8
+; IRCHECK: [[M1Elem_11:%[0-9]+]] = call float @llvm.spv.extractelt.f32.v2f32.i32(<2 x float> [[M1ROWOneVec_2]], i32 1)
+
+; // M1[2][0]
+; IRCHECK: [[M1ROWTwo:%[0-9]+]] = call ptr addrspace(10) (i1, ptr addrspace(10), ...) @llvm.spv.gep.p10.p10(i1 false, ptr addrspace(10) @M1, i32 0, i32 2)
+; IRCHECK: [[M1ROWTwoVec:%[0-9]+]] = load <2 x float>, ptr addrspace(10) [[M1ROWTwo]], align 8
+; IRCHECK: [[M1Elem_20:%[0-9]+]] = call float @llvm.spv.extractelt.f32.v2f32.i32(<2 x float> [[M1ROWTwoVec]], i32 0)
+
 @M1 = internal addrspace(10) global [4 x <2 x float>] zeroinitializer, align 4
 @OUT = internal addrspace(10) global <2 x float> zeroinitializer, align 4
 
-define spir_func void @main() {
+define spir_func void @main() #1 {
 entry:
   %0 = load <5 x float>, ptr addrspace(10) @M1, align 4
   %1 = shufflevector <5 x float> %0, <5 x float> poison, <2 x i32> <i32 0, i32 4>
   store <2 x float> %1, ptr addrspace(10) @OUT, align 4
   ret void
 }
+
+attributes #1 = { "hlsl.numthreads"="1,1,1" "hlsl.shader"="compute" }

--- a/llvm/test/CodeGen/SPIRV/pointers/load-vector-from-array-of-vectors.ll
+++ b/llvm/test/CodeGen/SPIRV/pointers/load-vector-from-array-of-vectors.ll
@@ -1,0 +1,19 @@
+; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv-unknown-vulkan %s -o - | FileCheck %s
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv-unknown-vulkan %s -o - -filetype=obj | spirv-val %}
+
+; CHECK-DAG: [[FLOAT:%[0-9]+]] = OpTypeFloat 32
+; CHECK-DAG: [[VEC2FLOAT:%[0-9]+]] = OpTypeVector [[FLOAT]] 2
+; CHECK: OpLoad [[VEC2FLOAT]]
+; CHECK: OpCompositeExtract [[FLOAT]]
+; CHECK: OpCompositeConstruct [[VEC2FLOAT]]
+
+@M1 = internal addrspace(10) global [4 x <2 x float>] zeroinitializer, align 4
+@OUT = internal addrspace(10) global <2 x float> zeroinitializer, align 4
+
+define spir_func void @main() {
+entry:
+  %0 = load <5 x float>, ptr addrspace(10) @M1, align 4
+  %1 = shufflevector <5 x float> %0, <5 x float> poison, <2 x i32> <i32 0, i32 4>
+  store <2 x float> %1, ptr addrspace(10) @OUT, align 4
+  ret void
+}


### PR DESCRIPTION
- fixes #179879
- Change is three fold:
1. Look for the Matrix Memory layout.
2. refactor out the common pieces of loadVectorFromArray into a helper that can be shared with the matrix case.
3. The matrix case needs special indexing so we can do vector geps instead of scalar geps that would require a 2d loop.