### PR TITLE
[NFCI][sanitizer_common] Realign #ifdefs in sanitizer_internal_defs.h

### DIFF
--- a/compiler-rt/lib/sanitizer_common/sanitizer_internal_defs.h
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_internal_defs.h
@@ -29,12 +29,12 @@
 
 // Only use SANITIZER_*ATTRIBUTE* before the function return type!
 #if SANITIZER_WINDOWS
-#if SANITIZER_IMPORT_INTERFACE
-# define SANITIZER_INTERFACE_ATTRIBUTE __declspec(dllimport)
-#else
-# define SANITIZER_INTERFACE_ATTRIBUTE __declspec(dllexport)
-#endif
-# define SANITIZER_WEAK_ATTRIBUTE
+#  if SANITIZER_IMPORT_INTERFACE
+#    define SANITIZER_INTERFACE_ATTRIBUTE __declspec(dllimport)
+#  else
+#    define SANITIZER_INTERFACE_ATTRIBUTE __declspec(dllexport)
+#  endif
+#  define SANITIZER_WEAK_ATTRIBUTE
 #  define SANITIZER_WEAK_IMPORT
 #else
 #  if SANITIZER_GO


### PR DESCRIPTION
Currently it is very hard to tell these nested ifdefs apart. This patch fixes that, while trying to be as light-touch as possible.