### PR TITLE
[CUDA][HIP] Fix missing caller notes and add HD-promoted function note for deferred diagnostics

### DIFF
--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -9687,6 +9687,7 @@ def err_deleted_inherited_ctor_use : Error<
 
 def note_called_by : Note<"called by %0">;
 def note_which_is_called_by : Note<"which is called by %0">;
+def note_in_hd_promoted_function : Note<"in HD-promoted function %0">;
 def err_kern_type_not_void_return : Error<
   "kernel function type %0 must have void return type">;
 def err_kern_is_nonstatic_method : Error<

--- a/clang/lib/Sema/Sema.cpp
+++ b/clang/lib/Sema/Sema.cpp
@@ -2023,22 +2023,21 @@ public:
     auto It = S.DeviceDeferredDiags.find(FD);
     if (It == S.DeviceDeferredDiags.end())
       return;
-    bool HasWarningOrError = false;
     for (PartialDiagnosticAt &PDAt : It->second) {
       if (S.Diags.hasFatalErrorOccurred())
         return;
       const SourceLocation &Loc = PDAt.first;
       const PartialDiagnostic &PD = PDAt.second;
-      HasWarningOrError |=
+      bool IsWarningOrError =
           S.getDiagnostics().getDiagnosticLevel(PD.getDiagID(), Loc) >=
           DiagnosticsEngine::Warning;
       {
         DiagnosticBuilder Builder(S.Diags.Report(Loc, PD.getDiagID()));
         PD.Emit(Builder);
       }
+      if (IsWarningOrError)
+        emitCallStackNotes(S, FD);
     }
-    if (HasWarningOrError)
-      emitCallStackNotes(S, FD);
   }
 
   void emitCollectedDiags() {

--- a/clang/lib/Sema/Sema.cpp
+++ b/clang/lib/Sema/Sema.cpp
@@ -2035,8 +2035,13 @@ public:
         DiagnosticBuilder Builder(S.Diags.Report(Loc, PD.getDiagID()));
         PD.Emit(Builder);
       }
-      if (IsWarningOrError)
+      if (IsWarningOrError) {
+        if (FD->hasAttr<CUDAHostAttr>() && FD->hasAttr<CUDADeviceAttr>())
+          S.Diags.Report(FD->getLocation(),
+                         diag::note_in_hd_promoted_function)
+              << FD;
         emitCallStackNotes(S, FD);
+      }
     }
   }
 

--- a/clang/test/SemaCUDA/add-inline-in-definition.cu
+++ b/clang/test/SemaCUDA/add-inline-in-definition.cu
@@ -23,6 +23,9 @@ void host_fn() {}
 #endif
 
 __host__ __device__ void foo();
+#ifdef __CUDA_ARCH__
+  // expected-note@-2 {{in HD-promoted function 'foo'}}
+#endif
 __device__ void bar() {
   foo();
 #ifdef __CUDA_ARCH__

--- a/clang/test/SemaCUDA/bad-calls-on-same-line.cu
+++ b/clang/test/SemaCUDA/bad-calls-on-same-line.cu
@@ -26,7 +26,7 @@ struct Selector<double> {
 };
 
 template <typename T>
-inline __host__ __device__ void hd() {
+inline __host__ __device__ void hd() { // expected-note 2{{in HD-promoted function 'hd<}}
   Selector<T>().f();
   // expected-error@-1 2 {{reference to __device__ function}}
 }

--- a/clang/test/SemaCUDA/call-stack-for-deferred-err.cu
+++ b/clang/test/SemaCUDA/call-stack-for-deferred-err.cu
@@ -8,7 +8,7 @@
 //
 // Compare to no-call-stack-for-deferred-err.cu.
 
-inline __host__ __device__ void hd_fn(int n);
+inline __host__ __device__ void hd_fn(int n); // expected-note {{in HD-promoted function 'hd_fn'}}
 inline __device__ void device_fn2() { hd_fn(42); } // expected-note {{called by 'device_fn2'}}
 
 __global__ void kernel() { device_fn2(); } // expected-note {{called by 'kernel'}}

--- a/clang/test/SemaCUDA/constexpr-ctor.cu
+++ b/clang/test/SemaCUDA/constexpr-ctor.cu
@@ -13,7 +13,8 @@ struct A {
 
 template <class T, int x> struct B {
   T a;
-  constexpr B() = default; // dev-error 2{{reference to __host__ function 'A' in __host__ __device__ function}}
+  constexpr B() = default; // dev-error 2{{reference to __host__ function 'A' in __host__ __device__ function}} \
+                             // dev-note 2{{in HD-promoted function 'B'}}
 };
 
 __host__ void f() { B<A, 1> x; }

--- a/clang/test/SemaCUDA/deferred-diags-dedup.cu
+++ b/clang/test/SemaCUDA/deferred-diags-dedup.cu
@@ -16,7 +16,7 @@ __host__ void hf(); // expected-note 3{{'hf' declared here}}
 // Lambda calling a host function. Its deferred diagnostics should be
 // emitted only once even when multiple device functions call it.
 __device__ auto l =
-  [] {
+  [] { // expected-note 2{{in HD-promoted function 'operator()'}}
     hf(); // expected-error {{reference to __host__ function 'hf' in __host__ __device__ function}}
     hf(); // expected-error {{reference to __host__ function 'hf' in __host__ __device__ function}}
   };
@@ -35,7 +35,7 @@ __device__ void df3() {
 
 // Test with shared call chains: two chains reaching the same function
 // through different intermediate callers.
-inline __host__ __device__ void hdf() {
+inline __host__ __device__ void hdf() { // expected-note {{in HD-promoted function 'hdf'}}
   hf(); // expected-error {{reference to __host__ function 'hf' in __host__ __device__ function}}
 }
 

--- a/clang/test/SemaCUDA/deferred-diags-dedup.cu
+++ b/clang/test/SemaCUDA/deferred-diags-dedup.cu
@@ -22,15 +22,15 @@ __device__ auto l =
   };
 
 __device__ void df1() {
-  l(); // expected-note {{called by 'df1'}}
+  l(); // expected-note 2{{called by 'df1'}}
 }
 
 __device__ void df2() {
-  l(); // expected-note {{called by 'df2'}}
+  l(); // expected-note 2{{called by 'df2'}}
 }
 
 __device__ void df3() {
-  l(); // expected-note {{called by 'df3'}}
+  l(); // expected-note 2{{called by 'df3'}}
 }
 
 // Test with shared call chains: two chains reaching the same function

--- a/clang/test/SemaCUDA/deferred-diags-missing-caller.cu
+++ b/clang/test/SemaCUDA/deferred-diags-missing-caller.cu
@@ -12,7 +12,7 @@
 __host__ void hf(); // expected-note 2{{'hf' declared here}}
 
 __device__ auto l =
-  [] {
+  [] { // expected-note 2{{in HD-promoted function 'operator()'}}
     hf(); // expected-error {{reference to __host__ function 'hf' in __host__ __device__ function}}
     hf(); // expected-error {{reference to __host__ function 'hf' in __host__ __device__ function}}
   };

--- a/clang/test/SemaCUDA/deferred-diags-missing-caller.cu
+++ b/clang/test/SemaCUDA/deferred-diags-missing-caller.cu
@@ -1,0 +1,26 @@
+// RUN: %clang_cc1 -triple amdgcn-amd-amdhsa -fcuda-is-device -fsyntax-only \
+// RUN:   -verify %s
+// RUN: %clang_cc1 -triple nvptx64-nvidia-cuda -fcuda-is-device -fsyntax-only \
+// RUN:   -verify %s
+
+// NOTE: Do not autogenerate. Tests that "called by" notes are attached to
+// all deferred diagnostics, not just the last one in a function.
+// See https://github.com/llvm/llvm-project/issues/180638.
+
+#include "Inputs/cuda.h"
+
+__host__ void hf(); // expected-note 2{{'hf' declared here}}
+
+__device__ auto l =
+  [] {
+    hf(); // expected-error {{reference to __host__ function 'hf' in __host__ __device__ function}}
+    hf(); // expected-error {{reference to __host__ function 'hf' in __host__ __device__ function}}
+  };
+
+__device__ void df1() {
+  l(); // expected-note 2{{called by 'df1'}}
+}
+
+__device__ void df2() {
+  l(); // expected-note 2{{called by 'df2'}}
+}

--- a/clang/test/SemaCUDA/deferred-diags.cu
+++ b/clang/test/SemaCUDA/deferred-diags.cu
@@ -3,12 +3,12 @@
 #include "Inputs/cuda.h"
 
 // Error, instantiated on device.
-inline __host__ __device__ void hasInvalid() {
+inline __host__ __device__ void hasInvalid() { // expected-note {{in HD-promoted function 'hasInvalid'}}
   throw NULL;
   // expected-error@-1 {{cannot use 'throw' in __host__ __device__ function}}
 }
 
-inline __host__ __device__ void hasInvalid2() {
+inline __host__ __device__ void hasInvalid2() { // expected-note {{in HD-promoted function 'hasInvalid2'}}
   throw NULL;
   // expected-error@-1 {{cannot use 'throw' in __host__ __device__ function}}
 }

--- a/clang/test/SemaCUDA/device-use-host-var.cu
+++ b/clang/test/SemaCUDA/device-use-host-var.cu
@@ -198,7 +198,7 @@ inline __host__ __device__ void inline_host_dev_fun(int *out) {
 
 void dev_lambda_capture_by_ref(int *out) {
   int &ref_host_var = global_host_var;
-  kernel<<<1,1>>>([&]() {
+  kernel<<<1,1>>>([&]() { // dev-note 3{{in HD-promoted function 'operator()'}}
   int &ref_dev_var = global_dev_var;
   int &ref_constant_var = global_constant_var;
   int &ref_shared_var = global_shared_var;
@@ -224,7 +224,7 @@ void dev_lambda_capture_by_ref(int *out) {
 
 void dev_lambda_capture_by_copy(int *out) {
   int &ref_host_var = global_host_var;
-  kernel<<<1,1>>>([=]() {
+  kernel<<<1,1>>>([=]() { // dev-note {{in HD-promoted function 'operator()'}}
   int &ref_dev_var = global_dev_var;
   int &ref_constant_var = global_constant_var;
   int &ref_shared_var = global_shared_var;

--- a/clang/test/SemaCUDA/device-use-host-var.cu
+++ b/clang/test/SemaCUDA/device-use-host-var.cu
@@ -61,7 +61,7 @@ const B2 b2; // dev-note {{const variable cannot be emitted on device side due t
 const int b3 = func(); // dev-note {{const variable cannot be emitted on device side due to dynamic initialization}}
 
 template<typename F>
-__global__ void kernel(F f) { f(); } // dev-note2 {{called by 'kernel<(lambda}}
+__global__ void kernel(F f) { f(); } // dev-note4 {{called by 'kernel<(lambda}}
 
 __device__ void dev_fun(int *out) {
   // Check access device variables are allowed.

--- a/clang/test/SemaCUDA/dtor.cu
+++ b/clang/test/SemaCUDA/dtor.cu
@@ -12,7 +12,7 @@ void host_fun() // dev-note {{'host_fun' declared here}}
 {}
 
 template <unsigned>
-constexpr void hd_fun() {
+constexpr void hd_fun() { // dev-note {{in HD-promoted function 'hd_fun<8U>'}}
   host_fun(); // dev-error {{reference to __host__ function 'host_fun' in __host__ __device__ function}}
 }
 
@@ -81,7 +81,7 @@ void host_fun() // dev-note {{'host_fun' declared here}}
 {}
 
 template <unsigned>
-constexpr void hd_fun() {
+constexpr void hd_fun() { // dev-note {{in HD-promoted function 'hd_fun<8U>'}}
   host_fun(); // dev-error {{reference to __host__ function 'host_fun' in __host__ __device__ function}}
 }
 

--- a/clang/test/SemaCUDA/exceptions.cu
+++ b/clang/test/SemaCUDA/exceptions.cu
@@ -46,6 +46,7 @@ inline __host__ __device__ void hd3() {
 #ifdef __CUDA_ARCH__
   // expected-error@-3 {{cannot use 'throw' in __host__ __device__ function}}
   // expected-error@-3 {{cannot use 'try' in __host__ __device__ function}}
+  // expected-note@-6 2{{in HD-promoted function 'hd3'}}
 #endif
 }
 

--- a/clang/test/SemaCUDA/exceptions.cu
+++ b/clang/test/SemaCUDA/exceptions.cu
@@ -51,5 +51,5 @@ inline __host__ __device__ void hd3() {
 
 __device__ void call_hd3() { hd3(); }
 #ifdef __CUDA_ARCH__
-// expected-note@-2 {{called by 'call_hd3'}}
+// expected-note@-2 2{{called by 'call_hd3'}}
 #endif

--- a/clang/test/SemaCUDA/function-overload.cu
+++ b/clang/test/SemaCUDA/function-overload.cu
@@ -422,7 +422,7 @@ inline __host__ __device__ void test_host_device_wrong_side_overloading_inline_d
 
 __host__ __device__ void test_host_device_wrong_side_overloading_inline_diag_caller() {
   test_host_device_wrong_side_overloading_inline_diag();
-  // expected-note@-1 {{called by 'test_host_device_wrong_side_overloading_inline_diag_caller'}}
+  // expected-note@-1 2{{called by 'test_host_device_wrong_side_overloading_inline_diag_caller'}}
 }
 
 // Verify that we allow overloading function templates.

--- a/clang/test/SemaCUDA/function-overload.cu
+++ b/clang/test/SemaCUDA/function-overload.cu
@@ -406,6 +406,7 @@ inline __host__ __device__ void test_host_device_wrong_side_overloading_inline_n
 // wrong-sided overloading should cause diagnostic if it is emitted.
 // This inline function is emitted since it is called by an emitted function.
 inline __host__ __device__ void test_host_device_wrong_side_overloading_inline_diag() {
+  // expected-note@-1 2{{in HD-promoted function 'test_host_device_wrong_side_overloading_inline_diag'}}
   DeviceReturnTy ret1 = device_only_function(1);
   DeviceReturnTy2 ret2 = device_only_function(1.0f);
 #ifndef __CUDA_ARCH__
@@ -617,7 +618,7 @@ namespace TestDeferNoMatchingFuncEmitted {
     // devnodeferonly-note@-1{{'ag<TestDeferNoMatchingFuncEmitted::b::c>' declared here}}
   } // namespace b
   template <typename ae>
-  __host__ __device__ void ag(a<ae>) {
+  __host__ __device__ void ag(a<ae>) { // dev-note {{in HD-promoted function 'ag<}}
     ae e;
     ag(e);
     // devnodeferonly-error@-1{{reference to __host__ function 'ag<TestDeferNoMatchingFuncEmitted::b::c>' in __host__ __device__ function}}

--- a/clang/test/SemaCUDA/lambda.cu
+++ b/clang/test/SemaCUDA/lambda.cu
@@ -26,16 +26,16 @@ public:
 
     kernel<<<1,1>>>([](){ hd(0); });
 
-    kernel<<<1,1>>>([=](){ hd(b); });
+    kernel<<<1,1>>>([=](){ hd(b); }); // warn-note {{in HD-promoted function 'operator()'}}
     // warn-warning@-1 {{capture host side class data member by this pointer in device or host device lambda function may result in invalid memory access if this pointer is not accessible on device side}}
 
-    kernel<<<1,1>>>([&](){ hd(b); });
+    kernel<<<1,1>>>([&](){ hd(b); }); // warn-note {{in HD-promoted function 'operator()'}}
     // warn-warning@-1 {{capture host side class data member by this pointer in device or host device lambda function may result in invalid memory access if this pointer is not accessible on device side}}
 
     kernel<<<1,1>>>([&] __device__ (){ hd(b); });
     // warn-warning@-1 {{capture host side class data member by this pointer in device or host device lambda function may result in invalid memory access if this pointer is not accessible on device side}}
 
-    kernel<<<1,1>>>([&](){
+    kernel<<<1,1>>>([&](){ // warn-note {{in HD-promoted function 'operator()'}}
       auto f = [&]{ hd(b); };
       // warn-warning@-1 {{capture host side class data member by this pointer in device or host device lambda function may result in invalid memory access if this pointer is not accessible on device side}}
       f();
@@ -64,15 +64,15 @@ int main(void) {
 
   kernel<<<1,1>>>([b](){ hd(b); });
 
-  kernel<<<1,1>>>([&](){ hd(b); });
+  kernel<<<1,1>>>([&](){ hd(b); }); // dev-note {{in HD-promoted function 'operator()'}}
   // dev-error@-1 {{capture host variable 'b' by reference in device or host device lambda function}}
 
-  kernel<<<1,1>>>([=, &b](){ hd(b); });
+  kernel<<<1,1>>>([=, &b](){ hd(b); }); // dev-note {{in HD-promoted function 'operator()'}}
   // dev-error@-1 {{capture host variable 'b' by reference in device or host device lambda function}}
 
   kernel<<<1,1>>>([&, b](){ hd(b); });
 
-  kernel<<<1,1>>>([&](){
+  kernel<<<1,1>>>([&](){ // dev-note {{in HD-promoted function 'operator()'}}
       auto f = [&]{ hd(b); };
       // dev-error@-1 {{capture host variable 'b' by reference in device or host device lambda function}}
       f();

--- a/clang/test/SemaCUDA/openmp-parallel.cu
+++ b/clang/test/SemaCUDA/openmp-parallel.cu
@@ -13,7 +13,7 @@ int main() {
     new int;
   }
 
-  auto Lambda = []() {
+  auto Lambda = []() { // expected-note {{in HD-promoted function 'operator()'}}
     #pragma omp parallel
     for (int i = 0; i < 100; i++) {
       foo(1); // expected-error {{reference to __device__ function 'foo' in __host__ __device__ function}}

--- a/clang/test/SemaCUDA/trace-through-global.cu
+++ b/clang/test/SemaCUDA/trace-through-global.cu
@@ -8,7 +8,7 @@
 __device__ void device_fn(int) {}
 // expected-note@-1 2 {{declared here}}
 
-inline __host__ __device__ int hd1() {
+inline __host__ __device__ int hd1() { // expected-note {{in HD-promoted function 'hd1'}}
   device_fn(0);  // expected-error {{reference to __device__ function}}
   return 0;
 }
@@ -19,7 +19,7 @@ inline __host__ __device__ int hd2() {
   return 0;
 }
 
-inline __host__ __device__ void hd3(int) {
+inline __host__ __device__ void hd3(int) { // expected-note {{in HD-promoted function 'hd3'}}
   device_fn(0);  // expected-error {{reference to __device__ function 'device_fn'}}
 }
 inline __host__ __device__ void hd3(double) {}


### PR DESCRIPTION
This PR improves the diagnostic experience for deferred
diagnostics in CUDA/HIP. Previously, when an HD-promoted
function (like a lambda or constexpr function) contained
multiple errors, the "called by" notes only appeared after
the last error, making it hard to tell which device function
triggered the earlier ones. Now each error gets its own
"called by" notes immediately after it, and a new "in
HD-promoted function" note points back to the function
definition so users can easily see where the error lives —
especially helpful for lambdas where the function name isn't
obvious from the error message alone.

Fixes: https://github.com/llvm/llvm-project/issues/180638
