### PR TITLE
[flang][acc] Handle deduplicated use_device in ACCUseDeviceCanonicalizer

### DIFF
--- a/flang/lib/Optimizer/OpenACC/Transforms/ACCUseDeviceCanonicalizer.cpp
+++ b/flang/lib/Optimizer/OpenACC/Transforms/ACCUseDeviceCanonicalizer.cpp
@@ -157,6 +157,8 @@ private:
                                         acc::UseDeviceOp useDeviceOp,
                                         acc::HostDataOp hostDataOp,
                                         fir::BoxAddrOp boxAddr) const {
+    OpBuilder::InsertionGuard guard(rewriter);
+    rewriter.setInsertionPoint(hostDataOp);
     // Create use_device on the raw pointer
     acc::UseDeviceOp newUseDeviceOp = acc::UseDeviceOp::create(
         rewriter, useDeviceOp.getLoc(), boxAddr.getType(), boxAddr.getResult(),
@@ -364,9 +366,14 @@ private:
     for (mlir::Operation *user : usersToUpdate)
       user->replaceUsesOfWith(useDeviceOp.getResult(), newBoxWithDevicePtr);
 
-    assert(useDeviceOp.getResult().use_empty() &&
-           "expected all uses of use_device to be replaced");
-    rewriter.eraseOp(useDeviceOp);
+    // Remove the use_device operation if it is no longer needed.
+    if (useDeviceOp.getResult().use_empty()) {
+      LLVM_DEBUG(
+          llvm::dbgs()
+          << "ACCUseDeviceCanonicalizer: Removing dead use_device operation: "
+          << *useDeviceOp << "\n");
+      rewriter.eraseOp(useDeviceOp);
+    }
     return true;
   }
 };

--- a/flang/test/Fir/OpenACC/use-device-canonicalizer.mlir
+++ b/flang/test/Fir/OpenACC/use-device-canonicalizer.mlir
@@ -94,3 +94,36 @@ func.func @test_host_data_hoisting_ref_to_box() {
   return
 }
 
+// -----
+
+// Test single use_device used by multiple host_data: one use_device is created
+// per host_data, each inserted right before its host_data.
+func.func @multiple_host_data_(%arg0: !fir.box<!fir.array<?xf32>> {fir.bindc_name = "arr"}) {
+  %0 = fir.dummy_scope : !fir.dscope
+  %1 = fir.declare %arg0 dummy_scope %0 arg 1 {uniq_name = "_QFmultiple_host_dataEarr"} : (!fir.box<!fir.array<?xf32>>, !fir.dscope) -> !fir.box<!fir.array<?xf32>>
+  %2 = fir.rebox %1 : (!fir.box<!fir.array<?xf32>>) -> !fir.box<!fir.array<?xf32>>
+  %3 = acc.use_device var(%2 : !fir.box<!fir.array<?xf32>>) -> !fir.box<!fir.array<?xf32>> {name = "arr"}
+  acc.host_data dataOperands(%3 : !fir.box<!fir.array<?xf32>>) {
+    %4 = fir.dummy_scope : !fir.dscope
+    %5 = fir.declare %3 dummy_scope %4 arg 1 {uniq_name = "_QFmultiple_host_dataEarr"} : (!fir.box<!fir.array<?xf32>>, !fir.dscope) -> !fir.box<!fir.array<?xf32>>
+    acc.terminator
+  }
+  acc.host_data dataOperands(%3 : !fir.box<!fir.array<?xf32>>) {
+    %4 = fir.dummy_scope : !fir.dscope
+    %5 = fir.declare %3 dummy_scope %4 arg 1 {uniq_name = "_QFmultiple_host_dataEarr"} : (!fir.box<!fir.array<?xf32>>, !fir.dscope) -> !fir.box<!fir.array<?xf32>>
+    acc.terminator
+  }
+  return
+}
+// CHECK-LABEL: func.func @multiple_host_data_
+// CHECK-SAME: %arg0: !fir.box<!fir.array<?xf32>>
+// CHECK: fir.box_addr %2
+// CHECK: fir.box_addr %2
+// CHECK: %[[USE_DEVICE_1:.*]] = acc.use_device varPtr({{.*}} : !fir.ref<!fir.array<?xf32>>) varType(!fir.box<!fir.array<?xf32>>) -> !fir.ref<!fir.array<?xf32>> {name = "arr"}
+// CHECK: acc.host_data dataOperands(%[[USE_DEVICE_1]] : !fir.ref<!fir.array<?xf32>>) {
+// CHECK: acc.terminator
+// CHECK: }
+// CHECK: %[[USE_DEVICE_2:.*]] = acc.use_device varPtr({{.*}} : !fir.ref<!fir.array<?xf32>>) varType(!fir.box<!fir.array<?xf32>>) -> !fir.ref<!fir.array<?xf32>> {name = "arr"}
+// CHECK: acc.host_data dataOperands(%[[USE_DEVICE_2]] : !fir.ref<!fir.array<?xf32>>) {
+// CHECK: acc.terminator
+// CHECK: }


### PR DESCRIPTION
The ACCUseDeviceCanonicalizer was attempting to remove `acc.use_device` operation even when it was used in multiple constructs. This updates the pass to remove it only when no longer used, which for the attached example is after the handling of the second `acc.host_data` construct.