### PR TITLE
[HLSL][SPIRV] Use 0 to represent unbounded arrays on shader flags

### DIFF
--- a/llvm/lib/Target/DirectX/DXILShaderFlags.cpp
+++ b/llvm/lib/Target/DirectX/DXILShaderFlags.cpp
@@ -272,8 +272,11 @@ ModuleShaderFlags::gatherGlobalModuleFlags(const Module &M,
     if (MMDI.ValidatorVersion < VersionTuple(1, 6)) {
       NumUAVs++;
     } else { // MMDI.ValidatorVersion >= VersionTuple(1, 6)
-      const uint32_t Size = UAV.getBinding().Size;
-      NumUAVs += Size == 0 ? ~0u : Size;
+      uint32_t Size = UAV.getBinding().Size;
+      uint32_t NewNum = NumUAVs + (Size == 0 ? ~0U : Size);
+      if (NewNum < NumUAVs)
+        NewNum = ~0U;
+      NumUAVs = NewNum;
     }
   if (NumUAVs > 8)
     CSF.Max64UAVs = true;

--- a/llvm/lib/Target/DirectX/DXILShaderFlags.cpp
+++ b/llvm/lib/Target/DirectX/DXILShaderFlags.cpp
@@ -271,8 +271,10 @@ ModuleShaderFlags::gatherGlobalModuleFlags(const Module &M,
   for (auto &UAV : DRM.uavs())
     if (MMDI.ValidatorVersion < VersionTuple(1, 6))
       NumUAVs++;
-    else // MMDI.ValidatorVersion >= VersionTuple(1, 6)
-      NumUAVs += UAV.getBinding().Size;
+    else{ // MMDI.ValidatorVersion >= VersionTuple(1, 6)
+      const uint32_t Size = UAV.getBinding().Size;
+      NumUAVs += Size == 0 ? ~0u : Size;
+    }
   if (NumUAVs > 8)
     CSF.Max64UAVs = true;
 

--- a/llvm/lib/Target/DirectX/DXILShaderFlags.cpp
+++ b/llvm/lib/Target/DirectX/DXILShaderFlags.cpp
@@ -269,9 +269,9 @@ ModuleShaderFlags::gatherGlobalModuleFlags(const Module &M,
   // Set the Max64UAVs flag if the number of UAVs is > 8
   uint32_t NumUAVs = 0;
   for (auto &UAV : DRM.uavs())
-    if (MMDI.ValidatorVersion < VersionTuple(1, 6))
+    if (MMDI.ValidatorVersion < VersionTuple(1, 6)) {
       NumUAVs++;
-    else{ // MMDI.ValidatorVersion >= VersionTuple(1, 6)
+    } else { // MMDI.ValidatorVersion >= VersionTuple(1, 6)
       const uint32_t Size = UAV.getBinding().Size;
       NumUAVs += Size == 0 ? ~0u : Size;
     }

--- a/llvm/test/CodeGen/DirectX/ShaderFlags/overflow-uavs-array.ll
+++ b/llvm/test/CodeGen/DirectX/ShaderFlags/overflow-uavs-array.ll
@@ -1,5 +1,5 @@
 ; RUN: opt -S --passes="print-dx-shader-flags" 2>&1 %s | FileCheck %s
-; RUN: llc %s --filetype=obj -o - | obj2yaml | FileCheck %s --check-prefix=DXC
+; RUN: llc %s --filetype=obj -o - | obj2yaml | FileCheck %s --check-prefix=OBJ
 
 ; This test makes sure that no overflow is happening when a resource is followed
 ; by an unbounded array of UAVs. 
@@ -7,13 +7,13 @@
 target triple = "dxil-pc-shadermodel6.7-library"
 
 ; CHECK:      Combined Shader Flags for Module
-; CHECK-NEXT: Shader Flags Value: 0x00018000
+; CHECK-NEXT: Shader Flags Value: 0x200018000
 
 ; CHECK: Note: shader requires additional functionality:
 ; CHECK:        UAVs at every shader stage
 ; CHECK:        64 UAV slots
 
-; CHECK: Function test : 0x00018000
+; CHECK: Function test : 0x200018000
 define void @test() "hlsl.export" {
   ; RWBuffer<float> Buf : register(u0, space0)
   %buf0 = call target("dx.TypedBuffer", float, 1, 0, 1)
@@ -30,12 +30,7 @@ define void @test() "hlsl.export" {
 !dx.valver = !{!1}
 !1 = !{i32 1, i32 6}
 
-!llvm.module.flags = !{!0}
-!0 = !{i32 1, !"dx.resmayalias", i32 1}
-
-; DXC: - Name:            SFI0
-; DXC-NEXT:     Size:            8
-; DXC-NEXT:     Flags:
-; DXC:       Max64UAVs:         true
-; DXC:       NextUnusedBit:   false
-; DXC: ...
+; OBJ:      - Name: SFI0
+; OBJ-NEXT:   Size: 8
+; OBJ-NEXT:   Flags:
+; OBJ:          Max64UAVs: true

--- a/llvm/test/CodeGen/DirectX/ShaderFlags/overflow-uavs-array.ll
+++ b/llvm/test/CodeGen/DirectX/ShaderFlags/overflow-uavs-array.ll
@@ -1,0 +1,42 @@
+; RUN: opt -S --passes="print-dx-shader-flags" 2>&1 %s | FileCheck %s
+; RUN: llc %s --filetype=obj -o - | obj2yaml | FileCheck %s --check-prefix=DXC
+
+; This test makes sure that resource arrays sizes are accounted for when
+; counting the number of UAVs for setting the shader flag '64 UAV slots' when
+; the validator version is >= 1.6
+
+target triple = "dxil-pc-shadermodel6.7-library"
+
+; CHECK:      Combined Shader Flags for Module
+; CHECK-NEXT: Shader Flags Value: 0x00018000
+
+; CHECK: Note: shader requires additional functionality:
+; CHECK:        UAVs at every shader stage
+; CHECK:        64 UAV slots
+
+; CHECK: Function test : 0x00018000
+define void @test() "hlsl.export" {
+  ; RWBuffer<float> Buf : register(u0, space0)
+  %buf0 = call target("dx.TypedBuffer", float, 1, 0, 1)
+       @llvm.dx.resource.handlefrombinding.tdx.TypedBuffer_f32_1_0t(
+           i32 0, i32 0, i32 1, i32 0, ptr null)
+
+  ; RWBuffer<float> Buf[] : register(u1, space0)
+  %buf1 = call target("dx.TypedBuffer", float, 1, 0, 1)
+       @llvm.dx.resource.handlefrombinding.tdx.TypedBuffer_f32_1_0t(
+           i32 0, i32 1, i32 0, i32 0, ptr null)
+  ret void
+}
+
+!dx.valver = !{!1}
+!1 = !{i32 1, i32 6}
+
+!llvm.module.flags = !{!0}
+!0 = !{i32 1, !"dx.resmayalias", i32 1}
+
+; DXC: - Name:            SFI0
+; DXC-NEXT:     Size:            8
+; DXC-NEXT:     Flags:
+; DXC:       Max64UAVs:         true
+; DXC:       NextUnusedBit:   false
+; DXC: ...

--- a/llvm/test/CodeGen/DirectX/ShaderFlags/overflow-uavs-array.ll
+++ b/llvm/test/CodeGen/DirectX/ShaderFlags/overflow-uavs-array.ll
@@ -1,9 +1,8 @@
 ; RUN: opt -S --passes="print-dx-shader-flags" 2>&1 %s | FileCheck %s
 ; RUN: llc %s --filetype=obj -o - | obj2yaml | FileCheck %s --check-prefix=DXC
 
-; This test makes sure that resource arrays sizes are accounted for when
-; counting the number of UAVs for setting the shader flag '64 UAV slots' when
-; the validator version is >= 1.6
+; This test makes sure that no overflow is happening when a resource is followed
+; by an unbounded array of UAVs. 
 
 target triple = "dxil-pc-shadermodel6.7-library"
 

--- a/llvm/test/CodeGen/DirectX/ShaderFlags/unbounded-uavs-array.ll
+++ b/llvm/test/CodeGen/DirectX/ShaderFlags/unbounded-uavs-array.ll
@@ -1,0 +1,37 @@
+; RUN: opt -S --passes="print-dx-shader-flags" 2>&1 %s | FileCheck %s
+; RUN: llc %s --filetype=obj -o - | obj2yaml | FileCheck %s --check-prefix=DXC
+
+; This test makes sure that resource arrays sizes are accounted for when
+; counting the number of UAVs for setting the shader flag '64 UAV slots' when
+; the validator version is >= 1.6
+
+target triple = "dxil-pc-shadermodel6.7-library"
+
+; CHECK:      Combined Shader Flags for Module
+; CHECK-NEXT: Shader Flags Value: 0x00018000
+
+; CHECK: Note: shader requires additional functionality:
+; CHECK:        UAVs at every shader stage
+; CHECK:        64 UAV slots
+
+; CHECK: Function test : 0x00018000
+define void @test() "hlsl.export" {
+  ; RWBuffer<float> Buf[] : register(u1, space0)
+  %buf1 = call target("dx.TypedBuffer", float, 1, 0, 1)
+       @llvm.dx.resource.handlefrombinding.tdx.TypedBuffer_f32_1_0t(
+           i32 0, i32 1, i32 0, i32 0, ptr null)
+  ret void
+}
+
+!dx.valver = !{!1}
+!1 = !{i32 1, i32 6}
+
+!llvm.module.flags = !{!0}
+!0 = !{i32 1, !"dx.resmayalias", i32 1}
+
+; DXC: - Name:            SFI0
+; DXC-NEXT:     Size:            8
+; DXC-NEXT:     Flags:
+; DXC:       Max64UAVs:         true
+; DXC:       NextUnusedBit:   false
+; DXC: ...

--- a/llvm/test/CodeGen/DirectX/ShaderFlags/unbounded-uavs-array.ll
+++ b/llvm/test/CodeGen/DirectX/ShaderFlags/unbounded-uavs-array.ll
@@ -1,9 +1,8 @@
 ; RUN: opt -S --passes="print-dx-shader-flags" 2>&1 %s | FileCheck %s
 ; RUN: llc %s --filetype=obj -o - | obj2yaml | FileCheck %s --check-prefix=DXC
 
-; This test makes sure that resource arrays sizes are accounted for when
-; counting the number of UAVs for setting the shader flag '64 UAV slots' when
-; the validator version is >= 1.6
+; This test makes sure that Max64UAVs is correctly set when using an
+; unbounded array of UAVs;
 
 target triple = "dxil-pc-shadermodel6.7-library"
 

--- a/llvm/test/CodeGen/DirectX/ShaderFlags/unbounded-uavs-array.ll
+++ b/llvm/test/CodeGen/DirectX/ShaderFlags/unbounded-uavs-array.ll
@@ -1,5 +1,5 @@
 ; RUN: opt -S --passes="print-dx-shader-flags" 2>&1 %s | FileCheck %s
-; RUN: llc %s --filetype=obj -o - | obj2yaml | FileCheck %s --check-prefix=DXC
+; RUN: llc %s --filetype=obj -o - | obj2yaml | FileCheck %s --check-prefix=OBJ
 
 ; This test makes sure that Max64UAVs is correctly set when using an
 ; unbounded array of UAVs;
@@ -7,13 +7,13 @@
 target triple = "dxil-pc-shadermodel6.7-library"
 
 ; CHECK:      Combined Shader Flags for Module
-; CHECK-NEXT: Shader Flags Value: 0x00018000
+; CHECK-NEXT: Shader Flags Value: 0x200018000
 
 ; CHECK: Note: shader requires additional functionality:
 ; CHECK:        UAVs at every shader stage
 ; CHECK:        64 UAV slots
 
-; CHECK: Function test : 0x00018000
+; CHECK: Function test : 0x200018000
 define void @test() "hlsl.export" {
   ; RWBuffer<float> Buf[] : register(u1, space0)
   %buf1 = call target("dx.TypedBuffer", float, 1, 0, 1)
@@ -25,12 +25,7 @@ define void @test() "hlsl.export" {
 !dx.valver = !{!1}
 !1 = !{i32 1, i32 6}
 
-!llvm.module.flags = !{!0}
-!0 = !{i32 1, !"dx.resmayalias", i32 1}
-
-; DXC: - Name:            SFI0
-; DXC-NEXT:     Size:            8
-; DXC-NEXT:     Flags:
-; DXC:       Max64UAVs:         true
-; DXC:       NextUnusedBit:   false
-; DXC: ...
+; OBJ:      - Name: SFI0
+; OBJ-NEXT:     Size: 8
+; OBJ-NEXT:     Flags:
+; OBJ:       Max64UAVs: true


### PR DESCRIPTION
this patch updates the shader flags to account for 0 being used to represent unbounded arrays. This was a missed updated from the previous pr #186022. This change is required to make sure the following offload test pass dxv validation:

```
  OffloadTest-clang-d3d12 :: Feature/ResourceArrays/multi-dim-unbounded-array-nuri.test
  OffloadTest-clang-d3d12 :: Feature/ResourceArrays/multi-dim-unbounded-array.test
  OffloadTest-clang-d3d12 :: Feature/ResourceArrays/unbounded-array-nuri.test
  OffloadTest-clang-d3d12 :: Feature/ResourceArrays/unbounded-array.test
```