### PR TITLE
Exclude known failure case

### DIFF
--- a/mlir/test/Dialect/Builtin/Bytecode/builtin_fixed.mlir
+++ b/mlir/test/Dialect/Builtin/Bytecode/builtin_fixed.mlir
@@ -11,6 +11,9 @@
 
 // allow-unregisterd-dialect is set to allow for the string constant types.
 
+// Parsing external resources does not work on big-endian platforms currently
+// XFAIL: target={{(s390x|sparc.*)-.*}}
+
 module {
 
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
External resources does not produce same result on big-endian. Keeping this test for regressions of the encoding scoped keeps it simple while it doesn't affect the usage there. So just mark as XFAIL.