### PR TITLE
[clang] Fixed 'implicitly deleted' diagnostic for explicitly deleted candidate function

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -286,6 +286,9 @@ Improvements to Clang's diagnostics
   when parsing alias declarations involving a token-split ``>>`` sequence
   (for example, ``using A = X<int>>;``). (#GH184425)
 
+- Fixed incorrect ``implicitly deleted`` diagnostic for explicitly deleted
+  candidate function. (#GH185693)
+
 - The ``-Wloop-analysis`` warning has been extended to catch more cases of
   variable modification inside lambda expressions (#GH132038).
 

--- a/clang/lib/Sema/SemaOverload.cpp
+++ b/clang/lib/Sema/SemaOverload.cpp
@@ -12841,7 +12841,9 @@ static void NoteFunctionCandidate(Sema &S, OverloadCandidate *Cand,
 
       S.Diag(Fn->getLocation(), diag::note_ovl_candidate_deleted)
           << (unsigned)FnKindPair.first << (unsigned)FnKindPair.second << FnDesc
-          << (Fn->isDeleted() ? (Fn->isDeletedAsWritten() ? 1 : 2) : 0);
+          << (Fn->isDeleted()
+                  ? (Fn->getCanonicalDecl()->isDeletedAsWritten() ? 1 : 2)
+                  : 0);
       MaybeEmitInheritedConstructorNote(S, Cand->FoundDecl);
       return;
     }

--- a/clang/test/CXX/drs/cwg8xx.cpp
+++ b/clang/test/CXX/drs/cwg8xx.cpp
@@ -23,10 +23,10 @@ template <> void f(int &&) = delete; // #cwg873-rvalue-ref
 void g(int i) {
   f(i); // calls f<int&>(int&)
   // since-cxx11-error@-1 {{call to deleted function 'f'}}
-  //   since-cxx11-note@#cwg873-lvalue-ref {{candidate function [with T = int &] has been implicitly deleted}}
+  //   since-cxx11-note@#cwg873-lvalue-ref {{candidate function [with T = int &] has been explicitly deleted}}
   f(0); // calls f<int>(int&&)
   // since-cxx11-error@-1 {{call to deleted function 'f'}}
-  //   since-cxx11-note@#cwg873-rvalue-ref {{candidate function [with T = int] has been implicitly deleted}}
+  //   since-cxx11-note@#cwg873-rvalue-ref {{candidate function [with T = int] has been explicitly deleted}}
 }
 #endif
 } // namespace cwg873

--- a/clang/test/SemaCXX/deleted-template-spec-diag.cpp
+++ b/clang/test/SemaCXX/deleted-template-spec-diag.cpp
@@ -1,0 +1,12 @@
+// RUN: %clang_cc1 -std=c++11 -verify %s
+
+// https://github.com/llvm/llvm-project/issues/185693
+// Explicitly deleted function template specializations were incorrectly
+// reported as "implicitly deleted" in overload resolution diagnostics.
+
+template <typename T> void fred(const T &x);
+template <> void fred(const double &) = delete; // expected-note {{explicitly deleted}}
+
+int main() {
+  fred(8.0); // expected-error {{call to deleted function 'fred'}}
+}


### PR DESCRIPTION
When an explicit function template specialization is deleted, the overload candidate `Fn` may be a non-canonical `FunctionDecl` where `IsDeleted` is not set, even though the canonical decl has it set. `isDeletedAsWritten()` reads `this` while `isDeleted()` reads `getCanonicalDecl()`, causing the mismatch. Fix by using `getCanonicalDecl()` consistently in the diagnostic.                                                                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                            
Fixes #185693  