### PR TITLE
[LifetimeSafety] Exclude basic_string::insert from capturing methods

### DIFF
--- a/clang/lib/Sema/SemaAttr.cpp
+++ b/clang/lib/Sema/SemaAttr.cpp
@@ -320,6 +320,8 @@ void Sema::inferLifetimeCaptureByAttribute(FunctionDecl *FD) {
       "insert", "insert_or_assign", "push", "push_front", "push_back"};
   if (!CapturingMethods.contains(MD->getName()))
     return;
+  if (MD->getName() == "insert" && MD->getParent()->getName() == "basic_string")
+    return;
   Annotate(MD);
 }
 

--- a/clang/test/Sema/Inputs/lifetime-analysis.h
+++ b/clang/test/Sema/Inputs/lifetime-analysis.h
@@ -176,6 +176,9 @@ struct basic_string {
   basic_string& operator+=(const basic_string&);
   basic_string& operator+=(const T*);
   void push_back(T);
+
+  template<class StringViewLike> basic_string& insert(size_t index, const StringViewLike&);
+
   void clear();
   const T *c_str() const;
   operator basic_string_view<T> () const;

--- a/clang/test/Sema/warn-lifetime-analysis-nocfg.cpp
+++ b/clang/test/Sema/warn-lifetime-analysis-nocfg.cpp
@@ -1287,3 +1287,8 @@ void test() {
     const auto ptrTSC = StringTemplateSpecC<char>().data();  // Both have attribute         // expected-warning {{temporary whose address is used}}
 }
 } // namespace GH175391
+
+void string_insert_GH_186817() {
+    std::string msg;
+    msg.insert(0, std::string_view(std::string("a temporary")));
+}


### PR DESCRIPTION
Fixes https://github.com/llvm/llvm-project/issues/186817