### PR TITLE
[lldb][Module] Add interactive prompt when loading script from symbol files

### DIFF
--- a/lldb/source/Core/Module.cpp
+++ b/lldb/source/Core/Module.cpp
@@ -1486,7 +1486,12 @@ To run all discovered debug scripts in this session:
           debugger.GetID());
       // clang-format on
 
-      return false;
+      if (!debugger.GetCommandInterpreter().Confirm(
+              llvm::formatv("Do you want to load the script '{0}' right now?",
+                            scripting_fspec.GetPath())
+                  .str(),
+              false))
+        continue;
     }
 
     StreamString scripting_stream;

--- a/lldb/test/API/macosx/dsym_script_load_prompt/Makefile
+++ b/lldb/test/API/macosx/dsym_script_load_prompt/Makefile
@@ -1,0 +1,3 @@
+C_SOURCES := main.c
+
+include Makefile.rules

--- a/lldb/test/API/macosx/dsym_script_load_prompt/TestDSYMScriptLoadPrompt.py
+++ b/lldb/test/API/macosx/dsym_script_load_prompt/TestDSYMScriptLoadPrompt.py
@@ -13,7 +13,6 @@ from lldbsuite.test.lldbpexpect import PExpectTest
 
 @skipUnlessDarwin
 class TestDSYMScriptLoadPrompt(PExpectTest):
-
     def build_with_dsym_script(self):
         self.build(debug_info="dsym")
         exe = self.getBuildArtifact("a.out")

--- a/lldb/test/API/macosx/dsym_script_load_prompt/TestDSYMScriptLoadPrompt.py
+++ b/lldb/test/API/macosx/dsym_script_load_prompt/TestDSYMScriptLoadPrompt.py
@@ -1,0 +1,88 @@
+"""
+Test the interactive prompt when target.load-script-from-symbol-file
+is set to 'warn' and a dSYM contains a Python script.
+"""
+
+import os
+import shutil
+
+from lldbsuite.test.decorators import *
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.lldbpexpect import PExpectTest
+
+
+@skipUnlessDarwin
+class TestDSYMScriptLoadPrompt(PExpectTest):
+
+    def build_with_dsym_script(self):
+        self.build(debug_info="dsym")
+        exe = self.getBuildArtifact("a.out")
+        dsym_path = exe + ".dSYM"
+        python_dir = os.path.join(dsym_path, "Contents", "Resources", "Python")
+        os.makedirs(python_dir, exist_ok=True)
+        shutil.copy(
+            os.path.join(self.getSourceDir(), "dsym_script.py"),
+            os.path.join(python_dir, "a.py"),
+        )
+        return exe
+
+    def test_prompt_accept(self):
+        """Test that replying 'Y' to the prompt loads the script."""
+        exe = self.build_with_dsym_script()
+
+        self.launch(
+            extra_args=[
+                "-O",
+                "settings set target.load-script-from-symbol-file warn",
+            ]
+        )
+        self.child.sendline("target create " + exe)
+        self.child.expect_exact("To run this script in this debug")
+        self.child.expect_exact("Do you want to load the script")
+        self.child.expect_exact("a.py")
+        self.child.sendline("Y")
+        self.expect_prompt()
+        self.child.sendline("script lldb.LOADED")
+        self.child.expect_exact("True")
+        self.expect_prompt()
+        self.quit()
+
+    def test_prompt_deny(self):
+        """Test that replying 'N' to the prompt does not load the script."""
+        exe = self.build_with_dsym_script()
+
+        self.launch(
+            extra_args=[
+                "-O",
+                "settings set target.load-script-from-symbol-file warn",
+            ]
+        )
+        self.child.sendline("target create " + exe)
+        self.child.expect_exact("To run this script in this debug")
+        self.child.expect_exact("Do you want to load the script")
+        self.child.expect_exact("a.py")
+        self.child.sendline("N")
+        self.expect_prompt()
+        self.child.sendline("script lldb.LOADED")
+        self.child.expect_exact("module 'lldb' has no attribute 'LOADED'")
+        self.quit()
+
+    def test_prompt_default_is_no(self):
+        """Test that the default reply (just pressing 'Enter') is 'N'."""
+        exe = self.build_with_dsym_script()
+
+        self.launch(
+            extra_args=[
+                "-O",
+                "settings set target.load-script-from-symbol-file warn",
+            ]
+        )
+        self.child.sendline("target create " + exe)
+        self.child.expect_exact("To run this script in this debug")
+        self.child.expect_exact("Do you want to load the script")
+        self.child.expect_exact("a.py")
+        self.child.sendline("")
+        self.expect_prompt()
+        self.child.sendline("script lldb.LOADED")
+        self.child.expect_exact("module 'lldb' has no attribute 'LOADED'")
+        self.quit()

--- a/lldb/test/API/macosx/dsym_script_load_prompt/dsym_script.py
+++ b/lldb/test/API/macosx/dsym_script_load_prompt/dsym_script.py
@@ -1,0 +1,5 @@
+import lldb
+
+
+def __lldb_init_module(debugger, internal_dict):
+    lldb.LOADED = True

--- a/lldb/test/API/macosx/dsym_script_load_prompt/main.c
+++ b/lldb/test/API/macosx/dsym_script_load_prompt/main.c
@@ -1,0 +1,1 @@
+int main() { return 0; }

--- a/lldb/test/Shell/Platform/AutoLoad/Darwin/dsym-python-script-prompt.test
+++ b/lldb/test/Shell/Platform/AutoLoad/Darwin/dsym-python-script-prompt.test
@@ -1,0 +1,47 @@
+# REQUIRES: python, system-darwin
+#
+# Tests the 'target.load-script-from-symbol-file warn' prompt in a non-interactive environment.
+
+# RUN: split-file %s %t
+# RUN: %clang_host -g %t/main.c -o %t/TestModule.out
+# RUN: mkdir -p %t/TestModule.out.dSYM/Contents/Resources/Python
+# RUN: cp %t/dsym_script.py %t/TestModule.out.dSYM/Contents/Resources/Python/TestModule.py
+#
+## Tests that default reply is "N" in a non-interactive auto-confirm environment.
+#
+# RUN: %lldb \
+# RUN:   -o 'settings set target.load-script-from-symbol-file warn' \
+# RUN:   -o 'settings set auto-confirm true' \
+# RUN:   -o 'target create %t/TestModule.out' 2>&1 \
+# RUN:   | FileCheck %s --implicit-check-not=DSYM_SCRIPT --check-prefix=CHECK-WARN
+
+## Tests that in a non-interactive no-auto-confirm environment we still don't load the.
+## script. But we do print a warning.
+#
+# RUN: %lldb -b \
+# RUN:   -o 'settings set auto-confirm false' \
+# RUN:   -o 'settings set target.load-script-from-symbol-file warn' \
+# RUN:   -o 'target create %t/TestModule.out' 2>&1 \
+# RUN:   | FileCheck %s --implicit-check-not=DSYM_SCRIPT --check-prefix=CHECK-WARN
+
+# CHECK-WARN: warning: '{{.*}}' contains a debug script. To run this script in this debug session:
+
+## Tests that the warning appears every time we prompt.
+## FIXME: do we want to limit the warning to once per session?
+#
+# RUN: %lldb -b \
+# RUN:   -o 'settings set auto-confirm true' \
+# RUN:   -o 'settings set target.load-script-from-symbol-file warn' \
+# RUN:   -o 'target create %t/TestModule.out' \
+# RUN:   -o 'target create %t/TestModule.out' 2>&1 \
+# RUN:   | FileCheck %s --check-prefix=CHECK-MULTIPLE
+
+# CHECK-MULTIPLE-COUNT-2: warning: '{{.*}}' contains a debug script. To run this script
+
+#--- main.c
+int main() { return 0; }
+
+#--- dsym_script.py
+import sys
+def __lldb_init_module(debugger, internal_dict):
+    print("DSYM_SCRIPT", file=sys.stderr)


### PR DESCRIPTION
With `settings set target.load-script-from-symbol-file` set to `warn` (which is the default), when LLDB detects a Python script inside a dSYM, it emits following warning (and doesn't proceed to load the script):
```
warning: '/path/to/module.o' contains a debug script. To run this script in this debug session:

    command script import "/path/to/blah.py"

To run all discovered debug scripts in this session:

    settings set target.load-script-from-symbol-file true
```

This patch adds a prompt right after this warning that says:
```
Do you want to load the script '/path/to/blah.py' right now? (Y/[N])
```

If the user agrees, we would proceed with loading the script.

The motivation is [this RFC](https://discourse.llvm.org/t/rfc-lldb-moving-libc-data-formatters-out-of-lldb/89591) where we propose an infrastructure for automatically loading scripts from pre-configured paths. For better UX, we'd like to have the user be able to opt-in/out of loading scripts without fiddling with a setting.

Happy to consider re-wording the warning and/or prompt. I think we should consider only emitting the warning once per session, but prompt every time we try to load a new script. That way we don't spam the console with warnings.

*AI usage*: Claude helped write the bulk of `TestDSYMScriptLoadPrompt.py` which i then reviewed and cleaned up.