### PR TITLE
[mlir] Fix UB in comparator lambdas in getRegisteredOperationsByDialect

### DIFF
--- a/mlir/lib/IR/MLIRContext.cpp
+++ b/mlir/lib/IR/MLIRContext.cpp
@@ -709,20 +709,21 @@ ArrayRef<RegisteredOperationName> MLIRContext::getRegisteredOperations() {
 /// Return information for registered operations by dialect.
 ArrayRef<RegisteredOperationName>
 MLIRContext::getRegisteredOperationsByDialect(StringRef dialectName) {
-  auto *lowerBound = llvm::lower_bound(
-      impl->sortedRegisteredOperations, dialectName, [](auto &lhs, auto &rhs) {
-        return lhs.getDialect().getNamespace().compare(rhs);
-      });
+  auto *lowerBound =
+      llvm::lower_bound(impl->sortedRegisteredOperations, dialectName,
+                        [](const RegisteredOperationName &lhs, StringRef rhs) {
+                          return lhs.getDialect().getNamespace() < rhs;
+                        });
 
   if (lowerBound == impl->sortedRegisteredOperations.end() ||
       lowerBound->getDialect().getNamespace() != dialectName)
     return ArrayRef<RegisteredOperationName>();
 
-  auto *upperBound =
-      std::upper_bound(lowerBound, impl->sortedRegisteredOperations.end(),
-                       dialectName, [](auto &lhs, auto &rhs) {
-                         return lhs.compare(rhs.getDialect().getNamespace());
-                       });
+  auto *upperBound = std::upper_bound(
+      lowerBound, impl->sortedRegisteredOperations.end(), dialectName,
+      [](StringRef lhs, const RegisteredOperationName &rhs) {
+        return lhs < rhs.getDialect().getNamespace();
+      });
 
   size_t count = std::distance(lowerBound, upperBound);
   return ArrayRef(&*lowerBound, count);
@@ -998,8 +999,8 @@ void RegisteredOperationName::insert(
   ctxImpl.sortedRegisteredOperations.insert(
       llvm::upper_bound(ctxImpl.sortedRegisteredOperations, value,
                         [](auto &lhs, auto &rhs) {
-                          return lhs.getIdentifier().compare(
-                              rhs.getIdentifier());
+                          return lhs.getIdentifier().strref() <
+                                 rhs.getIdentifier().strref();
                         }),
       value);
 }


### PR DESCRIPTION
The comparators in `getRegisteredOperationsByDialect` and `RegisteredOperationName::insert` were returning `StringRef::compare()` directly (an `int`) instead of a boolean, breaking the strict weak ordering requirement. Fix by using `StringRef` comparison operator `<` directly.

Fixes #146940

Assisted-by: Claude Code