### PR TITLE
[clang][docs] Fix unhandled Error in LibTooling examples

### DIFF
--- a/clang/docs/LibTooling.rst
+++ b/clang/docs/LibTooling.rst
@@ -75,7 +75,7 @@ and automatic location of the compilation database using source files paths.
     auto ExpectedParser = CommonOptionsParser::create(argc, argv, MyToolCategory);
     if (!ExpectedParser) {
       // Fail gracefully for unsupported options.
-      llvm::errs() << ExpectedParser.takeError();
+      llvm::errs() << toString(ExpectedParser.takeError());
       return 1;
     }
     CommonOptionsParser& OptionsParser = ExpectedParser.get();
@@ -142,7 +142,7 @@ version of this example tool is also checked into the clang tree at
   int main(int argc, const char **argv) {
     auto ExpectedParser = CommonOptionsParser::create(argc, argv, MyToolCategory);
     if (!ExpectedParser) {
-      llvm::errs() << ExpectedParser.takeError();
+      llvm::errs() << toString(ExpectedParser.takeError());
       return 1;
     }
     CommonOptionsParser& OptionsParser = ExpectedParser.get();


### PR DESCRIPTION
## Summary
- Use `toString()` to wrap `ExpectedParser.takeError()` so the `Error` is properly consumed before destruction
- Without this, the `Error` destructor fires an assertion/abort (core dump) because LLVM's `Error` type enforces that errors must be explicitly handled
- Fixes both occurrences in the file (lines 78 and 145)

Fixes #97983
Continues the work from #98129 (approved by @nickhuang99 and @Sirraide but never merged)