### PR TITLE
[IRBuilder] add a general CreateLayoutReinterpretCast cast builder

### DIFF
--- a/llvm/include/llvm/IR/IRBuilder.h
+++ b/llvm/include/llvm/IR/IRBuilder.h
@@ -2300,6 +2300,18 @@ public:
   LLVM_ABI Value *CreateBitPreservingCastChain(const DataLayout &DL, Value *V,
                                                Type *NewTy);
 
+  /// Reinterpret the bits of \p Src (starting at \p SrcBitOffset) into \p
+  /// DestTy (starting at \p DstBitOffset). Operate on arbitrary aggregate types
+  /// using DataLayout for field offsets. Destination bits not covered by \p Src
+  /// are poison. Bit manipulation is performed leaf-by-leaf at most one leaf's
+  /// width at a time, so no unnecessary ptr casts will be inserted.
+  /// Does not support SVE, since it needs the layout to interpret offsets and
+  /// sizes. Use CreateBitPreservingCastChain internally to generate casts.
+  LLVM_ABI Value *CreateLayoutReinterpretCast(Value *Src, Type *DestTy,
+                                              uint64_t SrcBitOffset = 0,
+                                              uint64_t DstBitOffset = 0,
+                                              const Twine &Name = "");
+
   //===--------------------------------------------------------------------===//
   // Instruction creation methods: Compare Instructions
   //===--------------------------------------------------------------------===//

--- a/llvm/lib/IR/IRBuilder.cpp
+++ b/llvm/lib/IR/IRBuilder.cpp
@@ -139,7 +139,7 @@ Value *IRBuilderBase::CreateBitPreservingCastChain(const DataLayout &DL,
   };
 
   // See if we need inttoptr for this type pair. May require additional bitcast.
-  if (OldTy->isIntOrIntVectorTy() && NewTy->isPtrOrPtrVectorTy()) {
+  if (!OldTy->isPtrOrPtrVectorTy() && NewTy->isPtrOrPtrVectorTy()) {
     // Expand <2 x i32> to i8* --> <2 x i32> to i64 to i8*
     // Expand i128 to <2 x i8*> --> i128 to <2 x i64> to <2 x i8*>
     // Expand <4 x i32> to <2 x i8*> --> <4 x i32> to <2 x i64> to <2 x i8*>
@@ -148,7 +148,7 @@ Value *IRBuilderBase::CreateBitPreservingCastChain(const DataLayout &DL,
   }
 
   // See if we need ptrtoint for this type pair. May require additional bitcast.
-  if (OldTy->isPtrOrPtrVectorTy() && NewTy->isIntOrIntVectorTy()) {
+  if (OldTy->isPtrOrPtrVectorTy() && !NewTy->isPtrOrPtrVectorTy()) {
     // Expand <2 x i8*> to i128 --> <2 x i8*> to <2 x i64> to i128
     // Expand i8* to <2 x i32> --> i8* to i64 to <2 x i32>
     // Expand <2 x i8*> to <4 x i32> --> <2 x i8*> to <2 x i64> to <4 x i32>
@@ -174,6 +174,550 @@ Value *IRBuilderBase::CreateBitPreservingCastChain(const DataLayout &DL,
   }
 
   return CreateBitCastLike(V, NewTy);
+}
+
+//===----------------------------------------------------------------------===//
+// CreateLayoutReinterpretCast helpers
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+// Lazy DFS iterator over the leaves of a type tree.
+struct TypeLeafIterator {
+  // A fully structured GEP representation over a specific type
+  struct PathGEP {
+    // Type of parent
+    Type *ParentTy;
+    // Index of leaf element in Parent
+    unsigned CurrentIdx;
+    // Count of elements in Parent
+    unsigned EndIdx;
+    // Absolute byte offset, from start of outermost type.
+    uint64_t ParentOffset;
+  };
+
+  struct Leaf {
+    // Absolute byte offset, from start of outermost type.
+    uint64_t Offset;
+    // Size of Ty
+    uint64_t BitWidth;
+    // `advance` sets this to an integer, float, pointer, or vector thereof.
+    // `pop` sets it to the parent of that.
+    Type *Ty;
+  };
+
+  const DataLayout &DL;
+  SmallVector<PathGEP, 8> Path;
+  Leaf Element;
+  bool Done;
+
+  static unsigned numChildren(Type *Ty) {
+    if (auto *STy = dyn_cast<StructType>(Ty))
+      return STy->getNumElements();
+    if (auto *ATy = dyn_cast<ArrayType>(Ty))
+      return ATy->getNumElements();
+    return 0;
+  }
+
+  TypeLeafIterator(Type *RootTy, const DataLayout &DL) : DL(DL), Done(false) {
+    unsigned N = numChildren(RootTy);
+    if (N) {
+      Path.push_back({RootTy, -1U, N, 0});
+      advance();
+    } else
+      Element = Leaf{0, DL.getTypeStoreSizeInBits(RootTy), RootTy};
+  }
+
+  bool done() { return Done; }
+
+  void advance() {
+    while (!Path.empty()) {
+      PathGEP &W = Path.back();
+
+      unsigned Idx = ++W.CurrentIdx;
+      if (Idx == W.EndIdx) {
+        Path.pop_back();
+        continue;
+      }
+
+      Type *ChildTy;
+      uint64_t ChildBitOffset;
+      if (auto *STy = dyn_cast<StructType>(W.ParentTy)) {
+        ChildTy = STy->getElementType(Idx);
+        ChildBitOffset =
+            W.ParentOffset + DL.getStructLayout(STy)->getElementOffset(Idx);
+      } else if (auto *ATy = dyn_cast<ArrayType>(W.ParentTy)) {
+        // Arrays: stride is alloc size (includes tail padding on element)
+        ChildTy = ATy->getElementType();
+        ChildBitOffset = W.ParentOffset + Idx * DL.getTypeAllocSize(ChildTy);
+      }
+
+      unsigned N = numChildren(ChildTy);
+      if (N)
+        Path.push_back({ChildTy, -1U, N, ChildBitOffset});
+      else {
+        Element = {ChildBitOffset, DL.getTypeStoreSizeInBits(ChildTy), ChildTy};
+        return;
+      }
+    }
+    Done = true;
+  }
+
+  bool parent_equal(const TypeLeafIterator &O) const {
+    if (Path.empty() || O.Path.empty())
+      return false;
+    const PathGEP &PT = Path.back();
+    const PathGEP &PO = O.Path.back();
+    return PT.ParentTy == PO.ParentTy && PT.CurrentIdx == 0 &&
+           PO.CurrentIdx == 0;
+  }
+
+  void pop() {
+    PathGEP &W = Path.back();
+    assert(W.CurrentIdx == 0);
+    Element = {W.ParentOffset, DL.getTypeStoreSizeInBits(W.ParentTy),
+               W.ParentTy};
+    Path.pop_back();
+  }
+};
+
+// Build parameter for testing nested vs flat FCA: use incremental
+// insert/extract or full
+static const bool USE_FULL_IDX = false;
+struct AggChild {
+  Value *V = nullptr;
+  unsigned AtIdx = 0;
+};
+using IncompleteAgg = SmallVector<AggChild>;
+
+// Given a GEP path in SrcIt, extract Src, caching in Srcs.
+static Value *buildExtractSrc(IRBuilderBase &B, Value *Src,
+                              TypeLeafIterator SrcIt, IncompleteAgg &Srcs) {
+  auto &Path = SrcIt.Path;
+  size_t NumElem = Path.size();
+  if (NumElem == 0)
+    return Src;
+  if (USE_FULL_IDX) {
+    // TODO: implement caching in Srcs
+    SmallVector<unsigned> ChildIdxs;
+    ChildIdxs.reserve(NumElem);
+    for (auto Child : Path)
+      ChildIdxs.push_back(Child.CurrentIdx);
+    return B.CreateExtractValue(Src, ChildIdxs);
+  }
+  // Truncate old Srcs at first mismatching index
+  size_t Idx = 0;
+  for (; Idx < Srcs.size(); ++Idx) {
+    if (Idx >= NumElem || Srcs[Idx].AtIdx != Path[Idx].CurrentIdx) {
+      Srcs.truncate(Idx);
+      break;
+    }
+  }
+  // Then extract new index until completed
+  for (; Idx < NumElem; ++Idx) {
+    unsigned ChildIdx = Path[Idx].CurrentIdx;
+    Value *Base = Idx == 0 ? Src : Srcs[Idx - 1].V;
+    Base = B.CreateExtractValue(Base, ChildIdx);
+    Srcs.push_back({Base, ChildIdx});
+  }
+  return Srcs.back().V;
+}
+
+// Given a GEP path in DstIt, insert Fragment, caching in Dsts.
+static void buildInsertDst(IRBuilderBase &B, const TypeLeafIterator &DstIt,
+                           Value *Fragment, IncompleteAgg &Dsts) {
+  auto &Path = DstIt.Path;
+  size_t NumElem = Path.size();
+  if (NumElem == 0 && Fragment) {
+    assert(Dsts.empty());
+    Dsts.push_back({Fragment, -1U});
+    return;
+  }
+  if (USE_FULL_IDX) {
+    if (Dsts.empty())
+      Dsts.push_back({PoisonValue::get(Path[0].ParentTy), -1U});
+    if (!Fragment)
+      return;
+    SmallVector<unsigned> ChildIdxs;
+    ChildIdxs.reserve(NumElem);
+    for (auto Child : Path)
+      ChildIdxs.push_back(Child.CurrentIdx);
+    Dsts[0].V = B.CreateInsertValue(Dsts[0].V, Fragment, ChildIdxs);
+    return;
+  }
+  volatile size_t Idx = 0;
+  if (!Dsts.empty()) {
+    // Find first mismatching index in Dsts
+    for (; Idx < NumElem && Idx < Dsts.size(); ++Idx) {
+      unsigned ChildIdx = Path[Idx].CurrentIdx;
+      if (Dsts[Idx].AtIdx != ChildIdx)
+        break;
+    }
+    // Truncate until that is the last item
+    while (Idx + 1 < Dsts.size()) {
+      volatile AggChild Last = Dsts.pop_back_val();
+      AggChild &Parent = Dsts.back();
+      assert(Parent.AtIdx != -1U);
+      Parent.V = B.CreateInsertValue(Parent.V, Last.V, Parent.AtIdx);
+      Parent.AtIdx = -1;
+    }
+    if (NumElem == 0)
+      return;
+    // Update just child index of last item
+    Dsts[Idx].AtIdx = Path[Idx].CurrentIdx;
+    ++Idx;
+  }
+  assert(NumElem);
+  // Now initialize new elements in this path with poison
+  for (; Idx < NumElem; ++Idx) {
+    unsigned ChildIdx = Path[Idx].CurrentIdx;
+    Value *Base = PoisonValue::get(Path[Idx].ParentTy);
+    Dsts.push_back({Base, ChildIdx});
+  }
+  AggChild &Tail = Dsts.back();
+  assert(Tail.AtIdx == Path.back().CurrentIdx);
+  Tail.AtIdx = -1U; // Unused.
+  Tail.V = B.CreateInsertValue(Tail.V, Fragment, Path.back().CurrentIdx);
+}
+
+// Build the IR value for one destination leaf, given its source contributions.
+static Value *
+buildDstLeaf(IRBuilderBase &B, const DataLayout &DL,
+             Value *Fragment,      // Current parts of Dst, or nullptr
+             Type *Ty,             // Target Type
+             Value *SrcVal,        // Source Value
+             uint64_t SrcBitWidth, // Size of Src
+             uint64_t DstBitWidth, // Size of Dst
+             uint64_t SrcShift,    // Bytes to shift within src leaf before use.
+             uint64_t DstShift,    // Bytes to shift before placing in dst leaf.
+             uint64_t BitWidth) {  // Bits to be transferred.
+
+  // Type-preserving path: single full-width, zero-shift contribution where the
+  // source leaf is exactly the same width as the destination leaf.
+  if (Fragment == nullptr && SrcShift == 0 && DstShift == 0 &&
+      BitWidth == DstBitWidth && BitWidth == SrcBitWidth) {
+    return B.CreateBitPreservingCastChain(DL, SrcVal, Ty);
+  }
+
+  // Try to keep vectors as vectors, instead of using large integers.
+  // This is required, at minimum, when both types contain ptrs,
+  // since those need to get moved without inttoptr / ptrtoint pairs whenever
+  // applicable and possible.
+  if (BitWidth > 0 && BitWidth % 8 == 0) {
+    // If the source is a vector, try to extract the relevant element directly
+    // with extractelement, rather than converting the whole vector to an
+    // integer.
+    if ((SrcShift * 8) % BitWidth == 0) {
+      if (auto *SrcVecTy = dyn_cast<FixedVectorType>(SrcVal->getType())) {
+        Type *EltTy = SrcVecTy->getElementType();
+        bool SameWidthAsSrc = BitWidth == DL.getTypeSizeInBits(EltTy);
+        if (!SameWidthAsSrc && BitWidth == DstBitWidth && !Ty->isVectorTy() &&
+            SrcBitWidth % BitWidth == 0) {
+          // Bitcast SrcVal to a vector of Ty so that extractelement below can
+          // be used
+          unsigned NewNumElts = SrcBitWidth / BitWidth;
+          SrcVecTy = FixedVectorType::get(Ty, NewNumElts);
+          SrcVal = B.CreateBitPreservingCastChain(DL, SrcVal, SrcVecTy);
+          SameWidthAsSrc = true;
+        }
+        if (SameWidthAsSrc) {
+          // SrcShift is the byte offset from the start (LE) or end (BE) of the
+          // source vector register to the overlap region. Convert to element
+          // index.
+          uint64_t EltIdx = SrcShift * 8 / BitWidth;
+          if (DL.isBigEndian())
+            EltIdx = SrcVecTy->getNumElements() - 1 - EltIdx;
+          SrcVal = B.CreateExtractElement(SrcVal, EltIdx);
+          SrcBitWidth = BitWidth;
+          SrcShift = 0;
+          // After extractelement the type-preserving conditions may now hold;
+          // short-circuit to avoid the integer round-trip in the general path.
+          if (Fragment == nullptr && DstShift == 0 && BitWidth == DstBitWidth)
+            return B.CreateBitPreservingCastChain(DL, SrcVal, Ty);
+        }
+      }
+    }
+
+    // If the destination is a vector, try to place the
+    // value with insertelement rather than building a large integer and
+    // bitcasting at the end.
+    if ((DstShift * 8) % BitWidth == 0) {
+      if (auto *DstVecTy = dyn_cast<FixedVectorType>(Ty)) {
+        Type *EltTy = DstVecTy->getElementType();
+        bool SameWidthAsDst = BitWidth == DL.getTypeSizeInBits(EltTy);
+        if (!SameWidthAsDst && BitWidth == SrcBitWidth &&
+            !SrcVal->getType()->isVectorTy() && DstBitWidth % BitWidth == 0) {
+          // If possible, replace DstVecTy with a vector of SrcVal's type so
+          // that insertelement below can be used.
+          Type *SrcTy = SrcVal->getType();
+          unsigned NewNumElts = DstBitWidth / BitWidth;
+          DstVecTy = FixedVectorType::get(SrcTy, NewNumElts);
+          EltTy = SrcTy;
+          SameWidthAsDst = true;
+        }
+        if (SameWidthAsDst) {
+          // DstShift is the byte offset from the start (LE) or end (BE) of the
+          // destination vector register to the overlap region.
+          uint64_t EltIdx = DstShift * 8 / BitWidth;
+          if (DL.isBigEndian())
+            EltIdx = DstVecTy->getNumElements() - 1 - EltIdx;
+          Value *EltVal;
+          if (SrcShift == 0 && SrcBitWidth == BitWidth) {
+            // Source is already the right size; just bitcast to the element
+            // type.
+            EltVal = B.CreateBitPreservingCastChain(DL, SrcVal, EltTy);
+          } else {
+            // Extract the relevant bits from a larger source via integer ops.
+            if (!isa<IntegerType>(SrcVal->getType()))
+              SrcVal = B.CreateBitPreservingCastChain(DL, SrcVal,
+                                                      B.getIntNTy(SrcBitWidth));
+            if (SrcShift)
+              SrcVal = B.CreateLShr(SrcVal, SrcShift * 8);
+            SrcVal = B.CreateZExtOrTrunc(SrcVal, B.getIntNTy(BitWidth));
+            EltVal = B.CreateBitPreservingCastChain(DL, SrcVal, EltTy);
+          }
+          if (Fragment)
+            Fragment = B.CreateBitPreservingCastChain(DL, Fragment, DstVecTy);
+          else
+            Fragment = PoisonValue::get(DstVecTy);
+          return B.CreateInsertElement(Fragment, EltVal, EltIdx);
+        }
+      }
+    }
+
+    // If both source and destination are vectors, use shufflevector to transfer
+    // multiple elements at once, avoiding integer intermediates.
+    // Requires element-aligned shifts and transfer size.
+    if (isa<FixedVectorType>(SrcVal->getType())) {
+      if (auto *DVTy = dyn_cast<FixedVectorType>(Ty)) {
+        auto *SVTy = cast<FixedVectorType>(SrcVal->getType());
+        uint64_t DstEltBitSize = DL.getTypeSizeInBits(DVTy->getElementType());
+        uint64_t SrcEltBitSize = DL.getTypeSizeInBits(SVTy->getElementType());
+        // Prefer DstEltTy as the common element type (SrcVal gets
+        // reinterpreted). Fall back to SrcEltTy (result gets reinterpreted)
+        // when SrcBitWidth is not divisible by DstEltBitSize but DstBitWidth is
+        // by SrcEltBitSize.
+        Type *EltTy = nullptr;
+        uint64_t EltBitSize = 0;
+        if (DstEltBitSize > 0 && SrcBitWidth % DstEltBitSize == 0 &&
+            BitWidth % DstEltBitSize == 0 &&
+            (DstShift * 8) % DstEltBitSize == 0) {
+          EltTy = DVTy->getElementType();
+          EltBitSize = DstEltBitSize;
+        } else if (SrcEltBitSize > 0 && DstBitWidth % SrcEltBitSize == 0 &&
+                   BitWidth % SrcEltBitSize == 0 &&
+                   (DstShift * 8) % SrcEltBitSize == 0) {
+          EltTy = SVTy->getElementType();
+          EltBitSize = SrcEltBitSize;
+        }
+        if (EltTy) {
+          // Check whether the source extraction can be done directly in
+          // EltBitSize units, or whether we need to shuffle in SrcEltBitSize
+          // units first (when SrcShift is only aligned to SrcEltBitSize, not
+          // EltBitSize).
+          bool SrcShiftAligned = (SrcShift * 8) % EltBitSize == 0;
+          // Shuffle-before-cast: SrcShift aligns to SrcEltBitSize (not
+          // EltBitSize). A single shufflevector in SrcEltTy space directly into
+          // a NumResultElts_src-sized result, then bitcast to ResultVecTy.
+          // Requires both Src/DstShift aligned to SrcEltBitSize.
+          bool ShuffleBeforeCast = !SrcShiftAligned && SrcEltBitSize > 0 &&
+                                   BitWidth % SrcEltBitSize == 0 &&
+                                   (SrcShift * 8) % SrcEltBitSize == 0 &&
+                                   DstBitWidth % SrcEltBitSize == 0 &&
+                                   (DstShift * 8) % SrcEltBitSize == 0;
+          if (SrcShiftAligned || ShuffleBeforeCast) {
+
+            uint64_t NumResultElts = DstBitWidth / EltBitSize;
+            uint64_t NumTransferElts = BitWidth / EltBitSize;
+            uint64_t DstStartElt = (DstShift * 8) / EltBitSize;
+            if (DL.isBigEndian())
+              DstStartElt = NumResultElts - DstStartElt - NumTransferElts;
+
+            auto *ResultVecTy = FixedVectorType::get(EltTy, NumResultElts);
+            // Step 1: scatter the transferred elements into a ResultVecTy-sized
+            // vector at their destination positions (poison elsewhere).
+            // SrcShiftAligned: cast SrcVal to EltTy view, then shufflevector.
+            // ShuffleBeforeCast: shufflevector in SrcEltTy space, then bitcast.
+            Value *SrcExtracted;
+            if (SrcShiftAligned) {
+              uint64_t NumCommonElts = SrcBitWidth / EltBitSize;
+              uint64_t SrcStartElt = (SrcShift * 8) / EltBitSize;
+              if (DL.isBigEndian())
+                SrcStartElt = NumCommonElts - SrcStartElt - NumTransferElts;
+              auto *CommonVecTy = FixedVectorType::get(EltTy, NumCommonElts);
+              Value *SrcAsCommon =
+                  B.CreateBitPreservingCastChain(DL, SrcVal, CommonVecTy);
+              SmallVector<int, 16> ScatterMask(NumResultElts, -1);
+              for (unsigned k = 0; k < NumTransferElts; ++k)
+                ScatterMask[DstStartElt + k] = SrcStartElt + k;
+              Value *FragAsCommon = Fragment && NumCommonElts == NumResultElts
+                                        ? B.CreateBitPreservingCastChain(
+                                              DL, Fragment, CommonVecTy)
+                                        : PoisonValue::get(CommonVecTy);
+              if (Fragment && NumCommonElts == NumResultElts) {
+                for (unsigned i = 0; i < NumResultElts; ++i)
+                  if (ScatterMask[i] == -1)
+                    ScatterMask[i] = NumCommonElts + i;
+                Fragment = nullptr;
+              }
+              SrcExtracted =
+                  B.CreateShuffleVector(SrcAsCommon, FragAsCommon, ScatterMask);
+            } else {
+              // SrcShift aligns to SrcEltBitSize but not EltBitSize: scatter in
+              // SrcEltTy space directly to the result-sized vector, then
+              // bitcast.
+              uint64_t NumResultElts_src = DstBitWidth / SrcEltBitSize;
+              uint64_t NumTransferElts_src = BitWidth / SrcEltBitSize;
+              uint64_t NumSrcElts = SrcBitWidth / SrcEltBitSize;
+              uint64_t SrcStartElt_src = (SrcShift * 8) / SrcEltBitSize;
+              uint64_t DstStartElt_src = (DstShift * 8) / SrcEltBitSize;
+              if (DL.isBigEndian()) {
+                SrcStartElt_src =
+                    NumSrcElts - SrcStartElt_src - NumTransferElts_src;
+                DstStartElt_src =
+                    NumResultElts_src - DstStartElt_src - NumTransferElts_src;
+              }
+              SmallVector<int, 16> ScatterMask(NumResultElts_src, -1);
+              for (unsigned k = 0; k < NumTransferElts_src; ++k)
+                ScatterMask[DstStartElt_src + k] = SrcStartElt_src + k;
+              Value *Shuffled = B.CreateShuffleVector(
+                  SrcVal, PoisonValue::get(SVTy), ScatterMask);
+              SrcExtracted =
+                  B.CreateBitPreservingCastChain(DL, Shuffled, ResultVecTy);
+            }
+
+            // Step 2: blend SrcExtracted with Fragment if needed.
+            if (!Fragment)
+              return SrcExtracted;
+            Value *FragAsDst =
+                Fragment
+                    ? B.CreateBitPreservingCastChain(DL, Fragment, ResultVecTy)
+                    : PoisonValue::get(ResultVecTy);
+            SmallVector<int, 16> Mask(NumResultElts);
+            for (unsigned i = 0; i < NumResultElts; ++i)
+              Mask[i] = (i >= DstStartElt && i < DstStartElt + NumTransferElts)
+                            ? (int)(NumResultElts + i)
+                            : (Fragment ? (int)i : -1);
+            return B.CreateShuffleVector(FragAsDst, SrcExtracted, Mask);
+          } // SrcShiftAligned || ShuffleBeforeCast
+        }
+      }
+    }
+  }
+
+  // General path: accumulate into an integer of DstLeaf.BitWidth
+  // for integers, floats, and pointers.
+  if (!isa<IntegerType>(SrcVal->getType()))
+    SrcVal =
+        B.CreateBitPreservingCastChain(DL, SrcVal, B.getIntNTy(SrcBitWidth));
+  if (SrcShift)
+    SrcVal = B.CreateLShr(SrcVal, SrcShift * 8);
+  if (BitWidth < DstBitWidth && BitWidth + SrcShift * 8 < SrcBitWidth)
+    SrcVal = B.CreateAnd(SrcVal, APInt::getLowBitsSet(SrcBitWidth, BitWidth));
+  SrcVal = B.CreateZExtOrTrunc(SrcVal, B.getIntNTy(DstBitWidth));
+  if (DstShift)
+    SrcVal = B.CreateShl(SrcVal, DstShift * 8);
+  if (Fragment) {
+    if (Fragment->getType() != SrcVal->getType()) {
+      assert(isa<FixedVectorType>(Ty));
+      Fragment = B.CreateBitPreservingCastChain(DL, Fragment,
+                                                B.getIntNTy(DstBitWidth));
+    }
+    SrcVal = B.CreateOr(Fragment, SrcVal);
+  }
+  return SrcVal;
+}
+
+} // anonymous namespace
+
+Value *IRBuilderBase::CreateLayoutReinterpretCast(Value *Src, Type *DestTy,
+                                                  uint64_t SrcOffset,
+                                                  uint64_t DstOffset,
+                                                  const Twine &Name) {
+  const DataLayout &DL = BB->getDataLayout();
+  TypeLeafIterator SrcIt(Src->getType(), DL);
+  TypeLeafIterator DstIt(DestTy, DL);
+  IncompleteAgg ExtractedSrc;
+  IncompleteAgg InsertedDst;
+
+  // Build destination aggregate leaf by leaf.
+  for (; !DstIt.done(); DstIt.advance()) {
+    TypeLeafIterator::Leaf &DstLeaf = DstIt.Element;
+    if (DstLeaf.BitWidth == 0)
+      continue;
+    uint64_t DStart = DstLeaf.Offset + DstOffset;
+    uint64_t DBitEnd = DStart * 8 + DstLeaf.BitWidth;
+    Value *Fragment = nullptr;
+    for (; !SrcIt.done(); SrcIt.advance()) {
+      TypeLeafIterator::Leaf &SrcLeaf = SrcIt.Element;
+      if (SrcLeaf.BitWidth == 0)
+        continue;
+      uint64_t SStart = SrcLeaf.Offset + SrcOffset;
+      uint64_t SBitEnd = SStart * 8 + SrcLeaf.BitWidth;
+      if (SBitEnd <= DStart * 8)
+        continue;
+      if (SStart * 8 >= DBitEnd)
+        break;
+      // Have the first element with any overlap.
+      if (SStart == DStart && SrcLeaf.Ty == DstLeaf.Ty) {
+        // In this case, all the math and casts below are zeros and no-ops.
+        // But that also means we might be able to extract more at once.
+        while (DstIt.parent_equal(SrcIt)) {
+          DstIt.pop();
+          SrcIt.pop();
+        }
+        Fragment = buildExtractSrc(*this, Src, SrcIt, ExtractedSrc);
+        assert(Fragment->getType() == DstLeaf.Ty);
+        break;
+      }
+      // Compute the range of bits that overlap in memory.
+      Value *Extract = buildExtractSrc(*this, Src, SrcIt, ExtractedSrc);
+      uint64_t OvStart = std::max(SStart, DStart);
+      uint64_t OvBitEnd = std::min(SBitEnd, DBitEnd);
+      uint64_t OvBitWidth = OvBitEnd - OvStart * 8;
+      // Convert that byte index to a register bit shift, from either the start
+      // (LE) or the end (BE).
+      //
+      // LangRef: a non-byte-sized store behaves like a zext followed by a
+      // byte-sized store.
+      bool LE = DL.isLittleEndian();
+      uint64_t SrcShift =
+          LE ? OvStart - SStart
+             : (alignToPowerOf2(SBitEnd, 8) - alignToPowerOf2(OvBitEnd, 8)) / 8;
+      uint64_t DstShift =
+          LE ? OvStart - DStart
+             : (alignToPowerOf2(DBitEnd, 8) - alignToPowerOf2(OvBitEnd, 8)) / 8;
+      Fragment = buildDstLeaf(*this, DL, Fragment, DstLeaf.Ty, Extract,
+                              SrcLeaf.BitWidth, DstLeaf.BitWidth, SrcShift,
+                              DstShift, OvBitWidth);
+      if (SBitEnd >= DBitEnd)
+        break;
+    }
+    if (Fragment) {
+      Fragment = CreateBitPreservingCastChain(DL, Fragment, DstLeaf.Ty);
+      buildInsertDst(*this, DstIt, Fragment, InsertedDst);
+    }
+    if (SrcIt.done()) {
+      DstIt.Path.clear();
+      break;
+    }
+  }
+
+  assert(DstIt.Path.empty());
+  Value *Result;
+  if (InsertedDst.empty()) {
+    // No overlapping bits got extracted.
+    Result = PoisonValue::get(DestTy);
+  } else {
+    // Create final CreateInsertValue chain.
+    buildInsertDst(*this, DstIt, nullptr, InsertedDst);
+    assert(InsertedDst.size() == 1);
+    Result = InsertedDst.back().V;
+  }
+
+  if (auto *I = dyn_cast<Instruction>(Result))
+    I->setName(Name);
+  return Result;
 }
 
 CallInst *

--- a/llvm/unittests/IR/IRBuilderTest.cpp
+++ b/llvm/unittests/IR/IRBuilderTest.cpp
@@ -21,9 +21,11 @@
 #include "llvm/IR/NoFolder.h"
 #include "llvm/IR/PatternMatch.h"
 #include "llvm/IR/Verifier.h"
+#include "llvm/Support/raw_ostream.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
+#include <string>
 #include <type_traits>
 
 using namespace llvm;
@@ -1436,4 +1438,1219 @@ TEST_F(IRBuilderTest, CreateAggregateRet) {
 
   EXPECT_FALSE(verifyModule(*M));
 }
+
+// ============================================================
+// Tests for IRBuilderBase::CreateLayoutReinterpretCast
+// ============================================================
+
+struct DLConfig {
+  bool BigEndian;
+  unsigned AS0PtrBits; ///< pointer size for address space 0 (32 or 64)
+};
+
+void PrintTo(const DLConfig &C, std::ostream *OS) {
+  *OS << (C.BigEndian ? "BE" : "LE") << C.AS0PtrBits;
 }
+
+/// Fixture that sets a concrete DataLayout on the shared module so that
+/// aggregate-field offsets and pointer sizes are well-defined.
+///
+/// Parameterized over endianness and AS0 pointer width.  AS1 is always
+/// 32-bit and AS2 is always 64-bit so that the pointer-cast tests have
+/// a fixed reference for "diff-size" and "same-size" variants.
+class LayoutReinterpretCastTest
+    : public IRBuilderTest,
+      public ::testing::WithParamInterface<DLConfig> {
+protected:
+  bool isBigEndian() const { return GetParam().BigEndian; }
+  unsigned as0PtrBits() const { return GetParam().AS0PtrBits; }
+
+  void SetUp() override {
+    IRBuilderTest::SetUp();
+    unsigned PS = as0PtrBits();
+    std::string DL = isBigEndian() ? "E" : "e";
+    DL += "-p:" + std::to_string(PS) + ":" + std::to_string(PS);
+    DL += "-p1:32:32-p2:64:64"
+          "-i8:8:8-i16:16:16-i32:32:32-i64:64:64"
+          "-f32:32:32-f64:64:64-n8:16:32:64";
+    M->setDataLayout(DL);
+    IRBuilder<>(BB).CreateRetVoid();
+  }
+
+  /// Verify the module and check that the instructions printed before the
+  /// trailing "  ret void" end with \p Expected.  Pass an empty string to
+  /// skip the suffix check and only verify the module.
+  void nameBB() {
+    size_t Idx = 0;
+    for (auto &I : *BB) {
+      ++Idx;
+      if (!I.getType()->isVoidTy() && !I.hasName())
+        I.setName(BB->getName() + "." + Twine(Idx));
+    }
+  }
+
+  void checkBB(StringRef Expected) {
+    EXPECT_FALSE(verifyModule(*M, &errs()));
+    std::string S;
+    raw_string_ostream OS(S);
+    BB->print(OS);
+    // Strip the shared "  ret void\n" trailer so callers only supply the
+    // instructions of interest.
+    StringRef Actual(S);
+    const StringRef RetVoid = "  ret void\n";
+    if (Actual.ends_with(RetVoid))
+      Actual = Actual.drop_back(RetVoid.size());
+    if (Expected.empty())
+      EXPECT_TRUE(Actual.trim().empty())
+          << "Expected no instructions before ret:\n"
+          << Expected << "\nActual BB:\n"
+          << S;
+    else
+      EXPECT_TRUE(Actual.ends_with(Expected))
+          << "Expected BB suffix (before ret void):\n"
+          << Expected << "\nActual BB:\n"
+          << S;
+  }
+
+  /// Build a non-constant value of type Ty so that instructions emitted by
+  /// CreateLayoutReinterpretCast are visible (not folded away).
+  Value *makeVal(IRBuilderBase &B, Type *Ty) { return B.CreateLoad(Ty, GV); }
+};
+
+// ---------------------------------------------------------------------------
+// Fast path: leaf-to-leaf with matching bitwidth
+// ---------------------------------------------------------------------------
+
+/// i32 → float: single bitcast, no integer accumulation.
+TEST_P(LayoutReinterpretCastTest, I32ToFloat) {
+  IRBuilder<NoFolder> B(BB->getTerminator());
+  Type *I32Ty = B.getInt32Ty();
+  Type *F32Ty = B.getFloatTy();
+  Value *Src = makeVal(B, I32Ty);
+  Value *Result = B.CreateLayoutReinterpretCast(Src, F32Ty);
+  EXPECT_EQ(Result->getType(), F32Ty);
+  EXPECT_TRUE(isa<BitCastInst>(Result));
+  checkBB("  %2 = bitcast i32 %1 to float\n");
+}
+
+/// float → i32: single bitcast.
+TEST_P(LayoutReinterpretCastTest, FloatToI32) {
+  IRBuilder<NoFolder> B(BB->getTerminator());
+  Type *F32Ty = B.getFloatTy();
+  Type *I32Ty = B.getInt32Ty();
+  Value *Src = makeVal(B, F32Ty);
+  Value *Result = B.CreateLayoutReinterpretCast(Src, I32Ty);
+  EXPECT_EQ(Result->getType(), I32Ty);
+  EXPECT_TRUE(isa<BitCastInst>(Result));
+  checkBB("  %2 = bitcast float %1 to i32\n");
+}
+
+/// Same source and destination type
+TEST_P(LayoutReinterpretCastTest, SameType) {
+  IRBuilder<NoFolder> B(BB->getTerminator());
+  Type *I32Ty = B.getInt32Ty();
+  Value *Src = makeVal(B, I32Ty);
+  Value *Result = B.CreateLayoutReinterpretCast(Src, I32Ty);
+  EXPECT_EQ(Result, Src);
+  checkBB("  %1 = load i32, ptr @0, align 4\n");
+}
+
+/// {ptr, i32} → {ptr, i32} → {{ptr, i32}} → {ptr, i32} → {{ptr, i32}, {ptr,
+/// i32}}
+TEST_P(LayoutReinterpretCastTest, PtrStruct_SameType) {
+  IRBuilder<NoFolder> B(BB->getTerminator());
+  Type *PtrTy = B.getPtrTy(0);
+  StructType *STy = StructType::get(PtrTy, B.getInt32Ty());
+  Value *Src = makeVal(B, STy);
+  Value *Result = B.CreateLayoutReinterpretCast(Src, STy);
+  EXPECT_EQ(Result->getType(), STy);
+  EXPECT_TRUE(isa<LoadInst>(Result));
+  if (as0PtrBits() == 64)
+    checkBB("  %1 = load { ptr, i32 }, ptr @0, align 8\n");
+  else
+    checkBB("  %1 = load { ptr, i32 }, ptr @0, align 4\n");
+
+  StructType *STyW = StructType::get(STy);
+  Result = B.CreateLayoutReinterpretCast(Result, STyW);
+  EXPECT_EQ(Result->getType(), STyW);
+  EXPECT_TRUE(isa<InsertValueInst>(Result));
+  Result = B.CreateLayoutReinterpretCast(Result, STy);
+  EXPECT_EQ(Result->getType(), STy);
+  EXPECT_TRUE(isa<ExtractValueInst>(Result));
+  StructType *STyW2 = StructType::get(STy, STy);
+  Result = B.CreateLayoutReinterpretCast(Result, STyW2);
+  EXPECT_EQ(Result->getType(), STyW2);
+  EXPECT_TRUE(isa<InsertValueInst>(Result));
+  checkBB("  %2 = insertvalue { { ptr, i32 } } poison, { ptr, i32 } %1, 0\n"
+          "  %3 = extractvalue { { ptr, i32 } } %2, 0\n"
+          "  %4 = insertvalue { { ptr, i32 }, { ptr, i32 } } poison, { ptr, "
+          "i32 } %3, 0\n");
+}
+
+// ---------------------------------------------------------------------------
+// Pointer casts
+// ---------------------------------------------------------------------------
+
+/// ptr (AS0) → i64: single ptrtoint when AS0=64, ptrtoint+zext when AS0=32.
+TEST_P(LayoutReinterpretCastTest, PtrToI64) {
+  IRBuilder<NoFolder> B(BB->getTerminator());
+  Type *PtrTy = B.getPtrTy(0);
+  Type *I64Ty = B.getInt64Ty();
+  Value *Src = makeVal(B, PtrTy);
+  Value *Result = B.CreateLayoutReinterpretCast(Src, I64Ty);
+  EXPECT_EQ(Result->getType(), I64Ty);
+  if (as0PtrBits() == 64) {
+    EXPECT_TRUE(isa<PtrToIntInst>(Result));
+    checkBB("  %2 = ptrtoint ptr %1 to i64\n");
+  } else if (!isBigEndian()) {
+    EXPECT_TRUE(isa<ZExtInst>(Result));
+    checkBB("  %2 = ptrtoint ptr %1 to i32\n"
+            "  %3 = zext i32 %2 to i64\n");
+  } else {
+    EXPECT_TRUE(isa<BinaryOperator>(Result));
+    checkBB("  %2 = ptrtoint ptr %1 to i32\n"
+            "  %3 = zext i32 %2 to i64\n"
+            "  %4 = shl i64 %3, 32\n");
+  }
+}
+
+/// i64 → ptr (AS0): single inttoptr when AS0=64, trunc+inttoptr when AS0=32.
+TEST_P(LayoutReinterpretCastTest, I64ToPtr) {
+  IRBuilder<NoFolder> B(BB->getTerminator());
+  Type *I64Ty = B.getInt64Ty();
+  Type *PtrTy = B.getPtrTy(0);
+  Value *Src = makeVal(B, I64Ty);
+  Value *Result = B.CreateLayoutReinterpretCast(Src, PtrTy);
+  EXPECT_EQ(Result->getType(), PtrTy);
+  EXPECT_TRUE(isa<IntToPtrInst>(Result));
+  if (as0PtrBits() == 64) {
+    checkBB("  %2 = inttoptr i64 %1 to ptr\n");
+  } else if (!isBigEndian()) {
+    checkBB("  %2 = trunc i64 %1 to i32\n"
+            "  %3 = inttoptr i32 %2 to ptr\n");
+  } else {
+    checkBB("  %2 = lshr i64 %1, 32\n"
+            "  %3 = trunc i64 %2 to i32\n"
+            "  %4 = inttoptr i32 %3 to ptr\n");
+  }
+}
+
+/// ptr (AS0) → float: ptrtoint to integer, trunc if needed, bitcast to float.
+TEST_P(LayoutReinterpretCastTest, PtrToFloat) {
+  IRBuilder<NoFolder> B(BB->getTerminator());
+  Type *PtrTy = B.getPtrTy(0);
+  Type *F32Ty = B.getFloatTy();
+  Value *Src = makeVal(B, PtrTy);
+  Value *Result = B.CreateLayoutReinterpretCast(Src, F32Ty);
+  EXPECT_EQ(Result->getType(), F32Ty);
+  if (as0PtrBits() == 64) {
+    if (!isBigEndian()) {
+      checkBB("  %2 = ptrtoint ptr %1 to i64\n"
+              "  %3 = trunc i64 %2 to i32\n"
+              "  %4 = bitcast i32 %3 to float\n");
+    } else {
+      checkBB("  %2 = ptrtoint ptr %1 to i64\n"
+              "  %3 = lshr i64 %2, 32\n"
+              "  %4 = trunc i64 %3 to i32\n"
+              "  %5 = bitcast i32 %4 to float\n");
+    }
+  } else {
+    checkBB("  %2 = ptrtoint ptr %1 to i32\n"
+            "  %3 = bitcast i32 %2 to float\n");
+  }
+}
+
+/// ptr (AS0) → ptr (AS2, always 64-bit): always uses ptrtoint/inttoptr.
+TEST_P(LayoutReinterpretCastTest, PtrSameSize) {
+  IRBuilder<NoFolder> B(BB->getTerminator());
+  Type *PtrAS0 = B.getPtrTy(0);
+  Type *PtrAS2 = B.getPtrTy(2); // always 64-bit
+  Value *Src = makeVal(B, PtrAS0);
+  Value *Result = B.CreateLayoutReinterpretCast(Src, PtrAS2);
+  EXPECT_EQ(Result->getType(), PtrAS2);
+  EXPECT_TRUE(isa<IntToPtrInst>(Result));
+  if (as0PtrBits() == 64) {
+    checkBB("  %2 = ptrtoint ptr %1 to i64\n"
+            "  %3 = inttoptr i64 %2 to ptr addrspace(2)\n");
+  } else if (!isBigEndian()) {
+    checkBB("  %2 = ptrtoint ptr %1 to i32\n"
+            "  %3 = zext i32 %2 to i64\n"
+            "  %4 = inttoptr i64 %3 to ptr addrspace(2)\n");
+  } else {
+    checkBB("  %2 = ptrtoint ptr %1 to i32\n"
+            "  %3 = zext i32 %2 to i64\n"
+            "  %4 = shl i64 %3, 32\n"
+            "  %5 = inttoptr i64 %4 to ptr addrspace(2)\n");
+  }
+}
+
+/// ptr (AS0) → ptr (AS1, always 32-bit): ptrtoint/trunc/inttoptr when AS0 >
+/// AS1; ptrtoint/inttoptr when both are 32-bit.
+TEST_P(LayoutReinterpretCastTest, PtrDiffSize) {
+  IRBuilder<NoFolder> B(BB->getTerminator());
+  Type *PtrAS0 = B.getPtrTy(0);
+  Type *PtrAS1 = B.getPtrTy(1); // always 32-bit
+  Value *Src = makeVal(B, PtrAS0);
+  Value *Result = B.CreateLayoutReinterpretCast(Src, PtrAS1);
+  EXPECT_EQ(Result->getType(), PtrAS1);
+  if (as0PtrBits() == 64 && !isBigEndian()) {
+    EXPECT_TRUE(isa<IntToPtrInst>(Result));
+    checkBB("  %2 = ptrtoint ptr %1 to i64\n"
+            "  %3 = trunc i64 %2 to i32\n"
+            "  %4 = inttoptr i32 %3 to ptr addrspace(1)\n");
+  } else if (as0PtrBits() == 64) {
+    EXPECT_TRUE(isa<IntToPtrInst>(Result));
+    checkBB("  %2 = ptrtoint ptr %1 to i64\n"
+            "  %3 = lshr i64 %2, 32\n"
+            "  %4 = trunc i64 %3 to i32\n"
+            "  %5 = inttoptr i32 %4 to ptr addrspace(1)\n");
+  } else {
+    EXPECT_FALSE(isa<AddrSpaceCastInst>(Result));
+    EXPECT_TRUE(isa<IntToPtrInst>(Result));
+    checkBB("  %2 = ptrtoint ptr %1 to i32\n"
+            "  %3 = inttoptr i32 %2 to ptr addrspace(1)\n");
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Struct ↔ integer
+// ---------------------------------------------------------------------------
+
+/// {i32, i32} → i64: two i32 halves are OR-assembled into an i64.
+TEST_P(LayoutReinterpretCastTest, StructI32x2_ToI64) {
+  IRBuilder<NoFolder> B(BB->getTerminator());
+  StructType *STy = StructType::get(B.getInt32Ty(), B.getInt32Ty());
+  Type *I64Ty = B.getInt64Ty();
+  Value *Src = makeVal(B, STy);
+  Value *Result = B.CreateLayoutReinterpretCast(Src, I64Ty);
+  EXPECT_EQ(Result->getType(), I64Ty);
+  if (!isBigEndian()) {
+    checkBB("  %2 = extractvalue { i32, i32 } %1, 0\n"
+            "  %3 = zext i32 %2 to i64\n"
+            "  %4 = extractvalue { i32, i32 } %1, 1\n"
+            "  %5 = zext i32 %4 to i64\n"
+            "  %6 = shl i64 %5, 32\n"
+            "  %7 = or i64 %3, %6\n");
+  } else {
+    checkBB("  %2 = extractvalue { i32, i32 } %1, 0\n"
+            "  %3 = zext i32 %2 to i64\n"
+            "  %4 = shl i64 %3, 32\n"
+            "  %5 = extractvalue { i32, i32 } %1, 1\n"
+            "  %6 = zext i32 %5 to i64\n"
+            "  %7 = or i64 %4, %6\n");
+  }
+}
+
+/// i64 → {i32, i32}: i64 is split into two i32 fields.
+TEST_P(LayoutReinterpretCastTest, I64_ToStructI32x2) {
+  IRBuilder<NoFolder> B(BB->getTerminator());
+  Type *I64Ty = B.getInt64Ty();
+  StructType *STy = StructType::get(B.getInt32Ty(), B.getInt32Ty());
+  Value *Src = makeVal(B, I64Ty);
+  Value *Result = B.CreateLayoutReinterpretCast(Src, STy);
+  EXPECT_EQ(Result->getType(), STy);
+  if (!isBigEndian()) {
+    checkBB("  %2 = trunc i64 %1 to i32\n"
+            "  %3 = insertvalue { i32, i32 } poison, i32 %2, 0\n"
+            "  %4 = lshr i64 %1, 32\n"
+            "  %5 = trunc i64 %4 to i32\n"
+            "  %6 = insertvalue { i32, i32 } %3, i32 %5, 1\n");
+  } else {
+    checkBB("  %2 = lshr i64 %1, 32\n"
+            "  %3 = trunc i64 %2 to i32\n"
+            "  %4 = insertvalue { i32, i32 } poison, i32 %3, 0\n"
+            "  %5 = trunc i64 %1 to i32\n"
+            "  %6 = insertvalue { i32, i32 } %4, i32 %5, 1\n");
+  }
+}
+
+/// {i16, i16} → i32: two 16-bit halves zext-shifted into a 32-bit integer.
+TEST_P(LayoutReinterpretCastTest, StructI16x2_ToI32) {
+  IRBuilder<NoFolder> B(BB->getTerminator());
+  StructType *STy = StructType::get(B.getInt16Ty(), B.getInt16Ty());
+  Type *I32Ty = B.getInt32Ty();
+  Value *Src = makeVal(B, STy);
+  Value *Result = B.CreateLayoutReinterpretCast(Src, I32Ty);
+  EXPECT_EQ(Result->getType(), I32Ty);
+  if (!isBigEndian()) {
+    checkBB("  %2 = extractvalue { i16, i16 } %1, 0\n"
+            "  %3 = zext i16 %2 to i32\n"
+            "  %4 = extractvalue { i16, i16 } %1, 1\n"
+            "  %5 = zext i16 %4 to i32\n"
+            "  %6 = shl i32 %5, 16\n"
+            "  %7 = or i32 %3, %6\n");
+  } else {
+    checkBB("  %2 = extractvalue { i16, i16 } %1, 0\n"
+            "  %3 = zext i16 %2 to i32\n"
+            "  %4 = shl i32 %3, 16\n"
+            "  %5 = extractvalue { i16, i16 } %1, 1\n"
+            "  %6 = zext i16 %5 to i32\n"
+            "  %7 = or i32 %4, %6\n");
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Vector ↔ scalar / struct
+// ---------------------------------------------------------------------------
+
+/// <4 x i8> → i32: four bytes OR-assembled into a 32-bit integer.
+TEST_P(LayoutReinterpretCastTest, Vec4xi8_ToI32) {
+  IRBuilder<NoFolder> B(BB->getTerminator());
+  Type *VTy = FixedVectorType::get(B.getInt8Ty(), 4);
+  Type *I32Ty = B.getInt32Ty();
+  Value *Src = makeVal(B, VTy);
+  Value *Result = B.CreateLayoutReinterpretCast(Src, I32Ty);
+  EXPECT_EQ(Result->getType(), I32Ty);
+  checkBB("  %2 = bitcast <4 x i8> %1 to i32\n");
+}
+
+/// i32 → <4 x i8>: i32 is split into four byte-wide vector elements.
+TEST_P(LayoutReinterpretCastTest, I32_ToVec4xi8) {
+  IRBuilder<NoFolder> B(BB->getTerminator());
+  Type *I32Ty = B.getInt32Ty();
+  Type *VTy = FixedVectorType::get(B.getInt8Ty(), 4);
+  Value *Src = makeVal(B, I32Ty);
+  Value *Result = B.CreateLayoutReinterpretCast(Src, VTy);
+  EXPECT_EQ(Result->getType(), VTy);
+  checkBB("  %2 = bitcast i32 %1 to <4 x i8>\n");
+}
+
+// ---------------------------------------------------------------------------
+// Sub-byte element vector (<4 x i4>) casts
+// ---------------------------------------------------------------------------
+
+/// <4 x i4> → i16: same 16-bit reinterpretation via bitcast.
+TEST_P(LayoutReinterpretCastTest, Vec4xi4_ToI16) {
+  IRBuilder<NoFolder> B(BB->getTerminator());
+  Type *VTy = FixedVectorType::get(Type::getIntNTy(Ctx, 4), 4);
+  Type *I16Ty = B.getInt16Ty();
+  Value *Src = makeVal(B, VTy);
+  Value *Result = B.CreateLayoutReinterpretCast(Src, I16Ty);
+  EXPECT_EQ(Result->getType(), I16Ty);
+  EXPECT_TRUE(isa<BitCastInst>(Result));
+  checkBB("  %2 = bitcast <4 x i4> %1 to i16\n");
+}
+
+/// i16 → <4 x i4>: same 16-bit reinterpretation via bitcast.
+TEST_P(LayoutReinterpretCastTest, I16_ToVec4xi4) {
+  IRBuilder<NoFolder> B(BB->getTerminator());
+  Type *I16Ty = B.getInt16Ty();
+  Type *VTy = FixedVectorType::get(Type::getIntNTy(Ctx, 4), 4);
+  Value *Src = makeVal(B, I16Ty);
+  Value *Result = B.CreateLayoutReinterpretCast(Src, VTy);
+  EXPECT_EQ(Result->getType(), VTy);
+  EXPECT_TRUE(isa<BitCastInst>(Result));
+  checkBB("  %2 = bitcast i16 %1 to <4 x i4>\n");
+}
+
+/// <4 x i4> → <2 x i8>: both 16-bit vectors, single bitcast.
+TEST_P(LayoutReinterpretCastTest, Vec4xi4_ToVec2xi8) {
+  IRBuilder<NoFolder> B(BB->getTerminator());
+  Type *Src4xi4 = FixedVectorType::get(Type::getIntNTy(Ctx, 4), 4);
+  Type *Dst2xi8 = FixedVectorType::get(B.getInt8Ty(), 2);
+  Value *Src = makeVal(B, Src4xi4);
+  Value *Result = B.CreateLayoutReinterpretCast(Src, Dst2xi8);
+  EXPECT_EQ(Result->getType(), Dst2xi8);
+  EXPECT_TRUE(isa<BitCastInst>(Result));
+  checkBB("  %2 = bitcast <4 x i4> %1 to <2 x i8>\n");
+}
+
+/// <2 x i8> → <4 x i4>: both 16-bit vectors, single bitcast.
+TEST_P(LayoutReinterpretCastTest, Vec2xi8_ToVec4xi4) {
+  IRBuilder<NoFolder> B(BB->getTerminator());
+  Type *Src2xi8 = FixedVectorType::get(B.getInt8Ty(), 2);
+  Type *Dst4xi4 = FixedVectorType::get(Type::getIntNTy(Ctx, 4), 4);
+  Value *Src = makeVal(B, Src2xi8);
+  Value *Result = B.CreateLayoutReinterpretCast(Src, Dst4xi4);
+  EXPECT_EQ(Result->getType(), Dst4xi4);
+  EXPECT_TRUE(isa<BitCastInst>(Result));
+  checkBB("  %2 = bitcast <2 x i8> %1 to <4 x i4>\n");
+}
+
+/// <4 x i4> → [2 x i8]
+TEST_P(LayoutReinterpretCastTest, Vec4xi4_ToArr2xi8) {
+  IRBuilder<NoFolder> B(BB->getTerminator());
+  Type *VTy = FixedVectorType::get(Type::getIntNTy(Ctx, 4), 4);
+  Type *ArrTy = ArrayType::get(B.getInt8Ty(), 2);
+  Value *Src = makeVal(B, VTy);
+  Value *Result = B.CreateLayoutReinterpretCast(Src, ArrTy);
+  EXPECT_EQ(Result->getType(), ArrTy);
+  checkBB("  %2 = bitcast <4 x i4> %1 to <2 x i8>\n"
+          "  %3 = extractelement <2 x i8> %2, i64 0\n"
+          "  %4 = insertvalue [2 x i8] poison, i8 %3, 0\n"
+          "  %5 = bitcast <4 x i4> %1 to <2 x i8>\n"
+          "  %6 = extractelement <2 x i8> %5, i64 1\n"
+          "  %7 = insertvalue [2 x i8] %4, i8 %6, 1\n");
+}
+
+/// [2 x i8] → <4 x i4>
+TEST_P(LayoutReinterpretCastTest, Arr2xi8_ToVec4xi4) {
+  IRBuilder<NoFolder> B(BB->getTerminator());
+  Type *ArrTy = ArrayType::get(B.getInt8Ty(), 2);
+  Type *VTy = FixedVectorType::get(Type::getIntNTy(Ctx, 4), 4);
+  Value *Src = makeVal(B, ArrTy);
+  Value *Result = B.CreateLayoutReinterpretCast(Src, VTy);
+  EXPECT_EQ(Result->getType(), VTy);
+  checkBB("  %2 = extractvalue [2 x i8] %1, 0\n"
+          "  %3 = insertelement <2 x i8> poison, i8 %2, i64 0\n"
+          "  %4 = extractvalue [2 x i8] %1, 1\n"
+          "  %5 = insertelement <2 x i8> %3, i8 %4, i64 1\n"
+          "  %6 = bitcast <2 x i8> %5 to <4 x i4>\n");
+}
+
+/// {float, float} → <2 x float>
+TEST_P(LayoutReinterpretCastTest, StructFloatx2_ToVec2xFloat) {
+  IRBuilder<NoFolder> B(BB->getTerminator());
+  StructType *STy = StructType::get(B.getFloatTy(), B.getFloatTy());
+  Type *VTy = FixedVectorType::get(B.getFloatTy(), 2);
+  Value *Src = makeVal(B, STy);
+  Value *Result = B.CreateLayoutReinterpretCast(Src, VTy);
+  EXPECT_EQ(Result->getType(), VTy);
+  // Vector fast path: each float struct field aligns exactly with one vector
+  // element, so insertelement is used directly instead of integer accumulation.
+  checkBB("  %2 = extractvalue { float, float } %1, 0\n"
+          "  %3 = insertelement <2 x float> poison, float %2, i64 0\n"
+          "  %4 = extractvalue { float, float } %1, 1\n"
+          "  %5 = insertelement <2 x float> %3, float %4, i64 1\n");
+}
+
+/// [i16, i16, i32] → <2 x float>
+TEST_P(LayoutReinterpretCastTest, StructMixedAAB_ToVec2xFloat) {
+  IRBuilder<NoFolder> B(BB->getTerminator());
+  StructType *STy =
+      StructType::get(B.getInt16Ty(), B.getInt16Ty(), B.getInt32Ty());
+  Type *VTy = FixedVectorType::get(B.getInt32Ty(), 2);
+  Value *Src = makeVal(B, STy);
+  Value *Result = B.CreateLayoutReinterpretCast(Src, VTy);
+  EXPECT_EQ(Result->getType(), VTy);
+  checkBB("  %2 = extractvalue { i16, i16, i32 } %1, 0\n"
+          "  %3 = insertelement <4 x i16> poison, i16 %2, i64 0\n"
+          "  %4 = extractvalue { i16, i16, i32 } %1, 1\n"
+          "  %5 = insertelement <4 x i16> %3, i16 %4, i64 1\n"
+          "  %6 = extractvalue { i16, i16, i32 } %1, 2\n"
+          "  %7 = bitcast <4 x i16> %5 to <2 x i32>\n"
+          "  %8 = insertelement <2 x i32> %7, i32 %6, i64 1\n");
+}
+
+/// [i32, i16, i16] → <2 x float>
+TEST_P(LayoutReinterpretCastTest, StructMixedBAA_ToVec2xFloat) {
+  IRBuilder<NoFolder> B(BB->getTerminator());
+  StructType *STy =
+      StructType::get(B.getInt32Ty(), B.getInt16Ty(), B.getInt16Ty());
+  Type *VTy = FixedVectorType::get(B.getInt32Ty(), 2);
+  Value *Src = makeVal(B, STy);
+  Value *Result = B.CreateLayoutReinterpretCast(Src, VTy);
+  EXPECT_EQ(Result->getType(), VTy);
+  checkBB("  %2 = extractvalue { i32, i16, i16 } %1, 0\n"
+          "  %3 = insertelement <2 x i32> poison, i32 %2, i64 0\n"
+          "  %4 = extractvalue { i32, i16, i16 } %1, 1\n"
+          "  %5 = bitcast <2 x i32> %3 to <4 x i16>\n"
+          "  %6 = insertelement <4 x i16> %5, i16 %4, i64 2\n"
+          "  %7 = extractvalue { i32, i16, i16 } %1, 2\n"
+          "  %8 = insertelement <4 x i16> %6, i16 %7, i64 3\n"
+          "  %9 = bitcast <4 x i16> %8 to <2 x i32>\n");
+}
+
+/// <2 x float> → <3 x float>
+TEST_P(LayoutReinterpretCastTest, VecFloatCast_2_3) {
+  IRBuilder<NoFolder> B(BB->getTerminator());
+  Type *STy = FixedVectorType::get(B.getFloatTy(), 2);
+  Type *DTy = FixedVectorType::get(B.getFloatTy(), 3);
+  Value *Src = makeVal(B, STy);
+  Value *Result = B.CreateLayoutReinterpretCast(Src, DTy);
+  EXPECT_EQ(Result->getType(), DTy);
+  checkBB("  %2 = shufflevector <2 x float> %1, <2 x float> poison, <3 x i32> "
+          "<i32 0, i32 1, i32 poison>\n");
+}
+
+/// [<2 x float>, float] → <3 x float>
+TEST_P(LayoutReinterpretCastTest, VecFloatCast_21_3) {
+  IRBuilder<NoFolder> B(BB->getTerminator());
+  Type *DTy = FixedVectorType::get(B.getFloatTy(), 3);
+  StructType *STy =
+      StructType::get(FixedVectorType::get(B.getFloatTy(), 2), B.getFloatTy());
+  Value *Src = makeVal(B, STy);
+  Value *Result = B.CreateLayoutReinterpretCast(Src, DTy);
+  EXPECT_EQ(Result->getType(), DTy);
+  checkBB("  %2 = extractvalue { <2 x float>, float } %1, 0\n"
+          "  %3 = shufflevector <2 x float> %2, <2 x float> poison, <3 x i32> "
+          "<i32 0, i32 1, i32 poison>\n"
+          "  %4 = extractvalue { <2 x float>, float } %1, 1\n"
+          "  %5 = insertelement <3 x float> %3, float %4, i64 2\n");
+}
+
+/// <3 x float> → <2 x float>
+TEST_P(LayoutReinterpretCastTest, VecFloatCast_3_2) {
+  IRBuilder<NoFolder> B(BB->getTerminator());
+  Type *DTy = FixedVectorType::get(B.getFloatTy(), 2);
+  Type *STy = FixedVectorType::get(B.getFloatTy(), 3);
+  Value *Src = makeVal(B, STy);
+  Value *Result = B.CreateLayoutReinterpretCast(Src, DTy);
+  EXPECT_EQ(Result->getType(), DTy);
+  checkBB("  %2 = shufflevector <3 x float> %1, <3 x float> poison, <2 x i32> "
+          "<i32 0, i32 1>\n");
+}
+
+/// <3 x float> → [<2 x float>, float]
+TEST_P(LayoutReinterpretCastTest, VecFloatCast_3_21) {
+  IRBuilder<NoFolder> B(BB->getTerminator());
+  StructType *DTy =
+      StructType::get(FixedVectorType::get(B.getFloatTy(), 2), B.getFloatTy());
+  Type *STy = FixedVectorType::get(B.getFloatTy(), 3);
+  Value *Src = makeVal(B, STy);
+  Value *Result = B.CreateLayoutReinterpretCast(Src, DTy);
+  EXPECT_EQ(Result->getType(), DTy);
+  checkBB(
+      "  %2 = shufflevector <3 x float> %1, <3 x float> poison, <2 x i32> <i32 "
+      "0, i32 1>\n"
+      "  %3 = insertvalue { <2 x float>, float } poison, <2 x float> %2, 0\n"
+      "  %4 = extractelement <3 x float> %1, i64 2\n"
+      "  %5 = insertvalue { <2 x float>, float } %3, float %4, 1\n");
+}
+
+/// {<2 x float>, <2 x float>} → {<2 x i32>, <2 x i32>}: element-type
+/// reinterpret within a same-shape struct; each field is an independent
+/// bitcast with no cross-field data movement.
+TEST_P(LayoutReinterpretCastTest, StructVec2Float_ToStructVec2I32) {
+  IRBuilder<NoFolder> B(BB->getTerminator());
+  Type *V2F = FixedVectorType::get(B.getFloatTy(), 2);
+  Type *V2I = FixedVectorType::get(B.getInt32Ty(), 2);
+  StructType *STy = StructType::get(V2F, V2F);
+  StructType *DTy = StructType::get(V2I, V2I);
+  Value *Src = makeVal(B, STy);
+  Value *Result = B.CreateLayoutReinterpretCast(Src, DTy);
+  EXPECT_EQ(Result->getType(), DTy);
+  checkBB(
+      "  %2 = extractvalue { <2 x float>, <2 x float> } %1, 0\n"
+      "  %3 = bitcast <2 x float> %2 to <2 x i32>\n"
+      "  %4 = insertvalue { <2 x i32>, <2 x i32> } poison, <2 x i32> %3, 0\n"
+      "  %5 = extractvalue { <2 x float>, <2 x float> } %1, 1\n"
+      "  %6 = bitcast <2 x float> %5 to <2 x i32>\n"
+      "  %7 = insertvalue { <2 x i32>, <2 x i32> } %4, <2 x i32> %6, 1\n");
+}
+
+/// {<4 x i32>, <2 x i32>} → {<2 x i32>, <2 x i32>, <2 x i32>}: split the
+/// 128-bit first field into two 64-bit fields; third dst field = second src
+/// field.  Field boundaries cross, requiring shuffles or extracts.
+TEST_P(LayoutReinterpretCastTest, StructVec4_SplitTo3Vec2) {
+  IRBuilder<NoFolder> B(BB->getTerminator());
+  Type *V2 = FixedVectorType::get(B.getInt32Ty(), 2);
+  Type *V4 = FixedVectorType::get(B.getInt32Ty(), 4);
+  StructType *STy = StructType::get(V4, V2);
+  StructType *DTy = StructType::get(V2, V2, V2);
+  Value *Src = makeVal(B, STy);
+  Value *Result = B.CreateLayoutReinterpretCast(Src, DTy);
+  EXPECT_EQ(Result->getType(), DTy);
+  checkBB("  %2 = extractvalue { <4 x i32>, <2 x i32> } %1, 0\n"
+          "  %3 = shufflevector <4 x i32> %2, <4 x i32> poison, <2 x i32> <i32 "
+          "0, i32 1>\n"
+          "  %4 = insertvalue { <2 x i32>, <2 x i32>, <2 x i32> } poison, <2 x "
+          "i32> %3, 0\n"
+          "  %5 = shufflevector <4 x i32> %2, <4 x i32> poison, <2 x i32> <i32 "
+          "2, i32 3>\n"
+          "  %6 = insertvalue { <2 x i32>, <2 x i32>, <2 x i32> } %4, <2 x "
+          "i32> %5, 1\n"
+          "  %7 = extractvalue { <4 x i32>, <2 x i32> } %1, 1\n"
+          "  %8 = insertvalue { <2 x i32>, <2 x i32>, <2 x i32> } %6, <2 x "
+          "i32> %7, 2\n");
+}
+
+/// {<2 x i32>, <2 x i32>, <2 x i32>} → {<4 x i32>, <2 x i32>}: merge the
+/// first two 64-bit fields into a single 128-bit field; second dst field =
+/// third src field.  Reverse of StructVec4_SplitTo3Vec2.
+TEST_P(LayoutReinterpretCastTest, Struct3Vec2_MergeToVec4) {
+  IRBuilder<NoFolder> B(BB->getTerminator());
+  Type *V2 = FixedVectorType::get(B.getInt32Ty(), 2);
+  Type *V4 = FixedVectorType::get(B.getInt32Ty(), 4);
+  StructType *STy = StructType::get(V2, V2, V2);
+  StructType *DTy = StructType::get(V4, V2);
+  Value *Src = makeVal(B, STy);
+  Value *Result = B.CreateLayoutReinterpretCast(Src, DTy);
+  EXPECT_EQ(Result->getType(), DTy);
+  checkBB(
+      "  %2 = extractvalue { <2 x i32>, <2 x i32>, <2 x i32> } %1, 0\n"
+      "  %3 = shufflevector <2 x i32> %2, <2 x i32> poison, <4 x i32> <i32 0, "
+      "i32 1, i32 poison, i32 poison>\n"
+      "  %4 = extractvalue { <2 x i32>, <2 x i32>, <2 x i32> } %1, 1\n"
+      "  %5 = shufflevector <2 x i32> %4, <2 x i32> poison, <4 x i32> <i32 "
+      "poison, i32 poison, i32 0, i32 1>\n"
+      "  %6 = shufflevector <4 x i32> %3, <4 x i32> %5, <4 x i32> <i32 0, i32 "
+      "1, i32 6, i32 7>\n"
+      "  %7 = insertvalue { <4 x i32>, <2 x i32> } poison, <4 x i32> %6, 0\n"
+      "  %8 = extractvalue { <2 x i32>, <2 x i32>, <2 x i32> } %1, 2\n"
+      "  %9 = insertvalue { <4 x i32>, <2 x i32> } %7, <2 x i32> %8, 1\n");
+}
+
+/// {<2 x float>, float, float} → {float, float, <2 x float>}: both structs
+/// are 128 bits but with different field positions.  The vector occupies bits
+/// 0-63 in the source and bits 64-127 in the destination, so every field
+/// crosses a source/destination boundary.
+TEST_P(LayoutReinterpretCastTest, StructVec2FF_ToStructFFVec2) {
+  IRBuilder<NoFolder> B(BB->getTerminator());
+  Type *F32 = B.getFloatTy();
+  Type *V2F = FixedVectorType::get(F32, 2);
+  StructType *STy = StructType::get(V2F, F32, F32);
+  StructType *DTy = StructType::get(F32, F32, V2F);
+  Value *Src = makeVal(B, STy);
+  Value *Result = B.CreateLayoutReinterpretCast(Src, DTy);
+  EXPECT_EQ(Result->getType(), DTy);
+  checkBB(
+      "  %2 = extractvalue { <2 x float>, float, float } %1, 0\n"
+      "  %3 = extractelement <2 x float> %2, i64 0\n"
+      "  %4 = insertvalue { float, float, <2 x float> } poison, float %3, 0\n"
+      "  %5 = extractelement <2 x float> %2, i64 1\n"
+      "  %6 = insertvalue { float, float, <2 x float> } %4, float %5, 1\n"
+      "  %7 = extractvalue { <2 x float>, float, float } %1, 1\n"
+      "  %8 = insertelement <2 x float> poison, float %7, i64 0\n"
+      "  %9 = extractvalue { <2 x float>, float, float } %1, 2\n"
+      "  %10 = insertelement <2 x float> %8, float %9, i64 1\n"
+      "  %11 = insertvalue { float, float, <2 x float> } %6, <2 x float> %10, "
+      "2\n");
+}
+
+/// [2 x <3 x i32>] → <3 x i64>: array-of-odd-vector to packed vector.
+/// The array element stride is 16 bytes (alloc size of <3 x i32> with 128-bit
+/// alignment), so element[1] starts at byte offset 16 even though it only
+/// holds 12 bytes of data.  The destination i64 elements cross those alloc
+/// boundaries, giving the implementation a non-trivial stitching problem.
+TEST_P(LayoutReinterpretCastTest, ArrOf3xi32_ToVec3xi64) {
+  IRBuilder<NoFolder> B(BB->getTerminator());
+  Type *V3I32 = FixedVectorType::get(B.getInt32Ty(), 3);
+  Type *ArrTy = ArrayType::get(V3I32, 2);
+  Type *DTy = FixedVectorType::get(B.getInt64Ty(), 3);
+  Value *Src = makeVal(B, ArrTy);
+  Value *Result = B.CreateLayoutReinterpretCast(Src, DTy);
+  EXPECT_EQ(Result->getType(), DTy);
+  if (!isBigEndian())
+    checkBB("  %2 = extractvalue [2 x <3 x i32>] %1, 0\n"
+            "  %3 = shufflevector <3 x i32> %2, <3 x i32> poison, <6 x i32> "
+            "<i32 0, i32 1, i32 2, i32 poison, i32 poison, i32 poison>\n"
+            "  %4 = extractvalue [2 x <3 x i32>] %1, 1\n"
+            "  %5 = bitcast <3 x i32> %4 to i96\n"
+            "  %6 = trunc i96 %5 to i64\n"
+            "  %7 = bitcast <6 x i32> %3 to <3 x i64>\n"
+            "  %8 = insertelement <3 x i64> %7, i64 %6, i64 2\n");
+  else
+    checkBB("  %2 = extractvalue [2 x <3 x i32>] %1, 0\n"
+            "  %3 = shufflevector <3 x i32> %2, <3 x i32> poison, <6 x i32> "
+            "<i32 0, i32 1, i32 2, i32 poison, i32 poison, i32 poison>\n"
+            "  %4 = extractvalue [2 x <3 x i32>] %1, 1\n"
+            "  %5 = bitcast <3 x i32> %4 to i96\n"
+            "  %6 = lshr i96 %5, 32\n"
+            "  %7 = trunc i96 %6 to i64\n"
+            "  %8 = bitcast <6 x i32> %3 to <3 x i64>\n"
+            "  %9 = insertelement <3 x i64> %8, i64 %7, i64 2\n");
+}
+
+/// <5 x i32> → <3 x i64>: 160 source bits into 192 destination bits.
+/// The first four i32 lanes fill the first two i64 slots completely; the fifth
+/// i32 fills only the low half of the third i64, leaving the high 32 bits as
+/// poison.
+TEST_P(LayoutReinterpretCastTest, Vec5xi32_ToVec3xi64) {
+  IRBuilder<NoFolder> B(BB->getTerminator());
+  Type *STy = FixedVectorType::get(B.getInt32Ty(), 5);
+  Type *DTy = FixedVectorType::get(B.getInt64Ty(), 3);
+  Value *Src = makeVal(B, STy);
+  Value *Result = B.CreateLayoutReinterpretCast(Src, DTy);
+  EXPECT_EQ(Result->getType(), DTy);
+  checkBB("  %2 = shufflevector <5 x i32> %1, <5 x i32> poison, <6 x i32> <i32 "
+          "0, i32 1, i32 2, i32 3, i32 4, i32 poison>\n"
+          "  %3 = bitcast <6 x i32> %2 to <3 x i64>\n");
+}
+
+/// <4 x i16> → <3 x i32>: src bitcast to i32 view, then scatter first 2 of 3.
+TEST_P(LayoutReinterpretCastTest, Vec4xi16_ToVec3xi32) {
+  IRBuilder<NoFolder> B(BB->getTerminator());
+  Type *STy = FixedVectorType::get(B.getInt16Ty(), 4);
+  Type *DTy = FixedVectorType::get(B.getInt32Ty(), 3);
+  Value *Src = makeVal(B, STy);
+  Value *Result = B.CreateLayoutReinterpretCast(Src, DTy);
+  EXPECT_EQ(Result->getType(), DTy);
+  checkBB("  %2 = bitcast <4 x i16> %1 to <2 x i32>\n"
+          "  %3 = shufflevector <2 x i32> %2, <2 x i32> poison, <3 x i32> <i32 "
+          "0, i32 1, i32 poison>\n");
+}
+
+/// <3 x i32> → <4 x i16>: src bitcast to i16 view, then extract first 4 of 6.
+TEST_P(LayoutReinterpretCastTest, Vec3xi32_ToVec4xi16) {
+  IRBuilder<NoFolder> B(BB->getTerminator());
+  Type *STy = FixedVectorType::get(B.getInt32Ty(), 3);
+  Type *DTy = FixedVectorType::get(B.getInt16Ty(), 4);
+  Value *Src = makeVal(B, STy);
+  Value *Result = B.CreateLayoutReinterpretCast(Src, DTy);
+  EXPECT_EQ(Result->getType(), DTy);
+  checkBB("  %2 = bitcast <3 x i32> %1 to <6 x i16>\n"
+          "  %3 = shufflevector <6 x i16> %2, <6 x i16> poison, <4 x i32> <i32 "
+          "0, i32 1, i32 2, i32 3>\n");
+}
+
+// ---------------------------------------------------------------------------
+// Mixed / nested aggregates
+// ---------------------------------------------------------------------------
+
+/// {i32, [2 x i16]} → i64: struct with a nested array.
+/// Three leaves (i32, i16, i16) are OR-assembled into i64.
+TEST_P(LayoutReinterpretCastTest, MixedStruct_ToI64) {
+  IRBuilder<NoFolder> B(BB->getTerminator());
+  Type *ArrayTy = ArrayType::get(B.getInt16Ty(), 2);
+  StructType *STy = StructType::get(B.getInt32Ty(), ArrayTy);
+  Type *I64Ty = B.getInt64Ty();
+  Value *Src = makeVal(B, STy);
+  Value *Result = B.CreateLayoutReinterpretCast(Src, I64Ty);
+  EXPECT_EQ(Result->getType(), I64Ty);
+  if (!isBigEndian()) {
+    checkBB("  %2 = extractvalue { i32, [2 x i16] } %1, 0\n"
+            "  %3 = zext i32 %2 to i64\n"
+            "  %4 = extractvalue { i32, [2 x i16] } %1, 1\n"
+            "  %5 = extractvalue [2 x i16] %4, 0\n"
+            "  %6 = zext i16 %5 to i64\n"
+            "  %7 = shl i64 %6, 32\n"
+            "  %8 = or i64 %3, %7\n"
+            "  %9 = extractvalue [2 x i16] %4, 1\n"
+            "  %10 = zext i16 %9 to i64\n"
+            "  %11 = shl i64 %10, 48\n"
+            "  %12 = or i64 %8, %11\n");
+  } else {
+    checkBB("  %2 = extractvalue { i32, [2 x i16] } %1, 0\n"
+            "  %3 = zext i32 %2 to i64\n"
+            "  %4 = shl i64 %3, 32\n"
+            "  %5 = extractvalue { i32, [2 x i16] } %1, 1\n"
+            "  %6 = extractvalue [2 x i16] %5, 0\n"
+            "  %7 = zext i16 %6 to i64\n"
+            "  %8 = shl i64 %7, 16\n"
+            "  %9 = or i64 %4, %8\n"
+            "  %10 = extractvalue [2 x i16] %5, 1\n"
+            "  %11 = zext i16 %10 to i64\n"
+            "  %12 = or i64 %9, %11\n");
+  }
+}
+
+/// {i32, i32} → {i16, i16, i16, i16}: cross-struct layout reinterpret.
+/// Destination has twice as many leaves, each half the width of a source leaf.
+TEST_P(LayoutReinterpretCastTest, CrossStructLayout) {
+  IRBuilder<NoFolder> B(BB->getTerminator());
+  Type *I16Ty = B.getInt16Ty();
+  Type *I32Ty = B.getInt32Ty();
+  StructType *SrcTy = StructType::get(I32Ty, I32Ty);
+  StructType *DstTy = StructType::get(I16Ty, I16Ty, I16Ty, I16Ty);
+  Value *Src = makeVal(B, SrcTy);
+  Value *Result = B.CreateLayoutReinterpretCast(Src, DstTy);
+  EXPECT_EQ(Result->getType(), DstTy);
+  if (!isBigEndian()) {
+    checkBB("  %2 = extractvalue { i32, i32 } %1, 0\n"
+            "  %3 = trunc i32 %2 to i16\n"
+            "  %4 = insertvalue { i16, i16, i16, i16 } poison, i16 %3, 0\n"
+            "  %5 = lshr i32 %2, 16\n"
+            "  %6 = trunc i32 %5 to i16\n"
+            "  %7 = insertvalue { i16, i16, i16, i16 } %4, i16 %6, 1\n"
+            "  %8 = extractvalue { i32, i32 } %1, 1\n"
+            "  %9 = trunc i32 %8 to i16\n"
+            "  %10 = insertvalue { i16, i16, i16, i16 } %7, i16 %9, 2\n"
+            "  %11 = lshr i32 %8, 16\n"
+            "  %12 = trunc i32 %11 to i16\n"
+            "  %13 = insertvalue { i16, i16, i16, i16 } %10, i16 %12, 3\n");
+  } else {
+    checkBB("  %2 = extractvalue { i32, i32 } %1, 0\n"
+            "  %3 = lshr i32 %2, 16\n"
+            "  %4 = trunc i32 %3 to i16\n"
+            "  %5 = insertvalue { i16, i16, i16, i16 } poison, i16 %4, 0\n"
+            "  %6 = trunc i32 %2 to i16\n"
+            "  %7 = insertvalue { i16, i16, i16, i16 } %5, i16 %6, 1\n"
+            "  %8 = extractvalue { i32, i32 } %1, 1\n"
+            "  %9 = lshr i32 %8, 16\n"
+            "  %10 = trunc i32 %9 to i16\n"
+            "  %11 = insertvalue { i16, i16, i16, i16 } %7, i16 %10, 2\n"
+            "  %12 = trunc i32 %8 to i16\n"
+            "  %13 = insertvalue { i16, i16, i16, i16 } %11, i16 %12, 3\n");
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Struct padding
+// ---------------------------------------------------------------------------
+
+/// {i8, i32} (with 3-byte natural padding after i8) → i64.
+/// The two data leaves (i8, i32) must be placed at the correct bit offsets;
+/// padding bits are not touched and remain as the zero base of the accumulator.
+TEST_P(LayoutReinterpretCastTest, PaddedStruct_ToI64) {
+  IRBuilder<NoFolder> B(BB->getTerminator());
+  // {i8, i32} natural layout: i8@bit0, padding bits 8-31, i32@bit32.
+  StructType *STy = StructType::get(B.getInt8Ty(), B.getInt32Ty());
+  Type *I64Ty = B.getInt64Ty();
+  Value *Src = makeVal(B, STy);
+  Value *Result = B.CreateLayoutReinterpretCast(Src, I64Ty);
+  EXPECT_EQ(Result->getType(), I64Ty);
+  if (!isBigEndian()) {
+    checkBB("  %2 = extractvalue { i8, i32 } %1, 0\n"
+            "  %3 = zext i8 %2 to i64\n"
+            "  %4 = extractvalue { i8, i32 } %1, 1\n"
+            "  %5 = zext i32 %4 to i64\n"
+            "  %6 = shl i64 %5, 32\n"
+            "  %7 = or i64 %3, %6\n");
+  } else {
+    checkBB("  %2 = extractvalue { i8, i32 } %1, 0\n"
+            "  %3 = zext i8 %2 to i64\n"
+            "  %4 = shl i64 %3, 56\n"
+            "  %5 = extractvalue { i8, i32 } %1, 1\n"
+            "  %6 = zext i32 %5 to i64\n"
+            "  %7 = or i64 %4, %6\n");
+  }
+}
+
+/// i64 → {i8, i32} (with 3-byte padding).
+TEST_P(LayoutReinterpretCastTest, I64_ToPaddedStruct) {
+  IRBuilder<NoFolder> B(BB->getTerminator());
+  StructType *STy = StructType::get(B.getInt8Ty(), B.getInt32Ty());
+  Type *I64Ty = B.getInt64Ty();
+  Value *Src = makeVal(B, I64Ty);
+  Value *Result = B.CreateLayoutReinterpretCast(Src, STy);
+  EXPECT_EQ(Result->getType(), STy);
+  if (!isBigEndian()) {
+    checkBB("  %2 = trunc i64 %1 to i8\n"
+            "  %3 = insertvalue { i8, i32 } poison, i8 %2, 0\n"
+            "  %4 = lshr i64 %1, 32\n"
+            "  %5 = trunc i64 %4 to i32\n"
+            "  %6 = insertvalue { i8, i32 } %3, i32 %5, 1\n");
+  } else {
+    checkBB("  %2 = lshr i64 %1, 56\n"
+            "  %3 = trunc i64 %2 to i8\n"
+            "  %4 = insertvalue { i8, i32 } poison, i8 %3, 0\n"
+            "  %5 = trunc i64 %1 to i32\n"
+            "  %6 = insertvalue { i8, i32 } %4, i32 %5, 1\n");
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Bit offsets
+// ---------------------------------------------------------------------------
+
+/// DstOffset=1: read bits [8..23] of an i32, produce an i16.
+TEST_P(LayoutReinterpretCastTest, SrcBitOffset) {
+  IRBuilder<NoFolder> B(BB->getTerminator());
+  Type *I32Ty = B.getInt32Ty();
+  Type *I16Ty = B.getInt16Ty();
+  Value *Src = makeVal(B, I32Ty);
+  Value *Result = B.CreateLayoutReinterpretCast(Src, I16Ty, /*SrcOffset=*/0,
+                                                /*DstOffset=*/1);
+  EXPECT_EQ(Result->getType(), I16Ty);
+  EXPECT_TRUE(isa<TruncInst>(Result));
+
+  Result = B.CreateLayoutReinterpretCast(Src, I16Ty, /*SrcOffset=*/0,
+                                         /*DstOffset=*/64);
+  EXPECT_EQ(Result->getType(), I16Ty);
+  EXPECT_TRUE(isa<PoisonValue>(Result));
+
+  // Symmetric shift for either of BE or LE
+  checkBB("  %2 = lshr i32 %1, 8\n"
+          "  %3 = trunc i32 %2 to i16\n");
+}
+
+/// SrcOffset=2: place an i16 value into bits [16..31] of an i32.
+TEST_P(LayoutReinterpretCastTest, DstBitOffset) {
+  IRBuilder<NoFolder> B(BB->getTerminator());
+  Type *I16Ty = B.getInt16Ty();
+  Type *I32Ty = B.getInt32Ty();
+  Value *Src = makeVal(B, I16Ty);
+  Value *Result = B.CreateLayoutReinterpretCast(Src, I32Ty, /*SrcOffset=*/2,
+                                                /*DstOffset=*/0);
+  EXPECT_EQ(Result->getType(), I32Ty);
+  if (!isBigEndian())
+    EXPECT_TRUE(isa<BinaryOperator>(Result));
+  else
+    EXPECT_TRUE(isa<ZExtInst>(Result));
+
+  Result = B.CreateLayoutReinterpretCast(Src, I32Ty, /*SrcOffset=*/64,
+                                         /*DstOffset=*/0);
+  EXPECT_EQ(Result->getType(), I32Ty);
+  EXPECT_TRUE(isa<PoisonValue>(Result));
+
+  if (!isBigEndian())
+    checkBB("  %2 = zext i16 %1 to i32\n"
+            "  %3 = shl i32 %2, 16\n");
+  else
+    checkBB("  %2 = zext i16 %1 to i32\n");
+}
+
+// ---------------------------------------------------------------------------
+// Size mismatch
+// ---------------------------------------------------------------------------
+
+/// Src (i64) larger than Dst (i16): extra source bits are dropped via trunc.
+TEST_P(LayoutReinterpretCastTest, SrcLargerThanDst) {
+  IRBuilder<NoFolder> B(BB->getTerminator());
+  Value *Src = makeVal(B, B.getInt64Ty());
+  Value *Result = B.CreateLayoutReinterpretCast(Src, B.getInt16Ty());
+  EXPECT_EQ(Result->getType(), B.getInt16Ty());
+  if (!isBigEndian())
+    checkBB("  %2 = trunc i64 %1 to i16\n");
+  else
+    checkBB("  %2 = lshr i64 %1, 48\n"
+            "  %3 = trunc i64 %2 to i16\n");
+}
+
+/// Dst (i32) larger than Src (i16): source is zero-extended to fill Dst.
+TEST_P(LayoutReinterpretCastTest, DstLargerThanSrc) {
+  IRBuilder<NoFolder> B(BB->getTerminator());
+  Value *Src = makeVal(B, B.getInt16Ty());
+  Value *Result = B.CreateLayoutReinterpretCast(Src, B.getInt32Ty());
+  EXPECT_EQ(Result->getType(), B.getInt32Ty());
+  if (!isBigEndian())
+    checkBB("  %2 = zext i16 %1 to i32\n");
+  else
+    checkBB("  %2 = zext i16 %1 to i32\n"
+            "  %3 = shl i32 %2, 16\n");
+}
+
+// ---------------------------------------------------------------------------
+// Empty aggregate
+// ---------------------------------------------------------------------------
+
+/// Empty struct {} → i32: no source leaves
+TEST_P(LayoutReinterpretCastTest, EmptyStruct_ToI32) {
+  IRBuilder<NoFolder> B(BB->getTerminator());
+  StructType *EmptyTy = StructType::get(Ctx, {});
+  Value *Src = makeVal(B, EmptyTy);
+  Value *Result = B.CreateLayoutReinterpretCast(Src, B.getInt32Ty());
+  EXPECT_TRUE(isa<PoisonValue>(Result));
+  checkBB("  %1 = load {}, ptr @0, align 1\n");
+}
+
+/// i32 → empty struct {}: no destination leaves
+TEST_P(LayoutReinterpretCastTest, I32_ToEmptyStruct) {
+  IRBuilder<NoFolder> B(BB->getTerminator());
+  StructType *EmptyTy = StructType::get(Ctx, {});
+  Value *Src = makeVal(B, B.getInt32Ty());
+  Value *Result = B.CreateLayoutReinterpretCast(Src, EmptyTy);
+  EXPECT_TRUE(isa<PoisonValue>(Result));
+  checkBB("  %1 = load i32, ptr @0, align 4\n");
+}
+
+// ---------------------------------------------------------------------------
+// Constant folding
+// ---------------------------------------------------------------------------
+
+/// A constant source produces a constant result with ConstantFolder.
+TEST_P(LayoutReinterpretCastTest, ConstantSource_I32ToFloat_Folds) {
+  IRBuilder<> B(BB->getTerminator());
+  // 0x3F800000 = IEEE 1.0f
+  Constant *Src = ConstantInt::get(B.getInt32Ty(), 0x3F800000u);
+  Value *Result = B.CreateLayoutReinterpretCast(Src, B.getFloatTy());
+  EXPECT_TRUE(isa<ConstantFP>(Result));
+  checkBB("");
+}
+
+TEST_P(LayoutReinterpretCastTest, ConstantSource_StructJoin_Folds) {
+  IRBuilder<> B(BB->getTerminator());
+  Type *I32Ty = B.getInt32Ty();
+  StructType *STy = StructType::get(I32Ty, I32Ty);
+  Constant *Src = ConstantStruct::get(
+      STy, {ConstantInt::get(I32Ty, 1), ConstantInt::get(I32Ty, 2)});
+  Value *Result = B.CreateLayoutReinterpretCast(Src, B.getInt64Ty());
+  EXPECT_TRUE(isa<ConstantInt>(Result));
+  checkBB("");
+}
+
+// ---------------------------------------------------------------------------
+// Round-trip
+// ---------------------------------------------------------------------------
+
+/// Cast A→B then B→A on a constant input; the round-trip must reproduce the
+/// original value in all non-padding bits.  Verified by constant folding.
+TEST_P(LayoutReinterpretCastTest, RoundTrip_I32ToFloat_ToI32) {
+  IRBuilder<> B(BB->getTerminator());
+  Type *I32Ty = B.getInt32Ty();
+  Type *F32Ty = B.getFloatTy();
+  Constant *Orig = ConstantInt::get(I32Ty, 0xDEADBEEFu);
+  Value *Mid = B.CreateLayoutReinterpretCast(Orig, F32Ty);
+  Value *Back = B.CreateLayoutReinterpretCast(Mid, I32Ty);
+  EXPECT_EQ(Back, Orig) << "round-trip i32→float→i32 must be identity";
+  checkBB("");
+}
+
+TEST_P(LayoutReinterpretCastTest, RoundTrip_StructJoinSplit) {
+  IRBuilder<> B(BB->getTerminator());
+  Type *I32Ty = B.getInt32Ty();
+  StructType *STy = StructType::get(I32Ty, I32Ty);
+  Type *I64Ty = B.getInt64Ty();
+  Constant *Orig =
+      ConstantStruct::get(STy, {ConstantInt::get(I32Ty, 0xAAAAAAAAu),
+                                ConstantInt::get(I32Ty, 0x55555555u)});
+  Value *Mid = B.CreateLayoutReinterpretCast(Orig, I64Ty);
+  Value *Back = B.CreateLayoutReinterpretCast(Mid, STy);
+  EXPECT_EQ(Back->getType(), STy);
+  checkBB("");
+}
+
+// ---------------------------------------------------------------------------
+// Pointer struct with addrspacecast
+// ---------------------------------------------------------------------------
+
+/// {ptr addrspace(1), i32} → {ptr addrspace(2), i32}
+TEST_P(LayoutReinterpretCastTest, PtrStructSameSize) {
+  IRBuilder<NoFolder> B(BB->getTerminator());
+  Type *PtrAS0 = B.getPtrTy(0);
+  Type *PtrAS2 = B.getPtrTy(2); // always 64-bit
+  Type *I32Ty = B.getInt32Ty();
+  StructType *SrcTy = StructType::get(PtrAS0, I32Ty);
+  StructType *DstTy = StructType::get(PtrAS2, I32Ty);
+  Value *Src = makeVal(B, SrcTy);
+  Value *Result = B.CreateLayoutReinterpretCast(Src, DstTy);
+  EXPECT_EQ(Result->getType(), DstTy);
+  if (as0PtrBits() == 64) {
+    checkBB("  %2 = extractvalue { ptr, i32 } %1, 0\n"
+            "  %3 = ptrtoint ptr %2 to i64\n"
+            "  %4 = inttoptr i64 %3 to ptr addrspace(2)\n"
+            "  %5 = insertvalue { ptr addrspace(2), i32 } poison, ptr "
+            "addrspace(2) %4, 0\n"
+            "  %6 = extractvalue { ptr, i32 } %1, 1\n"
+            "  %7 = insertvalue { ptr addrspace(2), i32 } %5, i32 %6, 1\n");
+  } else if (!isBigEndian()) {
+    checkBB("  %2 = extractvalue { ptr, i32 } %1, 0\n"
+            "  %3 = ptrtoint ptr %2 to i32\n"
+            "  %4 = zext i32 %3 to i64\n"
+            "  %5 = extractvalue { ptr, i32 } %1, 1\n"
+            "  %6 = zext i32 %5 to i64\n"
+            "  %7 = shl i64 %6, 32\n"
+            "  %8 = or i64 %4, %7\n"
+            "  %9 = inttoptr i64 %8 to ptr addrspace(2)\n"
+            "  %10 = insertvalue { ptr addrspace(2), i32 } poison, ptr "
+            "addrspace(2) %9, 0\n");
+  } else {
+    checkBB("  %2 = extractvalue { ptr, i32 } %1, 0\n"
+            "  %3 = ptrtoint ptr %2 to i32\n"
+            "  %4 = zext i32 %3 to i64\n"
+            "  %5 = shl i64 %4, 32\n"
+            "  %6 = extractvalue { ptr, i32 } %1, 1\n"
+            "  %7 = zext i32 %6 to i64\n"
+            "  %8 = or i64 %5, %7\n"
+            "  %9 = inttoptr i64 %8 to ptr addrspace(2)\n"
+            "  %10 = insertvalue { ptr addrspace(2), i32 } poison, ptr "
+            "addrspace(2) %9, 0\n");
+  }
+}
+
+TEST_P(LayoutReinterpretCastTest, Nested) {
+  IRBuilder<NoFolder> B(BB->getTerminator());
+  Type *I8Ty = B.getInt8Ty();
+  Type *I16Ty = ArrayType::get(I8Ty, 2);
+  StructType *STyL = StructType::get(
+      I16Ty, StructType::get(
+                 I16Ty, StructType::get(I16Ty, StructType::get(I16Ty, I8Ty))));
+  StructType *STyR = StructType::get(
+      StructType::get(StructType::get(StructType::get(I8Ty, I16Ty), I16Ty),
+                      I16Ty),
+      I16Ty);
+  Value *Src = makeVal(B, STyL);
+  Value *Result = B.CreateLayoutReinterpretCast(Src, STyR);
+  EXPECT_EQ(Result->getType(), STyR);
+  BB->setName("LtoR");
+  nameBB();
+  checkBB(
+      "  %LtoR.2 = extractvalue { [2 x i8], { [2 x i8], { [2 x i8], { [2 x "
+      "i8], i8 } } } } %LtoR.1, 0\n"
+      "  %LtoR.3 = extractvalue [2 x i8] %LtoR.2, 0\n"
+      "  %LtoR.4 = insertvalue { i8, [2 x i8] } poison, i8 %LtoR.3, 0\n"
+      "  %LtoR.5 = extractvalue [2 x i8] %LtoR.2, 1\n"
+      "  %LtoR.6 = insertvalue [2 x i8] poison, i8 %LtoR.5, 0\n"
+      "  %LtoR.7 = extractvalue { [2 x i8], { [2 x i8], { [2 x i8], { [2 x "
+      "i8], i8 } } } } %LtoR.1, 1\n"
+      "  %LtoR.8 = extractvalue { [2 x i8], { [2 x i8], { [2 x i8], i8 } } } "
+      "%LtoR.7, 0\n"
+      "  %LtoR.9 = extractvalue [2 x i8] %LtoR.8, 0\n"
+      "  %LtoR.10 = insertvalue [2 x i8] %LtoR.6, i8 %LtoR.9, 1\n"
+      "  %LtoR.11 = extractvalue [2 x i8] %LtoR.8, 1\n"
+      "  %LtoR.12 = insertvalue { i8, [2 x i8] } %LtoR.4, [2 x i8] %LtoR.10, "
+      "1\n"
+      "  %LtoR.13 = insertvalue { { i8, [2 x i8] }, [2 x i8] } poison, { i8, "
+      "[2 x i8] } %LtoR.12, 0\n"
+      "  %LtoR.14 = insertvalue [2 x i8] poison, i8 %LtoR.11, 0\n"
+      "  %LtoR.15 = extractvalue { [2 x i8], { [2 x i8], { [2 x i8], i8 } } } "
+      "%LtoR.7, 1\n"
+      "  %LtoR.16 = extractvalue { [2 x i8], { [2 x i8], i8 } } %LtoR.15, 0\n"
+      "  %LtoR.17 = extractvalue [2 x i8] %LtoR.16, 0\n"
+      "  %LtoR.18 = insertvalue [2 x i8] %LtoR.14, i8 %LtoR.17, 1\n"
+      "  %LtoR.19 = extractvalue [2 x i8] %LtoR.16, 1\n"
+      "  %LtoR.20 = insertvalue { { i8, [2 x i8] }, [2 x i8] } %LtoR.13, [2 x "
+      "i8] %LtoR.18, 1\n"
+      "  %LtoR.21 = insertvalue { { { i8, [2 x i8] }, [2 x i8] }, [2 x i8] } "
+      "poison, { { i8, [2 x i8] }, [2 x i8] } %LtoR.20, 0\n"
+      "  %LtoR.22 = insertvalue [2 x i8] poison, i8 %LtoR.19, 0\n"
+      "  %LtoR.23 = extractvalue { [2 x i8], { [2 x i8], i8 } } %LtoR.15, 1\n"
+      "  %LtoR.24 = extractvalue { [2 x i8], i8 } %LtoR.23, 0\n"
+      "  %LtoR.25 = extractvalue [2 x i8] %LtoR.24, 0\n"
+      "  %LtoR.26 = insertvalue [2 x i8] %LtoR.22, i8 %LtoR.25, 1\n"
+      "  %LtoR.27 = extractvalue [2 x i8] %LtoR.24, 1\n"
+      "  %LtoR.28 = insertvalue { { { i8, [2 x i8] }, [2 x i8] }, [2 x i8] } "
+      "%LtoR.21, [2 x i8] %LtoR.26, 1\n"
+      "  %LtoR.29 = insertvalue { { { { i8, [2 x i8] }, [2 x i8] }, [2 x i8] "
+      "}, [2 x i8] } poison, { { { i8, [2 x i8] }, [2 x i8] }, [2 x i8] } "
+      "%LtoR.28, 0\n"
+      "  %LtoR.30 = insertvalue [2 x i8] poison, i8 %LtoR.27, 0\n"
+      "  %LtoR.31 = extractvalue { [2 x i8], i8 } %LtoR.23, 1\n"
+      "  %LtoR.32 = insertvalue [2 x i8] %LtoR.30, i8 %LtoR.31, 1\n"
+      "  %LtoR.33 = insertvalue { { { { i8, [2 x i8] }, [2 x i8] }, [2 x i8] "
+      "}, [2 x i8] } %LtoR.29, [2 x i8] %LtoR.32, 1\n");
+
+  BB = BasicBlock::Create(Ctx, "RtoL", F);
+  B.SetInsertPoint(BB);
+  Src = makeVal(B, STyR);
+  Result = B.CreateLayoutReinterpretCast(Src, STyL);
+  EXPECT_EQ(Result->getType(), STyL);
+  B.CreateRetVoid();
+  nameBB();
+  checkBB(
+      "  %RtoL.2 = extractvalue { { { { i8, [2 x i8] }, [2 x i8] }, [2 x i8] "
+      "}, [2 x i8] } %RtoL.1, 0\n"
+      "  %RtoL.3 = extractvalue { { { i8, [2 x i8] }, [2 x i8] }, [2 x i8] } "
+      "%RtoL.2, 0\n"
+      "  %RtoL.4 = extractvalue { { i8, [2 x i8] }, [2 x i8] } %RtoL.3, 0\n"
+      "  %RtoL.5 = extractvalue { i8, [2 x i8] } %RtoL.4, 0\n"
+      "  %RtoL.6 = insertvalue [2 x i8] poison, i8 %RtoL.5, 0\n"
+      "  %RtoL.7 = extractvalue { i8, [2 x i8] } %RtoL.4, 1\n"
+      "  %RtoL.8 = extractvalue [2 x i8] %RtoL.7, 0\n"
+      "  %RtoL.9 = insertvalue [2 x i8] %RtoL.6, i8 %RtoL.8, 1\n"
+      "  %RtoL.10 = extractvalue [2 x i8] %RtoL.7, 1\n"
+      "  %RtoL.11 = insertvalue { [2 x i8], { [2 x i8], { [2 x i8], { [2 x "
+      "i8], i8 } } } } poison, [2 x i8] %RtoL.9, 0\n"
+      "  %RtoL.12 = insertvalue [2 x i8] poison, i8 %RtoL.10, 0\n"
+      "  %RtoL.13 = extractvalue { { i8, [2 x i8] }, [2 x i8] } %RtoL.3, 1\n"
+      "  %RtoL.14 = extractvalue [2 x i8] %RtoL.13, 0\n"
+      "  %RtoL.15 = insertvalue [2 x i8] %RtoL.12, i8 %RtoL.14, 1\n"
+      "  %RtoL.16 = extractvalue [2 x i8] %RtoL.13, 1\n"
+      "  %RtoL.17 = insertvalue { [2 x i8], { [2 x i8], { [2 x i8], i8 } } } "
+      "poison, [2 x i8] %RtoL.15, 0\n"
+      "  %RtoL.18 = insertvalue [2 x i8] poison, i8 %RtoL.16, 0\n"
+      "  %RtoL.19 = extractvalue { { { i8, [2 x i8] }, [2 x i8] }, [2 x i8] } "
+      "%RtoL.2, 1\n"
+      "  %RtoL.20 = extractvalue [2 x i8] %RtoL.19, 0\n"
+      "  %RtoL.21 = insertvalue [2 x i8] %RtoL.18, i8 %RtoL.20, 1\n"
+      "  %RtoL.22 = extractvalue [2 x i8] %RtoL.19, 1\n"
+      "  %RtoL.23 = insertvalue { [2 x i8], { [2 x i8], i8 } } poison, [2 x "
+      "i8] %RtoL.21, 0\n"
+      "  %RtoL.24 = insertvalue [2 x i8] poison, i8 %RtoL.22, 0\n"
+      "  %RtoL.25 = extractvalue { { { { i8, [2 x i8] }, [2 x i8] }, [2 x i8] "
+      "}, [2 x i8] } %RtoL.1, 1\n"
+      "  %RtoL.26 = extractvalue [2 x i8] %RtoL.25, 0\n"
+      "  %RtoL.27 = insertvalue [2 x i8] %RtoL.24, i8 %RtoL.26, 1\n"
+      "  %RtoL.28 = extractvalue [2 x i8] %RtoL.25, 1\n"
+      "  %RtoL.29 = insertvalue { [2 x i8], i8 } poison, [2 x i8] %RtoL.27, 0\n"
+      "  %RtoL.30 = insertvalue { [2 x i8], i8 } %RtoL.29, i8 %RtoL.28, 1\n"
+      "  %RtoL.31 = insertvalue { [2 x i8], { [2 x i8], i8 } } %RtoL.23, { [2 "
+      "x i8], i8 } %RtoL.30, 1\n"
+      "  %RtoL.32 = insertvalue { [2 x i8], { [2 x i8], { [2 x i8], i8 } } } "
+      "%RtoL.17, { [2 x i8], { [2 x i8], i8 } } %RtoL.31, 1\n"
+      "  %RtoL.33 = insertvalue { [2 x i8], { [2 x i8], { [2 x i8], { [2 x "
+      "i8], i8 } } } } %RtoL.11, { [2 x i8], { [2 x i8], { [2 x i8], i8 } } } "
+      "%RtoL.32, 1\n");
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    LayoutVariants, LayoutReinterpretCastTest,
+    ::testing::Values(DLConfig{false, 64}, DLConfig{false, 32},
+                      DLConfig{true, 64}, DLConfig{true, 32}),
+    [](const ::testing::TestParamInfo<DLConfig> &Info) {
+      return std::string(Info.param.BigEndian ? "BE" : "LE") +
+             std::to_string(Info.param.AS0PtrBits);
+    });
+
+} // namespace


### PR DESCRIPTION
This can convert any fixed-size structure into any other fixed-size structure, as if by store+load through memory. This is intended to help replace the common store+load patterns that are inserted for ABI requirements, as well as eventually serve as a basis for a replacement SROA which relies less on the alloca type for semantics.

In particular, this was motivated by a concern I had that SROA is more concerned about what which combinations of bitcasts it knows how to implement, than about the profitability of SROA. This limited its perceived accuracy as an full SROA pass, as well as lead to a particular reliance on more heuristics (canConvertValue) than may be intended based on the exact alloca type declared--such as whether it has the ability to rewrite an operation as an integer or an array as a vector, if it sees both appear. That predicate would still be required to check if there's any "weirdness" happening with treating the result as just bits (like having matching offsets of all TargetExt and of NonIntegralPointer address space equality, or if either is an SVE). But at least the pass won't be forced to decide up front if operation should be an integer or an array or other representation.

This implements a (hopefully) correct pass in all cases. However any moderately complicated poison inputs are currently known to be incorrectly handled in general in LLVM. The most recent discussion on these poison semantics seems to be that they are logically contradictory right now: the last recommendation I know of is that vector operations must never be cast to an iN type, since that spreads poison where it is unsound to spread it. However, many passes (including SROA upon which this was modeled) was never fixed not to cast to iN: https://discourse.llvm.org/t/rfc-killing-undef-and-spreading-poison/42843/87 Simple poison inputs are dealt with by the need to maintain original types whenever possible.

To make this pass more careful, this could always use the vector-to-vector transforms (using the gcd or i1 type), or could always insert freeze when the source is a vector and the destination is not. However, either case may be challenging for many users of this pass, since SROA optimizations may make many common patterns and ABIs miscompile (e.g. source type {i8, i8} getting passed as i16 or used in a 2-byte atomic, where any part of the original type was padding). The byte type has been proposed to help fix this, but not yet merged.
  Sources:
  - https://discourse.llvm.org/t/rfc-add-a-new-byte-type-to-llvm-ir/89522
  - https://gist.github.com/georgemitenkov/3def898b8845c2cc161bd216cbbdb81f
  - https://blog.llvm.org/posts/2025-08-29-gsoc-byte-type/

Note that there's two extract/insert strategies provided here, based on whether llvm backends are more canonical to handle being given a full index or a tree merge, controlled by `const bool USE_FULL_IDX` for current/future testing.

Assisted-By: Claude Sonnet 4.6 <noreply@anthropic.com>