### PR TITLE
[libc]: implement 'iswpunct' entrypoint

### DIFF
--- a/libc/config/baremetal/aarch64/entrypoints.txt
+++ b/libc/config/baremetal/aarch64/entrypoints.txt
@@ -300,6 +300,9 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.wchar.wcslen
     libc.src.wchar.wctob
 
+    # wctype.h entrypoints
+    libc.src.wctype.iswpunct
+
     # internal entrypoints
     libc.startup.baremetal.init
     libc.startup.baremetal.fini

--- a/libc/config/baremetal/arm/entrypoints.txt
+++ b/libc/config/baremetal/arm/entrypoints.txt
@@ -311,6 +311,7 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.wctype.iswspace
     libc.src.wctype.iswblank
     libc.src.wctype.iswxdigit
+    libc.src.wctype.iswpunct
     # internal entrypoints
     libc.startup.baremetal.init
     libc.startup.baremetal.fini

--- a/libc/config/baremetal/riscv/entrypoints.txt
+++ b/libc/config/baremetal/riscv/entrypoints.txt
@@ -308,6 +308,7 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.wctype.iswspace
     libc.src.wctype.iswblank
     libc.src.wctype.iswxdigit
+    libc.src.wctype.iswpunct
 
     # internal entrypoints
     libc.startup.baremetal.init

--- a/libc/config/darwin/aarch64/entrypoints.txt
+++ b/libc/config/darwin/aarch64/entrypoints.txt
@@ -111,6 +111,7 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.wctype.iswspace
     libc.src.wctype.iswblank
     libc.src.wctype.iswxdigit
+    libc.src.wctype.iswpunct
 )
 
 if(LLVM_LIBC_FULL_BUILD)

--- a/libc/config/linux/aarch64/entrypoints.txt
+++ b/libc/config/linux/aarch64/entrypoints.txt
@@ -382,6 +382,7 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.wctype.iswspace
     libc.src.wctype.iswblank
     libc.src.wctype.iswxdigit
+    libc.src.wctype.iswpunct
 
     # sys/uio.h entrypoints
     libc.src.sys.uio.writev

--- a/libc/config/linux/arm/entrypoints.txt
+++ b/libc/config/linux/arm/entrypoints.txt
@@ -203,6 +203,7 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.wctype.iswspace
     libc.src.wctype.iswblank
     libc.src.wctype.iswxdigit
+    libc.src.wctype.iswpunct
 )
 
 if(LLVM_LIBC_FULL_BUILD)

--- a/libc/config/linux/riscv/entrypoints.txt
+++ b/libc/config/linux/riscv/entrypoints.txt
@@ -386,6 +386,7 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.wctype.iswspace
     libc.src.wctype.iswblank
     libc.src.wctype.iswxdigit
+    libc.src.wctype.iswpunct
 
     # sys/uio.h entrypoints
     libc.src.sys.uio.writev

--- a/libc/config/linux/x86_64/entrypoints.txt
+++ b/libc/config/linux/x86_64/entrypoints.txt
@@ -431,6 +431,7 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.wctype.iswspace
     libc.src.wctype.iswblank
     libc.src.wctype.iswxdigit
+    libc.src.wctype.iswpunct
 
     # sys/uio.h entrypoints
     libc.src.sys.uio.writev

--- a/libc/config/windows/entrypoints.txt
+++ b/libc/config/windows/entrypoints.txt
@@ -117,6 +117,7 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.wctype.iswspace
     libc.src.wctype.iswblank
     libc.src.wctype.iswxdigit
+    libc.src.wctype.iswpunct
 )
 
 set(TARGET_LIBM_ENTRYPOINTS

--- a/libc/include/wctype.yaml
+++ b/libc/include/wctype.yaml
@@ -62,3 +62,9 @@ functions:
     return_type: int
     arguments:
       - type: wint_t
+  - name: iswpunct
+    standards:
+      - stdc
+    return_type: int
+    arguments:
+      - type: wint_t

--- a/libc/src/wctype/CMakeLists.txt
+++ b/libc/src/wctype/CMakeLists.txt
@@ -115,6 +115,7 @@ add_entrypoint_object(
   HDRS
     iswpunct.h
   DEPENDS
+    libc.src.__support.common
     libc.hdr.types.wint_t
     libc.src.__support.wctype_utils
 )

--- a/libc/src/wctype/CMakeLists.txt
+++ b/libc/src/wctype/CMakeLists.txt
@@ -116,6 +116,6 @@ add_entrypoint_object(
     iswpunct.h
   DEPENDS
     libc.src.__support.common
-    libc.hdr.types.wint_t
     libc.src.__support.wctype_utils
+    libc.hdr.types.wint_t
 )

--- a/libc/src/wctype/CMakeLists.txt
+++ b/libc/src/wctype/CMakeLists.txt
@@ -107,3 +107,14 @@ add_entrypoint_object(
     libc.hdr.types.wint_t
     libc.src.__support.wctype_utils
 )
+
+add_entrypoint_object(
+  iswpunct
+  SRCS
+    iswpunct.cpp
+  HDRS
+    iswpunct.h
+  DEPENDS
+    libc.hdr.types.wint_t
+    libc.src.__support.wctype_utils
+)

--- a/libc/src/wctype/iswpunct.cpp
+++ b/libc/src/wctype/iswpunct.cpp
@@ -1,4 +1,4 @@
-//===-- Implementation of iswspace ----------------------------------------===//
+//===-- Implementation of iswpunct ----------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/libc/src/wctype/iswpunct.cpp
+++ b/libc/src/wctype/iswpunct.cpp
@@ -1,0 +1,19 @@
+//===-- Implementation of iswspace ----------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/wctype/iswpunct.h"
+#include "src/__support/common.h"
+#include "src/__support/wctype_utils.h"
+
+#include "hdr/types/wint_t.h"
+
+namespace LIBC_NAMESPACE_DECL {
+LLVM_LIBC_FUNCTION(int, iswpunct, (wint_t c)) {
+  return internal::ispunct(static_cast<wchar_t>(c));
+}
+} // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/wctype/iswpunct.h
+++ b/libc/src/wctype/iswpunct.h
@@ -1,4 +1,4 @@
-//===-- Implementation header for iswspace ----------------------*- C++ -*-===//
+//===-- Implementation header for iswpunct ----------------------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/libc/src/wctype/iswpunct.h
+++ b/libc/src/wctype/iswpunct.h
@@ -1,0 +1,21 @@
+//===-- Implementation header for iswspace ----------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_WCTYPE_ISWPUNCT_H
+#define LLVM_LIBC_SRC_WCTYPE_ISWPUNCT_H
+
+#include "hdr/types/wint_t.h"
+#include "src/__support/common.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+int iswpunct(wint_t c);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_WCTYPE_ISWPUNCT_H

--- a/libc/test/src/wctype/CMakeLists.txt
+++ b/libc/test/src/wctype/CMakeLists.txt
@@ -101,3 +101,13 @@ add_libc_test(
   DEPENDS
     libc.src.wctype.iswupper
 )
+
+add_libc_test(
+  iswpunct_test
+  SUITE
+    libc_wctype_unittests
+  SRCS
+    iswpunct_test.cpp
+  DEPENDS
+    libc.src.wctype.iswpunct
+)

--- a/libc/test/src/wctype/iswpunct_test.cpp
+++ b/libc/test/src/wctype/iswpunct_test.cpp
@@ -1,4 +1,4 @@
-//===-- Unittests for iswspace --------------------------------------------===//
+//===-- Unittests for iswpunct --------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/libc/test/src/wctype/iswpunct_test.cpp
+++ b/libc/test/src/wctype/iswpunct_test.cpp
@@ -1,0 +1,63 @@
+//===-- Unittests for iswspace --------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/wctype/iswpunct.h"
+
+#include "test/UnitTest/Test.h"
+
+TEST(LlvmLibciswpunct, SimpleTest) {
+  EXPECT_NE(LIBC_NAMESPACE::iswpunct('!'), 0);
+  EXPECT_NE(LIBC_NAMESPACE::iswpunct('\"'), 0);
+  EXPECT_NE(LIBC_NAMESPACE::iswpunct('#'), 0);
+  EXPECT_NE(LIBC_NAMESPACE::iswpunct('$'), 0);
+  EXPECT_NE(LIBC_NAMESPACE::iswpunct('%'), 0);
+  EXPECT_NE(LIBC_NAMESPACE::iswpunct('&'), 0);
+  EXPECT_NE(LIBC_NAMESPACE::iswpunct('\''), 0);
+  EXPECT_NE(LIBC_NAMESPACE::iswpunct('('), 0);
+  EXPECT_NE(LIBC_NAMESPACE::iswpunct(')'), 0);
+  EXPECT_NE(LIBC_NAMESPACE::iswpunct('*'), 0);
+  EXPECT_NE(LIBC_NAMESPACE::iswpunct('+'), 0);
+  EXPECT_NE(LIBC_NAMESPACE::iswpunct(','), 0);
+  EXPECT_NE(LIBC_NAMESPACE::iswpunct('-'), 0);
+  EXPECT_NE(LIBC_NAMESPACE::iswpunct('.'), 0);
+  EXPECT_NE(LIBC_NAMESPACE::iswpunct('/'), 0);
+  EXPECT_NE(LIBC_NAMESPACE::iswpunct(':'), 0);
+  EXPECT_NE(LIBC_NAMESPACE::iswpunct(';'), 0);
+  EXPECT_NE(LIBC_NAMESPACE::iswpunct('<'), 0);
+  EXPECT_NE(LIBC_NAMESPACE::iswpunct('='), 0);
+  EXPECT_NE(LIBC_NAMESPACE::iswpunct('>'), 0);
+  EXPECT_NE(LIBC_NAMESPACE::iswpunct('?'), 0);
+  EXPECT_NE(LIBC_NAMESPACE::iswpunct('@'), 0);
+  EXPECT_NE(LIBC_NAMESPACE::iswpunct('['), 0);
+  EXPECT_NE(LIBC_NAMESPACE::iswpunct('\\'), 0);
+  EXPECT_NE(LIBC_NAMESPACE::iswpunct(']'), 0);
+  EXPECT_NE(LIBC_NAMESPACE::iswpunct('^'), 0);
+  EXPECT_NE(LIBC_NAMESPACE::iswpunct('_'), 0);
+  EXPECT_NE(LIBC_NAMESPACE::iswpunct('`'), 0);
+  EXPECT_NE(LIBC_NAMESPACE::iswpunct('{'), 0);
+  EXPECT_NE(LIBC_NAMESPACE::iswpunct('|'), 0);
+  EXPECT_NE(LIBC_NAMESPACE::iswpunct('}'), 0);
+  EXPECT_NE(LIBC_NAMESPACE::iswpunct('~'), 0);
+
+  EXPECT_EQ(LIBC_NAMESPACE::iswpunct('\n'), 0);
+  EXPECT_EQ(LIBC_NAMESPACE::iswpunct('\v'), 0);
+  EXPECT_EQ(LIBC_NAMESPACE::iswpunct('\f'), 0);
+  EXPECT_EQ(LIBC_NAMESPACE::iswpunct('\r'), 0);
+  EXPECT_EQ(LIBC_NAMESPACE::iswpunct('\0'), 0);
+  EXPECT_EQ(LIBC_NAMESPACE::iswpunct('\t'), 0);
+  EXPECT_EQ(LIBC_NAMESPACE::iswpunct(' '), 0);
+  EXPECT_EQ(LIBC_NAMESPACE::iswpunct('0'), 0);
+  EXPECT_EQ(LIBC_NAMESPACE::iswpunct('5'), 0);
+  EXPECT_EQ(LIBC_NAMESPACE::iswpunct('9'), 0);
+  EXPECT_EQ(LIBC_NAMESPACE::iswpunct('A'), 0);
+  EXPECT_EQ(LIBC_NAMESPACE::iswpunct('M'), 0);
+  EXPECT_EQ(LIBC_NAMESPACE::iswpunct('Z'), 0);
+  EXPECT_EQ(LIBC_NAMESPACE::iswpunct('a'), 0);
+  EXPECT_EQ(LIBC_NAMESPACE::iswpunct('m'), 0);
+  EXPECT_EQ(LIBC_NAMESPACE::iswpunct('z'), 0);
+}


### PR DESCRIPTION
Added entrypoints:
- baremetal/arm
- baremetal/aarch64
- baremetal/riscv
- darwin/aarch64
- linux/aarch64
- linux/arm
- linux/riscv
- linux/x86_64
- windows

Also added the unit test for iswpunct.

Part of the issue: #185136 