### PR TITLE
[LV] Add select instruction to VPReplicateRecipe::computeCost

### DIFF
--- a/llvm/lib/Transforms/Vectorize/VPlanRecipes.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanRecipes.cpp
@@ -3603,6 +3603,7 @@ InstructionCost VPReplicateRecipe::computeCost(ElementCount VF,
   case Instruction::UIToFP:
   case Instruction::Trunc:
   case Instruction::FPTrunc:
+  case Instruction::Select:
   case Instruction::AddrSpaceCast: {
     return getCostForRecipeWithOpcode(getOpcode(), ElementCount::getFixed(1),
                                       Ctx) *

--- a/llvm/lib/Transforms/Vectorize/VPlanRecipes.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanRecipes.cpp
@@ -1099,7 +1099,7 @@ InstructionCost VPRecipeWithIRFlags::getCostForRecipeWithOpcode(
     }
 
     Type *CondTy = Ctx.Types.inferScalarType(getOperand(0));
-    if (!IsScalarCond)
+    if (!IsScalarCond && VF.isVector())
       CondTy = VectorType::get(CondTy, VF);
 
     llvm::CmpPredicate Pred;


### PR DESCRIPTION
I've added the Instruction::Select opcode to the existing list of opcodes that call getCostForRecipeWithOpcode. There are currently 5 tests that ask for the cost of the select:

  Transforms/LoopVectorize/AArch64/widen-gep-all-indices-invariant.ll
  Transforms/LoopVectorize/first-order-recurrence-with-uniform-ops.ll
  Transforms/LoopVectorize/narrow-to-single-scalar.ll
  Transforms/LoopVectorize/replicate_fneg.ll
  Transforms/LoopVectorize/single-scalar-cast-minbw.ll

The fact they all pass with this change is hopefully proof enough that the costs are correct. However, in general I think we rarely execute VPReplicateRecipe::computeCost for instructions in the vector loop due to LoopVectorizationPlanner::precomputeCosts forcing us to use the legacy costs instead. This does help to stop the legacy/vplan cost model assert firing, but doesn't help with it's eventual removal. I intend to follow up with more PRs to remove these pre-computed costs because otherwise the replicate cost model will just end up being dead code.