### PR TITLE
[llvm][DebugInfo] DWARFCompileUnit use formatv instead of format

### DIFF
--- a/llvm/lib/DebugInfo/DWARF/DWARFCompileUnit.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFCompileUnit.cpp
@@ -11,6 +11,8 @@
 #include "llvm/DebugInfo/DWARF/DWARFDie.h"
 
 #include "llvm/Support/Format.h"
+#include "llvm/Support/FormatAdapters.h"
+#include "llvm/Support/FormatVariadic.h"
 #include "llvm/Support/raw_ostream.h"
 
 using namespace llvm;
@@ -19,21 +21,23 @@ void DWARFCompileUnit::dump(raw_ostream &OS, DIDumpOptions DumpOpts) {
   if (DumpOpts.SummarizeTypes)
     return;
   int OffsetDumpWidth = 2 * dwarf::getDwarfOffsetByteSize(getFormat());
-  OS << format("0x%08" PRIx64, getOffset()) << ": Compile Unit:"
-     << " length = " << format("0x%0*" PRIx64, OffsetDumpWidth, getLength())
+  OS << formatv("{0:x+8}", getOffset()) << ": Compile Unit:"
+     << " length = "
+     << formatv("0x{0:x-}",
+                fmt_align(getLength(), AlignStyle::Right, OffsetDumpWidth, '0'))
      << ", format = " << dwarf::FormatString(getFormat())
-     << ", version = " << format("0x%04x", getVersion());
+     << ", version = " << formatv("{0:x+4}", getVersion());
+
   if (getVersion() >= 5)
     OS << ", unit_type = " << dwarf::UnitTypeString(getUnitType());
-  OS << ", abbr_offset = " << format("0x%04" PRIx64, getAbbrOffset());
+  OS << ", abbr_offset = " << formatv("{0:x+4}", getAbbrOffset());
   if (!getAbbreviations())
     OS << " (invalid)";
-  OS << ", addr_size = " << format("0x%02x", getAddressByteSize());
+  OS << ", addr_size = " << formatv("{0:x+2}", getAddressByteSize());
   if (getVersion() >= 5 && (getUnitType() == dwarf::DW_UT_skeleton ||
                             getUnitType() == dwarf::DW_UT_split_compile))
-    OS << ", DWO_id = " << format("0x%016" PRIx64, *getDWOId());
-  OS << " (next unit at " << format("0x%08" PRIx64, getNextUnitOffset())
-     << ")\n";
+    OS << ", DWO_id = " << formatv("{0:x+16}", *getDWOId());
+  OS << " (next unit at " << formatv("{0:x+8}", getNextUnitOffset()) << ")\n";
 
   if (DWARFDie CUDie = getUnitDIE(false)) {
     CUDie.dump(OS, 0, DumpOpts);


### PR DESCRIPTION
This relates to #35980.