### PR TITLE
[orc-rt] Rename SimpleSymbolTable::addSymbolsUnique, relax error cond…

### DIFF
--- a/orc-rt/include/orc-rt/SimpleSymbolTable.h
+++ b/orc-rt/include/orc-rt/SimpleSymbolTable.h
@@ -47,17 +47,22 @@ public:
   /// symbols in NewSymbols are unique (i.e. not previously defined).
   ///
   /// NewSymbols must not contain any internal duplicates.
-  template <typename SymbolRangeT>
-  Error addSymbolsUnique(SymbolRangeT &&NewSymbols) {
+  template <typename SymbolRangeT> Error addUnique(SymbolRangeT &&NewSymbols) {
 
-    // First check for duplicates, error out if any are found.
+    // First check for incompatible duplicate definitions (duplicates are
+    // only permitted if they resolve to the same address). Error out if any
+    // incompatible defs are found.
     {
-      std::vector<std::string_view> Dups;
-      for (auto &[Name, Addr] : NewSymbols)
+      std::vector<std::string_view> IncompatibleDefs;
+      for (auto &[Name, Addr] : NewSymbols) {
+        auto I = Symbols.find(Name);
+        if (I == Symbols.end() || I->second == Addr)
+          continue;
         if (Symbols.count(Name))
-          Dups.push_back(Name);
-      if (!Dups.empty())
-        return makeDuplicatesError(std::move(Dups));
+          IncompatibleDefs.push_back(Name);
+      }
+      if (!IncompatibleDefs.empty())
+        return makeIncompatibleDefsError(std::move(IncompatibleDefs));
     }
 
     // No duplicates. Add entries.
@@ -70,7 +75,8 @@ public:
   }
 
 private:
-  static Error makeDuplicatesError(std::vector<std::string_view> Dups);
+  static Error
+  makeIncompatibleDefsError(std::vector<std::string_view> IncompatibleDefs);
 
   SymbolTable Symbols;
 };

--- a/orc-rt/lib/executor/Session.cpp
+++ b/orc-rt/lib/executor/Session.cpp
@@ -24,7 +24,7 @@ Session::Session(ExecutorProcessInfo EPI,
   std::pair<const char *, void *> InitialSymbols[] = {
       {"orc_rt_SessionInstance", static_cast<void *>(this)}};
 
-  cantFail(CI.addSymbolsUnique(InitialSymbols));
+  cantFail(CI.addUnique(InitialSymbols));
 }
 
 Session::~Session() { waitForShutdown(); }

--- a/orc-rt/lib/executor/SimpleSymbolTable.cpp
+++ b/orc-rt/lib/executor/SimpleSymbolTable.cpp
@@ -18,14 +18,15 @@
 
 namespace orc_rt {
 
-Error SimpleSymbolTable::makeDuplicatesError(
-    std::vector<std::string_view> Dups) {
-  std::sort(Dups.begin(), Dups.end());
-  std::string ErrMsg = "Could not add duplicate symbols: [ ";
-  ErrMsg += Dups.front();
-  for (auto &Dup : iterator_range(std::next(Dups.begin()), Dups.end())) {
+Error SimpleSymbolTable::makeIncompatibleDefsError(
+    std::vector<std::string_view> IncompatibleDefs) {
+  std::sort(IncompatibleDefs.begin(), IncompatibleDefs.end());
+  std::string ErrMsg = "Incompatible definitions for symbols: [ ";
+  ErrMsg += IncompatibleDefs.front();
+  for (auto &Def : iterator_range(std::next(IncompatibleDefs.begin()),
+                                  IncompatibleDefs.end())) {
     ErrMsg += ", ";
-    ErrMsg += Dup;
+    ErrMsg += Def;
   }
   ErrMsg += " ]";
   return make_error<StringError>(std::move(ErrMsg));

--- a/orc-rt/lib/executor/sps-ci/SimpleNativeMemoryMapSPSCI.cpp
+++ b/orc-rt/lib/executor/sps-ci/SimpleNativeMemoryMapSPSCI.cpp
@@ -97,7 +97,7 @@ static std::pair<const char *, const void *>
             orc_rt_sps_ci_SimpleNativeMemoryMap_deinitializeMultiple_sps_wrapper)};
 
 Error addSimpleNativeMemoryMap(SimpleSymbolTable &ST) {
-  return ST.addSymbolsUnique(orc_rt_sps_ci_SimpleNativeMemoryMap_sps_interface);
+  return ST.addUnique(orc_rt_sps_ci_SimpleNativeMemoryMap_sps_interface);
 }
 
 } // namespace sps_ci

--- a/orc-rt/unittests/SessionTest.cpp
+++ b/orc-rt/unittests/SessionTest.cpp
@@ -414,7 +414,7 @@ TEST(SessionTest, ControllerInterfaceWithRef) {
     std::pair<const char *, void *> Syms[] = {
         {"orc_rt_A", static_cast<void *>(&X)},
         {"orc_rt_B", static_cast<void *>(&Y)}};
-    cantFail(ST.addSymbolsUnique(Syms));
+    cantFail(ST.addUnique(Syms));
   });
 
   EXPECT_EQ(S.controllerInterface()->at("orc_rt_A"), &X);
@@ -426,7 +426,7 @@ TEST(SessionTest, ControllerInterfaceConstAccess) {
             noErrors);
   int X = 0;
   std::pair<const char *, void *> Syms[] = {{"orc_rt_X", &X}};
-  cantFail(S.controllerInterface()->addSymbolsUnique(Syms));
+  cantFail(S.controllerInterface()->addUnique(Syms));
 
   const Session &CS = S;
   ASSERT_TRUE(CS.controllerInterface()->count("orc_rt_X"));

--- a/orc-rt/unittests/SimpleSymbolTableTest.cpp
+++ b/orc-rt/unittests/SimpleSymbolTableTest.cpp
@@ -30,7 +30,7 @@ TEST(SimpleSymbolTableTest, AddSymbolsUnique) {
   int X = 0, Y = 0;
   std::pair<const char *, void *> Syms[] = {{"orc_rt_A", &X}, {"orc_rt_B", &Y}};
 
-  auto Err = ST.addSymbolsUnique(Syms);
+  auto Err = ST.addUnique(Syms);
   EXPECT_FALSE(Err) << "Unexpected error adding unique symbols";
 
   EXPECT_EQ(ST.size(), 2U);
@@ -47,7 +47,7 @@ TEST(SimpleSymbolTableTest, AddConstPointers) {
   const int Y = 7;
   std::pair<const char *, const void *> Syms[] = {{"orc_rt_A", &X},
                                                   {"orc_rt_B", &Y}};
-  cantFail(ST.addSymbolsUnique(Syms));
+  cantFail(ST.addUnique(Syms));
 
   EXPECT_EQ(ST.at("orc_rt_A"), &X);
   EXPECT_EQ(ST.at("orc_rt_B"), &Y);
@@ -60,8 +60,8 @@ TEST(SimpleSymbolTableTest, AddSymbolsUniqueMultipleCalls) {
   std::pair<const char *, void *> First[] = {{"orc_rt_A", &X}};
   std::pair<const char *, void *> Second[] = {{"orc_rt_B", &Y}};
 
-  cantFail(ST.addSymbolsUnique(First));
-  cantFail(ST.addSymbolsUnique(Second));
+  cantFail(ST.addUnique(First));
+  cantFail(ST.addUnique(Second));
 
   EXPECT_EQ(ST.size(), 2U);
   EXPECT_EQ(ST.at("orc_rt_A"), &X);
@@ -73,10 +73,10 @@ TEST(SimpleSymbolTableTest, AddSymbolsUniqueDuplicateRejected) {
   int X = 0, Y = 0;
 
   std::pair<const char *, void *> First[] = {{"orc_rt_A", &X}};
-  cantFail(ST.addSymbolsUnique(First));
+  cantFail(ST.addUnique(First));
 
   std::pair<const char *, void *> Second[] = {{"orc_rt_A", &Y}};
-  auto Err = ST.addSymbolsUnique(Second);
+  auto Err = ST.addUnique(Second);
   EXPECT_TRUE(Err.isA<StringError>());
 
   auto ErrMsg = toString(std::move(Err));
@@ -93,11 +93,11 @@ TEST(SimpleSymbolTableTest, AddSymbolsUniqueMultipleDuplicates) {
 
   std::pair<const char *, void *> First[] = {{"orc_rt_A", &X},
                                              {"orc_rt_B", &Y}};
-  cantFail(ST.addSymbolsUnique(First));
+  cantFail(ST.addUnique(First));
 
   std::pair<const char *, void *> Second[] = {{"orc_rt_A", &Z},
                                               {"orc_rt_B", &Z}};
-  auto Err = ST.addSymbolsUnique(Second);
+  auto Err = ST.addUnique(Second);
   EXPECT_TRUE(Err.isA<StringError>());
 
   auto ErrMsg = toString(std::move(Err));
@@ -114,12 +114,12 @@ TEST(SimpleSymbolTableTest, AddSymbolsUniqueAllOrNothing) {
   int X = 0, Y = 0, Z = 0;
 
   std::pair<const char *, void *> First[] = {{"orc_rt_existing", &X}};
-  cantFail(ST.addSymbolsUnique(First));
+  cantFail(ST.addUnique(First));
 
-  // One new, one duplicate — neither should be added.
+  // One new, one incompatible — neither should be added.
   std::pair<const char *, void *> Second[] = {{"orc_rt_new", &Y},
                                               {"orc_rt_existing", &Z}};
-  auto Err = ST.addSymbolsUnique(Second);
+  auto Err = ST.addUnique(Second);
   EXPECT_TRUE(Err.isA<StringError>());
   consumeError(std::move(Err));
 
@@ -128,12 +128,22 @@ TEST(SimpleSymbolTableTest, AddSymbolsUniqueAllOrNothing) {
   EXPECT_FALSE(ST.count("orc_rt_new"));
 }
 
+TEST(SimpleSymbolTableTest, AddUniqueSameAddressSucceeds) {
+  SimpleSymbolTable ST;
+  int X = 0;
+  std::pair<const char *, void *> Syms[] = {{"orc_rt_A", &X}};
+  cantFail(ST.addUnique(Syms));
+  cantFail(ST.addUnique(Syms)); // Same name, same address — should succeed.
+  EXPECT_EQ(ST.size(), 1U);
+  EXPECT_EQ(ST.at("orc_rt_A"), &X);
+}
+
 TEST(SimpleSymbolTableTest, Iteration) {
   SimpleSymbolTable ST;
   int X = 0, Y = 0, Z = 0;
   std::pair<const char *, void *> Syms[] = {
       {"orc_rt_A", &X}, {"orc_rt_B", &Y}, {"orc_rt_C", &Z}};
-  cantFail(ST.addSymbolsUnique(Syms));
+  cantFail(ST.addUnique(Syms));
 
   std::set<std::string> Names;
   for (auto &[Name, Addr] : ST)


### PR DESCRIPTION
…ition.

Renames the SimpleSymbolTable addSymbolsUnique method to addUnique. The new class name (from c727cd9a4b2) already implies that we're adding symbols.

This commit also relaxes the error condition for addUnique: Rather than rejecting any duplicate symbols, it only rejects symbols that were previously added with a different address. This makes it safe to add the same symbol(s) multiple time, as long as all definitions point to the same address. The intent of this is to allow ORC runtime components to unconditionally add their interfaces to symbols, even if that interface might have been added previously.