### PR TITLE
[flang] Fix the CHECK: directive to ensure flagging RWE (NFC)

### DIFF
--- a/flang-rt/test/Driver/safe-trampoline-gnustack.f90
+++ b/flang-rt/test/Driver/safe-trampoline-gnustack.f90
@@ -11,9 +11,7 @@
 ! RUN: llvm-readelf -lW %t | FileCheck %s
 
 ! Ensure GNU_STACK exists and has RW flags (no E).
-! CHECK: GNU_STACK
-! CHECK-SAME: RW
-! CHECK-NOT: RWE
+! CHECK: GNU_STACK{{.*}}RW{{[^E]|$}}
 
 subroutine host_proc(x, res)
   implicit none


### PR DESCRIPTION
Currently, the test passes with `powerpc64le--unknown-linux-gnu`. The check does not catch the following output from `llvm-readelf`:
```
GNU_EH_FRAME   0x000ed8 0x0000000000000ed8 0x0000000000000ed8 0x000074 0x000074 R   0x4
GNU_STACK      0x000000 0x0000000000000000 0x0000000000000000 0x000000 0x000000 RWE 0x10
GNU_RELRO      0x00fca8 0x000000000001fca8 0x000000000001fca8 0x000358 0x000358 R   0x1
```


@Saieiei 
