### PR TITLE
[MLIR][MemRefToLLVM] Fix crash in MemorySpaceCastOpLowering when type conversion fails

### DIFF
--- a/mlir/lib/Conversion/MemRefToLLVM/MemRefToLLVM.cpp
+++ b/mlir/lib/Conversion/MemRefToLLVM/MemRefToLLVM.cpp
@@ -1255,9 +1255,11 @@ struct MemorySpaceCastOpLowering
 
     Type resultType = op.getDest().getType();
     if (auto resultTypeR = dyn_cast<MemRefType>(resultType)) {
-      auto resultDescType =
-          cast<LLVM::LLVMStructType>(typeConverter->convertType(resultTypeR));
-      Type newPtrType = resultDescType.getBody()[0];
+      auto convertedType =
+          typeConverter->convertType<LLVM::LLVMStructType>(resultTypeR);
+      if (!convertedType)
+        return rewriter.notifyMatchFailure(op, "memref type conversion failed");
+      Type newPtrType = convertedType.getBody()[0];
 
       SmallVector<Value> descVals;
       MemRefDescriptor::unpack(rewriter, loc, adaptor.getSource(), resultTypeR,
@@ -1416,8 +1418,8 @@ private:
       memref::ReinterpretCastOp::Adaptor adaptor, Value *descriptor) const {
     MemRefType targetMemRefType =
         cast<MemRefType>(castOp.getResult().getType());
-    auto llvmTargetDescriptorTy = dyn_cast_or_null<LLVM::LLVMStructType>(
-        typeConverter->convertType(targetMemRefType));
+    auto llvmTargetDescriptorTy =
+        typeConverter->convertType<LLVM::LLVMStructType>(targetMemRefType);
     if (!llvmTargetDescriptorTy)
       return failure();
 
@@ -1485,8 +1487,8 @@ private:
     if (shapeMemRefType.hasStaticShape()) {
       MemRefType targetMemRefType =
           cast<MemRefType>(reshapeOp.getResult().getType());
-      auto llvmTargetDescriptorTy = dyn_cast_or_null<LLVM::LLVMStructType>(
-          typeConverter->convertType(targetMemRefType));
+      auto llvmTargetDescriptorTy =
+          typeConverter->convertType<LLVM::LLVMStructType>(targetMemRefType);
       if (!llvmTargetDescriptorTy)
         return failure();
 

--- a/mlir/test/Conversion/MemRefToLLVM/memory-space-cast-non-integer-addrspace.mlir
+++ b/mlir/test/Conversion/MemRefToLLVM/memory-space-cast-non-integer-addrspace.mlir
@@ -1,0 +1,12 @@
+// RUN: mlir-opt %s -finalize-memref-to-llvm | FileCheck %s
+// Regression test for https://github.com/llvm/llvm-project/issues/186041.
+// memref.memory_space_cast to a non-integer address space should not crash when
+// the MemRefToLLVM type conversion fails for the result type. The op is left
+// unconverted (partial conversion succeeds, exit 0).
+
+// CHECK-LABEL: @memory_space_cast_non_integer_addrspace
+// CHECK: memref.memory_space_cast
+func.func @memory_space_cast_non_integer_addrspace(%arg0: memref<128xi32, 3>) {
+  %cast = memref.memory_space_cast %arg0 : memref<128xi32, 3> to memref<128xi32, #gpu.address_space<workgroup>>
+  return
+}


### PR DESCRIPTION
`MemorySpaceCastOpLowering::matchAndRewrite` called `cast<LLVMStructType>` on the result of `typeConverter->convertType(resultType)` without checking whether the conversion succeeded. When the destination memref has a non-integer address space (e.g. `#gpu.address_space<workgroup>`), `convertType` returns a null `Type`, and the subsequent `cast<>` dereferences a null pointer, causing a crash.

Fix by checking the result of `convertType` and returning `notifyMatchFailure` on failure, allowing the conversion framework to produce a proper diagnostic instead of crashing.

Fixes #186041

Assisted-by: Claude Code