### PR TITLE
Fix stale pivot usage in computeSmithNormalForm

### DIFF
--- a/mlir/lib/Analysis/Presburger/Matrix.cpp
+++ b/mlir/lib/Analysis/Presburger/Matrix.cpp
@@ -684,7 +684,7 @@ IntMatrix::computeSmithNormalForm() const {
         }
       }
 
-      if (auto row = findNonMultipleRow(d, i + 1, pivot)) {
+      if (auto row = findNonMultipleRow(d, i + 1, d(i, i))) {
         // Add the row (r) to row i. This brings d(r, c) into the i-th row,
         // creating a new value at d(i, c) that will be used to reduce the
         // pivot size.

--- a/mlir/unittests/Analysis/Presburger/MatrixTest.cpp
+++ b/mlir/unittests/Analysis/Presburger/MatrixTest.cpp
@@ -307,6 +307,16 @@ TEST(MatrixTest, computeSmithNormalForm) {
     IntMatrix mat = makeIntMatrix(1, 1, {{9}});
     checkSmithNormalForm(mat);
   }
+
+  {
+    // Regression test for stale pivot bug.
+    // In the first iteration, pvt = 2. Clearing rows/cols will not change
+    // d(0,0). findNonMultipleRow will then check if d(1,1) is a multiple of 2.
+    // If it uses the stale pivot (2), it will find d(1,1) = 1 is not a multiple
+    // and add row 1 to row 0.
+    IntMatrix mat = makeIntMatrix(2, 2, {{2, 2}, {0, 1}});
+    checkSmithNormalForm(mat);
+  }
 }
 
 TEST(MatrixTest, inverse) {


### PR DESCRIPTION
The `findNonMultipleRow` function was incorrectly using a potentially stale `pivot` variable instead of the current value at `d(i, i)`. This could lead to incorrect reductions. The fix is to use `d(i, i)` directly.

A regression test case is added to catch this issue.