### PR TITLE
[Hexagon] Driver: Always use resource include directory

### DIFF
--- a/clang/lib/Driver/ToolChains/Hexagon.cpp
+++ b/clang/lib/Driver/ToolChains/Hexagon.cpp
@@ -706,21 +706,18 @@ void HexagonToolChain::AddClangSystemIncludeArgs(const ArgList &DriverArgs,
   if (DriverArgs.hasArg(options::OPT_nostdinc))
     return;
 
-  const bool IsELF = !getTriple().isMusl() && !getTriple().isOSLinux();
+  const Driver &D = getDriver();
+  const bool UseBuiltins = !DriverArgs.hasArg(options::OPT_nobuiltininc);
+  const bool HasSysRoot = !D.SysRoot.empty();
   const bool IsLinuxMusl = getTriple().isMusl() && getTriple().isOSLinux();
 
-  const Driver &D = getDriver();
-  SmallString<128> ResourceDirInclude(D.ResourceDir);
-  if (!IsELF) {
+  if (UseBuiltins) {
+    SmallString<128> ResourceDirInclude(D.ResourceDir);
     llvm::sys::path::append(ResourceDirInclude, "include");
-    if (!DriverArgs.hasArg(options::OPT_nobuiltininc) &&
-        (!IsLinuxMusl || DriverArgs.hasArg(options::OPT_nostdlibinc)))
-      addSystemInclude(DriverArgs, CC1Args, ResourceDirInclude);
+    addSystemInclude(DriverArgs, CC1Args, ResourceDirInclude);
   }
   if (DriverArgs.hasArg(options::OPT_nostdlibinc))
     return;
-
-  const bool HasSysRoot = !D.SysRoot.empty();
   if (HasSysRoot) {
     SmallString<128> P(D.SysRoot);
     if (IsLinuxMusl)
@@ -733,15 +730,11 @@ void HexagonToolChain::AddClangSystemIncludeArgs(const ArgList &DriverArgs,
     addSystemInclude(DriverArgs, CC1Args, P + "/usr/local/include");
     // TOOL_INCLUDE_DIR
     AddMultilibIncludeArgs(DriverArgs, CC1Args);
+  } else {
+    std::string TargetDir = getHexagonTargetDir(D.Dir, D.PrefixDirs);
+    addExternCSystemInclude(DriverArgs, CC1Args,
+                            TargetDir + "/hexagon/include");
   }
-
-  if (!DriverArgs.hasArg(options::OPT_nobuiltininc) && IsLinuxMusl)
-    addSystemInclude(DriverArgs, CC1Args, ResourceDirInclude);
-
-  if (HasSysRoot)
-    return;
-  std::string TargetDir = getHexagonTargetDir(D.Dir, D.PrefixDirs);
-  addExternCSystemInclude(DriverArgs, CC1Args, TargetDir + "/hexagon/include");
 }
 
 void HexagonToolChain::addLibCxxIncludePaths(

--- a/clang/test/Driver/hexagon-toolchain-elf.c
+++ b/clang/test/Driver/hexagon-toolchain-elf.c
@@ -27,17 +27,32 @@
 // CHECK111: "-cc1"
 // CHECK111-NOT: "-internal-externc-isystem"
 
+// RUN: %clang -### --target=hexagon-unknown-elf \
+// RUN:   -ccc-install-dir %S/Inputs/hexagon_tree/Tools/bin \
+// RUN:   -resource-dir=%S/Inputs/resource_dir %s 2>&1 | FileCheck -check-prefix=CHECK-RESOURCE-DIR %s
+// CHECK-RESOURCE-DIR: InstalledDir: [[INSTALLED_DIR:.+]]
+// CHECK-RESOURCE-DIR: "-cc1"
+// CHECK-RESOURCE-DIR: "-resource-dir" "[[RESOURCE:[^"]+]]"
+// CHECK-RESOURCE-DIR: "-internal-isystem" "[[RESOURCE]]{{/|\\\\}}include"
+// CHECK-RESOURCE-DIR: "-internal-externc-isystem" "{{.*}}/Inputs/hexagon_tree/Tools/bin/../target/hexagon/include"
+
 // RUN: %clangxx -### --target=hexagon-unknown-elf \
 // RUN:   -ccc-install-dir %S/Inputs/hexagon_tree/Tools/bin \
 // RUN:   -nostdinc++ %s 2>&1 | FileCheck -check-prefix=CHECK112 %s
+// CHECK112: InstalledDir: [[INSTALLED_DIR:.+]]
 // CHECK112: "-cc1"
+// CHECK112: "-resource-dir" "[[RESOURCE:[^"]+]]"
+// CHECK112: "-internal-isystem" "[[RESOURCE]]{{/|\\\\}}include"
 // CHECK112-NOT: "-internal-isystem"
 // CHECK112-DAG: "-internal-externc-isystem" "{{.*}}/Inputs/hexagon_tree/Tools/bin/../target/hexagon/include"
 
 // RUN: %clangxx -### --target=hexagon-unknown-elf -fno-integrated-as    \
 // RUN:   -ccc-install-dir %S/Inputs/hexagon_tree/qc/bin \
 // RUN:   -nostdlibinc %s 2>&1 | FileCheck -check-prefix=CHECK113 %s
+// CHECK113: InstalledDir: [[INSTALLED_DIR:.+]]
 // CHECK113: "-cc1"
+// CHECK113: "-resource-dir" "[[RESOURCE:[^"]+]]"
+// CHECK113: "-internal-isystem" "[[RESOURCE]]{{/|\\\\}}include"
 // CHECK113-NOT: "-internal-isystem"
 // CHECK113-NOT: "-internal-externc-isystem"
 


### PR DESCRIPTION
Before https://github.com/llvm/llvm-project/pull/185456, non-linux triples used the resource include directory
implicitly, by logic in preprocessor. https://github.com/llvm/llvm-project/pull/185456 disables that logic
for all Hexagon triples. To compensate, add the resource include
directory in the driver. This also makes the corresponding driver
logic less convoluted.

The order of inclusion is now uniform for all triples: resource
directory first and default or user-specified sysroot next.