### PR TITLE
[SandboxVec][DAG] Fix DAG update when user is scheduled

### DIFF
--- a/llvm/lib/Transforms/Vectorize/SandboxVectorizer/DependencyGraph.cpp
+++ b/llvm/lib/Transforms/Vectorize/SandboxVectorizer/DependencyGraph.cpp
@@ -531,7 +531,14 @@ void DependencyGraph::notifySetUse(const Use &U, Value *NewSrc) {
   //  ---|---   ---|---   -
   //  U.User     U.User
   auto *UserI = dyn_cast_or_null<Instruction>(U.getUser());
-  if (UserI == nullptr || !getNode(UserI))
+  if (UserI == nullptr)
+    return;
+  auto *UserN = getNode(UserI);
+  if (UserN == nullptr)
+    return;
+  // If UserN is marked as scheduled then we should not update CrrSrcN' or
+  // NewSrcN's unscheduled successors.
+  if (UserN->scheduled())
     return;
   // Update the UnscheduledSuccs counter for both the current source and
   // NewSrc if needed.

--- a/llvm/unittests/Transforms/Vectorize/SandboxVectorizer/DependencyGraphTest.cpp
+++ b/llvm/unittests/Transforms/Vectorize/SandboxVectorizer/DependencyGraphTest.cpp
@@ -1284,3 +1284,41 @@ define void @foo(i8 %v0) {
   EXPECT_DEATH(Add1N->getNumUnscheduledSuccs(), ".*");
 #endif
 }
+
+// Don't udpate the unscheduled succs if the user is scheduled.
+TEST_F(DependencyGraphTest, MaintainUnscheduledSuccsWhenUserScheduled) {
+  parseIR(C, R"IR(
+define void @foo(i8 %v0) {
+  %add0 = add i8 %v0, 0
+  %add1 = add i8 %v0, 1
+  %modify = add i8 %add0, 1
+  ret void
+}
+)IR");
+  llvm::Function *LLVMF = &*M->getFunction("foo");
+  sandboxir::Context Ctx(C);
+  auto *F = Ctx.createFunction(LLVMF);
+  auto *BB = &*F->begin();
+  auto It = BB->begin();
+  auto *Add0 = cast<sandboxir::BinaryOperator>(&*It++);
+  auto *Add1 = cast<sandboxir::BinaryOperator>(&*It++);
+  auto *Modify = cast<sandboxir::BinaryOperator>(&*It++);
+  // DAG contains all Add0, Add1 and Modify
+  sandboxir::DependencyGraph DAG(getAA(*LLVMF), Ctx);
+  DAG.extend({Add0, Add1, Modify});
+  auto *Add0N = DAG.getNode(Add0);
+  auto *Add1N = DAG.getNode(Add1);
+  auto *ModifyN = DAG.getNode(Modify);
+  EXPECT_EQ(Add0N->getNumUnscheduledSuccs(), 1u);
+  // Mark Modify as scheduled and decrement Add1N's unscheduled succs.
+  ModifyN->setScheduled();
+  Add0N->decrUnscheduledSuccs();
+  EXPECT_EQ(Add0N->getNumUnscheduledSuccs(), 0u);
+  EXPECT_EQ(Add1N->getNumUnscheduledSuccs(), 0u);
+
+  // Change Modify's operand and make sure that this won't update Add0N's or
+  // Add1N's unscheduled succs because ModifyN is "scheduled".
+  Modify->setOperand(0, Add1);
+  EXPECT_EQ(Add0N->getNumUnscheduledSuccs(), 0u);
+  EXPECT_EQ(Add1N->getNumUnscheduledSuccs(), 0u);
+}


### PR DESCRIPTION
This patch fixes the update of the DAGNode UnscheduledSucc counter when a use edge is modified. This is the result of a setOperand() or a RAUW (and friends) operation.

Before this patch we would not check if the User (i.e., the consumer of the use-def edge) is scheduled and we would update the definition's UnscheduledSucc counter, resulting in counting errors.

For example, consider the following IR:
```
  %A = ...
  %B = ...
  %U = %A  ; scheduled
```
Note that %U's DAGNode is marked as "scheduled" while %A and %B are not.

If we change %U's operand from %A to %B then we should not attempt to update %A's or %B's UnscheduledSuccs because %U is scheduled so it should not get counted as an "unscheduled" successor.