### PR TITLE
[libc][math] Fix missing underflow exception in DyadicFloat::generic_as

### DIFF
--- a/libc/src/__support/FPUtil/dyadic_float.h
+++ b/libc/src/__support/FPUtil/dyadic_float.h
@@ -219,6 +219,8 @@ template <size_t Bits> struct DyadicFloat {
       underflow = true;
     } else if (unbiased_exp == -FPBits::EXP_BIAS - FPBits::FRACTION_LEN) {
       round = true;
+      // underflow is detected pre-rounding FE_UNDERFLOW may be raised
+      // even if rounding produces a non-underflow result
       underflow = true;
       MantissaType sticky_mask = (MantissaType(1) << (Bits - 1)) - 1;
       sticky = (mantissa & sticky_mask) != 0;

--- a/libc/src/__support/FPUtil/dyadic_float.h
+++ b/libc/src/__support/FPUtil/dyadic_float.h
@@ -219,6 +219,7 @@ template <size_t Bits> struct DyadicFloat {
       underflow = true;
     } else if (unbiased_exp == -FPBits::EXP_BIAS - FPBits::FRACTION_LEN) {
       round = true;
+      underflow = true;
       MantissaType sticky_mask = (MantissaType(1) << (Bits - 1)) - 1;
       sticky = (mantissa & sticky_mask) != 0;
     } else {


### PR DESCRIPTION
The `generic_as` function in `dyadic_float.h` had a missing `underflow = true` at the exact boundary where `unbiased_exp == -EXP_BIAS - FRACTION_LEN`.
At this boundary, the mantissa MSB maps exactly to the round bit, so out_mantissa is 0 and the result can only be 0 or min_subnormal. The value is at most min_subnormal / 2, so it is always tiny and always inexact  `underflow` must be signaled. The < case and the general subnormal range both already set underflow = true this boundary case was the only gap.

this specifically fix this error in the erfcf16 function 
```
Extracted erfcf16.cpp.o from archive for linking
Running exhaustive check in --rndn mode...
Missing underflow exception for x=0x1.eacp+1 (y=0x1p-24)
```

this fix may also apply to other bfloat16 missing exceptions (@Sukumarsawant)

part of: #186483 

CC: @lntue 