### PR TITLE
[CIR] Implement abstract conditional operator handling for aggregates

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenExprAggregate.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprAggregate.cpp
@@ -348,8 +348,60 @@ public:
     VisitInitListExpr(e->getUpdater());
   }
   void VisitAbstractConditionalOperator(const AbstractConditionalOperator *e) {
-    cgf.cgm.errorNYI(e->getSourceRange(),
-                     "AggExprEmitter: VisitAbstractConditionalOperator");
+    mlir::Location loc = cgf.getLoc(e->getSourceRange());
+
+    CIRGenFunction::OpaqueValueMapping binding(cgf, e);
+    CIRGenFunction::ConditionalEvaluation eval(cgf);
+
+    // Save whether the destination's lifetime is externally managed.
+    bool isExternallyDestructed = dest.isExternallyDestructed();
+    bool destructNonTrivialCStruct =
+        !isExternallyDestructed &&
+        e->getType().isDestructedType() == QualType::DK_nontrivial_c_struct;
+    isExternallyDestructed |= destructNonTrivialCStruct;
+
+    cgf.emitIfOnBoolExpr(
+        e->getCond(),
+        /*thenBuilder=*/
+        [&](mlir::OpBuilder &b, mlir::Location loc) {
+          eval.beginEvaluation();
+          {
+            CIRGenFunction::LexicalScope lexScope{cgf, loc,
+                                                  b.getInsertionBlock()};
+            cgf.curLexScope->setAsTernary();
+            dest.setExternallyDestructed(isExternallyDestructed);
+            assert(!cir::MissingFeatures::incrementProfileCounter());
+            Visit(e->getTrueExpr());
+            cir::YieldOp::create(b, loc);
+          }
+          eval.endEvaluation();
+        },
+        loc,
+        /*elseBuilder=*/
+        [&](mlir::OpBuilder &b, mlir::Location loc) {
+          eval.beginEvaluation();
+          {
+            CIRGenFunction::LexicalScope lexScope{cgf, loc,
+                                                  b.getInsertionBlock()};
+            cgf.curLexScope->setAsTernary();
+
+            // If the result of an agg expression is unused, then the emission
+            // of the LHS might need to create a destination slot. That's fine
+            // with us, and we can safely emit the RHS into the same slot, but
+            // we shouldn't claim that it's already being destructed.
+            dest.setExternallyDestructed(isExternallyDestructed);
+            assert(!cir::MissingFeatures::incrementProfileCounter());
+            Visit(e->getFalseExpr());
+            cir::YieldOp::create(b, loc);
+          }
+          eval.endEvaluation();
+        },
+        loc);
+
+    if (destructNonTrivialCStruct)
+      cgf.cgm.errorNYI(
+          e->getSourceRange(),
+          "Abstract conditional aggregate: destructNonTrivialCStruct");
   }
   void VisitChooseExpr(const ChooseExpr *e) { Visit(e->getChosenSubExpr()); }
   void VisitCXXParenListInitExpr(CXXParenListInitExpr *e) {

--- a/clang/test/CIR/CodeGen/abstract-cond.c
+++ b/clang/test/CIR/CodeGen/abstract-cond.c
@@ -7,11 +7,11 @@
 
 // ?: in "lvalue"
 struct s6 { int f0; };
-int f6(int a0, struct s6 a1, struct s6 a2) {
+int test_agg_cond(int a0, struct s6 a1, struct s6 a2) {
   return (a0 ? a1 : a2).f0;
 }
 
-// CIR: cir.func {{.*}} @f6
+// CIR: cir.func {{.*}} @test_agg_cond
 // CIR:  %[[A0:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["a0"
 // CIR:  %[[A1:.*]] = cir.alloca !rec_s6, !cir.ptr<!rec_s6>, ["a1"
 // CIR:  %[[A2:.*]] = cir.alloca !rec_s6, !cir.ptr<!rec_s6>, ["a2"
@@ -26,7 +26,7 @@ int f6(int a0, struct s6 a1, struct s6 a2) {
 // CIR:    }
 // CIR:    cir.get_member %[[TMP]][0] {name = "f0"} : !cir.ptr<!rec_s6> -> !cir.ptr<!s32i>
 
-// LLVM: define {{.*}} i32 @f6
+// LLVM: define {{.*}} i32 @test_agg_cond
 // LLVM:    %[[LOAD_A0:.*]] = load i32, ptr {{.*}}
 // LLVM:    %[[COND:.*]] = icmp ne i32 %[[LOAD_A0]], 0
 // LLVM:    br i1 %[[COND]], label %[[A1_PATH:.*]], label %[[A2_PATH:.*]]
@@ -39,7 +39,7 @@ int f6(int a0, struct s6 a1, struct s6 a2) {
 // LLVM:  [[EXIT]]:
 // LLVM:    getelementptr {{.*}}, ptr %[[TMP]], i32 0, i32 0
 
-// OGCG: define {{.*}} i32 @f6
+// OGCG: define {{.*}} i32 @test_agg_cond
 // OGCG:    %[[LOAD_A0:.*]] = load i32, ptr {{.*}}
 // OGCG:    %[[COND:.*]] = icmp ne i32 %[[LOAD_A0]], 0
 // OGCG:    br i1 %[[COND]], label %[[A1_PATH:.*]], label %[[A2_PATH:.*]]
@@ -47,6 +47,69 @@ int f6(int a0, struct s6 a1, struct s6 a2) {
 // OGCG:    call void @llvm.memcpy.p0.p0.i64(ptr {{.*}} %[[TMP:.*]], ptr {{.*}}, i64 4, i1 false)
 // OGCG:    br label %[[EXIT:.*]]
 // OGCG:  [[A2_PATH]]:
+// OGCG:    call void @llvm.memcpy.p0.p0.i64(ptr {{.*}} %[[TMP]], ptr {{.*}}, i64 4, i1 false)
+// OGCG:    br label %[[EXIT]]
+// OGCG:  [[EXIT]]:
+// OGCG:    getelementptr {{.*}}, ptr %[[TMP]], i32 0, i32 0
+
+void foo(void);
+int test_stmt_expr(int flag, struct s6 a1, struct s6 a2) {
+  return (flag
+            ? ({ struct s6 t = a1; foo(); t; })   // statement expression arm
+            : a2)
+      .f0;
+}
+
+// CIR: cir.func {{.*}} @test_stmt_expr
+// CIR:  %[[FLAG:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["flag"
+// CIR:  %[[A1:.*]] = cir.alloca !rec_s6, !cir.ptr<!rec_s6>, ["a1"
+// CIR:  %[[A2:.*]] = cir.alloca !rec_s6, !cir.ptr<!rec_s6>, ["a2"
+// CIR:  cir.scope {
+// CIR:    %[[TMP:.*]] = cir.alloca !rec_s6, !cir.ptr<!rec_s6>, ["ref.tmp0"]
+// CIR:    %[[LOAD_FLAG:.*]] = cir.load{{.*}} %[[FLAG]] : !cir.ptr<!s32i>, !s32i
+// CIR:    %[[COND:.*]] = cir.cast int_to_bool %[[LOAD_FLAG]] : !s32i -> !cir.bool
+// CIR:    cir.if %[[COND]] {
+// CIR:      %[[STMT_TMP:.*]] = cir.alloca !rec_s6, !cir.ptr<!rec_s6>, ["tmp"]
+// CIR:      cir.scope {
+// CIR:        %[[T:.*]] = cir.alloca !rec_s6, !cir.ptr<!rec_s6>, ["t", init]
+// CIR:        cir.copy %[[A1]] to %[[T]] : !cir.ptr<!rec_s6>
+// CIR:        cir.call @foo() : () -> ()
+// CIR:        cir.copy %[[T]] to %[[TMP]] : !cir.ptr<!rec_s6>
+// CIR:      }
+// CIR:    } else {
+// CIR:      cir.copy %[[A2]] to %[[TMP]] : !cir.ptr<!rec_s6>
+// CIR:    }
+// CIR:    cir.get_member %[[TMP]][0] {name = "f0"} : !cir.ptr<!rec_s6> -> !cir.ptr<!s32i>
+
+// LLVM: define {{.*}} i32 @test_stmt_expr
+// LLVM:    %[[LOAD_FLAG:.*]] = load i32, ptr {{.*}}
+// LLVM:    %[[COND:.*]] = icmp ne i32 %[[LOAD_FLAG]], 0
+// LLVM:    br i1 %[[COND]], label %[[TRUE:.*]], label %[[FALSE:.*]]
+// LLVM:  [[TRUE]]:
+// LLVM:    br label %[[STMT_BODY:.*]]
+// LLVM:  [[STMT_BODY]]:
+// LLVM:    call void @llvm.memcpy.p0.p0.i64(ptr %[[T:.*]], ptr {{.*}}, i64 4, i1 false)
+// LLVM:    call void @foo()
+// LLVM:    call void @llvm.memcpy.p0.p0.i64(ptr %[[TMP:.*]], ptr %[[T]], i64 4, i1 false)
+// LLVM:    br label %[[JOIN_FROM_TRUE:.*]]
+// LLVM:  [[JOIN_FROM_TRUE]]:
+// LLVM:    br label %[[EXIT:.*]]
+// LLVM:  [[FALSE]]:
+// LLVM:    call void @llvm.memcpy.p0.p0.i64(ptr %[[TMP]], ptr {{.*}}, i64 4, i1 false)
+// LLVM:    br label %[[EXIT]]
+// LLVM:  [[EXIT]]:
+// LLVM:    getelementptr %struct.s6, ptr %[[TMP]], i32 0, i32 0
+
+// OGCG: define {{.*}} i32 @test_stmt_expr
+// OGCG:    %[[LOAD_FLAG:.*]] = load i32, ptr {{.*}}
+// OGCG:    %[[COND:.*]] = icmp ne i32 %[[LOAD_FLAG]], 0
+// OGCG:    br i1 %[[COND]], label %[[TRUE:.*]], label %[[FALSE:.*]]
+// OGCG:  [[TRUE]]:
+// OGCG:    call void @llvm.memcpy.p0.p0.i64(ptr {{.*}} %[[T:.*]], ptr {{.*}}, i64 4, i1 false)
+// OGCG:    call void @foo()
+// OGCG:    call void @llvm.memcpy.p0.p0.i64(ptr {{.*}} %[[TMP:.*]], ptr {{.*}} %[[T]], i64 4, i1 false)
+// OGCG:    br label %[[EXIT:.*]]
+// OGCG:  [[FALSE]]:
 // OGCG:    call void @llvm.memcpy.p0.p0.i64(ptr {{.*}} %[[TMP]], ptr {{.*}}, i64 4, i1 false)
 // OGCG:    br label %[[EXIT]]
 // OGCG:  [[EXIT]]:

--- a/clang/test/CIR/CodeGen/abstract-cond.c
+++ b/clang/test/CIR/CodeGen/abstract-cond.c
@@ -1,0 +1,53 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o %t.cir
+// RUN: FileCheck --check-prefix=CIR --input-file=%t.cir %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o %t-cir.ll
+// RUN: FileCheck --check-prefix=LLVM --input-file=%t-cir.ll %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -emit-llvm %s -o %t.ll
+// RUN: FileCheck --check-prefix=OGCG --input-file=%t.ll %s
+
+// ?: in "lvalue"
+struct s6 { int f0; };
+int f6(int a0, struct s6 a1, struct s6 a2) {
+  return (a0 ? a1 : a2).f0;
+}
+
+// CIR: cir.func {{.*}} @f6
+// CIR:  %[[A0:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["a0"
+// CIR:  %[[A1:.*]] = cir.alloca !rec_s6, !cir.ptr<!rec_s6>, ["a1"
+// CIR:  %[[A2:.*]] = cir.alloca !rec_s6, !cir.ptr<!rec_s6>, ["a2"
+// CIR:  cir.scope {
+// CIR:    %[[TMP:.*]] = cir.alloca !rec_s6, !cir.ptr<!rec_s6>, ["ref.tmp0"]
+// CIR:    %[[LOAD_A0:.*]] = cir.load{{.*}} %[[A0]] : !cir.ptr<!s32i>, !s32i
+// CIR:    %[[COND:.*]] = cir.cast int_to_bool %[[LOAD_A0]] : !s32i -> !cir.bool
+// CIR:    cir.if %[[COND]] {
+// CIR:      cir.copy %[[A1]] to %[[TMP]] : !cir.ptr<!rec_s6>
+// CIR:    } else {
+// CIR:      cir.copy %[[A2]] to %[[TMP]] : !cir.ptr<!rec_s6>
+// CIR:    }
+// CIR:    cir.get_member %[[TMP]][0] {name = "f0"} : !cir.ptr<!rec_s6> -> !cir.ptr<!s32i>
+
+// LLVM: define {{.*}} i32 @f6
+// LLVM:    %[[LOAD_A0:.*]] = load i32, ptr {{.*}}
+// LLVM:    %[[COND:.*]] = icmp ne i32 %[[LOAD_A0]], 0
+// LLVM:    br i1 %[[COND]], label %[[A1_PATH:.*]], label %[[A2_PATH:.*]]
+// LLVM:  [[A1_PATH]]:
+// LLVM:    call void @llvm.memcpy.p0.p0.i64(ptr %[[TMP:.*]], ptr {{.*}}, i64 4, i1 false)
+// LLVM:    br label %[[EXIT:.*]]
+// LLVM:  [[A2_PATH]]:
+// LLVM:    call void @llvm.memcpy.p0.p0.i64(ptr %[[TMP]], ptr {{.*}}, i64 4, i1 false)
+// LLVM:    br label %[[EXIT]]
+// LLVM:  [[EXIT]]:
+// LLVM:    getelementptr {{.*}}, ptr %[[TMP]], i32 0, i32 0
+
+// OGCG: define {{.*}} i32 @f6
+// OGCG:    %[[LOAD_A0:.*]] = load i32, ptr {{.*}}
+// OGCG:    %[[COND:.*]] = icmp ne i32 %[[LOAD_A0]], 0
+// OGCG:    br i1 %[[COND]], label %[[A1_PATH:.*]], label %[[A2_PATH:.*]]
+// OGCG:  [[A1_PATH]]:
+// OGCG:    call void @llvm.memcpy.p0.p0.i64(ptr {{.*}} %[[TMP:.*]], ptr {{.*}}, i64 4, i1 false)
+// OGCG:    br label %[[EXIT:.*]]
+// OGCG:  [[A2_PATH]]:
+// OGCG:    call void @llvm.memcpy.p0.p0.i64(ptr {{.*}} %[[TMP]], ptr {{.*}}, i64 4, i1 false)
+// OGCG:    br label %[[EXIT]]
+// OGCG:  [[EXIT]]:
+// OGCG:    getelementptr {{.*}}, ptr %[[TMP]], i32 0, i32 0

--- a/clang/test/CIR/CodeGen/ternary-throw.cpp
+++ b/clang/test/CIR/CodeGen/ternary-throw.cpp
@@ -238,3 +238,286 @@ const int &test_cond_const_true_throw_true() {
 // OGCG:  unreachable
 // OGCG: [[NO_PRED_LABEL:.*]]:
 // OGCG:  ret ptr [[UNDEF:.*]]
+
+struct s6 { int f0; };
+int test_agg_cond_throw_false(bool flag, struct s6 a1, struct s6 a2) {
+  return (flag ? a1 : throw 0).f0;
+}
+
+// CIR-LABEL: cir.func{{.*}} @_Z25test_agg_cond_throw_falseb2s6S_(
+// CIR: %[[FLAG:.*]] = cir.alloca !cir.bool, !cir.ptr<!cir.bool>, ["flag", init]
+// CIR: %[[A1:.*]] = cir.alloca !rec_s6, !cir.ptr<!rec_s6>, ["a1", init]
+// CIR: %[[A2:.*]] = cir.alloca !rec_s6, !cir.ptr<!rec_s6>, ["a2", init]
+// CIR: %[[FLAG_VAL:.*]] = cir.load{{.*}} %[[FLAG]] : !cir.ptr<!cir.bool>, !cir.bool
+// CIR: %[[COND_RES:.*]] = cir.ternary(%[[FLAG_VAL]], true {
+// CIR:   cir.yield %[[A1]] : !cir.ptr<!rec_s6>
+// CIR: }, false {
+// CIR:   %[[EXC:.*]] = cir.alloc.exception{{.*}} -> !cir.ptr<!s32i>
+// CIR:   %[[ZERO:.*]] = cir.const #cir.int<0> : !s32i
+// CIR:   cir.store{{.*}} %[[ZERO]], %[[EXC]] : !s32i, !cir.ptr<!s32i>
+// CIR:   cir.throw %[[EXC]] : !cir.ptr<!s32i>, @_ZTIi
+// CIR:   cir.unreachable
+// CIR: }) : (!cir.bool) -> !cir.ptr<!rec_s6>
+// CIR: %[[F0:.*]] = cir.get_member %[[A1]][0] {name = "f0"} : !cir.ptr<!rec_s6> -> !cir.ptr<!s32i>
+// CIR: %[[LOAD:.*]] = cir.load{{.*}} %[[F0]] : !cir.ptr<!s32i>, !s32i
+// CIR: cir.return %{{.*}} : !s32i
+
+// LLVM-LABEL: define{{.*}} i32 @_Z25test_agg_cond_throw_falseb2s6S_(
+// LLVM: %[[FLAG_ALLOCA:.*]] = alloca i8
+// LLVM: %[[A1_ALLOCA:.*]] = alloca %struct.s6
+// LLVM: %[[A2_ALLOCA:.*]] = alloca %struct.s6
+// LLVM: %[[ZEXT:.*]] = zext i1 %{{.*}} to i8
+// LLVM: store i8 %[[ZEXT]], ptr %[[FLAG_ALLOCA]]
+// LLVM: %[[FLAG_LOAD:.*]] = load i8, ptr %[[FLAG_ALLOCA]]
+// LLVM: %[[BOOL:.*]] = trunc i8 %[[FLAG_LOAD]] to i1
+// LLVM: br i1 %[[BOOL]], label %[[TRUE_BB:.*]], label %[[FALSE_BB:.*]]
+// LLVM: [[TRUE_BB]]:
+// LLVM:   br label %[[PHI_BB:.*]]
+// LLVM: [[FALSE_BB]]:
+// LLVM:   %[[EXC:.*]] = call{{.*}} ptr @__cxa_allocate_exception
+// LLVM:   store i32 0, ptr %[[EXC]]
+// LLVM:   call void @__cxa_throw(ptr %[[EXC]], ptr @_ZTIi
+// LLVM:   unreachable
+// LLVM: [[PHI_BB]]:
+// LLVM:   %[[PHI:.*]] = phi ptr [ %[[A1_ALLOCA]], %[[TRUE_BB]] ]
+// LLVM:   br label %[[CONT_BB:.*]]
+// LLVM: [[CONT_BB]]:
+// LLVM:   %[[F0_PTR:.*]] = getelementptr %struct.s6, ptr %[[A1_ALLOCA]], i32 0, i32 0
+// LLVM:   %[[F0_VAL:.*]] = load i32, ptr %[[F0_PTR]]
+// LLVM:   ret i32 %{{.*}}
+
+// OGCG-LABEL: define{{.*}} i32 @_Z25test_agg_cond_throw_falseb2s6S_(
+// OGCG: %[[A1:.*]] = alloca %struct.s6
+// OGCG: %[[A2:.*]] = alloca %struct.s6
+// OGCG: %{{.*}} = alloca i8
+// OGCG: %[[LOAD:.*]] = load i8, ptr %{{.*}}
+// OGCG: %[[BOOL:.*]] = trunc i8 %[[LOAD]] to i1
+// OGCG: br i1 %[[BOOL]], label %[[TRUE_BB:.*]], label %[[FALSE_BB:.*]]
+// OGCG: [[TRUE_BB]]:
+// OGCG:   br label %[[END:.*]]
+// OGCG: [[FALSE_BB]]:
+// OGCG:   %[[EXC:.*]] = call{{.*}} ptr @__cxa_allocate_exception
+// OGCG:   store i32 0, ptr %[[EXC]]
+// OGCG:   call void @__cxa_throw(ptr %[[EXC]], ptr @_ZTIi
+// OGCG:   unreachable
+// OGCG: [[END]]:
+// OGCG:   %[[F0_PTR:.*]] = getelementptr inbounds nuw %struct.s6, ptr %[[A1]], i32 0, i32 0
+// OGCG:   %[[F0_VAL:.*]] = load i32, ptr %[[F0_PTR]]
+// OGCG:   ret i32 %{{.*}}
+
+int test_agg_cond_throw_true(bool flag, struct s6 a1, struct s6 a2) {
+  return (flag ? throw 0 : a1).f0;
+}
+
+// CIR-LABEL: cir.func{{.*}} @_Z24test_agg_cond_throw_trueb2s6S_(
+// CIR: %[[FLAG:.*]] = cir.alloca !cir.bool, !cir.ptr<!cir.bool>, ["flag", init]
+// CIR: %[[A1:.*]] = cir.alloca !rec_s6, !cir.ptr<!rec_s6>, ["a1", init]
+// CIR: %[[A2:.*]] = cir.alloca !rec_s6, !cir.ptr<!rec_s6>, ["a2", init]
+// CIR: %[[FLAG_VAL:.*]] = cir.load{{.*}} %[[FLAG]] : !cir.ptr<!cir.bool>, !cir.bool
+// CIR: %[[COND_RES:.*]] = cir.ternary(%[[FLAG_VAL]], true {
+// CIR:   %[[EXC:.*]] = cir.alloc.exception{{.*}} -> !cir.ptr<!s32i>
+// CIR:   %[[ZERO:.*]] = cir.const #cir.int<0> : !s32i
+// CIR:   cir.store{{.*}} %[[ZERO]], %[[EXC]] : !s32i, !cir.ptr<!s32i>
+// CIR:   cir.throw %[[EXC]] : !cir.ptr<!s32i>, @_ZTIi
+// CIR:   cir.unreachable
+// CIR: }, false {
+// CIR:   cir.yield %[[A1]] : !cir.ptr<!rec_s6>
+// CIR: }) : (!cir.bool) -> !cir.ptr<!rec_s6>
+// CIR: %[[F0:.*]] = cir.get_member %[[A1]][0] {name = "f0"} : !cir.ptr<!rec_s6> -> !cir.ptr<!s32i>
+// CIR: %[[LOAD:.*]] = cir.load{{.*}} %[[F0]] : !cir.ptr<!s32i>, !s32i
+// CIR: cir.return %{{.*}} : !s32i
+
+// LLVM-LABEL: define{{.*}} i32 @_Z24test_agg_cond_throw_trueb2s6S_(
+// LLVM: %[[FLAG_ALLOCA:.*]] = alloca i8
+// LLVM: %[[A1_ALLOCA:.*]] = alloca %struct.s6
+// LLVM: %[[A2_ALLOCA:.*]] = alloca %struct.s6
+// LLVM: %[[ZEXT:.*]] = zext i1 %{{.*}} to i8
+// LLVM: store i8 %[[ZEXT]], ptr %[[FLAG_ALLOCA]]
+// LLVM: %[[FLAG_LOAD:.*]] = load i8, ptr %[[FLAG_ALLOCA]]
+// LLVM: %[[BOOL:.*]] = trunc i8 %[[FLAG_LOAD]] to i1
+// LLVM: br i1 %[[BOOL]], label %[[TRUE_BB:.*]], label %[[FALSE_BB:.*]]
+// LLVM: [[TRUE_BB]]:
+// LLVM:   %[[EXC:.*]] = call{{.*}} ptr @__cxa_allocate_exception
+// LLVM:   store i32 0, ptr %[[EXC]]
+// LLVM:   call void @__cxa_throw(ptr %[[EXC]], ptr @_ZTIi
+// LLVM:   unreachable
+// LLVM: [[FALSE_BB]]:
+// LLVM:   br label %[[PHI_BB:.*]]
+// LLVM: [[PHI_BB]]:
+// LLVM:   %[[PHI:.*]] = phi ptr [ %[[A1_ALLOCA]], %[[FALSE_BB]] ]
+// LLVM:   br label %[[CONT_BB:.*]]
+// LLVM: [[CONT_BB]]:
+// LLVM:   %[[F0_PTR:.*]] = getelementptr %struct.s6, ptr %[[A1_ALLOCA]], i32 0, i32 0
+// LLVM:   %[[F0_VAL:.*]] = load i32, ptr %[[F0_PTR]]
+// LLVM:   ret i32 %{{.*}}
+
+// OGCG-LABEL: define{{.*}} i32 @_Z24test_agg_cond_throw_trueb2s6S_(
+// OGCG: %[[A1:.*]] = alloca %struct.s6
+// OGCG: %[[A2:.*]] = alloca %struct.s6
+// OGCG: %{{.*}} = alloca i8
+// OGCG: %[[LOAD:.*]] = load i8, ptr %{{.*}}
+// OGCG: %[[BOOL:.*]] = trunc i8 %[[LOAD]] to i1
+// OGCG: br i1 %[[BOOL]], label %[[TRUE_BB:.*]], label %[[FALSE_BB:.*]]
+// OGCG: [[TRUE_BB]]:
+// OGCG:   %[[EXC:.*]] = call{{.*}} ptr @__cxa_allocate_exception
+// OGCG:   store i32 0, ptr %[[EXC]]
+// OGCG:   call void @__cxa_throw(ptr %[[EXC]], ptr @_ZTIi
+// OGCG:   unreachable
+// OGCG: [[FALSE_BB]]:
+// OGCG:   br label %[[END:.*]]
+// OGCG: [[END]]:
+// OGCG:   %[[F0_PTR:.*]] = getelementptr inbounds nuw %struct.s6, ptr %[[A1]], i32 0, i32 0
+// OGCG:   %[[F0_VAL:.*]] = load i32, ptr %[[F0_PTR]]
+// OGCG:   ret i32 %{{.*}}
+
+const int test_agg_cond_const_true_throw_false(struct s6 a1, struct s6 a2) {
+  return (true ? a1 : throw 0).f0;
+}
+
+// CIR-LABEL: cir.func{{.*}} @_Z36test_agg_cond_const_true_throw_false2s6S_(
+// CIR: %[[A1:.*]] = cir.alloca !rec_s6, !cir.ptr<!rec_s6>, ["a1", init]
+// CIR: %[[A2:.*]] = cir.alloca !rec_s6, !cir.ptr<!rec_s6>, ["a2", init]
+// CIR-NOT: cir.ternary
+// CIR-NOT: cir.throw
+// CIR: %[[F0:.*]] = cir.get_member %[[A1]][0] {name = "f0"} : !cir.ptr<!rec_s6> -> !cir.ptr<!s32i>
+// CIR: %[[LOAD:.*]] = cir.load{{.*}} %[[F0]] : !cir.ptr<!s32i>, !s32i
+// CIR: cir.return %{{.*}} : !s32i
+
+// LLVM-LABEL: define{{.*}} i32 @_Z36test_agg_cond_const_true_throw_false2s6S_(
+// LLVM: %[[A1_ALLOCA:.*]] = alloca %struct.s6
+// LLVM: %[[A2_ALLOCA:.*]] = alloca %struct.s6
+// LLVM-NOT: br i1
+// LLVM-NOT: __cxa_throw
+// LLVM: %[[F0_PTR:.*]] = getelementptr %struct.s6, ptr %[[A1_ALLOCA]], i32 0, i32 0
+// LLVM: %[[F0_VAL:.*]] = load i32, ptr %[[F0_PTR]]
+// LLVM: ret i32 %{{.*}}
+
+// OGCG-LABEL: define{{.*}} i32 @_Z36test_agg_cond_const_true_throw_false2s6S_(
+// OGCG: %[[A1:.*]] = alloca %struct.s6
+// OGCG: %[[A2:.*]] = alloca %struct.s6
+// Match the coerce stores so we match the F0 gep and load correctly.
+// OGCG: getelementptr
+// OGCG: store
+// OGCG: getelementptr
+// OGCG: store
+// OGCG-NOT: br i1
+// OGCG-NOT: __cxa_throw
+// OGCG: %[[F0_PTR:.*]] = getelementptr inbounds nuw %struct.s6, ptr %[[A1]], i32 0, i32 0
+// OGCG: %[[F0_VAL:.*]] = load i32, ptr %[[F0_PTR]]
+// OGCG: ret i32 %{{.*}}
+
+const int test_agg_cond_const_true_throw_true(struct s6 a1, struct s6 a2) {
+  return (true ? throw 0 : a2).f0;
+}
+
+// CIR-LABEL: cir.func{{.*}} @_Z35test_agg_cond_const_true_throw_true2s6S_(
+// CIR: %[[A1:.*]] = cir.alloca !rec_s6, !cir.ptr<!rec_s6>, ["a1", init]
+// CIR: %[[A2:.*]] = cir.alloca !rec_s6, !cir.ptr<!rec_s6>, ["a2", init]
+// CIR: %[[EXC:.*]] = cir.alloc.exception{{.*}} -> !cir.ptr<!s32i>
+// CIR: %[[ZERO:.*]] = cir.const #cir.int<0> : !s32i
+// CIR: cir.store{{.*}} %[[ZERO]], %[[EXC]] : !s32i, !cir.ptr<!s32i>
+// CIR: cir.throw %[[EXC]] : !cir.ptr<!s32i>, @_ZTIi
+// CIR: cir.unreachable
+// CIR: ^[[NO_PRED:.*]]:
+// CIR: %[[NULL_REC:.*]] = cir.const #cir.ptr<null> : !cir.ptr<!rec_s6>
+// CIR: %[[F0:.*]] = cir.get_member %[[NULL_REC]][0] {name = "f0"} : !cir.ptr<!rec_s6> -> !cir.ptr<!s32i>
+// CIR: %[[LOAD:.*]] = cir.load{{.*}} %[[F0]] : !cir.ptr<!s32i>, !s32i
+// CIR: cir.return %{{.*}} : !s32i
+
+// LLVM-LABEL: define{{.*}} i32 @_Z35test_agg_cond_const_true_throw_true2s6S_(
+// LLVM: %[[A1_ALLOCA:.*]] = alloca %struct.s6
+// LLVM: %[[A2_ALLOCA:.*]] = alloca %struct.s6
+// LLVM: %[[EXC:.*]] = call{{.*}} ptr @__cxa_allocate_exception
+// LLVM: store i32 0, ptr %[[EXC]]
+// LLVM: call void @__cxa_throw(ptr %[[EXC]], ptr @_ZTIi
+// LLVM: unreachable
+// LLVM: [[NO_PRED:.*]]:
+// LLVM: %[[LOAD_UNDEF:.*]] = load i32, ptr null, align 1
+// LLVM: ret i32 %{{.*}}
+
+// OGCG-LABEL: define{{.*}} i32 @_Z35test_agg_cond_const_true_throw_true2s6S_(
+// OGCG: %[[A1:.*]] = alloca %struct.s6
+// OGCG: %[[A2:.*]] = alloca %struct.s6
+// OGCG: %[[EXC:.*]] = call{{.*}} ptr @__cxa_allocate_exception
+// OGCG: store i32 0, ptr %[[EXC]]
+// OGCG: call void @__cxa_throw(ptr %[[EXC]], ptr @_ZTIi
+// OGCG: unreachable
+// OGCG: [[NO_PRED:.*]]:
+// OGCG: %[[LOAD_UNDEF:.*]] = load i32, ptr undef, align 1
+// OGCG: ret i32 %{{.*}}
+
+const int test_agg_cond_const_false_throw_false(struct s6 a1, struct s6 a2) {
+  return (false ? a1 : throw 0).f0;
+}
+
+// CIR-LABEL: cir.func{{.*}} @_Z37test_agg_cond_const_false_throw_false2s6S_(
+// CIR: %[[A1:.*]] = cir.alloca !rec_s6, !cir.ptr<!rec_s6>, ["a1", init]
+// CIR: %[[A2:.*]] = cir.alloca !rec_s6, !cir.ptr<!rec_s6>, ["a2", init]
+// CIR: %[[EXC:.*]] = cir.alloc.exception{{.*}} -> !cir.ptr<!s32i>
+// CIR: %[[ZERO:.*]] = cir.const #cir.int<0> : !s32i
+// CIR: cir.store{{.*}} %[[ZERO]], %[[EXC]] : !s32i, !cir.ptr<!s32i>
+// CIR: cir.throw %[[EXC]] : !cir.ptr<!s32i>, @_ZTIi
+// CIR: cir.unreachable
+// CIR: ^[[NO_PRED:.*]]:
+// CIR: %[[NULL_REC:.*]] = cir.const #cir.ptr<null> : !cir.ptr<!rec_s6>
+// CIR: %[[F0:.*]] = cir.get_member %[[NULL_REC]][0] {name = "f0"} : !cir.ptr<!rec_s6> -> !cir.ptr<!s32i>
+// CIR: %[[LOAD:.*]] = cir.load{{.*}} %[[F0]] : !cir.ptr<!s32i>, !s32i
+// CIR: cir.return %{{.*}} : !s32i
+
+// LLVM-LABEL: define{{.*}} i32 @_Z37test_agg_cond_const_false_throw_false2s6S_(
+// LLVM: %[[A1_ALLOCA:.*]] = alloca %struct.s6
+// LLVM: %[[A2_ALLOCA:.*]] = alloca %struct.s6
+// LLVM: %[[EXC:.*]] = call{{.*}} ptr @__cxa_allocate_exception
+// LLVM: store i32 0, ptr %[[EXC]]
+// LLVM: call void @__cxa_throw(ptr %[[EXC]], ptr @_ZTIi
+// LLVM: unreachable
+// LLVM: [[NO_PRED:.*]]:
+// LLVM: %[[LOAD_UNDEF:.*]] = load i32, ptr null, align 1
+// LLVM: ret i32 %{{.*}}
+
+// OGCG-LABEL: define{{.*}} i32 @_Z37test_agg_cond_const_false_throw_false2s6S_(
+// OGCG: %[[A1:.*]] = alloca %struct.s6
+// OGCG: %[[A2:.*]] = alloca %struct.s6
+// OGCG: %[[EXC:.*]] = call{{.*}} ptr @__cxa_allocate_exception
+// OGCG: store i32 0, ptr %[[EXC]]
+// OGCG: call void @__cxa_throw(ptr %[[EXC]], ptr @_ZTIi
+// OGCG: unreachable
+// OGCG: [[NO_PRED:.*]]:
+// OGCG: %[[LOAD_UNDEF:.*]] = load i32, ptr undef, align 1
+// OGCG: ret i32 %{{.*}}
+
+const int test_agg_cond_const_false_throw_true(struct s6 a1, struct s6 a2) {
+  return (false ? throw 0 : a1).f0;
+}
+
+// CIR-LABEL: cir.func{{.*}} @_Z36test_agg_cond_const_false_throw_true2s6S_(
+// CIR: %[[A1:.*]] = cir.alloca !rec_s6, !cir.ptr<!rec_s6>, ["a1", init]
+// CIR: %[[A2:.*]] = cir.alloca !rec_s6, !cir.ptr<!rec_s6>, ["a2", init]
+// CIR-NOT: cir.ternary
+// CIR-NOT: cir.throw
+// CIR: %[[F0:.*]] = cir.get_member %[[A1]][0] {name = "f0"} : !cir.ptr<!rec_s6> -> !cir.ptr<!s32i>
+// CIR: %[[LOAD:.*]] = cir.load{{.*}} %[[F0]] : !cir.ptr<!s32i>, !s32i
+// CIR: cir.return %{{.*}} : !s32i
+
+// LLVM-LABEL: define{{.*}} i32 @_Z36test_agg_cond_const_false_throw_true2s6S_(
+// LLVM: %[[A1_ALLOCA:.*]] = alloca %struct.s6
+// LLVM: %[[A2_ALLOCA:.*]] = alloca %struct.s6
+// LLVM-NOT: br i1
+// LLVM-NOT: __cxa_throw
+// LLVM: %[[F0_PTR:.*]] = getelementptr %struct.s6, ptr %[[A1_ALLOCA]], i32 0, i32 0
+// LLVM: %[[F0_VAL:.*]] = load i32, ptr %[[F0_PTR]]
+// LLVM: ret i32 %{{.*}}
+
+// OGCG-LABEL: define{{.*}} i32 @_Z36test_agg_cond_const_false_throw_true2s6S_(
+// OGCG: %[[A1:.*]] = alloca %struct.s6
+// OGCG: %[[A2:.*]] = alloca %struct.s6
+// Match the coerce stores so we match the F0 gep and load correctly.
+// OGCG: getelementptr
+// OGCG: store
+// OGCG: getelementptr
+// OGCG: store
+// OGCG-NOT: br i1
+// OGCG-NOT: __cxa_throw
+// OGCG: %[[F0_PTR:.*]] = getelementptr inbounds nuw %struct.s6, ptr %[[A1]], i32 0, i32 0
+// OGCG: %[[F0_VAL:.*]] = load i32, ptr %[[F0_PTR]]
+// OGCG: ret i32 %{{.*}}


### PR DESCRIPTION
This implements AggExprEmitter::VisitAbstractConditionalOperator for CIR.