### PR TITLE
[orc-rt] Hold `const void*` rather than `void*` in ControllerInterface.

### DIFF
--- a/orc-rt/include/orc-rt/ControllerInterface.h
+++ b/orc-rt/include/orc-rt/ControllerInterface.h
@@ -26,7 +26,7 @@ namespace orc_rt {
 /// duplicates with an error.
 class ControllerInterface {
 public:
-  using SymbolTable = std::unordered_map<std::string, void *>;
+  using SymbolTable = std::unordered_map<std::string, const void *>;
   using iterator = SymbolTable::const_iterator;
 
   bool empty() const noexcept { return Symbols.empty(); }

--- a/orc-rt/unittests/ControllerInterfaceTest.cpp
+++ b/orc-rt/unittests/ControllerInterfaceTest.cpp
@@ -41,6 +41,18 @@ TEST(ControllerInterfaceTest, AddSymbolsUnique) {
   EXPECT_EQ(CI.at("orc_rt_B"), &Y);
 }
 
+TEST(ControllerInterfaceTest, AddConstPointers) {
+  ControllerInterface CI;
+  const int X = 42;
+  const int Y = 7;
+  std::pair<const char *, const void *> Syms[] = {{"orc_rt_A", &X},
+                                                  {"orc_rt_B", &Y}};
+  cantFail(CI.addSymbolsUnique(Syms));
+
+  EXPECT_EQ(CI.at("orc_rt_A"), &X);
+  EXPECT_EQ(CI.at("orc_rt_B"), &Y);
+}
+
 TEST(ControllerInterfaceTest, AddSymbolsUniqueMultipleCalls) {
   ControllerInterface CI;
   int X = 0, Y = 0;


### PR DESCRIPTION
We only care about addresses in ControllerInterface, not the underlying memory.