### PR TITLE
[libc] Add software Float128 fallback wrapper

### DIFF
--- a/libc/include/llvm-libc-types/float128.h
+++ b/libc/include/llvm-libc-types/float128.h
@@ -31,6 +31,9 @@ typedef __float128 float128;
 #elif (LDBL_MANT_DIG == 113)
 #define LIBC_TYPES_HAS_FLOAT128
 typedef long double float128;
+#else
+#include "src/__support/FPUtil/float128.h"
+typedef LIBC_NAMESPACE::fputil::Float128 float128;
 #endif
 
 #endif // LLVM_LIBC_TYPES_FLOAT128_H

--- a/libc/src/__support/FPUtil/float128.h
+++ b/libc/src/__support/FPUtil/float128.h
@@ -1,0 +1,37 @@
+//===-- Float128 software wrapper ----------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines a minimal software-backed Float128 wrapper type used when
+// the host compiler does not provide a native 128-bit floating-point type.
+// The wrapper currently only stores the raw 128-bit representation.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_SUPPORT_FPUTIL_FLOAT128_H
+#define LLVM_LIBC_SRC_SUPPORT_FPUTIL_FLOAT128_H
+
+#include "src/__support/uint128.h"
+
+namespace LIBC_NAMESPACE_DECL {
+namespace fputil {
+
+class Float128 {
+private:
+  UInt128 bits_;
+
+public:
+  constexpr Float128() = default;
+
+  constexpr explicit Float128(UInt128 value) : bits_(value) {}
+
+  constexpr UInt128 get_bits() const { return bits_; }
+};
+} // namespace fputil
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_SUPPORT_FPUTIL_FLOAT128_H

--- a/libc/src/__support/FPUtil/float128.h
+++ b/libc/src/__support/FPUtil/float128.h
@@ -22,14 +22,14 @@ namespace fputil {
 
 class Float128 {
 private:
-  UInt128 bits_;
+  UInt128 bits_ = 0;
 
 public:
-  constexpr Float128() = default;
+    constexpr Float128() = default;
 
-  constexpr explicit Float128(UInt128 value) : bits_(value) {}
+    constexpr explicit Float128(UInt128 value) : bits_(value) {}
 
-  constexpr UInt128 get_bits() const { return bits_; }
+    constexpr UInt128 get_bits() const { return bits_; }
 };
 } // namespace fputil
 } // namespace LIBC_NAMESPACE_DECL


### PR DESCRIPTION
This patch introduces a minimal software-backed Float128 wrapper used as a fallback when the host compiler does not provide native 128-bit floating-point support.

LLVM libc relies on templated implementations of math routines that expect the availability of types such as float128. However, some toolchains and platforms (e.g. MSVC or certain non-x86 targets) do not provide a native _Float128 or __float128 type. This prevents parts of the libc math infrastructure from compiling on those systems.

To address this, this patch adds a minimal fputil::Float128 wrapper that stores the raw 128-bit representation using UInt128. The wrapper currently provides only basic storage and access functionality and is intended as an initial infrastructure step toward supporting software-emulated float128 semantics.

The existing type detection logic in llvm-libc-types/float128.h is extended to fall back to this wrapper when no native float128 representation is available.

This change enables libc code that depends on the float128 type to compile on platforms lacking native float128 support. Future work will extend this wrapper with arithmetic operations and integrate it with software floating-point implementations.