### PR TITLE
[mcp-frameinst: 1/4]: [CodeGen][MC][NFC] Clarify MCRegister ctor behavior

### DIFF
--- a/llvm/include/llvm/CodeGen/Register.h
+++ b/llvm/include/llvm/CodeGen/Register.h
@@ -104,10 +104,7 @@ public:
   /// Utility to check-convert this value to a MCRegister. The caller is
   /// expected to have already validated that this Register is, indeed,
   /// physical.
-  MCRegister asMCReg() const {
-    assert(!isValid() || isPhysical());
-    return MCRegister(Reg);
-  }
+  constexpr MCRegister asMCReg() const { return MCRegister::from(Reg); }
 
   constexpr bool isValid() const { return Reg != MCRegister::NoRegister; }
 

--- a/llvm/include/llvm/MC/MCRegister.h
+++ b/llvm/include/llvm/MC/MCRegister.h
@@ -43,7 +43,20 @@ class MCRegister {
   unsigned Reg;
 
 public:
-  constexpr MCRegister(unsigned Val = 0) : Reg(Val) {}
+  constexpr MCRegister(unsigned Val = 0) : Reg(Val) {
+    // N.B. this does not assert `isPhysicalRegister(Val)` to avoid paying the
+    // compilation/runtime cost for developers of the compiler. Every consumer
+    // is expected to `assert(Reg.isPhysicalRegister())`, so this should only
+    // cost developers having to add an assert here while debugging the original
+    // source of such an assert.
+    //
+    // Where the producer wishes to `assert` they can use `Register::asMCReg`
+    // and/or `MCRegister::from`.
+    //
+    // See the thread "[llvm-dev] Relation between Register and MCRegister"
+    // (https://groups.google.com/g/llvm-dev/c/36h4LluUaJY/m/dgItXNwQCgAJ)
+    // for more historical context.
+  }
 
   // Register numbers can represent physical registers, virtual registers, and
   // sometimes stack slots. The unsigned values are divided into these ranges:
@@ -73,8 +86,8 @@ public:
 
   constexpr operator unsigned() const { return Reg; }
 
-  /// Check the provided unsigned value is a valid MCRegister.
-  static MCRegister from(unsigned Val) {
+  /// Check-convert the provided unsigned value to an MCRegister.
+  static constexpr MCRegister from(unsigned Val) {
     assert(Val == NoRegister || isPhysicalRegister(Val));
     return MCRegister(Val);
   }


### PR DESCRIPTION
This is something I have learned, forgotten, and relearned
at least once now, so I figured it is worth noting in a comment:
the `MCRegister` constructor does not `assert` on non-Physical,
non-Invalid values.

Also do some related cleanup:

Make `MCRegister::from` be `constexpr` and use it in `Register::asMCReg`
instead of duplicating the `assert`.

Reword the doc-comment on `MCRegister::from` to avoid using the
overloaded term "valid" (an "invalid" `MCRegister` is perfectly valid here).

Change-Id: I0985a825ae83d0601899fa4ab046ff262359e93f

---

**Stack**:
- #186237
- #186239
- #186240
- #186238⬅
- `main`

<sub>(Note: Closed and merged PRs may not be reflected here and PR numbering is not stable.)</sub>
