### PR TITLE
[MLIR][XeVM] Update HandleVectorExtractPattern

### DIFF
--- a/mlir/lib/Conversion/XeVMToLLVM/XeVMToLLVM.cpp
+++ b/mlir/lib/Conversion/XeVMToLLVM/XeVMToLLVM.cpp
@@ -895,10 +895,16 @@ static bool isExtractingContiguousSlice(LLVM::ShuffleVectorOp op) {
   if (op.getV1() != op.getV2())
     return false;
   auto maskAttr = op.getMask();
+  int64_t maskSize = static_cast<int64_t>(maskAttr.size());
+  int64_t sourceSize = op.getV1().getType().getNumElements();
+  if (maskSize > sourceSize)
+    return false;
   int64_t firstIndex = maskAttr[0];
-  for (int64_t i = 1; i < static_cast<int64_t>(maskAttr.size()); ++i) {
+  for (int64_t i = 1; i < maskSize; ++i) {
     int64_t index = maskAttr[i];
     if (index != firstIndex + i)
+      return false;
+    if (index >= sourceSize)
       return false;
   }
   return true;
@@ -984,9 +990,18 @@ class HandleVectorExtractPattern
             LLVM::BitcastOp::create(rewriter, loc, ty, newShuffle);
         rewriter.replaceOp(op, newBitcast);
       } else if (isa<LLVM::ShuffleVectorOp>(srcOp)) {
-        // 2. Merge with another shuffle vector op
+        // 2. Merge with source shuffle vector op if,
+        //  - the source op is also extracting a contigous slice.
+        //  - the source op mask size is not smaller than the current
+        //    op mask size.
+        // And create a new shuffle vector op directly from the source
+        // of the first shuffle.
         auto srcShuffle = cast<LLVM::ShuffleVectorOp>(srcOp);
+        if (!isExtractingContiguousSlice(srcShuffle))
+          return failure();
         auto srcMask = srcShuffle.getMask();
+        if (srcMask.size() < mask.size())
+          return failure();
         SmallVector<int32_t> combinedMask;
         for (auto index : mask) {
           combinedMask.push_back(srcMask[index]);

--- a/mlir/lib/Conversion/XeVMToLLVM/XeVMToLLVM.cpp
+++ b/mlir/lib/Conversion/XeVMToLLVM/XeVMToLLVM.cpp
@@ -891,6 +891,12 @@ private:
   }
 };
 
+// Checks if shufflevector is used as a way to extract a contiguous slice
+// from a vector.
+// - source vector V1 and V2 are the same vector.
+// - mask size is not greater than the source vector size
+// - mask values represent a sequence of consecutive increasing numbers
+//   that stay in bounds of the source vector when used for indexing.
 static bool isExtractingContiguousSlice(LLVM::ShuffleVectorOp op) {
   if (op.getV1() != op.getV2())
     return false;
@@ -990,12 +996,10 @@ class HandleVectorExtractPattern
             LLVM::BitcastOp::create(rewriter, loc, ty, newShuffle);
         rewriter.replaceOp(op, newBitcast);
       } else if (isa<LLVM::ShuffleVectorOp>(srcOp)) {
-        // 2. Merge with source shuffle vector op if,
-        //  - the source op is also extracting a contigous slice.
-        //  - the source op mask size is not smaller than the current
-        //    op mask size.
-        // And create a new shuffle vector op directly from the source
-        // of the first shuffle.
+        // 2. Merge with source shuffle vector op if, the source op is
+        //    also extracting a contigous slice and create a new
+        //    shuffle vector op directly from the source of
+        //    the first shuffle.
         auto srcShuffle = cast<LLVM::ShuffleVectorOp>(srcOp);
         if (!isExtractingContiguousSlice(srcShuffle))
           return failure();

--- a/mlir/lib/Conversion/XeVMToLLVM/XeVMToLLVM.cpp
+++ b/mlir/lib/Conversion/XeVMToLLVM/XeVMToLLVM.cpp
@@ -1000,8 +1000,6 @@ class HandleVectorExtractPattern
         if (!isExtractingContiguousSlice(srcShuffle))
           return failure();
         auto srcMask = srcShuffle.getMask();
-        if (srcMask.size() < mask.size())
-          return failure();
         SmallVector<int32_t> combinedMask;
         for (auto index : mask) {
           combinedMask.push_back(srcMask[index]);

--- a/mlir/test/Conversion/XeVMToLLVM/legalize_large_vector.mlir
+++ b/mlir/test/Conversion/XeVMToLLVM/legalize_large_vector.mlir
@@ -49,3 +49,27 @@ module @test_illegal_vector {
       llvm.return
   }
 }
+
+// -----
+
+module @test_match_fail {
+  // CHECK-LABEL: llvm.func @test_match_fail
+  // CHECK-SAME: %[[ARG0:.*]]: !llvm.ptr, %[[ARG1:.*]]: !llvm.ptr, %[[ARG2:.*]]: !llvm.ptr, %[[ARG3:.*]]: !llvm.ptr
+  llvm.func @test_match_fail(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) {
+    // CHECK: %[[VAR0:.*]] = llvm.load %[[ARG0]]
+    %0 = llvm.load %arg0 : !llvm.ptr -> vector<4xi16>
+    // CHECK: %[[VAR1:.*]] = llvm.load %[[ARG1]]
+    %1 = llvm.load %arg1 : !llvm.ptr -> vector<4xi16>
+    // CHECK: %[[VAR2:.*]] = llvm.shufflevector %[[VAR0]], %[[VAR1]]
+    %2 = llvm.shufflevector %0, %1 [0, 1, 2, 3, 4, 5, 6, 7] : vector<4xi16>
+    // CHECK: %[[VAR3:.*]] = llvm.shufflevector %[[VAR0]], %[[VAR0]]
+    %3 = llvm.shufflevector %0, %0 [0, 1, 2, 3, 4, 5, 6, 7] : vector<4xi16>
+    // CHECK: %[[VAR4:.*]] = llvm.shufflevector %[[VAR2]], %[[VAR2]]
+    %4 = llvm.shufflevector %2, %2 [0, 1, 2, 3, 4, 5] : vector<8xi16>
+    // CHECK: %[[VAR5:.*]] = llvm.shufflevector %[[VAR3]], %[[VAR3]]
+    %5 = llvm.shufflevector %3, %3 [0, 1, 2, 3, 4, 5] : vector<8xi16>
+    llvm.store %4, %arg2 : vector<6xi16>, !llvm.ptr
+    llvm.store %5, %arg3 : vector<6xi16>, !llvm.ptr
+    llvm.return
+  }
+}


### PR DESCRIPTION
isExtractContiguousSlice:
- Check if mask size is not greater than the vector size of the operand.
- Check if mask values do not exceed vector size. 

HandleVectorExtractPattern:
- Narrow the scope of matching to, 
  - Source shuffle doing contiguous extract
  - Source shuffle with at least the same mask size.