### PR TITLE
[flang] Fix SELECT TYPE in OpenACC construct

### DIFF
--- a/flang/lib/Semantics/resolve-directives.cpp
+++ b/flang/lib/Semantics/resolve-directives.cpp
@@ -1802,7 +1802,8 @@ void AccAttributeVisitor::Post(const parser::Name &name) {
   if (name.symbol && WithinConstruct()) {
     const Symbol &symbol{name.symbol->GetUltimate()};
     if (!symbol.owner().IsDerivedType() && !symbol.has<ProcEntityDetails>() &&
-        !symbol.has<SubprogramDetails>() && !IsObjectWithVisibleDSA(symbol)) {
+        !symbol.has<SubprogramDetails>() && !IsObjectWithVisibleDSA(symbol) &&
+        !symbol.has<AssocEntityDetails>()) {
       if (Symbol * found{currScope().FindSymbol(name.source)}) {
         if (&symbol != found) {
           // adjust the symbol within the region

--- a/flang/lib/Semantics/resolve-names.cpp
+++ b/flang/lib/Semantics/resolve-names.cpp
@@ -1510,7 +1510,7 @@ void AccVisitor::CopySymbolWithDevice(const parser::Name *name) {
   // clause. These new symbols have the CUDA Fortran device
   // attribute.
   if (context_.languageFeatures().IsEnabled(common::LanguageFeature::CUDA) &&
-      name->symbol) {
+      name && name->symbol) {
     if (Symbol * copy{currScope().CopySymbol(*name->symbol)}) {
       name->symbol = copy;
       if (auto *object{copy->detailsIf<ObjectEntityDetails>()}) {
@@ -1913,11 +1913,12 @@ void OmpVisitor::ResolveMapperModifier(const parser::OmpMapper &mapper) {
     auto &ultimate{symbol->GetUltimate()};
     auto *misc{ultimate.detailsIf<MiscDetails>()};
     auto *md{ultimate.detailsIf<MapperDetails>()};
-    if (!md && (!misc || misc->kind() != MiscDetails::Kind::ConstructName))
+    if (!md && (!misc || misc->kind() != MiscDetails::Kind::ConstructName)) {
       context().Say(mapper.v.source,
           "Name '%s' should be a mapper name"_err_en_US, mapper.v.source);
-    else
+    } else {
       mapper.v.symbol = symbol;
+    }
   } else {
     // Allow the special 'default' mapper identifier without prior
     // declaration so lowering can recognize and handle it. Emit an

--- a/flang/test/Semantics/bug2359.f90
+++ b/flang/test/Semantics/bug2359.f90
@@ -1,0 +1,33 @@
+! RUN: %python %S/test_symbols.py %s %flang_fc1 -fopenacc
+!DEF: /MAIN MainProgram
+program MAIN
+ !DEF: /MAIN/t ABSTRACT DerivedType
+ type, abstract :: t
+ end type
+ !REF: /MAIN/t
+ !DEF: /MAIN/t2 DerivedType
+ type, extends(t) :: t2
+  !DEF: /MAIN/t2/y ObjectEntity REAL(4)
+  real :: y
+ end type
+contains
+ !DEF: /MAIN/s (Subroutine) Subprogram
+ !DEF: /MAIN/s/d ObjectEntity CLASS(t)
+ subroutine s (d)
+  !REF: /MAIN/t
+  !REF: /MAIN/s/d
+  class(t) :: d
+  !DEF: /MAIN/s/a ObjectEntity REAL(4)
+  real a
+!$acc data create(a)
+  !REF: /MAIN/s/d
+  select type (d)
+   !REF: /MAIN/t2
+  class is (t2)
+   !DEF: /MAIN/s/OpenACCConstruct1/OtherConstruct1/d AssocEntity CLASS(t2)
+   !REF: /MAIN/t2/y
+   d%y = 1.
+  end select
+!$acc end data
+ end subroutine
+end program


### PR DESCRIPTION
A routine in Semantics/resolve-directives.cpp was overwriting a symbol table pointer in a parse tree Name, thereby removing the AssocEntity with the correct type for a TYPE IS or CLASS IS clause that had been placed there.  I don't really understand why resolve-directives has to overwrite symbol table pointers in the first place, but it definitely shouldn't be replacing these.