### PR TITLE
[AMDGPU] SIFixSGPRCopies avoid placing V_READFIRSTLANE inside the loop.

### DIFF
--- a/llvm/lib/Target/AMDGPU/SIFixSGPRCopies.cpp
+++ b/llvm/lib/Target/AMDGPU/SIFixSGPRCopies.cpp
@@ -1029,9 +1029,11 @@ void SIFixSGPRCopies::analyzeVGPRToSGPRCopy(MachineInstr* MI) {
 
       if (auto SrcIdx = TII->getReadlaneOperandOnVALUConversion(*U)) {
         MachineOperand &Src = U->getOperand(*SrcIdx);
-        unsigned Width = Src.isReg() && Src.getReg().isVirtual()
-            ? TRI->getRegSizeInBits(*MRI->getRegClass(Src.getReg()))
-            : 32;
+        if (!Src.isReg() || !Src.getReg().isVirtual())
+          continue;
+
+        unsigned Width =
+            TRI->getRegSizeInBits(*MRI->getRegClass(Src.getReg()));
         unsigned RFLCount = Width / 32;
         Info.NumUnavoidableReadfirstlanes += RFLCount;
 

--- a/llvm/lib/Target/AMDGPU/SIFixSGPRCopies.cpp
+++ b/llvm/lib/Target/AMDGPU/SIFixSGPRCopies.cpp
@@ -1027,19 +1027,23 @@ void SIFixSGPRCopies::analyzeVGPRToSGPRCopy(MachineInstr* MI) {
       if (TII->isSALU(*U))
         Info.SChain.insert(U);
 
-      if (TII->needsReadlaneOnVALUConversion(*U)) {
-        unsigned SrcIdx = U->getOpcode() == AMDGPU::SI_INIT_M0 ? 0 : 1;
-        MachineOperand &Src = U->getOperand(SrcIdx);
+      if (auto SrcIdx = TII->getReadlaneOperandOnVALUConversion(*U)) {
+        MachineOperand &Src = U->getOperand(*SrcIdx);
         unsigned Width = Src.isReg() && Src.getReg().isVirtual()
             ? TRI->getRegSizeInBits(*MRI->getRegClass(Src.getReg()))
             : 32;
         unsigned RFLCount = Width / 32;
         Info.NumUnavoidableReadfirstlanes += RFLCount;
 
+        // Each loop nesting level crossed by an unavoidable readfirstlane
+        // adds a heavy penalty because the instruction would execute every
+        // iteration instead of once in the preheader.
+        static constexpr unsigned LoopNestingPenaltyFactor = 10;
         unsigned CopyDepth = MLI->getLoopDepth(Info.Copy->getParent());
         unsigned UseDepth = MLI->getLoopDepth(U->getParent());
         if (UseDepth > CopyDepth)
-          Info.LoopDepthPenalty += RFLCount * (UseDepth - CopyDepth) * 10;
+          Info.LoopDepthPenalty +=
+              RFLCount * (UseDepth - CopyDepth) * LoopNestingPenaltyFactor;
       }
 
       AnalysisWorklist.push_back(U);

--- a/llvm/lib/Target/AMDGPU/SIFixSGPRCopies.cpp
+++ b/llvm/lib/Target/AMDGPU/SIFixSGPRCopies.cpp
@@ -70,6 +70,7 @@
 #include "GCNSubtarget.h"
 #include "MCTargetDesc/AMDGPUMCTargetDesc.h"
 #include "llvm/CodeGen/MachineDominators.h"
+#include "llvm/CodeGen/MachineLoopInfo.h"
 #include "llvm/InitializePasses.h"
 #include "llvm/Target/TargetMachine.h"
 
@@ -98,6 +99,12 @@ public:
   // Actual count of v_readfirstlane_b32
   // which need to be inserted to keep SChain SALU
   unsigned NumReadfirstlanes = 0;
+  // Count of v_readfirstlane_b32 that legalizeOperands would insert at
+  // unconvertible use sites if the chain is moved to VALU.
+  unsigned NumUnavoidableReadfirstlanes = 0;
+  // Penalty for unavoidable readfirstlanes placed inside a loop when the
+  // original COPY was outside.
+  unsigned LoopDepthPenalty = 0;
   // Current score state. To speedup selection V2SCopyInfos for processing
   bool NeedToBeConvertedToVALU = false;
   // Unique ID. Used as a key for mapping to keep permanent order.
@@ -114,6 +121,8 @@ public:
   void dump() const {
     dbgs() << ID << " : " << *Copy << "\n\tS:" << SChain.size()
            << "\n\tSV:" << NumSVCopies << "\n\tSP: " << SiblingPenalty
+           << "\n\tURFL: " << NumUnavoidableReadfirstlanes
+           << "\n\tLDP: " << LoopDepthPenalty
            << "\nScore: " << Score << "\n";
   }
 #endif
@@ -121,6 +130,7 @@ public:
 
 class SIFixSGPRCopies {
   MachineDominatorTree *MDT;
+  MachineLoopInfo *MLI;
   SmallVector<MachineInstr*, 4> SCCCopies;
   SmallVector<MachineInstr*, 4> RegSequences;
   SmallVector<MachineInstr*, 4> PHINodes;
@@ -135,7 +145,8 @@ public:
   const SIRegisterInfo *TRI;
   const SIInstrInfo *TII;
 
-  SIFixSGPRCopies(MachineDominatorTree *MDT) : MDT(MDT) {}
+  SIFixSGPRCopies(MachineDominatorTree *MDT, MachineLoopInfo *MLI)
+      : MDT(MDT), MLI(MLI) {}
 
   bool run(MachineFunction &MF);
   void fixSCCCopies(MachineFunction &MF);
@@ -170,7 +181,9 @@ public:
   bool runOnMachineFunction(MachineFunction &MF) override {
     MachineDominatorTree *MDT =
         &getAnalysis<MachineDominatorTreeWrapperPass>().getDomTree();
-    SIFixSGPRCopies Impl(MDT);
+    MachineLoopInfo *MLI =
+        &getAnalysis<MachineLoopInfoWrapperPass>().getLI();
+    SIFixSGPRCopies Impl(MDT, MLI);
     return Impl.run(MF);
   }
 
@@ -178,7 +191,9 @@ public:
 
   void getAnalysisUsage(AnalysisUsage &AU) const override {
     AU.addRequired<MachineDominatorTreeWrapperPass>();
+    AU.addRequired<MachineLoopInfoWrapperPass>();
     AU.addPreserved<MachineDominatorTreeWrapperPass>();
+    AU.addPreserved<MachineLoopInfoWrapperPass>();
     AU.setPreservesCFG();
     MachineFunctionPass::getAnalysisUsage(AU);
   }
@@ -189,6 +204,7 @@ public:
 INITIALIZE_PASS_BEGIN(SIFixSGPRCopiesLegacy, DEBUG_TYPE, "SI Fix SGPR copies",
                       false, false)
 INITIALIZE_PASS_DEPENDENCY(MachineDominatorTreeWrapperPass)
+INITIALIZE_PASS_DEPENDENCY(MachineLoopInfoWrapperPass)
 INITIALIZE_PASS_END(SIFixSGPRCopiesLegacy, DEBUG_TYPE, "SI Fix SGPR copies",
                     false, false)
 
@@ -1010,6 +1026,22 @@ void SIFixSGPRCopies::analyzeVGPRToSGPRCopy(MachineInstr* MI) {
     for (auto *U : Users) {
       if (TII->isSALU(*U))
         Info.SChain.insert(U);
+
+      if (TII->needsReadlaneOnVALUConversion(*U)) {
+        unsigned SrcIdx = U->getOpcode() == AMDGPU::SI_INIT_M0 ? 0 : 1;
+        MachineOperand &Src = U->getOperand(SrcIdx);
+        unsigned Width = Src.isReg() && Src.getReg().isVirtual()
+            ? TRI->getRegSizeInBits(*MRI->getRegClass(Src.getReg()))
+            : 32;
+        unsigned RFLCount = Width / 32;
+        Info.NumUnavoidableReadfirstlanes += RFLCount;
+
+        unsigned CopyDepth = MLI->getLoopDepth(Info.Copy->getParent());
+        unsigned UseDepth = MLI->getLoopDepth(U->getParent());
+        if (UseDepth > CopyDepth)
+          Info.LoopDepthPenalty += RFLCount * (UseDepth - CopyDepth) * 10;
+      }
+
       AnalysisWorklist.push_back(U);
     }
   }
@@ -1050,7 +1082,8 @@ bool SIFixSGPRCopies::needToBeConvertedToVALU(V2SCopyInfo *Info) {
 
   unsigned Penalty =
       Info->NumSVCopies + Info->SiblingPenalty + Info->NumReadfirstlanes;
-  unsigned Profit = Info->SChain.size();
+  unsigned Profit = Info->SChain.size() +
+      Info->NumUnavoidableReadfirstlanes + Info->LoopDepthPenalty;
   Info->Score = Penalty > Profit ? 0 : Profit - Penalty;
   Info->NeedToBeConvertedToVALU = Info->Score < 3;
   return Info->NeedToBeConvertedToVALU;
@@ -1212,7 +1245,8 @@ PreservedAnalyses
 SIFixSGPRCopiesPass::run(MachineFunction &MF,
                          MachineFunctionAnalysisManager &MFAM) {
   MachineDominatorTree &MDT = MFAM.getResult<MachineDominatorTreeAnalysis>(MF);
-  SIFixSGPRCopies Impl(&MDT);
+  MachineLoopInfo &MLI = MFAM.getResult<MachineLoopAnalysis>(MF);
+  SIFixSGPRCopies Impl(&MDT, &MLI);
   bool Changed = Impl.run(MF);
   if (!Changed)
     return PreservedAnalyses::all();

--- a/llvm/lib/Target/AMDGPU/SIInstrInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/SIInstrInfo.cpp
@@ -7461,23 +7461,11 @@ SIInstrInfo::legalizeOperands(MachineInstr &MI,
     return CreatedBB;
   }
 
-  // Legalize SI_INIT_M0
-  if (MI.getOpcode() == AMDGPU::SI_INIT_M0) {
-    MachineOperand &Src = MI.getOperand(0);
-    if (Src.isReg() && RI.hasVectorRegisters(MRI.getRegClass(Src.getReg())))
-      Src.setReg(readlaneVGPRToSGPR(Src.getReg(), MI, MRI));
-    return CreatedBB;
-  }
-
-  // Legalize S_BITREPLICATE, S_QUADMASK and S_WQM
-  if (MI.getOpcode() == AMDGPU::S_BITREPLICATE_B64_B32 ||
-      MI.getOpcode() == AMDGPU::S_QUADMASK_B32 ||
-      MI.getOpcode() == AMDGPU::S_QUADMASK_B64 ||
-      MI.getOpcode() == AMDGPU::S_WQM_B32 ||
-      MI.getOpcode() == AMDGPU::S_WQM_B64 ||
-      MI.getOpcode() == AMDGPU::S_INVERSE_BALLOT_U32 ||
-      MI.getOpcode() == AMDGPU::S_INVERSE_BALLOT_U64) {
-    MachineOperand &Src = MI.getOperand(1);
+  // Legalize instructions with no VALU equivalent — insert readlane for
+  // any VGPR source operand.
+  if (needsReadlaneOnVALUConversion(MI)) {
+    unsigned SrcIdx = MI.getOpcode() == AMDGPU::SI_INIT_M0 ? 0 : 1;
+    MachineOperand &Src = MI.getOperand(SrcIdx);
     if (Src.isReg() && RI.hasVectorRegisters(MRI.getRegClass(Src.getReg())))
       Src.setReg(readlaneVGPRToSGPR(Src.getReg(), MI, MRI));
     return CreatedBB;

--- a/llvm/lib/Target/AMDGPU/SIInstrInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/SIInstrInfo.cpp
@@ -6744,10 +6744,11 @@ void SIInstrInfo::legalizeOperandsVOP2(MachineRegisterInfo &MRI,
   fixImplicitOperands(MI);
 }
 
-bool SIInstrInfo::needsReadlaneOnVALUConversion(
+std::optional<unsigned> SIInstrInfo::getReadlaneOperandOnVALUConversion(
     const MachineInstr &MI) const {
   switch (MI.getOpcode()) {
   case AMDGPU::SI_INIT_M0:
+    return 0;
   case AMDGPU::S_BITREPLICATE_B64_B32:
   case AMDGPU::S_QUADMASK_B32:
   case AMDGPU::S_QUADMASK_B64:
@@ -6755,9 +6756,9 @@ bool SIInstrInfo::needsReadlaneOnVALUConversion(
   case AMDGPU::S_WQM_B64:
   case AMDGPU::S_INVERSE_BALLOT_U32:
   case AMDGPU::S_INVERSE_BALLOT_U64:
-    return true;
+    return 1;
   default:
-    return false;
+    return std::nullopt;
   }
 }
 
@@ -7461,11 +7462,8 @@ SIInstrInfo::legalizeOperands(MachineInstr &MI,
     return CreatedBB;
   }
 
-  // Legalize instructions with no VALU equivalent — insert readlane for
-  // any VGPR source operand.
-  if (needsReadlaneOnVALUConversion(MI)) {
-    unsigned SrcIdx = MI.getOpcode() == AMDGPU::SI_INIT_M0 ? 0 : 1;
-    MachineOperand &Src = MI.getOperand(SrcIdx);
+  if (auto SrcIdx = getReadlaneOperandOnVALUConversion(MI)) {
+    MachineOperand &Src = MI.getOperand(*SrcIdx);
     if (Src.isReg() && RI.hasVectorRegisters(MRI.getRegClass(Src.getReg())))
       Src.setReg(readlaneVGPRToSGPR(Src.getReg(), MI, MRI));
     return CreatedBB;

--- a/llvm/lib/Target/AMDGPU/SIInstrInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/SIInstrInfo.cpp
@@ -6744,6 +6744,23 @@ void SIInstrInfo::legalizeOperandsVOP2(MachineRegisterInfo &MRI,
   fixImplicitOperands(MI);
 }
 
+bool SIInstrInfo::needsReadlaneOnVALUConversion(
+    const MachineInstr &MI) const {
+  switch (MI.getOpcode()) {
+  case AMDGPU::SI_INIT_M0:
+  case AMDGPU::S_BITREPLICATE_B64_B32:
+  case AMDGPU::S_QUADMASK_B32:
+  case AMDGPU::S_QUADMASK_B64:
+  case AMDGPU::S_WQM_B32:
+  case AMDGPU::S_WQM_B64:
+  case AMDGPU::S_INVERSE_BALLOT_U32:
+  case AMDGPU::S_INVERSE_BALLOT_U64:
+    return true;
+  default:
+    return false;
+  }
+}
+
 // Legalize VOP3 operands. All operand types are supported for any operand
 // but only one literal constant and only starting from GFX10.
 void SIInstrInfo::legalizeOperandsVOP3(MachineRegisterInfo &MRI,

--- a/llvm/lib/Target/AMDGPU/SIInstrInfo.h
+++ b/llvm/lib/Target/AMDGPU/SIInstrInfo.h
@@ -1457,7 +1457,7 @@ public:
   /// Fix operands in \p MI to satisfy constant bus requirements.
   void legalizeOperandsVOP3(MachineRegisterInfo &MRI, MachineInstr &MI) const;
 
-  /// Returns the source operand index that would need a readlane insertion
+  /// Returns the source operand index that would need a readfirstlane insertion
   /// if this instruction were reached via VALU conversion, or std::nullopt
   /// if the instruction has a proper VALU equivalent.
   std::optional<unsigned> getReadlaneOperandOnVALUConversion(const MachineInstr &MI) const;

--- a/llvm/lib/Target/AMDGPU/SIInstrInfo.h
+++ b/llvm/lib/Target/AMDGPU/SIInstrInfo.h
@@ -1457,10 +1457,10 @@ public:
   /// Fix operands in \p MI to satisfy constant bus requirements.
   void legalizeOperandsVOP3(MachineRegisterInfo &MRI, MachineInstr &MI) const;
 
-  /// Returns true if moveToVALU would fall through to legalizeOperands for
-  /// this instruction, resulting in a readlane insertion at the use site
-  /// rather than a genuine VALU conversion.
-  bool needsReadlaneOnVALUConversion(const MachineInstr &MI) const;
+  /// Returns the source operand index that would need a readlane insertion
+  /// if this instruction were reached via VALU conversion, or std::nullopt
+  /// if the instruction has a proper VALU equivalent.
+  std::optional<unsigned> getReadlaneOperandOnVALUConversion(const MachineInstr &MI) const;
 
   /// Copy a value from a VGPR (\p SrcReg) to SGPR. The desired register class
   /// for the dst register (\p DstRC) can be optionally supplied. This function

--- a/llvm/lib/Target/AMDGPU/SIInstrInfo.h
+++ b/llvm/lib/Target/AMDGPU/SIInstrInfo.h
@@ -1457,6 +1457,11 @@ public:
   /// Fix operands in \p MI to satisfy constant bus requirements.
   void legalizeOperandsVOP3(MachineRegisterInfo &MRI, MachineInstr &MI) const;
 
+  /// Returns true if moveToVALU would fall through to legalizeOperands for
+  /// this instruction, resulting in a readlane insertion at the use site
+  /// rather than a genuine VALU conversion.
+  bool needsReadlaneOnVALUConversion(const MachineInstr &MI) const;
+
   /// Copy a value from a VGPR (\p SrcReg) to SGPR. The desired register class
   /// for the dst register (\p DstRC) can be optionally supplied. This function
   /// can only be used when it is know that the value in SrcReg is same across

--- a/llvm/test/CodeGen/AMDGPU/fix-sgpr-copies-v2s-readfirstlane-loop.ll
+++ b/llvm/test/CodeGen/AMDGPU/fix-sgpr-copies-v2s-readfirstlane-loop.ll
@@ -19,8 +19,6 @@
 ; CHECK-NOT:   v_readfirstlane_b32
 ; CHECK:       s_endpgm
 
-target triple = "amdgcn-amd-amdhsa"
-
 @a = internal unnamed_addr addrspace(3) global [2048 x i8] poison, align 16
 
 declare void @llvm.amdgcn.load.to.lds.p1(ptr addrspace(1), ptr addrspace(3), i32, i32, i32)

--- a/llvm/test/CodeGen/AMDGPU/fix-sgpr-copies-v2s-readfirstlane-loop.ll
+++ b/llvm/test/CodeGen/AMDGPU/fix-sgpr-copies-v2s-readfirstlane-loop.ll
@@ -1,4 +1,4 @@
-; RUN: llc -march=amdgcn -mcpu=gfx950 -verify-machineinstrs < %s | FileCheck %s
+; RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx950 < %s | FileCheck %s
 
 ; Test that the SIFixSGPRCopies cost model keeps V_READFIRSTLANE_B32 outside
 ; the loop when it feeds an unconvertible SALU instruction (SI_INIT_M0) inside

--- a/llvm/test/CodeGen/AMDGPU/fix-sgpr-copies-v2s-readfirstlane-loop.ll
+++ b/llvm/test/CodeGen/AMDGPU/fix-sgpr-copies-v2s-readfirstlane-loop.ll
@@ -1,0 +1,63 @@
+; RUN: llc -march=amdgcn -mcpu=gfx950 -verify-machineinstrs < %s | FileCheck %s
+
+; Test that the SIFixSGPRCopies cost model keeps V_READFIRSTLANE_B32 outside
+; the loop when it feeds an unconvertible SALU instruction (SI_INIT_M0) inside
+; the loop.
+;
+; Without the cost model accounting for unavoidable readfirstlanes and loop
+; depth penalty, the VGPR-to-SGPR copy would be converted to VALU, causing
+; legalizeOperands to insert V_READFIRSTLANE_B32 at the SI_INIT_M0 use site
+; inside the loop.
+
+; The v_readfirstlane_b32 must appear before the loop, not inside it.
+; CHECK-LABEL: readfirstlane_in_loop:
+; CHECK:       ; %bb.0:
+; CHECK:       v_readfirstlane_b32
+; CHECK:       ; %loop
+; CHECK-NOT:   v_readfirstlane_b32
+; CHECK:       s_mov_b32 m0,
+; CHECK-NOT:   v_readfirstlane_b32
+; CHECK:       s_endpgm
+
+target triple = "amdgcn-amd-amdhsa"
+
+@a = internal unnamed_addr addrspace(3) global [2048 x i8] poison, align 16
+
+declare void @llvm.amdgcn.load.to.lds.p1(ptr addrspace(1), ptr addrspace(3), i32, i32, i32)
+
+define amdgpu_kernel void @readfirstlane_in_loop(ptr addrspace(1) noalias noundef nocapture readonly %inp, ptr addrspace(1) noalias noundef nocapture writeonly %out) #0 !reqd_work_group_size !0 {
+entry:
+  %tid = call range(i32 0, 128) i32 @llvm.amdgcn.workitem.id.x()
+  %wgid = call i32 @llvm.amdgcn.workgroup.id.x()
+  %wgid.zext = zext nneg i32 %wgid to i64
+  %wgoff = shl nsw i64 %wgid.zext, 11
+  %tidoff = shl nsw i32 %tid, 4
+  %tidoff.zext = zext nneg i32 %tid to i64
+  %globaloff = add nsw nuw i64 %wgoff, %tidoff.zext
+  %src.base = getelementptr inbounds nuw i8, ptr addrspace(1) %inp, i64 %globaloff
+  %dst.base = getelementptr inbounds nuw i8, ptr addrspace(1) %out, i64 %globaloff
+  %waveid = lshr i32 %tid, 6
+  %waveoff = shl nsw nuw i32 %waveid, 4
+  %our.lds = getelementptr inbounds nuw i8, ptr addrspace(3) @a, i32 %waveoff
+  %my.lds = getelementptr inbounds nuw i8, ptr addrspace(3) @a, i32 %tidoff
+  br label %loop
+
+loop:
+  %k = phi i32 [%k.next, %loop], [0, %entry]
+  %src = phi ptr addrspace(1) [%src.next, %loop], [%src.base, %entry]
+  %dst = phi ptr addrspace(1) [%dst.next, %loop], [%dst.base, %entry]
+  call void @llvm.amdgcn.load.to.lds.p1(ptr addrspace(1) %src, ptr addrspace(3) %our.lds, i32 16, i32 0, i32 0)
+  %v = load <4 x i32>, ptr addrspace(3) %my.lds, align 16
+  store <4 x i32> %v, ptr addrspace(1) %dst, align 16
+  %k.next = add nsw nuw i32 %k, 1
+  %src.next = getelementptr inbounds nuw i8, ptr addrspace(1) %src, i64 65536
+  %dst.next = getelementptr inbounds nuw i8, ptr addrspace(1) %dst, i64 65536
+  %cond = icmp samesign ult i32 %k, 9
+  br i1 %cond, label %loop, label %exit
+
+exit:
+  ret void
+}
+
+attributes #0 = { nounwind "amdgpu-flat-work-group-size"="128,128" }
+!0 = !{i32 128, i32 1, i32 1}

--- a/llvm/test/CodeGen/AMDGPU/llc-pipeline.ll
+++ b/llvm/test/CodeGen/AMDGPU/llc-pipeline.ll
@@ -103,6 +103,7 @@
 ; GCN-O0-NEXT:        Assignment Tracking Analysis
 ; GCN-O0-NEXT:        AMDGPU DAG->DAG Pattern Instruction Selection
 ; GCN-O0-NEXT:        MachineDominator Tree Construction
+; GCN-O0-NEXT:        Machine Natural Loop Construction
 ; GCN-O0-NEXT:        SI Fix SGPR copies
 ; GCN-O0-NEXT:        MachinePostDominator Tree Construction
 ; GCN-O0-NEXT:        SI Lower i1 Copies
@@ -315,6 +316,7 @@
 ; GCN-O1-NEXT:        Lazy Block Frequency Analysis
 ; GCN-O1-NEXT:        AMDGPU DAG->DAG Pattern Instruction Selection
 ; GCN-O1-NEXT:        MachineDominator Tree Construction
+; GCN-O1-NEXT:        Machine Natural Loop Construction
 ; GCN-O1-NEXT:        SI Fix SGPR copies
 ; GCN-O1-NEXT:        MachinePostDominator Tree Construction
 ; GCN-O1-NEXT:        SI Lower i1 Copies
@@ -627,6 +629,7 @@
 ; GCN-O1-OPTS-NEXT:        Lazy Block Frequency Analysis
 ; GCN-O1-OPTS-NEXT:        AMDGPU DAG->DAG Pattern Instruction Selection
 ; GCN-O1-OPTS-NEXT:        MachineDominator Tree Construction
+; GCN-O1-OPTS-NEXT:        Machine Natural Loop Construction
 ; GCN-O1-OPTS-NEXT:        SI Fix SGPR copies
 ; GCN-O1-OPTS-NEXT:        MachinePostDominator Tree Construction
 ; GCN-O1-OPTS-NEXT:        SI Lower i1 Copies
@@ -950,6 +953,7 @@
 ; GCN-O2-NEXT:        Lazy Block Frequency Analysis
 ; GCN-O2-NEXT:        AMDGPU DAG->DAG Pattern Instruction Selection
 ; GCN-O2-NEXT:        MachineDominator Tree Construction
+; GCN-O2-NEXT:        Machine Natural Loop Construction
 ; GCN-O2-NEXT:        SI Fix SGPR copies
 ; GCN-O2-NEXT:        MachinePostDominator Tree Construction
 ; GCN-O2-NEXT:        SI Lower i1 Copies
@@ -1287,6 +1291,7 @@
 ; GCN-O3-NEXT:        Lazy Block Frequency Analysis
 ; GCN-O3-NEXT:        AMDGPU DAG->DAG Pattern Instruction Selection
 ; GCN-O3-NEXT:        MachineDominator Tree Construction
+; GCN-O3-NEXT:        Machine Natural Loop Construction
 ; GCN-O3-NEXT:        SI Fix SGPR copies
 ; GCN-O3-NEXT:        MachinePostDominator Tree Construction
 ; GCN-O3-NEXT:        SI Lower i1 Copies


### PR DESCRIPTION
SIFixSGPRCopies cost model does not account for unavoidable V_READFIRSTLANE_B32 which are inserted by legalizeOperand called from moveToVALU for the opcodes which have no VALU equivalent. This leads to inserting V_READFIRSTLANE_B32 right before the user. If the user is located in a loop body and V_READFIRSTLANE_B32 result is a loop invariant, this adds unnecessary instruction inside the loop.

Fix: Update cost model to add positive bias to VALU def-use chains with such users. This prevent moving to VALU short chains with a SALU-only users inside the loop.