### PR TITLE
[LoongArch] Remove unreachable Value check in fixupLeb128

### DIFF
--- a/llvm/lib/Target/LoongArch/MCTargetDesc/LoongArchAsmBackend.cpp
+++ b/llvm/lib/Target/LoongArch/MCTargetDesc/LoongArchAsmBackend.cpp
@@ -136,8 +136,6 @@ static void fixupLeb128(MCContext &Ctx, const MCFixup &Fixup, uint8_t *Data,
   unsigned I;
   for (I = 0; Value; ++I, Value >>= 7)
     Data[I] |= uint8_t(Value & 0x7f);
-  if (Value)
-    Ctx.reportError(Fixup.getLoc(), "Invalid uleb128 value!");
 }
 
 void LoongArchAsmBackend::applyFixup(const MCFragment &F, const MCFixup &Fixup,


### PR DESCRIPTION
Value is guaranteed to be zero after the loop:

  for (I = 0; Value; ++I, Value >>= 7)

Therefore the subsequent `if (Value)` condition is always false.
Remove the unreachable code. Reported by PVS-Studio.

Fixed: #170122
