### PR TITLE
[clang-tidy] Detect std::rot[lr] pattern within modernize.use-std-bit

### DIFF
--- a/clang-tools-extra/clang-tidy/modernize/UseStdBitCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/UseStdBitCheck.cpp
@@ -19,7 +19,7 @@ UseStdBitCheck::UseStdBitCheck(StringRef Name, ClangTidyContext *Context)
       IncludeInserter(Options.getLocalOrGlobal("IncludeStyle",
                                                utils::IncludeSorter::IS_LLVM),
                       areDiagsSelfContained()),
-      StrictMode(Options.get("StrictMode", false)) {}
+      HonorIntPromotion(Options.get("HonorIntPromotion", false)) {}
 
 void UseStdBitCheck::registerMatchers(MatchFinder *Finder) {
   const auto MakeBinaryOperatorMatcher = [](auto Op) {
@@ -112,7 +112,7 @@ void UseStdBitCheck::registerPPCallbacks(const SourceManager &SM,
 
 void UseStdBitCheck::storeOptions(ClangTidyOptions::OptionMap &Opts) {
   Options.store(Opts, "IncludeStyle", IncludeInserter.getStyle());
-  Options.store(Opts, "StrictMode", StrictMode);
+  Options.store(Opts, "HonorIntPromotion", HonorIntPromotion);
 }
 
 void UseStdBitCheck::check(const MatchFinder::MatchResult &Result) {
@@ -187,7 +187,7 @@ void UseStdBitCheck::check(const MatchFinder::MatchResult &Result) {
     // Only insert cast if the operand is not subject to cast and
     // some implicit promotion happened.
     const bool NeedsIntCast =
-        StrictMode && !HasExplicitIntegerCast &&
+        HonorIntPromotion && !HasExplicitIntegerCast &&
         Context.getTypeSize(MatchedExpr->getType()) > MatchedVarSize;
     const bool IsRotl = ShiftRightAmount.sge(ShiftLeftAmount);
 

--- a/clang-tools-extra/clang-tidy/modernize/UseStdBitCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/UseStdBitCheck.cpp
@@ -95,13 +95,12 @@ void UseStdBitCheck::registerMatchers(MatchFinder *Finder) {
 
   // Rotating an integer by a fixed amount
   Finder->addMatcher(
-      traverse(
-          TK_AsIs,
-          BitwiseOr(ShiftLeft(BindDeclRef("v"),
-                              integerLiteral().bind("shift_left_amount")),
-                    ShiftRight(BoundDeclRef("v"),
-                               integerLiteral().bind("shift_right_amount")))
-              .bind("rotate_expr")),
+      expr(BitwiseOr(ShiftLeft(BindDeclRef("v"),
+                               integerLiteral().bind("shift_left_amount")),
+                     ShiftRight(BoundDeclRef("v"),
+                                integerLiteral().bind("shift_right_amount"))),
+           optionally(hasParent(castExpr(hasType(isInteger())).bind("cast"))))
+          .bind("rotate_expr"),
       this);
 }
 
@@ -114,16 +113,6 @@ void UseStdBitCheck::registerPPCallbacks(const SourceManager &SM,
 void UseStdBitCheck::storeOptions(ClangTidyOptions::OptionMap &Opts) {
   Options.store(Opts, "IncludeStyle", IncludeInserter.getStyle());
   Options.store(Opts, "StrictMode", StrictMode);
-}
-
-static const Expr *getParentExprOrSelf(const Expr *E, ASTContext &Context) {
-  ParentMapContext &PMap = Context.getParentMapContext();
-  const DynTypedNodeList P = PMap.getParents(*E);
-  if (P.size() != 1)
-    return nullptr;
-
-  const Expr *ParentE = P[0].get<Expr>();
-  return ParentE ? ParentE : E;
 }
 
 void UseStdBitCheck::check(const MatchFinder::MatchResult &Result) {
@@ -172,12 +161,10 @@ void UseStdBitCheck::check(const MatchFinder::MatchResult &Result) {
                  Result.Nodes.getNodeAs<Expr>("rotate_expr")) {
     // Detect if the expression is an explicit cast. If that's the case we don't
     // need to insert a cast.
-    const Expr *ParentExprOrSelf = getParentExprOrSelf(MatchedExpr, Context);
+
     bool HasExplicitIntegerCast = false;
-    if (const auto *CE = dyn_cast<CastExpr>(ParentExprOrSelf)) {
-      HasExplicitIntegerCast =
-          CE->getType()->isIntegerType() && !isa<ImplicitCastExpr>(CE);
-    }
+    if (const Expr *CE = Result.Nodes.getNodeAs<CastExpr>("cast"))
+      HasExplicitIntegerCast = !isa<ImplicitCastExpr>(CE);
 
     const auto *MatchedVarDecl = Result.Nodes.getNodeAs<VarDecl>("v");
     const llvm::APInt ShiftLeftAmount =
@@ -197,7 +184,7 @@ void UseStdBitCheck::check(const MatchFinder::MatchResult &Result) {
     if (MatchedVarSize != (ShiftLeftAmount + ShiftRightAmount))
       return;
 
-    // Only insert cast if the operand is the result is not subject to cast and
+    // Only insert cast if the operand is not subject to cast and
     // some implicit promotion happened.
     const bool NeedsIntCast =
         StrictMode && !HasExplicitIntegerCast &&
@@ -210,19 +197,13 @@ void UseStdBitCheck::check(const MatchFinder::MatchResult &Result) {
     auto Diag = diag(MatchedExpr->getBeginLoc(), "use 'std::%0' instead")
                 << ReplacementFuncName;
     if (auto R = MatchedExpr->getSourceRange();
-        R.getBegin().isMacroID() && !R.getEnd().isMacroID())
+        R.getBegin().isMacroID() || R.getEnd().isMacroID())
       return;
-
-    const SourceLocation PreviousLocation =
-        MatchedExpr->getBeginLoc().getLocWithOffset(-1);
-    const bool NeedsSpace =
-        isAlphanumeric(*Source.getCharacterData(PreviousLocation));
 
     Diag << FixItHint::CreateReplacement(
                 MatchedExpr->getSourceRange(),
-                llvm::formatv("{3}{4}std::{0}({1}, {2}){5}",
-                              ReplacementFuncName, MatchedVarDecl->getName(),
-                              ReplacementShiftAmount, NeedsSpace ? " " : "",
+                llvm::formatv("{3}std::{0}({1}, {2}){4}", ReplacementFuncName,
+                              MatchedVarDecl->getName(), ReplacementShiftAmount,
                               NeedsIntCast ? "static_cast<int>(" : "",
                               NeedsIntCast ? ")" : "")
                     .str())

--- a/clang-tools-extra/clang-tidy/modernize/UseStdBitCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/UseStdBitCheck.cpp
@@ -18,7 +18,8 @@ UseStdBitCheck::UseStdBitCheck(StringRef Name, ClangTidyContext *Context)
     : ClangTidyCheck(Name, Context),
       IncludeInserter(Options.getLocalOrGlobal("IncludeStyle",
                                                utils::IncludeSorter::IS_LLVM),
-                      areDiagsSelfContained()) {}
+                      areDiagsSelfContained()),
+      StrictMode(Options.get("StrictMode", false)) {}
 
 void UseStdBitCheck::registerMatchers(MatchFinder *Finder) {
   const auto MakeBinaryOperatorMatcher = [](auto Op) {
@@ -94,11 +95,13 @@ void UseStdBitCheck::registerMatchers(MatchFinder *Finder) {
 
   // Rotating an integer by a fixed amount
   Finder->addMatcher(
-      BitwiseOr(ShiftLeft(BindDeclRef("v"),
-                          integerLiteral().bind("shift_left_amount")),
-                ShiftRight(BoundDeclRef("v"),
-                           integerLiteral().bind("shift_right_amount")))
-          .bind("rotate_expr"),
+      traverse(
+          TK_AsIs,
+          BitwiseOr(ShiftLeft(BindDeclRef("v"),
+                              integerLiteral().bind("shift_left_amount")),
+                    ShiftRight(BoundDeclRef("v"),
+                               integerLiteral().bind("shift_right_amount")))
+              .bind("rotate_expr")),
       this);
 }
 
@@ -110,10 +113,21 @@ void UseStdBitCheck::registerPPCallbacks(const SourceManager &SM,
 
 void UseStdBitCheck::storeOptions(ClangTidyOptions::OptionMap &Opts) {
   Options.store(Opts, "IncludeStyle", IncludeInserter.getStyle());
+  Options.store(Opts, "StrictMode", StrictMode);
+}
+
+static const Expr *GetParentExprOrSelf(const Expr *E, ASTContext &Context) {
+  ParentMapContext &PMap = Context.getParentMapContext();
+  DynTypedNodeList P = PMap.getParents(*E);
+  if (P.size() != 1)
+    return nullptr;
+
+  const Expr *ParentE = P[0].get<Expr>();
+  return ParentE ? ParentE : E;
 }
 
 void UseStdBitCheck::check(const MatchFinder::MatchResult &Result) {
-  const ASTContext &Context = *Result.Context;
+  ASTContext &Context = *Result.Context;
   const SourceManager &Source = Context.getSourceManager();
 
   if (const auto *MatchedExpr =
@@ -155,11 +169,20 @@ void UseStdBitCheck::check(const MatchFinder::MatchResult &Result) {
                   Source.getFileID(MatchedExpr->getBeginLoc()), "<bit>");
     }
   } else if (const auto *MatchedExpr =
-                 Result.Nodes.getNodeAs<BinaryOperator>("rotate_expr")) {
+                 Result.Nodes.getNodeAs<Expr>("rotate_expr")) {
+    // Detect if the expression is an explicit cast. If that's the case we don't
+    // need to insert a cast.
+    const Expr *ParentExprOrSelf = GetParentExprOrSelf(MatchedExpr, Context);
+    bool HasExplicitIntegerCast = false;
+    if (const auto *CE = dyn_cast<CastExpr>(ParentExprOrSelf)) {
+      HasExplicitIntegerCast =
+          CE->getType()->isIntegerType() && !isa<ImplicitCastExpr>(CE);
+    }
+
     const auto *MatchedVarDecl = Result.Nodes.getNodeAs<VarDecl>("v");
-    const auto ShiftLeftAmount =
+    const llvm::APInt ShiftLeftAmount =
         Result.Nodes.getNodeAs<IntegerLiteral>("shift_left_amount")->getValue();
-    const auto ShiftRightAmount =
+    const llvm::APInt ShiftRightAmount =
         Result.Nodes.getNodeAs<IntegerLiteral>("shift_right_amount")
             ->getValue();
     const uint64_t MatchedVarSize =
@@ -174,8 +197,11 @@ void UseStdBitCheck::check(const MatchFinder::MatchResult &Result) {
     if (MatchedVarSize != (ShiftLeftAmount + ShiftRightAmount))
       return;
 
+    // Only insert cast if the operand is the result is not subject to cast and
+    // some implicit promotion happened.
     const bool NeedsIntCast =
-        MatchedExpr->getType() != MatchedVarDecl->getType();
+        StrictMode && !HasExplicitIntegerCast &&
+        Context.getTypeSize(MatchedExpr->getType()) > MatchedVarSize;
     const bool IsRotl = ShiftRightAmount.sge(ShiftLeftAmount);
 
     const StringRef ReplacementFuncName = IsRotl ? "rotl" : "rotr";
@@ -184,17 +210,24 @@ void UseStdBitCheck::check(const MatchFinder::MatchResult &Result) {
     auto Diag = diag(MatchedExpr->getBeginLoc(), "use 'std::%0' instead")
                 << ReplacementFuncName;
     if (auto R = MatchedExpr->getSourceRange();
-        !R.getBegin().isMacroID() && !R.getEnd().isMacroID()) {
-      Diag << FixItHint::CreateReplacement(
-                  MatchedExpr->getSourceRange(),
-                  llvm::formatv("{3}std::{0}({1}, {2})", ReplacementFuncName,
-                                MatchedVarDecl->getName(),
-                                ReplacementShiftAmount,
-                                NeedsIntCast ? "(int)" : "")
-                      .str())
-           << IncludeInserter.createIncludeInsertion(
-                  Source.getFileID(MatchedExpr->getBeginLoc()), "<bit>");
-    }
+        R.getBegin().isMacroID() && !R.getEnd().isMacroID())
+      return;
+
+    const SourceLocation PreviousLocation =
+        MatchedExpr->getBeginLoc().getLocWithOffset(-1);
+    const bool NeedsSpace =
+        isAlphanumeric(*Source.getCharacterData(PreviousLocation));
+
+    Diag << FixItHint::CreateReplacement(
+                MatchedExpr->getSourceRange(),
+                llvm::formatv("{3}{4}std::{0}({1}, {2}){5}",
+                              ReplacementFuncName, MatchedVarDecl->getName(),
+                              ReplacementShiftAmount, NeedsSpace ? " " : "",
+                              NeedsIntCast ? "static_cast<int>(" : "",
+                              NeedsIntCast ? ")" : "")
+                    .str())
+         << IncludeInserter.createIncludeInsertion(
+                Source.getFileID(MatchedExpr->getBeginLoc()), "<bit>");
 
   } else {
     llvm_unreachable("unexpected match");

--- a/clang-tools-extra/clang-tidy/modernize/UseStdBitCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/UseStdBitCheck.cpp
@@ -116,9 +116,9 @@ void UseStdBitCheck::storeOptions(ClangTidyOptions::OptionMap &Opts) {
   Options.store(Opts, "StrictMode", StrictMode);
 }
 
-static const Expr *GetParentExprOrSelf(const Expr *E, ASTContext &Context) {
+static const Expr *getParentExprOrSelf(const Expr *E, ASTContext &Context) {
   ParentMapContext &PMap = Context.getParentMapContext();
-  DynTypedNodeList P = PMap.getParents(*E);
+  const DynTypedNodeList P = PMap.getParents(*E);
   if (P.size() != 1)
     return nullptr;
 
@@ -172,7 +172,7 @@ void UseStdBitCheck::check(const MatchFinder::MatchResult &Result) {
                  Result.Nodes.getNodeAs<Expr>("rotate_expr")) {
     // Detect if the expression is an explicit cast. If that's the case we don't
     // need to insert a cast.
-    const Expr *ParentExprOrSelf = GetParentExprOrSelf(MatchedExpr, Context);
+    const Expr *ParentExprOrSelf = getParentExprOrSelf(MatchedExpr, Context);
     bool HasExplicitIntegerCast = false;
     if (const auto *CE = dyn_cast<CastExpr>(ParentExprOrSelf)) {
       HasExplicitIntegerCast =

--- a/clang-tools-extra/clang-tidy/modernize/UseStdBitCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/UseStdBitCheck.cpp
@@ -8,6 +8,7 @@
 
 #include "UseStdBitCheck.h"
 #include "clang/ASTMatchers/ASTMatchFinder.h"
+#include "llvm/Support/FormatVariadic.h"
 
 using namespace clang::ast_matchers;
 
@@ -37,7 +38,10 @@ void UseStdBitCheck::registerMatchers(MatchFinder *Finder) {
 
   const auto LogicalAnd = MakeCommutativeBinaryOperatorMatcher("&&");
   const auto Sub = MakeBinaryOperatorMatcher("-");
+  const auto ShiftLeft = MakeBinaryOperatorMatcher("<<");
+  const auto ShiftRight = MakeBinaryOperatorMatcher(">>");
   const auto BitwiseAnd = MakeCommutativeBinaryOperatorMatcher("&");
+  const auto BitwiseOr = MakeCommutativeBinaryOperatorMatcher("|");
   const auto CmpNot = MakeCommutativeBinaryOperatorMatcher("!=");
   const auto CmpGt = MakeBinaryOperatorMatcher(">");
   const auto CmpGte = MakeBinaryOperatorMatcher(">=");
@@ -86,6 +90,15 @@ void UseStdBitCheck::registerMatchers(MatchFinder *Finder) {
           on(cxxConstructExpr(
               hasArgument(0, expr(hasType(isUnsignedInteger())).bind("v")))))
           .bind("popcount_expr"),
+      this);
+
+  // Rotating an integer by a fixed amount
+  Finder->addMatcher(
+      BitwiseOr(ShiftLeft(BindDeclRef("v"),
+                          integerLiteral().bind("shift_left_amount")),
+                ShiftRight(BoundDeclRef("v"),
+                           integerLiteral().bind("shift_right_amount")))
+          .bind("rotate_expr"),
       this);
 }
 
@@ -141,6 +154,48 @@ void UseStdBitCheck::check(const MatchFinder::MatchResult &Result) {
            << IncludeInserter.createIncludeInsertion(
                   Source.getFileID(MatchedExpr->getBeginLoc()), "<bit>");
     }
+  } else if (const auto *MatchedExpr =
+                 Result.Nodes.getNodeAs<BinaryOperator>("rotate_expr")) {
+    const auto *MatchedVarDecl = Result.Nodes.getNodeAs<VarDecl>("v");
+    const auto ShiftLeftAmount =
+        Result.Nodes.getNodeAs<IntegerLiteral>("shift_left_amount")->getValue();
+    const auto ShiftRightAmount =
+        Result.Nodes.getNodeAs<IntegerLiteral>("shift_right_amount")
+            ->getValue();
+    const uint64_t MatchedVarSize =
+        Context.getTypeSize(MatchedVarDecl->getType());
+
+    // Overflowing shifts
+    if (ShiftLeftAmount.sge(MatchedVarSize))
+      return;
+    if (ShiftRightAmount.sge(MatchedVarSize))
+      return;
+    // Not a rotation.
+    if (MatchedVarSize != (ShiftLeftAmount + ShiftRightAmount))
+      return;
+
+    const bool NeedsIntCast =
+        MatchedExpr->getType() != MatchedVarDecl->getType();
+    const bool IsRotl = ShiftRightAmount.sge(ShiftLeftAmount);
+
+    const StringRef ReplacementFuncName = IsRotl ? "rotl" : "rotr";
+    const uint64_t ReplacementShiftAmount =
+        (IsRotl ? ShiftLeftAmount : ShiftRightAmount).getZExtValue();
+    auto Diag = diag(MatchedExpr->getBeginLoc(), "use 'std::%0' instead")
+                << ReplacementFuncName;
+    if (auto R = MatchedExpr->getSourceRange();
+        !R.getBegin().isMacroID() && !R.getEnd().isMacroID()) {
+      Diag << FixItHint::CreateReplacement(
+                  MatchedExpr->getSourceRange(),
+                  llvm::formatv("{3}std::{0}({1}, {2})", ReplacementFuncName,
+                                MatchedVarDecl->getName(),
+                                ReplacementShiftAmount,
+                                NeedsIntCast ? "(int)" : "")
+                      .str())
+           << IncludeInserter.createIncludeInsertion(
+                  Source.getFileID(MatchedExpr->getBeginLoc()), "<bit>");
+    }
+
   } else {
     llvm_unreachable("unexpected match");
   }

--- a/clang-tools-extra/clang-tidy/modernize/UseStdBitCheck.h
+++ b/clang-tools-extra/clang-tidy/modernize/UseStdBitCheck.h
@@ -37,7 +37,7 @@ public:
 
 private:
   utils::IncludeInserter IncludeInserter;
-  const bool StrictMode;
+  const bool HonorIntPromotion;
 };
 
 } // namespace clang::tidy::modernize

--- a/clang-tools-extra/clang-tidy/modernize/UseStdBitCheck.h
+++ b/clang-tools-extra/clang-tidy/modernize/UseStdBitCheck.h
@@ -37,6 +37,7 @@ public:
 
 private:
   utils::IncludeInserter IncludeInserter;
+  const bool StrictMode;
 };
 
 } // namespace clang::tidy::modernize

--- a/clang-tools-extra/docs/clang-tidy/checks/modernize/use-std-bit.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/modernize/use-std-bit.rst
@@ -29,6 +29,7 @@ Options
 
   .. code:: c++
 
+    // Return type is deduced as 'int' (not 'unsigned char') due to implicit conversions.
     auto foo(unsigned char x) {
       return x << 3 | x >> 5;
     }

--- a/clang-tools-extra/docs/clang-tidy/checks/modernize/use-std-bit.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/modernize/use-std-bit.rst
@@ -22,7 +22,7 @@ Expression                     Replacement
 Options
 -------
 
-.. option:: StrictMode
+.. option:: HonorIntPromotion
 
   When set to ``true`` (default is ``false``), insert explicit cast to make sure the
   type of the substituted expression is unchanged. Example:

--- a/clang-tools-extra/docs/clang-tidy/checks/modernize/use-std-bit.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/modernize/use-std-bit.rst
@@ -18,3 +18,27 @@ Expression                     Replacement
 ``x << 3 | x >> 61``           ``std::rotl(x, 3)``
 ``x << 61 | x >> 3``           ``std::rotr(x, 3)``
 ============================== =======================
+
+Options
+-------
+
+.. option:: StrictMode
+
+  When set to ``true`` (default is ``false``), insert explicit cast to make sure the
+  type of the substituted expression is unchanged. Example:
+
+  .. code:: c++
+
+    auto foo(unsigned char x) {
+      return x << 3 | x >> 5;
+    }
+
+  Becomes:
+
+  .. code:: c++
+
+    #include <bit>
+
+    auto foo(unsigned char x) {
+      return static_cast<int>(std::rotl(x, 3));
+    }

--- a/clang-tools-extra/docs/clang-tidy/checks/modernize/use-std-bit.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/modernize/use-std-bit.rst
@@ -15,4 +15,6 @@ Expression                     Replacement
 ``(x != 0) && !(x & (x - 1))`` ``std::has_one_bit(x)``
 ``(x > 0) && !(x & (x - 1))``  ``std::has_one_bit(x)``
 ``std::bitset<N>(x).count()``  ``std::popcount(x)``
+``x << 3 | x >> 61``           ``std::rotl(x, 3)``
+``x << 61 | x >> 3``           ``std::rotr(x, 3)``
 ============================== =======================

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/use-std-bit.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/use-std-bit.cpp
@@ -1,5 +1,5 @@
-// RUN: %check_clang_tidy -std=c++20-or-later %s modernize-use-std-bit %t -check-suffixes=,NOSTRICT
-// RUN: %check_clang_tidy -std=c++20-or-later %s modernize-use-std-bit %t -config="{CheckOptions: { modernize-use-std-bit.StrictMode: true }}" -check-suffixes=,STRICT
+// RUN: %check_clang_tidy -std=c++20-or-later %s modernize-use-std-bit %t -check-suffixes=,NOPROMOTION
+// RUN: %check_clang_tidy -std=c++20-or-later %s modernize-use-std-bit %t -config="{CheckOptions: { modernize-use-std-bit.HonorIntPromotion: true }}" -check-suffixes=,PROMOTION
 // CHECK-FIXES: #include <bit>
 
 /*
@@ -206,8 +206,8 @@ using uint32_t = __UINT32_TYPE__;
 
 int rotate_left_pattern(unsigned char x) {
   // CHECK-MESSAGES: :[[@LINE+3]]:10: warning: use 'std::rotl' instead [modernize-use-std-bit]
-  // CHECK-FIXES-NOSTRICT: return std::rotl(x, 3);
-  // CHECK-FIXES-STRICT: return static_cast<int>(std::rotl(x, 3));
+  // CHECK-FIXES-NOPROMOTION: return std::rotl(x, 3);
+  // CHECK-FIXES-PROMOTION: return static_cast<int>(std::rotl(x, 3));
   return (x) << 3 | x >> 5;
 }
 
@@ -219,22 +219,22 @@ auto rotate_left_pattern_with_cast(unsigned char x) {
 
 unsigned char rotate_left_pattern_with_implicit_cast(unsigned char x) {
   // CHECK-MESSAGES: :[[@LINE+3]]:10: warning: use 'std::rotl' instead [modernize-use-std-bit]
-  // CHECK-FIXES-NOSTRICT: return std::rotl(x, 3);
-  // CHECK-FIXES-STRICT: return static_cast<int>(std::rotl(x, 3));
+  // CHECK-FIXES-NOPROMOTION: return std::rotl(x, 3);
+  // CHECK-FIXES-PROMOTION: return static_cast<int>(std::rotl(x, 3));
   return (x) << 3 | x >> 5;
 }
 
 auto rotate_left_pattern_without_cast(unsigned char x) {
   // CHECK-MESSAGES: :[[@LINE+3]]:10: warning: use 'std::rotl' instead [modernize-use-std-bit]
-  // CHECK-FIXES-NOSTRICT: return std::rotl(x, 3);
-  // CHECK-FIXES-STRICT: return static_cast<int>(std::rotl(x, 3));
+  // CHECK-FIXES-NOPROMOTION: return std::rotl(x, 3);
+  // CHECK-FIXES-PROMOTION: return static_cast<int>(std::rotl(x, 3));
   return x << 3 | x >> 5;
 }
 
 uint32_t rotate_left_pattern_with_surrounding_parenthesis(unsigned char x) {
   // CHECK-MESSAGES: :[[@LINE+3]]:11: warning: use 'std::rotl' instead [modernize-use-std-bit]
-  // CHECK-FIXES-NOSTRICT: return (std::rotl(x, 3));
-  // CHECK-FIXES-STRICT: return (static_cast<int>(std::rotl(x, 3)));
+  // CHECK-FIXES-NOPROMOTION: return (std::rotl(x, 3));
+  // CHECK-FIXES-PROMOTION: return (static_cast<int>(std::rotl(x, 3)));
   return (x << 3 | x >> 5);
 }
 
@@ -252,8 +252,8 @@ uint32_t rotate_left_pattern_int32(uint32_t x) {
 
 unsigned char rotate_left_pattern_perm(unsigned char x) {
   // CHECK-MESSAGES: :[[@LINE+3]]:10: warning: use 'std::rotl' instead [modernize-use-std-bit]
-  // CHECK-FIXES-NOSTRICT: return std::rotl(x, 3);
-  // CHECK-FIXES-STRICT: return static_cast<int>(std::rotl(x, 3));
+  // CHECK-FIXES-NOPROMOTION: return std::rotl(x, 3);
+  // CHECK-FIXES-PROMOTION: return static_cast<int>(std::rotl(x, 3));
   return x >> 5 | x << 3;
 }
 
@@ -271,8 +271,8 @@ uint64_t rotate_right_pattern(uint64_t x) {
 
 unsigned char rotate_right_pattern_perm(unsigned char x0) {
   // CHECK-MESSAGES: :[[@LINE+3]]:10: warning: use 'std::rotr' instead [modernize-use-std-bit]
-  // CHECK-FIXES-NOSTRICT: return std::rotr(x0, 3);
-  // CHECK-FIXES-STRICT: return static_cast<int>(std::rotr(x0, 3));
+  // CHECK-FIXES-NOPROMOTION: return std::rotr(x0, 3);
+  // CHECK-FIXES-PROMOTION: return static_cast<int>(std::rotr(x0, 3));
   return x0 >> 3 | x0 << 5;
 }
 

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/use-std-bit.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/use-std-bit.cpp
@@ -1,4 +1,5 @@
-// RUN: %check_clang_tidy -std=c++20-or-later %s modernize-use-std-bit %t
+// RUN: %check_clang_tidy -std=c++20-or-later %s modernize-use-std-bit %t -check-suffixes=,NOSTRICT
+// RUN: %check_clang_tidy -std=c++20-or-later %s modernize-use-std-bit %t -config="{CheckOptions: { modernize-use-std-bit.StrictMode: true }}" -check-suffixes=,STRICT
 // CHECK-FIXES: #include <bit>
 
 /*
@@ -199,30 +200,80 @@ unsigned invalid_popcount_bitset(unsigned x, signed y) {
 /*
  * rotate patterns
  */
-unsigned char rotate_left_pattern(unsigned char x) {
-  // CHECK-MESSAGES: :[[@LINE+2]]:10: warning: use 'std::rotl' instead [modernize-use-std-bit]
-  // CHECK-FIXES: return (int)std::rotl(x, 3);
+
+using uint64_t = __UINT64_TYPE__;
+using uint32_t = __UINT32_TYPE__;
+
+int rotate_left_pattern(unsigned char x) {
+  // CHECK-MESSAGES: :[[@LINE+3]]:10: warning: use 'std::rotl' instead [modernize-use-std-bit]
+  // CHECK-FIXES-NOSTRICT: return std::rotl(x, 3);
+  // CHECK-FIXES-STRICT: return static_cast<int>(std::rotl(x, 3));
+  return (x) << 3 | x >> 5;
+}
+
+auto rotate_left_pattern_with_cast(unsigned char x) {
+  // CHECK-MESSAGES: :[[@LINE+2]]:29: warning: use 'std::rotl' instead [modernize-use-std-bit]
+  // CHECK-FIXES: return static_cast<short>(std::rotl(x, 3));
+  return static_cast<short>((x) << 3 | x >> 5);
+}
+
+unsigned char rotate_left_pattern_with_implicit_cast(unsigned char x) {
+  // CHECK-MESSAGES: :[[@LINE+3]]:10: warning: use 'std::rotl' instead [modernize-use-std-bit]
+  // CHECK-FIXES-NOSTRICT: return std::rotl(x, 3);
+  // CHECK-FIXES-STRICT: return static_cast<int>(std::rotl(x, 3));
+  return (x) << 3 | x >> 5;
+}
+
+auto rotate_left_pattern_without_cast(unsigned char x) {
+  // CHECK-MESSAGES: :[[@LINE+3]]:10: warning: use 'std::rotl' instead [modernize-use-std-bit]
+  // CHECK-FIXES-NOSTRICT: return std::rotl(x, 3);
+  // CHECK-FIXES-STRICT: return static_cast<int>(std::rotl(x, 3));
   return x << 3 | x >> 5;
 }
-unsigned char rotate_left_pattern_perm(unsigned char x) {
+
+uint32_t rotate_left_pattern_with_surrounding_parenthesis(unsigned char x) {
+  // CHECK-MESSAGES: :[[@LINE+3]]:11: warning: use 'std::rotl' instead [modernize-use-std-bit]
+  // CHECK-FIXES-NOSTRICT: return (std::rotl(x, 3));
+  // CHECK-FIXES-STRICT: return (static_cast<int>(std::rotl(x, 3)));
+  return (x << 3 | x >> 5);
+}
+
+uint64_t rotate_left_pattern_int64(uint64_t x) {
   // CHECK-MESSAGES: :[[@LINE+2]]:10: warning: use 'std::rotl' instead [modernize-use-std-bit]
-  // CHECK-FIXES: return (int)std::rotl(x, 3);
+  // CHECK-FIXES: return std::rotl(x, 3);
+  return x << 3 | x >> 61;
+}
+
+uint32_t rotate_left_pattern_int32(uint32_t x) {
+  // CHECK-MESSAGES: :[[@LINE+2]]:10: warning: use 'std::rotl' instead [modernize-use-std-bit]
+  // CHECK-FIXES: return std::rotl(x, 3);
+  return (x) << 3 | x >> 29;
+}
+
+unsigned char rotate_left_pattern_perm(unsigned char x) {
+  // CHECK-MESSAGES: :[[@LINE+3]]:10: warning: use 'std::rotl' instead [modernize-use-std-bit]
+  // CHECK-FIXES-NOSTRICT: return std::rotl(x, 3);
+  // CHECK-FIXES-STRICT: return static_cast<int>(std::rotl(x, 3));
   return x >> 5 | x << 3;
 }
-unsigned char rotate_swap_pattern(unsigned char x) {
+
+uint32_t rotate_swap_pattern(uint32_t x) {
   // CHECK-MESSAGES: :[[@LINE+2]]:10: warning: use 'std::rotl' instead [modernize-use-std-bit]
-  // CHECK-FIXES: return (int)std::rotl(x, 4);
-  return x << 4 | x >> 4;
+  // CHECK-FIXES: return std::rotl(x, 16);
+  return x << 16 | x >> 16;
 }
-unsigned char rotate_right_pattern(unsigned char x) {
+
+uint64_t rotate_right_pattern(uint64_t x) {
   // CHECK-MESSAGES: :[[@LINE+2]]:10: warning: use 'std::rotr' instead [modernize-use-std-bit]
-  // CHECK-FIXES: return (int)std::rotr(x, 3);
-  return x << 5 | x >> 3;
+  // CHECK-FIXES: return std::rotr(x, 3);
+  return (x << 61) | ((x >> 3));
 }
-unsigned char rotate_right_pattern_perm(unsigned char x) {
-  // CHECK-MESSAGES: :[[@LINE+2]]:10: warning: use 'std::rotr' instead [modernize-use-std-bit]
-  // CHECK-FIXES: return (int)std::rotr(x, 3);
-  return x >> 3 | x << 5;
+
+unsigned char rotate_right_pattern_perm(unsigned char x0) {
+  // CHECK-MESSAGES: :[[@LINE+3]]:10: warning: use 'std::rotr' instead [modernize-use-std-bit]
+  // CHECK-FIXES-NOSTRICT: return std::rotr(x0, 3);
+  // CHECK-FIXES-STRICT: return static_cast<int>(std::rotr(x0, 3));
+  return x0 >> 3 | x0 << 5;
 }
 
 #define ROTR v >> 3 | v << 5

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/use-std-bit.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/use-std-bit.cpp
@@ -195,3 +195,59 @@ unsigned invalid_popcount_bitset(unsigned x, signed y) {
   };
 }
 
+
+/*
+ * rotate patterns
+ */
+unsigned char rotate_left_pattern(unsigned char x) {
+  // CHECK-MESSAGES: :[[@LINE+2]]:10: warning: use 'std::rotl' instead [modernize-use-std-bit]
+  // CHECK-FIXES: return (int)std::rotl(x, 3);
+  return x << 3 | x >> 5;
+}
+unsigned char rotate_left_pattern_perm(unsigned char x) {
+  // CHECK-MESSAGES: :[[@LINE+2]]:10: warning: use 'std::rotl' instead [modernize-use-std-bit]
+  // CHECK-FIXES: return (int)std::rotl(x, 3);
+  return x >> 5 | x << 3;
+}
+unsigned char rotate_swap_pattern(unsigned char x) {
+  // CHECK-MESSAGES: :[[@LINE+2]]:10: warning: use 'std::rotl' instead [modernize-use-std-bit]
+  // CHECK-FIXES: return (int)std::rotl(x, 4);
+  return x << 4 | x >> 4;
+}
+unsigned char rotate_right_pattern(unsigned char x) {
+  // CHECK-MESSAGES: :[[@LINE+2]]:10: warning: use 'std::rotr' instead [modernize-use-std-bit]
+  // CHECK-FIXES: return (int)std::rotr(x, 3);
+  return x << 5 | x >> 3;
+}
+unsigned char rotate_right_pattern_perm(unsigned char x) {
+  // CHECK-MESSAGES: :[[@LINE+2]]:10: warning: use 'std::rotr' instead [modernize-use-std-bit]
+  // CHECK-FIXES: return (int)std::rotr(x, 3);
+  return x >> 3 | x << 5;
+}
+
+#define ROTR v >> 3 | v << 5
+unsigned char rotate_macro(unsigned char v) {
+  // CHECK-MESSAGES: :[[@LINE+2]]:10: warning: use 'std::rotr' instead [modernize-use-std-bit]
+  // No fixes, it comes from macro expansion.
+  return ROTR;
+}
+
+/*
+ * Invalid rotate patterns
+ */
+void invalid_rotate_patterns(unsigned char x, signed char y, unsigned char z) {
+  int patterns[] = {
+    // non-matching references
+    x >> 3 | z << 5,
+    // bad shift combination
+    x >> 3 | x << 6,
+    x >> 4 | x << 3,
+    // bad operator combination
+    x << 3 | x << 6,
+    x + 3 | x << 6,
+    x >> 3 & x << 5,
+    x >> 5 ^ x << 3,
+    // unsupported types
+    y >> 4 | y << 4,
+  };
+}


### PR DESCRIPTION
Basically turning `x << N | x >> (64 - N)` into `std::rotl(x, N)`.