### PR TITLE
[libc][math] Fixed Hypotbf16 build failure.

### DIFF
--- a/libc/src/__support/FPUtil/Hypot.h
+++ b/libc/src/__support/FPUtil/Hypot.h
@@ -218,7 +218,8 @@ LIBC_INLINE T hypot(T x, T y) {
 
   for (StorageType current_bit = leading_one >> 1; current_bit;
        current_bit >>= 1) {
-    r = static_cast<StorageType>((r << 1) + ((tail_bits & current_bit) ? 1 : 0));
+    r = static_cast<StorageType>((r << 1) +
+                                 ((tail_bits & current_bit) ? 1 : 0));
     StorageType tmp = static_cast<StorageType>((y_new << 1)) +
                       current_bit; // 2*y_new(n - 1) + 2^(-n)
     if (r >= tmp) {

--- a/libc/src/__support/FPUtil/Hypot.h
+++ b/libc/src/__support/FPUtil/Hypot.h
@@ -219,7 +219,7 @@ LIBC_INLINE T hypot(T x, T y) {
   for (StorageType current_bit = leading_one >> 1; current_bit;
        current_bit >>= 1) {
     r = static_cast<StorageType>((r << 1)) +
-        ((tail_bits & current_bit) ? 1 : 0);
+        static_cast<StorageType>((tail_bits & current_bit) ? 1 : 0);
     StorageType tmp = static_cast<StorageType>((y_new << 1)) +
                       current_bit; // 2*y_new(n - 1) + 2^(-n)
     if (r >= tmp) {

--- a/libc/src/__support/FPUtil/Hypot.h
+++ b/libc/src/__support/FPUtil/Hypot.h
@@ -218,8 +218,7 @@ LIBC_INLINE T hypot(T x, T y) {
 
   for (StorageType current_bit = leading_one >> 1; current_bit;
        current_bit >>= 1) {
-    r = static_cast<StorageType>((r << 1)) +
-        static_cast<StorageType>((tail_bits & current_bit) ? 1 : 0);
+    r = static_cast<StorageType>((r << 1) + (tail_bits & current_bit) ? 1 : 0);
     StorageType tmp = static_cast<StorageType>((y_new << 1)) +
                       current_bit; // 2*y_new(n - 1) + 2^(-n)
     if (r >= tmp) {

--- a/libc/src/__support/FPUtil/Hypot.h
+++ b/libc/src/__support/FPUtil/Hypot.h
@@ -218,7 +218,7 @@ LIBC_INLINE T hypot(T x, T y) {
 
   for (StorageType current_bit = leading_one >> 1; current_bit;
        current_bit >>= 1) {
-    r = static_cast<StorageType>((r << 1) + (tail_bits & current_bit) ? 1 : 0);
+    r = static_cast<StorageType>((r << 1) + ((tail_bits & current_bit) ? 1 : 0));
     StorageType tmp = static_cast<StorageType>((y_new << 1)) +
                       current_bit; // 2*y_new(n - 1) + 2^(-n)
     if (r >= tmp) {


### PR DESCRIPTION
Ref from the build failure in hypotbf16
```CPP
project/libc/src/__support/math/hypotbf16.h:22:33:   required from here
/home/llvm-libc-buildbot/buildbot-worker/libc-x86_64-debian-fullbuild/libc-x86_64-debian-gcc-fullbuild-dbg/llvm-project/libc/src/__support/FPUtil/Hypot.h:221:44: error: conversion from ‘int’ to ‘StorageType’ {aka ‘short unsigned int’} may change value [-Werror=conversion]
  221 |     r = static_cast<StorageType>((r << 1)) +
      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
  222 |         ((tail_bits & current_bit) ? 1 : 0);
      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ 
cc1plus: all warnings being treated as errors
```

This PR intends to fix that by adding static_cast