### PR TITLE
[flang][OpenMP] Account for GenericExprWrapper being null

### DIFF
--- a/flang/lib/Semantics/openmp-utils.cpp
+++ b/flang/lib/Semantics/openmp-utils.cpp
@@ -249,7 +249,10 @@ static MaybeExpr GetEvaluateExprFromTyped(const parser::TypedExpr &typedExpr) {
   // ForwardOwningPointer           typedExpr
   // `- GenericExprWrapper          ^.get()
   //    `- std::optional<Expr>      ^->v
-  return DEREF(typedExpr.get()).v;
+  if (auto *wrapper{typedExpr.get()}) {
+    return wrapper->v;
+  }
+  return std::nullopt;
 }
 
 MaybeExpr GetEvaluateExpr(const parser::Expr &parserExpr) {


### PR DESCRIPTION
When getting a MaybeExpr from parser::Expr, take into account that the GeneticExprWrapper (that wraps MaybeExpr) may itself be null.