### PR TITLE
[NFC][sanitizer] Accept ETIMEDOUT in getpwnam_r_invalid_user.cpp

### DIFF
--- a/compiler-rt/test/sanitizer_common/TestCases/Linux/getpwnam_r_invalid_user.cpp
+++ b/compiler-rt/test/sanitizer_common/TestCases/Linux/getpwnam_r_invalid_user.cpp
@@ -16,6 +16,7 @@ int main(void) {
   int res = getpwnam_r("no-such-user", &pwd, buf, sizeof(buf), &pwdres);
   fprintf(stderr, "Result: %d\n", res);
   fflush(stderr);
+  // It can fail inconsistently on some bots with these errors.
   assert(res == 0 || res == ENOENT || res == ETIMEDOUT);
   assert(pwdres == 0);
   return 0;

--- a/compiler-rt/test/sanitizer_common/TestCases/Linux/getpwnam_r_invalid_user.cpp
+++ b/compiler-rt/test/sanitizer_common/TestCases/Linux/getpwnam_r_invalid_user.cpp
@@ -16,7 +16,7 @@ int main(void) {
   int res = getpwnam_r("no-such-user", &pwd, buf, sizeof(buf), &pwdres);
   fprintf(stderr, "Result: %d\n", res);
   fflush(stderr);
-  assert(res == 0 || res == ENOENT);
+  assert(res == 0 || res == ENOENT || res == ETIMEDOUT);
   assert(pwdres == 0);
   return 0;
 }


### PR DESCRIPTION
On some systems, looking up an result in a timeout.

Error here is not a sign of compiler-rt issue.

Fixes flakiness on https://lab.llvm.org/buildbot/#/builders/sanitizer-ppc64le-linux