### PR TITLE
[libc][Github] Bump libc-fullbuild-tests.yml to clang 23

### DIFF
--- a/.github/workflows/libc-fullbuild-tests.yml
+++ b/.github/workflows/libc-fullbuild-tests.yml
@@ -27,68 +27,68 @@ jobs:
         include:
           - os: ubuntu-24.04
             build_type: Debug
-            c_compiler: clang-21
-            cpp_compiler: clang++-21
+            c_compiler: clang-23
+            cpp_compiler: clang++-23
             target: x86_64-unknown-linux-llvm
             include_scudo: ON
           - os: ubuntu-24.04
             build_type: Release
-            c_compiler: clang-21
-            cpp_compiler: clang++-21
+            c_compiler: clang-23
+            cpp_compiler: clang++-23
             target: x86_64-unknown-linux-llvm
             include_scudo: ON
           - os: ubuntu-24.04
             build_type: MinSizeRel
-            c_compiler: clang-21
-            cpp_compiler: clang++-21
+            c_compiler: clang-23
+            cpp_compiler: clang++-23
             target: x86_64-unknown-linux-llvm
             include_scudo: ON
           - os: ubuntu-24.04-arm
             build_type: Debug
-            c_compiler: clang-21
-            cpp_compiler: clang++-21
+            c_compiler: clang-23
+            cpp_compiler: clang++-23
             target: aarch64-unknown-linux-llvm
             include_scudo: ON
           - os: ubuntu-24.04
             build_type: Debug
-            c_compiler: clang-21
-            cpp_compiler: clang++-21
+            c_compiler: clang-23
+            cpp_compiler: clang++-23
             target: x86_64-unknown-uefi-llvm
             include_scudo: OFF
           - os: ubuntu-24.04
             build_type: MinSizeRel
-            c_compiler: clang-21
-            cpp_compiler: clang++-21
+            c_compiler: clang-23
+            cpp_compiler: clang++-23
             target: armv6m-none-eabi
             include_scudo: OFF
           - os: ubuntu-24.04
             build_type: MinSizeRel
-            c_compiler: clang-21
-            cpp_compiler: clang++-21
+            c_compiler: clang-23
+            cpp_compiler: clang++-23
             target: armv7m-none-eabi
             include_scudo: OFF
           - os: ubuntu-24.04
             build_type: MinSizeRel
-            c_compiler: clang-21
-            cpp_compiler: clang++-21
+            c_compiler: clang-23
+            cpp_compiler: clang++-23
             target: armv7em-none-eabi
             include_scudo: OFF
           - os: ubuntu-24.04
             build_type: MinSizeRel
-            c_compiler: clang-21
-            cpp_compiler: clang++-21
+            c_compiler: clang-23
+            cpp_compiler: clang++-23
             target: armv8m.main-none-eabi
             include_scudo: OFF
           - os: ubuntu-24.04
             build_type: MinSizeRel
-            c_compiler: clang-21
-            cpp_compiler: clang++-21
+            c_compiler: clang-23
+            cpp_compiler: clang++-23
             target: armv8.1m.main-none-eabi
             include_scudo: OFF
           - os: ubuntu-24.04
             build_type: MinSizeRel
-            c_compiler: clang-21
-            cpp_compiler: clang++-21
+            c_compiler: clang-23
+            cpp_compiler: clang++-23
             target: riscv32-unknown-elf
             include_scudo: OFF
           # TODO: add back gcc build when it is fixed


### PR DESCRIPTION
Do this now that it is available in the container.