### PR TITLE
[lldb] Preserve TargetSP in Platform module lookup

### DIFF
--- a/lldb/source/Target/ModuleCache.cpp
+++ b/lldb/source/Target/ModuleCache.cpp
@@ -255,7 +255,8 @@ Status ModuleCache::Get(const FileSpec &root_dir_spec, const char *hostname,
   cached_module_spec.GetPlatformFileSpec() = module_spec.GetFileSpec();
 
   error = ModuleList::GetSharedModule(cached_module_spec, cached_module_sp,
-                                      nullptr, did_create_ptr, false);
+                                      nullptr, did_create_ptr,
+                                      /*invoke_locate_callback=*/false);
   if (error.Fail())
     return error;
 

--- a/lldb/source/Target/ModuleCache.cpp
+++ b/lldb/source/Target/ModuleCache.cpp
@@ -255,7 +255,7 @@ Status ModuleCache::Get(const FileSpec &root_dir_spec, const char *hostname,
   cached_module_spec.GetPlatformFileSpec() = module_spec.GetFileSpec();
 
   error = ModuleList::GetSharedModule(cached_module_spec, cached_module_sp,
-                                      nullptr, did_create_ptr);
+                                      nullptr, did_create_ptr, false);
   if (error.Fail())
     return error;
 

--- a/lldb/source/Target/Platform.cpp
+++ b/lldb/source/Target/Platform.cpp
@@ -181,15 +181,17 @@ Status Platform::GetSharedModule(
       resolved_spec = spec;
       resolved_spec.GetFileSpec().PrependPathComponent(m_sdk_sysroot);
       // Try to get shared module with resolved spec.
-      error = ModuleList::GetSharedModule(resolved_spec, module_sp, old_modules,
-                                          did_create_ptr, false);
+      error = ModuleList::GetSharedModule(
+          resolved_spec, module_sp, old_modules, did_create_ptr,
+          /*invoke_locate_callback=*/false);
     }
     // If we don't have sysroot or it didn't work then
     // try original module spec.
     if (!error.Success()) {
       resolved_spec = spec;
-      error = ModuleList::GetSharedModule(resolved_spec, module_sp, old_modules,
-                                          did_create_ptr, false);
+      error = ModuleList::GetSharedModule(
+          resolved_spec, module_sp, old_modules, did_create_ptr,
+          /*invoke_locate_callback=*/false);
     }
     if (error.Success() && module_sp)
       module_sp->SetPlatformFileSpec(resolved_spec.GetFileSpec());

--- a/lldb/source/Target/Platform.cpp
+++ b/lldb/source/Target/Platform.cpp
@@ -181,17 +181,17 @@ Status Platform::GetSharedModule(
       resolved_spec = spec;
       resolved_spec.GetFileSpec().PrependPathComponent(m_sdk_sysroot);
       // Try to get shared module with resolved spec.
-      error = ModuleList::GetSharedModule(
-          resolved_spec, module_sp, old_modules, did_create_ptr,
-          /*invoke_locate_callback=*/false);
+      error = ModuleList::GetSharedModule(resolved_spec, module_sp, old_modules,
+                                          did_create_ptr,
+                                          /*invoke_locate_callback=*/false);
     }
     // If we don't have sysroot or it didn't work then
     // try original module spec.
     if (!error.Success()) {
       resolved_spec = spec;
-      error = ModuleList::GetSharedModule(
-          resolved_spec, module_sp, old_modules, did_create_ptr,
-          /*invoke_locate_callback=*/false);
+      error = ModuleList::GetSharedModule(resolved_spec, module_sp, old_modules,
+                                          did_create_ptr,
+                                          /*invoke_locate_callback=*/false);
     }
     if (error.Success() && module_sp)
       module_sp->SetPlatformFileSpec(resolved_spec.GetFileSpec());

--- a/lldb/source/Target/Platform.cpp
+++ b/lldb/source/Target/Platform.cpp
@@ -182,14 +182,14 @@ Status Platform::GetSharedModule(
       resolved_spec.GetFileSpec().PrependPathComponent(m_sdk_sysroot);
       // Try to get shared module with resolved spec.
       error = ModuleList::GetSharedModule(resolved_spec, module_sp, old_modules,
-                                          did_create_ptr);
+                                          did_create_ptr, false);
     }
     // If we don't have sysroot or it didn't work then
     // try original module spec.
     if (!error.Success()) {
       resolved_spec = spec;
       error = ModuleList::GetSharedModule(resolved_spec, module_sp, old_modules,
-                                          did_create_ptr);
+                                          did_create_ptr, false);
     }
     if (error.Success() && module_sp)
       module_sp->SetPlatformFileSpec(resolved_spec.GetFileSpec());
@@ -1524,6 +1524,10 @@ Status Platform::GetRemoteSharedModule(const ModuleSpec &module_spec,
   if (module_spec.GetUUID().IsValid()) {
     resolved_module_spec.GetUUID() = module_spec.GetUUID();
   }
+
+  // Retain the target context from the original module_spec since
+  // process->GetModuleSpec might have cleared it.
+  resolved_module_spec.SetTarget(module_spec.GetTargetSP());
 
   // Call locate module callback if set. This allows users to implement their
   // own module cache system. For example, to leverage build system artifacts,

--- a/lldb/unittests/Target/LocateModuleCallbackTest.cpp
+++ b/lldb/unittests/Target/LocateModuleCallbackTest.cpp
@@ -1034,6 +1034,7 @@ TEST_F(LocateModuleCallbackTest, ModuleCacheGetDoesNotInvokeCallback) {
 
   ASSERT_TRUE(error.Success());
   ASSERT_TRUE(cached_module_sp);
+  ASSERT_EQ(cached_module_sp->GetFileSpec(), uuid_view);
   // The locate module callback should not be called.
   EXPECT_EQ(callback_call_count, 0);
 

--- a/lldb/unittests/Target/LocateModuleCallbackTest.cpp
+++ b/lldb/unittests/Target/LocateModuleCallbackTest.cpp
@@ -1000,3 +1000,41 @@ TEST_F(LocateModuleCallbackTest,
             FileSpec(GetInputFilePath(k_module_file)));
   ModuleList::RemoveSharedModule(m_module_sp);
 }
+
+TEST_F(LocateModuleCallbackTest, ModuleCacheGetDoesNotInvokeCallback) {
+  // The module file is cached. ModuleCache::Get should succeed to return the
+  // module from the cache without calling the locate module callback.
+  FileSpec uuid_view = BuildCacheDir(m_test_dir);
+
+  int callback_call_count = 0;
+  m_platform_sp->SetLocateModuleCallback(
+      [&callback_call_count](const ModuleSpec &module_spec,
+                             FileSpec &module_file_spec,
+                             FileSpec &symbol_file_spec) {
+        callback_call_count++;
+        return Status();
+      });
+
+  ModuleCache mc;
+  ModuleSP cached_module_sp;
+  bool did_create = false;
+  FileSpec root_dir_spec(m_test_dir);
+  root_dir_spec.AppendPathComponent(k_platform_dir);
+  Status error = mc.GetAndPut(
+      root_dir_spec, "hostname", m_module_spec,
+      [](const ModuleSpec &module_spec,
+         const FileSpec &tmp_download_file_spec) {
+        return Status::FromErrorString("Should not be called");
+      },
+      [](const ModuleSP &module_sp, const FileSpec &tmp_download_file_spec) {
+        return Status::FromErrorString("Should not be called");
+      },
+      cached_module_sp, &did_create);
+
+  ASSERT_TRUE(error.Success());
+  ASSERT_TRUE(cached_module_sp);
+  // The locate module callback should not be called.
+  EXPECT_EQ(callback_call_count, 0);
+
+  ModuleList::RemoveSharedModule(cached_module_sp);
+}

--- a/lldb/unittests/Target/LocateModuleCallbackTest.cpp
+++ b/lldb/unittests/Target/LocateModuleCallbackTest.cpp
@@ -16,6 +16,7 @@
 #include "lldb/Core/Debugger.h"
 #include "lldb/Core/PluginManager.h"
 #include "lldb/Host/HostInfo.h"
+#include "lldb/Target/ModuleCache.h"
 #include "lldb/Target/Target.h"
 #include "gmock/gmock.h"
 


### PR DESCRIPTION
[lldb] Preserve TargetSP in Platform module lookup

When `Platform::GetRemoteSharedModule` resolves a module specification by calling `GetModuleSpec` on
the process, the target context (`TargetSP`) is lost. This happens because the underlying process plugin populates a new `ModuleSpec` object that does not inherit the target context.

This causes failures in subsequent symbol resolution steps. For example, when `ModuleList` relies on the `TargetSP` to query target-specific settings like `target.exec-search-paths` and `target.symbols-search-paths`, the lookup fails
because `TargetSP` evaluates to null. This prevents LLDB from finding local unstripped libraries.

This commit fixes the issue by transferring the target context from the original `module_spec` over to the `resolved_module_spec` before proceeding with the lookup.

Additionally, this commit avoids redundant calls to the locate module callback. Since the platform already handles the callback explicitly, passing the target context to subsequent `ModuleList::GetSharedModule` calls would normally trigger the callback again redundantly. This is suppressed by passing `invoke_locate_callback=false` in `Platform::GetSharedModule` and `ModuleCache::Get`. This also avoids triggering the callback with incomplete module specifications (e.g. cleared UUIDs) during cache lookups.