### PR TITLE
[Clang][NFC] Remove redundant DeclContext workaround for local extern decls

### DIFF
--- a/clang/lib/AST/ItaniumMangle.cpp
+++ b/clang/lib/AST/ItaniumMangle.cpp
@@ -800,10 +800,6 @@ bool ItaniumMangleContextImpl::shouldMangleCXXName(const NamedDecl *D) {
     // Variables at global scope are not mangled unless they have internal
     // linkage or are specializations or are attached to a named module.
     const DeclContext *DC = getEffectiveDeclContext(D);
-    // Check for extern variable declared locally.
-    if (DC->isFunctionOrMethod() && D->hasLinkage())
-      while (!DC->isFileContext())
-        DC = getEffectiveParentContext(DC);
     if (DC->isTranslationUnit() && D->getFormalLinkage() != Linkage::Internal &&
         !CXXNameMangler::shouldHaveAbiTags(*this, VD) &&
         !isa<VarTemplateSpecializationDecl>(VD) &&
@@ -1077,15 +1073,8 @@ void CXXNameMangler::mangleNameWithAbiTags(GlobalDecl GD,
   const DeclContext *DC = Context.getEffectiveDeclContext(ND);
   bool IsLambda = isLambda(ND);
 
-  // If this is an extern variable declared locally, the relevant DeclContext
-  // is that of the containing namespace, or the translation unit.
-  // FIXME: This is a hack; extern variables declared locally should have
-  // a proper semantic declaration context!
-  if (isLocalContainerContext(DC) && ND->hasLinkage() && !IsLambda)
-    while (!DC->isNamespace() && !DC->isTranslationUnit())
-      DC = Context.getEffectiveParentContext(DC);
-  else if (GetLocalClassDecl(ND) &&
-           (!IsLambda || isCompatibleWith(LangOptions::ClangABI::Ver18))) {
+  if (GetLocalClassDecl(ND) &&
+      (!IsLambda || isCompatibleWith(LangOptions::ClangABI::Ver18))) {
     mangleLocalName(GD, AdditionalAbiTags);
     return;
   }

--- a/clang/lib/AST/MicrosoftMangle.cpp
+++ b/clang/lib/AST/MicrosoftMangle.cpp
@@ -122,10 +122,6 @@ static const DeclContext *getEffectiveDeclContext(const Decl *D) {
   return DC->getRedeclContext();
 }
 
-static const DeclContext *getEffectiveParentContext(const DeclContext *DC) {
-  return getEffectiveDeclContext(cast<Decl>(DC));
-}
-
 static const FunctionDecl *getStructor(const NamedDecl *ND) {
   if (const auto *FTD = dyn_cast<FunctionTemplateDecl>(ND))
     return FTD->getTemplatedDecl()->getCanonicalDecl();
@@ -557,11 +553,6 @@ bool MicrosoftMangleContextImpl::shouldMangleCXXName(const NamedDecl *D) {
 
     // Variables at global scope with internal linkage are not mangled.
     const DeclContext *DC = getEffectiveDeclContext(D);
-    // Check for extern variable declared locally.
-    if (DC->isFunctionOrMethod() && D->hasLinkage())
-      while (!DC->isNamespace() && !DC->isTranslationUnit())
-        DC = getEffectiveParentContext(DC);
-
     if (DC->isTranslationUnit() && D->getFormalLinkage() == Linkage::Internal &&
         !isa<VarTemplateSpecializationDecl>(D) && D->getIdentifier() != nullptr)
       return false;


### PR DESCRIPTION
This patch removes an out-of-date FIXME.

The underlying issue was already fixed by `Sema::adjustContextForLocalExternDecl` introduced by https://github.com/llvm/llvm-project/commit/541b38be7bf3afded3269a33586418254d82d7b3