### PR TITLE
[NFCI] [Serialization] Deduplicate DeclID properly

### DIFF
--- a/clang/lib/Serialization/ASTReaderInternals.h
+++ b/clang/lib/Serialization/ASTReaderInternals.h
@@ -61,7 +61,7 @@ public:
       // Just use a linear scan unless we have more than a few IDs.
       if (Found.empty() && !Data.empty()) {
         if (Data.size() <= 4) {
-          for (auto I : Found)
+          for (auto I : Data)
             if (I == ID)
               return;
           Data.push_back(ID);
@@ -183,7 +183,7 @@ public:
       // Just use a linear scan unless we have more than a few IDs.
       if (Found.empty() && !Data.empty()) {
         if (Data.size() <= 4) {
-          for (auto I : Found)
+          for (auto I : Data)
             if (I == Info)
               return;
           Data.push_back(Info);


### PR DESCRIPTION
In the original code, the operation to iterate Found is meaningless, as it is guarded by Found.empty(). So this is always a noop for 10 years.

According to the context, I believe the intention is to avoid duplicated DeclID to be in Data. So changing iterating Found to Data.

Just found by looking around the code.

This is not strictly NFC but NFC intentionally. I will be surprised if this breaks anything.