### PR TITLE
[C2y] Update the C Status Page from the recent meetings

### DIFF
--- a/clang/www/c_status.html
+++ b/clang/www/c_status.html
@@ -361,6 +361,53 @@ conformance.</p>
       <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n3532.pdf">N3532</a></td>
       <td class="full" align="center">Yes</td>
 	</tr>
+    <!-- Virtual Feb 2026 Papers -->
+    <tr>
+      <td>Retire the concept of consume operations</td>
+      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n3607.htm">N3607</a></td>
+      <td class="unknown" align="center">Unknown</td>
+    </tr>
+    <tr>
+      <td>Allow calling static inline within extern inline</td>
+      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n3622.txt">N3622</a></td>
+      <td class="unknown" align="center">Unknown</td>
+    </tr>
+    <tr>
+      <td>Static assertions in expressions</td>
+      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n3715.pdf">N3715</a></td>
+      <td class="none" align="center">No</td>
+    </tr>
+    <tr>
+      <td>Integer Sets</td>
+      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n3747.pdf">N3747</a></td>
+      <td class="unknown" align="center">Unknown</td>
+    </tr>
+    <tr>
+      <td>Remove the imaginary I</td>
+      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n3786.htm">N3786</a></td>
+      <td class="unknown" align="center">Unknown</td>
+    </tr>
+    <tr>
+      <td>Earthly Demon: Accessing a Member of an Atomic Structure or Union</td>
+      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n3653.pdf">N3653</a></td>
+      <td class="unknown" align="center">Unknown</td>
+    </tr>
+    <!-- Virtual Mar 2026 Papers -->
+    <tr>
+      <td>Integer Constant Expression-Initialized const Integer Declarations are Implicitly constexpr</td>
+      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n3693.htm">N3693</a></td>
+      <td class="unknown" align="center">Unknown</td>
+    </tr>
+    <tr>
+      <td>bit-precise enum</td>
+      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n3705.htm">N3705</a></td>
+      <td class="none" align="center">No</td>
+    </tr>
+    <tr>
+      <td>Generic replacement</td> <!-- both changes from paper were adopted -->
+      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n3722.pdf">N3722</a></td>
+      <td class="unknown" align="center">Unknown</td>
+    </tr>
 </table>
 </details>
 


### PR DESCRIPTION
The Feb and Mar 2026 virtual meetings are now concluded, these are the adopted papers which could potentially impact the compiler.