### PR TITLE
[HLSL] Fix intrinsics header file for wave intrinsics using u/int16_t types, updating them to 6.2

### DIFF
--- a/clang/lib/Headers/hlsl/hlsl_alias_intrinsics.h
+++ b/clang/lib/Headers/hlsl/hlsl_alias_intrinsics.h
@@ -30,15 +30,16 @@ namespace hlsl {
 #define _HLSL_16BIT_AVAILABILITY_STAGE(platform, version, stage)               \
   __attribute__((                                                              \
       availability(platform, introduced = version, environment = stage)))
-#define _HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel) \
+#define _HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)                          \
   _HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
 #else
 #define _HLSL_16BIT_AVAILABILITY(environment, version)
 #define _HLSL_16BIT_AVAILABILITY_STAGE(environment, version, stage)
-#define _HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel) 
+#define _HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 #endif
 
-#define _HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel) _HLSL_AVAILABILITY(shadermodel, 6.2)
+#define _HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)                            \
+  _HLSL_AVAILABILITY(shadermodel, 6.2)
 
 //===----------------------------------------------------------------------===//
 // abs builtins

--- a/clang/lib/Headers/hlsl/hlsl_alias_intrinsics.h
+++ b/clang/lib/Headers/hlsl/hlsl_alias_intrinsics.h
@@ -30,12 +30,12 @@ namespace hlsl {
 #define _HLSL_16BIT_AVAILABILITY_STAGE(platform, version, stage)               \
   __attribute__((                                                              \
       availability(platform, introduced = version, environment = stage)))
-#define _HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)              \
+#define _HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()                         \
   _HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
 #else
 #define _HLSL_16BIT_AVAILABILITY(environment, version)
 #define _HLSL_16BIT_AVAILABILITY_STAGE(environment, version, stage)
-#define _HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+#define _HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 #endif
 
 //===----------------------------------------------------------------------===//
@@ -47,39 +47,39 @@ namespace hlsl {
 /// \param Val The input value.
 
 #ifdef __HLSL_ENABLE_16_BIT
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_abs)
 int16_t abs(int16_t);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_abs)
 int16_t2 abs(int16_t2);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_abs)
 int16_t3 abs(int16_t3);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_abs)
 int16_t4 abs(int16_t4);
 
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 constexpr uint16_t abs(uint16_t V) { return V; }
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 constexpr uint16_t2 abs(uint16_t2 V) { return V; }
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 constexpr uint16_t3 abs(uint16_t3 V) { return V; }
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 constexpr uint16_t4 abs(uint16_t4 V) { return V; }
 #endif
 
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_abs)
 half abs(half);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_abs)
 half2 abs(half2);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_abs)
 half3 abs(half3);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_abs)
 half4 abs(half4);
 
@@ -137,16 +137,16 @@ double4 abs(double4);
 /// \brief Returns the arccosine of the input value, \a Val.
 /// \param Val The input value.
 
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_acos)
 half acos(half);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_acos)
 half2 acos(half2);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_acos)
 half3 acos(half3);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_acos)
 half4 acos(half4);
 
@@ -189,42 +189,42 @@ uint32_t4 AddUint64(uint32_t4, uint32_t4);
 /// otherwise, false. \param x The input value.
 
 #ifdef __HLSL_ENABLE_16_BIT
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_all)
 bool all(int16_t);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_all)
 bool all(int16_t2);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_all)
 bool all(int16_t3);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_all)
 bool all(int16_t4);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_all)
 bool all(uint16_t);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_all)
 bool all(uint16_t2);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_all)
 bool all(uint16_t3);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_all)
 bool all(uint16_t4);
 #endif
 
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_all)
 bool all(half);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_all)
 bool all(half2);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_all)
 bool all(half3);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_all)
 bool all(half4);
 
@@ -355,42 +355,42 @@ bool4x4 and(bool4x4 x, bool4x4 y);
 /// otherwise, false. \param x The input value.
 
 #ifdef __HLSL_ENABLE_16_BIT
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_any)
 bool any(int16_t);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_any)
 bool any(int16_t2);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_any)
 bool any(int16_t3);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_any)
 bool any(int16_t4);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_any)
 bool any(uint16_t);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_any)
 bool any(uint16_t2);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_any)
 bool any(uint16_t3);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_any)
 bool any(uint16_t4);
 #endif
 
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_any)
 bool any(half);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_any)
 bool any(half2);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_any)
 bool any(half3);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_any)
 bool any(half4);
 
@@ -484,16 +484,16 @@ double4 asdouble(uint4, uint4);
 /// \brief Returns the arcsine of the input value, \a Val.
 /// \param Val The input value.
 
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_asin)
 half asin(half);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_asin)
 half2 asin(half2);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_asin)
 half3 asin(half3);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_asin)
 half4 asin(half4);
 
@@ -514,16 +514,16 @@ float4 asin(float4);
 /// \brief Returns the arctangent of the input value, \a Val.
 /// \param Val The input value.
 
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_atan)
 half atan(half);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_atan)
 half2 atan(half2);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_atan)
 half3 atan(half3);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_atan)
 half4 atan(half4);
 
@@ -546,16 +546,16 @@ float4 atan(float4);
 /// \param y The y-coordinate.
 /// \param x The x-coordinate.
 
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_atan2)
 half atan2(half y, half x);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_atan2)
 half2 atan2(half2 y, half2 x);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_atan2)
 half3 atan2(half3 y, half3 x);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_atan2)
 half4 atan2(half4 y, half4 x);
 
@@ -577,16 +577,16 @@ float4 atan2(float4 y, float4 x);
 /// the input value, \a Val.
 /// \param Val The input value.
 
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_ceil)
 half ceil(half);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_ceil)
 half2 ceil(half2);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_ceil)
 half3 ceil(half3);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_ceil)
 half4 ceil(half4);
 
@@ -614,43 +614,43 @@ float4 ceil(float4);
 /// For values of -INF or INF, clamp will behave as expected.
 /// However for values of NaN, the results are undefined.
 
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_clamp)
 half clamp(half, half, half);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_clamp)
 half2 clamp(half2, half2, half2);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_clamp)
 half3 clamp(half3, half3, half3);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_clamp)
 half4 clamp(half4, half4, half4);
 
 #ifdef __HLSL_ENABLE_16_BIT
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_clamp)
 int16_t clamp(int16_t, int16_t, int16_t);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_clamp)
 int16_t2 clamp(int16_t2, int16_t2, int16_t2);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_clamp)
 int16_t3 clamp(int16_t3, int16_t3, int16_t3);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_clamp)
 int16_t4 clamp(int16_t4, int16_t4, int16_t4);
 
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_clamp)
 uint16_t clamp(uint16_t, uint16_t, uint16_t);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_clamp)
 uint16_t2 clamp(uint16_t2, uint16_t2, uint16_t2);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_clamp)
 uint16_t3 clamp(uint16_t3, uint16_t3, uint16_t3);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_clamp)
 uint16_t4 clamp(uint16_t4, uint16_t4, uint16_t4);
 #endif
@@ -734,16 +734,16 @@ void clip(float4);
 /// \brief Returns the cosine of the input value, \a Val.
 /// \param Val The input value.
 
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_cos)
 half cos(half);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_cos)
 half2 cos(half2);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_cos)
 half3 cos(half3);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_cos)
 half4 cos(half4);
 
@@ -764,16 +764,16 @@ float4 cos(float4);
 /// \brief Returns the hyperbolic cosine of the input value, \a Val.
 /// \param Val The input value.
 
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_cosh)
 half cosh(half);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_cosh)
 half2 cosh(half2);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_cosh)
 half3 cosh(half3);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_cosh)
 half4 cosh(half4);
 
@@ -795,35 +795,35 @@ float4 cosh(float4);
 /// \param Val The input value.
 
 #ifdef __HLSL_ENABLE_16_BIT
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 const inline uint countbits(int16_t x) {
   return __builtin_elementwise_popcount(x);
 }
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 const inline uint2 countbits(int16_t2 x) {
   return __builtin_elementwise_popcount(x);
 }
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 const inline uint3 countbits(int16_t3 x) {
   return __builtin_elementwise_popcount(x);
 }
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 const inline uint4 countbits(int16_t4 x) {
   return __builtin_elementwise_popcount(x);
 }
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 const inline uint countbits(uint16_t x) {
   return __builtin_elementwise_popcount(x);
 }
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 const inline uint2 countbits(uint16_t2 x) {
   return __builtin_elementwise_popcount(x);
 }
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 const inline uint3 countbits(uint16_t3 x) {
   return __builtin_elementwise_popcount(x);
 }
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 const inline uint4 countbits(uint16_t4 x) {
   return __builtin_elementwise_popcount(x);
 }
@@ -887,16 +887,16 @@ const inline uint4 countbits(uint64_t4 x) {
 /// \brief Converts the specified value from radians to degrees.
 /// \param x The specified input value.
 
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_degrees)
 half degrees(half);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_degrees)
 half2 degrees(half2);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_degrees)
 half3 degrees(half3);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_degrees)
 half4 degrees(half4);
 
@@ -918,43 +918,43 @@ float4 degrees(float4);
 /// \param X The X input value.
 /// \param Y The Y input value.
 
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_dot)
 half dot(half, half);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_dot)
 half dot(half2, half2);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_dot)
 half dot(half3, half3);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_dot)
 half dot(half4, half4);
 
 #ifdef __HLSL_ENABLE_16_BIT
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_dot)
 int16_t dot(int16_t, int16_t);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_dot)
 int16_t dot(int16_t2, int16_t2);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_dot)
 int16_t dot(int16_t3, int16_t3);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_dot)
 int16_t dot(int16_t4, int16_t4);
 
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_dot)
 uint16_t dot(uint16_t, uint16_t);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_dot)
 uint16_t dot(uint16_t2, uint16_t2);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_dot)
 uint16_t dot(uint16_t3, uint16_t3);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_dot)
 uint16_t dot(uint16_t4, uint16_t4);
 #endif
@@ -1033,16 +1033,16 @@ uint dot4add_u8packed(uint, uint, uint);
 ///
 /// The return value is the base-e exponential of the \a x parameter.
 
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_exp)
 half exp(half);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_exp)
 half2 exp(half2);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_exp)
 half3 exp(half3);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_exp)
 half4 exp(half4);
 
@@ -1065,16 +1065,16 @@ float4 exp(float4);
 ///
 /// The base 2 exponential of the \a x parameter.
 
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_exp2)
 half exp2(half);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_exp2)
 half2 exp2(half2);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_exp2)
 half3 exp2(half3);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_exp2)
 half4 exp2(half4);
 
@@ -1139,28 +1139,28 @@ uint4 f32tof16(float4);
 /// \param Val the input value.
 
 #ifdef __HLSL_ENABLE_16_BIT
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_firstbitlow)
 uint firstbitlow(int16_t);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_firstbitlow)
 uint2 firstbitlow(int16_t2);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_firstbitlow)
 uint3 firstbitlow(int16_t3);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_firstbitlow)
 uint4 firstbitlow(int16_t4);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_firstbitlow)
 uint firstbitlow(uint16_t);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_firstbitlow)
 uint2 firstbitlow(uint16_t2);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_firstbitlow)
 uint3 firstbitlow(uint16_t3);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_firstbitlow)
 uint4 firstbitlow(uint16_t4);
 #endif
@@ -1210,16 +1210,16 @@ uint4 firstbitlow(uint64_t4);
 /// value, \a Val.
 /// \param Val The input value.
 
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_floor)
 half floor(half);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_floor)
 half2 floor(half2);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_floor)
 half3 floor(half3);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_floor)
 half4 floor(half4);
 
@@ -1242,16 +1242,16 @@ float4 floor(float4);
 ///
 /// If \a the return value is greater than or equal to 0 and less than 1.
 
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_frac)
 half frac(half);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_frac)
 half2 frac(half2);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_frac)
 half3 frac(half3);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_frac)
 half4 frac(half4);
 
@@ -1275,16 +1275,16 @@ float4 frac(float4);
 /// Returns a value of the same size as the input, with a value set
 /// to True if the x parameter is +INF or -INF. Otherwise, False.
 
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_isinf)
 bool isinf(half);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_isinf)
 bool2 isinf(half2);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_isinf)
 bool3 isinf(half3);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_isinf)
 bool4 isinf(half4);
 
@@ -1308,16 +1308,16 @@ bool4 isinf(float4);
 /// Returns a value of the same size as the input, with a value set
 /// to True if the x parameter is NaN or QNaN. Otherwise, False.
 
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_isnan)
 bool isnan(half);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_isnan)
 bool2 isnan(half2);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_isnan)
 bool3 isnan(half3);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_isnan)
 bool4 isnan(half4);
 
@@ -1344,16 +1344,16 @@ bool4 isnan(float4);
 /// Linear interpolation is based on the following formula: x*(1-s) + y*s which
 /// can equivalently be written as x + s(y-x).
 
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_lerp)
 half lerp(half, half, half);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_lerp)
 half2 lerp(half2, half2, half2);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_lerp)
 half3 lerp(half3, half3, half3);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_lerp)
 half4 lerp(half4, half4, half4);
 
@@ -1377,16 +1377,16 @@ float4 lerp(float4, float4, float4);
 /// If \a Val is negative, this result is undefined. If \a Val is 0, this
 /// function returns negative infinity.
 
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_log)
 half log(half);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_log)
 half2 log(half2);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_log)
 half3 log(half3);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_log)
 half4 log(half4);
 
@@ -1410,16 +1410,16 @@ float4 log(float4);
 /// If \a Val is negative, this result is undefined. If \a Val is 0, this
 /// function returns negative infinity.
 
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_log10)
 half log10(half);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_log10)
 half2 log10(half2);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_log10)
 half3 log10(half3);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_log10)
 half4 log10(half4);
 
@@ -1443,16 +1443,16 @@ float4 log10(float4);
 /// If \a Val is negative, this result is undefined. If \a Val is 0, this
 /// function returns negative infinity.
 
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_log2)
 half log2(half);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_log2)
 half2 log2(half2);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_log2)
 half3 log2(half3);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_log2)
 half4 log2(half4);
 
@@ -1475,43 +1475,43 @@ float4 log2(float4);
 /// \param A The first addition value.
 /// \param B The second addition value.
 
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_mad)
 half mad(half, half, half);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_mad)
 half2 mad(half2, half2, half2);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_mad)
 half3 mad(half3, half3, half3);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_mad)
 half4 mad(half4, half4, half4);
 
 #ifdef __HLSL_ENABLE_16_BIT
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_mad)
 int16_t mad(int16_t, int16_t, int16_t);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_mad)
 int16_t2 mad(int16_t2, int16_t2, int16_t2);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_mad)
 int16_t3 mad(int16_t3, int16_t3, int16_t3);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_mad)
 int16_t4 mad(int16_t4, int16_t4, int16_t4);
 
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_mad)
 uint16_t mad(uint16_t, uint16_t, uint16_t);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_mad)
 uint16_t2 mad(uint16_t2, uint16_t2, uint16_t2);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_mad)
 uint16_t3 mad(uint16_t3, uint16_t3, uint16_t3);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_mad)
 uint16_t4 mad(uint16_t4, uint16_t4, uint16_t4);
 #endif
@@ -1579,43 +1579,43 @@ double4 mad(double4, double4, double4);
 /// \param X The X input value.
 /// \param Y The Y input value.
 
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_max)
 half max(half, half);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_max)
 half2 max(half2, half2);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_max)
 half3 max(half3, half3);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_max)
 half4 max(half4, half4);
 
 #ifdef __HLSL_ENABLE_16_BIT
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_max)
 int16_t max(int16_t, int16_t);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_max)
 int16_t2 max(int16_t2, int16_t2);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_max)
 int16_t3 max(int16_t3, int16_t3);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_max)
 int16_t4 max(int16_t4, int16_t4);
 
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_max)
 uint16_t max(uint16_t, uint16_t);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_max)
 uint16_t2 max(uint16_t2, uint16_t2);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_max)
 uint16_t3 max(uint16_t3, uint16_t3);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_max)
 uint16_t4 max(uint16_t4, uint16_t4);
 #endif
@@ -1683,43 +1683,43 @@ double4 max(double4, double4);
 /// \param X The X input value.
 /// \param Y The Y input value.
 
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_min)
 half min(half, half);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_min)
 half2 min(half2, half2);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_min)
 half3 min(half3, half3);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_min)
 half4 min(half4, half4);
 
 #ifdef __HLSL_ENABLE_16_BIT
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_min)
 int16_t min(int16_t, int16_t);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_min)
 int16_t2 min(int16_t2, int16_t2);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_min)
 int16_t3 min(int16_t3, int16_t3);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_min)
 int16_t4 min(int16_t4, int16_t4);
 
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_min)
 uint16_t min(uint16_t, uint16_t);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_min)
 uint16_t2 min(uint16_t2, uint16_t2);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_min)
 uint16_t3 min(uint16_t3, uint16_t3);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_min)
 uint16_t4 min(uint16_t4, uint16_t4);
 #endif
@@ -1814,7 +1814,7 @@ double4 min(double4, double4);
 
 // Case 6: vector * matrix -> vector
 template <int R, int C>
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_mul) vector<half, C> mul(vector<half, R>,
                                                             matrix<half, R, C>);
 
@@ -1824,7 +1824,7 @@ vector<T, C> mul(vector<T, R>, matrix<T, R, C>);
 
 // Case 8: matrix * vector -> vector
 template <int R, int C>
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_mul) vector<half, R> mul(matrix<half, R, C>,
                                                             vector<half, C>);
 
@@ -1834,7 +1834,7 @@ vector<T, R> mul(matrix<T, R, C>, vector<T, C>);
 
 // Case 9: matrix * matrix -> matrix
 template <int R, int K, int C>
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_mul) matrix<half, R, C> mul(
     matrix<half, R, K>, matrix<half, K, C>);
 
@@ -1852,16 +1852,16 @@ matrix<T, R, C> mul(matrix<T, R, K>, matrix<T, K, C>);
 ///
 /// Normalize is based on the following formula: x / length(x).
 
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_normalize)
 half normalize(half);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_normalize)
 half2 normalize(half2);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_normalize)
 half3 normalize(half3);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_normalize)
 half4 normalize(half4);
 
@@ -1936,16 +1936,16 @@ bool4x4 or(bool4x4 x, bool4x4 y);
 /// \param Val The input value.
 /// \param Pow The specified power.
 
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_pow)
 half pow(half, half);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_pow)
 half2 pow(half2, half2);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_pow)
 half3 pow(half3, half3);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_pow)
 half4 pow(half4, half4);
 
@@ -1967,16 +1967,16 @@ float4 pow(float4, float4);
 /// \param Val The input value.
 
 #ifdef __HLSL_ENABLE_16_BIT
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_bitreverse)
 uint16_t reversebits(uint16_t);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_bitreverse)
 uint16_t2 reversebits(uint16_t2);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_bitreverse)
 uint16_t3 reversebits(uint16_t3);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_bitreverse)
 uint16_t4 reversebits(uint16_t4);
 #endif
@@ -2014,7 +2014,7 @@ uint64_t4 reversebits(uint64_t4);
 /// x[2] * y[0] - y[2] * x[0]
 /// x[0] * y[1] - y[0] * x[1]
 
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_crossf16)
 half3 cross(half3, half3);
 
@@ -2031,16 +2031,16 @@ float3 cross(float3, float3);
 ///
 /// The return value is the reciprocal of the \a x parameter.
 
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_rcp)
 half rcp(half);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_rcp)
 half2 rcp(half2);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_rcp)
 half3 rcp(half3);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_rcp)
 half4 rcp(half4);
 
@@ -2073,16 +2073,16 @@ double4 rcp(double4);
 ///
 /// This function uses the following formula: 1 / sqrt(x).
 
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_rsqrt)
 half rsqrt(half);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_rsqrt)
 half2 rsqrt(half2);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_rsqrt)
 half3 rsqrt(half3);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_rsqrt)
 half4 rsqrt(half4);
 
@@ -2107,16 +2107,16 @@ float4 rsqrt(float4);
 /// within a floating-point type. Halfway cases are
 /// rounded to the nearest even value.
 
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_roundeven)
 half round(half);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_roundeven)
 half2 round(half2);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_roundeven)
 half3 round(half3);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_roundeven)
 half4 round(half4);
 
@@ -2137,16 +2137,16 @@ float4 round(float4);
 /// \brief Returns input value, \a Val, clamped within the range of 0.0f
 /// to 1.0f. \param Val The input value.
 
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_saturate)
 half saturate(half);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_saturate)
 half2 saturate(half2);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_saturate)
 half3 saturate(half3);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_saturate)
 half4 saturate(half4);
 
@@ -2271,16 +2271,16 @@ __detail::enable_if_t<__detail::is_arithmetic<T>::Value, vector<T, 4>> select(
 /// \brief Returns the sine of the input value, \a Val.
 /// \param Val The input value.
 
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_sin)
 half sin(half);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_sin)
 half2 sin(half2);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_sin)
 half3 sin(half3);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_sin)
 half4 sin(half4);
 
@@ -2301,16 +2301,16 @@ float4 sin(float4);
 /// \brief Returns the hyperbolic sine of the input value, \a Val.
 /// \param Val The input value.
 
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_sinh)
 half sinh(half);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_sinh)
 half2 sinh(half2);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_sinh)
 half3 sinh(half3);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_sinh)
 half4 sinh(half4);
 
@@ -2331,16 +2331,16 @@ float4 sinh(float4);
 /// \brief Returns the square root of the input value, \a Val.
 /// \param Val The input value.
 
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_sqrt)
 half sqrt(half);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_sqrt)
 half2 sqrt(half2);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_sqrt)
 half3 sqrt(half3);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_sqrt)
 half4 sqrt(half4);
 
@@ -2364,16 +2364,16 @@ float4 sqrt(float4);
 ///
 /// Step is based on the following formula: (x >= y) ? 1 : 0
 
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_step)
 half step(half, half);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_step)
 half2 step(half2, half2);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_step)
 half3 step(half3, half3);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_step)
 half4 step(half4, half4);
 
@@ -2394,16 +2394,16 @@ float4 step(float4, float4);
 /// \brief Returns the tangent of the input value, \a Val.
 /// \param Val The input value.
 
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_tan)
 half tan(half);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_tan)
 half2 tan(half2);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_tan)
 half3 tan(half3);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_tan)
 half4 tan(half4);
 
@@ -2424,16 +2424,16 @@ float4 tan(float4);
 /// \brief Returns the hyperbolic tangent of the input value, \a Val.
 /// \param Val The input value.
 
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_tanh)
 half tanh(half);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_tanh)
 half2 tanh(half2);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_tanh)
 half3 tanh(half3);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_tanh)
 half4 tanh(half4);
 
@@ -2454,16 +2454,16 @@ float4 tanh(float4);
 /// \brief Returns the truncated integer value of the input value, \a Val.
 /// \param Val The input value.
 
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_trunc)
 half trunc(half);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_trunc)
 half2 trunc(half2);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_trunc)
 half3 trunc(half3);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_trunc)
 half4 trunc(half4);
 
@@ -2485,43 +2485,43 @@ float4 trunc(float4);
 /// group. Otherwise, the result is false.
 /// \param Value The value to compare with
 /// \return True if all values across all lanes are equal, false otherwise
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_all_equal)
 __attribute__((convergent)) bool WaveActiveAllEqual(half);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_all_equal)
 __attribute__((convergent)) bool2 WaveActiveAllEqual(half2);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_all_equal)
 __attribute__((convergent)) bool3 WaveActiveAllEqual(half3);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_all_equal)
 __attribute__((convergent)) bool4 WaveActiveAllEqual(half4);
 
 #ifdef __HLSL_ENABLE_16_BIT
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_all_equal)
 __attribute__((convergent)) bool WaveActiveAllEqual(int16_t);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_all_equal)
 __attribute__((convergent)) bool2 WaveActiveAllEqual(int16_t2);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_all_equal)
 __attribute__((convergent)) bool3 WaveActiveAllEqual(int16_t3);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_all_equal)
 __attribute__((convergent)) bool4 WaveActiveAllEqual(int16_t4);
 
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_all_equal)
 __attribute__((convergent)) bool WaveActiveAllEqual(uint16_t);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_all_equal)
 __attribute__((convergent)) bool2 WaveActiveAllEqual(uint16_t2);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_all_equal)
 __attribute__((convergent)) bool3 WaveActiveAllEqual(uint16_t3);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_all_equal)
 __attribute__((convergent)) bool4 WaveActiveAllEqual(uint16_t4);
 #endif
@@ -2684,43 +2684,43 @@ _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_read_lane_at)
 __attribute__((convergent)) bool4 WaveReadLaneAt(bool4, uint32_t);
 
 #ifdef __HLSL_ENABLE_16_BIT
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_read_lane_at)
 __attribute__((convergent)) int16_t WaveReadLaneAt(int16_t, uint32_t);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_read_lane_at)
 __attribute__((convergent)) int16_t2 WaveReadLaneAt(int16_t2, uint32_t);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_read_lane_at)
 __attribute__((convergent)) int16_t3 WaveReadLaneAt(int16_t3, uint32_t);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_read_lane_at)
 __attribute__((convergent)) int16_t4 WaveReadLaneAt(int16_t4, uint32_t);
 
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_read_lane_at)
 __attribute__((convergent)) uint16_t WaveReadLaneAt(uint16_t, uint32_t);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_read_lane_at)
 __attribute__((convergent)) uint16_t2 WaveReadLaneAt(uint16_t2, uint32_t);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_read_lane_at)
 __attribute__((convergent)) uint16_t3 WaveReadLaneAt(uint16_t3, uint32_t);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_read_lane_at)
 __attribute__((convergent)) uint16_t4 WaveReadLaneAt(uint16_t4, uint32_t);
 #endif
 
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_read_lane_at)
 __attribute__((convergent)) half WaveReadLaneAt(half, uint32_t);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_read_lane_at)
 __attribute__((convergent)) half2 WaveReadLaneAt(half2, uint32_t);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_read_lane_at)
 __attribute__((convergent)) half3 WaveReadLaneAt(half3, uint32_t);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_read_lane_at)
 __attribute__((convergent)) half4 WaveReadLaneAt(half4, uint32_t);
 
@@ -2816,43 +2816,43 @@ __attribute__((convergent)) uint64_t4 WaveActiveBitOr(uint64_t4);
 // WaveActiveMax builtins
 //===----------------------------------------------------------------------===//
 
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_max)
 __attribute__((convergent)) half WaveActiveMax(half);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_max)
 __attribute__((convergent)) half2 WaveActiveMax(half2);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_max)
 __attribute__((convergent)) half3 WaveActiveMax(half3);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_max)
 __attribute__((convergent)) half4 WaveActiveMax(half4);
 
 #ifdef __HLSL_ENABLE_16_BIT
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_max)
 __attribute__((convergent)) int16_t WaveActiveMax(int16_t);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_max)
 __attribute__((convergent)) int16_t2 WaveActiveMax(int16_t2);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_max)
 __attribute__((convergent)) int16_t3 WaveActiveMax(int16_t3);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_max)
 __attribute__((convergent)) int16_t4 WaveActiveMax(int16_t4);
 
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_max)
 __attribute__((convergent)) uint16_t WaveActiveMax(uint16_t);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_max)
 __attribute__((convergent)) uint16_t2 WaveActiveMax(uint16_t2);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_max)
 __attribute__((convergent)) uint16_t3 WaveActiveMax(uint16_t3);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_max)
 __attribute__((convergent)) uint16_t4 WaveActiveMax(uint16_t4);
 #endif
@@ -2915,43 +2915,43 @@ __attribute__((convergent)) double4 WaveActiveMax(double4);
 // WaveActiveMin builtins
 //===----------------------------------------------------------------------===//
 
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_min)
 __attribute__((convergent)) half WaveActiveMin(half);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_min)
 __attribute__((convergent)) half2 WaveActiveMin(half2);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_min)
 __attribute__((convergent)) half3 WaveActiveMin(half3);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_min)
 __attribute__((convergent)) half4 WaveActiveMin(half4);
 
 #ifdef __HLSL_ENABLE_16_BIT
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_min)
 __attribute__((convergent)) int16_t WaveActiveMin(int16_t);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_min)
 __attribute__((convergent)) int16_t2 WaveActiveMin(int16_t2);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_min)
 __attribute__((convergent)) int16_t3 WaveActiveMin(int16_t3);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_min)
 __attribute__((convergent)) int16_t4 WaveActiveMin(int16_t4);
 
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_min)
 __attribute__((convergent)) uint16_t WaveActiveMin(uint16_t);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_min)
 __attribute__((convergent)) uint16_t2 WaveActiveMin(uint16_t2);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_min)
 __attribute__((convergent)) uint16_t3 WaveActiveMin(uint16_t3);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_min)
 __attribute__((convergent)) uint16_t4 WaveActiveMin(uint16_t4);
 #endif
@@ -3038,43 +3038,43 @@ __attribute__((convergent)) double4 WaveActiveMin(double4);
 // WaveActiveSum builtins
 //===----------------------------------------------------------------------===//
 
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_sum)
 __attribute__((convergent)) half WaveActiveSum(half);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_sum)
 __attribute__((convergent)) half2 WaveActiveSum(half2);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_sum)
 __attribute__((convergent)) half3 WaveActiveSum(half3);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_sum)
 __attribute__((convergent)) half4 WaveActiveSum(half4);
 
 #ifdef __HLSL_ENABLE_16_BIT
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_sum)
 __attribute__((convergent)) int16_t WaveActiveSum(int16_t);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_sum)
 __attribute__((convergent)) int16_t2 WaveActiveSum(int16_t2);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_sum)
 __attribute__((convergent)) int16_t3 WaveActiveSum(int16_t3);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_sum)
 __attribute__((convergent)) int16_t4 WaveActiveSum(int16_t4);
 
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_sum)
 __attribute__((convergent)) uint16_t WaveActiveSum(uint16_t);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_sum)
 __attribute__((convergent)) uint16_t2 WaveActiveSum(uint16_t2);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_sum)
 __attribute__((convergent)) uint16_t3 WaveActiveSum(uint16_t3);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_sum)
 __attribute__((convergent)) uint16_t4 WaveActiveSum(uint16_t4);
 #endif
@@ -3137,43 +3137,43 @@ __attribute__((convergent)) double4 WaveActiveSum(double4);
 // WaveActiveProduct builtins
 //===----------------------------------------------------------------------===//
 
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_product)
 __attribute__((convergent)) half WaveActiveProduct(half);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_product)
 __attribute__((convergent)) half2 WaveActiveProduct(half2);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_product)
 __attribute__((convergent)) half3 WaveActiveProduct(half3);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_product)
 __attribute__((convergent)) half4 WaveActiveProduct(half4);
 
 #ifdef __HLSL_ENABLE_16_BIT
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_product)
 __attribute__((convergent)) int16_t WaveActiveProduct(int16_t);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_product)
 __attribute__((convergent)) int16_t2 WaveActiveProduct(int16_t2);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_product)
 __attribute__((convergent)) int16_t3 WaveActiveProduct(int16_t3);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_product)
 __attribute__((convergent)) int16_t4 WaveActiveProduct(int16_t4);
 
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_product)
 __attribute__((convergent)) uint16_t WaveActiveProduct(uint16_t);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_product)
 __attribute__((convergent)) uint16_t2 WaveActiveProduct(uint16_t2);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_product)
 __attribute__((convergent)) uint16_t3 WaveActiveProduct(uint16_t3);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_product)
 __attribute__((convergent)) uint16_t4 WaveActiveProduct(uint16_t4);
 #endif
@@ -3260,43 +3260,43 @@ __attribute__((convergent)) double4 WaveActiveProduct(double4);
 // WavePrefixSum builtins
 //===----------------------------------------------------------------------===//
 
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_sum)
 __attribute__((convergent)) half WavePrefixSum(half);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_sum)
 __attribute__((convergent)) half2 WavePrefixSum(half2);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_sum)
 __attribute__((convergent)) half3 WavePrefixSum(half3);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_sum)
 __attribute__((convergent)) half4 WavePrefixSum(half4);
 
 #ifdef __HLSL_ENABLE_16_BIT
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_sum)
 __attribute__((convergent)) int16_t WavePrefixSum(int16_t);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_sum)
 __attribute__((convergent)) int16_t2 WavePrefixSum(int16_t2);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_sum)
 __attribute__((convergent)) int16_t3 WavePrefixSum(int16_t3);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_sum)
 __attribute__((convergent)) int16_t4 WavePrefixSum(int16_t4);
 
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_sum)
 __attribute__((convergent)) uint16_t WavePrefixSum(uint16_t);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_sum)
 __attribute__((convergent)) uint16_t2 WavePrefixSum(uint16_t2);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_sum)
 __attribute__((convergent)) uint16_t3 WavePrefixSum(uint16_t3);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_sum)
 __attribute__((convergent)) uint16_t4 WavePrefixSum(uint16_t4);
 #endif
@@ -3359,43 +3359,43 @@ __attribute__((convergent)) double4 WavePrefixSum(double4);
 // WavePrefixProduct builtins
 //===----------------------------------------------------------------------===//
 
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_product)
 __attribute__((convergent)) half WavePrefixProduct(half);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_product)
 __attribute__((convergent)) half2 WavePrefixProduct(half2);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_product)
 __attribute__((convergent)) half3 WavePrefixProduct(half3);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_product)
 __attribute__((convergent)) half4 WavePrefixProduct(half4);
 
 #ifdef __HLSL_ENABLE_16_BIT
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_product)
 __attribute__((convergent)) int16_t WavePrefixProduct(int16_t);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_product)
 __attribute__((convergent)) int16_t2 WavePrefixProduct(int16_t2);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_product)
 __attribute__((convergent)) int16_t3 WavePrefixProduct(int16_t3);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_product)
 __attribute__((convergent)) int16_t4 WavePrefixProduct(int16_t4);
 
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_product)
 __attribute__((convergent)) uint16_t WavePrefixProduct(uint16_t);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_product)
 __attribute__((convergent)) uint16_t2 WavePrefixProduct(uint16_t2);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_product)
 __attribute__((convergent)) uint16_t3 WavePrefixProduct(uint16_t3);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_product)
 __attribute__((convergent)) uint16_t4 WavePrefixProduct(uint16_t4);
 #endif
@@ -3463,43 +3463,43 @@ __attribute__((convergent)) double4 WavePrefixProduct(double4);
 /// 1 if \a Val is greater than zero. \param Val The input value.
 
 #ifdef __HLSL_ENABLE_16_BIT
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_sign)
 int sign(int16_t);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_sign)
 int2 sign(int16_t2);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_sign)
 int3 sign(int16_t3);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_sign)
 int4 sign(int16_t4);
 
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_sign)
 int sign(uint16_t);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_sign)
 int2 sign(uint16_t2);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_sign)
 int3 sign(uint16_t3);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_sign)
 int4 sign(uint16_t4);
 #endif
 
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_sign)
 int sign(half);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_sign)
 int2 sign(half2);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_sign)
 int3 sign(half3);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_sign)
 int4 sign(half4);
 
@@ -3564,16 +3564,16 @@ int4 sign(double4);
 /// \fn T radians(T Val)
 /// \brief Converts the specified value from degrees to radians.
 
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_radians)
 half radians(half);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_radians)
 half2 radians(half2);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_radians)
 half3 radians(half3);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_radians)
 half4 radians(half4);
 
@@ -3610,16 +3610,16 @@ __attribute__((convergent)) void GroupMemoryBarrierWithGroupSync(void);
 /// The return value is a floating point scalar or vector containing the low
 /// prevision partial derivative of the input value.
 
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_ddx_coarse)
 half ddx_coarse(half);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_ddx_coarse)
 half2 ddx_coarse(half2);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_ddx_coarse)
 half3 ddx_coarse(half3);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_ddx_coarse)
 half4 ddx_coarse(half4);
 
@@ -3644,16 +3644,16 @@ float4 ddx_coarse(float4);
 /// The return value is a floating point scalar or vector containing the low
 /// prevision partial derivative of the input value.
 
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_ddy_coarse)
 half ddy_coarse(half);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_ddy_coarse)
 half2 ddy_coarse(half2);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_ddy_coarse)
 half3 ddy_coarse(half3);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_ddy_coarse)
 half4 ddy_coarse(half4);
 
@@ -3678,16 +3678,16 @@ float4 ddy_coarse(float4);
 /// The return value is a floating point scalar or vector containing the high
 /// prevision partial derivative of the input value.
 
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_ddx_fine)
 half ddx_fine(half);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_ddx_fine)
 half2 ddx_fine(half2);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_ddx_fine)
 half3 ddx_fine(half3);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_ddx_fine)
 half4 ddx_fine(half4);
 
@@ -3712,16 +3712,16 @@ float4 ddx_fine(float4);
 /// The return value is a floating point scalar or vector containing the high
 /// prevision partial derivative of the input value.
 
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_ddy_fine)
 half ddy_fine(half);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_ddy_fine)
 half2 ddy_fine(half2);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_ddy_fine)
 half3 ddy_fine(half3);
-_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_ddy_fine)
 half4 ddy_fine(half4);
 

--- a/clang/lib/Headers/hlsl/hlsl_alias_intrinsics.h
+++ b/clang/lib/Headers/hlsl/hlsl_alias_intrinsics.h
@@ -35,6 +35,8 @@ namespace hlsl {
 #define _HLSL_16BIT_AVAILABILITY_STAGE(environment, version, stage)
 #endif
 
+#define _HLSL_16BIT_AVAILABILITY_DEFAULT() _HLSL_AVAILABILITY(shadermodel, 6.2)
+
 //===----------------------------------------------------------------------===//
 // abs builtins
 //===----------------------------------------------------------------------===//
@@ -2482,43 +2484,43 @@ float4 trunc(float4);
 /// group. Otherwise, the result is false.
 /// \param Value The value to compare with
 /// \return True if all values across all lanes are equal, false otherwise
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_all_equal)
 __attribute__((convergent)) bool WaveActiveAllEqual(half);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_all_equal)
 __attribute__((convergent)) bool2 WaveActiveAllEqual(half2);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_all_equal)
 __attribute__((convergent)) bool3 WaveActiveAllEqual(half3);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_all_equal)
 __attribute__((convergent)) bool4 WaveActiveAllEqual(half4);
 
 #ifdef __HLSL_ENABLE_16_BIT
-_HLSL_AVAILABILITY(shadermodel, 6.0)
+_HLSL_16BIT_AVAILABILITY_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_all_equal)
 __attribute__((convergent)) bool WaveActiveAllEqual(int16_t);
-_HLSL_AVAILABILITY(shadermodel, 6.0)
+_HLSL_16BIT_AVAILABILITY_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_all_equal)
 __attribute__((convergent)) bool2 WaveActiveAllEqual(int16_t2);
-_HLSL_AVAILABILITY(shadermodel, 6.0)
+_HLSL_16BIT_AVAILABILITY_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_all_equal)
 __attribute__((convergent)) bool3 WaveActiveAllEqual(int16_t3);
-_HLSL_AVAILABILITY(shadermodel, 6.0)
+_HLSL_16BIT_AVAILABILITY_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_all_equal)
 __attribute__((convergent)) bool4 WaveActiveAllEqual(int16_t4);
 
-_HLSL_AVAILABILITY(shadermodel, 6.0)
+_HLSL_16BIT_AVAILABILITY_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_all_equal)
 __attribute__((convergent)) bool WaveActiveAllEqual(uint16_t);
-_HLSL_AVAILABILITY(shadermodel, 6.0)
+_HLSL_16BIT_AVAILABILITY_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_all_equal)
 __attribute__((convergent)) bool2 WaveActiveAllEqual(uint16_t2);
-_HLSL_AVAILABILITY(shadermodel, 6.0)
+_HLSL_16BIT_AVAILABILITY_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_all_equal)
 __attribute__((convergent)) bool3 WaveActiveAllEqual(uint16_t3);
-_HLSL_AVAILABILITY(shadermodel, 6.0)
+_HLSL_16BIT_AVAILABILITY_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_all_equal)
 __attribute__((convergent)) bool4 WaveActiveAllEqual(uint16_t4);
 #endif
@@ -2681,29 +2683,29 @@ _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_read_lane_at)
 __attribute__((convergent)) bool4 WaveReadLaneAt(bool4, uint32_t);
 
 #ifdef __HLSL_ENABLE_16_BIT
-_HLSL_AVAILABILITY(shadermodel, 6.0)
+_HLSL_16BIT_AVAILABILITY_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_read_lane_at)
 __attribute__((convergent)) int16_t WaveReadLaneAt(int16_t, uint32_t);
-_HLSL_AVAILABILITY(shadermodel, 6.0)
+_HLSL_16BIT_AVAILABILITY_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_read_lane_at)
 __attribute__((convergent)) int16_t2 WaveReadLaneAt(int16_t2, uint32_t);
-_HLSL_AVAILABILITY(shadermodel, 6.0)
+_HLSL_16BIT_AVAILABILITY_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_read_lane_at)
 __attribute__((convergent)) int16_t3 WaveReadLaneAt(int16_t3, uint32_t);
-_HLSL_AVAILABILITY(shadermodel, 6.0)
+_HLSL_16BIT_AVAILABILITY_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_read_lane_at)
 __attribute__((convergent)) int16_t4 WaveReadLaneAt(int16_t4, uint32_t);
 
-_HLSL_AVAILABILITY(shadermodel, 6.0)
+_HLSL_16BIT_AVAILABILITY_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_read_lane_at)
 __attribute__((convergent)) uint16_t WaveReadLaneAt(uint16_t, uint32_t);
-_HLSL_AVAILABILITY(shadermodel, 6.0)
+_HLSL_16BIT_AVAILABILITY_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_read_lane_at)
 __attribute__((convergent)) uint16_t2 WaveReadLaneAt(uint16_t2, uint32_t);
-_HLSL_AVAILABILITY(shadermodel, 6.0)
+_HLSL_16BIT_AVAILABILITY_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_read_lane_at)
 __attribute__((convergent)) uint16_t3 WaveReadLaneAt(uint16_t3, uint32_t);
-_HLSL_AVAILABILITY(shadermodel, 6.0)
+_HLSL_16BIT_AVAILABILITY_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_read_lane_at)
 __attribute__((convergent)) uint16_t4 WaveReadLaneAt(uint16_t4, uint32_t);
 #endif
@@ -2827,29 +2829,29 @@ _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_max)
 __attribute__((convergent)) half4 WaveActiveMax(half4);
 
 #ifdef __HLSL_ENABLE_16_BIT
-_HLSL_AVAILABILITY(shadermodel, 6.0)
+_HLSL_16BIT_AVAILABILITY_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_max)
 __attribute__((convergent)) int16_t WaveActiveMax(int16_t);
-_HLSL_AVAILABILITY(shadermodel, 6.0)
+_HLSL_16BIT_AVAILABILITY_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_max)
 __attribute__((convergent)) int16_t2 WaveActiveMax(int16_t2);
-_HLSL_AVAILABILITY(shadermodel, 6.0)
+_HLSL_16BIT_AVAILABILITY_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_max)
 __attribute__((convergent)) int16_t3 WaveActiveMax(int16_t3);
-_HLSL_AVAILABILITY(shadermodel, 6.0)
+_HLSL_16BIT_AVAILABILITY_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_max)
 __attribute__((convergent)) int16_t4 WaveActiveMax(int16_t4);
 
-_HLSL_AVAILABILITY(shadermodel, 6.0)
+_HLSL_16BIT_AVAILABILITY_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_max)
 __attribute__((convergent)) uint16_t WaveActiveMax(uint16_t);
-_HLSL_AVAILABILITY(shadermodel, 6.0)
+_HLSL_16BIT_AVAILABILITY_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_max)
 __attribute__((convergent)) uint16_t2 WaveActiveMax(uint16_t2);
-_HLSL_AVAILABILITY(shadermodel, 6.0)
+_HLSL_16BIT_AVAILABILITY_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_max)
 __attribute__((convergent)) uint16_t3 WaveActiveMax(uint16_t3);
-_HLSL_AVAILABILITY(shadermodel, 6.0)
+_HLSL_16BIT_AVAILABILITY_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_max)
 __attribute__((convergent)) uint16_t4 WaveActiveMax(uint16_t4);
 #endif
@@ -2926,29 +2928,29 @@ _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_min)
 __attribute__((convergent)) half4 WaveActiveMin(half4);
 
 #ifdef __HLSL_ENABLE_16_BIT
-_HLSL_AVAILABILITY(shadermodel, 6.0)
+_HLSL_16BIT_AVAILABILITY_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_min)
 __attribute__((convergent)) int16_t WaveActiveMin(int16_t);
-_HLSL_AVAILABILITY(shadermodel, 6.0)
+_HLSL_16BIT_AVAILABILITY_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_min)
 __attribute__((convergent)) int16_t2 WaveActiveMin(int16_t2);
-_HLSL_AVAILABILITY(shadermodel, 6.0)
+_HLSL_16BIT_AVAILABILITY_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_min)
 __attribute__((convergent)) int16_t3 WaveActiveMin(int16_t3);
-_HLSL_AVAILABILITY(shadermodel, 6.0)
+_HLSL_16BIT_AVAILABILITY_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_min)
 __attribute__((convergent)) int16_t4 WaveActiveMin(int16_t4);
 
-_HLSL_AVAILABILITY(shadermodel, 6.0)
+_HLSL_16BIT_AVAILABILITY_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_min)
 __attribute__((convergent)) uint16_t WaveActiveMin(uint16_t);
-_HLSL_AVAILABILITY(shadermodel, 6.0)
+_HLSL_16BIT_AVAILABILITY_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_min)
 __attribute__((convergent)) uint16_t2 WaveActiveMin(uint16_t2);
-_HLSL_AVAILABILITY(shadermodel, 6.0)
+_HLSL_16BIT_AVAILABILITY_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_min)
 __attribute__((convergent)) uint16_t3 WaveActiveMin(uint16_t3);
-_HLSL_AVAILABILITY(shadermodel, 6.0)
+_HLSL_16BIT_AVAILABILITY_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_min)
 __attribute__((convergent)) uint16_t4 WaveActiveMin(uint16_t4);
 #endif
@@ -3049,29 +3051,29 @@ _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_sum)
 __attribute__((convergent)) half4 WaveActiveSum(half4);
 
 #ifdef __HLSL_ENABLE_16_BIT
-_HLSL_AVAILABILITY(shadermodel, 6.0)
+_HLSL_16BIT_AVAILABILITY_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_sum)
 __attribute__((convergent)) int16_t WaveActiveSum(int16_t);
-_HLSL_AVAILABILITY(shadermodel, 6.0)
+_HLSL_16BIT_AVAILABILITY_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_sum)
 __attribute__((convergent)) int16_t2 WaveActiveSum(int16_t2);
-_HLSL_AVAILABILITY(shadermodel, 6.0)
+_HLSL_16BIT_AVAILABILITY_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_sum)
 __attribute__((convergent)) int16_t3 WaveActiveSum(int16_t3);
-_HLSL_AVAILABILITY(shadermodel, 6.0)
+_HLSL_16BIT_AVAILABILITY_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_sum)
 __attribute__((convergent)) int16_t4 WaveActiveSum(int16_t4);
 
-_HLSL_AVAILABILITY(shadermodel, 6.0)
+_HLSL_16BIT_AVAILABILITY_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_sum)
 __attribute__((convergent)) uint16_t WaveActiveSum(uint16_t);
-_HLSL_AVAILABILITY(shadermodel, 6.0)
+_HLSL_16BIT_AVAILABILITY_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_sum)
 __attribute__((convergent)) uint16_t2 WaveActiveSum(uint16_t2);
-_HLSL_AVAILABILITY(shadermodel, 6.0)
+_HLSL_16BIT_AVAILABILITY_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_sum)
 __attribute__((convergent)) uint16_t3 WaveActiveSum(uint16_t3);
-_HLSL_AVAILABILITY(shadermodel, 6.0)
+_HLSL_16BIT_AVAILABILITY_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_sum)
 __attribute__((convergent)) uint16_t4 WaveActiveSum(uint16_t4);
 #endif
@@ -3148,29 +3150,29 @@ _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_product)
 __attribute__((convergent)) half4 WaveActiveProduct(half4);
 
 #ifdef __HLSL_ENABLE_16_BIT
-_HLSL_AVAILABILITY(shadermodel, 6.0)
+_HLSL_16BIT_AVAILABILITY_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_product)
 __attribute__((convergent)) int16_t WaveActiveProduct(int16_t);
-_HLSL_AVAILABILITY(shadermodel, 6.0)
+_HLSL_16BIT_AVAILABILITY_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_product)
 __attribute__((convergent)) int16_t2 WaveActiveProduct(int16_t2);
-_HLSL_AVAILABILITY(shadermodel, 6.0)
+_HLSL_16BIT_AVAILABILITY_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_product)
 __attribute__((convergent)) int16_t3 WaveActiveProduct(int16_t3);
-_HLSL_AVAILABILITY(shadermodel, 6.0)
+_HLSL_16BIT_AVAILABILITY_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_product)
 __attribute__((convergent)) int16_t4 WaveActiveProduct(int16_t4);
 
-_HLSL_AVAILABILITY(shadermodel, 6.0)
+_HLSL_16BIT_AVAILABILITY_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_product)
 __attribute__((convergent)) uint16_t WaveActiveProduct(uint16_t);
-_HLSL_AVAILABILITY(shadermodel, 6.0)
+_HLSL_16BIT_AVAILABILITY_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_product)
 __attribute__((convergent)) uint16_t2 WaveActiveProduct(uint16_t2);
-_HLSL_AVAILABILITY(shadermodel, 6.0)
+_HLSL_16BIT_AVAILABILITY_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_product)
 __attribute__((convergent)) uint16_t3 WaveActiveProduct(uint16_t3);
-_HLSL_AVAILABILITY(shadermodel, 6.0)
+_HLSL_16BIT_AVAILABILITY_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_product)
 __attribute__((convergent)) uint16_t4 WaveActiveProduct(uint16_t4);
 #endif
@@ -3271,29 +3273,29 @@ _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_sum)
 __attribute__((convergent)) half4 WavePrefixSum(half4);
 
 #ifdef __HLSL_ENABLE_16_BIT
-_HLSL_AVAILABILITY(shadermodel, 6.0)
+_HLSL_16BIT_AVAILABILITY_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_sum)
 __attribute__((convergent)) int16_t WavePrefixSum(int16_t);
-_HLSL_AVAILABILITY(shadermodel, 6.0)
+_HLSL_16BIT_AVAILABILITY_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_sum)
 __attribute__((convergent)) int16_t2 WavePrefixSum(int16_t2);
-_HLSL_AVAILABILITY(shadermodel, 6.0)
+_HLSL_16BIT_AVAILABILITY_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_sum)
 __attribute__((convergent)) int16_t3 WavePrefixSum(int16_t3);
-_HLSL_AVAILABILITY(shadermodel, 6.0)
+_HLSL_16BIT_AVAILABILITY_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_sum)
 __attribute__((convergent)) int16_t4 WavePrefixSum(int16_t4);
 
-_HLSL_AVAILABILITY(shadermodel, 6.0)
+_HLSL_16BIT_AVAILABILITY_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_sum)
 __attribute__((convergent)) uint16_t WavePrefixSum(uint16_t);
-_HLSL_AVAILABILITY(shadermodel, 6.0)
+_HLSL_16BIT_AVAILABILITY_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_sum)
 __attribute__((convergent)) uint16_t2 WavePrefixSum(uint16_t2);
-_HLSL_AVAILABILITY(shadermodel, 6.0)
+_HLSL_16BIT_AVAILABILITY_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_sum)
 __attribute__((convergent)) uint16_t3 WavePrefixSum(uint16_t3);
-_HLSL_AVAILABILITY(shadermodel, 6.0)
+_HLSL_16BIT_AVAILABILITY_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_sum)
 __attribute__((convergent)) uint16_t4 WavePrefixSum(uint16_t4);
 #endif
@@ -3370,29 +3372,29 @@ _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_product)
 __attribute__((convergent)) half4 WavePrefixProduct(half4);
 
 #ifdef __HLSL_ENABLE_16_BIT
-_HLSL_AVAILABILITY(shadermodel, 6.0)
+_HLSL_16BIT_AVAILABILITY_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_product)
 __attribute__((convergent)) int16_t WavePrefixProduct(int16_t);
-_HLSL_AVAILABILITY(shadermodel, 6.0)
+_HLSL_16BIT_AVAILABILITY_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_product)
 __attribute__((convergent)) int16_t2 WavePrefixProduct(int16_t2);
-_HLSL_AVAILABILITY(shadermodel, 6.0)
+_HLSL_16BIT_AVAILABILITY_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_product)
 __attribute__((convergent)) int16_t3 WavePrefixProduct(int16_t3);
-_HLSL_AVAILABILITY(shadermodel, 6.0)
+_HLSL_16BIT_AVAILABILITY_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_product)
 __attribute__((convergent)) int16_t4 WavePrefixProduct(int16_t4);
 
-_HLSL_AVAILABILITY(shadermodel, 6.0)
+_HLSL_16BIT_AVAILABILITY_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_product)
 __attribute__((convergent)) uint16_t WavePrefixProduct(uint16_t);
-_HLSL_AVAILABILITY(shadermodel, 6.0)
+_HLSL_16BIT_AVAILABILITY_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_product)
 __attribute__((convergent)) uint16_t2 WavePrefixProduct(uint16_t2);
-_HLSL_AVAILABILITY(shadermodel, 6.0)
+_HLSL_16BIT_AVAILABILITY_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_product)
 __attribute__((convergent)) uint16_t3 WavePrefixProduct(uint16_t3);
-_HLSL_AVAILABILITY(shadermodel, 6.0)
+_HLSL_16BIT_AVAILABILITY_DEFAULT()
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_product)
 __attribute__((convergent)) uint16_t4 WavePrefixProduct(uint16_t4);
 #endif

--- a/clang/lib/Headers/hlsl/hlsl_alias_intrinsics.h
+++ b/clang/lib/Headers/hlsl/hlsl_alias_intrinsics.h
@@ -30,15 +30,13 @@ namespace hlsl {
 #define _HLSL_16BIT_AVAILABILITY_STAGE(platform, version, stage)               \
   __attribute__((                                                              \
       availability(platform, introduced = version, environment = stage)))
-#define _HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)                          \
+#define _HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)              \
   _HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
 #else
 #define _HLSL_16BIT_AVAILABILITY(environment, version)
 #define _HLSL_16BIT_AVAILABILITY_STAGE(environment, version, stage)
-#define _HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+#define _HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 #endif
-
-#define _HLSL_AVAILABILITY_6_2(shadermodel) _HLSL_AVAILABILITY(shadermodel, 6.2)
 
 //===----------------------------------------------------------------------===//
 // abs builtins
@@ -49,39 +47,39 @@ namespace hlsl {
 /// \param Val The input value.
 
 #ifdef __HLSL_ENABLE_16_BIT
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_abs)
 int16_t abs(int16_t);
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_abs)
 int16_t2 abs(int16_t2);
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_abs)
 int16_t3 abs(int16_t3);
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_abs)
 int16_t4 abs(int16_t4);
 
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 constexpr uint16_t abs(uint16_t V) { return V; }
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 constexpr uint16_t2 abs(uint16_t2 V) { return V; }
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 constexpr uint16_t3 abs(uint16_t3 V) { return V; }
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 constexpr uint16_t4 abs(uint16_t4 V) { return V; }
 #endif
 
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_abs)
 half abs(half);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_abs)
 half2 abs(half2);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_abs)
 half3 abs(half3);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_abs)
 half4 abs(half4);
 
@@ -139,16 +137,16 @@ double4 abs(double4);
 /// \brief Returns the arccosine of the input value, \a Val.
 /// \param Val The input value.
 
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_acos)
 half acos(half);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_acos)
 half2 acos(half2);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_acos)
 half3 acos(half3);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_acos)
 half4 acos(half4);
 
@@ -191,42 +189,42 @@ uint32_t4 AddUint64(uint32_t4, uint32_t4);
 /// otherwise, false. \param x The input value.
 
 #ifdef __HLSL_ENABLE_16_BIT
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_all)
 bool all(int16_t);
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_all)
 bool all(int16_t2);
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_all)
 bool all(int16_t3);
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_all)
 bool all(int16_t4);
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_all)
 bool all(uint16_t);
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_all)
 bool all(uint16_t2);
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_all)
 bool all(uint16_t3);
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_all)
 bool all(uint16_t4);
 #endif
 
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_all)
 bool all(half);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_all)
 bool all(half2);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_all)
 bool all(half3);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_all)
 bool all(half4);
 
@@ -357,42 +355,42 @@ bool4x4 and(bool4x4 x, bool4x4 y);
 /// otherwise, false. \param x The input value.
 
 #ifdef __HLSL_ENABLE_16_BIT
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_any)
 bool any(int16_t);
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_any)
 bool any(int16_t2);
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_any)
 bool any(int16_t3);
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_any)
 bool any(int16_t4);
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_any)
 bool any(uint16_t);
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_any)
 bool any(uint16_t2);
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_any)
 bool any(uint16_t3);
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_any)
 bool any(uint16_t4);
 #endif
 
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_any)
 bool any(half);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_any)
 bool any(half2);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_any)
 bool any(half3);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_any)
 bool any(half4);
 
@@ -486,16 +484,16 @@ double4 asdouble(uint4, uint4);
 /// \brief Returns the arcsine of the input value, \a Val.
 /// \param Val The input value.
 
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_asin)
 half asin(half);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_asin)
 half2 asin(half2);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_asin)
 half3 asin(half3);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_asin)
 half4 asin(half4);
 
@@ -516,16 +514,16 @@ float4 asin(float4);
 /// \brief Returns the arctangent of the input value, \a Val.
 /// \param Val The input value.
 
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_atan)
 half atan(half);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_atan)
 half2 atan(half2);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_atan)
 half3 atan(half3);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_atan)
 half4 atan(half4);
 
@@ -548,16 +546,16 @@ float4 atan(float4);
 /// \param y The y-coordinate.
 /// \param x The x-coordinate.
 
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_atan2)
 half atan2(half y, half x);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_atan2)
 half2 atan2(half2 y, half2 x);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_atan2)
 half3 atan2(half3 y, half3 x);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_atan2)
 half4 atan2(half4 y, half4 x);
 
@@ -579,16 +577,16 @@ float4 atan2(float4 y, float4 x);
 /// the input value, \a Val.
 /// \param Val The input value.
 
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_ceil)
 half ceil(half);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_ceil)
 half2 ceil(half2);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_ceil)
 half3 ceil(half3);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_ceil)
 half4 ceil(half4);
 
@@ -616,43 +614,43 @@ float4 ceil(float4);
 /// For values of -INF or INF, clamp will behave as expected.
 /// However for values of NaN, the results are undefined.
 
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_clamp)
 half clamp(half, half, half);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_clamp)
 half2 clamp(half2, half2, half2);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_clamp)
 half3 clamp(half3, half3, half3);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_clamp)
 half4 clamp(half4, half4, half4);
 
 #ifdef __HLSL_ENABLE_16_BIT
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_clamp)
 int16_t clamp(int16_t, int16_t, int16_t);
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_clamp)
 int16_t2 clamp(int16_t2, int16_t2, int16_t2);
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_clamp)
 int16_t3 clamp(int16_t3, int16_t3, int16_t3);
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_clamp)
 int16_t4 clamp(int16_t4, int16_t4, int16_t4);
 
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_clamp)
 uint16_t clamp(uint16_t, uint16_t, uint16_t);
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_clamp)
 uint16_t2 clamp(uint16_t2, uint16_t2, uint16_t2);
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_clamp)
 uint16_t3 clamp(uint16_t3, uint16_t3, uint16_t3);
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_clamp)
 uint16_t4 clamp(uint16_t4, uint16_t4, uint16_t4);
 #endif
@@ -736,16 +734,16 @@ void clip(float4);
 /// \brief Returns the cosine of the input value, \a Val.
 /// \param Val The input value.
 
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_cos)
 half cos(half);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_cos)
 half2 cos(half2);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_cos)
 half3 cos(half3);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_cos)
 half4 cos(half4);
 
@@ -766,16 +764,16 @@ float4 cos(float4);
 /// \brief Returns the hyperbolic cosine of the input value, \a Val.
 /// \param Val The input value.
 
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_cosh)
 half cosh(half);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_cosh)
 half2 cosh(half2);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_cosh)
 half3 cosh(half3);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_cosh)
 half4 cosh(half4);
 
@@ -797,35 +795,35 @@ float4 cosh(float4);
 /// \param Val The input value.
 
 #ifdef __HLSL_ENABLE_16_BIT
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 const inline uint countbits(int16_t x) {
   return __builtin_elementwise_popcount(x);
 }
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 const inline uint2 countbits(int16_t2 x) {
   return __builtin_elementwise_popcount(x);
 }
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 const inline uint3 countbits(int16_t3 x) {
   return __builtin_elementwise_popcount(x);
 }
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 const inline uint4 countbits(int16_t4 x) {
   return __builtin_elementwise_popcount(x);
 }
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 const inline uint countbits(uint16_t x) {
   return __builtin_elementwise_popcount(x);
 }
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 const inline uint2 countbits(uint16_t2 x) {
   return __builtin_elementwise_popcount(x);
 }
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 const inline uint3 countbits(uint16_t3 x) {
   return __builtin_elementwise_popcount(x);
 }
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 const inline uint4 countbits(uint16_t4 x) {
   return __builtin_elementwise_popcount(x);
 }
@@ -889,16 +887,16 @@ const inline uint4 countbits(uint64_t4 x) {
 /// \brief Converts the specified value from radians to degrees.
 /// \param x The specified input value.
 
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_degrees)
 half degrees(half);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_degrees)
 half2 degrees(half2);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_degrees)
 half3 degrees(half3);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_degrees)
 half4 degrees(half4);
 
@@ -920,43 +918,43 @@ float4 degrees(float4);
 /// \param X The X input value.
 /// \param Y The Y input value.
 
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_dot)
 half dot(half, half);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_dot)
 half dot(half2, half2);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_dot)
 half dot(half3, half3);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_dot)
 half dot(half4, half4);
 
 #ifdef __HLSL_ENABLE_16_BIT
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_dot)
 int16_t dot(int16_t, int16_t);
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_dot)
 int16_t dot(int16_t2, int16_t2);
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_dot)
 int16_t dot(int16_t3, int16_t3);
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_dot)
 int16_t dot(int16_t4, int16_t4);
 
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_dot)
 uint16_t dot(uint16_t, uint16_t);
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_dot)
 uint16_t dot(uint16_t2, uint16_t2);
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_dot)
 uint16_t dot(uint16_t3, uint16_t3);
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_dot)
 uint16_t dot(uint16_t4, uint16_t4);
 #endif
@@ -1035,16 +1033,16 @@ uint dot4add_u8packed(uint, uint, uint);
 ///
 /// The return value is the base-e exponential of the \a x parameter.
 
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_exp)
 half exp(half);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_exp)
 half2 exp(half2);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_exp)
 half3 exp(half3);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_exp)
 half4 exp(half4);
 
@@ -1067,16 +1065,16 @@ float4 exp(float4);
 ///
 /// The base 2 exponential of the \a x parameter.
 
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_exp2)
 half exp2(half);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_exp2)
 half2 exp2(half2);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_exp2)
 half3 exp2(half3);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_exp2)
 half4 exp2(half4);
 
@@ -1141,28 +1139,28 @@ uint4 f32tof16(float4);
 /// \param Val the input value.
 
 #ifdef __HLSL_ENABLE_16_BIT
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_firstbitlow)
 uint firstbitlow(int16_t);
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_firstbitlow)
 uint2 firstbitlow(int16_t2);
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_firstbitlow)
 uint3 firstbitlow(int16_t3);
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_firstbitlow)
 uint4 firstbitlow(int16_t4);
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_firstbitlow)
 uint firstbitlow(uint16_t);
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_firstbitlow)
 uint2 firstbitlow(uint16_t2);
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_firstbitlow)
 uint3 firstbitlow(uint16_t3);
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_firstbitlow)
 uint4 firstbitlow(uint16_t4);
 #endif
@@ -1212,16 +1210,16 @@ uint4 firstbitlow(uint64_t4);
 /// value, \a Val.
 /// \param Val The input value.
 
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_floor)
 half floor(half);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_floor)
 half2 floor(half2);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_floor)
 half3 floor(half3);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_floor)
 half4 floor(half4);
 
@@ -1244,16 +1242,16 @@ float4 floor(float4);
 ///
 /// If \a the return value is greater than or equal to 0 and less than 1.
 
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_frac)
 half frac(half);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_frac)
 half2 frac(half2);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_frac)
 half3 frac(half3);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_frac)
 half4 frac(half4);
 
@@ -1277,16 +1275,16 @@ float4 frac(float4);
 /// Returns a value of the same size as the input, with a value set
 /// to True if the x parameter is +INF or -INF. Otherwise, False.
 
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_isinf)
 bool isinf(half);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_isinf)
 bool2 isinf(half2);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_isinf)
 bool3 isinf(half3);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_isinf)
 bool4 isinf(half4);
 
@@ -1310,16 +1308,16 @@ bool4 isinf(float4);
 /// Returns a value of the same size as the input, with a value set
 /// to True if the x parameter is NaN or QNaN. Otherwise, False.
 
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_isnan)
 bool isnan(half);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_isnan)
 bool2 isnan(half2);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_isnan)
 bool3 isnan(half3);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_isnan)
 bool4 isnan(half4);
 
@@ -1346,16 +1344,16 @@ bool4 isnan(float4);
 /// Linear interpolation is based on the following formula: x*(1-s) + y*s which
 /// can equivalently be written as x + s(y-x).
 
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_lerp)
 half lerp(half, half, half);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_lerp)
 half2 lerp(half2, half2, half2);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_lerp)
 half3 lerp(half3, half3, half3);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_lerp)
 half4 lerp(half4, half4, half4);
 
@@ -1379,16 +1377,16 @@ float4 lerp(float4, float4, float4);
 /// If \a Val is negative, this result is undefined. If \a Val is 0, this
 /// function returns negative infinity.
 
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_log)
 half log(half);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_log)
 half2 log(half2);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_log)
 half3 log(half3);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_log)
 half4 log(half4);
 
@@ -1412,16 +1410,16 @@ float4 log(float4);
 /// If \a Val is negative, this result is undefined. If \a Val is 0, this
 /// function returns negative infinity.
 
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_log10)
 half log10(half);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_log10)
 half2 log10(half2);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_log10)
 half3 log10(half3);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_log10)
 half4 log10(half4);
 
@@ -1445,16 +1443,16 @@ float4 log10(float4);
 /// If \a Val is negative, this result is undefined. If \a Val is 0, this
 /// function returns negative infinity.
 
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_log2)
 half log2(half);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_log2)
 half2 log2(half2);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_log2)
 half3 log2(half3);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_log2)
 half4 log2(half4);
 
@@ -1477,43 +1475,43 @@ float4 log2(float4);
 /// \param A The first addition value.
 /// \param B The second addition value.
 
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_mad)
 half mad(half, half, half);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_mad)
 half2 mad(half2, half2, half2);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_mad)
 half3 mad(half3, half3, half3);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_mad)
 half4 mad(half4, half4, half4);
 
 #ifdef __HLSL_ENABLE_16_BIT
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_mad)
 int16_t mad(int16_t, int16_t, int16_t);
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_mad)
 int16_t2 mad(int16_t2, int16_t2, int16_t2);
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_mad)
 int16_t3 mad(int16_t3, int16_t3, int16_t3);
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_mad)
 int16_t4 mad(int16_t4, int16_t4, int16_t4);
 
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_mad)
 uint16_t mad(uint16_t, uint16_t, uint16_t);
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_mad)
 uint16_t2 mad(uint16_t2, uint16_t2, uint16_t2);
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_mad)
 uint16_t3 mad(uint16_t3, uint16_t3, uint16_t3);
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_mad)
 uint16_t4 mad(uint16_t4, uint16_t4, uint16_t4);
 #endif
@@ -1581,43 +1579,43 @@ double4 mad(double4, double4, double4);
 /// \param X The X input value.
 /// \param Y The Y input value.
 
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_max)
 half max(half, half);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_max)
 half2 max(half2, half2);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_max)
 half3 max(half3, half3);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_max)
 half4 max(half4, half4);
 
 #ifdef __HLSL_ENABLE_16_BIT
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_max)
 int16_t max(int16_t, int16_t);
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_max)
 int16_t2 max(int16_t2, int16_t2);
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_max)
 int16_t3 max(int16_t3, int16_t3);
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_max)
 int16_t4 max(int16_t4, int16_t4);
 
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_max)
 uint16_t max(uint16_t, uint16_t);
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_max)
 uint16_t2 max(uint16_t2, uint16_t2);
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_max)
 uint16_t3 max(uint16_t3, uint16_t3);
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_max)
 uint16_t4 max(uint16_t4, uint16_t4);
 #endif
@@ -1685,43 +1683,43 @@ double4 max(double4, double4);
 /// \param X The X input value.
 /// \param Y The Y input value.
 
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_min)
 half min(half, half);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_min)
 half2 min(half2, half2);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_min)
 half3 min(half3, half3);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_min)
 half4 min(half4, half4);
 
 #ifdef __HLSL_ENABLE_16_BIT
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_min)
 int16_t min(int16_t, int16_t);
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_min)
 int16_t2 min(int16_t2, int16_t2);
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_min)
 int16_t3 min(int16_t3, int16_t3);
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_min)
 int16_t4 min(int16_t4, int16_t4);
 
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_min)
 uint16_t min(uint16_t, uint16_t);
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_min)
 uint16_t2 min(uint16_t2, uint16_t2);
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_min)
 uint16_t3 min(uint16_t3, uint16_t3);
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_min)
 uint16_t4 min(uint16_t4, uint16_t4);
 #endif
@@ -1816,7 +1814,7 @@ double4 min(double4, double4);
 
 // Case 6: vector * matrix -> vector
 template <int R, int C>
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_mul) vector<half, C> mul(vector<half, R>,
                                                             matrix<half, R, C>);
 
@@ -1826,7 +1824,7 @@ vector<T, C> mul(vector<T, R>, matrix<T, R, C>);
 
 // Case 8: matrix * vector -> vector
 template <int R, int C>
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_mul) vector<half, R> mul(matrix<half, R, C>,
                                                             vector<half, C>);
 
@@ -1836,7 +1834,7 @@ vector<T, R> mul(matrix<T, R, C>, vector<T, C>);
 
 // Case 9: matrix * matrix -> matrix
 template <int R, int K, int C>
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_mul) matrix<half, R, C> mul(
     matrix<half, R, K>, matrix<half, K, C>);
 
@@ -1854,16 +1852,16 @@ matrix<T, R, C> mul(matrix<T, R, K>, matrix<T, K, C>);
 ///
 /// Normalize is based on the following formula: x / length(x).
 
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_normalize)
 half normalize(half);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_normalize)
 half2 normalize(half2);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_normalize)
 half3 normalize(half3);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_normalize)
 half4 normalize(half4);
 
@@ -1938,16 +1936,16 @@ bool4x4 or(bool4x4 x, bool4x4 y);
 /// \param Val The input value.
 /// \param Pow The specified power.
 
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_pow)
 half pow(half, half);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_pow)
 half2 pow(half2, half2);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_pow)
 half3 pow(half3, half3);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_pow)
 half4 pow(half4, half4);
 
@@ -1969,16 +1967,16 @@ float4 pow(float4, float4);
 /// \param Val The input value.
 
 #ifdef __HLSL_ENABLE_16_BIT
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_bitreverse)
 uint16_t reversebits(uint16_t);
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_bitreverse)
 uint16_t2 reversebits(uint16_t2);
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_bitreverse)
 uint16_t3 reversebits(uint16_t3);
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_bitreverse)
 uint16_t4 reversebits(uint16_t4);
 #endif
@@ -2016,7 +2014,7 @@ uint64_t4 reversebits(uint64_t4);
 /// x[2] * y[0] - y[2] * x[0]
 /// x[0] * y[1] - y[0] * x[1]
 
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_crossf16)
 half3 cross(half3, half3);
 
@@ -2033,16 +2031,16 @@ float3 cross(float3, float3);
 ///
 /// The return value is the reciprocal of the \a x parameter.
 
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_rcp)
 half rcp(half);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_rcp)
 half2 rcp(half2);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_rcp)
 half3 rcp(half3);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_rcp)
 half4 rcp(half4);
 
@@ -2075,16 +2073,16 @@ double4 rcp(double4);
 ///
 /// This function uses the following formula: 1 / sqrt(x).
 
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_rsqrt)
 half rsqrt(half);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_rsqrt)
 half2 rsqrt(half2);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_rsqrt)
 half3 rsqrt(half3);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_rsqrt)
 half4 rsqrt(half4);
 
@@ -2109,16 +2107,16 @@ float4 rsqrt(float4);
 /// within a floating-point type. Halfway cases are
 /// rounded to the nearest even value.
 
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_roundeven)
 half round(half);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_roundeven)
 half2 round(half2);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_roundeven)
 half3 round(half3);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_roundeven)
 half4 round(half4);
 
@@ -2139,16 +2137,16 @@ float4 round(float4);
 /// \brief Returns input value, \a Val, clamped within the range of 0.0f
 /// to 1.0f. \param Val The input value.
 
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_saturate)
 half saturate(half);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_saturate)
 half2 saturate(half2);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_saturate)
 half3 saturate(half3);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_saturate)
 half4 saturate(half4);
 
@@ -2273,16 +2271,16 @@ __detail::enable_if_t<__detail::is_arithmetic<T>::Value, vector<T, 4>> select(
 /// \brief Returns the sine of the input value, \a Val.
 /// \param Val The input value.
 
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_sin)
 half sin(half);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_sin)
 half2 sin(half2);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_sin)
 half3 sin(half3);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_sin)
 half4 sin(half4);
 
@@ -2303,16 +2301,16 @@ float4 sin(float4);
 /// \brief Returns the hyperbolic sine of the input value, \a Val.
 /// \param Val The input value.
 
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_sinh)
 half sinh(half);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_sinh)
 half2 sinh(half2);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_sinh)
 half3 sinh(half3);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_sinh)
 half4 sinh(half4);
 
@@ -2333,16 +2331,16 @@ float4 sinh(float4);
 /// \brief Returns the square root of the input value, \a Val.
 /// \param Val The input value.
 
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_sqrt)
 half sqrt(half);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_sqrt)
 half2 sqrt(half2);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_sqrt)
 half3 sqrt(half3);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_sqrt)
 half4 sqrt(half4);
 
@@ -2366,16 +2364,16 @@ float4 sqrt(float4);
 ///
 /// Step is based on the following formula: (x >= y) ? 1 : 0
 
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_step)
 half step(half, half);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_step)
 half2 step(half2, half2);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_step)
 half3 step(half3, half3);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_step)
 half4 step(half4, half4);
 
@@ -2396,16 +2394,16 @@ float4 step(float4, float4);
 /// \brief Returns the tangent of the input value, \a Val.
 /// \param Val The input value.
 
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_tan)
 half tan(half);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_tan)
 half2 tan(half2);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_tan)
 half3 tan(half3);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_tan)
 half4 tan(half4);
 
@@ -2426,16 +2424,16 @@ float4 tan(float4);
 /// \brief Returns the hyperbolic tangent of the input value, \a Val.
 /// \param Val The input value.
 
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_tanh)
 half tanh(half);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_tanh)
 half2 tanh(half2);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_tanh)
 half3 tanh(half3);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_tanh)
 half4 tanh(half4);
 
@@ -2456,16 +2454,16 @@ float4 tanh(float4);
 /// \brief Returns the truncated integer value of the input value, \a Val.
 /// \param Val The input value.
 
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_trunc)
 half trunc(half);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_trunc)
 half2 trunc(half2);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_trunc)
 half3 trunc(half3);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_trunc)
 half4 trunc(half4);
 
@@ -2487,43 +2485,43 @@ float4 trunc(float4);
 /// group. Otherwise, the result is false.
 /// \param Value The value to compare with
 /// \return True if all values across all lanes are equal, false otherwise
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_all_equal)
 __attribute__((convergent)) bool WaveActiveAllEqual(half);
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_all_equal)
 __attribute__((convergent)) bool2 WaveActiveAllEqual(half2);
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_all_equal)
 __attribute__((convergent)) bool3 WaveActiveAllEqual(half3);
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_all_equal)
 __attribute__((convergent)) bool4 WaveActiveAllEqual(half4);
 
 #ifdef __HLSL_ENABLE_16_BIT
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_all_equal)
 __attribute__((convergent)) bool WaveActiveAllEqual(int16_t);
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_all_equal)
 __attribute__((convergent)) bool2 WaveActiveAllEqual(int16_t2);
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_all_equal)
 __attribute__((convergent)) bool3 WaveActiveAllEqual(int16_t3);
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_all_equal)
 __attribute__((convergent)) bool4 WaveActiveAllEqual(int16_t4);
 
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_all_equal)
 __attribute__((convergent)) bool WaveActiveAllEqual(uint16_t);
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_all_equal)
 __attribute__((convergent)) bool2 WaveActiveAllEqual(uint16_t2);
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_all_equal)
 __attribute__((convergent)) bool3 WaveActiveAllEqual(uint16_t3);
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_all_equal)
 __attribute__((convergent)) bool4 WaveActiveAllEqual(uint16_t4);
 #endif
@@ -2686,43 +2684,43 @@ _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_read_lane_at)
 __attribute__((convergent)) bool4 WaveReadLaneAt(bool4, uint32_t);
 
 #ifdef __HLSL_ENABLE_16_BIT
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_read_lane_at)
 __attribute__((convergent)) int16_t WaveReadLaneAt(int16_t, uint32_t);
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_read_lane_at)
 __attribute__((convergent)) int16_t2 WaveReadLaneAt(int16_t2, uint32_t);
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_read_lane_at)
 __attribute__((convergent)) int16_t3 WaveReadLaneAt(int16_t3, uint32_t);
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_read_lane_at)
 __attribute__((convergent)) int16_t4 WaveReadLaneAt(int16_t4, uint32_t);
 
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_read_lane_at)
 __attribute__((convergent)) uint16_t WaveReadLaneAt(uint16_t, uint32_t);
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_read_lane_at)
 __attribute__((convergent)) uint16_t2 WaveReadLaneAt(uint16_t2, uint32_t);
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_read_lane_at)
 __attribute__((convergent)) uint16_t3 WaveReadLaneAt(uint16_t3, uint32_t);
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_read_lane_at)
 __attribute__((convergent)) uint16_t4 WaveReadLaneAt(uint16_t4, uint32_t);
 #endif
 
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_read_lane_at)
 __attribute__((convergent)) half WaveReadLaneAt(half, uint32_t);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_read_lane_at)
 __attribute__((convergent)) half2 WaveReadLaneAt(half2, uint32_t);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_read_lane_at)
 __attribute__((convergent)) half3 WaveReadLaneAt(half3, uint32_t);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_read_lane_at)
 __attribute__((convergent)) half4 WaveReadLaneAt(half4, uint32_t);
 
@@ -2818,43 +2816,43 @@ __attribute__((convergent)) uint64_t4 WaveActiveBitOr(uint64_t4);
 // WaveActiveMax builtins
 //===----------------------------------------------------------------------===//
 
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_max)
 __attribute__((convergent)) half WaveActiveMax(half);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_max)
 __attribute__((convergent)) half2 WaveActiveMax(half2);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_max)
 __attribute__((convergent)) half3 WaveActiveMax(half3);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_max)
 __attribute__((convergent)) half4 WaveActiveMax(half4);
 
 #ifdef __HLSL_ENABLE_16_BIT
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_max)
 __attribute__((convergent)) int16_t WaveActiveMax(int16_t);
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_max)
 __attribute__((convergent)) int16_t2 WaveActiveMax(int16_t2);
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_max)
 __attribute__((convergent)) int16_t3 WaveActiveMax(int16_t3);
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_max)
 __attribute__((convergent)) int16_t4 WaveActiveMax(int16_t4);
 
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_max)
 __attribute__((convergent)) uint16_t WaveActiveMax(uint16_t);
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_max)
 __attribute__((convergent)) uint16_t2 WaveActiveMax(uint16_t2);
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_max)
 __attribute__((convergent)) uint16_t3 WaveActiveMax(uint16_t3);
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_max)
 __attribute__((convergent)) uint16_t4 WaveActiveMax(uint16_t4);
 #endif
@@ -2917,43 +2915,43 @@ __attribute__((convergent)) double4 WaveActiveMax(double4);
 // WaveActiveMin builtins
 //===----------------------------------------------------------------------===//
 
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_min)
 __attribute__((convergent)) half WaveActiveMin(half);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_min)
 __attribute__((convergent)) half2 WaveActiveMin(half2);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_min)
 __attribute__((convergent)) half3 WaveActiveMin(half3);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_min)
 __attribute__((convergent)) half4 WaveActiveMin(half4);
 
 #ifdef __HLSL_ENABLE_16_BIT
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_min)
 __attribute__((convergent)) int16_t WaveActiveMin(int16_t);
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_min)
 __attribute__((convergent)) int16_t2 WaveActiveMin(int16_t2);
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_min)
 __attribute__((convergent)) int16_t3 WaveActiveMin(int16_t3);
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_min)
 __attribute__((convergent)) int16_t4 WaveActiveMin(int16_t4);
 
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_min)
 __attribute__((convergent)) uint16_t WaveActiveMin(uint16_t);
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_min)
 __attribute__((convergent)) uint16_t2 WaveActiveMin(uint16_t2);
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_min)
 __attribute__((convergent)) uint16_t3 WaveActiveMin(uint16_t3);
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_min)
 __attribute__((convergent)) uint16_t4 WaveActiveMin(uint16_t4);
 #endif
@@ -3040,43 +3038,43 @@ __attribute__((convergent)) double4 WaveActiveMin(double4);
 // WaveActiveSum builtins
 //===----------------------------------------------------------------------===//
 
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_sum)
 __attribute__((convergent)) half WaveActiveSum(half);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_sum)
 __attribute__((convergent)) half2 WaveActiveSum(half2);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_sum)
 __attribute__((convergent)) half3 WaveActiveSum(half3);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_sum)
 __attribute__((convergent)) half4 WaveActiveSum(half4);
 
 #ifdef __HLSL_ENABLE_16_BIT
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_sum)
 __attribute__((convergent)) int16_t WaveActiveSum(int16_t);
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_sum)
 __attribute__((convergent)) int16_t2 WaveActiveSum(int16_t2);
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_sum)
 __attribute__((convergent)) int16_t3 WaveActiveSum(int16_t3);
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_sum)
 __attribute__((convergent)) int16_t4 WaveActiveSum(int16_t4);
 
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_sum)
 __attribute__((convergent)) uint16_t WaveActiveSum(uint16_t);
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_sum)
 __attribute__((convergent)) uint16_t2 WaveActiveSum(uint16_t2);
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_sum)
 __attribute__((convergent)) uint16_t3 WaveActiveSum(uint16_t3);
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_sum)
 __attribute__((convergent)) uint16_t4 WaveActiveSum(uint16_t4);
 #endif
@@ -3139,43 +3137,43 @@ __attribute__((convergent)) double4 WaveActiveSum(double4);
 // WaveActiveProduct builtins
 //===----------------------------------------------------------------------===//
 
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_product)
 __attribute__((convergent)) half WaveActiveProduct(half);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_product)
 __attribute__((convergent)) half2 WaveActiveProduct(half2);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_product)
 __attribute__((convergent)) half3 WaveActiveProduct(half3);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_product)
 __attribute__((convergent)) half4 WaveActiveProduct(half4);
 
 #ifdef __HLSL_ENABLE_16_BIT
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_product)
 __attribute__((convergent)) int16_t WaveActiveProduct(int16_t);
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_product)
 __attribute__((convergent)) int16_t2 WaveActiveProduct(int16_t2);
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_product)
 __attribute__((convergent)) int16_t3 WaveActiveProduct(int16_t3);
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_product)
 __attribute__((convergent)) int16_t4 WaveActiveProduct(int16_t4);
 
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_product)
 __attribute__((convergent)) uint16_t WaveActiveProduct(uint16_t);
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_product)
 __attribute__((convergent)) uint16_t2 WaveActiveProduct(uint16_t2);
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_product)
 __attribute__((convergent)) uint16_t3 WaveActiveProduct(uint16_t3);
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_product)
 __attribute__((convergent)) uint16_t4 WaveActiveProduct(uint16_t4);
 #endif
@@ -3262,43 +3260,43 @@ __attribute__((convergent)) double4 WaveActiveProduct(double4);
 // WavePrefixSum builtins
 //===----------------------------------------------------------------------===//
 
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_sum)
 __attribute__((convergent)) half WavePrefixSum(half);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_sum)
 __attribute__((convergent)) half2 WavePrefixSum(half2);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_sum)
 __attribute__((convergent)) half3 WavePrefixSum(half3);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_sum)
 __attribute__((convergent)) half4 WavePrefixSum(half4);
 
 #ifdef __HLSL_ENABLE_16_BIT
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_sum)
 __attribute__((convergent)) int16_t WavePrefixSum(int16_t);
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_sum)
 __attribute__((convergent)) int16_t2 WavePrefixSum(int16_t2);
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_sum)
 __attribute__((convergent)) int16_t3 WavePrefixSum(int16_t3);
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_sum)
 __attribute__((convergent)) int16_t4 WavePrefixSum(int16_t4);
 
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_sum)
 __attribute__((convergent)) uint16_t WavePrefixSum(uint16_t);
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_sum)
 __attribute__((convergent)) uint16_t2 WavePrefixSum(uint16_t2);
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_sum)
 __attribute__((convergent)) uint16_t3 WavePrefixSum(uint16_t3);
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_sum)
 __attribute__((convergent)) uint16_t4 WavePrefixSum(uint16_t4);
 #endif
@@ -3361,43 +3359,43 @@ __attribute__((convergent)) double4 WavePrefixSum(double4);
 // WavePrefixProduct builtins
 //===----------------------------------------------------------------------===//
 
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_product)
 __attribute__((convergent)) half WavePrefixProduct(half);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_product)
 __attribute__((convergent)) half2 WavePrefixProduct(half2);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_product)
 __attribute__((convergent)) half3 WavePrefixProduct(half3);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_product)
 __attribute__((convergent)) half4 WavePrefixProduct(half4);
 
 #ifdef __HLSL_ENABLE_16_BIT
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_product)
 __attribute__((convergent)) int16_t WavePrefixProduct(int16_t);
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_product)
 __attribute__((convergent)) int16_t2 WavePrefixProduct(int16_t2);
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_product)
 __attribute__((convergent)) int16_t3 WavePrefixProduct(int16_t3);
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_product)
 __attribute__((convergent)) int16_t4 WavePrefixProduct(int16_t4);
 
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_product)
 __attribute__((convergent)) uint16_t WavePrefixProduct(uint16_t);
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_product)
 __attribute__((convergent)) uint16_t2 WavePrefixProduct(uint16_t2);
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_product)
 __attribute__((convergent)) uint16_t3 WavePrefixProduct(uint16_t3);
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_product)
 __attribute__((convergent)) uint16_t4 WavePrefixProduct(uint16_t4);
 #endif
@@ -3465,43 +3463,43 @@ __attribute__((convergent)) double4 WavePrefixProduct(double4);
 /// 1 if \a Val is greater than zero. \param Val The input value.
 
 #ifdef __HLSL_ENABLE_16_BIT
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_sign)
 int sign(int16_t);
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_sign)
 int2 sign(int16_t2);
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_sign)
 int3 sign(int16_t3);
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_sign)
 int4 sign(int16_t4);
 
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_sign)
 int sign(uint16_t);
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_sign)
 int2 sign(uint16_t2);
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_sign)
 int3 sign(uint16_t3);
-_HLSL_AVAILABILITY_6_2(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_sign)
 int4 sign(uint16_t4);
 #endif
 
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_sign)
 int sign(half);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_sign)
 int2 sign(half2);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_sign)
 int3 sign(half3);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_sign)
 int4 sign(half4);
 
@@ -3566,16 +3564,16 @@ int4 sign(double4);
 /// \fn T radians(T Val)
 /// \brief Converts the specified value from degrees to radians.
 
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_radians)
 half radians(half);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_radians)
 half2 radians(half2);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_radians)
 half3 radians(half3);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_radians)
 half4 radians(half4);
 
@@ -3612,16 +3610,16 @@ __attribute__((convergent)) void GroupMemoryBarrierWithGroupSync(void);
 /// The return value is a floating point scalar or vector containing the low
 /// prevision partial derivative of the input value.
 
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_ddx_coarse)
 half ddx_coarse(half);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_ddx_coarse)
 half2 ddx_coarse(half2);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_ddx_coarse)
 half3 ddx_coarse(half3);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_ddx_coarse)
 half4 ddx_coarse(half4);
 
@@ -3646,16 +3644,16 @@ float4 ddx_coarse(float4);
 /// The return value is a floating point scalar or vector containing the low
 /// prevision partial derivative of the input value.
 
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_ddy_coarse)
 half ddy_coarse(half);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_ddy_coarse)
 half2 ddy_coarse(half2);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_ddy_coarse)
 half3 ddy_coarse(half3);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_ddy_coarse)
 half4 ddy_coarse(half4);
 
@@ -3680,16 +3678,16 @@ float4 ddy_coarse(float4);
 /// The return value is a floating point scalar or vector containing the high
 /// prevision partial derivative of the input value.
 
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_ddx_fine)
 half ddx_fine(half);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_ddx_fine)
 half2 ddx_fine(half2);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_ddx_fine)
 half3 ddx_fine(half3);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_ddx_fine)
 half4 ddx_fine(half4);
 
@@ -3714,16 +3712,16 @@ float4 ddx_fine(float4);
 /// The return value is a floating point scalar or vector containing the high
 /// prevision partial derivative of the input value.
 
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_ddy_fine)
 half ddy_fine(half);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_ddy_fine)
 half2 ddy_fine(half2);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_ddy_fine)
 half3 ddy_fine(half3);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_ddy_fine)
 half4 ddy_fine(half4);
 

--- a/clang/lib/Headers/hlsl/hlsl_alias_intrinsics.h
+++ b/clang/lib/Headers/hlsl/hlsl_alias_intrinsics.h
@@ -38,8 +38,7 @@ namespace hlsl {
 #define _HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 #endif
 
-#define _HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)                            \
-  _HLSL_AVAILABILITY(shadermodel, 6.2)
+#define _HLSL_AVAILABILITY_6_2(shadermodel) _HLSL_AVAILABILITY(shadermodel, 6.2)
 
 //===----------------------------------------------------------------------===//
 // abs builtins
@@ -50,26 +49,26 @@ namespace hlsl {
 /// \param Val The input value.
 
 #ifdef __HLSL_ENABLE_16_BIT
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_abs)
 int16_t abs(int16_t);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_abs)
 int16_t2 abs(int16_t2);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_abs)
 int16_t3 abs(int16_t3);
-_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_abs)
 int16_t4 abs(int16_t4);
 
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 constexpr uint16_t abs(uint16_t V) { return V; }
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 constexpr uint16_t2 abs(uint16_t2 V) { return V; }
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 constexpr uint16_t3 abs(uint16_t3 V) { return V; }
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 constexpr uint16_t4 abs(uint16_t4 V) { return V; }
 #endif
 
@@ -192,28 +191,28 @@ uint32_t4 AddUint64(uint32_t4, uint32_t4);
 /// otherwise, false. \param x The input value.
 
 #ifdef __HLSL_ENABLE_16_BIT
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_all)
 bool all(int16_t);
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_all)
 bool all(int16_t2);
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_all)
 bool all(int16_t3);
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_all)
 bool all(int16_t4);
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_all)
 bool all(uint16_t);
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_all)
 bool all(uint16_t2);
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_all)
 bool all(uint16_t3);
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_all)
 bool all(uint16_t4);
 #endif
@@ -358,28 +357,28 @@ bool4x4 and(bool4x4 x, bool4x4 y);
 /// otherwise, false. \param x The input value.
 
 #ifdef __HLSL_ENABLE_16_BIT
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_any)
 bool any(int16_t);
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_any)
 bool any(int16_t2);
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_any)
 bool any(int16_t3);
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_any)
 bool any(int16_t4);
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_any)
 bool any(uint16_t);
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_any)
 bool any(uint16_t2);
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_any)
 bool any(uint16_t3);
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_any)
 bool any(uint16_t4);
 #endif
@@ -631,29 +630,29 @@ _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_clamp)
 half4 clamp(half4, half4, half4);
 
 #ifdef __HLSL_ENABLE_16_BIT
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_clamp)
 int16_t clamp(int16_t, int16_t, int16_t);
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_clamp)
 int16_t2 clamp(int16_t2, int16_t2, int16_t2);
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_clamp)
 int16_t3 clamp(int16_t3, int16_t3, int16_t3);
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_clamp)
 int16_t4 clamp(int16_t4, int16_t4, int16_t4);
 
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_clamp)
 uint16_t clamp(uint16_t, uint16_t, uint16_t);
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_clamp)
 uint16_t2 clamp(uint16_t2, uint16_t2, uint16_t2);
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_clamp)
 uint16_t3 clamp(uint16_t3, uint16_t3, uint16_t3);
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_clamp)
 uint16_t4 clamp(uint16_t4, uint16_t4, uint16_t4);
 #endif
@@ -798,35 +797,35 @@ float4 cosh(float4);
 /// \param Val The input value.
 
 #ifdef __HLSL_ENABLE_16_BIT
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 const inline uint countbits(int16_t x) {
   return __builtin_elementwise_popcount(x);
 }
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 const inline uint2 countbits(int16_t2 x) {
   return __builtin_elementwise_popcount(x);
 }
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 const inline uint3 countbits(int16_t3 x) {
   return __builtin_elementwise_popcount(x);
 }
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 const inline uint4 countbits(int16_t4 x) {
   return __builtin_elementwise_popcount(x);
 }
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 const inline uint countbits(uint16_t x) {
   return __builtin_elementwise_popcount(x);
 }
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 const inline uint2 countbits(uint16_t2 x) {
   return __builtin_elementwise_popcount(x);
 }
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 const inline uint3 countbits(uint16_t3 x) {
   return __builtin_elementwise_popcount(x);
 }
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 const inline uint4 countbits(uint16_t4 x) {
   return __builtin_elementwise_popcount(x);
 }
@@ -935,29 +934,29 @@ _HLSL_BUILTIN_ALIAS(__builtin_hlsl_dot)
 half dot(half4, half4);
 
 #ifdef __HLSL_ENABLE_16_BIT
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_dot)
 int16_t dot(int16_t, int16_t);
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_dot)
 int16_t dot(int16_t2, int16_t2);
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_dot)
 int16_t dot(int16_t3, int16_t3);
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_dot)
 int16_t dot(int16_t4, int16_t4);
 
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_dot)
 uint16_t dot(uint16_t, uint16_t);
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_dot)
 uint16_t dot(uint16_t2, uint16_t2);
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_dot)
 uint16_t dot(uint16_t3, uint16_t3);
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_dot)
 uint16_t dot(uint16_t4, uint16_t4);
 #endif
@@ -1142,28 +1141,28 @@ uint4 f32tof16(float4);
 /// \param Val the input value.
 
 #ifdef __HLSL_ENABLE_16_BIT
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_firstbitlow)
 uint firstbitlow(int16_t);
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_firstbitlow)
 uint2 firstbitlow(int16_t2);
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_firstbitlow)
 uint3 firstbitlow(int16_t3);
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_firstbitlow)
 uint4 firstbitlow(int16_t4);
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_firstbitlow)
 uint firstbitlow(uint16_t);
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_firstbitlow)
 uint2 firstbitlow(uint16_t2);
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_firstbitlow)
 uint3 firstbitlow(uint16_t3);
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_firstbitlow)
 uint4 firstbitlow(uint16_t4);
 #endif
@@ -1492,29 +1491,29 @@ _HLSL_BUILTIN_ALIAS(__builtin_hlsl_mad)
 half4 mad(half4, half4, half4);
 
 #ifdef __HLSL_ENABLE_16_BIT
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_mad)
 int16_t mad(int16_t, int16_t, int16_t);
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_mad)
 int16_t2 mad(int16_t2, int16_t2, int16_t2);
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_mad)
 int16_t3 mad(int16_t3, int16_t3, int16_t3);
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_mad)
 int16_t4 mad(int16_t4, int16_t4, int16_t4);
 
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_mad)
 uint16_t mad(uint16_t, uint16_t, uint16_t);
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_mad)
 uint16_t2 mad(uint16_t2, uint16_t2, uint16_t2);
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_mad)
 uint16_t3 mad(uint16_t3, uint16_t3, uint16_t3);
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_mad)
 uint16_t4 mad(uint16_t4, uint16_t4, uint16_t4);
 #endif
@@ -1596,29 +1595,29 @@ _HLSL_BUILTIN_ALIAS(__builtin_elementwise_max)
 half4 max(half4, half4);
 
 #ifdef __HLSL_ENABLE_16_BIT
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_max)
 int16_t max(int16_t, int16_t);
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_max)
 int16_t2 max(int16_t2, int16_t2);
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_max)
 int16_t3 max(int16_t3, int16_t3);
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_max)
 int16_t4 max(int16_t4, int16_t4);
 
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_max)
 uint16_t max(uint16_t, uint16_t);
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_max)
 uint16_t2 max(uint16_t2, uint16_t2);
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_max)
 uint16_t3 max(uint16_t3, uint16_t3);
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_max)
 uint16_t4 max(uint16_t4, uint16_t4);
 #endif
@@ -1700,29 +1699,29 @@ _HLSL_BUILTIN_ALIAS(__builtin_elementwise_min)
 half4 min(half4, half4);
 
 #ifdef __HLSL_ENABLE_16_BIT
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_min)
 int16_t min(int16_t, int16_t);
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_min)
 int16_t2 min(int16_t2, int16_t2);
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_min)
 int16_t3 min(int16_t3, int16_t3);
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_min)
 int16_t4 min(int16_t4, int16_t4);
 
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_min)
 uint16_t min(uint16_t, uint16_t);
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_min)
 uint16_t2 min(uint16_t2, uint16_t2);
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_min)
 uint16_t3 min(uint16_t3, uint16_t3);
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_min)
 uint16_t4 min(uint16_t4, uint16_t4);
 #endif
@@ -1970,16 +1969,16 @@ float4 pow(float4, float4);
 /// \param Val The input value.
 
 #ifdef __HLSL_ENABLE_16_BIT
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_bitreverse)
 uint16_t reversebits(uint16_t);
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_bitreverse)
 uint16_t2 reversebits(uint16_t2);
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_bitreverse)
 uint16_t3 reversebits(uint16_t3);
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_bitreverse)
 uint16_t4 reversebits(uint16_t4);
 #endif
@@ -2488,43 +2487,43 @@ float4 trunc(float4);
 /// group. Otherwise, the result is false.
 /// \param Value The value to compare with
 /// \return True if all values across all lanes are equal, false otherwise
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_all_equal)
 __attribute__((convergent)) bool WaveActiveAllEqual(half);
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_all_equal)
 __attribute__((convergent)) bool2 WaveActiveAllEqual(half2);
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_all_equal)
 __attribute__((convergent)) bool3 WaveActiveAllEqual(half3);
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_all_equal)
 __attribute__((convergent)) bool4 WaveActiveAllEqual(half4);
 
 #ifdef __HLSL_ENABLE_16_BIT
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_all_equal)
 __attribute__((convergent)) bool WaveActiveAllEqual(int16_t);
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_all_equal)
 __attribute__((convergent)) bool2 WaveActiveAllEqual(int16_t2);
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_all_equal)
 __attribute__((convergent)) bool3 WaveActiveAllEqual(int16_t3);
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_all_equal)
 __attribute__((convergent)) bool4 WaveActiveAllEqual(int16_t4);
 
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_all_equal)
 __attribute__((convergent)) bool WaveActiveAllEqual(uint16_t);
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_all_equal)
 __attribute__((convergent)) bool2 WaveActiveAllEqual(uint16_t2);
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_all_equal)
 __attribute__((convergent)) bool3 WaveActiveAllEqual(uint16_t3);
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_all_equal)
 __attribute__((convergent)) bool4 WaveActiveAllEqual(uint16_t4);
 #endif
@@ -2687,29 +2686,29 @@ _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_read_lane_at)
 __attribute__((convergent)) bool4 WaveReadLaneAt(bool4, uint32_t);
 
 #ifdef __HLSL_ENABLE_16_BIT
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_read_lane_at)
 __attribute__((convergent)) int16_t WaveReadLaneAt(int16_t, uint32_t);
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_read_lane_at)
 __attribute__((convergent)) int16_t2 WaveReadLaneAt(int16_t2, uint32_t);
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_read_lane_at)
 __attribute__((convergent)) int16_t3 WaveReadLaneAt(int16_t3, uint32_t);
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_read_lane_at)
 __attribute__((convergent)) int16_t4 WaveReadLaneAt(int16_t4, uint32_t);
 
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_read_lane_at)
 __attribute__((convergent)) uint16_t WaveReadLaneAt(uint16_t, uint32_t);
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_read_lane_at)
 __attribute__((convergent)) uint16_t2 WaveReadLaneAt(uint16_t2, uint32_t);
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_read_lane_at)
 __attribute__((convergent)) uint16_t3 WaveReadLaneAt(uint16_t3, uint32_t);
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_read_lane_at)
 __attribute__((convergent)) uint16_t4 WaveReadLaneAt(uint16_t4, uint32_t);
 #endif
@@ -2833,29 +2832,29 @@ _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_max)
 __attribute__((convergent)) half4 WaveActiveMax(half4);
 
 #ifdef __HLSL_ENABLE_16_BIT
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_max)
 __attribute__((convergent)) int16_t WaveActiveMax(int16_t);
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_max)
 __attribute__((convergent)) int16_t2 WaveActiveMax(int16_t2);
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_max)
 __attribute__((convergent)) int16_t3 WaveActiveMax(int16_t3);
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_max)
 __attribute__((convergent)) int16_t4 WaveActiveMax(int16_t4);
 
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_max)
 __attribute__((convergent)) uint16_t WaveActiveMax(uint16_t);
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_max)
 __attribute__((convergent)) uint16_t2 WaveActiveMax(uint16_t2);
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_max)
 __attribute__((convergent)) uint16_t3 WaveActiveMax(uint16_t3);
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_max)
 __attribute__((convergent)) uint16_t4 WaveActiveMax(uint16_t4);
 #endif
@@ -2932,29 +2931,29 @@ _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_min)
 __attribute__((convergent)) half4 WaveActiveMin(half4);
 
 #ifdef __HLSL_ENABLE_16_BIT
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_min)
 __attribute__((convergent)) int16_t WaveActiveMin(int16_t);
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_min)
 __attribute__((convergent)) int16_t2 WaveActiveMin(int16_t2);
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_min)
 __attribute__((convergent)) int16_t3 WaveActiveMin(int16_t3);
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_min)
 __attribute__((convergent)) int16_t4 WaveActiveMin(int16_t4);
 
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_min)
 __attribute__((convergent)) uint16_t WaveActiveMin(uint16_t);
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_min)
 __attribute__((convergent)) uint16_t2 WaveActiveMin(uint16_t2);
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_min)
 __attribute__((convergent)) uint16_t3 WaveActiveMin(uint16_t3);
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_min)
 __attribute__((convergent)) uint16_t4 WaveActiveMin(uint16_t4);
 #endif
@@ -3055,29 +3054,29 @@ _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_sum)
 __attribute__((convergent)) half4 WaveActiveSum(half4);
 
 #ifdef __HLSL_ENABLE_16_BIT
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_sum)
 __attribute__((convergent)) int16_t WaveActiveSum(int16_t);
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_sum)
 __attribute__((convergent)) int16_t2 WaveActiveSum(int16_t2);
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_sum)
 __attribute__((convergent)) int16_t3 WaveActiveSum(int16_t3);
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_sum)
 __attribute__((convergent)) int16_t4 WaveActiveSum(int16_t4);
 
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_sum)
 __attribute__((convergent)) uint16_t WaveActiveSum(uint16_t);
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_sum)
 __attribute__((convergent)) uint16_t2 WaveActiveSum(uint16_t2);
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_sum)
 __attribute__((convergent)) uint16_t3 WaveActiveSum(uint16_t3);
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_sum)
 __attribute__((convergent)) uint16_t4 WaveActiveSum(uint16_t4);
 #endif
@@ -3154,29 +3153,29 @@ _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_product)
 __attribute__((convergent)) half4 WaveActiveProduct(half4);
 
 #ifdef __HLSL_ENABLE_16_BIT
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_product)
 __attribute__((convergent)) int16_t WaveActiveProduct(int16_t);
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_product)
 __attribute__((convergent)) int16_t2 WaveActiveProduct(int16_t2);
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_product)
 __attribute__((convergent)) int16_t3 WaveActiveProduct(int16_t3);
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_product)
 __attribute__((convergent)) int16_t4 WaveActiveProduct(int16_t4);
 
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_product)
 __attribute__((convergent)) uint16_t WaveActiveProduct(uint16_t);
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_product)
 __attribute__((convergent)) uint16_t2 WaveActiveProduct(uint16_t2);
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_product)
 __attribute__((convergent)) uint16_t3 WaveActiveProduct(uint16_t3);
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_product)
 __attribute__((convergent)) uint16_t4 WaveActiveProduct(uint16_t4);
 #endif
@@ -3277,29 +3276,29 @@ _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_sum)
 __attribute__((convergent)) half4 WavePrefixSum(half4);
 
 #ifdef __HLSL_ENABLE_16_BIT
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_sum)
 __attribute__((convergent)) int16_t WavePrefixSum(int16_t);
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_sum)
 __attribute__((convergent)) int16_t2 WavePrefixSum(int16_t2);
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_sum)
 __attribute__((convergent)) int16_t3 WavePrefixSum(int16_t3);
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_sum)
 __attribute__((convergent)) int16_t4 WavePrefixSum(int16_t4);
 
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_sum)
 __attribute__((convergent)) uint16_t WavePrefixSum(uint16_t);
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_sum)
 __attribute__((convergent)) uint16_t2 WavePrefixSum(uint16_t2);
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_sum)
 __attribute__((convergent)) uint16_t3 WavePrefixSum(uint16_t3);
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_sum)
 __attribute__((convergent)) uint16_t4 WavePrefixSum(uint16_t4);
 #endif
@@ -3376,29 +3375,29 @@ _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_product)
 __attribute__((convergent)) half4 WavePrefixProduct(half4);
 
 #ifdef __HLSL_ENABLE_16_BIT
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_product)
 __attribute__((convergent)) int16_t WavePrefixProduct(int16_t);
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_product)
 __attribute__((convergent)) int16_t2 WavePrefixProduct(int16_t2);
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_product)
 __attribute__((convergent)) int16_t3 WavePrefixProduct(int16_t3);
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_product)
 __attribute__((convergent)) int16_t4 WavePrefixProduct(int16_t4);
 
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_product)
 __attribute__((convergent)) uint16_t WavePrefixProduct(uint16_t);
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_product)
 __attribute__((convergent)) uint16_t2 WavePrefixProduct(uint16_t2);
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_product)
 __attribute__((convergent)) uint16_t3 WavePrefixProduct(uint16_t3);
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_product)
 __attribute__((convergent)) uint16_t4 WavePrefixProduct(uint16_t4);
 #endif
@@ -3466,29 +3465,29 @@ __attribute__((convergent)) double4 WavePrefixProduct(double4);
 /// 1 if \a Val is greater than zero. \param Val The input value.
 
 #ifdef __HLSL_ENABLE_16_BIT
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_sign)
 int sign(int16_t);
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_sign)
 int2 sign(int16_t2);
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_sign)
 int3 sign(int16_t3);
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_sign)
 int4 sign(int16_t4);
 
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_sign)
 int sign(uint16_t);
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_sign)
 int2 sign(uint16_t2);
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_sign)
 int3 sign(uint16_t3);
-_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
+_HLSL_AVAILABILITY_6_2(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_sign)
 int4 sign(uint16_t4);
 #endif

--- a/clang/lib/Headers/hlsl/hlsl_alias_intrinsics.h
+++ b/clang/lib/Headers/hlsl/hlsl_alias_intrinsics.h
@@ -30,12 +30,15 @@ namespace hlsl {
 #define _HLSL_16BIT_AVAILABILITY_STAGE(platform, version, stage)               \
   __attribute__((                                                              \
       availability(platform, introduced = version, environment = stage)))
+#define _HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel) \
+  _HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
 #else
 #define _HLSL_16BIT_AVAILABILITY(environment, version)
 #define _HLSL_16BIT_AVAILABILITY_STAGE(environment, version, stage)
+#define _HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel) 
 #endif
 
-#define _HLSL_16BIT_AVAILABILITY_DEFAULT() _HLSL_AVAILABILITY(shadermodel, 6.2)
+#define _HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel) _HLSL_AVAILABILITY(shadermodel, 6.2)
 
 //===----------------------------------------------------------------------===//
 // abs builtins
@@ -46,39 +49,39 @@ namespace hlsl {
 /// \param Val The input value.
 
 #ifdef __HLSL_ENABLE_16_BIT
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_abs)
 int16_t abs(int16_t);
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_abs)
 int16_t2 abs(int16_t2);
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_abs)
 int16_t3 abs(int16_t3);
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_abs)
 int16_t4 abs(int16_t4);
 
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 constexpr uint16_t abs(uint16_t V) { return V; }
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 constexpr uint16_t2 abs(uint16_t2 V) { return V; }
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 constexpr uint16_t3 abs(uint16_t3 V) { return V; }
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 constexpr uint16_t4 abs(uint16_t4 V) { return V; }
 #endif
 
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_abs)
 half abs(half);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_abs)
 half2 abs(half2);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_abs)
 half3 abs(half3);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_abs)
 half4 abs(half4);
 
@@ -136,16 +139,16 @@ double4 abs(double4);
 /// \brief Returns the arccosine of the input value, \a Val.
 /// \param Val The input value.
 
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_acos)
 half acos(half);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_acos)
 half2 acos(half2);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_acos)
 half3 acos(half3);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_acos)
 half4 acos(half4);
 
@@ -188,42 +191,42 @@ uint32_t4 AddUint64(uint32_t4, uint32_t4);
 /// otherwise, false. \param x The input value.
 
 #ifdef __HLSL_ENABLE_16_BIT
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_all)
 bool all(int16_t);
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_all)
 bool all(int16_t2);
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_all)
 bool all(int16_t3);
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_all)
 bool all(int16_t4);
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_all)
 bool all(uint16_t);
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_all)
 bool all(uint16_t2);
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_all)
 bool all(uint16_t3);
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_all)
 bool all(uint16_t4);
 #endif
 
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_all)
 bool all(half);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_all)
 bool all(half2);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_all)
 bool all(half3);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_all)
 bool all(half4);
 
@@ -354,42 +357,42 @@ bool4x4 and(bool4x4 x, bool4x4 y);
 /// otherwise, false. \param x The input value.
 
 #ifdef __HLSL_ENABLE_16_BIT
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_any)
 bool any(int16_t);
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_any)
 bool any(int16_t2);
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_any)
 bool any(int16_t3);
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_any)
 bool any(int16_t4);
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_any)
 bool any(uint16_t);
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_any)
 bool any(uint16_t2);
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_any)
 bool any(uint16_t3);
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_any)
 bool any(uint16_t4);
 #endif
 
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_any)
 bool any(half);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_any)
 bool any(half2);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_any)
 bool any(half3);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_any)
 bool any(half4);
 
@@ -483,16 +486,16 @@ double4 asdouble(uint4, uint4);
 /// \brief Returns the arcsine of the input value, \a Val.
 /// \param Val The input value.
 
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_asin)
 half asin(half);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_asin)
 half2 asin(half2);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_asin)
 half3 asin(half3);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_asin)
 half4 asin(half4);
 
@@ -513,16 +516,16 @@ float4 asin(float4);
 /// \brief Returns the arctangent of the input value, \a Val.
 /// \param Val The input value.
 
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_atan)
 half atan(half);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_atan)
 half2 atan(half2);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_atan)
 half3 atan(half3);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_atan)
 half4 atan(half4);
 
@@ -545,16 +548,16 @@ float4 atan(float4);
 /// \param y The y-coordinate.
 /// \param x The x-coordinate.
 
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_atan2)
 half atan2(half y, half x);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_atan2)
 half2 atan2(half2 y, half2 x);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_atan2)
 half3 atan2(half3 y, half3 x);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_atan2)
 half4 atan2(half4 y, half4 x);
 
@@ -576,16 +579,16 @@ float4 atan2(float4 y, float4 x);
 /// the input value, \a Val.
 /// \param Val The input value.
 
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_ceil)
 half ceil(half);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_ceil)
 half2 ceil(half2);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_ceil)
 half3 ceil(half3);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_ceil)
 half4 ceil(half4);
 
@@ -613,43 +616,43 @@ float4 ceil(float4);
 /// For values of -INF or INF, clamp will behave as expected.
 /// However for values of NaN, the results are undefined.
 
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_clamp)
 half clamp(half, half, half);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_clamp)
 half2 clamp(half2, half2, half2);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_clamp)
 half3 clamp(half3, half3, half3);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_clamp)
 half4 clamp(half4, half4, half4);
 
 #ifdef __HLSL_ENABLE_16_BIT
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_clamp)
 int16_t clamp(int16_t, int16_t, int16_t);
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_clamp)
 int16_t2 clamp(int16_t2, int16_t2, int16_t2);
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_clamp)
 int16_t3 clamp(int16_t3, int16_t3, int16_t3);
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_clamp)
 int16_t4 clamp(int16_t4, int16_t4, int16_t4);
 
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_clamp)
 uint16_t clamp(uint16_t, uint16_t, uint16_t);
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_clamp)
 uint16_t2 clamp(uint16_t2, uint16_t2, uint16_t2);
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_clamp)
 uint16_t3 clamp(uint16_t3, uint16_t3, uint16_t3);
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_clamp)
 uint16_t4 clamp(uint16_t4, uint16_t4, uint16_t4);
 #endif
@@ -733,16 +736,16 @@ void clip(float4);
 /// \brief Returns the cosine of the input value, \a Val.
 /// \param Val The input value.
 
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_cos)
 half cos(half);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_cos)
 half2 cos(half2);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_cos)
 half3 cos(half3);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_cos)
 half4 cos(half4);
 
@@ -763,16 +766,16 @@ float4 cos(float4);
 /// \brief Returns the hyperbolic cosine of the input value, \a Val.
 /// \param Val The input value.
 
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_cosh)
 half cosh(half);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_cosh)
 half2 cosh(half2);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_cosh)
 half3 cosh(half3);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_cosh)
 half4 cosh(half4);
 
@@ -794,35 +797,35 @@ float4 cosh(float4);
 /// \param Val The input value.
 
 #ifdef __HLSL_ENABLE_16_BIT
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 const inline uint countbits(int16_t x) {
   return __builtin_elementwise_popcount(x);
 }
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 const inline uint2 countbits(int16_t2 x) {
   return __builtin_elementwise_popcount(x);
 }
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 const inline uint3 countbits(int16_t3 x) {
   return __builtin_elementwise_popcount(x);
 }
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 const inline uint4 countbits(int16_t4 x) {
   return __builtin_elementwise_popcount(x);
 }
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 const inline uint countbits(uint16_t x) {
   return __builtin_elementwise_popcount(x);
 }
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 const inline uint2 countbits(uint16_t2 x) {
   return __builtin_elementwise_popcount(x);
 }
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 const inline uint3 countbits(uint16_t3 x) {
   return __builtin_elementwise_popcount(x);
 }
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 const inline uint4 countbits(uint16_t4 x) {
   return __builtin_elementwise_popcount(x);
 }
@@ -886,16 +889,16 @@ const inline uint4 countbits(uint64_t4 x) {
 /// \brief Converts the specified value from radians to degrees.
 /// \param x The specified input value.
 
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_degrees)
 half degrees(half);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_degrees)
 half2 degrees(half2);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_degrees)
 half3 degrees(half3);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_degrees)
 half4 degrees(half4);
 
@@ -917,43 +920,43 @@ float4 degrees(float4);
 /// \param X The X input value.
 /// \param Y The Y input value.
 
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_dot)
 half dot(half, half);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_dot)
 half dot(half2, half2);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_dot)
 half dot(half3, half3);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_dot)
 half dot(half4, half4);
 
 #ifdef __HLSL_ENABLE_16_BIT
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_dot)
 int16_t dot(int16_t, int16_t);
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_dot)
 int16_t dot(int16_t2, int16_t2);
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_dot)
 int16_t dot(int16_t3, int16_t3);
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_dot)
 int16_t dot(int16_t4, int16_t4);
 
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_dot)
 uint16_t dot(uint16_t, uint16_t);
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_dot)
 uint16_t dot(uint16_t2, uint16_t2);
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_dot)
 uint16_t dot(uint16_t3, uint16_t3);
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_dot)
 uint16_t dot(uint16_t4, uint16_t4);
 #endif
@@ -1032,16 +1035,16 @@ uint dot4add_u8packed(uint, uint, uint);
 ///
 /// The return value is the base-e exponential of the \a x parameter.
 
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_exp)
 half exp(half);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_exp)
 half2 exp(half2);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_exp)
 half3 exp(half3);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_exp)
 half4 exp(half4);
 
@@ -1064,16 +1067,16 @@ float4 exp(float4);
 ///
 /// The base 2 exponential of the \a x parameter.
 
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_exp2)
 half exp2(half);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_exp2)
 half2 exp2(half2);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_exp2)
 half3 exp2(half3);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_exp2)
 half4 exp2(half4);
 
@@ -1138,28 +1141,28 @@ uint4 f32tof16(float4);
 /// \param Val the input value.
 
 #ifdef __HLSL_ENABLE_16_BIT
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_firstbitlow)
 uint firstbitlow(int16_t);
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_firstbitlow)
 uint2 firstbitlow(int16_t2);
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_firstbitlow)
 uint3 firstbitlow(int16_t3);
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_firstbitlow)
 uint4 firstbitlow(int16_t4);
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_firstbitlow)
 uint firstbitlow(uint16_t);
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_firstbitlow)
 uint2 firstbitlow(uint16_t2);
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_firstbitlow)
 uint3 firstbitlow(uint16_t3);
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_firstbitlow)
 uint4 firstbitlow(uint16_t4);
 #endif
@@ -1209,16 +1212,16 @@ uint4 firstbitlow(uint64_t4);
 /// value, \a Val.
 /// \param Val The input value.
 
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_floor)
 half floor(half);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_floor)
 half2 floor(half2);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_floor)
 half3 floor(half3);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_floor)
 half4 floor(half4);
 
@@ -1241,16 +1244,16 @@ float4 floor(float4);
 ///
 /// If \a the return value is greater than or equal to 0 and less than 1.
 
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_frac)
 half frac(half);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_frac)
 half2 frac(half2);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_frac)
 half3 frac(half3);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_frac)
 half4 frac(half4);
 
@@ -1274,16 +1277,16 @@ float4 frac(float4);
 /// Returns a value of the same size as the input, with a value set
 /// to True if the x parameter is +INF or -INF. Otherwise, False.
 
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_isinf)
 bool isinf(half);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_isinf)
 bool2 isinf(half2);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_isinf)
 bool3 isinf(half3);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_isinf)
 bool4 isinf(half4);
 
@@ -1307,16 +1310,16 @@ bool4 isinf(float4);
 /// Returns a value of the same size as the input, with a value set
 /// to True if the x parameter is NaN or QNaN. Otherwise, False.
 
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_isnan)
 bool isnan(half);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_isnan)
 bool2 isnan(half2);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_isnan)
 bool3 isnan(half3);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_isnan)
 bool4 isnan(half4);
 
@@ -1343,16 +1346,16 @@ bool4 isnan(float4);
 /// Linear interpolation is based on the following formula: x*(1-s) + y*s which
 /// can equivalently be written as x + s(y-x).
 
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_lerp)
 half lerp(half, half, half);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_lerp)
 half2 lerp(half2, half2, half2);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_lerp)
 half3 lerp(half3, half3, half3);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_lerp)
 half4 lerp(half4, half4, half4);
 
@@ -1376,16 +1379,16 @@ float4 lerp(float4, float4, float4);
 /// If \a Val is negative, this result is undefined. If \a Val is 0, this
 /// function returns negative infinity.
 
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_log)
 half log(half);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_log)
 half2 log(half2);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_log)
 half3 log(half3);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_log)
 half4 log(half4);
 
@@ -1409,16 +1412,16 @@ float4 log(float4);
 /// If \a Val is negative, this result is undefined. If \a Val is 0, this
 /// function returns negative infinity.
 
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_log10)
 half log10(half);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_log10)
 half2 log10(half2);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_log10)
 half3 log10(half3);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_log10)
 half4 log10(half4);
 
@@ -1442,16 +1445,16 @@ float4 log10(float4);
 /// If \a Val is negative, this result is undefined. If \a Val is 0, this
 /// function returns negative infinity.
 
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_log2)
 half log2(half);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_log2)
 half2 log2(half2);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_log2)
 half3 log2(half3);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_log2)
 half4 log2(half4);
 
@@ -1474,43 +1477,43 @@ float4 log2(float4);
 /// \param A The first addition value.
 /// \param B The second addition value.
 
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_mad)
 half mad(half, half, half);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_mad)
 half2 mad(half2, half2, half2);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_mad)
 half3 mad(half3, half3, half3);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_mad)
 half4 mad(half4, half4, half4);
 
 #ifdef __HLSL_ENABLE_16_BIT
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_mad)
 int16_t mad(int16_t, int16_t, int16_t);
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_mad)
 int16_t2 mad(int16_t2, int16_t2, int16_t2);
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_mad)
 int16_t3 mad(int16_t3, int16_t3, int16_t3);
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_mad)
 int16_t4 mad(int16_t4, int16_t4, int16_t4);
 
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_mad)
 uint16_t mad(uint16_t, uint16_t, uint16_t);
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_mad)
 uint16_t2 mad(uint16_t2, uint16_t2, uint16_t2);
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_mad)
 uint16_t3 mad(uint16_t3, uint16_t3, uint16_t3);
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_mad)
 uint16_t4 mad(uint16_t4, uint16_t4, uint16_t4);
 #endif
@@ -1578,43 +1581,43 @@ double4 mad(double4, double4, double4);
 /// \param X The X input value.
 /// \param Y The Y input value.
 
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_max)
 half max(half, half);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_max)
 half2 max(half2, half2);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_max)
 half3 max(half3, half3);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_max)
 half4 max(half4, half4);
 
 #ifdef __HLSL_ENABLE_16_BIT
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_max)
 int16_t max(int16_t, int16_t);
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_max)
 int16_t2 max(int16_t2, int16_t2);
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_max)
 int16_t3 max(int16_t3, int16_t3);
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_max)
 int16_t4 max(int16_t4, int16_t4);
 
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_max)
 uint16_t max(uint16_t, uint16_t);
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_max)
 uint16_t2 max(uint16_t2, uint16_t2);
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_max)
 uint16_t3 max(uint16_t3, uint16_t3);
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_max)
 uint16_t4 max(uint16_t4, uint16_t4);
 #endif
@@ -1682,43 +1685,43 @@ double4 max(double4, double4);
 /// \param X The X input value.
 /// \param Y The Y input value.
 
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_min)
 half min(half, half);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_min)
 half2 min(half2, half2);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_min)
 half3 min(half3, half3);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_min)
 half4 min(half4, half4);
 
 #ifdef __HLSL_ENABLE_16_BIT
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_min)
 int16_t min(int16_t, int16_t);
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_min)
 int16_t2 min(int16_t2, int16_t2);
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_min)
 int16_t3 min(int16_t3, int16_t3);
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_min)
 int16_t4 min(int16_t4, int16_t4);
 
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_min)
 uint16_t min(uint16_t, uint16_t);
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_min)
 uint16_t2 min(uint16_t2, uint16_t2);
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_min)
 uint16_t3 min(uint16_t3, uint16_t3);
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_min)
 uint16_t4 min(uint16_t4, uint16_t4);
 #endif
@@ -1813,7 +1816,7 @@ double4 min(double4, double4);
 
 // Case 6: vector * matrix -> vector
 template <int R, int C>
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_mul) vector<half, C> mul(vector<half, R>,
                                                             matrix<half, R, C>);
 
@@ -1823,7 +1826,7 @@ vector<T, C> mul(vector<T, R>, matrix<T, R, C>);
 
 // Case 8: matrix * vector -> vector
 template <int R, int C>
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_mul) vector<half, R> mul(matrix<half, R, C>,
                                                             vector<half, C>);
 
@@ -1833,7 +1836,7 @@ vector<T, R> mul(matrix<T, R, C>, vector<T, C>);
 
 // Case 9: matrix * matrix -> matrix
 template <int R, int K, int C>
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_mul) matrix<half, R, C> mul(
     matrix<half, R, K>, matrix<half, K, C>);
 
@@ -1851,16 +1854,16 @@ matrix<T, R, C> mul(matrix<T, R, K>, matrix<T, K, C>);
 ///
 /// Normalize is based on the following formula: x / length(x).
 
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_normalize)
 half normalize(half);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_normalize)
 half2 normalize(half2);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_normalize)
 half3 normalize(half3);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_normalize)
 half4 normalize(half4);
 
@@ -1935,16 +1938,16 @@ bool4x4 or(bool4x4 x, bool4x4 y);
 /// \param Val The input value.
 /// \param Pow The specified power.
 
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_pow)
 half pow(half, half);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_pow)
 half2 pow(half2, half2);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_pow)
 half3 pow(half3, half3);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_pow)
 half4 pow(half4, half4);
 
@@ -1966,16 +1969,16 @@ float4 pow(float4, float4);
 /// \param Val The input value.
 
 #ifdef __HLSL_ENABLE_16_BIT
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_bitreverse)
 uint16_t reversebits(uint16_t);
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_bitreverse)
 uint16_t2 reversebits(uint16_t2);
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_bitreverse)
 uint16_t3 reversebits(uint16_t3);
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_bitreverse)
 uint16_t4 reversebits(uint16_t4);
 #endif
@@ -2013,7 +2016,7 @@ uint64_t4 reversebits(uint64_t4);
 /// x[2] * y[0] - y[2] * x[0]
 /// x[0] * y[1] - y[0] * x[1]
 
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_crossf16)
 half3 cross(half3, half3);
 
@@ -2030,16 +2033,16 @@ float3 cross(float3, float3);
 ///
 /// The return value is the reciprocal of the \a x parameter.
 
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_rcp)
 half rcp(half);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_rcp)
 half2 rcp(half2);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_rcp)
 half3 rcp(half3);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_rcp)
 half4 rcp(half4);
 
@@ -2072,16 +2075,16 @@ double4 rcp(double4);
 ///
 /// This function uses the following formula: 1 / sqrt(x).
 
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_rsqrt)
 half rsqrt(half);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_rsqrt)
 half2 rsqrt(half2);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_rsqrt)
 half3 rsqrt(half3);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_rsqrt)
 half4 rsqrt(half4);
 
@@ -2106,16 +2109,16 @@ float4 rsqrt(float4);
 /// within a floating-point type. Halfway cases are
 /// rounded to the nearest even value.
 
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_roundeven)
 half round(half);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_roundeven)
 half2 round(half2);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_roundeven)
 half3 round(half3);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_roundeven)
 half4 round(half4);
 
@@ -2136,16 +2139,16 @@ float4 round(float4);
 /// \brief Returns input value, \a Val, clamped within the range of 0.0f
 /// to 1.0f. \param Val The input value.
 
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_saturate)
 half saturate(half);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_saturate)
 half2 saturate(half2);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_saturate)
 half3 saturate(half3);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_saturate)
 half4 saturate(half4);
 
@@ -2270,16 +2273,16 @@ __detail::enable_if_t<__detail::is_arithmetic<T>::Value, vector<T, 4>> select(
 /// \brief Returns the sine of the input value, \a Val.
 /// \param Val The input value.
 
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_sin)
 half sin(half);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_sin)
 half2 sin(half2);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_sin)
 half3 sin(half3);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_sin)
 half4 sin(half4);
 
@@ -2300,16 +2303,16 @@ float4 sin(float4);
 /// \brief Returns the hyperbolic sine of the input value, \a Val.
 /// \param Val The input value.
 
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_sinh)
 half sinh(half);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_sinh)
 half2 sinh(half2);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_sinh)
 half3 sinh(half3);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_sinh)
 half4 sinh(half4);
 
@@ -2330,16 +2333,16 @@ float4 sinh(float4);
 /// \brief Returns the square root of the input value, \a Val.
 /// \param Val The input value.
 
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_sqrt)
 half sqrt(half);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_sqrt)
 half2 sqrt(half2);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_sqrt)
 half3 sqrt(half3);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_sqrt)
 half4 sqrt(half4);
 
@@ -2363,16 +2366,16 @@ float4 sqrt(float4);
 ///
 /// Step is based on the following formula: (x >= y) ? 1 : 0
 
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_step)
 half step(half, half);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_step)
 half2 step(half2, half2);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_step)
 half3 step(half3, half3);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_step)
 half4 step(half4, half4);
 
@@ -2393,16 +2396,16 @@ float4 step(float4, float4);
 /// \brief Returns the tangent of the input value, \a Val.
 /// \param Val The input value.
 
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_tan)
 half tan(half);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_tan)
 half2 tan(half2);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_tan)
 half3 tan(half3);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_tan)
 half4 tan(half4);
 
@@ -2423,16 +2426,16 @@ float4 tan(float4);
 /// \brief Returns the hyperbolic tangent of the input value, \a Val.
 /// \param Val The input value.
 
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_tanh)
 half tanh(half);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_tanh)
 half2 tanh(half2);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_tanh)
 half3 tanh(half3);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_tanh)
 half4 tanh(half4);
 
@@ -2453,16 +2456,16 @@ float4 tanh(float4);
 /// \brief Returns the truncated integer value of the input value, \a Val.
 /// \param Val The input value.
 
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_trunc)
 half trunc(half);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_trunc)
 half2 trunc(half2);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_trunc)
 half3 trunc(half3);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_trunc)
 half4 trunc(half4);
 
@@ -2484,43 +2487,43 @@ float4 trunc(float4);
 /// group. Otherwise, the result is false.
 /// \param Value The value to compare with
 /// \return True if all values across all lanes are equal, false otherwise
-_HLSL_16BIT_AVAILABILITY_DEFAULT()
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_all_equal)
 __attribute__((convergent)) bool WaveActiveAllEqual(half);
-_HLSL_16BIT_AVAILABILITY_DEFAULT()
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_all_equal)
 __attribute__((convergent)) bool2 WaveActiveAllEqual(half2);
-_HLSL_16BIT_AVAILABILITY_DEFAULT()
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_all_equal)
 __attribute__((convergent)) bool3 WaveActiveAllEqual(half3);
-_HLSL_16BIT_AVAILABILITY_DEFAULT()
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_all_equal)
 __attribute__((convergent)) bool4 WaveActiveAllEqual(half4);
 
 #ifdef __HLSL_ENABLE_16_BIT
-_HLSL_16BIT_AVAILABILITY_DEFAULT()
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_all_equal)
 __attribute__((convergent)) bool WaveActiveAllEqual(int16_t);
-_HLSL_16BIT_AVAILABILITY_DEFAULT()
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_all_equal)
 __attribute__((convergent)) bool2 WaveActiveAllEqual(int16_t2);
-_HLSL_16BIT_AVAILABILITY_DEFAULT()
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_all_equal)
 __attribute__((convergent)) bool3 WaveActiveAllEqual(int16_t3);
-_HLSL_16BIT_AVAILABILITY_DEFAULT()
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_all_equal)
 __attribute__((convergent)) bool4 WaveActiveAllEqual(int16_t4);
 
-_HLSL_16BIT_AVAILABILITY_DEFAULT()
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_all_equal)
 __attribute__((convergent)) bool WaveActiveAllEqual(uint16_t);
-_HLSL_16BIT_AVAILABILITY_DEFAULT()
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_all_equal)
 __attribute__((convergent)) bool2 WaveActiveAllEqual(uint16_t2);
-_HLSL_16BIT_AVAILABILITY_DEFAULT()
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_all_equal)
 __attribute__((convergent)) bool3 WaveActiveAllEqual(uint16_t3);
-_HLSL_16BIT_AVAILABILITY_DEFAULT()
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_all_equal)
 __attribute__((convergent)) bool4 WaveActiveAllEqual(uint16_t4);
 #endif
@@ -2683,43 +2686,43 @@ _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_read_lane_at)
 __attribute__((convergent)) bool4 WaveReadLaneAt(bool4, uint32_t);
 
 #ifdef __HLSL_ENABLE_16_BIT
-_HLSL_16BIT_AVAILABILITY_DEFAULT()
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_read_lane_at)
 __attribute__((convergent)) int16_t WaveReadLaneAt(int16_t, uint32_t);
-_HLSL_16BIT_AVAILABILITY_DEFAULT()
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_read_lane_at)
 __attribute__((convergent)) int16_t2 WaveReadLaneAt(int16_t2, uint32_t);
-_HLSL_16BIT_AVAILABILITY_DEFAULT()
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_read_lane_at)
 __attribute__((convergent)) int16_t3 WaveReadLaneAt(int16_t3, uint32_t);
-_HLSL_16BIT_AVAILABILITY_DEFAULT()
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_read_lane_at)
 __attribute__((convergent)) int16_t4 WaveReadLaneAt(int16_t4, uint32_t);
 
-_HLSL_16BIT_AVAILABILITY_DEFAULT()
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_read_lane_at)
 __attribute__((convergent)) uint16_t WaveReadLaneAt(uint16_t, uint32_t);
-_HLSL_16BIT_AVAILABILITY_DEFAULT()
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_read_lane_at)
 __attribute__((convergent)) uint16_t2 WaveReadLaneAt(uint16_t2, uint32_t);
-_HLSL_16BIT_AVAILABILITY_DEFAULT()
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_read_lane_at)
 __attribute__((convergent)) uint16_t3 WaveReadLaneAt(uint16_t3, uint32_t);
-_HLSL_16BIT_AVAILABILITY_DEFAULT()
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_read_lane_at)
 __attribute__((convergent)) uint16_t4 WaveReadLaneAt(uint16_t4, uint32_t);
 #endif
 
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_read_lane_at)
 __attribute__((convergent)) half WaveReadLaneAt(half, uint32_t);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_read_lane_at)
 __attribute__((convergent)) half2 WaveReadLaneAt(half2, uint32_t);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_read_lane_at)
 __attribute__((convergent)) half3 WaveReadLaneAt(half3, uint32_t);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_read_lane_at)
 __attribute__((convergent)) half4 WaveReadLaneAt(half4, uint32_t);
 
@@ -2815,43 +2818,43 @@ __attribute__((convergent)) uint64_t4 WaveActiveBitOr(uint64_t4);
 // WaveActiveMax builtins
 //===----------------------------------------------------------------------===//
 
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_max)
 __attribute__((convergent)) half WaveActiveMax(half);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_max)
 __attribute__((convergent)) half2 WaveActiveMax(half2);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_max)
 __attribute__((convergent)) half3 WaveActiveMax(half3);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_max)
 __attribute__((convergent)) half4 WaveActiveMax(half4);
 
 #ifdef __HLSL_ENABLE_16_BIT
-_HLSL_16BIT_AVAILABILITY_DEFAULT()
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_max)
 __attribute__((convergent)) int16_t WaveActiveMax(int16_t);
-_HLSL_16BIT_AVAILABILITY_DEFAULT()
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_max)
 __attribute__((convergent)) int16_t2 WaveActiveMax(int16_t2);
-_HLSL_16BIT_AVAILABILITY_DEFAULT()
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_max)
 __attribute__((convergent)) int16_t3 WaveActiveMax(int16_t3);
-_HLSL_16BIT_AVAILABILITY_DEFAULT()
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_max)
 __attribute__((convergent)) int16_t4 WaveActiveMax(int16_t4);
 
-_HLSL_16BIT_AVAILABILITY_DEFAULT()
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_max)
 __attribute__((convergent)) uint16_t WaveActiveMax(uint16_t);
-_HLSL_16BIT_AVAILABILITY_DEFAULT()
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_max)
 __attribute__((convergent)) uint16_t2 WaveActiveMax(uint16_t2);
-_HLSL_16BIT_AVAILABILITY_DEFAULT()
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_max)
 __attribute__((convergent)) uint16_t3 WaveActiveMax(uint16_t3);
-_HLSL_16BIT_AVAILABILITY_DEFAULT()
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_max)
 __attribute__((convergent)) uint16_t4 WaveActiveMax(uint16_t4);
 #endif
@@ -2914,43 +2917,43 @@ __attribute__((convergent)) double4 WaveActiveMax(double4);
 // WaveActiveMin builtins
 //===----------------------------------------------------------------------===//
 
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_min)
 __attribute__((convergent)) half WaveActiveMin(half);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_min)
 __attribute__((convergent)) half2 WaveActiveMin(half2);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_min)
 __attribute__((convergent)) half3 WaveActiveMin(half3);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_min)
 __attribute__((convergent)) half4 WaveActiveMin(half4);
 
 #ifdef __HLSL_ENABLE_16_BIT
-_HLSL_16BIT_AVAILABILITY_DEFAULT()
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_min)
 __attribute__((convergent)) int16_t WaveActiveMin(int16_t);
-_HLSL_16BIT_AVAILABILITY_DEFAULT()
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_min)
 __attribute__((convergent)) int16_t2 WaveActiveMin(int16_t2);
-_HLSL_16BIT_AVAILABILITY_DEFAULT()
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_min)
 __attribute__((convergent)) int16_t3 WaveActiveMin(int16_t3);
-_HLSL_16BIT_AVAILABILITY_DEFAULT()
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_min)
 __attribute__((convergent)) int16_t4 WaveActiveMin(int16_t4);
 
-_HLSL_16BIT_AVAILABILITY_DEFAULT()
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_min)
 __attribute__((convergent)) uint16_t WaveActiveMin(uint16_t);
-_HLSL_16BIT_AVAILABILITY_DEFAULT()
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_min)
 __attribute__((convergent)) uint16_t2 WaveActiveMin(uint16_t2);
-_HLSL_16BIT_AVAILABILITY_DEFAULT()
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_min)
 __attribute__((convergent)) uint16_t3 WaveActiveMin(uint16_t3);
-_HLSL_16BIT_AVAILABILITY_DEFAULT()
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_min)
 __attribute__((convergent)) uint16_t4 WaveActiveMin(uint16_t4);
 #endif
@@ -3037,43 +3040,43 @@ __attribute__((convergent)) double4 WaveActiveMin(double4);
 // WaveActiveSum builtins
 //===----------------------------------------------------------------------===//
 
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_sum)
 __attribute__((convergent)) half WaveActiveSum(half);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_sum)
 __attribute__((convergent)) half2 WaveActiveSum(half2);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_sum)
 __attribute__((convergent)) half3 WaveActiveSum(half3);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_sum)
 __attribute__((convergent)) half4 WaveActiveSum(half4);
 
 #ifdef __HLSL_ENABLE_16_BIT
-_HLSL_16BIT_AVAILABILITY_DEFAULT()
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_sum)
 __attribute__((convergent)) int16_t WaveActiveSum(int16_t);
-_HLSL_16BIT_AVAILABILITY_DEFAULT()
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_sum)
 __attribute__((convergent)) int16_t2 WaveActiveSum(int16_t2);
-_HLSL_16BIT_AVAILABILITY_DEFAULT()
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_sum)
 __attribute__((convergent)) int16_t3 WaveActiveSum(int16_t3);
-_HLSL_16BIT_AVAILABILITY_DEFAULT()
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_sum)
 __attribute__((convergent)) int16_t4 WaveActiveSum(int16_t4);
 
-_HLSL_16BIT_AVAILABILITY_DEFAULT()
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_sum)
 __attribute__((convergent)) uint16_t WaveActiveSum(uint16_t);
-_HLSL_16BIT_AVAILABILITY_DEFAULT()
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_sum)
 __attribute__((convergent)) uint16_t2 WaveActiveSum(uint16_t2);
-_HLSL_16BIT_AVAILABILITY_DEFAULT()
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_sum)
 __attribute__((convergent)) uint16_t3 WaveActiveSum(uint16_t3);
-_HLSL_16BIT_AVAILABILITY_DEFAULT()
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_sum)
 __attribute__((convergent)) uint16_t4 WaveActiveSum(uint16_t4);
 #endif
@@ -3136,43 +3139,43 @@ __attribute__((convergent)) double4 WaveActiveSum(double4);
 // WaveActiveProduct builtins
 //===----------------------------------------------------------------------===//
 
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_product)
 __attribute__((convergent)) half WaveActiveProduct(half);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_product)
 __attribute__((convergent)) half2 WaveActiveProduct(half2);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_product)
 __attribute__((convergent)) half3 WaveActiveProduct(half3);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_product)
 __attribute__((convergent)) half4 WaveActiveProduct(half4);
 
 #ifdef __HLSL_ENABLE_16_BIT
-_HLSL_16BIT_AVAILABILITY_DEFAULT()
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_product)
 __attribute__((convergent)) int16_t WaveActiveProduct(int16_t);
-_HLSL_16BIT_AVAILABILITY_DEFAULT()
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_product)
 __attribute__((convergent)) int16_t2 WaveActiveProduct(int16_t2);
-_HLSL_16BIT_AVAILABILITY_DEFAULT()
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_product)
 __attribute__((convergent)) int16_t3 WaveActiveProduct(int16_t3);
-_HLSL_16BIT_AVAILABILITY_DEFAULT()
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_product)
 __attribute__((convergent)) int16_t4 WaveActiveProduct(int16_t4);
 
-_HLSL_16BIT_AVAILABILITY_DEFAULT()
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_product)
 __attribute__((convergent)) uint16_t WaveActiveProduct(uint16_t);
-_HLSL_16BIT_AVAILABILITY_DEFAULT()
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_product)
 __attribute__((convergent)) uint16_t2 WaveActiveProduct(uint16_t2);
-_HLSL_16BIT_AVAILABILITY_DEFAULT()
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_product)
 __attribute__((convergent)) uint16_t3 WaveActiveProduct(uint16_t3);
-_HLSL_16BIT_AVAILABILITY_DEFAULT()
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_product)
 __attribute__((convergent)) uint16_t4 WaveActiveProduct(uint16_t4);
 #endif
@@ -3259,43 +3262,43 @@ __attribute__((convergent)) double4 WaveActiveProduct(double4);
 // WavePrefixSum builtins
 //===----------------------------------------------------------------------===//
 
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_sum)
 __attribute__((convergent)) half WavePrefixSum(half);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_sum)
 __attribute__((convergent)) half2 WavePrefixSum(half2);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_sum)
 __attribute__((convergent)) half3 WavePrefixSum(half3);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_sum)
 __attribute__((convergent)) half4 WavePrefixSum(half4);
 
 #ifdef __HLSL_ENABLE_16_BIT
-_HLSL_16BIT_AVAILABILITY_DEFAULT()
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_sum)
 __attribute__((convergent)) int16_t WavePrefixSum(int16_t);
-_HLSL_16BIT_AVAILABILITY_DEFAULT()
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_sum)
 __attribute__((convergent)) int16_t2 WavePrefixSum(int16_t2);
-_HLSL_16BIT_AVAILABILITY_DEFAULT()
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_sum)
 __attribute__((convergent)) int16_t3 WavePrefixSum(int16_t3);
-_HLSL_16BIT_AVAILABILITY_DEFAULT()
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_sum)
 __attribute__((convergent)) int16_t4 WavePrefixSum(int16_t4);
 
-_HLSL_16BIT_AVAILABILITY_DEFAULT()
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_sum)
 __attribute__((convergent)) uint16_t WavePrefixSum(uint16_t);
-_HLSL_16BIT_AVAILABILITY_DEFAULT()
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_sum)
 __attribute__((convergent)) uint16_t2 WavePrefixSum(uint16_t2);
-_HLSL_16BIT_AVAILABILITY_DEFAULT()
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_sum)
 __attribute__((convergent)) uint16_t3 WavePrefixSum(uint16_t3);
-_HLSL_16BIT_AVAILABILITY_DEFAULT()
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_sum)
 __attribute__((convergent)) uint16_t4 WavePrefixSum(uint16_t4);
 #endif
@@ -3358,43 +3361,43 @@ __attribute__((convergent)) double4 WavePrefixSum(double4);
 // WavePrefixProduct builtins
 //===----------------------------------------------------------------------===//
 
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_product)
 __attribute__((convergent)) half WavePrefixProduct(half);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_product)
 __attribute__((convergent)) half2 WavePrefixProduct(half2);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_product)
 __attribute__((convergent)) half3 WavePrefixProduct(half3);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_product)
 __attribute__((convergent)) half4 WavePrefixProduct(half4);
 
 #ifdef __HLSL_ENABLE_16_BIT
-_HLSL_16BIT_AVAILABILITY_DEFAULT()
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_product)
 __attribute__((convergent)) int16_t WavePrefixProduct(int16_t);
-_HLSL_16BIT_AVAILABILITY_DEFAULT()
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_product)
 __attribute__((convergent)) int16_t2 WavePrefixProduct(int16_t2);
-_HLSL_16BIT_AVAILABILITY_DEFAULT()
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_product)
 __attribute__((convergent)) int16_t3 WavePrefixProduct(int16_t3);
-_HLSL_16BIT_AVAILABILITY_DEFAULT()
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_product)
 __attribute__((convergent)) int16_t4 WavePrefixProduct(int16_t4);
 
-_HLSL_16BIT_AVAILABILITY_DEFAULT()
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_product)
 __attribute__((convergent)) uint16_t WavePrefixProduct(uint16_t);
-_HLSL_16BIT_AVAILABILITY_DEFAULT()
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_product)
 __attribute__((convergent)) uint16_t2 WavePrefixProduct(uint16_t2);
-_HLSL_16BIT_AVAILABILITY_DEFAULT()
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_product)
 __attribute__((convergent)) uint16_t3 WavePrefixProduct(uint16_t3);
-_HLSL_16BIT_AVAILABILITY_DEFAULT()
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_product)
 __attribute__((convergent)) uint16_t4 WavePrefixProduct(uint16_t4);
 #endif
@@ -3462,43 +3465,43 @@ __attribute__((convergent)) double4 WavePrefixProduct(double4);
 /// 1 if \a Val is greater than zero. \param Val The input value.
 
 #ifdef __HLSL_ENABLE_16_BIT
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_sign)
 int sign(int16_t);
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_sign)
 int2 sign(int16_t2);
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_sign)
 int3 sign(int16_t3);
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_sign)
 int4 sign(int16_t4);
 
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_sign)
 int sign(uint16_t);
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_sign)
 int2 sign(uint16_t2);
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_sign)
 int3 sign(uint16_t3);
-_HLSL_AVAILABILITY(shadermodel, 6.2)
+_HLSL_AVAILABILITY_6_2_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_sign)
 int4 sign(uint16_t4);
 #endif
 
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_sign)
 int sign(half);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_sign)
 int2 sign(half2);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_sign)
 int3 sign(half3);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_sign)
 int4 sign(half4);
 
@@ -3563,16 +3566,16 @@ int4 sign(double4);
 /// \fn T radians(T Val)
 /// \brief Converts the specified value from degrees to radians.
 
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_radians)
 half radians(half);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_radians)
 half2 radians(half2);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_radians)
 half3 radians(half3);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_radians)
 half4 radians(half4);
 
@@ -3609,16 +3612,16 @@ __attribute__((convergent)) void GroupMemoryBarrierWithGroupSync(void);
 /// The return value is a floating point scalar or vector containing the low
 /// prevision partial derivative of the input value.
 
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_ddx_coarse)
 half ddx_coarse(half);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_ddx_coarse)
 half2 ddx_coarse(half2);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_ddx_coarse)
 half3 ddx_coarse(half3);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_ddx_coarse)
 half4 ddx_coarse(half4);
 
@@ -3643,16 +3646,16 @@ float4 ddx_coarse(float4);
 /// The return value is a floating point scalar or vector containing the low
 /// prevision partial derivative of the input value.
 
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_ddy_coarse)
 half ddy_coarse(half);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_ddy_coarse)
 half2 ddy_coarse(half2);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_ddy_coarse)
 half3 ddy_coarse(half3);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_ddy_coarse)
 half4 ddy_coarse(half4);
 
@@ -3677,16 +3680,16 @@ float4 ddy_coarse(float4);
 /// The return value is a floating point scalar or vector containing the high
 /// prevision partial derivative of the input value.
 
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_ddx_fine)
 half ddx_fine(half);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_ddx_fine)
 half2 ddx_fine(half2);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_ddx_fine)
 half3 ddx_fine(half3);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_ddx_fine)
 half4 ddx_fine(half4);
 
@@ -3711,16 +3714,16 @@ float4 ddx_fine(float4);
 /// The return value is a floating point scalar or vector containing the high
 /// prevision partial derivative of the input value.
 
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_ddy_fine)
 half ddy_fine(half);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_ddy_fine)
 half2 ddy_fine(half2);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_ddy_fine)
 half3 ddy_fine(half3);
-_HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
+_HLSL_16BIT_AVAILABILITY_DEFAULT(shadermodel)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_ddy_fine)
 half4 ddy_fine(half4);
 


### PR DESCRIPTION
This is actually a surprise part 2 to:
https://github.com/llvm/llvm-project/pull/185757

Fully addresses https://github.com/llvm/llvm-project/issues/185756