### PR TITLE
[lldb][test] Skip 32-bit MSVC tests on ARM64 Windows

### DIFF
--- a/lldb/test/Shell/BuildScript/toolchain-msvc.test
+++ b/lldb/test/Shell/BuildScript/toolchain-msvc.test
@@ -1,4 +1,4 @@
-REQUIRES: system-windows, msvc
+REQUIRES: system-windows, msvc, msvc-32-bit
 
 RUN: %build -n --verbose --arch=32 --compiler=msvc --mode=compile-and-link -o %t/foo.exe foobar.c \
 RUN:    | FileCheck --check-prefix=32BIT %s

--- a/lldb/test/Shell/SymbolFile/PDB/class-layout.test
+++ b/lldb/test/Shell/SymbolFile/PDB/class-layout.test
@@ -1,4 +1,4 @@
-REQUIRES: target-windows, msvc
+REQUIRES: target-windows, msvc, msvc-32-bit
 RUN: mkdir -p %t.dir
 RUN: %build --compiler=clang-cl --mode=compile --arch=32 --nodefaultlib --output=%t.dir/ClassLayoutTest.cpp.obj %S/Inputs/ClassLayoutTest.cpp
 RUN: %build --compiler=msvc --mode=link --arch=32 --nodefaultlib --output=%t.dir/ClassLayoutTest.cpp.exe %t.dir/ClassLayoutTest.cpp.obj

--- a/lldb/test/Shell/SymbolFile/PDB/compilands.test
+++ b/lldb/test/Shell/SymbolFile/PDB/compilands.test
@@ -1,4 +1,4 @@
-REQUIRES: target-windows, msvc
+REQUIRES: target-windows, msvc, msvc-32-bit
 RUN: mkdir -p %t.dir
 RUN: %build --compiler=clang-cl --mode=compile --arch=32 --nodefaultlib --output=%t.dir/CompilandsTest.cpp.obj %S/Inputs/CompilandsTest.cpp
 RUN: %build --compiler=msvc --mode=link --arch=32 --nodefaultlib --output=%t.dir/CompilandsTest.cpp.exe %t.dir/CompilandsTest.cpp.obj

--- a/lldb/test/Shell/SymbolFile/PDB/enums-layout.test
+++ b/lldb/test/Shell/SymbolFile/PDB/enums-layout.test
@@ -1,4 +1,4 @@
-REQUIRES: system-windows, msvc
+REQUIRES: system-windows, msvc, msvc-32-bit
 RUN: mkdir -p %t.dir
 RUN: %build --compiler=msvc --arch=32 --nodefaultlib --output=%t.dir/SimpleTypesTest.cpp.enums.exe %S/Inputs/SimpleTypesTest.cpp
 RUN: lldb-test symbols %t.dir/SimpleTypesTest.cpp.enums.exe | FileCheck --check-prefix=ENUM %s

--- a/lldb/test/Shell/SymbolFile/PDB/pointers.test
+++ b/lldb/test/Shell/SymbolFile/PDB/pointers.test
@@ -1,4 +1,4 @@
-REQUIRES: target-windows, msvc
+REQUIRES: target-windows, msvc, msvc-32-bit
 RUN: mkdir -p %t.dir
 RUN: %build --compiler=clang-cl --mode=compile --arch=32 --nodefaultlib --output=%t.dir/PointerTypeTest.cpp.obj %S/Inputs/PointerTypeTest.cpp
 RUN: %build --compiler=msvc --mode=link --arch=32 --nodefaultlib --output=%t.dir/PointerTypeTest.cpp.exe %t.dir/PointerTypeTest.cpp.obj

--- a/lldb/test/Shell/SymbolFile/PDB/type-quals.test
+++ b/lldb/test/Shell/SymbolFile/PDB/type-quals.test
@@ -1,4 +1,4 @@
-REQUIRES: target-windows, msvc
+REQUIRES: target-windows, msvc, msvc-32-bit
 RUN: mkdir -p %t.dir
 RUN: %build --compiler=clang-cl --mode=compile --arch=32 --nodefaultlib --output=%t.dir/TypeQualsTest.cpp.obj %S/Inputs/TypeQualsTest.cpp
 RUN: %build --compiler=msvc --mode=link --arch=32 --nodefaultlib --output=%t.dir/TypeQualsTest.cpp.exe %t.dir/TypeQualsTest.cpp.obj

--- a/lldb/test/Shell/SymbolFile/PDB/typedefs.test
+++ b/lldb/test/Shell/SymbolFile/PDB/typedefs.test
@@ -1,4 +1,4 @@
-REQUIRES: system-windows, msvc
+REQUIRES: system-windows, msvc, msvc-32-bit
 RUN: mkdir -p %t.dir
 RUN: %build --compiler=msvc --arch=32 --nodefaultlib --output=%t.dir/SimpleTypesTest.cpp.typedefs.exe %S/Inputs/SimpleTypesTest.cpp
 RUN: env LLDB_USE_NATIVE_PDB_READER=0 lldb-test symbols %t.dir/SimpleTypesTest.cpp.typedefs.exe | FileCheck %s

--- a/lldb/test/Shell/helper/toolchain.py
+++ b/lldb/test/Shell/helper/toolchain.py
@@ -200,6 +200,21 @@ def _use_msvc_substitutions(config):
     libs = os.getenv("LIB", "").split(";")
 
     config.available_features.add("msvc")
+
+    # Check if the 32-bit MSVC toolchain is available. On ARM64 hosts,
+    # --arch=32 maps to the "arm" toolchain subdirectory, while on x64/x86
+    # hosts it maps to "x86". Visual Studio 2022+ no longer ships the ARM32
+    # MSVC toolchain, so these tests need to be skipped on ARM64 Windows.
+    if platform.uname().machine.lower() == "arm64":
+        msvc_32_arch = "arm"
+    else:
+        msvc_32_arch = "x86"
+
+    compiler_parent_dir = os.path.dirname(os.path.dirname(cl.strip('"')))
+    msvc_32_cl = os.path.join(compiler_parent_dir, msvc_32_arch, "cl.exe")
+    if os.path.exists(msvc_32_cl):
+        config.available_features.add("msvc-32-bit")
+
     compiler_flags = ['"/I{}"'.format(x) for x in includes if os.path.exists(x)]
     linker_flags = ['"/LIBPATH:{}"'.format(x) for x in libs if os.path.exists(x)]
 


### PR DESCRIPTION
We are phasing out Windows 10 SDK from our buildbots in favor of Windows 11 SDK which does not include ARM32 support. Visual Studio is no longer shipped with latest MSVC ARM toolchain. This causes 32-bit MSVC tests to fail on ARM64 Windows hosts.

This patch introduces a new lit feature msvc-32-bit that checks whether the 32-bit MSVC compiler actually exists on the host before enabling tests that depend on it.