### PR TITLE
[NFC][Support] Don't test UB in Caching.WriteAfterCommit

### DIFF
--- a/llvm/unittests/Support/Caching.cpp
+++ b/llvm/unittests/Support/Caching.cpp
@@ -105,9 +105,7 @@ TEST(Caching, WriteAfterCommit) {
   (*CFS->OS).write(data, sizeof(data));
   ASSERT_THAT_ERROR(CFS->commit(), Succeeded());
 
-  EXPECT_DEATH(
-      { (*CFS->OS).write(data, sizeof(data)); }, "")
-      << "Write after commit did not cause abort";
+  ASSERT_EQ(CFS->OS, nullptr);
 
   ASSERT_NO_ERROR(sys::fs::remove_directories(CacheDir.str()));
 }


### PR DESCRIPTION
The test expects crash after commit essentially null-dereferencing.
Just check that it's nullptr directly.

Fixes asan/ubsan buildbot.
