### PR TITLE
[IR][Core][NFC] Drop some BranchInst uses

### DIFF
--- a/llvm/docs/BranchWeightMetadata.rst
+++ b/llvm/docs/BranchWeightMetadata.rst
@@ -23,11 +23,10 @@ indicates a greater chance of being taken.
 Supported Instructions
 ======================
 
-``BranchInst``
+``CondBrInst``
 ^^^^^^^^^^^^^^
 
-Metadata is only assigned to conditional branches. There are two extra
-operands for the true and the false branch.
+There are two extra operands for the true and the false branch.
 We optionally track if the metadata was added by ``__builtin_expect`` or
 ``__builtin_expect_with_probability`` with an optional field ``!"expected"``.
 

--- a/llvm/include/llvm-c/Core.h
+++ b/llvm/include/llvm-c/Core.h
@@ -2053,6 +2053,8 @@ LLVM_C_ABI unsigned LLVMGetTargetExtTypeIntParam(LLVMTypeRef TargetExtTy,
       macro(ShuffleVectorInst)              \
       macro(StoreInst)                      \
       macro(BranchInst)                     \
+        macro(UncondBrInst)                 \
+        macro(CondBrInst)                   \
       macro(IndirectBrInst)                 \
       macro(InvokeInst)                     \
       macro(ReturnInst)                     \
@@ -4297,29 +4299,27 @@ LLVM_C_ABI void LLVMSetSuccessor(LLVMValueRef Term, unsigned i,
                                  LLVMBasicBlockRef block);
 
 /**
- * Return if a branch is conditional.
+ * Return if an instruction is a conditional branch.
  *
- * This only works on llvm::BranchInst instructions.
- *
- * @see llvm::BranchInst::isConditional
+ * Deprecated: Use LLVMIsACondBrInst instead.
  */
 LLVM_C_ABI LLVMBool LLVMIsConditional(LLVMValueRef Branch);
 
 /**
  * Return the condition of a branch instruction.
  *
- * This only works on llvm::BranchInst instructions.
+ * This only works on llvm::CondBrInst instructions.
  *
- * @see llvm::BranchInst::getCondition
+ * @see llvm::CondBrInst::getCondition
  */
 LLVM_C_ABI LLVMValueRef LLVMGetCondition(LLVMValueRef Branch);
 
 /**
  * Set the condition of a branch instruction.
  *
- * This only works on llvm::BranchInst instructions.
+ * This only works on llvm::CondBrInst instructions.
  *
- * @see llvm::BranchInst::setCondition
+ * @see llvm::CondBrInst::setCondition
  */
 LLVM_C_ABI void LLVMSetCondition(LLVMValueRef Branch, LLVMValueRef Cond);
 

--- a/llvm/include/llvm/ADT/GenericUniformityInfo.h
+++ b/llvm/include/llvm/ADT/GenericUniformityInfo.h
@@ -68,7 +68,7 @@ public:
 
   // Similar queries for InstructionT. These accept a pointer argument so that
   // in LLVM IR, they overload the equivalent queries for Value*. For example,
-  // if querying whether a BranchInst is divergent, it should not be treated as
+  // if querying whether a CondBrInst is divergent, it should not be treated as
   // a Value in LLVM IR.
   bool isUniform(const InstructionT *I) const { return !isDivergent(I); };
   bool isDivergent(const InstructionT *I) const;

--- a/llvm/include/llvm/IR/IRBuilder.h
+++ b/llvm/include/llvm/IR/IRBuilder.h
@@ -1191,24 +1191,24 @@ public:
   }
 
   /// Create an unconditional 'br label X' instruction.
-  BranchInst *CreateBr(BasicBlock *Dest) {
-    return Insert(BranchInst::Create(Dest));
+  UncondBrInst *CreateBr(BasicBlock *Dest) {
+    return Insert(UncondBrInst::Create(Dest));
   }
 
   /// Create a conditional 'br Cond, TrueDest, FalseDest'
   /// instruction.
-  BranchInst *CreateCondBr(Value *Cond, BasicBlock *True, BasicBlock *False,
+  CondBrInst *CreateCondBr(Value *Cond, BasicBlock *True, BasicBlock *False,
                            MDNode *BranchWeights = nullptr,
                            MDNode *Unpredictable = nullptr) {
-    return Insert(addBranchMetadata(BranchInst::Create(True, False, Cond),
+    return Insert(addBranchMetadata(CondBrInst::Create(Cond, True, False),
                                     BranchWeights, Unpredictable));
   }
 
   /// Create a conditional 'br Cond, TrueDest, FalseDest'
   /// instruction. Copy branch meta data if available.
-  BranchInst *CreateCondBr(Value *Cond, BasicBlock *True, BasicBlock *False,
+  CondBrInst *CreateCondBr(Value *Cond, BasicBlock *True, BasicBlock *False,
                            Instruction *MDSrc) {
-    BranchInst *Br = BranchInst::Create(True, False, Cond);
+    CondBrInst *Br = CondBrInst::Create(Cond, True, False);
     if (MDSrc) {
       unsigned WL[4] = {LLVMContext::MD_prof, LLVMContext::MD_unpredictable,
                         LLVMContext::MD_make_implicit, LLVMContext::MD_dbg};

--- a/llvm/include/llvm/IR/PatternMatch.h
+++ b/llvm/include/llvm/IR/PatternMatch.h
@@ -2468,11 +2468,10 @@ struct br_match {
   br_match(BasicBlock *&Succ) : Succ(Succ) {}
 
   template <typename OpTy> bool match(OpTy *V) const {
-    if (auto *BI = dyn_cast<BranchInst>(V))
-      if (BI->isUnconditional()) {
-        Succ = BI->getSuccessor(0);
-        return true;
-      }
+    if (auto *BI = dyn_cast<UncondBrInst>(V)) {
+      Succ = BI->getSuccessor();
+      return true;
+    }
     return false;
   }
 };
@@ -2489,8 +2488,8 @@ struct brc_match {
       : Cond(C), T(t), F(f) {}
 
   template <typename OpTy> bool match(OpTy *V) const {
-    if (auto *BI = dyn_cast<BranchInst>(V))
-      if (BI->isConditional() && Cond.match(BI->getCondition()))
+    if (auto *BI = dyn_cast<CondBrInst>(V))
+      if (Cond.match(BI->getCondition()))
         return T.match(BI->getSuccessor(0)) && F.match(BI->getSuccessor(1));
     return false;
   }

--- a/llvm/lib/AsmParser/LLParser.cpp
+++ b/llvm/lib/AsmParser/LLParser.cpp
@@ -7780,7 +7780,7 @@ bool LLParser::parseBr(Instruction *&Inst, PerFunctionState &PFS) {
     return true;
 
   if (BasicBlock *BB = dyn_cast<BasicBlock>(Op0)) {
-    Inst = BranchInst::Create(BB);
+    Inst = UncondBrInst::Create(BB);
     return false;
   }
 
@@ -7793,7 +7793,7 @@ bool LLParser::parseBr(Instruction *&Inst, PerFunctionState &PFS) {
       parseTypeAndBasicBlock(Op2, Loc2, PFS))
     return true;
 
-  Inst = BranchInst::Create(Op1, Op2, Op0);
+  Inst = CondBrInst::Create(Op0, Op1, Op2);
   return false;
 }
 

--- a/llvm/lib/Bitcode/Reader/BitcodeReader.cpp
+++ b/llvm/lib/Bitcode/Reader/BitcodeReader.cpp
@@ -5653,7 +5653,7 @@ Error BitcodeReader::parseFunctionBody(Function *F) {
         return error("Invalid br record");
 
       if (Record.size() == 1) {
-        I = BranchInst::Create(TrueDest);
+        I = UncondBrInst::Create(TrueDest);
         InstructionList.push_back(I);
       }
       else {
@@ -5663,7 +5663,7 @@ Error BitcodeReader::parseFunctionBody(Function *F) {
                                getVirtualTypeID(CondType), CurBB);
         if (!FalseDest || !Cond)
           return error("Invalid br record");
-        I = BranchInst::Create(TrueDest, FalseDest, Cond);
+        I = CondBrInst::Create(Cond, TrueDest, FalseDest);
         InstructionList.push_back(I);
       }
       break;
@@ -7011,7 +7011,7 @@ OutOfRecordLoop:
     BasicBlock *From = Pair.first.first;
     BasicBlock *To = Pair.first.second;
     BasicBlock *EdgeBB = Pair.second;
-    BranchInst::Create(To, EdgeBB);
+    UncondBrInst::Create(To, EdgeBB);
     From->getTerminator()->replaceSuccessorWith(To, EdgeBB);
     To->replacePhiUsesWith(From, EdgeBB);
     EdgeBB->moveBefore(To);
@@ -7113,8 +7113,8 @@ Error BitcodeReader::materialize(GlobalValue *GV) {
         if (ProfName != MDProfLabels::BranchWeights)
           continue;
         unsigned ExpectedNumOperands = 0;
-        if (BranchInst *BI = dyn_cast<BranchInst>(&I))
-          ExpectedNumOperands = BI->getNumSuccessors();
+        if (isa<CondBrInst>(&I))
+          ExpectedNumOperands = 2;
         else if (SwitchInst *SI = dyn_cast<SwitchInst>(&I))
           ExpectedNumOperands = SI->getNumSuccessors();
         else if (isa<CallInst>(&I))

--- a/llvm/lib/ExecutionEngine/Interpreter/Execution.cpp
+++ b/llvm/lib/ExecutionEngine/Interpreter/Execution.cpp
@@ -897,17 +897,15 @@ void Interpreter::visitUnreachableInst(UnreachableInst &I) {
   report_fatal_error("Program executed an 'unreachable' instruction!");
 }
 
-void Interpreter::visitBranchInst(BranchInst &I) {
+void Interpreter::visitUncondBrInst(UncondBrInst &I) {
   ExecutionContext &SF = ECStack.back();
-  BasicBlock *Dest;
+  SwitchToNewBasicBlock(I.getSuccessor(), SF);
+}
 
-  Dest = I.getSuccessor(0);          // Uncond branches have a fixed dest...
-  if (!I.isUnconditional()) {
-    Value *Cond = I.getCondition();
-    if (getOperandValue(Cond, SF).IntVal == 0) // If false cond...
-      Dest = I.getSuccessor(1);
-  }
-  SwitchToNewBasicBlock(Dest, SF);
+void Interpreter::visitCondBrInst(CondBrInst &I) {
+  ExecutionContext &SF = ECStack.back();
+  bool Cond = getOperandValue(I.getCondition(), SF).IntVal != 0;
+  SwitchToNewBasicBlock(I.getSuccessor(Cond ? 0 : 1), SF);
 }
 
 void Interpreter::visitSwitchInst(SwitchInst &I) {

--- a/llvm/lib/ExecutionEngine/Interpreter/Interpreter.h
+++ b/llvm/lib/ExecutionEngine/Interpreter/Interpreter.h
@@ -119,7 +119,8 @@ public:
 
   // Opcode Implementations
   void visitReturnInst(ReturnInst &I);
-  void visitBranchInst(BranchInst &I);
+  void visitUncondBrInst(UncondBrInst &I);
+  void visitCondBrInst(CondBrInst &I);
   void visitSwitchInst(SwitchInst &I);
   void visitIndirectBrInst(IndirectBrInst &I);
 

--- a/llvm/lib/FuzzMutate/IRMutator.cpp
+++ b/llvm/lib/FuzzMutate/IRMutator.cpp
@@ -518,7 +518,7 @@ void InsertCFGStrategy::mutate(BasicBlock &BB, RandomIRBuilder &IB) {
   uint64_t IP = uniform<uint64_t>(IB.Rand, 0, Insts.size() - 1);
   auto InstsBeforeSplit = ArrayRef(Insts).slice(0, IP);
 
-  // `Sink` inherits Blocks' terminator, `Source` will have a BranchInst
+  // `Sink` inherits Blocks' terminator, `Source` will have a UncondBrInst
   // directly jumps to `Sink`. Here, we have to create a new terminator for
   // `Source`.
   BasicBlock *Block = Insts[IP]->getParent();
@@ -535,7 +535,7 @@ void InsertCFGStrategy::mutate(BasicBlock &BB, RandomIRBuilder &IB) {
     Value *Cond =
         IB.findOrCreateSource(*Source, InstsBeforeSplit, {},
                               fuzzerop::onlyType(Type::getInt1Ty(C)), false);
-    BranchInst *Branch = BranchInst::Create(IfTrue, IfFalse, Cond);
+    CondBrInst *Branch = CondBrInst::Create(Cond, IfTrue, IfFalse);
     // Remove the old terminator.
     ReplaceInstWithInst(Source->getTerminator(), Branch);
     // Connect these blocks to `Sink`
@@ -607,7 +607,7 @@ void InsertCFGStrategy::connectBlocksToSink(ArrayRef<BasicBlock *> Blocks,
       break;
     }
     case CFGToSink::DirectSink: {
-      BranchInst::Create(Sink, BB);
+      UncondBrInst::Create(Sink, BB);
       break;
     }
     case CFGToSink::SinkOrSelfLoop: {
@@ -616,7 +616,7 @@ void InsertCFGStrategy::connectBlocksToSink(ArrayRef<BasicBlock *> Blocks,
       uint64_t coin = uniform<uint64_t>(IB.Rand, 0, 1);
       Value *Cond = IB.findOrCreateSource(
           *BB, {}, {}, fuzzerop::onlyType(Type::getInt1Ty(C)), false);
-      BranchInst::Create(Branches[coin], Branches[1 - coin], Cond, BB);
+      CondBrInst::Create(Cond, Branches[coin], Branches[1 - coin], BB);
       break;
     }
     case CFGToSink::EndOfCFGToLink:

--- a/llvm/lib/FuzzMutate/Operations.cpp
+++ b/llvm/lib/FuzzMutate/Operations.cpp
@@ -176,7 +176,7 @@ OpDescriptor llvm::fuzzerop::splitBlockDescriptor(unsigned Weight) {
     // Loop back on this block by replacing the unconditional forward branch
     // with a conditional with a backedge.
     if (Block != &Block->getParent()->getEntryBlock()) {
-      BranchInst::Create(Block, Next, Srcs[0],
+      CondBrInst::Create(Srcs[0], Block, Next,
                          Block->getTerminator()->getIterator());
       Block->getTerminator()->eraseFromParent();
 

--- a/llvm/lib/IR/AsmWriter.cpp
+++ b/llvm/lib/IR/AsmWriter.cpp
@@ -4453,15 +4453,13 @@ void AssemblyWriter::printInstruction(const Instruction &I) {
   const Value *Operand = I.getNumOperands() ? I.getOperand(0) : nullptr;
 
   // Special case conditional branches to swizzle the condition out to the front
-  if (isa<BranchInst>(I) && cast<BranchInst>(I).isConditional()) {
-    const BranchInst &BI(cast<BranchInst>(I));
+  if (const auto *BI = dyn_cast<CondBrInst>(&I)) {
     Out << ' ';
-    writeOperand(BI.getCondition(), true);
+    writeOperand(BI->getCondition(), true);
     Out << ", ";
-    writeOperand(BI.getSuccessor(0), true);
+    writeOperand(BI->getSuccessor(0), true);
     Out << ", ";
-    writeOperand(BI.getSuccessor(1), true);
-
+    writeOperand(BI->getSuccessor(1), true);
   } else if (isa<SwitchInst>(I)) {
     const SwitchInst& SI(cast<SwitchInst>(I));
     // Special case switch instruction to get formatting nice and correct.

--- a/llvm/lib/IR/BasicBlock.cpp
+++ b/llvm/lib/IR/BasicBlock.cpp
@@ -570,7 +570,7 @@ BasicBlock *BasicBlock::splitBasicBlock(iterator I, const Twine &BBName) {
   New->splice(New->end(), this, I, end());
 
   // Add a branch instruction to the newly formed basic block.
-  BranchInst *BI = BranchInst::Create(New, this);
+  UncondBrInst *BI = UncondBrInst::Create(New, this);
   BI->setDebugLoc(Loc);
 
   // Now we must loop through all of the successors of the New block (which
@@ -615,7 +615,7 @@ BasicBlock *BasicBlock::splitBasicBlockBefore(iterator I, const Twine &BBName) {
     this->replacePhiUsesWith(Pred, New);
   }
   // Add a branch instruction from  "New" to "this" Block.
-  BranchInst *BI = BranchInst::Create(this, New);
+  UncondBrInst *BI = UncondBrInst::Create(this, New);
   BI->setDebugLoc(Loc);
 
   return New;

--- a/llvm/lib/IR/Core.cpp
+++ b/llvm/lib/IR/Core.cpp
@@ -3252,15 +3252,15 @@ void LLVMSetSuccessor(LLVMValueRef Term, unsigned i, LLVMBasicBlockRef block) {
 /*--.. Operations on branch instructions (only) ............................--*/
 
 LLVMBool LLVMIsConditional(LLVMValueRef Branch) {
-  return unwrap<BranchInst>(Branch)->isConditional();
+  return isa<CondBrInst>(unwrap<Instruction>(Branch));
 }
 
 LLVMValueRef LLVMGetCondition(LLVMValueRef Branch) {
-  return wrap(unwrap<BranchInst>(Branch)->getCondition());
+  return wrap(unwrap<CondBrInst>(Branch)->getCondition());
 }
 
 void LLVMSetCondition(LLVMValueRef Branch, LLVMValueRef Cond) {
-  return unwrap<BranchInst>(Branch)->setCondition(unwrap(Cond));
+  return unwrap<CondBrInst>(Branch)->setCondition(unwrap(Cond));
 }
 
 /*--.. Operations on switch instructions (only) ............................--*/

--- a/llvm/lib/IR/ProfDataUtils.cpp
+++ b/llvm/lib/IR/ProfDataUtils.cpp
@@ -217,9 +217,8 @@ bool llvm::extractBranchWeights(const Instruction &I,
 
 bool llvm::extractBranchWeights(const Instruction &I, uint64_t &TrueVal,
                                 uint64_t &FalseVal) {
-  assert((isa<BranchInst, SelectInst>(I)) &&
-         "Looking for branch weights on something besides branch, select, or "
-         "switch");
+  assert((isa<CondBrInst, SelectInst>(I)) &&
+         "Looking for branch weights on something besides CondBr or Select");
 
   SmallVector<uint32_t, 2> Weights;
   auto *ProfileData = I.getMetadata(LLVMContext::MD_prof);

--- a/llvm/lib/IR/SafepointIRVerifier.cpp
+++ b/llvm/lib/IR/SafepointIRVerifier.cpp
@@ -138,8 +138,8 @@ public:
 
       // For conditional branches, we can perform simple conditional propagation on
       // the condition value itself.
-      const BranchInst *BI = dyn_cast<BranchInst>(TI);
-      if (!BI || !BI->isConditional() || !isa<Constant>(BI->getCondition()))
+      const CondBrInst *BI = dyn_cast<CondBrInst>(TI);
+      if (!BI || !isa<Constant>(BI->getCondition()))
         continue;
 
       // If a branch has two identical successors, we cannot declare either dead.

--- a/llvm/lib/IR/Verifier.cpp
+++ b/llvm/lib/IR/Verifier.cpp
@@ -597,7 +597,7 @@ private:
   void verifyDominatesUse(Instruction &I, unsigned i);
   void visitInstruction(Instruction &I);
   void visitTerminator(Instruction &I);
-  void visitBranchInst(BranchInst &BI);
+  void visitCondBrInst(CondBrInst &BI);
   void visitReturnInst(ReturnInst &RI);
   void visitSwitchInst(SwitchInst &SI);
   void visitIndirectBrInst(IndirectBrInst &BI);
@@ -3443,11 +3443,9 @@ void Verifier::visitTerminator(Instruction &I) {
   visitInstruction(I);
 }
 
-void Verifier::visitBranchInst(BranchInst &BI) {
-  if (BI.isConditional()) {
-    Check(BI.getCondition()->getType()->isIntegerTy(1),
-          "Branch condition is not 'i1' type!", &BI, BI.getCondition());
-  }
+void Verifier::visitCondBrInst(CondBrInst &BI) {
+  Check(BI.getCondition()->getType()->isIntegerTy(1),
+        "Branch condition is not 'i1' type!", &BI, BI.getCondition());
   visitTerminator(BI);
 }
 
@@ -5257,7 +5255,7 @@ void Verifier::visitNofreeMetadata(Instruction &I, MDNode *MD) {
 void Verifier::visitProfMetadata(Instruction &I, MDNode *MD) {
   auto GetBranchingTerminatorNumOperands = [&]() {
     unsigned ExpectedNumOperands = 0;
-    if (BranchInst *BI = dyn_cast<BranchInst>(&I))
+    if (CondBrInst *BI = dyn_cast<CondBrInst>(&I))
       ExpectedNumOperands = BI->getNumSuccessors();
     else if (SwitchInst *SI = dyn_cast<SwitchInst>(&I))
       ExpectedNumOperands = SI->getNumSuccessors();

--- a/llvm/lib/Passes/StandardInstrumentations.cpp
+++ b/llvm/lib/Passes/StandardInstrumentations.cpp
@@ -2192,14 +2192,10 @@ namespace llvm {
 DCData::DCData(const BasicBlock &B) {
   // Build up transition labels.
   const Instruction *Term = B.getTerminator();
-  if (const BranchInst *Br = dyn_cast<const BranchInst>(Term))
-    if (Br->isUnconditional())
-      addSuccessorLabel(Br->getSuccessor(0)->getName().str(), "");
-    else {
-      addSuccessorLabel(Br->getSuccessor(0)->getName().str(), "true");
-      addSuccessorLabel(Br->getSuccessor(1)->getName().str(), "false");
-    }
-  else if (const SwitchInst *Sw = dyn_cast<const SwitchInst>(Term)) {
+  if (const CondBrInst *Br = dyn_cast<const CondBrInst>(Term)) {
+    addSuccessorLabel(Br->getSuccessor(0)->getName().str(), "true");
+    addSuccessorLabel(Br->getSuccessor(1)->getName().str(), "false");
+  } else if (const SwitchInst *Sw = dyn_cast<const SwitchInst>(Term)) {
     addSuccessorLabel(Sw->case_default()->getCaseSuccessor()->getName().str(),
                       "default");
     for (auto &C : Sw->cases()) {

--- a/llvm/lib/Transforms/IPO/HotColdSplitting.cpp
+++ b/llvm/lib/Transforms/IPO/HotColdSplitting.cpp
@@ -112,7 +112,7 @@ void analyzeProfMetadata(BasicBlock *BB,
                          BranchProbability ColdProbThresh,
                          SmallPtrSetImpl<BasicBlock *> &AnnotatedColdBlocks) {
   // TODO: Handle branches with > 2 successors.
-  BranchInst *CondBr = dyn_cast<BranchInst>(BB->getTerminator());
+  CondBrInst *CondBr = dyn_cast<CondBrInst>(BB->getTerminator());
   if (!CondBr)
     return;
 

--- a/llvm/unittests/FuzzMutate/OperationsTest.cpp
+++ b/llvm/unittests/FuzzMutate/OperationsTest.cpp
@@ -264,9 +264,8 @@ TEST(OperationsTest, SplitBlock) {
 
   // We should end up with an unconditional branch from BB to BB1, and the
   // return ends up in BB1.
-  auto *UncondBr = cast<BranchInst>(BB->getTerminator());
-  ASSERT_TRUE(UncondBr->isUnconditional());
-  auto *BB1 = UncondBr->getSuccessor(0);
+  auto *UncondBr = cast<UncondBrInst>(BB->getTerminator());
+  auto *BB1 = UncondBr->getSuccessor();
   ASSERT_THAT(RI->getParent(), Eq(BB1));
 
   // Now add an instruction to BB1 and split on that.
@@ -276,9 +275,7 @@ TEST(OperationsTest, SplitBlock) {
 
   // We should end up with a loop back on BB1 and the instruction we split on
   // moves to BB2.
-  auto *CondBr = cast<BranchInst>(BB1->getTerminator());
-  EXPECT_THAT(CondBr->getCondition(), Eq(Cond));
-  ASSERT_THAT(CondBr->getNumSuccessors(), Eq(2u));
+  auto *CondBr = cast<CondBrInst>(BB1->getTerminator());
   ASSERT_THAT(CondBr->getSuccessor(0), Eq(BB1));
   auto *BB2 = CondBr->getSuccessor(1);
   EXPECT_THAT(AI->getParent(), Eq(BB2));
@@ -331,8 +328,8 @@ TEST(OperationsTest, SplitBlockWithPhis) {
   auto *BB1 = BasicBlock::Create(Ctx, "BB1", F);
   auto *BB2 = BasicBlock::Create(Ctx, "BB2", F);
   auto *BB3 = BasicBlock::Create(Ctx, "BB3", F);
-  BranchInst::Create(BB2, BB3, ConstantInt::getFalse(Ctx), BB1);
-  BranchInst::Create(BB3, BB2);
+  CondBrInst::Create(ConstantInt::getFalse(Ctx), BB2, BB3, BB1);
+  UncondBrInst::Create(BB3, BB2);
 
   // Set up phi nodes selecting values for the incoming edges.
   auto *PHI1 = PHINode::Create(Int8Ty, /*NumReservedValues=*/2, "p1", BB3);

--- a/llvm/unittests/IR/BasicBlockTest.cpp
+++ b/llvm/unittests/IR/BasicBlockTest.cpp
@@ -32,9 +32,9 @@ TEST(BasicBlockTest, PhiRange) {
 
   // Create some predecessors of it.
   std::unique_ptr<BasicBlock> BB1(BasicBlock::Create(Context));
-  BranchInst::Create(BB.get(), BB1.get());
+  UncondBrInst::Create(BB.get(), BB1.get());
   std::unique_ptr<BasicBlock> BB2(BasicBlock::Create(Context));
-  BranchInst::Create(BB.get(), BB2.get());
+  UncondBrInst::Create(BB.get(), BB2.get());
 
   // Make sure this doesn't crash if there are no phis.
   int PhiCount = 0;
@@ -45,7 +45,7 @@ TEST(BasicBlockTest, PhiRange) {
   ASSERT_EQ(PhiCount, 0) << "empty block should have no phis";
 
   // Make it a cycle.
-  auto *BI = BranchInst::Create(BB.get(), BB.get());
+  auto *BI = UncondBrInst::Create(BB.get(), BB.get());
 
   // Now insert some PHI nodes.
   auto *Int32Ty = Type::getInt32Ty(Context);

--- a/llvm/unittests/IR/DominatorTreeTest.cpp
+++ b/llvm/unittests/IR/DominatorTreeTest.cpp
@@ -269,7 +269,7 @@ TEST(DominatorTree, Unreachable) {
 
         // Reattach block 3 to block 1 and recalculate
         BB1->getTerminator()->eraseFromParent();
-        BranchInst::Create(BB4, BB3, ConstantInt::getTrue(F.getContext()), BB1);
+        CondBrInst::Create(ConstantInt::getTrue(F.getContext()), BB4, BB3, BB1);
         DT->recalculate(F);
 
         // Check DFS Numbers after
@@ -296,7 +296,7 @@ TEST(DominatorTree, Unreachable) {
         EXPECT_TRUE(DT->verify());
         BasicBlock *NewEntry =
             BasicBlock::Create(F.getContext(), "new_entry", &F, BB0);
-        BranchInst::Create(BB0, NewEntry);
+        UncondBrInst::Create(BB0, NewEntry);
         EXPECT_EQ(F.begin()->getName(), NewEntry->getName());
         EXPECT_TRUE(&F.getEntryBlock() == NewEntry);
         DT->setNewRoot(NewEntry);

--- a/llvm/unittests/IR/IRBuilderTest.cpp
+++ b/llvm/unittests/IR/IRBuilderTest.cpp
@@ -547,7 +547,7 @@ TEST_F(IRBuilderTest, CreateCondBr) {
   BasicBlock *TBB = BasicBlock::Create(Ctx, "", F);
   BasicBlock *FBB = BasicBlock::Create(Ctx, "", F);
 
-  BranchInst *BI = Builder.CreateCondBr(Builder.getTrue(), TBB, FBB);
+  CondBrInst *BI = Builder.CreateCondBr(Builder.getTrue(), TBB, FBB);
   Instruction *TI = BB->getTerminator();
   EXPECT_EQ(BI, TI);
   EXPECT_EQ(2u, TI->getNumSuccessors());
@@ -1229,7 +1229,7 @@ TEST_F(IRBuilderTest, DebugLoc) {
   DebugLoc DL2 = DILocation::get(Ctx, 3, 0, SP);
 
   auto BB2 = BasicBlock::Create(Ctx, "bb2", F);
-  auto Br = BranchInst::Create(BB2, BB);
+  auto Br = UncondBrInst::Create(BB2, BB);
   Br->setDebugLoc(DL1);
 
   IRBuilder<> Builder(Ctx);

--- a/llvm/unittests/IR/InstructionsTest.cpp
+++ b/llvm/unittests/IR/InstructionsTest.cpp
@@ -129,18 +129,18 @@ TEST_F(ModuleWithFunctionTest, InvokeInst) {
   }
 }
 
-TEST(InstructionsTest, BranchInst) {
+TEST(InstructionsTest, UncondBrInst) {
   LLVMContext C;
 
-  // Make a BasicBlocks
-  BasicBlock* bb0 = BasicBlock::Create(C);
-  BasicBlock* bb1 = BasicBlock::Create(C);
+  // Make a BasicBlock
+  BasicBlock *bb0 = BasicBlock::Create(C);
 
-  // Mandatory BranchInst
-  const BranchInst* b0 = BranchInst::Create(bb0);
+  const UncondBrInst *b0 = UncondBrInst::Create(bb0);
 
-  EXPECT_TRUE(b0->isUnconditional());
-  EXPECT_FALSE(b0->isConditional());
+  // Test legacy BranchInst API.
+  EXPECT_TRUE(cast<BranchInst>(b0)->isUnconditional());
+  EXPECT_FALSE(cast<BranchInst>(b0)->isConditional());
+
   EXPECT_EQ(1U, b0->getNumSuccessors());
 
   // check num operands
@@ -151,14 +151,27 @@ TEST(InstructionsTest, BranchInst) {
 
   EXPECT_EQ(b0->op_end(), std::next(b0->op_begin()));
 
+  // clean up
+  delete b0;
+  delete bb0;
+}
+
+TEST(InstructionsTest, CondBrInst) {
+  LLVMContext C;
+
+  // Make a BasicBlocks
+  BasicBlock *bb0 = BasicBlock::Create(C);
+  BasicBlock *bb1 = BasicBlock::Create(C);
+
   IntegerType* Int1 = IntegerType::get(C, 1);
   Constant* One = ConstantInt::getTrue(Int1);
 
-  // Conditional BranchInst
-  BranchInst* b1 = BranchInst::Create(bb0, bb1, One);
+  CondBrInst *b1 = CondBrInst::Create(One, bb0, bb1);
 
-  EXPECT_FALSE(b1->isUnconditional());
-  EXPECT_TRUE(b1->isConditional());
+  // Test legacy BranchInst API.
+  EXPECT_FALSE(cast<BranchInst>(b1)->isUnconditional());
+  EXPECT_TRUE(cast<BranchInst>(b1)->isConditional());
+
   EXPECT_EQ(2U, b1->getNumSuccessors());
 
   // check num operands
@@ -188,7 +201,6 @@ TEST(InstructionsTest, BranchInst) {
   EXPECT_EQ(b1->op_end(), b);
 
   // clean up
-  delete b0;
   delete b1;
 
   delete bb0;

--- a/llvm/unittests/IR/LegacyPassManagerTest.cpp
+++ b/llvm/unittests/IR/LegacyPassManagerTest.cpp
@@ -552,13 +552,13 @@ namespace llvm {
         auto *AI = new AllocaInst(func_test3->getType(), 0, "func3ptr",
                                   label_entry_11);
         new StoreInst(func_test3, AI, label_entry_11);
-        BranchInst::Create(label_bb, label_entry_11);
+        UncondBrInst::Create(label_bb, label_entry_11);
 
         // Block bb (label_bb)
-        BranchInst::Create(label_bb, label_bb1, int1_f, label_bb);
+        CondBrInst::Create(int1_f, label_bb, label_bb1, label_bb);
 
         // Block bb1 (label_bb1)
-        BranchInst::Create(label_bb1, label_return, int1_f, label_bb1);
+        CondBrInst::Create(int1_f, label_bb1, label_return, label_bb1);
 
         // Block return (label_return)
         ReturnInst::Create(Context, label_return);

--- a/llvm/unittests/IR/VerifierTest.cpp
+++ b/llvm/unittests/IR/VerifierTest.cpp
@@ -33,11 +33,11 @@ TEST(VerifierTest, Branch_i1) {
   BasicBlock *Exit = BasicBlock::Create(C, "exit", F);
   ReturnInst::Create(C, Exit);
 
-  // To avoid triggering an assertion in BranchInst::Create, we first create
+  // To avoid triggering an assertion in CondBrInst::Create, we first create
   // a branch with an 'i1' condition ...
 
   Constant *False = ConstantInt::getFalse(C);
-  BranchInst *BI = BranchInst::Create(Exit, Exit, False, Entry);
+  CondBrInst *BI = CondBrInst::Create(False, Exit, Exit, Entry);
 
   // ... then use setOperand to redirect it to a value of different type.
 
@@ -318,9 +318,9 @@ TEST(VerifierTest, SwitchInst) {
 
   BasicBlock *Exit = BasicBlock::Create(C, "exit", F);
 
-  BranchInst::Create(Exit, Default);
-  BranchInst::Create(Exit, OnTwo);
-  BranchInst::Create(Exit, OnOne);
+  UncondBrInst::Create(Exit, Default);
+  UncondBrInst::Create(Exit, OnTwo);
+  UncondBrInst::Create(Exit, OnOne);
   ReturnInst::Create(C, Exit);
 
   Value *Cond = F->getArg(0);


### PR DESCRIPTION
Now that CondBrInst and UncondBrInst are explicit subclasses, use them instead.

HotColdSplitting was trying to inspect prof metadata also on unconditional branches, fix this.

Also introduce C API cast functions and deprecate LLVMIsConditional in favor of LLVMIsACondBrInst.

This patch covers all LLVM uses outside of Transforms, Analysis, CodeGen/Target, SandboxIR, Frontend/OpenMP, tools, examples.