### PR TITLE
[LLDB][Accelerators][1/M] Scaffold a basic Mock plugin for testing accelerator flows

### DIFF
--- a/lldb/test/API/accelerator/mock/Makefile
+++ b/lldb/test/API/accelerator/mock/Makefile
@@ -1,0 +1,4 @@
+C_SOURCES := main.c
+
+include Makefile.rules
+

--- a/lldb/test/API/accelerator/mock/TestMockAcceleratorPlugin.py
+++ b/lldb/test/API/accelerator/mock/TestMockAcceleratorPlugin.py
@@ -1,0 +1,69 @@
+"""
+Tests for the lldb-server Mock Accelerator Plugin.
+"""
+
+import os
+
+import lldb
+from lldbsuite.test.decorators import *
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test import lldbutil
+
+"""This will go away once the mock plugin starts creating a target."""
+_PLUGIN_OUTPUT_PATH = "/tmp/accelerator_plugin_test.txt"
+
+
+class MockAcceleratorPluginTestCase(TestBase):
+    NO_DEBUG_INFO_TESTCASE = True
+
+    def clean_expected_output_file(self):
+        try:
+            os.remove(_PLUGIN_OUTPUT_PATH)
+        except OSError:
+            pass
+
+    def tearDown(self):
+        super().tearDown()
+        self.clean_expected_output_file()
+
+    @add_test_categories(["llgs"])
+    def test_mock_accelerator_plugin_writes_pid(self):
+        """
+        When LLDB_SERVER_ENABLE_MOCK_ACCELERATOR_PLUGIN is set, the mock accelerator
+        plugin must create /tmp/accelerator_plugin_test.txt containing a valid PID.
+        """
+        self.build()
+
+        # Remove any stale file left by a previous run.
+        self.clean_expected_output_file()
+
+        # Launch the target and let it run to completion.
+        exe = self.getBuildArtifact("a.out")
+        target = self.dbg.CreateTarget(exe)
+        self.assertTrue(target.IsValid())
+
+        process = target.LaunchSimple(None, None, self.get_process_working_directory())
+        self.assertEqual(
+            process.GetState(),
+            lldb.eStateExited,
+            "Process should have exited cleanly",
+        )
+
+        # After the process exits, verify the plugin output file.
+        self.assertTrue(
+            os.path.exists(_PLUGIN_OUTPUT_PATH),
+            "Mock accelerator plugin did not create %s" % _PLUGIN_OUTPUT_PATH,
+        )
+        with open(_PLUGIN_OUTPUT_PATH) as f:
+            content = f.read().strip()
+        self.assertTrue(
+            content.isdigit(),
+            "Plugin output file should contain an integer PID, got: %r" % content,
+        )
+
+        pid = int(content)
+        self.assertGreater(
+            pid,
+            0,
+            "PID in plugin output file should be a valid positive integer",
+        )

--- a/lldb/test/API/accelerator/mock/lit.local.cfg
+++ b/lldb/test/API/accelerator/mock/lit.local.cfg
@@ -1,0 +1,3 @@
+# Enable the mock accelerator plugin in lldb-server for all tests in this
+# directory. The plugin activates when this variable is present and non-empty.
+config.environment["LLDB_SERVER_ENABLE_MOCK_ACCELERATOR_PLUGIN"] = "1"

--- a/lldb/test/API/accelerator/mock/main.c
+++ b/lldb/test/API/accelerator/mock/main.c
@@ -1,0 +1,1 @@
+int main(void) { return 0; }

--- a/lldb/tools/lldb-server/CMakeLists.txt
+++ b/lldb/tools/lldb-server/CMakeLists.txt
@@ -46,12 +46,17 @@ if(APPLE_EMBEDDED)
   endif()
 endif()
 
+add_subdirectory(Plugins)
+
+set(LLDB_SERVER_PLUGINS lldbServerPluginMockAccelerator)
+
 add_lldb_tool(lldb-server
     lldb-gdbserver.cpp
     lldb-platform.cpp
     lldb-server.cpp
     LLDBServerUtilities.cpp
     SystemInitializerLLGS.cpp
+    LLDBServerPluginRegistry.cpp
 
     LINK_COMPONENTS
       Option
@@ -61,6 +66,7 @@ add_lldb_tool(lldb-server
       lldbInitialization
       lldbVersion
       ${LLDB_PLUGINS}
+      ${LLDB_SERVER_PLUGINS}
       lldbPluginInstructionARM
       lldbPluginInstructionLoongArch
       lldbPluginInstructionMIPS
@@ -75,4 +81,5 @@ add_dependencies(lldb-server
   ${tablegen_deps}
 )
 target_include_directories(lldb-server PRIVATE "${LLDB_SOURCE_DIR}/source")
+target_include_directories(lldb-server PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}")
 target_link_libraries(lldb-server PRIVATE ${LLDB_SYSTEM_LIBS})

--- a/lldb/tools/lldb-server/LLDBServerPluginRegistry.cpp
+++ b/lldb/tools/lldb-server/LLDBServerPluginRegistry.cpp
@@ -1,0 +1,50 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "LLDBServerPluginRegistry.h"
+#include "Plugins/Accelerator/Mock/LLDBServerPluginMockAccelerator.h"
+#include "llvm/Support/Threading.h"
+
+using namespace lldb_private::lldb_server;
+
+LLDBServerPluginRegistry &LLDBServerPluginRegistry::Instance() {
+  static LLDBServerPluginRegistry registry;
+  static llvm::once_flag once;
+
+  llvm::call_once(once, []() { registry.Initialize(); });
+
+  return registry;
+}
+
+void LLDBServerPluginRegistry::Initialize() {
+  // Register all known accelerator plugins
+  Register(PluginKind::Accelerator,
+           [](LLDBServerPluginAccelerator::GDBServer &gdb_server,
+              lldb_private::MainLoop &main_loop)
+               -> std::unique_ptr<LLDBServerPluginAccelerator> {
+             return std::make_unique<LLDBServerPluginMockAccelerator>(gdb_server,
+                                                                      main_loop);
+           });
+}
+
+void LLDBServerPluginRegistry::Register(PluginKind kind,
+                                        AcceleratorFactory factory) {
+  m_accelerator_factories.push_back(std::move(factory));
+}
+
+std::vector<std::unique_ptr<LLDBServerPluginAccelerator>>
+LLDBServerPluginRegistry::TryInstantiateAllAcceleratorPlugins(
+    LLDBServerPluginAccelerator::GDBServer &gdb_server, MainLoop &main_loop) {
+  std::vector<std::unique_ptr<LLDBServerPluginAccelerator>> activated;
+  for (const AcceleratorFactory &factory : m_accelerator_factories) {
+    std::unique_ptr<LLDBServerPluginAccelerator> plugin = factory(gdb_server, main_loop);
+    if (plugin && plugin->TryActivate())
+      activated.push_back(std::move(plugin));
+  }
+  return activated;
+}

--- a/lldb/tools/lldb-server/LLDBServerPluginRegistry.h
+++ b/lldb/tools/lldb-server/LLDBServerPluginRegistry.h
@@ -1,0 +1,53 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLDB_TOOLS_LLDB_SERVER_LLDBSERVERPLUGINREGISTRY_H
+#define LLDB_TOOLS_LLDB_SERVER_LLDBSERVERPLUGINREGISTRY_H
+
+#include "Plugins/Accelerator/LLDBServerPluginAccelerator.h"
+
+namespace lldb_private {
+
+namespace lldb_server {
+
+class LLDBServerPluginRegistry {
+public:
+  /// Identifies the category of a plugin.
+  enum class PluginKind {
+    Accelerator,
+  };
+
+  using AcceleratorFactory =
+      std::function<std::unique_ptr<LLDBServerPluginAccelerator>(
+          LLDBServerPluginAccelerator::GDBServer &, MainLoop &)>;
+
+  /// Return a singleton instance of the registry that is initialized on first
+  /// use and that knows of all available plugins.
+  static LLDBServerPluginRegistry &Instance();
+
+  /// Instantiate all registered accelerator plugins and return those that
+  /// successfully activated (TryActivate() returned true).
+  std::vector<std::unique_ptr<LLDBServerPluginAccelerator>>
+  TryInstantiateAllAcceleratorPlugins(
+      LLDBServerPluginAccelerator::GDBServer &gdb_server, MainLoop &main_loop);
+
+private:
+  /// Initialize and register all known plugins.
+  void Initialize();
+
+  /// Register an accelerator plugin factory.
+  void Register(PluginKind kind, AcceleratorFactory factory);
+
+  LLDBServerPluginRegistry() = default;
+  std::vector<AcceleratorFactory> m_accelerator_factories;
+};
+
+} // namespace lldb_server
+} // namespace lldb_private
+
+#endif // LLDB_TOOLS_LLDB_SERVER_LLDBSERVERPLUGINREGISTRY_H

--- a/lldb/tools/lldb-server/Plugins/Accelerator/CMakeLists.txt
+++ b/lldb/tools/lldb-server/Plugins/Accelerator/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(Mock)

--- a/lldb/tools/lldb-server/Plugins/Accelerator/LLDBServerPluginAccelerator.cpp
+++ b/lldb/tools/lldb-server/Plugins/Accelerator/LLDBServerPluginAccelerator.cpp
@@ -1,0 +1,15 @@
+//===-- LLDBServerPluginAccelerator.cpp -------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "LLDBServerPluginAccelerator.h"
+
+using namespace lldb_private::lldb_server;
+
+LLDBServerPluginAccelerator::LLDBServerPluginAccelerator(GDBServer &gdb_server,
+                                                         MainLoop &main_loop)
+    : m_gdb_server(gdb_server), m_main_loop(main_loop) {}

--- a/lldb/tools/lldb-server/Plugins/Accelerator/LLDBServerPluginAccelerator.h
+++ b/lldb/tools/lldb-server/Plugins/Accelerator/LLDBServerPluginAccelerator.h
@@ -1,0 +1,54 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLDB_TOOLS_LLDB_SERVER_PLUGINS_ACCELERATOR_LLDBSERVERPLUGINACCELERATOR_H
+#define LLDB_TOOLS_LLDB_SERVER_PLUGINS_ACCELERATOR_LLDBSERVERPLUGINACCELERATOR_H
+
+#include "llvm/ADT/StringRef.h"
+#include "lldb/Host/MainLoop.h"
+
+namespace lldb_private {
+
+namespace process_gdb_remote {
+class GDBRemoteCommunicationServerLLGS;
+} // namespace process_gdb_remote
+
+namespace lldb_server {
+
+/// Abstract base class for lldb-server accelerator plugins.
+///
+/// An accelerator plugin allows lldb-server to support debugging of hardware
+/// accelerators (e.g. GPUs, FPGAs) alongside the native host process.
+class LLDBServerPluginAccelerator {
+public:
+  using GDBServer = process_gdb_remote::GDBRemoteCommunicationServerLLGS;
+
+  LLDBServerPluginAccelerator(GDBServer &gdb_server, MainLoop &main_loop);
+  virtual ~LLDBServerPluginAccelerator() = default;
+
+  /// Returns a short, unique name identifying this plugin (e.g. "mock-accel").
+  virtual llvm::StringRef GetPluginName() = 0;
+
+  /// Attempts to activate the plugin if it should be enabled in the current
+  /// environment (e.g. required hardware is present, an enabling environment
+  /// variable is set, etc.). Returns true if the plugin was activated.
+  virtual bool TryActivate() = 0;
+
+  /// Called before lldb-server exits to allow the plugin to perform cleanup.
+  /// This is called for all plugins that successfully activated.
+  virtual void Teardown() = 0;
+
+protected:
+  GDBServer &m_gdb_server;
+  MainLoop &m_main_loop;
+};
+
+} // namespace lldb_server
+} // namespace lldb_private
+
+#endif // LLDB_TOOLS_LLDB_SERVER_PLUGINS_ACCELERATOR_LLDBSERVERPLUGINACCELERATOR_H

--- a/lldb/tools/lldb-server/Plugins/Accelerator/Mock/CMakeLists.txt
+++ b/lldb/tools/lldb-server/Plugins/Accelerator/Mock/CMakeLists.txt
@@ -1,0 +1,11 @@
+add_lldb_library(lldbServerPluginMockAccelerator
+  LLDBServerPluginMockAccelerator.cpp
+  ../LLDBServerPluginAccelerator.cpp
+)
+
+target_include_directories(lldbServerPluginMockAccelerator
+  PRIVATE
+    "${LLDB_SOURCE_DIR}/source"
+    "${CMAKE_CURRENT_SOURCE_DIR}/../../.."
+    "${CMAKE_CURRENT_SOURCE_DIR}/.."
+)

--- a/lldb/tools/lldb-server/Plugins/Accelerator/Mock/LLDBServerPluginMockAccelerator.cpp
+++ b/lldb/tools/lldb-server/Plugins/Accelerator/Mock/LLDBServerPluginMockAccelerator.cpp
@@ -1,0 +1,36 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "LLDBServerPluginMockAccelerator.h"
+
+#include "llvm/Support/Process.h"
+
+using namespace lldb_private::lldb_server;
+
+LLDBServerPluginMockAccelerator::LLDBServerPluginMockAccelerator(
+    GDBServer &gdb_server, MainLoop &main_loop)
+    : LLDBServerPluginAccelerator(gdb_server, main_loop) {}
+
+llvm::StringRef LLDBServerPluginMockAccelerator::GetPluginName() {
+  return "mock-accelerator";
+}
+
+bool LLDBServerPluginMockAccelerator::TryActivate() {
+  // Check if the plugin should be enabled
+  std::optional<std::string> val = llvm::sys::Process::GetEnv(kEnableEnvVar);
+  if (!val || val->empty())
+    return false;
+
+  // Activate the plugin by writing the parent PID to the test file
+  std::error_code ec;
+  llvm::raw_fd_ostream out("/tmp/accelerator_plugin_test.txt", ec,
+                          llvm::sys::fs::OF_Text);
+  out << llvm::sys::Process::getProcessId() << '\n';
+
+  return true;
+}

--- a/lldb/tools/lldb-server/Plugins/Accelerator/Mock/LLDBServerPluginMockAccelerator.h
+++ b/lldb/tools/lldb-server/Plugins/Accelerator/Mock/LLDBServerPluginMockAccelerator.h
@@ -1,0 +1,38 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLDB_TOOLS_LLDB_SERVER_PLUGINS_ACCELERATOR_LLDBSERVERPLUGINMOCKACCELERATOR_H
+#define LLDB_TOOLS_LLDB_SERVER_PLUGINS_ACCELERATOR_LLDBSERVERPLUGINMOCKACCELERATOR_H
+
+#include "../LLDBServerPluginAccelerator.h"
+
+namespace lldb_private {
+namespace lldb_server {
+
+/// A mock accelerator plugin used for testing the accelerator plugin
+/// infrastructure.
+///
+/// This plugin is enabled when the environment variable
+/// LLDB_SERVER_ENABLE_MOCK_ACCELERATOR_PLUGIN is set to any non-empty value.
+class LLDBServerPluginMockAccelerator : public LLDBServerPluginAccelerator {
+public:
+  /// Environment variable that enables this plugin.
+  static constexpr const char *kEnableEnvVar =
+      "LLDB_SERVER_ENABLE_MOCK_ACCELERATOR_PLUGIN";
+
+  LLDBServerPluginMockAccelerator(GDBServer &gdb_server, MainLoop &main_loop);
+
+  llvm::StringRef GetPluginName() override;
+  bool TryActivate() override;
+  void Teardown() override {}
+};
+
+} // namespace lldb_server
+} // namespace lldb_private
+
+#endif // LLDB_TOOLS_LLDB_SERVER_PLUGINS_ACCELERATOR_LLDBSERVERPLUGINMOCKACCELERATOR_H

--- a/lldb/tools/lldb-server/Plugins/CMakeLists.txt
+++ b/lldb/tools/lldb-server/Plugins/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(Accelerator)

--- a/lldb/tools/lldb-server/lldb-gdbserver.cpp
+++ b/lldb/tools/lldb-server/lldb-gdbserver.cpp
@@ -17,6 +17,7 @@
 #include <unistd.h>
 #endif
 
+#include "LLDBServerPluginRegistry.h"
 #include "LLDBServerUtilities.h"
 #include "Plugins/Process/gdb-remote/GDBRemoteCommunicationServerLLGS.h"
 #include "Plugins/Process/gdb-remote/ProcessGDBRemoteLog.h"
@@ -452,6 +453,17 @@ int main_gdbserver(int argc, char *argv[]) {
 
   NativeProcessManager manager(mainloop);
   GDBRemoteCommunicationServerLLGS gdb_server(mainloop, manager);
+
+  // Create and activate all accelerator plugins.
+  auto accelerator_plugins =
+      LLDBServerPluginRegistry::Instance().TryInstantiateAllAcceleratorPlugins(
+          gdb_server, mainloop);
+
+  // Ensure plugins are torn down on all exit paths.
+  llvm::scope_exit teardown_plugins([&]() {
+    for (auto &plugin : accelerator_plugins)
+        plugin->Teardown();
+  });
 
   llvm::StringRef host_and_port;
   if (!Inputs.empty() && connection_fd == SharedSocket::kInvalidFD) {


### PR DESCRIPTION
This is the first patch of many related to https://discourse.llvm.org/t/upstreaming-basic-support-for-accelerators/89827/6

In this patch, I introduce the concept of `LLDBServerPlugin`, whose implementation is much simpler than the ones in the client. Maybe one day we can do something fancier if needed.

I also introduce the concept of a `LLDBServerAcceleratorPlugin`, which is a kind of plugin that gets initialized when the main server target is also initialized but before the main loop starts running. Implementation of this plugin can be disabled via #ifdef blocks or via a `TryActivate` method. 

I include a reference implementation, `LLDBServerPluginMockAccelerator`, which currently, for the sake of testing a minimal functionality, is activated only if the env var `LLDB_SERVER_ENABLE_MOCK_ACCELERATOR_PLUGIN` is present, and when enabled, prints the pid of the current process to a file. This logic will go away in the next patch, but it was useful for being able to write a python test. Once I make this plugin create a new target for the accelerator, the test will assert that a new target has been created.

The idea is that this new plugin is only enabled via the env var for testing purposes. Whichever APIs or contracts we want to establish for concrete accelerator plugins will require also a reference implementation in the Mock plugin. That way we'll always have proper testing even if a plugin can't be enabled in a build bot, e.g like when it doesn't have an actual GPU attached.

