### PR TITLE
[IR] Drop BasicBlockEdge::isSingleEdge

### DIFF
--- a/llvm/include/llvm/IR/Dominators.h
+++ b/llvm/include/llvm/IR/Dominators.h
@@ -111,12 +111,7 @@ public:
     return Start;
   }
 
-  const BasicBlock *getEnd() const {
-    return End;
-  }
-
-  /// Check if this is the only edge between Start and End.
-  LLVM_ABI bool isSingleEdge() const;
+  const BasicBlock *getEnd() const { return End; }
 };
 
 template <> struct DenseMapInfo<BasicBlockEdge> {

--- a/llvm/lib/Analysis/ScalarEvolution.cpp
+++ b/llvm/lib/Analysis/ScalarEvolution.cpp
@@ -6035,15 +6035,12 @@ const SCEV *ScalarEvolution::createAddRecFromPHI(PHINode *PN) {
 // match.
 static bool BrPHIToSelect(DominatorTree &DT, CondBrInst *BI, PHINode *Merge,
                           Value *&C, Value *&LHS, Value *&RHS) {
+  if (BI->getSuccessor(0) == BI->getSuccessor(1))
+    return false;
   C = BI->getCondition();
 
   BasicBlockEdge LeftEdge(BI->getParent(), BI->getSuccessor(0));
   BasicBlockEdge RightEdge(BI->getParent(), BI->getSuccessor(1));
-
-  if (!LeftEdge.isSingleEdge())
-    return false;
-
-  assert(RightEdge.isSingleEdge() && "Follows from LeftEdge.isSingleEdge()");
 
   Use &LeftUse = Merge->getOperandUse(0);
   Use &RightUse = Merge->getOperandUse(1);
@@ -11878,27 +11875,20 @@ bool ScalarEvolution::isLoopBackedgeGuardedByCond(const Loop *L,
     if (!PBB)
       continue;
 
-    CondBrInst *ContinuePredicate = dyn_cast<CondBrInst>(PBB->getTerminator());
-    if (!ContinuePredicate)
+    CondBrInst *ContBr = dyn_cast<CondBrInst>(PBB->getTerminator());
+    if (!ContBr || ContBr->getSuccessor(0) == ContBr->getSuccessor(1))
       continue;
-
-    Value *Condition = ContinuePredicate->getCondition();
 
     // If we have an edge `E` within the loop body that dominates the only
     // latch, the condition guarding `E` also guards the backedge.  This
     // reasoning works only for loops with a single latch.
-
-    BasicBlockEdge DominatingEdge(PBB, BB);
-    if (DominatingEdge.isSingleEdge()) {
-      // We're constructively (and conservatively) enumerating edges within the
-      // loop body that dominate the latch.  The dominator tree better agree
-      // with us on this:
-      assert(DT.dominates(DominatingEdge, Latch) && "should be!");
-
-      if (isImpliedCond(Pred, LHS, RHS, Condition,
-                        BB != ContinuePredicate->getSuccessor(0)))
-        return true;
-    }
+    // We're constructively (and conservatively) enumerating edges within the
+    // loop body that dominate the latch.  The dominator tree better agree
+    // with us on this:
+    assert(DT.dominates(BasicBlockEdge(PBB, BB), Latch) && "should be!");
+    if (isImpliedCond(Pred, LHS, RHS, ContBr->getCondition(),
+                      BB != ContBr->getSuccessor(0)))
+      return true;
   }
 
   return false;

--- a/llvm/lib/Analysis/ScalarEvolution.cpp
+++ b/llvm/lib/Analysis/ScalarEvolution.cpp
@@ -6035,8 +6035,6 @@ const SCEV *ScalarEvolution::createAddRecFromPHI(PHINode *PN) {
 // match.
 static bool BrPHIToSelect(DominatorTree &DT, CondBrInst *BI, PHINode *Merge,
                           Value *&C, Value *&LHS, Value *&RHS) {
-  if (BI->getSuccessor(0) == BI->getSuccessor(1))
-    return false;
   C = BI->getCondition();
 
   BasicBlockEdge LeftEdge(BI->getParent(), BI->getSuccessor(0));

--- a/llvm/lib/Analysis/ValueTracking.cpp
+++ b/llvm/lib/Analysis/ValueTracking.cpp
@@ -3002,10 +3002,12 @@ static bool isKnownNonNullFromDominatingCondition(const Value *V,
           }
 
         if (const CondBrInst *BI = dyn_cast<CondBrInst>(Curr)) {
+          if (BI->getSuccessor(0) == BI->getSuccessor(1))
+            continue;
           BasicBlock *NonNullSuccessor =
               BI->getSuccessor(NonNullIfTrue ? 0 : 1);
           BasicBlockEdge Edge(BI->getParent(), NonNullSuccessor);
-          if (Edge.isSingleEdge() && DT->dominates(Edge, CtxI->getParent()))
+          if (DT->dominates(Edge, CtxI->getParent()))
             return true;
         } else if (NonNullIfTrue && isGuard(Curr) &&
                    DT->dominates(cast<Instruction>(Curr), CtxI)) {
@@ -7528,9 +7530,9 @@ bool llvm::isOverflowIntrinsicNoWrap(const WithOverflowInst *WO,
   }
 
   auto AllUsesGuardedByBranch = [&](const CondBrInst *BI) {
-    BasicBlockEdge NoWrapEdge(BI->getParent(), BI->getSuccessor(1));
-    if (!NoWrapEdge.isSingleEdge())
+    if (BI->getSuccessor(0) == BI->getSuccessor(1))
       return false;
+    BasicBlockEdge NoWrapEdge(BI->getParent(), BI->getSuccessor(1));
 
     // Check if all users of the add are provably no-wrap.
     for (const auto *Result : Results) {

--- a/llvm/lib/Analysis/ValueTracking.cpp
+++ b/llvm/lib/Analysis/ValueTracking.cpp
@@ -3002,8 +3002,6 @@ static bool isKnownNonNullFromDominatingCondition(const Value *V,
           }
 
         if (const CondBrInst *BI = dyn_cast<CondBrInst>(Curr)) {
-          if (BI->getSuccessor(0) == BI->getSuccessor(1))
-            continue;
           BasicBlock *NonNullSuccessor =
               BI->getSuccessor(NonNullIfTrue ? 0 : 1);
           BasicBlockEdge Edge(BI->getParent(), NonNullSuccessor);
@@ -7530,8 +7528,6 @@ bool llvm::isOverflowIntrinsicNoWrap(const WithOverflowInst *WO,
   }
 
   auto AllUsesGuardedByBranch = [&](const CondBrInst *BI) {
-    if (BI->getSuccessor(0) == BI->getSuccessor(1))
-      return false;
     BasicBlockEdge NoWrapEdge(BI->getParent(), BI->getSuccessor(1));
 
     // Check if all users of the add are provably no-wrap.

--- a/llvm/lib/IR/Dominators.cpp
+++ b/llvm/lib/IR/Dominators.cpp
@@ -49,18 +49,6 @@ static constexpr bool ExpensiveChecksEnabled = true;
 static constexpr bool ExpensiveChecksEnabled = false;
 #endif
 
-bool BasicBlockEdge::isSingleEdge() const {
-  unsigned NumEdgesToEnd = 0;
-  for (const BasicBlock *Succ : successors(Start)) {
-    if (Succ == End)
-      ++NumEdgesToEnd;
-    if (NumEdgesToEnd >= 2)
-      return false;
-  }
-  assert(NumEdgesToEnd == 1);
-  return true;
-}
-
 //===----------------------------------------------------------------------===//
 //  DominatorTree Implementation
 //===----------------------------------------------------------------------===//

--- a/llvm/lib/Transforms/Utils/SimplifyIndVar.cpp
+++ b/llvm/lib/Transforms/Utils/SimplifyIndVar.cpp
@@ -2237,16 +2237,13 @@ void WidenIV::calculatePostIncRange(Instruction *NarrowDef,
 
     auto *TrueSuccessor = BI->getSuccessor(0);
     auto *FalseSuccessor = BI->getSuccessor(1);
+    if (TrueSuccessor == FalseSuccessor)
+      continue;
 
-    auto DominatesNarrowUser = [this, NarrowUser] (BasicBlockEdge BBE) {
-      return BBE.isSingleEdge() &&
-             DT->dominates(BBE, NarrowUser->getParent());
-    };
-
-    if (DominatesNarrowUser(BasicBlockEdge(BB, TrueSuccessor)))
+    if (DT->dominates(BasicBlockEdge(BB, TrueSuccessor), NarrowUserBB))
       UpdateRangeFromCondition(BI->getCondition(), /*TrueDest=*/true);
 
-    if (DominatesNarrowUser(BasicBlockEdge(BB, FalseSuccessor)))
+    if (DT->dominates(BasicBlockEdge(BB, FalseSuccessor), NarrowUserBB))
       UpdateRangeFromCondition(BI->getCondition(), /*TrueDest=*/false);
   }
 }

--- a/llvm/lib/Transforms/Utils/SimplifyIndVar.cpp
+++ b/llvm/lib/Transforms/Utils/SimplifyIndVar.cpp
@@ -2237,8 +2237,6 @@ void WidenIV::calculatePostIncRange(Instruction *NarrowDef,
 
     auto *TrueSuccessor = BI->getSuccessor(0);
     auto *FalseSuccessor = BI->getSuccessor(1);
-    if (TrueSuccessor == FalseSuccessor)
-      continue;
 
     if (DT->dominates(BasicBlockEdge(BB, TrueSuccessor), NarrowUserBB))
       UpdateRangeFromCondition(BI->getCondition(), /*TrueDest=*/true);


### PR DESCRIPTION
This was only called on CondBr instructions, where it is always faster to access the successors directly than to use successors().

There is a very [small (hardly measurable) performance improvement](https://llvm-compile-time-tracker.com/compare.php?from=35d9eaa2f27e7e27c6f6636d6f4721dc1e8fc4db&to=6268206207734501c64e3b1fecd86e5d7e138e53&stat=instructions:u) here (it did show up in profiles at 0.03% or so), but I think the main benefit is that it's more obvious what is checked for: degenerate conditional branches.