### PR TITLE
[clang][CMake] Fix clangSupport_tablegen ODR violation with LLVM_LINK_LLVM_DYLIB

### DIFF
--- a/clang/lib/Support/CMakeLists.txt
+++ b/clang/lib/Support/CMakeLists.txt
@@ -15,11 +15,7 @@ set(clangSupport_sources
 
 add_clang_library(clangSupport ${clangSupport_sources})
 
-if (TARGET obj.clangSupport)
-  add_library(clangSupport_tablegen ALIAS obj.clangSupport)
-elseif (NOT LLVM_LINK_LLVM_DYLIB)
-  add_library(clangSupport_tablegen ALIAS clangSupport)
-else()
+if (LLVM_LINK_LLVM_DYLIB)
   # Build a version of the support library that does not link against
   # libLLVM-*.so, to be used by clang-tblgen. This is so clang-tblgen doesn't
   # link against libLLVMSupport twice (once statically and once via
@@ -27,6 +23,10 @@ else()
   add_llvm_library(clangSupport_tablegen
     BUILDTREE_ONLY STATIC DISABLE_LLVM_LINK_LLVM_DYLIB
     ${clangSupport_sources})
+elseif (TARGET obj.clangSupport)
+  add_library(clangSupport_tablegen ALIAS obj.clangSupport)
+else()
+  add_library(clangSupport_tablegen ALIAS clangSupport)
 endif()
 
 set(LLVM_COMMON_DEPENDS ${LLVM_COMMON_DEPENDS_OLD})


### PR DESCRIPTION
After 42b638c6b40d ("Propagate dependencies to OBJECT libraries in add_llvm_library"), obj.clangSupport now inherits clangSupport's LINK_LIBRARIES via target_link_libraries, which includes libLLVM.so when LLVM_LINK_LLVM_DYLIB is enabled.

Previously the obj.clangSupport alias path was harmless because the OBJECT library carried no link dependencies. Now, aliasing clangSupport_tablegen to obj.clangSupport in DYLIB mode causes clang-tblgen to transitively link libLLVM.so, while also having LLVM symbols compiled in statically — triggering an ASan ODR violation on globals like llvm::vfs::FileSystem::ID.

Fix by checking LLVM_LINK_LLVM_DYLIB first and unconditionally taking the DISABLE_LLVM_LINK_LLVM_DYLIB static rebuild path in that case, regardless of whether obj.clangSupport exists.