### PR TITLE
[MC][NFC] Clarify the `Reg` value range in `MCRegister`'s comments

### DIFF
--- a/llvm/include/llvm/MC/MCRegister.h
+++ b/llvm/include/llvm/MC/MCRegister.h
@@ -45,13 +45,14 @@ class MCRegister {
 public:
   constexpr MCRegister(unsigned Val = 0) : Reg(Val) {}
 
-  // Register numbers can represent physical registers, virtual registers, and
-  // sometimes stack slots. The unsigned values are divided into these ranges:
+  // Only a small range of `Reg` value is considered valid:
   //
   //   0           Not a register, can be used as a sentinel.
   //   [1;2^30)    Physical registers assigned by TableGen.
-  //   [2^30;2^31) Stack slots. (Rarely used.)
-  //   [2^31;2^32) Virtual registers assigned by MachineRegisterInfo.
+  //
+  // Any other `Reg` values, which are most likely originated from incorrectly
+  // copying virtual register or stack slot from `Register`, are not allowed
+  // in `MCRegister`. This is currently enforced by `MCRegister::from` below.
   //
   // Further sentinels can be allocated from the small negative integers.
   // DenseMapInfo<unsigned> uses -1u and -2u.


### PR DESCRIPTION
In the comment for `Reg` value in MCRegister, the semantic of virtual register and stack slot bits are irrelevant -- we really only care if `Reg` falls within `[0;2^30)`. So I feel like keeping / presenting those information might confuse the readers.

This patch changes that comment to be more explicit on the allowed `Reg` value.

Related discussion: https://discourse.llvm.org/t/relation-between-register-and-mcregister/56545