### PR TITLE
[orc-rt] Add ControllerInterface symbol table.

### DIFF
--- a/orc-rt/include/CMakeLists.txt
+++ b/orc-rt/include/CMakeLists.txt
@@ -7,6 +7,7 @@ set(ORC_RT_HEADERS
     orc-rt/AllocAction.h
     orc-rt/BitmaskEnum.h
     orc-rt/Compiler.h
+    orc-rt/ControllerInterface.h
     orc-rt/Error.h
     orc-rt/ExecutorAddress.h
     orc-rt/IntervalMap.h

--- a/orc-rt/include/orc-rt/ControllerInterface.h
+++ b/orc-rt/include/orc-rt/ControllerInterface.h
@@ -1,0 +1,79 @@
+//===--- ControllerInterface.h -- Controller Interface Symtab ---*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Controller interface symbol table.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef ORC_RT_CONTROLLERINTERFACE_H
+#define ORC_RT_CONTROLLERINTERFACE_H
+
+#include "orc-rt/Error.h"
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <vector>
+
+namespace orc_rt {
+
+/// A symbol table defining the interface exposed by the ORC runtime to the
+/// controller. Symbols are added via addSymbolsUnique, which rejects
+/// duplicates with an error.
+class ControllerInterface {
+public:
+  using SymbolTable = std::unordered_map<std::string, void *>;
+  using iterator = SymbolTable::const_iterator;
+
+  bool empty() const noexcept { return Symbols.empty(); }
+  size_t size() const noexcept { return Symbols.size(); }
+  iterator begin() const noexcept { return Symbols.begin(); }
+  iterator end() const noexcept { return Symbols.end(); }
+
+  template <typename KeyT> decltype(auto) count(KeyT &&K) const {
+    return Symbols.count(std::forward<KeyT>(K));
+  }
+
+  template <typename KeyT> decltype(auto) at(KeyT &&K) const {
+    return Symbols.at(std::forward<KeyT>(K));
+  }
+
+  /// Adds symbol/address pairs from NewSymbols, first checking that all
+  /// symbols in NewSymbols are unique (i.e. not previously defined).
+  ///
+  /// NewSymbols must not contain any internal duplicates.
+  template <typename SymbolRangeT>
+  Error addSymbolsUnique(SymbolRangeT &&NewSymbols) {
+
+    // First check for duplicates, error out if any are found.
+    {
+      std::vector<std::string_view> Dups;
+      for (auto &[Name, Addr] : NewSymbols)
+        if (Symbols.count(Name))
+          Dups.push_back(Name);
+      if (!Dups.empty())
+        return makeDuplicatesError(std::move(Dups));
+    }
+
+    // No duplicates. Add entries.
+    for (auto &P : NewSymbols) {
+      [[maybe_unused]] bool Added = Symbols.insert(P).second;
+      assert(Added && "NewSymbols contains duplicate definitions");
+    }
+
+    return Error::success();
+  }
+
+private:
+  static Error makeDuplicatesError(std::vector<std::string_view> Dups);
+
+  SymbolTable Symbols;
+};
+
+} // namespace orc_rt
+
+#endif // ORC_RT_CONTROLLERINTERFACE_H

--- a/orc-rt/include/orc-rt/Session.h
+++ b/orc-rt/include/orc-rt/Session.h
@@ -13,6 +13,7 @@
 #ifndef ORC_RT_SESSION_H
 #define ORC_RT_SESSION_H
 
+#include "orc-rt/ControllerInterface.h"
 #include "orc-rt/Error.h"
 #include "orc-rt/LockedAccess.h"
 #include "orc-rt/Service.h"
@@ -50,8 +51,6 @@ public:
   using HandlerTag = void *;
   using OnCallHandlerCompleteFn =
       move_only_function<void(WrapperFunctionBuffer)>;
-
-  using SymbolMap = std::unordered_map<std::string, void *>;
 
   /// Provides access to the controller.
   class ControllerAccess {
@@ -136,10 +135,8 @@ public:
   void reportError(Error Err) { ReportError(std::move(Err)); }
 
   /// Controller interface symbols map.
-  auto controllerInterface() { return LockedAccess(ControllerInterface, M); }
-  auto controllerInterface() const {
-    return LockedAccess(ControllerInterface, M);
-  }
+  auto controllerInterface() { return LockedAccess(CI, M); }
+  auto controllerInterface() const { return LockedAccess(CI, M); }
 
   /// Initiate session shutdown.
   ///
@@ -213,7 +210,7 @@ private:
 
   mutable std::mutex M;
   std::vector<std::unique_ptr<Service>> Services;
-  SymbolMap ControllerInterface;
+  ControllerInterface CI;
   std::unique_ptr<ShutdownInfo> SI;
 };
 

--- a/orc-rt/lib/executor/CMakeLists.txt
+++ b/orc-rt/lib/executor/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(files
   AllocAction.cpp
+  ControllerInterface.cpp
   Error.cpp
   QueueingTaskDispatcher.cpp
   RTTI.cpp

--- a/orc-rt/lib/executor/ControllerInterface.cpp
+++ b/orc-rt/lib/executor/ControllerInterface.cpp
@@ -1,0 +1,34 @@
+//===- ControllerInterface.cpp --------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Contains the implementation of APIs in the orc-rt/ControllerInterface.h
+// header.
+//
+//===----------------------------------------------------------------------===//
+
+#include "orc-rt/ControllerInterface.h"
+#include "orc-rt/iterator_range.h"
+
+#include <algorithm>
+
+namespace orc_rt {
+
+Error ControllerInterface::makeDuplicatesError(
+    std::vector<std::string_view> Dups) {
+  std::sort(Dups.begin(), Dups.end());
+  std::string ErrMsg = "Could not add duplicate symbols: [ ";
+  ErrMsg += Dups.front();
+  for (auto &Dup : iterator_range(std::next(Dups.begin()), Dups.end())) {
+    ErrMsg += ", ";
+    ErrMsg += Dup;
+  }
+  ErrMsg += " ]";
+  return make_error<StringError>(std::move(ErrMsg));
+}
+
+} // namespace orc_rt

--- a/orc-rt/lib/executor/Session.cpp
+++ b/orc-rt/lib/executor/Session.cpp
@@ -19,7 +19,10 @@ Session::ControllerAccess::~ControllerAccess() = default;
 Session::Session(std::unique_ptr<TaskDispatcher> Dispatcher,
                  ErrorReporterFn ReportError)
     : Dispatcher(std::move(Dispatcher)), ReportError(std::move(ReportError)) {
-  ControllerInterface["orc_rt_SessionInstance"] = static_cast<void *>(this);
+  std::pair<const char *, void *> InitialSymbols[] = {
+      {"orc_rt_SessionInstance", static_cast<void *>(this)}};
+
+  cantFail(CI.addSymbolsUnique(InitialSymbols));
 }
 
 Session::~Session() { waitForShutdown(); }

--- a/orc-rt/unittests/CMakeLists.txt
+++ b/orc-rt/unittests/CMakeLists.txt
@@ -15,6 +15,7 @@ add_orc_rt_unittest(CoreTests
   AllocActionTest.cpp
   BitmaskEnumTest.cpp
   CallableTraitsHelperTest.cpp
+  ControllerInterfaceTest.cpp
   EndianTest.cpp
   ErrorCAPITest.cpp
   ErrorTest.cpp

--- a/orc-rt/unittests/ControllerInterfaceTest.cpp
+++ b/orc-rt/unittests/ControllerInterfaceTest.cpp
@@ -79,10 +79,12 @@ TEST(ControllerInterfaceTest, AddSymbolsUniqueMultipleDuplicates) {
   ControllerInterface CI;
   int X = 0, Y = 0, Z = 0;
 
-  std::pair<const char *, void *> First[] = {{"orc_rt_A", &X}, {"orc_rt_B", &Y}};
+  std::pair<const char *, void *> First[] = {{"orc_rt_A", &X},
+                                             {"orc_rt_B", &Y}};
   cantFail(CI.addSymbolsUnique(First));
 
-  std::pair<const char *, void *> Second[] = {{"orc_rt_A", &Z}, {"orc_rt_B", &Z}};
+  std::pair<const char *, void *> Second[] = {{"orc_rt_A", &Z},
+                                              {"orc_rt_B", &Z}};
   auto Err = CI.addSymbolsUnique(Second);
   EXPECT_TRUE(Err.isA<StringError>());
 

--- a/orc-rt/unittests/ControllerInterfaceTest.cpp
+++ b/orc-rt/unittests/ControllerInterfaceTest.cpp
@@ -1,0 +1,132 @@
+//===- ControllerInterfaceTest.cpp ----------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Tests for orc-rt's ControllerInterface.h APIs.
+//
+//===----------------------------------------------------------------------===//
+
+#include "orc-rt/ControllerInterface.h"
+#include "gtest/gtest.h"
+
+#include <set>
+#include <string>
+
+using namespace orc_rt;
+
+TEST(ControllerInterfaceTest, EmptyByDefault) {
+  ControllerInterface CI;
+  EXPECT_TRUE(CI.empty());
+  EXPECT_EQ(CI.size(), 0U);
+  EXPECT_EQ(CI.begin(), CI.end());
+}
+
+TEST(ControllerInterfaceTest, AddSymbolsUnique) {
+  ControllerInterface CI;
+  int X = 0, Y = 0;
+  std::pair<const char *, void *> Syms[] = {{"orc_rt_A", &X}, {"orc_rt_B", &Y}};
+
+  auto Err = CI.addSymbolsUnique(Syms);
+  EXPECT_FALSE(Err) << "Unexpected error adding unique symbols";
+
+  EXPECT_EQ(CI.size(), 2U);
+  EXPECT_FALSE(CI.empty());
+  EXPECT_TRUE(CI.count("orc_rt_A"));
+  EXPECT_TRUE(CI.count("orc_rt_B"));
+  EXPECT_EQ(CI.at("orc_rt_A"), &X);
+  EXPECT_EQ(CI.at("orc_rt_B"), &Y);
+}
+
+TEST(ControllerInterfaceTest, AddSymbolsUniqueMultipleCalls) {
+  ControllerInterface CI;
+  int X = 0, Y = 0;
+
+  std::pair<const char *, void *> First[] = {{"orc_rt_A", &X}};
+  std::pair<const char *, void *> Second[] = {{"orc_rt_B", &Y}};
+
+  cantFail(CI.addSymbolsUnique(First));
+  cantFail(CI.addSymbolsUnique(Second));
+
+  EXPECT_EQ(CI.size(), 2U);
+  EXPECT_EQ(CI.at("orc_rt_A"), &X);
+  EXPECT_EQ(CI.at("orc_rt_B"), &Y);
+}
+
+TEST(ControllerInterfaceTest, AddSymbolsUniqueDuplicateRejected) {
+  ControllerInterface CI;
+  int X = 0, Y = 0;
+
+  std::pair<const char *, void *> First[] = {{"orc_rt_A", &X}};
+  cantFail(CI.addSymbolsUnique(First));
+
+  std::pair<const char *, void *> Second[] = {{"orc_rt_A", &Y}};
+  auto Err = CI.addSymbolsUnique(Second);
+  EXPECT_TRUE(Err.isA<StringError>());
+
+  auto ErrMsg = toString(std::move(Err));
+  EXPECT_NE(ErrMsg.find("orc_rt_A"), std::string::npos)
+      << "Error message should mention the duplicate symbol name";
+
+  // Original not overwritten.
+  EXPECT_EQ(CI.at("orc_rt_A"), &X);
+}
+
+TEST(ControllerInterfaceTest, AddSymbolsUniqueMultipleDuplicates) {
+  ControllerInterface CI;
+  int X = 0, Y = 0, Z = 0;
+
+  std::pair<const char *, void *> First[] = {{"orc_rt_A", &X}, {"orc_rt_B", &Y}};
+  cantFail(CI.addSymbolsUnique(First));
+
+  std::pair<const char *, void *> Second[] = {{"orc_rt_A", &Z}, {"orc_rt_B", &Z}};
+  auto Err = CI.addSymbolsUnique(Second);
+  EXPECT_TRUE(Err.isA<StringError>());
+
+  auto ErrMsg = toString(std::move(Err));
+  EXPECT_NE(ErrMsg.find("orc_rt_A"), std::string::npos);
+  EXPECT_NE(ErrMsg.find("orc_rt_B"), std::string::npos);
+
+  // Originals not overwritten.
+  EXPECT_EQ(CI.at("orc_rt_A"), &X);
+  EXPECT_EQ(CI.at("orc_rt_B"), &Y);
+}
+
+TEST(ControllerInterfaceTest, AddSymbolsUniqueAllOrNothing) {
+  ControllerInterface CI;
+  int X = 0, Y = 0, Z = 0;
+
+  std::pair<const char *, void *> First[] = {{"orc_rt_existing", &X}};
+  cantFail(CI.addSymbolsUnique(First));
+
+  // One new, one duplicate — neither should be added.
+  std::pair<const char *, void *> Second[] = {{"orc_rt_new", &Y},
+                                              {"orc_rt_existing", &Z}};
+  auto Err = CI.addSymbolsUnique(Second);
+  EXPECT_TRUE(Err.isA<StringError>());
+  consumeError(std::move(Err));
+
+  EXPECT_EQ(CI.size(), 1U);
+  EXPECT_EQ(CI.at("orc_rt_existing"), &X);
+  EXPECT_FALSE(CI.count("orc_rt_new"));
+}
+
+TEST(ControllerInterfaceTest, Iteration) {
+  ControllerInterface CI;
+  int X = 0, Y = 0, Z = 0;
+  std::pair<const char *, void *> Syms[] = {
+      {"orc_rt_A", &X}, {"orc_rt_B", &Y}, {"orc_rt_C", &Z}};
+  cantFail(CI.addSymbolsUnique(Syms));
+
+  std::set<std::string> Names;
+  for (auto &[Name, Addr] : CI)
+    Names.insert(Name);
+
+  EXPECT_EQ(Names.size(), 3U);
+  EXPECT_TRUE(Names.count("orc_rt_A"));
+  EXPECT_TRUE(Names.count("orc_rt_B"));
+  EXPECT_TRUE(Names.count("orc_rt_C"));
+}

--- a/orc-rt/unittests/SessionTest.cpp
+++ b/orc-rt/unittests/SessionTest.cpp
@@ -397,9 +397,11 @@ TEST(SessionTest, ControllerInterfaceContainsSessionByDefault) {
 TEST(SessionTest, ControllerInterfaceWithRef) {
   Session S(std::make_unique<NoDispatcher>(), noErrors);
   int X = 0, Y = 0;
-  S.controllerInterface().with_ref([&](Session::SymbolMap &Syms) {
-    Syms["orc_rt_A"] = &X;
-    Syms["orc_rt_B"] = &Y;
+  S.controllerInterface().with_ref([&](ControllerInterface &CI) {
+    std::pair<const char *, void *> Syms[] = {
+        {"orc_rt_A", static_cast<void *>(&X)},
+        {"orc_rt_B", static_cast<void *>(&Y)}};
+    cantFail(CI.addSymbolsUnique(Syms));
   });
 
   EXPECT_EQ(S.controllerInterface()->at("orc_rt_A"), &X);
@@ -409,7 +411,8 @@ TEST(SessionTest, ControllerInterfaceWithRef) {
 TEST(SessionTest, ControllerInterfaceConstAccess) {
   Session S(std::make_unique<NoDispatcher>(), noErrors);
   int X = 0;
-  S.controllerInterface()->emplace("orc_rt_X", &X);
+  std::pair<const char *, void *> Syms[] = {{"orc_rt_X", &X}};
+  cantFail(S.controllerInterface()->addSymbolsUnique(Syms));
 
   const Session &CS = S;
   ASSERT_TRUE(CS.controllerInterface()->count("orc_rt_X"));


### PR DESCRIPTION
ControllerInterface holds the set of named symbols that the ORC runtime exposes to the controller for bootstrapping the ExecutionSession. Insertion is checked: duplicate symbols are rejected with an error.

Session is updated to own a ControllerInterface instance, pre-populated with an orc_rt_SessionInstance entry pointing to the Session object.