### PR TITLE
[flang] Fix FIRToMemRef index computation for array_coor with shape_shift and slice

### DIFF
--- a/flang/lib/Optimizer/Transforms/FIRToMemRef.cpp
+++ b/flang/lib/Optimizer/Transforms/FIRToMemRef.cpp
@@ -443,8 +443,16 @@ FIRToMemRef::getMemrefIndices(fir::ArrayCoorOp arrayCoorOp, Operation *memref,
     Value stride = isSliced ? sliceStrides[i] : one;
     Value sliceLb = isSliced ? sliceLbs[i] : shift;
 
-    Value oneIdx = arith::ConstantIndexOp::create(rewriter, loc, 1);
-    Value indexAdjustment = isSliced ? oneIdx : sliceLb;
+    // When the array_coor has an explicit slice with a shape_shift (i.e.
+    // non-default lower bounds), the indices are Fortran indices; subtract
+    // the slice lower bound to get 0-based memref indices. Otherwise (the
+    // slice comes from an embox, or the shape has no shift), the indices
+    // are 1-based section indices; subtract 1.
+    bool indicesAreFortran = isShifted && arrayCoorOp.getSlice() != nullptr;
+    Value indexAdjustment =
+        (isSliced && !indicesAreFortran)
+            ? arith::ConstantIndexOp::create(rewriter, loc, 1)
+            : sliceLb;
     Value delta = arith::SubIOp::create(rewriter, loc, index, indexAdjustment);
 
     Value scaled = arith::MulIOp::create(rewriter, loc, delta, stride);

--- a/flang/test/Transforms/FIRToMemRef/array-coor-slice-shift.mlir
+++ b/flang/test/Transforms/FIRToMemRef/array-coor-slice-shift.mlir
@@ -1,0 +1,49 @@
+// Verify fir.array_coor with explicit shape_shift and slice correctly
+// computes 0-based memref indices when lower bounds are non-default.
+// This pattern arises after inlining canonicalizes fir.embox+fir.array_coor
+// into a single fir.array_coor with explicit shape and slice operands,
+// where the indices become Fortran indices rather than 1-based section indices.
+//
+// RUN: fir-opt %s --fir-to-memref --allow-unregistered-dialect | FileCheck %s
+
+// A(0:9) = 1  (lower bound 0)
+// The Fortran index 0 must map to memref index 0, not -1.
+// CHECK-LABEL: func.func @array_coor_slice_shift_1d
+// CHECK:       memref.store
+// CHECK-NOT:   fir.array_coor
+func.func @array_coor_slice_shift_1d() {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c10 = arith.constant 10 : index
+  %c1_i32 = arith.constant 1 : i32
+  %0 = fir.alloca !fir.array<10xi32> {bindc_name = "a", uniq_name = "_QFEa"}
+  %1 = fir.shape_shift %c0, %c10 : (index, index) -> !fir.shapeshift<1>
+  %2 = fir.declare %0(%1) {uniq_name = "_QFEa"} : (!fir.ref<!fir.array<10xi32>>, !fir.shapeshift<1>) -> !fir.ref<!fir.array<10xi32>>
+  %3 = fir.slice %c0, %c10, %c1 : (index, index, index) -> !fir.slice<1>
+  // Index %c0 is Fortran index 0 (= lower bound). Must produce memref index 0.
+  %4 = fir.array_coor %2(%1) [%3] %c0 : (!fir.ref<!fir.array<10xi32>>, !fir.shapeshift<1>, !fir.slice<1>, index) -> !fir.ref<i32>
+  fir.store %c1_i32 to %4 : !fir.ref<i32>
+  return
+}
+
+// A(0:9, -1:8) = 1  (lower bounds 0 and -1)
+// Fortran indices (0, -1) must map to memref indices (0, 0).
+// CHECK-LABEL: func.func @array_coor_slice_shift_2d
+// CHECK:       memref.store {{%.+}}, {{%.+}}[{{%.+}}, {{%.+}}] : memref<10x10xi32>
+// CHECK-NOT:   fir.array_coor
+func.func @array_coor_slice_shift_2d() {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c10 = arith.constant 10 : index
+  %c_neg1 = arith.constant -1 : index
+  %c8 = arith.constant 8 : index
+  %c1_i32 = arith.constant 1 : i32
+  %0 = fir.alloca !fir.array<10x10xi32> {bindc_name = "a", uniq_name = "_QFEa"}
+  %1 = fir.shape_shift %c0, %c10, %c_neg1, %c10 : (index, index, index, index) -> !fir.shapeshift<2>
+  %2 = fir.declare %0(%1) {uniq_name = "_QFEa"} : (!fir.ref<!fir.array<10x10xi32>>, !fir.shapeshift<2>) -> !fir.ref<!fir.array<10x10xi32>>
+  %3 = fir.slice %c0, %c10, %c1, %c_neg1, %c8, %c1 : (index, index, index, index, index, index) -> !fir.slice<2>
+  // Fortran indices (0, -1) = lower bounds => memref indices must be (0, 0).
+  %4 = fir.array_coor %2(%1) [%3] %c0, %c_neg1 : (!fir.ref<!fir.array<10x10xi32>>, !fir.shapeshift<2>, !fir.slice<2>, index, index) -> !fir.ref<i32>
+  fir.store %c1_i32 to %4 : !fir.ref<i32>
+  return
+}


### PR DESCRIPTION
When fir.array_coor carries an explicit shape_shift (non-default lower bounds) and an explicit slice, the indices are Fortran indices rather than 1-based section indices. The FIRToMemRef pass was unconditionally subtracting 1 from sliced indices, which is only correct for 1-based section indices (the embox-with-embedded-slice case).

For shape_shift + explicit slice, the correct adjustment is to subtract the slice lower bound instead of 1. This produces proper 0-based memref indices.

This pattern arises after the FIR inliner canonicalizes fir.embox(shape_shift, slice) + fir.array_coor(box) into a single fir.array_coor with explicit shape_shift and slice operands, where the indices become Fortran indices.

Without this fix, arrays with non-default lower bounds (e.g., A(0:N) or A(-1:N)) produce negative memref indices, writing before the array allocation and causing a segfault.
