### PR TITLE
[flang] Implement conditional expressions lowering (F2023)

### DIFF
--- a/flang/lib/Lower/ConvertExprToHLFIR.cpp
+++ b/flang/lib/Lower/ConvertExprToHLFIR.cpp
@@ -1788,12 +1788,6 @@ private:
     TODO(getLoc(), "lowering type parameter inquiry to HLFIR");
   }
 
-  template <typename T>
-  hlfir::EntityWithAttributes
-  gen(const Fortran::evaluate::ConditionalExpr<T> &) {
-    TODO(getLoc(), "lowering conditional expression to HLFIR");
-  }
-
   hlfir::EntityWithAttributes
   gen(const Fortran::evaluate::DescriptorInquiry &desc) {
     mlir::Location loc = getLoc();

--- a/flang/lib/Lower/ConvertExprToHLFIR.cpp
+++ b/flang/lib/Lower/ConvertExprToHLFIR.cpp
@@ -1827,6 +1827,194 @@ private:
     llvm_unreachable("unknown descriptor inquiry");
   }
 
+  /// Build nested if-then-else chain for conditional expressions with lazy
+  /// evaluation. The assignValue callback generates and assigns each value to
+  /// avoid evaluating non-taken branches.
+  template <typename T>
+  void buildConditionalIfChain(
+      const Fortran::evaluate::ConditionalExpr<T> &condExpr,
+      const std::function<void(int valueIndex)> &assignValue) {
+    const mlir::Location loc = getLoc();
+    fir::FirOpBuilder &builder = getBuilder();
+    std::function<void(int)> buildIfChain = [&](int i) {
+      if (i >= static_cast<int>(condExpr.conditions().size())) {
+        // All conditions false: assign final else value.
+        getStmtCtx().pushScope();
+        assignValue(static_cast<int>(condExpr.values().size()) - 1);
+        getStmtCtx().finalizeAndPop();
+      } else {
+        getStmtCtx().pushScope();
+        const hlfir::EntityWithAttributes condEntity =
+            gen(condExpr.conditions()[i]);
+        mlir::Value condition =
+            hlfir::loadTrivialScalar(loc, builder, condEntity);
+        condition = builder.createConvert(loc, builder.getI1Type(), condition);
+        builder.genIfOp(loc, {}, condition, /*withElseRegion=*/true)
+            .genThen([&]() {
+              getStmtCtx().pushScope();
+              assignValue(i);
+              getStmtCtx().finalizeAndPop();
+            })
+            .genElse([&]() { buildIfChain(i + 1); })
+            .end();
+        getStmtCtx().finalizeAndPop();
+      }
+    };
+    buildIfChain(0);
+  }
+
+  /// Generate scalar conditional with lazy evaluation using assignment.
+  /// Creates a temporary and assigns the selected branch value to it.
+  template <typename T>
+  hlfir::Entity genScalarConditionalLazy(
+      const Fortran::evaluate::ConditionalExpr<T> &condExpr,
+      mlir::Type elementType,
+      const llvm::SmallVector<mlir::Value, 1> &typeParams) {
+    const mlir::Location loc = getLoc();
+    fir::FirOpBuilder &builder = getBuilder();
+    const mlir::Value tempStorage = builder.createTemporary(
+        loc, elementType, ".cond.scalar",
+        /*shape=*/mlir::ValueRange{}, /*typeParams=*/typeParams);
+    const hlfir::DeclareOp tempDecl = hlfir::DeclareOp::create(
+        builder, loc, tempStorage, ".cond.result",
+        /*shape=*/mlir::Value{}, /*typeParams=*/typeParams);
+    const hlfir::Entity temp{tempDecl};
+    buildConditionalIfChain(condExpr, [&](int valueIndex) {
+      hlfir::Entity entity = gen(condExpr.values()[valueIndex]);
+      auto [exv, cleanup] = hlfir::convertToValue(loc, builder, entity);
+      hlfir::Entity value{fir::getBase(exv)};
+      if (cleanup) {
+        getStmtCtx().attachCleanup(*cleanup);
+      }
+      hlfir::AssignOp::create(builder, loc, value, temp);
+    });
+    return temp;
+  }
+
+  /// Generate conditional expression using an allocatable temporary with lazy
+  /// evaluation. Creates an unallocated allocatable, then uses assignment to
+  /// set the value from the chosen branch (allocation/reallocation handled by
+  /// runtime).
+  template <typename T>
+  hlfir::Entity genAllocatableConditionalLazy(
+      const Fortran::evaluate::ConditionalExpr<T> &condExpr,
+      mlir::Type resultType, llvm::StringRef debugName) {
+    const mlir::Location loc = getLoc();
+    fir::FirOpBuilder &builder = getBuilder();
+    const mlir::Type heapType = fir::HeapType::get(resultType);
+    const mlir::Type boxHeapType = fir::BoxType::get(heapType);
+    const mlir::Value tempStorage =
+        builder.createTemporary(loc, boxHeapType, debugName);
+    const mlir::Value unallocBox = fir::factory::createUnallocatedBox(
+        builder, loc, boxHeapType, /*nonDeferredParams=*/{});
+    builder.createStoreWithConvert(loc, unallocBox, tempStorage);
+    const hlfir::DeclareOp tempDecl =
+        hlfir::DeclareOp::create(builder, loc, tempStorage, ".cond.result");
+    const hlfir::Entity temp{tempDecl};
+    // Lazy evaluation: only the selected branch is evaluated and assigned.
+    buildConditionalIfChain(condExpr, [&](int valueIndex) {
+      const hlfir::Entity entity = gen(condExpr.values()[valueIndex]);
+      hlfir::AssignOp::create(builder, loc, entity, temp,
+                              /*isWholeAllocatableAssignment=*/true,
+                              /*keepLhsLengthIfRealloc=*/false,
+                              /*temporary_lhs=*/true);
+    });
+    return temp;
+  }
+
+  /// Generate scalar CHARACTER conditional with deferred-length using lazy
+  /// evaluation. Only the chosen branch is evaluated; the result gets that
+  /// branch's length.
+  template <typename T>
+  hlfir::Entity genScalarDeferredCharConditionalLazy(
+      const Fortran::evaluate::ConditionalExpr<T> &condExpr,
+      mlir::Type elementType) {
+    return genAllocatableConditionalLazy(condExpr, elementType, ".cond.char");
+  }
+
+  /// Generate array conditional expression with lazy evaluation using
+  /// assignment. Per F2023 10.1.4(7), the shape is determined by the chosen
+  /// branch.
+  template <typename T>
+  hlfir::Entity genArrayConditionalLazy(
+      const Fortran::evaluate::ConditionalExpr<T> &condExpr) {
+    mlir::Type condResultType = Fortran::lower::translateSomeExprToFIRType(
+        converter, toEvExpr(condExpr));
+    if (auto boxTy = mlir::dyn_cast<fir::BoxType>(condResultType)) {
+      condResultType = fir::unwrapRefType(boxTy.getEleTy());
+    }
+    return genAllocatableConditionalLazy(condExpr, condResultType,
+                                         ".cond.array");
+  }
+
+  /// Generate scalar CHARACTER conditional with proper length handling.
+  template <typename T>
+  std::optional<hlfir::EntityWithAttributes> genCharacterConditional(
+      const Fortran::evaluate::ConditionalExpr<T> &condExpr) {
+    const mlir::Location loc = getLoc();
+    fir::FirOpBuilder &builder = getBuilder();
+    const mlir::Type resultType = Fortran::lower::translateSomeExprToFIRType(
+        converter, toEvExpr(condExpr));
+    const mlir::Type elementType = hlfir::getFortranElementType(resultType);
+    if (auto charType = mlir::dyn_cast<fir::CharacterType>(elementType)) {
+      if (charType.hasConstantLen()) {
+        llvm::SmallVector<mlir::Value, 1> typeParams;
+        const mlir::Value len = builder.createIntegerConstant(
+            loc, builder.getCharacterLengthType(), charType.getLen());
+        typeParams.push_back(len);
+        return hlfir::EntityWithAttributes{
+            genScalarConditionalLazy(condExpr, elementType, typeParams)};
+      }
+      // Non-constant/varying length: use allocatable conditional to get length
+      // from selected branch.
+      return hlfir::EntityWithAttributes{
+          genScalarDeferredCharConditionalLazy(condExpr, elementType)};
+    }
+    return std::nullopt;
+  }
+
+  /// Conditional expression (Fortran 2023)
+  template <typename T>
+  hlfir::EntityWithAttributes
+  gen(const Fortran::evaluate::ConditionalExpr<T> &condExpr) {
+    assert(!condExpr.conditions().empty() &&
+           "conditional expression must have conditions");
+    assert(!condExpr.values().empty() &&
+           "conditional expression must have values");
+    assert(condExpr.values().size() == condExpr.conditions().size() + 1 &&
+           "values must have exactly one more element than conditions");
+    const int rank = condExpr.Rank();
+
+    // Arrays: handle early to avoid unnecessary type checks.
+    // Per F2023 10.1.4(7), the shape is determined by the chosen branch.
+    if (rank != 0) {
+      return hlfir::EntityWithAttributes{genArrayConditionalLazy(condExpr)};
+    }
+    // CHARACTER scalars require special handling for type parameters.
+    if constexpr (T::category == Fortran::common::TypeCategory::Character) {
+      if (auto result = genCharacterConditional(condExpr)) {
+        return *result;
+      }
+    }
+    // Derived type scalars require special handling for type parameters.
+    if constexpr (T::category == Fortran::common::TypeCategory::Derived) {
+      const mlir::Type resultType = Fortran::lower::translateSomeExprToFIRType(
+          converter, toEvExpr(condExpr));
+      const mlir::Type elementType = hlfir::getFortranElementType(resultType);
+      return hlfir::EntityWithAttributes{
+          genScalarConditionalLazy(condExpr, elementType, {})};
+    }
+    // Other scalar types (INTEGER, REAL, COMPLEX, LOGICAL, UNSIGNED).
+    mlir::Type condResultType = Fortran::lower::translateSomeExprToFIRType(
+        converter, toEvExpr(condExpr));
+    if (auto boxTy = mlir::dyn_cast<fir::BoxType>(condResultType)) {
+      condResultType = fir::unwrapRefType(boxTy.getEleTy());
+    }
+    const mlir::Type resultType = hlfir::getFortranElementType(condResultType);
+    return hlfir::EntityWithAttributes{
+        genScalarConditionalLazy(condExpr, resultType, {})};
+  }
+
   hlfir::EntityWithAttributes
   gen(const Fortran::evaluate::ImpliedDoIndex &var) {
     mlir::Value value = symMap.lookupImpliedDo(toStringRef(var.name));

--- a/flang/lib/Lower/ConvertExprToHLFIR.cpp
+++ b/flang/lib/Lower/ConvertExprToHLFIR.cpp
@@ -1834,11 +1834,11 @@ private:
   void
   buildConditionalIfChain(const Fortran::evaluate::ConditionalExpr<T> &condExpr,
                           const Callback &assignValue) {
-    const mlir::Location loc = getLoc();
-    fir::FirOpBuilder &builder = getBuilder();
+    const mlir::Location loc{getLoc()};
+    fir::FirOpBuilder &builder{getBuilder()};
     getStmtCtx().pushScope();
-    const hlfir::EntityWithAttributes condEntity = gen(condExpr.condition());
-    mlir::Value condition = hlfir::loadTrivialScalar(loc, builder, condEntity);
+    const hlfir::EntityWithAttributes condEntity{gen(condExpr.condition())};
+    mlir::Value condition{hlfir::loadTrivialScalar(loc, builder, condEntity)};
     condition = builder.createConvert(loc, builder.getI1Type(), condition);
     builder.genIfOp(loc, {}, condition, /*withElseRegion=*/true)
         .genThen([&]() {
@@ -1869,18 +1869,18 @@ private:
       const Fortran::evaluate::ConditionalExpr<T> &condExpr,
       mlir::Type elementType,
       const llvm::SmallVector<mlir::Value, 1> &typeParams) {
-    const mlir::Location loc = getLoc();
-    fir::FirOpBuilder &builder = getBuilder();
-    const mlir::Value tempStorage = builder.createTemporary(
+    const mlir::Location loc{getLoc()};
+    fir::FirOpBuilder &builder{getBuilder()};
+    const mlir::Value tempStorage{builder.createTemporary(
         loc, elementType, ".cond.scalar",
-        /*shape=*/mlir::ValueRange{}, /*typeParams=*/typeParams);
-    const hlfir::DeclareOp tempDecl = hlfir::DeclareOp::create(
+        /*shape=*/mlir::ValueRange{}, /*typeParams=*/typeParams)};
+    const hlfir::DeclareOp tempDecl{hlfir::DeclareOp::create(
         builder, loc, tempStorage, ".cond.result",
-        /*shape=*/mlir::Value{}, /*typeParams=*/typeParams);
+        /*shape=*/mlir::Value{}, /*typeParams=*/typeParams)};
     const hlfir::Entity temp{tempDecl};
     buildConditionalIfChain(
         condExpr, [&](const Fortran::evaluate::Expr<T> &expr) {
-          hlfir::Entity entity = gen(expr);
+          hlfir::Entity entity{gen(expr)};
           auto [exv, cleanup] = hlfir::convertToValue(loc, builder, entity);
           hlfir::Entity value{fir::getBase(exv)};
           if (cleanup) {
@@ -1899,22 +1899,22 @@ private:
   hlfir::Entity genAllocatableConditionalLazy(
       const Fortran::evaluate::ConditionalExpr<T> &condExpr,
       mlir::Type resultType, llvm::StringRef debugName) {
-    const mlir::Location loc = getLoc();
-    fir::FirOpBuilder &builder = getBuilder();
-    const mlir::Type heapType = fir::HeapType::get(resultType);
-    const mlir::Type boxHeapType = fir::BoxType::get(heapType);
-    const mlir::Value tempStorage =
-        builder.createTemporary(loc, boxHeapType, debugName);
-    const mlir::Value unallocBox = fir::factory::createUnallocatedBox(
-        builder, loc, boxHeapType, /*nonDeferredParams=*/{});
+    const mlir::Location loc{getLoc()};
+    fir::FirOpBuilder &builder{getBuilder()};
+    const mlir::Type heapType{fir::HeapType::get(resultType)};
+    const mlir::Type boxHeapType{fir::BoxType::get(heapType)};
+    const mlir::Value tempStorage{
+        builder.createTemporary(loc, boxHeapType, debugName)};
+    const mlir::Value unallocBox{fir::factory::createUnallocatedBox(
+        builder, loc, boxHeapType, /*nonDeferredParams=*/{})};
     builder.createStoreWithConvert(loc, unallocBox, tempStorage);
-    const hlfir::DeclareOp tempDecl =
-        hlfir::DeclareOp::create(builder, loc, tempStorage, ".cond.result");
+    const hlfir::DeclareOp tempDecl{
+        hlfir::DeclareOp::create(builder, loc, tempStorage, ".cond.result")};
     const hlfir::Entity temp{tempDecl};
     // Lazy evaluation: only the selected branch is evaluated and assigned.
     buildConditionalIfChain(
         condExpr, [&](const Fortran::evaluate::Expr<T> &expr) {
-          const hlfir::Entity entity = gen(expr);
+          const hlfir::Entity entity{gen(expr)};
           hlfir::AssignOp::create(builder, loc, entity, temp,
                                   /*isWholeAllocatableAssignment=*/true,
                                   /*keepLhsLengthIfRealloc=*/false,
@@ -1939,8 +1939,8 @@ private:
   template <typename T>
   hlfir::Entity genArrayConditionalLazy(
       const Fortran::evaluate::ConditionalExpr<T> &condExpr) {
-    mlir::Type condResultType = Fortran::lower::translateSomeExprToFIRType(
-        converter, toEvExpr(condExpr));
+    mlir::Type condResultType{Fortran::lower::translateSomeExprToFIRType(
+        converter, toEvExpr(condExpr))};
     if (auto boxTy = mlir::dyn_cast<fir::BoxType>(condResultType)) {
       condResultType = fir::unwrapRefType(boxTy.getEleTy());
     }
@@ -1952,16 +1952,16 @@ private:
   template <typename T>
   std::optional<hlfir::EntityWithAttributes> genCharacterConditional(
       const Fortran::evaluate::ConditionalExpr<T> &condExpr) {
-    const mlir::Location loc = getLoc();
-    fir::FirOpBuilder &builder = getBuilder();
-    const mlir::Type resultType = Fortran::lower::translateSomeExprToFIRType(
-        converter, toEvExpr(condExpr));
-    const mlir::Type elementType = hlfir::getFortranElementType(resultType);
+    const mlir::Location loc{getLoc()};
+    fir::FirOpBuilder &builder{getBuilder()};
+    const mlir::Type resultType{Fortran::lower::translateSomeExprToFIRType(
+        converter, toEvExpr(condExpr))};
+    const mlir::Type elementType{hlfir::getFortranElementType(resultType)};
     if (auto charType = mlir::dyn_cast<fir::CharacterType>(elementType)) {
       if (charType.hasConstantLen()) {
         llvm::SmallVector<mlir::Value, 1> typeParams;
-        const mlir::Value len = builder.createIntegerConstant(
-            loc, builder.getCharacterLengthType(), charType.getLen());
+        const mlir::Value len{builder.createIntegerConstant(
+            loc, builder.getCharacterLengthType(), charType.getLen())};
         typeParams.push_back(len);
         return hlfir::EntityWithAttributes{
             genScalarConditionalLazy(condExpr, elementType, typeParams)};
@@ -1978,7 +1978,7 @@ private:
   template <typename T>
   hlfir::EntityWithAttributes
   gen(const Fortran::evaluate::ConditionalExpr<T> &condExpr) {
-    const int rank = condExpr.Rank();
+    const int rank{condExpr.Rank()};
 
     // Arrays: handle early to avoid unnecessary type checks.
     // Per F2023 10.1.4(7), the shape is determined by the chosen branch.
@@ -1993,19 +1993,19 @@ private:
     }
     // Derived type scalars require special handling for type parameters.
     if constexpr (T::category == Fortran::common::TypeCategory::Derived) {
-      const mlir::Type resultType = Fortran::lower::translateSomeExprToFIRType(
-          converter, toEvExpr(condExpr));
-      const mlir::Type elementType = hlfir::getFortranElementType(resultType);
+      const mlir::Type resultType{Fortran::lower::translateSomeExprToFIRType(
+          converter, toEvExpr(condExpr))};
+      const mlir::Type elementType{hlfir::getFortranElementType(resultType)};
       return hlfir::EntityWithAttributes{
           genScalarConditionalLazy(condExpr, elementType, {})};
     }
     // Other scalar types (INTEGER, REAL, COMPLEX, LOGICAL, UNSIGNED).
-    mlir::Type condResultType = Fortran::lower::translateSomeExprToFIRType(
-        converter, toEvExpr(condExpr));
+    mlir::Type condResultType{Fortran::lower::translateSomeExprToFIRType(
+        converter, toEvExpr(condExpr))};
     if (auto boxTy = mlir::dyn_cast<fir::BoxType>(condResultType)) {
       condResultType = fir::unwrapRefType(boxTy.getEleTy());
     }
-    const mlir::Type resultType = hlfir::getFortranElementType(condResultType);
+    const mlir::Type resultType{hlfir::getFortranElementType(condResultType)};
     return hlfir::EntityWithAttributes{
         genScalarConditionalLazy(condExpr, resultType, {})};
   }

--- a/flang/lib/Lower/ConvertExprToHLFIR.cpp
+++ b/flang/lib/Lower/ConvertExprToHLFIR.cpp
@@ -1874,7 +1874,7 @@ private:
     buildConditionalIfChain(
         condExpr, [&](const Fortran::evaluate::Expr<T> &expr) {
           hlfir::Entity entity{gen(expr)};
-          entity = hlfir::derefPointersAndAllocatables(loc, builder, entity);
+          entity = hlfir::loadTrivialScalar(loc, builder, entity);
           hlfir::AssignOp::create(builder, loc, entity, temp);
         });
     return temp;
@@ -1950,31 +1950,28 @@ private:
   hlfir::EntityWithAttributes
   gen(const Fortran::evaluate::ConditionalExpr<T> &condExpr) {
     const int rank{condExpr.Rank()};
-
+    mlir::Type resultType{Fortran::lower::translateSomeExprToFIRType(
+        converter, toEvExpr(condExpr))};
+    if (fir::isPolymorphicType(resultType))
+      TODO(getLoc(), "polymorphic conditional expression");
+    if (fir::isRecordWithTypeParameters(
+            hlfir::getFortranElementType(resultType)))
+      TODO(getLoc(), "conditional expression with length-parameterized "
+                     "derived type");
     // Arrays: handle early to avoid unnecessary type checks.
     // Per F2023 10.1.4(7), the shape is determined by the chosen branch.
     if (rank != 0) {
-      mlir::Type condResultType{Fortran::lower::translateSomeExprToFIRType(
-          converter, toEvExpr(condExpr))};
-      if (auto boxTy = mlir::dyn_cast<fir::BoxType>(condResultType))
-        condResultType = fir::unwrapRefType(boxTy.getEleTy());
+      const mlir::Type condResultType{
+          hlfir::getFortranElementOrSequenceType(resultType)};
       return hlfir::EntityWithAttributes{
           genAllocatableConditional(condExpr, condResultType, ".cond.array")};
     }
     // CHARACTER scalars require special handling for type parameters.
     if constexpr (T::category == Fortran::common::TypeCategory::Character) {
-      if (auto result = genCharacterConditional(condExpr)) {
+      if (auto result = genCharacterConditional(condExpr))
         return *result;
-      }
     }
     // Scalar types (INTEGER, REAL, COMPLEX, LOGICAL, UNSIGNED, Derived).
-    mlir::Type resultType{Fortran::lower::translateSomeExprToFIRType(
-        converter, toEvExpr(condExpr))};
-    if constexpr (T::category != Fortran::common::TypeCategory::Derived) {
-      if (auto boxTy = mlir::dyn_cast<fir::BoxType>(resultType)) {
-        resultType = fir::unwrapRefType(boxTy.getEleTy());
-      }
-    }
     return hlfir::EntityWithAttributes{genScalarConditional(
         condExpr, hlfir::getFortranElementType(resultType), {})};
   }

--- a/flang/lib/Lower/ConvertExprToHLFIR.cpp
+++ b/flang/lib/Lower/ConvertExprToHLFIR.cpp
@@ -1827,40 +1827,39 @@ private:
     llvm_unreachable("unknown descriptor inquiry");
   }
 
-  /// Build nested if-then-else chain for conditional expressions with lazy
-  /// evaluation. The assignValue callback generates and assigns each value to
-  /// avoid evaluating non-taken branches.
-  template <typename T>
-  void buildConditionalIfChain(
-      const Fortran::evaluate::ConditionalExpr<T> &condExpr,
-      const std::function<void(int valueIndex)> &assignValue) {
+  /// Build nested if-then-else chain by walking the right-skewed
+  /// ConditionalExpr tree. The assignValue callback generates and assigns
+  /// each value to avoid evaluating non-taken branches.
+  template <typename T, typename Callback>
+  void
+  buildConditionalIfChain(const Fortran::evaluate::ConditionalExpr<T> &condExpr,
+                          const Callback &assignValue) {
     const mlir::Location loc = getLoc();
     fir::FirOpBuilder &builder = getBuilder();
-    std::function<void(int)> buildIfChain = [&](int i) {
-      if (i >= static_cast<int>(condExpr.conditions().size())) {
-        // All conditions false: assign final else value.
-        getStmtCtx().pushScope();
-        assignValue(static_cast<int>(condExpr.values().size()) - 1);
-        getStmtCtx().finalizeAndPop();
-      } else {
-        getStmtCtx().pushScope();
-        const hlfir::EntityWithAttributes condEntity =
-            gen(condExpr.conditions()[i]);
-        mlir::Value condition =
-            hlfir::loadTrivialScalar(loc, builder, condEntity);
-        condition = builder.createConvert(loc, builder.getI1Type(), condition);
-        builder.genIfOp(loc, {}, condition, /*withElseRegion=*/true)
-            .genThen([&]() {
-              getStmtCtx().pushScope();
-              assignValue(i);
-              getStmtCtx().finalizeAndPop();
-            })
-            .genElse([&]() { buildIfChain(i + 1); })
-            .end();
-        getStmtCtx().finalizeAndPop();
-      }
-    };
-    buildIfChain(0);
+    getStmtCtx().pushScope();
+    const hlfir::EntityWithAttributes condEntity = gen(condExpr.condition());
+    mlir::Value condition = hlfir::loadTrivialScalar(loc, builder, condEntity);
+    condition = builder.createConvert(loc, builder.getI1Type(), condition);
+    builder.genIfOp(loc, {}, condition, /*withElseRegion=*/true)
+        .genThen([&]() {
+          getStmtCtx().pushScope();
+          assignValue(condExpr.thenValue());
+          getStmtCtx().finalizeAndPop();
+        })
+        .genElse([&]() {
+          // Recurse for nested ConditionalExpr; else assign terminal value.
+          if (const auto *nested =
+                  std::get_if<Fortran::evaluate::ConditionalExpr<T>>(
+                      &condExpr.elseValue().u)) {
+            buildConditionalIfChain(*nested, assignValue);
+          } else {
+            getStmtCtx().pushScope();
+            assignValue(condExpr.elseValue());
+            getStmtCtx().finalizeAndPop();
+          }
+        })
+        .end();
+    getStmtCtx().finalizeAndPop();
   }
 
   /// Generate scalar conditional with lazy evaluation using assignment.
@@ -1879,15 +1878,16 @@ private:
         builder, loc, tempStorage, ".cond.result",
         /*shape=*/mlir::Value{}, /*typeParams=*/typeParams);
     const hlfir::Entity temp{tempDecl};
-    buildConditionalIfChain(condExpr, [&](int valueIndex) {
-      hlfir::Entity entity = gen(condExpr.values()[valueIndex]);
-      auto [exv, cleanup] = hlfir::convertToValue(loc, builder, entity);
-      hlfir::Entity value{fir::getBase(exv)};
-      if (cleanup) {
-        getStmtCtx().attachCleanup(*cleanup);
-      }
-      hlfir::AssignOp::create(builder, loc, value, temp);
-    });
+    buildConditionalIfChain(
+        condExpr, [&](const Fortran::evaluate::Expr<T> &expr) {
+          hlfir::Entity entity = gen(expr);
+          auto [exv, cleanup] = hlfir::convertToValue(loc, builder, entity);
+          hlfir::Entity value{fir::getBase(exv)};
+          if (cleanup) {
+            getStmtCtx().attachCleanup(*cleanup);
+          }
+          hlfir::AssignOp::create(builder, loc, value, temp);
+        });
     return temp;
   }
 
@@ -1912,13 +1912,14 @@ private:
         hlfir::DeclareOp::create(builder, loc, tempStorage, ".cond.result");
     const hlfir::Entity temp{tempDecl};
     // Lazy evaluation: only the selected branch is evaluated and assigned.
-    buildConditionalIfChain(condExpr, [&](int valueIndex) {
-      const hlfir::Entity entity = gen(condExpr.values()[valueIndex]);
-      hlfir::AssignOp::create(builder, loc, entity, temp,
-                              /*isWholeAllocatableAssignment=*/true,
-                              /*keepLhsLengthIfRealloc=*/false,
-                              /*temporary_lhs=*/true);
-    });
+    buildConditionalIfChain(
+        condExpr, [&](const Fortran::evaluate::Expr<T> &expr) {
+          const hlfir::Entity entity = gen(expr);
+          hlfir::AssignOp::create(builder, loc, entity, temp,
+                                  /*isWholeAllocatableAssignment=*/true,
+                                  /*keepLhsLengthIfRealloc=*/false,
+                                  /*temporary_lhs=*/true);
+        });
     return temp;
   }
 
@@ -1977,12 +1978,6 @@ private:
   template <typename T>
   hlfir::EntityWithAttributes
   gen(const Fortran::evaluate::ConditionalExpr<T> &condExpr) {
-    assert(!condExpr.conditions().empty() &&
-           "conditional expression must have conditions");
-    assert(!condExpr.values().empty() &&
-           "conditional expression must have values");
-    assert(condExpr.values().size() == condExpr.conditions().size() + 1 &&
-           "values must have exactly one more element than conditions");
     const int rank = condExpr.Rank();
 
     // Arrays: handle early to avoid unnecessary type checks.

--- a/flang/lib/Lower/ConvertExprToHLFIR.cpp
+++ b/flang/lib/Lower/ConvertExprToHLFIR.cpp
@@ -1920,6 +1920,13 @@ private:
                                   /*keepLhsLengthIfRealloc=*/false,
                                   /*temporary_lhs=*/true);
         });
+    fir::FirOpBuilder *const bldr{&builder};
+    getStmtCtx().attachCleanup([=]() {
+      fir::factory::genFreememIfAllocated(
+          *bldr, loc,
+          fir::MutableBoxValue{tempStorage, /*lenParams=*/{},
+                               fir::MutableProperties{}});
+    });
     return temp;
   }
 

--- a/flang/lib/Lower/ConvertExprToHLFIR.cpp
+++ b/flang/lib/Lower/ConvertExprToHLFIR.cpp
@@ -1847,16 +1847,9 @@ private:
           getStmtCtx().finalizeAndPop();
         })
         .genElse([&]() {
-          // Recurse for nested ConditionalExpr; else assign terminal value.
-          if (const auto *nested =
-                  std::get_if<Fortran::evaluate::ConditionalExpr<T>>(
-                      &condExpr.elseValue().u)) {
-            buildConditionalIfChain(*nested, assignValue);
-          } else {
-            getStmtCtx().pushScope();
-            assignValue(condExpr.elseValue());
-            getStmtCtx().finalizeAndPop();
-          }
+          getStmtCtx().pushScope();
+          assignValue(condExpr.elseValue());
+          getStmtCtx().finalizeAndPop();
         })
         .end();
     getStmtCtx().finalizeAndPop();
@@ -1865,10 +1858,10 @@ private:
   /// Generate scalar conditional with lazy evaluation using assignment.
   /// Creates a temporary and assigns the selected branch value to it.
   template <typename T>
-  hlfir::Entity genScalarConditionalLazy(
-      const Fortran::evaluate::ConditionalExpr<T> &condExpr,
-      mlir::Type elementType,
-      const llvm::SmallVector<mlir::Value, 1> &typeParams) {
+  hlfir::Entity
+  genScalarConditional(const Fortran::evaluate::ConditionalExpr<T> &condExpr,
+                       mlir::Type elementType,
+                       const llvm::SmallVector<mlir::Value, 1> &typeParams) {
     const mlir::Location loc{getLoc()};
     fir::FirOpBuilder &builder{getBuilder()};
     const mlir::Value tempStorage{builder.createTemporary(
@@ -1881,12 +1874,8 @@ private:
     buildConditionalIfChain(
         condExpr, [&](const Fortran::evaluate::Expr<T> &expr) {
           hlfir::Entity entity{gen(expr)};
-          auto [exv, cleanup] = hlfir::convertToValue(loc, builder, entity);
-          hlfir::Entity value{fir::getBase(exv)};
-          if (cleanup) {
-            getStmtCtx().attachCleanup(*cleanup);
-          }
-          hlfir::AssignOp::create(builder, loc, value, temp);
+          entity = hlfir::derefPointersAndAllocatables(loc, builder, entity);
+          hlfir::AssignOp::create(builder, loc, entity, temp);
         });
     return temp;
   }
@@ -1896,7 +1885,7 @@ private:
   /// set the value from the chosen branch (allocation/reallocation handled by
   /// runtime).
   template <typename T>
-  hlfir::Entity genAllocatableConditionalLazy(
+  hlfir::Entity genAllocatableConditional(
       const Fortran::evaluate::ConditionalExpr<T> &condExpr,
       mlir::Type resultType, llvm::StringRef debugName) {
     const mlir::Location loc{getLoc()};
@@ -1930,31 +1919,6 @@ private:
     return temp;
   }
 
-  /// Generate scalar CHARACTER conditional with deferred-length using lazy
-  /// evaluation. Only the chosen branch is evaluated; the result gets that
-  /// branch's length.
-  template <typename T>
-  hlfir::Entity genScalarDeferredCharConditionalLazy(
-      const Fortran::evaluate::ConditionalExpr<T> &condExpr,
-      mlir::Type elementType) {
-    return genAllocatableConditionalLazy(condExpr, elementType, ".cond.char");
-  }
-
-  /// Generate array conditional expression with lazy evaluation using
-  /// assignment. Per F2023 10.1.4(7), the shape is determined by the chosen
-  /// branch.
-  template <typename T>
-  hlfir::Entity genArrayConditionalLazy(
-      const Fortran::evaluate::ConditionalExpr<T> &condExpr) {
-    mlir::Type condResultType{Fortran::lower::translateSomeExprToFIRType(
-        converter, toEvExpr(condExpr))};
-    if (auto boxTy = mlir::dyn_cast<fir::BoxType>(condResultType)) {
-      condResultType = fir::unwrapRefType(boxTy.getEleTy());
-    }
-    return genAllocatableConditionalLazy(condExpr, condResultType,
-                                         ".cond.array");
-  }
-
   /// Generate scalar CHARACTER conditional with proper length handling.
   template <typename T>
   std::optional<hlfir::EntityWithAttributes> genCharacterConditional(
@@ -1971,12 +1935,12 @@ private:
             loc, builder.getCharacterLengthType(), charType.getLen())};
         typeParams.push_back(len);
         return hlfir::EntityWithAttributes{
-            genScalarConditionalLazy(condExpr, elementType, typeParams)};
+            genScalarConditional(condExpr, elementType, typeParams)};
       }
       // Non-constant/varying length: use allocatable conditional to get length
       // from selected branch.
       return hlfir::EntityWithAttributes{
-          genScalarDeferredCharConditionalLazy(condExpr, elementType)};
+          genAllocatableConditional(condExpr, elementType, ".cond.char")};
     }
     return std::nullopt;
   }
@@ -1990,7 +1954,12 @@ private:
     // Arrays: handle early to avoid unnecessary type checks.
     // Per F2023 10.1.4(7), the shape is determined by the chosen branch.
     if (rank != 0) {
-      return hlfir::EntityWithAttributes{genArrayConditionalLazy(condExpr)};
+      mlir::Type condResultType{Fortran::lower::translateSomeExprToFIRType(
+          converter, toEvExpr(condExpr))};
+      if (auto boxTy = mlir::dyn_cast<fir::BoxType>(condResultType))
+        condResultType = fir::unwrapRefType(boxTy.getEleTy());
+      return hlfir::EntityWithAttributes{
+          genAllocatableConditional(condExpr, condResultType, ".cond.array")};
     }
     // CHARACTER scalars require special handling for type parameters.
     if constexpr (T::category == Fortran::common::TypeCategory::Character) {
@@ -1998,23 +1967,16 @@ private:
         return *result;
       }
     }
-    // Derived type scalars require special handling for type parameters.
-    if constexpr (T::category == Fortran::common::TypeCategory::Derived) {
-      const mlir::Type resultType{Fortran::lower::translateSomeExprToFIRType(
-          converter, toEvExpr(condExpr))};
-      const mlir::Type elementType{hlfir::getFortranElementType(resultType)};
-      return hlfir::EntityWithAttributes{
-          genScalarConditionalLazy(condExpr, elementType, {})};
-    }
-    // Other scalar types (INTEGER, REAL, COMPLEX, LOGICAL, UNSIGNED).
-    mlir::Type condResultType{Fortran::lower::translateSomeExprToFIRType(
+    // Scalar types (INTEGER, REAL, COMPLEX, LOGICAL, UNSIGNED, Derived).
+    mlir::Type resultType{Fortran::lower::translateSomeExprToFIRType(
         converter, toEvExpr(condExpr))};
-    if (auto boxTy = mlir::dyn_cast<fir::BoxType>(condResultType)) {
-      condResultType = fir::unwrapRefType(boxTy.getEleTy());
+    if constexpr (T::category != Fortran::common::TypeCategory::Derived) {
+      if (auto boxTy = mlir::dyn_cast<fir::BoxType>(resultType)) {
+        resultType = fir::unwrapRefType(boxTy.getEleTy());
+      }
     }
-    const mlir::Type resultType{hlfir::getFortranElementType(condResultType)};
-    return hlfir::EntityWithAttributes{
-        genScalarConditionalLazy(condExpr, resultType, {})};
+    return hlfir::EntityWithAttributes{genScalarConditional(
+        condExpr, hlfir::getFortranElementType(resultType), {})};
   }
 
   hlfir::EntityWithAttributes

--- a/flang/test/Lower/HLFIR/conditional-expr.f90
+++ b/flang/test/Lower/HLFIR/conditional-expr.f90
@@ -137,8 +137,8 @@ subroutine test_array(flag)
   arr1 = 1
   arr2 = 2
   result = (flag ? arr1 : arr2)
-  ! CHECK: %[[BOX_ALLOC:.*]] = fir.alloca !fir.box<!fir.heap<!fir.array<?xi32>>> {bindc_name = ".cond.array"
-  ! CHECK: %[[UNALLOC:.*]] = fir.zero_bits !fir.heap<!fir.array<?xi32>>
+  ! CHECK: %[[BOX_ALLOC:.*]] = fir.alloca !fir.box<!fir.heap<!fir.array<{{.*}}xi32>>> {bindc_name = ".cond.array"
+  ! CHECK: %[[UNALLOC:.*]] = fir.zero_bits !fir.heap<!fir.array<{{.*}}xi32>>
   ! CHECK: %[[SHAPE:.*]] = fir.shape
   ! CHECK: %[[BOX:.*]] = fir.embox %[[UNALLOC]](%[[SHAPE]])
   ! CHECK: fir.store %[[BOX]] to %[[BOX_ALLOC]]
@@ -249,7 +249,7 @@ subroutine test_array_section(flag)
   logical :: flag
   integer :: arr1(20), arr2(20), result(10)
   result = (flag ? arr1(1:10) : arr2(11:20))
-  ! CHECK: %[[BOX_ALLOC:.*]] = fir.alloca !fir.box<!fir.heap<!fir.array<?xi32>>> {bindc_name = ".cond.array"
+  ! CHECK: %[[BOX_ALLOC:.*]] = fir.alloca !fir.box<!fir.heap<!fir.array<{{.*}}xi32>>> {bindc_name = ".cond.array"
   ! CHECK: fir.if
   ! CHECK:   hlfir.assign {{.*}} to {{.*}} realloc temporary_lhs
   ! CHECK: } else {

--- a/flang/test/Lower/HLFIR/conditional-expr.f90
+++ b/flang/test/Lower/HLFIR/conditional-expr.f90
@@ -1,5 +1,5 @@
 ! Test lowering of conditional expressions (Fortran 2023)
-! RUN: bbc -emit-hlfir -o - %s 2>&1 | FileCheck %s
+! RUN: %flang_fc1 -emit-hlfir -o - %s 2>&1 | FileCheck %s
 
 ! CHECK-LABEL: func.func @_QPtest_scalar_integer(
 ! CHECK-SAME:    %[[FLAG:.*]]: !fir.ref<!fir.logical<4>> {fir.bindc_name = "flag"},
@@ -98,13 +98,14 @@ subroutine test_char_constant_len(flag)
   str1 = "HELLO"
   str2 = "WORLD"
   result = (flag ? str1 : str2)
-  ! CHECK: %[[TEMP:.*]] = fir.alloca !fir.char<1,5> {bindc_name = ".cond.scalar"
-  ! CHECK: %{{.*}} = arith.constant 5 : index
-  ! CHECK: %[[TEMP_DECL:.*]]:2 = hlfir.declare %[[TEMP]] typeparams %{{.*}} {uniq_name = ".cond.result"}
+  ! Per F2023, the length type parameter is that of the chosen branch, so
+  ! branches may have different lengths. The result length is therefore
+  ! always only known at runtime: use the allocatable (deferred) path.
+  ! CHECK: %[[BOX_ALLOC:.*]] = fir.alloca !fir.box<!fir.heap<!fir.char<1,?>>> {bindc_name = ".cond.char"
   ! CHECK: fir.if
-  ! CHECK:   hlfir.assign {{.*}} to %[[TEMP_DECL]]#0 : !fir.ref<!fir.char<1,5>>, !fir.ref<!fir.char<1,5>>
+  ! CHECK:   hlfir.assign {{.*}} to {{.*}} realloc temporary_lhs
   ! CHECK: } else {
-  ! CHECK:   hlfir.assign {{.*}} to %[[TEMP_DECL]]#0 : !fir.ref<!fir.char<1,5>>, !fir.ref<!fir.char<1,5>>
+  ! CHECK:   hlfir.assign {{.*}} to {{.*}} realloc temporary_lhs
   ! CHECK: }
 end subroutine
 

--- a/flang/test/Lower/HLFIR/conditional-expr.f90
+++ b/flang/test/Lower/HLFIR/conditional-expr.f90
@@ -98,14 +98,13 @@ subroutine test_char_constant_len(flag)
   str1 = "HELLO"
   str2 = "WORLD"
   result = (flag ? str1 : str2)
-  ! Per F2023, the length type parameter is that of the chosen branch, so
-  ! branches may have different lengths. The result length is therefore
-  ! always only known at runtime: use the allocatable (deferred) path.
-  ! CHECK: %[[BOX_ALLOC:.*]] = fir.alloca !fir.box<!fir.heap<!fir.char<1,?>>> {bindc_name = ".cond.char"
+  ! Constant length: use scalar temp path.
+  ! CHECK: %[[TEMP:.*]] = fir.alloca !fir.char<1,5> {bindc_name = ".cond.scalar"
+  ! CHECK: %[[TEMP_DECL:.*]]:2 = hlfir.declare %[[TEMP]] typeparams {{.*}} {uniq_name = ".cond.result"}
   ! CHECK: fir.if
-  ! CHECK:   hlfir.assign {{.*}} to {{.*}} realloc temporary_lhs
+  ! CHECK:   hlfir.assign {{.*}} to %[[TEMP_DECL]]#0
   ! CHECK: } else {
-  ! CHECK:   hlfir.assign {{.*}} to {{.*}} realloc temporary_lhs
+  ! CHECK:   hlfir.assign {{.*}} to %[[TEMP_DECL]]#0
   ! CHECK: }
 end subroutine
 

--- a/flang/test/Lower/HLFIR/conditional-expr.f90
+++ b/flang/test/Lower/HLFIR/conditional-expr.f90
@@ -18,9 +18,11 @@ subroutine test_scalar_integer(flag, x, y)
   ! CHECK: %[[FLAG_LOAD:.*]] = fir.load %[[FLAG_DECL]]#0
   ! CHECK: %[[FLAG_CONV:.*]] = fir.convert %[[FLAG_LOAD]] : (!fir.logical<4>) -> i1
   ! CHECK: fir.if %[[FLAG_CONV]] {
-  ! CHECK:   hlfir.assign %[[X_DECL]]#0 to %[[TEMP_DECL]]#0 : !fir.ref<i32>, !fir.ref<i32>
+  ! CHECK:   %[[X_LOAD:.*]] = fir.load %[[X_DECL]]#0 : !fir.ref<i32>
+  ! CHECK:   hlfir.assign %[[X_LOAD]] to %[[TEMP_DECL]]#0 : i32, !fir.ref<i32>
   ! CHECK: } else {
-  ! CHECK:   hlfir.assign %[[Y_DECL]]#0 to %[[TEMP_DECL]]#0 : !fir.ref<i32>, !fir.ref<i32>
+  ! CHECK:   %[[Y_LOAD:.*]] = fir.load %[[Y_DECL]]#0 : !fir.ref<i32>
+  ! CHECK:   hlfir.assign %[[Y_LOAD]] to %[[TEMP_DECL]]#0 : i32, !fir.ref<i32>
   ! CHECK: }
   ! CHECK: %[[LOAD:.*]] = fir.load %[[TEMP_DECL]]#0
   ! CHECK: hlfir.assign %[[LOAD]] to %{{.*}} : i32, !fir.ref<i32>
@@ -34,9 +36,9 @@ subroutine test_scalar_real(flag, x, y)
   ! CHECK: %[[TEMP:.*]] = fir.alloca f32 {bindc_name = ".cond.scalar"
   ! CHECK: %[[TEMP_DECL:.*]]:2 = hlfir.declare %[[TEMP]] {uniq_name = ".cond.result"}
   ! CHECK: fir.if
-  ! CHECK:   hlfir.assign {{.*}} to %[[TEMP_DECL]]#0 : !fir.ref<f32>, !fir.ref<f32>
+  ! CHECK:   hlfir.assign {{.*}} to %[[TEMP_DECL]]#0 : f32, !fir.ref<f32>
   ! CHECK: } else {
-  ! CHECK:   hlfir.assign {{.*}} to %[[TEMP_DECL]]#0 : !fir.ref<f32>, !fir.ref<f32>
+  ! CHECK:   hlfir.assign {{.*}} to %[[TEMP_DECL]]#0 : f32, !fir.ref<f32>
   ! CHECK: }
 end subroutine
 
@@ -48,9 +50,9 @@ subroutine test_scalar_complex(flag, x, y)
   ! CHECK: %[[TEMP:.*]] = fir.alloca complex<f32> {bindc_name = ".cond.scalar"
   ! CHECK: %[[TEMP_DECL:.*]]:2 = hlfir.declare %[[TEMP]] {uniq_name = ".cond.result"}
   ! CHECK: fir.if
-  ! CHECK:   hlfir.assign {{.*}} to %[[TEMP_DECL]]#0 : !fir.ref<complex<f32>>, !fir.ref<complex<f32>>
+  ! CHECK:   hlfir.assign {{.*}} to %[[TEMP_DECL]]#0 : complex<f32>, !fir.ref<complex<f32>>
   ! CHECK: } else {
-  ! CHECK:   hlfir.assign {{.*}} to %[[TEMP_DECL]]#0 : !fir.ref<complex<f32>>, !fir.ref<complex<f32>>
+  ! CHECK:   hlfir.assign {{.*}} to %[[TEMP_DECL]]#0 : complex<f32>, !fir.ref<complex<f32>>
   ! CHECK: }
 end subroutine
 

--- a/flang/test/Lower/HLFIR/conditional-expr.f90
+++ b/flang/test/Lower/HLFIR/conditional-expr.f90
@@ -18,11 +18,9 @@ subroutine test_scalar_integer(flag, x, y)
   ! CHECK: %[[FLAG_LOAD:.*]] = fir.load %[[FLAG_DECL]]#0
   ! CHECK: %[[FLAG_CONV:.*]] = fir.convert %[[FLAG_LOAD]] : (!fir.logical<4>) -> i1
   ! CHECK: fir.if %[[FLAG_CONV]] {
-  ! CHECK:   %[[X_LOAD:.*]] = fir.load %[[X_DECL]]#0
-  ! CHECK:   hlfir.assign %[[X_LOAD]] to %[[TEMP_DECL]]#0 : i32, !fir.ref<i32>
+  ! CHECK:   hlfir.assign %[[X_DECL]]#0 to %[[TEMP_DECL]]#0 : !fir.ref<i32>, !fir.ref<i32>
   ! CHECK: } else {
-  ! CHECK:   %[[Y_LOAD:.*]] = fir.load %[[Y_DECL]]#0
-  ! CHECK:   hlfir.assign %[[Y_LOAD]] to %[[TEMP_DECL]]#0 : i32, !fir.ref<i32>
+  ! CHECK:   hlfir.assign %[[Y_DECL]]#0 to %[[TEMP_DECL]]#0 : !fir.ref<i32>, !fir.ref<i32>
   ! CHECK: }
   ! CHECK: %[[LOAD:.*]] = fir.load %[[TEMP_DECL]]#0
   ! CHECK: hlfir.assign %[[LOAD]] to %{{.*}} : i32, !fir.ref<i32>
@@ -36,9 +34,9 @@ subroutine test_scalar_real(flag, x, y)
   ! CHECK: %[[TEMP:.*]] = fir.alloca f32 {bindc_name = ".cond.scalar"
   ! CHECK: %[[TEMP_DECL:.*]]:2 = hlfir.declare %[[TEMP]] {uniq_name = ".cond.result"}
   ! CHECK: fir.if
-  ! CHECK:   hlfir.assign {{.*}} to %[[TEMP_DECL]]#0 : f32, !fir.ref<f32>
+  ! CHECK:   hlfir.assign {{.*}} to %[[TEMP_DECL]]#0 : !fir.ref<f32>, !fir.ref<f32>
   ! CHECK: } else {
-  ! CHECK:   hlfir.assign {{.*}} to %[[TEMP_DECL]]#0 : f32, !fir.ref<f32>
+  ! CHECK:   hlfir.assign {{.*}} to %[[TEMP_DECL]]#0 : !fir.ref<f32>, !fir.ref<f32>
   ! CHECK: }
 end subroutine
 
@@ -50,9 +48,9 @@ subroutine test_scalar_complex(flag, x, y)
   ! CHECK: %[[TEMP:.*]] = fir.alloca complex<f32> {bindc_name = ".cond.scalar"
   ! CHECK: %[[TEMP_DECL:.*]]:2 = hlfir.declare %[[TEMP]] {uniq_name = ".cond.result"}
   ! CHECK: fir.if
-  ! CHECK:   hlfir.assign {{.*}} to %[[TEMP_DECL]]#0 : complex<f32>, !fir.ref<complex<f32>>
+  ! CHECK:   hlfir.assign {{.*}} to %[[TEMP_DECL]]#0 : !fir.ref<complex<f32>>, !fir.ref<complex<f32>>
   ! CHECK: } else {
-  ! CHECK:   hlfir.assign {{.*}} to %[[TEMP_DECL]]#0 : complex<f32>, !fir.ref<complex<f32>>
+  ! CHECK:   hlfir.assign {{.*}} to %[[TEMP_DECL]]#0 : !fir.ref<complex<f32>>, !fir.ref<complex<f32>>
   ! CHECK: }
 end subroutine
 
@@ -71,23 +69,25 @@ subroutine test_multi_branch(x)
   integer :: x, result
   ! Multi-branch: x > 10 ? 100 : x > 5 ? 50 : 0
   result = (x > 10 ? 100 : x > 5 ? 50 : 0)
-  ! CHECK: %[[TEMP:.*]] = fir.alloca i32 {bindc_name = ".cond.scalar"
-  ! CHECK: %[[TEMP_DECL:.*]]:2 = hlfir.declare %[[TEMP]] {uniq_name = ".cond.result"}
-  ! First condition: x > 10
-  ! CHECK: %[[CMP1:.*]] = arith.cmpi sgt
-  ! CHECK: fir.if %[[CMP1]] {
-  ! CHECK:   %[[C100:.*]] = arith.constant 100
-  ! CHECK:   hlfir.assign %[[C100]] to %[[TEMP_DECL]]#0
+  ! Both outer and inner temps are hoisted to function entry.
+  ! CHECK-DAG: fir.alloca i32 {bindc_name = ".cond.scalar"
+  ! CHECK-DAG: fir.alloca i32 {bindc_name = ".cond.scalar"
+  ! Outer temp declaration and first condition: x > 10
+  ! CHECK: hlfir.declare {{.*}} {uniq_name = ".cond.result"}
+  ! CHECK: arith.cmpi sgt
+  ! CHECK: fir.if {{.*}} {
+  ! CHECK:   hlfir.assign {{.*}}
   ! CHECK: } else {
-  ! Second condition: x > 5
-  ! CHECK:   %[[CMP2:.*]] = arith.cmpi sgt
-  ! CHECK:   fir.if %[[CMP2]] {
-  ! CHECK:     %[[C50:.*]] = arith.constant 50
-  ! CHECK:     hlfir.assign %[[C50]] to %[[TEMP_DECL]]#0
+  ! Inner temp for the nested conditional: x > 5 ? 50 : 0
+  ! CHECK:   hlfir.declare {{.*}} {uniq_name = ".cond.result"}
+  ! CHECK:   arith.cmpi sgt
+  ! CHECK:   fir.if {{.*}} {
+  ! CHECK:     hlfir.assign {{.*}}
   ! CHECK:   } else {
-  ! CHECK:     %[[C0:.*]] = arith.constant 0
-  ! CHECK:     hlfir.assign %[[C0]] to %[[TEMP_DECL]]#0
+  ! CHECK:     hlfir.assign {{.*}}
   ! CHECK:   }
+  ! CHECK:   fir.load
+  ! CHECK:   hlfir.assign {{.*}}
   ! CHECK: }
 end subroutine
 
@@ -174,8 +174,9 @@ subroutine test_nested_conditionals(flag1, flag2, x, y, z)
   integer :: x, y, z, result
   ! Nested: flag1 ? (flag2 ? x : y) : z
   result = (flag1 ? (flag2 ? x : y) : z)
-  ! Outer temp allocation
-  ! CHECK: fir.alloca i32 {bindc_name = ".cond.scalar"
+  ! Both outer and inner temps are hoisted to function entry.
+  ! CHECK-DAG: fir.alloca i32 {bindc_name = ".cond.scalar"
+  ! CHECK-DAG: fir.alloca i32 {bindc_name = ".cond.scalar"
   ! Outer temp declaration and conditional
   ! CHECK: hlfir.declare {{.*}} {uniq_name = ".cond.result"}
   ! CHECK: fir.if {{%.*}} {
@@ -186,7 +187,6 @@ subroutine test_nested_conditionals(flag1, flag2, x, y, z)
   ! CHECK:   } else {
   ! CHECK:     hlfir.assign {{.*}}
   ! CHECK:   }
-  ! CHECK:   fir.load
   ! CHECK:   hlfir.assign {{.*}}
   ! CHECK: } else {
   ! CHECK:   hlfir.assign {{.*}}

--- a/flang/test/Lower/HLFIR/conditional-expr.f90
+++ b/flang/test/Lower/HLFIR/conditional-expr.f90
@@ -1,0 +1,257 @@
+! Test lowering of conditional expressions (Fortran 2023)
+! RUN: bbc -emit-hlfir -o - %s 2>&1 | FileCheck %s
+
+! CHECK-LABEL: func.func @_QPtest_scalar_integer(
+! CHECK-SAME:    %[[FLAG:.*]]: !fir.ref<!fir.logical<4>> {fir.bindc_name = "flag"},
+! CHECK-SAME:    %[[X:.*]]: !fir.ref<i32> {fir.bindc_name = "x"},
+! CHECK-SAME:    %[[Y:.*]]: !fir.ref<i32> {fir.bindc_name = "y"})
+subroutine test_scalar_integer(flag, x, y)
+  logical :: flag
+  integer :: x, y, result
+  ! CHECK: %[[TEMP:.*]] = fir.alloca i32 {bindc_name = ".cond.scalar"
+  ! CHECK-DAG: %[[FLAG_DECL:.*]]:2 = hlfir.declare %[[FLAG]]
+  ! CHECK-DAG: %[[X_DECL:.*]]:2 = hlfir.declare %[[X]]
+  ! CHECK-DAG: %[[Y_DECL:.*]]:2 = hlfir.declare %[[Y]]
+  ! CHECK: %[[TEMP_DECL:.*]]:2 = hlfir.declare %[[TEMP]] {uniq_name = ".cond.result"}
+
+  result = (flag ? x : y)
+  ! CHECK: %[[FLAG_LOAD:.*]] = fir.load %[[FLAG_DECL]]#0
+  ! CHECK: %[[FLAG_CONV:.*]] = fir.convert %[[FLAG_LOAD]] : (!fir.logical<4>) -> i1
+  ! CHECK: fir.if %[[FLAG_CONV]] {
+  ! CHECK:   %[[X_LOAD:.*]] = fir.load %[[X_DECL]]#0
+  ! CHECK:   hlfir.assign %[[X_LOAD]] to %[[TEMP_DECL]]#0 : i32, !fir.ref<i32>
+  ! CHECK: } else {
+  ! CHECK:   %[[Y_LOAD:.*]] = fir.load %[[Y_DECL]]#0
+  ! CHECK:   hlfir.assign %[[Y_LOAD]] to %[[TEMP_DECL]]#0 : i32, !fir.ref<i32>
+  ! CHECK: }
+  ! CHECK: %[[LOAD:.*]] = fir.load %[[TEMP_DECL]]#0
+  ! CHECK: hlfir.assign %[[LOAD]] to %{{.*}} : i32, !fir.ref<i32>
+end subroutine
+
+! CHECK-LABEL: func.func @_QPtest_scalar_real(
+subroutine test_scalar_real(flag, x, y)
+  logical :: flag
+  real :: x, y, result
+  result = (flag ? x : y)
+  ! CHECK: %[[TEMP:.*]] = fir.alloca f32 {bindc_name = ".cond.scalar"
+  ! CHECK: %[[TEMP_DECL:.*]]:2 = hlfir.declare %[[TEMP]] {uniq_name = ".cond.result"}
+  ! CHECK: fir.if
+  ! CHECK:   hlfir.assign {{.*}} to %[[TEMP_DECL]]#0 : f32, !fir.ref<f32>
+  ! CHECK: } else {
+  ! CHECK:   hlfir.assign {{.*}} to %[[TEMP_DECL]]#0 : f32, !fir.ref<f32>
+  ! CHECK: }
+end subroutine
+
+! CHECK-LABEL: func.func @_QPtest_scalar_complex(
+subroutine test_scalar_complex(flag, x, y)
+  logical :: flag
+  complex :: x, y, result
+  result = (flag ? x : y)
+  ! CHECK: %[[TEMP:.*]] = fir.alloca complex<f32> {bindc_name = ".cond.scalar"
+  ! CHECK: %[[TEMP_DECL:.*]]:2 = hlfir.declare %[[TEMP]] {uniq_name = ".cond.result"}
+  ! CHECK: fir.if
+  ! CHECK:   hlfir.assign {{.*}} to %[[TEMP_DECL]]#0 : complex<f32>, !fir.ref<complex<f32>>
+  ! CHECK: } else {
+  ! CHECK:   hlfir.assign {{.*}} to %[[TEMP_DECL]]#0 : complex<f32>, !fir.ref<complex<f32>>
+  ! CHECK: }
+end subroutine
+
+! CHECK-LABEL: func.func @_QPtest_scalar_logical(
+subroutine test_scalar_logical(flag, x, y)
+  logical :: flag, x, y, result
+  result = (flag ? x : y)
+  ! CHECK: %[[TEMP:.*]] = fir.alloca !fir.logical<4> {bindc_name = ".cond.scalar"
+  ! CHECK: fir.if
+  ! CHECK: } else {
+  ! CHECK: }
+end subroutine
+
+! CHECK-LABEL: func.func @_QPtest_multi_branch(
+subroutine test_multi_branch(x)
+  integer :: x, result
+  ! Multi-branch: x > 10 ? 100 : x > 5 ? 50 : 0
+  result = (x > 10 ? 100 : x > 5 ? 50 : 0)
+  ! CHECK: %[[TEMP:.*]] = fir.alloca i32 {bindc_name = ".cond.scalar"
+  ! CHECK: %[[TEMP_DECL:.*]]:2 = hlfir.declare %[[TEMP]] {uniq_name = ".cond.result"}
+  ! First condition: x > 10
+  ! CHECK: %[[CMP1:.*]] = arith.cmpi sgt
+  ! CHECK: fir.if %[[CMP1]] {
+  ! CHECK:   %[[C100:.*]] = arith.constant 100
+  ! CHECK:   hlfir.assign %[[C100]] to %[[TEMP_DECL]]#0
+  ! CHECK: } else {
+  ! Second condition: x > 5
+  ! CHECK:   %[[CMP2:.*]] = arith.cmpi sgt
+  ! CHECK:   fir.if %[[CMP2]] {
+  ! CHECK:     %[[C50:.*]] = arith.constant 50
+  ! CHECK:     hlfir.assign %[[C50]] to %[[TEMP_DECL]]#0
+  ! CHECK:   } else {
+  ! CHECK:     %[[C0:.*]] = arith.constant 0
+  ! CHECK:     hlfir.assign %[[C0]] to %[[TEMP_DECL]]#0
+  ! CHECK:   }
+  ! CHECK: }
+end subroutine
+
+! CHECK-LABEL: func.func @_QPtest_char_constant_len(
+subroutine test_char_constant_len(flag)
+  logical :: flag
+  character(len=5) :: str1, str2, result
+  str1 = "HELLO"
+  str2 = "WORLD"
+  result = (flag ? str1 : str2)
+  ! CHECK: %[[TEMP:.*]] = fir.alloca !fir.char<1,5> {bindc_name = ".cond.scalar"
+  ! CHECK: %{{.*}} = arith.constant 5 : index
+  ! CHECK: %[[TEMP_DECL:.*]]:2 = hlfir.declare %[[TEMP]] typeparams %{{.*}} {uniq_name = ".cond.result"}
+  ! CHECK: fir.if
+  ! CHECK:   hlfir.assign {{.*}} to %[[TEMP_DECL]]#0 : !fir.ref<!fir.char<1,5>>, !fir.ref<!fir.char<1,5>>
+  ! CHECK: } else {
+  ! CHECK:   hlfir.assign {{.*}} to %[[TEMP_DECL]]#0 : !fir.ref<!fir.char<1,5>>, !fir.ref<!fir.char<1,5>>
+  ! CHECK: }
+end subroutine
+
+! CHECK-LABEL: func.func @_QPtest_char_deferred_len(
+subroutine test_char_deferred_len(flag)
+  logical :: flag
+  character(len=:), allocatable :: str1, str2, result
+  str1 = "SHORT"
+  str2 = "A MUCH LONGER STRING"
+  ! Result length comes from selected branch
+  result = (flag ? str1 : str2)
+  ! CHECK-DAG: %[[BOX_ALLOC:.*]] = fir.alloca !fir.box<!fir.heap<!fir.char<1,?>>> {bindc_name = ".cond.char"
+  ! CHECK-DAG: %[[UNALLOC:.*]] = fir.zero_bits !fir.heap<!fir.char<1,?>>
+  ! CHECK-DAG: %[[C0:.*]] = arith.constant 0 : index
+  ! CHECK: %[[BOX:.*]] = fir.embox %[[UNALLOC]] typeparams %[[C0]]
+  ! CHECK: fir.store %[[BOX]] to %{{.*}} : !fir.ref<!fir.box<!fir.heap<!fir.char<1,?>>>>
+  ! CHECK: %[[BOX_DECL:.*]]:2 = hlfir.declare %[[BOX_ALLOC]] {uniq_name = ".cond.result"}
+  ! CHECK: fir.if
+  ! CHECK:   hlfir.assign {{.*}} to %[[BOX_DECL]]#0 realloc temporary_lhs
+  ! CHECK: } else {
+  ! CHECK:   hlfir.assign {{.*}} to %[[BOX_DECL]]#0 realloc temporary_lhs
+  ! CHECK: }
+end subroutine
+
+! CHECK-LABEL: func.func @_QPtest_array(
+subroutine test_array(flag)
+  logical :: flag
+  integer :: arr1(10), arr2(10), result(10)
+  arr1 = 1
+  arr2 = 2
+  result = (flag ? arr1 : arr2)
+  ! CHECK: %[[BOX_ALLOC:.*]] = fir.alloca !fir.box<!fir.heap<!fir.array<?xi32>>> {bindc_name = ".cond.array"
+  ! CHECK: %[[UNALLOC:.*]] = fir.zero_bits !fir.heap<!fir.array<?xi32>>
+  ! CHECK: %[[SHAPE:.*]] = fir.shape
+  ! CHECK: %[[BOX:.*]] = fir.embox %[[UNALLOC]](%[[SHAPE]])
+  ! CHECK: fir.store %[[BOX]] to %[[BOX_ALLOC]]
+  ! CHECK: %[[BOX_DECL:.*]]:2 = hlfir.declare %[[BOX_ALLOC]] {uniq_name = ".cond.result"}
+  ! CHECK: fir.if
+  ! CHECK:   hlfir.assign {{.*}} to %[[BOX_DECL]]#0 realloc temporary_lhs
+  ! CHECK: } else {
+  ! CHECK:   hlfir.assign {{.*}} to %[[BOX_DECL]]#0 realloc temporary_lhs
+  ! CHECK: }
+end subroutine
+
+! CHECK-LABEL: func.func @_QPtest_derived_type(
+subroutine test_derived_type(flag)
+  type :: point
+    real :: x, y
+  end type
+  logical :: flag
+  type(point) :: p1, p2, result
+  p1 = point(1.0, 2.0)
+  p2 = point(3.0, 4.0)
+  result = (flag ? p1 : p2)
+  ! CHECK: %[[TEMP:.*]] = fir.alloca !fir.type<_QFtest_derived_typeTpoint{x:f32,y:f32}> {bindc_name = ".cond.scalar"
+  ! CHECK: %[[TEMP_DECL:.*]]:2 = hlfir.declare %[[TEMP]] {uniq_name = ".cond.result"}
+  ! CHECK: fir.if
+  ! CHECK:   hlfir.assign {{.*}} to %[[TEMP_DECL]]#0 : !fir.ref<!fir.type<_QFtest_derived_typeTpoint{x:f32,y:f32}>>, !fir.ref<!fir.type<_QFtest_derived_typeTpoint{x:f32,y:f32}>>
+  ! CHECK: } else {
+  ! CHECK:   hlfir.assign {{.*}} to %[[TEMP_DECL]]#0 : !fir.ref<!fir.type<_QFtest_derived_typeTpoint{x:f32,y:f32}>>, !fir.ref<!fir.type<_QFtest_derived_typeTpoint{x:f32,y:f32}>>
+  ! CHECK: }
+end subroutine
+
+! CHECK-LABEL: func.func @_QPtest_nested_conditionals(
+subroutine test_nested_conditionals(flag1, flag2, x, y, z)
+  logical :: flag1, flag2
+  integer :: x, y, z, result
+  ! Nested: flag1 ? (flag2 ? x : y) : z
+  result = (flag1 ? (flag2 ? x : y) : z)
+  ! Outer temp allocation
+  ! CHECK: fir.alloca i32 {bindc_name = ".cond.scalar"
+  ! Outer temp declaration and conditional
+  ! CHECK: hlfir.declare {{.*}} {uniq_name = ".cond.result"}
+  ! CHECK: fir.if {{%.*}} {
+  ! Inner temp declaration and conditional
+  ! CHECK:   hlfir.declare {{.*}} {uniq_name = ".cond.result"}
+  ! CHECK:   fir.if {{%.*}} {
+  ! CHECK:     hlfir.assign {{.*}}
+  ! CHECK:   } else {
+  ! CHECK:     hlfir.assign {{.*}}
+  ! CHECK:   }
+  ! CHECK:   fir.load
+  ! CHECK:   hlfir.assign {{.*}}
+  ! CHECK: } else {
+  ! CHECK:   hlfir.assign {{.*}}
+  ! CHECK: }
+end subroutine
+
+! CHECK-LABEL: func.func @_QPtest_in_expression(
+subroutine test_in_expression(flag, x, y)
+  logical :: flag
+  integer :: x, y, z
+  ! Conditional in larger expression: (flag ? x : y) + 10
+  z = (flag ? x : y) + 10
+  ! CHECK: %[[TEMP:.*]] = fir.alloca i32 {bindc_name = ".cond.scalar"
+  ! CHECK: fir.if
+  ! CHECK: } else {
+  ! CHECK: }
+  ! CHECK: %[[COND_RESULT:.*]] = fir.load
+  ! CHECK: %[[C10:.*]] = arith.constant 10
+  ! CHECK: %[[SUM:.*]] = arith.addi %[[COND_RESULT]], %[[C10]]
+  ! CHECK: hlfir.assign %[[SUM]]
+end subroutine
+
+! CHECK-LABEL: func.func @_QPtest_assumed_length_char(
+subroutine test_assumed_length_char(flag, str1, str2)
+  logical :: flag
+  character(len=*) :: str1, str2
+  character(len=100) :: result
+  result = (flag ? str1 : str2)
+  ! Deferred length path since len=* is not constant
+  ! CHECK: %[[BOX_ALLOC:.*]] = fir.alloca !fir.box<!fir.heap<!fir.char<1,?>>> {bindc_name = ".cond.char"
+  ! CHECK: fir.if
+  ! CHECK:   hlfir.assign {{.*}} to {{.*}} realloc temporary_lhs
+  ! CHECK: } else {
+  ! CHECK:   hlfir.assign {{.*}} to {{.*}} realloc temporary_lhs
+  ! CHECK: }
+end subroutine
+
+! CHECK-LABEL: func.func @_QPtest_different_kinds(
+subroutine test_different_kinds(flag)
+  logical :: flag
+  integer(kind=4) :: i4_1, i4_2, i4_result
+  integer(kind=8) :: i8_1, i8_2, i8_result
+
+  ! Both temps allocated at function start
+  ! CHECK-DAG: %{{.*}} = fir.alloca i64 {bindc_name = ".cond.scalar"}
+  ! CHECK-DAG: %{{.*}} = fir.alloca i32 {bindc_name = ".cond.scalar"}
+
+  i4_1 = 1
+  i4_2 = 2
+  i4_result = (flag ? i4_1 : i4_2)
+
+  i8_1 = 3
+  i8_2 = 4
+  i8_result = (flag ? i8_1 : i8_2)
+end subroutine
+
+! CHECK-LABEL: func.func @_QPtest_array_section(
+subroutine test_array_section(flag)
+  logical :: flag
+  integer :: arr1(20), arr2(20), result(10)
+  result = (flag ? arr1(1:10) : arr2(11:20))
+  ! CHECK: %[[BOX_ALLOC:.*]] = fir.alloca !fir.box<!fir.heap<!fir.array<?xi32>>> {bindc_name = ".cond.array"
+  ! CHECK: fir.if
+  ! CHECK:   hlfir.assign {{.*}} to {{.*}} realloc temporary_lhs
+  ! CHECK: } else {
+  ! CHECK:   hlfir.assign {{.*}} to {{.*}} realloc temporary_lhs
+  ! CHECK: }
+end subroutine

--- a/flang/test/Lower/HLFIR/conditional-expr.f90
+++ b/flang/test/Lower/HLFIR/conditional-expr.f90
@@ -255,3 +255,17 @@ subroutine test_array_section(flag)
   ! CHECK:   hlfir.assign {{.*}} to {{.*}} realloc temporary_lhs
   ! CHECK: }
 end subroutine
+
+! CHECK-LABEL: func.func @_QPtest_noncontiguous_section(
+subroutine test_noncontiguous_section(flag)
+  logical :: flag
+  integer :: arr1(20), arr2(20), result(5)
+  ! Non-contiguous stride-2 sections: result must be contiguous.
+  result = (flag ? arr1(1:10:2) : arr2(2:10:2))
+  ! CHECK: %[[BOX_ALLOC:.*]] = fir.alloca !fir.box<!fir.heap<!fir.array<{{.*}}xi32>>> {bindc_name = ".cond.array"
+  ! CHECK: fir.if
+  ! CHECK:   hlfir.assign {{.*}} to {{.*}} realloc temporary_lhs
+  ! CHECK: } else {
+  ! CHECK:   hlfir.assign {{.*}} to {{.*}} realloc temporary_lhs
+  ! CHECK: }
+end subroutine


### PR DESCRIPTION
## Implement Lowering for Fortran 2023 Conditional Expressions (R1002)

***This PR contains the lowering steps only for ease of review. DO NOT MERGE until #186489 is merged.***

Implements Fortran 2023 conditional expressions with syntax: `result = (condition ? value1 : condition2 ? value2 : ... : elseValue)`

Issue: #176999
Discourse: https://discourse.llvm.org/t/rfc-adding-conditional-expressions-in-flang-f2023/89869/1 -- note that some of the details provided in the RFC post are no longer accurate

### Implementation Details
**Lowering to HLFIR:**
- Lazy evaluation via nested if-then-else control flow
- Only the selected branch is evaluated
- Temporary allocation with proper cleanup
- Special handling for:
    - CHARACTER types with deferred length
    - Arrays (shape determined by selected branch per F2023 10.1.4(7))
    - Derived types

**LIT Testing:**
- Lowering tests: HLFIR code generation verification
- Note: Executable tests will be added to the llvm-test-suite repo (https://github.com/llvm/llvm-test-suite/pull/369)

**Limitations**
- Conditional arguments are not yet supported. This work is planned 
    - #180592
- Polymorphic types (CLASS) not yet supported in lowering
- Both limitations will emit clear error message if encountered

### Examples
```
! Simple conditional
x = (flag ? 10 : 20)

! Chained
result = (x > 0 ? 1 : x < 0 ? -1 : 0)

! Examples from F2023
( ABS (RESIDUAL)<=TOLERANCE ? ’ok’ : ’did not converge’ )
( I>0 .AND. I<=SIZE (A) ? A (I) : PRESENT (VAL) ? VAL : 0.0 )
```

AI Usage Disclosure: AI tools (Claude Sonnet 4.5) were used to assist with implementation of this feature and test code generation. I have reviewed, modified, and tested all AI-generated code.