### PR TITLE
[AMDGPU][NFC] Adds an optional TargetOccupancy argument to getMaxNumVectorRegs.

### DIFF
--- a/llvm/lib/Target/AMDGPU/GCNSubtarget.cpp
+++ b/llvm/lib/Target/AMDGPU/GCNSubtarget.cpp
@@ -565,11 +565,15 @@ GCNSubtarget::getMaxNumVGPRs(const Function &F,
   if (DynamicVGPRBlockSize == 0 && isDynamicVGPREnabled())
     DynamicVGPRBlockSize = getDynamicVGPRBlockSize();
 
-  std::pair<unsigned, unsigned> Waves;
-  if (TargetOccupancy)
-    Waves = {*TargetOccupancy, *TargetOccupancy};
-  else
-    Waves = getWavesPerEU(F);
+  std::pair<unsigned, unsigned> Waves = getWavesPerEU(F);
+  if (TargetOccupancy) {
+    if (*TargetOccupancy >= Waves.first && *TargetOccupancy <= Waves.second)
+      Waves = {*TargetOccupancy, *TargetOccupancy};
+    else if (*TargetOccupancy < Waves.first)
+      Waves = {Waves.first, Waves.first};
+    else
+      Waves = {Waves.second, Waves.second};
+  }
   return getBaseMaxNumVGPRs(
       F, {getMinNumVGPRs(Waves.second, DynamicVGPRBlockSize),
           getMaxNumVGPRs(Waves.first, DynamicVGPRBlockSize)});

--- a/llvm/lib/Target/AMDGPU/GCNSubtarget.cpp
+++ b/llvm/lib/Target/AMDGPU/GCNSubtarget.cpp
@@ -556,14 +556,20 @@ unsigned GCNSubtarget::getBaseMaxNumVGPRs(
   return std::clamp(Requested, Min, Max);
 }
 
-unsigned GCNSubtarget::getMaxNumVGPRs(const Function &F) const {
+unsigned
+GCNSubtarget::getMaxNumVGPRs(const Function &F,
+                             std::optional<unsigned> TargetOccupancy) const {
   // Temporarily check both the attribute and the subtarget feature, until the
   // latter is removed.
   unsigned DynamicVGPRBlockSize = AMDGPU::getDynamicVGPRBlockSize(F);
   if (DynamicVGPRBlockSize == 0 && isDynamicVGPREnabled())
     DynamicVGPRBlockSize = getDynamicVGPRBlockSize();
 
-  std::pair<unsigned, unsigned> Waves = getWavesPerEU(F);
+  std::pair<unsigned, unsigned> Waves;
+  if (TargetOccupancy)
+    Waves = {*TargetOccupancy, *TargetOccupancy};
+  else
+    Waves = getWavesPerEU(F);
   return getBaseMaxNumVGPRs(
       F, {getMinNumVGPRs(Waves.second, DynamicVGPRBlockSize),
           getMaxNumVGPRs(Waves.first, DynamicVGPRBlockSize)});
@@ -573,9 +579,9 @@ unsigned GCNSubtarget::getMaxNumVGPRs(const MachineFunction &MF) const {
   return getMaxNumVGPRs(MF.getFunction());
 }
 
-std::pair<unsigned, unsigned>
-GCNSubtarget::getMaxNumVectorRegs(const Function &F) const {
-  const unsigned MaxVectorRegs = getMaxNumVGPRs(F);
+std::pair<unsigned, unsigned> GCNSubtarget::getMaxNumVectorRegs(
+    const Function &F, std::optional<unsigned> TargetOccupancy) const {
+  const unsigned MaxVectorRegs = getMaxNumVGPRs(F, TargetOccupancy);
 
   unsigned MaxNumVGPRs = MaxVectorRegs;
   unsigned MaxNumAGPRs = 0;

--- a/llvm/lib/Target/AMDGPU/GCNSubtarget.h
+++ b/llvm/lib/Target/AMDGPU/GCNSubtarget.h
@@ -859,7 +859,10 @@ public:
   /// subtarget's specifications, or does not meet number of waves per execution
   /// unit requirement.
   /// When \p TargetOccupancy is present, use it for both min and max waves
-  /// instead of getWavesPerEU(F).
+  /// if it lies within the function's wave range from getWavesPerEU(F)
+  /// (inclusive). Otherwise clamp \p TargetOccupancy to the nearest endpoint
+  /// of that range (below the minimum -> minimum waves; above the maximum ->
+  /// maximum waves).
   unsigned
   getMaxNumVGPRs(const Function &F,
                  std::optional<unsigned> TargetOccupancy = std::nullopt) const;

--- a/llvm/lib/Target/AMDGPU/GCNSubtarget.h
+++ b/llvm/lib/Target/AMDGPU/GCNSubtarget.h
@@ -23,6 +23,8 @@
 #include "Utils/AMDGPUBaseInfo.h"
 #include "llvm/Support/ErrorHandling.h"
 
+#include <optional>
+
 #define GET_SUBTARGETINFO_HEADER
 #include "AMDGPUGenSubtargetInfo.inc"
 
@@ -856,13 +858,20 @@ public:
   /// if explicitly requested value cannot be converted to integer, violates
   /// subtarget's specifications, or does not meet number of waves per execution
   /// unit requirement.
-  unsigned getMaxNumVGPRs(const Function &F) const;
+  /// When \p TargetOccupancy is present, use it for both min and max waves
+  /// instead of getWavesPerEU(F).
+  unsigned
+  getMaxNumVGPRs(const Function &F,
+                 std::optional<unsigned> TargetOccupancy = std::nullopt) const;
 
   unsigned getMaxNumAGPRs(const Function &F) const { return getMaxNumVGPRs(F); }
 
   /// Return a pair of maximum numbers of VGPRs and AGPRs that meet the number
   /// of waves per execution unit required for the function \p MF.
-  std::pair<unsigned, unsigned> getMaxNumVectorRegs(const Function &F) const;
+  /// When \p TargetOccupancy is present, it is passed to getMaxNumVGPRs.
+  std::pair<unsigned, unsigned> getMaxNumVectorRegs(
+      const Function &F,
+      std::optional<unsigned> TargetOccupancy = std::nullopt) const;
 
   /// \returns Maximum number of VGPRs that meets number of waves per execution
   /// unit requirement for function \p MF, or number of VGPRs explicitly


### PR DESCRIPTION
If a target occupancy is provided, that value is used as the min/max number of waves instead of getting the waves-per-eu from the function.

https://github.com/llvm/llvm-project/pull/185733 depends on this PR.

Assisted-by: Cursor