### PR TITLE
[mlir][linalg] Fix crash in tileToForallOpImpl when tileUsingSCF returns empty loops

### DIFF
--- a/mlir/lib/Dialect/Linalg/TransformOps/LinalgTransformOps.cpp
+++ b/mlir/lib/Dialect/Linalg/TransformOps/LinalgTransformOps.cpp
@@ -3888,6 +3888,11 @@ DiagnosedSilenceableFailure transform::tileToForallOpImpl(
 
   tilingResult = *maybeTilingResult;
 
+  if (tilingResult.loops.empty()) {
+    return transformOp.emitSilenceableError()
+           << "tiling did not generate any loops";
+  }
+
   if (mixedNumThreads.empty()) {
     auto generatedForallOp = cast<scf::ForallOp>(tilingResult.loops.front());
     OpBuilder::InsertionGuard g(rewriter);

--- a/mlir/test/Dialect/Linalg/tile-to-forall.mlir
+++ b/mlir/test/Dialect/Linalg/tile-to-forall.mlir
@@ -723,3 +723,30 @@ module attributes {transform.with_named_sequence} {
     transform.yield
   }
 }
+
+// -----
+
+// Rank-0 linalg.generic (no iteration dimensions) should produce a silenceable
+// error because tiling generates no loops.
+
+func.func @tile_rank0_no_loops(%arg0: tensor<f32>, %arg1: tensor<f32>) -> tensor<f32> {
+  %0 = linalg.generic {
+    indexing_maps = [affine_map<() -> ()>, affine_map<() -> ()>],
+    iterator_types = []}
+    ins(%arg0 : tensor<f32>) outs(%arg1 : tensor<f32>) {
+  ^bb0(%in: f32, %out: f32):
+    %1 = arith.addf %in, %out : f32
+    linalg.yield %1 : f32
+  } -> tensor<f32>
+  return %0 : tensor<f32>
+}
+
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%arg0: !transform.any_op {transform.readonly}) {
+    %0 = transform.structured.match ops{["linalg.generic"]} in %arg0 : (!transform.any_op) -> !transform.any_op
+    // expected-error @below {{tiling did not generate any loops}}
+    %forall, %tiled_generic = transform.structured.tile_using_forall %0 tile_sizes [1]
+          : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+    transform.yield
+  }
+}


### PR DESCRIPTION
`tileToForallOpImpl` accesses `tilingResult.loops.front()` without checking if `loops` is empty. `tileUsingSCF` can return an empty `loops` vector when the tiling produces no loop iterations (e.g. a rank-0 op with an empty iteration domain). This causes two crashes:

1. `normalizeForallLoopOp` dereferences the garbage `ForallOp` pointer from `loops.front()` on the empty vector
2. The garbage pointer propagates into the transform state's reverse mapping via `TileUsingForallOp::apply` (which also calls `loops.front()`), corrupting it and causing a second crash in `checkAndRecordHandleInvalidation` on subsequent transform applications

Fix: return a silenceable error from `tileToForallOpImpl` when `tileUsingSCF` produces no loops, before either call site can access the empty vector.

Fixes https://github.com/llvm/llvm-project/issues/187073