### PR TITLE
[lldb][Process/FreeBSDKernelCore] Defer actual core loading to DoLoadCore()

### DIFF
--- a/lldb/source/Plugins/Process/FreeBSD-Kernel-Core/ProcessFreeBSDKernelCore.cpp
+++ b/lldb/source/Plugins/Process/FreeBSD-Kernel-Core/ProcessFreeBSDKernelCore.cpp
@@ -62,9 +62,8 @@ static PluginProperties &GetGlobalPluginProperties() {
 
 ProcessFreeBSDKernelCore::ProcessFreeBSDKernelCore(lldb::TargetSP target_sp,
                                                    ListenerSP listener_sp,
-                                                   kvm_t *kvm,
                                                    const FileSpec &core_file)
-    : PostMortemProcess(target_sp, listener_sp, core_file), m_kvm(kvm) {}
+    : PostMortemProcess(target_sp, listener_sp, core_file) {}
 
 ProcessFreeBSDKernelCore::~ProcessFreeBSDKernelCore() {
   if (m_kvm)
@@ -79,9 +78,11 @@ lldb::ProcessSP ProcessFreeBSDKernelCore::CreateInstance(
     kvm_t *kvm =
         kvm_open2(executable->GetFileSpec().GetPath().c_str(),
                   crash_file->GetPath().c_str(), O_RDONLY, nullptr, nullptr);
-    if (kvm)
+    if (kvm) {
+      kvm_close(kvm);
       return std::make_shared<ProcessFreeBSDKernelCore>(target_sp, listener_sp,
-                                                        kvm, *crash_file);
+                                                        *crash_file);
+    }
   }
   return nullptr;
 }
@@ -113,7 +114,21 @@ bool ProcessFreeBSDKernelCore::CanDebug(lldb::TargetSP target_sp,
 }
 
 Status ProcessFreeBSDKernelCore::DoLoadCore() {
-  // The core is already loaded by CreateInstance().
+  ModuleSP executable = GetTarget().GetExecutableModule();
+  if (!executable)
+    return Status::FromErrorString(
+        "ProcessFreeBSDKernelCore: no executable module set on target");
+
+  m_kvm = kvm_open2(executable->GetFileSpec().GetPath().c_str(),
+                    GetCoreFile().GetPath().c_str(), O_RDWR, nullptr, nullptr);
+
+  if (!m_kvm)
+    return Status::FromErrorStringWithFormat(
+        "ProcessFreeBSDKernelCore: kvm_open2 failed for core '%s' "
+        "with kernel '%s'",
+        GetCoreFile().GetPath().c_str(),
+        executable->GetFileSpec().GetPath().c_str());
+
   SetKernelDisplacement();
 
   return Status();

--- a/lldb/source/Plugins/Process/FreeBSD-Kernel-Core/ProcessFreeBSDKernelCore.h
+++ b/lldb/source/Plugins/Process/FreeBSD-Kernel-Core/ProcessFreeBSDKernelCore.h
@@ -17,7 +17,7 @@
 class ProcessFreeBSDKernelCore : public lldb_private::PostMortemProcess {
 public:
   ProcessFreeBSDKernelCore(lldb::TargetSP target_sp, lldb::ListenerSP listener,
-                           kvm_t *kvm, const lldb_private::FileSpec &core_file);
+                           const lldb_private::FileSpec &core_file);
 
   ~ProcessFreeBSDKernelCore();
 


### PR DESCRIPTION
`ProcessFreeBSDKernelCore` initializes `m_kvm` in class initialization, thus invoking `kvm_open2()` only once. Although this approach is effective, it violates the expected bahaviour of `DoLoadCore()`, loading core file before the function is invoked. Later when I implement another flavour of `ProcessFreeBSDKernelCore` inherited from `ProcessElfCore`, ELF plugin will load core in `DoLoadCore()` while kvm plugin will do so in the class initializer, causing discrepancy between the two classes. Like the kvm/fvc precedent, the plugin variant (ELF and kvm) will be chosen using vtable override, so if the behaviour differs like above, it gets harder to add new features and debug the code. Thus, detecting and loading core file in `ProcessFreeBSDKernelCore` should be handled separately.