### PR TITLE
[IR][NFC] Inline CmpInst::isSigned/isUnsigned

### DIFF
--- a/llvm/include/llvm/IR/InstrTypes.h
+++ b/llvm/include/llvm/IR/InstrTypes.h
@@ -951,11 +951,15 @@ public:
 
   /// @returns true if the predicate is unsigned, false otherwise.
   /// Determine if the predicate is an unsigned operation.
-  LLVM_ABI static bool isUnsigned(Predicate predicate);
+  static bool isUnsigned(Predicate Pred) {
+    return Pred >= ICMP_UGT && Pred <= ICMP_ULE;
+  }
 
   /// @returns true if the predicate is signed, false otherwise.
   /// Determine if the predicate is an signed operation.
-  LLVM_ABI static bool isSigned(Predicate predicate);
+  static bool isSigned(Predicate Pred) {
+    return Pred >= ICMP_SGT && Pred <= ICMP_SLE;
+  }
 
   /// Determine if the predicate is an ordered operation.
   LLVM_ABI static bool isOrdered(Predicate predicate);

--- a/llvm/lib/IR/Instructions.cpp
+++ b/llvm/lib/IR/Instructions.cpp
@@ -3809,22 +3809,6 @@ CmpInst::Predicate CmpInst::getFlippedStrictnessPredicate(Predicate pred) {
   llvm_unreachable("Unknown predicate!");
 }
 
-bool CmpInst::isUnsigned(Predicate predicate) {
-  switch (predicate) {
-    default: return false;
-    case ICmpInst::ICMP_ULT: case ICmpInst::ICMP_ULE: case ICmpInst::ICMP_UGT:
-    case ICmpInst::ICMP_UGE: return true;
-  }
-}
-
-bool CmpInst::isSigned(Predicate predicate) {
-  switch (predicate) {
-    default: return false;
-    case ICmpInst::ICMP_SLT: case ICmpInst::ICMP_SLE: case ICmpInst::ICMP_SGT:
-    case ICmpInst::ICMP_SGE: return true;
-  }
-}
-
 bool ICmpInst::compare(const APInt &LHS, const APInt &RHS,
                        ICmpInst::Predicate Pred) {
   assert(ICmpInst::isIntPredicate(Pred) && "Only for integer predicates!");


### PR DESCRIPTION
These are small helper functions that are called somewhat often, so inlining is beneficial.

A very minor [improvement](http://llvm-compile-time-tracker.com/compare.php?from=6268206207734501c64e3b1fecd86e5d7e138e53&to=ae64c4e96db271c42943a43e834ef4fa6782bc77&stat=instructions:u). Nonetheless, these two functions are called somewhat regularly and compile to three instructions each, so it is always beneficial to inline them.