### PR TITLE
[lldb] Unify logging for GetAttributeAddressRanges error

### DIFF
--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFCompileUnit.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFCompileUnit.cpp
@@ -52,7 +52,7 @@ void DWARFCompileUnit::BuildAddressRangeTable(
         return;
     } else {
       LLDB_LOG_ERROR(GetLog(DWARFLog::DebugInfo), ranges.takeError(),
-                     "{1:x}: {0}", cu_offset);
+                     "DIE({1:x}): {0}", cu_offset);
     }
   }
 


### PR DESCRIPTION
Use the same format string in DWARFCompileUnit.cpp as we do everywhere else to report the error from GetAttributeAddressRanges. I noticed the inconsistency when looking at our system log:

```
2026-03-12 05:36:48.600914 -0700	0x2e66: DIE has no address range information
2026-03-12 05:36:48.600950 -0700	0x2e8c: DIE has no address range information
2026-03-12 05:36:48.601068 -0700	DIE(0x1dc2): DIE has no address range information
2026-03-12 05:36:48.631000 -0700	DIE(0x80f4): DIE has no address range information
```