### PR TITLE
[CIR][CIRGen] Introduce ExtraFuncAttr to FuncOp

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIRAttrs.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRAttrs.td
@@ -944,6 +944,28 @@ def CIR_VisibilityAttr : CIR_EnumAttr<CIR_VisibilityKind, "visibility"> {
 }
 
 //===----------------------------------------------------------------------===//
+// ExtraFuncAttr
+//===----------------------------------------------------------------------===//
+
+def CIR_ExtraFuncAttr : CIR_Attr<"ExtraFuncAttributes", "extra"> {
+  let summary = "Represents aggregated attributes for a function";
+  let description = [{
+    This is a wrapper of attribute dictionary that contains extra attributes of
+    a function.
+  }];
+
+  let parameters = (ins "mlir::DictionaryAttr":$elements);
+
+  let builders = [
+    AttrBuilderWithInferredContext<(ins "mlir::DictionaryAttr":$elements), [{
+      return $_get(elements.getContext(), elements);
+    }]>
+  ];
+
+  let assemblyFormat = [{ `(` $elements `)` }];
+}
+
+//===----------------------------------------------------------------------===//
 // GloblCtorAttr
 //===----------------------------------------------------------------------===//
 

--- a/clang/include/clang/CIR/Dialect/IR/CIRDialect.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRDialect.td
@@ -76,6 +76,9 @@ def CIR_Dialect : Dialect {
     static llvm::StringRef getResAttrsAttrName() { return "res_attrs"; }
     static llvm::StringRef getArgAttrsAttrName() { return "arg_attrs"; }
 
+    static llvm::StringRef getAMDGPUCodeObjectVersionAttrName() { return "cir.amdhsa_code_object_version"; }
+    static llvm::StringRef getAMDGPUPrintfKindAttrName() { return "cir.amdgpu_printf_kind"; }
+
     void registerAttributes();
     void registerTypes();
 

--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -3418,6 +3418,11 @@ def CIR_FuncOp : CIR_Op<"func", [
     without a prototype and, consequently, may contain calls with invalid
     arguments and undefined behavior.
 
+    The `extra_attrs`, which is an aggregate of function-specific attributes is
+    required and mandatory to describle additional attributes that are not listed
+    above. Though mandatory, the prining of the attribute can be omitted if it is
+    empty.
+
     The `global_ctor` keyword indicates whether a function should execute before
     `main()` function, as specified by `__attribute__((constructor))`. An
     execution priority can also be specified `global_ctor(<priority>)`.
@@ -3473,6 +3478,7 @@ def CIR_FuncOp : CIR_Op<"func", [
       CIR_GlobalLinkageKind,
       "cir::GlobalLinkageKind::ExternalLinkage"
     >:$linkage,
+    CIR_ExtraFuncAttr:$extra_attrs,
     OptionalAttr<StrAttr>:$sym_visibility,
     UnitAttr:$comdat,
     OptionalAttr<DictArrayAttr>:$arg_attrs,

--- a/clang/include/clang/CIR/MissingFeatures.h
+++ b/clang/include/clang/CIR/MissingFeatures.h
@@ -75,7 +75,6 @@ struct MissingFeatures {
   static bool opFuncColdHotAttr() { return false; }
   static bool opFuncCPUAndFeaturesAttributes() { return false; }
   static bool opFuncExceptions() { return false; }
-  static bool opFuncExtraAttrs() { return false; }
   static bool opFuncMaybeHandleStaticInExternC() { return false; }
   static bool opFuncMinSizeAttr() { return false; }
   static bool opFuncMultipleReturnVals() { return false; }

--- a/clang/lib/CIR/CodeGen/CIRGenAMDGPU.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenAMDGPU.cpp
@@ -1,0 +1,41 @@
+//===- CIRGenAMDGPU.cpp - AMDGPU-specific logic for CIR generation --------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This contains code dealing with AMDGPU-specific logic of CIR generation.
+//
+//===----------------------------------------------------------------------===//
+
+#include "CIRGenModule.h"
+
+#include "clang/Basic/TargetOptions.h"
+#include "clang/CIR/Dialect/IR/CIRDialect.h"
+#include "llvm/TargetParser/Triple.h"
+
+using namespace clang;
+using namespace clang::CIRGen;
+
+void CIRGenModule::emitAMDGPUMetadata() {
+  // Emit code object version module flag.
+  if (target.getTargetOpts().CodeObjectVersion !=
+      llvm::CodeObjectVersionKind::COV_None) {
+    theModule->setAttr(
+        cir::CIRDialect::getAMDGPUCodeObjectVersionAttrName(),
+        builder.getI32IntegerAttr(target.getTargetOpts().CodeObjectVersion));
+  }
+
+  // Emit printf kind module flag for HIP.
+  if (langOpts.HIP) {
+    llvm::StringRef printfKind =
+        target.getTargetOpts().AMDGPUPrintfKindVal ==
+                TargetOptions::AMDGPUPrintfKind::Hostcall
+            ? "hostcall"
+            : "buffered";
+    theModule->setAttr(cir::CIRDialect::getAMDGPUPrintfKindAttrName(),
+                       builder.getStringAttr(printfKind));
+  }
+}

--- a/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
@@ -1975,6 +1975,9 @@ CIRGenCallee CIRGenFunction::emitDirectCallee(const GlobalDecl &gd) {
             &cgm.getMLIRContext(), cir::GlobalLinkageKind::InternalLinkage));
         clone.setSymVisibility("private");
         clone.setInlineKind(cir::InlineKind::AlwaysInline);
+        mlir::NamedAttrList attrs;
+        clone.setExtraAttrsAttr(cir::ExtraFuncAttributesAttr::get(
+            attrs.getDictionary(&cgm.getMLIRContext())));
       }
       return CIRGenCallee::forDirect(clone, gd);
     }

--- a/clang/lib/CIR/CodeGen/CIRGenFunction.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.cpp
@@ -720,6 +720,9 @@ cir::FuncOp CIRGenFunction::generateCode(clang::GlobalDecl gd, cir::FuncOp fn,
       clone.setLinkage(cir::GlobalLinkageKind::InternalLinkage);
       clone.setSymVisibility("private");
       clone.setInlineKind(cir::InlineKind::AlwaysInline);
+      mlir::NamedAttrList attrs;
+      clone.setExtraAttrsAttr(cir::ExtraFuncAttributesAttr::get(
+          attrs.getDictionary(builder.getContext())));
     }
     fn.setLinkage(cir::GlobalLinkageKind::ExternalLinkage);
     fn.setSymVisibility("private");

--- a/clang/lib/CIR/CodeGen/CIRGenModule.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.cpp
@@ -2356,11 +2356,7 @@ void CIRGenModule::setCIRFunctionAttributes(GlobalDecl globalDecl,
   cir::CallingConv callingConv;
   cir::SideEffect sideEffect;
 
-  // TODO(cir): The current list should be initialized with the extra function
-  // attributes, but we don't have those yet.  For now, the PAL is initialized
-  // with nothing.
-  assert(!cir::MissingFeatures::opFuncExtraAttrs());
-  // Initialize PAL with existing attributes to merge attributes.
+  // TODO(cir): Move all function attributes into extra_attrs.
   mlir::NamedAttrList pal{};
   std::vector<mlir::NamedAttrList> argAttrs(info.arguments().size());
   mlir::NamedAttrList retAttrs{};
@@ -2694,7 +2690,9 @@ CIRGenModule::createCIRFunction(mlir::Location loc, StringRef name,
     mlir::SymbolTable::setSymbolVisibility(
         func, mlir::SymbolTable::Visibility::Private);
 
-    assert(!cir::MissingFeatures::opFuncExtraAttrs());
+    // Initialize with empty dict of extra attributes.
+    func.setExtraAttrsAttr(cir::ExtraFuncAttributesAttr::get(
+        &getMLIRContext(), mlir::DictionaryAttr::get(&getMLIRContext())));
 
     // Mark C++ special member functions (Constructor, Destructor etc.)
     setCXXSpecialMemberAttr(func, funcDecl);

--- a/clang/lib/CIR/CodeGen/CIRGenModule.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.cpp
@@ -2878,6 +2878,9 @@ void CIRGenModule::release() {
   theModule->setAttr(cir::CIRDialect::getModuleLevelAsmAttrName(),
                      builder.getArrayAttr(globalScopeAsm));
 
+  if (getTriple().isAMDGPU())
+    emitAMDGPUMetadata();
+
   // There's a lot of code that is not implemented yet.
   assert(!cir::MissingFeatures::cgmRelease());
 }

--- a/clang/lib/CIR/CodeGen/CIRGenModule.h
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.h
@@ -778,6 +778,9 @@ public:
   /// Print out an error that codegen doesn't support the specified decl yet.
   void errorUnsupported(const Decl *d, llvm::StringRef type);
 
+  /// Emits AMDGPU specific Metadata.
+  void emitAMDGPUMetadata();
+
 private:
   // An ordered map of canonical GlobalDecls to their mangled names.
   llvm::MapVector<clang::GlobalDecl, llvm::StringRef> mangledDeclNames;

--- a/clang/lib/CIR/CodeGen/CIRGenVTables.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenVTables.cpp
@@ -858,6 +858,9 @@ cir::FuncOp CIRGenVTables::maybeEmitThunk(GlobalDecl gd,
     thunkFn =
         cir::FuncOp::create(cgm.getBuilder(), thunk->getLoc(), name.str(),
                             thunkFnTy, cir::GlobalLinkageKind::ExternalLinkage);
+    mlir::NamedAttrList attrs;
+    thunkFn.setExtraAttrsAttr(cir::ExtraFuncAttributesAttr::get(
+        attrs.getDictionary(cgm.getBuilder().getContext())));
     cgm.setCIRFunctionAttributes(md, fnInfo, thunkFn, /*isThunk=*/false);
 
     if (!oldThunkFn->use_empty())

--- a/clang/lib/CIR/CodeGen/CMakeLists.txt
+++ b/clang/lib/CIR/CodeGen/CMakeLists.txt
@@ -14,6 +14,7 @@ add_clang_library(clangCIR
   CIRGenBuiltin.cpp
   CIRGenBuiltinAArch64.cpp
   CIRGenBuiltinAMDGPU.cpp
+  CIRGenAMDGPU.cpp
   CIRGenBuiltinX86.cpp
   CIRGenCall.cpp
   CIRGenClass.cpp

--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -2153,6 +2153,21 @@ ParseResult cir::FuncOp::parse(OpAsmParser &parser, OperationState &state) {
     hasAlias = true;
   }
 
+  // If extra func attributes are present, parse them.
+  NamedAttrList extraAttrs;
+  if (::mlir::succeeded(parser.parseOptionalKeyword("extra"))) {
+    if (parser.parseLParen().failed())
+      return failure();
+    if (parser.parseOptionalAttrDict(extraAttrs).failed())
+      return failure();
+    if (parser.parseRParen().failed())
+      return failure();
+  }
+  state.addAttribute(
+      getExtraAttrsAttrName(state.name),
+      cir::ExtraFuncAttributesAttr::get(
+          parser.getContext(), extraAttrs.getDictionary(parser.getContext())));
+
   mlir::StringAttr personalityNameAttr = getPersonalityAttrName(state.name);
   if (parser.parseOptionalKeyword("personality").succeeded()) {
     if (parser.parseLParen().failed())
@@ -2412,6 +2427,12 @@ void cir::FuncOp::print(OpAsmPrinter &p) {
 
   function_interface_impl::printFunctionAttributes(
       p, *this, cir::FuncOp::getAttributeNames());
+
+  if (!getExtraAttrs().getElements().empty()) {
+    p << " extra(";
+    p.printOptionalAttrDict(getExtraAttrs().getElements().getValue());
+    p << ')';
+  }
 
   // Print the body if this is not an external function.
   Region &body = getOperation()->getRegion(0);

--- a/clang/lib/CIR/Dialect/Transforms/EHABILowering.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/EHABILowering.cpp
@@ -25,6 +25,7 @@
 
 #include "PassDetail.h"
 #include "mlir/IR/Builders.h"
+#include "clang/CIR/Dialect/IR/CIRAttrs.h"
 #include "clang/CIR/Dialect/IR/CIRDialect.h"
 #include "clang/CIR/Dialect/IR/CIROpsEnums.h"
 #include "clang/CIR/Dialect/IR/CIRTypes.h"
@@ -61,6 +62,9 @@ static cir::FuncOp getOrCreateRuntimeFuncDecl(mlir::ModuleOp mod,
   auto funcOp = cir::FuncOp::create(builder, loc, name, funcTy);
   funcOp.setLinkage(cir::GlobalLinkageKind::ExternalLinkage);
   funcOp.setPrivate();
+  mlir::NamedAttrList attrs;
+  funcOp.setExtraAttrsAttr(cir::ExtraFuncAttributesAttr::get(
+      attrs.getDictionary(builder.getContext())));
   return funcOp;
 }
 

--- a/clang/lib/CIR/Dialect/Transforms/LoweringPrepare.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/LoweringPrepare.cpp
@@ -334,8 +334,9 @@ cir::FuncOp LoweringPreparePass::buildRuntimeFunction(
         cir::GlobalLinkageKindAttr::get(builder.getContext(), linkage));
     mlir::SymbolTable::setSymbolVisibility(
         f, mlir::SymbolTable::Visibility::Private);
-
-    assert(!cir::MissingFeatures::opFuncExtraAttrs());
+    mlir::NamedAttrList attrs;
+    f.setExtraAttrsAttr(cir::ExtraFuncAttributesAttr::get(
+        attrs.getDictionary(builder.getContext())));
   }
   return f;
 }

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -1881,7 +1881,6 @@ static void lowerCallAttributes(cir::CIRCallOpInterface op,
         attr.getName() == CIRDialect::getNoReturnAttrName())
       continue;
 
-    assert(!cir::MissingFeatures::opFuncExtraAttrs());
     result.push_back(attr);
   }
 }
@@ -2386,7 +2385,18 @@ void CIRToLLVMFuncOpLowering::lowerFuncAttributes(
           attr.getName() == func.getResAttrsAttrName())))
       continue;
 
-    assert(!cir::MissingFeatures::opFuncExtraAttrs());
+    // Propagate extra function attributes to LLVM via amendOperation. Rename
+    // with "cir." prefix so CIRDialectLLVMIRTranslationInterface picks them up.
+    // Skip empty extra_attrs to avoid leaking CIR dialect attributes into the
+    // LLVM dialect output when there's nothing to translate.
+    if (attr.getName() == func.getExtraAttrsAttrName()) {
+      if (auto extraAttr =
+              mlir::dyn_cast<cir::ExtraFuncAttributesAttr>(attr.getValue());
+          extraAttr && extraAttr.getElements().empty())
+        continue;
+      std::string cirName = "cir." + func.getExtraAttrsAttrName().str();
+      attr.setName(mlir::StringAttr::get(getContext(), cirName));
+    }
     result.push_back(attr);
   }
 }

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVMIR.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVMIR.cpp
@@ -74,7 +74,28 @@ private:
   // Translate CIR's module attributes to LLVM's module metadata
   void amendModule(mlir::ModuleOp mod, mlir::NamedAttribute attribute,
                    mlir::LLVM::ModuleTranslation &moduleTranslation) const {
-    // TODO(cir): Implement this
+    llvm::Module *llvmModule = moduleTranslation.getLLVMModule();
+    llvm::LLVMContext &llvmContext = llvmModule->getContext();
+
+    // AMDGPU module flags
+    if (attribute.getName() == "cir.amdhsa_code_object_version") {
+      if (auto intAttr =
+              mlir::dyn_cast<mlir::IntegerAttr>(attribute.getValue())) {
+        llvmModule->addModuleFlag(llvm::Module::Error,
+                                  "amdhsa_code_object_version",
+                                  static_cast<uint32_t>(intAttr.getInt()));
+      }
+    }
+
+    if (attribute.getName() == "cir.amdgpu_printf_kind") {
+      if (auto strAttr =
+              mlir::dyn_cast<mlir::StringAttr>(attribute.getValue())) {
+        llvm::MDString *mdStr =
+            llvm::MDString::get(llvmContext, strAttr.getValue());
+        llvmModule->addModuleFlag(llvm::Module::Error, "amdgpu_printf_kind",
+                                  mdStr);
+      }
+    }
   }
 };
 

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVMIR.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVMIR.cpp
@@ -68,7 +68,17 @@ private:
                      llvm::ArrayRef<llvm::Instruction *> instructions,
                      mlir::NamedAttribute attribute,
                      mlir::LLVM::ModuleTranslation &moduleTranslation) const {
-    // TODO(cir): Implement this
+    llvm::Function *llvmFunc = moduleTranslation.lookupFunction(func.getName());
+    if (auto extraAttr = mlir::dyn_cast<cir::ExtraFuncAttributesAttr>(
+            attribute.getValue())) {
+      for (mlir::NamedAttribute attr : extraAttr.getElements()) {
+        if (auto strAttr = mlir::dyn_cast<mlir::StringAttr>(attr.getValue())) {
+          llvmFunc->addFnAttr(attr.getName().str(), strAttr.getValue().str());
+        }
+      }
+    }
+    // Drop ammended CIR attribute from LLVM op.
+    func->removeAttr(attribute.getName());
   }
 
   // Translate CIR's module attributes to LLVM's module metadata

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVMIR.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVMIR.cpp
@@ -47,6 +47,35 @@ public:
 
     return mlir::success();
   }
+
+  /// Any named attribute in the CIR dialect, i.e, with name started with
+  /// "cir.", will be handled here.
+  virtual mlir::LogicalResult amendOperation(
+      mlir::Operation *op, llvm::ArrayRef<llvm::Instruction *> instructions,
+      mlir::NamedAttribute attribute,
+      mlir::LLVM::ModuleTranslation &moduleTranslation) const override {
+    if (auto func = dyn_cast<mlir::LLVM::LLVMFuncOp>(op)) {
+      amendFunction(func, instructions, attribute, moduleTranslation);
+    } else if (auto mod = dyn_cast<mlir::ModuleOp>(op)) {
+      amendModule(mod, attribute, moduleTranslation);
+    }
+    return mlir::success();
+  }
+
+private:
+  // Translate CIR's extra function attributes to LLVM's function attributes.
+  void amendFunction(mlir::LLVM::LLVMFuncOp func,
+                     llvm::ArrayRef<llvm::Instruction *> instructions,
+                     mlir::NamedAttribute attribute,
+                     mlir::LLVM::ModuleTranslation &moduleTranslation) const {
+    // TODO(cir): Implement this
+  }
+
+  // Translate CIR's module attributes to LLVM's module metadata
+  void amendModule(mlir::ModuleOp mod, mlir::NamedAttribute attribute,
+                   mlir::LLVM::ModuleTranslation &moduleTranslation) const {
+    // TODO(cir): Implement this
+  }
 };
 
 void registerCIRDialectTranslation(mlir::DialectRegistry &registry) {

--- a/clang/test/CIR/CodeGenHIP/amdgpu-module-flags.hip
+++ b/clang/test/CIR/CodeGenHIP/amdgpu-module-flags.hip
@@ -1,0 +1,30 @@
+#include "../CodeGenCUDA/Inputs/cuda.h"
+
+// REQUIRES: amdgpu-registered-target
+// RUN: %clang_cc1 -triple=amdgcn-amd-amdhsa -x hip -fclangir \
+// RUN:            -fcuda-is-device -emit-cir %s -o %t.cir
+// RUN: FileCheck --check-prefix=CIR %s --input-file=%t.cir
+
+// RUN: %clang_cc1 -triple=amdgcn-amd-amdhsa -x hip -fclangir \
+// RUN:            -fcuda-is-device -emit-llvm %s -o %t.cir.ll
+// RUN: FileCheck --check-prefix=LLVM %s --input-file=%t.cir.ll
+
+// RUN: %clang_cc1 -triple=amdgcn-amd-amdhsa -x hip \
+// RUN:            -fcuda-is-device -emit-llvm %s -o %t.ogcg.ll
+// RUN: FileCheck --check-prefix=OGCG %s --input-file=%t.ogcg.ll
+
+// Test that AMDGPU module flags are emitted correctly.
+
+// CIR: module {{.*}} attributes {
+// CIR-SAME: cir.amdgpu_printf_kind = "hostcall"
+// CIR-SAME: cir.amdhsa_code_object_version = 600
+
+// LLVM: !llvm.module.flags = !{
+// LLVM-DAG: !{i32 1, !"amdhsa_code_object_version", i32 600}
+// LLVM-DAG: !{i32 1, !"amdgpu_printf_kind", !"hostcall"}
+
+// OGCG: !llvm.module.flags = !{
+// OGCG-DAG: !{i32 1, !"amdhsa_code_object_version", i32 600}
+// OGCG-DAG: !{i32 1, !"amdgpu_printf_kind", !"hostcall"}
+
+__global__ void kernel() {}


### PR DESCRIPTION
Upstreaming introduction of extra_attrs from clangIR PR: https://github.com/llvm/clangir/pull/134

This PR adds the extra_attrs attribute to cir.func to hold target-specific function attributes. 
These attributes are propagated to LLVM IR via the amendOperation mechanism in CIRDialectLLVMIRTranslationInterface.