### PR TITLE
Revert "[DomTree] Assert non-null block for pre-dom tree"

### DIFF
--- a/llvm/include/llvm/Support/GenericDomTree.h
+++ b/llvm/include/llvm/Support/GenericDomTree.h
@@ -384,15 +384,11 @@ protected:
 private:
   std::optional<unsigned> getNodeIndex(const NodeT *BB) const {
     if constexpr (GraphHasNodeNumbers<NodeT *>) {
+      // BB can be nullptr, map nullptr to index 0.
       assert(BlockNumberEpoch ==
                  GraphTraits<ParentPtr>::getNumberEpoch(Parent) &&
              "dominator tree used with outdated block numbers");
-      if constexpr (IsPostDom) {
-        if (!BB)
-          return 0; // BB may be nullptr for post-dominator tree, map to 0.
-      } else
-        assert(BB && "dominator tree block must be non-null");
-      return GraphTraits<const NodeT *>::getNumber(BB) + 1;
+      return BB ? GraphTraits<const NodeT *>::getNumber(BB) + 1 : 0;
     } else {
       if (auto It = NodeNumberMap.find(BB); It != NodeNumberMap.end())
         return It->second;

--- a/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
+++ b/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
@@ -28333,8 +28333,6 @@ bool SLPVectorizerPass::vectorizeGEPIndices(BasicBlock *BB, BoUpSLP &R) {
         const SCEV *SCEVI = SE->getSCEV(GEPList[I]);
         for (int J = I + 1; J < E && Candidates.size() > 1; ++J) {
           auto *GEPJ = GEPList[J];
-          if (!Candidates.count(GEPJ))
-            continue;
           const SCEV *SCEVJ = SE->getSCEV(GEPList[J]);
           if (isa<SCEVConstant>(SE->getMinusSCEV(SCEVI, SCEVJ))) {
             Candidates.remove(GEPI);

--- a/polly/lib/Analysis/ScopBuilder.cpp
+++ b/polly/lib/Analysis/ScopBuilder.cpp
@@ -637,7 +637,7 @@ void ScopBuilder::propagateDomainConstraintsToRegionExit(
   auto *RI = scop->getRegion().getRegionInfo();
   auto *BBReg = RI ? RI->getRegionFor(BB) : nullptr;
   auto *ExitBB = BBReg ? BBReg->getExit() : nullptr;
-  if (!BBReg || BBReg->getEntry() != BB || !ExitBB || !scop->contains(ExitBB))
+  if (!BBReg || BBReg->getEntry() != BB || !scop->contains(ExitBB))
     return;
 
   // Do not propagate the domain if there is a loop backedge inside the region


### PR DESCRIPTION
Reverts llvm/llvm-project#186790

Breaks buildbots, there are more SLPVectorizer problems.

https://lab.llvm.org/buildbot/#/builders/52/builds/15810