### PR TITLE
[lldb] fix build on linux when undef SEGV_PKUERR

### DIFF
--- a/lldb/source/Plugins/Process/Utility/LinuxSignals.cpp
+++ b/lldb/source/Plugins/Process/Utility/LinuxSignals.cpp
@@ -18,6 +18,9 @@
 #ifndef SEGV_BNDERR
 #define SEGV_BNDERR 3
 #endif
+#ifndef SEGV_PKUERR
+#define SEGV_PKUERR 4
+#endif
 #ifndef SEGV_MTEAERR
 #define SEGV_MTEAERR 8
 #endif


### PR DESCRIPTION
build logs refs: https://github.com/valord577/nativepkgs/actions/runs/22346192467/job/64661318198