### PR TITLE
[mlir][GPU] Bump static bound on cluster IDs

### DIFF
--- a/mlir/lib/Dialect/GPU/IR/InferIntRangeInterfaceImpls.cpp
+++ b/mlir/lib/Dialect/GPU/IR/InferIntRangeInterfaceImpls.cpp
@@ -18,7 +18,7 @@ using namespace mlir::gpu;
 // Maximum grid and block dimensions of all known GPUs are less than 2^32.
 static constexpr uint64_t kMaxDim = std::numeric_limits<uint32_t>::max();
 // Maximum cluster size.
-static constexpr uint64_t kMaxClusterDim = 8;
+static constexpr uint64_t kMaxClusterDim = 16;
 // Maximum subgroups are no larger than 128.
 static constexpr uint64_t kMaxSubgroupSize = 128;
 

--- a/mlir/test/Dialect/GPU/int-range-interface-cluster.mlir
+++ b/mlir/test/Dialect/GPU/int-range-interface-cluster.mlir
@@ -1,5 +1,5 @@
 // RUN: mlir-opt -int-range-optimizations %s | FileCheck %s
- 
+
 gpu.module @test_module {
   gpu.func @test_cluster_ranges() kernel attributes {known_cluster_size = array<i32: 8, 4, 1>} {
     %c0 = gpu.cluster_block_id x
@@ -20,6 +20,30 @@ gpu.module @test_module {
     %d1_0 = test.reflect_bounds %d1 : index
     %d2 = gpu.cluster_dim_blocks z
     // CHECK: test.reflect_bounds {smax = 1 : index, smin = 1 : index, umax = 1 : index, umin = 1 : index}
+    %d2_0 = test.reflect_bounds %d2 : index
+
+    gpu.return
+  }
+
+  gpu.func @test_cluster_unknown() kernel {
+    %c0 = gpu.cluster_block_id x
+    // CHECK: test.reflect_bounds {smax = 15 : index, smin = 0 : index, umax = 15 : index, umin = 0 : index}
+    %c0_0 = test.reflect_bounds %c0 : index
+    %c1 = gpu.cluster_block_id y
+    // CHECK: test.reflect_bounds {smax = 15 : index, smin = 0 : index, umax = 15 : index, umin = 0 : index}
+    %c1_0 = test.reflect_bounds %c1 : index
+    %c2 = gpu.cluster_block_id z
+    // CHECK: test.reflect_bounds {smax = 15 : index, smin = 0 : index, umax = 15 : index, umin = 0 : index}
+    %c2_0 = test.reflect_bounds %c2 : index
+
+    %d0 = gpu.cluster_dim_blocks x
+    // CHECK: test.reflect_bounds {smax = 16 : index, smin = 1 : index, umax = 16 : index, umin = 1 : index}
+    %d0_0 = test.reflect_bounds %d0 : index
+    %d1 = gpu.cluster_dim_blocks y
+    // CHECK: test.reflect_bounds {smax = 16 : index, smin = 1 : index, umax = 16 : index, umin = 1 : index}
+    %d1_0 = test.reflect_bounds %d1 : index
+    %d2 = gpu.cluster_dim_blocks z
+    // CHECK: test.reflect_bounds {smax = 16 : index, smin = 1 : index, umax = 16 : index, umin = 1 : index}
     %d2_0 = test.reflect_bounds %d2 : index
 
     gpu.return


### PR DESCRIPTION
Hardware (like AMD's gfx1250) allows 16 workgroups per cluster, but the static bound of 8 from many years ago hasn't been updated. This commit adds such an update and adds a test for that bound.