### PR TITLE
[MC] Improve documentation of MCRegister. Lower physical register id to 28 bits.

### DIFF
--- a/llvm/include/llvm/CodeGen/Register.h
+++ b/llvm/include/llvm/CodeGen/Register.h
@@ -28,7 +28,8 @@ public:
   // sometimes stack slots. The unsigned values are divided into these ranges:
   //
   //   0           Not a register, can be used as a sentinel.
-  //   [1;2^30)    Physical registers assigned by TableGen.
+  //   [1;2^28)    Physical registers assigned by TableGen.
+  //   [2^28;2^30) Unused.
   //   [2^30;2^31) Stack slots. (Rarely used.)
   //   [2^31;2^32) Virtual registers assigned by MachineRegisterInfo.
   //
@@ -104,10 +105,7 @@ public:
   /// Utility to check-convert this value to a MCRegister. The caller is
   /// expected to have already validated that this Register is, indeed,
   /// physical.
-  MCRegister asMCReg() const {
-    assert(!isValid() || isPhysical());
-    return MCRegister(Reg);
-  }
+  MCRegister asMCReg() const { return MCRegister::from(Reg); }
 
   constexpr bool isValid() const { return Reg != MCRegister::NoRegister; }
 

--- a/llvm/include/llvm/MC/MCRegister.h
+++ b/llvm/include/llvm/MC/MCRegister.h
@@ -38,7 +38,7 @@ struct MCRegUnitToIndex {
 };
 
 /// Wrapper class representing physical registers and target specific virtual
-// registers. Should be passed by value.
+/// registers. Should be passed by value.
 class MCRegister {
   friend hash_code hash_value(const MCRegister &);
   unsigned Reg;

--- a/llvm/include/llvm/MC/MCRegister.h
+++ b/llvm/include/llvm/MC/MCRegister.h
@@ -45,7 +45,7 @@ class MCRegister {
 
 public:
   constexpr MCRegister(unsigned Val = 0) : Reg(Val) {
-    // N.B. this does not assert `Val == NoRegister || `isPhysicalRegister(Val)`
+    // N.B. this does not assert `Val == NoRegister || isPhysicalRegister(Val)`
     // to avoid paying the compilation/runtime cost for developers of the
     // compiler and to allow target specific virtual registers.
     //

--- a/llvm/include/llvm/MC/MCRegister.h
+++ b/llvm/include/llvm/MC/MCRegister.h
@@ -37,21 +37,32 @@ struct MCRegUnitToIndex {
   }
 };
 
-/// Wrapper class representing physical registers. Should be passed by value.
+/// Wrapper class representing physical registers and target specific virtual
+// registers. Should be passed by value.
 class MCRegister {
   friend hash_code hash_value(const MCRegister &);
   unsigned Reg;
 
 public:
-  constexpr MCRegister(unsigned Val = 0) : Reg(Val) {}
+  constexpr MCRegister(unsigned Val = 0) : Reg(Val) {
+    // N.B. this does not assert `Val == NoRegister || `isPhysicalRegister(Val)`
+    // to avoid paying the compilation/runtime cost for developers of the
+    // compiler and to allow target specific virtual registers.
+    //
+    // Where the producer wishes to `assert` they can use `Register::asMCReg`
+    // and/or `MCRegister::from`.
+    //
+    // Within CodeGen, consumers can assume a valid MCRegister contains a
+    // physical register.
+  }
 
-  // Register numbers can represent physical registers, virtual registers, and
-  // sometimes stack slots. The unsigned values are divided into these ranges:
+  // Register numbers can represent physical registers and virtual registers
+  // used after codegen by some targets (NVPTX, SPIRV, and WebAssembly).
+  // The unsigned values are divided into these ranges:
   //
   //   0           Not a register, can be used as a sentinel.
-  //   [1;2^30)    Physical registers assigned by TableGen.
-  //   [2^30;2^31) Stack slots. (Rarely used.)
-  //   [2^31;2^32) Virtual registers assigned by MachineRegisterInfo.
+  //   [1;2^28)    Physical registers assigned by TableGen.
+  //   [2^28;2^32) Target specific virtual registers after codegen.
   //
   // Further sentinels can be allocated from the small negative integers.
   // DenseMapInfo<unsigned> uses -1u and -2u.
@@ -59,7 +70,7 @@ public:
                 "Reg isn't large enough to hold full range.");
   static constexpr unsigned NoRegister = 0u;
   static constexpr unsigned FirstPhysicalReg = 1u;
-  static constexpr unsigned LastPhysicalReg = (1u << 30) - 1;
+  static constexpr unsigned LastPhysicalReg = (1u << 28) - 1;
 
   /// Return true if the specified register number is in
   /// the physical register namespace.
@@ -73,8 +84,8 @@ public:
 
   constexpr operator unsigned() const { return Reg; }
 
-  /// Check the provided unsigned value is a valid MCRegister.
-  static MCRegister from(unsigned Val) {
+  /// Check-convert the provided unsigned value to an MCRegister.
+  static constexpr MCRegister from(unsigned Val) {
     assert(Val == NoRegister || isPhysicalRegister(Val));
     return MCRegister(Val);
   }

--- a/llvm/lib/Target/NVPTX/NVPTXAsmPrinter.cpp
+++ b/llvm/lib/Target/NVPTX/NVPTXAsmPrinter.cpp
@@ -211,7 +211,7 @@ unsigned NVPTXAsmPrinter::encodeVirtualRegister(unsigned Reg) {
     DenseMap<unsigned, unsigned> &RegMap = VRegMapping[RC];
     unsigned RegNum = RegMap[Reg];
 
-    static_assert(MCRegister::LastPhysicalReg <= (1 << 28));
+    static_assert(MCRegister::LastPhysicalReg < (1 << 28));
 
     // Encode the register class in the upper 4 bits
     // Must be kept in sync with NVPTXInstPrinter::printRegName

--- a/llvm/lib/Target/NVPTX/NVPTXAsmPrinter.cpp
+++ b/llvm/lib/Target/NVPTX/NVPTXAsmPrinter.cpp
@@ -211,6 +211,8 @@ unsigned NVPTXAsmPrinter::encodeVirtualRegister(unsigned Reg) {
     DenseMap<unsigned, unsigned> &RegMap = VRegMapping[RC];
     unsigned RegNum = RegMap[Reg];
 
+    static_assert(MCRegister::LastPhysicalReg <= (1 << 28));
+
     // Encode the register class in the upper 4 bits
     // Must be kept in sync with NVPTXInstPrinter::printRegName
     unsigned Ret = 0;


### PR DESCRIPTION
NVPTX, SPIR-V, and WebAssembly use MCRegister to store virtual registers after codegen. SPIR-V and WebAssembly use bit 31 to indicate a virtual register. NVPTX uses the upper 4 bits to store a register class for the virtual registers with class 0 being physical registers.

Lower the physical register size in MCRegister to bless the NVPTX usage.

Remove the comments about stack slot in MCRegister and add the concept of a target specific virtual register.

Make `MCRegister::from` be `constexpr` and use it in `Register::asMCReg` instead of duplicating the assert.

Replaces #186238 and #186714.