### PR TITLE
[WebAssembly][NFC] Rename and test FastISel selectBr

### DIFF
--- a/llvm/lib/Target/WebAssembly/WebAssemblyFastISel.cpp
+++ b/llvm/lib/Target/WebAssembly/WebAssemblyFastISel.cpp
@@ -189,7 +189,7 @@ private:
   bool selectBitCast(const Instruction *I);
   bool selectLoad(const Instruction *I);
   bool selectStore(const Instruction *I);
-  bool selectBr(const Instruction *I);
+  bool selectCondBr(const Instruction *I);
   bool selectRet(const Instruction *I);
   bool selectUnreachable(const Instruction *I);
 
@@ -1498,7 +1498,7 @@ bool WebAssemblyFastISel::selectStore(const Instruction *I) {
   return true;
 }
 
-bool WebAssemblyFastISel::selectBr(const Instruction *I) {
+bool WebAssemblyFastISel::selectCondBr(const Instruction *I) {
   const auto *Br = cast<CondBrInst>(I);
 
   MachineBasicBlock *TBB = FuncInfo.getMBB(Br->getSuccessor(0));
@@ -1610,7 +1610,7 @@ bool WebAssemblyFastISel::fastSelectInstruction(const Instruction *I) {
   case Instruction::Store:
     return selectStore(I);
   case Instruction::CondBr:
-    return selectBr(I);
+    return selectCondBr(I);
   case Instruction::Ret:
     return selectRet(I);
   case Instruction::Unreachable:

--- a/llvm/test/CodeGen/WebAssembly/fast-isel.ll
+++ b/llvm/test/CodeGen/WebAssembly/fast-isel.ll
@@ -1,6 +1,6 @@
 ; RUN: llc < %s -asm-verbose=false \
-; RUN:   -fast-isel -fast-isel-abort=1 -verify-machineinstrs \
-; RUN:   -wasm-disable-explicit-locals -wasm-keep-registers \
+; RUN:   -fast-isel -fast-isel-abort=3 -verify-machineinstrs \
+; RUN:   -wasm-disable-explicit-locals -wasm-keep-registers -O0 \
 ; RUN:   | FileCheck %s
 
 target triple = "wasm32-unknown-unknown"
@@ -75,4 +75,19 @@ bb:
   %tmp = getelementptr i64, ptr %p, i32 1
   %tmp2 = load i64, ptr %tmp, align 8
   ret i64 %tmp2
+}
+
+; CHECK-LABEL: br:
+; CHECK: br_if
+; CHECK: br
+; CHECK: f32.const $push{{[0-9]+}}=, 0x1.4p1{{$}}
+define float @br(i32 %a) {
+  %cond = icmp eq i32 %a, 0
+  br i1 %cond, label %block1, label %block2
+block1:
+  br label %block3
+block2:
+  br label %block3
+block3:
+  ret float 2.5
 }


### PR DESCRIPTION
selectBr only handles conditional branches and also wasn't tested. Clarify the name and add test that enforces that there's no fallback.