### PR TITLE
[NFC][SCEV] Use const_cast to avoid warnings/errors.

### DIFF
--- a/llvm/include/llvm/Analysis/ScalarEvolution.h
+++ b/llvm/include/llvm/Analysis/ScalarEvolution.h
@@ -70,7 +70,9 @@ class SCEV;
 
 struct SCEVUse : PointerIntPair<const SCEV *, 2> {
   SCEVUse() : PointerIntPair() { setFromOpaqueValue(nullptr); }
-  SCEVUse(const SCEV *S) : PointerIntPair() { setFromOpaqueValue((void *)S); }
+  SCEVUse(const SCEV *S) : PointerIntPair() {
+    setFromOpaqueValue(reinterpret_cast<void *>(const_cast<SCEV *>(S)));
+  }
   SCEVUse(const SCEV *S, unsigned Flags) : PointerIntPair(S, Flags) {}
 
   operator const SCEV *() const { return getPointer(); }


### PR DESCRIPTION
Follow-up on #91961. Some builds may fail, and other will issue
lots of warnings:
```
warning: cast from type ‘const llvm::SCEV*’ to type ‘void*’ casts away qualifiers [-Wcast-qual]
```
