### PR TITLE
[Frontend/OpenMP][NFC] Drop uses of BranchInst

### DIFF
--- a/llvm/include/llvm/Frontend/OpenMP/OMPIRBuilder.h
+++ b/llvm/include/llvm/Frontend/OpenMP/OMPIRBuilder.h
@@ -4112,7 +4112,7 @@ public:
   /// eventually branch to the \p Latch block.
   BasicBlock *getBody() const {
     assert(isValid() && "Requires a valid canonical loop");
-    return cast<BranchInst>(Cond->getTerminator())->getSuccessor(0);
+    return cast<CondBrInst>(Cond->getTerminator())->getSuccessor(0);
   }
 
   /// Reaching the latch indicates the end of the loop body code. In the

--- a/llvm/lib/Frontend/OpenMP/OMPIRBuilder.cpp
+++ b/llvm/lib/Frontend/OpenMP/OMPIRBuilder.cpp
@@ -297,16 +297,14 @@ computeOpenMPScheduleType(ScheduleKind ClauseKind, bool HasChunks,
 ///             the current head of the IR construction).
 static void redirectTo(BasicBlock *Source, BasicBlock *Target, DebugLoc DL) {
   if (Instruction *Term = Source->getTerminator()) {
-    auto *Br = cast<BranchInst>(Term);
-    assert(!Br->isConditional() &&
-           "BB's terminator must be an unconditional branch (or degenerate)");
-    BasicBlock *Succ = Br->getSuccessor(0);
+    auto *Br = cast<UncondBrInst>(Term);
+    BasicBlock *Succ = Br->getSuccessor();
     Succ->removePredecessor(Source, /*KeepOneInputPHIs=*/true);
-    Br->setSuccessor(0, Target);
+    Br->setSuccessor(Target);
     return;
   }
 
-  auto *NewBr = BranchInst::Create(Target, Source);
+  auto *NewBr = UncondBrInst::Create(Target, Source);
   NewBr->setDebugLoc(DL);
 }
 
@@ -332,7 +330,7 @@ void llvm::spliceBB(IRBuilderBase::InsertPoint IP, BasicBlock *New,
     New->splice(New->begin(), Old, IP.getPoint(), Old->end());
 
   if (CreateBranch) {
-    auto *NewBr = BranchInst::Create(New, Old);
+    auto *NewBr = UncondBrInst::Create(New, Old);
     NewBr->setDebugLoc(DL);
   }
 }
@@ -2764,7 +2762,7 @@ OpenMPIRBuilder::InsertPointOrErrorTy OpenMPIRBuilder::createSections(
           M.getContext(), "omp_section_loop.body.case", CurFn, Continue);
       SwitchStmt->addCase(Builder.getInt32(CaseNumber), CaseBB);
       Builder.SetInsertPoint(CaseBB);
-      BranchInst *CaseEndBr = Builder.CreateBr(Continue);
+      UncondBrInst *CaseEndBr = Builder.CreateBr(Continue);
       if (Error Err = SectionCB(InsertPointTy(), {CaseEndBr->getParent(),
                                                   CaseEndBr->getIterator()}))
         return Err;
@@ -6196,8 +6194,8 @@ OpenMPIRBuilder::applyDynamicWorkshareLoop(DebugLoc DL, CanonicalLoopInfo *CLI,
 
   // Then set the pre-header to jump to the OuterCond
   Instruction *Term = PreHeader->getTerminator();
-  auto *Br = cast<BranchInst>(Term);
-  Br->setSuccessor(0, OuterCond);
+  auto *Br = cast<UncondBrInst>(Term);
+  Br->setSuccessor(OuterCond);
 
   // Modify the inner condition:
   // * Use the UpperBound returned from the DynamicNext call.
@@ -6209,7 +6207,7 @@ OpenMPIRBuilder::applyDynamicWorkshareLoop(DebugLoc DL, CanonicalLoopInfo *CLI,
   CI->setOperand(1, UpperBound);
   // Redirect the inner exit to branch to outer condition.
   Instruction *Branch = &Cond->back();
-  auto *BI = cast<BranchInst>(Branch);
+  auto *BI = cast<CondBrInst>(Branch);
   assert(BI->getSuccessor(1) == Exit);
   BI->setSuccessor(1, OuterCond);
 
@@ -7408,7 +7406,7 @@ OpenMPIRBuilder::InsertPointOrErrorTy OpenMPIRBuilder::EmitOMPInlinedRegion(
   // for conditional creation
   BasicBlock *EntryBB = Builder.GetInsertBlock();
   Instruction *SplitPos = EntryBB->getTerminator();
-  if (!isa_and_nonnull<BranchInst>(SplitPos))
+  if (!isa_and_nonnull<UncondBrInst, CondBrInst>(SplitPos))
     SplitPos = new UnreachableInst(Builder.getContext(), EntryBB);
   BasicBlock *ExitBB = EntryBB->splitBasicBlock(SplitPos, "omp_region.end");
   BasicBlock *FiniBB =
@@ -7439,7 +7437,7 @@ OpenMPIRBuilder::InsertPointOrErrorTy OpenMPIRBuilder::EmitOMPInlinedRegion(
   auto merged = MergeBlockIntoPredecessor(ExitBB);
   BasicBlock *ExitPredBB = SplitPos->getParent();
   auto InsertBB = merged ? ExitPredBB : ExitBB;
-  if (!isa_and_nonnull<BranchInst>(SplitPos))
+  if (!isa_and_nonnull<UncondBrInst, CondBrInst>(SplitPos))
     SplitPos->eraseFromParent();
   Builder.SetInsertPoint(InsertBB);
 
@@ -7537,7 +7535,7 @@ OpenMPIRBuilder::InsertPointTy OpenMPIRBuilder::createCopyinClauseBlocks(
 
   // If entry block is terminated, split to preserve the branch to following
   // basic block (i.e. OMP.Entry.Next), otherwise, leave everything as is.
-  if (isa_and_nonnull<BranchInst>(OMP_Entry->getTerminator())) {
+  if (isa_and_nonnull<CondBrInst>(OMP_Entry->getTerminator())) {
     CopyEnd = OMP_Entry->splitBasicBlock(OMP_Entry->getTerminator(),
                                          "copyin.not.master.end");
     OMP_Entry->getTerminator()->eraseFromParent();
@@ -11764,13 +11762,13 @@ void CanonicalLoopInfo::assertOK() const {
 
   // Verify standard control-flow we use for OpenMP loops.
   assert(Preheader);
-  assert(isa<BranchInst>(Preheader->getTerminator()) &&
+  assert(isa<UncondBrInst>(Preheader->getTerminator()) &&
          "Preheader must terminate with unconditional branch");
   assert(Preheader->getSingleSuccessor() == Header &&
          "Preheader must jump to header");
 
   assert(Header);
-  assert(isa<BranchInst>(Header->getTerminator()) &&
+  assert(isa<UncondBrInst>(Header->getTerminator()) &&
          "Header must terminate with unconditional branch");
   assert(Header->getSingleSuccessor() == Cond &&
          "Header must jump to exiting block");
@@ -11779,13 +11777,11 @@ void CanonicalLoopInfo::assertOK() const {
   assert(Cond->getSinglePredecessor() == Header &&
          "Exiting block only reachable from header");
 
-  assert(isa<BranchInst>(Cond->getTerminator()) &&
+  assert(isa<CondBrInst>(Cond->getTerminator()) &&
          "Exiting block must terminate with conditional branch");
-  assert(size(successors(Cond)) == 2 &&
-         "Exiting block must have two successors");
-  assert(cast<BranchInst>(Cond->getTerminator())->getSuccessor(0) == Body &&
+  assert(cast<CondBrInst>(Cond->getTerminator())->getSuccessor(0) == Body &&
          "Exiting block's first successor jump to the body");
-  assert(cast<BranchInst>(Cond->getTerminator())->getSuccessor(1) == Exit &&
+  assert(cast<CondBrInst>(Cond->getTerminator())->getSuccessor(1) == Exit &&
          "Exiting block's second successor must exit the loop");
 
   assert(Body);
@@ -11794,7 +11790,7 @@ void CanonicalLoopInfo::assertOK() const {
   assert(!isa<PHINode>(Body->front()));
 
   assert(Latch);
-  assert(isa<BranchInst>(Latch->getTerminator()) &&
+  assert(isa<UncondBrInst>(Latch->getTerminator()) &&
          "Latch must terminate with unconditional branch");
   assert(Latch->getSingleSuccessor() == Header && "Latch must jump to header");
   // TODO: To support simple redirecting of the end of the body code that has
@@ -11803,7 +11799,7 @@ void CanonicalLoopInfo::assertOK() const {
   assert(!isa<PHINode>(Latch->front()));
 
   assert(Exit);
-  assert(isa<BranchInst>(Exit->getTerminator()) &&
+  assert(isa<UncondBrInst>(Exit->getTerminator()) &&
          "Exit block must terminate with unconditional branch");
   assert(Exit->getSingleSuccessor() == After &&
          "Exit block must jump to after block");

--- a/llvm/unittests/Frontend/OpenMPIRBuilderTest.cpp
+++ b/llvm/unittests/Frontend/OpenMPIRBuilderTest.cpp
@@ -413,7 +413,7 @@ TEST_F(OpenMPIRBuilderTest, CreateCancel) {
   auto FiniCB = [&](InsertPointTy IP) {
     ASSERT_NE(IP.getBlock(), nullptr);
     ASSERT_EQ(IP.getBlock()->end(), IP.getPoint());
-    BranchInst::Create(CBB, IP.getBlock());
+    UncondBrInst::Create(CBB, IP.getBlock());
   };
   OMPBuilder.pushFinalizationCB({FINICB_WRAPPER(FiniCB), OMPD_parallel, true});
 
@@ -474,7 +474,7 @@ TEST_F(OpenMPIRBuilderTest, CreateCancelIfCond) {
   auto FiniCB = [&](InsertPointTy IP) {
     ASSERT_NE(IP.getBlock(), nullptr);
     ASSERT_EQ(IP.getBlock()->end(), IP.getPoint());
-    BranchInst::Create(CBB, IP.getBlock());
+    UncondBrInst::Create(CBB, IP.getBlock());
   };
   OMPBuilder.pushFinalizationCB({FINICB_WRAPPER(FiniCB), OMPD_parallel, true});
 
@@ -489,8 +489,7 @@ TEST_F(OpenMPIRBuilderTest, CreateCancelIfCond) {
   EXPECT_EQ(M->size(), 4U);
   EXPECT_EQ(F->size(), 10U);
   EXPECT_EQ(BB->size(), 1U);
-  ASSERT_TRUE(isa<BranchInst>(BB->getTerminator()));
-  ASSERT_EQ(BB->getTerminator()->getNumSuccessors(), 2U);
+  ASSERT_TRUE(isa<CondBrInst>(BB->getTerminator()));
   BB = BB->getTerminator()->getSuccessor(0);
   EXPECT_EQ(BB->size(), 4U);
 
@@ -541,7 +540,7 @@ TEST_F(OpenMPIRBuilderTest, CreateCancelBarrier) {
   auto FiniCB = [&](InsertPointTy IP) {
     ASSERT_NE(IP.getBlock(), nullptr);
     ASSERT_EQ(IP.getBlock()->end(), IP.getPoint());
-    BranchInst::Create(CBB, IP.getBlock());
+    UncondBrInst::Create(CBB, IP.getBlock());
   };
   OMPBuilder.pushFinalizationCB({FINICB_WRAPPER(FiniCB), OMPD_parallel, true});
 
@@ -1289,18 +1288,16 @@ TEST_F(OpenMPIRBuilderTest, ParallelCancelBarrier) {
   for (const User *Usr : FakeDestructor->users()) {
     const CallInst *CI = dyn_cast<CallInst>(Usr);
     ASSERT_EQ(CI->getCalledFunction(), FakeDestructor);
-    ASSERT_TRUE(isa<BranchInst>(CI->getNextNode()));
-    ASSERT_EQ(CI->getNextNode()->getNumSuccessors(), 1U);
+    ASSERT_TRUE(isa<UncondBrInst>(CI->getNextNode()));
     if (ExitBB)
       ASSERT_EQ(CI->getNextNode()->getSuccessor(0), ExitBB);
     else
       ExitBB = CI->getNextNode()->getSuccessor(0);
     ASSERT_EQ(ExitBB->size(), 1U);
     if (!isa<ReturnInst>(ExitBB->front())) {
-      ASSERT_TRUE(isa<BranchInst>(ExitBB->front()));
-      ASSERT_EQ(cast<BranchInst>(ExitBB->front()).getNumSuccessors(), 1U);
+      ASSERT_TRUE(isa<UncondBrInst>(ExitBB->front()));
       ASSERT_TRUE(isa<ReturnInst>(
-          cast<BranchInst>(ExitBB->front()).getSuccessor(0)->front()));
+          cast<UncondBrInst>(ExitBB->front()).getSuccessor()->front()));
     }
   }
 }
@@ -1517,7 +1514,7 @@ TEST_F(OpenMPIRBuilderTest, CollapseNestedLoops) {
   BasicBlock *LoopNextEnter =
       BasicBlock::Create(M->getContext(), "loopnest.enter", F,
                          Builder.GetInsertBlock()->getNextNode());
-  BranchInst *EnterBr = Builder.CreateBr(LoopNextEnter);
+  UncondBrInst *EnterBr = Builder.CreateBr(LoopNextEnter);
   InsertPointTy ComputeIP{EnterBr->getParent(), EnterBr->getIterator()};
 
   Builder.SetInsertPoint(LoopNextEnter);
@@ -1750,7 +1747,7 @@ TEST_F(OpenMPIRBuilderTest, TileNestedLoopsWithBounds) {
   BasicBlock *LoopNextEnter =
       BasicBlock::Create(M->getContext(), "loopnest.enter", F,
                          Builder.GetInsertBlock()->getNextNode());
-  BranchInst *EnterBr = Builder.CreateBr(LoopNextEnter);
+  UncondBrInst *EnterBr = Builder.CreateBr(LoopNextEnter);
   InsertPointTy ComputeIP{EnterBr->getParent(), EnterBr->getIterator()};
 
   InsertPointTy LoopIP{LoopNextEnter, LoopNextEnter->begin()};
@@ -2243,7 +2240,7 @@ TEST_F(OpenMPIRBuilderTest, ApplySimdIf) {
 
   // Check for if condition
   BasicBlock *LoopBody = CLI->getBody();
-  BranchInst *IfCond = cast<BranchInst>(LoopBody->getTerminator());
+  CondBrInst *IfCond = cast<CondBrInst>(LoopBody->getTerminator());
   EXPECT_EQ(IfCond->getCondition(), IfCmp);
   BasicBlock *TrueBranch = IfCond->getSuccessor(0);
   BasicBlock *FalseBranch = IfCond->getSuccessor(1)->getUniqueSuccessor();
@@ -2897,9 +2894,8 @@ TEST_F(OpenMPIRBuilderTest, MasterDirective) {
   Builder.restoreIP(AfterIP);
   Value *EntryBBTI = EntryBB->getTerminator();
   EXPECT_NE(EntryBBTI, nullptr);
-  EXPECT_TRUE(isa<BranchInst>(EntryBBTI));
-  BranchInst *EntryBr = cast<BranchInst>(EntryBB->getTerminator());
-  EXPECT_TRUE(EntryBr->isConditional());
+  EXPECT_TRUE(isa<CondBrInst>(EntryBBTI));
+  CondBrInst *EntryBr = cast<CondBrInst>(EntryBB->getTerminator());
   EXPECT_EQ(EntryBr->getSuccessor(0), ThenBB);
   BasicBlock *FinalizeBB = ThenBB->getUniqueSuccessor();
   BasicBlock *ExitBB = FinalizeBB->getUniqueSuccessor();
@@ -2980,9 +2976,8 @@ TEST_F(OpenMPIRBuilderTest, MaskedDirective) {
   Builder.restoreIP(AfterIP);
   Value *EntryBBTI = EntryBB->getTerminator();
   EXPECT_NE(EntryBBTI, nullptr);
-  EXPECT_TRUE(isa<BranchInst>(EntryBBTI));
-  BranchInst *EntryBr = cast<BranchInst>(EntryBB->getTerminator());
-  EXPECT_TRUE(EntryBr->isConditional());
+  EXPECT_TRUE(isa<CondBrInst>(EntryBBTI));
+  CondBrInst *EntryBr = cast<CondBrInst>(EntryBB->getTerminator());
   EXPECT_EQ(EntryBr->getSuccessor(0), ThenBB);
   BasicBlock *FinalizeBB = ThenBB->getUniqueSuccessor();
   BasicBlock *ExitBB = FinalizeBB->getUniqueSuccessor();
@@ -3425,10 +3420,9 @@ TEST_F(OpenMPIRBuilderTest, CopyinBlocks) {
   OMPBuilder.createCopyinClauseBlocks(Builder.saveIP(), MasterAddress,
                                       PrivAddress, Int32, /*BranchtoEnd*/ true);
 
-  BranchInst *EntryBr = dyn_cast_or_null<BranchInst>(EntryBB->getTerminator());
+  CondBrInst *EntryBr = dyn_cast_or_null<CondBrInst>(EntryBB->getTerminator());
 
   EXPECT_NE(EntryBr, nullptr);
-  EXPECT_TRUE(EntryBr->isConditional());
 
   BasicBlock *NotMasterBB = EntryBr->getSuccessor(0);
   BasicBlock *CopyinEnd = EntryBr->getSuccessor(1);
@@ -3438,11 +3432,10 @@ TEST_F(OpenMPIRBuilderTest, CopyinBlocks) {
   EXPECT_NE(NotMasterBB, nullptr);
   EXPECT_NE(CopyinEnd, nullptr);
 
-  BranchInst *NotMasterBr =
-      dyn_cast_or_null<BranchInst>(NotMasterBB->getTerminator());
+  UncondBrInst *NotMasterBr =
+      dyn_cast_or_null<UncondBrInst>(NotMasterBB->getTerminator());
   EXPECT_NE(NotMasterBr, nullptr);
-  EXPECT_FALSE(NotMasterBr->isConditional());
-  EXPECT_EQ(CopyinEnd, NotMasterBr->getSuccessor(0));
+  EXPECT_EQ(CopyinEnd, NotMasterBr->getSuccessor());
 }
 
 TEST_F(OpenMPIRBuilderTest, SingleDirective) {
@@ -3495,9 +3488,8 @@ TEST_F(OpenMPIRBuilderTest, SingleDirective) {
   Builder.restoreIP(AfterIP);
   Value *EntryBBTI = EntryBB->getTerminator();
   EXPECT_NE(EntryBBTI, nullptr);
-  EXPECT_TRUE(isa<BranchInst>(EntryBBTI));
-  BranchInst *EntryBr = cast<BranchInst>(EntryBB->getTerminator());
-  EXPECT_TRUE(EntryBr->isConditional());
+  EXPECT_TRUE(isa<CondBrInst>(EntryBBTI));
+  CondBrInst *EntryBr = cast<CondBrInst>(EntryBB->getTerminator());
   EXPECT_EQ(EntryBr->getSuccessor(0), ThenBB);
   BasicBlock *FinalizeBB = ThenBB->getUniqueSuccessor();
   BasicBlock *ExitBB = FinalizeBB->getUniqueSuccessor();
@@ -3589,9 +3581,8 @@ TEST_F(OpenMPIRBuilderTest, SingleDirectiveNowait) {
   Builder.restoreIP(AfterIP);
   Value *EntryBBTI = EntryBB->getTerminator();
   EXPECT_NE(EntryBBTI, nullptr);
-  EXPECT_TRUE(isa<BranchInst>(EntryBBTI));
-  BranchInst *EntryBr = cast<BranchInst>(EntryBB->getTerminator());
-  EXPECT_TRUE(EntryBr->isConditional());
+  EXPECT_TRUE(isa<CondBrInst>(EntryBBTI));
+  CondBrInst *EntryBr = cast<CondBrInst>(EntryBB->getTerminator());
   EXPECT_EQ(EntryBr->getSuccessor(0), ThenBB);
   BasicBlock *FinalizeBB = ThenBB->getUniqueSuccessor();
   BasicBlock *ExitBB = FinalizeBB->getUniqueSuccessor();
@@ -3713,9 +3704,8 @@ TEST_F(OpenMPIRBuilderTest, SingleDirectiveCopyPrivate) {
   Builder.restoreIP(AfterIP);
   Value *EntryBBTI = EntryBB->getTerminator();
   EXPECT_NE(EntryBBTI, nullptr);
-  EXPECT_TRUE(isa<BranchInst>(EntryBBTI));
-  BranchInst *EntryBr = cast<BranchInst>(EntryBB->getTerminator());
-  EXPECT_TRUE(EntryBr->isConditional());
+  EXPECT_TRUE(isa<CondBrInst>(EntryBBTI));
+  CondBrInst *EntryBr = cast<CondBrInst>(EntryBB->getTerminator());
   EXPECT_EQ(EntryBr->getSuccessor(0), ThenBB);
   BasicBlock *FinalizeBB = ThenBB->getUniqueSuccessor();
   BasicBlock *ExitBB = FinalizeBB->getUniqueSuccessor();
@@ -3754,10 +3744,9 @@ TEST_F(OpenMPIRBuilderTest, SingleDirectiveCopyPrivate) {
   EXPECT_TRUE(isa<GlobalVariable>(SingleEndCI->getArgOperand(0)));
   EXPECT_EQ(SingleEndCI->getArgOperand(1), SingleEntryCI->getArgOperand(1));
   // br ExitBB
-  auto *ExitBBBI = FinalizeBBI.next<BranchInst>();
+  auto *ExitBBBI = FinalizeBBI.next<UncondBrInst>();
   EXPECT_NE(ExitBBBI, nullptr);
-  EXPECT_TRUE(ExitBBBI->isUnconditional());
-  EXPECT_EQ(ExitBBBI->getOperand(0), ExitBB);
+  EXPECT_EQ(ExitBBBI->getSuccessor(), ExitBB);
   EXPECT_FALSE(FinalizeBBI.hasNext());
 
   // check ExitBB
@@ -3993,10 +3982,9 @@ TEST_F(OpenMPIRBuilderTest, OMPAtomicUpdate) {
                                                      IsXLHSInRHSPart));
   Builder.restoreIP(AfterIP);
   BasicBlock *ContBB = EntryBB->getSingleSuccessor();
-  BranchInst *ContTI = dyn_cast<BranchInst>(ContBB->getTerminator());
+  CondBrInst *ContTI = dyn_cast<CondBrInst>(ContBB->getTerminator());
   EXPECT_NE(ContTI, nullptr);
   BasicBlock *EndBB = ContTI->getSuccessor(0);
-  EXPECT_TRUE(ContTI->isConditional());
   EXPECT_EQ(ContTI->getSuccessor(1), ContBB);
   EXPECT_NE(EndBB, nullptr);
 
@@ -4063,10 +4051,9 @@ TEST_F(OpenMPIRBuilderTest, OMPAtomicUpdateFloat) {
                                                      IsXLHSInRHSPart));
   Builder.restoreIP(AfterIP);
   BasicBlock *ContBB = EntryBB->getSingleSuccessor();
-  BranchInst *ContTI = dyn_cast<BranchInst>(ContBB->getTerminator());
+  CondBrInst *ContTI = dyn_cast<CondBrInst>(ContBB->getTerminator());
   EXPECT_NE(ContTI, nullptr);
   BasicBlock *EndBB = ContTI->getSuccessor(0);
-  EXPECT_TRUE(ContTI->isConditional());
   EXPECT_EQ(ContTI->getSuccessor(1), ContBB);
   EXPECT_NE(EndBB, nullptr);
 
@@ -4132,10 +4119,9 @@ TEST_F(OpenMPIRBuilderTest, OMPAtomicUpdateIntr) {
                                                      IsXLHSInRHSPart));
   Builder.restoreIP(AfterIP);
   BasicBlock *ContBB = EntryBB->getSingleSuccessor();
-  BranchInst *ContTI = dyn_cast<BranchInst>(ContBB->getTerminator());
+  CondBrInst *ContTI = dyn_cast<CondBrInst>(ContBB->getTerminator());
   EXPECT_NE(ContTI, nullptr);
   BasicBlock *EndBB = ContTI->getSuccessor(0);
-  EXPECT_TRUE(ContTI->isConditional());
   EXPECT_EQ(ContTI->getSuccessor(1), ContBB);
   EXPECT_NE(EndBB, nullptr);
 
@@ -4418,9 +4404,8 @@ TEST_F(OpenMPIRBuilderTest, OMPAtomicCompareCapture) {
   EXPECT_NE(ExtVal5, nullptr);
   EXPECT_EQ(ExtVal5->getAggregateOperand(), CmpXchg3);
   EXPECT_EQ(ExtVal5->getIndices(), ArrayRef<unsigned int>(1U));
-  BranchInst *Br1 = dyn_cast<BranchInst>(ExtVal5->getNextNode());
+  CondBrInst *Br1 = dyn_cast<CondBrInst>(ExtVal5->getNextNode());
   EXPECT_NE(Br1, nullptr);
-  EXPECT_EQ(Br1->isConditional(), true);
   EXPECT_EQ(Br1->getCondition(), ExtVal5);
   EXPECT_EQ(Br1->getSuccessor(0), Exit1);
   EXPECT_EQ(Br1->getSuccessor(1), Cont1);
@@ -4429,10 +4414,9 @@ TEST_F(OpenMPIRBuilderTest, OMPAtomicCompareCapture) {
   EXPECT_NE(Store3, nullptr);
   EXPECT_EQ(Store3->getPointerOperand(), VVal);
   EXPECT_EQ(Store3->getValueOperand(), ExtVal4);
-  BranchInst *Br2 = dyn_cast<BranchInst>(Store3->getNextNode());
+  UncondBrInst *Br2 = dyn_cast<UncondBrInst>(Store3->getNextNode());
   EXPECT_NE(Br2, nullptr);
-  EXPECT_EQ(Br2->isUnconditional(), true);
-  EXPECT_EQ(Br2->getSuccessor(0), Exit1);
+  EXPECT_EQ(Br2->getSuccessor(), Exit1);
 
   AtomicCmpXchgInst *CmpXchg4 = dyn_cast<AtomicCmpXchgInst>(&Exit1->front());
   EXPECT_NE(CmpXchg4, nullptr);
@@ -4468,9 +4452,8 @@ TEST_F(OpenMPIRBuilderTest, OMPAtomicCompareCapture) {
   EXPECT_NE(ExtVal8, nullptr);
   EXPECT_EQ(ExtVal8->getAggregateOperand(), CmpXchg5);
   EXPECT_EQ(ExtVal8->getIndices(), ArrayRef<unsigned int>(1U));
-  BranchInst *Br3 = dyn_cast<BranchInst>(ExtVal8->getNextNode());
+  CondBrInst *Br3 = dyn_cast<CondBrInst>(ExtVal8->getNextNode());
   EXPECT_NE(Br3, nullptr);
-  EXPECT_EQ(Br3->isConditional(), true);
   EXPECT_EQ(Br3->getCondition(), ExtVal8);
   EXPECT_EQ(Br3->getSuccessor(0), Exit2);
   EXPECT_EQ(Br3->getSuccessor(1), Cont2);
@@ -4479,9 +4462,8 @@ TEST_F(OpenMPIRBuilderTest, OMPAtomicCompareCapture) {
   EXPECT_NE(Store5, nullptr);
   EXPECT_EQ(Store5->getPointerOperand(), VVal);
   EXPECT_EQ(Store5->getValueOperand(), ExtVal7);
-  BranchInst *Br4 = dyn_cast<BranchInst>(Store5->getNextNode());
+  UncondBrInst *Br4 = dyn_cast<UncondBrInst>(Store5->getNextNode());
   EXPECT_NE(Br4, nullptr);
-  EXPECT_EQ(Br4->isUnconditional(), true);
   EXPECT_EQ(Br4->getSuccessor(0), Exit2);
 
   ExtractValueInst *ExtVal9 = dyn_cast<ExtractValueInst>(&Exit2->front());
@@ -4732,14 +4714,13 @@ TEST_F(OpenMPIRBuilderTest, CreateTeamsWithThreadLimit) {
   EXPECT_EQ(PushNumTeamsCallInst->getArgOperand(4), &*F->arg_begin());
 
   // Verifying that the next instruction to execute is kmpc_fork_teams
-  BranchInst *BrInst =
-      dyn_cast<BranchInst>(PushNumTeamsCallInst->getNextNode());
+  UncondBrInst *BrInst =
+      dyn_cast<UncondBrInst>(PushNumTeamsCallInst->getNextNode());
   ASSERT_NE(BrInst, nullptr);
-  ASSERT_EQ(BrInst->getNumSuccessors(), 1U);
   BasicBlock::iterator NextInstruction =
       BrInst->getSuccessor(0)->getFirstNonPHIOrDbgOrLifetime();
   CallInst *ForkTeamsCI = nullptr;
-  if (NextInstruction != BrInst->getSuccessor(0)->end())
+  if (NextInstruction != BrInst->getSuccessor()->end())
     ForkTeamsCI = dyn_cast_if_present<CallInst>(NextInstruction);
   ASSERT_NE(ForkTeamsCI, nullptr);
   EXPECT_EQ(ForkTeamsCI->getCalledFunction(),
@@ -4789,14 +4770,13 @@ TEST_F(OpenMPIRBuilderTest, CreateTeamsWithNumTeamsUpper) {
   EXPECT_EQ(PushNumTeamsCallInst->getArgOperand(4), Builder.getInt32(0));
 
   // Verifying that the next instruction to execute is kmpc_fork_teams
-  BranchInst *BrInst =
-      dyn_cast<BranchInst>(PushNumTeamsCallInst->getNextNode());
+  UncondBrInst *BrInst =
+      dyn_cast<UncondBrInst>(PushNumTeamsCallInst->getNextNode());
   ASSERT_NE(BrInst, nullptr);
-  ASSERT_EQ(BrInst->getNumSuccessors(), 1U);
   BasicBlock::iterator NextInstruction =
-      BrInst->getSuccessor(0)->getFirstNonPHIOrDbgOrLifetime();
+      BrInst->getSuccessor()->getFirstNonPHIOrDbgOrLifetime();
   CallInst *ForkTeamsCI = nullptr;
-  if (NextInstruction != BrInst->getSuccessor(0)->end())
+  if (NextInstruction != BrInst->getSuccessor()->end())
     ForkTeamsCI = dyn_cast_if_present<CallInst>(NextInstruction);
   ASSERT_NE(ForkTeamsCI, nullptr);
   EXPECT_EQ(ForkTeamsCI->getCalledFunction(),
@@ -4849,14 +4829,13 @@ TEST_F(OpenMPIRBuilderTest, CreateTeamsWithNumTeamsBoth) {
   EXPECT_EQ(PushNumTeamsCallInst->getArgOperand(4), Builder.getInt32(0));
 
   // Verifying that the next instruction to execute is kmpc_fork_teams
-  BranchInst *BrInst =
-      dyn_cast<BranchInst>(PushNumTeamsCallInst->getNextNode());
+  UncondBrInst *BrInst =
+      dyn_cast<UncondBrInst>(PushNumTeamsCallInst->getNextNode());
   ASSERT_NE(BrInst, nullptr);
-  ASSERT_EQ(BrInst->getNumSuccessors(), 1U);
   BasicBlock::iterator NextInstruction =
-      BrInst->getSuccessor(0)->getFirstNonPHIOrDbgOrLifetime();
+      BrInst->getSuccessor()->getFirstNonPHIOrDbgOrLifetime();
   CallInst *ForkTeamsCI = nullptr;
-  if (NextInstruction != BrInst->getSuccessor(0)->end())
+  if (NextInstruction != BrInst->getSuccessor()->end())
     ForkTeamsCI = dyn_cast_if_present<CallInst>(NextInstruction);
   ASSERT_NE(ForkTeamsCI, nullptr);
   EXPECT_EQ(ForkTeamsCI->getCalledFunction(),
@@ -4915,14 +4894,13 @@ TEST_F(OpenMPIRBuilderTest, CreateTeamsWithNumTeamsAndThreadLimit) {
   EXPECT_EQ(PushNumTeamsCallInst->getArgOperand(4), ThreadLimit);
 
   // Verifying that the next instruction to execute is kmpc_fork_teams
-  BranchInst *BrInst =
-      dyn_cast<BranchInst>(PushNumTeamsCallInst->getNextNode());
+  UncondBrInst *BrInst =
+      dyn_cast<UncondBrInst>(PushNumTeamsCallInst->getNextNode());
   ASSERT_NE(BrInst, nullptr);
-  ASSERT_EQ(BrInst->getNumSuccessors(), 1U);
   BasicBlock::iterator NextInstruction =
-      BrInst->getSuccessor(0)->getFirstNonPHIOrDbgOrLifetime();
+      BrInst->getSuccessor()->getFirstNonPHIOrDbgOrLifetime();
   CallInst *ForkTeamsCI = nullptr;
-  if (NextInstruction != BrInst->getSuccessor(0)->end())
+  if (NextInstruction != BrInst->getSuccessor()->end())
     ForkTeamsCI = dyn_cast_if_present<CallInst>(NextInstruction);
   ASSERT_NE(ForkTeamsCI, nullptr);
   EXPECT_EQ(ForkTeamsCI->getCalledFunction(),
@@ -6491,8 +6469,8 @@ TEST_F(OpenMPIRBuilderTest, TargetRegion) {
 
   // Check the kernel launch sequence
   auto Iter = F->getEntryBlock().rbegin();
-  EXPECT_TRUE(isa<BranchInst>(&*(Iter)));
-  BranchInst *Branch = dyn_cast<BranchInst>(&*(Iter));
+  EXPECT_TRUE(isa<CondBrInst>(&*(Iter)));
+  CondBrInst *Branch = dyn_cast<CondBrInst>(&*(Iter));
   EXPECT_TRUE(isa<CmpInst>(&*(++Iter)));
   EXPECT_TRUE(isa<CallInst>(&*(++Iter)));
   CallInst *Call = dyn_cast<CallInst>(&*(Iter));
@@ -6726,7 +6704,7 @@ TEST_F(OpenMPIRBuilderTest, TargetRegionDevice) {
   EXPECT_TRUE(isa<LoadInst>(Load2));
 
   auto *OutlinedBlockBr = Load2->getNextNode();
-  EXPECT_TRUE(isa<BranchInst>(OutlinedBlockBr));
+  EXPECT_TRUE(isa<UncondBrInst>(OutlinedBlockBr));
 
   auto *OutlinedBlock = OutlinedBlockBr->getSuccessor(0);
   EXPECT_EQ(OutlinedBlock->getName(), "outlined.body");
@@ -6827,8 +6805,8 @@ TEST_F(OpenMPIRBuilderTest, TargetRegionSPMD) {
 
   // Check the kernel launch sequence
   auto Iter = F->getEntryBlock().rbegin();
-  EXPECT_TRUE(isa<BranchInst>(&*(Iter)));
-  BranchInst *Branch = dyn_cast<BranchInst>(&*(Iter));
+  EXPECT_TRUE(isa<CondBrInst>(&*(Iter)));
+  CondBrInst *Branch = dyn_cast<CondBrInst>(&*(Iter));
   EXPECT_TRUE(isa<CmpInst>(&*(++Iter)));
   EXPECT_TRUE(isa<CallInst>(&*(++Iter)));
   CallInst *Call = dyn_cast<CallInst>(&*(Iter));
@@ -7116,7 +7094,7 @@ TEST_F(OpenMPIRBuilderTest, ConstantAllocaRaise) {
   EXPECT_TRUE(isa<LoadInst>(Load1));
 
   auto *OutlinedBlockBr = Load1->getNextNode();
-  EXPECT_TRUE(isa<BranchInst>(OutlinedBlockBr));
+  EXPECT_TRUE(isa<UncondBrInst>(OutlinedBlockBr));
 
   auto *OutlinedBlock = OutlinedBlockBr->getSuccessor(0);
   EXPECT_EQ(OutlinedBlock->getName(), "outlined.body");
@@ -7517,10 +7495,9 @@ TEST_F(OpenMPIRBuilderTest, CreateTaskIfCondition) {
   ASSERT_NE(TaskAllocCall, nullptr);
 
   // Check the branching is based on the if condition argument.
-  BranchInst *IfConditionBranchInst =
-      dyn_cast<BranchInst>(TaskAllocCall->getParent()->getTerminator());
+  CondBrInst *IfConditionBranchInst =
+      dyn_cast<CondBrInst>(TaskAllocCall->getParent()->getTerminator());
   ASSERT_NE(IfConditionBranchInst, nullptr);
-  ASSERT_TRUE(IfConditionBranchInst->isConditional());
   EXPECT_EQ(IfConditionBranchInst->getCondition(), IfCondition);
 
   // Check that the `__kmpc_omp_task` executes only in the then branch.


### PR DESCRIPTION
In OpenMPIRBuilder::EmitOMPInlinedRegion there are two checks w.r.t. SplitPos, which appear to be always true. I conservatively left the code as-is.