### PR TITLE
[libcxx] p3008 atomic fp min/max

### DIFF
--- a/libcxx/docs/ReleaseNotes/23.rst
+++ b/libcxx/docs/ReleaseNotes/23.rst
@@ -39,6 +39,7 @@ Implemented Papers
 ------------------
 
 - P2440R1: ``ranges::iota``, ``ranges::shift_left`` and ``ranges::shift_right`` (`Github <https://llvm.org/PR105184>`__)
+- P3008R6: Atomic floating-point min/max (`Github <https://github.com/llvm/llvm-project/issues/148168>`__)
 
 Improvements and New Features
 -----------------------------

--- a/libcxx/docs/Status/Cxx2cPapers.csv
+++ b/libcxx/docs/Status/Cxx2cPapers.csv
@@ -147,7 +147,7 @@
 "`P3557R3 <https://wg21.link/P3557R3>`__","High-Quality Sender Diagnostics with Constexpr Exceptions","2025-06 (Sofia)","","","`#148162 <https://github.com/llvm/llvm-project/issues/148162>`__",""
 "`P3560R2 <https://wg21.link/P3560R2>`__","Error Handling in Reflection","2025-06 (Sofia)","","","`#148128 <https://github.com/llvm/llvm-project/issues/148128>`__",""
 "`P3503R3 <https://wg21.link/P3503R3>`__","Make type-erased allocator use in ``promise`` and ``packaged_task`` consistent","2025-06 (Sofia)","","","`#148164 <https://github.com/llvm/llvm-project/issues/148164>`__",""
-"`P3008R6 <https://wg21.link/P3008R6>`__","Atomic floating-point min/max","2025-06 (Sofia)","","","`#148168 <https://github.com/llvm/llvm-project/issues/148168>`__",""
+"`P3008R6 <https://wg21.link/P3008R6>`__","Atomic floating-point min/max","2025-06 (Sofia)","|Complete|","23","`#148168 <https://github.com/llvm/llvm-project/issues/148168>`__",""
 "`P3111R8 <https://wg21.link/P3111R8>`__","Atomic Reduction Operations","2025-06 (Sofia)","","","`#148174 <https://github.com/llvm/llvm-project/issues/148174>`__",""
 "`P3060R3 <https://wg21.link/P3060R3>`__","Add ``std::views::indices(n)``","2025-06 (Sofia)","|Complete|","22","`#148175 <https://github.com/llvm/llvm-project/issues/148175>`__",""
 "`P2319R5 <https://wg21.link/P2319R5>`__","Prevent ``path`` presentation problems","2025-06 (Sofia)","","","`#148177 <https://github.com/llvm/llvm-project/issues/148177>`__",""

--- a/libcxx/include/__atomic/atomic.h
+++ b/libcxx/include/__atomic/atomic.h
@@ -18,6 +18,7 @@
 #include <__atomic/support.h>
 #include <__config>
 #include <__cstddef/ptrdiff_t.h>
+#include <__math/min_max.h>
 #include <__memory/addressof.h>
 #include <__type_traits/enable_if.h>
 #include <__type_traits/is_floating_point.h>
@@ -331,10 +332,15 @@ template <class _Tp>
   requires is_floating_point_v<_Tp>
 struct atomic<_Tp> : __atomic_base<_Tp> {
 private:
-  template <class _This, class _Operation, class _BuiltinOp>
+  template <class _This, class _Operation, class _BuiltinOp, bool _HasBuiltin = std::__has_rmw_builtin<_Tp>()>
   _LIBCPP_HIDE_FROM_ABI static _Tp
-  __rmw_op(_This&& __self, _Tp __operand, memory_order __m, _Operation __operation, _BuiltinOp __builtin_op) {
-    if constexpr (std::__has_rmw_builtin<_Tp>()) {
+  __rmw_op(_This&& __self,
+           _Tp __operand,
+           memory_order __m,
+           _Operation __operation,
+           _BuiltinOp __builtin_op,
+           std::integral_constant<bool, _HasBuiltin> = {}) {
+    if constexpr (_HasBuiltin) {
       return __builtin_op(std::addressof(std::forward<_This>(__self).__a_), __operand, __m);
     } else {
       _Tp __old = __self.load(memory_order_relaxed);
@@ -371,6 +377,44 @@ private:
     auto __minus = [](auto __a, auto __b) { return __a - __b; };
     return __rmw_op(std::forward<_This>(__self), __operand, __m, __minus, __builtin_op);
   }
+
+  template <class _This>
+  _LIBCPP_HIDE_FROM_ABI static _Tp __fetch_min(_This&& __self, _Tp __operand, memory_order __m) {
+    auto __op = [](_Tp __a, _Tp __b) { return std::__math::fmin(__a, __b); };
+    return __rmw_op(std::forward<_This>(__self), __operand, __m, __op, __op, std::false_type{});
+  }
+
+  template <class _This>
+  _LIBCPP_HIDE_FROM_ABI static _Tp __fetch_max(_This&& __self, _Tp __operand, memory_order __m) {
+    auto __op = [](_Tp __a, _Tp __b) { return std::__math::fmax(__a, __b); };
+    return __rmw_op(std::forward<_This>(__self), __operand, __m, __op, __op, std::false_type{});
+  }
+
+#  if _LIBCPP_STD_VER >= 26
+  template <class _This>
+  _LIBCPP_HIDE_FROM_ABI static _Tp __fetch_fminimum(_This&& __self, _Tp __operand, memory_order __m) {
+    auto __op = [](_Tp __a, _Tp __b) { return std::__math::fminimum(__a, __b); };
+    return __rmw_op(std::forward<_This>(__self), __operand, __m, __op, __op, std::false_type{});
+  }
+
+  template <class _This>
+  _LIBCPP_HIDE_FROM_ABI static _Tp __fetch_fmaximum(_This&& __self, _Tp __operand, memory_order __m) {
+    auto __op = [](_Tp __a, _Tp __b) { return std::__math::fmaximum(__a, __b); };
+    return __rmw_op(std::forward<_This>(__self), __operand, __m, __op, __op, std::false_type{});
+  }
+
+  template <class _This>
+  _LIBCPP_HIDE_FROM_ABI static _Tp __fetch_fminimum_num(_This&& __self, _Tp __operand, memory_order __m) {
+    auto __op = [](_Tp __a, _Tp __b) { return std::__math::fminimum_num(__a, __b); };
+    return __rmw_op(std::forward<_This>(__self), __operand, __m, __op, __op, std::false_type{});
+  }
+
+  template <class _This>
+  _LIBCPP_HIDE_FROM_ABI static _Tp __fetch_fmaximum_num(_This&& __self, _Tp __operand, memory_order __m) {
+    auto __op = [](_Tp __a, _Tp __b) { return std::__math::fmaximum_num(__a, __b); };
+    return __rmw_op(std::forward<_This>(__self), __operand, __m, __op, __op, std::false_type{});
+  }
+#  endif // _LIBCPP_STD_VER >= 26
 
 public:
   using __base _LIBCPP_NODEBUG = __atomic_base<_Tp>;
@@ -414,6 +458,68 @@ public:
   _LIBCPP_HIDE_FROM_ABI _Tp fetch_sub(_Tp __op, memory_order __m = memory_order_seq_cst) noexcept {
     return __fetch_sub(*this, __op, __m);
   }
+
+  _LIBCPP_HIDE_FROM_ABI _Tp fetch_min(_Tp __op, memory_order __m = memory_order_seq_cst) volatile noexcept
+    requires __base::is_always_lock_free
+  {
+    return __fetch_min(*this, __op, __m);
+  }
+
+  _LIBCPP_HIDE_FROM_ABI _Tp fetch_min(_Tp __op, memory_order __m = memory_order_seq_cst) noexcept {
+    return __fetch_min(*this, __op, __m);
+  }
+
+  _LIBCPP_HIDE_FROM_ABI _Tp fetch_max(_Tp __op, memory_order __m = memory_order_seq_cst) volatile noexcept
+    requires __base::is_always_lock_free
+  {
+    return __fetch_max(*this, __op, __m);
+  }
+
+  _LIBCPP_HIDE_FROM_ABI _Tp fetch_max(_Tp __op, memory_order __m = memory_order_seq_cst) noexcept {
+    return __fetch_max(*this, __op, __m);
+  }
+
+#  if _LIBCPP_STD_VER >= 26
+  _LIBCPP_HIDE_FROM_ABI _Tp fetch_fminimum(_Tp __op, memory_order __m = memory_order_seq_cst) volatile noexcept
+    requires __base::is_always_lock_free
+  {
+    return __fetch_fminimum(*this, __op, __m);
+  }
+
+  _LIBCPP_HIDE_FROM_ABI _Tp fetch_fminimum(_Tp __op, memory_order __m = memory_order_seq_cst) noexcept {
+    return __fetch_fminimum(*this, __op, __m);
+  }
+
+  _LIBCPP_HIDE_FROM_ABI _Tp fetch_fmaximum(_Tp __op, memory_order __m = memory_order_seq_cst) volatile noexcept
+    requires __base::is_always_lock_free
+  {
+    return __fetch_fmaximum(*this, __op, __m);
+  }
+
+  _LIBCPP_HIDE_FROM_ABI _Tp fetch_fmaximum(_Tp __op, memory_order __m = memory_order_seq_cst) noexcept {
+    return __fetch_fmaximum(*this, __op, __m);
+  }
+
+  _LIBCPP_HIDE_FROM_ABI _Tp fetch_fminimum_num(_Tp __op, memory_order __m = memory_order_seq_cst) volatile noexcept
+    requires __base::is_always_lock_free
+  {
+    return __fetch_fminimum_num(*this, __op, __m);
+  }
+
+  _LIBCPP_HIDE_FROM_ABI _Tp fetch_fminimum_num(_Tp __op, memory_order __m = memory_order_seq_cst) noexcept {
+    return __fetch_fminimum_num(*this, __op, __m);
+  }
+
+  _LIBCPP_HIDE_FROM_ABI _Tp fetch_fmaximum_num(_Tp __op, memory_order __m = memory_order_seq_cst) volatile noexcept
+    requires __base::is_always_lock_free
+  {
+    return __fetch_fmaximum_num(*this, __op, __m);
+  }
+
+  _LIBCPP_HIDE_FROM_ABI _Tp fetch_fmaximum_num(_Tp __op, memory_order __m = memory_order_seq_cst) noexcept {
+    return __fetch_fmaximum_num(*this, __op, __m);
+  }
+#  endif // _LIBCPP_STD_VER >= 26
 
   _LIBCPP_HIDE_FROM_ABI _Tp operator+=(_Tp __op) volatile noexcept
     requires __base::is_always_lock_free

--- a/libcxx/include/__atomic/atomic_ref.h
+++ b/libcxx/include/__atomic/atomic_ref.h
@@ -29,8 +29,10 @@
 #include <__config>
 #include <__cstddef/byte.h>
 #include <__cstddef/ptrdiff_t.h>
+#include <__math/min_max.h>
 #include <__memory/addressof.h>
 #include <__type_traits/has_unique_object_representation.h>
+#include <__type_traits/is_same.h>
 #include <__type_traits/is_trivially_copyable.h>
 #include <cstdint>
 #include <cstring>
@@ -354,6 +356,62 @@ struct atomic_ref<_Tp> : public __atomic_ref_base<_Tp> {
       return __old;
     }
   }
+
+  _LIBCPP_HIDE_FROM_ABI _Tp fetch_min(_Tp __arg, memory_order __order = memory_order_seq_cst) const noexcept {
+    _Tp __old = this->load(memory_order_relaxed);
+    _Tp __new = std::__math::fmin(__old, __arg);
+    while (!this->compare_exchange_weak(__old, __new, __order, memory_order_relaxed)) {
+      __new = std::__math::fmin(__old, __arg);
+    }
+    return __old;
+  }
+
+  _LIBCPP_HIDE_FROM_ABI _Tp fetch_max(_Tp __arg, memory_order __order = memory_order_seq_cst) const noexcept {
+    _Tp __old = this->load(memory_order_relaxed);
+    _Tp __new = std::__math::fmax(__old, __arg);
+    while (!this->compare_exchange_weak(__old, __new, __order, memory_order_relaxed)) {
+      __new = std::__math::fmax(__old, __arg);
+    }
+    return __old;
+  }
+
+#  if _LIBCPP_STD_VER >= 26
+  _LIBCPP_HIDE_FROM_ABI _Tp fetch_fminimum(_Tp __arg, memory_order __order = memory_order_seq_cst) const noexcept {
+    _Tp __old = this->load(memory_order_relaxed);
+    _Tp __new = std::__math::fminimum(__old, __arg);
+    while (!this->compare_exchange_weak(__old, __new, __order, memory_order_relaxed)) {
+      __new = std::__math::fminimum(__old, __arg);
+    }
+    return __old;
+  }
+
+  _LIBCPP_HIDE_FROM_ABI _Tp fetch_fmaximum(_Tp __arg, memory_order __order = memory_order_seq_cst) const noexcept {
+    _Tp __old = this->load(memory_order_relaxed);
+    _Tp __new = std::__math::fmaximum(__old, __arg);
+    while (!this->compare_exchange_weak(__old, __new, __order, memory_order_relaxed)) {
+      __new = std::__math::fmaximum(__old, __arg);
+    }
+    return __old;
+  }
+
+  _LIBCPP_HIDE_FROM_ABI _Tp fetch_fminimum_num(_Tp __arg, memory_order __order = memory_order_seq_cst) const noexcept {
+    _Tp __old = this->load(memory_order_relaxed);
+    _Tp __new = std::__math::fminimum_num(__old, __arg);
+    while (!this->compare_exchange_weak(__old, __new, __order, memory_order_relaxed)) {
+      __new = std::__math::fminimum_num(__old, __arg);
+    }
+    return __old;
+  }
+
+  _LIBCPP_HIDE_FROM_ABI _Tp fetch_fmaximum_num(_Tp __arg, memory_order __order = memory_order_seq_cst) const noexcept {
+    _Tp __old = this->load(memory_order_relaxed);
+    _Tp __new = std::__math::fmaximum_num(__old, __arg);
+    while (!this->compare_exchange_weak(__old, __new, __order, memory_order_relaxed)) {
+      __new = std::__math::fmaximum_num(__old, __arg);
+    }
+    return __old;
+  }
+#  endif // _LIBCPP_STD_VER >= 26
 
   _LIBCPP_HIDE_FROM_ABI _Tp operator+=(_Tp __arg) const noexcept { return fetch_add(__arg) + __arg; }
   _LIBCPP_HIDE_FROM_ABI _Tp operator-=(_Tp __arg) const noexcept { return fetch_sub(__arg) - __arg; }

--- a/libcxx/include/__math/min_max.h
+++ b/libcxx/include/__math/min_max.h
@@ -12,6 +12,7 @@
 #include <__config>
 #include <__type_traits/enable_if.h>
 #include <__type_traits/is_arithmetic.h>
+#include <__type_traits/is_constant_evaluated.h>
 #include <__type_traits/is_same.h>
 #include <__type_traits/promote.h>
 
@@ -66,6 +67,210 @@ template <class _A1, class _A2, __enable_if_t<is_arithmetic<_A1>::value && is_ar
   static_assert(!(_IsSame<_A1, __result_type>::value && _IsSame<_A2, __result_type>::value), "");
   return __math::fmin((__result_type)__x, (__result_type)__y);
 }
+
+#if _LIBCPP_STD_VER >= 26
+
+// fminimum (IEEE 754-2019 minimum)
+
+// Fallback implementation for all floating-point types
+template <typename _Tp>
+inline _LIBCPP_HIDE_FROM_ABI constexpr _Tp __fminimum_fallback(_Tp __x, _Tp __y) _NOEXCEPT {
+  // Handle NaN: propagate NaN
+  if (__builtin_isnan(__x))
+    return __x;
+  if (__builtin_isnan(__y))
+    return __y;
+
+  // Handle signed zeros: -0.0 < +0.0
+  if (__x == _Tp(0) && __y == _Tp(0)) {
+    const bool __x_is_neg = __builtin_signbit(__x);
+    const bool __y_is_neg = __builtin_signbit(__y);
+    if (__x_is_neg != __y_is_neg)
+      return __x_is_neg ? __x : __y;
+  }
+
+  // Regular comparison
+  return __x < __y ? __x : __y;
+}
+
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI constexpr float fminimum(float __x, float __y) _NOEXCEPT {
+#  if __has_builtin(__builtin_fminimumf) && !(defined(__ARM_ARCH) && __ARM_ARCH == 7)
+  return __builtin_fminimumf(__x, __y);
+#  else
+  return __fminimum_fallback(__x, __y);
+#  endif
+}
+
+template <class = int>
+[[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI constexpr double fminimum(double __x, double __y) _NOEXCEPT {
+#  if __has_builtin(__builtin_fminimum) && !(defined(__ARM_ARCH) && __ARM_ARCH == 7)
+  return __builtin_fminimum(__x, __y);
+#  else
+  return __fminimum_fallback(__x, __y);
+#  endif
+}
+
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI constexpr long double
+fminimum(long double __x, long double __y) _NOEXCEPT {
+#  if __has_builtin(__builtin_fminimuml) && !(defined(__ARM_ARCH) && __ARM_ARCH == 7)
+  return __builtin_fminimuml(__x, __y);
+#  else
+  return __fminimum_fallback(__x, __y);
+#  endif
+}
+
+// fminimum_num (IEEE 754-2019 minimumNumber)
+
+// Fallback implementation for all floating-point types
+template <typename _Tp>
+inline _LIBCPP_HIDE_FROM_ABI constexpr _Tp __fminimum_num_fallback(_Tp __x, _Tp __y) _NOEXCEPT {
+  // Handle NaN: favor non-NaN values
+  const bool __x_is_nan = __builtin_isnan(__x);
+  const bool __y_is_nan = __builtin_isnan(__y);
+  if (__x_is_nan)
+    return __y_is_nan ? __x : __y;
+  if (__y_is_nan)
+    return __x;
+
+  // Handle signed zeros: -0.0 < +0.0
+  if (__x == _Tp(0) && __y == _Tp(0)) {
+    const bool __x_is_neg = __builtin_signbit(__x);
+    const bool __y_is_neg = __builtin_signbit(__y);
+    if (__x_is_neg != __y_is_neg)
+      return __x_is_neg ? __x : __y;
+  }
+
+  // Regular comparison
+  return __x < __y ? __x : __y;
+}
+
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI constexpr float fminimum_num(float __x, float __y) _NOEXCEPT {
+#  if 0 // TODO: __has_builtin(__builtin_fminimum_numf) - builtins are currently broken
+  return __builtin_fminimum_numf(__x, __y);
+#  else
+  return __fminimum_num_fallback(__x, __y);
+#  endif
+}
+
+template <class = int>
+[[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI constexpr double fminimum_num(double __x, double __y) _NOEXCEPT {
+#  if 0 // TODO: __has_builtin(__builtin_fminimum_num) - builtins are currently broken
+  return __builtin_fminimum_num(__x, __y);
+#  else
+  return __fminimum_num_fallback(__x, __y);
+#  endif
+}
+
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI constexpr long double
+fminimum_num(long double __x, long double __y) _NOEXCEPT {
+#  if 0 // TODO: __has_builtin(__builtin_fminimum_numl) - builtins are currently broken
+  return __builtin_fminimum_numl(__x, __y);
+#  else
+  return __fminimum_num_fallback(__x, __y);
+#  endif
+}
+
+// fmaximum (IEEE 754-2019 maximum)
+
+// Fallback implementation for all floating-point types
+template <typename _Tp>
+inline _LIBCPP_HIDE_FROM_ABI constexpr _Tp __fmaximum_fallback(_Tp __x, _Tp __y) _NOEXCEPT {
+  // Handle NaN: propagate NaN
+  if (__builtin_isnan(__x))
+    return __x;
+  if (__builtin_isnan(__y))
+    return __y;
+
+  // Handle signed zeros: -0.0 < +0.0, so max returns +0.0
+  if (__x == _Tp(0) && __y == _Tp(0)) {
+    const bool __x_is_neg = __builtin_signbit(__x);
+    const bool __y_is_neg = __builtin_signbit(__y);
+    if (__x_is_neg != __y_is_neg)
+      return __x_is_neg ? __y : __x; // Return the positive zero
+  }
+
+  // Regular comparison
+  return __x > __y ? __x : __y;
+}
+
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI constexpr float fmaximum(float __x, float __y) _NOEXCEPT {
+#  if __has_builtin(__builtin_fmaximumf) && !(defined(__ARM_ARCH) && __ARM_ARCH == 7)
+  return __builtin_fmaximumf(__x, __y);
+#  else
+  return __fmaximum_fallback(__x, __y);
+#  endif
+}
+
+template <class = int>
+[[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI constexpr double fmaximum(double __x, double __y) _NOEXCEPT {
+#  if __has_builtin(__builtin_fmaximum) && !(defined(__ARM_ARCH) && __ARM_ARCH == 7)
+  return __builtin_fmaximum(__x, __y);
+#  else
+  return __fmaximum_fallback(__x, __y);
+#  endif
+}
+
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI constexpr long double
+fmaximum(long double __x, long double __y) _NOEXCEPT {
+#  if __has_builtin(__builtin_fmaximuml) && !(defined(__ARM_ARCH) && __ARM_ARCH == 7)
+  return __builtin_fmaximuml(__x, __y);
+#  else
+  return __fmaximum_fallback(__x, __y);
+#  endif
+}
+
+// fmaximum_num (IEEE 754-2019 maximumNumber)
+
+// Fallback implementation for all floating-point types
+template <typename _Tp>
+inline _LIBCPP_HIDE_FROM_ABI constexpr _Tp __fmaximum_num_fallback(_Tp __x, _Tp __y) _NOEXCEPT {
+  // Handle NaN: favor non-NaN values
+  const bool __x_is_nan = __builtin_isnan(__x);
+  const bool __y_is_nan = __builtin_isnan(__y);
+  if (__x_is_nan)
+    return __y_is_nan ? __x : __y;
+  if (__y_is_nan)
+    return __x;
+
+  // Handle signed zeros: -0.0 < +0.0, so max returns +0.0
+  if (__x == _Tp(0) && __y == _Tp(0)) {
+    const bool __x_is_neg = __builtin_signbit(__x);
+    const bool __y_is_neg = __builtin_signbit(__y);
+    if (__x_is_neg != __y_is_neg)
+      return __x_is_neg ? __y : __x; // Return the positive zero
+  }
+
+  // Regular comparison
+  return __x > __y ? __x : __y;
+}
+
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI constexpr float fmaximum_num(float __x, float __y) _NOEXCEPT {
+#  if 0 // TODO: __has_builtin(__builtin_fmaximum_numf) - builtins are currently broken
+  return __builtin_fmaximum_numf(__x, __y);
+#  else
+  return __fmaximum_num_fallback(__x, __y);
+#  endif
+}
+
+template <class = int>
+[[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI constexpr double fmaximum_num(double __x, double __y) _NOEXCEPT {
+#  if 0 // TODO: __has_builtin(__builtin_fmaximum_num) - builtins are currently broken
+  return __builtin_fmaximum_num(__x, __y);
+#  else
+  return __fmaximum_num_fallback(__x, __y);
+#  endif
+}
+
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI constexpr long double
+fmaximum_num(long double __x, long double __y) _NOEXCEPT {
+#  if 0 // TODO: __has_builtin(__builtin_fmaximum_numl) - builtins are currently broken
+  return __builtin_fmaximum_numl(__x, __y);
+#  else
+  return __fmaximum_num_fallback(__x, __y);
+#  endif
+}
+
+#endif // _LIBCPP_STD_VER >= 26
 
 } // namespace __math
 

--- a/libcxx/include/cmath
+++ b/libcxx/include/cmath
@@ -204,6 +204,14 @@ floating_point fmin (arithmetic x, arithmetic y);
 float          fminf(float x, float y);
 long double    fminl(long double x, long double y);
 
+constexpr float       fminimum_num(float x, float y);            // C++26 (from C23)
+constexpr double      fminimum_num(double x, double y);          // C++26 (from C23)
+constexpr long double fminimum_num(long double x, long double y); // C++26 (from C23)
+
+constexpr float       fmaximum_num(float x, float y);            // C++26 (from C23)
+constexpr double      fmaximum_num(double x, double y);          // C++26 (from C23)
+constexpr long double fmaximum_num(long double x, long double y); // C++26 (from C23)
+
 double         hermite(unsigned n, double x);                    // C++17
 float          hermite(unsigned n, float x);                     // C++17
 long double    hermite(unsigned n, long double x);               // C++17
@@ -317,6 +325,7 @@ constexpr long double lerp(long double a, long double b, long double t) noexcept
 #else
 #  include <__config>
 #  include <__math/hypot.h>
+#  include <__math/min_max.h>
 #  include <__type_traits/enable_if.h>
 #  include <__type_traits/is_arithmetic.h>
 #  include <__type_traits/is_constant_evaluated.h>
@@ -607,6 +616,14 @@ _LIBCPP_HIDE_FROM_ABI inline constexpr __promote_t<_A1, _A2, _A3> lerp(_A1 __a, 
   return std::__lerp((__result_type)__a, (__result_type)__b, (__result_type)__t);
 }
 #  endif // _LIBCPP_STD_VER >= 20
+
+#  if _LIBCPP_STD_VER >= 26
+// C++26 IEEE 754-2019 min/max functions (from C23)
+using __math::fmaximum;
+using __math::fmaximum_num;
+using __math::fminimum;
+using __math::fminimum_num;
+#  endif // _LIBCPP_STD_VER >= 26
 
 _LIBCPP_END_NAMESPACE_STD
 

--- a/libcxx/modules/std/cmath.inc
+++ b/libcxx/modules/std/cmath.inc
@@ -241,6 +241,11 @@ export namespace std {
   using std::fminf _LIBCPP_USING_IF_EXISTS;
   using std::fminl _LIBCPP_USING_IF_EXISTS;
 
+  using std::fminimum _LIBCPP_USING_IF_EXISTS;
+  using std::fmaximum _LIBCPP_USING_IF_EXISTS;
+  using std::fminimum_num _LIBCPP_USING_IF_EXISTS;
+  using std::fmaximum_num _LIBCPP_USING_IF_EXISTS;
+
   using std::fma _LIBCPP_USING_IF_EXISTS;
   using std::fmaf _LIBCPP_USING_IF_EXISTS;
   using std::fmal _LIBCPP_USING_IF_EXISTS;

--- a/libcxx/test/std/atomics/atomics.ref/fetch_fmax.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.ref/fetch_fmax.pass.cpp
@@ -22,15 +22,15 @@
 #include "../atomics.types.operations/atomics.types.operations.req/atomic_fetch_fmax_helper.h"
 
 template <typename T>
-concept has_fetch_max = requires(T t) {
-  std::declval<T const>().fetch_max(std::declval<typename T::value_type>());
-  std::declval<T const>().fetch_max(std::declval<typename T::value_type>(), std::declval<std::memory_order>());
+concept has_fetch_max = requires(T const& t, typename T::value_type v, std::memory_order m) {
+  t.fetch_max(v);
+  t.fetch_max(v, m);
 };
 
 template <typename T>
-struct TestDoesNotHaveFetchMax {
-  void operator()() const { static_assert(!has_fetch_max<std::atomic_ref<T>>); }
-};
+void test_does_not_have_fetch_max() {
+  static_assert(!has_fetch_max<std::atomic_ref<T>>);
+}
 
 template <typename T>
 struct TestFetchMax {
@@ -55,11 +55,12 @@ struct TestFetchMax {
 int main(int, char**) {
   TestFetchMax<float>{}();
   TestFetchMax<double>{}();
+  TestFetchMax<long double>{}();
 
-  TestDoesNotHaveFetchMax<bool>{}();
-  TestDoesNotHaveFetchMax<int>{}();
-  TestDoesNotHaveFetchMax<unsigned int>{}();
-  TestDoesNotHaveFetchMax<int*>{}();
+  test_does_not_have_fetch_max<bool>();
+  test_does_not_have_fetch_max<int>();
+  test_does_not_have_fetch_max<unsigned int>();
+  test_does_not_have_fetch_max<int*>();
 
   return 0;
 }

--- a/libcxx/test/std/atomics/atomics.ref/fetch_fmax.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.ref/fetch_fmax.pass.cpp
@@ -55,7 +55,7 @@ struct TestFetchMax {
 int main(int, char**) {
   TestFetchMax<float>{}();
   TestFetchMax<double>{}();
-  TestFetchMax<long double>{}();
+  // TestFetchMax<long double>{}(); // TODO: timeout in CI
 
   test_does_not_have_fetch_max<bool>();
   test_does_not_have_fetch_max<int>();

--- a/libcxx/test/std/atomics/atomics.ref/fetch_fmax.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.ref/fetch_fmax.pass.cpp
@@ -1,0 +1,65 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03, c++11, c++14, c++17, c++20, c++23
+// XFAIL: !has-64-bit-atomics
+
+// floating-point-type fetch_max(floating-point-type, memory_order = memory_order::seq_cst) const noexcept;
+
+#include <atomic>
+#include <cassert>
+#include <concepts>
+#include <type_traits>
+#include <utility>
+
+#include "test_macros.h"
+#include "atomic_helpers.h"
+#include "../atomics.types.operations/atomics.types.operations.req/atomic_fetch_fmax_helper.h"
+
+template <typename T>
+concept has_fetch_max = requires(T t) {
+  std::declval<T const>().fetch_max(std::declval<typename T::value_type>());
+  std::declval<T const>().fetch_max(std::declval<typename T::value_type>(), std::declval<std::memory_order>());
+};
+
+template <typename T>
+struct TestDoesNotHaveFetchMax {
+  void operator()() const { static_assert(!has_fetch_max<std::atomic_ref<T>>); }
+};
+
+template <typename T>
+struct TestFetchMax {
+  void operator()() const {
+    if constexpr (std::is_floating_point_v<T>) {
+      alignas(std::atomic_ref<T>::required_alignment) T x;
+      std::atomic_ref<T> const a(x);
+
+      auto load   = [&]() { return x; };
+      auto store  = [&](T val) { x = val; };
+      auto max_op = [&](T val, auto order) { return a.fetch_max(val, order); };
+
+      ASSERT_NOEXCEPT(a.fetch_max(T(0), std::memory_order_seq_cst));
+      test_fetch_fmax<T>(load, store, max_op);
+
+    } else {
+      static_assert(std::is_void_v<T>);
+    }
+  }
+};
+
+int main(int, char**) {
+  TestFetchMax<float>{}();
+  TestFetchMax<double>{}();
+
+  TestDoesNotHaveFetchMax<bool>{}();
+  TestDoesNotHaveFetchMax<int>{}();
+  TestDoesNotHaveFetchMax<unsigned int>{}();
+  TestDoesNotHaveFetchMax<int*>{}();
+
+  return 0;
+}

--- a/libcxx/test/std/atomics/atomics.ref/fetch_fmaximum.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.ref/fetch_fmaximum.pass.cpp
@@ -22,15 +22,15 @@
 #include "../atomics.types.operations/atomics.types.operations.req/atomic_fetch_fmaximum_helper.h"
 
 template <typename T>
-concept has_fetch_fmaximum = requires(T t) {
-  std::declval<T const>().fetch_fmaximum(std::declval<typename T::value_type>());
-  std::declval<T const>().fetch_fmaximum(std::declval<typename T::value_type>(), std::declval<std::memory_order>());
+concept has_fetch_fmaximum = requires(T const& t, typename T::value_type v, std::memory_order m) {
+  t.fetch_fmaximum(v);
+  t.fetch_fmaximum(v, m);
 };
 
 template <typename T>
-struct TestDoesNotHaveFetchFMaximum {
-  void operator()() const { static_assert(!has_fetch_fmaximum<std::atomic_ref<T>>); }
-};
+void test_does_not_have_fetch_fmaximum() {
+  static_assert(!has_fetch_fmaximum<std::atomic_ref<T>>);
+}
 
 template <typename T>
 struct TestFetchFMaximum {
@@ -55,11 +55,12 @@ struct TestFetchFMaximum {
 int main(int, char**) {
   TestFetchFMaximum<float>{}();
   TestFetchFMaximum<double>{}();
+  TestFetchFMaximum<long double>{}();
 
-  TestDoesNotHaveFetchFMaximum<bool>{}();
-  TestDoesNotHaveFetchFMaximum<int>{}();
-  TestDoesNotHaveFetchFMaximum<unsigned int>{}();
-  TestDoesNotHaveFetchFMaximum<int*>{}();
+  test_does_not_have_fetch_fmaximum<bool>();
+  test_does_not_have_fetch_fmaximum<int>();
+  test_does_not_have_fetch_fmaximum<unsigned int>();
+  test_does_not_have_fetch_fmaximum<int*>();
 
   return 0;
 }

--- a/libcxx/test/std/atomics/atomics.ref/fetch_fmaximum.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.ref/fetch_fmaximum.pass.cpp
@@ -55,7 +55,7 @@ struct TestFetchFMaximum {
 int main(int, char**) {
   TestFetchFMaximum<float>{}();
   TestFetchFMaximum<double>{}();
-  TestFetchFMaximum<long double>{}();
+  // TestFetchFMaximum<long double>{}(); // TODO: timeout in CI
 
   test_does_not_have_fetch_fmaximum<bool>();
   test_does_not_have_fetch_fmaximum<int>();

--- a/libcxx/test/std/atomics/atomics.ref/fetch_fmaximum.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.ref/fetch_fmaximum.pass.cpp
@@ -1,0 +1,65 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03, c++11, c++14, c++17, c++20, c++23
+// XFAIL: !has-64-bit-atomics
+
+// floating-point-type fetch_fmaximum(floating-point-type, memory_order = memory_order::seq_cst) const noexcept;
+
+#include <atomic>
+#include <cassert>
+#include <concepts>
+#include <type_traits>
+#include <utility>
+
+#include "test_macros.h"
+#include "atomic_helpers.h"
+#include "../atomics.types.operations/atomics.types.operations.req/atomic_fetch_fmaximum_helper.h"
+
+template <typename T>
+concept has_fetch_fmaximum = requires(T t) {
+  std::declval<T const>().fetch_fmaximum(std::declval<typename T::value_type>());
+  std::declval<T const>().fetch_fmaximum(std::declval<typename T::value_type>(), std::declval<std::memory_order>());
+};
+
+template <typename T>
+struct TestDoesNotHaveFetchFMaximum {
+  void operator()() const { static_assert(!has_fetch_fmaximum<std::atomic_ref<T>>); }
+};
+
+template <typename T>
+struct TestFetchFMaximum {
+  void operator()() const {
+    if constexpr (std::is_floating_point_v<T>) {
+      alignas(std::atomic_ref<T>::required_alignment) T x;
+      std::atomic_ref<T> const a(x);
+
+      auto load     = [&]() { return x; };
+      auto store    = [&](T val) { x = val; };
+      auto fmaximum = [&](T val, auto order) { return a.fetch_fmaximum(val, order); };
+
+      ASSERT_NOEXCEPT(a.fetch_fmaximum(T(0), std::memory_order_seq_cst));
+      test_fetch_fmaximum<T>(load, store, fmaximum);
+
+    } else {
+      static_assert(std::is_void_v<T>);
+    }
+  }
+};
+
+int main(int, char**) {
+  TestFetchFMaximum<float>{}();
+  TestFetchFMaximum<double>{}();
+
+  TestDoesNotHaveFetchFMaximum<bool>{}();
+  TestDoesNotHaveFetchFMaximum<int>{}();
+  TestDoesNotHaveFetchFMaximum<unsigned int>{}();
+  TestDoesNotHaveFetchFMaximum<int*>{}();
+
+  return 0;
+}

--- a/libcxx/test/std/atomics/atomics.ref/fetch_fmaximum_num.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.ref/fetch_fmaximum_num.pass.cpp
@@ -22,15 +22,15 @@
 #include "../atomics.types.operations/atomics.types.operations.req/atomic_fetch_fmaximum_num_helper.h"
 
 template <typename T>
-concept has_fetch_fmaximum_num = requires(T t) {
-  std::declval<T const>().fetch_fmaximum_num(std::declval<typename T::value_type>());
-  std::declval<T const>().fetch_fmaximum_num(std::declval<typename T::value_type>(), std::declval<std::memory_order>());
+concept has_fetch_fmaximum_num = requires(T const& t, typename T::value_type v, std::memory_order m) {
+  t.fetch_fmaximum_num(v);
+  t.fetch_fmaximum_num(v, m);
 };
 
 template <typename T>
-struct TestDoesNotHaveFetchFMaximumNum {
-  void operator()() const { static_assert(!has_fetch_fmaximum_num<std::atomic_ref<T>>); }
-};
+void test_does_not_have_fetch_fmaximum_num() {
+  static_assert(!has_fetch_fmaximum_num<std::atomic_ref<T>>);
+}
 
 template <typename T>
 struct TestFetchFMaximumNum {
@@ -55,11 +55,12 @@ struct TestFetchFMaximumNum {
 int main(int, char**) {
   TestFetchFMaximumNum<float>{}();
   TestFetchFMaximumNum<double>{}();
+  TestFetchFMaximumNum<long double>{}();
 
-  TestDoesNotHaveFetchFMaximumNum<bool>{}();
-  TestDoesNotHaveFetchFMaximumNum<int>{}();
-  TestDoesNotHaveFetchFMaximumNum<unsigned int>{}();
-  TestDoesNotHaveFetchFMaximumNum<int*>{}();
+  test_does_not_have_fetch_fmaximum_num<bool>();
+  test_does_not_have_fetch_fmaximum_num<int>();
+  test_does_not_have_fetch_fmaximum_num<unsigned int>();
+  test_does_not_have_fetch_fmaximum_num<int*>();
 
   return 0;
 }

--- a/libcxx/test/std/atomics/atomics.ref/fetch_fmaximum_num.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.ref/fetch_fmaximum_num.pass.cpp
@@ -55,7 +55,7 @@ struct TestFetchFMaximumNum {
 int main(int, char**) {
   TestFetchFMaximumNum<float>{}();
   TestFetchFMaximumNum<double>{}();
-  TestFetchFMaximumNum<long double>{}();
+  // TestFetchFMaximumNum<long double>{}(); // TODO: timeout in CI
 
   test_does_not_have_fetch_fmaximum_num<bool>();
   test_does_not_have_fetch_fmaximum_num<int>();

--- a/libcxx/test/std/atomics/atomics.ref/fetch_fmaximum_num.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.ref/fetch_fmaximum_num.pass.cpp
@@ -1,0 +1,65 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03, c++11, c++14, c++17, c++20, c++23
+// XFAIL: !has-64-bit-atomics
+
+// floating-point-type fetch_fmaximum_num(floating-point-type, memory_order = memory_order::seq_cst) const noexcept;
+
+#include <atomic>
+#include <cassert>
+#include <concepts>
+#include <type_traits>
+#include <utility>
+
+#include "test_macros.h"
+#include "atomic_helpers.h"
+#include "../atomics.types.operations/atomics.types.operations.req/atomic_fetch_fmaximum_num_helper.h"
+
+template <typename T>
+concept has_fetch_fmaximum_num = requires(T t) {
+  std::declval<T const>().fetch_fmaximum_num(std::declval<typename T::value_type>());
+  std::declval<T const>().fetch_fmaximum_num(std::declval<typename T::value_type>(), std::declval<std::memory_order>());
+};
+
+template <typename T>
+struct TestDoesNotHaveFetchFMaximumNum {
+  void operator()() const { static_assert(!has_fetch_fmaximum_num<std::atomic_ref<T>>); }
+};
+
+template <typename T>
+struct TestFetchFMaximumNum {
+  void operator()() const {
+    if constexpr (std::is_floating_point_v<T>) {
+      alignas(std::atomic_ref<T>::required_alignment) T x;
+      std::atomic_ref<T> const a(x);
+
+      auto load         = [&]() { return x; };
+      auto store        = [&](T val) { x = val; };
+      auto fmaximum_num = [&](T val, auto order) { return a.fetch_fmaximum_num(val, order); };
+
+      ASSERT_NOEXCEPT(a.fetch_fmaximum_num(T(0), std::memory_order_seq_cst));
+      test_fetch_fmaximum_num<T>(load, store, fmaximum_num);
+
+    } else {
+      static_assert(std::is_void_v<T>);
+    }
+  }
+};
+
+int main(int, char**) {
+  TestFetchFMaximumNum<float>{}();
+  TestFetchFMaximumNum<double>{}();
+
+  TestDoesNotHaveFetchFMaximumNum<bool>{}();
+  TestDoesNotHaveFetchFMaximumNum<int>{}();
+  TestDoesNotHaveFetchFMaximumNum<unsigned int>{}();
+  TestDoesNotHaveFetchFMaximumNum<int*>{}();
+
+  return 0;
+}

--- a/libcxx/test/std/atomics/atomics.ref/fetch_fmin.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.ref/fetch_fmin.pass.cpp
@@ -22,15 +22,15 @@
 #include "../atomics.types.operations/atomics.types.operations.req/atomic_fetch_fmin_helper.h"
 
 template <typename T>
-concept has_fetch_min = requires(T t) {
-  std::declval<T const>().fetch_min(std::declval<typename T::value_type>());
-  std::declval<T const>().fetch_min(std::declval<typename T::value_type>(), std::declval<std::memory_order>());
+concept has_fetch_min = requires(T const& t, typename T::value_type v, std::memory_order m) {
+  t.fetch_min(v);
+  t.fetch_min(v, m);
 };
 
 template <typename T>
-struct TestDoesNotHaveFetchMin {
-  void operator()() const { static_assert(!has_fetch_min<std::atomic_ref<T>>); }
-};
+void test_does_not_have_fetch_min() {
+  static_assert(!has_fetch_min<std::atomic_ref<T>>);
+}
 
 template <typename T>
 struct TestFetchMin {
@@ -55,11 +55,12 @@ struct TestFetchMin {
 int main(int, char**) {
   TestFetchMin<float>{}();
   TestFetchMin<double>{}();
+  TestFetchMin<long double>{}();
 
-  TestDoesNotHaveFetchMin<bool>{}();
-  TestDoesNotHaveFetchMin<int>{}();
-  TestDoesNotHaveFetchMin<unsigned int>{}();
-  TestDoesNotHaveFetchMin<int*>{}();
+  test_does_not_have_fetch_min<bool>();
+  test_does_not_have_fetch_min<int>();
+  test_does_not_have_fetch_min<unsigned int>();
+  test_does_not_have_fetch_min<int*>();
 
   return 0;
 }

--- a/libcxx/test/std/atomics/atomics.ref/fetch_fmin.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.ref/fetch_fmin.pass.cpp
@@ -55,7 +55,7 @@ struct TestFetchMin {
 int main(int, char**) {
   TestFetchMin<float>{}();
   TestFetchMin<double>{}();
-  TestFetchMin<long double>{}();
+  // TestFetchMin<long double>{}(); // TODO: timeout in CI
 
   test_does_not_have_fetch_min<bool>();
   test_does_not_have_fetch_min<int>();

--- a/libcxx/test/std/atomics/atomics.ref/fetch_fmin.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.ref/fetch_fmin.pass.cpp
@@ -1,0 +1,65 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03, c++11, c++14, c++17, c++20, c++23
+// XFAIL: !has-64-bit-atomics
+
+// floating-point-type fetch_min(floating-point-type, memory_order = memory_order::seq_cst) const noexcept;
+
+#include <atomic>
+#include <cassert>
+#include <concepts>
+#include <type_traits>
+#include <utility>
+
+#include "test_macros.h"
+#include "atomic_helpers.h"
+#include "../atomics.types.operations/atomics.types.operations.req/atomic_fetch_fmin_helper.h"
+
+template <typename T>
+concept has_fetch_min = requires(T t) {
+  std::declval<T const>().fetch_min(std::declval<typename T::value_type>());
+  std::declval<T const>().fetch_min(std::declval<typename T::value_type>(), std::declval<std::memory_order>());
+};
+
+template <typename T>
+struct TestDoesNotHaveFetchMin {
+  void operator()() const { static_assert(!has_fetch_min<std::atomic_ref<T>>); }
+};
+
+template <typename T>
+struct TestFetchMin {
+  void operator()() const {
+    if constexpr (std::is_floating_point_v<T>) {
+      alignas(std::atomic_ref<T>::required_alignment) T x;
+      std::atomic_ref<T> const a(x);
+
+      auto load   = [&]() { return x; };
+      auto store  = [&](T val) { x = val; };
+      auto min_op = [&](T val, auto order) { return a.fetch_min(val, order); };
+
+      ASSERT_NOEXCEPT(a.fetch_min(T(0), std::memory_order_seq_cst));
+      test_fetch_fmin<T>(load, store, min_op);
+
+    } else {
+      static_assert(std::is_void_v<T>);
+    }
+  }
+};
+
+int main(int, char**) {
+  TestFetchMin<float>{}();
+  TestFetchMin<double>{}();
+
+  TestDoesNotHaveFetchMin<bool>{}();
+  TestDoesNotHaveFetchMin<int>{}();
+  TestDoesNotHaveFetchMin<unsigned int>{}();
+  TestDoesNotHaveFetchMin<int*>{}();
+
+  return 0;
+}

--- a/libcxx/test/std/atomics/atomics.ref/fetch_fminimum.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.ref/fetch_fminimum.pass.cpp
@@ -55,7 +55,7 @@ struct TestFetchFMinimum {
 int main(int, char**) {
   TestFetchFMinimum<float>{}();
   TestFetchFMinimum<double>{}();
-  TestFetchFMinimum<long double>{}();
+  // TestFetchFMinimum<long double>{}(); // TODO: timeout in CI
 
   test_does_not_have_fetch_fminimum<bool>();
   test_does_not_have_fetch_fminimum<int>();

--- a/libcxx/test/std/atomics/atomics.ref/fetch_fminimum.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.ref/fetch_fminimum.pass.cpp
@@ -22,15 +22,15 @@
 #include "../atomics.types.operations/atomics.types.operations.req/atomic_fetch_fminimum_helper.h"
 
 template <typename T>
-concept has_fetch_fminimum = requires(T t) {
-  std::declval<T const>().fetch_fminimum(std::declval<typename T::value_type>());
-  std::declval<T const>().fetch_fminimum(std::declval<typename T::value_type>(), std::declval<std::memory_order>());
+concept has_fetch_fminimum = requires(T const& t, typename T::value_type v, std::memory_order m) {
+  t.fetch_fminimum(v);
+  t.fetch_fminimum(v, m);
 };
 
 template <typename T>
-struct TestDoesNotHaveFetchFMinimum {
-  void operator()() const { static_assert(!has_fetch_fminimum<std::atomic_ref<T>>); }
-};
+void test_does_not_have_fetch_fminimum() {
+  static_assert(!has_fetch_fminimum<std::atomic_ref<T>>);
+}
 
 template <typename T>
 struct TestFetchFMinimum {
@@ -55,11 +55,12 @@ struct TestFetchFMinimum {
 int main(int, char**) {
   TestFetchFMinimum<float>{}();
   TestFetchFMinimum<double>{}();
+  TestFetchFMinimum<long double>{}();
 
-  TestDoesNotHaveFetchFMinimum<bool>{}();
-  TestDoesNotHaveFetchFMinimum<int>{}();
-  TestDoesNotHaveFetchFMinimum<unsigned int>{}();
-  TestDoesNotHaveFetchFMinimum<int*>{}();
+  test_does_not_have_fetch_fminimum<bool>();
+  test_does_not_have_fetch_fminimum<int>();
+  test_does_not_have_fetch_fminimum<unsigned int>();
+  test_does_not_have_fetch_fminimum<int*>();
 
   return 0;
 }

--- a/libcxx/test/std/atomics/atomics.ref/fetch_fminimum.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.ref/fetch_fminimum.pass.cpp
@@ -1,0 +1,65 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03, c++11, c++14, c++17, c++20, c++23
+// XFAIL: !has-64-bit-atomics
+
+// floating-point-type fetch_fminimum(floating-point-type, memory_order = memory_order::seq_cst) const noexcept;
+
+#include <atomic>
+#include <cassert>
+#include <concepts>
+#include <type_traits>
+#include <utility>
+
+#include "test_macros.h"
+#include "atomic_helpers.h"
+#include "../atomics.types.operations/atomics.types.operations.req/atomic_fetch_fminimum_helper.h"
+
+template <typename T>
+concept has_fetch_fminimum = requires(T t) {
+  std::declval<T const>().fetch_fminimum(std::declval<typename T::value_type>());
+  std::declval<T const>().fetch_fminimum(std::declval<typename T::value_type>(), std::declval<std::memory_order>());
+};
+
+template <typename T>
+struct TestDoesNotHaveFetchFMinimum {
+  void operator()() const { static_assert(!has_fetch_fminimum<std::atomic_ref<T>>); }
+};
+
+template <typename T>
+struct TestFetchFMinimum {
+  void operator()() const {
+    if constexpr (std::is_floating_point_v<T>) {
+      alignas(std::atomic_ref<T>::required_alignment) T x;
+      std::atomic_ref<T> const a(x);
+
+      auto load     = [&]() { return x; };
+      auto store    = [&](T val) { x = val; };
+      auto fminimum = [&](T val, auto order) { return a.fetch_fminimum(val, order); };
+
+      ASSERT_NOEXCEPT(a.fetch_fminimum(T(0), std::memory_order_seq_cst));
+      test_fetch_fminimum<T>(load, store, fminimum);
+
+    } else {
+      static_assert(std::is_void_v<T>);
+    }
+  }
+};
+
+int main(int, char**) {
+  TestFetchFMinimum<float>{}();
+  TestFetchFMinimum<double>{}();
+
+  TestDoesNotHaveFetchFMinimum<bool>{}();
+  TestDoesNotHaveFetchFMinimum<int>{}();
+  TestDoesNotHaveFetchFMinimum<unsigned int>{}();
+  TestDoesNotHaveFetchFMinimum<int*>{}();
+
+  return 0;
+}

--- a/libcxx/test/std/atomics/atomics.ref/fetch_fminimum_num.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.ref/fetch_fminimum_num.pass.cpp
@@ -22,15 +22,15 @@
 #include "../atomics.types.operations/atomics.types.operations.req/atomic_fetch_fminimum_num_helper.h"
 
 template <typename T>
-concept has_fetch_fminimum_num = requires(T t) {
-  std::declval<T const>().fetch_fminimum_num(std::declval<typename T::value_type>());
-  std::declval<T const>().fetch_fminimum_num(std::declval<typename T::value_type>(), std::declval<std::memory_order>());
+concept has_fetch_fminimum_num = requires(T const& t, typename T::value_type v, std::memory_order m) {
+  t.fetch_fminimum_num(v);
+  t.fetch_fminimum_num(v, m);
 };
 
 template <typename T>
-struct TestDoesNotHaveFetchFMinimumNum {
-  void operator()() const { static_assert(!has_fetch_fminimum_num<std::atomic_ref<T>>); }
-};
+void test_does_not_have_fetch_fminimum_num() {
+  static_assert(!has_fetch_fminimum_num<std::atomic_ref<T>>);
+}
 
 template <typename T>
 struct TestFetchFMinimumNum {
@@ -55,11 +55,12 @@ struct TestFetchFMinimumNum {
 int main(int, char**) {
   TestFetchFMinimumNum<float>{}();
   TestFetchFMinimumNum<double>{}();
+  TestFetchFMinimumNum<long double>{}();
 
-  TestDoesNotHaveFetchFMinimumNum<bool>{}();
-  TestDoesNotHaveFetchFMinimumNum<int>{}();
-  TestDoesNotHaveFetchFMinimumNum<unsigned int>{}();
-  TestDoesNotHaveFetchFMinimumNum<int*>{}();
+  test_does_not_have_fetch_fminimum_num<bool>();
+  test_does_not_have_fetch_fminimum_num<int>();
+  test_does_not_have_fetch_fminimum_num<unsigned int>();
+  test_does_not_have_fetch_fminimum_num<int*>();
 
   return 0;
 }

--- a/libcxx/test/std/atomics/atomics.ref/fetch_fminimum_num.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.ref/fetch_fminimum_num.pass.cpp
@@ -55,7 +55,7 @@ struct TestFetchFMinimumNum {
 int main(int, char**) {
   TestFetchFMinimumNum<float>{}();
   TestFetchFMinimumNum<double>{}();
-  TestFetchFMinimumNum<long double>{}();
+  // TestFetchFMinimumNum<long double>{}(); // TODO: timeout in CI
 
   test_does_not_have_fetch_fminimum_num<bool>();
   test_does_not_have_fetch_fminimum_num<int>();

--- a/libcxx/test/std/atomics/atomics.ref/fetch_fminimum_num.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.ref/fetch_fminimum_num.pass.cpp
@@ -1,0 +1,65 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03, c++11, c++14, c++17, c++20, c++23
+// XFAIL: !has-64-bit-atomics
+
+// floating-point-type fetch_fminimum_num(floating-point-type, memory_order = memory_order::seq_cst) const noexcept;
+
+#include <atomic>
+#include <cassert>
+#include <concepts>
+#include <type_traits>
+#include <utility>
+
+#include "test_macros.h"
+#include "atomic_helpers.h"
+#include "../atomics.types.operations/atomics.types.operations.req/atomic_fetch_fminimum_num_helper.h"
+
+template <typename T>
+concept has_fetch_fminimum_num = requires(T t) {
+  std::declval<T const>().fetch_fminimum_num(std::declval<typename T::value_type>());
+  std::declval<T const>().fetch_fminimum_num(std::declval<typename T::value_type>(), std::declval<std::memory_order>());
+};
+
+template <typename T>
+struct TestDoesNotHaveFetchFMinimumNum {
+  void operator()() const { static_assert(!has_fetch_fminimum_num<std::atomic_ref<T>>); }
+};
+
+template <typename T>
+struct TestFetchFMinimumNum {
+  void operator()() const {
+    if constexpr (std::is_floating_point_v<T>) {
+      alignas(std::atomic_ref<T>::required_alignment) T x;
+      std::atomic_ref<T> const a(x);
+
+      auto load         = [&]() { return x; };
+      auto store        = [&](T val) { x = val; };
+      auto fminimum_num = [&](T val, auto order) { return a.fetch_fminimum_num(val, order); };
+
+      ASSERT_NOEXCEPT(a.fetch_fminimum_num(T(0), std::memory_order_seq_cst));
+      test_fetch_fminimum_num<T>(load, store, fminimum_num);
+
+    } else {
+      static_assert(std::is_void_v<T>);
+    }
+  }
+};
+
+int main(int, char**) {
+  TestFetchFMinimumNum<float>{}();
+  TestFetchFMinimumNum<double>{}();
+
+  TestDoesNotHaveFetchFMinimumNum<bool>{}();
+  TestDoesNotHaveFetchFMinimumNum<int>{}();
+  TestDoesNotHaveFetchFMinimumNum<unsigned int>{}();
+  TestDoesNotHaveFetchFMinimumNum<int*>{}();
+
+  return 0;
+}

--- a/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/fetch_fmax.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/fetch_fmax.pass.cpp
@@ -1,0 +1,54 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03, c++11, c++14, c++17, c++20, c++23
+// XFAIL: !has-64-bit-atomics
+
+// floating-point-type fetch_max(floating-point-type, memory_order = memory_order::seq_cst) volatile noexcept;
+// floating-point-type fetch_max(floating-point-type, memory_order = memory_order::seq_cst) noexcept;
+
+#include <atomic>
+#include <cassert>
+#include <concepts>
+#include <type_traits>
+#include <utility>
+
+#include "test_macros.h"
+#include "../../atomics.types.operations/atomics.types.operations.req/atomic_fetch_fmax_helper.h"
+
+template <class T>
+concept HasVolatileFetchMax = requires(volatile std::atomic<T>& a, T t) { a.fetch_max(t); };
+
+template <class T, template <class> class MaybeVolatile = std::type_identity_t>
+void test_impl() {
+  static_assert(HasVolatileFetchMax<T> == std::atomic<T>::is_always_lock_free);
+  static_assert(noexcept(std::declval<MaybeVolatile<std::atomic<T>>&>().fetch_max(T(0))));
+
+  MaybeVolatile<std::atomic<T>> a;
+
+  auto load   = [&]() { return a.load(); };
+  auto store  = [&](T val) { a.store(val); };
+  auto max_op = [&](T val, auto order) { return a.fetch_max(val, order); };
+
+  test_fetch_fmax<T>(load, store, max_op);
+}
+
+template <class T>
+void test() {
+  test_impl<T>();
+  if constexpr (std::atomic<T>::is_always_lock_free) {
+    test_impl<T, std::add_volatile_t>();
+  }
+}
+
+int main(int, char**) {
+  test<float>();
+  test<double>();
+
+  return 0;
+}

--- a/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/fetch_fmaximum.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/fetch_fmaximum.pass.cpp
@@ -1,0 +1,54 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03, c++11, c++14, c++17, c++20, c++23
+// XFAIL: !has-64-bit-atomics
+
+// floating-point-type fetch_fmaximum(floating-point-type, memory_order = memory_order::seq_cst) volatile noexcept;
+// floating-point-type fetch_fmaximum(floating-point-type, memory_order = memory_order::seq_cst) noexcept;
+
+#include <atomic>
+#include <cassert>
+#include <concepts>
+#include <type_traits>
+#include <utility>
+
+#include "test_macros.h"
+#include "../../atomics.types.operations/atomics.types.operations.req/atomic_fetch_fmaximum_helper.h"
+
+template <class T>
+concept HasVolatileFetchFMaximum = requires(volatile std::atomic<T>& a, T t) { a.fetch_fmaximum(t); };
+
+template <class T, template <class> class MaybeVolatile = std::type_identity_t>
+void test_impl() {
+  static_assert(HasVolatileFetchFMaximum<T> == std::atomic<T>::is_always_lock_free);
+  static_assert(noexcept(std::declval<MaybeVolatile<std::atomic<T>>&>().fetch_fmaximum(T(0))));
+
+  MaybeVolatile<std::atomic<T>> a;
+
+  auto load     = [&]() { return a.load(); };
+  auto store    = [&](T val) { a.store(val); };
+  auto fmaximum = [&](T val, auto order) { return a.fetch_fmaximum(val, order); };
+
+  test_fetch_fmaximum<T>(load, store, fmaximum);
+}
+
+template <class T>
+void test() {
+  test_impl<T>();
+  if constexpr (std::atomic<T>::is_always_lock_free) {
+    test_impl<T, std::add_volatile_t>();
+  }
+}
+
+int main(int, char**) {
+  test<float>();
+  test<double>();
+
+  return 0;
+}

--- a/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/fetch_fmaximum_num.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/fetch_fmaximum_num.pass.cpp
@@ -1,0 +1,54 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03, c++11, c++14, c++17, c++20, c++23
+// XFAIL: !has-64-bit-atomics
+
+// floating-point-type fetch_fmaximum_num(floating-point-type, memory_order = memory_order::seq_cst) volatile noexcept;
+// floating-point-type fetch_fmaximum_num(floating-point-type, memory_order = memory_order::seq_cst) noexcept;
+
+#include <atomic>
+#include <cassert>
+#include <concepts>
+#include <type_traits>
+#include <utility>
+
+#include "test_macros.h"
+#include "../../atomics.types.operations/atomics.types.operations.req/atomic_fetch_fmaximum_num_helper.h"
+
+template <class T>
+concept HasVolatileFetchFMaximumNum = requires(volatile std::atomic<T>& a, T t) { a.fetch_fmaximum_num(t); };
+
+template <class T, template <class> class MaybeVolatile = std::type_identity_t>
+void test_impl() {
+  static_assert(HasVolatileFetchFMaximumNum<T> == std::atomic<T>::is_always_lock_free);
+  static_assert(noexcept(std::declval<MaybeVolatile<std::atomic<T>>&>().fetch_fmaximum_num(T(0))));
+
+  MaybeVolatile<std::atomic<T>> a;
+
+  auto load         = [&]() { return a.load(); };
+  auto store        = [&](T val) { a.store(val); };
+  auto fmaximum_num = [&](T val, auto order) { return a.fetch_fmaximum_num(val, order); };
+
+  test_fetch_fmaximum_num<T>(load, store, fmaximum_num);
+}
+
+template <class T>
+void test() {
+  test_impl<T>();
+  if constexpr (std::atomic<T>::is_always_lock_free) {
+    test_impl<T, std::add_volatile_t>();
+  }
+}
+
+int main(int, char**) {
+  test<float>();
+  test<double>();
+
+  return 0;
+}

--- a/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/fetch_fmin.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/fetch_fmin.pass.cpp
@@ -1,0 +1,54 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03, c++11, c++14, c++17, c++20, c++23
+// XFAIL: !has-64-bit-atomics
+
+// floating-point-type fetch_min(floating-point-type, memory_order = memory_order::seq_cst) volatile noexcept;
+// floating-point-type fetch_min(floating-point-type, memory_order = memory_order::seq_cst) noexcept;
+
+#include <atomic>
+#include <cassert>
+#include <concepts>
+#include <type_traits>
+#include <utility>
+
+#include "test_macros.h"
+#include "../../atomics.types.operations/atomics.types.operations.req/atomic_fetch_fmin_helper.h"
+
+template <class T>
+concept HasVolatileFetchMin = requires(volatile std::atomic<T>& a, T t) { a.fetch_min(t); };
+
+template <class T, template <class> class MaybeVolatile = std::type_identity_t>
+void test_impl() {
+  static_assert(HasVolatileFetchMin<T> == std::atomic<T>::is_always_lock_free);
+  static_assert(noexcept(std::declval<MaybeVolatile<std::atomic<T>>&>().fetch_min(T(0))));
+
+  MaybeVolatile<std::atomic<T>> a;
+
+  auto load   = [&]() { return a.load(); };
+  auto store  = [&](T val) { a.store(val); };
+  auto min_op = [&](T val, auto order) { return a.fetch_min(val, order); };
+
+  test_fetch_fmin<T>(load, store, min_op);
+}
+
+template <class T>
+void test() {
+  test_impl<T>();
+  if constexpr (std::atomic<T>::is_always_lock_free) {
+    test_impl<T, std::add_volatile_t>();
+  }
+}
+
+int main(int, char**) {
+  test<float>();
+  test<double>();
+
+  return 0;
+}

--- a/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/fetch_fminimum.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/fetch_fminimum.pass.cpp
@@ -1,0 +1,54 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03, c++11, c++14, c++17, c++20, c++23
+// XFAIL: !has-64-bit-atomics
+
+// floating-point-type fetch_fminimum(floating-point-type, memory_order = memory_order::seq_cst) volatile noexcept;
+// floating-point-type fetch_fminimum(floating-point-type, memory_order = memory_order::seq_cst) noexcept;
+
+#include <atomic>
+#include <cassert>
+#include <concepts>
+#include <type_traits>
+#include <utility>
+
+#include "test_macros.h"
+#include "../../atomics.types.operations/atomics.types.operations.req/atomic_fetch_fminimum_helper.h"
+
+template <class T>
+concept HasVolatileFetchFMinimum = requires(volatile std::atomic<T>& a, T t) { a.fetch_fminimum(t); };
+
+template <class T, template <class> class MaybeVolatile = std::type_identity_t>
+void test_impl() {
+  static_assert(HasVolatileFetchFMinimum<T> == std::atomic<T>::is_always_lock_free);
+  static_assert(noexcept(std::declval<MaybeVolatile<std::atomic<T>>&>().fetch_fminimum(T(0))));
+
+  MaybeVolatile<std::atomic<T>> a;
+
+  auto load     = [&]() { return a.load(); };
+  auto store    = [&](T val) { a.store(val); };
+  auto fminimum = [&](T val, auto order) { return a.fetch_fminimum(val, order); };
+
+  test_fetch_fminimum<T>(load, store, fminimum);
+}
+
+template <class T>
+void test() {
+  test_impl<T>();
+  if constexpr (std::atomic<T>::is_always_lock_free) {
+    test_impl<T, std::add_volatile_t>();
+  }
+}
+
+int main(int, char**) {
+  test<float>();
+  test<double>();
+
+  return 0;
+}

--- a/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/fetch_fminimum_num.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/fetch_fminimum_num.pass.cpp
@@ -1,0 +1,54 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03, c++11, c++14, c++17, c++20, c++23
+// XFAIL: !has-64-bit-atomics
+
+// floating-point-type fetch_fminimum_num(floating-point-type, memory_order = memory_order::seq_cst) volatile noexcept;
+// floating-point-type fetch_fminimum_num(floating-point-type, memory_order = memory_order::seq_cst) noexcept;
+
+#include <atomic>
+#include <cassert>
+#include <concepts>
+#include <type_traits>
+#include <utility>
+
+#include "test_macros.h"
+#include "../../atomics.types.operations/atomics.types.operations.req/atomic_fetch_fminimum_num_helper.h"
+
+template <class T>
+concept HasVolatileFetchFMinimumNum = requires(volatile std::atomic<T>& a, T t) { a.fetch_fminimum_num(t); };
+
+template <class T, template <class> class MaybeVolatile = std::type_identity_t>
+void test_impl() {
+  static_assert(HasVolatileFetchFMinimumNum<T> == std::atomic<T>::is_always_lock_free);
+  static_assert(noexcept(std::declval<MaybeVolatile<std::atomic<T>>&>().fetch_fminimum_num(T(0))));
+
+  MaybeVolatile<std::atomic<T>> a;
+
+  auto load         = [&]() { return a.load(); };
+  auto store        = [&](T val) { a.store(val); };
+  auto fminimum_num = [&](T val, auto order) { return a.fetch_fminimum_num(val, order); };
+
+  test_fetch_fminimum_num<T>(load, store, fminimum_num);
+}
+
+template <class T>
+void test() {
+  test_impl<T>();
+  if constexpr (std::atomic<T>::is_always_lock_free) {
+    test_impl<T, std::add_volatile_t>();
+  }
+}
+
+int main(int, char**) {
+  test<float>();
+  test<double>();
+
+  return 0;
+}

--- a/libcxx/test/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_fetch_fmax_helper.h
+++ b/libcxx/test/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_fetch_fmax_helper.h
@@ -30,7 +30,7 @@ void test_fetch_fmax(LoadOp load, StoreOp store, MaxOp max_op) {
   // Test basic fetch_max (update to larger value)
   {
     store(T(10.0));
-    T old = max_op(T(20.0), std::memory_order_seq_cst);
+    std::same_as<T> decltype(auto) old = max_op(T(20.0), std::memory_order_seq_cst);
     assert(old == T(10.0));
     assert(load() == T(20.0));
   }
@@ -38,7 +38,7 @@ void test_fetch_fmax(LoadOp load, StoreOp store, MaxOp max_op) {
   // Test with smaller value (no change)
   {
     store(T(10.0));
-    T old = max_op(T(5.0), std::memory_order_seq_cst);
+    std::same_as<T> decltype(auto) old = max_op(T(5.0), std::memory_order_seq_cst);
     assert(old == T(10.0));
     assert(load() == T(10.0));
   }
@@ -46,14 +46,14 @@ void test_fetch_fmax(LoadOp load, StoreOp store, MaxOp max_op) {
   // Test with negative values
   {
     store(T(-10.0));
-    T old = max_op(T(-5.0), std::memory_order_seq_cst);
+    std::same_as<T> decltype(auto) old = max_op(T(-5.0), std::memory_order_seq_cst);
     assert(old == T(-10.0));
     assert(load() == T(-5.0));
   }
 
   {
     store(T(-5.0));
-    T old = max_op(T(-10.0), std::memory_order_seq_cst);
+    std::same_as<T> decltype(auto) old = max_op(T(-10.0), std::memory_order_seq_cst);
     assert(old == T(-5.0));
     assert(load() == T(-5.0));
   }
@@ -61,14 +61,14 @@ void test_fetch_fmax(LoadOp load, StoreOp store, MaxOp max_op) {
   // Test infinity
   {
     store(T(1.0));
-    T old = max_op(inf, std::memory_order_seq_cst);
+    std::same_as<T> decltype(auto) old = max_op(inf, std::memory_order_seq_cst);
     assert(old == T(1.0));
     assert(load() == inf);
   }
 
   {
     store(-inf);
-    T old = max_op(T(1.0), std::memory_order_seq_cst);
+    std::same_as<T> decltype(auto) old = max_op(T(1.0), std::memory_order_seq_cst);
     assert(old == -inf);
     assert(load() == T(1.0));
   }
@@ -76,36 +76,30 @@ void test_fetch_fmax(LoadOp load, StoreOp store, MaxOp max_op) {
   // Test different memory orderings
   {
     store(T(8.0));
-    T old = max_op(T(15.0), std::memory_order_relaxed);
+    std::same_as<T> decltype(auto) old = max_op(T(15.0), std::memory_order_relaxed);
     assert(old == T(8.0));
     assert(load() == T(15.0));
   }
 
   {
     store(T(3.0));
-    T old = max_op(T(10.0), std::memory_order_acquire);
+    std::same_as<T> decltype(auto) old = max_op(T(10.0), std::memory_order_acquire);
     assert(old == T(3.0));
     assert(load() == T(10.0));
   }
 
   {
     store(T(2.0));
-    T old = max_op(T(10.0), std::memory_order_release);
+    std::same_as<T> decltype(auto) old = max_op(T(10.0), std::memory_order_release);
     assert(old == T(2.0));
     assert(load() == T(10.0));
   }
 
   {
     store(T(7.0));
-    T old = max_op(T(10.0), std::memory_order_acq_rel);
+    std::same_as<T> decltype(auto) old = max_op(T(10.0), std::memory_order_acq_rel);
     assert(old == T(7.0));
     assert(load() == T(10.0));
-  }
-
-  // Test return type
-  {
-    store(T(10.0));
-    static_assert(std::is_same_v<decltype(max_op(T(5.0), std::memory_order_seq_cst)), T>);
   }
 }
 

--- a/libcxx/test/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_fetch_fmax_helper.h
+++ b/libcxx/test/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_fetch_fmax_helper.h
@@ -1,0 +1,112 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef TEST_STD_ATOMICS_ATOMIC_FETCH_FMAX_HELPER_H
+#define TEST_STD_ATOMICS_ATOMIC_FETCH_FMAX_HELPER_H
+
+#include <cassert>
+#include <cmath>
+#include <limits>
+#include <type_traits>
+
+#include "test_macros.h"
+
+// Test fetch_max for floating-point types
+// NOTE: NaN handling and signed zero comparison (-0.0 vs +0.0) are unspecified
+// LoadOp: () -> T - reads current value
+// StoreOp: (T) -> void - stores a value
+// MaxOp: (T, memory_order) -> T - performs fetch_max operation
+template <class T, class LoadOp, class StoreOp, class MaxOp>
+void test_fetch_fmax(LoadOp load, StoreOp store, MaxOp max_op) {
+  static_assert(std::is_floating_point_v<T>);
+
+  constexpr T inf = std::numeric_limits<T>::infinity();
+
+  // Test basic fetch_max (update to larger value)
+  {
+    store(T(10.0));
+    T old = max_op(T(20.0), std::memory_order_seq_cst);
+    assert(old == T(10.0));
+    assert(load() == T(20.0));
+  }
+
+  // Test with smaller value (no change)
+  {
+    store(T(10.0));
+    T old = max_op(T(5.0), std::memory_order_seq_cst);
+    assert(old == T(10.0));
+    assert(load() == T(10.0));
+  }
+
+  // Test with negative values
+  {
+    store(T(-10.0));
+    T old = max_op(T(-5.0), std::memory_order_seq_cst);
+    assert(old == T(-10.0));
+    assert(load() == T(-5.0));
+  }
+
+  {
+    store(T(-5.0));
+    T old = max_op(T(-10.0), std::memory_order_seq_cst);
+    assert(old == T(-5.0));
+    assert(load() == T(-5.0));
+  }
+
+  // Test infinity
+  {
+    store(T(1.0));
+    T old = max_op(inf, std::memory_order_seq_cst);
+    assert(old == T(1.0));
+    assert(load() == inf);
+  }
+
+  {
+    store(-inf);
+    T old = max_op(T(1.0), std::memory_order_seq_cst);
+    assert(old == -inf);
+    assert(load() == T(1.0));
+  }
+
+  // Test different memory orderings
+  {
+    store(T(8.0));
+    T old = max_op(T(15.0), std::memory_order_relaxed);
+    assert(old == T(8.0));
+    assert(load() == T(15.0));
+  }
+
+  {
+    store(T(3.0));
+    T old = max_op(T(10.0), std::memory_order_acquire);
+    assert(old == T(3.0));
+    assert(load() == T(10.0));
+  }
+
+  {
+    store(T(2.0));
+    T old = max_op(T(10.0), std::memory_order_release);
+    assert(old == T(2.0));
+    assert(load() == T(10.0));
+  }
+
+  {
+    store(T(7.0));
+    T old = max_op(T(10.0), std::memory_order_acq_rel);
+    assert(old == T(7.0));
+    assert(load() == T(10.0));
+  }
+
+  // Test return type
+  {
+    store(T(10.0));
+    static_assert(std::is_same_v<decltype(max_op(T(5.0), std::memory_order_seq_cst)), T>);
+  }
+}
+
+#endif // TEST_STD_ATOMICS_ATOMIC_FETCH_FMAX_HELPER_H

--- a/libcxx/test/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_fetch_fmaximum_helper.h
+++ b/libcxx/test/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_fetch_fmaximum_helper.h
@@ -23,13 +23,28 @@ template <class T>
 T make_nan_with_payload(unsigned int payload) {
   static_assert(std::is_floating_point_v<T>);
   T nan = std::numeric_limits<T>::quiet_NaN();
-  // Create NaN with different bit pattern by manipulating the payload
-  using UIntType = std::conditional_t<sizeof(T) == 4, uint32_t, uint64_t>;
-  UIntType bits;
-  std::memcpy(&bits, &nan, sizeof(T));
+
+  // Use a byte array sized to T to handle all floating-point types
+  alignas(T) unsigned char bits[sizeof(T)];
+  std::memcpy(bits, &nan, sizeof(T));
+
   // Modify the mantissa bits (payload) while keeping it a NaN
-  bits = (bits & ~UIntType(0xFFFFF)) | (payload & 0xFFFFF);
-  std::memcpy(&nan, &bits, sizeof(T));
+  // For float and double, modify the lower bits directly
+  // For long double, modify the first 8 bytes which contain the mantissa
+  if constexpr (sizeof(T) == sizeof(float)) {
+    uint32_t int_bits;
+    std::memcpy(&int_bits, bits, sizeof(uint32_t));
+    int_bits = (int_bits & ~uint32_t(0xFFFFF)) | (payload & 0xFFFFF);
+    std::memcpy(bits, &int_bits, sizeof(uint32_t));
+  } else {
+    // For double and long double, modify the first 64 bits
+    uint64_t int_bits;
+    std::memcpy(&int_bits, bits, sizeof(uint64_t));
+    int_bits = (int_bits & ~uint64_t(0xFFFFF)) | (payload & 0xFFFFF);
+    std::memcpy(bits, &int_bits, sizeof(uint64_t));
+  }
+
+  std::memcpy(&nan, bits, sizeof(T));
   return nan;
 }
 
@@ -47,7 +62,7 @@ void test_fetch_fmaximum(LoadOp load, StoreOp store, FMaximumOp fmaximum) {
   // Test basic fetch_fmaximum (update to larger value)
   {
     store(T(10.0));
-    T old = fmaximum(T(20.0), std::memory_order_seq_cst);
+    std::same_as<T> decltype(auto) old = fmaximum(T(20.0), std::memory_order_seq_cst);
     assert(old == T(10.0));
     assert(load() == T(20.0));
   }
@@ -55,7 +70,7 @@ void test_fetch_fmaximum(LoadOp load, StoreOp store, FMaximumOp fmaximum) {
   // Test with smaller value (no change)
   {
     store(T(10.0));
-    T old = fmaximum(T(5.0), std::memory_order_seq_cst);
+    std::same_as<T> decltype(auto) old = fmaximum(T(5.0), std::memory_order_seq_cst);
     assert(old == T(10.0));
     assert(load() == T(10.0));
   }
@@ -63,14 +78,14 @@ void test_fetch_fmaximum(LoadOp load, StoreOp store, FMaximumOp fmaximum) {
   // Test with negative values
   {
     store(T(-10.0));
-    T old = fmaximum(T(-5.0), std::memory_order_seq_cst);
+    std::same_as<T> decltype(auto) old = fmaximum(T(-5.0), std::memory_order_seq_cst);
     assert(old == T(-10.0));
     assert(load() == T(-5.0));
   }
 
   {
     store(T(-5.0));
-    T old = fmaximum(T(-10.0), std::memory_order_seq_cst);
+    std::same_as<T> decltype(auto) old = fmaximum(T(-10.0), std::memory_order_seq_cst);
     assert(old == T(-5.0));
     assert(load() == T(-5.0));
   }
@@ -78,14 +93,14 @@ void test_fetch_fmaximum(LoadOp load, StoreOp store, FMaximumOp fmaximum) {
   // Test NaN handling: propagate NaN
   {
     store(nan);
-    T old = fmaximum(T(5.0), std::memory_order_seq_cst);
+    std::same_as<T> decltype(auto) old = fmaximum(T(5.0), std::memory_order_seq_cst);
     assert(std::isnan(old));
     assert(std::isnan(load()));
   }
 
   {
     store(T(5.0));
-    T old = fmaximum(nan, std::memory_order_seq_cst);
+    std::same_as<T> decltype(auto) old = fmaximum(nan, std::memory_order_seq_cst);
     assert(old == T(5.0));
     assert(std::isnan(load()));
   }
@@ -93,7 +108,7 @@ void test_fetch_fmaximum(LoadOp load, StoreOp store, FMaximumOp fmaximum) {
   // Both NaN: return NaN
   {
     store(nan);
-    T old = fmaximum(nan, std::memory_order_seq_cst);
+    std::same_as<T> decltype(auto) old = fmaximum(nan, std::memory_order_seq_cst);
     assert(std::isnan(old));
     assert(std::isnan(load()));
   }
@@ -101,7 +116,7 @@ void test_fetch_fmaximum(LoadOp load, StoreOp store, FMaximumOp fmaximum) {
   // Test signed zero handling: -0.0 < +0.0, so max returns +0.0
   {
     store(T(-0.0));
-    T old = fmaximum(T(+0.0), std::memory_order_seq_cst);
+    std::same_as<T> decltype(auto) old = fmaximum(T(+0.0), std::memory_order_seq_cst);
     assert(old == T(-0.0));
     assert(std::signbit(old));
     assert(!std::signbit(load()));
@@ -109,7 +124,7 @@ void test_fetch_fmaximum(LoadOp load, StoreOp store, FMaximumOp fmaximum) {
 
   {
     store(T(+0.0));
-    T old = fmaximum(T(-0.0), std::memory_order_seq_cst);
+    std::same_as<T> decltype(auto) old = fmaximum(T(-0.0), std::memory_order_seq_cst);
     assert(old == T(+0.0));
     assert(!std::signbit(old));
     assert(!std::signbit(load()));
@@ -118,14 +133,14 @@ void test_fetch_fmaximum(LoadOp load, StoreOp store, FMaximumOp fmaximum) {
   // Test infinity
   {
     store(T(1.0));
-    T old = fmaximum(inf, std::memory_order_seq_cst);
+    std::same_as<T> decltype(auto) old = fmaximum(inf, std::memory_order_seq_cst);
     assert(old == T(1.0));
     assert(load() == inf);
   }
 
   {
     store(-inf);
-    T old = fmaximum(T(1.0), std::memory_order_seq_cst);
+    std::same_as<T> decltype(auto) old = fmaximum(T(1.0), std::memory_order_seq_cst);
     assert(old == -inf);
     assert(load() == T(1.0));
   }
@@ -133,28 +148,28 @@ void test_fetch_fmaximum(LoadOp load, StoreOp store, FMaximumOp fmaximum) {
   // Test different memory orderings
   {
     store(T(8.0));
-    T old = fmaximum(T(15.0), std::memory_order_relaxed);
+    std::same_as<T> decltype(auto) old = fmaximum(T(15.0), std::memory_order_relaxed);
     assert(old == T(8.0));
     assert(load() == T(15.0));
   }
 
   {
     store(T(3.0));
-    T old = fmaximum(T(10.0), std::memory_order_acquire);
+    std::same_as<T> decltype(auto) old = fmaximum(T(10.0), std::memory_order_acquire);
     assert(old == T(3.0));
     assert(load() == T(10.0));
   }
 
   {
     store(T(2.0));
-    T old = fmaximum(T(10.0), std::memory_order_release);
+    std::same_as<T> decltype(auto) old = fmaximum(T(10.0), std::memory_order_release);
     assert(old == T(2.0));
     assert(load() == T(10.0));
   }
 
   {
     store(T(7.0));
-    T old = fmaximum(T(10.0), std::memory_order_acq_rel);
+    std::same_as<T> decltype(auto) old = fmaximum(T(10.0), std::memory_order_acq_rel);
     assert(old == T(7.0));
     assert(load() == T(10.0));
   }
@@ -165,7 +180,7 @@ void test_fetch_fmaximum(LoadOp load, StoreOp store, FMaximumOp fmaximum) {
 
     // Store NaN with payload 1, fetch with non-NaN (propagates NaN)
     store(nan1);
-    T old = fmaximum(T(5.0), std::memory_order_seq_cst);
+    std::same_as<T> decltype(auto) old = fmaximum(T(5.0), std::memory_order_seq_cst);
     assert(std::isnan(old));
     assert(std::isnan(load()));
   }
@@ -175,7 +190,7 @@ void test_fetch_fmaximum(LoadOp load, StoreOp store, FMaximumOp fmaximum) {
 
     // Store non-NaN, fetch with NaN with payload 2 (propagates NaN)
     store(T(5.0));
-    T old = fmaximum(nan2, std::memory_order_seq_cst);
+    std::same_as<T> decltype(auto) old = fmaximum(nan2, std::memory_order_seq_cst);
     assert(old == T(5.0));
     assert(std::isnan(load()));
   }
@@ -186,16 +201,10 @@ void test_fetch_fmaximum(LoadOp load, StoreOp store, FMaximumOp fmaximum) {
 
     // Store NaN with payload 1, fetch with NaN with payload 2 (propagates NaN)
     store(nan1);
-    T old = fmaximum(nan2, std::memory_order_seq_cst);
+    std::same_as<T> decltype(auto) old = fmaximum(nan2, std::memory_order_seq_cst);
     assert(std::isnan(old));
     assert(std::isnan(load()));
     // Result should be one of the NaN values (implementation-defined which)
-  }
-
-  // Test return type
-  {
-    store(T(10.0));
-    static_assert(std::is_same_v<decltype(fmaximum(T(5.0), std::memory_order_seq_cst)), T>);
   }
 }
 

--- a/libcxx/test/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_fetch_fmaximum_helper.h
+++ b/libcxx/test/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_fetch_fmaximum_helper.h
@@ -1,0 +1,202 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef TEST_STD_ATOMICS_ATOMIC_FETCH_FMAXIMUM_HELPER_H
+#define TEST_STD_ATOMICS_ATOMIC_FETCH_FMAXIMUM_HELPER_H
+
+#include <cassert>
+#include <cmath>
+#include <cstdint>
+#include <cstring>
+#include <limits>
+#include <type_traits>
+
+#include "test_macros.h"
+
+// Create a NaN with a specific payload to get different bit representations
+template <class T>
+T make_nan_with_payload(unsigned int payload) {
+  static_assert(std::is_floating_point_v<T>);
+  T nan = std::numeric_limits<T>::quiet_NaN();
+  // Create NaN with different bit pattern by manipulating the payload
+  using UIntType = std::conditional_t<sizeof(T) == 4, uint32_t, uint64_t>;
+  UIntType bits;
+  std::memcpy(&bits, &nan, sizeof(T));
+  // Modify the mantissa bits (payload) while keeping it a NaN
+  bits = (bits & ~UIntType(0xFFFFF)) | (payload & 0xFFFFF);
+  std::memcpy(&nan, &bits, sizeof(T));
+  return nan;
+}
+
+// Test fetch_fmaximum for floating-point types
+// LoadOp: () -> T - reads current value
+// StoreOp: (T) -> void - stores a value
+// FMaximumOp: (T, memory_order) -> T - performs fetch_fmaximum operation
+template <class T, class LoadOp, class StoreOp, class FMaximumOp>
+void test_fetch_fmaximum(LoadOp load, StoreOp store, FMaximumOp fmaximum) {
+  static_assert(std::is_floating_point_v<T>);
+
+  constexpr T nan = std::numeric_limits<T>::quiet_NaN();
+  constexpr T inf = std::numeric_limits<T>::infinity();
+
+  // Test basic fetch_fmaximum (update to larger value)
+  {
+    store(T(10.0));
+    T old = fmaximum(T(20.0), std::memory_order_seq_cst);
+    assert(old == T(10.0));
+    assert(load() == T(20.0));
+  }
+
+  // Test with smaller value (no change)
+  {
+    store(T(10.0));
+    T old = fmaximum(T(5.0), std::memory_order_seq_cst);
+    assert(old == T(10.0));
+    assert(load() == T(10.0));
+  }
+
+  // Test with negative values
+  {
+    store(T(-10.0));
+    T old = fmaximum(T(-5.0), std::memory_order_seq_cst);
+    assert(old == T(-10.0));
+    assert(load() == T(-5.0));
+  }
+
+  {
+    store(T(-5.0));
+    T old = fmaximum(T(-10.0), std::memory_order_seq_cst);
+    assert(old == T(-5.0));
+    assert(load() == T(-5.0));
+  }
+
+  // Test NaN handling: propagate NaN
+  {
+    store(nan);
+    T old = fmaximum(T(5.0), std::memory_order_seq_cst);
+    assert(std::isnan(old));
+    assert(std::isnan(load()));
+  }
+
+  {
+    store(T(5.0));
+    T old = fmaximum(nan, std::memory_order_seq_cst);
+    assert(old == T(5.0));
+    assert(std::isnan(load()));
+  }
+
+  // Both NaN: return NaN
+  {
+    store(nan);
+    T old = fmaximum(nan, std::memory_order_seq_cst);
+    assert(std::isnan(old));
+    assert(std::isnan(load()));
+  }
+
+  // Test signed zero handling: -0.0 < +0.0, so max returns +0.0
+  {
+    store(T(-0.0));
+    T old = fmaximum(T(+0.0), std::memory_order_seq_cst);
+    assert(old == T(-0.0));
+    assert(std::signbit(old));
+    assert(!std::signbit(load()));
+  }
+
+  {
+    store(T(+0.0));
+    T old = fmaximum(T(-0.0), std::memory_order_seq_cst);
+    assert(old == T(+0.0));
+    assert(!std::signbit(old));
+    assert(!std::signbit(load()));
+  }
+
+  // Test infinity
+  {
+    store(T(1.0));
+    T old = fmaximum(inf, std::memory_order_seq_cst);
+    assert(old == T(1.0));
+    assert(load() == inf);
+  }
+
+  {
+    store(-inf);
+    T old = fmaximum(T(1.0), std::memory_order_seq_cst);
+    assert(old == -inf);
+    assert(load() == T(1.0));
+  }
+
+  // Test different memory orderings
+  {
+    store(T(8.0));
+    T old = fmaximum(T(15.0), std::memory_order_relaxed);
+    assert(old == T(8.0));
+    assert(load() == T(15.0));
+  }
+
+  {
+    store(T(3.0));
+    T old = fmaximum(T(10.0), std::memory_order_acquire);
+    assert(old == T(3.0));
+    assert(load() == T(10.0));
+  }
+
+  {
+    store(T(2.0));
+    T old = fmaximum(T(10.0), std::memory_order_release);
+    assert(old == T(2.0));
+    assert(load() == T(10.0));
+  }
+
+  {
+    store(T(7.0));
+    T old = fmaximum(T(10.0), std::memory_order_acq_rel);
+    assert(old == T(7.0));
+    assert(load() == T(10.0));
+  }
+
+  // Test with different NaN representations
+  {
+    T nan1 = make_nan_with_payload<T>(1);
+
+    // Store NaN with payload 1, fetch with non-NaN (propagates NaN)
+    store(nan1);
+    T old = fmaximum(T(5.0), std::memory_order_seq_cst);
+    assert(std::isnan(old));
+    assert(std::isnan(load()));
+  }
+
+  {
+    T nan2 = make_nan_with_payload<T>(2);
+
+    // Store non-NaN, fetch with NaN with payload 2 (propagates NaN)
+    store(T(5.0));
+    T old = fmaximum(nan2, std::memory_order_seq_cst);
+    assert(old == T(5.0));
+    assert(std::isnan(load()));
+  }
+
+  {
+    T nan1 = make_nan_with_payload<T>(1);
+    T nan2 = make_nan_with_payload<T>(2);
+
+    // Store NaN with payload 1, fetch with NaN with payload 2 (propagates NaN)
+    store(nan1);
+    T old = fmaximum(nan2, std::memory_order_seq_cst);
+    assert(std::isnan(old));
+    assert(std::isnan(load()));
+    // Result should be one of the NaN values (implementation-defined which)
+  }
+
+  // Test return type
+  {
+    store(T(10.0));
+    static_assert(std::is_same_v<decltype(fmaximum(T(5.0), std::memory_order_seq_cst)), T>);
+  }
+}
+
+#endif // TEST_STD_ATOMICS_ATOMIC_FETCH_FMAXIMUM_HELPER_H

--- a/libcxx/test/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_fetch_fmaximum_num_helper.h
+++ b/libcxx/test/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_fetch_fmaximum_num_helper.h
@@ -23,13 +23,28 @@ template <class T>
 T make_nan_with_payload(unsigned int payload) {
   static_assert(std::is_floating_point_v<T>);
   T nan = std::numeric_limits<T>::quiet_NaN();
-  // Create NaN with different bit pattern by manipulating the payload
-  using UIntType = std::conditional_t<sizeof(T) == 4, uint32_t, uint64_t>;
-  UIntType bits;
-  std::memcpy(&bits, &nan, sizeof(T));
+
+  // Use a byte array sized to T to handle all floating-point types
+  alignas(T) unsigned char bits[sizeof(T)];
+  std::memcpy(bits, &nan, sizeof(T));
+
   // Modify the mantissa bits (payload) while keeping it a NaN
-  bits = (bits & ~UIntType(0xFFFFF)) | (payload & 0xFFFFF);
-  std::memcpy(&nan, &bits, sizeof(T));
+  // For float and double, modify the lower bits directly
+  // For long double, modify the first 8 bytes which contain the mantissa
+  if constexpr (sizeof(T) == sizeof(float)) {
+    uint32_t int_bits;
+    std::memcpy(&int_bits, bits, sizeof(uint32_t));
+    int_bits = (int_bits & ~uint32_t(0xFFFFF)) | (payload & 0xFFFFF);
+    std::memcpy(bits, &int_bits, sizeof(uint32_t));
+  } else {
+    // For double and long double, modify the first 64 bits
+    uint64_t int_bits;
+    std::memcpy(&int_bits, bits, sizeof(uint64_t));
+    int_bits = (int_bits & ~uint64_t(0xFFFFF)) | (payload & 0xFFFFF);
+    std::memcpy(bits, &int_bits, sizeof(uint64_t));
+  }
+
+  std::memcpy(&nan, bits, sizeof(T));
   return nan;
 }
 
@@ -47,7 +62,7 @@ void test_fetch_fmaximum_num(LoadOp load, StoreOp store, FMaximumNumOp fmaximum_
   // Test basic fetch_fmaximum_num (update to larger value)
   {
     store(T(10.0));
-    T old = fmaximum_num(T(20.0), std::memory_order_seq_cst);
+    std::same_as<T> decltype(auto) old = fmaximum_num(T(20.0), std::memory_order_seq_cst);
     assert(old == T(10.0));
     assert(load() == T(20.0));
   }
@@ -55,7 +70,7 @@ void test_fetch_fmaximum_num(LoadOp load, StoreOp store, FMaximumNumOp fmaximum_
   // Test with smaller value (no change)
   {
     store(T(10.0));
-    T old = fmaximum_num(T(5.0), std::memory_order_seq_cst);
+    std::same_as<T> decltype(auto) old = fmaximum_num(T(5.0), std::memory_order_seq_cst);
     assert(old == T(10.0));
     assert(load() == T(10.0));
   }
@@ -63,14 +78,14 @@ void test_fetch_fmaximum_num(LoadOp load, StoreOp store, FMaximumNumOp fmaximum_
   // Test with negative values
   {
     store(T(-10.0));
-    T old = fmaximum_num(T(-5.0), std::memory_order_seq_cst);
+    std::same_as<T> decltype(auto) old = fmaximum_num(T(-5.0), std::memory_order_seq_cst);
     assert(old == T(-10.0));
     assert(load() == T(-5.0));
   }
 
   {
     store(T(-5.0));
-    T old = fmaximum_num(T(-10.0), std::memory_order_seq_cst);
+    std::same_as<T> decltype(auto) old = fmaximum_num(T(-10.0), std::memory_order_seq_cst);
     assert(old == T(-5.0));
     assert(load() == T(-5.0));
   }
@@ -78,14 +93,14 @@ void test_fetch_fmaximum_num(LoadOp load, StoreOp store, FMaximumNumOp fmaximum_
   // Test NaN handling: favor non-NaN values
   {
     store(nan);
-    T old = fmaximum_num(T(5.0), std::memory_order_seq_cst);
+    std::same_as<T> decltype(auto) old = fmaximum_num(T(5.0), std::memory_order_seq_cst);
     assert(std::isnan(old));
     assert(load() == T(5.0));
   }
 
   {
     store(T(5.0));
-    T old = fmaximum_num(nan, std::memory_order_seq_cst);
+    std::same_as<T> decltype(auto) old = fmaximum_num(nan, std::memory_order_seq_cst);
     assert(old == T(5.0));
     assert(load() == T(5.0));
   }
@@ -93,7 +108,7 @@ void test_fetch_fmaximum_num(LoadOp load, StoreOp store, FMaximumNumOp fmaximum_
   // Both NaN: return NaN
   {
     store(nan);
-    T old = fmaximum_num(nan, std::memory_order_seq_cst);
+    std::same_as<T> decltype(auto) old = fmaximum_num(nan, std::memory_order_seq_cst);
     assert(std::isnan(old));
     assert(std::isnan(load()));
   }
@@ -101,7 +116,7 @@ void test_fetch_fmaximum_num(LoadOp load, StoreOp store, FMaximumNumOp fmaximum_
   // Test signed zero handling: -0.0 < +0.0, so max returns +0.0
   {
     store(T(-0.0));
-    T old = fmaximum_num(T(+0.0), std::memory_order_seq_cst);
+    std::same_as<T> decltype(auto) old = fmaximum_num(T(+0.0), std::memory_order_seq_cst);
     assert(old == T(-0.0));
     assert(std::signbit(old));
     assert(!std::signbit(load()));
@@ -109,7 +124,7 @@ void test_fetch_fmaximum_num(LoadOp load, StoreOp store, FMaximumNumOp fmaximum_
 
   {
     store(T(+0.0));
-    T old = fmaximum_num(T(-0.0), std::memory_order_seq_cst);
+    std::same_as<T> decltype(auto) old = fmaximum_num(T(-0.0), std::memory_order_seq_cst);
     assert(old == T(+0.0));
     assert(!std::signbit(old));
     assert(!std::signbit(load()));
@@ -118,14 +133,14 @@ void test_fetch_fmaximum_num(LoadOp load, StoreOp store, FMaximumNumOp fmaximum_
   // Test infinity
   {
     store(T(1.0));
-    T old = fmaximum_num(inf, std::memory_order_seq_cst);
+    std::same_as<T> decltype(auto) old = fmaximum_num(inf, std::memory_order_seq_cst);
     assert(old == T(1.0));
     assert(load() == inf);
   }
 
   {
     store(-inf);
-    T old = fmaximum_num(T(1.0), std::memory_order_seq_cst);
+    std::same_as<T> decltype(auto) old = fmaximum_num(T(1.0), std::memory_order_seq_cst);
     assert(old == -inf);
     assert(load() == T(1.0));
   }
@@ -133,28 +148,28 @@ void test_fetch_fmaximum_num(LoadOp load, StoreOp store, FMaximumNumOp fmaximum_
   // Test different memory orderings
   {
     store(T(8.0));
-    T old = fmaximum_num(T(15.0), std::memory_order_relaxed);
+    std::same_as<T> decltype(auto) old = fmaximum_num(T(15.0), std::memory_order_relaxed);
     assert(old == T(8.0));
     assert(load() == T(15.0));
   }
 
   {
     store(T(3.0));
-    T old = fmaximum_num(T(10.0), std::memory_order_acquire);
+    std::same_as<T> decltype(auto) old = fmaximum_num(T(10.0), std::memory_order_acquire);
     assert(old == T(3.0));
     assert(load() == T(10.0));
   }
 
   {
     store(T(2.0));
-    T old = fmaximum_num(T(10.0), std::memory_order_release);
+    std::same_as<T> decltype(auto) old = fmaximum_num(T(10.0), std::memory_order_release);
     assert(old == T(2.0));
     assert(load() == T(10.0));
   }
 
   {
     store(T(7.0));
-    T old = fmaximum_num(T(10.0), std::memory_order_acq_rel);
+    std::same_as<T> decltype(auto) old = fmaximum_num(T(10.0), std::memory_order_acq_rel);
     assert(old == T(7.0));
     assert(load() == T(10.0));
   }
@@ -165,7 +180,7 @@ void test_fetch_fmaximum_num(LoadOp load, StoreOp store, FMaximumNumOp fmaximum_
 
     // Store NaN with payload 1, fetch with non-NaN
     store(nan1);
-    T old = fmaximum_num(T(5.0), std::memory_order_seq_cst);
+    std::same_as<T> decltype(auto) old = fmaximum_num(T(5.0), std::memory_order_seq_cst);
     assert(std::isnan(old));
     assert(load() == T(5.0));
   }
@@ -175,7 +190,7 @@ void test_fetch_fmaximum_num(LoadOp load, StoreOp store, FMaximumNumOp fmaximum_
 
     // Store non-NaN, fetch with NaN with payload 2
     store(T(5.0));
-    T old = fmaximum_num(nan2, std::memory_order_seq_cst);
+    std::same_as<T> decltype(auto) old = fmaximum_num(nan2, std::memory_order_seq_cst);
     assert(old == T(5.0));
     assert(load() == T(5.0));
   }
@@ -186,16 +201,10 @@ void test_fetch_fmaximum_num(LoadOp load, StoreOp store, FMaximumNumOp fmaximum_
 
     // Store NaN with payload 1, fetch with NaN with payload 2
     store(nan1);
-    T old = fmaximum_num(nan2, std::memory_order_seq_cst);
+    std::same_as<T> decltype(auto) old = fmaximum_num(nan2, std::memory_order_seq_cst);
     assert(std::isnan(old));
     assert(std::isnan(load()));
     // Result should be one of the NaN values (implementation-defined which)
-  }
-
-  // Test return type
-  {
-    store(T(10.0));
-    static_assert(std::is_same_v<decltype(fmaximum_num(T(5.0), std::memory_order_seq_cst)), T>);
   }
 }
 

--- a/libcxx/test/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_fetch_fmaximum_num_helper.h
+++ b/libcxx/test/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_fetch_fmaximum_num_helper.h
@@ -1,0 +1,202 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef TEST_STD_ATOMICS_ATOMIC_FETCH_FMAXIMUM_NUM_HELPER_H
+#define TEST_STD_ATOMICS_ATOMIC_FETCH_FMAXIMUM_NUM_HELPER_H
+
+#include <cassert>
+#include <cmath>
+#include <cstdint>
+#include <cstring>
+#include <limits>
+#include <type_traits>
+
+#include "test_macros.h"
+
+// Create a NaN with a specific payload to get different bit representations
+template <class T>
+T make_nan_with_payload(unsigned int payload) {
+  static_assert(std::is_floating_point_v<T>);
+  T nan = std::numeric_limits<T>::quiet_NaN();
+  // Create NaN with different bit pattern by manipulating the payload
+  using UIntType = std::conditional_t<sizeof(T) == 4, uint32_t, uint64_t>;
+  UIntType bits;
+  std::memcpy(&bits, &nan, sizeof(T));
+  // Modify the mantissa bits (payload) while keeping it a NaN
+  bits = (bits & ~UIntType(0xFFFFF)) | (payload & 0xFFFFF);
+  std::memcpy(&nan, &bits, sizeof(T));
+  return nan;
+}
+
+// Test fetch_fmaximum_num for floating-point types
+// LoadOp: () -> T - reads current value
+// StoreOp: (T) -> void - stores a value
+// FMaximumNumOp: (T, memory_order) -> T - performs fetch_fmaximum_num operation
+template <class T, class LoadOp, class StoreOp, class FMaximumNumOp>
+void test_fetch_fmaximum_num(LoadOp load, StoreOp store, FMaximumNumOp fmaximum_num) {
+  static_assert(std::is_floating_point_v<T>);
+
+  constexpr T nan = std::numeric_limits<T>::quiet_NaN();
+  constexpr T inf = std::numeric_limits<T>::infinity();
+
+  // Test basic fetch_fmaximum_num (update to larger value)
+  {
+    store(T(10.0));
+    T old = fmaximum_num(T(20.0), std::memory_order_seq_cst);
+    assert(old == T(10.0));
+    assert(load() == T(20.0));
+  }
+
+  // Test with smaller value (no change)
+  {
+    store(T(10.0));
+    T old = fmaximum_num(T(5.0), std::memory_order_seq_cst);
+    assert(old == T(10.0));
+    assert(load() == T(10.0));
+  }
+
+  // Test with negative values
+  {
+    store(T(-10.0));
+    T old = fmaximum_num(T(-5.0), std::memory_order_seq_cst);
+    assert(old == T(-10.0));
+    assert(load() == T(-5.0));
+  }
+
+  {
+    store(T(-5.0));
+    T old = fmaximum_num(T(-10.0), std::memory_order_seq_cst);
+    assert(old == T(-5.0));
+    assert(load() == T(-5.0));
+  }
+
+  // Test NaN handling: favor non-NaN values
+  {
+    store(nan);
+    T old = fmaximum_num(T(5.0), std::memory_order_seq_cst);
+    assert(std::isnan(old));
+    assert(load() == T(5.0));
+  }
+
+  {
+    store(T(5.0));
+    T old = fmaximum_num(nan, std::memory_order_seq_cst);
+    assert(old == T(5.0));
+    assert(load() == T(5.0));
+  }
+
+  // Both NaN: return NaN
+  {
+    store(nan);
+    T old = fmaximum_num(nan, std::memory_order_seq_cst);
+    assert(std::isnan(old));
+    assert(std::isnan(load()));
+  }
+
+  // Test signed zero handling: -0.0 < +0.0, so max returns +0.0
+  {
+    store(T(-0.0));
+    T old = fmaximum_num(T(+0.0), std::memory_order_seq_cst);
+    assert(old == T(-0.0));
+    assert(std::signbit(old));
+    assert(!std::signbit(load()));
+  }
+
+  {
+    store(T(+0.0));
+    T old = fmaximum_num(T(-0.0), std::memory_order_seq_cst);
+    assert(old == T(+0.0));
+    assert(!std::signbit(old));
+    assert(!std::signbit(load()));
+  }
+
+  // Test infinity
+  {
+    store(T(1.0));
+    T old = fmaximum_num(inf, std::memory_order_seq_cst);
+    assert(old == T(1.0));
+    assert(load() == inf);
+  }
+
+  {
+    store(-inf);
+    T old = fmaximum_num(T(1.0), std::memory_order_seq_cst);
+    assert(old == -inf);
+    assert(load() == T(1.0));
+  }
+
+  // Test different memory orderings
+  {
+    store(T(8.0));
+    T old = fmaximum_num(T(15.0), std::memory_order_relaxed);
+    assert(old == T(8.0));
+    assert(load() == T(15.0));
+  }
+
+  {
+    store(T(3.0));
+    T old = fmaximum_num(T(10.0), std::memory_order_acquire);
+    assert(old == T(3.0));
+    assert(load() == T(10.0));
+  }
+
+  {
+    store(T(2.0));
+    T old = fmaximum_num(T(10.0), std::memory_order_release);
+    assert(old == T(2.0));
+    assert(load() == T(10.0));
+  }
+
+  {
+    store(T(7.0));
+    T old = fmaximum_num(T(10.0), std::memory_order_acq_rel);
+    assert(old == T(7.0));
+    assert(load() == T(10.0));
+  }
+
+  // Test with different NaN representations
+  {
+    T nan1 = make_nan_with_payload<T>(1);
+
+    // Store NaN with payload 1, fetch with non-NaN
+    store(nan1);
+    T old = fmaximum_num(T(5.0), std::memory_order_seq_cst);
+    assert(std::isnan(old));
+    assert(load() == T(5.0));
+  }
+
+  {
+    T nan2 = make_nan_with_payload<T>(2);
+
+    // Store non-NaN, fetch with NaN with payload 2
+    store(T(5.0));
+    T old = fmaximum_num(nan2, std::memory_order_seq_cst);
+    assert(old == T(5.0));
+    assert(load() == T(5.0));
+  }
+
+  {
+    T nan1 = make_nan_with_payload<T>(1);
+    T nan2 = make_nan_with_payload<T>(2);
+
+    // Store NaN with payload 1, fetch with NaN with payload 2
+    store(nan1);
+    T old = fmaximum_num(nan2, std::memory_order_seq_cst);
+    assert(std::isnan(old));
+    assert(std::isnan(load()));
+    // Result should be one of the NaN values (implementation-defined which)
+  }
+
+  // Test return type
+  {
+    store(T(10.0));
+    static_assert(std::is_same_v<decltype(fmaximum_num(T(5.0), std::memory_order_seq_cst)), T>);
+  }
+}
+
+#endif // TEST_STD_ATOMICS_ATOMIC_FETCH_FMAXIMUM_NUM_HELPER_H

--- a/libcxx/test/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_fetch_fmin_helper.h
+++ b/libcxx/test/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_fetch_fmin_helper.h
@@ -30,7 +30,7 @@ void test_fetch_fmin(LoadOp load, StoreOp store, MinOp min_op) {
   // Test basic fetch_min (update to smaller value)
   {
     store(T(10.0));
-    T old = min_op(T(5.0), std::memory_order_seq_cst);
+    std::same_as<T> decltype(auto) old = min_op(T(5.0), std::memory_order_seq_cst);
     assert(old == T(10.0));
     assert(load() == T(5.0));
   }
@@ -38,7 +38,7 @@ void test_fetch_fmin(LoadOp load, StoreOp store, MinOp min_op) {
   // Test with larger value (no change)
   {
     store(T(10.0));
-    T old = min_op(T(20.0), std::memory_order_seq_cst);
+    std::same_as<T> decltype(auto) old = min_op(T(20.0), std::memory_order_seq_cst);
     assert(old == T(10.0));
     assert(load() == T(10.0));
   }
@@ -46,14 +46,14 @@ void test_fetch_fmin(LoadOp load, StoreOp store, MinOp min_op) {
   // Test with negative values
   {
     store(T(-5.0));
-    T old = min_op(T(-10.0), std::memory_order_seq_cst);
+    std::same_as<T> decltype(auto) old = min_op(T(-10.0), std::memory_order_seq_cst);
     assert(old == T(-5.0));
     assert(load() == T(-10.0));
   }
 
   {
     store(T(-10.0));
-    T old = min_op(T(-5.0), std::memory_order_seq_cst);
+    std::same_as<T> decltype(auto) old = min_op(T(-5.0), std::memory_order_seq_cst);
     assert(old == T(-10.0));
     assert(load() == T(-10.0));
   }
@@ -61,14 +61,14 @@ void test_fetch_fmin(LoadOp load, StoreOp store, MinOp min_op) {
   // Test infinity
   {
     store(inf);
-    T old = min_op(T(1.0), std::memory_order_seq_cst);
+    std::same_as<T> decltype(auto) old = min_op(T(1.0), std::memory_order_seq_cst);
     assert(old == inf);
     assert(load() == T(1.0));
   }
 
   {
     store(T(1.0));
-    T old = min_op(-inf, std::memory_order_seq_cst);
+    std::same_as<T> decltype(auto) old = min_op(-inf, std::memory_order_seq_cst);
     assert(old == T(1.0));
     assert(load() == -inf);
   }
@@ -76,36 +76,30 @@ void test_fetch_fmin(LoadOp load, StoreOp store, MinOp min_op) {
   // Test different memory orderings
   {
     store(T(15.0));
-    T old = min_op(T(8.0), std::memory_order_relaxed);
+    std::same_as<T> decltype(auto) old = min_op(T(8.0), std::memory_order_relaxed);
     assert(old == T(15.0));
     assert(load() == T(8.0));
   }
 
   {
     store(T(10.0));
-    T old = min_op(T(3.0), std::memory_order_acquire);
+    std::same_as<T> decltype(auto) old = min_op(T(3.0), std::memory_order_acquire);
     assert(old == T(10.0));
     assert(load() == T(3.0));
   }
 
   {
     store(T(10.0));
-    T old = min_op(T(2.0), std::memory_order_release);
+    std::same_as<T> decltype(auto) old = min_op(T(2.0), std::memory_order_release);
     assert(old == T(10.0));
     assert(load() == T(2.0));
   }
 
   {
     store(T(10.0));
-    T old = min_op(T(7.0), std::memory_order_acq_rel);
+    std::same_as<T> decltype(auto) old = min_op(T(7.0), std::memory_order_acq_rel);
     assert(old == T(10.0));
     assert(load() == T(7.0));
-  }
-
-  // Test return type
-  {
-    store(T(10.0));
-    static_assert(std::is_same_v<decltype(min_op(T(5.0), std::memory_order_seq_cst)), T>);
   }
 }
 

--- a/libcxx/test/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_fetch_fmin_helper.h
+++ b/libcxx/test/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_fetch_fmin_helper.h
@@ -1,0 +1,112 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef TEST_STD_ATOMICS_ATOMIC_FETCH_FMIN_HELPER_H
+#define TEST_STD_ATOMICS_ATOMIC_FETCH_FMIN_HELPER_H
+
+#include <cassert>
+#include <cmath>
+#include <limits>
+#include <type_traits>
+
+#include "test_macros.h"
+
+// Test fetch_min for floating-point types
+// NOTE: NaN handling and signed zero comparison (-0.0 vs +0.0) are unspecified
+// LoadOp: () -> T - reads current value
+// StoreOp: (T) -> void - stores a value
+// MinOp: (T, memory_order) -> T - performs fetch_min operation
+template <class T, class LoadOp, class StoreOp, class MinOp>
+void test_fetch_fmin(LoadOp load, StoreOp store, MinOp min_op) {
+  static_assert(std::is_floating_point_v<T>);
+
+  constexpr T inf = std::numeric_limits<T>::infinity();
+
+  // Test basic fetch_min (update to smaller value)
+  {
+    store(T(10.0));
+    T old = min_op(T(5.0), std::memory_order_seq_cst);
+    assert(old == T(10.0));
+    assert(load() == T(5.0));
+  }
+
+  // Test with larger value (no change)
+  {
+    store(T(10.0));
+    T old = min_op(T(20.0), std::memory_order_seq_cst);
+    assert(old == T(10.0));
+    assert(load() == T(10.0));
+  }
+
+  // Test with negative values
+  {
+    store(T(-5.0));
+    T old = min_op(T(-10.0), std::memory_order_seq_cst);
+    assert(old == T(-5.0));
+    assert(load() == T(-10.0));
+  }
+
+  {
+    store(T(-10.0));
+    T old = min_op(T(-5.0), std::memory_order_seq_cst);
+    assert(old == T(-10.0));
+    assert(load() == T(-10.0));
+  }
+
+  // Test infinity
+  {
+    store(inf);
+    T old = min_op(T(1.0), std::memory_order_seq_cst);
+    assert(old == inf);
+    assert(load() == T(1.0));
+  }
+
+  {
+    store(T(1.0));
+    T old = min_op(-inf, std::memory_order_seq_cst);
+    assert(old == T(1.0));
+    assert(load() == -inf);
+  }
+
+  // Test different memory orderings
+  {
+    store(T(15.0));
+    T old = min_op(T(8.0), std::memory_order_relaxed);
+    assert(old == T(15.0));
+    assert(load() == T(8.0));
+  }
+
+  {
+    store(T(10.0));
+    T old = min_op(T(3.0), std::memory_order_acquire);
+    assert(old == T(10.0));
+    assert(load() == T(3.0));
+  }
+
+  {
+    store(T(10.0));
+    T old = min_op(T(2.0), std::memory_order_release);
+    assert(old == T(10.0));
+    assert(load() == T(2.0));
+  }
+
+  {
+    store(T(10.0));
+    T old = min_op(T(7.0), std::memory_order_acq_rel);
+    assert(old == T(10.0));
+    assert(load() == T(7.0));
+  }
+
+  // Test return type
+  {
+    store(T(10.0));
+    static_assert(std::is_same_v<decltype(min_op(T(5.0), std::memory_order_seq_cst)), T>);
+  }
+}
+
+#endif // TEST_STD_ATOMICS_ATOMIC_FETCH_FMIN_HELPER_H

--- a/libcxx/test/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_fetch_fminimum_helper.h
+++ b/libcxx/test/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_fetch_fminimum_helper.h
@@ -23,13 +23,28 @@ template <class T>
 T make_nan_with_payload(unsigned int payload) {
   static_assert(std::is_floating_point_v<T>);
   T nan = std::numeric_limits<T>::quiet_NaN();
-  // Create NaN with different bit pattern by manipulating the payload
-  using UIntType = std::conditional_t<sizeof(T) == 4, uint32_t, uint64_t>;
-  UIntType bits;
-  std::memcpy(&bits, &nan, sizeof(T));
+
+  // Use a byte array sized to T to handle all floating-point types
+  alignas(T) unsigned char bits[sizeof(T)];
+  std::memcpy(bits, &nan, sizeof(T));
+
   // Modify the mantissa bits (payload) while keeping it a NaN
-  bits = (bits & ~UIntType(0xFFFFF)) | (payload & 0xFFFFF);
-  std::memcpy(&nan, &bits, sizeof(T));
+  // For float and double, modify the lower bits directly
+  // For long double, modify the first 8 bytes which contain the mantissa
+  if constexpr (sizeof(T) == sizeof(float)) {
+    uint32_t int_bits;
+    std::memcpy(&int_bits, bits, sizeof(uint32_t));
+    int_bits = (int_bits & ~uint32_t(0xFFFFF)) | (payload & 0xFFFFF);
+    std::memcpy(bits, &int_bits, sizeof(uint32_t));
+  } else {
+    // For double and long double, modify the first 64 bits
+    uint64_t int_bits;
+    std::memcpy(&int_bits, bits, sizeof(uint64_t));
+    int_bits = (int_bits & ~uint64_t(0xFFFFF)) | (payload & 0xFFFFF);
+    std::memcpy(bits, &int_bits, sizeof(uint64_t));
+  }
+
+  std::memcpy(&nan, bits, sizeof(T));
   return nan;
 }
 
@@ -47,7 +62,7 @@ void test_fetch_fminimum(LoadOp load, StoreOp store, FMinimumOp fminimum) {
   // Test basic fetch_fminimum (update to smaller value)
   {
     store(T(10.0));
-    T old = fminimum(T(5.0), std::memory_order_seq_cst);
+    std::same_as<T> decltype(auto) old = fminimum(T(5.0), std::memory_order_seq_cst);
     assert(old == T(10.0));
     assert(load() == T(5.0));
   }
@@ -55,7 +70,7 @@ void test_fetch_fminimum(LoadOp load, StoreOp store, FMinimumOp fminimum) {
   // Test with larger value (no change)
   {
     store(T(10.0));
-    T old = fminimum(T(20.0), std::memory_order_seq_cst);
+    std::same_as<T> decltype(auto) old = fminimum(T(20.0), std::memory_order_seq_cst);
     assert(old == T(10.0));
     assert(load() == T(10.0));
   }
@@ -63,14 +78,14 @@ void test_fetch_fminimum(LoadOp load, StoreOp store, FMinimumOp fminimum) {
   // Test with negative values
   {
     store(T(-5.0));
-    T old = fminimum(T(-10.0), std::memory_order_seq_cst);
+    std::same_as<T> decltype(auto) old = fminimum(T(-10.0), std::memory_order_seq_cst);
     assert(old == T(-5.0));
     assert(load() == T(-10.0));
   }
 
   {
     store(T(-10.0));
-    T old = fminimum(T(-5.0), std::memory_order_seq_cst);
+    std::same_as<T> decltype(auto) old = fminimum(T(-5.0), std::memory_order_seq_cst);
     assert(old == T(-10.0));
     assert(load() == T(-10.0));
   }
@@ -78,14 +93,14 @@ void test_fetch_fminimum(LoadOp load, StoreOp store, FMinimumOp fminimum) {
   // Test NaN handling: propagate NaN
   {
     store(nan);
-    T old = fminimum(T(5.0), std::memory_order_seq_cst);
+    std::same_as<T> decltype(auto) old = fminimum(T(5.0), std::memory_order_seq_cst);
     assert(std::isnan(old));
     assert(std::isnan(load()));
   }
 
   {
     store(T(5.0));
-    T old = fminimum(nan, std::memory_order_seq_cst);
+    std::same_as<T> decltype(auto) old = fminimum(nan, std::memory_order_seq_cst);
     assert(old == T(5.0));
     assert(std::isnan(load()));
   }
@@ -93,7 +108,7 @@ void test_fetch_fminimum(LoadOp load, StoreOp store, FMinimumOp fminimum) {
   // Both NaN: return NaN
   {
     store(nan);
-    T old = fminimum(nan, std::memory_order_seq_cst);
+    std::same_as<T> decltype(auto) old = fminimum(nan, std::memory_order_seq_cst);
     assert(std::isnan(old));
     assert(std::isnan(load()));
   }
@@ -101,7 +116,7 @@ void test_fetch_fminimum(LoadOp load, StoreOp store, FMinimumOp fminimum) {
   // Test signed zero handling: -0.0 < +0.0
   {
     store(T(+0.0));
-    T old = fminimum(T(-0.0), std::memory_order_seq_cst);
+    std::same_as<T> decltype(auto) old = fminimum(T(-0.0), std::memory_order_seq_cst);
     assert(old == T(+0.0));
     assert(!std::signbit(old));
     assert(std::signbit(load()));
@@ -109,7 +124,7 @@ void test_fetch_fminimum(LoadOp load, StoreOp store, FMinimumOp fminimum) {
 
   {
     store(T(-0.0));
-    T old = fminimum(T(+0.0), std::memory_order_seq_cst);
+    std::same_as<T> decltype(auto) old = fminimum(T(+0.0), std::memory_order_seq_cst);
     assert(old == T(-0.0));
     assert(std::signbit(old));
     assert(std::signbit(load()));
@@ -118,14 +133,14 @@ void test_fetch_fminimum(LoadOp load, StoreOp store, FMinimumOp fminimum) {
   // Test infinity
   {
     store(inf);
-    T old = fminimum(T(1.0), std::memory_order_seq_cst);
+    std::same_as<T> decltype(auto) old = fminimum(T(1.0), std::memory_order_seq_cst);
     assert(old == inf);
     assert(load() == T(1.0));
   }
 
   {
     store(T(1.0));
-    T old = fminimum(-inf, std::memory_order_seq_cst);
+    std::same_as<T> decltype(auto) old = fminimum(-inf, std::memory_order_seq_cst);
     assert(old == T(1.0));
     assert(load() == -inf);
   }
@@ -133,28 +148,28 @@ void test_fetch_fminimum(LoadOp load, StoreOp store, FMinimumOp fminimum) {
   // Test different memory orderings
   {
     store(T(15.0));
-    T old = fminimum(T(8.0), std::memory_order_relaxed);
+    std::same_as<T> decltype(auto) old = fminimum(T(8.0), std::memory_order_relaxed);
     assert(old == T(15.0));
     assert(load() == T(8.0));
   }
 
   {
     store(T(10.0));
-    T old = fminimum(T(3.0), std::memory_order_acquire);
+    std::same_as<T> decltype(auto) old = fminimum(T(3.0), std::memory_order_acquire);
     assert(old == T(10.0));
     assert(load() == T(3.0));
   }
 
   {
     store(T(10.0));
-    T old = fminimum(T(2.0), std::memory_order_release);
+    std::same_as<T> decltype(auto) old = fminimum(T(2.0), std::memory_order_release);
     assert(old == T(10.0));
     assert(load() == T(2.0));
   }
 
   {
     store(T(10.0));
-    T old = fminimum(T(7.0), std::memory_order_acq_rel);
+    std::same_as<T> decltype(auto) old = fminimum(T(7.0), std::memory_order_acq_rel);
     assert(old == T(10.0));
     assert(load() == T(7.0));
   }
@@ -165,7 +180,7 @@ void test_fetch_fminimum(LoadOp load, StoreOp store, FMinimumOp fminimum) {
 
     // Store NaN with payload 1, fetch with non-NaN (propagates NaN)
     store(nan1);
-    T old = fminimum(T(5.0), std::memory_order_seq_cst);
+    std::same_as<T> decltype(auto) old = fminimum(T(5.0), std::memory_order_seq_cst);
     assert(std::isnan(old));
     assert(std::isnan(load()));
   }
@@ -175,7 +190,7 @@ void test_fetch_fminimum(LoadOp load, StoreOp store, FMinimumOp fminimum) {
 
     // Store non-NaN, fetch with NaN with payload 2 (propagates NaN)
     store(T(5.0));
-    T old = fminimum(nan2, std::memory_order_seq_cst);
+    std::same_as<T> decltype(auto) old = fminimum(nan2, std::memory_order_seq_cst);
     assert(old == T(5.0));
     assert(std::isnan(load()));
   }
@@ -186,16 +201,10 @@ void test_fetch_fminimum(LoadOp load, StoreOp store, FMinimumOp fminimum) {
 
     // Store NaN with payload 1, fetch with NaN with payload 2 (propagates NaN)
     store(nan1);
-    T old = fminimum(nan2, std::memory_order_seq_cst);
+    std::same_as<T> decltype(auto) old = fminimum(nan2, std::memory_order_seq_cst);
     assert(std::isnan(old));
     assert(std::isnan(load()));
     // Result should be one of the NaN values (implementation-defined which)
-  }
-
-  // Test return type
-  {
-    store(T(10.0));
-    static_assert(std::is_same_v<decltype(fminimum(T(5.0), std::memory_order_seq_cst)), T>);
   }
 }
 

--- a/libcxx/test/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_fetch_fminimum_helper.h
+++ b/libcxx/test/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_fetch_fminimum_helper.h
@@ -1,0 +1,202 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef TEST_STD_ATOMICS_ATOMIC_FETCH_FMINIMUM_HELPER_H
+#define TEST_STD_ATOMICS_ATOMIC_FETCH_FMINIMUM_HELPER_H
+
+#include <cassert>
+#include <cmath>
+#include <cstdint>
+#include <cstring>
+#include <limits>
+#include <type_traits>
+
+#include "test_macros.h"
+
+// Create a NaN with a specific payload to get different bit representations
+template <class T>
+T make_nan_with_payload(unsigned int payload) {
+  static_assert(std::is_floating_point_v<T>);
+  T nan = std::numeric_limits<T>::quiet_NaN();
+  // Create NaN with different bit pattern by manipulating the payload
+  using UIntType = std::conditional_t<sizeof(T) == 4, uint32_t, uint64_t>;
+  UIntType bits;
+  std::memcpy(&bits, &nan, sizeof(T));
+  // Modify the mantissa bits (payload) while keeping it a NaN
+  bits = (bits & ~UIntType(0xFFFFF)) | (payload & 0xFFFFF);
+  std::memcpy(&nan, &bits, sizeof(T));
+  return nan;
+}
+
+// Test fetch_fminimum for floating-point types
+// LoadOp: () -> T - reads current value
+// StoreOp: (T) -> void - stores a value
+// FMinimumOp: (T, memory_order) -> T - performs fetch_fminimum operation
+template <class T, class LoadOp, class StoreOp, class FMinimumOp>
+void test_fetch_fminimum(LoadOp load, StoreOp store, FMinimumOp fminimum) {
+  static_assert(std::is_floating_point_v<T>);
+
+  constexpr T nan = std::numeric_limits<T>::quiet_NaN();
+  constexpr T inf = std::numeric_limits<T>::infinity();
+
+  // Test basic fetch_fminimum (update to smaller value)
+  {
+    store(T(10.0));
+    T old = fminimum(T(5.0), std::memory_order_seq_cst);
+    assert(old == T(10.0));
+    assert(load() == T(5.0));
+  }
+
+  // Test with larger value (no change)
+  {
+    store(T(10.0));
+    T old = fminimum(T(20.0), std::memory_order_seq_cst);
+    assert(old == T(10.0));
+    assert(load() == T(10.0));
+  }
+
+  // Test with negative values
+  {
+    store(T(-5.0));
+    T old = fminimum(T(-10.0), std::memory_order_seq_cst);
+    assert(old == T(-5.0));
+    assert(load() == T(-10.0));
+  }
+
+  {
+    store(T(-10.0));
+    T old = fminimum(T(-5.0), std::memory_order_seq_cst);
+    assert(old == T(-10.0));
+    assert(load() == T(-10.0));
+  }
+
+  // Test NaN handling: propagate NaN
+  {
+    store(nan);
+    T old = fminimum(T(5.0), std::memory_order_seq_cst);
+    assert(std::isnan(old));
+    assert(std::isnan(load()));
+  }
+
+  {
+    store(T(5.0));
+    T old = fminimum(nan, std::memory_order_seq_cst);
+    assert(old == T(5.0));
+    assert(std::isnan(load()));
+  }
+
+  // Both NaN: return NaN
+  {
+    store(nan);
+    T old = fminimum(nan, std::memory_order_seq_cst);
+    assert(std::isnan(old));
+    assert(std::isnan(load()));
+  }
+
+  // Test signed zero handling: -0.0 < +0.0
+  {
+    store(T(+0.0));
+    T old = fminimum(T(-0.0), std::memory_order_seq_cst);
+    assert(old == T(+0.0));
+    assert(!std::signbit(old));
+    assert(std::signbit(load()));
+  }
+
+  {
+    store(T(-0.0));
+    T old = fminimum(T(+0.0), std::memory_order_seq_cst);
+    assert(old == T(-0.0));
+    assert(std::signbit(old));
+    assert(std::signbit(load()));
+  }
+
+  // Test infinity
+  {
+    store(inf);
+    T old = fminimum(T(1.0), std::memory_order_seq_cst);
+    assert(old == inf);
+    assert(load() == T(1.0));
+  }
+
+  {
+    store(T(1.0));
+    T old = fminimum(-inf, std::memory_order_seq_cst);
+    assert(old == T(1.0));
+    assert(load() == -inf);
+  }
+
+  // Test different memory orderings
+  {
+    store(T(15.0));
+    T old = fminimum(T(8.0), std::memory_order_relaxed);
+    assert(old == T(15.0));
+    assert(load() == T(8.0));
+  }
+
+  {
+    store(T(10.0));
+    T old = fminimum(T(3.0), std::memory_order_acquire);
+    assert(old == T(10.0));
+    assert(load() == T(3.0));
+  }
+
+  {
+    store(T(10.0));
+    T old = fminimum(T(2.0), std::memory_order_release);
+    assert(old == T(10.0));
+    assert(load() == T(2.0));
+  }
+
+  {
+    store(T(10.0));
+    T old = fminimum(T(7.0), std::memory_order_acq_rel);
+    assert(old == T(10.0));
+    assert(load() == T(7.0));
+  }
+
+  // Test with different NaN representations
+  {
+    T nan1 = make_nan_with_payload<T>(1);
+
+    // Store NaN with payload 1, fetch with non-NaN (propagates NaN)
+    store(nan1);
+    T old = fminimum(T(5.0), std::memory_order_seq_cst);
+    assert(std::isnan(old));
+    assert(std::isnan(load()));
+  }
+
+  {
+    T nan2 = make_nan_with_payload<T>(2);
+
+    // Store non-NaN, fetch with NaN with payload 2 (propagates NaN)
+    store(T(5.0));
+    T old = fminimum(nan2, std::memory_order_seq_cst);
+    assert(old == T(5.0));
+    assert(std::isnan(load()));
+  }
+
+  {
+    T nan1 = make_nan_with_payload<T>(1);
+    T nan2 = make_nan_with_payload<T>(2);
+
+    // Store NaN with payload 1, fetch with NaN with payload 2 (propagates NaN)
+    store(nan1);
+    T old = fminimum(nan2, std::memory_order_seq_cst);
+    assert(std::isnan(old));
+    assert(std::isnan(load()));
+    // Result should be one of the NaN values (implementation-defined which)
+  }
+
+  // Test return type
+  {
+    store(T(10.0));
+    static_assert(std::is_same_v<decltype(fminimum(T(5.0), std::memory_order_seq_cst)), T>);
+  }
+}
+
+#endif // TEST_STD_ATOMICS_ATOMIC_FETCH_FMINIMUM_HELPER_H

--- a/libcxx/test/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_fetch_fminimum_num_helper.h
+++ b/libcxx/test/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_fetch_fminimum_num_helper.h
@@ -23,13 +23,28 @@ template <class T>
 T make_nan_with_payload(unsigned int payload) {
   static_assert(std::is_floating_point_v<T>);
   T nan = std::numeric_limits<T>::quiet_NaN();
-  // Create NaN with different bit pattern by manipulating the payload
-  using UIntType = std::conditional_t<sizeof(T) == 4, uint32_t, uint64_t>;
-  UIntType bits;
-  std::memcpy(&bits, &nan, sizeof(T));
+
+  // Use a byte array sized to T to handle all floating-point types
+  alignas(T) unsigned char bits[sizeof(T)];
+  std::memcpy(bits, &nan, sizeof(T));
+
   // Modify the mantissa bits (payload) while keeping it a NaN
-  bits = (bits & ~UIntType(0xFFFFF)) | (payload & 0xFFFFF);
-  std::memcpy(&nan, &bits, sizeof(T));
+  // For float and double, modify the lower bits directly
+  // For long double, modify the first 8 bytes which contain the mantissa
+  if constexpr (sizeof(T) == sizeof(float)) {
+    uint32_t int_bits;
+    std::memcpy(&int_bits, bits, sizeof(uint32_t));
+    int_bits = (int_bits & ~uint32_t(0xFFFFF)) | (payload & 0xFFFFF);
+    std::memcpy(bits, &int_bits, sizeof(uint32_t));
+  } else {
+    // For double and long double, modify the first 64 bits
+    uint64_t int_bits;
+    std::memcpy(&int_bits, bits, sizeof(uint64_t));
+    int_bits = (int_bits & ~uint64_t(0xFFFFF)) | (payload & 0xFFFFF);
+    std::memcpy(bits, &int_bits, sizeof(uint64_t));
+  }
+
+  std::memcpy(&nan, bits, sizeof(T));
   return nan;
 }
 
@@ -47,7 +62,7 @@ void test_fetch_fminimum_num(LoadOp load, StoreOp store, FMinimumNumOp fminimum_
   // Test basic fetch_fminimum_num (update to smaller value)
   {
     store(T(10.0));
-    T old = fminimum_num(T(5.0), std::memory_order_seq_cst);
+    std::same_as<T> decltype(auto) old = fminimum_num(T(5.0), std::memory_order_seq_cst);
     assert(old == T(10.0));
     assert(load() == T(5.0));
   }
@@ -55,7 +70,7 @@ void test_fetch_fminimum_num(LoadOp load, StoreOp store, FMinimumNumOp fminimum_
   // Test with larger value (no change)
   {
     store(T(10.0));
-    T old = fminimum_num(T(20.0), std::memory_order_seq_cst);
+    std::same_as<T> decltype(auto) old = fminimum_num(T(20.0), std::memory_order_seq_cst);
     assert(old == T(10.0));
     assert(load() == T(10.0));
   }
@@ -63,14 +78,14 @@ void test_fetch_fminimum_num(LoadOp load, StoreOp store, FMinimumNumOp fminimum_
   // Test with negative values
   {
     store(T(-5.0));
-    T old = fminimum_num(T(-10.0), std::memory_order_seq_cst);
+    std::same_as<T> decltype(auto) old = fminimum_num(T(-10.0), std::memory_order_seq_cst);
     assert(old == T(-5.0));
     assert(load() == T(-10.0));
   }
 
   {
     store(T(-10.0));
-    T old = fminimum_num(T(-5.0), std::memory_order_seq_cst);
+    std::same_as<T> decltype(auto) old = fminimum_num(T(-5.0), std::memory_order_seq_cst);
     assert(old == T(-10.0));
     assert(load() == T(-10.0));
   }
@@ -78,14 +93,14 @@ void test_fetch_fminimum_num(LoadOp load, StoreOp store, FMinimumNumOp fminimum_
   // Test NaN handling: favor non-NaN values
   {
     store(nan);
-    T old = fminimum_num(T(5.0), std::memory_order_seq_cst);
+    std::same_as<T> decltype(auto) old = fminimum_num(T(5.0), std::memory_order_seq_cst);
     assert(std::isnan(old));
     assert(load() == T(5.0));
   }
 
   {
     store(T(5.0));
-    T old = fminimum_num(nan, std::memory_order_seq_cst);
+    std::same_as<T> decltype(auto) old = fminimum_num(nan, std::memory_order_seq_cst);
     assert(old == T(5.0));
     assert(load() == T(5.0));
   }
@@ -93,7 +108,7 @@ void test_fetch_fminimum_num(LoadOp load, StoreOp store, FMinimumNumOp fminimum_
   // Both NaN: return NaN
   {
     store(nan);
-    T old = fminimum_num(nan, std::memory_order_seq_cst);
+    std::same_as<T> decltype(auto) old = fminimum_num(nan, std::memory_order_seq_cst);
     assert(std::isnan(old));
     assert(std::isnan(load()));
   }
@@ -101,7 +116,7 @@ void test_fetch_fminimum_num(LoadOp load, StoreOp store, FMinimumNumOp fminimum_
   // Test signed zero handling: -0.0 < +0.0
   {
     store(T(+0.0));
-    T old = fminimum_num(T(-0.0), std::memory_order_seq_cst);
+    std::same_as<T> decltype(auto) old = fminimum_num(T(-0.0), std::memory_order_seq_cst);
     assert(old == T(+0.0));
     assert(!std::signbit(old));
     assert(std::signbit(load()));
@@ -109,7 +124,7 @@ void test_fetch_fminimum_num(LoadOp load, StoreOp store, FMinimumNumOp fminimum_
 
   {
     store(T(-0.0));
-    T old = fminimum_num(T(+0.0), std::memory_order_seq_cst);
+    std::same_as<T> decltype(auto) old = fminimum_num(T(+0.0), std::memory_order_seq_cst);
     assert(old == T(-0.0));
     assert(std::signbit(old));
     assert(std::signbit(load()));
@@ -118,14 +133,14 @@ void test_fetch_fminimum_num(LoadOp load, StoreOp store, FMinimumNumOp fminimum_
   // Test infinity
   {
     store(inf);
-    T old = fminimum_num(T(1.0), std::memory_order_seq_cst);
+    std::same_as<T> decltype(auto) old = fminimum_num(T(1.0), std::memory_order_seq_cst);
     assert(old == inf);
     assert(load() == T(1.0));
   }
 
   {
     store(T(1.0));
-    T old = fminimum_num(-inf, std::memory_order_seq_cst);
+    std::same_as<T> decltype(auto) old = fminimum_num(-inf, std::memory_order_seq_cst);
     assert(old == T(1.0));
     assert(load() == -inf);
   }
@@ -133,28 +148,28 @@ void test_fetch_fminimum_num(LoadOp load, StoreOp store, FMinimumNumOp fminimum_
   // Test different memory orderings
   {
     store(T(15.0));
-    T old = fminimum_num(T(8.0), std::memory_order_relaxed);
+    std::same_as<T> decltype(auto) old = fminimum_num(T(8.0), std::memory_order_relaxed);
     assert(old == T(15.0));
     assert(load() == T(8.0));
   }
 
   {
     store(T(10.0));
-    T old = fminimum_num(T(3.0), std::memory_order_acquire);
+    std::same_as<T> decltype(auto) old = fminimum_num(T(3.0), std::memory_order_acquire);
     assert(old == T(10.0));
     assert(load() == T(3.0));
   }
 
   {
     store(T(10.0));
-    T old = fminimum_num(T(2.0), std::memory_order_release);
+    std::same_as<T> decltype(auto) old = fminimum_num(T(2.0), std::memory_order_release);
     assert(old == T(10.0));
     assert(load() == T(2.0));
   }
 
   {
     store(T(10.0));
-    T old = fminimum_num(T(7.0), std::memory_order_acq_rel);
+    std::same_as<T> decltype(auto) old = fminimum_num(T(7.0), std::memory_order_acq_rel);
     assert(old == T(10.0));
     assert(load() == T(7.0));
   }
@@ -165,7 +180,7 @@ void test_fetch_fminimum_num(LoadOp load, StoreOp store, FMinimumNumOp fminimum_
 
     // Store NaN with payload 1, fetch with non-NaN
     store(nan1);
-    T old = fminimum_num(T(5.0), std::memory_order_seq_cst);
+    std::same_as<T> decltype(auto) old = fminimum_num(T(5.0), std::memory_order_seq_cst);
     assert(std::isnan(old));
     assert(load() == T(5.0));
   }
@@ -175,7 +190,7 @@ void test_fetch_fminimum_num(LoadOp load, StoreOp store, FMinimumNumOp fminimum_
 
     // Store non-NaN, fetch with NaN with payload 2
     store(T(5.0));
-    T old = fminimum_num(nan2, std::memory_order_seq_cst);
+    std::same_as<T> decltype(auto) old = fminimum_num(nan2, std::memory_order_seq_cst);
     assert(old == T(5.0));
     assert(load() == T(5.0));
   }
@@ -186,16 +201,10 @@ void test_fetch_fminimum_num(LoadOp load, StoreOp store, FMinimumNumOp fminimum_
 
     // Store NaN with payload 1, fetch with NaN with payload 2
     store(nan1);
-    T old = fminimum_num(nan2, std::memory_order_seq_cst);
+    std::same_as<T> decltype(auto) old = fminimum_num(nan2, std::memory_order_seq_cst);
     assert(std::isnan(old));
     assert(std::isnan(load()));
     // Result should be one of the NaN values (implementation-defined which)
-  }
-
-  // Test return type
-  {
-    store(T(10.0));
-    static_assert(std::is_same_v<decltype(fminimum_num(T(5.0), std::memory_order_seq_cst)), T>);
   }
 }
 

--- a/libcxx/test/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_fetch_fminimum_num_helper.h
+++ b/libcxx/test/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_fetch_fminimum_num_helper.h
@@ -1,0 +1,202 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef TEST_STD_ATOMICS_ATOMIC_FETCH_FMINIMUM_NUM_HELPER_H
+#define TEST_STD_ATOMICS_ATOMIC_FETCH_FMINIMUM_NUM_HELPER_H
+
+#include <cassert>
+#include <cmath>
+#include <cstdint>
+#include <cstring>
+#include <limits>
+#include <type_traits>
+
+#include "test_macros.h"
+
+// Create a NaN with a specific payload to get different bit representations
+template <class T>
+T make_nan_with_payload(unsigned int payload) {
+  static_assert(std::is_floating_point_v<T>);
+  T nan = std::numeric_limits<T>::quiet_NaN();
+  // Create NaN with different bit pattern by manipulating the payload
+  using UIntType = std::conditional_t<sizeof(T) == 4, uint32_t, uint64_t>;
+  UIntType bits;
+  std::memcpy(&bits, &nan, sizeof(T));
+  // Modify the mantissa bits (payload) while keeping it a NaN
+  bits = (bits & ~UIntType(0xFFFFF)) | (payload & 0xFFFFF);
+  std::memcpy(&nan, &bits, sizeof(T));
+  return nan;
+}
+
+// Test fetch_fminimum_num for floating-point types
+// LoadOp: () -> T - reads current value
+// StoreOp: (T) -> void - stores a value
+// FMinimumNumOp: (T, memory_order) -> T - performs fetch_fminimum_num operation
+template <class T, class LoadOp, class StoreOp, class FMinimumNumOp>
+void test_fetch_fminimum_num(LoadOp load, StoreOp store, FMinimumNumOp fminimum_num) {
+  static_assert(std::is_floating_point_v<T>);
+
+  constexpr T nan = std::numeric_limits<T>::quiet_NaN();
+  constexpr T inf = std::numeric_limits<T>::infinity();
+
+  // Test basic fetch_fminimum_num (update to smaller value)
+  {
+    store(T(10.0));
+    T old = fminimum_num(T(5.0), std::memory_order_seq_cst);
+    assert(old == T(10.0));
+    assert(load() == T(5.0));
+  }
+
+  // Test with larger value (no change)
+  {
+    store(T(10.0));
+    T old = fminimum_num(T(20.0), std::memory_order_seq_cst);
+    assert(old == T(10.0));
+    assert(load() == T(10.0));
+  }
+
+  // Test with negative values
+  {
+    store(T(-5.0));
+    T old = fminimum_num(T(-10.0), std::memory_order_seq_cst);
+    assert(old == T(-5.0));
+    assert(load() == T(-10.0));
+  }
+
+  {
+    store(T(-10.0));
+    T old = fminimum_num(T(-5.0), std::memory_order_seq_cst);
+    assert(old == T(-10.0));
+    assert(load() == T(-10.0));
+  }
+
+  // Test NaN handling: favor non-NaN values
+  {
+    store(nan);
+    T old = fminimum_num(T(5.0), std::memory_order_seq_cst);
+    assert(std::isnan(old));
+    assert(load() == T(5.0));
+  }
+
+  {
+    store(T(5.0));
+    T old = fminimum_num(nan, std::memory_order_seq_cst);
+    assert(old == T(5.0));
+    assert(load() == T(5.0));
+  }
+
+  // Both NaN: return NaN
+  {
+    store(nan);
+    T old = fminimum_num(nan, std::memory_order_seq_cst);
+    assert(std::isnan(old));
+    assert(std::isnan(load()));
+  }
+
+  // Test signed zero handling: -0.0 < +0.0
+  {
+    store(T(+0.0));
+    T old = fminimum_num(T(-0.0), std::memory_order_seq_cst);
+    assert(old == T(+0.0));
+    assert(!std::signbit(old));
+    assert(std::signbit(load()));
+  }
+
+  {
+    store(T(-0.0));
+    T old = fminimum_num(T(+0.0), std::memory_order_seq_cst);
+    assert(old == T(-0.0));
+    assert(std::signbit(old));
+    assert(std::signbit(load()));
+  }
+
+  // Test infinity
+  {
+    store(inf);
+    T old = fminimum_num(T(1.0), std::memory_order_seq_cst);
+    assert(old == inf);
+    assert(load() == T(1.0));
+  }
+
+  {
+    store(T(1.0));
+    T old = fminimum_num(-inf, std::memory_order_seq_cst);
+    assert(old == T(1.0));
+    assert(load() == -inf);
+  }
+
+  // Test different memory orderings
+  {
+    store(T(15.0));
+    T old = fminimum_num(T(8.0), std::memory_order_relaxed);
+    assert(old == T(15.0));
+    assert(load() == T(8.0));
+  }
+
+  {
+    store(T(10.0));
+    T old = fminimum_num(T(3.0), std::memory_order_acquire);
+    assert(old == T(10.0));
+    assert(load() == T(3.0));
+  }
+
+  {
+    store(T(10.0));
+    T old = fminimum_num(T(2.0), std::memory_order_release);
+    assert(old == T(10.0));
+    assert(load() == T(2.0));
+  }
+
+  {
+    store(T(10.0));
+    T old = fminimum_num(T(7.0), std::memory_order_acq_rel);
+    assert(old == T(10.0));
+    assert(load() == T(7.0));
+  }
+
+  // Test with different NaN representations
+  {
+    T nan1 = make_nan_with_payload<T>(1);
+
+    // Store NaN with payload 1, fetch with non-NaN
+    store(nan1);
+    T old = fminimum_num(T(5.0), std::memory_order_seq_cst);
+    assert(std::isnan(old));
+    assert(load() == T(5.0));
+  }
+
+  {
+    T nan2 = make_nan_with_payload<T>(2);
+
+    // Store non-NaN, fetch with NaN with payload 2
+    store(T(5.0));
+    T old = fminimum_num(nan2, std::memory_order_seq_cst);
+    assert(old == T(5.0));
+    assert(load() == T(5.0));
+  }
+
+  {
+    T nan1 = make_nan_with_payload<T>(1);
+    T nan2 = make_nan_with_payload<T>(2);
+
+    // Store NaN with payload 1, fetch with NaN with payload 2
+    store(nan1);
+    T old = fminimum_num(nan2, std::memory_order_seq_cst);
+    assert(std::isnan(old));
+    assert(std::isnan(load()));
+    // Result should be one of the NaN values (implementation-defined which)
+  }
+
+  // Test return type
+  {
+    store(T(10.0));
+    static_assert(std::is_same_v<decltype(fminimum_num(T(5.0), std::memory_order_seq_cst)), T>);
+  }
+}
+
+#endif // TEST_STD_ATOMICS_ATOMIC_FETCH_FMINIMUM_NUM_HELPER_H

--- a/libcxx/test/std/numerics/c.math/fmaximum.pass.cpp
+++ b/libcxx/test/std/numerics/c.math/fmaximum.pass.cpp
@@ -1,0 +1,89 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03, c++11, c++14, c++17, c++20, c++23
+
+// <cmath>
+
+// constexpr float       fmaximum(float x, float y);
+// constexpr double      fmaximum(double x, double y);
+// constexpr long double fmaximum(long double x, long double y);
+
+#include <cmath>
+#include <cassert>
+#include <limits>
+#include <type_traits>
+
+#include "test_macros.h"
+
+template <typename T>
+constexpr bool test() {
+  if (!TEST_IS_CONSTANT_EVALUATED) {
+    ASSERT_SAME_TYPE(T, decltype(std::fmaximum(T(), T())));
+    ASSERT_NOEXCEPT(std::fmaximum(T(), T()));
+  }
+
+  constexpr T nan = std::numeric_limits<T>::quiet_NaN();
+  constexpr T inf = std::numeric_limits<T>::infinity();
+
+  // Basic maximum
+  assert(std::fmaximum(T(1.0), T(2.0)) == T(2.0));
+  assert(std::fmaximum(T(2.0), T(1.0)) == T(2.0));
+  assert(std::fmaximum(T(-1.0), T(-2.0)) == T(-1.0));
+  assert(std::fmaximum(T(-2.0), T(-1.0)) == T(-1.0));
+
+  // Test case from atomic failure: 5.0 vs 10.0
+  assert(std::fmaximum(T(5.0), T(10.0)) == T(10.0));
+  assert(std::fmaximum(T(10.0), T(5.0)) == T(10.0));
+
+  // NaN handling: propagate NaN
+  assert(__builtin_isnan(std::fmaximum(nan, T(1.0))));
+  assert(__builtin_isnan(std::fmaximum(T(1.0), nan)));
+  assert(__builtin_isnan(std::fmaximum(nan, T(-1.0))));
+  assert(__builtin_isnan(std::fmaximum(T(-1.0), nan)));
+
+  // Both NaN: return NaN
+  assert(__builtin_isnan(std::fmaximum(nan, nan)));
+
+  // Signed zero handling: -0.0 < +0.0, so max returns +0.0
+  assert(std::fmaximum(T(-0.0), T(+0.0)) == T(+0.0));
+  assert(std::fmaximum(T(+0.0), T(-0.0)) == T(+0.0));
+  assert(!__builtin_signbit(std::fmaximum(T(-0.0), T(+0.0))));
+  assert(!__builtin_signbit(std::fmaximum(T(+0.0), T(-0.0))));
+
+  // Infinity
+  assert(std::fmaximum(inf, T(1.0)) == inf);
+  assert(std::fmaximum(T(1.0), inf) == inf);
+  assert(std::fmaximum(-inf, T(1.0)) == T(1.0));
+  assert(std::fmaximum(T(1.0), -inf) == T(1.0));
+  assert(std::fmaximum(-inf, inf) == inf);
+  assert(std::fmaximum(inf, -inf) == inf);
+
+  // NaN with infinity: propagate NaN
+  assert(__builtin_isnan(std::fmaximum(nan, inf)));
+  assert(__builtin_isnan(std::fmaximum(inf, nan)));
+  assert(__builtin_isnan(std::fmaximum(nan, -inf)));
+  assert(__builtin_isnan(std::fmaximum(-inf, nan)));
+
+  return true;
+}
+
+int main(int, char**) {
+  // TODO: Enable static_assert on macOS once __builtin_signbit is constexpr-compatible
+#ifndef __APPLE__
+  static_assert(test<float>());
+  static_assert(test<double>());
+  static_assert(test<long double>());
+#endif
+
+  test<float>();
+  test<double>();
+  test<long double>();
+
+  return 0;
+}

--- a/libcxx/test/std/numerics/c.math/fmaximum_num.pass.cpp
+++ b/libcxx/test/std/numerics/c.math/fmaximum_num.pass.cpp
@@ -1,0 +1,89 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03, c++11, c++14, c++17, c++20, c++23
+
+// <cmath>
+
+// constexpr float       fmaximum_num(float x, float y);
+// constexpr double      fmaximum_num(double x, double y);
+// constexpr long double fmaximum_num(long double x, long double y);
+
+#include <cmath>
+#include <cassert>
+#include <limits>
+#include <type_traits>
+
+#include "test_macros.h"
+
+template <typename T>
+constexpr bool test() {
+  if (!TEST_IS_CONSTANT_EVALUATED) {
+    ASSERT_SAME_TYPE(T, decltype(std::fmaximum_num(T(), T())));
+    ASSERT_NOEXCEPT(std::fmaximum_num(T(), T()));
+  }
+
+  constexpr T nan = std::numeric_limits<T>::quiet_NaN();
+  constexpr T inf = std::numeric_limits<T>::infinity();
+
+  // Basic maximum
+  assert(std::fmaximum_num(T(1.0), T(2.0)) == T(2.0));
+  assert(std::fmaximum_num(T(2.0), T(1.0)) == T(2.0));
+  assert(std::fmaximum_num(T(-1.0), T(-2.0)) == T(-1.0));
+  assert(std::fmaximum_num(T(-2.0), T(-1.0)) == T(-1.0));
+
+  // Test case from atomic failure: 5.0 vs 10.0
+  assert(std::fmaximum_num(T(5.0), T(10.0)) == T(10.0));
+  assert(std::fmaximum_num(T(10.0), T(5.0)) == T(10.0));
+
+  // NaN handling: favor non-NaN values
+  assert(std::fmaximum_num(nan, T(1.0)) == T(1.0));
+  assert(std::fmaximum_num(T(1.0), nan) == T(1.0));
+  assert(std::fmaximum_num(nan, T(-1.0)) == T(-1.0));
+  assert(std::fmaximum_num(T(-1.0), nan) == T(-1.0));
+
+  // Both NaN: return NaN
+  assert(__builtin_isnan(std::fmaximum_num(nan, nan)));
+
+  // Signed zero handling: -0.0 < +0.0, so max returns +0.0
+  assert(std::fmaximum_num(T(-0.0), T(+0.0)) == T(+0.0));
+  assert(std::fmaximum_num(T(+0.0), T(-0.0)) == T(+0.0));
+  assert(!__builtin_signbit(std::fmaximum_num(T(-0.0), T(+0.0))));
+  assert(!__builtin_signbit(std::fmaximum_num(T(+0.0), T(-0.0))));
+
+  // Infinity
+  assert(std::fmaximum_num(inf, T(1.0)) == inf);
+  assert(std::fmaximum_num(T(1.0), inf) == inf);
+  assert(std::fmaximum_num(-inf, T(1.0)) == T(1.0));
+  assert(std::fmaximum_num(T(1.0), -inf) == T(1.0));
+  assert(std::fmaximum_num(-inf, inf) == inf);
+  assert(std::fmaximum_num(inf, -inf) == inf);
+
+  // NaN with infinity: favor infinity
+  assert(std::fmaximum_num(nan, inf) == inf);
+  assert(std::fmaximum_num(inf, nan) == inf);
+  assert(std::fmaximum_num(nan, -inf) == -inf);
+  assert(std::fmaximum_num(-inf, nan) == -inf);
+
+  return true;
+}
+
+int main(int, char**) {
+  // TODO: Enable static_assert on macOS once __builtin_signbit is constexpr-compatible
+#ifndef __APPLE__
+  static_assert(test<float>());
+  static_assert(test<double>());
+  static_assert(test<long double>());
+#endif
+
+  test<float>();
+  test<double>();
+  test<long double>();
+
+  return 0;
+}

--- a/libcxx/test/std/numerics/c.math/fminimum.pass.cpp
+++ b/libcxx/test/std/numerics/c.math/fminimum.pass.cpp
@@ -1,0 +1,89 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03, c++11, c++14, c++17, c++20, c++23
+
+// <cmath>
+
+// constexpr float       fminimum(float x, float y);
+// constexpr double      fminimum(double x, double y);
+// constexpr long double fminimum(long double x, long double y);
+
+#include <cmath>
+#include <cassert>
+#include <limits>
+#include <type_traits>
+
+#include "test_macros.h"
+
+template <typename T>
+constexpr bool test() {
+  if (!TEST_IS_CONSTANT_EVALUATED) {
+    ASSERT_SAME_TYPE(T, decltype(std::fminimum(T(), T())));
+    ASSERT_NOEXCEPT(std::fminimum(T(), T()));
+  }
+
+  constexpr T nan = std::numeric_limits<T>::quiet_NaN();
+  constexpr T inf = std::numeric_limits<T>::infinity();
+
+  // Basic minimum
+  assert(std::fminimum(T(1.0), T(2.0)) == T(1.0));
+  assert(std::fminimum(T(2.0), T(1.0)) == T(1.0));
+  assert(std::fminimum(T(-1.0), T(-2.0)) == T(-2.0));
+  assert(std::fminimum(T(-2.0), T(-1.0)) == T(-2.0));
+
+  // Test case from atomic failure: 10.0 vs 5.0
+  assert(std::fminimum(T(10.0), T(5.0)) == T(5.0));
+  assert(std::fminimum(T(5.0), T(10.0)) == T(5.0));
+
+  // NaN handling: propagate NaN
+  assert(__builtin_isnan(std::fminimum(nan, T(1.0))));
+  assert(__builtin_isnan(std::fminimum(T(1.0), nan)));
+  assert(__builtin_isnan(std::fminimum(nan, T(-1.0))));
+  assert(__builtin_isnan(std::fminimum(T(-1.0), nan)));
+
+  // Both NaN: return NaN
+  assert(__builtin_isnan(std::fminimum(nan, nan)));
+
+  // Signed zero handling: -0.0 < +0.0
+  assert(std::fminimum(T(-0.0), T(+0.0)) == T(-0.0));
+  assert(std::fminimum(T(+0.0), T(-0.0)) == T(-0.0));
+  assert(__builtin_signbit(std::fminimum(T(-0.0), T(+0.0))));
+  assert(__builtin_signbit(std::fminimum(T(+0.0), T(-0.0))));
+
+  // Infinity
+  assert(std::fminimum(inf, T(1.0)) == T(1.0));
+  assert(std::fminimum(T(1.0), inf) == T(1.0));
+  assert(std::fminimum(-inf, T(1.0)) == -inf);
+  assert(std::fminimum(T(1.0), -inf) == -inf);
+  assert(std::fminimum(-inf, inf) == -inf);
+  assert(std::fminimum(inf, -inf) == -inf);
+
+  // NaN with infinity: propagate NaN
+  assert(__builtin_isnan(std::fminimum(nan, inf)));
+  assert(__builtin_isnan(std::fminimum(inf, nan)));
+  assert(__builtin_isnan(std::fminimum(nan, -inf)));
+  assert(__builtin_isnan(std::fminimum(-inf, nan)));
+
+  return true;
+}
+
+int main(int, char**) {
+  // TODO: Enable static_assert on macOS once __builtin_signbit is constexpr-compatible
+#ifndef __APPLE__
+  static_assert(test<float>());
+  static_assert(test<double>());
+  static_assert(test<long double>());
+#endif
+
+  test<float>();
+  test<double>();
+  test<long double>();
+
+  return 0;
+}

--- a/libcxx/test/std/numerics/c.math/fminimum_num.pass.cpp
+++ b/libcxx/test/std/numerics/c.math/fminimum_num.pass.cpp
@@ -1,0 +1,89 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03, c++11, c++14, c++17, c++20, c++23
+
+// <cmath>
+
+// constexpr float       fminimum_num(float x, float y);
+// constexpr double      fminimum_num(double x, double y);
+// constexpr long double fminimum_num(long double x, long double y);
+
+#include <cmath>
+#include <cassert>
+#include <limits>
+#include <type_traits>
+
+#include "test_macros.h"
+
+template <typename T>
+constexpr bool test() {
+  if (!TEST_IS_CONSTANT_EVALUATED) {
+    ASSERT_SAME_TYPE(T, decltype(std::fminimum_num(T(), T())));
+    ASSERT_NOEXCEPT(std::fminimum_num(T(), T()));
+  }
+
+  constexpr T nan = std::numeric_limits<T>::quiet_NaN();
+  constexpr T inf = std::numeric_limits<T>::infinity();
+
+  // Basic minimum
+  assert(std::fminimum_num(T(1.0), T(2.0)) == T(1.0));
+  assert(std::fminimum_num(T(2.0), T(1.0)) == T(1.0));
+  assert(std::fminimum_num(T(-1.0), T(-2.0)) == T(-2.0));
+  assert(std::fminimum_num(T(-2.0), T(-1.0)) == T(-2.0));
+
+  // Test case from atomic failure: 10.0 vs 5.0
+  assert(std::fminimum_num(T(10.0), T(5.0)) == T(5.0));
+  assert(std::fminimum_num(T(5.0), T(10.0)) == T(5.0));
+
+  // NaN handling: favor non-NaN values
+  assert(std::fminimum_num(nan, T(1.0)) == T(1.0));
+  assert(std::fminimum_num(T(1.0), nan) == T(1.0));
+  assert(std::fminimum_num(nan, T(-1.0)) == T(-1.0));
+  assert(std::fminimum_num(T(-1.0), nan) == T(-1.0));
+
+  // Both NaN: return NaN
+  assert(__builtin_isnan(std::fminimum_num(nan, nan)));
+
+  // Signed zero handling: -0.0 < +0.0
+  assert(std::fminimum_num(T(-0.0), T(+0.0)) == T(-0.0));
+  assert(std::fminimum_num(T(+0.0), T(-0.0)) == T(-0.0));
+  assert(__builtin_signbit(std::fminimum_num(T(-0.0), T(+0.0))));
+  assert(__builtin_signbit(std::fminimum_num(T(+0.0), T(-0.0))));
+
+  // Infinity
+  assert(std::fminimum_num(inf, T(1.0)) == T(1.0));
+  assert(std::fminimum_num(T(1.0), inf) == T(1.0));
+  assert(std::fminimum_num(-inf, T(1.0)) == -inf);
+  assert(std::fminimum_num(T(1.0), -inf) == -inf);
+  assert(std::fminimum_num(-inf, inf) == -inf);
+  assert(std::fminimum_num(inf, -inf) == -inf);
+
+  // NaN with infinity: favor infinity
+  assert(std::fminimum_num(nan, inf) == inf);
+  assert(std::fminimum_num(inf, nan) == inf);
+  assert(std::fminimum_num(nan, -inf) == -inf);
+  assert(std::fminimum_num(-inf, nan) == -inf);
+
+  return true;
+}
+
+int main(int, char**) {
+  // TODO: Enable static_assert on macOS once __builtin_signbit is constexpr-compatible
+#ifndef __APPLE__
+  static_assert(test<float>());
+  static_assert(test<double>());
+  static_assert(test<long double>());
+#endif
+
+  test<float>();
+  test<double>();
+  test<long double>();
+
+  return 0;
+}


### PR DESCRIPTION
Closes #148168 .
Blocked by #186694 since this will need to bump the version macro further.
Future work (need to open GitHub issues to track these): 
- Update implementation to use builtins (will be done as a separate PR that only impacts the internal implementation).
-  MacOS SDK 15 constexpr support: the constexpr tests fail there because this compiler lacks constexpr support for `__builtin_signbit`. A possible workaround would be to test whether `__builtin_copysign` is constexpr on that toolchain, and fall back to implementing a constexpr signbit on top of that one there. If not, we could just don't use the builtin on this system. Either way, this belongs in a different PR focused on this issue.