### PR TITLE
[lldb-dap] Mark return value as readonly

### DIFF
--- a/lldb/test/API/tools/lldb-dap/variables/TestDAP_variables.py
+++ b/lldb/test/API/tools/lldb-dap/variables/TestDAP_variables.py
@@ -718,7 +718,7 @@ class TestDAP_variables(lldbdap_testcase.DAPTestCaseBase):
 
         return_name = "(Return Value)"
         verify_locals = {
-            return_name: {"equals": {"type": "int", "value": "300"}},
+            return_name: {"equals": {"type": "int", "value": "300"}, "readOnly": True},
             "argc": {},
             "argv": {},
             "pt": {"readOnly": True},

--- a/lldb/tools/lldb-dap/ProtocolUtils.cpp
+++ b/lldb/tools/lldb-dap/ProtocolUtils.cpp
@@ -300,7 +300,8 @@ Variable CreateVariable(lldb::SBValue v, var_ref_t var_ref, bool format_hex,
     var.memoryReference = addr;
 
   bool is_readonly = v.GetType().IsAggregateType() ||
-                     v.GetValueType() == lldb::eValueTypeRegisterSet;
+                     v.GetValueType() == lldb::eValueTypeRegisterSet ||
+                     var.name == "(Return Value)";
   if (is_readonly) {
     if (!var.presentationHint)
       var.presentationHint = {VariablePresentationHint()};


### PR DESCRIPTION
Marked return value as readonly to give VS Code a hint that this variable doesn't support `setVariable` request.