### PR TITLE
[libc] Avoid host header collisions in full builds (-nostdinc)

### DIFF
--- a/libc/hdr/func/aligned_alloc.h
+++ b/libc/hdr/func/aligned_alloc.h
@@ -11,7 +11,11 @@
 
 #ifdef LIBC_FULL_BUILD
 #include "hdr/types/size_t.h"
+#ifdef __cplusplus
+extern "C" void *aligned_alloc(size_t, size_t) noexcept;
+#else
 extern "C" void *aligned_alloc(size_t, size_t);
+#endif
 
 #else // Overlay mode
 

--- a/libc/hdr/stdint_proxy.h
+++ b/libc/hdr/stdint_proxy.h
@@ -13,6 +13,10 @@
 // that is `libc.include.stdint` is added to the dependency of all targets
 // that use <stdint.h> header.
 
+#ifdef LIBC_FULL_BUILD
+#include "include/llvm-libc-macros/stdint-macros.h"
+#else
 #include <stdint.h>
+#endif
 
 #endif // LLVM_LIBC_HDR_STDINT_PROXY_H


### PR DESCRIPTION
When building the full library with -nostdinc, directly including <stdint.h> may pull in host or compiler-provided headers that collide with LLVM-libc's local macro definitions. Switch to using our internal stdint-macros.h when LIBC_FULL_BUILD is enabled.

Additionally, declare aligned_alloc with noexcept in C++ to match common C library declarations and avoid fatal type specification mismatches during sysroot builds.