### PR TITLE
[InstCombine] Fix comment in SimplifyDemandedUseBits (NFC)

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineSimplifyDemanded.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineSimplifyDemanded.cpp
@@ -590,8 +590,8 @@ Value *InstCombinerImpl::SimplifyDemandedUseBits(Instruction *I,
         // Truth table for inputs and output signbits:
         //       X:0 | X:1
         //      -----------
-        // Y:0  | -1 | -1 |
-        // Y:1  | -1 |  0 |
+        // Y:0  |  0 | -1 |
+        // Y:1  | -1 | -1 |
         //      -----------
         IRBuilderBase::InsertPointGuard Guard(Builder);
         Builder.SetInsertPoint(I);


### PR DESCRIPTION
Fix the values in the truth table comment for the combine

  add iN (sext i1 X), (sext i1 Y) --> sext (X | Y) to iN