### PR TITLE
[dsymutil] Fall back to compatible triple in BinaryHolder

### DIFF
--- a/llvm/test/tools/dsymutil/X86/fat-object-compatible-triple.test
+++ b/llvm/test/tools/dsymutil/X86/fat-object-compatible-triple.test
@@ -1,0 +1,23 @@
+# Verify that dsymutil can match an object file by compatible triple when there
+# is no exact string match (e.g. the debug map triple has a version suffix that
+# the object file triple lacks).
+
+# RUN: dsymutil -f -oso-prepend-path=%p/../Inputs -y %s -o - | llvm-dwarfdump -debug-info - | FileCheck %s
+
+# RUN: dsymutil --linker parallel -f -oso-prepend-path=%p/../Inputs -y %s -o - | llvm-dwarfdump -debug-info - | FileCheck %s
+
+# The fat-test.o object reports its x86_64 slice as "x86_64-apple-darwin".
+# Using "x86_64-apple-darwin20" here exercises the compatible-triple fallback:
+# the strings differ, but the triples are compatible (same arch, vendor, OS kind).
+---
+triple:          'x86_64-apple-darwin20'
+objects:
+  - filename: fat-test.o
+    symbols:
+      - { sym: _x86_64_var, objAddr: 0x0, binAddr: 0x1000, size: 0x4 }
+...
+
+# CHECK: .debug_info contents:
+# CHECK: DW_TAG_variable
+# CHECK-NOT: {{DW_TAG|NULL}}
+# CHECK:  DW_AT_name{{.*}}"x86_64_var"

--- a/llvm/tools/dsymutil/BinaryHolder.cpp
+++ b/llvm/tools/dsymutil/BinaryHolder.cpp
@@ -162,7 +162,7 @@ BinaryHolder::ObjectEntry::getObject(const Triple &T) const {
       llvm::Triple ObjTriple = MachO->getArchTriple();
       if (ObjTriple.str() == T.str())
         return *MachO;
-      if (ObjTriple.isCompatibleWith(T) && !CompatibleMatch)
+      if (!CompatibleMatch && ObjTriple.isCompatibleWith(T))
         CompatibleMatch = MachO;
     } else {
       llvm::Triple ObjTriple = Obj->makeTriple();

--- a/llvm/tools/dsymutil/BinaryHolder.cpp
+++ b/llvm/tools/dsymutil/BinaryHolder.cpp
@@ -155,13 +155,25 @@ BinaryHolder::ObjectEntry::getObjects() const {
 }
 Expected<const object::ObjectFile &>
 BinaryHolder::ObjectEntry::getObject(const Triple &T) const {
+  // Prefer an exact match, but settle for a compatible match if there is one.
+  object::ObjectFile const *CompatibleMatch = nullptr;
   for (const auto &Obj : Objects) {
     if (const auto *MachO = dyn_cast<object::MachOObjectFile>(Obj.get())) {
-      if (MachO->getArchTriple().str() == T.str())
+      llvm::Triple ObjTriple = MachO->getArchTriple();
+      if (ObjTriple.str() == T.str())
         return *MachO;
-    } else if (Obj->getArch() == T.getArch())
-      return *Obj;
+      if (ObjTriple.isCompatibleWith(T) && !CompatibleMatch)
+        CompatibleMatch = MachO;
+    } else {
+      llvm::Triple ObjTriple = Obj->makeTriple();
+      if (ObjTriple.str() == T.str())
+        return *Obj;
+      if (!CompatibleMatch && ObjTriple.isCompatibleWith(T))
+        CompatibleMatch = Obj.get();
+    }
   }
+  if (CompatibleMatch)
+    return *CompatibleMatch;
   return errorCodeToError(object::object_error::arch_not_found);
 }
 


### PR DESCRIPTION
When dsymutil can't find an exact match in its BinaryHolder, fall back to a compatible triple instead of erroring out completely.

rdar://171676213