### PR TITLE
[lldb][windows] fix TestReplaceDLL.py reruns

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/lldbtest.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbtest.py
@@ -777,7 +777,7 @@ class Base(unittest.TestCase):
         if os.path.isdir(bdir) and not self.SHARED_BUILD_TESTCASE:
             shutil.rmtree(bdir)
         lldbutil.mkdir_p(bdir)
-    
+
     def getBuildArtifact(self, name="a.out"):
         """Return absolute path to an artifact in the test's build directory."""
         return os.path.join(self.getBuildDir(), name)

--- a/lldb/packages/Python/lldbsuite/test/lldbtest.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbtest.py
@@ -777,7 +777,7 @@ class Base(unittest.TestCase):
         if os.path.isdir(bdir) and not self.SHARED_BUILD_TESTCASE:
             shutil.rmtree(bdir)
         lldbutil.mkdir_p(bdir)
-
+    
     def getBuildArtifact(self, name="a.out"):
         """Return absolute path to an artifact in the test's build directory."""
         return os.path.join(self.getBuildDir(), name)

--- a/lldb/test/API/windows/launch/replace-dll/TestReplaceDLL.py
+++ b/lldb/test/API/windows/launch/replace-dll/TestReplaceDLL.py
@@ -8,6 +8,8 @@ import os
 
 
 class ReplaceDllTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     @skipUnlessWindows
     def test(self):
         """


### PR DESCRIPTION
This patch fixes reruns of `TestReplaceDLL.py` which are failing due to `bar.dll` not being rebuilt properly.