### PR TITLE
[Transforms/Scalar][NFC] Drop uses of BranchInst

### DIFF
--- a/llvm/lib/Transforms/Scalar/ADCE.cpp
+++ b/llvm/lib/Transforms/Scalar/ADCE.cpp
@@ -212,11 +212,6 @@ ADCEChanged AggressiveDeadCodeElimination::performDeadCodeElimination() {
   return removeDeadInstructions();
 }
 
-static bool isUnconditionalBranch(Instruction *Term) {
-  auto *BR = dyn_cast<BranchInst>(Term);
-  return BR && BR->isUnconditional();
-}
-
 void AggressiveDeadCodeElimination::initialize() {
   auto NumBlocks = F.size();
 
@@ -232,7 +227,7 @@ void AggressiveDeadCodeElimination::initialize() {
     auto &Info = BlockInfo[&BB];
     Info.BB = &BB;
     Info.Terminator = BB.getTerminator();
-    Info.UnconditionalBranch = isUnconditionalBranch(Info.Terminator);
+    Info.UnconditionalBranch = isa<UncondBrInst>(Info.Terminator);
   }
 
   // Initialize instruction map and set pointers to block info.
@@ -339,7 +334,7 @@ bool AggressiveDeadCodeElimination::isAlwaysLive(Instruction &I) {
   }
   if (!I.isTerminator())
     return false;
-  if (RemoveControlFlowFlag && (isa<BranchInst>(I) || isa<SwitchInst>(I)))
+  if (RemoveControlFlowFlag && isa<UncondBrInst, CondBrInst, SwitchInst>(I))
     return false;
   return true;
 }
@@ -682,8 +677,8 @@ void AggressiveDeadCodeElimination::makeUnconditional(BasicBlock *BB,
     collectLiveScopes(*DL);
 
   // Just mark live an existing unconditional branch
-  if (isUnconditionalBranch(PredTerm)) {
-    PredTerm->setSuccessor(0, Target);
+  if (auto *BI = dyn_cast<UncondBrInst>(PredTerm)) {
+    BI->setSuccessor(Target);
     InstInfo[PredTerm].Live = true;
     return;
   }

--- a/llvm/lib/Transforms/Scalar/CallSiteSplitting.cpp
+++ b/llvm/lib/Transforms/Scalar/CallSiteSplitting.cpp
@@ -128,8 +128,8 @@ using ConditionsTy = SmallVector<ConditionTy, 2>;
 /// if it is relevant to any argument at CB.
 static void recordCondition(CallBase &CB, BasicBlock *From, BasicBlock *To,
                             ConditionsTy &Conditions) {
-  auto *BI = dyn_cast<BranchInst>(From->getTerminator());
-  if (!BI || !BI->isConditional())
+  auto *BI = dyn_cast<CondBrInst>(From->getTerminator());
+  if (!BI)
     return;
 
   CmpPredicate Pred;

--- a/llvm/lib/Transforms/Scalar/ConstraintElimination.cpp
+++ b/llvm/lib/Transforms/Scalar/ConstraintElimination.cpp
@@ -956,9 +956,9 @@ void State::addInfoForInductions(BasicBlock &BB) {
 
   BasicBlock *InLoopSucc = nullptr;
   if (Pred == CmpInst::ICMP_NE)
-    InLoopSucc = cast<BranchInst>(BB.getTerminator())->getSuccessor(0);
+    InLoopSucc = cast<CondBrInst>(BB.getTerminator())->getSuccessor(0);
   else if (Pred == CmpInst::ICMP_EQ)
-    InLoopSucc = cast<BranchInst>(BB.getTerminator())->getSuccessor(1);
+    InLoopSucc = cast<CondBrInst>(BB.getTerminator())->getSuccessor(1);
   else
     return;
 
@@ -1248,8 +1248,8 @@ void State::addInfoFor(BasicBlock &BB) {
     return;
   }
 
-  auto *Br = dyn_cast<BranchInst>(BB.getTerminator());
-  if (!Br || !Br->isConditional())
+  auto *Br = dyn_cast<CondBrInst>(BB.getTerminator());
+  if (!Br)
     return;
 
   Value *Cond = Br->getCondition();

--- a/llvm/lib/Transforms/Scalar/DFAJumpThreading.cpp
+++ b/llvm/lib/Transforms/Scalar/DFAJumpThreading.cpp
@@ -207,18 +207,16 @@ void DFAJumpThreading::unfold(DomTreeUpdater *DTU, LoopInfo *LI,
   assert(SI->hasOneUse());
   // The select may come indirectly, instead of from where it is defined.
   BasicBlock *StartBlock = SIUse->getIncomingBlock(*SI->use_begin());
-  BranchInst *StartBlockTerm =
-      dyn_cast<BranchInst>(StartBlock->getTerminator());
-  assert(StartBlockTerm);
 
-  if (StartBlockTerm->isUnconditional()) {
+  if (UncondBrInst *StartBlockTerm =
+          dyn_cast<UncondBrInst>(StartBlock->getTerminator())) {
     BasicBlock *EndBlock = StartBlock->getUniqueSuccessor();
     // Arbitrarily choose the 'false' side for a new input value to the PHI.
     BasicBlock *NewBlock = BasicBlock::Create(
         SI->getContext(), Twine(SI->getName(), ".si.unfold.false"),
         EndBlock->getParent(), EndBlock);
     NewBBs->push_back(NewBlock);
-    BranchInst::Create(EndBlock, NewBlock);
+    UncondBrInst::Create(EndBlock, NewBlock);
     DTU->applyUpdates({{DominatorTree::Insert, NewBlock, EndBlock}});
 
     // StartBlock
@@ -268,7 +266,7 @@ void DFAJumpThreading::unfold(DomTreeUpdater *DTU, LoopInfo *LI,
     // Insert the real conditional branch based on the original condition.
     StartBlockTerm->eraseFromParent();
     auto *BI =
-        BranchInst::Create(EndBlock, NewBlock, SI->getCondition(), StartBlock);
+        CondBrInst::Create(SI->getCondition(), EndBlock, NewBlock, StartBlock);
     if (!ProfcheckDisableMetadataFixes)
       BI->setMetadata(LLVMContext::MD_prof,
                       SI->getMetadata(LLVMContext::MD_prof));
@@ -303,10 +301,10 @@ void DFAJumpThreading::unfold(DomTreeUpdater *DTU, LoopInfo *LI,
     //   |     /
     // EndBlock
     //  (Use)
-    BranchInst::Create(EndBlock, NewBlockF);
+    UncondBrInst::Create(EndBlock, NewBlockF);
     // Insert the real conditional branch based on the original condition.
     auto *BI =
-        BranchInst::Create(EndBlock, NewBlockF, SI->getCondition(), NewBlockT);
+        CondBrInst::Create(SI->getCondition(), EndBlock, NewBlockF, NewBlockT);
     if (!ProfcheckDisableMetadataFixes)
       BI->setMetadata(LLVMContext::MD_prof,
                       SI->getMetadata(LLVMContext::MD_prof));
@@ -346,8 +344,9 @@ void DFAJumpThreading::unfold(DomTreeUpdater *DTU, LoopInfo *LI,
 
     // Update the appropriate successor of the start block to point to the new
     // unfolded block.
-    unsigned SuccNum = StartBlockTerm->getSuccessor(1) == EndBlock ? 1 : 0;
-    StartBlockTerm->setSuccessor(SuccNum, NewBlockT);
+    CondBrInst *CondBr = cast<CondBrInst>(StartBlock->getTerminator());
+    unsigned SuccNum = CondBr->getSuccessor(1) == EndBlock ? 1 : 0;
+    CondBr->setSuccessor(SuccNum, NewBlockT);
     DTU->applyUpdates({{DominatorTree::Delete, StartBlock, EndBlock},
                        {DominatorTree::Insert, StartBlock, NewBlockT}});
   }
@@ -549,8 +548,8 @@ private:
 
     // Currently, we can only expand select instructions in basic blocks with
     // one successor.
-    BranchInst *SITerm = dyn_cast<BranchInst>(SIBB->getTerminator());
-    if (!SITerm || !SITerm->isUnconditional())
+    UncondBrInst *SITerm = dyn_cast<UncondBrInst>(SIBB->getTerminator());
+    if (!SITerm)
       return false;
 
     // Only fold the select coming from directly where it is defined.
@@ -1339,10 +1338,9 @@ private:
     for (auto Entry : VMap) {
       Instruction *Inst =
           dyn_cast<Instruction>(const_cast<Value *>(Entry.first));
-      if (!Inst || !Entry.second || isa<BranchInst>(Inst) ||
-          isa<SwitchInst>(Inst)) {
+      if (!Inst || !Entry.second ||
+          isa<UncondBrInst, CondBrInst, SwitchInst>(Inst))
         continue;
-      }
 
       Instruction *Cloned = dyn_cast<Instruction>(Entry.second);
       if (!Cloned)
@@ -1389,7 +1387,7 @@ private:
     }
 
     Switch->eraseFromParent();
-    BranchInst::Create(NextCase, LastBlock);
+    UncondBrInst::Create(NextCase, LastBlock);
 
     DTU->applyUpdates(DTUpdates);
   }

--- a/llvm/lib/Transforms/Scalar/DeadStoreElimination.cpp
+++ b/llvm/lib/Transforms/Scalar/DeadStoreElimination.cpp
@@ -2256,8 +2256,8 @@ bool DSEState::dominatingConditionImpliesValue(MemoryDef *Def) {
   if (!IDom)
     return false;
 
-  auto *BI = dyn_cast<BranchInst>(IDom->getBlock()->getTerminator());
-  if (!BI || !BI->isConditional())
+  auto *BI = dyn_cast<CondBrInst>(IDom->getBlock()->getTerminator());
+  if (!BI)
     return false;
 
   // In case both blocks are the same, it is not possible to determine

--- a/llvm/lib/Transforms/Scalar/EarlyCSE.cpp
+++ b/llvm/lib/Transforms/Scalar/EarlyCSE.cpp
@@ -937,7 +937,7 @@ private:
 
   bool processNode(DomTreeNode *Node);
 
-  bool handleBranchCondition(Instruction *CondInst, const BranchInst *BI,
+  bool handleBranchCondition(Instruction *CondInst, const CondBrInst *BI,
                              const BasicBlock *BB, const BasicBlock *Pred);
 
   Value *getMatchingValue(LoadValue &InVal, ParseMemoryInst &MemInst,
@@ -1166,9 +1166,8 @@ bool EarlyCSE::isOperatingOnInvariantMemAt(Instruction *I, unsigned GenAt) {
 }
 
 bool EarlyCSE::handleBranchCondition(Instruction *CondInst,
-                                     const BranchInst *BI, const BasicBlock *BB,
+                                     const CondBrInst *BI, const BasicBlock *BB,
                                      const BasicBlock *Pred) {
-  assert(BI->isConditional() && "Should be a conditional branch!");
   assert(BI->getCondition() == CondInst && "Wrong condition?");
   assert(BI->getSuccessor(0) == BB || BI->getSuccessor(1) == BB);
   auto *TorF = (BI->getSuccessor(0) == BB)
@@ -1358,8 +1357,7 @@ bool EarlyCSE::processNode(DomTreeNode *Node) {
   // value.  Since we're adding this to the scoped hash table (like any other
   // def), it will have been popped if we encounter a future merge block.
   if (BasicBlock *Pred = BB->getSinglePredecessor()) {
-    auto *BI = dyn_cast<BranchInst>(Pred->getTerminator());
-    if (BI && BI->isConditional()) {
+    if (auto *BI = dyn_cast<CondBrInst>(Pred->getTerminator())) {
       auto *CondInst = dyn_cast<Instruction>(BI->getCondition());
       if (CondInst && SimpleValue::canHandle(CondInst))
         Changed |= handleBranchCondition(CondInst, BI, BB, Pred);

--- a/llvm/lib/Transforms/Scalar/GVNSink.cpp
+++ b/llvm/lib/Transforms/Scalar/GVNSink.cpp
@@ -730,7 +730,7 @@ unsigned GVNSink::sinkBB(BasicBlock *BBEnd) {
     if (!RPOTOrder.count(B))
       return 0;
     auto *T = B->getTerminator();
-    if (isa<BranchInst>(T) || isa<SwitchInst>(T))
+    if (isa<UncondBrInst, CondBrInst, SwitchInst>(T))
       Preds.push_back(B);
     else
       return 0;

--- a/llvm/lib/Transforms/Scalar/GuardWidening.cpp
+++ b/llvm/lib/Transforms/Scalar/GuardWidening.cpp
@@ -87,7 +87,7 @@ static Value *getCondition(Instruction *I) {
   if (parseWidenableBranch(I, Cond, WC, IfTrueBB, IfFalseBB))
     return Cond;
 
-  return cast<BranchInst>(I)->getCondition();
+  return cast<CondBrInst>(I)->getCondition();
 }
 
 // Set the condition for \p I to \p NewCond. \p I can either be a guard or a
@@ -99,7 +99,7 @@ static void setCondition(Instruction *I, Value *NewCond) {
     GI->setArgOperand(0, NewCond);
     return;
   }
-  cast<BranchInst>(I)->setCondition(NewCond);
+  cast<CondBrInst>(I)->setCondition(NewCond);
 }
 
 // Eliminates the guard instruction properly.
@@ -364,7 +364,7 @@ bool GuardWideningImpl::run() {
       if (isSupportedGuardInstruction(I))
         eliminateGuard(I, MSSAU);
       else {
-        assert(isa<BranchInst>(I) &&
+        assert(isa<CondBrInst>(I) &&
                "Eliminated something other than guard or branch?");
         ++CondBranchEliminated;
       }

--- a/llvm/lib/Transforms/Scalar/IndVarSimplify.cpp
+++ b/llvm/lib/Transforms/Scalar/IndVarSimplify.cpp
@@ -305,11 +305,10 @@ maybeFloatingPointRecurrence(Loop *L, PHINode *PN) {
   // of the loop.  If not, the new IV can overflow and no one will notice.
   // The branch block must be in the loop and one of the successors must be out
   // of the loop.
-  auto *BI = dyn_cast<BranchInst>(Compare->user_back());
+  auto *BI = dyn_cast<CondBrInst>(Compare->user_back());
   if (!BI)
     return std::nullopt;
 
-  assert(BI->isConditional() && "Can't use fcmp if not conditional");
   if (!L->contains(BI->getParent()) ||
       (L->contains(BI->getSuccessor(0)) && L->contains(BI->getSuccessor(1))))
     return std::nullopt;
@@ -432,7 +431,7 @@ static void canonicalizeToIntegerIV(Loop *L, PHINode *PN,
 
   IntegerType *Int32Ty = Type::getInt32Ty(PN->getContext());
   auto *Incr = cast<BinaryOperator>(PN->getIncomingValue(BackEdge));
-  auto *BI = cast<BranchInst>(FPIV.Compare->user_back());
+  auto *BI = cast<CondBrInst>(FPIV.Compare->user_back());
 
   LLVM_DEBUG(dbgs() << "INDVARS: Rewriting floating-point IV to integer IV:\n"
                     << "   Init: " << IIV.InitValue << "\n"
@@ -572,7 +571,7 @@ bool IndVarSimplify::rewriteFirstIterationLoopExitValues(Loop *L) {
         auto *TermInst = IncomingBB->getTerminator();
 
         Value *Cond = nullptr;
-        if (auto *BI = dyn_cast<BranchInst>(TermInst)) {
+        if (auto *BI = dyn_cast<CondBrInst>(TermInst)) {
           // Must be a conditional branch, otherwise the block
           // should not be in the loop.
           Cond = BI->getCondition();
@@ -807,7 +806,7 @@ static PHINode *getLoopPhiForCounter(Value *IncV, Loop *L) {
 /// Whether the current loop exit test is based on this value.  Currently this
 /// is limited to a direct use in the loop condition.
 static bool isLoopExitTestBasedOn(Value *V, BasicBlock *ExitingBB) {
-  BranchInst *BI = cast<BranchInst>(ExitingBB->getTerminator());
+  CondBrInst *BI = cast<CondBrInst>(ExitingBB->getTerminator());
   ICmpInst *ICmp = dyn_cast<ICmpInst>(BI->getCondition());
   // TODO: Allow non-icmp loop test.
   if (!ICmp)
@@ -826,7 +825,7 @@ static bool needsLFTR(Loop *L, BasicBlock *ExitingBB) {
   // test.  This is critical for when SCEV's cached ExitCount is less precise
   // than the current IR (such as after we've proven a particular exit is
   // actually dead and thus the BE count never reaches our ExitCount.)
-  BranchInst *BI = cast<BranchInst>(ExitingBB->getTerminator());
+  CondBrInst *BI = cast<CondBrInst>(ExitingBB->getTerminator());
   if (L->isLoopInvariant(BI->getCondition()))
     return false;
 
@@ -941,7 +940,7 @@ static PHINode *FindLoopCounter(Loop *L, BasicBlock *ExitingBB,
                                 ScalarEvolution *SE, DominatorTree *DT) {
   uint64_t BCWidth = SE->getTypeSizeInBits(BECount->getType());
 
-  Value *Cond = cast<BranchInst>(ExitingBB->getTerminator())->getCondition();
+  Value *Cond = cast<CondBrInst>(ExitingBB->getTerminator())->getCondition();
 
   // Loop over all of the PHI nodes, looking for a simple counter.
   PHINode *BestPhi = nullptr;
@@ -1118,7 +1117,7 @@ linearFunctionTestReplace(Loop *L, BasicBlock *ExitingBB,
   }
 
   // Insert a new icmp_ne or icmp_eq instruction before the branch.
-  BranchInst *BI = cast<BranchInst>(ExitingBB->getTerminator());
+  CondBrInst *BI = cast<CondBrInst>(ExitingBB->getTerminator());
   ICmpInst::Predicate P;
   if (L->contains(BI->getSuccessor(0)))
     P = ICmpInst::ICMP_NE;
@@ -1276,7 +1275,7 @@ bool IndVarSimplify::sinkUnusedInvariants(Loop *L) {
   return MadeAnyChanges;
 }
 
-static void replaceExitCond(BranchInst *BI, Value *NewCond,
+static void replaceExitCond(CondBrInst *BI, Value *NewCond,
                             SmallVectorImpl<WeakTrackingVH> &DeadInsts) {
   auto *OldCond = BI->getCondition();
   LLVM_DEBUG(dbgs() << "Replacing condition of loop-exiting branch " << *BI
@@ -1288,7 +1287,7 @@ static void replaceExitCond(BranchInst *BI, Value *NewCond,
 
 static Constant *createFoldedExitCond(const Loop *L, BasicBlock *ExitingBB,
                                       bool IsTaken) {
-  BranchInst *BI = cast<BranchInst>(ExitingBB->getTerminator());
+  CondBrInst *BI = cast<CondBrInst>(ExitingBB->getTerminator());
   bool ExitIfTrue = !L->contains(*succ_begin(ExitingBB));
   auto *OldCond = BI->getCondition();
   return ConstantInt::get(OldCond->getType(),
@@ -1297,7 +1296,7 @@ static Constant *createFoldedExitCond(const Loop *L, BasicBlock *ExitingBB,
 
 static void foldExit(const Loop *L, BasicBlock *ExitingBB, bool IsTaken,
                      SmallVectorImpl<WeakTrackingVH> &DeadInsts) {
-  BranchInst *BI = cast<BranchInst>(ExitingBB->getTerminator());
+  CondBrInst *BI = cast<CondBrInst>(ExitingBB->getTerminator());
   auto *NewCond = createFoldedExitCond(L, ExitingBB, IsTaken);
   replaceExitCond(BI, NewCond, DeadInsts);
 }
@@ -1354,7 +1353,7 @@ createInvariantCond(const Loop *L, BasicBlock *ExitingBB,
   if (ExitIfTrue)
     InvariantPred = ICmpInst::getInversePredicate(InvariantPred);
   IRBuilder<> Builder(Preheader->getTerminator());
-  BranchInst *BI = cast<BranchInst>(ExitingBB->getTerminator());
+  CondBrInst *BI = cast<CondBrInst>(ExitingBB->getTerminator());
   return Builder.CreateICmp(InvariantPred, LHSV, RHSV,
                             BI->getCondition()->getName());
 }
@@ -1368,7 +1367,7 @@ createReplacement(ICmpInst *ICmp, const Loop *L, BasicBlock *ExitingBB,
   Value *RHS = ICmp->getOperand(1);
 
   // 'LHS pred RHS' should now mean that we stay in loop.
-  auto *BI = cast<BranchInst>(ExitingBB->getTerminator());
+  auto *BI = cast<CondBrInst>(ExitingBB->getTerminator());
   if (Inverted)
     Pred = ICmpInst::getInverseCmpPredicate(Pred);
 
@@ -1418,7 +1417,7 @@ createReplacement(ICmpInst *ICmp, const Loop *L, BasicBlock *ExitingBB,
 }
 
 static bool optimizeLoopExitWithUnknownExitCount(
-    const Loop *L, BranchInst *BI, BasicBlock *ExitingBB, const SCEV *MaxIter,
+    const Loop *L, CondBrInst *BI, BasicBlock *ExitingBB, const SCEV *MaxIter,
     bool SkipLastIter, ScalarEvolution *SE, SCEVExpander &Rewriter,
     SmallVectorImpl<WeakTrackingVH> &DeadInsts) {
   assert(
@@ -1535,10 +1534,9 @@ bool IndVarSimplify::canonicalizeExitCondition(Loop *L) {
   L->getExitingBlocks(ExitingBlocks);
   bool Changed = false;
   for (auto *ExitingBB : ExitingBlocks) {
-    auto *BI = dyn_cast<BranchInst>(ExitingBB->getTerminator());
+    auto *BI = dyn_cast<CondBrInst>(ExitingBB->getTerminator());
     if (!BI)
       continue;
-    assert(BI->isConditional() && "exit branch must be conditional");
 
     auto *ICmp = dyn_cast<ICmpInst>(BI->getCondition());
     if (!ICmp || !ICmp->hasOneUse())
@@ -1580,10 +1578,9 @@ bool IndVarSimplify::canonicalizeExitCondition(Loop *L) {
   // Now that we've canonicalized the condition to match the extend,
   // see if we can rotate the extend out of the loop.
   for (auto *ExitingBB : ExitingBlocks) {
-    auto *BI = dyn_cast<BranchInst>(ExitingBB->getTerminator());
+    auto *BI = dyn_cast<CondBrInst>(ExitingBB->getTerminator());
     if (!BI)
       continue;
-    assert(BI->isConditional() && "exit branch must be conditional");
 
     auto *ICmp = dyn_cast<ICmpInst>(BI->getCondition());
     if (!ICmp || !ICmp->hasOneUse() || !ICmp->isUnsigned())
@@ -1671,7 +1668,7 @@ bool IndVarSimplify::optimizeLoopExits(Loop *L, SCEVExpander &Rewriter) {
       return true;
 
     // Can't rewrite non-branch yet.
-    BranchInst *BI = dyn_cast<BranchInst>(ExitingBB->getTerminator());
+    CondBrInst *BI = dyn_cast<CondBrInst>(ExitingBB->getTerminator());
     if (!BI)
       return true;
 
@@ -1743,7 +1740,7 @@ bool IndVarSimplify::optimizeLoopExits(Loop *L, SCEVExpander &Rewriter) {
     if (isa<SCEVCouldNotCompute>(ExactExitCount)) {
       // Okay, we do not know the exit count here. Can we at least prove that it
       // will remain the same within iteration space?
-      auto *BI = cast<BranchInst>(ExitingBB->getTerminator());
+      auto *BI = cast<CondBrInst>(ExitingBB->getTerminator());
       auto OptimizeCond = [&](bool SkipLastIter) {
         return optimizeLoopExitWithUnknownExitCount(L, BI, ExitingBB,
                                                     MaxBECount, SkipLastIter,
@@ -1879,7 +1876,7 @@ bool IndVarSimplify::predicateLoopExits(Loop *L, SCEVExpander &Rewriter) {
       return true;
 
     // Can't rewrite non-branch yet.
-    BranchInst *BI = dyn_cast<BranchInst>(ExitingBB->getTerminator());
+    CondBrInst *BI = dyn_cast<CondBrInst>(ExitingBB->getTerminator());
     if (!BI)
       return true;
 
@@ -2006,7 +2003,7 @@ bool IndVarSimplify::predicateLoopExits(Loop *L, SCEVExpander &Rewriter) {
   for (BasicBlock *ExitingBB : ExitingBlocks) {
     const SCEV *ExitCount = SE->getExitCount(L, ExitingBB);
 
-    auto *BI = cast<BranchInst>(ExitingBB->getTerminator());
+    auto *BI = cast<CondBrInst>(ExitingBB->getTerminator());
     if (HasThreadLocalSideEffects) {
       const BasicBlock *Unreachable = nullptr;
       for (const BasicBlock *Succ : BI->successors()) {
@@ -2135,7 +2132,7 @@ bool IndVarSimplify::run(Loop *L) {
     L->getExitingBlocks(ExitingBlocks);
     for (BasicBlock *ExitingBB : ExitingBlocks) {
       // Can't rewrite non-branch yet.
-      if (!isa<BranchInst>(ExitingBB->getTerminator()))
+      if (!isa<CondBrInst>(ExitingBB->getTerminator()))
         continue;
 
       // If our exitting block exits multiple loops, we can only rewrite the

--- a/llvm/lib/Transforms/Scalar/JumpTableToSwitch.cpp
+++ b/llvm/lib/Transforms/Scalar/JumpTableToSwitch.cpp
@@ -181,7 +181,7 @@ expandToSwitch(CallBase *CB, const JumpTableTy &JT, DomTreeUpdater &DTU,
     // just some of the jump targets are taken (for the given profile).
     BranchWeights.push_back(FctID == 0U ? 0U
                                         : GuidToCounter.lookup_or(FctID, 0U));
-    BranchInst::Create(Tail, B);
+    UncondBrInst::Create(Tail, B);
     if (PHI)
       PHI->addIncoming(Call, B);
   }

--- a/llvm/lib/Transforms/Scalar/JumpThreading.cpp
+++ b/llvm/lib/Transforms/Scalar/JumpThreading.cpp
@@ -1019,7 +1019,8 @@ bool JumpThreadingPass::processBlock(BasicBlock *BB) {
 
     LLVM_DEBUG(dbgs() << "  In block '" << BB->getName()
                       << "' folding undef terminator: " << *BBTerm << '\n');
-    Instruction *NewBI = UncondBrInst::Create(BBTerm->getSuccessor(BestSucc), BBTerm->getIterator());
+    Instruction *NewBI = UncondBrInst::Create(BBTerm->getSuccessor(BestSucc),
+                                              BBTerm->getIterator());
     NewBI->setDebugLoc(BBTerm->getDebugLoc());
     ++NumFolds;
     BBTerm->eraseFromParent();
@@ -1182,7 +1183,8 @@ bool JumpThreadingPass::processImpliedCondition(BasicBlock *BB) {
       BasicBlock *KeepSucc = BI->getSuccessor(*Implication ? 0 : 1);
       BasicBlock *RemoveSucc = BI->getSuccessor(*Implication ? 1 : 0);
       RemoveSucc->removePredecessor(BB);
-      UncondBrInst *UncondBI = UncondBrInst::Create(KeepSucc, BI->getIterator());
+      UncondBrInst *UncondBI =
+          UncondBrInst::Create(KeepSucc, BI->getIterator());
       UncondBI->setDebugLoc(BI->getDebugLoc());
       ++NumFolds;
       BI->eraseFromParent();
@@ -2870,8 +2872,7 @@ bool JumpThreadingPass::tryToUnfoldSelect(CmpInst *CondCmp, BasicBlock *BB) {
   PHINode *CondLHS = dyn_cast<PHINode>(CondCmp->getOperand(0));
   Constant *CondRHS = cast<Constant>(CondCmp->getOperand(1));
 
-  if (!CondBr || !CondLHS ||
-      CondLHS->getParent() != BB)
+  if (!CondBr || !CondLHS || CondLHS->getParent() != BB)
     return false;
 
   for (unsigned I = 0, E = CondLHS->getNumIncomingValues(); I != E; ++I) {

--- a/llvm/lib/Transforms/Scalar/JumpThreading.cpp
+++ b/llvm/lib/Transforms/Scalar/JumpThreading.cpp
@@ -146,7 +146,7 @@ JumpThreadingPass::JumpThreadingPass(int T) {
 //  that P(t == true) is also unlikely.
 //
 static void updatePredecessorProfileMetadata(PHINode *PN, BasicBlock *BB) {
-  BranchInst *CondBr = dyn_cast<BranchInst>(BB->getTerminator());
+  CondBrInst *CondBr = dyn_cast<CondBrInst>(BB->getTerminator());
   if (!CondBr)
     return;
 
@@ -169,8 +169,7 @@ static void updatePredecessorProfileMetadata(PHINode *PN, BasicBlock *BB) {
     auto *SuccBB = PhiBB;
     SmallPtrSet<BasicBlock *, 16> Visited;
     while (true) {
-      BranchInst *PredBr = dyn_cast<BranchInst>(PredBB->getTerminator());
-      if (PredBr && PredBr->isConditional())
+      if (isa<CondBrInst>(PredBB->getTerminator()))
         return {PredBB, SuccBB};
       Visited.insert(PredBB);
       auto *SinglePredBB = PredBB->getSinglePredecessor();
@@ -205,7 +204,7 @@ static void updatePredecessorProfileMetadata(PHINode *PN, BasicBlock *BB) {
       return;
 
     BasicBlock *PredBB = PredOutEdge.first;
-    BranchInst *PredBr = dyn_cast<BranchInst>(PredBB->getTerminator());
+    CondBrInst *PredBr = dyn_cast<CondBrInst>(PredBB->getTerminator());
     if (!PredBr)
       return;
 
@@ -351,9 +350,8 @@ bool JumpThreadingPass::runImpl(Function &F_, FunctionAnalysisManager *FAM_,
 
       // processBlock doesn't thread BBs with unconditional TIs. However, if BB
       // is "almost empty", we attempt to merge BB with its sole successor.
-      auto *BI = dyn_cast<BranchInst>(BB.getTerminator());
-      if (BI && BI->isUnconditional()) {
-        BasicBlock *Succ = BI->getSuccessor(0);
+      if (auto *BI = dyn_cast<UncondBrInst>(BB.getTerminator())) {
+        BasicBlock *Succ = BI->getSuccessor();
         if (
             // The terminator must be the only non-phi instruction in BB.
             BB.getFirstNonPHIOrDbg(true)->isTerminator() &&
@@ -971,9 +969,7 @@ bool JumpThreadingPass::processBlock(BasicBlock *BB) {
   // branch, if not we can't thread it.
   Value *Condition;
   Instruction *Terminator = BB->getTerminator();
-  if (BranchInst *BI = dyn_cast<BranchInst>(Terminator)) {
-    // Can't thread an unconditional jump.
-    if (BI->isUnconditional()) return false;
+  if (CondBrInst *BI = dyn_cast<CondBrInst>(Terminator)) {
     Condition = BI->getCondition();
   } else if (SwitchInst *SI = dyn_cast<SwitchInst>(Terminator)) {
     Condition = SI->getCondition();
@@ -1023,7 +1019,7 @@ bool JumpThreadingPass::processBlock(BasicBlock *BB) {
 
     LLVM_DEBUG(dbgs() << "  In block '" << BB->getName()
                       << "' folding undef terminator: " << *BBTerm << '\n');
-    Instruction *NewBI = BranchInst::Create(BBTerm->getSuccessor(BestSucc), BBTerm->getIterator());
+    Instruction *NewBI = UncondBrInst::Create(BBTerm->getSuccessor(BestSucc), BBTerm->getIterator());
     NewBI->setDebugLoc(BBTerm->getDebugLoc());
     ++NumFolds;
     BBTerm->eraseFromParent();
@@ -1112,7 +1108,7 @@ bool JumpThreadingPass::processBlock(BasicBlock *BB) {
 
   // Before threading, try to propagate profile data backwards:
   if (PHINode *PN = dyn_cast<PHINode>(CondInst))
-    if (PN->getParent() == BB && isa<BranchInst>(BB->getTerminator()))
+    if (PN->getParent() == BB && isa<CondBrInst>(BB->getTerminator()))
       updatePredecessorProfileMetadata(PN, BB);
 
   // Handle a variety of cases where we are branching on something derived from
@@ -1124,12 +1120,12 @@ bool JumpThreadingPass::processBlock(BasicBlock *BB) {
   // If this is an otherwise-unfoldable branch on a phi node or freeze(phi) in
   // the current block, see if we can simplify.
   PHINode *PN = dyn_cast<PHINode>(CondWithoutFreeze);
-  if (PN && PN->getParent() == BB && isa<BranchInst>(BB->getTerminator()))
+  if (PN && PN->getParent() == BB && isa<CondBrInst>(BB->getTerminator()))
     return processBranchOnPHI(PN);
 
   // If this is an otherwise-unfoldable branch on a XOR, see if we can simplify.
   if (CondInst->getOpcode() == Instruction::Xor &&
-      CondInst->getParent() == BB && isa<BranchInst>(BB->getTerminator()))
+      CondInst->getParent() == BB && isa<CondBrInst>(BB->getTerminator()))
     return processBranchOnXOR(cast<BinaryOperator>(CondInst));
 
   // Search for a stronger dominating condition that can be used to simplify a
@@ -1141,8 +1137,8 @@ bool JumpThreadingPass::processBlock(BasicBlock *BB) {
 }
 
 bool JumpThreadingPass::processImpliedCondition(BasicBlock *BB) {
-  auto *BI = dyn_cast<BranchInst>(BB->getTerminator());
-  if (!BI || !BI->isConditional())
+  auto *BI = dyn_cast<CondBrInst>(BB->getTerminator());
+  if (!BI)
     return false;
 
   Value *Cond = BI->getCondition();
@@ -1164,8 +1160,8 @@ bool JumpThreadingPass::processImpliedCondition(BasicBlock *BB) {
   auto &DL = BB->getDataLayout();
 
   while (CurrentPred && Iter++ < ImplicationSearchThreshold) {
-    auto *PBI = dyn_cast<BranchInst>(CurrentPred->getTerminator());
-    if (!PBI || !PBI->isConditional())
+    auto *PBI = dyn_cast<CondBrInst>(CurrentPred->getTerminator());
+    if (!PBI)
       return false;
     if (PBI->getSuccessor(0) != CurrentBB && PBI->getSuccessor(1) != CurrentBB)
       return false;
@@ -1186,7 +1182,7 @@ bool JumpThreadingPass::processImpliedCondition(BasicBlock *BB) {
       BasicBlock *KeepSucc = BI->getSuccessor(*Implication ? 0 : 1);
       BasicBlock *RemoveSucc = BI->getSuccessor(*Implication ? 1 : 0);
       RemoveSucc->removePredecessor(BB);
-      BranchInst *UncondBI = BranchInst::Create(KeepSucc, BI->getIterator());
+      UncondBrInst *UncondBI = UncondBrInst::Create(KeepSucc, BI->getIterator());
       UncondBI->setDebugLoc(BI->getDebugLoc());
       ++NumFolds;
       BI->eraseFromParent();
@@ -1605,7 +1601,7 @@ bool JumpThreadingPass::processThreadableEdges(Value *Cond, BasicBlock *BB,
     BasicBlock *DestBB;
     if (isa<UndefValue>(Val))
       DestBB = nullptr;
-    else if (BranchInst *BI = dyn_cast<BranchInst>(BB->getTerminator())) {
+    else if (CondBrInst *BI = dyn_cast<CondBrInst>(BB->getTerminator())) {
       assert(isa<ConstantInt>(Val) && "Expecting a constant integer");
       DestBB = BI->getSuccessor(cast<ConstantInt>(Val)->isZero());
     } else if (SwitchInst *SI = dyn_cast<SwitchInst>(BB->getTerminator())) {
@@ -1662,7 +1658,7 @@ bool JumpThreadingPass::processThreadableEdges(Value *Cond, BasicBlock *BB,
 
       // Finally update the terminator.
       Instruction *Term = BB->getTerminator();
-      Instruction *NewBI = BranchInst::Create(OnlyDest, Term->getIterator());
+      Instruction *NewBI = UncondBrInst::Create(OnlyDest, Term->getIterator());
       NewBI->setDebugLoc(Term->getDebugLoc());
       ++NumFolds;
       Term->eraseFromParent();
@@ -1755,13 +1751,12 @@ bool JumpThreadingPass::processBranchOnPHI(PHINode *PN) {
   // to br(icmp(freeze ...)).
   for (unsigned i = 0, e = PN->getNumIncomingValues(); i != e; ++i) {
     BasicBlock *PredBB = PN->getIncomingBlock(i);
-    if (BranchInst *PredBr = dyn_cast<BranchInst>(PredBB->getTerminator()))
-      if (PredBr->isUnconditional()) {
-        PredBBs[0] = PredBB;
-        // Try to duplicate BB into PredBB.
-        if (duplicateCondBranchOnPHIIntoPred(BB, PredBBs))
-          return true;
-      }
+    if (isa<UncondBrInst>(PredBB->getTerminator())) {
+      PredBBs[0] = PredBB;
+      // Try to duplicate BB into PredBB.
+      if (duplicateCondBranchOnPHIIntoPred(BB, PredBBs))
+        return true;
+    }
   }
 
   return false;
@@ -2142,7 +2137,7 @@ bool JumpThreadingPass::maybethreadThroughTwoBasicBlocks(BasicBlock *BB,
   // PredBB.  Then we can thread edges PredBB1->BB and PredBB2->BB through BB.
 
   // Require that BB end with a Branch for simplicity.
-  BranchInst *CondBr = dyn_cast<BranchInst>(BB->getTerminator());
+  CondBrInst *CondBr = dyn_cast<CondBrInst>(BB->getTerminator());
   if (!CondBr)
     return false;
 
@@ -2154,8 +2149,8 @@ bool JumpThreadingPass::maybethreadThroughTwoBasicBlocks(BasicBlock *BB,
   // Require that PredBB end with a conditional Branch. If PredBB ends with an
   // unconditional branch, we should be merging PredBB and BB instead. For
   // simplicity, we don't deal with a switch.
-  BranchInst *PredBBBranch = dyn_cast<BranchInst>(PredBB->getTerminator());
-  if (!PredBBBranch || PredBBBranch->isUnconditional())
+  CondBrInst *PredBBBranch = dyn_cast<CondBrInst>(PredBB->getTerminator());
+  if (!PredBBBranch)
     return false;
 
   // If PredBB has exactly one incoming edge, we don't gain anything by copying
@@ -2276,8 +2271,8 @@ void JumpThreadingPass::threadThroughTwoBasicBlocks(BasicBlock *PredPredBB,
   auto *BFI = getOrCreateBFI(HasProfile);
   auto *BPI = getOrCreateBPI(BFI != nullptr);
 
-  BranchInst *CondBr = cast<BranchInst>(BB->getTerminator());
-  BranchInst *PredBBBranch = cast<BranchInst>(PredBB->getTerminator());
+  CondBrInst *CondBr = cast<CondBrInst>(BB->getTerminator());
+  CondBrInst *PredBBBranch = cast<CondBrInst>(PredBB->getTerminator());
 
   BasicBlock *NewBB =
       BasicBlock::Create(PredBB->getContext(), PredBB->getName() + ".thread",
@@ -2429,7 +2424,7 @@ void JumpThreadingPass::threadEdge(BasicBlock *BB,
 
   // We didn't copy the terminator from BB over to NewBB, because there is now
   // an unconditional jump to SuccBB.  Insert the unconditional jump.
-  BranchInst *NewBI = BranchInst::Create(SuccBB, NewBB);
+  UncondBrInst *NewBI = UncondBrInst::Create(SuccBB, NewBB);
   NewBI->setDebugLoc(BB->getTerminator()->getDebugLoc());
 
   // Check to see if SuccBB has PHI nodes. If so, we need to add entries to the
@@ -2667,15 +2662,15 @@ bool JumpThreadingPass::duplicateCondBranchOnPHIIntoPred(
 
   // Unless PredBB ends with an unconditional branch, split the edge so that we
   // can just clone the bits from BB into the end of the new PredBB.
-  BranchInst *OldPredBranch = dyn_cast<BranchInst>(PredBB->getTerminator());
+  UncondBrInst *OldPredBranch = dyn_cast<UncondBrInst>(PredBB->getTerminator());
 
-  if (!OldPredBranch || !OldPredBranch->isUnconditional()) {
+  if (!OldPredBranch) {
     BasicBlock *OldPredBB = PredBB;
     PredBB = SplitEdge(OldPredBB, BB);
     Updates.push_back({DominatorTree::Insert, OldPredBB, PredBB});
     Updates.push_back({DominatorTree::Insert, PredBB, BB});
     Updates.push_back({DominatorTree::Delete, OldPredBB, BB});
-    OldPredBranch = cast<BranchInst>(PredBB->getTerminator());
+    OldPredBranch = cast<UncondBrInst>(PredBB->getTerminator());
   }
 
   // We are going to have to map operands from the original BB block into the
@@ -2738,7 +2733,7 @@ bool JumpThreadingPass::duplicateCondBranchOnPHIIntoPred(
 
   // Check to see if the targets of the branch had PHI nodes. If so, we need to
   // add entries to the PHI nodes for branch from PredBB now.
-  BranchInst *BBBranch = cast<BranchInst>(BB->getTerminator());
+  CondBrInst *BBBranch = cast<CondBrInst>(BB->getTerminator());
   addPHINodeEntriesForMappedBlock(BBBranch->getSuccessor(0), BB, PredBB,
                                   ValueMapping);
   addPHINodeEntriesForMappedBlock(BBBranch->getSuccessor(1), BB, PredBB,
@@ -2781,14 +2776,14 @@ void JumpThreadingPass::unfoldSelectInstr(BasicBlock *Pred, BasicBlock *BB,
   //  |-----
   //  v
   // BB
-  BranchInst *PredTerm = cast<BranchInst>(Pred->getTerminator());
+  UncondBrInst *PredTerm = cast<UncondBrInst>(Pred->getTerminator());
   BasicBlock *NewBB = BasicBlock::Create(BB->getContext(), "select.unfold",
                                          BB->getParent(), BB);
   // Move the unconditional branch to NewBB.
   PredTerm->removeFromParent();
   PredTerm->insertInto(NewBB, NewBB->end());
   // Create a conditional branch and update PHI nodes.
-  auto *BI = BranchInst::Create(NewBB, BB, SI->getCondition(), Pred);
+  auto *BI = CondBrInst::Create(SI->getCondition(), NewBB, BB, Pred);
   BI->applyMergedLocation(PredTerm->getDebugLoc(), SI->getDebugLoc());
   BI->copyMetadata(*SI, {LLVMContext::MD_prof});
   SIUse->setIncomingValue(Idx, SI->getFalseValue());
@@ -2848,8 +2843,8 @@ bool JumpThreadingPass::tryToUnfoldSelect(SwitchInst *SI, BasicBlock *BB) {
     if (!PredSI || PredSI->getParent() != Pred || !PredSI->hasOneUse())
       continue;
 
-    BranchInst *PredTerm = dyn_cast<BranchInst>(Pred->getTerminator());
-    if (!PredTerm || !PredTerm->isUnconditional())
+    UncondBrInst *PredTerm = dyn_cast<UncondBrInst>(Pred->getTerminator());
+    if (!PredTerm)
       continue;
 
     unfoldSelectInstr(Pred, BB, PredSI, CondPHI, I);
@@ -2871,11 +2866,11 @@ bool JumpThreadingPass::tryToUnfoldSelect(SwitchInst *SI, BasicBlock *BB) {
 /// And expand the select into a branch structure if one of its arms allows %c
 /// to be folded. This later enables threading from bb1 over bb2.
 bool JumpThreadingPass::tryToUnfoldSelect(CmpInst *CondCmp, BasicBlock *BB) {
-  BranchInst *CondBr = dyn_cast<BranchInst>(BB->getTerminator());
+  CondBrInst *CondBr = dyn_cast<CondBrInst>(BB->getTerminator());
   PHINode *CondLHS = dyn_cast<PHINode>(CondCmp->getOperand(0));
   Constant *CondRHS = cast<Constant>(CondCmp->getOperand(1));
 
-  if (!CondBr || !CondBr->isConditional() || !CondLHS ||
+  if (!CondBr || !CondLHS ||
       CondLHS->getParent() != BB)
     return false;
 
@@ -2888,8 +2883,8 @@ bool JumpThreadingPass::tryToUnfoldSelect(CmpInst *CondCmp, BasicBlock *BB) {
     if (!SI || SI->getParent() != Pred || !SI->hasOneUse())
       continue;
 
-    BranchInst *PredTerm = dyn_cast<BranchInst>(Pred->getTerminator());
-    if (!PredTerm || !PredTerm->isUnconditional())
+    UncondBrInst *PredTerm = dyn_cast<UncondBrInst>(Pred->getTerminator());
+    if (!PredTerm)
       continue;
 
     // Now check if one of the select values would allow us to constant fold the

--- a/llvm/lib/Transforms/Scalar/LICM.cpp
+++ b/llvm/lib/Transforms/Scalar/LICM.cpp
@@ -665,17 +665,16 @@ private:
 
   // The branches that we can hoist, mapped to the block that marks a
   // convergence point of their control flow.
-  DenseMap<BranchInst *, BasicBlock *> HoistableBranches;
+  DenseMap<CondBrInst *, BasicBlock *> HoistableBranches;
 
 public:
   ControlFlowHoister(LoopInfo *LI, DominatorTree *DT, Loop *CurLoop,
                      MemorySSAUpdater &MSSAU)
       : LI(LI), DT(DT), CurLoop(CurLoop), MSSAU(MSSAU) {}
 
-  void registerPossiblyHoistableBranch(BranchInst *BI) {
+  void registerPossiblyHoistableBranch(CondBrInst *BI) {
     // We can only hoist conditional branches with loop invariant operands.
-    if (!ControlFlowHoisting || !BI->isConditional() ||
-        !CurLoop->hasLoopInvariantOperands(BI))
+    if (!ControlFlowHoisting || !CurLoop->hasLoopInvariantOperands(BI))
       return;
 
     // The branch destinations need to be in the loop, and we don't gain
@@ -775,7 +774,7 @@ public:
 
     // Check if this block is conditional based on a pending branch
     auto HasBBAsSuccessor =
-        [&](DenseMap<BranchInst *, BasicBlock *>::value_type &Pair) {
+        [&](DenseMap<CondBrInst *, BasicBlock *>::value_type &Pair) {
           return BB != Pair.second && (Pair.first->getSuccessor(0) == BB ||
                                        Pair.first->getSuccessor(1) == BB);
         };
@@ -791,7 +790,7 @@ public:
       HoistDestinationMap[BB] = InitialPreheader;
       return InitialPreheader;
     }
-    BranchInst *BI = It->first;
+    CondBrInst *BI = It->first;
     assert(std::none_of(std::next(It), HoistableBranches.end(),
                         HasBBAsSuccessor) &&
            "BB is expected to be the target of at most one branch");
@@ -830,15 +829,15 @@ public:
       BasicBlock *TargetSucc = HoistTarget->getSingleSuccessor();
       assert(TargetSucc && "Expected hoist target to have a single successor");
       HoistCommonSucc->moveBefore(TargetSucc);
-      BranchInst::Create(TargetSucc, HoistCommonSucc);
+      UncondBrInst::Create(TargetSucc, HoistCommonSucc);
     }
     if (!HoistTrueDest->getTerminator()) {
       HoistTrueDest->moveBefore(HoistCommonSucc);
-      BranchInst::Create(HoistCommonSucc, HoistTrueDest);
+      UncondBrInst::Create(HoistCommonSucc, HoistTrueDest);
     }
     if (!HoistFalseDest->getTerminator()) {
       HoistFalseDest->moveBefore(HoistCommonSucc);
-      BranchInst::Create(HoistCommonSucc, HoistFalseDest);
+      UncondBrInst::Create(HoistCommonSucc, HoistFalseDest);
     }
 
     // If BI is being cloned to what was originally the preheader then
@@ -861,7 +860,7 @@ public:
 
     // Now finally clone BI.
     auto *NewBI =
-        BranchInst::Create(HoistTrueDest, HoistFalseDest, BI->getCondition(),
+        CondBrInst::Create(BI->getCondition(), HoistTrueDest, HoistFalseDest,
                            HoistTarget->getTerminator()->getIterator());
     HoistTarget->getTerminator()->eraseFromParent();
     // md_prof should also come from the original branch - since the
@@ -1008,7 +1007,7 @@ bool llvm::hoistRegion(DomTreeNode *N, AAResults *AA, LoopInfo *LI,
 
       // Remember possibly hoistable branches so we can actually hoist them
       // later if needed.
-      if (BranchInst *BI = dyn_cast<BranchInst>(&I))
+      if (CondBrInst *BI = dyn_cast<CondBrInst>(&I))
         CFH.registerPossiblyHoistableBranch(BI);
     }
   }

--- a/llvm/lib/Transforms/Scalar/LoopBoundSplit.cpp
+++ b/llvm/lib/Transforms/Scalar/LoopBoundSplit.cpp
@@ -27,7 +27,7 @@ using namespace PatternMatch;
 namespace {
 struct ConditionInfo {
   /// Branch instruction with this condition
-  BranchInst *BI = nullptr;
+  CondBrInst *BI = nullptr;
   /// ICmp instruction with this condition
   ICmpInst *ICmp = nullptr;
   /// Preciate info
@@ -156,7 +156,7 @@ static bool hasProcessableCondition(const Loop &L, ScalarEvolution &SE,
 }
 
 static bool isProcessableCondBI(const ScalarEvolution &SE,
-                                const BranchInst *BI) {
+                                const CondBrInst *BI) {
   BasicBlock *TrueSucc = nullptr;
   BasicBlock *FalseSucc = nullptr;
   Value *LHS, *RHS;
@@ -201,7 +201,7 @@ static bool canSplitLoopBound(const Loop &L, const DominatorTree &DT,
   if (!ExitingBB)
     return false;
 
-  BranchInst *ExitingBI = dyn_cast<BranchInst>(ExitingBB->getTerminator());
+  CondBrInst *ExitingBI = dyn_cast<CondBrInst>(ExitingBB->getTerminator());
   if (!ExitingBI)
     return false;
 
@@ -218,7 +218,7 @@ static bool canSplitLoopBound(const Loop &L, const DominatorTree &DT,
   return true;
 }
 
-static bool isProfitableToTransform(const Loop &L, const BranchInst *BI) {
+static bool isProfitableToTransform(const Loop &L, const CondBrInst *BI) {
   // If the conditional branch splits a loop into two halves, we could
   // generally say it is profitable.
   //
@@ -238,7 +238,7 @@ static bool isProfitableToTransform(const Loop &L, const BranchInst *BI) {
   return true;
 }
 
-static BranchInst *findSplitCandidate(const Loop &L, ScalarEvolution &SE,
+static CondBrInst *findSplitCandidate(const Loop &L, ScalarEvolution &SE,
                                       ConditionInfo &ExitingCond,
                                       ConditionInfo &SplitCandidateCond) {
   for (auto *BB : L.blocks()) {
@@ -246,7 +246,7 @@ static BranchInst *findSplitCandidate(const Loop &L, ScalarEvolution &SE,
     if (L.getLoopLatch() == BB)
       continue;
 
-    auto *BI = dyn_cast<BranchInst>(BB->getTerminator());
+    auto *BI = dyn_cast<CondBrInst>(BB->getTerminator());
     if (!BI)
       continue;
 
@@ -415,8 +415,8 @@ static bool splitLoopBound(Loop &L, DominatorTree &DT, LoopInfo &LI,
   SplitCandidateCond.BI->setCondition(ConstantInt::getTrue(Context));
 
   // Replace cloned SplitCandidateCond.BI's condition in post-loop by False.
-  BranchInst *ClonedSplitCandidateBI =
-      cast<BranchInst>(VMap[SplitCandidateCond.BI]);
+  CondBrInst *ClonedSplitCandidateBI =
+      cast<CondBrInst>(VMap[SplitCandidateCond.BI]);
   ClonedSplitCandidateBI->setCondition(ConstantInt::getFalse(Context));
 
   // Replace exit branch target of pre-loop by post-loop's preheader.

--- a/llvm/lib/Transforms/Scalar/LoopDistribute.cpp
+++ b/llvm/lib/Transforms/Scalar/LoopDistribute.cpp
@@ -218,7 +218,7 @@ public:
           if (!VMap.empty())
             NewInst = cast<Instruction>(VMap[NewInst]);
 
-          assert(!isa<BranchInst>(NewInst) &&
+          assert((!isa<UncondBrInst, CondBrInst>(NewInst)) &&
                  "Branches are marked used early on");
           Unused.push_back(NewInst);
         }

--- a/llvm/lib/Transforms/Scalar/LoopFlatten.cpp
+++ b/llvm/lib/Transforms/Scalar/LoopFlatten.cpp
@@ -132,9 +132,9 @@ struct FlattenInfo {
 
   BinaryOperator *InnerIncrement = nullptr;  // Uses of induction variables in
   BinaryOperator *OuterIncrement = nullptr;  // loop control statements that
-  BranchInst *InnerBranch = nullptr;         // are safe to ignore.
+  CondBrInst *InnerBranch = nullptr;         // are safe to ignore.
 
-  BranchInst *OuterBranch = nullptr; // The instruction that needs to be
+  CondBrInst *OuterBranch = nullptr; // The instruction that needs to be
                                      // updated with new tripcount.
 
   SmallPtrSet<PHINode *, 4> InnerPHIsToTransform;
@@ -319,10 +319,10 @@ setLoopComponents(Value *&TC, Value *&TripCount, BinaryOperator *&Increment,
 // complicated now. It is therefore worth revisiting what the additional
 // benefits are of this (compared to relying on canonical loops and pattern
 // matching).
-static bool verifyTripCount(Value *RHS, Loop *L,
-     SmallPtrSetImpl<Instruction *> &IterationInstructions,
+static bool verifyTripCount(
+    Value *RHS, Loop *L, SmallPtrSetImpl<Instruction *> &IterationInstructions,
     PHINode *&InductionPHI, Value *&TripCount, BinaryOperator *&Increment,
-    BranchInst *&BackBranch, ScalarEvolution *SE, bool IsWidened) {
+    CondBrInst *&BackBranch, ScalarEvolution *SE, bool IsWidened) {
   const SCEV *BackedgeTakenCount = SE->getBackedgeTakenCount(L);
   if (isa<SCEVCouldNotCompute>(BackedgeTakenCount)) {
     LLVM_DEBUG(dbgs() << "Backedge-taken count is not predictable\n");
@@ -389,7 +389,7 @@ static bool verifyTripCount(Value *RHS, Loop *L,
 static bool findLoopComponents(
     Loop *L, SmallPtrSetImpl<Instruction *> &IterationInstructions,
     PHINode *&InductionPHI, Value *&TripCount, BinaryOperator *&Increment,
-    BranchInst *&BackBranch, ScalarEvolution *SE, bool IsWidened) {
+    CondBrInst *&BackBranch, ScalarEvolution *SE, bool IsWidened) {
   LLVM_DEBUG(dbgs() << "Finding components of loop: " << L->getName() << "\n");
 
   if (!L->isLoopSimplifyForm()) {
@@ -438,7 +438,7 @@ static bool findLoopComponents(
     LLVM_DEBUG(dbgs() << "Could not find valid comparison\n");
     return false;
   }
-  BackBranch = cast<BranchInst>(Latch->getTerminator());
+  BackBranch = cast<CondBrInst>(Latch->getTerminator());
   IterationInstructions.insert(BackBranch);
   LLVM_DEBUG(dbgs() << "Found back branch: "; BackBranch->dump());
   IterationInstructions.insert(Compare);
@@ -580,9 +580,8 @@ checkOuterLoopInsts(FlattenInfo &FI,
         continue;
       // The unconditional branch to the inner loop's header will turn into
       // a fall-through, so adds no cost.
-      BranchInst *Br = dyn_cast<BranchInst>(&I);
-      if (Br && Br->isUnconditional() &&
-          Br->getSuccessor(0) == FI.InnerLoop->getHeader())
+      UncondBrInst *Br = dyn_cast<UncondBrInst>(&I);
+      if (Br && Br->getSuccessor() == FI.InnerLoop->getHeader())
         continue;
       // Multiplies of the outer iteration variable and inner iteration
       // count will be optimised out.
@@ -785,7 +784,7 @@ static bool DoFlattenLoopPair(FlattenInfo &FI, DominatorTree *DT, LoopInfo *LI,
   BasicBlock *InnerExitBlock = FI.InnerLoop->getExitBlock();
   BasicBlock *InnerExitingBlock = FI.InnerLoop->getExitingBlock();
   Instruction *Term = InnerExitingBlock->getTerminator();
-  Instruction *BI = BranchInst::Create(InnerExitBlock, InnerExitingBlock);
+  Instruction *BI = UncondBrInst::Create(InnerExitBlock, InnerExitingBlock);
   BI->setDebugLoc(Term->getDebugLoc());
   Term->eraseFromParent();
 
@@ -973,9 +972,7 @@ static bool FlattenLoopPair(FlattenInfo &FI, DominatorTree *DT, LoopInfo *LI,
 
     // Check for overflow by calculating the new tripcount using
     // umul_with_overflow and then checking if it overflowed.
-    BranchInst *Br = cast<BranchInst>(CheckBlock->getTerminator());
-    assert(Br->isConditional() &&
-           "Expected LoopVersioning to generate a conditional branch");
+    CondBrInst *Br = cast<CondBrInst>(CheckBlock->getTerminator());
     assert(match(Br->getCondition(), m_Zero()) &&
            "Expected branch condition to be false");
     IRBuilder<> Builder(Br);

--- a/llvm/lib/Transforms/Scalar/LoopFuse.cpp
+++ b/llvm/lib/Transforms/Scalar/LoopFuse.cpp
@@ -166,7 +166,7 @@ struct FusionCandidate {
   /// Are all of the members of this fusion candidate still valid
   bool Valid;
   /// Guard branch of the loop, if it exists
-  BranchInst *GuardBranch;
+  CondBrInst *GuardBranch;
   /// Peeling Paramaters of the Loop.
   TTI::PeelingPreferences PP;
   /// Can you Peel this Loop?
@@ -275,8 +275,6 @@ struct FusionCandidate {
   /// This method is only valid for guarded loops.
   BasicBlock *getNonLoopBlock() const {
     assert(GuardBranch && "Only valid on guarded loops.");
-    assert(GuardBranch->isConditional() &&
-           "Expecting guard to be a conditional branch.");
     if (Peeled)
       return GuardBranch->getSuccessor(1);
     return (GuardBranch->getSuccessor(0) == Preheader)
@@ -742,7 +740,7 @@ private:
         BasicBlock *Succ = CurrentBranch->getSuccessor(0);
         if (Succ == BB)
           Succ = CurrentBranch->getSuccessor(1);
-        ReplaceInstWithInst(CurrentBranch, BranchInst::Create(Succ));
+        ReplaceInstWithInst(CurrentBranch, UncondBrInst::Create(Succ));
       }
 
       DTU.applyUpdates(TreeUpdates);
@@ -1473,13 +1471,12 @@ private:
   /// Modify the latch branch of FC to be unconditional since successors of the
   /// branch are the same.
   void simplifyLatchBranch(const FusionCandidate &FC) const {
-    BranchInst *FCLatchBranch = dyn_cast<BranchInst>(FC.Latch->getTerminator());
+    CondBrInst *FCLatchBranch = dyn_cast<CondBrInst>(FC.Latch->getTerminator());
     if (FCLatchBranch) {
-      assert(FCLatchBranch->isConditional() &&
-             FCLatchBranch->getSuccessor(0) == FCLatchBranch->getSuccessor(1) &&
+      assert(FCLatchBranch->getSuccessor(0) == FCLatchBranch->getSuccessor(1) &&
              "Expecting the two successors of FCLatchBranch to be the same");
-      BranchInst *NewBranch =
-          BranchInst::Create(FCLatchBranch->getSuccessor(0));
+      UncondBrInst *NewBranch =
+          UncondBrInst::Create(FCLatchBranch->getSuccessor(0));
       ReplaceInstWithInst(FCLatchBranch, NewBranch);
     }
   }

--- a/llvm/lib/Transforms/Scalar/LoopIdiomRecognize.cpp
+++ b/llvm/lib/Transforms/Scalar/LoopIdiomRecognize.cpp
@@ -1581,7 +1581,7 @@ bool LoopIdiomRecognize::optimizeCRCLoop(const PolynomialInfo &Info) {
   {
     unsigned NewBTC = (Info.TripCount / 8) - 1;
     BasicBlock *LoopBlk = CurLoop->getLoopLatch();
-    BranchInst *BrInst = cast<BranchInst>(LoopBlk->getTerminator());
+    CondBrInst *BrInst = cast<CondBrInst>(LoopBlk->getTerminator());
     CmpPredicate ExitPred = BrInst->getSuccessor(0) == LoopBlk
                                 ? ICmpInst::Predicate::ICMP_NE
                                 : ICmpInst::Predicate::ICMP_EQ;
@@ -1707,9 +1707,9 @@ bool LoopIdiomRecognize::runOnNoncountableLoop() {
 /// behavior, the variable involved in the comparison is returned. This function
 /// will be called to see if the precondition and postcondition of the loop are
 /// in desirable form.
-static Value *matchCondition(BranchInst *BI, BasicBlock *LoopEntry,
+static Value *matchCondition(CondBrInst *BI, BasicBlock *LoopEntry,
                              bool JmpOnZero = false) {
-  if (!BI || !BI->isConditional())
+  if (!BI)
     return nullptr;
 
   ICmpInst *Cond = dyn_cast<ICmpInst>(BI->getCondition());
@@ -1750,11 +1750,7 @@ public:
 
     // It should have a preheader and a branch instruction.
     BasicBlock *Preheader = CurLoop->getLoopPreheader();
-    if (!Preheader)
-      return false;
-
-    BranchInst *EntryBI = dyn_cast<BranchInst>(Preheader->getTerminator());
-    if (!EntryBI)
+    if (!Preheader || !isa<UncondBrInst, CondBrInst>(Preheader->getTerminator()))
       return false;
 
     // The loop exit must be conditioned on an icmp with 0 the null terminator.
@@ -1766,7 +1762,7 @@ public:
     if (!LoopBody || LoopBody->size() >= 15)
       return false;
 
-    BranchInst *LoopTerm = dyn_cast<BranchInst>(LoopBody->getTerminator());
+    CondBrInst *LoopTerm = dyn_cast<CondBrInst>(LoopBody->getTerminator());
     Value *LoopCond = matchCondition(LoopTerm, LoopBody);
     if (!LoopCond)
       return false;
@@ -1923,8 +1919,8 @@ bool LoopIdiomRecognize::recognizeAndInsertStrLen() {
   BasicBlock *Preheader = CurLoop->getLoopPreheader();
   BasicBlock *LoopBody = *CurLoop->block_begin();
   BasicBlock *LoopExitBB = CurLoop->getExitBlock();
-  BranchInst *LoopTerm = dyn_cast<BranchInst>(LoopBody->getTerminator());
-  assert(Preheader && LoopBody && LoopExitBB && LoopTerm &&
+  CondBrInst *LoopTerm = cast<CondBrInst>(LoopBody->getTerminator());
+  assert(Preheader && LoopBody && LoopExitBB &&
          "Should be verified to be valid by StrlenVerifier");
 
   if (Verifier.OpWidth == 8) {
@@ -1987,8 +1983,7 @@ bool LoopIdiomRecognize::recognizeAndInsertStrLen() {
 
   // LoopDeletion only delete invariant loops with known trip-count. We can
   // update the condition so it will reliablely delete the invariant loop
-  assert(LoopTerm->getNumSuccessors() == 2 &&
-         (LoopTerm->getSuccessor(0) == LoopBody ||
+  assert((LoopTerm->getSuccessor(0) == LoopBody ||
           LoopTerm->getSuccessor(1) == LoopBody) &&
          "loop body must have a successor that is it self");
   ConstantInt *NewLoopCond = LoopTerm->getSuccessor(0) == LoopBody
@@ -2012,11 +2007,8 @@ bool LoopIdiomRecognize::recognizeAndInsertStrLen() {
 /// comparison between a variable and a constant, and if the comparison is false
 /// the control yields to the loop entry. If the branch matches the behaviour,
 /// the variable involved in the comparison is returned.
-static Value *matchShiftULTCondition(BranchInst *BI, BasicBlock *LoopEntry,
+static Value *matchShiftULTCondition(CondBrInst *BI, BasicBlock *LoopEntry,
                                      APInt &Threshold) {
-  if (!BI || !BI->isConditional())
-    return nullptr;
-
   ICmpInst *Cond = dyn_cast<ICmpInst>(BI->getCondition());
   if (!Cond)
     return nullptr;
@@ -2087,9 +2079,10 @@ static bool detectShiftUntilLessThanIdiom(Loop *CurLoop, const DataLayout &DL,
   LoopEntry = *(CurLoop->block_begin());
 
   // step 1: Check if the loop-back branch is in desirable form.
-  if (Value *T = matchShiftULTCondition(
-          dyn_cast<BranchInst>(LoopEntry->getTerminator()), LoopEntry,
-          Threshold))
+  auto *EntryBI = dyn_cast<CondBrInst>(LoopEntry->getTerminator());
+  if (!EntryBI)
+    return false;
+  if (Value *T = matchShiftULTCondition(EntryBI, LoopEntry, Threshold))
     DefX = dyn_cast<Instruction>(T);
   else
     return false;
@@ -2190,7 +2183,7 @@ static bool detectPopcountIdiom(Loop *CurLoop, BasicBlock *PreCondBB,
   // step 1: Check if the loop-back branch is in desirable form.
   {
     if (Value *T = matchCondition(
-            dyn_cast<BranchInst>(LoopEntry->getTerminator()), LoopEntry))
+            dyn_cast<CondBrInst>(LoopEntry->getTerminator()), LoopEntry))
       DefX2 = dyn_cast<Instruction>(T);
     else
       return false;
@@ -2265,7 +2258,7 @@ static bool detectPopcountIdiom(Loop *CurLoop, BasicBlock *PreCondBB,
   // step 5: check if the precondition is in this form:
   //   "if (x != 0) goto loop-head ; else goto somewhere-we-don't-care;"
   {
-    auto *PreCondBr = dyn_cast<BranchInst>(PreCondBB->getTerminator());
+    auto *PreCondBr = dyn_cast<CondBrInst>(PreCondBB->getTerminator());
     Value *T = matchCondition(PreCondBr, CurLoop->getLoopPreheader());
     if (T != PhiX->getOperand(0) && T != PhiX->getOperand(1))
       return false;
@@ -2319,7 +2312,7 @@ static bool detectShiftUntilZeroIdiom(Loop *CurLoop, const DataLayout &DL,
 
   // step 1: Check if the loop-back branch is in desirable form.
   if (Value *T = matchCondition(
-          dyn_cast<BranchInst>(LoopEntry->getTerminator()), LoopEntry))
+          dyn_cast<CondBrInst>(LoopEntry->getTerminator()), LoopEntry))
     DefX = dyn_cast<Instruction>(T);
   else
     return false;
@@ -2438,9 +2431,7 @@ bool LoopIdiomRecognize::insertFFSIfProfitable(Intrinsic::ID IntrinID,
     auto *PreCondBB = PH->getSinglePredecessor();
     if (!PreCondBB)
       return false;
-    auto *PreCondBI = dyn_cast<BranchInst>(PreCondBB->getTerminator());
-    if (!PreCondBI)
-      return false;
+    auto *PreCondBI = dyn_cast<CondBrInst>(PreCondBB->getTerminator());
     if (matchCondition(PreCondBI, PH) != InitX)
       return false;
     ZeroCheck = true;
@@ -2520,7 +2511,7 @@ bool LoopIdiomRecognize::recognizeShiftUntilLessThan() {
   auto *PreCondBB = PH->getSinglePredecessor();
   if (!PreCondBB)
     return false;
-  auto *PreCondBI = dyn_cast<BranchInst>(PreCondBB->getTerminator());
+  auto *PreCondBI = dyn_cast<CondBrInst>(PreCondBB->getTerminator());
   if (!PreCondBI)
     return false;
 
@@ -2577,8 +2568,8 @@ bool LoopIdiomRecognize::recognizePopcount() {
   BasicBlock *PH = CurLoop->getLoopPreheader();
   if (!PH || &PH->front() != PH->getTerminator())
     return false;
-  auto *EntryBI = dyn_cast<BranchInst>(PH->getTerminator());
-  if (!EntryBI || EntryBI->isConditional())
+  auto *EntryBI = dyn_cast<UncondBrInst>(PH->getTerminator());
+  if (!EntryBI)
     return false;
 
   // It should have a precondition block where the generated popcount intrinsic
@@ -2586,8 +2577,8 @@ bool LoopIdiomRecognize::recognizePopcount() {
   auto *PreCondBB = PH->getSinglePredecessor();
   if (!PreCondBB)
     return false;
-  auto *PreCondBI = dyn_cast<BranchInst>(PreCondBB->getTerminator());
-  if (!PreCondBI || PreCondBI->isUnconditional())
+  auto *PreCondBI = dyn_cast<CondBrInst>(PreCondBB->getTerminator());
+  if (!PreCondBI)
     return false;
 
   Instruction *CntInst;
@@ -2658,10 +2649,8 @@ void LoopIdiomRecognize::transformLoopToCountable(
     Intrinsic::ID IntrinID, BasicBlock *Preheader, Instruction *CntInst,
     PHINode *CntPhi, Value *InitX, Instruction *DefX, const DebugLoc &DL,
     bool ZeroCheck, bool IsCntPhiUsedOutsideLoop, bool InsertSub) {
-  BranchInst *PreheaderBr = cast<BranchInst>(Preheader->getTerminator());
-
   // Step 1: Insert the CTLZ/CTTZ instruction at the end of the preheader block
-  IRBuilder<> Builder(PreheaderBr);
+  IRBuilder<> Builder(Preheader->getTerminator());
   Builder.SetCurrentDebugLocation(DL);
 
   // If there are no uses of CntPhi crate:
@@ -2717,7 +2706,7 @@ void LoopIdiomRecognize::transformLoopToCountable(
   //   ...
   //   Br: loop if (Dec != 0)
   BasicBlock *Body = *(CurLoop->block_begin());
-  auto *LbBr = cast<BranchInst>(Body->getTerminator());
+  auto *LbBr = cast<CondBrInst>(Body->getTerminator());
   ICmpInst *LbCond = cast<ICmpInst>(LbBr->getCondition());
 
   PHINode *TcPhi = PHINode::Create(CountTy, 2, "tcphi");
@@ -2752,7 +2741,7 @@ void LoopIdiomRecognize::transformLoopToPopcount(BasicBlock *PreCondBB,
                                                  Instruction *CntInst,
                                                  PHINode *CntPhi, Value *Var) {
   BasicBlock *PreHead = CurLoop->getLoopPreheader();
-  auto *PreCondBr = cast<BranchInst>(PreCondBB->getTerminator());
+  auto *PreCondBr = cast<CondBrInst>(PreCondBB->getTerminator());
   const DebugLoc &DL = CntInst->getDebugLoc();
 
   // Assuming before transformation, the loop is following:
@@ -2823,7 +2812,7 @@ void LoopIdiomRecognize::transformLoopToPopcount(BasicBlock *PreCondBB,
   //     do { cnt++; x &= x-1; t--) } while (t > 0);
   BasicBlock *Body = *(CurLoop->block_begin());
   {
-    auto *LbBr = cast<BranchInst>(Body->getTerminator());
+    auto *LbBr = cast<CondBrInst>(Body->getTerminator());
     ICmpInst *LbCond = cast<ICmpInst>(LbBr->getCondition());
     Type *Ty = TripCnt->getType();
 

--- a/llvm/lib/Transforms/Scalar/LoopIdiomRecognize.cpp
+++ b/llvm/lib/Transforms/Scalar/LoopIdiomRecognize.cpp
@@ -1709,9 +1709,6 @@ bool LoopIdiomRecognize::runOnNoncountableLoop() {
 /// in desirable form.
 static Value *matchCondition(CondBrInst *BI, BasicBlock *LoopEntry,
                              bool JmpOnZero = false) {
-  if (!BI)
-    return nullptr;
-
   ICmpInst *Cond = dyn_cast<ICmpInst>(BI->getCondition());
   if (!Cond)
     return nullptr;
@@ -1764,6 +1761,8 @@ public:
       return false;
 
     CondBrInst *LoopTerm = dyn_cast<CondBrInst>(LoopBody->getTerminator());
+    if (!LoopTerm)
+      return false;
     Value *LoopCond = matchCondition(LoopTerm, LoopBody);
     if (!LoopCond)
       return false;
@@ -2183,11 +2182,10 @@ static bool detectPopcountIdiom(Loop *CurLoop, BasicBlock *PreCondBB,
 
   // step 1: Check if the loop-back branch is in desirable form.
   {
-    if (Value *T = matchCondition(
-            dyn_cast<CondBrInst>(LoopEntry->getTerminator()), LoopEntry))
-      DefX2 = dyn_cast<Instruction>(T);
-    else
+    auto *LoopTerm = dyn_cast<CondBrInst>(LoopEntry->getTerminator());
+    if (!LoopTerm)
       return false;
+    DefX2 = dyn_cast_or_null<Instruction>(matchCondition(LoopTerm, LoopEntry));
   }
 
   // step 2: detect instructions corresponding to "x2 = x1 & (x1 - 1)"
@@ -2260,6 +2258,8 @@ static bool detectPopcountIdiom(Loop *CurLoop, BasicBlock *PreCondBB,
   //   "if (x != 0) goto loop-head ; else goto somewhere-we-don't-care;"
   {
     auto *PreCondBr = dyn_cast<CondBrInst>(PreCondBB->getTerminator());
+    if (!PreCondBr)
+      return false;
     Value *T = matchCondition(PreCondBr, CurLoop->getLoopPreheader());
     if (T != PhiX->getOperand(0) && T != PhiX->getOperand(1))
       return false;
@@ -2312,11 +2312,10 @@ static bool detectShiftUntilZeroIdiom(Loop *CurLoop, const DataLayout &DL,
   LoopEntry = *(CurLoop->block_begin());
 
   // step 1: Check if the loop-back branch is in desirable form.
-  if (Value *T = matchCondition(
-          dyn_cast<CondBrInst>(LoopEntry->getTerminator()), LoopEntry))
-    DefX = dyn_cast<Instruction>(T);
-  else
+  auto *LoopTerm = dyn_cast<CondBrInst>(LoopEntry->getTerminator());
+  if (!LoopTerm)
     return false;
+  DefX = dyn_cast_or_null<Instruction>(matchCondition(LoopTerm, LoopEntry));
 
   // step 2: detect instructions corresponding to "x.next = x >> 1 or x << 1"
   if (!DefX || !DefX->isShift())
@@ -2433,6 +2432,8 @@ bool LoopIdiomRecognize::insertFFSIfProfitable(Intrinsic::ID IntrinID,
     if (!PreCondBB)
       return false;
     auto *PreCondBI = dyn_cast<CondBrInst>(PreCondBB->getTerminator());
+    if (!PreCondBI)
+      return false;
     if (matchCondition(PreCondBI, PH) != InitX)
       return false;
     ZeroCheck = true;

--- a/llvm/lib/Transforms/Scalar/LoopIdiomRecognize.cpp
+++ b/llvm/lib/Transforms/Scalar/LoopIdiomRecognize.cpp
@@ -1750,7 +1750,8 @@ public:
 
     // It should have a preheader and a branch instruction.
     BasicBlock *Preheader = CurLoop->getLoopPreheader();
-    if (!Preheader || !isa<UncondBrInst, CondBrInst>(Preheader->getTerminator()))
+    if (!Preheader ||
+        !isa<UncondBrInst, CondBrInst>(Preheader->getTerminator()))
       return false;
 
     // The loop exit must be conditioned on an icmp with 0 the null terminator.

--- a/llvm/lib/Transforms/Scalar/LoopInterchange.cpp
+++ b/llvm/lib/Transforms/Scalar/LoopInterchange.cpp
@@ -816,12 +816,7 @@ bool LoopInterchangeLegality::tightlyNested(Loop *OuterLoop, Loop *InnerLoop) {
   // A perfectly nested loop will not have any branch in between the outer and
   // inner block i.e. outer header will branch to either inner preheader and
   // outerloop latch.
-  BranchInst *OuterLoopHeaderBI =
-      dyn_cast<BranchInst>(OuterLoopHeader->getTerminator());
-  if (!OuterLoopHeaderBI)
-    return false;
-
-  for (BasicBlock *Succ : successors(OuterLoopHeaderBI))
+  for (BasicBlock *Succ : successors(OuterLoopHeader))
     if (Succ != InnerLoopPreHeader && Succ != InnerLoop->getHeader() &&
         Succ != OuterLoopLatch)
       return false;
@@ -901,9 +896,9 @@ bool LoopInterchangeLegality::isLoopStructureUnderstood() {
   //      for(int i=0;i<N;i++)
   //        for(int j=0;j*i<N;j++)
   BasicBlock *InnerLoopLatch = InnerLoop->getLoopLatch();
-  BranchInst *InnerLoopLatchBI =
-      dyn_cast<BranchInst>(InnerLoopLatch->getTerminator());
-  if (!InnerLoopLatchBI->isConditional())
+  CondBrInst *InnerLoopLatchBI =
+      dyn_cast<CondBrInst>(InnerLoopLatch->getTerminator());
+  if (!InnerLoopLatchBI)
     return false;
   if (CmpInst *InnerLoopCmp =
           dyn_cast<CmpInst>(InnerLoopLatchBI->getCondition())) {
@@ -1256,8 +1251,8 @@ bool LoopInterchangeLegality::currentLimitations() {
   // blocks.
   if (InnerLoop->getExitingBlock() != InnerLoopLatch ||
       OuterLoop->getExitingBlock() != OuterLoop->getLoopLatch() ||
-      !isa<BranchInst>(InnerLoopLatch->getTerminator()) ||
-      !isa<BranchInst>(OuterLoop->getLoopLatch()->getTerminator())) {
+      !isa<CondBrInst>(InnerLoopLatch->getTerminator()) ||
+      !isa<CondBrInst>(OuterLoop->getLoopLatch()->getTerminator())) {
     LLVM_DEBUG(
         dbgs() << "Loops where the latch is not the exiting block are not"
                << " supported currently.\n");
@@ -1999,7 +1994,7 @@ bool LoopInterchangeTransform::transform(
 
     // FIXME: Should we interchange when we have a constant condition?
     Instruction *CondI = dyn_cast<Instruction>(
-        cast<BranchInst>(InnerLoop->getLoopLatch()->getTerminator())
+        cast<CondBrInst>(InnerLoop->getLoopLatch()->getTerminator())
             ->getCondition());
     if (CondI)
       WorkList.insert(CondI);
@@ -2076,14 +2071,14 @@ static void swapBBContents(BasicBlock *BB1, BasicBlock *BB2) {
 // Update BI to jump to NewBB instead of OldBB. Records updates to the
 // dominator tree in DTUpdates. If \p MustUpdateOnce is true, assert that
 // \p OldBB  is exactly once in BI's successor list.
-static void updateSuccessor(BranchInst *BI, BasicBlock *OldBB,
+static void updateSuccessor(Instruction *Term, BasicBlock *OldBB,
                             BasicBlock *NewBB,
                             std::vector<DominatorTree::UpdateType> &DTUpdates,
                             bool MustUpdateOnce = true) {
-  assert((!MustUpdateOnce || llvm::count(successors(BI), OldBB) == 1) &&
+  assert((!MustUpdateOnce || llvm::count(successors(Term), OldBB) == 1) &&
          "BI must jump to OldBB exactly once.");
   bool Changed = false;
-  for (Use &Op : BI->operands())
+  for (Use &Op : Term->operands())
     if (Op == OldBB) {
       Op.set(NewBB);
       Changed = true;
@@ -2091,9 +2086,9 @@ static void updateSuccessor(BranchInst *BI, BasicBlock *OldBB,
 
   if (Changed) {
     DTUpdates.push_back(
-        {DominatorTree::UpdateKind::Insert, BI->getParent(), NewBB});
+        {DominatorTree::UpdateKind::Insert, Term->getParent(), NewBB});
     DTUpdates.push_back(
-        {DominatorTree::UpdateKind::Delete, BI->getParent(), OldBB});
+        {DominatorTree::UpdateKind::Delete, Term->getParent(), OldBB});
   }
   assert(Changed && "Expected a successor to be updated");
 }
@@ -2274,24 +2269,21 @@ bool LoopInterchangeTransform::adjustLoopBranches() {
   BasicBlock *InnerLoopLatchSuccessor;
   BasicBlock *OuterLoopLatchSuccessor;
 
-  BranchInst *OuterLoopLatchBI =
-      dyn_cast<BranchInst>(OuterLoopLatch->getTerminator());
-  BranchInst *InnerLoopLatchBI =
-      dyn_cast<BranchInst>(InnerLoopLatch->getTerminator());
-  BranchInst *OuterLoopHeaderBI =
-      dyn_cast<BranchInst>(OuterLoopHeader->getTerminator());
-  BranchInst *InnerLoopHeaderBI =
-      dyn_cast<BranchInst>(InnerLoopHeader->getTerminator());
+  CondBrInst *OuterLoopLatchBI =
+      dyn_cast<CondBrInst>(OuterLoopLatch->getTerminator());
+  CondBrInst *InnerLoopLatchBI =
+      dyn_cast<CondBrInst>(InnerLoopLatch->getTerminator());
+  Instruction *OuterLoopHeaderBI = OuterLoopHeader->getTerminator();
+  Instruction *InnerLoopHeaderBI = InnerLoopHeader->getTerminator();
 
   if (!OuterLoopPredecessor || !InnerLoopLatchPredecessor ||
       !OuterLoopLatchBI || !InnerLoopLatchBI || !OuterLoopHeaderBI ||
       !InnerLoopHeaderBI)
     return false;
 
-  BranchInst *InnerLoopLatchPredecessorBI =
-      dyn_cast<BranchInst>(InnerLoopLatchPredecessor->getTerminator());
-  BranchInst *OuterLoopPredecessorBI =
-      dyn_cast<BranchInst>(OuterLoopPredecessor->getTerminator());
+  Instruction *InnerLoopLatchPredecessorBI =
+      InnerLoopLatchPredecessor->getTerminator();
+  Instruction *OuterLoopPredecessorBI = OuterLoopPredecessor->getTerminator();
 
   if (!OuterLoopPredecessorBI || !InnerLoopLatchPredecessorBI)
     return false;
@@ -2307,7 +2299,7 @@ bool LoopInterchangeTransform::adjustLoopBranches() {
                   InnerLoopPreHeader, DTUpdates, /*MustUpdateOnce=*/false);
   // The outer loop header might or might not branch to the outer latch.
   // We are guaranteed to branch to the inner loop preheader.
-  if (llvm::is_contained(OuterLoopHeaderBI->successors(), OuterLoopLatch)) {
+  if (llvm::is_contained(successors(OuterLoopHeaderBI), OuterLoopLatch)) {
     // In this case the outerLoopHeader should branch to the InnerLoopLatch.
     updateSuccessor(OuterLoopHeaderBI, OuterLoopLatch, InnerLoopLatch,
                     DTUpdates,

--- a/llvm/lib/Transforms/Scalar/LoopPredication.cpp
+++ b/llvm/lib/Transforms/Scalar/LoopPredication.cpp
@@ -310,7 +310,8 @@ class LoopPredication {
                    SmallVectorImpl<Value *> &WidenedChecks,
                    SCEVExpander &Expander, Instruction *Guard);
   bool widenGuardConditions(IntrinsicInst *II, SCEVExpander &Expander);
-  bool widenWidenableBranchGuardConditions(BranchInst *Guard, SCEVExpander &Expander);
+  bool widenWidenableBranchGuardConditions(CondBrInst *Guard,
+                                           SCEVExpander &Expander);
   // If the loop always exits through another block in the loop, we should not
   // predicate based on the latch check. For example, the latch check can be a
   // very coarse grained check and there can be more fine grained exit checks
@@ -755,7 +756,7 @@ bool LoopPredication::widenGuardConditions(IntrinsicInst *Guard,
 }
 
 bool LoopPredication::widenWidenableBranchGuardConditions(
-    BranchInst *BI, SCEVExpander &Expander) {
+    CondBrInst *BI, SCEVExpander &Expander) {
   assert(isGuardAsWidenableBranch(BI) && "Must be!");
   LLVM_DEBUG(dbgs() << "Processing guard:\n");
   LLVM_DEBUG(BI->dump());
@@ -813,8 +814,8 @@ std::optional<LoopICmp> LoopPredication::parseLoopLatchICmp() {
     return std::nullopt;
   }
 
-  auto *BI = dyn_cast<BranchInst>(LoopLatch->getTerminator());
-  if (!BI || !BI->isConditional()) {
+  auto *BI = dyn_cast<CondBrInst>(LoopLatch->getTerminator());
+  if (!BI) {
     LLVM_DEBUG(dbgs() << "Failed to match the latch terminator!\n");
     return std::nullopt;
   }
@@ -1076,7 +1077,7 @@ bool LoopPredication::predicateLoopExits(Loop *L, SCEVExpander &Rewriter) {
     if (LI->getLoopFor(ExitingBB) != L)
       continue;
 
-    auto *BI = dyn_cast<BranchInst>(ExitingBB->getTerminator());
+    auto *BI = dyn_cast<CondBrInst>(ExitingBB->getTerminator());
     if (!BI)
       continue;
 
@@ -1222,7 +1223,7 @@ bool LoopPredication::runOnLoop(Loop *Loop) {
   // Collect all the guards into a vector and process later, so as not
   // to invalidate the instruction iterator.
   SmallVector<IntrinsicInst *, 4> Guards;
-  SmallVector<BranchInst *, 4> GuardsAsWidenableBranches;
+  SmallVector<CondBrInst *, 4> GuardsAsWidenableBranches;
   for (const auto BB : L->blocks()) {
     for (auto &I : *BB)
       if (isGuard(&I))
@@ -1230,7 +1231,7 @@ bool LoopPredication::runOnLoop(Loop *Loop) {
     if (PredicateWidenableBranchGuards &&
         isGuardAsWidenableBranch(BB->getTerminator()))
       GuardsAsWidenableBranches.push_back(
-          cast<BranchInst>(BB->getTerminator()));
+          cast<CondBrInst>(BB->getTerminator()));
   }
 
   SCEVExpander Expander(*SE, "loop-predication");

--- a/llvm/lib/Transforms/Scalar/LoopSimplifyCFG.cpp
+++ b/llvm/lib/Transforms/Scalar/LoopSimplifyCFG.cpp
@@ -50,9 +50,7 @@ STATISTIC(NumLoopExitsDeleted,
 /// return nullptr.
 static BasicBlock *getOnlyLiveSuccessor(BasicBlock *BB) {
   Instruction *TI = BB->getTerminator();
-  if (BranchInst *BI = dyn_cast<BranchInst>(TI)) {
-    if (BI->isUnconditional())
-      return nullptr;
+  if (CondBrInst *BI = dyn_cast<CondBrInst>(TI)) {
     if (BI->getSuccessor(0) == BI->getSuccessor(1))
       return BI->getSuccessor(0);
     ConstantInt *Cond = dyn_cast<ConstantInt>(BI->getCondition());

--- a/llvm/lib/Transforms/Scalar/LoopStrengthReduce.cpp
+++ b/llvm/lib/Transforms/Scalar/LoopStrengthReduce.cpp
@@ -2631,8 +2631,8 @@ LSRInstance::OptimizeLoopTermCond() {
     // induction variable, to allow coalescing the live ranges for the IV into
     // one register value.
 
-    BranchInst *TermBr = dyn_cast<BranchInst>(ExitingBlock->getTerminator());
-    if (!TermBr || TermBr->isUnconditional())
+    CondBrInst *TermBr = dyn_cast<CondBrInst>(ExitingBlock->getTerminator());
+    if (!TermBr)
       continue;
 
     Instruction *Cond = dyn_cast<Instruction>(TermBr->getCondition());

--- a/llvm/lib/Transforms/Scalar/LoopTermFold.cpp
+++ b/llvm/lib/Transforms/Scalar/LoopTermFold.cpp
@@ -67,8 +67,8 @@ canFoldTermCondOfLoop(Loop *L, ScalarEvolution &SE, DominatorTree &DT,
   }
 
   BasicBlock *LoopLatch = L->getLoopLatch();
-  BranchInst *BI = dyn_cast<BranchInst>(LoopLatch->getTerminator());
-  if (!BI || BI->isUnconditional())
+  CondBrInst *BI = dyn_cast<CondBrInst>(LoopLatch->getTerminator());
+  if (!BI)
     return std::nullopt;
   auto *TermCond = dyn_cast<ICmpInst>(BI->getCondition());
   if (!TermCond) {
@@ -274,7 +274,7 @@ static bool RunTermFold(Loop *L, ScalarEvolution &SE, DominatorTree &DT,
                     << *TermValue << "\n");
 
   // Create new terminating condition at loop latch
-  BranchInst *BI = cast<BranchInst>(LoopLatch->getTerminator());
+  CondBrInst *BI = cast<CondBrInst>(LoopLatch->getTerminator());
   ICmpInst *OldTermCond = cast<ICmpInst>(BI->getCondition());
   IRBuilder<> LatchBuilder(LoopLatch->getTerminator());
   Value *NewTermCond =

--- a/llvm/lib/Transforms/Scalar/LoopUnrollPass.cpp
+++ b/llvm/lib/Transforms/Scalar/LoopUnrollPass.cpp
@@ -609,16 +609,14 @@ static std::optional<EstimatedUnrollCost> analyzeLoopUnrollCost(
       // Add in the live successors by first checking whether we have terminator
       // that may be simplified based on the values simplified by this call.
       BasicBlock *KnownSucc = nullptr;
-      if (BranchInst *BI = dyn_cast<BranchInst>(TI)) {
-        if (BI->isConditional()) {
-          if (auto *SimpleCond = getSimplifiedConstant(BI->getCondition())) {
-            // Just take the first successor if condition is undef
-            if (isa<UndefValue>(SimpleCond))
-              KnownSucc = BI->getSuccessor(0);
-            else if (ConstantInt *SimpleCondVal =
-                         dyn_cast<ConstantInt>(SimpleCond))
-              KnownSucc = BI->getSuccessor(SimpleCondVal->isZero() ? 1 : 0);
-          }
+      if (CondBrInst *BI = dyn_cast<CondBrInst>(TI)) {
+        if (auto *SimpleCond = getSimplifiedConstant(BI->getCondition())) {
+          // Just take the first successor if condition is undef
+          if (isa<UndefValue>(SimpleCond))
+            KnownSucc = BI->getSuccessor(0);
+          else if (ConstantInt *SimpleCondVal =
+                       dyn_cast<ConstantInt>(SimpleCond))
+            KnownSucc = BI->getSuccessor(SimpleCondVal->isZero() ? 1 : 0);
         }
       } else if (SwitchInst *SI = dyn_cast<SwitchInst>(TI)) {
         if (auto *SimpleCond = getSimplifiedConstant(SI->getCondition())) {

--- a/llvm/lib/Transforms/Scalar/LowerConstantIntrinsics.cpp
+++ b/llvm/lib/Transforms/Scalar/LowerConstantIntrinsics.cpp
@@ -64,10 +64,8 @@ static bool replaceConditionalBranchesOnConstant(Instruction *II,
                                   UnsimplifiedUsers.end());
 
   for (auto &VH : Worklist) {
-    BranchInst *BI = dyn_cast_or_null<BranchInst>(VH);
+    CondBrInst *BI = dyn_cast_or_null<CondBrInst>(VH);
     if (!BI)
-      continue;
-    if (BI->isUnconditional())
       continue;
 
     BasicBlock *Target, *Other;
@@ -85,7 +83,7 @@ static bool replaceConditionalBranchesOnConstant(Instruction *II,
       BasicBlock *Source = BI->getParent();
       Other->removePredecessor(Source);
 
-      Instruction *NewBI = BranchInst::Create(Target, Source);
+      Instruction *NewBI = UncondBrInst::Create(Target, Source);
       NewBI->setDebugLoc(BI->getDebugLoc());
       BI->eraseFromParent();
 

--- a/llvm/lib/Transforms/Scalar/LowerExpectIntrinsic.cpp
+++ b/llvm/lib/Transforms/Scalar/LowerExpectIntrinsic.cpp
@@ -193,18 +193,14 @@ static void handlePhiDef(CallInst *Expect) {
 
   // Get the first dominating conditional branch of the operand
   // i's incoming block.
-  auto GetDomConditional = [&](unsigned i) -> BranchInst * {
+  auto GetDomConditional = [&](unsigned i) -> CondBrInst * {
     BasicBlock *BB = PhiDef->getIncomingBlock(i);
-    BranchInst *BI = dyn_cast<BranchInst>(BB->getTerminator());
-    if (BI && BI->isConditional())
+    if (CondBrInst *BI = dyn_cast<CondBrInst>(BB->getTerminator()))
       return BI;
     BB = BB->getSinglePredecessor();
     if (!BB)
       return nullptr;
-    BI = dyn_cast<BranchInst>(BB->getTerminator());
-    if (!BI || BI->isUnconditional())
-      return nullptr;
-    return BI;
+    return dyn_cast<CondBrInst>(BB->getTerminator());
   };
 
   // Now walk through all Phi operands to find phi oprerands with values
@@ -226,7 +222,7 @@ static void handlePhiDef(CallInst *Expect) {
     if (ExpectedValueIsLikely == (ExpectedPhiValue == CurrentPhiValue))
       continue;
 
-    BranchInst *BI = GetDomConditional(i);
+    CondBrInst *BI = GetDomConditional(i);
     if (!BI)
       continue;
 
@@ -272,7 +268,7 @@ static void handlePhiDef(CallInst *Expect) {
   }
 }
 
-// Handle both BranchInst and SelectInst.
+// Handle both CondBrInst and SelectInst.
 template <class BrSelInst> static bool handleBrSelExpect(BrSelInst &BSI) {
 
   // Handle non-optimized IR code like:
@@ -354,20 +350,13 @@ template <class BrSelInst> static bool handleBrSelExpect(BrSelInst &BSI) {
   return true;
 }
 
-static bool handleBranchExpect(BranchInst &BI) {
-  if (BI.isUnconditional())
-    return false;
-
-  return handleBrSelExpect<BranchInst>(BI);
-}
-
 static bool lowerExpectIntrinsic(Function &F) {
   bool Changed = false;
 
   for (BasicBlock &BB : F) {
     // Create "block_weights" metadata.
-    if (BranchInst *BI = dyn_cast<BranchInst>(BB.getTerminator())) {
-      if (handleBranchExpect(*BI))
+    if (CondBrInst *BI = dyn_cast<CondBrInst>(BB.getTerminator())) {
+      if (handleBrSelExpect<CondBrInst>(*BI))
         ExpectIntrinsicsHandled++;
     } else if (SwitchInst *SI = dyn_cast<SwitchInst>(BB.getTerminator())) {
       if (handleSwitchExpect(*SI))

--- a/llvm/lib/Transforms/Scalar/LowerMatrixIntrinsics.cpp
+++ b/llvm/lib/Transforms/Scalar/LowerMatrixIntrinsics.cpp
@@ -1917,7 +1917,7 @@ public:
         "store.end",
         GEPNoWrapFlags::inBounds() | GEPNoWrapFlags::noUnsignedWrap());
     Value *LoadBegin = Load->getPointerOperand();
-    BranchInst *BR1 = Builder.CreateCondBr(
+    CondBrInst *BR1 = Builder.CreateCondBr(
         Builder.CreateICmpULT(LoadBegin, StoreEnd), Check1, Fusion);
     setExplicitlyUnknownBranchWeightsIfProfiled(*BR1, DEBUG_TYPE);
 
@@ -1930,7 +1930,7 @@ public:
         LoadBegin, ConstantInt::get(AddrTy, LoadLoc.Size.getValue()),
         "load.end",
         GEPNoWrapFlags::inBounds() | GEPNoWrapFlags::noUnsignedWrap());
-    BranchInst *BR2 = Builder.CreateCondBr(
+    CondBrInst *BR2 = Builder.CreateCondBr(
         Builder.CreateICmpULT(StoreBegin, LoadEnd), Copy, Fusion);
     setExplicitlyUnknownBranchWeightsIfProfiled(*BR2, DEBUG_TYPE);
 

--- a/llvm/lib/Transforms/Scalar/MergeICmps.cpp
+++ b/llvm/lib/Transforms/Scalar/MergeICmps.cpp
@@ -344,20 +344,17 @@ visitCmpBlock(Value *const Val, BasicBlock *const Block,
               const BasicBlock *const PhiBlock, BaseIdentifier &BaseId) {
   if (Block->empty())
     return std::nullopt;
-  auto *const BranchI = dyn_cast<BranchInst>(Block->getTerminator());
-  if (!BranchI)
-    return std::nullopt;
-  LLVM_DEBUG(dbgs() << "branch\n");
+  auto *Term = Block->getTerminator();
   Value *Cond;
   ICmpInst::Predicate ExpectedPredicate;
-  if (BranchI->isUnconditional()) {
+  if (isa<UncondBrInst>(Term)) {
     // In this case, we expect an incoming value which is the result of the
     // comparison. This is the last link in the chain of comparisons (note
     // that this does not mean that this is the last incoming value, blocks
     // can be reordered).
     Cond = Val;
     ExpectedPredicate = ICmpInst::ICMP_EQ;
-  } else {
+  } else if (auto *BranchI = dyn_cast<CondBrInst>(Term)) {
     // In this case, we expect a constant incoming value (the comparison is
     // chained).
     const auto *const Const = cast<ConstantInt>(Val);
@@ -370,7 +367,8 @@ visitCmpBlock(Value *const Val, BasicBlock *const Block,
     Cond = BranchI->getCondition();
     ExpectedPredicate =
         FalseBlock == PhiBlock ? ICmpInst::ICMP_EQ : ICmpInst::ICMP_NE;
-  }
+  } else
+    return std::nullopt;
 
   auto *CmpI = dyn_cast<ICmpInst>(Cond);
   if (!CmpI)
@@ -382,7 +380,7 @@ visitCmpBlock(Value *const Val, BasicBlock *const Block,
     return std::nullopt;
 
   BCECmpBlock::InstructionSet BlockInsts(
-      {Result->Lhs.LoadI, Result->Rhs.LoadI, Result->CmpI, BranchI});
+      {Result->Lhs.LoadI, Result->Rhs.LoadI, Result->CmpI, Term});
   if (Result->Lhs.GEP)
     BlockInsts.insert(Result->Lhs.GEP);
   if (Result->Rhs.GEP)

--- a/llvm/lib/Transforms/Scalar/MergedLoadStoreMotion.cpp
+++ b/llvm/lib/Transforms/Scalar/MergedLoadStoreMotion.cpp
@@ -137,8 +137,8 @@ BasicBlock *MergedLoadStoreMotion::getDiamondTail(BasicBlock *BB) {
 bool MergedLoadStoreMotion::isDiamondHead(BasicBlock *BB) {
   if (!BB)
     return false;
-  auto *BI = dyn_cast<BranchInst>(BB->getTerminator());
-  if (!BI || !BI->isConditional())
+  auto *BI = dyn_cast<CondBrInst>(BB->getTerminator());
+  if (!BI)
     return false;
 
   BasicBlock *Succ0 = BI->getSuccessor(0);

--- a/llvm/lib/Transforms/Scalar/PartiallyInlineLibCalls.cpp
+++ b/llvm/lib/Transforms/Scalar/PartiallyInlineLibCalls.cpp
@@ -70,9 +70,9 @@ static bool optimizeSQRT(CallInst *Call, Function *CalledFunc,
       Builder.getTrue(), Call->getNextNode(), /*Unreachable=*/false,
       /*BranchWeights*/ nullptr, DTU);
 
-  auto *CurrBBTerm = cast<BranchInst>(CurrBB.getTerminator());
+  auto *CurrBBTerm = cast<CondBrInst>(CurrBB.getTerminator());
   // We want an 'else' block though, not a 'then' block.
-  cast<BranchInst>(CurrBBTerm)->swapSuccessors();
+  cast<CondBrInst>(CurrBBTerm)->swapSuccessors();
 
   // Create phi that will merge results of either sqrt and replace all uses.
   BasicBlock *JoinBB = LibCallTerm->getSuccessor(0);

--- a/llvm/lib/Transforms/Scalar/PartiallyInlineLibCalls.cpp
+++ b/llvm/lib/Transforms/Scalar/PartiallyInlineLibCalls.cpp
@@ -72,7 +72,7 @@ static bool optimizeSQRT(CallInst *Call, Function *CalledFunc,
 
   auto *CurrBBTerm = cast<CondBrInst>(CurrBB.getTerminator());
   // We want an 'else' block though, not a 'then' block.
-  cast<CondBrInst>(CurrBBTerm)->swapSuccessors();
+  CurrBBTerm->swapSuccessors();
 
   // Create phi that will merge results of either sqrt and replace all uses.
   BasicBlock *JoinBB = LibCallTerm->getSuccessor(0);

--- a/llvm/lib/Transforms/Scalar/RewriteStatepointsForGC.cpp
+++ b/llvm/lib/Transforms/Scalar/RewriteStatepointsForGC.cpp
@@ -3115,9 +3115,8 @@ bool RewriteStatepointsForGC::runOnFunction(Function &F, DominatorTree &DT,
   // as long as all statepoints are in rare blocks.  If we had in-register
   // lowering for live values this would be a much safer transform.
   auto getConditionInst = [](Instruction *TI) -> Instruction * {
-    if (auto *BI = dyn_cast<BranchInst>(TI))
-      if (BI->isConditional())
-        return dyn_cast<Instruction>(BI->getCondition());
+    if (auto *BI = dyn_cast<CondBrInst>(TI))
+      return dyn_cast<Instruction>(BI->getCondition());
     // TODO: Extend this to handle switches
     return nullptr;
   };

--- a/llvm/lib/Transforms/Scalar/SROA.cpp
+++ b/llvm/lib/Transforms/Scalar/SROA.cpp
@@ -1861,9 +1861,9 @@ static void rewriteMemOpOfSelect(SelectInst &SI, T &I,
                               SI.getMetadata(LLVMContext::MD_prof), &DTU,
                               /*LI=*/nullptr, /*ThenBlock=*/nullptr);
     if (Spec.isSpeculatable(/*isTrueVal=*/true))
-      cast<BranchInst>(Head->getTerminator())->swapSuccessors();
+      cast<CondBrInst>(Head->getTerminator())->swapSuccessors();
   }
-  auto *HeadBI = cast<BranchInst>(Head->getTerminator());
+  auto *HeadBI = cast<CondBrInst>(Head->getTerminator());
   Spec = {}; // Do not use `Spec` beyond this point.
   BasicBlock *Tail = I.getParent();
   Tail->setName(Head->getName() + ".cont");

--- a/llvm/lib/Transforms/Scalar/SimpleLoopUnswitch.cpp
+++ b/llvm/lib/Transforms/Scalar/SimpleLoopUnswitch.cpp
@@ -147,11 +147,11 @@ extern cl::opt<bool> ProfcheckDisableMetadataFixes;
 AnalysisKey ShouldRunExtraSimpleLoopUnswitch::Key;
 namespace {
 struct CompareDesc {
-  BranchInst *Term;
+  CondBrInst *Term;
   Value *Invariant;
   BasicBlock *InLoopSucc;
 
-  CompareDesc(BranchInst *Term, Value *Invariant, BasicBlock *InLoopSucc)
+  CompareDesc(CondBrInst *Term, Value *Invariant, BasicBlock *InLoopSucc)
       : Term(Term), Invariant(Invariant), InLoopSucc(InLoopSucc) {}
 };
 
@@ -290,7 +290,7 @@ static void buildPartialUnswitchConditionalBranch(
     BasicBlock &BB, ArrayRef<Value *> Invariants, bool Direction,
     BasicBlock &UnswitchedSucc, BasicBlock &NormalSucc, bool InsertFreeze,
     const Instruction *I, AssumptionCache *AC, const DominatorTree &DT,
-    const BranchInst &ComputeProfFrom) {
+    const CondBrInst &ComputeProfFrom) {
 
   SmallVector<uint32_t> BranchWeights;
   bool HasBranchWeights = EstimateProfile && !ProfcheckDisableMetadataFixes &&
@@ -337,7 +337,7 @@ static void buildPartialUnswitchConditionalBranch(
 static void buildPartialInvariantUnswitchConditionalBranch(
     BasicBlock &BB, ArrayRef<Value *> ToDuplicate, bool Direction,
     BasicBlock &UnswitchedSucc, BasicBlock &NormalSucc, Loop &L,
-    MemorySSAUpdater *MSSAU, const BranchInst &OriginalBranch) {
+    MemorySSAUpdater *MSSAU, const CondBrInst &OriginalBranch) {
   ValueToValueMapTy VMap;
   for (auto *Val : reverse(ToDuplicate)) {
     Instruction *Inst = cast<Instruction>(Val);
@@ -566,10 +566,9 @@ static Loop *getTopMostExitingLoop(const BasicBlock *ExitBB,
 ///
 /// If `SE` is not null, it will be updated based on the potential loop SCEVs
 /// invalidated by this.
-static bool unswitchTrivialBranch(Loop &L, BranchInst &BI, DominatorTree &DT,
+static bool unswitchTrivialBranch(Loop &L, CondBrInst &BI, DominatorTree &DT,
                                   LoopInfo &LI, ScalarEvolution *SE,
                                   MemorySSAUpdater *MSSAU) {
-  assert(BI.isConditional() && "Can only unswitch a conditional branch!");
   LLVM_DEBUG(dbgs() << "  Trying to unswitch branch: " << BI << "\n");
 
   // The loop invariant values that we want to unswitch.
@@ -692,7 +691,7 @@ static bool unswitchTrivialBranch(Loop &L, BranchInst &BI, DominatorTree &DT,
     } else {
       // Create a new unconditional branch that will continue the loop as a new
       // terminator.
-      Instruction *NewBI = BranchInst::Create(ContinueBB, ParentBB);
+      Instruction *NewBI = UncondBrInst::Create(ContinueBB, ParentBB);
       NewBI->setDebugLoc(BI.getDebugLoc());
     }
     BI.setSuccessor(LoopExitSuccIdx, UnswitchedBB);
@@ -730,7 +729,7 @@ static bool unswitchTrivialBranch(Loop &L, BranchInst &BI, DominatorTree &DT,
       Instruction *Term = ParentBB->getTerminator();
       // Remove the cloned branch instruction and create unconditional branch
       // now.
-      Instruction *NewBI = BranchInst::Create(ContinueBB, ParentBB);
+      Instruction *NewBI = UncondBrInst::Create(ContinueBB, ParentBB);
       NewBI->setDebugLoc(Term->getDebugLoc());
       Term->eraseFromParent();
       MSSAU->removeEdge(ParentBB, LoopExitBB);
@@ -1037,7 +1036,7 @@ static bool unswitchTrivialSwitch(Loop &L, SwitchInst &SI, DominatorTree &DT,
                                       /*KeepOneInputPHIs*/ true);
     }
     // Now nuke the switch and replace it with a direct branch.
-    Instruction *NewBI = BranchInst::Create(CommonSuccBB, BB);
+    Instruction *NewBI = UncondBrInst::Create(CommonSuccBB, BB);
     NewBI->setDebugLoc(SIW->getDebugLoc());
     SIW.eraseFromParent();
   } else if (DefaultExitBB) {
@@ -1155,15 +1154,15 @@ static bool unswitchAllTrivialConditions(Loop &L, DominatorTree &DT,
       // we can continue. The unswitching logic specifically works to fold any
       // cases it can into an unconditional branch to make it easier to
       // recognize here.
-      auto *BI = dyn_cast<BranchInst>(CurrentBB->getTerminator());
-      if (!BI || BI->isConditional())
+      auto *BI = dyn_cast<UncondBrInst>(CurrentBB->getTerminator());
+      if (!BI)
         return Changed;
 
-      CurrentBB = BI->getSuccessor(0);
+      CurrentBB = BI->getSuccessor();
       continue;
     }
 
-    auto *BI = dyn_cast<BranchInst>(CurrentTerm);
+    auto *BI = dyn_cast<CondBrInst>(CurrentTerm);
     if (!BI)
       // We do not understand other terminator instructions.
       return Changed;
@@ -1171,8 +1170,7 @@ static bool unswitchAllTrivialConditions(Loop &L, DominatorTree &DT,
     // Don't bother trying to unswitch past an unconditional branch or a branch
     // with a constant value. These should be removed by simplifycfg prior to
     // running this pass.
-    if (!BI->isConditional() ||
-        isa<Constant>(skipTrivialSelect(BI->getCondition())))
+    if (isa<Constant>(skipTrivialSelect(BI->getCondition())))
       return Changed;
 
     // Found a trivial condition candidate: non-foldable conditional branch. If
@@ -1185,12 +1183,11 @@ static bool unswitchAllTrivialConditions(Loop &L, DominatorTree &DT,
 
     // If we only unswitched some of the conditions feeding the branch, we won't
     // have collapsed it to a single successor.
-    BI = cast<BranchInst>(CurrentBB->getTerminator());
-    if (BI->isConditional())
+    if (isa<CondBrInst>(CurrentBB->getTerminator()))
       return Changed;
 
     // Follow the newly unconditional branch into its successor.
-    CurrentBB = BI->getSuccessor(0);
+    CurrentBB = cast<UncondBrInst>(CurrentBB->getTerminator())->getSuccessor();
 
     // When continuing, if we exit the loop or reach a previous visited block,
     // then we can not reach any trivial condition candidates (unfoldable
@@ -1371,12 +1368,12 @@ static BasicBlock *buildClonedLoopBlocks(
   // Trivial Simplification. If Terminator is a conditional branch and
   // condition becomes dead - erase it.
   Value *ClonedConditionToErase = nullptr;
-  if (auto *BI = dyn_cast<BranchInst>(ClonedTerminator))
+  if (auto *BI = dyn_cast<CondBrInst>(ClonedTerminator))
     ClonedConditionToErase = BI->getCondition();
   else if (auto *SI = dyn_cast<SwitchInst>(ClonedTerminator))
     ClonedConditionToErase = SI->getCondition();
 
-  Instruction *BI = BranchInst::Create(ClonedSuccBB, ClonedParentBB);
+  Instruction *BI = UncondBrInst::Create(ClonedSuccBB, ClonedParentBB);
   BI->setDebugLoc(ClonedTerminator->getDebugLoc());
   ClonedTerminator->eraseFromParent();
 
@@ -2238,7 +2235,7 @@ static void unswitchNontrivialInvariants(
     AssumptionCache &AC, ScalarEvolution *SE, MemorySSAUpdater *MSSAU,
     LPMUpdater &LoopUpdater, bool InsertFreeze, bool InjectedCondition) {
   auto *ParentBB = TI.getParent();
-  BranchInst *BI = dyn_cast<BranchInst>(&TI);
+  CondBrInst *BI = dyn_cast<CondBrInst>(&TI);
   SwitchInst *SI = BI ? nullptr : cast<SwitchInst>(&TI);
 
   // Save the current loop name in a variable so that we can report it even
@@ -2248,8 +2245,7 @@ static void unswitchNontrivialInvariants(
   // We can only unswitch switches, conditional branches with an invariant
   // condition, or combining invariant conditions with an instruction or
   // partially invariant instructions.
-  assert((SI || (BI && BI->isConditional())) &&
-         "Can only unswitch switches and conditional branch!");
+  assert((SI || BI) && "Can only unswitch switches and conditional branch!");
   bool PartiallyInvariant = !PartialIVInfo.InstToDuplicate.empty();
   bool FullUnswitch =
       SI || (skipTrivialSelect(BI->getCondition()) == Invariants[0] &&
@@ -2422,7 +2418,7 @@ static void unswitchNontrivialInvariants(
       Value *Cond = skipTrivialSelect(BI->getCondition());
       if (InsertFreeze) {
         // We don't give any debug location to the new freeze, because the
-        // BI (`dyn_cast<BranchInst>(TI)`) is an in-loop instruction hoisted
+        // BI (`dyn_cast<CondBrInst>(TI)`) is an in-loop instruction hoisted
         // out of the loop.
         Cond = new FreezeInst(Cond, Cond->getName() + ".fr", BI->getIterator());
         cast<Instruction>(Cond)->setDebugLoc(DebugLoc::getDropped());
@@ -2511,7 +2507,7 @@ static void unswitchNontrivialInvariants(
 
     // Create a new unconditional branch to the continuing block (as opposed to
     // the one cloned).
-    Instruction *NewBI = BranchInst::Create(RetainedSuccBB, ParentBB);
+    Instruction *NewBI = UncondBrInst::Create(RetainedSuccBB, ParentBB);
     NewBI->setDebugLoc(NewTI->getDebugLoc());
 
     // After MSSAU update, remove the cloned terminator instruction NewTI.
@@ -2771,7 +2767,7 @@ static InstructionCost computeDomSubtreeCost(
 ///
 /// It also makes all relevant DT and LI updates, so that all structures are in
 /// valid state after this transform.
-static BranchInst *turnSelectIntoBranch(SelectInst *SI, DominatorTree &DT,
+static CondBrInst *turnSelectIntoBranch(SelectInst *SI, DominatorTree &DT,
                                         LoopInfo &LI, MemorySSAUpdater *MSSAU,
                                         AssumptionCache *AC) {
   LLVM_DEBUG(dbgs() << "Turning " << *SI << " into a branch.\n");
@@ -2780,7 +2776,7 @@ static BranchInst *turnSelectIntoBranch(SelectInst *SI, DominatorTree &DT,
   DomTreeUpdater DTU(DT, DomTreeUpdater::UpdateStrategy::Eager);
   SplitBlockAndInsertIfThen(SI->getCondition(), SI, false,
                             SI->getMetadata(LLVMContext::MD_prof), &DTU, &LI);
-  auto *CondBr = cast<BranchInst>(HeadBB->getTerminator());
+  auto *CondBr = cast<CondBrInst>(HeadBB->getTerminator());
   BasicBlock *ThenBB = CondBr->getSuccessor(0),
              *TailBB = CondBr->getSuccessor(1);
   if (MSSAU)
@@ -2822,7 +2818,7 @@ static BranchInst *turnSelectIntoBranch(SelectInst *SI, DominatorTree &DT,
 ///
 /// It also makes all relevant DT and LI updates, so that all structures are in
 /// valid state after this transform.
-static BranchInst *turnGuardIntoBranch(IntrinsicInst *GI, Loop &L,
+static CondBrInst *turnGuardIntoBranch(IntrinsicInst *GI, Loop &L,
                                        DominatorTree &DT, LoopInfo &LI,
                                        MemorySSAUpdater *MSSAU) {
   LLVM_DEBUG(dbgs() << "Turning " << *GI << " into a branch.\n");
@@ -2840,7 +2836,7 @@ static BranchInst *turnGuardIntoBranch(IntrinsicInst *GI, Loop &L,
           ? MDBuilder(GI->getContext()).createUnlikelyBranchWeights()
           : nullptr,
       &DTU, &LI);
-  BranchInst *CheckBI = cast<BranchInst>(CheckBB->getTerminator());
+  CondBrInst *CheckBI = cast<CondBrInst>(CheckBB->getTerminator());
   // SplitBlockAndInsertIfThen inserts control flow that branches to
   // DeoptBlockTerm if the condition is true.  We want the opposite.
   CheckBI->swapSuccessors();
@@ -3036,9 +3032,8 @@ static bool collectUnswitchCandidates(
       continue;
     }
 
-    auto *BI = dyn_cast<BranchInst>(BB->getTerminator());
-    if (!BI || !BI->isConditional() ||
-        BI->getSuccessor(0) == BI->getSuccessor(1))
+    auto *BI = dyn_cast<CondBrInst>(BB->getTerminator());
+    if (!BI || BI->getSuccessor(0) == BI->getSuccessor(1))
       continue;
 
     AddUnswitchCandidatesForInst(BI, BI->getCondition());
@@ -3121,7 +3116,7 @@ static bool shouldTryInjectInvariantCondition(
 /// TakenSucc via injection of invariant conditions. The branch should be not
 /// enough and not previously unswitched, the information about this comes from
 /// the metadata.
-bool shouldTryInjectBasingOnMetadata(const BranchInst *BI,
+bool shouldTryInjectBasingOnMetadata(const CondBrInst *BI,
                                      const BasicBlock *TakenSucc) {
   SmallVector<uint32_t> Weights;
   if (!extractBranchWeights(*BI, Weights))
@@ -3174,7 +3169,7 @@ injectPendingInvariantConditions(NonTrivialUnswitchCandidate Candidate, Loop &L,
   auto *LHS = Candidate.PendingInjection->LHS;
   auto *RHS = Candidate.PendingInjection->RHS;
   auto *InLoopSucc = Candidate.PendingInjection->InLoopSucc;
-  auto *TI = cast<BranchInst>(Candidate.TI);
+  auto *TI = cast<CondBrInst>(Candidate.TI);
   auto *BB = Candidate.TI->getParent();
   auto *OutOfLoopSucc = InLoopSucc == TI->getSuccessor(0) ? TI->getSuccessor(1)
                                                           : TI->getSuccessor(0);
@@ -3339,11 +3334,11 @@ static bool collectUnswitchCandidatesWithInjections(
                                                L);
     if (!shouldTryInjectInvariantCondition(Pred, LHS, RHS, IfTrue, IfFalse, L))
       continue;
-    if (!shouldTryInjectBasingOnMetadata(cast<BranchInst>(Term), IfTrue))
+    if (!shouldTryInjectBasingOnMetadata(cast<CondBrInst>(Term), IfTrue))
       continue;
     // Strip ZEXT for unsigned predicate.
     // TODO: once signed predicates are supported, also strip SEXT.
-    CompareDesc Desc(cast<BranchInst>(Term), RHS, IfTrue);
+    CompareDesc Desc(cast<CondBrInst>(Term), RHS, IfTrue);
     while (auto *Zext = dyn_cast<ZExtInst>(LHS))
       LHS = Zext->getOperand(0);
     CandidatesULT[LHS].push_back(Desc);
@@ -3474,7 +3469,7 @@ static NonTrivialUnswitchCandidate findBestNonTrivialUnswitchCandidate(
       // the successors is necessarily duplicated, so don't even try to remove
       // its cost.
       if (!FullUnswitch) {
-        auto &BI = cast<BranchInst>(TI);
+        auto &BI = cast<CondBrInst>(TI);
         Value *Cond = skipTrivialSelect(BI.getCondition());
         if (match(Cond, m_LogicalAnd())) {
           if (SuccBB == BI.getSuccessor(1))
@@ -3518,7 +3513,7 @@ static NonTrivialUnswitchCandidate findBestNonTrivialUnswitchCandidate(
   for (auto &Candidate : UnswitchCandidates) {
     Instruction &TI = *Candidate.TI;
     ArrayRef<Value *> Invariants = Candidate.Invariants;
-    BranchInst *BI = dyn_cast<BranchInst>(&TI);
+    CondBrInst *BI = dyn_cast<CondBrInst>(&TI);
     bool FullUnswitch =
         !BI || Candidate.hasPendingInjection() ||
         (Invariants.size() == 1 &&
@@ -3558,7 +3553,7 @@ static NonTrivialUnswitchCandidate findBestNonTrivialUnswitchCandidate(
 // 3. The branch condition may be poison or undef
 static bool shouldInsertFreeze(Loop &L, Instruction &TI, DominatorTree &DT,
                                AssumptionCache &AC) {
-  assert(isa<BranchInst>(TI) || isa<SwitchInst>(TI));
+  assert(isa<CondBrInst>(TI) || isa<SwitchInst>(TI));
   if (!FreezeLoopUnswitchCond)
     return false;
 
@@ -3568,7 +3563,7 @@ static bool shouldInsertFreeze(Loop &L, Instruction &TI, DominatorTree &DT,
     return false;
 
   Value *Cond;
-  if (BranchInst *BI = dyn_cast<BranchInst>(&TI))
+  if (CondBrInst *BI = dyn_cast<CondBrInst>(&TI))
     Cond = skipTrivialSelect(BI->getCondition());
   else
     Cond = skipTrivialSelect(cast<SwitchInst>(&TI)->getCondition());

--- a/llvm/lib/Transforms/Scalar/SimplifyCFGPass.cpp
+++ b/llvm/lib/Transforms/Scalar/SimplifyCFGPass.cpp
@@ -148,7 +148,7 @@ performBlockTailMerging(Function &F, ArrayRef<BasicBlock *> BBs,
 
     // And turn BB into a block that just unconditionally branches
     // to the canonical block.
-    Instruction *BI = BranchInst::Create(CanonicalBB, BB);
+    Instruction *BI = UncondBrInst::Create(CanonicalBB, BB);
     BI->setDebugLoc(Term->getDebugLoc());
     Term->eraseFromParent();
 

--- a/llvm/lib/Transforms/Scalar/SpeculativeExecution.cpp
+++ b/llvm/lib/Transforms/Scalar/SpeculativeExecution.cpp
@@ -165,12 +165,10 @@ bool SpeculativeExecutionPass::runImpl(Function &F, TargetTransformInfo *TTI) {
 }
 
 bool SpeculativeExecutionPass::runOnBasicBlock(BasicBlock &B) {
-  BranchInst *BI = dyn_cast<BranchInst>(B.getTerminator());
-  if (BI == nullptr)
+  CondBrInst *BI = dyn_cast<CondBrInst>(B.getTerminator());
+  if (!BI)
     return false;
 
-  if (BI->getNumSuccessors() != 2)
-    return false;
   BasicBlock &Succ0 = *BI->getSuccessor(0);
   BasicBlock &Succ1 = *BI->getSuccessor(1);
 

--- a/llvm/lib/Transforms/Scalar/StructurizeCFG.cpp
+++ b/llvm/lib/Transforms/Scalar/StructurizeCFG.cpp
@@ -554,6 +554,7 @@ void StructurizeCFG::analyzeLoops(RegionNode *N) {
 
   } else {
     // Test for successors as back edge
+    // TODO: support other terminators other than branches.
     BasicBlock *BB = N->getNodeAs<BasicBlock>();
     if (isa<UncondBrInst, CondBrInst>(BB->getTerminator()))
       for (BasicBlock *Succ : successors(BB))

--- a/llvm/lib/Transforms/Scalar/StructurizeCFG.cpp
+++ b/llvm/lib/Transforms/Scalar/StructurizeCFG.cpp
@@ -555,9 +555,10 @@ void StructurizeCFG::analyzeLoops(RegionNode *N) {
   } else {
     // Test for successors as back edge
     BasicBlock *BB = N->getNodeAs<BasicBlock>();
-    for (BasicBlock *Succ : successors(BB))
-      if (Visited.count(Succ))
-        Loops[Succ] = BB;
+    if (isa<UncondBrInst, CondBrInst>(BB->getTerminator()))
+      for (BasicBlock *Succ : successors(BB))
+        if (Visited.count(Succ))
+          Loops[Succ] = BB;
   }
 }
 

--- a/llvm/lib/Transforms/Scalar/StructurizeCFG.cpp
+++ b/llvm/lib/Transforms/Scalar/StructurizeCFG.cpp
@@ -78,7 +78,7 @@ using BBValuePair = std::pair<BasicBlock *, Value *>;
 
 using RNVector = SmallVector<RegionNode *, 8>;
 using BBVector = SmallVector<BasicBlock *, 8>;
-using BranchVector = SmallVector<BranchInst *, 8>;
+using BranchVector = SmallVector<CondBrInst *, 8>;
 using BBValueVector = SmallVector<BBValuePair, 2>;
 
 using BBSet = SmallPtrSet<BasicBlock *, 8>;
@@ -97,9 +97,7 @@ class CondBranchWeights {
   CondBranchWeights(uint32_t T, uint32_t F) : TrueWeight(T), FalseWeight(F) {}
 
 public:
-  static MaybeCondBranchWeights tryParse(const BranchInst &Br) {
-    assert(Br.isConditional());
-
+  static MaybeCondBranchWeights tryParse(const CondBrInst &Br) {
     uint64_t T, F;
     if (!extractBranchWeights(Br, T, F))
       return std::nullopt;
@@ -107,9 +105,8 @@ public:
     return CondBranchWeights(T, F);
   }
 
-  static void setMetadata(BranchInst &Br,
+  static void setMetadata(CondBrInst &Br,
                           const MaybeCondBranchWeights &Weights) {
-    assert(Br.isConditional());
     if (!Weights)
       return;
     uint32_t Arr[] = {Weights->TrueWeight, Weights->FalseWeight};
@@ -316,7 +313,7 @@ class StructurizeCFG {
 
   void analyzeLoops(RegionNode *N);
 
-  PredInfo buildCondition(BranchInst *Term, unsigned Idx, bool Invert);
+  PredInfo buildCondition(CondBrInst *Term, unsigned Idx, bool Invert);
 
   void gatherPredicates(RegionNode *N);
 
@@ -558,28 +555,21 @@ void StructurizeCFG::analyzeLoops(RegionNode *N) {
   } else {
     // Test for successors as back edge
     BasicBlock *BB = N->getNodeAs<BasicBlock>();
-    if (BranchInst *Term = dyn_cast<BranchInst>(BB->getTerminator()))
-      for (BasicBlock *Succ : Term->successors())
-        if (Visited.count(Succ))
-          Loops[Succ] = BB;
+    for (BasicBlock *Succ : successors(BB))
+      if (Visited.count(Succ))
+        Loops[Succ] = BB;
   }
 }
 
 /// Build the condition for one edge
-PredInfo StructurizeCFG::buildCondition(BranchInst *Term, unsigned Idx,
+PredInfo StructurizeCFG::buildCondition(CondBrInst *Term, unsigned Idx,
                                         bool Invert) {
-  Value *Cond = Invert ? BoolFalse : BoolTrue;
-  MaybeCondBranchWeights Weights;
-
-  if (Term->isConditional()) {
-    Cond = Term->getCondition();
-    Weights = CondBranchWeights::tryParse(*Term);
-
-    if (Idx != (unsigned)Invert) {
-      Cond = invertCondition(Cond);
-      if (Weights)
-        Weights = Weights->invert();
-    }
+  Value *Cond = Term->getCondition();
+  auto Weights = CondBranchWeights::tryParse(*Term);
+  if (Idx != (unsigned)Invert) {
+    Cond = invertCondition(Cond);
+    if (Weights)
+      Weights = Weights->invert();
   }
   return {Cond, Weights};
 }
@@ -593,35 +583,32 @@ void StructurizeCFG::gatherPredicates(RegionNode *N) {
 
   for (BasicBlock *P : predecessors(BB)) {
     // Ignore it if it's a branch from outside into our region entry
-    if (!ParentRegion->contains(P) || !dyn_cast<BranchInst>(P->getTerminator()))
+    if (!ParentRegion->contains(P))
       continue;
 
     Region *R = RI->getRegionFor(P);
     if (R == ParentRegion) {
-      // It's a top level block in our region
-      BranchInst *Term = cast<BranchInst>(P->getTerminator());
-      for (unsigned i = 0, e = Term->getNumSuccessors(); i != e; ++i) {
-        BasicBlock *Succ = Term->getSuccessor(i);
-        if (Succ != BB)
-          continue;
-
+      if (isa<UncondBrInst>(P->getTerminator())) {
+        if (Visited.count(P))
+          Pred[P] = {BoolTrue, std::nullopt};
+        else
+          LPred[P] = {BoolFalse, std::nullopt};
+      } else if (auto *CondBr = dyn_cast<CondBrInst>(P->getTerminator())) {
+        bool Idx = CondBr->getSuccessor(0) == BB ? 0 : 1;
         if (Visited.count(P)) {
           // Normal forward edge
-          if (Term->isConditional()) {
-            // Try to treat it like an ELSE block
-            BasicBlock *Other = Term->getSuccessor(!i);
-            if (Visited.count(Other) && !Loops.count(Other) &&
-                !Pred.count(Other) && !Pred.count(P)) {
-              hoistZeroCostElseBlockPhiValues(Succ, Other);
-              Pred[Other] = {BoolFalse, std::nullopt};
-              Pred[P] = {BoolTrue, std::nullopt};
-              continue;
-            }
-          }
-          Pred[P] = buildCondition(Term, i, false);
+          // Try to treat Other like an ELSE block
+          BasicBlock *Other = CondBr->getSuccessor(!Idx);
+          if (Visited.count(Other) && !Loops.count(Other) &&
+              !Pred.count(Other) && !Pred.count(P)) {
+            hoistZeroCostElseBlockPhiValues(BB, Other);
+            Pred[Other] = {BoolFalse, std::nullopt};
+            Pred[P] = {BoolTrue, std::nullopt};
+          } else
+            Pred[P] = buildCondition(CondBr, Idx, false);
         } else {
           // Back edge
-          LPred[P] = buildCondition(Term, i, true);
+          LPred[P] = buildCondition(CondBr, Idx, true);
         }
       }
     } else {
@@ -675,9 +662,7 @@ void StructurizeCFG::insertConditions(bool Loops, SSAUpdaterBulk &PhiInserter) {
   BranchVector &Conds = Loops ? LoopConds : Conditions;
   Value *Default = Loops ? BoolTrue : BoolFalse;
 
-  for (BranchInst *Term : Conds) {
-    assert(Term->isConditional());
-
+  for (CondBrInst *Term : Conds) {
     BasicBlock *Parent = Term->getParent();
     BasicBlock *SuccTrue = Term->getSuccessor(0);
     BasicBlock *SuccFalse = Term->getSuccessor(1);
@@ -1079,7 +1064,7 @@ void StructurizeCFG::changeExit(RegionNode *Node, BasicBlock *NewExit,
   } else {
     BasicBlock *BB = Node->getNodeAs<BasicBlock>();
     DebugLoc DL = killTerminator(BB);
-    BranchInst *Br = BranchInst::Create(NewExit, BB);
+    UncondBrInst *Br = UncondBrInst::Create(NewExit, BB);
     Br->setDebugLoc(DL);
     addPhiValues(BB, NewExit);
     if (IncludeDominator)
@@ -1188,7 +1173,7 @@ void StructurizeCFG::wireFlow(bool ExitUseAllowed,
     BasicBlock *Next = needPostfix(Flow, ExitUseAllowed);
 
     // let it point to entry and next block
-    BranchInst *Br = BranchInst::Create(Entry, Next, BoolPoison, Flow);
+    CondBrInst *Br = CondBrInst::Create(BoolPoison, Entry, Next, Flow);
     Br->setDebugLoc(DL);
     Conditions.push_back(Br);
     addPhiValues(Flow, Entry);
@@ -1230,7 +1215,7 @@ void StructurizeCFG::handleLoops(bool ExitUseAllowed,
   DebugLoc DL;
   std::tie(LoopEnd, DL) = needPrefix(false);
   BasicBlock *Next = needPostfix(LoopEnd, ExitUseAllowed);
-  BranchInst *Br = BranchInst::Create(Next, LoopStart, BoolPoison, LoopEnd);
+  CondBrInst *Br = CondBrInst::Create(BoolPoison, Next, LoopStart, LoopEnd);
   Br->setDebugLoc(DL);
   LoopConds.push_back(Br);
   addPhiValues(LoopEnd, LoopStart);
@@ -1304,8 +1289,8 @@ static bool hasOnlyUniformBranches(Region *R, unsigned UniformMDKindID,
 
   for (auto *E : R->elements()) {
     if (!E->isSubRegion()) {
-      auto Br = dyn_cast<BranchInst>(E->getEntry()->getTerminator());
-      if (!Br || !Br->isConditional())
+      auto Br = dyn_cast<CondBrInst>(E->getEntry()->getTerminator());
+      if (!Br)
         continue;
 
       if (!UA.isUniform(Br))
@@ -1327,8 +1312,8 @@ static bool hasOnlyUniformBranches(Region *R, unsigned UniformMDKindID,
       // subregions are uniform or not. However, this requires a very careful
       // look at SIAnnotateControlFlow to make sure nothing breaks there.
       for (auto *BB : E->getNodeAs<Region>()->blocks()) {
-        auto Br = dyn_cast<BranchInst>(BB->getTerminator());
-        if (!Br || !Br->isConditional())
+        auto Br = dyn_cast<CondBrInst>(BB->getTerminator());
+        if (!Br)
           continue;
 
         if (!Br->getMetadata(UniformMDKindID)) {

--- a/llvm/lib/Transforms/Scalar/TailRecursionElimination.cpp
+++ b/llvm/lib/Transforms/Scalar/TailRecursionElimination.cpp
@@ -525,7 +525,7 @@ void TailRecursionEliminator::createTailRecurseLoopHeader(CallInst *CI) {
   BasicBlock *NewEntry = BasicBlock::Create(F.getContext(), "", &F, HeaderBB);
   NewEntry->takeName(HeaderBB);
   HeaderBB->setName("tailrecurse");
-  auto *BI = BranchInst::Create(HeaderBB, NewEntry);
+  auto *BI = UncondBrInst::Create(HeaderBB, NewEntry);
   BI->setDebugLoc(DebugLoc::getCompilerGenerated());
   // If the new branch preserves the debug location of CI, it could result in
   // misleading stepping, if CI is located in a conditional branch.
@@ -749,7 +749,7 @@ bool TailRecursionEliminator::eliminateCall(CallInst *CI) {
 
   // Now that all of the PHI nodes are in place, remove the call and
   // ret instructions, replacing them with an unconditional branch.
-  BranchInst *NewBI = BranchInst::Create(HeaderBB, Ret->getIterator());
+  UncondBrInst *NewBI = UncondBrInst::Create(HeaderBB, Ret->getIterator());
   NewBI->setDebugLoc(CI->getDebugLoc());
 
   Ret->eraseFromParent();  // Remove return.
@@ -860,11 +860,8 @@ void TailRecursionEliminator::cleanupAndFinalize() {
 bool TailRecursionEliminator::processBlock(BasicBlock &BB) {
   Instruction *TI = BB.getTerminator();
 
-  if (BranchInst *BI = dyn_cast<BranchInst>(TI)) {
-    if (BI->isConditional())
-      return false;
-
-    BasicBlock *Succ = BI->getSuccessor(0);
+  if (UncondBrInst *BI = dyn_cast<UncondBrInst>(TI)) {
+    BasicBlock *Succ = BI->getSuccessor();
     ReturnInst *Ret = dyn_cast<ReturnInst>(Succ->getFirstNonPHIOrDbg(true));
 
     if (!Ret)

--- a/llvm/unittests/Transforms/Scalar/LoopPassManagerTest.cpp
+++ b/llvm/unittests/Transforms/Scalar/LoopPassManagerTest.cpp
@@ -919,7 +919,7 @@ TEST_F(LoopPassManagerTest, LoopChildInsertion) {
                           const char *Name, BasicBlock *BB) {
     auto *Cond = new LoadInst(Type::getInt1Ty(Context), &Ptr, Name,
                               /*isVolatile*/ true, BB);
-    BranchInst::Create(TrueBB, FalseBB, Cond, BB);
+    CondBrInst::Create(Cond, TrueBB, FalseBB, BB);
   };
 
   // Build the pass managers and register our pipeline. We build a single loop
@@ -969,10 +969,10 @@ TEST_F(LoopPassManagerTest, LoopChildInsertion) {
         NewLoop01LatchBB =
             BasicBlock::Create(Context, "loop.0.1.latch", &F, &Loop02PHBB);
         Loop01BB.getTerminator()->replaceUsesOfWith(&Loop01BB, NewLoop010PHBB);
-        BranchInst::Create(NewLoop010BB, NewLoop010PHBB);
+        UncondBrInst::Create(NewLoop010BB, NewLoop010PHBB);
         CreateCondBr(NewLoop01LatchBB, NewLoop010BB, "cond.0.1.0",
                      NewLoop010BB);
-        BranchInst::Create(&Loop01BB, NewLoop01LatchBB);
+        UncondBrInst::Create(&Loop01BB, NewLoop01LatchBB);
         AR.DT.addNewBlock(NewLoop010PHBB, &Loop01BB);
         AR.DT.addNewBlock(NewLoop010BB, NewLoop010PHBB);
         AR.DT.addNewBlock(NewLoop01LatchBB, NewLoop010BB);
@@ -1012,7 +1012,7 @@ TEST_F(LoopPassManagerTest, LoopChildInsertion) {
         auto *NewLoop011BB = BasicBlock::Create(Context, "loop.0.1.1", &F, NewLoop01LatchBB);
         NewLoop010BB->getTerminator()->replaceUsesOfWith(NewLoop01LatchBB,
                                                          NewLoop011PHBB);
-        BranchInst::Create(NewLoop011BB, NewLoop011PHBB);
+        UncondBrInst::Create(NewLoop011BB, NewLoop011PHBB);
         CreateCondBr(NewLoop01LatchBB, NewLoop011BB, "cond.0.1.1",
                      NewLoop011BB);
         AR.DT.addNewBlock(NewLoop011PHBB, NewLoop010BB);
@@ -1122,7 +1122,7 @@ TEST_F(LoopPassManagerTest, LoopPeerInsertion) {
                           const char *Name, BasicBlock *BB) {
     auto *Cond = new LoadInst(Type::getInt1Ty(Context), &Ptr, Name,
                               /*isVolatile*/ true, BB);
-    BranchInst::Create(TrueBB, FalseBB, Cond, BB);
+    CondBrInst::Create(Cond, TrueBB, FalseBB, BB);
   };
 
   // Build the pass managers and register our pipeline. We build a single loop
@@ -1158,7 +1158,7 @@ TEST_F(LoopPassManagerTest, LoopPeerInsertion) {
         L.getParentLoop()->addChildLoop(NewLoop);
         auto *NewLoop01PHBB = BasicBlock::Create(Context, "loop.0.1.ph", &F, &Loop02PHBB);
         auto *NewLoop01BB = BasicBlock::Create(Context, "loop.0.1", &F, &Loop02PHBB);
-        BranchInst::Create(NewLoop01BB, NewLoop01PHBB);
+        UncondBrInst::Create(NewLoop01BB, NewLoop01PHBB);
         CreateCondBr(&Loop02PHBB, NewLoop01BB, "cond.0.1", NewLoop01BB);
         Loop00BB.getTerminator()->replaceUsesOfWith(&Loop02PHBB, NewLoop01PHBB);
         AR.DT.addNewBlock(NewLoop01PHBB, &Loop00BB);
@@ -1216,13 +1216,13 @@ TEST_F(LoopPassManagerTest, LoopPeerInsertion) {
         auto *NewLoop04LatchBB =
             BasicBlock::Create(Context, "loop.0.4.latch", &F, &Loop0LatchBB);
         Loop02BB.getTerminator()->replaceUsesOfWith(&Loop0LatchBB, NewLoop03PHBB);
-        BranchInst::Create(NewLoop03BB, NewLoop03PHBB);
+        UncondBrInst::Create(NewLoop03BB, NewLoop03PHBB);
         CreateCondBr(NewLoop04PHBB, NewLoop03BB, "cond.0.3", NewLoop03BB);
-        BranchInst::Create(NewLoop04BB, NewLoop04PHBB);
+        UncondBrInst::Create(NewLoop04BB, NewLoop04PHBB);
         CreateCondBr(&Loop0LatchBB, NewLoop040PHBB, "cond.0.4", NewLoop04BB);
-        BranchInst::Create(NewLoop040BB, NewLoop040PHBB);
+        UncondBrInst::Create(NewLoop040BB, NewLoop040PHBB);
         CreateCondBr(NewLoop04LatchBB, NewLoop040BB, "cond.0.4.0", NewLoop040BB);
-        BranchInst::Create(NewLoop04BB, NewLoop04LatchBB);
+        UncondBrInst::Create(NewLoop04BB, NewLoop04LatchBB);
         AR.DT.addNewBlock(NewLoop03PHBB, &Loop02BB);
         AR.DT.addNewBlock(NewLoop03BB, NewLoop03PHBB);
         AR.DT.addNewBlock(NewLoop04PHBB, NewLoop03BB);
@@ -1280,7 +1280,7 @@ TEST_F(LoopPassManagerTest, LoopPeerInsertion) {
         AR.LI.addTopLevelLoop(NewLoop);
         auto *NewLoop1PHBB = BasicBlock::Create(Context, "loop.1.ph", &F, &Loop2BB);
         auto *NewLoop1BB = BasicBlock::Create(Context, "loop.1", &F, &Loop2BB);
-        BranchInst::Create(NewLoop1BB, NewLoop1PHBB);
+        UncondBrInst::Create(NewLoop1BB, NewLoop1PHBB);
         CreateCondBr(&Loop2PHBB, NewLoop1BB, "cond.1", NewLoop1BB);
         Loop0BB.getTerminator()->replaceUsesOfWith(&Loop2PHBB, NewLoop1PHBB);
         AR.DT.addNewBlock(NewLoop1PHBB, &Loop0BB);
@@ -1513,11 +1513,11 @@ TEST_F(LoopPassManagerTest, LoopDeletion) {
                 BasicBlock::Create(Context, "loop.0.3.ph", &F, &Loop0LatchBB);
             auto *NewLoop03BB =
                 BasicBlock::Create(Context, "loop.0.3", &F, &Loop0LatchBB);
-            BranchInst::Create(NewLoop03BB, NewLoop03PHBB);
+            UncondBrInst::Create(NewLoop03BB, NewLoop03PHBB);
             auto *Cond =
                 new LoadInst(Type::getInt1Ty(Context), &Ptr, "cond.0.3",
                              /*isVolatile*/ true, NewLoop03BB);
-            BranchInst::Create(&Loop0LatchBB, NewLoop03BB, Cond, NewLoop03BB);
+            CondBrInst::Create(Cond, &Loop0LatchBB, NewLoop03BB, NewLoop03BB);
             Loop02PHBB.getTerminator()->replaceUsesOfWith(&Loop0LatchBB,
                                                           NewLoop03PHBB);
             AR.DT.addNewBlock(NewLoop03PHBB, &Loop02PHBB);


### PR DESCRIPTION
I ended up relaxing some of the checks that LoopInterchange made, the assumptions that certain instructions were branches seemed to not be used at all.