### PR TITLE
[orc-rt] Capture a Session& in SimpleNativeMemoryMap, fix TODOs.

### DIFF
--- a/orc-rt/include/orc-rt/SimpleNativeMemoryMap.h
+++ b/orc-rt/include/orc-rt/SimpleNativeMemoryMap.h
@@ -114,7 +114,7 @@ public:
   void onShutdown(Service::OnCompleteFn OnComplete) override;
 
 private:
-  SimpleNativeMemoryMap() = default;
+  SimpleNativeMemoryMap(Session &S) : S(S) {}
 
   struct SlabInfo {
     SlabInfo(size_t Size) : Size(Size) {}
@@ -133,6 +133,7 @@ private:
   Error recordDeallocActions(void *Base,
                              std::vector<AllocAction> DeallocActions);
 
+  Session &S;
   std::mutex M;
   std::map<void *, SlabInfo> Slabs;
 };

--- a/orc-rt/lib/executor/SimpleNativeMemoryMap.cpp
+++ b/orc-rt/lib/executor/SimpleNativeMemoryMap.cpp
@@ -30,7 +30,7 @@ SimpleNativeMemoryMap::Create(Session &S, SimpleSymbolTable &ST,
                               const char *InstanceName,
                               SimpleSymbolTable::MutatorFn AddInterface) {
 
-  std::unique_ptr<SimpleNativeMemoryMap> Instance(new SimpleNativeMemoryMap());
+  std::unique_ptr<SimpleNativeMemoryMap> Instance(new SimpleNativeMemoryMap(S));
 
   SimpleSymbolTable SNMMST;
   if (auto Err = AddInterface(SNMMST))
@@ -48,8 +48,7 @@ SimpleNativeMemoryMap::Create(Session &S, SimpleSymbolTable &ST,
 
 void SimpleNativeMemoryMap::reserve(OnReserveCompleteFn &&OnComplete,
                                     size_t Size) {
-  // FIXME: Get page size from session object.
-  if (Size % (64 * 1024)) {
+  if (Size % S.processInfo().pageSize()) {
     return OnComplete(make_error<StringError>(
         (std::ostringstream()
          << "SimpleNativeMemoryMap error: reserved size " << std::hex << Size
@@ -225,9 +224,8 @@ void SimpleNativeMemoryMap::onShutdown(Service::OnCompleteFn OnComplete) {
 void SimpleNativeMemoryMap::releaseNext(OnReleaseCompleteFn &&OnComplete,
                                         std::vector<void *> Addrs,
                                         bool AnyError, Error LastErr) {
-  // TODO: Log error?
   if (LastErr) {
-    consumeError(std::move(LastErr));
+    S.reportError(std::move(LastErr));
     AnyError |= true;
   }
 
@@ -254,9 +252,8 @@ void SimpleNativeMemoryMap::releaseNext(OnReleaseCompleteFn &&OnComplete,
 void SimpleNativeMemoryMap::deinitializeNext(
     OnDeinitializeCompleteFn &&OnComplete, std::vector<void *> Addrs,
     bool AnyError, Error LastErr) {
-  // TODO: Log error?
   if (LastErr) {
-    consumeError(std::move(LastErr));
+    S.reportError(std::move(LastErr));
     AnyError |= true;
   }
 

--- a/orc-rt/unittests/SimpleNativeMemoryMapTest.cpp
+++ b/orc-rt/unittests/SimpleNativeMemoryMapTest.cpp
@@ -19,6 +19,8 @@
 #include "gtest/gtest.h"
 
 #include <cstring>
+#include <string>
+#include <vector>
 
 using namespace orc_rt;
 
@@ -150,6 +152,87 @@ TEST(SimpleNativeMemoryMapTest, FullPipelineForOneRWSegment) {
   EXPECT_EQ(SentinelValue1, 42U);
   EXPECT_EQ(SentinelValue2, 42U);
   EXPECT_EQ(SentinelValue3, 0U);
+
+  std::future<Error> ReleaseResult;
+  SNMM->releaseMultiple(waitFor(ReleaseResult), {Addr});
+  cantFail(ReleaseResult.get());
+}
+
+TEST(SimpleNativeMemoryMapTest, ReserveRejectsNonPageSizeMultiple) {
+  // Verify that reserve rejects sizes that aren't page-size multiples.
+  Session S(mockExecutorProcessInfo(), std::make_unique<NoDispatcher>(),
+            noErrors);
+  SimpleSymbolTable ThrowAway;
+  auto SNMM = cantFail(SimpleNativeMemoryMap::Create(S, ThrowAway));
+
+  std::future<Expected<void *>> ReserveResult;
+  SNMM->reserve(waitFor(ReserveResult), S.processInfo().pageSize() + 1);
+  auto Result = ReserveResult.get();
+  EXPECT_FALSE(!!Result);
+  consumeError(Result.takeError());
+}
+
+TEST(SimpleNativeMemoryMapTest, ReserveAcceptsPageSizeMultiple) {
+  // Verify that reserve accepts a size that's an exact page-size multiple.
+  Session S(mockExecutorProcessInfo(), std::make_unique<NoDispatcher>(),
+            noErrors);
+  SimpleSymbolTable ThrowAway;
+  auto SNMM = cantFail(SimpleNativeMemoryMap::Create(S, ThrowAway));
+
+  std::future<Expected<void *>> ReserveResult;
+  SNMM->reserve(waitFor(ReserveResult), S.processInfo().pageSize());
+  void *Addr = cantFail(ReserveResult.get());
+
+  std::future<Error> ReleaseResult;
+  SNMM->releaseMultiple(waitFor(ReleaseResult), {Addr});
+  cantFail(ReleaseResult.get());
+}
+
+TEST(SimpleNativeMemoryMapTest, ReleaseMultipleReportsErrors) {
+  // Test that releaseMultiple reports errors via Session::reportError
+  // when some addresses aren't recognized.
+  std::vector<std::string> Errors;
+  Session S(mockExecutorProcessInfo(), std::make_unique<NoDispatcher>(),
+            [&](Error Err) { Errors.push_back(toString(std::move(Err))); });
+  SimpleSymbolTable ThrowAway;
+  auto SNMM = cantFail(SimpleNativeMemoryMap::Create(S, ThrowAway));
+
+  // Try to release an address that was never reserved.
+  int Dummy;
+  std::future<Error> ReleaseResult;
+  SNMM->releaseMultiple(waitFor(ReleaseResult), {&Dummy});
+  auto Err = ReleaseResult.get();
+  EXPECT_TRUE(!!Err);
+  consumeError(std::move(Err));
+
+  // The error for the unrecognized address should have been reported
+  // via reportError (not silently consumed).
+  EXPECT_EQ(Errors.size(), 1U);
+}
+
+TEST(SimpleNativeMemoryMapTest, DeinitializeMultipleReportsErrors) {
+  // Test that deinitializeMultiple reports errors via Session::reportError
+  // when some addresses aren't recognized.
+  std::vector<std::string> Errors;
+  Session S(mockExecutorProcessInfo(), std::make_unique<NoDispatcher>(),
+            [&](Error Err) { Errors.push_back(toString(std::move(Err))); });
+  SimpleSymbolTable ThrowAway;
+  auto SNMM = cantFail(SimpleNativeMemoryMap::Create(S, ThrowAway));
+
+  // Reserve and initialize a slab so we have a valid context.
+  std::future<Expected<void *>> ReserveResult;
+  SNMM->reserve(waitFor(ReserveResult), 1024 * 1024 * 1024);
+  void *Addr = cantFail(ReserveResult.get());
+
+  // Try to deinitialize an address that was never initialized.
+  // This should fail and report the error.
+  std::future<Error> DeinitResult;
+  SNMM->deinitializeMultiple(waitFor(DeinitResult), {Addr});
+  auto Err = DeinitResult.get();
+  EXPECT_TRUE(!!Err);
+  consumeError(std::move(Err));
+
+  EXPECT_EQ(Errors.size(), 1U);
 
   std::future<Error> ReleaseResult;
   SNMM->releaseMultiple(waitFor(ReleaseResult), {Addr});


### PR DESCRIPTION
SimpleNativeMemoryMap now captures a reference to the Session that it was constructed for. This is used to fix some outstanding TODOs: using the real page size for the process, and reporting errors that were previously discarded.