### PR TITLE
[orc-rt] Add a simple iterator_range class.

### DIFF
--- a/orc-rt/include/orc-rt/iterator_range.h
+++ b/orc-rt/include/orc-rt/iterator_range.h
@@ -1,0 +1,47 @@
+//===---- iterator_range.h -- Simple iterator range template ----*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Simple iterator range template.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef ORC_RT_ITERATOR_RANGE_H
+#define ORC_RT_ITERATOR_RANGE_H
+
+#include <iterator>
+
+namespace orc_rt {
+
+/// A simple wrapper around a pair of iterators, enabling range-based for
+/// loops over iterator pairs or subranges of containers.
+template <typename IteratorT> class iterator_range {
+public:
+  /// Construct an iterator_range from a container or range. The underlying
+  /// container must outlive this iterator_range.
+  template <typename Container>
+  iterator_range(Container &&C) : Begin(std::begin(C)), End(std::end(C)) {}
+
+  /// Construct an iterator_range from an explicit begin/end pair.
+  iterator_range(IteratorT Begin, IteratorT End)
+      : Begin(std::move(Begin)), End(std::move(End)) {}
+
+  IteratorT begin() const { return Begin; }
+  IteratorT end() const { return End; }
+  bool empty() const { return Begin == End; }
+
+private:
+  IteratorT Begin, End;
+};
+
+template <typename Container>
+iterator_range(Container &&)
+    -> iterator_range<decltype(std::begin(std::declval<Container &&>()))>;
+
+} // namespace orc_rt
+
+#endif // ORC_RT_ITERATOR_RANGE_H

--- a/orc-rt/unittests/CMakeLists.txt
+++ b/orc-rt/unittests/CMakeLists.txt
@@ -38,6 +38,7 @@ add_orc_rt_unittest(CoreTests
   WrapperFunctionBufferTest.cpp
   bind-test.cpp
   bit-test.cpp
+  iterator_range-test.cpp
   move_only_function-test.cpp
   span-test.cpp
   DISABLE_LLVM_LINK_LLVM_DYLIB

--- a/orc-rt/unittests/iterator_range-test.cpp
+++ b/orc-rt/unittests/iterator_range-test.cpp
@@ -1,0 +1,79 @@
+//===- iterator_range-test.cpp --------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Tests for orc-rt's iterator_range.h APIs.
+//
+//===----------------------------------------------------------------------===//
+
+#include "orc-rt/iterator_range.h"
+#include "gtest/gtest.h"
+
+#include <type_traits>
+#include <vector>
+
+using namespace orc_rt;
+
+TEST(IteratorRangeTest, EmptyArray) {
+  int A[1]; // zero-length arrays aren't allowed.
+  iterator_range<int *> R(std::begin(A), std::begin(A));
+
+  EXPECT_TRUE(R.empty());
+  EXPECT_EQ(R.begin(), R.end());
+}
+
+TEST(IteratorRangeTest, NonEmptyArray) {
+  int A[] = {10, 11, 12, 13, 14, 15};
+
+  size_t Index = 0;
+  for (auto &E : iterator_range(A))
+    EXPECT_EQ(E, A[Index++]);
+}
+
+TEST(IteratorRangeTest, EmptyVector) {
+  std::vector<int> V;
+  auto R = iterator_range(V);
+  EXPECT_TRUE(R.empty());
+  EXPECT_EQ(R.begin(), R.end());
+}
+
+TEST(IteratorRangeTest, NonEmptyVector) {
+  std::vector<int> V({{10, 12, 14, 16, 18, 20}});
+
+  size_t Index = 0;
+  for (auto &E : iterator_range(V))
+    EXPECT_EQ(E, V[Index++]);
+}
+
+TEST(IteratorRangeTest, Subrange) {
+  std::vector<int> V = {1, 2, 3, 4, 5};
+  iterator_range R(V.begin() + 1, V.begin() + 4);
+
+  EXPECT_FALSE(R.empty());
+  std::vector<int> Result(R.begin(), R.end());
+  EXPECT_EQ(Result, (std::vector<int>{2, 3, 4}));
+}
+
+TEST(IteratorRangeTest, MutateThroughRange) {
+  std::vector<int> V = {1, 2, 3};
+  for (auto &E : iterator_range(V))
+    E *= 2;
+  EXPECT_EQ(V, (std::vector<int>{2, 4, 6}));
+}
+
+TEST(IteratorRangeTest, NonEmptyIsNotEmpty) {
+  std::vector<int> V = {1};
+  auto R = iterator_range(V);
+  EXPECT_FALSE(R.empty());
+}
+
+TEST(IteratorRangeTest, ConstContainer) {
+  const std::vector<int> V = {1, 2, 3};
+  for (auto &E : iterator_range(V))
+    static_assert(std::is_const_v<std::remove_reference_t<decltype(E)>>,
+                  "elements from const container should be const");
+}


### PR DESCRIPTION
This will be used to simplify operations on iterator ranges in the ORC runtime.