### PR TITLE
[DTLTO] Speed up temporary file removal in the ThinLTO backend

### DIFF
--- a/llvm/lib/LTO/LTO.cpp
+++ b/llvm/lib/LTO/LTO.cpp
@@ -43,6 +43,7 @@
 #include "llvm/Support/Error.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/JSON.h"
+#include "llvm/Support/ManagedStatic.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/Path.h"
 #include "llvm/Support/Process.h"
@@ -2231,6 +2232,52 @@ std::vector<int> lto::generateModulesOrdering(ArrayRef<BitcodeModule *> R) {
 }
 
 namespace {
+// There can be many temporary files to remove. Performing deletion in
+// the background can save a few seconds on Windows hosts. Experimentation
+// showed that serial deletion is most efficient, hence a single thread.
+struct BackgroundDeletion : llvm::DefaultThreadPool {
+  BackgroundDeletion()
+      : llvm::DefaultThreadPool(llvm::heavyweight_hardware_concurrency(1)) {}
+
+  ~BackgroundDeletion() {
+    wait();
+    for (std::string &Warning : Warnings)
+      errs() << Warning;
+  }
+
+  void remove(SmallVector<std::string> &&Files,
+              std::optional<unsigned> TimeTraceGranularity) {
+    async([this, Files = std::move(Files), TTG = TimeTraceGranularity] {
+      if (TTG)
+        timeTraceProfilerInitialize(*TTG, "Remove DTLTO temporary files");
+      {
+        llvm::TimeTraceScope TimeScope("Remove DTLTO temporary files");
+        for (auto &F : Files) {
+          std::error_code EC = sys::fs::remove(F, true);
+          if (EC && EC != std::make_error_code(
+                              std::errc::no_such_file_or_directory)) {
+            std::lock_guard<std::mutex> Lock(WarningMutex);
+            Warnings.emplace_back(
+                (Twine("warning: could not remove the file '") + F +
+                 "': " + EC.message() + "\n")
+                    .str());
+          }
+        }
+      }
+      if (TTG)
+        timeTraceProfilerFinishThread();
+    });
+  }
+
+private:
+  std::mutex WarningMutex;
+  SmallVector<std::string> Warnings;
+};
+
+// Use a ManagedStatic to allow the thread to run until llvm_shutdown() is
+// called for the current process.
+static llvm::ManagedStatic<BackgroundDeletion> BackgroundDeleter;
+
 /// This out-of-process backend does not perform code generation when invoked
 /// for each task. Instead, it generates the necessary information (e.g., the
 /// summary index shard, import list, etc.) to enable code generation to be
@@ -2563,13 +2610,18 @@ public:
       return std::move(*Err);
 
     llvm::scope_exit CleanPerJobFiles([&] {
-      llvm::TimeTraceScope TimeScope("Remove DTLTO temporary files");
-      if (!SaveTemps)
-        for (auto &Job : Jobs) {
-          removeFile(Job.NativeObjectPath);
-          if (!ShouldEmitIndexFiles)
-            removeFile(Job.SummaryIndexPath);
-        }
+      if (SaveTemps)
+        return;
+      SmallVector<std::string> Files;
+      for (auto &Job : Jobs) {
+        Files.push_back(std::string(Job.NativeObjectPath));
+        if (!ShouldEmitIndexFiles)
+          Files.push_back(std::string(Job.SummaryIndexPath));
+      }
+      std::optional<unsigned> TimeTraceGranularity;
+      if (LLVM_ENABLE_THREADS && Conf.TimeTraceEnabled)
+        TimeTraceGranularity = Conf.TimeTraceGranularity;
+      BackgroundDeleter->remove(std::move(Files), TimeTraceGranularity);
     });
 
     const StringRef BCError = "DTLTO backend compilation: ";

--- a/llvm/lib/LTO/LTO.cpp
+++ b/llvm/lib/LTO/LTO.cpp
@@ -2245,11 +2245,12 @@ struct BackgroundDeletion : llvm::DefaultThreadPool {
       errs() << Warning;
   }
 
-  void remove(SmallVector<std::string> &&Files,
-              std::optional<unsigned> TimeTraceGranularity) {
-    async([this, Files = std::move(Files), TTG = TimeTraceGranularity] {
-      if (TTG)
-        timeTraceProfilerInitialize(*TTG, "Remove DTLTO temporary files");
+  void remove(SmallVector<std::string> &&Files, bool TimeTraceEnabled,
+              unsigned TimeTraceGranularity) {
+    async([this, Files = std::move(Files), TTE = TimeTraceEnabled,
+           TTG = TimeTraceGranularity] {
+      if (LLVM_ENABLE_THREADS && TTE)
+        timeTraceProfilerInitialize(TTG, "Remove DTLTO temporary files");
       {
         llvm::TimeTraceScope TimeScope("Remove DTLTO temporary files");
         for (auto &F : Files) {
@@ -2263,7 +2264,7 @@ struct BackgroundDeletion : llvm::DefaultThreadPool {
           }
         }
       }
-      if (TTG)
+      if (LLVM_ENABLE_THREADS && TTE)
         timeTraceProfilerFinishThread();
     });
   }
@@ -2615,10 +2616,8 @@ public:
         if (!ShouldEmitIndexFiles)
           Files.push_back(std::string(Job.SummaryIndexPath));
       }
-      std::optional<unsigned> TimeTraceGranularity;
-      if (LLVM_ENABLE_THREADS && Conf.TimeTraceEnabled)
-        TimeTraceGranularity = Conf.TimeTraceGranularity;
-      BackgroundDeleter->remove(std::move(Files), TimeTraceGranularity);
+      BackgroundDeleter->remove(std::move(Files), Conf.TimeTraceEnabled,
+                                Conf.TimeTraceGranularity);
     });
 
     const StringRef BCError = "DTLTO backend compilation: ";

--- a/llvm/lib/LTO/LTO.cpp
+++ b/llvm/lib/LTO/LTO.cpp
@@ -2256,7 +2256,6 @@ struct BackgroundDeletion : llvm::DefaultThreadPool {
           std::error_code EC = sys::fs::remove(F, true);
           if (EC && EC != std::make_error_code(
                               std::errc::no_such_file_or_directory)) {
-            std::lock_guard<std::mutex> Lock(WarningMutex);
             Warnings.emplace_back(
                 (Twine("warning: could not remove the file '") + F +
                  "': " + EC.message() + "\n")
@@ -2269,8 +2268,6 @@ struct BackgroundDeletion : llvm::DefaultThreadPool {
     });
   }
 
-private:
-  std::mutex WarningMutex;
   SmallVector<std::string> Warnings;
 };
 

--- a/llvm/lib/LTO/LTO.cpp
+++ b/llvm/lib/LTO/LTO.cpp
@@ -2241,27 +2241,22 @@ struct BackgroundDeletion : llvm::DefaultThreadPool {
 
   ~BackgroundDeletion() {
     wait();
-    for (std::string &Warning : Warnings)
-      errs() << Warning;
+    for (const std::string &Warning : Warnings)
+      errs() << "warning: could not remove the file " << Warning << "\n";
   }
 
-  void remove(SmallVector<std::string> &&Files, bool TimeTraceEnabled,
-              unsigned TimeTraceGranularity) {
-    async([this, Files = std::move(Files), TTE = TimeTraceEnabled,
-           TTG = TimeTraceGranularity] {
+  void remove(SmallVector<std::string> &&Files, const Config &Conf) {
+    async([this, Files = std::move(Files), TTE = Conf.TimeTraceEnabled,
+           TTG = Conf.TimeTraceGranularity] {
       if (LLVM_ENABLE_THREADS && TTE)
         timeTraceProfilerInitialize(TTG, "Remove DTLTO temporary files");
       {
         llvm::TimeTraceScope TimeScope("Remove DTLTO temporary files");
-        for (auto &F : Files) {
+        for (const auto &F : Files) {
           std::error_code EC = sys::fs::remove(F, true);
-          if (EC && EC != std::make_error_code(
-                              std::errc::no_such_file_or_directory)) {
-            Warnings.emplace_back(
-                (Twine("warning: could not remove the file '") + F +
-                 "': " + EC.message() + "\n")
-                    .str());
-          }
+          if (EC &&
+              EC != std::make_error_code(std::errc::no_such_file_or_directory))
+            Warnings.emplace_back("'" + F + "': " + EC.message());
         }
       }
       if (LLVM_ENABLE_THREADS && TTE)
@@ -2616,8 +2611,7 @@ public:
         if (!ShouldEmitIndexFiles)
           Files.push_back(std::string(Job.SummaryIndexPath));
       }
-      BackgroundDeleter->remove(std::move(Files), Conf.TimeTraceEnabled,
-                                Conf.TimeTraceGranularity);
+      BackgroundDeleter->remove(std::move(Files), Conf);
     });
 
     const StringRef BCError = "DTLTO backend compilation: ";

--- a/llvm/tools/llvm-lto2/llvm-lto2.cpp
+++ b/llvm/tools/llvm-lto2/llvm-lto2.cpp
@@ -26,6 +26,7 @@
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/InitLLVM.h"
+#include "llvm/Support/ManagedStatic.h"
 #include "llvm/Support/PluginLoader.h"
 #include "llvm/Support/TargetSelect.h"
 #include "llvm/Support/Threading.h"
@@ -285,6 +286,7 @@ static int run(int argc, char **argv) {
   if (TimeTrace)
     timeTraceProfilerInitialize(TimeTraceGranularity, argv[0]);
   llvm::scope_exit TimeTraceScopeExit([]() {
+    llvm::llvm_shutdown();
     if (TimeTrace) {
       check(timeTraceProfilerWrite(TimeTraceFile, OutputFilename),
             "timeTraceProfilerWrite failed");

--- a/llvm/tools/llvm-lto2/llvm-lto2.cpp
+++ b/llvm/tools/llvm-lto2/llvm-lto2.cpp
@@ -285,7 +285,7 @@ static int run(int argc, char **argv) {
 
   if (TimeTrace)
     timeTraceProfilerInitialize(TimeTraceGranularity, argv[0]);
-  llvm::scope_exit TimeTraceScopeExit([]() {
+  llvm::scope_exit ShutdownScopeExit([]() {
     llvm::llvm_shutdown();
     if (TimeTrace) {
       check(timeTraceProfilerWrite(TimeTraceFile, OutputFilename),

--- a/llvm/tools/llvm-lto2/llvm-lto2.cpp
+++ b/llvm/tools/llvm-lto2/llvm-lto2.cpp
@@ -286,6 +286,9 @@ static int run(int argc, char **argv) {
   if (TimeTrace)
     timeTraceProfilerInitialize(TimeTraceGranularity, argv[0]);
   llvm::scope_exit ShutdownScopeExit([]() {
+    // llvm_shutdown must be called before finalizing the time trace to
+    // ensure that time trace scopes from ManagedStatic destructors are
+    // flushed and recorded.
     llvm::llvm_shutdown();
     if (TimeTrace) {
       check(timeTraceProfilerWrite(TimeTraceFile, OutputFilename),


### PR DESCRIPTION
Deleting the temporary files produced by the DTLTO ThinLTO backend can be expensive on Windows hosts. For a Clang link (Debug build with sanitizers and instrumentation) using an optimized toolchain (PGO non-LTO, llvmorg-22.1.0) on a Windows 11 Pro (Build 26200), AMD Family 25 @ ~4.5 GHz, 16 cores / 32 threads, 64 GB RAM machine, the mean duration of the "Remove DTLTO temporary files" time trace scope was 1267.789 ms (measured over 10 runs).

This patch performs the deletions on a background thread, allowing them to overlap with the remainder of the link to hide this cost.

Based on work by @romanova-ekaterina and @kbelochapka.

