### PR TITLE
[orc-rt] Remove ORC_RT_SPS_INTERFACE.

### DIFF
--- a/orc-rt/include/orc-rt/SPSWrapperFunction.h
+++ b/orc-rt/include/orc-rt/SPSWrapperFunction.h
@@ -18,8 +18,6 @@
 #include "orc-rt/SimplePackedSerialization.h"
 #include "orc-rt/WrapperFunction.h"
 
-#define ORC_RT_SPS_INTERFACE ORC_RT_INTERFACE
-
 namespace orc_rt {
 namespace detail {
 

--- a/orc-rt/include/orc-rt/SimpleNativeMemoryMap.h
+++ b/orc-rt/include/orc-rt/SimpleNativeMemoryMap.h
@@ -111,24 +111,22 @@ private:
   std::map<void *, SlabInfo> Slabs;
 };
 
+void orc_rt_SimpleNativeMemoryMap_reserve_sps_wrapper(
+    orc_rt_SessionRef S, uint64_t CallId, orc_rt_WrapperFunctionReturn Return,
+    orc_rt_WrapperFunctionBuffer ArgBytes);
+
+void orc_rt_SimpleNativeMemoryMap_releaseMultiple_sps_wrapper(
+    orc_rt_SessionRef S, uint64_t CallId, orc_rt_WrapperFunctionReturn Return,
+    orc_rt_WrapperFunctionBuffer ArgBytes);
+
+void orc_rt_SimpleNativeMemoryMap_initialize_sps_wrapper(
+    orc_rt_SessionRef S, uint64_t CallId, orc_rt_WrapperFunctionReturn Return,
+    orc_rt_WrapperFunctionBuffer ArgBytes);
+
+void orc_rt_SimpleNativeMemoryMap_deinitializeMultiple_sps_wrapper(
+    orc_rt_SessionRef S, uint64_t CallId, orc_rt_WrapperFunctionReturn Return,
+    orc_rt_WrapperFunctionBuffer ArgBytes);
+
 } // namespace orc_rt
-
-ORC_RT_SPS_INTERFACE void orc_rt_SimpleNativeMemoryMap_reserve_sps_wrapper(
-    orc_rt_SessionRef S, uint64_t CallId, orc_rt_WrapperFunctionReturn Return,
-    orc_rt_WrapperFunctionBuffer ArgBytes);
-
-ORC_RT_SPS_INTERFACE void
-orc_rt_SimpleNativeMemoryMap_releaseMultiple_sps_wrapper(
-    orc_rt_SessionRef S, uint64_t CallId, orc_rt_WrapperFunctionReturn Return,
-    orc_rt_WrapperFunctionBuffer ArgBytes);
-
-ORC_RT_SPS_INTERFACE void orc_rt_SimpleNativeMemoryMap_initialize_sps_wrapper(
-    orc_rt_SessionRef S, uint64_t CallId, orc_rt_WrapperFunctionReturn Return,
-    orc_rt_WrapperFunctionBuffer ArgBytes);
-
-ORC_RT_SPS_INTERFACE void
-orc_rt_SimpleNativeMemoryMap_deinitializeMultiple_sps_wrapper(
-    orc_rt_SessionRef S, uint64_t CallId, orc_rt_WrapperFunctionReturn Return,
-    orc_rt_WrapperFunctionBuffer ArgBytes);
 
 #endif // ORC_RT_SIMPLENATIVEMEMORYMAP_H

--- a/orc-rt/lib/executor/SimpleNativeMemoryMap.cpp
+++ b/orc-rt/lib/executor/SimpleNativeMemoryMap.cpp
@@ -366,7 +366,7 @@ Error SimpleNativeMemoryMap::recordDeallocActions(
   return Error::success();
 }
 
-ORC_RT_SPS_INTERFACE void orc_rt_SimpleNativeMemoryMap_reserve_sps_wrapper(
+void orc_rt_SimpleNativeMemoryMap_reserve_sps_wrapper(
     orc_rt_SessionRef S, uint64_t CallId, orc_rt_WrapperFunctionReturn Return,
     orc_rt_WrapperFunctionBuffer ArgBytes) {
   using Sig = SPSExpected<SPSExecutorAddr>(SPSExecutorAddr, SPSSize);
@@ -375,8 +375,7 @@ ORC_RT_SPS_INTERFACE void orc_rt_SimpleNativeMemoryMap_reserve_sps_wrapper(
       WrapperFunction::handleWithAsyncMethod(&SimpleNativeMemoryMap::reserve));
 }
 
-ORC_RT_SPS_INTERFACE void
-orc_rt_SimpleNativeMemoryMap_releaseMultiple_sps_wrapper(
+void orc_rt_SimpleNativeMemoryMap_releaseMultiple_sps_wrapper(
     orc_rt_SessionRef S, uint64_t CallId, orc_rt_WrapperFunctionReturn Return,
     orc_rt_WrapperFunctionBuffer ArgBytes) {
   using Sig = SPSError(SPSExecutorAddr, SPSSequence<SPSExecutorAddr>);
@@ -385,7 +384,7 @@ orc_rt_SimpleNativeMemoryMap_releaseMultiple_sps_wrapper(
                                       &SimpleNativeMemoryMap::releaseMultiple));
 }
 
-ORC_RT_SPS_INTERFACE void orc_rt_SimpleNativeMemoryMap_initialize_sps_wrapper(
+void orc_rt_SimpleNativeMemoryMap_initialize_sps_wrapper(
     orc_rt_SessionRef S, uint64_t CallId, orc_rt_WrapperFunctionReturn Return,
     orc_rt_WrapperFunctionBuffer ArgBytes) {
   using Sig = SPSExpected<SPSExecutorAddr>(
@@ -395,8 +394,7 @@ ORC_RT_SPS_INTERFACE void orc_rt_SimpleNativeMemoryMap_initialize_sps_wrapper(
                                       &SimpleNativeMemoryMap::initialize));
 }
 
-ORC_RT_SPS_INTERFACE void
-orc_rt_SimpleNativeMemoryMap_deinitializeMultiple_sps_wrapper(
+void orc_rt_SimpleNativeMemoryMap_deinitializeMultiple_sps_wrapper(
     orc_rt_SessionRef S, uint64_t CallId, orc_rt_WrapperFunctionReturn Return,
     orc_rt_WrapperFunctionBuffer ArgBytes) {
   using Sig = SPSError(SPSExecutorAddr, SPSSequence<SPSExecutorAddr>);


### PR DESCRIPTION
SPS symbols are part of the Controller Interface (CI) for the runtime. They don't need to be exposed to ORC runtime API clients.