### PR TITLE
[MLIR][Interfaces] Make `getMutableSuccessorOperands` overridable on `ReturnLike` ops

### DIFF
--- a/mlir/include/mlir/Dialect/OpenACC/OpenACCOps.td
+++ b/mlir/include/mlir/Dialect/OpenACC/OpenACCOps.td
@@ -2354,7 +2354,8 @@ def OpenACC_DataOp
 def OpenACC_TerminatorOp
     : OpenACC_Op<"terminator", [Pure, Terminator,
                                 DeclareOpInterfaceMethods<
-                                    RegionBranchTerminatorOpInterface>]> {
+                                    RegionBranchTerminatorOpInterface,
+                                    ["getMutableSuccessorOperands"]>]> {
   let summary = "Generic terminator for OpenACC regions";
 
   let description = [{

--- a/mlir/include/mlir/Dialect/SCF/IR/SCFOps.td
+++ b/mlir/include/mlir/Dialect/SCF/IR/SCFOps.td
@@ -51,12 +51,13 @@ class SCF_Op<string mnemonic, list<Trait> traits = []> :
 // ConditionOp
 //===----------------------------------------------------------------------===//
 
-def ConditionOp : SCF_Op<"condition", [HasParent<"WhileOp">,
-                                       DeclareOpInterfaceMethods<
-                                           RegionBranchTerminatorOpInterface,
-                                           ["getSuccessorRegions",
-                                            "getMutableSuccessorOperands"]>,
-                                       Pure, Terminator]> {
+def ConditionOp : SCF_Op<"condition", [
+  HasParent<"WhileOp">,
+  DeclareOpInterfaceMethods<RegionBranchTerminatorOpInterface,
+    ["getSuccessorRegions", "getMutableSuccessorOperands"]>,
+  Pure,
+  Terminator
+]> {
   let summary = "loop continuation condition";
   let description = [{
     This operation accepts the continuation (i.e., inverse of exit) condition
@@ -901,11 +902,10 @@ def ParallelOp : SCF_Op<"parallel",
 // ReduceOp
 //===----------------------------------------------------------------------===//
 
-def ReduceOp
-    : SCF_Op<"reduce",
-             [Terminator, HasParent<"ParallelOp">, RecursiveMemoryEffects,
-              DeclareOpInterfaceMethods<RegionBranchTerminatorOpInterface,
-                                        ["getMutableSuccessorOperands"]>]> {
+def ReduceOp : SCF_Op<"reduce", [
+    Terminator, HasParent<"ParallelOp">, RecursiveMemoryEffects,
+    DeclareOpInterfaceMethods<RegionBranchTerminatorOpInterface,
+                              ["getMutableSuccessorOperands"]>]> {
   let summary = "reduce operation for scf.parallel";
   let description = [{
     The `scf.reduce` operation is the terminator for `scf.parallel` operations. It can model

--- a/mlir/include/mlir/Dialect/SCF/IR/SCFOps.td
+++ b/mlir/include/mlir/Dialect/SCF/IR/SCFOps.td
@@ -51,13 +51,12 @@ class SCF_Op<string mnemonic, list<Trait> traits = []> :
 // ConditionOp
 //===----------------------------------------------------------------------===//
 
-def ConditionOp : SCF_Op<"condition", [
-  HasParent<"WhileOp">,
-  DeclareOpInterfaceMethods<RegionBranchTerminatorOpInterface,
-    ["getSuccessorRegions"]>,
-  Pure,
-  Terminator
-]> {
+def ConditionOp : SCF_Op<"condition", [HasParent<"WhileOp">,
+                                       DeclareOpInterfaceMethods<
+                                           RegionBranchTerminatorOpInterface,
+                                           ["getSuccessorRegions",
+                                            "getMutableSuccessorOperands"]>,
+                                       Pure, Terminator]> {
   let summary = "loop continuation condition";
   let description = [{
     This operation accepts the continuation (i.e., inverse of exit) condition
@@ -902,9 +901,11 @@ def ParallelOp : SCF_Op<"parallel",
 // ReduceOp
 //===----------------------------------------------------------------------===//
 
-def ReduceOp : SCF_Op<"reduce", [
-    Terminator, HasParent<"ParallelOp">, RecursiveMemoryEffects,
-    DeclareOpInterfaceMethods<RegionBranchTerminatorOpInterface>]> {
+def ReduceOp
+    : SCF_Op<"reduce",
+             [Terminator, HasParent<"ParallelOp">, RecursiveMemoryEffects,
+              DeclareOpInterfaceMethods<RegionBranchTerminatorOpInterface,
+                                        ["getMutableSuccessorOperands"]>]> {
   let summary = "reduce operation for scf.parallel";
   let description = [{
     The `scf.reduce` operation is the terminator for `scf.parallel` operations. It can model

--- a/mlir/include/mlir/Interfaces/ControlFlowInterfaces.td
+++ b/mlir/include/mlir/Interfaces/ControlFlowInterfaces.td
@@ -426,15 +426,19 @@ def RegionBranchTerminatorOpInterface :
   }];
   let cppNamespace = "::mlir";
 
-  let methods = [
-    InterfaceMethod<[{
+  let methods =
+      [InterfaceMethod<[{
         Returns a mutable range of operands that are semantically "returned" by
         passing them to the region successor indicated by `point`.
       }],
-      "::mlir::MutableOperandRange", "getMutableSuccessorOperands",
-      (ins "::mlir::RegionSuccessor":$point)
-    >,
-    InterfaceMethod<[{
+                       "::mlir::MutableOperandRange",
+                       "getMutableSuccessorOperands",
+                       (ins "::mlir::RegionSuccessor":$point), [{}],
+                       /*defaultImplementation=*/[{
+        return ::mlir::MutableOperandRange($_op);
+      }]>,
+       InterfaceMethod<
+           [{
         Returns the potential region successors that are branched to after this
         terminator based on the given constant operands.
 
@@ -445,15 +449,15 @@ def RegionBranchTerminatorOpInterface :
         The default implementation simply dispatches to the parent
         `RegionBranchOpInterface`'s `getSuccessorRegions` implementation.
       }],
-      "void", "getSuccessorRegions",
-      (ins "::llvm::ArrayRef<::mlir::Attribute>":$operands,
-           "::llvm::SmallVectorImpl<::mlir::RegionSuccessor> &":$regions), [{}],
-      /*defaultImplementation=*/[{
+           "void", "getSuccessorRegions",
+           (ins "::llvm::ArrayRef<::mlir::Attribute>":$operands,
+               "::llvm::SmallVectorImpl<::mlir::RegionSuccessor> &":$regions),
+           [{}],
+           /*defaultImplementation=*/[{
         ::mlir::Operation *op = $_op;
         ::llvm::cast<::mlir::RegionBranchOpInterface>(op->getParentOp())
           .getSuccessorRegions(::llvm::cast<::mlir::RegionBranchTerminatorOpInterface>(op), regions);
-      }]
-    >,
+      }]>,
   ];
 
   let verify = [{
@@ -630,19 +634,8 @@ def WeightedRegionBranchOpInterface
 //===----------------------------------------------------------------------===//
 
 // Op is "return-like".
-def ReturnLike : TraitList<[
-    DeclareOpInterfaceMethods<RegionBranchTerminatorOpInterface>,
-    NativeOpTrait<
-        /*name=*/"ReturnLike",
-        /*traits=*/[],
-        /*extraOpDeclaration=*/"",
-        /*extraOpDefinition=*/[{
-          ::mlir::MutableOperandRange $cppClass::getMutableSuccessorOperands(
-            ::mlir::RegionSuccessor successor) {
-            return ::mlir::MutableOperandRange(*this);
-          }
-        }]
-    >
-]>;
+def ReturnLike
+    : TraitList<[DeclareOpInterfaceMethods<RegionBranchTerminatorOpInterface>,
+                 NativeOpTrait</*name=*/"ReturnLike">]>;
 
 #endif // MLIR_INTERFACES_CONTROLFLOWINTERFACES

--- a/mlir/include/mlir/Interfaces/ControlFlowInterfaces.td
+++ b/mlir/include/mlir/Interfaces/ControlFlowInterfaces.td
@@ -426,19 +426,19 @@ def RegionBranchTerminatorOpInterface :
   }];
   let cppNamespace = "::mlir";
 
-  let methods =
-      [InterfaceMethod<[{
+  let methods = [
+    InterfaceMethod<[{
         Returns a mutable range of operands that are semantically "returned" by
         passing them to the region successor indicated by `point`.
       }],
-                       "::mlir::MutableOperandRange",
-                       "getMutableSuccessorOperands",
-                       (ins "::mlir::RegionSuccessor":$point), [{}],
-                       /*defaultImplementation=*/[{
+      "::mlir::MutableOperandRange", "getMutableSuccessorOperands",
+      (ins "::mlir::RegionSuccessor":$point),
+      [{}],
+      /*defaultImplementation=*/[{
         return ::mlir::MutableOperandRange($_op);
-      }]>,
-       InterfaceMethod<
-           [{
+      }]
+    >,
+    InterfaceMethod<[{
         Returns the potential region successors that are branched to after this
         terminator based on the given constant operands.
 
@@ -449,15 +449,15 @@ def RegionBranchTerminatorOpInterface :
         The default implementation simply dispatches to the parent
         `RegionBranchOpInterface`'s `getSuccessorRegions` implementation.
       }],
-           "void", "getSuccessorRegions",
-           (ins "::llvm::ArrayRef<::mlir::Attribute>":$operands,
-               "::llvm::SmallVectorImpl<::mlir::RegionSuccessor> &":$regions),
-           [{}],
-           /*defaultImplementation=*/[{
+      "void", "getSuccessorRegions",
+      (ins "::llvm::ArrayRef<::mlir::Attribute>":$operands,
+           "::llvm::SmallVectorImpl<::mlir::RegionSuccessor> &":$regions), [{}],
+      /*defaultImplementation=*/[{
         ::mlir::Operation *op = $_op;
         ::llvm::cast<::mlir::RegionBranchOpInterface>(op->getParentOp())
           .getSuccessorRegions(::llvm::cast<::mlir::RegionBranchTerminatorOpInterface>(op), regions);
-      }]>,
+      }]
+    >,
   ];
 
   let verify = [{
@@ -634,8 +634,8 @@ def WeightedRegionBranchOpInterface
 //===----------------------------------------------------------------------===//
 
 // Op is "return-like".
-def ReturnLike
-    : TraitList<[DeclareOpInterfaceMethods<RegionBranchTerminatorOpInterface>,
-                 NativeOpTrait</*name=*/"ReturnLike">]>;
+def ReturnLike : TraitList<[
+    DeclareOpInterfaceMethods<RegionBranchTerminatorOpInterface>,
+    NativeOpTrait</*name=*/"ReturnLike">]>;
 
 #endif // MLIR_INTERFACES_CONTROLFLOWINTERFACES

--- a/mlir/test/lib/Dialect/Test/TestOpDefs.cpp
+++ b/mlir/test/lib/Dialect/Test/TestOpDefs.cpp
@@ -1332,6 +1332,15 @@ TestCrashingReturnOp::getMutableSuccessorOperands(RegionSuccessor successor) {
 }
 
 //===----------------------------------------------------------------------===//
+// TestReturnWithIgnoredValueOp
+//===----------------------------------------------------------------------===//
+
+MutableOperandRange TestReturnWithIgnoredValueOp::getMutableSuccessorOperands(
+    RegionSuccessor /*successor*/) {
+  return getValuesMutable();
+}
+
+//===----------------------------------------------------------------------===//
 // SwitchWithNoBreakOp
 //===----------------------------------------------------------------------===//
 

--- a/mlir/test/lib/Dialect/Test/TestOps.td
+++ b/mlir/test/lib/Dialect/Test/TestOps.td
@@ -2243,11 +2243,10 @@ def TestReturnOp : TEST_Op<"return", [Pure, ReturnLike, Terminator]> {
 // When 'valid' unit-attr is absent the op is malformed; its verifier
 // emits an error, but getMutableSuccessorOperands() calls report_fatal_error
 // to expose the fact that FuncOp::verify() runs before the region is checked.
-def TestCrashingReturnOp
-    : TEST_Op<"crashing_return", [DeclareOpInterfaceMethods<
-                                      RegionBranchTerminatorOpInterface,
-                                      ["getMutableSuccessorOperands"]>,
-                                  Terminator]> {
+def TestCrashingReturnOp : TEST_Op<"crashing_return", [
+    DeclareOpInterfaceMethods<RegionBranchTerminatorOpInterface,
+       ["getMutableSuccessorOperands"]>,
+    Terminator]> {
   let arguments = (ins Variadic<AnyType>:$args, UnitAttr:$valid);
   let assemblyFormat = "($args^ `:` type($args))? attr-dict";
   let hasVerifier = 1;
@@ -2304,11 +2303,14 @@ def TestSignatureConversionNoConverterOp
 
 // A return-like operation with override on the successor operand getter
 // interface method.
-def TestReturnWithIgnoredValueOp
-    : TEST_Op<"return_with_ignored_value",
-              [Pure, ReturnLike, Terminator,
-               DeclareOpInterfaceMethods<RegionBranchTerminatorOpInterface,
-                                         ["getMutableSuccessorOperands"]>]> {
+def TestReturnWithIgnoredValueOp : TEST_Op<"return_with_ignored_value", [
+    Pure,
+    ReturnLike,
+    DeclareOpInterfaceMethods<RegionBranchTerminatorOpInterface, [
+      "getMutableSuccessorOperands"
+    ]>,
+    Terminator
+]> {
   let arguments = (ins Variadic<AnyType>:$values, AnyType:$unwanted_value);
 }
 
@@ -2718,11 +2720,10 @@ def LoopBlockOp : TEST_Op<"loop_block",
   }];
 }
 
-def LoopBlockTerminatorOp
-    : TEST_Op<"loop_block_term", [DeclareOpInterfaceMethods<
-                                      RegionBranchTerminatorOpInterface,
-                                      ["getMutableSuccessorOperands"]>,
-                                  Pure, Terminator]> {
+def LoopBlockTerminatorOp : TEST_Op<"loop_block_term",
+    [DeclareOpInterfaceMethods<RegionBranchTerminatorOpInterface,
+        ["getMutableSuccessorOperands"]>,
+     Pure, Terminator]> {
   let arguments = (ins I32:$nextIterArg, F32:$exitArg);
 
   let assemblyFormat = [{

--- a/mlir/test/lib/Dialect/Test/TestOps.td
+++ b/mlir/test/lib/Dialect/Test/TestOps.td
@@ -2243,9 +2243,11 @@ def TestReturnOp : TEST_Op<"return", [Pure, ReturnLike, Terminator]> {
 // When 'valid' unit-attr is absent the op is malformed; its verifier
 // emits an error, but getMutableSuccessorOperands() calls report_fatal_error
 // to expose the fact that FuncOp::verify() runs before the region is checked.
-def TestCrashingReturnOp : TEST_Op<"crashing_return", [
-    DeclareOpInterfaceMethods<RegionBranchTerminatorOpInterface>,
-    Terminator]> {
+def TestCrashingReturnOp
+    : TEST_Op<"crashing_return", [DeclareOpInterfaceMethods<
+                                      RegionBranchTerminatorOpInterface,
+                                      ["getMutableSuccessorOperands"]>,
+                                  Terminator]> {
   let arguments = (ins Variadic<AnyType>:$args, UnitAttr:$valid);
   let assemblyFormat = "($args^ `:` type($args))? attr-dict";
   let hasVerifier = 1;
@@ -2298,6 +2300,16 @@ def TestSignatureConversionUndoOp : TEST_Op<"signature_conversion_undo"> {
 def TestSignatureConversionNoConverterOp
   : TEST_Op<"signature_conversion_no_converter"> {
   let regions = (region AnyRegion);
+}
+
+// A return-like operation with override on the successor operand getter
+// interface method.
+def TestReturnWithIgnoredValueOp
+    : TEST_Op<"return_with_ignored_value",
+              [Pure, ReturnLike, Terminator,
+               DeclareOpInterfaceMethods<RegionBranchTerminatorOpInterface,
+                                         ["getMutableSuccessorOperands"]>]> {
+  let arguments = (ins Variadic<AnyType>:$values, AnyType:$unwanted_value);
 }
 
 //===----------------------------------------------------------------------===//
@@ -2706,9 +2718,11 @@ def LoopBlockOp : TEST_Op<"loop_block",
   }];
 }
 
-def LoopBlockTerminatorOp : TEST_Op<"loop_block_term",
-    [DeclareOpInterfaceMethods<RegionBranchTerminatorOpInterface>, Pure,
-     Terminator]> {
+def LoopBlockTerminatorOp
+    : TEST_Op<"loop_block_term", [DeclareOpInterfaceMethods<
+                                      RegionBranchTerminatorOpInterface,
+                                      ["getMutableSuccessorOperands"]>,
+                                  Pure, Terminator]> {
   let arguments = (ins I32:$nextIterArg, F32:$exitArg);
 
   let assemblyFormat = [{


### PR DESCRIPTION
Move the `getMutableSuccessorOperands` implementation from `ReturnLike` trait to the `RegionBranchTerminatorOpInterface` to allow overriding of the implementation. This allows to have the trait on operations that are not a return of all of their operands. This can be used, for example, to implement custom `ReturnLike` terminator that consumes non-returned operands in combination with `func.func`.

The `RegionBranchTerminatorOpInterface` now provides a default implementation for the `getMutableSuccessorOperands` method that returns all of the operands.
