### PR TITLE
[clang-tidy] Fix false positives for dependent initializers

### DIFF
--- a/clang-tools-extra/clang-tidy/readability/NonConstParameterCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/NonConstParameterCheck.cpp
@@ -103,10 +103,26 @@ void NonConstParameterCheck::check(const MatchFinder::MatchResult &Result) {
     }
   } else if (const auto *VD = Result.Nodes.getNodeAs<VarDecl>("Mark")) {
     const QualType T = VD->getType();
-    if (T->isDependentType())
-      markCanNotBeConst(VD->getInit(), false);
-    else if ((T->isPointerType() && !T->getPointeeType().isConstQualified()) ||
-             T->isArrayType() || T->isRecordType())
+    if (T->isDependentType()) {
+      const Expr *Init = VD->getInit()->IgnoreParenCasts();
+      if (const auto *U = dyn_cast<UnaryOperator>(Init);
+          U && U->getOpcode() == UO_Deref) {
+        markCanNotBeConst(U->getSubExpr(), true);
+      } else if (const auto *PLE = dyn_cast<ParenListExpr>(Init)) {
+        for (unsigned I = 0; I < PLE->getNumExprs(); ++I) {
+          const Expr *E = PLE->getExpr(I)->IgnoreParenCasts();
+          if (const auto *U = dyn_cast<UnaryOperator>(E);
+              U && U->getOpcode() == UO_Deref)
+            markCanNotBeConst(U->getSubExpr(), true);
+          else
+            markCanNotBeConst(E, true);
+        }
+      } else {
+        markCanNotBeConst(Init, true);
+      }
+    } else if ((T->isPointerType() &&
+                !T->getPointeeType().isConstQualified()) ||
+               T->isArrayType() || T->isRecordType())
       markCanNotBeConst(VD->getInit(), true);
     else if (T->isLValueReferenceType() &&
              !T->getPointeeType().isConstQualified())

--- a/clang-tools-extra/clang-tidy/readability/NonConstParameterCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/NonConstParameterCheck.cpp
@@ -122,10 +122,10 @@ void NonConstParameterCheck::check(const MatchFinder::MatchResult &Result) {
       }
     } else if ((T->isPointerType() &&
                 !T->getPointeeType().isConstQualified()) ||
-               T->isArrayType() || T->isRecordType())
+               T->isArrayType() || T->isRecordType()) {
       markCanNotBeConst(VD->getInit(), true);
-    else if (T->isLValueReferenceType() &&
-             !T->getPointeeType().isConstQualified())
+    } else if (T->isLValueReferenceType() &&
+               !T->getPointeeType().isConstQualified())
       markCanNotBeConst(VD->getInit(), false);
   }
 }

--- a/clang-tools-extra/clang-tidy/readability/NonConstParameterCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/NonConstParameterCheck.cpp
@@ -125,8 +125,9 @@ void NonConstParameterCheck::check(const MatchFinder::MatchResult &Result) {
                T->isArrayType() || T->isRecordType()) {
       markCanNotBeConst(VD->getInit(), true);
     } else if (T->isLValueReferenceType() &&
-               !T->getPointeeType().isConstQualified())
+               !T->getPointeeType().isConstQualified()) {
       markCanNotBeConst(VD->getInit(), false);
+    }
   }
 }
 

--- a/clang-tools-extra/clang-tidy/readability/NonConstParameterCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/NonConstParameterCheck.cpp
@@ -109,8 +109,8 @@ void NonConstParameterCheck::check(const MatchFinder::MatchResult &Result) {
           U && U->getOpcode() == UO_Deref) {
         markCanNotBeConst(U->getSubExpr(), true);
       } else if (const auto *PLE = dyn_cast<ParenListExpr>(Init)) {
-        for (unsigned I = 0; I < PLE->getNumExprs(); ++I) {
-          const Expr *E = PLE->getExpr(I)->IgnoreParenCasts();
+        for (const Expr *E : PLE->exprs()) {
+          E = E->IgnoreParenCasts();
           if (const auto *U = dyn_cast<UnaryOperator>(E);
               U && U->getOpcode() == UO_Deref)
             markCanNotBeConst(U->getSubExpr(), true);

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -582,7 +582,7 @@ Changes in existing checks
   <clang-tidy/checks/readability/non-const-parameter>` check:
 
   - Avoid false positives on parameters used in dependent expressions
-    (e.g. inside generic lambdas).
+    (e.g. inside generic lambdas), including constructor-style dependent initializers.
 
   - Fixed a false positive in array subscript expressions where the types are
     not yet resolved.

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/non-const-parameter.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/non-const-parameter.cpp
@@ -387,16 +387,47 @@ void useDependentArray() {
   double ToFill[2] = {};
   dependentArray1(ToFill, 0, 1.0);
   dependentArray2(ToFill, 0, 1.0);
+void testGenericLambdaIssue177354EqualsInit() {
+  // CHECK-MESSAGES-NOT: warning: pointer parameter 'p' can be pointer to const
+  auto genericLambda = []<typename T>(int *p) {
+    T x = *p;
+  };
+}
+
+void testGenericLambdaIssue177354Parens() {
+  // CHECK-MESSAGES-NOT: warning: pointer parameter 'p' can be pointer to const
+  auto genericLambda = []<typename T>(int *p) {
+    T x((*p));
+  };
+}
+
 template <typename T>
 struct DependentCtor {
   DependentCtor(int *p);
 };
 
+template <typename T>
+struct DependentCtor2 {
+  DependentCtor2(int *p, int *q);
+};
+
 void dependentInitInGenericLambda() {
+  // CHECK-MESSAGES-NOT: warning: pointer parameter 'p' can be pointer to const
   auto lambda = []<typename T>(int *p) {
     DependentCtor<T> s(p);
   };
+}
 
-  int x = 0;
-  lambda.operator()<int>(&x);
+void dependentInitInGenericLambdaParens() {
+  // CHECK-MESSAGES-NOT: warning: pointer parameter 'p' can be pointer to const
+  auto lambda = []<typename T>(int *p) {
+    DependentCtor<T> s((p));
+  };
+}
+
+void dependentInitInGenericLambdaMultiArg() {
+  // CHECK-MESSAGES-NOT: warning: pointer parameter 'p' can be pointer to const
+  auto lambda = []<typename T>(int *p) {
+    DependentCtor2<T> s(p, p);
+  };
 }

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/non-const-parameter.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/non-const-parameter.cpp
@@ -387,4 +387,16 @@ void useDependentArray() {
   double ToFill[2] = {};
   dependentArray1(ToFill, 0, 1.0);
   dependentArray2(ToFill, 0, 1.0);
+template <typename T>
+struct DependentCtor {
+  DependentCtor(int *p);
+};
+
+void dependentInitInGenericLambda() {
+  auto lambda = []<typename T>(int *p) {
+    DependentCtor<T> s(p);
+  };
+
+  int x = 0;
+  lambda.operator()<int>(&x);
 }

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/non-const-parameter.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/non-const-parameter.cpp
@@ -387,6 +387,8 @@ void useDependentArray() {
   double ToFill[2] = {};
   dependentArray1(ToFill, 0, 1.0);
   dependentArray2(ToFill, 0, 1.0);
+}
+
 void testGenericLambdaIssue177354EqualsInit() {
   // CHECK-MESSAGES-NOT: warning: pointer parameter 'p' can be pointer to const
   auto genericLambda = []<typename T>(int *p) {


### PR DESCRIPTION
Fixes #177354.

Handle dependent initializers in `readability-non-const-parameter` more conservatively to avoid false positives in generic lambdas.

This fixes cases like:
- `T x(*p)`
- `DependentCtor<T> s(p)`

Testing:
- `llvm-lit -sv clang-tools-extra/test/clang-tidy/checkers/readability/non-const-parameter.cpp`