### PR TITLE
[RISCV] SFB with Immediates to QC.MVccI

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVExpandPseudoInsts.cpp
+++ b/llvm/lib/Target/RISCV/RISCVExpandPseudoInsts.cpp
@@ -342,8 +342,7 @@ bool RISCVExpandPseudo::expandCCOpToCMov(MachineBasicBlock &MBB,
   MachineOperand &RHS = MI.getOperand(MI.getNumExplicitOperands() - 1);
 
   // FIXME: Would be wonderful to support LHS=X0, but not very easy.
-  if (LHS.getReg() == RISCV::X0 ||
-      MI.getOperand(1).getReg() == RISCV::X0 ||
+  if (LHS.getReg() == RISCV::X0 || MI.getOperand(1).getReg() == RISCV::X0 ||
       MI.getOperand(2).getReg() == RISCV::X0)
     return false;
 
@@ -399,8 +398,8 @@ bool RISCVExpandPseudo::expandCCOpToCMov(MachineBasicBlock &MBB,
   }
 
   if (RHS.isImm() && isInt<5>(RHS.getImm())) {
-    // $dst = PseudoCCMOVGPR $falsev (=$dst), $truev, $opcode, $lhs, $rhs_imm
-    // $dst = PseudoCCMOVGPRNoX0 $falsev (=$dst), $truev, $opcode, $lhs, $rhs_imm
+    // $dst = PseudoCCMOVGPR $falsev(=$dst), $truev, $opcode, $lhs, $rhs_imm
+    // $dst = PseudoCCMOVGPRNoX0 $falsev(=$dst), $truev, $opcode, $lhs, $rhs_imm
     // =>
     // $dst = QC_MVccI $falsev (=$dst), $lhs, $rhs_imm, $truev
     BuildMI(MBB, MBBI, DL, TII->get(CMovImmOpcode))

--- a/llvm/lib/Target/RISCV/RISCVExpandPseudoInsts.cpp
+++ b/llvm/lib/Target/RISCV/RISCVExpandPseudoInsts.cpp
@@ -338,53 +338,91 @@ bool RISCVExpandPseudo::expandCCOpToCMov(MachineBasicBlock &MBB,
   if (!STI->hasVendorXqcicm())
     return false;
 
+  MachineOperand &LHS = MI.getOperand(MI.getNumExplicitOperands() - 2);
+  MachineOperand &RHS = MI.getOperand(MI.getNumExplicitOperands() - 1);
+
   // FIXME: Would be wonderful to support LHS=X0, but not very easy.
-  if (MI.getOperand(MI.getNumExplicitOperands() - 2).getReg() == RISCV::X0 ||
+  if (LHS.getReg() == RISCV::X0 ||
       MI.getOperand(1).getReg() == RISCV::X0 ||
       MI.getOperand(2).getReg() == RISCV::X0)
     return false;
 
   // Use branch opcode to select appropriate Xqcicm instruction
   unsigned BCC = MI.getOperand(MI.getNumExplicitOperands() - 3).getImm();
-  unsigned CMovOpcode, CMovIOpcode;
+  std::optional<unsigned> CMovRegOpcode;
+  unsigned CMovImmOpcode;
   switch (BCC) {
   default:
     return false; // Unhandled branch opcodes
   case RISCV::BNE:
-    CMovOpcode = RISCV::QC_MVEQ;
-    CMovIOpcode = RISCV::QC_MVEQI;
+    CMovRegOpcode = RISCV::QC_MVEQ;
+    CMovImmOpcode = RISCV::QC_MVEQI;
     break;
   case RISCV::BEQ:
-    CMovOpcode = RISCV::QC_MVNE;
-    CMovIOpcode = RISCV::QC_MVNEI;
+    CMovRegOpcode = RISCV::QC_MVNE;
+    CMovImmOpcode = RISCV::QC_MVNEI;
     break;
   case RISCV::BGE:
-    CMovOpcode = RISCV::QC_MVLT;
-    CMovIOpcode = RISCV::QC_MVLTI;
+    CMovRegOpcode = RISCV::QC_MVLT;
+    CMovImmOpcode = RISCV::QC_MVLTI;
     break;
   case RISCV::BLT:
-    CMovOpcode = RISCV::QC_MVGE;
-    CMovIOpcode = RISCV::QC_MVGEI;
+    CMovRegOpcode = RISCV::QC_MVGE;
+    CMovImmOpcode = RISCV::QC_MVGEI;
     break;
   case RISCV::BGEU:
-    CMovOpcode = RISCV::QC_MVLTU;
-    CMovIOpcode = RISCV::QC_MVLTUI;
+    CMovRegOpcode = RISCV::QC_MVLTU;
+    CMovImmOpcode = RISCV::QC_MVLTUI;
     break;
   case RISCV::BLTU:
-    CMovOpcode = RISCV::QC_MVGEU;
-    CMovIOpcode = RISCV::QC_MVGEUI;
+    CMovRegOpcode = RISCV::QC_MVGEU;
+    CMovImmOpcode = RISCV::QC_MVGEUI;
+    break;
+  case RISCV::QC_BEQI:
+    CMovImmOpcode = RISCV::QC_MVEQI;
+    break;
+  case RISCV::QC_BNEI:
+    CMovImmOpcode = RISCV::QC_MVNEI;
+    break;
+  case RISCV::QC_BLTI:
+    CMovImmOpcode = RISCV::QC_MVLTI;
+    break;
+  case RISCV::QC_BGEI:
+    CMovImmOpcode = RISCV::QC_MVGEI;
+    break;
+  case RISCV::QC_BLTUI:
+    CMovImmOpcode = RISCV::QC_MVLTUI;
+    break;
+  case RISCV::QC_BGEUI:
+    CMovImmOpcode = RISCV::QC_MVGEUI;
     break;
   }
 
-  if (MI.getOperand(MI.getNumExplicitOperands() - 1).getReg() == RISCV::X0) {
-    // $dst = PseudoCCMOVGPR $lhs, X0, $cc, $falsev (=$dst), $truev
-    // $dst = PseudoCCMOVGPRNoX0 $lhs, X0, $cc, $falsev (=$dst), $truev
+  if (RHS.isImm() && isInt<5>(RHS.getImm())) {
+    // $dst = PseudoCCMOVGPR $falsev (=$dst), $truev, $opcode, $lhs, $rhs_imm
+    // $dst = PseudoCCMOVGPRNoX0 $falsev (=$dst), $truev, $opcode, $lhs, $rhs_imm
     // =>
-    // $dst = QC_MVccI $falsev (=$dst), $lhs, 0, $truev
-    BuildMI(MBB, MBBI, DL, TII->get(CMovIOpcode))
+    // $dst = QC_MVccI $falsev (=$dst), $lhs, $rhs_imm, $truev
+    BuildMI(MBB, MBBI, DL, TII->get(CMovImmOpcode))
         .addDef(MI.getOperand(0).getReg())
         .addReg(MI.getOperand(1).getReg())
-        .addReg(MI.getOperand(MI.getNumExplicitOperands() - 2).getReg())
+        .addReg(LHS.getReg())
+        .add(RHS)
+        .addReg(MI.getOperand(2).getReg());
+
+    MI.eraseFromParent();
+    return true;
+  }
+
+  if (RHS.getReg() == RISCV::X0) {
+    // $dst = PseudoCCMOVGPR $falsev (=$dst), $truev, $opcode, $lhs, X0
+    // $dst = PseudoCCMOVGPRNoX0 $falsev (=$dst), $truev, $opcode, $lhs, X0
+    // =>
+    // $dst = QC_MVccI $falsev (=$dst), $lhs, 0, $truev
+    BuildMI(MBB, MBBI, DL, TII->get(CMovImmOpcode))
+        .addDef(MI.getOperand(0).getReg())
+        .addReg(MI.getOperand(1).getReg())
+        .addReg(LHS.getReg())
         .addImm(0)
         .addReg(MI.getOperand(2).getReg());
 
@@ -392,15 +430,18 @@ bool RISCVExpandPseudo::expandCCOpToCMov(MachineBasicBlock &MBB,
     return true;
   }
 
-  // $dst = PseudoCCMOVGPR $lhs, $rhs, $cc, $falsev (=$dst), $truev
-  // $dst = PseudoCCMOVGPRNoX0 $lhs, $rhs, $cc, $falsev (=$dst), $truev
+  if (!CMovRegOpcode)
+    return false;
+
+  // $dst = PseudoCCMOVGPR $falsev (=$dst), $truev, $opcode, $lhs, $rhs
+  // $dst = PseudoCCMOVGPRNoX0 $falsev (=$dst), $truev, $opcode, $lhs, $rhs
   // =>
   // $dst = QC_MVcc $falsev (=$dst), $lhs, $rhs, $truev
-  BuildMI(MBB, MBBI, DL, TII->get(CMovOpcode))
+  BuildMI(MBB, MBBI, DL, TII->get(*CMovRegOpcode))
       .addDef(MI.getOperand(0).getReg())
       .addReg(MI.getOperand(1).getReg())
-      .addReg(MI.getOperand(MI.getNumExplicitOperands() - 2).getReg())
-      .addReg(MI.getOperand(MI.getNumExplicitOperands() - 1).getReg())
+      .addReg(LHS.getReg())
+      .addReg(RHS.getReg())
       .addReg(MI.getOperand(2).getReg());
   MI.eraseFromParent();
   return true;

--- a/llvm/test/CodeGen/RISCV/short-forward-branch-opt-with-branch-with-immediates_32_eq.ll
+++ b/llvm/test/CodeGen/RISCV/short-forward-branch-opt-with-branch-with-immediates_32_eq.ll
@@ -15,10 +15,7 @@ define i32 @branch_with_immSFB_mv(i32 %a, i32 %c, i32 %d) {
 ;
 ; RV32I-SFB-WITH-IMM-LABEL: branch_with_immSFB_mv:
 ; RV32I-SFB-WITH-IMM:       # %bb.0: # %entry
-; RV32I-SFB-WITH-IMM-NEXT:    qc.beqi a2, 2, .LBB0_2
-; RV32I-SFB-WITH-IMM-NEXT:  # %bb.1: # %entry
-; RV32I-SFB-WITH-IMM-NEXT:    mv a0, a1
-; RV32I-SFB-WITH-IMM-NEXT:  .LBB0_2: # %entry
+; RV32I-SFB-WITH-IMM-NEXT:    qc.mveqi a0, a2, 2, a1
 ; RV32I-SFB-WITH-IMM-NEXT:    ret
 entry:
   %x = icmp eq i32 %d, 2

--- a/llvm/test/CodeGen/RISCV/short-forward-branch-opt-with-branch-with-immediates_32_ne.ll
+++ b/llvm/test/CodeGen/RISCV/short-forward-branch-opt-with-branch-with-immediates_32_ne.ll
@@ -15,10 +15,7 @@ define i32 @branch_with_immSFB_mv(i32 %a, i32 %c, i32 %d) {
 ;
 ; RV32I-SFB-WITH-IMM-LABEL: branch_with_immSFB_mv:
 ; RV32I-SFB-WITH-IMM:       # %bb.0: # %entry
-; RV32I-SFB-WITH-IMM-NEXT:    qc.bnei a2, 2, .LBB0_2
-; RV32I-SFB-WITH-IMM-NEXT:  # %bb.1: # %entry
-; RV32I-SFB-WITH-IMM-NEXT:    mv a0, a1
-; RV32I-SFB-WITH-IMM-NEXT:  .LBB0_2: # %entry
+; RV32I-SFB-WITH-IMM-NEXT:    qc.mvnei a0, a2, 2, a1
 ; RV32I-SFB-WITH-IMM-NEXT:    ret
 entry:
   %x = icmp ne i32 %d, 2

--- a/llvm/test/CodeGen/RISCV/short-forward-branch-opt-with-branch-with-immediates_32_sge.ll
+++ b/llvm/test/CodeGen/RISCV/short-forward-branch-opt-with-branch-with-immediates_32_sge.ll
@@ -15,10 +15,7 @@ define i32 @branch_with_immSFB_mv(i32 %a, i32 %c, i32 %d) {
 ;
 ; RV32I-SFB-WITH-IMM-LABEL: branch_with_immSFB_mv:
 ; RV32I-SFB-WITH-IMM:       # %bb.0: # %entry
-; RV32I-SFB-WITH-IMM-NEXT:    qc.bgei a2, 2, .LBB0_2
-; RV32I-SFB-WITH-IMM-NEXT:  # %bb.1: # %entry
-; RV32I-SFB-WITH-IMM-NEXT:    mv a0, a1
-; RV32I-SFB-WITH-IMM-NEXT:  .LBB0_2: # %entry
+; RV32I-SFB-WITH-IMM-NEXT:    qc.mvgei a0, a2, 2, a1
 ; RV32I-SFB-WITH-IMM-NEXT:    ret
 entry:
   %x = icmp sge i32 %d, 2

--- a/llvm/test/CodeGen/RISCV/short-forward-branch-opt-with-branch-with-immediates_32_slt.ll
+++ b/llvm/test/CodeGen/RISCV/short-forward-branch-opt-with-branch-with-immediates_32_slt.ll
@@ -15,10 +15,7 @@ define i32 @branch_with_immSFB_mv(i32 %a, i32 %c, i32 %d) {
 ;
 ; RV32I-SFB-WITH-IMM-LABEL: branch_with_immSFB_mv:
 ; RV32I-SFB-WITH-IMM:       # %bb.0: # %entry
-; RV32I-SFB-WITH-IMM-NEXT:    qc.blti a2, 2, .LBB0_2
-; RV32I-SFB-WITH-IMM-NEXT:  # %bb.1: # %entry
-; RV32I-SFB-WITH-IMM-NEXT:    mv a0, a1
-; RV32I-SFB-WITH-IMM-NEXT:  .LBB0_2: # %entry
+; RV32I-SFB-WITH-IMM-NEXT:    qc.mvlti a0, a2, 2, a1
 ; RV32I-SFB-WITH-IMM-NEXT:    ret
 entry:
   %x = icmp slt i32 %d, 2

--- a/llvm/test/CodeGen/RISCV/short-forward-branch-opt-with-branch-with-immediates_32_uge.ll
+++ b/llvm/test/CodeGen/RISCV/short-forward-branch-opt-with-branch-with-immediates_32_uge.ll
@@ -15,10 +15,7 @@ define i32 @branch_with_immSFB_mv(i32 %a, i32 %c, i32 %d) {
 ;
 ; RV32I-SFB-WITH-IMM-LABEL: branch_with_immSFB_mv:
 ; RV32I-SFB-WITH-IMM:       # %bb.0: # %entry
-; RV32I-SFB-WITH-IMM-NEXT:    qc.bgeui a2, 2, .LBB0_2
-; RV32I-SFB-WITH-IMM-NEXT:  # %bb.1: # %entry
-; RV32I-SFB-WITH-IMM-NEXT:    mv a0, a1
-; RV32I-SFB-WITH-IMM-NEXT:  .LBB0_2: # %entry
+; RV32I-SFB-WITH-IMM-NEXT:    qc.mvgeui a0, a2, 2, a1
 ; RV32I-SFB-WITH-IMM-NEXT:    ret
 entry:
   %x = icmp uge i32 %d, 2

--- a/llvm/test/CodeGen/RISCV/short-forward-branch-opt-with-branch-with-immediates_32_ult.ll
+++ b/llvm/test/CodeGen/RISCV/short-forward-branch-opt-with-branch-with-immediates_32_ult.ll
@@ -15,10 +15,7 @@ define i32 @branch_with_immSFB_mv(i32 %a, i32 %c, i32 %d) {
 ;
 ; RV32I-SFB-WITH-IMM-LABEL: branch_with_immSFB_mv:
 ; RV32I-SFB-WITH-IMM:       # %bb.0: # %entry
-; RV32I-SFB-WITH-IMM-NEXT:    qc.bltui a2, 2, .LBB0_2
-; RV32I-SFB-WITH-IMM-NEXT:  # %bb.1: # %entry
-; RV32I-SFB-WITH-IMM-NEXT:    mv a0, a1
-; RV32I-SFB-WITH-IMM-NEXT:  .LBB0_2: # %entry
+; RV32I-SFB-WITH-IMM-NEXT:    qc.mvltui a0, a2, 2, a1
 ; RV32I-SFB-WITH-IMM-NEXT:    ret
 entry:
   %x = icmp ult i32 %d, 2


### PR DESCRIPTION
When we are just branching over a move (rather than a more complex instruction), then Xqcicm sometimes has equivalent conditional move instructions for that which are shorter.

We can only turn `qc.b<cc>i` instructions into `qc.mv<cc>i` instructions because the immediate ranges match (5-bit). The `qc.e.b<cc>i` take larger immediates (16-bit) for which there is no equivalent.