### PR TITLE
[CycleInfo] Support forward declarations

### DIFF
--- a/llvm/include/llvm/IR/CycleInfo.h
+++ b/llvm/include/llvm/IR/CycleInfo.h
@@ -20,7 +20,9 @@
 
 namespace llvm {
 
-using CycleInfo = GenericCycleInfo<SSAContext>;
+// Use class instead of using to allow forward declarations.
+class CycleInfo : public GenericCycleInfo<SSAContext> {};
+
 using Cycle = CycleInfo::CycleT;
 
 } // namespace llvm

--- a/llvm/include/llvm/Transforms/Utils/BasicBlockUtils.h
+++ b/llvm/include/llvm/Transforms/Utils/BasicBlockUtils.h
@@ -19,7 +19,6 @@
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/SetVector.h"
 #include "llvm/IR/BasicBlock.h"
-#include "llvm/IR/CycleInfo.h"
 #include "llvm/IR/Dominators.h"
 #include "llvm/Support/Compiler.h"
 #include "llvm/Support/Printable.h"
@@ -27,6 +26,7 @@
 
 namespace llvm {
 class CondBrInst;
+class CycleInfo;
 class LandingPadInst;
 class Loop;
 class PHINode;

--- a/llvm/include/llvm/Transforms/Utils/ControlFlowUtils.h
+++ b/llvm/include/llvm/Transforms/Utils/ControlFlowUtils.h
@@ -15,7 +15,6 @@
 
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
-#include "llvm/IR/CycleInfo.h"
 
 namespace llvm {
 

--- a/llvm/lib/Transforms/Utils/BasicBlockUtils.cpp
+++ b/llvm/lib/Transforms/Utils/BasicBlockUtils.cpp
@@ -24,6 +24,7 @@
 #include "llvm/IR/BasicBlock.h"
 #include "llvm/IR/CFG.h"
 #include "llvm/IR/Constants.h"
+#include "llvm/IR/CycleInfo.h"
 #include "llvm/IR/DebugInfo.h"
 #include "llvm/IR/DebugInfoMetadata.h"
 #include "llvm/IR/Dominators.h"


### PR DESCRIPTION
Use a class instead of an alias, so that CycleInfo can be forward-declared.

We can't do the same for Cycle without further changes (a LoopInfo like CRTP scheme).