### PR TITLE
Revert "[CMake] Propagate dependencies to OBJECT libraries in add_llvm_library (re-land)

### DIFF
--- a/clang/cmake/modules/AddClang.cmake
+++ b/clang/cmake/modules/AddClang.cmake
@@ -217,7 +217,7 @@ endmacro()
 
 function(clang_target_link_libraries target type)
   if (TARGET obj.${target})
-    target_link_libraries(obj.${target} ${type} ${ARGN})
+    target_link_libraries(obj.${target} ${ARGN})
   endif()
 
   get_property(LLVM_DRIVER_TOOLS GLOBAL PROPERTY LLVM_DRIVER_TOOLS)

--- a/lld/tools/lld/CMakeLists.txt
+++ b/lld/tools/lld/CMakeLists.txt
@@ -13,7 +13,7 @@ export_executable_symbols_for_plugins(lld)
 
 function(lld_target_link_libraries target type)
   if (TARGET obj.${target})
-    target_link_libraries(obj.${target} ${type} ${ARGN})
+    target_link_libraries(obj.${target} ${ARGN})
   endif()
 
   get_property(LLVM_DRIVER_TOOLS GLOBAL PROPERTY LLVM_DRIVER_TOOLS)

--- a/llvm/cmake/modules/AddLLVM.cmake
+++ b/llvm/cmake/modules/AddLLVM.cmake
@@ -6,14 +6,14 @@ include(DetermineGCCCompatible)
 
 # get_subproject_title(titlevar)
 #   Set ${outvar} to the title of the current LLVM subproject (Clang, MLIR ...)
-#
+# 
 # The title is set in the subproject's top-level using the variable
 # LLVM_SUBPROJECT_TITLE. If it does not exist, it is assumed it is LLVM itself.
 # The title is not semantically significant, but use to create folders in
 # CMake-generated IDE projects (Visual Studio/XCode).
 function(get_subproject_title outvar)
   if (LLVM_SUBPROJECT_TITLE)
-    set(${outvar} "${LLVM_SUBPROJECT_TITLE}" PARENT_SCOPE)
+    set(${outvar} "${LLVM_SUBPROJECT_TITLE}" PARENT_SCOPE) 
   else ()
     set(${outvar} "LLVM" PARENT_SCOPE)
   endif ()
@@ -641,12 +641,7 @@ function(llvm_add_library name)
     # Do add_dependencies(obj) later due to CMake issue 14747.
     list(APPEND objlibs ${obj_name})
 
-    # Bring in the target include directories and link info from our original
-    # target. target_link_libraries propagates transitive dependencies with
-    # proper SYSTEM include handling from IMPORTED targets.
-    # target_include_directories propagates include directories set directly on
-    # the target.
-    target_link_libraries(${obj_name} PRIVATE $<TARGET_PROPERTY:${name},LINK_LIBRARIES>)
+    # Bring in the target include directories from our original target.
     target_include_directories(${obj_name} PRIVATE $<TARGET_PROPERTY:${name},INCLUDE_DIRECTORIES>)
 
     set_target_properties(${obj_name} PROPERTIES FOLDER "${subproject_title}/Object Libraries")
@@ -712,11 +707,11 @@ function(llvm_add_library name)
   endif()
   set_target_properties(${name} PROPERTIES FOLDER "${subproject_title}/Libraries")
 
-  ## If were compiling with clang-cl use /Zc:dllexportInlines- to exclude inline
+  ## If were compiling with clang-cl use /Zc:dllexportInlines- to exclude inline 
   ## class members from being dllexport'ed to reduce compile time.
   ## This will also keep us below the 64k exported symbol limit
   ## https://blog.llvm.org/2018/11/30-faster-windows-builds-with-clang-cl_14.html
-  if(LLVM_BUILD_LLVM_DYLIB AND NOT LLVM_DYLIB_EXPORT_INLINES AND
+  if(LLVM_BUILD_LLVM_DYLIB AND NOT LLVM_DYLIB_EXPORT_INLINES AND 
      MSVC AND CMAKE_CXX_COMPILER_ID MATCHES Clang)
     target_compile_options(${name} PUBLIC /Zc:dllexportInlines-)
     if(TARGET ${obj_name})
@@ -1127,7 +1122,7 @@ macro(generate_llvm_objects name)
 
       set_property(GLOBAL APPEND PROPERTY LLVM_DRIVER_TOOLS ${name})
       set_property(GLOBAL APPEND PROPERTY LLVM_DRIVER_TOOL_ALIASES_${name} ${name})
-      target_link_libraries(${obj_name} PUBLIC ${LLVM_PTHREAD_LIB})
+      target_link_libraries(${obj_name} ${LLVM_PTHREAD_LIB})
       llvm_config(${obj_name} ${USE_SHARED} ${LLVM_LINK_COMPONENTS} )
     endif()
   endif()
@@ -1609,8 +1604,8 @@ macro(llvm_add_tool project name)
                 RUNTIME DESTINATION ${${project}_TOOLS_INSTALL_DIR}
                 COMPONENT ${name})
         if (LLVM_ENABLE_PDB)
-          install(FILES $<TARGET_PDB_FILE:${name}>
-                DESTINATION "${${project}_TOOLS_INSTALL_DIR}" COMPONENT ${name}
+          install(FILES $<TARGET_PDB_FILE:${name}> 
+                DESTINATION "${${project}_TOOLS_INSTALL_DIR}" COMPONENT ${name} 
                 OPTIONAL)
         endif()
 
@@ -1644,8 +1639,8 @@ macro(add_llvm_example name)
   if( LLVM_BUILD_EXAMPLES )
     install(TARGETS ${name} RUNTIME DESTINATION "${LLVM_EXAMPLES_INSTALL_DIR}")
     if (LLVM_ENABLE_PDB)
-      install(FILES $<TARGET_PDB_FILE:${name}>
-              DESTINATION "${LLVM_EXAMPLES_INSTALL_DIR}" COMPONENT ${name}
+      install(FILES $<TARGET_PDB_FILE:${name}> 
+              DESTINATION "${LLVM_EXAMPLES_INSTALL_DIR}" COMPONENT ${name} 
               OPTIONAL)
     endif()
   endif()
@@ -1683,8 +1678,8 @@ macro(add_llvm_utility name)
               RUNTIME DESTINATION ${LLVM_UTILS_INSTALL_DIR}
               COMPONENT ${name})
       if (LLVM_ENABLE_PDB)
-        install(FILES $<TARGET_PDB_FILE:${name}>
-                DESTINATION "${LLVM_UTILS_INSTALL_DIR}" COMPONENT ${name}
+        install(FILES $<TARGET_PDB_FILE:${name}> 
+                DESTINATION "${LLVM_UTILS_INSTALL_DIR}" COMPONENT ${name} 
                 OPTIONAL)
       endif()
 

--- a/llvm/cmake/modules/LLVM-Config.cmake
+++ b/llvm/cmake/modules/LLVM-Config.cmake
@@ -106,10 +106,7 @@ function(explicit_llvm_config executable)
   get_target_property(t ${executable} TYPE)
   if(t STREQUAL "STATIC_LIBRARY")
     target_link_libraries(${executable} INTERFACE ${LIBRARIES})
-  elseif(t STREQUAL "EXECUTABLE" OR
-         t STREQUAL "SHARED_LIBRARY" OR
-         t STREQUAL "MODULE_LIBRARY" OR
-         t STREQUAL "OBJECT_LIBRARY")
+  elseif(t STREQUAL "EXECUTABLE" OR t STREQUAL "SHARED_LIBRARY" OR t STREQUAL "MODULE_LIBRARY")
     target_link_libraries(${executable} PRIVATE ${LIBRARIES})
   else()
     # Use plain form for legacy user.

--- a/mlir/cmake/modules/AddMLIR.cmake
+++ b/mlir/cmake/modules/AddMLIR.cmake
@@ -769,7 +769,7 @@ endfunction(mlir_check_all_link_libraries)
 # used.
 function(mlir_target_link_libraries target type)
   if (TARGET obj.${target})
-    target_link_libraries(obj.${target} ${type} ${ARGN})
+    target_link_libraries(obj.${target} ${ARGN})
   endif()
 
   if (MLIR_LINK_MLIR_DYLIB)


### PR DESCRIPTION
This reverts commit 42b638c6b40d2670560bc5d855154d8677760360.

We revert due to an ODR violation regression described in https://github.com/llvm/llvm-project/pull/184201#issuecomment-4062785640

The clang-tblgen binary ends up linking against clangSupport both through the objlib and through libLLVM-*.so due to link interface propagation. A reland needs to find a way for the change in llvm_add_library to not propagate the link interface, just the include interface, like the $<COMPILE_ONLY:...> generator expression from CMake 3.27 achieves:
https://cmake.org/cmake/help/latest/manual/cmake-generator-expressions.7.html#genex:COMPILE_ONLY