### PR TITLE
[clang-format] Fix a bug in indenting lambda comments with only tabs

### DIFF
--- a/clang/lib/Format/BreakableToken.cpp
+++ b/clang/lib/Format/BreakableToken.cpp
@@ -1042,38 +1042,40 @@ BreakableComment::Split BreakableLineCommentSection::getReflowSplit(
 
 void BreakableLineCommentSection::reflow(unsigned LineIndex,
                                          WhitespaceManager &Whitespaces) const {
-  if (LineIndex > 0 && Tokens[LineIndex] != Tokens[LineIndex - 1]) {
-    // Reflow happens between tokens. Replace the whitespace between the
-    // tokens by the empty string.
-    Whitespaces.replaceWhitespace(
-        *Tokens[LineIndex], /*Newlines=*/0, /*Spaces=*/0,
-        /*StartOfTokenColumn=*/StartColumn, /*IsAligned=*/true,
-        /*InPPDirective=*/false);
-  } else if (LineIndex > 0) {
-    // In case we're reflowing after the '\' in:
-    //
-    //   // line comment \
-    //   // line 2
-    //
-    // the reflow happens inside the single comment token (it is a single line
-    // comment with an unescaped newline).
-    // Replace the whitespace between the '\' and '//' with the empty string.
-    //
-    // Offset points to after the '\' relative to start of the token.
-    unsigned Offset = Lines[LineIndex - 1].data() +
-                      Lines[LineIndex - 1].size() -
-                      tokenAt(LineIndex - 1).TokenText.data();
-    // WhitespaceLength is the number of chars between the '\' and the '//' on
-    // the next line.
-    unsigned WhitespaceLength =
-        Lines[LineIndex].data() - tokenAt(LineIndex).TokenText.data() - Offset;
-    Whitespaces.replaceWhitespaceInToken(*Tokens[LineIndex], Offset,
-                                         /*ReplaceChars=*/WhitespaceLength,
-                                         /*PreviousPostfix=*/"",
-                                         /*CurrentPrefix=*/"",
-                                         /*InPPDirective=*/false,
-                                         /*Newlines=*/0,
-                                         /*Spaces=*/0);
+  if (LineIndex > 0) {
+    if (Tokens[LineIndex] != Tokens[LineIndex - 1]) {
+      // Reflow happens between tokens. Replace the whitespace between the
+      // tokens by the empty string.
+      Whitespaces.replaceWhitespace(
+          *Tokens[LineIndex], /*Newlines=*/0, /*Spaces=*/0,
+          /*StartOfTokenColumn=*/StartColumn, /*IsAligned=*/true,
+          /*InPPDirective=*/false);
+    } else {
+      // In case we're reflowing after the '\' in:
+      //
+      //   // line comment \
+      //   // line 2
+      //
+      // the reflow happens inside the single comment token (it is a single line
+      // comment with an unescaped newline).
+      // Replace the whitespace between the '\' and '//' with the empty string.
+      //
+      // Offset points to after the '\' relative to start of the token.
+      unsigned Offset = Lines[LineIndex - 1].data() +
+                        Lines[LineIndex - 1].size() -
+                        tokenAt(LineIndex - 1).TokenText.data();
+      // WhitespaceLength is the number of chars between the '\' and the '//' on
+      // the next line.
+      unsigned WhitespaceLength = Lines[LineIndex].data() -
+                                  tokenAt(LineIndex).TokenText.data() - Offset;
+      Whitespaces.replaceWhitespaceInToken(*Tokens[LineIndex], Offset,
+                                           /*ReplaceChars=*/WhitespaceLength,
+                                           /*PreviousPostfix=*/"",
+                                           /*CurrentPrefix=*/"",
+                                           /*InPPDirective=*/false,
+                                           /*Newlines=*/0,
+                                           /*Spaces=*/0);
+    }
   }
   // Replace the indent and prefix of the token with the reflow prefix.
   unsigned Offset =
@@ -1116,7 +1118,7 @@ void BreakableLineCommentSection::adaptStartOfLine(
                                   /*Newlines=*/1,
                                   /*Spaces=*/LineColumn,
                                   /*StartOfTokenColumn=*/LineColumn,
-                                  /*IsAligned=*/true,
+                                  /*IsAligned=*/tokenAt(0).NewlinesBefore == 0,
                                   /*InPPDirective=*/false);
   }
   if (OriginalPrefix[LineIndex] != Prefix[LineIndex]) {

--- a/clang/unittests/Format/FormatTest.cpp
+++ b/clang/unittests/Format/FormatTest.cpp
@@ -17343,6 +17343,16 @@ TEST_F(FormatTest, ConfigurableUseOfTab) {
   verifyFormat("int aaaaaaaaaa = bbbbbbbbbbbbbbbbbbbb\n"
                "               + cccccccccccccccccccc;",
                Tab);
+
+  Tab.BreakBeforeBraces = FormatStyle::BS_Custom;
+  Tab.BraceWrapping.BeforeLambdaBody = true;
+  verifyNoChange("example(\n"
+                 "\t[]\n"
+                 "\t{\n"
+                 "\t\t// foo\n"
+                 "\t\t// bar\n"
+                 "\t});",
+                 Tab);
 }
 
 TEST_F(FormatTest, ZeroTabWidth) {


### PR DESCRIPTION
Fixes #175151