### PR TITLE
[libc++] Avoid using ranges::upper_bound in <format>

### DIFF
--- a/libcxx/include/__format/escaped_output_table.h
+++ b/libcxx/include/__format/escaped_output_table.h
@@ -61,9 +61,10 @@
 #ifndef _LIBCPP___FORMAT_ESCAPED_OUTPUT_TABLE_H
 #define _LIBCPP___FORMAT_ESCAPED_OUTPUT_TABLE_H
 
-#include <__algorithm/ranges_upper_bound.h>
+#include <__algorithm/upper_bound.h>
 #include <__config>
 #include <__cstddef/ptrdiff_t.h>
+#include <__iterator/access.h>
 #include <cstdint>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
@@ -868,7 +869,7 @@ _LIBCPP_HIDE_FROM_ABI inline constexpr uint32_t __entries[735] = {
   if (__code_point >= 0x000323b0)
     return true;
 
-  ptrdiff_t __i = std::ranges::upper_bound(__entries, (__code_point << 14) | 0x3fffu) - __entries;
+  ptrdiff_t __i = std::upper_bound(std::begin(__entries), std::end(__entries), (__code_point << 14) | 0x3fffu) - __entries;
   if (__i == 0)
     return false;
 

--- a/libcxx/utils/generate_escaped_output_table.py
+++ b/libcxx/utils/generate_escaped_output_table.py
@@ -142,7 +142,7 @@ _LIBCPP_HIDE_FROM_ABI inline constexpr uint32_t __entries[{size}] = {{
   if (__code_point >= 0x{unallocated:08x})
     return true;
 
-  ptrdiff_t __i = std::ranges::upper_bound(__entries, (__code_point << 14) | 0x3fffu) - __entries;
+  ptrdiff_t __i = std::upper_bound(std::begin(__entries), std::end(__entries), (__code_point << 14) | 0x3fffu) - __entries;
   if (__i == 0)
     return false;
 
@@ -216,9 +216,10 @@ TABLES_HPP_TEMPLATE = """
 #ifndef _LIBCPP___FORMAT_ESCAPED_OUTPUT_TABLE_H
 #define _LIBCPP___FORMAT_ESCAPED_OUTPUT_TABLE_H
 
-#include <__algorithm/ranges_upper_bound.h>
+#include <__algorithm/upper_bound.h>
 #include <__config>
 #include <__cstddef/ptrdiff_t.h>
+#include <__iterator/access.h>
 #include <cstdint>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)


### PR DESCRIPTION
The `ranges` algorithms take a significant time to instantiate. Replacing `ranges::upper_bound` with `std::upper_bound` reduces the time to parse `<format>` by ~50ms, or 10%.
