### PR TITLE
[flang][openacc][cuda] Add implicit device attribute for use_device unconditionally

### DIFF
--- a/flang/lib/Lower/OpenACC.cpp
+++ b/flang/lib/Lower/OpenACC.cpp
@@ -1759,7 +1759,7 @@ void AccDataMap::remapDataOperandSymbols(
       llvm::cast<hlfir::DeclareOp>(*computeDef).setSkipRebox(true);
 
     symbolMap.addVariableDefinition(
-        symbol, llvm::cast<fir::FortranVariableOpInterface>(computeDef));
+        symbol, llvm::cast<fir::FortranVariableOpInterface>(computeDef), true);
   }
 
   for (const auto &comp : components) {
@@ -2857,41 +2857,40 @@ genACCHostDataOp(Fortran::lower::AbstractConverter &converter,
   for (const Fortran::parser::AccClause &clause : accClauseList.v) {
     if (const auto *useDevice =
             std::get_if<Fortran::parser::AccClause::UseDevice>(&clause.u)) {
-      // When CUDA Fortran is enabled, extra symbols are used in the host_data
-      // region. Look for them and bind their values with the symbols in the
-      // outer scope.
-      if (semanticsContext.IsEnabled(Fortran::common::LanguageFeature::CUDA)) {
-        const Fortran::parser::AccObjectList &objectList{useDevice->v};
-        for (const auto &accObject : objectList.v) {
-          const Fortran::semantics::Symbol *newSym = nullptr;
-          if (const auto *designator =
-                  std::get_if<Fortran::parser::Designator>(&accObject.u)) {
-            if (const auto *name =
-                    Fortran::parser::GetDesignatorNameIfDataRef(*designator)) {
-              newSym = name->symbol;
-            } else if (const auto *arrayElement = Fortran::parser::Unwrap<
-                           Fortran::parser::ArrayElement>(*designator)) {
-              const Fortran::parser::Name &name =
-                  Fortran::parser::GetLastName(arrayElement->Base());
-              newSym = name.symbol;
-            } else if (const auto *component = Fortran::parser::Unwrap<
-                           Fortran::parser::StructureComponent>(*designator)) {
-              const Fortran::parser::DataRef &base{component->Base()};
-              if (const auto *name =
-                      std::get_if<Fortran::parser::Name>(&base.u)) {
-                newSym = name->symbol;
-              }
-            }
-          } else if (const auto *name =
-                         std::get_if<Fortran::parser::Name>(&accObject.u)) {
+      // For CUDA Fortran interoperability, extra symbols are used in the
+      // host_data region. Look for them and bind their values with the symbols
+      // in the outer scope.
+      const Fortran::parser::AccObjectList &objectList{useDevice->v};
+      for (const auto &accObject : objectList.v) {
+        const Fortran::semantics::Symbol *newSym = nullptr;
+        if (const auto *designator =
+                std::get_if<Fortran::parser::Designator>(&accObject.u)) {
+          if (const auto *name =
+                  Fortran::parser::GetDesignatorNameIfDataRef(*designator)) {
             newSym = name->symbol;
+          } else if (const auto *arrayElement =
+                         Fortran::parser::Unwrap<Fortran::parser::ArrayElement>(
+                             *designator)) {
+            const Fortran::parser::Name &name =
+                Fortran::parser::GetLastName(arrayElement->Base());
+            newSym = name.symbol;
+          } else if (const auto *component = Fortran::parser::Unwrap<
+                         Fortran::parser::StructureComponent>(*designator)) {
+            const Fortran::parser::DataRef &base{component->Base()};
+            if (const auto *name =
+                    std::get_if<Fortran::parser::Name>(&base.u)) {
+              newSym = name->symbol;
+            }
           }
-          if (newSym) {
-            const Fortran::semantics::Symbol *origSym =
-                localSymbols.lookupSymbolByName(newSym->name().ToString());
-            if (origSym)
-              localSymbols.copySymbolBinding(*origSym, *newSym);
-          }
+        } else if (const auto *name =
+                       std::get_if<Fortran::parser::Name>(&accObject.u)) {
+          newSym = name->symbol;
+        }
+        if (newSym) {
+          const Fortran::semantics::Symbol *origSym =
+              localSymbols.lookupSymbolByName(newSym->name().ToString());
+          if (origSym)
+            localSymbols.copySymbolBinding(*origSym, *newSym);
         }
       }
       genDataOperandOperations<mlir::acc::UseDeviceOp>(

--- a/flang/lib/Lower/OpenACC.cpp
+++ b/flang/lib/Lower/OpenACC.cpp
@@ -2889,7 +2889,7 @@ genACCHostDataOp(Fortran::lower::AbstractConverter &converter,
         if (newSym) {
           const Fortran::semantics::Symbol *origSym =
               localSymbols.lookupSymbolByName(newSym->name().ToString());
-          if (origSym)
+          if (origSym && *origSym != *newSym)
             localSymbols.copySymbolBinding(*origSym, *newSym);
         }
       }

--- a/flang/lib/Semantics/resolve-names.cpp
+++ b/flang/lib/Semantics/resolve-names.cpp
@@ -1505,12 +1505,10 @@ bool AccVisitor::Pre(const parser::OpenACCBlockConstruct &x) {
 }
 
 void AccVisitor::CopySymbolWithDevice(const parser::Name *name) {
-  // When CUDA Fortran is enabled together with OpenACC, new
-  // symbols are created for the one appearing in the use_device
-  // clause. These new symbols have the CUDA Fortran device
-  // attribute.
-  if (context_.languageFeatures().IsEnabled(common::LanguageFeature::CUDA) &&
-      name && name->symbol) {
+  // For CUDA Fortran interoperability, new symbols are created for the ones
+  // appearing in the use_device clause. These new symbols have the CUDA Fortran
+  // device attribute.
+  if (name && name->symbol) {
     if (Symbol * copy{currScope().CopySymbol(*name->symbol)}) {
       name->symbol = copy;
       if (auto *object{copy->detailsIf<ObjectEntityDetails>()}) {

--- a/flang/lib/Semantics/resolve-names.cpp
+++ b/flang/lib/Semantics/resolve-names.cpp
@@ -1400,8 +1400,6 @@ private:
 // Create scopes for OpenACC constructs
 class AccVisitor : public virtual DeclarationVisitor {
 public:
-  explicit AccVisitor(SemanticsContext &context) : context_{context} {}
-
   void AddAccSourceRange(const parser::CharBlock &);
 
   static bool NeedsScope(const parser::OpenACCBlockConstruct &);
@@ -1472,9 +1470,6 @@ public:
   }
 
   void CopySymbolWithDevice(const parser::Name *name);
-
-private:
-  SemanticsContext &context_;
 };
 
 bool AccVisitor::NeedsScope(const parser::OpenACCBlockConstruct &x) {
@@ -2172,8 +2167,7 @@ public:
 
   ResolveNamesVisitor(
       SemanticsContext &context, ImplicitRulesMap &rules, Scope &top)
-      : BaseVisitor{context, *this, rules}, AccVisitor(context),
-        topScope_{top} {
+      : BaseVisitor{context, *this, rules}, topScope_{top} {
     PushScope(top);
   }
 

--- a/flang/test/Semantics/OpenACC/bug1583.f90
+++ b/flang/test/Semantics/OpenACC/bug1583.f90
@@ -15,7 +15,7 @@ contains
   type(t) :: v
 !$acc host_data use_device(v%c)
   !DEF: /foo EXTERNAL (Subroutine) ProcEntity
-  !REF: /m/sub/v
+  !DEF: /m/sub/OpenACCConstruct1/v ObjectEntity TYPE(t)
   !REF: /m/t/c
   call foo(v%c)
 !$acc end host_data


### PR DESCRIPTION
For interoperability between CUDA Fortran and OpenACC. 