### PR TITLE
[libc] Add Jeff Bailey to Maintainers.rst

### DIFF
--- a/libc/Maintainers.rst
+++ b/libc/Maintainers.rst
@@ -61,6 +61,11 @@ Public Headers / hdrgen
 | Roland McGrath
 | mcgrathr\@google.com (email), `frobtech <https://github.com/frobtech>`_ (github)
 
+General Maintenance and Documentation
+-------------------------------------
+| Jeff Bailey
+| jbailey\@raspberryginger.com (email), `kaladron <https://github.com/kaladron>`_ (github), kaladron (discourse), kaladron725 (discord)
+
 
 Inactive Maintainers
 ====================


### PR DESCRIPTION
Add Jeff Bailey as a maintainer for General Maintenance and Documentation. Jeff has been contributing to LLVM-libc since January 2022. This addition was discussed at the most recent LLVM-libc meeting with no objections raised.