### PR TITLE
[clang][CMake] Fix ODR violation with LLVM_LINK_LLVM_DYLIB

### DIFF
--- a/llvm/cmake/modules/AddLLVM.cmake
+++ b/llvm/cmake/modules/AddLLVM.cmake
@@ -641,13 +641,16 @@ function(llvm_add_library name)
     # Do add_dependencies(obj) later due to CMake issue 14747.
     list(APPEND objlibs ${obj_name})
 
-    # Bring in the target include directories and link info from our original
-    # target. target_link_libraries propagates transitive dependencies with
-    # proper SYSTEM include handling from IMPORTED targets.
-    # target_include_directories propagates include directories set directly on
-    # the target.
-    target_link_libraries(${obj_name} PRIVATE $<TARGET_PROPERTY:${name},LINK_LIBRARIES>)
-    target_include_directories(${obj_name} PRIVATE $<TARGET_PROPERTY:${name},INCLUDE_DIRECTORIES>)
+    # Propagate include directories from our original target.
+    # TODO: Use $<COMPILE_ONLY:${name}> instead of this manual propagation
+    # when minimum required CMake version is 3.27 or higher.
+    target_include_directories(${obj_name} SYSTEM
+      INTERFACE $<TARGET_PROPERTY:${name},INTERFACE_SYSTEM_INCLUDE_DIRECTORIES>
+      )
+    target_include_directories(${obj_name}
+      INTERFACE $<TARGET_PROPERTY:${name},INTERFACE_INCLUDE_DIRECTORIES>
+      PRIVATE $<TARGET_PROPERTY:${name},INCLUDE_DIRECTORIES>
+      )
 
     set_target_properties(${obj_name} PROPERTIES FOLDER "${subproject_title}/Object Libraries")
     if(ARG_DEPENDS)


### PR DESCRIPTION
After 42b638c6b40d ("Propagate dependencies to OBJECT libraries in add_llvm_library"), obj.clangSupport now inherits clangSupport's LINK_LIBRARIES via target_link_libraries, which includes libLLVM.so when LLVM_LINK_LLVM_DYLIB is enabled.

Previously the obj.clangSupport alias path was harmless because the OBJECT library carried no link dependencies. Now, aliasing clangSupport_tablegen to obj.clangSupport in DYLIB mode causes clang-tblgen to transitively link libLLVM.so, while also having LLVM symbols compiled in statically — triggering an ASan ODR violation on globals like llvm::vfs::FileSystem::ID.

Fix by only propagating parts of the compile interface instead of the full link interface - INTERFACE_INCLUDE_DIRECTORIES and INTERFACE_SYSTEM_INCLUDE_DIRECTORIES. Also add a TODO to consider replacing with target_link_libraries($<COMPILE_ONLY:tgt>) once minimum CMake version is 3.27 or higher.