### PR TITLE
[lldb] Upstream arm64e support in ValueObject

### DIFF
--- a/lldb/include/lldb/Symbol/CompilerType.h
+++ b/lldb/include/lldb/Symbol/CompilerType.h
@@ -202,6 +202,8 @@ public:
 
   bool IsVoidType() const;
 
+  bool HasPointerAuthQualifier() const;
+
   /// This is used when you don't care about the signedness of the integer.
   bool IsInteger() const;
 

--- a/lldb/include/lldb/Symbol/TypeSystem.h
+++ b/lldb/include/lldb/Symbol/TypeSystem.h
@@ -203,6 +203,10 @@ public:
 
   virtual bool IsVoidType(lldb::opaque_compiler_type_t type) = 0;
 
+  virtual bool HasPointerAuthQualifier(lldb::opaque_compiler_type_t type) {
+    return false;
+  }
+
   virtual bool CanPassInRegisters(const CompilerType &type) = 0;
 
   // TypeSystems can support more than one language

--- a/lldb/include/lldb/ValueObject/ValueObject.h
+++ b/lldb/include/lldb/ValueObject/ValueObject.h
@@ -580,6 +580,9 @@ public:
 
   virtual AddrAndType GetAddressOf(bool scalar_is_load_address = true);
 
+  /// Remove ptrauth bits from address if the type has a ptrauth qualifier.
+  std::optional<lldb::addr_t> GetStrippedPointerValue(lldb::addr_t address);
+
   AddrAndType GetPointerValue();
 
   lldb::ValueObjectSP GetSyntheticChild(ConstString key) const;

--- a/lldb/source/DataFormatters/ValueObjectPrinter.cpp
+++ b/lldb/source/DataFormatters/ValueObjectPrinter.cpp
@@ -17,6 +17,7 @@
 #include "lldb/ValueObject/ValueObject.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/MathExtras.h"
+#include <cinttypes>
 #include <cstdint>
 #include <memory>
 #include <optional>
@@ -470,6 +471,9 @@ bool ValueObjectPrinter::PrintValueAndSummaryIfNeeded(bool &value_printed,
         if (m_options.m_hide_pointer_value &&
             IsPointerValue(valobj.GetCompilerType())) {
         } else {
+          if (auto stripped = valobj.GetStrippedPointerValue(
+                  valobj.GetPointerValue().address))
+            m_stream->Printf(" (actual=0x%" PRIx64 ")", *stripped);
           if (ShouldShowName())
             m_stream->PutChar(' ');
           m_stream->PutCString(m_value);

--- a/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
+++ b/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
@@ -3634,6 +3634,13 @@ bool TypeSystemClang::IsVoidType(lldb::opaque_compiler_type_t type) {
   return GetCanonicalQualType(type)->isVoidType();
 }
 
+bool TypeSystemClang::HasPointerAuthQualifier(
+    lldb::opaque_compiler_type_t type) {
+  if (!type)
+    return false;
+  return GetCanonicalQualType(type).getPointerAuth().isPresent();
+}
+
 bool TypeSystemClang::CanPassInRegisters(const CompilerType &type) {
   if (auto *record_decl =
       TypeSystemClang::GetAsRecordDecl(type)) {

--- a/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.h
+++ b/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.h
@@ -717,6 +717,8 @@ public:
 
   bool IsVoidType(lldb::opaque_compiler_type_t type) override;
 
+  bool HasPointerAuthQualifier(lldb::opaque_compiler_type_t type) override;
+
   bool CanPassInRegisters(const CompilerType &type) override;
 
   bool SupportsLanguage(lldb::LanguageType language) override;

--- a/lldb/source/Symbol/CompilerType.cpp
+++ b/lldb/source/Symbol/CompilerType.cpp
@@ -311,6 +311,13 @@ bool CompilerType::IsVoidType() const {
   return false;
 }
 
+bool CompilerType::HasPointerAuthQualifier() const {
+  if (IsValid())
+    if (auto type_system_sp = GetTypeSystem())
+      return type_system_sp->HasPointerAuthQualifier(m_type);
+  return false;
+}
+
 bool CompilerType::IsPointerToScalarType() const {
   if (!IsValid())
     return false;

--- a/lldb/source/ValueObject/ValueObject.cpp
+++ b/lldb/source/ValueObject/ValueObject.cpp
@@ -25,6 +25,7 @@
 #include "lldb/Symbol/SymbolContext.h"
 #include "lldb/Symbol/Type.h"
 #include "lldb/Symbol/Variable.h"
+#include "lldb/Target/ABI.h"
 #include "lldb/Target/ExecutionContext.h"
 #include "lldb/Target/Language.h"
 #include "lldb/Target/LanguageRuntime.h"
@@ -1624,6 +1625,16 @@ ValueObject::GetAddressOf(bool scalar_is_load_address) {
     return {LLDB_INVALID_ADDRESS, m_value.GetValueAddressType()};
   }
   llvm_unreachable("Unhandled value type!");
+}
+
+std::optional<addr_t> ValueObject::GetStrippedPointerValue(addr_t address) {
+  if (GetCompilerType().HasPointerAuthQualifier()) {
+    ExecutionContext exe_ctx(GetExecutionContextRef());
+    if (Process *process = exe_ctx.GetProcessPtr())
+      if (ABISP abi_sp = process->GetABI())
+        return abi_sp->FixCodeAddress(address);
+  }
+  return std::nullopt;
 }
 
 ValueObject::AddrAndType ValueObject::GetPointerValue() {

--- a/lldb/test/API/lang/c/ptrauth/Makefile
+++ b/lldb/test/API/lang/c/ptrauth/Makefile
@@ -1,0 +1,6 @@
+LEVEL = ../../../make
+override ARCH := arm64e
+CFLAGS_EXTRAS = -fptrauth-calls -fptrauth-intrinsics
+C_SOURCES := main.c
+
+include Makefile.rules

--- a/lldb/test/API/lang/c/ptrauth/TestPtrAuth.py
+++ b/lldb/test/API/lang/c/ptrauth/TestPtrAuth.py
@@ -1,0 +1,4 @@
+import lldbsuite.test.lldbinline as lldbinline
+from lldbsuite.test.decorators import *
+
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[skipUnlessArm64eSupported])

--- a/lldb/test/API/lang/c/ptrauth/main.c
+++ b/lldb/test/API/lang/c/ptrauth/main.c
@@ -1,0 +1,69 @@
+#if __aarch64__
+#define VALID_DATA_KEY 2
+#else
+#error Provide these constants if you port this test
+#endif
+
+int *__ptrauth(VALID_DATA_KEY) valid0;
+
+typedef int *intp;
+
+int nonConstantGlobal = 5;
+
+int *__ptrauth(VALID_DATA_KEY) valid0;
+int *__ptrauth(VALID_DATA_KEY) * valid1;
+__ptrauth(VALID_DATA_KEY) intp valid2;
+__ptrauth(VALID_DATA_KEY) intp *valid3;
+intp __ptrauth(VALID_DATA_KEY) valid4;
+intp __ptrauth(VALID_DATA_KEY) * valid5;
+int *__ptrauth(VALID_DATA_KEY, 0) valid6;
+int *__ptrauth(VALID_DATA_KEY, 1) valid7;
+int *__ptrauth(VALID_DATA_KEY, (_Bool)1) valid8;
+int *__ptrauth(VALID_DATA_KEY, 1, 0) valid9;
+int *__ptrauth(VALID_DATA_KEY, 1, 65535) valid10;
+
+void test_code(intp p) {
+  __ptrauth(VALID_DATA_KEY) intp pSpecial = p;
+  //% self.expect("fr var pSpecial",
+  //%     substrs=['(__ptrauth(2,0,0) intp)', 'pSpecial =', '(actual=0x'])
+  //% self.expect("fr var *pSpecial", substrs=['5'])
+  //% self.expect("p pSpecial",
+  //%     substrs=['(__ptrauth(2,0,0) intp)', '(actual=0x'])
+  pSpecial = p;
+  intp pNormal = pSpecial;
+  pNormal = pSpecial;
+
+  intp __ptrauth(VALID_DATA_KEY) *ppSpecial0 = &pSpecial;
+  intp *ppNormal1 = &pNormal;
+}
+
+void test_array(void) {
+  intp __ptrauth(VALID_DATA_KEY) pSpecialArray[10];
+  intp __ptrauth(VALID_DATA_KEY) *ppSpecial0 = pSpecialArray;
+  intp __ptrauth(VALID_DATA_KEY) *ppSpecial1 = &pSpecialArray[0];
+}
+
+int printf(const char *, ...);
+
+int main(int argc, char **argv) {
+  valid0 = &nonConstantGlobal;
+  valid1 = &valid0;
+  valid2 = &nonConstantGlobal;
+  valid3 = &valid2;
+  valid4 = &nonConstantGlobal;
+  //% self.expect("target var valid0",
+  //%     substrs=['(int *__ptrauth(2,0,0))', 'valid0 =', '(actual=0x'])
+  //% self.expect("target var valid1",
+  //%     substrs=['(int *__ptrauth(2,0,0) *)', 'valid1 ='])
+  //% self.expect("target var valid2",
+  //%     substrs=['(__ptrauth(2,0,0) intp)', 'valid2 =', '(actual=0x'])
+  //% self.expect("target var valid3",
+  //%     substrs=['(__ptrauth(2,0,0) intp *)', 'valid3 ='])
+  //% self.expect("target var valid4",
+  //%     substrs=['(__ptrauth(2,0,0) intp)', 'valid4 =', '(actual=0x'])
+  int (*f)(int, char **) = main;
+  test_code(valid4);
+  test_code(valid4);
+  test_array();
+  return 0;
+}


### PR DESCRIPTION
In #186001, I said the last large chunk of downstream PtrAuth code in LLDB was the expression evaluator support. However, that wasn't accurate, as we also have changes to thread this through ValueObject.