### PR TITLE
[flang][cuda][openacc] Fix interoperability when host_data is not generated

### DIFF
--- a/flang/lib/Lower/OpenACC.cpp
+++ b/flang/lib/Lower/OpenACC.cpp
@@ -2832,15 +2832,35 @@ genACCHostDataOp(Fortran::lower::AbstractConverter &converter,
 
   fir::FirOpBuilder &builder = converter.getFirOpBuilder();
 
-  AccDataMap dataMap;
   for (const Fortran::parser::AccClause &clause : accClauseList.v) {
     mlir::Location clauseLocation = converter.genLocation(clause.source);
     if (const auto *ifClause =
             std::get_if<Fortran::parser::AccClause::If>(&clause.u)) {
       genIfClause(converter, clauseLocation, ifClause, ifCond, stmtCtx);
-    } else if (const auto *useDevice =
-                   std::get_if<Fortran::parser::AccClause::UseDevice>(
-                       &clause.u)) {
+    } else if (std::get_if<Fortran::parser::AccClause::IfPresent>(&clause.u)) {
+      addIfPresentAttr = true;
+    }
+  }
+
+  if (ifCond) {
+    if (auto cst =
+            mlir::dyn_cast<mlir::arith::ConstantOp>(ifCond.getDefiningOp()))
+      if (auto boolAttr = mlir::dyn_cast<mlir::BoolAttr>(cst.getValue())) {
+        if (boolAttr.getValue()) {
+          // get rid of the if condition if it is always true.
+          ifCond = mlir::Value();
+        } else {
+          // Do not generate the acc.host_data op if the if condition is always
+          // false.
+          return;
+        }
+      }
+  }
+
+  AccDataMap dataMap;
+  for (const Fortran::parser::AccClause &clause : accClauseList.v) {
+    if (const auto *useDevice =
+            std::get_if<Fortran::parser::AccClause::UseDevice>(&clause.u)) {
       // When CUDA Fortran is enabled, extra symbols are used in the host_data
       // region. Look for them and bind their values with the symbols in the
       // outer scope.
@@ -2884,24 +2904,7 @@ genACCHostDataOp(Fortran::lower::AbstractConverter &converter,
           /*structured=*/true, /*implicit=*/false, /*async=*/{},
           /*asyncDeviceTypes=*/{}, /*asyncOnlyDeviceTypes=*/{},
           /*setDeclareAttr=*/false, &dataMap);
-    } else if (std::get_if<Fortran::parser::AccClause::IfPresent>(&clause.u)) {
-      addIfPresentAttr = true;
     }
-  }
-
-  if (ifCond) {
-    if (auto cst =
-            mlir::dyn_cast<mlir::arith::ConstantOp>(ifCond.getDefiningOp()))
-      if (auto boolAttr = mlir::dyn_cast<mlir::BoolAttr>(cst.getValue())) {
-        if (boolAttr.getValue()) {
-          // get rid of the if condition if it is always true.
-          ifCond = mlir::Value();
-        } else {
-          // Do not generate the acc.host_data op if the if condition is always
-          // false.
-          return;
-        }
-      }
   }
 
   // Prepare the operand segment size attribute and the operands value range.

--- a/flang/lib/Lower/OpenACC.cpp
+++ b/flang/lib/Lower/OpenACC.cpp
@@ -2849,10 +2849,6 @@ genACCHostDataOp(Fortran::lower::AbstractConverter &converter,
         if (boolAttr.getValue()) {
           // get rid of the if condition if it is always true.
           ifCond = mlir::Value();
-        } else {
-          // Do not generate the acc.host_data op if the if condition is always
-          // false.
-          return;
         }
       }
   }

--- a/flang/lib/Optimizer/Builder/CUFCommon.cpp
+++ b/flang/lib/Optimizer/Builder/CUFCommon.cpp
@@ -50,6 +50,8 @@ bool cuf::isCUDADeviceContext(mlir::Region &region,
     return true;
   if (region.getParentOfType<mlir::acc::ComputeRegionOpInterface>())
     return true;
+  if (region.getParentOfType<mlir::acc::HostDataOp>())
+    return true;
   if (auto funcOp = region.getParentOfType<mlir::func::FuncOp>()) {
     if (auto cudaProcAttr =
             funcOp.getOperation()->getAttrOfType<cuf::ProcAttributeAttr>(

--- a/flang/test/Lower/OpenACC/acc-host-data.f90
+++ b/flang/test/Lower/OpenACC/acc-host-data.f90
@@ -48,7 +48,7 @@ subroutine acc_host_data()
     a = 1.0
   !$acc end host_data
 
-! CHECK-NOT: acc.host_data
-! CHECK: hlfir.assign %{{.*}} to %[[DECLA]]#0
+! CHECK: acc.host_data if(%{{.*}})
+! CHECK: hlfir.assign %{{.*}} to %{{.*}}#0
 
 end subroutine

--- a/flang/test/Lower/OpenACC/acc-host-data.f90
+++ b/flang/test/Lower/OpenACC/acc-host-data.f90
@@ -1,6 +1,7 @@
 ! This test checks lowering of OpenACC host_data directive.
 
 ! RUN: bbc -fopenacc -emit-hlfir %s -o - | FileCheck %s
+! RUN: bbc -fopenacc -fcuda -emit-hlfir %s -o - | FileCheck %s
 
 subroutine acc_host_data()
   real, dimension(10) :: a
@@ -32,9 +33,9 @@ subroutine acc_host_data()
   !$acc host_data use_device(a) if(ifCondition)
   !$acc end host_data
 
-! CHECK: %[[DA0:.*]] = acc.use_device varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10xf32>>) -> !fir.ref<!fir.array<10xf32>> {name = "a"}
 ! CHECK: %[[LOAD_IFCOND:.*]] = fir.load %[[DECLIFCOND]]#0 : !fir.ref<!fir.logical<4>>
 ! CHECK: %[[IFCOND_I1:.*]] = fir.convert %[[LOAD_IFCOND]] : (!fir.logical<4>) -> i1
+! CHECK: %[[DA0:.*]] = acc.use_device varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10xf32>>) -> !fir.ref<!fir.array<10xf32>> {name = "a"}
 ! CHECK: acc.host_data if(%[[IFCOND_I1]]) dataOperands(%[[DA0]] : !fir.ref<!fir.array<10xf32>>)
 
   !$acc host_data use_device(a) if(.true.)


### PR DESCRIPTION
Update lowering to not process operands if the operation will not be generated because of a `if(.false.)` clause. This was breaking when enabling CUDA Fortran on the same test. 