### PR TITLE
[lldb][windows] fix MSVCRTCFrameRecognizer's registration

### DIFF
--- a/lldb/source/Plugins/Process/Windows/Common/MSVCRTCFrameRecognizer.cpp
+++ b/lldb/source/Plugins/Process/Windows/Common/MSVCRTCFrameRecognizer.cpp
@@ -23,7 +23,7 @@ namespace lldb_private {
 
 void RegisterMSVCRTCFrameRecognizer(ProcessWindows &process) {
   process.GetTarget().GetFrameRecognizerManager().AddRecognizer(
-      std::make_shared<MSVCRTCFrameRecognizer>(), ConstString(),
+      std::make_shared<MSVCRTCFrameRecognizer>(), ConstString(""),
       {ConstString("failwithmessage")}, Mangled::ePreferDemangled,
       /*first_instruction_only=*/false);
 }


### PR DESCRIPTION
This patch fixes a test failure which was introduced by https://github.com/llvm/llvm-project/pull/185473.

The default constructor for `ConstString` is `std::string(nullptr)` which is invalid.