### PR TITLE
[lldb] Include stdio.h in synthetic subscript test

### DIFF
--- a/lldb/test/API/functionalities/data-formatter/synthetic_subscript/main.c
+++ b/lldb/test/API/functionalities/data-formatter/synthetic_subscript/main.c
@@ -1,3 +1,5 @@
+#include <stdio.h>
+
 struct Thing {
   int zero;
   int one;
@@ -7,6 +9,6 @@ int main() {
   struct Thing x;
   x.zero = 1;
   x.one = 2;
-  __builtin_printf("break here\n");
+  printf("break here\n");
   return 0;
 }


### PR DESCRIPTION
The [lldb-aarch64-windows](https://lab.llvm.org/buildbot/#/builders/141) buildbot failed with:

```
lld-link: error: undefined symbol: printf
>>> referenced by main.o:(main)
```

I'm assuming that's because of the use of `__builtin_printf`. In other tests, we use `printf` form `stdio.h` and these build fine, so I added an include and used `printf`.