### PR TITLE
[orc-rt] Publish controller interface from SimpleNativeMemoryMap ctor.

### DIFF
--- a/orc-rt/include/orc-rt/SimpleNativeMemoryMap.h
+++ b/orc-rt/include/orc-rt/SimpleNativeMemoryMap.h
@@ -14,10 +14,13 @@
 #define ORC_RT_SIMPLENATIVEMEMORYMAP_H
 
 #include "orc-rt/AllocAction.h"
+#include "orc-rt/BootstrapInfo.h"
 #include "orc-rt/Error.h"
 #include "orc-rt/MemoryFlags.h"
 #include "orc-rt/Service.h"
+#include "orc-rt/SimpleSymbolTable.h"
 #include "orc-rt/move_only_function.h"
+#include "orc-rt/sps-ci/SimpleNativeMemoryMapSPSCI.h"
 
 #include <map>
 #include <mutex>
@@ -25,6 +28,8 @@
 #include <vector>
 
 namespace orc_rt {
+
+class Session;
 
 /// JIT'd memory management backend.
 ///
@@ -41,6 +46,26 @@ namespace orc_rt {
 ///    the system permits).
 class SimpleNativeMemoryMap : public Service {
 public:
+  /// Create a SimpleNativeMemoryMap, adding associated symbols to the given
+  /// SimpleSymbolTable (typically the BootstrapInfo table).
+  static Expected<std::unique_ptr<SimpleNativeMemoryMap>>
+  Create(Session &S, SimpleSymbolTable &ST,
+         const char *InstanceName = "orc_rt_SimpleNativeMemoryMap_Instance",
+         SimpleSymbolTable::MutatorFn AddInterface =
+             sps_ci::addSimpleNativeMemoryMap);
+
+  /// Convenience constructor that adds default symbols to the given
+  /// BootstrapInfo's symbols map.
+  static Expected<std::unique_ptr<SimpleNativeMemoryMap>>
+  Create(Session &S, BootstrapInfo &BI) {
+    return Create(S, BI.symbols());
+  }
+  /// SimpleNativeMemoryMap is not copyable / moveable.
+  SimpleNativeMemoryMap(const SimpleNativeMemoryMap &) = delete;
+  SimpleNativeMemoryMap &operator=(const SimpleNativeMemoryMap &) = delete;
+  SimpleNativeMemoryMap(SimpleNativeMemoryMap &&) = delete;
+  SimpleNativeMemoryMap &operator=(SimpleNativeMemoryMap &&) = delete;
+
   /// Reserves a slab of contiguous address space for allocation.
   ///
   /// Returns the base address of the allocated memory.
@@ -89,6 +114,8 @@ public:
   void onShutdown(Service::OnCompleteFn OnComplete) override;
 
 private:
+  SimpleNativeMemoryMap() = default;
+
   struct SlabInfo {
     SlabInfo(size_t Size) : Size(Size) {}
     size_t Size;

--- a/orc-rt/include/orc-rt/SimpleSymbolTable.h
+++ b/orc-rt/include/orc-rt/SimpleSymbolTable.h
@@ -14,6 +14,7 @@
 #define ORC_RT_SIMPLESYMBOLTABLE_H
 
 #include "orc-rt/Error.h"
+#include "orc-rt/move_only_function.h"
 #include <string>
 #include <string_view>
 #include <unordered_map>
@@ -29,6 +30,8 @@ class SimpleSymbolTable {
 public:
   using SymbolTable = std::unordered_map<std::string, const void *>;
   using iterator = SymbolTable::const_iterator;
+
+  using MutatorFn = move_only_function<Error(SimpleSymbolTable &)>;
 
   bool empty() const noexcept { return Symbols.empty(); }
   size_t size() const noexcept { return Symbols.size(); }

--- a/orc-rt/lib/executor/SimpleNativeMemoryMap.cpp
+++ b/orc-rt/lib/executor/SimpleNativeMemoryMap.cpp
@@ -14,6 +14,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "orc-rt/SimpleNativeMemoryMap.h"
+#include "orc-rt/Session.h"
 #include <sstream>
 
 #if defined(__APPLE__) || defined(__linux__)
@@ -23,6 +24,27 @@
 #endif
 
 namespace orc_rt {
+
+Expected<std::unique_ptr<SimpleNativeMemoryMap>>
+SimpleNativeMemoryMap::Create(Session &S, SimpleSymbolTable &ST,
+                              const char *InstanceName,
+                              SimpleSymbolTable::MutatorFn AddInterface) {
+
+  std::unique_ptr<SimpleNativeMemoryMap> Instance(new SimpleNativeMemoryMap());
+
+  SimpleSymbolTable SNMMST;
+  if (auto Err = AddInterface(SNMMST))
+    return Err;
+  std::pair<const char *, const void *> InstanceSym[] = {
+      {InstanceName, static_cast<const void *>(Instance.get())}};
+  if (auto Err = SNMMST.addUnique(InstanceSym))
+    return std::move(Err);
+
+  if (auto Err = ST.addUnique(SNMMST))
+    return std::move(Err);
+
+  return std::move(Instance);
+}
 
 void SimpleNativeMemoryMap::reserve(OnReserveCompleteFn &&OnComplete,
                                     size_t Size) {

--- a/orc-rt/unittests/SimpleNativeMemoryMapSPSCITest.cpp
+++ b/orc-rt/unittests/SimpleNativeMemoryMapSPSCITest.cpp
@@ -14,6 +14,7 @@
 #include "orc-rt/SPSAllocAction.h"
 #include "orc-rt/SPSMemoryFlags.h"
 #include "orc-rt/SPSWrapperFunction.h"
+#include "orc-rt/Session.h"
 #include "orc-rt/SimpleNativeMemoryMap.h"
 
 #include "AllocActionTestUtils.h"
@@ -113,7 +114,9 @@ class SimpleNativeMemoryMapSPSCITest : public ::testing::Test {
 protected:
   void SetUp() override {
     cantFail(sps_ci::addSimpleNativeMemoryMap(CI));
-    SNMM = std::make_unique<SimpleNativeMemoryMap>();
+    S = std::make_unique<Session>(mockExecutorProcessInfo(),
+                                  std::make_unique<NoDispatcher>(), noErrors);
+    SNMM = cantFail(SimpleNativeMemoryMap::Create(*S, CI));
   }
 
   void TearDown() override {
@@ -165,6 +168,7 @@ protected:
   }
 
   SimpleSymbolTable CI;
+  std::unique_ptr<Session> S;
   std::unique_ptr<SimpleNativeMemoryMap> SNMM;
 };
 

--- a/orc-rt/unittests/SimpleNativeMemoryMapTest.cpp
+++ b/orc-rt/unittests/SimpleNativeMemoryMapTest.cpp
@@ -12,6 +12,7 @@
 
 #include "orc-rt/SimpleNativeMemoryMap.h"
 #include "orc-rt/SPSAllocAction.h"
+#include "orc-rt/Session.h"
 
 #include "AllocActionTestUtils.h"
 #include "CommonTestUtils.h"
@@ -48,20 +49,26 @@ read_value_sps_allocaction(const char *ArgData, size_t ArgSize) {
 TEST(SimpleNativeMemoryMapTest, CreateAndDestroy) {
   // Test that we can create and destroy a SimpleNativeMemoryMap instance as
   // expected.
-  auto SNMM = std::make_unique<SimpleNativeMemoryMap>();
+  Session S(mockExecutorProcessInfo(), std::make_unique<NoDispatcher>(),
+            noErrors);
+  SimpleSymbolTable ThrowAway;
+  auto SNMM = cantFail(SimpleNativeMemoryMap::Create(S, ThrowAway));
 }
 
 TEST(SimpleNativeMemoryMapTest, ReserveAndRelease) {
   // Test that we can reserve and release a slab of address space as expected,
   // without finalizing any memory within it.
-  SimpleNativeMemoryMap SNMM;
+  Session S(mockExecutorProcessInfo(), std::make_unique<NoDispatcher>(),
+            noErrors);
+  SimpleSymbolTable ThrowAway;
+  auto SNMM = cantFail(SimpleNativeMemoryMap::Create(S, ThrowAway));
 
   std::future<Expected<void *>> ReserveResult;
-  SNMM.reserve(waitFor(ReserveResult), 1024 * 1024 * 1024);
+  SNMM->reserve(waitFor(ReserveResult), 1024 * 1024 * 1024);
   void *Addr = cantFail(ReserveResult.get());
 
   std::future<Error> ReleaseResult;
-  SNMM.releaseMultiple(waitFor(ReleaseResult), {Addr});
+  SNMM->releaseMultiple(waitFor(ReleaseResult), {Addr});
   cantFail(ReleaseResult.get());
 }
 
@@ -74,10 +81,13 @@ TEST(SimpleNativeMemoryMapTest, FullPipelineForOneRWSegment) {
   //    expected.
   // 4. release the address range.
 
-  SimpleNativeMemoryMap SNMM;
+  Session S(mockExecutorProcessInfo(), std::make_unique<NoDispatcher>(),
+            noErrors);
+  SimpleSymbolTable ThrowAway;
+  auto SNMM = cantFail(SimpleNativeMemoryMap::Create(S, ThrowAway));
 
   std::future<Expected<void *>> ReserveResult;
-  SNMM.reserve(waitFor(ReserveResult), 1024 * 1024 * 1024);
+  SNMM->reserve(waitFor(ReserveResult), 1024 * 1024 * 1024);
   void *Addr = cantFail(ReserveResult.get());
 
   char *InitializeBase = // Initialize addr at non-zero (64kb) offset from base.
@@ -126,7 +136,7 @@ TEST(SimpleNativeMemoryMapTest, FullPipelineForOneRWSegment) {
   });
 
   std::future<Expected<void *>> InitializeResult;
-  SNMM.initialize(waitFor(InitializeResult), std::move(IR));
+  SNMM->initialize(waitFor(InitializeResult), std::move(IR));
   void *InitializeKeyAddr = cantFail(InitializeResult.get());
 
   EXPECT_EQ(SentinelValue1, 42U);
@@ -134,7 +144,7 @@ TEST(SimpleNativeMemoryMapTest, FullPipelineForOneRWSegment) {
   EXPECT_EQ(SentinelValue3, 0U);
 
   std::future<Error> DeallocResult;
-  SNMM.deinitializeMultiple(waitFor(DeallocResult), {InitializeKeyAddr});
+  SNMM->deinitializeMultiple(waitFor(DeallocResult), {InitializeKeyAddr});
   cantFail(DeallocResult.get());
 
   EXPECT_EQ(SentinelValue1, 42U);
@@ -142,7 +152,7 @@ TEST(SimpleNativeMemoryMapTest, FullPipelineForOneRWSegment) {
   EXPECT_EQ(SentinelValue3, 0U);
 
   std::future<Error> ReleaseResult;
-  SNMM.releaseMultiple(waitFor(ReleaseResult), {Addr});
+  SNMM->releaseMultiple(waitFor(ReleaseResult), {Addr});
   cantFail(ReleaseResult.get());
 }
 
@@ -150,10 +160,13 @@ TEST(SimpleNativeMemoryMapTest, ReserveInitializeShutdown) {
   // Test that memory is deinitialized in the case where we reserve and
   // initialize some memory, then just shut down the memory manager.
 
-  SimpleNativeMemoryMap SNMM;
+  Session S(mockExecutorProcessInfo(), std::make_unique<NoDispatcher>(),
+            noErrors);
+  SimpleSymbolTable ThrowAway;
+  auto SNMM = cantFail(SimpleNativeMemoryMap::Create(S, ThrowAway));
 
   std::future<Expected<void *>> ReserveResult;
-  SNMM.reserve(waitFor(ReserveResult), 1024 * 1024 * 1024);
+  SNMM->reserve(waitFor(ReserveResult), 1024 * 1024 * 1024);
   void *Addr = cantFail(ReserveResult.get());
 
   char *InitializeBase = // Initialize addr at non-zero (64kb) offset from base.
@@ -173,13 +186,13 @@ TEST(SimpleNativeMemoryMapTest, ReserveInitializeShutdown) {
            ExecutorAddr::fromPtr(InitializeBase))});
 
   std::future<Expected<void *>> InitializeResult;
-  SNMM.initialize(waitFor(InitializeResult), std::move(IR));
+  SNMM->initialize(waitFor(InitializeResult), std::move(IR));
   cantFail(InitializeResult.get());
 
   EXPECT_EQ(SentinelValue, 0U);
 
   std::future<void> ShutdownResult;
-  SNMM.onShutdown(waitFor(ShutdownResult));
+  SNMM->onShutdown(waitFor(ShutdownResult));
   ShutdownResult.get();
 
   EXPECT_EQ(SentinelValue, 42);
@@ -189,10 +202,13 @@ TEST(SimpleNativeMemoryMapTest, ReserveInitializeDetachShutdown) {
   // Test that memory is deinitialized in the case where we reserve and
   // initialize some memory, then just shut down the memory manager.
 
-  SimpleNativeMemoryMap SNMM;
+  Session S(mockExecutorProcessInfo(), std::make_unique<NoDispatcher>(),
+            noErrors);
+  SimpleSymbolTable ThrowAway;
+  auto SNMM = cantFail(SimpleNativeMemoryMap::Create(S, ThrowAway));
 
   std::future<Expected<void *>> ReserveResult;
-  SNMM.reserve(waitFor(ReserveResult), 1024 * 1024 * 1024);
+  SNMM->reserve(waitFor(ReserveResult), 1024 * 1024 * 1024);
   void *Addr = cantFail(ReserveResult.get());
 
   char *InitializeBase = // Initialize addr at non-zero (64kb) offset from base.
@@ -212,19 +228,19 @@ TEST(SimpleNativeMemoryMapTest, ReserveInitializeDetachShutdown) {
            ExecutorAddr::fromPtr(InitializeBase))});
 
   std::future<Expected<void *>> InitializeResult;
-  SNMM.initialize(waitFor(InitializeResult), std::move(IR));
+  SNMM->initialize(waitFor(InitializeResult), std::move(IR));
   cantFail(InitializeResult.get());
 
   EXPECT_EQ(SentinelValue, 0U);
 
   std::future<void> DetachResult;
-  SNMM.onDetach(waitFor(DetachResult));
+  SNMM->onDetach(waitFor(DetachResult));
   DetachResult.get();
 
   EXPECT_EQ(SentinelValue, 0);
 
   std::future<void> ShutdownResult;
-  SNMM.onShutdown(waitFor(ShutdownResult));
+  SNMM->onShutdown(waitFor(ShutdownResult));
   ShutdownResult.get();
 
   EXPECT_EQ(SentinelValue, 42);


### PR DESCRIPTION
Add named constructors to SimpleNativeMemoryMap to publish SimpleNativeMemoryMap's controller interface when an instance is constructed.

This supports correct setup by construction, since API clients can't forget to publish the interface that the controller will need to interact with the SimpleNativeMemoryMap object.