### PR TITLE
[Sema] Propagate preferred_name attribute to existing specializations

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -299,6 +299,7 @@ Bug Fixes in This Version
 - Fixed an assertion failure when evaluating ``_Countof`` on invalid ``void``-typed operands. (#GH180893)
 - Fixed an assertion failure in the serialized diagnostic printer when it is destroyed without calling ``finish()``. (#GH140433)
 - Fixed an assertion failure caused by error recovery while extending a nested name specifier with results from ordinary lookup. (#GH181470)
+- Fixed a bug where the ``preferred_name`` attribute was not propagated to existing specializations. (#GH106358)
 
 Bug Fixes to Compiler Builtins
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -1209,7 +1209,6 @@ static void handlePreferredName(Sema &S, Decl *D, const ParsedAttr &AL) {
     TSI = S.Context.getTrivialTypeSourceInfo(T, AL.getLoc());
 
   if (!T.hasQualifiers() && T->isTypedefNameType()) {
-    // Find the template name, if this type names a template specialization.
     const TemplateDecl *Template = nullptr;
     if (const auto *CTSD = dyn_cast_if_present<ClassTemplateSpecializationDecl>(
             T->getAsCXXRecordDecl())) {
@@ -1222,7 +1221,19 @@ static void handlePreferredName(Sema &S, Decl *D, const ParsedAttr &AL) {
     }
 
     if (Template && declaresSameEntity(Template, CTD)) {
-      D->addAttr(::new (S.Context) PreferredNameAttr(S.Context, AL, TSI));
+      auto *PNA = ::new (S.Context) PreferredNameAttr(S.Context, AL, TSI);
+      D->addAttr(PNA);
+
+      for (auto *Spec : CTD->specializations()) {
+        const TypeDecl *TD = static_cast<const TypeDecl *>(Spec);
+        if (S.Context.hasSameType(S.Context.getTypeDeclType(TD),
+                                  TSI->getType())) {
+          for (auto *R : Spec->redecls()) {
+            if (!R->hasAttr<PreferredNameAttr>())
+              R->addAttr(PNA->clone(S.Context));
+          }
+        }
+      }
       return;
     }
   }
@@ -1233,7 +1244,6 @@ static void handlePreferredName(Sema &S, Decl *D, const ParsedAttr &AL) {
     S.Diag(TT->getDecl()->getLocation(), diag::note_entity_declared_at)
         << TT->getDecl();
 }
-
 static void handleNoSpecializations(Sema &S, Decl *D, const ParsedAttr &AL) {
   StringRef Message;
   if (AL.getNumArgs() != 0)

--- a/clang/test/SemaCXX/gh106358.cpp
+++ b/clang/test/SemaCXX/gh106358.cpp
@@ -1,0 +1,18 @@
+// RUN: %clang_cc1 -fsyntax-only -verify %s
+
+// GH106358: Test that preferred_name propagates to specializations 
+// instantiated before the attribute is seen.
+
+template<typename T>
+void foo(T arg) {} // expected-note {{candidate function template not viable: no known conversion from 'int' to 'my_string' (aka 'my_basic_string<char>') for 1st argument}}
+
+template<typename T> struct my_basic_string;
+using my_string = my_basic_string<char>;
+
+// This attribute application now correctly propagates to the existing specialization
+template<typename T> 
+struct __attribute__((__preferred_name__(my_string))) my_basic_string {};
+
+int main() {
+    foo<my_string>(123); // expected-error {{no matching function for call to 'foo'}}
+}


### PR DESCRIPTION
Fixes #106358

This PR ensures the `preferred_name` attribute is propagated to specializations 
that were instantiated before the attribute was seen on the primary template.

The fix iterates through the redeclaration chain of matching specializations 
and applies a cloned attribute to each, ensuring consistent diagnostic 
output (the 'aka' message) regardless of which declaration node is accessed.

Validated with new test: `clang/test/SemaCXX/gh106358.cpp`