### PR TITLE
 [RISCV] Select (sext_inreg (sra X, C), i8/i16) as slli+srai.

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVISelDAGToDAG.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelDAGToDAG.cpp
@@ -1443,6 +1443,38 @@ void RISCVDAGToDAGISel::Select(SDNode *Node) {
     ReplaceNode(Node, SRAI);
     return;
   }
+  case ISD::SIGN_EXTEND_INREG: {
+    // Optimize (sext_inreg (srl X, C), i8/i16) ->
+    //          (srai (slli X, XLen-ExtSize-C), XLen-ExtSize)
+    // This is a bitfield extract pattern where we're extracting a signed
+    // 8-bit or 16-bit field from position C.
+    SDValue N0 = Node->getOperand(0);
+    if (N0.getOpcode() != ISD::SRL || !N0.hasOneUse())
+      break;
+
+    auto *ShAmtC = dyn_cast<ConstantSDNode>(N0.getOperand(1));
+    if (!ShAmtC)
+      break;
+
+    unsigned ExtSize =
+        cast<VTSDNode>(Node->getOperand(1))->getVT().getSizeInBits();
+    unsigned ShAmt = ShAmtC->getZExtValue();
+    unsigned XLen = Subtarget->getXLen();
+
+    // Only handle types less than 32, and make sure the shift amount is valid.
+    if (ExtSize >= 32 || ShAmt >= XLen - ExtSize)
+      break;
+
+    unsigned LShAmt = XLen - ExtSize - ShAmt;
+    SDNode *SLLI =
+        CurDAG->getMachineNode(RISCV::SLLI, DL, VT, N0.getOperand(0),
+                               CurDAG->getTargetConstant(LShAmt, DL, VT));
+    SDNode *SRAI = CurDAG->getMachineNode(
+        RISCV::SRAI, DL, VT, SDValue(SLLI, 0),
+        CurDAG->getTargetConstant(XLen - ExtSize, DL, VT));
+    ReplaceNode(Node, SRAI);
+    return;
+  }
   case ISD::OR: {
     if (tryShrinkShlLogicImm(Node))
       return;

--- a/llvm/test/CodeGen/RISCV/rv32zbb.ll
+++ b/llvm/test/CodeGen/RISCV/rv32zbb.ll
@@ -935,17 +935,11 @@ define i64 @sexth_i64(i64 %a) nounwind {
 }
 
 define i32 @sextb_extract_i32(i32 %x) {
-; RV32I-LABEL: sextb_extract_i32:
-; RV32I:       # %bb.0:
-; RV32I-NEXT:    slli a0, a0, 15
-; RV32I-NEXT:    srai a0, a0, 24
-; RV32I-NEXT:    ret
-;
-; RV32ZBB-LABEL: sextb_extract_i32:
-; RV32ZBB:       # %bb.0:
-; RV32ZBB-NEXT:    srli a0, a0, 9
-; RV32ZBB-NEXT:    sext.b a0, a0
-; RV32ZBB-NEXT:    ret
+; CHECK-LABEL: sextb_extract_i32:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    slli a0, a0, 15
+; CHECK-NEXT:    srai a0, a0, 24
+; CHECK-NEXT:    ret
   %a = lshr i32 %x, 9
   %b = trunc i32 %a to i8
   %c = sext i8 %b to i32
@@ -962,8 +956,8 @@ define i64 @sextb_extract_i64(i64 %x) {
 ;
 ; RV32ZBB-LABEL: sextb_extract_i64:
 ; RV32ZBB:       # %bb.0:
-; RV32ZBB-NEXT:    srli a1, a1, 13
-; RV32ZBB-NEXT:    sext.b a0, a1
+; RV32ZBB-NEXT:    slli a0, a1, 11
+; RV32ZBB-NEXT:    srai a0, a0, 24
 ; RV32ZBB-NEXT:    srai a1, a0, 31
 ; RV32ZBB-NEXT:    ret
   %a = lshr i64 %x, 45
@@ -973,17 +967,11 @@ define i64 @sextb_extract_i64(i64 %x) {
 }
 
 define i32 @sexth_extract_i32(i32 %x) {
-; RV32I-LABEL: sexth_extract_i32:
-; RV32I:       # %bb.0:
-; RV32I-NEXT:    slli a0, a0, 3
-; RV32I-NEXT:    srai a0, a0, 16
-; RV32I-NEXT:    ret
-;
-; RV32ZBB-LABEL: sexth_extract_i32:
-; RV32ZBB:       # %bb.0:
-; RV32ZBB-NEXT:    srli a0, a0, 13
-; RV32ZBB-NEXT:    sext.h a0, a0
-; RV32ZBB-NEXT:    ret
+; CHECK-LABEL: sexth_extract_i32:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    slli a0, a0, 3
+; CHECK-NEXT:    srai a0, a0, 16
+; CHECK-NEXT:    ret
   %a = lshr i32 %x, 13
   %b = trunc i32 %a to i16
   %c = sext i16 %b to i32
@@ -1000,8 +988,8 @@ define i64 @sexth_extract_i64(i64 %x) {
 ;
 ; RV32ZBB-LABEL: sexth_extract_i64:
 ; RV32ZBB:       # %bb.0:
-; RV32ZBB-NEXT:    srli a1, a1, 5
-; RV32ZBB-NEXT:    sext.h a0, a1
+; RV32ZBB-NEXT:    slli a0, a1, 11
+; RV32ZBB-NEXT:    srai a0, a0, 16
 ; RV32ZBB-NEXT:    srai a1, a0, 31
 ; RV32ZBB-NEXT:    ret
   %a = lshr i64 %x, 37

--- a/llvm/test/CodeGen/RISCV/rv32zbb.ll
+++ b/llvm/test/CodeGen/RISCV/rv32zbb.ll
@@ -934,13 +934,89 @@ define i64 @sexth_i64(i64 %a) nounwind {
   ret i64 %shr
 }
 
+define i32 @sextb_extract_i32(i32 %x) {
+; RV32I-LABEL: sextb_extract_i32:
+; RV32I:       # %bb.0:
+; RV32I-NEXT:    slli a0, a0, 15
+; RV32I-NEXT:    srai a0, a0, 24
+; RV32I-NEXT:    ret
+;
+; RV32ZBB-LABEL: sextb_extract_i32:
+; RV32ZBB:       # %bb.0:
+; RV32ZBB-NEXT:    srli a0, a0, 9
+; RV32ZBB-NEXT:    sext.b a0, a0
+; RV32ZBB-NEXT:    ret
+  %a = lshr i32 %x, 9
+  %b = trunc i32 %a to i8
+  %c = sext i8 %b to i32
+  ret i32 %c
+}
+
+define i64 @sextb_extract_i64(i64 %x) {
+; RV32I-LABEL: sextb_extract_i64:
+; RV32I:       # %bb.0:
+; RV32I-NEXT:    slli a1, a1, 11
+; RV32I-NEXT:    srai a0, a1, 24
+; RV32I-NEXT:    srai a1, a1, 31
+; RV32I-NEXT:    ret
+;
+; RV32ZBB-LABEL: sextb_extract_i64:
+; RV32ZBB:       # %bb.0:
+; RV32ZBB-NEXT:    srli a1, a1, 13
+; RV32ZBB-NEXT:    sext.b a0, a1
+; RV32ZBB-NEXT:    srai a1, a0, 31
+; RV32ZBB-NEXT:    ret
+  %a = lshr i64 %x, 45
+  %b = trunc i64 %a to i8
+  %c = sext i8 %b to i64
+  ret i64 %c
+}
+
+define i32 @sexth_extract_i32(i32 %x) {
+; RV32I-LABEL: sexth_extract_i32:
+; RV32I:       # %bb.0:
+; RV32I-NEXT:    slli a0, a0, 3
+; RV32I-NEXT:    srai a0, a0, 16
+; RV32I-NEXT:    ret
+;
+; RV32ZBB-LABEL: sexth_extract_i32:
+; RV32ZBB:       # %bb.0:
+; RV32ZBB-NEXT:    srli a0, a0, 13
+; RV32ZBB-NEXT:    sext.h a0, a0
+; RV32ZBB-NEXT:    ret
+  %a = lshr i32 %x, 13
+  %b = trunc i32 %a to i16
+  %c = sext i16 %b to i32
+  ret i32 %c
+}
+
+define i64 @sexth_extract_i64(i64 %x) {
+; RV32I-LABEL: sexth_extract_i64:
+; RV32I:       # %bb.0:
+; RV32I-NEXT:    slli a1, a1, 11
+; RV32I-NEXT:    srai a0, a1, 16
+; RV32I-NEXT:    srai a1, a1, 31
+; RV32I-NEXT:    ret
+;
+; RV32ZBB-LABEL: sexth_extract_i64:
+; RV32ZBB:       # %bb.0:
+; RV32ZBB-NEXT:    srli a1, a1, 5
+; RV32ZBB-NEXT:    sext.h a0, a1
+; RV32ZBB-NEXT:    srai a1, a0, 31
+; RV32ZBB-NEXT:    ret
+  %a = lshr i64 %x, 37
+  %b = trunc i64 %a to i16
+  %c = sext i16 %b to i64
+  ret i64 %c
+}
+
 define i32 @min_i32(i32 %a, i32 %b) nounwind {
 ; RV32I-LABEL: min_i32:
 ; RV32I:       # %bb.0:
-; RV32I-NEXT:    blt a0, a1, .LBB28_2
+; RV32I-NEXT:    blt a0, a1, .LBB32_2
 ; RV32I-NEXT:  # %bb.1:
 ; RV32I-NEXT:    mv a0, a1
-; RV32I-NEXT:  .LBB28_2:
+; RV32I-NEXT:  .LBB32_2:
 ; RV32I-NEXT:    ret
 ;
 ; RV32ZBB-LABEL: min_i32:
@@ -960,18 +1036,18 @@ define i32 @min_i32(i32 %a, i32 %b) nounwind {
 define i64 @min_i64(i64 %a, i64 %b) nounwind {
 ; CHECK-LABEL: min_i64:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    beq a1, a3, .LBB29_2
+; CHECK-NEXT:    beq a1, a3, .LBB33_2
 ; CHECK-NEXT:  # %bb.1:
 ; CHECK-NEXT:    slt a4, a1, a3
-; CHECK-NEXT:    beqz a4, .LBB29_3
-; CHECK-NEXT:    j .LBB29_4
-; CHECK-NEXT:  .LBB29_2:
+; CHECK-NEXT:    beqz a4, .LBB33_3
+; CHECK-NEXT:    j .LBB33_4
+; CHECK-NEXT:  .LBB33_2:
 ; CHECK-NEXT:    sltu a4, a0, a2
-; CHECK-NEXT:    bnez a4, .LBB29_4
-; CHECK-NEXT:  .LBB29_3:
+; CHECK-NEXT:    bnez a4, .LBB33_4
+; CHECK-NEXT:  .LBB33_3:
 ; CHECK-NEXT:    mv a0, a2
 ; CHECK-NEXT:    mv a1, a3
-; CHECK-NEXT:  .LBB29_4:
+; CHECK-NEXT:  .LBB33_4:
 ; CHECK-NEXT:    ret
   %cmp = icmp slt i64 %a, %b
   %cond = select i1 %cmp, i64 %a, i64 %b
@@ -981,10 +1057,10 @@ define i64 @min_i64(i64 %a, i64 %b) nounwind {
 define i32 @max_i32(i32 %a, i32 %b) nounwind {
 ; RV32I-LABEL: max_i32:
 ; RV32I:       # %bb.0:
-; RV32I-NEXT:    blt a1, a0, .LBB30_2
+; RV32I-NEXT:    blt a1, a0, .LBB34_2
 ; RV32I-NEXT:  # %bb.1:
 ; RV32I-NEXT:    mv a0, a1
-; RV32I-NEXT:  .LBB30_2:
+; RV32I-NEXT:  .LBB34_2:
 ; RV32I-NEXT:    ret
 ;
 ; RV32ZBB-LABEL: max_i32:
@@ -1004,18 +1080,18 @@ define i32 @max_i32(i32 %a, i32 %b) nounwind {
 define i64 @max_i64(i64 %a, i64 %b) nounwind {
 ; CHECK-LABEL: max_i64:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    beq a1, a3, .LBB31_2
+; CHECK-NEXT:    beq a1, a3, .LBB35_2
 ; CHECK-NEXT:  # %bb.1:
 ; CHECK-NEXT:    slt a4, a3, a1
-; CHECK-NEXT:    beqz a4, .LBB31_3
-; CHECK-NEXT:    j .LBB31_4
-; CHECK-NEXT:  .LBB31_2:
+; CHECK-NEXT:    beqz a4, .LBB35_3
+; CHECK-NEXT:    j .LBB35_4
+; CHECK-NEXT:  .LBB35_2:
 ; CHECK-NEXT:    sltu a4, a2, a0
-; CHECK-NEXT:    bnez a4, .LBB31_4
-; CHECK-NEXT:  .LBB31_3:
+; CHECK-NEXT:    bnez a4, .LBB35_4
+; CHECK-NEXT:  .LBB35_3:
 ; CHECK-NEXT:    mv a0, a2
 ; CHECK-NEXT:    mv a1, a3
-; CHECK-NEXT:  .LBB31_4:
+; CHECK-NEXT:  .LBB35_4:
 ; CHECK-NEXT:    ret
   %cmp = icmp sgt i64 %a, %b
   %cond = select i1 %cmp, i64 %a, i64 %b
@@ -1025,10 +1101,10 @@ define i64 @max_i64(i64 %a, i64 %b) nounwind {
 define i32 @minu_i32(i32 %a, i32 %b) nounwind {
 ; RV32I-LABEL: minu_i32:
 ; RV32I:       # %bb.0:
-; RV32I-NEXT:    bltu a0, a1, .LBB32_2
+; RV32I-NEXT:    bltu a0, a1, .LBB36_2
 ; RV32I-NEXT:  # %bb.1:
 ; RV32I-NEXT:    mv a0, a1
-; RV32I-NEXT:  .LBB32_2:
+; RV32I-NEXT:  .LBB36_2:
 ; RV32I-NEXT:    ret
 ;
 ; RV32ZBB-LABEL: minu_i32:
@@ -1048,18 +1124,18 @@ define i32 @minu_i32(i32 %a, i32 %b) nounwind {
 define i64 @minu_i64(i64 %a, i64 %b) nounwind {
 ; CHECK-LABEL: minu_i64:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    beq a1, a3, .LBB33_2
+; CHECK-NEXT:    beq a1, a3, .LBB37_2
 ; CHECK-NEXT:  # %bb.1:
 ; CHECK-NEXT:    sltu a4, a1, a3
-; CHECK-NEXT:    beqz a4, .LBB33_3
-; CHECK-NEXT:    j .LBB33_4
-; CHECK-NEXT:  .LBB33_2:
+; CHECK-NEXT:    beqz a4, .LBB37_3
+; CHECK-NEXT:    j .LBB37_4
+; CHECK-NEXT:  .LBB37_2:
 ; CHECK-NEXT:    sltu a4, a0, a2
-; CHECK-NEXT:    bnez a4, .LBB33_4
-; CHECK-NEXT:  .LBB33_3:
+; CHECK-NEXT:    bnez a4, .LBB37_4
+; CHECK-NEXT:  .LBB37_3:
 ; CHECK-NEXT:    mv a0, a2
 ; CHECK-NEXT:    mv a1, a3
-; CHECK-NEXT:  .LBB33_4:
+; CHECK-NEXT:  .LBB37_4:
 ; CHECK-NEXT:    ret
   %cmp = icmp ult i64 %a, %b
   %cond = select i1 %cmp, i64 %a, i64 %b
@@ -1069,10 +1145,10 @@ define i64 @minu_i64(i64 %a, i64 %b) nounwind {
 define i32 @maxu_i32(i32 %a, i32 %b) nounwind {
 ; RV32I-LABEL: maxu_i32:
 ; RV32I:       # %bb.0:
-; RV32I-NEXT:    bltu a1, a0, .LBB34_2
+; RV32I-NEXT:    bltu a1, a0, .LBB38_2
 ; RV32I-NEXT:  # %bb.1:
 ; RV32I-NEXT:    mv a0, a1
-; RV32I-NEXT:  .LBB34_2:
+; RV32I-NEXT:  .LBB38_2:
 ; RV32I-NEXT:    ret
 ;
 ; RV32ZBB-LABEL: maxu_i32:
@@ -1092,18 +1168,18 @@ define i32 @maxu_i32(i32 %a, i32 %b) nounwind {
 define i64 @maxu_i64(i64 %a, i64 %b) nounwind {
 ; CHECK-LABEL: maxu_i64:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    beq a1, a3, .LBB35_2
+; CHECK-NEXT:    beq a1, a3, .LBB39_2
 ; CHECK-NEXT:  # %bb.1:
 ; CHECK-NEXT:    sltu a4, a3, a1
-; CHECK-NEXT:    beqz a4, .LBB35_3
-; CHECK-NEXT:    j .LBB35_4
-; CHECK-NEXT:  .LBB35_2:
+; CHECK-NEXT:    beqz a4, .LBB39_3
+; CHECK-NEXT:    j .LBB39_4
+; CHECK-NEXT:  .LBB39_2:
 ; CHECK-NEXT:    sltu a4, a2, a0
-; CHECK-NEXT:    bnez a4, .LBB35_4
-; CHECK-NEXT:  .LBB35_3:
+; CHECK-NEXT:    bnez a4, .LBB39_4
+; CHECK-NEXT:  .LBB39_3:
 ; CHECK-NEXT:    mv a0, a2
 ; CHECK-NEXT:    mv a1, a3
-; CHECK-NEXT:  .LBB35_4:
+; CHECK-NEXT:  .LBB39_4:
 ; CHECK-NEXT:    ret
   %cmp = icmp ugt i64 %a, %b
   %cond = select i1 %cmp, i64 %a, i64 %b
@@ -1130,13 +1206,13 @@ define i32 @abs_i32(i32 %x) {
 define i64 @abs_i64(i64 %x) {
 ; CHECK-LABEL: abs_i64:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    bgez a1, .LBB37_2
+; CHECK-NEXT:    bgez a1, .LBB41_2
 ; CHECK-NEXT:  # %bb.1:
 ; CHECK-NEXT:    snez a2, a0
 ; CHECK-NEXT:    neg a0, a0
 ; CHECK-NEXT:    neg a1, a1
 ; CHECK-NEXT:    sub a1, a1, a2
-; CHECK-NEXT:  .LBB37_2:
+; CHECK-NEXT:  .LBB41_2:
 ; CHECK-NEXT:    ret
   %abs = tail call i64 @llvm.abs.i64(i64 %x, i1 true)
   ret i64 %abs
@@ -1430,13 +1506,13 @@ define i32 @sub_if_uge_i32(i32 %x, i32 %y) {
 define i64 @sub_if_uge_i64(i64 %x, i64 %y) {
 ; CHECK-LABEL: sub_if_uge_i64:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    beq a1, a3, .LBB52_2
+; CHECK-NEXT:    beq a1, a3, .LBB56_2
 ; CHECK-NEXT:  # %bb.1:
 ; CHECK-NEXT:    sltu a4, a1, a3
-; CHECK-NEXT:    j .LBB52_3
-; CHECK-NEXT:  .LBB52_2:
+; CHECK-NEXT:    j .LBB56_3
+; CHECK-NEXT:  .LBB56_2:
 ; CHECK-NEXT:    sltu a4, a0, a2
-; CHECK-NEXT:  .LBB52_3:
+; CHECK-NEXT:  .LBB56_3:
 ; CHECK-NEXT:    addi a4, a4, -1
 ; CHECK-NEXT:    and a3, a4, a3
 ; CHECK-NEXT:    and a2, a4, a2
@@ -1460,29 +1536,29 @@ define i128 @sub_if_uge_i128(i128 %x, i128 %y) {
 ; CHECK-NEXT:    lw a6, 4(a2)
 ; CHECK-NEXT:    lw t0, 12(a2)
 ; CHECK-NEXT:    lw a7, 8(a2)
-; CHECK-NEXT:    beq a5, t0, .LBB53_2
+; CHECK-NEXT:    beq a5, t0, .LBB57_2
 ; CHECK-NEXT:  # %bb.1:
 ; CHECK-NEXT:    sltu t1, a5, t0
-; CHECK-NEXT:    j .LBB53_3
-; CHECK-NEXT:  .LBB53_2:
+; CHECK-NEXT:    j .LBB57_3
+; CHECK-NEXT:  .LBB57_2:
 ; CHECK-NEXT:    sltu t1, a4, a7
-; CHECK-NEXT:  .LBB53_3:
+; CHECK-NEXT:  .LBB57_3:
 ; CHECK-NEXT:    lw a1, 0(a1)
 ; CHECK-NEXT:    lw a2, 0(a2)
-; CHECK-NEXT:    beq a3, a6, .LBB53_5
+; CHECK-NEXT:    beq a3, a6, .LBB57_5
 ; CHECK-NEXT:  # %bb.4:
 ; CHECK-NEXT:    sltu t2, a3, a6
-; CHECK-NEXT:    j .LBB53_6
-; CHECK-NEXT:  .LBB53_5:
+; CHECK-NEXT:    j .LBB57_6
+; CHECK-NEXT:  .LBB57_5:
 ; CHECK-NEXT:    sltu t2, a1, a2
-; CHECK-NEXT:  .LBB53_6:
+; CHECK-NEXT:  .LBB57_6:
 ; CHECK-NEXT:    xor t3, a5, t0
 ; CHECK-NEXT:    xor t4, a4, a7
 ; CHECK-NEXT:    or t3, t4, t3
-; CHECK-NEXT:    beqz t3, .LBB53_8
+; CHECK-NEXT:    beqz t3, .LBB57_8
 ; CHECK-NEXT:  # %bb.7:
 ; CHECK-NEXT:    mv t2, t1
-; CHECK-NEXT:  .LBB53_8:
+; CHECK-NEXT:  .LBB57_8:
 ; CHECK-NEXT:    addi t3, t2, -1
 ; CHECK-NEXT:    and t2, t3, t0
 ; CHECK-NEXT:    and t0, t3, a2
@@ -1490,10 +1566,10 @@ define i128 @sub_if_uge_i128(i128 %x, i128 %y) {
 ; CHECK-NEXT:    sltu a2, a1, t0
 ; CHECK-NEXT:    and a7, t3, a7
 ; CHECK-NEXT:    mv a6, a2
-; CHECK-NEXT:    beq a3, t1, .LBB53_10
+; CHECK-NEXT:    beq a3, t1, .LBB57_10
 ; CHECK-NEXT:  # %bb.9:
 ; CHECK-NEXT:    sltu a6, a3, t1
-; CHECK-NEXT:  .LBB53_10:
+; CHECK-NEXT:  .LBB57_10:
 ; CHECK-NEXT:    sub t3, a4, a7
 ; CHECK-NEXT:    sltu a4, a4, a7
 ; CHECK-NEXT:    sub a5, a5, t2
@@ -1538,12 +1614,12 @@ define i32 @sub_if_uge_multiuse_cmp_i32(i32 %x, i32 %y) {
 ; RV32I-NEXT:    addi a2, a2, -1
 ; RV32I-NEXT:    and a2, a2, a1
 ; RV32I-NEXT:    sub a2, a0, a2
-; RV32I-NEXT:    bltu a0, a1, .LBB55_2
+; RV32I-NEXT:    bltu a0, a1, .LBB59_2
 ; RV32I-NEXT:  # %bb.1:
 ; RV32I-NEXT:    li a0, 4
 ; RV32I-NEXT:    sll a0, a2, a0
 ; RV32I-NEXT:    ret
-; RV32I-NEXT:  .LBB55_2:
+; RV32I-NEXT:  .LBB59_2:
 ; RV32I-NEXT:    li a0, 2
 ; RV32I-NEXT:    sll a0, a2, a0
 ; RV32I-NEXT:    ret
@@ -1552,12 +1628,12 @@ define i32 @sub_if_uge_multiuse_cmp_i32(i32 %x, i32 %y) {
 ; RV32ZBB:       # %bb.0:
 ; RV32ZBB-NEXT:    sub a2, a0, a1
 ; RV32ZBB-NEXT:    minu a2, a0, a2
-; RV32ZBB-NEXT:    bltu a0, a1, .LBB55_2
+; RV32ZBB-NEXT:    bltu a0, a1, .LBB59_2
 ; RV32ZBB-NEXT:  # %bb.1:
 ; RV32ZBB-NEXT:    li a0, 4
 ; RV32ZBB-NEXT:    sll a0, a2, a0
 ; RV32ZBB-NEXT:    ret
-; RV32ZBB-NEXT:  .LBB55_2:
+; RV32ZBB-NEXT:  .LBB59_2:
 ; RV32ZBB-NEXT:    li a0, 2
 ; RV32ZBB-NEXT:    sll a0, a2, a0
 ; RV32ZBB-NEXT:    ret
@@ -1668,16 +1744,16 @@ define i64 @sub_if_uge_C_i64(i64 %x) {
 ; CHECK-LABEL: sub_if_uge_C_i64:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    li a2, 1
-; CHECK-NEXT:    beq a1, a2, .LBB60_2
+; CHECK-NEXT:    beq a1, a2, .LBB64_2
 ; CHECK-NEXT:  # %bb.1:
 ; CHECK-NEXT:    sltiu a2, a1, 2
 ; CHECK-NEXT:    xori a2, a2, 1
-; CHECK-NEXT:    j .LBB60_3
-; CHECK-NEXT:  .LBB60_2:
+; CHECK-NEXT:    j .LBB64_3
+; CHECK-NEXT:  .LBB64_2:
 ; CHECK-NEXT:    lui a2, 172127
 ; CHECK-NEXT:    addi a2, a2, 511
 ; CHECK-NEXT:    sltu a2, a2, a0
-; CHECK-NEXT:  .LBB60_3:
+; CHECK-NEXT:  .LBB64_3:
 ; CHECK-NEXT:    neg a2, a2
 ; CHECK-NEXT:    andi a3, a2, -2
 ; CHECK-NEXT:    add a1, a1, a3
@@ -1737,10 +1813,10 @@ define i32 @sub_if_uge_C_multiuse_sub_i32(i32 signext %x, ptr %z) {
 ; RV32I-NEXT:    add a2, a0, a2
 ; RV32I-NEXT:    addi a3, a3, -16
 ; RV32I-NEXT:    sw a2, 0(a1)
-; RV32I-NEXT:    bltu a3, a0, .LBB62_2
+; RV32I-NEXT:    bltu a3, a0, .LBB66_2
 ; RV32I-NEXT:  # %bb.1:
 ; RV32I-NEXT:    mv a2, a0
-; RV32I-NEXT:  .LBB62_2:
+; RV32I-NEXT:  .LBB66_2:
 ; RV32I-NEXT:    mv a0, a2
 ; RV32I-NEXT:    ret
 ;

--- a/llvm/test/CodeGen/RISCV/rv64zbb.ll
+++ b/llvm/test/CodeGen/RISCV/rv64zbb.ll
@@ -1123,13 +1123,85 @@ define i64 @sexth_i64(i64 %a) nounwind {
   ret i64 %shr
 }
 
+define i32 @sextb_extract_i32(i32 %x) {
+; RV64I-LABEL: sextb_extract_i32:
+; RV64I:       # %bb.0:
+; RV64I-NEXT:    slli a0, a0, 35
+; RV64I-NEXT:    srai a0, a0, 56
+; RV64I-NEXT:    ret
+;
+; RV64ZBB-LABEL: sextb_extract_i32:
+; RV64ZBB:       # %bb.0:
+; RV64ZBB-NEXT:    srli a0, a0, 21
+; RV64ZBB-NEXT:    sext.b a0, a0
+; RV64ZBB-NEXT:    ret
+  %a = lshr i32 %x, 21
+  %b = trunc i32 %a to i8
+  %c = sext i8 %b to i32
+  ret i32 %c
+}
+
+define i64 @sextb_extract_i64(i64 %x) {
+; RV64I-LABEL: sextb_extract_i64:
+; RV64I:       # %bb.0:
+; RV64I-NEXT:    slli a0, a0, 44
+; RV64I-NEXT:    srai a0, a0, 56
+; RV64I-NEXT:    ret
+;
+; RV64ZBB-LABEL: sextb_extract_i64:
+; RV64ZBB:       # %bb.0:
+; RV64ZBB-NEXT:    srli a0, a0, 12
+; RV64ZBB-NEXT:    sext.b a0, a0
+; RV64ZBB-NEXT:    ret
+  %a = lshr i64 %x, 12
+  %b = trunc i64 %a to i8
+  %c = sext i8 %b to i64
+  ret i64 %c
+}
+
+define i32 @sexth_extract_i32(i32 %x) {
+; RV64I-LABEL: sexth_extract_i32:
+; RV64I:       # %bb.0:
+; RV64I-NEXT:    slli a0, a0, 40
+; RV64I-NEXT:    srai a0, a0, 48
+; RV64I-NEXT:    ret
+;
+; RV64ZBB-LABEL: sexth_extract_i32:
+; RV64ZBB:       # %bb.0:
+; RV64ZBB-NEXT:    srli a0, a0, 8
+; RV64ZBB-NEXT:    sext.h a0, a0
+; RV64ZBB-NEXT:    ret
+  %a = lshr i32 %x, 8
+  %b = trunc i32 %a to i16
+  %c = sext i16 %b to i32
+  ret i32 %c
+}
+
+define i64 @sexth_extract_i64(i64 %x) {
+; RV64I-LABEL: sexth_extract_i64:
+; RV64I:       # %bb.0:
+; RV64I-NEXT:    slli a0, a0, 1
+; RV64I-NEXT:    srai a0, a0, 48
+; RV64I-NEXT:    ret
+;
+; RV64ZBB-LABEL: sexth_extract_i64:
+; RV64ZBB:       # %bb.0:
+; RV64ZBB-NEXT:    srli a0, a0, 47
+; RV64ZBB-NEXT:    sext.h a0, a0
+; RV64ZBB-NEXT:    ret
+  %a = lshr i64 %x, 47
+  %b = trunc i64 %a to i16
+  %c = sext i16 %b to i64
+  ret i64 %c
+}
+
 define signext i32 @min_i32(i32 signext %a, i32 signext %b) nounwind {
 ; RV64I-LABEL: min_i32:
 ; RV64I:       # %bb.0:
-; RV64I-NEXT:    blt a0, a1, .LBB36_2
+; RV64I-NEXT:    blt a0, a1, .LBB40_2
 ; RV64I-NEXT:  # %bb.1:
 ; RV64I-NEXT:    mv a0, a1
-; RV64I-NEXT:  .LBB36_2:
+; RV64I-NEXT:  .LBB40_2:
 ; RV64I-NEXT:    ret
 ;
 ; RV64ZBB-LABEL: min_i32:
@@ -1144,10 +1216,10 @@ define signext i32 @min_i32(i32 signext %a, i32 signext %b) nounwind {
 define i64 @min_i64(i64 %a, i64 %b) nounwind {
 ; RV64I-LABEL: min_i64:
 ; RV64I:       # %bb.0:
-; RV64I-NEXT:    blt a0, a1, .LBB37_2
+; RV64I-NEXT:    blt a0, a1, .LBB41_2
 ; RV64I-NEXT:  # %bb.1:
 ; RV64I-NEXT:    mv a0, a1
-; RV64I-NEXT:  .LBB37_2:
+; RV64I-NEXT:  .LBB41_2:
 ; RV64I-NEXT:    ret
 ;
 ; RV64ZBB-LABEL: min_i64:
@@ -1162,10 +1234,10 @@ define i64 @min_i64(i64 %a, i64 %b) nounwind {
 define signext i32 @max_i32(i32 signext %a, i32 signext %b) nounwind {
 ; RV64I-LABEL: max_i32:
 ; RV64I:       # %bb.0:
-; RV64I-NEXT:    blt a1, a0, .LBB38_2
+; RV64I-NEXT:    blt a1, a0, .LBB42_2
 ; RV64I-NEXT:  # %bb.1:
 ; RV64I-NEXT:    mv a0, a1
-; RV64I-NEXT:  .LBB38_2:
+; RV64I-NEXT:  .LBB42_2:
 ; RV64I-NEXT:    ret
 ;
 ; RV64ZBB-LABEL: max_i32:
@@ -1180,10 +1252,10 @@ define signext i32 @max_i32(i32 signext %a, i32 signext %b) nounwind {
 define i64 @max_i64(i64 %a, i64 %b) nounwind {
 ; RV64I-LABEL: max_i64:
 ; RV64I:       # %bb.0:
-; RV64I-NEXT:    blt a1, a0, .LBB39_2
+; RV64I-NEXT:    blt a1, a0, .LBB43_2
 ; RV64I-NEXT:  # %bb.1:
 ; RV64I-NEXT:    mv a0, a1
-; RV64I-NEXT:  .LBB39_2:
+; RV64I-NEXT:  .LBB43_2:
 ; RV64I-NEXT:    ret
 ;
 ; RV64ZBB-LABEL: max_i64:
@@ -1198,10 +1270,10 @@ define i64 @max_i64(i64 %a, i64 %b) nounwind {
 define signext i32 @minu_i32(i32 signext %a, i32 signext %b) nounwind {
 ; RV64I-LABEL: minu_i32:
 ; RV64I:       # %bb.0:
-; RV64I-NEXT:    bltu a0, a1, .LBB40_2
+; RV64I-NEXT:    bltu a0, a1, .LBB44_2
 ; RV64I-NEXT:  # %bb.1:
 ; RV64I-NEXT:    mv a0, a1
-; RV64I-NEXT:  .LBB40_2:
+; RV64I-NEXT:  .LBB44_2:
 ; RV64I-NEXT:    ret
 ;
 ; RV64ZBB-LABEL: minu_i32:
@@ -1216,10 +1288,10 @@ define signext i32 @minu_i32(i32 signext %a, i32 signext %b) nounwind {
 define i64 @minu_i64(i64 %a, i64 %b) nounwind {
 ; RV64I-LABEL: minu_i64:
 ; RV64I:       # %bb.0:
-; RV64I-NEXT:    bltu a0, a1, .LBB41_2
+; RV64I-NEXT:    bltu a0, a1, .LBB45_2
 ; RV64I-NEXT:  # %bb.1:
 ; RV64I-NEXT:    mv a0, a1
-; RV64I-NEXT:  .LBB41_2:
+; RV64I-NEXT:  .LBB45_2:
 ; RV64I-NEXT:    ret
 ;
 ; RV64ZBB-LABEL: minu_i64:
@@ -1234,10 +1306,10 @@ define i64 @minu_i64(i64 %a, i64 %b) nounwind {
 define signext i32 @maxu_i32(i32 signext %a, i32 signext %b) nounwind {
 ; RV64I-LABEL: maxu_i32:
 ; RV64I:       # %bb.0:
-; RV64I-NEXT:    bltu a1, a0, .LBB42_2
+; RV64I-NEXT:    bltu a1, a0, .LBB46_2
 ; RV64I-NEXT:  # %bb.1:
 ; RV64I-NEXT:    mv a0, a1
-; RV64I-NEXT:  .LBB42_2:
+; RV64I-NEXT:  .LBB46_2:
 ; RV64I-NEXT:    ret
 ;
 ; RV64ZBB-LABEL: maxu_i32:
@@ -1252,10 +1324,10 @@ define signext i32 @maxu_i32(i32 signext %a, i32 signext %b) nounwind {
 define i64 @maxu_i64(i64 %a, i64 %b) nounwind {
 ; RV64I-LABEL: maxu_i64:
 ; RV64I:       # %bb.0:
-; RV64I-NEXT:    bltu a1, a0, .LBB43_2
+; RV64I-NEXT:    bltu a1, a0, .LBB47_2
 ; RV64I-NEXT:  # %bb.1:
 ; RV64I-NEXT:    mv a0, a1
-; RV64I-NEXT:  .LBB43_2:
+; RV64I-NEXT:  .LBB47_2:
 ; RV64I-NEXT:    ret
 ;
 ; RV64ZBB-LABEL: maxu_i64:
@@ -1723,13 +1795,13 @@ define i64 @sub_if_uge_i64(i64 %x, i64 %y) {
 define i128 @sub_if_uge_i128(i128 %x, i128 %y) {
 ; CHECK-LABEL: sub_if_uge_i128:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    beq a1, a3, .LBB66_2
+; CHECK-NEXT:    beq a1, a3, .LBB70_2
 ; CHECK-NEXT:  # %bb.1:
 ; CHECK-NEXT:    sltu a4, a1, a3
-; CHECK-NEXT:    j .LBB66_3
-; CHECK-NEXT:  .LBB66_2:
+; CHECK-NEXT:    j .LBB70_3
+; CHECK-NEXT:  .LBB70_2:
 ; CHECK-NEXT:    sltu a4, a0, a2
-; CHECK-NEXT:  .LBB66_3:
+; CHECK-NEXT:  .LBB70_3:
 ; CHECK-NEXT:    addi a4, a4, -1
 ; CHECK-NEXT:    and a3, a4, a3
 ; CHECK-NEXT:    and a2, a4, a2
@@ -1771,12 +1843,12 @@ define i32 @sub_if_uge_multiuse_cmp_i32(i32 %x, i32 %y) {
 ; RV64I-NEXT:    addi a4, a4, -1
 ; RV64I-NEXT:    and a1, a4, a1
 ; RV64I-NEXT:    sub a0, a0, a1
-; RV64I-NEXT:    bltu a3, a2, .LBB68_2
+; RV64I-NEXT:    bltu a3, a2, .LBB72_2
 ; RV64I-NEXT:  # %bb.1:
 ; RV64I-NEXT:    li a1, 4
 ; RV64I-NEXT:    sllw a0, a0, a1
 ; RV64I-NEXT:    ret
-; RV64I-NEXT:  .LBB68_2:
+; RV64I-NEXT:  .LBB72_2:
 ; RV64I-NEXT:    li a1, 2
 ; RV64I-NEXT:    sllw a0, a0, a1
 ; RV64I-NEXT:    ret
@@ -1787,12 +1859,12 @@ define i32 @sub_if_uge_multiuse_cmp_i32(i32 %x, i32 %y) {
 ; RV64ZBB-NEXT:    sext.w a3, a0
 ; RV64ZBB-NEXT:    subw a0, a0, a1
 ; RV64ZBB-NEXT:    minu a0, a3, a0
-; RV64ZBB-NEXT:    bltu a3, a2, .LBB68_2
+; RV64ZBB-NEXT:    bltu a3, a2, .LBB72_2
 ; RV64ZBB-NEXT:  # %bb.1:
 ; RV64ZBB-NEXT:    li a1, 4
 ; RV64ZBB-NEXT:    sllw a0, a0, a1
 ; RV64ZBB-NEXT:    ret
-; RV64ZBB-NEXT:  .LBB68_2:
+; RV64ZBB-NEXT:  .LBB72_2:
 ; RV64ZBB-NEXT:    li a1, 2
 ; RV64ZBB-NEXT:    sllw a0, a0, a1
 ; RV64ZBB-NEXT:    ret
@@ -1971,10 +2043,10 @@ define i32 @sub_if_uge_C_multiuse_sub_i32(i32 signext %x, ptr %z) {
 ; RV64I-NEXT:    addw a2, a0, a2
 ; RV64I-NEXT:    addi a3, a3, -16
 ; RV64I-NEXT:    sw a2, 0(a1)
-; RV64I-NEXT:    bltu a3, a0, .LBB75_2
+; RV64I-NEXT:    bltu a3, a0, .LBB79_2
 ; RV64I-NEXT:  # %bb.1:
 ; RV64I-NEXT:    mv a2, a0
-; RV64I-NEXT:  .LBB75_2:
+; RV64I-NEXT:  .LBB79_2:
 ; RV64I-NEXT:    mv a0, a2
 ; RV64I-NEXT:    ret
 ;

--- a/llvm/test/CodeGen/RISCV/rv64zbb.ll
+++ b/llvm/test/CodeGen/RISCV/rv64zbb.ll
@@ -1124,17 +1124,11 @@ define i64 @sexth_i64(i64 %a) nounwind {
 }
 
 define i32 @sextb_extract_i32(i32 %x) {
-; RV64I-LABEL: sextb_extract_i32:
-; RV64I:       # %bb.0:
-; RV64I-NEXT:    slli a0, a0, 35
-; RV64I-NEXT:    srai a0, a0, 56
-; RV64I-NEXT:    ret
-;
-; RV64ZBB-LABEL: sextb_extract_i32:
-; RV64ZBB:       # %bb.0:
-; RV64ZBB-NEXT:    srli a0, a0, 21
-; RV64ZBB-NEXT:    sext.b a0, a0
-; RV64ZBB-NEXT:    ret
+; CHECK-LABEL: sextb_extract_i32:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    slli a0, a0, 35
+; CHECK-NEXT:    srai a0, a0, 56
+; CHECK-NEXT:    ret
   %a = lshr i32 %x, 21
   %b = trunc i32 %a to i8
   %c = sext i8 %b to i32
@@ -1142,17 +1136,11 @@ define i32 @sextb_extract_i32(i32 %x) {
 }
 
 define i64 @sextb_extract_i64(i64 %x) {
-; RV64I-LABEL: sextb_extract_i64:
-; RV64I:       # %bb.0:
-; RV64I-NEXT:    slli a0, a0, 44
-; RV64I-NEXT:    srai a0, a0, 56
-; RV64I-NEXT:    ret
-;
-; RV64ZBB-LABEL: sextb_extract_i64:
-; RV64ZBB:       # %bb.0:
-; RV64ZBB-NEXT:    srli a0, a0, 12
-; RV64ZBB-NEXT:    sext.b a0, a0
-; RV64ZBB-NEXT:    ret
+; CHECK-LABEL: sextb_extract_i64:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    slli a0, a0, 44
+; CHECK-NEXT:    srai a0, a0, 56
+; CHECK-NEXT:    ret
   %a = lshr i64 %x, 12
   %b = trunc i64 %a to i8
   %c = sext i8 %b to i64
@@ -1160,17 +1148,11 @@ define i64 @sextb_extract_i64(i64 %x) {
 }
 
 define i32 @sexth_extract_i32(i32 %x) {
-; RV64I-LABEL: sexth_extract_i32:
-; RV64I:       # %bb.0:
-; RV64I-NEXT:    slli a0, a0, 40
-; RV64I-NEXT:    srai a0, a0, 48
-; RV64I-NEXT:    ret
-;
-; RV64ZBB-LABEL: sexth_extract_i32:
-; RV64ZBB:       # %bb.0:
-; RV64ZBB-NEXT:    srli a0, a0, 8
-; RV64ZBB-NEXT:    sext.h a0, a0
-; RV64ZBB-NEXT:    ret
+; CHECK-LABEL: sexth_extract_i32:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    slli a0, a0, 40
+; CHECK-NEXT:    srai a0, a0, 48
+; CHECK-NEXT:    ret
   %a = lshr i32 %x, 8
   %b = trunc i32 %a to i16
   %c = sext i16 %b to i32
@@ -1178,17 +1160,11 @@ define i32 @sexth_extract_i32(i32 %x) {
 }
 
 define i64 @sexth_extract_i64(i64 %x) {
-; RV64I-LABEL: sexth_extract_i64:
-; RV64I:       # %bb.0:
-; RV64I-NEXT:    slli a0, a0, 1
-; RV64I-NEXT:    srai a0, a0, 48
-; RV64I-NEXT:    ret
-;
-; RV64ZBB-LABEL: sexth_extract_i64:
-; RV64ZBB:       # %bb.0:
-; RV64ZBB-NEXT:    srli a0, a0, 47
-; RV64ZBB-NEXT:    sext.h a0, a0
-; RV64ZBB-NEXT:    ret
+; CHECK-LABEL: sexth_extract_i64:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    slli a0, a0, 1
+; CHECK-NEXT:    srai a0, a0, 48
+; CHECK-NEXT:    ret
   %a = lshr i64 %x, 47
   %b = trunc i64 %a to i16
   %c = sext i16 %b to i64

--- a/llvm/test/CodeGen/RISCV/rvp-ext-rv32.ll
+++ b/llvm/test/CodeGen/RISCV/rvp-ext-rv32.ll
@@ -1115,8 +1115,8 @@ define <2 x i16> @test_psra_hs_vec_shamt(<2 x i16> %a, <2 x i16> %b) {
 ; CHECK-RV64-NEXT:    sext.h a2, a0
 ; CHECK-RV64-NEXT:    sra a2, a2, a1
 ; CHECK-RV64-NEXT:    srli a1, a1, 16
-; CHECK-RV64-NEXT:    srli a0, a0, 16
-; CHECK-RV64-NEXT:    sext.h a0, a0
+; CHECK-RV64-NEXT:    slli a0, a0, 32
+; CHECK-RV64-NEXT:    srai a0, a0, 48
 ; CHECK-RV64-NEXT:    sra a0, a0, a1
 ; CHECK-RV64-NEXT:    ppaire.h a0, a2, a0
 ; CHECK-RV64-NEXT:    ret
@@ -1130,15 +1130,15 @@ define <4 x i8> @test_psra_bs_vec_shamt(<4 x i8> %a, <4 x i8> %b) {
 ; CHECK-RV32-NEXT:    srli a2, a1, 24
 ; CHECK-RV32-NEXT:    srai a3, a0, 24
 ; CHECK-RV32-NEXT:    srli a4, a1, 8
-; CHECK-RV32-NEXT:    srli a5, a0, 8
+; CHECK-RV32-NEXT:    slli a5, a0, 16
 ; CHECK-RV32-NEXT:    sra a3, a3, a2
-; CHECK-RV32-NEXT:    sext.b a2, a5
-; CHECK-RV32-NEXT:    sra a2, a2, a4
+; CHECK-RV32-NEXT:    srai a5, a5, 24
+; CHECK-RV32-NEXT:    sra a2, a5, a4
 ; CHECK-RV32-NEXT:    sext.b a4, a0
 ; CHECK-RV32-NEXT:    srli a5, a1, 16
-; CHECK-RV32-NEXT:    srli a0, a0, 16
+; CHECK-RV32-NEXT:    slli a0, a0, 8
 ; CHECK-RV32-NEXT:    sra a4, a4, a1
-; CHECK-RV32-NEXT:    sext.b a0, a0
+; CHECK-RV32-NEXT:    srai a0, a0, 24
 ; CHECK-RV32-NEXT:    sra a5, a0, a5
 ; CHECK-RV32-NEXT:    ppaire.db a0, a4, a2
 ; CHECK-RV32-NEXT:    pack a0, a0, a1
@@ -1147,18 +1147,18 @@ define <4 x i8> @test_psra_bs_vec_shamt(<4 x i8> %a, <4 x i8> %b) {
 ; CHECK-RV64-LABEL: test_psra_bs_vec_shamt:
 ; CHECK-RV64:       # %bb.0:
 ; CHECK-RV64-NEXT:    srli a2, a1, 24
-; CHECK-RV64-NEXT:    srli a3, a0, 24
+; CHECK-RV64-NEXT:    slli a3, a0, 32
 ; CHECK-RV64-NEXT:    srli a4, a1, 16
-; CHECK-RV64-NEXT:    sext.b a3, a3
+; CHECK-RV64-NEXT:    srai a3, a3, 56
 ; CHECK-RV64-NEXT:    sra a2, a3, a2
-; CHECK-RV64-NEXT:    srli a3, a0, 16
-; CHECK-RV64-NEXT:    sext.b a3, a3
+; CHECK-RV64-NEXT:    slli a3, a0, 40
+; CHECK-RV64-NEXT:    srai a3, a3, 56
 ; CHECK-RV64-NEXT:    sra a3, a3, a4
 ; CHECK-RV64-NEXT:    sext.b a4, a0
 ; CHECK-RV64-NEXT:    sra a4, a4, a1
 ; CHECK-RV64-NEXT:    srli a1, a1, 8
-; CHECK-RV64-NEXT:    srli a0, a0, 8
-; CHECK-RV64-NEXT:    sext.b a0, a0
+; CHECK-RV64-NEXT:    slli a0, a0, 48
+; CHECK-RV64-NEXT:    srai a0, a0, 56
 ; CHECK-RV64-NEXT:    sra a0, a0, a1
 ; CHECK-RV64-NEXT:    ppaire.b a1, a3, a2
 ; CHECK-RV64-NEXT:    ppaire.b a0, a4, a0
@@ -1335,11 +1335,11 @@ define <2 x i16> @test_psdiv_h(<2 x i16> %a, <2 x i16> %b) {
 ; CHECK-RV64:       # %bb.0:
 ; CHECK-RV64-NEXT:    sext.h a2, a1
 ; CHECK-RV64-NEXT:    sext.h a3, a0
-; CHECK-RV64-NEXT:    srli a1, a1, 16
-; CHECK-RV64-NEXT:    srli a0, a0, 16
+; CHECK-RV64-NEXT:    slli a1, a1, 32
+; CHECK-RV64-NEXT:    slli a0, a0, 32
 ; CHECK-RV64-NEXT:    divw a2, a3, a2
-; CHECK-RV64-NEXT:    sext.h a1, a1
-; CHECK-RV64-NEXT:    sext.h a0, a0
+; CHECK-RV64-NEXT:    srai a1, a1, 48
+; CHECK-RV64-NEXT:    srai a0, a0, 48
 ; CHECK-RV64-NEXT:    divw a0, a0, a1
 ; CHECK-RV64-NEXT:    ppaire.h a0, a2, a0
 ; CHECK-RV64-NEXT:    ret
@@ -1352,19 +1352,19 @@ define <4 x i8> @test_psdiv_b(<4 x i8> %a, <4 x i8> %b) {
 ; CHECK-RV32:       # %bb.0:
 ; CHECK-RV32-NEXT:    srai a2, a1, 24
 ; CHECK-RV32-NEXT:    srai a3, a0, 24
-; CHECK-RV32-NEXT:    srli a4, a1, 8
-; CHECK-RV32-NEXT:    srli a5, a0, 8
+; CHECK-RV32-NEXT:    slli a4, a1, 16
+; CHECK-RV32-NEXT:    slli a5, a0, 16
 ; CHECK-RV32-NEXT:    div a3, a3, a2
-; CHECK-RV32-NEXT:    sext.b a2, a4
-; CHECK-RV32-NEXT:    sext.b a4, a5
-; CHECK-RV32-NEXT:    div a2, a4, a2
+; CHECK-RV32-NEXT:    srai a4, a4, 24
+; CHECK-RV32-NEXT:    srai a5, a5, 24
+; CHECK-RV32-NEXT:    div a2, a5, a4
 ; CHECK-RV32-NEXT:    sext.b a4, a1
 ; CHECK-RV32-NEXT:    sext.b a5, a0
-; CHECK-RV32-NEXT:    srli a1, a1, 16
-; CHECK-RV32-NEXT:    srli a0, a0, 16
+; CHECK-RV32-NEXT:    slli a1, a1, 8
+; CHECK-RV32-NEXT:    slli a0, a0, 8
 ; CHECK-RV32-NEXT:    div a4, a5, a4
-; CHECK-RV32-NEXT:    sext.b a1, a1
-; CHECK-RV32-NEXT:    sext.b a0, a0
+; CHECK-RV32-NEXT:    srai a1, a1, 24
+; CHECK-RV32-NEXT:    srai a0, a0, 24
 ; CHECK-RV32-NEXT:    div a5, a0, a1
 ; CHECK-RV32-NEXT:    ppaire.db a0, a4, a2
 ; CHECK-RV32-NEXT:    pack a0, a0, a1
@@ -1372,23 +1372,23 @@ define <4 x i8> @test_psdiv_b(<4 x i8> %a, <4 x i8> %b) {
 ;
 ; CHECK-RV64-LABEL: test_psdiv_b:
 ; CHECK-RV64:       # %bb.0:
-; CHECK-RV64-NEXT:    srli a2, a1, 24
-; CHECK-RV64-NEXT:    srli a3, a0, 24
+; CHECK-RV64-NEXT:    slli a2, a1, 32
+; CHECK-RV64-NEXT:    slli a3, a0, 32
 ; CHECK-RV64-NEXT:    sext.b a4, a1
 ; CHECK-RV64-NEXT:    sext.b a5, a0
 ; CHECK-RV64-NEXT:    divw a4, a5, a4
-; CHECK-RV64-NEXT:    srli a5, a1, 16
-; CHECK-RV64-NEXT:    sext.b a2, a2
-; CHECK-RV64-NEXT:    sext.b a3, a3
+; CHECK-RV64-NEXT:    slli a5, a1, 40
+; CHECK-RV64-NEXT:    srai a2, a2, 56
+; CHECK-RV64-NEXT:    srai a3, a3, 56
 ; CHECK-RV64-NEXT:    divw a2, a3, a2
-; CHECK-RV64-NEXT:    srli a3, a0, 16
-; CHECK-RV64-NEXT:    sext.b a5, a5
-; CHECK-RV64-NEXT:    sext.b a3, a3
+; CHECK-RV64-NEXT:    slli a3, a0, 40
+; CHECK-RV64-NEXT:    srai a5, a5, 56
+; CHECK-RV64-NEXT:    srai a3, a3, 56
 ; CHECK-RV64-NEXT:    divw a3, a3, a5
-; CHECK-RV64-NEXT:    srli a1, a1, 8
-; CHECK-RV64-NEXT:    srli a0, a0, 8
-; CHECK-RV64-NEXT:    sext.b a1, a1
-; CHECK-RV64-NEXT:    sext.b a0, a0
+; CHECK-RV64-NEXT:    slli a1, a1, 48
+; CHECK-RV64-NEXT:    slli a0, a0, 48
+; CHECK-RV64-NEXT:    srai a1, a1, 56
+; CHECK-RV64-NEXT:    srai a0, a0, 56
 ; CHECK-RV64-NEXT:    divw a0, a0, a1
 ; CHECK-RV64-NEXT:    ppaire.b a1, a3, a2
 ; CHECK-RV64-NEXT:    ppaire.b a0, a4, a0
@@ -1489,11 +1489,11 @@ define <2 x i16> @test_psrem_h(<2 x i16> %a, <2 x i16> %b) {
 ; CHECK-RV64:       # %bb.0:
 ; CHECK-RV64-NEXT:    sext.h a2, a1
 ; CHECK-RV64-NEXT:    sext.h a3, a0
-; CHECK-RV64-NEXT:    srli a1, a1, 16
-; CHECK-RV64-NEXT:    srli a0, a0, 16
+; CHECK-RV64-NEXT:    slli a1, a1, 32
+; CHECK-RV64-NEXT:    slli a0, a0, 32
 ; CHECK-RV64-NEXT:    remw a2, a3, a2
-; CHECK-RV64-NEXT:    sext.h a1, a1
-; CHECK-RV64-NEXT:    sext.h a0, a0
+; CHECK-RV64-NEXT:    srai a1, a1, 48
+; CHECK-RV64-NEXT:    srai a0, a0, 48
 ; CHECK-RV64-NEXT:    remw a0, a0, a1
 ; CHECK-RV64-NEXT:    ppaire.h a0, a2, a0
 ; CHECK-RV64-NEXT:    ret
@@ -1506,19 +1506,19 @@ define <4 x i8> @test_psrem_b(<4 x i8> %a, <4 x i8> %b) {
 ; CHECK-RV32:       # %bb.0:
 ; CHECK-RV32-NEXT:    srai a2, a1, 24
 ; CHECK-RV32-NEXT:    srai a3, a0, 24
-; CHECK-RV32-NEXT:    srli a4, a1, 8
-; CHECK-RV32-NEXT:    srli a5, a0, 8
+; CHECK-RV32-NEXT:    slli a4, a1, 16
+; CHECK-RV32-NEXT:    slli a5, a0, 16
 ; CHECK-RV32-NEXT:    rem a3, a3, a2
-; CHECK-RV32-NEXT:    sext.b a2, a4
-; CHECK-RV32-NEXT:    sext.b a4, a5
-; CHECK-RV32-NEXT:    rem a2, a4, a2
+; CHECK-RV32-NEXT:    srai a4, a4, 24
+; CHECK-RV32-NEXT:    srai a5, a5, 24
+; CHECK-RV32-NEXT:    rem a2, a5, a4
 ; CHECK-RV32-NEXT:    sext.b a4, a1
 ; CHECK-RV32-NEXT:    sext.b a5, a0
-; CHECK-RV32-NEXT:    srli a1, a1, 16
-; CHECK-RV32-NEXT:    srli a0, a0, 16
+; CHECK-RV32-NEXT:    slli a1, a1, 8
+; CHECK-RV32-NEXT:    slli a0, a0, 8
 ; CHECK-RV32-NEXT:    rem a4, a5, a4
-; CHECK-RV32-NEXT:    sext.b a1, a1
-; CHECK-RV32-NEXT:    sext.b a0, a0
+; CHECK-RV32-NEXT:    srai a1, a1, 24
+; CHECK-RV32-NEXT:    srai a0, a0, 24
 ; CHECK-RV32-NEXT:    rem a5, a0, a1
 ; CHECK-RV32-NEXT:    ppaire.db a0, a4, a2
 ; CHECK-RV32-NEXT:    pack a0, a0, a1
@@ -1526,23 +1526,23 @@ define <4 x i8> @test_psrem_b(<4 x i8> %a, <4 x i8> %b) {
 ;
 ; CHECK-RV64-LABEL: test_psrem_b:
 ; CHECK-RV64:       # %bb.0:
-; CHECK-RV64-NEXT:    srli a2, a1, 24
-; CHECK-RV64-NEXT:    srli a3, a0, 24
+; CHECK-RV64-NEXT:    slli a2, a1, 32
+; CHECK-RV64-NEXT:    slli a3, a0, 32
 ; CHECK-RV64-NEXT:    sext.b a4, a1
 ; CHECK-RV64-NEXT:    sext.b a5, a0
 ; CHECK-RV64-NEXT:    remw a4, a5, a4
-; CHECK-RV64-NEXT:    srli a5, a1, 16
-; CHECK-RV64-NEXT:    sext.b a2, a2
-; CHECK-RV64-NEXT:    sext.b a3, a3
+; CHECK-RV64-NEXT:    slli a5, a1, 40
+; CHECK-RV64-NEXT:    srai a2, a2, 56
+; CHECK-RV64-NEXT:    srai a3, a3, 56
 ; CHECK-RV64-NEXT:    remw a2, a3, a2
-; CHECK-RV64-NEXT:    srli a3, a0, 16
-; CHECK-RV64-NEXT:    sext.b a5, a5
-; CHECK-RV64-NEXT:    sext.b a3, a3
+; CHECK-RV64-NEXT:    slli a3, a0, 40
+; CHECK-RV64-NEXT:    srai a5, a5, 56
+; CHECK-RV64-NEXT:    srai a3, a3, 56
 ; CHECK-RV64-NEXT:    remw a3, a3, a5
-; CHECK-RV64-NEXT:    srli a1, a1, 8
-; CHECK-RV64-NEXT:    srli a0, a0, 8
-; CHECK-RV64-NEXT:    sext.b a1, a1
-; CHECK-RV64-NEXT:    sext.b a0, a0
+; CHECK-RV64-NEXT:    slli a1, a1, 48
+; CHECK-RV64-NEXT:    slli a0, a0, 48
+; CHECK-RV64-NEXT:    srai a1, a1, 56
+; CHECK-RV64-NEXT:    srai a0, a0, 56
 ; CHECK-RV64-NEXT:    remw a0, a0, a1
 ; CHECK-RV64-NEXT:    ppaire.b a1, a3, a2
 ; CHECK-RV64-NEXT:    ppaire.b a0, a4, a0

--- a/llvm/test/CodeGen/RISCV/rvp-ext-rv64.ll
+++ b/llvm/test/CodeGen/RISCV/rvp-ext-rv64.ll
@@ -1656,19 +1656,19 @@ define <4 x i16> @test_psdiv_h(<4 x i16> %a, <4 x i16> %b) {
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    srai a2, a1, 48
 ; CHECK-NEXT:    srai a3, a0, 48
-; CHECK-NEXT:    srli a4, a1, 32
+; CHECK-NEXT:    slli a4, a1, 16
 ; CHECK-NEXT:    sext.h a5, a1
 ; CHECK-NEXT:    divw a2, a3, a2
 ; CHECK-NEXT:    sext.h a3, a0
 ; CHECK-NEXT:    divw a3, a3, a5
-; CHECK-NEXT:    srli a5, a0, 32
-; CHECK-NEXT:    sext.h a4, a4
-; CHECK-NEXT:    sext.h a5, a5
+; CHECK-NEXT:    slli a5, a0, 16
+; CHECK-NEXT:    srai a4, a4, 48
+; CHECK-NEXT:    srai a5, a5, 48
 ; CHECK-NEXT:    divw a4, a5, a4
-; CHECK-NEXT:    srli a1, a1, 16
-; CHECK-NEXT:    srli a0, a0, 16
-; CHECK-NEXT:    sext.h a1, a1
-; CHECK-NEXT:    sext.h a0, a0
+; CHECK-NEXT:    slli a1, a1, 32
+; CHECK-NEXT:    slli a0, a0, 32
+; CHECK-NEXT:    srai a1, a1, 48
+; CHECK-NEXT:    srai a0, a0, 48
 ; CHECK-NEXT:    divw a0, a0, a1
 ; CHECK-NEXT:    ppaire.h a1, a4, a2
 ; CHECK-NEXT:    ppaire.h a0, a3, a0
@@ -1683,39 +1683,39 @@ define <8 x i8> @test_psdiv_b(<8 x i8> %a, <8 x i8> %b) {
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    srai a2, a1, 56
 ; CHECK-NEXT:    srai a3, a0, 56
-; CHECK-NEXT:    srli a4, a1, 48
-; CHECK-NEXT:    srli a5, a0, 48
-; CHECK-NEXT:    srli a6, a1, 40
-; CHECK-NEXT:    srli a7, a0, 40
-; CHECK-NEXT:    srli t0, a1, 32
+; CHECK-NEXT:    slli a4, a1, 8
+; CHECK-NEXT:    slli a5, a0, 8
+; CHECK-NEXT:    slli a6, a1, 16
+; CHECK-NEXT:    slli a7, a0, 16
+; CHECK-NEXT:    slli t0, a1, 24
 ; CHECK-NEXT:    sext.b t1, a1
 ; CHECK-NEXT:    divw a2, a3, a2
 ; CHECK-NEXT:    sext.b a3, a0
 ; CHECK-NEXT:    divw a3, a3, t1
-; CHECK-NEXT:    srli t1, a0, 32
-; CHECK-NEXT:    sext.b a4, a4
-; CHECK-NEXT:    sext.b a5, a5
+; CHECK-NEXT:    slli t1, a0, 24
+; CHECK-NEXT:    srai a4, a4, 56
+; CHECK-NEXT:    srai a5, a5, 56
 ; CHECK-NEXT:    divw a4, a5, a4
-; CHECK-NEXT:    srli a5, a1, 24
-; CHECK-NEXT:    sext.b a6, a6
-; CHECK-NEXT:    sext.b a7, a7
+; CHECK-NEXT:    slli a5, a1, 32
+; CHECK-NEXT:    srai a6, a6, 56
+; CHECK-NEXT:    srai a7, a7, 56
 ; CHECK-NEXT:    divw a6, a7, a6
-; CHECK-NEXT:    srli a7, a0, 24
-; CHECK-NEXT:    sext.b t0, t0
-; CHECK-NEXT:    sext.b t1, t1
+; CHECK-NEXT:    slli a7, a0, 32
+; CHECK-NEXT:    srai t0, t0, 56
+; CHECK-NEXT:    srai t1, t1, 56
 ; CHECK-NEXT:    divw t0, t1, t0
-; CHECK-NEXT:    srli t1, a1, 16
-; CHECK-NEXT:    sext.b a5, a5
-; CHECK-NEXT:    sext.b a7, a7
+; CHECK-NEXT:    slli t1, a1, 40
+; CHECK-NEXT:    srai a5, a5, 56
+; CHECK-NEXT:    srai a7, a7, 56
 ; CHECK-NEXT:    divw a5, a7, a5
-; CHECK-NEXT:    srli a7, a0, 16
-; CHECK-NEXT:    sext.b t1, t1
-; CHECK-NEXT:    sext.b a7, a7
+; CHECK-NEXT:    slli a7, a0, 40
+; CHECK-NEXT:    srai t1, t1, 56
+; CHECK-NEXT:    srai a7, a7, 56
 ; CHECK-NEXT:    divw a7, a7, t1
-; CHECK-NEXT:    srli a1, a1, 8
-; CHECK-NEXT:    srli a0, a0, 8
-; CHECK-NEXT:    sext.b a1, a1
-; CHECK-NEXT:    sext.b a0, a0
+; CHECK-NEXT:    slli a1, a1, 48
+; CHECK-NEXT:    slli a0, a0, 48
+; CHECK-NEXT:    srai a1, a1, 56
+; CHECK-NEXT:    srai a0, a0, 56
 ; CHECK-NEXT:    divw a0, a0, a1
 ; CHECK-NEXT:    ppaire.b a1, a4, a2
 ; CHECK-NEXT:    ppaire.b a2, t0, a6
@@ -1834,19 +1834,19 @@ define <4 x i16> @test_psrem_h(<4 x i16> %a, <4 x i16> %b) {
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    srai a2, a1, 48
 ; CHECK-NEXT:    srai a3, a0, 48
-; CHECK-NEXT:    srli a4, a1, 32
+; CHECK-NEXT:    slli a4, a1, 16
 ; CHECK-NEXT:    sext.h a5, a1
 ; CHECK-NEXT:    remw a2, a3, a2
 ; CHECK-NEXT:    sext.h a3, a0
 ; CHECK-NEXT:    remw a3, a3, a5
-; CHECK-NEXT:    srli a5, a0, 32
-; CHECK-NEXT:    sext.h a4, a4
-; CHECK-NEXT:    sext.h a5, a5
+; CHECK-NEXT:    slli a5, a0, 16
+; CHECK-NEXT:    srai a4, a4, 48
+; CHECK-NEXT:    srai a5, a5, 48
 ; CHECK-NEXT:    remw a4, a5, a4
-; CHECK-NEXT:    srli a1, a1, 16
-; CHECK-NEXT:    srli a0, a0, 16
-; CHECK-NEXT:    sext.h a1, a1
-; CHECK-NEXT:    sext.h a0, a0
+; CHECK-NEXT:    slli a1, a1, 32
+; CHECK-NEXT:    slli a0, a0, 32
+; CHECK-NEXT:    srai a1, a1, 48
+; CHECK-NEXT:    srai a0, a0, 48
 ; CHECK-NEXT:    remw a0, a0, a1
 ; CHECK-NEXT:    ppaire.h a1, a4, a2
 ; CHECK-NEXT:    ppaire.h a0, a3, a0
@@ -1861,39 +1861,39 @@ define <8 x i8> @test_psrem_b(<8 x i8> %a, <8 x i8> %b) {
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    srai a2, a1, 56
 ; CHECK-NEXT:    srai a3, a0, 56
-; CHECK-NEXT:    srli a4, a1, 48
-; CHECK-NEXT:    srli a5, a0, 48
-; CHECK-NEXT:    srli a6, a1, 40
-; CHECK-NEXT:    srli a7, a0, 40
-; CHECK-NEXT:    srli t0, a1, 32
+; CHECK-NEXT:    slli a4, a1, 8
+; CHECK-NEXT:    slli a5, a0, 8
+; CHECK-NEXT:    slli a6, a1, 16
+; CHECK-NEXT:    slli a7, a0, 16
+; CHECK-NEXT:    slli t0, a1, 24
 ; CHECK-NEXT:    sext.b t1, a1
 ; CHECK-NEXT:    remw a2, a3, a2
 ; CHECK-NEXT:    sext.b a3, a0
 ; CHECK-NEXT:    remw a3, a3, t1
-; CHECK-NEXT:    srli t1, a0, 32
-; CHECK-NEXT:    sext.b a4, a4
-; CHECK-NEXT:    sext.b a5, a5
+; CHECK-NEXT:    slli t1, a0, 24
+; CHECK-NEXT:    srai a4, a4, 56
+; CHECK-NEXT:    srai a5, a5, 56
 ; CHECK-NEXT:    remw a4, a5, a4
-; CHECK-NEXT:    srli a5, a1, 24
-; CHECK-NEXT:    sext.b a6, a6
-; CHECK-NEXT:    sext.b a7, a7
+; CHECK-NEXT:    slli a5, a1, 32
+; CHECK-NEXT:    srai a6, a6, 56
+; CHECK-NEXT:    srai a7, a7, 56
 ; CHECK-NEXT:    remw a6, a7, a6
-; CHECK-NEXT:    srli a7, a0, 24
-; CHECK-NEXT:    sext.b t0, t0
-; CHECK-NEXT:    sext.b t1, t1
+; CHECK-NEXT:    slli a7, a0, 32
+; CHECK-NEXT:    srai t0, t0, 56
+; CHECK-NEXT:    srai t1, t1, 56
 ; CHECK-NEXT:    remw t0, t1, t0
-; CHECK-NEXT:    srli t1, a1, 16
-; CHECK-NEXT:    sext.b a5, a5
-; CHECK-NEXT:    sext.b a7, a7
+; CHECK-NEXT:    slli t1, a1, 40
+; CHECK-NEXT:    srai a5, a5, 56
+; CHECK-NEXT:    srai a7, a7, 56
 ; CHECK-NEXT:    remw a5, a7, a5
-; CHECK-NEXT:    srli a7, a0, 16
-; CHECK-NEXT:    sext.b t1, t1
-; CHECK-NEXT:    sext.b a7, a7
+; CHECK-NEXT:    slli a7, a0, 40
+; CHECK-NEXT:    srai t1, t1, 56
+; CHECK-NEXT:    srai a7, a7, 56
 ; CHECK-NEXT:    remw a7, a7, t1
-; CHECK-NEXT:    srli a1, a1, 8
-; CHECK-NEXT:    srli a0, a0, 8
-; CHECK-NEXT:    sext.b a1, a1
-; CHECK-NEXT:    sext.b a0, a0
+; CHECK-NEXT:    slli a1, a1, 48
+; CHECK-NEXT:    slli a0, a0, 48
+; CHECK-NEXT:    srai a1, a1, 56
+; CHECK-NEXT:    srai a0, a0, 56
 ; CHECK-NEXT:    remw a0, a0, a1
 ; CHECK-NEXT:    ppaire.b a1, a4, a2
 ; CHECK-NEXT:    ppaire.b a2, t0, a6


### PR DESCRIPTION
Without Zcb, the slli+srai may be more compressible