### PR TITLE
[X86][regcall] Rework struct classification for non-Windows x86-64 targets

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -53,6 +53,12 @@ ABI Changes in This Version
   on MSVC targets. Internal bitfield tracking fields were changed from
   ``unsigned char`` to ``uint64_t`` to prevent overflow. This might be an ABI
   break for such structs compared to earlier Clang versions.
+- Fixed a number of issues with the ``__regcall`` calling convention for passing
+  structs on non-Windows x86-64 targets, including a crash when handling empty
+  struct arguments. This changes how structs that contain arrays, floating point
+  types, or ``_Complex float`` types are passed, and may introduce
+  incompatibilities with code compiled by earlier versions of Clang that uses
+  the ``__regcall`` calling convention on these targets. (#GH62999) (#GH98635)
 
 AST Dumping Potentially Breaking Changes
 ----------------------------------------

--- a/clang/lib/CodeGen/Targets/X86.cpp
+++ b/clang/lib/CodeGen/Targets/X86.cpp
@@ -2190,8 +2190,9 @@ ABIArgInfo X86_64ABIInfo::getIndirectReturnResult(QualType Ty) const {
     if (Ty->isBitIntType())
       return getNaturalAlignIndirect(Ty, getDataLayout().getAllocaAddrSpace());
 
-    return (isPromotableIntegerTypeForABI(Ty) ? ABIArgInfo::getExtend(Ty)
-                                              : ABIArgInfo::getDirect());
+    llvm::Type *IRTy = CGT.ConvertType(Ty);
+    return (isPromotableIntegerTypeForABI(Ty) ? ABIArgInfo::getExtend(Ty, IRTy)
+                                              : ABIArgInfo::getDirect(IRTy));
   }
 
   return getNaturalAlignIndirect(Ty, getDataLayout().getAllocaAddrSpace());
@@ -2229,8 +2230,9 @@ ABIArgInfo X86_64ABIInfo::getIndirectResult(QualType Ty,
     if (const auto *ED = Ty->getAsEnumDecl())
       Ty = ED->getIntegerType();
 
-    return (isPromotableIntegerTypeForABI(Ty) ? ABIArgInfo::getExtend(Ty)
-                                              : ABIArgInfo::getDirect());
+    llvm::Type *IRTy = CGT.ConvertType(Ty);
+    return (isPromotableIntegerTypeForABI(Ty) ? ABIArgInfo::getExtend(Ty, IRTy)
+                                              : ABIArgInfo::getDirect(IRTy));
   }
 
   if (CGCXXABI::RecordArgABI RAA = getRecordArgABI(Ty, getCXXABI()))
@@ -2914,22 +2916,7 @@ bool X86_64ABIInfo::passRegCallStructTypeDirectly(
       return false;
 
     llvm::Type *CoerceTy = AI.getCoerceToType();
-    if (!CoerceTy) {
-      // We need to explicitly construct the coerce type for x87 long double
-      // arguments because X86_64ABIInfo::classifyArgumentType classifies them
-      // as direct without specifying a coerce type.
-      if (const BuiltinType *BT = MTy->getAs<BuiltinType>()) {
-        assert(BT->getKind() == BuiltinType::LongDouble &&
-               "Unexpected builtin type with no coerce type");
-        assert(&getTarget().getLongDoubleFormat() ==
-                   &llvm::APFloat::x87DoubleExtended() &&
-               "Unexpected long double representation");
-        CoerceTy = llvm::Type::getX86_FP80Ty(getVMContext());
-      } else {
-        llvm_unreachable("ABI info for struct member has no coerce type");
-      }
-    }
-
+    assert(CoerceTy && "ABI info for struct member has no coerce type");
     if (AT) {
       uint64_t NumElts = AT->getZExtSize();
       LocalNeededInt *= NumElts;

--- a/clang/lib/CodeGen/Targets/X86.cpp
+++ b/clang/lib/CodeGen/Targets/X86.cpp
@@ -2869,9 +2869,6 @@ bool X86_64ABIInfo::passRegCallStructTypeDirectly(
     QualType Ty, SmallVectorImpl<llvm::Type *> &CoerceElts, unsigned &NeededInt,
     unsigned &NeededSSE, unsigned &MaxVectorWidth) const {
 
-  if (isEmptyRecord(getContext(), Ty, true))
-    return true;
-
   auto *RD =
       cast<RecordType>(Ty.getCanonicalType())->getDecl()->getDefinitionOrSelf();
   if (RD->hasFlexibleArrayMember())
@@ -2896,6 +2893,8 @@ bool X86_64ABIInfo::passRegCallStructTypeDirectly(
   for (const auto *FD : RD->fields()) {
     QualType MTy = FD->getType();
     if (MTy->isRecordType() && !MTy->isUnionType()) {
+      if (isEmptyRecord(getContext(), MTy, true))
+        continue;
       if (!passRegCallStructTypeDirectly(MTy, CoerceElts, NeededInt, NeededSSE,
                                          MaxVectorWidth))
         return false;

--- a/clang/lib/CodeGen/Targets/X86.cpp
+++ b/clang/lib/CodeGen/Targets/X86.cpp
@@ -2864,6 +2864,9 @@ ABIArgInfo
 X86_64ABIInfo::classifyRegCallStructTypeImpl(QualType Ty, unsigned &NeededInt,
                                              unsigned &NeededSSE,
                                              unsigned &MaxVectorWidth) const {
+  if (isEmptyRecord(getContext(), Ty, true))
+    return ABIArgInfo::getIgnore();
+
   auto *RD =
       cast<RecordType>(Ty.getCanonicalType())->getDecl()->getDefinitionOrSelf();
 

--- a/clang/lib/CodeGen/Targets/X86.cpp
+++ b/clang/lib/CodeGen/Targets/X86.cpp
@@ -1309,9 +1309,10 @@ class X86_64ABIInfo : public ABIInfo {
                                        unsigned &NeededSSE,
                                        unsigned &MaxVectorWidth) const;
 
-  ABIArgInfo classifyRegCallStructTypeImpl(QualType Ty, unsigned &NeededInt,
-                                           unsigned &NeededSSE,
-                                           unsigned &MaxVectorWidth) const;
+  bool passRegCallStructTypeDirectly(QualType Ty,
+                                     SmallVectorImpl<llvm::Type *> &CoerceElts,
+                                     unsigned &NeededInt, unsigned &NeededSSE,
+                                     unsigned &MaxVectorWidth) const;
 
   bool IsIllegalVectorType(QualType Ty) const;
 
@@ -2860,77 +2861,117 @@ X86_64ABIInfo::classifyArgumentType(QualType Ty, unsigned freeIntRegs,
   return ABIArgInfo::getDirect(ResType);
 }
 
-ABIArgInfo
-X86_64ABIInfo::classifyRegCallStructTypeImpl(QualType Ty, unsigned &NeededInt,
-                                             unsigned &NeededSSE,
-                                             unsigned &MaxVectorWidth) const {
+// Returns true if the struct can be passed directly in registers. If so, the
+// number of registers required will be returned in `NeededInt` and `NeededSSE`,
+// and `CoerceElts` will contain an expanded sequence of LLVM IR types that each
+// field should coerce to.
+bool X86_64ABIInfo::passRegCallStructTypeDirectly(
+    QualType Ty, SmallVectorImpl<llvm::Type *> &CoerceElts, unsigned &NeededInt,
+    unsigned &NeededSSE, unsigned &MaxVectorWidth) const {
+
   if (isEmptyRecord(getContext(), Ty, true))
-    return ABIArgInfo::getIgnore();
+    return true;
 
   auto *RD =
       cast<RecordType>(Ty.getCanonicalType())->getDecl()->getDefinitionOrSelf();
-
   if (RD->hasFlexibleArrayMember())
-    return getIndirectReturnResult(Ty);
+    return false;
 
-  // Sum up bases
+  // Classify the bases.
   if (auto CXXRD = dyn_cast<CXXRecordDecl>(RD)) {
-    if (CXXRD->isDynamicClass()) {
-      NeededInt = NeededSSE = 0;
-      return getIndirectReturnResult(Ty);
-    }
+    if (CXXRD->isDynamicClass())
+      return false;
 
-    for (const auto &I : CXXRD->bases())
-      if (classifyRegCallStructTypeImpl(I.getType(), NeededInt, NeededSSE,
-                                        MaxVectorWidth)
-              .isIndirect()) {
-        NeededInt = NeededSSE = 0;
-        return getIndirectReturnResult(Ty);
-      }
+    for (const auto &I : CXXRD->bases()) {
+      QualType BaseTy = I.getType();
+      if (isEmptyRecord(getContext(), BaseTy, true))
+        continue;
+      if (!passRegCallStructTypeDirectly(BaseTy, CoerceElts, NeededInt,
+                                         NeededSSE, MaxVectorWidth))
+        return false;
+    }
   }
 
-  // Sum up members
+  // Classify the members.
   for (const auto *FD : RD->fields()) {
     QualType MTy = FD->getType();
     if (MTy->isRecordType() && !MTy->isUnionType()) {
-      if (classifyRegCallStructTypeImpl(MTy, NeededInt, NeededSSE,
-                                        MaxVectorWidth)
-              .isIndirect()) {
-        NeededInt = NeededSSE = 0;
-        return getIndirectReturnResult(Ty);
-      }
-    } else {
-      unsigned LocalNeededInt, LocalNeededSSE;
-      if (classifyArgumentType(MTy, UINT_MAX, LocalNeededInt, LocalNeededSSE,
-                               true, true)
-              .isIndirect()) {
-        NeededInt = NeededSSE = 0;
-        return getIndirectReturnResult(Ty);
-      }
-      if (const auto *AT = getContext().getAsConstantArrayType(MTy))
-        MTy = AT->getElementType();
-      if (const auto *VT = MTy->getAs<VectorType>())
-        if (getContext().getTypeSize(VT) > MaxVectorWidth)
-          MaxVectorWidth = getContext().getTypeSize(VT);
-      NeededInt += LocalNeededInt;
-      NeededSSE += LocalNeededSSE;
+      if (!passRegCallStructTypeDirectly(MTy, CoerceElts, NeededInt, NeededSSE,
+                                         MaxVectorWidth))
+        return false;
+      continue;
     }
+
+    const auto *AT = getContext().getAsConstantArrayType(MTy);
+    if (AT)
+      MTy = AT->getElementType();
+
+    unsigned LocalNeededInt, LocalNeededSSE;
+    ABIArgInfo AI = classifyArgumentType(MTy, UINT_MAX, LocalNeededInt,
+                                         LocalNeededSSE, true, true);
+    if (AI.isIgnore())
+      continue;
+    if (AI.isIndirect())
+      return false;
+
+    llvm::Type *CoerceTy = AI.getCoerceToType();
+    if (!CoerceTy) {
+      // We need to explicitly construct the coerce type for x87 long double
+      // arguments because X86_64ABIInfo::classifyArgumentType classifies them
+      // as direct without specifying a coerce type.
+      if (const BuiltinType *BT = MTy->getAs<BuiltinType>()) {
+        assert(BT->getKind() == BuiltinType::LongDouble &&
+               "Unexpected builtin type with no coerce type");
+        assert(&getTarget().getLongDoubleFormat() ==
+                   &llvm::APFloat::x87DoubleExtended() &&
+               "Unexpected long double representation");
+        CoerceTy = llvm::Type::getX86_FP80Ty(getVMContext());
+      } else {
+        llvm_unreachable("ABI info for struct member has no coerce type");
+      }
+    }
+
+    if (AT) {
+      uint64_t NumElts = AT->getZExtSize();
+      LocalNeededInt *= NumElts;
+      LocalNeededSSE *= NumElts;
+      CoerceElts.push_back(llvm::ArrayType::get(CoerceTy, NumElts));
+    } else {
+      CoerceElts.push_back(CoerceTy);
+    }
+
+    if (const auto *VT = MTy->getAs<VectorType>())
+      if (getContext().getTypeSize(VT) > MaxVectorWidth)
+        MaxVectorWidth = getContext().getTypeSize(VT);
+
+    NeededInt += LocalNeededInt;
+    NeededSSE += LocalNeededSSE;
   }
 
-  return ABIArgInfo::getDirect();
+  return true;
 }
 
 ABIArgInfo
 X86_64ABIInfo::classifyRegCallStructType(QualType Ty, unsigned &NeededInt,
                                          unsigned &NeededSSE,
                                          unsigned &MaxVectorWidth) const {
-
   NeededInt = 0;
   NeededSSE = 0;
   MaxVectorWidth = 0;
 
-  return classifyRegCallStructTypeImpl(Ty, NeededInt, NeededSSE,
-                                       MaxVectorWidth);
+  if (isEmptyRecord(getContext(), Ty, true))
+    return ABIArgInfo::getIgnore();
+
+  SmallVector<llvm::Type *, 16> CoerceElts;
+  if (!passRegCallStructTypeDirectly(Ty, CoerceElts, NeededInt, NeededSSE,
+                                     MaxVectorWidth)) {
+    NeededInt = NeededSSE = 0;
+    return getIndirectReturnResult(Ty);
+  }
+
+  assert(!CoerceElts.empty() && "Non-empty struct produced no element types");
+  return ABIArgInfo::getDirect(
+      llvm::StructType::get(getVMContext(), CoerceElts));
 }
 
 void X86_64ABIInfo::computeInfo(CGFunctionInfo &FI) const {
@@ -2985,6 +3026,10 @@ void X86_64ABIInfo::computeInfo(CGFunctionInfo &FI) const {
   // The chain argument effectively gives us another free register.
   if (FI.isChainCall())
     ++FreeIntRegs;
+
+  // RegCall lets us reuse the return registers.
+  if (IsRegCall)
+    FreeSSERegs = 16;
 
   unsigned NumRequiredArgs = FI.getNumRequiredArgs();
   // AMD64-ABI 3.2.3p3: Once arguments are classified, the registers

--- a/clang/test/CodeGen/regcall.c
+++ b/clang/test/CodeGen/regcall.c
@@ -1,7 +1,7 @@
-// RUN: %clang_cc1 -emit-llvm %s -o - -ffreestanding -triple=i386-pc-win32       | FileCheck %s --check-prefixes=X86,Win32
-// RUN: %clang_cc1 -emit-llvm %s -o - -ffreestanding -triple=x86_64-pc-win32     | FileCheck %s --check-prefixes=X64,Win64
-// RUN: %clang_cc1 -emit-llvm %s -o - -ffreestanding -triple=i386-pc-linux-gnu   | FileCheck %s --check-prefixes=X86,Lin32
-// RUN: %clang_cc1 -emit-llvm %s -o - -ffreestanding -triple=x86_64-pc-linux-gnu | FileCheck %s --check-prefixes=X64,Lin64
+// RUN: %clang_cc1 -emit-llvm %s -o - -ffreestanding -triple=i386-pc-win32       | FileCheck %s --check-prefixes=X86,Win32,Windows
+// RUN: %clang_cc1 -emit-llvm %s -o - -ffreestanding -triple=x86_64-pc-win32     | FileCheck %s --check-prefixes=X64,Win64,Windows
+// RUN: %clang_cc1 -emit-llvm %s -o - -ffreestanding -triple=i386-pc-linux-gnu   | FileCheck %s --check-prefixes=X86,Lin32,Linux
+// RUN: %clang_cc1 -emit-llvm %s -o - -ffreestanding -triple=x86_64-pc-linux-gnu | FileCheck %s --check-prefixes=X64,Lin64,Linux
 
 #include <xmmintrin.h>
 
@@ -42,12 +42,55 @@ void __regcall v6(struct Empty a, int b) {}
 // Win64: define dso_local x86_regcallcc void @__regcall3__v6(i32 %a.coerce, i32 noundef %b)
 // Lin64: define dso_local x86_regcallcc void @__regcall3__v6(i32 noundef %b)
 
-static struct Empty g_empty;
-struct Empty __regcall v7(void) { return g_empty; }
-// Win32: define dso_local x86_regcallcc void @__regcall3__v7()
-// Lin32: define dso_local x86_regcallcc void @__regcall3__v7(ptr dead_on_unwind inreg noalias writable sret(%struct.Empty) align 1 %agg.result)
-// Win64: define dso_local x86_regcallcc i32 @__regcall3__v7()
-// Lin64: define dso_local x86_regcallcc void @__regcall3__v7()
+struct IntDouble { int x; double y; };
+void __regcall v7(struct IntDouble a) {}
+// Win32: define dso_local x86_regcallcc void @__regcall3__v7(ptr noundef byval(%struct.IntDouble) align 4 %0)
+// Win64: define dso_local x86_regcallcc void @__regcall3__v7(ptr noundef dead_on_return %a)
+// Linux: define dso_local x86_regcallcc void @__regcall3__v7(i32 %{{.*}}, double %{{.*}})
+
+struct Nested { struct IntDouble a; double b; };
+void __regcall v8(struct Nested a) {}
+// X86: define dso_local x86_regcallcc void @__regcall3__v8(ptr noundef byval(%struct.Nested) align 4 %{{.*}})
+// Win64: define dso_local x86_regcallcc void @__regcall3__v8(ptr noundef dead_on_return %a)
+// Lin64: define dso_local x86_regcallcc void @__regcall3__v8(i32 %a.coerce0, double %a.coerce1, double %a.coerce2)
+
+struct NestedEmpty { struct Empty e; int x; };
+void __regcall v9(struct NestedEmpty a) {}
+// X86: define dso_local x86_regcallcc void @__regcall3__v9(ptr noundef byval(%struct.NestedEmpty) align 4 %a)
+// Win64: define dso_local x86_regcallcc void @__regcall3__v9(i64 %a.coerce)
+// Lin64: define dso_local x86_regcallcc void @__regcall3__v9(i32 %a.coerce)
+
+struct LongDouble { long double x, y; };
+void __regcall v10(struct LongDouble a) {}
+// Windows: define dso_local x86_regcallcc void @__regcall3__v10(double %a.0, double %a.1)
+// Lin32: define dso_local x86_regcallcc void @__regcall3__v10(ptr noundef byval(%struct.LongDouble) align 4 %a)
+// Lin64: define dso_local x86_regcallcc void @__regcall3__v10(x86_fp80 %a.coerce0, x86_fp80 %a.coerce1)
+
+// Ensure that we correctly count the number of registers used by an array of
+// elements that each consume more than one register.
+struct MultiIntDirect { _Complex long long a[5]; };
+void __regcall v11(struct MultiIntDirect a) {}
+// X86: define dso_local x86_regcallcc void @__regcall3__v11(ptr noundef byval(%struct.MultiIntDirect) align 4 %{{.*}})
+// Win64: define dso_local x86_regcallcc void @__regcall3__v11(ptr noundef dead_on_return %a)
+// Lin64: define dso_local x86_regcallcc void @__regcall3__v11([5 x { i64, i64 }] %a.coerce)
+
+struct MultiSSESpill { _Complex double a[9]; };
+void __regcall v12(struct MultiSSESpill a) {}
+// X86: define dso_local x86_regcallcc void @__regcall3__v12(ptr noundef byval(%struct.MultiSSESpill) align 4 %{{.*}})
+// Win64: define dso_local x86_regcallcc void @__regcall3__v12(ptr noundef dead_on_return %a)
+// Lin64: define dso_local x86_regcallcc void @__regcall3__v12(ptr noundef byval(%struct.MultiSSESpill) align 8 %a)
+
+struct ComplexFloat { _Complex float a; int b; };
+void __regcall v13(struct ComplexFloat a) {}
+// X86: define dso_local x86_regcallcc void @__regcall3__v13(float %a.0, float %a.1, i32 %a.2)
+// Win64: define dso_local x86_regcallcc void @__regcall3__v13(ptr noundef dead_on_return %a)
+// Lin64: define dso_local x86_regcallcc void @__regcall3__v13(<2 x float> %a.coerce0, i32 %a.coerce1)
+
+struct FlexibleArrayMember { int a; int b[]; };
+void __regcall v14(struct FlexibleArrayMember a) {}
+// X86: define dso_local x86_regcallcc void @__regcall3__v14(ptr noundef byval(%struct.FlexibleArrayMember) align 4 %a)
+// Win64: define dso_local x86_regcallcc void @__regcall3__v14(ptr noundef dead_on_return %a)
+// Lin64: define dso_local x86_regcallcc void @__regcall3__v14(ptr noundef byval(%struct.FlexibleArrayMember) align 4 %a)
 
 struct HFA2 { double x, y; };
 struct HFA4 { double w, x, y, z; };
@@ -82,7 +125,8 @@ void __regcall hfa4(struct HFA5 a) {}
 static struct HFA2 g_hfa2;
 struct HFA2 __regcall hfa5(void) { return g_hfa2; }
 // X86: define dso_local x86_regcallcc %struct.HFA2 @__regcall3__hfa5()
-// X64: define dso_local x86_regcallcc %struct.HFA2 @__regcall3__hfa5()
+// Win64: define dso_local x86_regcallcc %struct.HFA2 @__regcall3__hfa5()
+// Lin64: define dso_local x86_regcallcc { double, double } @__regcall3__hfa5()
 
 typedef float __attribute__((vector_size(16))) v4f32;
 struct HVA2 { v4f32 x, y; };
@@ -111,4 +155,4 @@ struct HFA6 { __m128 f[4]; };
 struct HFA6 __regcall ret_reg_reused(struct HFA6 a, struct HFA6 b, struct HFA6 c, struct HFA6 d){ struct HFA6 h; return h;}
 // X86: define dso_local x86_regcallcc %struct.HFA6 @__regcall3__ret_reg_reused(<4 x float> %a.0, <4 x float> %a.1, <4 x float> %a.2, <4 x float> %a.3, <4 x float> %b.0, <4 x float> %b.1, <4 x float> %b.2, <4 x float> %b.3, ptr inreg noundef dead_on_return %c, ptr inreg noundef dead_on_return %d)
 // Win64: define dso_local x86_regcallcc %struct.HFA6 @__regcall3__ret_reg_reused(<4 x float> %a.0, <4 x float> %a.1, <4 x float> %a.2, <4 x float> %a.3, <4 x float> %b.0, <4 x float> %b.1, <4 x float> %b.2, <4 x float> %b.3, <4 x float> %c.0, <4 x float> %c.1, <4 x float> %c.2, <4 x float> %c.3, <4 x float> %d.0, <4 x float> %d.1, <4 x float> %d.2, <4 x float> %d.3)
-// Lin64: define dso_local x86_regcallcc %struct.HFA6 @__regcall3__ret_reg_reused([4 x <4 x float>] %a.coerce, [4 x <4 x float>] %b.coerce, [4 x <4 x float>] %c.coerce, [4 x <4 x float>] %d.coerce)
+// Lin64: define dso_local x86_regcallcc { [4 x <4 x float>] } @__regcall3__ret_reg_reused([4 x <4 x float>] %a.coerce, [4 x <4 x float>] %b.coerce, [4 x <4 x float>] %c.coerce, [4 x <4 x float>] %d.coerce)

--- a/clang/test/CodeGen/regcall.c
+++ b/clang/test/CodeGen/regcall.c
@@ -35,6 +35,20 @@ void __regcall v5(long long a, int b, int c) {}
 // X86: define dso_local x86_regcallcc void @__regcall3__v5(i64 noundef %a, i32 inreg noundef %b, i32 inreg noundef %c)
 // X64: define dso_local x86_regcallcc void @__regcall3__v5(i64 noundef %a, i32 noundef %b, i32 noundef %c)
 
+struct Empty {};
+void __regcall v6(struct Empty a, int b) {}
+// Win32: define dso_local x86_regcallcc void @__regcall3__v6(ptr noundef byval(%struct.Empty) align 4 %a, i32 inreg noundef %b)
+// Lin32: define dso_local x86_regcallcc void @__regcall3__v6(i32 inreg noundef %b)
+// Win64: define dso_local x86_regcallcc void @__regcall3__v6(i32 %a.coerce, i32 noundef %b)
+// Lin64: define dso_local x86_regcallcc void @__regcall3__v6(i32 noundef %b)
+
+static struct Empty g_empty;
+struct Empty __regcall v7(void) { return g_empty; }
+// Win32: define dso_local x86_regcallcc void @__regcall3__v7()
+// Lin32: define dso_local x86_regcallcc void @__regcall3__v7(ptr dead_on_unwind inreg noalias writable sret(%struct.Empty) align 1 %agg.result)
+// Win64: define dso_local x86_regcallcc i32 @__regcall3__v7()
+// Lin64: define dso_local x86_regcallcc void @__regcall3__v7()
+
 struct HFA2 { double x, y; };
 struct HFA4 { double w, x, y, z; };
 struct HFA5 { double v, w, x, y, z; };

--- a/clang/test/CodeGen/regcall4.c
+++ b/clang/test/CodeGen/regcall4.c
@@ -1,7 +1,7 @@
-// RUN: %clang_cc1 -regcall4 -emit-llvm %s -o - -ffreestanding -triple=i386-pc-win32       | FileCheck %s --check-prefixes=X86,Win32
-// RUN: %clang_cc1 -regcall4 -emit-llvm %s -o - -ffreestanding -triple=x86_64-pc-win32     | FileCheck %s --check-prefixes=X64,Win64
-// RUN: %clang_cc1 -regcall4 -emit-llvm %s -o - -ffreestanding -triple=i386-pc-linux-gnu   | FileCheck %s --check-prefixes=X86,Lin32
-// RUN: %clang_cc1 -regcall4 -emit-llvm %s -o - -ffreestanding -triple=x86_64-pc-linux-gnu | FileCheck %s --check-prefixes=X64,Lin64
+// RUN: %clang_cc1 -regcall4 -emit-llvm %s -o - -ffreestanding -triple=i386-pc-win32       | FileCheck %s --check-prefixes=X86,Win32,Windows
+// RUN: %clang_cc1 -regcall4 -emit-llvm %s -o - -ffreestanding -triple=x86_64-pc-win32     | FileCheck %s --check-prefixes=X64,Win64,Windows
+// RUN: %clang_cc1 -regcall4 -emit-llvm %s -o - -ffreestanding -triple=i386-pc-linux-gnu   | FileCheck %s --check-prefixes=X86,Lin32,Linux
+// RUN: %clang_cc1 -regcall4 -emit-llvm %s -o - -ffreestanding -triple=x86_64-pc-linux-gnu | FileCheck %s --check-prefixes=X64,Lin64,Linux
 
 #include <xmmintrin.h>
 
@@ -42,12 +42,55 @@ void __regcall v6(struct Empty a, int b) {}
 // Win64: define dso_local x86_regcallcc void @__regcall4__v6(i32 %a.coerce, i32 noundef %b)
 // Lin64: define dso_local x86_regcallcc void @__regcall4__v6(i32 noundef %b)
 
-static struct Empty g_empty;
-struct Empty __regcall v7(void) { return g_empty; }
-// Win32: define dso_local x86_regcallcc void @__regcall4__v7()
-// Lin32: define dso_local x86_regcallcc void @__regcall4__v7(ptr dead_on_unwind inreg noalias writable sret(%struct.Empty) align 1 %agg.result)
-// Win64: define dso_local x86_regcallcc i32 @__regcall4__v7()
-// Lin64: define dso_local x86_regcallcc void @__regcall4__v7()
+struct IntDouble { int x; double y; };
+void __regcall v7(struct IntDouble a) {}
+// Win32: define dso_local x86_regcallcc void @__regcall4__v7(ptr noundef byval(%struct.IntDouble) align 4 %0)
+// Win64: define dso_local x86_regcallcc void @__regcall4__v7(ptr noundef dead_on_return %a)
+// Linux: define dso_local x86_regcallcc void @__regcall4__v7(i32 %{{.*}}, double %{{.*}})
+
+struct Nested { struct IntDouble a; double b; };
+void __regcall v8(struct Nested a) {}
+// X86: define dso_local x86_regcallcc void @__regcall4__v8(ptr noundef byval(%struct.Nested) align 4 %{{.*}})
+// Win64: define dso_local x86_regcallcc void @__regcall4__v8(ptr noundef dead_on_return %a)
+// Lin64: define dso_local x86_regcallcc void @__regcall4__v8(i32 %a.coerce0, double %a.coerce1, double %a.coerce2)
+
+struct NestedEmpty { struct Empty e; int x; };
+void __regcall v9(struct NestedEmpty a) {}
+// X86: define dso_local x86_regcallcc void @__regcall4__v9(ptr noundef byval(%struct.NestedEmpty) align 4 %a)
+// Win64: define dso_local x86_regcallcc void @__regcall4__v9(i64 %a.coerce)
+// Lin64: define dso_local x86_regcallcc void @__regcall4__v9(i32 %a.coerce)
+
+struct LongDouble { long double x, y; };
+void __regcall v10(struct LongDouble a) {}
+// Windows: define dso_local x86_regcallcc void @__regcall4__v10(double %a.0, double %a.1)
+// Lin32: define dso_local x86_regcallcc void @__regcall4__v10(ptr noundef byval(%struct.LongDouble) align 4 %a)
+// Lin64: define dso_local x86_regcallcc void @__regcall4__v10(x86_fp80 %a.coerce0, x86_fp80 %a.coerce1)
+
+// Ensure that we correctly count the number of registers used by an array of
+// elements that each consume more than one register.
+struct MultiIntDirect { _Complex long long a[5]; };
+void __regcall v11(struct MultiIntDirect a) {}
+// X86: define dso_local x86_regcallcc void @__regcall4__v11(ptr noundef byval(%struct.MultiIntDirect) align 4 %{{.*}})
+// Win64: define dso_local x86_regcallcc void @__regcall4__v11(ptr noundef dead_on_return %a)
+// Lin64: define dso_local x86_regcallcc void @__regcall4__v11([5 x { i64, i64 }] %a.coerce)
+
+struct MultiSSESpill { _Complex double a[9]; };
+void __regcall v12(struct MultiSSESpill a) {}
+// X86: define dso_local x86_regcallcc void @__regcall4__v12(ptr noundef byval(%struct.MultiSSESpill) align 4 %{{.*}})
+// Win64: define dso_local x86_regcallcc void @__regcall4__v12(ptr noundef dead_on_return %a)
+// Lin64: define dso_local x86_regcallcc void @__regcall4__v12(ptr noundef byval(%struct.MultiSSESpill) align 8 %a)
+
+struct ComplexFloat { _Complex float a; int b; };
+void __regcall v13(struct ComplexFloat a) {}
+// X86: define dso_local x86_regcallcc void @__regcall4__v13(float %a.0, float %a.1, i32 %a.2)
+// Win64: define dso_local x86_regcallcc void @__regcall4__v13(ptr noundef dead_on_return %a)
+// Lin64: define dso_local x86_regcallcc void @__regcall4__v13(<2 x float> %a.coerce0, i32 %a.coerce1)
+
+struct FlexibleArrayMember { int a; int b[]; };
+void __regcall v14(struct FlexibleArrayMember a) {}
+// X86: define dso_local x86_regcallcc void @__regcall4__v14(ptr noundef byval(%struct.FlexibleArrayMember) align 4 %a)
+// Win64: define dso_local x86_regcallcc void @__regcall4__v14(ptr noundef dead_on_return %a)
+// Lin64: define dso_local x86_regcallcc void @__regcall4__v14(ptr noundef byval(%struct.FlexibleArrayMember) align 4 %a)
 
 struct HFA2 { double x, y; };
 struct HFA4 { double w, x, y, z; };
@@ -82,7 +125,8 @@ void __regcall hfa4(struct HFA5 a) {}
 static struct HFA2 g_hfa2;
 struct HFA2 __regcall hfa5(void) { return g_hfa2; }
 // X86: define dso_local x86_regcallcc %struct.HFA2 @__regcall4__hfa5()
-// X64: define dso_local x86_regcallcc %struct.HFA2 @__regcall4__hfa5()
+// Win64: define dso_local x86_regcallcc %struct.HFA2 @__regcall4__hfa5()
+// Lin64: define dso_local x86_regcallcc { double, double } @__regcall4__hfa5()
 
 typedef float __attribute__((vector_size(16))) v4f32;
 struct HVA2 { v4f32 x, y; };
@@ -111,4 +155,4 @@ struct HFA6 { __m128 f[4]; };
 struct HFA6 __regcall ret_reg_reused(struct HFA6 a, struct HFA6 b, struct HFA6 c, struct HFA6 d){ struct HFA6 h; return h;}
 // X86: define dso_local x86_regcallcc %struct.HFA6 @__regcall4__ret_reg_reused(<4 x float> %a.0, <4 x float> %a.1, <4 x float> %a.2, <4 x float> %a.3, <4 x float> %b.0, <4 x float> %b.1, <4 x float> %b.2, <4 x float> %b.3, ptr inreg noundef dead_on_return %c, ptr inreg noundef dead_on_return %d)
 // Win64: define dso_local x86_regcallcc %struct.HFA6 @__regcall4__ret_reg_reused(<4 x float> %a.0, <4 x float> %a.1, <4 x float> %a.2, <4 x float> %a.3, <4 x float> %b.0, <4 x float> %b.1, <4 x float> %b.2, <4 x float> %b.3, <4 x float> %c.0, <4 x float> %c.1, <4 x float> %c.2, <4 x float> %c.3, <4 x float> %d.0, <4 x float> %d.1, <4 x float> %d.2, <4 x float> %d.3)
-// Lin64: define dso_local x86_regcallcc %struct.HFA6 @__regcall4__ret_reg_reused([4 x <4 x float>] %a.coerce, [4 x <4 x float>] %b.coerce, [4 x <4 x float>] %c.coerce, [4 x <4 x float>] %d.coerce)
+// Lin64: define dso_local x86_regcallcc { [4 x <4 x float>] } @__regcall4__ret_reg_reused([4 x <4 x float>] %a.coerce, [4 x <4 x float>] %b.coerce, [4 x <4 x float>] %c.coerce, [4 x <4 x float>] %d.coerce)

--- a/clang/test/CodeGen/regcall4.c
+++ b/clang/test/CodeGen/regcall4.c
@@ -35,6 +35,20 @@ void __regcall v5(long long a, int b, int c) {}
 // X86: define dso_local x86_regcallcc void @__regcall4__v5(i64 noundef %a, i32 inreg noundef %b, i32 inreg noundef %c)
 // X64: define dso_local x86_regcallcc void @__regcall4__v5(i64 noundef %a, i32 noundef %b, i32 noundef %c)
 
+struct Empty {};
+void __regcall v6(struct Empty a, int b) {}
+// Win32: define dso_local x86_regcallcc void @__regcall4__v6(ptr noundef byval(%struct.Empty) align 4 %a, i32 inreg noundef %b)
+// Lin32: define dso_local x86_regcallcc void @__regcall4__v6(i32 inreg noundef %b)
+// Win64: define dso_local x86_regcallcc void @__regcall4__v6(i32 %a.coerce, i32 noundef %b)
+// Lin64: define dso_local x86_regcallcc void @__regcall4__v6(i32 noundef %b)
+
+static struct Empty g_empty;
+struct Empty __regcall v7(void) { return g_empty; }
+// Win32: define dso_local x86_regcallcc void @__regcall4__v7()
+// Lin32: define dso_local x86_regcallcc void @__regcall4__v7(ptr dead_on_unwind inreg noalias writable sret(%struct.Empty) align 1 %agg.result)
+// Win64: define dso_local x86_regcallcc i32 @__regcall4__v7()
+// Lin64: define dso_local x86_regcallcc void @__regcall4__v7()
+
 struct HFA2 { double x, y; };
 struct HFA4 { double w, x, y, z; };
 struct HFA5 { double v, w, x, y, z; };

--- a/clang/test/CodeGenCXX/regcall.cpp
+++ b/clang/test/CodeGenCXX/regcall.cpp
@@ -25,6 +25,30 @@ int __regcall foo (int i){
 // CHECK-WIN64: define dso_local x86_regcallcc noundef {{.+}}@"?foo@@YwHH@Z"
 // CHECK-WIN32: define dso_local x86_regcallcc noundef {{.+}}@"?foo@@YwHH@Z"
 
+struct DynBase { int x; virtual void v() = 0; };
+struct Dyn : public DynBase { double a; void v() {} };
+void __regcall f1(Dyn a) { a.x = 42; }
+// CHECK-LIN64: define dso_local x86_regcallcc void @_Z14__regcall3__f13Dyn(ptr noundef byval(%struct.Dyn) align 8 %a)
+// CHECK-LIN32: define dso_local x86_regcallcc void @_Z14__regcall3__f13Dyn(ptr inreg noundef dead_on_return %a)
+// CHECK-WIN64: define dso_local x86_regcallcc void @"?f1@@YwXUDyn@@@Z"(ptr noundef dead_on_return %a)
+// CHECK-WIN32: define dso_local x86_regcallcc void @"?f1@@YwXUDyn@@@Z"(ptr inalloca(<{ %struct.Dyn }>) %0)
+
+struct Base { int x; };
+struct Derived : public Base { double a; };
+void __regcall f2(Derived a) { a.x = 42; }
+// CHECK-LIN64: define dso_local x86_regcallcc void @_Z14__regcall3__f27Derived(i32 %a.coerce0, double %a.coerce1)
+// CHECK-LIN32: define dso_local x86_regcallcc void @_Z14__regcall3__f27Derived(ptr noundef byval(%struct.Derived) align 4 %a)
+// CHECK-WIN64: define dso_local x86_regcallcc void @"?f2@@YwXUDerived@@@Z"(ptr noundef dead_on_return %a)
+// CHECK-WIN32: define dso_local x86_regcallcc void @"?f2@@YwXUDerived@@@Z"(ptr noundef byval(%struct.Derived) align 4 %0)
+
+struct Empty {};
+struct NestedEmpty : public Empty { int x; };
+void __regcall f3(NestedEmpty a) { a.x = 42; }
+// CHECK-LIN64: define dso_local x86_regcallcc void @_Z14__regcall3__f311NestedEmpty(i32 %a.coerce)
+// CHECK-LIN32: define dso_local x86_regcallcc void @_Z14__regcall3__f311NestedEmpty(ptr noundef byval(%struct.NestedEmpty) align 4 %a)
+// CHECK-WIN64: define dso_local x86_regcallcc void @"?f3@@YwXUNestedEmpty@@@Z"(i32 %a.coerce)
+// CHECK-WIN32: define dso_local x86_regcallcc void @"?f3@@YwXUNestedEmpty@@@Z"(i32 %a.0)
+
 // used to give a body to test_class functions
 static int x = 0;
 class test_class {

--- a/clang/test/CodeGenCXX/regcall4.cpp
+++ b/clang/test/CodeGenCXX/regcall4.cpp
@@ -25,6 +25,30 @@ int __regcall foo (int i){
 // CHECK-WIN64: define dso_local x86_regcallcc noundef {{.+}}@"?foo@@YxHH@Z"
 // CHECK-WIN32: define dso_local x86_regcallcc noundef {{.+}}@"?foo@@YxHH@Z"
 
+struct DynBase { int x; virtual void v() = 0; };
+struct Dyn : public DynBase { double a; void v() {} };
+void __regcall f1(Dyn a) { a.x = 42; }
+// CHECK-LIN64: define dso_local x86_regcallcc void @_Z14__regcall4__f13Dyn(ptr noundef byval(%struct.Dyn) align 8 %a)
+// CHECK-LIN32: define dso_local x86_regcallcc void @_Z14__regcall4__f13Dyn(ptr inreg noundef dead_on_return %a)
+// CHECK-WIN64: define dso_local x86_regcallcc void @"?f1@@YxXUDyn@@@Z"(ptr noundef dead_on_return %a)
+// CHECK-WIN32: define dso_local x86_regcallcc void @"?f1@@YxXUDyn@@@Z"(ptr inalloca(<{ %struct.Dyn }>) %0)
+
+struct Base { int x; };
+struct Derived : public Base { double a; };
+void __regcall f2(Derived a) { a.x = 42; }
+// CHECK-LIN64: define dso_local x86_regcallcc void @_Z14__regcall4__f27Derived(i32 %a.coerce0, double %a.coerce1)
+// CHECK-LIN32: define dso_local x86_regcallcc void @_Z14__regcall4__f27Derived(ptr noundef byval(%struct.Derived) align 4 %a)
+// CHECK-WIN64: define dso_local x86_regcallcc void @"?f2@@YxXUDerived@@@Z"(ptr noundef dead_on_return %a)
+// CHECK-WIN32: define dso_local x86_regcallcc void @"?f2@@YxXUDerived@@@Z"(ptr noundef byval(%struct.Derived) align 4 %0)
+
+struct Empty {};
+struct NestedEmpty : public Empty { int x; };
+void __regcall f3(NestedEmpty a) { a.x = 42; }
+// CHECK-LIN64: define dso_local x86_regcallcc void @_Z14__regcall4__f311NestedEmpty(i32 %a.coerce)
+// CHECK-LIN32: define dso_local x86_regcallcc void @_Z14__regcall4__f311NestedEmpty(ptr noundef byval(%struct.NestedEmpty) align 4 %a)
+// CHECK-WIN64: define dso_local x86_regcallcc void @"?f3@@YxXUNestedEmpty@@@Z"(i32 %a.coerce)
+// CHECK-WIN32: define dso_local x86_regcallcc void @"?f3@@YxXUNestedEmpty@@@Z"(i32 %a.0)
+
 // used to give a body to test_class functions
 static int x = 0;
 class test_class {


### PR DESCRIPTION
Currently, when `X86_64ABIInfo::classifyRegCallStructTypeImpl` classifies a struct argument or return value as direct, it leaves the LLVM IR coerce type unspecified, implicitly relying on `CodeGenTypes::ConvertType` to eventually construct a default IR type based on the struct's layout. This conversion is neither stable nor guaranteed to adhere to the ABI's classification rules.

Instead, rewrite `classifyRegCallStructTypeImpl` to construct an explicit sequence of coerce types, using the existing field classification to obtain a coerce type for each member of the struct. Also, rename the function to `passRegCallStructTypeDirectly` and return a boolean instead, so that now `classifyRegCallStructType` is the only place that computes `ABIArgInfo`.

This rewrite also fixes several other issues with the `X86_64ABIInfo` implementation of `__regcall`:

* Empty structs are now ignored instead of being misclassified as direct.
* Arrays are now classified specially based on the element type, since `X86_64ABIInfo::classifyArgumentType` ignores standalone array types.
* SSE registers used for return values are now correctly reused for arguments, matching the 64-bit Windows behavior.

Since this is an ABI change, it has the potential to cause incompatibilities with `__regcall` code compiled by earlier versions of Clang. Specifically:

* Because SSE return registers can now be reused as argument registers, functions will now pass more floating point arguments in SSE registers.
* `_Complex float` struct fields are now passed in one SSE register instead of two.

Fixes #62999
Fixes #98635