### PR TITLE
[clang][BoundsSafety] Bring nested struct support into AST/Sema

### DIFF
--- a/clang/include/clang/AST/TypeBase.h
+++ b/clang/include/clang/AST/TypeBase.h
@@ -3363,12 +3363,14 @@ public:
 /// arguments of the `counted_by` attribute and the likes.
 class TypeCoupledDeclRefInfo {
 public:
-  using BaseTy = llvm::PointerIntPair<ValueDecl *, 1, unsigned>;
+  using BaseTy = llvm::PointerIntPair<ValueDecl *, 2, unsigned>;
 
 private:
   enum {
     DerefShift = 0,
     DerefMask = 1,
+    MemberShift = 1,
+    MemberMask = 1,
   };
   BaseTy Data;
 
@@ -3376,9 +3378,15 @@ public:
   /// \p D is to a declaration referenced by the argument of attribute. \p Deref
   /// indicates whether \p D is referenced as a dereferenced form, e.g., \p
   /// Deref is true for `*n` in `int *__counted_by(*n)`.
-  TypeCoupledDeclRefInfo(ValueDecl *D = nullptr, bool Deref = false);
+  /// \p Member indicates that \p D is referenced as the member for a struct,
+  /// e.g __counted_by(hdr.len) `hdr`, although a FieldDecl is referred to by
+  /// a DeclRefExpr, while `len` is referred to by a MemberExpr. In this
+  /// example `Member` is false for `hdr` and true for `len`.
+  TypeCoupledDeclRefInfo(ValueDecl *D = nullptr, bool Deref = false,
+                         bool Member = false);
 
   bool isDeref() const;
+  bool isMember() const;
   ValueDecl *getDecl() const;
   unsigned getInt() const;
   void *getOpaqueValue() const;

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -7102,6 +7102,28 @@ def err_count_attr_argument_not_integer : Error<
   "'%select{counted_by|sized_by|counted_by_or_null|sized_by_or_null}0' requires a non-boolean integer type argument">;
 def err_count_attr_only_support_simple_decl_reference : Error<
   "'%select{counted_by|sized_by|counted_by_or_null|sized_by_or_null}0' argument must be a simple declaration reference">;
+def err_bounds_safety_dynamic_count_function_call
+    : Error<"argument of "
+            "'%select{__counted_by|__sized_by|__counted_by_or_null|__sized_by_"
+            "or_null}0' attribute can only reference "
+            "function with 'const' attribute">;
+def err_bounds_safety_dynamic_count_function_call_argument
+    : Error<"argument of function call %0 in "
+            "'%select{__counted_by|__sized_by|__counted_by_or_null|__sized_by_"
+            "or_null}1' attribute is not a constant expression">;
+def err_attribute_invalid_argument_expression_for_pointer_bounds_attribute
+    : Error<"invalid argument expression to bounds attribute">;
+def err_deref_in_bounds_safety_count_non_parm_decl
+    : Error<"dereference operator in "
+            "'%select{__counted_by|__sized_by|__counted_by_or_null|__sized_by_"
+            "or_null|__ended_by}0' is only allowed for function parameters">;
+def note_bounds_safety_struct_fields_only_in_fam
+    : Note<"nested struct member in count parameter only supported for "
+           "flexible array members">;
+def error_bounds_safety_no_arrow_members
+    : Error<"arrow notation not allowed for struct member in count parameter">;
+def error_bounds_safety_no_count_in_unions
+    : Error<"count parameter refers to union %0 of type %1">;
 def err_count_attr_in_union : Error<
   "'%select{counted_by|sized_by|counted_by_or_null|sized_by_or_null}0' cannot be applied to a union member">;
 def err_count_attr_refer_to_union : Error<

--- a/clang/include/clang/Basic/LangOptions.def
+++ b/clang/include/clang/Basic/LangOptions.def
@@ -514,6 +514,7 @@ LANGOPT(CheckConstexprFunctionBodies, 1, 1, Benign,
         "be used in a constant expression.")
 
 LANGOPT(BoundsSafety, 1, 0, NotCompatible, "Bounds safety extension for C")
+LANGOPT(BoundsSafetyExpressions, 1, 0, NotCompatible, "Experimental expression support in bounds safety attributes")
 
 LANGOPT(EnableLifetimeSafety, 1, 0, NotCompatible, "Lifetime safety analysis for C++")
 

--- a/clang/include/clang/Options/Options.td
+++ b/clang/include/clang/Options/Options.td
@@ -1965,6 +1965,15 @@ defm bounds_safety : BoolFOption<
   BothFlags<[], [CC1Option],
           " experimental bounds safety extension for C">>;
 
+defm bounds_safety_expressions
+    : BoolFOption<"experimental-bounds-safety-expressions",
+                  LangOpts<"BoundsSafetyExpressions">, DefaultFalse,
+                  PosFlag<SetTrue, [], [CC1Option], "Enable">,
+                  NegFlag<SetFalse, [], [CC1Option], "Disable">,
+                  BothFlags<[], [CC1Option],
+                            " experimental expression support in bounds safety "
+                            "attributes">>;
+
 defm lifetime_safety : BoolFOption<
   "lifetime-safety",
   LangOpts<"EnableLifetimeSafety">, DefaultTrue,

--- a/clang/include/clang/Serialization/ASTRecordWriter.h
+++ b/clang/include/clang/Serialization/ASTRecordWriter.h
@@ -156,6 +156,7 @@ public:
   void writeTypeCoupledDeclRefInfo(TypeCoupledDeclRefInfo Info) {
     writeDeclRef(Info.getDecl());
     writeBool(Info.isDeref());
+    writeBool(Info.isMember());
   }
 
   void writeHLSLSpirvOperand(SpirvOperand Op) {

--- a/clang/lib/AST/Decl.cpp
+++ b/clang/lib/AST/Decl.cpp
@@ -4858,7 +4858,16 @@ const FieldDecl *FieldDecl::findCountedByField() const {
   if (!CAT)
     return nullptr;
 
-  const auto *CountDRE = cast<DeclRefExpr>(CAT->getCountExpr());
+  // Return leaf FieldDecl for nested struct case (MemberExpr), which is
+  // produced when -fexperimental-bounds-safety-expressions is enabled.
+  const Expr *CountExpr = CAT->getCountExpr();
+  if (const auto *ME = dyn_cast<MemberExpr>(CountExpr))
+    return dyn_cast<FieldDecl>(ME->getMemberDecl());
+
+  const auto *CountDRE = dyn_cast<DeclRefExpr>(CountExpr);
+  if (!CountDRE)
+    return nullptr;
+
   const auto *CountDecl = CountDRE->getDecl();
   if (const auto *IFD = dyn_cast<IndirectFieldDecl>(CountDecl))
     CountDecl = IFD->getAnonField();

--- a/clang/lib/AST/Type.cpp
+++ b/clang/lib/AST/Type.cpp
@@ -4027,11 +4027,15 @@ void FunctionProtoType::Profile(llvm::FoldingSetNodeID &ID,
           getExtProtoInfo(), Ctx, isCanonicalUnqualified());
 }
 
-TypeCoupledDeclRefInfo::TypeCoupledDeclRefInfo(ValueDecl *D, bool Deref)
-    : Data(D, Deref << DerefShift) {}
+TypeCoupledDeclRefInfo::TypeCoupledDeclRefInfo(ValueDecl *D, bool Deref,
+                                               bool Member)
+    : Data(D, (Deref << DerefShift) | (Member << MemberShift)) {}
 
 bool TypeCoupledDeclRefInfo::isDeref() const {
-  return Data.getInt() & DerefMask;
+  return (Data.getInt() >> DerefShift) & DerefMask;
+}
+bool TypeCoupledDeclRefInfo::isMember() const {
+  return (Data.getInt() >> MemberShift) & MemberMask;
 }
 ValueDecl *TypeCoupledDeclRefInfo::getDecl() const { return Data.getPointer(); }
 unsigned TypeCoupledDeclRefInfo::getInt() const { return Data.getInt(); }

--- a/clang/lib/Sema/SemaBoundsSafety.cpp
+++ b/clang/lib/Sema/SemaBoundsSafety.cpp
@@ -186,10 +186,22 @@ bool Sema::CheckCountedByAttrOnField(FieldDecl *FD, Expr *E, bool CountInBytes,
 
   auto *DRE = dyn_cast<DeclRefExpr>(E);
   if (!DRE) {
-    Diag(E->getBeginLoc(),
-         diag::err_count_attr_only_support_simple_decl_reference)
-        << Kind << E->getSourceRange();
-    return true;
+    // Apple's non-fbounds-safety path only accepts DeclRefExprs here. Under
+    // -fexperimental-bounds-safety-expression we relax this to allow MemberExpr
+    // chains (e.g., counted_by(s.len)). Detailed validation of the member chain
+    // is done by CountArgChecker.
+    if (getLangOpts().BoundsSafetyExpressions) {
+      const Expr *Base = E;
+      while (auto *ME = dyn_cast<MemberExpr>(Base))
+        Base = ME->getBase()->IgnoreParenImpCasts();
+      DRE = dyn_cast<DeclRefExpr>(const_cast<Expr *>(Base));
+    }
+    if (!DRE) {
+      Diag(E->getBeginLoc(),
+           diag::err_count_attr_only_support_simple_decl_reference)
+          << Kind << E->getSourceRange();
+      return true;
+    }
   }
 
   auto *CountDecl = DRE->getDecl();

--- a/clang/lib/Sema/SemaType.cpp
+++ b/clang/lib/Sema/SemaType.cpp
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "TreeTransform.h"
 #include "TypeLocBuilder.h"
 #include "clang/AST/ASTConsumer.h"
 #include "clang/AST/ASTContext.h"
@@ -47,6 +48,7 @@
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/IR/DerivedTypes.h"
 #include "llvm/Support/ErrorHandling.h"
+#include "llvm/Support/SaveAndRestore.h"
 #include <bitset>
 #include <optional>
 
@@ -9952,13 +9954,277 @@ QualType Sema::BuildTypeofExprType(Expr *E, TypeOfKind Kind) {
   return Context.getTypeOfExprType(E, Kind);
 }
 
-static void
-BuildTypeCoupledDecls(Expr *E,
-                      llvm::SmallVectorImpl<TypeCoupledDeclRefInfo> &Decls) {
-  // Currently, 'counted_by' only allows direct DeclRefExpr to FieldDecl.
-  auto *CountDecl = cast<DeclRefExpr>(E)->getDecl();
-  Decls.push_back(TypeCoupledDeclRefInfo(CountDecl, /*IsDref*/ false));
+namespace {
+
+Expr *UnwrapDerefAddrOfPairs(Expr *E) {
+  UnaryOperator *UO = dyn_cast<UnaryOperator>(E);
+  if (!UO)
+    return E;
+  switch (UO->getOpcode()) {
+  case UO_Deref:
+    UO = dyn_cast<UnaryOperator>(UO->getSubExpr()->IgnoreParens());
+    if (!UO || UO->getOpcode() != UO_AddrOf)
+      return E;
+    break;
+  case UO_AddrOf:
+    UO = dyn_cast<UnaryOperator>(UO->getSubExpr()->IgnoreParens());
+    if (!UO || UO->getOpcode() != UO_Deref)
+      return E;
+    break;
+  default:
+    return E;
+  }
+  /// XXX: This way we are leaving out '*((int *)&ch)'.
+  return UnwrapDerefAddrOfPairs(UO->getSubExpr()->IgnoreParens());
 }
+
+/// CountArgChecker - performs sanity checks for an argument in
+/// '__counted_by()' or '__sized_by()', and returns a constant-folded
+/// count expression if feasible.
+class CountArgChecker : public TreeTransform<CountArgChecker> {
+  using BaseTransform = TreeTransform<CountArgChecker>;
+  using DeclList = llvm::SmallVector<TypeCoupledDeclRefInfo, 1>;
+  using DeclSet = llvm::SmallPtrSet<Decl *, 1>;
+  DeclList &Dependees;
+  bool CountInBytes : 1;
+  bool OrNull : 1;
+  bool ScopeCheck : 1;
+  bool IsArray : 1;
+  DeclSet Visited;
+  bool InDeref = false;
+  BinaryOperator *VisitedBinOp = nullptr;
+
+private:
+  ExprResult Fallback(Expr *E) {
+    if (auto CF = ConstantFoldOrNull(E))
+      return CF;
+    SemaRef.Diag(
+        E->getExprLoc(),
+        diag::
+            err_attribute_invalid_argument_expression_for_pointer_bounds_attribute);
+    return ExprError();
+  }
+
+  IntegerLiteral *ConstantFoldOrNull(Expr *E) {
+    if (E->isValueDependent())
+      return nullptr;
+
+    Expr::EvalResult Eval;
+    /// EvaluateAsInt is enough because nodes are visited in-order and
+    /// we require the final results be integer. Hence, cases like
+    /// '(int)(float)f' should work.
+    if (E->EvaluateAsInt(Eval, SemaRef.Context))
+      return IntegerLiteral::Create(SemaRef.Context, Eval.Val.getInt(),
+                                    E->getType(), E->getExprLoc());
+    return nullptr;
+  }
+
+  CountAttributedType::DynamicCountPointerKind getDynamicCountKind() {
+    return CountInBytes ? (OrNull ? CountAttributedType::SizedByOrNull
+                                  : CountAttributedType::SizedBy)
+                        : (OrNull ? CountAttributedType::CountedByOrNull
+                                  : CountAttributedType::CountedBy);
+  }
+
+public:
+  explicit CountArgChecker(Sema &S, DeclList &DList, bool CountInBytes,
+                           bool OrNull, bool ScopeCheck, bool IsArray)
+      : BaseTransform(S), Dependees(DList), CountInBytes(CountInBytes),
+        OrNull(OrNull), ScopeCheck(ScopeCheck), IsArray(IsArray) {}
+
+  ExprResult TransformExpr(Expr *E) {
+    switch (E->getStmtClass()) {
+
+#define TRANSFORM_EXPR(Node)                                                   \
+  case Stmt::Node##Class:                                                      \
+    return Transform##Node(cast<Node>(E));
+
+#define FORWARD_EXPR(Node)                                                     \
+  case Stmt::Node##Class:                                                      \
+    return E;
+
+      TRANSFORM_EXPR(CallExpr)
+      TRANSFORM_EXPR(ImplicitCastExpr)
+      TRANSFORM_EXPR(CStyleCastExpr)
+      TRANSFORM_EXPR(ParenExpr)
+      TRANSFORM_EXPR(BinaryOperator)
+      TRANSFORM_EXPR(UnaryOperator)
+      TRANSFORM_EXPR(DeclRefExpr)
+      TRANSFORM_EXPR(MemberExpr)
+      FORWARD_EXPR(IntegerLiteral)
+      FORWARD_EXPR(FloatingLiteral)
+      FORWARD_EXPR(FixedPointLiteral)
+
+#undef TRANSFORM_EXPR
+#undef FORWARD_EXPR
+    default:
+      break;
+    }
+    return Fallback(E);
+  }
+
+  ExprResult TransformCallExpr(CallExpr *E) {
+    const auto *Callee = E->getDirectCallee();
+    if (Callee && Callee->hasAttr<ConstAttr>()) {
+      for (auto *Arg : E->arguments()) {
+        if (!Arg->isEvaluatable(SemaRef.Context)) {
+          SemaRef.Diag(
+              E->getExprLoc(),
+              diag::err_bounds_safety_dynamic_count_function_call_argument)
+              << E << getDynamicCountKind();
+          return ExprError();
+        }
+      }
+      return E;
+    }
+    SemaRef.Diag(E->getExprLoc(),
+                 diag::err_bounds_safety_dynamic_count_function_call)
+        << getDynamicCountKind();
+    if (Callee) {
+      SemaRef.Diag(Callee->getLocation(), diag::note_callee_decl) << Callee;
+    }
+    return ExprError();
+  }
+
+  ExprResult TransformImplicitCastExpr(ImplicitCastExpr *E) {
+    return BaseTransform::TransformImplicitCastExpr(E);
+  }
+
+  ExprResult TransformCStyleCastExpr(CStyleCastExpr *E) {
+    Expr::EvalResult Eval;
+    /// EvaluateAsInt is enough because nodes are visited in-order and
+    /// we require the final results be integer. Hence, cases like
+    /// '(int)(float)f' should work.
+    if (!E->EvaluateAsInt(Eval, SemaRef.Context))
+      return BaseTransform::TransformCStyleCastExpr(E);
+    return IntegerLiteral::Create(SemaRef.Context, Eval.Val.getInt(),
+                                  E->getType(), E->getExprLoc());
+  }
+
+  ExprResult TransformParenExpr(ParenExpr *E) {
+    if (auto CF = ConstantFoldOrNull(E))
+      return CF;
+    return BaseTransform::TransformParenExpr(E);
+  }
+
+  ExprResult TransformBinaryOperator(BinaryOperator *E) {
+    VisitedBinOp = E;
+    if (auto CF = ConstantFoldOrNull(E))
+      return CF;
+    return BaseTransform::TransformBinaryOperator(E);
+  }
+
+  /// Add support for UO_Deref in particular to support out parameters.
+  /// e.g., 'void foo(int *__counted_by(len)* out_buf, int len)'
+  ExprResult TransformUnaryOperator(UnaryOperator *E) {
+    if (auto CF = ConstantFoldOrNull(E))
+      return CF;
+
+    Expr *UnwrappedExpr = UnwrapDerefAddrOfPairs(E);
+    E = dyn_cast<UnaryOperator>(UnwrappedExpr);
+    if (!E)
+      return TransformExpr(UnwrappedExpr);
+
+    if (E->getOpcode() == UO_Deref && !InDeref) {
+      if (VisitedBinOp)
+        return Fallback(E);
+      SaveAndRestore<bool> InDerefLocal(InDeref, true);
+      Expr *SubExpr = E->getSubExpr()->IgnoreParenCasts();
+      if (auto *DR = dyn_cast<DeclRefExpr>(SubExpr)) {
+        if (!isa<ParmVarDecl>(DR->getDecl()) || ScopeCheck) {
+          SemaRef.Diag(E->getExprLoc(),
+                       diag::err_deref_in_bounds_safety_count_non_parm_decl)
+              << getDynamicCountKind();
+          return E;
+        }
+        return BaseTransform::TransformUnaryOperator(E);
+      }
+      return Fallback(E);
+    }
+    if (E->isArithmeticOp())
+      return BaseTransform::TransformUnaryOperator(E);
+
+    return Fallback(E);
+  }
+
+  ExprResult TransformDeclRefExpr(DeclRefExpr *E) {
+    if (auto CF = ConstantFoldOrNull(E))
+      return CF;
+
+    ValueDecl *VD = E->getDecl();
+    bool IsNewVD = Visited.insert(VD).second;
+    if (IsNewVD) {
+      Dependees.push_back(TypeCoupledDeclRefInfo(VD, InDeref));
+    }
+    return E;
+  }
+
+  ExprResult TransformMemberExpr(MemberExpr *E) {
+    if (auto CF = ConstantFoldOrNull(E))
+      return CF;
+
+    const Expr *Base = E->getBase();
+
+    // For structs/classes in C++, referring to a field creates a MemberExpr
+    // instead of DeclRefExpr. To support other parts of bounds-safety logic,
+    // replace the MemberExpr by DeclRefExpr.
+    // TODO: Add support for MemberExpr (rdar://134311605).
+    if (SemaRef.getLangOpts().CPlusPlus &&
+        // The MemberExprs that are allowed in C++ but not in C are those having
+        // `this->` implicitly or explicitly as their bases.
+        (Base->isImplicitCXXThis() ||
+         isa<CXXThisExpr>(Base->IgnoreParenImpCasts()))) {
+      ValueDecl *VD = E->getMemberDecl();
+      bool IsNewVD = Visited.insert(VD).second;
+      if (IsNewVD)
+        Dependees.push_back(TypeCoupledDeclRefInfo(VD, InDeref));
+      Expr *DRE = DeclRefExpr::Create(
+          SemaRef.Context, NestedNameSpecifierLoc{}, SourceLocation{}, VD,
+          false, DeclarationNameInfo{VD->getDeclName(), VD->getLocation()},
+          VD->getType(), VK_LValue);
+      return DRE;
+    }
+
+    if (!IsArray) {
+      SemaRef.Diag(
+          E->getExprLoc(),
+          diag::
+              err_attribute_invalid_argument_expression_for_pointer_bounds_attribute);
+      SemaRef.Diag(E->getOperatorLoc(),
+                   diag::note_bounds_safety_struct_fields_only_in_fam);
+      return ExprError();
+    }
+
+    if (E->isArrow()) {
+      SemaRef.Diag(E->getExprLoc(), diag::error_bounds_safety_no_arrow_members);
+      return ExprError();
+    }
+
+    // Recursive call adds base decls to Dependees, i.e. for `a.b.c` it adds `a`
+    // and `b`. `c` is added by the call to Dependees.push_back() further down.
+    ExprResult BaseRes = TransformExpr(E->getBase());
+    if (BaseRes.isInvalid())
+      return ExprError();
+
+    if (BaseRes.get()->getType()->isUnionType()) {
+      SemaRef.Diag(E->getExprLoc(),
+                   diag::error_bounds_safety_no_count_in_unions)
+          << BaseRes.get() << BaseRes.get()->getType();
+      return ExprError();
+    }
+
+    ValueDecl *VD = E->getMemberDecl();
+    bool IsNewVD = Visited.insert(VD).second;
+    if (IsNewVD) {
+      Dependees.push_back(
+          TypeCoupledDeclRefInfo(VD, InDeref, /* Member */ true));
+    }
+
+    return E;
+  }
+};
+
+} // end anonymous namespace
 
 QualType Sema::BuildCountAttributedArrayOrPointerType(QualType WrappedTy,
                                                       Expr *CountExpr,
@@ -9966,10 +10232,26 @@ QualType Sema::BuildCountAttributedArrayOrPointerType(QualType WrappedTy,
                                                       bool OrNull) {
   assert(WrappedTy->isIncompleteArrayType() || WrappedTy->isPointerType());
 
+  // Apple wires CountArgChecker into a separate function
+  // (BuildCountAttributedType) only reachable via -fbounds-safety. We gate it
+  // behind -fexperimental-bounds-safety-expressions instead, keeping the
+  // standard path unchanged.
   llvm::SmallVector<TypeCoupledDeclRefInfo, 1> Decls;
-  BuildTypeCoupledDecls(CountExpr, Decls);
-  /// When the resulting expression is invalid, we still create the AST using
-  /// the original count expression for the sake of AST dump.
+  if (getLangOpts().BoundsSafetyExpressions) {
+    ExprResult R =
+        CountArgChecker(*this, Decls, CountInBytes, OrNull,
+                        /*ScopeCheck=*/false, WrappedTy->isArrayType())
+            .TransformExpr(CountExpr);
+    if (!R.isInvalid())
+      CountExpr = R.get();
+    R = DefaultLvalueConversion(CountExpr);
+    if (!R.isInvalid())
+      CountExpr = R.get();
+  } else {
+    // Standard path: only simple DeclRefExpr allowed.
+    auto *CountDecl = cast<DeclRefExpr>(CountExpr)->getDecl();
+    Decls.push_back(TypeCoupledDeclRefInfo(CountDecl, /*IsDref*/ false));
+  }
   return Context.getCountAttributedType(WrappedTy, CountExpr, CountInBytes,
                                         OrNull, Decls);
 }

--- a/clang/lib/Serialization/ASTReader.cpp
+++ b/clang/lib/Serialization/ASTReader.cpp
@@ -10134,7 +10134,10 @@ DeclarationNameInfo ASTRecordReader::readDeclarationNameInfo() {
 }
 
 TypeCoupledDeclRefInfo ASTRecordReader::readTypeCoupledDeclRefInfo() {
-  return TypeCoupledDeclRefInfo(readDeclAs<ValueDecl>(), readBool());
+  auto *D = readDeclAs<ValueDecl>();
+  bool Deref = readBool();
+  bool Member = readBool();
+  return TypeCoupledDeclRefInfo(D, Deref, Member);
 }
 
 SpirvOperand ASTRecordReader::readHLSLSpirvOperand() {

--- a/clang/test/AST/attr-counted-by-nested-struct.c
+++ b/clang/test/AST/attr-counted-by-nested-struct.c
@@ -1,0 +1,44 @@
+// RUN: %clang_cc1 -fexperimental-bounds-safety-expressions %s -ast-dump | FileCheck %s
+
+#define __counted_by(f)  __attribute__((counted_by(f)))
+
+struct inner {
+  int len;
+};
+
+// CHECK-LABEL: RecordDecl {{.+}} struct basic_nested definition
+// CHECK-NEXT: |-FieldDecl {{.+}} referenced s 'struct inner'
+// CHECK-NEXT: `-FieldDecl {{.+}} data 'int[] __counted_by(s.len)':'int[]'
+struct basic_nested {
+  struct inner s;
+  int data[] __counted_by(s.len);
+};
+
+struct level2 { int count; };
+struct level1 { struct level2 l2; };
+
+// CHECK-LABEL: RecordDecl {{.+}} struct deep_nested definition
+// CHECK-NEXT: |-FieldDecl {{.+}} referenced l1 'struct level1'
+// CHECK-NEXT: `-FieldDecl {{.+}} data 'int[] __counted_by(l1.l2.count)':'int[]'
+struct deep_nested {
+  struct level1 l1;
+  int data[] __counted_by(l1.l2.count);
+};
+
+// CHECK-LABEL: RecordDecl {{.+}} struct simple definition
+// CHECK-NEXT: |-FieldDecl {{.+}} referenced len 'int'
+// CHECK-NEXT: `-FieldDecl {{.+}} data 'int[] __counted_by(len)':'int[]'
+struct simple {
+  int len;
+  int data[] __counted_by(len);
+};
+
+// CHECK-LABEL: RecordDecl {{.+}} struct anon_struct definition
+// CHECK-NEXT: |-RecordDecl {{.+}} struct definition
+// CHECK-NEXT: | `-FieldDecl {{.+}} referenced len 'int'
+// CHECK-NEXT: |-FieldDecl {{.+}} referenced s 'struct (unnamed at {{.+}})'
+// CHECK-NEXT: `-FieldDecl {{.+}} data 'int[] __counted_by(s.len)':'int[]'
+struct anon_struct {
+  struct { int len; } s;
+  int data[] __counted_by(s.len);
+};

--- a/clang/test/Sema/attr-counted-by-nested-struct.c
+++ b/clang/test/Sema/attr-counted-by-nested-struct.c
@@ -1,0 +1,59 @@
+// RUN: %clang_cc1 -fexperimental-bounds-safety-expressions -fsyntax-only -verify=expr %s
+// RUN: %clang_cc1 -fsyntax-only -verify=std %s
+
+#define __counted_by(f)  __attribute__((counted_by(f)))
+
+struct inner { int len; };
+
+// Arrow notation not supported
+struct arrow_test {
+  struct inner *s;
+  int data[] __counted_by(s->len);  // expr-error{{arrow notation not allowed for struct member in count parameter}}
+                                    // std-error@-1{{'counted_by' argument must be a simple declaration reference}}
+};
+
+// Union members not supported
+union u { int a; float b; };
+struct union_test {
+  union u u;
+  int data[] __counted_by(u.a); // expr-error{{count parameter refers to union 'u' of type 'union u'}}
+                                // std-error@-1{{'counted_by' argument must be a simple declaration reference}}
+};
+
+// Pointer fields not supported
+struct ptr_member_test {
+  struct inner s;
+  int *__counted_by(s.len) p; // expr-error{{invalid argument expression to bounds attribute}}
+                              // expr-note@-1{{nested struct member in count parameter only supported for flexible array members}}
+                              // std-error@-2{{'counted_by' argument must be a simple declaration reference}}
+};
+
+// Non-integer counts not supported
+struct non_int_leaf {
+  struct inner s;
+  int data[] __counted_by(s); // expr-error{{'counted_by' requires a non-boolean integer type argument}}
+                              // std-error@-1{{'counted_by' requires a non-boolean integer type argument}}
+};
+struct bool_struct {
+  _Bool b;
+};
+struct bool_leaf {
+  struct bool_struct s;
+  int data[] __counted_by(s); // expr-error{{'counted_by' requires a non-boolean integer type argument}}
+                              // std-error@-1{{'counted_by' requires a non-boolean integer type argument}}
+};
+
+// Bad anon struct
+struct anon_struct_nonexistent_leaf {
+  struct { int len; } s;
+  int data[] __counted_by(s.ben); // expr-error{{no member named 'ben'}}
+                                  // expr-error@-1{{'counted_by' requires a non-boolean integer type argument}}
+                                  // std-error@-2{{no member named 'ben'}}
+                                  // std-error@-3{{'counted_by' requires a non-boolean integer type argument}}
+};
+
+struct expr_leaf {
+  struct inner s;
+  int data[] __counted_by(s.len + 2); // expr-error{{'counted_by' argument must be a simple declaration reference}}
+                                      // std-error@-1{{'counted_by' argument must be a simple declaration reference}}
+};


### PR DESCRIPTION
This patch adds AST and Sema support for references to nested struct members in the `counted_by` attribute (e.g., `__counted_by(s.len)`), and gates it behind a new `-fexperimental-bounds-safety-expressions` flag. In the real world, structs are often bounded not by a direct reference, but rather inside a nested struct member. Much of the code was ported from Apple's `-fbounds-safety` implementation - https://github.com/swiftlang/llvm-project. The idea here is to lay the groundwork to support actual bounds checking during CodeGen, which is more of a challenge to do without importing the entire 'wide-pointer' infrastructure from Apple's implementation.

Support for nested struct members is facilitated by the addition of a `Member` bit to `TypeCoupledDeclRefInfo` to track `MemberExpr`s (the `len` in `__counted_by(hdr.len)`), and the porting of `CountArgChecker`, a subclass of `TreeTransform` that validates the count expression. This change only applies to the `counted_by` attribute and not related variants like `sized_by` since we restrict the change to FAM declarations only.

Assisted-by: claude-opus-4.6