### PR TITLE
[libc++] Fix missing availability check for visionOS in apple_availability.h

### DIFF
--- a/libcxx/src/include/apple_availability.h
+++ b/libcxx/src/include/apple_availability.h
@@ -27,6 +27,10 @@
 #    if __ENVIRONMENT_WATCH_OS_VERSION_MIN_REQUIRED__ >= 60000
 #      define _LIBCPP_USE_ULOCK
 #    endif
+#  elif defined(__ENVIRONMENT_OS_VERSION_MIN_REQUIRED__) && __is_target_os(visionos)
+#    if __ENVIRONMENT_OS_VERSION_MIN_REQUIRED__ >= 10000
+#      define _LIBCPP_USE_ULOCK
+#    endif
 #  endif // __ENVIRONMENT_.*_VERSION_MIN_REQUIRED__
 
 #endif // __APPLE__


### PR DESCRIPTION
Without this, we were assuming that __ulock was unavailable on visionOS and falling back to the manual implementation, when in reality we can always rely on the existence of ulock.

Fixes #186467