### PR TITLE
[orc-rt] Rename ControllerInterface to SimpleSymbolTable. NFCI.

### DIFF
--- a/orc-rt/include/CMakeLists.txt
+++ b/orc-rt/include/CMakeLists.txt
@@ -7,7 +7,7 @@ set(ORC_RT_HEADERS
     orc-rt/AllocAction.h
     orc-rt/BitmaskEnum.h
     orc-rt/Compiler.h
-    orc-rt/ControllerInterface.h
+    orc-rt/SimpleSymbolTable.h
     orc-rt/Error.h
     orc-rt/ExecutorAddress.h
     orc-rt/IntervalMap.h

--- a/orc-rt/include/orc-rt/Session.h
+++ b/orc-rt/include/orc-rt/Session.h
@@ -13,11 +13,11 @@
 #ifndef ORC_RT_SESSION_H
 #define ORC_RT_SESSION_H
 
-#include "orc-rt/ControllerInterface.h"
 #include "orc-rt/Error.h"
 #include "orc-rt/ExecutorProcessInfo.h"
 #include "orc-rt/LockedAccess.h"
 #include "orc-rt/Service.h"
+#include "orc-rt/SimpleSymbolTable.h"
 #include "orc-rt/TaskDispatcher.h"
 #include "orc-rt/WrapperFunction.h"
 #include "orc-rt/move_only_function.h"
@@ -216,7 +216,7 @@ private:
 
   mutable std::mutex M;
   std::vector<std::unique_ptr<Service>> Services;
-  ControllerInterface CI;
+  SimpleSymbolTable CI;
   std::unique_ptr<ShutdownInfo> SI;
 };
 

--- a/orc-rt/include/orc-rt/SimpleSymbolTable.h
+++ b/orc-rt/include/orc-rt/SimpleSymbolTable.h
@@ -1,4 +1,4 @@
-//===--- ControllerInterface.h -- Controller Interface Symtab ---*- C++ -*-===//
+//===------- SimpleSymbolTable.h -- Simple Symbol Table ---------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -6,12 +6,12 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// Controller interface symbol table.
+// Simple symbol table.
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef ORC_RT_CONTROLLERINTERFACE_H
-#define ORC_RT_CONTROLLERINTERFACE_H
+#ifndef ORC_RT_SIMPLESYMBOLTABLE_H
+#define ORC_RT_SIMPLESYMBOLTABLE_H
 
 #include "orc-rt/Error.h"
 #include <string>
@@ -23,10 +23,9 @@
 
 namespace orc_rt {
 
-/// A symbol table defining the interface exposed by the ORC runtime to the
-/// controller. Symbols are added via addSymbolsUnique, which rejects
-/// duplicates with an error.
-class ControllerInterface {
+/// A simple string-to-pointer symbol table. Symbols are added via
+/// addSymbolsUnique, which rejects duplicates with an error.
+class SimpleSymbolTable {
 public:
   using SymbolTable = std::unordered_map<std::string, const void *>;
   using iterator = SymbolTable::const_iterator;
@@ -78,4 +77,4 @@ private:
 
 } // namespace orc_rt
 
-#endif // ORC_RT_CONTROLLERINTERFACE_H
+#endif // ORC_RT_SIMPLESYMBOLTABLE_H

--- a/orc-rt/include/orc-rt/sps-ci/AllSPSCI.h
+++ b/orc-rt/include/orc-rt/sps-ci/AllSPSCI.h
@@ -19,7 +19,7 @@
 namespace orc_rt::sps_ci {
 
 /// Add all SPS interfaces to the controller interface.
-Error addAll(ControllerInterface &CI);
+Error addAll(SimpleSymbolTable &ST);
 
 } // namespace orc_rt::sps_ci
 

--- a/orc-rt/include/orc-rt/sps-ci/SimpleNativeMemoryMapSPSCI.h
+++ b/orc-rt/include/orc-rt/sps-ci/SimpleNativeMemoryMapSPSCI.h
@@ -13,12 +13,12 @@
 #ifndef ORC_RT_SPS_CI_SIMPLENATIVEMEMORYMAPSPSCI_H
 #define ORC_RT_SPS_CI_SIMPLENATIVEMEMORYMAPSPSCI_H
 
-#include "orc-rt/ControllerInterface.h"
+#include "orc-rt/SimpleSymbolTable.h"
 
 namespace orc_rt::sps_ci {
 
 /// Add the SimpleNativeMemoryMap SPS interface to the controller interface.
-Error addSimpleNativeMemoryMap(ControllerInterface &CI);
+Error addSimpleNativeMemoryMap(SimpleSymbolTable &ST);
 
 } // namespace orc_rt::sps_ci
 

--- a/orc-rt/lib/executor/CMakeLists.txt
+++ b/orc-rt/lib/executor/CMakeLists.txt
@@ -1,6 +1,6 @@
 set(files
   AllocAction.cpp
-  ControllerInterface.cpp
+  SimpleSymbolTable.cpp
   Error.cpp
   ExecutorProcessInfo.cpp
   QueueingTaskDispatcher.cpp

--- a/orc-rt/lib/executor/SimpleSymbolTable.cpp
+++ b/orc-rt/lib/executor/SimpleSymbolTable.cpp
@@ -1,4 +1,4 @@
-//===- ControllerInterface.cpp --------------------------------------------===//
+//===- SimpleSymbolTable.cpp ----------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -6,19 +6,19 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// Contains the implementation of APIs in the orc-rt/ControllerInterface.h
+// Contains the implementation of APIs in the orc-rt/SimpleSymbolTable.h
 // header.
 //
 //===----------------------------------------------------------------------===//
 
-#include "orc-rt/ControllerInterface.h"
+#include "orc-rt/SimpleSymbolTable.h"
 #include "orc-rt/iterator_range.h"
 
 #include <algorithm>
 
 namespace orc_rt {
 
-Error ControllerInterface::makeDuplicatesError(
+Error SimpleSymbolTable::makeDuplicatesError(
     std::vector<std::string_view> Dups) {
   std::sort(Dups.begin(), Dups.end());
   std::string ErrMsg = "Could not add duplicate symbols: [ ";

--- a/orc-rt/lib/executor/sps-ci/AllSPSCI.cpp
+++ b/orc-rt/lib/executor/sps-ci/AllSPSCI.cpp
@@ -14,12 +14,12 @@
 
 namespace orc_rt::sps_ci {
 
-Error addAll(ControllerInterface &CI) {
-  using AdderFn = Error (*)(ControllerInterface &);
+Error addAll(SimpleSymbolTable &ST) {
+  using AdderFn = Error (*)(SimpleSymbolTable &);
   AdderFn Adders[] = {addSimpleNativeMemoryMap};
 
   for (auto *Adder : Adders)
-    if (auto Err = Adder(CI))
+    if (auto Err = Adder(ST))
       return Err;
 
   return Error::success();

--- a/orc-rt/lib/executor/sps-ci/SimpleNativeMemoryMapSPSCI.cpp
+++ b/orc-rt/lib/executor/sps-ci/SimpleNativeMemoryMapSPSCI.cpp
@@ -96,8 +96,8 @@ static std::pair<const char *, const void *>
         ORC_RT_SYMTAB_PAIR(
             orc_rt_sps_ci_SimpleNativeMemoryMap_deinitializeMultiple_sps_wrapper)};
 
-Error addSimpleNativeMemoryMap(ControllerInterface &CI) {
-  return CI.addSymbolsUnique(orc_rt_sps_ci_SimpleNativeMemoryMap_sps_interface);
+Error addSimpleNativeMemoryMap(SimpleSymbolTable &ST) {
+  return ST.addSymbolsUnique(orc_rt_sps_ci_SimpleNativeMemoryMap_sps_interface);
 }
 
 } // namespace sps_ci

--- a/orc-rt/unittests/CMakeLists.txt
+++ b/orc-rt/unittests/CMakeLists.txt
@@ -15,7 +15,7 @@ add_orc_rt_unittest(CoreTests
   AllocActionTest.cpp
   BitmaskEnumTest.cpp
   CallableTraitsHelperTest.cpp
-  ControllerInterfaceTest.cpp
+  SimpleSymbolTableTest.cpp
   EndianTest.cpp
   ErrorCAPITest.cpp
   ErrorTest.cpp

--- a/orc-rt/unittests/SessionTest.cpp
+++ b/orc-rt/unittests/SessionTest.cpp
@@ -410,11 +410,11 @@ TEST(SessionTest, ControllerInterfaceWithRef) {
   Session S(mockExecutorProcessInfo(), std::make_unique<NoDispatcher>(),
             noErrors);
   int X = 0, Y = 0;
-  S.controllerInterface().with_ref([&](ControllerInterface &CI) {
+  S.controllerInterface().with_ref([&](SimpleSymbolTable &ST) {
     std::pair<const char *, void *> Syms[] = {
         {"orc_rt_A", static_cast<void *>(&X)},
         {"orc_rt_B", static_cast<void *>(&Y)}};
-    cantFail(CI.addSymbolsUnique(Syms));
+    cantFail(ST.addSymbolsUnique(Syms));
   });
 
   EXPECT_EQ(S.controllerInterface()->at("orc_rt_A"), &X);

--- a/orc-rt/unittests/SimpleNativeMemoryMapSPSCITest.cpp
+++ b/orc-rt/unittests/SimpleNativeMemoryMapSPSCITest.cpp
@@ -164,7 +164,7 @@ protected:
         std::forward<OnCompleteFn>(OnComplete), SNMM.get(), Bases);
   }
 
-  ControllerInterface CI;
+  SimpleSymbolTable CI;
   std::unique_ptr<SimpleNativeMemoryMap> SNMM;
 };
 

--- a/orc-rt/unittests/SimpleSymbolTableTest.cpp
+++ b/orc-rt/unittests/SimpleSymbolTableTest.cpp
@@ -1,4 +1,4 @@
-//===- ControllerInterfaceTest.cpp ----------------------------------------===//
+//===- SimpleSymbolTableTest.cpp ------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -6,11 +6,11 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// Tests for orc-rt's ControllerInterface.h APIs.
+// Tests for orc-rt's SimpleSymbolTable.h APIs.
 //
 //===----------------------------------------------------------------------===//
 
-#include "orc-rt/ControllerInterface.h"
+#include "orc-rt/SimpleSymbolTable.h"
 #include "gtest/gtest.h"
 
 #include <set>
@@ -18,65 +18,65 @@
 
 using namespace orc_rt;
 
-TEST(ControllerInterfaceTest, EmptyByDefault) {
-  ControllerInterface CI;
-  EXPECT_TRUE(CI.empty());
-  EXPECT_EQ(CI.size(), 0U);
-  EXPECT_EQ(CI.begin(), CI.end());
+TEST(SimpleSymbolTableTest, EmptyByDefault) {
+  SimpleSymbolTable ST;
+  EXPECT_TRUE(ST.empty());
+  EXPECT_EQ(ST.size(), 0U);
+  EXPECT_EQ(ST.begin(), ST.end());
 }
 
-TEST(ControllerInterfaceTest, AddSymbolsUnique) {
-  ControllerInterface CI;
+TEST(SimpleSymbolTableTest, AddSymbolsUnique) {
+  SimpleSymbolTable ST;
   int X = 0, Y = 0;
   std::pair<const char *, void *> Syms[] = {{"orc_rt_A", &X}, {"orc_rt_B", &Y}};
 
-  auto Err = CI.addSymbolsUnique(Syms);
+  auto Err = ST.addSymbolsUnique(Syms);
   EXPECT_FALSE(Err) << "Unexpected error adding unique symbols";
 
-  EXPECT_EQ(CI.size(), 2U);
-  EXPECT_FALSE(CI.empty());
-  EXPECT_TRUE(CI.count("orc_rt_A"));
-  EXPECT_TRUE(CI.count("orc_rt_B"));
-  EXPECT_EQ(CI.at("orc_rt_A"), &X);
-  EXPECT_EQ(CI.at("orc_rt_B"), &Y);
+  EXPECT_EQ(ST.size(), 2U);
+  EXPECT_FALSE(ST.empty());
+  EXPECT_TRUE(ST.count("orc_rt_A"));
+  EXPECT_TRUE(ST.count("orc_rt_B"));
+  EXPECT_EQ(ST.at("orc_rt_A"), &X);
+  EXPECT_EQ(ST.at("orc_rt_B"), &Y);
 }
 
-TEST(ControllerInterfaceTest, AddConstPointers) {
-  ControllerInterface CI;
+TEST(SimpleSymbolTableTest, AddConstPointers) {
+  SimpleSymbolTable ST;
   const int X = 42;
   const int Y = 7;
   std::pair<const char *, const void *> Syms[] = {{"orc_rt_A", &X},
                                                   {"orc_rt_B", &Y}};
-  cantFail(CI.addSymbolsUnique(Syms));
+  cantFail(ST.addSymbolsUnique(Syms));
 
-  EXPECT_EQ(CI.at("orc_rt_A"), &X);
-  EXPECT_EQ(CI.at("orc_rt_B"), &Y);
+  EXPECT_EQ(ST.at("orc_rt_A"), &X);
+  EXPECT_EQ(ST.at("orc_rt_B"), &Y);
 }
 
-TEST(ControllerInterfaceTest, AddSymbolsUniqueMultipleCalls) {
-  ControllerInterface CI;
+TEST(SimpleSymbolTableTest, AddSymbolsUniqueMultipleCalls) {
+  SimpleSymbolTable ST;
   int X = 0, Y = 0;
 
   std::pair<const char *, void *> First[] = {{"orc_rt_A", &X}};
   std::pair<const char *, void *> Second[] = {{"orc_rt_B", &Y}};
 
-  cantFail(CI.addSymbolsUnique(First));
-  cantFail(CI.addSymbolsUnique(Second));
+  cantFail(ST.addSymbolsUnique(First));
+  cantFail(ST.addSymbolsUnique(Second));
 
-  EXPECT_EQ(CI.size(), 2U);
-  EXPECT_EQ(CI.at("orc_rt_A"), &X);
-  EXPECT_EQ(CI.at("orc_rt_B"), &Y);
+  EXPECT_EQ(ST.size(), 2U);
+  EXPECT_EQ(ST.at("orc_rt_A"), &X);
+  EXPECT_EQ(ST.at("orc_rt_B"), &Y);
 }
 
-TEST(ControllerInterfaceTest, AddSymbolsUniqueDuplicateRejected) {
-  ControllerInterface CI;
+TEST(SimpleSymbolTableTest, AddSymbolsUniqueDuplicateRejected) {
+  SimpleSymbolTable ST;
   int X = 0, Y = 0;
 
   std::pair<const char *, void *> First[] = {{"orc_rt_A", &X}};
-  cantFail(CI.addSymbolsUnique(First));
+  cantFail(ST.addSymbolsUnique(First));
 
   std::pair<const char *, void *> Second[] = {{"orc_rt_A", &Y}};
-  auto Err = CI.addSymbolsUnique(Second);
+  auto Err = ST.addSymbolsUnique(Second);
   EXPECT_TRUE(Err.isA<StringError>());
 
   auto ErrMsg = toString(std::move(Err));
@@ -84,20 +84,20 @@ TEST(ControllerInterfaceTest, AddSymbolsUniqueDuplicateRejected) {
       << "Error message should mention the duplicate symbol name";
 
   // Original not overwritten.
-  EXPECT_EQ(CI.at("orc_rt_A"), &X);
+  EXPECT_EQ(ST.at("orc_rt_A"), &X);
 }
 
-TEST(ControllerInterfaceTest, AddSymbolsUniqueMultipleDuplicates) {
-  ControllerInterface CI;
+TEST(SimpleSymbolTableTest, AddSymbolsUniqueMultipleDuplicates) {
+  SimpleSymbolTable ST;
   int X = 0, Y = 0, Z = 0;
 
   std::pair<const char *, void *> First[] = {{"orc_rt_A", &X},
                                              {"orc_rt_B", &Y}};
-  cantFail(CI.addSymbolsUnique(First));
+  cantFail(ST.addSymbolsUnique(First));
 
   std::pair<const char *, void *> Second[] = {{"orc_rt_A", &Z},
                                               {"orc_rt_B", &Z}};
-  auto Err = CI.addSymbolsUnique(Second);
+  auto Err = ST.addSymbolsUnique(Second);
   EXPECT_TRUE(Err.isA<StringError>());
 
   auto ErrMsg = toString(std::move(Err));
@@ -105,38 +105,38 @@ TEST(ControllerInterfaceTest, AddSymbolsUniqueMultipleDuplicates) {
   EXPECT_NE(ErrMsg.find("orc_rt_B"), std::string::npos);
 
   // Originals not overwritten.
-  EXPECT_EQ(CI.at("orc_rt_A"), &X);
-  EXPECT_EQ(CI.at("orc_rt_B"), &Y);
+  EXPECT_EQ(ST.at("orc_rt_A"), &X);
+  EXPECT_EQ(ST.at("orc_rt_B"), &Y);
 }
 
-TEST(ControllerInterfaceTest, AddSymbolsUniqueAllOrNothing) {
-  ControllerInterface CI;
+TEST(SimpleSymbolTableTest, AddSymbolsUniqueAllOrNothing) {
+  SimpleSymbolTable ST;
   int X = 0, Y = 0, Z = 0;
 
   std::pair<const char *, void *> First[] = {{"orc_rt_existing", &X}};
-  cantFail(CI.addSymbolsUnique(First));
+  cantFail(ST.addSymbolsUnique(First));
 
   // One new, one duplicate — neither should be added.
   std::pair<const char *, void *> Second[] = {{"orc_rt_new", &Y},
                                               {"orc_rt_existing", &Z}};
-  auto Err = CI.addSymbolsUnique(Second);
+  auto Err = ST.addSymbolsUnique(Second);
   EXPECT_TRUE(Err.isA<StringError>());
   consumeError(std::move(Err));
 
-  EXPECT_EQ(CI.size(), 1U);
-  EXPECT_EQ(CI.at("orc_rt_existing"), &X);
-  EXPECT_FALSE(CI.count("orc_rt_new"));
+  EXPECT_EQ(ST.size(), 1U);
+  EXPECT_EQ(ST.at("orc_rt_existing"), &X);
+  EXPECT_FALSE(ST.count("orc_rt_new"));
 }
 
-TEST(ControllerInterfaceTest, Iteration) {
-  ControllerInterface CI;
+TEST(SimpleSymbolTableTest, Iteration) {
+  SimpleSymbolTable ST;
   int X = 0, Y = 0, Z = 0;
   std::pair<const char *, void *> Syms[] = {
       {"orc_rt_A", &X}, {"orc_rt_B", &Y}, {"orc_rt_C", &Z}};
-  cantFail(CI.addSymbolsUnique(Syms));
+  cantFail(ST.addSymbolsUnique(Syms));
 
   std::set<std::string> Names;
-  for (auto &[Name, Addr] : CI)
+  for (auto &[Name, Addr] : ST)
     Names.insert(Name);
 
   EXPECT_EQ(Names.size(), 3U);


### PR DESCRIPTION
This type will be used more contexts than just the controller interface.