### PR TITLE
[AArch64][AsmParser] Add MC support for %dtprel() relocation

### DIFF
--- a/llvm/lib/Target/AArch64/AsmParser/AArch64AsmParser.cpp
+++ b/llvm/lib/Target/AArch64/AsmParser/AArch64AsmParser.cpp
@@ -4659,6 +4659,7 @@ bool AArch64AsmParser::parseSymbolicImmVal(const MCExpr *&ImmVal) {
                   .Case("prel_g1_nc", AArch64::S_PREL_G1_NC)
                   .Case("prel_g0", AArch64::S_PREL_G0)
                   .Case("prel_g0_nc", AArch64::S_PREL_G0_NC)
+                  .Case("dtprel", AArch64::S_DTPREL)
                   .Case("dtprel_g2", AArch64::S_DTPREL_G2)
                   .Case("dtprel_g1", AArch64::S_DTPREL_G1)
                   .Case("dtprel_g1_nc", AArch64::S_DTPREL_G1_NC)

--- a/llvm/lib/Target/AArch64/MCTargetDesc/AArch64ELFObjectWriter.cpp
+++ b/llvm/lib/Target/AArch64/MCTargetDesc/AArch64ELFObjectWriter.cpp
@@ -249,6 +249,8 @@ unsigned AArch64ELFObjectWriter::getRelocType(const MCFixup &Fixup,
       }
       if (RefKind == AArch64::S_AUTH || RefKind == AArch64::S_AUTHADDR)
         return ELF::R_AARCH64_AUTH_ABS64;
+      if (RefKind == AArch64::S_DTPREL)
+        return ELF::R_AARCH64_TLS_DTPREL64;
       if (RefKind == AArch64::S_FUNCINIT)
         return ELF::R_AARCH64_FUNCINIT64;
       return ELF::R_AARCH64_ABS64;
@@ -465,6 +467,8 @@ unsigned AArch64ELFObjectWriter::getRelocType(const MCFixup &Fixup,
         return R_CLS(MOVW_PREL_G0);
       if (RefKind == AArch64::S_PREL_G0_NC)
         return R_CLS(MOVW_PREL_G0_NC);
+      if (RefKind == AArch64::S_DTPREL)
+        return ELF::R_AARCH64_TLS_DTPREL64;
       if (RefKind == AArch64::S_DTPREL_G2)
         return ELF::R_AARCH64_TLSLD_MOVW_DTPREL_G2;
       if (RefKind == AArch64::S_DTPREL_G1)

--- a/llvm/lib/Target/AArch64/MCTargetDesc/AArch64MCAsmInfo.cpp
+++ b/llvm/lib/Target/AArch64/MCTargetDesc/AArch64MCAsmInfo.cpp
@@ -114,6 +114,7 @@ StringRef AArch64::getSpecifierName(AArch64::Specifier S) {
 
   case AArch64::S_GOTPCREL:            return "%gotpcrel";
   case AArch64::S_PLT:                 return "%pltpcrel";
+  case AArch64::S_DTPREL:              return "%dtprel";
   case AArch64::S_FUNCINIT:            return "%funcinit";
   default:
     llvm_unreachable("Invalid relocation specifier");
@@ -125,6 +126,7 @@ AArch64::Specifier AArch64::parsePercentSpecifierName(StringRef name) {
   return StringSwitch<AArch64::Specifier>(name)
       .Case("pltpcrel", AArch64::S_PLT)
       .Case("gotpcrel", AArch64::S_GOTPCREL)
+      .Case("dtprel", AArch64::S_DTPREL)
       .Case("funcinit", AArch64::S_FUNCINIT)
       .Default(0);
 }

--- a/llvm/test/MC/AArch64/tls-dtprel64.s
+++ b/llvm/test/MC/AArch64/tls-dtprel64.s
@@ -2,40 +2,26 @@
 // RUN: llvm-mc -filetype=obj -triple=aarch64 %s | llvm-readobj -r - | FileCheck --check-prefix=CHECK-ELF %s
 
 # CHECK: .xword %dtprel(var)
+# CHECK: .xword	%dtprel(var+1)
+# CHECK: .xword	%dtprel(.tdata)
+# CHECK: .xword	%dtprel(.tdata+1)
 
 # CHECK-ELF: Relocations [
-# CHECK-ELF:   Section {{.*}} .rela.debug_info {
-# CHECK-ELF:     0x{{[0-9A-F]+}} R_AARCH64_TLS_DTPREL64 var {{.*}}
+# CHECK-ELF:   Section (5) .rela.debug_info {
+# CHECK-ELF:     0x0 R_AARCH64_TLS_DTPREL64 var 0x0
+# CHECK-ELF:     0x8 R_AARCH64_TLS_DTPREL64 var 0x1
+# CHECK-ELF:     0x10 R_AARCH64_TLS_DTPREL64 .tdata 0x0
+# CHECK-ELF:     0x18 R_AARCH64_TLS_DTPREL64 .tdata 0x1
 # CHECK-ELF:   }
 
 .section .tdata,"awT",@progbits
+.skip 8
 .globl var
 var:
   .word 0
 
-.section .debug_abbrev,"",@progbits
-.byte 1                  // Abbreviation Code
-.byte 17                 // DW_TAG_compile_unit
-.byte 1                  // DW_CHILDREN_yes
-.byte 0                  // EOM(1)
-.byte 0                  // EOM(2)
-
-.byte 2                  // Abbreviation Code
-.byte 52                 // DW_TAG_variable
-.byte 0                  // DW_CHILDREN_no
-.byte 2;                 // DW_AT_location
-.byte 24                 // DW_FORM_exprloc
-.byte 0                  // EOM(1)
-.byte 0                  // EOM(2)
-
 .section        .debug_info,"",@progbits
-.Lcu_begin0:
-  .word .Lcu_end - .Lcu_body // Length of Unit
-.Lcu_body:
-  .hword 4               // DWARF version number
-  .word   .debug_abbrev  // Offset Into Abbrev. Section
-  .byte   8              // Address Size (in bytes)
-  .byte   1              // Abbrev [1] DW_TAG_compile_unit
-  .byte   2              // Abbrev [2] DW_TAG_variable
   .xword  %dtprel(var)
-.Lcu_end:
+  .xword  %dtprel(var+1)
+  .xword  %dtprel(.tdata)
+  .xword  %dtprel(.tdata+1)

--- a/llvm/test/MC/AArch64/tls-dtprel64.s
+++ b/llvm/test/MC/AArch64/tls-dtprel64.s
@@ -1,0 +1,41 @@
+// RUN: llvm-mc -triple=aarch64 -show-encoding < %s | FileCheck %s
+// RUN: llvm-mc -filetype=obj -triple=aarch64 %s | llvm-readobj -r - | FileCheck --check-prefix=CHECK-ELF %s
+
+# CHECK: .xword %dtprel(var)
+
+# CHECK-ELF: Relocations [
+# CHECK-ELF:   Section {{.*}} .rela.debug_info {
+# CHECK-ELF:     0x{{[0-9A-F]+}} R_AARCH64_TLS_DTPREL64 var {{.*}}
+# CHECK-ELF:   }
+
+.section .tdata,"awT",@progbits
+.globl var
+var:
+  .word 0
+
+.section .debug_abbrev,"",@progbits
+.byte 1                  // Abbreviation Code
+.byte 17                 // DW_TAG_compile_unit
+.byte 1                  // DW_CHILDREN_yes
+.byte 0                  // EOM(1)
+.byte 0                  // EOM(2)
+
+.byte 2                  // Abbreviation Code
+.byte 52                 // DW_TAG_variable
+.byte 0                  // DW_CHILDREN_no
+.byte 2;                 // DW_AT_location
+.byte 24                 // DW_FORM_exprloc
+.byte 0                  // EOM(1)
+.byte 0                  // EOM(2)
+
+.section        .debug_info,"",@progbits
+.Lcu_begin0:
+  .word .Lcu_end - .Lcu_body // Length of Unit
+.Lcu_body:
+  .hword 4               // DWARF version number
+  .word   .debug_abbrev  // Offset Into Abbrev. Section
+  .byte   8              // Address Size (in bytes)
+  .byte   1              // Abbrev [1] DW_TAG_compile_unit
+  .byte   2              // Abbrev [2] DW_TAG_variable
+  .xword  %dtprel(var)
+.Lcu_end:


### PR DESCRIPTION
This patch adds support for the %dtprel relocation specifier in the AArch64 assembler. This specifier is used to generate the R_AARCH64_TLS_DTPREL64 relocation, which is used in .debug_info sections to describe the location of thread-local variables.

Prerequisite for  https://github.com/llvm/llvm-project/pull/146572 