### PR TITLE
[clang] atomic fetch op misbehaves on atomic bool

### DIFF
--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -9636,6 +9636,9 @@ def err_atomic_op_needs_atomic_int_or_fp : Error<
 def err_atomic_op_needs_atomic_int : Error<
   "address argument to atomic operation must be a pointer to "
   "%select{|atomic }0integer (%1 invalid)">;
+def err_atomic_op_not_supported_for_bool : Error<
+  "address argument to atomic arithmetic operation must not be a pointer to "
+  "a boolean type (%0 invalid)">;
 def warn_atomic_op_has_invalid_memory_order : Warning<
   "%select{|success |failure }0memory order argument to atomic operation is invalid">,
   InGroup<DiagGroup<"atomic-memory-ordering">>;

--- a/clang/lib/Sema/SemaChecking.cpp
+++ b/clang/lib/Sema/SemaChecking.cpp
@@ -4884,6 +4884,14 @@ ExprResult Sema::BuildAtomicExpr(SourceRange CallRange, SourceRange ExprRange,
   // For an arithmetic operation, the implied arithmetic must be well-formed.
   // For _n operations, the value type must also be a valid atomic type.
   if (Form == Arithmetic || IsN) {
+    // C23 §7.17.7.5p1: atomic arithmetic operations are not permitted on
+    // atomic_bool (_Bool). GCC similarly rejects this. Only applies to
+    // arithmetic forms; non-arithmetic _n ops (load, store, exchange) are fine.
+    if (Form == Arithmetic && ValType->isBooleanType()) {
+      Diag(ExprRange.getBegin(), diag::err_atomic_op_not_supported_for_bool)
+          << Ptr->getType() << Ptr->getSourceRange();
+      return ExprError();
+    }
     // GCC does not enforce these rules for GNU atomics, but we do to help catch
     // trivial type errors.
     auto IsAllowedValueType = [&](QualType ValType,

--- a/clang/test/Sema/atomic-ops.c
+++ b/clang/test/Sema/atomic-ops.c
@@ -915,3 +915,44 @@ void nullPointerWarning(void) {
   (void)__atomic_fetch_max(&vi, 0, memory_order_relaxed);
   (void)__atomic_fetch_max(&i, 0, memory_order_relaxed);
 }
+
+// C23 §7.17.7.5p1: atomic_fetch_* operations are not permitted on atomic_bool.
+void test_atomic_fetch_bool_rejected(atomic_bool *b, _Bool *b_plain) {
+  // C11 stdatomic.h high-level macros
+  atomic_fetch_add(b, 1);                            // expected-error {{must not be a pointer to a boolean type}}
+  atomic_fetch_sub(b, 1);                            // expected-error {{must not be a pointer to a boolean type}}
+  atomic_fetch_and(b, 1);                            // expected-error {{must not be a pointer to a boolean type}}
+  atomic_fetch_or(b, 1);                             // expected-error {{must not be a pointer to a boolean type}}
+  atomic_fetch_xor(b, 1);                            // expected-error {{must not be a pointer to a boolean type}}
+  atomic_fetch_add_explicit(b, 1, memory_order_seq_cst); // expected-error {{must not be a pointer to a boolean type}}
+  atomic_fetch_sub_explicit(b, 1, memory_order_seq_cst); // expected-error {{must not be a pointer to a boolean type}}
+  atomic_fetch_and_explicit(b, 1, memory_order_seq_cst); // expected-error {{must not be a pointer to a boolean type}}
+  atomic_fetch_or_explicit(b, 1, memory_order_seq_cst);  // expected-error {{must not be a pointer to a boolean type}}
+  atomic_fetch_xor_explicit(b, 1, memory_order_seq_cst); // expected-error {{must not be a pointer to a boolean type}}
+
+  // Low-level __c11_atomic_fetch_* builtins
+  __c11_atomic_fetch_add(b, 1, memory_order_seq_cst); // expected-error {{must not be a pointer to a boolean type}}
+  __c11_atomic_fetch_sub(b, 1, memory_order_seq_cst); // expected-error {{must not be a pointer to a boolean type}}
+  __c11_atomic_fetch_and(b, 1, memory_order_seq_cst); // expected-error {{must not be a pointer to a boolean type}}
+  __c11_atomic_fetch_or(b, 1, memory_order_seq_cst);  // expected-error {{must not be a pointer to a boolean type}}
+  __c11_atomic_fetch_xor(b, 1, memory_order_seq_cst); // expected-error {{must not be a pointer to a boolean type}}
+  __c11_atomic_fetch_min(b, 1, memory_order_seq_cst); // expected-error {{must not be a pointer to a boolean type}}
+  __c11_atomic_fetch_max(b, 1, memory_order_seq_cst); // expected-error {{must not be a pointer to a boolean type}}
+
+  // GNU __atomic_fetch_* builtins (take plain pointer, not _Atomic)
+  __atomic_fetch_add(b_plain, 1, memory_order_seq_cst); // expected-error {{must not be a pointer to a boolean type}}
+  __atomic_fetch_sub(b_plain, 1, memory_order_seq_cst); // expected-error {{must not be a pointer to a boolean type}}
+  __atomic_fetch_and(b_plain, 1, memory_order_seq_cst); // expected-error {{must not be a pointer to a boolean type}}
+  __atomic_fetch_or(b_plain, 1, memory_order_seq_cst);  // expected-error {{must not be a pointer to a boolean type}}
+  __atomic_fetch_xor(b_plain, 1, memory_order_seq_cst); // expected-error {{must not be a pointer to a boolean type}}
+  __atomic_fetch_min(b_plain, 1, memory_order_seq_cst); // expected-error {{must not be a pointer to a boolean type}}
+  __atomic_fetch_max(b_plain, 1, memory_order_seq_cst); // expected-error {{must not be a pointer to a boolean type}}
+}
+
+// Non-arithmetic _n ops on _Bool must remain valid. Load/store/exchange are
+// not covered by C23 §7.17.7.5p1 and must not be rejected.
+void test_atomic_n_bool_allowed(_Bool *b_plain) {
+  __atomic_load_n(b_plain, memory_order_seq_cst);
+  __atomic_store_n(b_plain, 1, memory_order_seq_cst);
+  (void)__atomic_exchange_n(b_plain, 1, memory_order_seq_cst);
+}


### PR DESCRIPTION
Resolves: https://github.com/llvm/llvm-project/issues/186682

`atomic_bool` shouldn't be usable by the atomic fetch and modify ops (add, sub, and, or, xor). Like the issue says, clang accepts these and did arithmetic on bools, which other compilers (like GCC) + the standard says should be rejected with an error.

This PR adds a diagnostic that fires for this case. Non-arithmetic operations aren't affected and are provided as negative tests.