### PR TITLE
[lldb][Module] Remove feedback_stream parameter from LoadScriptingResources

### DIFF
--- a/lldb/include/lldb/Core/Module.h
+++ b/lldb/include/lldb/Core/Module.h
@@ -510,8 +510,7 @@ public:
   ///     \b true if it is, \b false otherwise.
   bool IsLoadedInTarget(Target *target);
 
-  bool LoadScriptingResourceInTarget(Target *target, Status &error,
-                                     Stream &feedback_stream);
+  bool LoadScriptingResourceInTarget(Target *target, Status &error);
 
   /// Get the number of compile units for this module.
   ///

--- a/lldb/include/lldb/Core/ModuleList.h
+++ b/lldb/include/lldb/Core/ModuleList.h
@@ -488,7 +488,6 @@ public:
   bool IsEmpty() const { return !GetSize(); }
 
   bool LoadScriptingResourcesInTarget(Target *target, std::list<Status> &errors,
-                                      Stream &feedback_stream,
                                       bool continue_on_error = true);
 
   static ModuleListProperties &GetGlobalModuleListProperties();

--- a/lldb/include/lldb/Target/Target.h
+++ b/lldb/include/lldb/Target/Target.h
@@ -1115,10 +1115,9 @@ public:
       LoadDependentFiles load_dependent_files = eLoadDependentsDefault);
 
   bool LoadScriptingResources(std::list<Status> &errors,
-                              Stream &feedback_stream,
                               bool continue_on_error = true) {
-    return m_images.LoadScriptingResourcesInTarget(
-        this, errors, feedback_stream, continue_on_error);
+    return m_images.LoadScriptingResourcesInTarget(this, errors,
+                                                   continue_on_error);
   }
 
   /// Get accessor for the images for this process.

--- a/lldb/source/Commands/CommandObjectTarget.cpp
+++ b/lldb/source/Commands/CommandObjectTarget.cpp
@@ -4402,9 +4402,7 @@ protected:
           // Make sure we load any scripting resources that may be embedded
           // in the debug info files in case the platform supports that.
           Status error;
-          StreamString feedback_stream;
-          module_sp->LoadScriptingResourceInTarget(target, error,
-                                                   feedback_stream);
+          module_sp->LoadScriptingResourceInTarget(target, error);
           if (error.Fail() && error.AsCString())
             result.AppendWarningWithFormat(
                 "unable to load scripting data for module %s - error "
@@ -4413,8 +4411,6 @@ protected:
                     .GetFileNameStrippingExtension()
                     .GetCString(),
                 error.AsCString());
-          else if (feedback_stream.GetSize())
-            result.AppendWarning(feedback_stream.GetData());
 
           flush = true;
           result.SetStatus(eReturnStatusSuccessFinishResult);

--- a/lldb/source/Core/Debugger.cpp
+++ b/lldb/source/Core/Debugger.cpp
@@ -307,13 +307,10 @@ Status Debugger::SetPropertyValue(const ExecutionContext *exe_ctx,
       if (target_sp->TargetProperties::GetLoadScriptFromSymbolFile() ==
           eLoadScriptFromSymFileTrue) {
         std::list<Status> errors;
-        StreamString feedback_stream;
-        if (!target_sp->LoadScriptingResources(errors, feedback_stream)) {
+        if (!target_sp->LoadScriptingResources(errors)) {
           lldb::StreamUP s = GetAsyncErrorStream();
           for (auto &error : errors)
             s->Printf("%s\n", error.AsCString());
-          if (feedback_stream.GetSize())
-            s->PutCString(feedback_stream.GetString());
         }
       }
     }

--- a/lldb/source/Core/Module.cpp
+++ b/lldb/source/Core/Module.cpp
@@ -1423,8 +1423,7 @@ bool Module::IsLoadedInTarget(Target *target) {
   return false;
 }
 
-bool Module::LoadScriptingResourceInTarget(Target *target, Status &error,
-                                           Stream &feedback_stream) {
+bool Module::LoadScriptingResourceInTarget(Target *target, Status &error) {
   if (!target) {
     error = Status::FromErrorString("invalid destination Target");
     return false;
@@ -1448,8 +1447,12 @@ bool Module::LoadScriptingResourceInTarget(Target *target, Status &error,
     return false;
   }
 
+  StreamString feedback_stream;
   FileSpecList file_specs = platform_sp->LocateExecutableScriptingResources(
       target, *this, feedback_stream);
+
+  if (!feedback_stream.Empty())
+    debugger.ReportWarning(feedback_stream.GetString().str(), debugger.GetID());
 
   const uint32_t num_specs = file_specs.GetSize();
   if (num_specs == 0)
@@ -1467,8 +1470,9 @@ bool Module::LoadScriptingResourceInTarget(Target *target, Status &error,
       continue;
 
     if (should_load == eLoadScriptFromSymFileWarn) {
-      feedback_stream.Format(R"(
-warning: '{0}' contains a debug script. To run this script in this debug session:
+      debugger.ReportWarning(
+          llvm::formatv(
+              R"('{0}' contains a debug script. To run this script in this debug session:
 
     command script import "{1}"
 
@@ -1476,8 +1480,9 @@ To run all discovered debug scripts in this session:
 
     settings set target.load-script-from-symbol-file true
 )",
-                             GetFileSpec().GetFileNameStrippingExtension(),
-                             scripting_fspec.GetPath());
+              GetFileSpec().GetFileNameStrippingExtension(),
+              scripting_fspec.GetPath()),
+          debugger.GetID());
 
       return false;
     }

--- a/lldb/source/Core/Module.cpp
+++ b/lldb/source/Core/Module.cpp
@@ -1470,9 +1470,10 @@ bool Module::LoadScriptingResourceInTarget(Target *target, Status &error) {
       continue;
 
     if (should_load == eLoadScriptFromSymFileWarn) {
+      // clang-format off
       debugger.ReportWarning(
           llvm::formatv(
-              R"('{0}' contains a debug script. To run this script in this debug session:
+R"('{0}' contains a debug script. To run this script in this debug session:
 
     command script import "{1}"
 
@@ -1483,6 +1484,7 @@ To run all discovered debug scripts in this session:
               GetFileSpec().GetFileNameStrippingExtension(),
               scripting_fspec.GetPath()),
           debugger.GetID());
+      // clang-format on
 
       return false;
     }

--- a/lldb/source/Core/ModuleList.cpp
+++ b/lldb/source/Core/ModuleList.cpp
@@ -1335,7 +1335,6 @@ bool ModuleList::RemoveSharedModuleIfOrphaned(const ModuleWP module_wp) {
 
 bool ModuleList::LoadScriptingResourcesInTarget(Target *target,
                                                 std::list<Status> &errors,
-                                                Stream &feedback_stream,
                                                 bool continue_on_error) {
   if (!target)
     return false;
@@ -1349,8 +1348,7 @@ bool ModuleList::LoadScriptingResourcesInTarget(Target *target,
   for (auto module : tmp_module_list.ModulesNoLocking()) {
     if (module) {
       Status error;
-      if (!module->LoadScriptingResourceInTarget(target, error,
-                                                 feedback_stream)) {
+      if (!module->LoadScriptingResourceInTarget(target, error)) {
         if (error.Fail() && error.AsCString()) {
           error = Status::FromErrorStringWithFormat(
               "unable to load scripting data for "

--- a/lldb/source/Plugins/Platform/MacOSX/PlatformDarwin.cpp
+++ b/lldb/source/Plugins/Platform/MacOSX/PlatformDarwin.cpp
@@ -287,7 +287,7 @@ FileSpecList PlatformDarwin::LocateExecutableScriptingResourcesFromDSYM(
                                              : "contains reserved characters";
       if (FileSystem::Instance().Exists(script_fspec))
         feedback_stream.Format(
-            "warning: the symbol file '{0}' contains a debug "
+            "the symbol file '{0}' contains a debug "
             "script. However, its name"
             " '{1}' {2} and as such cannot be loaded. LLDB will"
             " load '{3}' instead. Consider removing the file with "
@@ -297,7 +297,7 @@ FileSpecList PlatformDarwin::LocateExecutableScriptingResourcesFromDSYM(
             reason_for_complaint, path_string.GetString());
       else
         feedback_stream.Format(
-            "warning: the symbol file '{0}' contains a debug "
+            "the symbol file '{0}' contains a debug "
             "script. However, its name"
             " {1} and as such cannot be loaded. If you intend"
             " to have this script loaded, please rename '{2}' to "

--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -1545,9 +1545,7 @@ Module *Target::GetExecutableModulePointer() {
 static void LoadScriptingResourceForModule(const ModuleSP &module_sp,
                                            Target *target) {
   Status error;
-  StreamString feedback_stream;
-  if (module_sp && !module_sp->LoadScriptingResourceInTarget(target, error,
-                                                             feedback_stream)) {
+  if (module_sp && !module_sp->LoadScriptingResourceInTarget(target, error)) {
     if (error.AsCString())
       target->GetDebugger().GetAsyncErrorStream()->Printf(
           "unable to load scripting data for module %s - error reported was "
@@ -1555,9 +1553,6 @@ static void LoadScriptingResourceForModule(const ModuleSP &module_sp,
           module_sp->GetFileSpec().GetFileNameStrippingExtension().GetCString(),
           error.AsCString());
   }
-  if (feedback_stream.GetSize())
-    target->GetDebugger().GetAsyncErrorStream()->Printf(
-        "%s\n", feedback_stream.GetData());
 }
 
 void Target::ClearModules(bool delete_locations) {

--- a/lldb/test/Shell/Platform/AutoLoad/Darwin/dsym-python-script-name-warnings.test
+++ b/lldb/test/Shell/Platform/AutoLoad/Darwin/dsym-python-script-name-warnings.test
@@ -31,8 +31,8 @@
 # CHECK-REMOVE:      warning: the symbol file {{.*}} contains reserved characters
 # CHECK-REMOVE-SAME: Consider removing the file with the malformed name to eliminate this warning
 
-## Also confirm that the warning message about loading auto-loading scripts is printed
-## afterwards.
+## Also confirm that the warning message about auto-loading scripts is printed afterwards.
+
 # CHECK-REMOVE: warning: 'Test-Module2' contains a debug script. To run this script in this
 
 #--- main.c

--- a/lldb/test/Shell/Platform/AutoLoad/Darwin/dsym-python-script-name-warnings.test
+++ b/lldb/test/Shell/Platform/AutoLoad/Darwin/dsym-python-script-name-warnings.test
@@ -1,0 +1,39 @@
+# REQUIRES: python, system-darwin
+
+# Tests that LLDB prints warning messages that occur while locating scripts in dSYMs.
+
+# RUN: split-file %s %t
+
+## Module name contains reserved characters but no script with a corrected
+## name exists.
+
+# RUN: %clang_host -g %t/main.c -o "%t/Test-Module.out"
+# RUN: mkdir -p "%t/Test-Module.out.dSYM/Contents/Resources/Python"
+# RUN: touch "%t/Test-Module.out.dSYM/Contents/Resources/Python/Test-Module.py"
+# RUN: %lldb -b \
+# RUN:   -o 'target create "%t/Test-Module.out"' 2>&1 \
+# RUN:   | FileCheck %s --check-prefix=CHECK-RENAME
+
+# CHECK-RENAME:      warning: the symbol file {{.*}} contains reserved characters
+# CHECK-RENAME-SAME: If you intend to have this script loaded, please rename
+
+## Module name contains reserved characters but a script with a corrected
+## name does exists.
+
+# RUN: %clang_host -g %t/main.c -o "%t/Test-Module2.out"
+# RUN: mkdir -p "%t/Test-Module2.out.dSYM/Contents/Resources/Python"
+# RUN: touch "%t/Test-Module2.out.dSYM/Contents/Resources/Python/Test_Module2.py"
+# RUN: touch "%t/Test-Module2.out.dSYM/Contents/Resources/Python/Test-Module2.py"
+# RUN: %lldb -b \
+# RUN:   -o 'target create "%t/Test-Module2.out"' 2>&1 \
+# RUN:   | FileCheck %s --check-prefix=CHECK-REMOVE
+
+# CHECK-REMOVE:      warning: the symbol file {{.*}} contains reserved characters
+# CHECK-REMOVE-SAME: Consider removing the file with the malformed name to eliminate this warning
+
+## Also confirm that the warning message about loading auto-loading scripts is printed
+## afterwards.
+# CHECK-REMOVE: warning: 'Test-Module2' contains a debug script. To run this script in this
+
+#--- main.c
+int main() { return 0; }

--- a/lldb/unittests/Platform/PlatformDarwinTest.cpp
+++ b/lldb/unittests/Platform/PlatformDarwinTest.cpp
@@ -354,7 +354,7 @@ TEST_F(PlatformDarwinLocateTest,
   std::string fixed_script =
       (m_tmp_dsym_dwarf_dir + "/../Python/_import.py").str();
   std::string expected = llvm::formatv(
-      "warning: the symbol file '{0}' contains a debug script. However, its "
+      "the symbol file '{0}' contains a debug script. However, its "
       "name conflicts with a keyword and as such cannot be loaded. If you "
       "intend to have this script loaded, please rename '{1}' to '{2}' and "
       "retry.\n",
@@ -394,7 +394,7 @@ TEST_F(PlatformDarwinLocateTest,
   std::string fixed_script =
       (m_tmp_dsym_dwarf_dir + "/../Python/_import.py").str();
   std::string expected = llvm::formatv(
-      "warning: the symbol file '{0}' contains a debug script. However, its "
+      "the symbol file '{0}' contains a debug script. However, its "
       "name '{1}' conflicts with a keyword and as such cannot be loaded. LLDB "
       "will load '{2}' instead. Consider removing the file with the malformed "
       "name to eliminate this warning.\n",
@@ -461,7 +461,7 @@ TEST_F(
   std::string fixed_script =
       (m_tmp_dsym_dwarf_dir + "/../Python/TestModule_1_1_1.py").str();
   std::string expected = llvm::formatv(
-      "warning: the symbol file '{0}' contains a debug script. However, its "
+      "the symbol file '{0}' contains a debug script. However, its "
       "name contains reserved characters and as such cannot be loaded. If you "
       "intend to have this script loaded, please rename '{1}' to '{2}' and "
       "retry.\n",
@@ -502,7 +502,7 @@ TEST_F(
   std::string fixed_script =
       (m_tmp_dsym_dwarf_dir + "/../Python/TestModule_1_1_1.py").str();
   std::string expected = llvm::formatv(
-      "warning: the symbol file '{0}' contains a debug script. However, its "
+      "the symbol file '{0}' contains a debug script. However, its "
       "name '{1}' contains reserved characters and as such cannot be loaded. "
       "LLDB will load '{2}' instead. Consider removing the file with the "
       "malformed name to eliminate this warning.\n",


### PR DESCRIPTION
I'm in the process of making `LoadScriptingResources` interactively ask a user whether to load a script. I'd like to turn the existing warning into the prompt. The simplest way to achieve this is to not print into a `feedback_stream` parameter, and instead create a prompt right there. This patch removes the `feedback_stream` parameter and emits a `ReportWarning` instead. If we get around to adding the prompt instead of the warning, those changes will be simpler to review. But even if we don't end up replacing the warning with a prompt, moving away from output parameters and towards more structured error reporting is a nice-to-have (e.g., the `warning` prefix is now colored, IDEs have more flexibility on how to present the warning, etc.).

For a command-line user nothing should change with this patch (apart from `warning:` being highlighted).