### PR TITLE
[mlir] avoid comparing char with `~0x00` literal.

### DIFF
--- a/mlir/lib/IR/BuiltinDialectBytecode.cpp
+++ b/mlir/lib/IR/BuiltinDialectBytecode.cpp
@@ -181,7 +181,7 @@ readDenseIntOrFPElementsAttr(DialectBytecodeReader &reader, ShapedType type,
   size_t packedSize = llvm::divideCeil(numElements, 8);
 
   // Unpack splats to single element 0x01 to match unpacked splat format.
-  if (blob.size() == 1 && blob[0] == ~0x00) {
+  if (blob.size() == 1 && blob[0] == static_cast<char>(~0x00)) {
     rawData.resize(1);
     rawData[0] = 0x01;
     return success();


### PR DESCRIPTION
Introduced in #186221. This is actually incorrect; `~0x00` should produce an int literal, so the comparison will always return false if the char type is unsigned.