### PR TITLE
[analyzer] Fix logic in CallEvent::getReturnValueUnderConstruction

### DIFF
--- a/clang/lib/StaticAnalyzer/Core/CallEvent.cpp
+++ b/clang/lib/StaticAnalyzer/Core/CallEvent.cpp
@@ -562,13 +562,11 @@ std::optional<SVal> CallEvent::getReturnValueUnderConstruction() const {
 
   EvalCallOptions CallOpts;
   ExprEngine &Engine = getState()->getStateManager().getOwningEngine();
-  // FIXME: This code assumes that the _current_ location context and block is
-  // the location and block where this `CallExpr` is called. For a more stable
-  // solution `Engine.getNumVisitedCurrent()` should be replaced with a call to
-  // `Engine.getNumVisited(<CallerLCtx>, <CallerBlock>)`.
+  unsigned NumVisitedCall = Engine.getNumVisited(
+      getLocationContext(), getCFGElementRef().getParent());
   SVal RetVal = Engine.computeObjectUnderConstruction(
-      getOriginExpr(), getState(), Engine.getNumVisitedCurrent(),
-      getLocationContext(), CC, CallOpts);
+      getOriginExpr(), getState(), NumVisitedCall, getLocationContext(), CC,
+      CallOpts);
   return RetVal;
 }
 


### PR DESCRIPTION
The `CallEvent` has data members that store the `LocationContext` and the `CFGElementRef` (i.e. `CFGBlock` + index of statement within that block); but the method `getReturnValueUnderConstruction` ignored these and used the currently analyzed `LocationContext` and `CFGBlock` instead of them.

This was logically incorrect and would have caused problems if the `CallEvent` was used later when the "currently analyzed" things are different. However, the lit tests do pass even if I assert that the currently analyzed `LocationContext` and `CFGBlock` is the same as the ones saved in the `CallEvent`, so I'm pretty sure that there was no actual problem caused by this bad logic and this commit won't cause functional changes.

I also evaluated this change on a set of open source projects (postgres, tinyxml2, libwebm, xerces, bitcoin, protobuf, qtbase, contour, openrct2) and validated that it doesn't change the results of the analysis.

----

I originally uploaded this change as a part of PR https://github.com/llvm/llvm-project/pull/186186, but following a reviewer suggestion, I created this separate PR instead.