### PR TITLE
Removed Hardcoded SM Number from Mlir Test

### DIFF
--- a/mlir/test/Integration/GPU/CUDA/module-to-binary-compiler-log.mlir
+++ b/mlir/test/Integration/GPU/CUDA/module-to-binary-compiler-log.mlir
@@ -4,7 +4,7 @@
 module attributes {gpu.container_module} {
   // CHECK-LABEL: gpu.binary @kernel_module
   // CHECK: properties = {{{.*}}ISACompilerLog = {{.*}}
-  gpu.module @kernel_module [#nvvm.target<chip = "sm_70", flags = {"collect-compiler-diagnostics"}>] {
+  gpu.module @kernel_module [#nvvm.target<flags = {"collect-compiler-diagnostics"}>] {
     llvm.func @kernel(%arg0: i32, %arg1: !llvm.ptr,
         %arg2: !llvm.ptr, %arg3: i64, %arg4: i64,
         %arg5: i64) attributes {gpu.kernel} {


### PR DESCRIPTION
This MR removes a hard-coded compute number in an MLIR test. This will allow the test to not need to be updated in the future. The default value will come from `NVVMOps.td`.