### PR TITLE
[lldb] Provide fallback definition for `SEGV_PKUERR`

### DIFF
--- a/lldb/source/Plugins/Process/Utility/LinuxSignals.cpp
+++ b/lldb/source/Plugins/Process/Utility/LinuxSignals.cpp
@@ -18,6 +18,9 @@
 #ifndef SEGV_BNDERR
 #define SEGV_BNDERR 3
 #endif
+#ifndef SEGV_PKUERR
+#define SEGV_PKUERR 4
+#endif
 #ifndef SEGV_MTEAERR
 #define SEGV_MTEAERR 8
 #endif


### PR DESCRIPTION
lldb used `SEGV_PKUERR` without a fallback definition, which caused build failures on older headers. This patch fixes this issue.