### PR TITLE
[Hexagon] Optimize load/store instruction during widening

### DIFF
--- a/llvm/lib/Target/Hexagon/HexagonLoadStoreWidening.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonLoadStoreWidening.cpp
@@ -121,6 +121,9 @@ private:
   bool replaceInsts(InstrGroup &OG, InstrGroup &NG);
   bool areAdjacent(const MachineInstr *S1, const MachineInstr *S2);
   bool canSwapInstructions(const MachineInstr *A, const MachineInstr *B);
+  MachineInstr *widenLoadStoreAddAsl(Register NewPairReg,
+                                     const MachineInstr *FirstMem,
+                                     const DebugLoc &DL);
 };
 
 struct HexagonStoreWidening : public MachineFunctionPass {
@@ -538,6 +541,73 @@ bool HexagonLoadStoreWidening::createWideInsts(InstrGroup &OG, InstrGroup &NG,
   return createWideLoads(OG, NG, TotalSize);
 }
 
+// check for the pattern:
+// %def = S2_addasl_rrri %base, %offset, #imm
+// %other = L2_loadrd_io %def, 0
+// to
+// %other = L4_loadrd_rr %base, %offset, #imm
+// If addasl does not define the base of the load,
+// do a normal widening.
+// Same behavior followed for store.
+MachineInstr *HexagonLoadStoreWidening::widenLoadStoreAddAsl(
+    Register NewPairReg, const MachineInstr *FirstMem, const DebugLoc &DL) {
+
+  unsigned Base, Offset;
+  HII->getBaseAndOffsetPosition(*FirstMem, Base, Offset);
+  auto BaseOp = FirstMem->getOperand(Base);
+  auto OffMO = FirstMem->getOperand(Offset);
+  Register BaseReg = BaseOp.getReg();
+
+  MachineInstr *AddaslDef = nullptr;
+  if (Register::isVirtualRegister(BaseReg))
+    AddaslDef = MRI->getVRegDef(BaseReg);
+
+  // Skip through trivial copies to the defining addasl.
+  while (AddaslDef && AddaslDef->getOpcode() == Hexagon::COPY) {
+    const MachineOperand &Src = AddaslDef->getOperand(1);
+    if (!Src.isReg() || !Register::isVirtualRegister(Src.getReg()))
+      break;
+    AddaslDef = MRI->getUniqueVRegDef(Src.getReg());
+  }
+
+  if (!AddaslDef || AddaslDef->getOpcode() != Hexagon::S2_addasl_rrri ||
+      (OffMO.isImm() && OffMO.getImm() != 0))
+    return nullptr;
+
+  int64_t ImmVal = AddaslDef->getOperand(3).getImm();
+  if (ImmVal > 3 || ImmVal < 0)
+    return nullptr;
+
+  MachineInstr *WidenedInstr = nullptr;
+  auto Reg1 = AddaslDef->getOperand(1).getReg();
+  auto Reg2 = AddaslDef->getOperand(2).getReg();
+  auto Reg3 = AddaslDef->getOperand(3).getImm();
+  MachineInstrBuilder MIB;
+
+  if (Mode == WideningMode::Load) {
+    auto LdOp = FirstMem->getOperand(0);
+    MIB = BuildMI(*MF, DL, TII->get(Hexagon::L4_loadrd_rr))
+              .addDef(NewPairReg, getKillRegState(LdOp.isKill()),
+                      LdOp.getSubReg())
+              .addReg(Reg1)
+              .addReg(Reg2)
+              .addImm(Reg3);
+  } else {
+    MIB = BuildMI(*MF, DL, TII->get(Hexagon::S4_storerd_rr))
+              .addReg(Reg1)
+              .addReg(Reg2)
+              .addImm(Reg3)
+              .addReg(NewPairReg);
+  }
+
+  // Reset kill flags of the addasl instruction
+  AddaslDef->getOperand(1).setIsKill(false);
+  AddaslDef->getOperand(2).setIsKill(false);
+
+  WidenedInstr = *&MIB;
+  return WidenedInstr;
+}
+
 /// Given an "old group" OG of stores, create a "new group" NG of instructions
 /// to replace them.  Ideally, NG would only have a single instruction in it,
 /// but that may only be possible for store-immediate.
@@ -623,9 +693,12 @@ bool HexagonLoadStoreWidening::createWideStores(InstrGroup &OG, InstrGroup &NG,
       StI =
           BuildMI(*MF, DL, StD).add(IncDestMO).add(MR).add(IncMO).addReg(VReg);
     } else {
-      const MCInstrDesc &StD = TII->get(Hexagon::S2_storerd_io);
-      auto OffMO = FirstSt->getOperand(1);
-      StI = BuildMI(*MF, DL, StD).add(MR).add(OffMO).addReg(VReg);
+      StI = widenLoadStoreAddAsl(VReg, FirstSt, DL);
+      if (!StI) {
+        const MCInstrDesc &StD = TII->get(Hexagon::S2_storerd_io);
+        auto OffMO = FirstSt->getOperand(1);
+        StI = BuildMI(*MF, DL, StD).add(MR).add(OffMO).addReg(VReg);
+      }
     }
     StI->addMemOperand(*MF, NewM);
     NG.push_back(StI);
@@ -737,12 +810,19 @@ bool HexagonLoadStoreWidening::createWideLoads(InstrGroup &OG, InstrGroup &NG,
               .add(IncMO);
     LdI->addMemOperand(*MF, NewM);
   } else {
-    auto OffMO = FirstLd->getOperand(2);
-    LdI = BuildMI(*MF, DL, TII->get(Hexagon::L2_loadrd_io))
-              .addDef(NewMR, getKillRegState(MR.isKill()), MR.getSubReg())
-              .add(MRBase)
-              .add(OffMO);
-    LdI->addMemOperand(*MF, NewM);
+    // Try rr widening with addasl-defined base; otherwise fall back to io.
+    MachineInstr *RR = widenLoadStoreAddAsl(NewMR, FirstLd, DL);
+    if (RR) {
+      RR->addMemOperand(*MF, NewM);
+      LdI = RR;
+    } else {
+      auto OffMO = FirstLd->getOperand(2);
+      LdI = BuildMI(*MF, DL, TII->get(Hexagon::L2_loadrd_io))
+                .addDef(NewMR, getKillRegState(MR.isKill()), MR.getSubReg())
+                .add(MRBase)
+                .add(OffMO);
+      LdI->addMemOperand(*MF, NewM);
+    }
   }
   NG.push_back(LdI);
 

--- a/llvm/test/CodeGen/Hexagon/load-widen-addasl.mir
+++ b/llvm/test/CodeGen/Hexagon/load-widen-addasl.mir
@@ -1,0 +1,35 @@
+# RUN: llc -march=hexagon -run-pass=hexagon-widen-loads -verify-machineinstrs %s -o - | FileCheck %s
+
+# CHECK: S2_addasl_rrri [[VREG0:%[0-9]+]], [[VREG1:%[0-9]+]], [[IMM:[0-9]+]]
+# CHECK-NEXT: doubleregs = L4_loadrd_rr [[VREG0]], [[VREG1]], [[IMM]]
+
+--- |
+  define float @qhl_scalar_dsp_fft_f32(ptr %x, i32 %0) {
+  entry:
+    %arrayidx = getelementptr { float, float }, ptr %x, i32 %0
+    %cgep = getelementptr { float, float }, ptr %x, i32 %0
+    %arrayidx.real = load float, ptr %cgep, align 8
+    store float %arrayidx.real, ptr %x, align 8
+    %arrayidx.imagp = getelementptr i8, ptr %arrayidx, i32 4
+    %arrayidx.imag = load float, ptr %arrayidx.imagp, align 4
+    ret float %arrayidx.imag
+  }
+...
+---
+name:            qhl_scalar_dsp_fft_f32
+liveins:
+  - { reg: '$r0', virtual-reg: '%0' }
+  - { reg: '$r1', virtual-reg: '%1' }
+body:             |
+  bb.0.entry:
+    liveins: $r0, $r1
+
+    %1:intregs = COPY $r1
+    %0:intregs = COPY $r0
+    %2:intregs = S2_addasl_rrri %0, %1, 3
+    %3:intregs = L2_loadri_io %2, 0 :: (load (s32) from %ir.cgep, align 8)
+    S2_storeri_io %0, 0, killed %3 :: (store (s32) into %ir.x, align 8)
+    %4:intregs = L2_loadri_io %2, 4 :: (load (s32) from %ir.arrayidx.imagp)
+    $r0 = COPY %4
+    PS_jmpret $r31, implicit-def dead $pc, implicit $r0
+...

--- a/llvm/test/CodeGen/Hexagon/store-widen-addasl.mir
+++ b/llvm/test/CodeGen/Hexagon/store-widen-addasl.mir
@@ -1,0 +1,47 @@
+# RUN: llc -march=hexagon -run-pass=hexagon-widen-stores -verify-machineinstrs %s -o - | FileCheck %s
+
+# CHECK: S2_addasl_rrri [[VREG0:%[0-9]+]], [[VREG1:%[0-9]+]], 3
+# CHECK-NEXT: [[NEWREG:%[0-9]+]]:doubleregs = A2_combinew
+# CHECK-NEXT: S4_storerd_rr [[VREG0]], [[VREG1]], 3, [[NEWREG]]
+# CHECK: [[VREG6:%[0-9]+]]:intregs = S2_addasl_rrri [[VREG0]], [[VREG1]], 4
+# CHECK-NEXT: [[NEWREG2:%[0-9]+]]:doubleregs = A2_combinew
+# CHECK-NEXT: S2_storerd_io [[VREG6]], 0, [[NEWREG2]]
+
+--- |
+  define float @qhl_scalar_dsp_fft_f32(ptr %0, ptr %1, i32 %2, i32 %3, i32 %4) {
+  entry:
+    %arrayidx = getelementptr { float, float }, ptr %1, i32 %2
+    %cgep = getelementptr { float, float }, ptr %0, i32 %3
+    %arrayidx.real = load float, ptr %cgep, align 8
+    store float %arrayidx.real, ptr %1, align 8
+    %arrayidx.imagp = getelementptr i8, ptr %arrayidx, i32 4
+    %arrayidx.imag = load float, ptr %arrayidx.imagp, align 4
+    ret float %arrayidx.imag
+  }
+...
+---
+name:            qhl_scalar_dsp_fft_f32
+liveins:
+  - { reg: '$r0', virtual-reg: '%0' }
+  - { reg: '$r1', virtual-reg: '%1' }
+  - { reg: '$r2', virtual-reg: '%2' }
+  - { reg: '$r3', virtual-reg: '%3' }
+  - { reg: '$r4', virtual-reg: '%4' }
+body:             |
+  bb.0.entry:
+    liveins: $r0, $r1, $r2, $r3
+
+    %0:intregs = COPY $r0
+    %1:intregs = COPY $r1
+    %2:intregs = COPY $r2
+    %3:intregs = COPY $r3
+    %4:intregs = COPY $r4
+    %5:intregs = S2_addasl_rrri %0, %1, 3
+    S2_storeri_io %5, 0, killed %3 :: (store (s32) into %ir.arrayidx, align 8)
+    S2_storeri_io %5, 4, killed %4 :: (store (s32) into %ir.cgep, align 4)
+    %6:intregs = S2_addasl_rrri %0, %1, 4
+    S2_storeri_io %6, 0, killed %3 :: (store (s32) into %ir.arrayidx, align 8)
+    S2_storeri_io %6, 4, killed %4 :: (store (s32) into %ir.cgep, align 4)
+    $r0 = COPY %3
+    PS_jmpret $r31, implicit-def dead $pc, implicit $r0
+...


### PR DESCRIPTION
This change enhances the Hexagon Load-Store Widening pass to recognize and optimize a specific pattern involving the S2_addasl_rrri instruction. When widening loads/stores, the pass now detects cases where the base register is defined by an S2_addasl_rrri instruction and combines the operations into a single load double/store double instruction with register shift op, eliminating the intermediate address calculation.

Eg, for load,

If the definition of the base register came from a addasl instruction, we generate a 
memd(Rs + Rt << #imm) instead of memd(Rs + #imm) instruction.

Transform:

%18 = S2_addasl_rrri %8, %17, 3
%19 = L2_loadri_io %18, 0

to

%19 = L4_loadrd_rr %8, %17, 3

Patch By: Pavani Karveti <pkarveti@qti.qulacomm.com>
Author: Santanu Das <santdas@qti.qualcomm.com>