### PR TITLE
[clang][bytecode][NFC] Add Function::dump() taking no arguments

### DIFF
--- a/clang/lib/AST/ByteCode/Function.h
+++ b/clang/lib/AST/ByteCode/Function.h
@@ -327,7 +327,8 @@ private:
 
 public:
   /// Dumps the disassembled bytecode to \c llvm::errs().
-  void dump(CodePtr PC = {}) const;
+  void dump() const { dump({}); }
+  void dump(CodePtr PC) const;
   void dump(llvm::raw_ostream &OS, CodePtr PC = {}) const;
 };
 


### PR DESCRIPTION
Instead of relying on the default value. That one doesn't work properly in lldb and I have to pass the `{}` explicitly every time.