### PR TITLE
[CIR] Fix reference alignment to use pointee type

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenCall.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenCall.cpp
@@ -620,7 +620,7 @@ void CIRGenModule::constructFunctionReturnAttributes(
       if (pointeeTy->isObjectType())
         retAttrs.set(mlir::LLVM::LLVMDialect::getAlignAttrName(),
                      builder.getI64IntegerAttr(
-                         getNaturalTypeAlignment(pointeeTy).getQuantity()));
+                         getNaturalPointeeTypeAlignment(retTy).getQuantity()));
     }
   }
 }
@@ -657,9 +657,10 @@ void CIRGenModule::constructFunctionArgumentAttributes(
               builder.getI64IntegerAttr(bytes));
       }
 
-      argAttrs[0].set(mlir::LLVM::LLVMDialect::getAlignAttrName(),
-                      builder.getI64IntegerAttr(
-                          getNaturalTypeAlignment(thisTy).getQuantity()));
+      argAttrs[0].set(
+          mlir::LLVM::LLVMDialect::getAlignAttrName(),
+          builder.getI64IntegerAttr(
+              getNaturalPointeeTypeAlignment(thisPtrTy).getQuantity()));
 
       // TODO(cir): the classic codegen has a recently-added bunch of logic for
       // 'dead_on_return' as an attribute. This both doesn't exist in the LLVM
@@ -702,9 +703,10 @@ void CIRGenModule::constructFunctionArgumentAttributes(
         argAttrList.set(mlir::LLVM::LLVMDialect::getNonNullAttrName(),
                         mlir::UnitAttr::get(&getMLIRContext()));
       if (pointeeTy->isObjectType())
-        argAttrList.set(mlir::LLVM::LLVMDialect::getAlignAttrName(),
-                        builder.getI64IntegerAttr(
-                            getNaturalTypeAlignment(argType).getQuantity()));
+        argAttrList.set(
+            mlir::LLVM::LLVMDialect::getAlignAttrName(),
+            builder.getI64IntegerAttr(
+                getNaturalPointeeTypeAlignment(argType).getQuantity()));
     }
   }
 }

--- a/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
@@ -903,10 +903,8 @@ LValue CIRGenFunction::emitDeclRefLValue(const DeclRefExpr *e) {
         }
       } else {
         // Should we be using the alignment of the constant pointer we emitted?
-        CharUnits alignment =
-            cgm.getNaturalTypeAlignment(e->getType(),
-                                        /*BaseInfo=*/nullptr,
-                                        /*forPointeeType=*/true);
+        CharUnits alignment = cgm.getNaturalTypeAlignment(
+            e->getType(), /*baseInfo=*/nullptr, /*forPointeeType=*/true);
         // Classic codegen passes TBAA as null-ptr to the above function, so it
         // probably needs to deal with that.
         assert(!cir::MissingFeatures::opTBAA());

--- a/clang/lib/CIR/CodeGen/CIRGenModule.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.cpp
@@ -239,6 +239,13 @@ CharUnits CIRGenModule::getNaturalTypeAlignment(QualType t,
   return alignment;
 }
 
+CharUnits
+CIRGenModule::getNaturalPointeeTypeAlignment(QualType t,
+                                             LValueBaseInfo *baseInfo) {
+  return getNaturalTypeAlignment(t->getPointeeType(), baseInfo,
+                                 /*forPointeeType=*/true);
+}
+
 const TargetCIRGenInfo &CIRGenModule::getTargetCIRGenInfo() {
   if (theTargetCIRGenInfo)
     return *theTargetCIRGenInfo;

--- a/clang/lib/CIR/CodeGen/CIRGenModule.h
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.h
@@ -400,6 +400,9 @@ public:
   clang::CharUnits getNaturalTypeAlignment(clang::QualType t,
                                            LValueBaseInfo *baseInfo = nullptr,
                                            bool forPointeeType = false);
+  clang::CharUnits
+  getNaturalPointeeTypeAlignment(clang::QualType t,
+                                 LValueBaseInfo *baseInfo = nullptr);
 
   /// Returns the minimum object size for an object of the given class type
   /// (or a class derived from it).

--- a/clang/test/CIR/CodeGen/arg-attrs.cpp
+++ b/clang/test/CIR/CodeGen/arg-attrs.cpp
@@ -18,9 +18,32 @@ void Struct::this_func(){}
   // CIR: cir.func {{.*}}@_ZN6Struct9this_funcEv(%{{.*}}: !cir.ptr<!rec_Struct> {llvm.align = 4 : i64, llvm.dereferenceable = 20 : i64, llvm.nonnull, llvm.noundef} {{.*}}) {{.*}} {
   // BOTH: define {{.*}}void @_ZN6Struct9this_funcEv(ptr noundef nonnull align 4 dereferenceable(20) %{{.*}})
 void Struct::arg_attr(Struct s, int &i, Incomplete &j){}
-  // CIR: cir.func {{.*}}@_ZN6Struct8arg_attrES_RiR10Incomplete(%{{.*}}: !cir.ptr<!rec_Struct> {llvm.align = 4 : i64, llvm.dereferenceable = 20 : i64, llvm.nonnull, llvm.noundef} {{.*}}, %{{.*}}: !rec_Struct {{.*}}, %{{.*}}: !cir.ptr<!s32i> {llvm.align = 8 : i64, llvm.dereferenceable = 4 : i64, llvm.nonnull, llvm.noundef} {{.*}}, %arg3: !cir.ptr<!rec_Incomplete> {llvm.align = 8 : i64, llvm.nonnull, llvm.noundef} {{.*}}) {{.*}} {
-  // LLVM: define {{.*}}void @_ZN6Struct8arg_attrES_RiR10Incomplete(ptr noundef nonnull align 4 dereferenceable(20) %{{.*}}, %struct.Struct %{{.*}}, ptr noundef nonnull align 8 dereferenceable(4) %{{.*}}, ptr noundef nonnull align 8 %{{.*}})
+  // CIR: cir.func {{.*}}@_ZN6Struct8arg_attrES_RiR10Incomplete(%{{.*}}: !cir.ptr<!rec_Struct> {llvm.align = 4 : i64, llvm.dereferenceable = 20 : i64, llvm.nonnull, llvm.noundef} {{.*}}, %{{.*}}: !rec_Struct {{.*}}, %{{.*}}: !cir.ptr<!s32i> {llvm.align = 4 : i64, llvm.dereferenceable = 4 : i64, llvm.nonnull, llvm.noundef} {{.*}}, %arg3: !cir.ptr<!rec_Incomplete> {llvm.align = 1 : i64, llvm.nonnull, llvm.noundef} {{.*}}) {{.*}} {
+  // LLVM: define {{.*}}void @_ZN6Struct8arg_attrES_RiR10Incomplete(ptr noundef nonnull align 4 dereferenceable(20) %{{.*}}, %struct.Struct %{{.*}}, ptr noundef nonnull align 4 dereferenceable(4) %{{.*}}, ptr noundef nonnull align 1 %{{.*}})
   // OGCG: define {{.*}}void @_ZN6Struct8arg_attrES_RiR10Incomplete(ptr noundef nonnull align 4 dereferenceable(20) %{{.*}}, ptr noundef byval(%struct.Struct) align 8 %{{.*}}, ptr noundef nonnull align 4 dereferenceable(4) %{{.*}}, ptr noundef nonnull align 1 %{{.*}})
+
+struct __attribute__((aligned(32))) Aligned32 {
+  int x;
+  void method();
+};
+
+void Aligned32::method() {}
+  // CIR: cir.func {{.*}}@_ZN9Aligned326methodEv(%{{.*}}: !cir.ptr<!rec_Aligned32> {llvm.align = 32 : i64, llvm.dereferenceable = 32 : i64, llvm.nonnull, llvm.noundef} {{.*}}) {{.*}} {
+  // BOTH: define {{.*}}void @_ZN9Aligned326methodEv(ptr noundef nonnull align 32 dereferenceable(32) %{{.*}})
+
+void aligned_ref(Aligned32 &a) {}
+  // CIR: cir.func {{.*}}@_Z11aligned_refR9Aligned32(%{{.*}}: !cir.ptr<!rec_Aligned32> {llvm.align = 32 : i64, llvm.dereferenceable = 32 : i64, llvm.nonnull, llvm.noundef} {{.*}}) {{.*}} {
+  // BOTH: define {{.*}}void @_Z11aligned_refR9Aligned32(ptr noundef nonnull align 32 dereferenceable(32) %{{.*}})
+
+int g;
+int &return_int_ref() { return g; }
+  // CIR: cir.func {{.*}}@_Z14return_int_refv() -> (!cir.ptr<!s32i> {llvm.align = 4 : i64, llvm.dereferenceable = 4 : i64, llvm.nonnull, llvm.noundef}) {{.*}} {
+  // BOTH: define {{.*}}noundef nonnull align 4 dereferenceable(4) ptr @_Z14return_int_refv()
+
+Aligned32 ga;
+Aligned32 &return_aligned_ref() { return ga; }
+  // CIR: cir.func {{.*}}@_Z18return_aligned_refv() -> (!cir.ptr<!rec_Aligned32> {llvm.align = 32 : i64, llvm.dereferenceable = 32 : i64, llvm.nonnull, llvm.noundef}) {{.*}} {
+  // BOTH: define {{.*}}noundef nonnull align 32 dereferenceable(32) ptr @_Z18return_aligned_refv()
 
 void caller(Struct s, int i, Incomplete &inc) {
 
@@ -28,8 +51,8 @@ void caller(Struct s, int i, Incomplete &inc) {
   // CIR: cir.call @_ZN6Struct9this_funcEv(%{{.*}}) : (!cir.ptr<!rec_Struct> {llvm.align = 4 : i64, llvm.dereferenceable = 20 : i64, llvm.nonnull, llvm.noundef})
   // BOTH: call void @_ZN6Struct9this_funcEv(ptr noundef nonnull align 4 dereferenceable(20) %{{.*}})
   s.arg_attr(s, i, inc);
-  // CIR: cir.call @_ZN6Struct8arg_attrES_RiR10Incomplete(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) : (!cir.ptr<!rec_Struct> {llvm.align = 4 : i64, llvm.dereferenceable = 20 : i64, llvm.nonnull, llvm.noundef}, !rec_Struct, !cir.ptr<!s32i> {llvm.align = 8 : i64, llvm.dereferenceable = 4 : i64, llvm.nonnull, llvm.noundef}, !cir.ptr<!rec_Incomplete> {llvm.align = 8 : i64, llvm.nonnull, llvm.noundef})
-  // LLVM: call void @_ZN6Struct8arg_attrES_RiR10Incomplete(ptr noundef nonnull align 4 dereferenceable(20) %{{.*}}, %struct.Struct %{{.*}}, ptr noundef nonnull align 8 dereferenceable(4) %{{.*}}, ptr noundef nonnull align 8 %{{.*}})
+  // CIR: cir.call @_ZN6Struct8arg_attrES_RiR10Incomplete(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) : (!cir.ptr<!rec_Struct> {llvm.align = 4 : i64, llvm.dereferenceable = 20 : i64, llvm.nonnull, llvm.noundef}, !rec_Struct, !cir.ptr<!s32i> {llvm.align = 4 : i64, llvm.dereferenceable = 4 : i64, llvm.nonnull, llvm.noundef}, !cir.ptr<!rec_Incomplete> {llvm.align = 1 : i64, llvm.nonnull, llvm.noundef})
+  // LLVM: call void @_ZN6Struct8arg_attrES_RiR10Incomplete(ptr noundef nonnull align 4 dereferenceable(20) %{{.*}}, %struct.Struct %{{.*}}, ptr noundef nonnull align 4 dereferenceable(4) %{{.*}}, ptr noundef nonnull align 1 %{{.*}})
   // OGCG: call void @_ZN6Struct8arg_attrES_RiR10Incomplete(ptr noundef nonnull align 4 dereferenceable(20) %{{.*}}, ptr noundef byval(%struct.Struct) align 8 %{{.*}}, ptr noundef nonnull align 4 dereferenceable(4) %{{.*}}, ptr noundef nonnull align 1 %{{.*}})
 }
 

--- a/clang/test/CIR/CodeGen/invoke-attrs.cpp
+++ b/clang/test/CIR/CodeGen/invoke-attrs.cpp
@@ -44,13 +44,13 @@ void test_ref_param_attrs(S &s, int &i) {
 }
 
 // CIR-LABEL: cir.func {{.*}}@_Z20test_ref_param_attrsR1SRi
-// CIR:         cir.call @_ZN1S9ref_paramERi({{%.*}}, {{%.*}}) : (!cir.ptr<!rec_S> {llvm.align = 4 : i64, llvm.dereferenceable = 20 : i64, llvm.nonnull, llvm.noundef}, !cir.ptr<!s32i> {llvm.align = 8 : i64, llvm.dereferenceable = 4 : i64, llvm.nonnull, llvm.noundef}) -> ()
+// CIR:         cir.call @_ZN1S9ref_paramERi({{%.*}}, {{%.*}}) : (!cir.ptr<!rec_S> {llvm.align = 4 : i64, llvm.dereferenceable = 20 : i64, llvm.nonnull, llvm.noundef}, !cir.ptr<!s32i> {llvm.align = 4 : i64, llvm.dereferenceable = 4 : i64, llvm.nonnull, llvm.noundef}) -> ()
 
 // CIR-FLAT-LABEL: cir.func {{.*}}@_Z20test_ref_param_attrsR1SRi
-// CIR-FLAT:         cir.try_call @_ZN1S9ref_paramERi({{%.*}}, {{%.*}}) ^{{bb[0-9]+}}, ^{{bb[0-9]+}} : (!cir.ptr<!rec_S> {llvm.align = 4 : i64, llvm.dereferenceable = 20 : i64, llvm.nonnull, llvm.noundef}, !cir.ptr<!s32i> {llvm.align = 8 : i64, llvm.dereferenceable = 4 : i64, llvm.nonnull, llvm.noundef}) -> ()
+// CIR-FLAT:         cir.try_call @_ZN1S9ref_paramERi({{%.*}}, {{%.*}}) ^{{bb[0-9]+}}, ^{{bb[0-9]+}} : (!cir.ptr<!rec_S> {llvm.align = 4 : i64, llvm.dereferenceable = 20 : i64, llvm.nonnull, llvm.noundef}, !cir.ptr<!s32i> {llvm.align = 4 : i64, llvm.dereferenceable = 4 : i64, llvm.nonnull, llvm.noundef}) -> ()
 
 // LLVM-LABEL: define {{.*}} void @_Z20test_ref_param_attrsR1SRi
-// LLVM:         invoke void @_ZN1S9ref_paramERi(ptr noundef nonnull align 4 dereferenceable(20) {{%.*}}, ptr noundef nonnull align 8 dereferenceable(4) {{%.*}})
+// LLVM:         invoke void @_ZN1S9ref_paramERi(ptr noundef nonnull align 4 dereferenceable(20) {{%.*}}, ptr noundef nonnull align 4 dereferenceable(4) {{%.*}})
 
 // OGCG-LABEL: define {{.*}} void @_Z20test_ref_param_attrsR1SRi
 // OGCG:         invoke void @_ZN1S9ref_paramERi(ptr noundef nonnull align 4 dereferenceable(20) {{%.*}}, ptr noundef nonnull align 4 dereferenceable(4) {{%.*}})


### PR DESCRIPTION
getNaturalTypeAlignment on a reference type returned pointer alignment
instead of pointee alignment. Pass the pointee type with
forPointeeType=true to match traditional codegen's
getNaturalPointeeTypeAlignment behavior. Fix applies to both argument
and return type attribute construction paths.