### PR TITLE
[OFFLOAD] Add Device properties required for libomptarget migration

### DIFF
--- a/offload/liboffload/API/Device.td
+++ b/offload/liboffload/API/Device.td
@@ -44,6 +44,8 @@ def ol_device_info_t : Enum {
     TaggedEtor<"MAX_MEM_ALLOC_SIZE", "uint64_t", "The maximum size of memory object allocation in bytes">,
     TaggedEtor<"GLOBAL_MEM_SIZE", "uint64_t", "The size of global device memory in bytes">,
     TaggedEtor<"WORK_GROUP_LOCAL_MEM_SIZE", "uint64_t", "The maximum size of local shared memory per work group in bytes">,
+    TaggedEtor<"IS_VA_SUPPORTED", "bool", "Is virtual address management supported on this device.">,
+    TaggedEtor<"USE_AUTO_ZERO_COPY", "bool", "Use Auto Zero Copy">,
   ];
   list<TaggedEtor> fp_configs = !foreach(type, ["Single", "Double", "Half"], TaggedEtor<type # "_FP_CONFIG", "ol_device_fp_capability_flags_t", type # " precision floating point capability">);
   list<TaggedEtor> native_vec_widths = !foreach(type, ["char","short","int","long","float","double","half"], TaggedEtor<"NATIVE_VECTOR_WIDTH_" # type, "uint32_t", "Native vector width for " # type>);

--- a/offload/liboffload/src/OffloadImpl.cpp
+++ b/offload/liboffload/src/OffloadImpl.cpp
@@ -469,6 +469,11 @@ Error olGetDeviceInfoImplDetail(ol_device_handle_t Device,
     return Info.write<uint64_t>(Mem);
   } break;
 
+  case OL_DEVICE_INFO_IS_VA_SUPPORTED:
+    return Info.write<bool>(Device->Device->supportVAManagement());
+  case OL_DEVICE_INFO_USE_AUTO_ZERO_COPY:
+    return Info.write<bool>(Device->Device->useAutoZeroCopy());
+
   default:
     break;
   }

--- a/offload/unittests/OffloadAPI/device/olGetDeviceInfo.cpp
+++ b/offload/unittests/OffloadAPI/device/olGetDeviceInfo.cpp
@@ -222,6 +222,8 @@ OL_DEVICE_INFO_TEST_DEVICE_VALUE_GT(SharedMemSize, uint64_t,
                                     0);
 OL_DEVICE_INFO_TEST_HOST_SUCCESS(SharedMemSize, uint64_t,
                                  OL_DEVICE_INFO_WORK_GROUP_LOCAL_MEM_SIZE);
+OL_DEVICE_INFO_TEST_SUCCESS(IsVASupported, bool, OL_DEVICE_INFO_IS_VA_SUPPORTED);
+OL_DEVICE_INFO_TEST_SUCCESS(UseAutoZeroCopy, bool, OL_DEVICE_INFO_USE_AUTO_ZERO_COPY);
 
 TEST_P(olGetDeviceInfoTest, InvalidNullHandleDevice) {
   ol_device_type_t DeviceType;

--- a/offload/unittests/OffloadAPI/device/olGetDeviceInfo.cpp
+++ b/offload/unittests/OffloadAPI/device/olGetDeviceInfo.cpp
@@ -222,8 +222,10 @@ OL_DEVICE_INFO_TEST_DEVICE_VALUE_GT(SharedMemSize, uint64_t,
                                     0);
 OL_DEVICE_INFO_TEST_HOST_SUCCESS(SharedMemSize, uint64_t,
                                  OL_DEVICE_INFO_WORK_GROUP_LOCAL_MEM_SIZE);
-OL_DEVICE_INFO_TEST_SUCCESS(IsVASupported, bool, OL_DEVICE_INFO_IS_VA_SUPPORTED);
-OL_DEVICE_INFO_TEST_SUCCESS(UseAutoZeroCopy, bool, OL_DEVICE_INFO_USE_AUTO_ZERO_COPY);
+OL_DEVICE_INFO_TEST_SUCCESS(IsVASupported, bool,
+                            OL_DEVICE_INFO_IS_VA_SUPPORTED);
+OL_DEVICE_INFO_TEST_SUCCESS(UseAutoZeroCopy, bool,
+                            OL_DEVICE_INFO_USE_AUTO_ZERO_COPY);
 
 TEST_P(olGetDeviceInfoTest, InvalidNullHandleDevice) {
   ol_device_type_t DeviceType;

--- a/offload/unittests/OffloadAPI/device/olGetDeviceInfoSize.cpp
+++ b/offload/unittests/OffloadAPI/device/olGetDeviceInfoSize.cpp
@@ -73,6 +73,10 @@ OL_DEVICE_INFO_SIZE_TEST_EQ(GlobalMemSize, uint64_t,
                             OL_DEVICE_INFO_GLOBAL_MEM_SIZE);
 OL_DEVICE_INFO_SIZE_TEST_EQ(SharedMemSize, uint64_t,
                             OL_DEVICE_INFO_WORK_GROUP_LOCAL_MEM_SIZE);
+OL_DEVICE_INFO_SIZE_TEST_EQ(IsVASupported, bool,
+                            OL_DEVICE_INFO_IS_VA_SUPPORTED);
+OL_DEVICE_INFO_SIZE_TEST_EQ(UseAutoZeroCopy, bool,
+                            OL_DEVICE_INFO_USE_AUTO_ZERO_COPY);
 
 TEST_P(olGetDeviceInfoSizeTest, SuccessMaxWorkGroupSizePerDimension) {
   size_t Size = 0;


### PR DESCRIPTION
This PR adds liboffload device properties that needed to migrate libomptarget to use liboffload