### PR TITLE
[lldb-dap][windows] don't use the ConPTY in internalConsole mode

### DIFF
--- a/lldb/include/lldb/Host/ProcessLaunchInfo.h
+++ b/lldb/include/lldb/Host/ProcessLaunchInfo.h
@@ -64,6 +64,14 @@ public:
   // but stderr doesn't, then only stderr will be redirected to a pty.)
   llvm::Error SetUpPtyRedirection();
 
+#ifdef _WIN32
+  // Redirect stdin/stdout/stderr to anonymous pipes instead of a ConPTY.
+  // Used when terminal emulation is not needed (e.g. lldb-dap internalConsole).
+  llvm::Error SetUpPipeRedirection();
+#endif
+
+  bool HasPTY() const { return m_pty != nullptr; }
+
   size_t GetNumFileActions() const { return m_file_actions.size(); }
 
   const FileAction *GetFileActionAtIndex(size_t idx) const;
@@ -138,7 +146,7 @@ public:
 #ifdef _WIN32
     if (!m_pty)
       return false;
-    return GetPTY().GetPseudoTerminalHandle() != ((HANDLE)(long long)-1) &&
+    return GetPTY().GetMode() != PseudoConsole::Mode::None &&
            GetNumFileActions() == 0;
 #else
     return true;

--- a/lldb/include/lldb/Host/windows/PseudoConsole.h
+++ b/lldb/include/lldb/Host/windows/PseudoConsole.h
@@ -22,7 +22,7 @@ namespace lldb_private {
 class PseudoConsole {
 
 public:
-  enum Mode { ConPTY, Pipe, None };
+  enum class Mode { ConPTY, Pipe, None };
 
   PseudoConsole() = default;
   ~PseudoConsole();
@@ -31,6 +31,13 @@ public:
   PseudoConsole(PseudoConsole &&) = delete;
   PseudoConsole &operator=(const PseudoConsole &) = delete;
   PseudoConsole &operator=(PseudoConsole &&) = delete;
+
+  /// Creates a named pipe pair for overlapped I/O. The read end is set to
+  /// non-blocking (PIPE_NOWAIT).
+  /// On failure any handles that were successfully opened are closed and an
+  /// error is returned.
+  llvm::Error CreateOverlappedPipePair(HANDLE &out_read, HANDLE &out_write,
+                                       bool inheritable);
 
   /// Creates and opens a new ConPTY instance with a default console size of
   /// 80x25. Also sets up the associated STDIN/STDOUT pipes and drains any

--- a/lldb/include/lldb/Host/windows/PseudoConsole.h
+++ b/lldb/include/lldb/Host/windows/PseudoConsole.h
@@ -61,12 +61,12 @@ public:
   void Close();
 
   /// Closes the STDIN and STDOUT pipe handles and invalidates them.
-  void ClosePipes();
+  void ClosePseudoConsolePipes();
 
   /// Closes the child-side pipe handles (stdin read end and stdout/stderr write
   /// end) that were passed to CreateProcessW. Must be called after a successful
   /// CreateProcessW to avoid keeping the pipes alive indefinitely.
-  void CloseChildHandles();
+  void CloseAnonymousPipes();
 
   /// Returns whether the ConPTY and its pipes are currently open and valid.
   bool IsConnected() const;

--- a/lldb/include/lldb/Host/windows/PseudoConsole.h
+++ b/lldb/include/lldb/Host/windows/PseudoConsole.h
@@ -22,6 +22,8 @@ namespace lldb_private {
 class PseudoConsole {
 
 public:
+  enum Mode { ConPTY, Pipe, None };
+
   PseudoConsole() = default;
   ~PseudoConsole();
 
@@ -40,13 +42,24 @@ public:
   ///     otherwise.
   llvm::Error OpenPseudoConsole();
 
+  /// Creates a pair of anonymous pipes to use for stdio instead of a ConPTY.
+  ///
+  /// \return
+  ///     An llvm::Error if the pipes could not be created.
+  llvm::Error OpenAnonymousPipes();
+
   /// Closes the ConPTY and invalidates its handle, without closing the STDIN
   /// and STDOUT pipes. Closing the ConPTY signals EOF to any process currently
   /// attached to it.
   void Close();
 
-  /// Closes the STDIN and STDOUT pipe handles and invalidates them
+  /// Closes the STDIN and STDOUT pipe handles and invalidates them.
   void ClosePipes();
+
+  /// Closes the child-side pipe handles (stdin read end and stdout/stderr write
+  /// end) that were passed to CreateProcessW. Must be called after a successful
+  /// CreateProcessW to avoid keeping the pipes alive indefinitely.
+  void CloseChildHandles();
 
   /// Returns whether the ConPTY and its pipes are currently open and valid.
   bool IsConnected() const;
@@ -77,6 +90,14 @@ public:
   ///     The STDIN write HANDLE, or INVALID_HANDLE_VALUE if it is currently
   ///     invalid.
   HANDLE GetSTDINHandle() const { return m_conpty_input; };
+
+  /// The child-side stdin read HANDLE (pipe mode only).
+  HANDLE GetChildStdinHandle() const { return m_pipe_child_stdin; };
+
+  /// The child-side stdout/stderr write HANDLE (pipe mode only).
+  HANDLE GetChildStdoutHandle() const { return m_pipe_child_stdout; };
+
+  Mode GetMode() const { return m_mode; };
 
   /// Drains initialization sequences from the ConPTY output pipe.
   ///
@@ -112,6 +133,10 @@ protected:
   HANDLE m_conpty_handle = ((HANDLE)(long long)-1);
   HANDLE m_conpty_output = ((HANDLE)(long long)-1);
   HANDLE m_conpty_input = ((HANDLE)(long long)-1);
+  // Pipe mode: child-side handles passed to CreateProcessW, closed after launch
+  HANDLE m_pipe_child_stdin = ((HANDLE)(long long)-1);
+  HANDLE m_pipe_child_stdout = ((HANDLE)(long long)-1);
+  Mode m_mode = Mode::None;
   std::mutex m_mutex{};
   std::condition_variable m_cv{};
   std::atomic<bool> m_stopping = false;

--- a/lldb/include/lldb/lldb-enumerations.h
+++ b/lldb/include/lldb/lldb-enumerations.h
@@ -132,6 +132,10 @@ FLAGS_ENUM(LaunchFlags){
                     ///< permissions but instead inherit them from its parent.
     eLaunchFlagMemoryTagging =
         (1u << 13), ///< Launch process with memory tagging explicitly enabled.
+    eLaunchFlagUsePipes =
+        (1u << 14), ///< Use anonymous pipes for stdio instead of a ConPTY on
+                    ///< Windows. Useful when terminal emulation is not needed
+                    ///< (e.g. lldb-dap internalConsole mode).
 };
 
 /// Thread Run Modes.

--- a/lldb/source/Host/common/ProcessLaunchInfo.cpp
+++ b/lldb/source/Host/common/ProcessLaunchInfo.cpp
@@ -242,6 +242,14 @@ llvm::Error ProcessLaunchInfo::SetUpPtyRedirection() {
 #endif
 }
 
+#ifdef _WIN32
+llvm::Error ProcessLaunchInfo::SetUpPipeRedirection() {
+  if (!m_pty)
+    m_pty = std::make_shared<PTY>();
+  return m_pty->OpenAnonymousPipes();
+}
+#endif
+
 bool ProcessLaunchInfo::ConvertArgumentsForLaunchingInShell(
     Status &error, bool will_debug, bool first_arg_is_full_shell_command,
     uint32_t num_resumes) {

--- a/lldb/source/Host/windows/ProcessLauncherWindows.cpp
+++ b/lldb/source/Host/windows/ProcessLauncherWindows.cpp
@@ -251,7 +251,7 @@ ProcessLauncherWindows::LaunchProcess(const ProcessLaunchInfo &launch_info,
     // through the HostProcess.
     ::CloseHandle(pi.hThread);
     if (pty_mode == PseudoConsole::Mode::Pipe)
-      launch_info.GetPTY().CloseChildHandles();
+      launch_info.GetPTY().CloseAnonymousPipes();
   }
 
   if (!result)

--- a/lldb/source/Host/windows/ProcessLauncherWindows.cpp
+++ b/lldb/source/Host/windows/ProcessLauncherWindows.cpp
@@ -130,7 +130,9 @@ ProcessLauncherWindows::LaunchProcess(const ProcessLaunchInfo &launch_info,
   startupinfoex.StartupInfo.cb = sizeof(STARTUPINFOEXW);
   startupinfoex.StartupInfo.dwFlags |= STARTF_USESTDHANDLES;
 
-  bool use_pty = launch_info.ShouldUsePTY();
+  PseudoConsole::Mode pty_mode = launch_info.ShouldUsePTY()
+                                     ? launch_info.GetPTY().GetMode()
+                                     : PseudoConsole::Mode::None;
 
   HANDLE stdin_handle = GetStdioHandle(launch_info, STDIN_FILENO);
   HANDLE stdout_handle = GetStdioHandle(launch_info, STDOUT_FILENO);
@@ -152,13 +154,31 @@ ProcessLauncherWindows::LaunchProcess(const ProcessLaunchInfo &launch_info,
   ProcThreadAttributeList attributelist = std::move(*attributelist_or_err);
 
   std::vector<HANDLE> inherited_handles;
-  if (use_pty) {
+  switch (pty_mode) {
+  case PseudoConsole::Mode::ConPTY: {
     HPCON hPC = launch_info.GetPTY().GetPseudoTerminalHandle();
     if (auto err = attributelist.SetupPseudoConsole(hPC)) {
       error = Status::FromError(std::move(err));
       return HostProcess();
     }
-  } else {
+    break;
+  }
+  case PseudoConsole::Mode::Pipe: {
+    PseudoConsole &pty = launch_info.GetPTY();
+    startupinfoex.StartupInfo.hStdInput = pty.GetChildStdinHandle();
+    startupinfoex.StartupInfo.hStdOutput = pty.GetChildStdoutHandle();
+    startupinfoex.StartupInfo.hStdError = pty.GetChildStdoutHandle();
+    inherited_handles = {pty.GetChildStdinHandle(), pty.GetChildStdoutHandle()};
+    if (!UpdateProcThreadAttribute(
+            startupinfoex.lpAttributeList, 0, PROC_THREAD_ATTRIBUTE_HANDLE_LIST,
+            inherited_handles.data(), inherited_handles.size() * sizeof(HANDLE),
+            nullptr, nullptr)) {
+      error = Status(::GetLastError(), eErrorTypeWin32);
+      return HostProcess();
+    }
+    break;
+  }
+  case PseudoConsole::Mode::None: {
     auto inherited_handles_or_err =
         GetInheritedHandles(startupinfoex, &launch_info, stdout_handle,
                             stderr_handle, stdin_handle);
@@ -167,6 +187,8 @@ ProcessLauncherWindows::LaunchProcess(const ProcessLaunchInfo &launch_info,
       return HostProcess();
     }
     inherited_handles = std::move(*inherited_handles_or_err);
+    break;
+  }
   }
 
   const char *hide_console_var =
@@ -182,7 +204,8 @@ ProcessLauncherWindows::LaunchProcess(const ProcessLaunchInfo &launch_info,
   if (launch_info.GetFlags().Test(eLaunchFlagDebug))
     flags |= DEBUG_ONLY_THIS_PROCESS;
 
-  if (launch_info.GetFlags().Test(eLaunchFlagDisableSTDIO) || use_pty)
+  if (launch_info.GetFlags().Test(eLaunchFlagDisableSTDIO) ||
+      pty_mode != PseudoConsole::Mode::None)
     flags &= ~CREATE_NEW_CONSOLE;
 
   std::vector<wchar_t> environment =
@@ -210,8 +233,9 @@ ProcessLauncherWindows::LaunchProcess(const ProcessLaunchInfo &launch_info,
 
   BOOL result = ::CreateProcessW(
       wexecutable.c_str(), pwcommandLine, NULL, NULL,
-      /*bInheritHandles=*/!inherited_handles.empty() || use_pty, flags,
-      environment.data(),
+      /*bInheritHandles=*/!inherited_handles.empty() ||
+          pty_mode != PseudoConsole::Mode::None,
+      flags, environment.data(),
       wworkingDirectory.size() == 0 ? NULL : wworkingDirectory.c_str(),
       reinterpret_cast<STARTUPINFOW *>(&startupinfoex), &pi);
 
@@ -226,6 +250,8 @@ ProcessLauncherWindows::LaunchProcess(const ProcessLaunchInfo &launch_info,
     // Do not call CloseHandle on pi.hProcess, since we want to pass that back
     // through the HostProcess.
     ::CloseHandle(pi.hThread);
+    if (pty_mode == PseudoConsole::Mode::Pipe)
+      launch_info.GetPTY().CloseChildHandles();
   }
 
   if (!result)

--- a/lldb/source/Host/windows/PseudoConsole.cpp
+++ b/lldb/source/Host/windows/PseudoConsole.cpp
@@ -126,6 +126,7 @@ llvm::Error PseudoConsole::OpenPseudoConsole() {
   m_conpty_handle = hPC;
   m_conpty_output = hOutputRead;
   m_conpty_input = hInputWrite;
+  m_mode = Mode::ConPTY;
 
   if (auto error = DrainInitSequences()) {
     Log *log = GetLog(LLDBLog::Host);
@@ -137,6 +138,9 @@ llvm::Error PseudoConsole::OpenPseudoConsole() {
 }
 
 bool PseudoConsole::IsConnected() const {
+  if (m_mode == Mode::Pipe)
+    return m_conpty_input != INVALID_HANDLE_VALUE &&
+           m_conpty_output != INVALID_HANDLE_VALUE;
   return m_conpty_handle != INVALID_HANDLE_VALUE &&
          m_conpty_input != INVALID_HANDLE_VALUE &&
          m_conpty_output != INVALID_HANDLE_VALUE;
@@ -160,6 +164,64 @@ void PseudoConsole::ClosePipes() {
 
   m_conpty_input = INVALID_HANDLE_VALUE;
   m_conpty_output = INVALID_HANDLE_VALUE;
+}
+
+void PseudoConsole::CloseChildHandles() {
+  if (m_pipe_child_stdin != INVALID_HANDLE_VALUE)
+    CloseHandle(m_pipe_child_stdin);
+  if (m_pipe_child_stdout != INVALID_HANDLE_VALUE)
+    CloseHandle(m_pipe_child_stdout);
+
+  m_pipe_child_stdin = INVALID_HANDLE_VALUE;
+  m_pipe_child_stdout = INVALID_HANDLE_VALUE;
+}
+
+llvm::Error PseudoConsole::OpenAnonymousPipes() {
+  SECURITY_ATTRIBUTES sa = {sizeof(SECURITY_ATTRIBUTES), NULL, TRUE};
+  HANDLE hStdinRead = INVALID_HANDLE_VALUE;
+  HANDLE hStdinWrite = INVALID_HANDLE_VALUE;
+  if (!CreatePipe(&hStdinRead, &hStdinWrite, &sa, 0))
+    return llvm::errorCodeToError(
+        std::error_code(GetLastError(), std::system_category()));
+  // Parent write end must not be inherited by the child.
+  SetHandleInformation(hStdinWrite, HANDLE_FLAG_INHERIT, 0);
+
+  wchar_t pipe_name[MAX_PATH];
+  swprintf(pipe_name, MAX_PATH, L"\\\\.\\pipe\\pipes-lldb-%d-%p",
+           GetCurrentProcessId(), this);
+
+  HANDLE hStdoutRead =
+      CreateNamedPipeW(pipe_name, PIPE_ACCESS_INBOUND | FILE_FLAG_OVERLAPPED,
+                       PIPE_TYPE_BYTE | PIPE_WAIT, 1, 4096, 4096, 0, NULL);
+  if (hStdoutRead == INVALID_HANDLE_VALUE) {
+    CloseHandle(hStdinRead);
+    CloseHandle(hStdinWrite);
+    return llvm::errorCodeToError(
+        std::error_code(GetLastError(), std::system_category()));
+  }
+
+  SECURITY_ATTRIBUTES child_security_attributes = {sizeof(SECURITY_ATTRIBUTES),
+                                                   NULL, TRUE};
+  HANDLE hStdoutWrite =
+      CreateFileW(pipe_name, GENERIC_WRITE, 0, &child_security_attributes,
+                  OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
+  if (hStdoutWrite == INVALID_HANDLE_VALUE) {
+    CloseHandle(hStdinRead);
+    CloseHandle(hStdinWrite);
+    CloseHandle(hStdoutRead);
+    return llvm::errorCodeToError(
+        std::error_code(GetLastError(), std::system_category()));
+  }
+
+  DWORD mode = PIPE_NOWAIT;
+  SetNamedPipeHandleState(hStdoutRead, &mode, NULL, NULL);
+
+  m_conpty_input = hStdinWrite;
+  m_conpty_output = hStdoutRead;
+  m_pipe_child_stdin = hStdinRead;
+  m_pipe_child_stdout = hStdoutWrite;
+  m_mode = Mode::Pipe;
+  return llvm::Error::success();
 }
 
 llvm::Error PseudoConsole::DrainInitSequences() {

--- a/lldb/source/Host/windows/PseudoConsole.cpp
+++ b/lldb/source/Host/windows/PseudoConsole.cpp
@@ -65,12 +65,44 @@ private:
 
 static Kernel32 kernel32;
 
+llvm::Error PseudoConsole::CreateOverlappedPipePair(HANDLE &out_read,
+                                                    HANDLE &out_write,
+                                                    bool inheritable) {
+  wchar_t pipe_name[MAX_PATH];
+  swprintf(pipe_name, MAX_PATH, L"\\\\.\\pipe\\conpty-lldb-%d-%p",
+           GetCurrentProcessId(), this);
+  out_read =
+      CreateNamedPipeW(pipe_name, PIPE_ACCESS_INBOUND | FILE_FLAG_OVERLAPPED,
+                       PIPE_TYPE_BYTE | PIPE_WAIT, 1, 4096, 4096, 0, NULL);
+  if (out_read == INVALID_HANDLE_VALUE)
+    return llvm::errorCodeToError(
+        std::error_code(GetLastError(), std::system_category()));
+  SECURITY_ATTRIBUTES write_sa = {sizeof(SECURITY_ATTRIBUTES), NULL, TRUE};
+  out_write =
+      CreateFileW(pipe_name, GENERIC_WRITE, 0, inheritable ? &write_sa : NULL,
+                  OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
+  if (out_write == INVALID_HANDLE_VALUE) {
+    CloseHandle(out_read);
+    out_read = INVALID_HANDLE_VALUE;
+    return llvm::errorCodeToError(
+        std::error_code(GetLastError(), std::system_category()));
+  }
+
+  DWORD mode = PIPE_NOWAIT;
+  SetNamedPipeHandleState(out_read, &mode, NULL, NULL);
+  return llvm::Error::success();
+}
+
 PseudoConsole::~PseudoConsole() {
   Close();
   ClosePipes();
+  CloseChildHandles();
 }
 
 llvm::Error PseudoConsole::OpenPseudoConsole() {
+  assert(m_mode == Mode::None &&
+         "Attempted to open a PseudoConsole in a different mode than None");
+
   if (!kernel32.IsConPTYAvailable())
     return llvm::make_error<llvm::StringError>("ConPTY is not available",
                                                llvm::errc::io_error);
@@ -78,27 +110,24 @@ llvm::Error PseudoConsole::OpenPseudoConsole() {
   assert(m_conpty_handle == INVALID_HANDLE_VALUE &&
          "ConPTY has already been opened");
 
-  HRESULT hr;
-  HANDLE hInputRead = INVALID_HANDLE_VALUE;
-  HANDLE hInputWrite = INVALID_HANDLE_VALUE;
-  HANDLE hOutputRead = INVALID_HANDLE_VALUE;
-  HANDLE hOutputWrite = INVALID_HANDLE_VALUE;
-
+  // A 4096 bytes buffer should be large enough for the majority of console
+  // burst outputs.
   wchar_t pipe_name[MAX_PATH];
   swprintf(pipe_name, MAX_PATH, L"\\\\.\\pipe\\conpty-lldb-%d-%p",
            GetCurrentProcessId(), this);
+  HANDLE hOutputRead = INVALID_HANDLE_VALUE;
+  HANDLE hOutputWrite = INVALID_HANDLE_VALUE;
+  if (auto err = CreateOverlappedPipePair(hOutputRead, hOutputWrite, false))
+    return err;
 
-  // A 4096 bytes buffer should be large enough for the majority of console
-  // burst outputs.
-  hOutputRead =
-      CreateNamedPipeW(pipe_name, PIPE_ACCESS_INBOUND | FILE_FLAG_OVERLAPPED,
-                       PIPE_TYPE_BYTE | PIPE_WAIT, 1, 4096, 4096, 0, NULL);
-  hOutputWrite = CreateFileW(pipe_name, GENERIC_WRITE, 0, NULL, OPEN_EXISTING,
-                             FILE_ATTRIBUTE_NORMAL, NULL);
-
-  if (!CreatePipe(&hInputRead, &hInputWrite, NULL, 0))
+  HANDLE hInputRead = INVALID_HANDLE_VALUE;
+  HANDLE hInputWrite = INVALID_HANDLE_VALUE;
+  if (!CreatePipe(&hInputRead, &hInputWrite, NULL, 0)) {
+    CloseHandle(hOutputRead);
+    CloseHandle(hOutputWrite);
     return llvm::errorCodeToError(
         std::error_code(GetLastError(), std::system_category()));
+  }
 
   COORD consoleSize{80, 25};
   CONSOLE_SCREEN_BUFFER_INFO csbi;
@@ -107,8 +136,8 @@ llvm::Error PseudoConsole::OpenPseudoConsole() {
         static_cast<SHORT>(csbi.srWindow.Right - csbi.srWindow.Left + 1),
         static_cast<SHORT>(csbi.srWindow.Bottom - csbi.srWindow.Top + 1)};
   HPCON hPC = INVALID_HANDLE_VALUE;
-  hr = kernel32.CreatePseudoConsole(consoleSize, hInputRead, hOutputWrite, 0,
-                                    &hPC);
+  HRESULT hr = kernel32.CreatePseudoConsole(consoleSize, hInputRead,
+                                            hOutputWrite, 0, &hPC);
   CloseHandle(hInputRead);
   CloseHandle(hOutputWrite);
 
@@ -119,9 +148,6 @@ llvm::Error PseudoConsole::OpenPseudoConsole() {
         "Failed to create Windows ConPTY pseudo terminal",
         llvm::errc::io_error);
   }
-
-  DWORD mode = PIPE_NOWAIT;
-  SetNamedPipeHandleState(hOutputRead, &mode, NULL, NULL);
 
   m_conpty_handle = hPC;
   m_conpty_output = hOutputRead;
@@ -177,6 +203,9 @@ void PseudoConsole::CloseChildHandles() {
 }
 
 llvm::Error PseudoConsole::OpenAnonymousPipes() {
+  assert(m_mode == Mode::None &&
+         "Attempted to open a AnonymousPipes in a different mode than None");
+
   SECURITY_ATTRIBUTES sa = {sizeof(SECURITY_ATTRIBUTES), NULL, TRUE};
   HANDLE hStdinRead = INVALID_HANDLE_VALUE;
   HANDLE hStdinWrite = INVALID_HANDLE_VALUE;
@@ -186,35 +215,13 @@ llvm::Error PseudoConsole::OpenAnonymousPipes() {
   // Parent write end must not be inherited by the child.
   SetHandleInformation(hStdinWrite, HANDLE_FLAG_INHERIT, 0);
 
-  wchar_t pipe_name[MAX_PATH];
-  swprintf(pipe_name, MAX_PATH, L"\\\\.\\pipe\\pipes-lldb-%d-%p",
-           GetCurrentProcessId(), this);
-
-  HANDLE hStdoutRead =
-      CreateNamedPipeW(pipe_name, PIPE_ACCESS_INBOUND | FILE_FLAG_OVERLAPPED,
-                       PIPE_TYPE_BYTE | PIPE_WAIT, 1, 4096, 4096, 0, NULL);
-  if (hStdoutRead == INVALID_HANDLE_VALUE) {
+  HANDLE hStdoutRead = INVALID_HANDLE_VALUE;
+  HANDLE hStdoutWrite = INVALID_HANDLE_VALUE;
+  if (auto err = CreateOverlappedPipePair(hStdoutRead, hStdoutWrite, true)) {
     CloseHandle(hStdinRead);
     CloseHandle(hStdinWrite);
-    return llvm::errorCodeToError(
-        std::error_code(GetLastError(), std::system_category()));
+    return err;
   }
-
-  SECURITY_ATTRIBUTES child_security_attributes = {sizeof(SECURITY_ATTRIBUTES),
-                                                   NULL, TRUE};
-  HANDLE hStdoutWrite =
-      CreateFileW(pipe_name, GENERIC_WRITE, 0, &child_security_attributes,
-                  OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
-  if (hStdoutWrite == INVALID_HANDLE_VALUE) {
-    CloseHandle(hStdinRead);
-    CloseHandle(hStdinWrite);
-    CloseHandle(hStdoutRead);
-    return llvm::errorCodeToError(
-        std::error_code(GetLastError(), std::system_category()));
-  }
-
-  DWORD mode = PIPE_NOWAIT;
-  SetNamedPipeHandleState(hStdoutRead, &mode, NULL, NULL);
 
   m_conpty_input = hStdinWrite;
   m_conpty_output = hStdoutRead;

--- a/lldb/source/Host/windows/PseudoConsole.cpp
+++ b/lldb/source/Host/windows/PseudoConsole.cpp
@@ -95,8 +95,8 @@ llvm::Error PseudoConsole::CreateOverlappedPipePair(HANDLE &out_read,
 
 PseudoConsole::~PseudoConsole() {
   Close();
-  ClosePipes();
-  CloseChildHandles();
+  ClosePseudoConsolePipes();
+  CloseAnonymousPipes();
 }
 
 llvm::Error PseudoConsole::OpenPseudoConsole() {
@@ -182,7 +182,7 @@ void PseudoConsole::Close() {
   m_cv.notify_all();
 }
 
-void PseudoConsole::ClosePipes() {
+void PseudoConsole::ClosePseudoConsolePipes() {
   if (m_conpty_input != INVALID_HANDLE_VALUE)
     CloseHandle(m_conpty_input);
   if (m_conpty_output != INVALID_HANDLE_VALUE)
@@ -192,7 +192,7 @@ void PseudoConsole::ClosePipes() {
   m_conpty_output = INVALID_HANDLE_VALUE;
 }
 
-void PseudoConsole::CloseChildHandles() {
+void PseudoConsole::CloseAnonymousPipes() {
   if (m_pipe_child_stdin != INVALID_HANDLE_VALUE)
     CloseHandle(m_pipe_child_stdin);
   if (m_pipe_child_stdout != INVALID_HANDLE_VALUE)

--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -3859,8 +3859,19 @@ void Target::FinalizeFileActions(ProcessLaunchInfo &info) {
       }
 
       if (default_to_use_pty) {
-        llvm::Error Err = info.SetUpPtyRedirection();
-        LLDB_LOG_ERROR(log, std::move(Err), "SetUpPtyRedirection failed: {0}");
+#ifdef _WIN32
+        if (info.GetFlags().Test(eLaunchFlagUsePipes)) {
+          llvm::Error Err = info.SetUpPipeRedirection();
+          LLDB_LOG_ERROR(log, std::move(Err),
+                         "SetUpPipeRedirection failed: {0}");
+        } else {
+#endif
+          llvm::Error Err = info.SetUpPtyRedirection();
+          LLDB_LOG_ERROR(log, std::move(Err),
+                         "SetUpPtyRedirection failed: {0}");
+#ifdef _WIN32
+        }
+#endif
       }
     }
   }

--- a/lldb/tools/lldb-dap/Handler/RequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/RequestHandler.cpp
@@ -223,6 +223,10 @@ llvm::Error BaseRequestHandler::LaunchProcess(
       SetLaunchFlag(flags, arguments.disableASLR, lldb::eLaunchFlagDisableASLR);
   flags = SetLaunchFlag(flags, arguments.disableSTDIO,
                         lldb::eLaunchFlagDisableSTDIO);
+#ifdef _WIN32
+  flags = SetLaunchFlag(flags, arguments.console == protocol::eConsoleInternal,
+                        lldb::eLaunchFlagUsePipes);
+#endif
   launch_info.SetLaunchFlags(flags | lldb::eLaunchFlagDebug |
                              lldb::eLaunchFlagStopAtEntry);
 


### PR DESCRIPTION
In `internalConsole` mode (especially in VSCode), lldb-dap should not use the ConPTY to read the process' output. This is because the internalConsole is not a real terminal, there is no reason to use terminal emulation, which will add arbitrary line returns to the output.

Instead, this patch introduces the `eLaunchFlagUsePipes` flag in ProcessLaunchInfo which tells ProcessLaunchWindows to use regular pipes instead of a ConPTY to get the stdin and stdout of the debuggee.

The result is that output which is supposed to be on a single line is properly rendered.

---

The following example is when debugging a program through lldb-dap on Windows. The program prints the numbers 0 through 999 on a single line.

# Before
<img width="2214" height="672" alt="Screenshot 2026-03-13 at 17 07 35" src="https://github.com/user-attachments/assets/26292d11-2288-46ee-a6d2-0b66bfa41288" />

The line is split if it's longer than 80 characters (default terminal size).

# After
<img width="2215" height="689" alt="Screenshot 2026-03-13 at 17 12 39" src="https://github.com/user-attachments/assets/c9cad9af-b1ce-4c7b-91d5-f684e48e64ca" />

The line is correctly printed as a single line.

rdar://172491166
