### PR TITLE
[X86] Fix syntax directive for --output-asm-variant=1

### DIFF
--- a/llvm/lib/Target/X86/X86AsmPrinter.cpp
+++ b/llvm/lib/Target/X86/X86AsmPrinter.cpp
@@ -958,7 +958,9 @@ void X86AsmPrinter::emitStartOfAsmFile(Module &M) {
   }
 
   // TODO: Support prefixed registers for the Intel syntax.
-  const bool IntelSyntax = MAI->getAssemblerDialect() == InlineAsm::AD_Intel;
+  unsigned Dialect = TM.Options.MCOptions.OutputAsmVariant.value_or(
+      MAI->getAssemblerDialect());
+  const bool IntelSyntax = Dialect == InlineAsm::AD_Intel;
   OutStreamer->emitSyntaxDirective(IntelSyntax ? "intel" : "att",
                                    IntelSyntax ? "noprefix" : "");
 

--- a/llvm/test/CodeGen/X86/dollar-name-asm.ll
+++ b/llvm/test/CodeGen/X86/dollar-name-asm.ll
@@ -3,5 +3,7 @@
 
 module asm "mov ($foo), %eax"
 
+; ATT:   .att_syntax{{$}}
 ; ATT:   movl ($foo), %eax
+; INTEL: .intel_syntax noprefix{{$}}
 ; INTEL: mov eax, dword ptr [$foo]


### PR DESCRIPTION
`--output-asm-variant=1` in llc/clang correctly prints instructions in
Intel syntax but incorrectly emits `.att_syntax` as the first directive.

Fix this by consulting OutputAsmVariant (with fallback to
AssemblerDialect) when deciding which syntax directive to emit, matching
the same pattern in CodeGenTargetMachineImpl::createMCStreamer
(#109360).
