### PR TITLE
Revert "[libc] Avoid host header collisions in full builds (-nostdinc)"

### DIFF
--- a/libc/hdr/func/aligned_alloc.h
+++ b/libc/hdr/func/aligned_alloc.h
@@ -11,11 +11,7 @@
 
 #ifdef LIBC_FULL_BUILD
 #include "hdr/types/size_t.h"
-#ifdef __cplusplus
-extern "C" void *aligned_alloc(size_t, size_t) noexcept;
-#else
 extern "C" void *aligned_alloc(size_t, size_t);
-#endif
 
 #else // Overlay mode
 

--- a/libc/hdr/stdint_proxy.h
+++ b/libc/hdr/stdint_proxy.h
@@ -13,10 +13,6 @@
 // that is `libc.include.stdint` is added to the dependency of all targets
 // that use <stdint.h> header.
 
-#ifdef LIBC_FULL_BUILD
-#include "include/llvm-libc-macros/stdint-macros.h"
-#else
 #include <stdint.h>
-#endif
 
 #endif // LLVM_LIBC_HDR_STDINT_PROXY_H


### PR DESCRIPTION
Reverts llvm/llvm-project#187025

Fails on openmp bot: https://lab.llvm.org/buildbot/#/builders/10/builds/24743
('INT64_MIN' macro redefined when used Clang-provided <stdint.h> is used)
fails on  RISC-V-32 bot: https://lab.llvm.org/buildbot/#/builders/196/builds/17067
due to MPFRNumber constructor not picking the right overload for uint32_t argument.