### PR TITLE
[llvm-jitlink] [test] Add an XFAIL for a JITLink test on MinGW

### DIFF
--- a/llvm/test/ExecutionEngine/JITLink/Generic/waiting-on-graph-capture-replay.test
+++ b/llvm/test/ExecutionEngine/JITLink/Generic/waiting-on-graph-capture-replay.test
@@ -14,6 +14,11 @@
 # JITLink does not support ARM64 COFF files.
 # UNSUPPORTED: target=aarch64-{{.*}}-windows-{{.*}}
 
+# On MinGW targets, when compiling the main() function, it gets
+# an implicitly generated call to __main(), which is missing in
+# this context.
+# XFAIL: target={{.*}}-windows-gnu
+
 # CAPTURE: simplify-and-emit
 # CAPTURE: end
 


### PR DESCRIPTION
This testcase fails on MinGW targets, because when compiling the main() function, it gets an implicit call to __main(), which is missing in this context.

See 4c642b62b99fa128c180f28278637b32be5e5576 and
9b282afb8ac1c810da684591c27faf6117e62e3b for existing precedent for such XFAILs.