### PR TITLE
libclc: Use small trig reduction for nan

### DIFF
--- a/libclc/clc/lib/generic/math/clc_sincos_helpers.cl
+++ b/libclc/clc/lib/generic/math/clc_sincos_helpers.cl
@@ -6,6 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "clc/math/clc_frexp.h"
+#include "clc/math/clc_ldexp.h"
 #include <clc/clc_convert.h>
 #include <clc/integer/clc_clz.h>
 #include <clc/integer/clc_mul_hi.h>

--- a/libclc/clc/lib/generic/math/clc_sincos_helpers.inc
+++ b/libclc/clc/lib/generic/math/clc_sincos_helpers.inc
@@ -348,18 +348,17 @@ _CLC_DEF _CLC_OVERLOAD __CLC_INTN __clc_argReductionLargeS(
 _CLC_DEF _CLC_OVERLOAD __CLC_INTN __clc_argReductionS(private __CLC_FLOATN *r,
                                                       private __CLC_FLOATN *rr,
                                                       __CLC_FLOATN x) {
-  __CLC_INTN is_small = x < (__CLC_FLOATN)0x1.0p+23f;
+  __CLC_INTN is_large = x >= (__CLC_FLOATN)0x1.0p+23f;
 #ifdef __CLC_SCALAR
-  if (is_small)
-    return __clc_argReductionSmallS(r, rr, x);
-  else
+  if (is_large)
     return __clc_argReductionLargeS(r, rr, x);
+  return __clc_argReductionSmallS(r, rr, x);
 #else
   __CLC_FLOATN r1, rr1, r2, rr2;
   __CLC_INTN ret1 = __clc_argReductionSmallS(&r1, &rr1, x);
   __CLC_INTN ret2 = __clc_argReductionLargeS(&r2, &rr2, x);
-  *r = is_small ? r1 : r2;
-  *rr = is_small ? rr1 : rr2;
-  return is_small ? ret1 : ret2;
+  *r = is_large ? r2 : r1;
+  *rr = is_large ? rr2 : rr1;
+  return is_large ? ret2 : ret1;
 #endif
 }

--- a/libclc/clc/lib/generic/math/clc_sincos_helpers.inc
+++ b/libclc/clc/lib/generic/math/clc_sincos_helpers.inc
@@ -199,8 +199,11 @@ _CLC_DEF _CLC_OVERLOAD __CLC_INTN __clc_argReductionSmallS(
 
 _CLC_DEF _CLC_OVERLOAD __CLC_INTN __clc_argReductionLargeS(
     private __CLC_FLOATN *r, private __CLC_FLOATN *rr, __CLC_FLOATN x) {
-  __CLC_INTN xe = __CLC_AS_INTN((__CLC_AS_UINTN(x) >> 23) - 127);
-  __CLC_UINTN xm = 0x00800000U | (__CLC_AS_UINTN(x) & 0x7fffffU);
+  __CLC_INTN xe;
+  __CLC_FLOATN m = __clc_frexp(x, &xe);
+  --xe;
+
+  __CLC_UINTN xm = __CLC_CONVERT_UINTN(__clc_ldexp(m, 24));
 
   // 224 bits of 2/PI: . A2F9836E 4E441529 FC2757D1 F534DDC0 DB629599 3C439041
   // FE5163AB


### PR DESCRIPTION
Nan should work on either path, but the small reduction
path is smaller. There's also possible codegen benefits to
knowing the large reduction will not need to handle nans.