### PR TITLE
[VPlan][Predicator] Simplify block mask by using PostDomFrontier

### DIFF
--- a/llvm/lib/Transforms/Vectorize/VPlanDominatorTree.h
+++ b/llvm/lib/Transforms/Vectorize/VPlanDominatorTree.h
@@ -18,6 +18,8 @@
 #include "VPlan.h"
 #include "VPlanCFG.h"
 #include "llvm/ADT/GraphTraits.h"
+#include "llvm/Analysis/DominanceFrontier.h"
+#include "llvm/Analysis/DominanceFrontierImpl.h"
 #include "llvm/IR/Dominators.h"
 #include "llvm/Support/GenericDomTree.h"
 #include "llvm/Support/GenericDomTreeConstruction.h"
@@ -67,5 +69,11 @@ template <>
 struct GraphTraits<const VPDomTreeNode *>
     : public DomTreeGraphTraitsBase<const VPDomTreeNode,
                                     VPDomTreeNode::const_iterator> {};
+
+class VPPostDominanceFrontier
+    : public DominanceFrontierBase<VPBlockBase, true> {
+public:
+  explicit VPPostDominanceFrontier(const DomTreeT &VPDT) { analyze(VPDT); }
+};
 } // namespace llvm
 #endif // LLVM_TRANSFORMS_VECTORIZE_VPLANDOMINATORTREE_H

--- a/llvm/lib/Transforms/Vectorize/VPlanPredicator.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanPredicator.cpp
@@ -34,6 +34,9 @@ class VPPredicator {
   /// Post-dominator tree for the VPlan.
   VPPostDominatorTree VPPDT;
 
+  /// Post-dominance frontier for the VPlan.
+  VPPostDominanceFrontier VPPDF;
+
   /// When we if-convert we need to create edge masks. We have to cache values
   /// so that we don't end up with exponential recursion/IR.
   using EdgeMaskCacheTy =
@@ -70,7 +73,7 @@ class VPPredicator {
   }
 
 public:
-  VPPredicator(VPlan &Plan) : VPDT(Plan), VPPDT(Plan) {}
+  VPPredicator(VPlan &Plan) : VPDT(Plan), VPPDT(Plan), VPPDF(VPPDT) {}
 
   /// Returns the *entry* mask for \p VPBB.
   VPValue *getBlockInMask(const VPBasicBlock *VPBB) const {
@@ -148,22 +151,25 @@ void VPPredicator::createBlockInMask(VPBasicBlock *VPBB) {
   // All-one mask is modelled as no-mask following the convention for masked
   // load/store/gather/scatter. Initialize BlockMask to no-mask.
   VPValue *BlockMask = nullptr;
-  // This is the block mask. We OR all unique incoming edges.
-  for (auto *Predecessor : SetVector<VPBlockBase *>(
-           VPBB->getPredecessors().begin(), VPBB->getPredecessors().end())) {
-    VPValue *EdgeMask = createEdgeMask(cast<VPBasicBlock>(Predecessor), VPBB);
-    if (!EdgeMask) { // Mask of predecessor is all-one so mask of block is
-                     // too.
-      setBlockInMask(VPBB, EdgeMask);
-      return;
-    }
+  auto AffectingBlocks = VPPDF.find(VPBB)->second;
+  for (VPBlockBase *AffectingBB : AffectingBlocks) {
+    // Switch can have multiple edges to the same successor, don't need to "or"
+    // it more than once.
+    SmallPtrSet<VPBlockBase *, 4> ProcessedSuccessors;
 
-    if (!BlockMask) { // BlockMask has its initial nullptr value.
-      BlockMask = EdgeMask;
-      continue;
-    }
+    for (auto *Succ : AffectingBB->successors()) {
+      if (!VPPDT.dominates(VPBB, Succ))
+        // That edge doesn't affect us:
+        continue;
 
-    BlockMask = Builder.createOr(BlockMask, EdgeMask, {});
+      if (!ProcessedSuccessors.insert(Succ).second)
+        continue;
+
+      VPValue *EdgeMask = createEdgeMask(cast<VPBasicBlock>(AffectingBB),
+                                         cast<VPBasicBlock>(Succ));
+      BlockMask =
+          BlockMask ? Builder.createOr(BlockMask, EdgeMask, {}) : EdgeMask;
+    }
   }
 
   setBlockInMask(VPBB, BlockMask);

--- a/llvm/lib/Transforms/Vectorize/VPlanPredicator.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanPredicator.cpp
@@ -152,6 +152,12 @@ void VPPredicator::createBlockInMask(VPBasicBlock *VPBB) {
     return;
   }
 
+  // Identify all branches/edges that **directly** control VPBB's mask, i.e.,
+  //   * control flow does not re-converge before reaching VPBB
+  //   * control flow does not branch further beore reaching VPBB
+  // Those conditional branches originate exactly in the post-dominance frontier
+  // of VPBB, with the edge destinations being post-dominated by VPBB.
+
   VPValue *BlockMask = nullptr;
   assert(VPPDF.find(VPBB) != VPPDF.end() &&
          "PostDomFrontier cannot be empty because header mask should have been "

--- a/llvm/lib/Transforms/Vectorize/VPlanPredicator.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanPredicator.cpp
@@ -141,9 +141,8 @@ void VPPredicator::createBlockInMask(VPBasicBlock *VPBB) {
   Builder.setInsertPoint(VPBB, VPBB->getFirstNonPhi());
 
   // Reuse the mask of the immediate dominator if the VPBB post-dominates it.
-  // This isn't "just" an optimization but is necessary for the
-  // post-dom-frontier-based mask creation to avoid (backward) tarversing the
-  // CFG past the loop header.
+  // This is also necessary to avoid traversing past the loop header in the post
+  // dominance frontier below.
   auto *IDom = VPDT.getNode(VPBB)->getIDom();
   assert(IDom && "Block in loop must have immediate dominator");
   auto *IDomBB = cast<VPBasicBlock>(IDom->getBlock());
@@ -152,21 +151,25 @@ void VPPredicator::createBlockInMask(VPBasicBlock *VPBB) {
     return;
   }
 
-  // Identify all branches/edges that **directly** control VPBB's mask, i.e.,
-  //   * control flow does not re-converge before reaching VPBB
-  //   * control flow does not branch further beore reaching VPBB
+  // Identify all edges that **directly** control VPBB's mask, i.e.,
+  //   * control flow does not fully reconverge before reaching VPBB
+  //   * control flow does not branch further before reaching VPBB
   // Those conditional branches originate exactly in the post-dominance frontier
   // of VPBB, with the edge destinations being post-dominated by VPBB.
 
   VPValue *BlockMask = nullptr;
-  assert(VPPDF.find(VPBB) != VPPDF.end() &&
+  auto It = VPPDF.find(VPBB);
+  assert(It != VPPDF.end() &&
          "PostDomFrontier cannot be empty because header mask should have been "
-         "re-used via IDom logic above.");
-  auto FrontierBlocks = VPPDF.find(VPBB)->second;
+         "reused via IDom logic above.");
+  auto FrontierBlocks = It->second;
   for (VPBlockBase *FrontierBB : FrontierBlocks) {
+    assert(FrontierBB->getParent() == VPBB->getParent() &&
+           "IDom logic above should have prevented going outside loop region "
+           "here!");
     // Switch can have multiple edges to the same successor, don't need to "or"
     // it more than once.
-    SmallPtrSet<VPBlockBase *, 4> ProcessedSuccessors;
+    SmallPtrSet<VPBlockBase *, 4> Visited;
 
     for (auto *Succ : FrontierBB->successors()) {
       if (!VPPDT.dominates(VPBB, Succ))
@@ -175,7 +178,7 @@ void VPPredicator::createBlockInMask(VPBasicBlock *VPBB) {
         // through another block in the post-dom-frontier.
         continue;
 
-      if (!ProcessedSuccessors.insert(Succ).second)
+      if (!Visited.insert(Succ).second)
         continue;
 
       VPValue *EdgeMask = createEdgeMask(cast<VPBasicBlock>(FrontierBB),
@@ -184,9 +187,8 @@ void VPPredicator::createBlockInMask(VPBasicBlock *VPBB) {
           BlockMask ? Builder.createOr(BlockMask, EdgeMask, {}) : EdgeMask;
     }
   }
-  assert(
-      BlockMask &&
-      "Header mask re-use expected to have happenned using IDom logic above.");
+  assert(BlockMask &&
+         "Header mask reuse expected to have happened using IDom logic above.");
 
   setBlockInMask(VPBB, BlockMask);
 }

--- a/llvm/lib/Transforms/Vectorize/VPlanPredicator.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanPredicator.cpp
@@ -35,6 +35,7 @@ class VPPredicator {
   VPPostDominatorTree VPPDT;
 
   /// Post-dominance frontier for the VPlan.
+  // NOTE: Must appear after VPPDT because VPPDT is used during initialization.
   VPPostDominanceFrontier VPPDF;
 
   /// When we if-convert we need to create edge masks. We have to cache values
@@ -136,11 +137,13 @@ VPValue *VPPredicator::createEdgeMask(const VPBasicBlock *Src,
 }
 
 void VPPredicator::createBlockInMask(VPBasicBlock *VPBB) {
-  // Start inserting after the block's phis, which be replaced by blends later.
+  // Insert after the block's phis, they will be replaced by blends later.
   Builder.setInsertPoint(VPBB, VPBB->getFirstNonPhi());
 
-  // Reuse the mask of the immediate dominator if the VPBB post-dominates the
-  // immediate dominator.
+  // Reuse the mask of the immediate dominator if the VPBB post-dominates it.
+  // This isn't "just" an optimization but is necessary for the
+  // post-dom-frontier-based mask creation to avoid (backward) tarversing the
+  // CFG past the loop header.
   auto *IDom = VPDT.getNode(VPBB)->getIDom();
   assert(IDom && "Block in loop must have immediate dominator");
   auto *IDomBB = cast<VPBasicBlock>(IDom->getBlock());
@@ -148,29 +151,36 @@ void VPPredicator::createBlockInMask(VPBasicBlock *VPBB) {
     setBlockInMask(VPBB, getBlockInMask(IDomBB));
     return;
   }
-  // All-one mask is modelled as no-mask following the convention for masked
-  // load/store/gather/scatter. Initialize BlockMask to no-mask.
+
   VPValue *BlockMask = nullptr;
-  auto AffectingBlocks = VPPDF.find(VPBB)->second;
-  for (VPBlockBase *AffectingBB : AffectingBlocks) {
+  assert(VPPDF.find(VPBB) != VPPDF.end() &&
+         "PostDomFrontier cannot be empty because header mask should have been "
+         "re-used via IDom logic above.");
+  auto FrontierBlocks = VPPDF.find(VPBB)->second;
+  for (VPBlockBase *FrontierBB : FrontierBlocks) {
     // Switch can have multiple edges to the same successor, don't need to "or"
     // it more than once.
     SmallPtrSet<VPBlockBase *, 4> ProcessedSuccessors;
 
-    for (auto *Succ : AffectingBB->successors()) {
+    for (auto *Succ : FrontierBB->successors()) {
       if (!VPPDT.dominates(VPBB, Succ))
-        // That edge doesn't affect us:
+        // That edge doesn't **directly** affect us. If VPBB is reachable
+        // through this edge, the condition it "carries" would be handled
+        // through another block in the post-dom-frontier.
         continue;
 
       if (!ProcessedSuccessors.insert(Succ).second)
         continue;
 
-      VPValue *EdgeMask = createEdgeMask(cast<VPBasicBlock>(AffectingBB),
+      VPValue *EdgeMask = createEdgeMask(cast<VPBasicBlock>(FrontierBB),
                                          cast<VPBasicBlock>(Succ));
       BlockMask =
           BlockMask ? Builder.createOr(BlockMask, EdgeMask, {}) : EdgeMask;
     }
   }
+  assert(
+      BlockMask &&
+      "Header mask re-use expected to have happenned using IDom logic above.");
 
   setBlockInMask(VPBB, BlockMask);
 }

--- a/llvm/lib/Transforms/Vectorize/VPlanPredicator.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanPredicator.cpp
@@ -137,7 +137,7 @@ VPValue *VPPredicator::createEdgeMask(const VPBasicBlock *Src,
 }
 
 void VPPredicator::createBlockInMask(VPBasicBlock *VPBB) {
-  // Insert after the block's phis, they will be replaced by blends later.
+  // Insert after the block's phis, which will be replaced by blends later.
   Builder.setInsertPoint(VPBB, VPBB->getFirstNonPhi());
 
   // Reuse the mask of the immediate dominator if the VPBB post-dominates it.
@@ -167,15 +167,15 @@ void VPPredicator::createBlockInMask(VPBasicBlock *VPBB) {
     assert(FrontierBB->getParent() == VPBB->getParent() &&
            "IDom logic above should have prevented going outside loop region "
            "here!");
-    // Switch can have multiple edges to the same successor, don't need to "or"
-    // it more than once.
+    // A switch can have multiple edges to the same successor, avoid adding such
+    // edges more than once.
     SmallPtrSet<VPBlockBase *, 4> Visited;
 
     for (auto *Succ : FrontierBB->successors()) {
       if (!VPPDT.dominates(VPBB, Succ))
-        // That edge doesn't **directly** affect us. If VPBB is reachable
-        // through this edge, the condition it "carries" would be handled
-        // through another block in the post-dom-frontier.
+        // This edge doesn't **directly** contribute to the VPBB's mask. If VPBB
+        // is reachable through this edge, the condition it "carries" will be
+        // handled through another block in the post-dom-frontier.
         continue;
 
       if (!Visited.insert(Succ).second)

--- a/llvm/test/Transforms/LoopVectorize/AArch64/drop-poison-generating-flags.ll
+++ b/llvm/test/Transforms/LoopVectorize/AArch64/drop-poison-generating-flags.ll
@@ -57,7 +57,7 @@ define void @check_widen_intrinsic_with_nnan(ptr noalias %dst.0, ptr noalias %ds
 ; CHECK-NEXT:    call void @llvm.masked.store.v4f64.p0(<4 x double> zeroinitializer, ptr align 8 [[TMP7]], <4 x i1> [[TMP4]])
 ; CHECK-NEXT:    [[TMP28:%.*]] = fcmp oeq <4 x double> [[TMP24]], zeroinitializer
 ; CHECK-NEXT:    [[TMP29:%.*]] = select <4 x i1> [[TMP4]], <4 x i1> [[TMP28]], <4 x i1> zeroinitializer
-; CHECK-NEXT:    [[TMP30:%.*]] = or <4 x i1> [[TMP5]], [[TMP29]]
+; CHECK-NEXT:    [[TMP30:%.*]] = or <4 x i1> [[TMP29]], [[TMP5]]
 ; CHECK-NEXT:    [[TMP32:%.*]] = getelementptr i32, ptr [[DST_1]], i64 [[TMP6]]
 ; CHECK-NEXT:    call void @llvm.masked.store.v4i32.p0(<4 x i32> splat (i32 10), ptr align 4 [[TMP32]], <4 x i1> [[TMP30]])
 ; CHECK-NEXT:    [[INDEX_NEXT]] = add nuw i64 [[INDEX]], 4

--- a/llvm/test/Transforms/LoopVectorize/AArch64/force-target-instruction-cost.ll
+++ b/llvm/test/Transforms/LoopVectorize/AArch64/force-target-instruction-cost.ll
@@ -183,11 +183,10 @@ define void @test_exit_branch_cost(ptr %dst, ptr noalias %x.ptr, ptr noalias %y.
 ; COMMON:       [[VECTOR_PH]]:
 ; COMMON-NEXT:    [[BROADCAST_SPLATINSERT:%.*]] = insertelement <2 x i1> poison, i1 [[C_3]], i64 0
 ; COMMON-NEXT:    [[BROADCAST_SPLAT:%.*]] = shufflevector <2 x i1> [[BROADCAST_SPLATINSERT]], <2 x i1> poison, <2 x i32> zeroinitializer
-; COMMON-NEXT:    [[BROADCAST_SPLATINSERT2:%.*]] = insertelement <2 x i1> poison, i1 [[C_4]], i64 0
-; COMMON-NEXT:    [[BROADCAST_SPLAT3:%.*]] = shufflevector <2 x i1> [[BROADCAST_SPLATINSERT2]], <2 x i1> poison, <2 x i32> zeroinitializer
 ; COMMON-NEXT:    [[TMP0:%.*]] = select i1 [[C_4]], <2 x i1> [[BROADCAST_SPLAT]], <2 x i1> zeroinitializer
 ; COMMON-NEXT:    [[TMP1:%.*]] = xor <2 x i1> [[TMP0]], splat (i1 true)
-; COMMON-NEXT:    [[TMP3:%.*]] = xor <2 x i1> [[BROADCAST_SPLAT3]], splat (i1 true)
+; COMMON-NEXT:    [[BROADCAST_SPLATINSERT2:%.*]] = insertelement <2 x i1> poison, i1 [[C_4]], i64 0
+; COMMON-NEXT:    [[BROADCAST_SPLAT3:%.*]] = shufflevector <2 x i1> [[BROADCAST_SPLATINSERT2]], <2 x i1> poison, <2 x i32> zeroinitializer
 ; COMMON-NEXT:    br label %[[VECTOR_BODY:.*]]
 ; COMMON:       [[VECTOR_BODY]]:
 ; COMMON-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[PRED_STORE_CONTINUE17:.*]] ]
@@ -222,7 +221,7 @@ define void @test_exit_branch_cost(ptr %dst, ptr noalias %x.ptr, ptr noalias %y.
 ; COMMON:       [[PRED_STORE_CONTINUE9]]:
 ; COMMON-NEXT:    [[TMP22:%.*]] = select <2 x i1> [[TMP7]], <2 x i1> [[BROADCAST_SPLAT]], <2 x i1> zeroinitializer
 ; COMMON-NEXT:    [[TMP13:%.*]] = select <2 x i1> [[TMP22]], <2 x i1> [[BROADCAST_SPLAT3]], <2 x i1> zeroinitializer
-; COMMON-NEXT:    [[TMP14:%.*]] = or <2 x i1> [[TMP6]], [[TMP13]]
+; COMMON-NEXT:    [[TMP14:%.*]] = or <2 x i1> [[TMP13]], [[TMP6]]
 ; COMMON-NEXT:    [[PREDPHI:%.*]] = select <2 x i1> [[TMP13]], <2 x i64> zeroinitializer, <2 x i64> splat (i64 1)
 ; COMMON-NEXT:    [[TMP15:%.*]] = extractelement <2 x i1> [[TMP14]], i32 0
 ; COMMON-NEXT:    br i1 [[TMP15]], label %[[PRED_STORE_IF10:.*]], label %[[PRED_STORE_CONTINUE11:.*]]
@@ -238,20 +237,19 @@ define void @test_exit_branch_cost(ptr %dst, ptr noalias %x.ptr, ptr noalias %y.
 ; COMMON-NEXT:    store i64 [[TMP18]], ptr [[DST_2]], align 8
 ; COMMON-NEXT:    br label %[[PRED_STORE_CONTINUE13]]
 ; COMMON:       [[PRED_STORE_CONTINUE13]]:
-; COMMON-NEXT:    [[TMP19:%.*]] = select <2 x i1> [[TMP22]], <2 x i1> [[TMP3]], <2 x i1> zeroinitializer
-; COMMON-NEXT:    [[TMP20:%.*]] = or <2 x i1> [[TMP14]], [[TMP19]]
+; COMMON-NEXT:    [[TMP20:%.*]] = or <2 x i1> [[TMP6]], [[TMP22]]
 ; COMMON-NEXT:    [[TMP21:%.*]] = extractelement <2 x i1> [[TMP20]], i32 0
 ; COMMON-NEXT:    br i1 [[TMP21]], label %[[PRED_STORE_IF14:.*]], label %[[PRED_STORE_CONTINUE15:.*]]
 ; COMMON:       [[PRED_STORE_IF14]]:
-; COMMON-NEXT:    [[TMP24:%.*]] = load i64, ptr [[SRC]], align 8, !alias.scope [[META7:![0-9]+]]
-; COMMON-NEXT:    store i64 [[TMP24]], ptr [[DST]], align 8, !alias.scope [[META10:![0-9]+]], !noalias [[META7]]
+; COMMON-NEXT:    [[TMP19:%.*]] = load i64, ptr [[SRC]], align 8, !alias.scope [[META7:![0-9]+]]
+; COMMON-NEXT:    store i64 [[TMP19]], ptr [[DST]], align 8, !alias.scope [[META10:![0-9]+]], !noalias [[META7]]
 ; COMMON-NEXT:    br label %[[PRED_STORE_CONTINUE15]]
 ; COMMON:       [[PRED_STORE_CONTINUE15]]:
 ; COMMON-NEXT:    [[TMP23:%.*]] = extractelement <2 x i1> [[TMP20]], i32 1
 ; COMMON-NEXT:    br i1 [[TMP23]], label %[[PRED_STORE_IF16:.*]], label %[[PRED_STORE_CONTINUE17]]
 ; COMMON:       [[PRED_STORE_IF16]]:
-; COMMON-NEXT:    [[TMP26:%.*]] = load i64, ptr [[SRC]], align 8, !alias.scope [[META7]]
-; COMMON-NEXT:    store i64 [[TMP26]], ptr [[DST]], align 8, !alias.scope [[META10]], !noalias [[META7]]
+; COMMON-NEXT:    [[TMP24:%.*]] = load i64, ptr [[SRC]], align 8, !alias.scope [[META7]]
+; COMMON-NEXT:    store i64 [[TMP24]], ptr [[DST]], align 8, !alias.scope [[META10]], !noalias [[META7]]
 ; COMMON-NEXT:    br label %[[PRED_STORE_CONTINUE17]]
 ; COMMON:       [[PRED_STORE_CONTINUE17]]:
 ; COMMON-NEXT:    [[INDEX_NEXT]] = add nuw i64 [[INDEX]], 2

--- a/llvm/test/Transforms/LoopVectorize/RISCV/pr87378-vpinstruction-or-drop-poison-generating-flags.ll
+++ b/llvm/test/Transforms/LoopVectorize/RISCV/pr87378-vpinstruction-or-drop-poison-generating-flags.ll
@@ -36,7 +36,7 @@ define void @pr87378_vpinstruction_or_drop_poison_generating_flags(ptr %arg, i64
 ; CHECK-NEXT:    [[TMP19:%.*]] = select <vscale x 8 x i1> [[TMP17]], <vscale x 8 x i1> [[TMP18]], <vscale x 8 x i1> zeroinitializer
 ; CHECK-NEXT:    [[TMP20:%.*]] = xor <vscale x 8 x i1> [[TMP14]], splat (i1 true)
 ; CHECK-NEXT:    [[TMP21:%.*]] = select <vscale x 8 x i1> [[TMP13]], <vscale x 8 x i1> [[TMP20]], <vscale x 8 x i1> zeroinitializer
-; CHECK-NEXT:    [[TMP22:%.*]] = or <vscale x 8 x i1> [[TMP19]], [[TMP21]]
+; CHECK-NEXT:    [[TMP22:%.*]] = or <vscale x 8 x i1> [[TMP21]], [[TMP19]]
 ; CHECK-NEXT:    [[TMP24:%.*]] = getelementptr i16, ptr [[ARG]], i64 [[INDEX]]
 ; CHECK-NEXT:    call void @llvm.vp.store.nxv8i16.p0(<vscale x 8 x i16> zeroinitializer, ptr align 2 [[TMP24]], <vscale x 8 x i1> [[TMP22]], i32 [[TMP25]])
 ; CHECK-NEXT:    [[INDEX_NEXT]] = add nuw i64 [[TMP8]], [[INDEX]]

--- a/llvm/test/Transforms/LoopVectorize/RISCV/tail-folding-complex-mask.ll
+++ b/llvm/test/Transforms/LoopVectorize/RISCV/tail-folding-complex-mask.ll
@@ -20,7 +20,7 @@ define void @test(i64 %n, ptr noalias %src0, ptr noalias %src1, ptr noalias %src
 ; IF-EVL-NEXT:    [[BROADCAST_SPLAT2:%.*]] = shufflevector <vscale x 4 x i1> [[BROADCAST_SPLATINSERT1]], <vscale x 4 x i1> poison, <vscale x 4 x i32> zeroinitializer
 ; IF-EVL-NEXT:    [[TMP1:%.*]] = or <vscale x 4 x i1> [[BROADCAST_SPLAT]], [[BROADCAST_SPLAT2]]
 ; IF-EVL-NEXT:    [[TMP3:%.*]] = select <vscale x 4 x i1> [[TMP2]], <vscale x 4 x i1> [[TMP1]], <vscale x 4 x i1> zeroinitializer
-; IF-EVL-NEXT:    [[TMP4:%.*]] = or <vscale x 4 x i1> [[BROADCAST_SPLAT]], [[TMP3]]
+; IF-EVL-NEXT:    [[TMP4:%.*]] = or <vscale x 4 x i1> [[TMP3]], [[BROADCAST_SPLAT]]
 ; IF-EVL-NEXT:    [[BROADCAST_SPLATINSERT3:%.*]] = insertelement <vscale x 4 x i1> poison, i1 [[C3]], i64 0
 ; IF-EVL-NEXT:    [[BROADCAST_SPLAT4:%.*]] = shufflevector <vscale x 4 x i1> [[BROADCAST_SPLATINSERT3]], <vscale x 4 x i1> poison, <vscale x 4 x i32> zeroinitializer
 ; IF-EVL-NEXT:    br label %[[VECTOR_BODY:.*]]
@@ -76,7 +76,7 @@ define void @test(i64 %n, ptr noalias %src0, ptr noalias %src1, ptr noalias %src
 ; NO-VP-NEXT:    [[BROADCAST_SPLAT4:%.*]] = shufflevector <vscale x 4 x i1> [[BROADCAST_SPLATINSERT3]], <vscale x 4 x i1> poison, <vscale x 4 x i32> zeroinitializer
 ; NO-VP-NEXT:    [[TMP9:%.*]] = or <vscale x 4 x i1> [[BROADCAST_SPLAT2]], [[BROADCAST_SPLAT4]]
 ; NO-VP-NEXT:    [[TMP10:%.*]] = select <vscale x 4 x i1> [[TMP6]], <vscale x 4 x i1> [[TMP9]], <vscale x 4 x i1> zeroinitializer
-; NO-VP-NEXT:    [[TMP8:%.*]] = or <vscale x 4 x i1> [[BROADCAST_SPLAT2]], [[TMP10]]
+; NO-VP-NEXT:    [[TMP8:%.*]] = or <vscale x 4 x i1> [[TMP10]], [[BROADCAST_SPLAT2]]
 ; NO-VP-NEXT:    [[BROADCAST_SPLATINSERT4:%.*]] = insertelement <vscale x 4 x i1> poison, i1 [[C3]], i64 0
 ; NO-VP-NEXT:    [[TMP12:%.*]] = shufflevector <vscale x 4 x i1> [[BROADCAST_SPLATINSERT4]], <vscale x 4 x i1> poison, <vscale x 4 x i32> zeroinitializer
 ; NO-VP-NEXT:    br label %[[VECTOR_BODY:.*]]

--- a/llvm/test/Transforms/LoopVectorize/VPlan/predicator.ll
+++ b/llvm/test/Transforms/LoopVectorize/VPlan/predicator.ll
@@ -192,18 +192,17 @@ define void @optimized_mask(ptr %a) {
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    bb5:
 ; CHECK-NEXT:      EMIT vp<[[VP10:%[0-9]+]]> = logical-and vp<[[VP4]]>, ir<%c6>
-; CHECK-NEXT:      EMIT vp<[[VP11:%[0-9]+]]> = or vp<[[VP10]]>, vp<[[VP9]]>
+; CHECK-NEXT:      EMIT vp<[[VP11:%[0-9]+]]> = or vp<[[VP10]]>, ir<%c0>
 ; CHECK-NEXT:      EMIT vp<[[VP12:%[0-9]+]]> = not ir<%c3>
 ; CHECK-NEXT:      EMIT vp<[[VP13:%[0-9]+]]> = logical-and vp<[[VP6]]>, vp<[[VP12]]>
-; CHECK-NEXT:      EMIT vp<[[VP14:%[0-9]+]]> = or vp<[[VP11]]>, vp<[[VP13]]>
 ; CHECK-NEXT:      BLEND ir<%phi5> = ir<%add6>/vp<[[VP10]]> ir<%add4>/vp<[[VP9]]> ir<%add3>/vp<[[VP13]]>
-; CHECK-NEXT:      EMIT ir<%add5> = add ir<%iv>, ir<5>, vp<[[VP14]]>
+; CHECK-NEXT:      EMIT ir<%add5> = add ir<%iv>, ir<5>, vp<[[VP11]]>
 ; CHECK-NEXT:    Successor(s): bb7
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    bb7:
-; CHECK-NEXT:      EMIT vp<[[VP15:%[0-9]+]]> = not ir<%c6>
-; CHECK-NEXT:      EMIT vp<[[VP16:%[0-9]+]]> = logical-and vp<[[VP4]]>, vp<[[VP15]]>
-; CHECK-NEXT:      BLEND ir<%phi7> = ir<%add6>/vp<[[VP16]]> ir<%add5>/vp<[[VP14]]>
+; CHECK-NEXT:      EMIT vp<[[VP14:%[0-9]+]]> = not ir<%c6>
+; CHECK-NEXT:      EMIT vp<[[VP15:%[0-9]+]]> = logical-and vp<[[VP4]]>, vp<[[VP14]]>
+; CHECK-NEXT:      BLEND ir<%phi7> = ir<%add6>/vp<[[VP15]]> ir<%add5>/vp<[[VP11]]>
 ; CHECK-NEXT:      EMIT store ir<%phi7>, ir<%gep>
 ; CHECK-NEXT:      EMIT ir<%iv.next> = add nuw nsw ir<%iv>, ir<1>
 ; CHECK-NEXT:      EMIT ir<%ec> = icmp eq ir<%iv.next>, ir<128>
@@ -229,7 +228,7 @@ bb0:
 ;             bb5  /
 ;               \ /
 ;               bb7
-; TODO: bb5's mask shouldn't depend on c1/c3.
+; Verify bb5's mask is "c0 || (!c0 && c6)" and doesn't depend on c1/c3.
   %iv = phi i64 [0, %entry], [%iv.next, %bb7]
   %gep = getelementptr i64, ptr %a, i64 %iv
   %c0 = icmp sle i64 %iv, 0
@@ -513,10 +512,11 @@ define void @blend_masks(ptr noalias %p, i1 %c0, i1 %c1, i1 %c2, i1 %c3, i1 %c4)
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    bb7:
 ; CHECK-NEXT:      EMIT vp<[[VP15:%[0-9]+]]> = logical-and vp<[[VP9]]>, ir<%c4>
-; CHECK-NEXT:      EMIT vp<[[VP16:%[0-9]+]]> = or vp<[[VP15]]>, vp<[[VP14]]>
+; CHECK-NEXT:      EMIT vp<[[VP16:%[0-9]+]]> = or vp<[[VP15]]>, vp<[[VP11]]>
+; CHECK-NEXT:      EMIT vp<[[VP17:%[0-9]+]]> = or vp<[[VP16]]>, vp<[[VP13]]>
 ; CHECK-NEXT:      BLEND ir<%phi> = ir<1>/vp<[[VP15]]> ir<0>/vp<[[VP14]]>
 ; CHECK-NEXT:      EMIT ir<%gep> = getelementptr ir<%p>, ir<%iv>
-; CHECK-NEXT:      EMIT store ir<%phi>, ir<%gep>, vp<[[VP16]]>
+; CHECK-NEXT:      EMIT store ir<%phi>, ir<%gep>, vp<[[VP17]]>
 ; CHECK-NEXT:    Successor(s): bb8
 ; CHECK-EMPTY:
 ; CHECK-NEXT:    bb8:

--- a/llvm/test/Transforms/LoopVectorize/X86/predicate-switch.ll
+++ b/llvm/test/Transforms/LoopVectorize/X86/predicate-switch.ll
@@ -1192,8 +1192,8 @@ define void @br_under_switch_default_common_dest_with_case(ptr %start, ptr %end,
 ; FORCED-NEXT:    [[TMP33:%.*]] = select <4 x i1> [[TMP10]], <4 x i1> [[TMP18]], <4 x i1> zeroinitializer
 ; FORCED-NEXT:    call void @llvm.masked.store.v4i64.p0(<4 x i64> splat (i64 42), ptr align 1 [[NEXT_GEP]], <4 x i1> [[TMP32]])
 ; FORCED-NEXT:    call void @llvm.masked.store.v4i64.p0(<4 x i64> splat (i64 42), ptr align 1 [[TMP8]], <4 x i1> [[TMP33]])
-; FORCED-NEXT:    [[TMP36:%.*]] = or <4 x i1> [[TMP32]], [[TMP15]]
-; FORCED-NEXT:    [[TMP37:%.*]] = or <4 x i1> [[TMP33]], [[TMP16]]
+; FORCED-NEXT:    [[TMP36:%.*]] = or <4 x i1> [[TMP15]], [[TMP32]]
+; FORCED-NEXT:    [[TMP37:%.*]] = or <4 x i1> [[TMP16]], [[TMP33]]
 ; FORCED-NEXT:    call void @llvm.masked.store.v4i64.p0(<4 x i64> splat (i64 2), ptr align 1 [[NEXT_GEP]], <4 x i1> [[TMP36]])
 ; FORCED-NEXT:    call void @llvm.masked.store.v4i64.p0(<4 x i64> splat (i64 2), ptr align 1 [[TMP8]], <4 x i1> [[TMP37]])
 ; FORCED-NEXT:    [[INDEX_NEXT]] = add nuw i64 [[INDEX]], 8

--- a/llvm/test/Transforms/LoopVectorize/predicator.ll
+++ b/llvm/test/Transforms/LoopVectorize/predicator.ll
@@ -101,10 +101,10 @@ define void @blend_masks(ptr noalias %p, i1 %c0, i1 %c1, i1 %c3, i1 %c4, i1 %c6)
 ; CHECK-NEXT:    [[TMP7:%.*]] = select <4 x i1> [[TMP2]], <4 x i1> [[BROADCAST_SPLAT4]], <4 x i1> zeroinitializer
 ; CHECK-NEXT:    [[TMP8:%.*]] = xor <4 x i1> [[BROADCAST_SPLAT]], splat (i1 true)
 ; CHECK-NEXT:    [[TMP9:%.*]] = select <4 x i1> [[TMP6]], <4 x i1> [[TMP8]], <4 x i1> zeroinitializer
-; CHECK-NEXT:    [[TMP10:%.*]] = or <4 x i1> [[TMP7]], [[TMP9]]
 ; CHECK-NEXT:    [[TMP11:%.*]] = select <4 x i1> [[TMP5]], <4 x i1> [[BROADCAST_SPLAT2]], <4 x i1> zeroinitializer
-; CHECK-NEXT:    [[TMP12:%.*]] = or <4 x i1> [[TMP11]], [[TMP10]]
-; CHECK-NEXT:    [[PREDPHI:%.*]] = select <4 x i1> [[TMP10]], <4 x i32> zeroinitializer, <4 x i32> splat (i32 1)
+; CHECK-NEXT:    [[TMP13:%.*]] = or <4 x i1> [[TMP11]], [[TMP7]]
+; CHECK-NEXT:    [[TMP12:%.*]] = or <4 x i1> [[TMP13]], [[TMP9]]
+; CHECK-NEXT:    [[PREDPHI:%.*]] = select <4 x i1> [[TMP11]], <4 x i32> splat (i32 1), <4 x i32> zeroinitializer
 ; CHECK-NEXT:    br label %[[PRED_STORE_CONTINUE12:.*]]
 ; CHECK:       [[PRED_STORE_CONTINUE12]]:
 ; CHECK-NEXT:    [[TMP26:%.*]] = phi i32 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[PRED_STORE_CONTINUE12]] ]

--- a/llvm/unittests/Transforms/Vectorize/VPPostDomFrontierTest.cpp
+++ b/llvm/unittests/Transforms/Vectorize/VPPostDomFrontierTest.cpp
@@ -51,8 +51,7 @@ TEST_F(VPPostDomFrontierTest, SingleExitTest) {
   VPBlockUtils::connectBlocks(VPBB6, VPBB7);
 
   VPPostDominatorTree VPPDT(Plan);
-  DominanceFrontierBase<VPBlockBase, true> VPPDF;
-  VPPDF.analyze(VPPDT);
+  VPPostDominanceFrontier VPPDF(VPPDT);
 
   EXPECT_TRUE(VPPDF.find(VPBB0) != VPPDF.end());
   EXPECT_TRUE(VPPDF.find(VPBB1) != VPPDF.end());
@@ -117,7 +116,7 @@ TEST_F(VPPostDomFrontierTest, MultipleExitsTest) {
   VPBlockUtils::connectBlocks(VPBB5, VPBB6);
 
   VPPostDominatorTree VPPDT(Plan);
-  DominanceFrontierBase<VPBlockBase, true> VPPDF;
+  VPPostDominanceFrontier VPPDF(VPPDT);
   VPPDF.analyze(VPPDT);
 
   EXPECT_TRUE(VPPDF.find(VPBB0) != VPPDF.end());


### PR DESCRIPTION
This optimizes the case below (from `VPlan/predicator.ll`):

```
               bb0:
              /   \
             /     \
          bb1       bb6
          /  \      / |
        bb2  bb3   /  /
          \  /|   /  /
           bb4|  /  /
            \ | /  /
             bb5  /
               \ /
               bb7
Verify bb5's mask is "c0 || (!c0 && c6)" and doesn't depend on c1/c3.
```