### PR TITLE
[IR2Vec] Remove redundant death test for invalid TypeID

### DIFF
--- a/llvm/unittests/Analysis/IR2VecTest.cpp
+++ b/llvm/unittests/Analysis/IR2VecTest.cpp
@@ -604,8 +604,6 @@ TEST(IR2VecVocabularyTest, NumericIDMapInvalidInputs) {
   // Test invalid type IDs
   EXPECT_DEATH(Vocabulary::getIndex(static_cast<Type::TypeID>(MaxTypeIDs)),
                "Invalid type ID");
-  EXPECT_DEATH(Vocabulary::getIndex(static_cast<Type::TypeID>(MaxTypeIDs + 10)),
-               "Invalid type ID");
 }
 #endif // NDEBUG
 #endif // GTEST_HAS_DEATH_TEST


### PR DESCRIPTION
The `NumericIDMapInvalidInputs` test has two `EXPECT_DEATH` calls for invalid `Type::TypeID` values. The second value (`MaxTypeIDs + 10`) is redundant: `getIndex` has a one-sided assert, so any value greater or equal to `MaxTypeIDs` takes the same code path as the value already tested by the first call.

The test began failing after https://github.com/llvm/llvm-project/pull/186888, which introduced `ByteTyID`. The value of `MaxTypeIDs + 10` became 32, which falls outside the representable range of the `enum`, making the cast UB. To avoid accidentally triggering this test when adding new types, it should probably be removed.