### PR TITLE
[mlir][tblgen] Emit diagnostic instead of crashing for invalid interface method arg type

### DIFF
--- a/mlir/lib/TableGen/Interfaces.cpp
+++ b/mlir/lib/TableGen/Interfaces.cpp
@@ -9,6 +9,7 @@
 #include "mlir/TableGen/Interfaces.h"
 #include "llvm/ADT/FunctionExtras.h"
 #include "llvm/ADT/StringSet.h"
+#include "llvm/ADT/Twine.h"
 #include "llvm/TableGen/Error.h"
 #include "llvm/TableGen/Record.h"
 #include <utility>
@@ -30,8 +31,15 @@ InterfaceMethod::InterfaceMethod(const Record *def, std::string uniqueName)
     : def(def), uniqueName(uniqueName) {
   const DagInit *args = def->getValueAsDag("arguments");
   for (unsigned i = 0, e = args->getNumArgs(); i != e; ++i) {
-    arguments.push_back({cast<StringInit>(args->getArg(i))->getValue(),
-                         args->getArgNameStr(i)});
+    const Init *arg = args->getArg(i);
+    const auto *strArg = dyn_cast<StringInit>(arg);
+    if (!strArg)
+      llvm::PrintFatalError(
+          def->getLoc(),
+          "expected string type for interface method argument #" + Twine(i) +
+              " ('" + args->getArgNameStr(i) + "') in '" + def->getName() +
+              "', but got '" + arg->getAsString() + "'");
+    arguments.push_back({strArg->getValue(), args->getArgNameStr(i)});
   }
 }
 

--- a/mlir/test/mlir-tblgen/interface-method-arg-error.td
+++ b/mlir/test/mlir-tblgen/interface-method-arg-error.td
@@ -1,0 +1,13 @@
+// RUN: not mlir-tblgen -gen-op-interface-decls -I %S/../../include %s 2>&1 | FileCheck %s
+
+// Test that a non-string argument type in an interface method gives a readable
+// error instead of a crash. See https://github.com/llvm/llvm-project/issues/61869
+
+include "mlir/IR/OpBase.td"
+
+def Foo {}
+
+// CHECK: error: expected string type for interface method argument #0 ('arg')
+def Bar : OpInterface<"Bar"> {
+  let methods = [InterfaceMethod<[{}], "void", "baz", (ins Foo:$arg)>];
+}


### PR DESCRIPTION
When an interface method argument uses a non-string type (e.g., a TableGen class reference like `Foo` instead of a string literal `"Foo"`), the code in `InterfaceMethod::InterfaceMethod` would crash with an assertion failure in `cast<StringInit>`. Replace the unchecked cast with a `dyn_cast` and emit a `PrintFatalError` with a descriptive error message pointing to the source location and identifying which argument has the wrong type.

Before this fix:
  mlir-tblgen: Assertion `isa<To>(Val) && "cast<Ty>() argument of incompatible type\!"' failed.

After this fix:
  error: expected string type for interface method argument #0 ('arg') ...

Fixes #61869

Assisted-by: Claude Code