### PR TITLE
[orc-rt] De-duplicate some test helper APIs.

### DIFF
--- a/orc-rt/unittests/BootstrapInfoTest.cpp
+++ b/orc-rt/unittests/BootstrapInfoTest.cpp
@@ -15,21 +15,9 @@
 #include "orc-rt/TaskDispatcher.h"
 #include "gtest/gtest.h"
 
+#include "CommonTestUtils.h"
+
 using namespace orc_rt;
-
-static ExecutorProcessInfo mockExecutorProcessInfo() noexcept {
-  return ExecutorProcessInfo("arm64-apple-darwin", 16384);
-}
-
-class NoDispatcher : public TaskDispatcher {
-public:
-  void dispatch(std::unique_ptr<Task> T) override {
-    assert(false && "strictly no dispatching!");
-  }
-  void shutdown() override {}
-};
-
-static void noErrors(Error Err) { cantFail(std::move(Err)); }
 
 TEST(BootstrapInfoTest, ExplicitConstruction) {
   Session S(mockExecutorProcessInfo(), std::make_unique<NoDispatcher>(),

--- a/orc-rt/unittests/CommonTestUtils.h
+++ b/orc-rt/unittests/CommonTestUtils.h
@@ -9,10 +9,27 @@
 #ifndef ORC_RT_UNITTEST_COMMONTESTUTILS_H
 #define ORC_RT_UNITTEST_COMMONTESTUTILS_H
 
+#include "orc-rt/Error.h"
+#include "orc-rt/ExecutorProcessInfo.h"
+#include "orc-rt/TaskDispatcher.h"
 #include "orc-rt/move_only_function.h"
 
 #include <cstddef>
 #include <future>
+
+inline void noErrors(orc_rt::Error Err) { orc_rt::cantFail(std::move(Err)); }
+
+inline orc_rt::ExecutorProcessInfo mockExecutorProcessInfo() noexcept {
+  return orc_rt::ExecutorProcessInfo("arm64-apple-darwin", 16384);
+}
+
+class NoDispatcher : public orc_rt::TaskDispatcher {
+public:
+  void dispatch(std::unique_ptr<orc_rt::Task> T) override {
+    assert(false && "strictly no dispatching!");
+  }
+  void shutdown() override {}
+};
 
 template <size_t Idx = 0> class OpCounter {
 public:

--- a/orc-rt/unittests/SessionTest.cpp
+++ b/orc-rt/unittests/SessionTest.cpp
@@ -17,6 +17,8 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
+#include "CommonTestUtils.h"
+
 #include <chrono>
 #include <deque>
 #include <future>
@@ -66,18 +68,6 @@ public:
   void onShutdown(OnCompleteFn OnComplete) override { OnComplete(); }
 
   void doMoreConfig(int) noexcept {}
-};
-
-static ExecutorProcessInfo mockExecutorProcessInfo() noexcept {
-  return ExecutorProcessInfo("arm64-apple-darwin", 16384);
-}
-
-class NoDispatcher : public TaskDispatcher {
-public:
-  void dispatch(std::unique_ptr<Task> T) override {
-    assert(false && "strictly no dispatching!");
-  }
-  void shutdown() override {}
 };
 
 class EnqueueingDispatcher : public TaskDispatcher {
@@ -272,10 +262,6 @@ private:
   MockControllerAccess &CA;
   orc_rt_WrapperFunction Fn;
 };
-
-// Non-overloaded version of cantFail: allows easy construction of
-// move_only_functions<void(Error)>s.
-static void noErrors(Error Err) { cantFail(std::move(Err)); }
 
 TEST(SessionTest, TrivialConstructionAndDestruction) {
   Session S(mockExecutorProcessInfo(), std::make_unique<NoDispatcher>(),


### PR DESCRIPTION
Moves noErrors, mockExecutorProcessInfo, and NoDispatcher into CommonTestUtils.h where they can be re-used between tests.