### PR TITLE
[LLVM] [SeparateConstOffsetFromGEP] patch PR 183402 to handle negative C correctly

### DIFF
--- a/llvm/lib/Transforms/Scalar/SeparateConstOffsetFromGEP.cpp
+++ b/llvm/lib/Transforms/Scalar/SeparateConstOffsetFromGEP.cpp
@@ -542,7 +542,7 @@ static bool canReorderAddSextToGEP(const GetElementPtrInst *GEP,
   } else {
     // (2^(N-1) + C) * stride
     Threshold = (APInt::getSignedMinValue(N).zext(128) +
-                 CI->getValue().zextOrTrunc(128)) *
+                 CI->getValue().sextOrTrunc(128)) *
                 APInt(128, Stride);
   }
 


### PR DESCRIPTION
Small typo in negative C threshold calculation would result in a threshold that is too conservative due to overflow.