### PR TITLE
[clang][OpenMP] Parse/Sema for OpenMP 6.0 declare_target 'local' clause

### DIFF
--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -4715,17 +4715,15 @@ def OMPDeclareTargetDecl : InheritableAttr {
   let SemaHandler = 0;
   let Subjects = SubjectList<[Function, SharedVar]>;
   let Documentation = [OMPDeclareTargetDocs];
-  let Args = [
-    EnumArgument<"MapType", "MapTypeTy", /*is_string=*/false,
-                 [ "to", "enter", "link" ],
-                 [ "MT_To", "MT_Enter", "MT_Link" ]>,
-    EnumArgument<"DevType", "DevTypeTy", /*is_string=*/false,
-                 [ "host", "nohost", "any" ],
-                 [ "DT_Host", "DT_NoHost", "DT_Any" ]>,
-    ExprArgument<"IndirectExpr">,
-    BoolArgument<"Indirect">,
-    UnsignedArgument<"Level">
-  ];
+  let Args = [EnumArgument<
+                  "MapType", "MapTypeTy",
+                  /*is_string=*/false, ["to", "enter", "link", "local"],
+                  ["MT_To", "MT_Enter", "MT_Link", "MT_Local"]>,
+              EnumArgument<"DevType", "DevTypeTy",
+                           /*is_string=*/false, ["host", "nohost", "any"],
+                           ["DT_Host", "DT_NoHost", "DT_Any"]>,
+              ExprArgument<"IndirectExpr">, BoolArgument<"Indirect">,
+              UnsignedArgument<"Level">];
   let AdditionalMembers = [{
     void printPrettyPragma(raw_ostream &OS, const PrintingPolicy &Policy) const;
     static std::optional<MapTypeTy>

--- a/clang/include/clang/Basic/DiagnosticParseKinds.td
+++ b/clang/include/clang/Basic/DiagnosticParseKinds.td
@@ -1558,18 +1558,21 @@ def note_omp_assumption_clause_continue_here
     : Note<"the ignored tokens spans until here">;
 def err_omp_declare_target_unexpected_clause: Error<
   "unexpected '%0' clause, only %select{'device_type'|'to' or 'link'|'to', 'link' or 'device_type'|'device_type', 'indirect'|'to', 'link', 'device_type' or 'indirect'}1 clauses expected">;
-def err_omp_declare_target_unexpected_clause_52: Error<
-  "unexpected '%0' clause, only %select{'device_type'|'enter' or 'link'|'enter', 'link' or 'device_type'|'device_type', 'indirect'|'enter', 'link', 'device_type' or 'indirect'}1 clauses expected">;
+def err_omp_declare_target_unexpected_clause_52
+    : Error<"unexpected '%0' clause, only %select{'device_type'|'enter' or "
+            "'link'|'enter', 'link' or 'device_type'|'device_type', "
+            "'indirect'|'enter', 'link', 'device_type' or 'indirect'|'enter', "
+            "'link', 'device_type', 'indirect' or 'local'}1 clauses expected">;
 def err_omp_begin_declare_target_unexpected_implicit_to_clause: Error<
   "unexpected '(', only 'to', 'link' or 'device_type' clauses expected for 'begin declare target' directive">;
 def err_omp_declare_target_wrong_clause_after_implicit_to: Error<
   "unexpected clause after an implicit 'to' clause">;
 def err_omp_declare_target_wrong_clause_after_implicit_enter: Error<
   "unexpected clause after an implicit 'enter' clause">;
-def err_omp_declare_target_missing_to_or_link_clause: Error<
-  "expected at least one %select{'to' or 'link'|'to', 'link' or 'indirect'}0 clause">;
-def err_omp_declare_target_missing_enter_or_link_clause: Error<
-  "expected at least one %select{'enter' or 'link'|'enter', 'link' or 'indirect'}0 clause">;
+def err_omp_declare_target_missing_required_clause
+    : Error<"expected at least one %select{'to' or 'link'|'to', 'link' or "
+            "'indirect'|'enter', 'link' or 'indirect'|'enter', 'link', "
+            "'indirect' or 'local'}0 clause">;
 def err_omp_declare_target_unexpected_to_clause: Error<
   "unexpected 'to' clause, use 'enter' instead">;
 def err_omp_declare_target_unexpected_enter_clause: Error<

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -12127,13 +12127,16 @@ def warn_omp_alignment_not_power_of_two : Warning<
   InGroup<OpenMPClauses>;
 def err_omp_invalid_target_decl : Error<
   "%0 used in declare target directive is not a variable or a function name">;
-def err_omp_declare_target_to_and_link : Error<
-  "%0 must not appear in both clauses 'to' and 'link'">;
+def err_omp_declare_target_var_in_both_clauses
+    : Error<"%0 must not appear in both clauses '%1' and '%2'">;
+def err_omp_declare_target_local_host_only
+    : Error<"'local' clause is incompatible with 'device_type(host)'; "
+            "local variables exist only on the device">;
 def warn_omp_not_in_target_context : Warning<
   "declaration is not declared in any declare target region">,
   InGroup<OpenMPTarget>;
-def err_omp_function_in_link_clause : Error<
-  "function name is not allowed in 'link' clause">;
+def err_omp_function_in_target_clause_list
+    : Error<"function name is not allowed in '%0' clause">;
 def err_omp_aligned_expected_array_or_ptr : Error<
   "argument of aligned clause should be array"
   "%select{ or pointer|, pointer, reference to array or reference to pointer}1"
@@ -12549,6 +12552,11 @@ def err_omp_declare_target_has_local_vars : Error<
 def warn_omp_declare_target_after_first_use : Warning<
   "declaration marked as declare target after first use, it may lead to incorrect results">,
   InGroup<OpenMPTarget>;
+def warn_omp_declare_target_local_not_implemented
+    : Warning<"'local' clause on 'declare_target' directive is not yet fully "
+              "implemented; "
+              "variable will be treated as 'enter'">,
+      InGroup<OpenMPTarget>;
 def err_omp_declare_variant_incompat_attributes : Error<
   "'#pragma omp declare variant' is not compatible with any target-specific attributes">;
 def warn_omp_declare_variant_score_not_constant

--- a/clang/lib/CodeGen/CGExpr.cpp
+++ b/clang/lib/CodeGen/CGExpr.cpp
@@ -3327,15 +3327,18 @@ static Address emitDeclTargetVarDeclLValue(CodeGenFunction &CGF,
   std::optional<OMPDeclareTargetDeclAttr::MapTypeTy> Res =
       OMPDeclareTargetDeclAttr::isDeclareTargetDeclaration(VD);
   // Return an invalid address if variable is MT_To (or MT_Enter starting with
-  // OpenMP 5.2) and unified memory is not enabled. For all other cases: MT_Link
-  // and MT_To (or MT_Enter) with unified memory, return a valid address.
+  // OpenMP 5.2, or MT_Local in OpenMP 6.0) and unified memory is not enabled.
+  // For all other cases: MT_Link and MT_To (or MT_Enter/MT_Local) with unified
+  // memory, return a valid address.
   if (!Res || ((*Res == OMPDeclareTargetDeclAttr::MT_To ||
-                *Res == OMPDeclareTargetDeclAttr::MT_Enter) &&
+                *Res == OMPDeclareTargetDeclAttr::MT_Enter ||
+                *Res == OMPDeclareTargetDeclAttr::MT_Local) &&
                !CGF.CGM.getOpenMPRuntime().hasRequiresUnifiedSharedMemory()))
     return Address::invalid();
   assert(((*Res == OMPDeclareTargetDeclAttr::MT_Link) ||
           ((*Res == OMPDeclareTargetDeclAttr::MT_To ||
-            *Res == OMPDeclareTargetDeclAttr::MT_Enter) &&
+            *Res == OMPDeclareTargetDeclAttr::MT_Enter ||
+            *Res == OMPDeclareTargetDeclAttr::MT_Local) &&
            CGF.CGM.getOpenMPRuntime().hasRequiresUnifiedSharedMemory())) &&
          "Expected link clause OR to clause with unified memory enabled.");
   QualType PtrTy = CGF.getContext().getPointerType(VD->getType());

--- a/clang/lib/CodeGen/CGOpenMPRuntime.cpp
+++ b/clang/lib/CodeGen/CGOpenMPRuntime.cpp
@@ -1529,6 +1529,7 @@ convertCaptureClause(const VarDecl *VD) {
     return llvm::OffloadEntriesInfoManager::OMPTargetGlobalVarEntryTo;
     break;
   case OMPDeclareTargetDeclAttr::MapTypeTy::MT_Enter:
+  case OMPDeclareTargetDeclAttr::MapTypeTy::MT_Local:
     return llvm::OffloadEntriesInfoManager::OMPTargetGlobalVarEntryEnter;
     break;
   case OMPDeclareTargetDeclAttr::MapTypeTy::MT_Link:
@@ -7980,7 +7981,8 @@ private:
                 OMPDeclareTargetDeclAttr::isDeclareTargetDeclaration(VD)) {
           if ((*Res == OMPDeclareTargetDeclAttr::MT_Link) ||
               ((*Res == OMPDeclareTargetDeclAttr::MT_To ||
-                *Res == OMPDeclareTargetDeclAttr::MT_Enter) &&
+                *Res == OMPDeclareTargetDeclAttr::MT_Enter ||
+                *Res == OMPDeclareTargetDeclAttr::MT_Local) &&
                CGF.CGM.getOpenMPRuntime().hasRequiresUnifiedSharedMemory())) {
             RequiresReference = true;
             BP = CGF.CGM.getOpenMPRuntime().getAddrOfDeclareTargetVar(VD);
@@ -11299,7 +11301,8 @@ bool CGOpenMPRuntime::emitTargetGlobalVariable(GlobalDecl GD) {
           cast<VarDecl>(GD.getDecl()));
   if (!Res || *Res == OMPDeclareTargetDeclAttr::MT_Link ||
       ((*Res == OMPDeclareTargetDeclAttr::MT_To ||
-        *Res == OMPDeclareTargetDeclAttr::MT_Enter) &&
+        *Res == OMPDeclareTargetDeclAttr::MT_Enter ||
+        *Res == OMPDeclareTargetDeclAttr::MT_Local) &&
        HasRequiresUnifiedSharedMemory)) {
     DeferredGlobalVariables.insert(cast<VarDecl>(GD.getDecl()));
     return true;
@@ -11369,13 +11372,15 @@ void CGOpenMPRuntime::emitDeferredTargetDecls() const {
     if (!Res)
       continue;
     if ((*Res == OMPDeclareTargetDeclAttr::MT_To ||
-         *Res == OMPDeclareTargetDeclAttr::MT_Enter) &&
+         *Res == OMPDeclareTargetDeclAttr::MT_Enter ||
+         *Res == OMPDeclareTargetDeclAttr::MT_Local) &&
         !HasRequiresUnifiedSharedMemory) {
       CGM.EmitGlobal(VD);
     } else {
       assert((*Res == OMPDeclareTargetDeclAttr::MT_Link ||
               ((*Res == OMPDeclareTargetDeclAttr::MT_To ||
-                *Res == OMPDeclareTargetDeclAttr::MT_Enter) &&
+                *Res == OMPDeclareTargetDeclAttr::MT_Enter ||
+                *Res == OMPDeclareTargetDeclAttr::MT_Local) &&
                HasRequiresUnifiedSharedMemory)) &&
              "Expected link clause or to clause with unified memory.");
       (void)CGM.getOpenMPRuntime().getAddrOfDeclareTargetVar(VD);

--- a/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/clang/lib/CodeGen/CodeGenModule.cpp
@@ -4407,13 +4407,15 @@ void CodeGenModule::EmitGlobal(GlobalDecl GD) {
           bool UnifiedMemoryEnabled =
               getOpenMPRuntime().hasRequiresUnifiedSharedMemory();
           if ((*Res == OMPDeclareTargetDeclAttr::MT_To ||
-               *Res == OMPDeclareTargetDeclAttr::MT_Enter) &&
+               *Res == OMPDeclareTargetDeclAttr::MT_Enter ||
+               *Res == OMPDeclareTargetDeclAttr::MT_Local) &&
               !UnifiedMemoryEnabled) {
             (void)GetAddrOfGlobalVar(VD);
           } else {
             assert(((*Res == OMPDeclareTargetDeclAttr::MT_Link) ||
                     ((*Res == OMPDeclareTargetDeclAttr::MT_To ||
-                      *Res == OMPDeclareTargetDeclAttr::MT_Enter) &&
+                      *Res == OMPDeclareTargetDeclAttr::MT_Enter ||
+                      *Res == OMPDeclareTargetDeclAttr::MT_Local) &&
                      UnifiedMemoryEnabled)) &&
                    "Link clause or to clause with unified memory expected.");
             (void)getOpenMPRuntime().getAddrOfDeclareTargetVar(VD);

--- a/clang/lib/Parse/ParseOpenMP.cpp
+++ b/clang/lib/Parse/ParseOpenMP.cpp
@@ -1758,14 +1758,14 @@ parseOpenMPSimpleClause(Parser &P, OpenMPClauseKind Kind) {
 void Parser::ParseOMPDeclareTargetClauses(
     SemaOpenMP::DeclareTargetContextInfo &DTCI) {
   SourceLocation DeviceTypeLoc;
-  bool RequiresToOrLinkOrIndirectClause = false;
-  bool HasToOrLinkOrIndirectClause = false;
+  bool RequiresToLinkLocalOrIndirectClause = false;
+  bool HasToLinkLocalOrIndirectClause = false;
   while (Tok.isNot(tok::annot_pragma_openmp_end)) {
     OMPDeclareTargetDeclAttr::MapTypeTy MT = OMPDeclareTargetDeclAttr::MT_To;
     bool HasIdentifier = Tok.is(tok::identifier);
     if (HasIdentifier) {
-      // If we see any clause we need a to or link clause.
-      RequiresToOrLinkOrIndirectClause = true;
+      // If we see any clause we need a to, link, or local clause.
+      RequiresToLinkLocalOrIndirectClause = true;
       IdentifierInfo *II = Tok.getIdentifierInfo();
       StringRef ClauseName = II->getName();
       bool IsDeviceTypeClause =
@@ -1774,6 +1774,7 @@ void Parser::ParseOMPDeclareTargetClauses(
 
       bool IsIndirectClause = getLangOpts().OpenMP >= 51 &&
                               getOpenMPClauseKind(ClauseName) == OMPC_indirect;
+
       if (DTCI.Indirect && IsIndirectClause) {
         unsigned OMPVersion = Actions.getLangOpts().OpenMP;
         Diag(Tok, diag::err_omp_more_one_clause)
@@ -1781,9 +1782,9 @@ void Parser::ParseOMPDeclareTargetClauses(
             << getOpenMPClauseName(OMPC_indirect) << 0;
         break;
       }
-      bool IsToEnterOrLinkClause =
+      bool IsToEnterLinkOrLocalClause =
           OMPDeclareTargetDeclAttr::ConvertStrToMapTypeTy(ClauseName, MT);
-      assert((!IsDeviceTypeClause || !IsToEnterOrLinkClause) &&
+      assert((!IsDeviceTypeClause || !IsToEnterLinkOrLocalClause) &&
              "Cannot be both!");
 
       // Starting with OpenMP 5.2 the `to` clause has been replaced by the
@@ -1797,25 +1798,42 @@ void Parser::ParseOMPDeclareTargetClauses(
         break;
       }
 
-      if (!IsDeviceTypeClause && !IsIndirectClause &&
-          DTCI.Kind == OMPD_begin_declare_target) {
-        Diag(Tok, diag::err_omp_declare_target_unexpected_clause)
-            << ClauseName << (getLangOpts().OpenMP >= 51 ? 3 : 0);
-        break;
-      }
-      if (!IsDeviceTypeClause && !IsToEnterOrLinkClause && !IsIndirectClause) {
+      // The 'local' clause is only available in OpenMP 6.0.
+      if (getLangOpts().OpenMP < 60 && ClauseName == "local") {
         Diag(Tok, getLangOpts().OpenMP >= 52
                       ? diag::err_omp_declare_target_unexpected_clause_52
                       : diag::err_omp_declare_target_unexpected_clause)
             << ClauseName
-            << (getLangOpts().OpenMP >= 51
-                    ? 4
-                    : getLangOpts().OpenMP >= 50 ? 2 : 1);
+            << (getLangOpts().OpenMP >= 51   ? 4
+                : getLangOpts().OpenMP >= 50 ? 2
+                                             : 1);
         break;
       }
 
-      if (IsToEnterOrLinkClause || IsIndirectClause)
-        HasToOrLinkOrIndirectClause = true;
+      if (!IsDeviceTypeClause && !IsIndirectClause &&
+          DTCI.Kind == OMPD_begin_declare_target) {
+        Diag(Tok, getLangOpts().OpenMP >= 52
+                      ? diag::err_omp_declare_target_unexpected_clause_52
+                      : diag::err_omp_declare_target_unexpected_clause)
+            << ClauseName << (getLangOpts().OpenMP >= 51 ? 3 : 0);
+        break;
+      }
+
+      if (!IsDeviceTypeClause && !IsToEnterLinkOrLocalClause &&
+          !IsIndirectClause) {
+        Diag(Tok, getLangOpts().OpenMP >= 52
+                      ? diag::err_omp_declare_target_unexpected_clause_52
+                      : diag::err_omp_declare_target_unexpected_clause)
+            << ClauseName
+            << (getLangOpts().OpenMP > 52    ? 5
+                : getLangOpts().OpenMP >= 51 ? 4
+                : getLangOpts().OpenMP >= 50 ? 2
+                                             : 1);
+        break;
+      }
+
+      if (IsToEnterLinkOrLocalClause || IsIndirectClause)
+        HasToLinkLocalOrIndirectClause = true;
 
       if (IsIndirectClause) {
         if (!ParseOpenMPIndirectClause(DTCI, /*ParseOnly*/ false))
@@ -1892,14 +1910,14 @@ void Parser::ParseOMPDeclareTargetClauses(
   if (DTCI.Indirect && DTCI.DT != OMPDeclareTargetDeclAttr::DT_Any)
     Diag(DeviceTypeLoc, diag::err_omp_declare_target_indirect_device_type);
 
-  // For declare target require at least 'to' or 'link' to be present.
-  if (DTCI.Kind == OMPD_declare_target && RequiresToOrLinkOrIndirectClause &&
-      !HasToOrLinkOrIndirectClause)
-    Diag(DTCI.Loc,
-         getLangOpts().OpenMP >= 52
-             ? diag::err_omp_declare_target_missing_enter_or_link_clause
-             : diag::err_omp_declare_target_missing_to_or_link_clause)
-        << (getLangOpts().OpenMP >= 51 ? 1 : 0);
+  // declare target requires at least one clause.
+  if (DTCI.Kind == OMPD_declare_target && RequiresToLinkLocalOrIndirectClause &&
+      !HasToLinkLocalOrIndirectClause)
+    Diag(DTCI.Loc, diag::err_omp_declare_target_missing_required_clause)
+        << (getLangOpts().OpenMP >= 60   ? 3
+            : getLangOpts().OpenMP == 52 ? 2
+            : getLangOpts().OpenMP == 51 ? 1
+                                         : 0);
 
   SkipUntil(tok::annot_pragma_openmp_end, StopBeforeMatch);
 }

--- a/clang/lib/Sema/SemaOpenMP.cpp
+++ b/clang/lib/Sema/SemaOpenMP.cpp
@@ -24453,6 +24453,14 @@ void SemaOpenMP::ActOnOpenMPDeclareTargetName(
   if (getLangOpts().HIP)
     Diag(Loc, diag::warn_hip_omp_target_directives);
 
+  // 'local' is incompatible with 'device_type(host)' because 'local'
+  // variables exist only on the device.
+  if (MT == OMPDeclareTargetDeclAttr::MT_Local &&
+      DTCI.DT == OMPDeclareTargetDeclAttr::DT_Host) {
+    Diag(Loc, diag::err_omp_declare_target_local_host_only);
+    return;
+  }
+
   // Explicit declare target lists have precedence.
   const unsigned Level = -1;
 
@@ -24469,7 +24477,11 @@ void SemaOpenMP::ActOnOpenMPDeclareTargetName(
   }
   if (ActiveAttr && (*ActiveAttr)->getMapType() != MT &&
       (*ActiveAttr)->getLevel() == Level) {
-    Diag(Loc, diag::err_omp_declare_target_to_and_link) << ND;
+    Diag(Loc, diag::err_omp_declare_target_var_in_both_clauses)
+        << ND
+        << OMPDeclareTargetDeclAttr::ConvertMapTypeTyToStr(
+               (*ActiveAttr)->getMapType())
+        << OMPDeclareTargetDeclAttr::ConvertMapTypeTyToStr(MT);
     return;
   }
 
@@ -24483,6 +24495,11 @@ void SemaOpenMP::ActOnOpenMPDeclareTargetName(
     if (!IndirectE)
       IsIndirect = true;
   }
+  // FIXME: 'local' clause is not yet implemented in CodeGen. For now, it is
+  // treated as 'enter'. For host compilation, 'local' is a no-op.
+  if (MT == OMPDeclareTargetDeclAttr::MT_Local &&
+      getLangOpts().OpenMPIsTargetDevice)
+    Diag(Loc, diag::warn_omp_declare_target_local_not_implemented);
   auto *A = OMPDeclareTargetDeclAttr::CreateImplicit(
       getASTContext(), MT, DTCI.DT, IndirectE, IsIndirect, Level,
       SourceRange(Loc, Loc));
@@ -24508,7 +24525,8 @@ static void checkDeclInTargetContext(SourceLocation SL, SourceRange SR,
        SemaRef.getCurBlock() || SemaRef.getCurCapturedRegion()) &&
       VD->hasGlobalStorage()) {
     if (!MapTy || (*MapTy != OMPDeclareTargetDeclAttr::MT_To &&
-                   *MapTy != OMPDeclareTargetDeclAttr::MT_Enter)) {
+                   *MapTy != OMPDeclareTargetDeclAttr::MT_Enter &&
+                   *MapTy != OMPDeclareTargetDeclAttr::MT_Local)) {
       // OpenMP 5.0, 2.12.7 declare target Directive, Restrictions
       // If a lambda declaration and definition appears between a
       // declare target directive and the matching end declare target
@@ -24559,8 +24577,11 @@ void SemaOpenMP::checkDeclIsAllowedInOpenMPTarget(Expr *E, Decl *D,
   if (auto *FD = dyn_cast<FunctionDecl>(D)) {
     std::optional<OMPDeclareTargetDeclAttr::MapTypeTy> Res =
         OMPDeclareTargetDeclAttr::isDeclareTargetDeclaration(FD);
-    if (IdLoc.isValid() && Res && *Res == OMPDeclareTargetDeclAttr::MT_Link) {
-      Diag(IdLoc, diag::err_omp_function_in_link_clause);
+    if (IdLoc.isValid() && Res &&
+        (*Res == OMPDeclareTargetDeclAttr::MT_Link ||
+         *Res == OMPDeclareTargetDeclAttr::MT_Local)) {
+      Diag(IdLoc, diag::err_omp_function_in_target_clause_list)
+          << OMPDeclareTargetDeclAttr::ConvertMapTypeTyToStr(*Res);
       Diag(FD->getLocation(), diag::note_defined_here) << FD;
       return;
     }

--- a/clang/test/AST/dump.cpp
+++ b/clang/test/AST/dump.cpp
@@ -1,5 +1,6 @@
 // RUN: %clang_cc1 -verify -fopenmp -ast-dump %s | FileCheck %s -implicit-check-not=openmp_structured_block
 // RUN: %clang_cc1 -verify -fopenmp-simd -ast-dump %s | FileCheck %s -implicit-check-not=openmp_structured_block
+// RUN: %clang_cc1 -verify -fopenmp -fopenmp-version=60 -ast-dump %s | FileCheck %s --check-prefix=OMP60
 // expected-no-diagnostics
 
 int ga, gb;
@@ -72,7 +73,13 @@ void foo();
 // CHECK-NEXT:   |-OMPDeclareSimdDeclAttr {{.+}} <line:[[@LINE-4]]:1, col:34> Implicit BS_Inbranch
 // CHECK:        `-OMPDeclareSimdDeclAttr {{.+}} <line:[[@LINE-6]]:1, col:25> Implicit BS_Undefined
 
+// Beginning in OpenMP 5.2, this form began generating a warning that it
+// is deprecated and to use the 'begin declare target' form instead.
+#if _OPENMP <= 202011
 #pragma omp declare target
+#else
+#pragma omp begin declare target
+#endif // _OPENMP
 int bar() {
   int f;
   return f;
@@ -86,4 +93,22 @@ int bar() {
 // CHECK-NEXT:  | `-ReturnStmt {{.+}} <line:[[@LINE-8]]:3, col:10>
 // CHECK-NEXT:  |   `-ImplicitCastExpr {{.+}} <col:10> 'int' <LValueToRValue>
 // CHECK-NEXT:  |     `-DeclRefExpr {{.+}} <col:10> 'int' lvalue Var {{.+}} 'f' 'int'
-// CHECK-NEXT:  `-OMPDeclareTargetDeclAttr {{.+}} <line:75:21> Implicit MT_To DT_Any 1
+// CHECK-NEXT:  `-OMPDeclareTargetDeclAttr {{.+}} Implicit MT_To DT_Any 1
+
+#if _OPENMP >= 202411
+int v_enter;
+#pragma omp declare target enter(v_enter) device_type(nohost)
+int v_link;
+#pragma omp declare target link(v_link) device_type(host)
+int v_local;
+#pragma omp declare target local(v_local)
+#endif
+
+// OMP60:      FunctionDecl {{.+}} bar 'int ()'
+// OMP60:      `-OMPDeclareTargetDeclAttr {{.+}} Implicit MT_Enter DT_Any 1
+// OMP60:      VarDecl {{.+}} v_enter 'int'
+// OMP60-NEXT: `-OMPDeclareTargetDeclAttr {{.+}} Implicit MT_Enter DT_NoHost 4294967295
+// OMP60:      VarDecl {{.+}} v_link 'int'
+// OMP60-NEXT: `-OMPDeclareTargetDeclAttr {{.+}} Implicit MT_Link DT_Host 4294967295
+// OMP60:      VarDecl {{.+}} v_local 'int'
+// OMP60-NEXT: `-OMPDeclareTargetDeclAttr {{.+}} Implicit MT_Local DT_Any 4294967295

--- a/clang/test/OpenMP/declare_target_ast_print.cpp
+++ b/clang/test/OpenMP/declare_target_ast_print.cpp
@@ -4,7 +4,7 @@
 // RUN: %clang_cc1 -verify -fopenmp -fopenmp-version=50 -I %S/Inputs -ast-print %s | FileCheck %s --check-prefix=CHECK --check-prefix=OMP50
 // RUN: %clang_cc1 -verify -fopenmp -I %S/Inputs -ast-print %s | FileCheck %s --check-prefix=CHECK --check-prefix=OMP51
 // RUN: %clang_cc1 -verify -fopenmp -fopenmp-version=52 -I %S/Inputs -ast-print %s | FileCheck %s --check-prefix=CHECK --check-prefix=OMP52
-// RUN: %clang_cc1 -verify -fopenmp -fopenmp-version=60 -I %S/Inputs -ast-print %s | FileCheck %s --check-prefix=CHECK
+// RUN: %clang_cc1 -verify -fopenmp -fopenmp-version=60 -I %S/Inputs -ast-print %s | FileCheck %s --check-prefix=CHECK --check-prefix=OMP60
 
 // RUN: %clang_cc1 -fopenmp -fopenmp-version=50 -x c++ -std=c++11 -I %S/Inputs -emit-pch -o %t %s
 // RUN: %clang_cc1 -fopenmp -fopenmp-version=50 -std=c++11 -include-pch %t -I %S/Inputs -verify %s -ast-print | FileCheck %s --check-prefix=CHECK --check-prefix=OMP50
@@ -12,6 +12,8 @@
 // RUN: %clang_cc1 -fopenmp -std=c++11 -include-pch %t -I %S/Inputs -verify %s -ast-print | FileCheck %s --check-prefix=CHECK --check-prefix=OMP51
 // RUN: %clang_cc1 -fopenmp -fopenmp-version=52 -x c++ -std=c++11 -I %S/Inputs -emit-pch -o %t %s
 // RUN: %clang_cc1 -fopenmp -fopenmp-version=52 -std=c++11 -include-pch %t -I %S/Inputs -verify %s -ast-print | FileCheck %s --check-prefix=CHECK --check-prefix=OMP52
+// RUN: %clang_cc1 -fopenmp -fopenmp-version=60 -x c++ -std=c++11 -I %S/Inputs -emit-pch -o %t %s
+// RUN: %clang_cc1 -fopenmp -fopenmp-version=60 -std=c++11 -include-pch %t -I %S/Inputs -verify %s -ast-print | FileCheck %s --check-prefix=CHECK --check-prefix=OMP60
 
 // RUN: %clang_cc1 -verify -fopenmp-simd -I %S/Inputs -ast-print %s | FileCheck %s
 // RUN: %clang_cc1 -fopenmp-simd -x c++ -std=c++11 -I %S/Inputs -emit-pch -o %t %s
@@ -121,6 +123,41 @@ void xoo();
 // OMP52: #pragma omp end declare target
 
 }
+#endif // _OPENMP
+
+#if _OPENMP == 202411
+int l1;
+#pragma omp declare target local(l1) device_type(any)
+// OMP60: #pragma omp declare target local
+// OMP60: int l1;
+// OMP60: #pragma omp end declare target
+
+int l2;
+#pragma omp declare target device_type(nohost) local(l2)
+// OMP60: #pragma omp declare target device_type(nohost) local
+// OMP60: int l2;
+// OMP60: #pragma omp end declare target
+
+int l3;
+int a = 0;
+#pragma omp declare target local(l3) device_type(nohost) local(a)
+// OMP60: #pragma omp declare target device_type(nohost) local
+// OMP60: int l3;
+// OMP60: #pragma omp end declare target
+// OMP60: #pragma omp declare target device_type(nohost) local
+// OMP60: int a = 0;
+// OMP60: #pragma omp end declare target
+
+int b = 0, c = 0;
+#pragma omp declare target local(b,c)
+void zoo();
+// OMP60: #pragma omp declare target local
+// OMP60: int b = 0;
+// OMP60: #pragma omp end declare target
+// OMP60: #pragma omp declare target local
+// OMP60: int c = 0;
+// OMP60: #pragma omp end declare target
+// OMP60: void zoo();
 #endif // _OPENMP
 
 int out_decl_target = 0;
@@ -373,6 +410,13 @@ int x;
 // CHECK-NEXT: int x;
 // CHECK-NEXT: #pragma omp end declare target
 
+#if _OPENMP >= 202411
+int x_local;
+// OMP60: #pragma omp declare target local
+// OMP60-NEXT: int x_local;
+// OMP60-NEXT: #pragma omp end declare target
+#endif // _OPENMP
+
 int main (int argc, char **argv) {
   foo();
   foo_c();
@@ -388,6 +432,10 @@ int main (int argc, char **argv) {
 #endif
 
   #pragma omp declare target link(x)
+
+#if _OPENMP >= 202411
+  #pragma omp declare target local(x_local)
+#endif // _OPENMP
   return (0);
 }
 

--- a/clang/test/OpenMP/declare_target_messages.cpp
+++ b/clang/test/OpenMP/declare_target_messages.cpp
@@ -13,7 +13,7 @@
 // RUN: %clang_cc1 %{common_opts_mac} -verify=expected,omp5,ompvar,omp45-to-51,omp5-and-51,omp5-or-later,omp5-or-later-var,omp45-to-51-var,omp45-to-51-clause,host5,host-5-and-51,no-host5-and-51  %{openmp50} %{target_mac} %{limit} -o - %s
 // RUN: %clang_cc1 %{common_opts_mac} -verify=expected,omp60,omp52-or-later,ompvar,omp5-or-later,omp5-or-later-var  %{openmp60} %{target_mac} %{limit} -o - %s
 // RUN: %clang_cc1 %{common_opts_mac} -verify=expected,omp5,ompvar,omp45-to-51,omp5-and-51,omp5-or-later,omp5-or-later-var,omp45-to-51-var,omp45-to-51-clause,host-5-and-51,no-host5-and-51,dev5  %{openmp50} -fopenmp-is-target-device %{target_mac} %{aux_triple} %{limit} -o - %s
-// RUN: %clang_cc1 %{common_opts_mac} -verify=expected,omp60,omp52-or-later,ompvar,omp5-or-later,omp5-or-later-var %{openmp60} -fopenmp-is-target-device %{target_mac} %{aux_triple} %{limit} -o - %s
+// RUN: %clang_cc1 %{common_opts_mac} -verify=expected,omp60,dev60,omp52-or-later,ompvar,omp5-or-later,omp5-or-later-var %{openmp60} -fopenmp-is-target-device %{target_mac} %{aux_triple} %{limit} -o - %s
 
 // RUN: %clang_cc1 %{common_opts_mac} -verify=expected,omp5,ompvar,omp45-to-51,omp5-and-51,omp5-or-later,omp5-or-later-var,omp45-to-51-var,omp45-to-51-clause,host5,host-5-and-51,no-host5-and-51 %{openmp50_simd} %{target_mac} %{limit} -o - %s
 // RUN: %clang_cc1 %{common_opts_mac} -verify=expected,omp60,omp52-or-later,ompvar,omp5-or-later,omp5-or-later-var %{openmp60_simd} %{target_mac} %{limit} -o - %s
@@ -61,8 +61,8 @@ void f();
 // omp45-to-51-warning@+1 {{extra tokens at the end of '#pragma omp end declare target' are ignored}}
 #pragma omp end declare target shared(a) 
 
-// omp60-error@+10 {{unexpected 'map' clause, only 'enter', 'link', 'device_type' or 'indirect' clauses expected}}
-// omp60-error@+9 {{expected at least one 'enter', 'link' or 'indirect' clause}}
+// omp60-error@+10 {{unexpected 'map' clause, only 'enter', 'link', 'device_type', 'indirect' or 'local' clauses expected}}
+// omp60-error@+9 {{expected at least one 'enter', 'link', 'indirect' or 'local' clause}}
 // omp52-error@+8 {{unexpected 'map' clause, only 'enter', 'link', 'device_type' or 'indirect' clauses expected}}
 // omp52-error@+7 {{expected at least one 'enter', 'link' or 'indirect' clause}}
 // omp51-error@+6 {{unexpected 'map' clause, only 'to', 'link', 'device_type' or 'indirect' clauses expected}} 
@@ -74,7 +74,7 @@ void f();
 #pragma omp declare target map(a)
 
 // omp60-error@+5 {{unexpected 'to' clause, use 'enter' instead}}
-// omp60-error@+4 {{expected at least one 'enter', 'link' or 'indirect' clause}}
+// omp60-error@+4 {{expected at least one 'enter', 'link', 'indirect' or 'local' clause}}
 // omp52-error@+3 {{unexpected 'to' clause, use 'enter' instead}}
 // omp52-error@+2 {{expected at least one 'enter', 'link' or 'indirect' clause}}
 // omp45-to-51-error@+1 {{use of undeclared identifier 'foo1'}}
@@ -83,8 +83,13 @@ void f();
 // expected-error@+1 {{use of undeclared identifier 'foo2'}}
 #pragma omp declare target link(foo2) 
 
+#if _OPENMP == 202411
+// omp60-error@+1 {{use of undeclared identifier 'foo3'}}
+#pragma omp declare target local(foo3) 
+#endif // _OPENMP
+
 // omp60-error@+6 {{unexpected 'to' clause, use 'enter' instead}}
-// omp60-error@+5 {{expected at least one 'enter', 'link' or 'indirect' clause}}
+// omp60-error@+5 {{expected at least one 'enter', 'link', 'indirect' or 'local' clause}}
 // omp52-error@+4 {{unexpected 'to' clause, use 'enter' instead}}
 // omp52-error@+3 {{expected at least one 'enter', 'link' or 'indirect' clause}}
 // dev5-note@+2 {{marked as 'device_type(host)' here}}
@@ -92,8 +97,10 @@ void f();
 #pragma omp declare target to(f) device_type(host)
 
 void q();
-// omp52-or-later-error@+4 {{unexpected 'to' clause, use 'enter' instead}}
-// omp52-or-later-error@+3 {{expected at least one 'enter', 'link' or 'indirect' clause}}
+// omp60-error@+6 {{unexpected 'to' clause, use 'enter' instead}}
+// omp60-error@+5 {{expected at least one 'enter', 'link', 'indirect' or 'local' clause}}
+// omp52-error@+4 {{unexpected 'to' clause, use 'enter' instead}}
+// omp52-error@+3 {{expected at least one 'enter', 'link' or 'indirect' clause}}
 // omp5-and-51-warning@+2 {{more than one 'device_type' clause is specified}}
 // omp45-error@+1 {{unexpected 'device_type' clause, only 'to' or 'link' clauses expected}}
 #pragma omp declare target to(q) device_type(any) device_type(any) device_type(host) 
@@ -133,12 +140,23 @@ void c();
 // expected-note@+1 {{'func' defined here}}
 void func() {} 
 
-// omp52-or-later-error@+5 {{unexpected 'allocate' clause, only 'enter', 'link', 'device_type' or 'indirect' clauses expected}}
+// omp60-error@+6 {{unexpected 'allocate' clause, only 'enter', 'link', 'device_type', 'indirect' or 'local' clauses expected}}
+// omp52-error@+5 {{unexpected 'allocate' clause, only 'enter', 'link', 'device_type' or 'indirect' clauses expected}}
 // omp51-error@+4 {{unexpected 'allocate' clause, only 'to', 'link', 'device_type' or 'indirect' clauses expected}}
 // omp5-error@+3 {{unexpected 'allocate' clause, only 'to', 'link' or 'device_type' clauses expected}}
 // expected-error@+2 {{function name is not allowed in 'link' clause}}
 // omp45-error@+1 {{unexpected 'allocate' clause, only 'to' or 'link' clauses expected}}
 #pragma omp declare target link(func) allocate(a)
+
+#if _OPENMP == 202411
+// expected-note@+1 {{'func_local' defined here}}
+void func_local() {} 
+
+// dev60-warning@+3 {{'local' clause on 'declare_target' directive is not yet fully implemented; variable will be treated as 'enter'}}
+// omp60-error@+2 {{unexpected 'allocate' clause, only 'enter', 'link', 'device_type', 'indirect' or 'local' clauses expected}}
+// expected-error@+1 {{function name is not allowed in 'local' clause}}
+#pragma omp declare target local(func_local) allocate(a)
+#endif // _OPENMP
 
 void bar();
 void baz() {bar();}
@@ -282,11 +300,13 @@ int main (int argc, char **argv) {
 #pragma omp end declare target 
   foo(v);
 
-  // omp52-or-later-error@+2 {{expected at least one 'enter', 'link' or 'indirect' clause}}
+  // omp60-error@+3 {{expected at least one 'enter', 'link', 'indirect' or 'local' clause}}
+  // omp52-error@+2 {{expected at least one 'enter', 'link' or 'indirect' clause}}
   // omp52-or-later-error@+1 {{unexpected 'to' clause, use 'enter' instead}}
 #pragma omp declare target to(foo3) link(w)
+  // omp60-error@+4 {{expected at least one 'enter', 'link', 'indirect' or 'local' clause}}
   // omp52-or-later-error@+3 {{unexpected 'to' clause, use 'enter' instead}}
-  // omp52-or-later-error@+2 {{expected at least one 'enter', 'link' or 'indirect' clause}}
+  // omp52-error@+2 {{expected at least one 'enter', 'link' or 'indirect' clause}}
   // omp45-to-51-var-error@+1 {{local variable 'a' should not be used in 'declare target' directive}}
 #pragma omp declare target to(a) 
   return (0);
@@ -301,50 +321,114 @@ namespace {
 // expected-error@+1 {{'S' used in declare target directive is not a variable or a function name}}
 #pragma omp declare target link(S) 
 
+#if _OPENMP == 202411
+// omp60-error@+1 {{'S' used in declare target directive is not a variable or a function name}}
+#pragma omp declare target local(S)
+
+int x_local;
+// expected-error@+1 {{'x_local' appears multiple times in clauses on the same declare target directive}}
+#pragma omp declare target enter(x_local) local(x_local)
+
+int y_enter_local;
+#pragma omp declare target enter(y_enter_local)
+// expected-error@+1 {{'y_enter_local' must not appear in both clauses 'enter' and 'local'}}
+#pragma omp declare target local(y_enter_local)
+
+int y_local_enter;
+// dev60-warning@+1 {{'local' clause on 'declare_target' directive is not yet fully implemented; variable will be treated as 'enter'}}
+#pragma omp declare target local(y_local_enter)
+// expected-error@+1 {{'y_local_enter' must not appear in both clauses 'local' and 'enter'}}
+#pragma omp declare target enter(y_local_enter)
+
+int y_link_local;
+#pragma omp declare target link(y_link_local)
+// expected-error@+1 {{'y_link_local' must not appear in both clauses 'link' and 'local'}}
+#pragma omp declare target local(y_link_local)
+
+int y_local_link;
+// dev60-warning@+1 {{'local' clause on 'declare_target' directive is not yet fully implemented; variable will be treated as 'enter'}}
+#pragma omp declare target local(y_local_link)
+// expected-error@+1 {{'y_local_link' must not appear in both clauses 'local' and 'link'}}
+#pragma omp declare target link(y_local_link)
+
+int y_local_dev;
+// omp60-error@+1 {{'local' clause is incompatible with 'device_type(host)'; local variables exist only on the device}}
+#pragma omp declare_target local(y_local_dev) device_type(host)
+#endif // _OPENMP
+
 // expected-error@+1 {{'x' appears multiple times in clauses on the same declare target directive}}
 #pragma omp declare target (x, x) 
+
+// omp52-or-later-error@+2 {{unexpected clause after an implicit 'enter' clause}}
+// omp45-to-51-error@+1 {{unexpected clause after an implicit 'to' clause}}
+#pragma omp declare target (x) local(x)
+
+// omp60-error@+4 {{expected at least one 'enter', 'link', 'indirect' or 'local' clause}}
 // omp52-or-later-error@+3 {{unexpected 'to' clause, use 'enter' instead}}
-// omp52-or-later-error@+2 {{expected at least one 'enter', 'link' or 'indirect' clause}}
+// omp52-error@+2 {{expected at least one 'enter', 'link' or 'indirect' clause}}
 // omp45-to-51-clause-error@+1 {{'x' appears multiple times in clauses on the same declare target directive}}
 #pragma omp declare target to(x) to(x)
 // expected-error@+1 {{'x' must not appear in both clauses 'to' and 'link'}}
 #pragma omp declare target link(x) 
 
+#if defined(_OPENMP) && _OPENMP < 202111
+int y_link_to;
+#pragma omp declare target link(y_link_to)
+// omp45-to-51-error@+1 {{'y_link_to' must not appear in both clauses 'link' and 'to'}}
+#pragma omp declare target to(y_link_to)
+#elif defined(_OPENMP) && _OPENMP >= 202111
+int y_link_enter;
+#pragma omp declare target link(y_link_enter)
+// omp52-or-later-error@+1 {{'y_link_enter' must not appear in both clauses 'link' and 'enter'}}
+#pragma omp declare target enter(y_link_enter)
+
+int y_enter_link;
+#pragma omp declare target enter(y_enter_link)
+// omp52-or-later-error@+1 {{'y_enter_link' must not appear in both clauses 'enter' and 'link'}}
+#pragma omp declare target link(y_enter_link)
+#endif
+
 void bazz() {}
+// omp60-error@+5 {{expected at least one 'enter', 'link', 'indirect' or 'local' clause}}
 // omp52-or-later-error@+4 {{unexpected 'to' clause, use 'enter' instead}}
-// omp52-or-later-error@+3 {{expected at least one 'enter', 'link' or 'indirect' clause}}
+// omp52-error@+3 {{expected at least one 'enter', 'link' or 'indirect' clause}}
 // host5-note@+2 3 {{marked as 'device_type(nohost)' here}}
 // omp45-error@+1 {{unexpected 'device_type' clause, only 'to' or 'link' clauses expected}} 
 #pragma omp declare target to(bazz) device_type(nohost)
 void bazzz() {bazz();}
+// omp60-error@+4 {{expected at least one 'enter', 'link', 'indirect' or 'local' clause}}
 // omp52-or-later-error@+3 {{unexpected 'to' clause, use 'enter' instead}}
-// omp52-or-later-error@+2 {{expected at least one 'enter', 'link' or 'indirect' clause}}
+// omp52-error@+2 {{expected at least one 'enter', 'link' or 'indirect' clause}}
 // omp45-error@+1 {{unexpected 'device_type' clause, only 'to' or 'link' clauses expected}}
 #pragma omp declare target to(bazzz) device_type(nohost) 
 // host5-error@+1 {{function with 'device_type(nohost)' is not available on host}}
 void any() {bazz();} 
 // host5-error@+1 {{function with 'device_type(nohost)' is not available on host}}
 void host1() {bazz();}
+// omp60-error@+5 {{expected at least one 'enter', 'link', 'indirect' or 'local' clause}}
 // omp52-or-later-error@+4 {{unexpected 'to' clause, use 'enter' instead}}
-// omp52-or-later-error@+3 {{expected at least one 'enter', 'link' or 'indirect' clause}}
+// omp52-error@+3 {{expected at least one 'enter', 'link' or 'indirect' clause}}
 // dev5-note@+2 3 {{marked as 'device_type(host)' here}}
 // omp45-error@+1 {{unexpected 'device_type' clause, only 'to' or 'link' clauses expected}}
 #pragma omp declare target to(host1) device_type(host)
 //host5-error@+1 {{function with 'device_type(nohost)' is not available on host}}
 void host2() {bazz();}
+// omp60-error@+3 {{expected at least one 'enter', 'link', 'indirect' or 'local' clause}}
 // omp52-or-later-error@+2 {{unexpected 'to' clause, use 'enter' instead}}
-// omp52-or-later-error@+1 {{expected at least one 'enter', 'link' or 'indirect' clause}}
+// omp52-error@+1 {{expected at least one 'enter', 'link' or 'indirect' clause}}
 #pragma omp declare target to(host2) 
 // dev5-error@+1 {{function with 'device_type(host)' is not available on device}}
 void device() {host1();}
+// omp60-error@+5 {{expected at least one 'enter', 'link', 'indirect' or 'local' clause}}
 // omp52-or-later-error@+4 {{unexpected 'to' clause, use 'enter' instead}}
-// omp52-or-later-error@+3 {{expected at least one 'enter', 'link' or 'indirect' clause}}
+// omp52-error@+3 {{expected at least one 'enter', 'link' or 'indirect' clause}}
 // host5-note@+2 2 {{marked as 'device_type(nohost)' here}} 
 // omp45-error@+1 {{unexpected 'device_type' clause, only 'to' or 'link' clauses expected}}
 #pragma omp declare target to(device) device_type(nohost)
 void host3() {host1();} // dev5-error {{function with 'device_type(host)' is not available on device}}
+// omp60-error@+3 {{expected at least one 'enter', 'link', 'indirect' or 'local' clause}}
 // omp52-or-later-error@+2 {{unexpected 'to' clause, use 'enter' instead}}
-// omp52-or-later-error@+1 {{expected at least one 'enter', 'link' or 'indirect' clause}}
+// omp52-error@+1 {{expected at least one 'enter', 'link' or 'indirect' clause}}
 #pragma omp declare target to(host3)
 
 #pragma omp begin declare target
@@ -363,20 +447,35 @@ void any7() {device();}
 void any8() {any2();}
 
 int MultiDevTy;
+// omp60-error@+4 {{expected at least one 'enter', 'link', 'indirect' or 'local' clause}}
 // omp52-or-later-error@+3 {{unexpected 'to' clause, use 'enter' instead}}
-// omp52-or-later-error@+2 {{expected at least one 'enter', 'link' or 'indirect' clause}}
+// omp52-error@+2 {{expected at least one 'enter', 'link' or 'indirect' clause}}
 // omp45-error@+1 {{unexpected 'device_type' clause, only 'to' or 'link' clauses expected}}
 #pragma omp declare target to(MultiDevTy) device_type(any)
+// omp60-error@+5 {{expected at least one 'enter', 'link', 'indirect' or 'local' clause}}
 // omp52-or-later-error@+4 {{unexpected 'to' clause, use 'enter' instead}}
-// omp52-or-later-error@+3 {{expected at least one 'enter', 'link' or 'indirect' clause}}
+// omp52-error@+3 {{expected at least one 'enter', 'link' or 'indirect' clause}}
 // host-5-and-51-error@+2 {{'device_type(host)' does not match previously specified 'device_type(any)' for the same declaration}}
 // omp45-error@+1 {{unexpected 'device_type' clause, only 'to' or 'link' clauses expected}}
 #pragma omp declare target to(MultiDevTy) device_type(host)
+// omp60-error@+5 {{expected at least one 'enter', 'link', 'indirect' or 'local' clause}}
 // omp52-or-later-error@+4 {{unexpected 'to' clause, use 'enter' instead}}
-// omp52-or-later-error@+3 {{expected at least one 'enter', 'link' or 'indirect' clause}}
+// omp52-error@+3 {{expected at least one 'enter', 'link' or 'indirect' clause}}
 // no-host5-and-51-error@+2 {{'device_type(nohost)' does not match previously specified 'device_type(any)' for the same declaration}}
 // omp45-error@+1 {{unexpected 'device_type' clause, only 'to' or 'link' clauses expected}}
 #pragma omp declare target to(MultiDevTy) device_type(nohost)
+
+int counter = 0;
+// dev60-warning@+9 {{'local' clause on 'declare_target' directive is not yet fully implemented; variable will be treated as 'enter'}}
+// omp52-error@+8 {{unexpected 'local' clause, only 'enter', 'link', 'device_type' or 'indirect' clauses expected}}
+// omp52-error@+7 {{expected at least one 'enter', 'link' or 'indirect' clause}}
+// omp51-error@+6 {{unexpected 'local' clause, only 'to', 'link', 'device_type' or 'indirect' clauses expected}}
+// omp51-error@+5 {{expected at least one 'to', 'link' or 'indirect' clause}}
+// omp5-error@+4 {{expected at least one 'to' or 'link' clause}} 
+// omp5-error@+3 {{unexpected 'local' clause, only 'to', 'link' or 'device_type' clauses expected}}
+// omp45-error@+2 {{expected at least one 'to' or 'link' clause}} 
+// omp45-error@+1 {{unexpected 'local' clause, only 'to' or 'link' clauses expected}}
+#pragma omp declare target local(counter)
 
 // expected-warning@+1 {{declaration is not declared in any declare target region}}
 static int variable = 100; 

--- a/llvm/include/llvm/Frontend/OpenMP/OMP.td
+++ b/llvm/include/llvm/Frontend/OpenMP/OMP.td
@@ -829,6 +829,7 @@ def OMP_DeclareTarget : Directive<[Spelling<"declare target", 1, 52>,
     VersionedClause<OMPC_Enter, 52>,
     VersionedClause<OMPC_Indirect, 51>,
     VersionedClause<OMPC_Link>,
+    VersionedClause<OMPC_Local, 60>,
     VersionedClause<OMPC_To>,
   ];
   let allowedOnceClauses = [


### PR DESCRIPTION
Parse and perform semantic checks for declare_target 'local' clause. When compiling for device offloading, generate a warning that 'local' is not yet fully supported. On the host, 'local' is/will be a no-op, so no warning is generated.

NOTE: The minimal CodeGen changes allow 'local' to flow through as equivalent to the 'enter' clause after warning is generated.

Testing:
  - Updated messages and ast tests for declare target/declare_target
  - ninja check-all.