### PR TITLE
libclc: Remove attempt at subnormal flush from trig functions

### DIFF
--- a/libclc/clc/lib/generic/math/clc_sin.inc
+++ b/libclc/clc/lib/generic/math/clc_sin.inc
@@ -21,12 +21,7 @@ _CLC_OVERLOAD _CLC_DEF __CLC_FLOATN __clc_sin(__CLC_FLOATN x) {
   s = __CLC_AS_FLOATN(__CLC_AS_INTN(s) ^ ((regn > 1) << 31) ^
                       (__CLC_AS_INTN(x) ^ __CLC_AS_INTN(absx)));
 
-  s = __clc_select(s, __CLC_GENTYPE_NAN, __clc_isnan(x) || __clc_isinf(x));
-
-  // Subnormals
-  s = x == 0.0f ? x : s;
-
-  return s;
+  return __clc_select(s, __CLC_GENTYPE_NAN, __clc_isnan(x) || __clc_isinf(x));
 }
 
 #elif __CLC_FPSIZE == 16

--- a/libclc/clc/lib/generic/math/clc_tan.inc
+++ b/libclc/clc/lib/generic/math/clc_tan.inc
@@ -18,10 +18,7 @@ _CLC_DEF _CLC_OVERLOAD __CLC_GENTYPE __clc_tan(__CLC_GENTYPE x) {
   __CLC_GENTYPE t = __clc_tanf_piby4(r0 + r1, regn);
   t = __CLC_AS_GENTYPE(__CLC_AS_UINTN(t) ^ x_signbit);
 
-  t = __clc_select(t, __CLC_GENTYPE_NAN, __clc_isnan(x) || __clc_isinf(x));
-  // Take care of subnormals
-  t = (x == 0.0f) ? x : t;
-  return t;
+  return __clc_select(t, __CLC_GENTYPE_NAN, __clc_isnan(x) || __clc_isinf(x));
 }
 
 #elif __CLC_FPSIZE == 64


### PR DESCRIPTION
There's no obligation to flush the result if DAZ. This also
wasn't consistently used in all of the functions, so it doesn't
make much sense to do it only in sin and tan, but not cos.