### PR TITLE
[libc++] Refactor __is_transparent_v to make it clear what it depends on

### DIFF
--- a/libcxx/include/__functional/is_transparent.h
+++ b/libcxx/include/__functional/is_transparent.h
@@ -21,11 +21,11 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 
 #if _LIBCPP_STD_VER >= 14
 
-template <class _Tp, class _Key = void, class = void>
+template <class _Comparator, class = void>
 inline const bool __is_transparent_v = false;
 
-template <class _Tp, class _Key>
-inline const bool __is_transparent_v<_Tp, _Key, __void_t<typename _Tp::is_transparent> > = true;
+template <class _Comparator>
+inline const bool __is_transparent_v<_Comparator, __void_t<typename _Comparator::is_transparent> > = true;
 
 #endif
 

--- a/libcxx/include/map
+++ b/libcxx/include/map
@@ -1313,15 +1313,15 @@ public:
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI iterator find(const key_type& __k) { return __tree_.find(__k); }
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI const_iterator find(const key_type& __k) const { return __tree_.find(__k); }
 #  if _LIBCPP_STD_VER >= 14
-  template <typename _K2, class _Comp = _Compare,
-            enable_if_t<__is_transparent_v<_Comp> || __is_transparently_comparable_v<_Comp, key_type, _K2>,
-                        int> = 0>
+  template <typename _K2,
+            class _Comp = _Compare,
+            enable_if_t<__is_transparent_v<_Comp> || __is_transparently_comparable_v<_Comp, key_type, _K2>, int> = 0>
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI iterator find(const _K2& __k) {
     return __tree_.find(__k);
   }
-  template <typename _K2, class _Comp = _Compare,
-            enable_if_t<__is_transparent_v<_Comp> || __is_transparently_comparable_v<_Comp, key_type, _K2>,
-                        int> = 0>
+  template <typename _K2,
+            class _Comp = _Compare,
+            enable_if_t<__is_transparent_v<_Comp> || __is_transparently_comparable_v<_Comp, key_type, _K2>, int> = 0>
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI const_iterator find(const _K2& __k) const {
     return __tree_.find(__k);
   }
@@ -1339,9 +1339,9 @@ public:
 
 #  if _LIBCPP_STD_VER >= 20
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI bool contains(const key_type& __k) const { return find(__k) != end(); }
-  template <typename _K2, class _Comp = _Compare,
-            enable_if_t<__is_transparent_v<_Comp> || __is_transparently_comparable_v<_Comp, key_type, _K2>,
-                        int> = 0>
+  template <typename _K2,
+            class _Comp = _Compare,
+            enable_if_t<__is_transparent_v<_Comp> || __is_transparently_comparable_v<_Comp, key_type, _K2>, int> = 0>
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI bool contains(const _K2& __k) const {
     return find(__k) != end();
   }
@@ -1358,16 +1358,16 @@ public:
   // The transparent versions of the lookup functions use the _multi version, since a non-element key is allowed to
   // match multiple elements.
 #  if _LIBCPP_STD_VER >= 14
-  template <typename _K2, class _Comp = _Compare,
-            enable_if_t<__is_transparent_v<_Comp> || __is_transparently_comparable_v<_Comp, key_type, _K2>,
-                        int> = 0>
+  template <typename _K2,
+            class _Comp = _Compare,
+            enable_if_t<__is_transparent_v<_Comp> || __is_transparently_comparable_v<_Comp, key_type, _K2>, int> = 0>
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI iterator lower_bound(const _K2& __k) {
     return __tree_.__lower_bound_multi(__k);
   }
 
-  template <typename _K2, class _Comp = _Compare,
-            enable_if_t<__is_transparent_v<_Comp> || __is_transparently_comparable_v<_Comp, key_type, _K2>,
-                        int> = 0>
+  template <typename _K2,
+            class _Comp = _Compare,
+            enable_if_t<__is_transparent_v<_Comp> || __is_transparently_comparable_v<_Comp, key_type, _K2>, int> = 0>
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI const_iterator lower_bound(const _K2& __k) const {
     return __tree_.__lower_bound_multi(__k);
   }
@@ -1382,15 +1382,15 @@ public:
   }
 
 #  if _LIBCPP_STD_VER >= 14
-  template <typename _K2, class _Comp = _Compare,
-            enable_if_t<__is_transparent_v<_Comp> || __is_transparently_comparable_v<_Comp, key_type, _K2>,
-                        int> = 0>
+  template <typename _K2,
+            class _Comp = _Compare,
+            enable_if_t<__is_transparent_v<_Comp> || __is_transparently_comparable_v<_Comp, key_type, _K2>, int> = 0>
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI iterator upper_bound(const _K2& __k) {
     return __tree_.__upper_bound_multi(__k);
   }
-  template <typename _K2, class _Comp = _Compare,
-            enable_if_t<__is_transparent_v<_Comp> || __is_transparently_comparable_v<_Comp, key_type, _K2>,
-                        int> = 0>
+  template <typename _K2,
+            class _Comp = _Compare,
+            enable_if_t<__is_transparent_v<_Comp> || __is_transparently_comparable_v<_Comp, key_type, _K2>, int> = 0>
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI const_iterator upper_bound(const _K2& __k) const {
     return __tree_.__upper_bound_multi(__k);
   }

--- a/libcxx/include/map
+++ b/libcxx/include/map
@@ -1313,14 +1313,14 @@ public:
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI iterator find(const key_type& __k) { return __tree_.find(__k); }
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI const_iterator find(const key_type& __k) const { return __tree_.find(__k); }
 #  if _LIBCPP_STD_VER >= 14
-  template <typename _K2,
-            enable_if_t<__is_transparent_v<_Compare, _K2> || __is_transparently_comparable_v<_Compare, key_type, _K2>,
+  template <typename _K2, class _Comp = _Compare,
+            enable_if_t<__is_transparent_v<_Comp> || __is_transparently_comparable_v<_Comp, key_type, _K2>,
                         int> = 0>
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI iterator find(const _K2& __k) {
     return __tree_.find(__k);
   }
-  template <typename _K2,
-            enable_if_t<__is_transparent_v<_Compare, _K2> || __is_transparently_comparable_v<_Compare, key_type, _K2>,
+  template <typename _K2, class _Comp = _Compare,
+            enable_if_t<__is_transparent_v<_Comp> || __is_transparently_comparable_v<_Comp, key_type, _K2>,
                         int> = 0>
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI const_iterator find(const _K2& __k) const {
     return __tree_.find(__k);
@@ -1331,7 +1331,7 @@ public:
     return __tree_.__count_unique(__k);
   }
 #  if _LIBCPP_STD_VER >= 14
-  template <typename _K2, enable_if_t<__is_transparent_v<_Compare, _K2>, int> = 0>
+  template <typename _K2, class _Comp = _Compare, enable_if_t<__is_transparent_v<_Comp>, int> = 0>
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI size_type count(const _K2& __k) const {
     return __tree_.__count_multi(__k);
   }
@@ -1339,8 +1339,8 @@ public:
 
 #  if _LIBCPP_STD_VER >= 20
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI bool contains(const key_type& __k) const { return find(__k) != end(); }
-  template <typename _K2,
-            enable_if_t<__is_transparent_v<_Compare, _K2> || __is_transparently_comparable_v<_Compare, key_type, _K2>,
+  template <typename _K2, class _Comp = _Compare,
+            enable_if_t<__is_transparent_v<_Comp> || __is_transparently_comparable_v<_Comp, key_type, _K2>,
                         int> = 0>
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI bool contains(const _K2& __k) const {
     return find(__k) != end();
@@ -1358,15 +1358,15 @@ public:
   // The transparent versions of the lookup functions use the _multi version, since a non-element key is allowed to
   // match multiple elements.
 #  if _LIBCPP_STD_VER >= 14
-  template <typename _K2,
-            enable_if_t<__is_transparent_v<_Compare, _K2> || __is_transparently_comparable_v<_Compare, key_type, _K2>,
+  template <typename _K2, class _Comp = _Compare,
+            enable_if_t<__is_transparent_v<_Comp> || __is_transparently_comparable_v<_Comp, key_type, _K2>,
                         int> = 0>
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI iterator lower_bound(const _K2& __k) {
     return __tree_.__lower_bound_multi(__k);
   }
 
-  template <typename _K2,
-            enable_if_t<__is_transparent_v<_Compare, _K2> || __is_transparently_comparable_v<_Compare, key_type, _K2>,
+  template <typename _K2, class _Comp = _Compare,
+            enable_if_t<__is_transparent_v<_Comp> || __is_transparently_comparable_v<_Comp, key_type, _K2>,
                         int> = 0>
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI const_iterator lower_bound(const _K2& __k) const {
     return __tree_.__lower_bound_multi(__k);
@@ -1382,14 +1382,14 @@ public:
   }
 
 #  if _LIBCPP_STD_VER >= 14
-  template <typename _K2,
-            enable_if_t<__is_transparent_v<_Compare, _K2> || __is_transparently_comparable_v<_Compare, key_type, _K2>,
+  template <typename _K2, class _Comp = _Compare,
+            enable_if_t<__is_transparent_v<_Comp> || __is_transparently_comparable_v<_Comp, key_type, _K2>,
                         int> = 0>
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI iterator upper_bound(const _K2& __k) {
     return __tree_.__upper_bound_multi(__k);
   }
-  template <typename _K2,
-            enable_if_t<__is_transparent_v<_Compare, _K2> || __is_transparently_comparable_v<_Compare, key_type, _K2>,
+  template <typename _K2, class _Comp = _Compare,
+            enable_if_t<__is_transparent_v<_Comp> || __is_transparently_comparable_v<_Comp, key_type, _K2>,
                         int> = 0>
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI const_iterator upper_bound(const _K2& __k) const {
     return __tree_.__upper_bound_multi(__k);
@@ -1403,11 +1403,11 @@ public:
     return __tree_.__equal_range_unique(__k);
   }
 #  if _LIBCPP_STD_VER >= 14
-  template <typename _K2, enable_if_t<__is_transparent_v<_Compare, _K2>, int> = 0>
+  template <typename _K2, class _Comp = _Compare, enable_if_t<__is_transparent_v<_Comp>, int> = 0>
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI pair<iterator, iterator> equal_range(const _K2& __k) {
     return __tree_.__equal_range_multi(__k);
   }
-  template <typename _K2, enable_if_t<__is_transparent_v<_Compare, _K2>, int> = 0>
+  template <typename _K2, class _Comp = _Compare, enable_if_t<__is_transparent_v<_Comp>, int> = 0>
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI pair<const_iterator, const_iterator> equal_range(const _K2& __k) const {
     return __tree_.__equal_range_multi(__k);
   }
@@ -1917,11 +1917,11 @@ public:
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI iterator find(const key_type& __k) { return __tree_.find(__k); }
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI const_iterator find(const key_type& __k) const { return __tree_.find(__k); }
 #  if _LIBCPP_STD_VER >= 14
-  template <typename _K2, enable_if_t<__is_transparent_v<_Compare, _K2>, int> = 0>
+  template <typename _K2, class _Comp = _Compare, enable_if_t<__is_transparent_v<_Comp>, int> = 0>
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI iterator find(const _K2& __k) {
     return __tree_.find(__k);
   }
-  template <typename _K2, enable_if_t<__is_transparent_v<_Compare, _K2>, int> = 0>
+  template <typename _K2, class _Comp = _Compare, enable_if_t<__is_transparent_v<_Comp>, int> = 0>
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI const_iterator find(const _K2& __k) const {
     return __tree_.find(__k);
   }
@@ -1931,7 +1931,7 @@ public:
     return __tree_.__count_multi(__k);
   }
 #  if _LIBCPP_STD_VER >= 14
-  template <typename _K2, enable_if_t<__is_transparent_v<_Compare, _K2>, int> = 0>
+  template <typename _K2, class _Comp = _Compare, enable_if_t<__is_transparent_v<_Comp>, int> = 0>
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI size_type count(const _K2& __k) const {
     return __tree_.__count_multi(__k);
   }
@@ -1939,7 +1939,7 @@ public:
 
 #  if _LIBCPP_STD_VER >= 20
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI bool contains(const key_type& __k) const { return find(__k) != end(); }
-  template <typename _K2, enable_if_t<__is_transparent_v<_Compare, _K2>, int> = 0>
+  template <typename _K2, class _Comp = _Compare, enable_if_t<__is_transparent_v<_Comp>, int> = 0>
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI bool contains(const _K2& __k) const {
     return find(__k) != end();
   }
@@ -1954,12 +1954,12 @@ public:
   }
 
 #  if _LIBCPP_STD_VER >= 14
-  template <typename _K2, enable_if_t<__is_transparent_v<_Compare, _K2>, int> = 0>
+  template <typename _K2, class _Comp = _Compare, enable_if_t<__is_transparent_v<_Comp>, int> = 0>
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI iterator lower_bound(const _K2& __k) {
     return __tree_.__lower_bound_multi(__k);
   }
 
-  template <typename _K2, enable_if_t<__is_transparent_v<_Compare, _K2>, int> = 0>
+  template <typename _K2, class _Comp = _Compare, enable_if_t<__is_transparent_v<_Comp>, int> = 0>
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI const_iterator lower_bound(const _K2& __k) const {
     return __tree_.__lower_bound_multi(__k);
   }
@@ -1974,11 +1974,11 @@ public:
   }
 
 #  if _LIBCPP_STD_VER >= 14
-  template <typename _K2, enable_if_t<__is_transparent_v<_Compare, _K2>, int> = 0>
+  template <typename _K2, class _Comp = _Compare, enable_if_t<__is_transparent_v<_Comp>, int> = 0>
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI iterator upper_bound(const _K2& __k) {
     return __tree_.__upper_bound_multi(__k);
   }
-  template <typename _K2, enable_if_t<__is_transparent_v<_Compare, _K2>, int> = 0>
+  template <typename _K2, class _Comp = _Compare, enable_if_t<__is_transparent_v<_Comp>, int> = 0>
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI const_iterator upper_bound(const _K2& __k) const {
     return __tree_.__upper_bound_multi(__k);
   }
@@ -1991,11 +1991,11 @@ public:
     return __tree_.__equal_range_multi(__k);
   }
 #  if _LIBCPP_STD_VER >= 14
-  template <typename _K2, enable_if_t<__is_transparent_v<_Compare, _K2>, int> = 0>
+  template <typename _K2, class _Comp = _Compare, enable_if_t<__is_transparent_v<_Comp>, int> = 0>
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI pair<iterator, iterator> equal_range(const _K2& __k) {
     return __tree_.__equal_range_multi(__k);
   }
-  template <typename _K2, enable_if_t<__is_transparent_v<_Compare, _K2>, int> = 0>
+  template <typename _K2, class _Comp = _Compare, enable_if_t<__is_transparent_v<_Comp>, int> = 0>
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI pair<const_iterator, const_iterator> equal_range(const _K2& __k) const {
     return __tree_.__equal_range_multi(__k);
   }

--- a/libcxx/include/set
+++ b/libcxx/include/set
@@ -825,11 +825,11 @@ public:
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI iterator find(const key_type& __k) { return __tree_.find(__k); }
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI const_iterator find(const key_type& __k) const { return __tree_.find(__k); }
 #  if _LIBCPP_STD_VER >= 14
-  template <typename _K2, enable_if_t<__is_transparent_v<_Compare, _K2>, int> = 0>
+  template <typename _K2, class _Comp = _Compare, enable_if_t<__is_transparent_v<_Comp>, int> = 0>
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI iterator find(const _K2& __k) {
     return __tree_.find(__k);
   }
-  template <typename _K2, enable_if_t<__is_transparent_v<_Compare, _K2>, int> = 0>
+  template <typename _K2, class _Comp = _Compare, enable_if_t<__is_transparent_v<_Comp>, int> = 0>
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI const_iterator find(const _K2& __k) const {
     return __tree_.find(__k);
   }
@@ -839,7 +839,7 @@ public:
     return __tree_.__count_unique(__k);
   }
 #  if _LIBCPP_STD_VER >= 14
-  template <typename _K2, enable_if_t<__is_transparent_v<_Compare, _K2>, int> = 0>
+  template <typename _K2, class _Comp = _Compare, enable_if_t<__is_transparent_v<_Comp>, int> = 0>
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI size_type count(const _K2& __k) const {
     return __tree_.__count_multi(__k);
   }
@@ -847,7 +847,7 @@ public:
 
 #  if _LIBCPP_STD_VER >= 20
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI bool contains(const key_type& __k) const { return find(__k) != end(); }
-  template <typename _K2, enable_if_t<__is_transparent_v<_Compare, _K2>, int> = 0>
+  template <typename _K2, class _Comp = _Compare, enable_if_t<__is_transparent_v<_Comp>, int> = 0>
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI bool contains(const _K2& __k) const {
     return find(__k) != end();
   }
@@ -864,12 +864,12 @@ public:
   // The transparent versions of the lookup functions use the _multi version, since a non-element key is allowed to
   // match multiple elements.
 #  if _LIBCPP_STD_VER >= 14
-  template <typename _K2, enable_if_t<__is_transparent_v<_Compare, _K2>, int> = 0>
+  template <typename _K2, class _Comp = _Compare, enable_if_t<__is_transparent_v<_Comp>, int> = 0>
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI iterator lower_bound(const _K2& __k) {
     return __tree_.__lower_bound_multi(__k);
   }
 
-  template <typename _K2, enable_if_t<__is_transparent_v<_Compare, _K2>, int> = 0>
+  template <typename _K2, class _Comp = _Compare, enable_if_t<__is_transparent_v<_Comp>, int> = 0>
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI const_iterator lower_bound(const _K2& __k) const {
     return __tree_.__lower_bound_multi(__k);
   }
@@ -884,11 +884,11 @@ public:
   }
 
 #  if _LIBCPP_STD_VER >= 14
-  template <typename _K2, enable_if_t<__is_transparent_v<_Compare, _K2>, int> = 0>
+  template <typename _K2, class _Comp = _Compare, enable_if_t<__is_transparent_v<_Comp>, int> = 0>
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI iterator upper_bound(const _K2& __k) {
     return __tree_.__upper_bound_multi(__k);
   }
-  template <typename _K2, enable_if_t<__is_transparent_v<_Compare, _K2>, int> = 0>
+  template <typename _K2, class _Comp = _Compare, enable_if_t<__is_transparent_v<_Comp>, int> = 0>
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI const_iterator upper_bound(const _K2& __k) const {
     return __tree_.__upper_bound_multi(__k);
   }
@@ -901,11 +901,11 @@ public:
     return __tree_.__equal_range_unique(__k);
   }
 #  if _LIBCPP_STD_VER >= 14
-  template <typename _K2, enable_if_t<__is_transparent_v<_Compare, _K2>, int> = 0>
+  template <typename _K2, class _Comp = _Compare, enable_if_t<__is_transparent_v<_Comp>, int> = 0>
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI pair<iterator, iterator> equal_range(const _K2& __k) {
     return __tree_.__equal_range_multi(__k);
   }
-  template <typename _K2, enable_if_t<__is_transparent_v<_Compare, _K2>, int> = 0>
+  template <typename _K2, class _Comp = _Compare, enable_if_t<__is_transparent_v<_Comp>, int> = 0>
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI pair<const_iterator, const_iterator> equal_range(const _K2& __k) const {
     return __tree_.__equal_range_multi(__k);
   }
@@ -1302,11 +1302,11 @@ public:
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI iterator find(const key_type& __k) { return __tree_.find(__k); }
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI const_iterator find(const key_type& __k) const { return __tree_.find(__k); }
 #  if _LIBCPP_STD_VER >= 14
-  template <typename _K2, enable_if_t<__is_transparent_v<_Compare, _K2>, int> = 0>
+  template <typename _K2, class _Comp = _Compare, enable_if_t<__is_transparent_v<_Comp>, int> = 0>
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI iterator find(const _K2& __k) {
     return __tree_.find(__k);
   }
-  template <typename _K2, enable_if_t<__is_transparent_v<_Compare, _K2>, int> = 0>
+  template <typename _K2, class _Comp = _Compare, enable_if_t<__is_transparent_v<_Comp>, int> = 0>
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI const_iterator find(const _K2& __k) const {
     return __tree_.find(__k);
   }
@@ -1316,7 +1316,7 @@ public:
     return __tree_.__count_multi(__k);
   }
 #  if _LIBCPP_STD_VER >= 14
-  template <typename _K2, enable_if_t<__is_transparent_v<_Compare, _K2>, int> = 0>
+  template <typename _K2, class _Comp = _Compare, enable_if_t<__is_transparent_v<_Comp>, int> = 0>
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI size_type count(const _K2& __k) const {
     return __tree_.__count_multi(__k);
   }
@@ -1324,7 +1324,7 @@ public:
 
 #  if _LIBCPP_STD_VER >= 20
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI bool contains(const key_type& __k) const { return find(__k) != end(); }
-  template <typename _K2, enable_if_t<__is_transparent_v<_Compare, _K2>, int> = 0>
+  template <typename _K2, class _Comp = _Compare, enable_if_t<__is_transparent_v<_Comp>, int> = 0>
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI bool contains(const _K2& __k) const {
     return find(__k) != end();
   }
@@ -1339,12 +1339,12 @@ public:
   }
 
 #  if _LIBCPP_STD_VER >= 14
-  template <typename _K2, enable_if_t<__is_transparent_v<_Compare, _K2>, int> = 0>
+  template <typename _K2, class _Comp = _Compare, enable_if_t<__is_transparent_v<_Comp>, int> = 0>
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI iterator lower_bound(const _K2& __k) {
     return __tree_.__lower_bound_multi(__k);
   }
 
-  template <typename _K2, enable_if_t<__is_transparent_v<_Compare, _K2>, int> = 0>
+  template <typename _K2, class _Comp = _Compare, enable_if_t<__is_transparent_v<_Comp>, int> = 0>
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI const_iterator lower_bound(const _K2& __k) const {
     return __tree_.__lower_bound_multi(__k);
   }
@@ -1359,11 +1359,11 @@ public:
   }
 
 #  if _LIBCPP_STD_VER >= 14
-  template <typename _K2, enable_if_t<__is_transparent_v<_Compare, _K2>, int> = 0>
+  template <typename _K2, class _Comp = _Compare, enable_if_t<__is_transparent_v<_Comp>, int> = 0>
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI iterator upper_bound(const _K2& __k) {
     return __tree_.__upper_bound_multi(__k);
   }
-  template <typename _K2, enable_if_t<__is_transparent_v<_Compare, _K2>, int> = 0>
+  template <typename _K2, class _Comp = _Compare, enable_if_t<__is_transparent_v<_Comp>, int> = 0>
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI const_iterator upper_bound(const _K2& __k) const {
     return __tree_.__upper_bound_multi(__k);
   }
@@ -1376,11 +1376,11 @@ public:
     return __tree_.__equal_range_multi(__k);
   }
 #  if _LIBCPP_STD_VER >= 14
-  template <typename _K2, enable_if_t<__is_transparent_v<_Compare, _K2>, int> = 0>
+  template <typename _K2, class _Comp = _Compare, enable_if_t<__is_transparent_v<_Comp>, int> = 0>
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI pair<iterator, iterator> equal_range(const _K2& __k) {
     return __tree_.__equal_range_multi(__k);
   }
-  template <typename _K2, enable_if_t<__is_transparent_v<_Compare, _K2>, int> = 0>
+  template <typename _K2, class _Comp = _Compare, enable_if_t<__is_transparent_v<_Comp>, int> = 0>
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI pair<const_iterator, const_iterator> equal_range(const _K2& __k) const {
     return __tree_.__equal_range_multi(__k);
   }

--- a/libcxx/include/unordered_map
+++ b/libcxx/include/unordered_map
@@ -1216,12 +1216,16 @@ public:
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI iterator find(const key_type& __k) { return __table_.find(__k); }
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI const_iterator find(const key_type& __k) const { return __table_.find(__k); }
 #  if _LIBCPP_STD_VER >= 20
-  template <class _K2, class _Hasher = hasher, class _Comp = key_equal,
+  template <class _K2,
+            class _Hasher                                                          = hasher,
+            class _Comp                                                            = key_equal,
             enable_if_t<__is_transparent_v<_Hasher> && __is_transparent_v<_Comp>>* = nullptr>
   [[nodiscard]] _LIBCPP_HIDE_FROM_ABI iterator find(const _K2& __k) {
     return __table_.find(__k);
   }
-  template <class _K2, class _Hasher = hasher, class _Comp = key_equal,
+  template <class _K2,
+            class _Hasher                                                          = hasher,
+            class _Comp                                                            = key_equal,
             enable_if_t<__is_transparent_v<_Hasher> && __is_transparent_v<_Comp>>* = nullptr>
   [[nodiscard]] _LIBCPP_HIDE_FROM_ABI const_iterator find(const _K2& __k) const {
     return __table_.find(__k);
@@ -1232,7 +1236,9 @@ public:
     return __table_.__count_unique(__k);
   }
 #  if _LIBCPP_STD_VER >= 20
-  template <class _K2, class _Hasher = hasher, class _Comp = key_equal,
+  template <class _K2,
+            class _Hasher                                                          = hasher,
+            class _Comp                                                            = key_equal,
             enable_if_t<__is_transparent_v<_Hasher> && __is_transparent_v<_Comp>>* = nullptr>
   [[nodiscard]] _LIBCPP_HIDE_FROM_ABI size_type count(const _K2& __k) const {
     return __table_.__count_unique(__k);
@@ -1242,7 +1248,9 @@ public:
 #  if _LIBCPP_STD_VER >= 20
   [[nodiscard]] _LIBCPP_HIDE_FROM_ABI bool contains(const key_type& __k) const { return find(__k) != end(); }
 
-  template <class _K2, class _Hasher = hasher, class _Comp = key_equal,
+  template <class _K2,
+            class _Hasher                                                          = hasher,
+            class _Comp                                                            = key_equal,
             enable_if_t<__is_transparent_v<_Hasher> && __is_transparent_v<_Comp>>* = nullptr>
   [[nodiscard]] _LIBCPP_HIDE_FROM_ABI bool contains(const _K2& __k) const {
     return find(__k) != end();
@@ -1256,12 +1264,16 @@ public:
     return __table_.__equal_range_unique(__k);
   }
 #  if _LIBCPP_STD_VER >= 20
-  template <class _K2, class _Hasher = hasher, class _Comp = key_equal,
+  template <class _K2,
+            class _Hasher                                                          = hasher,
+            class _Comp                                                            = key_equal,
             enable_if_t<__is_transparent_v<_Hasher> && __is_transparent_v<_Comp>>* = nullptr>
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI pair<iterator, iterator> equal_range(const _K2& __k) {
     return __table_.__equal_range_unique(__k);
   }
-  template <class _K2, class _Hasher = hasher, class _Comp = key_equal,
+  template <class _K2,
+            class _Hasher                                                          = hasher,
+            class _Comp                                                            = key_equal,
             enable_if_t<__is_transparent_v<_Hasher> && __is_transparent_v<_Comp>>* = nullptr>
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI pair<const_iterator, const_iterator> equal_range(const _K2& __k) const {
     return __table_.__equal_range_unique(__k);
@@ -1942,12 +1954,16 @@ public:
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI iterator find(const key_type& __k) { return __table_.find(__k); }
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI const_iterator find(const key_type& __k) const { return __table_.find(__k); }
 #  if _LIBCPP_STD_VER >= 20
-  template <class _K2, class _Hasher = hasher, class _Comp = key_equal,
+  template <class _K2,
+            class _Hasher                                                          = hasher,
+            class _Comp                                                            = key_equal,
             enable_if_t<__is_transparent_v<_Hasher> && __is_transparent_v<_Comp>>* = nullptr>
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI iterator find(const _K2& __k) {
     return __table_.find(__k);
   }
-  template <class _K2, class _Hasher = hasher, class _Comp = key_equal,
+  template <class _K2,
+            class _Hasher                                                          = hasher,
+            class _Comp                                                            = key_equal,
             enable_if_t<__is_transparent_v<_Hasher> && __is_transparent_v<_Comp>>* = nullptr>
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI const_iterator find(const _K2& __k) const {
     return __table_.find(__k);
@@ -1958,7 +1974,9 @@ public:
     return __table_.__count_multi(__k);
   }
 #  if _LIBCPP_STD_VER >= 20
-  template <class _K2, class _Hasher = hasher, class _Comp = key_equal,
+  template <class _K2,
+            class _Hasher                                                          = hasher,
+            class _Comp                                                            = key_equal,
             enable_if_t<__is_transparent_v<_Hasher> && __is_transparent_v<_Comp>>* = nullptr>
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI size_type count(const _K2& __k) const {
     return __table_.__count_multi(__k);
@@ -1968,7 +1986,9 @@ public:
 #  if _LIBCPP_STD_VER >= 20
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI bool contains(const key_type& __k) const { return find(__k) != end(); }
 
-  template <class _K2, class _Hasher = hasher, class _Comp = key_equal,
+  template <class _K2,
+            class _Hasher                                                          = hasher,
+            class _Comp                                                            = key_equal,
             enable_if_t<__is_transparent_v<_Hasher> && __is_transparent_v<_Comp>>* = nullptr>
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI bool contains(const _K2& __k) const {
     return find(__k) != end();
@@ -1982,12 +2002,16 @@ public:
     return __table_.__equal_range_multi(__k);
   }
 #  if _LIBCPP_STD_VER >= 20
-  template <class _K2, class _Hasher = hasher, class _Comp = key_equal,
+  template <class _K2,
+            class _Hasher                                                          = hasher,
+            class _Comp                                                            = key_equal,
             enable_if_t<__is_transparent_v<_Hasher> && __is_transparent_v<_Comp>>* = nullptr>
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI pair<iterator, iterator> equal_range(const _K2& __k) {
     return __table_.__equal_range_multi(__k);
   }
-  template <class _K2, class _Hasher = hasher, class _Comp = key_equal,
+  template <class _K2,
+            class _Hasher                                                          = hasher,
+            class _Comp                                                            = key_equal,
             enable_if_t<__is_transparent_v<_Hasher> && __is_transparent_v<_Comp>>* = nullptr>
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI pair<const_iterator, const_iterator> equal_range(const _K2& __k) const {
     return __table_.__equal_range_multi(__k);

--- a/libcxx/include/unordered_map
+++ b/libcxx/include/unordered_map
@@ -1216,11 +1216,13 @@ public:
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI iterator find(const key_type& __k) { return __table_.find(__k); }
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI const_iterator find(const key_type& __k) const { return __table_.find(__k); }
 #  if _LIBCPP_STD_VER >= 20
-  template <class _K2, enable_if_t<__is_transparent_v<hasher, _K2> && __is_transparent_v<key_equal, _K2>>* = nullptr>
+  template <class _K2, class _Hasher = hasher, class _Comp = key_equal,
+            enable_if_t<__is_transparent_v<_Hasher> && __is_transparent_v<_Comp>>* = nullptr>
   [[nodiscard]] _LIBCPP_HIDE_FROM_ABI iterator find(const _K2& __k) {
     return __table_.find(__k);
   }
-  template <class _K2, enable_if_t<__is_transparent_v<hasher, _K2> && __is_transparent_v<key_equal, _K2>>* = nullptr>
+  template <class _K2, class _Hasher = hasher, class _Comp = key_equal,
+            enable_if_t<__is_transparent_v<_Hasher> && __is_transparent_v<_Comp>>* = nullptr>
   [[nodiscard]] _LIBCPP_HIDE_FROM_ABI const_iterator find(const _K2& __k) const {
     return __table_.find(__k);
   }
@@ -1230,7 +1232,8 @@ public:
     return __table_.__count_unique(__k);
   }
 #  if _LIBCPP_STD_VER >= 20
-  template <class _K2, enable_if_t<__is_transparent_v<hasher, _K2> && __is_transparent_v<key_equal, _K2>>* = nullptr>
+  template <class _K2, class _Hasher = hasher, class _Comp = key_equal,
+            enable_if_t<__is_transparent_v<_Hasher> && __is_transparent_v<_Comp>>* = nullptr>
   [[nodiscard]] _LIBCPP_HIDE_FROM_ABI size_type count(const _K2& __k) const {
     return __table_.__count_unique(__k);
   }
@@ -1239,7 +1242,8 @@ public:
 #  if _LIBCPP_STD_VER >= 20
   [[nodiscard]] _LIBCPP_HIDE_FROM_ABI bool contains(const key_type& __k) const { return find(__k) != end(); }
 
-  template <class _K2, enable_if_t<__is_transparent_v<hasher, _K2> && __is_transparent_v<key_equal, _K2>>* = nullptr>
+  template <class _K2, class _Hasher = hasher, class _Comp = key_equal,
+            enable_if_t<__is_transparent_v<_Hasher> && __is_transparent_v<_Comp>>* = nullptr>
   [[nodiscard]] _LIBCPP_HIDE_FROM_ABI bool contains(const _K2& __k) const {
     return find(__k) != end();
   }
@@ -1252,11 +1256,13 @@ public:
     return __table_.__equal_range_unique(__k);
   }
 #  if _LIBCPP_STD_VER >= 20
-  template <class _K2, enable_if_t<__is_transparent_v<hasher, _K2> && __is_transparent_v<key_equal, _K2>>* = nullptr>
+  template <class _K2, class _Hasher = hasher, class _Comp = key_equal,
+            enable_if_t<__is_transparent_v<_Hasher> && __is_transparent_v<_Comp>>* = nullptr>
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI pair<iterator, iterator> equal_range(const _K2& __k) {
     return __table_.__equal_range_unique(__k);
   }
-  template <class _K2, enable_if_t<__is_transparent_v<hasher, _K2> && __is_transparent_v<key_equal, _K2>>* = nullptr>
+  template <class _K2, class _Hasher = hasher, class _Comp = key_equal,
+            enable_if_t<__is_transparent_v<_Hasher> && __is_transparent_v<_Comp>>* = nullptr>
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI pair<const_iterator, const_iterator> equal_range(const _K2& __k) const {
     return __table_.__equal_range_unique(__k);
   }
@@ -1936,11 +1942,13 @@ public:
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI iterator find(const key_type& __k) { return __table_.find(__k); }
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI const_iterator find(const key_type& __k) const { return __table_.find(__k); }
 #  if _LIBCPP_STD_VER >= 20
-  template <class _K2, enable_if_t<__is_transparent_v<hasher, _K2> && __is_transparent_v<key_equal, _K2>>* = nullptr>
+  template <class _K2, class _Hasher = hasher, class _Comp = key_equal,
+            enable_if_t<__is_transparent_v<_Hasher> && __is_transparent_v<_Comp>>* = nullptr>
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI iterator find(const _K2& __k) {
     return __table_.find(__k);
   }
-  template <class _K2, enable_if_t<__is_transparent_v<hasher, _K2> && __is_transparent_v<key_equal, _K2>>* = nullptr>
+  template <class _K2, class _Hasher = hasher, class _Comp = key_equal,
+            enable_if_t<__is_transparent_v<_Hasher> && __is_transparent_v<_Comp>>* = nullptr>
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI const_iterator find(const _K2& __k) const {
     return __table_.find(__k);
   }
@@ -1950,7 +1958,8 @@ public:
     return __table_.__count_multi(__k);
   }
 #  if _LIBCPP_STD_VER >= 20
-  template <class _K2, enable_if_t<__is_transparent_v<hasher, _K2> && __is_transparent_v<key_equal, _K2>>* = nullptr>
+  template <class _K2, class _Hasher = hasher, class _Comp = key_equal,
+            enable_if_t<__is_transparent_v<_Hasher> && __is_transparent_v<_Comp>>* = nullptr>
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI size_type count(const _K2& __k) const {
     return __table_.__count_multi(__k);
   }
@@ -1959,7 +1968,8 @@ public:
 #  if _LIBCPP_STD_VER >= 20
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI bool contains(const key_type& __k) const { return find(__k) != end(); }
 
-  template <class _K2, enable_if_t<__is_transparent_v<hasher, _K2> && __is_transparent_v<key_equal, _K2>>* = nullptr>
+  template <class _K2, class _Hasher = hasher, class _Comp = key_equal,
+            enable_if_t<__is_transparent_v<_Hasher> && __is_transparent_v<_Comp>>* = nullptr>
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI bool contains(const _K2& __k) const {
     return find(__k) != end();
   }
@@ -1972,11 +1982,13 @@ public:
     return __table_.__equal_range_multi(__k);
   }
 #  if _LIBCPP_STD_VER >= 20
-  template <class _K2, enable_if_t<__is_transparent_v<hasher, _K2> && __is_transparent_v<key_equal, _K2>>* = nullptr>
+  template <class _K2, class _Hasher = hasher, class _Comp = key_equal,
+            enable_if_t<__is_transparent_v<_Hasher> && __is_transparent_v<_Comp>>* = nullptr>
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI pair<iterator, iterator> equal_range(const _K2& __k) {
     return __table_.__equal_range_multi(__k);
   }
-  template <class _K2, enable_if_t<__is_transparent_v<hasher, _K2> && __is_transparent_v<key_equal, _K2>>* = nullptr>
+  template <class _K2, class _Hasher = hasher, class _Comp = key_equal,
+            enable_if_t<__is_transparent_v<_Hasher> && __is_transparent_v<_Comp>>* = nullptr>
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI pair<const_iterator, const_iterator> equal_range(const _K2& __k) const {
     return __table_.__equal_range_multi(__k);
   }

--- a/libcxx/include/unordered_set
+++ b/libcxx/include/unordered_set
@@ -844,12 +844,16 @@ public:
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI iterator find(const key_type& __k) { return __table_.find(__k); }
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI const_iterator find(const key_type& __k) const { return __table_.find(__k); }
 #  if _LIBCPP_STD_VER >= 20
-  template <class _K2, class _Hasher = hasher, class _Comp = key_equal,
+  template <class _K2,
+            class _Hasher                                                          = hasher,
+            class _Comp                                                            = key_equal,
             enable_if_t<__is_transparent_v<_Hasher> && __is_transparent_v<_Comp>>* = nullptr>
   [[nodiscard]] _LIBCPP_HIDE_FROM_ABI iterator find(const _K2& __k) {
     return __table_.find(__k);
   }
-  template <class _K2, class _Hasher = hasher, class _Comp = key_equal,
+  template <class _K2,
+            class _Hasher                                                          = hasher,
+            class _Comp                                                            = key_equal,
             enable_if_t<__is_transparent_v<_Hasher> && __is_transparent_v<_Comp>>* = nullptr>
   [[nodiscard]] _LIBCPP_HIDE_FROM_ABI const_iterator find(const _K2& __k) const {
     return __table_.find(__k);
@@ -860,7 +864,9 @@ public:
     return __table_.__count_unique(__k);
   }
 #  if _LIBCPP_STD_VER >= 20
-  template <class _K2, class _Hasher = hasher, class _Comp = key_equal,
+  template <class _K2,
+            class _Hasher                                                          = hasher,
+            class _Comp                                                            = key_equal,
             enable_if_t<__is_transparent_v<_Hasher> && __is_transparent_v<_Comp>>* = nullptr>
   [[nodiscard]] _LIBCPP_HIDE_FROM_ABI size_type count(const _K2& __k) const {
     return __table_.__count_unique(__k);
@@ -870,7 +876,9 @@ public:
 #  if _LIBCPP_STD_VER >= 20
   [[nodiscard]] _LIBCPP_HIDE_FROM_ABI bool contains(const key_type& __k) const { return find(__k) != end(); }
 
-  template <class _K2, class _Hasher = hasher, class _Comp = key_equal,
+  template <class _K2,
+            class _Hasher                                                          = hasher,
+            class _Comp                                                            = key_equal,
             enable_if_t<__is_transparent_v<_Hasher> && __is_transparent_v<_Comp>>* = nullptr>
   [[nodiscard]] _LIBCPP_HIDE_FROM_ABI bool contains(const _K2& __k) const {
     return find(__k) != end();
@@ -884,12 +892,16 @@ public:
     return __table_.__equal_range_unique(__k);
   }
 #  if _LIBCPP_STD_VER >= 20
-  template <class _K2, class _Hasher = hasher, class _Comp = key_equal,
+  template <class _K2,
+            class _Hasher                                                          = hasher,
+            class _Comp                                                            = key_equal,
             enable_if_t<__is_transparent_v<_Hasher> && __is_transparent_v<_Comp>>* = nullptr>
   [[nodiscard]] _LIBCPP_HIDE_FROM_ABI pair<iterator, iterator> equal_range(const _K2& __k) {
     return __table_.__equal_range_unique(__k);
   }
-  template <class _K2, class _Hasher = hasher, class _Comp = key_equal,
+  template <class _K2,
+            class _Hasher                                                          = hasher,
+            class _Comp                                                            = key_equal,
             enable_if_t<__is_transparent_v<_Hasher> && __is_transparent_v<_Comp>>* = nullptr>
   [[nodiscard]] _LIBCPP_HIDE_FROM_ABI pair<const_iterator, const_iterator> equal_range(const _K2& __k) const {
     return __table_.__equal_range_unique(__k);
@@ -1449,12 +1461,16 @@ public:
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI iterator find(const key_type& __k) { return __table_.find(__k); }
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI const_iterator find(const key_type& __k) const { return __table_.find(__k); }
 #  if _LIBCPP_STD_VER >= 20
-  template <class _K2, class _Hasher = hasher, class _Comp = key_equal,
+  template <class _K2,
+            class _Hasher                                                          = hasher,
+            class _Comp                                                            = key_equal,
             enable_if_t<__is_transparent_v<_Hasher> && __is_transparent_v<_Comp>>* = nullptr>
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI iterator find(const _K2& __k) {
     return __table_.find(__k);
   }
-  template <class _K2, class _Hasher = hasher, class _Comp = key_equal,
+  template <class _K2,
+            class _Hasher                                                          = hasher,
+            class _Comp                                                            = key_equal,
             enable_if_t<__is_transparent_v<_Hasher> && __is_transparent_v<_Comp>>* = nullptr>
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI const_iterator find(const _K2& __k) const {
     return __table_.find(__k);
@@ -1465,7 +1481,9 @@ public:
     return __table_.__count_multi(__k);
   }
 #  if _LIBCPP_STD_VER >= 20
-  template <class _K2, class _Hasher = hasher, class _Comp = key_equal,
+  template <class _K2,
+            class _Hasher                                                          = hasher,
+            class _Comp                                                            = key_equal,
             enable_if_t<__is_transparent_v<_Hasher> && __is_transparent_v<_Comp>>* = nullptr>
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI size_type count(const _K2& __k) const {
     return __table_.__count_multi(__k);
@@ -1475,7 +1493,9 @@ public:
 #  if _LIBCPP_STD_VER >= 20
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI bool contains(const key_type& __k) const { return find(__k) != end(); }
 
-  template <class _K2, class _Hasher = hasher, class _Comp = key_equal,
+  template <class _K2,
+            class _Hasher                                                          = hasher,
+            class _Comp                                                            = key_equal,
             enable_if_t<__is_transparent_v<_Hasher> && __is_transparent_v<_Comp>>* = nullptr>
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI bool contains(const _K2& __k) const {
     return find(__k) != end();
@@ -1489,12 +1509,16 @@ public:
     return __table_.__equal_range_multi(__k);
   }
 #  if _LIBCPP_STD_VER >= 20
-  template <class _K2, class _Hasher = hasher, class _Comp = key_equal,
+  template <class _K2,
+            class _Hasher                                                          = hasher,
+            class _Comp                                                            = key_equal,
             enable_if_t<__is_transparent_v<_Hasher> && __is_transparent_v<_Comp>>* = nullptr>
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI pair<iterator, iterator> equal_range(const _K2& __k) {
     return __table_.__equal_range_multi(__k);
   }
-  template <class _K2, class _Hasher = hasher, class _Comp = key_equal,
+  template <class _K2,
+            class _Hasher                                                          = hasher,
+            class _Comp                                                            = key_equal,
             enable_if_t<__is_transparent_v<_Hasher> && __is_transparent_v<_Comp>>* = nullptr>
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI pair<const_iterator, const_iterator> equal_range(const _K2& __k) const {
     return __table_.__equal_range_multi(__k);

--- a/libcxx/include/unordered_set
+++ b/libcxx/include/unordered_set
@@ -844,11 +844,13 @@ public:
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI iterator find(const key_type& __k) { return __table_.find(__k); }
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI const_iterator find(const key_type& __k) const { return __table_.find(__k); }
 #  if _LIBCPP_STD_VER >= 20
-  template <class _K2, enable_if_t<__is_transparent_v<hasher, _K2> && __is_transparent_v<key_equal, _K2>>* = nullptr>
+  template <class _K2, class _Hasher = hasher, class _Comp = key_equal,
+            enable_if_t<__is_transparent_v<_Hasher> && __is_transparent_v<_Comp>>* = nullptr>
   [[nodiscard]] _LIBCPP_HIDE_FROM_ABI iterator find(const _K2& __k) {
     return __table_.find(__k);
   }
-  template <class _K2, enable_if_t<__is_transparent_v<hasher, _K2> && __is_transparent_v<key_equal, _K2>>* = nullptr>
+  template <class _K2, class _Hasher = hasher, class _Comp = key_equal,
+            enable_if_t<__is_transparent_v<_Hasher> && __is_transparent_v<_Comp>>* = nullptr>
   [[nodiscard]] _LIBCPP_HIDE_FROM_ABI const_iterator find(const _K2& __k) const {
     return __table_.find(__k);
   }
@@ -858,7 +860,8 @@ public:
     return __table_.__count_unique(__k);
   }
 #  if _LIBCPP_STD_VER >= 20
-  template <class _K2, enable_if_t<__is_transparent_v<hasher, _K2> && __is_transparent_v<key_equal, _K2>>* = nullptr>
+  template <class _K2, class _Hasher = hasher, class _Comp = key_equal,
+            enable_if_t<__is_transparent_v<_Hasher> && __is_transparent_v<_Comp>>* = nullptr>
   [[nodiscard]] _LIBCPP_HIDE_FROM_ABI size_type count(const _K2& __k) const {
     return __table_.__count_unique(__k);
   }
@@ -867,7 +870,8 @@ public:
 #  if _LIBCPP_STD_VER >= 20
   [[nodiscard]] _LIBCPP_HIDE_FROM_ABI bool contains(const key_type& __k) const { return find(__k) != end(); }
 
-  template <class _K2, enable_if_t<__is_transparent_v<hasher, _K2> && __is_transparent_v<key_equal, _K2>>* = nullptr>
+  template <class _K2, class _Hasher = hasher, class _Comp = key_equal,
+            enable_if_t<__is_transparent_v<_Hasher> && __is_transparent_v<_Comp>>* = nullptr>
   [[nodiscard]] _LIBCPP_HIDE_FROM_ABI bool contains(const _K2& __k) const {
     return find(__k) != end();
   }
@@ -880,11 +884,13 @@ public:
     return __table_.__equal_range_unique(__k);
   }
 #  if _LIBCPP_STD_VER >= 20
-  template <class _K2, enable_if_t<__is_transparent_v<hasher, _K2> && __is_transparent_v<key_equal, _K2>>* = nullptr>
+  template <class _K2, class _Hasher = hasher, class _Comp = key_equal,
+            enable_if_t<__is_transparent_v<_Hasher> && __is_transparent_v<_Comp>>* = nullptr>
   [[nodiscard]] _LIBCPP_HIDE_FROM_ABI pair<iterator, iterator> equal_range(const _K2& __k) {
     return __table_.__equal_range_unique(__k);
   }
-  template <class _K2, enable_if_t<__is_transparent_v<hasher, _K2> && __is_transparent_v<key_equal, _K2>>* = nullptr>
+  template <class _K2, class _Hasher = hasher, class _Comp = key_equal,
+            enable_if_t<__is_transparent_v<_Hasher> && __is_transparent_v<_Comp>>* = nullptr>
   [[nodiscard]] _LIBCPP_HIDE_FROM_ABI pair<const_iterator, const_iterator> equal_range(const _K2& __k) const {
     return __table_.__equal_range_unique(__k);
   }
@@ -1443,11 +1449,13 @@ public:
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI iterator find(const key_type& __k) { return __table_.find(__k); }
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI const_iterator find(const key_type& __k) const { return __table_.find(__k); }
 #  if _LIBCPP_STD_VER >= 20
-  template <class _K2, enable_if_t<__is_transparent_v<hasher, _K2> && __is_transparent_v<key_equal, _K2>>* = nullptr>
+  template <class _K2, class _Hasher = hasher, class _Comp = key_equal,
+            enable_if_t<__is_transparent_v<_Hasher> && __is_transparent_v<_Comp>>* = nullptr>
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI iterator find(const _K2& __k) {
     return __table_.find(__k);
   }
-  template <class _K2, enable_if_t<__is_transparent_v<hasher, _K2> && __is_transparent_v<key_equal, _K2>>* = nullptr>
+  template <class _K2, class _Hasher = hasher, class _Comp = key_equal,
+            enable_if_t<__is_transparent_v<_Hasher> && __is_transparent_v<_Comp>>* = nullptr>
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI const_iterator find(const _K2& __k) const {
     return __table_.find(__k);
   }
@@ -1457,7 +1465,8 @@ public:
     return __table_.__count_multi(__k);
   }
 #  if _LIBCPP_STD_VER >= 20
-  template <class _K2, enable_if_t<__is_transparent_v<hasher, _K2> && __is_transparent_v<key_equal, _K2>>* = nullptr>
+  template <class _K2, class _Hasher = hasher, class _Comp = key_equal,
+            enable_if_t<__is_transparent_v<_Hasher> && __is_transparent_v<_Comp>>* = nullptr>
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI size_type count(const _K2& __k) const {
     return __table_.__count_multi(__k);
   }
@@ -1466,7 +1475,8 @@ public:
 #  if _LIBCPP_STD_VER >= 20
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI bool contains(const key_type& __k) const { return find(__k) != end(); }
 
-  template <class _K2, enable_if_t<__is_transparent_v<hasher, _K2> && __is_transparent_v<key_equal, _K2>>* = nullptr>
+  template <class _K2, class _Hasher = hasher, class _Comp = key_equal,
+            enable_if_t<__is_transparent_v<_Hasher> && __is_transparent_v<_Comp>>* = nullptr>
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI bool contains(const _K2& __k) const {
     return find(__k) != end();
   }
@@ -1479,11 +1489,13 @@ public:
     return __table_.__equal_range_multi(__k);
   }
 #  if _LIBCPP_STD_VER >= 20
-  template <class _K2, enable_if_t<__is_transparent_v<hasher, _K2> && __is_transparent_v<key_equal, _K2>>* = nullptr>
+  template <class _K2, class _Hasher = hasher, class _Comp = key_equal,
+            enable_if_t<__is_transparent_v<_Hasher> && __is_transparent_v<_Comp>>* = nullptr>
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI pair<iterator, iterator> equal_range(const _K2& __k) {
     return __table_.__equal_range_multi(__k);
   }
-  template <class _K2, enable_if_t<__is_transparent_v<hasher, _K2> && __is_transparent_v<key_equal, _K2>>* = nullptr>
+  template <class _K2, class _Hasher = hasher, class _Comp = key_equal,
+            enable_if_t<__is_transparent_v<_Hasher> && __is_transparent_v<_Comp>>* = nullptr>
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI pair<const_iterator, const_iterator> equal_range(const _K2& __k) const {
     return __table_.__equal_range_multi(__k);
   }


### PR DESCRIPTION
__is_transparent_v used to accept an additional _Key template argument whose sole purpose was to make the instantiation as a whole dependent. It turns out that creates confusion around whether that trait takes into account the key type (it does not). Instead, we can use our traditional approach for making template params artificially dependent, which allows removing the confusing parameter.

For disclaimer, I authored this patch with Claude code just to see if I could get it to do the right thing. It works, but you have to steer it right.

Fixes #186417