### PR TITLE
[CIR][NFC] Unify the 'null data member attr' getters

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenBuilder.h
+++ b/clang/lib/CIR/CodeGen/CIRGenBuilder.h
@@ -422,16 +422,6 @@ public:
     return getConstantInt(loc, getUInt64Ty(), c);
   }
 
-  /// Create constant nullptr for pointer-to-data-member type ty.
-  cir::ConstantOp getNullDataMemberPtr(cir::DataMemberType ty,
-                                       mlir::Location loc) {
-    return cir::ConstantOp::create(*this, loc, getNullDataMemberAttr(ty));
-  }
-
-  cir::ConstantOp getNullMethodPtr(cir::MethodType ty, mlir::Location loc) {
-    return cir::ConstantOp::create(*this, loc, getNullMethodAttr(ty));
-  }
-
   //===--------------------------------------------------------------------===//
   // UnaryOp creation helpers
   //===--------------------------------------------------------------------===//

--- a/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
@@ -2232,13 +2232,9 @@ mlir::Value ScalarExprEmitter::VisitCastExpr(CastExpr *ce) {
     assert(!cir::MissingFeatures::cxxABI());
 
     const MemberPointerType *mpt = ce->getType()->getAs<MemberPointerType>();
-    if (mpt->isMemberFunctionPointerType()) {
-      auto ty = mlir::cast<cir::MethodType>(cgf.convertType(destTy));
-      return builder.getNullMethodPtr(ty, cgf.getLoc(subExpr->getExprLoc()));
-    }
-
-    auto ty = mlir::cast<cir::DataMemberType>(cgf.convertType(destTy));
-    return builder.getNullDataMemberPtr(ty, cgf.getLoc(subExpr->getExprLoc()));
+    mlir::Location loc = cgf.getLoc(subExpr->getExprLoc());
+    return cgf.getBuilder().getConstant(
+        loc, cgf.cgm.emitNullMemberAttr(destTy, mpt));
   }
 
   case CK_ReinterpretMemberPointer: {

--- a/clang/lib/CIR/CodeGen/CIRGenModule.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.cpp
@@ -1714,6 +1714,17 @@ void CIRGenModule::emitExplicitCastExprType(const ExplicitCastExpr *e,
          "emitExplicitCastExprType");
 }
 
+mlir::TypedAttr CIRGenModule::emitNullMemberAttr(QualType destTy,
+                                                 const MemberPointerType *mpt) {
+  if (mpt->isMemberFunctionPointerType()) {
+    auto ty = mlir::cast<cir::MethodType>(convertType(destTy));
+    return builder.getNullMethodAttr(ty);
+  }
+
+  auto ty = mlir::cast<cir::DataMemberType>(convertType(destTy));
+  return builder.getNullDataMemberAttr(ty);
+}
+
 mlir::Value CIRGenModule::emitMemberPointerConstant(const UnaryOperator *e) {
   assert(!cir::MissingFeatures::cxxABI());
 

--- a/clang/lib/CIR/CodeGen/CIRGenModule.h
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.h
@@ -590,6 +590,9 @@ public:
   mlir::TypedAttr emitNullConstantForBase(const CXXRecordDecl *record);
 
   mlir::Value emitMemberPointerConstant(const UnaryOperator *e);
+  /// Returns a null attribute to represent either a null method or null data
+  /// member, depending on the type of mpt.
+  mlir::TypedAttr emitNullMemberAttr(QualType t, const MemberPointerType *mpt);
 
   llvm::StringRef getMangledName(clang::GlobalDecl gd);
   // This function is to support the OpenACC 'bind' clause, which names an


### PR DESCRIPTION
In preperation of actually lowering data members as fields to a record type, this patch does a minor refactor to make their single current use have a slightly simpler interface.  This will prevent us from having to copy/paste this later.

Also, this patch removes a pair of now-orphaned builders, instead preferring to use the ones that come from the parent builder type.