### PR TITLE
[mlir] Add simple MLProgram pass pair for externalized weights.

### DIFF
--- a/mlir/include/mlir/Dialect/MLProgram/Transforms/Passes.h
+++ b/mlir/include/mlir/Dialect/MLProgram/Transforms/Passes.h
@@ -19,6 +19,15 @@ namespace ml_program {
 #define GEN_PASS_DECL
 #include "mlir/Dialect/MLProgram/Transforms/Passes.h.inc"
 
+/// Repopulate constants in `op` from `externalWeightsModule`.
+LogicalResult repopulateConstants(Operation *op,
+                                  Operation *externalWeightsModule);
+
+/// Externalize constants in `module` to the specified file.
+LogicalResult externalizeConstants(ModuleOp module, int64_t minSize,
+                                   bool dropLocations,
+                                   StringRef outputFilename);
+
 //===----------------------------------------------------------------------===//
 // Registration
 //===----------------------------------------------------------------------===//

--- a/mlir/include/mlir/Dialect/MLProgram/Transforms/Passes.td
+++ b/mlir/include/mlir/Dialect/MLProgram/Transforms/Passes.td
@@ -24,4 +24,28 @@ def MLProgramPipelineGlobalsPass
   }];
 }
 
+def MLProgramExternalizeConstantsPass
+    : Pass<"mlprogram-externalize-constants", "ModuleOp"> {
+  let summary = "Externalize large constants to a separate weights module";
+  let options = [
+    Option<"minSize", "min-size", "int64_t", /*default=*/"1024",
+           "Minimum size of ElementsAttr to externalize">,
+    Option<"outputFilename", "output-filename", "std::string", /*default=*/"",
+           "Output filename for the weights module">,
+    Option<"dropLocations", "drop-locations", "bool", /*default=*/"false",
+           "Drop locations (use UnknownLoc) for the externalized constants">,
+  ];
+  let dependentDialects = ["mlir::ml_program::MLProgramDialect"];
+}
+
+def MLProgramRepopulateConstantsPass
+    : Pass<"mlprogram-repopulate-constants", "ModuleOp"> {
+  let summary = "Repopulate externalized constants from a weights module";
+  let options = [
+    Option<"inputFilename", "input-filename", "std::string", /*default=*/"",
+           "Input filename for the weights module">,
+  ];
+  let dependentDialects = ["mlir::ml_program::MLProgramDialect"];
+}
+
 #endif // MLIR_DIALECT_MLPROGRAM_TRANSFORMS_PASSES

--- a/mlir/lib/Dialect/MLProgram/Transforms/CMakeLists.txt
+++ b/mlir/lib/Dialect/MLProgram/Transforms/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_mlir_dialect_library(MLIRMLProgramTransforms
   BufferizableOpInterfaceImpl.cpp
+  ExternalizeLargeConstants.cpp
   PipelineGlobalOps.cpp
 
   ADDITIONAL_HEADER_DIRS
@@ -11,7 +12,10 @@ add_mlir_dialect_library(MLIRMLProgramTransforms
   LINK_LIBS PUBLIC
   MLIRBufferizationDialect
   MLIRBufferizationTransforms
+  MLIRBytecodeWriter
   MLIRIR
   MLIRMLProgramDialect
+  MLIRParser
   MLIRPass
+  MLIRSupport
 )

--- a/mlir/lib/Dialect/MLProgram/Transforms/ExternalizeLargeConstants.cpp
+++ b/mlir/lib/Dialect/MLProgram/Transforms/ExternalizeLargeConstants.cpp
@@ -1,0 +1,218 @@
+//===- ExternalizeLargeConstants.cpp - Externalize Large Constants Pass ---===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "mlir/Dialect/MLProgram/Transforms/Passes.h"
+
+#include "mlir/Bytecode/BytecodeWriter.h"
+#include "mlir/Dialect/MLProgram/IR/MLProgram.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/SymbolTable.h"
+#include "mlir/Parser/Parser.h"
+#include "mlir/Support/FileUtilities.h"
+#include "llvm/Support/FileSystem.h"
+#include "llvm/Support/ToolOutputFile.h"
+
+namespace mlir {
+namespace ml_program {
+#define GEN_PASS_DEF_MLPROGRAMEXTERNALIZECONSTANTSPASS
+#define GEN_PASS_DEF_MLPROGRAMREPOPULATECONSTANTSPASS
+#include "mlir/Dialect/MLProgram/Transforms/Passes.h.inc"
+
+/// Repopulate constants in `op` from `externalWeightsModule`.
+LogicalResult repopulateConstants(Operation *op,
+                                  Operation *externalWeightsModule) {
+  MLIRContext *ctx = op->getContext();
+  OpBuilder builder(ctx);
+
+  auto weightsModule = dyn_cast<ModuleOp>(externalWeightsModule);
+  if (!weightsModule)
+    return failure();
+
+  SymbolTable weightsSymbolTable(weightsModule);
+
+  auto walkResult = op->walk([&](GlobalLoadConstOp loadOp) {
+    auto globalName = loadOp.getGlobal().getLeafReference();
+
+    auto nestedModule = weightsSymbolTable.lookup<ModuleOp>(globalName);
+    if (!nestedModule)
+      return WalkResult::advance();
+
+    // Find the first operation in the nested module
+    if (nestedModule.getBody()->empty()) {
+      loadOp.emitError() << "weight module is empty: " << globalName;
+      return WalkResult::interrupt();
+    }
+
+    Operation *constOp = &nestedModule.getBody()->front();
+    if (constOp->getNumResults() != 1 ||
+        constOp->getResult(0).getType() != loadOp.getType()) {
+      loadOp.emitError() << "weight type mismatch for: " << globalName;
+      return WalkResult::interrupt();
+    }
+
+    builder.setInsertionPoint(loadOp);
+    Operation *clonedOp = builder.clone(*constOp);
+    loadOp.getResult().replaceAllUsesWith(clonedOp->getResult(0));
+    loadOp.erase();
+
+    return WalkResult::advance();
+  });
+
+  if (walkResult.wasInterrupted())
+    return failure();
+
+  // Optionally clean up the extern globals if they are no longer used
+  // For now we keep them as they might be needed for other things.
+
+  return success();
+}
+
+LogicalResult externalizeConstants(ModuleOp module, int64_t minSize,
+                                   bool dropLocations,
+                                   StringRef outputFilename) {
+  if (outputFilename.empty())
+    return module.emitError() << "outputFilename is required for externalizing constants";
+
+  MLIRContext *ctx = module.getContext();
+  OpBuilder builder(ctx);
+
+  Location moduleLoc = dropLocations ? UnknownLoc::get(ctx) : module.getLoc();
+  auto weightsModule =
+      ModuleOp::create(moduleLoc, StringAttr::get(ctx, "top"));
+  int weightCounter = 0;
+  llvm::DenseMap<Attribute, std::string> deduplicatedConstants;
+
+  auto walkResult = module.walk([&](Operation *op) {
+    if (!op->hasTrait<OpTrait::ConstantLike>() || op->getNumResults() != 1)
+      return WalkResult::advance();
+
+    ElementsAttr largeElementsAttr;
+    if (!matchPattern(op, m_Constant(&largeElementsAttr)) ||
+        largeElementsAttr.getNumElements() < minSize)
+      return WalkResult::advance();
+
+    Location loc = dropLocations ? UnknownLoc::get(ctx) : op->getLoc();
+    std::string weightName;
+
+    // Only capture one of the constants with the same value.
+    if (dropLocations) {
+      auto it = deduplicatedConstants.find(largeElementsAttr);
+      if (it != deduplicatedConstants.end())
+        weightName = it->second;
+    }
+
+    if (weightName.empty()) {
+      // Create unique name for the weight
+      // TODO: We can do something better here to make identification better.
+      weightName = "_weight_" + std::to_string(weightCounter++);
+      if (dropLocations)
+        deduplicatedConstants[largeElementsAttr] = weightName;
+
+      // Create extern global in the original module
+      builder.setInsertionPointToStart(module.getBody());
+      auto externAttr = ExternAttr::get(ctx, op->getResult(0).getType());
+      GlobalOp::create(builder, loc, weightName, op->getResult(0).getType(),
+                       /*is_mutable=*/false, externAttr,
+                       /*sym_visibility=*/nullptr);
+
+      // Create nested module in weightsModule
+      builder.setInsertionPointToEnd(weightsModule.getBody());
+      auto nestedModule = ModuleOp::create(loc, weightName);
+      builder.insert(nestedModule);
+
+      // Clone the constant op into nestedModule
+      builder.setInsertionPointToEnd(nestedModule.getBody());
+      Operation *clonedOp = builder.clone(*op);
+      if (dropLocations)
+        clonedOp->setLoc(loc);
+    }
+
+    // Replace original op with ml_program.global_load_const
+    builder.setInsertionPoint(op);
+    auto loadOp = GlobalLoadConstOp::create(
+        builder, loc, op->getResult(0).getType(),
+        FlatSymbolRefAttr::get(ctx, weightName));
+
+    op->replaceAllUsesWith(loadOp);
+    op->erase();
+
+    return WalkResult::advance();
+  });
+
+  if (walkResult.wasInterrupted()) {
+    weightsModule->erase();
+    return failure();
+  }
+
+  if (weightCounter > 0) {
+    std::string errorMessage;
+    auto output = openOutputFile(outputFilename, &errorMessage);
+    if (!output) {
+      module.emitError() << "failed to open output file: " << errorMessage;
+      weightsModule->erase();
+      return failure();
+    }
+    if (failed(writeBytecodeToFile(weightsModule, output->os()))) {
+      module.emitError() << "failed to write bytecode to file";
+      weightsModule->erase();
+      return failure();
+    }
+    output->keep();
+  }
+  weightsModule->erase();
+  return success();
+}
+
+namespace {
+
+class MLProgramExternalizeConstants
+    : public impl::MLProgramExternalizeConstantsPassBase<
+          MLProgramExternalizeConstants> {
+public:
+  using impl::MLProgramExternalizeConstantsPassBase<
+      MLProgramExternalizeConstants>::MLProgramExternalizeConstantsPassBase;
+
+  void runOnOperation() override {
+    if (failed(externalizeConstants(getOperation(), minSize, dropLocations,
+                                    outputFilename)))
+      signalPassFailure();
+  }
+};
+
+class MLProgramRepopulateConstants
+    : public impl::MLProgramRepopulateConstantsPassBase<
+          MLProgramRepopulateConstants> {
+public:
+  using impl::MLProgramRepopulateConstantsPassBase<
+      MLProgramRepopulateConstants>::MLProgramRepopulateConstantsPassBase;
+
+  void runOnOperation() override {
+    ModuleOp module = getOperation();
+    MLIRContext *ctx = &getContext();
+
+    if (inputFilename.empty())
+      return;
+
+    ParserConfig config(ctx);
+    auto weightsModuleOwned = parseSourceFile<ModuleOp>(inputFilename, config);
+    if (!weightsModuleOwned) {
+      emitError(module.getLoc()) << "failed to parse weights file: "
+                                 << inputFilename;
+      return signalPassFailure();
+    }
+
+    if (failed(repopulateConstants(module, weightsModuleOwned.get())))
+      return signalPassFailure();
+  }
+};
+
+} // namespace
+
+} // namespace ml_program
+} // namespace mlir

--- a/mlir/test/Dialect/MLProgram/externalize-constants.mlir
+++ b/mlir/test/Dialect/MLProgram/externalize-constants.mlir
@@ -1,0 +1,32 @@
+// RUN: mlir-opt %s --mlprogram-externalize-constants="min-size=2 output-filename=%t.mlirbc" | FileCheck %s --check-prefix=EXT
+// RUN: mlir-opt %s --mlprogram-externalize-constants="min-size=2 output-filename=%t.mlirbc" | mlir-opt --mlprogram-repopulate-constants="input-filename=%t.mlirbc" | FileCheck %s --check-prefix=REP
+// RUN: mlir-opt %s --mlprogram-externalize-constants="min-size=2 drop-locations=true" -mlir-print-debuginfo | FileCheck %s --check-prefix=LOC
+
+// EXT-DAG: ml_program.global public @_weight_0
+// EXT-DAG: #ml_program.extern
+// EXT-DAG: ml_program.global public @_weight_1
+// EXT-DAG: #ml_program.extern
+
+// EXT-LABEL: func.func @main
+// EXT: %[[LOAD0:.*]] = ml_program.global_load_const @_weight_0 : tensor<4xf32>
+// EXT: %[[LOAD1:.*]] = ml_program.global_load_const @_weight_1 : tensor<2xf32>
+// EXT: return %[[LOAD0]], %[[LOAD1]]
+
+// REP-LABEL: func.func @main
+// REP: %[[CST0:.*]] = arith.constant dense<[1.000000e+00, 2.000000e+00, 3.000000e+00, 4.000000e+00]> : tensor<4xf32>
+// REP: %[[CST1:.*]] = arith.constant dense<[5.000000e+00, 6.000000e+00]> : tensor<2xf32>
+// REP: return %[[CST0]], %[[CST1]]
+
+// LOC-DAG: ml_program.global public @_weight_0{{.*}}loc(#loc1)
+// LOC-DAG: ml_program.global public @_weight_1{{.*}}loc(#loc1)
+// LOC-LABEL: func.func @main
+// LOC: %[[LOAD0:.*]] = ml_program.global_load_const @_weight_0 : tensor<4xf32> loc(#loc1)
+// LOC: %[[LOAD1:.*]] = ml_program.global_load_const @_weight_1 : tensor<2xf32> loc(#loc1)
+// LOC: #loc1 = loc(unknown)
+
+func.func @main() -> (tensor<4xf32>, tensor<2xf32>) {
+  %cst = arith.constant dense<[1.0, 2.0, 3.0, 4.0]> : tensor<4xf32> loc("loc1")
+  %cst2 = arith.constant dense<[5.0, 6.0]> : tensor<2xf32> loc("loc2")
+  %cst3 = arith.constant dense<[7.0]> : tensor<1xf32> loc("loc3")
+  return %cst, %cst2 : tensor<4xf32>, tensor<2xf32>
+}


### PR DESCRIPTION
This is showing a simple example where we have a pair of passes, one externalizes to external mlirbc file and the next would undo it. This leans into MLProgram having tool interpretation, and here it is this pair just. It would be more concise with an "inline" load or if I used keypaths on the ops, but I didn't want to change the dialect as part of this.

I considered having only the weights in the external files but this would then complicate/restrict the kind of constants that can be materialized. But the bytecode cost is rather small and locations could be used better to identify things.

This could be improved (and couple of other alternatives) but we were missing a simple example for further refinement and comparison.