### PR TITLE
[mlir][memref] Fix crash in expand-strided-metadata with multiple dynamic dims per group

### DIFF
--- a/mlir/lib/Dialect/MemRef/Transforms/ExpandStridedMetadata.cpp
+++ b/mlir/lib/Dialect/MemRef/Transforms/ExpandStridedMetadata.cpp
@@ -279,12 +279,13 @@ getExpandedSizes(memref::ExpandShapeOp expandShape, OpBuilder &builder,
   uint64_t productOfAllStaticSizes = 1;
   std::optional<unsigned> dynSizeIdx;
   MemRefType expandShapeType = expandShape.getResultType();
+  unsigned numDynamicDims = 0;
 
   // Fill up all the statically known sizes.
   for (unsigned i = 0; i < groupSize; ++i) {
     uint64_t dimSize = expandShapeType.getDimSize(reassocGroup[i]);
     if (ShapedType::isDynamic(dimSize)) {
-      assert(!dynSizeIdx && "There must be at most one dynamic size per group");
+      ++numDynamicDims;
       dynSizeIdx = i;
       continue;
     }
@@ -292,8 +293,18 @@ getExpandedSizes(memref::ExpandShapeOp expandShape, OpBuilder &builder,
     expandedSizes[i] = builder.getIndexAttr(dimSize);
   }
 
-  // Compute the dynamic size using the original size and all the other known
-  // static sizes:
+  // If there are multiple dynamic dims in this group, we cannot derive them
+  // from the source size alone. Use the output_shape operands directly.
+  if (numDynamicDims > 1) {
+    SmallVector<OpFoldResult> mixedOutputShape =
+        expandShape.getMixedOutputShape();
+    for (unsigned i = 0; i < groupSize; ++i)
+      expandedSizes[i] = mixedOutputShape[reassocGroup[i]];
+    return expandedSizes;
+  }
+
+  // Compute the single dynamic size using the original size and all the other
+  // known static sizes:
   // expandSize = origSize / productOfAllStaticSizes.
   if (dynSizeIdx) {
     AffineExpr s0 = builder.getAffineSymbolExpr(0);
@@ -342,6 +353,41 @@ SmallVector<OpFoldResult> getExpandedStrides(memref::ExpandShapeOp expandShape,
   unsigned groupSize = reassocGroup.size();
   MemRefType expandShapeType = expandShape.getResultType();
 
+  // Collect the statically known information about the original stride.
+  Value source = expandShape.getSrc();
+  auto sourceType = cast<MemRefType>(source.getType());
+  auto [strides, offset] = sourceType.getStridesAndOffset();
+
+  OpFoldResult origStride = ShapedType::isDynamic(strides[groupId])
+                                ? origStrides[groupId]
+                                : builder.getIndexAttr(strides[groupId]);
+
+  // Count the number of dynamic dims in this group.
+  unsigned numDynamicDims = 0;
+  for (unsigned i = 0; i < groupSize; ++i) {
+    if (ShapedType::isDynamic(expandShapeType.getDimSize(reassocGroup[i])))
+      ++numDynamicDims;
+  }
+
+  // If there are multiple dynamic dims, compute strides directly from
+  // output_shape sizes:
+  //   stride[last] = origStride
+  //   stride[i]    = stride[i+1] * outputShape[reassocGroup[i+1]]
+  if (numDynamicDims > 1) {
+    SmallVector<OpFoldResult> mixedOutputShape =
+        expandShape.getMixedOutputShape();
+    SmallVector<OpFoldResult> expandedStrides(groupSize);
+    expandedStrides[groupSize - 1] = origStride;
+    AffineExpr s0 = builder.getAffineSymbolExpr(0);
+    AffineExpr s1 = builder.getAffineSymbolExpr(1);
+    for (int i = groupSize - 2; i >= 0; --i) {
+      expandedStrides[i] = makeComposedFoldedAffineApply(
+          builder, expandShape.getLoc(), s0 * s1,
+          {expandedStrides[i + 1], mixedOutputShape[reassocGroup[i + 1]]});
+    }
+    return expandedStrides;
+  }
+
   std::optional<int64_t> dynSizeIdx;
 
   // Fill up the expanded strides, with the information we can deduce from the
@@ -352,22 +398,12 @@ SmallVector<OpFoldResult> getExpandedStrides(memref::ExpandShapeOp expandShape,
     expandedStrides[i] = builder.getIndexAttr(currentStride);
     uint64_t dimSize = expandShapeType.getDimSize(reassocGroup[i]);
     if (ShapedType::isDynamic(dimSize)) {
-      assert(!dynSizeIdx && "There must be at most one dynamic size per group");
       dynSizeIdx = i;
       continue;
     }
 
     currentStride *= dimSize;
   }
-
-  // Collect the statically known information about the original stride.
-  Value source = expandShape.getSrc();
-  auto sourceType = cast<MemRefType>(source.getType());
-  auto [strides, offset] = sourceType.getStridesAndOffset();
-
-  OpFoldResult origStride = ShapedType::isDynamic(strides[groupId])
-                                ? origStrides[groupId]
-                                : builder.getIndexAttr(strides[groupId]);
 
   // Apply the original stride to all the strides.
   int64_t doneStrideIdx = 0;

--- a/mlir/test/Dialect/MemRef/expand-strided-metadata.mlir
+++ b/mlir/test/Dialect/MemRef/expand-strided-metadata.mlir
@@ -1472,3 +1472,25 @@ func.func @negative_memref_view_extract_aligned_pointer(%arg0: memref<?xi8>) -> 
   %1 = memref.extract_aligned_pointer_as_index %0: memref<f32> -> index
   return %1 : index
 }
+
+// -----
+
+// Verify that expand_shape with multiple dynamic dims in one reassociation
+// group does not crash and produces correct reinterpret_cast.
+//
+// CHECK-DAG: #[[$EXPAND_STRIDE_MAP:.*]] = affine_map<()[s0, s1] -> (s0 * s1)>
+// CHECK-LABEL: func @simplify_expand_shape_multiple_dynamic_dims_per_group
+//  CHECK-SAME: (%[[ARG:.*]]: memref<?x?x?xf32>, %[[SZ0:.*]]: index, %[[SZ1:.*]]: index, %[[SZ2:.*]]: index, %[[SZ3:.*]]: index)
+//
+//   CHECK-DAG: %[[BASE:.*]], %[[OFFSET:.*]], %[[SIZES:.*]]:3, %[[STRIDES:.*]]:3 = memref.extract_strided_metadata %[[ARG]]
+//   CHECK-DAG: %[[STRIDE0:.*]] = affine.apply #[[$EXPAND_STRIDE_MAP]]()[%[[STRIDES]]#0, %[[SZ1]]]
+//       CHECK: %[[REINTERPRET_CAST:.*]] = memref.reinterpret_cast %[[BASE]] to offset: [0], sizes: [%[[SZ0]], %[[SZ1]], %[[SIZES]]#1, %[[SIZES]]#2], strides: [%[[STRIDE0]], %[[STRIDES]]#0, %[[STRIDES]]#1, 1]
+//       CHECK: return %[[REINTERPRET_CAST]]
+func.func @simplify_expand_shape_multiple_dynamic_dims_per_group(
+    %base: memref<?x?x?xf32>,
+    %sz0: index, %sz1: index, %sz2: index, %sz3: index) -> memref<?x?x?x?xf32> {
+  %expand = memref.expand_shape %base [[0, 1], [2], [3]]
+      output_shape [%sz0, %sz1, %sz2, %sz3]
+      : memref<?x?x?xf32> into memref<?x?x?x?xf32>
+  return %expand : memref<?x?x?x?xf32>
+}


### PR DESCRIPTION
`getExpandedSizes` and `getExpandedStrides` in `ExpandStridedMetadata.cpp` assumed at most one dynamic dimension per reassociation group in `expand_shape`. That assumption predates the `output_shape` operand, which allows multiple dynamic dims per group. When violated, a null `OpFoldResult` was passed to `dispatchIndexOpFoldResult`, causing a segfault in the `APInt` copy constructor.

Both functions now count dynamic dims in the group first. When there are more than one, they fall back to `getMixedOutputShape()` to get the actual sizes directly, then compute strides as `stride[i] = stride[i+1] * outputShape[reassocGroup[i+1]]` working from the innermost dim outward.

Regression test added in `expand-strided-metadata.mlir`.

Fixes https://github.com/llvm/llvm-project/issues/186830