### PR TITLE
[Hexagon] Fix use-before-def bug by using caller-saved register for AP

### DIFF
--- a/llvm/lib/Target/Hexagon/HexagonFrameLowering.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonFrameLowering.cpp
@@ -1572,25 +1572,6 @@ bool HexagonFrameLowering::assignCalleeSavedSpillSlots(MachineFunction &MF,
   // (2) For each reserved register, remove that register and all of its
   // sub- and super-registers from SRegs.
   BitVector Reserved = TRI->getReservedRegs(MF);
-  // Unreserve the stack align register: it is reserved for this function
-  // only, it still needs to be saved/restored.
-  Register AP =
-      MF.getInfo<HexagonMachineFunctionInfo>()->getStackAlignBaseReg();
-  if (AP.isValid()) {
-    Reserved[AP] = false;
-    // Unreserve super-regs if no other subregisters are reserved.
-    for (MCPhysReg SP : TRI->superregs(AP)) {
-      bool HasResSub = false;
-      for (MCPhysReg SB : TRI->subregs(SP)) {
-        if (!Reserved[SB])
-          continue;
-        HasResSub = true;
-        break;
-      }
-      if (!HasResSub)
-        Reserved[SP] = false;
-    }
-  }
 
   for (int x = Reserved.find_first(); x >= 0; x = Reserved.find_next(x)) {
     Register R = x;

--- a/llvm/lib/Target/Hexagon/HexagonISelDAGToDAG.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonISelDAGToDAG.cpp
@@ -1428,11 +1428,22 @@ void HexagonDAGToDAGISel::emitFunctionEntryCode() {
   MachineBasicBlock *EntryBB = &MF->front();
   Align EntryMaxA = MFI.getMaxAlign();
 
-  // Reserve the first non-volatile register.
+  // Reserve a caller-saved register for AP (aligned pointer).
   Register AP = 0;
   auto &HRI = *HST.getRegisterInfo();
   BitVector Reserved = HRI.getReservedRegs(*MF);
-  for (const MCPhysReg *R = HRI.getCalleeSavedRegs(MF); *R; ++R) {
+
+  // Get caller-saved registers and pick the first available one.
+  // We iterate in reverse order to prefer higher-numbered registers and avoid
+  // conflicts with argument passing (R0-R5).
+  const MCPhysReg *CallerSavedRegs =
+      HRI.getCallerSavedRegs(MF, &Hexagon::IntRegsRegClass);
+
+  const MCPhysReg *LastReg = CallerSavedRegs;
+  while (*LastReg)
+    ++LastReg;
+
+  for (const MCPhysReg *R = LastReg - 1; R >= CallerSavedRegs; --R) {
     if (Reserved[*R])
       continue;
     AP = *R;

--- a/llvm/test/CodeGen/Hexagon/aligna-prologue-expansion.ll
+++ b/llvm/test/CodeGen/Hexagon/aligna-prologue-expansion.ll
@@ -1,0 +1,31 @@
+; RUN: llc -mtriple=hexagon  < %s | FileCheck %s
+
+; CHECK-LABEL: test_aligna_expansion:
+; CHECK: allocframe(r29,#{{[0-9]+}}):raw
+; CHECK: r[[AP:[0-9]+]] = and(r30,#-128)
+
+declare void @external_func(ptr, ptr, i32, i32)
+declare i32 @llvm.smin.i32(i32, i32) #0
+
+define void @test_aligna_expansion(i32 %rows, i32 %depth, ptr %lhs_, ptr %blocking, i32 %param1, i32 %mul) {
+entry:
+  %buffer = alloca i8, i32 %rows, align 128
+  br label %loop_header
+
+loop_header:
+  %i = phi i32 [ 0, %entry ], [ %mul, %loop_body ]
+  %add = or i32 %i, %param1
+  br label %loop_body
+
+loop_body:
+  %k = phi i32 [ 0, %loop_header ], [ %add_k, %loop_body ]
+  %add_k = add i32 %k, %depth
+  %min_val = call i32 @llvm.smin.i32(i32 %add_k, i32 0)
+  %sub = sub i32 %min_val, %k
+  store i32 %rows, ptr %lhs_, align 4
+  call void @external_func(ptr %buffer, ptr %blocking, i32 %sub, i32 %add)
+  %cmp = icmp slt i32 %add_k, 0
+  br i1 %cmp, label %loop_body, label %loop_header
+}
+
+attributes #0 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }


### PR DESCRIPTION
 Fixes #184531 
