### PR TITLE
[NewPM] Add port for AArch64DeadRegisterDefinitionsPass

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64.h
+++ b/llvm/lib/Target/AArch64/AArch64.h
@@ -93,7 +93,7 @@ void initializeAArch64CondBrTuningPass(PassRegistry &);
 void initializeAArch64ConditionOptimizerLegacyPass(PassRegistry &);
 void initializeAArch64ConditionalComparesPass(PassRegistry &);
 void initializeAArch64DAGToDAGISelLegacyPass(PassRegistry &);
-void initializeAArch64DeadRegisterDefinitionsPass(PassRegistry&);
+void initializeAArch64DeadRegisterDefinitionsLegacyPass(PassRegistry &);
 void initializeAArch64ExpandPseudoPass(PassRegistry &);
 void initializeAArch64LoadStoreOptLegacyPass(PassRegistry &);
 void initializeAArch64LowerHomogeneousPrologEpilogPass(PassRegistry &);
@@ -157,6 +157,13 @@ public:
 
 class AArch64CompressJumpTablesPass
     : public PassInfoMixin<AArch64CompressJumpTablesPass> {
+public:
+  PreservedAnalyses run(MachineFunction &MF,
+                        MachineFunctionAnalysisManager &MFAM);
+};
+
+class AArch64DeadRegisterDefinitionsPass
+    : public PassInfoMixin<AArch64DeadRegisterDefinitionsPass> {
 public:
   PreservedAnalyses run(MachineFunction &MF,
                         MachineFunctionAnalysisManager &MFAM);

--- a/llvm/lib/Target/AArch64/AArch64DeadRegisterDefinitionsPass.cpp
+++ b/llvm/lib/Target/AArch64/AArch64DeadRegisterDefinitionsPass.cpp
@@ -31,16 +31,22 @@ STATISTIC(NumDeadDefsReplaced, "Number of dead definitions replaced");
 #define AARCH64_DEAD_REG_DEF_NAME "AArch64 Dead register definitions"
 
 namespace {
-class AArch64DeadRegisterDefinitions : public MachineFunctionPass {
+class AArch64DeadRegisterDefinitionsImpl {
+public:
+  bool run(MachineFunction &MF);
+
 private:
   const TargetRegisterInfo *TRI;
   const MachineRegisterInfo *MRI;
   const TargetInstrInfo *TII;
   bool Changed;
   void processMachineBasicBlock(MachineBasicBlock &MBB);
+};
+
+class AArch64DeadRegisterDefinitionsLegacy : public MachineFunctionPass {
 public:
   static char ID; // Pass identification, replacement for typeid.
-  AArch64DeadRegisterDefinitions() : MachineFunctionPass(ID) {}
+  AArch64DeadRegisterDefinitionsLegacy() : MachineFunctionPass(ID) {}
 
   bool runOnMachineFunction(MachineFunction &F) override;
 
@@ -51,10 +57,10 @@ public:
     MachineFunctionPass::getAnalysisUsage(AU);
   }
 };
-char AArch64DeadRegisterDefinitions::ID = 0;
+char AArch64DeadRegisterDefinitionsLegacy::ID = 0;
 } // end anonymous namespace
 
-INITIALIZE_PASS(AArch64DeadRegisterDefinitions, "aarch64-dead-defs",
+INITIALIZE_PASS(AArch64DeadRegisterDefinitionsLegacy, "aarch64-dead-defs",
                 AARCH64_DEAD_REG_DEF_NAME, false, false)
 
 static bool usesFrameIndex(const MachineInstr &MI) {
@@ -113,7 +119,7 @@ static bool atomicReadDroppedOnZero(unsigned Opcode) {
   return false;
 }
 
-void AArch64DeadRegisterDefinitions::processMachineBasicBlock(
+void AArch64DeadRegisterDefinitionsImpl::processMachineBasicBlock(
     MachineBasicBlock &MBB) {
   for (MachineInstr &MI : MBB) {
     if (usesFrameIndex(MI)) {
@@ -183,10 +189,7 @@ void AArch64DeadRegisterDefinitions::processMachineBasicBlock(
 
 // Scan the function for instructions that have a dead definition of a
 // register. Replace that register with the zero register when possible.
-bool AArch64DeadRegisterDefinitions::runOnMachineFunction(MachineFunction &MF) {
-  if (skipFunction(MF.getFunction()))
-    return false;
-
+bool AArch64DeadRegisterDefinitionsImpl::run(MachineFunction &MF) {
   TRI = MF.getSubtarget().getRegisterInfo();
   TII = MF.getSubtarget().getInstrInfo();
   MRI = &MF.getRegInfo();
@@ -197,6 +200,24 @@ bool AArch64DeadRegisterDefinitions::runOnMachineFunction(MachineFunction &MF) {
   return Changed;
 }
 
+bool AArch64DeadRegisterDefinitionsLegacy::runOnMachineFunction(
+    MachineFunction &MF) {
+  if (skipFunction(MF.getFunction()))
+    return false;
+  return AArch64DeadRegisterDefinitionsImpl().run(MF);
+}
+
+PreservedAnalyses
+AArch64DeadRegisterDefinitionsPass::run(MachineFunction &MF,
+                                        MachineFunctionAnalysisManager &MFAM) {
+  const bool Changed = AArch64DeadRegisterDefinitionsImpl().run(MF);
+  if (!Changed)
+    return PreservedAnalyses::all();
+  PreservedAnalyses PA = getMachineFunctionPassPreservedAnalyses();
+  PA.preserveSet<CFGAnalyses>();
+  return PA;
+}
+
 FunctionPass *llvm::createAArch64DeadRegisterDefinitions() {
-  return new AArch64DeadRegisterDefinitions();
+  return new AArch64DeadRegisterDefinitionsLegacy();
 }

--- a/llvm/lib/Target/AArch64/AArch64PassRegistry.def
+++ b/llvm/lib/Target/AArch64/AArch64PassRegistry.def
@@ -29,6 +29,7 @@
 MACHINE_FUNCTION_PASS("aarch64-branch-targets", AArch64BranchTargetsPass())
 MACHINE_FUNCTION_PASS("aarch64-collect-loh", AArch64CollectLOHPass())
 MACHINE_FUNCTION_PASS("aarch64-condopt", AArch64ConditionOptimizerPass())
+MACHINE_FUNCTION_PASS("aarch64-dead-defs", AArch64DeadRegisterDefinitionsPass())
 MACHINE_FUNCTION_PASS("aarch64-fix-cortex-a53-835769", AArch64A53Fix835769Pass())
 MACHINE_FUNCTION_PASS("aarch64-jump-tables", AArch64CompressJumpTablesPass())
 MACHINE_FUNCTION_PASS("aarch64-ldst-opt", AArch64LoadStoreOptPass())

--- a/llvm/lib/Target/AArch64/AArch64TargetMachine.cpp
+++ b/llvm/lib/Target/AArch64/AArch64TargetMachine.cpp
@@ -252,7 +252,7 @@ LLVMInitializeAArch64Target() {
   initializeAArch64CompressJumpTablesLegacyPass(PR);
   initializeAArch64ConditionalComparesPass(PR);
   initializeAArch64ConditionOptimizerLegacyPass(PR);
-  initializeAArch64DeadRegisterDefinitionsPass(PR);
+  initializeAArch64DeadRegisterDefinitionsLegacyPass(PR);
   initializeAArch64ExpandPseudoPass(PR);
   initializeAArch64LoadStoreOptLegacyPass(PR);
   initializeAArch64MIPeepholeOptPass(PR);


### PR DESCRIPTION
Adds a newPM pass for AArch64DeadRegisterDefinitions

* Refactors base logic into an Impl class
* Renames old pass with the "Legacy" suffix
* Adds the new pass manager pass using refactored logic

No existing `.mir` tests to update.

Context and motivation in https://llvm.org/docs/NewPassManager.html#status-of-the-new-and-legacy-pass-managers