### PR TITLE
[flang][openacc][cuda] Fix array section and implicit device attribute

### DIFF
--- a/flang/lib/Lower/OpenACC.cpp
+++ b/flang/lib/Lower/OpenACC.cpp
@@ -2853,6 +2853,11 @@ genACCHostDataOp(Fortran::lower::AbstractConverter &converter,
             if (const auto *name =
                     Fortran::parser::GetDesignatorNameIfDataRef(*designator)) {
               newSym = name->symbol;
+            } else if (const auto *arrayElement = Fortran::parser::Unwrap<
+                           Fortran::parser::ArrayElement>(*designator)) {
+              const Fortran::parser::Name &name =
+                  Fortran::parser::GetLastName(arrayElement->Base());
+              newSym = name.symbol;
             } else if (const auto *component = Fortran::parser::Unwrap<
                            Fortran::parser::StructureComponent>(*designator)) {
               const Fortran::parser::DataRef &base{component->Base()};

--- a/flang/test/Lower/OpenACC/acc-terminator.f90
+++ b/flang/test/Lower/OpenACC/acc-terminator.f90
@@ -1,6 +1,7 @@
 ! Check that acc.terminator is not inserted in data construct
 
 ! RUN: bbc -fopenacc -emit-hlfir %s -o - | FileCheck %s
+! RUN: bbc -fopenacc -fcuda -emit-hlfir %s -o - | FileCheck %s
 
 program main
   use, intrinsic :: iso_c_binding


### PR DESCRIPTION
When CUDA Fortran is enabled, the copySymbolBinding block in
genACCHostDataOp did not handle ArrayElement designators (e.g.,
use_device(a(:,:,i))), causing a crash in getDataOperandBaseAddr
due to the copied symbol missing its IR binding.