### PR TITLE
[libclc] Fix check-libclc dependency on llvm-dis

### DIFF
--- a/libclc/CMakeLists.txt
+++ b/libclc/CMakeLists.txt
@@ -48,7 +48,7 @@ if( LIBCLC_STANDALONE_BUILD OR CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DI
 
   message( STATUS "libclc LLVM version: ${LLVM_PACKAGE_VERSION}" )
 
-  foreach( tool IN ITEMS llvm-link opt )
+  foreach( tool IN ITEMS llvm-link llvm-dis opt )
     find_program( LLVM_TOOL_${tool} ${tool} PATHS ${LLVM_TOOLS_BINARY_DIR} NO_DEFAULT_PATH )
     set( ${tool}_exe ${LLVM_TOOL_${tool}} )
     set( ${tool}_target )
@@ -73,6 +73,7 @@ else()
   endif()
 
   get_host_tool_path( llvm-link LLVM_LINK llvm-link_exe llvm-link_target )
+  get_host_tool_path( llvm-dis LLVM_DIS llvm-dis_exe llvm-dis_target )
   get_host_tool_path( opt OPT opt_exe opt_target )
 
   # Setup the paths where libclc runtimes should be stored. By default, in an

--- a/libclc/test/CMakeLists.txt
+++ b/libclc/test/CMakeLists.txt
@@ -2,7 +2,7 @@ set(LIBCLC_LIBRARY_DIR ${LIBCLC_OUTPUT_LIBRARY_DIR})
 set(LLVM_TOOLS_DIR ${LLVM_TOOLS_BINARY_DIR})
 
 set(LIBCLC_TEST_DEPS
-  llvm-dis
+  ${llvm-dis_target}
 )
 
 umbrella_lit_testsuite_begin(check-libclc)

--- a/llvm/runtimes/CMakeLists.txt
+++ b/llvm/runtimes/CMakeLists.txt
@@ -554,7 +554,7 @@ if(build_runtimes)
 
   # TODO: We need to consider passing it as '-DRUNTIMES_x86_64_LLVM_ENABLE_RUNTIMES'.
   if("libclc" IN_LIST LLVM_ENABLE_RUNTIMES)
-    foreach(dep clang llvm-as llvm-link opt llvm-ar llvm-ranlib)
+    foreach(dep clang llvm-as llvm-dis llvm-link opt llvm-ar llvm-ranlib)
       if(TARGET ${dep})
         list(APPEND extra_deps ${dep})
       endif()


### PR DESCRIPTION
Add llvm-dis to libclc runtime dependencies.