### PR TITLE
[RISCV][P-ext] Remove unecessary AND from packed shift amounts.

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVInstrInfo.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfo.td
@@ -1503,7 +1503,7 @@ def : Pat<(XLenVT (and GPR:$rs, immop_oneuse<TrailingOnesMask>:$mask)),
 // zero-extends it). For RISC-V, the mask is unnecessary as shifts in the base
 // ISA only read the least significant 5 bits (RV32I) or 6 bits (RV64I).
 def shiftMaskXLen : ComplexPattern<XLenVT, 1, "selectShiftMaskXLen", [], [], 0>;
-def shiftMask32   : ComplexPattern<i64, 1, "selectShiftMask<32>", [], [], 0>;
+def shiftMask32   : ComplexPattern<XLenVT, 1, "selectShiftMask<32>", [], [], 0>;
 // FIXME: This is labelled as handling 's32', however the ComplexPattern it
 // refers to handles both i32 and i64 based on the HwMode. Currently this LLT
 // parameter appears to be ignored so this pattern works for both, however we
@@ -1516,12 +1516,14 @@ def GIShiftMask32 :
     GIComplexOperandMatcher<s64, "selectShiftMask32">,
     GIComplexPatternEquiv<shiftMask32>;
 
+class PatGprShiftMask<SDPatternOperator OpNode, RVInst Inst,
+                      ComplexPattern ShiftMask, ValueType vt = XLenVT>
+    : Pat<(vt (OpNode GPR:$rs1, ShiftMask:$rs2)),
+          (Inst GPR:$rs1, ShiftMask:$rs2)>;
 class PatGprShiftMaskXLen<SDPatternOperator OpNode, RVInst Inst>
-    : Pat<(OpNode GPR:$rs1, shiftMaskXLen:$rs2),
-          (Inst GPR:$rs1, shiftMaskXLen:$rs2)>;
+    : PatGprShiftMask<OpNode, Inst, shiftMaskXLen>;
 class PatGprShiftMask32<SDPatternOperator OpNode, RVInst Inst>
-    : Pat<(OpNode GPR:$rs1, shiftMask32:$rs2),
-          (Inst GPR:$rs1, shiftMask32:$rs2)>;
+    : PatGprShiftMask<OpNode, Inst, shiftMask32, i64>;
 
 def : PatGprShiftMaskXLen<shl, SLL>;
 def : PatGprShiftMaskXLen<srl, SRL>;

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoP.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoP.td
@@ -1643,14 +1643,16 @@ def riscv_wsla : RVSDNode<"WSLA", SDT_RISCVWideningShiftLeft>;
 // Narrowing shift: res = nsrl(lo, hi, shamt) is equivalent to
 // res = truncate (srl (build_pair lo, hi), shamt), XLenVT
 def SDT_RISCVNarrowingShift : SDTypeProfile<1, 3, [SDTCisVT<0, i32>,
-                                                   SDTCisVT<1, i32>,
-                                                   SDTCisVT<2, i32>,
-                                                   SDTCisVT<3, i32>]>;
+                                                   SDTCisSameAs<0, 1>,
+                                                   SDTCisSameAs<0, 2>,
+                                                   SDTCisSameAs<0, 3>]>;
 def riscv_nsrl : RVSDNode<"NSRL", SDT_RISCVNarrowingShift>;
 def riscv_nsra : RVSDNode<"NSRA", SDT_RISCVNarrowingShift>;
 
 // ComplexPattern for 64-bit shift mask (NSRL/NSRA only read 6 bits).
-def shiftMask64 : ComplexPattern<i32, 1, "selectShiftMask<64>", [], [], 0>;
+def shiftMask64 : ComplexPattern<XLenVT, 1, "selectShiftMask<64>", [], [], 0>;
+def shiftMask8 : ComplexPattern<XLenVT, 1, "selectShiftMask<8>", [], [], 0>;
+def shiftMask16 : ComplexPattern<XLenVT, 1, "selectShiftMask<16>", [], [], 0>;
 
 // Build a GPRPair from two GPR registers for narrowing shift instructions.
 def BuildGPRPair : OutPatFrag<(ops node:$lo, node:$hi),
@@ -1800,24 +1802,18 @@ let Predicates = [HasStdExtP] in {
   def : PatGprImm<riscv_psslai, PSSLAI_H, timm, XLenVecI16VT>;
 
   // 8-bit logical shift left/right
-  def : Pat<(XLenVecI8VT (riscv_pshl GPR:$rs1, GPR:$rs2)),
-            (PSLL_BS GPR:$rs1, GPR:$rs2)>;
-  def : Pat<(XLenVecI8VT (riscv_psrl GPR:$rs1, GPR:$rs2)),
-            (PSRL_BS GPR:$rs1, GPR:$rs2)>;
+  def : PatGprShiftMask<riscv_pshl, PSLL_BS, shiftMask8, XLenVecI8VT>;
+  def : PatGprShiftMask<riscv_psrl, PSRL_BS, shiftMask8, XLenVecI8VT>;
 
   // 8-bit arithmetic shift left/right
-  def : Pat<(XLenVecI8VT (riscv_psra GPR:$rs1, GPR:$rs2)),
-            (PSRA_BS GPR:$rs1, GPR:$rs2)>;
+  def : PatGprShiftMask<riscv_psra, PSRA_BS, shiftMask8, XLenVecI8VT>;
 
   // 16-bit logical shift left/right
-  def : Pat<(XLenVecI16VT (riscv_pshl GPR:$rs1, GPR:$rs2)),
-            (PSLL_HS GPR:$rs1, GPR:$rs2)>;
-  def : Pat<(XLenVecI16VT (riscv_psrl GPR:$rs1, GPR:$rs2)),
-            (PSRL_HS GPR:$rs1, GPR:$rs2)>;
+  def : PatGprShiftMask<riscv_pshl, PSLL_HS, shiftMask16, XLenVecI16VT>;
+  def : PatGprShiftMask<riscv_psrl, PSRL_HS, shiftMask16, XLenVecI16VT>;
 
   // 16-bit arithmetic shift left/right
-  def : Pat<(XLenVecI16VT (riscv_psra GPR:$rs1, GPR:$rs2)),
-            (PSRA_HS GPR:$rs1, GPR:$rs2)>;
+  def : PatGprShiftMask<riscv_psra, PSRA_HS, shiftMask16, XLenVecI16VT>;
 
   // // splat pattern
   def : Pat<(XLenVecI8VT (splat_vector (XLenVT GPR:$rs2))), (PADD_BS (XLenVT X0), GPR:$rs2)>;
@@ -1862,14 +1858,14 @@ let Predicates = [HasStdExtP, IsRV32] in {
 
   // Narrowing shift patterns (NSRL/NSRA)
   // Immediate shift amount patterns
-  def : Pat<(i32 (riscv_nsrl GPR:$lo, GPR:$hi, uimm6:$shamt)),
+  def : Pat<(riscv_nsrl GPR:$lo, GPR:$hi, uimm6:$shamt),
             (NSRLI (BuildGPRPair GPR:$lo, GPR:$hi), uimm6:$shamt)>;
-  def : Pat<(i32 (riscv_nsra GPR:$lo, GPR:$hi, uimm6:$shamt)),
+  def : Pat<(riscv_nsra GPR:$lo, GPR:$hi, uimm6:$shamt),
             (NSRAI (BuildGPRPair GPR:$lo, GPR:$hi), uimm6:$shamt)>;
   // Register shift amount patterns
-  def : Pat<(i32 (riscv_nsrl GPR:$lo, GPR:$hi, shiftMask64:$shamt)),
+  def : Pat<(riscv_nsrl GPR:$lo, GPR:$hi, shiftMask64:$shamt),
             (NSRL (BuildGPRPair GPR:$lo, GPR:$hi), shiftMask64:$shamt)>;
-  def : Pat<(i32 (riscv_nsra GPR:$lo, GPR:$hi, shiftMask64:$shamt)),
+  def : Pat<(riscv_nsra GPR:$lo, GPR:$hi, shiftMask64:$shamt),
             (NSRA (BuildGPRPair GPR:$lo, GPR:$hi), shiftMask64:$shamt)>;
 
   // Match a pattern of 2 bytes being inserted into bits [31:16], with bits
@@ -1974,14 +1970,11 @@ let Predicates = [HasStdExtP, IsRV64] in {
   def : PatGprImm<riscv_psslai, PSSLAI_W, timm, v2i32>;
 
   // 32-bit logical shift left/right
-  def : Pat<(v2i32 (riscv_pshl GPR:$rs1, GPR:$rs2)),
-            (PSLL_WS GPR:$rs1, GPR:$rs2)>;
-  def : Pat<(v2i32 (riscv_psrl GPR:$rs1, GPR:$rs2)),
-            (PSRL_WS GPR:$rs1, GPR:$rs2)>;
+  def : PatGprShiftMask<riscv_pshl, PSLL_WS, shiftMask32, v2i32>;
+  def : PatGprShiftMask<riscv_psrl, PSRL_WS, shiftMask32, v2i32>;
 
   // 32-bit arithmetic shift left/right
-  def : Pat<(v2i32 (riscv_psra GPR:$rs1, GPR:$rs2)),
-            (PSRA_WS GPR:$rs1, GPR:$rs2)>;
+  def : PatGprShiftMask<riscv_psra, PSRA_WS, shiftMask32, v2i32>;
 
   // splat pattern
   def : Pat<(v2i32 (splat_vector (XLenVT GPR:$rs2))), (PADD_WS (XLenVT X0), GPR:$rs2)>;

--- a/llvm/test/CodeGen/RISCV/rvp-ext-rv32.ll
+++ b/llvm/test/CodeGen/RISCV/rvp-ext-rv32.ll
@@ -844,7 +844,6 @@ define <2 x i16> @test_psll_hs(<2 x i16> %a, i16 %shamt) {
 define <2 x i16> @test_psll_hs_mask(<2 x i16> %a, i16 %shamt) {
 ; CHECK-LABEL: test_psll_hs_mask:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    andi a1, a1, 15
 ; CHECK-NEXT:    psll.hs a0, a0, a1
 ; CHECK-NEXT:    ret
   %masked = and i16 %shamt, 15
@@ -868,7 +867,6 @@ define <4 x i8> @test_psll_bs(<4 x i8> %a, i8 %shamt) {
 define <4 x i8> @test_psll_bs_mask(<4 x i8> %a, i8 %shamt) {
 ; CHECK-LABEL: test_psll_bs_mask:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    andi a1, a1, 7
 ; CHECK-NEXT:    psll.bs a0, a0, a1
 ; CHECK-NEXT:    ret
   %masked = and i8 %shamt, 7
@@ -953,7 +951,6 @@ define <2 x i16> @test_psrl_hs(<2 x i16> %a, i16 %shamt) {
 define <2 x i16> @test_psrl_hs_mask(<2 x i16> %a, i16 %shamt) {
 ; CHECK-LABEL: test_psrl_hs_mask:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    andi a1, a1, 15
 ; CHECK-NEXT:    psrl.hs a0, a0, a1
 ; CHECK-NEXT:    ret
   %masked = and i16 %shamt, 15
@@ -977,7 +974,6 @@ define <4 x i8> @test_psrl_bs(<4 x i8> %a, i8 %shamt) {
 define <4 x i8> @test_psrl_bs_mask(<4 x i8> %a, i8 %shamt) {
 ; CHECK-LABEL: test_psrl_bs_mask:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    andi a1, a1, 7
 ; CHECK-NEXT:    psrl.bs a0, a0, a1
 ; CHECK-NEXT:    ret
   %masked = and i8 %shamt, 7
@@ -1002,7 +998,6 @@ define <2 x i16> @test_psra_hs(<2 x i16> %a, i16 %shamt) {
 define <2 x i16> @test_psra_hs_mask(<2 x i16> %a, i16 %shamt) {
 ; CHECK-LABEL: test_psra_hs_mask:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    andi a1, a1, 15
 ; CHECK-NEXT:    psra.hs a0, a0, a1
 ; CHECK-NEXT:    ret
   %masked = and i16 %shamt, 15
@@ -1026,7 +1021,6 @@ define <4 x i8> @test_psra_bs(<4 x i8> %a, i8 %shamt) {
 define <4 x i8> @test_psra_bs_mask(<4 x i8> %a, i8 %shamt) {
 ; CHECK-LABEL: test_psra_bs_mask:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    andi a1, a1, 7
 ; CHECK-NEXT:    psra.bs a0, a0, a1
 ; CHECK-NEXT:    ret
   %masked = and i8 %shamt, 7

--- a/llvm/test/CodeGen/RISCV/rvp-ext-rv32.ll
+++ b/llvm/test/CodeGen/RISCV/rvp-ext-rv32.ll
@@ -841,12 +841,38 @@ define <2 x i16> @test_psll_hs(<2 x i16> %a, i16 %shamt) {
   ret <2 x i16> %res
 }
 
+define <2 x i16> @test_psll_hs_mask(<2 x i16> %a, i16 %shamt) {
+; CHECK-LABEL: test_psll_hs_mask:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    andi a1, a1, 15
+; CHECK-NEXT:    psll.hs a0, a0, a1
+; CHECK-NEXT:    ret
+  %masked = and i16 %shamt, 15
+  %insert = insertelement <2 x i16> poison, i16 %masked, i32 0
+  %b = shufflevector <2 x i16> %insert, <2 x i16> poison, <2 x i32> zeroinitializer
+  %res = shl <2 x i16> %a, %b
+  ret <2 x i16> %res
+}
+
 define <4 x i8> @test_psll_bs(<4 x i8> %a, i8 %shamt) {
 ; CHECK-LABEL: test_psll_bs:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    psll.bs a0, a0, a1
 ; CHECK-NEXT:    ret
   %insert = insertelement <4 x i8> poison, i8 %shamt, i32 0
+  %b = shufflevector <4 x i8> %insert, <4 x i8> poison, <4 x i32> zeroinitializer
+  %res = shl <4 x i8> %a, %b
+  ret <4 x i8> %res
+}
+
+define <4 x i8> @test_psll_bs_mask(<4 x i8> %a, i8 %shamt) {
+; CHECK-LABEL: test_psll_bs_mask:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    andi a1, a1, 7
+; CHECK-NEXT:    psll.bs a0, a0, a1
+; CHECK-NEXT:    ret
+  %masked = and i8 %shamt, 7
+  %insert = insertelement <4 x i8> poison, i8 %masked, i32 0
   %b = shufflevector <4 x i8> %insert, <4 x i8> poison, <4 x i32> zeroinitializer
   %res = shl <4 x i8> %a, %b
   ret <4 x i8> %res
@@ -924,12 +950,38 @@ define <2 x i16> @test_psrl_hs(<2 x i16> %a, i16 %shamt) {
   ret <2 x i16> %res
 }
 
+define <2 x i16> @test_psrl_hs_mask(<2 x i16> %a, i16 %shamt) {
+; CHECK-LABEL: test_psrl_hs_mask:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    andi a1, a1, 15
+; CHECK-NEXT:    psrl.hs a0, a0, a1
+; CHECK-NEXT:    ret
+  %masked = and i16 %shamt, 15
+  %insert = insertelement <2 x i16> poison, i16 %masked, i32 0
+  %b = shufflevector <2 x i16> %insert, <2 x i16> poison, <2 x i32> zeroinitializer
+  %res = lshr <2 x i16> %a, %b
+  ret <2 x i16> %res
+}
+
 define <4 x i8> @test_psrl_bs(<4 x i8> %a, i8 %shamt) {
 ; CHECK-LABEL: test_psrl_bs:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    psrl.bs a0, a0, a1
 ; CHECK-NEXT:    ret
   %insert = insertelement <4 x i8> poison, i8 %shamt, i32 0
+  %b = shufflevector <4 x i8> %insert, <4 x i8> poison, <4 x i32> zeroinitializer
+  %res = lshr <4 x i8> %a, %b
+  ret <4 x i8> %res
+}
+
+define <4 x i8> @test_psrl_bs_mask(<4 x i8> %a, i8 %shamt) {
+; CHECK-LABEL: test_psrl_bs_mask:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    andi a1, a1, 7
+; CHECK-NEXT:    psrl.bs a0, a0, a1
+; CHECK-NEXT:    ret
+  %masked = and i8 %shamt, 7
+  %insert = insertelement <4 x i8> poison, i8 %masked, i32 0
   %b = shufflevector <4 x i8> %insert, <4 x i8> poison, <4 x i32> zeroinitializer
   %res = lshr <4 x i8> %a, %b
   ret <4 x i8> %res
@@ -947,12 +999,38 @@ define <2 x i16> @test_psra_hs(<2 x i16> %a, i16 %shamt) {
   ret <2 x i16> %res
 }
 
+define <2 x i16> @test_psra_hs_mask(<2 x i16> %a, i16 %shamt) {
+; CHECK-LABEL: test_psra_hs_mask:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    andi a1, a1, 15
+; CHECK-NEXT:    psra.hs a0, a0, a1
+; CHECK-NEXT:    ret
+  %masked = and i16 %shamt, 15
+  %insert = insertelement <2 x i16> poison, i16 %masked, i32 0
+  %b = shufflevector <2 x i16> %insert, <2 x i16> poison, <2 x i32> zeroinitializer
+  %res = ashr <2 x i16> %a, %b
+  ret <2 x i16> %res
+}
+
 define <4 x i8> @test_psra_bs(<4 x i8> %a, i8 %shamt) {
 ; CHECK-LABEL: test_psra_bs:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    psra.bs a0, a0, a1
 ; CHECK-NEXT:    ret
   %insert = insertelement <4 x i8> poison, i8 %shamt, i32 0
+  %b = shufflevector <4 x i8> %insert, <4 x i8> poison, <4 x i32> zeroinitializer
+  %res = ashr <4 x i8> %a, %b
+  ret <4 x i8> %res
+}
+
+define <4 x i8> @test_psra_bs_mask(<4 x i8> %a, i8 %shamt) {
+; CHECK-LABEL: test_psra_bs_mask:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    andi a1, a1, 7
+; CHECK-NEXT:    psra.bs a0, a0, a1
+; CHECK-NEXT:    ret
+  %masked = and i8 %shamt, 7
+  %insert = insertelement <4 x i8> poison, i8 %masked, i32 0
   %b = shufflevector <4 x i8> %insert, <4 x i8> poison, <4 x i32> zeroinitializer
   %res = ashr <4 x i8> %a, %b
   ret <4 x i8> %res
@@ -1846,10 +1924,10 @@ define <2 x i16> @test_select_v2i16(i1 %cond, <2 x i16> %a, <2 x i16> %b) {
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    andi a3, a0, 1
 ; CHECK-NEXT:    mv a0, a1
-; CHECK-NEXT:    bnez a3, .LBB128_2
+; CHECK-NEXT:    bnez a3, .LBB134_2
 ; CHECK-NEXT:  # %bb.1:
 ; CHECK-NEXT:    mv a0, a2
-; CHECK-NEXT:  .LBB128_2:
+; CHECK-NEXT:  .LBB134_2:
 ; CHECK-NEXT:    ret
   %res = select i1 %cond, <2 x i16> %a, <2 x i16> %b
   ret <2 x i16> %res
@@ -1860,10 +1938,10 @@ define <4 x i8> @test_select_v4i8(i1 %cond, <4 x i8> %a, <4 x i8> %b) {
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    andi a3, a0, 1
 ; CHECK-NEXT:    mv a0, a1
-; CHECK-NEXT:    bnez a3, .LBB129_2
+; CHECK-NEXT:    bnez a3, .LBB135_2
 ; CHECK-NEXT:  # %bb.1:
 ; CHECK-NEXT:    mv a0, a2
-; CHECK-NEXT:  .LBB129_2:
+; CHECK-NEXT:  .LBB135_2:
 ; CHECK-NEXT:    ret
   %res = select i1 %cond, <4 x i8> %a, <4 x i8> %b
   ret <4 x i8> %res

--- a/llvm/test/CodeGen/RISCV/rvp-ext-rv64.ll
+++ b/llvm/test/CodeGen/RISCV/rvp-ext-rv64.ll
@@ -1141,12 +1141,73 @@ define <2 x i32> @test_pssla_w(<2 x i32> %a, <2 x i32> %b) {
 }
 
 ; Test logical shift left(scalar shamt)
+define <4 x i16> @test_psll_hs(<4 x i16> %a, i16 %shamt) {
+; CHECK-LABEL: test_psll_hs:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    psll.hs a0, a0, a1
+; CHECK-NEXT:    ret
+  %insert = insertelement <4 x i16> poison, i16 %shamt, i32 0
+  %b = shufflevector <4 x i16> %insert, <4 x i16> poison, <4 x i32> zeroinitializer
+  %res = shl <4 x i16> %a, %b
+  ret <4 x i16> %res
+}
+
+define <4 x i16> @test_psll_hs_mask(<4 x i16> %a, i16 %shamt) {
+; CHECK-LABEL: test_psll_hs_mask:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    andi a1, a1, 15
+; CHECK-NEXT:    psll.hs a0, a0, a1
+; CHECK-NEXT:    ret
+  %masked = and i16 %shamt, 15
+  %insert = insertelement <4 x i16> poison, i16 %masked, i32 0
+  %b = shufflevector <4 x i16> %insert, <4 x i16> poison, <4 x i32> zeroinitializer
+  %res = shl <4 x i16> %a, %b
+  ret <4 x i16> %res
+}
+
+define <8 x i8> @test_psll_bs(<8 x i8> %a, i8 %shamt) {
+; CHECK-LABEL: test_psll_bs:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    psll.bs a0, a0, a1
+; CHECK-NEXT:    ret
+  %insert = insertelement <8 x i8> poison, i8 %shamt, i32 0
+  %b = shufflevector <8 x i8> %insert, <8 x i8> poison, <8 x i32> zeroinitializer
+  %res = shl <8 x i8> %a, %b
+  ret <8 x i8> %res
+}
+
+define <8 x i8> @test_psll_bs_mask(<8 x i8> %a, i8 %shamt) {
+; CHECK-LABEL: test_psll_bs_mask:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    andi a1, a1, 7
+; CHECK-NEXT:    psll.bs a0, a0, a1
+; CHECK-NEXT:    ret
+  %masked = and i8 %shamt, 7
+  %insert = insertelement <8 x i8> poison, i8 %masked, i32 0
+  %b = shufflevector <8 x i8> %insert, <8 x i8> poison, <8 x i32> zeroinitializer
+  %res = shl <8 x i8> %a, %b
+  ret <8 x i8> %res
+}
+
 define <2 x i32> @test_psll_ws(<2 x i32> %a, i32 %shamt) {
 ; CHECK-LABEL: test_psll_ws:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    psll.ws a0, a0, a1
 ; CHECK-NEXT:    ret
   %insert = insertelement <2 x i32> poison, i32 %shamt, i32 0
+  %b = shufflevector <2 x i32> %insert, <2 x i32> poison, <2 x i32> zeroinitializer
+  %res = shl <2 x i32> %a, %b
+  ret <2 x i32> %res
+}
+
+define <2 x i32> @test_psll_ws_mask(<2 x i32> %a, i32 %shamt) {
+; CHECK-LABEL: test_psll_ws_mask:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    andi a1, a1, 31
+; CHECK-NEXT:    psll.ws a0, a0, a1
+; CHECK-NEXT:    ret
+  %masked = and i32 %shamt, 31
+  %insert = insertelement <2 x i32> poison, i32 %masked, i32 0
   %b = shufflevector <2 x i32> %insert, <2 x i32> poison, <2 x i32> zeroinitializer
   %res = shl <2 x i32> %a, %b
   ret <2 x i32> %res
@@ -1167,6 +1228,54 @@ define <2 x i32> @test_psll_ws_vec_shamt(<2 x i32> %a, <2 x i32> %b) {
 }
 
 ; Test logical shift right(scalar shamt)
+define <4 x i16> @test_psrl_hs(<4 x i16> %a, i16 %shamt) {
+; CHECK-LABEL: test_psrl_hs:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    psrl.hs a0, a0, a1
+; CHECK-NEXT:    ret
+  %insert = insertelement <4 x i16> poison, i16 %shamt, i32 0
+  %b = shufflevector <4 x i16> %insert, <4 x i16> poison, <4 x i32> zeroinitializer
+  %res = lshr <4 x i16> %a, %b
+  ret <4 x i16> %res
+}
+
+define <4 x i16> @test_psrl_hs_mask(<4 x i16> %a, i16 %shamt) {
+; CHECK-LABEL: test_psrl_hs_mask:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    andi a1, a1, 15
+; CHECK-NEXT:    psrl.hs a0, a0, a1
+; CHECK-NEXT:    ret
+  %masked = and i16 %shamt, 15
+  %insert = insertelement <4 x i16> poison, i16 %masked, i32 0
+  %b = shufflevector <4 x i16> %insert, <4 x i16> poison, <4 x i32> zeroinitializer
+  %res = lshr <4 x i16> %a, %b
+  ret <4 x i16> %res
+}
+
+define <8 x i8> @test_psrl_bs(<8 x i8> %a, i8 %shamt) {
+; CHECK-LABEL: test_psrl_bs:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    psrl.bs a0, a0, a1
+; CHECK-NEXT:    ret
+  %insert = insertelement <8 x i8> poison, i8 %shamt, i32 0
+  %b = shufflevector <8 x i8> %insert, <8 x i8> poison, <8 x i32> zeroinitializer
+  %res = lshr <8 x i8> %a, %b
+  ret <8 x i8> %res
+}
+
+define <8 x i8> @test_psrl_bs_mask(<8 x i8> %a, i8 %shamt) {
+; CHECK-LABEL: test_psrl_bs_mask:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    andi a1, a1, 7
+; CHECK-NEXT:    psrl.bs a0, a0, a1
+; CHECK-NEXT:    ret
+  %masked = and i8 %shamt, 7
+  %insert = insertelement <8 x i8> poison, i8 %masked, i32 0
+  %b = shufflevector <8 x i8> %insert, <8 x i8> poison, <8 x i32> zeroinitializer
+  %res = lshr <8 x i8> %a, %b
+  ret <8 x i8> %res
+}
+
 define <2 x i32> @test_psrl_ws(<2 x i32> %a, i32 %shamt) {
 ; CHECK-LABEL: test_psrl_ws:
 ; CHECK:       # %bb.0:
@@ -1178,13 +1287,87 @@ define <2 x i32> @test_psrl_ws(<2 x i32> %a, i32 %shamt) {
   ret <2 x i32> %res
 }
 
+define <2 x i32> @test_psrl_ws_mask(<2 x i32> %a, i32 %shamt) {
+; CHECK-LABEL: test_psrl_ws_mask:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    andi a1, a1, 31
+; CHECK-NEXT:    psrl.ws a0, a0, a1
+; CHECK-NEXT:    ret
+  %masked = and i32 %shamt, 31
+  %insert = insertelement <2 x i32> poison, i32 %masked, i32 0
+  %b = shufflevector <2 x i32> %insert, <2 x i32> poison, <2 x i32> zeroinitializer
+  %res = lshr <2 x i32> %a, %b
+  ret <2 x i32> %res
+}
+
 ; Test arithmetic shift right(scalar shamt)
+define <4 x i16> @test_psra_hs(<4 x i16> %a, i16 %shamt) {
+; CHECK-LABEL: test_psra_hs:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    psra.hs a0, a0, a1
+; CHECK-NEXT:    ret
+  %insert = insertelement <4 x i16> poison, i16 %shamt, i32 0
+  %b = shufflevector <4 x i16> %insert, <4 x i16> poison, <4 x i32> zeroinitializer
+  %res = ashr <4 x i16> %a, %b
+  ret <4 x i16> %res
+}
+
+define <4 x i16> @test_psra_hs_mask(<4 x i16> %a, i16 %shamt) {
+; CHECK-LABEL: test_psra_hs_mask:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    andi a1, a1, 15
+; CHECK-NEXT:    psra.hs a0, a0, a1
+; CHECK-NEXT:    ret
+  %masked = and i16 %shamt, 15
+  %insert = insertelement <4 x i16> poison, i16 %masked, i32 0
+  %b = shufflevector <4 x i16> %insert, <4 x i16> poison, <4 x i32> zeroinitializer
+  %res = ashr <4 x i16> %a, %b
+  ret <4 x i16> %res
+}
+
+define <8 x i8> @test_psra_bs(<8 x i8> %a, i8 %shamt) {
+; CHECK-LABEL: test_psra_bs:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    psra.bs a0, a0, a1
+; CHECK-NEXT:    ret
+  %insert = insertelement <8 x i8> poison, i8 %shamt, i32 0
+  %b = shufflevector <8 x i8> %insert, <8 x i8> poison, <8 x i32> zeroinitializer
+  %res = ashr <8 x i8> %a, %b
+  ret <8 x i8> %res
+}
+
+define <8 x i8> @test_psra_bs_mask(<8 x i8> %a, i8 %shamt) {
+; CHECK-LABEL: test_psra_bs_mask:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    andi a1, a1, 7
+; CHECK-NEXT:    psra.bs a0, a0, a1
+; CHECK-NEXT:    ret
+  %masked = and i8 %shamt, 7
+  %insert = insertelement <8 x i8> poison, i8 %masked, i32 0
+  %b = shufflevector <8 x i8> %insert, <8 x i8> poison, <8 x i32> zeroinitializer
+  %res = ashr <8 x i8> %a, %b
+  ret <8 x i8> %res
+}
+
 define <2 x i32> @test_psra_ws(<2 x i32> %a, i32 %shamt) {
 ; CHECK-LABEL: test_psra_ws:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    psra.ws a0, a0, a1
 ; CHECK-NEXT:    ret
   %insert = insertelement <2 x i32> poison, i32 %shamt, i32 0
+  %b = shufflevector <2 x i32> %insert, <2 x i32> poison, <2 x i32> zeroinitializer
+  %res = ashr <2 x i32> %a, %b
+  ret <2 x i32> %res
+}
+
+define <2 x i32> @test_psra_ws_mask(<2 x i32> %a, i32 %shamt) {
+; CHECK-LABEL: test_psra_ws_mask:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    andi a1, a1, 31
+; CHECK-NEXT:    psra.ws a0, a0, a1
+; CHECK-NEXT:    ret
+  %masked = and i32 %shamt, 31
+  %insert = insertelement <2 x i32> poison, i32 %masked, i32 0
   %b = shufflevector <2 x i32> %insert, <2 x i32> poison, <2 x i32> zeroinitializer
   %res = ashr <2 x i32> %a, %b
   ret <2 x i32> %res
@@ -2266,10 +2449,10 @@ define <4 x i16> @test_select_v4i16(i1 %cond, <4 x i16> %a, <4 x i16> %b) {
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    andi a3, a0, 1
 ; CHECK-NEXT:    mv a0, a1
-; CHECK-NEXT:    bnez a3, .LBB181_2
+; CHECK-NEXT:    bnez a3, .LBB196_2
 ; CHECK-NEXT:  # %bb.1:
 ; CHECK-NEXT:    mv a0, a2
-; CHECK-NEXT:  .LBB181_2:
+; CHECK-NEXT:  .LBB196_2:
 ; CHECK-NEXT:    ret
   %res = select i1 %cond, <4 x i16> %a, <4 x i16> %b
   ret <4 x i16> %res
@@ -2280,10 +2463,10 @@ define <8 x i8> @test_select_v8i8(i1 %cond, <8 x i8> %a, <8 x i8> %b) {
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    andi a3, a0, 1
 ; CHECK-NEXT:    mv a0, a1
-; CHECK-NEXT:    bnez a3, .LBB182_2
+; CHECK-NEXT:    bnez a3, .LBB197_2
 ; CHECK-NEXT:  # %bb.1:
 ; CHECK-NEXT:    mv a0, a2
-; CHECK-NEXT:  .LBB182_2:
+; CHECK-NEXT:  .LBB197_2:
 ; CHECK-NEXT:    ret
   %res = select i1 %cond, <8 x i8> %a, <8 x i8> %b
   ret <8 x i8> %res
@@ -2294,10 +2477,10 @@ define <2 x i32> @test_select_v2i32(i1 %cond, <2 x i32> %a, <2 x i32> %b) {
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    andi a3, a0, 1
 ; CHECK-NEXT:    mv a0, a1
-; CHECK-NEXT:    bnez a3, .LBB183_2
+; CHECK-NEXT:    bnez a3, .LBB198_2
 ; CHECK-NEXT:  # %bb.1:
 ; CHECK-NEXT:    mv a0, a2
-; CHECK-NEXT:  .LBB183_2:
+; CHECK-NEXT:  .LBB198_2:
 ; CHECK-NEXT:    ret
   %res = select i1 %cond, <2 x i32> %a, <2 x i32> %b
   ret <2 x i32> %res

--- a/llvm/test/CodeGen/RISCV/rvp-ext-rv64.ll
+++ b/llvm/test/CodeGen/RISCV/rvp-ext-rv64.ll
@@ -1155,7 +1155,6 @@ define <4 x i16> @test_psll_hs(<4 x i16> %a, i16 %shamt) {
 define <4 x i16> @test_psll_hs_mask(<4 x i16> %a, i16 %shamt) {
 ; CHECK-LABEL: test_psll_hs_mask:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    andi a1, a1, 15
 ; CHECK-NEXT:    psll.hs a0, a0, a1
 ; CHECK-NEXT:    ret
   %masked = and i16 %shamt, 15
@@ -1179,7 +1178,6 @@ define <8 x i8> @test_psll_bs(<8 x i8> %a, i8 %shamt) {
 define <8 x i8> @test_psll_bs_mask(<8 x i8> %a, i8 %shamt) {
 ; CHECK-LABEL: test_psll_bs_mask:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    andi a1, a1, 7
 ; CHECK-NEXT:    psll.bs a0, a0, a1
 ; CHECK-NEXT:    ret
   %masked = and i8 %shamt, 7
@@ -1203,7 +1201,6 @@ define <2 x i32> @test_psll_ws(<2 x i32> %a, i32 %shamt) {
 define <2 x i32> @test_psll_ws_mask(<2 x i32> %a, i32 %shamt) {
 ; CHECK-LABEL: test_psll_ws_mask:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    andi a1, a1, 31
 ; CHECK-NEXT:    psll.ws a0, a0, a1
 ; CHECK-NEXT:    ret
   %masked = and i32 %shamt, 31
@@ -1242,7 +1239,6 @@ define <4 x i16> @test_psrl_hs(<4 x i16> %a, i16 %shamt) {
 define <4 x i16> @test_psrl_hs_mask(<4 x i16> %a, i16 %shamt) {
 ; CHECK-LABEL: test_psrl_hs_mask:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    andi a1, a1, 15
 ; CHECK-NEXT:    psrl.hs a0, a0, a1
 ; CHECK-NEXT:    ret
   %masked = and i16 %shamt, 15
@@ -1266,7 +1262,6 @@ define <8 x i8> @test_psrl_bs(<8 x i8> %a, i8 %shamt) {
 define <8 x i8> @test_psrl_bs_mask(<8 x i8> %a, i8 %shamt) {
 ; CHECK-LABEL: test_psrl_bs_mask:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    andi a1, a1, 7
 ; CHECK-NEXT:    psrl.bs a0, a0, a1
 ; CHECK-NEXT:    ret
   %masked = and i8 %shamt, 7
@@ -1290,7 +1285,6 @@ define <2 x i32> @test_psrl_ws(<2 x i32> %a, i32 %shamt) {
 define <2 x i32> @test_psrl_ws_mask(<2 x i32> %a, i32 %shamt) {
 ; CHECK-LABEL: test_psrl_ws_mask:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    andi a1, a1, 31
 ; CHECK-NEXT:    psrl.ws a0, a0, a1
 ; CHECK-NEXT:    ret
   %masked = and i32 %shamt, 31
@@ -1315,7 +1309,6 @@ define <4 x i16> @test_psra_hs(<4 x i16> %a, i16 %shamt) {
 define <4 x i16> @test_psra_hs_mask(<4 x i16> %a, i16 %shamt) {
 ; CHECK-LABEL: test_psra_hs_mask:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    andi a1, a1, 15
 ; CHECK-NEXT:    psra.hs a0, a0, a1
 ; CHECK-NEXT:    ret
   %masked = and i16 %shamt, 15
@@ -1339,7 +1332,6 @@ define <8 x i8> @test_psra_bs(<8 x i8> %a, i8 %shamt) {
 define <8 x i8> @test_psra_bs_mask(<8 x i8> %a, i8 %shamt) {
 ; CHECK-LABEL: test_psra_bs_mask:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    andi a1, a1, 7
 ; CHECK-NEXT:    psra.bs a0, a0, a1
 ; CHECK-NEXT:    ret
   %masked = and i8 %shamt, 7
@@ -1363,7 +1355,6 @@ define <2 x i32> @test_psra_ws(<2 x i32> %a, i32 %shamt) {
 define <2 x i32> @test_psra_ws_mask(<2 x i32> %a, i32 %shamt) {
 ; CHECK-LABEL: test_psra_ws_mask:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    andi a1, a1, 31
 ; CHECK-NEXT:    psra.ws a0, a0, a1
 ; CHECK-NEXT:    ret
   %masked = and i32 %shamt, 31


### PR DESCRIPTION
Add missing test coverage for 64-bit vectors with scalar shift
amounts.