### PR TITLE
[StaticAnalyzer] Remove FIXME from InnerPointerBRVisitor

### DIFF
--- a/clang/lib/StaticAnalyzer/Checkers/InnerPointerChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/InnerPointerChecker.cpp
@@ -76,8 +76,6 @@ public:
                                      BugReporterContext &BRC,
                                      PathSensitiveBugReport &BR) override;
 
-    // FIXME: Scan the map once in the visitor's constructor and do a direct
-    // lookup by region.
     bool isSymbolTracked(ProgramStateRef State, SymbolRef Sym) {
       RawPtrMapTy Map = State->get<RawPtrMap>();
       for (const auto &Entry : Map) {


### PR DESCRIPTION
Removed the FIXME based on the discussion in #185796 . The code path only happens during bug reporting therefore it is not performance sensitive.