### PR TITLE
[lldb][NativePDB] Compile `vbases.test` without default libraries

### DIFF
--- a/lldb/test/Shell/SymbolFile/NativePDB/vbases.test
+++ b/lldb/test/Shell/SymbolFile/NativePDB/vbases.test
@@ -4,11 +4,11 @@
 
 # RUN: split-file %s %t
 
-# RUN: %clang_cl --target=x86_64-windows-msvc -Z7 -c /Fo%t.cv.obj -- %t/main.cpp
-# RUN: %clang_cl --target=x86_64-windows-msvc -Z7 -gdwarf -c /Fo%t.dwarf.obj -- %t/main.cpp
+# RUN: %clang_cl --target=x86_64-windows-msvc -Z7 -c /GS- /Fo%t.cv.obj -- %t/main.cpp
+# RUN: %clang_cl --target=x86_64-windows-msvc -Z7 -gdwarf -c /GS- /Fo%t.dwarf.obj -- %t/main.cpp
 
-# RUN: lld-link -debug %t.cv.obj -out:%t.cv.exe
-# RUN: lld-link -debug %t.dwarf.obj -out:%t.dwarf.exe
+# RUN: lld-link -debug -nodefaultlib -entry:main %t.cv.obj -out:%t.cv.exe
+# RUN: lld-link -debug -nodefaultlib -entry:main %t.dwarf.obj -out:%t.dwarf.exe
 
 # RUN: %lldb -f %t.cv.exe -s %t/commands.input 2>&1 | FileCheck %s
 # RUN: %lldb -f %t.dwarf.exe -s %t/commands.input 2>&1 | FileCheck %s


### PR DESCRIPTION
#185735 added the `vbases.test`, which compiles with `--target=x86_64-windows-msvc`. This will cause the final executable to be linked to `libcmt.lib`. That doesn't work on ARM, so this PR changes the command line to link without the default libraries. They're not needed if we disable `/GS` (buffer security check) like in other tests.

We use `%clang_cl` over `%build` to be able to compile with DWARF as well.