### PR TITLE
[clang][ssaf] Fix shared library build by adding missing clangBasic dependency

### DIFF
--- a/clang/unittests/ScalableStaticAnalysisFramework/CMakeLists.txt
+++ b/clang/unittests/ScalableStaticAnalysisFramework/CMakeLists.txt
@@ -26,6 +26,7 @@ add_distinct_clang_unittest(ClangScalableAnalysisTests
   CLANG_LIBS
   clangAST
   clangASTMatchers
+  clangBasic
   clangFrontend
   clangScalableStaticAnalysisFrameworkCore
   clangSerialization

--- a/llvm/utils/gn/secondary/clang/unittests/ScalableStaticAnalysisFramework/BUILD.gn
+++ b/llvm/utils/gn/secondary/clang/unittests/ScalableStaticAnalysisFramework/BUILD.gn
@@ -5,6 +5,7 @@ unittest("ClangScalableAnalysisTests") {
   deps = [
     "//clang/lib/AST",
     "//clang/lib/ASTMatchers",
+    "//clang/lib/Basic",
     "//clang/lib/Frontend",
     "//clang/lib/ScalableStaticAnalysisFramework/Core",
     "//clang/lib/Serialization",


### PR DESCRIPTION
The ClangScalableAnalysisTests target was missing a link dependency on clangBasic, causing linker failures on shared library builds where transitive dependencies are not automatically resolved.

Fixes https://github.com/llvm/llvm-project/pull/186442#issuecomment-4056922413 https://lab.llvm.org/buildbot/#/builders/10/builds/24522

```
AILED: tools/clang/unittests/ScalableStaticAnalysisFramework/ClangScalableAnalysisTests
/usr/bin/ld: tools/clang/unittests/ScalableStaticAnalysisFramework/CMakeFiles/ClangScalableAnalysisTests.dir/ASTEntityMappingTest.cpp.o: undefined reference to symbol '_ZNK5clang19AttributeCommonInfo35calculateAttributeSpellingListIndexEv'
/usr/bin/ld: /home/botworker/builds/openmp-offload-amdgpu-runtime-2/llvm.build/lib/libclangBasic.so.23.0git: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
[329/334] Building CXX object tools/clang/unittests/Interpreter/CMakeFiles/ClangReplInterpreterTests.dir/CodeCompletionTest.cpp.o
[330/334] Building CXX object tools/clang/unittests/Interpreter/CMakeFiles/ClangReplInterpreterTests.dir/IncrementalProcessingTest.cpp.o
[331/334] Linking CXX executable tools/clang/unittests/Sema/SemaTests
[332/334] Linking CXX executable tools/clang/unittests/AllClangUnitTests
ninja: build stopped: subcommand failed.
```

Assisted-By: claude