### PR TITLE
[OFFLOAD] Improve handling of synchronization errors in L0 plugin and reenable tests

### DIFF
--- a/offload/plugins-nextgen/level_zero/include/L0Device.h
+++ b/offload/plugins-nextgen/level_zero/include/L0Device.h
@@ -650,20 +650,5 @@ public:
                                          int32_t NumPrefers,
                                          interop_spec_t *Prefers) override;
 };
-
-struct L0DeviceQueueGuard {
-  L0DeviceQueueGuard(AsyncQueueTy *Queue, L0DeviceTy *Device)
-      : queue(Queue), device(Device) {}
-  ~L0DeviceQueueGuard() {
-    for (auto &Event : queue->WaitEvents)
-      auto Err = device->releaseEvent(Event);
-    queue->WaitEvents.clear();
-  }
-
-private:
-  AsyncQueueTy *queue;
-  L0DeviceTy *device;
-};
-
 } // namespace llvm::omp::target::plugin
 #endif // OPENMP_LIBOMPTARGET_PLUGINS_NEXTGEN_LEVEL_ZERO_L0DEVICE_H

--- a/offload/plugins-nextgen/level_zero/include/L0Device.h
+++ b/offload/plugins-nextgen/level_zero/include/L0Device.h
@@ -650,5 +650,6 @@ public:
                                          int32_t NumPrefers,
                                          interop_spec_t *Prefers) override;
 };
+
 } // namespace llvm::omp::target::plugin
 #endif // OPENMP_LIBOMPTARGET_PLUGINS_NEXTGEN_LEVEL_ZERO_L0DEVICE_H

--- a/offload/plugins-nextgen/level_zero/include/L0Device.h
+++ b/offload/plugins-nextgen/level_zero/include/L0Device.h
@@ -651,5 +651,17 @@ public:
                                          interop_spec_t *Prefers) override;
 };
 
+struct L0DeviceQueueGuard{
+  L0DeviceQueueGuard(AsyncQueueTy *Queue, L0DeviceTy *Device) : queue(Queue), device(Device) {}
+  ~L0DeviceQueueGuard(){
+    for (auto &Event : queue->WaitEvents)
+      auto Err = device->releaseEvent(Event);
+    queue->WaitEvents.clear();
+  }
+  private:
+    AsyncQueueTy *queue;
+    L0DeviceTy *device;
+};
+
 } // namespace llvm::omp::target::plugin
 #endif // OPENMP_LIBOMPTARGET_PLUGINS_NEXTGEN_LEVEL_ZERO_L0DEVICE_H

--- a/offload/plugins-nextgen/level_zero/include/L0Device.h
+++ b/offload/plugins-nextgen/level_zero/include/L0Device.h
@@ -659,6 +659,7 @@ struct L0DeviceQueueGuard {
       auto Err = device->releaseEvent(Event);
     queue->WaitEvents.clear();
   }
+
 private:
   AsyncQueueTy *queue;
   L0DeviceTy *device;

--- a/offload/plugins-nextgen/level_zero/include/L0Device.h
+++ b/offload/plugins-nextgen/level_zero/include/L0Device.h
@@ -651,16 +651,17 @@ public:
                                          interop_spec_t *Prefers) override;
 };
 
-struct L0DeviceQueueGuard{
-  L0DeviceQueueGuard(AsyncQueueTy *Queue, L0DeviceTy *Device) : queue(Queue), device(Device) {}
-  ~L0DeviceQueueGuard(){
+struct L0DeviceQueueGuard {
+  L0DeviceQueueGuard(AsyncQueueTy *Queue, L0DeviceTy *Device)
+      : queue(Queue), device(Device) {}
+  ~L0DeviceQueueGuard() {
     for (auto &Event : queue->WaitEvents)
       auto Err = device->releaseEvent(Event);
     queue->WaitEvents.clear();
   }
-  private:
-    AsyncQueueTy *queue;
-    L0DeviceTy *device;
+private:
+  AsyncQueueTy *queue;
+  L0DeviceTy *device;
 };
 
 } // namespace llvm::omp::target::plugin

--- a/offload/plugins-nextgen/level_zero/include/L0Trace.h
+++ b/offload/plugins-nextgen/level_zero/include/L0Trace.h
@@ -60,6 +60,17 @@ using namespace llvm::offload::debug;
     Plugin::error(ErrorCode::UNKNOWN, "%s failed with error %d, %s",           \
     #Fn, rc, getZeErrorName(rc)), Fn, __VA_ARGS__)
 
+
+#define CALL_ZE_HANDLE_ERROR(HandleErrFn, Fn, ...)                             \
+  do {                                                                         \
+    ze_result_t rc;                                                            \
+    CALL_ZE(rc, Fn, __VA_ARGS__);                                              \
+    if (rc != ZE_RESULT_SUCCESS) {                                             \
+      HandleErrFn(Plugin::error(ErrorCode::UNKNOWN, "%s failed with error %d," \
+                  " %s",   #Fn, rc, getZeErrorName(rc)));                      \
+    }                                                                          \
+  } while (0)
+
 #define CALL_ZE_EXT_SILENT_RET(Device, Ret, Name, ...)                         \
   do {                                                                         \
     ze_result_t rc;                                                            \

--- a/offload/plugins-nextgen/level_zero/src/L0Device.cpp
+++ b/offload/plugins-nextgen/level_zero/src/L0Device.cpp
@@ -298,7 +298,7 @@ Error L0DeviceTy::synchronizeImpl(__tgt_async_info &AsyncInfo,
                            L0DefaultTimeout);
       // Synchronize on kernel event to support printf().
       auto KE = AsyncQueue->KernelEvent;
-      if (KE && KE != WaitEvents.back()) {
+      if (KE && KE != WaitEvents.back() && !SyncErrors) {
         CALL_ZE_HANDLE_ERROR(addError, zeEventHostSynchronize, KE,
                              L0DefaultTimeout);
       }

--- a/offload/plugins-nextgen/level_zero/src/L0Device.cpp
+++ b/offload/plugins-nextgen/level_zero/src/L0Device.cpp
@@ -324,10 +324,10 @@ Error L0DeviceTy::synchronizeImpl(__tgt_async_info &AsyncInfo,
         if (auto Err = releaseEvent(*Itr))
           addError(std::move(Err));
       }
-      // In either case, all the events are now reset and released
-      // back into the pool. We need to clear them from the queue.
-      AsyncQueue->WaitEvents.clear();
     }
+    // In either case, all the events are now reset and released
+    // back into the pool. We need to clear them from the queue.
+    AsyncQueue->WaitEvents.clear();
   }
 
   // Commit delayed USM2M copies.

--- a/offload/plugins-nextgen/level_zero/src/L0Device.cpp
+++ b/offload/plugins-nextgen/level_zero/src/L0Device.cpp
@@ -285,40 +285,44 @@ Error L0DeviceTy::synchronizeImpl(__tgt_async_info &AsyncInfo,
   auto &Plugin = getPlugin();
 
   AsyncQueueTy *AsyncQueue = reinterpret_cast<AsyncQueueTy *>(AsyncInfo.Queue);
-  {
-    L0DeviceQueueGuard Guard(AsyncQueue, this);
-    if (!AsyncQueue->WaitEvents.empty()) {
-      const auto &WaitEvents = AsyncQueue->WaitEvents;
-      if (Plugin.getOptions().CommandMode == CommandModeTy::AsyncOrdered) {
-        // Only need to wait for the last event.
-        CALL_ZE_RET_ERROR(zeEventHostSynchronize, WaitEvents.back(),
-                          L0DefaultTimeout);
-        // Synchronize on kernel event to support printf().
-        auto KE = AsyncQueue->KernelEvent;
-        if (KE && KE != WaitEvents.back()) {
-          CALL_ZE_RET_ERROR(zeEventHostSynchronize, KE, L0DefaultTimeout);
+
+  Error SyncErrors = Error::success();
+  auto addError = [&](Error Err) {
+    SyncErrors = joinErrors(std::move(SyncErrors), std::move(Err));
+  };
+  if (!AsyncQueue->WaitEvents.empty()) {
+    const auto &WaitEvents = AsyncQueue->WaitEvents;
+    if (Plugin.getOptions().CommandMode == CommandModeTy::AsyncOrdered) {
+      // Only need to wait for the last event.
+      CALL_ZE_HANDLE_ERROR(addError, zeEventHostSynchronize, WaitEvents.back(),
+                           L0DefaultTimeout);
+      // Synchronize on kernel event to support printf().
+      auto KE = AsyncQueue->KernelEvent;
+      if (KE && KE != WaitEvents.back()) {
+        CALL_ZE_HANDLE_ERROR(addError, zeEventHostSynchronize, KE,
+                             L0DefaultTimeout);
+      }
+      for (auto &Event : WaitEvents) {
+        if (auto Err = releaseEvent(Event))
+          addError(std::move(Err));
+      }
+    } else {
+      // Async case.
+      // Wait for all events. We should wait and reset events in reverse order
+      // to avoid premature event reset. If we have a kernel event in the
+      // queue, it is the last event to wait for since all wait events of the
+      // kernel are signaled before the kernel is invoked. We always invoke
+      // synchronization on kernel event to support printf().
+      bool WaitDone = false;
+      for (auto Itr = WaitEvents.rbegin(); Itr != WaitEvents.rend(); Itr++) {
+        if (!WaitDone) {
+          CALL_ZE_HANDLE_ERROR(addError, zeEventHostSynchronize, *Itr,
+                               L0DefaultTimeout);
+          if (*Itr == AsyncQueue->KernelEvent)
+            WaitDone = true;
         }
-        for (auto &Event : WaitEvents) {
-          if (auto Err = releaseEvent(Event))
-            return Err;
-        }
-      } else {
-        // Async case.
-        // Wait for all events. We should wait and reset events in reverse order
-        // to avoid premature event reset. If we have a kernel event in the
-        // queue, it is the last event to wait for since all wait events of the
-        // kernel are signaled before the kernel is invoked. We always invoke
-        // synchronization on kernel event to support printf().
-        bool WaitDone = false;
-        for (auto Itr = WaitEvents.rbegin(); Itr != WaitEvents.rend(); Itr++) {
-          if (!WaitDone) {
-            CALL_ZE_RET_ERROR(zeEventHostSynchronize, *Itr, L0DefaultTimeout);
-            if (*Itr == AsyncQueue->KernelEvent)
-              WaitDone = true;
-          }
-          if (auto Err = releaseEvent(*Itr))
-            return Err;
-        }
+        if (auto Err = releaseEvent(*Itr))
+          addError(std::move(Err));
       }
       // In either case, all the events are now reset and released
       // back into the pool. We need to clear them from the queue.
@@ -342,7 +346,7 @@ Error L0DeviceTy::synchronizeImpl(__tgt_async_info &AsyncInfo,
     AsyncInfo.Queue = nullptr;
   }
 
-  return Plugin::success();
+  return SyncErrors;
 }
 
 Expected<bool>

--- a/offload/plugins-nextgen/level_zero/src/L0Device.cpp
+++ b/offload/plugins-nextgen/level_zero/src/L0Device.cpp
@@ -285,43 +285,45 @@ Error L0DeviceTy::synchronizeImpl(__tgt_async_info &AsyncInfo,
   auto &Plugin = getPlugin();
 
   AsyncQueueTy *AsyncQueue = reinterpret_cast<AsyncQueueTy *>(AsyncInfo.Queue);
-
-  if (!AsyncQueue->WaitEvents.empty()) {
-    const auto &WaitEvents = AsyncQueue->WaitEvents;
-    if (Plugin.getOptions().CommandMode == CommandModeTy::AsyncOrdered) {
-      // Only need to wait for the last event.
-      CALL_ZE_RET_ERROR(zeEventHostSynchronize, WaitEvents.back(),
-                        L0DefaultTimeout);
-      // Synchronize on kernel event to support printf().
-      auto KE = AsyncQueue->KernelEvent;
-      if (KE && KE != WaitEvents.back()) {
-        CALL_ZE_RET_ERROR(zeEventHostSynchronize, KE, L0DefaultTimeout);
-      }
-      for (auto &Event : WaitEvents) {
-        if (auto Err = releaseEvent(Event))
-          return Err;
-      }
-    } else {
-      // Async case.
-      // Wait for all events. We should wait and reset events in reverse order
-      // to avoid premature event reset. If we have a kernel event in the
-      // queue, it is the last event to wait for since all wait events of the
-      // kernel are signaled before the kernel is invoked. We always invoke
-      // synchronization on kernel event to support printf().
-      bool WaitDone = false;
-      for (auto Itr = WaitEvents.rbegin(); Itr != WaitEvents.rend(); Itr++) {
-        if (!WaitDone) {
-          CALL_ZE_RET_ERROR(zeEventHostSynchronize, *Itr, L0DefaultTimeout);
-          if (*Itr == AsyncQueue->KernelEvent)
-            WaitDone = true;
+  {
+    L0DeviceQueueGuard Guard(AsyncQueue, this);
+    if (!AsyncQueue->WaitEvents.empty()) {
+      const auto &WaitEvents = AsyncQueue->WaitEvents;
+      if (Plugin.getOptions().CommandMode == CommandModeTy::AsyncOrdered) {
+        // Only need to wait for the last event.
+        CALL_ZE_RET_ERROR(zeEventHostSynchronize, WaitEvents.back(),
+                          L0DefaultTimeout);
+        // Synchronize on kernel event to support printf().
+        auto KE = AsyncQueue->KernelEvent;
+        if (KE && KE != WaitEvents.back()) {
+          CALL_ZE_RET_ERROR(zeEventHostSynchronize, KE, L0DefaultTimeout);
         }
-        if (auto Err = releaseEvent(*Itr))
-          return Err;
+        for (auto &Event : WaitEvents) {
+          if (auto Err = releaseEvent(Event))
+            return Err;
+        }
+      } else {
+        // Async case.
+        // Wait for all events. We should wait and reset events in reverse order
+        // to avoid premature event reset. If we have a kernel event in the
+        // queue, it is the last event to wait for since all wait events of the
+        // kernel are signaled before the kernel is invoked. We always invoke
+        // synchronization on kernel event to support printf().
+        bool WaitDone = false;
+        for (auto Itr = WaitEvents.rbegin(); Itr != WaitEvents.rend(); Itr++) {
+          if (!WaitDone) {
+            CALL_ZE_RET_ERROR(zeEventHostSynchronize, *Itr, L0DefaultTimeout);
+            if (*Itr == AsyncQueue->KernelEvent)
+              WaitDone = true;
+          }
+          if (auto Err = releaseEvent(*Itr))
+            return Err;
+        }
       }
+      // In either case, all the events are now reset and released
+      // back into the pool. We need to clear them from the queue.
+      AsyncQueue->WaitEvents.clear();
     }
-    // In either case, all the events are now reset and released
-    // back into the pool. We need to clear them from the queue.
-    AsyncQueue->WaitEvents.clear();
   }
 
   // Commit delayed USM2M copies.

--- a/offload/plugins-nextgen/level_zero/src/L0Memory.cpp
+++ b/offload/plugins-nextgen/level_zero/src/L0Memory.cpp
@@ -725,10 +725,8 @@ Expected<ze_event_handle_t> EventPoolTy::getEvent() {
 /// Return an event to the pool.
 Error EventPoolTy::releaseEvent(ze_event_handle_t Event, L0DeviceTy &Device) {
   std::lock_guard<std::mutex> Lock(*Mtx);
-  if (std::find(Events.begin(), Events.end(), Event) == Events.end()) {
-    CALL_ZE_RET_ERROR(zeEventHostReset, Event);
-    Events.push_back(Event);
-  }
+  CALL_ZE_RET_ERROR(zeEventHostReset, Event);
+  Events.push_back(Event);
   return Plugin::success();
 }
 

--- a/offload/plugins-nextgen/level_zero/src/L0Memory.cpp
+++ b/offload/plugins-nextgen/level_zero/src/L0Memory.cpp
@@ -725,8 +725,10 @@ Expected<ze_event_handle_t> EventPoolTy::getEvent() {
 /// Return an event to the pool.
 Error EventPoolTy::releaseEvent(ze_event_handle_t Event, L0DeviceTy &Device) {
   std::lock_guard<std::mutex> Lock(*Mtx);
-  CALL_ZE_RET_ERROR(zeEventHostReset, Event);
-  Events.push_back(Event);
+  if (std::find(Events.begin(), Events.end(), Event) == Events.end()) {
+    CALL_ZE_RET_ERROR(zeEventHostReset, Event);
+    Events.push_back(Event);
+  }
   return Plugin::success();
 }
 

--- a/offload/test/api/assert.c
+++ b/offload/test/api/assert.c
@@ -1,7 +1,6 @@
 // RUN: %libomptarget-compile-run-and-check-generic
 // RUN: %libomptarget-compileopt-run-and-check-generic
 
-
 #include <assert.h>
 #include <stdio.h>
 

--- a/offload/test/api/assert.c
+++ b/offload/test/api/assert.c
@@ -1,7 +1,6 @@
 // RUN: %libomptarget-compile-run-and-check-generic
 // RUN: %libomptarget-compileopt-run-and-check-generic
-// https://github.com/llvm/llvm-project/issues/182119
-// UNSUPPORTED: intelgpu
+
 
 #include <assert.h>
 #include <stdio.h>

--- a/offload/test/api/omp_device_managed_memory_alloc.c
+++ b/offload/test/api/omp_device_managed_memory_alloc.c
@@ -1,7 +1,6 @@
 // RUN: %libomptarget-compile-run-and-check-generic
 // RUN: %libomptarget-compileopt-run-and-check-generic
-// https://github.com/llvm/llvm-project/issues/182119
-// UNSUPPORTED: intelgpu
+// XFAIL: intelgpu
 
 #include <omp.h>
 #include <stdio.h>

--- a/offload/test/api/omp_host_call.c
+++ b/offload/test/api/omp_host_call.c
@@ -1,6 +1,5 @@
 // RUN: %libomptarget-compile-run-and-check-generic
-// https://github.com/llvm/llvm-project/issues/182119
-// UNSUPPORTED: intelgpu
+// XFAIL: intelgpu
 
 #include <assert.h>
 #include <omp.h>

--- a/offload/test/api/omp_indirect_func_array.c
+++ b/offload/test/api/omp_indirect_func_array.c
@@ -1,5 +1,5 @@
 // RUN: %libomptarget-compile-run-and-check-generic
-// UNSUPPORTED: intelgpu
+// XFAIL: intelgpu
 // REQUIRES: gpu
 
 #include <assert.h>

--- a/offload/test/api/omp_indirect_func_basic.c
+++ b/offload/test/api/omp_indirect_func_basic.c
@@ -1,5 +1,5 @@
 // RUN: %libomptarget-compile-run-and-check-generic
-// UNSUPPORTED: intelgpu
+// XFAIL: intelgpu
 // REQUIRES: gpu
 
 #include <assert.h>

--- a/offload/test/api/omp_indirect_func_struct.c
+++ b/offload/test/api/omp_indirect_func_struct.c
@@ -1,5 +1,5 @@
 // RUN: %libomptarget-compile-run-and-check-generic
-// UNSUPPORTED: intelgpu
+// XFAIL: intelgpu
 // REQUIRES: gpu
 
 #include <assert.h>

--- a/offload/test/api/omp_virtual_func.cpp
+++ b/offload/test/api/omp_virtual_func.cpp
@@ -1,5 +1,5 @@
 // RUN: %libomptarget-compilexx-run-and-check-generic
-// UNSUPPORTED: intelgpu
+// XFAIL: intelgpu
 // REQUIRES: gpu
 
 #include <assert.h>

--- a/offload/test/api/omp_virtual_func_multiple_inheritance_01.cpp
+++ b/offload/test/api/omp_virtual_func_multiple_inheritance_01.cpp
@@ -1,5 +1,5 @@
 // RUN: %libomptarget-compilexx-run-and-check-generic
-// UNSUPPORTED: intelgpu
+// XFAIL: intelgpu
 // REQUIRES: gpu
 
 #include <assert.h>

--- a/offload/test/api/omp_virtual_func_multiple_inheritance_02.cpp
+++ b/offload/test/api/omp_virtual_func_multiple_inheritance_02.cpp
@@ -1,5 +1,5 @@
 // RUN: %libomptarget-compilexx-run-and-check-generic
-// UNSUPPORTED: intelgpu
+// XFAIL: intelgpu
 // REQUIRES: gpu
 
 #include <assert.h>

--- a/offload/test/api/omp_virtual_func_reference.cpp
+++ b/offload/test/api/omp_virtual_func_reference.cpp
@@ -1,5 +1,5 @@
 // RUN: %libomptarget-compilexx-run-and-check-generic
-// UNSUPPORTED: intelgpu
+// XFAIL: intelgpu
 // REQUIRES: gpu
 
 #include <assert.h>

--- a/offload/test/libc/malloc_parallel.c
+++ b/offload/test/libc/malloc_parallel.c
@@ -1,7 +1,6 @@
 // RUN: %libomptarget-compile-run-and-check-generic
 // RUN: %libomptarget-compileopt-run-and-check-generic
-// https://github.com/llvm/llvm-project/issues/182119
-// UNSUPPORTED: intelgpu
+// XFAIL: intelgpu
 
 #include <omp.h>
 #include <stdio.h>

--- a/offload/test/mapping/lambda_by_value.cpp
+++ b/offload/test/mapping/lambda_by_value.cpp
@@ -1,7 +1,6 @@
 // RUN: %libomptarget-compileopt-generic -fno-exceptions
 // RUN: %libomptarget-run-generic 2>&1 | %fcheck-generic
-// https://github.com/llvm/llvm-project/issues/182119
-// UNSUPPORTED: intelgpu
+// XFAIL: intelgpu
 
 #include <stdint.h>
 #include <stdio.h>

--- a/offload/test/mapping/reduction_implicit_map.cpp
+++ b/offload/test/mapping/reduction_implicit_map.cpp
@@ -1,6 +1,5 @@
 // RUN: %libomptarget-compilexx-run-and-check-generic
-// https://github.com/llvm/llvm-project/issues/182119
-// UNSUPPORTED: intelgpu
+// XFAIL: intelgpu
 
 #include <stdio.h>
 

--- a/offload/test/mapping/use_device_addr/target_use_device_addr.c
+++ b/offload/test/mapping/use_device_addr/target_use_device_addr.c
@@ -1,8 +1,7 @@
 // RUN: %libomptarget-compile-generic -fopenmp-version=51
 // RUN: %libomptarget-run-generic 2>&1 \
 // RUN: | %fcheck-generic
-// https://github.com/llvm/llvm-project/issues/182119
-// UNSUPPORTED: intelgpu
+// XFAIL: intelgpu
 
 #include <stdio.h>
 int main() {

--- a/offload/test/offloading/assert.cpp
+++ b/offload/test/offloading/assert.cpp
@@ -1,7 +1,6 @@
 // RUN: %libomptarget-compilexx-generic && %libomptarget-run-fail-generic
 // RUN: %libomptarget-compileoptxx-generic && %libomptarget-run-fail-generic
-// https://github.com/llvm/llvm-project/issues/182119
-// UNSUPPORTED: intelgpu
+// XFAIL: intelgpu
 
 int main(int argc, char *argv[]) {
 #pragma omp target

--- a/offload/test/offloading/back2back_distribute.c
+++ b/offload/test/offloading/back2back_distribute.c
@@ -1,7 +1,6 @@
 // clang-format off
 // RUN: %libomptarget-compile-generic -O3 && %libomptarget-run-generic | %fcheck-generic
-// https://github.com/llvm/llvm-project/issues/182119
-// UNSUPPORTED: intelgpu
+// XFAIL: intelgpu
 // clang-format on
 #include <omp.h>
 #include <stdio.h>

--- a/offload/test/offloading/bug49334.cpp
+++ b/offload/test/offloading/bug49334.cpp
@@ -8,8 +8,7 @@
 // REQUIRES: gpu
 // UNSUPPORTED: nvidiagpu
 // UNSUPPORTED: amdgpu
-// https://github.com/llvm/llvm-project/issues/182119
-// UNSUPPORTED: intelgpu
+// XFAIL: intelgpu
 
 #include <cassert>
 #include <cmath>

--- a/offload/test/offloading/bug51982.c
+++ b/offload/test/offloading/bug51982.c
@@ -1,8 +1,7 @@
 // RUN: %libomptarget-compile-generic -O2 && %libomptarget-run-generic
 // -O2 to run openmp-opt
 // RUN: %libomptarget-compileopt-generic -O2 && %libomptarget-run-generic
-// https://github.com/llvm/llvm-project/issues/182119
-// UNSUPPORTED: intelgpu
+// XFAIL: intelgpu
 
 int main(void) {
   long int aa = 0;

--- a/offload/test/offloading/bug74582.c
+++ b/offload/test/offloading/bug74582.c
@@ -1,7 +1,6 @@
 // RUN: %libomptarget-compile-generic && %libomptarget-run-generic
 // RUN: %libomptarget-compileopt-generic && %libomptarget-run-generic
-// https://github.com/llvm/llvm-project/issues/182119
-// UNSUPPORTED: intelgpu
+
 
 // Verify we do not read bits in the image that are not there (nobits section).
 

--- a/offload/test/offloading/bug74582.c
+++ b/offload/test/offloading/bug74582.c
@@ -1,7 +1,6 @@
 // RUN: %libomptarget-compile-generic && %libomptarget-run-generic
 // RUN: %libomptarget-compileopt-generic && %libomptarget-run-generic
 
-
 // Verify we do not read bits in the image that are not there (nobits section).
 
 #pragma omp begin declare target

--- a/offload/test/offloading/ctor_dtor_api.cpp
+++ b/offload/test/offloading/ctor_dtor_api.cpp
@@ -1,7 +1,6 @@
 // RUN: %libomptarget-compilexx-run-and-check-generic
 // RUN: %libomptarget-compileoptxx-run-and-check-generic
-// https://github.com/llvm/llvm-project/issues/182119
-// UNSUPPORTED: intelgpu
+// XFAIL: intelgpu
 
 #include <cstdio>
 #include <omp.h>

--- a/offload/test/offloading/ctor_dtor_lazy.cpp
+++ b/offload/test/offloading/ctor_dtor_lazy.cpp
@@ -4,8 +4,7 @@
 // RUN: %not --crash %libomptarget-run-generic
 // RUN: %libomptarget-compilexx-generic -DCTOR_API
 // RUN: %not --crash %libomptarget-run-generic
-// https://github.com/llvm/llvm-project/issues/182119
-// UNSUPPORTED: intelgpu
+// XFAIL: intelgpu
 
 #include <cstdio>
 #include <omp.h>

--- a/offload/test/offloading/dyn_groupprivate.cpp
+++ b/offload/test/offloading/dyn_groupprivate.cpp
@@ -3,7 +3,7 @@
 // RUN: %libomptarget-compileoptxx-generic -fopenmp-version=61
 // RUN: %libomptarget-run-generic | %fcheck-generic
 // REQUIRES: gpu
-// UNSUPPORTED: intelgpu
+// XFAIL: intelgpu
 
 #include <omp.h>
 #include <stdio.h>

--- a/offload/test/offloading/dynamic_module.c
+++ b/offload/test/offloading/dynamic_module.c
@@ -5,8 +5,7 @@
 // RUN: %libomptarget-compileopt-generic %t.so && %libomptarget-run-generic 2>&1 | %fcheck-generic
 //
 // REQUIRES: gpu
-// https://github.com/llvm/llvm-project/issues/182119
-// UNSUPPORTED: intelgpu
+
 // clang-format on
 
 #ifdef SHARED

--- a/offload/test/offloading/high_trip_count_block_limit.cpp
+++ b/offload/test/offloading/high_trip_count_block_limit.cpp
@@ -5,8 +5,7 @@
 // UNSUPPORTED: aarch64-unknown-linux-gnu
 // UNSUPPORTED: x86_64-unknown-linux-gnu
 // UNSUPPORTED: s390x-ibm-linux-gnu
-// https://github.com/llvm/llvm-project/issues/182119
-// UNSUPPORTED: intelgpu
+
 // clang-format on
 
 /*

--- a/offload/test/offloading/malloc.c
+++ b/offload/test/offloading/malloc.c
@@ -1,7 +1,6 @@
 // RUN: %libomptarget-compile-generic && %libomptarget-run-generic
 // RUN: %libomptarget-compileopt-generic && %libomptarget-run-generic
-// https://github.com/llvm/llvm-project/issues/182119
-// UNSUPPORTED: intelgpu
+// XFAIL: intelgpu
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/offload/test/offloading/multiple_reductions_simple.c
+++ b/offload/test/offloading/multiple_reductions_simple.c
@@ -1,7 +1,6 @@
 // RUN: %libomptarget-compile-run-and-check-generic
 // RUN: %libomptarget-compileopt-run-and-check-generic
-// https://github.com/llvm/llvm-project/issues/182119
-// UNSUPPORTED: intelgpu
+// XFAIL: intelgpu
 
 #include <stdio.h>
 

--- a/offload/test/offloading/ompx_coords.c
+++ b/offload/test/offloading/ompx_coords.c
@@ -1,8 +1,7 @@
 // RUN: %libomptarget-compileopt-run-and-check-generic
 //
 // REQUIRES: gpu
-// https://github.com/llvm/llvm-project/issues/182119
-// UNSUPPORTED: intelgpu
+// XFAIL: intelgpu
 
 #include <omp.h>
 #include <ompx.h>

--- a/offload/test/offloading/ompx_saxpy_mixed.c
+++ b/offload/test/offloading/ompx_saxpy_mixed.c
@@ -1,8 +1,7 @@
 // RUN: %libomptarget-compileopt-run-and-check-generic
 //
 // REQUIRES: gpu
-// https://github.com/llvm/llvm-project/issues/182119
-// UNSUPPORTED: intelgpu
+// XFAIL: intelgpu
 
 #include <math.h>
 #include <omp.h>

--- a/offload/test/offloading/parallel_target_teams_reduction.cpp
+++ b/offload/test/offloading/parallel_target_teams_reduction.cpp
@@ -3,8 +3,7 @@
 
 // FIXME: This is a bug in host offload, this should run fine.
 // REQUIRES: gpu
-// https://github.com/llvm/llvm-project/issues/182119
-// UNSUPPORTED: intelgpu
+// XFAIL: intelgpu
 
 #include <iostream>
 #include <vector>

--- a/offload/test/offloading/parallel_target_teams_reduction_max.cpp
+++ b/offload/test/offloading/parallel_target_teams_reduction_max.cpp
@@ -3,8 +3,7 @@
 
 // FIXME: This is a bug in host offload, this should run fine.
 // REQUIRES: gpu
-// https://github.com/llvm/llvm-project/issues/182119
-// UNSUPPORTED: intelgpu
+// XFAIL: intelgpu
 
 // This test validates that the OpenMP target reductions to find a maximum work
 // as intended for a few common data types.

--- a/offload/test/offloading/parallel_target_teams_reduction_min.cpp
+++ b/offload/test/offloading/parallel_target_teams_reduction_min.cpp
@@ -3,8 +3,7 @@
 
 // FIXME: This is a bug in host offload, this should run fine.
 // REQUIRES: gpu
-// https://github.com/llvm/llvm-project/issues/182119
-// UNSUPPORTED: intelgpu
+// XFAIL: intelgpu
 
 // This test validates that the OpenMP target reductions to find a minimum work
 // as intended for a few common data types.

--- a/offload/test/offloading/spmdization.c
+++ b/offload/test/offloading/spmdization.c
@@ -9,8 +9,7 @@
 // clang-format on
 
 // REQUIRES: gpu
-// https://github.com/llvm/llvm-project/issues/182119
-// UNSUPPORTED: intelgpu
+// XFAIL: intelgpu
 
 #include <omp.h>
 #include <stdio.h>

--- a/offload/test/offloading/target_constexpr_mapping.cpp
+++ b/offload/test/offloading/target_constexpr_mapping.cpp
@@ -1,6 +1,5 @@
 // RUN: %libomptarget-compileoptxx-run-and-check-generic
-// https://github.com/llvm/llvm-project/issues/182119
-// UNSUPPORTED: intelgpu
+// XFAIL: intelgpu
 
 #include <omp.h>
 #include <stdio.h>

--- a/offload/test/offloading/wtime.c
+++ b/offload/test/offloading/wtime.c
@@ -1,8 +1,7 @@
 // RUN: %libomptarget-compileopt-and-run-generic
 
 // UNSUPPORTED: amdgcn-amd-amdhsa
-// https://github.com/llvm/llvm-project/issues/182119
-// UNSUPPORTED: intelgpu
+// XFAIL: intelgpu
 
 #include <assert.h>
 #include <omp.h>

--- a/offload/test/sanitizer/double_free_racy.c
+++ b/offload/test/sanitizer/double_free_racy.c
@@ -9,7 +9,6 @@
 // UNSUPPORTED: x86_64-unknown-linux-gnu
 // UNSUPPORTED: s390x-ibm-linux-gnu
 
-
 #include <omp.h>
 
 int main(void) {

--- a/offload/test/sanitizer/double_free_racy.c
+++ b/offload/test/sanitizer/double_free_racy.c
@@ -8,8 +8,7 @@
 // UNSUPPORTED: aarch64-unknown-linux-gnu
 // UNSUPPORTED: x86_64-unknown-linux-gnu
 // UNSUPPORTED: s390x-ibm-linux-gnu
-// https://github.com/llvm/llvm-project/issues/182119
-// UNSUPPORTED: intelgpu
+
 
 #include <omp.h>
 

--- a/offload/test/sanitizer/ptr_outside_alloc_1.c
+++ b/offload/test/sanitizer/ptr_outside_alloc_1.c
@@ -9,8 +9,7 @@
 // UNSUPPORTED: nvidiagpu
 //
 // REQUIRES: gpu
-// https://github.com/llvm/llvm-project/issues/182119
-// UNSUPPORTED: intelgpu
+// XFAIL: intelgpu
 
 #include <omp.h>
 

--- a/offload/test/sanitizer/ptr_outside_alloc_2.c
+++ b/offload/test/sanitizer/ptr_outside_alloc_2.c
@@ -7,8 +7,7 @@
 // UNSUPPORTED: nvidiagpu
 //
 // REQUIRES: gpu
-// https://github.com/llvm/llvm-project/issues/182119
-// UNSUPPORTED: intelgpu
+// XFAIL: intelgpu
 
 #include <omp.h>
 


### PR DESCRIPTION
This change improves handling of errors during synchronization in Level Zero plugin by ensuring cleanup of queues and events in case of an synchronization error. As a result multiple tests stopped hanging.