### PR TITLE
[lldb] Upstream missing FixCodeAddress in CPPLanguageRuntime

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/CPlusPlus/CPPLanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/CPlusPlus/CPPLanguageRuntime.cpp
@@ -250,11 +250,19 @@ CPPLanguageRuntime::FindLibCppStdFunctionCallableInfo(
   lldb::addr_t vtable_address =
       process->ReadPointerFromMemory(member_f_pointer_value, status);
 
+  ABISP abi_sp = process->GetABI();
+  if (abi_sp)
+    vtable_address = abi_sp->FixCodeAddress(vtable_address);
+
   if (status.Fail())
     return optional_info;
 
   lldb::addr_t vtable_address_first_entry =
       process->ReadPointerFromMemory(vtable_address + address_size, status);
+
+  if (abi_sp)
+    vtable_address_first_entry =
+        abi_sp->FixCodeAddress(vtable_address_first_entry);
 
   if (status.Fail())
     return optional_info;
@@ -264,6 +272,10 @@ CPPLanguageRuntime::FindLibCppStdFunctionCallableInfo(
   // need it.
   lldb::addr_t possible_function_address =
       process->ReadPointerFromMemory(address_after_vtable, status);
+
+  if (abi_sp)
+    possible_function_address =
+        abi_sp->FixCodeAddress(possible_function_address);
 
   if (status.Fail())
     return optional_info;


### PR DESCRIPTION
When working on #186001, I found these calls to `FixCodeAddress` that were missing from upstream. These were added to make the std::function tests passing when running the test suite against arm64e, which explains the lack of a dedicated test.

rdar://58692850