### PR TITLE
[mlir] Fix op comparisons in extensible dialects

### DIFF
--- a/mlir/include/mlir/IR/ExtensibleDialect.h
+++ b/mlir/include/mlir/IR/ExtensibleDialect.h
@@ -566,7 +566,7 @@ public:
   Attribute getPropertiesAsAttr(Operation *op) final { return {}; }
   void copyProperties(OpaqueProperties lhs, OpaqueProperties rhs) final {}
   bool compareProperties(OpaqueProperties, OpaqueProperties) final {
-    return false;
+    return true;
   }
   llvm::hash_code hashProperties(OpaqueProperties prop) final { return {}; }
 


### PR DESCRIPTION
The extensible dialect system defined `compareProperties` to false because it doesn't use properties. However, this should have been `true`, as the empty properties are trivially always equal to themselves. Doing otherwise means that no operations in extensible dialects that aren't the exact same operation will ever compare equal for the purposes of operations like CSE.