### PR TITLE
[X86][APX] Remove patterns for ArithBinOp

### DIFF
--- a/llvm/lib/Target/X86/X86InstrArithmetic.td
+++ b/llvm/lib/Target/X86/X86InstrArithmetic.td
@@ -918,10 +918,10 @@ multiclass ArithBinOp_RFF<bits<8> BaseOpc, bits<8> BaseOpc2, bits<8> BaseOpc4,
     def 64rm_ND  : BinOpRMF_RF<BaseOpc2, mnemonic, Xi64, opnode, 1>;
   }
   let Predicates = [In64BitMode] in {
-    def 8rm_EVEX   : BinOpRMF_RF<BaseOpc2, mnemonic, Xi8 , opnode>, PL;
-    def 16rm_EVEX  : BinOpRMF_RF<BaseOpc2, mnemonic, Xi16, opnode>, PL, PD;
-    def 32rm_EVEX  : BinOpRMF_RF<BaseOpc2, mnemonic, Xi32, opnode>, PL;
-    def 64rm_EVEX  : BinOpRMF_RF<BaseOpc2, mnemonic, Xi64, opnode>, PL;
+    def 8rm_EVEX   : BinOpRMF_RF<BaseOpc2, mnemonic, Xi8 , null_frag>, PL;
+    def 16rm_EVEX  : BinOpRMF_RF<BaseOpc2, mnemonic, Xi16, null_frag>, PL, PD;
+    def 32rm_EVEX  : BinOpRMF_RF<BaseOpc2, mnemonic, Xi32, null_frag>, PL;
+    def 64rm_EVEX  : BinOpRMF_RF<BaseOpc2, mnemonic, Xi64, null_frag>, PL;
   }
 
   let Predicates = [NoNDD] in {
@@ -951,13 +951,13 @@ multiclass ArithBinOp_RFF<bits<8> BaseOpc, bits<8> BaseOpc2, bits<8> BaseOpc4,
     }
   }
   let Predicates = [In64BitMode] in {
-    def 8ri_EVEX   : BinOpRIF_RF<0x80, mnemonic, Xi8 , opnode, RegMRM>, PL;
+    def 8ri_EVEX   : BinOpRIF_RF<0x80, mnemonic, Xi8 , null_frag, RegMRM>, PL;
     def 16ri8_EVEX : BinOpRI8F_RF<0x83, mnemonic, Xi16, RegMRM>, PL, PD;
     def 32ri8_EVEX : BinOpRI8F_RF<0x83, mnemonic, Xi32, RegMRM>, PL;
     def 64ri8_EVEX : BinOpRI8F_RF<0x83, mnemonic, Xi64, RegMRM>, PL;
-    def 16ri_EVEX  : BinOpRIF_RF<0x81, mnemonic, Xi16, opnode, RegMRM>, PL, PD;
-    def 32ri_EVEX  : BinOpRIF_RF<0x81, mnemonic, Xi32, opnode, RegMRM>, PL;
-    def 64ri32_EVEX: BinOpRIF_RF<0x81, mnemonic, Xi64, opnode, RegMRM>, PL;
+    def 16ri_EVEX  : BinOpRIF_RF<0x81, mnemonic, Xi16, null_frag, RegMRM>, PL, PD;
+    def 32ri_EVEX  : BinOpRIF_RF<0x81, mnemonic, Xi32, null_frag, RegMRM>, PL;
+    def 64ri32_EVEX: BinOpRIF_RF<0x81, mnemonic, Xi64, null_frag, RegMRM>, PL;
   }
 
   def 8mr    : BinOpMRF_MF<BaseOpc, mnemonic, Xi8 , opnode>;
@@ -1000,13 +1000,13 @@ multiclass ArithBinOp_RFF<bits<8> BaseOpc, bits<8> BaseOpc2, bits<8> BaseOpc4,
     def 64mi32_ND : BinOpMIF_RF<0x81, mnemonic, Xi64, opnode, MemMRM>;
   }
   let Predicates = [In64BitMode] in {
-    def 8mi_EVEX    : BinOpMIF_MF<0x80, mnemonic, Xi8 , opnode, MemMRM>, PL;
+    def 8mi_EVEX    : BinOpMIF_MF<0x80, mnemonic, Xi8 , null_frag, MemMRM>, PL;
     def 16mi8_EVEX  : BinOpMI8F_MF<mnemonic, Xi16, MemMRM>, PL, PD;
     def 32mi8_EVEX  : BinOpMI8F_MF<mnemonic, Xi32, MemMRM>, PL;
     def 64mi8_EVEX  : BinOpMI8F_MF<mnemonic, Xi64, MemMRM>, PL;
-    def 16mi_EVEX   : BinOpMIF_MF<0x81, mnemonic, Xi16, opnode, MemMRM>, PL, PD;
-    def 32mi_EVEX   : BinOpMIF_MF<0x81, mnemonic, Xi32, opnode, MemMRM>, PL;
-    def 64mi32_EVEX : BinOpMIF_MF<0x81, mnemonic, Xi64, opnode, MemMRM>, PL;
+    def 16mi_EVEX   : BinOpMIF_MF<0x81, mnemonic, Xi16, null_frag, MemMRM>, PL, PD;
+    def 32mi_EVEX   : BinOpMIF_MF<0x81, mnemonic, Xi32, null_frag, MemMRM>, PL;
+    def 64mi32_EVEX : BinOpMIF_MF<0x81, mnemonic, Xi64, null_frag, MemMRM>, PL;
   }
 
   // These are for the disassembler since 0x82 opcode behaves like 0x80, but

--- a/llvm/lib/Target/X86/X86InstrUtils.td
+++ b/llvm/lib/Target/X86/X86InstrUtils.td
@@ -1084,7 +1084,7 @@ class BinOpRI_RF<bits<8> o, string m, X86TypeInfo t, SDPatternOperator node, For
              (node t.RegClass:$src1, t.ImmOperator:$src2))]>, DefEFLAGS, NDD<ndd>;
 // BinOpRIF_RF - Instructions that read "reg, imm", write "reg" and read/write
 // EFLAGS.
-class BinOpRIF_RF<bits<8> o, string m, X86TypeInfo t, SDNode node, Format f, bit ndd = 0>
+class BinOpRIF_RF<bits<8> o, string m, X86TypeInfo t, SDPatternOperator node, Format f, bit ndd = 0>
   : BinOpRI<o, m, !if(!eq(ndd, 0), binop_args, binop_ndd_args), t, f, (outs t.RegClass:$dst),
             [(set t.RegClass:$dst, EFLAGS,
              (node t.RegClass:$src1, t.ImmOperator:$src2,
@@ -1221,7 +1221,7 @@ class BinOpMIF_RF<bits<8> o, string m, X86TypeInfo t, SDNode node, Format f>
     Sched<[WriteADC.Folded, WriteADC.ReadAfterFold]>, DefEFLAGS, UseEFLAGS, NDD<1>;
 // BinOpMIF_MF - Instructions that read "[mem], imm", write "[mem]" and
 // read/write EFLAGS.
-class BinOpMIF_MF<bits<8> o, string m, X86TypeInfo t, SDNode node, Format f>
+class BinOpMIF_MF<bits<8> o, string m, X86TypeInfo t, SDPatternOperator node, Format f>
   : BinOpMI<o, m, binop_args, t, f, (outs),
             [(store (node (t.VT (load addr:$src1)),
              t.ImmOperator:$src2, EFLAGS), addr:$src1)]>,

--- a/llvm/test/CodeGen/X86/apx/adc.ll
+++ b/llvm/test/CodeGen/X86/apx/adc.ll
@@ -59,10 +59,9 @@ define i64 @adc64rr(i64 %a, i64 %b, i64 %x, i64 %y) nounwind {
 define i8 @adc8rm(i8 %a, ptr %ptr, i8 %x, i8 %y) nounwind {
 ; NDD-LABEL: adc8rm:
 ; NDD:       # %bb.0:
-; NDD-NEXT:    movl %edi, %eax # encoding: [0x89,0xf8]
+; NDD-NEXT:    movzbl (%rsi), %eax # encoding: [0x0f,0xb6,0x06]
 ; NDD-NEXT:    cmpb %dl, %cl # encoding: [0x38,0xd1]
-; NDD-NEXT:    {evex} adcb (%rsi), %al # encoding: [0x62,0xf4,0x7c,0x08,0x12,0x06]
-; NDD-NEXT:    # kill: def $al killed $al killed $eax
+; NDD-NEXT:    adcb %dil, %al # EVEX TO LEGACY Compression encoding: [0x40,0x10,0xf8]
 ; NDD-NEXT:    retq # encoding: [0xc3]
 ;
 ; MEM-LABEL: adc8rm:
@@ -81,10 +80,9 @@ define i8 @adc8rm(i8 %a, ptr %ptr, i8 %x, i8 %y) nounwind {
 define i16 @adc16rm(i16 %a, ptr %ptr, i16 %x, i16 %y) nounwind {
 ; NDD-LABEL: adc16rm:
 ; NDD:       # %bb.0:
-; NDD-NEXT:    movl %edi, %eax # encoding: [0x89,0xf8]
+; NDD-NEXT:    movzwl (%rsi), %eax # encoding: [0x0f,0xb7,0x06]
 ; NDD-NEXT:    cmpw %dx, %cx # encoding: [0x66,0x39,0xd1]
-; NDD-NEXT:    {evex} adcw (%rsi), %ax # encoding: [0x62,0xf4,0x7d,0x08,0x13,0x06]
-; NDD-NEXT:    # kill: def $ax killed $ax killed $eax
+; NDD-NEXT:    adcw %di, %ax # EVEX TO LEGACY Compression encoding: [0x66,0x11,0xf8]
 ; NDD-NEXT:    retq # encoding: [0xc3]
 ;
 ; MEM-LABEL: adc16rm:
@@ -103,9 +101,9 @@ define i16 @adc16rm(i16 %a, ptr %ptr, i16 %x, i16 %y) nounwind {
 define i32 @adc32rm(i32 %a, ptr %ptr, i32 %x, i32 %y) nounwind {
 ; NDD-LABEL: adc32rm:
 ; NDD:       # %bb.0:
-; NDD-NEXT:    movl %edi, %eax # encoding: [0x89,0xf8]
+; NDD-NEXT:    movl (%rsi), %eax # encoding: [0x8b,0x06]
 ; NDD-NEXT:    cmpl %edx, %ecx # encoding: [0x39,0xd1]
-; NDD-NEXT:    {evex} adcl (%rsi), %eax # encoding: [0x62,0xf4,0x7c,0x08,0x13,0x06]
+; NDD-NEXT:    adcl %edi, %eax # EVEX TO LEGACY Compression encoding: [0x11,0xf8]
 ; NDD-NEXT:    retq # encoding: [0xc3]
 ;
 ; MEM-LABEL: adc32rm:
@@ -124,9 +122,9 @@ define i32 @adc32rm(i32 %a, ptr %ptr, i32 %x, i32 %y) nounwind {
 define i64 @adc64rm(i64 %a, ptr %ptr, i64 %x, i64 %y) nounwind {
 ; NDD-LABEL: adc64rm:
 ; NDD:       # %bb.0:
-; NDD-NEXT:    movq %rdi, %rax # encoding: [0x48,0x89,0xf8]
+; NDD-NEXT:    movq (%rsi), %rax # encoding: [0x48,0x8b,0x06]
 ; NDD-NEXT:    cmpq %rdx, %rcx # encoding: [0x48,0x39,0xd1]
-; NDD-NEXT:    {evex} adcq (%rsi), %rax # encoding: [0x62,0xf4,0xfc,0x08,0x13,0x06]
+; NDD-NEXT:    adcq %rdi, %rax # EVEX TO LEGACY Compression encoding: [0x48,0x11,0xf8]
 ; NDD-NEXT:    retq # encoding: [0xc3]
 ;
 ; MEM-LABEL: adc64rm:

--- a/llvm/test/CodeGen/X86/apx/sbb.ll
+++ b/llvm/test/CodeGen/X86/apx/sbb.ll
@@ -59,18 +59,16 @@ define i64 @sbb64rr(i64 %a, i64 %b, i64 %x, i64 %y) nounwind {
 define i8 @sbb8rm(i8 %a, ptr %ptr, i8 %x, i8 %y) nounwind {
 ; NDD-LABEL: sbb8rm:
 ; NDD:       # %bb.0:
-; NDD-NEXT:    movl %edi, %eax # encoding: [0x89,0xf8]
+; NDD-NEXT:    movzbl (%rsi), %eax # encoding: [0x0f,0xb6,0x06]
 ; NDD-NEXT:    cmpb %dl, %cl # encoding: [0x38,0xd1]
-; NDD-NEXT:    {evex} sbbb (%rsi), %al # encoding: [0x62,0xf4,0x7c,0x08,0x1a,0x06]
-; NDD-NEXT:    # kill: def $al killed $al killed $eax
+; NDD-NEXT:    sbbb %al, %dil, %al # encoding: [0x62,0xf4,0x7c,0x18,0x18,0xc7]
 ; NDD-NEXT:    retq # encoding: [0xc3]
 ;
 ; IMMONLY-LABEL: sbb8rm:
 ; IMMONLY:       # %bb.0:
-; IMMONLY-NEXT:    movl %edi, %eax # encoding: [0x89,0xf8]
+; IMMONLY-NEXT:    movzbl (%rsi), %eax # encoding: [0x0f,0xb6,0x06]
 ; IMMONLY-NEXT:    cmpb %dl, %cl # encoding: [0x38,0xd1]
-; IMMONLY-NEXT:    {evex} sbbb (%rsi), %al # encoding: [0x62,0xf4,0x7c,0x08,0x1a,0x06]
-; IMMONLY-NEXT:    # kill: def $al killed $al killed $eax
+; IMMONLY-NEXT:    sbbb %al, %dil, %al # encoding: [0x62,0xf4,0x7c,0x18,0x18,0xc7]
 ; IMMONLY-NEXT:    retq # encoding: [0xc3]
 ;
 ; MEM-LABEL: sbb8rm:
@@ -89,18 +87,16 @@ define i8 @sbb8rm(i8 %a, ptr %ptr, i8 %x, i8 %y) nounwind {
 define i16 @sbb16rm(i16 %a, ptr %ptr, i16 %x, i16 %y) nounwind {
 ; NDD-LABEL: sbb16rm:
 ; NDD:       # %bb.0:
-; NDD-NEXT:    movl %edi, %eax # encoding: [0x89,0xf8]
+; NDD-NEXT:    movzwl (%rsi), %eax # encoding: [0x0f,0xb7,0x06]
 ; NDD-NEXT:    cmpw %dx, %cx # encoding: [0x66,0x39,0xd1]
-; NDD-NEXT:    {evex} sbbw (%rsi), %ax # encoding: [0x62,0xf4,0x7d,0x08,0x1b,0x06]
-; NDD-NEXT:    # kill: def $ax killed $ax killed $eax
+; NDD-NEXT:    sbbw %ax, %di, %ax # encoding: [0x62,0xf4,0x7d,0x18,0x19,0xc7]
 ; NDD-NEXT:    retq # encoding: [0xc3]
 ;
 ; IMMONLY-LABEL: sbb16rm:
 ; IMMONLY:       # %bb.0:
-; IMMONLY-NEXT:    movl %edi, %eax # encoding: [0x89,0xf8]
+; IMMONLY-NEXT:    movzwl (%rsi), %eax # encoding: [0x0f,0xb7,0x06]
 ; IMMONLY-NEXT:    cmpw %dx, %cx # encoding: [0x66,0x39,0xd1]
-; IMMONLY-NEXT:    {evex} sbbw (%rsi), %ax # encoding: [0x62,0xf4,0x7d,0x08,0x1b,0x06]
-; IMMONLY-NEXT:    # kill: def $ax killed $ax killed $eax
+; IMMONLY-NEXT:    sbbw %ax, %di, %ax # encoding: [0x62,0xf4,0x7d,0x18,0x19,0xc7]
 ; IMMONLY-NEXT:    retq # encoding: [0xc3]
 ;
 ; MEM-LABEL: sbb16rm:
@@ -119,16 +115,16 @@ define i16 @sbb16rm(i16 %a, ptr %ptr, i16 %x, i16 %y) nounwind {
 define i32 @sbb32rm(i32 %a, ptr %ptr, i32 %x, i32 %y) nounwind {
 ; NDD-LABEL: sbb32rm:
 ; NDD:       # %bb.0:
-; NDD-NEXT:    movl %edi, %eax # encoding: [0x89,0xf8]
+; NDD-NEXT:    movl (%rsi), %eax # encoding: [0x8b,0x06]
 ; NDD-NEXT:    cmpl %edx, %ecx # encoding: [0x39,0xd1]
-; NDD-NEXT:    {evex} sbbl (%rsi), %eax # encoding: [0x62,0xf4,0x7c,0x08,0x1b,0x06]
+; NDD-NEXT:    sbbl %eax, %edi, %eax # encoding: [0x62,0xf4,0x7c,0x18,0x19,0xc7]
 ; NDD-NEXT:    retq # encoding: [0xc3]
 ;
 ; IMMONLY-LABEL: sbb32rm:
 ; IMMONLY:       # %bb.0:
-; IMMONLY-NEXT:    movl %edi, %eax # encoding: [0x89,0xf8]
+; IMMONLY-NEXT:    movl (%rsi), %eax # encoding: [0x8b,0x06]
 ; IMMONLY-NEXT:    cmpl %edx, %ecx # encoding: [0x39,0xd1]
-; IMMONLY-NEXT:    {evex} sbbl (%rsi), %eax # encoding: [0x62,0xf4,0x7c,0x08,0x1b,0x06]
+; IMMONLY-NEXT:    sbbl %eax, %edi, %eax # encoding: [0x62,0xf4,0x7c,0x18,0x19,0xc7]
 ; IMMONLY-NEXT:    retq # encoding: [0xc3]
 ;
 ; MEM-LABEL: sbb32rm:
@@ -147,16 +143,16 @@ define i32 @sbb32rm(i32 %a, ptr %ptr, i32 %x, i32 %y) nounwind {
 define i64 @sbb64rm(i64 %a, ptr %ptr, i64 %x, i64 %y) nounwind {
 ; NDD-LABEL: sbb64rm:
 ; NDD:       # %bb.0:
-; NDD-NEXT:    movq %rdi, %rax # encoding: [0x48,0x89,0xf8]
+; NDD-NEXT:    movq (%rsi), %rax # encoding: [0x48,0x8b,0x06]
 ; NDD-NEXT:    cmpq %rdx, %rcx # encoding: [0x48,0x39,0xd1]
-; NDD-NEXT:    {evex} sbbq (%rsi), %rax # encoding: [0x62,0xf4,0xfc,0x08,0x1b,0x06]
+; NDD-NEXT:    sbbq %rax, %rdi, %rax # encoding: [0x62,0xf4,0xfc,0x18,0x19,0xc7]
 ; NDD-NEXT:    retq # encoding: [0xc3]
 ;
 ; IMMONLY-LABEL: sbb64rm:
 ; IMMONLY:       # %bb.0:
-; IMMONLY-NEXT:    movq %rdi, %rax # encoding: [0x48,0x89,0xf8]
+; IMMONLY-NEXT:    movq (%rsi), %rax # encoding: [0x48,0x8b,0x06]
 ; IMMONLY-NEXT:    cmpq %rdx, %rcx # encoding: [0x48,0x39,0xd1]
-; IMMONLY-NEXT:    {evex} sbbq (%rsi), %rax # encoding: [0x62,0xf4,0xfc,0x08,0x1b,0x06]
+; IMMONLY-NEXT:    sbbq %rax, %rdi, %rax # encoding: [0x62,0xf4,0xfc,0x18,0x19,0xc7]
 ; IMMONLY-NEXT:    retq # encoding: [0xc3]
 ;
 ; MEM-LABEL: sbb64rm:


### PR DESCRIPTION
We should never select to these _EVEX variants. A follow up of #186049.