### PR TITLE
[LLVM] Change IRBuilder::CreateAggregateRet to accept an ArrayRef

### DIFF
--- a/llvm/include/llvm/IR/IRBuilder.h
+++ b/llvm/include/llvm/IR/IRBuilder.h
@@ -1176,18 +1176,21 @@ public:
     return Insert(ReturnInst::Create(Context, V));
   }
 
-  /// Create a sequence of N insertvalue instructions,
-  /// with one Value from the retVals array each, that build a aggregate
-  /// return value one value at a time, and a ret instruction to return
-  /// the resulting aggregate value.
+  /// Create a sequence of N insertvalue instructions, with one Value from the
+  /// RetVals array each, that build a aggregate return value one value at a
+  /// time, and a ret instruction to return the resulting aggregate value.
   ///
   /// This is a convenience function for code that uses aggregate return values
   /// as a vehicle for having multiple return values.
-  ReturnInst *CreateAggregateRet(Value *const *retVals, unsigned N) {
+  ReturnInst *CreateAggregateRet(ArrayRef<Value *> RetVals) {
     Value *V = PoisonValue::get(getCurrentFunctionReturnType());
-    for (unsigned i = 0; i != N; ++i)
-      V = CreateInsertValue(V, retVals[i], i, "mrv");
+    for (size_t i = 0, N = RetVals.size(); i != N; ++i)
+      V = CreateInsertValue(V, RetVals[i], i, "mrv");
     return Insert(ReturnInst::Create(Context, V));
+  }
+
+  ReturnInst *CreateAggregateRet(Value *const *RetVals, unsigned N) {
+    return CreateAggregateRet({RetVals, N});
   }
 
   /// Create an unconditional 'br label X' instruction.

--- a/llvm/include/llvm/IR/IRBuilder.h
+++ b/llvm/include/llvm/IR/IRBuilder.h
@@ -1189,10 +1189,6 @@ public:
     return Insert(ReturnInst::Create(Context, V));
   }
 
-  ReturnInst *CreateAggregateRet(Value *const *RetVals, unsigned N) {
-    return CreateAggregateRet({RetVals, N});
-  }
-
   /// Create an unconditional 'br label X' instruction.
   UncondBrInst *CreateBr(BasicBlock *Dest) {
     return Insert(UncondBrInst::Create(Dest));

--- a/llvm/lib/IR/Core.cpp
+++ b/llvm/lib/IR/Core.cpp
@@ -3486,7 +3486,7 @@ LLVMValueRef LLVMBuildRet(LLVMBuilderRef B, LLVMValueRef V) {
 
 LLVMValueRef LLVMBuildAggregateRet(LLVMBuilderRef B, LLVMValueRef *RetVals,
                                    unsigned N) {
-  return wrap(unwrap(B)->CreateAggregateRet(unwrap(RetVals), N));
+  return wrap(unwrap(B)->CreateAggregateRet({unwrap(RetVals), N}));
 }
 
 LLVMValueRef LLVMBuildBr(LLVMBuilderRef B, LLVMBasicBlockRef Dest) {

--- a/llvm/unittests/IR/IRBuilderTest.cpp
+++ b/llvm/unittests/IR/IRBuilderTest.cpp
@@ -1418,7 +1418,7 @@ TEST_F(IRBuilderTest, finalizeSubprogram) {
 
 TEST_F(IRBuilderTest, CreateAggregateRet) {
   IRBuilder<> Builder(BB);
-  // Terminate the function/block created in SetUp()
+  // Terminate the function/block created in SetUp.
   Builder.CreateRetVoid();
 
   Type *AggType =
@@ -1428,22 +1428,11 @@ TEST_F(IRBuilderTest, CreateAggregateRet) {
 
   FunctionType *FTy = FunctionType::get(AggType, /*isVarArg=*/false);
 
-  {
-    Function *F1 =
-        Function::Create(FTy, Function::ExternalLinkage, "F1", M.get());
-    BasicBlock *CalleeBB = BasicBlock::Create(Ctx, "", F1);
-    IRBuilder<> CalleeBuilder(CalleeBB);
-    Value *RVs[] = {RV0, RV1};
-    CalleeBuilder.CreateAggregateRet(RVs, 2);
-  }
-
-  {
-    Function *F2 =
-        Function::Create(FTy, Function::ExternalLinkage, "F2", M.get());
-    BasicBlock *CalleeBB = BasicBlock::Create(Ctx, "", F2);
-    IRBuilder<> CalleeBuilder(CalleeBB);
-    CalleeBuilder.CreateAggregateRet({RV0, RV1});
-  }
+  Function *F1 =
+      Function::Create(FTy, Function::ExternalLinkage, "F2", M.get());
+  BasicBlock *CalleeBB = BasicBlock::Create(Ctx, "", F1);
+  IRBuilder<> CalleeBuilder(CalleeBB);
+  CalleeBuilder.CreateAggregateRet({RV0, RV1});
 
   EXPECT_FALSE(verifyModule(*M));
 }

--- a/llvm/unittests/IR/IRBuilderTest.cpp
+++ b/llvm/unittests/IR/IRBuilderTest.cpp
@@ -1415,4 +1415,36 @@ TEST_F(IRBuilderTest, finalizeSubprogram) {
   EXPECT_EQ(BarSP->getRetainedNodes()[0], Type);
   EXPECT_TRUE(FooSP->getRetainedNodes().empty());
 }
+
+TEST_F(IRBuilderTest, CreateAggregateRet) {
+  IRBuilder<> Builder(BB);
+  // Terminate the function/block created in SetUp()
+  Builder.CreateRetVoid();
+
+  Type *AggType =
+      StructType::create(Ctx, {Builder.getInt8Ty(), Builder.getInt64Ty()});
+  ConstantInt *RV0 = Builder.getInt8(5);
+  ConstantInt *RV1 = Builder.getInt64(55);
+
+  FunctionType *FTy = FunctionType::get(AggType, /*isVarArg=*/false);
+
+  {
+    Function *F1 =
+        Function::Create(FTy, Function::ExternalLinkage, "F1", M.get());
+    BasicBlock *CalleeBB = BasicBlock::Create(Ctx, "", F1);
+    IRBuilder<> CalleeBuilder(CalleeBB);
+    Value *RVs[] = {RV0, RV1};
+    CalleeBuilder.CreateAggregateRet(RVs, 2);
+  }
+
+  {
+    Function *F2 =
+        Function::Create(FTy, Function::ExternalLinkage, "F2", M.get());
+    BasicBlock *CalleeBB = BasicBlock::Create(Ctx, "", F2);
+    IRBuilder<> CalleeBuilder(CalleeBB);
+    CalleeBuilder.CreateAggregateRet({RV0, RV1});
+  }
+
+  EXPECT_FALSE(verifyModule(*M));
+}
 }


### PR DESCRIPTION
Change  `IRBuilder::CreateAggregateRet()` to accept an `ArrayRef` instead of a pointer and size, and extend IRBuilder unit test to exercise it.