### PR TITLE
[mlir][python] Fix PyObjectRef copy/move assignment for MSVC

### DIFF
--- a/mlir/include/mlir/Bindings/Python/IRCore.h
+++ b/mlir/include/mlir/Bindings/Python/IRCore.h
@@ -77,6 +77,18 @@ public:
   }
   PyObjectRef(const PyObjectRef &other)
       : referrent(other.referrent), object(other.object /* copies */) {}
+  PyObjectRef &operator=(const PyObjectRef &other) {
+    referrent = other.referrent;
+    object = other.object;
+    return *this;
+  }
+  PyObjectRef &operator=(PyObjectRef &&other) noexcept {
+    referrent = other.referrent;
+    object = std::move(other.object);
+    other.referrent = nullptr;
+    assert(!other.object);
+    return *this;
+  }
   ~PyObjectRef() = default;
 
   int getRefCount() {


### PR DESCRIPTION
PyObjectRef has a user-declared move constructor but no explicit copy/move assignment operators. On at least some version of MSVC, instantiation of operator= is forced, causing a compile error:

```
In file included from mlir/lib/Bindings/Python/Globals.cpp:9:
In file included from mlir/include/mlir/Bindings/Python/IRCore.h:16:
<MSVC>/include/vector(1461,27): error: object of type 'value_type' (aka 'mlir::python::mlir::PyDiagnostic::DiagnosticInfo') cannot be assigned because its copy assignment operator is implicitly deleted
 1461 |                     *_Mid = *_First;
      |                           ^
<MSVC>/include/vector(1539,9): note: in instantiation of function template specialization 'std::vector<mlir::python::mlir::PyDiagnostic::DiagnosticInfo>::_Assign_counted_range<mlir::python::mlir::PyDiagnostic::DiagnosticInfo *>' requested here
 1539 |         _Assign_counted_range(_Right_data._Myfirst, static_cast<size_type>(_Right_data._Mylast - _Right_data._Myfirst));
      |         ^
mlir/include/mlir/Bindings/Python/IRCore.h(1317,33): note: in instantiation of member function 'std::vector<mlir::python::mlir::PyDiagnostic::DiagnosticInfo>::operator=' requested here
 1317 | struct MLIR_PYTHON_API_EXPORTED MLIRError {
      |                                 ^
mlir/include/mlir/Bindings/Python/IRCore.h(369,16): note: copy assignment operator of 'DiagnosticInfo' is implicitly deleted because field 'location' has a deleted copy assignment operator
  369 |     PyLocation location;
      |                ^
mlir/include/mlir/Bindings/Python/IRCore.h(304,45): note: copy assignment operator of 'PyLocation' is implicitly deleted because base class 'BaseContextObject' has a deleted copy assignment operator
  304 | class MLIR_PYTHON_API_EXPORTED PyLocation : public BaseContextObject {
      |                                             ^
mlir/include/mlir/Bindings/Python/IRCore.h(300,20): note: copy assignment operator of 'BaseContextObject' is implicitly deleted because field 'contextRef' has a deleted copy assignment operator
  300 |   PyMlirContextRef contextRef;
      |                    ^
mlir/include/mlir/Bindings/Python/IRCore.h(73,3): note: copy assignment operator is implicitly deleted because 'PyObjectRef<mlir::python::mlir::PyMlirContext>' has a user-declared move constructor
   73 |   PyObjectRef(PyObjectRef &&other) noexcept
      |   ^
1 error generated.
```

Encountered on this env:

```
Compiler: clang-cl 20.1.8
STL: MSVC 14.44.35207 (Visual Studio 2022 Enterprise)
Runner: windows-2022 (GitHub Actions)
```