### PR TITLE
[lldb] Add additional logging to wait_for_file_on_target

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/lldbutil.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbutil.py
@@ -1687,7 +1687,14 @@ def read_file_from_process_wd(test, name):
 
 def wait_for_file_on_target(testcase, file_path, max_attempts=6):
     for i in range(max_attempts):
-        err, retcode, msg = testcase.run_platform_command("ls %s" % file_path)
+        command = f"ls {file_path}"
+        err, retcode, msg = testcase.run_platform_command(command)
+        if testcase.TraceOn():
+            testcase.trace(f"Ran command: {command}")
+            testcase.trace(f"Retcode: {retcode}")
+            testcase.trace(f"Output: {msg}")
+            testcase.trace(f"Error: {err.description}")
+
         if err.Success() and retcode == 0:
             break
         if i < max_attempts:


### PR DESCRIPTION
Occasionally wait_for_file_on_target will time out on the Green Dragon bots and we're not sure why. I'm adding this logging in an attempt to get more clues as to what's happening when it fails.