### PR TITLE
[clang][Darwin] Externalize pseudoprobe and debug info

### DIFF
--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -2923,10 +2923,11 @@ void Driver::BuildUniversalActions(Compilation &C, const ToolChain &TC,
          enablesDebugInfoForProfiling) &&
         ContainsCompileOrAssembleAction(Actions.back())) {
 
-      // Add a 'dsymutil' step if necessary, when debug info is enabled and we
-      // have a compile input. We need to run 'dsymutil' ourselves in such cases
-      // because the debug info will refer to a temporary object file which
-      // will be removed at the end of the compilation process.
+      // Add a 'dsymutil' step if necessary, when debug info, remarks, or
+      // pseudo probes are enabled and we have a compile input. We need to run
+      // 'dsymutil' ourselves in such cases because the debug info will refer
+      // to a temporary object file which will be removed at the end of the
+      // compilation process.
       if (Act->getType() == types::TY_Image) {
         ActionList Inputs;
         Inputs.push_back(Actions.back());

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -2913,7 +2913,14 @@ void Driver::BuildUniversalActions(Compilation &C, const ToolChain &TC,
     Arg *A = Args.getLastArg(options::OPT_g_Group);
     bool enablesDebugInfo = A && !A->getOption().matches(options::OPT_g0) &&
                             !A->getOption().matches(options::OPT_gstabs);
-    if ((enablesDebugInfo || willEmitRemarks(Args)) &&
+    bool enablesPseudoProbe =
+        Args.hasFlag(options::OPT_fpseudo_probe_for_profiling,
+                     options::OPT_fno_pseudo_probe_for_profiling, false);
+    bool enablesDebugInfoForProfiling =
+        Args.hasFlag(options::OPT_fdebug_info_for_profiling,
+                     options::OPT_fno_debug_info_for_profiling, false);
+    if ((enablesDebugInfo || willEmitRemarks(Args) || enablesPseudoProbe ||
+         enablesDebugInfoForProfiling) &&
         ContainsCompileOrAssembleAction(Actions.back())) {
 
       // Add a 'dsymutil' step if necessary, when debug info is enabled and we

--- a/clang/test/Driver/pseudo-probe.c
+++ b/clang/test/Driver/pseudo-probe.c
@@ -13,13 +13,23 @@
 // NONAME-NOT: -funique-internal-linkage-names
 
 // On Darwin, -fpseudo-probe-for-profiling should trigger dsymutil
-// RUN: %clang -target x86_64-apple-darwin10 -### -o foo -fpseudo-probe-for-profiling %s 2>&1 | FileCheck %s --check-prefix=CHECK-DSYMUTIL-PSEUDO-PROBE
+// RUN: %clang -target arm64-apple-darwin -### -o foo -fpseudo-probe-for-profiling %s 2>&1 | FileCheck %s --check-prefix=CHECK-DSYMUTIL-PSEUDO-PROBE
 // CHECK-DSYMUTIL-PSEUDO-PROBE: "-cc1"
 // CHECK-DSYMUTIL-PSEUDO-PROBE: ld
 // CHECK-DSYMUTIL-PSEUDO-PROBE: dsymutil
 
+// RUN: %clang -target arm64-apple-darwin -### -o foo -fno-pseudo-probe-for-profiling %s 2>&1 | FileCheck %s --check-prefix=CHECK-NO-DSYMUTIL-PSEUDO-PROBE
+// CHECK-NO-DSYMUTIL-PSEUDO-PROBE: "-cc1"
+// CHECK-NO-DSYMUTIL-PSEUDO-PROBE: ld
+// CHECK-NO-DSYMUTIL-PSEUDO-PROBE-NOT: dsymutil
+
 // On Darwin, -fdebug-info-for-profiling should trigger dsymutil
-// RUN: %clang -target x86_64-apple-darwin10 -### -o foo -fdebug-info-for-profiling %s 2>&1 | FileCheck %s --check-prefix=CHECK-DSYMUTIL-DEBUG-PROF
+// RUN: %clang -target arm64-apple-darwin -### -o foo -fdebug-info-for-profiling %s 2>&1 | FileCheck %s --check-prefix=CHECK-DSYMUTIL-DEBUG-PROF
 // CHECK-DSYMUTIL-DEBUG-PROF: "-cc1"
 // CHECK-DSYMUTIL-DEBUG-PROF: ld
 // CHECK-DSYMUTIL-DEBUG-PROF: dsymutil
+
+// RUN: %clang -target arm64-apple-darwin -### -o foo -fno-debug-info-for-profiling %s 2>&1 | FileCheck %s --check-prefix=CHECK-NO-DSYMUTIL-DEBUG-PROF
+// CHECK-NO-DSYMUTIL-DEBUG-PROF: "-cc1"
+// CHECK-NO-DSYMUTIL-DEBUG-PROF: ld
+// CHECK-NO-DSYMUTIL-DEBUG-PROF-NOT: dsymutil

--- a/clang/test/Driver/pseudo-probe.c
+++ b/clang/test/Driver/pseudo-probe.c
@@ -11,3 +11,15 @@
 // NOPROBE-NOT: -funique-internal-linkage-names
 // NONAME: -fpseudo-probe-for-profiling
 // NONAME-NOT: -funique-internal-linkage-names
+
+// On Darwin, -fpseudo-probe-for-profiling should trigger dsymutil
+// RUN: %clang -target x86_64-apple-darwin10 -### -o foo -fpseudo-probe-for-profiling %s 2>&1 | FileCheck %s --check-prefix=CHECK-DSYMUTIL-PSEUDO-PROBE
+// CHECK-DSYMUTIL-PSEUDO-PROBE: "-cc1"
+// CHECK-DSYMUTIL-PSEUDO-PROBE: ld
+// CHECK-DSYMUTIL-PSEUDO-PROBE: dsymutil
+
+// On Darwin, -fdebug-info-for-profiling should trigger dsymutil
+// RUN: %clang -target x86_64-apple-darwin10 -### -o foo -fdebug-info-for-profiling %s 2>&1 | FileCheck %s --check-prefix=CHECK-DSYMUTIL-DEBUG-PROF
+// CHECK-DSYMUTIL-DEBUG-PROF: "-cc1"
+// CHECK-DSYMUTIL-DEBUG-PROF: ld
+// CHECK-DSYMUTIL-DEBUG-PROF: dsymutil


### PR DESCRIPTION
Currently, `dsymutil` is not called when passing `-fpseudo-probe-for-profiling` or `-debug-info-for-profiling`. When either flags is present, we should externalize these content into the `.dSYM` bundle.