### PR TITLE
[mlir][LLVM] add llvm.fake.use to LLVM dialect

### DIFF
--- a/mlir/include/mlir/Dialect/LLVMIR/LLVMIntrinsicOps.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/LLVMIntrinsicOps.td
@@ -560,6 +560,11 @@ def LLVM_USHLSat : LLVM_BinarySameArgsIntrOpI<"ushl.sat">;
 // Optimization hint intrinsics.
 //
 
+def LLVM_FakeUseOp : LLVM_ZeroResultIntrOp<"fake.use"> {
+  let arguments = (ins Variadic<LLVM_Type>:$args);
+  let assemblyFormat = "$args attr-dict `:` type($args)";
+}
+
 def LLVM_AssumeOp
     : LLVM_ZeroResultIntrOp<"assume", /*overloadedOperands=*/[], /*traits=*/[],
                             /*requiresAccessGroup=*/0,

--- a/mlir/test/Target/LLVMIR/Import/intrinsic.ll
+++ b/mlir/test/Target/LLVMIR/Import/intrinsic.ll
@@ -724,6 +724,19 @@ define void @va_intrinsics_test(ptr %0, ptr %1, ...) {
   ret void
 }
 
+; CHECK-LABEL: @fake_use
+; CHECK-SAME:  %[[VAL:[a-zA-Z0-9]+]]
+; CHECK-SAME:  %[[PTR:[a-zA-Z0-9]+]]
+define void @fake_use(i32 %0, ptr %1) {
+  ; CHECK: llvm.intr.fake.use %[[VAL]] : i32
+  call void (...) @llvm.fake.use(i32 %0)
+  ; CHECK: llvm.intr.fake.use %[[PTR]] : !llvm.ptr
+  call void (...) @llvm.fake.use(ptr %1)
+  ; CHECK: llvm.intr.fake.use %[[VAL]], %[[PTR]] : i32, !llvm.ptr
+  call void (...) @llvm.fake.use(i32 %0, ptr %1)
+  ret void
+}
+
 ; CHECK-LABEL: @assume
 ; CHECK-SAME:  %[[TRUE:[a-zA-Z0-9]+]]
 define void @assume(i1 %true) {
@@ -1414,3 +1427,4 @@ declare i2 @llvm.ucmp.i2.i32(i32, i32)
 declare <4 x i32> @llvm.ucmp.v4i32.v4i32(<4 x i32>, <4 x i32>)
 declare i2 @llvm.scmp.i2.i32(i32, i32)
 declare <4 x i32> @llvm.scmp.v4i32.v4i32(<4 x i32>, <4 x i32>)
+declare void @llvm.fake.use(...)

--- a/mlir/test/Target/LLVMIR/llvmir-intrinsics.mlir
+++ b/mlir/test/Target/LLVMIR/llvmir-intrinsics.mlir
@@ -457,6 +457,17 @@ llvm.func @umin_test(%arg0: i32, %arg1: i32, %arg2: vector<8xi32>, %arg3: vector
   llvm.return
 }
 
+// CHECK-LABEL: @fake_use
+llvm.func @fake_use(%arg0: i32, %arg1: !llvm.ptr) {
+  // CHECK: call void (...) @llvm.fake.use(i32 %{{.*}})
+  llvm.intr.fake.use %arg0 : i32
+  // CHECK: call void (...) @llvm.fake.use(ptr %{{.*}})
+  llvm.intr.fake.use %arg1 : !llvm.ptr
+  // CHECK: call void (...) @llvm.fake.use(i32 %{{.*}}, ptr %{{.*}})
+  llvm.intr.fake.use %arg0, %arg1 : i32, !llvm.ptr
+  llvm.return
+}
+
 // CHECK-LABEL: @assume_without_opbundles
 llvm.func @assume_without_opbundles(%cond: i1) {
   // CHECK: call void @llvm.assume(i1 %{{.+}})
@@ -1496,3 +1507,4 @@ llvm.func @vector_scmp(%a: vector<4 x i32>, %b: vector<4 x i32>) -> vector<4 x i
 // CHECK-DAG: declare range(i32 -1, 2) <4 x i32> @llvm.ucmp.v4i32.v4i32(<4 x i32>, <4 x i32>)
 // CHECK-DAG: declare range(i2 -1, -2) i2 @llvm.scmp.i2.i32(i32, i32)
 // CHECK-DAG: declare range(i32 -1, 2) <4 x i32> @llvm.scmp.v4i32.v4i32(<4 x i32>, <4 x i32>)
+// CHECK-DAG: declare void @llvm.fake.use(...)


### PR DESCRIPTION
Add [llvm.fake.use](https://llvm.org/docs/LangRef.html#llvm-fake-use-intrinsic) to the LLVM dialect intrinsic.

I am planning to use it in flang to improve debug information for arguments.