### PR TITLE
[libc][docs] Add spawn.h POSIX header documentation

### DIFF
--- a/libc/docs/CMakeLists.txt
+++ b/libc/docs/CMakeLists.txt
@@ -58,6 +58,7 @@ if (SPHINX_FOUND)
       # pthread
       setjmp
       signal
+      spawn
       stdbit
       stdio
       stdlib

--- a/libc/docs/headers/index.rst
+++ b/libc/docs/headers/index.rst
@@ -24,6 +24,7 @@ Implementation Status
    search
    setjmp
    signal
+   spawn
    stdbit
    stdfix
    stdio

--- a/libc/utils/docgen/spawn.yaml
+++ b/libc/utils/docgen/spawn.yaml
@@ -1,0 +1,63 @@
+macros:
+  POSIX_SPAWN_RESETIDS:
+    in-latest-posix: ''
+  POSIX_SPAWN_SETPGROUP:
+    in-latest-posix: ''
+  POSIX_SPAWN_SETSCHEDPARAM:
+    in-latest-posix: ''
+  POSIX_SPAWN_SETSCHEDULER:
+    in-latest-posix: ''
+  POSIX_SPAWN_SETSID:
+    in-latest-posix: ''
+  POSIX_SPAWN_SETSIGDEF:
+    in-latest-posix: ''
+  POSIX_SPAWN_SETSIGMASK:
+    in-latest-posix: ''
+
+functions:
+  posix_spawn:
+    in-latest-posix: ''
+  posix_spawn_file_actions_addchdir:
+    in-latest-posix: ''
+  posix_spawn_file_actions_addclose:
+    in-latest-posix: ''
+  posix_spawn_file_actions_adddup2:
+    in-latest-posix: ''
+  posix_spawn_file_actions_addfchdir:
+    in-latest-posix: ''
+  posix_spawn_file_actions_addopen:
+    in-latest-posix: ''
+  posix_spawn_file_actions_destroy:
+    in-latest-posix: ''
+  posix_spawn_file_actions_init:
+    in-latest-posix: ''
+  posix_spawnattr_destroy:
+    in-latest-posix: ''
+  posix_spawnattr_getflags:
+    in-latest-posix: ''
+  posix_spawnattr_getpgroup:
+    in-latest-posix: ''
+  posix_spawnattr_getschedparam:
+    in-latest-posix: ''
+  posix_spawnattr_getschedpolicy:
+    in-latest-posix: ''
+  posix_spawnattr_getsigdefault:
+    in-latest-posix: ''
+  posix_spawnattr_getsigmask:
+    in-latest-posix: ''
+  posix_spawnattr_init:
+    in-latest-posix: ''
+  posix_spawnattr_setflags:
+    in-latest-posix: ''
+  posix_spawnattr_setpgroup:
+    in-latest-posix: ''
+  posix_spawnattr_setschedparam:
+    in-latest-posix: ''
+  posix_spawnattr_setschedpolicy:
+    in-latest-posix: ''
+  posix_spawnattr_setsigdefault:
+    in-latest-posix: ''
+  posix_spawnattr_setsigmask:
+    in-latest-posix: ''
+  posix_spawnp:
+    in-latest-posix: ''


### PR DESCRIPTION
Add YAML metadata for `spawn.h` listing all POSIX-mandated macros
(`POSIX_SPAWN_RESETIDS`, `POSIX_SPAWN_SETPGROUP`, `POSIX_SPAWN_SETSCHEDPARAM`,
`POSIX_SPAWN_SETSCHEDULER`, `POSIX_SPAWN_SETSID`, `POSIX_SPAWN_SETSIGDEF`,
`POSIX_SPAWN_SETSIGMASK`) and all 23 functions (`posix_spawn`, `posix_spawnp`,
`posix_spawn_file_actions_*`, `posix_spawnattr_*`).

Add `spawn` to `index.rst` and `CMakeLists.txt` `docgen_list`.

Verified with `python3 docgen.py spawn.h` — generates valid RST with correct POSIX links.

Partial fix for #122006