### PR TITLE
[NFC][SPIR-V] Verify baseline test status on main

### DIFF
--- a/llvm/test/CodeGen/SPIRV/pointers/PtrCast-in-OpSpecConstantOp.ll
+++ b/llvm/test/CodeGen/SPIRV/pointers/PtrCast-in-OpSpecConstantOp.ll
@@ -1,3 +1,4 @@
+; No-op change to trigger CI and verify baseline test status on main.
 ; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv32-unknown-unknown %s -o - | FileCheck %s
 ; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv64-unknown-unknown %s -o - -filetype=obj | spirv-val %}
 


### PR DESCRIPTION
## Summary

No-op comment addition to trigger CI and verify that the 5 SPIR-V pointer/SpecConstantOp validation test failures exist on current `main`, independent of any other PRs.

Failing tests to verify:
- `CodeGen/SPIRV/pointers/PtrCast-in-OpSpecConstantOp.ll`
- `CodeGen/SPIRV/pointers/global-ptrtoint.ll`
- `CodeGen/SPIRV/pointers/nested-struct-opaque-pointers.ll`
- `CodeGen/SPIRV/pointers/struct-opaque-pointers.ll`
- `CodeGen/SPIRV/transcoding/ConvertPtrInGlobalInit.ll`

**This PR is not intended to be merged.** Will be closed once CI results confirm.