### PR TITLE
[lldb][TypeSystem] Add CompilerType::IsMemberDataPointerType

### DIFF
--- a/lldb/include/lldb/Symbol/CompilerType.h
+++ b/lldb/include/lldb/Symbol/CompilerType.h
@@ -166,6 +166,8 @@ public:
 
   bool IsMemberFunctionPointerType() const;
 
+  bool IsMemberDataPointerType() const;
+
   bool
   IsBlockPointerType(CompilerType *function_pointer_type_ptr = nullptr) const;
 

--- a/lldb/include/lldb/Symbol/TypeSystem.h
+++ b/lldb/include/lldb/Symbol/TypeSystem.h
@@ -178,6 +178,8 @@ public:
   virtual bool
   IsMemberFunctionPointerType(lldb::opaque_compiler_type_t type) = 0;
 
+  virtual bool IsMemberDataPointerType(lldb::opaque_compiler_type_t type) = 0;
+
   virtual bool IsBlockPointerType(lldb::opaque_compiler_type_t type,
                                   CompilerType *function_pointer_type_ptr) = 0;
 

--- a/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
+++ b/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
@@ -3169,6 +3169,15 @@ bool TypeSystemClang::IsMemberFunctionPointerType(
   return IsTypeImpl(type, isMemberFunctionPointerType);
 }
 
+bool TypeSystemClang::IsMemberDataPointerType(
+    lldb::opaque_compiler_type_t type) {
+  auto isMemberDataPointerType = [](clang::QualType qual_type) {
+    return qual_type->isMemberDataPointerType();
+  };
+
+  return IsTypeImpl(type, isMemberDataPointerType);
+}
+
 bool TypeSystemClang::IsFunctionPointerType(lldb::opaque_compiler_type_t type) {
   auto isFunctionPointerType = [](clang::QualType qual_type) {
     return qual_type->isFunctionPointerType();

--- a/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.h
+++ b/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.h
@@ -672,6 +672,8 @@ public:
 
   bool IsMemberFunctionPointerType(lldb::opaque_compiler_type_t type) override;
 
+  bool IsMemberDataPointerType(lldb::opaque_compiler_type_t type) override;
+
   bool IsBlockPointerType(lldb::opaque_compiler_type_t type,
                           CompilerType *function_pointer_type_ptr) override;
 

--- a/lldb/source/Symbol/CompilerType.cpp
+++ b/lldb/source/Symbol/CompilerType.cpp
@@ -177,6 +177,13 @@ bool CompilerType::IsMemberFunctionPointerType() const {
   return false;
 }
 
+bool CompilerType::IsMemberDataPointerType() const {
+  if (IsValid())
+    if (auto type_system_sp = GetTypeSystem())
+      return type_system_sp->IsMemberDataPointerType(m_type);
+  return false;
+}
+
 bool CompilerType::IsBlockPointerType(
     CompilerType *function_pointer_type_ptr) const {
   if (IsValid())

--- a/lldb/unittests/Symbol/TestTypeSystemClang.cpp
+++ b/lldb/unittests/Symbol/TestTypeSystemClang.cpp
@@ -1518,3 +1518,32 @@ TEST_P(TestTypeSystemClangAsmLabel, DeclGetMangledName) {
 
 INSTANTIATE_TEST_SUITE_P(AsmLabelTests, TestTypeSystemClangAsmLabel,
                          testing::ValuesIn(g_asm_label_test_cases));
+
+TEST_F(TestTypeSystemClang, TestIsMemberDataPointerType) {
+  // Create struct S { int x; void foo(); };
+  CompilerType int_type = m_ast->GetBasicType(lldb::eBasicTypeInt);
+  CompilerType record_type = clang_utils::createRecord(*m_ast, "S");
+
+  // int S::* — member data pointer
+  CompilerType member_data_ptr =
+      TypeSystemClang::CreateMemberPointerType(record_type, int_type);
+  EXPECT_TRUE(member_data_ptr.IsMemberDataPointerType());
+  EXPECT_FALSE(member_data_ptr.IsMemberFunctionPointerType());
+
+  // void (S::*)() — member function pointer
+  CompilerType void_type = m_ast->GetBasicType(lldb::eBasicTypeVoid);
+  CompilerType func_type = m_ast->CreateFunctionType(void_type, {}, false, 0U);
+  CompilerType member_func_ptr =
+      TypeSystemClang::CreateMemberPointerType(record_type, func_type);
+  EXPECT_FALSE(member_func_ptr.IsMemberDataPointerType());
+  EXPECT_TRUE(member_func_ptr.IsMemberFunctionPointerType());
+
+  // int* — regular pointer, neither member data nor member function
+  CompilerType regular_ptr = int_type.GetPointerType();
+  EXPECT_FALSE(regular_ptr.IsMemberDataPointerType());
+  EXPECT_FALSE(regular_ptr.IsMemberFunctionPointerType());
+
+  // int — not a pointer at all
+  EXPECT_FALSE(int_type.IsMemberDataPointerType());
+  EXPECT_FALSE(int_type.IsMemberFunctionPointerType());
+}


### PR DESCRIPTION
**Description:**

Adds `IsMemberDataPointerType()` to CompilerType / TypeSystem / TypeSystemClang, mirroring the existing `IsMemberFunctionPointerType()`.

LLDB already has `IsMemberFunctionPointerType()` to identify member function pointers but no counterpart for member data pointers. The only way to check for member data pointers was the indirect `GetTypeClass() == eTypeClassMemberPointer && !IsMemberFunctionPointerType()`, which is awkward.

This pr is split out from a larger [fix, 186629](https://github.com/llvm/llvm-project/pull/186629) for LLDB mishandling non-type template parameters (NTTPs) of pointer-to-member types, where cleanly distinguishing member data pointers from member function pointers is needed. The new API delegates to clang's `QualType::isMemberDataPointerType()` via the same I`sTypeImpl` pattern used by `IsMemberFunctionPointerType`.

**Test Plan:**

Added `TestIsMemberDataPointerType` to `TestTypeSystemClang.cpp` that verifies:

`int S::*` → `IsMemberDataPointerType() = true`, `IsMemberFunctionPointerType() = false`
`void (S::*)()` → `IsMemberDataPointerType() = false`, `IsMemberFunctionPointerType() = true`
`int * (regular pointer)` → both false
`int (non-pointer)`→ both false