### PR TITLE
[mlir][bufferization] Fix integer overflow crash in promote-buffers-to-stack

### DIFF
--- a/mlir/lib/Dialect/Bufferization/Transforms/BufferOptimizations.cpp
+++ b/mlir/lib/Dialect/Bufferization/Transforms/BufferOptimizations.cpp
@@ -105,7 +105,17 @@ static bool defaultIsSmallAlloc(Value alloc, unsigned maximumSizeInBytes,
   }
   unsigned bitwidth = mlir::DataLayout::closest(alloc.getDefiningOp())
                           .getTypeSizeInBits(type.getElementType());
-  return type.getNumElements() * bitwidth <= maximumSizeInBytes * 8;
+  // Use tryGetNumElements to avoid an assertion on integer overflow (e.g. for
+  // very large statically-shaped memrefs).  If the element count overflows
+  // int64_t the allocation is certainly not "small", so return false.
+  std::optional<int64_t> numElements = type.tryGetNumElements();
+  if (!numElements)
+    return false;
+  // Guard against overflow in the size computation as well.
+  if (bitwidth != 0 &&
+      *numElements > static_cast<int64_t>(maximumSizeInBytes * 8ULL / bitwidth))
+    return false;
+  return *numElements * bitwidth <= maximumSizeInBytes * 8;
 }
 
 /// Checks whether the given aliases leave the allocation scope.

--- a/mlir/test/Transforms/promote-buffers-to-stack.mlir
+++ b/mlir/test/Transforms/promote-buffers-to-stack.mlir
@@ -611,3 +611,18 @@ module attributes { dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<index, 256>>} {
 // LOWLIMIT-NEXT: memref.alloc() {alignment = 64 : i64, custom_attr}
 // RANK-NEXT: memref.alloca() {alignment = 64 : i64, custom_attr}
 // CHECK-NEXT: return
+
+// -----
+
+// Regression test for https://github.com/llvm/llvm-project/issues/64638.
+// A memref whose static element count overflows int64_t must not trigger an
+// assertion in ShapedType::getNumElements().  The allocation is too large to
+// promote to the stack, so it must remain as a heap allocation.
+
+// CHECK-LABEL: func @huge_static_memref
+// CHECK:         memref.alloc
+// CHECK-NOT:     memref.alloca
+func.func @huge_static_memref() {
+  %alloc = memref.alloc() : memref<3090540x3090540x3090540xi32>
+  return
+}


### PR DESCRIPTION
`defaultIsSmallAlloc` called `ShapedType::getNumElements()` which asserts when the static element count overflows `int64_t` (e.g. a `memref<3090540x3090540x3090540xi32>` whose element count is ~29e18).

Switch to `ShapedType::tryGetNumElements()`, which returns `std::nullopt` on overflow.  An overflowing element count means the allocation is definitely not small, so we return `false` immediately. A secondary overflow guard is added for the final size comparison.

Fixes #64638

Assisted-by: Claude Code