### PR TITLE
[clang][Driver][SPIRV] Fix assertion when using -emit-llvm

### DIFF
--- a/clang/lib/Driver/ToolChains/SPIRV.cpp
+++ b/clang/lib/Driver/ToolChains/SPIRV.cpp
@@ -83,8 +83,22 @@ void SPIRV::constructLLVMLinkCommand(Compilation &C, const Tool &T,
 
   ArgStringList LlvmLinkArgs;
 
-  for (auto Input : Inputs)
-    LlvmLinkArgs.push_back(Input.getFilename());
+  for (auto Input : Inputs) {
+    if (Input.isFilename()) {
+      LlvmLinkArgs.push_back(Input.getFilename());
+    } else {
+      // Warn that any linker arguments will be dropped.
+      assert(Input.isInputArg() && "Unexpected linker input");
+      const llvm::opt::Arg &LinkerOpt = Input.getInputArg();
+      std::string LinkerOptStr = LinkerOpt.getAsString(Args);
+      const llvm::opt::Arg *EmitLLVM = Args.getLastArg(options::OPT_emit_llvm);
+      assert(EmitLLVM && "Unexpected linker input");
+      std::string EmitLLVMStr = EmitLLVM ? EmitLLVM->getAsString(Args) : "";
+      llvm::Triple Triple(T.getToolChain().getTriple());
+      C.getDriver().Diag(clang::diag::warn_drv_input_file_unused)
+          << Triple.getTriple() << LinkerOptStr << false << EmitLLVMStr;
+    }
+  }
 
   tools::constructLLVMLinkCommand(C, T, JA, Inputs, LlvmLinkArgs, Output, Args);
 }

--- a/clang/test/Driver/spirv-llvm-link.c
+++ b/clang/test/Driver/spirv-llvm-link.c
@@ -31,3 +31,6 @@
 // CHECK-BINDINGS-SRC: "spirv64" - "clang", inputs: ["{{.*}}foo.c"], output: "[[TMP1_BINDINGS_SRC_BC:.+]]"
 // CHECK-BINDINGS-SRC: "spirv64" - "clang", inputs: ["{{.*}}bar.c"], output: "[[TMP2_BINDINGS_SRC_BC:.+]]"
 // CHECK-BINDINGS-SRC: "spirv64" - "SPIR-V::Linker", inputs: ["[[TMP1_BINDINGS_SRC_BC]]", "[[TMP2_BINDINGS_SRC_BC]]"], output: "{{.*}}.bc"
+
+// RUN: %clang -### --target=spirv64 -emit-llvm %t/a.bc %t/b.bc -Wl,-O1 2>&1 | FileCheck --check-prefix=CHECK-WARN %s
+// CHECK-WARN: warning: spirv64: '-Wl,-O1' input unused when '-emit-llvm' is present


### PR DESCRIPTION
In the failing case we are in the link phase with `-emit-llvm` passed, which means we are going to call `llvm-link` so all inputs are expected to be `.bc` files, and linker options aren't supported as we aren't calling a real linker.

I can't imagine anyone wants to pass arguments to `llvm-link`. Just drop them and warn instead of asserting.

Closes: https://github.com/llvm/llvm-project/issues/186598