### PR TITLE
[mcp-frameinst: 3/3]: [MCP] Never eliminate frame-setup/destroy instructions

### DIFF
--- a/llvm/lib/CodeGen/MachineCopyPropagation.cpp
+++ b/llvm/lib/CodeGen/MachineCopyPropagation.cpp
@@ -490,6 +490,12 @@ private:
     // zero).
     return MRI->isReserved(CopyOperand);
   }
+  /// Returns true iff the @p Copy instruction must never be eliminated as
+  /// redundant. This overload does not consider the operands of @p Copy.
+  bool isNeverRedundant(const MachineInstr &Copy) {
+    return Copy.getFlag(MachineInstr::FrameSetup) ||
+           Copy.getFlag(MachineInstr::FrameDestroy);
+  }
   bool hasImplicitOverlap(const MachineInstr &MI, const MachineOperand &Use);
   bool hasOverlappingMultipleDef(const MachineInstr &MI,
                                  const MachineOperand &MODef, MCRegister Def);
@@ -598,7 +604,7 @@ static bool isNopCopy(const MachineInstr &PreviousCopy, MCRegister Src,
 /// copying the super registers.
 bool MachineCopyPropagation::eraseIfRedundant(MachineInstr &Copy,
                                               MCRegister Dst, MCRegister Src) {
-  if (isNeverRedundant(Src) || isNeverRedundant(Dst))
+  if (isNeverRedundant(Copy) || isNeverRedundant(Src) || isNeverRedundant(Dst))
     return false;
 
   // Search for an existing copy.
@@ -659,7 +665,7 @@ bool MachineCopyPropagation::isBackwardPropagatableCopy(
   if (!Dst || !Src)
     return false;
 
-  if (isNeverRedundant(Dst) || isNeverRedundant(Src))
+  if (isNeverRedundant(Copy) || isNeverRedundant(Dst) || isNeverRedundant(Src))
     return false;
 
   return CopyOperands.Source->isRenamable() && CopyOperands.Source->isKill();
@@ -946,7 +952,7 @@ void MachineCopyPropagation::forwardCopyPropagateBlock(MachineBasicBlock &MBB) {
       if (!TRI->regsOverlap(Dst, Src)) {
         // FIXME: Document why this does not consider `RegSrc`, similar to how
         // `backwardCopyPropagateBlock` does.
-        if (!isNeverRedundant(Dst))
+        if (!isNeverRedundant(MI) && !isNeverRedundant(Dst))
           MaybeDeadCopies.insert(&MI);
       }
     }
@@ -991,7 +997,7 @@ void MachineCopyPropagation::forwardCopyPropagateBlock(MachineBasicBlock &MBB) {
         std::optional<DestSourcePair> CopyOperands =
             isCopyInstr(*MaybeDead, *TII, UseCopyInstr);
         MCRegister Reg = CopyOperands->Destination->getReg().asMCReg();
-        assert(!isNeverRedundant(Reg));
+        assert(!isNeverRedundant(*MaybeDead) && !isNeverRedundant(Reg));
 
         if (!RegMask->clobbersPhysReg(Reg)) {
           ++DI;
@@ -1059,7 +1065,7 @@ void MachineCopyPropagation::forwardCopyPropagateBlock(MachineBasicBlock &MBB) {
           *isCopyInstr(*MaybeDead, *TII, UseCopyInstr);
 
       auto [Dst, Src] = getDstSrcMCRegs(CopyOperands);
-      assert(!isNeverRedundant(Dst));
+      assert(!isNeverRedundant(*MaybeDead) && !isNeverRedundant(Dst));
 
       // Update matching debug values, if any.
       const auto &DbgUsers = CopyDbgUsers[MaybeDead];

--- a/llvm/test/CodeGen/X86/machine-copy-prop.mir
+++ b/llvm/test/CodeGen/X86/machine-copy-prop.mir
@@ -16,6 +16,8 @@
   define void @nocopyprop3() { ret void }
   define void @nocopyprop4() { ret void }
   define void @nocopyprop5() { ret void }
+  define void @nocopyprop_frame_setup() { ret void }
+  define void @nocopyprop_frame_destroy() { ret void }
 ...
 ---
 # The second copy is redundant and will be removed, check that we also remove
@@ -252,4 +254,24 @@ body: |
   bb.0:
     $rip = COPY $rax
     $rip = COPY $rax
+...
+---
+# Conservatively assume prologue/epilogue instructions may have
+# additional effects.
+# CHECK-LABEL: name: nocopyprop_frame_setup
+# CHECK: bb.0:
+# CHECK-NEXT: $rbx = frame-setup COPY $rax
+name: nocopyprop_frame_setup
+body: |
+  bb.0:
+    $rbx = frame-setup COPY $rax
+...
+---
+# CHECK-LABEL: name: nocopyprop_frame_destroy
+# CHECK: bb.0:
+# CHECK-NEXT: $rbx = frame-destroy COPY $rax
+name: nocopyprop_frame_destroy
+body: |
+  bb.0:
+    $rbx = frame-destroy COPY $rax
 ...


### PR DESCRIPTION
Presumably targets only insert frame instructions which are significant,
and there may be effects MCP doesn't model. Similar to reserved registers this
is probably overly conservative, but as this causes no codegen change in
any lit test I think it is benign.

The motivation is just to clean up #183149 for AMDGPU, as we can spill
to physical registers, and currently have to spill the EXEC mask purely
to enable debug-info.

Change-Id: I9ea4a09b34464c43322edd2900361bf635efd9f7

---

**Stack**:
- #186237⬅
- #186239
- #186240
- `main`

<sub>(Note: Closed and merged PRs may not be reflected here and PR numbering is not stable.)</sub>
