### PR TITLE
[libc++] Expand test coverage for converting comparators in associative containers

### DIFF
--- a/libcxx/test/std/containers/associative/lookup_with_converting_comparator.pass.cpp
+++ b/libcxx/test/std/containers/associative/lookup_with_converting_comparator.pass.cpp
@@ -33,17 +33,36 @@ struct S {
 };
 
 template <class Container>
-void test(Container& c) {
-  S v(1);
-  assert(c.find(v) == c.end());
-  assert(c.count(v) == 0);
-  assert(c.lower_bound(v) == c.end());
-  assert(c.upper_bound(v) == c.end());
-  assert(c.equal_range(v).first == c.end());
-  assert(c.equal_range(v).second == c.end());
+void test(Container& container) {
+  // non-const
+  {
+    Container& c = container;
+    S v(1);
+    assert(c.find(v) == c.end());
+    assert(c.count(v) == 0);
+    assert(c.lower_bound(v) == c.end());
+    assert(c.upper_bound(v) == c.end());
+    assert(c.equal_range(v).first == c.end());
+    assert(c.equal_range(v).second == c.end());
 #if TEST_STD_VER >= 20
-  assert(!c.contains(v));
+    assert(!c.contains(v));
 #endif
+  }
+
+  // const
+  {
+    Container const& c = container;
+    S v(1);
+    assert(c.find(v) == c.end());
+    assert(c.count(v) == 0);
+    assert(c.lower_bound(v) == c.end());
+    assert(c.upper_bound(v) == c.end());
+    assert(c.equal_range(v).first == c.end());
+    assert(c.equal_range(v).second == c.end());
+#if TEST_STD_VER >= 20
+    assert(!c.contains(v));
+#endif
+  }
 }
 
 int main(int, char**) {

--- a/libcxx/test/std/containers/associative/lookup_with_converting_comparator.pass.cpp
+++ b/libcxx/test/std/containers/associative/lookup_with_converting_comparator.pass.cpp
@@ -1,0 +1,68 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03
+
+// Make sure that lookup methods on ordered associative containers work properly
+// with comparators that require an implicit conversion on lookup. Using a
+// comparator like less<S> with reference_wrapper<S> as the key type causes an
+// implicit conversion from reference_wrapper<S> to const S& during comparison.
+//
+// Potential heterogeneous lookup optimizations must not break this by making the
+// comparator "transparent" when doing so would remove that conversion.
+//
+// This is a regression test for https://llvm.org/PR179319.
+
+#include <cassert>
+#include <functional>
+#include <map>
+#include <set>
+
+#include "test_macros.h"
+
+struct S {
+  int i_;
+
+  S(int i) : i_(i) {}
+  bool operator<(S lhs) const { return lhs.i_ < i_; }
+};
+
+template <class Container>
+void test(Container& c) {
+  S v(1);
+  assert(c.find(v) == c.end());
+  assert(c.count(v) == 0);
+  assert(c.lower_bound(v) == c.end());
+  assert(c.upper_bound(v) == c.end());
+  assert(c.equal_range(v).first == c.end());
+  assert(c.equal_range(v).second == c.end());
+#if TEST_STD_VER >= 20
+  assert(!c.contains(v));
+#endif
+}
+
+int main(int, char**) {
+  {
+    std::map<std::reference_wrapper<S>, void*, std::less<S>> m;
+    test(m);
+  }
+  {
+    std::multimap<std::reference_wrapper<S>, void*, std::less<S>> m;
+    test(m);
+  }
+  {
+    std::set<std::reference_wrapper<S>, std::less<S>> s;
+    test(s);
+  }
+  {
+    std::multiset<std::reference_wrapper<S>, std::less<S>> s;
+    test(s);
+  }
+
+  return 0;
+}

--- a/libcxx/test/std/containers/associative/map/map.ops/find.pass.cpp
+++ b/libcxx/test/std/containers/associative/map/map.ops/find.pass.cpp
@@ -222,18 +222,5 @@ int main(int, char**) {
     assert(r == std::next(m.begin(), 8));
   }
 #endif
-  { // Make sure we only make the comparator transparent if it's not converting the arguments
-    struct S {
-      int i_;
-
-      S(int i) : i_(i) {}
-      bool operator<(S lhs) const { return lhs.i_ < i_; }
-    };
-    // less<S> causes an implicit conversion from reference_wrapper<S> to const S&, making the `<` lookup succeed
-    std::map<std::reference_wrapper<S>, void*, std::less<S> > m;
-    S v(1);
-    assert(m.find(v) == m.end());
-  }
-
   return 0;
 }


### PR DESCRIPTION
This is in preparation for fixing #187105.