### PR TITLE
[lldb][NativePDB] Require `target-windows` for MSVC test

### DIFF
--- a/lldb/test/Shell/SymbolFile/NativePDB/structured-bindings-msvc.test
+++ b/lldb/test/Shell/SymbolFile/NativePDB/structured-bindings-msvc.test
@@ -1,4 +1,4 @@
-# REQUIRES: lld, msvc
+# REQUIRES: lld, msvc, target-windows
 
 # Test that LLDB can show variables introduced in C++ 17 structured bindings
 # when compiled with MSVC.


### PR DESCRIPTION
Fixes the failure on the lldb-remote-linux-win buildbot (https://github.com/llvm/llvm-project/pull/186124#issuecomment-4060098881).

The test runs MSVC to produce an executable that only runs on Windows.