### PR TITLE
[FastISel] generate FAKE_USE for llvm.fake.use

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/FastISel.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/FastISel.cpp
@@ -1417,9 +1417,14 @@ bool FastISel::selectIntrinsicCall(const IntrinsicInst *II) {
     updateValueMap(II, ResultReg);
     return true;
   }
-  case Intrinsic::fake_use:
-    // At -O0, we don't need fake use, so just ignore it.
+  case Intrinsic::fake_use: {
+    const Value *V = II->getArgOperand(0);
+    if (Register Reg = getRegForValue(V))
+      BuildMI(*FuncInfo.MBB, FuncInfo.InsertPt, MIMD,
+              TII.get(TargetOpcode::FAKE_USE))
+          .addReg(Reg);
     return true;
+  }
   case Intrinsic::experimental_stackmap:
     return selectStackmap(II);
   case Intrinsic::experimental_patchpoint_void:

--- a/llvm/test/CodeGen/X86/fake-use-fastisel.ll
+++ b/llvm/test/CodeGen/X86/fake-use-fastisel.ll
@@ -1,0 +1,20 @@
+; RUN: llc < %s -fast-isel -stop-after=finalize-isel -mtriple=x86_64-unknown-linux | FileCheck %s
+;
+; Verify that llvm.fake.use is lowered to FAKE_USE by FastISel.
+; This is relevant for compilers (e.g. Flang) that use llvm.fake.use at O0
+; for addresses of variables that are in registers rather than in allocas (e.g.
+; addresses of arguments in Flang).
+
+; CHECK-LABEL: name: test_fake_use
+; CHECK: hasFakeUses: true
+; CHECK: FAKE_USE %{{[0-9]+}}
+; CHECK: FAKE_USE %{{[0-9]+}}
+; CHECK: FAKE_USE %{{[0-9]+}}
+; CHECK: RET64
+define void @test_fake_use(ptr %p, i32 %x, i64 %y) {
+entry:
+  notail call void (...) @llvm.fake.use(ptr %p)
+  notail call void (...) @llvm.fake.use(i32 %x)
+  notail call void (...) @llvm.fake.use(i64 %y)
+  ret void
+}


### PR DESCRIPTION
FastISel was dropping llvm.fake.use because they are not meant to be generated at O0 with clang.

I am currently working on patches in flang to generate llvm.fake.use for function arguments under `-g` (and O0). This is because Fortran arguments are not copied to the stack (they are reference like arguments in most cases), and instead the LLVM IR produced by flang is directly using the input arguments (at any optimization level).

Doing like clang and putting the argument addresses on the stack at O0 is not the best solution for flang because debuggers heuristics for Fortran code do not understand this as prologue (at least for gdb), and gdb only honors prologue_end flag in DWARF since version 13 (*). Hence the choice of using llvm.fake.use in flang for procedure arguments at O0, and the need for the current patch to FastISel.

The handling is simpler than the equivalent in in [SelectionDAGBuilder](https://github.com/llvm/llvm-project/blame/8238ae27f032e04ca9e566ec31b788394a8377f8/llvm/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.cpp#L7897) because I think it is best to keep fast-isel simple even if that means generating useless FAKE_USE in some cases.

The code is still always returning true (even if no register was found to emit the instruction) because I think fake.use may not justify falling to slower compilation paths (I am very open to change that, I did it to avoid impacting existing toolchain, although I am not sure there is any where emitting llvm.fake.use with fast-isel is a use case since they were dropped).

(*) admittedly, when llvm is promoting the input register to the stack itself, the same issue with prologue appears. I think that fast-isel should maybe generate DBG_VALUE for both the physical and stack location when doing this promotion, like it is done in similar cases without fast-isel, but that is a different topic and I will open a separate patch to discuss it.