### PR TITLE
[AMDGPU] IGroupLP: Fix BestCost assignment in greedy solver (NFC)

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUIGroupLP.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUIGroupLP.cpp
@@ -761,8 +761,6 @@ void PipelineSolver::greedyFind(
     BestCost += Best->Cost;
   } else
     BestCost += MissPenalty;
-
-  CurrPipeline[CurrSyncGroupIdx] = SyncPipeline;
 }
 
 bool PipelineSolver::solveGreedy() {

--- a/llvm/lib/Target/AMDGPU/AMDGPUIGroupLP.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUIGroupLP.cpp
@@ -696,8 +696,8 @@ void PipelineSolver::greedyFind(
 
   struct GroupInfo {
     SchedGroup *SG;
-    int Cost = 0;
     std::list<std::pair<SUnit *, SUnit *>> Edges;
+    int Cost = 0;
   };
   std::optional<GroupInfo> Best;
 
@@ -732,8 +732,8 @@ void PipelineSolver::greedyFind(
     int TempCost = addEdges(SyncPipeline, CurrSU.first, CandSGID, TempEdges);
     LLVM_DEBUG(dbgs() << "Cost of Group " << TempCost << "\n");
 
-    if (!Best.has_value() || TempCost < Best->Cost) {
-      Best = {Match, TempCost, TempEdges};
+    if (!Best || TempCost < Best->Cost) {
+      Best = {Match, TempEdges, TempCost};
       if (Best->Cost == 0)
         break;
     }
@@ -741,7 +741,7 @@ void PipelineSolver::greedyFind(
     removeEdges(TempEdges);
   }
 
-  if (Best.has_value()) {
+  if (Best) {
     SchedGroup *SG = Best->SG;
     std::list<std::pair<SUnit *, SUnit *>> &Edges = Best->Edges;
 

--- a/llvm/lib/Target/AMDGPU/AMDGPUIGroupLP.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUIGroupLP.cpp
@@ -694,7 +694,6 @@ void PipelineSolver::greedyFind(
     std::list<std::pair<SUnit *, SUnit *>> &AddedEdges, T I, T E) {
   SUToCandSGsPair CurrSU = PipelineInstrs[CurrSyncGroupIdx][CurrConflInstNo];
   int BestNodeCost = -1;
-  int TempCost;
   SchedGroup *BestGroup = nullptr;
   int BestGroupID = -1;
   std::list<std::pair<SUnit *, SUnit *>> BestEdges;
@@ -726,7 +725,7 @@ void PipelineSolver::greedyFind(
     }
 
     std::list<std::pair<SUnit *, SUnit *>> TempEdges;
-    TempCost = addEdges(SyncPipeline, CurrSU.first, CandSGID, TempEdges);
+    int TempCost = addEdges(SyncPipeline, CurrSU.first, CandSGID, TempEdges);
     LLVM_DEBUG(dbgs() << "Cost of Group " << TempCost << "\n");
 
     if (TempCost < BestNodeCost || BestNodeCost == -1) {
@@ -756,7 +755,7 @@ void PipelineSolver::greedyFind(
 
     LLVM_DEBUG(dbgs() << "Best Group has ID: " << BestGroupID << " and Mask"
                       << (int)BestGroup->getMask() << "\n");
-    BestCost += TempCost;
+    BestCost += BestNodeCost;
   } else
     BestCost += MissPenalty;
 
@@ -812,6 +811,7 @@ void PipelineSolver::solve() {
   } else { // Use the Greedy Algorithm by default
     LLVM_DEBUG(dbgs() << "Starting GREEDY pipeline solver\n");
     solveGreedy();
+    LLVM_DEBUG(dbgs() << "Greedy produced best cost of " << BestCost << "\n");
   }
 
   makePipeline();

--- a/llvm/lib/Target/AMDGPU/AMDGPUIGroupLP.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUIGroupLP.cpp
@@ -693,10 +693,14 @@ template <typename T>
 void PipelineSolver::greedyFind(
     std::list<std::pair<SUnit *, SUnit *>> &AddedEdges, T I, T E) {
   SUToCandSGsPair CurrSU = PipelineInstrs[CurrSyncGroupIdx][CurrConflInstNo];
-  int BestNodeCost = -1;
-  SchedGroup *BestGroup = nullptr;
-  int BestGroupID = -1;
-  std::list<std::pair<SUnit *, SUnit *>> BestEdges;
+
+  struct GroupInfo {
+    SchedGroup *SG;
+    int Cost = 0;
+    std::list<std::pair<SUnit *, SUnit *>> Edges;
+  };
+  std::optional<GroupInfo> Best;
+
   auto &SyncPipeline = CurrPipeline[CurrSyncGroupIdx];
   LLVM_DEBUG(dbgs() << "Fitting SU(" << CurrSU.first->NodeNum
                     << ") in Pipeline # " << CurrSyncGroupIdx << "\n");
@@ -728,34 +732,33 @@ void PipelineSolver::greedyFind(
     int TempCost = addEdges(SyncPipeline, CurrSU.first, CandSGID, TempEdges);
     LLVM_DEBUG(dbgs() << "Cost of Group " << TempCost << "\n");
 
-    if (TempCost < BestNodeCost || BestNodeCost == -1) {
-      BestEdges = TempEdges;
-      BestGroup = Match;
-      BestNodeCost = TempCost;
-      BestGroupID = CandSGID;
-
-      if (BestNodeCost == 0)
+    if (!Best.has_value() || TempCost < Best->Cost) {
+      Best = {Match, TempCost, TempEdges};
+      if (Best->Cost == 0)
         break;
     }
 
     removeEdges(TempEdges);
   }
 
-  if (BestGroupID != -1) {
-    BestGroup->add(*CurrSU.first);
-    if (AddedEdges.empty())
-      AddedEdges = BestEdges;
-    else
-      AddedEdges.splice(std::prev(AddedEdges.cend()), BestEdges);
+  if (Best.has_value()) {
+    SchedGroup *SG = Best->SG;
+    std::list<std::pair<SUnit *, SUnit *>> &Edges = Best->Edges;
 
-    for (const std::pair<SUnit *, SUnit *> &E : BestEdges) {
-      if (!BestGroup->tryAddEdge(E.first, E.second))
+    SG->add(*CurrSU.first);
+    if (AddedEdges.empty())
+      AddedEdges = Edges;
+    else
+      AddedEdges.splice(std::prev(AddedEdges.cend()), Edges);
+
+    for (const std::pair<SUnit *, SUnit *> &E : Edges) {
+      if (!SG->tryAddEdge(E.first, E.second))
         llvm_unreachable("Edges known to be insertable.");
     }
 
-    LLVM_DEBUG(dbgs() << "Best Group has ID: " << BestGroupID << " and Mask"
-                      << (int)BestGroup->getMask() << "\n");
-    BestCost += BestNodeCost;
+    LLVM_DEBUG(dbgs() << "Best Group has ID: " << SG->getSGID() << " and Mask"
+                      << (int)SG->getMask() << "\n");
+    BestCost += Best->Cost;
   } else
     BestCost += MissPenalty;
 


### PR DESCRIPTION
The greedy solver's greedyFind method incorrectly reports the cost of the
last processed group instead of the best one.  In practice, this does
not have any effect since (1) the cost is only used to decide whether
or not to run the exact solver and for this it only matters if it is
zero or not, and (2) the edges of the best group are used correctly.
But it clearly is conceptually wrong.

Use the best group cost, refactor how the information about the best group
is represented, and add debug output which always outputs the greedy solver's
overall cost.