### PR TITLE
[IR]Delete UB test from IR2VecVocabularyTest

### DIFF
--- a/llvm/include/llvm/IR/Type.h
+++ b/llvm/include/llvm/IR/Type.h
@@ -43,7 +43,7 @@ template <typename PtrType> class SmallPtrSetImpl;
 /// in class Type and in derived classes.  Once allocated, Types are never
 /// free'd.
 ///
-class Type : unsigned {
+class Type {
 public:
   //===--------------------------------------------------------------------===//
   /// Definitions of all of the base types for the Type system.  Based on this
@@ -52,7 +52,7 @@ public:
   /// Type::getPrimitiveType function, or else things will break!
   /// Also update LLVMTypeKind and LLVMGetTypeKind () in the C binding.
   ///
-  enum TypeID {
+  enum TypeID : unsigned {
     // PrimitiveTypes
     HalfTyID = 0,  ///< 16-bit floating point type
     BFloatTyID,    ///< 16-bit floating point type (7-bit significand)

--- a/llvm/include/llvm/IR/Type.h
+++ b/llvm/include/llvm/IR/Type.h
@@ -52,7 +52,7 @@ public:
   /// Type::getPrimitiveType function, or else things will break!
   /// Also update LLVMTypeKind and LLVMGetTypeKind () in the C binding.
   ///
-  enum TypeID : unsigned {
+  enum TypeID : uint8_t {
     // PrimitiveTypes
     HalfTyID = 0,  ///< 16-bit floating point type
     BFloatTyID,    ///< 16-bit floating point type (7-bit significand)

--- a/llvm/include/llvm/IR/Type.h
+++ b/llvm/include/llvm/IR/Type.h
@@ -43,7 +43,7 @@ template <typename PtrType> class SmallPtrSetImpl;
 /// in class Type and in derived classes.  Once allocated, Types are never
 /// free'd.
 ///
-class Type {
+class Type : unsigned {
 public:
   //===--------------------------------------------------------------------===//
   /// Definitions of all of the base types for the Type system.  Based on this

--- a/llvm/include/llvm/IR/Type.h
+++ b/llvm/include/llvm/IR/Type.h
@@ -52,7 +52,7 @@ public:
   /// Type::getPrimitiveType function, or else things will break!
   /// Also update LLVMTypeKind and LLVMGetTypeKind () in the C binding.
   ///
-  enum TypeID : uint8_t {
+  enum TypeID {
     // PrimitiveTypes
     HalfTyID = 0,  ///< 16-bit floating point type
     BFloatTyID,    ///< 16-bit floating point type (7-bit significand)

--- a/llvm/unittests/Analysis/IR2VecTest.cpp
+++ b/llvm/unittests/Analysis/IR2VecTest.cpp
@@ -604,8 +604,6 @@ TEST(IR2VecVocabularyTest, NumericIDMapInvalidInputs) {
   // Test invalid type IDs
   EXPECT_DEATH(Vocabulary::getIndex(static_cast<Type::TypeID>(MaxTypeIDs)),
                "Invalid type ID");
-  EXPECT_DEATH(Vocabulary::getIndex(static_cast<Type::TypeID>(MaxTypeIDs + 10)),
-               "Invalid type ID");
 }
 #endif // NDEBUG
 #endif // GTEST_HAS_DEATH_TEST


### PR DESCRIPTION
An EXPECT in `IR2VecVocabularyTest, NumericIDMapInvalidInput`  triggers UB for arithmetic on out-of-range values:
```
  EXPECT_DEATH(Vocabulary::getIndex(static_cast<Type::TypeID>(MaxTypeIDs + 10)),
               "Invalid type ID");
```

`MaxTypeIDs + 10` causes an overflow