### PR TITLE
[orc-rt] Add ExecutorProcessInfo APIs.

### DIFF
--- a/orc-rt/include/orc-rt/ExecutorProcessInfo.h
+++ b/orc-rt/include/orc-rt/ExecutorProcessInfo.h
@@ -1,0 +1,48 @@
+//===---- ExecutorProcessInfo.h - Executor Process Info APIs ----*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// APIs to provide information about the host process in which the executor
+// is running.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef ORC_RT_EXECUTORPROCESSINFO_H
+#define ORC_RT_EXECUTORPROCESSINFO_H
+
+#include "orc-rt/Error.h"
+#include <string>
+
+namespace orc_rt {
+
+/// Provides information about the host process in which the ORC runtime
+/// executor is running.
+class ExecutorProcessInfo {
+public:
+  /// Create an ExecutorProcessInfo from the given values.
+  ExecutorProcessInfo(std::string Triple, size_t PageSize) noexcept;
+
+  /// Create an ExecutorProcessInfo, auto-detecting values.
+  static Expected<ExecutorProcessInfo> Detect() noexcept;
+
+  /// Returns a target triple string for the host process.
+  const std::string &targetTriple() const noexcept { return Triple; }
+
+  /// Returns the host process's page size.
+  size_t pageSize() const noexcept { return PageSize; }
+
+  static std::string detectTargetTriple() noexcept;
+  static Expected<size_t> detectPageSize() noexcept;
+
+private:
+  std::string Triple;
+  size_t PageSize;
+};
+
+} // namespace orc_rt
+
+#endif // ORC_RT_EXECUTORPROCESSINFO_H

--- a/orc-rt/lib/executor/CMakeLists.txt
+++ b/orc-rt/lib/executor/CMakeLists.txt
@@ -2,6 +2,7 @@ set(files
   AllocAction.cpp
   ControllerInterface.cpp
   Error.cpp
+  ExecutorProcessInfo.cpp
   QueueingTaskDispatcher.cpp
   RTTI.cpp
   Service.cpp

--- a/orc-rt/lib/executor/ExecutorProcessInfo.cpp
+++ b/orc-rt/lib/executor/ExecutorProcessInfo.cpp
@@ -1,0 +1,72 @@
+//===- ExecutorProcessInfo.cpp --------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Contains the implementation of APIs in the orc-rt/ExecutorProcessInfo.h
+// header.
+//
+//===----------------------------------------------------------------------===//
+
+#include "orc-rt/ExecutorProcessInfo.h"
+
+#include <cstring>
+#include <unistd.h>
+
+namespace orc_rt {
+
+ExecutorProcessInfo::ExecutorProcessInfo(std::string Triple,
+                                         size_t PageSize) noexcept
+    : Triple(std::move(Triple)), PageSize(PageSize) {}
+
+/// Create an ExecutorProcessInfo, auto-detecting property values.
+Expected<ExecutorProcessInfo> ExecutorProcessInfo::Detect() noexcept {
+  auto Triple = detectTargetTriple();
+  auto PageSize = detectPageSize();
+  if (!PageSize)
+    return PageSize.takeError();
+  return ExecutorProcessInfo(std::move(Triple), std::move(*PageSize));
+}
+
+std::string ExecutorProcessInfo::detectTargetTriple() noexcept {
+  std::string Triple;
+
+// Arch
+#if defined(__x86_64__) || defined(_M_X64)
+  Triple += "x86_64";
+#elif defined(__aarch64__) || defined(_M_ARM64)
+  Triple += "aarch64";
+#else
+#error "Unsupported architecture"
+#endif
+
+  // Vendor
+#if defined(__APPLE__)
+  Triple += "-apple";
+#else
+  Triple += "-unknown";
+#endif
+
+  // OS
+#if defined(__APPLE__)
+  Triple += "-darwin";
+#elif defined(__linux__)
+  Triple += "-linux";
+#else
+#error "Unsupported OS"
+#endif
+
+  return Triple;
+}
+
+Expected<size_t> ExecutorProcessInfo::detectPageSize() noexcept {
+  long PageSize = sysconf(_SC_PAGESIZE);
+  if (PageSize == -1)
+    return make_error<StringError>(strerror(errno));
+  return static_cast<size_t>(PageSize);
+}
+
+} // namespace orc_rt

--- a/orc-rt/unittests/CMakeLists.txt
+++ b/orc-rt/unittests/CMakeLists.txt
@@ -21,6 +21,7 @@ add_orc_rt_unittest(CoreTests
   ErrorTest.cpp
   ErrorExceptionInteropTest.cpp
   ExecutorAddressTest.cpp
+  ExecutorProcessInfoTest.cpp
   IntervalMapTest.cpp
   IntervalSetTest.cpp
   LockedAccessTest.cpp

--- a/orc-rt/unittests/ExecutorProcessInfoTest.cpp
+++ b/orc-rt/unittests/ExecutorProcessInfoTest.cpp
@@ -1,0 +1,79 @@
+//===- ExecutorProcessInfoTest.cpp ----------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Tests for ExecutorProcessInfo APIs.
+//
+//===----------------------------------------------------------------------===//
+
+#include "orc-rt/ExecutorProcessInfo.h"
+#include "orc-rt/Math.h"
+#include "gtest/gtest.h"
+
+#include <algorithm>
+#include <unistd.h>
+
+using namespace orc_rt;
+
+TEST(ExecutorProcessInfoTest, DetectSucceeds) {
+  auto EPI = ExecutorProcessInfo::Detect();
+  EXPECT_TRUE(!!EPI);
+}
+
+TEST(ExecutorProcessInfoTest, DetectPageSizeIsPowerOfTwo) {
+  auto EPI = cantFail(ExecutorProcessInfo::Detect());
+  EXPECT_GT(EPI.pageSize(), 0U);
+  EXPECT_TRUE(isPowerOf2(EPI.pageSize()));
+}
+
+TEST(ExecutorProcessInfoTest, DetectPageSizeAtLeast4096) {
+  auto EPI = cantFail(ExecutorProcessInfo::Detect());
+  EXPECT_GE(EPI.pageSize(), 4096U);
+}
+
+TEST(ExecutorProcessInfoTest, DetectPageSizeMatchesSysconf) {
+  auto EPI = cantFail(ExecutorProcessInfo::Detect());
+  EXPECT_EQ(EPI.pageSize(), static_cast<size_t>(sysconf(_SC_PAGESIZE)));
+}
+
+TEST(ExecutorProcessInfoTest, DetectTargetTripleNotEmpty) {
+  auto EPI = cantFail(ExecutorProcessInfo::Detect());
+  EXPECT_FALSE(EPI.targetTriple().empty());
+}
+
+TEST(ExecutorProcessInfoTest, DetectTargetTripleHasValidStructure) {
+  auto EPI = cantFail(ExecutorProcessInfo::Detect());
+  // A valid triple has 2 hyphens (arch-vendor-os) or 3 (arch-vendor-os-env).
+  auto NumHyphens =
+      std::count(EPI.targetTriple().begin(), EPI.targetTriple().end(), '-');
+  EXPECT_GE(NumHyphens, 2);
+  EXPECT_LE(NumHyphens, 3);
+}
+
+TEST(ExecutorProcessInfoTest, DetectTargetTripleArchMatchesCompileTarget) {
+  auto EPI = cantFail(ExecutorProcessInfo::Detect());
+#if defined(__x86_64__) || defined(_M_X64)
+  EXPECT_EQ(EPI.targetTriple().substr(0, 6), "x86_64");
+#elif defined(__aarch64__) || defined(_M_ARM64)
+  EXPECT_EQ(EPI.targetTriple().substr(0, 7), "aarch64");
+#endif
+}
+
+TEST(ExecutorProcessInfoTest, DetectTargetTripleOSMatchesCompileTarget) {
+  auto EPI = cantFail(ExecutorProcessInfo::Detect());
+#if defined(__APPLE__)
+  EXPECT_NE(EPI.targetTriple().find("darwin"), std::string::npos);
+#elif defined(__linux__)
+  EXPECT_NE(EPI.targetTriple().find("linux"), std::string::npos);
+#endif
+}
+
+TEST(ExecutorProcessInfoTest, ConstructWithExplicitValues) {
+  ExecutorProcessInfo EPI("x86_64-unknown-linux-gnu", 4096);
+  EXPECT_EQ(EPI.targetTriple(), "x86_64-unknown-linux-gnu");
+  EXPECT_EQ(EPI.pageSize(), 4096U);
+}


### PR DESCRIPTION
ExecutorProcessInfo provides information about the process in which the ORC runtime is running.