### PR TITLE
[z/OS] Recognize EBCDIC archive magic

### DIFF
--- a/llvm/include/llvm/Object/Archive.h
+++ b/llvm/include/llvm/Object/Archive.h
@@ -34,6 +34,8 @@ namespace object {
 const char ArchiveMagic[] = "!<arch>\n";
 const char ThinArchiveMagic[] = "!<thin>\n";
 const char BigArchiveMagic[] = "<bigaf>\n";
+const char ZOSArchiveMagic[] =
+    "\x5A\x4C\x81\x99\x83\x88\x6E\x15"; // "!<arch>\n" in EBCDIC
 
 class Archive;
 

--- a/llvm/lib/BinaryFormat/Magic.cpp
+++ b/llvm/lib/BinaryFormat/Magic.cpp
@@ -101,6 +101,11 @@ file_magic llvm::identify_magic(StringRef Magic) {
     if (startswith(Magic, "CPCH"))
       return file_magic::clang_ast;
     break;
+  case 0x5A:
+    if (startswith(Magic,
+                   "\x5A\x4C\x81\x99\x83\x88\x6E\x15")) // "!<arch>\n" in EBCDIC
+      return file_magic::archive;
+    break;
   case '!':
     if (startswith(Magic, "!<arch>\n") || startswith(Magic, "!<thin>\n"))
       return file_magic::archive;

--- a/llvm/unittests/BinaryFormat/TestFileMagic.cpp
+++ b/llvm/unittests/BinaryFormat/TestFileMagic.cpp
@@ -47,6 +47,7 @@ protected:
 
 const char archive[] = "!<arch>\x0A";
 const char big_archive[] = "<bigaf>\x0A";
+const char zos_archive[] = "\x5A\x4C\x81\x99\x83\x88\x6E\x15";
 const char bitcode[] = "\xde\xc0\x17\x0b";
 const char coff_object[] = "\x00\x00......";
 const char coff_bigobj[] =
@@ -100,6 +101,7 @@ TEST_F(MagicTest, Magic) {
 #define DEFINE(magic) {#magic, magic, sizeof(magic), file_magic::magic}
       DEFINE(archive),
       {"big_archive", big_archive, sizeof(big_archive), file_magic::archive},
+      {"zos_archive", zos_archive, sizeof(zos_archive), file_magic::archive},
       DEFINE(bitcode),
       DEFINE(coff_object),
       {"coff_bigobj", coff_bigobj, sizeof(coff_bigobj),


### PR DESCRIPTION
`z/OS` archives use the same structural layout as traditional Unix archives but encode all text fields in EBCDIC. The magic string is the EBCDIC representation of `\"!<arch>\n\" (hex: 5A 4C 81 99 83 88 6E 15)`. This patch adds recognition of the `z/OS` archive magic to `identify_magic()` and defines the `ZOSArchiveMagic` constant. This is the first in a series of patches adding `z/OS` archive support to LLVM.