### PR TITLE
[AMDGPU] Add basic verification for source modifiers

### DIFF
--- a/llvm/lib/Target/AMDGPU/SIInstrInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/SIInstrInfo.cpp
@@ -5260,12 +5260,12 @@ bool SIInstrInfo::verifyInstruction(const MachineInstr &MI,
       break;
     }
     case AMDGPU::OPERAND_INLINE_SPLIT_BARRIER_INT32:
+    case AMDGPU::OPERAND_INPUT_MODS:
       if (!MI.getOperand(i).isImm() || !isInlineConstant(MI, i)) {
         ErrInfo = "Expected inline constant for operand.";
         return false;
       }
       break;
-    case AMDGPU::OPERAND_INPUT_MODS:
     case AMDGPU::OPERAND_SDWA_VOPC_DST:
     case AMDGPU::OPERAND_KIMM16:
       break;
@@ -5548,28 +5548,6 @@ bool SIInstrInfo::verifyInstruction(const MachineInstr &MI,
     if (isVOP3(MI) && UsesLiteral && !ST.hasVOP3Literal()) {
       ErrInfo = "VOP3 instruction uses literal";
       return false;
-    }
-
-    // Verify VOP3/VOP3P source modifiers.
-    if (isVOP3(MI) || isVOP3P(MI)) {
-      int Src0ModIdx =
-          AMDGPU::getNamedOperandIdx(Opcode, AMDGPU::OpName::src0_modifiers);
-      int Src1ModIdx =
-          AMDGPU::getNamedOperandIdx(Opcode, AMDGPU::OpName::src1_modifiers);
-      int Src2ModIdx =
-          AMDGPU::getNamedOperandIdx(Opcode, AMDGPU::OpName::src2_modifiers);
-
-      for (int ModIdx : {Src0ModIdx, Src1ModIdx, Src2ModIdx}) {
-        if (ModIdx == -1)
-          continue;
-
-        const MachineOperand &MO = MI.getOperand(ModIdx);
-        if (!MO.isImm()) {
-          ErrInfo =
-              "Source modifier of VOP3/VOP3P instruction should be immediate";
-          return false;
-        }
-      }
     }
   }
 

--- a/llvm/lib/Target/AMDGPU/SIInstrInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/SIInstrInfo.cpp
@@ -5549,6 +5549,27 @@ bool SIInstrInfo::verifyInstruction(const MachineInstr &MI,
       ErrInfo = "VOP3 instruction uses literal";
       return false;
     }
+
+    // Verify VOP3/VOP3P source modifiers.
+    if (isVOP3(MI) || isVOP3P(MI)) {
+      int Src0ModIdx =
+          AMDGPU::getNamedOperandIdx(Opcode, AMDGPU::OpName::src0_modifiers);
+      int Src1ModIdx =
+          AMDGPU::getNamedOperandIdx(Opcode, AMDGPU::OpName::src1_modifiers);
+      int Src2ModIdx =
+          AMDGPU::getNamedOperandIdx(Opcode, AMDGPU::OpName::src2_modifiers);
+
+      for (int ModIdx : {Src0ModIdx, Src1ModIdx, Src2ModIdx}) {
+        if (ModIdx == -1)
+          continue;
+
+        const MachineOperand &MO = MI.getOperand(ModIdx);
+        if (!MO.isImm()) {
+          ErrInfo = "Source modifier of VOP3/VOP3P instruction should be immediate";
+          return false;
+        }
+      }
+    }
   }
 
   // Special case for writelane - this can break the multiple constant bus rule,

--- a/llvm/lib/Target/AMDGPU/SIInstrInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/SIInstrInfo.cpp
@@ -5565,7 +5565,8 @@ bool SIInstrInfo::verifyInstruction(const MachineInstr &MI,
 
         const MachineOperand &MO = MI.getOperand(ModIdx);
         if (!MO.isImm()) {
-          ErrInfo = "Source modifier of VOP3/VOP3P instruction should be immediate";
+          ErrInfo =
+              "Source modifier of VOP3/VOP3P instruction should be immediate";
           return false;
         }
       }

--- a/llvm/test/CodeGen/AMDGPU/convergent.mir
+++ b/llvm/test/CodeGen/AMDGPU/convergent.mir
@@ -511,7 +511,7 @@ body:             |
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:vgpr_32 = IMPLICIT_DEF
   ; CHECK-NEXT:   [[DEF1:%[0-9]+]]:sreg_32 = IMPLICIT_DEF
-  ; CHECK-NEXT:   [[V_DOT2C_F32_BF16_dpp_vi:%[0-9]+]]:vgpr_32 = V_DOT2C_F32_BF16_dpp_vi 8, [[DEF]], [[DEF]], [[DEF]], [[DEF]], 0, 0, 0, 0, implicit $exec, implicit $mode
+  ; CHECK-NEXT:   [[V_DOT2C_F32_BF16_dpp_vi:%[0-9]+]]:vgpr_32 = V_DOT2C_F32_BF16_dpp_vi 8, [[DEF]], 0, [[DEF]], [[DEF]], 0, 0, 0, 0, implicit $exec, implicit $mode
   ; CHECK-NEXT:   [[SI_IF:%[0-9]+]]:sreg_32 = SI_IF [[DEF1]], %bb.2, implicit-def dead $exec, implicit-def dead $scc, implicit $exec
   ; CHECK-NEXT:   S_BRANCH %bb.1
   ; CHECK-NEXT: {{  $}}
@@ -526,7 +526,7 @@ body:             |
   bb.0:
     %0:vgpr_32 = IMPLICIT_DEF
     %1:sreg_32 = IMPLICIT_DEF
-    %2:vgpr_32 = V_DOT2C_F32_BF16_dpp_vi 8, %0:vgpr_32, %0:vgpr_32, %0:vgpr_32, %0:vgpr_32, 0, 0, 0, 0, implicit $exec, implicit $mode
+    %2:vgpr_32 = V_DOT2C_F32_BF16_dpp_vi 8, %0:vgpr_32, 0, %0:vgpr_32, %0:vgpr_32, 0, 0, 0, 0, implicit $exec, implicit $mode
     %3:sreg_32 = SI_IF %1:sreg_32, %bb.2, implicit-def dead $exec, implicit-def dead $scc, implicit $exec
     S_BRANCH %bb.1
 
@@ -547,7 +547,7 @@ body:             |
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:vgpr_32 = IMPLICIT_DEF
   ; CHECK-NEXT:   [[DEF1:%[0-9]+]]:sreg_32 = IMPLICIT_DEF
-  ; CHECK-NEXT:   [[V_DOT2C_F32_F16_dpp_vi:%[0-9]+]]:vgpr_32 = V_DOT2C_F32_F16_dpp_vi 8, [[DEF]], [[DEF]], [[DEF]], [[DEF]], 0, 0, 0, 0, implicit $exec, implicit $mode
+  ; CHECK-NEXT:   [[V_DOT2C_F32_F16_dpp_vi:%[0-9]+]]:vgpr_32 = V_DOT2C_F32_F16_dpp_vi 8, [[DEF]], 0, [[DEF]], [[DEF]], 0, 0, 0, 0, implicit $exec, implicit $mode
   ; CHECK-NEXT:   [[SI_IF:%[0-9]+]]:sreg_32 = SI_IF [[DEF1]], %bb.2, implicit-def dead $exec, implicit-def dead $scc, implicit $exec
   ; CHECK-NEXT:   S_BRANCH %bb.1
   ; CHECK-NEXT: {{  $}}
@@ -562,7 +562,7 @@ body:             |
   bb.0:
     %0:vgpr_32 = IMPLICIT_DEF
     %1:sreg_32 = IMPLICIT_DEF
-    %2:vgpr_32 = V_DOT2C_F32_F16_dpp_vi 8, %0:vgpr_32, %0:vgpr_32, %0:vgpr_32, %0:vgpr_32, 0, 0, 0, 0, implicit $exec, implicit $mode
+    %2:vgpr_32 = V_DOT2C_F32_F16_dpp_vi 8, %0:vgpr_32, 0, %0:vgpr_32, %0:vgpr_32, 0, 0, 0, 0, implicit $exec, implicit $mode
     %3:sreg_32 = SI_IF %1:sreg_32, %bb.2, implicit-def dead $exec, implicit-def dead $scc, implicit $exec
     S_BRANCH %bb.1
 
@@ -583,7 +583,7 @@ body:             |
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:vgpr_32 = IMPLICIT_DEF
   ; CHECK-NEXT:   [[DEF1:%[0-9]+]]:sreg_32 = IMPLICIT_DEF
-  ; CHECK-NEXT:   [[V_DOT2C_I32_I16_dpp_vi:%[0-9]+]]:vgpr_32 = V_DOT2C_I32_I16_dpp_vi 8, [[DEF]], [[DEF]], [[DEF]], [[DEF]], 0, 0, 0, 0, implicit $exec, implicit $mode
+  ; CHECK-NEXT:   [[V_DOT2C_I32_I16_dpp_vi:%[0-9]+]]:vgpr_32 = V_DOT2C_I32_I16_dpp_vi 8, [[DEF]], 0, [[DEF]], [[DEF]], 0, 0, 0, 0, implicit $exec, implicit $mode
   ; CHECK-NEXT:   [[SI_IF:%[0-9]+]]:sreg_32 = SI_IF [[DEF1]], %bb.2, implicit-def dead $exec, implicit-def dead $scc, implicit $exec
   ; CHECK-NEXT:   S_BRANCH %bb.1
   ; CHECK-NEXT: {{  $}}
@@ -598,7 +598,7 @@ body:             |
   bb.0:
     %0:vgpr_32 = IMPLICIT_DEF
     %1:sreg_32 = IMPLICIT_DEF
-    %2:vgpr_32 = V_DOT2C_I32_I16_dpp_vi 8, %0:vgpr_32, %0:vgpr_32, %0:vgpr_32, %0:vgpr_32, 0, 0, 0, 0, implicit $exec, implicit $mode
+    %2:vgpr_32 = V_DOT2C_I32_I16_dpp_vi 8, %0:vgpr_32, 0, %0:vgpr_32, %0:vgpr_32, 0, 0, 0, 0, implicit $exec, implicit $mode
     %3:sreg_32 = SI_IF %1:sreg_32, %bb.2, implicit-def dead $exec, implicit-def dead $scc, implicit $exec
     S_BRANCH %bb.1
 
@@ -619,7 +619,7 @@ body:             |
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:vgpr_32 = IMPLICIT_DEF
   ; CHECK-NEXT:   [[DEF1:%[0-9]+]]:sreg_32 = IMPLICIT_DEF
-  ; CHECK-NEXT:   [[V_DOT4C_I32_I8_dpp_vi:%[0-9]+]]:vgpr_32 = V_DOT4C_I32_I8_dpp_vi 8, [[DEF]], [[DEF]], [[DEF]], [[DEF]], 0, 0, 0, 0, implicit $exec, implicit $mode
+  ; CHECK-NEXT:   [[V_DOT4C_I32_I8_dpp_vi:%[0-9]+]]:vgpr_32 = V_DOT4C_I32_I8_dpp_vi 8, [[DEF]], 0, [[DEF]], [[DEF]], 0, 0, 0, 0, implicit $exec, implicit $mode
   ; CHECK-NEXT:   [[SI_IF:%[0-9]+]]:sreg_32 = SI_IF [[DEF1]], %bb.2, implicit-def dead $exec, implicit-def dead $scc, implicit $exec
   ; CHECK-NEXT:   S_BRANCH %bb.1
   ; CHECK-NEXT: {{  $}}
@@ -634,7 +634,7 @@ body:             |
   bb.0:
     %0:vgpr_32 = IMPLICIT_DEF
     %1:sreg_32 = IMPLICIT_DEF
-    %2:vgpr_32 = V_DOT4C_I32_I8_dpp_vi 8, %0:vgpr_32, %0:vgpr_32, %0:vgpr_32, %0:vgpr_32, 0, 0, 0, 0, implicit $exec, implicit $mode
+    %2:vgpr_32 = V_DOT4C_I32_I8_dpp_vi 8, %0:vgpr_32, 0, %0:vgpr_32, %0:vgpr_32, 0, 0, 0, 0, implicit $exec, implicit $mode
     %3:sreg_32 = SI_IF %1:sreg_32, %bb.2, implicit-def dead $exec, implicit-def dead $scc, implicit $exec
     S_BRANCH %bb.1
 
@@ -655,7 +655,7 @@ body:             |
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:vgpr_32 = IMPLICIT_DEF
   ; CHECK-NEXT:   [[DEF1:%[0-9]+]]:sreg_32 = IMPLICIT_DEF
-  ; CHECK-NEXT:   [[V_DOT8C_I32_I4_dpp_vi:%[0-9]+]]:vgpr_32 = V_DOT8C_I32_I4_dpp_vi 8, [[DEF]], [[DEF]], [[DEF]], [[DEF]], 0, 0, 0, 0, implicit $exec
+  ; CHECK-NEXT:   [[V_DOT8C_I32_I4_dpp_vi:%[0-9]+]]:vgpr_32 = V_DOT8C_I32_I4_dpp_vi 8, [[DEF]], 0, [[DEF]], [[DEF]], 0, 0, 0, 0, implicit $exec
   ; CHECK-NEXT:   [[SI_IF:%[0-9]+]]:sreg_32 = SI_IF [[DEF1]], %bb.2, implicit-def dead $exec, implicit-def dead $scc, implicit $exec
   ; CHECK-NEXT:   S_BRANCH %bb.1
   ; CHECK-NEXT: {{  $}}
@@ -670,7 +670,7 @@ body:             |
   bb.0:
     %0:vgpr_32 = IMPLICIT_DEF
     %1:sreg_32 = IMPLICIT_DEF
-    %2:vgpr_32 = V_DOT8C_I32_I4_dpp_vi 8, %0:vgpr_32, %0:vgpr_32, %0:vgpr_32, %0:vgpr_32, 0, 0, 0, 0, implicit $exec
+    %2:vgpr_32 = V_DOT8C_I32_I4_dpp_vi 8, %0:vgpr_32, 0, %0:vgpr_32, %0:vgpr_32, 0, 0, 0, 0, implicit $exec
     %3:sreg_32 = SI_IF %1:sreg_32, %bb.2, implicit-def dead $exec, implicit-def dead $scc, implicit $exec
     S_BRANCH %bb.1
 

--- a/llvm/test/CodeGen/AMDGPU/invalid-vop3-source-modifiers.mir
+++ b/llvm/test/CodeGen/AMDGPU/invalid-vop3-source-modifiers.mir
@@ -1,0 +1,30 @@
+# RUN: not --crash llc -mtriple=amdgcn-- -mcpu=gfx1030 -run-pass=none %s 2>&1 | FileCheck -check-prefix=ERR %s
+
+# ERR: *** Bad machine code: Source modifier of VOP3/VOP3P instruction should be immediate ***
+# ERR: - instruction: $vgpr1 = V_CNDMASK_B32_e64 %stack.0, $vgpr0, 0, 0, $sgpr0, implicit $exec
+# ERR: *** Bad machine code: Source modifier of VOP3/VOP3P instruction should be immediate ***
+# ERR: - instruction: $vgpr1 = V_CNDMASK_B32_e64 0, 0, $vgpr0, $vgpr0, $sgpr0, implicit $exec
+# ERR: *** Bad machine code: Source modifier of VOP3/VOP3P instruction should be immediate ***
+# ERR: - instruction: $vgpr2 = V_FMA_MIX_F32 %stack.0, $vgpr0, 0, $vgpr0, 0, $vgpr0, 0, 0, 0, implicit $mode, implicit $exec
+# ERR: *** Bad machine code: Source modifier of VOP3/VOP3P instruction should be immediate ***
+# ERR: - instruction: $vgpr2 = V_FMA_MIX_F32 0, $vgpr0, $vgpr0, $vgpr0, 0, $vgpr0, 0, 0, 0, implicit $mode, implicit $exec
+# ERR: *** Bad machine code: Source modifier of VOP3/VOP3P instruction should be immediate ***
+# ERR: - instruction: $vgpr2 = V_FMA_MIX_F32 0, $vgpr0, $vgpr0, $vgpr0, %stack.0, $vgpr0, 0, 0, 0, implicit $mode, implicit $exec
+
+---
+name:            invalid_vop3_source_modifiers
+tracksRegLiveness: true
+stack:
+  - { id: 0, size: 8 }
+body:             |
+  bb.0:
+    liveins: $sgpr0, $sgpr1
+    $vgpr0 = V_MOV_B32_e32 0, implicit $exec
+    $vgpr1 = V_CNDMASK_B32_e64 %stack.0, $vgpr0, 0, 0, $sgpr0, implicit $exec
+    $vgpr1 = V_CNDMASK_B32_e64 0, 0, $vgpr0, $vgpr0, $sgpr0, implicit $exec
+    $vgpr2 = V_FMA_MIX_F32 %stack.0, $vgpr0, 0, $vgpr0, 0, $vgpr0, 0, 0, 0, implicit $mode, implicit $exec
+    $vgpr2 = V_FMA_MIX_F32 0, $vgpr0, $vgpr0, $vgpr0, 0, $vgpr0, 0, 0, 0, implicit $mode, implicit $exec
+    $vgpr2 = V_FMA_MIX_F32 0, $vgpr0, $vgpr0, $vgpr0, %stack.0, $vgpr0, 0, 0, 0, implicit $mode, implicit $exec
+
+    SI_RETURN
+...

--- a/llvm/test/MachineVerifier/AMDGPU/invalid-vop3-source-modifiers.mir
+++ b/llvm/test/MachineVerifier/AMDGPU/invalid-vop3-source-modifiers.mir
@@ -1,14 +1,14 @@
 # RUN: not --crash llc -mtriple=amdgcn-- -mcpu=gfx1030 -run-pass=none %s 2>&1 | FileCheck -check-prefix=ERR %s
 
-# ERR: *** Bad machine code: Source modifier of VOP3/VOP3P instruction should be immediate ***
+# ERR: *** Bad machine code: Expected immediate, but got non-immediate ***
 # ERR: - instruction: $vgpr1 = V_CNDMASK_B32_e64 %stack.0, $vgpr0, 0, 0, $sgpr0, implicit $exec
-# ERR: *** Bad machine code: Source modifier of VOP3/VOP3P instruction should be immediate ***
+# ERR: *** Bad machine code: Expected immediate, but got non-immediate ***
 # ERR: - instruction: $vgpr1 = V_CNDMASK_B32_e64 0, 0, $vgpr0, $vgpr0, $sgpr0, implicit $exec
-# ERR: *** Bad machine code: Source modifier of VOP3/VOP3P instruction should be immediate ***
+# ERR: *** Bad machine code: Expected immediate, but got non-immediate ***
 # ERR: - instruction: $vgpr2 = V_FMA_MIX_F32 %stack.0, $vgpr0, 0, $vgpr0, 0, $vgpr0, 0, 0, 0, implicit $mode, implicit $exec
-# ERR: *** Bad machine code: Source modifier of VOP3/VOP3P instruction should be immediate ***
+# ERR: *** Bad machine code: Expected immediate, but got non-immediate ***
 # ERR: - instruction: $vgpr2 = V_FMA_MIX_F32 0, $vgpr0, $vgpr0, $vgpr0, 0, $vgpr0, 0, 0, 0, implicit $mode, implicit $exec
-# ERR: *** Bad machine code: Source modifier of VOP3/VOP3P instruction should be immediate ***
+# ERR: *** Bad machine code: Expected immediate, but got non-immediate ***
 # ERR: - instruction: $vgpr2 = V_FMA_MIX_F32 0, $vgpr0, $vgpr0, $vgpr0, %stack.0, $vgpr0, 0, 0, 0, implicit $mode, implicit $exec
 
 ---

--- a/llvm/test/MachineVerifier/AMDGPU/invalid-vop3-source-modifiers.mir
+++ b/llvm/test/MachineVerifier/AMDGPU/invalid-vop3-source-modifiers.mir
@@ -1,14 +1,14 @@
 # RUN: not --crash llc -mtriple=amdgcn-- -mcpu=gfx1030 -run-pass=none %s 2>&1 | FileCheck -check-prefix=ERR %s
 
-# ERR: *** Bad machine code: Expected immediate, but got non-immediate ***
+# ERR: *** Bad machine code: Expected inline constant for operand. ***
 # ERR: - instruction: $vgpr1 = V_CNDMASK_B32_e64 %stack.0, $vgpr0, 0, 0, $sgpr0, implicit $exec
-# ERR: *** Bad machine code: Expected immediate, but got non-immediate ***
+# ERR: *** Bad machine code: Expected inline constant for operand. ***
 # ERR: - instruction: $vgpr1 = V_CNDMASK_B32_e64 0, 0, $vgpr0, $vgpr0, $sgpr0, implicit $exec
-# ERR: *** Bad machine code: Expected immediate, but got non-immediate ***
+# ERR: *** Bad machine code: Expected inline constant for operand. ***
 # ERR: - instruction: $vgpr2 = V_FMA_MIX_F32 %stack.0, $vgpr0, 0, $vgpr0, 0, $vgpr0, 0, 0, 0, implicit $mode, implicit $exec
-# ERR: *** Bad machine code: Expected immediate, but got non-immediate ***
+# ERR: *** Bad machine code: Expected inline constant for operand. ***
 # ERR: - instruction: $vgpr2 = V_FMA_MIX_F32 0, $vgpr0, $vgpr0, $vgpr0, 0, $vgpr0, 0, 0, 0, implicit $mode, implicit $exec
-# ERR: *** Bad machine code: Expected immediate, but got non-immediate ***
+# ERR: *** Bad machine code: Expected inline constant for operand. ***
 # ERR: - instruction: $vgpr2 = V_FMA_MIX_F32 0, $vgpr0, $vgpr0, $vgpr0, %stack.0, $vgpr0, 0, 0, 0, implicit $mode, implicit $exec
 
 ---


### PR DESCRIPTION
Source modifiers (input modifiers) should always be immediates.
This commit made machine verifier reject non-immediate source modifiers.

Closes #182243