### PR TITLE
[TailCallElimination] Don't mark tail calls when callee uses llvm.returnaddress/llvm.frameaddress

### DIFF
--- a/llvm/lib/Transforms/Scalar/TailRecursionElimination.cpp
+++ b/llvm/lib/Transforms/Scalar/TailRecursionElimination.cpp
@@ -194,6 +194,23 @@ struct AllocaDerivedValueTracker {
 };
 } // namespace
 
+/// Check if the callee of CI directly uses @llvm.returnaddress or
+/// @llvm.frameaddress. Tail-calling such a function would alter the observed
+/// return/frame address, because the caller's stack frame is eliminated by the
+/// tail call optimization.
+static bool calleeUsesReturnOrFrameAddress(const CallInst *CI) {
+  const Function *Callee = CI->getCalledFunction();
+  if (!Callee || Callee->isDeclaration())
+    return false;
+  for (const auto &BB : *Callee)
+    for (const auto &I : BB)
+      if (const auto *II = dyn_cast<IntrinsicInst>(&I))
+        if (II->getIntrinsicID() == Intrinsic::returnaddress ||
+            II->getIntrinsicID() == Intrinsic::frameaddress)
+          return true;
+  return false;
+}
+
 static bool markTails(Function &F, OptimizationRemarkEmitter *ORE) {
   if (F.callsFunctionThatReturnsTwice())
     return false;
@@ -281,7 +298,7 @@ static bool markTails(Function &F, OptimizationRemarkEmitter *ORE) {
           SafeToTail = false;
           break;
         }
-        if (SafeToTail) {
+        if (SafeToTail && !calleeUsesReturnOrFrameAddress(CI)) {
           using namespace ore;
           ORE->emit([&]() {
             return OptimizationRemark(DEBUG_TYPE, "tailcall-readnone", CI)
@@ -326,6 +343,8 @@ static bool markTails(Function &F, OptimizationRemarkEmitter *ORE) {
 
   for (CallInst *CI : DeferredTails) {
     if (Visited[CI->getParent()] != ESCAPED) {
+      if (calleeUsesReturnOrFrameAddress(CI))
+        continue;
       // If the escape point was part way through the block, calls after the
       // escape point wouldn't have been put into DeferredTails.
       LLVM_DEBUG(dbgs() << "Marked as tail call candidate: " << *CI << "\n");

--- a/llvm/test/Transforms/TailCallElim/no-tail-returnaddress.ll
+++ b/llvm/test/Transforms/TailCallElim/no-tail-returnaddress.ll
@@ -1,0 +1,55 @@
+; RUN: opt < %s -passes=tailcallelim -verify-dom-info -S | FileCheck %s
+
+; Reduced from gcc-c-torture/execute/pr17377.c
+;
+; A call must not be marked as tail if the callee uses @llvm.returnaddress
+; or @llvm.frameaddress, because tail-call optimization destroys the
+; caller's stack frame and changes what these intrinsics observe.
+
+; The call from @y to @f must NOT be marked tail because @f uses
+; @llvm.returnaddress.
+define ptr @y(i32 %i) {
+; CHECK-LABEL: define ptr @y
+; CHECK: %call = call ptr @f(i32 %i)
+; CHECK-NOT: tail call ptr @f
+entry:
+  %call = call ptr @f(i32 %i)
+  ret ptr %call
+}
+
+define ptr @f(i32 %i) noinline {
+entry:
+  %addr = call ptr @llvm.returnaddress(i32 0)
+  ret ptr %addr
+}
+
+; Same test but for @llvm.frameaddress — the call from @y2 to @g must
+; NOT be marked tail.
+define ptr @y2(i32 %i) {
+; CHECK-LABEL: define ptr @y2
+; CHECK: %call = call ptr @g(i32 %i)
+; CHECK-NOT: tail call ptr @g
+entry:
+  %call = call ptr @g(i32 %i)
+  ret ptr %call
+}
+
+define ptr @g(i32 %i) noinline {
+entry:
+  %addr = call ptr @llvm.frameaddress(i32 0)
+  ret ptr %addr
+}
+
+; Negative test: a callee that does NOT use returnaddress/frameaddress
+; SHOULD still be marked tail.
+define void @caller_normal() {
+; CHECK-LABEL: define void @caller_normal
+; CHECK: tail call void @normal_callee()
+entry:
+  call void @normal_callee()
+  ret void
+}
+
+declare void @normal_callee()
+declare ptr @llvm.returnaddress(i32 immarg)
+declare ptr @llvm.frameaddress(i32 immarg)


### PR DESCRIPTION
## Summary

`markTails()` in `TailRecursionElimination.cpp` incorrectly marks calls as `tail` when the callee uses `@llvm.returnaddress` or `@llvm.frameaddress`. Tail-call optimization (CALL → JMP) destroys the caller's stack frame, changing what these intrinsics observe and producing wrong results at runtime.

This adds a helper `calleeUsesReturnOrFrameAddress()` and guards both the readnone fast path and the deferred tails path in `markTails()`.

For detailed root cause analysis and timeline, see #186353.

## Test plan

- [x] Lit test `no-tail-returnaddress.ll` - positive tests for `@llvm.returnaddress` and `@llvm.frameaddress`, negative test for normal callee
- [x] `gcc-c-torture/execute/pr17377.c` passes with `-O2 -flto` after fix
- [x] Verified bug reproduces without fix, passes with fix on upstream trunk

Fixes #186353.