### PR TITLE
[C++20] [Modules] Don't add discardable variables to module initializers

### DIFF
--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -15138,7 +15138,10 @@ void Sema::CheckCompleteVariableDeclaration(VarDecl *var) {
 
   // If this variable must be emitted, add it as an initializer for the current
   // module.
-  if (Context.DeclMustBeEmitted(var) && !ModuleScopes.empty())
+  if (Context.DeclMustBeEmitted(var) && !ModuleScopes.empty() &&
+      (ModuleScopes.back().Module->isHeaderLikeModule() ||
+       // For named modules, we may only emit non discardable variables.
+       !isDiscardableGVALinkage(Context.GetGVALinkageForVariable(var))))
     Context.addModuleInitializer(ModuleScopes.back().Module, var);
 
   // Build the bindings if this is a structured binding declaration.

--- a/clang/test/Modules/pr170099.cppm
+++ b/clang/test/Modules/pr170099.cppm
@@ -1,0 +1,20 @@
+// RUN: %clang_cc1 -triple %itanium_abi_triple -std=c++26 -O3 -emit-llvm %s -o - | FileCheck %s
+module;
+
+struct A {};
+
+struct B {
+	int x;
+	A   a;
+	constexpr B(char *) { x = int(); }
+	~B();
+};
+
+struct C {
+	B b = "";
+} inline c{};
+
+export module foo;
+
+// Just to make sure it won't crash
+// CHECK: @_ZGIW3foo


### PR DESCRIPTION
Close https://github.com/llvm/llvm-project/issues/170099

The root cause of the problem is, we shouldn't add the inline variable (which is discardable in linker's point of view) to the module's initializers.

I verified with GCC's generated code to make the behavior consistent.

This is also a small optimization by the way.