### PR TITLE
[Flang][Docs][NFC] Move OpenMP API extensions to separate document

### DIFF
--- a/flang/docs/OpenMP-extensions.md
+++ b/flang/docs/OpenMP-extensions.md
@@ -1,0 +1,36 @@
+<!--===- docs/OpenMP-extensions.md
+
+   Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+   See https://llvm.org/LICENSE.txt for license information.
+   SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+-->
+
+# OpenMP API Extensions Supported by Flang
+
+```{contents}
+---
+local:
+---
+```
+The Flang compiler supports several extensions to OpenMP API features, providing enhanced parallelism and data management capabilities for Fortran applications.  This document outlines the supported extensions and their usage within Flang.
+
+
+## Supported OpenMP API Extensions
+
+The following extensions are supported by Flang.
+
+
+### ATOMIC Construct
+The implementation of the ATOMIC construct follows OpenMP 6.0 with the following extensions:
+- `x = x` is an allowed form of ATOMIC UPDATE.
+This is motivated by the fact that the equivalent forms `x = x+0` or `x = x*1` are allowed.
+- Explicit type conversions are allowed in ATOMIC READ, WRITE or UPDATE constructs, and in the capture statement in ATOMIC UPDATE CAPTURE.
+The OpenMP spec requires intrinsic- or pointer-assignments, which include (as per the Fortran standard) implicit type conversions.  Since such conversions need to be handled, allowing explicit conversions comes at no extra cost.
+- A literal `.true.` or `.false.` is an allowed condition in ATOMIC UPDATE COMPARE. [1]
+- A logical variable is an allowed form of the condition even if its value is not computed within the ATOMIC UPDATE COMPARE construct [1].
+- `expr equalop x` is an allowed condition in ATOMIC UPDATE COMPARE. [1]
+
+
+### Data-sharing Clauses and Directives
+- Using `COMMON` block variables in an `EQUIVALENCE` statement in `THREADPRIVATE` directives.

--- a/flang/docs/OpenMP-extensions.md
+++ b/flang/docs/OpenMP-extensions.md
@@ -28,7 +28,7 @@ The following extensions are supported by Flang.
 ### ATOMIC Construct
 The implementation of the ATOMIC construct follows OpenMP 6.0 with the following extensions:
 - `x = x` is an allowed form of ATOMIC UPDATE.
-   This is motivated by the fact that the equivalent forms `x = x+0` or `x = x*1` are allowed.
+  This is motivated by the fact that the equivalent forms `x = x+0` or `x = x*1` are allowed.
 - Explicit type conversions are allowed in ATOMIC READ, WRITE or UPDATE constructs, and in the capture statement in ATOMIC UPDATE CAPTURE.
   The OpenMP spec requires intrinsic- or pointer-assignments, which include (as per the Fortran standard) implicit type conversions.  Since such conversions need to be handled, allowing explicit conversions comes at no extra cost.
 - A literal `.true.` or `.false.` is an allowed condition in ATOMIC UPDATE COMPARE. [1]

--- a/flang/docs/OpenMP-extensions.md
+++ b/flang/docs/OpenMP-extensions.md
@@ -16,6 +16,7 @@ See also {doc}`OpenMPSupport` for a general overview of OpenMP support in Flang.
 local:
 ---
 ```
+
 The Flang compiler supports several extensions to OpenMP API features, providing enhanced parallelism and data management capabilities for Fortran applications.  This document outlines the supported extensions and their usage within Flang.
 
 
@@ -27,13 +28,14 @@ The following extensions are supported by Flang.
 ### ATOMIC Construct
 The implementation of the ATOMIC construct follows OpenMP 6.0 with the following extensions:
 - `x = x` is an allowed form of ATOMIC UPDATE.
-This is motivated by the fact that the equivalent forms `x = x+0` or `x = x*1` are allowed.
+   This is motivated by the fact that the equivalent forms `x = x+0` or `x = x*1` are allowed.
 - Explicit type conversions are allowed in ATOMIC READ, WRITE or UPDATE constructs, and in the capture statement in ATOMIC UPDATE CAPTURE.
-The OpenMP spec requires intrinsic- or pointer-assignments, which include (as per the Fortran standard) implicit type conversions.  Since such conversions need to be handled, allowing explicit conversions comes at no extra cost.
-- A literal `.true.` or `.false.` is an allowed condition in ATOMIC UPDATE COMPARE. [1]
+  The OpenMP spec requires intrinsic- or pointer-assignments, which include (as per the Fortran standard) implicit type conversions.  Since such conversions need to be handled, allowing explicit conversions comes at no extra cost.
+- A literal `.true.` or `.false.` is an allowed condition in ATOMIC UPDATE COMPARE. (Code generation for ATOMIC UPDATE COMPARE is not implemented yet.)
 - A logical variable is an allowed form of the condition even if its value is not computed within the ATOMIC UPDATE COMPARE construct [1].
 - `expr equalop x` is an allowed condition in ATOMIC UPDATE COMPARE. [1]
 
 
 ### Data-sharing Clauses and Directives
 - Using `COMMON` block variables in an `EQUIVALENCE` statement in `THREADPRIVATE` directives.
+

--- a/flang/docs/OpenMP-extensions.md
+++ b/flang/docs/OpenMP-extensions.md
@@ -6,7 +6,10 @@
 
 -->
 
+(openmp-extensions)=
 # OpenMP API Extensions Supported by Flang
+
+See also {doc}`OpenMPSupport` for a general overview of OpenMP support in Flang.
 
 ```{contents}
 ---

--- a/flang/docs/OpenMP-extensions.md
+++ b/flang/docs/OpenMP-extensions.md
@@ -31,7 +31,7 @@ The implementation of the ATOMIC construct follows OpenMP 6.0 with the following
    This is motivated by the fact that the equivalent forms `x = x+0` or `x = x*1` are allowed.
 - Explicit type conversions are allowed in ATOMIC READ, WRITE or UPDATE constructs, and in the capture statement in ATOMIC UPDATE CAPTURE.
   The OpenMP spec requires intrinsic- or pointer-assignments, which include (as per the Fortran standard) implicit type conversions.  Since such conversions need to be handled, allowing explicit conversions comes at no extra cost.
-- A literal `.true.` or `.false.` is an allowed condition in ATOMIC UPDATE COMPARE. (Code generation for ATOMIC UPDATE COMPARE is not implemented yet.)
+- A literal `.true.` or `.false.` is an allowed condition in ATOMIC UPDATE COMPARE. [1]
 - A logical variable is an allowed form of the condition even if its value is not computed within the ATOMIC UPDATE COMPARE construct [1].
 - `expr equalop x` is an allowed condition in ATOMIC UPDATE COMPARE. [1]
 
@@ -39,3 +39,4 @@ The implementation of the ATOMIC construct follows OpenMP 6.0 with the following
 ### Data-sharing Clauses and Directives
 - Using `COMMON` block variables in an `EQUIVALENCE` statement in `THREADPRIVATE` directives.
 
+[1] Code generation for ATOMIC UPDATE COMPARE is not implemented yet.

--- a/flang/docs/OpenMPSupport.md
+++ b/flang/docs/OpenMPSupport.md
@@ -61,15 +61,4 @@ Note : No distinction is made between the support in Parser/Semantics, MLIR, Low
 | teams distribute parallel loop simd construct              | P      | Implicit linearization is skipped if iv is a pointer or allocatable |
 | target teams distribute parallel loop simd construct       | P      | Implicit linearization is completely skipped |
 
-## Extensions
-### ATOMIC construct
-The implementation of the ATOMIC construct follows OpenMP 6.0 with the following extensions:
-- `x = x` is an allowed form of ATOMIC UPDATE.
-This is motivated by the fact that the equivalent forms `x = x+0` or `x = x*1` are allowed.
-- Explicit type conversions are allowed in ATOMIC READ, WRITE or UPDATE constructs, and in the capture statement in ATOMIC UPDATE CAPTURE.
-The OpenMP spec requires intrinsic- or pointer-assignments, which include (as per the Fortran standard) implicit type conversions.  Since such conversions need to be handled, allowing explicit conversions comes at no extra cost.
-- A literal `.true.` or `.false.` is an allowed condition in ATOMIC UPDATE COMPARE. [1]
-- A logical variable is an allowed form of the condition even if its value is not computed within the ATOMIC UPDATE COMPARE construct [1].
-- `expr equalop x` is an allowed condition in ATOMIC UPDATE COMPARE. [1]
-
 [1] Code generation for ATOMIC UPDATE COMPARE is not implemented yet.

--- a/flang/docs/OpenMPSupport.md
+++ b/flang/docs/OpenMPSupport.md
@@ -48,7 +48,7 @@ Note : No distinction is made between the support in Parser/Semantics, MLIR, Low
 | distribute parallel loop simd construct                    | P      | Implicit linearization is skipped if iv is a pointer or allocatable |
 | depend clause                                              | Y      | |
 | declare reduction construct                                | N      | |
-| atomic construct extensions                                | Y      | |
+| atomic construct extensions                                | Y      | Code generation for ATOMIC UPDATE COMPARE is not implemented yet. |
 | cancel construct                                           | Y      | |
 | cancellation point construct                               | Y      | |
 | parallel do simd construct                                 | P      | Implicit linearization is skipped if iv is a pointer or allocatable |
@@ -61,4 +61,3 @@ Note : No distinction is made between the support in Parser/Semantics, MLIR, Low
 | teams distribute parallel loop simd construct              | P      | Implicit linearization is skipped if iv is a pointer or allocatable |
 | target teams distribute parallel loop simd construct       | P      | Implicit linearization is completely skipped |
 
-[1] Code generation for ATOMIC UPDATE COMPARE is not implemented yet.

--- a/flang/docs/OpenMPSupport.md
+++ b/flang/docs/OpenMPSupport.md
@@ -48,7 +48,7 @@ Note : No distinction is made between the support in Parser/Semantics, MLIR, Low
 | distribute parallel loop simd construct                    | P      | Implicit linearization is skipped if iv is a pointer or allocatable |
 | depend clause                                              | Y      | |
 | declare reduction construct                                | N      | |
-| atomic construct extensions                                | Y      | Code generation for ATOMIC UPDATE COMPARE is not implemented yet. |
+| atomic construct extensions                                | Y      | |
 | cancel construct                                           | Y      | |
 | cancellation point construct                               | Y      | |
 | parallel do simd construct                                 | P      | Implicit linearization is skipped if iv is a pointer or allocatable |

--- a/flang/docs/index.md
+++ b/flang/docs/index.md
@@ -28,6 +28,7 @@ on how to get in touch with us and to learn more about the current status.
    Extensions
    Directives
    OpenMPSupport
+   OpenMP-extensions
    Real16MathSupport
    Unsigned
    FAQ


### PR DESCRIPTION
This PR follows suit of the Extensions.md document and provides the same file for OpenMP API extensions.  These have previously been stored in OpenMPSupport.md.  Having a more centralized view and place for these extensions seems useful.