### PR TITLE
[libc++][Android] Update Compiler for Android CI

### DIFF
--- a/libcxx/utils/ci/docker/docker-compose.yml
+++ b/libcxx/utils/ci/docker/docker-compose.yml
@@ -33,6 +33,6 @@ services:
       dockerfile: libcxx/utils/ci/docker/android-builder.dockerfile
       args:
         BASE_IMAGE_VERSION: e9437d01e4a95c0752937b9a35121457b5835afa
-        ANDROID_CLANG_VERSION: r563880
-        ANDROID_CLANG_PREBUILTS_COMMIT: 6ae4184bb8706f9731569b9a0a82be3fcdcb951c
+        ANDROID_CLANG_VERSION: r584948b
+        ANDROID_CLANG_PREBUILTS_COMMIT: 2b062008b0a7be59ad85f012cfeee60f052808f1
         ANDROID_SYSROOT_COMMIT: f8b85cc5262c6e5cbc9a92c1bab2b18b32a4c63f


### PR DESCRIPTION
Upgrade Android compiler from r563880 to r584948b because libc++ does not support LLVM 20 anymore