### PR TITLE
[llvm][CompactUnwind] Compact Unwind does not support .cfi_signal_frame

### DIFF
--- a/libunwind/test/signal_frame.pass.cpp
+++ b/libunwind/test/signal_frame.pass.cpp
@@ -10,8 +10,8 @@
 // Ensure that functions marked as signal frames are reported as such.
 
 // Older clang versions had a bug: .cfi_signal_frame can't be encoded in compact
-// unwind. Work around that by forcing DWARF unwind.
-// ADDITIONAL_COMPILE_FLAGS(apple-clang-17): -femit-dwarf-unwind=always
+// unwind.
+// XFAIL: apple-clang-17
 
 // TODO: Figure out why this fails with Memory Sanitizer.
 // XFAIL: msan

--- a/libunwind/test/signal_frame.pass.cpp
+++ b/libunwind/test/signal_frame.pass.cpp
@@ -9,9 +9,6 @@
 
 // Ensure that functions marked as signal frames are reported as such.
 
-// TODO: Investigate this failure on Apple
-// XFAIL: target={{.+}}-apple-{{.+}}
-
 // TODO: Figure out why this fails with Memory Sanitizer.
 // XFAIL: msan
 

--- a/libunwind/test/signal_frame.pass.cpp
+++ b/libunwind/test/signal_frame.pass.cpp
@@ -9,6 +9,10 @@
 
 // Ensure that functions marked as signal frames are reported as such.
 
+// Older clang versions had a bug: .cfi_signal_frame can't be encoded in compact
+// unwind. Work around that by forcing DWARF unwind.
+// ADDITIONAL_COMPILE_FLAGS(apple-clang-17): -femit-dwarf-unwind=always
+
 // TODO: Figure out why this fails with Memory Sanitizer.
 // XFAIL: msan
 

--- a/llvm/lib/Target/AArch64/MCTargetDesc/AArch64AsmBackend.cpp
+++ b/llvm/lib/Target/AArch64/MCTargetDesc/AArch64AsmBackend.cpp
@@ -580,6 +580,10 @@ public:
     if (FI->IsMTETaggedFrame)
       return CU::UNWIND_ARM64_MODE_DWARF;
 
+    // Signal frames cannot be encoded in compact unwind.
+    if (FI->IsSignalFrame)
+      return CU::UNWIND_ARM64_MODE_DWARF;
+
     ArrayRef<MCCFIInstruction> Instrs = FI->Instructions;
     if (Instrs.empty())
       return CU::UNWIND_ARM64_MODE_FRAMELESS;

--- a/llvm/lib/Target/ARM/MCTargetDesc/ARMAsmBackend.cpp
+++ b/llvm/lib/Target/ARM/MCTargetDesc/ARMAsmBackend.cpp
@@ -1171,13 +1171,20 @@ enum CompactUnwindEncodings {
 uint64_t ARMAsmBackendDarwin::generateCompactUnwindEncoding(
     const MCDwarfFrameInfo *FI, const MCContext *Ctxt) const {
   DEBUG_WITH_TYPE("compact-unwind", llvm::dbgs() << "generateCU()\n");
+
   // Only armv7k uses CFI based unwinding.
   if (Subtype != MachO::CPU_SUBTYPE_ARM_V7K)
     return 0;
+
+  // Signal frames cannot be encoded in compact unwind.
+  if (FI->IsSignalFrame)
+    return CU::UNWIND_ARM_MODE_DWARF;
+
   // No .cfi directives means no frame.
   ArrayRef<MCCFIInstruction> Instrs = FI->Instructions;
   if (Instrs.empty())
     return 0;
+
   if (!isDarwinCanonicalPersonality(FI->Personality) &&
       !Ctxt->emitCompactUnwindNonCanonical())
     return CU::UNWIND_ARM_MODE_DWARF;

--- a/llvm/lib/Target/X86/MCTargetDesc/X86AsmBackend.cpp
+++ b/llvm/lib/Target/X86/MCTargetDesc/X86AsmBackend.cpp
@@ -1306,6 +1306,10 @@ public:
   /// for the CFI instructions.
   uint64_t generateCompactUnwindEncoding(const MCDwarfFrameInfo *FI,
                                          const MCContext *Ctxt) const override {
+    // Signal frames cannot be encoded in compact unwind.
+    if (FI->IsSignalFrame)
+      return CU::UNWIND_MODE_DWARF;
+
     ArrayRef<MCCFIInstruction> Instrs = FI->Instructions;
     if (Instrs.empty()) return 0;
     if (!isDarwinCanonicalPersonality(FI->Personality) &&

--- a/llvm/test/MC/AArch64/arm64-compact-unwind-signal-frame.s
+++ b/llvm/test/MC/AArch64/arm64-compact-unwind-signal-frame.s
@@ -1,0 +1,33 @@
+// RUN: llvm-mc -triple=arm64-apple-ios -filetype=obj %s -o %t.o
+// RUN: llvm-objdump --macho --unwind-info --dwarf=frames %t.o | FileCheck %s
+
+/// Signal frames cannot be encoded in compact unwind.  Verify that
+/// .cfi_signal_frame causes UNWIND_ARM64_MODE_DWARF (0x03000000) to be
+/// emitted in the __compact_unwind section, and that the corresponding DWARF
+/// CIE carries the 'S' augmentation character.  A non-signal frame in the
+/// same translation unit is encoded normally (UNWIND_ARM64_MODE_FRAMELESS,
+/// 0x02000000) and needs no DWARF FDE.
+
+  .globl _f
+_f:
+  .cfi_startproc
+  .cfi_signal_frame
+  ret
+  .cfi_endproc
+
+  .globl _g
+_g:
+  .cfi_startproc
+  ret
+  .cfi_endproc
+
+// CHECK: Contents of __compact_unwind section:
+// CHECK:   Entry at offset 0x0:
+// CHECK:     compact encoding:     0x03000000
+// CHECK:   Entry at offset 0x20:
+// CHECK:     start:                0x{{.*}} _g
+// CHECK:     compact encoding:     0x02000000
+
+// CHECK: .eh_frame contents:
+// CHECK: CIE
+// CHECK:   Augmentation:          "zRS"

--- a/llvm/test/MC/ARM/compact-unwind-signal-frame.s
+++ b/llvm/test/MC/ARM/compact-unwind-signal-frame.s
@@ -1,0 +1,24 @@
+// RUN: llvm-mc -triple=armv7k-apple-ios -filetype=obj %s -o %t.o
+// RUN: llvm-objdump --macho --unwind-info --dwarf=frames %t.o | FileCheck %s
+
+/// Signal frames cannot be encoded in compact unwind.  Verify that
+/// .cfi_signal_frame causes UNWIND_ARM_MODE_DWARF (0x04000000) to be emitted
+/// in the __compact_unwind section, and that the corresponding DWARF CIE
+/// carries the 'S' augmentation character.
+
+  .globl _f
+_f:
+  .cfi_startproc
+  .cfi_signal_frame
+  bx lr
+  .cfi_endproc
+
+// CHECK: Contents of __compact_unwind section:
+// CHECK:   Entry at offset 0x0:
+// CHECK:     start:                0x0 _f
+// CHECK:     length:               0x4
+// CHECK:     compact encoding:     0x04000000
+
+// CHECK: .eh_frame contents:
+// CHECK: CIE
+// CHECK:   Augmentation:          "zRS"

--- a/llvm/test/MC/X86/compact-unwind-signal-frame.s
+++ b/llvm/test/MC/X86/compact-unwind-signal-frame.s
@@ -1,0 +1,23 @@
+// RUN: llvm-mc -triple x86_64-apple-macos10.6 -filetype=obj %s -o %t.o
+// RUN: llvm-objdump --macho --unwind-info --dwarf=frames %t.o | FileCheck %s
+
+/// Signal frames cannot be encoded in compact unwind.  Verify that
+/// .cfi_signal_frame causes UNWIND_X86_MODE_DWARF (0x04000000) to be emitted
+/// in the __compact_unwind section, and that the corresponding DWARF CIE
+/// carries the 'S' augmentation character.
+
+_f:
+  .cfi_startproc
+  .cfi_signal_frame
+  ret
+  .cfi_endproc
+
+// CHECK: Contents of __compact_unwind section:
+// CHECK:   Entry at offset 0x0:
+// CHECK:     start:                0x0 _f
+// CHECK:     length:               0x1
+// CHECK:     compact encoding:     0x04000000
+
+// CHECK: .eh_frame contents:
+// CHECK: CIE
+// CHECK:   Augmentation:          "zRS"


### PR DESCRIPTION
Fixes libunwind's signal_frame.pass.cpp test on Mach-O platforms.