### PR TITLE
[CIR] Make the -save-temps flag emit .cir and .mlir files

### DIFF
--- a/clang/include/clang/CIR/LowerToLLVM.h
+++ b/clang/include/clang/CIR/LowerToLLVM.h
@@ -12,6 +12,7 @@
 #ifndef CLANG_CIR_LOWERTOLLVM_H
 #define CLANG_CIR_LOWERTOLLVM_H
 
+#include "llvm/ADT/StringRef.h"
 #include <memory>
 
 namespace llvm {
@@ -28,7 +29,8 @@ namespace cir {
 namespace direct {
 std::unique_ptr<llvm::Module>
 lowerDirectlyFromCIRToLLVMIR(mlir::ModuleOp mlirModule,
-                             llvm::LLVMContext &llvmCtx);
+                             llvm::LLVMContext &llvmCtx,
+                             llvm::StringRef mlirSaveTempsOutFile = {});
 } // namespace direct
 } // namespace cir
 

--- a/clang/lib/CIR/FrontendAction/CIRGenAction.cpp
+++ b/clang/lib/CIR/FrontendAction/CIRGenAction.cpp
@@ -15,7 +15,10 @@
 #include "clang/CIR/LowerToLLVM.h"
 #include "clang/CodeGen/BackendUtil.h"
 #include "clang/Frontend/CompilerInstance.h"
+#include "llvm/ADT/SmallString.h"
 #include "llvm/IR/Module.h"
+#include "llvm/Support/Path.h"
+#include "llvm/Support/raw_ostream.h"
 
 using namespace cir;
 using namespace clang;
@@ -44,8 +47,10 @@ getBackendActionFromOutputType(CIRGenAction::OutputType Action) {
 }
 
 static std::unique_ptr<llvm::Module>
-lowerFromCIRToLLVMIR(mlir::ModuleOp MLIRModule, llvm::LLVMContext &LLVMCtx) {
-  return direct::lowerDirectlyFromCIRToLLVMIR(MLIRModule, LLVMCtx);
+lowerFromCIRToLLVMIR(mlir::ModuleOp MLIRModule, llvm::LLVMContext &LLVMCtx,
+                     llvm::StringRef mlirSaveTempsOutFile = {}) {
+  return direct::lowerDirectlyFromCIRToLLVMIR(MLIRModule, LLVMCtx,
+                                              mlirSaveTempsOutFile);
 }
 
 class CIRGenConsumer : public clang::ASTConsumer {
@@ -136,9 +141,26 @@ public:
     case CIRGenAction::OutputType::EmitBC:
     case CIRGenAction::OutputType::EmitObj:
     case CIRGenAction::OutputType::EmitAssembly: {
+      StringRef saveTempsPrefix = CGO.SaveTempsFilePrefix;
+      std::string cirSaveTempsOutFile, mlirSaveTempsOutFile;
+      if (!saveTempsPrefix.empty()) {
+        SmallString<128> stem(saveTempsPrefix);
+        llvm::sys::path::replace_extension(stem, "cir");
+        cirSaveTempsOutFile = std::string(stem);
+        llvm::sys::path::replace_extension(stem, "mlir");
+        mlirSaveTempsOutFile = std::string(stem);
+      }
+
+      if (!cirSaveTempsOutFile.empty()) {
+        std::error_code ec;
+        llvm::raw_fd_ostream out(cirSaveTempsOutFile, ec);
+        if (!ec)
+          MlirModule->print(out);
+      }
+
       llvm::LLVMContext LLVMCtx;
       std::unique_ptr<llvm::Module> LLVMModule =
-          lowerFromCIRToLLVMIR(MlirModule, LLVMCtx);
+          lowerFromCIRToLLVMIR(MlirModule, LLVMCtx, mlirSaveTempsOutFile);
 
       BackendAction BEAction = getBackendActionFromOutputType(Action);
       emitBackendOutput(

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -46,6 +46,7 @@
 #include "llvm/Support/Casting.h"
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/TimeProfiler.h"
+#include "llvm/Support/raw_ostream.h"
 
 using namespace cir;
 using namespace llvm;
@@ -4926,7 +4927,8 @@ void populateCIRToLLVMPasses(mlir::OpPassManager &pm) {
 }
 
 std::unique_ptr<llvm::Module>
-lowerDirectlyFromCIRToLLVMIR(mlir::ModuleOp mlirModule, LLVMContext &llvmCtx) {
+lowerDirectlyFromCIRToLLVMIR(mlir::ModuleOp mlirModule, LLVMContext &llvmCtx,
+                             StringRef mlirSaveTempsOutFile) {
   llvm::TimeTraceScope scope("lower from CIR to LLVM directly");
 
   mlir::MLIRContext *mlirCtx = mlirModule.getContext();
@@ -4940,6 +4942,13 @@ lowerDirectlyFromCIRToLLVMIR(mlir::ModuleOp mlirModule, LLVMContext &llvmCtx) {
     // FIXME: Handle any errors where they occurs and return a nullptr here.
     report_fatal_error(
         "The pass manager failed to lower CIR to LLVMIR dialect!");
+  }
+
+  if (!mlirSaveTempsOutFile.empty()) {
+    std::error_code ec;
+    llvm::raw_fd_ostream out(mlirSaveTempsOutFile, ec);
+    if (!ec)
+      mlirModule->print(out);
   }
 
   mlir::registerBuiltinDialectTranslation(*mlirCtx);

--- a/clang/test/CIR/CodeGen/save-temps.c
+++ b/clang/test/CIR/CodeGen/save-temps.c
@@ -1,0 +1,20 @@
+// Test that -save-temps with -fclangir emits .cir and .mlir intermediate files.
+
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm \
+// RUN:   -save-temps=obj -o %t.ll %s
+
+// Check that the .cir file was created and contains CIR dialect ops
+// RUN: FileCheck --input-file=%t.cir %s --check-prefix=CIR
+
+// CIR: cir.func
+// CIR: cir.return
+
+// Check that the .mlir file was created and contains LLVM dialect ops
+// RUN: FileCheck --input-file=%t.mlir %s --check-prefix=MLIR
+
+// MLIR: llvm.func
+// MLIR: llvm.return
+
+int foo(int x) {
+  return x + 1;
+}


### PR DESCRIPTION
This patch makes ClangIR emit .cir and .mlir files when the-save-temps flag is specified. Having these files emitted is useful e.g. when inspecting the generated code for OpenMP offloading.

Co-authored-by: Claude Opus 4.6 noreply@anthropic.com