### PR TITLE
[lldb] Use clang_cl_host to build `vbases.test`

### DIFF
--- a/lldb/test/Shell/SymbolFile/NativePDB/vbases.test
+++ b/lldb/test/Shell/SymbolFile/NativePDB/vbases.test
@@ -4,8 +4,8 @@
 
 # RUN: split-file %s %t
 
-# RUN: %clang_cl --target=x86_64-windows-msvc -Z7 -c /GS- /Fo%t.cv.obj -- %t/main.cpp
-# RUN: %clang_cl --target=x86_64-windows-msvc -Z7 -gdwarf -c /GS- /Fo%t.dwarf.obj -- %t/main.cpp
+# RUN: %clang_cl_host -Z7 -c /GS- /Fo%t.cv.obj -- %t/main.cpp
+# RUN: %clang_cl_host -Z7 -gdwarf -c /GS- /Fo%t.dwarf.obj -- %t/main.cpp
 
 # RUN: lld-link -debug -nodefaultlib -entry:main %t.cv.obj -out:%t.cv.exe
 # RUN: lld-link -debug -nodefaultlib -entry:main %t.dwarf.obj -out:%t.dwarf.exe


### PR DESCRIPTION
The `vbases.test` failed on the [lldb-aarch64-windows](https://lab.llvm.org/buildbot/#/builders/141) buildbot with:

```
(lldb) v useruser 
(UserUser) useruser = { 
  Base1 = (member = <read memory from 0x28 failed (0 of 2 bytes read)>) 
  User = { 
    VBase1 = (member = <read memory from 0x3a failed (0 of 2 bytes read)>) 
    VBase2 = (member = <read memory from 0x3c failed (0 of 2 bytes read)>) 
    member = <read memory from 0x38 failed (0 of 2 bytes read)> 
```

As far as I know, we don't have a test for Windows on ARM running x86 executables and reading registers (we only inspect global variables). It seems like here, we fail to read RSP and return 0, because  `useruser` is at RSP+0x28.

This uses `%clang_cl_host` to build the executables.