### PR TITLE
[VPlan] Detect simple integer inductions in VPlan. (NFC)

### DIFF
--- a/llvm/include/llvm/Analysis/IVDescriptors.h
+++ b/llvm/include/llvm/Analysis/IVDescriptors.h
@@ -439,12 +439,11 @@ public:
   /// SCEV overflow check.
   ArrayRef<Instruction *> getCastInsts() const { return RedundantCasts; }
 
-private:
-  /// Private constructor - used by \c isInductionPHI.
   InductionDescriptor(Value *Start, InductionKind K, const SCEV *Step,
                       BinaryOperator *InductionBinOp = nullptr,
                       SmallVectorImpl<Instruction *> *Casts = nullptr);
 
+private:
   /// Start value.
   TrackingVH<Value> StartValue;
   /// Induction kind.

--- a/llvm/lib/Transforms/Vectorize/VPlan.h
+++ b/llvm/lib/Transforms/Vectorize/VPlan.h
@@ -2338,7 +2338,7 @@ protected:
 /// VPWidenPointerInductionRecipe), providing shared functionality, including
 /// retrieving the step value, induction descriptor and original phi node.
 class VPWidenInductionRecipe : public VPHeaderPHIRecipe {
-  const InductionDescriptor &IndDesc;
+  InductionDescriptor IndDesc;
 
 public:
   VPWidenInductionRecipe(unsigned char Kind, PHINode *IV, VPValue *Start,

--- a/llvm/lib/Transforms/Vectorize/VPlanConstruction.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanConstruction.cpp
@@ -25,6 +25,7 @@
 #include "llvm/Analysis/OptimizationRemarkEmitter.h"
 #include "llvm/Analysis/ScalarEvolution.h"
 #include "llvm/Analysis/ScalarEvolutionExpressions.h"
+#include "llvm/Analysis/ScalarEvolutionPatternMatch.h"
 #include "llvm/Analysis/TargetTransformInfo.h"
 #include "llvm/IR/InstrTypes.h"
 #include "llvm/IR/MDBuilder.h"
@@ -35,6 +36,7 @@
 
 using namespace llvm;
 using namespace VPlanPatternMatch;
+using namespace SCEVPatternMatch;
 
 namespace {
 // Class that is used to build the plain CFG for the incoming IR.
@@ -705,8 +707,8 @@ void VPlanTransforms::createHeaderPhiRecipes(
   // Retrieve the header manually from the intial plain-CFG VPlan.
   VPBasicBlock *HeaderVPBB = cast<VPBasicBlock>(
       Plan.getEntry()->getSuccessors()[1]->getSingleSuccessor());
-  assert(VPDominatorTree(Plan).dominates(HeaderVPBB,
-                                         HeaderVPBB->getPredecessors()[1]) &&
+  VPDominatorTree VPDT(Plan);
+  assert(VPDT.dominates(HeaderVPBB, HeaderVPBB->getPredecessors()[1]) &&
          "header must dominate its latch");
 
   auto CreateHeaderPhiRecipe = [&](VPPhi *PhiR) -> VPHeaderPHIRecipe * {
@@ -728,6 +730,33 @@ void VPlanTransforms::createHeaderPhiRecipes(
       return new VPFirstOrderRecurrencePHIRecipe(Phi, *Start, *BackedgeValue);
     }
 
+    // Try VPlan-based induction detection for integer inductions.
+    const SCEV *StartSCEV, *StepSCEV;
+    if (!Reductions.contains(Phi) &&
+        match(vputils::getSCEVExprForVPValue(PhiR, PSE, &OrigLoop, &VPDT),
+              m_scev_AffineAddRec(m_SCEV(StartSCEV), m_SCEV(StepSCEV)))) {
+      BinaryOperator *BOp =
+          dyn_cast<BinaryOperator>(BackedgeValue->getUnderlyingValue());
+      InductionDescriptor IndDesc(Start->getValue(),
+                                  InductionDescriptor::IK_IntInduction,
+                                  StepSCEV, BOp);
+      ScalarEvolution &SE = *PSE.getSE();
+      assert([&]() {
+        if (!Inductions.contains(Phi))
+          return true;
+        const auto &Exp = Inductions.lookup(Phi);
+        return Exp.getKind() == IndDesc.getKind() &&
+               PSE.getPredicatedSCEV(Exp.getStep()) == IndDesc.getStep() &&
+               Exp.getInductionBinOp() == IndDesc.getInductionBinOp() &&
+               SE.getSCEV(Exp.getStartValue()) ==
+                   SE.getSCEV(IndDesc.getStartValue());
+      }() && "VPlan-detected induction must match pre-computed "
+             "InductionDescriptor");
+      return createWidenInductionRecipe(Phi, PhiR, Start, IndDesc, Plan, PSE,
+                                        OrigLoop, PhiR->getDebugLoc());
+    }
+
+    // Fallback: use pre-computed Inductions map.
     auto InductionIt = Inductions.find(Phi);
     if (InductionIt != Inductions.end())
       return createWidenInductionRecipe(Phi, PhiR, Start, InductionIt->second,

--- a/llvm/lib/Transforms/Vectorize/VPlanUtils.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanUtils.cpp
@@ -139,7 +139,8 @@ static bool poisonGuaranteesUB(const VPValue *V) {
 
 const SCEV *vputils::getSCEVExprForVPValue(const VPValue *V,
                                            PredicatedScalarEvolution &PSE,
-                                           const Loop *L) {
+                                           const Loop *L,
+                                           const VPDominatorTree *VPDT) {
   ScalarEvolution &SE = *PSE.getSE();
   if (isa<VPIRValue, VPSymbolicValue>(V)) {
     Value *LiveIn = V->getUnderlyingValue();
@@ -269,6 +270,30 @@ const SCEV *vputils::getSCEVExprForVPValue(const VPValue *V,
             const SCEV *Start = getSCEVExprForVPValue(R->getOperand(0), PSE, L);
             return SE.getAddRecExpr(Start, SE.getOne(Start->getType()), L,
                                     SCEV::FlagAnyWrap);
+          })
+          .Case([&SE, &PSE, L, VPDT](const VPPhi *R) -> const SCEV * {
+            if (!L || !VPDT || R->getNumOperands() != 2 ||
+                !VPBlockUtils::isHeader(R->getParent(), *VPDT))
+              return SE.getCouldNotCompute();
+            // Only construct AddRecExprs for phis in the top-level loop
+            // header. Inner loop header phis would need their own loop,
+            // not L.
+            const VPBlockBase *Entry = R->getParent()->getPlan()->getEntry();
+            if (Entry->getNumSuccessors() < 2 ||
+                R->getParent() !=
+                    Entry->getSuccessors()[1]->getSingleSuccessor())
+              return SE.getCouldNotCompute();
+            VPValue *StepVPV = nullptr;
+            if (!match(R->getOperand(1),
+                       m_c_Add(m_Specific(R), m_VPValue(StepVPV))))
+              return SE.getCouldNotCompute();
+            const SCEV *Step = getSCEVExprForVPValue(StepVPV, PSE, L);
+            if (isa<SCEVCouldNotCompute>(Step) || !SE.isLoopInvariant(Step, L))
+              return SE.getCouldNotCompute();
+            const SCEV *Start = getSCEVExprForVPValue(R->getOperand(0), PSE, L);
+            if (isa<SCEVCouldNotCompute>(Start))
+              return SE.getCouldNotCompute();
+            return SE.getAddRecExpr(Start, Step, L, SCEV::FlagAnyWrap);
           })
           .Case([&SE, &PSE, L](const VPWidenIntOrFpInductionRecipe *R) {
             const SCEV *Step = getSCEVExprForVPValue(R->getStepValue(), PSE, L);

--- a/llvm/lib/Transforms/Vectorize/VPlanUtils.h
+++ b/llvm/lib/Transforms/Vectorize/VPlanUtils.h
@@ -40,10 +40,12 @@ bool onlyScalarValuesUsed(const VPValue *Def);
 VPValue *getOrCreateVPValueForSCEVExpr(VPlan &Plan, const SCEV *Expr);
 
 /// Return the SCEV expression for \p V. Returns SCEVCouldNotCompute if no
-/// SCEV expression could be constructed.
+/// SCEV expression could be constructed. If \p VPDT is provided, it is used to
+/// detect header phis for constructing AddRecExprs.
 const SCEV *getSCEVExprForVPValue(const VPValue *V,
                                   PredicatedScalarEvolution &PSE,
-                                  const Loop *L = nullptr);
+                                  const Loop *L = nullptr,
+                                  const VPDominatorTree *VPDT = nullptr);
 
 /// Returns true if \p Addr is an address SCEV that can be passed to
 /// TTI::getAddressComputationCost, i.e. the address SCEV is loop invariant, an


### PR DESCRIPTION
Update create createHeaderPhiRecipes to use VPlan-based SCEV to detect simple integer inductions.

getSCEVExprForVPValue has been updated to detect simple AddRecs for the top-level header in the plan.