### PR TITLE
[clang][test] Fix solaris ld driver test to not assume gnu ld location

### DIFF
--- a/clang/test/Driver/Inputs/fake_ld/ld
+++ b/clang/test/Driver/Inputs/fake_ld/ld
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+echo "Unexpectedly running fake ld" 1>&2
+
+exit 1

--- a/clang/test/Driver/solaris-ld-sld.c
+++ b/clang/test/Driver/solaris-ld-sld.c
@@ -1,7 +1,7 @@
 // REQUIRES: system-solaris
 
-// Check that clang invokes the native ld.
+// Check that clang invokes the native ld, not whatever "ld" that happens to be in PATH
 
-// RUN: test -f /usr/gnu/bin/ld && env PATH=/usr/gnu/bin %clang -o %t.o %s
+// RUN: env PATH=%S/Inputs/fake_ld/ %clang -v -o %t.o %s
 
 int main() { return 0; }


### PR DESCRIPTION
@rorth, I guess you might be the right one to look at this?

Commit message:
```
[clang][test] Fix solaris ld driver test to not assume gnu ld location

AFAICU This test intends to check that system ld is invoked by clang,
and not some other "ld" that happens to be in path.

Part of doing that it checked that "/usr/gnu/bin/ld" existed, and if
it doesn't the test fails. But not all opensolaris/illumos
distributions have it there. E.g SmartOS has gnu ld in
/opt/local/bin/. One could build llvm without having gnu ld installed
at all, so it would be nice to not require it to be installed to be
able to run one single test (which tests that gnu ld is _not_
executed).

Instead of requiring a real gnu ld, that causes the test to fail if it
executed (due to getting arguments it doesn't understand) this adds a
fake "ld" script that always fails and makes the test put that into
PATH to make sure it is not picked up.

This makes the test pass on systems without gnu ld installed, or where
it is installed in a different path.
```

I have tested this on illumos/SmartOS.
