### PR TITLE
[Offload][L0] clear completed events from a wait list

### DIFF
--- a/offload/plugins-nextgen/level_zero/src/L0Device.cpp
+++ b/offload/plugins-nextgen/level_zero/src/L0Device.cpp
@@ -319,6 +319,9 @@ Error L0DeviceTy::synchronizeImpl(__tgt_async_info &AsyncInfo,
           return Err;
       }
     }
+    // In either case, all the events are now reset and released
+    // back into the pool. We need to clear them from the queue.
+    AsyncQueue->WaitEvents.clear();
   }
 
   // Commit delayed USM2M copies.


### PR DESCRIPTION
Queue's WaitEvent collection wasn't being cleared after synchronization and resetting of the events. This led to hangs on subsequent host synchronizations if not preceeded by any other operation.