### PR TITLE
[mlir][arith][NFC] Use type parser instead of hard-coding type keywords

### DIFF
--- a/mlir/include/mlir/Dialect/Arith/Utils/Utils.h
+++ b/mlir/include/mlir/Dialect/Arith/Utils/Utils.h
@@ -143,8 +143,9 @@ Value createProduct(OpBuilder &builder, Location loc, ArrayRef<Value> values);
 Value createProduct(OpBuilder &builder, Location loc, ArrayRef<Value> values,
                     Type resultType);
 
-// Map strings to float types.
-std::optional<FloatType> parseFloatType(MLIRContext *ctx, StringRef name);
+// Map strings to float types. Returns nullptr if the name is not a known
+// floating-point type.
+FloatType parseFloatType(MLIRContext *ctx, StringRef name);
 
 } // namespace arith
 } // namespace mlir

--- a/mlir/lib/Dialect/Arith/Transforms/EmulateUnsupportedFloats.cpp
+++ b/mlir/lib/Dialect/Arith/Transforms/EmulateUnsupportedFloats.cpp
@@ -132,25 +132,23 @@ void EmulateUnsupportedFloatsPass::runOnOperation() {
   SmallVector<Type> sourceTypes;
   Type targetType;
 
-  std::optional<FloatType> maybeTargetType =
-      arith::parseFloatType(ctx, targetTypeStr);
-  if (!maybeTargetType) {
+  FloatType parsedTargetType = arith::parseFloatType(ctx, targetTypeStr);
+  if (!parsedTargetType) {
     emitError(UnknownLoc::get(ctx), "could not map target type '" +
                                         targetTypeStr +
                                         "' to a known floating-point type");
     return signalPassFailure();
   }
-  targetType = *maybeTargetType;
+  targetType = parsedTargetType;
   for (StringRef sourceTypeStr : sourceTypeStrs) {
-    std::optional<FloatType> maybeSourceType =
-        arith::parseFloatType(ctx, sourceTypeStr);
-    if (!maybeSourceType) {
+    FloatType sourceType = arith::parseFloatType(ctx, sourceTypeStr);
+    if (!sourceType) {
       emitError(UnknownLoc::get(ctx), "could not map source type '" +
                                           sourceTypeStr +
                                           "' to a known floating-point type");
       return signalPassFailure();
     }
-    sourceTypes.push_back(*maybeSourceType);
+    sourceTypes.push_back(sourceType);
   }
   if (sourceTypes.empty())
     (void)emitOptionalWarning(

--- a/mlir/lib/Dialect/Arith/Utils/CMakeLists.txt
+++ b/mlir/lib/Dialect/Arith/Utils/CMakeLists.txt
@@ -6,6 +6,7 @@ add_mlir_dialect_library(MLIRArithUtils
 
   LINK_LIBS PUBLIC
   MLIRArithDialect
+  MLIRAsmParser
   MLIRComplexDialect
   MLIRDialect
   MLIRDialectUtils

--- a/mlir/lib/Dialect/Arith/Utils/Utils.cpp
+++ b/mlir/lib/Dialect/Arith/Utils/Utils.cpp
@@ -11,9 +11,11 @@
 //===----------------------------------------------------------------------===//
 
 #include "mlir/Dialect/Arith/Utils/Utils.h"
+#include "mlir/AsmParser/AsmParser.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Complex/IR/Complex.h"
 #include "mlir/Dialect/Utils/StaticValueUtils.h"
+#include "mlir/IR/Diagnostics.h"
 #include "llvm/ADT/SmallBitVector.h"
 #include "llvm/ADT/SmallVectorExtras.h"
 #include <numeric>
@@ -357,27 +359,15 @@ Value createProduct(OpBuilder &builder, Location loc, ArrayRef<Value> values,
   });
 }
 
-/// Map strings to float types.
-std::optional<FloatType> parseFloatType(MLIRContext *ctx, StringRef name) {
-  Builder b(ctx);
-  return llvm::StringSwitch<std::optional<FloatType>>(name)
-      .Case("f4E2M1FN", b.getType<Float4E2M1FNType>())
-      .Case("f6E2M3FN", b.getType<Float6E2M3FNType>())
-      .Case("f6E3M2FN", b.getType<Float6E3M2FNType>())
-      .Case("f8E5M2", b.getType<Float8E5M2Type>())
-      .Case("f8E4M3", b.getType<Float8E4M3Type>())
-      .Case("f8E4M3FN", b.getType<Float8E4M3FNType>())
-      .Case("f8E5M2FNUZ", b.getType<Float8E5M2FNUZType>())
-      .Case("f8E4M3FNUZ", b.getType<Float8E4M3FNUZType>())
-      .Case("f8E3M4", b.getType<Float8E3M4Type>())
-      .Case("f8E8M0FNU", b.getType<Float8E8M0FNUType>())
-      .Case("bf16", b.getType<BFloat16Type>())
-      .Case("f16", b.getType<Float16Type>())
-      .Case("f32", b.getType<Float32Type>())
-      .Case("f64", b.getType<Float64Type>())
-      .Case("f80", b.getType<Float80Type>())
-      .Case("f128", b.getType<Float128Type>())
-      .Default(std::nullopt);
+FloatType parseFloatType(MLIRContext *ctx, StringRef name) {
+  // Parsing non-builtin types is unsafe because the respective dialect may not
+  // have been loaded.
+  if (!name.empty() && name.front() == '!')
+    return FloatType();
+
+  // Suppress diagnostics: callers handle invalid type strings themselves.
+  ScopedDiagnosticHandler handler(ctx, [](Diagnostic &) {});
+  return dyn_cast_or_null<FloatType>(mlir::parseType(name, ctx));
 }
 
 } // namespace mlir::arith

--- a/mlir/lib/Dialect/Math/Transforms/ExtendToSupportedTypes.cpp
+++ b/mlir/lib/Dialect/Math/Transforms/ExtendToSupportedTypes.cpp
@@ -124,28 +124,25 @@ void ExtendToSupportedTypesPass::runOnOperation() {
   MLIRContext *ctx = &getContext();
 
   // Parse target type
-  std::optional<Type> maybeTargetType =
-      arith::parseFloatType(ctx, targetTypeStr);
-  if (!maybeTargetType.has_value()) {
+  FloatType targetType = arith::parseFloatType(ctx, targetTypeStr);
+  if (!targetType) {
     emitError(UnknownLoc::get(ctx), "could not map target type '" +
                                         targetTypeStr +
                                         "' to a known floating-point type");
     return signalPassFailure();
   }
-  Type targetType = maybeTargetType.value();
 
   // Parse source types
   llvm::SetVector<Type> sourceTypes;
   for (const auto &extraTypeStr : extraTypeStrs) {
-    std::optional<FloatType> maybeExtraType =
-        arith::parseFloatType(ctx, extraTypeStr);
-    if (!maybeExtraType.has_value()) {
+    FloatType extraType = arith::parseFloatType(ctx, extraTypeStr);
+    if (!extraType) {
       emitError(UnknownLoc::get(ctx), "could not map source type '" +
                                           extraTypeStr +
                                           "' to a known floating-point type");
       return signalPassFailure();
     }
-    sourceTypes.insert(maybeExtraType.value());
+    sourceTypes.insert(extraType);
   }
   // f64 and f32 are implicitly supported
   Builder b(ctx);


### PR DESCRIPTION
Parse type literals instead of hard-coding them in a switch-case statement.

Assisted by: claude-opus-4.6
