### PR TITLE
[IR] Add Instruction::successors()

### DIFF
--- a/llvm/include/llvm/IR/Instruction.h
+++ b/llvm/include/llvm/IR/Instruction.h
@@ -71,6 +71,36 @@ public:
   using InstListType = SymbolTableList<Instruction, ilist_iterator_bits<true>,
                                        ilist_parent<BasicBlock>>;
 
+  /// Iterator type that casts an operand to a basic block.
+  ///
+  /// All terminators store successors as adjacent operands.
+  struct succ_iterator
+      : iterator_adaptor_base<succ_iterator, op_iterator,
+                              std::random_access_iterator_tag, BasicBlock *,
+                              ptrdiff_t, BasicBlock *, BasicBlock *> {
+    explicit succ_iterator(op_iterator I) : iterator_adaptor_base(I) {}
+
+    BasicBlock *operator*() const { return cast<BasicBlock>(*I); }
+    BasicBlock *operator->() const { return operator*(); }
+
+    op_iterator getUse() const { return I; }
+  };
+
+  /// The const version of `succ_iterator`.
+  struct const_succ_iterator
+      : iterator_adaptor_base<const_succ_iterator, const_op_iterator,
+                              std::random_access_iterator_tag,
+                              const BasicBlock *, ptrdiff_t, const BasicBlock *,
+                              const BasicBlock *> {
+    explicit const_succ_iterator(const_op_iterator I)
+        : iterator_adaptor_base(I) {}
+
+    const BasicBlock *operator*() const { return cast<BasicBlock>(*I); }
+    const BasicBlock *operator->() const { return operator*(); }
+
+    const_op_iterator getUse() const { return I; }
+  };
+
 private:
   DebugLoc DbgLoc;                         // 'dbg' Metadata cache.
 
@@ -974,6 +1004,14 @@ public:
   /// Update the specified successor to point at the provided block. This
   /// instruction must be a terminator.
   LLVM_ABI void setSuccessor(unsigned Idx, BasicBlock *BB);
+
+  LLVM_ABI iterator_range<const_succ_iterator> successors() const LLVM_READONLY;
+  LLVM_ABI iterator_range<succ_iterator> successors() {
+    auto Ops = static_cast<const Instruction *>(this)->successors();
+    Use *Begin = const_cast<Use *>(Ops.begin().getUse());
+    Use *End = const_cast<Use *>(Ops.end().getUse());
+    return make_range(succ_iterator(Begin), succ_iterator(End));
+  }
 
   /// Replace specified successor OldBB to point at the provided block.
   /// This instruction must be a terminator.

--- a/llvm/include/llvm/IR/Instructions.h
+++ b/llvm/include/llvm/IR/Instructions.h
@@ -3023,6 +3023,13 @@ public:
     return getNumOperands() != 0 ? getOperand(0) : nullptr;
   }
 
+  iterator_range<succ_iterator> successors() {
+    return {succ_iterator(op_end()), succ_iterator(op_end())};
+  }
+  iterator_range<const_succ_iterator> successors() const {
+    return {const_succ_iterator(op_end()), const_succ_iterator(op_end())};
+  }
+
   unsigned getNumSuccessors() const { return 0; }
 
   // Methods for support type inquiry through isa, cast, and dyn_cast:
@@ -3062,33 +3069,6 @@ protected:
       : Instruction(Ty, Opcode, AllocInfo, InsertBefore) {}
 
 public:
-  /// Iterator type that casts an operand to a basic block.
-  ///
-  /// This only makes sense because the successors are stored as adjacent
-  /// operands for branch instructions.
-  struct succ_op_iterator
-      : iterator_adaptor_base<succ_op_iterator, value_op_iterator,
-                              std::random_access_iterator_tag, BasicBlock *,
-                              ptrdiff_t, BasicBlock *, BasicBlock *> {
-    explicit succ_op_iterator(value_op_iterator I) : iterator_adaptor_base(I) {}
-
-    BasicBlock *operator*() const { return cast<BasicBlock>(*I); }
-    BasicBlock *operator->() const { return operator*(); }
-  };
-
-  /// The const version of `succ_op_iterator`.
-  struct const_succ_op_iterator
-      : iterator_adaptor_base<const_succ_op_iterator, const_value_op_iterator,
-                              std::random_access_iterator_tag,
-                              const BasicBlock *, ptrdiff_t, const BasicBlock *,
-                              const BasicBlock *> {
-    explicit const_succ_op_iterator(const_value_op_iterator I)
-        : iterator_adaptor_base(I) {}
-
-    const BasicBlock *operator*() const { return cast<BasicBlock>(*I); }
-    const BasicBlock *operator->() const { return operator*(); }
-  };
-
   static BranchInst *Create(BasicBlock *IfTrue,
                             InsertPosition InsertBefore = nullptr);
 
@@ -3123,18 +3103,6 @@ public:
   /// branch weight metadata associated with the instruction so that it
   /// continues to map correctly to each operand.
   void swapSuccessors();
-
-  iterator_range<succ_op_iterator> successors() {
-    return make_range(
-        succ_op_iterator(std::next(value_op_begin(), isConditional() ? 1 : 0)),
-        succ_op_iterator(value_op_end()));
-  }
-
-  iterator_range<const_succ_op_iterator> successors() const {
-    return make_range(const_succ_op_iterator(
-                          std::next(value_op_begin(), isConditional() ? 1 : 0)),
-                      const_succ_op_iterator(value_op_end()));
-  }
 
   // Methods for support type inquiry through isa, cast, and dyn_cast:
   static bool classof(const Instruction *I) {
@@ -3202,14 +3170,13 @@ public:
     Op<-1>() = NewSucc;
   }
 
-  iterator_range<succ_op_iterator> successors() {
-    return make_range(succ_op_iterator(value_op_begin()),
-                      succ_op_iterator(value_op_end()));
+  iterator_range<succ_iterator> successors() {
+    return make_range(succ_iterator(op_begin()), succ_iterator(op_end()));
   }
 
-  iterator_range<const_succ_op_iterator> successors() const {
-    return make_range(const_succ_op_iterator(value_op_begin()),
-                      const_succ_op_iterator(value_op_end()));
+  iterator_range<const_succ_iterator> successors() const {
+    return make_range(const_succ_iterator(op_begin()),
+                      const_succ_iterator(op_end()));
   }
 
   // Methods for support type inquiry through isa, cast, and dyn_cast:
@@ -3286,14 +3253,14 @@ public:
   /// continues to map correctly to each operand.
   LLVM_ABI void swapSuccessors();
 
-  iterator_range<succ_op_iterator> successors() {
-    return make_range(succ_op_iterator(std::next(value_op_begin())),
-                      succ_op_iterator(value_op_end()));
+  iterator_range<succ_iterator> successors() {
+    return make_range(succ_iterator(std::next(op_begin())),
+                      succ_iterator(op_end()));
   }
 
-  iterator_range<const_succ_op_iterator> successors() const {
-    return make_range(const_succ_op_iterator(std::next(value_op_begin())),
-                      const_succ_op_iterator(value_op_end()));
+  iterator_range<const_succ_iterator> successors() const {
+    return make_range(const_succ_iterator(std::next(op_begin())),
+                      const_succ_iterator(op_end()));
   }
 
   // Methods for support type inquiry through isa, cast, and dyn_cast:
@@ -3675,6 +3642,13 @@ public:
   /// case.
   LLVM_ABI CaseIt removeCase(CaseIt I);
 
+  iterator_range<succ_iterator> successors() {
+    return make_range(std::next(op_begin()), op_end());
+  }
+  iterator_range<const_succ_iterator> successors() const {
+    return make_range(std::next(op_begin()), op_end());
+  }
+
   unsigned getNumSuccessors() const { return getNumOperands() - 1; }
   BasicBlock *getSuccessor(unsigned idx) const {
     assert(idx < getNumSuccessors() &&"Successor idx out of range for switch!");
@@ -3783,33 +3757,6 @@ protected:
 public:
   void operator delete(void *Ptr) { User::operator delete(Ptr, AllocMarker); }
 
-  /// Iterator type that casts an operand to a basic block.
-  ///
-  /// This only makes sense because the successors are stored as adjacent
-  /// operands for indirectbr instructions.
-  struct succ_op_iterator
-      : iterator_adaptor_base<succ_op_iterator, value_op_iterator,
-                              std::random_access_iterator_tag, BasicBlock *,
-                              ptrdiff_t, BasicBlock *, BasicBlock *> {
-    explicit succ_op_iterator(value_op_iterator I) : iterator_adaptor_base(I) {}
-
-    BasicBlock *operator*() const { return cast<BasicBlock>(*I); }
-    BasicBlock *operator->() const { return operator*(); }
-  };
-
-  /// The const version of `succ_op_iterator`.
-  struct const_succ_op_iterator
-      : iterator_adaptor_base<const_succ_op_iterator, const_value_op_iterator,
-                              std::random_access_iterator_tag,
-                              const BasicBlock *, ptrdiff_t, const BasicBlock *,
-                              const BasicBlock *> {
-    explicit const_succ_op_iterator(const_value_op_iterator I)
-        : iterator_adaptor_base(I) {}
-
-    const BasicBlock *operator*() const { return cast<BasicBlock>(*I); }
-    const BasicBlock *operator->() const { return operator*(); }
-  };
-
   static IndirectBrInst *Create(Value *Address, unsigned NumDests,
                                 InsertPosition InsertBefore = nullptr) {
     return new IndirectBrInst(Address, NumDests, InsertBefore);
@@ -3847,14 +3794,14 @@ public:
     setOperand(i + 1, NewSucc);
   }
 
-  iterator_range<succ_op_iterator> successors() {
-    return make_range(succ_op_iterator(std::next(value_op_begin())),
-                      succ_op_iterator(value_op_end()));
+  iterator_range<succ_iterator> successors() {
+    return make_range(succ_iterator(std::next(op_begin())),
+                      succ_iterator(op_end()));
   }
 
-  iterator_range<const_succ_op_iterator> successors() const {
-    return make_range(const_succ_op_iterator(std::next(value_op_begin())),
-                      const_succ_op_iterator(value_op_end()));
+  iterator_range<const_succ_iterator> successors() const {
+    return make_range(const_succ_iterator(std::next(op_begin())),
+                      const_succ_iterator(op_end()));
   }
 
   // Methods for support type inquiry through isa, cast, and dyn_cast:
@@ -4001,6 +3948,15 @@ public:
   }
 
   unsigned getNumSuccessors() const { return 2; }
+
+  iterator_range<succ_iterator> successors() {
+    Use *First = &Op<NormalDestOpEndIdx>();
+    return {succ_iterator(First), succ_iterator(First + 2)};
+  }
+  iterator_range<const_succ_iterator> successors() const {
+    const Use *First = &Op<NormalDestOpEndIdx>();
+    return {const_succ_iterator(First), const_succ_iterator(First + 2)};
+  }
 
   /// Updates profile metadata by scaling it by \p S / \p T.
   LLVM_ABI void updateProfWeight(uint64_t S, uint64_t T);
@@ -4179,6 +4135,15 @@ public:
 
   unsigned getNumSuccessors() const { return getNumIndirectDests() + 1; }
 
+  iterator_range<succ_iterator> successors() {
+    Use *First = &Op<-1>() - getNumIndirectDests() - 1;
+    return {succ_iterator(First), succ_iterator(&Op<-1>())};
+  }
+  iterator_range<const_succ_iterator> successors() const {
+    const Use *First = &Op<-1>() - getNumIndirectDests() - 1;
+    return {const_succ_iterator(First), const_succ_iterator(&Op<-1>())};
+  }
+
   // Methods for support type inquiry through isa, cast, and dyn_cast:
   static bool classof(const Instruction *I) {
     return (I->getOpcode() == Instruction::CallBr);
@@ -4255,6 +4220,13 @@ private:
 
   void setSuccessor(unsigned idx, BasicBlock *NewSucc) {
     llvm_unreachable("ResumeInst has no successors!");
+  }
+
+  iterator_range<succ_iterator> successors() {
+    return {succ_iterator(op_end()), succ_iterator(op_end())};
+  }
+  iterator_range<const_succ_iterator> successors() const {
+    return {const_succ_iterator(op_end()), const_succ_iterator(op_end())};
   }
 };
 
@@ -4418,6 +4390,14 @@ public:
     setOperand(Idx + 1, NewSucc);
   }
 
+  iterator_range<succ_iterator> successors() {
+    return {succ_iterator(std::next(op_begin())), succ_iterator(op_end())};
+  }
+  iterator_range<const_succ_iterator> successors() const {
+    return {const_succ_iterator(std::next(op_begin())),
+            const_succ_iterator(op_end())};
+  }
+
   // Methods for support type inquiry through isa, cast, and dyn_cast:
   static bool classof(const Instruction *I) {
     return I->getOpcode() == Instruction::CatchSwitch;
@@ -4567,6 +4547,14 @@ private:
     assert(Idx < getNumSuccessors() && "Successor # out of range for catchret!");
     setSuccessor(B);
   }
+
+  iterator_range<succ_iterator> successors() {
+    return {succ_iterator(std::next(op_begin())), succ_iterator(op_end())};
+  }
+  iterator_range<const_succ_iterator> successors() const {
+    return {const_succ_iterator(std::next(op_begin())),
+            const_succ_iterator(op_end())};
+  }
 };
 
 template <>
@@ -4654,6 +4642,14 @@ private:
     setUnwindDest(B);
   }
 
+  iterator_range<succ_iterator> successors() {
+    return {succ_iterator(std::next(op_begin())), succ_iterator(op_end())};
+  }
+  iterator_range<const_succ_iterator> successors() const {
+    return {const_succ_iterator(std::next(op_begin())),
+            const_succ_iterator(op_end())};
+  }
+
   // Shadow Instruction::setInstructionSubclassData with a private forwarding
   // method so that subclasses cannot accidentally use it.
   template <typename Bitfield>
@@ -4715,6 +4711,13 @@ private:
 
   void setSuccessor(unsigned idx, BasicBlock *B) {
     llvm_unreachable("UnreachableInst has no successors!");
+  }
+
+  iterator_range<succ_iterator> successors() {
+    return {succ_iterator(op_end()), succ_iterator(op_end())};
+  }
+  iterator_range<const_succ_iterator> successors() const {
+    return {const_succ_iterator(op_end()), const_succ_iterator(op_end())};
   }
 };
 

--- a/llvm/include/llvm/SandboxIR/Instruction.h
+++ b/llvm/include/llvm/SandboxIR/Instruction.h
@@ -1061,9 +1061,9 @@ private:
 
 public:
   using sb_succ_op_iterator =
-      mapped_iterator<llvm::BranchInst::succ_op_iterator, LLVMBBToSBBB>;
+      mapped_iterator<llvm::BranchInst::succ_iterator, LLVMBBToSBBB>;
   iterator_range<sb_succ_op_iterator> successors() {
-    iterator_range<llvm::BranchInst::succ_op_iterator> LLVMRange =
+    iterator_range<llvm::BranchInst::succ_iterator> LLVMRange =
         cast<llvm::BranchInst>(Val)->successors();
     LLVMBBToSBBB BBMap(Ctx);
     sb_succ_op_iterator MappedBegin = map_iterator(LLVMRange.begin(), BBMap);
@@ -1072,10 +1072,9 @@ public:
   }
 
   using const_sb_succ_op_iterator =
-      mapped_iterator<llvm::BranchInst::const_succ_op_iterator,
-                      ConstLLVMBBToSBBB>;
+      mapped_iterator<llvm::BranchInst::const_succ_iterator, ConstLLVMBBToSBBB>;
   iterator_range<const_sb_succ_op_iterator> successors() const {
-    iterator_range<llvm::BranchInst::const_succ_op_iterator> ConstLLVMRange =
+    iterator_range<llvm::BranchInst::const_succ_iterator> ConstLLVMRange =
         static_cast<const llvm::BranchInst *>(cast<llvm::BranchInst>(Val))
             ->successors();
     ConstLLVMBBToSBBB ConstBBMap(Ctx);

--- a/llvm/lib/IR/Instruction.cpp
+++ b/llvm/lib/IR/Instruction.cpp
@@ -1352,11 +1352,24 @@ void Instruction::setSuccessor(unsigned idx, BasicBlock *B) {
   llvm_unreachable("not a terminator");
 }
 
+iterator_range<Instruction::const_succ_iterator>
+Instruction::successors() const {
+  switch (getOpcode()) {
+#define HANDLE_TERM_INST(N, OPC, CLASS)                                        \
+  case Instruction::OPC:                                                       \
+    return static_cast<const CLASS *>(this)->successors();
+#include "llvm/IR/Instruction.def"
+  default:
+    break;
+  }
+  llvm_unreachable("not a terminator");
+}
+
 void Instruction::replaceSuccessorWith(BasicBlock *OldBB, BasicBlock *NewBB) {
-  for (unsigned Idx = 0, NumSuccessors = Instruction::getNumSuccessors();
-       Idx != NumSuccessors; ++Idx)
-    if (getSuccessor(Idx) == OldBB)
-      setSuccessor(Idx, NewBB);
+  auto Succs = successors();
+  for (auto I = Succs.begin(), E = Succs.end(); I != E; ++I)
+    if (*I == OldBB)
+      I.getUse()->set(NewBB);
 }
 
 Instruction *Instruction::cloneImpl() const {


### PR DESCRIPTION
Nowadays all terminators store all successor operands consecutively, so we can expose the range of successors through a unified interface.

Rename succ_op_iterator to succ_iterator for consistency, also with Machine IR.

Preliminary work for replacing the succ_iterator in CFG.h with an iterator that iterates directly over the uses.