### PR TITLE
[llvm][DebugInfo] Use formatv instead of format in DebugAbbrev/Addr/ArangeSet

### DIFF
--- a/llvm/lib/DebugInfo/DWARF/DWARFDebugAbbrev.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFDebugAbbrev.cpp
@@ -8,6 +8,7 @@
 
 #include "llvm/DebugInfo/DWARF/DWARFDebugAbbrev.h"
 #include "llvm/Support/Format.h"
+#include "llvm/Support/FormatVariadic.h"
 #include "llvm/Support/raw_ostream.h"
 #include <cinttypes>
 #include <cstdint>
@@ -135,7 +136,7 @@ void DWARFDebugAbbrev::dump(raw_ostream &OS) const {
   }
 
   for (const auto &I : AbbrDeclSets) {
-    OS << format("Abbrev table for offset: 0x%8.8" PRIx64 "\n", I.first);
+    OS << formatv("Abbrev table for offset: {0:x+8}\n", I.first);
     I.second.dump(OS);
   }
 }

--- a/llvm/lib/DebugInfo/DWARF/DWARFDebugAddr.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFDebugAddr.cpp
@@ -10,6 +10,8 @@
 #include "llvm/BinaryFormat/Dwarf.h"
 #include "llvm/DebugInfo/DWARF/DWARFContext.h"
 #include "llvm/Support/Errc.h"
+#include "llvm/Support/FormatAdapters.h"
+#include "llvm/Support/FormatVariadic.h"
 
 using namespace llvm;
 
@@ -135,35 +137,36 @@ Error DWARFDebugAddrTable::extract(const DWARFDataExtractor &Data,
 
 void DWARFDebugAddrTable::dump(raw_ostream &OS, DIDumpOptions DumpOpts) const {
   if (DumpOpts.Verbose)
-    OS << format("0x%8.8" PRIx64 ": ", Offset);
+    OS << formatv("{0:x+8}: ", Offset);
   if (Length) {
     int OffsetDumpWidth = 2 * dwarf::getDwarfOffsetByteSize(Format);
     OS << "Address table header: "
-       << format("length = 0x%0*" PRIx64, OffsetDumpWidth, Length)
+       << formatv("length = 0x{0:x-}",
+                  fmt_align(Length, AlignStyle::Right, OffsetDumpWidth, '0'))
        << ", format = " << dwarf::FormatString(Format)
-       << format(", version = 0x%4.4" PRIx16, Version)
-       << format(", addr_size = 0x%2.2" PRIx8, AddrSize)
-       << format(", seg_size = 0x%2.2" PRIx8, SegSize) << "\n";
+       << formatv(", version = {0:x+4}", Version)
+       << formatv(", addr_size = {0:x+2}", AddrSize)
+       << formatv(", seg_size = {0:x+2}", SegSize) << "\n";
   }
 
   if (Addrs.size() > 0) {
     const char *AddrFmt;
     switch (AddrSize) {
     case 2:
-      AddrFmt = "0x%4.4" PRIx64 "\n";
+      AddrFmt = "{0:x+4}\n";
       break;
     case 4:
-      AddrFmt = "0x%8.8" PRIx64 "\n";
+      AddrFmt = "{0:x+8}\n";
       break;
     case 8:
-      AddrFmt = "0x%16.16" PRIx64 "\n";
+      AddrFmt = "{0:x+16}\n";
       break;
     default:
       llvm_unreachable("unsupported address size");
     }
     OS << "Addrs: [\n";
     for (uint64_t Addr : Addrs)
-      OS << format(AddrFmt, Addr);
+      OS << formatv(AddrFmt, Addr);
     OS << "]\n";
   }
 }

--- a/llvm/lib/DebugInfo/DWARF/DWARFDebugArangeSet.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFDebugArangeSet.cpp
@@ -12,6 +12,8 @@
 #include "llvm/DebugInfo/DWARF/DWARFFormValue.h"
 #include "llvm/Support/Errc.h"
 #include "llvm/Support/Format.h"
+#include "llvm/Support/FormatAdapters.h"
+#include "llvm/Support/FormatVariadic.h"
 #include "llvm/Support/raw_ostream.h"
 #include <cassert>
 #include <cinttypes>
@@ -165,13 +167,16 @@ Error DWARFDebugArangeSet::extract(DWARFDataExtractor data,
 void DWARFDebugArangeSet::dump(raw_ostream &OS) const {
   int OffsetDumpWidth = 2 * dwarf::getDwarfOffsetByteSize(HeaderData.Format);
   OS << "Address Range Header: "
-     << format("length = 0x%0*" PRIx64 ", ", OffsetDumpWidth, HeaderData.Length)
+     << formatv("length = 0x{0:x-}, ",
+                fmt_align(HeaderData.Length, AlignStyle::Right, OffsetDumpWidth,
+                          '0'))
      << "format = " << dwarf::FormatString(HeaderData.Format) << ", "
-     << format("version = 0x%4.4x, ", HeaderData.Version)
-     << format("cu_offset = 0x%0*" PRIx64 ", ", OffsetDumpWidth,
-               HeaderData.CuOffset)
-     << format("addr_size = 0x%2.2x, ", HeaderData.AddrSize)
-     << format("seg_size = 0x%2.2x\n", HeaderData.SegSize);
+     << formatv("version = {0:x+4}, ", HeaderData.Version)
+     << formatv("cu_offset = 0x{0:x-}, ",
+                fmt_align(HeaderData.CuOffset, AlignStyle::Right,
+                          OffsetDumpWidth, '0'))
+     << formatv("addr_size = {0:x+2}, ", HeaderData.AddrSize)
+     << formatv("seg_size = {0:x+2}\n", HeaderData.SegSize);
 
   for (const auto &Desc : ArangeDescriptors) {
     Desc.dump(OS, HeaderData.AddrSize);


### PR DESCRIPTION
This relates to #35980.