### PR TITLE
[lldb][Process/FreeBSDKernelCore] Remove interactive mode check

### DIFF
--- a/lldb/source/Plugins/Process/FreeBSD-Kernel-Core/ProcessFreeBSDKernelCore.cpp
+++ b/lldb/source/Plugins/Process/FreeBSD-Kernel-Core/ProcessFreeBSDKernelCore.cpp
@@ -394,10 +394,7 @@ void ProcessFreeBSDKernelCore::PrintUnreadMessage() {
   Target &target = GetTarget();
   Debugger &debugger = target.GetDebugger();
 
-  // Todo: GetCommandInterpreter().IsInteractive() is flaky. When it is
-  // stabilized, restore the following code.
-  // if (!debugger.GetCommandInterpreter().IsInteractive())
-  //   return;
+  // Todo: Return early when lldb is in non-batch mode.
 
   Status error;
 

--- a/lldb/source/Plugins/Process/FreeBSD-Kernel-Core/ProcessFreeBSDKernelCore.cpp
+++ b/lldb/source/Plugins/Process/FreeBSD-Kernel-Core/ProcessFreeBSDKernelCore.cpp
@@ -394,8 +394,10 @@ void ProcessFreeBSDKernelCore::PrintUnreadMessage() {
   Target &target = GetTarget();
   Debugger &debugger = target.GetDebugger();
 
-  if (!debugger.GetCommandInterpreter().IsInteractive())
-    return;
+  // Todo: GetCommandInterpreter().IsInteractive() is flaky. When it is
+  // stabilized, restore the following code.
+  // if (!debugger.GetCommandInterpreter().IsInteractive())
+  //   return;
 
   Status error;
 


### PR DESCRIPTION
`Debugger.GetCommandInterpreter().IsInteractive()` returned true when I tested on #178027's source branch. But after it was merged into main some change that was merged between the parent commit of #178027 and parent commit of the merge commit made `IsInteractive()` return false in non-batch mode, making `ProcessFreeBSDKernelCore::PrintUnreadMessage()` returns early. Disable the interactive mode check until a fix or workaround is found.

Fixes: 9d9c7fc00bdddd72e78b19e9fbb6af9d07c2218b (#178027)