### PR TITLE
[SandboxVec][BottomUpVec] Fix crash caused by Cmps with different operand types

### DIFF
--- a/llvm/lib/Transforms/Vectorize/SandboxVectorizer/Legality.cpp
+++ b/llvm/lib/Transforms/Vectorize/SandboxVectorizer/Legality.cpp
@@ -106,10 +106,13 @@ LegalityAnalysis::notVectorizableBasedOnOpcodesAndTypes(
   }
   case Instruction::Opcode::FCmp:
   case Instruction::Opcode::ICmp: {
-    // We need the same predicate..
+    // We need the same predicate and the same operand type.
     auto Pred0 = cast<CmpInst>(I0)->getPredicate();
-    bool Same = all_of(Bndl, [Pred0](Value *V) {
-      return cast<CmpInst>(V)->getPredicate() == Pred0;
+    Type *Ty0 = cast<CmpInst>(I0)->getOperand(0)->getType();
+    bool Same = all_of(Bndl, [Pred0, Ty0](Value *V) {
+      auto *CmpI = cast<CmpInst>(V);
+      return CmpI->getPredicate() == Pred0 &&
+             CmpI->getOperand(0)->getType() == Ty0;
     });
     if (Same)
       return std::nullopt;

--- a/llvm/test/Transforms/SandboxVectorizer/bottomup_basic.ll
+++ b/llvm/test/Transforms/SandboxVectorizer/bottomup_basic.ll
@@ -700,6 +700,51 @@ define void @vectorize_constant_vectors(ptr %ptr) {
   store <2 x i8> %sub1, ptr %ptr1
   ret void
 }
+
+; ZExt's operands can be of different types.
+define void @diff_types(ptr %ptr, ptr %ptrX, ptr %ptrY) {
+; CHECK-LABEL: define void @diff_types(
+; CHECK-SAME: ptr [[PTR:%.*]], ptr [[PTRX:%.*]], ptr [[PTRY:%.*]]) {
+; CHECK-NEXT:    [[PTR0:%.*]] = getelementptr float, ptr [[PTR]], i32 0
+; CHECK-NEXT:    [[LDX:%.*]] = load i16, ptr [[PTRX]], align 2
+; CHECK-NEXT:    [[LDY:%.*]] = load i8, ptr [[PTRY]], align 1
+; CHECK-NEXT:    [[CMP0:%.*]] = icmp eq i16 [[LDX]], 0
+; CHECK-NEXT:    [[CMP1:%.*]] = icmp eq i8 [[LDY]], 0
+; CHECK-NEXT:    [[PACK:%.*]] = insertelement <2 x i1> poison, i1 [[CMP0]], i32 0, !sandboxvec [[META20:![0-9]+]]
+; CHECK-NEXT:    [[PACK1:%.*]] = insertelement <2 x i1> [[PACK]], i1 [[CMP1]], i32 1, !sandboxvec [[META20]]
+; CHECK-NEXT:    [[VCAST:%.*]] = zext <2 x i1> [[PACK1]] to <2 x i32>, !sandboxvec [[META20]]
+; CHECK-NEXT:    store <2 x i32> [[VCAST]], ptr [[PTR0]], align 4, !sandboxvec [[META20]]
+; CHECK-NEXT:    ret void
+;
+; REVERT-LABEL: define void @diff_types(
+; REVERT-SAME: ptr [[PTR:%.*]], ptr [[PTRX:%.*]], ptr [[PTRY:%.*]]) {
+; REVERT-NEXT:    [[PTR0:%.*]] = getelementptr float, ptr [[PTR]], i32 0
+; REVERT-NEXT:    [[PTR1:%.*]] = getelementptr float, ptr [[PTR]], i32 1, !sandboxvec [[META20:![0-9]+]]
+; REVERT-NEXT:    [[LDX:%.*]] = load i16, ptr [[PTRX]], align 2
+; REVERT-NEXT:    [[LDY:%.*]] = load i8, ptr [[PTRY]], align 1
+; REVERT-NEXT:    [[CMP0:%.*]] = icmp eq i16 [[LDX]], 0
+; REVERT-NEXT:    [[CMP1:%.*]] = icmp eq i8 [[LDY]], 0
+; REVERT-NEXT:    [[ZEXT0:%.*]] = zext i1 [[CMP0]] to i32, !sandboxvec [[META20]]
+; REVERT-NEXT:    [[ZEXT1:%.*]] = zext i1 [[CMP1]] to i32, !sandboxvec [[META20]]
+; REVERT-NEXT:    store i32 [[ZEXT0]], ptr [[PTR0]], align 4, !sandboxvec [[META20]]
+; REVERT-NEXT:    store i32 [[ZEXT1]], ptr [[PTR1]], align 4, !sandboxvec [[META20]]
+; REVERT-NEXT:    ret void
+;
+  %ptr0 = getelementptr float, ptr %ptr, i32 0
+  %ptr1 = getelementptr float, ptr %ptr, i32 1
+
+  %ldX = load i16, ptr %ptrX
+  %ldY = load i8, ptr %ptrY
+  %cmp0 = icmp eq i16 %ldX, 0
+  %cmp1 = icmp eq i8 %ldY, 0
+  %zext0 = zext i1 %cmp0 to i32
+  %zext1 = zext i1 %cmp1 to i32
+  store i32 %zext0, ptr %ptr0
+  store i32 %zext1, ptr %ptr1
+
+  ret void
+}
+
 ;.
 ; CHECK: [[META0]] = distinct !{!"sandboxregion"}
 ; CHECK: [[META1]] = distinct !{!"sandboxregion"}
@@ -721,6 +766,7 @@ define void @vectorize_constant_vectors(ptr %ptr) {
 ; CHECK: [[META17]] = distinct !{!"sandboxregion"}
 ; CHECK: [[META18]] = distinct !{!"sandboxregion"}
 ; CHECK: [[META19]] = distinct !{!"sandboxregion"}
+; CHECK: [[META20]] = distinct !{!"sandboxregion"}
 ;.
 ; REVERT: [[META0]] = distinct !{!"sandboxregion"}
 ; REVERT: [[META1]] = distinct !{!"sandboxregion"}
@@ -742,4 +788,5 @@ define void @vectorize_constant_vectors(ptr %ptr) {
 ; REVERT: [[META17]] = distinct !{!"sandboxregion"}
 ; REVERT: [[META18]] = distinct !{!"sandboxregion"}
 ; REVERT: [[META19]] = distinct !{!"sandboxregion"}
+; REVERT: [[META20]] = distinct !{!"sandboxregion"}
 ;.


### PR DESCRIPTION
This patch disables vectorizing Cmps with different operand types because we can't form a legal vector.
This used to cause an assertion check crash once we attempted to pack the bundle formed by Cmp's operands.