### PR TITLE
[Draft][AIX][PPC] Refactor -mabi=vec-extabi to use target ABI

### DIFF
--- a/clang/include/clang/Basic/CodeGenOptions.def
+++ b/clang/include/clang/Basic/CodeGenOptions.def
@@ -53,7 +53,6 @@ CODEGENOPT(UniqueBasicBlockSectionNames, 1, 1, Benign) ///< Set for -funique-bas
                                                ///< Produce unique section names with
                                                ///< basic block sections.
 CODEGENOPT(SeparateNamedSections, 1, 0, Benign) ///< Set for -fseparate-named-sections.
-CODEGENOPT(EnableAIXExtendedAltivecABI, 1, 0, Benign) ///< Set for -mabi=vec-extabi. Enables the extended Altivec ABI on AIX.
 CODEGENOPT(XCOFFReadOnlyPointers, 1, 0, Benign) ///< Set for -mxcoff-roptr.
 CODEGENOPT(AllTocData, 1, 0, Benign) ///< AIX -mtocdata
 ENUM_CODEGENOPT(FramePointer, FramePointerKind, 3, FramePointerKind::None, Benign) /// frame-pointer: all,non-leaf,non-leaf-no-reserve,reserved,none

--- a/clang/include/clang/Basic/LangOptions.def
+++ b/clang/include/clang/Basic/LangOptions.def
@@ -178,7 +178,6 @@ VALUE_LANGOPT(AlignDouble            , 1, 0, NotCompatible, "Controls if doubles
 VALUE_LANGOPT(DoubleSize            , 32, 0, NotCompatible, "width of double")
 VALUE_LANGOPT(LongDoubleSize        , 32, 0, NotCompatible, "width of long double")
 LANGOPT(PPCIEEELongDouble            , 1, 0, NotCompatible, "use IEEE 754 quadruple-precision for long double")
-LANGOPT(EnableAIXExtendedAltivecABI  , 1, 0, NotCompatible, "__EXTABI__  predefined macro")
 LANGOPT(EnableAIXQuadwordAtomicsABI  , 1, 0, NotCompatible, "Use 16-byte atomic lock free semantics")
 VALUE_LANGOPT(PICLevel               , 2, 0, Compatible, "__PIC__ level")
 VALUE_LANGOPT(PIE                    , 1, 0, Compatible, "is pie")

--- a/clang/include/clang/Options/Options.td
+++ b/clang/include/clang/Options/Options.td
@@ -8194,8 +8194,7 @@ def mabi_EQ_ieeelongdouble : Flag<["-"], "mabi=ieeelongdouble">,
   MarshallingInfoFlag<LangOpts<"PPCIEEELongDouble">>;
 def mabi_EQ_vec_extabi : Flag<["-"], "mabi=vec-extabi">,
   Visibility<[ClangOption, CC1Option, FlangOption, FC1Option]>,
-  HelpText<"Enable the extended Altivec ABI on AIX. Use volatile and nonvolatile vector registers">,
-  MarshallingInfoFlag<LangOpts<"EnableAIXExtendedAltivecABI">>;
+  HelpText<"Enable the extended Altivec ABI on AIX. Use volatile and nonvolatile vector registers">;
 def mfloat_abi : Separate<["-"], "mfloat-abi">,
   HelpText<"The float ABI to use">,
   MarshallingInfoString<CodeGenOpts<"FloatABI">>;

--- a/clang/lib/Basic/Targets/OSTargets.h
+++ b/clang/lib/Basic/Targets/OSTargets.h
@@ -726,7 +726,7 @@ protected:
       Builder.defineMacro("__STDC_NO_THREADS__");
     }
 
-    if (Opts.EnableAIXExtendedAltivecABI)
+    if (this->getABI() == "vec-extabi")
       Builder.defineMacro("__EXTABI__");
 
     VersionTuple OsVersion = Triple.getOSVersion();

--- a/clang/lib/Basic/Targets/PPC.h
+++ b/clang/lib/Basic/Targets/PPC.h
@@ -510,12 +510,28 @@ public:
   BuiltinVaListKind getBuiltinVaListKind() const override {
     return TargetInfo::CharPtrBuiltinVaList;
   }
+
+  bool setABI(const std::string &Name) override {
+    if (Name == "vec-extabi" || Name == "vec-default") {
+      ABI = Name;
+      return true;
+    }
+    return false;
+  }
 };
 
 class LLVM_LIBRARY_VISIBILITY AIXPPC64TargetInfo :
   public AIXTargetInfo<PPC64TargetInfo> {
 public:
   using AIXTargetInfo::AIXTargetInfo;
+
+  bool setABI(const std::string &Name) override {
+    if (Name == "vec-extabi" || Name == "vec-default") {
+      ABI = Name;
+      return true;
+    }
+    return false;
+  }
 };
 
 } // namespace targets

--- a/clang/lib/CodeGen/BackendUtil.cpp
+++ b/clang/lib/CodeGen/BackendUtil.cpp
@@ -456,7 +456,7 @@ static bool initTargetOptions(const CompilerInstance &CI,
   Options.ForceDwarfFrameSection = CodeGenOpts.ForceDwarfFrameSection;
   Options.EmitCallGraphSection = CodeGenOpts.CallGraphSection;
   Options.EmitCallSiteInfo = CodeGenOpts.EmitCallSiteInfo;
-  Options.EnableAIXExtendedAltivecABI = LangOpts.EnableAIXExtendedAltivecABI;
+  Options.EnableAIXExtendedAltivecABI = TargetOpts.ABI == "vec-extabi";
   Options.XRayFunctionIndex = CodeGenOpts.XRayFunctionIndex;
   Options.LoopAlignment = CodeGenOpts.LoopAlignment;
   Options.DebugStrictDwarf = CodeGenOpts.DebugStrictDwarf;

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -1984,7 +1984,7 @@ void Clang::AddPPCTargetArgs(const ArgList &Args,
     if (!T.isOSAIX())
       D.Diag(diag::err_drv_unsupported_opt_for_target)
           << "-mabi=vec-extabi" << T.str();
-    CmdArgs.push_back("-mabi=vec-extabi");
+    ABIName = "vec-extabi";
   }
 
   if (!Args.hasFlag(options::OPT_mred_zone, options::OPT_mno_red_zone, true))

--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -1748,9 +1748,6 @@ void CompilerInvocationBase::GenerateCodeGenArgs(const CodeGenOptions &Opts,
     GenerateArg(Consumer, Opt);
   }
 
-  if (Opts.EnableAIXExtendedAltivecABI)
-    GenerateArg(Consumer, OPT_mabi_EQ_vec_extabi);
-
   if (Opts.XCOFFReadOnlyPointers)
     GenerateArg(Consumer, OPT_mxcoff_roptr);
 

--- a/clang/test/Driver/aix-vec_extabi.c
+++ b/clang/test/Driver/aix-vec_extabi.c
@@ -9,8 +9,8 @@
 // RUN:  %clang -### -target powerpc-unknown-aix -S -maltivec -mabi=vec-extabi %s 2>&1 | \
 // RUN:  FileCheck %s --check-prefix=EXTABI
 /
-// EXTABI:       "-cc1"
-// EXTABI-SAME:  "-mabi=vec-extabi"
+// EXTABI:       "-target-abi"
+// EXTABI-SAME:  "vec-extabi"
 
-// DFLTABI:      "-cc1"
-// DFLTABI-NOT:  "-mabi=vec-extabi"
+// DFLTABI-NOT:  "-target-abi"
+// DFLTABI-NOT:  "vec-extabi"

--- a/llvm/lib/Target/PowerPC/PPCTargetMachine.cpp
+++ b/llvm/lib/Target/PowerPC/PPCTargetMachine.cpp
@@ -200,7 +200,11 @@ static PPCTargetMachine::PPCABI computeTargetABI(const Triple &TT,
   else if (Options.MCOptions.getABIName().starts_with("elfv2"))
     return PPCTargetMachine::PPC_ABI_ELFv2;
 
-  assert(Options.MCOptions.getABIName().empty() &&
+  // vec-extabi and vec-default are AIX-specific ABI options that don't
+  // affect the ELF ABI selection, so ignore them here.
+  assert((Options.MCOptions.getABIName().empty() ||
+          Options.MCOptions.getABIName() == "vec-extabi" ||
+          Options.MCOptions.getABIName() == "vec-default") &&
          "Unknown target-abi option!");
 
   switch (TT.getArch()) {


### PR DESCRIPTION
Previously, -mabi=vec-extabi was implemented in both LangOptions and CodeGenOptions. 
This was not consistent with other ABI options which makes it more difficult for not-clang LLVM frontends (like Rust) to support the option. 
