### PR TITLE
[MLIR][BAZEL]Update Bazel overlay for MLIR_ENABLE_ROCM_CONVERSIONS removal

### DIFF
--- a/utils/bazel/llvm-project-overlay/mlir/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/mlir/BUILD.bazel
@@ -15,7 +15,6 @@ load(
     "cc_headers_only",
     "if_cuda_available",
     "mlir_c_api_cc_library",
-    "nanobind_pyi_genrule",
 )
 load(":linalggen.bzl", "genlinalg")
 load(":tblgen.bzl", "gentbl_cc_library", "td_library")
@@ -29,7 +28,6 @@ licenses(["notice"])
 
 exports_files([
     "LICENSE.TXT",
-    "run_lit.sh",
     "utils/lldb-scripts/mlirDataFormatters.py",
     "utils/pygments/mlir_lexer.py",
     "utils/textmate/mlir.json",
@@ -59,6 +57,7 @@ expand_template(
         "#cmakedefine MLIR_GREEDY_REWRITE_RANDOMIZER_SEED ${MLIR_GREEDY_REWRITE_RANDOMIZER_SEED}": "/* #undef MLIR_GREEDY_REWRITE_RANDOMIZER_SEED */",
         "#cmakedefine01 MLIR_ENABLE_NVPTXCOMPILER": "#define MLIR_ENABLE_NVPTXCOMPILER 0",
         "#cmakedefine01 MLIR_ENABLE_PDL_IN_PATTERNMATCH": "#define MLIR_ENABLE_PDL_IN_PATTERNMATCH 1",
+        "#cmakedefine01 LLVM_HAS_AMDGPU_TARGET": "#define LLVM_HAS_AMDGPU_TARGET 0",
     },
     template = "include/mlir/Config/mlir-config.h.cmake",
 )
@@ -1328,29 +1327,6 @@ cc_binary(
         "@nanobind",
         "@rules_python//python/cc:current_py_cc_headers",
     ],
-)
-
-##---------------------------------------------------------------------------##
-# Python stub generation for native extensions.
-##---------------------------------------------------------------------------##
-
-py_binary(
-    name = "stubgen_runner",
-    srcs = ["lib/Bindings/Python/stubgen_runner.py"],
-    data = ["@nanobind//:src/stubgen.py"],
-    deps = ["@rules_python//python/runfiles"],
-)
-
-nanobind_pyi_genrule(
-    name = "_mlir_pyi",
-    outs = [
-        "_mlir/__init__.pyi",
-        "_mlir/ir.pyi",
-        "_mlir/passmanager.pyi",
-        "_mlir/rewrite.pyi",
-    ],
-    module_name = "_mlir",
-    deps = [":_mlir.so"],
 )
 
 ##---------------------------------------------------------------------------##
@@ -4521,6 +4497,7 @@ cc_library(
     hdrs = ["include/mlir/Interfaces/LoopLikeInterface.h"],
     includes = ["include"],
     deps = [
+        ":ControlFlowInterfaces",
         ":FunctionInterfaces",
         ":IR",
         ":LoopLikeInterfaceIncGen",
@@ -6082,6 +6059,7 @@ cc_library(
         "lib/Conversion/GPUCommon/AttrToSPIRVConverter.cpp",
         "lib/Conversion/GPUCommon/GPUOpsLowering.cpp",
         "lib/Conversion/GPUCommon/GPUToLLVMConversion.cpp",
+        "lib/Conversion/GPUCommon/IndexIntrinsicsOpLowering.cpp",
     ],
     hdrs = [
         "include/mlir/Conversion/GPUCommon/AttrToSPIRVConverter.h",
@@ -8307,6 +8285,7 @@ cc_library(
         ":TransformUtils",
         ":Transforms",
         ":VectorDialect",
+        ":VectorToGPU",
         ":XeGPUDialect",
         ":XeGPUUtils",
         "//llvm:Support",
@@ -10367,6 +10346,7 @@ cc_library(
         ":BytecodeOpInterface",
         ":ControlFlowInterfaces",
         ":DataLayoutInterfaces",
+        ":DialectUtils",
         ":GPUDialect",
         ":IR",
         ":LLVMDialect",
@@ -10377,6 +10357,7 @@ cc_library(
         ":OpenACCOpsInterfacesIncGen",
         ":OpenACCTypeInterfacesIncGen",
         ":OpenACCTypesIncGen",
+        ":SCFDialect",
         ":SideEffectInterfaces",
         ":Support",
         ":TransformUtils",
@@ -10453,6 +10434,7 @@ cc_library(
         ":Analysis",
         ":ArithDialect",
         ":ArithUtils",
+        ":DialectUtils",
         ":FuncDialect",
         ":FunctionInterfaces",
         ":GPUDialect",
@@ -14286,7 +14268,10 @@ cc_library(
     srcs = [
         "lib/Dialect/UB/IR/UBOps.cpp",
     ],
-    hdrs = ["include/mlir/Dialect/UB/IR/UBOps.h"],
+    hdrs = [
+        "include/mlir/Dialect/UB/IR/UBMatchers.h",
+        "include/mlir/Dialect/UB/IR/UBOps.h",
+    ],
     includes = ["include"],
     deps = [
         ":BytecodeOpInterface",

--- a/utils/bazel/llvm-project-overlay/mlir/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/mlir/BUILD.bazel
@@ -59,7 +59,6 @@ expand_template(
         "#cmakedefine MLIR_GREEDY_REWRITE_RANDOMIZER_SEED ${MLIR_GREEDY_REWRITE_RANDOMIZER_SEED}": "/* #undef MLIR_GREEDY_REWRITE_RANDOMIZER_SEED */",
         "#cmakedefine01 MLIR_ENABLE_NVPTXCOMPILER": "#define MLIR_ENABLE_NVPTXCOMPILER 0",
         "#cmakedefine01 MLIR_ENABLE_PDL_IN_PATTERNMATCH": "#define MLIR_ENABLE_PDL_IN_PATTERNMATCH 1",
-        "#cmakedefine01 MLIR_ENABLE_ROCM_CONVERSIONS": "#define MLIR_ENABLE_ROCM_CONVERSIONS 0",
     },
     template = "include/mlir/Config/mlir-config.h.cmake",
 )
@@ -6534,12 +6533,15 @@ cc_library(
         ":Support",
         ":TargetLLVM",
         ":ToLLVMIRTranslation",
+        "//llvm:AMDGPUAsmParser",
+        "//llvm:AMDGPUCodeGen",
         "//llvm:Core",
         "//llvm:FrontendOffloading",
         "//llvm:MC",
         "//llvm:MCParser",
         "//llvm:Support",
         "//llvm:TargetParser",
+        "//llvm:config",
     ],
 )
 

--- a/utils/bazel/llvm-project-overlay/mlir/test/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/mlir/test/BUILD.bazel
@@ -38,10 +38,10 @@ expand_template(
         "\"@MLIR_BINARY_DIR@\"": "os.environ[\"TEST_UNDECLARED_OUTPUTS_DIR\"]",
         # All disabled, but required to substituted because they are not in quotes.
         "@LLVM_BUILD_EXAMPLES@": "0",
-        "@LLVM_HAS_NVPTX_TARGET@": "0",
+        "@LLVM_HAS_AMDGPU_TARGET@": "1" if (targets.contains("AMDGPU")) else "0",
+        "@LLVM_HAS_NVPTX_TARGET@": "1" if (targets.contains("NVPTX")) else "0",
         "@LLVM_INCLUDE_SPIRV_TOOLS_TESTS@": "0",
         "@MLIR_ENABLE_CUDA_RUNNER@": "0",
-        "@MLIR_ENABLE_ROCM_CONVERSIONS@": "0",
         "@MLIR_ENABLE_ROCM_RUNNER@": "0",
         "@MLIR_ENABLE_SYCL_RUNNER@": "0",
         "@MLIR_ENABLE_LEVELZERO_RUNNER@": "0",

--- a/utils/bazel/llvm-project-overlay/mlir/test/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/mlir/test/BUILD.bazel
@@ -38,8 +38,8 @@ expand_template(
         "\"@MLIR_BINARY_DIR@\"": "os.environ[\"TEST_UNDECLARED_OUTPUTS_DIR\"]",
         # All disabled, but required to substituted because they are not in quotes.
         "@LLVM_BUILD_EXAMPLES@": "0",
-        "@LLVM_HAS_AMDGPU_TARGET@": "1" if (targets.contains("AMDGPU")) else "0",
-        "@LLVM_HAS_NVPTX_TARGET@": "1" if (targets.contains("NVPTX")) else "0",
+        "@LLVM_HAS_AMDGPU_TARGET@": "1" if targets.contains("AMDGPU") else "0",
+        "@LLVM_HAS_NVPTX_TARGET@": "1" if targets.contains("NVPTX") else "0",
         "@LLVM_INCLUDE_SPIRV_TOOLS_TESTS@": "0",
         "@MLIR_ENABLE_CUDA_RUNNER@": "0",
         "@MLIR_ENABLE_ROCM_RUNNER@": "0",


### PR DESCRIPTION
This is the Bazel side follow-up to #182652, which replaced `MLIR_ENABLE_ROCM_CONVERSIONS` with `LLVM_HAS_AMDGPU_TARGET`. `LLVM_HAS_AMDGPU_TARGET` is automatically set when AMDGPU is enabled during the LLVM build, without needing a separate manually-defined CMake option. This is consistent with how NVPTX already uses `LLVM_HAS_NVPTX_TARGET`.
In `mlir/BUILD.bazel`, removed the hardcoded substitution `"#cmakedefine01 MLIR_ENABLE_ROCM_CONVERSIONS": "#define MLIR_ENABLE_ROCM_CONVERSIONS 0"` from the `mlir/config.h` template. This is no longer needed because the library code now uses `LLVM_HAS_AMDGPU_TARGET` from `llvm/Config/Targets.h`, which is automatically generated by llvm_configure based on the configured targets attribute. So when downstream projects like XLA configure LLVM with AMDGPU in their target list, LLVM_HAS_AMDGPU_TARGET is correctly set to 1.
In `mlir/test/BUILD.bazel`, replaced `@MLIR_ENABLE_ROCM_CONVERSIONS@` with `@LLVM_HAS_AMDGPU_TARGET@` and wrap it up with proper conditionals based on the configured targets, instead of hardcoding to 0.