### PR TITLE
[ValueTracking] Refine SIToFP/UIToFP FPClass inference with KnownBits

### DIFF
--- a/llvm/lib/Analysis/ValueTracking.cpp
+++ b/llvm/lib/Analysis/ValueTracking.cpp
@@ -5788,12 +5788,13 @@ void computeKnownFPClass(const Value *V, const APInt &DemandedElts,
 
     if (Op->getOpcode() == Instruction::SIToFP) {
       // If the signed integer is known non-negative, the result is
-      // non-negative.
-      if (IntKnown.isNonNegative())
+      // non-negative. If the signed integer is known negative, the result is
+      // negative.
+      if (IntKnown.isNonNegative()) {
         Known.signBitMustBeZero();
-      // If the signed integer is known negative, the result is negative.
-      else if (IntKnown.isNegative())
+      } else if (IntKnown.isNegative()) {
         Known.signBitMustBeOne();
+      }
     }
 
     // Guard kept for ilogb()

--- a/llvm/lib/Analysis/ValueTracking.cpp
+++ b/llvm/lib/Analysis/ValueTracking.cpp
@@ -5787,7 +5787,7 @@ void computeKnownFPClass(const Value *V, const APInt &DemandedElts,
       // Get width of largest magnitude integer known.
       // This still works for a signed minimum value because the largest FP
       // value is scaled by some fraction close to 2.0 (1.0 + 0.xxxx).
-      unsigned IntSize = IntKnown.getBitWidth();
+      int IntSize = IntKnown.getBitWidth();
       if (Op->getOpcode() == Instruction::UIToFP)
         IntSize -= IntKnown.countMinLeadingZeros();
       else if (Op->getOpcode() == Instruction::SIToFP)

--- a/llvm/lib/Analysis/ValueTracking.cpp
+++ b/llvm/lib/Analysis/ValueTracking.cpp
@@ -5768,18 +5768,30 @@ void computeKnownFPClass(const Value *V, const APInt &DemandedElts,
     // Integers cannot be subnormal
     Known.knownNot(fcSubnormal);
 
+    KnownBits IntKnown =
+        computeKnownBits(Op->getOperand(0), DemandedElts, Q, Depth + 1);
+
     // sitofp and uitofp turn into +0.0 for zero.
     Known.knownNot(fcNegZero);
-    if (Op->getOpcode() == Instruction::UIToFP)
+
+    // If the integer is non-zero, the result cannot be +0.0
+    if (IntKnown.isNonZero())
+      Known.knownNot(fcPosZero);
+
+    // If UIToFP, or SIToFP with a known non-negative value,
+    // it can't be negative
+    if (Op->getOpcode() == Instruction::UIToFP || IntKnown.isNonNegative())
       Known.signBitMustBeZero();
 
     if (InterestedClasses & fcInf) {
-      // Get width of largest magnitude integer (remove a bit if signed).
+      // Get width of largest magnitude integer known.
       // This still works for a signed minimum value because the largest FP
       // value is scaled by some fraction close to 2.0 (1.0 + 0.xxxx).
-      int IntSize = Op->getOperand(0)->getType()->getScalarSizeInBits();
-      if (Op->getOpcode() == Instruction::SIToFP)
-        --IntSize;
+      unsigned IntSize = IntKnown.getBitWidth();
+      if (Op->getOpcode() == Instruction::UIToFP)
+        IntSize -= IntKnown.countMinLeadingZeros();
+      else if (Op->getOpcode() == Instruction::SIToFP)
+        IntSize -= IntKnown.countMinSignBits();
 
       // If the exponent of the largest finite FP value can hold the largest
       // integer, the result of the cast must be finite.

--- a/llvm/lib/Analysis/ValueTracking.cpp
+++ b/llvm/lib/Analysis/ValueTracking.cpp
@@ -5768,21 +5768,35 @@ void computeKnownFPClass(const Value *V, const APInt &DemandedElts,
     // Integers cannot be subnormal
     Known.knownNot(fcSubnormal);
 
-    KnownBits IntKnown =
-        computeKnownBits(Op->getOperand(0), DemandedElts, Q, Depth + 1);
-
     // sitofp and uitofp turn into +0.0 for zero.
     Known.knownNot(fcNegZero);
+
+    // UIToFP is always non-negative regardless of known bits.
+    if (Op->getOpcode() == Instruction::UIToFP)
+      Known.signBitMustBeZero();
+
+    // Only compute known bits if we can learn something useful from them.
+    if (!(InterestedClasses & (fcPosZero | fcNormal | fcInf)))
+      break;
+
+    KnownBits IntKnown =
+        computeKnownBits(Op->getOperand(0), DemandedElts, Q, Depth + 1);
 
     // If the integer is non-zero, the result cannot be +0.0
     if (IntKnown.isNonZero())
       Known.knownNot(fcPosZero);
 
-    // If UIToFP, or SIToFP with a known non-negative value,
-    // it can't be negative
-    if (Op->getOpcode() == Instruction::UIToFP || IntKnown.isNonNegative())
-      Known.signBitMustBeZero();
+    if (Op->getOpcode() == Instruction::SIToFP) {
+      // If the signed integer is known non-negative, the result is
+      // non-negative.
+      if (IntKnown.isNonNegative())
+        Known.signBitMustBeZero();
+      // If the signed integer is known negative, the result is negative.
+      else if (IntKnown.isNegative())
+        Known.signBitMustBeOne();
+    }
 
+    // Guard kept for ilogb()
     if (InterestedClasses & fcInf) {
       // Get width of largest magnitude integer known.
       // This still works for a signed minimum value because the largest FP

--- a/llvm/test/CodeGen/AMDGPU/bug-sdag-emitcopyfromreg.ll
+++ b/llvm/test/CodeGen/AMDGPU/bug-sdag-emitcopyfromreg.ll
@@ -30,7 +30,7 @@ define void @f(i32 %arg, ptr %ptr) {
 ; ISA-NEXT:    s_and_b32 s5, exec_lo, vcc_lo
 ; ISA-NEXT:    s_or_b32 s4, s5, s4
 ; ISA-NEXT:    v_add_f32_e32 v6, v7, v0
-; ISA-NEXT:    v_add_f32_e64 v6, v6, |v3|
+; ISA-NEXT:    v_add_f32_e32 v6, v6, v3
 ; ISA-NEXT:    v_add_f32_e32 v6, v6, v4
 ; ISA-NEXT:    v_add_f32_e32 v6, v6, v5
 ; ISA-NEXT:    s_andn2_b32 exec_lo, exec_lo, s4

--- a/llvm/test/CodeGen/PowerPC/p10-spill-creq.ll
+++ b/llvm/test/CodeGen/PowerPC/p10-spill-creq.ll
@@ -44,8 +44,8 @@ define dso_local double @P10_Spill_CR_EQ(ptr %arg) local_unnamed_addr #0 {
 ; CHECK-NEXT:  .LBB0_4:
 ; CHECK-NEXT:    # implicit-def: $r5
 ; CHECK-NEXT:  .LBB0_5: # %bb16
-; CHECK-NEXT:    crnot 4*cr1+lt, eq
-; CHECK-NEXT:    crnot 4*cr5+un, 4*cr5+eq
+; CHECK-NEXT:    crnot 4*cr5+un, eq
+; CHECK-NEXT:    crnot 4*cr1+lt, 4*cr5+eq
 ; CHECK-NEXT:    bc 12, 4*cr5+eq, .LBB0_7
 ; CHECK-NEXT:  # %bb.6: # %bb18
 ; CHECK-NEXT:    lwz r4, 0(r3)
@@ -57,10 +57,10 @@ define dso_local double @P10_Spill_CR_EQ(ptr %arg) local_unnamed_addr #0 {
 ; CHECK-NEXT:    cmpwi cr3, r4, -1
 ; CHECK-NEXT:    cmpwi cr2, r3, -1
 ; CHECK-NEXT:    stw r12, 8(r1)
-; CHECK-NEXT:    cmpwi cr7, r3, 0
-; CHECK-NEXT:    cmpwi cr6, r4, 0
-; CHECK-NEXT:    crand 4*cr5+lt, 4*cr3+gt, 4*cr5+un
-; CHECK-NEXT:    crand 4*cr5+gt, 4*cr2+gt, 4*cr1+lt
+; CHECK-NEXT:    cmpwi cr6, r3, 0
+; CHECK-NEXT:    cmpwi cr7, r4, 0
+; CHECK-NEXT:    crand 4*cr5+lt, 4*cr3+gt, 4*cr1+lt
+; CHECK-NEXT:    crand 4*cr5+gt, 4*cr2+gt, 4*cr5+un
 ; CHECK-NEXT:    # implicit-def: $x3
 ; CHECK-NEXT:    bc 4, 4*cr5+gt, .LBB0_10
 ; CHECK-NEXT:  # %bb.9: # %bb34
@@ -72,78 +72,68 @@ define dso_local double @P10_Spill_CR_EQ(ptr %arg) local_unnamed_addr #0 {
 ; CHECK-NEXT:  # %bb.11: # %bb38
 ; CHECK-NEXT:    ld r4, 0(r3)
 ; CHECK-NEXT:  .LBB0_12: # %bb40
-; CHECK-NEXT:    crand 4*cr6+gt, 4*cr7+lt, 4*cr1+lt
 ; CHECK-NEXT:    crand 4*cr6+lt, 4*cr6+lt, 4*cr5+un
-; CHECK-NEXT:    crnot 4*cr6+un, 4*cr1+eq
+; CHECK-NEXT:    crand 4*cr5+un, 4*cr7+lt, 4*cr1+lt
+; CHECK-NEXT:    crnot 4*cr6+gt, 4*cr1+eq
 ; CHECK-NEXT:    # implicit-def: $x6
-; CHECK-NEXT:    bc 4, 4*cr6+lt, .LBB0_14
+; CHECK-NEXT:    bc 4, 4*cr5+un, .LBB0_14
 ; CHECK-NEXT:  # %bb.13: # %bb48
 ; CHECK-NEXT:    ld r6, 0(r3)
 ; CHECK-NEXT:  .LBB0_14: # %bb50
+; CHECK-NEXT:    mfocrf r7, 1
 ; CHECK-NEXT:    cmpwi cr3, r5, -1
-; CHECK-NEXT:    crand 4*cr7+lt, 4*cr2+lt, 4*cr6+un
+; CHECK-NEXT:    crand 4*cr6+un, 4*cr2+lt, 4*cr6+gt
 ; CHECK-NEXT:    # implicit-def: $r5
-; CHECK-NEXT:    bc 4, 4*cr6+gt, .LBB0_16
+; CHECK-NEXT:    rotlwi r7, r7, 28
+; CHECK-NEXT:    stw r7, -4(r1)
+; CHECK-NEXT:    bc 4, 4*cr6+lt, .LBB0_16
 ; CHECK-NEXT:  # %bb.15: # %bb52
 ; CHECK-NEXT:    lwz r5, 0(r3)
 ; CHECK-NEXT:  .LBB0_16: # %bb54
-; CHECK-NEXT:    mfocrf r7, 128
-; CHECK-NEXT:    stw r7, -4(r1)
+; CHECK-NEXT:    crmove 4*cr7+eq, 4*cr1+eq
+; CHECK-NEXT:    crmove 4*cr1+eq, eq
 ; CHECK-NEXT:    # implicit-def: $r7
-; CHECK-NEXT:    bc 4, 4*cr7+lt, .LBB0_18
+; CHECK-NEXT:    bc 4, 4*cr6+un, .LBB0_18
 ; CHECK-NEXT:  # %bb.17: # %bb56
 ; CHECK-NEXT:    lwz r7, 0(r3)
 ; CHECK-NEXT:  .LBB0_18: # %bb58
 ; CHECK-NEXT:    lwz r6, 92(r6)
 ; CHECK-NEXT:    cmpwi cr4, r7, 1
-; CHECK-NEXT:    crand 4*cr7+un, 4*cr3+gt, 4*cr6+un
+; CHECK-NEXT:    crand 4*cr6+gt, 4*cr3+gt, 4*cr6+gt
 ; CHECK-NEXT:    cmpwi cr3, r5, 1
-; CHECK-NEXT:    crand 4*cr7+gt, 4*cr7+eq, 4*cr1+lt
 ; CHECK-NEXT:    # implicit-def: $x5
-; CHECK-NEXT:    crand 4*cr6+un, 4*cr2+eq, 4*cr6+un
-; CHECK-NEXT:    crand 4*cr5+un, 4*cr6+eq, 4*cr5+un
-; CHECK-NEXT:    crand 4*cr7+lt, 4*cr4+lt, 4*cr7+lt
-; CHECK-NEXT:    crand 4*cr6+gt, 4*cr3+lt, 4*cr6+gt
+; CHECK-NEXT:    crand 4*cr6+un, 4*cr4+lt, 4*cr6+un
+; CHECK-NEXT:    crand 4*cr6+lt, 4*cr3+lt, 4*cr6+lt
 ; CHECK-NEXT:    cmpwi r6, 1
-; CHECK-NEXT:    crand 4*cr6+lt, lt, 4*cr6+lt
-; CHECK-NEXT:    bc 4, 4*cr6+gt, .LBB0_20
+; CHECK-NEXT:    crand 4*cr5+un, lt, 4*cr5+un
+; CHECK-NEXT:    bc 4, 4*cr6+lt, .LBB0_20
 ; CHECK-NEXT:  # %bb.19: # %bb68
 ; CHECK-NEXT:    ld r5, 0(r3)
 ; CHECK-NEXT:  .LBB0_20: # %bb70
 ; CHECK-NEXT:    ld r6, 0(r3)
-; CHECK-NEXT:    lwz r9, -4(r1)
-; CHECK-NEXT:    crandc 4*cr5+gt, 4*cr5+gt, 4*cr7+eq
-; CHECK-NEXT:    crandc 4*cr7+eq, 4*cr7+un, 4*cr2+eq
-; CHECK-NEXT:    crandc 4*cr5+lt, 4*cr5+lt, 4*cr6+eq
-; CHECK-NEXT:    setbc r7, 4*cr6+un
-; CHECK-NEXT:    setbc r8, 4*cr5+un
-; CHECK-NEXT:    lwz r12, 8(r1)
-; CHECK-NEXT:    xxlxor f2, f2, f2
+; CHECK-NEXT:    lwz r7, -4(r1)
+; CHECK-NEXT:    crandc 4*cr5+gt, 4*cr5+gt, 4*cr6+eq
+; CHECK-NEXT:    crandc 4*cr6+gt, 4*cr6+gt, 4*cr2+eq
 ; CHECK-NEXT:    isel r3, r3, r5, 4*cr5+gt
-; CHECK-NEXT:    setbc r5, 4*cr7+gt
-; CHECK-NEXT:    crnor 4*cr5+gt, 4*cr6+gt, 4*cr5+gt
-; CHECK-NEXT:    crnor 4*cr6+gt, 4*cr7+lt, 4*cr7+eq
-; CHECK-NEXT:    crnor 4*cr5+lt, 4*cr6+lt, 4*cr5+lt
-; CHECK-NEXT:    add r5, r7, r5
-; CHECK-NEXT:    add r5, r8, r5
+; CHECK-NEXT:    crnor 4*cr5+gt, 4*cr6+lt, 4*cr5+gt
+; CHECK-NEXT:    crnor 4*cr6+lt, 4*cr6+un, 4*cr6+gt
+; CHECK-NEXT:    lwz r12, 8(r1)
 ; CHECK-NEXT:    isel r3, 0, r3, 4*cr5+gt
-; CHECK-NEXT:    isel r4, 0, r4, 4*cr5+lt
-; CHECK-NEXT:    isel r6, 0, r6, 4*cr6+gt
-; CHECK-NEXT:    mtocrf 128, r9
-; CHECK-NEXT:    mtfprd f0, r5
-; CHECK-NEXT:    isel r4, 0, r4, 4*cr5+eq
+; CHECK-NEXT:    mtocrf 128, r7
+; CHECK-NEXT:    isel r5, 0, r6, 4*cr6+lt
+; CHECK-NEXT:    isel r3, 0, r3, 4*cr1+eq
 ; CHECK-NEXT:    mtocrf 32, r12
 ; CHECK-NEXT:    mtocrf 16, r12
 ; CHECK-NEXT:    mtocrf 8, r12
-; CHECK-NEXT:    iseleq r3, 0, r3
-; CHECK-NEXT:    isel r6, 0, r6, 4*cr1+eq
-; CHECK-NEXT:    xscvsxddp f0, f0
-; CHECK-NEXT:    add r3, r6, r3
+; CHECK-NEXT:    crandc 4*cr5+lt, 4*cr5+lt, eq
+; CHECK-NEXT:    isel r5, 0, r5, 4*cr7+eq
+; CHECK-NEXT:    crnor 4*cr5+lt, 4*cr5+un, 4*cr5+lt
+; CHECK-NEXT:    isel r4, 0, r4, 4*cr5+lt
+; CHECK-NEXT:    isel r4, 0, r4, 4*cr5+eq
+; CHECK-NEXT:    add r3, r5, r3
 ; CHECK-NEXT:    add r3, r4, r3
-; CHECK-NEXT:    mtfprd f1, r3
-; CHECK-NEXT:    xsmuldp f0, f0, f2
-; CHECK-NEXT:    xscvsxddp f1, f1
-; CHECK-NEXT:    xsadddp f1, f0, f1
+; CHECK-NEXT:    mtfprd f0, r3
+; CHECK-NEXT:    xscvsxddp f1, f0
 ; CHECK-NEXT:    blr
 bb:
   %tmp = getelementptr inbounds %4, ptr null, i64 undef, i32 7

--- a/llvm/test/Transforms/InstCombine/binop-itofp.ll
+++ b/llvm/test/Transforms/InstCombine/binop-itofp.ll
@@ -1010,11 +1010,8 @@ define float @test_ui_add_with_signed_constant(i32 %shr.i) {
 define float @missed_nonzero_check_on_constant_for_si_fmul(i1 %c, i1 %.b, ptr %g_2345) {
 ; CHECK-LABEL: @missed_nonzero_check_on_constant_for_si_fmul(
 ; CHECK-NEXT:    [[SEL:%.*]] = select i1 [[C:%.*]], i32 65529, i32 53264
-; CHECK-NEXT:    [[CONV_I:%.*]] = trunc nuw i32 [[SEL]] to i16
-; CHECK-NEXT:    [[CONV1_I:%.*]] = sitofp i16 [[CONV_I]] to float
-; CHECK-NEXT:    [[MUL3_I_I:%.*]] = call float @llvm.copysign.f32(float 0.000000e+00, float [[CONV1_I]])
 ; CHECK-NEXT:    store i32 [[SEL]], ptr [[G_2345:%.*]], align 4
-; CHECK-NEXT:    ret float [[MUL3_I_I]]
+; CHECK-NEXT:    ret float -0.000000e+00
 ;
   %sel = select i1 %c, i32 65529, i32 53264
   %conv.i = trunc i32 %sel to i16
@@ -1027,13 +1024,8 @@ define float @missed_nonzero_check_on_constant_for_si_fmul(i1 %c, i1 %.b, ptr %g
 define <2 x float> @missed_nonzero_check_on_constant_for_si_fmul_vec(i1 %c, i1 %.b, ptr %g_2345) {
 ; CHECK-LABEL: @missed_nonzero_check_on_constant_for_si_fmul_vec(
 ; CHECK-NEXT:    [[SEL:%.*]] = select i1 [[C:%.*]], i32 65529, i32 53264
-; CHECK-NEXT:    [[CONV_I_S:%.*]] = trunc nuw i32 [[SEL]] to i16
-; CHECK-NEXT:    [[CONV_I_V:%.*]] = insertelement <2 x i16> poison, i16 [[CONV_I_S]], i64 0
-; CHECK-NEXT:    [[CONV_I:%.*]] = shufflevector <2 x i16> [[CONV_I_V]], <2 x i16> poison, <2 x i32> zeroinitializer
-; CHECK-NEXT:    [[CONV1_I:%.*]] = sitofp <2 x i16> [[CONV_I]] to <2 x float>
-; CHECK-NEXT:    [[MUL3_I_I:%.*]] = call <2 x float> @llvm.copysign.v2f32(<2 x float> zeroinitializer, <2 x float> [[CONV1_I]])
 ; CHECK-NEXT:    store i32 [[SEL]], ptr [[G_2345:%.*]], align 4
-; CHECK-NEXT:    ret <2 x float> [[MUL3_I_I]]
+; CHECK-NEXT:    ret <2 x float> splat (float -0.000000e+00)
 ;
   %sel = select i1 %c, i32 65529, i32 53264
   %conv.i.s = trunc i32 %sel to i16
@@ -1048,12 +1040,8 @@ define <2 x float> @missed_nonzero_check_on_constant_for_si_fmul_vec(i1 %c, i1 %
 define float @negzero_check_on_constant_for_si_fmul(i1 %c, i1 %.b, ptr %g_2345) {
 ; CHECK-LABEL: @negzero_check_on_constant_for_si_fmul(
 ; CHECK-NEXT:    [[SEL:%.*]] = select i1 [[C:%.*]], i32 65529, i32 53264
-; CHECK-NEXT:    [[CONV_I:%.*]] = trunc nuw i32 [[SEL]] to i16
-; CHECK-NEXT:    [[CONV1_I:%.*]] = sitofp i16 [[CONV_I]] to float
-; CHECK-NEXT:    [[TMP1:%.*]] = fneg float [[CONV1_I]]
-; CHECK-NEXT:    [[MUL3_I_I:%.*]] = call float @llvm.copysign.f32(float 0.000000e+00, float [[TMP1]])
 ; CHECK-NEXT:    store i32 [[SEL]], ptr [[G_2345:%.*]], align 4
-; CHECK-NEXT:    ret float [[MUL3_I_I]]
+; CHECK-NEXT:    ret float 0.000000e+00
 ;
   %sel = select i1 %c, i32 65529, i32 53264
   %conv.i = trunc i32 %sel to i16
@@ -1085,13 +1073,8 @@ define <2 x half> @test_ui_ui_i8_mul_vec(<2 x i8> noundef %x_in, <2 x i8> nounde
 define <2 x float> @nonzero_check_on_constant_for_si_fmul_vec_w_poison(i1 %c, i1 %.b, ptr %g_2345) {
 ; CHECK-LABEL: @nonzero_check_on_constant_for_si_fmul_vec_w_poison(
 ; CHECK-NEXT:    [[SEL:%.*]] = select i1 [[C:%.*]], i32 65529, i32 53264
-; CHECK-NEXT:    [[CONV_I_S:%.*]] = trunc nuw i32 [[SEL]] to i16
-; CHECK-NEXT:    [[CONV_I_V:%.*]] = insertelement <2 x i16> poison, i16 [[CONV_I_S]], i64 0
-; CHECK-NEXT:    [[CONV_I:%.*]] = shufflevector <2 x i16> [[CONV_I_V]], <2 x i16> poison, <2 x i32> zeroinitializer
-; CHECK-NEXT:    [[CONV1_I:%.*]] = sitofp <2 x i16> [[CONV_I]] to <2 x float>
-; CHECK-NEXT:    [[MUL3_I_I:%.*]] = call <2 x float> @llvm.copysign.v2f32(<2 x float> <float poison, float 0.000000e+00>, <2 x float> [[CONV1_I]])
 ; CHECK-NEXT:    store i32 [[SEL]], ptr [[G_2345:%.*]], align 4
-; CHECK-NEXT:    ret <2 x float> [[MUL3_I_I]]
+; CHECK-NEXT:    ret <2 x float> <float poison, float -0.000000e+00>
 ;
   %sel = select i1 %c, i32 65529, i32 53264
   %conv.i.s = trunc i32 %sel to i16
@@ -1127,14 +1110,8 @@ define <2 x float> @nonzero_check_on_constant_for_si_fmul_nz_vec_w_poison(i1 %c,
 define <2 x float> @nonzero_check_on_constant_for_si_fmul_negz_vec_w_poison(i1 %c, i1 %.b, ptr %g_2345) {
 ; CHECK-LABEL: @nonzero_check_on_constant_for_si_fmul_negz_vec_w_poison(
 ; CHECK-NEXT:    [[SEL:%.*]] = select i1 [[C:%.*]], i32 65529, i32 53264
-; CHECK-NEXT:    [[CONV_I_S:%.*]] = trunc nuw i32 [[SEL]] to i16
-; CHECK-NEXT:    [[CONV_I_V:%.*]] = insertelement <2 x i16> poison, i16 [[CONV_I_S]], i64 0
-; CHECK-NEXT:    [[CONV_I:%.*]] = shufflevector <2 x i16> [[CONV_I_V]], <2 x i16> poison, <2 x i32> zeroinitializer
-; CHECK-NEXT:    [[CONV1_I:%.*]] = sitofp <2 x i16> [[CONV_I]] to <2 x float>
-; CHECK-NEXT:    [[TMP1:%.*]] = fneg <2 x float> [[CONV1_I]]
-; CHECK-NEXT:    [[MUL3_I_I:%.*]] = call <2 x float> @llvm.copysign.v2f32(<2 x float> <float poison, float -0.000000e+00>, <2 x float> [[TMP1]])
 ; CHECK-NEXT:    store i32 [[SEL]], ptr [[G_2345:%.*]], align 4
-; CHECK-NEXT:    ret <2 x float> [[MUL3_I_I]]
+; CHECK-NEXT:    ret <2 x float> <float poison, float 0.000000e+00>
 ;
   %sel = select i1 %c, i32 65529, i32 53264
   %conv.i.s = trunc i32 %sel to i16

--- a/llvm/test/Transforms/InstCombine/binop-itofp.ll
+++ b/llvm/test/Transforms/InstCombine/binop-itofp.ll
@@ -609,7 +609,7 @@ define half @test_ui_ui_i16_mul_fail_no_promotion(i16 noundef %x_in, i16 noundef
 ; CHECK-NEXT:    [[Y:%.*]] = and i16 [[Y_IN:%.*]], 3
 ; CHECK-NEXT:    [[XF:%.*]] = uitofp nneg i16 [[X]] to half
 ; CHECK-NEXT:    [[YF:%.*]] = uitofp nneg i16 [[Y]] to half
-; CHECK-NEXT:    [[R:%.*]] = fmul half [[XF]], [[YF]]
+; CHECK-NEXT:    [[R:%.*]] = fmul nnan half [[XF]], [[YF]]
 ; CHECK-NEXT:    ret half [[R]]
 ;
   %x = and i16 %x_in, 4095
@@ -645,7 +645,7 @@ define half @test_si_si_i16_mul_fail_overflow(i16 noundef %x_in, i16 noundef %y_
 ; CHECK-NEXT:    [[Y:%.*]] = or i16 [[Y_IN:%.*]], -257
 ; CHECK-NEXT:    [[XF:%.*]] = uitofp nneg i16 [[X]] to half
 ; CHECK-NEXT:    [[YF:%.*]] = sitofp i16 [[Y]] to half
-; CHECK-NEXT:    [[R:%.*]] = fmul half [[XF]], [[YF]]
+; CHECK-NEXT:    [[R:%.*]] = fmul nnan half [[XF]], [[YF]]
 ; CHECK-NEXT:    ret half [[R]]
 ;
   %xx = and i16 %x_in, 126

--- a/llvm/test/Transforms/InstCombine/sitofp.ll
+++ b/llvm/test/Transforms/InstCombine/sitofp.ll
@@ -429,6 +429,36 @@ entry:
   ret i1 %is.zero
 }
 
+; The i32 value 0xFF80 truncated to i16 is 0xFF80 = -128 (signed).
+; Mask 960 = PosInf(512) | PosNormal(256) | PosSubnormal(128) | PosZero(64)
+define i1 @test_sitofp_known_negative_trunc(i32 %a) {
+; CHECK-LABEL: @test_sitofp_known_negative_trunc(
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    ret i1 false
+;
+entry:
+  %or = or i32 %a, 65408
+  %trunc = trunc i32 %or to i16
+  %f = sitofp i16 %trunc to float
+  %is.pos = call i1 @llvm.is.fpclass.f32(float %f, i32 960)
+  ret i1 %is.pos
+}
+
+; The i32 value masked with 0x7FFF truncated to i16 clears the sign bit.
+; Mask 60 = NegInf(4) | NegNormal(8) | NegSubnormal(16) | NegZero(32)
+define i1 @test_sitofp_known_nonneg_trunc(i32 %a) {
+; CHECK-LABEL: @test_sitofp_known_nonneg_trunc(
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    ret i1 false
+;
+entry:
+  %and = and i32 %a, 32767
+  %trunc = trunc i32 %and to i16
+  %f = sitofp i16 %trunc to float
+  %is.neg = call i1 @llvm.is.fpclass.f32(float %f, i32 60)
+  ret i1 %is.neg
+}
+
 ; Mask 516 = PosInf (512) | NegInf (4)
 define i1 @test_uitofp_no_inf(i64 %a) {
 ; CHECK-LABEL: @test_uitofp_no_inf(
@@ -438,6 +468,20 @@ define i1 @test_uitofp_no_inf(i64 %a) {
 entry:
   %and = and i64 %a, 32767
   %f = uitofp i64 %and to half
+  ; 516 checks for +Inf or -Inf
+  %is.inf = call i1 @llvm.is.fpclass.f16(half %f, i32 516)
+  ret i1 %is.inf
+}
+
+; Mask 516 = PosInf (512) | NegInf (4)
+define i1 @test_sitofp_no_inf(i64 %a) {
+; CHECK-LABEL: @test_sitofp_no_inf(
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    ret i1 false
+;
+entry:
+  %and = and i64 %a, 32767
+  %f = sitofp i64 %and to half
   ; 516 checks for +Inf or -Inf
   %is.inf = call i1 @llvm.is.fpclass.f16(half %f, i32 516)
   ret i1 %is.inf

--- a/llvm/test/Transforms/InstCombine/sitofp.ll
+++ b/llvm/test/Transforms/InstCombine/sitofp.ll
@@ -415,3 +415,30 @@ define <2 x i1> @i8_vec_sitofp_test4(<2 x i8> %A) {
   %C = fcmp ult <2 x double> %B, <double 127.0, double 127.0>
   ret <2 x i1> %C
 }
+
+; Mask 98 = PosZero (64) | NegZero (32) | QNan (2)
+define i1 @test_sitofp_nonzero(i32 %a) {
+; CHECK-LABEL: @test_sitofp_nonzero(
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    ret i1 false
+;
+entry:
+  %or = or i32 %a, 1
+  %f = sitofp i32 %or to float
+  %is.zero = call i1 @llvm.is.fpclass.f32(float %f, i32 98)
+  ret i1 %is.zero
+}
+
+; Mask 516 = PosInf (512) | NegInf (4)
+define i1 @test_uitofp_no_inf(i64 %a) {
+; CHECK-LABEL: @test_uitofp_no_inf(
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    ret i1 false
+;
+entry:
+  %and = and i64 %a, 32767
+  %f = uitofp i64 %and to half
+  ; 516 checks for +Inf or -Inf
+  %is.inf = call i1 @llvm.is.fpclass.f16(half %f, i32 516)
+  ret i1 %is.inf
+}


### PR DESCRIPTION
This patch propagates the KnownBits of the source integer to improve floating-point class inference for sitofp and uitofp instructions.

Specifically,
1. The result is never -0.0.
2. The result is not +0.0 if the source integer is known non-zero.
3. The result is not negative if the source integer is known non-negative (or for uitofp).
4. The result is not Infinity if the largest possible integer magnitude fits within the target FP type's exponent limits.

alive2 results for added testcases:
testcase 1: https://alive2.llvm.org/ce/z/eM34LB
testcase 2: https://alive2.llvm.org/ce/z/ext7XF 
testcase 3: https://alive2.llvm.org/ce/z/g8yb6q
testcase 4: https://alive2.llvm.org/ce/z/cyFYRy
testcase 5: https://alive2.llvm.org/ce/z/LePFrm

alive2 for updated testcase in binop-itofp:

updated 1: https://alive2.llvm.org/ce/z/KPQ5bZ
udpated 2: https://alive2.llvm.org/ce/z/bGf43t
updated 3: https://alive2.llvm.org/ce/z/YKnCwU
updaetd 4: https://alive2.llvm.org/ce/z/mqKaq-
updated 5: https://alive2.llvm.org/ce/z/jYSAB5

Fix #186952