### PR TITLE
[NFC] Remove unused InlineFunctionInfo::InlinedCalls

### DIFF
--- a/llvm/include/llvm/Transforms/Utils/Cloning.h
+++ b/llvm/include/llvm/Transforms/Utils/Cloning.h
@@ -268,15 +268,9 @@ public:
   /// the caller.
   SmallVector<AllocaInst *, 4> StaticAllocas;
 
-  /// InlineFunction fills this in with callsites that were inlined from the
-  /// callee. This is only filled in if CG is non-null.
-  SmallVector<WeakTrackingVH, 8> InlinedCalls;
-
   /// All of the new call sites inlined into the caller.
   ///
-  /// 'InlineFunction' fills this in by scanning the inlined instructions, and
-  /// only if CG is null. If CG is non-null, instead the value handle
-  /// `InlinedCalls` above is used.
+  /// 'InlineFunction' fills this in by scanning the inlined instructions.
   SmallVector<CallBase *, 8> InlinedCallSites;
 
   Value *ConvergenceControlToken = nullptr;
@@ -288,7 +282,6 @@ public:
 
   void reset() {
     StaticAllocas.clear();
-    InlinedCalls.clear();
     InlinedCallSites.clear();
     ConvergenceControlToken = nullptr;
     CallSiteEHPad = nullptr;


### PR DESCRIPTION
Looks to be a relic of the legacy pass manager.