### PR TITLE
[BOLT] Fix a crash for calling `pwrite`

### DIFF
--- a/bolt/lib/Rewrite/RewriteInstance.cpp
+++ b/bolt/lib/Rewrite/RewriteInstance.cpp
@@ -6295,8 +6295,12 @@ void RewriteInstance::rewriteFile() {
                  << Section.getOutputSize() << "\n at offset "
                  << Section.getOutputFileOffset() << " with content size "
                  << Section.getOutputContents().size() << '\n';
+
+    uint64_t SavedPos = OS.tell();
     OS.seek(Section.getOutputFileOffset());
     Section.write(OS);
+    SavedPos = std::max(SavedPos, OS.tell());
+    OS.seek(SavedPos);
   }
 
   for (BinarySection &Section : BC->allocatableSections())
@@ -6357,6 +6361,7 @@ void RewriteInstance::rewriteFile() {
 }
 
 void RewriteInstance::writeEHFrameHeader() {
+  uint64_t SavedPos = Out->os().tell();
   BinarySection *NewEHFrameSection =
       getSection(getNewSecPrefix() + getEHFrameSectionName());
 
@@ -6462,6 +6467,9 @@ void RewriteInstance::writeEHFrameHeader() {
 
   LLVM_DEBUG(dbgs() << "BOLT-DEBUG: size of .eh_frame after merge is "
                     << NewEHFrameSection->getOutputSize() << '\n');
+
+  SavedPos = std::max(SavedPos, Out->os().tell());
+  Out->os().seek(SavedPos);
 }
 
 uint64_t RewriteInstance::getNewValueForSymbol(const StringRef Name) {

--- a/bolt/lib/Rewrite/RewriteInstance.cpp
+++ b/bolt/lib/Rewrite/RewriteInstance.cpp
@@ -5595,13 +5595,13 @@ void RewriteInstance::patchELFSymTabs(ELFObjectFile<ELFT> *File) {
   if (DynSymSection) {
     updateELFSymbolTable(
         File,
-        /*IsDynSym=*/true, *DynSymSection, NewSectionIndex,
+        /*IsDynSym=*/true,
+        *DynSymSection,
+        NewSectionIndex,
         [&](size_t Offset, const ELFSymTy &Sym) {
-          raw_fd_ostream &OS = Out->os();
-          uint64_t SavedPos = OS.tell();
-          OS.seek(DynSymSection->sh_offset + Offset);
-          OS.write(reinterpret_cast<const char *>(&Sym), sizeof(ELFSymTy));
-          OS.seek(SavedPos);
+          Out->os().pwrite(reinterpret_cast<const char *>(&Sym),
+                           sizeof(ELFSymTy),
+                           DynSymSection->sh_offset + Offset);
         },
         [](StringRef) -> size_t { return 0; });
   }

--- a/bolt/lib/Rewrite/RewriteInstance.cpp
+++ b/bolt/lib/Rewrite/RewriteInstance.cpp
@@ -5595,13 +5595,13 @@ void RewriteInstance::patchELFSymTabs(ELFObjectFile<ELFT> *File) {
   if (DynSymSection) {
     updateELFSymbolTable(
         File,
-        /*IsDynSym=*/true,
-        *DynSymSection,
-        NewSectionIndex,
+        /*IsDynSym=*/true, *DynSymSection, NewSectionIndex,
         [&](size_t Offset, const ELFSymTy &Sym) {
-          Out->os().pwrite(reinterpret_cast<const char *>(&Sym),
-                           sizeof(ELFSymTy),
-                           DynSymSection->sh_offset + Offset);
+          raw_fd_ostream &OS = Out->os();
+          uint64_t SavedPos = OS.tell();
+          OS.seek(DynSymSection->sh_offset + Offset);
+          OS.write(reinterpret_cast<const char *>(&Sym), sizeof(ELFSymTy));
+          OS.seek(SavedPos);
         },
         [](StringRef) -> size_t { return 0; });
   }


### PR DESCRIPTION
Since `raw_pwrite_stream::pwrite` does not support extending the stream, each seek-and-write operation in `rewriteFile` either extends the stream or requires restoring the stream position after seeking backwards.

Fixes #185051