### PR TITLE
[libc++][NFC] Rename the template parameter of __make_transparent

### DIFF
--- a/libcxx/include/__functional/operations.h
+++ b/libcxx/include/__functional/operations.h
@@ -379,8 +379,8 @@ struct less<void> {
   typedef void is_transparent;
 };
 
-template <class _Tp>
-struct __make_transparent<_Tp, less<_Tp> > {
+template <class _ArgumentType>
+struct __make_transparent<_ArgumentType, less<_ArgumentType> > {
   using type _LIBCPP_NODEBUG = less<>;
 };
 
@@ -477,8 +477,8 @@ struct greater<void> {
 template <class _Tp, class _Up>
 inline const bool __desugars_to_v<__greater_tag, greater<>, _Tp, _Up> = true;
 
-template <class _Tp>
-struct __make_transparent<_Tp, greater<_Tp>> {
+template <class _ArgumentType>
+struct __make_transparent<_ArgumentType, greater<_ArgumentType>> {
   using type _LIBCPP_NODEBUG = greater<>;
 };
 

--- a/libcxx/include/__type_traits/make_transparent.h
+++ b/libcxx/include/__type_traits/make_transparent.h
@@ -22,29 +22,30 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 
 // __make_transparent tries to create a transparent comparator from its non-transparent counterpart, e.g. obtain
 // `less<>` from `less<T>`. This is useful in cases where conversions can be avoided (e.g. a string literal to a
-// std::string).
+// std::string). This depends on the argument type provided to the comparator, because a comparator might be
+// transparent for some argument types but not for others.
 
-template <class _Tp, class _Comparator>
+template <class _ArgumentType, class _Comparator>
 struct __make_transparent {
   using type _LIBCPP_NODEBUG = _Comparator;
 };
 
-template <class _Tp, class _Comparator>
-using __make_transparent_t _LIBCPP_NODEBUG = typename __make_transparent<_Tp, _Comparator>::type;
+template <class _ArgumentType, class _Comparator>
+using __make_transparent_t _LIBCPP_NODEBUG = typename __make_transparent<_ArgumentType, _Comparator>::type;
 
-template <class _Tp,
+template <class _ArgumentType,
           class _Comparator,
-          __enable_if_t<is_same<_Comparator, __make_transparent_t<_Tp, _Comparator> >::value, int> = 0>
+          __enable_if_t<is_same<_Comparator, __make_transparent_t<_ArgumentType, _Comparator> >::value, int> = 0>
 _LIBCPP_HIDE_FROM_ABI _Comparator& __as_transparent(_Comparator& __comp) {
   return __comp;
 }
 
-template <class _Tp,
+template <class _ArgumentType,
           class _Comparator,
-          __enable_if_t<!is_same<_Comparator, __make_transparent_t<_Tp, _Comparator> >::value, int> = 0>
-_LIBCPP_HIDE_FROM_ABI __make_transparent_t<_Tp, _Comparator> __as_transparent(_Comparator&) {
+          __enable_if_t<!is_same<_Comparator, __make_transparent_t<_ArgumentType, _Comparator> >::value, int> = 0>
+_LIBCPP_HIDE_FROM_ABI __make_transparent_t<_ArgumentType, _Comparator> __as_transparent(_Comparator&) {
   static_assert(is_empty<_Comparator>::value);
-  return __make_transparent_t<_Tp, _Comparator>();
+  return __make_transparent_t<_ArgumentType, _Comparator>();
 }
 
 _LIBCPP_END_NAMESPACE_STD


### PR DESCRIPTION
Renaming from _Tp to _ArgumentType makes it clearer that we're passing the argument type intended for the comparator, which allows checking whether *that specific use* of the comparator would be transparent.

Fixes #186396