### PR TITLE
[DAGCombiner] Use `cannotBeOrderedNegativeFP` in `foldFPToIntToFP`

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
@@ -19460,8 +19460,10 @@ static SDValue foldFPToIntToFP(SDNode *N, const SDLoc &DL, SelectionDAG &DAG,
   bool IsSigned = N->getOpcode() == ISD::SINT_TO_FP;
   assert(IsSigned || IsUnsigned);
 
-  bool IsSignedZeroSafe = DAG.getTarget().Options.NoSignedZerosFPMath ||
-                          DAG.canIgnoreSignBitOfZero(SDValue(N, 0));
+  bool IsSignedZeroSafe =
+      DAG.getTarget().Options.NoSignedZerosFPMath ||
+      DAG.cannotBeOrderedNegativeFP(N->getOperand(0)->getOperand(0)) ||
+      DAG.canIgnoreSignBitOfZero(SDValue(N, 0));
   // For signed conversions: The optimization changes signed zero behavior.
   if (IsSigned && !IsSignedZeroSafe)
     return SDValue();

--- a/llvm/test/CodeGen/AArch64/fp-to-int-to-fp.ll
+++ b/llvm/test/CodeGen/AArch64/fp-to-int-to-fp.ll
@@ -275,6 +275,18 @@ define float @test_fabs(float %x) {
   ret float %abs
 }
 
+define float @test_fabs_nneg(float %x) {
+; CHECK-LABEL: test_fabs_nneg:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    fabs s0, s0
+; CHECK-NEXT:    frintz s0, s0
+; CHECK-NEXT:    ret
+  %nneg = call float @llvm.fabs(float %x)
+  %conv1 = fptosi float %nneg to i32
+  %conv2 = sitofp i32 %conv1 to float
+  ret float %conv2
+}
+
 define float @test_copysign(float %x, float %y) {
 ; CHECK-LABEL: test_copysign:
 ; CHECK:       // %bb.0:


### PR DESCRIPTION
Reluctantly use function attribute directly and `cannotBeOrderedNegativeFP`, because I can't find a good enough solution to get/infer nsz in this situation, see also #83381