### PR TITLE
[mlir][gpu] Fix null-deref crash in gpu-kernel-outlining for unresolved symbols

### DIFF
--- a/mlir/lib/Dialect/GPU/Transforms/KernelOutlining.cpp
+++ b/mlir/lib/Dialect/GPU/Transforms/KernelOutlining.cpp
@@ -439,8 +439,10 @@ private:
           if (symbolTable.lookup(symbolName))
             continue;
 
-          Operation *symbolDefClone =
-              parentSymbolTable.lookup(symbolName)->clone();
+          Operation *symbolDef = parentSymbolTable.lookup(symbolName);
+          if (!symbolDef)
+            continue;
+          Operation *symbolDefClone = symbolDef->clone();
           symbolDefWorklist.push_back(symbolDefClone);
           symbolTable.insert(symbolDefClone);
         }

--- a/mlir/test/Dialect/GPU/outlining.mlir
+++ b/mlir/test/Dialect/GPU/outlining.mlir
@@ -638,6 +638,30 @@ func.func @testNoAttributes() {
 
 // -----
 
+// Regression test for https://github.com/llvm/llvm-project/issues/185357.
+// A gpu.launch whose body contains a gpu.launch_func referencing a symbol in a
+// nested gpu.module must not crash when the leaf reference cannot be found in
+// the parent symbol table.
+
+// CHECK-LABEL: func.func @launch_with_launch_func_body(
+module attributes {gpu.container_module} {
+  gpu.module @some_kernels {
+    gpu.func @some_kernel() kernel {
+      gpu.return
+    }
+  }
+  func.func @launch_with_launch_func_body(%sz : index) {
+    gpu.launch blocks(%bx, %by, %bz) in (%gx = %sz, %gy = %sz, %gz = %sz)
+               threads(%tx, %ty, %tz) in (%bsx = %sz, %bsy = %sz, %bsz = %sz) {
+      "test.use_nested"()  {uses = [@public_module::@nested_function]} : () -> ()
+      gpu.terminator
+    }
+    return
+  }
+}
+
+// -----
+
 // This test tests nested `gpu.launch`.
 
 // CHECK-LABEL: func.func @nested_launch(


### PR DESCRIPTION
In `GpuKernelOutliningPass::createKernelModule`, the symbol-copying worklist iterates over all symbol uses inside the outlined kernel and looks each leaf reference up in the parent symbol table.  If the symbol refers to a name inside a nested module (e.g. `@some_module::@func`), the leaf reference `@func` is not directly present in the parent table, so `SymbolTable::lookup` returns nullptr.  Calling `->clone()` on that null pointer causes a segfault.

Add a null check: if the symbol is not found in the parent table (it may live in a nested gpu.module that is already handled separately), skip it.

Fixes #185357

Assisted-by: Claude Code