### PR TITLE
[lldb][DWARFASTParserClang] Fix duplicate template specializations for non-type template parameters

### DIFF
--- a/lldb/include/lldb/Symbol/CompilerType.h
+++ b/lldb/include/lldb/Symbol/CompilerType.h
@@ -166,6 +166,8 @@ public:
 
   bool IsMemberFunctionPointerType() const;
 
+  bool IsMemberDataPointerType() const;
+
   bool
   IsBlockPointerType(CompilerType *function_pointer_type_ptr = nullptr) const;
 

--- a/lldb/include/lldb/Symbol/TypeSystem.h
+++ b/lldb/include/lldb/Symbol/TypeSystem.h
@@ -178,6 +178,8 @@ public:
   virtual bool
   IsMemberFunctionPointerType(lldb::opaque_compiler_type_t type) = 0;
 
+  virtual bool IsMemberDataPointerType(lldb::opaque_compiler_type_t type) = 0;
+
   virtual bool IsBlockPointerType(lldb::opaque_compiler_type_t type,
                                   CompilerType *function_pointer_type_ptr) = 0;
 

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserClang.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserClang.cpp
@@ -2015,7 +2015,11 @@ static std::optional<clang::APValue> MakeAPValue(const clang::ASTContext &ast,
     return std::nullopt;
 
   bool is_signed = false;
-  const bool is_integral = clang_type.IsIntegerOrEnumerationType(is_signed);
+  const bool is_integral = clang_type.IsIntegerOrEnumerationType(is_signed) ||
+                           clang_type.IsPointerOrReferenceType() ||
+                           clang_type.IsMemberFunctionPointerType() ||
+                           clang_type.IsMemberDataPointerType() ||
+                           clang_type.IsNullPtrType();
 
   llvm::APSInt apint(*bit_width, !is_signed);
   apint = value;
@@ -2023,13 +2027,21 @@ static std::optional<clang::APValue> MakeAPValue(const clang::ASTContext &ast,
   if (is_integral)
     return clang::APValue(apint);
 
+  if (clang_type.IsRealFloatingPointType()) {
+    return clang::APValue(llvm::APFloat(
+        ast.getFloatTypeSemantics(ClangUtil::GetQualType(clang_type)), apint));
+  }
+
   // FIXME: we currently support a limited set of floating point types.
   // E.g., 16-bit floats are not supported.
-  if (!clang_type.IsRealFloatingPointType())
-    return std::nullopt;
 
-  return clang::APValue(llvm::APFloat(
-      ast.getFloatTypeSemantics(ClangUtil::GetQualType(clang_type)), apint));
+  LLDB_LOG(GetLog(LLDBLog::Types),
+           "MakeAPValue: Unsupported NTTP type class: {0}",
+           clang_type.GetTypeClass());
+
+  lldbassert(false && "Unsupported type for non-type template parameter");
+
+  return std::nullopt;
 }
 
 bool DWARFASTParserClang::ParseTemplateDIE(

--- a/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
+++ b/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
@@ -3169,6 +3169,15 @@ bool TypeSystemClang::IsMemberFunctionPointerType(
   return IsTypeImpl(type, isMemberFunctionPointerType);
 }
 
+bool TypeSystemClang::IsMemberDataPointerType(
+    lldb::opaque_compiler_type_t type) {
+  auto isMemberDataPointerType = [](clang::QualType qual_type) {
+    return qual_type->isMemberDataPointerType();
+  };
+
+  return IsTypeImpl(type, isMemberDataPointerType);
+}
+
 bool TypeSystemClang::IsFunctionPointerType(lldb::opaque_compiler_type_t type) {
   auto isFunctionPointerType = [](clang::QualType qual_type) {
     return qual_type->isFunctionPointerType();

--- a/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.h
+++ b/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.h
@@ -672,6 +672,8 @@ public:
 
   bool IsMemberFunctionPointerType(lldb::opaque_compiler_type_t type) override;
 
+  bool IsMemberDataPointerType(lldb::opaque_compiler_type_t type) override;
+
   bool IsBlockPointerType(lldb::opaque_compiler_type_t type,
                           CompilerType *function_pointer_type_ptr) override;
 

--- a/lldb/source/Symbol/CompilerType.cpp
+++ b/lldb/source/Symbol/CompilerType.cpp
@@ -177,6 +177,13 @@ bool CompilerType::IsMemberFunctionPointerType() const {
   return false;
 }
 
+bool CompilerType::IsMemberDataPointerType() const {
+  if (IsValid())
+    if (auto type_system_sp = GetTypeSystem())
+      return type_system_sp->IsMemberDataPointerType(m_type);
+  return false;
+}
+
 bool CompilerType::IsBlockPointerType(
     CompilerType *function_pointer_type_ptr) const {
   if (IsValid())

--- a/lldb/test/API/lang/cpp/non-type-template-param-member-ptr/Makefile
+++ b/lldb/test/API/lang/cpp/non-type-template-param-member-ptr/Makefile
@@ -1,0 +1,3 @@
+CXX_SOURCES := main.cpp
+
+include Makefile.rules

--- a/lldb/test/API/lang/cpp/non-type-template-param-member-ptr/TestCppNonTypeTemplateParamPtrToMember.py
+++ b/lldb/test/API/lang/cpp/non-type-template-param-member-ptr/TestCppNonTypeTemplateParamPtrToMember.py
@@ -1,0 +1,26 @@
+import lldb
+from lldbsuite.test.decorators import *
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test import lldbutil
+
+
+class TestCase(TestBase):
+    @no_debug_info_test
+    def test_member_data_pointer(self):
+        """Member data pointer NTTPs: MemberData<&S::x> vs MemberData<&S::y>"""
+        self.build()
+        self.dbg.CreateTarget(self.getBuildArtifact("a.out"))
+        # Both must be resolvable as distinct specializations.
+        # Without the fix, md2 fails with "undeclared identifier".
+        self.expect_expr("md1")
+        self.expect_expr("md2")
+
+    @no_debug_info_test
+    def test_nullptr(self):
+        """nullptr NTTP: MaybeNull<nullptr> vs MaybeNull<&g1>"""
+        self.build()
+        self.dbg.CreateTarget(self.getBuildArtifact("a.out"))
+        # nullptr (const_value=0) vs pointer (DW_AT_location) produce
+        # different TemplateArgument kinds, so they are naturally distinct.
+        self.expect_expr("mn1")
+        self.expect_expr("mn2")

--- a/lldb/test/API/lang/cpp/non-type-template-param-member-ptr/main.cpp
+++ b/lldb/test/API/lang/cpp/non-type-template-param-member-ptr/main.cpp
@@ -1,0 +1,24 @@
+struct S {
+  int x;
+  int y;
+};
+
+// --- Member data pointer NTTP ---
+template <int S::*P> struct MemberData {
+  int get(S &s) { return s.*P; }
+};
+MemberData<&S::x> md1;
+MemberData<&S::y> md2;
+
+// --- nullptr NTTP ---
+int g1 = 10;
+template <int *P> struct MaybeNull {
+  bool is_null() { return P == nullptr; }
+};
+MaybeNull<nullptr> mn1;
+MaybeNull<&g1> mn2;
+
+int main() {
+  S s{1, 2};
+  return md1.get(s) + md2.get(s);
+}

--- a/lldb/unittests/Symbol/TestTypeSystemClang.cpp
+++ b/lldb/unittests/Symbol/TestTypeSystemClang.cpp
@@ -1518,3 +1518,32 @@ TEST_P(TestTypeSystemClangAsmLabel, DeclGetMangledName) {
 
 INSTANTIATE_TEST_SUITE_P(AsmLabelTests, TestTypeSystemClangAsmLabel,
                          testing::ValuesIn(g_asm_label_test_cases));
+
+TEST_F(TestTypeSystemClang, TestIsMemberDataPointerType) {
+  // Create struct S { int x; void foo(); };
+  CompilerType int_type = m_ast->GetBasicType(lldb::eBasicTypeInt);
+  CompilerType record_type = clang_utils::createRecord(*m_ast, "S");
+
+  // int S::* — member data pointer
+  CompilerType member_data_ptr =
+      TypeSystemClang::CreateMemberPointerType(record_type, int_type);
+  EXPECT_TRUE(member_data_ptr.IsMemberDataPointerType());
+  EXPECT_FALSE(member_data_ptr.IsMemberFunctionPointerType());
+
+  // void (S::*)() — member function pointer
+  CompilerType void_type = m_ast->GetBasicType(lldb::eBasicTypeVoid);
+  CompilerType func_type = m_ast->CreateFunctionType(void_type, {}, false, 0U);
+  CompilerType member_func_ptr =
+      TypeSystemClang::CreateMemberPointerType(record_type, func_type);
+  EXPECT_FALSE(member_func_ptr.IsMemberDataPointerType());
+  EXPECT_TRUE(member_func_ptr.IsMemberFunctionPointerType());
+
+  // int* — regular pointer, neither member data nor member function
+  CompilerType regular_ptr = int_type.GetPointerType();
+  EXPECT_FALSE(regular_ptr.IsMemberDataPointerType());
+  EXPECT_FALSE(regular_ptr.IsMemberFunctionPointerType());
+
+  // int — not a pointer at all
+  EXPECT_FALSE(int_type.IsMemberDataPointerType());
+  EXPECT_FALSE(int_type.IsMemberFunctionPointerType());
+}


### PR DESCRIPTION
## **depends on pull request:  [187172](https://github.com/llvm/llvm-project/pull/187172)**

## **Summary**
MakeAPValue in `DWARFASTParserClang.cpp` did not handle pointer-to-member non-type template parameters (e.g., `template <int S::*P>`), causing LLDB to silently produce incorrect results or crash.

When DWARF encodes a pointer-to-member non-type template parameter, it uses `DW_TAG_template_value_parameter` with a `DW_AT_const_value` representing the byte offset of the member within the struct. MakeAPValue is responsible for converting this value into a clang APValue, but it only handled integer/enum and floating-point types. For pointer-to-member types, it returned `std::nullopt`.

This caused the caller (`ParseTemplateDIE`) to fall back to creating a type-only TemplateArgument (kind=Type) instead of a value-carrying one. When two specializations differ only by which member they point to (e.g., `MemberData<&S::x> / MemberData<&S::y>`), both produce identical TemplateArguments. Clang's [**findSpecialization**](https://github.com/llvm/llvm-project/blob/3bc216c29cb42c7d94b617943b1d44afce605588/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp#L1674-L1677) then treats the second as a duplicate, so only one specialization exists in the AST. The second variable becomes unresolvable.

(See Debugger Evidence section below)

In more complex cases, this triggers an assertion failure in [clang::CXXRecordDecl::setBases(): cast<Ty>()](https://github.com/llvm/llvm-project/blob/3bc216c29cb42c7d94b617943b1d44afce605588/clang/lib/AST/DeclCXX.cpp#L219) argument of incompatible type. 

## **Fix**
This PR contains two commits:
1. Handle additional NTTP types in MakeAPValue
Refactored MakeAPValue to handle additional NTTP type categories using CompilerType queries:

* Member data pointer (IsMemberDataPointerType): Resolves the reported issue. DWARF encodes these as 
* DW_AT_const_value with the byte offset — now produces distinct APValues.
* nullptr (IsNullPtrType): DWARF encodes as DW_AT_const_value(0).
* Pointer/reference (IsPointerOrReferenceType): Defensive — DWARF currently encodes these with DW_AT_location, not DW_AT_const_value, so MakeAPValue is not reached today. Handled by a follow-up PR.
* Member function pointer (IsMemberFunctionPointerType): Defensive — DWARF currently emits no value attribute for these. Handled by a follow-up PR.

Also replaced the silent return `std::nullopt` for unhandled types with log and lldbassert, so unknown type classes are caught during development.

2. Resolve pointer-to-member NTTP values to FieldDecls
Added `ResolveFieldFromPtrToMemberValue`, which follows the DWARF chain to create `TemplateArgument(Declaration)` matching clang's own AST:

DW_TAG_template_value_parameter (DW_AT_type)
  → DW_TAG_ptr_to_member_type (DW_AT_containing_type)
    → DW_TAG_structure_type → match DW_TAG_member by byte offset

If resolution fails at any step, falls through to the integer path from commit 1 as a safe fallback.

Verified by comparing clang's AST with LLDB's reconstructed AST — both produce MemberData<&S::x> / MemberData<&S::y>.

## **Test Plan**
Added lldb/test/API/lang/cpp/non-type-template-param-member-ptr/ with tests that verify:

1. MemberData<&S::x> and MemberData<&S::y> are resolvable as distinct specializations with correct type names
2. MaybeNull<nullptr> and MaybeNull<&g1> are resolvable as distinct specializations
3. manual comparison of ast dump and lldb output
```
| |-ClassTemplateSpecializationDecl 0x234e2314800 <line:18:1, line:21:1> line:19:8 struct MemberData definition instantiated_from 0x234e2314110 implicit_instantiation
| | |-DefinitionData pass_in_registers empty aggregate standard_layout trivially_copyable pod trivial literal has_constexpr_non_copy_move_ctor can_const_default_init
| | | |-DefaultConstructor exists trivial constexpr defaulted_is_constexpr
--
| | |-TemplateArgument decl '&S::x'
| | | `-Field 0x234e2313ed0 'x' 'int'
| | |-CXXRecordDecl 0x234e2314ac0 <col:1, col:8> col:8 implicit struct MemberData
--
| `-ClassTemplateSpecializationDecl 0x234e25b5968 <line:18:1, line:21:1> line:19:8 struct MemberData definition instantiated_from 0x234e2314110 implicit_instantiation
|   |-DefinitionData pass_in_registers empty aggregate standard_layout trivially_copyable pod trivial literal has_constexpr_non_copy_move_ctor can_const_default_init
|   | |-DefaultConstructor exists trivial constexpr defaulted_is_constexpr
--
|   |-TemplateArgument decl '&S::y'
|   | `-Field 0x234e2313f38 'y' 'int'
|   |-CXXRecordDecl 0x234e25b5bd8 <col:1, col:8> col:8 implicit struct MemberData
--
| |-ClassTemplateSpecializationDecl 0x234e25b7080 <line:27:1, line:30:1> line:28:8 struct MaybeNull definition instantiated_from 0x234e25b6b50 implicit_instantiation
| | |-DefinitionData pass_in_registers empty aggregate standard_layout trivially_copyable pod trivial literal has_constexpr_non_copy_move_ctor can_const_default_init
| | | |-DefaultConstructor exists trivial constexpr defaulted_is_constexpr
--
| `-ClassTemplateSpecializationDecl 0x234e25b80c0 <line:27:1, line:30:1> line:28:8 struct MaybeNull definition instantiated_from 0x234e25b6b50 implicit_instantiation
|   |-DefinitionData pass_in_registers empty aggregate standard_layout trivially_copyable pod trivial literal has_constexpr_non_copy_move_ctor can_const_default_init
|   | |-DefaultConstructor exists trivial constexpr defaulted_is_constexpr
--
|   |-TemplateArgument decl '&g1'
|   | `-Var 0x234e25b69b8 'g1' 'int'
|   |-CXXRecordDecl 0x234e25b8338 <col:1, col:8> col:8 implicit struct MaybeNull
```
```
lldb a.out -o "type lookup MemberData<&S::x>" -o "type lookup MemberData<&S::y>" -o quit
(lldb) target create "a.out"
Current executable set to 'a.out' (x86_64).
(lldb) type lookup MemberData<&S::x>
template<> struct MemberData<&S::x> {
    int get(S &);
}
(lldb) type lookup MemberData<&S::y>
template<> struct MemberData<&S::y> {
    int get(S &);
}
```

## **Debugger Evidence**
Collected at two `DW_TAG_template_value_parameter` DIEs during ParseTemplateDIE, both with name="PtrToMember" and `type_class=256` (eTypeClassMemberPointer): DIE `0xcb: uval64=8`; DIE `0x1e9 : uval64=24`

These correspond to two members of Fiber:
```
DW_TAG_member "listHook_"        DW_AT_data_member_location(0x08)  ← uval64=8
DW_TAG_member "globalListHook_"  DW_AT_data_member_location(0x18)  ← uval64=24
```
Clang's ground truth AST correctly produces TemplateArgument decl (kind=Declaration) with distinct FieldDecl references for each specialization.
```
22:| | |-ClassTemplateSpecializationDecl 0x36d785b7cc0 <line:43:1, line:56:1> line:44:8 struct mhtraits definition instantiated_from 0x36d785b4238 implicit_instantiation
23-| | | |-DefinitionData pass_in_registers empty aggregate standard_layout trivially_copyable pod trivial literal has_constexpr_non_copy_move_ctor can_const_default_init
24-| | | | |-DefaultConstructor exists trivial constexpr defaulted_is_constexpr
25-| | | | |-CopyConstructor simple trivial has_const_param implicit_has_const_param
26-| | | | |-MoveConstructor exists simple trivial
27-| | | | |-CopyAssignment simple trivial has_const_param needs_implicit implicit_has_const_param
28-| | | | |-MoveAssignment exists simple trivial needs_implicit
29-| | | | `-Destructor simple irrelevant trivial
30-| | | |-TemplateArgument type 'intrusive::Fiber'
31-| | | | `-RecordType 0x36d785b3fb0 'intrusive::Fiber' canonical
32-| | | |   `-CXXRecord 0x36d78344850 'Fiber'
33-| | | |-TemplateArgument type 'intrusive::list_member_hook<>'
34-| | | | `-RecordType 0x36d785b3c20 'intrusive::list_member_hook<>' canonical
35-| | | |   `-ClassTemplateSpecialization 0x36d78344b48 'list_member_hook'
36-| | | |-TemplateArgument decl '&intrusive::Fiber::listHook_'
37-| | | | `-Field 0x36d785b3e70 'listHook_' 'list_member_hook<>':'intrusive::list_member_hook<>'
38-| | | |-CXXRecordDecl 0x36d785b93a0 <col:1, col:8> col:8 implicit struct mhtraits
39-| | | |-TypeAliasDecl 0x36d785b9470 <line:45:3, col:22> col:9 referenced value_type 'intrusive::Fiber'
40-| | | | `-SubstTemplateTypeParmType 0x36d785b9430 'intrusive::Fiber' sugar typename depth 0 index 0 T
41-| | | |   |-ClassTemplateSpecialization 0x36d785b7cc0 'mhtraits'
42-| | | |   `-RecordType 0x36d785b3fb0 'intrusive::Fiber' canonical
--
78:| | `-ClassTemplateSpecializationDecl 0x36d785b8210 <line:43:1, line:56:1> line:44:8 struct mhtraits definition instantiated_from 0x36d785b4238 implicit_instantiation
79-| |   |-DefinitionData pass_in_registers empty aggregate standard_layout trivially_copyable pod trivial literal has_constexpr_non_copy_move_ctor can_const_default_init
80-| |   | |-DefaultConstructor exists trivial constexpr defaulted_is_constexpr
81-| |   | |-CopyConstructor simple trivial has_const_param implicit_has_const_param
82-| |   | |-MoveConstructor exists simple trivial
83-| |   | |-CopyAssignment simple trivial has_const_param needs_implicit implicit_has_const_param
84-| |   | |-MoveAssignment exists simple trivial needs_implicit
85-| |   | `-Destructor simple irrelevant trivial
86-| |   |-TemplateArgument type 'intrusive::Fiber'
87-| |   | `-RecordType 0x36d785b3fb0 'intrusive::Fiber' canonical
88-| |   |   `-CXXRecord 0x36d78344850 'Fiber'
89-| |   |-TemplateArgument type 'intrusive::list_member_hook<>'
90-| |   | `-RecordType 0x36d785b3c20 'intrusive::list_member_hook<>' canonical
91-| |   |   `-ClassTemplateSpecialization 0x36d78344b48 'list_member_hook'
92-| |   |-TemplateArgument decl '&intrusive::Fiber::globalListHook_'
93-| |   | `-Field 0x36d785b3f60 'globalListHook_' 'list_member_hook<>':'intrusive::list_member_hook<>'
94-| |   |-CXXRecordDecl 0x36d785be080 <col:1, col:8> col:8 implicit struct mhtraits
95-| |   |-TypeAliasDecl 0x36d785be150 <line:45:3, col:22> col:9 referenced value_type 'intrusive::Fiber'
96-| |   | `-SubstTemplateTypeParmType 0x36d785be110 'intrusive::Fiber' sugar typename depth 0 index 0 T
97-| |   |   |-ClassTemplateSpecialization 0x36d785b8210 'mhtraits'
98-| |   |   `-RecordType 0x36d785b3fb0 'intrusive::Fiber' canonical
```


### **Full Paste**
```
$ llvm-dwarfdump --debug-info=0x000000cb repro.dwp -c -p
repro.dwp:	file format elf64-x86-64
.debug_info.dwo contents:
0x00000014: DW_TAG_compile_unit
              DW_AT_producer	("clang version 22.1.20 ...)
              DW_AT_language	(DW_LANG_C_plus_plus_14)
              DW_AT_name	("repro.cpp")
              DW_AT_dwo_name	("repro-repro.dwo")
0x0000001a:   DW_TAG_namespace
                DW_AT_name	("intrusive")
0x000000b9:     DW_TAG_structure_type
                  DW_AT_calling_convention	(DW_CC_pass_by_value)
                  DW_AT_name	("mhtraits<intrusive::Fiber, intrusive::list_member_hook<(intrusive::link_mode_type)2>, &intrusive::Fiber::listHook_>")
                  DW_AT_byte_size	(0x01)
                  DW_AT_decl_file	(0x00)
                  DW_AT_decl_line	(44)
0x000000cb:       DW_TAG_template_value_parameter
                    DW_AT_type	(0x0000022d "intrusive::list_member_hook<(intrusive::link_mode_type)2> intrusive::Fiber::*")
                    DW_AT_name	("PtrToMember")
                    DW_AT_const_value	(8)
```
lldb prints: 
```
p name
(const char *) 0x000055f44554c4ca "PtrToMember"
p uval64
(uint64_t) 8
p (unsigned)clang_type.GetTypeClass()
(unsigned int) 256
```
```
$ llvm-dwarfdump --debug-info=0x000001e9 repro.dwp -c -p
repro.dwp:	file format elf64-x86-64
.debug_info.dwo contents:
0x00000014: DW_TAG_compile_unit
              DW_AT_producer	("clang version 22.1.20")
              DW_AT_language	(DW_LANG_C_plus_plus_14)
              DW_AT_name	("repro.cpp")
              DW_AT_dwo_name	("repro-repro.dwo")
0x0000001a:   DW_TAG_namespace
                DW_AT_name	("intrusive")
0x000001d7:     DW_TAG_structure_type
                  DW_AT_calling_convention	(DW_CC_pass_by_value)
                  DW_AT_name	("mhtraits<intrusive::Fiber, intrusive::list_member_hook<(intrusive::link_mode_type)2>, &intrusive::Fiber::globalListHook_>")
                  DW_AT_byte_size	(0x01)
                  DW_AT_decl_file	(0x00)
                  DW_AT_decl_line	(44)
0x000001e9:       DW_TAG_template_value_parameter
                    DW_AT_type	(0x0000022d "intrusive::list_member_hook<(intrusive::link_mode_type)2> intrusive::Fiber::*")
                    DW_AT_name	("PtrToMember")
                    DW_AT_const_value	(24)
```
lldb prints: 
```
 p name
(const char *) 0x000055f44554c4ca "PtrToMember"
p uval64
(uint64_t) 24
p (unsigned)clang_type.GetTypeClass()
(unsigned int) 256
```