### PR TITLE
[lldb] Wrap HWCAP defines in ifndef (NFC)

### DIFF
--- a/lldb/source/Plugins/Process/Linux/NativeRegisterContextLinux_arm64.cpp
+++ b/lldb/source/Plugins/Process/Linux/NativeRegisterContextLinux_arm64.cpp
@@ -73,15 +73,25 @@
 #define NT_ARM_GCS 0x410 /* Guarded Control Stack control registers */
 #endif
 
+#ifndef HWCAP_PACA
 #define HWCAP_PACA (1 << 30)
+#endif
 
+#ifndef HWCAP_GCS
 #define HWCAP_GCS (1UL << 32)
+#endif
 
+#ifndef HWCAP2_MTE
 #define HWCAP2_MTE (1 << 18)
+#endif
 
+#ifndef HWCAP2_FPMR
 #define HWCAP2_FPMR (1UL << 48)
+#endif
 
+#ifndef HWCAP2_POE
 #define HWCAP2_POE (1ULL << 63)
+#endif
 
 using namespace lldb;
 using namespace lldb_private;


### PR DESCRIPTION
Fixes a redefinition warning on Ubuntu 25.10 coming from `ptrace.h` including `hwcap.h`.

```
/home/jonas/llvm/llvm-project/lldb/source/Plugins/Process/Linux/NativeRegisterContextLinux_arm64.cpp:84:9: warning: ‘HWCAP2_POE’ redefined
   84 | #define HWCAP2_POE (1ULL << 63)
      |         ^~~~~~~~~~
In file included from /usr/include/aarch64-linux-gnu/asm/ptrace.h:25,
                 from /home/jonas/llvm/llvm-project/lldb/source/Plugins/Process/Linux/NativeRegisterContextLinux_arm64.h:19,
                 from /home/jonas/llvm/llvm-project/lldb/source/Plugins/Process/Linux/NativeRegisterContextLinux_arm64.cpp:11:
/usr/include/aarch64-linux-gnu/asm/hwcap.h:141:9: note: this is the location of the previous definition
  141 | #define kkk              (1UL << 63)
      |         ^~~~~~~~~~
```