### PR TITLE
[mlir][EmitC] Support pointer-based memrefs in load/store lowering

### DIFF
--- a/mlir/lib/Conversion/MemRefToEmitC/MemRefToEmitC.cpp
+++ b/mlir/lib/Conversion/MemRefToEmitC/MemRefToEmitC.cpp
@@ -140,38 +140,35 @@ createPointerFromEmitcArray(Location loc, OpBuilder &builder,
   return ptr;
 }
 
+// If `v` is defined through an unrealized cast and the source of that cast
+// is `emitc.ptr`, return the pointer.
 static Value stripPointerUnrealizedCast(Value v) {
   if (auto cast = v.getDefiningOp<UnrealizedConversionCastOp>())
     if (cast.getNumOperands() == 1 &&
         isa<emitc::PointerType>(cast.getOperand(0).getType()))
-      return cast.getOperand(0); // Pointer path
-  return Value();                // Array path
+      return cast.getOperand(0);
+  return Value();
 }
 
-static Value computeRowMajorLinearIndex(Location loc, MemRefType memrefType,
-                                        ValueRange indices,
-                                        OpBuilder &builder) {
+static Value computeRowMajorLinearIndex(ImplicitLocOpBuilder &builder,
+                                        MemRefType memrefType,
+                                        ValueRange indices) {
   ArrayRef<int64_t> shape = memrefType.getShape();
 
   Type idxType =
       indices.empty() ? builder.getIndexType() : indices[0].getType();
 
-  Value linearIndex = indices.empty()
-                          ? emitc::ConstantOp::create(builder, loc, idxType,
-                                                      builder.getIndexAttr(0))
-                          : indices[0];
+  Value linearIndex =
+      indices.empty()
+          ? emitc::ConstantOp::create(builder, idxType, builder.getIndexAttr(0))
+          : indices[0];
 
-  for (size_t i = 1; i < shape.size(); ++i) {
-    Value dimSize = emitc::ConstantOp::create(builder, loc, idxType,
-                                              builder.getIndexAttr(shape[i]));
-
-    linearIndex =
-        emitc::MulOp::create(builder, loc, idxType, linearIndex, dimSize);
-
-    linearIndex =
-        emitc::AddOp::create(builder, loc, idxType, linearIndex, indices[i]);
+  for (auto [dim, idx] : llvm::zip(shape.drop_front(), indices.drop_front())) {
+    Value dimSize =
+        emitc::ConstantOp::create(builder, idxType, builder.getIndexAttr(dim));
+    linearIndex = emitc::MulOp::create(builder, idxType, linearIndex, dimSize);
+    linearIndex = emitc::AddOp::create(builder, idxType, linearIndex, idx);
   }
-
   return linearIndex;
 }
 
@@ -374,40 +371,36 @@ struct ConvertLoad final : public OpConversionPattern<memref::LoadOp> {
   LogicalResult
   matchAndRewrite(memref::LoadOp op, OpAdaptor operands,
                   ConversionPatternRewriter &rewriter) const override {
-
+    Location loc = op.getLoc();
     auto resultTy = getTypeConverter()->convertType(op.getType());
     if (!resultTy) {
-      return rewriter.notifyMatchFailure(op.getLoc(), "cannot convert type");
+      return rewriter.notifyMatchFailure(loc, "cannot convert type");
     }
 
     auto arrayValue =
         dyn_cast<TypedValue<emitc::ArrayType>>(operands.getMemref());
     Value strippedPtr = stripPointerUnrealizedCast(operands.getMemref());
     if (!strippedPtr && arrayValue) {
-      auto subscript = emitc::SubscriptOp::create(
-          rewriter, op.getLoc(), arrayValue, operands.getIndices());
+      auto subscript = emitc::SubscriptOp::create(rewriter, loc, arrayValue,
+                                                  operands.getIndices());
 
       rewriter.replaceOpWithNewOp<emitc::LoadOp>(op, resultTy, subscript);
       return success();
     }
-    if (strippedPtr) {
-      Location loc = op.getLoc();
-      MemRefType opMemrefType = cast<MemRefType>(op.getMemref().getType());
-      ValueRange indices = operands.getIndices();
 
-      // Compute row-major linear index
-      Value linearIndex =
-          computeRowMajorLinearIndex(loc, opMemrefType, indices, rewriter);
+    if (!strippedPtr)
+      return rewriter.notifyMatchFailure(loc, "expected array or pointer type");
+    MemRefType opMemrefType = cast<MemRefType>(op.getMemref().getType());
+    ValueRange indices = operands.getIndices();
 
-      auto typedPtr = cast<TypedValue<emitc::PointerType>>(strippedPtr);
-      auto subscript = emitc::SubscriptOp::create(rewriter, op.getLoc(),
-                                                  typedPtr, linearIndex);
+    ImplicitLocOpBuilder b(loc, rewriter);
+    Value linearIndex = computeRowMajorLinearIndex(b, opMemrefType, indices);
+    auto typedPtr = cast<TypedValue<emitc::PointerType>>(strippedPtr);
+    auto subscript =
+        emitc::SubscriptOp::create(rewriter, loc, typedPtr, linearIndex);
 
-      rewriter.replaceOpWithNewOp<emitc::LoadOp>(op, resultTy, subscript);
-      return success();
-    }
-    return rewriter.notifyMatchFailure(op.getLoc(),
-                                       "expected array or pointer type");
+    rewriter.replaceOpWithNewOp<emitc::LoadOp>(op, resultTy, subscript);
+    return success();
   }
 };
 
@@ -417,35 +410,32 @@ struct ConvertStore final : public OpConversionPattern<memref::StoreOp> {
   LogicalResult
   matchAndRewrite(memref::StoreOp op, OpAdaptor operands,
                   ConversionPatternRewriter &rewriter) const override {
+    Location loc = op.getLoc();
     auto arrayValue =
         dyn_cast<TypedValue<emitc::ArrayType>>(operands.getMemref());
     Value strippedPtr = stripPointerUnrealizedCast(operands.getMemref());
     if (!strippedPtr && arrayValue) {
-      auto subscript = emitc::SubscriptOp::create(
-          rewriter, op.getLoc(), arrayValue, operands.getIndices());
+      auto subscript = emitc::SubscriptOp::create(rewriter, loc, arrayValue,
+                                                  operands.getIndices());
       rewriter.replaceOpWithNewOp<emitc::AssignOp>(op, subscript,
                                                    operands.getValue());
       return success();
     }
 
-    if (strippedPtr) {
-      Location loc = op.getLoc();
-      MemRefType opMemrefType = cast<MemRefType>(op.getMemref().getType());
-      ValueRange indices = operands.getIndices();
+    if (!strippedPtr)
+      return rewriter.notifyMatchFailure(loc, "expected array or pointer type");
+    MemRefType opMemrefType = cast<MemRefType>(op.getMemref().getType());
+    ValueRange indices = operands.getIndices();
 
-      // Compute row-major linear index
-      Value linearIndex =
-          computeRowMajorLinearIndex(loc, opMemrefType, indices, rewriter);
-      auto typedPtr = cast<TypedValue<emitc::PointerType>>(strippedPtr);
-      auto subscript =
-          emitc::SubscriptOp::create(rewriter, loc, typedPtr, linearIndex);
+    ImplicitLocOpBuilder b(loc, rewriter);
+    Value linearIndex = computeRowMajorLinearIndex(b, opMemrefType, indices);
+    auto typedPtr = cast<TypedValue<emitc::PointerType>>(strippedPtr);
+    auto subscript =
+        emitc::SubscriptOp::create(rewriter, loc, typedPtr, linearIndex);
 
-      rewriter.replaceOpWithNewOp<emitc::AssignOp>(op, subscript,
-                                                   operands.getValue());
-      return success();
-    }
-    return rewriter.notifyMatchFailure(op.getLoc(),
-                                       "expected array or pointer type");
+    rewriter.replaceOpWithNewOp<emitc::AssignOp>(op, subscript,
+                                                 operands.getValue());
+    return success();
   }
 };
 

--- a/mlir/lib/Conversion/MemRefToEmitC/MemRefToEmitC.cpp
+++ b/mlir/lib/Conversion/MemRefToEmitC/MemRefToEmitC.cpp
@@ -140,6 +140,41 @@ createPointerFromEmitcArray(Location loc, OpBuilder &builder,
   return ptr;
 }
 
+static Value stripPointerUnrealizedCast(Value v) {
+  if (auto cast = v.getDefiningOp<UnrealizedConversionCastOp>())
+    if (cast.getNumOperands() == 1 &&
+        isa<emitc::PointerType>(cast.getOperand(0).getType()))
+      return cast.getOperand(0); // Pointer path
+  return Value();                // Array path
+}
+
+static Value computeRowMajorLinearIndex(Location loc, MemRefType memrefType,
+                                        ValueRange indices,
+                                        OpBuilder &builder) {
+  ArrayRef<int64_t> shape = memrefType.getShape();
+
+  Type idxType =
+      indices.empty() ? builder.getIndexType() : indices[0].getType();
+
+  Value linearIndex = indices.empty()
+                          ? emitc::ConstantOp::create(builder, loc, idxType,
+                                                      builder.getIndexAttr(0))
+                          : indices[0];
+
+  for (size_t i = 1; i < shape.size(); ++i) {
+    Value dimSize = emitc::ConstantOp::create(builder, loc, idxType,
+                                              builder.getIndexAttr(shape[i]));
+
+    linearIndex =
+        emitc::MulOp::create(builder, loc, idxType, linearIndex, dimSize);
+
+    linearIndex =
+        emitc::AddOp::create(builder, loc, idxType, linearIndex, indices[i]);
+  }
+
+  return linearIndex;
+}
+
 struct ConvertAlloc final : public OpConversionPattern<memref::AllocOp> {
   using OpConversionPattern::OpConversionPattern;
   LogicalResult
@@ -347,15 +382,32 @@ struct ConvertLoad final : public OpConversionPattern<memref::LoadOp> {
 
     auto arrayValue =
         dyn_cast<TypedValue<emitc::ArrayType>>(operands.getMemref());
-    if (!arrayValue) {
-      return rewriter.notifyMatchFailure(op.getLoc(), "expected array type");
+    Value strippedPtr = stripPointerUnrealizedCast(operands.getMemref());
+    if (!strippedPtr && arrayValue) {
+      auto subscript = emitc::SubscriptOp::create(
+          rewriter, op.getLoc(), arrayValue, operands.getIndices());
+
+      rewriter.replaceOpWithNewOp<emitc::LoadOp>(op, resultTy, subscript);
+      return success();
     }
+    if (strippedPtr) {
+      Location loc = op.getLoc();
+      MemRefType opMemrefType = cast<MemRefType>(op.getMemref().getType());
+      ValueRange indices = operands.getIndices();
 
-    auto subscript = emitc::SubscriptOp::create(
-        rewriter, op.getLoc(), arrayValue, operands.getIndices());
+      // Compute row-major linear index
+      Value linearIndex =
+          computeRowMajorLinearIndex(loc, opMemrefType, indices, rewriter);
 
-    rewriter.replaceOpWithNewOp<emitc::LoadOp>(op, resultTy, subscript);
-    return success();
+      auto typedPtr = cast<TypedValue<emitc::PointerType>>(strippedPtr);
+      auto subscript = emitc::SubscriptOp::create(rewriter, op.getLoc(),
+                                                  typedPtr, linearIndex);
+
+      rewriter.replaceOpWithNewOp<emitc::LoadOp>(op, resultTy, subscript);
+      return success();
+    }
+    return rewriter.notifyMatchFailure(op.getLoc(),
+                                       "expected array or pointer type");
   }
 };
 
@@ -367,17 +419,36 @@ struct ConvertStore final : public OpConversionPattern<memref::StoreOp> {
                   ConversionPatternRewriter &rewriter) const override {
     auto arrayValue =
         dyn_cast<TypedValue<emitc::ArrayType>>(operands.getMemref());
-    if (!arrayValue) {
-      return rewriter.notifyMatchFailure(op.getLoc(), "expected array type");
+    Value strippedPtr = stripPointerUnrealizedCast(operands.getMemref());
+    if (!strippedPtr && arrayValue) {
+      auto subscript = emitc::SubscriptOp::create(
+          rewriter, op.getLoc(), arrayValue, operands.getIndices());
+      rewriter.replaceOpWithNewOp<emitc::AssignOp>(op, subscript,
+                                                   operands.getValue());
+      return success();
     }
 
-    auto subscript = emitc::SubscriptOp::create(
-        rewriter, op.getLoc(), arrayValue, operands.getIndices());
-    rewriter.replaceOpWithNewOp<emitc::AssignOp>(op, subscript,
-                                                 operands.getValue());
-    return success();
+    if (strippedPtr) {
+      Location loc = op.getLoc();
+      MemRefType opMemrefType = cast<MemRefType>(op.getMemref().getType());
+      ValueRange indices = operands.getIndices();
+
+      // Compute row-major linear index
+      Value linearIndex =
+          computeRowMajorLinearIndex(loc, opMemrefType, indices, rewriter);
+      auto typedPtr = cast<TypedValue<emitc::PointerType>>(strippedPtr);
+      auto subscript =
+          emitc::SubscriptOp::create(rewriter, loc, typedPtr, linearIndex);
+
+      rewriter.replaceOpWithNewOp<emitc::AssignOp>(op, subscript,
+                                                   operands.getValue());
+      return success();
+    }
+    return rewriter.notifyMatchFailure(op.getLoc(),
+                                       "expected array or pointer type");
   }
 };
+
 } // namespace
 
 void mlir::populateMemRefToEmitCTypeConversion(TypeConverter &typeConverter) {

--- a/mlir/test/Conversion/MemRefToEmitC/memref-to-emitc-alloc-load-store.mlir
+++ b/mlir/test/Conversion/MemRefToEmitC/memref-to-emitc-alloc-load-store.mlir
@@ -1,5 +1,4 @@
-// RUN: mlir-opt -convert-to-emitc %s -split-input-file \
-// RUN: | FileCheck %s
+// RUN: mlir-opt -convert-to-emitc %s | FileCheck %s
 
 /// NOTE: This test intentionally uses `-convert-to-emitc` only.
 ///
@@ -21,18 +20,20 @@
 // CHECK-SAME:  %[[ARG_I:.*]]: !emitc.size_t,
 // CHECK-SAME:  %[[ARG_J:.*]]: !emitc.size_t)
 func.func private @memref_alloc_store(%v : f32, %i: index, %j: index) {
-  /// Size to alloc computation
+  /// Allocation size  computation
   // CHECK:     %[[SIZEOF_F32:.*]] = call_opaque "sizeof"() {args = [f32]} : () -> !emitc.size_t
   // CHECK:     %[[NUM_ELEMS:.*]] = "emitc.constant"() <{value = 32 : index}> : () -> index
   // CHECK:     %[[TOTAL_BYTES:.*]] = mul %[[SIZEOF_F32]], %[[NUM_ELEMS]] : (!emitc.size_t, index) -> !emitc.size_t
+  /// Alloc
   // CHECK:     %[[MALLOC_PTR:.*]] = call_opaque "malloc"(%[[TOTAL_BYTES]]) : (!emitc.size_t) -> !emitc.ptr<!emitc.opaque<"void">>
   // CHECK:     %[[ELEM_PTR:.*]] = cast %[[MALLOC_PTR]] : !emitc.ptr<!emitc.opaque<"void">> to !emitc.ptr<f32>
   %alloc = memref.alloc() : memref<4x8xf32>
-  /// Subscript computation
+  /// Store subscript computation
   // CHECK:     %[[ROW_STRIDE:.*]] = "emitc.constant"() <{value = 8 : index}> : () -> !emitc.size_t
   // CHECK:     %[[ROW_OFFSET:.*]] = mul %[[ARG_I]], %[[ROW_STRIDE]] : (!emitc.size_t, !emitc.size_t) -> !emitc.size_t
   // CHECK:     %[[LINEAR_INDEX:.*]] = add %[[ROW_OFFSET]], %[[ARG_J]] : (!emitc.size_t, !emitc.size_t) -> !emitc.size_t
   // CHECK:     %[[ELEM_LVALUE:.*]] = subscript %[[ELEM_PTR]]{{\[}}%[[LINEAR_INDEX]]] : (!emitc.ptr<f32>, !emitc.size_t) -> !emitc.lvalue<f32>
+  /// Store
   // CHECK:     assign %[[VAL]] : f32 to %[[ELEM_LVALUE]] : <f32>
   memref.store %v, %alloc[%i, %j] : memref<4x8xf32>
   return
@@ -61,14 +62,12 @@ func.func private @memref_alloc_load(%i: index, %j: index) -> f32 {
 // CHECK-LABEL: emitc.func @memref_load_store(
 // CHECK-SAME:  %[[BUFF0:.*]]: !emitc.array<2xf32>,
 // CHECK-SAME:  %[[BUFF1:.*]]: !emitc.array<4x8xf32>,
-// CHECK-SAME:  %[[ARG_I:.*]]: !emitc.size_t,
-// CHECK-SAME:  %[[ARG_J:.*]]: !emitc.size_t) {
 func.func @memref_load_store(%buff0: memref<2xf32>,
   %buff1: memref<4x8xf32>, %i : index, %j : index) {
-  // CHECK:     %[[ELEM_LVALUE0:.*]] = subscript %[[BUFF0]]{{\[}}%[[ARG_I]]] : (!emitc.array<2xf32>, !emitc.size_t) -> !emitc.lvalue<f32>
+  // CHECK:     %[[ELEM_LVALUE0:.*]] = subscript %[[BUFF0]]{{.*}} (!emitc.array<2xf32>, !emitc.size_t) -> !emitc.lvalue<f32>
   // CHECK:     %[[VAL:.*]] = load %[[ELEM_LVALUE0]] : <f32>
   %v = memref.load %buff0[%i] : memref<2xf32>
-  // CHECK:     %[[ELEM_LVALUE1:.*]] = subscript %[[BUFF1]]{{\[}}%[[ARG_I]], %[[ARG_J]]] : (!emitc.array<4x8xf32>, !emitc.size_t, !emitc.size_t) -> !emitc.lvalue<f32>
+  // CHECK:     %[[ELEM_LVALUE1:.*]] = subscript %[[BUFF1]]{{.*}} (!emitc.array<4x8xf32>, !emitc.size_t, !emitc.size_t) -> !emitc.lvalue<f32>
   // CHECK:     assign %[[VAL]] : f32 to %[[ELEM_LVALUE1]] : <f32>
   memref.store %v, %buff1[%i, %j] : memref<4x8xf32>
   return

--- a/mlir/test/Conversion/MemRefToEmitC/memref-to-emitc-alloc-load-store.mlir
+++ b/mlir/test/Conversion/MemRefToEmitC/memref-to-emitc-alloc-load-store.mlir
@@ -1,0 +1,75 @@
+// RUN: mlir-opt -convert-to-emitc %s -split-input-file \
+// RUN: | FileCheck %s
+
+/// NOTE: This test intentionally uses `-convert-to-emitc` only.
+///
+/// The `-convert-memref-to-emitc` pass introduces
+/// `builtin.unrealized_conversion_cast` operations when lowering
+/// `memref.alloc` results (which are lowered to `emitc.ptr`) to the canonical
+/// memref representation used by the type converter (`emitc.array`).
+/// These casts are expected at that stage of the pipeline.
+///
+/// The purpose of this test is to verify the final lowering produced by
+/// `-convert-to-emitc`, where `memref.load` and `memref.store` conversions now
+/// handle pointer-backed buffers directly and eliminate the intermediate
+/// `unrealized_conversion_cast`.
+/// Therefore, the test must run the full EmitC conversion pipeline.
+
+/// AllocOp conversion always returns a ptr
+// CHECK-LABEL: emitc.func private @memref_alloc_store(
+// CHECK-SAME:  %[[VAL:.*]]: f32,
+// CHECK-SAME:  %[[ARG_I:.*]]: !emitc.size_t,
+// CHECK-SAME:  %[[ARG_J:.*]]: !emitc.size_t)
+func.func private @memref_alloc_store(%v : f32, %i: index, %j: index) {
+  /// Size to alloc computation
+  // CHECK:     %[[SIZEOF_F32:.*]] = call_opaque "sizeof"() {args = [f32]} : () -> !emitc.size_t
+  // CHECK:     %[[NUM_ELEMS:.*]] = "emitc.constant"() <{value = 32 : index}> : () -> index
+  // CHECK:     %[[TOTAL_BYTES:.*]] = mul %[[SIZEOF_F32]], %[[NUM_ELEMS]] : (!emitc.size_t, index) -> !emitc.size_t
+  // CHECK:     %[[MALLOC_PTR:.*]] = call_opaque "malloc"(%[[TOTAL_BYTES]]) : (!emitc.size_t) -> !emitc.ptr<!emitc.opaque<"void">>
+  // CHECK:     %[[ELEM_PTR:.*]] = cast %[[MALLOC_PTR]] : !emitc.ptr<!emitc.opaque<"void">> to !emitc.ptr<f32>
+  %alloc = memref.alloc() : memref<4x8xf32>
+  /// Subscript computation
+  // CHECK:     %[[ROW_STRIDE:.*]] = "emitc.constant"() <{value = 8 : index}> : () -> !emitc.size_t
+  // CHECK:     %[[ROW_OFFSET:.*]] = mul %[[ARG_I]], %[[ROW_STRIDE]] : (!emitc.size_t, !emitc.size_t) -> !emitc.size_t
+  // CHECK:     %[[LINEAR_INDEX:.*]] = add %[[ROW_OFFSET]], %[[ARG_J]] : (!emitc.size_t, !emitc.size_t) -> !emitc.size_t
+  // CHECK:     %[[ELEM_LVALUE:.*]] = subscript %[[ELEM_PTR]]{{\[}}%[[LINEAR_INDEX]]] : (!emitc.ptr<f32>, !emitc.size_t) -> !emitc.lvalue<f32>
+  // CHECK:     assign %[[VAL]] : f32 to %[[ELEM_LVALUE]] : <f32>
+  memref.store %v, %alloc[%i, %j] : memref<4x8xf32>
+  return
+}
+// CHECK-LABEL: emitc.func private @memref_alloc_load(
+// CHECK-SAME:  %[[ARG_I:.*]]: !emitc.size_t,
+// CHECK-SAME:  %[[ARG_J:.*]]: !emitc.size_t) -> f32
+func.func private @memref_alloc_load(%i: index, %j: index) -> f32 {
+  // CHECK:     %[[SIZEOF_F32:.*]] = call_opaque "sizeof"() {args = [f32]} : () -> !emitc.size_t
+  // CHECK:     %[[NUM_ELEMS:.*]] = "emitc.constant"() <{value = 32 : index}> : () -> index
+  // CHECK:     %[[TOTAL_BYTES:.*]] = mul %[[SIZEOF_F32]], %[[NUM_ELEMS]] : (!emitc.size_t, index) -> !emitc.size_t
+  // CHECK:     %[[MALLOC_PTR:.*]] = call_opaque "malloc"(%[[TOTAL_BYTES]]) : (!emitc.size_t) -> !emitc.ptr<!emitc.opaque<"void">>
+  // CHECK:     %[[ELEM_PTR:.*]] = cast %[[MALLOC_PTR]] : !emitc.ptr<!emitc.opaque<"void">> to !emitc.ptr<f32>
+  %alloc = memref.alloc() : memref<4x8xf32>
+  // CHECK:     %[[ROW_STRIDE:.*]] = "emitc.constant"() <{value = 8 : index}> : () -> !emitc.size_t
+  // CHECK:     %[[ROW_OFFSET:.*]] = mul %[[ARG_I]], %[[ROW_STRIDE]] : (!emitc.size_t, !emitc.size_t) -> !emitc.size_t
+  // CHECK:     %[[LINEAR_INDEX:.*]] = add %[[ROW_OFFSET]], %[[ARG_J]] : (!emitc.size_t, !emitc.size_t) -> !emitc.size_t
+  // CHECK:     %[[ELEM_LVALUE:.*]] = subscript %[[ELEM_PTR]]{{\[}}%[[LINEAR_INDEX]]] : (!emitc.ptr<f32>, !emitc.size_t) -> !emitc.lvalue<f32>
+  // CHECK:     %[[LOADED_VAL:.*]] = load %[[ELEM_LVALUE]] : <f32>
+  %v = memref.load %alloc[%i, %j] : memref<4x8xf32>
+  return %v : f32
+}
+
+/// LoadOp and StoreOp still compatible
+/// Previous array paths still available
+// CHECK-LABEL: emitc.func @memref_load_store(
+// CHECK-SAME:  %[[BUFF0:.*]]: !emitc.array<2xf32>,
+// CHECK-SAME:  %[[BUFF1:.*]]: !emitc.array<4x8xf32>,
+// CHECK-SAME:  %[[ARG_I:.*]]: !emitc.size_t,
+// CHECK-SAME:  %[[ARG_J:.*]]: !emitc.size_t) {
+func.func @memref_load_store(%buff0: memref<2xf32>,
+  %buff1: memref<4x8xf32>, %i : index, %j : index) {
+  // CHECK:     %[[ELEM_LVALUE0:.*]] = subscript %[[BUFF0]]{{\[}}%[[ARG_I]]] : (!emitc.array<2xf32>, !emitc.size_t) -> !emitc.lvalue<f32>
+  // CHECK:     %[[VAL:.*]] = load %[[ELEM_LVALUE0]] : <f32>
+  %v = memref.load %buff0[%i] : memref<2xf32>
+  // CHECK:     %[[ELEM_LVALUE1:.*]] = subscript %[[BUFF1]]{{\[}}%[[ARG_I]], %[[ARG_J]]] : (!emitc.array<4x8xf32>, !emitc.size_t, !emitc.size_t) -> !emitc.lvalue<f32>
+  // CHECK:     assign %[[VAL]] : f32 to %[[ELEM_LVALUE1]] : <f32>
+  memref.store %v, %buff1[%i, %j] : memref<4x8xf32>
+  return
+}


### PR DESCRIPTION
## Problem  
  
In the MemRef → EmitC conversion, `memref.load` and `memref.store` assume that the converted memref operand is an `emitc.array`, as defined by the type conversion in `populateMemRefToEmitCTypeConversion`.  
  
However, `memref.alloc` is lowered to a `malloc` call returning `emitc.ptr`. When such values are used by `memref.load` or `memref.store`, the conversion framework inserts a bridging `builtin.unrealized_conversion_cast` from `emitc.ptr` to `emitc.array`.  
  
These casts have no EmitC representation and therefore remain in the IR after conversion, preventing valid C/C++ emission.  

## Solution  
  
Extend the `memref.load` and `memref.store` conversions to handle pointer-backed buffers.  
  
If the memref operand is defined by an `UnrealizedConversionCastOp` whose input is an `emitc.ptr`, the cast is stripped and the underlying pointer operand is used directly. Since pointer subscripting in EmitC is one-dimensional, the multi-dimensional memref indices are converted to a row-major linear index (matching the default memref layout) using the original `MemRefType` shape before emitting `emitc.subscript`.  
  
The existing array-based lowering path remains unchanged.  
  
This patch intentionally does ***not*** modify the MemRef → EmitC type conversion rule (`memref → emitc.array`). Instead, the mismatch introduced by `memref.alloc` returning a pointer is handled locally in the `LoadOp` and `StoreOp` conversions.  

## Example 1: Single-dimensional store  
  
### Input  
```mlir
func.func @alloc_store(%arg0: i32, %i: index) {
  %alloc = memref.alloc() : memref<999xi32>
  memref.store %arg0, %alloc[%i] : memref<999xi32>
  return
}
```
### Current lowering  
```mlir
// AllocOp conversion unchanged -> excluded for brevity
%5 = builtin.unrealized_conversion_cast %4 : !emitc.ptr<i32> to !emitc.array<999xi32>
%6 = subscript %5[%arg1]
assign %arg0 to %6 : <i32>
```
  
The `unrealized_conversion_cast` remains in the IR.  
### Lowering after this patch  
```mlir
%5 = subscript %4[%arg1] : (!emitc.ptr<i32>, !emitc.size_t) -> !emitc.lvalue<i32>
assign %arg0 : i32 to %5 : <i32>
```

The cast is eliminated and pointer subscripting is used directly.  
  
## Example 2: Multi-dimensional store  
  
### Input  
```mlir
func.func @memref_alloc_store(%v : f32, %i : index, %j : index) {
  %alloc = memref.alloc() : memref<4x8xf32>
  memref.store %v, %alloc[%i, %j] : memref<4x8xf32>
  return
}
```
### Current lowering  
```mlir
// AllocOp conversion unchanged -> excluded for brevity
%5 = builtin.unrealized_conversion_cast %4 : !emitc.ptr<f32> to !emitc.array<4x8xf32>
%6 = subscript %5[%arg1, %arg2] : (!emitc.array<4x8xf32>, !emitc.size_t, !emitc.size_t) -> !emitc.lvalue<f32>
assign %arg0 : f32 to %6 : <f32>
```
### Lowering after this patch  
```mlir
%5 = "emitc.constant"() <{value = 8 : index}> : () -> !emitc.size_t
%6 = mul %arg1, %5 : (!emitc.size_t, !emitc.size_t) -> !emitc.size_t
%7 = add %6, %arg2 : (!emitc.size_t, !emitc.size_t) -> !emitc.size_t
%8 = subscript %4[%7] : (!emitc.ptr<f32>, !emitc.size_t) -> !emitc.lvalue<f32>
assign %arg0 : f32 to %8 : <f32>
```

The multi-dimensional indices are converted into a linear row-major index before pointer subscripting.


Assisted-by: ChatGPT (refine implementation + tests). I reviewed all code and tests before submission.
