### PR TITLE
[llvm-objdump] Skip dump of actual output for -mcpu=help

### DIFF
--- a/llvm/docs/ReleaseNotes.md
+++ b/llvm/docs/ReleaseNotes.md
@@ -197,6 +197,7 @@ Changes to the LLVM tools
 * `llvm-objcopy` no longer corrupts the symbol table when `--update-section` is called for ELF files.
 * `FileCheck` option `-check-prefix` now accepts a comma-separated list of
   prefixes, making it an alias of the existing `-check-prefixes` option.
+* `llvm-objdump` no longer dumps actual output when `--mcpu=help` or `--mattr=help` are passed
 
 Changes to LLDB
 ---------------

--- a/llvm/test/tools/llvm-objdump/mattr-mcpu-help.test
+++ b/llvm/test/tools/llvm-objdump/mattr-mcpu-help.test
@@ -1,32 +1,32 @@
 # REQUIRES: x86-registered-target
 
 # RUN: yaml2obj --docnum=1 %s -o %t
+# RUN: llvm-objdump --mattr=help %t 2>&1 \
+# RUN:   | FileCheck %s --check-prefixes=CHECK
+# RUN: llvm-objdump --mcpu=help %t 2>&1 \
+# RUN:   | FileCheck %s --check-prefixes=CHECK
+
+## The help message should be printed without disassembly.
 # RUN: llvm-objdump -d %t --mattr=help 2>&1 \
-# RUN:   | FileCheck %s --check-prefixes=CHECK,CHECK-DISASSEMBLE
+# RUN:   | FileCheck %s --check-prefixes=CHECK
 # RUN: llvm-objdump -d %t --mcpu=help 2>&1 \
-# RUN:   | FileCheck %s --check-prefixes=CHECK,CHECK-DISASSEMBLE
+# RUN:   | FileCheck %s --check-prefixes=CHECK
+
+## We also dont handle other options.
+# RUN: llvm-objdump --mattr=help --section-headers %t 2>&1 \
+# RUN:   | FileCheck %s --check-prefixes=CHECK
+# RUN: llvm-objdump --mcpu=help --section-headers %t 2>&1 \
+# RUN:   | FileCheck %s --check-prefixes=CHECK
 
 # CHECK: Available CPUs for this target:
 # CHECK: Available features for this target:
-## To check we still disassemble the file:
-# CHECK-DISASSEMBLE: file format elf64-x86-64
 
-## The help message can be printed without -d.
-# RUN: llvm-objdump --mattr=help %t 2>&1 \
-# RUN:   | FileCheck %s --check-prefixes=CHECK,CHECK-NO-DISASSEMBLE
-# RUN: llvm-objdump --mcpu=help %t 2>&1 \
-# RUN:   | FileCheck %s --check-prefixes=CHECK,CHECK-NO-DISASSEMBLE
+## To check we dont disassemble the file:
+# CHECK-NOT: file format elf64-x86-64
 
-# CHECK-NO-DISASSEMBLE-NOT: file format elf64-x86-64
-
-## We still handle other options.
-# RUN: llvm-objdump --mattr=help --section-headers %t 2>&1 \
-# RUN:   | FileCheck %s --check-prefixes=CHECK,CHECK-SECTION-HEADERS
-# RUN: llvm-objdump --mcpu=help --section-headers %t 2>&1 \
-# RUN:   | FileCheck %s --check-prefixes=CHECK,CHECK-SECTION-HEADERS
-
-# CHECK-SECTION-HEADERS: Sections:
-# CHECK-SECTION-HEADERS: Idx Name               Size     VMA              Type
+## To check we dont dump sections:
+# CHECK-NOT: Sections:
+# CHECK-NOT: Idx Name               Size     VMA              Type
 
 ## We report an error when we can't infer the triple because we don't have --triple or an input object (including a.out).
 # RUN: not llvm-objdump --mattr=help 2>&1 \

--- a/llvm/tools/llvm-objdump/llvm-objdump.cpp
+++ b/llvm/tools/llvm-objdump/llvm-objdump.cpp
@@ -3940,7 +3940,10 @@ int llvm_objdump_main(int argc, char **argv, const llvm::ToolContext &) {
       !DisassembleSymbols.empty())
     Disassemble = true;
 
-  const bool PrintCpuHelp = (MCPU == "help" || is_contained(MAttrs, "help"));
+  if ((MCPU == "help" || is_contained(MAttrs, "help"))) {
+    mcpuHelp();
+    return EXIT_SUCCESS;
+  }
 
   const bool ShouldDump =
       ArchiveHeaders || Disassemble || DwarfDumpType != DIDT_Null ||
@@ -3954,14 +3957,9 @@ int llvm_objdump_main(int argc, char **argv, const llvm::ToolContext &) {
         InfoPlist || LazyBind || LinkOptHints || ObjcMetaData || Rebase ||
         Rpaths || UniversalHeaders || WeakBind || !FilterSections.empty()));
 
-  if (!ShouldDump && !PrintCpuHelp) {
+  if (!ShouldDump) {
     T->printHelp(ToolName);
     return 2;
-  }
-
-  if (PrintCpuHelp) {
-    mcpuHelp();
-    return EXIT_SUCCESS;
   }
 
   DisasmSymbolSet.insert_range(DisassembleSymbols);

--- a/llvm/tools/llvm-objdump/llvm-objdump.cpp
+++ b/llvm/tools/llvm-objdump/llvm-objdump.cpp
@@ -3961,8 +3961,7 @@ int llvm_objdump_main(int argc, char **argv, const llvm::ToolContext &) {
 
   if (PrintCpuHelp) {
     mcpuHelp();
-    if (!ShouldDump)
-      return EXIT_SUCCESS;
+    return EXIT_SUCCESS;
   }
 
   DisasmSymbolSet.insert_range(DisassembleSymbols);


### PR DESCRIPTION
This patch aims to align the output of llvm-objdump for target help purposes with the rest of the in-tree tools, including Clang and llvm/tools like llc, and make a cleaner distincting between help text and actual dumps. When passed `--mcpu=help` or `--mattr=help`, print the help text and exit early, suppressing the actual output (disassembly, sections, etc). External users should probably mostly not get broken, unless they rely on the mixed output, which is unlikely for real world scenarios (in this case they need 2 invocations now).