### PR TITLE
[Clang][Sema] Add fortify warnings for bcopy and bzero  (#168965)

### DIFF
--- a/clang/lib/Sema/SemaChecking.cpp
+++ b/clang/lib/Sema/SemaChecking.cpp
@@ -1405,6 +1405,8 @@ void Sema::checkFortifiedBuiltinMemoryFunction(FunctionDecl *FD,
     break;
   }
 
+  case Builtin::BIbzero:
+  case Builtin::BI__builtin_bzero:
   case Builtin::BImemcpy:
   case Builtin::BI__builtin_memcpy:
   case Builtin::BImemmove:
@@ -1416,6 +1418,13 @@ void Sema::checkFortifiedBuiltinMemoryFunction(FunctionDecl *FD,
     DiagID = diag::warn_fortify_source_overflow;
     SourceSize = ComputeExplicitObjectSizeArgument(TheCall->getNumArgs() - 1);
     DestinationSize = ComputeSizeArgument(0);
+    break;
+  }
+  case Builtin::BIbcopy:
+  case Builtin::BI__builtin_bcopy: {
+    DiagID = diag::warn_fortify_source_overflow;
+    SourceSize = ComputeExplicitObjectSizeArgument(TheCall->getNumArgs() - 1);
+    DestinationSize = ComputeSizeArgument(1);
     break;
   }
   case Builtin::BIsnprintf:

--- a/clang/test/Analysis/bstring.c
+++ b/clang/test/Analysis/bstring.c
@@ -508,7 +508,8 @@ void bcopy2 (void) {
   char src[] = {1, 2, 3, 4};
   char dst[1];
 
-  bcopy(src, dst, 4); // expected-warning{{overflow}}
+  bcopy(src, dst, 4); // expected-warning {{Memory copy function overflows the destination buffer}}
+  // expected-warning@-1 {{bcopy' will always overflow; destination buffer has size 1, but size argument is 4}}
 }
 
 void *malloc(size_t);

--- a/clang/test/Sema/warn-fortify-source.c
+++ b/clang/test/Sema/warn-fortify-source.c
@@ -21,6 +21,8 @@ extern int sprintf(char *str, const char *format, ...);
 #else
 void *memcpy(void *dst, const void *src, size_t c);
 #endif
+void bcopy(const void *src, void *dst, size_t n);
+void bzero(void *dst, size_t n);
 
 #ifdef __cplusplus
 }
@@ -102,6 +104,16 @@ void call_memset(void) {
   char buf[10];
   __builtin_memset(buf, 0xff, 10);
   __builtin_memset(buf, 0xff, 11); // expected-warning {{'memset' will always overflow; destination buffer has size 10, but size argument is 11}}
+}
+
+void call_bcopy_bzero(void) {
+  char src[20], dst[10];
+  bcopy(src, dst, 20); // expected-warning {{'bcopy' will always overflow; destination buffer has size 10, but size argument is 20}}
+  bzero(dst, 11); // expected-warning {{'bzero' will always overflow; destination buffer has size 10, but size argument is 11}}
+  __builtin_bcopy(src, dst, 10);
+  __builtin_bcopy(src, dst, 20); // expected-warning {{'bcopy' will always overflow; destination buffer has size 10, but size argument is 20}}
+  __builtin_bzero(dst, 10);
+  __builtin_bzero(dst, 11); // expected-warning {{'bzero' will always overflow; destination buffer has size 10, but size argument is 11}}
 }
 
 void call_snprintf(double d, int n) {


### PR DESCRIPTION
Add fortify warnings for bcopy and bzero as part of [llvm#142230](https://github.com/llvm/llvm-project/issues/142230)