### PR TITLE
[MLIR][OpenACC] Fix crash in verifyDeviceTypeCountMatch when deviceTypes is null

### DIFF
--- a/mlir/lib/Dialect/OpenACC/IR/OpenACC.cpp
+++ b/mlir/lib/Dialect/OpenACC/IR/OpenACC.cpp
@@ -1942,7 +1942,8 @@ template <typename Op>
 static LogicalResult verifyDeviceTypeCountMatch(Op op, OperandRange operands,
                                                 ArrayAttr deviceTypes,
                                                 llvm::StringRef keyword) {
-  if (!operands.empty() && deviceTypes.getValue().size() != operands.size())
+  if (!operands.empty() &&
+      (!deviceTypes || deviceTypes.getValue().size() != operands.size()))
     return op.emitOpError() << keyword << " operands count must match "
                             << keyword << " device_type count";
   return success();

--- a/mlir/test/Dialect/OpenACC/invalid.mlir
+++ b/mlir/test/Dialect/OpenACC/invalid.mlir
@@ -968,3 +968,19 @@ func.func @verify_host_data_duplicate_use_device(%arg0 : memref<i32>) {
   }
   return
 }
+
+// -----
+
+// Regression test for https://github.com/llvm/llvm-project/issues/107027.
+// acc.parallel with async operands but no asyncOperandsDeviceType attribute
+// must produce a diagnostic instead of crashing in verifyDeviceTypeCountMatch.
+
+func.func @verify_parallel_async_missing_device_type(%arg0: i64) {
+// expected-error @below {{async operands count must match async device_type count}}
+  "acc.parallel"(%arg0) <{
+    operandSegmentSizes = array<i32: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0>
+  }> ({
+    acc.yield
+  }) : (i64) -> ()
+  return
+}


### PR DESCRIPTION
When an acc.parallel op has async operands (via operandSegmentSizes) but no corresponding asyncOperandsDeviceType attribute, the verifier called verifyDeviceTypeCountMatch with a null ArrayAttr. The function then dereferenced the null pointer via deviceTypes.getValue(), causing a segfault instead of a diagnostic.

Fix by guarding the getValue() call with a null check. When deviceTypes is absent but operands are present, the mismatch is now reported as a proper verifier error.

Fixes #107027

Assisted-by: Claude Code