### PR TITLE
[libc][strings] Refactor load_aligned for cleaner endianness handling

### DIFF
--- a/libc/src/string/memory_utils/utils.h
+++ b/libc/src/string/memory_utils/utils.h
@@ -231,6 +231,7 @@ template <typename T> LIBC_INLINE void store(Ptr ptr, T value) {
 template <typename ValueType, typename T, typename... TS>
 LIBC_INLINE ValueType load_aligned(CPtr src) {
   static_assert(sizeof(ValueType) >= (sizeof(T) + ... + sizeof(TS)));
+  static_assert(Endian::IS_LITTLE || Endian::IS_BIG, "Invalid endianness");
   const ValueType value = load<T>(assume_aligned<sizeof(T)>(src));
 
   if constexpr (sizeof...(TS) > 0) {

--- a/libc/src/string/memory_utils/utils.h
+++ b/libc/src/string/memory_utils/utils.h
@@ -232,20 +232,18 @@ template <typename ValueType, typename T, typename... TS>
 LIBC_INLINE ValueType load_aligned(CPtr src) {
   static_assert(sizeof(ValueType) >= (sizeof(T) + ... + sizeof(TS)));
   const ValueType value = load<T>(assume_aligned<sizeof(T)>(src));
+
   if constexpr (sizeof...(TS) > 0) {
     const ValueType next = load_aligned<ValueType, TS...>(src + sizeof(T));
-    if constexpr (Endian::IS_LITTLE) {
-      // T goes at the bottom of the output, so shift up everything
-      // else by the number of bits in T.
-      constexpr size_t SHIFT = sizeof(T) * 8;
-      return value | (next << SHIFT);
-    } else if constexpr (Endian::IS_BIG) {
-      // T goes at the top of the output, so shift it up by the number
-      // of bits in everything else that goes below it.
-      constexpr size_t SHIFT = (0 + ... + sizeof(TS)) * 8;
-      return (value << SHIFT) | next;
-    } else
-      static_assert(cpp::always_false<T>, "Invalid endianness");
+
+    // Calculate shifts at compile time.
+    // In Little Endian, 'value' stays at the bottom (shift 0).
+    // In Big Endian, 'next' stays at the bottom (shift 0).
+    constexpr size_t VAL_SHIFT = Endian::IS_LITTLE ? 0 : (sizeof(TS) + ...) * 8;
+    constexpr size_t NEXT_SHIFT = Endian::IS_LITTLE ? sizeof(T) * 8 : 0;
+
+    // The compiler will constant-fold '<< 0' into a no-op.
+    return (value << VAL_SHIFT) | (next << NEXT_SHIFT);
   } else {
     return value;
   }


### PR DESCRIPTION
Replace the explicit `if constexpr` branching for big and little endianness with compile-time calculated shift constants `VAL_SHIFT` and `NEXT_SHIFT`. This simplifies the logic and reduces code duplication, relying on the compiler to constant-fold the zero shifts into no-ops.