### PR TITLE
[LLVM] Make -use-constant-fp-for-scalable-splat the default.

### DIFF
--- a/llvm/lib/IR/Constants.cpp
+++ b/llvm/lib/IR/Constants.cpp
@@ -46,7 +46,7 @@ static cl::opt<bool> UseConstantIntForScalableSplat(
     "use-constant-int-for-scalable-splat", cl::init(false), cl::Hidden,
     cl::desc("Use ConstantInt's native scalable vector splat support."));
 static cl::opt<bool> UseConstantFPForScalableSplat(
-    "use-constant-fp-for-scalable-splat", cl::init(false), cl::Hidden,
+    "use-constant-fp-for-scalable-splat", cl::init(true), cl::Hidden,
     cl::desc("Use ConstantFP's native scalable vector splat support."));
 
 //===----------------------------------------------------------------------===//

--- a/llvm/lib/Transforms/Scalar/Reassociate.cpp
+++ b/llvm/lib/Transforms/Scalar/Reassociate.cpp
@@ -1626,7 +1626,7 @@ Value *ReassociatePass::OptimizeAdd(Instruction *I,
         if (CF->isNegative()) {
           APFloat F(CF->getValueAPF());
           F.changeSign();
-          Factor = ConstantFP::get(CF->getContext(), F);
+          Factor = ConstantFP::get(CF->getType(), F);
           if (!Duplicates.insert(Factor).second)
             continue;
           unsigned Occ = ++FactorOccurrences[Factor];


### PR DESCRIPTION
Includes a "fix" to ReassociatePass::OptimizeAdd to force the type of new ConstantFP nodes. I say "fix" because I have not been able to exercise the affected code in a way that shows the expected error. However, the fix is trivial and effectively NFC for the original scalar only use case.

I was hoping to enable ConstantFP across all vector types but the transition is taking longer than expected so given fixed-length and scalable vectors are already using a different representation for splats I figured there's no harm in maintaining this but having scalable vectors using the new preferred representation?

It's a moving target but I think all uses of `<ConstantFP>` are now either scalar specific or vector safe. Auditing `<ConstantDataVector>` and `<ConstantVector>` I'm down to less than ten issues all of which look fixed-length specific.  

A possible exception to this is ValueMapper.cpp (Mapper::mapValue) where my confidence is low but I don't see any specific handling of scalar ConstantInt/FP and so I've interpreted the constant use case to be either (a) ConstantExpr operands can be changed so a new ConstantVector must be built, or (b) undef/poison/zero structs can result in new types that require new ConstantVectors to be built. Which would mean it is not expected for a vector constant to be transformed into a vector constant of different type? If true then that suggests the transition to ConstantInt/FP based splats has no effect on this code.