### PR TITLE
[CodeGen] Use separate MBB number for analyses

### DIFF
--- a/llvm/include/llvm/CodeGen/MachineBasicBlock.h
+++ b/llvm/include/llvm/CodeGen/MachineBasicBlock.h
@@ -189,6 +189,9 @@ private:
   /// as predecessor/successor, a terminator MachineInstr, or a jump table.
   bool MachineBlockAddressTaken = false;
 
+  /// Relatively stable number used for analyses.
+  unsigned AnalysisNumber = 0;
+
   /// If this MachineBasicBlock corresponds to an IR-level "blockaddress"
   /// constant, this contains a pointer to that block.
   BasicBlock *AddressTakenIRBlock = nullptr;
@@ -1269,6 +1272,10 @@ public:
   int getNumber() const { return Number; }
   void setNumber(int N) { Number = N; }
 
+  /// For analyses, we blocks have a more stable number.
+  int getAnalysisNumber() const { return AnalysisNumber; }
+  void setAnalysisNumber(int N) { AnalysisNumber = N; }
+
   /// Return the call frame size on entry to this basic block.
   unsigned getCallFrameSize() const { return CallFrameSize; }
   /// Set the call frame size on entry to this basic block.
@@ -1364,8 +1371,8 @@ template <> struct GraphTraits<MachineBasicBlock *> {
   static ChildIteratorType child_end(NodeRef N) { return N->succ_end(); }
 
   static unsigned getNumber(MachineBasicBlock *BB) {
-    assert(BB->getNumber() >= 0 && "negative block number");
-    return BB->getNumber();
+    assert(BB->getAnalysisNumber() >= 0 && "negative block number");
+    return BB->getAnalysisNumber();
   }
 };
 
@@ -1381,8 +1388,8 @@ template <> struct GraphTraits<const MachineBasicBlock *> {
   static ChildIteratorType child_end(NodeRef N) { return N->succ_end(); }
 
   static unsigned getNumber(const MachineBasicBlock *BB) {
-    assert(BB->getNumber() >= 0 && "negative block number");
-    return BB->getNumber();
+    assert(BB->getAnalysisNumber() >= 0 && "negative block number");
+    return BB->getAnalysisNumber();
   }
 };
 
@@ -1407,8 +1414,8 @@ template <> struct GraphTraits<Inverse<MachineBasicBlock*>> {
   static ChildIteratorType child_end(NodeRef N) { return N->pred_end(); }
 
   static unsigned getNumber(MachineBasicBlock *BB) {
-    assert(BB->getNumber() >= 0 && "negative block number");
-    return BB->getNumber();
+    assert(BB->getAnalysisNumber() >= 0 && "negative block number");
+    return BB->getAnalysisNumber();
   }
 };
 
@@ -1427,8 +1434,8 @@ template <> struct GraphTraits<Inverse<const MachineBasicBlock*>> {
   static ChildIteratorType child_end(NodeRef N) { return N->pred_end(); }
 
   static unsigned getNumber(const MachineBasicBlock *BB) {
-    assert(BB->getNumber() >= 0 && "negative block number");
-    return BB->getNumber();
+    assert(BB->getAnalysisNumber() >= 0 && "negative block number");
+    return BB->getAnalysisNumber();
   }
 };
 

--- a/llvm/include/llvm/CodeGen/MachineBasicBlock.h
+++ b/llvm/include/llvm/CodeGen/MachineBasicBlock.h
@@ -1272,7 +1272,7 @@ public:
   int getNumber() const { return Number; }
   void setNumber(int N) { Number = N; }
 
-  /// For analyses, we blocks have a more stable number.
+  /// For analyses, blocks have a more stable number.
   int getAnalysisNumber() const { return AnalysisNumber; }
   void setAnalysisNumber(int N) { AnalysisNumber = N; }
 

--- a/llvm/include/llvm/CodeGen/MachineFunction.h
+++ b/llvm/include/llvm/CodeGen/MachineFunction.h
@@ -941,7 +941,9 @@ public:
   unsigned getNumBlockIDs() const { return (unsigned)MBBNumbering.size(); }
 
   /// Return the numbering "epoch" of analysis block numbers.
-  unsigned getBlockNumberEpoch() const { return AnalysisNumberingEpoch; }
+  unsigned getAnalysisBlockNumberEpoch() const {
+    return AnalysisNumberingEpoch;
+  }
 
   unsigned assignAnalysisNumber() { return NextAnalysisNumber++; }
 
@@ -1551,7 +1553,7 @@ template <> struct GraphTraits<MachineFunction*> :
     return F->getMaxAnalysisBlockNumber();
   }
   static unsigned getNumberEpoch(MachineFunction *F) {
-    return F->getBlockNumberEpoch();
+    return F->getAnalysisBlockNumberEpoch();
   }
 };
 template <> struct GraphTraits<const MachineFunction*> :
@@ -1577,7 +1579,7 @@ template <> struct GraphTraits<const MachineFunction*> :
     return F->getMaxAnalysisBlockNumber();
   }
   static unsigned getNumberEpoch(const MachineFunction *F) {
-    return F->getBlockNumberEpoch();
+    return F->getAnalysisBlockNumberEpoch();
   }
 };
 
@@ -1596,7 +1598,7 @@ template <> struct GraphTraits<Inverse<MachineFunction*>> :
     return F->getMaxAnalysisBlockNumber();
   }
   static unsigned getNumberEpoch(MachineFunction *F) {
-    return F->getBlockNumberEpoch();
+    return F->getAnalysisBlockNumberEpoch();
   }
 };
 template <> struct GraphTraits<Inverse<const MachineFunction*>> :
@@ -1609,7 +1611,7 @@ template <> struct GraphTraits<Inverse<const MachineFunction*>> :
     return F->getMaxAnalysisBlockNumber();
   }
   static unsigned getNumberEpoch(const MachineFunction *F) {
-    return F->getBlockNumberEpoch();
+    return F->getAnalysisBlockNumberEpoch();
   }
 };
 

--- a/llvm/include/llvm/CodeGen/MachineFunction.h
+++ b/llvm/include/llvm/CodeGen/MachineFunction.h
@@ -331,9 +331,12 @@ class LLVM_ABI MachineFunction {
   // numbered and this vector keeps track of the mapping from ID's to MBB's.
   std::vector<MachineBasicBlock*> MBBNumbering;
 
-  // MBBNumbering epoch, incremented after renumbering to detect use of old
-  // block numbers.
-  unsigned MBBNumberingEpoch = 0;
+  // Analysis number epoch, currently never changed as we don't renumber the
+  // block numbers used for analyses.
+  unsigned AnalysisNumberingEpoch = 0;
+
+  // Next MBB analysis number.
+  unsigned NextAnalysisNumber = 0;
 
   // Pool-allocate MachineFunction-lifetime and IR objects.
   BumpPtrAllocator Allocator;
@@ -937,10 +940,12 @@ public:
   /// getNumBlockIDs - Return the number of MBB ID's allocated.
   unsigned getNumBlockIDs() const { return (unsigned)MBBNumbering.size(); }
 
-  /// Return the numbering "epoch" of block numbers, incremented after each
-  /// numbering. Intended for asserting that no renumbering was performed when
-  /// used by, e.g., preserved analyses.
-  unsigned getBlockNumberEpoch() const { return MBBNumberingEpoch; }
+  /// Return the numbering "epoch" of analysis block numbers.
+  unsigned getBlockNumberEpoch() const { return AnalysisNumberingEpoch; }
+
+  unsigned assignAnalysisNumber() { return NextAnalysisNumber++; }
+
+  unsigned getMaxAnalysisBlockNumber() const { return NextAnalysisNumber; }
 
   /// RenumberBlocks - This discards all of the MachineBasicBlock numbers and
   /// recomputes them.  This guarantees that the MBB numbers are sequential,
@@ -1543,7 +1548,7 @@ template <> struct GraphTraits<MachineFunction*> :
   static unsigned       size       (MachineFunction *F) { return F->size(); }
 
   static unsigned getMaxNumber(MachineFunction *F) {
-    return F->getNumBlockIDs();
+    return F->getMaxAnalysisBlockNumber();
   }
   static unsigned getNumberEpoch(MachineFunction *F) {
     return F->getBlockNumberEpoch();
@@ -1569,7 +1574,7 @@ template <> struct GraphTraits<const MachineFunction*> :
   }
 
   static unsigned getMaxNumber(const MachineFunction *F) {
-    return F->getNumBlockIDs();
+    return F->getMaxAnalysisBlockNumber();
   }
   static unsigned getNumberEpoch(const MachineFunction *F) {
     return F->getBlockNumberEpoch();
@@ -1588,7 +1593,7 @@ template <> struct GraphTraits<Inverse<MachineFunction*>> :
   }
 
   static unsigned getMaxNumber(MachineFunction *F) {
-    return F->getNumBlockIDs();
+    return F->getMaxAnalysisBlockNumber();
   }
   static unsigned getNumberEpoch(MachineFunction *F) {
     return F->getBlockNumberEpoch();
@@ -1601,7 +1606,7 @@ template <> struct GraphTraits<Inverse<const MachineFunction*>> :
   }
 
   static unsigned getMaxNumber(const MachineFunction *F) {
-    return F->getNumBlockIDs();
+    return F->getMaxAnalysisBlockNumber();
   }
   static unsigned getNumberEpoch(const MachineFunction *F) {
     return F->getBlockNumberEpoch();

--- a/llvm/lib/CodeGen/BasicBlockSections.cpp
+++ b/llvm/lib/CodeGen/BasicBlockSections.cpp
@@ -470,13 +470,6 @@ bool BasicBlockSections::runOnMachineFunction(MachineFunction &MF) {
   auto R1 = handleBBSections(MF);
   // Handle basic block address map after basic block sections are finalized.
   auto R2 = handleBBAddrMap(MF);
-
-  // We renumber blocks, so update the dominator tree we want to preserve.
-  if (auto *WP = getAnalysisIfAvailable<MachineDominatorTreeWrapperPass>())
-    WP->getDomTree().updateBlockNumbers();
-  if (auto *WP = getAnalysisIfAvailable<MachinePostDominatorTreeWrapperPass>())
-    WP->getPostDomTree().updateBlockNumbers();
-
   return R1 || R2;
 }
 

--- a/llvm/lib/CodeGen/BranchFolding.cpp
+++ b/llvm/lib/CodeGen/BranchFolding.cpp
@@ -137,8 +137,6 @@ PreservedAnalyses BranchFolderPass::run(MachineFunction &MF,
         "ProfileSummaryAnalysis is required for BranchFoldingPass", false);
 
   auto &MBFI = MFAM.getResult<MachineBlockFrequencyAnalysis>(MF);
-  auto *MDT = MFAM.getCachedResult<MachineDominatorTreeAnalysis>(MF);
-  auto *MPDT = MFAM.getCachedResult<MachinePostDominatorTreeAnalysis>(MF);
   MBFIWrapper MBBFreqInfo(MBFI);
   BranchFolder Folder(EnableTailMerge, /*CommonHoist=*/true, MBBFreqInfo, MBPI,
                       PSI);
@@ -146,10 +144,6 @@ PreservedAnalyses BranchFolderPass::run(MachineFunction &MF,
                               MF.getSubtarget().getRegisterInfo()))
     return getMachineFunctionPassPreservedAnalyses();
 
-  if (MDT)
-    MDT->updateBlockNumbers();
-  if (MPDT)
-    MPDT->updateBlockNumbers();
   return PreservedAnalyses::all();
 }
 

--- a/llvm/lib/CodeGen/BranchRelaxation.cpp
+++ b/llvm/lib/CodeGen/BranchRelaxation.cpp
@@ -771,16 +771,8 @@ bool BranchRelaxation::relaxBranchInstructions() {
 PreservedAnalyses
 BranchRelaxationPass::run(MachineFunction &MF,
                           MachineFunctionAnalysisManager &MFAM) {
-  auto *MDT = MFAM.getCachedResult<MachineDominatorTreeAnalysis>(MF);
-  auto *MPDT = MFAM.getCachedResult<MachinePostDominatorTreeAnalysis>(MF);
-
   if (BranchRelaxation().run(MF))
     return getMachineFunctionPassPreservedAnalyses();
-
-  if (MDT)
-    MDT->updateBlockNumbers();
-  if (MPDT)
-    MPDT->updateBlockNumbers();
   return PreservedAnalyses::all();
 }
 

--- a/llvm/lib/CodeGen/MIRSampleProfile.cpp
+++ b/llvm/lib/CodeGen/MIRSampleProfile.cpp
@@ -370,8 +370,6 @@ bool MIRProfileLoaderPass::runOnMachineFunction(MachineFunction &MF) {
       &getAnalysis<MachinePostDominatorTreeWrapperPass>().getPostDomTree();
 
   MF.RenumberBlocks();
-  MDT->updateBlockNumbers();
-  MPDT->updateBlockNumbers();
 
   MIRSampleLoader->setInitVals(
       MDT, MPDT, &getAnalysis<MachineLoopInfoWrapperPass>().getLI(), MBFI,

--- a/llvm/lib/CodeGen/MachineBasicBlock.cpp
+++ b/llvm/lib/CodeGen/MachineBasicBlock.cpp
@@ -132,6 +132,7 @@ void ilist_callback_traits<MachineBasicBlock>::addNodeToList(
     MachineBasicBlock *N) {
   MachineFunction &MF = *N->getParent();
   N->Number = MF.addToMBBNumbering(N);
+  N->AnalysisNumber = MF.assignAnalysisNumber();
 
   // Make sure the instructions have their operands in the reginfo lists.
   MachineRegisterInfo &RegInfo = MF.getRegInfo();
@@ -143,6 +144,7 @@ void ilist_callback_traits<MachineBasicBlock>::removeNodeFromList(
     MachineBasicBlock *N) {
   N->getParent()->removeFromMBBNumbering(N->Number);
   N->Number = -1;
+  N->AnalysisNumber = -1;
 }
 
 /// When we add an instruction to a basic block list, we update its parent

--- a/llvm/lib/CodeGen/MachineBlockPlacement.cpp
+++ b/llvm/lib/CodeGen/MachineBlockPlacement.cpp
@@ -3538,7 +3538,6 @@ MachineBlockPlacementPass::run(MachineFunction &MF,
   auto *MPDT = MachineBlockPlacement::allowTailDupPlacement(MF)
                    ? &MFAM.getResult<MachinePostDominatorTreeAnalysis>(MF)
                    : nullptr;
-  auto *MDT = MFAM.getCachedResult<MachineDominatorTreeAnalysis>(MF);
   auto *PSI = MFAM.getResult<ModuleAnalysisManagerMachineFunctionProxy>(MF)
                   .getCachedResult<ProfileSummaryAnalysis>(
                       *MF.getFunction().getParent());
@@ -3551,10 +3550,6 @@ MachineBlockPlacementPass::run(MachineFunction &MF,
   if (MBP.run(MF))
     return getMachineFunctionPassPreservedAnalyses();
 
-  if (MDT)
-    MDT->updateBlockNumbers();
-  if (MPDT)
-    MPDT->updateBlockNumbers();
   return PreservedAnalyses::all();
 }
 
@@ -3772,11 +3767,6 @@ void MachineBlockPlacement::assignBlockOrder(
     const std::vector<const MachineBasicBlock *> &NewBlockOrder) {
   assert(F->size() == NewBlockOrder.size() && "Incorrect size of block order");
   F->RenumberBlocks();
-  // At this point, we possibly removed blocks from the function, so we can't
-  // renumber the domtree. At this point, we don't need it anymore, though.
-  // TODO: move this to the point where the dominator tree is actually
-  // invalidated (i.e., where blocks are removed without updating the domtree).
-  MPDT = nullptr;
 
   bool HasChanges = false;
   for (size_t I = 0; I < NewBlockOrder.size(); I++) {

--- a/llvm/lib/CodeGen/MachineFunction.cpp
+++ b/llvm/lib/CodeGen/MachineFunction.cpp
@@ -383,7 +383,6 @@ void MachineFunction::RenumberBlocks(MachineBasicBlock *MBB) {
   // numbering, shrink MBBNumbering now.
   assert(BlockNo <= MBBNumbering.size() && "Mismatch!");
   MBBNumbering.resize(BlockNo);
-  MBBNumberingEpoch++;
 }
 
 int64_t MachineFunction::estimateFunctionSizeInBytes() {

--- a/llvm/lib/CodeGen/UnreachableBlockElim.cpp
+++ b/llvm/lib/CodeGen/UnreachableBlockElim.cpp
@@ -233,11 +233,6 @@ bool UnreachableMachineBlockElim::run(MachineFunction &F) {
   }
 
   F.RenumberBlocks();
-  if (MDT)
-    MDT->updateBlockNumbers();
-
-  if (MPDT)
-    MPDT->updateBlockNumbers();
 
   return (!DeadBlocks.empty() || ModifiedPHI);
 }

--- a/llvm/lib/Target/AMDGPU/SIPreEmitPeephole.cpp
+++ b/llvm/lib/Target/AMDGPU/SIPreEmitPeephole.cpp
@@ -766,8 +766,6 @@ MachineInstrBuilder SIPreEmitPeephole::createUnpackedMI(MachineInstr &I,
 PreservedAnalyses
 llvm::SIPreEmitPeepholePass::run(MachineFunction &MF,
                                  MachineFunctionAnalysisManager &MFAM) {
-  auto *MDT = MFAM.getCachedResult<MachineDominatorTreeAnalysis>(MF);
-  auto *MPDT = MFAM.getCachedResult<MachinePostDominatorTreeAnalysis>(MF);
   auto *MLI = MFAM.getCachedResult<MachineLoopAnalysis>(MF);
   SIPreEmitPeephole Impl;
 
@@ -777,10 +775,6 @@ llvm::SIPreEmitPeepholePass::run(MachineFunction &MF,
     return PA;
   }
 
-  if (MDT)
-    MDT->updateBlockNumbers();
-  if (MPDT)
-    MPDT->updateBlockNumbers();
   return PreservedAnalyses::all();
 }
 

--- a/llvm/lib/Target/ARM/ARMConstantIslandPass.cpp
+++ b/llvm/lib/Target/ARM/ARMConstantIslandPass.cpp
@@ -408,7 +408,6 @@ bool ARMConstantIslands::runOnMachineFunction(MachineFunction &mf) {
   // Renumber all of the machine basic blocks in the function, guaranteeing that
   // the numbers agree with the position of the block in the function.
   MF->RenumberBlocks();
-  DT->updateBlockNumbers();
 
   // Try to reorder and otherwise adjust the block layout to make good use
   // of the TB[BH] instructions.
@@ -420,7 +419,6 @@ bool ARMConstantIslands::runOnMachineFunction(MachineFunction &mf) {
     T2JumpTables.clear();
     // Blocks may have shifted around. Keep the numbering up to date.
     MF->RenumberBlocks();
-    DT->updateBlockNumbers();
   }
 
   // Align any non-fallthrough blocks
@@ -667,10 +665,8 @@ void ARMConstantIslands::doInitialJumpTablePlacement(
   }
 
   // If we did anything then we need to renumber the subsequent blocks.
-  if (LastCorrectlyNumberedBB) {
+  if (LastCorrectlyNumberedBB)
     MF->RenumberBlocks(LastCorrectlyNumberedBB);
-    DT->updateBlockNumbers();
-  }
 }
 
 /// BBHasFallthrough - Return true if the specified basic block can fallthrough
@@ -949,7 +945,6 @@ static bool CompareMBBNumbers(const MachineBasicBlock *LHS,
 void ARMConstantIslands::updateForInsertedWaterBlock(MachineBasicBlock *NewBB) {
   // Renumber the MBB's to keep them consecutive.
   NewBB->getParent()->RenumberBlocks(NewBB);
-  DT->updateBlockNumbers();
 
   // Insert an entry into BBInfo to align it properly with the (newly
   // renumbered) block numbers.
@@ -1012,7 +1007,6 @@ MachineBasicBlock *ARMConstantIslands::splitBlockBeforeInstr(MachineInstr *MI) {
   // This is almost the same as updateForInsertedWaterBlock, except that
   // the Water goes after OrigBB, not NewBB.
   MF->RenumberBlocks(NewBB);
-  DT->updateBlockNumbers();
 
   // Insert an entry into BBInfo to align it properly with the (newly
   // renumbered) block numbers.
@@ -2464,7 +2458,6 @@ MachineBasicBlock *ARMConstantIslands::adjustJTTargetBlockForward(
     BB->updateTerminator(OldNext != MF->end() ? &*OldNext : nullptr);
     // Update numbering to account for the block being moved.
     MF->RenumberBlocks();
-    DT->updateBlockNumbers();
     ++NumJTMoved;
     return nullptr;
   }
@@ -2493,7 +2486,6 @@ MachineBasicBlock *ARMConstantIslands::adjustJTTargetBlockForward(
 
   // Update internal data structures to account for the newly inserted MBB.
   MF->RenumberBlocks(NewBB);
-  DT->updateBlockNumbers();
 
   // Update the CFG.
   NewBB->addSuccessor(BB);

--- a/llvm/lib/Target/Hexagon/HexagonLiveVariables.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonLiveVariables.cpp
@@ -373,9 +373,6 @@ bool HexagonLiveVariablesImpl::runOnMachineFunction(
     MachinePostDominatorTree &MPDT) {
   LLVM_DEBUG(dbgs() << "\nHexagon Live Variables";);
   Fn.RenumberBlocks();
-  // Update the block numbers in the dominator tree since we preserve it.
-  MDT.updateBlockNumbers();
-  MPDT.updateBlockNumbers();
 
   MF = &Fn;
   MRI = &Fn.getRegInfo();

--- a/llvm/lib/Target/WebAssembly/WebAssemblyCFGSort.cpp
+++ b/llvm/lib/Target/WebAssembly/WebAssemblyCFGSort.cpp
@@ -188,7 +188,6 @@ static void sortBlocks(MachineFunction &MF, const MachineLoopInfo &MLI,
   // Remember original layout ordering, so we can update terminators after
   // reordering to point to the original layout successor.
   MF.RenumberBlocks();
-  MDT.updateBlockNumbers();
 
   // Prepare for a topological sort: Record the number of predecessors each
   // block has, ignoring loop backedges.
@@ -329,7 +328,6 @@ static void sortBlocks(MachineFunction &MF, const MachineLoopInfo &MLI,
   }
   assert(Entries.empty() && "Active sort region list not finished");
   MF.RenumberBlocks();
-  MDT.updateBlockNumbers();
 
 #ifndef NDEBUG
   for (auto &MBB : MF) {

--- a/llvm/lib/Target/WebAssembly/WebAssemblyCFGStackify.cpp
+++ b/llvm/lib/Target/WebAssembly/WebAssemblyCFGStackify.cpp
@@ -2305,7 +2305,6 @@ void WebAssemblyCFGStackify::recalculateScopeTops(MachineFunction &MF) {
   // Renumber BBs and recalculate ScopeTop info because new BBs might have been
   // created and inserted during fixing unwind mismatches.
   MF.RenumberBlocks();
-  MDT->updateBlockNumbers();
   ScopeTops.clear();
   ScopeTops.resize(MF.getNumBlockIDs());
   for (auto &MBB : reverse(MF)) {


### PR DESCRIPTION
Block numbers are updated too frequently, which makes it difficult to keep analyses up to date. Therefore, introduce a second number per basic block that is used for analyses and is renumbered less often. This frees analyses from providing somewhat efficient facilities for dealing with changed block numbers, making it simpler to implement in e.g. LoopInfo or CycleInfo.

(Currently, "less often" means not at all, but we might want to renumber after certain passes if the numbering gets too sparse and no analyses are preserved anyway.)

When we introduced a more general use of block numbers some time ago, using the existing numbers seemed to be a somewhat obvious choice, but I now think that this was a bad decision, as it conflates a number that is used for ordering with a number that should be more stable.

MachineBasicBlock isn't particularly size-optimized and there's a fair amount of padding where we can add another number.

There should be no performance impact ([c-t-t](https://llvm-compile-time-tracker.com/compare.php?from=7a8903566dd099c169d25d13154fff7ec607bdb0&to=4ca7ec69912bb743629b69df5260567fa201abce&stat=instructions:u)).