### PR TITLE
[MC] Early return on CPU help text invocation

### DIFF
--- a/llvm/docs/ReleaseNotes.md
+++ b/llvm/docs/ReleaseNotes.md
@@ -197,6 +197,7 @@ Changes to the LLVM tools
 * `llvm-objcopy` no longer corrupts the symbol table when `--update-section` is called for ELF files.
 * `FileCheck` option `-check-prefix` now accepts a comma-separated list of
   prefixes, making it an alias of the existing `-check-prefixes` option.
+* `llvm-objdump` no longer dumps actual output when `--mcpu=help` or `--mattr=help` are passed
 
 Changes to LLDB
 ---------------

--- a/llvm/lib/MC/MCSubtargetInfo.cpp
+++ b/llvm/lib/MC/MCSubtargetInfo.cpp
@@ -179,15 +179,17 @@ static FeatureBitset getFeatures(MCSubtargetInfo &STI, StringRef CPU,
 
   assert(llvm::is_sorted(ProcDesc) && "CPU table is not sorted");
   assert(llvm::is_sorted(ProcFeatures) && "CPU features table is not sorted");
-  // Resulting bits
+
+  // Return empty early if this is a CPU help print call, which should not mix
+  // actual feature collection
+  if (CPU == "help") {
+    Help(ProcNames, ProcFeatures);
+    return FeatureBitset();
+  }
+
   FeatureBitset Bits;
 
-  // Check if help is needed
-  if (CPU == "help")
-    Help(ProcNames, ProcFeatures);
-
-  // Find CPU entry if CPU name is specified.
-  else if (!CPU.empty()) {
+  if (!CPU.empty()) {
     const SubtargetSubTypeKV *CPUEntry = Find(CPU, ProcDesc);
 
     // If there is a match
@@ -215,13 +217,18 @@ static FeatureBitset getFeatures(MCSubtargetInfo &STI, StringRef CPU,
 
   // Iterate through each feature
   for (const std::string &Feature : Features.getFeatures()) {
-    // Check for help
-    if (Feature == "+help")
+    // Return empty early if this is a features help print call, which should
+    // not mix actual feature collection
+    if (Feature == "+help") {
       Help(ProcNames, ProcFeatures);
-    else if (Feature == "+cpuhelp")
+      return FeatureBitset();
+    }
+    if (Feature == "+cpuhelp") {
       cpuHelp(ProcNames);
-    else
-      ApplyFeatureFlag(Bits, Feature, ProcFeatures);
+      return FeatureBitset();
+    }
+
+    ApplyFeatureFlag(Bits, Feature, ProcFeatures);
   }
 
   return Bits;

--- a/llvm/test/tools/llvm-objdump/mattr-mcpu-help.test
+++ b/llvm/test/tools/llvm-objdump/mattr-mcpu-help.test
@@ -1,32 +1,32 @@
 # REQUIRES: x86-registered-target
 
 # RUN: yaml2obj --docnum=1 %s -o %t
+# RUN: llvm-objdump --mattr=help %t 2>&1 \
+# RUN:   | FileCheck %s --check-prefixes=CHECK
+# RUN: llvm-objdump --mcpu=help %t 2>&1 \
+# RUN:   | FileCheck %s --check-prefixes=CHECK
+
+## The help message should be printed without disassembly.
 # RUN: llvm-objdump -d %t --mattr=help 2>&1 \
-# RUN:   | FileCheck %s --check-prefixes=CHECK,CHECK-DISASSEMBLE
+# RUN:   | FileCheck %s --check-prefixes=CHECK
 # RUN: llvm-objdump -d %t --mcpu=help 2>&1 \
-# RUN:   | FileCheck %s --check-prefixes=CHECK,CHECK-DISASSEMBLE
+# RUN:   | FileCheck %s --check-prefixes=CHECK
+
+## We also dont handle other options.
+# RUN: llvm-objdump --mattr=help --section-headers %t 2>&1 \
+# RUN:   | FileCheck %s --check-prefixes=CHECK
+# RUN: llvm-objdump --mcpu=help --section-headers %t 2>&1 \
+# RUN:   | FileCheck %s --check-prefixes=CHECK
 
 # CHECK: Available CPUs for this target:
 # CHECK: Available features for this target:
-## To check we still disassemble the file:
-# CHECK-DISASSEMBLE: file format elf64-x86-64
 
-## The help message can be printed without -d.
-# RUN: llvm-objdump --mattr=help %t 2>&1 \
-# RUN:   | FileCheck %s --check-prefixes=CHECK,CHECK-NO-DISASSEMBLE
-# RUN: llvm-objdump --mcpu=help %t 2>&1 \
-# RUN:   | FileCheck %s --check-prefixes=CHECK,CHECK-NO-DISASSEMBLE
+## To check we dont disassemble the file:
+# CHECK-NOT: file format elf64-x86-64
 
-# CHECK-NO-DISASSEMBLE-NOT: file format elf64-x86-64
-
-## We still handle other options.
-# RUN: llvm-objdump --mattr=help --section-headers %t 2>&1 \
-# RUN:   | FileCheck %s --check-prefixes=CHECK,CHECK-SECTION-HEADERS
-# RUN: llvm-objdump --mcpu=help --section-headers %t 2>&1 \
-# RUN:   | FileCheck %s --check-prefixes=CHECK,CHECK-SECTION-HEADERS
-
-# CHECK-SECTION-HEADERS: Sections:
-# CHECK-SECTION-HEADERS: Idx Name               Size     VMA              Type
+## To check we dont dump sections:
+# CHECK-NOT: Sections:
+# CHECK-NOT: Idx Name               Size     VMA              Type
 
 ## We report an error when we can't infer the triple because we don't have --triple or an input object (including a.out).
 # RUN: not llvm-objdump --mattr=help 2>&1 \

--- a/llvm/tools/llvm-objdump/llvm-objdump.cpp
+++ b/llvm/tools/llvm-objdump/llvm-objdump.cpp
@@ -3961,8 +3961,7 @@ int llvm_objdump_main(int argc, char **argv, const llvm::ToolContext &) {
 
   if (PrintCpuHelp) {
     mcpuHelp();
-    if (!ShouldDump)
-      return EXIT_SUCCESS;
+    return EXIT_SUCCESS;
   }
 
   DisasmSymbolSet.insert_range(DisassembleSymbols);


### PR DESCRIPTION
When calling `MCSubtargetInfo` methods like `MCSubtargetInfo::InitMCProcessorInfo` that invoke `getFeatures` in `llvm/lib/MC/MCSubtargetInfo.cpp`, I think there should be no sense for caller tools to both print CPUs/features help text to stdout, and actually collect features for futher use. Thus, I think we should remove the dual logic from the callee. This patch adds early returns for help text invocations, returning a empty feature bitset in those cases.

This should effectively be a NFC. I think it is a reasonable assumption for out-of-tree tools, and for in-tree the safety ind icator should be regression tests passing.

Depends on https://github.com/llvm/llvm-project/pull/186750. The first 1 commits are from the base PR.