### PR TITLE
[ClangScanDeps] Do not emit warning for P1689 format

### DIFF
--- a/clang/lib/DependencyScanning/DependencyScannerImpl.cpp
+++ b/clang/lib/DependencyScanning/DependencyScannerImpl.cpp
@@ -412,6 +412,8 @@ void dependencies::initializeScanCompilerInstance(
   ScanInstance.setBuildingModule(false);
   ScanInstance.createVirtualFileSystem(FS, DiagConsumer);
   ScanInstance.createDiagnostics(DiagConsumer, /*ShouldOwnClient=*/false);
+  if (Service.getOpts().Format == ScanningOutputFormat::P1689)
+    ScanInstance.getDiagnostics().setIgnoreAllWarnings(true);
   ScanInstance.createFileManager();
   ScanInstance.createSourceManager();
 

--- a/clang/test/ClangScanDeps/p1689-suppress-warnings.cppm
+++ b/clang/test/ClangScanDeps/p1689-suppress-warnings.cppm
@@ -1,0 +1,23 @@
+// Test that P1689 format suppresses warnings during dependency scanning.
+// This addresses https://github.com/llvm/llvm-project/issues/185394
+
+// RUN: rm -rf %t
+// RUN: mkdir -p %t
+// RUN: split-file %s %t
+
+// Test P1689 format - should NOT emit warnings
+// RUN: clang-scan-deps -format=p1689 -- %clang++ -std=c++20 -I%t -c %t/mylib.cppm -o %t/mylib.o 2>&1 | FileCheck %s
+
+// CHECK-NOT: warning:
+// CHECK: {
+// CHECK: "revision"
+
+//--- header.h
+// Empty header for testing
+
+//--- mylib.cppm
+module;
+
+export module mylib;
+
+#include <header.h>


### PR DESCRIPTION
Close https://github.com/llvm/llvm-project/issues/185394

This is only for P1689 format as  ClangScanDeps/optimize-vfs-pch.m will check for warning message. I'll leave this to people who want to change that.