### PR TITLE
[clang-tidy] Fix performance-use-std-move when moving a forward decl

### DIFF
--- a/clang-tools-extra/clang-tidy/performance/UseStdMoveCheck.cpp
+++ b/clang-tools-extra/clang-tidy/performance/UseStdMoveCheck.cpp
@@ -24,12 +24,12 @@ namespace clang::tidy::performance {
 
 namespace {
 AST_MATCHER(CXXRecordDecl, hasAccessibleNonTrivialMoveAssignment) {
-  const auto *ND = Node.getDefinition();
+  const CXXRecordDecl *ND = Node.getDefinition();
   if (!ND)
     return false;
   if (!ND->hasNonTrivialMoveAssignment())
     return false;
-  for (const auto *CM : ND->methods())
+  for (const CXXMethodDecl *CM : ND->methods())
     if (CM->isMoveAssignmentOperator())
       return !CM->isDeleted() && CM->getAccess() == AS_public;
   llvm_unreachable("Move Assignment Operator Not Found");

--- a/clang-tools-extra/clang-tidy/performance/UseStdMoveCheck.cpp
+++ b/clang-tools-extra/clang-tidy/performance/UseStdMoveCheck.cpp
@@ -24,9 +24,12 @@ namespace clang::tidy::performance {
 
 namespace {
 AST_MATCHER(CXXRecordDecl, hasAccessibleNonTrivialMoveAssignment) {
-  if (!Node.hasNonTrivialMoveAssignment())
+  const auto *ND = Node.getDefinition();
+  if (!ND)
     return false;
-  for (const auto *CM : Node.methods())
+  if (!ND->hasNonTrivialMoveAssignment())
+    return false;
+  for (const auto *CM : ND->methods())
     if (CM->isMoveAssignmentOperator())
       return !CM->isDeleted() && CM->getAccess() == AS_public;
   llvm_unreachable("Move Assignment Operator Not Found");

--- a/clang-tools-extra/test/clang-tidy/checkers/performance/use-std-move.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/performance/use-std-move.cpp
@@ -289,6 +289,21 @@ void NonConvertibleNonTrivialMoveAssignInLoop(NonTrivialMoveAssign& target, NonT
     target = source;
 }
 
+// Check moving incomplete definition
+// ----------------------------------
+
+struct fwd_cls;
+struct fwd_cls {
+  void ConvertibleNonTrivialMoveAssignReferecingForwardDecl(fwd_cls src) {
+    // CHECK-MESSAGES: [[@LINE+2]]:13: warning: 'src' could be moved here [performance-use-std-move]
+    // CHECK-FIXES: *this = std::move(src);
+    *this = src;
+  }
+  fwd_cls &operator=(const fwd_cls &C);
+  fwd_cls &operator=(fwd_cls &&);
+};
+
+
 // Check moving for invalid / non profitable type or operation
 // -----------------------------------------------------------
 


### PR DESCRIPTION
This fixes running clang-tidy on top-of-tree with that check on.