### PR TITLE
[orc-rt] Don't return Error in Service::OnComplete.

### DIFF
--- a/orc-rt/include/orc-rt/Service.h
+++ b/orc-rt/include/orc-rt/Service.h
@@ -24,7 +24,7 @@ namespace orc_rt {
 /// detaches, and when the Session shuts down.
 class Service {
 public:
-  using OnCompleteFn = move_only_function<void(Error)>;
+  using OnCompleteFn = move_only_function<void()>;
 
   virtual ~Service();
 

--- a/orc-rt/include/orc-rt/Session.h
+++ b/orc-rt/include/orc-rt/Session.h
@@ -182,7 +182,7 @@ private:
     std::vector<OnShutdownCompleteFn> OnCompletes;
   };
 
-  void shutdownNext(Error Err);
+  void shutdownNext();
   void shutdownComplete();
 
   void handleWrapperCall(uint64_t CallId, orc_rt_WrapperFunction Fn,

--- a/orc-rt/lib/executor/Session.cpp
+++ b/orc-rt/lib/executor/Session.cpp
@@ -53,7 +53,7 @@ void Session::shutdown(OnShutdownCompleteFn OnShutdownComplete) {
   // OnShutdownComplete is _not_ set (i.e. was moved into the list of pending
   // handlers), and we didn't return under the lock above, so we must be
   // responsible for the shutdown. Call shutdownNext.
-  shutdownNext(Error::success());
+  shutdownNext();
 }
 
 void Session::waitForShutdown() {
@@ -78,17 +78,14 @@ void Session::detachFromController() {
   }
 }
 
-void Session::shutdownNext(Error Err) {
-  if (Err)
-    reportError(std::move(Err));
-
+void Session::shutdownNext() {
   if (SI->Services.empty())
     return shutdownComplete();
 
   // Get the next Service to shut down.
   auto NextSrv = std::move(SI->Services.back());
   SI->Services.pop_back();
-  NextSrv->onShutdown([this](Error Err) { shutdownNext(std::move(Err)); });
+  NextSrv->onShutdown([this]() { shutdownNext(); });
 }
 
 void Session::shutdownComplete() {

--- a/orc-rt/lib/executor/SimpleNativeMemoryMap.cpp
+++ b/orc-rt/lib/executor/SimpleNativeMemoryMap.cpp
@@ -225,7 +225,7 @@ void SimpleNativeMemoryMap::deinitializeMultiple(
 void SimpleNativeMemoryMap::onDetach(Service::OnCompleteFn OnComplete) {
   // Detach is a noop for now: we just retain all actions to run at shutdown
   // time.
-  OnComplete(Error::success());
+  OnComplete();
 }
 
 void SimpleNativeMemoryMap::onShutdown(Service::OnCompleteFn OnComplete) {
@@ -304,7 +304,7 @@ void SimpleNativeMemoryMap::deinitializeNext(
 void SimpleNativeMemoryMap::shutdownNext(Service::OnCompleteFn OnComplete,
                                          std::vector<void *> Bases) {
   if (Bases.empty())
-    return OnComplete(Error::success());
+    return OnComplete();
 
   auto *Base = Bases.back();
   Bases.pop_back();


### PR DESCRIPTION
The Session can't do anything useful with these errors, it can only report them. It's cleaner if the Service objects just report the error directly.