### PR TITLE
XFAIL clang/test/CodeGen/distributed-thin-lto/pass-plugin.ll

### DIFF
--- a/clang/test/CodeGen/distributed-thin-lto/pass-plugin.ll
+++ b/clang/test/CodeGen/distributed-thin-lto/pass-plugin.ll
@@ -1,4 +1,7 @@
 ; REQUIRES: x86-registered-target, plugins, llvm-examples
+; There is an issue with export symbols on AIX that is currently
+; causing this test case to fail. XFAIL for now.
+; XFAIL: target={{.*}}-aix{{.*}}
 
 ;; Validate that -fpass-plugin works for distributed ThinLTO backends.
 


### PR DESCRIPTION
Failing on AIX as it can't find the new symbol in the exported list.  XFAIL to bring the bots green while we investigate.

Test introduced in: https://github.com/llvm/llvm-project/pull/183525