### PR TITLE
[Clang][NFC] Add two CWG2369 regression tests

### DIFF
--- a/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp
+++ b/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp
@@ -5965,20 +5965,12 @@ void Sema::InstantiateFunctionDefinition(SourceLocation PointOfInstantiation,
     savedContext.pop();
   }
 
-  // We never need to emit the code for a lambda in unevaluated context.
-  // We also can't mangle a lambda in the require clause of a function template
-  // during constraint checking as the MSI ABI would need to mangle the (not yet
-  // specialized) enclosing declaration
-  // FIXME: Should we try to skip this for non-lambda functions too?
-  bool ShouldSkipCG = [&] {
-    auto *RD = dyn_cast<CXXRecordDecl>(Function->getParent());
-    if (!RD || !RD->isLambda())
-      return false;
-
-    return llvm::any_of(ExprEvalContexts, [](auto &Context) {
-      return Context.isUnevaluated() || Context.isImmediateFunctionContext();
-    });
-  }();
+  // We never need to emit the code in constriant substitution.
+  // For example, we can't mangle a lambda in the require clause of a function
+  // template during constraint checking as the MS ABI would need to mangle the
+  // (not yet specialized) enclosing declaration.
+  // FIXME: This can be removed when MS ABI supports concepts.
+  bool ShouldSkipCG = inConstraintSubstitution();
   if (!ShouldSkipCG) {
     DeclGroupRef DG(Function);
     Consumer.HandleTopLevelDecl(DG);

--- a/clang/test/CodeGenCXX/ms-mangle-requires.cpp
+++ b/clang/test/CodeGenCXX/ms-mangle-requires.cpp
@@ -69,3 +69,58 @@ void test() {
 }
 // CHECK-LABEL:define {{.*}} void @"??$f@$0CK@@GH147650@@YAXXZ"()
 }
+
+namespace GH173160 {
+
+template< typename TypeList, typename Func >
+auto for_each_type(Func func) {
+  return func;
+}
+
+template< class T >
+struct X {};
+
+template< class T >
+concept Component = requires(T component) {
+  for_each_type<typename T::required_type>( []{} );
+};
+
+struct EntityRegistry {
+  template< Component C >
+  auto get_component(const int id) -> X<C> {
+    return {};
+  }
+};
+
+struct A {
+  struct required_type {};
+};
+
+void foo() {
+  EntityRegistry entities;
+  entities.get_component<A>(0);
+  // CHECK: define {{.*}} @"??$get_component@UA@GH173160@@@EntityRegistry@GH173160@@QEAA?AU?$X@UA@GH173160@@@1@H@Z"
+}
+
+}
+
+namespace GH191588 {
+
+template<typename T> concept HasBar = requires(T t) {
+  t.bar([](const auto&) {});
+};
+
+template<class V, class... F> requires (HasBar<V>)
+decltype(auto) testBar(V&& v, F&&... f) { return 0; }
+
+struct WithVariadic {
+  template<typename... F> decltype(auto) bar(F&&... f) { return 0; }
+};
+
+void caller() {
+  testBar(WithVariadic{}, [](auto){});
+}
+
+// CHECK: define {{.*}} @"??$testBar@UWithVariadic@GH191588@@V<lambda_0>@?0??caller@2@YAXXZ@@GH191588@@YA?A?<decltype-auto>@@$$QEAUWithVariadic@0@$$QEAV<lambda_0>@?0??caller@0@YAXXZ@@Z"
+
+}

--- a/clang/test/CodeGenCXX/ms-mangle-requires.cpp
+++ b/clang/test/CodeGenCXX/ms-mangle-requires.cpp
@@ -69,3 +69,37 @@ void test() {
 }
 // CHECK-LABEL:define {{.*}} void @"??$f@$0CK@@GH147650@@YAXXZ"()
 }
+
+namespace GH173160 {
+
+template< typename TypeList, typename Func >
+auto for_each_type(Func func) {
+  return func;
+}
+
+template< class T >
+struct X {};
+
+template< class T >
+concept Component = requires(T component) {
+  for_each_type<typename T::required_type>( []{} );
+};
+
+struct EntityRegistry {
+  template< Component C >
+  auto get_component(const int id) -> X<C> {
+    return {};
+  }
+};
+
+struct A {
+  struct required_type {};
+};
+
+void foo() {
+  EntityRegistry entities;
+  entities.get_component<A>(0);
+  // CHECK: define {{.*}} @"??$get_component@UA@GH173160@@@EntityRegistry@GH173160@@QEAA?AU?$X@UA@GH173160@@@1@H@Z"
+}
+
+}


### PR DESCRIPTION
Some of the MS ABI regressions, which were caused by CWG2369, were fixed by https://github.com/llvm/llvm-project/pull/197215. Let's add those regressions to our tests.

Closes https://github.com/llvm/llvm-project/issues/173160
Closes https://github.com/llvm/llvm-project/issues/191588