### PR TITLE
[IR][NFC] Remove BranchInst successor functions

### DIFF
--- a/llvm/include/llvm/IR/Instructions.h
+++ b/llvm/include/llvm/IR/Instructions.h
@@ -3105,18 +3105,6 @@ public:
   Value *getCondition() const;
   void setCondition(Value *V);
 
-  unsigned getNumSuccessors() const { return 1+isConditional(); }
-
-  BasicBlock *getSuccessor(unsigned i) const {
-    assert(i < getNumSuccessors() && "Successor # out of range for Branch!");
-    return cast_or_null<BasicBlock>((&Op<-1>() - i)->get());
-  }
-
-  void setSuccessor(unsigned idx, BasicBlock *NewSucc) {
-    assert(idx < getNumSuccessors() && "Successor # out of range for Branch!");
-    *(&Op<-1>() - idx) = NewSucc;
-  }
-
   /// Swap the successors of this branch instruction.
   ///
   /// Swaps the successors of the branch instruction. This also swaps any


### PR DESCRIPTION
The efficient access is now handled by UncondBrInst/CondBrInst, Instruction functions handle the more generic cases. These functions are now largely unused now that most uses of BranchInst are gone.

Preliminary work for making the CondBrInst operand order consistent.