### PR TITLE
[SimplifyCFG][NFC] Renumber blocks when changing func

### DIFF
--- a/llvm/lib/Transforms/Scalar/SimplifyCFGPass.cpp
+++ b/llvm/lib/Transforms/Scalar/SimplifyCFGPass.cpp
@@ -380,9 +380,13 @@ PreservedAnalyses SimplifyCFGPass::run(Function &F,
     DT = &AM.getResult<DominatorTreeAnalysis>(F);
   if (!simplifyFunctionCFG(F, TTI, DT, Options))
     return PreservedAnalyses::all();
+  // If we removed some blocks, update block numbers to keep dense numbering.
+  F.renumberBlocks();
   PreservedAnalyses PA;
-  if (RequireAndPreserveDomTree)
+  if (RequireAndPreserveDomTree) {
+    DT->updateBlockNumbers();
     PA.preserve<DominatorTreeAnalysis>();
+  }
   return PA;
 }
 


### PR DESCRIPTION
Keep numbering dense when changing the function. SimplifyCFG is a good candidate, because it is likely to remove blocks and preserves few analyses.

[stage2-O3 -0.07%](http://llvm-compile-time-tracker.com/compare.php?from=a7aebd809d49fd1c8205e8f0fcdc8d97777e5103&to=d77a3d37a5d16025371c3b407838d011cbcc6da9&stat=instructions:u)