### PR TITLE
[lldb] Fix user-after-free in CommandInterpreter

### DIFF
--- a/lldb/source/Interpreter/CommandInterpreter.cpp
+++ b/lldb/source/Interpreter/CommandInterpreter.cpp
@@ -1187,13 +1187,14 @@ CommandInterpreter::GetCommandSP(llvm::StringRef cmd_str, bool include_aliases,
       command_sp = pos->second;
   }
 
+  StringList local_matches;
+
   if (!exact && !command_sp) {
     // We will only get into here if we didn't find any exact matches.
 
     CommandObjectSP user_match_sp, user_mw_match_sp, alias_match_sp,
         real_match_sp;
 
-    StringList local_matches;
     if (matches == nullptr)
       matches = &local_matches;
 


### PR DESCRIPTION
The variable `matches` may be assigned the address of block-scope `local_matches`, which is defined in a scope strictly smaller than the scope of `matches`. Towards the end of the function, after `loacl_matches` has been destroyed, `matches` is accessed, possibly triggering a user-after-free.