### PR TITLE
[MLIR][Presburger] Fix tangent cone identification

### DIFF
--- a/mlir/lib/Analysis/Presburger/Barvinok.cpp
+++ b/mlir/lib/Analysis/Presburger/Barvinok.cpp
@@ -417,6 +417,20 @@ mlir::presburger::detail::computePolytopeGeneratingFunction(
         ineq[k] = subset(j, k);
       tangentCone.addInequality(ineq);
     }
+    // There might be more active inequalities other than the ones chosen.
+    // For an inequality Ax + Bp + c >= 0 to be active, the equality must hold;
+    // This means the corresponding row of the active region must be zero,
+    // since that is produced by substituting `x` back into the inequality.
+    for (unsigned j = 0, e = activeRegion.getNumRows(); j < e; ++j) {
+      if (llvm::any_of(activeRegion.getRow(j),
+                       [](const Fraction &x) { return x != 0; }))
+        continue;
+      SmallVector<DynamicAPInt> ineq(numVars + 1);
+      for (unsigned k = 0; k < numVars; ++k)
+        ineq[k] = remainder(j, k);
+      tangentCone.addInequality(ineq);
+    }
+
     // We assume that the tangent cone is unimodular, so there is no need
     // to decompose it.
     //


### PR DESCRIPTION
For a $n$-dimensional polyhedron, we enumerate tangent cones by selecting $n$ inequalities and set them to zero. The tangent cone is then defined by these $n$ inequalities.

But there might be the case where $m > n$ inequalities (halfspaces) meet at a single point. In this case, the tangent cone should be formed by all $m$ active inequalities, rather than just the selected $n$. This patch fixes this. (Existing code already does deduplication.)

In this case, the formed tangent cone is never unimodular, and any test case will trigger an assertion failure when calling to `computeUnimodularConeGeneratingFunction` in what follows, since we don't have unimodular decomposition yet.