### PR TITLE
[lldb][PlatformDarwin][test] Move Platform test utilities into common header for re-use

### DIFF
--- a/lldb/unittests/Platform/CMakeLists.txt
+++ b/lldb/unittests/Platform/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_lldb_unittest(LLDBPlatformTests
+  TestUtils.cpp
   PlatformAppleSimulatorTest.cpp
   PlatformDarwinTest.cpp
   PlatformMacOSXTest.cpp

--- a/lldb/unittests/Platform/PlatformDarwinTest.cpp
+++ b/lldb/unittests/Platform/PlatformDarwinTest.cpp
@@ -18,7 +18,6 @@
 #include "lldb/Core/Debugger.h"
 #include "lldb/Core/PluginManager.h"
 #include "lldb/Host/HostInfo.h"
-#include "lldb/Target/Platform.h"
 
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/FileSystem.h"

--- a/lldb/unittests/Platform/PlatformDarwinTest.cpp
+++ b/lldb/unittests/Platform/PlatformDarwinTest.cpp
@@ -8,6 +8,8 @@
 
 #include "gtest/gtest.h"
 
+#include "TestUtils.h"
+
 #include "Plugins/Platform/MacOSX/PlatformDarwin.h"
 #include "Plugins/Platform/MacOSX/PlatformMacOSX.h"
 #include "Plugins/Platform/MacOSX/PlatformRemoteMacOSX.h"
@@ -16,7 +18,7 @@
 #include "lldb/Core/Debugger.h"
 #include "lldb/Core/PluginManager.h"
 #include "lldb/Host/HostInfo.h"
-#include "lldb/Interpreter/ScriptInterpreter.h"
+#include "lldb/Target/Platform.h"
 
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/FileSystem.h"
@@ -27,54 +29,6 @@
 
 using namespace lldb;
 using namespace lldb_private;
-
-namespace {
-class MockScriptInterpreterPython : public ScriptInterpreter {
-public:
-  MockScriptInterpreterPython(Debugger &debugger)
-      : ScriptInterpreter(debugger,
-                          lldb::ScriptLanguage::eScriptLanguagePython) {}
-
-  ~MockScriptInterpreterPython() override = default;
-
-  bool ExecuteOneLine(llvm::StringRef command, CommandReturnObject *,
-                      const ExecuteScriptOptions &) override {
-    return false;
-  }
-
-  void ExecuteInterpreterLoop() override {}
-
-  static void Initialize() {
-    PluginManager::RegisterPlugin(GetPluginNameStatic(),
-                                  GetPluginDescriptionStatic(),
-                                  lldb::eScriptLanguagePython, CreateInstance);
-  }
-
-  static void Terminate() { PluginManager::UnregisterPlugin(CreateInstance); }
-
-  bool IsReservedWord(const char *word) override {
-    return llvm::is_contained({"import", "mykeyword_1_1_1"},
-                              llvm::StringRef(word));
-  }
-
-  static lldb::ScriptInterpreterSP CreateInstance(Debugger &debugger) {
-    return std::make_shared<MockScriptInterpreterPython>(debugger);
-  }
-
-  static llvm::StringRef GetPluginNameStatic() {
-    return "MockScriptInterpreterPython";
-  }
-
-  static llvm::StringRef GetPluginDescriptionStatic() {
-    return "MockScriptInterpreterPython";
-  }
-
-  // PluginInterface protocol
-  llvm::StringRef GetPluginName() override { return GetPluginNameStatic(); }
-};
-
-LLDB_PLUGIN_DEFINE(MockScriptInterpreterPython)
-} // namespace
 
 struct PlatformDarwinLocateTest : public testing::Test {
 protected:
@@ -143,18 +97,6 @@ protected:
                 MockScriptInterpreterPython>
       subsystems;
 };
-
-static std::string CreateFile(llvm::StringRef filename,
-                              llvm::SmallString<128> parent_dir) {
-  llvm::SmallString<128> path(parent_dir);
-  llvm::sys::path::append(path, filename);
-  int fd;
-  std::error_code ret = llvm::sys::fs::openFileForWrite(path, fd);
-  assert(!ret && "Failed to create test file.");
-  ::close(fd);
-
-  return path.c_str();
-}
 
 TEST(PlatformDarwinTest, TestParseVersionBuildDir) {
   llvm::VersionTuple V;

--- a/lldb/unittests/Platform/TestUtils.cpp
+++ b/lldb/unittests/Platform/TestUtils.cpp
@@ -1,0 +1,42 @@
+//===-- TestUtils.cpp -----------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "TestUtils.h"
+
+#include "lldb/Core/PluginManager.h"
+
+using namespace lldb;
+using namespace lldb_private;
+
+MockScriptInterpreterPython::MockScriptInterpreterPython(Debugger &debugger)
+    : ScriptInterpreter(debugger, lldb::ScriptLanguage::eScriptLanguagePython) {
+}
+
+void MockScriptInterpreterPython::Initialize() {
+  PluginManager::RegisterPlugin(GetPluginNameStatic(),
+                                GetPluginDescriptionStatic(),
+                                lldb::eScriptLanguagePython, CreateInstance);
+}
+
+void MockScriptInterpreterPython::Terminate() {
+  PluginManager::UnregisterPlugin(CreateInstance);
+}
+
+LLDB_PLUGIN_DEFINE(MockScriptInterpreterPython)
+
+std::string lldb_private::CreateFile(llvm::StringRef filename,
+                                     llvm::SmallString<128> parent_dir) {
+  llvm::SmallString<128> path(parent_dir);
+  llvm::sys::path::append(path, filename);
+  int fd;
+  std::error_code ret = llvm::sys::fs::openFileForWrite(path, fd);
+  assert(!ret && "Failed to create test file.");
+  ::close(fd);
+
+  return path.c_str();
+}

--- a/lldb/unittests/Platform/TestUtils.h
+++ b/lldb/unittests/Platform/TestUtils.h
@@ -1,0 +1,59 @@
+//===-- TestUtils.h -------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLDB_UNITTESTS_PLATFORM_TESTUTILS
+#define LLDB_UNITTESTS_PLATFORM_TESTUTILS
+
+#include "lldb/Interpreter/ScriptInterpreter.h"
+
+namespace lldb_private {
+class Debugger;
+
+class MockScriptInterpreterPython : public ScriptInterpreter {
+public:
+  MockScriptInterpreterPython(Debugger &debugger);
+  ~MockScriptInterpreterPython() override = default;
+
+  bool ExecuteOneLine(llvm::StringRef command, CommandReturnObject *,
+                      const ExecuteScriptOptions &) override {
+    return false;
+  }
+
+  void ExecuteInterpreterLoop() override {}
+
+  static void Initialize();
+
+  static void Terminate();
+
+  bool IsReservedWord(const char *word) override {
+    return llvm::is_contained({"import", "mykeyword_1_1_1"},
+                              llvm::StringRef(word));
+  }
+
+  static lldb::ScriptInterpreterSP CreateInstance(Debugger &debugger) {
+    return std::make_shared<MockScriptInterpreterPython>(debugger);
+  }
+
+  static llvm::StringRef GetPluginNameStatic() {
+    return "MockScriptInterpreterPython";
+  }
+
+  static llvm::StringRef GetPluginDescriptionStatic() {
+    return "MockScriptInterpreterPython";
+  }
+
+  // PluginInterface protocol
+  llvm::StringRef GetPluginName() override { return GetPluginNameStatic(); }
+};
+
+std::string CreateFile(llvm::StringRef filename,
+                       llvm::SmallString<128> parent_dir);
+
+} // namespace lldb_private
+
+#endif // LLDB_UNITTESTS_PLATFORM_TESTUTILS_H_IN


### PR DESCRIPTION
In https://github.com/llvm/llvm-project/pull/187031 I'm planning on re-using the `MockScriptInterpreterPython` and `CreateFile` API from a different unit-test in `Platform/`.