### PR TITLE
[lldb] Fix permission issue in API test on lldb-x86_64-win

### DIFF
--- a/lldb/test/API/symstore/TestSymStoreLocal.py
+++ b/lldb/test/API/symstore/TestSymStoreLocal.py
@@ -50,7 +50,7 @@ class MockedSymStore:
         self._test.assertIsNotNone(key)
         self._tmp = self._test.getBuildArtifact("tmp")
         pdb_dir = os.path.join(self._tmp, self._pdb, key)
-        os.makedirs(pdb_dir, exists_ok=True)
+        os.makedirs(pdb_dir, exist_ok=True)
         shutil.move(
             self._test.getBuildArtifact(self._pdb),
             os.path.join(pdb_dir, self._pdb),
@@ -96,7 +96,7 @@ class SymStoreLocalTests(TestBase):
         exe, sym = self.build_inferior()
         with MockedSymStore(self, exe, sym):
             self.try_breakpoint(exe, should_have_loc=False)
-            self.runCmd("exit")
+            self.runCmd("quit", check=False)
 
     def test_external_lookup_off(self):
         """
@@ -108,7 +108,7 @@ class SymStoreLocalTests(TestBase):
                 f"settings set plugin.symbol-locator.symstore.urls {symstore_dir}"
             )
             self.try_breakpoint(exe, ext_lookup=False, should_have_loc=False)
-            self.runCmd("exit")
+            self.runCmd("quit", check=False)
 
     def test_local_dir(self):
         """
@@ -120,4 +120,4 @@ class SymStoreLocalTests(TestBase):
                 f"settings set plugin.symbol-locator.symstore.urls {symstore_dir}"
             )
             self.try_breakpoint(exe, should_have_loc=True)
-            self.runCmd("exit")
+            self.runCmd("quit", check=False)

--- a/lldb/test/API/symstore/TestSymStoreLocal.py
+++ b/lldb/test/API/symstore/TestSymStoreLocal.py
@@ -50,7 +50,7 @@ class MockedSymStore:
         self._test.assertIsNotNone(key)
         self._tmp = self._test.getBuildArtifact("tmp")
         pdb_dir = os.path.join(self._tmp, self._pdb, key)
-        os.makedirs(pdb_dir)
+        os.makedirs(pdb_dir, exists_ok=True)
         shutil.move(
             self._test.getBuildArtifact(self._pdb),
             os.path.join(pdb_dir, self._pdb),

--- a/lldb/test/API/symstore/TestSymStoreLocal.py
+++ b/lldb/test/API/symstore/TestSymStoreLocal.py
@@ -1,6 +1,5 @@
 import os
 import shutil
-import tempfile
 
 import lldb
 from lldbsuite.test.decorators import *
@@ -97,6 +96,7 @@ class SymStoreLocalTests(TestBase):
         exe, sym = self.build_inferior()
         with MockedSymStore(self, exe, sym):
             self.try_breakpoint(exe, should_have_loc=False)
+            self.runCmd("exit")
 
     def test_external_lookup_off(self):
         """
@@ -108,6 +108,7 @@ class SymStoreLocalTests(TestBase):
                 f"settings set plugin.symbol-locator.symstore.urls {symstore_dir}"
             )
             self.try_breakpoint(exe, ext_lookup=False, should_have_loc=False)
+            self.runCmd("exit")
 
     def test_local_dir(self):
         """
@@ -119,3 +120,4 @@ class SymStoreLocalTests(TestBase):
                 f"settings set plugin.symbol-locator.symstore.urls {symstore_dir}"
             )
             self.try_breakpoint(exe, should_have_loc=True)
+            self.runCmd("exit")


### PR DESCRIPTION
Deleting the executable at the end of this API test-case fails with a permission error, likely because lldb still holds a reference to the EXE. Exit explicitly to avoid that.