### PR TITLE
[lldb] Fix typo in SymbolFilePDBTests

### DIFF
--- a/lldb/unittests/SymbolFile/PDB/SymbolFilePDBTests.cpp
+++ b/lldb/unittests/SymbolFile/PDB/SymbolFilePDBTests.cpp
@@ -72,7 +72,7 @@ public:
 
   void TearDown() override {
     SymbolFilePDB::Terminate();
-    TypeSystemClang::Initialize();
+    TypeSystemClang::Terminate();
     plugin::dwarf::SymbolFileDWARF::Terminate();
     ObjectFilePECOFF::Terminate();
     HostInfo::Terminate();


### PR DESCRIPTION
This should fix the assertion on Windows caused by #185537.