### PR TITLE
[lldb] Fix liblldb linkage in libllvm build after 5eaf19a15129

### DIFF
--- a/lldb/source/Plugins/SymbolLocator/Debuginfod/CMakeLists.txt
+++ b/lldb/source/Plugins/SymbolLocator/Debuginfod/CMakeLists.txt
@@ -14,7 +14,9 @@ add_lldb_library(lldbPluginSymbolLocatorDebuginfod PLUGIN
     lldbHost
     lldbSymbol
     LLVMDebuginfod
-    LLVMSupportHTTP
+
+  LINK_COMPONENTS
+    SupportHTTP
   )
 
 add_dependencies(lldbPluginSymbolLocatorDebuginfod


### PR DESCRIPTION
Referencing libSupportHTTP under LINK_LIBS of add_lldb_library() pulls in the archive even in a build configuration with LLVM_LINK_LLVM_DYLIB=On, where libSupportHTTP is part of libLLVM. This patch moves it to LINK_COMPONENTS to fix the issue.