### PR TITLE
[lldb][Module][NFC] Use raw string literal and formatv-style format in LoadScriptingResourceInTarget

### DIFF
--- a/lldb/source/Core/Module.cpp
+++ b/lldb/source/Core/Module.cpp
@@ -1467,13 +1467,18 @@ bool Module::LoadScriptingResourceInTarget(Target *target, Status &error,
       continue;
 
     if (should_load == eLoadScriptFromSymFileWarn) {
-      feedback_stream.Printf(
-          "warning: '%s' contains a debug script. To run this script in this "
-          "debug session:\n\n    command script import \"%s\"\n\nTo run all "
-          "discovered debug scripts in this session:\n\nsettings set "
-          "target.load-script-from-symbol-file true\n",
-          GetFileSpec().GetFileNameStrippingExtension().GetCString(),
-          scripting_fspec.GetPath().c_str());
+      feedback_stream.Format(R"(
+warning: '{0}' contains a debug script. To run this script in this debug session:
+
+    command script import "{1}"
+
+To run all discovered debug scripts in this session:
+
+    settings set target.load-script-from-symbol-file true
+)",
+                             GetFileSpec().GetFileNameStrippingExtension(),
+                             scripting_fspec.GetPath());
+
       return false;
     }
 

--- a/lldb/test/Shell/Platform/AutoLoad/Darwin/dsym-python-script.test
+++ b/lldb/test/Shell/Platform/AutoLoad/Darwin/dsym-python-script.test
@@ -1,0 +1,42 @@
+# REQUIRES: python, system-darwin
+#
+# Tests that we loading a Python script from a dSYM and the various
+# ways target.load-script-from-symbol-file controls that behaviour.
+
+# RUN: split-file %s %t
+# RUN: %clang_host -g %t/main.c -o %t/TestModule.out
+# RUN: mkdir -p %t/TestModule.out.dSYM/Contents/Resources/Python
+# RUN: cp %t/dsym_script.py %t/TestModule.out.dSYM/Contents/Resources/Python/TestModule.py
+#
+# RUN: %lldb -b \
+# RUN:   -o 'settings set target.load-script-from-symbol-file false' \
+# RUN:   -o 'target create %t/TestModule.out' 2>&1 \
+# RUN:   | FileCheck %s --implicit-check-not=DSYM_SCRIPT --implicit-check-not=warning
+#
+# RUN: %lldb -b \
+# RUN:   -o 'settings set target.load-script-from-symbol-file warn' \
+# RUN:   -o 'target create %t/TestModule.out' 2>&1 \
+# RUN:   | FileCheck %s --implicit-check-not=DSYM_SCRIPT --check-prefix=CHECK-WARN --strict-whitespace
+#
+# RUN: %lldb -b \
+# RUN:   -o 'settings set target.load-script-from-symbol-file true' \
+# RUN:   -o 'target create %t/TestModule.out' 2>&1 \
+# RUN:   | FileCheck %s --implicit-check-not=warning --check-prefix=CHECK-LOADED
+
+# CHECK-WARN:      warning: 'TestModule' contains a debug script. To run this script in this debug session:
+# CHECK-WARN-EMPTY:
+# CHECK-WARN-NEXT:{{^}}    command script import "{{.*}}/TestModule.out.dSYM/Contents/Resources/Python/TestModule.py"
+# CHECK-WARN-EMPTY:
+# CHECK-WARN-NEXT: To run all discovered debug scripts in this session:
+# CHECK-WARN-EMPTY:
+# CHECK-WARN-NEXT:{{^}}    settings set target.load-script-from-symbol-file true
+
+# CHECK-LOADED: DSYM_SCRIPT
+
+#--- main.c
+int main() { return 0; }
+
+#--- dsym_script.py
+import sys
+def __lldb_init_module(debugger, internal_dict):
+    print("DSYM_SCRIPT", file=sys.stderr)


### PR DESCRIPTION
Makes it obvious what the warning will look like (with the indenentation etc.). Also adds a test since we had no coverage for the warning before (as far as I'm aware).