### PR TITLE
[InlineAsm] Fix InlineAsm dialect decoding in getExtraInfoNames

### DIFF
--- a/llvm/include/llvm/IR/InlineAsm.h
+++ b/llvm/include/llvm/IR/InlineAsm.h
@@ -459,8 +459,9 @@ public:
     if (ExtraInfo & InlineAsm::Extra_MayUnwind)
       Result.push_back("unwind");
 
-    AsmDialect Dialect =
-        InlineAsm::AsmDialect((ExtraInfo & InlineAsm::Extra_AsmDialect));
+    AsmDialect Dialect = (ExtraInfo & InlineAsm::Extra_AsmDialect)
+                             ? InlineAsm::AD_Intel
+                             : InlineAsm::AD_ATT;
 
     if (Dialect == InlineAsm::AD_ATT)
       Result.push_back("attdialect");

--- a/llvm/lib/CodeGen/MachineInstr.cpp
+++ b/llvm/lib/CodeGen/MachineInstr.cpp
@@ -927,7 +927,8 @@ bool MachineInstr::isStackAligningInlineAsm() const {
 InlineAsm::AsmDialect MachineInstr::getInlineAsmDialect() const {
   assert(isInlineAsm() && "getInlineAsmDialect() only works for inline asms!");
   unsigned ExtraInfo = getOperand(InlineAsm::MIOp_ExtraInfo).getImm();
-  return InlineAsm::AsmDialect((ExtraInfo & InlineAsm::Extra_AsmDialect) != 0);
+  return (ExtraInfo & InlineAsm::Extra_AsmDialect) ? InlineAsm::AD_Intel
+                                                   : InlineAsm::AD_ATT;
 }
 
 int MachineInstr::findInlineAsmFlagIdx(unsigned OpIdx,

--- a/llvm/test/CodeGen/X86/inline-asm-inteldialect-mir.ll
+++ b/llvm/test/CodeGen/X86/inline-asm-inteldialect-mir.ll
@@ -1,0 +1,11 @@
+; RUN: llc < %s -mtriple=x86_64 -stop-after=finalize-isel -o - | FileCheck %s
+
+; Verify that the MIR printer correctly handles the inteldialect flag
+; on INLINEASM instructions (ExtraInfo bit decoding).
+; CHECK: INLINEASM {{.*}}inteldialect
+; CHECK: INLINEASM {{.*}}attdialect
+define void @test_inteldialect() {
+  call void asm sideeffect inteldialect "nop", ""()
+  call void asm sideeffect "nop", ""()
+  ret void
+}


### PR DESCRIPTION
The getExtraInfoNames() function incorrectly cast the raw bit value from (ExtraInfo & Extra_AsmDialect) directly to AsmDialect. Since Extra_AsmDialect=4 and AD_Intel=1, Intel dialect produced AsmDialect(4) which never matched AD_Intel, causing inteldialect to not appear when dumping MIR.

Fix by using an explicit ternary to map the bit flag to the correct enum value. Also apply the same change to MachineInstr::getInlineAsmDialect for consistency.