### PR TITLE
[release] Add zstd archives to github releases

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -66,6 +66,7 @@ jobs:
       build-flang: ${{ steps.vars.outputs.build-flang }}
       release-binary-basename: ${{ steps.vars.outputs.release-binary-basename }}
       release-binary-filename: ${{ steps.vars.outputs.release-binary-filename }}
+      release-binary-filename-zstd: ${{ steps.vars.outputs.release-binary-filename-zstd }}
       build-runs-on: ${{ steps.vars.outputs.build-runs-on }}
       test-runs-on: ${{ steps.vars.outputs.build-runs-on }}
       attestation-name: ${{ steps.vars.outputs.attestation-name }}
@@ -147,6 +148,7 @@ jobs:
         fi
         echo "release-binary-basename=$release_binary_basename" >> $GITHUB_OUTPUT
         echo "release-binary-filename=$release_binary_basename.tar.xz" >> $GITHUB_OUTPUT
+        echo "release-binary-filename-zstd=$release_binary_basename.tar.zst" >> $GITHUB_OUTPUT
 
         target="$RUNNER_OS-$RUNNER_ARCH"
 
@@ -299,6 +301,11 @@ jobs:
         mv $tarball $env:GITHUB_WORKSPACE
         echo "windows-installer-filename=$(Split-Path -Path $installer -Leaf)" >> $env:GITHUB_OUTPUT
 
+    - name: Create zstd compressed tarball
+      shell: bash
+      run: |
+        xz -dc ${{ needs.prepare.outputs.release-binary-filename }} | zstd --ultra -22 -T0 -o ${{ needs.prepare.outputs.release-binary-filename-zstd }}
+
     - name: Generate sha256 digest for binaries
       id: digest
       shell: bash
@@ -306,6 +313,7 @@ jobs:
         RELEASE_BINARY_FILENAME: ${{ needs.prepare.outputs.release-binary-filename }}
         # This will be empty on non-Windows builds.
         WINDOWS_INSTALLER_FILENAME: ${{ steps.build-windows.outputs.windows-installer-filename }}
+        RELEASE_BINARY_FILENAME_ZSTD: ${{ needs.prepare.outputs.release-binary-filename-zstd }}
       run: |
           if [ "$RUNNER_OS" = "macOS" ]; then
             # Mac runners don't have sha256sum.
@@ -313,7 +321,7 @@ jobs:
           else
             sha256sum="sha256sum"
           fi
-          echo "digest=$(cat $WINDOWS_INSTALLER_FILENAME $RELEASE_BINARY_FILENAME | $sha256sum | cut -d ' ' -f 1)" >> $GITHUB_OUTPUT
+          echo "digest=$(cat $WINDOWS_INSTALLER_FILENAME $RELEASE_BINARY_FILENAME $RELEASE_BINARY_FILENAME_ZSTD | $sha256sum | cut -d ' ' -f 1)" >> $GITHUB_OUTPUT
 
     - name: Install LLDB test Python dependencies
       if: runner.os == 'Linux'
@@ -329,6 +337,7 @@ jobs:
         # The steps.build-windows.* variables will be empty on Linux/MacOS.
         path: |
           ${{ needs.prepare.outputs.release-binary-filename }}
+          ${{ needs.prepare.outputs.release-binary-filename-zstd }}
           ${{ steps.build-windows.outputs.windows-installer-filename }}
 
     - name: Run Tests

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -303,8 +303,11 @@ jobs:
 
     - name: Create zstd compressed tarball
       shell: bash
+      env:
+        RELEASE_BINARY_FILENAME: ${{ needs.prepare.outputs.release-binary-filename }}
+        RELEASE_BINARY_FILENAME_ZSTD: ${{ needs.prepare.outputs.release-binary-filename-zstd }}
       run: |
-        xz -dc ${{ needs.prepare.outputs.release-binary-filename }} | zstd --ultra -22 -T0 -o ${{ needs.prepare.outputs.release-binary-filename-zstd }}
+        xz -dc "$RELEASE_BINARY_FILENAME" | zstd --ultra -22 -T0 -o "$RELEASE_BINARY_FILENAME_ZSTD"
 
     - name: Generate sha256 digest for binaries
       id: digest

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -60,6 +60,7 @@ jobs:
       build-flang: ${{ steps.vars.outputs.build-flang }}
       release-binary-basename: ${{ steps.vars.outputs.release-binary-basename }}
       release-binary-filename: ${{ steps.vars.outputs.release-binary-filename }}
+      release-binary-filename-zstd: ${{ steps.vars.outputs.release-binary-filename-zstd }}
       build-runs-on: ${{ steps.vars.outputs.build-runs-on }}
       test-runs-on: ${{ steps.vars.outputs.build-runs-on }}
       attestation-name: ${{ steps.vars.outputs.attestation-name }}
@@ -151,6 +152,7 @@ jobs:
         fi
         echo "release-binary-basename=$release_binary_basename" >> $GITHUB_OUTPUT
         echo "release-binary-filename=$release_binary_basename.tar.xz" >> $GITHUB_OUTPUT
+        echo "release-binary-filename-zstd=$release_binary_basename.tar.zst" >> $GITHUB_OUTPUT
 
         target="$RUNNER_OS-$RUNNER_ARCH"
 
@@ -296,6 +298,11 @@ jobs:
         mv $tarball $env:GITHUB_WORKSPACE
         echo "windows-installer-filename=$(Split-Path -Path $installer -Leaf)" >> $env:GITHUB_OUTPUT
 
+    - name: Create zstd compressed tarball
+      shell: bash
+      run: |
+        xz -dc ${{ needs.prepare.outputs.release-binary-filename }} | zstd --ultra -22 -T0 -o ${{ needs.prepare.outputs.release-binary-filename-zstd }}
+
     - name: Generate sha256 digest for binaries
       id: digest
       shell: bash
@@ -303,6 +310,7 @@ jobs:
         RELEASE_BINARY_FILENAME: ${{ needs.prepare.outputs.release-binary-filename }}
         # This will be empty on non-Windows builds.
         WINDOWS_INSTALLER_FILENAME: ${{ steps.build-windows.outputs.windows-installer-filename }}
+        RELEASE_BINARY_FILENAME_ZSTD: ${{ needs.prepare.outputs.release-binary-filename-zstd }}
       run: |
           if [ "$RUNNER_OS" = "macOS" ]; then
             # Mac runners don't have sha256sum.
@@ -310,7 +318,7 @@ jobs:
           else
             sha256sum="sha256sum"
           fi
-          echo "digest=$(cat $WINDOWS_INSTALLER_FILENAME $RELEASE_BINARY_FILENAME | $sha256sum | cut -d ' ' -f 1)" >> $GITHUB_OUTPUT
+          echo "digest=$(cat $WINDOWS_INSTALLER_FILENAME $RELEASE_BINARY_FILENAME $RELEASE_BINARY_FILENAME_ZSTD | $sha256sum | cut -d ' ' -f 1)" >> $GITHUB_OUTPUT
 
     - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
       id: artifact-upload
@@ -321,6 +329,7 @@ jobs:
         # The steps.build-windows.* variables will be empty on Linux/MacOS.
         path: |
           ${{ needs.prepare.outputs.release-binary-filename }}
+          ${{ needs.prepare.outputs.release-binary-filename-zstd }}
           ${{ steps.build-windows.outputs.windows-installer-filename }}
 
     - name: Run Tests

--- a/llvm/utils/release/github-upload-release.py
+++ b/llvm/utils/release/github-upload-release.py
@@ -170,7 +170,7 @@ If you do not find a release package for your platform, you may be able to find 
 
 ## Package Types
 
-Each platform has one binary release package. The file name starts with either `LLVM-` or `clang+llvm-` and ends with the platform's name. For example, `LLVM-{release}-Linux-ARM64.tar.xz` contains LLVM binaries for Arm64 Linux.
+Each platform has binary release packages. The file name starts with either `LLVM-` or `clang+llvm-` and ends with the platform's name. For example, `LLVM-{release}-Linux-ARM64.tar.xz` contains LLVM binaries for Arm64 Linux. Binary archive packages may be available as `.tar.xz` or `.tar.zst` files. The `.tar.zst` files contain the same package contents, but use zstd compression.
 
 Except for Windows. Where `LLVM-*.exe` is an installer intended for using LLVM as a toolchain and the archive `clang+llvm-` contains the contents of the installer, plus libraries and tools not normally used in a toolchain. You most likely want the `LLVM-` installer, unless you are developing software which itself uses LLVM, in which case choose `clang+llvm-`.
 

--- a/llvm/utils/release/github-upload-release.py
+++ b/llvm/utils/release/github-upload-release.py
@@ -55,18 +55,22 @@ release_links = (
     (
         (
             "LINUX_X86",
-            "* [Linux x86_64]({0}) ([signature]({1}))",
+            "* Linux x86_64: [xz archive]({0}) ([signature]({1})), [zstd archive]({2}) ([signature]({3}))",
             (
                 "LLVM-{release}-Linux-X64.tar.xz",
                 "LLVM-{release}-Linux-X64.tar.xz.jsonl",
+                "LLVM-{release}-Linux-X64.tar.zst",
+                "LLVM-{release}-Linux-X64.tar.zst.jsonl",
             ),
         ),
         (
             "LINUX_ARM64",
-            "* [Linux Arm64]({0}) ([signature]({1}))",
+            "* Linux Arm64: [xz archive]({0}) ([signature]({1})), [zstd archive]({2}) ([signature]({3}))",
             (
                 "LLVM-{release}-Linux-ARM64.tar.xz",
                 "LLVM-{release}-Linux-ARM64.tar.xz.jsonl",
+                "LLVM-{release}-Linux-ARM64.tar.zst",
+                "LLVM-{release}-Linux-ARM64.tar.zst.jsonl",
             ),
         ),
         (
@@ -81,30 +85,36 @@ release_links = (
     (
         (
             "MACOS_ARM64",
-            "* [macOS Apple Silicon]({0}) (ARM64) ([signature]({1}))",
+            "* macOS Apple Silicon (ARM64): [xz archive]({0}) ([signature]({1})), [zstd archive]({2}) ([signature]({3}))",
             (
                 "LLVM-{release}-macOS-ARM64.tar.xz",
                 "LLVM-{release}-macOS-ARM64.tar.xz.jsonl",
+                "LLVM-{release}-macOS-ARM64.tar.zst",
+                "LLVM-{release}-macOS-ARM64.tar.zst.jsonl",
             ),
         ),
         (
             "MACOS_X86",
-            "* [macOS Intel]({0}) (x86-64) ([signature]({1}))",
+            "* macOS Intel (x86-64): [xz archive]({0}) ([signature]({1})), [zstd archive]({2}) ([signature]({3}))",
             (
                 "LLVM-{release}-macOS-X64.tar.xz",
                 "LLVM-{release}-macOS-X64.tar.xz.jsonl",
+                "LLVM-{release}-macOS-X64.tar.zst",
+                "LLVM-{release}-macOS-X64.tar.zst.jsonl",
             ),
         ),
     ),
     (
         (
             "WINDOWS_X64",
-            "* Windows x64 (64-bit): [installer]({0}) ([signature]({1})), [archive]({2}) ([signature]({3}))",
+            "* Windows x64 (64-bit): [installer]({0}) ([signature]({1})), [xz archive]({2}) ([signature]({3})), [zstd archive]({4}) ([signature]({5}))",
             (
                 "LLVM-{release}-win64.exe",
                 "LLVM-{release}-win64.exe.jsonl",
                 "clang+llvm-{release}-x86_64-pc-windows-msvc.tar.xz",
                 "clang+llvm-{release}-x86_64-pc-windows-msvc.tar.xz.jsonl",
+                "clang+llvm-{release}-x86_64-pc-windows-msvc.tar.zst",
+                "clang+llvm-{release}-x86_64-pc-windows-msvc.tar.zst.jsonl",
             ),
         ),
         (
@@ -114,12 +124,14 @@ release_links = (
         ),
         (
             "WINDOWS_ARM64",
-            "* Windows on Arm (ARM64): [installer]({0}) ([signature]({1})), [archive]({2}) ([signature]({3}))",
+            "* Windows on Arm (ARM64): [installer]({0}) ([signature]({1})), [xz archive]({2}) ([signature]({3})), [zstd archive]({4}) ([signature]({5}))",
             (
                 "LLVM-{release}-woa64.exe",
                 "LLVM-{release}-woa64.exe.jsonl",
                 "clang+llvm-{release}-aarch64-pc-windows-msvc.tar.xz",
                 "clang+llvm-{release}-aarch64-pc-windows-msvc.tar.xz.jsonl",
+                "clang+llvm-{release}-aarch64-pc-windows-msvc.tar.zst",
+                "clang+llvm-{release}-aarch64-pc-windows-msvc.tar.zst.jsonl",
             ),
         ),
     ),


### PR DESCRIPTION
This leaves the previous xz files but also creates zstd archives of the
binaries. This provides significantly reduced download sizes. We could
integrate this with cpack but we don't have control over the compression
level in that until version 4.3 which isn't even released yet.

Fixes https://github.com/llvm/llvm-project/issues/164537
