### PR TITLE
libclc: Move edge case handling of trig functions

### DIFF
--- a/libclc/clc/lib/generic/math/clc_cos.inc
+++ b/libclc/clc/lib/generic/math/clc_cos.inc
@@ -9,6 +9,8 @@
 #if __CLC_FPSIZE == 32
 
 _CLC_OVERLOAD _CLC_DEF __CLC_FLOATN __clc_cos(__CLC_FLOATN x) {
+  x = __clc_isinf(x) ? __CLC_GENTYPE_NAN : x;
+
   __CLC_FLOATN absx = __clc_fabs(x);
 
   __CLC_FLOATN r0, r1;
@@ -18,11 +20,7 @@ _CLC_OVERLOAD _CLC_DEF __CLC_FLOATN __clc_cos(__CLC_FLOATN x) {
   __CLC_FLOATN cc = __clc_cosf_piby4(r0, r1);
 
   __CLC_FLOATN c = (regn & 1) != 0 ? ss : cc;
-  c = __CLC_AS_FLOATN(__CLC_AS_INTN(c) ^ ((regn > 1) << 31));
-
-  c = __clc_select(c, __CLC_GENTYPE_NAN, __clc_isnan(x) || __clc_isinf(x));
-
-  return c;
+  return __CLC_AS_FLOATN(__CLC_AS_INTN(c) ^ ((regn > 1) << 31));
 }
 
 #elif __CLC_FPSIZE == 16
@@ -34,6 +32,8 @@ _CLC_OVERLOAD _CLC_DEF __CLC_GENTYPE __clc_cos(__CLC_GENTYPE x) {
 #elif __CLC_FPSIZE == 64
 
 _CLC_OVERLOAD _CLC_DEF __CLC_GENTYPE __clc_cos(__CLC_GENTYPE x) {
+  x = __clc_isinf(x) ? __CLC_GENTYPE_NAN : x;
+
   __CLC_GENTYPE absx = __clc_fabs(x);
 
   __CLC_BIT_INTN is_medium = absx < 0x1.0p+47;
@@ -56,8 +56,7 @@ _CLC_OVERLOAD _CLC_DEF __CLC_GENTYPE __clc_cos(__CLC_GENTYPE x) {
       __CLC_AS_LONGN(__CLC_CONVERT_BIT_INTN((regn & 1) != 0) ? sinval : cosval);
   c ^= __CLC_CONVERT_BIT_INTN(regn > 1) << 63;
 
-  return __clc_isnan(absx) | __clc_isinf(absx) ? __CLC_GENTYPE_NAN
-                                               : __CLC_AS_GENTYPE(c);
+  return __CLC_AS_GENTYPE(c);
 }
 
 #endif

--- a/libclc/clc/lib/generic/math/clc_sin.inc
+++ b/libclc/clc/lib/generic/math/clc_sin.inc
@@ -9,6 +9,8 @@
 #if __CLC_FPSIZE == 32
 
 _CLC_OVERLOAD _CLC_DEF __CLC_FLOATN __clc_sin(__CLC_FLOATN x) {
+  x = __clc_isinf(x) ? __CLC_GENTYPE_NAN : x;
+
   __CLC_FLOATN absx = __clc_fabs(x);
 
   __CLC_FLOATN r0, r1;
@@ -18,10 +20,8 @@ _CLC_OVERLOAD _CLC_DEF __CLC_FLOATN __clc_sin(__CLC_FLOATN x) {
   __CLC_FLOATN cc = __clc_cosf_piby4(r0, r1);
 
   __CLC_FLOATN s = (regn & 1) != 0 ? cc : ss;
-  s = __CLC_AS_FLOATN(__CLC_AS_INTN(s) ^ ((regn > 1) << 31) ^
-                      (__CLC_AS_INTN(x) ^ __CLC_AS_INTN(absx)));
-
-  return __clc_select(s, __CLC_GENTYPE_NAN, __clc_isnan(x) || __clc_isinf(x));
+  return __CLC_AS_FLOATN(__CLC_AS_INTN(s) ^ ((regn > 1) << 31) ^
+                         (__CLC_AS_INTN(x) ^ __CLC_AS_INTN(absx)));
 }
 
 #elif __CLC_FPSIZE == 16
@@ -33,6 +33,8 @@ _CLC_OVERLOAD _CLC_DEF __CLC_GENTYPE __clc_sin(__CLC_GENTYPE x) {
 #elif __CLC_FPSIZE == 64
 
 _CLC_OVERLOAD _CLC_DEF __CLC_GENTYPE __clc_sin(__CLC_GENTYPE x) {
+  x = __clc_isinf(x) ? __CLC_GENTYPE_NAN : x;
+
   __CLC_GENTYPE absx = __clc_fabs(x);
 
   __CLC_BIT_INTN is_medium = absx < 0x1.0p+47;
@@ -56,8 +58,7 @@ _CLC_OVERLOAD _CLC_DEF __CLC_GENTYPE __clc_sin(__CLC_GENTYPE x) {
   s ^= (__CLC_CONVERT_BIT_INTN(regn > 1) << 63) ^
        (__CLC_CONVERT_BIT_INTN(x < 0.0) << 63);
 
-  return __clc_isinf(x) | __clc_isnan(x) ? __CLC_GENTYPE_NAN
-                                         : __CLC_AS_GENTYPE(s);
+  return __CLC_AS_GENTYPE(s);
 }
 
 #endif

--- a/libclc/clc/lib/generic/math/clc_tan.inc
+++ b/libclc/clc/lib/generic/math/clc_tan.inc
@@ -9,6 +9,8 @@
 #if __CLC_FPSIZE == 32
 
 _CLC_DEF _CLC_OVERLOAD __CLC_GENTYPE __clc_tan(__CLC_GENTYPE x) {
+  x = __clc_isinf(x) ? __CLC_GENTYPE_NAN : x;
+
   __CLC_GENTYPE absx = __clc_fabs(x);
   __CLC_UINTN x_signbit = __CLC_AS_UINTN(x) & SIGNBIT_SP32;
 
@@ -16,14 +18,14 @@ _CLC_DEF _CLC_OVERLOAD __CLC_GENTYPE __clc_tan(__CLC_GENTYPE x) {
   __CLC_INTN regn = __clc_argReductionS(&r0, &r1, absx);
 
   __CLC_GENTYPE t = __clc_tanf_piby4(r0 + r1, regn);
-  t = __CLC_AS_GENTYPE(__CLC_AS_UINTN(t) ^ x_signbit);
-
-  return __clc_select(t, __CLC_GENTYPE_NAN, __clc_isnan(x) || __clc_isinf(x));
+  return __CLC_AS_GENTYPE(__CLC_AS_UINTN(t) ^ x_signbit);
 }
 
 #elif __CLC_FPSIZE == 64
 
 _CLC_DEF _CLC_OVERLOAD __CLC_GENTYPE __clc_tan(__CLC_GENTYPE x) {
+  x = __clc_isinf(x) ? __CLC_GENTYPE_NAN : x;
+
   __CLC_GENTYPE y = __clc_fabs(x);
 
   __CLC_BIT_INTN is_medium = y < 0x1.0p+30;
@@ -45,8 +47,7 @@ _CLC_DEF _CLC_OVERLOAD __CLC_GENTYPE __clc_tan(__CLC_GENTYPE x) {
       __CLC_AS_LONGN(__CLC_CONVERT_BIT_INTN((regn & 1) != 0) ? tail : lead);
   t ^= __CLC_CONVERT_BIT_INTN(x < 0.0) << 63;
 
-  return __clc_isnan(x) || __clc_isinf(x) ? __CLC_GENTYPE_NAN
-                                          : __CLC_AS_GENTYPE(t);
+  return __CLC_AS_GENTYPE(t);
 }
 
 #elif __CLC_FPSIZE == 16


### PR DESCRIPTION
The explicit handling of nan is unnecessary. Clamp infinities
to nan at the input. This allows optimizations of the following
implementation code to take advantage of the knowledge that it
does not need to handle infinities.