### PR TITLE
[clang][docs] Clarify [[unlikely]] example in compound statement

### DIFF
--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -2686,8 +2686,10 @@ path of execution, but that can be confusing:
 .. code-block:: c++
 
   if (b) {
-    [[unlikely]] --b; // In the path of execution,
-                      // this branch is considered unlikely.
+    [[unlikely]] --b; // Per the standard this is in the path of
+                      // execution, so this branch should be considered
+                      // unlikely. However, Clang ignores the attribute
+                      // here since it is not on the substatement.
   }
 
   if (b) {


### PR DESCRIPTION
## Summary
- The first code example in the "confusing standard behavior" section had a comment claiming `[[unlikely]]` makes the branch unlikely, contradicting a later example showing the same placement being ignored
- Rewords the comment to clarify this is the C++ Standard's recommendation that Clang does not follow, since the attribute is not on the substatement
- The code example is kept unchanged — the contradiction was in the comment, not the code

Fixes #126362
Continues the work from #126372 (reviewer feedback from @Sirraide and @AaronBallman indicated the fix should reword the comment rather than move the attribute)