### PR TITLE
[libcxx] p3111 initial implementation

### DIFF
--- a/libcxx/include/__atomic/atomic.h
+++ b/libcxx/include/__atomic/atomic.h
@@ -179,6 +179,39 @@ struct __atomic_base<_Tp, true> : public __atomic_base<_Tp, false> {
     return std::__cxx_atomic_fetch_xor(std::addressof(this->__a_), __op, __m);
   }
 
+#if _LIBCPP_STD_VER >= 26
+  _LIBCPP_HIDE_FROM_ABI void store_add(_Tp __op, memory_order __m = memory_order_seq_cst) volatile _NOEXCEPT {
+    (void)fetch_add(__op, __m);
+  }
+  _LIBCPP_HIDE_FROM_ABI void store_add(_Tp __op, memory_order __m = memory_order_seq_cst) _NOEXCEPT {
+    (void)fetch_add(__op, __m);
+  }
+  _LIBCPP_HIDE_FROM_ABI void store_sub(_Tp __op, memory_order __m = memory_order_seq_cst) volatile _NOEXCEPT {
+    (void)fetch_sub(__op, __m);
+  }
+  _LIBCPP_HIDE_FROM_ABI void store_sub(_Tp __op, memory_order __m = memory_order_seq_cst) _NOEXCEPT {
+    (void)fetch_sub(__op, __m);
+  }
+  _LIBCPP_HIDE_FROM_ABI void store_and(_Tp __op, memory_order __m = memory_order_seq_cst) volatile _NOEXCEPT {
+    (void)fetch_and(__op, __m);
+  }
+  _LIBCPP_HIDE_FROM_ABI void store_and(_Tp __op, memory_order __m = memory_order_seq_cst) _NOEXCEPT {
+    (void)fetch_and(__op, __m);
+  }
+  _LIBCPP_HIDE_FROM_ABI void store_or(_Tp __op, memory_order __m = memory_order_seq_cst) volatile _NOEXCEPT {
+    (void)fetch_or(__op, __m);
+  }
+  _LIBCPP_HIDE_FROM_ABI void store_or(_Tp __op, memory_order __m = memory_order_seq_cst) _NOEXCEPT {
+    (void)fetch_or(__op, __m);
+  }
+  _LIBCPP_HIDE_FROM_ABI void store_xor(_Tp __op, memory_order __m = memory_order_seq_cst) volatile _NOEXCEPT {
+    (void)fetch_xor(__op, __m);
+  }
+  _LIBCPP_HIDE_FROM_ABI void store_xor(_Tp __op, memory_order __m = memory_order_seq_cst) _NOEXCEPT {
+    (void)fetch_xor(__op, __m);
+  }
+#endif // _LIBCPP_STD_VER >= 26
+
   _LIBCPP_HIDE_FROM_ABI _Tp operator++(int) volatile _NOEXCEPT { return fetch_add(_Tp(1)); }
   _LIBCPP_HIDE_FROM_ABI _Tp operator++(int) _NOEXCEPT { return fetch_add(_Tp(1)); }
   _LIBCPP_HIDE_FROM_ABI _Tp operator--(int) volatile _NOEXCEPT { return fetch_sub(_Tp(1)); }
@@ -306,6 +339,25 @@ struct atomic<_Tp*> : public __atomic_base<_Tp*> {
     return std::__cxx_atomic_fetch_sub(std::addressof(this->__a_), __op, __m);
   }
 
+#if _LIBCPP_STD_VER >= 26
+  _LIBCPP_HIDE_FROM_ABI void store_add(ptrdiff_t __op, memory_order __m = memory_order_seq_cst) volatile _NOEXCEPT {
+    static_assert(!is_function<__remove_pointer_t<_Tp> >::value, "Pointer to function isn't allowed");
+    (void)fetch_add(__op, __m);
+  }
+  _LIBCPP_HIDE_FROM_ABI void store_add(ptrdiff_t __op, memory_order __m = memory_order_seq_cst) _NOEXCEPT {
+    static_assert(!is_function<__remove_pointer_t<_Tp> >::value, "Pointer to function isn't allowed");
+    (void)fetch_add(__op, __m);
+  }
+  _LIBCPP_HIDE_FROM_ABI void store_sub(ptrdiff_t __op, memory_order __m = memory_order_seq_cst) volatile _NOEXCEPT {
+    static_assert(!is_function<__remove_pointer_t<_Tp> >::value, "Pointer to function isn't allowed");
+    (void)fetch_sub(__op, __m);
+  }
+  _LIBCPP_HIDE_FROM_ABI void store_sub(ptrdiff_t __op, memory_order __m = memory_order_seq_cst) _NOEXCEPT {
+    static_assert(!is_function<__remove_pointer_t<_Tp> >::value, "Pointer to function isn't allowed");
+    (void)fetch_sub(__op, __m);
+  }
+#endif // _LIBCPP_STD_VER >= 26
+
   _LIBCPP_HIDE_FROM_ABI _Tp* operator++(int) volatile _NOEXCEPT { return fetch_add(1); }
   _LIBCPP_HIDE_FROM_ABI _Tp* operator++(int) _NOEXCEPT { return fetch_add(1); }
   _LIBCPP_HIDE_FROM_ABI _Tp* operator--(int) volatile _NOEXCEPT { return fetch_sub(1); }
@@ -414,6 +466,25 @@ public:
   _LIBCPP_HIDE_FROM_ABI _Tp fetch_sub(_Tp __op, memory_order __m = memory_order_seq_cst) noexcept {
     return __fetch_sub(*this, __op, __m);
   }
+
+#  if _LIBCPP_STD_VER >= 26
+  _LIBCPP_HIDE_FROM_ABI void store_add(_Tp __op, memory_order __m = memory_order_seq_cst) volatile noexcept
+    requires __base::is_always_lock_free
+  {
+    (void)fetch_add(__op, __m);
+  }
+  _LIBCPP_HIDE_FROM_ABI void store_add(_Tp __op, memory_order __m = memory_order_seq_cst) noexcept {
+    (void)fetch_add(__op, __m);
+  }
+  _LIBCPP_HIDE_FROM_ABI void store_sub(_Tp __op, memory_order __m = memory_order_seq_cst) volatile noexcept
+    requires __base::is_always_lock_free
+  {
+    (void)fetch_sub(__op, __m);
+  }
+  _LIBCPP_HIDE_FROM_ABI void store_sub(_Tp __op, memory_order __m = memory_order_seq_cst) noexcept {
+    (void)fetch_sub(__op, __m);
+  }
+#  endif // _LIBCPP_STD_VER >= 26
 
   _LIBCPP_HIDE_FROM_ABI _Tp operator+=(_Tp __op) volatile noexcept
     requires __base::is_always_lock_free
@@ -798,6 +869,144 @@ _LIBCPP_HIDE_FROM_ABI _Tp
 atomic_fetch_xor_explicit(atomic<_Tp>* __o, typename atomic<_Tp>::value_type __op, memory_order __m) _NOEXCEPT {
   return __o->fetch_xor(__op, __m);
 }
+
+#if _LIBCPP_STD_VER >= 26
+
+// atomic_store_add
+
+template <class _Tp>
+_LIBCPP_HIDE_FROM_ABI void
+atomic_store_add(volatile atomic<_Tp>* __o, typename atomic<_Tp>::difference_type __op) _NOEXCEPT {
+  __o->store_add(__op);
+}
+
+template <class _Tp>
+_LIBCPP_HIDE_FROM_ABI void atomic_store_add(atomic<_Tp>* __o, typename atomic<_Tp>::difference_type __op) _NOEXCEPT {
+  __o->store_add(__op);
+}
+
+// atomic_store_add_explicit
+
+template <class _Tp>
+_LIBCPP_HIDE_FROM_ABI void atomic_store_add_explicit(
+    volatile atomic<_Tp>* __o, typename atomic<_Tp>::difference_type __op, memory_order __m) _NOEXCEPT {
+  __o->store_add(__op, __m);
+}
+
+template <class _Tp>
+_LIBCPP_HIDE_FROM_ABI void
+atomic_store_add_explicit(atomic<_Tp>* __o, typename atomic<_Tp>::difference_type __op, memory_order __m) _NOEXCEPT {
+  __o->store_add(__op, __m);
+}
+
+// atomic_store_sub
+
+template <class _Tp>
+_LIBCPP_HIDE_FROM_ABI void
+atomic_store_sub(volatile atomic<_Tp>* __o, typename atomic<_Tp>::difference_type __op) _NOEXCEPT {
+  __o->store_sub(__op);
+}
+
+template <class _Tp>
+_LIBCPP_HIDE_FROM_ABI void atomic_store_sub(atomic<_Tp>* __o, typename atomic<_Tp>::difference_type __op) _NOEXCEPT {
+  __o->store_sub(__op);
+}
+
+// atomic_store_sub_explicit
+
+template <class _Tp>
+_LIBCPP_HIDE_FROM_ABI void atomic_store_sub_explicit(
+    volatile atomic<_Tp>* __o, typename atomic<_Tp>::difference_type __op, memory_order __m) _NOEXCEPT {
+  __o->store_sub(__op, __m);
+}
+
+template <class _Tp>
+_LIBCPP_HIDE_FROM_ABI void
+atomic_store_sub_explicit(atomic<_Tp>* __o, typename atomic<_Tp>::difference_type __op, memory_order __m) _NOEXCEPT {
+  __o->store_sub(__op, __m);
+}
+
+// atomic_store_and
+
+template <class _Tp, __enable_if_t<is_integral<_Tp>::value && !is_same<_Tp, bool>::value, int> = 0>
+_LIBCPP_HIDE_FROM_ABI void
+atomic_store_and(volatile atomic<_Tp>* __o, typename atomic<_Tp>::value_type __op) _NOEXCEPT {
+  __o->store_and(__op);
+}
+
+template <class _Tp, __enable_if_t<is_integral<_Tp>::value && !is_same<_Tp, bool>::value, int> = 0>
+_LIBCPP_HIDE_FROM_ABI void atomic_store_and(atomic<_Tp>* __o, typename atomic<_Tp>::value_type __op) _NOEXCEPT {
+  __o->store_and(__op);
+}
+
+// atomic_store_and_explicit
+
+template <class _Tp, __enable_if_t<is_integral<_Tp>::value && !is_same<_Tp, bool>::value, int> = 0>
+_LIBCPP_HIDE_FROM_ABI void atomic_store_and_explicit(
+    volatile atomic<_Tp>* __o, typename atomic<_Tp>::value_type __op, memory_order __m) _NOEXCEPT {
+  __o->store_and(__op, __m);
+}
+
+template <class _Tp, __enable_if_t<is_integral<_Tp>::value && !is_same<_Tp, bool>::value, int> = 0>
+_LIBCPP_HIDE_FROM_ABI void
+atomic_store_and_explicit(atomic<_Tp>* __o, typename atomic<_Tp>::value_type __op, memory_order __m) _NOEXCEPT {
+  __o->store_and(__op, __m);
+}
+
+// atomic_store_or
+
+template <class _Tp, __enable_if_t<is_integral<_Tp>::value && !is_same<_Tp, bool>::value, int> = 0>
+_LIBCPP_HIDE_FROM_ABI void atomic_store_or(volatile atomic<_Tp>* __o, typename atomic<_Tp>::value_type __op) _NOEXCEPT {
+  __o->store_or(__op);
+}
+
+template <class _Tp, __enable_if_t<is_integral<_Tp>::value && !is_same<_Tp, bool>::value, int> = 0>
+_LIBCPP_HIDE_FROM_ABI void atomic_store_or(atomic<_Tp>* __o, typename atomic<_Tp>::value_type __op) _NOEXCEPT {
+  __o->store_or(__op);
+}
+
+// atomic_store_or_explicit
+
+template <class _Tp, __enable_if_t<is_integral<_Tp>::value && !is_same<_Tp, bool>::value, int> = 0>
+_LIBCPP_HIDE_FROM_ABI void
+atomic_store_or_explicit(volatile atomic<_Tp>* __o, typename atomic<_Tp>::value_type __op, memory_order __m) _NOEXCEPT {
+  __o->store_or(__op, __m);
+}
+
+template <class _Tp, __enable_if_t<is_integral<_Tp>::value && !is_same<_Tp, bool>::value, int> = 0>
+_LIBCPP_HIDE_FROM_ABI void
+atomic_store_or_explicit(atomic<_Tp>* __o, typename atomic<_Tp>::value_type __op, memory_order __m) _NOEXCEPT {
+  __o->store_or(__op, __m);
+}
+
+// atomic_store_xor
+
+template <class _Tp, __enable_if_t<is_integral<_Tp>::value && !is_same<_Tp, bool>::value, int> = 0>
+_LIBCPP_HIDE_FROM_ABI void
+atomic_store_xor(volatile atomic<_Tp>* __o, typename atomic<_Tp>::value_type __op) _NOEXCEPT {
+  __o->store_xor(__op);
+}
+
+template <class _Tp, __enable_if_t<is_integral<_Tp>::value && !is_same<_Tp, bool>::value, int> = 0>
+_LIBCPP_HIDE_FROM_ABI void atomic_store_xor(atomic<_Tp>* __o, typename atomic<_Tp>::value_type __op) _NOEXCEPT {
+  __o->store_xor(__op);
+}
+
+// atomic_store_xor_explicit
+
+template <class _Tp, __enable_if_t<is_integral<_Tp>::value && !is_same<_Tp, bool>::value, int> = 0>
+_LIBCPP_HIDE_FROM_ABI void atomic_store_xor_explicit(
+    volatile atomic<_Tp>* __o, typename atomic<_Tp>::value_type __op, memory_order __m) _NOEXCEPT {
+  __o->store_xor(__op, __m);
+}
+
+template <class _Tp, __enable_if_t<is_integral<_Tp>::value && !is_same<_Tp, bool>::value, int> = 0>
+_LIBCPP_HIDE_FROM_ABI void
+atomic_store_xor_explicit(atomic<_Tp>* __o, typename atomic<_Tp>::value_type __op, memory_order __m) _NOEXCEPT {
+  __o->store_xor(__op, __m);
+}
+
+#endif // _LIBCPP_STD_VER >= 26
 
 _LIBCPP_END_NAMESPACE_STD
 

--- a/libcxx/include/__atomic/atomic_ref.h
+++ b/libcxx/include/__atomic/atomic_ref.h
@@ -300,6 +300,24 @@ struct atomic_ref<_Tp> : public __atomic_ref_base<_Tp> {
     return __atomic_fetch_xor(this->__ptr_, __arg, std::__to_gcc_order(__order));
   }
 
+#  if _LIBCPP_STD_VER >= 26
+  _LIBCPP_HIDE_FROM_ABI void store_add(_Tp __arg, memory_order __order = memory_order_seq_cst) const noexcept {
+    (void)fetch_add(__arg, __order);
+  }
+  _LIBCPP_HIDE_FROM_ABI void store_sub(_Tp __arg, memory_order __order = memory_order_seq_cst) const noexcept {
+    (void)fetch_sub(__arg, __order);
+  }
+  _LIBCPP_HIDE_FROM_ABI void store_and(_Tp __arg, memory_order __order = memory_order_seq_cst) const noexcept {
+    (void)fetch_and(__arg, __order);
+  }
+  _LIBCPP_HIDE_FROM_ABI void store_or(_Tp __arg, memory_order __order = memory_order_seq_cst) const noexcept {
+    (void)fetch_or(__arg, __order);
+  }
+  _LIBCPP_HIDE_FROM_ABI void store_xor(_Tp __arg, memory_order __order = memory_order_seq_cst) const noexcept {
+    (void)fetch_xor(__arg, __order);
+  }
+#  endif // _LIBCPP_STD_VER >= 26
+
   _LIBCPP_HIDE_FROM_ABI _Tp operator++(int) const noexcept { return fetch_add(_Tp(1)); }
   _LIBCPP_HIDE_FROM_ABI _Tp operator--(int) const noexcept { return fetch_sub(_Tp(1)); }
   _LIBCPP_HIDE_FROM_ABI _Tp operator++() const noexcept { return fetch_add(_Tp(1)) + _Tp(1); }
@@ -355,6 +373,15 @@ struct atomic_ref<_Tp> : public __atomic_ref_base<_Tp> {
     }
   }
 
+#  if _LIBCPP_STD_VER >= 26
+  _LIBCPP_HIDE_FROM_ABI void store_add(_Tp __arg, memory_order __order = memory_order_seq_cst) const noexcept {
+    (void)fetch_add(__arg, __order);
+  }
+  _LIBCPP_HIDE_FROM_ABI void store_sub(_Tp __arg, memory_order __order = memory_order_seq_cst) const noexcept {
+    (void)fetch_sub(__arg, __order);
+  }
+#  endif // _LIBCPP_STD_VER >= 26
+
   _LIBCPP_HIDE_FROM_ABI _Tp operator+=(_Tp __arg) const noexcept { return fetch_add(__arg) + __arg; }
   _LIBCPP_HIDE_FROM_ABI _Tp operator-=(_Tp __arg) const noexcept { return fetch_sub(__arg) - __arg; }
 };
@@ -377,6 +404,15 @@ struct atomic_ref<_Tp*> : public __atomic_ref_base<_Tp*> {
   _LIBCPP_HIDE_FROM_ABI _Tp* fetch_sub(ptrdiff_t __arg, memory_order __order = memory_order_seq_cst) const noexcept {
     return __atomic_fetch_sub(this->__ptr_, __arg * sizeof(_Tp), std::__to_gcc_order(__order));
   }
+
+#  if _LIBCPP_STD_VER >= 26
+  _LIBCPP_HIDE_FROM_ABI void store_add(ptrdiff_t __arg, memory_order __order = memory_order_seq_cst) const noexcept {
+    (void)fetch_add(__arg, __order);
+  }
+  _LIBCPP_HIDE_FROM_ABI void store_sub(ptrdiff_t __arg, memory_order __order = memory_order_seq_cst) const noexcept {
+    (void)fetch_sub(__arg, __order);
+  }
+#  endif // _LIBCPP_STD_VER >= 26
 
   _LIBCPP_HIDE_FROM_ABI _Tp* operator++(int) const noexcept { return fetch_add(1); }
   _LIBCPP_HIDE_FROM_ABI _Tp* operator--(int) const noexcept { return fetch_sub(1); }

--- a/libcxx/include/atomic
+++ b/libcxx/include/atomic
@@ -442,6 +442,57 @@ template<class T>
   T atomic_fetch_xor_explicit(atomic<T>*, atomic<T>::value_type,
                               memory_order) noexcept;
 
+template<class T>                                                                     // since C++26
+  void atomic_store_add(volatile atomic<T>*, atomic<T>::difference_type) noexcept;   // since C++26
+template<class T>                                                                     // since C++26
+  void atomic_store_add(atomic<T>*, atomic<T>::difference_type) noexcept;            // since C++26
+template<class T>                                                                     // since C++26
+  void atomic_store_add_explicit(volatile atomic<T>*, atomic<T>::difference_type,    // since C++26
+                                 memory_order) noexcept;                             // since C++26
+template<class T>                                                                     // since C++26
+  void atomic_store_add_explicit(atomic<T>*, atomic<T>::difference_type,             // since C++26
+                                 memory_order) noexcept;                             // since C++26
+template<class T>                                                                     // since C++26
+  void atomic_store_sub(volatile atomic<T>*, atomic<T>::difference_type) noexcept;   // since C++26
+template<class T>                                                                     // since C++26
+  void atomic_store_sub(atomic<T>*, atomic<T>::difference_type) noexcept;            // since C++26
+template<class T>                                                                     // since C++26
+  void atomic_store_sub_explicit(volatile atomic<T>*, atomic<T>::difference_type,    // since C++26
+                                 memory_order) noexcept;                             // since C++26
+template<class T>                                                                     // since C++26
+  void atomic_store_sub_explicit(atomic<T>*, atomic<T>::difference_type,             // since C++26
+                                 memory_order) noexcept;                             // since C++26
+template<class T>                                                                     // since C++26
+  void atomic_store_and(volatile atomic<T>*, atomic<T>::value_type) noexcept;        // since C++26
+template<class T>                                                                     // since C++26
+  void atomic_store_and(atomic<T>*, atomic<T>::value_type) noexcept;                 // since C++26
+template<class T>                                                                     // since C++26
+  void atomic_store_and_explicit(volatile atomic<T>*, atomic<T>::value_type,         // since C++26
+                                 memory_order) noexcept;                             // since C++26
+template<class T>                                                                     // since C++26
+  void atomic_store_and_explicit(atomic<T>*, atomic<T>::value_type,                  // since C++26
+                                 memory_order) noexcept;                             // since C++26
+template<class T>                                                                     // since C++26
+  void atomic_store_or(volatile atomic<T>*, atomic<T>::value_type) noexcept;         // since C++26
+template<class T>                                                                     // since C++26
+  void atomic_store_or(atomic<T>*, atomic<T>::value_type) noexcept;                  // since C++26
+template<class T>                                                                     // since C++26
+  void atomic_store_or_explicit(volatile atomic<T>*, atomic<T>::value_type,          // since C++26
+                                memory_order) noexcept;                              // since C++26
+template<class T>                                                                     // since C++26
+  void atomic_store_or_explicit(atomic<T>*, atomic<T>::value_type,                   // since C++26
+                                memory_order) noexcept;                              // since C++26
+template<class T>                                                                     // since C++26
+  void atomic_store_xor(volatile atomic<T>*, atomic<T>::value_type) noexcept;        // since C++26
+template<class T>                                                                     // since C++26
+  void atomic_store_xor(atomic<T>*, atomic<T>::value_type) noexcept;                 // since C++26
+template<class T>                                                                     // since C++26
+  void atomic_store_xor_explicit(volatile atomic<T>*, atomic<T>::value_type,         // since C++26
+                                 memory_order) noexcept;                             // since C++26
+template<class T>                                                                     // since C++26
+  void atomic_store_xor_explicit(atomic<T>*, atomic<T>::value_type,                  // since C++26
+                                 memory_order) noexcept;                             // since C++26
+
 template<class T>
   void atomic_wait(const volatile atomic<T>*, atomic<T>::value_type) noexcept; // since C++20
 template<class T>

--- a/libcxx/test/std/atomics/atomics.ref/store_operations.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.ref/store_operations.pass.cpp
@@ -1,0 +1,95 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03, c++11, c++14, c++17, c++20, c++23
+// XFAIL: !has-64-bit-atomics
+
+// <atomic>
+
+// Test atomic_ref<T> member functions:
+//   store_add, store_sub, store_and, store_or, store_xor
+//
+// void store_add(T operand, memory_order order = memory_order::seq_cst) const noexcept;
+// (Same pattern for store_sub, store_and, store_or, store_xor)
+
+#include <atomic>
+#include <type_traits>
+#include <cassert>
+
+#include "test_macros.h"
+#include "atomic_helpers.h"
+#include "../atomics.types.operations/atomics.types.operations.req/atomic_store_operations_helper.h"
+
+template <class T>
+struct TestFn {
+  void operator()() const {
+    {
+      T val;
+      std::atomic_ref<T> ref(val);
+
+      auto load      = [&]() { return ref.load(); };
+      auto store     = [&](T v) { ref.store(v); };
+      auto store_add = [&](T v, auto order) { ref.store_add(v, order); };
+      auto store_sub = [&](T v, auto order) { ref.store_sub(v, order); };
+      auto store_and = [&](T v, auto order) { ref.store_and(v, order); };
+      auto store_or  = [&](T v, auto order) { ref.store_or(v, order); };
+      auto store_xor = [&](T v, auto order) { ref.store_xor(v, order); };
+
+      test_store_operations_integral<T>(load, store, store_add, store_sub, store_and, store_or, store_xor);
+      ASSERT_NOEXCEPT(ref.store_add(T(0)));
+      ASSERT_NOEXCEPT(ref.store_sub(T(0)));
+      ASSERT_NOEXCEPT(ref.store_and(T(0)));
+      ASSERT_NOEXCEPT(ref.store_or(T(0)));
+      ASSERT_NOEXCEPT(ref.store_xor(T(0)));
+    }
+  }
+};
+
+template <class T>
+void testp() {
+  {
+    T val;
+    std::atomic_ref<T> ref(val);
+
+    auto load      = [&]() { return ref.load(); };
+    auto store     = [&](T v) { ref.store(v); };
+    auto store_add = [&](std::ptrdiff_t v, auto order) { ref.store_add(v, order); };
+    auto store_sub = [&](std::ptrdiff_t v, auto order) { ref.store_sub(v, order); };
+
+    test_store_operations_pointer<T>(load, store, store_add, store_sub);
+    ASSERT_NOEXCEPT(ref.store_add(0));
+    ASSERT_NOEXCEPT(ref.store_sub(0));
+  }
+}
+
+template <class T>
+void testf() {
+  {
+    T val;
+    std::atomic_ref<T> ref(val);
+
+    auto load      = [&]() { return ref.load(); };
+    auto store     = [&](T v) { ref.store(v); };
+    auto store_add = [&](T v, auto order) { ref.store_add(v, order); };
+    auto store_sub = [&](T v, auto order) { ref.store_sub(v, order); };
+
+    test_store_operations_floating<T>(load, store, store_add, store_sub);
+    ASSERT_NOEXCEPT(ref.store_add(T(0)));
+    ASSERT_NOEXCEPT(ref.store_sub(T(0)));
+  }
+}
+
+int main(int, char**) {
+  TestEachIntegralType<TestFn>()();
+  testp<int*>();
+  testp<const int*>();
+  testf<float>();
+  testf<double>();
+
+  return 0;
+}

--- a/libcxx/test/std/atomics/atomics.types.generic/address.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.types.generic/address.pass.cpp
@@ -121,6 +121,96 @@ do_test()
     assert((obj -= std::ptrdiff_t(3)) == T(2*sizeof(X)));
     assert(obj == T(2*sizeof(X)));
 
+#if TEST_STD_VER >= 26
+    // Test store_add with various offsets and memory orders
+    {
+      X a[20] = {};
+
+      // Test with default memory order (seq_cst)
+      obj.store(&a[0]);
+      obj.store_add(5);
+      assert(obj == &a[5]);
+
+      // Test with memory_order_relaxed
+      obj.store(&a[2]);
+      obj.store_add(3, std::memory_order_relaxed);
+      assert(obj == &a[5]);
+
+      // Test with memory_order_release
+      obj.store(&a[1]);
+      obj.store_add(7, std::memory_order_release);
+      assert(obj == &a[8]);
+
+      // Test with zero offset
+      obj.store(&a[10]);
+      obj.store_add(0);
+      assert(obj == &a[10]);
+
+      // Test with negative offset
+      obj.store(&a[15]);
+      obj.store_add(-5);
+      assert(obj == &a[10]);
+
+      // Test chaining multiple store_add operations
+      obj.store(&a[0]);
+      obj.store_add(2);
+      obj.store_add(3);
+      obj.store_add(4);
+      assert(obj == &a[9]);
+    }
+
+    // Test store_sub with various offsets and memory orders
+    {
+      X a[20] = {};
+
+      // Test with default memory order (seq_cst)
+      obj.store(&a[10]);
+      obj.store_sub(5);
+      assert(obj == &a[5]);
+
+      // Test with memory_order_relaxed
+      obj.store(&a[15]);
+      obj.store_sub(3, std::memory_order_relaxed);
+      assert(obj == &a[12]);
+
+      // Test with memory_order_release
+      obj.store(&a[18]);
+      obj.store_sub(7, std::memory_order_release);
+      assert(obj == &a[11]);
+
+      // Test with zero offset
+      obj.store(&a[10]);
+      obj.store_sub(0);
+      assert(obj == &a[10]);
+
+      // Test with negative offset (moves forward)
+      obj.store(&a[5]);
+      obj.store_sub(-5);
+      assert(obj == &a[10]);
+
+      // Test chaining multiple store_sub operations
+      obj.store(&a[19]);
+      obj.store_sub(2);
+      obj.store_sub(3);
+      obj.store_sub(4);
+      assert(obj == &a[10]);
+    }
+
+    // Test mixing store_add and store_sub
+    {
+      X a[20] = {};
+      obj.store(&a[10]);
+      obj.store_add(5);
+      assert(obj == &a[15]);
+      obj.store_sub(3);
+      assert(obj == &a[12]);
+      obj.store_add(-2);
+      assert(obj == &a[10]);
+      obj.store_sub(-4);
+      assert(obj == &a[14]);
+    }
+#endif
+
     {
         TEST_ALIGNAS_TYPE(A) char storage[sizeof(A)] = {23};
         A& zero = *new (storage) A();

--- a/libcxx/test/std/atomics/atomics.types.generic/integral.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.types.generic/integral.pass.cpp
@@ -57,6 +57,22 @@
 //         fetch_xor(integral op, memory_order m = memory_order_seq_cst) volatile;
 //     integral fetch_xor(integral op, memory_order m = memory_order_seq_cst);
 //
+//     void
+//         store_add(integral op, memory_order m = memory_order_seq_cst) volatile;
+//     void store_add(integral op, memory_order m = memory_order_seq_cst);
+//     void
+//         store_sub(integral op, memory_order m = memory_order_seq_cst) volatile;
+//     void store_sub(integral op, memory_order m = memory_order_seq_cst);
+//     void
+//         store_and(integral op, memory_order m = memory_order_seq_cst) volatile;
+//     void store_and(integral op, memory_order m = memory_order_seq_cst);
+//     void
+//         store_or(integral op, memory_order m = memory_order_seq_cst) volatile;
+//     void store_or(integral op, memory_order m = memory_order_seq_cst);
+//     void
+//         store_xor(integral op, memory_order m = memory_order_seq_cst) volatile;
+//     void store_xor(integral op, memory_order m = memory_order_seq_cst);
+//
 //     atomic() = default;
 //     constexpr atomic(integral desr);
 //     atomic(const atomic&) = delete;
@@ -153,6 +169,43 @@ do_test()
     assert(obj == T(7));
     assert((obj ^= T(0xF)) == T(8));
     assert(obj == T(8));
+
+#if TEST_STD_VER >= 26
+    // Test store_add
+    obj.store(T(1));
+    obj.store_add(T(2));
+    assert(obj == T(3));
+    obj.store_add(T(0), std::memory_order_relaxed);
+    assert(obj == T(3));
+
+    // Test store_sub
+    obj.store(T(10));
+    obj.store_sub(T(3));
+    assert(obj == T(7));
+    obj.store_sub(T(0), std::memory_order_release);
+    assert(obj == T(7));
+
+    // Test store_and
+    obj.store(T(0b1111));
+    obj.store_and(T(0b1010));
+    assert(obj == T(0b1010));
+    obj.store_and(T(0b1111), std::memory_order_relaxed);
+    assert(obj == T(0b1010));
+
+    // Test store_or
+    obj.store(T(0b1010));
+    obj.store_or(T(0b0101));
+    assert(obj == T(0b1111));
+    obj.store_or(T(0b0000), std::memory_order_release);
+    assert(obj == T(0b1111));
+
+    // Test store_xor
+    obj.store(T(0b1100));
+    obj.store_xor(T(0b1010));
+    assert(obj == T(0b0110));
+    obj.store_xor(T(0b0000), std::memory_order_relaxed);
+    assert(obj == T(0b0110));
+#endif
 
     {
         TEST_ALIGNAS_TYPE(A) char storage[sizeof(A)] = {23};

--- a/libcxx/test/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_member_store_operations.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_member_store_operations.pass.cpp
@@ -1,0 +1,115 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03, c++11, c++14, c++17, c++20, c++23
+// XFAIL: !has-64-bit-atomics
+
+// <atomic>
+
+// Test atomic<T> member functions:
+//   store_add, store_sub, store_and, store_or, store_xor
+//
+// void store_add(T operand, memory_order order = memory_order::seq_cst) volatile noexcept;
+// void store_add(T operand, memory_order order = memory_order::seq_cst) noexcept;
+// (Same pattern for store_sub, store_and, store_or, store_xor)
+
+#include <atomic>
+#include <type_traits>
+#include <cassert>
+
+#include "test_macros.h"
+#include "atomic_helpers.h"
+#include "atomic_store_operations_helper.h"
+
+template <class T>
+struct TestFn {
+  void operator()() const {
+    // Test non-volatile atomic<T>
+    {
+      typedef std::atomic<T> A;
+      A t;
+
+      auto load      = [&]() { return t.load(); };
+      auto store     = [&](T val) { t.store(val); };
+      auto store_add = [&](T val, auto order) { t.store_add(val, order); };
+      auto store_sub = [&](T val, auto order) { t.store_sub(val, order); };
+      auto store_and = [&](T val, auto order) { t.store_and(val, order); };
+      auto store_or  = [&](T val, auto order) { t.store_or(val, order); };
+      auto store_xor = [&](T val, auto order) { t.store_xor(val, order); };
+
+      test_store_operations_integral<T>(load, store, store_add, store_sub, store_and, store_or, store_xor);
+      ASSERT_NOEXCEPT(t.store_add(T(0)));
+      ASSERT_NOEXCEPT(t.store_sub(T(0)));
+      ASSERT_NOEXCEPT(t.store_and(T(0)));
+      ASSERT_NOEXCEPT(t.store_or(T(0)));
+      ASSERT_NOEXCEPT(t.store_xor(T(0)));
+    }
+
+    // Test volatile atomic<T>
+    {
+      typedef std::atomic<T> A;
+      volatile A t;
+
+      auto load      = [&]() { return t.load(); };
+      auto store     = [&](T val) { t.store(val); };
+      auto store_add = [&](T val, auto order) { t.store_add(val, order); };
+      auto store_sub = [&](T val, auto order) { t.store_sub(val, order); };
+      auto store_and = [&](T val, auto order) { t.store_and(val, order); };
+      auto store_or  = [&](T val, auto order) { t.store_or(val, order); };
+      auto store_xor = [&](T val, auto order) { t.store_xor(val, order); };
+
+      test_store_operations_integral<T>(load, store, store_add, store_sub, store_and, store_or, store_xor);
+      ASSERT_NOEXCEPT(t.store_add(T(0)));
+      ASSERT_NOEXCEPT(t.store_sub(T(0)));
+      ASSERT_NOEXCEPT(t.store_and(T(0)));
+      ASSERT_NOEXCEPT(t.store_or(T(0)));
+      ASSERT_NOEXCEPT(t.store_xor(T(0)));
+    }
+  }
+};
+
+template <class T>
+void testp() {
+  // Test non-volatile atomic<T*>
+  {
+    typedef std::atomic<T> A;
+    A t;
+
+    auto load      = [&]() { return t.load(); };
+    auto store     = [&](T val) { t.store(val); };
+    auto store_add = [&](std::ptrdiff_t val, auto order) { t.store_add(val, order); };
+    auto store_sub = [&](std::ptrdiff_t val, auto order) { t.store_sub(val, order); };
+
+    test_store_operations_pointer<T>(load, store, store_add, store_sub);
+    ASSERT_NOEXCEPT(t.store_add(0));
+    ASSERT_NOEXCEPT(t.store_sub(0));
+  }
+
+  // Test volatile atomic<T*>
+  {
+    typedef std::atomic<T> A;
+    volatile A t;
+
+    auto load      = [&]() { return t.load(); };
+    auto store     = [&](T val) { t.store(val); };
+    auto store_add = [&](std::ptrdiff_t val, auto order) { t.store_add(val, order); };
+    auto store_sub = [&](std::ptrdiff_t val, auto order) { t.store_sub(val, order); };
+
+    test_store_operations_pointer<T>(load, store, store_add, store_sub);
+    ASSERT_NOEXCEPT(t.store_add(0));
+    ASSERT_NOEXCEPT(t.store_sub(0));
+  }
+}
+
+int main(int, char**) {
+  TestEachIntegralType<TestFn>()();
+  testp<int*>();
+  testp<const int*>();
+
+  return 0;
+}

--- a/libcxx/test/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_store_operations.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_store_operations.pass.cpp
@@ -1,0 +1,112 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03, c++11, c++14, c++17, c++20, c++23
+// XFAIL: !has-64-bit-atomics
+
+// <atomic>
+
+// Test all atomic_store_* non-member functions (non-explicit versions):
+//   atomic_store_add, atomic_store_sub, atomic_store_and, atomic_store_or, atomic_store_xor
+//
+// template<class T>
+//     void atomic_store_add(volatile atomic<T>*, atomic<T>::difference_type) noexcept;
+// template<class T>
+//     void atomic_store_add(atomic<T>*, atomic<T>::difference_type) noexcept;
+//
+// (Same pattern for store_sub, store_and, store_or, store_xor)
+
+#include <atomic>
+#include <type_traits>
+#include <cassert>
+
+#include "test_macros.h"
+#include "atomic_helpers.h"
+#include "atomic_store_operations_helper.h"
+
+template <class T>
+struct TestFn {
+  void operator()() const {
+    {
+      typedef std::atomic<T> A;
+      A t;
+
+      auto load      = [&]() { return t.load(); };
+      auto store     = [&](T val) { t.store(val); };
+      auto store_add = [&](T val, auto) { std::atomic_store_add(&t, val); };
+      auto store_sub = [&](T val, auto) { std::atomic_store_sub(&t, val); };
+      auto store_and = [&](T val, auto) { std::atomic_store_and(&t, val); };
+      auto store_or  = [&](T val, auto) { std::atomic_store_or(&t, val); };
+      auto store_xor = [&](T val, auto) { std::atomic_store_xor(&t, val); };
+
+      test_store_operations_integral<T>(load, store, store_add, store_sub, store_and, store_or, store_xor);
+      ASSERT_NOEXCEPT(std::atomic_store_add(&t, T(0)));
+      ASSERT_NOEXCEPT(std::atomic_store_sub(&t, T(0)));
+      ASSERT_NOEXCEPT(std::atomic_store_and(&t, T(0)));
+      ASSERT_NOEXCEPT(std::atomic_store_or(&t, T(0)));
+      ASSERT_NOEXCEPT(std::atomic_store_xor(&t, T(0)));
+    }
+    {
+      typedef std::atomic<T> A;
+      volatile A t;
+
+      auto load      = [&]() { return t.load(); };
+      auto store     = [&](T val) { t.store(val); };
+      auto store_add = [&](T val, auto) { std::atomic_store_add(&t, val); };
+      auto store_sub = [&](T val, auto) { std::atomic_store_sub(&t, val); };
+      auto store_and = [&](T val, auto) { std::atomic_store_and(&t, val); };
+      auto store_or  = [&](T val, auto) { std::atomic_store_or(&t, val); };
+      auto store_xor = [&](T val, auto) { std::atomic_store_xor(&t, val); };
+
+      test_store_operations_integral<T>(load, store, store_add, store_sub, store_and, store_or, store_xor);
+      ASSERT_NOEXCEPT(std::atomic_store_add(&t, T(0)));
+      ASSERT_NOEXCEPT(std::atomic_store_sub(&t, T(0)));
+      ASSERT_NOEXCEPT(std::atomic_store_and(&t, T(0)));
+      ASSERT_NOEXCEPT(std::atomic_store_or(&t, T(0)));
+      ASSERT_NOEXCEPT(std::atomic_store_xor(&t, T(0)));
+    }
+  }
+};
+
+template <class T>
+void testp() {
+  {
+    typedef std::atomic<T> A;
+    A t;
+
+    auto load      = [&]() { return t.load(); };
+    auto store     = [&](T val) { t.store(val); };
+    auto store_add = [&](std::ptrdiff_t val, auto) { std::atomic_store_add(&t, val); };
+    auto store_sub = [&](std::ptrdiff_t val, auto) { std::atomic_store_sub(&t, val); };
+
+    test_store_operations_pointer<T>(load, store, store_add, store_sub);
+    ASSERT_NOEXCEPT(std::atomic_store_add(&t, 0));
+    ASSERT_NOEXCEPT(std::atomic_store_sub(&t, 0));
+  }
+  {
+    typedef std::atomic<T> A;
+    volatile A t;
+
+    auto load      = [&]() { return t.load(); };
+    auto store     = [&](T val) { t.store(val); };
+    auto store_add = [&](std::ptrdiff_t val, auto) { std::atomic_store_add(&t, val); };
+    auto store_sub = [&](std::ptrdiff_t val, auto) { std::atomic_store_sub(&t, val); };
+
+    test_store_operations_pointer<T>(load, store, store_add, store_sub);
+    ASSERT_NOEXCEPT(std::atomic_store_add(&t, 0));
+    ASSERT_NOEXCEPT(std::atomic_store_sub(&t, 0));
+  }
+}
+
+int main(int, char**) {
+  TestEachIntegralType<TestFn>()();
+  testp<int*>();
+  testp<const int*>();
+
+  return 0;
+}

--- a/libcxx/test/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_store_operations_explicit.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_store_operations_explicit.pass.cpp
@@ -1,0 +1,113 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03, c++11, c++14, c++17, c++20, c++23
+// XFAIL: !has-64-bit-atomics
+
+// <atomic>
+
+// Test all atomic_store_*_explicit non-member functions:
+//   atomic_store_add_explicit, atomic_store_sub_explicit,
+//   atomic_store_and_explicit, atomic_store_or_explicit, atomic_store_xor_explicit
+//
+// template<class T>
+//     void atomic_store_add_explicit(volatile atomic<T>*, atomic<T>::difference_type, memory_order) noexcept;
+// template<class T>
+//     void atomic_store_add_explicit(atomic<T>*, atomic<T>::difference_type, memory_order) noexcept;
+//
+// (Same pattern for store_sub, store_and, store_or, store_xor)
+
+#include <atomic>
+#include <type_traits>
+#include <cassert>
+
+#include "test_macros.h"
+#include "atomic_helpers.h"
+#include "atomic_store_operations_helper.h"
+
+template <class T>
+struct TestFn {
+  void operator()() const {
+    {
+      typedef std::atomic<T> A;
+      A t;
+
+      auto load      = [&]() { return t.load(); };
+      auto store     = [&](T val) { t.store(val); };
+      auto store_add = [&](T val, auto order) { std::atomic_store_add_explicit(&t, val, order); };
+      auto store_sub = [&](T val, auto order) { std::atomic_store_sub_explicit(&t, val, order); };
+      auto store_and = [&](T val, auto order) { std::atomic_store_and_explicit(&t, val, order); };
+      auto store_or  = [&](T val, auto order) { std::atomic_store_or_explicit(&t, val, order); };
+      auto store_xor = [&](T val, auto order) { std::atomic_store_xor_explicit(&t, val, order); };
+
+      test_store_operations_integral<T>(load, store, store_add, store_sub, store_and, store_or, store_xor);
+      ASSERT_NOEXCEPT(std::atomic_store_add_explicit(&t, T(0), std::memory_order_seq_cst));
+      ASSERT_NOEXCEPT(std::atomic_store_sub_explicit(&t, T(0), std::memory_order_seq_cst));
+      ASSERT_NOEXCEPT(std::atomic_store_and_explicit(&t, T(0), std::memory_order_seq_cst));
+      ASSERT_NOEXCEPT(std::atomic_store_or_explicit(&t, T(0), std::memory_order_seq_cst));
+      ASSERT_NOEXCEPT(std::atomic_store_xor_explicit(&t, T(0), std::memory_order_seq_cst));
+    }
+    {
+      typedef std::atomic<T> A;
+      volatile A t;
+
+      auto load      = [&]() { return t.load(); };
+      auto store     = [&](T val) { t.store(val); };
+      auto store_add = [&](T val, auto order) { std::atomic_store_add_explicit(&t, val, order); };
+      auto store_sub = [&](T val, auto order) { std::atomic_store_sub_explicit(&t, val, order); };
+      auto store_and = [&](T val, auto order) { std::atomic_store_and_explicit(&t, val, order); };
+      auto store_or  = [&](T val, auto order) { std::atomic_store_or_explicit(&t, val, order); };
+      auto store_xor = [&](T val, auto order) { std::atomic_store_xor_explicit(&t, val, order); };
+
+      test_store_operations_integral<T>(load, store, store_add, store_sub, store_and, store_or, store_xor);
+      ASSERT_NOEXCEPT(std::atomic_store_add_explicit(&t, T(0), std::memory_order_seq_cst));
+      ASSERT_NOEXCEPT(std::atomic_store_sub_explicit(&t, T(0), std::memory_order_seq_cst));
+      ASSERT_NOEXCEPT(std::atomic_store_and_explicit(&t, T(0), std::memory_order_seq_cst));
+      ASSERT_NOEXCEPT(std::atomic_store_or_explicit(&t, T(0), std::memory_order_seq_cst));
+      ASSERT_NOEXCEPT(std::atomic_store_xor_explicit(&t, T(0), std::memory_order_seq_cst));
+    }
+  }
+};
+
+template <class T>
+void testp() {
+  {
+    typedef std::atomic<T> A;
+    A t;
+
+    auto load      = [&]() { return t.load(); };
+    auto store     = [&](T val) { t.store(val); };
+    auto store_add = [&](std::ptrdiff_t val, auto order) { std::atomic_store_add_explicit(&t, val, order); };
+    auto store_sub = [&](std::ptrdiff_t val, auto order) { std::atomic_store_sub_explicit(&t, val, order); };
+
+    test_store_operations_pointer<T>(load, store, store_add, store_sub);
+    ASSERT_NOEXCEPT(std::atomic_store_add_explicit(&t, 0, std::memory_order_seq_cst));
+    ASSERT_NOEXCEPT(std::atomic_store_sub_explicit(&t, 0, std::memory_order_seq_cst));
+  }
+  {
+    typedef std::atomic<T> A;
+    volatile A t;
+
+    auto load      = [&]() { return t.load(); };
+    auto store     = [&](T val) { t.store(val); };
+    auto store_add = [&](std::ptrdiff_t val, auto order) { std::atomic_store_add_explicit(&t, val, order); };
+    auto store_sub = [&](std::ptrdiff_t val, auto order) { std::atomic_store_sub_explicit(&t, val, order); };
+
+    test_store_operations_pointer<T>(load, store, store_add, store_sub);
+    ASSERT_NOEXCEPT(std::atomic_store_add_explicit(&t, 0, std::memory_order_seq_cst));
+    ASSERT_NOEXCEPT(std::atomic_store_sub_explicit(&t, 0, std::memory_order_seq_cst));
+  }
+}
+
+int main(int, char**) {
+  TestEachIntegralType<TestFn>()();
+  testp<int*>();
+  testp<const int*>();
+
+  return 0;
+}

--- a/libcxx/test/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_store_operations_helper.h
+++ b/libcxx/test/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_store_operations_helper.h
@@ -1,0 +1,388 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef TEST_STD_ATOMICS_ATOMIC_STORE_OPERATIONS_HELPER_H
+#define TEST_STD_ATOMICS_ATOMIC_STORE_OPERATIONS_HELPER_H
+
+#include <cassert>
+#include <type_traits>
+
+#include "test_macros.h"
+
+// Test store_* operations for integral types
+// LoadOp: () -> T - reads current value
+// StoreOp: (T) -> void - stores a value
+// StoreAddOp: (T, memory_order) -> void - performs store_add operation
+// StoreSubOp: (T, memory_order) -> void - performs store_sub operation
+// StoreAndOp: (T, memory_order) -> void - performs store_and operation
+// StoreOrOp: (T, memory_order) -> void - performs store_or operation
+// StoreXorOp: (T, memory_order) -> void - performs store_xor operation
+template <class T,
+          class LoadOp,
+          class StoreOp,
+          class StoreAddOp,
+          class StoreSubOp,
+          class StoreAndOp,
+          class StoreOrOp,
+          class StoreXorOp>
+void test_store_operations_integral(
+    LoadOp load,
+    StoreOp store,
+    StoreAddOp store_add,
+    StoreSubOp store_sub,
+    StoreAndOp store_and,
+    StoreOrOp store_or,
+    StoreXorOp store_xor) {
+  static_assert(std::is_integral_v<T>);
+
+  // Test store_add
+  {
+    store(T(1));
+    store_add(T(2), std::memory_order_seq_cst);
+    assert(load() == T(3));
+  }
+
+  {
+    store(T(10));
+    store_add(T(0), std::memory_order_seq_cst);
+    assert(load() == T(10));
+  }
+
+  if constexpr (std::is_signed_v<T>) {
+    store(T(5));
+    store_add(T(-3), std::memory_order_seq_cst);
+    assert(load() == T(2));
+
+    store(T(-10));
+    store_add(T(15), std::memory_order_seq_cst);
+    assert(load() == T(5));
+  }
+
+  {
+    store(T(10));
+    store_add(T(5), std::memory_order_relaxed);
+    assert(load() == T(15));
+  }
+
+  {
+    store(T(20));
+    store_add(T(10), std::memory_order_release);
+    assert(load() == T(30));
+  }
+
+  // Test store_sub
+  {
+    store(T(10));
+    store_sub(T(3), std::memory_order_seq_cst);
+    assert(load() == T(7));
+  }
+
+  {
+    store(T(10));
+    store_sub(T(0), std::memory_order_seq_cst);
+    assert(load() == T(10));
+  }
+
+  if constexpr (std::is_signed_v<T>) {
+    store(T(5));
+    store_sub(T(-3), std::memory_order_seq_cst);
+    assert(load() == T(8));
+
+    store(T(-10));
+    store_sub(T(5), std::memory_order_seq_cst);
+    assert(load() == T(-15));
+  }
+
+  {
+    store(T(20));
+    store_sub(T(5), std::memory_order_relaxed);
+    assert(load() == T(15));
+  }
+
+  {
+    store(T(50));
+    store_sub(T(10), std::memory_order_release);
+    assert(load() == T(40));
+  }
+
+  // Test store_and
+  {
+    store(T(0b1111));
+    store_and(T(0b1010), std::memory_order_seq_cst);
+    assert(load() == T(0b1010));
+  }
+
+  {
+    store(T(0b1111));
+    store_and(T(0b0000), std::memory_order_seq_cst);
+    assert(load() == T(0b0000));
+  }
+
+  {
+    store(T(0b1111));
+    store_and(T(0b1111), std::memory_order_seq_cst);
+    assert(load() == T(0b1111));
+  }
+
+  {
+    store(T(0b1100));
+    store_and(T(0b1010), std::memory_order_relaxed);
+    assert(load() == T(0b1000));
+  }
+
+  {
+    store(T(0b1111));
+    store_and(T(0b0101), std::memory_order_release);
+    assert(load() == T(0b0101));
+  }
+
+  // Test store_or
+  {
+    store(T(0b1010));
+    store_or(T(0b0101), std::memory_order_seq_cst);
+    assert(load() == T(0b1111));
+  }
+
+  {
+    store(T(0b1010));
+    store_or(T(0b0000), std::memory_order_seq_cst);
+    assert(load() == T(0b1010));
+  }
+
+  {
+    store(T(0b0000));
+    store_or(T(0b1111), std::memory_order_seq_cst);
+    assert(load() == T(0b1111));
+  }
+
+  {
+    store(T(0b1000));
+    store_or(T(0b0010), std::memory_order_relaxed);
+    assert(load() == T(0b1010));
+  }
+
+  {
+    store(T(0b0101));
+    store_or(T(0b1010), std::memory_order_release);
+    assert(load() == T(0b1111));
+  }
+
+  // Test store_xor
+  {
+    store(T(0b1100));
+    store_xor(T(0b1010), std::memory_order_seq_cst);
+    assert(load() == T(0b0110));
+  }
+
+  {
+    store(T(0b1010));
+    store_xor(T(0b0000), std::memory_order_seq_cst);
+    assert(load() == T(0b1010));
+  }
+
+  {
+    store(T(0b1111));
+    store_xor(T(0b1111), std::memory_order_seq_cst);
+    assert(load() == T(0b0000));
+  }
+
+  {
+    store(T(0b1100));
+    store_xor(T(0b0110), std::memory_order_relaxed);
+    assert(load() == T(0b1010));
+  }
+
+  {
+    store(T(0b1010));
+    store_xor(T(0b1111), std::memory_order_release);
+    assert(load() == T(0b0101));
+  }
+
+  // Test return types (should all be void)
+  {
+    store(T(1));
+    static_assert(std::is_same_v<decltype(store_add(T(2), std::memory_order_seq_cst)), void>);
+    static_assert(std::is_same_v<decltype(store_sub(T(2), std::memory_order_seq_cst)), void>);
+    static_assert(std::is_same_v<decltype(store_and(T(2), std::memory_order_seq_cst)), void>);
+    static_assert(std::is_same_v<decltype(store_or(T(2), std::memory_order_seq_cst)), void>);
+    static_assert(std::is_same_v<decltype(store_xor(T(2), std::memory_order_seq_cst)), void>);
+  }
+}
+
+// Test store_add and store_sub for floating-point types
+// LoadOp: () -> T - reads current value
+// StoreOp: (T) -> void - stores a value
+// StoreAddOp: (T, memory_order) -> void - performs store_add operation
+// StoreSubOp: (T, memory_order) -> void - performs store_sub operation
+template <class T, class LoadOp, class StoreOp, class StoreAddOp, class StoreSubOp>
+  requires std::is_floating_point_v<T>
+void test_store_operations_floating(LoadOp load, StoreOp store, StoreAddOp store_add, StoreSubOp store_sub) {
+  // Test store_add
+  {
+    store(T(1.5));
+    store_add(T(2.5), std::memory_order_seq_cst);
+    assert(load() == T(4.0));
+  }
+
+  {
+    store(T(10.5));
+    store_add(T(0.0), std::memory_order_seq_cst);
+    assert(load() == T(10.5));
+  }
+
+  {
+    store(T(5.5));
+    store_add(T(-3.5), std::memory_order_seq_cst);
+    assert(load() == T(2.0));
+  }
+
+  {
+    store(T(-10.0));
+    store_add(T(15.5), std::memory_order_seq_cst);
+    assert(load() == T(5.5));
+  }
+
+  {
+    store(T(10.0));
+    store_add(T(5.5), std::memory_order_relaxed);
+    assert(load() == T(15.5));
+  }
+
+  {
+    store(T(20.0));
+    store_add(T(10.5), std::memory_order_release);
+    assert(load() == T(30.5));
+  }
+
+  // Test store_sub
+  {
+    store(T(10.0));
+    store_sub(T(3.5), std::memory_order_seq_cst);
+    assert(load() == T(6.5));
+  }
+
+  {
+    store(T(10.5));
+    store_sub(T(0.0), std::memory_order_seq_cst);
+    assert(load() == T(10.5));
+  }
+
+  {
+    store(T(5.5));
+    store_sub(T(-3.5), std::memory_order_seq_cst);
+    assert(load() == T(9.0));
+  }
+
+  {
+    store(T(-10.0));
+    store_sub(T(5.5), std::memory_order_seq_cst);
+    assert(load() == T(-15.5));
+  }
+
+  {
+    store(T(20.0));
+    store_sub(T(5.5), std::memory_order_relaxed);
+    assert(load() == T(14.5));
+  }
+
+  {
+    store(T(50.0));
+    store_sub(T(10.5), std::memory_order_release);
+    assert(load() == T(39.5));
+  }
+
+  // Test return types (should be void)
+  {
+    store(T(1.0));
+    static_assert(std::is_same_v<decltype(store_add(T(2.0), std::memory_order_seq_cst)), void>);
+    static_assert(std::is_same_v<decltype(store_sub(T(2.0), std::memory_order_seq_cst)), void>);
+  }
+}
+
+// Test store_add and store_sub for pointer types
+// LoadOp: () -> T* - reads current value
+// StoreOp: (T*) -> void - stores a value
+// StoreAddOp: (ptrdiff_t, memory_order) -> void - performs store_add operation
+// StoreSubOp: (ptrdiff_t, memory_order) -> void - performs store_sub operation
+template <class T, class LoadOp, class StoreOp, class StoreAddOp, class StoreSubOp>
+  requires std::is_pointer_v<T>
+void test_store_operations_pointer(LoadOp load, StoreOp store, StoreAddOp store_add, StoreSubOp store_sub) {
+  using X   = std::remove_pointer_t<T>;
+  X arr[10] = {};
+
+  // Test store_add
+  {
+    store(&arr[0]);
+    store_add(3, std::memory_order_seq_cst);
+    assert(load() == &arr[3]);
+  }
+
+  {
+    store(&arr[5]);
+    store_add(0, std::memory_order_seq_cst);
+    assert(load() == &arr[5]);
+  }
+
+  {
+    store(&arr[7]);
+    store_add(-3, std::memory_order_seq_cst);
+    assert(load() == &arr[4]);
+  }
+
+  {
+    store(&arr[0]);
+    store_add(2, std::memory_order_relaxed);
+    assert(load() == &arr[2]);
+  }
+
+  {
+    store(&arr[1]);
+    store_add(4, std::memory_order_release);
+    assert(load() == &arr[5]);
+  }
+
+  // Test store_sub
+  {
+    store(&arr[7]);
+    store_sub(3, std::memory_order_seq_cst);
+    assert(load() == &arr[4]);
+  }
+
+  {
+    store(&arr[5]);
+    store_sub(0, std::memory_order_seq_cst);
+    assert(load() == &arr[5]);
+  }
+
+  {
+    store(&arr[3]);
+    store_sub(-4, std::memory_order_seq_cst);
+    assert(load() == &arr[7]);
+  }
+
+  {
+    store(&arr[9]);
+    store_sub(2, std::memory_order_relaxed);
+    assert(load() == &arr[7]);
+  }
+
+  {
+    store(&arr[8]);
+    store_sub(4, std::memory_order_release);
+    assert(load() == &arr[4]);
+  }
+
+  // Test return types (should be void)
+  {
+    store(&arr[0]);
+    static_assert(std::is_same_v<decltype(store_add(1, std::memory_order_seq_cst)), void>);
+    static_assert(std::is_same_v<decltype(store_sub(1, std::memory_order_seq_cst)), void>);
+  }
+}
+
+#endif // TEST_STD_ATOMICS_ATOMIC_STORE_OPERATIONS_HELPER_H


### PR DESCRIPTION
This PR adds all of P3111 except for the min/max apis, which are blocked on #186694 and #186716 .
Future work is to update these APIs to use intrinsincs.