### PR TITLE
[DAG] Add back SelectionDAG::dump() without parameter

### DIFF
--- a/llvm/include/llvm/CodeGen/SelectionDAG.h
+++ b/llvm/include/llvm/CodeGen/SelectionDAG.h
@@ -2084,6 +2084,8 @@ public:
   LLVM_ABI void salvageDebugInfo(SDNode &N);
 
   /// Dump the textual format of this DAG. Nodes are not sorted.
+  /// Note that we overload it instead of using default value so that it is
+  /// convenient to be called from debuggers.
   LLVM_ABI void dump() const;
 
   /// Dump the textual format of this DAG. Print nodes in sorted orders if \p

--- a/llvm/include/llvm/CodeGen/SelectionDAG.h
+++ b/llvm/include/llvm/CodeGen/SelectionDAG.h
@@ -2083,9 +2083,12 @@ public:
   /// function mirrors \c llvm::salvageDebugInfo.
   LLVM_ABI void salvageDebugInfo(SDNode &N);
 
+  /// Dump the textual format of this DAG. Nodes are not sorted.
+  LLVM_ABI void dump() const;
+
   /// Dump the textual format of this DAG. Print nodes in sorted orders if \p
   /// Sorted is true.
-  LLVM_ABI void dump(bool Sorted = false) const;
+  LLVM_ABI void dump(bool Sorted) const;
 
   /// In most cases this function returns the ABI alignment for a given type,
   /// except for illegal vector types where the alignment exceeds that of the

--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAGDumper.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAGDumper.cpp
@@ -1092,6 +1092,8 @@ static void DumpNodes(const SDNode *N, unsigned indent, const SelectionDAG *G) {
   N->dump(G);
 }
 
+LLVM_DUMP_METHOD void SelectionDAG::dump() const { dump(false); }
+
 LLVM_DUMP_METHOD void SelectionDAG::dump(bool Sorted) const {
   dbgs() << "SelectionDAG has " << AllNodes.size() << " nodes:\n";
 


### PR DESCRIPTION
Usually `dump()`s are without parameter, so the practice is calling
`XXX::dump()` when debugging.

But we will get an error like below after #161097:

```
error: <user expression 128>:1:10: too few arguments to function call,
expected 1, have 0
    1 | DAG.dump()
      | ~~~~~~~~ ^
```

So to not surprise users, I added back the `SelectionDAG::dump()`
without parameter.
