### PR TITLE
[clang][ssaf] Fix missing library dependency

### DIFF
--- a/clang/unittests/ScalableStaticAnalysisFramework/CMakeLists.txt
+++ b/clang/unittests/ScalableStaticAnalysisFramework/CMakeLists.txt
@@ -36,4 +36,6 @@ add_distinct_clang_unittest(ClangScalableAnalysisTests
   LLVMTestingSupport
 
   LLVM_COMPONENTS
+  FrontendOpenMP
+  Support
   )

--- a/llvm/utils/gn/secondary/clang/unittests/ScalableStaticAnalysisFramework/BUILD.gn
+++ b/llvm/utils/gn/secondary/clang/unittests/ScalableStaticAnalysisFramework/BUILD.gn
@@ -10,6 +10,8 @@ unittest("ClangScalableAnalysisTests") {
     "//clang/lib/ScalableStaticAnalysisFramework/Core",
     "//clang/lib/Serialization",
     "//clang/lib/Tooling",
+    "//llvm/lib/Frontend/OpenMP",
+    "//llvm/lib/Support",
     "//llvm/lib/Testing/Support",
   ]
   include_dirs = [ "." ]


### PR DESCRIPTION
Caused by #186442
Similar to #186475
Addresses:
https://github.com/llvm/llvm-project/pull/186475#issuecomment-4057355167

```
/usr/bin/ld: tools/clang/unittests/ScalableStaticAnalysisFramework/CMakeFiles/ClangScalableAnalysisTests.dir/ASTEntityMappingTest.cpp.o: undefined reference to symbol '_ZN4llvm3omp27isAllowedClauseForDirectiveENS0_9DirectiveENS0_6ClauseEj'
/usr/bin/ld: /home/botworker/builds/openmp-offload-amdgpu-runtime-2/llvm.build/lib/libLLVMFrontendOpenMP.so.23.0git: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
```