### PR TITLE
[LoopFusion] Fusing with loop-invariant non-anti dependency

### DIFF
--- a/llvm/lib/Transforms/Scalar/LoopFuse.cpp
+++ b/llvm/lib/Transforms/Scalar/LoopFuse.cpp
@@ -1268,6 +1268,13 @@ private:
 
       assert(CurLoopLevel > Levels && "Fusion candidates are not separated");
 
+      if (DepResult->isScalar(CurLoopLevel, true) && !DepResult->isAnti()) {
+        LLVM_DEBUG(dbgs() << "Safe to fuse due to a loop-invariant non-anti "
+                             "dependency\n");
+        NumDA++;
+        return true;
+      }
+
       unsigned CurDir = DepResult->getDirection(CurLoopLevel, true);
 
       // Check if the direction vector does not include greater direction. In
@@ -1288,7 +1295,6 @@ private:
         LLVM_DEBUG(
             dbgs() << "TODO: Implement pred/succ dependence handling!\n");
 
-      // TODO: Can we actually use the dependence info analysis here?
       return false;
     }
 

--- a/llvm/test/Transforms/LoopFusion/loop_invariant.ll
+++ b/llvm/test/Transforms/LoopFusion/loop_invariant.ll
@@ -1,0 +1,69 @@
+; REQUIRES: asserts
+
+; RUN: opt -S -passes=loop-fusion -loop-fusion-dependence-analysis=da -debug-only=loop-fusion -disable-output < %s 2>&1 | FileCheck %s --check-prefix=CHECK-DA
+; RUN: opt -S -passes=loop-fusion -loop-fusion-dependence-analysis=scev -debug-only=loop-fusion -disable-output < %s 2>&1 | FileCheck %s --check-prefix=CHECK-SCEV
+
+define void @loop_invariant(i32 %N) {
+; CHECK-DA: Performing Loop Fusion on function loop_invariant
+; CHECK-DA: Safe to fuse due to a loop-invariant non-anti dependency
+; CHECK-SCEV: Performing Loop Fusion on function loop_invariant
+; CHECK-SCEV: Fusion done
+;
+pre1:
+  %ptr = alloca i32, align 4
+  br label %body1
+
+body1:  ; preds = %pre1, %body1
+  %i = phi i32 [%i_next, %body1], [0, %pre1]
+  %i_next = add i32 1, %i
+  %cond = icmp ne i32 %i, %N
+  store i32 3, ptr %ptr
+  br i1 %cond, label %body1, label %pre2
+
+pre2:
+  br label %body2
+
+body2:  ; preds = %pre2, %body2
+  %i2 = phi i32 [%i_next2, %body2], [0, %pre2]
+  %i_next2 = add i32 1, %i2
+  %cond2 = icmp ne i32 %i2, %N
+  store i32 3, ptr %ptr
+  br i1 %cond2, label %body2, label %exit
+
+exit:
+  ret void
+}
+
+; TODO: improve SCEV check to detect the loop-invariant anti dependence with
+; scalar access and prevent fusion.
+define void @anti_loop_invariant(i32 %N) {
+; CHECK-DA: Performing Loop Fusion on function anti_loop_invariant
+; CHECK-DA: Memory dependencies do not allow fusion!
+; CHECK-SCEV: Performing Loop Fusion on function anti_loop_invariant
+; XFAIL-CHECK-SCEV: Memory dependencies do not allow fusion!
+;
+pre1:
+  %ptr = alloca i32, align 4
+  store i32 1, ptr %ptr
+  br label %body1
+
+body1:  ; preds = %pre1, %body1
+  %i = phi i32 [%i_next, %body1], [0, %pre1]
+  %i_next = add i32 1, %i
+  %cond = icmp ne i32 %i, %N
+  %v = load i32, ptr %ptr
+  br i1 %cond, label %body1, label %pre2
+
+pre2:
+  br label %body2
+
+body2:  ; preds = %pre2, %body2
+  %i2 = phi i32 [%i_next2, %body2], [0, %pre2]
+  %i_next2 = add i32 1, %i2
+  %cond2 = icmp ne i32 %i2, %N
+  store i32 3, ptr %ptr
+  br i1 %cond2, label %body2, label %exit
+
+exit:
+  ret void
+}


### PR DESCRIPTION
Loop-invariant non-anti dependencies are safe for fusion.

 \+  In the test case provided in this patch, it is shown that there is a bug in the loop fusion check with SCEV. FUSION_DEPENDENCE_ANALYSIS_SCEV allows fusion if there is a loop-invariant anti dependency which is not legal. Seems the method have this assumption that their inputs are not loop-invariant, so if their difference is 0 it allows the fusion.  This is correct for loop-variant accesses such as `A[i*2]` and `A[i*2]`, but not for scalar accesses such as `*p` and `*p`.