### PR TITLE
[libc++] Avoid including <cmath> in <format>

### DIFF
--- a/libcxx/include/__format/formatter_floating_point.h
+++ b/libcxx/include/__format/formatter_floating_point.h
@@ -32,12 +32,12 @@
 #include <__format/formatter_output.h>
 #include <__format/parser_std_format_spec.h>
 #include <__iterator/concepts.h>
+#include <__math/traits.h>
 #include <__memory/allocator.h>
 #include <__system_error/errc.h>
 #include <__type_traits/conditional.h>
 #include <__utility/move.h>
 #include <__utility/unreachable.h>
-#include <cmath>
 
 #if _LIBCPP_HAS_LOCALIZATION
 #  include <__locale>
@@ -637,10 +637,10 @@ _LIBCPP_HIDE_FROM_ABI auto __write_using_trailing_zeros(
 template <floating_point _Tp, class _CharT, class _FormatContext>
 _LIBCPP_HIDE_FROM_ABI typename _FormatContext::iterator
 __format_floating_point(_Tp __value, _FormatContext& __ctx, __format_spec::__parsed_specifications<_CharT> __specs) {
-  bool __negative = std::signbit(__value);
+  bool __negative = __math::signbit(__value);
 
-  if (!std::isfinite(__value)) [[unlikely]]
-    return __formatter::__format_floating_point_non_finite(__ctx.out(), __specs, __negative, std::isnan(__value));
+  if (!__math::isfinite(__value)) [[unlikely]]
+    return __formatter::__format_floating_point_non_finite(__ctx.out(), __specs, __negative, __math::isnan(__value));
 
   // Depending on the std-format-spec string the sign and the value
   // might not be outputted together:

--- a/libcxx/include/format
+++ b/libcxx/include/format
@@ -233,12 +233,15 @@ namespace std {
 #    pragma GCC system_header
 #  endif
 
+#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 23
+#    include <cmath>
+#  endif
+
 #  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
 #    include <array>
 #    include <cctype>
 #    include <cerrno>
 #    include <clocale>
-#    include <cmath>
 #    include <cstddef>
 #    include <cstdint>
 #    include <cstdlib>

--- a/libcxx/test/libcxx/transitive_includes/cxx26.csv
+++ b/libcxx/test/libcxx/transitive_includes/cxx26.csv
@@ -354,7 +354,6 @@ format cctype
 format cerrno
 format climits
 format clocale
-format cmath
 format compare
 format cstddef
 format cstdint
@@ -508,7 +507,6 @@ iostream cctype
 iostream cerrno
 iostream climits
 iostream clocale
-iostream cmath
 iostream compare
 iostream cstddef
 iostream cstdint
@@ -694,7 +692,6 @@ ostream cctype
 ostream cerrno
 ostream climits
 ostream clocale
-ostream cmath
 ostream compare
 ostream cstddef
 ostream cstdint
@@ -724,7 +721,6 @@ print cctype
 print cerrno
 print climits
 print clocale
-print cmath
 print compare
 print cstddef
 print cstdint
@@ -995,7 +991,6 @@ syncstream cctype
 syncstream cerrno
 syncstream climits
 syncstream clocale
-syncstream cmath
 syncstream compare
 syncstream cstddef
 syncstream cstdint


### PR DESCRIPTION
This reduces the time to parse `<format>` a bit.