### PR TITLE
[gn] port b80248a0ea35df more (clang-doc md templates)

### DIFF
--- a/llvm/utils/gn/secondary/clang-tools-extra/clang-doc/tool/BUILD.gn
+++ b/llvm/utils/gn/secondary/clang-tools-extra/clang-doc/tool/BUILD.gn
@@ -10,11 +10,6 @@ copy("assets") {
     "../assets/head-template.mustache",
     "../assets/index-template.mustache",
     "../assets/index.js",
-    "../assets/md/all-files-template.mustache",
-    "../assets/md/class-template.mustache",
-    "../assets/md/comments-partial-template.mustache",
-    "../assets/md/index-template.mustache",
-    "../assets/md/namespace-template.mustache",
     "../assets/mustache-index.js",
     "../assets/namespace-template.mustache",
     "../assets/navbar-template.mustache",
@@ -23,10 +18,22 @@ copy("assets") {
   outputs = [ "$root_build_dir/share/clang-doc/{{source_file_part}}" ]
 }
 
+copy("md_assets") {
+  sources = [
+    "../assets/md/all-files-template.mustache",
+    "../assets/md/class-template.mustache",
+    "../assets/md/comments-partial.mustache",
+    "../assets/md/index-template.mustache",
+    "../assets/md/namespace-template.mustache",
+  ]
+  outputs = [ "$root_build_dir/share/clang-doc/md/{{source_file_part}}" ]
+}
+
 executable("clang-doc") {
   configs += [ "//llvm/utils/gn/build:clang_code" ]
   deps = [
     ":assets",
+    ":md_assets",
     "//clang-tools-extra/clang-doc",
     "//clang/lib/AST",
     "//clang/lib/ASTMatchers",


### PR DESCRIPTION
The previous version misspelled the name of comments-partial.mustache, and it put the md files in the wrong output directory.