### PR TITLE
[AArch64] Fix register scavenger crash when merging MTE stack tags

### DIFF
--- a/llvm/include/llvm/CodeGen/RegisterScavenging.h
+++ b/llvm/include/llvm/CodeGen/RegisterScavenging.h
@@ -129,6 +129,8 @@ public:
         A.push_back(I.FrameIndex);
   }
 
+  size_t getNumScavengingFrameIndices() const { return Scavenged.size(); }
+
   /// Make a register of the specific register class available from the current
   /// position backwards to the place before \p To. If \p RestoreAfter is true
   /// this includes the instruction following the current position.

--- a/llvm/lib/Target/AArch64/AArch64FrameLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64FrameLowering.cpp
@@ -3367,6 +3367,21 @@ bool isMergeableStackTaggingInstruction(MachineInstr &MI, int64_t &Offset,
   return true;
 }
 
+static size_t countAvailableScavengerSlots(LivePhysRegs &LiveRegs,
+                                           MachineRegisterInfo &MRI,
+                                           RegScavenger *RS) {
+  auto FreeGPRs =
+      llvm::count_if(AArch64::GPR64RegClass, [&LiveRegs, &MRI](auto Reg) {
+        return LiveRegs.available(MRI, Reg);
+      });
+
+  size_t NumEmergencySlots = 0;
+  if (RS)
+    NumEmergencySlots = RS->getNumScavengingFrameIndices();
+
+  return FreeGPRs + NumEmergencySlots;
+}
+
 // Detect a run of memory tagging instructions for adjacent stack frame slots,
 // and replace them with a shorter instruction sequence:
 // * replace STG + STG with ST2G
@@ -3445,6 +3460,19 @@ MachineBasicBlock::iterator tryMergeAdjacentSTG(MachineBasicBlock::iterator II,
   InsertI++;
   if (LiveRegs.contains(AArch64::NZCV))
     return InsertI;
+
+  // Emitting an MTE loop requires two physical registers (BaseReg and
+  // SizeReg).  If the function is under register pressure, the register
+  // scavenger will crash trying to allocate them. If we don't have at least
+  // two free slots (free registers + emergency slots), bail out and fall back
+  // to the unrolled sequence.
+  if (countAvailableScavengerSlots(LiveRegs, MBB->getParent()->getRegInfo(),
+                                   RS) < 2) {
+    LLVM_DEBUG(
+        dbgs() << "Failed to merge MTE stack tagging instructions into loop "
+               << "due to high register pressure.\n");
+    return InsertI;
+  }
 
   llvm::stable_sort(Instrs,
                     [](const TagStoreInstr &Left, const TagStoreInstr &Right) {

--- a/llvm/test/CodeGen/AArch64/memtag-stg-loop-reg-pressure.mir
+++ b/llvm/test/CodeGen/AArch64/memtag-stg-loop-reg-pressure.mir
@@ -92,7 +92,7 @@ body:             |
   bb.0.entry:
     liveins: $x22
 
-    ; Load all registers from memory (mimics swift async thunk).
+    ; Load all registers from memory
     $x0 = LDRXui $x22, 0
     $x1 = LDRXui $x22, 1
     $x2 = LDRXui $x22, 2
@@ -124,7 +124,6 @@ body:             |
     $lr = LDRXui $x22, 29
     $fp = LDRXui $x22, 30
 
-    ; MTE tagging - e.g. untagging the async thunk
     ST2Gi $sp, %stack.1, 0 :: (store (s256))
     ST2Gi $sp, %stack.2, 0 :: (store (s256))
     ST2Gi $sp, %stack.3, 0 :: (store (s256))
@@ -136,7 +135,7 @@ body:             |
     ST2Gi $sp, %stack.9, 0 :: (store (s256))
     ST2Gi $sp, %stack.10, 0 :: (store (s256))
 
-    ; Store all registers to stack (Usually stores into callee's stack)
+    ; Store all registers to stack
     STRXui $x0, %stack.11, 0
     STRXui $x1, %stack.12, 0
     STRXui $x2, %stack.13, 0
@@ -169,7 +168,6 @@ body:             |
     STRXui $lr, %stack.40, 0
     STRXui $fp, %stack.0, 0
 
-    ; Usually a tail call in a swift thunk
     RET_ReallyLR
 ...
 ---
@@ -223,7 +221,7 @@ body:             |
   bb.0.entry:
     liveins: $x22
 
-    ; Load all registers except $x28 from memory (mimics swift async thunk).
+    ; Load all registers except $x28 from memory
     $x0 = LDRXui $x22, 0
     $x1 = LDRXui $x22, 1
     $x2 = LDRXui $x22, 2
@@ -254,7 +252,6 @@ body:             |
     $lr = LDRXui $x22, 29
     $fp = LDRXui $x22, 30
 
-    ; MTE tagging - e.g. untagging the async thunk
     ST2Gi $sp, %stack.1, 0 :: (store (s256))
     ST2Gi $sp, %stack.2, 0 :: (store (s256))
     ST2Gi $sp, %stack.3, 0 :: (store (s256))
@@ -266,8 +263,7 @@ body:             |
     ST2Gi $sp, %stack.9, 0 :: (store (s256))
     ST2Gi $sp, %stack.10, 0 :: (store (s256))
 
-    ; Store all registers except $x28 to stack (Usually stores into callee's
-    ; stack)
+    ; Store all registers except $x28 to stack
     STRXui $x0, %stack.11, 0
     STRXui $x1, %stack.12, 0
     STRXui $x2, %stack.13, 0
@@ -299,7 +295,6 @@ body:             |
     STRXui $lr, %stack.40, 0
     STRXui $fp, %stack.0, 0
 
-    ; Usually a tail call in a swift thunk
     RET_ReallyLR
 ...
 ---
@@ -353,8 +348,7 @@ body:             |
   bb.0.entry:
     liveins: $x22
 
-    ; Load all registers except $0, $x28 from memory (mimics swift async
-    ; thunk).
+    ; Load all registers except $0, $x28 from memory
     $x1 = LDRXui $x22, 1
     $x2 = LDRXui $x22, 2
     $x3 = LDRXui $x22, 3
@@ -384,7 +378,6 @@ body:             |
     $lr = LDRXui $x22, 29
     $fp = LDRXui $x22, 30
 
-    ; MTE tagging - e.g. untagging the async thunk
     ST2Gi $sp, %stack.1, 0 :: (store (s256))
     ST2Gi $sp, %stack.2, 0 :: (store (s256))
     ST2Gi $sp, %stack.3, 0 :: (store (s256))
@@ -396,8 +389,7 @@ body:             |
     ST2Gi $sp, %stack.9, 0 :: (store (s256))
     ST2Gi $sp, %stack.10, 0 :: (store (s256))
 
-    ; Store all registers except $x0, $x28 to stack (Usually stores into
-    ; callee's stack)
+    ; Store all registers except $x0, $x28 to stack
     STRXui $x1, %stack.12, 0
     STRXui $x2, %stack.13, 0
     STRXui $x3, %stack.14, 0
@@ -428,7 +420,6 @@ body:             |
     STRXui $lr, %stack.40, 0
     STRXui $fp, %stack.0, 0
 
-    ; Usually a tail call in a swift thunk
     RET_ReallyLR
 ...
 ---
@@ -482,8 +473,7 @@ body:             |
   bb.0.entry:
     liveins: $x22
 
-    ; Load all registers except $0 from memory (mimics swift async
-    ; thunk).
+    ; Load all registers except $0 from memory
     $x1 = LDRXui $x22, 1
     $x2 = LDRXui $x22, 2
     $x3 = LDRXui $x22, 3
@@ -514,7 +504,6 @@ body:             |
     $lr = LDRXui $x22, 29
     $fp = LDRXui $x22, 30
 
-    ; MTE tagging - e.g. untagging the async thunk
     ST2Gi $sp, %stack.1, 0 :: (store (s256))
     ST2Gi $sp, %stack.2, 0 :: (store (s256))
     ST2Gi $sp, %stack.3, 0 :: (store (s256))
@@ -526,8 +515,7 @@ body:             |
     ST2Gi $sp, %stack.9, 0 :: (store (s256))
     ST2Gi $sp, %stack.10, 0 :: (store (s256))
 
-    ; Store all registers except $x0 to stack (Usually stores into
-    ; callee's stack)
+    ; Store all registers except $x0 to stack
     STRXui $x1, %stack.12, 0
     STRXui $x2, %stack.13, 0
     STRXui $x3, %stack.14, 0
@@ -559,6 +547,5 @@ body:             |
     STRXui $lr, %stack.40, 0
     STRXui $fp, %stack.0, 0
 
-    ; Usually a tail call in a swift thunk
     RET_ReallyLR
 ...

--- a/llvm/test/CodeGen/AArch64/memtag-stg-loop-reg-pressure.mir
+++ b/llvm/test/CodeGen/AArch64/memtag-stg-loop-reg-pressure.mir
@@ -1,0 +1,564 @@
+# RUN: llc -mtriple=aarch64 -mattr=+mte -run-pass=prologepilog %s -verify-machineinstrs -o - | FileCheck %s
+
+# This test ensures that when register pressure is extremely high, the compiler
+# does not attempt to merge ST2Gi instructions into an STGloop. STGloop requires
+# two scratch locations (either free GPRs or emergency spill slots) which the
+# scavenger cannot provide without crashing.
+#
+# The test pattern mimics a Swift async continuation thunk, which loads all
+# registers from an async context, performs MTE stack untagging, then stores
+# all registers to the callee's stack area before a tail call. This creates
+# maximum register pressure at the ST2Gi instructions.
+#
+# We test the 4 possible combinations of (Free GPRs) + (Emergency Spill Slots)
+# to ensure the loop is only formed when the sum is >= 2.
+#
+# CHECK-LABEL: name: test_no_free_regs_emergency_slot
+# CHECK-NOT: STGloop
+# CHECK-LABEL: name: test_one_csr_free_no_slot
+# CHECK-NOT: STGloop
+# CHECK-LABEL: name: test_one_csr_one_caller_free
+# CHECK: STGloop
+# CHECK-LABEL: name: test_emergency_slot_one_caller_free
+# CHECK: STGloop
+
+
+--- |
+  define void @test_no_free_regs_emergency_slot() {
+  entry:
+    ret void
+  }
+  define void @test_one_csr_free_no_slot() {
+  entry:
+    ret void
+  }
+  define void @test_one_csr_one_caller_free() {
+  entry:
+    ret void
+  }
+  define void @test_emergency_slot_one_caller_free() {
+  entry:
+    ret void
+  }
+...
+---
+name:            test_no_free_regs_emergency_slot
+tracksRegLiveness: true
+liveins:
+  - { reg: '$x22', virtual-reg: '' }
+stack:
+  - { id: 0, size: 8192, alignment: 16 }
+  - { id: 1, size: 32, alignment: 16 }
+  - { id: 2, size: 32, alignment: 16 }
+  - { id: 3, size: 32, alignment: 16 }
+  - { id: 4, size: 32, alignment: 16 }
+  - { id: 5, size: 32, alignment: 16 }
+  - { id: 6, size: 32, alignment: 16 }
+  - { id: 7, size: 32, alignment: 16 }
+  - { id: 8, size: 32, alignment: 16 }
+  - { id: 9, size: 32, alignment: 16 }
+  - { id: 10, size: 32, alignment: 16 }
+  - { id: 11, size: 8, alignment: 8 }
+  - { id: 12, size: 8, alignment: 8 }
+  - { id: 13, size: 8, alignment: 8 }
+  - { id: 14, size: 8, alignment: 8 }
+  - { id: 15, size: 8, alignment: 8 }
+  - { id: 16, size: 8, alignment: 8 }
+  - { id: 17, size: 8, alignment: 8 }
+  - { id: 18, size: 8, alignment: 8 }
+  - { id: 19, size: 8, alignment: 8 }
+  - { id: 20, size: 8, alignment: 8 }
+  - { id: 21, size: 8, alignment: 8 }
+  - { id: 22, size: 8, alignment: 8 }
+  - { id: 23, size: 8, alignment: 8 }
+  - { id: 24, size: 8, alignment: 8 }
+  - { id: 25, size: 8, alignment: 8 }
+  - { id: 26, size: 8, alignment: 8 }
+  - { id: 27, size: 8, alignment: 8 }
+  - { id: 28, size: 8, alignment: 8 }
+  - { id: 29, size: 8, alignment: 8 }
+  - { id: 30, size: 8, alignment: 8 }
+  - { id: 31, size: 8, alignment: 8 }
+  - { id: 32, size: 8, alignment: 8 }
+  - { id: 33, size: 8, alignment: 8 }
+  - { id: 34, size: 8, alignment: 8 }
+  - { id: 35, size: 8, alignment: 8 }
+  - { id: 36, size: 8, alignment: 8 }
+  - { id: 37, size: 8, alignment: 8 }
+  - { id: 38, size: 8, alignment: 8 }
+  - { id: 39, size: 8, alignment: 8 }
+  - { id: 40, size: 8, alignment: 8 }
+body:             |
+  bb.0.entry:
+    liveins: $x22
+
+    ; Load all registers from memory (mimics swift async thunk).
+    $x0 = LDRXui $x22, 0
+    $x1 = LDRXui $x22, 1
+    $x2 = LDRXui $x22, 2
+    $x3 = LDRXui $x22, 3
+    $x4 = LDRXui $x22, 4
+    $x5 = LDRXui $x22, 5
+    $x6 = LDRXui $x22, 6
+    $x7 = LDRXui $x22, 7
+    $x8 = LDRXui $x22, 8
+    $x9 = LDRXui $x22, 9
+    $x10 = LDRXui $x22, 10
+    $x11 = LDRXui $x22, 11
+    $x12 = LDRXui $x22, 12
+    $x13 = LDRXui $x22, 13
+    $x14 = LDRXui $x22, 14
+    $x15 = LDRXui $x22, 15
+    $x16 = LDRXui $x22, 16
+    $x17 = LDRXui $x22, 17
+    $x18 = LDRXui $x22, 18
+    $x19 = LDRXui $x22, 19
+    $x20 = LDRXui $x22, 20
+    $x21 = LDRXui $x22, 21
+    $x23 = LDRXui $x22, 23
+    $x24 = LDRXui $x22, 24
+    $x25 = LDRXui $x22, 25
+    $x26 = LDRXui $x22, 26
+    $x27 = LDRXui $x22, 27
+    $x28 = LDRXui $x22, 28
+    $lr = LDRXui $x22, 29
+    $fp = LDRXui $x22, 30
+
+    ; MTE tagging - e.g. untagging the async thunk
+    ST2Gi $sp, %stack.1, 0 :: (store (s256))
+    ST2Gi $sp, %stack.2, 0 :: (store (s256))
+    ST2Gi $sp, %stack.3, 0 :: (store (s256))
+    ST2Gi $sp, %stack.4, 0 :: (store (s256))
+    ST2Gi $sp, %stack.5, 0 :: (store (s256))
+    ST2Gi $sp, %stack.6, 0 :: (store (s256))
+    ST2Gi $sp, %stack.7, 0 :: (store (s256))
+    ST2Gi $sp, %stack.8, 0 :: (store (s256))
+    ST2Gi $sp, %stack.9, 0 :: (store (s256))
+    ST2Gi $sp, %stack.10, 0 :: (store (s256))
+
+    ; Store all registers to stack (Usually stores into callee's stack)
+    STRXui $x0, %stack.11, 0
+    STRXui $x1, %stack.12, 0
+    STRXui $x2, %stack.13, 0
+    STRXui $x3, %stack.14, 0
+    STRXui $x4, %stack.15, 0
+    STRXui $x5, %stack.16, 0
+    STRXui $x6, %stack.17, 0
+    STRXui $x7, %stack.18, 0
+    STRXui $x8, %stack.19, 0
+    STRXui $x9, %stack.20, 0
+    STRXui $x10, %stack.21, 0
+    STRXui $x11, %stack.22, 0
+    STRXui $x12, %stack.23, 0
+    STRXui $x13, %stack.24, 0
+    STRXui $x14, %stack.25, 0
+    STRXui $x15, %stack.26, 0
+    STRXui $x16, %stack.27, 0
+    STRXui $x17, %stack.28, 0
+    STRXui $x18, %stack.29, 0
+    STRXui $x19, %stack.30, 0
+    STRXui $x20, %stack.31, 0
+    STRXui $x21, %stack.32, 0
+    STRXui $x22, %stack.33, 0
+    STRXui $x23, %stack.34, 0
+    STRXui $x24, %stack.35, 0
+    STRXui $x25, %stack.36, 0
+    STRXui $x26, %stack.37, 0
+    STRXui $x27, %stack.38, 0
+    STRXui $x28, %stack.39, 0
+    STRXui $lr, %stack.40, 0
+    STRXui $fp, %stack.0, 0
+
+    ; Usually a tail call in a swift thunk
+    RET_ReallyLR
+...
+---
+name:            test_one_csr_free_no_slot
+tracksRegLiveness: true
+liveins:
+  - { reg: '$x22', virtual-reg: '' }
+stack:
+  - { id: 0, size: 8192, alignment: 16 }
+  - { id: 1, size: 32, alignment: 16 }
+  - { id: 2, size: 32, alignment: 16 }
+  - { id: 3, size: 32, alignment: 16 }
+  - { id: 4, size: 32, alignment: 16 }
+  - { id: 5, size: 32, alignment: 16 }
+  - { id: 6, size: 32, alignment: 16 }
+  - { id: 7, size: 32, alignment: 16 }
+  - { id: 8, size: 32, alignment: 16 }
+  - { id: 9, size: 32, alignment: 16 }
+  - { id: 10, size: 32, alignment: 16 }
+  - { id: 11, size: 8, alignment: 8 }
+  - { id: 12, size: 8, alignment: 8 }
+  - { id: 13, size: 8, alignment: 8 }
+  - { id: 14, size: 8, alignment: 8 }
+  - { id: 15, size: 8, alignment: 8 }
+  - { id: 16, size: 8, alignment: 8 }
+  - { id: 17, size: 8, alignment: 8 }
+  - { id: 18, size: 8, alignment: 8 }
+  - { id: 19, size: 8, alignment: 8 }
+  - { id: 20, size: 8, alignment: 8 }
+  - { id: 21, size: 8, alignment: 8 }
+  - { id: 22, size: 8, alignment: 8 }
+  - { id: 23, size: 8, alignment: 8 }
+  - { id: 24, size: 8, alignment: 8 }
+  - { id: 25, size: 8, alignment: 8 }
+  - { id: 26, size: 8, alignment: 8 }
+  - { id: 27, size: 8, alignment: 8 }
+  - { id: 28, size: 8, alignment: 8 }
+  - { id: 29, size: 8, alignment: 8 }
+  - { id: 30, size: 8, alignment: 8 }
+  - { id: 31, size: 8, alignment: 8 }
+  - { id: 32, size: 8, alignment: 8 }
+  - { id: 33, size: 8, alignment: 8 }
+  - { id: 34, size: 8, alignment: 8 }
+  - { id: 35, size: 8, alignment: 8 }
+  - { id: 36, size: 8, alignment: 8 }
+  - { id: 37, size: 8, alignment: 8 }
+  - { id: 38, size: 8, alignment: 8 }
+  - { id: 39, size: 8, alignment: 8 }
+  - { id: 40, size: 8, alignment: 8 }
+body:             |
+  bb.0.entry:
+    liveins: $x22
+
+    ; Load all registers except $x28 from memory (mimics swift async thunk).
+    $x0 = LDRXui $x22, 0
+    $x1 = LDRXui $x22, 1
+    $x2 = LDRXui $x22, 2
+    $x3 = LDRXui $x22, 3
+    $x4 = LDRXui $x22, 4
+    $x5 = LDRXui $x22, 5
+    $x6 = LDRXui $x22, 6
+    $x7 = LDRXui $x22, 7
+    $x8 = LDRXui $x22, 8
+    $x9 = LDRXui $x22, 9
+    $x10 = LDRXui $x22, 10
+    $x11 = LDRXui $x22, 11
+    $x12 = LDRXui $x22, 12
+    $x13 = LDRXui $x22, 13
+    $x14 = LDRXui $x22, 14
+    $x15 = LDRXui $x22, 15
+    $x16 = LDRXui $x22, 16
+    $x17 = LDRXui $x22, 17
+    $x18 = LDRXui $x22, 18
+    $x19 = LDRXui $x22, 19
+    $x20 = LDRXui $x22, 20
+    $x21 = LDRXui $x22, 21
+    $x23 = LDRXui $x22, 23
+    $x24 = LDRXui $x22, 24
+    $x25 = LDRXui $x22, 25
+    $x26 = LDRXui $x22, 26
+    $x27 = LDRXui $x22, 27
+    $lr = LDRXui $x22, 29
+    $fp = LDRXui $x22, 30
+
+    ; MTE tagging - e.g. untagging the async thunk
+    ST2Gi $sp, %stack.1, 0 :: (store (s256))
+    ST2Gi $sp, %stack.2, 0 :: (store (s256))
+    ST2Gi $sp, %stack.3, 0 :: (store (s256))
+    ST2Gi $sp, %stack.4, 0 :: (store (s256))
+    ST2Gi $sp, %stack.5, 0 :: (store (s256))
+    ST2Gi $sp, %stack.6, 0 :: (store (s256))
+    ST2Gi $sp, %stack.7, 0 :: (store (s256))
+    ST2Gi $sp, %stack.8, 0 :: (store (s256))
+    ST2Gi $sp, %stack.9, 0 :: (store (s256))
+    ST2Gi $sp, %stack.10, 0 :: (store (s256))
+
+    ; Store all registers except $x28 to stack (Usually stores into callee's
+    ; stack)
+    STRXui $x0, %stack.11, 0
+    STRXui $x1, %stack.12, 0
+    STRXui $x2, %stack.13, 0
+    STRXui $x3, %stack.14, 0
+    STRXui $x4, %stack.15, 0
+    STRXui $x5, %stack.16, 0
+    STRXui $x6, %stack.17, 0
+    STRXui $x7, %stack.18, 0
+    STRXui $x8, %stack.19, 0
+    STRXui $x9, %stack.20, 0
+    STRXui $x10, %stack.21, 0
+    STRXui $x11, %stack.22, 0
+    STRXui $x12, %stack.23, 0
+    STRXui $x13, %stack.24, 0
+    STRXui $x14, %stack.25, 0
+    STRXui $x15, %stack.26, 0
+    STRXui $x16, %stack.27, 0
+    STRXui $x17, %stack.28, 0
+    STRXui $x18, %stack.29, 0
+    STRXui $x19, %stack.30, 0
+    STRXui $x20, %stack.31, 0
+    STRXui $x21, %stack.32, 0
+    STRXui $x22, %stack.33, 0
+    STRXui $x23, %stack.34, 0
+    STRXui $x24, %stack.35, 0
+    STRXui $x25, %stack.36, 0
+    STRXui $x26, %stack.37, 0
+    STRXui $x27, %stack.38, 0
+    STRXui $lr, %stack.40, 0
+    STRXui $fp, %stack.0, 0
+
+    ; Usually a tail call in a swift thunk
+    RET_ReallyLR
+...
+---
+name:            test_one_csr_one_caller_free
+tracksRegLiveness: true
+liveins:
+  - { reg: '$x22', virtual-reg: '' }
+stack:
+  - { id: 0, size: 8192, alignment: 16 }
+  - { id: 1, size: 32, alignment: 16 }
+  - { id: 2, size: 32, alignment: 16 }
+  - { id: 3, size: 32, alignment: 16 }
+  - { id: 4, size: 32, alignment: 16 }
+  - { id: 5, size: 32, alignment: 16 }
+  - { id: 6, size: 32, alignment: 16 }
+  - { id: 7, size: 32, alignment: 16 }
+  - { id: 8, size: 32, alignment: 16 }
+  - { id: 9, size: 32, alignment: 16 }
+  - { id: 10, size: 32, alignment: 16 }
+  - { id: 11, size: 8, alignment: 8 }
+  - { id: 12, size: 8, alignment: 8 }
+  - { id: 13, size: 8, alignment: 8 }
+  - { id: 14, size: 8, alignment: 8 }
+  - { id: 15, size: 8, alignment: 8 }
+  - { id: 16, size: 8, alignment: 8 }
+  - { id: 17, size: 8, alignment: 8 }
+  - { id: 18, size: 8, alignment: 8 }
+  - { id: 19, size: 8, alignment: 8 }
+  - { id: 20, size: 8, alignment: 8 }
+  - { id: 21, size: 8, alignment: 8 }
+  - { id: 22, size: 8, alignment: 8 }
+  - { id: 23, size: 8, alignment: 8 }
+  - { id: 24, size: 8, alignment: 8 }
+  - { id: 25, size: 8, alignment: 8 }
+  - { id: 26, size: 8, alignment: 8 }
+  - { id: 27, size: 8, alignment: 8 }
+  - { id: 28, size: 8, alignment: 8 }
+  - { id: 29, size: 8, alignment: 8 }
+  - { id: 30, size: 8, alignment: 8 }
+  - { id: 31, size: 8, alignment: 8 }
+  - { id: 32, size: 8, alignment: 8 }
+  - { id: 33, size: 8, alignment: 8 }
+  - { id: 34, size: 8, alignment: 8 }
+  - { id: 35, size: 8, alignment: 8 }
+  - { id: 36, size: 8, alignment: 8 }
+  - { id: 37, size: 8, alignment: 8 }
+  - { id: 38, size: 8, alignment: 8 }
+  - { id: 39, size: 8, alignment: 8 }
+  - { id: 40, size: 8, alignment: 8 }
+body:             |
+  bb.0.entry:
+    liveins: $x22
+
+    ; Load all registers except $0, $x28 from memory (mimics swift async
+    ; thunk).
+    $x1 = LDRXui $x22, 1
+    $x2 = LDRXui $x22, 2
+    $x3 = LDRXui $x22, 3
+    $x4 = LDRXui $x22, 4
+    $x5 = LDRXui $x22, 5
+    $x6 = LDRXui $x22, 6
+    $x7 = LDRXui $x22, 7
+    $x8 = LDRXui $x22, 8
+    $x9 = LDRXui $x22, 9
+    $x10 = LDRXui $x22, 10
+    $x11 = LDRXui $x22, 11
+    $x12 = LDRXui $x22, 12
+    $x13 = LDRXui $x22, 13
+    $x14 = LDRXui $x22, 14
+    $x15 = LDRXui $x22, 15
+    $x16 = LDRXui $x22, 16
+    $x17 = LDRXui $x22, 17
+    $x18 = LDRXui $x22, 18
+    $x19 = LDRXui $x22, 19
+    $x20 = LDRXui $x22, 20
+    $x21 = LDRXui $x22, 21
+    $x23 = LDRXui $x22, 23
+    $x24 = LDRXui $x22, 24
+    $x25 = LDRXui $x22, 25
+    $x26 = LDRXui $x22, 26
+    $x27 = LDRXui $x22, 27
+    $lr = LDRXui $x22, 29
+    $fp = LDRXui $x22, 30
+
+    ; MTE tagging - e.g. untagging the async thunk
+    ST2Gi $sp, %stack.1, 0 :: (store (s256))
+    ST2Gi $sp, %stack.2, 0 :: (store (s256))
+    ST2Gi $sp, %stack.3, 0 :: (store (s256))
+    ST2Gi $sp, %stack.4, 0 :: (store (s256))
+    ST2Gi $sp, %stack.5, 0 :: (store (s256))
+    ST2Gi $sp, %stack.6, 0 :: (store (s256))
+    ST2Gi $sp, %stack.7, 0 :: (store (s256))
+    ST2Gi $sp, %stack.8, 0 :: (store (s256))
+    ST2Gi $sp, %stack.9, 0 :: (store (s256))
+    ST2Gi $sp, %stack.10, 0 :: (store (s256))
+
+    ; Store all registers except $x0, $x28 to stack (Usually stores into
+    ; callee's stack)
+    STRXui $x1, %stack.12, 0
+    STRXui $x2, %stack.13, 0
+    STRXui $x3, %stack.14, 0
+    STRXui $x4, %stack.15, 0
+    STRXui $x5, %stack.16, 0
+    STRXui $x6, %stack.17, 0
+    STRXui $x7, %stack.18, 0
+    STRXui $x8, %stack.19, 0
+    STRXui $x9, %stack.20, 0
+    STRXui $x10, %stack.21, 0
+    STRXui $x11, %stack.22, 0
+    STRXui $x12, %stack.23, 0
+    STRXui $x13, %stack.24, 0
+    STRXui $x14, %stack.25, 0
+    STRXui $x15, %stack.26, 0
+    STRXui $x16, %stack.27, 0
+    STRXui $x17, %stack.28, 0
+    STRXui $x18, %stack.29, 0
+    STRXui $x19, %stack.30, 0
+    STRXui $x20, %stack.31, 0
+    STRXui $x21, %stack.32, 0
+    STRXui $x22, %stack.33, 0
+    STRXui $x23, %stack.34, 0
+    STRXui $x24, %stack.35, 0
+    STRXui $x25, %stack.36, 0
+    STRXui $x26, %stack.37, 0
+    STRXui $x27, %stack.38, 0
+    STRXui $lr, %stack.40, 0
+    STRXui $fp, %stack.0, 0
+
+    ; Usually a tail call in a swift thunk
+    RET_ReallyLR
+...
+---
+name:            test_emergency_slot_one_caller_free
+tracksRegLiveness: true
+liveins:
+  - { reg: '$x22', virtual-reg: '' }
+stack:
+  - { id: 0, size: 8192, alignment: 16 }
+  - { id: 1, size: 32, alignment: 16 }
+  - { id: 2, size: 32, alignment: 16 }
+  - { id: 3, size: 32, alignment: 16 }
+  - { id: 4, size: 32, alignment: 16 }
+  - { id: 5, size: 32, alignment: 16 }
+  - { id: 6, size: 32, alignment: 16 }
+  - { id: 7, size: 32, alignment: 16 }
+  - { id: 8, size: 32, alignment: 16 }
+  - { id: 9, size: 32, alignment: 16 }
+  - { id: 10, size: 32, alignment: 16 }
+  - { id: 11, size: 8, alignment: 8 }
+  - { id: 12, size: 8, alignment: 8 }
+  - { id: 13, size: 8, alignment: 8 }
+  - { id: 14, size: 8, alignment: 8 }
+  - { id: 15, size: 8, alignment: 8 }
+  - { id: 16, size: 8, alignment: 8 }
+  - { id: 17, size: 8, alignment: 8 }
+  - { id: 18, size: 8, alignment: 8 }
+  - { id: 19, size: 8, alignment: 8 }
+  - { id: 20, size: 8, alignment: 8 }
+  - { id: 21, size: 8, alignment: 8 }
+  - { id: 22, size: 8, alignment: 8 }
+  - { id: 23, size: 8, alignment: 8 }
+  - { id: 24, size: 8, alignment: 8 }
+  - { id: 25, size: 8, alignment: 8 }
+  - { id: 26, size: 8, alignment: 8 }
+  - { id: 27, size: 8, alignment: 8 }
+  - { id: 28, size: 8, alignment: 8 }
+  - { id: 29, size: 8, alignment: 8 }
+  - { id: 30, size: 8, alignment: 8 }
+  - { id: 31, size: 8, alignment: 8 }
+  - { id: 32, size: 8, alignment: 8 }
+  - { id: 33, size: 8, alignment: 8 }
+  - { id: 34, size: 8, alignment: 8 }
+  - { id: 35, size: 8, alignment: 8 }
+  - { id: 36, size: 8, alignment: 8 }
+  - { id: 37, size: 8, alignment: 8 }
+  - { id: 38, size: 8, alignment: 8 }
+  - { id: 39, size: 8, alignment: 8 }
+  - { id: 40, size: 8, alignment: 8 }
+body:             |
+  bb.0.entry:
+    liveins: $x22
+
+    ; Load all registers except $0 from memory (mimics swift async
+    ; thunk).
+    $x1 = LDRXui $x22, 1
+    $x2 = LDRXui $x22, 2
+    $x3 = LDRXui $x22, 3
+    $x4 = LDRXui $x22, 4
+    $x5 = LDRXui $x22, 5
+    $x6 = LDRXui $x22, 6
+    $x7 = LDRXui $x22, 7
+    $x8 = LDRXui $x22, 8
+    $x9 = LDRXui $x22, 9
+    $x10 = LDRXui $x22, 10
+    $x11 = LDRXui $x22, 11
+    $x12 = LDRXui $x22, 12
+    $x13 = LDRXui $x22, 13
+    $x14 = LDRXui $x22, 14
+    $x15 = LDRXui $x22, 15
+    $x16 = LDRXui $x22, 16
+    $x17 = LDRXui $x22, 17
+    $x18 = LDRXui $x22, 18
+    $x19 = LDRXui $x22, 19
+    $x20 = LDRXui $x22, 20
+    $x21 = LDRXui $x22, 21
+    $x23 = LDRXui $x22, 23
+    $x24 = LDRXui $x22, 24
+    $x25 = LDRXui $x22, 25
+    $x26 = LDRXui $x22, 26
+    $x27 = LDRXui $x22, 27
+    $x28 = LDRXui $x22, 28
+    $lr = LDRXui $x22, 29
+    $fp = LDRXui $x22, 30
+
+    ; MTE tagging - e.g. untagging the async thunk
+    ST2Gi $sp, %stack.1, 0 :: (store (s256))
+    ST2Gi $sp, %stack.2, 0 :: (store (s256))
+    ST2Gi $sp, %stack.3, 0 :: (store (s256))
+    ST2Gi $sp, %stack.4, 0 :: (store (s256))
+    ST2Gi $sp, %stack.5, 0 :: (store (s256))
+    ST2Gi $sp, %stack.6, 0 :: (store (s256))
+    ST2Gi $sp, %stack.7, 0 :: (store (s256))
+    ST2Gi $sp, %stack.8, 0 :: (store (s256))
+    ST2Gi $sp, %stack.9, 0 :: (store (s256))
+    ST2Gi $sp, %stack.10, 0 :: (store (s256))
+
+    ; Store all registers except $x0 to stack (Usually stores into
+    ; callee's stack)
+    STRXui $x1, %stack.12, 0
+    STRXui $x2, %stack.13, 0
+    STRXui $x3, %stack.14, 0
+    STRXui $x4, %stack.15, 0
+    STRXui $x5, %stack.16, 0
+    STRXui $x6, %stack.17, 0
+    STRXui $x7, %stack.18, 0
+    STRXui $x8, %stack.19, 0
+    STRXui $x9, %stack.20, 0
+    STRXui $x10, %stack.21, 0
+    STRXui $x11, %stack.22, 0
+    STRXui $x12, %stack.23, 0
+    STRXui $x13, %stack.24, 0
+    STRXui $x14, %stack.25, 0
+    STRXui $x15, %stack.26, 0
+    STRXui $x16, %stack.27, 0
+    STRXui $x17, %stack.28, 0
+    STRXui $x18, %stack.29, 0
+    STRXui $x19, %stack.30, 0
+    STRXui $x20, %stack.31, 0
+    STRXui $x21, %stack.32, 0
+    STRXui $x22, %stack.33, 0
+    STRXui $x23, %stack.34, 0
+    STRXui $x24, %stack.35, 0
+    STRXui $x25, %stack.36, 0
+    STRXui $x26, %stack.37, 0
+    STRXui $x27, %stack.38, 0
+    STRXui $x28, %stack.39, 0
+    STRXui $lr, %stack.40, 0
+    STRXui $fp, %stack.0, 0
+
+    ; Usually a tail call in a swift thunk
+    RET_ReallyLR
+...


### PR DESCRIPTION
When `-sanitize=memtag-stack` is enabled, `TagStoreEdit::emitLoop` optimizes contiguous ST2Gi instructions into an STGloop. Because this runs during PEI (post-register allocation), it spawns two new virtual registers: BaseReg and SizeReg.

Under high register pressure (e.g., Swift async continuation thunks where almost all registers are kept live), the Register Scavenger must rely on emergency spill slots to assign physical registers to BaseReg and SizeReg.

Previously, the compiler assumed at most one emergency spill slot was needed. If PEI found an unused Callee-Saved Register (`ExtraCSSpill`), it bypassed allocating an emergency slot entirely. If no CSRs were free, it allocated exactly one slot. Because STGloop requires TWO scratch locations, the scavenger would crash trying to fulfill the second allocation.

This patch fixes the crash by checking the available scavenger capacity (Free GPRs + Allocated Emergency Spill Slots) prior to merging instructions. If there are fewer than 2 available slots, we bail out and fall back to emitting unrolled ST2Gi instructions, which can be safely scavenged.

Added a comprehensive MIR test verifying loop formation behavior across all combinations of free GPRs and emergency spill slots.

Assisted-by: claude

rdar://172501087