### PR TITLE
[AArch64][GlobalISel] Fix uqadd/sub with scalar operands

### DIFF
--- a/llvm/lib/Target/AArch64/GISel/AArch64RegisterBankInfo.cpp
+++ b/llvm/lib/Target/AArch64/GISel/AArch64RegisterBankInfo.cpp
@@ -619,7 +619,9 @@ static bool isFPIntrinsic(const MachineRegisterInfo &MRI,
   case Intrinsic::aarch64_neon_sqrdmlah:
   case Intrinsic::aarch64_neon_sqrdmlsh:
   case Intrinsic::aarch64_neon_sqrdmulh:
+  case Intrinsic::aarch64_neon_uqadd:
   case Intrinsic::aarch64_neon_sqadd:
+  case Intrinsic::aarch64_neon_uqsub:
   case Intrinsic::aarch64_neon_sqsub:
   case Intrinsic::aarch64_neon_srshl:
   case Intrinsic::aarch64_neon_urshl:

--- a/llvm/test/CodeGen/AArch64/arm64-int-neon.ll
+++ b/llvm/test/CodeGen/AArch64/arm64-int-neon.ll
@@ -6,10 +6,6 @@
 ; CHECK-GI-NEXT:    warning: Instruction selection used fallback path for test_suqadd_s64
 ; CHECK-GI-NEXT:    warning: Instruction selection used fallback path for test_usqadd_s32
 ; CHECK-GI-NEXT:    warning: Instruction selection used fallback path for test_usqadd_s64
-; CHECK-GI-NEXT:    warning: Instruction selection used fallback path for test_uqadd_s32
-; CHECK-GI-NEXT:    warning: Instruction selection used fallback path for test_uqadd_s64
-; CHECK-GI-NEXT:    warning: Instruction selection used fallback path for test_uqsub_s32
-; CHECK-GI-NEXT:    warning: Instruction selection used fallback path for test_uqsub_s64
 ; CHECK-GI-NEXT:    warning: Instruction selection used fallback path for test_sqdmulls_scalar
 ; CHECK-GI-NEXT:    warning: Instruction selection used fallback path for test_sqdmulh_scalar
 ; CHECK-GI-NEXT:    warning: Instruction selection used fallback path for test_sqabs_s32


### PR DESCRIPTION
Previously, neon uqadd/uqsub would not lower when given s32/s64 operands, as GlobalISel would wrongly try to put the operands on general-purpose register banks. Changing this in RegBankSelection allows the intrinsics to lower just like their signed versions.