### PR TITLE
[NFC] Delete `MCPseudoProbeDecoder`'s move constructor

### DIFF
--- a/llvm/include/llvm/MC/MCPseudoProbe.h
+++ b/llvm/include/llvm/MC/MCPseudoProbe.h
@@ -430,6 +430,14 @@ class MCPseudoProbeDecoder {
   ErrorOr<StringRef> readString(uint32_t Size);
 
 public:
+  // MCPseudoProbeDecoder cannot be copeied/moved due to address dependence on
+  // the DummyInlineRoot member address.
+  MCPseudoProbeDecoder() = default;
+  MCPseudoProbeDecoder(const MCPseudoProbeDecoder &) = delete;
+  MCPseudoProbeDecoder(MCPseudoProbeDecoder &&) = delete;
+  MCPseudoProbeDecoder &operator=(const MCPseudoProbeDecoder &) = delete;
+  MCPseudoProbeDecoder &operator=(MCPseudoProbeDecoder &&) = delete;
+
   using Uint64Set = DenseSet<uint64_t>;
   using Uint64Map = DenseMap<uint64_t, uint64_t>;
 

--- a/llvm/include/llvm/MC/MCPseudoProbe.h
+++ b/llvm/include/llvm/MC/MCPseudoProbe.h
@@ -430,7 +430,7 @@ class MCPseudoProbeDecoder {
   ErrorOr<StringRef> readString(uint32_t Size);
 
 public:
-  // MCPseudoProbeDecoder cannot be copeied/moved due to address dependence on
+  // MCPseudoProbeDecoder cannot be copied/moved due to address dependence on
   // the DummyInlineRoot member address.
   MCPseudoProbeDecoder() = default;
   MCPseudoProbeDecoder(const MCPseudoProbeDecoder &) = delete;


### PR DESCRIPTION
`MCPseudoProbeDecoder` cannot be copeied/moved due to its address dependence on the DummyInlineRoot member address. 