### PR TITLE
[lldb][Module] Don't try to locate scripting resources without a ScriptInterpreter

### DIFF
--- a/lldb/source/Core/Module.cpp
+++ b/lldb/source/Core/Module.cpp
@@ -1440,6 +1440,12 @@ bool Module::LoadScriptingResourceInTarget(Target *target, Status &error) {
   if (script_language == eScriptLanguageNone)
     return true;
 
+  ScriptInterpreter *script_interpreter = debugger.GetScriptInterpreter();
+  if (!script_interpreter) {
+    error = Status::FromErrorString("invalid ScriptInterpreter");
+    return false;
+  }
+
   PlatformSP platform_sp(target->GetPlatform());
 
   if (!platform_sp) {
@@ -1457,12 +1463,6 @@ bool Module::LoadScriptingResourceInTarget(Target *target, Status &error) {
   const uint32_t num_specs = file_specs.GetSize();
   if (num_specs == 0)
     return true;
-
-  ScriptInterpreter *script_interpreter = debugger.GetScriptInterpreter();
-  if (!script_interpreter) {
-    error = Status::FromErrorString("invalid ScriptInterpreter");
-    return false;
-  }
 
   for (uint32_t i = 0; i < num_specs; ++i) {
     FileSpec scripting_fspec(file_specs.GetFileSpecAtIndex(i));

--- a/lldb/source/Plugins/Platform/MacOSX/PlatformDarwin.cpp
+++ b/lldb/source/Plugins/Platform/MacOSX/PlatformDarwin.cpp
@@ -91,7 +91,7 @@ namespace {
 class SanitizedScriptingModuleName {
 public:
   SanitizedScriptingModuleName(llvm::StringRef name,
-                               ScriptInterpreter *script_interpreter)
+                               ScriptInterpreter &script_interpreter)
       : m_original_name(name), m_sanitized_name(name.str()) {
     // FIXME: for Python, don't allow certain characters in imported module
     // filenames. Theoretically, different scripting languages may have
@@ -104,8 +104,7 @@ public:
     llvm::replace(m_sanitized_name, '-', '_');
     llvm::replace(m_sanitized_name, '+', 'x');
 
-    if (script_interpreter &&
-        script_interpreter->IsReservedWord(m_sanitized_name.c_str())) {
+    if (script_interpreter.IsReservedWord(m_sanitized_name.c_str())) {
       m_conflicting_keyword = m_sanitized_name;
       m_sanitized_name.insert(m_sanitized_name.begin(), '_');
     }
@@ -291,11 +290,16 @@ PlatformDarwin::PutFile(const lldb_private::FileSpec &source,
 FileSpecList PlatformDarwin::LocateExecutableScriptingResourcesFromDSYM(
     Stream &feedback_stream, FileSpec module_spec, const Target &target,
     const FileSpec &symfile_spec) {
+
+  assert(target.GetDebugger().GetScriptInterpreter() &&
+         "Trying to locate scripting resources but no ScriptInterpreter is "
+         "available.");
+
   FileSpecList file_list;
   while (module_spec.GetFilename()) {
     SanitizedScriptingModuleName sanitized_name(
         module_spec.GetFilename().GetStringRef(),
-        target.GetDebugger().GetScriptInterpreter());
+        *target.GetDebugger().GetScriptInterpreter());
 
     StreamString path_string;
     StreamString original_path_string;


### PR DESCRIPTION
I'm in the process of moving `SanitizedScriptingModuleName` into `ScriptInterpreter` as a `virtual` API. The nullptr check inside the constructor made that more difficult because it implied we may not have a `ScriptInterpreter` available to call the sanitization API on. Really the `nullptr` check is redundant because even if we succesfully sanitize and then locate some scripts, `Module::LoadScriptingResourceInTarget` bails out if we don't have a `ScriptInterpreter`.

This patch moves the early exit in `LoadScriptingResourceInTarget` to before we make the call to `LocateExecutableScriptingResources`. That way we ensure we never get to `SanitizedScriptingModuleName` without a valid `ScriptInterpreter`.