### PR TITLE
[AtomicExpandPass][NFC] Refactor processAtomicInstr to be more readable

### DIFF
--- a/llvm/lib/CodeGen/AtomicExpandPass.cpp
+++ b/llvm/lib/CodeGen/AtomicExpandPass.cpp
@@ -292,7 +292,8 @@ bool AtomicExpandImpl::processAtomicInstr(Instruction *I) {
     }
 
     bool Fenced = false;
-    if (TLI->shouldInsertFencesForAtomic(LI) && isAcquireOrStronger(LI->getOrdering())) {
+    if (TLI->shouldInsertFencesForAtomic(LI) &&
+        isAcquireOrStronger(LI->getOrdering())) {
       AtomicOrdering FenceOrdering = LI->getOrdering();
       LI->setOrdering(AtomicOrdering::Monotonic);
       Fenced = bracketInstWithFences(LI, FenceOrdering);
@@ -321,7 +322,8 @@ bool AtomicExpandImpl::processAtomicInstr(Instruction *I) {
     }
 
     bool Fenced = false;
-    if (TLI->shouldInsertFencesForAtomic(SI) && isReleaseOrStronger(SI->getOrdering())) {
+    if (TLI->shouldInsertFencesForAtomic(SI) &&
+        isReleaseOrStronger(SI->getOrdering())) {
       AtomicOrdering FenceOrdering = SI->getOrdering();
       SI->setOrdering(AtomicOrdering::Monotonic);
       Fenced = bracketInstWithFences(SI, FenceOrdering);
@@ -347,8 +349,9 @@ bool AtomicExpandImpl::processAtomicInstr(Instruction *I) {
     }
 
     bool Fenced = false;
-    if (TLI->shouldInsertFencesForAtomic(RMWI) && (isReleaseOrStronger(RMWI->getOrdering()) ||
-          isAcquireOrStronger(RMWI->getOrdering()))) {
+    if (TLI->shouldInsertFencesForAtomic(RMWI) &&
+        (isReleaseOrStronger(RMWI->getOrdering()) ||
+         isAcquireOrStronger(RMWI->getOrdering()))) {
       AtomicOrdering FenceOrdering = RMWI->getOrdering();
       RMWI->setOrdering(TLI->atomicOperationOrderAfterFenceSplit(RMWI));
       Fenced = bracketInstWithFences(RMWI, FenceOrdering);

--- a/llvm/lib/CodeGen/AtomicExpandPass.cpp
+++ b/llvm/lib/CodeGen/AtomicExpandPass.cpp
@@ -267,10 +267,58 @@ bool AtomicExpandImpl::processAtomicInstr(Instruction *I) {
   auto *RMWI = dyn_cast<AtomicRMWInst>(I);
   auto *CASI = dyn_cast<AtomicCmpXchgInst>(I);
 
-  bool MadeChange = false;
+  auto TryInsertFencesForAtomic = [&]() -> bool {
+    if (TLI->shouldInsertFencesForAtomic(I)) {
+      auto FenceOrdering = AtomicOrdering::Monotonic;
+      if (LI && isAcquireOrStronger(LI->getOrdering())) {
+        FenceOrdering = LI->getOrdering();
+        LI->setOrdering(AtomicOrdering::Monotonic);
+      } else if (SI && isReleaseOrStronger(SI->getOrdering())) {
+        FenceOrdering = SI->getOrdering();
+        SI->setOrdering(AtomicOrdering::Monotonic);
+      } else if (RMWI && (isReleaseOrStronger(RMWI->getOrdering()) ||
+                          isAcquireOrStronger(RMWI->getOrdering()))) {
+        FenceOrdering = RMWI->getOrdering();
+        RMWI->setOrdering(TLI->atomicOperationOrderAfterFenceSplit(RMWI));
+      } else if (CASI &&
+                 TLI->shouldExpandAtomicCmpXchgInIR(CASI) ==
+                     TargetLoweringBase::AtomicExpansionKind::None &&
+                 (isReleaseOrStronger(CASI->getSuccessOrdering()) ||
+                  isAcquireOrStronger(CASI->getSuccessOrdering()) ||
+                  isAcquireOrStronger(CASI->getFailureOrdering()))) {
+        // If a compare and swap is lowered to LL/SC, we can do smarter fence
+        // insertion, with a stronger one on the success path than on the
+        // failure path. As a result, fence insertion is directly done by
+        // expandAtomicCmpXchg in that case.
+        FenceOrdering = CASI->getMergedOrdering();
+        auto CASOrdering = TLI->atomicOperationOrderAfterFenceSplit(CASI);
+  
+        CASI->setSuccessOrdering(CASOrdering);
+        CASI->setFailureOrdering(CASOrdering);
+      }
 
-  // If the Size/Alignment is not supported, replace with a libcall.
-  if (LI) {
+      if (FenceOrdering != AtomicOrdering::Monotonic)
+        return bracketInstWithFences(I, FenceOrdering);
+      return false;
+    }
+
+    if (!TLI->shouldInsertTrailingSeqCstFenceForAtomicStore(I) ||
+        (CASI && TLI->shouldExpandAtomicCmpXchgInIR(CASI) ==
+                     TargetLoweringBase::AtomicExpansionKind::LLSC))
+      return false;
+
+    // CmpXchg LLSC is handled in expandAtomicCmpXchg().
+    IRBuilder Builder(I);
+    if (auto *TrailingFence = TLI->emitTrailingFence(
+            Builder, I, AtomicOrdering::SequentiallyConsistent)) {
+      TrailingFence->moveAfter(I);
+      return true;
+    }
+    return false;
+  };
+
+  switch (I->getOpcode()) {
+  case Instruction::Load: {
     if (!LI->isAtomic())
       return false;
 
@@ -279,12 +327,18 @@ bool AtomicExpandImpl::processAtomicInstr(Instruction *I) {
       return true;
     }
 
+    bool Converted = false;
     if (TLI->shouldCastAtomicLoadInIR(LI) ==
         TargetLoweringBase::AtomicExpansionKind::CastToInteger) {
       I = LI = convertAtomicLoadToIntegerType(LI);
-      MadeChange = true;
+      Converted = true;
     }
-  } else if (SI) {
+
+    bool Fenced = TryInsertFencesForAtomic();
+    bool Expanded = tryExpandAtomicLoad(LI);
+    return Converted || Fenced || Expanded;
+  }
+  case Instruction::Store: {
     if (!SI->isAtomic())
       return false;
 
@@ -293,103 +347,67 @@ bool AtomicExpandImpl::processAtomicInstr(Instruction *I) {
       return true;
     }
 
+    bool Converted = false;
     if (TLI->shouldCastAtomicStoreInIR(SI) ==
         TargetLoweringBase::AtomicExpansionKind::CastToInteger) {
       I = SI = convertAtomicStoreToIntegerType(SI);
-      MadeChange = true;
+      Converted = true;
     }
-  } else if (RMWI) {
+
+    bool Fenced = TryInsertFencesForAtomic();
+    bool Expanded = tryExpandAtomicStore(SI);
+    return Converted || Fenced || Expanded;
+  }
+  case Instruction::AtomicRMW: {
     if (!atomicSizeSupported(TLI, RMWI)) {
       expandAtomicRMWToLibcall(RMWI);
       return true;
     }
 
+    bool Converted = false;
     if (TLI->shouldCastAtomicRMWIInIR(RMWI) ==
         TargetLoweringBase::AtomicExpansionKind::CastToInteger) {
       I = RMWI = convertAtomicXchgToIntegerType(RMWI);
-      MadeChange = true;
+      Converted = true;
     }
-  } else if (CASI) {
+
+    bool Fenced = TryInsertFencesForAtomic();
+
+    // There are two different ways of expanding RMW instructions:
+    // - into a load if it is idempotent
+    // - into a Cmpxchg/LL-SC loop otherwise
+    // we try them in that order.
+    bool Expanded = false;
+    if (isIdempotentRMW(RMWI) && simplifyIdempotentRMW(RMWI))
+      Expanded = true;
+    else
+      Expanded = tryExpandAtomicRMW(RMWI);
+
+    return Converted || Fenced || Expanded;
+  }
+  case Instruction::AtomicCmpXchg: {
     if (!atomicSizeSupported(TLI, CASI)) {
       expandAtomicCASToLibcall(CASI);
       return true;
     }
 
+    bool Converted = false;
     // TODO: when we're ready to make the change at the IR level, we can
     // extend convertCmpXchgToInteger for floating point too.
     if (CASI->getCompareOperand()->getType()->isPointerTy()) {
       // TODO: add a TLI hook to control this so that each target can
       // convert to lowering the original type one at a time.
       I = CASI = convertCmpXchgToIntegerType(CASI);
-      MadeChange = true;
-    }
-  } else
-    return false;
-
-  if (TLI->shouldInsertFencesForAtomic(I)) {
-    auto FenceOrdering = AtomicOrdering::Monotonic;
-    if (LI && isAcquireOrStronger(LI->getOrdering())) {
-      FenceOrdering = LI->getOrdering();
-      LI->setOrdering(AtomicOrdering::Monotonic);
-    } else if (SI && isReleaseOrStronger(SI->getOrdering())) {
-      FenceOrdering = SI->getOrdering();
-      SI->setOrdering(AtomicOrdering::Monotonic);
-    } else if (RMWI && (isReleaseOrStronger(RMWI->getOrdering()) ||
-                        isAcquireOrStronger(RMWI->getOrdering()))) {
-      FenceOrdering = RMWI->getOrdering();
-      RMWI->setOrdering(TLI->atomicOperationOrderAfterFenceSplit(RMWI));
-    } else if (CASI &&
-               TLI->shouldExpandAtomicCmpXchgInIR(CASI) ==
-                   TargetLoweringBase::AtomicExpansionKind::None &&
-               (isReleaseOrStronger(CASI->getSuccessOrdering()) ||
-                isAcquireOrStronger(CASI->getSuccessOrdering()) ||
-                isAcquireOrStronger(CASI->getFailureOrdering()))) {
-      // If a compare and swap is lowered to LL/SC, we can do smarter fence
-      // insertion, with a stronger one on the success path than on the
-      // failure path. As a result, fence insertion is directly done by
-      // expandAtomicCmpXchg in that case.
-      FenceOrdering = CASI->getMergedOrdering();
-      auto CASOrdering = TLI->atomicOperationOrderAfterFenceSplit(CASI);
-
-      CASI->setSuccessOrdering(CASOrdering);
-      CASI->setFailureOrdering(CASOrdering);
+      Converted = true;
     }
 
-    if (FenceOrdering != AtomicOrdering::Monotonic) {
-      MadeChange |= bracketInstWithFences(I, FenceOrdering);
-    }
-  } else if (TLI->shouldInsertTrailingSeqCstFenceForAtomicStore(I) &&
-             !(CASI && TLI->shouldExpandAtomicCmpXchgInIR(CASI) ==
-                           TargetLoweringBase::AtomicExpansionKind::LLSC)) {
-    // CmpXchg LLSC is handled in expandAtomicCmpXchg().
-    IRBuilder Builder(I);
-    if (auto TrailingFence = TLI->emitTrailingFence(
-            Builder, I, AtomicOrdering::SequentiallyConsistent)) {
-      TrailingFence->moveAfter(I);
-      MadeChange = true;
-    }
+    bool Fenced = TryInsertFencesForAtomic();
+    bool Expanded = tryExpandAtomicCmpXchg(CASI);
+    return Converted || Fenced || Expanded;
   }
-
-  if (LI)
-    MadeChange |= tryExpandAtomicLoad(LI);
-  else if (SI)
-    MadeChange |= tryExpandAtomicStore(SI);
-  else if (RMWI) {
-    // There are two different ways of expanding RMW instructions:
-    // - into a load if it is idempotent
-    // - into a Cmpxchg/LL-SC loop otherwise
-    // we try them in that order.
-
-    if (isIdempotentRMW(RMWI) && simplifyIdempotentRMW(RMWI)) {
-      MadeChange = true;
-
-    } else {
-      MadeChange |= tryExpandAtomicRMW(RMWI);
-    }
-  } else if (CASI)
-    MadeChange |= tryExpandAtomicCmpXchg(CASI);
-
-  return MadeChange;
+  default:
+    return false;
+  }
 }
 
 bool AtomicExpandImpl::run(

--- a/llvm/lib/CodeGen/AtomicExpandPass.cpp
+++ b/llvm/lib/CodeGen/AtomicExpandPass.cpp
@@ -296,9 +296,9 @@ bool AtomicExpandImpl::processAtomicInstr(Instruction *I) {
     if (isAcquireOrStronger(LI->getOrdering()) && ShouldInsertFences) {
       AtomicOrdering FenceOrdering = LI->getOrdering();
       LI->setOrdering(AtomicOrdering::Monotonic);
-      MadeChange = bracketInstWithFences(LI, FenceOrdering);
+      MadeChange |= bracketInstWithFences(LI, FenceOrdering);
     } else if (!ShouldInsertFences) {
-      MadeChange = tryInsertTrailingSeqCstFence(LI);
+      MadeChange |= tryInsertTrailingSeqCstFence(LI);
     }
 
     MadeChange |= tryExpandAtomicLoad(LI);
@@ -325,9 +325,9 @@ bool AtomicExpandImpl::processAtomicInstr(Instruction *I) {
     if (isReleaseOrStronger(SI->getOrdering()) && ShouldInsertFences) {
       AtomicOrdering FenceOrdering = SI->getOrdering();
       SI->setOrdering(AtomicOrdering::Monotonic);
-      MadeChange = bracketInstWithFences(SI, FenceOrdering);
+      MadeChange |= bracketInstWithFences(SI, FenceOrdering);
     } else if (!ShouldInsertFences) {
-      MadeChange = tryInsertTrailingSeqCstFence(SI);
+      MadeChange |= tryInsertTrailingSeqCstFence(SI);
     }
 
     MadeChange |= tryExpandAtomicStore(SI);
@@ -353,19 +353,17 @@ bool AtomicExpandImpl::processAtomicInstr(Instruction *I) {
         ShouldInsertFences) {
       AtomicOrdering FenceOrdering = RMWI->getOrdering();
       RMWI->setOrdering(TLI->atomicOperationOrderAfterFenceSplit(RMWI));
-      MadeChange = bracketInstWithFences(RMWI, FenceOrdering);
+      MadeChange |= bracketInstWithFences(RMWI, FenceOrdering);
     } else if (!ShouldInsertFences) {
-      MadeChange = tryInsertTrailingSeqCstFence(RMWI);
+      MadeChange |= tryInsertTrailingSeqCstFence(RMWI);
     }
 
     // There are two different ways of expanding RMW instructions:
     // - into a load if it is idempotent
     // - into a Cmpxchg/LL-SC loop otherwise
     // we try them in that order.
-    bool Expanded = (isIdempotentRMW(RMWI) && simplifyIdempotentRMW(RMWI)) ||
-                    tryExpandAtomicRMW(RMWI);
-
-    MadeChange |= Expanded;
+    MadeChange |= (isIdempotentRMW(RMWI) && simplifyIdempotentRMW(RMWI)) ||
+                  tryExpandAtomicRMW(RMWI);
     return MadeChange;
   }
 
@@ -400,12 +398,12 @@ bool AtomicExpandImpl::processAtomicInstr(Instruction *I) {
             TLI->atomicOperationOrderAfterFenceSplit(CASI);
         CASI->setSuccessOrdering(CASOrdering);
         CASI->setFailureOrdering(CASOrdering);
-        MadeChange = bracketInstWithFences(CASI, FenceOrdering);
+        MadeChange |= bracketInstWithFences(CASI, FenceOrdering);
       }
     } else if (CmpXchgExpansion !=
                TargetLoweringBase::AtomicExpansionKind::LLSC) {
       // CmpXchg LLSC is handled in expandAtomicCmpXchg().
-      MadeChange = tryInsertTrailingSeqCstFence(CASI);
+      MadeChange |= tryInsertTrailingSeqCstFence(CASI);
     }
 
     MadeChange |= tryExpandAtomicCmpXchg(CASI);

--- a/llvm/lib/CodeGen/AtomicExpandPass.cpp
+++ b/llvm/lib/CodeGen/AtomicExpandPass.cpp
@@ -88,8 +88,7 @@ private:
   bool bracketInstWithFences(Instruction *I, AtomicOrdering Order);
   bool tryInsertTrailingSeqCstFence(Instruction *AtomicI);
   template <typename AtomicInst>
-  bool tryInsertFencesForAtomic(AtomicInst *AtomicI,
-                                bool OrderingRequiresFence,
+  bool tryInsertFencesForAtomic(AtomicInst *AtomicI, bool OrderingRequiresFence,
                                 AtomicOrdering NewOrdering);
   IntegerType *getCorrespondingIntegerType(Type *T, const DataLayout &DL);
   LoadInst *convertAtomicLoadToIntegerType(LoadInst *LI);
@@ -280,9 +279,9 @@ bool AtomicExpandImpl::tryInsertTrailingSeqCstFence(Instruction *AtomicI) {
 }
 
 template <typename AtomicInst>
-bool AtomicExpandImpl::tryInsertFencesForAtomic(
-    AtomicInst *AtomicI, bool OrderingRequiresFence,
-    AtomicOrdering NewOrdering) {
+bool AtomicExpandImpl::tryInsertFencesForAtomic(AtomicInst *AtomicI,
+                                                bool OrderingRequiresFence,
+                                                AtomicOrdering NewOrdering) {
   bool ShouldInsertFences = TLI->shouldInsertFencesForAtomic(AtomicI);
   if (OrderingRequiresFence && ShouldInsertFences) {
     AtomicOrdering FenceOrdering = AtomicI->getOrdering();
@@ -312,8 +311,7 @@ bool AtomicExpandImpl::processAtomicInstr(Instruction *I) {
     }
 
     MadeChange |= tryInsertFencesForAtomic(
-        LI, isAcquireOrStronger(LI->getOrdering()),
-        AtomicOrdering::Monotonic);
+        LI, isAcquireOrStronger(LI->getOrdering()), AtomicOrdering::Monotonic);
 
     MadeChange |= tryExpandAtomicLoad(LI);
     return MadeChange;
@@ -336,8 +334,7 @@ bool AtomicExpandImpl::processAtomicInstr(Instruction *I) {
     }
 
     MadeChange |= tryInsertFencesForAtomic(
-        SI, isReleaseOrStronger(SI->getOrdering()),
-        AtomicOrdering::Monotonic);
+        SI, isReleaseOrStronger(SI->getOrdering()), AtomicOrdering::Monotonic);
 
     MadeChange |= tryExpandAtomicStore(SI);
     return MadeChange;
@@ -357,8 +354,9 @@ bool AtomicExpandImpl::processAtomicInstr(Instruction *I) {
     }
 
     MadeChange |= tryInsertFencesForAtomic(
-        RMWI, isReleaseOrStronger(RMWI->getOrdering()) ||
-                  isAcquireOrStronger(RMWI->getOrdering()),
+        RMWI,
+        isReleaseOrStronger(RMWI->getOrdering()) ||
+            isAcquireOrStronger(RMWI->getOrdering()),
         TLI->atomicOperationOrderAfterFenceSplit(RMWI));
 
     // There are two different ways of expanding RMW instructions:

--- a/llvm/lib/CodeGen/AtomicExpandPass.cpp
+++ b/llvm/lib/CodeGen/AtomicExpandPass.cpp
@@ -87,6 +87,10 @@ private:
 
   bool bracketInstWithFences(Instruction *I, AtomicOrdering Order);
   bool tryInsertTrailingSeqCstFence(Instruction *AtomicI);
+  template <typename AtomicInst>
+  bool tryInsertFencesForAtomic(AtomicInst *AtomicI,
+                                bool OrderingRequiresFence,
+                                AtomicOrdering NewOrdering);
   IntegerType *getCorrespondingIntegerType(Type *T, const DataLayout &DL);
   LoadInst *convertAtomicLoadToIntegerType(LoadInst *LI);
   bool tryExpandAtomicLoad(LoadInst *LI);
@@ -275,9 +279,23 @@ bool AtomicExpandImpl::tryInsertTrailingSeqCstFence(Instruction *AtomicI) {
   return false;
 }
 
+template <typename AtomicInst>
+bool AtomicExpandImpl::tryInsertFencesForAtomic(
+    AtomicInst *AtomicI, bool OrderingRequiresFence,
+    AtomicOrdering NewOrdering) {
+  bool ShouldInsertFences = TLI->shouldInsertFencesForAtomic(AtomicI);
+  if (OrderingRequiresFence && ShouldInsertFences) {
+    AtomicOrdering FenceOrdering = AtomicI->getOrdering();
+    AtomicI->setOrdering(NewOrdering);
+    return bracketInstWithFences(AtomicI, FenceOrdering);
+  }
+  if (!ShouldInsertFences)
+    return tryInsertTrailingSeqCstFence(AtomicI);
+  return false;
+}
+
 bool AtomicExpandImpl::processAtomicInstr(Instruction *I) {
   if (auto *LI = dyn_cast<LoadInst>(I)) {
-    bool MadeChange = false;
     if (!LI->isAtomic())
       return false;
 
@@ -286,27 +304,22 @@ bool AtomicExpandImpl::processAtomicInstr(Instruction *I) {
       return true;
     }
 
+    bool MadeChange = false;
     if (TLI->shouldCastAtomicLoadInIR(LI) ==
         TargetLoweringBase::AtomicExpansionKind::CastToInteger) {
       LI = convertAtomicLoadToIntegerType(LI);
       MadeChange = true;
     }
 
-    bool ShouldInsertFences = TLI->shouldInsertFencesForAtomic(LI);
-    if (isAcquireOrStronger(LI->getOrdering()) && ShouldInsertFences) {
-      AtomicOrdering FenceOrdering = LI->getOrdering();
-      LI->setOrdering(AtomicOrdering::Monotonic);
-      MadeChange |= bracketInstWithFences(LI, FenceOrdering);
-    } else if (!ShouldInsertFences) {
-      MadeChange |= tryInsertTrailingSeqCstFence(LI);
-    }
+    MadeChange |= tryInsertFencesForAtomic(
+        LI, isAcquireOrStronger(LI->getOrdering()),
+        AtomicOrdering::Monotonic);
 
     MadeChange |= tryExpandAtomicLoad(LI);
     return MadeChange;
   }
 
   if (auto *SI = dyn_cast<StoreInst>(I)) {
-    bool MadeChange = false;
     if (!SI->isAtomic())
       return false;
 
@@ -315,48 +328,38 @@ bool AtomicExpandImpl::processAtomicInstr(Instruction *I) {
       return true;
     }
 
+    bool MadeChange = false;
     if (TLI->shouldCastAtomicStoreInIR(SI) ==
         TargetLoweringBase::AtomicExpansionKind::CastToInteger) {
       SI = convertAtomicStoreToIntegerType(SI);
       MadeChange = true;
     }
 
-    bool ShouldInsertFences = TLI->shouldInsertFencesForAtomic(SI);
-    if (isReleaseOrStronger(SI->getOrdering()) && ShouldInsertFences) {
-      AtomicOrdering FenceOrdering = SI->getOrdering();
-      SI->setOrdering(AtomicOrdering::Monotonic);
-      MadeChange |= bracketInstWithFences(SI, FenceOrdering);
-    } else if (!ShouldInsertFences) {
-      MadeChange |= tryInsertTrailingSeqCstFence(SI);
-    }
+    MadeChange |= tryInsertFencesForAtomic(
+        SI, isReleaseOrStronger(SI->getOrdering()),
+        AtomicOrdering::Monotonic);
 
     MadeChange |= tryExpandAtomicStore(SI);
     return MadeChange;
   }
 
   if (auto *RMWI = dyn_cast<AtomicRMWInst>(I)) {
-    bool MadeChange = false;
     if (!atomicSizeSupported(TLI, RMWI)) {
       expandAtomicRMWToLibcall(RMWI);
       return true;
     }
 
+    bool MadeChange = false;
     if (TLI->shouldCastAtomicRMWIInIR(RMWI) ==
         TargetLoweringBase::AtomicExpansionKind::CastToInteger) {
       RMWI = convertAtomicXchgToIntegerType(RMWI);
       MadeChange = true;
     }
 
-    bool ShouldInsertFences = TLI->shouldInsertFencesForAtomic(RMWI);
-    if ((isReleaseOrStronger(RMWI->getOrdering()) ||
-         isAcquireOrStronger(RMWI->getOrdering())) &&
-        ShouldInsertFences) {
-      AtomicOrdering FenceOrdering = RMWI->getOrdering();
-      RMWI->setOrdering(TLI->atomicOperationOrderAfterFenceSplit(RMWI));
-      MadeChange |= bracketInstWithFences(RMWI, FenceOrdering);
-    } else if (!ShouldInsertFences) {
-      MadeChange |= tryInsertTrailingSeqCstFence(RMWI);
-    }
+    MadeChange |= tryInsertFencesForAtomic(
+        RMWI, isReleaseOrStronger(RMWI->getOrdering()) ||
+                  isAcquireOrStronger(RMWI->getOrdering()),
+        TLI->atomicOperationOrderAfterFenceSplit(RMWI));
 
     // There are two different ways of expanding RMW instructions:
     // - into a load if it is idempotent
@@ -368,7 +371,6 @@ bool AtomicExpandImpl::processAtomicInstr(Instruction *I) {
   }
 
   if (auto *CASI = dyn_cast<AtomicCmpXchgInst>(I)) {
-    bool MadeChange = false;
     if (!atomicSizeSupported(TLI, CASI)) {
       expandAtomicCASToLibcall(CASI);
       return true;
@@ -376,6 +378,7 @@ bool AtomicExpandImpl::processAtomicInstr(Instruction *I) {
 
     // TODO: when we're ready to make the change at the IR level, we can
     // extend convertCmpXchgToInteger for floating point too.
+    bool MadeChange = false;
     if (CASI->getCompareOperand()->getType()->isPointerTy()) {
       // TODO: add a TLI hook to control this so that each target can
       // convert to lowering the original type one at a time.

--- a/llvm/lib/CodeGen/AtomicExpandPass.cpp
+++ b/llvm/lib/CodeGen/AtomicExpandPass.cpp
@@ -86,6 +86,7 @@ private:
   }
 
   bool bracketInstWithFences(Instruction *I, AtomicOrdering Order);
+  bool tryInsertTrailingSeqCstFence(Instruction *AtomicI);
   IntegerType *getCorrespondingIntegerType(Type *T, const DataLayout &DL);
   LoadInst *convertAtomicLoadToIntegerType(LoadInst *LI);
   bool tryExpandAtomicLoad(LoadInst *LI);
@@ -261,21 +262,22 @@ static bool atomicSizeSupported(const TargetLowering *TLI, Inst *I) {
          Size <= TLI->getMaxAtomicSizeInBitsSupported() / 8;
 }
 
-bool AtomicExpandImpl::processAtomicInstr(Instruction *I) {
-  auto TryInsertTrailingSeqCstFence = [&](Instruction *AtomicI) {
-    if (!TLI->shouldInsertTrailingSeqCstFenceForAtomicStore(AtomicI))
-      return false;
-
-    IRBuilder Builder(AtomicI);
-    if (auto *TrailingFence = TLI->emitTrailingFence(
-            Builder, AtomicI, AtomicOrdering::SequentiallyConsistent)) {
-      TrailingFence->moveAfter(AtomicI);
-      return true;
-    }
+bool AtomicExpandImpl::tryInsertTrailingSeqCstFence(Instruction *AtomicI) {
+  if (!TLI->shouldInsertTrailingSeqCstFenceForAtomicStore(AtomicI))
     return false;
-  };
 
+  IRBuilder Builder(AtomicI);
+  if (auto *TrailingFence = TLI->emitTrailingFence(
+          Builder, AtomicI, AtomicOrdering::SequentiallyConsistent)) {
+    TrailingFence->moveAfter(AtomicI);
+    return true;
+  }
+  return false;
+}
+
+bool AtomicExpandImpl::processAtomicInstr(Instruction *I) {
   if (auto *LI = dyn_cast<LoadInst>(I)) {
+    bool MadeChange = false;
     if (!LI->isAtomic())
       return false;
 
@@ -284,28 +286,27 @@ bool AtomicExpandImpl::processAtomicInstr(Instruction *I) {
       return true;
     }
 
-    bool Converted = false;
     if (TLI->shouldCastAtomicLoadInIR(LI) ==
         TargetLoweringBase::AtomicExpansionKind::CastToInteger) {
       LI = convertAtomicLoadToIntegerType(LI);
-      Converted = true;
+      MadeChange = true;
     }
 
-    bool Fenced = false;
-    if (TLI->shouldInsertFencesForAtomic(LI) &&
-        isAcquireOrStronger(LI->getOrdering())) {
+    bool ShouldInsertFences = TLI->shouldInsertFencesForAtomic(LI);
+    if (isAcquireOrStronger(LI->getOrdering()) && ShouldInsertFences) {
       AtomicOrdering FenceOrdering = LI->getOrdering();
       LI->setOrdering(AtomicOrdering::Monotonic);
-      Fenced = bracketInstWithFences(LI, FenceOrdering);
-    } else {
-      Fenced = TryInsertTrailingSeqCstFence(LI);
+      MadeChange = bracketInstWithFences(LI, FenceOrdering);
+    } else if (!ShouldInsertFences) {
+      MadeChange = tryInsertTrailingSeqCstFence(LI);
     }
 
-    bool Expanded = tryExpandAtomicLoad(LI);
-    return Converted || Fenced || Expanded;
+    MadeChange |= tryExpandAtomicLoad(LI);
+    return MadeChange;
   }
 
   if (auto *SI = dyn_cast<StoreInst>(I)) {
+    bool MadeChange = false;
     if (!SI->isAtomic())
       return false;
 
@@ -314,84 +315,79 @@ bool AtomicExpandImpl::processAtomicInstr(Instruction *I) {
       return true;
     }
 
-    bool Converted = false;
     if (TLI->shouldCastAtomicStoreInIR(SI) ==
         TargetLoweringBase::AtomicExpansionKind::CastToInteger) {
       SI = convertAtomicStoreToIntegerType(SI);
-      Converted = true;
+      MadeChange = true;
     }
 
-    bool Fenced = false;
-    if (TLI->shouldInsertFencesForAtomic(SI) &&
-        isReleaseOrStronger(SI->getOrdering())) {
+    bool ShouldInsertFences = TLI->shouldInsertFencesForAtomic(SI);
+    if (isReleaseOrStronger(SI->getOrdering()) && ShouldInsertFences) {
       AtomicOrdering FenceOrdering = SI->getOrdering();
       SI->setOrdering(AtomicOrdering::Monotonic);
-      Fenced = bracketInstWithFences(SI, FenceOrdering);
-    } else {
-      Fenced = TryInsertTrailingSeqCstFence(SI);
+      MadeChange = bracketInstWithFences(SI, FenceOrdering);
+    } else if (!ShouldInsertFences) {
+      MadeChange = tryInsertTrailingSeqCstFence(SI);
     }
 
-    bool Expanded = tryExpandAtomicStore(SI);
-    return Converted || Fenced || Expanded;
+    MadeChange |= tryExpandAtomicStore(SI);
+    return MadeChange;
   }
 
   if (auto *RMWI = dyn_cast<AtomicRMWInst>(I)) {
+    bool MadeChange = false;
     if (!atomicSizeSupported(TLI, RMWI)) {
       expandAtomicRMWToLibcall(RMWI);
       return true;
     }
 
-    bool Converted = false;
     if (TLI->shouldCastAtomicRMWIInIR(RMWI) ==
         TargetLoweringBase::AtomicExpansionKind::CastToInteger) {
       RMWI = convertAtomicXchgToIntegerType(RMWI);
-      Converted = true;
+      MadeChange = true;
     }
 
-    bool Fenced = false;
-    if (TLI->shouldInsertFencesForAtomic(RMWI) &&
-        (isReleaseOrStronger(RMWI->getOrdering()) ||
-         isAcquireOrStronger(RMWI->getOrdering()))) {
+    bool ShouldInsertFences = TLI->shouldInsertFencesForAtomic(RMWI);
+    if ((isReleaseOrStronger(RMWI->getOrdering()) ||
+         isAcquireOrStronger(RMWI->getOrdering())) &&
+        ShouldInsertFences) {
       AtomicOrdering FenceOrdering = RMWI->getOrdering();
       RMWI->setOrdering(TLI->atomicOperationOrderAfterFenceSplit(RMWI));
-      Fenced = bracketInstWithFences(RMWI, FenceOrdering);
-    } else {
-      Fenced = TryInsertTrailingSeqCstFence(RMWI);
+      MadeChange = bracketInstWithFences(RMWI, FenceOrdering);
+    } else if (!ShouldInsertFences) {
+      MadeChange = tryInsertTrailingSeqCstFence(RMWI);
     }
 
     // There are two different ways of expanding RMW instructions:
     // - into a load if it is idempotent
     // - into a Cmpxchg/LL-SC loop otherwise
     // we try them in that order.
-    bool Expanded = false;
-    if (isIdempotentRMW(RMWI) && simplifyIdempotentRMW(RMWI))
-      Expanded = true;
-    else
-      Expanded = tryExpandAtomicRMW(RMWI);
+    bool Expanded = (isIdempotentRMW(RMWI) && simplifyIdempotentRMW(RMWI)) ||
+                    tryExpandAtomicRMW(RMWI);
 
-    return Converted || Fenced || Expanded;
+    MadeChange |= Expanded;
+    return MadeChange;
   }
 
   if (auto *CASI = dyn_cast<AtomicCmpXchgInst>(I)) {
+    bool MadeChange = false;
     if (!atomicSizeSupported(TLI, CASI)) {
       expandAtomicCASToLibcall(CASI);
       return true;
     }
 
-    bool Converted = false;
     // TODO: when we're ready to make the change at the IR level, we can
     // extend convertCmpXchgToInteger for floating point too.
     if (CASI->getCompareOperand()->getType()->isPointerTy()) {
       // TODO: add a TLI hook to control this so that each target can
       // convert to lowering the original type one at a time.
       CASI = convertCmpXchgToIntegerType(CASI);
-      Converted = true;
+      MadeChange = true;
     }
 
-    bool Fenced = false;
+    auto CmpXchgExpansion = TLI->shouldExpandAtomicCmpXchgInIR(CASI);
     if (TLI->shouldInsertFencesForAtomic(CASI)) {
-      if (TLI->shouldExpandAtomicCmpXchgInIR(CASI) ==
-              TargetLoweringBase::AtomicExpansionKind::None &&
+      if (CmpXchgExpansion == TargetLoweringBase::AtomicExpansionKind::None &&
           (isReleaseOrStronger(CASI->getSuccessOrdering()) ||
            isAcquireOrStronger(CASI->getSuccessOrdering()) ||
            isAcquireOrStronger(CASI->getFailureOrdering()))) {
@@ -404,16 +400,16 @@ bool AtomicExpandImpl::processAtomicInstr(Instruction *I) {
             TLI->atomicOperationOrderAfterFenceSplit(CASI);
         CASI->setSuccessOrdering(CASOrdering);
         CASI->setFailureOrdering(CASOrdering);
-        Fenced = bracketInstWithFences(CASI, FenceOrdering);
+        MadeChange = bracketInstWithFences(CASI, FenceOrdering);
       }
-    } else if (TLI->shouldExpandAtomicCmpXchgInIR(CASI) !=
+    } else if (CmpXchgExpansion !=
                TargetLoweringBase::AtomicExpansionKind::LLSC) {
       // CmpXchg LLSC is handled in expandAtomicCmpXchg().
-      Fenced = TryInsertTrailingSeqCstFence(CASI);
+      MadeChange = tryInsertTrailingSeqCstFence(CASI);
     }
 
-    bool Expanded = tryExpandAtomicCmpXchg(CASI);
-    return Converted || Fenced || Expanded;
+    MadeChange |= tryExpandAtomicCmpXchg(CASI);
+    return MadeChange;
   }
 
   return false;

--- a/llvm/lib/CodeGen/AtomicExpandPass.cpp
+++ b/llvm/lib/CodeGen/AtomicExpandPass.cpp
@@ -262,63 +262,20 @@ static bool atomicSizeSupported(const TargetLowering *TLI, Inst *I) {
 }
 
 bool AtomicExpandImpl::processAtomicInstr(Instruction *I) {
-  auto *LI = dyn_cast<LoadInst>(I);
-  auto *SI = dyn_cast<StoreInst>(I);
-  auto *RMWI = dyn_cast<AtomicRMWInst>(I);
-  auto *CASI = dyn_cast<AtomicCmpXchgInst>(I);
-
-  auto TryInsertFencesForAtomic = [&]() -> bool {
-    if (TLI->shouldInsertFencesForAtomic(I)) {
-      auto FenceOrdering = AtomicOrdering::Monotonic;
-      if (LI && isAcquireOrStronger(LI->getOrdering())) {
-        FenceOrdering = LI->getOrdering();
-        LI->setOrdering(AtomicOrdering::Monotonic);
-      } else if (SI && isReleaseOrStronger(SI->getOrdering())) {
-        FenceOrdering = SI->getOrdering();
-        SI->setOrdering(AtomicOrdering::Monotonic);
-      } else if (RMWI && (isReleaseOrStronger(RMWI->getOrdering()) ||
-                          isAcquireOrStronger(RMWI->getOrdering()))) {
-        FenceOrdering = RMWI->getOrdering();
-        RMWI->setOrdering(TLI->atomicOperationOrderAfterFenceSplit(RMWI));
-      } else if (CASI &&
-                 TLI->shouldExpandAtomicCmpXchgInIR(CASI) ==
-                     TargetLoweringBase::AtomicExpansionKind::None &&
-                 (isReleaseOrStronger(CASI->getSuccessOrdering()) ||
-                  isAcquireOrStronger(CASI->getSuccessOrdering()) ||
-                  isAcquireOrStronger(CASI->getFailureOrdering()))) {
-        // If a compare and swap is lowered to LL/SC, we can do smarter fence
-        // insertion, with a stronger one on the success path than on the
-        // failure path. As a result, fence insertion is directly done by
-        // expandAtomicCmpXchg in that case.
-        FenceOrdering = CASI->getMergedOrdering();
-        auto CASOrdering = TLI->atomicOperationOrderAfterFenceSplit(CASI);
-  
-        CASI->setSuccessOrdering(CASOrdering);
-        CASI->setFailureOrdering(CASOrdering);
-      }
-
-      if (FenceOrdering != AtomicOrdering::Monotonic)
-        return bracketInstWithFences(I, FenceOrdering);
-      return false;
-    }
-
-    if (!TLI->shouldInsertTrailingSeqCstFenceForAtomicStore(I) ||
-        (CASI && TLI->shouldExpandAtomicCmpXchgInIR(CASI) ==
-                     TargetLoweringBase::AtomicExpansionKind::LLSC))
+  auto TryInsertTrailingSeqCstFence = [&](Instruction *AtomicI) {
+    if (!TLI->shouldInsertTrailingSeqCstFenceForAtomicStore(AtomicI))
       return false;
 
-    // CmpXchg LLSC is handled in expandAtomicCmpXchg().
-    IRBuilder Builder(I);
+    IRBuilder Builder(AtomicI);
     if (auto *TrailingFence = TLI->emitTrailingFence(
-            Builder, I, AtomicOrdering::SequentiallyConsistent)) {
-      TrailingFence->moveAfter(I);
+            Builder, AtomicI, AtomicOrdering::SequentiallyConsistent)) {
+      TrailingFence->moveAfter(AtomicI);
       return true;
     }
     return false;
   };
 
-  switch (I->getOpcode()) {
-  case Instruction::Load: {
+  if (auto *LI = dyn_cast<LoadInst>(I)) {
     if (!LI->isAtomic())
       return false;
 
@@ -330,15 +287,24 @@ bool AtomicExpandImpl::processAtomicInstr(Instruction *I) {
     bool Converted = false;
     if (TLI->shouldCastAtomicLoadInIR(LI) ==
         TargetLoweringBase::AtomicExpansionKind::CastToInteger) {
-      I = LI = convertAtomicLoadToIntegerType(LI);
+      LI = convertAtomicLoadToIntegerType(LI);
       Converted = true;
     }
 
-    bool Fenced = TryInsertFencesForAtomic();
+    bool Fenced = false;
+    if (TLI->shouldInsertFencesForAtomic(LI) && isAcquireOrStronger(LI->getOrdering())) {
+      AtomicOrdering FenceOrdering = LI->getOrdering();
+      LI->setOrdering(AtomicOrdering::Monotonic);
+      Fenced = bracketInstWithFences(LI, FenceOrdering);
+    } else {
+      Fenced = TryInsertTrailingSeqCstFence(LI);
+    }
+
     bool Expanded = tryExpandAtomicLoad(LI);
     return Converted || Fenced || Expanded;
   }
-  case Instruction::Store: {
+
+  if (auto *SI = dyn_cast<StoreInst>(I)) {
     if (!SI->isAtomic())
       return false;
 
@@ -350,15 +316,24 @@ bool AtomicExpandImpl::processAtomicInstr(Instruction *I) {
     bool Converted = false;
     if (TLI->shouldCastAtomicStoreInIR(SI) ==
         TargetLoweringBase::AtomicExpansionKind::CastToInteger) {
-      I = SI = convertAtomicStoreToIntegerType(SI);
+      SI = convertAtomicStoreToIntegerType(SI);
       Converted = true;
     }
 
-    bool Fenced = TryInsertFencesForAtomic();
+    bool Fenced = false;
+    if (TLI->shouldInsertFencesForAtomic(SI) && isReleaseOrStronger(SI->getOrdering())) {
+      AtomicOrdering FenceOrdering = SI->getOrdering();
+      SI->setOrdering(AtomicOrdering::Monotonic);
+      Fenced = bracketInstWithFences(SI, FenceOrdering);
+    } else {
+      Fenced = TryInsertTrailingSeqCstFence(SI);
+    }
+
     bool Expanded = tryExpandAtomicStore(SI);
     return Converted || Fenced || Expanded;
   }
-  case Instruction::AtomicRMW: {
+
+  if (auto *RMWI = dyn_cast<AtomicRMWInst>(I)) {
     if (!atomicSizeSupported(TLI, RMWI)) {
       expandAtomicRMWToLibcall(RMWI);
       return true;
@@ -367,11 +342,19 @@ bool AtomicExpandImpl::processAtomicInstr(Instruction *I) {
     bool Converted = false;
     if (TLI->shouldCastAtomicRMWIInIR(RMWI) ==
         TargetLoweringBase::AtomicExpansionKind::CastToInteger) {
-      I = RMWI = convertAtomicXchgToIntegerType(RMWI);
+      RMWI = convertAtomicXchgToIntegerType(RMWI);
       Converted = true;
     }
 
-    bool Fenced = TryInsertFencesForAtomic();
+    bool Fenced = false;
+    if (TLI->shouldInsertFencesForAtomic(RMWI) && (isReleaseOrStronger(RMWI->getOrdering()) ||
+          isAcquireOrStronger(RMWI->getOrdering()))) {
+      AtomicOrdering FenceOrdering = RMWI->getOrdering();
+      RMWI->setOrdering(TLI->atomicOperationOrderAfterFenceSplit(RMWI));
+      Fenced = bracketInstWithFences(RMWI, FenceOrdering);
+    } else {
+      Fenced = TryInsertTrailingSeqCstFence(RMWI);
+    }
 
     // There are two different ways of expanding RMW instructions:
     // - into a load if it is idempotent
@@ -385,7 +368,8 @@ bool AtomicExpandImpl::processAtomicInstr(Instruction *I) {
 
     return Converted || Fenced || Expanded;
   }
-  case Instruction::AtomicCmpXchg: {
+
+  if (auto *CASI = dyn_cast<AtomicCmpXchgInst>(I)) {
     if (!atomicSizeSupported(TLI, CASI)) {
       expandAtomicCASToLibcall(CASI);
       return true;
@@ -397,17 +381,39 @@ bool AtomicExpandImpl::processAtomicInstr(Instruction *I) {
     if (CASI->getCompareOperand()->getType()->isPointerTy()) {
       // TODO: add a TLI hook to control this so that each target can
       // convert to lowering the original type one at a time.
-      I = CASI = convertCmpXchgToIntegerType(CASI);
+      CASI = convertCmpXchgToIntegerType(CASI);
       Converted = true;
     }
 
-    bool Fenced = TryInsertFencesForAtomic();
+    bool Fenced = false;
+    if (TLI->shouldInsertFencesForAtomic(CASI)) {
+      if (TLI->shouldExpandAtomicCmpXchgInIR(CASI) ==
+              TargetLoweringBase::AtomicExpansionKind::None &&
+          (isReleaseOrStronger(CASI->getSuccessOrdering()) ||
+           isAcquireOrStronger(CASI->getSuccessOrdering()) ||
+           isAcquireOrStronger(CASI->getFailureOrdering()))) {
+        // If a compare and swap is lowered to LL/SC, we can do smarter fence
+        // insertion, with a stronger one on the success path than on the
+        // failure path. As a result, fence insertion is directly done by
+        // expandAtomicCmpXchg in that case.
+        AtomicOrdering FenceOrdering = CASI->getMergedOrdering();
+        AtomicOrdering CASOrdering =
+            TLI->atomicOperationOrderAfterFenceSplit(CASI);
+        CASI->setSuccessOrdering(CASOrdering);
+        CASI->setFailureOrdering(CASOrdering);
+        Fenced = bracketInstWithFences(CASI, FenceOrdering);
+      }
+    } else if (TLI->shouldExpandAtomicCmpXchgInIR(CASI) !=
+               TargetLoweringBase::AtomicExpansionKind::LLSC) {
+      // CmpXchg LLSC is handled in expandAtomicCmpXchg().
+      Fenced = TryInsertTrailingSeqCstFence(CASI);
+    }
+
     bool Expanded = tryExpandAtomicCmpXchg(CASI);
     return Converted || Fenced || Expanded;
   }
-  default:
-    return false;
-  }
+
+  return false;
 }
 
 bool AtomicExpandImpl::run(


### PR DESCRIPTION
While working on https://discourse.llvm.org/t/rfc-add-elementwise-modifier-to-atomicrmw/90134/5 I found this `processAtomicInstr` to be a little hard to read, with casing on the instruction type all over the place. I think it reads nicer to just case on the instruction type once.