### PR TITLE
[AMDGPU] DPP implementations for Wave Reduction

### DIFF
--- a/llvm/lib/Target/AMDGPU/SIISelLowering.cpp
+++ b/llvm/lib/Target/AMDGPU/SIISelLowering.cpp
@@ -5660,6 +5660,13 @@ static unsigned getDPPOpcForWaveReduction(unsigned Opc,
     return AMDGPU::V_OR_B32_dpp;
   case AMDGPU::S_XOR_B32:
     return AMDGPU::V_XOR_B32_dpp;
+  case AMDGPU::V_ADD_F32_e64:
+  case AMDGPU::V_SUB_F32_e64:
+    return AMDGPU::V_ADD_F32_dpp;
+  case AMDGPU::V_MIN_F32_e64:
+    return AMDGPU::V_MIN_F32_dpp;
+  case AMDGPU::V_MAX_F32_e64:
+    return AMDGPU::V_MAX_F32_dpp;
   default:
     llvm_unreachable("unhandled lane op");
   }
@@ -6217,6 +6224,7 @@ static MachineBasicBlock *lowerWaveReduce(MachineInstr &MI,
     } else {
       assert(ST.hasDPP() && "Sub Target does not support DPP Operations");
 
+      bool IsFPOp = isFloatingPointWaveReduceOperation(Opc);
       Register SrcWithIdentity = MRI.createVirtualRegister(SrcRegClass);
       Register IdentityVGPR = MRI.createVirtualRegister(SrcRegClass);
       Register IdentitySGPR = MRI.createVirtualRegister(DstRegClass);
@@ -6249,14 +6257,39 @@ static MachineBasicBlock *lowerWaveReduce(MachineInstr &MI,
       unsigned DPPOpc = getDPPOpcForWaveReduction(Opc, ST);
       auto BuildDPPMachineInstr = [&](Register Dst, Register Src,
                                       unsigned DPPCtrl) {
-        BuildMI(BB, MI, DL, TII->get(DPPOpc), Dst)
-            .addReg(Src)     // old
-            .addReg(Src)     // src0
+        auto DPPInstr =
+            BuildMI(BB, MI, DL, TII->get(DPPOpc), Dst).addReg(Src); // old
+        if (IsFPOp)
+          DPPInstr.addImm(SISrcMods::NONE); // src0 modifier
+        DPPInstr.addReg(Src);               // src0
+        if (IsFPOp)
+          DPPInstr.addImm(SISrcMods::NONE); // src1 modifier
+        DPPInstr
             .addReg(Src)     // src1
             .addImm(DPPCtrl) // dpp-ctrl
             .addImm(0xf)     // row-mask
             .addImm(0xf)     // bank-mask
             .addImm(0);      // bound-control
+      };
+      auto BuildClampInstr = [&](Register Dst, Register Src0, Register Src1) {
+        auto ClampInstr = BuildMI(
+            BB, MI, DL,
+            TII->get(IsFPOp ? Opc
+                            : TII->getVALUOp(
+                                  Opc == AMDGPU::S_SUB_I32
+                                      ? static_cast<unsigned>(AMDGPU::S_ADD_I32)
+                                      : Opc)),
+            Dst);
+        if (IsFPOp)
+          ClampInstr.addImm(SISrcMods::NONE); // src0 mod
+        ClampInstr.addReg(Src0);              // src0
+        if (IsFPOp)
+          ClampInstr.addImm(SISrcMods::NONE); // src1 mod
+        ClampInstr.addReg(Src1);              // src1
+        if (TII->hasIntClamp(*ClampInstr) || TII->hasFPClamp(*ClampInstr))
+          ClampInstr.addImm(0); // clamp
+        if (IsFPOp)
+          ClampInstr.addImm(0); // omod
       };
       // DPP reduction
       BuildDPPMachineInstr(DPPRowShr1, SrcWithIdentity,
@@ -6285,17 +6318,7 @@ static MachineBasicBlock *lowerWaveReduce(MachineInstr &MI,
             .addReg(DPPRowShr8) // addr
             .addImm(0x1E0)      // swizzle offset (i16)
             .addImm(0x0);       // gds (i1)
-        auto ClampInstr =
-            BuildMI(BB, MI, DL,
-                    TII->get(TII->getVALUOp(
-                        Opc == AMDGPU::S_SUB_I32
-                            ? static_cast<unsigned>(AMDGPU::S_ADD_I32)
-                            : Opc)),
-                    RowBcast15)
-                .addReg(DPPRowShr8)
-                .addReg(SwizzledValue);
-        if (TII->hasIntClamp(*ClampInstr) || TII->hasFPClamp(*ClampInstr))
-          ClampInstr.addImm(0);
+        BuildClampInstr(RowBcast15, DPPRowShr8, SwizzledValue);
       }
       FinalDPPResult = RowBcast15;
       if (!IsWave32) {
@@ -6343,19 +6366,21 @@ static MachineBasicBlock *lowerWaveReduce(MachineInstr &MI,
               .addReg(PermuteByteOffset) // addr
               .addReg(RowBcast15)        // data
               .addImm(0);                // offset
-          auto ClampInstr =
-              BuildMI(BB, MI, DL,
-                      TII->get(TII->getVALUOp(
-                          Opc == AMDGPU::S_SUB_I32
-                              ? static_cast<unsigned>(AMDGPU::S_ADD_I32)
-                              : Opc)),
-                      RowBcast31)
-                  .addReg(RowBcast15)
-                  .addReg(PermutedValue);
-          if (TII->hasIntClamp(*ClampInstr) || TII->hasFPClamp(*ClampInstr))
-            ClampInstr.addImm(0);
+          BuildClampInstr(RowBcast31, RowBcast15, PermutedValue);
         }
         FinalDPPResult = RowBcast31;
+      }
+      if (Opc == AMDGPU::V_SUB_F32_e64) {
+        Register NegatedValVGPR =
+            MRI.createVirtualRegister(&AMDGPU::VGPR_32RegClass);
+        BuildMI(BB, MI, DL, TII->get(AMDGPU::V_SUB_F32_e64), NegatedValVGPR)
+            .addImm(SISrcMods::NONE)                    // src0 mods
+            .addReg(IdentityVGPR)                       // src0
+            .addImm(SISrcMods::NONE)                    // src1 mods
+            .addReg(IsWave32 ? RowBcast15 : RowBcast31) // src1
+            .addImm(SISrcMods::NONE)                    // clamp
+            .addImm(SISrcMods::NONE);                   // omod
+        FinalDPPResult = NegatedValVGPR;
       }
       // The final reduced value is in the last lane.
       BuildMI(BB, MI, DL, TII->get(AMDGPU::V_READLANE_B32), ReducedValSGPR)

--- a/llvm/lib/Target/AMDGPU/SIISelLowering.cpp
+++ b/llvm/lib/Target/AMDGPU/SIISelLowering.cpp
@@ -6272,14 +6272,13 @@ static MachineBasicBlock *lowerWaveReduce(MachineInstr &MI,
             .addImm(0);      // bound-control
       };
       auto BuildClampInstr = [&](Register Dst, Register Src0, Register Src1) {
-        auto ClampInstr = BuildMI(
-            BB, MI, DL,
-            TII->get(IsFPOp ? Opc
-                            : TII->getVALUOp(
-                                  Opc == AMDGPU::S_SUB_I32
-                                      ? static_cast<unsigned>(AMDGPU::S_ADD_I32)
-                                      : Opc)),
-            Dst);
+        unsigned ClampOpc = Opc;
+        if (!IsFPOp) {
+          if (Opc == AMDGPU::S_SUB_I32)
+            ClampOpc = AMDGPU::S_ADD_I32;
+          ClampOpc = TII->getVALUOp(ClampOpc);
+        }
+        auto ClampInstr = BuildMI(BB, MI, DL, TII->get(ClampOpc), Dst);
         if (IsFPOp)
           ClampInstr.addImm(SISrcMods::NONE); // src0 mod
         ClampInstr.addReg(Src0);              // src0

--- a/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.reduce.fadd.ll
+++ b/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.reduce.fadd.ll
@@ -491,6 +491,465 @@ entry:
   ret void
 }
 
+define void @divergent_value_float_dpp(ptr addrspace(1) %out, float %id.x) {
+; GFX8DAGISEL-LABEL: divergent_value_float_dpp:
+; GFX8DAGISEL:       ; %bb.0: ; %entry
+; GFX8DAGISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX8DAGISEL-NEXT:    s_xor_saveexec_b64 s[4:5], -1
+; GFX8DAGISEL-NEXT:    buffer_store_dword v3, off, s[0:3], s32 ; 4-byte Folded Spill
+; GFX8DAGISEL-NEXT:    s_mov_b64 exec, s[4:5]
+; GFX8DAGISEL-NEXT:    s_or_saveexec_b64 s[4:5], -1
+; GFX8DAGISEL-NEXT:    v_bfrev_b32_e32 v3, 1
+; GFX8DAGISEL-NEXT:    v_cndmask_b32_e64 v3, v3, v2, s[4:5]
+; GFX8DAGISEL-NEXT:    s_nop 1
+; GFX8DAGISEL-NEXT:    v_add_f32_dpp v3, v3, v3 row_shr:1 row_mask:0xf bank_mask:0xf
+; GFX8DAGISEL-NEXT:    s_nop 1
+; GFX8DAGISEL-NEXT:    v_add_f32_dpp v3, v3, v3 row_shr:2 row_mask:0xf bank_mask:0xf
+; GFX8DAGISEL-NEXT:    s_nop 1
+; GFX8DAGISEL-NEXT:    v_add_f32_dpp v3, v3, v3 row_shr:4 row_mask:0xf bank_mask:0xf
+; GFX8DAGISEL-NEXT:    s_nop 1
+; GFX8DAGISEL-NEXT:    v_add_f32_dpp v3, v3, v3 row_shr:8 row_mask:0xf bank_mask:0xf
+; GFX8DAGISEL-NEXT:    s_nop 1
+; GFX8DAGISEL-NEXT:    v_add_f32_dpp v3, v3, v3 row_bcast:15 row_mask:0xf bank_mask:0xf
+; GFX8DAGISEL-NEXT:    s_nop 1
+; GFX8DAGISEL-NEXT:    v_add_f32_dpp v3, v3, v3 row_bcast:31 row_mask:0xf bank_mask:0xf
+; GFX8DAGISEL-NEXT:    v_readlane_b32 s6, v3, 63
+; GFX8DAGISEL-NEXT:    s_mov_b64 exec, s[4:5]
+; GFX8DAGISEL-NEXT:    v_mov_b32_e32 v2, s6
+; GFX8DAGISEL-NEXT:    flat_store_dword v[0:1], v2
+; GFX8DAGISEL-NEXT:    s_xor_saveexec_b64 s[4:5], -1
+; GFX8DAGISEL-NEXT:    buffer_load_dword v3, off, s[0:3], s32 ; 4-byte Folded Reload
+; GFX8DAGISEL-NEXT:    s_mov_b64 exec, s[4:5]
+; GFX8DAGISEL-NEXT:    s_waitcnt vmcnt(0)
+; GFX8DAGISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX8GISEL-LABEL: divergent_value_float_dpp:
+; GFX8GISEL:       ; %bb.0: ; %entry
+; GFX8GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX8GISEL-NEXT:    s_xor_saveexec_b64 s[4:5], -1
+; GFX8GISEL-NEXT:    buffer_store_dword v3, off, s[0:3], s32 ; 4-byte Folded Spill
+; GFX8GISEL-NEXT:    s_mov_b64 exec, s[4:5]
+; GFX8GISEL-NEXT:    s_or_saveexec_b64 s[4:5], -1
+; GFX8GISEL-NEXT:    v_bfrev_b32_e32 v3, 1
+; GFX8GISEL-NEXT:    v_cndmask_b32_e64 v3, v3, v2, s[4:5]
+; GFX8GISEL-NEXT:    s_nop 1
+; GFX8GISEL-NEXT:    v_add_f32_dpp v3, v3, v3 row_shr:1 row_mask:0xf bank_mask:0xf
+; GFX8GISEL-NEXT:    s_nop 1
+; GFX8GISEL-NEXT:    v_add_f32_dpp v3, v3, v3 row_shr:2 row_mask:0xf bank_mask:0xf
+; GFX8GISEL-NEXT:    s_nop 1
+; GFX8GISEL-NEXT:    v_add_f32_dpp v3, v3, v3 row_shr:4 row_mask:0xf bank_mask:0xf
+; GFX8GISEL-NEXT:    s_nop 1
+; GFX8GISEL-NEXT:    v_add_f32_dpp v3, v3, v3 row_shr:8 row_mask:0xf bank_mask:0xf
+; GFX8GISEL-NEXT:    s_nop 1
+; GFX8GISEL-NEXT:    v_add_f32_dpp v3, v3, v3 row_bcast:15 row_mask:0xf bank_mask:0xf
+; GFX8GISEL-NEXT:    s_nop 1
+; GFX8GISEL-NEXT:    v_add_f32_dpp v3, v3, v3 row_bcast:31 row_mask:0xf bank_mask:0xf
+; GFX8GISEL-NEXT:    v_readlane_b32 s6, v3, 63
+; GFX8GISEL-NEXT:    s_mov_b64 exec, s[4:5]
+; GFX8GISEL-NEXT:    v_mov_b32_e32 v2, s6
+; GFX8GISEL-NEXT:    flat_store_dword v[0:1], v2
+; GFX8GISEL-NEXT:    s_xor_saveexec_b64 s[4:5], -1
+; GFX8GISEL-NEXT:    buffer_load_dword v3, off, s[0:3], s32 ; 4-byte Folded Reload
+; GFX8GISEL-NEXT:    s_mov_b64 exec, s[4:5]
+; GFX8GISEL-NEXT:    s_waitcnt vmcnt(0)
+; GFX8GISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX9DAGISEL-LABEL: divergent_value_float_dpp:
+; GFX9DAGISEL:       ; %bb.0: ; %entry
+; GFX9DAGISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9DAGISEL-NEXT:    s_xor_saveexec_b64 s[4:5], -1
+; GFX9DAGISEL-NEXT:    buffer_store_dword v3, off, s[0:3], s32 ; 4-byte Folded Spill
+; GFX9DAGISEL-NEXT:    s_mov_b64 exec, s[4:5]
+; GFX9DAGISEL-NEXT:    s_or_saveexec_b64 s[4:5], -1
+; GFX9DAGISEL-NEXT:    v_bfrev_b32_e32 v3, 1
+; GFX9DAGISEL-NEXT:    v_cndmask_b32_e64 v3, v3, v2, s[4:5]
+; GFX9DAGISEL-NEXT:    s_nop 1
+; GFX9DAGISEL-NEXT:    v_add_f32_dpp v3, v3, v3 row_shr:1 row_mask:0xf bank_mask:0xf
+; GFX9DAGISEL-NEXT:    s_nop 1
+; GFX9DAGISEL-NEXT:    v_add_f32_dpp v3, v3, v3 row_shr:2 row_mask:0xf bank_mask:0xf
+; GFX9DAGISEL-NEXT:    s_nop 1
+; GFX9DAGISEL-NEXT:    v_add_f32_dpp v3, v3, v3 row_shr:4 row_mask:0xf bank_mask:0xf
+; GFX9DAGISEL-NEXT:    s_nop 1
+; GFX9DAGISEL-NEXT:    v_add_f32_dpp v3, v3, v3 row_shr:8 row_mask:0xf bank_mask:0xf
+; GFX9DAGISEL-NEXT:    s_nop 1
+; GFX9DAGISEL-NEXT:    v_add_f32_dpp v3, v3, v3 row_bcast:15 row_mask:0xf bank_mask:0xf
+; GFX9DAGISEL-NEXT:    s_nop 1
+; GFX9DAGISEL-NEXT:    v_add_f32_dpp v3, v3, v3 row_bcast:31 row_mask:0xf bank_mask:0xf
+; GFX9DAGISEL-NEXT:    v_readlane_b32 s6, v3, 63
+; GFX9DAGISEL-NEXT:    s_mov_b64 exec, s[4:5]
+; GFX9DAGISEL-NEXT:    v_mov_b32_e32 v2, s6
+; GFX9DAGISEL-NEXT:    global_store_dword v[0:1], v2, off
+; GFX9DAGISEL-NEXT:    s_xor_saveexec_b64 s[4:5], -1
+; GFX9DAGISEL-NEXT:    buffer_load_dword v3, off, s[0:3], s32 ; 4-byte Folded Reload
+; GFX9DAGISEL-NEXT:    s_mov_b64 exec, s[4:5]
+; GFX9DAGISEL-NEXT:    s_waitcnt vmcnt(0)
+; GFX9DAGISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX9GISEL-LABEL: divergent_value_float_dpp:
+; GFX9GISEL:       ; %bb.0: ; %entry
+; GFX9GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9GISEL-NEXT:    s_xor_saveexec_b64 s[4:5], -1
+; GFX9GISEL-NEXT:    buffer_store_dword v3, off, s[0:3], s32 ; 4-byte Folded Spill
+; GFX9GISEL-NEXT:    s_mov_b64 exec, s[4:5]
+; GFX9GISEL-NEXT:    s_or_saveexec_b64 s[4:5], -1
+; GFX9GISEL-NEXT:    v_bfrev_b32_e32 v3, 1
+; GFX9GISEL-NEXT:    v_cndmask_b32_e64 v3, v3, v2, s[4:5]
+; GFX9GISEL-NEXT:    s_nop 1
+; GFX9GISEL-NEXT:    v_add_f32_dpp v3, v3, v3 row_shr:1 row_mask:0xf bank_mask:0xf
+; GFX9GISEL-NEXT:    s_nop 1
+; GFX9GISEL-NEXT:    v_add_f32_dpp v3, v3, v3 row_shr:2 row_mask:0xf bank_mask:0xf
+; GFX9GISEL-NEXT:    s_nop 1
+; GFX9GISEL-NEXT:    v_add_f32_dpp v3, v3, v3 row_shr:4 row_mask:0xf bank_mask:0xf
+; GFX9GISEL-NEXT:    s_nop 1
+; GFX9GISEL-NEXT:    v_add_f32_dpp v3, v3, v3 row_shr:8 row_mask:0xf bank_mask:0xf
+; GFX9GISEL-NEXT:    s_nop 1
+; GFX9GISEL-NEXT:    v_add_f32_dpp v3, v3, v3 row_bcast:15 row_mask:0xf bank_mask:0xf
+; GFX9GISEL-NEXT:    s_nop 1
+; GFX9GISEL-NEXT:    v_add_f32_dpp v3, v3, v3 row_bcast:31 row_mask:0xf bank_mask:0xf
+; GFX9GISEL-NEXT:    v_readlane_b32 s6, v3, 63
+; GFX9GISEL-NEXT:    s_mov_b64 exec, s[4:5]
+; GFX9GISEL-NEXT:    v_mov_b32_e32 v2, s6
+; GFX9GISEL-NEXT:    global_store_dword v[0:1], v2, off
+; GFX9GISEL-NEXT:    s_xor_saveexec_b64 s[4:5], -1
+; GFX9GISEL-NEXT:    buffer_load_dword v3, off, s[0:3], s32 ; 4-byte Folded Reload
+; GFX9GISEL-NEXT:    s_mov_b64 exec, s[4:5]
+; GFX9GISEL-NEXT:    s_waitcnt vmcnt(0)
+; GFX9GISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX1064DAGISEL-LABEL: divergent_value_float_dpp:
+; GFX1064DAGISEL:       ; %bb.0: ; %entry
+; GFX1064DAGISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX1064DAGISEL-NEXT:    s_xor_saveexec_b64 s[4:5], -1
+; GFX1064DAGISEL-NEXT:    buffer_store_dword v3, off, s[0:3], s32 ; 4-byte Folded Spill
+; GFX1064DAGISEL-NEXT:    buffer_store_dword v4, off, s[0:3], s32 offset:4 ; 4-byte Folded Spill
+; GFX1064DAGISEL-NEXT:    buffer_store_dword v5, off, s[0:3], s32 offset:8 ; 4-byte Folded Spill
+; GFX1064DAGISEL-NEXT:    s_waitcnt_depctr depctr_vm_vsrc(0)
+; GFX1064DAGISEL-NEXT:    s_mov_b64 exec, s[4:5]
+; GFX1064DAGISEL-NEXT:    s_or_saveexec_b64 s[4:5], -1
+; GFX1064DAGISEL-NEXT:    v_cndmask_b32_e64 v3, 0x80000000, v2, s[4:5]
+; GFX1064DAGISEL-NEXT:    v_mbcnt_lo_u32_b32 v5, -1, 0
+; GFX1064DAGISEL-NEXT:    v_add_f32_dpp v3, v3, v3 row_shr:1 row_mask:0xf bank_mask:0xf
+; GFX1064DAGISEL-NEXT:    v_mbcnt_hi_u32_b32 v5, -1, v5
+; GFX1064DAGISEL-NEXT:    v_add_f32_dpp v3, v3, v3 row_shr:2 row_mask:0xf bank_mask:0xf
+; GFX1064DAGISEL-NEXT:    v_add_nc_u32_e32 v5, 32, v5
+; GFX1064DAGISEL-NEXT:    v_add_f32_dpp v3, v3, v3 row_shr:4 row_mask:0xf bank_mask:0xf
+; GFX1064DAGISEL-NEXT:    v_mul_lo_u32 v5, 4, v5
+; GFX1064DAGISEL-NEXT:    v_add_f32_dpp v3, v3, v3 row_shr:8 row_mask:0xf bank_mask:0xf
+; GFX1064DAGISEL-NEXT:    ds_swizzle_b32 v4, v3 offset:swizzle(BROADCAST,32,15)
+; GFX1064DAGISEL-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX1064DAGISEL-NEXT:    v_add_f32_e32 v3, v3, v4
+; GFX1064DAGISEL-NEXT:    ds_permute_b32 v4, v5, v3
+; GFX1064DAGISEL-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX1064DAGISEL-NEXT:    v_add_f32_e32 v3, v3, v4
+; GFX1064DAGISEL-NEXT:    v_readlane_b32 s6, v3, 63
+; GFX1064DAGISEL-NEXT:    s_mov_b64 exec, s[4:5]
+; GFX1064DAGISEL-NEXT:    v_mov_b32_e32 v2, s6
+; GFX1064DAGISEL-NEXT:    global_store_dword v[0:1], v2, off
+; GFX1064DAGISEL-NEXT:    s_xor_saveexec_b64 s[4:5], -1
+; GFX1064DAGISEL-NEXT:    s_clause 0x2 ; 12-byte Folded Reload
+; GFX1064DAGISEL-NEXT:    buffer_load_dword v3, off, s[0:3], s32
+; GFX1064DAGISEL-NEXT:    buffer_load_dword v4, off, s[0:3], s32 offset:4
+; GFX1064DAGISEL-NEXT:    buffer_load_dword v5, off, s[0:3], s32 offset:8
+; GFX1064DAGISEL-NEXT:    s_waitcnt_depctr depctr_vm_vsrc(0)
+; GFX1064DAGISEL-NEXT:    s_mov_b64 exec, s[4:5]
+; GFX1064DAGISEL-NEXT:    s_waitcnt vmcnt(0)
+; GFX1064DAGISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX1064GISEL-LABEL: divergent_value_float_dpp:
+; GFX1064GISEL:       ; %bb.0: ; %entry
+; GFX1064GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX1064GISEL-NEXT:    s_xor_saveexec_b64 s[4:5], -1
+; GFX1064GISEL-NEXT:    buffer_store_dword v3, off, s[0:3], s32 ; 4-byte Folded Spill
+; GFX1064GISEL-NEXT:    buffer_store_dword v4, off, s[0:3], s32 offset:4 ; 4-byte Folded Spill
+; GFX1064GISEL-NEXT:    buffer_store_dword v5, off, s[0:3], s32 offset:8 ; 4-byte Folded Spill
+; GFX1064GISEL-NEXT:    s_waitcnt_depctr depctr_vm_vsrc(0)
+; GFX1064GISEL-NEXT:    s_mov_b64 exec, s[4:5]
+; GFX1064GISEL-NEXT:    s_or_saveexec_b64 s[4:5], -1
+; GFX1064GISEL-NEXT:    v_cndmask_b32_e64 v3, 0x80000000, v2, s[4:5]
+; GFX1064GISEL-NEXT:    v_mbcnt_lo_u32_b32 v5, -1, 0
+; GFX1064GISEL-NEXT:    v_add_f32_dpp v3, v3, v3 row_shr:1 row_mask:0xf bank_mask:0xf
+; GFX1064GISEL-NEXT:    v_mbcnt_hi_u32_b32 v5, -1, v5
+; GFX1064GISEL-NEXT:    v_add_f32_dpp v3, v3, v3 row_shr:2 row_mask:0xf bank_mask:0xf
+; GFX1064GISEL-NEXT:    v_add_nc_u32_e32 v5, 32, v5
+; GFX1064GISEL-NEXT:    v_add_f32_dpp v3, v3, v3 row_shr:4 row_mask:0xf bank_mask:0xf
+; GFX1064GISEL-NEXT:    v_mul_lo_u32 v5, 4, v5
+; GFX1064GISEL-NEXT:    v_add_f32_dpp v3, v3, v3 row_shr:8 row_mask:0xf bank_mask:0xf
+; GFX1064GISEL-NEXT:    ds_swizzle_b32 v4, v3 offset:swizzle(BROADCAST,32,15)
+; GFX1064GISEL-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX1064GISEL-NEXT:    v_add_f32_e32 v3, v3, v4
+; GFX1064GISEL-NEXT:    ds_permute_b32 v4, v5, v3
+; GFX1064GISEL-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX1064GISEL-NEXT:    v_add_f32_e32 v3, v3, v4
+; GFX1064GISEL-NEXT:    v_readlane_b32 s6, v3, 63
+; GFX1064GISEL-NEXT:    s_mov_b64 exec, s[4:5]
+; GFX1064GISEL-NEXT:    v_mov_b32_e32 v2, s6
+; GFX1064GISEL-NEXT:    global_store_dword v[0:1], v2, off
+; GFX1064GISEL-NEXT:    s_xor_saveexec_b64 s[4:5], -1
+; GFX1064GISEL-NEXT:    s_clause 0x2 ; 12-byte Folded Reload
+; GFX1064GISEL-NEXT:    buffer_load_dword v3, off, s[0:3], s32
+; GFX1064GISEL-NEXT:    buffer_load_dword v4, off, s[0:3], s32 offset:4
+; GFX1064GISEL-NEXT:    buffer_load_dword v5, off, s[0:3], s32 offset:8
+; GFX1064GISEL-NEXT:    s_waitcnt_depctr depctr_vm_vsrc(0)
+; GFX1064GISEL-NEXT:    s_mov_b64 exec, s[4:5]
+; GFX1064GISEL-NEXT:    s_waitcnt vmcnt(0)
+; GFX1064GISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX1032DAGISEL-LABEL: divergent_value_float_dpp:
+; GFX1032DAGISEL:       ; %bb.0: ; %entry
+; GFX1032DAGISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX1032DAGISEL-NEXT:    s_xor_saveexec_b32 s4, -1
+; GFX1032DAGISEL-NEXT:    buffer_store_dword v3, off, s[0:3], s32 ; 4-byte Folded Spill
+; GFX1032DAGISEL-NEXT:    buffer_store_dword v4, off, s[0:3], s32 offset:4 ; 4-byte Folded Spill
+; GFX1032DAGISEL-NEXT:    s_waitcnt_depctr depctr_vm_vsrc(0)
+; GFX1032DAGISEL-NEXT:    s_mov_b32 exec_lo, s4
+; GFX1032DAGISEL-NEXT:    s_or_saveexec_b32 s4, -1
+; GFX1032DAGISEL-NEXT:    v_cndmask_b32_e64 v3, 0x80000000, v2, s4
+; GFX1032DAGISEL-NEXT:    v_add_f32_dpp v3, v3, v3 row_shr:1 row_mask:0xf bank_mask:0xf
+; GFX1032DAGISEL-NEXT:    v_add_f32_dpp v3, v3, v3 row_shr:2 row_mask:0xf bank_mask:0xf
+; GFX1032DAGISEL-NEXT:    v_add_f32_dpp v3, v3, v3 row_shr:4 row_mask:0xf bank_mask:0xf
+; GFX1032DAGISEL-NEXT:    v_add_f32_dpp v3, v3, v3 row_shr:8 row_mask:0xf bank_mask:0xf
+; GFX1032DAGISEL-NEXT:    ds_swizzle_b32 v4, v3 offset:swizzle(BROADCAST,32,15)
+; GFX1032DAGISEL-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX1032DAGISEL-NEXT:    v_add_f32_e32 v3, v3, v4
+; GFX1032DAGISEL-NEXT:    v_readlane_b32 s5, v3, 31
+; GFX1032DAGISEL-NEXT:    s_mov_b32 exec_lo, s4
+; GFX1032DAGISEL-NEXT:    v_mov_b32_e32 v2, s5
+; GFX1032DAGISEL-NEXT:    global_store_dword v[0:1], v2, off
+; GFX1032DAGISEL-NEXT:    s_xor_saveexec_b32 s4, -1
+; GFX1032DAGISEL-NEXT:    s_clause 0x1 ; 8-byte Folded Reload
+; GFX1032DAGISEL-NEXT:    buffer_load_dword v3, off, s[0:3], s32
+; GFX1032DAGISEL-NEXT:    buffer_load_dword v4, off, s[0:3], s32 offset:4
+; GFX1032DAGISEL-NEXT:    s_waitcnt_depctr depctr_vm_vsrc(0)
+; GFX1032DAGISEL-NEXT:    s_mov_b32 exec_lo, s4
+; GFX1032DAGISEL-NEXT:    s_waitcnt vmcnt(0)
+; GFX1032DAGISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX1032GISEL-LABEL: divergent_value_float_dpp:
+; GFX1032GISEL:       ; %bb.0: ; %entry
+; GFX1032GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX1032GISEL-NEXT:    s_xor_saveexec_b32 s4, -1
+; GFX1032GISEL-NEXT:    buffer_store_dword v3, off, s[0:3], s32 ; 4-byte Folded Spill
+; GFX1032GISEL-NEXT:    buffer_store_dword v4, off, s[0:3], s32 offset:4 ; 4-byte Folded Spill
+; GFX1032GISEL-NEXT:    s_waitcnt_depctr depctr_vm_vsrc(0)
+; GFX1032GISEL-NEXT:    s_mov_b32 exec_lo, s4
+; GFX1032GISEL-NEXT:    s_or_saveexec_b32 s4, -1
+; GFX1032GISEL-NEXT:    v_cndmask_b32_e64 v3, 0x80000000, v2, s4
+; GFX1032GISEL-NEXT:    v_add_f32_dpp v3, v3, v3 row_shr:1 row_mask:0xf bank_mask:0xf
+; GFX1032GISEL-NEXT:    v_add_f32_dpp v3, v3, v3 row_shr:2 row_mask:0xf bank_mask:0xf
+; GFX1032GISEL-NEXT:    v_add_f32_dpp v3, v3, v3 row_shr:4 row_mask:0xf bank_mask:0xf
+; GFX1032GISEL-NEXT:    v_add_f32_dpp v3, v3, v3 row_shr:8 row_mask:0xf bank_mask:0xf
+; GFX1032GISEL-NEXT:    ds_swizzle_b32 v4, v3 offset:swizzle(BROADCAST,32,15)
+; GFX1032GISEL-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX1032GISEL-NEXT:    v_add_f32_e32 v3, v3, v4
+; GFX1032GISEL-NEXT:    v_readlane_b32 s5, v3, 31
+; GFX1032GISEL-NEXT:    s_mov_b32 exec_lo, s4
+; GFX1032GISEL-NEXT:    v_mov_b32_e32 v2, s5
+; GFX1032GISEL-NEXT:    global_store_dword v[0:1], v2, off
+; GFX1032GISEL-NEXT:    s_xor_saveexec_b32 s4, -1
+; GFX1032GISEL-NEXT:    s_clause 0x1 ; 8-byte Folded Reload
+; GFX1032GISEL-NEXT:    buffer_load_dword v3, off, s[0:3], s32
+; GFX1032GISEL-NEXT:    buffer_load_dword v4, off, s[0:3], s32 offset:4
+; GFX1032GISEL-NEXT:    s_waitcnt_depctr depctr_vm_vsrc(0)
+; GFX1032GISEL-NEXT:    s_mov_b32 exec_lo, s4
+; GFX1032GISEL-NEXT:    s_waitcnt vmcnt(0)
+; GFX1032GISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX1164DAGISEL-LABEL: divergent_value_float_dpp:
+; GFX1164DAGISEL:       ; %bb.0: ; %entry
+; GFX1164DAGISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX1164DAGISEL-NEXT:    s_xor_saveexec_b64 s[0:1], -1
+; GFX1164DAGISEL-NEXT:    s_clause 0x2 ; 12-byte Folded Spill
+; GFX1164DAGISEL-NEXT:    scratch_store_b32 off, v3, s32
+; GFX1164DAGISEL-NEXT:    scratch_store_b32 off, v4, s32 offset:4
+; GFX1164DAGISEL-NEXT:    scratch_store_b32 off, v5, s32 offset:8
+; GFX1164DAGISEL-NEXT:    s_mov_b64 exec, s[0:1]
+; GFX1164DAGISEL-NEXT:    s_or_saveexec_b64 s[0:1], -1
+; GFX1164DAGISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_1) | instid1(VALU_DEP_2)
+; GFX1164DAGISEL-NEXT:    v_cndmask_b32_e64 v3, 0x80000000, v2, s[0:1]
+; GFX1164DAGISEL-NEXT:    v_mbcnt_lo_u32_b32 v5, -1, 0
+; GFX1164DAGISEL-NEXT:    v_add_f32_dpp v3, v3, v3 row_shr:1 row_mask:0xf bank_mask:0xf
+; GFX1164DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GFX1164DAGISEL-NEXT:    v_mbcnt_hi_u32_b32 v5, -1, v5
+; GFX1164DAGISEL-NEXT:    v_add_f32_dpp v3, v3, v3 row_shr:2 row_mask:0xf bank_mask:0xf
+; GFX1164DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GFX1164DAGISEL-NEXT:    v_add_nc_u32_e32 v5, 32, v5
+; GFX1164DAGISEL-NEXT:    v_add_f32_dpp v3, v3, v3 row_shr:4 row_mask:0xf bank_mask:0xf
+; GFX1164DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GFX1164DAGISEL-NEXT:    v_mul_lo_u32 v5, 4, v5
+; GFX1164DAGISEL-NEXT:    v_add_f32_dpp v3, v3, v3 row_shr:8 row_mask:0xf bank_mask:0xf
+; GFX1164DAGISEL-NEXT:    ds_swizzle_b32 v4, v3 offset:swizzle(BROADCAST,32,15)
+; GFX1164DAGISEL-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX1164DAGISEL-NEXT:    v_add_f32_e32 v3, v3, v4
+; GFX1164DAGISEL-NEXT:    ds_permute_b32 v4, v5, v3
+; GFX1164DAGISEL-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX1164DAGISEL-NEXT:    v_add_f32_e32 v3, v3, v4
+; GFX1164DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1164DAGISEL-NEXT:    v_readlane_b32 s2, v3, 63
+; GFX1164DAGISEL-NEXT:    s_mov_b64 exec, s[0:1]
+; GFX1164DAGISEL-NEXT:    v_mov_b32_e32 v2, s2
+; GFX1164DAGISEL-NEXT:    global_store_b32 v[0:1], v2, off
+; GFX1164DAGISEL-NEXT:    s_xor_saveexec_b64 s[0:1], -1
+; GFX1164DAGISEL-NEXT:    s_waitcnt_depctr depctr_sa_sdst(0)
+; GFX1164DAGISEL-NEXT:    s_clause 0x2 ; 12-byte Folded Reload
+; GFX1164DAGISEL-NEXT:    scratch_load_b32 v3, off, s32
+; GFX1164DAGISEL-NEXT:    scratch_load_b32 v4, off, s32 offset:4
+; GFX1164DAGISEL-NEXT:    scratch_load_b32 v5, off, s32 offset:8
+; GFX1164DAGISEL-NEXT:    s_mov_b64 exec, s[0:1]
+; GFX1164DAGISEL-NEXT:    s_waitcnt vmcnt(0)
+; GFX1164DAGISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX1164GISEL-LABEL: divergent_value_float_dpp:
+; GFX1164GISEL:       ; %bb.0: ; %entry
+; GFX1164GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX1164GISEL-NEXT:    s_xor_saveexec_b64 s[0:1], -1
+; GFX1164GISEL-NEXT:    s_clause 0x2 ; 12-byte Folded Spill
+; GFX1164GISEL-NEXT:    scratch_store_b32 off, v3, s32
+; GFX1164GISEL-NEXT:    scratch_store_b32 off, v4, s32 offset:4
+; GFX1164GISEL-NEXT:    scratch_store_b32 off, v5, s32 offset:8
+; GFX1164GISEL-NEXT:    s_mov_b64 exec, s[0:1]
+; GFX1164GISEL-NEXT:    s_or_saveexec_b64 s[0:1], -1
+; GFX1164GISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_1) | instid1(VALU_DEP_2)
+; GFX1164GISEL-NEXT:    v_cndmask_b32_e64 v3, 0x80000000, v2, s[0:1]
+; GFX1164GISEL-NEXT:    v_mbcnt_lo_u32_b32 v5, -1, 0
+; GFX1164GISEL-NEXT:    v_add_f32_dpp v3, v3, v3 row_shr:1 row_mask:0xf bank_mask:0xf
+; GFX1164GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GFX1164GISEL-NEXT:    v_mbcnt_hi_u32_b32 v5, -1, v5
+; GFX1164GISEL-NEXT:    v_add_f32_dpp v3, v3, v3 row_shr:2 row_mask:0xf bank_mask:0xf
+; GFX1164GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GFX1164GISEL-NEXT:    v_add_nc_u32_e32 v5, 32, v5
+; GFX1164GISEL-NEXT:    v_add_f32_dpp v3, v3, v3 row_shr:4 row_mask:0xf bank_mask:0xf
+; GFX1164GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GFX1164GISEL-NEXT:    v_mul_lo_u32 v5, 4, v5
+; GFX1164GISEL-NEXT:    v_add_f32_dpp v3, v3, v3 row_shr:8 row_mask:0xf bank_mask:0xf
+; GFX1164GISEL-NEXT:    ds_swizzle_b32 v4, v3 offset:swizzle(BROADCAST,32,15)
+; GFX1164GISEL-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX1164GISEL-NEXT:    v_add_f32_e32 v3, v3, v4
+; GFX1164GISEL-NEXT:    ds_permute_b32 v4, v5, v3
+; GFX1164GISEL-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX1164GISEL-NEXT:    v_add_f32_e32 v3, v3, v4
+; GFX1164GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1164GISEL-NEXT:    v_readlane_b32 s2, v3, 63
+; GFX1164GISEL-NEXT:    s_mov_b64 exec, s[0:1]
+; GFX1164GISEL-NEXT:    v_mov_b32_e32 v2, s2
+; GFX1164GISEL-NEXT:    global_store_b32 v[0:1], v2, off
+; GFX1164GISEL-NEXT:    s_xor_saveexec_b64 s[0:1], -1
+; GFX1164GISEL-NEXT:    s_waitcnt_depctr depctr_sa_sdst(0)
+; GFX1164GISEL-NEXT:    s_clause 0x2 ; 12-byte Folded Reload
+; GFX1164GISEL-NEXT:    scratch_load_b32 v3, off, s32
+; GFX1164GISEL-NEXT:    scratch_load_b32 v4, off, s32 offset:4
+; GFX1164GISEL-NEXT:    scratch_load_b32 v5, off, s32 offset:8
+; GFX1164GISEL-NEXT:    s_mov_b64 exec, s[0:1]
+; GFX1164GISEL-NEXT:    s_waitcnt vmcnt(0)
+; GFX1164GISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX1132DAGISEL-LABEL: divergent_value_float_dpp:
+; GFX1132DAGISEL:       ; %bb.0: ; %entry
+; GFX1132DAGISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX1132DAGISEL-NEXT:    s_xor_saveexec_b32 s0, -1
+; GFX1132DAGISEL-NEXT:    s_clause 0x1 ; 8-byte Folded Spill
+; GFX1132DAGISEL-NEXT:    scratch_store_b32 off, v3, s32
+; GFX1132DAGISEL-NEXT:    scratch_store_b32 off, v4, s32 offset:4
+; GFX1132DAGISEL-NEXT:    s_mov_b32 exec_lo, s0
+; GFX1132DAGISEL-NEXT:    s_or_saveexec_b32 s0, -1
+; GFX1132DAGISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1132DAGISEL-NEXT:    v_cndmask_b32_e64 v3, 0x80000000, v2, s0
+; GFX1132DAGISEL-NEXT:    v_add_f32_dpp v3, v3, v3 row_shr:1 row_mask:0xf bank_mask:0xf
+; GFX1132DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1132DAGISEL-NEXT:    v_add_f32_dpp v3, v3, v3 row_shr:2 row_mask:0xf bank_mask:0xf
+; GFX1132DAGISEL-NEXT:    v_add_f32_dpp v3, v3, v3 row_shr:4 row_mask:0xf bank_mask:0xf
+; GFX1132DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_3) | instid1(VALU_DEP_1)
+; GFX1132DAGISEL-NEXT:    v_add_f32_dpp v3, v3, v3 row_shr:8 row_mask:0xf bank_mask:0xf
+; GFX1132DAGISEL-NEXT:    ds_swizzle_b32 v4, v3 offset:swizzle(BROADCAST,32,15)
+; GFX1132DAGISEL-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX1132DAGISEL-NEXT:    v_add_f32_e32 v3, v3, v4
+; GFX1132DAGISEL-NEXT:    v_readlane_b32 s1, v3, 31
+; GFX1132DAGISEL-NEXT:    s_mov_b32 exec_lo, s0
+; GFX1132DAGISEL-NEXT:    v_mov_b32_e32 v2, s1
+; GFX1132DAGISEL-NEXT:    global_store_b32 v[0:1], v2, off
+; GFX1132DAGISEL-NEXT:    s_xor_saveexec_b32 s0, -1
+; GFX1132DAGISEL-NEXT:    s_clause 0x1 ; 8-byte Folded Reload
+; GFX1132DAGISEL-NEXT:    scratch_load_b32 v3, off, s32
+; GFX1132DAGISEL-NEXT:    scratch_load_b32 v4, off, s32 offset:4
+; GFX1132DAGISEL-NEXT:    s_mov_b32 exec_lo, s0
+; GFX1132DAGISEL-NEXT:    s_waitcnt vmcnt(0)
+; GFX1132DAGISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX1132GISEL-LABEL: divergent_value_float_dpp:
+; GFX1132GISEL:       ; %bb.0: ; %entry
+; GFX1132GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX1132GISEL-NEXT:    s_xor_saveexec_b32 s0, -1
+; GFX1132GISEL-NEXT:    s_clause 0x1 ; 8-byte Folded Spill
+; GFX1132GISEL-NEXT:    scratch_store_b32 off, v3, s32
+; GFX1132GISEL-NEXT:    scratch_store_b32 off, v4, s32 offset:4
+; GFX1132GISEL-NEXT:    s_mov_b32 exec_lo, s0
+; GFX1132GISEL-NEXT:    s_or_saveexec_b32 s0, -1
+; GFX1132GISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1132GISEL-NEXT:    v_cndmask_b32_e64 v3, 0x80000000, v2, s0
+; GFX1132GISEL-NEXT:    v_add_f32_dpp v3, v3, v3 row_shr:1 row_mask:0xf bank_mask:0xf
+; GFX1132GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1132GISEL-NEXT:    v_add_f32_dpp v3, v3, v3 row_shr:2 row_mask:0xf bank_mask:0xf
+; GFX1132GISEL-NEXT:    v_add_f32_dpp v3, v3, v3 row_shr:4 row_mask:0xf bank_mask:0xf
+; GFX1132GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_3) | instid1(VALU_DEP_1)
+; GFX1132GISEL-NEXT:    v_add_f32_dpp v3, v3, v3 row_shr:8 row_mask:0xf bank_mask:0xf
+; GFX1132GISEL-NEXT:    ds_swizzle_b32 v4, v3 offset:swizzle(BROADCAST,32,15)
+; GFX1132GISEL-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX1132GISEL-NEXT:    v_add_f32_e32 v3, v3, v4
+; GFX1132GISEL-NEXT:    v_readlane_b32 s1, v3, 31
+; GFX1132GISEL-NEXT:    s_mov_b32 exec_lo, s0
+; GFX1132GISEL-NEXT:    v_mov_b32_e32 v2, s1
+; GFX1132GISEL-NEXT:    global_store_b32 v[0:1], v2, off
+; GFX1132GISEL-NEXT:    s_xor_saveexec_b32 s0, -1
+; GFX1132GISEL-NEXT:    s_clause 0x1 ; 8-byte Folded Reload
+; GFX1132GISEL-NEXT:    scratch_load_b32 v3, off, s32
+; GFX1132GISEL-NEXT:    scratch_load_b32 v4, off, s32 offset:4
+; GFX1132GISEL-NEXT:    s_mov_b32 exec_lo, s0
+; GFX1132GISEL-NEXT:    s_waitcnt vmcnt(0)
+; GFX1132GISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12DAGISEL-LABEL: divergent_value_float_dpp:
+; GFX12DAGISEL:       ; %bb.0: ; %entry
+; GFX12DAGISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12DAGISEL-NEXT:    s_wait_expcnt 0x0
+; GFX12DAGISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX12DAGISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX12DAGISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX12DAGISEL-NEXT:    s_xor_saveexec_b32 s0, -1
+; GFX12DAGISEL-NEXT:    s_clause 0x1 ; 8-byte Folded Spill
+; GFX12DAGISEL-NEXT:    scratch_store_b32 off, v3, s32
+; GFX12DAGISEL-NEXT:    scratch_store_b32 off, v4, s32 offset:4
+; GFX12DAGISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12DAGISEL-NEXT:    s_mov_b32 exec_lo, s0
+; GFX12DAGISEL-NEXT:    s_or_saveexec_b32 s0, -1
+; GFX12DAGISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12DAGISEL-NEXT:    v_cndmask_b32_e64 v3, 0x80000000, v2, s0
+; GFX12DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX12DAGISEL-NEXT:    v_add_f32_dpp v3, v3, v3 row_shr:1 row_mask:0xf bank_mask:0xf
+; GFX12DAGISEL-NEXT:    v_add_f32_dpp v3, v3, v3 row_shr:2 row_mask:0xf bank_mask:0xf
+; GFX12DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX12DAGISEL-NEXT:    v_add_f32_dpp v3, v3, v3 row_shr:4 row_mask:0xf bank_mask:0xf
+; GFX12DAGISEL-NEXT:    v_add_f32_dpp v3, v3, v3 row_shr:8 row_mask:0xf bank_mask:0xf
+; GFX12DAGISEL-NEXT:    ds_swizzle_b32 v4, v3 offset:swizzle(BROADCAST,32,15)
+; GFX12DAGISEL-NEXT:    s_wait_dscnt 0x0
+; GFX12DAGISEL-NEXT:    v_add_f32_e32 v3, v3, v4
+; GFX12DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX12DAGISEL-NEXT:    v_readlane_b32 s1, v3, 31
+; GFX12DAGISEL-NEXT:    s_mov_b32 exec_lo, s0
+; GFX12DAGISEL-NEXT:    v_mov_b32_e32 v2, s1
+; GFX12DAGISEL-NEXT:    global_store_b32 v[0:1], v2, off
+; GFX12DAGISEL-NEXT:    s_xor_saveexec_b32 s0, -1
+; GFX12DAGISEL-NEXT:    s_clause 0x1 ; 8-byte Folded Reload
+; GFX12DAGISEL-NEXT:    scratch_load_b32 v3, off, s32
+; GFX12DAGISEL-NEXT:    scratch_load_b32 v4, off, s32 offset:4
+; GFX12DAGISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12DAGISEL-NEXT:    s_mov_b32 exec_lo, s0
+; GFX12DAGISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX12DAGISEL-NEXT:    s_setpc_b64 s[30:31]
+entry:
+  %result = call float @llvm.amdgcn.wave.reduce.fadd(float %id.x, i32 2)
+  store float %result, ptr addrspace(1) %out
+  ret void
+}
+
 define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in, float %in2) {
 ; GFX8DAGISEL-LABEL: divergent_cfg_float:
 ; GFX8DAGISEL:       ; %bb.0: ; %entry
@@ -499,7 +958,7 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX8DAGISEL-NEXT:    ; implicit-def: $sgpr6
 ; GFX8DAGISEL-NEXT:    s_and_saveexec_b64 s[2:3], vcc
 ; GFX8DAGISEL-NEXT:    s_xor_b64 s[2:3], exec, s[2:3]
-; GFX8DAGISEL-NEXT:    s_cbranch_execz .LBB2_2
+; GFX8DAGISEL-NEXT:    s_cbranch_execz .LBB3_2
 ; GFX8DAGISEL-NEXT:  ; %bb.1: ; %else
 ; GFX8DAGISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX8DAGISEL-NEXT:    s_bcnt1_i32_b64 s6, s[6:7]
@@ -507,11 +966,11 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX8DAGISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX8DAGISEL-NEXT:    v_mul_f32_e32 v0, s0, v0
 ; GFX8DAGISEL-NEXT:    v_readfirstlane_b32 s6, v0
-; GFX8DAGISEL-NEXT:  .LBB2_2: ; %Flow
+; GFX8DAGISEL-NEXT:  .LBB3_2: ; %Flow
 ; GFX8DAGISEL-NEXT:    s_or_saveexec_b64 s[2:3], s[2:3]
 ; GFX8DAGISEL-NEXT:    v_mov_b32_e32 v0, s6
 ; GFX8DAGISEL-NEXT:    s_xor_b64 exec, exec, s[2:3]
-; GFX8DAGISEL-NEXT:    s_cbranch_execz .LBB2_4
+; GFX8DAGISEL-NEXT:    s_cbranch_execz .LBB3_4
 ; GFX8DAGISEL-NEXT:  ; %bb.3: ; %if
 ; GFX8DAGISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX8DAGISEL-NEXT:    s_waitcnt lgkmcnt(0)
@@ -520,7 +979,7 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX8DAGISEL-NEXT:    v_mul_f32_e32 v0, s1, v0
 ; GFX8DAGISEL-NEXT:    v_readfirstlane_b32 s0, v0
 ; GFX8DAGISEL-NEXT:    v_mov_b32_e32 v0, s0
-; GFX8DAGISEL-NEXT:  .LBB2_4: ; %endif
+; GFX8DAGISEL-NEXT:  .LBB3_4: ; %endif
 ; GFX8DAGISEL-NEXT:    s_or_b64 exec, exec, s[2:3]
 ; GFX8DAGISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX8DAGISEL-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x24
@@ -537,7 +996,7 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX8GISEL-NEXT:    ; implicit-def: $sgpr6
 ; GFX8GISEL-NEXT:    s_and_saveexec_b64 s[2:3], vcc
 ; GFX8GISEL-NEXT:    s_xor_b64 s[2:3], exec, s[2:3]
-; GFX8GISEL-NEXT:    s_cbranch_execz .LBB2_2
+; GFX8GISEL-NEXT:    s_cbranch_execz .LBB3_2
 ; GFX8GISEL-NEXT:  ; %bb.1: ; %else
 ; GFX8GISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX8GISEL-NEXT:    s_bcnt1_i32_b64 s6, s[6:7]
@@ -545,9 +1004,9 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX8GISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX8GISEL-NEXT:    v_mul_f32_e32 v0, s0, v0
 ; GFX8GISEL-NEXT:    v_readfirstlane_b32 s6, v0
-; GFX8GISEL-NEXT:  .LBB2_2: ; %Flow
+; GFX8GISEL-NEXT:  .LBB3_2: ; %Flow
 ; GFX8GISEL-NEXT:    s_andn2_saveexec_b64 s[2:3], s[2:3]
-; GFX8GISEL-NEXT:    s_cbranch_execz .LBB2_4
+; GFX8GISEL-NEXT:    s_cbranch_execz .LBB3_4
 ; GFX8GISEL-NEXT:  ; %bb.3: ; %if
 ; GFX8GISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX8GISEL-NEXT:    s_waitcnt lgkmcnt(0)
@@ -555,7 +1014,7 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX8GISEL-NEXT:    v_cvt_f32_i32_e32 v0, s0
 ; GFX8GISEL-NEXT:    v_mul_f32_e32 v0, s1, v0
 ; GFX8GISEL-NEXT:    v_readfirstlane_b32 s6, v0
-; GFX8GISEL-NEXT:  .LBB2_4: ; %endif
+; GFX8GISEL-NEXT:  .LBB3_4: ; %endif
 ; GFX8GISEL-NEXT:    s_or_b64 exec, exec, s[2:3]
 ; GFX8GISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX8GISEL-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x24
@@ -573,7 +1032,7 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX9DAGISEL-NEXT:    ; implicit-def: $sgpr6
 ; GFX9DAGISEL-NEXT:    s_and_saveexec_b64 s[2:3], vcc
 ; GFX9DAGISEL-NEXT:    s_xor_b64 s[2:3], exec, s[2:3]
-; GFX9DAGISEL-NEXT:    s_cbranch_execz .LBB2_2
+; GFX9DAGISEL-NEXT:    s_cbranch_execz .LBB3_2
 ; GFX9DAGISEL-NEXT:  ; %bb.1: ; %else
 ; GFX9DAGISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX9DAGISEL-NEXT:    s_bcnt1_i32_b64 s6, s[6:7]
@@ -581,11 +1040,11 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX9DAGISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX9DAGISEL-NEXT:    v_mul_f32_e32 v0, s0, v0
 ; GFX9DAGISEL-NEXT:    v_readfirstlane_b32 s6, v0
-; GFX9DAGISEL-NEXT:  .LBB2_2: ; %Flow
+; GFX9DAGISEL-NEXT:  .LBB3_2: ; %Flow
 ; GFX9DAGISEL-NEXT:    s_or_saveexec_b64 s[2:3], s[2:3]
 ; GFX9DAGISEL-NEXT:    v_mov_b32_e32 v0, s6
 ; GFX9DAGISEL-NEXT:    s_xor_b64 exec, exec, s[2:3]
-; GFX9DAGISEL-NEXT:    s_cbranch_execz .LBB2_4
+; GFX9DAGISEL-NEXT:    s_cbranch_execz .LBB3_4
 ; GFX9DAGISEL-NEXT:  ; %bb.3: ; %if
 ; GFX9DAGISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX9DAGISEL-NEXT:    s_waitcnt lgkmcnt(0)
@@ -594,7 +1053,7 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX9DAGISEL-NEXT:    v_mul_f32_e32 v0, s1, v0
 ; GFX9DAGISEL-NEXT:    v_readfirstlane_b32 s0, v0
 ; GFX9DAGISEL-NEXT:    v_mov_b32_e32 v0, s0
-; GFX9DAGISEL-NEXT:  .LBB2_4: ; %endif
+; GFX9DAGISEL-NEXT:  .LBB3_4: ; %endif
 ; GFX9DAGISEL-NEXT:    s_or_b64 exec, exec, s[2:3]
 ; GFX9DAGISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX9DAGISEL-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x24
@@ -610,7 +1069,7 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX9GISEL-NEXT:    ; implicit-def: $sgpr6
 ; GFX9GISEL-NEXT:    s_and_saveexec_b64 s[2:3], vcc
 ; GFX9GISEL-NEXT:    s_xor_b64 s[2:3], exec, s[2:3]
-; GFX9GISEL-NEXT:    s_cbranch_execz .LBB2_2
+; GFX9GISEL-NEXT:    s_cbranch_execz .LBB3_2
 ; GFX9GISEL-NEXT:  ; %bb.1: ; %else
 ; GFX9GISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX9GISEL-NEXT:    s_bcnt1_i32_b64 s6, s[6:7]
@@ -618,9 +1077,9 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX9GISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX9GISEL-NEXT:    v_mul_f32_e32 v0, s0, v0
 ; GFX9GISEL-NEXT:    v_readfirstlane_b32 s6, v0
-; GFX9GISEL-NEXT:  .LBB2_2: ; %Flow
+; GFX9GISEL-NEXT:  .LBB3_2: ; %Flow
 ; GFX9GISEL-NEXT:    s_andn2_saveexec_b64 s[2:3], s[2:3]
-; GFX9GISEL-NEXT:    s_cbranch_execz .LBB2_4
+; GFX9GISEL-NEXT:    s_cbranch_execz .LBB3_4
 ; GFX9GISEL-NEXT:  ; %bb.3: ; %if
 ; GFX9GISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX9GISEL-NEXT:    s_waitcnt lgkmcnt(0)
@@ -628,7 +1087,7 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX9GISEL-NEXT:    v_cvt_f32_i32_e32 v0, s0
 ; GFX9GISEL-NEXT:    v_mul_f32_e32 v0, s1, v0
 ; GFX9GISEL-NEXT:    v_readfirstlane_b32 s6, v0
-; GFX9GISEL-NEXT:  .LBB2_4: ; %endif
+; GFX9GISEL-NEXT:  .LBB3_4: ; %endif
 ; GFX9GISEL-NEXT:    s_or_b64 exec, exec, s[2:3]
 ; GFX9GISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX9GISEL-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x24
@@ -645,7 +1104,7 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX1064DAGISEL-NEXT:    ; implicit-def: $sgpr6
 ; GFX1064DAGISEL-NEXT:    s_and_saveexec_b64 s[2:3], vcc
 ; GFX1064DAGISEL-NEXT:    s_xor_b64 s[2:3], exec, s[2:3]
-; GFX1064DAGISEL-NEXT:    s_cbranch_execz .LBB2_2
+; GFX1064DAGISEL-NEXT:    s_cbranch_execz .LBB3_2
 ; GFX1064DAGISEL-NEXT:  ; %bb.1: ; %else
 ; GFX1064DAGISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX1064DAGISEL-NEXT:    s_bcnt1_i32_b64 s6, s[6:7]
@@ -653,11 +1112,11 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX1064DAGISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX1064DAGISEL-NEXT:    v_mul_f32_e32 v0, s0, v0
 ; GFX1064DAGISEL-NEXT:    v_readfirstlane_b32 s6, v0
-; GFX1064DAGISEL-NEXT:  .LBB2_2: ; %Flow
+; GFX1064DAGISEL-NEXT:  .LBB3_2: ; %Flow
 ; GFX1064DAGISEL-NEXT:    s_or_saveexec_b64 s[2:3], s[2:3]
 ; GFX1064DAGISEL-NEXT:    v_mov_b32_e32 v0, s6
 ; GFX1064DAGISEL-NEXT:    s_xor_b64 exec, exec, s[2:3]
-; GFX1064DAGISEL-NEXT:    s_cbranch_execz .LBB2_4
+; GFX1064DAGISEL-NEXT:    s_cbranch_execz .LBB3_4
 ; GFX1064DAGISEL-NEXT:  ; %bb.3: ; %if
 ; GFX1064DAGISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX1064DAGISEL-NEXT:    s_waitcnt lgkmcnt(0)
@@ -666,7 +1125,7 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX1064DAGISEL-NEXT:    v_mul_f32_e32 v0, s1, v0
 ; GFX1064DAGISEL-NEXT:    v_readfirstlane_b32 s0, v0
 ; GFX1064DAGISEL-NEXT:    v_mov_b32_e32 v0, s0
-; GFX1064DAGISEL-NEXT:  .LBB2_4: ; %endif
+; GFX1064DAGISEL-NEXT:  .LBB3_4: ; %endif
 ; GFX1064DAGISEL-NEXT:    s_or_b64 exec, exec, s[2:3]
 ; GFX1064DAGISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX1064DAGISEL-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x24
@@ -682,7 +1141,7 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX1064GISEL-NEXT:    ; implicit-def: $sgpr6
 ; GFX1064GISEL-NEXT:    s_and_saveexec_b64 s[2:3], vcc
 ; GFX1064GISEL-NEXT:    s_xor_b64 s[2:3], exec, s[2:3]
-; GFX1064GISEL-NEXT:    s_cbranch_execz .LBB2_2
+; GFX1064GISEL-NEXT:    s_cbranch_execz .LBB3_2
 ; GFX1064GISEL-NEXT:  ; %bb.1: ; %else
 ; GFX1064GISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX1064GISEL-NEXT:    s_bcnt1_i32_b64 s6, s[6:7]
@@ -690,9 +1149,9 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX1064GISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX1064GISEL-NEXT:    v_mul_f32_e32 v0, s0, v0
 ; GFX1064GISEL-NEXT:    v_readfirstlane_b32 s6, v0
-; GFX1064GISEL-NEXT:  .LBB2_2: ; %Flow
+; GFX1064GISEL-NEXT:  .LBB3_2: ; %Flow
 ; GFX1064GISEL-NEXT:    s_andn2_saveexec_b64 s[2:3], s[2:3]
-; GFX1064GISEL-NEXT:    s_cbranch_execz .LBB2_4
+; GFX1064GISEL-NEXT:    s_cbranch_execz .LBB3_4
 ; GFX1064GISEL-NEXT:  ; %bb.3: ; %if
 ; GFX1064GISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX1064GISEL-NEXT:    s_waitcnt lgkmcnt(0)
@@ -700,7 +1159,7 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX1064GISEL-NEXT:    v_cvt_f32_i32_e32 v0, s0
 ; GFX1064GISEL-NEXT:    v_mul_f32_e32 v0, s1, v0
 ; GFX1064GISEL-NEXT:    v_readfirstlane_b32 s6, v0
-; GFX1064GISEL-NEXT:  .LBB2_4: ; %endif
+; GFX1064GISEL-NEXT:  .LBB3_4: ; %endif
 ; GFX1064GISEL-NEXT:    s_or_b64 exec, exec, s[2:3]
 ; GFX1064GISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX1064GISEL-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x24
@@ -717,7 +1176,7 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX1032DAGISEL-NEXT:    ; implicit-def: $sgpr3
 ; GFX1032DAGISEL-NEXT:    s_and_saveexec_b32 s2, vcc_lo
 ; GFX1032DAGISEL-NEXT:    s_xor_b32 s2, exec_lo, s2
-; GFX1032DAGISEL-NEXT:    s_cbranch_execz .LBB2_2
+; GFX1032DAGISEL-NEXT:    s_cbranch_execz .LBB3_2
 ; GFX1032DAGISEL-NEXT:  ; %bb.1: ; %else
 ; GFX1032DAGISEL-NEXT:    s_mov_b32 s3, exec_lo
 ; GFX1032DAGISEL-NEXT:    s_bcnt1_i32_b32 s3, s3
@@ -725,12 +1184,12 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX1032DAGISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX1032DAGISEL-NEXT:    v_mul_f32_e32 v0, s0, v0
 ; GFX1032DAGISEL-NEXT:    v_readfirstlane_b32 s3, v0
-; GFX1032DAGISEL-NEXT:  .LBB2_2: ; %Flow
+; GFX1032DAGISEL-NEXT:  .LBB3_2: ; %Flow
 ; GFX1032DAGISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX1032DAGISEL-NEXT:    s_or_saveexec_b32 s0, s2
 ; GFX1032DAGISEL-NEXT:    v_mov_b32_e32 v0, s3
 ; GFX1032DAGISEL-NEXT:    s_xor_b32 exec_lo, exec_lo, s0
-; GFX1032DAGISEL-NEXT:    s_cbranch_execz .LBB2_4
+; GFX1032DAGISEL-NEXT:    s_cbranch_execz .LBB3_4
 ; GFX1032DAGISEL-NEXT:  ; %bb.3: ; %if
 ; GFX1032DAGISEL-NEXT:    s_mov_b32 s2, exec_lo
 ; GFX1032DAGISEL-NEXT:    s_bcnt1_i32_b32 s2, s2
@@ -738,7 +1197,7 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX1032DAGISEL-NEXT:    v_mul_f32_e32 v0, s1, v0
 ; GFX1032DAGISEL-NEXT:    v_readfirstlane_b32 s1, v0
 ; GFX1032DAGISEL-NEXT:    v_mov_b32_e32 v0, s1
-; GFX1032DAGISEL-NEXT:  .LBB2_4: ; %endif
+; GFX1032DAGISEL-NEXT:  .LBB3_4: ; %endif
 ; GFX1032DAGISEL-NEXT:    s_or_b32 exec_lo, exec_lo, s0
 ; GFX1032DAGISEL-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x24
 ; GFX1032DAGISEL-NEXT:    v_mov_b32_e32 v1, 0
@@ -753,7 +1212,7 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX1032GISEL-NEXT:    ; implicit-def: $sgpr2
 ; GFX1032GISEL-NEXT:    s_and_saveexec_b32 s3, vcc_lo
 ; GFX1032GISEL-NEXT:    s_xor_b32 s3, exec_lo, s3
-; GFX1032GISEL-NEXT:    s_cbranch_execz .LBB2_2
+; GFX1032GISEL-NEXT:    s_cbranch_execz .LBB3_2
 ; GFX1032GISEL-NEXT:  ; %bb.1: ; %else
 ; GFX1032GISEL-NEXT:    s_mov_b32 s2, exec_lo
 ; GFX1032GISEL-NEXT:    s_bcnt1_i32_b32 s2, s2
@@ -761,17 +1220,17 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX1032GISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX1032GISEL-NEXT:    v_mul_f32_e32 v0, s0, v0
 ; GFX1032GISEL-NEXT:    v_readfirstlane_b32 s2, v0
-; GFX1032GISEL-NEXT:  .LBB2_2: ; %Flow
+; GFX1032GISEL-NEXT:  .LBB3_2: ; %Flow
 ; GFX1032GISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX1032GISEL-NEXT:    s_andn2_saveexec_b32 s0, s3
-; GFX1032GISEL-NEXT:    s_cbranch_execz .LBB2_4
+; GFX1032GISEL-NEXT:    s_cbranch_execz .LBB3_4
 ; GFX1032GISEL-NEXT:  ; %bb.3: ; %if
 ; GFX1032GISEL-NEXT:    s_mov_b32 s2, exec_lo
 ; GFX1032GISEL-NEXT:    s_bcnt1_i32_b32 s2, s2
 ; GFX1032GISEL-NEXT:    v_cvt_f32_i32_e32 v0, s2
 ; GFX1032GISEL-NEXT:    v_mul_f32_e32 v0, s1, v0
 ; GFX1032GISEL-NEXT:    v_readfirstlane_b32 s2, v0
-; GFX1032GISEL-NEXT:  .LBB2_4: ; %endif
+; GFX1032GISEL-NEXT:  .LBB3_4: ; %endif
 ; GFX1032GISEL-NEXT:    s_or_b32 exec_lo, exec_lo, s0
 ; GFX1032GISEL-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x24
 ; GFX1032GISEL-NEXT:    v_mov_b32_e32 v0, s2
@@ -789,7 +1248,7 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX1164DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX1164DAGISEL-NEXT:    v_cmpx_lt_u32_e32 15, v0
 ; GFX1164DAGISEL-NEXT:    s_xor_b64 s[2:3], exec, s[2:3]
-; GFX1164DAGISEL-NEXT:    s_cbranch_execz .LBB2_2
+; GFX1164DAGISEL-NEXT:    s_cbranch_execz .LBB3_2
 ; GFX1164DAGISEL-NEXT:  ; %bb.1: ; %else
 ; GFX1164DAGISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX1164DAGISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
@@ -799,12 +1258,12 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX1164DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
 ; GFX1164DAGISEL-NEXT:    v_mul_f32_e32 v0, s0, v0
 ; GFX1164DAGISEL-NEXT:    v_readfirstlane_b32 s6, v0
-; GFX1164DAGISEL-NEXT:  .LBB2_2: ; %Flow
+; GFX1164DAGISEL-NEXT:  .LBB3_2: ; %Flow
 ; GFX1164DAGISEL-NEXT:    s_or_saveexec_b64 s[2:3], s[2:3]
 ; GFX1164DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX1164DAGISEL-NEXT:    v_mov_b32_e32 v0, s6
 ; GFX1164DAGISEL-NEXT:    s_xor_b64 exec, exec, s[2:3]
-; GFX1164DAGISEL-NEXT:    s_cbranch_execz .LBB2_4
+; GFX1164DAGISEL-NEXT:    s_cbranch_execz .LBB3_4
 ; GFX1164DAGISEL-NEXT:  ; %bb.3: ; %if
 ; GFX1164DAGISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX1164DAGISEL-NEXT:    s_waitcnt lgkmcnt(0)
@@ -815,7 +1274,7 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX1164DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
 ; GFX1164DAGISEL-NEXT:    v_readfirstlane_b32 s0, v0
 ; GFX1164DAGISEL-NEXT:    v_mov_b32_e32 v0, s0
-; GFX1164DAGISEL-NEXT:  .LBB2_4: ; %endif
+; GFX1164DAGISEL-NEXT:  .LBB3_4: ; %endif
 ; GFX1164DAGISEL-NEXT:    s_or_b64 exec, exec, s[2:3]
 ; GFX1164DAGISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX1164DAGISEL-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24
@@ -833,7 +1292,7 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX1164GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX1164GISEL-NEXT:    v_cmpx_le_u32_e32 16, v0
 ; GFX1164GISEL-NEXT:    s_xor_b64 s[2:3], exec, s[2:3]
-; GFX1164GISEL-NEXT:    s_cbranch_execz .LBB2_2
+; GFX1164GISEL-NEXT:    s_cbranch_execz .LBB3_2
 ; GFX1164GISEL-NEXT:  ; %bb.1: ; %else
 ; GFX1164GISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX1164GISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
@@ -843,9 +1302,9 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX1164GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
 ; GFX1164GISEL-NEXT:    v_mul_f32_e32 v0, s0, v0
 ; GFX1164GISEL-NEXT:    v_readfirstlane_b32 s6, v0
-; GFX1164GISEL-NEXT:  .LBB2_2: ; %Flow
+; GFX1164GISEL-NEXT:  .LBB3_2: ; %Flow
 ; GFX1164GISEL-NEXT:    s_and_not1_saveexec_b64 s[2:3], s[2:3]
-; GFX1164GISEL-NEXT:    s_cbranch_execz .LBB2_4
+; GFX1164GISEL-NEXT:    s_cbranch_execz .LBB3_4
 ; GFX1164GISEL-NEXT:  ; %bb.3: ; %if
 ; GFX1164GISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX1164GISEL-NEXT:    s_waitcnt lgkmcnt(0)
@@ -855,7 +1314,7 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX1164GISEL-NEXT:    v_mul_f32_e32 v0, s1, v0
 ; GFX1164GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX1164GISEL-NEXT:    v_readfirstlane_b32 s6, v0
-; GFX1164GISEL-NEXT:  .LBB2_4: ; %endif
+; GFX1164GISEL-NEXT:  .LBB3_4: ; %endif
 ; GFX1164GISEL-NEXT:    s_or_b64 exec, exec, s[2:3]
 ; GFX1164GISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX1164GISEL-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24
@@ -875,7 +1334,7 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX1132DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX1132DAGISEL-NEXT:    v_cmpx_lt_u32_e32 15, v0
 ; GFX1132DAGISEL-NEXT:    s_xor_b32 s2, exec_lo, s2
-; GFX1132DAGISEL-NEXT:    s_cbranch_execz .LBB2_2
+; GFX1132DAGISEL-NEXT:    s_cbranch_execz .LBB3_2
 ; GFX1132DAGISEL-NEXT:  ; %bb.1: ; %else
 ; GFX1132DAGISEL-NEXT:    s_mov_b32 s3, exec_lo
 ; GFX1132DAGISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
@@ -885,13 +1344,13 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX1132DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
 ; GFX1132DAGISEL-NEXT:    v_mul_f32_e32 v0, s0, v0
 ; GFX1132DAGISEL-NEXT:    v_readfirstlane_b32 s3, v0
-; GFX1132DAGISEL-NEXT:  .LBB2_2: ; %Flow
+; GFX1132DAGISEL-NEXT:  .LBB3_2: ; %Flow
 ; GFX1132DAGISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX1132DAGISEL-NEXT:    s_or_saveexec_b32 s0, s2
 ; GFX1132DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX1132DAGISEL-NEXT:    v_mov_b32_e32 v0, s3
 ; GFX1132DAGISEL-NEXT:    s_xor_b32 exec_lo, exec_lo, s0
-; GFX1132DAGISEL-NEXT:    s_cbranch_execz .LBB2_4
+; GFX1132DAGISEL-NEXT:    s_cbranch_execz .LBB3_4
 ; GFX1132DAGISEL-NEXT:  ; %bb.3: ; %if
 ; GFX1132DAGISEL-NEXT:    s_mov_b32 s2, exec_lo
 ; GFX1132DAGISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
@@ -902,7 +1361,7 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX1132DAGISEL-NEXT:    v_readfirstlane_b32 s1, v0
 ; GFX1132DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX1132DAGISEL-NEXT:    v_mov_b32_e32 v0, s1
-; GFX1132DAGISEL-NEXT:  .LBB2_4: ; %endif
+; GFX1132DAGISEL-NEXT:  .LBB3_4: ; %endif
 ; GFX1132DAGISEL-NEXT:    s_or_b32 exec_lo, exec_lo, s0
 ; GFX1132DAGISEL-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24
 ; GFX1132DAGISEL-NEXT:    v_mov_b32_e32 v1, 0
@@ -919,7 +1378,7 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX1132GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX1132GISEL-NEXT:    v_cmpx_le_u32_e32 16, v0
 ; GFX1132GISEL-NEXT:    s_xor_b32 s3, exec_lo, s3
-; GFX1132GISEL-NEXT:    s_cbranch_execz .LBB2_2
+; GFX1132GISEL-NEXT:    s_cbranch_execz .LBB3_2
 ; GFX1132GISEL-NEXT:  ; %bb.1: ; %else
 ; GFX1132GISEL-NEXT:    s_mov_b32 s2, exec_lo
 ; GFX1132GISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
@@ -929,10 +1388,10 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX1132GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
 ; GFX1132GISEL-NEXT:    v_mul_f32_e32 v0, s0, v0
 ; GFX1132GISEL-NEXT:    v_readfirstlane_b32 s2, v0
-; GFX1132GISEL-NEXT:  .LBB2_2: ; %Flow
+; GFX1132GISEL-NEXT:  .LBB3_2: ; %Flow
 ; GFX1132GISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX1132GISEL-NEXT:    s_and_not1_saveexec_b32 s0, s3
-; GFX1132GISEL-NEXT:    s_cbranch_execz .LBB2_4
+; GFX1132GISEL-NEXT:    s_cbranch_execz .LBB3_4
 ; GFX1132GISEL-NEXT:  ; %bb.3: ; %if
 ; GFX1132GISEL-NEXT:    s_mov_b32 s2, exec_lo
 ; GFX1132GISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
@@ -941,7 +1400,7 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX1132GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
 ; GFX1132GISEL-NEXT:    v_mul_f32_e32 v0, s1, v0
 ; GFX1132GISEL-NEXT:    v_readfirstlane_b32 s2, v0
-; GFX1132GISEL-NEXT:  .LBB2_4: ; %endif
+; GFX1132GISEL-NEXT:  .LBB3_4: ; %endif
 ; GFX1132GISEL-NEXT:    s_or_b32 exec_lo, exec_lo, s0
 ; GFX1132GISEL-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24
 ; GFX1132GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
@@ -959,7 +1418,7 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX12DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX12DAGISEL-NEXT:    v_cmpx_lt_u32_e32 15, v0
 ; GFX12DAGISEL-NEXT:    s_xor_b32 s2, exec_lo, s2
-; GFX12DAGISEL-NEXT:    s_cbranch_execz .LBB2_2
+; GFX12DAGISEL-NEXT:    s_cbranch_execz .LBB3_2
 ; GFX12DAGISEL-NEXT:  ; %bb.1: ; %else
 ; GFX12DAGISEL-NEXT:    s_mov_b32 s3, exec_lo
 ; GFX12DAGISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
@@ -969,14 +1428,14 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX12DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
 ; GFX12DAGISEL-NEXT:    v_mul_f32_e32 v0, s0, v0
 ; GFX12DAGISEL-NEXT:    v_readfirstlane_b32 s3, v0
-; GFX12DAGISEL-NEXT:  .LBB2_2: ; %Flow
+; GFX12DAGISEL-NEXT:  .LBB3_2: ; %Flow
 ; GFX12DAGISEL-NEXT:    s_wait_kmcnt 0x0
 ; GFX12DAGISEL-NEXT:    s_or_saveexec_b32 s0, s2
 ; GFX12DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX12DAGISEL-NEXT:    v_mov_b32_e32 v0, s3
 ; GFX12DAGISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
 ; GFX12DAGISEL-NEXT:    s_xor_b32 exec_lo, exec_lo, s0
-; GFX12DAGISEL-NEXT:    s_cbranch_execz .LBB2_4
+; GFX12DAGISEL-NEXT:    s_cbranch_execz .LBB3_4
 ; GFX12DAGISEL-NEXT:  ; %bb.3: ; %if
 ; GFX12DAGISEL-NEXT:    s_mov_b32 s2, exec_lo
 ; GFX12DAGISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
@@ -989,7 +1448,7 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX12DAGISEL-NEXT:    s_wait_alu depctr_va_sdst(0)
 ; GFX12DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX12DAGISEL-NEXT:    v_mov_b32_e32 v0, s1
-; GFX12DAGISEL-NEXT:  .LBB2_4: ; %endif
+; GFX12DAGISEL-NEXT:  .LBB3_4: ; %endif
 ; GFX12DAGISEL-NEXT:    s_or_b32 exec_lo, exec_lo, s0
 ; GFX12DAGISEL-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24
 ; GFX12DAGISEL-NEXT:    v_mov_b32_e32 v1, 0
@@ -1251,7 +1710,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %id.x) {
 ; GFX8DAGISEL-NEXT:    s_mov_b32 s6, 0
 ; GFX8DAGISEL-NEXT:    s_brev_b32 s7, 1
 ; GFX8DAGISEL-NEXT:    s_mov_b64 s[4:5], exec
-; GFX8DAGISEL-NEXT:  .LBB4_1: ; =>This Inner Loop Header: Depth=1
+; GFX8DAGISEL-NEXT:  .LBB5_1: ; =>This Inner Loop Header: Depth=1
 ; GFX8DAGISEL-NEXT:    s_ff1_i32_b64 s10, s[4:5]
 ; GFX8DAGISEL-NEXT:    v_mov_b32_e32 v4, s6
 ; GFX8DAGISEL-NEXT:    v_readlane_b32 s8, v2, s10
@@ -1262,7 +1721,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %id.x) {
 ; GFX8DAGISEL-NEXT:    s_cmp_lg_u64 s[4:5], 0
 ; GFX8DAGISEL-NEXT:    v_readfirstlane_b32 s6, v4
 ; GFX8DAGISEL-NEXT:    v_readfirstlane_b32 s7, v5
-; GFX8DAGISEL-NEXT:    s_cbranch_scc1 .LBB4_1
+; GFX8DAGISEL-NEXT:    s_cbranch_scc1 .LBB5_1
 ; GFX8DAGISEL-NEXT:  ; %bb.2:
 ; GFX8DAGISEL-NEXT:    v_mov_b32_e32 v2, s6
 ; GFX8DAGISEL-NEXT:    v_mov_b32_e32 v3, s7
@@ -1276,7 +1735,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %id.x) {
 ; GFX8GISEL-NEXT:    s_mov_b32 s6, 0
 ; GFX8GISEL-NEXT:    s_brev_b32 s7, 1
 ; GFX8GISEL-NEXT:    s_mov_b64 s[4:5], exec
-; GFX8GISEL-NEXT:  .LBB4_1: ; =>This Inner Loop Header: Depth=1
+; GFX8GISEL-NEXT:  .LBB5_1: ; =>This Inner Loop Header: Depth=1
 ; GFX8GISEL-NEXT:    s_ff1_i32_b64 s10, s[4:5]
 ; GFX8GISEL-NEXT:    v_mov_b32_e32 v4, s6
 ; GFX8GISEL-NEXT:    v_readlane_b32 s8, v2, s10
@@ -1287,7 +1746,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %id.x) {
 ; GFX8GISEL-NEXT:    s_cmp_lg_u64 s[4:5], 0
 ; GFX8GISEL-NEXT:    v_readfirstlane_b32 s6, v4
 ; GFX8GISEL-NEXT:    v_readfirstlane_b32 s7, v5
-; GFX8GISEL-NEXT:    s_cbranch_scc1 .LBB4_1
+; GFX8GISEL-NEXT:    s_cbranch_scc1 .LBB5_1
 ; GFX8GISEL-NEXT:  ; %bb.2:
 ; GFX8GISEL-NEXT:    v_mov_b32_e32 v2, s6
 ; GFX8GISEL-NEXT:    v_mov_b32_e32 v3, s7
@@ -1301,7 +1760,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %id.x) {
 ; GFX9DAGISEL-NEXT:    s_mov_b32 s6, 0
 ; GFX9DAGISEL-NEXT:    s_brev_b32 s7, 1
 ; GFX9DAGISEL-NEXT:    s_mov_b64 s[4:5], exec
-; GFX9DAGISEL-NEXT:  .LBB4_1: ; =>This Inner Loop Header: Depth=1
+; GFX9DAGISEL-NEXT:  .LBB5_1: ; =>This Inner Loop Header: Depth=1
 ; GFX9DAGISEL-NEXT:    s_ff1_i32_b64 s10, s[4:5]
 ; GFX9DAGISEL-NEXT:    v_mov_b32_e32 v4, s6
 ; GFX9DAGISEL-NEXT:    v_readlane_b32 s8, v2, s10
@@ -1312,7 +1771,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %id.x) {
 ; GFX9DAGISEL-NEXT:    s_cmp_lg_u64 s[4:5], 0
 ; GFX9DAGISEL-NEXT:    v_readfirstlane_b32 s6, v4
 ; GFX9DAGISEL-NEXT:    v_readfirstlane_b32 s7, v5
-; GFX9DAGISEL-NEXT:    s_cbranch_scc1 .LBB4_1
+; GFX9DAGISEL-NEXT:    s_cbranch_scc1 .LBB5_1
 ; GFX9DAGISEL-NEXT:  ; %bb.2:
 ; GFX9DAGISEL-NEXT:    v_mov_b32_e32 v2, s6
 ; GFX9DAGISEL-NEXT:    v_mov_b32_e32 v3, s7
@@ -1326,7 +1785,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %id.x) {
 ; GFX9GISEL-NEXT:    s_mov_b32 s6, 0
 ; GFX9GISEL-NEXT:    s_brev_b32 s7, 1
 ; GFX9GISEL-NEXT:    s_mov_b64 s[4:5], exec
-; GFX9GISEL-NEXT:  .LBB4_1: ; =>This Inner Loop Header: Depth=1
+; GFX9GISEL-NEXT:  .LBB5_1: ; =>This Inner Loop Header: Depth=1
 ; GFX9GISEL-NEXT:    s_ff1_i32_b64 s10, s[4:5]
 ; GFX9GISEL-NEXT:    v_mov_b32_e32 v4, s6
 ; GFX9GISEL-NEXT:    v_readlane_b32 s8, v2, s10
@@ -1337,7 +1796,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %id.x) {
 ; GFX9GISEL-NEXT:    s_cmp_lg_u64 s[4:5], 0
 ; GFX9GISEL-NEXT:    v_readfirstlane_b32 s6, v4
 ; GFX9GISEL-NEXT:    v_readfirstlane_b32 s7, v5
-; GFX9GISEL-NEXT:    s_cbranch_scc1 .LBB4_1
+; GFX9GISEL-NEXT:    s_cbranch_scc1 .LBB5_1
 ; GFX9GISEL-NEXT:  ; %bb.2:
 ; GFX9GISEL-NEXT:    v_mov_b32_e32 v2, s6
 ; GFX9GISEL-NEXT:    v_mov_b32_e32 v3, s7
@@ -1351,7 +1810,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %id.x) {
 ; GFX1064DAGISEL-NEXT:    s_mov_b32 s6, 0
 ; GFX1064DAGISEL-NEXT:    s_brev_b32 s7, 1
 ; GFX1064DAGISEL-NEXT:    s_mov_b64 s[4:5], exec
-; GFX1064DAGISEL-NEXT:  .LBB4_1: ; =>This Inner Loop Header: Depth=1
+; GFX1064DAGISEL-NEXT:  .LBB5_1: ; =>This Inner Loop Header: Depth=1
 ; GFX1064DAGISEL-NEXT:    s_ff1_i32_b64 s10, s[4:5]
 ; GFX1064DAGISEL-NEXT:    v_readlane_b32 s8, v2, s10
 ; GFX1064DAGISEL-NEXT:    v_readlane_b32 s9, v3, s10
@@ -1360,7 +1819,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %id.x) {
 ; GFX1064DAGISEL-NEXT:    v_add_f64 v[4:5], s[8:9], s[6:7]
 ; GFX1064DAGISEL-NEXT:    v_readfirstlane_b32 s6, v4
 ; GFX1064DAGISEL-NEXT:    v_readfirstlane_b32 s7, v5
-; GFX1064DAGISEL-NEXT:    s_cbranch_scc1 .LBB4_1
+; GFX1064DAGISEL-NEXT:    s_cbranch_scc1 .LBB5_1
 ; GFX1064DAGISEL-NEXT:  ; %bb.2:
 ; GFX1064DAGISEL-NEXT:    v_mov_b32_e32 v2, s6
 ; GFX1064DAGISEL-NEXT:    v_mov_b32_e32 v3, s7
@@ -1373,7 +1832,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %id.x) {
 ; GFX1064GISEL-NEXT:    s_mov_b32 s6, 0
 ; GFX1064GISEL-NEXT:    s_brev_b32 s7, 1
 ; GFX1064GISEL-NEXT:    s_mov_b64 s[4:5], exec
-; GFX1064GISEL-NEXT:  .LBB4_1: ; =>This Inner Loop Header: Depth=1
+; GFX1064GISEL-NEXT:  .LBB5_1: ; =>This Inner Loop Header: Depth=1
 ; GFX1064GISEL-NEXT:    s_ff1_i32_b64 s10, s[4:5]
 ; GFX1064GISEL-NEXT:    v_readlane_b32 s8, v2, s10
 ; GFX1064GISEL-NEXT:    v_readlane_b32 s9, v3, s10
@@ -1382,7 +1841,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %id.x) {
 ; GFX1064GISEL-NEXT:    v_add_f64 v[4:5], s[8:9], s[6:7]
 ; GFX1064GISEL-NEXT:    v_readfirstlane_b32 s6, v4
 ; GFX1064GISEL-NEXT:    v_readfirstlane_b32 s7, v5
-; GFX1064GISEL-NEXT:    s_cbranch_scc1 .LBB4_1
+; GFX1064GISEL-NEXT:    s_cbranch_scc1 .LBB5_1
 ; GFX1064GISEL-NEXT:  ; %bb.2:
 ; GFX1064GISEL-NEXT:    v_mov_b32_e32 v2, s6
 ; GFX1064GISEL-NEXT:    v_mov_b32_e32 v3, s7
@@ -1395,7 +1854,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %id.x) {
 ; GFX1032DAGISEL-NEXT:    s_mov_b32 s4, 0
 ; GFX1032DAGISEL-NEXT:    s_brev_b32 s5, 1
 ; GFX1032DAGISEL-NEXT:    s_mov_b32 s6, exec_lo
-; GFX1032DAGISEL-NEXT:  .LBB4_1: ; =>This Inner Loop Header: Depth=1
+; GFX1032DAGISEL-NEXT:  .LBB5_1: ; =>This Inner Loop Header: Depth=1
 ; GFX1032DAGISEL-NEXT:    s_ff1_i32_b32 s7, s6
 ; GFX1032DAGISEL-NEXT:    v_readlane_b32 s8, v2, s7
 ; GFX1032DAGISEL-NEXT:    v_readlane_b32 s9, v3, s7
@@ -1404,7 +1863,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %id.x) {
 ; GFX1032DAGISEL-NEXT:    v_add_f64 v[4:5], s[8:9], s[4:5]
 ; GFX1032DAGISEL-NEXT:    v_readfirstlane_b32 s4, v4
 ; GFX1032DAGISEL-NEXT:    v_readfirstlane_b32 s5, v5
-; GFX1032DAGISEL-NEXT:    s_cbranch_scc1 .LBB4_1
+; GFX1032DAGISEL-NEXT:    s_cbranch_scc1 .LBB5_1
 ; GFX1032DAGISEL-NEXT:  ; %bb.2:
 ; GFX1032DAGISEL-NEXT:    v_mov_b32_e32 v2, s4
 ; GFX1032DAGISEL-NEXT:    v_mov_b32_e32 v3, s5
@@ -1417,7 +1876,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %id.x) {
 ; GFX1032GISEL-NEXT:    s_mov_b32 s4, 0
 ; GFX1032GISEL-NEXT:    s_brev_b32 s5, 1
 ; GFX1032GISEL-NEXT:    s_mov_b32 s6, exec_lo
-; GFX1032GISEL-NEXT:  .LBB4_1: ; =>This Inner Loop Header: Depth=1
+; GFX1032GISEL-NEXT:  .LBB5_1: ; =>This Inner Loop Header: Depth=1
 ; GFX1032GISEL-NEXT:    s_ff1_i32_b32 s7, s6
 ; GFX1032GISEL-NEXT:    v_readlane_b32 s8, v2, s7
 ; GFX1032GISEL-NEXT:    v_readlane_b32 s9, v3, s7
@@ -1426,7 +1885,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %id.x) {
 ; GFX1032GISEL-NEXT:    v_add_f64 v[4:5], s[8:9], s[4:5]
 ; GFX1032GISEL-NEXT:    v_readfirstlane_b32 s4, v4
 ; GFX1032GISEL-NEXT:    v_readfirstlane_b32 s5, v5
-; GFX1032GISEL-NEXT:    s_cbranch_scc1 .LBB4_1
+; GFX1032GISEL-NEXT:    s_cbranch_scc1 .LBB5_1
 ; GFX1032GISEL-NEXT:  ; %bb.2:
 ; GFX1032GISEL-NEXT:    v_mov_b32_e32 v2, s4
 ; GFX1032GISEL-NEXT:    v_mov_b32_e32 v3, s5
@@ -1439,7 +1898,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %id.x) {
 ; GFX1164DAGISEL-NEXT:    s_mov_b32 s2, 0
 ; GFX1164DAGISEL-NEXT:    s_brev_b32 s3, 1
 ; GFX1164DAGISEL-NEXT:    s_mov_b64 s[0:1], exec
-; GFX1164DAGISEL-NEXT:  .LBB4_1: ; =>This Inner Loop Header: Depth=1
+; GFX1164DAGISEL-NEXT:  .LBB5_1: ; =>This Inner Loop Header: Depth=1
 ; GFX1164DAGISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
 ; GFX1164DAGISEL-NEXT:    s_ctz_i32_b64 s6, s[0:1]
 ; GFX1164DAGISEL-NEXT:    v_readlane_b32 s4, v2, s6
@@ -1451,7 +1910,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %id.x) {
 ; GFX1164DAGISEL-NEXT:    v_readfirstlane_b32 s2, v4
 ; GFX1164DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2)
 ; GFX1164DAGISEL-NEXT:    v_readfirstlane_b32 s3, v5
-; GFX1164DAGISEL-NEXT:    s_cbranch_scc1 .LBB4_1
+; GFX1164DAGISEL-NEXT:    s_cbranch_scc1 .LBB5_1
 ; GFX1164DAGISEL-NEXT:  ; %bb.2:
 ; GFX1164DAGISEL-NEXT:    v_mov_b32_e32 v2, s2
 ; GFX1164DAGISEL-NEXT:    v_mov_b32_e32 v3, s3
@@ -1464,7 +1923,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %id.x) {
 ; GFX1164GISEL-NEXT:    s_mov_b32 s2, 0
 ; GFX1164GISEL-NEXT:    s_brev_b32 s3, 1
 ; GFX1164GISEL-NEXT:    s_mov_b64 s[0:1], exec
-; GFX1164GISEL-NEXT:  .LBB4_1: ; =>This Inner Loop Header: Depth=1
+; GFX1164GISEL-NEXT:  .LBB5_1: ; =>This Inner Loop Header: Depth=1
 ; GFX1164GISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
 ; GFX1164GISEL-NEXT:    s_ctz_i32_b64 s6, s[0:1]
 ; GFX1164GISEL-NEXT:    v_readlane_b32 s4, v2, s6
@@ -1476,7 +1935,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %id.x) {
 ; GFX1164GISEL-NEXT:    v_readfirstlane_b32 s2, v4
 ; GFX1164GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2)
 ; GFX1164GISEL-NEXT:    v_readfirstlane_b32 s3, v5
-; GFX1164GISEL-NEXT:    s_cbranch_scc1 .LBB4_1
+; GFX1164GISEL-NEXT:    s_cbranch_scc1 .LBB5_1
 ; GFX1164GISEL-NEXT:  ; %bb.2:
 ; GFX1164GISEL-NEXT:    v_mov_b32_e32 v2, s2
 ; GFX1164GISEL-NEXT:    v_mov_b32_e32 v3, s3
@@ -1489,7 +1948,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %id.x) {
 ; GFX1132DAGISEL-NEXT:    s_mov_b32 s0, 0
 ; GFX1132DAGISEL-NEXT:    s_brev_b32 s1, 1
 ; GFX1132DAGISEL-NEXT:    s_mov_b32 s2, exec_lo
-; GFX1132DAGISEL-NEXT:  .LBB4_1: ; =>This Inner Loop Header: Depth=1
+; GFX1132DAGISEL-NEXT:  .LBB5_1: ; =>This Inner Loop Header: Depth=1
 ; GFX1132DAGISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
 ; GFX1132DAGISEL-NEXT:    s_ctz_i32_b32 s3, s2
 ; GFX1132DAGISEL-NEXT:    v_readlane_b32 s4, v2, s3
@@ -1501,7 +1960,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %id.x) {
 ; GFX1132DAGISEL-NEXT:    v_readfirstlane_b32 s0, v4
 ; GFX1132DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2)
 ; GFX1132DAGISEL-NEXT:    v_readfirstlane_b32 s1, v5
-; GFX1132DAGISEL-NEXT:    s_cbranch_scc1 .LBB4_1
+; GFX1132DAGISEL-NEXT:    s_cbranch_scc1 .LBB5_1
 ; GFX1132DAGISEL-NEXT:  ; %bb.2:
 ; GFX1132DAGISEL-NEXT:    v_dual_mov_b32 v3, s1 :: v_dual_mov_b32 v2, s0
 ; GFX1132DAGISEL-NEXT:    global_store_b64 v[0:1], v[2:3], off
@@ -1513,7 +1972,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %id.x) {
 ; GFX1132GISEL-NEXT:    s_mov_b32 s0, 0
 ; GFX1132GISEL-NEXT:    s_brev_b32 s1, 1
 ; GFX1132GISEL-NEXT:    s_mov_b32 s2, exec_lo
-; GFX1132GISEL-NEXT:  .LBB4_1: ; =>This Inner Loop Header: Depth=1
+; GFX1132GISEL-NEXT:  .LBB5_1: ; =>This Inner Loop Header: Depth=1
 ; GFX1132GISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
 ; GFX1132GISEL-NEXT:    s_ctz_i32_b32 s3, s2
 ; GFX1132GISEL-NEXT:    v_readlane_b32 s4, v2, s3
@@ -1525,7 +1984,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %id.x) {
 ; GFX1132GISEL-NEXT:    v_readfirstlane_b32 s0, v4
 ; GFX1132GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2)
 ; GFX1132GISEL-NEXT:    v_readfirstlane_b32 s1, v5
-; GFX1132GISEL-NEXT:    s_cbranch_scc1 .LBB4_1
+; GFX1132GISEL-NEXT:    s_cbranch_scc1 .LBB5_1
 ; GFX1132GISEL-NEXT:  ; %bb.2:
 ; GFX1132GISEL-NEXT:    v_dual_mov_b32 v3, s1 :: v_dual_mov_b32 v2, s0
 ; GFX1132GISEL-NEXT:    global_store_b64 v[0:1], v[2:3], off
@@ -1541,7 +2000,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %id.x) {
 ; GFX12DAGISEL-NEXT:    s_mov_b32 s0, 0
 ; GFX12DAGISEL-NEXT:    s_brev_b32 s1, 1
 ; GFX12DAGISEL-NEXT:    s_mov_b32 s2, exec_lo
-; GFX12DAGISEL-NEXT:  .LBB4_1: ; =>This Inner Loop Header: Depth=1
+; GFX12DAGISEL-NEXT:  .LBB5_1: ; =>This Inner Loop Header: Depth=1
 ; GFX12DAGISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
 ; GFX12DAGISEL-NEXT:    s_ctz_i32_b32 s3, s2
 ; GFX12DAGISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
@@ -1554,7 +2013,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %id.x) {
 ; GFX12DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_2)
 ; GFX12DAGISEL-NEXT:    v_readfirstlane_b32 s0, v4
 ; GFX12DAGISEL-NEXT:    v_readfirstlane_b32 s1, v5
-; GFX12DAGISEL-NEXT:    s_cbranch_scc1 .LBB4_1
+; GFX12DAGISEL-NEXT:    s_cbranch_scc1 .LBB5_1
 ; GFX12DAGISEL-NEXT:  ; %bb.2:
 ; GFX12DAGISEL-NEXT:    s_wait_alu depctr_va_sdst(0)
 ; GFX12DAGISEL-NEXT:    v_dual_mov_b32 v3, s1 :: v_dual_mov_b32 v2, s0
@@ -1575,7 +2034,7 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX8DAGISEL-NEXT:    ; implicit-def: $sgpr6_sgpr7
 ; GFX8DAGISEL-NEXT:    s_and_saveexec_b64 s[8:9], vcc
 ; GFX8DAGISEL-NEXT:    s_xor_b64 s[8:9], exec, s[8:9]
-; GFX8DAGISEL-NEXT:    s_cbranch_execz .LBB5_2
+; GFX8DAGISEL-NEXT:    s_cbranch_execz .LBB6_2
 ; GFX8DAGISEL-NEXT:  ; %bb.1: ; %else
 ; GFX8DAGISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX8DAGISEL-NEXT:    s_bcnt1_i32_b64 s6, s[6:7]
@@ -1584,13 +2043,13 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX8DAGISEL-NEXT:    v_mul_f64 v[0:1], s[2:3], v[0:1]
 ; GFX8DAGISEL-NEXT:    v_readfirstlane_b32 s6, v0
 ; GFX8DAGISEL-NEXT:    v_readfirstlane_b32 s7, v1
-; GFX8DAGISEL-NEXT:  .LBB5_2: ; %Flow
+; GFX8DAGISEL-NEXT:  .LBB6_2: ; %Flow
 ; GFX8DAGISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX8DAGISEL-NEXT:    s_or_saveexec_b64 s[2:3], s[8:9]
 ; GFX8DAGISEL-NEXT:    v_mov_b32_e32 v0, s6
 ; GFX8DAGISEL-NEXT:    v_mov_b32_e32 v1, s7
 ; GFX8DAGISEL-NEXT:    s_xor_b64 exec, exec, s[2:3]
-; GFX8DAGISEL-NEXT:    s_cbranch_execz .LBB5_4
+; GFX8DAGISEL-NEXT:    s_cbranch_execz .LBB6_4
 ; GFX8DAGISEL-NEXT:  ; %bb.3: ; %if
 ; GFX8DAGISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX8DAGISEL-NEXT:    s_bcnt1_i32_b64 s6, s[6:7]
@@ -1600,7 +2059,7 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX8DAGISEL-NEXT:    v_readfirstlane_b32 s5, v1
 ; GFX8DAGISEL-NEXT:    v_mov_b32_e32 v0, s4
 ; GFX8DAGISEL-NEXT:    v_mov_b32_e32 v1, s5
-; GFX8DAGISEL-NEXT:  .LBB5_4: ; %endif
+; GFX8DAGISEL-NEXT:  .LBB6_4: ; %endif
 ; GFX8DAGISEL-NEXT:    s_or_b64 exec, exec, s[2:3]
 ; GFX8DAGISEL-NEXT:    v_mov_b32_e32 v2, s0
 ; GFX8DAGISEL-NEXT:    v_mov_b32_e32 v3, s1
@@ -1614,7 +2073,7 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX8GISEL-NEXT:    ; implicit-def: $sgpr6_sgpr7
 ; GFX8GISEL-NEXT:    s_and_saveexec_b64 s[8:9], vcc
 ; GFX8GISEL-NEXT:    s_xor_b64 s[8:9], exec, s[8:9]
-; GFX8GISEL-NEXT:    s_cbranch_execz .LBB5_2
+; GFX8GISEL-NEXT:    s_cbranch_execz .LBB6_2
 ; GFX8GISEL-NEXT:  ; %bb.1: ; %else
 ; GFX8GISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX8GISEL-NEXT:    s_bcnt1_i32_b64 s6, s[6:7]
@@ -1623,10 +2082,10 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX8GISEL-NEXT:    v_mul_f64 v[0:1], s[2:3], v[0:1]
 ; GFX8GISEL-NEXT:    v_readfirstlane_b32 s6, v0
 ; GFX8GISEL-NEXT:    v_readfirstlane_b32 s7, v1
-; GFX8GISEL-NEXT:  .LBB5_2: ; %Flow
+; GFX8GISEL-NEXT:  .LBB6_2: ; %Flow
 ; GFX8GISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX8GISEL-NEXT:    s_andn2_saveexec_b64 s[2:3], s[8:9]
-; GFX8GISEL-NEXT:    s_cbranch_execz .LBB5_4
+; GFX8GISEL-NEXT:    s_cbranch_execz .LBB6_4
 ; GFX8GISEL-NEXT:  ; %bb.3: ; %if
 ; GFX8GISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX8GISEL-NEXT:    s_load_dwordx2 s[4:5], s[4:5], 0x34
@@ -1636,7 +2095,7 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX8GISEL-NEXT:    v_mul_f64 v[0:1], s[4:5], v[0:1]
 ; GFX8GISEL-NEXT:    v_readfirstlane_b32 s6, v0
 ; GFX8GISEL-NEXT:    v_readfirstlane_b32 s7, v1
-; GFX8GISEL-NEXT:  .LBB5_4: ; %endif
+; GFX8GISEL-NEXT:  .LBB6_4: ; %endif
 ; GFX8GISEL-NEXT:    s_or_b64 exec, exec, s[2:3]
 ; GFX8GISEL-NEXT:    v_mov_b32_e32 v0, s6
 ; GFX8GISEL-NEXT:    v_mov_b32_e32 v3, s1
@@ -1653,7 +2112,7 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX9DAGISEL-NEXT:    ; implicit-def: $sgpr4_sgpr5
 ; GFX9DAGISEL-NEXT:    s_and_saveexec_b64 s[8:9], vcc
 ; GFX9DAGISEL-NEXT:    s_xor_b64 s[8:9], exec, s[8:9]
-; GFX9DAGISEL-NEXT:    s_cbranch_execz .LBB5_2
+; GFX9DAGISEL-NEXT:    s_cbranch_execz .LBB6_2
 ; GFX9DAGISEL-NEXT:  ; %bb.1: ; %else
 ; GFX9DAGISEL-NEXT:    s_mov_b64 s[4:5], exec
 ; GFX9DAGISEL-NEXT:    s_bcnt1_i32_b64 s4, s[4:5]
@@ -1662,13 +2121,13 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX9DAGISEL-NEXT:    v_mul_f64 v[0:1], s[2:3], v[0:1]
 ; GFX9DAGISEL-NEXT:    v_readfirstlane_b32 s4, v0
 ; GFX9DAGISEL-NEXT:    v_readfirstlane_b32 s5, v1
-; GFX9DAGISEL-NEXT:  .LBB5_2: ; %Flow
+; GFX9DAGISEL-NEXT:  .LBB6_2: ; %Flow
 ; GFX9DAGISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX9DAGISEL-NEXT:    s_or_saveexec_b64 s[2:3], s[8:9]
 ; GFX9DAGISEL-NEXT:    v_mov_b32_e32 v0, s4
 ; GFX9DAGISEL-NEXT:    v_mov_b32_e32 v1, s5
 ; GFX9DAGISEL-NEXT:    s_xor_b64 exec, exec, s[2:3]
-; GFX9DAGISEL-NEXT:    s_cbranch_execz .LBB5_4
+; GFX9DAGISEL-NEXT:    s_cbranch_execz .LBB6_4
 ; GFX9DAGISEL-NEXT:  ; %bb.3: ; %if
 ; GFX9DAGISEL-NEXT:    s_mov_b64 s[4:5], exec
 ; GFX9DAGISEL-NEXT:    s_bcnt1_i32_b64 s4, s[4:5]
@@ -1678,7 +2137,7 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX9DAGISEL-NEXT:    v_readfirstlane_b32 s5, v1
 ; GFX9DAGISEL-NEXT:    v_mov_b32_e32 v0, s4
 ; GFX9DAGISEL-NEXT:    v_mov_b32_e32 v1, s5
-; GFX9DAGISEL-NEXT:  .LBB5_4: ; %endif
+; GFX9DAGISEL-NEXT:  .LBB6_4: ; %endif
 ; GFX9DAGISEL-NEXT:    s_or_b64 exec, exec, s[2:3]
 ; GFX9DAGISEL-NEXT:    v_mov_b32_e32 v2, 0
 ; GFX9DAGISEL-NEXT:    global_store_dwordx2 v2, v[0:1], s[0:1]
@@ -1691,7 +2150,7 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX9GISEL-NEXT:    ; implicit-def: $sgpr6_sgpr7
 ; GFX9GISEL-NEXT:    s_and_saveexec_b64 s[8:9], vcc
 ; GFX9GISEL-NEXT:    s_xor_b64 s[8:9], exec, s[8:9]
-; GFX9GISEL-NEXT:    s_cbranch_execz .LBB5_2
+; GFX9GISEL-NEXT:    s_cbranch_execz .LBB6_2
 ; GFX9GISEL-NEXT:  ; %bb.1: ; %else
 ; GFX9GISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX9GISEL-NEXT:    s_bcnt1_i32_b64 s6, s[6:7]
@@ -1700,10 +2159,10 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX9GISEL-NEXT:    v_mul_f64 v[0:1], s[2:3], v[0:1]
 ; GFX9GISEL-NEXT:    v_readfirstlane_b32 s6, v0
 ; GFX9GISEL-NEXT:    v_readfirstlane_b32 s7, v1
-; GFX9GISEL-NEXT:  .LBB5_2: ; %Flow
+; GFX9GISEL-NEXT:  .LBB6_2: ; %Flow
 ; GFX9GISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX9GISEL-NEXT:    s_andn2_saveexec_b64 s[2:3], s[8:9]
-; GFX9GISEL-NEXT:    s_cbranch_execz .LBB5_4
+; GFX9GISEL-NEXT:    s_cbranch_execz .LBB6_4
 ; GFX9GISEL-NEXT:  ; %bb.3: ; %if
 ; GFX9GISEL-NEXT:    s_load_dwordx2 s[6:7], s[4:5], 0x34
 ; GFX9GISEL-NEXT:    s_mov_b64 s[4:5], exec
@@ -1713,7 +2172,7 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX9GISEL-NEXT:    v_mul_f64 v[0:1], s[6:7], v[0:1]
 ; GFX9GISEL-NEXT:    v_readfirstlane_b32 s6, v0
 ; GFX9GISEL-NEXT:    v_readfirstlane_b32 s7, v1
-; GFX9GISEL-NEXT:  .LBB5_4: ; %endif
+; GFX9GISEL-NEXT:  .LBB6_4: ; %endif
 ; GFX9GISEL-NEXT:    s_or_b64 exec, exec, s[2:3]
 ; GFX9GISEL-NEXT:    v_mov_b32_e32 v0, s6
 ; GFX9GISEL-NEXT:    v_mov_b32_e32 v1, s7
@@ -1730,7 +2189,7 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX1064DAGISEL-NEXT:    ; implicit-def: $sgpr8_sgpr9
 ; GFX1064DAGISEL-NEXT:    s_and_saveexec_b64 s[4:5], vcc
 ; GFX1064DAGISEL-NEXT:    s_xor_b64 s[4:5], exec, s[4:5]
-; GFX1064DAGISEL-NEXT:    s_cbranch_execz .LBB5_2
+; GFX1064DAGISEL-NEXT:    s_cbranch_execz .LBB6_2
 ; GFX1064DAGISEL-NEXT:  ; %bb.1: ; %else
 ; GFX1064DAGISEL-NEXT:    s_mov_b64 s[8:9], exec
 ; GFX1064DAGISEL-NEXT:    s_bcnt1_i32_b64 s8, s[8:9]
@@ -1739,13 +2198,13 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX1064DAGISEL-NEXT:    v_mul_f64 v[0:1], s[2:3], v[0:1]
 ; GFX1064DAGISEL-NEXT:    v_readfirstlane_b32 s8, v0
 ; GFX1064DAGISEL-NEXT:    v_readfirstlane_b32 s9, v1
-; GFX1064DAGISEL-NEXT:  .LBB5_2: ; %Flow
+; GFX1064DAGISEL-NEXT:  .LBB6_2: ; %Flow
 ; GFX1064DAGISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX1064DAGISEL-NEXT:    s_or_saveexec_b64 s[2:3], s[4:5]
 ; GFX1064DAGISEL-NEXT:    v_mov_b32_e32 v0, s8
 ; GFX1064DAGISEL-NEXT:    v_mov_b32_e32 v1, s9
 ; GFX1064DAGISEL-NEXT:    s_xor_b64 exec, exec, s[2:3]
-; GFX1064DAGISEL-NEXT:    s_cbranch_execz .LBB5_4
+; GFX1064DAGISEL-NEXT:    s_cbranch_execz .LBB6_4
 ; GFX1064DAGISEL-NEXT:  ; %bb.3: ; %if
 ; GFX1064DAGISEL-NEXT:    s_mov_b64 s[4:5], exec
 ; GFX1064DAGISEL-NEXT:    s_bcnt1_i32_b64 s4, s[4:5]
@@ -1755,7 +2214,7 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX1064DAGISEL-NEXT:    v_readfirstlane_b32 s5, v1
 ; GFX1064DAGISEL-NEXT:    v_mov_b32_e32 v0, s4
 ; GFX1064DAGISEL-NEXT:    v_mov_b32_e32 v1, s5
-; GFX1064DAGISEL-NEXT:  .LBB5_4: ; %endif
+; GFX1064DAGISEL-NEXT:  .LBB6_4: ; %endif
 ; GFX1064DAGISEL-NEXT:    s_or_b64 exec, exec, s[2:3]
 ; GFX1064DAGISEL-NEXT:    v_mov_b32_e32 v2, 0
 ; GFX1064DAGISEL-NEXT:    global_store_dwordx2 v2, v[0:1], s[0:1]
@@ -1768,7 +2227,7 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX1064GISEL-NEXT:    ; implicit-def: $sgpr6_sgpr7
 ; GFX1064GISEL-NEXT:    s_and_saveexec_b64 s[8:9], vcc
 ; GFX1064GISEL-NEXT:    s_xor_b64 s[8:9], exec, s[8:9]
-; GFX1064GISEL-NEXT:    s_cbranch_execz .LBB5_2
+; GFX1064GISEL-NEXT:    s_cbranch_execz .LBB6_2
 ; GFX1064GISEL-NEXT:  ; %bb.1: ; %else
 ; GFX1064GISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX1064GISEL-NEXT:    s_bcnt1_i32_b64 s6, s[6:7]
@@ -1777,10 +2236,10 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX1064GISEL-NEXT:    v_mul_f64 v[0:1], s[2:3], v[0:1]
 ; GFX1064GISEL-NEXT:    v_readfirstlane_b32 s6, v0
 ; GFX1064GISEL-NEXT:    v_readfirstlane_b32 s7, v1
-; GFX1064GISEL-NEXT:  .LBB5_2: ; %Flow
+; GFX1064GISEL-NEXT:  .LBB6_2: ; %Flow
 ; GFX1064GISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX1064GISEL-NEXT:    s_andn2_saveexec_b64 s[2:3], s[8:9]
-; GFX1064GISEL-NEXT:    s_cbranch_execz .LBB5_4
+; GFX1064GISEL-NEXT:    s_cbranch_execz .LBB6_4
 ; GFX1064GISEL-NEXT:  ; %bb.3: ; %if
 ; GFX1064GISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX1064GISEL-NEXT:    s_bcnt1_i32_b64 s6, s[6:7]
@@ -1790,7 +2249,7 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX1064GISEL-NEXT:    v_mul_f64 v[0:1], s[6:7], v[0:1]
 ; GFX1064GISEL-NEXT:    v_readfirstlane_b32 s6, v0
 ; GFX1064GISEL-NEXT:    v_readfirstlane_b32 s7, v1
-; GFX1064GISEL-NEXT:  .LBB5_4: ; %endif
+; GFX1064GISEL-NEXT:  .LBB6_4: ; %endif
 ; GFX1064GISEL-NEXT:    s_or_b64 exec, exec, s[2:3]
 ; GFX1064GISEL-NEXT:    v_mov_b32_e32 v0, s6
 ; GFX1064GISEL-NEXT:    v_mov_b32_e32 v1, s7
@@ -1807,7 +2266,7 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX1032DAGISEL-NEXT:    ; implicit-def: $sgpr4_sgpr5
 ; GFX1032DAGISEL-NEXT:    s_and_saveexec_b32 s8, vcc_lo
 ; GFX1032DAGISEL-NEXT:    s_xor_b32 s8, exec_lo, s8
-; GFX1032DAGISEL-NEXT:    s_cbranch_execz .LBB5_2
+; GFX1032DAGISEL-NEXT:    s_cbranch_execz .LBB6_2
 ; GFX1032DAGISEL-NEXT:  ; %bb.1: ; %else
 ; GFX1032DAGISEL-NEXT:    s_mov_b32 s4, exec_lo
 ; GFX1032DAGISEL-NEXT:    s_bcnt1_i32_b32 s4, s4
@@ -1816,13 +2275,13 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX1032DAGISEL-NEXT:    v_mul_f64 v[0:1], s[2:3], v[0:1]
 ; GFX1032DAGISEL-NEXT:    v_readfirstlane_b32 s4, v0
 ; GFX1032DAGISEL-NEXT:    v_readfirstlane_b32 s5, v1
-; GFX1032DAGISEL-NEXT:  .LBB5_2: ; %Flow
+; GFX1032DAGISEL-NEXT:  .LBB6_2: ; %Flow
 ; GFX1032DAGISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX1032DAGISEL-NEXT:    s_or_saveexec_b32 s2, s8
 ; GFX1032DAGISEL-NEXT:    v_mov_b32_e32 v0, s4
 ; GFX1032DAGISEL-NEXT:    v_mov_b32_e32 v1, s5
 ; GFX1032DAGISEL-NEXT:    s_xor_b32 exec_lo, exec_lo, s2
-; GFX1032DAGISEL-NEXT:    s_cbranch_execz .LBB5_4
+; GFX1032DAGISEL-NEXT:    s_cbranch_execz .LBB6_4
 ; GFX1032DAGISEL-NEXT:  ; %bb.3: ; %if
 ; GFX1032DAGISEL-NEXT:    s_mov_b32 s3, exec_lo
 ; GFX1032DAGISEL-NEXT:    s_bcnt1_i32_b32 s3, s3
@@ -1832,7 +2291,7 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX1032DAGISEL-NEXT:    v_readfirstlane_b32 s5, v1
 ; GFX1032DAGISEL-NEXT:    v_mov_b32_e32 v0, s4
 ; GFX1032DAGISEL-NEXT:    v_mov_b32_e32 v1, s5
-; GFX1032DAGISEL-NEXT:  .LBB5_4: ; %endif
+; GFX1032DAGISEL-NEXT:  .LBB6_4: ; %endif
 ; GFX1032DAGISEL-NEXT:    s_or_b32 exec_lo, exec_lo, s2
 ; GFX1032DAGISEL-NEXT:    v_mov_b32_e32 v2, 0
 ; GFX1032DAGISEL-NEXT:    global_store_dwordx2 v2, v[0:1], s[0:1]
@@ -1845,7 +2304,7 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX1032GISEL-NEXT:    ; implicit-def: $sgpr6_sgpr7
 ; GFX1032GISEL-NEXT:    s_and_saveexec_b32 s8, vcc_lo
 ; GFX1032GISEL-NEXT:    s_xor_b32 s8, exec_lo, s8
-; GFX1032GISEL-NEXT:    s_cbranch_execz .LBB5_2
+; GFX1032GISEL-NEXT:    s_cbranch_execz .LBB6_2
 ; GFX1032GISEL-NEXT:  ; %bb.1: ; %else
 ; GFX1032GISEL-NEXT:    s_mov_b32 s6, exec_lo
 ; GFX1032GISEL-NEXT:    s_bcnt1_i32_b32 s6, s6
@@ -1854,10 +2313,10 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX1032GISEL-NEXT:    v_mul_f64 v[0:1], s[2:3], v[0:1]
 ; GFX1032GISEL-NEXT:    v_readfirstlane_b32 s6, v0
 ; GFX1032GISEL-NEXT:    v_readfirstlane_b32 s7, v1
-; GFX1032GISEL-NEXT:  .LBB5_2: ; %Flow
+; GFX1032GISEL-NEXT:  .LBB6_2: ; %Flow
 ; GFX1032GISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX1032GISEL-NEXT:    s_andn2_saveexec_b32 s2, s8
-; GFX1032GISEL-NEXT:    s_cbranch_execz .LBB5_4
+; GFX1032GISEL-NEXT:    s_cbranch_execz .LBB6_4
 ; GFX1032GISEL-NEXT:  ; %bb.3: ; %if
 ; GFX1032GISEL-NEXT:    s_mov_b32 s3, exec_lo
 ; GFX1032GISEL-NEXT:    s_load_dwordx2 s[6:7], s[4:5], 0x34
@@ -1867,7 +2326,7 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX1032GISEL-NEXT:    v_mul_f64 v[0:1], s[6:7], v[0:1]
 ; GFX1032GISEL-NEXT:    v_readfirstlane_b32 s6, v0
 ; GFX1032GISEL-NEXT:    v_readfirstlane_b32 s7, v1
-; GFX1032GISEL-NEXT:  .LBB5_4: ; %endif
+; GFX1032GISEL-NEXT:  .LBB6_4: ; %endif
 ; GFX1032GISEL-NEXT:    s_or_b32 exec_lo, exec_lo, s2
 ; GFX1032GISEL-NEXT:    v_mov_b32_e32 v0, s6
 ; GFX1032GISEL-NEXT:    v_mov_b32_e32 v1, s7
@@ -1886,7 +2345,7 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX1164DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX1164DAGISEL-NEXT:    v_cmpx_lt_u32_e32 15, v0
 ; GFX1164DAGISEL-NEXT:    s_xor_b64 s[6:7], exec, s[6:7]
-; GFX1164DAGISEL-NEXT:    s_cbranch_execz .LBB5_2
+; GFX1164DAGISEL-NEXT:    s_cbranch_execz .LBB6_2
 ; GFX1164DAGISEL-NEXT:  ; %bb.1: ; %else
 ; GFX1164DAGISEL-NEXT:    s_mov_b64 s[8:9], exec
 ; GFX1164DAGISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
@@ -1898,14 +2357,14 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX1164DAGISEL-NEXT:    v_readfirstlane_b32 s8, v0
 ; GFX1164DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2)
 ; GFX1164DAGISEL-NEXT:    v_readfirstlane_b32 s9, v1
-; GFX1164DAGISEL-NEXT:  .LBB5_2: ; %Flow
+; GFX1164DAGISEL-NEXT:  .LBB6_2: ; %Flow
 ; GFX1164DAGISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX1164DAGISEL-NEXT:    s_or_saveexec_b64 s[2:3], s[6:7]
 ; GFX1164DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
 ; GFX1164DAGISEL-NEXT:    v_mov_b32_e32 v0, s8
 ; GFX1164DAGISEL-NEXT:    v_mov_b32_e32 v1, s9
 ; GFX1164DAGISEL-NEXT:    s_xor_b64 exec, exec, s[2:3]
-; GFX1164DAGISEL-NEXT:    s_cbranch_execz .LBB5_4
+; GFX1164DAGISEL-NEXT:    s_cbranch_execz .LBB6_4
 ; GFX1164DAGISEL-NEXT:  ; %bb.3: ; %if
 ; GFX1164DAGISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX1164DAGISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
@@ -1919,7 +2378,7 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX1164DAGISEL-NEXT:    v_mov_b32_e32 v0, s4
 ; GFX1164DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2)
 ; GFX1164DAGISEL-NEXT:    v_mov_b32_e32 v1, s5
-; GFX1164DAGISEL-NEXT:  .LBB5_4: ; %endif
+; GFX1164DAGISEL-NEXT:  .LBB6_4: ; %endif
 ; GFX1164DAGISEL-NEXT:    s_or_b64 exec, exec, s[2:3]
 ; GFX1164DAGISEL-NEXT:    v_mov_b32_e32 v2, 0
 ; GFX1164DAGISEL-NEXT:    global_store_b64 v2, v[0:1], s[0:1]
@@ -1934,7 +2393,7 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX1164GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX1164GISEL-NEXT:    v_cmpx_le_u32_e32 16, v0
 ; GFX1164GISEL-NEXT:    s_xor_b64 s[8:9], exec, s[8:9]
-; GFX1164GISEL-NEXT:    s_cbranch_execz .LBB5_2
+; GFX1164GISEL-NEXT:    s_cbranch_execz .LBB6_2
 ; GFX1164GISEL-NEXT:  ; %bb.1: ; %else
 ; GFX1164GISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX1164GISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
@@ -1946,10 +2405,10 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX1164GISEL-NEXT:    v_readfirstlane_b32 s6, v0
 ; GFX1164GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2)
 ; GFX1164GISEL-NEXT:    v_readfirstlane_b32 s7, v1
-; GFX1164GISEL-NEXT:  .LBB5_2: ; %Flow
+; GFX1164GISEL-NEXT:  .LBB6_2: ; %Flow
 ; GFX1164GISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX1164GISEL-NEXT:    s_and_not1_saveexec_b64 s[2:3], s[8:9]
-; GFX1164GISEL-NEXT:    s_cbranch_execz .LBB5_4
+; GFX1164GISEL-NEXT:    s_cbranch_execz .LBB6_4
 ; GFX1164GISEL-NEXT:  ; %bb.3: ; %if
 ; GFX1164GISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX1164GISEL-NEXT:    s_load_b64 s[4:5], s[4:5], 0x34
@@ -1961,7 +2420,7 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX1164GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_2)
 ; GFX1164GISEL-NEXT:    v_readfirstlane_b32 s6, v0
 ; GFX1164GISEL-NEXT:    v_readfirstlane_b32 s7, v1
-; GFX1164GISEL-NEXT:  .LBB5_4: ; %endif
+; GFX1164GISEL-NEXT:  .LBB6_4: ; %endif
 ; GFX1164GISEL-NEXT:    s_or_b64 exec, exec, s[2:3]
 ; GFX1164GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
 ; GFX1164GISEL-NEXT:    v_mov_b32_e32 v0, s6
@@ -1981,7 +2440,7 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX1132DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX1132DAGISEL-NEXT:    v_cmpx_lt_u32_e32 15, v0
 ; GFX1132DAGISEL-NEXT:    s_xor_b32 s8, exec_lo, s8
-; GFX1132DAGISEL-NEXT:    s_cbranch_execz .LBB5_2
+; GFX1132DAGISEL-NEXT:    s_cbranch_execz .LBB6_2
 ; GFX1132DAGISEL-NEXT:  ; %bb.1: ; %else
 ; GFX1132DAGISEL-NEXT:    s_mov_b32 s6, exec_lo
 ; GFX1132DAGISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
@@ -1993,13 +2452,13 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX1132DAGISEL-NEXT:    v_readfirstlane_b32 s6, v0
 ; GFX1132DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2)
 ; GFX1132DAGISEL-NEXT:    v_readfirstlane_b32 s7, v1
-; GFX1132DAGISEL-NEXT:  .LBB5_2: ; %Flow
+; GFX1132DAGISEL-NEXT:  .LBB6_2: ; %Flow
 ; GFX1132DAGISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX1132DAGISEL-NEXT:    s_or_saveexec_b32 s2, s8
 ; GFX1132DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX1132DAGISEL-NEXT:    v_dual_mov_b32 v0, s6 :: v_dual_mov_b32 v1, s7
 ; GFX1132DAGISEL-NEXT:    s_xor_b32 exec_lo, exec_lo, s2
-; GFX1132DAGISEL-NEXT:    s_cbranch_execz .LBB5_4
+; GFX1132DAGISEL-NEXT:    s_cbranch_execz .LBB6_4
 ; GFX1132DAGISEL-NEXT:  ; %bb.3: ; %if
 ; GFX1132DAGISEL-NEXT:    s_mov_b32 s3, exec_lo
 ; GFX1132DAGISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
@@ -2011,7 +2470,7 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX1132DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_1)
 ; GFX1132DAGISEL-NEXT:    v_readfirstlane_b32 s5, v1
 ; GFX1132DAGISEL-NEXT:    v_dual_mov_b32 v0, s4 :: v_dual_mov_b32 v1, s5
-; GFX1132DAGISEL-NEXT:  .LBB5_4: ; %endif
+; GFX1132DAGISEL-NEXT:  .LBB6_4: ; %endif
 ; GFX1132DAGISEL-NEXT:    s_or_b32 exec_lo, exec_lo, s2
 ; GFX1132DAGISEL-NEXT:    v_mov_b32_e32 v2, 0
 ; GFX1132DAGISEL-NEXT:    global_store_b64 v2, v[0:1], s[0:1]
@@ -2026,7 +2485,7 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX1132GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX1132GISEL-NEXT:    v_cmpx_le_u32_e32 16, v0
 ; GFX1132GISEL-NEXT:    s_xor_b32 s8, exec_lo, s8
-; GFX1132GISEL-NEXT:    s_cbranch_execz .LBB5_2
+; GFX1132GISEL-NEXT:    s_cbranch_execz .LBB6_2
 ; GFX1132GISEL-NEXT:  ; %bb.1: ; %else
 ; GFX1132GISEL-NEXT:    s_mov_b32 s6, exec_lo
 ; GFX1132GISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
@@ -2038,10 +2497,10 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX1132GISEL-NEXT:    v_readfirstlane_b32 s6, v0
 ; GFX1132GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2)
 ; GFX1132GISEL-NEXT:    v_readfirstlane_b32 s7, v1
-; GFX1132GISEL-NEXT:  .LBB5_2: ; %Flow
+; GFX1132GISEL-NEXT:  .LBB6_2: ; %Flow
 ; GFX1132GISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX1132GISEL-NEXT:    s_and_not1_saveexec_b32 s2, s8
-; GFX1132GISEL-NEXT:    s_cbranch_execz .LBB5_4
+; GFX1132GISEL-NEXT:    s_cbranch_execz .LBB6_4
 ; GFX1132GISEL-NEXT:  ; %bb.3: ; %if
 ; GFX1132GISEL-NEXT:    s_mov_b32 s3, exec_lo
 ; GFX1132GISEL-NEXT:    s_load_b64 s[4:5], s[4:5], 0x34
@@ -2053,7 +2512,7 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX1132GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_2)
 ; GFX1132GISEL-NEXT:    v_readfirstlane_b32 s6, v0
 ; GFX1132GISEL-NEXT:    v_readfirstlane_b32 s7, v1
-; GFX1132GISEL-NEXT:  .LBB5_4: ; %endif
+; GFX1132GISEL-NEXT:  .LBB6_4: ; %endif
 ; GFX1132GISEL-NEXT:    s_or_b32 exec_lo, exec_lo, s2
 ; GFX1132GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX1132GISEL-NEXT:    v_dual_mov_b32 v0, s6 :: v_dual_mov_b32 v1, s7
@@ -2072,7 +2531,7 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX12DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX12DAGISEL-NEXT:    v_cmpx_lt_u32_e32 15, v0
 ; GFX12DAGISEL-NEXT:    s_xor_b32 s8, exec_lo, s8
-; GFX12DAGISEL-NEXT:    s_cbranch_execz .LBB5_2
+; GFX12DAGISEL-NEXT:    s_cbranch_execz .LBB6_2
 ; GFX12DAGISEL-NEXT:  ; %bb.1: ; %else
 ; GFX12DAGISEL-NEXT:    s_mov_b32 s6, exec_lo
 ; GFX12DAGISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
@@ -2084,7 +2543,7 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX12DAGISEL-NEXT:    v_readfirstlane_b32 s6, v0
 ; GFX12DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2)
 ; GFX12DAGISEL-NEXT:    v_readfirstlane_b32 s7, v1
-; GFX12DAGISEL-NEXT:  .LBB5_2: ; %Flow
+; GFX12DAGISEL-NEXT:  .LBB6_2: ; %Flow
 ; GFX12DAGISEL-NEXT:    s_wait_kmcnt 0x0
 ; GFX12DAGISEL-NEXT:    s_or_saveexec_b32 s2, s8
 ; GFX12DAGISEL-NEXT:    s_wait_alu depctr_va_sdst(0)
@@ -2092,7 +2551,7 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX12DAGISEL-NEXT:    v_dual_mov_b32 v0, s6 :: v_dual_mov_b32 v1, s7
 ; GFX12DAGISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
 ; GFX12DAGISEL-NEXT:    s_xor_b32 exec_lo, exec_lo, s2
-; GFX12DAGISEL-NEXT:    s_cbranch_execz .LBB5_4
+; GFX12DAGISEL-NEXT:    s_cbranch_execz .LBB6_4
 ; GFX12DAGISEL-NEXT:  ; %bb.3: ; %if
 ; GFX12DAGISEL-NEXT:    s_mov_b32 s3, exec_lo
 ; GFX12DAGISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
@@ -2106,7 +2565,7 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX12DAGISEL-NEXT:    v_readfirstlane_b32 s5, v1
 ; GFX12DAGISEL-NEXT:    s_wait_alu depctr_va_sdst(0)
 ; GFX12DAGISEL-NEXT:    v_dual_mov_b32 v0, s4 :: v_dual_mov_b32 v1, s5
-; GFX12DAGISEL-NEXT:  .LBB5_4: ; %endif
+; GFX12DAGISEL-NEXT:  .LBB6_4: ; %endif
 ; GFX12DAGISEL-NEXT:    s_or_b32 exec_lo, exec_lo, s2
 ; GFX12DAGISEL-NEXT:    v_mov_b32_e32 v2, 0
 ; GFX12DAGISEL-NEXT:    global_store_b64 v2, v[0:1], s[0:1]

--- a/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.reduce.fmax.ll
+++ b/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.reduce.fmax.ll
@@ -399,6 +399,465 @@ entry:
   ret void
 }
 
+define void @divergent_value_float_dpp(ptr addrspace(1) %out, float %in) {
+; GFX8DAGISEL-LABEL: divergent_value_float_dpp:
+; GFX8DAGISEL:       ; %bb.0: ; %entry
+; GFX8DAGISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX8DAGISEL-NEXT:    s_xor_saveexec_b64 s[4:5], -1
+; GFX8DAGISEL-NEXT:    buffer_store_dword v3, off, s[0:3], s32 ; 4-byte Folded Spill
+; GFX8DAGISEL-NEXT:    s_mov_b64 exec, s[4:5]
+; GFX8DAGISEL-NEXT:    s_or_saveexec_b64 s[4:5], -1
+; GFX8DAGISEL-NEXT:    v_mov_b32_e32 v3, 0x7fc00000
+; GFX8DAGISEL-NEXT:    v_cndmask_b32_e64 v3, v3, v2, s[4:5]
+; GFX8DAGISEL-NEXT:    s_nop 1
+; GFX8DAGISEL-NEXT:    v_max_f32_dpp v3, v3, v3 row_shr:1 row_mask:0xf bank_mask:0xf
+; GFX8DAGISEL-NEXT:    s_nop 1
+; GFX8DAGISEL-NEXT:    v_max_f32_dpp v3, v3, v3 row_shr:2 row_mask:0xf bank_mask:0xf
+; GFX8DAGISEL-NEXT:    s_nop 1
+; GFX8DAGISEL-NEXT:    v_max_f32_dpp v3, v3, v3 row_shr:4 row_mask:0xf bank_mask:0xf
+; GFX8DAGISEL-NEXT:    s_nop 1
+; GFX8DAGISEL-NEXT:    v_max_f32_dpp v3, v3, v3 row_shr:8 row_mask:0xf bank_mask:0xf
+; GFX8DAGISEL-NEXT:    s_nop 1
+; GFX8DAGISEL-NEXT:    v_max_f32_dpp v3, v3, v3 row_bcast:15 row_mask:0xf bank_mask:0xf
+; GFX8DAGISEL-NEXT:    s_nop 1
+; GFX8DAGISEL-NEXT:    v_max_f32_dpp v3, v3, v3 row_bcast:31 row_mask:0xf bank_mask:0xf
+; GFX8DAGISEL-NEXT:    v_readlane_b32 s6, v3, 63
+; GFX8DAGISEL-NEXT:    s_mov_b64 exec, s[4:5]
+; GFX8DAGISEL-NEXT:    v_mov_b32_e32 v2, s6
+; GFX8DAGISEL-NEXT:    flat_store_dword v[0:1], v2
+; GFX8DAGISEL-NEXT:    s_xor_saveexec_b64 s[4:5], -1
+; GFX8DAGISEL-NEXT:    buffer_load_dword v3, off, s[0:3], s32 ; 4-byte Folded Reload
+; GFX8DAGISEL-NEXT:    s_mov_b64 exec, s[4:5]
+; GFX8DAGISEL-NEXT:    s_waitcnt vmcnt(0)
+; GFX8DAGISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX8GISEL-LABEL: divergent_value_float_dpp:
+; GFX8GISEL:       ; %bb.0: ; %entry
+; GFX8GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX8GISEL-NEXT:    s_xor_saveexec_b64 s[4:5], -1
+; GFX8GISEL-NEXT:    buffer_store_dword v3, off, s[0:3], s32 ; 4-byte Folded Spill
+; GFX8GISEL-NEXT:    s_mov_b64 exec, s[4:5]
+; GFX8GISEL-NEXT:    s_or_saveexec_b64 s[4:5], -1
+; GFX8GISEL-NEXT:    v_mov_b32_e32 v3, 0x7fc00000
+; GFX8GISEL-NEXT:    v_cndmask_b32_e64 v3, v3, v2, s[4:5]
+; GFX8GISEL-NEXT:    s_nop 1
+; GFX8GISEL-NEXT:    v_max_f32_dpp v3, v3, v3 row_shr:1 row_mask:0xf bank_mask:0xf
+; GFX8GISEL-NEXT:    s_nop 1
+; GFX8GISEL-NEXT:    v_max_f32_dpp v3, v3, v3 row_shr:2 row_mask:0xf bank_mask:0xf
+; GFX8GISEL-NEXT:    s_nop 1
+; GFX8GISEL-NEXT:    v_max_f32_dpp v3, v3, v3 row_shr:4 row_mask:0xf bank_mask:0xf
+; GFX8GISEL-NEXT:    s_nop 1
+; GFX8GISEL-NEXT:    v_max_f32_dpp v3, v3, v3 row_shr:8 row_mask:0xf bank_mask:0xf
+; GFX8GISEL-NEXT:    s_nop 1
+; GFX8GISEL-NEXT:    v_max_f32_dpp v3, v3, v3 row_bcast:15 row_mask:0xf bank_mask:0xf
+; GFX8GISEL-NEXT:    s_nop 1
+; GFX8GISEL-NEXT:    v_max_f32_dpp v3, v3, v3 row_bcast:31 row_mask:0xf bank_mask:0xf
+; GFX8GISEL-NEXT:    v_readlane_b32 s6, v3, 63
+; GFX8GISEL-NEXT:    s_mov_b64 exec, s[4:5]
+; GFX8GISEL-NEXT:    v_mov_b32_e32 v2, s6
+; GFX8GISEL-NEXT:    flat_store_dword v[0:1], v2
+; GFX8GISEL-NEXT:    s_xor_saveexec_b64 s[4:5], -1
+; GFX8GISEL-NEXT:    buffer_load_dword v3, off, s[0:3], s32 ; 4-byte Folded Reload
+; GFX8GISEL-NEXT:    s_mov_b64 exec, s[4:5]
+; GFX8GISEL-NEXT:    s_waitcnt vmcnt(0)
+; GFX8GISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX9DAGISEL-LABEL: divergent_value_float_dpp:
+; GFX9DAGISEL:       ; %bb.0: ; %entry
+; GFX9DAGISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9DAGISEL-NEXT:    s_xor_saveexec_b64 s[4:5], -1
+; GFX9DAGISEL-NEXT:    buffer_store_dword v3, off, s[0:3], s32 ; 4-byte Folded Spill
+; GFX9DAGISEL-NEXT:    s_mov_b64 exec, s[4:5]
+; GFX9DAGISEL-NEXT:    s_or_saveexec_b64 s[4:5], -1
+; GFX9DAGISEL-NEXT:    v_mov_b32_e32 v3, 0x7fc00000
+; GFX9DAGISEL-NEXT:    v_cndmask_b32_e64 v3, v3, v2, s[4:5]
+; GFX9DAGISEL-NEXT:    s_nop 1
+; GFX9DAGISEL-NEXT:    v_max_f32_dpp v3, v3, v3 row_shr:1 row_mask:0xf bank_mask:0xf
+; GFX9DAGISEL-NEXT:    s_nop 1
+; GFX9DAGISEL-NEXT:    v_max_f32_dpp v3, v3, v3 row_shr:2 row_mask:0xf bank_mask:0xf
+; GFX9DAGISEL-NEXT:    s_nop 1
+; GFX9DAGISEL-NEXT:    v_max_f32_dpp v3, v3, v3 row_shr:4 row_mask:0xf bank_mask:0xf
+; GFX9DAGISEL-NEXT:    s_nop 1
+; GFX9DAGISEL-NEXT:    v_max_f32_dpp v3, v3, v3 row_shr:8 row_mask:0xf bank_mask:0xf
+; GFX9DAGISEL-NEXT:    s_nop 1
+; GFX9DAGISEL-NEXT:    v_max_f32_dpp v3, v3, v3 row_bcast:15 row_mask:0xf bank_mask:0xf
+; GFX9DAGISEL-NEXT:    s_nop 1
+; GFX9DAGISEL-NEXT:    v_max_f32_dpp v3, v3, v3 row_bcast:31 row_mask:0xf bank_mask:0xf
+; GFX9DAGISEL-NEXT:    v_readlane_b32 s6, v3, 63
+; GFX9DAGISEL-NEXT:    s_mov_b64 exec, s[4:5]
+; GFX9DAGISEL-NEXT:    v_mov_b32_e32 v2, s6
+; GFX9DAGISEL-NEXT:    global_store_dword v[0:1], v2, off
+; GFX9DAGISEL-NEXT:    s_xor_saveexec_b64 s[4:5], -1
+; GFX9DAGISEL-NEXT:    buffer_load_dword v3, off, s[0:3], s32 ; 4-byte Folded Reload
+; GFX9DAGISEL-NEXT:    s_mov_b64 exec, s[4:5]
+; GFX9DAGISEL-NEXT:    s_waitcnt vmcnt(0)
+; GFX9DAGISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX9GISEL-LABEL: divergent_value_float_dpp:
+; GFX9GISEL:       ; %bb.0: ; %entry
+; GFX9GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9GISEL-NEXT:    s_xor_saveexec_b64 s[4:5], -1
+; GFX9GISEL-NEXT:    buffer_store_dword v3, off, s[0:3], s32 ; 4-byte Folded Spill
+; GFX9GISEL-NEXT:    s_mov_b64 exec, s[4:5]
+; GFX9GISEL-NEXT:    s_or_saveexec_b64 s[4:5], -1
+; GFX9GISEL-NEXT:    v_mov_b32_e32 v3, 0x7fc00000
+; GFX9GISEL-NEXT:    v_cndmask_b32_e64 v3, v3, v2, s[4:5]
+; GFX9GISEL-NEXT:    s_nop 1
+; GFX9GISEL-NEXT:    v_max_f32_dpp v3, v3, v3 row_shr:1 row_mask:0xf bank_mask:0xf
+; GFX9GISEL-NEXT:    s_nop 1
+; GFX9GISEL-NEXT:    v_max_f32_dpp v3, v3, v3 row_shr:2 row_mask:0xf bank_mask:0xf
+; GFX9GISEL-NEXT:    s_nop 1
+; GFX9GISEL-NEXT:    v_max_f32_dpp v3, v3, v3 row_shr:4 row_mask:0xf bank_mask:0xf
+; GFX9GISEL-NEXT:    s_nop 1
+; GFX9GISEL-NEXT:    v_max_f32_dpp v3, v3, v3 row_shr:8 row_mask:0xf bank_mask:0xf
+; GFX9GISEL-NEXT:    s_nop 1
+; GFX9GISEL-NEXT:    v_max_f32_dpp v3, v3, v3 row_bcast:15 row_mask:0xf bank_mask:0xf
+; GFX9GISEL-NEXT:    s_nop 1
+; GFX9GISEL-NEXT:    v_max_f32_dpp v3, v3, v3 row_bcast:31 row_mask:0xf bank_mask:0xf
+; GFX9GISEL-NEXT:    v_readlane_b32 s6, v3, 63
+; GFX9GISEL-NEXT:    s_mov_b64 exec, s[4:5]
+; GFX9GISEL-NEXT:    v_mov_b32_e32 v2, s6
+; GFX9GISEL-NEXT:    global_store_dword v[0:1], v2, off
+; GFX9GISEL-NEXT:    s_xor_saveexec_b64 s[4:5], -1
+; GFX9GISEL-NEXT:    buffer_load_dword v3, off, s[0:3], s32 ; 4-byte Folded Reload
+; GFX9GISEL-NEXT:    s_mov_b64 exec, s[4:5]
+; GFX9GISEL-NEXT:    s_waitcnt vmcnt(0)
+; GFX9GISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX1064DAGISEL-LABEL: divergent_value_float_dpp:
+; GFX1064DAGISEL:       ; %bb.0: ; %entry
+; GFX1064DAGISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX1064DAGISEL-NEXT:    s_xor_saveexec_b64 s[4:5], -1
+; GFX1064DAGISEL-NEXT:    buffer_store_dword v3, off, s[0:3], s32 ; 4-byte Folded Spill
+; GFX1064DAGISEL-NEXT:    buffer_store_dword v4, off, s[0:3], s32 offset:4 ; 4-byte Folded Spill
+; GFX1064DAGISEL-NEXT:    buffer_store_dword v5, off, s[0:3], s32 offset:8 ; 4-byte Folded Spill
+; GFX1064DAGISEL-NEXT:    s_waitcnt_depctr depctr_vm_vsrc(0)
+; GFX1064DAGISEL-NEXT:    s_mov_b64 exec, s[4:5]
+; GFX1064DAGISEL-NEXT:    s_or_saveexec_b64 s[4:5], -1
+; GFX1064DAGISEL-NEXT:    v_cndmask_b32_e64 v3, 0x7fc00000, v2, s[4:5]
+; GFX1064DAGISEL-NEXT:    v_mbcnt_lo_u32_b32 v5, -1, 0
+; GFX1064DAGISEL-NEXT:    v_max_f32_dpp v3, v3, v3 row_shr:1 row_mask:0xf bank_mask:0xf
+; GFX1064DAGISEL-NEXT:    v_mbcnt_hi_u32_b32 v5, -1, v5
+; GFX1064DAGISEL-NEXT:    v_max_f32_dpp v3, v3, v3 row_shr:2 row_mask:0xf bank_mask:0xf
+; GFX1064DAGISEL-NEXT:    v_add_nc_u32_e32 v5, 32, v5
+; GFX1064DAGISEL-NEXT:    v_max_f32_dpp v3, v3, v3 row_shr:4 row_mask:0xf bank_mask:0xf
+; GFX1064DAGISEL-NEXT:    v_mul_lo_u32 v5, 4, v5
+; GFX1064DAGISEL-NEXT:    v_max_f32_dpp v3, v3, v3 row_shr:8 row_mask:0xf bank_mask:0xf
+; GFX1064DAGISEL-NEXT:    ds_swizzle_b32 v4, v3 offset:swizzle(BROADCAST,32,15)
+; GFX1064DAGISEL-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX1064DAGISEL-NEXT:    v_max_f32_e32 v3, v3, v4
+; GFX1064DAGISEL-NEXT:    ds_permute_b32 v4, v5, v3
+; GFX1064DAGISEL-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX1064DAGISEL-NEXT:    v_max_f32_e32 v3, v3, v4
+; GFX1064DAGISEL-NEXT:    v_readlane_b32 s6, v3, 63
+; GFX1064DAGISEL-NEXT:    s_mov_b64 exec, s[4:5]
+; GFX1064DAGISEL-NEXT:    v_mov_b32_e32 v2, s6
+; GFX1064DAGISEL-NEXT:    global_store_dword v[0:1], v2, off
+; GFX1064DAGISEL-NEXT:    s_xor_saveexec_b64 s[4:5], -1
+; GFX1064DAGISEL-NEXT:    s_clause 0x2 ; 12-byte Folded Reload
+; GFX1064DAGISEL-NEXT:    buffer_load_dword v3, off, s[0:3], s32
+; GFX1064DAGISEL-NEXT:    buffer_load_dword v4, off, s[0:3], s32 offset:4
+; GFX1064DAGISEL-NEXT:    buffer_load_dword v5, off, s[0:3], s32 offset:8
+; GFX1064DAGISEL-NEXT:    s_waitcnt_depctr depctr_vm_vsrc(0)
+; GFX1064DAGISEL-NEXT:    s_mov_b64 exec, s[4:5]
+; GFX1064DAGISEL-NEXT:    s_waitcnt vmcnt(0)
+; GFX1064DAGISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX1064GISEL-LABEL: divergent_value_float_dpp:
+; GFX1064GISEL:       ; %bb.0: ; %entry
+; GFX1064GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX1064GISEL-NEXT:    s_xor_saveexec_b64 s[4:5], -1
+; GFX1064GISEL-NEXT:    buffer_store_dword v3, off, s[0:3], s32 ; 4-byte Folded Spill
+; GFX1064GISEL-NEXT:    buffer_store_dword v4, off, s[0:3], s32 offset:4 ; 4-byte Folded Spill
+; GFX1064GISEL-NEXT:    buffer_store_dword v5, off, s[0:3], s32 offset:8 ; 4-byte Folded Spill
+; GFX1064GISEL-NEXT:    s_waitcnt_depctr depctr_vm_vsrc(0)
+; GFX1064GISEL-NEXT:    s_mov_b64 exec, s[4:5]
+; GFX1064GISEL-NEXT:    s_or_saveexec_b64 s[4:5], -1
+; GFX1064GISEL-NEXT:    v_cndmask_b32_e64 v3, 0x7fc00000, v2, s[4:5]
+; GFX1064GISEL-NEXT:    v_mbcnt_lo_u32_b32 v5, -1, 0
+; GFX1064GISEL-NEXT:    v_max_f32_dpp v3, v3, v3 row_shr:1 row_mask:0xf bank_mask:0xf
+; GFX1064GISEL-NEXT:    v_mbcnt_hi_u32_b32 v5, -1, v5
+; GFX1064GISEL-NEXT:    v_max_f32_dpp v3, v3, v3 row_shr:2 row_mask:0xf bank_mask:0xf
+; GFX1064GISEL-NEXT:    v_add_nc_u32_e32 v5, 32, v5
+; GFX1064GISEL-NEXT:    v_max_f32_dpp v3, v3, v3 row_shr:4 row_mask:0xf bank_mask:0xf
+; GFX1064GISEL-NEXT:    v_mul_lo_u32 v5, 4, v5
+; GFX1064GISEL-NEXT:    v_max_f32_dpp v3, v3, v3 row_shr:8 row_mask:0xf bank_mask:0xf
+; GFX1064GISEL-NEXT:    ds_swizzle_b32 v4, v3 offset:swizzle(BROADCAST,32,15)
+; GFX1064GISEL-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX1064GISEL-NEXT:    v_max_f32_e32 v3, v3, v4
+; GFX1064GISEL-NEXT:    ds_permute_b32 v4, v5, v3
+; GFX1064GISEL-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX1064GISEL-NEXT:    v_max_f32_e32 v3, v3, v4
+; GFX1064GISEL-NEXT:    v_readlane_b32 s6, v3, 63
+; GFX1064GISEL-NEXT:    s_mov_b64 exec, s[4:5]
+; GFX1064GISEL-NEXT:    v_mov_b32_e32 v2, s6
+; GFX1064GISEL-NEXT:    global_store_dword v[0:1], v2, off
+; GFX1064GISEL-NEXT:    s_xor_saveexec_b64 s[4:5], -1
+; GFX1064GISEL-NEXT:    s_clause 0x2 ; 12-byte Folded Reload
+; GFX1064GISEL-NEXT:    buffer_load_dword v3, off, s[0:3], s32
+; GFX1064GISEL-NEXT:    buffer_load_dword v4, off, s[0:3], s32 offset:4
+; GFX1064GISEL-NEXT:    buffer_load_dword v5, off, s[0:3], s32 offset:8
+; GFX1064GISEL-NEXT:    s_waitcnt_depctr depctr_vm_vsrc(0)
+; GFX1064GISEL-NEXT:    s_mov_b64 exec, s[4:5]
+; GFX1064GISEL-NEXT:    s_waitcnt vmcnt(0)
+; GFX1064GISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX1032DAGISEL-LABEL: divergent_value_float_dpp:
+; GFX1032DAGISEL:       ; %bb.0: ; %entry
+; GFX1032DAGISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX1032DAGISEL-NEXT:    s_xor_saveexec_b32 s4, -1
+; GFX1032DAGISEL-NEXT:    buffer_store_dword v3, off, s[0:3], s32 ; 4-byte Folded Spill
+; GFX1032DAGISEL-NEXT:    buffer_store_dword v4, off, s[0:3], s32 offset:4 ; 4-byte Folded Spill
+; GFX1032DAGISEL-NEXT:    s_waitcnt_depctr depctr_vm_vsrc(0)
+; GFX1032DAGISEL-NEXT:    s_mov_b32 exec_lo, s4
+; GFX1032DAGISEL-NEXT:    s_or_saveexec_b32 s4, -1
+; GFX1032DAGISEL-NEXT:    v_cndmask_b32_e64 v3, 0x7fc00000, v2, s4
+; GFX1032DAGISEL-NEXT:    v_max_f32_dpp v3, v3, v3 row_shr:1 row_mask:0xf bank_mask:0xf
+; GFX1032DAGISEL-NEXT:    v_max_f32_dpp v3, v3, v3 row_shr:2 row_mask:0xf bank_mask:0xf
+; GFX1032DAGISEL-NEXT:    v_max_f32_dpp v3, v3, v3 row_shr:4 row_mask:0xf bank_mask:0xf
+; GFX1032DAGISEL-NEXT:    v_max_f32_dpp v3, v3, v3 row_shr:8 row_mask:0xf bank_mask:0xf
+; GFX1032DAGISEL-NEXT:    ds_swizzle_b32 v4, v3 offset:swizzle(BROADCAST,32,15)
+; GFX1032DAGISEL-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX1032DAGISEL-NEXT:    v_max_f32_e32 v3, v3, v4
+; GFX1032DAGISEL-NEXT:    v_readlane_b32 s5, v3, 31
+; GFX1032DAGISEL-NEXT:    s_mov_b32 exec_lo, s4
+; GFX1032DAGISEL-NEXT:    v_mov_b32_e32 v2, s5
+; GFX1032DAGISEL-NEXT:    global_store_dword v[0:1], v2, off
+; GFX1032DAGISEL-NEXT:    s_xor_saveexec_b32 s4, -1
+; GFX1032DAGISEL-NEXT:    s_clause 0x1 ; 8-byte Folded Reload
+; GFX1032DAGISEL-NEXT:    buffer_load_dword v3, off, s[0:3], s32
+; GFX1032DAGISEL-NEXT:    buffer_load_dword v4, off, s[0:3], s32 offset:4
+; GFX1032DAGISEL-NEXT:    s_waitcnt_depctr depctr_vm_vsrc(0)
+; GFX1032DAGISEL-NEXT:    s_mov_b32 exec_lo, s4
+; GFX1032DAGISEL-NEXT:    s_waitcnt vmcnt(0)
+; GFX1032DAGISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX1032GISEL-LABEL: divergent_value_float_dpp:
+; GFX1032GISEL:       ; %bb.0: ; %entry
+; GFX1032GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX1032GISEL-NEXT:    s_xor_saveexec_b32 s4, -1
+; GFX1032GISEL-NEXT:    buffer_store_dword v3, off, s[0:3], s32 ; 4-byte Folded Spill
+; GFX1032GISEL-NEXT:    buffer_store_dword v4, off, s[0:3], s32 offset:4 ; 4-byte Folded Spill
+; GFX1032GISEL-NEXT:    s_waitcnt_depctr depctr_vm_vsrc(0)
+; GFX1032GISEL-NEXT:    s_mov_b32 exec_lo, s4
+; GFX1032GISEL-NEXT:    s_or_saveexec_b32 s4, -1
+; GFX1032GISEL-NEXT:    v_cndmask_b32_e64 v3, 0x7fc00000, v2, s4
+; GFX1032GISEL-NEXT:    v_max_f32_dpp v3, v3, v3 row_shr:1 row_mask:0xf bank_mask:0xf
+; GFX1032GISEL-NEXT:    v_max_f32_dpp v3, v3, v3 row_shr:2 row_mask:0xf bank_mask:0xf
+; GFX1032GISEL-NEXT:    v_max_f32_dpp v3, v3, v3 row_shr:4 row_mask:0xf bank_mask:0xf
+; GFX1032GISEL-NEXT:    v_max_f32_dpp v3, v3, v3 row_shr:8 row_mask:0xf bank_mask:0xf
+; GFX1032GISEL-NEXT:    ds_swizzle_b32 v4, v3 offset:swizzle(BROADCAST,32,15)
+; GFX1032GISEL-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX1032GISEL-NEXT:    v_max_f32_e32 v3, v3, v4
+; GFX1032GISEL-NEXT:    v_readlane_b32 s5, v3, 31
+; GFX1032GISEL-NEXT:    s_mov_b32 exec_lo, s4
+; GFX1032GISEL-NEXT:    v_mov_b32_e32 v2, s5
+; GFX1032GISEL-NEXT:    global_store_dword v[0:1], v2, off
+; GFX1032GISEL-NEXT:    s_xor_saveexec_b32 s4, -1
+; GFX1032GISEL-NEXT:    s_clause 0x1 ; 8-byte Folded Reload
+; GFX1032GISEL-NEXT:    buffer_load_dword v3, off, s[0:3], s32
+; GFX1032GISEL-NEXT:    buffer_load_dword v4, off, s[0:3], s32 offset:4
+; GFX1032GISEL-NEXT:    s_waitcnt_depctr depctr_vm_vsrc(0)
+; GFX1032GISEL-NEXT:    s_mov_b32 exec_lo, s4
+; GFX1032GISEL-NEXT:    s_waitcnt vmcnt(0)
+; GFX1032GISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX1164DAGISEL-LABEL: divergent_value_float_dpp:
+; GFX1164DAGISEL:       ; %bb.0: ; %entry
+; GFX1164DAGISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX1164DAGISEL-NEXT:    s_xor_saveexec_b64 s[0:1], -1
+; GFX1164DAGISEL-NEXT:    s_clause 0x2 ; 12-byte Folded Spill
+; GFX1164DAGISEL-NEXT:    scratch_store_b32 off, v3, s32
+; GFX1164DAGISEL-NEXT:    scratch_store_b32 off, v4, s32 offset:4
+; GFX1164DAGISEL-NEXT:    scratch_store_b32 off, v5, s32 offset:8
+; GFX1164DAGISEL-NEXT:    s_mov_b64 exec, s[0:1]
+; GFX1164DAGISEL-NEXT:    s_or_saveexec_b64 s[0:1], -1
+; GFX1164DAGISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_1) | instid1(VALU_DEP_2)
+; GFX1164DAGISEL-NEXT:    v_cndmask_b32_e64 v3, 0x7fc00000, v2, s[0:1]
+; GFX1164DAGISEL-NEXT:    v_mbcnt_lo_u32_b32 v5, -1, 0
+; GFX1164DAGISEL-NEXT:    v_max_f32_dpp v3, v3, v3 row_shr:1 row_mask:0xf bank_mask:0xf
+; GFX1164DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GFX1164DAGISEL-NEXT:    v_mbcnt_hi_u32_b32 v5, -1, v5
+; GFX1164DAGISEL-NEXT:    v_max_f32_dpp v3, v3, v3 row_shr:2 row_mask:0xf bank_mask:0xf
+; GFX1164DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GFX1164DAGISEL-NEXT:    v_add_nc_u32_e32 v5, 32, v5
+; GFX1164DAGISEL-NEXT:    v_max_f32_dpp v3, v3, v3 row_shr:4 row_mask:0xf bank_mask:0xf
+; GFX1164DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GFX1164DAGISEL-NEXT:    v_mul_lo_u32 v5, 4, v5
+; GFX1164DAGISEL-NEXT:    v_max_f32_dpp v3, v3, v3 row_shr:8 row_mask:0xf bank_mask:0xf
+; GFX1164DAGISEL-NEXT:    ds_swizzle_b32 v4, v3 offset:swizzle(BROADCAST,32,15)
+; GFX1164DAGISEL-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX1164DAGISEL-NEXT:    v_max_f32_e32 v3, v3, v4
+; GFX1164DAGISEL-NEXT:    ds_permute_b32 v4, v5, v3
+; GFX1164DAGISEL-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX1164DAGISEL-NEXT:    v_max_f32_e32 v3, v3, v4
+; GFX1164DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1164DAGISEL-NEXT:    v_readlane_b32 s2, v3, 63
+; GFX1164DAGISEL-NEXT:    s_mov_b64 exec, s[0:1]
+; GFX1164DAGISEL-NEXT:    v_mov_b32_e32 v2, s2
+; GFX1164DAGISEL-NEXT:    global_store_b32 v[0:1], v2, off
+; GFX1164DAGISEL-NEXT:    s_xor_saveexec_b64 s[0:1], -1
+; GFX1164DAGISEL-NEXT:    s_waitcnt_depctr depctr_sa_sdst(0)
+; GFX1164DAGISEL-NEXT:    s_clause 0x2 ; 12-byte Folded Reload
+; GFX1164DAGISEL-NEXT:    scratch_load_b32 v3, off, s32
+; GFX1164DAGISEL-NEXT:    scratch_load_b32 v4, off, s32 offset:4
+; GFX1164DAGISEL-NEXT:    scratch_load_b32 v5, off, s32 offset:8
+; GFX1164DAGISEL-NEXT:    s_mov_b64 exec, s[0:1]
+; GFX1164DAGISEL-NEXT:    s_waitcnt vmcnt(0)
+; GFX1164DAGISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX1164GISEL-LABEL: divergent_value_float_dpp:
+; GFX1164GISEL:       ; %bb.0: ; %entry
+; GFX1164GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX1164GISEL-NEXT:    s_xor_saveexec_b64 s[0:1], -1
+; GFX1164GISEL-NEXT:    s_clause 0x2 ; 12-byte Folded Spill
+; GFX1164GISEL-NEXT:    scratch_store_b32 off, v3, s32
+; GFX1164GISEL-NEXT:    scratch_store_b32 off, v4, s32 offset:4
+; GFX1164GISEL-NEXT:    scratch_store_b32 off, v5, s32 offset:8
+; GFX1164GISEL-NEXT:    s_mov_b64 exec, s[0:1]
+; GFX1164GISEL-NEXT:    s_or_saveexec_b64 s[0:1], -1
+; GFX1164GISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_1) | instid1(VALU_DEP_2)
+; GFX1164GISEL-NEXT:    v_cndmask_b32_e64 v3, 0x7fc00000, v2, s[0:1]
+; GFX1164GISEL-NEXT:    v_mbcnt_lo_u32_b32 v5, -1, 0
+; GFX1164GISEL-NEXT:    v_max_f32_dpp v3, v3, v3 row_shr:1 row_mask:0xf bank_mask:0xf
+; GFX1164GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GFX1164GISEL-NEXT:    v_mbcnt_hi_u32_b32 v5, -1, v5
+; GFX1164GISEL-NEXT:    v_max_f32_dpp v3, v3, v3 row_shr:2 row_mask:0xf bank_mask:0xf
+; GFX1164GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GFX1164GISEL-NEXT:    v_add_nc_u32_e32 v5, 32, v5
+; GFX1164GISEL-NEXT:    v_max_f32_dpp v3, v3, v3 row_shr:4 row_mask:0xf bank_mask:0xf
+; GFX1164GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GFX1164GISEL-NEXT:    v_mul_lo_u32 v5, 4, v5
+; GFX1164GISEL-NEXT:    v_max_f32_dpp v3, v3, v3 row_shr:8 row_mask:0xf bank_mask:0xf
+; GFX1164GISEL-NEXT:    ds_swizzle_b32 v4, v3 offset:swizzle(BROADCAST,32,15)
+; GFX1164GISEL-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX1164GISEL-NEXT:    v_max_f32_e32 v3, v3, v4
+; GFX1164GISEL-NEXT:    ds_permute_b32 v4, v5, v3
+; GFX1164GISEL-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX1164GISEL-NEXT:    v_max_f32_e32 v3, v3, v4
+; GFX1164GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1164GISEL-NEXT:    v_readlane_b32 s2, v3, 63
+; GFX1164GISEL-NEXT:    s_mov_b64 exec, s[0:1]
+; GFX1164GISEL-NEXT:    v_mov_b32_e32 v2, s2
+; GFX1164GISEL-NEXT:    global_store_b32 v[0:1], v2, off
+; GFX1164GISEL-NEXT:    s_xor_saveexec_b64 s[0:1], -1
+; GFX1164GISEL-NEXT:    s_waitcnt_depctr depctr_sa_sdst(0)
+; GFX1164GISEL-NEXT:    s_clause 0x2 ; 12-byte Folded Reload
+; GFX1164GISEL-NEXT:    scratch_load_b32 v3, off, s32
+; GFX1164GISEL-NEXT:    scratch_load_b32 v4, off, s32 offset:4
+; GFX1164GISEL-NEXT:    scratch_load_b32 v5, off, s32 offset:8
+; GFX1164GISEL-NEXT:    s_mov_b64 exec, s[0:1]
+; GFX1164GISEL-NEXT:    s_waitcnt vmcnt(0)
+; GFX1164GISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX1132DAGISEL-LABEL: divergent_value_float_dpp:
+; GFX1132DAGISEL:       ; %bb.0: ; %entry
+; GFX1132DAGISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX1132DAGISEL-NEXT:    s_xor_saveexec_b32 s0, -1
+; GFX1132DAGISEL-NEXT:    s_clause 0x1 ; 8-byte Folded Spill
+; GFX1132DAGISEL-NEXT:    scratch_store_b32 off, v3, s32
+; GFX1132DAGISEL-NEXT:    scratch_store_b32 off, v4, s32 offset:4
+; GFX1132DAGISEL-NEXT:    s_mov_b32 exec_lo, s0
+; GFX1132DAGISEL-NEXT:    s_or_saveexec_b32 s0, -1
+; GFX1132DAGISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1132DAGISEL-NEXT:    v_cndmask_b32_e64 v3, 0x7fc00000, v2, s0
+; GFX1132DAGISEL-NEXT:    v_max_f32_dpp v3, v3, v3 row_shr:1 row_mask:0xf bank_mask:0xf
+; GFX1132DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1132DAGISEL-NEXT:    v_max_f32_dpp v3, v3, v3 row_shr:2 row_mask:0xf bank_mask:0xf
+; GFX1132DAGISEL-NEXT:    v_max_f32_dpp v3, v3, v3 row_shr:4 row_mask:0xf bank_mask:0xf
+; GFX1132DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_3) | instid1(VALU_DEP_1)
+; GFX1132DAGISEL-NEXT:    v_max_f32_dpp v3, v3, v3 row_shr:8 row_mask:0xf bank_mask:0xf
+; GFX1132DAGISEL-NEXT:    ds_swizzle_b32 v4, v3 offset:swizzle(BROADCAST,32,15)
+; GFX1132DAGISEL-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX1132DAGISEL-NEXT:    v_max_f32_e32 v3, v3, v4
+; GFX1132DAGISEL-NEXT:    v_readlane_b32 s1, v3, 31
+; GFX1132DAGISEL-NEXT:    s_mov_b32 exec_lo, s0
+; GFX1132DAGISEL-NEXT:    v_mov_b32_e32 v2, s1
+; GFX1132DAGISEL-NEXT:    global_store_b32 v[0:1], v2, off
+; GFX1132DAGISEL-NEXT:    s_xor_saveexec_b32 s0, -1
+; GFX1132DAGISEL-NEXT:    s_clause 0x1 ; 8-byte Folded Reload
+; GFX1132DAGISEL-NEXT:    scratch_load_b32 v3, off, s32
+; GFX1132DAGISEL-NEXT:    scratch_load_b32 v4, off, s32 offset:4
+; GFX1132DAGISEL-NEXT:    s_mov_b32 exec_lo, s0
+; GFX1132DAGISEL-NEXT:    s_waitcnt vmcnt(0)
+; GFX1132DAGISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX1132GISEL-LABEL: divergent_value_float_dpp:
+; GFX1132GISEL:       ; %bb.0: ; %entry
+; GFX1132GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX1132GISEL-NEXT:    s_xor_saveexec_b32 s0, -1
+; GFX1132GISEL-NEXT:    s_clause 0x1 ; 8-byte Folded Spill
+; GFX1132GISEL-NEXT:    scratch_store_b32 off, v3, s32
+; GFX1132GISEL-NEXT:    scratch_store_b32 off, v4, s32 offset:4
+; GFX1132GISEL-NEXT:    s_mov_b32 exec_lo, s0
+; GFX1132GISEL-NEXT:    s_or_saveexec_b32 s0, -1
+; GFX1132GISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1132GISEL-NEXT:    v_cndmask_b32_e64 v3, 0x7fc00000, v2, s0
+; GFX1132GISEL-NEXT:    v_max_f32_dpp v3, v3, v3 row_shr:1 row_mask:0xf bank_mask:0xf
+; GFX1132GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1132GISEL-NEXT:    v_max_f32_dpp v3, v3, v3 row_shr:2 row_mask:0xf bank_mask:0xf
+; GFX1132GISEL-NEXT:    v_max_f32_dpp v3, v3, v3 row_shr:4 row_mask:0xf bank_mask:0xf
+; GFX1132GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_3) | instid1(VALU_DEP_1)
+; GFX1132GISEL-NEXT:    v_max_f32_dpp v3, v3, v3 row_shr:8 row_mask:0xf bank_mask:0xf
+; GFX1132GISEL-NEXT:    ds_swizzle_b32 v4, v3 offset:swizzle(BROADCAST,32,15)
+; GFX1132GISEL-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX1132GISEL-NEXT:    v_max_f32_e32 v3, v3, v4
+; GFX1132GISEL-NEXT:    v_readlane_b32 s1, v3, 31
+; GFX1132GISEL-NEXT:    s_mov_b32 exec_lo, s0
+; GFX1132GISEL-NEXT:    v_mov_b32_e32 v2, s1
+; GFX1132GISEL-NEXT:    global_store_b32 v[0:1], v2, off
+; GFX1132GISEL-NEXT:    s_xor_saveexec_b32 s0, -1
+; GFX1132GISEL-NEXT:    s_clause 0x1 ; 8-byte Folded Reload
+; GFX1132GISEL-NEXT:    scratch_load_b32 v3, off, s32
+; GFX1132GISEL-NEXT:    scratch_load_b32 v4, off, s32 offset:4
+; GFX1132GISEL-NEXT:    s_mov_b32 exec_lo, s0
+; GFX1132GISEL-NEXT:    s_waitcnt vmcnt(0)
+; GFX1132GISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12DAGISEL-LABEL: divergent_value_float_dpp:
+; GFX12DAGISEL:       ; %bb.0: ; %entry
+; GFX12DAGISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12DAGISEL-NEXT:    s_wait_expcnt 0x0
+; GFX12DAGISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX12DAGISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX12DAGISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX12DAGISEL-NEXT:    s_xor_saveexec_b32 s0, -1
+; GFX12DAGISEL-NEXT:    s_clause 0x1 ; 8-byte Folded Spill
+; GFX12DAGISEL-NEXT:    scratch_store_b32 off, v3, s32
+; GFX12DAGISEL-NEXT:    scratch_store_b32 off, v4, s32 offset:4
+; GFX12DAGISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12DAGISEL-NEXT:    s_mov_b32 exec_lo, s0
+; GFX12DAGISEL-NEXT:    s_or_saveexec_b32 s0, -1
+; GFX12DAGISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12DAGISEL-NEXT:    v_cndmask_b32_e64 v3, 0x7fc00000, v2, s0
+; GFX12DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX12DAGISEL-NEXT:    v_max_num_f32_dpp v3, v3, v3 row_shr:1 row_mask:0xf bank_mask:0xf
+; GFX12DAGISEL-NEXT:    v_max_num_f32_dpp v3, v3, v3 row_shr:2 row_mask:0xf bank_mask:0xf
+; GFX12DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX12DAGISEL-NEXT:    v_max_num_f32_dpp v3, v3, v3 row_shr:4 row_mask:0xf bank_mask:0xf
+; GFX12DAGISEL-NEXT:    v_max_num_f32_dpp v3, v3, v3 row_shr:8 row_mask:0xf bank_mask:0xf
+; GFX12DAGISEL-NEXT:    ds_swizzle_b32 v4, v3 offset:swizzle(BROADCAST,32,15)
+; GFX12DAGISEL-NEXT:    s_wait_dscnt 0x0
+; GFX12DAGISEL-NEXT:    v_max_num_f32_e32 v3, v3, v4
+; GFX12DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX12DAGISEL-NEXT:    v_readlane_b32 s1, v3, 31
+; GFX12DAGISEL-NEXT:    s_mov_b32 exec_lo, s0
+; GFX12DAGISEL-NEXT:    v_mov_b32_e32 v2, s1
+; GFX12DAGISEL-NEXT:    global_store_b32 v[0:1], v2, off
+; GFX12DAGISEL-NEXT:    s_xor_saveexec_b32 s0, -1
+; GFX12DAGISEL-NEXT:    s_clause 0x1 ; 8-byte Folded Reload
+; GFX12DAGISEL-NEXT:    scratch_load_b32 v3, off, s32
+; GFX12DAGISEL-NEXT:    scratch_load_b32 v4, off, s32 offset:4
+; GFX12DAGISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12DAGISEL-NEXT:    s_mov_b32 exec_lo, s0
+; GFX12DAGISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX12DAGISEL-NEXT:    s_setpc_b64 s[30:31]
+entry:
+  %result = call float @llvm.amdgcn.wave.reduce.fmax(float %in, i32 2)
+  store float %result, ptr addrspace(1) %out
+  ret void
+}
+
 define void @divergent_cfg_float(ptr addrspace(1) %out, float %in, float %in2) {
 ; GFX8DAGISEL-LABEL: divergent_cfg_float:
 ; GFX8DAGISEL:       ; %bb.0: ; %entry
@@ -408,11 +867,11 @@ define void @divergent_cfg_float(ptr addrspace(1) %out, float %in, float %in2) {
 ; GFX8DAGISEL-NEXT:    ; implicit-def: $vgpr4
 ; GFX8DAGISEL-NEXT:    s_and_saveexec_b64 s[4:5], vcc
 ; GFX8DAGISEL-NEXT:    s_xor_b64 s[4:5], exec, s[4:5]
-; GFX8DAGISEL-NEXT:    s_cbranch_execz .LBB2_4
+; GFX8DAGISEL-NEXT:    s_cbranch_execz .LBB3_4
 ; GFX8DAGISEL-NEXT:  ; %bb.1: ; %else
 ; GFX8DAGISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX8DAGISEL-NEXT:    s_mov_b32 s8, 0x7fc00000
-; GFX8DAGISEL-NEXT:  .LBB2_2: ; =>This Inner Loop Header: Depth=1
+; GFX8DAGISEL-NEXT:  .LBB3_2: ; =>This Inner Loop Header: Depth=1
 ; GFX8DAGISEL-NEXT:    s_ff1_i32_b64 s9, s[6:7]
 ; GFX8DAGISEL-NEXT:    v_readlane_b32 s10, v2, s9
 ; GFX8DAGISEL-NEXT:    v_mov_b32_e32 v3, s10
@@ -420,17 +879,17 @@ define void @divergent_cfg_float(ptr addrspace(1) %out, float %in, float %in2) {
 ; GFX8DAGISEL-NEXT:    v_max_f32_e32 v3, s8, v3
 ; GFX8DAGISEL-NEXT:    s_cmp_lg_u64 s[6:7], 0
 ; GFX8DAGISEL-NEXT:    v_readfirstlane_b32 s8, v3
-; GFX8DAGISEL-NEXT:    s_cbranch_scc1 .LBB2_2
+; GFX8DAGISEL-NEXT:    s_cbranch_scc1 .LBB3_2
 ; GFX8DAGISEL-NEXT:  ; %bb.3:
 ; GFX8DAGISEL-NEXT:    v_mov_b32_e32 v4, s8
 ; GFX8DAGISEL-NEXT:    ; implicit-def: $vgpr3
-; GFX8DAGISEL-NEXT:  .LBB2_4: ; %Flow
+; GFX8DAGISEL-NEXT:  .LBB3_4: ; %Flow
 ; GFX8DAGISEL-NEXT:    s_andn2_saveexec_b64 s[4:5], s[4:5]
-; GFX8DAGISEL-NEXT:    s_cbranch_execz .LBB2_8
+; GFX8DAGISEL-NEXT:    s_cbranch_execz .LBB3_8
 ; GFX8DAGISEL-NEXT:  ; %bb.5: ; %if
 ; GFX8DAGISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX8DAGISEL-NEXT:    s_mov_b32 s8, 0x7fc00000
-; GFX8DAGISEL-NEXT:  .LBB2_6: ; =>This Inner Loop Header: Depth=1
+; GFX8DAGISEL-NEXT:  .LBB3_6: ; =>This Inner Loop Header: Depth=1
 ; GFX8DAGISEL-NEXT:    s_ff1_i32_b64 s9, s[6:7]
 ; GFX8DAGISEL-NEXT:    v_readlane_b32 s10, v3, s9
 ; GFX8DAGISEL-NEXT:    v_mov_b32_e32 v2, s10
@@ -438,10 +897,10 @@ define void @divergent_cfg_float(ptr addrspace(1) %out, float %in, float %in2) {
 ; GFX8DAGISEL-NEXT:    v_max_f32_e32 v2, s8, v2
 ; GFX8DAGISEL-NEXT:    s_cmp_lg_u64 s[6:7], 0
 ; GFX8DAGISEL-NEXT:    v_readfirstlane_b32 s8, v2
-; GFX8DAGISEL-NEXT:    s_cbranch_scc1 .LBB2_6
+; GFX8DAGISEL-NEXT:    s_cbranch_scc1 .LBB3_6
 ; GFX8DAGISEL-NEXT:  ; %bb.7:
 ; GFX8DAGISEL-NEXT:    v_mov_b32_e32 v4, s8
-; GFX8DAGISEL-NEXT:  .LBB2_8: ; %endif
+; GFX8DAGISEL-NEXT:  .LBB3_8: ; %endif
 ; GFX8DAGISEL-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; GFX8DAGISEL-NEXT:    flat_store_dword v[0:1], v4
 ; GFX8DAGISEL-NEXT:    s_waitcnt vmcnt(0)
@@ -455,12 +914,12 @@ define void @divergent_cfg_float(ptr addrspace(1) %out, float %in, float %in2) {
 ; GFX8GISEL-NEXT:    ; implicit-def: $sgpr8
 ; GFX8GISEL-NEXT:    s_and_saveexec_b64 s[4:5], vcc
 ; GFX8GISEL-NEXT:    s_xor_b64 s[4:5], exec, s[4:5]
-; GFX8GISEL-NEXT:    s_cbranch_execz .LBB2_3
+; GFX8GISEL-NEXT:    s_cbranch_execz .LBB3_3
 ; GFX8GISEL-NEXT:  ; %bb.1: ; %else
 ; GFX8GISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX8GISEL-NEXT:    s_mov_b32 s8, 0x7fc00000
 ; GFX8GISEL-NEXT:    ; implicit-def: $vgpr3
-; GFX8GISEL-NEXT:  .LBB2_2: ; =>This Inner Loop Header: Depth=1
+; GFX8GISEL-NEXT:  .LBB3_2: ; =>This Inner Loop Header: Depth=1
 ; GFX8GISEL-NEXT:    s_ff1_i32_b64 s9, s[6:7]
 ; GFX8GISEL-NEXT:    v_readlane_b32 s10, v2, s9
 ; GFX8GISEL-NEXT:    v_mov_b32_e32 v4, s10
@@ -468,14 +927,14 @@ define void @divergent_cfg_float(ptr addrspace(1) %out, float %in, float %in2) {
 ; GFX8GISEL-NEXT:    v_max_f32_e32 v4, s8, v4
 ; GFX8GISEL-NEXT:    s_cmp_lg_u64 s[6:7], 0
 ; GFX8GISEL-NEXT:    v_readfirstlane_b32 s8, v4
-; GFX8GISEL-NEXT:    s_cbranch_scc1 .LBB2_2
-; GFX8GISEL-NEXT:  .LBB2_3: ; %Flow
+; GFX8GISEL-NEXT:    s_cbranch_scc1 .LBB3_2
+; GFX8GISEL-NEXT:  .LBB3_3: ; %Flow
 ; GFX8GISEL-NEXT:    s_andn2_saveexec_b64 s[4:5], s[4:5]
-; GFX8GISEL-NEXT:    s_cbranch_execz .LBB2_6
+; GFX8GISEL-NEXT:    s_cbranch_execz .LBB3_6
 ; GFX8GISEL-NEXT:  ; %bb.4: ; %if
 ; GFX8GISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX8GISEL-NEXT:    s_mov_b32 s8, 0x7fc00000
-; GFX8GISEL-NEXT:  .LBB2_5: ; =>This Inner Loop Header: Depth=1
+; GFX8GISEL-NEXT:  .LBB3_5: ; =>This Inner Loop Header: Depth=1
 ; GFX8GISEL-NEXT:    s_ff1_i32_b64 s9, s[6:7]
 ; GFX8GISEL-NEXT:    v_readlane_b32 s10, v3, s9
 ; GFX8GISEL-NEXT:    v_mov_b32_e32 v2, s10
@@ -483,8 +942,8 @@ define void @divergent_cfg_float(ptr addrspace(1) %out, float %in, float %in2) {
 ; GFX8GISEL-NEXT:    v_max_f32_e32 v2, s8, v2
 ; GFX8GISEL-NEXT:    s_cmp_lg_u64 s[6:7], 0
 ; GFX8GISEL-NEXT:    v_readfirstlane_b32 s8, v2
-; GFX8GISEL-NEXT:    s_cbranch_scc1 .LBB2_5
-; GFX8GISEL-NEXT:  .LBB2_6: ; %endif
+; GFX8GISEL-NEXT:    s_cbranch_scc1 .LBB3_5
+; GFX8GISEL-NEXT:  .LBB3_6: ; %endif
 ; GFX8GISEL-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; GFX8GISEL-NEXT:    v_mov_b32_e32 v2, s8
 ; GFX8GISEL-NEXT:    flat_store_dword v[0:1], v2
@@ -499,11 +958,11 @@ define void @divergent_cfg_float(ptr addrspace(1) %out, float %in, float %in2) {
 ; GFX9DAGISEL-NEXT:    ; implicit-def: $vgpr4
 ; GFX9DAGISEL-NEXT:    s_and_saveexec_b64 s[4:5], vcc
 ; GFX9DAGISEL-NEXT:    s_xor_b64 s[4:5], exec, s[4:5]
-; GFX9DAGISEL-NEXT:    s_cbranch_execz .LBB2_4
+; GFX9DAGISEL-NEXT:    s_cbranch_execz .LBB3_4
 ; GFX9DAGISEL-NEXT:  ; %bb.1: ; %else
 ; GFX9DAGISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX9DAGISEL-NEXT:    s_mov_b32 s8, 0x7fc00000
-; GFX9DAGISEL-NEXT:  .LBB2_2: ; =>This Inner Loop Header: Depth=1
+; GFX9DAGISEL-NEXT:  .LBB3_2: ; =>This Inner Loop Header: Depth=1
 ; GFX9DAGISEL-NEXT:    s_ff1_i32_b64 s9, s[6:7]
 ; GFX9DAGISEL-NEXT:    v_readlane_b32 s10, v2, s9
 ; GFX9DAGISEL-NEXT:    v_mov_b32_e32 v3, s10
@@ -511,17 +970,17 @@ define void @divergent_cfg_float(ptr addrspace(1) %out, float %in, float %in2) {
 ; GFX9DAGISEL-NEXT:    v_max_f32_e32 v3, s8, v3
 ; GFX9DAGISEL-NEXT:    s_cmp_lg_u64 s[6:7], 0
 ; GFX9DAGISEL-NEXT:    v_readfirstlane_b32 s8, v3
-; GFX9DAGISEL-NEXT:    s_cbranch_scc1 .LBB2_2
+; GFX9DAGISEL-NEXT:    s_cbranch_scc1 .LBB3_2
 ; GFX9DAGISEL-NEXT:  ; %bb.3:
 ; GFX9DAGISEL-NEXT:    v_mov_b32_e32 v4, s8
 ; GFX9DAGISEL-NEXT:    ; implicit-def: $vgpr3
-; GFX9DAGISEL-NEXT:  .LBB2_4: ; %Flow
+; GFX9DAGISEL-NEXT:  .LBB3_4: ; %Flow
 ; GFX9DAGISEL-NEXT:    s_andn2_saveexec_b64 s[4:5], s[4:5]
-; GFX9DAGISEL-NEXT:    s_cbranch_execz .LBB2_8
+; GFX9DAGISEL-NEXT:    s_cbranch_execz .LBB3_8
 ; GFX9DAGISEL-NEXT:  ; %bb.5: ; %if
 ; GFX9DAGISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX9DAGISEL-NEXT:    s_mov_b32 s8, 0x7fc00000
-; GFX9DAGISEL-NEXT:  .LBB2_6: ; =>This Inner Loop Header: Depth=1
+; GFX9DAGISEL-NEXT:  .LBB3_6: ; =>This Inner Loop Header: Depth=1
 ; GFX9DAGISEL-NEXT:    s_ff1_i32_b64 s9, s[6:7]
 ; GFX9DAGISEL-NEXT:    v_readlane_b32 s10, v3, s9
 ; GFX9DAGISEL-NEXT:    v_mov_b32_e32 v2, s10
@@ -529,10 +988,10 @@ define void @divergent_cfg_float(ptr addrspace(1) %out, float %in, float %in2) {
 ; GFX9DAGISEL-NEXT:    v_max_f32_e32 v2, s8, v2
 ; GFX9DAGISEL-NEXT:    s_cmp_lg_u64 s[6:7], 0
 ; GFX9DAGISEL-NEXT:    v_readfirstlane_b32 s8, v2
-; GFX9DAGISEL-NEXT:    s_cbranch_scc1 .LBB2_6
+; GFX9DAGISEL-NEXT:    s_cbranch_scc1 .LBB3_6
 ; GFX9DAGISEL-NEXT:  ; %bb.7:
 ; GFX9DAGISEL-NEXT:    v_mov_b32_e32 v4, s8
-; GFX9DAGISEL-NEXT:  .LBB2_8: ; %endif
+; GFX9DAGISEL-NEXT:  .LBB3_8: ; %endif
 ; GFX9DAGISEL-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; GFX9DAGISEL-NEXT:    global_store_dword v[0:1], v4, off
 ; GFX9DAGISEL-NEXT:    s_waitcnt vmcnt(0)
@@ -546,12 +1005,12 @@ define void @divergent_cfg_float(ptr addrspace(1) %out, float %in, float %in2) {
 ; GFX9GISEL-NEXT:    ; implicit-def: $sgpr8
 ; GFX9GISEL-NEXT:    s_and_saveexec_b64 s[4:5], vcc
 ; GFX9GISEL-NEXT:    s_xor_b64 s[4:5], exec, s[4:5]
-; GFX9GISEL-NEXT:    s_cbranch_execz .LBB2_3
+; GFX9GISEL-NEXT:    s_cbranch_execz .LBB3_3
 ; GFX9GISEL-NEXT:  ; %bb.1: ; %else
 ; GFX9GISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX9GISEL-NEXT:    s_mov_b32 s8, 0x7fc00000
 ; GFX9GISEL-NEXT:    ; implicit-def: $vgpr3
-; GFX9GISEL-NEXT:  .LBB2_2: ; =>This Inner Loop Header: Depth=1
+; GFX9GISEL-NEXT:  .LBB3_2: ; =>This Inner Loop Header: Depth=1
 ; GFX9GISEL-NEXT:    s_ff1_i32_b64 s9, s[6:7]
 ; GFX9GISEL-NEXT:    v_readlane_b32 s10, v2, s9
 ; GFX9GISEL-NEXT:    v_mov_b32_e32 v4, s10
@@ -559,14 +1018,14 @@ define void @divergent_cfg_float(ptr addrspace(1) %out, float %in, float %in2) {
 ; GFX9GISEL-NEXT:    v_max_f32_e32 v4, s8, v4
 ; GFX9GISEL-NEXT:    s_cmp_lg_u64 s[6:7], 0
 ; GFX9GISEL-NEXT:    v_readfirstlane_b32 s8, v4
-; GFX9GISEL-NEXT:    s_cbranch_scc1 .LBB2_2
-; GFX9GISEL-NEXT:  .LBB2_3: ; %Flow
+; GFX9GISEL-NEXT:    s_cbranch_scc1 .LBB3_2
+; GFX9GISEL-NEXT:  .LBB3_3: ; %Flow
 ; GFX9GISEL-NEXT:    s_andn2_saveexec_b64 s[4:5], s[4:5]
-; GFX9GISEL-NEXT:    s_cbranch_execz .LBB2_6
+; GFX9GISEL-NEXT:    s_cbranch_execz .LBB3_6
 ; GFX9GISEL-NEXT:  ; %bb.4: ; %if
 ; GFX9GISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX9GISEL-NEXT:    s_mov_b32 s8, 0x7fc00000
-; GFX9GISEL-NEXT:  .LBB2_5: ; =>This Inner Loop Header: Depth=1
+; GFX9GISEL-NEXT:  .LBB3_5: ; =>This Inner Loop Header: Depth=1
 ; GFX9GISEL-NEXT:    s_ff1_i32_b64 s9, s[6:7]
 ; GFX9GISEL-NEXT:    v_readlane_b32 s10, v3, s9
 ; GFX9GISEL-NEXT:    v_mov_b32_e32 v2, s10
@@ -574,8 +1033,8 @@ define void @divergent_cfg_float(ptr addrspace(1) %out, float %in, float %in2) {
 ; GFX9GISEL-NEXT:    v_max_f32_e32 v2, s8, v2
 ; GFX9GISEL-NEXT:    s_cmp_lg_u64 s[6:7], 0
 ; GFX9GISEL-NEXT:    v_readfirstlane_b32 s8, v2
-; GFX9GISEL-NEXT:    s_cbranch_scc1 .LBB2_5
-; GFX9GISEL-NEXT:  .LBB2_6: ; %endif
+; GFX9GISEL-NEXT:    s_cbranch_scc1 .LBB3_5
+; GFX9GISEL-NEXT:  .LBB3_6: ; %endif
 ; GFX9GISEL-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; GFX9GISEL-NEXT:    v_mov_b32_e32 v2, s8
 ; GFX9GISEL-NEXT:    global_store_dword v[0:1], v2, off
@@ -590,38 +1049,38 @@ define void @divergent_cfg_float(ptr addrspace(1) %out, float %in, float %in2) {
 ; GFX1064DAGISEL-NEXT:    ; implicit-def: $vgpr4
 ; GFX1064DAGISEL-NEXT:    s_and_saveexec_b64 s[4:5], vcc
 ; GFX1064DAGISEL-NEXT:    s_xor_b64 s[4:5], exec, s[4:5]
-; GFX1064DAGISEL-NEXT:    s_cbranch_execz .LBB2_4
+; GFX1064DAGISEL-NEXT:    s_cbranch_execz .LBB3_4
 ; GFX1064DAGISEL-NEXT:  ; %bb.1: ; %else
 ; GFX1064DAGISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX1064DAGISEL-NEXT:    s_mov_b32 s8, 0x7fc00000
-; GFX1064DAGISEL-NEXT:  .LBB2_2: ; =>This Inner Loop Header: Depth=1
+; GFX1064DAGISEL-NEXT:  .LBB3_2: ; =>This Inner Loop Header: Depth=1
 ; GFX1064DAGISEL-NEXT:    s_ff1_i32_b64 s9, s[6:7]
 ; GFX1064DAGISEL-NEXT:    v_readlane_b32 s10, v2, s9
 ; GFX1064DAGISEL-NEXT:    s_bitset0_b64 s[6:7], s9
 ; GFX1064DAGISEL-NEXT:    s_cmp_lg_u64 s[6:7], 0
 ; GFX1064DAGISEL-NEXT:    v_max_f32_e64 v3, s8, s10
 ; GFX1064DAGISEL-NEXT:    v_readfirstlane_b32 s8, v3
-; GFX1064DAGISEL-NEXT:    s_cbranch_scc1 .LBB2_2
+; GFX1064DAGISEL-NEXT:    s_cbranch_scc1 .LBB3_2
 ; GFX1064DAGISEL-NEXT:  ; %bb.3:
 ; GFX1064DAGISEL-NEXT:    v_mov_b32_e32 v4, s8
 ; GFX1064DAGISEL-NEXT:    ; implicit-def: $vgpr3
-; GFX1064DAGISEL-NEXT:  .LBB2_4: ; %Flow
+; GFX1064DAGISEL-NEXT:  .LBB3_4: ; %Flow
 ; GFX1064DAGISEL-NEXT:    s_andn2_saveexec_b64 s[4:5], s[4:5]
-; GFX1064DAGISEL-NEXT:    s_cbranch_execz .LBB2_8
+; GFX1064DAGISEL-NEXT:    s_cbranch_execz .LBB3_8
 ; GFX1064DAGISEL-NEXT:  ; %bb.5: ; %if
 ; GFX1064DAGISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX1064DAGISEL-NEXT:    s_mov_b32 s8, 0x7fc00000
-; GFX1064DAGISEL-NEXT:  .LBB2_6: ; =>This Inner Loop Header: Depth=1
+; GFX1064DAGISEL-NEXT:  .LBB3_6: ; =>This Inner Loop Header: Depth=1
 ; GFX1064DAGISEL-NEXT:    s_ff1_i32_b64 s9, s[6:7]
 ; GFX1064DAGISEL-NEXT:    v_readlane_b32 s10, v3, s9
 ; GFX1064DAGISEL-NEXT:    s_bitset0_b64 s[6:7], s9
 ; GFX1064DAGISEL-NEXT:    s_cmp_lg_u64 s[6:7], 0
 ; GFX1064DAGISEL-NEXT:    v_max_f32_e64 v2, s8, s10
 ; GFX1064DAGISEL-NEXT:    v_readfirstlane_b32 s8, v2
-; GFX1064DAGISEL-NEXT:    s_cbranch_scc1 .LBB2_6
+; GFX1064DAGISEL-NEXT:    s_cbranch_scc1 .LBB3_6
 ; GFX1064DAGISEL-NEXT:  ; %bb.7:
 ; GFX1064DAGISEL-NEXT:    v_mov_b32_e32 v4, s8
-; GFX1064DAGISEL-NEXT:  .LBB2_8: ; %endif
+; GFX1064DAGISEL-NEXT:  .LBB3_8: ; %endif
 ; GFX1064DAGISEL-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; GFX1064DAGISEL-NEXT:    global_store_dword v[0:1], v4, off
 ; GFX1064DAGISEL-NEXT:    s_setpc_b64 s[30:31]
@@ -634,11 +1093,11 @@ define void @divergent_cfg_float(ptr addrspace(1) %out, float %in, float %in2) {
 ; GFX1064GISEL-NEXT:    v_cmp_le_u32_e32 vcc, 16, v4
 ; GFX1064GISEL-NEXT:    s_and_saveexec_b64 s[4:5], vcc
 ; GFX1064GISEL-NEXT:    s_xor_b64 s[4:5], exec, s[4:5]
-; GFX1064GISEL-NEXT:    s_cbranch_execz .LBB2_3
+; GFX1064GISEL-NEXT:    s_cbranch_execz .LBB3_3
 ; GFX1064GISEL-NEXT:  ; %bb.1: ; %else
 ; GFX1064GISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX1064GISEL-NEXT:    s_mov_b32 s8, 0x7fc00000
-; GFX1064GISEL-NEXT:  .LBB2_2: ; =>This Inner Loop Header: Depth=1
+; GFX1064GISEL-NEXT:  .LBB3_2: ; =>This Inner Loop Header: Depth=1
 ; GFX1064GISEL-NEXT:    s_ff1_i32_b64 s9, s[6:7]
 ; GFX1064GISEL-NEXT:    v_readlane_b32 s10, v2, s9
 ; GFX1064GISEL-NEXT:    s_bitset0_b64 s[6:7], s9
@@ -646,22 +1105,22 @@ define void @divergent_cfg_float(ptr addrspace(1) %out, float %in, float %in2) {
 ; GFX1064GISEL-NEXT:    v_max_f32_e64 v3, s8, s10
 ; GFX1064GISEL-NEXT:    v_readfirstlane_b32 s8, v3
 ; GFX1064GISEL-NEXT:    ; implicit-def: $vgpr3
-; GFX1064GISEL-NEXT:    s_cbranch_scc1 .LBB2_2
-; GFX1064GISEL-NEXT:  .LBB2_3: ; %Flow
+; GFX1064GISEL-NEXT:    s_cbranch_scc1 .LBB3_2
+; GFX1064GISEL-NEXT:  .LBB3_3: ; %Flow
 ; GFX1064GISEL-NEXT:    s_andn2_saveexec_b64 s[4:5], s[4:5]
-; GFX1064GISEL-NEXT:    s_cbranch_execz .LBB2_6
+; GFX1064GISEL-NEXT:    s_cbranch_execz .LBB3_6
 ; GFX1064GISEL-NEXT:  ; %bb.4: ; %if
 ; GFX1064GISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX1064GISEL-NEXT:    s_mov_b32 s8, 0x7fc00000
-; GFX1064GISEL-NEXT:  .LBB2_5: ; =>This Inner Loop Header: Depth=1
+; GFX1064GISEL-NEXT:  .LBB3_5: ; =>This Inner Loop Header: Depth=1
 ; GFX1064GISEL-NEXT:    s_ff1_i32_b64 s9, s[6:7]
 ; GFX1064GISEL-NEXT:    v_readlane_b32 s10, v3, s9
 ; GFX1064GISEL-NEXT:    s_bitset0_b64 s[6:7], s9
 ; GFX1064GISEL-NEXT:    s_cmp_lg_u64 s[6:7], 0
 ; GFX1064GISEL-NEXT:    v_max_f32_e64 v2, s8, s10
 ; GFX1064GISEL-NEXT:    v_readfirstlane_b32 s8, v2
-; GFX1064GISEL-NEXT:    s_cbranch_scc1 .LBB2_5
-; GFX1064GISEL-NEXT:  .LBB2_6: ; %endif
+; GFX1064GISEL-NEXT:    s_cbranch_scc1 .LBB3_5
+; GFX1064GISEL-NEXT:  .LBB3_6: ; %endif
 ; GFX1064GISEL-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; GFX1064GISEL-NEXT:    v_mov_b32_e32 v2, s8
 ; GFX1064GISEL-NEXT:    global_store_dword v[0:1], v2, off
@@ -675,38 +1134,38 @@ define void @divergent_cfg_float(ptr addrspace(1) %out, float %in, float %in2) {
 ; GFX1032DAGISEL-NEXT:    ; implicit-def: $vgpr4
 ; GFX1032DAGISEL-NEXT:    s_and_saveexec_b32 s4, vcc_lo
 ; GFX1032DAGISEL-NEXT:    s_xor_b32 s4, exec_lo, s4
-; GFX1032DAGISEL-NEXT:    s_cbranch_execz .LBB2_4
+; GFX1032DAGISEL-NEXT:    s_cbranch_execz .LBB3_4
 ; GFX1032DAGISEL-NEXT:  ; %bb.1: ; %else
 ; GFX1032DAGISEL-NEXT:    s_mov_b32 s5, exec_lo
 ; GFX1032DAGISEL-NEXT:    s_mov_b32 s6, 0x7fc00000
-; GFX1032DAGISEL-NEXT:  .LBB2_2: ; =>This Inner Loop Header: Depth=1
+; GFX1032DAGISEL-NEXT:  .LBB3_2: ; =>This Inner Loop Header: Depth=1
 ; GFX1032DAGISEL-NEXT:    s_ff1_i32_b32 s7, s5
 ; GFX1032DAGISEL-NEXT:    v_readlane_b32 s8, v2, s7
 ; GFX1032DAGISEL-NEXT:    s_bitset0_b32 s5, s7
 ; GFX1032DAGISEL-NEXT:    s_cmp_lg_u32 s5, 0
 ; GFX1032DAGISEL-NEXT:    v_max_f32_e64 v3, s6, s8
 ; GFX1032DAGISEL-NEXT:    v_readfirstlane_b32 s6, v3
-; GFX1032DAGISEL-NEXT:    s_cbranch_scc1 .LBB2_2
+; GFX1032DAGISEL-NEXT:    s_cbranch_scc1 .LBB3_2
 ; GFX1032DAGISEL-NEXT:  ; %bb.3:
 ; GFX1032DAGISEL-NEXT:    v_mov_b32_e32 v4, s6
 ; GFX1032DAGISEL-NEXT:    ; implicit-def: $vgpr3
-; GFX1032DAGISEL-NEXT:  .LBB2_4: ; %Flow
+; GFX1032DAGISEL-NEXT:  .LBB3_4: ; %Flow
 ; GFX1032DAGISEL-NEXT:    s_andn2_saveexec_b32 s4, s4
-; GFX1032DAGISEL-NEXT:    s_cbranch_execz .LBB2_8
+; GFX1032DAGISEL-NEXT:    s_cbranch_execz .LBB3_8
 ; GFX1032DAGISEL-NEXT:  ; %bb.5: ; %if
 ; GFX1032DAGISEL-NEXT:    s_mov_b32 s5, exec_lo
 ; GFX1032DAGISEL-NEXT:    s_mov_b32 s6, 0x7fc00000
-; GFX1032DAGISEL-NEXT:  .LBB2_6: ; =>This Inner Loop Header: Depth=1
+; GFX1032DAGISEL-NEXT:  .LBB3_6: ; =>This Inner Loop Header: Depth=1
 ; GFX1032DAGISEL-NEXT:    s_ff1_i32_b32 s7, s5
 ; GFX1032DAGISEL-NEXT:    v_readlane_b32 s8, v3, s7
 ; GFX1032DAGISEL-NEXT:    s_bitset0_b32 s5, s7
 ; GFX1032DAGISEL-NEXT:    s_cmp_lg_u32 s5, 0
 ; GFX1032DAGISEL-NEXT:    v_max_f32_e64 v2, s6, s8
 ; GFX1032DAGISEL-NEXT:    v_readfirstlane_b32 s6, v2
-; GFX1032DAGISEL-NEXT:    s_cbranch_scc1 .LBB2_6
+; GFX1032DAGISEL-NEXT:    s_cbranch_scc1 .LBB3_6
 ; GFX1032DAGISEL-NEXT:  ; %bb.7:
 ; GFX1032DAGISEL-NEXT:    v_mov_b32_e32 v4, s6
-; GFX1032DAGISEL-NEXT:  .LBB2_8: ; %endif
+; GFX1032DAGISEL-NEXT:  .LBB3_8: ; %endif
 ; GFX1032DAGISEL-NEXT:    s_or_b32 exec_lo, exec_lo, s4
 ; GFX1032DAGISEL-NEXT:    global_store_dword v[0:1], v4, off
 ; GFX1032DAGISEL-NEXT:    s_setpc_b64 s[30:31]
@@ -719,11 +1178,11 @@ define void @divergent_cfg_float(ptr addrspace(1) %out, float %in, float %in2) {
 ; GFX1032GISEL-NEXT:    v_cmp_le_u32_e32 vcc_lo, 16, v4
 ; GFX1032GISEL-NEXT:    s_and_saveexec_b32 s5, vcc_lo
 ; GFX1032GISEL-NEXT:    s_xor_b32 s5, exec_lo, s5
-; GFX1032GISEL-NEXT:    s_cbranch_execz .LBB2_3
+; GFX1032GISEL-NEXT:    s_cbranch_execz .LBB3_3
 ; GFX1032GISEL-NEXT:  ; %bb.1: ; %else
 ; GFX1032GISEL-NEXT:    s_mov_b32 s6, exec_lo
 ; GFX1032GISEL-NEXT:    s_mov_b32 s4, 0x7fc00000
-; GFX1032GISEL-NEXT:  .LBB2_2: ; =>This Inner Loop Header: Depth=1
+; GFX1032GISEL-NEXT:  .LBB3_2: ; =>This Inner Loop Header: Depth=1
 ; GFX1032GISEL-NEXT:    s_ff1_i32_b32 s7, s6
 ; GFX1032GISEL-NEXT:    v_readlane_b32 s8, v2, s7
 ; GFX1032GISEL-NEXT:    s_bitset0_b32 s6, s7
@@ -731,22 +1190,22 @@ define void @divergent_cfg_float(ptr addrspace(1) %out, float %in, float %in2) {
 ; GFX1032GISEL-NEXT:    v_max_f32_e64 v3, s4, s8
 ; GFX1032GISEL-NEXT:    v_readfirstlane_b32 s4, v3
 ; GFX1032GISEL-NEXT:    ; implicit-def: $vgpr3
-; GFX1032GISEL-NEXT:    s_cbranch_scc1 .LBB2_2
-; GFX1032GISEL-NEXT:  .LBB2_3: ; %Flow
+; GFX1032GISEL-NEXT:    s_cbranch_scc1 .LBB3_2
+; GFX1032GISEL-NEXT:  .LBB3_3: ; %Flow
 ; GFX1032GISEL-NEXT:    s_andn2_saveexec_b32 s5, s5
-; GFX1032GISEL-NEXT:    s_cbranch_execz .LBB2_6
+; GFX1032GISEL-NEXT:    s_cbranch_execz .LBB3_6
 ; GFX1032GISEL-NEXT:  ; %bb.4: ; %if
 ; GFX1032GISEL-NEXT:    s_mov_b32 s6, exec_lo
 ; GFX1032GISEL-NEXT:    s_mov_b32 s4, 0x7fc00000
-; GFX1032GISEL-NEXT:  .LBB2_5: ; =>This Inner Loop Header: Depth=1
+; GFX1032GISEL-NEXT:  .LBB3_5: ; =>This Inner Loop Header: Depth=1
 ; GFX1032GISEL-NEXT:    s_ff1_i32_b32 s7, s6
 ; GFX1032GISEL-NEXT:    v_readlane_b32 s8, v3, s7
 ; GFX1032GISEL-NEXT:    s_bitset0_b32 s6, s7
 ; GFX1032GISEL-NEXT:    s_cmp_lg_u32 s6, 0
 ; GFX1032GISEL-NEXT:    v_max_f32_e64 v2, s4, s8
 ; GFX1032GISEL-NEXT:    v_readfirstlane_b32 s4, v2
-; GFX1032GISEL-NEXT:    s_cbranch_scc1 .LBB2_5
-; GFX1032GISEL-NEXT:  .LBB2_6: ; %endif
+; GFX1032GISEL-NEXT:    s_cbranch_scc1 .LBB3_5
+; GFX1032GISEL-NEXT:  .LBB3_6: ; %endif
 ; GFX1032GISEL-NEXT:    s_or_b32 exec_lo, exec_lo, s5
 ; GFX1032GISEL-NEXT:    v_mov_b32_e32 v2, s4
 ; GFX1032GISEL-NEXT:    global_store_dword v[0:1], v2, off
@@ -761,11 +1220,11 @@ define void @divergent_cfg_float(ptr addrspace(1) %out, float %in, float %in2) {
 ; GFX1164DAGISEL-NEXT:    ; implicit-def: $vgpr4
 ; GFX1164DAGISEL-NEXT:    s_and_saveexec_b64 s[0:1], vcc
 ; GFX1164DAGISEL-NEXT:    s_xor_b64 s[0:1], exec, s[0:1]
-; GFX1164DAGISEL-NEXT:    s_cbranch_execz .LBB2_4
+; GFX1164DAGISEL-NEXT:    s_cbranch_execz .LBB3_4
 ; GFX1164DAGISEL-NEXT:  ; %bb.1: ; %else
 ; GFX1164DAGISEL-NEXT:    s_mov_b64 s[2:3], exec
 ; GFX1164DAGISEL-NEXT:    s_mov_b32 s4, 0x7fc00000
-; GFX1164DAGISEL-NEXT:  .LBB2_2: ; =>This Inner Loop Header: Depth=1
+; GFX1164DAGISEL-NEXT:  .LBB3_2: ; =>This Inner Loop Header: Depth=1
 ; GFX1164DAGISEL-NEXT:    s_ctz_i32_b64 s5, s[2:3]
 ; GFX1164DAGISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_1) | instid1(SALU_CYCLE_1)
 ; GFX1164DAGISEL-NEXT:    v_readlane_b32 s6, v2, s5
@@ -774,17 +1233,17 @@ define void @divergent_cfg_float(ptr addrspace(1) %out, float %in, float %in2) {
 ; GFX1164DAGISEL-NEXT:    v_max_f32_e64 v3, s4, s6
 ; GFX1164DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX1164DAGISEL-NEXT:    v_readfirstlane_b32 s4, v3
-; GFX1164DAGISEL-NEXT:    s_cbranch_scc1 .LBB2_2
+; GFX1164DAGISEL-NEXT:    s_cbranch_scc1 .LBB3_2
 ; GFX1164DAGISEL-NEXT:  ; %bb.3:
 ; GFX1164DAGISEL-NEXT:    v_mov_b32_e32 v4, s4
 ; GFX1164DAGISEL-NEXT:    ; implicit-def: $vgpr3
-; GFX1164DAGISEL-NEXT:  .LBB2_4: ; %Flow
+; GFX1164DAGISEL-NEXT:  .LBB3_4: ; %Flow
 ; GFX1164DAGISEL-NEXT:    s_and_not1_saveexec_b64 s[0:1], s[0:1]
-; GFX1164DAGISEL-NEXT:    s_cbranch_execz .LBB2_8
+; GFX1164DAGISEL-NEXT:    s_cbranch_execz .LBB3_8
 ; GFX1164DAGISEL-NEXT:  ; %bb.5: ; %if
 ; GFX1164DAGISEL-NEXT:    s_mov_b64 s[2:3], exec
 ; GFX1164DAGISEL-NEXT:    s_mov_b32 s4, 0x7fc00000
-; GFX1164DAGISEL-NEXT:  .LBB2_6: ; =>This Inner Loop Header: Depth=1
+; GFX1164DAGISEL-NEXT:  .LBB3_6: ; =>This Inner Loop Header: Depth=1
 ; GFX1164DAGISEL-NEXT:    s_ctz_i32_b64 s5, s[2:3]
 ; GFX1164DAGISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_1) | instid1(SALU_CYCLE_1)
 ; GFX1164DAGISEL-NEXT:    v_readlane_b32 s6, v3, s5
@@ -793,10 +1252,10 @@ define void @divergent_cfg_float(ptr addrspace(1) %out, float %in, float %in2) {
 ; GFX1164DAGISEL-NEXT:    v_max_f32_e64 v2, s4, s6
 ; GFX1164DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX1164DAGISEL-NEXT:    v_readfirstlane_b32 s4, v2
-; GFX1164DAGISEL-NEXT:    s_cbranch_scc1 .LBB2_6
+; GFX1164DAGISEL-NEXT:    s_cbranch_scc1 .LBB3_6
 ; GFX1164DAGISEL-NEXT:  ; %bb.7:
 ; GFX1164DAGISEL-NEXT:    v_mov_b32_e32 v4, s4
-; GFX1164DAGISEL-NEXT:  .LBB2_8: ; %endif
+; GFX1164DAGISEL-NEXT:  .LBB3_8: ; %endif
 ; GFX1164DAGISEL-NEXT:    s_or_b64 exec, exec, s[0:1]
 ; GFX1164DAGISEL-NEXT:    global_store_b32 v[0:1], v4, off
 ; GFX1164DAGISEL-NEXT:    s_setpc_b64 s[30:31]
@@ -810,11 +1269,11 @@ define void @divergent_cfg_float(ptr addrspace(1) %out, float %in, float %in2) {
 ; GFX1164GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX1164GISEL-NEXT:    v_cmpx_le_u32_e32 16, v4
 ; GFX1164GISEL-NEXT:    s_xor_b64 s[0:1], exec, s[0:1]
-; GFX1164GISEL-NEXT:    s_cbranch_execz .LBB2_3
+; GFX1164GISEL-NEXT:    s_cbranch_execz .LBB3_3
 ; GFX1164GISEL-NEXT:  ; %bb.1: ; %else
 ; GFX1164GISEL-NEXT:    s_mov_b64 s[2:3], exec
 ; GFX1164GISEL-NEXT:    s_mov_b32 s4, 0x7fc00000
-; GFX1164GISEL-NEXT:  .LBB2_2: ; =>This Inner Loop Header: Depth=1
+; GFX1164GISEL-NEXT:  .LBB3_2: ; =>This Inner Loop Header: Depth=1
 ; GFX1164GISEL-NEXT:    s_ctz_i32_b64 s5, s[2:3]
 ; GFX1164GISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_1) | instid1(SALU_CYCLE_1)
 ; GFX1164GISEL-NEXT:    v_readlane_b32 s6, v2, s5
@@ -824,14 +1283,14 @@ define void @divergent_cfg_float(ptr addrspace(1) %out, float %in, float %in2) {
 ; GFX1164GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX1164GISEL-NEXT:    v_readfirstlane_b32 s4, v3
 ; GFX1164GISEL-NEXT:    ; implicit-def: $vgpr3
-; GFX1164GISEL-NEXT:    s_cbranch_scc1 .LBB2_2
-; GFX1164GISEL-NEXT:  .LBB2_3: ; %Flow
+; GFX1164GISEL-NEXT:    s_cbranch_scc1 .LBB3_2
+; GFX1164GISEL-NEXT:  .LBB3_3: ; %Flow
 ; GFX1164GISEL-NEXT:    s_and_not1_saveexec_b64 s[0:1], s[0:1]
-; GFX1164GISEL-NEXT:    s_cbranch_execz .LBB2_6
+; GFX1164GISEL-NEXT:    s_cbranch_execz .LBB3_6
 ; GFX1164GISEL-NEXT:  ; %bb.4: ; %if
 ; GFX1164GISEL-NEXT:    s_mov_b64 s[2:3], exec
 ; GFX1164GISEL-NEXT:    s_mov_b32 s4, 0x7fc00000
-; GFX1164GISEL-NEXT:  .LBB2_5: ; =>This Inner Loop Header: Depth=1
+; GFX1164GISEL-NEXT:  .LBB3_5: ; =>This Inner Loop Header: Depth=1
 ; GFX1164GISEL-NEXT:    s_ctz_i32_b64 s5, s[2:3]
 ; GFX1164GISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_1) | instid1(SALU_CYCLE_1)
 ; GFX1164GISEL-NEXT:    v_readlane_b32 s6, v3, s5
@@ -840,8 +1299,8 @@ define void @divergent_cfg_float(ptr addrspace(1) %out, float %in, float %in2) {
 ; GFX1164GISEL-NEXT:    v_max_f32_e64 v2, s4, s6
 ; GFX1164GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX1164GISEL-NEXT:    v_readfirstlane_b32 s4, v2
-; GFX1164GISEL-NEXT:    s_cbranch_scc1 .LBB2_5
-; GFX1164GISEL-NEXT:  .LBB2_6: ; %endif
+; GFX1164GISEL-NEXT:    s_cbranch_scc1 .LBB3_5
+; GFX1164GISEL-NEXT:  .LBB3_6: ; %endif
 ; GFX1164GISEL-NEXT:    s_or_b64 exec, exec, s[0:1]
 ; GFX1164GISEL-NEXT:    v_mov_b32_e32 v2, s4
 ; GFX1164GISEL-NEXT:    global_store_b32 v[0:1], v2, off
@@ -856,11 +1315,11 @@ define void @divergent_cfg_float(ptr addrspace(1) %out, float %in, float %in2) {
 ; GFX1132DAGISEL-NEXT:    ; implicit-def: $vgpr4
 ; GFX1132DAGISEL-NEXT:    s_and_saveexec_b32 s0, vcc_lo
 ; GFX1132DAGISEL-NEXT:    s_xor_b32 s0, exec_lo, s0
-; GFX1132DAGISEL-NEXT:    s_cbranch_execz .LBB2_4
+; GFX1132DAGISEL-NEXT:    s_cbranch_execz .LBB3_4
 ; GFX1132DAGISEL-NEXT:  ; %bb.1: ; %else
 ; GFX1132DAGISEL-NEXT:    s_mov_b32 s1, exec_lo
 ; GFX1132DAGISEL-NEXT:    s_mov_b32 s2, 0x7fc00000
-; GFX1132DAGISEL-NEXT:  .LBB2_2: ; =>This Inner Loop Header: Depth=1
+; GFX1132DAGISEL-NEXT:  .LBB3_2: ; =>This Inner Loop Header: Depth=1
 ; GFX1132DAGISEL-NEXT:    s_ctz_i32_b32 s3, s1
 ; GFX1132DAGISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_1) | instid1(SALU_CYCLE_1)
 ; GFX1132DAGISEL-NEXT:    v_readlane_b32 s4, v2, s3
@@ -869,17 +1328,17 @@ define void @divergent_cfg_float(ptr addrspace(1) %out, float %in, float %in2) {
 ; GFX1132DAGISEL-NEXT:    v_max_f32_e64 v3, s2, s4
 ; GFX1132DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX1132DAGISEL-NEXT:    v_readfirstlane_b32 s2, v3
-; GFX1132DAGISEL-NEXT:    s_cbranch_scc1 .LBB2_2
+; GFX1132DAGISEL-NEXT:    s_cbranch_scc1 .LBB3_2
 ; GFX1132DAGISEL-NEXT:  ; %bb.3:
 ; GFX1132DAGISEL-NEXT:    v_mov_b32_e32 v4, s2
 ; GFX1132DAGISEL-NEXT:    ; implicit-def: $vgpr3
-; GFX1132DAGISEL-NEXT:  .LBB2_4: ; %Flow
+; GFX1132DAGISEL-NEXT:  .LBB3_4: ; %Flow
 ; GFX1132DAGISEL-NEXT:    s_and_not1_saveexec_b32 s0, s0
-; GFX1132DAGISEL-NEXT:    s_cbranch_execz .LBB2_8
+; GFX1132DAGISEL-NEXT:    s_cbranch_execz .LBB3_8
 ; GFX1132DAGISEL-NEXT:  ; %bb.5: ; %if
 ; GFX1132DAGISEL-NEXT:    s_mov_b32 s1, exec_lo
 ; GFX1132DAGISEL-NEXT:    s_mov_b32 s2, 0x7fc00000
-; GFX1132DAGISEL-NEXT:  .LBB2_6: ; =>This Inner Loop Header: Depth=1
+; GFX1132DAGISEL-NEXT:  .LBB3_6: ; =>This Inner Loop Header: Depth=1
 ; GFX1132DAGISEL-NEXT:    s_ctz_i32_b32 s3, s1
 ; GFX1132DAGISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_1) | instid1(SALU_CYCLE_1)
 ; GFX1132DAGISEL-NEXT:    v_readlane_b32 s4, v3, s3
@@ -888,10 +1347,10 @@ define void @divergent_cfg_float(ptr addrspace(1) %out, float %in, float %in2) {
 ; GFX1132DAGISEL-NEXT:    v_max_f32_e64 v2, s2, s4
 ; GFX1132DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX1132DAGISEL-NEXT:    v_readfirstlane_b32 s2, v2
-; GFX1132DAGISEL-NEXT:    s_cbranch_scc1 .LBB2_6
+; GFX1132DAGISEL-NEXT:    s_cbranch_scc1 .LBB3_6
 ; GFX1132DAGISEL-NEXT:  ; %bb.7:
 ; GFX1132DAGISEL-NEXT:    v_mov_b32_e32 v4, s2
-; GFX1132DAGISEL-NEXT:  .LBB2_8: ; %endif
+; GFX1132DAGISEL-NEXT:  .LBB3_8: ; %endif
 ; GFX1132DAGISEL-NEXT:    s_or_b32 exec_lo, exec_lo, s0
 ; GFX1132DAGISEL-NEXT:    global_store_b32 v[0:1], v4, off
 ; GFX1132DAGISEL-NEXT:    s_setpc_b64 s[30:31]
@@ -905,11 +1364,11 @@ define void @divergent_cfg_float(ptr addrspace(1) %out, float %in, float %in2) {
 ; GFX1132GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX1132GISEL-NEXT:    v_cmpx_le_u32_e32 16, v4
 ; GFX1132GISEL-NEXT:    s_xor_b32 s1, exec_lo, s1
-; GFX1132GISEL-NEXT:    s_cbranch_execz .LBB2_3
+; GFX1132GISEL-NEXT:    s_cbranch_execz .LBB3_3
 ; GFX1132GISEL-NEXT:  ; %bb.1: ; %else
 ; GFX1132GISEL-NEXT:    s_mov_b32 s2, exec_lo
 ; GFX1132GISEL-NEXT:    s_mov_b32 s0, 0x7fc00000
-; GFX1132GISEL-NEXT:  .LBB2_2: ; =>This Inner Loop Header: Depth=1
+; GFX1132GISEL-NEXT:  .LBB3_2: ; =>This Inner Loop Header: Depth=1
 ; GFX1132GISEL-NEXT:    s_ctz_i32_b32 s3, s2
 ; GFX1132GISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_1) | instid1(SALU_CYCLE_1)
 ; GFX1132GISEL-NEXT:    v_readlane_b32 s4, v2, s3
@@ -919,14 +1378,14 @@ define void @divergent_cfg_float(ptr addrspace(1) %out, float %in, float %in2) {
 ; GFX1132GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX1132GISEL-NEXT:    v_readfirstlane_b32 s0, v3
 ; GFX1132GISEL-NEXT:    ; implicit-def: $vgpr3
-; GFX1132GISEL-NEXT:    s_cbranch_scc1 .LBB2_2
-; GFX1132GISEL-NEXT:  .LBB2_3: ; %Flow
+; GFX1132GISEL-NEXT:    s_cbranch_scc1 .LBB3_2
+; GFX1132GISEL-NEXT:  .LBB3_3: ; %Flow
 ; GFX1132GISEL-NEXT:    s_and_not1_saveexec_b32 s1, s1
-; GFX1132GISEL-NEXT:    s_cbranch_execz .LBB2_6
+; GFX1132GISEL-NEXT:    s_cbranch_execz .LBB3_6
 ; GFX1132GISEL-NEXT:  ; %bb.4: ; %if
 ; GFX1132GISEL-NEXT:    s_mov_b32 s2, exec_lo
 ; GFX1132GISEL-NEXT:    s_mov_b32 s0, 0x7fc00000
-; GFX1132GISEL-NEXT:  .LBB2_5: ; =>This Inner Loop Header: Depth=1
+; GFX1132GISEL-NEXT:  .LBB3_5: ; =>This Inner Loop Header: Depth=1
 ; GFX1132GISEL-NEXT:    s_ctz_i32_b32 s3, s2
 ; GFX1132GISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_1) | instid1(SALU_CYCLE_1)
 ; GFX1132GISEL-NEXT:    v_readlane_b32 s4, v3, s3
@@ -935,8 +1394,8 @@ define void @divergent_cfg_float(ptr addrspace(1) %out, float %in, float %in2) {
 ; GFX1132GISEL-NEXT:    v_max_f32_e64 v2, s0, s4
 ; GFX1132GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX1132GISEL-NEXT:    v_readfirstlane_b32 s0, v2
-; GFX1132GISEL-NEXT:    s_cbranch_scc1 .LBB2_5
-; GFX1132GISEL-NEXT:  .LBB2_6: ; %endif
+; GFX1132GISEL-NEXT:    s_cbranch_scc1 .LBB3_5
+; GFX1132GISEL-NEXT:  .LBB3_6: ; %endif
 ; GFX1132GISEL-NEXT:    s_or_b32 exec_lo, exec_lo, s1
 ; GFX1132GISEL-NEXT:    v_mov_b32_e32 v2, s0
 ; GFX1132GISEL-NEXT:    global_store_b32 v[0:1], v2, off
@@ -956,11 +1415,11 @@ define void @divergent_cfg_float(ptr addrspace(1) %out, float %in, float %in2) {
 ; GFX12DAGISEL-NEXT:    s_and_saveexec_b32 s0, vcc_lo
 ; GFX12DAGISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
 ; GFX12DAGISEL-NEXT:    s_xor_b32 s0, exec_lo, s0
-; GFX12DAGISEL-NEXT:    s_cbranch_execz .LBB2_4
+; GFX12DAGISEL-NEXT:    s_cbranch_execz .LBB3_4
 ; GFX12DAGISEL-NEXT:  ; %bb.1: ; %else
 ; GFX12DAGISEL-NEXT:    s_mov_b32 s1, exec_lo
 ; GFX12DAGISEL-NEXT:    s_mov_b32 s2, 0x7fc00000
-; GFX12DAGISEL-NEXT:  .LBB2_2: ; =>This Inner Loop Header: Depth=1
+; GFX12DAGISEL-NEXT:  .LBB3_2: ; =>This Inner Loop Header: Depth=1
 ; GFX12DAGISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
 ; GFX12DAGISEL-NEXT:    s_ctz_i32_b32 s3, s1
 ; GFX12DAGISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
@@ -971,19 +1430,19 @@ define void @divergent_cfg_float(ptr addrspace(1) %out, float %in, float %in2) {
 ; GFX12DAGISEL-NEXT:    v_max_num_f32_e64 v3, s2, s4
 ; GFX12DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX12DAGISEL-NEXT:    v_readfirstlane_b32 s2, v3
-; GFX12DAGISEL-NEXT:    s_cbranch_scc1 .LBB2_2
+; GFX12DAGISEL-NEXT:    s_cbranch_scc1 .LBB3_2
 ; GFX12DAGISEL-NEXT:  ; %bb.3:
 ; GFX12DAGISEL-NEXT:    s_wait_alu depctr_va_sdst(0)
 ; GFX12DAGISEL-NEXT:    v_mov_b32_e32 v4, s2
 ; GFX12DAGISEL-NEXT:    ; implicit-def: $vgpr3
-; GFX12DAGISEL-NEXT:  .LBB2_4: ; %Flow
+; GFX12DAGISEL-NEXT:  .LBB3_4: ; %Flow
 ; GFX12DAGISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
 ; GFX12DAGISEL-NEXT:    s_and_not1_saveexec_b32 s0, s0
-; GFX12DAGISEL-NEXT:    s_cbranch_execz .LBB2_8
+; GFX12DAGISEL-NEXT:    s_cbranch_execz .LBB3_8
 ; GFX12DAGISEL-NEXT:  ; %bb.5: ; %if
 ; GFX12DAGISEL-NEXT:    s_mov_b32 s1, exec_lo
 ; GFX12DAGISEL-NEXT:    s_mov_b32 s2, 0x7fc00000
-; GFX12DAGISEL-NEXT:  .LBB2_6: ; =>This Inner Loop Header: Depth=1
+; GFX12DAGISEL-NEXT:  .LBB3_6: ; =>This Inner Loop Header: Depth=1
 ; GFX12DAGISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
 ; GFX12DAGISEL-NEXT:    s_ctz_i32_b32 s3, s1
 ; GFX12DAGISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
@@ -994,11 +1453,11 @@ define void @divergent_cfg_float(ptr addrspace(1) %out, float %in, float %in2) {
 ; GFX12DAGISEL-NEXT:    v_max_num_f32_e64 v2, s2, s4
 ; GFX12DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX12DAGISEL-NEXT:    v_readfirstlane_b32 s2, v2
-; GFX12DAGISEL-NEXT:    s_cbranch_scc1 .LBB2_6
+; GFX12DAGISEL-NEXT:    s_cbranch_scc1 .LBB3_6
 ; GFX12DAGISEL-NEXT:  ; %bb.7:
 ; GFX12DAGISEL-NEXT:    s_wait_alu depctr_va_sdst(0)
 ; GFX12DAGISEL-NEXT:    v_mov_b32_e32 v4, s2
-; GFX12DAGISEL-NEXT:  .LBB2_8: ; %endif
+; GFX12DAGISEL-NEXT:  .LBB3_8: ; %endif
 ; GFX12DAGISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
 ; GFX12DAGISEL-NEXT:    s_or_b32 exec_lo, exec_lo, s0
 ; GFX12DAGISEL-NEXT:    global_store_b32 v[0:1], v4, off
@@ -1144,7 +1603,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %in) {
 ; GFX8DAGISEL-NEXT:    s_mov_b32 s6, 0
 ; GFX8DAGISEL-NEXT:    s_mov_b32 s7, 0x7ff80000
 ; GFX8DAGISEL-NEXT:    s_mov_b64 s[4:5], exec
-; GFX8DAGISEL-NEXT:  .LBB4_1: ; =>This Inner Loop Header: Depth=1
+; GFX8DAGISEL-NEXT:  .LBB5_1: ; =>This Inner Loop Header: Depth=1
 ; GFX8DAGISEL-NEXT:    s_ff1_i32_b64 s10, s[4:5]
 ; GFX8DAGISEL-NEXT:    v_mov_b32_e32 v4, s6
 ; GFX8DAGISEL-NEXT:    v_readlane_b32 s8, v2, s10
@@ -1155,7 +1614,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %in) {
 ; GFX8DAGISEL-NEXT:    s_cmp_lg_u64 s[4:5], 0
 ; GFX8DAGISEL-NEXT:    v_readfirstlane_b32 s6, v4
 ; GFX8DAGISEL-NEXT:    v_readfirstlane_b32 s7, v5
-; GFX8DAGISEL-NEXT:    s_cbranch_scc1 .LBB4_1
+; GFX8DAGISEL-NEXT:    s_cbranch_scc1 .LBB5_1
 ; GFX8DAGISEL-NEXT:  ; %bb.2:
 ; GFX8DAGISEL-NEXT:    v_mov_b32_e32 v2, s6
 ; GFX8DAGISEL-NEXT:    v_mov_b32_e32 v3, s7
@@ -1169,7 +1628,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %in) {
 ; GFX8GISEL-NEXT:    s_mov_b32 s6, 0
 ; GFX8GISEL-NEXT:    s_mov_b32 s7, 0x7ff80000
 ; GFX8GISEL-NEXT:    s_mov_b64 s[4:5], exec
-; GFX8GISEL-NEXT:  .LBB4_1: ; =>This Inner Loop Header: Depth=1
+; GFX8GISEL-NEXT:  .LBB5_1: ; =>This Inner Loop Header: Depth=1
 ; GFX8GISEL-NEXT:    s_ff1_i32_b64 s10, s[4:5]
 ; GFX8GISEL-NEXT:    v_mov_b32_e32 v4, s6
 ; GFX8GISEL-NEXT:    v_readlane_b32 s8, v2, s10
@@ -1180,7 +1639,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %in) {
 ; GFX8GISEL-NEXT:    s_cmp_lg_u64 s[4:5], 0
 ; GFX8GISEL-NEXT:    v_readfirstlane_b32 s6, v4
 ; GFX8GISEL-NEXT:    v_readfirstlane_b32 s7, v5
-; GFX8GISEL-NEXT:    s_cbranch_scc1 .LBB4_1
+; GFX8GISEL-NEXT:    s_cbranch_scc1 .LBB5_1
 ; GFX8GISEL-NEXT:  ; %bb.2:
 ; GFX8GISEL-NEXT:    v_mov_b32_e32 v2, s6
 ; GFX8GISEL-NEXT:    v_mov_b32_e32 v3, s7
@@ -1194,7 +1653,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %in) {
 ; GFX9DAGISEL-NEXT:    s_mov_b32 s6, 0
 ; GFX9DAGISEL-NEXT:    s_mov_b32 s7, 0x7ff80000
 ; GFX9DAGISEL-NEXT:    s_mov_b64 s[4:5], exec
-; GFX9DAGISEL-NEXT:  .LBB4_1: ; =>This Inner Loop Header: Depth=1
+; GFX9DAGISEL-NEXT:  .LBB5_1: ; =>This Inner Loop Header: Depth=1
 ; GFX9DAGISEL-NEXT:    s_ff1_i32_b64 s10, s[4:5]
 ; GFX9DAGISEL-NEXT:    v_mov_b32_e32 v4, s6
 ; GFX9DAGISEL-NEXT:    v_readlane_b32 s8, v2, s10
@@ -1205,7 +1664,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %in) {
 ; GFX9DAGISEL-NEXT:    s_cmp_lg_u64 s[4:5], 0
 ; GFX9DAGISEL-NEXT:    v_readfirstlane_b32 s6, v4
 ; GFX9DAGISEL-NEXT:    v_readfirstlane_b32 s7, v5
-; GFX9DAGISEL-NEXT:    s_cbranch_scc1 .LBB4_1
+; GFX9DAGISEL-NEXT:    s_cbranch_scc1 .LBB5_1
 ; GFX9DAGISEL-NEXT:  ; %bb.2:
 ; GFX9DAGISEL-NEXT:    v_mov_b32_e32 v2, s6
 ; GFX9DAGISEL-NEXT:    v_mov_b32_e32 v3, s7
@@ -1219,7 +1678,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %in) {
 ; GFX9GISEL-NEXT:    s_mov_b32 s6, 0
 ; GFX9GISEL-NEXT:    s_mov_b32 s7, 0x7ff80000
 ; GFX9GISEL-NEXT:    s_mov_b64 s[4:5], exec
-; GFX9GISEL-NEXT:  .LBB4_1: ; =>This Inner Loop Header: Depth=1
+; GFX9GISEL-NEXT:  .LBB5_1: ; =>This Inner Loop Header: Depth=1
 ; GFX9GISEL-NEXT:    s_ff1_i32_b64 s10, s[4:5]
 ; GFX9GISEL-NEXT:    v_mov_b32_e32 v4, s6
 ; GFX9GISEL-NEXT:    v_readlane_b32 s8, v2, s10
@@ -1230,7 +1689,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %in) {
 ; GFX9GISEL-NEXT:    s_cmp_lg_u64 s[4:5], 0
 ; GFX9GISEL-NEXT:    v_readfirstlane_b32 s6, v4
 ; GFX9GISEL-NEXT:    v_readfirstlane_b32 s7, v5
-; GFX9GISEL-NEXT:    s_cbranch_scc1 .LBB4_1
+; GFX9GISEL-NEXT:    s_cbranch_scc1 .LBB5_1
 ; GFX9GISEL-NEXT:  ; %bb.2:
 ; GFX9GISEL-NEXT:    v_mov_b32_e32 v2, s6
 ; GFX9GISEL-NEXT:    v_mov_b32_e32 v3, s7
@@ -1244,7 +1703,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %in) {
 ; GFX1064DAGISEL-NEXT:    s_mov_b32 s6, 0
 ; GFX1064DAGISEL-NEXT:    s_mov_b32 s7, 0x7ff80000
 ; GFX1064DAGISEL-NEXT:    s_mov_b64 s[4:5], exec
-; GFX1064DAGISEL-NEXT:  .LBB4_1: ; =>This Inner Loop Header: Depth=1
+; GFX1064DAGISEL-NEXT:  .LBB5_1: ; =>This Inner Loop Header: Depth=1
 ; GFX1064DAGISEL-NEXT:    s_ff1_i32_b64 s10, s[4:5]
 ; GFX1064DAGISEL-NEXT:    v_readlane_b32 s8, v2, s10
 ; GFX1064DAGISEL-NEXT:    v_readlane_b32 s9, v3, s10
@@ -1253,7 +1712,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %in) {
 ; GFX1064DAGISEL-NEXT:    v_max_f64 v[4:5], s[8:9], s[6:7]
 ; GFX1064DAGISEL-NEXT:    v_readfirstlane_b32 s6, v4
 ; GFX1064DAGISEL-NEXT:    v_readfirstlane_b32 s7, v5
-; GFX1064DAGISEL-NEXT:    s_cbranch_scc1 .LBB4_1
+; GFX1064DAGISEL-NEXT:    s_cbranch_scc1 .LBB5_1
 ; GFX1064DAGISEL-NEXT:  ; %bb.2:
 ; GFX1064DAGISEL-NEXT:    v_mov_b32_e32 v2, s6
 ; GFX1064DAGISEL-NEXT:    v_mov_b32_e32 v3, s7
@@ -1266,7 +1725,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %in) {
 ; GFX1064GISEL-NEXT:    s_mov_b32 s6, 0
 ; GFX1064GISEL-NEXT:    s_mov_b32 s7, 0x7ff80000
 ; GFX1064GISEL-NEXT:    s_mov_b64 s[4:5], exec
-; GFX1064GISEL-NEXT:  .LBB4_1: ; =>This Inner Loop Header: Depth=1
+; GFX1064GISEL-NEXT:  .LBB5_1: ; =>This Inner Loop Header: Depth=1
 ; GFX1064GISEL-NEXT:    s_ff1_i32_b64 s10, s[4:5]
 ; GFX1064GISEL-NEXT:    v_readlane_b32 s8, v2, s10
 ; GFX1064GISEL-NEXT:    v_readlane_b32 s9, v3, s10
@@ -1275,7 +1734,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %in) {
 ; GFX1064GISEL-NEXT:    v_max_f64 v[4:5], s[8:9], s[6:7]
 ; GFX1064GISEL-NEXT:    v_readfirstlane_b32 s6, v4
 ; GFX1064GISEL-NEXT:    v_readfirstlane_b32 s7, v5
-; GFX1064GISEL-NEXT:    s_cbranch_scc1 .LBB4_1
+; GFX1064GISEL-NEXT:    s_cbranch_scc1 .LBB5_1
 ; GFX1064GISEL-NEXT:  ; %bb.2:
 ; GFX1064GISEL-NEXT:    v_mov_b32_e32 v2, s6
 ; GFX1064GISEL-NEXT:    v_mov_b32_e32 v3, s7
@@ -1288,7 +1747,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %in) {
 ; GFX1032DAGISEL-NEXT:    s_mov_b32 s4, 0
 ; GFX1032DAGISEL-NEXT:    s_mov_b32 s5, 0x7ff80000
 ; GFX1032DAGISEL-NEXT:    s_mov_b32 s6, exec_lo
-; GFX1032DAGISEL-NEXT:  .LBB4_1: ; =>This Inner Loop Header: Depth=1
+; GFX1032DAGISEL-NEXT:  .LBB5_1: ; =>This Inner Loop Header: Depth=1
 ; GFX1032DAGISEL-NEXT:    s_ff1_i32_b32 s7, s6
 ; GFX1032DAGISEL-NEXT:    v_readlane_b32 s8, v2, s7
 ; GFX1032DAGISEL-NEXT:    v_readlane_b32 s9, v3, s7
@@ -1297,7 +1756,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %in) {
 ; GFX1032DAGISEL-NEXT:    v_max_f64 v[4:5], s[8:9], s[4:5]
 ; GFX1032DAGISEL-NEXT:    v_readfirstlane_b32 s4, v4
 ; GFX1032DAGISEL-NEXT:    v_readfirstlane_b32 s5, v5
-; GFX1032DAGISEL-NEXT:    s_cbranch_scc1 .LBB4_1
+; GFX1032DAGISEL-NEXT:    s_cbranch_scc1 .LBB5_1
 ; GFX1032DAGISEL-NEXT:  ; %bb.2:
 ; GFX1032DAGISEL-NEXT:    v_mov_b32_e32 v2, s4
 ; GFX1032DAGISEL-NEXT:    v_mov_b32_e32 v3, s5
@@ -1310,7 +1769,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %in) {
 ; GFX1032GISEL-NEXT:    s_mov_b32 s4, 0
 ; GFX1032GISEL-NEXT:    s_mov_b32 s5, 0x7ff80000
 ; GFX1032GISEL-NEXT:    s_mov_b32 s6, exec_lo
-; GFX1032GISEL-NEXT:  .LBB4_1: ; =>This Inner Loop Header: Depth=1
+; GFX1032GISEL-NEXT:  .LBB5_1: ; =>This Inner Loop Header: Depth=1
 ; GFX1032GISEL-NEXT:    s_ff1_i32_b32 s7, s6
 ; GFX1032GISEL-NEXT:    v_readlane_b32 s8, v2, s7
 ; GFX1032GISEL-NEXT:    v_readlane_b32 s9, v3, s7
@@ -1319,7 +1778,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %in) {
 ; GFX1032GISEL-NEXT:    v_max_f64 v[4:5], s[8:9], s[4:5]
 ; GFX1032GISEL-NEXT:    v_readfirstlane_b32 s4, v4
 ; GFX1032GISEL-NEXT:    v_readfirstlane_b32 s5, v5
-; GFX1032GISEL-NEXT:    s_cbranch_scc1 .LBB4_1
+; GFX1032GISEL-NEXT:    s_cbranch_scc1 .LBB5_1
 ; GFX1032GISEL-NEXT:  ; %bb.2:
 ; GFX1032GISEL-NEXT:    v_mov_b32_e32 v2, s4
 ; GFX1032GISEL-NEXT:    v_mov_b32_e32 v3, s5
@@ -1332,7 +1791,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %in) {
 ; GFX1164DAGISEL-NEXT:    s_mov_b32 s2, 0
 ; GFX1164DAGISEL-NEXT:    s_mov_b32 s3, 0x7ff80000
 ; GFX1164DAGISEL-NEXT:    s_mov_b64 s[0:1], exec
-; GFX1164DAGISEL-NEXT:  .LBB4_1: ; =>This Inner Loop Header: Depth=1
+; GFX1164DAGISEL-NEXT:  .LBB5_1: ; =>This Inner Loop Header: Depth=1
 ; GFX1164DAGISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
 ; GFX1164DAGISEL-NEXT:    s_ctz_i32_b64 s6, s[0:1]
 ; GFX1164DAGISEL-NEXT:    v_readlane_b32 s4, v2, s6
@@ -1344,7 +1803,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %in) {
 ; GFX1164DAGISEL-NEXT:    v_readfirstlane_b32 s2, v4
 ; GFX1164DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2)
 ; GFX1164DAGISEL-NEXT:    v_readfirstlane_b32 s3, v5
-; GFX1164DAGISEL-NEXT:    s_cbranch_scc1 .LBB4_1
+; GFX1164DAGISEL-NEXT:    s_cbranch_scc1 .LBB5_1
 ; GFX1164DAGISEL-NEXT:  ; %bb.2:
 ; GFX1164DAGISEL-NEXT:    v_mov_b32_e32 v2, s2
 ; GFX1164DAGISEL-NEXT:    v_mov_b32_e32 v3, s3
@@ -1357,7 +1816,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %in) {
 ; GFX1164GISEL-NEXT:    s_mov_b32 s2, 0
 ; GFX1164GISEL-NEXT:    s_mov_b32 s3, 0x7ff80000
 ; GFX1164GISEL-NEXT:    s_mov_b64 s[0:1], exec
-; GFX1164GISEL-NEXT:  .LBB4_1: ; =>This Inner Loop Header: Depth=1
+; GFX1164GISEL-NEXT:  .LBB5_1: ; =>This Inner Loop Header: Depth=1
 ; GFX1164GISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
 ; GFX1164GISEL-NEXT:    s_ctz_i32_b64 s6, s[0:1]
 ; GFX1164GISEL-NEXT:    v_readlane_b32 s4, v2, s6
@@ -1369,7 +1828,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %in) {
 ; GFX1164GISEL-NEXT:    v_readfirstlane_b32 s2, v4
 ; GFX1164GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2)
 ; GFX1164GISEL-NEXT:    v_readfirstlane_b32 s3, v5
-; GFX1164GISEL-NEXT:    s_cbranch_scc1 .LBB4_1
+; GFX1164GISEL-NEXT:    s_cbranch_scc1 .LBB5_1
 ; GFX1164GISEL-NEXT:  ; %bb.2:
 ; GFX1164GISEL-NEXT:    v_mov_b32_e32 v2, s2
 ; GFX1164GISEL-NEXT:    v_mov_b32_e32 v3, s3
@@ -1382,7 +1841,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %in) {
 ; GFX1132DAGISEL-NEXT:    s_mov_b32 s0, 0
 ; GFX1132DAGISEL-NEXT:    s_mov_b32 s1, 0x7ff80000
 ; GFX1132DAGISEL-NEXT:    s_mov_b32 s2, exec_lo
-; GFX1132DAGISEL-NEXT:  .LBB4_1: ; =>This Inner Loop Header: Depth=1
+; GFX1132DAGISEL-NEXT:  .LBB5_1: ; =>This Inner Loop Header: Depth=1
 ; GFX1132DAGISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
 ; GFX1132DAGISEL-NEXT:    s_ctz_i32_b32 s3, s2
 ; GFX1132DAGISEL-NEXT:    v_readlane_b32 s4, v2, s3
@@ -1394,7 +1853,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %in) {
 ; GFX1132DAGISEL-NEXT:    v_readfirstlane_b32 s0, v4
 ; GFX1132DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2)
 ; GFX1132DAGISEL-NEXT:    v_readfirstlane_b32 s1, v5
-; GFX1132DAGISEL-NEXT:    s_cbranch_scc1 .LBB4_1
+; GFX1132DAGISEL-NEXT:    s_cbranch_scc1 .LBB5_1
 ; GFX1132DAGISEL-NEXT:  ; %bb.2:
 ; GFX1132DAGISEL-NEXT:    v_dual_mov_b32 v3, s1 :: v_dual_mov_b32 v2, s0
 ; GFX1132DAGISEL-NEXT:    global_store_b64 v[0:1], v[2:3], off
@@ -1406,7 +1865,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %in) {
 ; GFX1132GISEL-NEXT:    s_mov_b32 s0, 0
 ; GFX1132GISEL-NEXT:    s_mov_b32 s1, 0x7ff80000
 ; GFX1132GISEL-NEXT:    s_mov_b32 s2, exec_lo
-; GFX1132GISEL-NEXT:  .LBB4_1: ; =>This Inner Loop Header: Depth=1
+; GFX1132GISEL-NEXT:  .LBB5_1: ; =>This Inner Loop Header: Depth=1
 ; GFX1132GISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
 ; GFX1132GISEL-NEXT:    s_ctz_i32_b32 s3, s2
 ; GFX1132GISEL-NEXT:    v_readlane_b32 s4, v2, s3
@@ -1418,7 +1877,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %in) {
 ; GFX1132GISEL-NEXT:    v_readfirstlane_b32 s0, v4
 ; GFX1132GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2)
 ; GFX1132GISEL-NEXT:    v_readfirstlane_b32 s1, v5
-; GFX1132GISEL-NEXT:    s_cbranch_scc1 .LBB4_1
+; GFX1132GISEL-NEXT:    s_cbranch_scc1 .LBB5_1
 ; GFX1132GISEL-NEXT:  ; %bb.2:
 ; GFX1132GISEL-NEXT:    v_dual_mov_b32 v3, s1 :: v_dual_mov_b32 v2, s0
 ; GFX1132GISEL-NEXT:    global_store_b64 v[0:1], v[2:3], off
@@ -1434,7 +1893,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %in) {
 ; GFX12DAGISEL-NEXT:    s_mov_b32 s0, 0
 ; GFX12DAGISEL-NEXT:    s_mov_b32 s1, 0x7ff80000
 ; GFX12DAGISEL-NEXT:    s_mov_b32 s2, exec_lo
-; GFX12DAGISEL-NEXT:  .LBB4_1: ; =>This Inner Loop Header: Depth=1
+; GFX12DAGISEL-NEXT:  .LBB5_1: ; =>This Inner Loop Header: Depth=1
 ; GFX12DAGISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
 ; GFX12DAGISEL-NEXT:    s_ctz_i32_b32 s3, s2
 ; GFX12DAGISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
@@ -1447,7 +1906,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %in) {
 ; GFX12DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_2)
 ; GFX12DAGISEL-NEXT:    v_readfirstlane_b32 s0, v4
 ; GFX12DAGISEL-NEXT:    v_readfirstlane_b32 s1, v5
-; GFX12DAGISEL-NEXT:    s_cbranch_scc1 .LBB4_1
+; GFX12DAGISEL-NEXT:    s_cbranch_scc1 .LBB5_1
 ; GFX12DAGISEL-NEXT:  ; %bb.2:
 ; GFX12DAGISEL-NEXT:    s_wait_alu depctr_va_sdst(0)
 ; GFX12DAGISEL-NEXT:    v_dual_mov_b32 v3, s1 :: v_dual_mov_b32 v2, s0
@@ -1468,12 +1927,12 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX8DAGISEL-NEXT:    ; implicit-def: $vgpr6_vgpr7
 ; GFX8DAGISEL-NEXT:    s_and_saveexec_b64 s[4:5], vcc
 ; GFX8DAGISEL-NEXT:    s_xor_b64 s[4:5], exec, s[4:5]
-; GFX8DAGISEL-NEXT:    s_cbranch_execz .LBB5_4
+; GFX8DAGISEL-NEXT:    s_cbranch_execz .LBB6_4
 ; GFX8DAGISEL-NEXT:  ; %bb.1: ; %else
 ; GFX8DAGISEL-NEXT:    s_mov_b32 s8, 0
 ; GFX8DAGISEL-NEXT:    s_mov_b32 s9, 0x7ff80000
 ; GFX8DAGISEL-NEXT:    s_mov_b64 s[6:7], exec
-; GFX8DAGISEL-NEXT:  .LBB5_2: ; =>This Inner Loop Header: Depth=1
+; GFX8DAGISEL-NEXT:  .LBB6_2: ; =>This Inner Loop Header: Depth=1
 ; GFX8DAGISEL-NEXT:    s_ff1_i32_b64 s12, s[6:7]
 ; GFX8DAGISEL-NEXT:    v_mov_b32_e32 v4, s8
 ; GFX8DAGISEL-NEXT:    v_readlane_b32 s10, v2, s12
@@ -1484,20 +1943,20 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX8DAGISEL-NEXT:    s_cmp_lg_u64 s[6:7], 0
 ; GFX8DAGISEL-NEXT:    v_readfirstlane_b32 s8, v4
 ; GFX8DAGISEL-NEXT:    v_readfirstlane_b32 s9, v5
-; GFX8DAGISEL-NEXT:    s_cbranch_scc1 .LBB5_2
+; GFX8DAGISEL-NEXT:    s_cbranch_scc1 .LBB6_2
 ; GFX8DAGISEL-NEXT:  ; %bb.3:
 ; GFX8DAGISEL-NEXT:    v_mov_b32_e32 v6, s8
 ; GFX8DAGISEL-NEXT:    v_mov_b32_e32 v7, s9
 ; GFX8DAGISEL-NEXT:    ; implicit-def: $vgpr4
 ; GFX8DAGISEL-NEXT:    ; implicit-def: $vgpr5
-; GFX8DAGISEL-NEXT:  .LBB5_4: ; %Flow
+; GFX8DAGISEL-NEXT:  .LBB6_4: ; %Flow
 ; GFX8DAGISEL-NEXT:    s_andn2_saveexec_b64 s[4:5], s[4:5]
-; GFX8DAGISEL-NEXT:    s_cbranch_execz .LBB5_8
+; GFX8DAGISEL-NEXT:    s_cbranch_execz .LBB6_8
 ; GFX8DAGISEL-NEXT:  ; %bb.5: ; %if
 ; GFX8DAGISEL-NEXT:    s_mov_b32 s8, 0
 ; GFX8DAGISEL-NEXT:    s_mov_b32 s9, 0x7ff80000
 ; GFX8DAGISEL-NEXT:    s_mov_b64 s[6:7], exec
-; GFX8DAGISEL-NEXT:  .LBB5_6: ; =>This Inner Loop Header: Depth=1
+; GFX8DAGISEL-NEXT:  .LBB6_6: ; =>This Inner Loop Header: Depth=1
 ; GFX8DAGISEL-NEXT:    s_ff1_i32_b64 s12, s[6:7]
 ; GFX8DAGISEL-NEXT:    v_mov_b32_e32 v2, s8
 ; GFX8DAGISEL-NEXT:    v_readlane_b32 s10, v4, s12
@@ -1508,11 +1967,11 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX8DAGISEL-NEXT:    s_cmp_lg_u64 s[6:7], 0
 ; GFX8DAGISEL-NEXT:    v_readfirstlane_b32 s8, v2
 ; GFX8DAGISEL-NEXT:    v_readfirstlane_b32 s9, v3
-; GFX8DAGISEL-NEXT:    s_cbranch_scc1 .LBB5_6
+; GFX8DAGISEL-NEXT:    s_cbranch_scc1 .LBB6_6
 ; GFX8DAGISEL-NEXT:  ; %bb.7:
 ; GFX8DAGISEL-NEXT:    v_mov_b32_e32 v6, s8
 ; GFX8DAGISEL-NEXT:    v_mov_b32_e32 v7, s9
-; GFX8DAGISEL-NEXT:  .LBB5_8: ; %endif
+; GFX8DAGISEL-NEXT:  .LBB6_8: ; %endif
 ; GFX8DAGISEL-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; GFX8DAGISEL-NEXT:    flat_store_dwordx2 v[0:1], v[6:7]
 ; GFX8DAGISEL-NEXT:    s_waitcnt vmcnt(0)
@@ -1526,12 +1985,12 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX8GISEL-NEXT:    ; implicit-def: $sgpr4_sgpr5
 ; GFX8GISEL-NEXT:    s_and_saveexec_b64 s[6:7], vcc
 ; GFX8GISEL-NEXT:    s_xor_b64 s[6:7], exec, s[6:7]
-; GFX8GISEL-NEXT:    s_cbranch_execz .LBB5_3
+; GFX8GISEL-NEXT:    s_cbranch_execz .LBB6_3
 ; GFX8GISEL-NEXT:  ; %bb.1: ; %else
 ; GFX8GISEL-NEXT:    s_mov_b32 s4, 0
 ; GFX8GISEL-NEXT:    s_mov_b32 s5, 0x7ff80000
 ; GFX8GISEL-NEXT:    s_mov_b64 s[8:9], exec
-; GFX8GISEL-NEXT:  .LBB5_2: ; =>This Inner Loop Header: Depth=1
+; GFX8GISEL-NEXT:  .LBB6_2: ; =>This Inner Loop Header: Depth=1
 ; GFX8GISEL-NEXT:    s_ff1_i32_b64 s12, s[8:9]
 ; GFX8GISEL-NEXT:    v_mov_b32_e32 v4, s4
 ; GFX8GISEL-NEXT:    v_readlane_b32 s10, v2, s12
@@ -1544,15 +2003,15 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX8GISEL-NEXT:    v_readfirstlane_b32 s5, v5
 ; GFX8GISEL-NEXT:    ; implicit-def: $vgpr4
 ; GFX8GISEL-NEXT:    ; implicit-def: $vgpr5
-; GFX8GISEL-NEXT:    s_cbranch_scc1 .LBB5_2
-; GFX8GISEL-NEXT:  .LBB5_3: ; %Flow
+; GFX8GISEL-NEXT:    s_cbranch_scc1 .LBB6_2
+; GFX8GISEL-NEXT:  .LBB6_3: ; %Flow
 ; GFX8GISEL-NEXT:    s_andn2_saveexec_b64 s[6:7], s[6:7]
-; GFX8GISEL-NEXT:    s_cbranch_execz .LBB5_6
+; GFX8GISEL-NEXT:    s_cbranch_execz .LBB6_6
 ; GFX8GISEL-NEXT:  ; %bb.4: ; %if
 ; GFX8GISEL-NEXT:    s_mov_b32 s4, 0
 ; GFX8GISEL-NEXT:    s_mov_b32 s5, 0x7ff80000
 ; GFX8GISEL-NEXT:    s_mov_b64 s[8:9], exec
-; GFX8GISEL-NEXT:  .LBB5_5: ; =>This Inner Loop Header: Depth=1
+; GFX8GISEL-NEXT:  .LBB6_5: ; =>This Inner Loop Header: Depth=1
 ; GFX8GISEL-NEXT:    s_ff1_i32_b64 s12, s[8:9]
 ; GFX8GISEL-NEXT:    v_mov_b32_e32 v2, s4
 ; GFX8GISEL-NEXT:    v_readlane_b32 s10, v4, s12
@@ -1563,8 +2022,8 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX8GISEL-NEXT:    s_cmp_lg_u64 s[8:9], 0
 ; GFX8GISEL-NEXT:    v_readfirstlane_b32 s4, v2
 ; GFX8GISEL-NEXT:    v_readfirstlane_b32 s5, v3
-; GFX8GISEL-NEXT:    s_cbranch_scc1 .LBB5_5
-; GFX8GISEL-NEXT:  .LBB5_6: ; %endif
+; GFX8GISEL-NEXT:    s_cbranch_scc1 .LBB6_5
+; GFX8GISEL-NEXT:  .LBB6_6: ; %endif
 ; GFX8GISEL-NEXT:    s_or_b64 exec, exec, s[6:7]
 ; GFX8GISEL-NEXT:    v_mov_b32_e32 v2, s4
 ; GFX8GISEL-NEXT:    v_mov_b32_e32 v3, s5
@@ -1580,12 +2039,12 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX9DAGISEL-NEXT:    ; implicit-def: $vgpr6_vgpr7
 ; GFX9DAGISEL-NEXT:    s_and_saveexec_b64 s[4:5], vcc
 ; GFX9DAGISEL-NEXT:    s_xor_b64 s[4:5], exec, s[4:5]
-; GFX9DAGISEL-NEXT:    s_cbranch_execz .LBB5_4
+; GFX9DAGISEL-NEXT:    s_cbranch_execz .LBB6_4
 ; GFX9DAGISEL-NEXT:  ; %bb.1: ; %else
 ; GFX9DAGISEL-NEXT:    s_mov_b32 s8, 0
 ; GFX9DAGISEL-NEXT:    s_mov_b32 s9, 0x7ff80000
 ; GFX9DAGISEL-NEXT:    s_mov_b64 s[6:7], exec
-; GFX9DAGISEL-NEXT:  .LBB5_2: ; =>This Inner Loop Header: Depth=1
+; GFX9DAGISEL-NEXT:  .LBB6_2: ; =>This Inner Loop Header: Depth=1
 ; GFX9DAGISEL-NEXT:    s_ff1_i32_b64 s12, s[6:7]
 ; GFX9DAGISEL-NEXT:    v_mov_b32_e32 v4, s8
 ; GFX9DAGISEL-NEXT:    v_readlane_b32 s10, v2, s12
@@ -1596,20 +2055,20 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX9DAGISEL-NEXT:    s_cmp_lg_u64 s[6:7], 0
 ; GFX9DAGISEL-NEXT:    v_readfirstlane_b32 s8, v4
 ; GFX9DAGISEL-NEXT:    v_readfirstlane_b32 s9, v5
-; GFX9DAGISEL-NEXT:    s_cbranch_scc1 .LBB5_2
+; GFX9DAGISEL-NEXT:    s_cbranch_scc1 .LBB6_2
 ; GFX9DAGISEL-NEXT:  ; %bb.3:
 ; GFX9DAGISEL-NEXT:    v_mov_b32_e32 v6, s8
 ; GFX9DAGISEL-NEXT:    v_mov_b32_e32 v7, s9
 ; GFX9DAGISEL-NEXT:    ; implicit-def: $vgpr4
 ; GFX9DAGISEL-NEXT:    ; implicit-def: $vgpr5
-; GFX9DAGISEL-NEXT:  .LBB5_4: ; %Flow
+; GFX9DAGISEL-NEXT:  .LBB6_4: ; %Flow
 ; GFX9DAGISEL-NEXT:    s_andn2_saveexec_b64 s[4:5], s[4:5]
-; GFX9DAGISEL-NEXT:    s_cbranch_execz .LBB5_8
+; GFX9DAGISEL-NEXT:    s_cbranch_execz .LBB6_8
 ; GFX9DAGISEL-NEXT:  ; %bb.5: ; %if
 ; GFX9DAGISEL-NEXT:    s_mov_b32 s8, 0
 ; GFX9DAGISEL-NEXT:    s_mov_b32 s9, 0x7ff80000
 ; GFX9DAGISEL-NEXT:    s_mov_b64 s[6:7], exec
-; GFX9DAGISEL-NEXT:  .LBB5_6: ; =>This Inner Loop Header: Depth=1
+; GFX9DAGISEL-NEXT:  .LBB6_6: ; =>This Inner Loop Header: Depth=1
 ; GFX9DAGISEL-NEXT:    s_ff1_i32_b64 s12, s[6:7]
 ; GFX9DAGISEL-NEXT:    v_mov_b32_e32 v2, s8
 ; GFX9DAGISEL-NEXT:    v_readlane_b32 s10, v4, s12
@@ -1620,11 +2079,11 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX9DAGISEL-NEXT:    s_cmp_lg_u64 s[6:7], 0
 ; GFX9DAGISEL-NEXT:    v_readfirstlane_b32 s8, v2
 ; GFX9DAGISEL-NEXT:    v_readfirstlane_b32 s9, v3
-; GFX9DAGISEL-NEXT:    s_cbranch_scc1 .LBB5_6
+; GFX9DAGISEL-NEXT:    s_cbranch_scc1 .LBB6_6
 ; GFX9DAGISEL-NEXT:  ; %bb.7:
 ; GFX9DAGISEL-NEXT:    v_mov_b32_e32 v6, s8
 ; GFX9DAGISEL-NEXT:    v_mov_b32_e32 v7, s9
-; GFX9DAGISEL-NEXT:  .LBB5_8: ; %endif
+; GFX9DAGISEL-NEXT:  .LBB6_8: ; %endif
 ; GFX9DAGISEL-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; GFX9DAGISEL-NEXT:    global_store_dwordx2 v[0:1], v[6:7], off
 ; GFX9DAGISEL-NEXT:    s_waitcnt vmcnt(0)
@@ -1638,12 +2097,12 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX9GISEL-NEXT:    ; implicit-def: $sgpr4_sgpr5
 ; GFX9GISEL-NEXT:    s_and_saveexec_b64 s[6:7], vcc
 ; GFX9GISEL-NEXT:    s_xor_b64 s[6:7], exec, s[6:7]
-; GFX9GISEL-NEXT:    s_cbranch_execz .LBB5_3
+; GFX9GISEL-NEXT:    s_cbranch_execz .LBB6_3
 ; GFX9GISEL-NEXT:  ; %bb.1: ; %else
 ; GFX9GISEL-NEXT:    s_mov_b32 s4, 0
 ; GFX9GISEL-NEXT:    s_mov_b32 s5, 0x7ff80000
 ; GFX9GISEL-NEXT:    s_mov_b64 s[8:9], exec
-; GFX9GISEL-NEXT:  .LBB5_2: ; =>This Inner Loop Header: Depth=1
+; GFX9GISEL-NEXT:  .LBB6_2: ; =>This Inner Loop Header: Depth=1
 ; GFX9GISEL-NEXT:    s_ff1_i32_b64 s12, s[8:9]
 ; GFX9GISEL-NEXT:    v_mov_b32_e32 v4, s4
 ; GFX9GISEL-NEXT:    v_readlane_b32 s10, v2, s12
@@ -1656,15 +2115,15 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX9GISEL-NEXT:    v_readfirstlane_b32 s5, v5
 ; GFX9GISEL-NEXT:    ; implicit-def: $vgpr4
 ; GFX9GISEL-NEXT:    ; implicit-def: $vgpr5
-; GFX9GISEL-NEXT:    s_cbranch_scc1 .LBB5_2
-; GFX9GISEL-NEXT:  .LBB5_3: ; %Flow
+; GFX9GISEL-NEXT:    s_cbranch_scc1 .LBB6_2
+; GFX9GISEL-NEXT:  .LBB6_3: ; %Flow
 ; GFX9GISEL-NEXT:    s_andn2_saveexec_b64 s[6:7], s[6:7]
-; GFX9GISEL-NEXT:    s_cbranch_execz .LBB5_6
+; GFX9GISEL-NEXT:    s_cbranch_execz .LBB6_6
 ; GFX9GISEL-NEXT:  ; %bb.4: ; %if
 ; GFX9GISEL-NEXT:    s_mov_b32 s4, 0
 ; GFX9GISEL-NEXT:    s_mov_b32 s5, 0x7ff80000
 ; GFX9GISEL-NEXT:    s_mov_b64 s[8:9], exec
-; GFX9GISEL-NEXT:  .LBB5_5: ; =>This Inner Loop Header: Depth=1
+; GFX9GISEL-NEXT:  .LBB6_5: ; =>This Inner Loop Header: Depth=1
 ; GFX9GISEL-NEXT:    s_ff1_i32_b64 s12, s[8:9]
 ; GFX9GISEL-NEXT:    v_mov_b32_e32 v2, s4
 ; GFX9GISEL-NEXT:    v_readlane_b32 s10, v4, s12
@@ -1675,8 +2134,8 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX9GISEL-NEXT:    s_cmp_lg_u64 s[8:9], 0
 ; GFX9GISEL-NEXT:    v_readfirstlane_b32 s4, v2
 ; GFX9GISEL-NEXT:    v_readfirstlane_b32 s5, v3
-; GFX9GISEL-NEXT:    s_cbranch_scc1 .LBB5_5
-; GFX9GISEL-NEXT:  .LBB5_6: ; %endif
+; GFX9GISEL-NEXT:    s_cbranch_scc1 .LBB6_5
+; GFX9GISEL-NEXT:  .LBB6_6: ; %endif
 ; GFX9GISEL-NEXT:    s_or_b64 exec, exec, s[6:7]
 ; GFX9GISEL-NEXT:    v_mov_b32_e32 v2, s4
 ; GFX9GISEL-NEXT:    v_mov_b32_e32 v3, s5
@@ -1692,12 +2151,12 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX1064DAGISEL-NEXT:    ; implicit-def: $vgpr6_vgpr7
 ; GFX1064DAGISEL-NEXT:    s_and_saveexec_b64 s[4:5], vcc
 ; GFX1064DAGISEL-NEXT:    s_xor_b64 s[4:5], exec, s[4:5]
-; GFX1064DAGISEL-NEXT:    s_cbranch_execz .LBB5_4
+; GFX1064DAGISEL-NEXT:    s_cbranch_execz .LBB6_4
 ; GFX1064DAGISEL-NEXT:  ; %bb.1: ; %else
 ; GFX1064DAGISEL-NEXT:    s_mov_b32 s8, 0
 ; GFX1064DAGISEL-NEXT:    s_mov_b32 s9, 0x7ff80000
 ; GFX1064DAGISEL-NEXT:    s_mov_b64 s[6:7], exec
-; GFX1064DAGISEL-NEXT:  .LBB5_2: ; =>This Inner Loop Header: Depth=1
+; GFX1064DAGISEL-NEXT:  .LBB6_2: ; =>This Inner Loop Header: Depth=1
 ; GFX1064DAGISEL-NEXT:    s_ff1_i32_b64 s12, s[6:7]
 ; GFX1064DAGISEL-NEXT:    v_readlane_b32 s10, v2, s12
 ; GFX1064DAGISEL-NEXT:    v_readlane_b32 s11, v3, s12
@@ -1706,20 +2165,20 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX1064DAGISEL-NEXT:    v_max_f64 v[4:5], s[10:11], s[8:9]
 ; GFX1064DAGISEL-NEXT:    v_readfirstlane_b32 s8, v4
 ; GFX1064DAGISEL-NEXT:    v_readfirstlane_b32 s9, v5
-; GFX1064DAGISEL-NEXT:    s_cbranch_scc1 .LBB5_2
+; GFX1064DAGISEL-NEXT:    s_cbranch_scc1 .LBB6_2
 ; GFX1064DAGISEL-NEXT:  ; %bb.3:
 ; GFX1064DAGISEL-NEXT:    v_mov_b32_e32 v6, s8
 ; GFX1064DAGISEL-NEXT:    v_mov_b32_e32 v7, s9
 ; GFX1064DAGISEL-NEXT:    ; implicit-def: $vgpr4
 ; GFX1064DAGISEL-NEXT:    ; implicit-def: $vgpr5
-; GFX1064DAGISEL-NEXT:  .LBB5_4: ; %Flow
+; GFX1064DAGISEL-NEXT:  .LBB6_4: ; %Flow
 ; GFX1064DAGISEL-NEXT:    s_andn2_saveexec_b64 s[4:5], s[4:5]
-; GFX1064DAGISEL-NEXT:    s_cbranch_execz .LBB5_8
+; GFX1064DAGISEL-NEXT:    s_cbranch_execz .LBB6_8
 ; GFX1064DAGISEL-NEXT:  ; %bb.5: ; %if
 ; GFX1064DAGISEL-NEXT:    s_mov_b32 s8, 0
 ; GFX1064DAGISEL-NEXT:    s_mov_b32 s9, 0x7ff80000
 ; GFX1064DAGISEL-NEXT:    s_mov_b64 s[6:7], exec
-; GFX1064DAGISEL-NEXT:  .LBB5_6: ; =>This Inner Loop Header: Depth=1
+; GFX1064DAGISEL-NEXT:  .LBB6_6: ; =>This Inner Loop Header: Depth=1
 ; GFX1064DAGISEL-NEXT:    s_ff1_i32_b64 s12, s[6:7]
 ; GFX1064DAGISEL-NEXT:    v_readlane_b32 s10, v4, s12
 ; GFX1064DAGISEL-NEXT:    v_readlane_b32 s11, v5, s12
@@ -1728,11 +2187,11 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX1064DAGISEL-NEXT:    v_max_f64 v[2:3], s[10:11], s[8:9]
 ; GFX1064DAGISEL-NEXT:    v_readfirstlane_b32 s8, v2
 ; GFX1064DAGISEL-NEXT:    v_readfirstlane_b32 s9, v3
-; GFX1064DAGISEL-NEXT:    s_cbranch_scc1 .LBB5_6
+; GFX1064DAGISEL-NEXT:    s_cbranch_scc1 .LBB6_6
 ; GFX1064DAGISEL-NEXT:  ; %bb.7:
 ; GFX1064DAGISEL-NEXT:    v_mov_b32_e32 v6, s8
 ; GFX1064DAGISEL-NEXT:    v_mov_b32_e32 v7, s9
-; GFX1064DAGISEL-NEXT:  .LBB5_8: ; %endif
+; GFX1064DAGISEL-NEXT:  .LBB6_8: ; %endif
 ; GFX1064DAGISEL-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; GFX1064DAGISEL-NEXT:    global_store_dwordx2 v[0:1], v[6:7], off
 ; GFX1064DAGISEL-NEXT:    s_setpc_b64 s[30:31]
@@ -1745,12 +2204,12 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX1064GISEL-NEXT:    v_cmp_le_u32_e32 vcc, 16, v6
 ; GFX1064GISEL-NEXT:    s_and_saveexec_b64 s[6:7], vcc
 ; GFX1064GISEL-NEXT:    s_xor_b64 s[6:7], exec, s[6:7]
-; GFX1064GISEL-NEXT:    s_cbranch_execz .LBB5_3
+; GFX1064GISEL-NEXT:    s_cbranch_execz .LBB6_3
 ; GFX1064GISEL-NEXT:  ; %bb.1: ; %else
 ; GFX1064GISEL-NEXT:    s_mov_b32 s4, 0
 ; GFX1064GISEL-NEXT:    s_mov_b32 s5, 0x7ff80000
 ; GFX1064GISEL-NEXT:    s_mov_b64 s[8:9], exec
-; GFX1064GISEL-NEXT:  .LBB5_2: ; =>This Inner Loop Header: Depth=1
+; GFX1064GISEL-NEXT:  .LBB6_2: ; =>This Inner Loop Header: Depth=1
 ; GFX1064GISEL-NEXT:    s_ff1_i32_b64 s12, s[8:9]
 ; GFX1064GISEL-NEXT:    v_readlane_b32 s10, v2, s12
 ; GFX1064GISEL-NEXT:    v_readlane_b32 s11, v3, s12
@@ -1761,15 +2220,15 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX1064GISEL-NEXT:    v_readfirstlane_b32 s5, v5
 ; GFX1064GISEL-NEXT:    ; implicit-def: $vgpr4
 ; GFX1064GISEL-NEXT:    ; implicit-def: $vgpr5
-; GFX1064GISEL-NEXT:    s_cbranch_scc1 .LBB5_2
-; GFX1064GISEL-NEXT:  .LBB5_3: ; %Flow
+; GFX1064GISEL-NEXT:    s_cbranch_scc1 .LBB6_2
+; GFX1064GISEL-NEXT:  .LBB6_3: ; %Flow
 ; GFX1064GISEL-NEXT:    s_andn2_saveexec_b64 s[6:7], s[6:7]
-; GFX1064GISEL-NEXT:    s_cbranch_execz .LBB5_6
+; GFX1064GISEL-NEXT:    s_cbranch_execz .LBB6_6
 ; GFX1064GISEL-NEXT:  ; %bb.4: ; %if
 ; GFX1064GISEL-NEXT:    s_mov_b32 s4, 0
 ; GFX1064GISEL-NEXT:    s_mov_b32 s5, 0x7ff80000
 ; GFX1064GISEL-NEXT:    s_mov_b64 s[8:9], exec
-; GFX1064GISEL-NEXT:  .LBB5_5: ; =>This Inner Loop Header: Depth=1
+; GFX1064GISEL-NEXT:  .LBB6_5: ; =>This Inner Loop Header: Depth=1
 ; GFX1064GISEL-NEXT:    s_ff1_i32_b64 s12, s[8:9]
 ; GFX1064GISEL-NEXT:    v_readlane_b32 s10, v4, s12
 ; GFX1064GISEL-NEXT:    v_readlane_b32 s11, v5, s12
@@ -1778,8 +2237,8 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX1064GISEL-NEXT:    v_max_f64 v[2:3], s[10:11], s[4:5]
 ; GFX1064GISEL-NEXT:    v_readfirstlane_b32 s4, v2
 ; GFX1064GISEL-NEXT:    v_readfirstlane_b32 s5, v3
-; GFX1064GISEL-NEXT:    s_cbranch_scc1 .LBB5_5
-; GFX1064GISEL-NEXT:  .LBB5_6: ; %endif
+; GFX1064GISEL-NEXT:    s_cbranch_scc1 .LBB6_5
+; GFX1064GISEL-NEXT:  .LBB6_6: ; %endif
 ; GFX1064GISEL-NEXT:    s_or_b64 exec, exec, s[6:7]
 ; GFX1064GISEL-NEXT:    v_mov_b32_e32 v2, s4
 ; GFX1064GISEL-NEXT:    v_mov_b32_e32 v3, s5
@@ -1794,12 +2253,12 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX1032DAGISEL-NEXT:    ; implicit-def: $vgpr6_vgpr7
 ; GFX1032DAGISEL-NEXT:    s_and_saveexec_b32 s4, vcc_lo
 ; GFX1032DAGISEL-NEXT:    s_xor_b32 s6, exec_lo, s4
-; GFX1032DAGISEL-NEXT:    s_cbranch_execz .LBB5_4
+; GFX1032DAGISEL-NEXT:    s_cbranch_execz .LBB6_4
 ; GFX1032DAGISEL-NEXT:  ; %bb.1: ; %else
 ; GFX1032DAGISEL-NEXT:    s_mov_b32 s4, 0
 ; GFX1032DAGISEL-NEXT:    s_mov_b32 s5, 0x7ff80000
 ; GFX1032DAGISEL-NEXT:    s_mov_b32 s7, exec_lo
-; GFX1032DAGISEL-NEXT:  .LBB5_2: ; =>This Inner Loop Header: Depth=1
+; GFX1032DAGISEL-NEXT:  .LBB6_2: ; =>This Inner Loop Header: Depth=1
 ; GFX1032DAGISEL-NEXT:    s_ff1_i32_b32 s10, s7
 ; GFX1032DAGISEL-NEXT:    v_readlane_b32 s8, v2, s10
 ; GFX1032DAGISEL-NEXT:    v_readlane_b32 s9, v3, s10
@@ -1808,20 +2267,20 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX1032DAGISEL-NEXT:    v_max_f64 v[4:5], s[8:9], s[4:5]
 ; GFX1032DAGISEL-NEXT:    v_readfirstlane_b32 s4, v4
 ; GFX1032DAGISEL-NEXT:    v_readfirstlane_b32 s5, v5
-; GFX1032DAGISEL-NEXT:    s_cbranch_scc1 .LBB5_2
+; GFX1032DAGISEL-NEXT:    s_cbranch_scc1 .LBB6_2
 ; GFX1032DAGISEL-NEXT:  ; %bb.3:
 ; GFX1032DAGISEL-NEXT:    v_mov_b32_e32 v7, s5
 ; GFX1032DAGISEL-NEXT:    v_mov_b32_e32 v6, s4
 ; GFX1032DAGISEL-NEXT:    ; implicit-def: $vgpr4
 ; GFX1032DAGISEL-NEXT:    ; implicit-def: $vgpr5
-; GFX1032DAGISEL-NEXT:  .LBB5_4: ; %Flow
+; GFX1032DAGISEL-NEXT:  .LBB6_4: ; %Flow
 ; GFX1032DAGISEL-NEXT:    s_andn2_saveexec_b32 s6, s6
-; GFX1032DAGISEL-NEXT:    s_cbranch_execz .LBB5_8
+; GFX1032DAGISEL-NEXT:    s_cbranch_execz .LBB6_8
 ; GFX1032DAGISEL-NEXT:  ; %bb.5: ; %if
 ; GFX1032DAGISEL-NEXT:    s_mov_b32 s4, 0
 ; GFX1032DAGISEL-NEXT:    s_mov_b32 s5, 0x7ff80000
 ; GFX1032DAGISEL-NEXT:    s_mov_b32 s7, exec_lo
-; GFX1032DAGISEL-NEXT:  .LBB5_6: ; =>This Inner Loop Header: Depth=1
+; GFX1032DAGISEL-NEXT:  .LBB6_6: ; =>This Inner Loop Header: Depth=1
 ; GFX1032DAGISEL-NEXT:    s_ff1_i32_b32 s10, s7
 ; GFX1032DAGISEL-NEXT:    v_readlane_b32 s8, v4, s10
 ; GFX1032DAGISEL-NEXT:    v_readlane_b32 s9, v5, s10
@@ -1830,11 +2289,11 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX1032DAGISEL-NEXT:    v_max_f64 v[2:3], s[8:9], s[4:5]
 ; GFX1032DAGISEL-NEXT:    v_readfirstlane_b32 s4, v2
 ; GFX1032DAGISEL-NEXT:    v_readfirstlane_b32 s5, v3
-; GFX1032DAGISEL-NEXT:    s_cbranch_scc1 .LBB5_6
+; GFX1032DAGISEL-NEXT:    s_cbranch_scc1 .LBB6_6
 ; GFX1032DAGISEL-NEXT:  ; %bb.7:
 ; GFX1032DAGISEL-NEXT:    v_mov_b32_e32 v7, s5
 ; GFX1032DAGISEL-NEXT:    v_mov_b32_e32 v6, s4
-; GFX1032DAGISEL-NEXT:  .LBB5_8: ; %endif
+; GFX1032DAGISEL-NEXT:  .LBB6_8: ; %endif
 ; GFX1032DAGISEL-NEXT:    s_or_b32 exec_lo, exec_lo, s6
 ; GFX1032DAGISEL-NEXT:    global_store_dwordx2 v[0:1], v[6:7], off
 ; GFX1032DAGISEL-NEXT:    s_setpc_b64 s[30:31]
@@ -1847,12 +2306,12 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX1032GISEL-NEXT:    v_cmp_le_u32_e32 vcc_lo, 16, v6
 ; GFX1032GISEL-NEXT:    s_and_saveexec_b32 s6, vcc_lo
 ; GFX1032GISEL-NEXT:    s_xor_b32 s6, exec_lo, s6
-; GFX1032GISEL-NEXT:    s_cbranch_execz .LBB5_3
+; GFX1032GISEL-NEXT:    s_cbranch_execz .LBB6_3
 ; GFX1032GISEL-NEXT:  ; %bb.1: ; %else
 ; GFX1032GISEL-NEXT:    s_mov_b32 s4, 0
 ; GFX1032GISEL-NEXT:    s_mov_b32 s5, 0x7ff80000
 ; GFX1032GISEL-NEXT:    s_mov_b32 s7, exec_lo
-; GFX1032GISEL-NEXT:  .LBB5_2: ; =>This Inner Loop Header: Depth=1
+; GFX1032GISEL-NEXT:  .LBB6_2: ; =>This Inner Loop Header: Depth=1
 ; GFX1032GISEL-NEXT:    s_ff1_i32_b32 s10, s7
 ; GFX1032GISEL-NEXT:    v_readlane_b32 s8, v2, s10
 ; GFX1032GISEL-NEXT:    v_readlane_b32 s9, v3, s10
@@ -1863,15 +2322,15 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX1032GISEL-NEXT:    v_readfirstlane_b32 s5, v5
 ; GFX1032GISEL-NEXT:    ; implicit-def: $vgpr4
 ; GFX1032GISEL-NEXT:    ; implicit-def: $vgpr5
-; GFX1032GISEL-NEXT:    s_cbranch_scc1 .LBB5_2
-; GFX1032GISEL-NEXT:  .LBB5_3: ; %Flow
+; GFX1032GISEL-NEXT:    s_cbranch_scc1 .LBB6_2
+; GFX1032GISEL-NEXT:  .LBB6_3: ; %Flow
 ; GFX1032GISEL-NEXT:    s_andn2_saveexec_b32 s6, s6
-; GFX1032GISEL-NEXT:    s_cbranch_execz .LBB5_6
+; GFX1032GISEL-NEXT:    s_cbranch_execz .LBB6_6
 ; GFX1032GISEL-NEXT:  ; %bb.4: ; %if
 ; GFX1032GISEL-NEXT:    s_mov_b32 s4, 0
 ; GFX1032GISEL-NEXT:    s_mov_b32 s5, 0x7ff80000
 ; GFX1032GISEL-NEXT:    s_mov_b32 s7, exec_lo
-; GFX1032GISEL-NEXT:  .LBB5_5: ; =>This Inner Loop Header: Depth=1
+; GFX1032GISEL-NEXT:  .LBB6_5: ; =>This Inner Loop Header: Depth=1
 ; GFX1032GISEL-NEXT:    s_ff1_i32_b32 s10, s7
 ; GFX1032GISEL-NEXT:    v_readlane_b32 s8, v4, s10
 ; GFX1032GISEL-NEXT:    v_readlane_b32 s9, v5, s10
@@ -1880,8 +2339,8 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX1032GISEL-NEXT:    v_max_f64 v[2:3], s[8:9], s[4:5]
 ; GFX1032GISEL-NEXT:    v_readfirstlane_b32 s4, v2
 ; GFX1032GISEL-NEXT:    v_readfirstlane_b32 s5, v3
-; GFX1032GISEL-NEXT:    s_cbranch_scc1 .LBB5_5
-; GFX1032GISEL-NEXT:  .LBB5_6: ; %endif
+; GFX1032GISEL-NEXT:    s_cbranch_scc1 .LBB6_5
+; GFX1032GISEL-NEXT:  .LBB6_6: ; %endif
 ; GFX1032GISEL-NEXT:    s_or_b32 exec_lo, exec_lo, s6
 ; GFX1032GISEL-NEXT:    v_mov_b32_e32 v2, s4
 ; GFX1032GISEL-NEXT:    v_mov_b32_e32 v3, s5
@@ -1897,12 +2356,12 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX1164DAGISEL-NEXT:    ; implicit-def: $vgpr6_vgpr7
 ; GFX1164DAGISEL-NEXT:    s_and_saveexec_b64 s[0:1], vcc
 ; GFX1164DAGISEL-NEXT:    s_xor_b64 s[0:1], exec, s[0:1]
-; GFX1164DAGISEL-NEXT:    s_cbranch_execz .LBB5_4
+; GFX1164DAGISEL-NEXT:    s_cbranch_execz .LBB6_4
 ; GFX1164DAGISEL-NEXT:  ; %bb.1: ; %else
 ; GFX1164DAGISEL-NEXT:    s_mov_b32 s4, 0
 ; GFX1164DAGISEL-NEXT:    s_mov_b32 s5, 0x7ff80000
 ; GFX1164DAGISEL-NEXT:    s_mov_b64 s[2:3], exec
-; GFX1164DAGISEL-NEXT:  .LBB5_2: ; =>This Inner Loop Header: Depth=1
+; GFX1164DAGISEL-NEXT:  .LBB6_2: ; =>This Inner Loop Header: Depth=1
 ; GFX1164DAGISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
 ; GFX1164DAGISEL-NEXT:    s_ctz_i32_b64 s8, s[2:3]
 ; GFX1164DAGISEL-NEXT:    v_readlane_b32 s6, v2, s8
@@ -1914,20 +2373,20 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX1164DAGISEL-NEXT:    v_readfirstlane_b32 s4, v4
 ; GFX1164DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2)
 ; GFX1164DAGISEL-NEXT:    v_readfirstlane_b32 s5, v5
-; GFX1164DAGISEL-NEXT:    s_cbranch_scc1 .LBB5_2
+; GFX1164DAGISEL-NEXT:    s_cbranch_scc1 .LBB6_2
 ; GFX1164DAGISEL-NEXT:  ; %bb.3:
 ; GFX1164DAGISEL-NEXT:    v_mov_b32_e32 v7, s5
 ; GFX1164DAGISEL-NEXT:    v_mov_b32_e32 v6, s4
 ; GFX1164DAGISEL-NEXT:    ; implicit-def: $vgpr4
 ; GFX1164DAGISEL-NEXT:    ; implicit-def: $vgpr5
-; GFX1164DAGISEL-NEXT:  .LBB5_4: ; %Flow
+; GFX1164DAGISEL-NEXT:  .LBB6_4: ; %Flow
 ; GFX1164DAGISEL-NEXT:    s_and_not1_saveexec_b64 s[0:1], s[0:1]
-; GFX1164DAGISEL-NEXT:    s_cbranch_execz .LBB5_8
+; GFX1164DAGISEL-NEXT:    s_cbranch_execz .LBB6_8
 ; GFX1164DAGISEL-NEXT:  ; %bb.5: ; %if
 ; GFX1164DAGISEL-NEXT:    s_mov_b32 s4, 0
 ; GFX1164DAGISEL-NEXT:    s_mov_b32 s5, 0x7ff80000
 ; GFX1164DAGISEL-NEXT:    s_mov_b64 s[2:3], exec
-; GFX1164DAGISEL-NEXT:  .LBB5_6: ; =>This Inner Loop Header: Depth=1
+; GFX1164DAGISEL-NEXT:  .LBB6_6: ; =>This Inner Loop Header: Depth=1
 ; GFX1164DAGISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
 ; GFX1164DAGISEL-NEXT:    s_ctz_i32_b64 s8, s[2:3]
 ; GFX1164DAGISEL-NEXT:    v_readlane_b32 s6, v4, s8
@@ -1939,11 +2398,11 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX1164DAGISEL-NEXT:    v_readfirstlane_b32 s4, v2
 ; GFX1164DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2)
 ; GFX1164DAGISEL-NEXT:    v_readfirstlane_b32 s5, v3
-; GFX1164DAGISEL-NEXT:    s_cbranch_scc1 .LBB5_6
+; GFX1164DAGISEL-NEXT:    s_cbranch_scc1 .LBB6_6
 ; GFX1164DAGISEL-NEXT:  ; %bb.7:
 ; GFX1164DAGISEL-NEXT:    v_mov_b32_e32 v7, s5
 ; GFX1164DAGISEL-NEXT:    v_mov_b32_e32 v6, s4
-; GFX1164DAGISEL-NEXT:  .LBB5_8: ; %endif
+; GFX1164DAGISEL-NEXT:  .LBB6_8: ; %endif
 ; GFX1164DAGISEL-NEXT:    s_or_b64 exec, exec, s[0:1]
 ; GFX1164DAGISEL-NEXT:    global_store_b64 v[0:1], v[6:7], off
 ; GFX1164DAGISEL-NEXT:    s_setpc_b64 s[30:31]
@@ -1957,12 +2416,12 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX1164GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX1164GISEL-NEXT:    v_cmpx_le_u32_e32 16, v6
 ; GFX1164GISEL-NEXT:    s_xor_b64 s[2:3], exec, s[2:3]
-; GFX1164GISEL-NEXT:    s_cbranch_execz .LBB5_3
+; GFX1164GISEL-NEXT:    s_cbranch_execz .LBB6_3
 ; GFX1164GISEL-NEXT:  ; %bb.1: ; %else
 ; GFX1164GISEL-NEXT:    s_mov_b32 s0, 0
 ; GFX1164GISEL-NEXT:    s_mov_b32 s1, 0x7ff80000
 ; GFX1164GISEL-NEXT:    s_mov_b64 s[4:5], exec
-; GFX1164GISEL-NEXT:  .LBB5_2: ; =>This Inner Loop Header: Depth=1
+; GFX1164GISEL-NEXT:  .LBB6_2: ; =>This Inner Loop Header: Depth=1
 ; GFX1164GISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
 ; GFX1164GISEL-NEXT:    s_ctz_i32_b64 s8, s[4:5]
 ; GFX1164GISEL-NEXT:    v_readlane_b32 s6, v2, s8
@@ -1976,15 +2435,15 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX1164GISEL-NEXT:    v_readfirstlane_b32 s1, v5
 ; GFX1164GISEL-NEXT:    ; implicit-def: $vgpr4
 ; GFX1164GISEL-NEXT:    ; implicit-def: $vgpr5
-; GFX1164GISEL-NEXT:    s_cbranch_scc1 .LBB5_2
-; GFX1164GISEL-NEXT:  .LBB5_3: ; %Flow
+; GFX1164GISEL-NEXT:    s_cbranch_scc1 .LBB6_2
+; GFX1164GISEL-NEXT:  .LBB6_3: ; %Flow
 ; GFX1164GISEL-NEXT:    s_and_not1_saveexec_b64 s[2:3], s[2:3]
-; GFX1164GISEL-NEXT:    s_cbranch_execz .LBB5_6
+; GFX1164GISEL-NEXT:    s_cbranch_execz .LBB6_6
 ; GFX1164GISEL-NEXT:  ; %bb.4: ; %if
 ; GFX1164GISEL-NEXT:    s_mov_b32 s0, 0
 ; GFX1164GISEL-NEXT:    s_mov_b32 s1, 0x7ff80000
 ; GFX1164GISEL-NEXT:    s_mov_b64 s[4:5], exec
-; GFX1164GISEL-NEXT:  .LBB5_5: ; =>This Inner Loop Header: Depth=1
+; GFX1164GISEL-NEXT:  .LBB6_5: ; =>This Inner Loop Header: Depth=1
 ; GFX1164GISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
 ; GFX1164GISEL-NEXT:    s_ctz_i32_b64 s8, s[4:5]
 ; GFX1164GISEL-NEXT:    v_readlane_b32 s6, v4, s8
@@ -1996,8 +2455,8 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX1164GISEL-NEXT:    v_readfirstlane_b32 s0, v2
 ; GFX1164GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2)
 ; GFX1164GISEL-NEXT:    v_readfirstlane_b32 s1, v3
-; GFX1164GISEL-NEXT:    s_cbranch_scc1 .LBB5_5
-; GFX1164GISEL-NEXT:  .LBB5_6: ; %endif
+; GFX1164GISEL-NEXT:    s_cbranch_scc1 .LBB6_5
+; GFX1164GISEL-NEXT:  .LBB6_6: ; %endif
 ; GFX1164GISEL-NEXT:    s_or_b64 exec, exec, s[2:3]
 ; GFX1164GISEL-NEXT:    v_mov_b32_e32 v3, s1
 ; GFX1164GISEL-NEXT:    v_mov_b32_e32 v2, s0
@@ -2013,12 +2472,12 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX1132DAGISEL-NEXT:    ; implicit-def: $vgpr6_vgpr7
 ; GFX1132DAGISEL-NEXT:    s_and_saveexec_b32 s0, vcc_lo
 ; GFX1132DAGISEL-NEXT:    s_xor_b32 s2, exec_lo, s0
-; GFX1132DAGISEL-NEXT:    s_cbranch_execz .LBB5_4
+; GFX1132DAGISEL-NEXT:    s_cbranch_execz .LBB6_4
 ; GFX1132DAGISEL-NEXT:  ; %bb.1: ; %else
 ; GFX1132DAGISEL-NEXT:    s_mov_b32 s0, 0
 ; GFX1132DAGISEL-NEXT:    s_mov_b32 s1, 0x7ff80000
 ; GFX1132DAGISEL-NEXT:    s_mov_b32 s3, exec_lo
-; GFX1132DAGISEL-NEXT:  .LBB5_2: ; =>This Inner Loop Header: Depth=1
+; GFX1132DAGISEL-NEXT:  .LBB6_2: ; =>This Inner Loop Header: Depth=1
 ; GFX1132DAGISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
 ; GFX1132DAGISEL-NEXT:    s_ctz_i32_b32 s6, s3
 ; GFX1132DAGISEL-NEXT:    v_readlane_b32 s4, v2, s6
@@ -2030,19 +2489,19 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX1132DAGISEL-NEXT:    v_readfirstlane_b32 s0, v4
 ; GFX1132DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2)
 ; GFX1132DAGISEL-NEXT:    v_readfirstlane_b32 s1, v5
-; GFX1132DAGISEL-NEXT:    s_cbranch_scc1 .LBB5_2
+; GFX1132DAGISEL-NEXT:    s_cbranch_scc1 .LBB6_2
 ; GFX1132DAGISEL-NEXT:  ; %bb.3:
 ; GFX1132DAGISEL-NEXT:    v_dual_mov_b32 v7, s1 :: v_dual_mov_b32 v6, s0
 ; GFX1132DAGISEL-NEXT:    ; implicit-def: $vgpr4
 ; GFX1132DAGISEL-NEXT:    ; implicit-def: $vgpr5
-; GFX1132DAGISEL-NEXT:  .LBB5_4: ; %Flow
+; GFX1132DAGISEL-NEXT:  .LBB6_4: ; %Flow
 ; GFX1132DAGISEL-NEXT:    s_and_not1_saveexec_b32 s2, s2
-; GFX1132DAGISEL-NEXT:    s_cbranch_execz .LBB5_8
+; GFX1132DAGISEL-NEXT:    s_cbranch_execz .LBB6_8
 ; GFX1132DAGISEL-NEXT:  ; %bb.5: ; %if
 ; GFX1132DAGISEL-NEXT:    s_mov_b32 s0, 0
 ; GFX1132DAGISEL-NEXT:    s_mov_b32 s1, 0x7ff80000
 ; GFX1132DAGISEL-NEXT:    s_mov_b32 s3, exec_lo
-; GFX1132DAGISEL-NEXT:  .LBB5_6: ; =>This Inner Loop Header: Depth=1
+; GFX1132DAGISEL-NEXT:  .LBB6_6: ; =>This Inner Loop Header: Depth=1
 ; GFX1132DAGISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
 ; GFX1132DAGISEL-NEXT:    s_ctz_i32_b32 s6, s3
 ; GFX1132DAGISEL-NEXT:    v_readlane_b32 s4, v4, s6
@@ -2054,10 +2513,10 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX1132DAGISEL-NEXT:    v_readfirstlane_b32 s0, v2
 ; GFX1132DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2)
 ; GFX1132DAGISEL-NEXT:    v_readfirstlane_b32 s1, v3
-; GFX1132DAGISEL-NEXT:    s_cbranch_scc1 .LBB5_6
+; GFX1132DAGISEL-NEXT:    s_cbranch_scc1 .LBB6_6
 ; GFX1132DAGISEL-NEXT:  ; %bb.7:
 ; GFX1132DAGISEL-NEXT:    v_dual_mov_b32 v7, s1 :: v_dual_mov_b32 v6, s0
-; GFX1132DAGISEL-NEXT:  .LBB5_8: ; %endif
+; GFX1132DAGISEL-NEXT:  .LBB6_8: ; %endif
 ; GFX1132DAGISEL-NEXT:    s_or_b32 exec_lo, exec_lo, s2
 ; GFX1132DAGISEL-NEXT:    global_store_b64 v[0:1], v[6:7], off
 ; GFX1132DAGISEL-NEXT:    s_setpc_b64 s[30:31]
@@ -2071,12 +2530,12 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX1132GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX1132GISEL-NEXT:    v_cmpx_le_u32_e32 16, v6
 ; GFX1132GISEL-NEXT:    s_xor_b32 s2, exec_lo, s2
-; GFX1132GISEL-NEXT:    s_cbranch_execz .LBB5_3
+; GFX1132GISEL-NEXT:    s_cbranch_execz .LBB6_3
 ; GFX1132GISEL-NEXT:  ; %bb.1: ; %else
 ; GFX1132GISEL-NEXT:    s_mov_b32 s0, 0
 ; GFX1132GISEL-NEXT:    s_mov_b32 s1, 0x7ff80000
 ; GFX1132GISEL-NEXT:    s_mov_b32 s3, exec_lo
-; GFX1132GISEL-NEXT:  .LBB5_2: ; =>This Inner Loop Header: Depth=1
+; GFX1132GISEL-NEXT:  .LBB6_2: ; =>This Inner Loop Header: Depth=1
 ; GFX1132GISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
 ; GFX1132GISEL-NEXT:    s_ctz_i32_b32 s6, s3
 ; GFX1132GISEL-NEXT:    v_readlane_b32 s4, v2, s6
@@ -2090,15 +2549,15 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX1132GISEL-NEXT:    v_readfirstlane_b32 s1, v5
 ; GFX1132GISEL-NEXT:    ; implicit-def: $vgpr4
 ; GFX1132GISEL-NEXT:    ; implicit-def: $vgpr5
-; GFX1132GISEL-NEXT:    s_cbranch_scc1 .LBB5_2
-; GFX1132GISEL-NEXT:  .LBB5_3: ; %Flow
+; GFX1132GISEL-NEXT:    s_cbranch_scc1 .LBB6_2
+; GFX1132GISEL-NEXT:  .LBB6_3: ; %Flow
 ; GFX1132GISEL-NEXT:    s_and_not1_saveexec_b32 s2, s2
-; GFX1132GISEL-NEXT:    s_cbranch_execz .LBB5_6
+; GFX1132GISEL-NEXT:    s_cbranch_execz .LBB6_6
 ; GFX1132GISEL-NEXT:  ; %bb.4: ; %if
 ; GFX1132GISEL-NEXT:    s_mov_b32 s0, 0
 ; GFX1132GISEL-NEXT:    s_mov_b32 s1, 0x7ff80000
 ; GFX1132GISEL-NEXT:    s_mov_b32 s3, exec_lo
-; GFX1132GISEL-NEXT:  .LBB5_5: ; =>This Inner Loop Header: Depth=1
+; GFX1132GISEL-NEXT:  .LBB6_5: ; =>This Inner Loop Header: Depth=1
 ; GFX1132GISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
 ; GFX1132GISEL-NEXT:    s_ctz_i32_b32 s6, s3
 ; GFX1132GISEL-NEXT:    v_readlane_b32 s4, v4, s6
@@ -2110,8 +2569,8 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX1132GISEL-NEXT:    v_readfirstlane_b32 s0, v2
 ; GFX1132GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2)
 ; GFX1132GISEL-NEXT:    v_readfirstlane_b32 s1, v3
-; GFX1132GISEL-NEXT:    s_cbranch_scc1 .LBB5_5
-; GFX1132GISEL-NEXT:  .LBB5_6: ; %endif
+; GFX1132GISEL-NEXT:    s_cbranch_scc1 .LBB6_5
+; GFX1132GISEL-NEXT:  .LBB6_6: ; %endif
 ; GFX1132GISEL-NEXT:    s_or_b32 exec_lo, exec_lo, s2
 ; GFX1132GISEL-NEXT:    v_dual_mov_b32 v3, s1 :: v_dual_mov_b32 v2, s0
 ; GFX1132GISEL-NEXT:    global_store_b64 v[0:1], v[2:3], off
@@ -2131,12 +2590,12 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX12DAGISEL-NEXT:    s_and_saveexec_b32 s0, vcc_lo
 ; GFX12DAGISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
 ; GFX12DAGISEL-NEXT:    s_xor_b32 s2, exec_lo, s0
-; GFX12DAGISEL-NEXT:    s_cbranch_execz .LBB5_4
+; GFX12DAGISEL-NEXT:    s_cbranch_execz .LBB6_4
 ; GFX12DAGISEL-NEXT:  ; %bb.1: ; %else
 ; GFX12DAGISEL-NEXT:    s_mov_b32 s0, 0
 ; GFX12DAGISEL-NEXT:    s_mov_b32 s1, 0x7ff80000
 ; GFX12DAGISEL-NEXT:    s_mov_b32 s3, exec_lo
-; GFX12DAGISEL-NEXT:  .LBB5_2: ; =>This Inner Loop Header: Depth=1
+; GFX12DAGISEL-NEXT:  .LBB6_2: ; =>This Inner Loop Header: Depth=1
 ; GFX12DAGISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
 ; GFX12DAGISEL-NEXT:    s_ctz_i32_b32 s6, s3
 ; GFX12DAGISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
@@ -2149,21 +2608,21 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX12DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_2)
 ; GFX12DAGISEL-NEXT:    v_readfirstlane_b32 s0, v4
 ; GFX12DAGISEL-NEXT:    v_readfirstlane_b32 s1, v5
-; GFX12DAGISEL-NEXT:    s_cbranch_scc1 .LBB5_2
+; GFX12DAGISEL-NEXT:    s_cbranch_scc1 .LBB6_2
 ; GFX12DAGISEL-NEXT:  ; %bb.3:
 ; GFX12DAGISEL-NEXT:    s_wait_alu depctr_va_sdst(0)
 ; GFX12DAGISEL-NEXT:    v_dual_mov_b32 v7, s1 :: v_dual_mov_b32 v6, s0
 ; GFX12DAGISEL-NEXT:    ; implicit-def: $vgpr4
 ; GFX12DAGISEL-NEXT:    ; implicit-def: $vgpr5
-; GFX12DAGISEL-NEXT:  .LBB5_4: ; %Flow
+; GFX12DAGISEL-NEXT:  .LBB6_4: ; %Flow
 ; GFX12DAGISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
 ; GFX12DAGISEL-NEXT:    s_and_not1_saveexec_b32 s2, s2
-; GFX12DAGISEL-NEXT:    s_cbranch_execz .LBB5_8
+; GFX12DAGISEL-NEXT:    s_cbranch_execz .LBB6_8
 ; GFX12DAGISEL-NEXT:  ; %bb.5: ; %if
 ; GFX12DAGISEL-NEXT:    s_mov_b32 s0, 0
 ; GFX12DAGISEL-NEXT:    s_mov_b32 s1, 0x7ff80000
 ; GFX12DAGISEL-NEXT:    s_mov_b32 s3, exec_lo
-; GFX12DAGISEL-NEXT:  .LBB5_6: ; =>This Inner Loop Header: Depth=1
+; GFX12DAGISEL-NEXT:  .LBB6_6: ; =>This Inner Loop Header: Depth=1
 ; GFX12DAGISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
 ; GFX12DAGISEL-NEXT:    s_ctz_i32_b32 s6, s3
 ; GFX12DAGISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
@@ -2176,11 +2635,11 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX12DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_2)
 ; GFX12DAGISEL-NEXT:    v_readfirstlane_b32 s0, v2
 ; GFX12DAGISEL-NEXT:    v_readfirstlane_b32 s1, v3
-; GFX12DAGISEL-NEXT:    s_cbranch_scc1 .LBB5_6
+; GFX12DAGISEL-NEXT:    s_cbranch_scc1 .LBB6_6
 ; GFX12DAGISEL-NEXT:  ; %bb.7:
 ; GFX12DAGISEL-NEXT:    s_wait_alu depctr_va_sdst(0)
 ; GFX12DAGISEL-NEXT:    v_dual_mov_b32 v7, s1 :: v_dual_mov_b32 v6, s0
-; GFX12DAGISEL-NEXT:  .LBB5_8: ; %endif
+; GFX12DAGISEL-NEXT:  .LBB6_8: ; %endif
 ; GFX12DAGISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
 ; GFX12DAGISEL-NEXT:    s_or_b32 exec_lo, exec_lo, s2
 ; GFX12DAGISEL-NEXT:    global_store_b64 v[0:1], v[6:7], off

--- a/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.reduce.fmin.ll
+++ b/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.reduce.fmin.ll
@@ -399,6 +399,465 @@ entry:
   ret void
 }
 
+define void @divergent_value_float_dpp(ptr addrspace(1) %out, float %in) {
+; GFX8DAGISEL-LABEL: divergent_value_float_dpp:
+; GFX8DAGISEL:       ; %bb.0: ; %entry
+; GFX8DAGISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX8DAGISEL-NEXT:    s_xor_saveexec_b64 s[4:5], -1
+; GFX8DAGISEL-NEXT:    buffer_store_dword v3, off, s[0:3], s32 ; 4-byte Folded Spill
+; GFX8DAGISEL-NEXT:    s_mov_b64 exec, s[4:5]
+; GFX8DAGISEL-NEXT:    s_or_saveexec_b64 s[4:5], -1
+; GFX8DAGISEL-NEXT:    v_mov_b32_e32 v3, 0x7fc00000
+; GFX8DAGISEL-NEXT:    v_cndmask_b32_e64 v3, v3, v2, s[4:5]
+; GFX8DAGISEL-NEXT:    s_nop 1
+; GFX8DAGISEL-NEXT:    v_min_f32_dpp v3, v3, v3 row_shr:1 row_mask:0xf bank_mask:0xf
+; GFX8DAGISEL-NEXT:    s_nop 1
+; GFX8DAGISEL-NEXT:    v_min_f32_dpp v3, v3, v3 row_shr:2 row_mask:0xf bank_mask:0xf
+; GFX8DAGISEL-NEXT:    s_nop 1
+; GFX8DAGISEL-NEXT:    v_min_f32_dpp v3, v3, v3 row_shr:4 row_mask:0xf bank_mask:0xf
+; GFX8DAGISEL-NEXT:    s_nop 1
+; GFX8DAGISEL-NEXT:    v_min_f32_dpp v3, v3, v3 row_shr:8 row_mask:0xf bank_mask:0xf
+; GFX8DAGISEL-NEXT:    s_nop 1
+; GFX8DAGISEL-NEXT:    v_min_f32_dpp v3, v3, v3 row_bcast:15 row_mask:0xf bank_mask:0xf
+; GFX8DAGISEL-NEXT:    s_nop 1
+; GFX8DAGISEL-NEXT:    v_min_f32_dpp v3, v3, v3 row_bcast:31 row_mask:0xf bank_mask:0xf
+; GFX8DAGISEL-NEXT:    v_readlane_b32 s6, v3, 63
+; GFX8DAGISEL-NEXT:    s_mov_b64 exec, s[4:5]
+; GFX8DAGISEL-NEXT:    v_mov_b32_e32 v2, s6
+; GFX8DAGISEL-NEXT:    flat_store_dword v[0:1], v2
+; GFX8DAGISEL-NEXT:    s_xor_saveexec_b64 s[4:5], -1
+; GFX8DAGISEL-NEXT:    buffer_load_dword v3, off, s[0:3], s32 ; 4-byte Folded Reload
+; GFX8DAGISEL-NEXT:    s_mov_b64 exec, s[4:5]
+; GFX8DAGISEL-NEXT:    s_waitcnt vmcnt(0)
+; GFX8DAGISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX8GISEL-LABEL: divergent_value_float_dpp:
+; GFX8GISEL:       ; %bb.0: ; %entry
+; GFX8GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX8GISEL-NEXT:    s_xor_saveexec_b64 s[4:5], -1
+; GFX8GISEL-NEXT:    buffer_store_dword v3, off, s[0:3], s32 ; 4-byte Folded Spill
+; GFX8GISEL-NEXT:    s_mov_b64 exec, s[4:5]
+; GFX8GISEL-NEXT:    s_or_saveexec_b64 s[4:5], -1
+; GFX8GISEL-NEXT:    v_mov_b32_e32 v3, 0x7fc00000
+; GFX8GISEL-NEXT:    v_cndmask_b32_e64 v3, v3, v2, s[4:5]
+; GFX8GISEL-NEXT:    s_nop 1
+; GFX8GISEL-NEXT:    v_min_f32_dpp v3, v3, v3 row_shr:1 row_mask:0xf bank_mask:0xf
+; GFX8GISEL-NEXT:    s_nop 1
+; GFX8GISEL-NEXT:    v_min_f32_dpp v3, v3, v3 row_shr:2 row_mask:0xf bank_mask:0xf
+; GFX8GISEL-NEXT:    s_nop 1
+; GFX8GISEL-NEXT:    v_min_f32_dpp v3, v3, v3 row_shr:4 row_mask:0xf bank_mask:0xf
+; GFX8GISEL-NEXT:    s_nop 1
+; GFX8GISEL-NEXT:    v_min_f32_dpp v3, v3, v3 row_shr:8 row_mask:0xf bank_mask:0xf
+; GFX8GISEL-NEXT:    s_nop 1
+; GFX8GISEL-NEXT:    v_min_f32_dpp v3, v3, v3 row_bcast:15 row_mask:0xf bank_mask:0xf
+; GFX8GISEL-NEXT:    s_nop 1
+; GFX8GISEL-NEXT:    v_min_f32_dpp v3, v3, v3 row_bcast:31 row_mask:0xf bank_mask:0xf
+; GFX8GISEL-NEXT:    v_readlane_b32 s6, v3, 63
+; GFX8GISEL-NEXT:    s_mov_b64 exec, s[4:5]
+; GFX8GISEL-NEXT:    v_mov_b32_e32 v2, s6
+; GFX8GISEL-NEXT:    flat_store_dword v[0:1], v2
+; GFX8GISEL-NEXT:    s_xor_saveexec_b64 s[4:5], -1
+; GFX8GISEL-NEXT:    buffer_load_dword v3, off, s[0:3], s32 ; 4-byte Folded Reload
+; GFX8GISEL-NEXT:    s_mov_b64 exec, s[4:5]
+; GFX8GISEL-NEXT:    s_waitcnt vmcnt(0)
+; GFX8GISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX9DAGISEL-LABEL: divergent_value_float_dpp:
+; GFX9DAGISEL:       ; %bb.0: ; %entry
+; GFX9DAGISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9DAGISEL-NEXT:    s_xor_saveexec_b64 s[4:5], -1
+; GFX9DAGISEL-NEXT:    buffer_store_dword v3, off, s[0:3], s32 ; 4-byte Folded Spill
+; GFX9DAGISEL-NEXT:    s_mov_b64 exec, s[4:5]
+; GFX9DAGISEL-NEXT:    s_or_saveexec_b64 s[4:5], -1
+; GFX9DAGISEL-NEXT:    v_mov_b32_e32 v3, 0x7fc00000
+; GFX9DAGISEL-NEXT:    v_cndmask_b32_e64 v3, v3, v2, s[4:5]
+; GFX9DAGISEL-NEXT:    s_nop 1
+; GFX9DAGISEL-NEXT:    v_min_f32_dpp v3, v3, v3 row_shr:1 row_mask:0xf bank_mask:0xf
+; GFX9DAGISEL-NEXT:    s_nop 1
+; GFX9DAGISEL-NEXT:    v_min_f32_dpp v3, v3, v3 row_shr:2 row_mask:0xf bank_mask:0xf
+; GFX9DAGISEL-NEXT:    s_nop 1
+; GFX9DAGISEL-NEXT:    v_min_f32_dpp v3, v3, v3 row_shr:4 row_mask:0xf bank_mask:0xf
+; GFX9DAGISEL-NEXT:    s_nop 1
+; GFX9DAGISEL-NEXT:    v_min_f32_dpp v3, v3, v3 row_shr:8 row_mask:0xf bank_mask:0xf
+; GFX9DAGISEL-NEXT:    s_nop 1
+; GFX9DAGISEL-NEXT:    v_min_f32_dpp v3, v3, v3 row_bcast:15 row_mask:0xf bank_mask:0xf
+; GFX9DAGISEL-NEXT:    s_nop 1
+; GFX9DAGISEL-NEXT:    v_min_f32_dpp v3, v3, v3 row_bcast:31 row_mask:0xf bank_mask:0xf
+; GFX9DAGISEL-NEXT:    v_readlane_b32 s6, v3, 63
+; GFX9DAGISEL-NEXT:    s_mov_b64 exec, s[4:5]
+; GFX9DAGISEL-NEXT:    v_mov_b32_e32 v2, s6
+; GFX9DAGISEL-NEXT:    global_store_dword v[0:1], v2, off
+; GFX9DAGISEL-NEXT:    s_xor_saveexec_b64 s[4:5], -1
+; GFX9DAGISEL-NEXT:    buffer_load_dword v3, off, s[0:3], s32 ; 4-byte Folded Reload
+; GFX9DAGISEL-NEXT:    s_mov_b64 exec, s[4:5]
+; GFX9DAGISEL-NEXT:    s_waitcnt vmcnt(0)
+; GFX9DAGISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX9GISEL-LABEL: divergent_value_float_dpp:
+; GFX9GISEL:       ; %bb.0: ; %entry
+; GFX9GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9GISEL-NEXT:    s_xor_saveexec_b64 s[4:5], -1
+; GFX9GISEL-NEXT:    buffer_store_dword v3, off, s[0:3], s32 ; 4-byte Folded Spill
+; GFX9GISEL-NEXT:    s_mov_b64 exec, s[4:5]
+; GFX9GISEL-NEXT:    s_or_saveexec_b64 s[4:5], -1
+; GFX9GISEL-NEXT:    v_mov_b32_e32 v3, 0x7fc00000
+; GFX9GISEL-NEXT:    v_cndmask_b32_e64 v3, v3, v2, s[4:5]
+; GFX9GISEL-NEXT:    s_nop 1
+; GFX9GISEL-NEXT:    v_min_f32_dpp v3, v3, v3 row_shr:1 row_mask:0xf bank_mask:0xf
+; GFX9GISEL-NEXT:    s_nop 1
+; GFX9GISEL-NEXT:    v_min_f32_dpp v3, v3, v3 row_shr:2 row_mask:0xf bank_mask:0xf
+; GFX9GISEL-NEXT:    s_nop 1
+; GFX9GISEL-NEXT:    v_min_f32_dpp v3, v3, v3 row_shr:4 row_mask:0xf bank_mask:0xf
+; GFX9GISEL-NEXT:    s_nop 1
+; GFX9GISEL-NEXT:    v_min_f32_dpp v3, v3, v3 row_shr:8 row_mask:0xf bank_mask:0xf
+; GFX9GISEL-NEXT:    s_nop 1
+; GFX9GISEL-NEXT:    v_min_f32_dpp v3, v3, v3 row_bcast:15 row_mask:0xf bank_mask:0xf
+; GFX9GISEL-NEXT:    s_nop 1
+; GFX9GISEL-NEXT:    v_min_f32_dpp v3, v3, v3 row_bcast:31 row_mask:0xf bank_mask:0xf
+; GFX9GISEL-NEXT:    v_readlane_b32 s6, v3, 63
+; GFX9GISEL-NEXT:    s_mov_b64 exec, s[4:5]
+; GFX9GISEL-NEXT:    v_mov_b32_e32 v2, s6
+; GFX9GISEL-NEXT:    global_store_dword v[0:1], v2, off
+; GFX9GISEL-NEXT:    s_xor_saveexec_b64 s[4:5], -1
+; GFX9GISEL-NEXT:    buffer_load_dword v3, off, s[0:3], s32 ; 4-byte Folded Reload
+; GFX9GISEL-NEXT:    s_mov_b64 exec, s[4:5]
+; GFX9GISEL-NEXT:    s_waitcnt vmcnt(0)
+; GFX9GISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX1064DAGISEL-LABEL: divergent_value_float_dpp:
+; GFX1064DAGISEL:       ; %bb.0: ; %entry
+; GFX1064DAGISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX1064DAGISEL-NEXT:    s_xor_saveexec_b64 s[4:5], -1
+; GFX1064DAGISEL-NEXT:    buffer_store_dword v3, off, s[0:3], s32 ; 4-byte Folded Spill
+; GFX1064DAGISEL-NEXT:    buffer_store_dword v4, off, s[0:3], s32 offset:4 ; 4-byte Folded Spill
+; GFX1064DAGISEL-NEXT:    buffer_store_dword v5, off, s[0:3], s32 offset:8 ; 4-byte Folded Spill
+; GFX1064DAGISEL-NEXT:    s_waitcnt_depctr depctr_vm_vsrc(0)
+; GFX1064DAGISEL-NEXT:    s_mov_b64 exec, s[4:5]
+; GFX1064DAGISEL-NEXT:    s_or_saveexec_b64 s[4:5], -1
+; GFX1064DAGISEL-NEXT:    v_cndmask_b32_e64 v3, 0x7fc00000, v2, s[4:5]
+; GFX1064DAGISEL-NEXT:    v_mbcnt_lo_u32_b32 v5, -1, 0
+; GFX1064DAGISEL-NEXT:    v_min_f32_dpp v3, v3, v3 row_shr:1 row_mask:0xf bank_mask:0xf
+; GFX1064DAGISEL-NEXT:    v_mbcnt_hi_u32_b32 v5, -1, v5
+; GFX1064DAGISEL-NEXT:    v_min_f32_dpp v3, v3, v3 row_shr:2 row_mask:0xf bank_mask:0xf
+; GFX1064DAGISEL-NEXT:    v_add_nc_u32_e32 v5, 32, v5
+; GFX1064DAGISEL-NEXT:    v_min_f32_dpp v3, v3, v3 row_shr:4 row_mask:0xf bank_mask:0xf
+; GFX1064DAGISEL-NEXT:    v_mul_lo_u32 v5, 4, v5
+; GFX1064DAGISEL-NEXT:    v_min_f32_dpp v3, v3, v3 row_shr:8 row_mask:0xf bank_mask:0xf
+; GFX1064DAGISEL-NEXT:    ds_swizzle_b32 v4, v3 offset:swizzle(BROADCAST,32,15)
+; GFX1064DAGISEL-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX1064DAGISEL-NEXT:    v_min_f32_e32 v3, v3, v4
+; GFX1064DAGISEL-NEXT:    ds_permute_b32 v4, v5, v3
+; GFX1064DAGISEL-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX1064DAGISEL-NEXT:    v_min_f32_e32 v3, v3, v4
+; GFX1064DAGISEL-NEXT:    v_readlane_b32 s6, v3, 63
+; GFX1064DAGISEL-NEXT:    s_mov_b64 exec, s[4:5]
+; GFX1064DAGISEL-NEXT:    v_mov_b32_e32 v2, s6
+; GFX1064DAGISEL-NEXT:    global_store_dword v[0:1], v2, off
+; GFX1064DAGISEL-NEXT:    s_xor_saveexec_b64 s[4:5], -1
+; GFX1064DAGISEL-NEXT:    s_clause 0x2 ; 12-byte Folded Reload
+; GFX1064DAGISEL-NEXT:    buffer_load_dword v3, off, s[0:3], s32
+; GFX1064DAGISEL-NEXT:    buffer_load_dword v4, off, s[0:3], s32 offset:4
+; GFX1064DAGISEL-NEXT:    buffer_load_dword v5, off, s[0:3], s32 offset:8
+; GFX1064DAGISEL-NEXT:    s_waitcnt_depctr depctr_vm_vsrc(0)
+; GFX1064DAGISEL-NEXT:    s_mov_b64 exec, s[4:5]
+; GFX1064DAGISEL-NEXT:    s_waitcnt vmcnt(0)
+; GFX1064DAGISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX1064GISEL-LABEL: divergent_value_float_dpp:
+; GFX1064GISEL:       ; %bb.0: ; %entry
+; GFX1064GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX1064GISEL-NEXT:    s_xor_saveexec_b64 s[4:5], -1
+; GFX1064GISEL-NEXT:    buffer_store_dword v3, off, s[0:3], s32 ; 4-byte Folded Spill
+; GFX1064GISEL-NEXT:    buffer_store_dword v4, off, s[0:3], s32 offset:4 ; 4-byte Folded Spill
+; GFX1064GISEL-NEXT:    buffer_store_dword v5, off, s[0:3], s32 offset:8 ; 4-byte Folded Spill
+; GFX1064GISEL-NEXT:    s_waitcnt_depctr depctr_vm_vsrc(0)
+; GFX1064GISEL-NEXT:    s_mov_b64 exec, s[4:5]
+; GFX1064GISEL-NEXT:    s_or_saveexec_b64 s[4:5], -1
+; GFX1064GISEL-NEXT:    v_cndmask_b32_e64 v3, 0x7fc00000, v2, s[4:5]
+; GFX1064GISEL-NEXT:    v_mbcnt_lo_u32_b32 v5, -1, 0
+; GFX1064GISEL-NEXT:    v_min_f32_dpp v3, v3, v3 row_shr:1 row_mask:0xf bank_mask:0xf
+; GFX1064GISEL-NEXT:    v_mbcnt_hi_u32_b32 v5, -1, v5
+; GFX1064GISEL-NEXT:    v_min_f32_dpp v3, v3, v3 row_shr:2 row_mask:0xf bank_mask:0xf
+; GFX1064GISEL-NEXT:    v_add_nc_u32_e32 v5, 32, v5
+; GFX1064GISEL-NEXT:    v_min_f32_dpp v3, v3, v3 row_shr:4 row_mask:0xf bank_mask:0xf
+; GFX1064GISEL-NEXT:    v_mul_lo_u32 v5, 4, v5
+; GFX1064GISEL-NEXT:    v_min_f32_dpp v3, v3, v3 row_shr:8 row_mask:0xf bank_mask:0xf
+; GFX1064GISEL-NEXT:    ds_swizzle_b32 v4, v3 offset:swizzle(BROADCAST,32,15)
+; GFX1064GISEL-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX1064GISEL-NEXT:    v_min_f32_e32 v3, v3, v4
+; GFX1064GISEL-NEXT:    ds_permute_b32 v4, v5, v3
+; GFX1064GISEL-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX1064GISEL-NEXT:    v_min_f32_e32 v3, v3, v4
+; GFX1064GISEL-NEXT:    v_readlane_b32 s6, v3, 63
+; GFX1064GISEL-NEXT:    s_mov_b64 exec, s[4:5]
+; GFX1064GISEL-NEXT:    v_mov_b32_e32 v2, s6
+; GFX1064GISEL-NEXT:    global_store_dword v[0:1], v2, off
+; GFX1064GISEL-NEXT:    s_xor_saveexec_b64 s[4:5], -1
+; GFX1064GISEL-NEXT:    s_clause 0x2 ; 12-byte Folded Reload
+; GFX1064GISEL-NEXT:    buffer_load_dword v3, off, s[0:3], s32
+; GFX1064GISEL-NEXT:    buffer_load_dword v4, off, s[0:3], s32 offset:4
+; GFX1064GISEL-NEXT:    buffer_load_dword v5, off, s[0:3], s32 offset:8
+; GFX1064GISEL-NEXT:    s_waitcnt_depctr depctr_vm_vsrc(0)
+; GFX1064GISEL-NEXT:    s_mov_b64 exec, s[4:5]
+; GFX1064GISEL-NEXT:    s_waitcnt vmcnt(0)
+; GFX1064GISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX1032DAGISEL-LABEL: divergent_value_float_dpp:
+; GFX1032DAGISEL:       ; %bb.0: ; %entry
+; GFX1032DAGISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX1032DAGISEL-NEXT:    s_xor_saveexec_b32 s4, -1
+; GFX1032DAGISEL-NEXT:    buffer_store_dword v3, off, s[0:3], s32 ; 4-byte Folded Spill
+; GFX1032DAGISEL-NEXT:    buffer_store_dword v4, off, s[0:3], s32 offset:4 ; 4-byte Folded Spill
+; GFX1032DAGISEL-NEXT:    s_waitcnt_depctr depctr_vm_vsrc(0)
+; GFX1032DAGISEL-NEXT:    s_mov_b32 exec_lo, s4
+; GFX1032DAGISEL-NEXT:    s_or_saveexec_b32 s4, -1
+; GFX1032DAGISEL-NEXT:    v_cndmask_b32_e64 v3, 0x7fc00000, v2, s4
+; GFX1032DAGISEL-NEXT:    v_min_f32_dpp v3, v3, v3 row_shr:1 row_mask:0xf bank_mask:0xf
+; GFX1032DAGISEL-NEXT:    v_min_f32_dpp v3, v3, v3 row_shr:2 row_mask:0xf bank_mask:0xf
+; GFX1032DAGISEL-NEXT:    v_min_f32_dpp v3, v3, v3 row_shr:4 row_mask:0xf bank_mask:0xf
+; GFX1032DAGISEL-NEXT:    v_min_f32_dpp v3, v3, v3 row_shr:8 row_mask:0xf bank_mask:0xf
+; GFX1032DAGISEL-NEXT:    ds_swizzle_b32 v4, v3 offset:swizzle(BROADCAST,32,15)
+; GFX1032DAGISEL-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX1032DAGISEL-NEXT:    v_min_f32_e32 v3, v3, v4
+; GFX1032DAGISEL-NEXT:    v_readlane_b32 s5, v3, 31
+; GFX1032DAGISEL-NEXT:    s_mov_b32 exec_lo, s4
+; GFX1032DAGISEL-NEXT:    v_mov_b32_e32 v2, s5
+; GFX1032DAGISEL-NEXT:    global_store_dword v[0:1], v2, off
+; GFX1032DAGISEL-NEXT:    s_xor_saveexec_b32 s4, -1
+; GFX1032DAGISEL-NEXT:    s_clause 0x1 ; 8-byte Folded Reload
+; GFX1032DAGISEL-NEXT:    buffer_load_dword v3, off, s[0:3], s32
+; GFX1032DAGISEL-NEXT:    buffer_load_dword v4, off, s[0:3], s32 offset:4
+; GFX1032DAGISEL-NEXT:    s_waitcnt_depctr depctr_vm_vsrc(0)
+; GFX1032DAGISEL-NEXT:    s_mov_b32 exec_lo, s4
+; GFX1032DAGISEL-NEXT:    s_waitcnt vmcnt(0)
+; GFX1032DAGISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX1032GISEL-LABEL: divergent_value_float_dpp:
+; GFX1032GISEL:       ; %bb.0: ; %entry
+; GFX1032GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX1032GISEL-NEXT:    s_xor_saveexec_b32 s4, -1
+; GFX1032GISEL-NEXT:    buffer_store_dword v3, off, s[0:3], s32 ; 4-byte Folded Spill
+; GFX1032GISEL-NEXT:    buffer_store_dword v4, off, s[0:3], s32 offset:4 ; 4-byte Folded Spill
+; GFX1032GISEL-NEXT:    s_waitcnt_depctr depctr_vm_vsrc(0)
+; GFX1032GISEL-NEXT:    s_mov_b32 exec_lo, s4
+; GFX1032GISEL-NEXT:    s_or_saveexec_b32 s4, -1
+; GFX1032GISEL-NEXT:    v_cndmask_b32_e64 v3, 0x7fc00000, v2, s4
+; GFX1032GISEL-NEXT:    v_min_f32_dpp v3, v3, v3 row_shr:1 row_mask:0xf bank_mask:0xf
+; GFX1032GISEL-NEXT:    v_min_f32_dpp v3, v3, v3 row_shr:2 row_mask:0xf bank_mask:0xf
+; GFX1032GISEL-NEXT:    v_min_f32_dpp v3, v3, v3 row_shr:4 row_mask:0xf bank_mask:0xf
+; GFX1032GISEL-NEXT:    v_min_f32_dpp v3, v3, v3 row_shr:8 row_mask:0xf bank_mask:0xf
+; GFX1032GISEL-NEXT:    ds_swizzle_b32 v4, v3 offset:swizzle(BROADCAST,32,15)
+; GFX1032GISEL-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX1032GISEL-NEXT:    v_min_f32_e32 v3, v3, v4
+; GFX1032GISEL-NEXT:    v_readlane_b32 s5, v3, 31
+; GFX1032GISEL-NEXT:    s_mov_b32 exec_lo, s4
+; GFX1032GISEL-NEXT:    v_mov_b32_e32 v2, s5
+; GFX1032GISEL-NEXT:    global_store_dword v[0:1], v2, off
+; GFX1032GISEL-NEXT:    s_xor_saveexec_b32 s4, -1
+; GFX1032GISEL-NEXT:    s_clause 0x1 ; 8-byte Folded Reload
+; GFX1032GISEL-NEXT:    buffer_load_dword v3, off, s[0:3], s32
+; GFX1032GISEL-NEXT:    buffer_load_dword v4, off, s[0:3], s32 offset:4
+; GFX1032GISEL-NEXT:    s_waitcnt_depctr depctr_vm_vsrc(0)
+; GFX1032GISEL-NEXT:    s_mov_b32 exec_lo, s4
+; GFX1032GISEL-NEXT:    s_waitcnt vmcnt(0)
+; GFX1032GISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX1164DAGISEL-LABEL: divergent_value_float_dpp:
+; GFX1164DAGISEL:       ; %bb.0: ; %entry
+; GFX1164DAGISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX1164DAGISEL-NEXT:    s_xor_saveexec_b64 s[0:1], -1
+; GFX1164DAGISEL-NEXT:    s_clause 0x2 ; 12-byte Folded Spill
+; GFX1164DAGISEL-NEXT:    scratch_store_b32 off, v3, s32
+; GFX1164DAGISEL-NEXT:    scratch_store_b32 off, v4, s32 offset:4
+; GFX1164DAGISEL-NEXT:    scratch_store_b32 off, v5, s32 offset:8
+; GFX1164DAGISEL-NEXT:    s_mov_b64 exec, s[0:1]
+; GFX1164DAGISEL-NEXT:    s_or_saveexec_b64 s[0:1], -1
+; GFX1164DAGISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_1) | instid1(VALU_DEP_2)
+; GFX1164DAGISEL-NEXT:    v_cndmask_b32_e64 v3, 0x7fc00000, v2, s[0:1]
+; GFX1164DAGISEL-NEXT:    v_mbcnt_lo_u32_b32 v5, -1, 0
+; GFX1164DAGISEL-NEXT:    v_min_f32_dpp v3, v3, v3 row_shr:1 row_mask:0xf bank_mask:0xf
+; GFX1164DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GFX1164DAGISEL-NEXT:    v_mbcnt_hi_u32_b32 v5, -1, v5
+; GFX1164DAGISEL-NEXT:    v_min_f32_dpp v3, v3, v3 row_shr:2 row_mask:0xf bank_mask:0xf
+; GFX1164DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GFX1164DAGISEL-NEXT:    v_add_nc_u32_e32 v5, 32, v5
+; GFX1164DAGISEL-NEXT:    v_min_f32_dpp v3, v3, v3 row_shr:4 row_mask:0xf bank_mask:0xf
+; GFX1164DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GFX1164DAGISEL-NEXT:    v_mul_lo_u32 v5, 4, v5
+; GFX1164DAGISEL-NEXT:    v_min_f32_dpp v3, v3, v3 row_shr:8 row_mask:0xf bank_mask:0xf
+; GFX1164DAGISEL-NEXT:    ds_swizzle_b32 v4, v3 offset:swizzle(BROADCAST,32,15)
+; GFX1164DAGISEL-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX1164DAGISEL-NEXT:    v_min_f32_e32 v3, v3, v4
+; GFX1164DAGISEL-NEXT:    ds_permute_b32 v4, v5, v3
+; GFX1164DAGISEL-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX1164DAGISEL-NEXT:    v_min_f32_e32 v3, v3, v4
+; GFX1164DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1164DAGISEL-NEXT:    v_readlane_b32 s2, v3, 63
+; GFX1164DAGISEL-NEXT:    s_mov_b64 exec, s[0:1]
+; GFX1164DAGISEL-NEXT:    v_mov_b32_e32 v2, s2
+; GFX1164DAGISEL-NEXT:    global_store_b32 v[0:1], v2, off
+; GFX1164DAGISEL-NEXT:    s_xor_saveexec_b64 s[0:1], -1
+; GFX1164DAGISEL-NEXT:    s_waitcnt_depctr depctr_sa_sdst(0)
+; GFX1164DAGISEL-NEXT:    s_clause 0x2 ; 12-byte Folded Reload
+; GFX1164DAGISEL-NEXT:    scratch_load_b32 v3, off, s32
+; GFX1164DAGISEL-NEXT:    scratch_load_b32 v4, off, s32 offset:4
+; GFX1164DAGISEL-NEXT:    scratch_load_b32 v5, off, s32 offset:8
+; GFX1164DAGISEL-NEXT:    s_mov_b64 exec, s[0:1]
+; GFX1164DAGISEL-NEXT:    s_waitcnt vmcnt(0)
+; GFX1164DAGISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX1164GISEL-LABEL: divergent_value_float_dpp:
+; GFX1164GISEL:       ; %bb.0: ; %entry
+; GFX1164GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX1164GISEL-NEXT:    s_xor_saveexec_b64 s[0:1], -1
+; GFX1164GISEL-NEXT:    s_clause 0x2 ; 12-byte Folded Spill
+; GFX1164GISEL-NEXT:    scratch_store_b32 off, v3, s32
+; GFX1164GISEL-NEXT:    scratch_store_b32 off, v4, s32 offset:4
+; GFX1164GISEL-NEXT:    scratch_store_b32 off, v5, s32 offset:8
+; GFX1164GISEL-NEXT:    s_mov_b64 exec, s[0:1]
+; GFX1164GISEL-NEXT:    s_or_saveexec_b64 s[0:1], -1
+; GFX1164GISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_1) | instid1(VALU_DEP_2)
+; GFX1164GISEL-NEXT:    v_cndmask_b32_e64 v3, 0x7fc00000, v2, s[0:1]
+; GFX1164GISEL-NEXT:    v_mbcnt_lo_u32_b32 v5, -1, 0
+; GFX1164GISEL-NEXT:    v_min_f32_dpp v3, v3, v3 row_shr:1 row_mask:0xf bank_mask:0xf
+; GFX1164GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GFX1164GISEL-NEXT:    v_mbcnt_hi_u32_b32 v5, -1, v5
+; GFX1164GISEL-NEXT:    v_min_f32_dpp v3, v3, v3 row_shr:2 row_mask:0xf bank_mask:0xf
+; GFX1164GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GFX1164GISEL-NEXT:    v_add_nc_u32_e32 v5, 32, v5
+; GFX1164GISEL-NEXT:    v_min_f32_dpp v3, v3, v3 row_shr:4 row_mask:0xf bank_mask:0xf
+; GFX1164GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GFX1164GISEL-NEXT:    v_mul_lo_u32 v5, 4, v5
+; GFX1164GISEL-NEXT:    v_min_f32_dpp v3, v3, v3 row_shr:8 row_mask:0xf bank_mask:0xf
+; GFX1164GISEL-NEXT:    ds_swizzle_b32 v4, v3 offset:swizzle(BROADCAST,32,15)
+; GFX1164GISEL-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX1164GISEL-NEXT:    v_min_f32_e32 v3, v3, v4
+; GFX1164GISEL-NEXT:    ds_permute_b32 v4, v5, v3
+; GFX1164GISEL-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX1164GISEL-NEXT:    v_min_f32_e32 v3, v3, v4
+; GFX1164GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1164GISEL-NEXT:    v_readlane_b32 s2, v3, 63
+; GFX1164GISEL-NEXT:    s_mov_b64 exec, s[0:1]
+; GFX1164GISEL-NEXT:    v_mov_b32_e32 v2, s2
+; GFX1164GISEL-NEXT:    global_store_b32 v[0:1], v2, off
+; GFX1164GISEL-NEXT:    s_xor_saveexec_b64 s[0:1], -1
+; GFX1164GISEL-NEXT:    s_waitcnt_depctr depctr_sa_sdst(0)
+; GFX1164GISEL-NEXT:    s_clause 0x2 ; 12-byte Folded Reload
+; GFX1164GISEL-NEXT:    scratch_load_b32 v3, off, s32
+; GFX1164GISEL-NEXT:    scratch_load_b32 v4, off, s32 offset:4
+; GFX1164GISEL-NEXT:    scratch_load_b32 v5, off, s32 offset:8
+; GFX1164GISEL-NEXT:    s_mov_b64 exec, s[0:1]
+; GFX1164GISEL-NEXT:    s_waitcnt vmcnt(0)
+; GFX1164GISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX1132DAGISEL-LABEL: divergent_value_float_dpp:
+; GFX1132DAGISEL:       ; %bb.0: ; %entry
+; GFX1132DAGISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX1132DAGISEL-NEXT:    s_xor_saveexec_b32 s0, -1
+; GFX1132DAGISEL-NEXT:    s_clause 0x1 ; 8-byte Folded Spill
+; GFX1132DAGISEL-NEXT:    scratch_store_b32 off, v3, s32
+; GFX1132DAGISEL-NEXT:    scratch_store_b32 off, v4, s32 offset:4
+; GFX1132DAGISEL-NEXT:    s_mov_b32 exec_lo, s0
+; GFX1132DAGISEL-NEXT:    s_or_saveexec_b32 s0, -1
+; GFX1132DAGISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1132DAGISEL-NEXT:    v_cndmask_b32_e64 v3, 0x7fc00000, v2, s0
+; GFX1132DAGISEL-NEXT:    v_min_f32_dpp v3, v3, v3 row_shr:1 row_mask:0xf bank_mask:0xf
+; GFX1132DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1132DAGISEL-NEXT:    v_min_f32_dpp v3, v3, v3 row_shr:2 row_mask:0xf bank_mask:0xf
+; GFX1132DAGISEL-NEXT:    v_min_f32_dpp v3, v3, v3 row_shr:4 row_mask:0xf bank_mask:0xf
+; GFX1132DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_3) | instid1(VALU_DEP_1)
+; GFX1132DAGISEL-NEXT:    v_min_f32_dpp v3, v3, v3 row_shr:8 row_mask:0xf bank_mask:0xf
+; GFX1132DAGISEL-NEXT:    ds_swizzle_b32 v4, v3 offset:swizzle(BROADCAST,32,15)
+; GFX1132DAGISEL-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX1132DAGISEL-NEXT:    v_min_f32_e32 v3, v3, v4
+; GFX1132DAGISEL-NEXT:    v_readlane_b32 s1, v3, 31
+; GFX1132DAGISEL-NEXT:    s_mov_b32 exec_lo, s0
+; GFX1132DAGISEL-NEXT:    v_mov_b32_e32 v2, s1
+; GFX1132DAGISEL-NEXT:    global_store_b32 v[0:1], v2, off
+; GFX1132DAGISEL-NEXT:    s_xor_saveexec_b32 s0, -1
+; GFX1132DAGISEL-NEXT:    s_clause 0x1 ; 8-byte Folded Reload
+; GFX1132DAGISEL-NEXT:    scratch_load_b32 v3, off, s32
+; GFX1132DAGISEL-NEXT:    scratch_load_b32 v4, off, s32 offset:4
+; GFX1132DAGISEL-NEXT:    s_mov_b32 exec_lo, s0
+; GFX1132DAGISEL-NEXT:    s_waitcnt vmcnt(0)
+; GFX1132DAGISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX1132GISEL-LABEL: divergent_value_float_dpp:
+; GFX1132GISEL:       ; %bb.0: ; %entry
+; GFX1132GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX1132GISEL-NEXT:    s_xor_saveexec_b32 s0, -1
+; GFX1132GISEL-NEXT:    s_clause 0x1 ; 8-byte Folded Spill
+; GFX1132GISEL-NEXT:    scratch_store_b32 off, v3, s32
+; GFX1132GISEL-NEXT:    scratch_store_b32 off, v4, s32 offset:4
+; GFX1132GISEL-NEXT:    s_mov_b32 exec_lo, s0
+; GFX1132GISEL-NEXT:    s_or_saveexec_b32 s0, -1
+; GFX1132GISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1132GISEL-NEXT:    v_cndmask_b32_e64 v3, 0x7fc00000, v2, s0
+; GFX1132GISEL-NEXT:    v_min_f32_dpp v3, v3, v3 row_shr:1 row_mask:0xf bank_mask:0xf
+; GFX1132GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1132GISEL-NEXT:    v_min_f32_dpp v3, v3, v3 row_shr:2 row_mask:0xf bank_mask:0xf
+; GFX1132GISEL-NEXT:    v_min_f32_dpp v3, v3, v3 row_shr:4 row_mask:0xf bank_mask:0xf
+; GFX1132GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_3) | instid1(VALU_DEP_1)
+; GFX1132GISEL-NEXT:    v_min_f32_dpp v3, v3, v3 row_shr:8 row_mask:0xf bank_mask:0xf
+; GFX1132GISEL-NEXT:    ds_swizzle_b32 v4, v3 offset:swizzle(BROADCAST,32,15)
+; GFX1132GISEL-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX1132GISEL-NEXT:    v_min_f32_e32 v3, v3, v4
+; GFX1132GISEL-NEXT:    v_readlane_b32 s1, v3, 31
+; GFX1132GISEL-NEXT:    s_mov_b32 exec_lo, s0
+; GFX1132GISEL-NEXT:    v_mov_b32_e32 v2, s1
+; GFX1132GISEL-NEXT:    global_store_b32 v[0:1], v2, off
+; GFX1132GISEL-NEXT:    s_xor_saveexec_b32 s0, -1
+; GFX1132GISEL-NEXT:    s_clause 0x1 ; 8-byte Folded Reload
+; GFX1132GISEL-NEXT:    scratch_load_b32 v3, off, s32
+; GFX1132GISEL-NEXT:    scratch_load_b32 v4, off, s32 offset:4
+; GFX1132GISEL-NEXT:    s_mov_b32 exec_lo, s0
+; GFX1132GISEL-NEXT:    s_waitcnt vmcnt(0)
+; GFX1132GISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12DAGISEL-LABEL: divergent_value_float_dpp:
+; GFX12DAGISEL:       ; %bb.0: ; %entry
+; GFX12DAGISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12DAGISEL-NEXT:    s_wait_expcnt 0x0
+; GFX12DAGISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX12DAGISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX12DAGISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX12DAGISEL-NEXT:    s_xor_saveexec_b32 s0, -1
+; GFX12DAGISEL-NEXT:    s_clause 0x1 ; 8-byte Folded Spill
+; GFX12DAGISEL-NEXT:    scratch_store_b32 off, v3, s32
+; GFX12DAGISEL-NEXT:    scratch_store_b32 off, v4, s32 offset:4
+; GFX12DAGISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12DAGISEL-NEXT:    s_mov_b32 exec_lo, s0
+; GFX12DAGISEL-NEXT:    s_or_saveexec_b32 s0, -1
+; GFX12DAGISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12DAGISEL-NEXT:    v_cndmask_b32_e64 v3, 0x7fc00000, v2, s0
+; GFX12DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX12DAGISEL-NEXT:    v_min_num_f32_dpp v3, v3, v3 row_shr:1 row_mask:0xf bank_mask:0xf
+; GFX12DAGISEL-NEXT:    v_min_num_f32_dpp v3, v3, v3 row_shr:2 row_mask:0xf bank_mask:0xf
+; GFX12DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX12DAGISEL-NEXT:    v_min_num_f32_dpp v3, v3, v3 row_shr:4 row_mask:0xf bank_mask:0xf
+; GFX12DAGISEL-NEXT:    v_min_num_f32_dpp v3, v3, v3 row_shr:8 row_mask:0xf bank_mask:0xf
+; GFX12DAGISEL-NEXT:    ds_swizzle_b32 v4, v3 offset:swizzle(BROADCAST,32,15)
+; GFX12DAGISEL-NEXT:    s_wait_dscnt 0x0
+; GFX12DAGISEL-NEXT:    v_min_num_f32_e32 v3, v3, v4
+; GFX12DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX12DAGISEL-NEXT:    v_readlane_b32 s1, v3, 31
+; GFX12DAGISEL-NEXT:    s_mov_b32 exec_lo, s0
+; GFX12DAGISEL-NEXT:    v_mov_b32_e32 v2, s1
+; GFX12DAGISEL-NEXT:    global_store_b32 v[0:1], v2, off
+; GFX12DAGISEL-NEXT:    s_xor_saveexec_b32 s0, -1
+; GFX12DAGISEL-NEXT:    s_clause 0x1 ; 8-byte Folded Reload
+; GFX12DAGISEL-NEXT:    scratch_load_b32 v3, off, s32
+; GFX12DAGISEL-NEXT:    scratch_load_b32 v4, off, s32 offset:4
+; GFX12DAGISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12DAGISEL-NEXT:    s_mov_b32 exec_lo, s0
+; GFX12DAGISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX12DAGISEL-NEXT:    s_setpc_b64 s[30:31]
+entry:
+  %result = call float @llvm.amdgcn.wave.reduce.fmin(float %in, i32 2)
+  store float %result, ptr addrspace(1) %out
+  ret void
+}
+
 define void @divergent_cfg_float(ptr addrspace(1) %out, float %in, float %in2) {
 ; GFX8DAGISEL-LABEL: divergent_cfg_float:
 ; GFX8DAGISEL:       ; %bb.0: ; %entry
@@ -408,11 +867,11 @@ define void @divergent_cfg_float(ptr addrspace(1) %out, float %in, float %in2) {
 ; GFX8DAGISEL-NEXT:    ; implicit-def: $vgpr4
 ; GFX8DAGISEL-NEXT:    s_and_saveexec_b64 s[4:5], vcc
 ; GFX8DAGISEL-NEXT:    s_xor_b64 s[4:5], exec, s[4:5]
-; GFX8DAGISEL-NEXT:    s_cbranch_execz .LBB2_4
+; GFX8DAGISEL-NEXT:    s_cbranch_execz .LBB3_4
 ; GFX8DAGISEL-NEXT:  ; %bb.1: ; %else
 ; GFX8DAGISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX8DAGISEL-NEXT:    s_mov_b32 s8, 0x7fc00000
-; GFX8DAGISEL-NEXT:  .LBB2_2: ; =>This Inner Loop Header: Depth=1
+; GFX8DAGISEL-NEXT:  .LBB3_2: ; =>This Inner Loop Header: Depth=1
 ; GFX8DAGISEL-NEXT:    s_ff1_i32_b64 s9, s[6:7]
 ; GFX8DAGISEL-NEXT:    v_readlane_b32 s10, v2, s9
 ; GFX8DAGISEL-NEXT:    v_mov_b32_e32 v3, s10
@@ -420,17 +879,17 @@ define void @divergent_cfg_float(ptr addrspace(1) %out, float %in, float %in2) {
 ; GFX8DAGISEL-NEXT:    v_min_f32_e32 v3, s8, v3
 ; GFX8DAGISEL-NEXT:    s_cmp_lg_u64 s[6:7], 0
 ; GFX8DAGISEL-NEXT:    v_readfirstlane_b32 s8, v3
-; GFX8DAGISEL-NEXT:    s_cbranch_scc1 .LBB2_2
+; GFX8DAGISEL-NEXT:    s_cbranch_scc1 .LBB3_2
 ; GFX8DAGISEL-NEXT:  ; %bb.3:
 ; GFX8DAGISEL-NEXT:    v_mov_b32_e32 v4, s8
 ; GFX8DAGISEL-NEXT:    ; implicit-def: $vgpr3
-; GFX8DAGISEL-NEXT:  .LBB2_4: ; %Flow
+; GFX8DAGISEL-NEXT:  .LBB3_4: ; %Flow
 ; GFX8DAGISEL-NEXT:    s_andn2_saveexec_b64 s[4:5], s[4:5]
-; GFX8DAGISEL-NEXT:    s_cbranch_execz .LBB2_8
+; GFX8DAGISEL-NEXT:    s_cbranch_execz .LBB3_8
 ; GFX8DAGISEL-NEXT:  ; %bb.5: ; %if
 ; GFX8DAGISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX8DAGISEL-NEXT:    s_mov_b32 s8, 0x7fc00000
-; GFX8DAGISEL-NEXT:  .LBB2_6: ; =>This Inner Loop Header: Depth=1
+; GFX8DAGISEL-NEXT:  .LBB3_6: ; =>This Inner Loop Header: Depth=1
 ; GFX8DAGISEL-NEXT:    s_ff1_i32_b64 s9, s[6:7]
 ; GFX8DAGISEL-NEXT:    v_readlane_b32 s10, v3, s9
 ; GFX8DAGISEL-NEXT:    v_mov_b32_e32 v2, s10
@@ -438,10 +897,10 @@ define void @divergent_cfg_float(ptr addrspace(1) %out, float %in, float %in2) {
 ; GFX8DAGISEL-NEXT:    v_min_f32_e32 v2, s8, v2
 ; GFX8DAGISEL-NEXT:    s_cmp_lg_u64 s[6:7], 0
 ; GFX8DAGISEL-NEXT:    v_readfirstlane_b32 s8, v2
-; GFX8DAGISEL-NEXT:    s_cbranch_scc1 .LBB2_6
+; GFX8DAGISEL-NEXT:    s_cbranch_scc1 .LBB3_6
 ; GFX8DAGISEL-NEXT:  ; %bb.7:
 ; GFX8DAGISEL-NEXT:    v_mov_b32_e32 v4, s8
-; GFX8DAGISEL-NEXT:  .LBB2_8: ; %endif
+; GFX8DAGISEL-NEXT:  .LBB3_8: ; %endif
 ; GFX8DAGISEL-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; GFX8DAGISEL-NEXT:    flat_store_dword v[0:1], v4
 ; GFX8DAGISEL-NEXT:    s_waitcnt vmcnt(0)
@@ -455,12 +914,12 @@ define void @divergent_cfg_float(ptr addrspace(1) %out, float %in, float %in2) {
 ; GFX8GISEL-NEXT:    ; implicit-def: $sgpr8
 ; GFX8GISEL-NEXT:    s_and_saveexec_b64 s[4:5], vcc
 ; GFX8GISEL-NEXT:    s_xor_b64 s[4:5], exec, s[4:5]
-; GFX8GISEL-NEXT:    s_cbranch_execz .LBB2_3
+; GFX8GISEL-NEXT:    s_cbranch_execz .LBB3_3
 ; GFX8GISEL-NEXT:  ; %bb.1: ; %else
 ; GFX8GISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX8GISEL-NEXT:    s_mov_b32 s8, 0x7fc00000
 ; GFX8GISEL-NEXT:    ; implicit-def: $vgpr3
-; GFX8GISEL-NEXT:  .LBB2_2: ; =>This Inner Loop Header: Depth=1
+; GFX8GISEL-NEXT:  .LBB3_2: ; =>This Inner Loop Header: Depth=1
 ; GFX8GISEL-NEXT:    s_ff1_i32_b64 s9, s[6:7]
 ; GFX8GISEL-NEXT:    v_readlane_b32 s10, v2, s9
 ; GFX8GISEL-NEXT:    v_mov_b32_e32 v4, s10
@@ -468,14 +927,14 @@ define void @divergent_cfg_float(ptr addrspace(1) %out, float %in, float %in2) {
 ; GFX8GISEL-NEXT:    v_min_f32_e32 v4, s8, v4
 ; GFX8GISEL-NEXT:    s_cmp_lg_u64 s[6:7], 0
 ; GFX8GISEL-NEXT:    v_readfirstlane_b32 s8, v4
-; GFX8GISEL-NEXT:    s_cbranch_scc1 .LBB2_2
-; GFX8GISEL-NEXT:  .LBB2_3: ; %Flow
+; GFX8GISEL-NEXT:    s_cbranch_scc1 .LBB3_2
+; GFX8GISEL-NEXT:  .LBB3_3: ; %Flow
 ; GFX8GISEL-NEXT:    s_andn2_saveexec_b64 s[4:5], s[4:5]
-; GFX8GISEL-NEXT:    s_cbranch_execz .LBB2_6
+; GFX8GISEL-NEXT:    s_cbranch_execz .LBB3_6
 ; GFX8GISEL-NEXT:  ; %bb.4: ; %if
 ; GFX8GISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX8GISEL-NEXT:    s_mov_b32 s8, 0x7fc00000
-; GFX8GISEL-NEXT:  .LBB2_5: ; =>This Inner Loop Header: Depth=1
+; GFX8GISEL-NEXT:  .LBB3_5: ; =>This Inner Loop Header: Depth=1
 ; GFX8GISEL-NEXT:    s_ff1_i32_b64 s9, s[6:7]
 ; GFX8GISEL-NEXT:    v_readlane_b32 s10, v3, s9
 ; GFX8GISEL-NEXT:    v_mov_b32_e32 v2, s10
@@ -483,8 +942,8 @@ define void @divergent_cfg_float(ptr addrspace(1) %out, float %in, float %in2) {
 ; GFX8GISEL-NEXT:    v_min_f32_e32 v2, s8, v2
 ; GFX8GISEL-NEXT:    s_cmp_lg_u64 s[6:7], 0
 ; GFX8GISEL-NEXT:    v_readfirstlane_b32 s8, v2
-; GFX8GISEL-NEXT:    s_cbranch_scc1 .LBB2_5
-; GFX8GISEL-NEXT:  .LBB2_6: ; %endif
+; GFX8GISEL-NEXT:    s_cbranch_scc1 .LBB3_5
+; GFX8GISEL-NEXT:  .LBB3_6: ; %endif
 ; GFX8GISEL-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; GFX8GISEL-NEXT:    v_mov_b32_e32 v2, s8
 ; GFX8GISEL-NEXT:    flat_store_dword v[0:1], v2
@@ -499,11 +958,11 @@ define void @divergent_cfg_float(ptr addrspace(1) %out, float %in, float %in2) {
 ; GFX9DAGISEL-NEXT:    ; implicit-def: $vgpr4
 ; GFX9DAGISEL-NEXT:    s_and_saveexec_b64 s[4:5], vcc
 ; GFX9DAGISEL-NEXT:    s_xor_b64 s[4:5], exec, s[4:5]
-; GFX9DAGISEL-NEXT:    s_cbranch_execz .LBB2_4
+; GFX9DAGISEL-NEXT:    s_cbranch_execz .LBB3_4
 ; GFX9DAGISEL-NEXT:  ; %bb.1: ; %else
 ; GFX9DAGISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX9DAGISEL-NEXT:    s_mov_b32 s8, 0x7fc00000
-; GFX9DAGISEL-NEXT:  .LBB2_2: ; =>This Inner Loop Header: Depth=1
+; GFX9DAGISEL-NEXT:  .LBB3_2: ; =>This Inner Loop Header: Depth=1
 ; GFX9DAGISEL-NEXT:    s_ff1_i32_b64 s9, s[6:7]
 ; GFX9DAGISEL-NEXT:    v_readlane_b32 s10, v2, s9
 ; GFX9DAGISEL-NEXT:    v_mov_b32_e32 v3, s10
@@ -511,17 +970,17 @@ define void @divergent_cfg_float(ptr addrspace(1) %out, float %in, float %in2) {
 ; GFX9DAGISEL-NEXT:    v_min_f32_e32 v3, s8, v3
 ; GFX9DAGISEL-NEXT:    s_cmp_lg_u64 s[6:7], 0
 ; GFX9DAGISEL-NEXT:    v_readfirstlane_b32 s8, v3
-; GFX9DAGISEL-NEXT:    s_cbranch_scc1 .LBB2_2
+; GFX9DAGISEL-NEXT:    s_cbranch_scc1 .LBB3_2
 ; GFX9DAGISEL-NEXT:  ; %bb.3:
 ; GFX9DAGISEL-NEXT:    v_mov_b32_e32 v4, s8
 ; GFX9DAGISEL-NEXT:    ; implicit-def: $vgpr3
-; GFX9DAGISEL-NEXT:  .LBB2_4: ; %Flow
+; GFX9DAGISEL-NEXT:  .LBB3_4: ; %Flow
 ; GFX9DAGISEL-NEXT:    s_andn2_saveexec_b64 s[4:5], s[4:5]
-; GFX9DAGISEL-NEXT:    s_cbranch_execz .LBB2_8
+; GFX9DAGISEL-NEXT:    s_cbranch_execz .LBB3_8
 ; GFX9DAGISEL-NEXT:  ; %bb.5: ; %if
 ; GFX9DAGISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX9DAGISEL-NEXT:    s_mov_b32 s8, 0x7fc00000
-; GFX9DAGISEL-NEXT:  .LBB2_6: ; =>This Inner Loop Header: Depth=1
+; GFX9DAGISEL-NEXT:  .LBB3_6: ; =>This Inner Loop Header: Depth=1
 ; GFX9DAGISEL-NEXT:    s_ff1_i32_b64 s9, s[6:7]
 ; GFX9DAGISEL-NEXT:    v_readlane_b32 s10, v3, s9
 ; GFX9DAGISEL-NEXT:    v_mov_b32_e32 v2, s10
@@ -529,10 +988,10 @@ define void @divergent_cfg_float(ptr addrspace(1) %out, float %in, float %in2) {
 ; GFX9DAGISEL-NEXT:    v_min_f32_e32 v2, s8, v2
 ; GFX9DAGISEL-NEXT:    s_cmp_lg_u64 s[6:7], 0
 ; GFX9DAGISEL-NEXT:    v_readfirstlane_b32 s8, v2
-; GFX9DAGISEL-NEXT:    s_cbranch_scc1 .LBB2_6
+; GFX9DAGISEL-NEXT:    s_cbranch_scc1 .LBB3_6
 ; GFX9DAGISEL-NEXT:  ; %bb.7:
 ; GFX9DAGISEL-NEXT:    v_mov_b32_e32 v4, s8
-; GFX9DAGISEL-NEXT:  .LBB2_8: ; %endif
+; GFX9DAGISEL-NEXT:  .LBB3_8: ; %endif
 ; GFX9DAGISEL-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; GFX9DAGISEL-NEXT:    global_store_dword v[0:1], v4, off
 ; GFX9DAGISEL-NEXT:    s_waitcnt vmcnt(0)
@@ -546,12 +1005,12 @@ define void @divergent_cfg_float(ptr addrspace(1) %out, float %in, float %in2) {
 ; GFX9GISEL-NEXT:    ; implicit-def: $sgpr8
 ; GFX9GISEL-NEXT:    s_and_saveexec_b64 s[4:5], vcc
 ; GFX9GISEL-NEXT:    s_xor_b64 s[4:5], exec, s[4:5]
-; GFX9GISEL-NEXT:    s_cbranch_execz .LBB2_3
+; GFX9GISEL-NEXT:    s_cbranch_execz .LBB3_3
 ; GFX9GISEL-NEXT:  ; %bb.1: ; %else
 ; GFX9GISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX9GISEL-NEXT:    s_mov_b32 s8, 0x7fc00000
 ; GFX9GISEL-NEXT:    ; implicit-def: $vgpr3
-; GFX9GISEL-NEXT:  .LBB2_2: ; =>This Inner Loop Header: Depth=1
+; GFX9GISEL-NEXT:  .LBB3_2: ; =>This Inner Loop Header: Depth=1
 ; GFX9GISEL-NEXT:    s_ff1_i32_b64 s9, s[6:7]
 ; GFX9GISEL-NEXT:    v_readlane_b32 s10, v2, s9
 ; GFX9GISEL-NEXT:    v_mov_b32_e32 v4, s10
@@ -559,14 +1018,14 @@ define void @divergent_cfg_float(ptr addrspace(1) %out, float %in, float %in2) {
 ; GFX9GISEL-NEXT:    v_min_f32_e32 v4, s8, v4
 ; GFX9GISEL-NEXT:    s_cmp_lg_u64 s[6:7], 0
 ; GFX9GISEL-NEXT:    v_readfirstlane_b32 s8, v4
-; GFX9GISEL-NEXT:    s_cbranch_scc1 .LBB2_2
-; GFX9GISEL-NEXT:  .LBB2_3: ; %Flow
+; GFX9GISEL-NEXT:    s_cbranch_scc1 .LBB3_2
+; GFX9GISEL-NEXT:  .LBB3_3: ; %Flow
 ; GFX9GISEL-NEXT:    s_andn2_saveexec_b64 s[4:5], s[4:5]
-; GFX9GISEL-NEXT:    s_cbranch_execz .LBB2_6
+; GFX9GISEL-NEXT:    s_cbranch_execz .LBB3_6
 ; GFX9GISEL-NEXT:  ; %bb.4: ; %if
 ; GFX9GISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX9GISEL-NEXT:    s_mov_b32 s8, 0x7fc00000
-; GFX9GISEL-NEXT:  .LBB2_5: ; =>This Inner Loop Header: Depth=1
+; GFX9GISEL-NEXT:  .LBB3_5: ; =>This Inner Loop Header: Depth=1
 ; GFX9GISEL-NEXT:    s_ff1_i32_b64 s9, s[6:7]
 ; GFX9GISEL-NEXT:    v_readlane_b32 s10, v3, s9
 ; GFX9GISEL-NEXT:    v_mov_b32_e32 v2, s10
@@ -574,8 +1033,8 @@ define void @divergent_cfg_float(ptr addrspace(1) %out, float %in, float %in2) {
 ; GFX9GISEL-NEXT:    v_min_f32_e32 v2, s8, v2
 ; GFX9GISEL-NEXT:    s_cmp_lg_u64 s[6:7], 0
 ; GFX9GISEL-NEXT:    v_readfirstlane_b32 s8, v2
-; GFX9GISEL-NEXT:    s_cbranch_scc1 .LBB2_5
-; GFX9GISEL-NEXT:  .LBB2_6: ; %endif
+; GFX9GISEL-NEXT:    s_cbranch_scc1 .LBB3_5
+; GFX9GISEL-NEXT:  .LBB3_6: ; %endif
 ; GFX9GISEL-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; GFX9GISEL-NEXT:    v_mov_b32_e32 v2, s8
 ; GFX9GISEL-NEXT:    global_store_dword v[0:1], v2, off
@@ -590,38 +1049,38 @@ define void @divergent_cfg_float(ptr addrspace(1) %out, float %in, float %in2) {
 ; GFX1064DAGISEL-NEXT:    ; implicit-def: $vgpr4
 ; GFX1064DAGISEL-NEXT:    s_and_saveexec_b64 s[4:5], vcc
 ; GFX1064DAGISEL-NEXT:    s_xor_b64 s[4:5], exec, s[4:5]
-; GFX1064DAGISEL-NEXT:    s_cbranch_execz .LBB2_4
+; GFX1064DAGISEL-NEXT:    s_cbranch_execz .LBB3_4
 ; GFX1064DAGISEL-NEXT:  ; %bb.1: ; %else
 ; GFX1064DAGISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX1064DAGISEL-NEXT:    s_mov_b32 s8, 0x7fc00000
-; GFX1064DAGISEL-NEXT:  .LBB2_2: ; =>This Inner Loop Header: Depth=1
+; GFX1064DAGISEL-NEXT:  .LBB3_2: ; =>This Inner Loop Header: Depth=1
 ; GFX1064DAGISEL-NEXT:    s_ff1_i32_b64 s9, s[6:7]
 ; GFX1064DAGISEL-NEXT:    v_readlane_b32 s10, v2, s9
 ; GFX1064DAGISEL-NEXT:    s_bitset0_b64 s[6:7], s9
 ; GFX1064DAGISEL-NEXT:    s_cmp_lg_u64 s[6:7], 0
 ; GFX1064DAGISEL-NEXT:    v_min_f32_e64 v3, s8, s10
 ; GFX1064DAGISEL-NEXT:    v_readfirstlane_b32 s8, v3
-; GFX1064DAGISEL-NEXT:    s_cbranch_scc1 .LBB2_2
+; GFX1064DAGISEL-NEXT:    s_cbranch_scc1 .LBB3_2
 ; GFX1064DAGISEL-NEXT:  ; %bb.3:
 ; GFX1064DAGISEL-NEXT:    v_mov_b32_e32 v4, s8
 ; GFX1064DAGISEL-NEXT:    ; implicit-def: $vgpr3
-; GFX1064DAGISEL-NEXT:  .LBB2_4: ; %Flow
+; GFX1064DAGISEL-NEXT:  .LBB3_4: ; %Flow
 ; GFX1064DAGISEL-NEXT:    s_andn2_saveexec_b64 s[4:5], s[4:5]
-; GFX1064DAGISEL-NEXT:    s_cbranch_execz .LBB2_8
+; GFX1064DAGISEL-NEXT:    s_cbranch_execz .LBB3_8
 ; GFX1064DAGISEL-NEXT:  ; %bb.5: ; %if
 ; GFX1064DAGISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX1064DAGISEL-NEXT:    s_mov_b32 s8, 0x7fc00000
-; GFX1064DAGISEL-NEXT:  .LBB2_6: ; =>This Inner Loop Header: Depth=1
+; GFX1064DAGISEL-NEXT:  .LBB3_6: ; =>This Inner Loop Header: Depth=1
 ; GFX1064DAGISEL-NEXT:    s_ff1_i32_b64 s9, s[6:7]
 ; GFX1064DAGISEL-NEXT:    v_readlane_b32 s10, v3, s9
 ; GFX1064DAGISEL-NEXT:    s_bitset0_b64 s[6:7], s9
 ; GFX1064DAGISEL-NEXT:    s_cmp_lg_u64 s[6:7], 0
 ; GFX1064DAGISEL-NEXT:    v_min_f32_e64 v2, s8, s10
 ; GFX1064DAGISEL-NEXT:    v_readfirstlane_b32 s8, v2
-; GFX1064DAGISEL-NEXT:    s_cbranch_scc1 .LBB2_6
+; GFX1064DAGISEL-NEXT:    s_cbranch_scc1 .LBB3_6
 ; GFX1064DAGISEL-NEXT:  ; %bb.7:
 ; GFX1064DAGISEL-NEXT:    v_mov_b32_e32 v4, s8
-; GFX1064DAGISEL-NEXT:  .LBB2_8: ; %endif
+; GFX1064DAGISEL-NEXT:  .LBB3_8: ; %endif
 ; GFX1064DAGISEL-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; GFX1064DAGISEL-NEXT:    global_store_dword v[0:1], v4, off
 ; GFX1064DAGISEL-NEXT:    s_setpc_b64 s[30:31]
@@ -634,11 +1093,11 @@ define void @divergent_cfg_float(ptr addrspace(1) %out, float %in, float %in2) {
 ; GFX1064GISEL-NEXT:    v_cmp_le_u32_e32 vcc, 16, v4
 ; GFX1064GISEL-NEXT:    s_and_saveexec_b64 s[4:5], vcc
 ; GFX1064GISEL-NEXT:    s_xor_b64 s[4:5], exec, s[4:5]
-; GFX1064GISEL-NEXT:    s_cbranch_execz .LBB2_3
+; GFX1064GISEL-NEXT:    s_cbranch_execz .LBB3_3
 ; GFX1064GISEL-NEXT:  ; %bb.1: ; %else
 ; GFX1064GISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX1064GISEL-NEXT:    s_mov_b32 s8, 0x7fc00000
-; GFX1064GISEL-NEXT:  .LBB2_2: ; =>This Inner Loop Header: Depth=1
+; GFX1064GISEL-NEXT:  .LBB3_2: ; =>This Inner Loop Header: Depth=1
 ; GFX1064GISEL-NEXT:    s_ff1_i32_b64 s9, s[6:7]
 ; GFX1064GISEL-NEXT:    v_readlane_b32 s10, v2, s9
 ; GFX1064GISEL-NEXT:    s_bitset0_b64 s[6:7], s9
@@ -646,22 +1105,22 @@ define void @divergent_cfg_float(ptr addrspace(1) %out, float %in, float %in2) {
 ; GFX1064GISEL-NEXT:    v_min_f32_e64 v3, s8, s10
 ; GFX1064GISEL-NEXT:    v_readfirstlane_b32 s8, v3
 ; GFX1064GISEL-NEXT:    ; implicit-def: $vgpr3
-; GFX1064GISEL-NEXT:    s_cbranch_scc1 .LBB2_2
-; GFX1064GISEL-NEXT:  .LBB2_3: ; %Flow
+; GFX1064GISEL-NEXT:    s_cbranch_scc1 .LBB3_2
+; GFX1064GISEL-NEXT:  .LBB3_3: ; %Flow
 ; GFX1064GISEL-NEXT:    s_andn2_saveexec_b64 s[4:5], s[4:5]
-; GFX1064GISEL-NEXT:    s_cbranch_execz .LBB2_6
+; GFX1064GISEL-NEXT:    s_cbranch_execz .LBB3_6
 ; GFX1064GISEL-NEXT:  ; %bb.4: ; %if
 ; GFX1064GISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX1064GISEL-NEXT:    s_mov_b32 s8, 0x7fc00000
-; GFX1064GISEL-NEXT:  .LBB2_5: ; =>This Inner Loop Header: Depth=1
+; GFX1064GISEL-NEXT:  .LBB3_5: ; =>This Inner Loop Header: Depth=1
 ; GFX1064GISEL-NEXT:    s_ff1_i32_b64 s9, s[6:7]
 ; GFX1064GISEL-NEXT:    v_readlane_b32 s10, v3, s9
 ; GFX1064GISEL-NEXT:    s_bitset0_b64 s[6:7], s9
 ; GFX1064GISEL-NEXT:    s_cmp_lg_u64 s[6:7], 0
 ; GFX1064GISEL-NEXT:    v_min_f32_e64 v2, s8, s10
 ; GFX1064GISEL-NEXT:    v_readfirstlane_b32 s8, v2
-; GFX1064GISEL-NEXT:    s_cbranch_scc1 .LBB2_5
-; GFX1064GISEL-NEXT:  .LBB2_6: ; %endif
+; GFX1064GISEL-NEXT:    s_cbranch_scc1 .LBB3_5
+; GFX1064GISEL-NEXT:  .LBB3_6: ; %endif
 ; GFX1064GISEL-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; GFX1064GISEL-NEXT:    v_mov_b32_e32 v2, s8
 ; GFX1064GISEL-NEXT:    global_store_dword v[0:1], v2, off
@@ -675,38 +1134,38 @@ define void @divergent_cfg_float(ptr addrspace(1) %out, float %in, float %in2) {
 ; GFX1032DAGISEL-NEXT:    ; implicit-def: $vgpr4
 ; GFX1032DAGISEL-NEXT:    s_and_saveexec_b32 s4, vcc_lo
 ; GFX1032DAGISEL-NEXT:    s_xor_b32 s4, exec_lo, s4
-; GFX1032DAGISEL-NEXT:    s_cbranch_execz .LBB2_4
+; GFX1032DAGISEL-NEXT:    s_cbranch_execz .LBB3_4
 ; GFX1032DAGISEL-NEXT:  ; %bb.1: ; %else
 ; GFX1032DAGISEL-NEXT:    s_mov_b32 s5, exec_lo
 ; GFX1032DAGISEL-NEXT:    s_mov_b32 s6, 0x7fc00000
-; GFX1032DAGISEL-NEXT:  .LBB2_2: ; =>This Inner Loop Header: Depth=1
+; GFX1032DAGISEL-NEXT:  .LBB3_2: ; =>This Inner Loop Header: Depth=1
 ; GFX1032DAGISEL-NEXT:    s_ff1_i32_b32 s7, s5
 ; GFX1032DAGISEL-NEXT:    v_readlane_b32 s8, v2, s7
 ; GFX1032DAGISEL-NEXT:    s_bitset0_b32 s5, s7
 ; GFX1032DAGISEL-NEXT:    s_cmp_lg_u32 s5, 0
 ; GFX1032DAGISEL-NEXT:    v_min_f32_e64 v3, s6, s8
 ; GFX1032DAGISEL-NEXT:    v_readfirstlane_b32 s6, v3
-; GFX1032DAGISEL-NEXT:    s_cbranch_scc1 .LBB2_2
+; GFX1032DAGISEL-NEXT:    s_cbranch_scc1 .LBB3_2
 ; GFX1032DAGISEL-NEXT:  ; %bb.3:
 ; GFX1032DAGISEL-NEXT:    v_mov_b32_e32 v4, s6
 ; GFX1032DAGISEL-NEXT:    ; implicit-def: $vgpr3
-; GFX1032DAGISEL-NEXT:  .LBB2_4: ; %Flow
+; GFX1032DAGISEL-NEXT:  .LBB3_4: ; %Flow
 ; GFX1032DAGISEL-NEXT:    s_andn2_saveexec_b32 s4, s4
-; GFX1032DAGISEL-NEXT:    s_cbranch_execz .LBB2_8
+; GFX1032DAGISEL-NEXT:    s_cbranch_execz .LBB3_8
 ; GFX1032DAGISEL-NEXT:  ; %bb.5: ; %if
 ; GFX1032DAGISEL-NEXT:    s_mov_b32 s5, exec_lo
 ; GFX1032DAGISEL-NEXT:    s_mov_b32 s6, 0x7fc00000
-; GFX1032DAGISEL-NEXT:  .LBB2_6: ; =>This Inner Loop Header: Depth=1
+; GFX1032DAGISEL-NEXT:  .LBB3_6: ; =>This Inner Loop Header: Depth=1
 ; GFX1032DAGISEL-NEXT:    s_ff1_i32_b32 s7, s5
 ; GFX1032DAGISEL-NEXT:    v_readlane_b32 s8, v3, s7
 ; GFX1032DAGISEL-NEXT:    s_bitset0_b32 s5, s7
 ; GFX1032DAGISEL-NEXT:    s_cmp_lg_u32 s5, 0
 ; GFX1032DAGISEL-NEXT:    v_min_f32_e64 v2, s6, s8
 ; GFX1032DAGISEL-NEXT:    v_readfirstlane_b32 s6, v2
-; GFX1032DAGISEL-NEXT:    s_cbranch_scc1 .LBB2_6
+; GFX1032DAGISEL-NEXT:    s_cbranch_scc1 .LBB3_6
 ; GFX1032DAGISEL-NEXT:  ; %bb.7:
 ; GFX1032DAGISEL-NEXT:    v_mov_b32_e32 v4, s6
-; GFX1032DAGISEL-NEXT:  .LBB2_8: ; %endif
+; GFX1032DAGISEL-NEXT:  .LBB3_8: ; %endif
 ; GFX1032DAGISEL-NEXT:    s_or_b32 exec_lo, exec_lo, s4
 ; GFX1032DAGISEL-NEXT:    global_store_dword v[0:1], v4, off
 ; GFX1032DAGISEL-NEXT:    s_setpc_b64 s[30:31]
@@ -719,11 +1178,11 @@ define void @divergent_cfg_float(ptr addrspace(1) %out, float %in, float %in2) {
 ; GFX1032GISEL-NEXT:    v_cmp_le_u32_e32 vcc_lo, 16, v4
 ; GFX1032GISEL-NEXT:    s_and_saveexec_b32 s5, vcc_lo
 ; GFX1032GISEL-NEXT:    s_xor_b32 s5, exec_lo, s5
-; GFX1032GISEL-NEXT:    s_cbranch_execz .LBB2_3
+; GFX1032GISEL-NEXT:    s_cbranch_execz .LBB3_3
 ; GFX1032GISEL-NEXT:  ; %bb.1: ; %else
 ; GFX1032GISEL-NEXT:    s_mov_b32 s6, exec_lo
 ; GFX1032GISEL-NEXT:    s_mov_b32 s4, 0x7fc00000
-; GFX1032GISEL-NEXT:  .LBB2_2: ; =>This Inner Loop Header: Depth=1
+; GFX1032GISEL-NEXT:  .LBB3_2: ; =>This Inner Loop Header: Depth=1
 ; GFX1032GISEL-NEXT:    s_ff1_i32_b32 s7, s6
 ; GFX1032GISEL-NEXT:    v_readlane_b32 s8, v2, s7
 ; GFX1032GISEL-NEXT:    s_bitset0_b32 s6, s7
@@ -731,22 +1190,22 @@ define void @divergent_cfg_float(ptr addrspace(1) %out, float %in, float %in2) {
 ; GFX1032GISEL-NEXT:    v_min_f32_e64 v3, s4, s8
 ; GFX1032GISEL-NEXT:    v_readfirstlane_b32 s4, v3
 ; GFX1032GISEL-NEXT:    ; implicit-def: $vgpr3
-; GFX1032GISEL-NEXT:    s_cbranch_scc1 .LBB2_2
-; GFX1032GISEL-NEXT:  .LBB2_3: ; %Flow
+; GFX1032GISEL-NEXT:    s_cbranch_scc1 .LBB3_2
+; GFX1032GISEL-NEXT:  .LBB3_3: ; %Flow
 ; GFX1032GISEL-NEXT:    s_andn2_saveexec_b32 s5, s5
-; GFX1032GISEL-NEXT:    s_cbranch_execz .LBB2_6
+; GFX1032GISEL-NEXT:    s_cbranch_execz .LBB3_6
 ; GFX1032GISEL-NEXT:  ; %bb.4: ; %if
 ; GFX1032GISEL-NEXT:    s_mov_b32 s6, exec_lo
 ; GFX1032GISEL-NEXT:    s_mov_b32 s4, 0x7fc00000
-; GFX1032GISEL-NEXT:  .LBB2_5: ; =>This Inner Loop Header: Depth=1
+; GFX1032GISEL-NEXT:  .LBB3_5: ; =>This Inner Loop Header: Depth=1
 ; GFX1032GISEL-NEXT:    s_ff1_i32_b32 s7, s6
 ; GFX1032GISEL-NEXT:    v_readlane_b32 s8, v3, s7
 ; GFX1032GISEL-NEXT:    s_bitset0_b32 s6, s7
 ; GFX1032GISEL-NEXT:    s_cmp_lg_u32 s6, 0
 ; GFX1032GISEL-NEXT:    v_min_f32_e64 v2, s4, s8
 ; GFX1032GISEL-NEXT:    v_readfirstlane_b32 s4, v2
-; GFX1032GISEL-NEXT:    s_cbranch_scc1 .LBB2_5
-; GFX1032GISEL-NEXT:  .LBB2_6: ; %endif
+; GFX1032GISEL-NEXT:    s_cbranch_scc1 .LBB3_5
+; GFX1032GISEL-NEXT:  .LBB3_6: ; %endif
 ; GFX1032GISEL-NEXT:    s_or_b32 exec_lo, exec_lo, s5
 ; GFX1032GISEL-NEXT:    v_mov_b32_e32 v2, s4
 ; GFX1032GISEL-NEXT:    global_store_dword v[0:1], v2, off
@@ -761,11 +1220,11 @@ define void @divergent_cfg_float(ptr addrspace(1) %out, float %in, float %in2) {
 ; GFX1164DAGISEL-NEXT:    ; implicit-def: $vgpr4
 ; GFX1164DAGISEL-NEXT:    s_and_saveexec_b64 s[0:1], vcc
 ; GFX1164DAGISEL-NEXT:    s_xor_b64 s[0:1], exec, s[0:1]
-; GFX1164DAGISEL-NEXT:    s_cbranch_execz .LBB2_4
+; GFX1164DAGISEL-NEXT:    s_cbranch_execz .LBB3_4
 ; GFX1164DAGISEL-NEXT:  ; %bb.1: ; %else
 ; GFX1164DAGISEL-NEXT:    s_mov_b64 s[2:3], exec
 ; GFX1164DAGISEL-NEXT:    s_mov_b32 s4, 0x7fc00000
-; GFX1164DAGISEL-NEXT:  .LBB2_2: ; =>This Inner Loop Header: Depth=1
+; GFX1164DAGISEL-NEXT:  .LBB3_2: ; =>This Inner Loop Header: Depth=1
 ; GFX1164DAGISEL-NEXT:    s_ctz_i32_b64 s5, s[2:3]
 ; GFX1164DAGISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_1) | instid1(SALU_CYCLE_1)
 ; GFX1164DAGISEL-NEXT:    v_readlane_b32 s6, v2, s5
@@ -774,17 +1233,17 @@ define void @divergent_cfg_float(ptr addrspace(1) %out, float %in, float %in2) {
 ; GFX1164DAGISEL-NEXT:    v_min_f32_e64 v3, s4, s6
 ; GFX1164DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX1164DAGISEL-NEXT:    v_readfirstlane_b32 s4, v3
-; GFX1164DAGISEL-NEXT:    s_cbranch_scc1 .LBB2_2
+; GFX1164DAGISEL-NEXT:    s_cbranch_scc1 .LBB3_2
 ; GFX1164DAGISEL-NEXT:  ; %bb.3:
 ; GFX1164DAGISEL-NEXT:    v_mov_b32_e32 v4, s4
 ; GFX1164DAGISEL-NEXT:    ; implicit-def: $vgpr3
-; GFX1164DAGISEL-NEXT:  .LBB2_4: ; %Flow
+; GFX1164DAGISEL-NEXT:  .LBB3_4: ; %Flow
 ; GFX1164DAGISEL-NEXT:    s_and_not1_saveexec_b64 s[0:1], s[0:1]
-; GFX1164DAGISEL-NEXT:    s_cbranch_execz .LBB2_8
+; GFX1164DAGISEL-NEXT:    s_cbranch_execz .LBB3_8
 ; GFX1164DAGISEL-NEXT:  ; %bb.5: ; %if
 ; GFX1164DAGISEL-NEXT:    s_mov_b64 s[2:3], exec
 ; GFX1164DAGISEL-NEXT:    s_mov_b32 s4, 0x7fc00000
-; GFX1164DAGISEL-NEXT:  .LBB2_6: ; =>This Inner Loop Header: Depth=1
+; GFX1164DAGISEL-NEXT:  .LBB3_6: ; =>This Inner Loop Header: Depth=1
 ; GFX1164DAGISEL-NEXT:    s_ctz_i32_b64 s5, s[2:3]
 ; GFX1164DAGISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_1) | instid1(SALU_CYCLE_1)
 ; GFX1164DAGISEL-NEXT:    v_readlane_b32 s6, v3, s5
@@ -793,10 +1252,10 @@ define void @divergent_cfg_float(ptr addrspace(1) %out, float %in, float %in2) {
 ; GFX1164DAGISEL-NEXT:    v_min_f32_e64 v2, s4, s6
 ; GFX1164DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX1164DAGISEL-NEXT:    v_readfirstlane_b32 s4, v2
-; GFX1164DAGISEL-NEXT:    s_cbranch_scc1 .LBB2_6
+; GFX1164DAGISEL-NEXT:    s_cbranch_scc1 .LBB3_6
 ; GFX1164DAGISEL-NEXT:  ; %bb.7:
 ; GFX1164DAGISEL-NEXT:    v_mov_b32_e32 v4, s4
-; GFX1164DAGISEL-NEXT:  .LBB2_8: ; %endif
+; GFX1164DAGISEL-NEXT:  .LBB3_8: ; %endif
 ; GFX1164DAGISEL-NEXT:    s_or_b64 exec, exec, s[0:1]
 ; GFX1164DAGISEL-NEXT:    global_store_b32 v[0:1], v4, off
 ; GFX1164DAGISEL-NEXT:    s_setpc_b64 s[30:31]
@@ -810,11 +1269,11 @@ define void @divergent_cfg_float(ptr addrspace(1) %out, float %in, float %in2) {
 ; GFX1164GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX1164GISEL-NEXT:    v_cmpx_le_u32_e32 16, v4
 ; GFX1164GISEL-NEXT:    s_xor_b64 s[0:1], exec, s[0:1]
-; GFX1164GISEL-NEXT:    s_cbranch_execz .LBB2_3
+; GFX1164GISEL-NEXT:    s_cbranch_execz .LBB3_3
 ; GFX1164GISEL-NEXT:  ; %bb.1: ; %else
 ; GFX1164GISEL-NEXT:    s_mov_b64 s[2:3], exec
 ; GFX1164GISEL-NEXT:    s_mov_b32 s4, 0x7fc00000
-; GFX1164GISEL-NEXT:  .LBB2_2: ; =>This Inner Loop Header: Depth=1
+; GFX1164GISEL-NEXT:  .LBB3_2: ; =>This Inner Loop Header: Depth=1
 ; GFX1164GISEL-NEXT:    s_ctz_i32_b64 s5, s[2:3]
 ; GFX1164GISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_1) | instid1(SALU_CYCLE_1)
 ; GFX1164GISEL-NEXT:    v_readlane_b32 s6, v2, s5
@@ -824,14 +1283,14 @@ define void @divergent_cfg_float(ptr addrspace(1) %out, float %in, float %in2) {
 ; GFX1164GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX1164GISEL-NEXT:    v_readfirstlane_b32 s4, v3
 ; GFX1164GISEL-NEXT:    ; implicit-def: $vgpr3
-; GFX1164GISEL-NEXT:    s_cbranch_scc1 .LBB2_2
-; GFX1164GISEL-NEXT:  .LBB2_3: ; %Flow
+; GFX1164GISEL-NEXT:    s_cbranch_scc1 .LBB3_2
+; GFX1164GISEL-NEXT:  .LBB3_3: ; %Flow
 ; GFX1164GISEL-NEXT:    s_and_not1_saveexec_b64 s[0:1], s[0:1]
-; GFX1164GISEL-NEXT:    s_cbranch_execz .LBB2_6
+; GFX1164GISEL-NEXT:    s_cbranch_execz .LBB3_6
 ; GFX1164GISEL-NEXT:  ; %bb.4: ; %if
 ; GFX1164GISEL-NEXT:    s_mov_b64 s[2:3], exec
 ; GFX1164GISEL-NEXT:    s_mov_b32 s4, 0x7fc00000
-; GFX1164GISEL-NEXT:  .LBB2_5: ; =>This Inner Loop Header: Depth=1
+; GFX1164GISEL-NEXT:  .LBB3_5: ; =>This Inner Loop Header: Depth=1
 ; GFX1164GISEL-NEXT:    s_ctz_i32_b64 s5, s[2:3]
 ; GFX1164GISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_1) | instid1(SALU_CYCLE_1)
 ; GFX1164GISEL-NEXT:    v_readlane_b32 s6, v3, s5
@@ -840,8 +1299,8 @@ define void @divergent_cfg_float(ptr addrspace(1) %out, float %in, float %in2) {
 ; GFX1164GISEL-NEXT:    v_min_f32_e64 v2, s4, s6
 ; GFX1164GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX1164GISEL-NEXT:    v_readfirstlane_b32 s4, v2
-; GFX1164GISEL-NEXT:    s_cbranch_scc1 .LBB2_5
-; GFX1164GISEL-NEXT:  .LBB2_6: ; %endif
+; GFX1164GISEL-NEXT:    s_cbranch_scc1 .LBB3_5
+; GFX1164GISEL-NEXT:  .LBB3_6: ; %endif
 ; GFX1164GISEL-NEXT:    s_or_b64 exec, exec, s[0:1]
 ; GFX1164GISEL-NEXT:    v_mov_b32_e32 v2, s4
 ; GFX1164GISEL-NEXT:    global_store_b32 v[0:1], v2, off
@@ -856,11 +1315,11 @@ define void @divergent_cfg_float(ptr addrspace(1) %out, float %in, float %in2) {
 ; GFX1132DAGISEL-NEXT:    ; implicit-def: $vgpr4
 ; GFX1132DAGISEL-NEXT:    s_and_saveexec_b32 s0, vcc_lo
 ; GFX1132DAGISEL-NEXT:    s_xor_b32 s0, exec_lo, s0
-; GFX1132DAGISEL-NEXT:    s_cbranch_execz .LBB2_4
+; GFX1132DAGISEL-NEXT:    s_cbranch_execz .LBB3_4
 ; GFX1132DAGISEL-NEXT:  ; %bb.1: ; %else
 ; GFX1132DAGISEL-NEXT:    s_mov_b32 s1, exec_lo
 ; GFX1132DAGISEL-NEXT:    s_mov_b32 s2, 0x7fc00000
-; GFX1132DAGISEL-NEXT:  .LBB2_2: ; =>This Inner Loop Header: Depth=1
+; GFX1132DAGISEL-NEXT:  .LBB3_2: ; =>This Inner Loop Header: Depth=1
 ; GFX1132DAGISEL-NEXT:    s_ctz_i32_b32 s3, s1
 ; GFX1132DAGISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_1) | instid1(SALU_CYCLE_1)
 ; GFX1132DAGISEL-NEXT:    v_readlane_b32 s4, v2, s3
@@ -869,17 +1328,17 @@ define void @divergent_cfg_float(ptr addrspace(1) %out, float %in, float %in2) {
 ; GFX1132DAGISEL-NEXT:    v_min_f32_e64 v3, s2, s4
 ; GFX1132DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX1132DAGISEL-NEXT:    v_readfirstlane_b32 s2, v3
-; GFX1132DAGISEL-NEXT:    s_cbranch_scc1 .LBB2_2
+; GFX1132DAGISEL-NEXT:    s_cbranch_scc1 .LBB3_2
 ; GFX1132DAGISEL-NEXT:  ; %bb.3:
 ; GFX1132DAGISEL-NEXT:    v_mov_b32_e32 v4, s2
 ; GFX1132DAGISEL-NEXT:    ; implicit-def: $vgpr3
-; GFX1132DAGISEL-NEXT:  .LBB2_4: ; %Flow
+; GFX1132DAGISEL-NEXT:  .LBB3_4: ; %Flow
 ; GFX1132DAGISEL-NEXT:    s_and_not1_saveexec_b32 s0, s0
-; GFX1132DAGISEL-NEXT:    s_cbranch_execz .LBB2_8
+; GFX1132DAGISEL-NEXT:    s_cbranch_execz .LBB3_8
 ; GFX1132DAGISEL-NEXT:  ; %bb.5: ; %if
 ; GFX1132DAGISEL-NEXT:    s_mov_b32 s1, exec_lo
 ; GFX1132DAGISEL-NEXT:    s_mov_b32 s2, 0x7fc00000
-; GFX1132DAGISEL-NEXT:  .LBB2_6: ; =>This Inner Loop Header: Depth=1
+; GFX1132DAGISEL-NEXT:  .LBB3_6: ; =>This Inner Loop Header: Depth=1
 ; GFX1132DAGISEL-NEXT:    s_ctz_i32_b32 s3, s1
 ; GFX1132DAGISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_1) | instid1(SALU_CYCLE_1)
 ; GFX1132DAGISEL-NEXT:    v_readlane_b32 s4, v3, s3
@@ -888,10 +1347,10 @@ define void @divergent_cfg_float(ptr addrspace(1) %out, float %in, float %in2) {
 ; GFX1132DAGISEL-NEXT:    v_min_f32_e64 v2, s2, s4
 ; GFX1132DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX1132DAGISEL-NEXT:    v_readfirstlane_b32 s2, v2
-; GFX1132DAGISEL-NEXT:    s_cbranch_scc1 .LBB2_6
+; GFX1132DAGISEL-NEXT:    s_cbranch_scc1 .LBB3_6
 ; GFX1132DAGISEL-NEXT:  ; %bb.7:
 ; GFX1132DAGISEL-NEXT:    v_mov_b32_e32 v4, s2
-; GFX1132DAGISEL-NEXT:  .LBB2_8: ; %endif
+; GFX1132DAGISEL-NEXT:  .LBB3_8: ; %endif
 ; GFX1132DAGISEL-NEXT:    s_or_b32 exec_lo, exec_lo, s0
 ; GFX1132DAGISEL-NEXT:    global_store_b32 v[0:1], v4, off
 ; GFX1132DAGISEL-NEXT:    s_setpc_b64 s[30:31]
@@ -905,11 +1364,11 @@ define void @divergent_cfg_float(ptr addrspace(1) %out, float %in, float %in2) {
 ; GFX1132GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX1132GISEL-NEXT:    v_cmpx_le_u32_e32 16, v4
 ; GFX1132GISEL-NEXT:    s_xor_b32 s1, exec_lo, s1
-; GFX1132GISEL-NEXT:    s_cbranch_execz .LBB2_3
+; GFX1132GISEL-NEXT:    s_cbranch_execz .LBB3_3
 ; GFX1132GISEL-NEXT:  ; %bb.1: ; %else
 ; GFX1132GISEL-NEXT:    s_mov_b32 s2, exec_lo
 ; GFX1132GISEL-NEXT:    s_mov_b32 s0, 0x7fc00000
-; GFX1132GISEL-NEXT:  .LBB2_2: ; =>This Inner Loop Header: Depth=1
+; GFX1132GISEL-NEXT:  .LBB3_2: ; =>This Inner Loop Header: Depth=1
 ; GFX1132GISEL-NEXT:    s_ctz_i32_b32 s3, s2
 ; GFX1132GISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_1) | instid1(SALU_CYCLE_1)
 ; GFX1132GISEL-NEXT:    v_readlane_b32 s4, v2, s3
@@ -919,14 +1378,14 @@ define void @divergent_cfg_float(ptr addrspace(1) %out, float %in, float %in2) {
 ; GFX1132GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX1132GISEL-NEXT:    v_readfirstlane_b32 s0, v3
 ; GFX1132GISEL-NEXT:    ; implicit-def: $vgpr3
-; GFX1132GISEL-NEXT:    s_cbranch_scc1 .LBB2_2
-; GFX1132GISEL-NEXT:  .LBB2_3: ; %Flow
+; GFX1132GISEL-NEXT:    s_cbranch_scc1 .LBB3_2
+; GFX1132GISEL-NEXT:  .LBB3_3: ; %Flow
 ; GFX1132GISEL-NEXT:    s_and_not1_saveexec_b32 s1, s1
-; GFX1132GISEL-NEXT:    s_cbranch_execz .LBB2_6
+; GFX1132GISEL-NEXT:    s_cbranch_execz .LBB3_6
 ; GFX1132GISEL-NEXT:  ; %bb.4: ; %if
 ; GFX1132GISEL-NEXT:    s_mov_b32 s2, exec_lo
 ; GFX1132GISEL-NEXT:    s_mov_b32 s0, 0x7fc00000
-; GFX1132GISEL-NEXT:  .LBB2_5: ; =>This Inner Loop Header: Depth=1
+; GFX1132GISEL-NEXT:  .LBB3_5: ; =>This Inner Loop Header: Depth=1
 ; GFX1132GISEL-NEXT:    s_ctz_i32_b32 s3, s2
 ; GFX1132GISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_1) | instid1(SALU_CYCLE_1)
 ; GFX1132GISEL-NEXT:    v_readlane_b32 s4, v3, s3
@@ -935,8 +1394,8 @@ define void @divergent_cfg_float(ptr addrspace(1) %out, float %in, float %in2) {
 ; GFX1132GISEL-NEXT:    v_min_f32_e64 v2, s0, s4
 ; GFX1132GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX1132GISEL-NEXT:    v_readfirstlane_b32 s0, v2
-; GFX1132GISEL-NEXT:    s_cbranch_scc1 .LBB2_5
-; GFX1132GISEL-NEXT:  .LBB2_6: ; %endif
+; GFX1132GISEL-NEXT:    s_cbranch_scc1 .LBB3_5
+; GFX1132GISEL-NEXT:  .LBB3_6: ; %endif
 ; GFX1132GISEL-NEXT:    s_or_b32 exec_lo, exec_lo, s1
 ; GFX1132GISEL-NEXT:    v_mov_b32_e32 v2, s0
 ; GFX1132GISEL-NEXT:    global_store_b32 v[0:1], v2, off
@@ -956,11 +1415,11 @@ define void @divergent_cfg_float(ptr addrspace(1) %out, float %in, float %in2) {
 ; GFX12DAGISEL-NEXT:    s_and_saveexec_b32 s0, vcc_lo
 ; GFX12DAGISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
 ; GFX12DAGISEL-NEXT:    s_xor_b32 s0, exec_lo, s0
-; GFX12DAGISEL-NEXT:    s_cbranch_execz .LBB2_4
+; GFX12DAGISEL-NEXT:    s_cbranch_execz .LBB3_4
 ; GFX12DAGISEL-NEXT:  ; %bb.1: ; %else
 ; GFX12DAGISEL-NEXT:    s_mov_b32 s1, exec_lo
 ; GFX12DAGISEL-NEXT:    s_mov_b32 s2, 0x7fc00000
-; GFX12DAGISEL-NEXT:  .LBB2_2: ; =>This Inner Loop Header: Depth=1
+; GFX12DAGISEL-NEXT:  .LBB3_2: ; =>This Inner Loop Header: Depth=1
 ; GFX12DAGISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
 ; GFX12DAGISEL-NEXT:    s_ctz_i32_b32 s3, s1
 ; GFX12DAGISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
@@ -971,19 +1430,19 @@ define void @divergent_cfg_float(ptr addrspace(1) %out, float %in, float %in2) {
 ; GFX12DAGISEL-NEXT:    v_min_num_f32_e64 v3, s2, s4
 ; GFX12DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX12DAGISEL-NEXT:    v_readfirstlane_b32 s2, v3
-; GFX12DAGISEL-NEXT:    s_cbranch_scc1 .LBB2_2
+; GFX12DAGISEL-NEXT:    s_cbranch_scc1 .LBB3_2
 ; GFX12DAGISEL-NEXT:  ; %bb.3:
 ; GFX12DAGISEL-NEXT:    s_wait_alu depctr_va_sdst(0)
 ; GFX12DAGISEL-NEXT:    v_mov_b32_e32 v4, s2
 ; GFX12DAGISEL-NEXT:    ; implicit-def: $vgpr3
-; GFX12DAGISEL-NEXT:  .LBB2_4: ; %Flow
+; GFX12DAGISEL-NEXT:  .LBB3_4: ; %Flow
 ; GFX12DAGISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
 ; GFX12DAGISEL-NEXT:    s_and_not1_saveexec_b32 s0, s0
-; GFX12DAGISEL-NEXT:    s_cbranch_execz .LBB2_8
+; GFX12DAGISEL-NEXT:    s_cbranch_execz .LBB3_8
 ; GFX12DAGISEL-NEXT:  ; %bb.5: ; %if
 ; GFX12DAGISEL-NEXT:    s_mov_b32 s1, exec_lo
 ; GFX12DAGISEL-NEXT:    s_mov_b32 s2, 0x7fc00000
-; GFX12DAGISEL-NEXT:  .LBB2_6: ; =>This Inner Loop Header: Depth=1
+; GFX12DAGISEL-NEXT:  .LBB3_6: ; =>This Inner Loop Header: Depth=1
 ; GFX12DAGISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
 ; GFX12DAGISEL-NEXT:    s_ctz_i32_b32 s3, s1
 ; GFX12DAGISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
@@ -994,11 +1453,11 @@ define void @divergent_cfg_float(ptr addrspace(1) %out, float %in, float %in2) {
 ; GFX12DAGISEL-NEXT:    v_min_num_f32_e64 v2, s2, s4
 ; GFX12DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX12DAGISEL-NEXT:    v_readfirstlane_b32 s2, v2
-; GFX12DAGISEL-NEXT:    s_cbranch_scc1 .LBB2_6
+; GFX12DAGISEL-NEXT:    s_cbranch_scc1 .LBB3_6
 ; GFX12DAGISEL-NEXT:  ; %bb.7:
 ; GFX12DAGISEL-NEXT:    s_wait_alu depctr_va_sdst(0)
 ; GFX12DAGISEL-NEXT:    v_mov_b32_e32 v4, s2
-; GFX12DAGISEL-NEXT:  .LBB2_8: ; %endif
+; GFX12DAGISEL-NEXT:  .LBB3_8: ; %endif
 ; GFX12DAGISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
 ; GFX12DAGISEL-NEXT:    s_or_b32 exec_lo, exec_lo, s0
 ; GFX12DAGISEL-NEXT:    global_store_b32 v[0:1], v4, off
@@ -1144,7 +1603,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %in) {
 ; GFX8DAGISEL-NEXT:    s_mov_b32 s6, 0
 ; GFX8DAGISEL-NEXT:    s_mov_b32 s7, 0x7ff80000
 ; GFX8DAGISEL-NEXT:    s_mov_b64 s[4:5], exec
-; GFX8DAGISEL-NEXT:  .LBB4_1: ; =>This Inner Loop Header: Depth=1
+; GFX8DAGISEL-NEXT:  .LBB5_1: ; =>This Inner Loop Header: Depth=1
 ; GFX8DAGISEL-NEXT:    s_ff1_i32_b64 s10, s[4:5]
 ; GFX8DAGISEL-NEXT:    v_mov_b32_e32 v4, s6
 ; GFX8DAGISEL-NEXT:    v_readlane_b32 s8, v2, s10
@@ -1155,7 +1614,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %in) {
 ; GFX8DAGISEL-NEXT:    s_cmp_lg_u64 s[4:5], 0
 ; GFX8DAGISEL-NEXT:    v_readfirstlane_b32 s6, v4
 ; GFX8DAGISEL-NEXT:    v_readfirstlane_b32 s7, v5
-; GFX8DAGISEL-NEXT:    s_cbranch_scc1 .LBB4_1
+; GFX8DAGISEL-NEXT:    s_cbranch_scc1 .LBB5_1
 ; GFX8DAGISEL-NEXT:  ; %bb.2:
 ; GFX8DAGISEL-NEXT:    v_mov_b32_e32 v2, s6
 ; GFX8DAGISEL-NEXT:    v_mov_b32_e32 v3, s7
@@ -1169,7 +1628,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %in) {
 ; GFX8GISEL-NEXT:    s_mov_b32 s6, 0
 ; GFX8GISEL-NEXT:    s_mov_b32 s7, 0x7ff80000
 ; GFX8GISEL-NEXT:    s_mov_b64 s[4:5], exec
-; GFX8GISEL-NEXT:  .LBB4_1: ; =>This Inner Loop Header: Depth=1
+; GFX8GISEL-NEXT:  .LBB5_1: ; =>This Inner Loop Header: Depth=1
 ; GFX8GISEL-NEXT:    s_ff1_i32_b64 s10, s[4:5]
 ; GFX8GISEL-NEXT:    v_mov_b32_e32 v4, s6
 ; GFX8GISEL-NEXT:    v_readlane_b32 s8, v2, s10
@@ -1180,7 +1639,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %in) {
 ; GFX8GISEL-NEXT:    s_cmp_lg_u64 s[4:5], 0
 ; GFX8GISEL-NEXT:    v_readfirstlane_b32 s6, v4
 ; GFX8GISEL-NEXT:    v_readfirstlane_b32 s7, v5
-; GFX8GISEL-NEXT:    s_cbranch_scc1 .LBB4_1
+; GFX8GISEL-NEXT:    s_cbranch_scc1 .LBB5_1
 ; GFX8GISEL-NEXT:  ; %bb.2:
 ; GFX8GISEL-NEXT:    v_mov_b32_e32 v2, s6
 ; GFX8GISEL-NEXT:    v_mov_b32_e32 v3, s7
@@ -1194,7 +1653,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %in) {
 ; GFX9DAGISEL-NEXT:    s_mov_b32 s6, 0
 ; GFX9DAGISEL-NEXT:    s_mov_b32 s7, 0x7ff80000
 ; GFX9DAGISEL-NEXT:    s_mov_b64 s[4:5], exec
-; GFX9DAGISEL-NEXT:  .LBB4_1: ; =>This Inner Loop Header: Depth=1
+; GFX9DAGISEL-NEXT:  .LBB5_1: ; =>This Inner Loop Header: Depth=1
 ; GFX9DAGISEL-NEXT:    s_ff1_i32_b64 s10, s[4:5]
 ; GFX9DAGISEL-NEXT:    v_mov_b32_e32 v4, s6
 ; GFX9DAGISEL-NEXT:    v_readlane_b32 s8, v2, s10
@@ -1205,7 +1664,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %in) {
 ; GFX9DAGISEL-NEXT:    s_cmp_lg_u64 s[4:5], 0
 ; GFX9DAGISEL-NEXT:    v_readfirstlane_b32 s6, v4
 ; GFX9DAGISEL-NEXT:    v_readfirstlane_b32 s7, v5
-; GFX9DAGISEL-NEXT:    s_cbranch_scc1 .LBB4_1
+; GFX9DAGISEL-NEXT:    s_cbranch_scc1 .LBB5_1
 ; GFX9DAGISEL-NEXT:  ; %bb.2:
 ; GFX9DAGISEL-NEXT:    v_mov_b32_e32 v2, s6
 ; GFX9DAGISEL-NEXT:    v_mov_b32_e32 v3, s7
@@ -1219,7 +1678,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %in) {
 ; GFX9GISEL-NEXT:    s_mov_b32 s6, 0
 ; GFX9GISEL-NEXT:    s_mov_b32 s7, 0x7ff80000
 ; GFX9GISEL-NEXT:    s_mov_b64 s[4:5], exec
-; GFX9GISEL-NEXT:  .LBB4_1: ; =>This Inner Loop Header: Depth=1
+; GFX9GISEL-NEXT:  .LBB5_1: ; =>This Inner Loop Header: Depth=1
 ; GFX9GISEL-NEXT:    s_ff1_i32_b64 s10, s[4:5]
 ; GFX9GISEL-NEXT:    v_mov_b32_e32 v4, s6
 ; GFX9GISEL-NEXT:    v_readlane_b32 s8, v2, s10
@@ -1230,7 +1689,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %in) {
 ; GFX9GISEL-NEXT:    s_cmp_lg_u64 s[4:5], 0
 ; GFX9GISEL-NEXT:    v_readfirstlane_b32 s6, v4
 ; GFX9GISEL-NEXT:    v_readfirstlane_b32 s7, v5
-; GFX9GISEL-NEXT:    s_cbranch_scc1 .LBB4_1
+; GFX9GISEL-NEXT:    s_cbranch_scc1 .LBB5_1
 ; GFX9GISEL-NEXT:  ; %bb.2:
 ; GFX9GISEL-NEXT:    v_mov_b32_e32 v2, s6
 ; GFX9GISEL-NEXT:    v_mov_b32_e32 v3, s7
@@ -1244,7 +1703,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %in) {
 ; GFX1064DAGISEL-NEXT:    s_mov_b32 s6, 0
 ; GFX1064DAGISEL-NEXT:    s_mov_b32 s7, 0x7ff80000
 ; GFX1064DAGISEL-NEXT:    s_mov_b64 s[4:5], exec
-; GFX1064DAGISEL-NEXT:  .LBB4_1: ; =>This Inner Loop Header: Depth=1
+; GFX1064DAGISEL-NEXT:  .LBB5_1: ; =>This Inner Loop Header: Depth=1
 ; GFX1064DAGISEL-NEXT:    s_ff1_i32_b64 s10, s[4:5]
 ; GFX1064DAGISEL-NEXT:    v_readlane_b32 s8, v2, s10
 ; GFX1064DAGISEL-NEXT:    v_readlane_b32 s9, v3, s10
@@ -1253,7 +1712,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %in) {
 ; GFX1064DAGISEL-NEXT:    v_min_f64 v[4:5], s[8:9], s[6:7]
 ; GFX1064DAGISEL-NEXT:    v_readfirstlane_b32 s6, v4
 ; GFX1064DAGISEL-NEXT:    v_readfirstlane_b32 s7, v5
-; GFX1064DAGISEL-NEXT:    s_cbranch_scc1 .LBB4_1
+; GFX1064DAGISEL-NEXT:    s_cbranch_scc1 .LBB5_1
 ; GFX1064DAGISEL-NEXT:  ; %bb.2:
 ; GFX1064DAGISEL-NEXT:    v_mov_b32_e32 v2, s6
 ; GFX1064DAGISEL-NEXT:    v_mov_b32_e32 v3, s7
@@ -1266,7 +1725,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %in) {
 ; GFX1064GISEL-NEXT:    s_mov_b32 s6, 0
 ; GFX1064GISEL-NEXT:    s_mov_b32 s7, 0x7ff80000
 ; GFX1064GISEL-NEXT:    s_mov_b64 s[4:5], exec
-; GFX1064GISEL-NEXT:  .LBB4_1: ; =>This Inner Loop Header: Depth=1
+; GFX1064GISEL-NEXT:  .LBB5_1: ; =>This Inner Loop Header: Depth=1
 ; GFX1064GISEL-NEXT:    s_ff1_i32_b64 s10, s[4:5]
 ; GFX1064GISEL-NEXT:    v_readlane_b32 s8, v2, s10
 ; GFX1064GISEL-NEXT:    v_readlane_b32 s9, v3, s10
@@ -1275,7 +1734,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %in) {
 ; GFX1064GISEL-NEXT:    v_min_f64 v[4:5], s[8:9], s[6:7]
 ; GFX1064GISEL-NEXT:    v_readfirstlane_b32 s6, v4
 ; GFX1064GISEL-NEXT:    v_readfirstlane_b32 s7, v5
-; GFX1064GISEL-NEXT:    s_cbranch_scc1 .LBB4_1
+; GFX1064GISEL-NEXT:    s_cbranch_scc1 .LBB5_1
 ; GFX1064GISEL-NEXT:  ; %bb.2:
 ; GFX1064GISEL-NEXT:    v_mov_b32_e32 v2, s6
 ; GFX1064GISEL-NEXT:    v_mov_b32_e32 v3, s7
@@ -1288,7 +1747,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %in) {
 ; GFX1032DAGISEL-NEXT:    s_mov_b32 s4, 0
 ; GFX1032DAGISEL-NEXT:    s_mov_b32 s5, 0x7ff80000
 ; GFX1032DAGISEL-NEXT:    s_mov_b32 s6, exec_lo
-; GFX1032DAGISEL-NEXT:  .LBB4_1: ; =>This Inner Loop Header: Depth=1
+; GFX1032DAGISEL-NEXT:  .LBB5_1: ; =>This Inner Loop Header: Depth=1
 ; GFX1032DAGISEL-NEXT:    s_ff1_i32_b32 s7, s6
 ; GFX1032DAGISEL-NEXT:    v_readlane_b32 s8, v2, s7
 ; GFX1032DAGISEL-NEXT:    v_readlane_b32 s9, v3, s7
@@ -1297,7 +1756,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %in) {
 ; GFX1032DAGISEL-NEXT:    v_min_f64 v[4:5], s[8:9], s[4:5]
 ; GFX1032DAGISEL-NEXT:    v_readfirstlane_b32 s4, v4
 ; GFX1032DAGISEL-NEXT:    v_readfirstlane_b32 s5, v5
-; GFX1032DAGISEL-NEXT:    s_cbranch_scc1 .LBB4_1
+; GFX1032DAGISEL-NEXT:    s_cbranch_scc1 .LBB5_1
 ; GFX1032DAGISEL-NEXT:  ; %bb.2:
 ; GFX1032DAGISEL-NEXT:    v_mov_b32_e32 v2, s4
 ; GFX1032DAGISEL-NEXT:    v_mov_b32_e32 v3, s5
@@ -1310,7 +1769,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %in) {
 ; GFX1032GISEL-NEXT:    s_mov_b32 s4, 0
 ; GFX1032GISEL-NEXT:    s_mov_b32 s5, 0x7ff80000
 ; GFX1032GISEL-NEXT:    s_mov_b32 s6, exec_lo
-; GFX1032GISEL-NEXT:  .LBB4_1: ; =>This Inner Loop Header: Depth=1
+; GFX1032GISEL-NEXT:  .LBB5_1: ; =>This Inner Loop Header: Depth=1
 ; GFX1032GISEL-NEXT:    s_ff1_i32_b32 s7, s6
 ; GFX1032GISEL-NEXT:    v_readlane_b32 s8, v2, s7
 ; GFX1032GISEL-NEXT:    v_readlane_b32 s9, v3, s7
@@ -1319,7 +1778,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %in) {
 ; GFX1032GISEL-NEXT:    v_min_f64 v[4:5], s[8:9], s[4:5]
 ; GFX1032GISEL-NEXT:    v_readfirstlane_b32 s4, v4
 ; GFX1032GISEL-NEXT:    v_readfirstlane_b32 s5, v5
-; GFX1032GISEL-NEXT:    s_cbranch_scc1 .LBB4_1
+; GFX1032GISEL-NEXT:    s_cbranch_scc1 .LBB5_1
 ; GFX1032GISEL-NEXT:  ; %bb.2:
 ; GFX1032GISEL-NEXT:    v_mov_b32_e32 v2, s4
 ; GFX1032GISEL-NEXT:    v_mov_b32_e32 v3, s5
@@ -1332,7 +1791,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %in) {
 ; GFX1164DAGISEL-NEXT:    s_mov_b32 s2, 0
 ; GFX1164DAGISEL-NEXT:    s_mov_b32 s3, 0x7ff80000
 ; GFX1164DAGISEL-NEXT:    s_mov_b64 s[0:1], exec
-; GFX1164DAGISEL-NEXT:  .LBB4_1: ; =>This Inner Loop Header: Depth=1
+; GFX1164DAGISEL-NEXT:  .LBB5_1: ; =>This Inner Loop Header: Depth=1
 ; GFX1164DAGISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
 ; GFX1164DAGISEL-NEXT:    s_ctz_i32_b64 s6, s[0:1]
 ; GFX1164DAGISEL-NEXT:    v_readlane_b32 s4, v2, s6
@@ -1344,7 +1803,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %in) {
 ; GFX1164DAGISEL-NEXT:    v_readfirstlane_b32 s2, v4
 ; GFX1164DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2)
 ; GFX1164DAGISEL-NEXT:    v_readfirstlane_b32 s3, v5
-; GFX1164DAGISEL-NEXT:    s_cbranch_scc1 .LBB4_1
+; GFX1164DAGISEL-NEXT:    s_cbranch_scc1 .LBB5_1
 ; GFX1164DAGISEL-NEXT:  ; %bb.2:
 ; GFX1164DAGISEL-NEXT:    v_mov_b32_e32 v2, s2
 ; GFX1164DAGISEL-NEXT:    v_mov_b32_e32 v3, s3
@@ -1357,7 +1816,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %in) {
 ; GFX1164GISEL-NEXT:    s_mov_b32 s2, 0
 ; GFX1164GISEL-NEXT:    s_mov_b32 s3, 0x7ff80000
 ; GFX1164GISEL-NEXT:    s_mov_b64 s[0:1], exec
-; GFX1164GISEL-NEXT:  .LBB4_1: ; =>This Inner Loop Header: Depth=1
+; GFX1164GISEL-NEXT:  .LBB5_1: ; =>This Inner Loop Header: Depth=1
 ; GFX1164GISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
 ; GFX1164GISEL-NEXT:    s_ctz_i32_b64 s6, s[0:1]
 ; GFX1164GISEL-NEXT:    v_readlane_b32 s4, v2, s6
@@ -1369,7 +1828,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %in) {
 ; GFX1164GISEL-NEXT:    v_readfirstlane_b32 s2, v4
 ; GFX1164GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2)
 ; GFX1164GISEL-NEXT:    v_readfirstlane_b32 s3, v5
-; GFX1164GISEL-NEXT:    s_cbranch_scc1 .LBB4_1
+; GFX1164GISEL-NEXT:    s_cbranch_scc1 .LBB5_1
 ; GFX1164GISEL-NEXT:  ; %bb.2:
 ; GFX1164GISEL-NEXT:    v_mov_b32_e32 v2, s2
 ; GFX1164GISEL-NEXT:    v_mov_b32_e32 v3, s3
@@ -1382,7 +1841,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %in) {
 ; GFX1132DAGISEL-NEXT:    s_mov_b32 s0, 0
 ; GFX1132DAGISEL-NEXT:    s_mov_b32 s1, 0x7ff80000
 ; GFX1132DAGISEL-NEXT:    s_mov_b32 s2, exec_lo
-; GFX1132DAGISEL-NEXT:  .LBB4_1: ; =>This Inner Loop Header: Depth=1
+; GFX1132DAGISEL-NEXT:  .LBB5_1: ; =>This Inner Loop Header: Depth=1
 ; GFX1132DAGISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
 ; GFX1132DAGISEL-NEXT:    s_ctz_i32_b32 s3, s2
 ; GFX1132DAGISEL-NEXT:    v_readlane_b32 s4, v2, s3
@@ -1394,7 +1853,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %in) {
 ; GFX1132DAGISEL-NEXT:    v_readfirstlane_b32 s0, v4
 ; GFX1132DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2)
 ; GFX1132DAGISEL-NEXT:    v_readfirstlane_b32 s1, v5
-; GFX1132DAGISEL-NEXT:    s_cbranch_scc1 .LBB4_1
+; GFX1132DAGISEL-NEXT:    s_cbranch_scc1 .LBB5_1
 ; GFX1132DAGISEL-NEXT:  ; %bb.2:
 ; GFX1132DAGISEL-NEXT:    v_dual_mov_b32 v3, s1 :: v_dual_mov_b32 v2, s0
 ; GFX1132DAGISEL-NEXT:    global_store_b64 v[0:1], v[2:3], off
@@ -1406,7 +1865,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %in) {
 ; GFX1132GISEL-NEXT:    s_mov_b32 s0, 0
 ; GFX1132GISEL-NEXT:    s_mov_b32 s1, 0x7ff80000
 ; GFX1132GISEL-NEXT:    s_mov_b32 s2, exec_lo
-; GFX1132GISEL-NEXT:  .LBB4_1: ; =>This Inner Loop Header: Depth=1
+; GFX1132GISEL-NEXT:  .LBB5_1: ; =>This Inner Loop Header: Depth=1
 ; GFX1132GISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
 ; GFX1132GISEL-NEXT:    s_ctz_i32_b32 s3, s2
 ; GFX1132GISEL-NEXT:    v_readlane_b32 s4, v2, s3
@@ -1418,7 +1877,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %in) {
 ; GFX1132GISEL-NEXT:    v_readfirstlane_b32 s0, v4
 ; GFX1132GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2)
 ; GFX1132GISEL-NEXT:    v_readfirstlane_b32 s1, v5
-; GFX1132GISEL-NEXT:    s_cbranch_scc1 .LBB4_1
+; GFX1132GISEL-NEXT:    s_cbranch_scc1 .LBB5_1
 ; GFX1132GISEL-NEXT:  ; %bb.2:
 ; GFX1132GISEL-NEXT:    v_dual_mov_b32 v3, s1 :: v_dual_mov_b32 v2, s0
 ; GFX1132GISEL-NEXT:    global_store_b64 v[0:1], v[2:3], off
@@ -1434,7 +1893,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %in) {
 ; GFX12DAGISEL-NEXT:    s_mov_b32 s0, 0
 ; GFX12DAGISEL-NEXT:    s_mov_b32 s1, 0x7ff80000
 ; GFX12DAGISEL-NEXT:    s_mov_b32 s2, exec_lo
-; GFX12DAGISEL-NEXT:  .LBB4_1: ; =>This Inner Loop Header: Depth=1
+; GFX12DAGISEL-NEXT:  .LBB5_1: ; =>This Inner Loop Header: Depth=1
 ; GFX12DAGISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
 ; GFX12DAGISEL-NEXT:    s_ctz_i32_b32 s3, s2
 ; GFX12DAGISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
@@ -1447,7 +1906,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %in) {
 ; GFX12DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_2)
 ; GFX12DAGISEL-NEXT:    v_readfirstlane_b32 s0, v4
 ; GFX12DAGISEL-NEXT:    v_readfirstlane_b32 s1, v5
-; GFX12DAGISEL-NEXT:    s_cbranch_scc1 .LBB4_1
+; GFX12DAGISEL-NEXT:    s_cbranch_scc1 .LBB5_1
 ; GFX12DAGISEL-NEXT:  ; %bb.2:
 ; GFX12DAGISEL-NEXT:    s_wait_alu depctr_va_sdst(0)
 ; GFX12DAGISEL-NEXT:    v_dual_mov_b32 v3, s1 :: v_dual_mov_b32 v2, s0
@@ -1468,12 +1927,12 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX8DAGISEL-NEXT:    ; implicit-def: $vgpr6_vgpr7
 ; GFX8DAGISEL-NEXT:    s_and_saveexec_b64 s[4:5], vcc
 ; GFX8DAGISEL-NEXT:    s_xor_b64 s[4:5], exec, s[4:5]
-; GFX8DAGISEL-NEXT:    s_cbranch_execz .LBB5_4
+; GFX8DAGISEL-NEXT:    s_cbranch_execz .LBB6_4
 ; GFX8DAGISEL-NEXT:  ; %bb.1: ; %else
 ; GFX8DAGISEL-NEXT:    s_mov_b32 s8, 0
 ; GFX8DAGISEL-NEXT:    s_mov_b32 s9, 0x7ff80000
 ; GFX8DAGISEL-NEXT:    s_mov_b64 s[6:7], exec
-; GFX8DAGISEL-NEXT:  .LBB5_2: ; =>This Inner Loop Header: Depth=1
+; GFX8DAGISEL-NEXT:  .LBB6_2: ; =>This Inner Loop Header: Depth=1
 ; GFX8DAGISEL-NEXT:    s_ff1_i32_b64 s12, s[6:7]
 ; GFX8DAGISEL-NEXT:    v_mov_b32_e32 v4, s8
 ; GFX8DAGISEL-NEXT:    v_readlane_b32 s10, v2, s12
@@ -1484,20 +1943,20 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX8DAGISEL-NEXT:    s_cmp_lg_u64 s[6:7], 0
 ; GFX8DAGISEL-NEXT:    v_readfirstlane_b32 s8, v4
 ; GFX8DAGISEL-NEXT:    v_readfirstlane_b32 s9, v5
-; GFX8DAGISEL-NEXT:    s_cbranch_scc1 .LBB5_2
+; GFX8DAGISEL-NEXT:    s_cbranch_scc1 .LBB6_2
 ; GFX8DAGISEL-NEXT:  ; %bb.3:
 ; GFX8DAGISEL-NEXT:    v_mov_b32_e32 v6, s8
 ; GFX8DAGISEL-NEXT:    v_mov_b32_e32 v7, s9
 ; GFX8DAGISEL-NEXT:    ; implicit-def: $vgpr4
 ; GFX8DAGISEL-NEXT:    ; implicit-def: $vgpr5
-; GFX8DAGISEL-NEXT:  .LBB5_4: ; %Flow
+; GFX8DAGISEL-NEXT:  .LBB6_4: ; %Flow
 ; GFX8DAGISEL-NEXT:    s_andn2_saveexec_b64 s[4:5], s[4:5]
-; GFX8DAGISEL-NEXT:    s_cbranch_execz .LBB5_8
+; GFX8DAGISEL-NEXT:    s_cbranch_execz .LBB6_8
 ; GFX8DAGISEL-NEXT:  ; %bb.5: ; %if
 ; GFX8DAGISEL-NEXT:    s_mov_b32 s8, 0
 ; GFX8DAGISEL-NEXT:    s_mov_b32 s9, 0x7ff80000
 ; GFX8DAGISEL-NEXT:    s_mov_b64 s[6:7], exec
-; GFX8DAGISEL-NEXT:  .LBB5_6: ; =>This Inner Loop Header: Depth=1
+; GFX8DAGISEL-NEXT:  .LBB6_6: ; =>This Inner Loop Header: Depth=1
 ; GFX8DAGISEL-NEXT:    s_ff1_i32_b64 s12, s[6:7]
 ; GFX8DAGISEL-NEXT:    v_mov_b32_e32 v2, s8
 ; GFX8DAGISEL-NEXT:    v_readlane_b32 s10, v4, s12
@@ -1508,11 +1967,11 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX8DAGISEL-NEXT:    s_cmp_lg_u64 s[6:7], 0
 ; GFX8DAGISEL-NEXT:    v_readfirstlane_b32 s8, v2
 ; GFX8DAGISEL-NEXT:    v_readfirstlane_b32 s9, v3
-; GFX8DAGISEL-NEXT:    s_cbranch_scc1 .LBB5_6
+; GFX8DAGISEL-NEXT:    s_cbranch_scc1 .LBB6_6
 ; GFX8DAGISEL-NEXT:  ; %bb.7:
 ; GFX8DAGISEL-NEXT:    v_mov_b32_e32 v6, s8
 ; GFX8DAGISEL-NEXT:    v_mov_b32_e32 v7, s9
-; GFX8DAGISEL-NEXT:  .LBB5_8: ; %endif
+; GFX8DAGISEL-NEXT:  .LBB6_8: ; %endif
 ; GFX8DAGISEL-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; GFX8DAGISEL-NEXT:    flat_store_dwordx2 v[0:1], v[6:7]
 ; GFX8DAGISEL-NEXT:    s_waitcnt vmcnt(0)
@@ -1526,12 +1985,12 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX8GISEL-NEXT:    ; implicit-def: $sgpr4_sgpr5
 ; GFX8GISEL-NEXT:    s_and_saveexec_b64 s[6:7], vcc
 ; GFX8GISEL-NEXT:    s_xor_b64 s[6:7], exec, s[6:7]
-; GFX8GISEL-NEXT:    s_cbranch_execz .LBB5_3
+; GFX8GISEL-NEXT:    s_cbranch_execz .LBB6_3
 ; GFX8GISEL-NEXT:  ; %bb.1: ; %else
 ; GFX8GISEL-NEXT:    s_mov_b32 s4, 0
 ; GFX8GISEL-NEXT:    s_mov_b32 s5, 0x7ff80000
 ; GFX8GISEL-NEXT:    s_mov_b64 s[8:9], exec
-; GFX8GISEL-NEXT:  .LBB5_2: ; =>This Inner Loop Header: Depth=1
+; GFX8GISEL-NEXT:  .LBB6_2: ; =>This Inner Loop Header: Depth=1
 ; GFX8GISEL-NEXT:    s_ff1_i32_b64 s12, s[8:9]
 ; GFX8GISEL-NEXT:    v_mov_b32_e32 v4, s4
 ; GFX8GISEL-NEXT:    v_readlane_b32 s10, v2, s12
@@ -1544,15 +2003,15 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX8GISEL-NEXT:    v_readfirstlane_b32 s5, v5
 ; GFX8GISEL-NEXT:    ; implicit-def: $vgpr4
 ; GFX8GISEL-NEXT:    ; implicit-def: $vgpr5
-; GFX8GISEL-NEXT:    s_cbranch_scc1 .LBB5_2
-; GFX8GISEL-NEXT:  .LBB5_3: ; %Flow
+; GFX8GISEL-NEXT:    s_cbranch_scc1 .LBB6_2
+; GFX8GISEL-NEXT:  .LBB6_3: ; %Flow
 ; GFX8GISEL-NEXT:    s_andn2_saveexec_b64 s[6:7], s[6:7]
-; GFX8GISEL-NEXT:    s_cbranch_execz .LBB5_6
+; GFX8GISEL-NEXT:    s_cbranch_execz .LBB6_6
 ; GFX8GISEL-NEXT:  ; %bb.4: ; %if
 ; GFX8GISEL-NEXT:    s_mov_b32 s4, 0
 ; GFX8GISEL-NEXT:    s_mov_b32 s5, 0x7ff80000
 ; GFX8GISEL-NEXT:    s_mov_b64 s[8:9], exec
-; GFX8GISEL-NEXT:  .LBB5_5: ; =>This Inner Loop Header: Depth=1
+; GFX8GISEL-NEXT:  .LBB6_5: ; =>This Inner Loop Header: Depth=1
 ; GFX8GISEL-NEXT:    s_ff1_i32_b64 s12, s[8:9]
 ; GFX8GISEL-NEXT:    v_mov_b32_e32 v2, s4
 ; GFX8GISEL-NEXT:    v_readlane_b32 s10, v4, s12
@@ -1563,8 +2022,8 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX8GISEL-NEXT:    s_cmp_lg_u64 s[8:9], 0
 ; GFX8GISEL-NEXT:    v_readfirstlane_b32 s4, v2
 ; GFX8GISEL-NEXT:    v_readfirstlane_b32 s5, v3
-; GFX8GISEL-NEXT:    s_cbranch_scc1 .LBB5_5
-; GFX8GISEL-NEXT:  .LBB5_6: ; %endif
+; GFX8GISEL-NEXT:    s_cbranch_scc1 .LBB6_5
+; GFX8GISEL-NEXT:  .LBB6_6: ; %endif
 ; GFX8GISEL-NEXT:    s_or_b64 exec, exec, s[6:7]
 ; GFX8GISEL-NEXT:    v_mov_b32_e32 v2, s4
 ; GFX8GISEL-NEXT:    v_mov_b32_e32 v3, s5
@@ -1580,12 +2039,12 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX9DAGISEL-NEXT:    ; implicit-def: $vgpr6_vgpr7
 ; GFX9DAGISEL-NEXT:    s_and_saveexec_b64 s[4:5], vcc
 ; GFX9DAGISEL-NEXT:    s_xor_b64 s[4:5], exec, s[4:5]
-; GFX9DAGISEL-NEXT:    s_cbranch_execz .LBB5_4
+; GFX9DAGISEL-NEXT:    s_cbranch_execz .LBB6_4
 ; GFX9DAGISEL-NEXT:  ; %bb.1: ; %else
 ; GFX9DAGISEL-NEXT:    s_mov_b32 s8, 0
 ; GFX9DAGISEL-NEXT:    s_mov_b32 s9, 0x7ff80000
 ; GFX9DAGISEL-NEXT:    s_mov_b64 s[6:7], exec
-; GFX9DAGISEL-NEXT:  .LBB5_2: ; =>This Inner Loop Header: Depth=1
+; GFX9DAGISEL-NEXT:  .LBB6_2: ; =>This Inner Loop Header: Depth=1
 ; GFX9DAGISEL-NEXT:    s_ff1_i32_b64 s12, s[6:7]
 ; GFX9DAGISEL-NEXT:    v_mov_b32_e32 v4, s8
 ; GFX9DAGISEL-NEXT:    v_readlane_b32 s10, v2, s12
@@ -1596,20 +2055,20 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX9DAGISEL-NEXT:    s_cmp_lg_u64 s[6:7], 0
 ; GFX9DAGISEL-NEXT:    v_readfirstlane_b32 s8, v4
 ; GFX9DAGISEL-NEXT:    v_readfirstlane_b32 s9, v5
-; GFX9DAGISEL-NEXT:    s_cbranch_scc1 .LBB5_2
+; GFX9DAGISEL-NEXT:    s_cbranch_scc1 .LBB6_2
 ; GFX9DAGISEL-NEXT:  ; %bb.3:
 ; GFX9DAGISEL-NEXT:    v_mov_b32_e32 v6, s8
 ; GFX9DAGISEL-NEXT:    v_mov_b32_e32 v7, s9
 ; GFX9DAGISEL-NEXT:    ; implicit-def: $vgpr4
 ; GFX9DAGISEL-NEXT:    ; implicit-def: $vgpr5
-; GFX9DAGISEL-NEXT:  .LBB5_4: ; %Flow
+; GFX9DAGISEL-NEXT:  .LBB6_4: ; %Flow
 ; GFX9DAGISEL-NEXT:    s_andn2_saveexec_b64 s[4:5], s[4:5]
-; GFX9DAGISEL-NEXT:    s_cbranch_execz .LBB5_8
+; GFX9DAGISEL-NEXT:    s_cbranch_execz .LBB6_8
 ; GFX9DAGISEL-NEXT:  ; %bb.5: ; %if
 ; GFX9DAGISEL-NEXT:    s_mov_b32 s8, 0
 ; GFX9DAGISEL-NEXT:    s_mov_b32 s9, 0x7ff80000
 ; GFX9DAGISEL-NEXT:    s_mov_b64 s[6:7], exec
-; GFX9DAGISEL-NEXT:  .LBB5_6: ; =>This Inner Loop Header: Depth=1
+; GFX9DAGISEL-NEXT:  .LBB6_6: ; =>This Inner Loop Header: Depth=1
 ; GFX9DAGISEL-NEXT:    s_ff1_i32_b64 s12, s[6:7]
 ; GFX9DAGISEL-NEXT:    v_mov_b32_e32 v2, s8
 ; GFX9DAGISEL-NEXT:    v_readlane_b32 s10, v4, s12
@@ -1620,11 +2079,11 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX9DAGISEL-NEXT:    s_cmp_lg_u64 s[6:7], 0
 ; GFX9DAGISEL-NEXT:    v_readfirstlane_b32 s8, v2
 ; GFX9DAGISEL-NEXT:    v_readfirstlane_b32 s9, v3
-; GFX9DAGISEL-NEXT:    s_cbranch_scc1 .LBB5_6
+; GFX9DAGISEL-NEXT:    s_cbranch_scc1 .LBB6_6
 ; GFX9DAGISEL-NEXT:  ; %bb.7:
 ; GFX9DAGISEL-NEXT:    v_mov_b32_e32 v6, s8
 ; GFX9DAGISEL-NEXT:    v_mov_b32_e32 v7, s9
-; GFX9DAGISEL-NEXT:  .LBB5_8: ; %endif
+; GFX9DAGISEL-NEXT:  .LBB6_8: ; %endif
 ; GFX9DAGISEL-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; GFX9DAGISEL-NEXT:    global_store_dwordx2 v[0:1], v[6:7], off
 ; GFX9DAGISEL-NEXT:    s_waitcnt vmcnt(0)
@@ -1638,12 +2097,12 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX9GISEL-NEXT:    ; implicit-def: $sgpr4_sgpr5
 ; GFX9GISEL-NEXT:    s_and_saveexec_b64 s[6:7], vcc
 ; GFX9GISEL-NEXT:    s_xor_b64 s[6:7], exec, s[6:7]
-; GFX9GISEL-NEXT:    s_cbranch_execz .LBB5_3
+; GFX9GISEL-NEXT:    s_cbranch_execz .LBB6_3
 ; GFX9GISEL-NEXT:  ; %bb.1: ; %else
 ; GFX9GISEL-NEXT:    s_mov_b32 s4, 0
 ; GFX9GISEL-NEXT:    s_mov_b32 s5, 0x7ff80000
 ; GFX9GISEL-NEXT:    s_mov_b64 s[8:9], exec
-; GFX9GISEL-NEXT:  .LBB5_2: ; =>This Inner Loop Header: Depth=1
+; GFX9GISEL-NEXT:  .LBB6_2: ; =>This Inner Loop Header: Depth=1
 ; GFX9GISEL-NEXT:    s_ff1_i32_b64 s12, s[8:9]
 ; GFX9GISEL-NEXT:    v_mov_b32_e32 v4, s4
 ; GFX9GISEL-NEXT:    v_readlane_b32 s10, v2, s12
@@ -1656,15 +2115,15 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX9GISEL-NEXT:    v_readfirstlane_b32 s5, v5
 ; GFX9GISEL-NEXT:    ; implicit-def: $vgpr4
 ; GFX9GISEL-NEXT:    ; implicit-def: $vgpr5
-; GFX9GISEL-NEXT:    s_cbranch_scc1 .LBB5_2
-; GFX9GISEL-NEXT:  .LBB5_3: ; %Flow
+; GFX9GISEL-NEXT:    s_cbranch_scc1 .LBB6_2
+; GFX9GISEL-NEXT:  .LBB6_3: ; %Flow
 ; GFX9GISEL-NEXT:    s_andn2_saveexec_b64 s[6:7], s[6:7]
-; GFX9GISEL-NEXT:    s_cbranch_execz .LBB5_6
+; GFX9GISEL-NEXT:    s_cbranch_execz .LBB6_6
 ; GFX9GISEL-NEXT:  ; %bb.4: ; %if
 ; GFX9GISEL-NEXT:    s_mov_b32 s4, 0
 ; GFX9GISEL-NEXT:    s_mov_b32 s5, 0x7ff80000
 ; GFX9GISEL-NEXT:    s_mov_b64 s[8:9], exec
-; GFX9GISEL-NEXT:  .LBB5_5: ; =>This Inner Loop Header: Depth=1
+; GFX9GISEL-NEXT:  .LBB6_5: ; =>This Inner Loop Header: Depth=1
 ; GFX9GISEL-NEXT:    s_ff1_i32_b64 s12, s[8:9]
 ; GFX9GISEL-NEXT:    v_mov_b32_e32 v2, s4
 ; GFX9GISEL-NEXT:    v_readlane_b32 s10, v4, s12
@@ -1675,8 +2134,8 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX9GISEL-NEXT:    s_cmp_lg_u64 s[8:9], 0
 ; GFX9GISEL-NEXT:    v_readfirstlane_b32 s4, v2
 ; GFX9GISEL-NEXT:    v_readfirstlane_b32 s5, v3
-; GFX9GISEL-NEXT:    s_cbranch_scc1 .LBB5_5
-; GFX9GISEL-NEXT:  .LBB5_6: ; %endif
+; GFX9GISEL-NEXT:    s_cbranch_scc1 .LBB6_5
+; GFX9GISEL-NEXT:  .LBB6_6: ; %endif
 ; GFX9GISEL-NEXT:    s_or_b64 exec, exec, s[6:7]
 ; GFX9GISEL-NEXT:    v_mov_b32_e32 v2, s4
 ; GFX9GISEL-NEXT:    v_mov_b32_e32 v3, s5
@@ -1692,12 +2151,12 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX1064DAGISEL-NEXT:    ; implicit-def: $vgpr6_vgpr7
 ; GFX1064DAGISEL-NEXT:    s_and_saveexec_b64 s[4:5], vcc
 ; GFX1064DAGISEL-NEXT:    s_xor_b64 s[4:5], exec, s[4:5]
-; GFX1064DAGISEL-NEXT:    s_cbranch_execz .LBB5_4
+; GFX1064DAGISEL-NEXT:    s_cbranch_execz .LBB6_4
 ; GFX1064DAGISEL-NEXT:  ; %bb.1: ; %else
 ; GFX1064DAGISEL-NEXT:    s_mov_b32 s8, 0
 ; GFX1064DAGISEL-NEXT:    s_mov_b32 s9, 0x7ff80000
 ; GFX1064DAGISEL-NEXT:    s_mov_b64 s[6:7], exec
-; GFX1064DAGISEL-NEXT:  .LBB5_2: ; =>This Inner Loop Header: Depth=1
+; GFX1064DAGISEL-NEXT:  .LBB6_2: ; =>This Inner Loop Header: Depth=1
 ; GFX1064DAGISEL-NEXT:    s_ff1_i32_b64 s12, s[6:7]
 ; GFX1064DAGISEL-NEXT:    v_readlane_b32 s10, v2, s12
 ; GFX1064DAGISEL-NEXT:    v_readlane_b32 s11, v3, s12
@@ -1706,20 +2165,20 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX1064DAGISEL-NEXT:    v_min_f64 v[4:5], s[10:11], s[8:9]
 ; GFX1064DAGISEL-NEXT:    v_readfirstlane_b32 s8, v4
 ; GFX1064DAGISEL-NEXT:    v_readfirstlane_b32 s9, v5
-; GFX1064DAGISEL-NEXT:    s_cbranch_scc1 .LBB5_2
+; GFX1064DAGISEL-NEXT:    s_cbranch_scc1 .LBB6_2
 ; GFX1064DAGISEL-NEXT:  ; %bb.3:
 ; GFX1064DAGISEL-NEXT:    v_mov_b32_e32 v6, s8
 ; GFX1064DAGISEL-NEXT:    v_mov_b32_e32 v7, s9
 ; GFX1064DAGISEL-NEXT:    ; implicit-def: $vgpr4
 ; GFX1064DAGISEL-NEXT:    ; implicit-def: $vgpr5
-; GFX1064DAGISEL-NEXT:  .LBB5_4: ; %Flow
+; GFX1064DAGISEL-NEXT:  .LBB6_4: ; %Flow
 ; GFX1064DAGISEL-NEXT:    s_andn2_saveexec_b64 s[4:5], s[4:5]
-; GFX1064DAGISEL-NEXT:    s_cbranch_execz .LBB5_8
+; GFX1064DAGISEL-NEXT:    s_cbranch_execz .LBB6_8
 ; GFX1064DAGISEL-NEXT:  ; %bb.5: ; %if
 ; GFX1064DAGISEL-NEXT:    s_mov_b32 s8, 0
 ; GFX1064DAGISEL-NEXT:    s_mov_b32 s9, 0x7ff80000
 ; GFX1064DAGISEL-NEXT:    s_mov_b64 s[6:7], exec
-; GFX1064DAGISEL-NEXT:  .LBB5_6: ; =>This Inner Loop Header: Depth=1
+; GFX1064DAGISEL-NEXT:  .LBB6_6: ; =>This Inner Loop Header: Depth=1
 ; GFX1064DAGISEL-NEXT:    s_ff1_i32_b64 s12, s[6:7]
 ; GFX1064DAGISEL-NEXT:    v_readlane_b32 s10, v4, s12
 ; GFX1064DAGISEL-NEXT:    v_readlane_b32 s11, v5, s12
@@ -1728,11 +2187,11 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX1064DAGISEL-NEXT:    v_min_f64 v[2:3], s[10:11], s[8:9]
 ; GFX1064DAGISEL-NEXT:    v_readfirstlane_b32 s8, v2
 ; GFX1064DAGISEL-NEXT:    v_readfirstlane_b32 s9, v3
-; GFX1064DAGISEL-NEXT:    s_cbranch_scc1 .LBB5_6
+; GFX1064DAGISEL-NEXT:    s_cbranch_scc1 .LBB6_6
 ; GFX1064DAGISEL-NEXT:  ; %bb.7:
 ; GFX1064DAGISEL-NEXT:    v_mov_b32_e32 v6, s8
 ; GFX1064DAGISEL-NEXT:    v_mov_b32_e32 v7, s9
-; GFX1064DAGISEL-NEXT:  .LBB5_8: ; %endif
+; GFX1064DAGISEL-NEXT:  .LBB6_8: ; %endif
 ; GFX1064DAGISEL-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; GFX1064DAGISEL-NEXT:    global_store_dwordx2 v[0:1], v[6:7], off
 ; GFX1064DAGISEL-NEXT:    s_setpc_b64 s[30:31]
@@ -1745,12 +2204,12 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX1064GISEL-NEXT:    v_cmp_le_u32_e32 vcc, 16, v6
 ; GFX1064GISEL-NEXT:    s_and_saveexec_b64 s[6:7], vcc
 ; GFX1064GISEL-NEXT:    s_xor_b64 s[6:7], exec, s[6:7]
-; GFX1064GISEL-NEXT:    s_cbranch_execz .LBB5_3
+; GFX1064GISEL-NEXT:    s_cbranch_execz .LBB6_3
 ; GFX1064GISEL-NEXT:  ; %bb.1: ; %else
 ; GFX1064GISEL-NEXT:    s_mov_b32 s4, 0
 ; GFX1064GISEL-NEXT:    s_mov_b32 s5, 0x7ff80000
 ; GFX1064GISEL-NEXT:    s_mov_b64 s[8:9], exec
-; GFX1064GISEL-NEXT:  .LBB5_2: ; =>This Inner Loop Header: Depth=1
+; GFX1064GISEL-NEXT:  .LBB6_2: ; =>This Inner Loop Header: Depth=1
 ; GFX1064GISEL-NEXT:    s_ff1_i32_b64 s12, s[8:9]
 ; GFX1064GISEL-NEXT:    v_readlane_b32 s10, v2, s12
 ; GFX1064GISEL-NEXT:    v_readlane_b32 s11, v3, s12
@@ -1761,15 +2220,15 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX1064GISEL-NEXT:    v_readfirstlane_b32 s5, v5
 ; GFX1064GISEL-NEXT:    ; implicit-def: $vgpr4
 ; GFX1064GISEL-NEXT:    ; implicit-def: $vgpr5
-; GFX1064GISEL-NEXT:    s_cbranch_scc1 .LBB5_2
-; GFX1064GISEL-NEXT:  .LBB5_3: ; %Flow
+; GFX1064GISEL-NEXT:    s_cbranch_scc1 .LBB6_2
+; GFX1064GISEL-NEXT:  .LBB6_3: ; %Flow
 ; GFX1064GISEL-NEXT:    s_andn2_saveexec_b64 s[6:7], s[6:7]
-; GFX1064GISEL-NEXT:    s_cbranch_execz .LBB5_6
+; GFX1064GISEL-NEXT:    s_cbranch_execz .LBB6_6
 ; GFX1064GISEL-NEXT:  ; %bb.4: ; %if
 ; GFX1064GISEL-NEXT:    s_mov_b32 s4, 0
 ; GFX1064GISEL-NEXT:    s_mov_b32 s5, 0x7ff80000
 ; GFX1064GISEL-NEXT:    s_mov_b64 s[8:9], exec
-; GFX1064GISEL-NEXT:  .LBB5_5: ; =>This Inner Loop Header: Depth=1
+; GFX1064GISEL-NEXT:  .LBB6_5: ; =>This Inner Loop Header: Depth=1
 ; GFX1064GISEL-NEXT:    s_ff1_i32_b64 s12, s[8:9]
 ; GFX1064GISEL-NEXT:    v_readlane_b32 s10, v4, s12
 ; GFX1064GISEL-NEXT:    v_readlane_b32 s11, v5, s12
@@ -1778,8 +2237,8 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX1064GISEL-NEXT:    v_min_f64 v[2:3], s[10:11], s[4:5]
 ; GFX1064GISEL-NEXT:    v_readfirstlane_b32 s4, v2
 ; GFX1064GISEL-NEXT:    v_readfirstlane_b32 s5, v3
-; GFX1064GISEL-NEXT:    s_cbranch_scc1 .LBB5_5
-; GFX1064GISEL-NEXT:  .LBB5_6: ; %endif
+; GFX1064GISEL-NEXT:    s_cbranch_scc1 .LBB6_5
+; GFX1064GISEL-NEXT:  .LBB6_6: ; %endif
 ; GFX1064GISEL-NEXT:    s_or_b64 exec, exec, s[6:7]
 ; GFX1064GISEL-NEXT:    v_mov_b32_e32 v2, s4
 ; GFX1064GISEL-NEXT:    v_mov_b32_e32 v3, s5
@@ -1794,12 +2253,12 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX1032DAGISEL-NEXT:    ; implicit-def: $vgpr6_vgpr7
 ; GFX1032DAGISEL-NEXT:    s_and_saveexec_b32 s4, vcc_lo
 ; GFX1032DAGISEL-NEXT:    s_xor_b32 s6, exec_lo, s4
-; GFX1032DAGISEL-NEXT:    s_cbranch_execz .LBB5_4
+; GFX1032DAGISEL-NEXT:    s_cbranch_execz .LBB6_4
 ; GFX1032DAGISEL-NEXT:  ; %bb.1: ; %else
 ; GFX1032DAGISEL-NEXT:    s_mov_b32 s4, 0
 ; GFX1032DAGISEL-NEXT:    s_mov_b32 s5, 0x7ff80000
 ; GFX1032DAGISEL-NEXT:    s_mov_b32 s7, exec_lo
-; GFX1032DAGISEL-NEXT:  .LBB5_2: ; =>This Inner Loop Header: Depth=1
+; GFX1032DAGISEL-NEXT:  .LBB6_2: ; =>This Inner Loop Header: Depth=1
 ; GFX1032DAGISEL-NEXT:    s_ff1_i32_b32 s10, s7
 ; GFX1032DAGISEL-NEXT:    v_readlane_b32 s8, v2, s10
 ; GFX1032DAGISEL-NEXT:    v_readlane_b32 s9, v3, s10
@@ -1808,20 +2267,20 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX1032DAGISEL-NEXT:    v_min_f64 v[4:5], s[8:9], s[4:5]
 ; GFX1032DAGISEL-NEXT:    v_readfirstlane_b32 s4, v4
 ; GFX1032DAGISEL-NEXT:    v_readfirstlane_b32 s5, v5
-; GFX1032DAGISEL-NEXT:    s_cbranch_scc1 .LBB5_2
+; GFX1032DAGISEL-NEXT:    s_cbranch_scc1 .LBB6_2
 ; GFX1032DAGISEL-NEXT:  ; %bb.3:
 ; GFX1032DAGISEL-NEXT:    v_mov_b32_e32 v7, s5
 ; GFX1032DAGISEL-NEXT:    v_mov_b32_e32 v6, s4
 ; GFX1032DAGISEL-NEXT:    ; implicit-def: $vgpr4
 ; GFX1032DAGISEL-NEXT:    ; implicit-def: $vgpr5
-; GFX1032DAGISEL-NEXT:  .LBB5_4: ; %Flow
+; GFX1032DAGISEL-NEXT:  .LBB6_4: ; %Flow
 ; GFX1032DAGISEL-NEXT:    s_andn2_saveexec_b32 s6, s6
-; GFX1032DAGISEL-NEXT:    s_cbranch_execz .LBB5_8
+; GFX1032DAGISEL-NEXT:    s_cbranch_execz .LBB6_8
 ; GFX1032DAGISEL-NEXT:  ; %bb.5: ; %if
 ; GFX1032DAGISEL-NEXT:    s_mov_b32 s4, 0
 ; GFX1032DAGISEL-NEXT:    s_mov_b32 s5, 0x7ff80000
 ; GFX1032DAGISEL-NEXT:    s_mov_b32 s7, exec_lo
-; GFX1032DAGISEL-NEXT:  .LBB5_6: ; =>This Inner Loop Header: Depth=1
+; GFX1032DAGISEL-NEXT:  .LBB6_6: ; =>This Inner Loop Header: Depth=1
 ; GFX1032DAGISEL-NEXT:    s_ff1_i32_b32 s10, s7
 ; GFX1032DAGISEL-NEXT:    v_readlane_b32 s8, v4, s10
 ; GFX1032DAGISEL-NEXT:    v_readlane_b32 s9, v5, s10
@@ -1830,11 +2289,11 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX1032DAGISEL-NEXT:    v_min_f64 v[2:3], s[8:9], s[4:5]
 ; GFX1032DAGISEL-NEXT:    v_readfirstlane_b32 s4, v2
 ; GFX1032DAGISEL-NEXT:    v_readfirstlane_b32 s5, v3
-; GFX1032DAGISEL-NEXT:    s_cbranch_scc1 .LBB5_6
+; GFX1032DAGISEL-NEXT:    s_cbranch_scc1 .LBB6_6
 ; GFX1032DAGISEL-NEXT:  ; %bb.7:
 ; GFX1032DAGISEL-NEXT:    v_mov_b32_e32 v7, s5
 ; GFX1032DAGISEL-NEXT:    v_mov_b32_e32 v6, s4
-; GFX1032DAGISEL-NEXT:  .LBB5_8: ; %endif
+; GFX1032DAGISEL-NEXT:  .LBB6_8: ; %endif
 ; GFX1032DAGISEL-NEXT:    s_or_b32 exec_lo, exec_lo, s6
 ; GFX1032DAGISEL-NEXT:    global_store_dwordx2 v[0:1], v[6:7], off
 ; GFX1032DAGISEL-NEXT:    s_setpc_b64 s[30:31]
@@ -1847,12 +2306,12 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX1032GISEL-NEXT:    v_cmp_le_u32_e32 vcc_lo, 16, v6
 ; GFX1032GISEL-NEXT:    s_and_saveexec_b32 s6, vcc_lo
 ; GFX1032GISEL-NEXT:    s_xor_b32 s6, exec_lo, s6
-; GFX1032GISEL-NEXT:    s_cbranch_execz .LBB5_3
+; GFX1032GISEL-NEXT:    s_cbranch_execz .LBB6_3
 ; GFX1032GISEL-NEXT:  ; %bb.1: ; %else
 ; GFX1032GISEL-NEXT:    s_mov_b32 s4, 0
 ; GFX1032GISEL-NEXT:    s_mov_b32 s5, 0x7ff80000
 ; GFX1032GISEL-NEXT:    s_mov_b32 s7, exec_lo
-; GFX1032GISEL-NEXT:  .LBB5_2: ; =>This Inner Loop Header: Depth=1
+; GFX1032GISEL-NEXT:  .LBB6_2: ; =>This Inner Loop Header: Depth=1
 ; GFX1032GISEL-NEXT:    s_ff1_i32_b32 s10, s7
 ; GFX1032GISEL-NEXT:    v_readlane_b32 s8, v2, s10
 ; GFX1032GISEL-NEXT:    v_readlane_b32 s9, v3, s10
@@ -1863,15 +2322,15 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX1032GISEL-NEXT:    v_readfirstlane_b32 s5, v5
 ; GFX1032GISEL-NEXT:    ; implicit-def: $vgpr4
 ; GFX1032GISEL-NEXT:    ; implicit-def: $vgpr5
-; GFX1032GISEL-NEXT:    s_cbranch_scc1 .LBB5_2
-; GFX1032GISEL-NEXT:  .LBB5_3: ; %Flow
+; GFX1032GISEL-NEXT:    s_cbranch_scc1 .LBB6_2
+; GFX1032GISEL-NEXT:  .LBB6_3: ; %Flow
 ; GFX1032GISEL-NEXT:    s_andn2_saveexec_b32 s6, s6
-; GFX1032GISEL-NEXT:    s_cbranch_execz .LBB5_6
+; GFX1032GISEL-NEXT:    s_cbranch_execz .LBB6_6
 ; GFX1032GISEL-NEXT:  ; %bb.4: ; %if
 ; GFX1032GISEL-NEXT:    s_mov_b32 s4, 0
 ; GFX1032GISEL-NEXT:    s_mov_b32 s5, 0x7ff80000
 ; GFX1032GISEL-NEXT:    s_mov_b32 s7, exec_lo
-; GFX1032GISEL-NEXT:  .LBB5_5: ; =>This Inner Loop Header: Depth=1
+; GFX1032GISEL-NEXT:  .LBB6_5: ; =>This Inner Loop Header: Depth=1
 ; GFX1032GISEL-NEXT:    s_ff1_i32_b32 s10, s7
 ; GFX1032GISEL-NEXT:    v_readlane_b32 s8, v4, s10
 ; GFX1032GISEL-NEXT:    v_readlane_b32 s9, v5, s10
@@ -1880,8 +2339,8 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX1032GISEL-NEXT:    v_min_f64 v[2:3], s[8:9], s[4:5]
 ; GFX1032GISEL-NEXT:    v_readfirstlane_b32 s4, v2
 ; GFX1032GISEL-NEXT:    v_readfirstlane_b32 s5, v3
-; GFX1032GISEL-NEXT:    s_cbranch_scc1 .LBB5_5
-; GFX1032GISEL-NEXT:  .LBB5_6: ; %endif
+; GFX1032GISEL-NEXT:    s_cbranch_scc1 .LBB6_5
+; GFX1032GISEL-NEXT:  .LBB6_6: ; %endif
 ; GFX1032GISEL-NEXT:    s_or_b32 exec_lo, exec_lo, s6
 ; GFX1032GISEL-NEXT:    v_mov_b32_e32 v2, s4
 ; GFX1032GISEL-NEXT:    v_mov_b32_e32 v3, s5
@@ -1897,12 +2356,12 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX1164DAGISEL-NEXT:    ; implicit-def: $vgpr6_vgpr7
 ; GFX1164DAGISEL-NEXT:    s_and_saveexec_b64 s[0:1], vcc
 ; GFX1164DAGISEL-NEXT:    s_xor_b64 s[0:1], exec, s[0:1]
-; GFX1164DAGISEL-NEXT:    s_cbranch_execz .LBB5_4
+; GFX1164DAGISEL-NEXT:    s_cbranch_execz .LBB6_4
 ; GFX1164DAGISEL-NEXT:  ; %bb.1: ; %else
 ; GFX1164DAGISEL-NEXT:    s_mov_b32 s4, 0
 ; GFX1164DAGISEL-NEXT:    s_mov_b32 s5, 0x7ff80000
 ; GFX1164DAGISEL-NEXT:    s_mov_b64 s[2:3], exec
-; GFX1164DAGISEL-NEXT:  .LBB5_2: ; =>This Inner Loop Header: Depth=1
+; GFX1164DAGISEL-NEXT:  .LBB6_2: ; =>This Inner Loop Header: Depth=1
 ; GFX1164DAGISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
 ; GFX1164DAGISEL-NEXT:    s_ctz_i32_b64 s8, s[2:3]
 ; GFX1164DAGISEL-NEXT:    v_readlane_b32 s6, v2, s8
@@ -1914,20 +2373,20 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX1164DAGISEL-NEXT:    v_readfirstlane_b32 s4, v4
 ; GFX1164DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2)
 ; GFX1164DAGISEL-NEXT:    v_readfirstlane_b32 s5, v5
-; GFX1164DAGISEL-NEXT:    s_cbranch_scc1 .LBB5_2
+; GFX1164DAGISEL-NEXT:    s_cbranch_scc1 .LBB6_2
 ; GFX1164DAGISEL-NEXT:  ; %bb.3:
 ; GFX1164DAGISEL-NEXT:    v_mov_b32_e32 v7, s5
 ; GFX1164DAGISEL-NEXT:    v_mov_b32_e32 v6, s4
 ; GFX1164DAGISEL-NEXT:    ; implicit-def: $vgpr4
 ; GFX1164DAGISEL-NEXT:    ; implicit-def: $vgpr5
-; GFX1164DAGISEL-NEXT:  .LBB5_4: ; %Flow
+; GFX1164DAGISEL-NEXT:  .LBB6_4: ; %Flow
 ; GFX1164DAGISEL-NEXT:    s_and_not1_saveexec_b64 s[0:1], s[0:1]
-; GFX1164DAGISEL-NEXT:    s_cbranch_execz .LBB5_8
+; GFX1164DAGISEL-NEXT:    s_cbranch_execz .LBB6_8
 ; GFX1164DAGISEL-NEXT:  ; %bb.5: ; %if
 ; GFX1164DAGISEL-NEXT:    s_mov_b32 s4, 0
 ; GFX1164DAGISEL-NEXT:    s_mov_b32 s5, 0x7ff80000
 ; GFX1164DAGISEL-NEXT:    s_mov_b64 s[2:3], exec
-; GFX1164DAGISEL-NEXT:  .LBB5_6: ; =>This Inner Loop Header: Depth=1
+; GFX1164DAGISEL-NEXT:  .LBB6_6: ; =>This Inner Loop Header: Depth=1
 ; GFX1164DAGISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
 ; GFX1164DAGISEL-NEXT:    s_ctz_i32_b64 s8, s[2:3]
 ; GFX1164DAGISEL-NEXT:    v_readlane_b32 s6, v4, s8
@@ -1939,11 +2398,11 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX1164DAGISEL-NEXT:    v_readfirstlane_b32 s4, v2
 ; GFX1164DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2)
 ; GFX1164DAGISEL-NEXT:    v_readfirstlane_b32 s5, v3
-; GFX1164DAGISEL-NEXT:    s_cbranch_scc1 .LBB5_6
+; GFX1164DAGISEL-NEXT:    s_cbranch_scc1 .LBB6_6
 ; GFX1164DAGISEL-NEXT:  ; %bb.7:
 ; GFX1164DAGISEL-NEXT:    v_mov_b32_e32 v7, s5
 ; GFX1164DAGISEL-NEXT:    v_mov_b32_e32 v6, s4
-; GFX1164DAGISEL-NEXT:  .LBB5_8: ; %endif
+; GFX1164DAGISEL-NEXT:  .LBB6_8: ; %endif
 ; GFX1164DAGISEL-NEXT:    s_or_b64 exec, exec, s[0:1]
 ; GFX1164DAGISEL-NEXT:    global_store_b64 v[0:1], v[6:7], off
 ; GFX1164DAGISEL-NEXT:    s_setpc_b64 s[30:31]
@@ -1957,12 +2416,12 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX1164GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX1164GISEL-NEXT:    v_cmpx_le_u32_e32 16, v6
 ; GFX1164GISEL-NEXT:    s_xor_b64 s[2:3], exec, s[2:3]
-; GFX1164GISEL-NEXT:    s_cbranch_execz .LBB5_3
+; GFX1164GISEL-NEXT:    s_cbranch_execz .LBB6_3
 ; GFX1164GISEL-NEXT:  ; %bb.1: ; %else
 ; GFX1164GISEL-NEXT:    s_mov_b32 s0, 0
 ; GFX1164GISEL-NEXT:    s_mov_b32 s1, 0x7ff80000
 ; GFX1164GISEL-NEXT:    s_mov_b64 s[4:5], exec
-; GFX1164GISEL-NEXT:  .LBB5_2: ; =>This Inner Loop Header: Depth=1
+; GFX1164GISEL-NEXT:  .LBB6_2: ; =>This Inner Loop Header: Depth=1
 ; GFX1164GISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
 ; GFX1164GISEL-NEXT:    s_ctz_i32_b64 s8, s[4:5]
 ; GFX1164GISEL-NEXT:    v_readlane_b32 s6, v2, s8
@@ -1976,15 +2435,15 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX1164GISEL-NEXT:    v_readfirstlane_b32 s1, v5
 ; GFX1164GISEL-NEXT:    ; implicit-def: $vgpr4
 ; GFX1164GISEL-NEXT:    ; implicit-def: $vgpr5
-; GFX1164GISEL-NEXT:    s_cbranch_scc1 .LBB5_2
-; GFX1164GISEL-NEXT:  .LBB5_3: ; %Flow
+; GFX1164GISEL-NEXT:    s_cbranch_scc1 .LBB6_2
+; GFX1164GISEL-NEXT:  .LBB6_3: ; %Flow
 ; GFX1164GISEL-NEXT:    s_and_not1_saveexec_b64 s[2:3], s[2:3]
-; GFX1164GISEL-NEXT:    s_cbranch_execz .LBB5_6
+; GFX1164GISEL-NEXT:    s_cbranch_execz .LBB6_6
 ; GFX1164GISEL-NEXT:  ; %bb.4: ; %if
 ; GFX1164GISEL-NEXT:    s_mov_b32 s0, 0
 ; GFX1164GISEL-NEXT:    s_mov_b32 s1, 0x7ff80000
 ; GFX1164GISEL-NEXT:    s_mov_b64 s[4:5], exec
-; GFX1164GISEL-NEXT:  .LBB5_5: ; =>This Inner Loop Header: Depth=1
+; GFX1164GISEL-NEXT:  .LBB6_5: ; =>This Inner Loop Header: Depth=1
 ; GFX1164GISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
 ; GFX1164GISEL-NEXT:    s_ctz_i32_b64 s8, s[4:5]
 ; GFX1164GISEL-NEXT:    v_readlane_b32 s6, v4, s8
@@ -1996,8 +2455,8 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX1164GISEL-NEXT:    v_readfirstlane_b32 s0, v2
 ; GFX1164GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2)
 ; GFX1164GISEL-NEXT:    v_readfirstlane_b32 s1, v3
-; GFX1164GISEL-NEXT:    s_cbranch_scc1 .LBB5_5
-; GFX1164GISEL-NEXT:  .LBB5_6: ; %endif
+; GFX1164GISEL-NEXT:    s_cbranch_scc1 .LBB6_5
+; GFX1164GISEL-NEXT:  .LBB6_6: ; %endif
 ; GFX1164GISEL-NEXT:    s_or_b64 exec, exec, s[2:3]
 ; GFX1164GISEL-NEXT:    v_mov_b32_e32 v3, s1
 ; GFX1164GISEL-NEXT:    v_mov_b32_e32 v2, s0
@@ -2013,12 +2472,12 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX1132DAGISEL-NEXT:    ; implicit-def: $vgpr6_vgpr7
 ; GFX1132DAGISEL-NEXT:    s_and_saveexec_b32 s0, vcc_lo
 ; GFX1132DAGISEL-NEXT:    s_xor_b32 s2, exec_lo, s0
-; GFX1132DAGISEL-NEXT:    s_cbranch_execz .LBB5_4
+; GFX1132DAGISEL-NEXT:    s_cbranch_execz .LBB6_4
 ; GFX1132DAGISEL-NEXT:  ; %bb.1: ; %else
 ; GFX1132DAGISEL-NEXT:    s_mov_b32 s0, 0
 ; GFX1132DAGISEL-NEXT:    s_mov_b32 s1, 0x7ff80000
 ; GFX1132DAGISEL-NEXT:    s_mov_b32 s3, exec_lo
-; GFX1132DAGISEL-NEXT:  .LBB5_2: ; =>This Inner Loop Header: Depth=1
+; GFX1132DAGISEL-NEXT:  .LBB6_2: ; =>This Inner Loop Header: Depth=1
 ; GFX1132DAGISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
 ; GFX1132DAGISEL-NEXT:    s_ctz_i32_b32 s6, s3
 ; GFX1132DAGISEL-NEXT:    v_readlane_b32 s4, v2, s6
@@ -2030,19 +2489,19 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX1132DAGISEL-NEXT:    v_readfirstlane_b32 s0, v4
 ; GFX1132DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2)
 ; GFX1132DAGISEL-NEXT:    v_readfirstlane_b32 s1, v5
-; GFX1132DAGISEL-NEXT:    s_cbranch_scc1 .LBB5_2
+; GFX1132DAGISEL-NEXT:    s_cbranch_scc1 .LBB6_2
 ; GFX1132DAGISEL-NEXT:  ; %bb.3:
 ; GFX1132DAGISEL-NEXT:    v_dual_mov_b32 v7, s1 :: v_dual_mov_b32 v6, s0
 ; GFX1132DAGISEL-NEXT:    ; implicit-def: $vgpr4
 ; GFX1132DAGISEL-NEXT:    ; implicit-def: $vgpr5
-; GFX1132DAGISEL-NEXT:  .LBB5_4: ; %Flow
+; GFX1132DAGISEL-NEXT:  .LBB6_4: ; %Flow
 ; GFX1132DAGISEL-NEXT:    s_and_not1_saveexec_b32 s2, s2
-; GFX1132DAGISEL-NEXT:    s_cbranch_execz .LBB5_8
+; GFX1132DAGISEL-NEXT:    s_cbranch_execz .LBB6_8
 ; GFX1132DAGISEL-NEXT:  ; %bb.5: ; %if
 ; GFX1132DAGISEL-NEXT:    s_mov_b32 s0, 0
 ; GFX1132DAGISEL-NEXT:    s_mov_b32 s1, 0x7ff80000
 ; GFX1132DAGISEL-NEXT:    s_mov_b32 s3, exec_lo
-; GFX1132DAGISEL-NEXT:  .LBB5_6: ; =>This Inner Loop Header: Depth=1
+; GFX1132DAGISEL-NEXT:  .LBB6_6: ; =>This Inner Loop Header: Depth=1
 ; GFX1132DAGISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
 ; GFX1132DAGISEL-NEXT:    s_ctz_i32_b32 s6, s3
 ; GFX1132DAGISEL-NEXT:    v_readlane_b32 s4, v4, s6
@@ -2054,10 +2513,10 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX1132DAGISEL-NEXT:    v_readfirstlane_b32 s0, v2
 ; GFX1132DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2)
 ; GFX1132DAGISEL-NEXT:    v_readfirstlane_b32 s1, v3
-; GFX1132DAGISEL-NEXT:    s_cbranch_scc1 .LBB5_6
+; GFX1132DAGISEL-NEXT:    s_cbranch_scc1 .LBB6_6
 ; GFX1132DAGISEL-NEXT:  ; %bb.7:
 ; GFX1132DAGISEL-NEXT:    v_dual_mov_b32 v7, s1 :: v_dual_mov_b32 v6, s0
-; GFX1132DAGISEL-NEXT:  .LBB5_8: ; %endif
+; GFX1132DAGISEL-NEXT:  .LBB6_8: ; %endif
 ; GFX1132DAGISEL-NEXT:    s_or_b32 exec_lo, exec_lo, s2
 ; GFX1132DAGISEL-NEXT:    global_store_b64 v[0:1], v[6:7], off
 ; GFX1132DAGISEL-NEXT:    s_setpc_b64 s[30:31]
@@ -2071,12 +2530,12 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX1132GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX1132GISEL-NEXT:    v_cmpx_le_u32_e32 16, v6
 ; GFX1132GISEL-NEXT:    s_xor_b32 s2, exec_lo, s2
-; GFX1132GISEL-NEXT:    s_cbranch_execz .LBB5_3
+; GFX1132GISEL-NEXT:    s_cbranch_execz .LBB6_3
 ; GFX1132GISEL-NEXT:  ; %bb.1: ; %else
 ; GFX1132GISEL-NEXT:    s_mov_b32 s0, 0
 ; GFX1132GISEL-NEXT:    s_mov_b32 s1, 0x7ff80000
 ; GFX1132GISEL-NEXT:    s_mov_b32 s3, exec_lo
-; GFX1132GISEL-NEXT:  .LBB5_2: ; =>This Inner Loop Header: Depth=1
+; GFX1132GISEL-NEXT:  .LBB6_2: ; =>This Inner Loop Header: Depth=1
 ; GFX1132GISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
 ; GFX1132GISEL-NEXT:    s_ctz_i32_b32 s6, s3
 ; GFX1132GISEL-NEXT:    v_readlane_b32 s4, v2, s6
@@ -2090,15 +2549,15 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX1132GISEL-NEXT:    v_readfirstlane_b32 s1, v5
 ; GFX1132GISEL-NEXT:    ; implicit-def: $vgpr4
 ; GFX1132GISEL-NEXT:    ; implicit-def: $vgpr5
-; GFX1132GISEL-NEXT:    s_cbranch_scc1 .LBB5_2
-; GFX1132GISEL-NEXT:  .LBB5_3: ; %Flow
+; GFX1132GISEL-NEXT:    s_cbranch_scc1 .LBB6_2
+; GFX1132GISEL-NEXT:  .LBB6_3: ; %Flow
 ; GFX1132GISEL-NEXT:    s_and_not1_saveexec_b32 s2, s2
-; GFX1132GISEL-NEXT:    s_cbranch_execz .LBB5_6
+; GFX1132GISEL-NEXT:    s_cbranch_execz .LBB6_6
 ; GFX1132GISEL-NEXT:  ; %bb.4: ; %if
 ; GFX1132GISEL-NEXT:    s_mov_b32 s0, 0
 ; GFX1132GISEL-NEXT:    s_mov_b32 s1, 0x7ff80000
 ; GFX1132GISEL-NEXT:    s_mov_b32 s3, exec_lo
-; GFX1132GISEL-NEXT:  .LBB5_5: ; =>This Inner Loop Header: Depth=1
+; GFX1132GISEL-NEXT:  .LBB6_5: ; =>This Inner Loop Header: Depth=1
 ; GFX1132GISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
 ; GFX1132GISEL-NEXT:    s_ctz_i32_b32 s6, s3
 ; GFX1132GISEL-NEXT:    v_readlane_b32 s4, v4, s6
@@ -2110,8 +2569,8 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX1132GISEL-NEXT:    v_readfirstlane_b32 s0, v2
 ; GFX1132GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2)
 ; GFX1132GISEL-NEXT:    v_readfirstlane_b32 s1, v3
-; GFX1132GISEL-NEXT:    s_cbranch_scc1 .LBB5_5
-; GFX1132GISEL-NEXT:  .LBB5_6: ; %endif
+; GFX1132GISEL-NEXT:    s_cbranch_scc1 .LBB6_5
+; GFX1132GISEL-NEXT:  .LBB6_6: ; %endif
 ; GFX1132GISEL-NEXT:    s_or_b32 exec_lo, exec_lo, s2
 ; GFX1132GISEL-NEXT:    v_dual_mov_b32 v3, s1 :: v_dual_mov_b32 v2, s0
 ; GFX1132GISEL-NEXT:    global_store_b64 v[0:1], v[2:3], off
@@ -2131,12 +2590,12 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX12DAGISEL-NEXT:    s_and_saveexec_b32 s0, vcc_lo
 ; GFX12DAGISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
 ; GFX12DAGISEL-NEXT:    s_xor_b32 s2, exec_lo, s0
-; GFX12DAGISEL-NEXT:    s_cbranch_execz .LBB5_4
+; GFX12DAGISEL-NEXT:    s_cbranch_execz .LBB6_4
 ; GFX12DAGISEL-NEXT:  ; %bb.1: ; %else
 ; GFX12DAGISEL-NEXT:    s_mov_b32 s0, 0
 ; GFX12DAGISEL-NEXT:    s_mov_b32 s1, 0x7ff80000
 ; GFX12DAGISEL-NEXT:    s_mov_b32 s3, exec_lo
-; GFX12DAGISEL-NEXT:  .LBB5_2: ; =>This Inner Loop Header: Depth=1
+; GFX12DAGISEL-NEXT:  .LBB6_2: ; =>This Inner Loop Header: Depth=1
 ; GFX12DAGISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
 ; GFX12DAGISEL-NEXT:    s_ctz_i32_b32 s6, s3
 ; GFX12DAGISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
@@ -2149,21 +2608,21 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX12DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_2)
 ; GFX12DAGISEL-NEXT:    v_readfirstlane_b32 s0, v4
 ; GFX12DAGISEL-NEXT:    v_readfirstlane_b32 s1, v5
-; GFX12DAGISEL-NEXT:    s_cbranch_scc1 .LBB5_2
+; GFX12DAGISEL-NEXT:    s_cbranch_scc1 .LBB6_2
 ; GFX12DAGISEL-NEXT:  ; %bb.3:
 ; GFX12DAGISEL-NEXT:    s_wait_alu depctr_va_sdst(0)
 ; GFX12DAGISEL-NEXT:    v_dual_mov_b32 v7, s1 :: v_dual_mov_b32 v6, s0
 ; GFX12DAGISEL-NEXT:    ; implicit-def: $vgpr4
 ; GFX12DAGISEL-NEXT:    ; implicit-def: $vgpr5
-; GFX12DAGISEL-NEXT:  .LBB5_4: ; %Flow
+; GFX12DAGISEL-NEXT:  .LBB6_4: ; %Flow
 ; GFX12DAGISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
 ; GFX12DAGISEL-NEXT:    s_and_not1_saveexec_b32 s2, s2
-; GFX12DAGISEL-NEXT:    s_cbranch_execz .LBB5_8
+; GFX12DAGISEL-NEXT:    s_cbranch_execz .LBB6_8
 ; GFX12DAGISEL-NEXT:  ; %bb.5: ; %if
 ; GFX12DAGISEL-NEXT:    s_mov_b32 s0, 0
 ; GFX12DAGISEL-NEXT:    s_mov_b32 s1, 0x7ff80000
 ; GFX12DAGISEL-NEXT:    s_mov_b32 s3, exec_lo
-; GFX12DAGISEL-NEXT:  .LBB5_6: ; =>This Inner Loop Header: Depth=1
+; GFX12DAGISEL-NEXT:  .LBB6_6: ; =>This Inner Loop Header: Depth=1
 ; GFX12DAGISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
 ; GFX12DAGISEL-NEXT:    s_ctz_i32_b32 s6, s3
 ; GFX12DAGISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
@@ -2176,11 +2635,11 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX12DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_2)
 ; GFX12DAGISEL-NEXT:    v_readfirstlane_b32 s0, v2
 ; GFX12DAGISEL-NEXT:    v_readfirstlane_b32 s1, v3
-; GFX12DAGISEL-NEXT:    s_cbranch_scc1 .LBB5_6
+; GFX12DAGISEL-NEXT:    s_cbranch_scc1 .LBB6_6
 ; GFX12DAGISEL-NEXT:  ; %bb.7:
 ; GFX12DAGISEL-NEXT:    s_wait_alu depctr_va_sdst(0)
 ; GFX12DAGISEL-NEXT:    v_dual_mov_b32 v7, s1 :: v_dual_mov_b32 v6, s0
-; GFX12DAGISEL-NEXT:  .LBB5_8: ; %endif
+; GFX12DAGISEL-NEXT:  .LBB6_8: ; %endif
 ; GFX12DAGISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
 ; GFX12DAGISEL-NEXT:    s_or_b32 exec_lo, exec_lo, s2
 ; GFX12DAGISEL-NEXT:    global_store_b64 v[0:1], v[6:7], off

--- a/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.reduce.fsub.ll
+++ b/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.reduce.fsub.ll
@@ -491,6 +491,476 @@ entry:
   ret void
 }
 
+define void @divergent_value_float_dpp(ptr addrspace(1) %out, float %id.x) {
+; GFX8DAGISEL-LABEL: divergent_value_float_dpp:
+; GFX8DAGISEL:       ; %bb.0: ; %entry
+; GFX8DAGISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX8DAGISEL-NEXT:    s_xor_saveexec_b64 s[4:5], -1
+; GFX8DAGISEL-NEXT:    buffer_store_dword v3, off, s[0:3], s32 ; 4-byte Folded Spill
+; GFX8DAGISEL-NEXT:    s_mov_b64 exec, s[4:5]
+; GFX8DAGISEL-NEXT:    s_or_saveexec_b64 s[4:5], -1
+; GFX8DAGISEL-NEXT:    v_cndmask_b32_e64 v3, 0, v2, s[4:5]
+; GFX8DAGISEL-NEXT:    s_nop 1
+; GFX8DAGISEL-NEXT:    v_add_f32_dpp v3, v3, v3 row_shr:1 row_mask:0xf bank_mask:0xf
+; GFX8DAGISEL-NEXT:    s_nop 1
+; GFX8DAGISEL-NEXT:    v_add_f32_dpp v3, v3, v3 row_shr:2 row_mask:0xf bank_mask:0xf
+; GFX8DAGISEL-NEXT:    s_nop 1
+; GFX8DAGISEL-NEXT:    v_add_f32_dpp v3, v3, v3 row_shr:4 row_mask:0xf bank_mask:0xf
+; GFX8DAGISEL-NEXT:    s_nop 1
+; GFX8DAGISEL-NEXT:    v_add_f32_dpp v3, v3, v3 row_shr:8 row_mask:0xf bank_mask:0xf
+; GFX8DAGISEL-NEXT:    s_nop 1
+; GFX8DAGISEL-NEXT:    v_add_f32_dpp v3, v3, v3 row_bcast:15 row_mask:0xf bank_mask:0xf
+; GFX8DAGISEL-NEXT:    s_nop 1
+; GFX8DAGISEL-NEXT:    v_add_f32_dpp v3, v3, v3 row_bcast:31 row_mask:0xf bank_mask:0xf
+; GFX8DAGISEL-NEXT:    v_sub_f32_e32 v3, 0, v3
+; GFX8DAGISEL-NEXT:    v_readlane_b32 s6, v3, 63
+; GFX8DAGISEL-NEXT:    s_mov_b64 exec, s[4:5]
+; GFX8DAGISEL-NEXT:    v_mov_b32_e32 v2, s6
+; GFX8DAGISEL-NEXT:    flat_store_dword v[0:1], v2
+; GFX8DAGISEL-NEXT:    s_xor_saveexec_b64 s[4:5], -1
+; GFX8DAGISEL-NEXT:    buffer_load_dword v3, off, s[0:3], s32 ; 4-byte Folded Reload
+; GFX8DAGISEL-NEXT:    s_mov_b64 exec, s[4:5]
+; GFX8DAGISEL-NEXT:    s_waitcnt vmcnt(0)
+; GFX8DAGISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX8GISEL-LABEL: divergent_value_float_dpp:
+; GFX8GISEL:       ; %bb.0: ; %entry
+; GFX8GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX8GISEL-NEXT:    s_xor_saveexec_b64 s[4:5], -1
+; GFX8GISEL-NEXT:    buffer_store_dword v3, off, s[0:3], s32 ; 4-byte Folded Spill
+; GFX8GISEL-NEXT:    s_mov_b64 exec, s[4:5]
+; GFX8GISEL-NEXT:    s_or_saveexec_b64 s[4:5], -1
+; GFX8GISEL-NEXT:    v_cndmask_b32_e64 v3, 0, v2, s[4:5]
+; GFX8GISEL-NEXT:    s_nop 1
+; GFX8GISEL-NEXT:    v_add_f32_dpp v3, v3, v3 row_shr:1 row_mask:0xf bank_mask:0xf
+; GFX8GISEL-NEXT:    s_nop 1
+; GFX8GISEL-NEXT:    v_add_f32_dpp v3, v3, v3 row_shr:2 row_mask:0xf bank_mask:0xf
+; GFX8GISEL-NEXT:    s_nop 1
+; GFX8GISEL-NEXT:    v_add_f32_dpp v3, v3, v3 row_shr:4 row_mask:0xf bank_mask:0xf
+; GFX8GISEL-NEXT:    s_nop 1
+; GFX8GISEL-NEXT:    v_add_f32_dpp v3, v3, v3 row_shr:8 row_mask:0xf bank_mask:0xf
+; GFX8GISEL-NEXT:    s_nop 1
+; GFX8GISEL-NEXT:    v_add_f32_dpp v3, v3, v3 row_bcast:15 row_mask:0xf bank_mask:0xf
+; GFX8GISEL-NEXT:    s_nop 1
+; GFX8GISEL-NEXT:    v_add_f32_dpp v3, v3, v3 row_bcast:31 row_mask:0xf bank_mask:0xf
+; GFX8GISEL-NEXT:    v_sub_f32_e32 v3, 0, v3
+; GFX8GISEL-NEXT:    v_readlane_b32 s6, v3, 63
+; GFX8GISEL-NEXT:    s_mov_b64 exec, s[4:5]
+; GFX8GISEL-NEXT:    v_mov_b32_e32 v2, s6
+; GFX8GISEL-NEXT:    flat_store_dword v[0:1], v2
+; GFX8GISEL-NEXT:    s_xor_saveexec_b64 s[4:5], -1
+; GFX8GISEL-NEXT:    buffer_load_dword v3, off, s[0:3], s32 ; 4-byte Folded Reload
+; GFX8GISEL-NEXT:    s_mov_b64 exec, s[4:5]
+; GFX8GISEL-NEXT:    s_waitcnt vmcnt(0)
+; GFX8GISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX9DAGISEL-LABEL: divergent_value_float_dpp:
+; GFX9DAGISEL:       ; %bb.0: ; %entry
+; GFX9DAGISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9DAGISEL-NEXT:    s_xor_saveexec_b64 s[4:5], -1
+; GFX9DAGISEL-NEXT:    buffer_store_dword v3, off, s[0:3], s32 ; 4-byte Folded Spill
+; GFX9DAGISEL-NEXT:    s_mov_b64 exec, s[4:5]
+; GFX9DAGISEL-NEXT:    s_or_saveexec_b64 s[4:5], -1
+; GFX9DAGISEL-NEXT:    v_cndmask_b32_e64 v3, 0, v2, s[4:5]
+; GFX9DAGISEL-NEXT:    s_nop 1
+; GFX9DAGISEL-NEXT:    v_add_f32_dpp v3, v3, v3 row_shr:1 row_mask:0xf bank_mask:0xf
+; GFX9DAGISEL-NEXT:    s_nop 1
+; GFX9DAGISEL-NEXT:    v_add_f32_dpp v3, v3, v3 row_shr:2 row_mask:0xf bank_mask:0xf
+; GFX9DAGISEL-NEXT:    s_nop 1
+; GFX9DAGISEL-NEXT:    v_add_f32_dpp v3, v3, v3 row_shr:4 row_mask:0xf bank_mask:0xf
+; GFX9DAGISEL-NEXT:    s_nop 1
+; GFX9DAGISEL-NEXT:    v_add_f32_dpp v3, v3, v3 row_shr:8 row_mask:0xf bank_mask:0xf
+; GFX9DAGISEL-NEXT:    s_nop 1
+; GFX9DAGISEL-NEXT:    v_add_f32_dpp v3, v3, v3 row_bcast:15 row_mask:0xf bank_mask:0xf
+; GFX9DAGISEL-NEXT:    s_nop 1
+; GFX9DAGISEL-NEXT:    v_add_f32_dpp v3, v3, v3 row_bcast:31 row_mask:0xf bank_mask:0xf
+; GFX9DAGISEL-NEXT:    v_sub_f32_e32 v3, 0, v3
+; GFX9DAGISEL-NEXT:    v_readlane_b32 s6, v3, 63
+; GFX9DAGISEL-NEXT:    s_mov_b64 exec, s[4:5]
+; GFX9DAGISEL-NEXT:    v_mov_b32_e32 v2, s6
+; GFX9DAGISEL-NEXT:    global_store_dword v[0:1], v2, off
+; GFX9DAGISEL-NEXT:    s_xor_saveexec_b64 s[4:5], -1
+; GFX9DAGISEL-NEXT:    buffer_load_dword v3, off, s[0:3], s32 ; 4-byte Folded Reload
+; GFX9DAGISEL-NEXT:    s_mov_b64 exec, s[4:5]
+; GFX9DAGISEL-NEXT:    s_waitcnt vmcnt(0)
+; GFX9DAGISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX9GISEL-LABEL: divergent_value_float_dpp:
+; GFX9GISEL:       ; %bb.0: ; %entry
+; GFX9GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9GISEL-NEXT:    s_xor_saveexec_b64 s[4:5], -1
+; GFX9GISEL-NEXT:    buffer_store_dword v3, off, s[0:3], s32 ; 4-byte Folded Spill
+; GFX9GISEL-NEXT:    s_mov_b64 exec, s[4:5]
+; GFX9GISEL-NEXT:    s_or_saveexec_b64 s[4:5], -1
+; GFX9GISEL-NEXT:    v_cndmask_b32_e64 v3, 0, v2, s[4:5]
+; GFX9GISEL-NEXT:    s_nop 1
+; GFX9GISEL-NEXT:    v_add_f32_dpp v3, v3, v3 row_shr:1 row_mask:0xf bank_mask:0xf
+; GFX9GISEL-NEXT:    s_nop 1
+; GFX9GISEL-NEXT:    v_add_f32_dpp v3, v3, v3 row_shr:2 row_mask:0xf bank_mask:0xf
+; GFX9GISEL-NEXT:    s_nop 1
+; GFX9GISEL-NEXT:    v_add_f32_dpp v3, v3, v3 row_shr:4 row_mask:0xf bank_mask:0xf
+; GFX9GISEL-NEXT:    s_nop 1
+; GFX9GISEL-NEXT:    v_add_f32_dpp v3, v3, v3 row_shr:8 row_mask:0xf bank_mask:0xf
+; GFX9GISEL-NEXT:    s_nop 1
+; GFX9GISEL-NEXT:    v_add_f32_dpp v3, v3, v3 row_bcast:15 row_mask:0xf bank_mask:0xf
+; GFX9GISEL-NEXT:    s_nop 1
+; GFX9GISEL-NEXT:    v_add_f32_dpp v3, v3, v3 row_bcast:31 row_mask:0xf bank_mask:0xf
+; GFX9GISEL-NEXT:    v_sub_f32_e32 v3, 0, v3
+; GFX9GISEL-NEXT:    v_readlane_b32 s6, v3, 63
+; GFX9GISEL-NEXT:    s_mov_b64 exec, s[4:5]
+; GFX9GISEL-NEXT:    v_mov_b32_e32 v2, s6
+; GFX9GISEL-NEXT:    global_store_dword v[0:1], v2, off
+; GFX9GISEL-NEXT:    s_xor_saveexec_b64 s[4:5], -1
+; GFX9GISEL-NEXT:    buffer_load_dword v3, off, s[0:3], s32 ; 4-byte Folded Reload
+; GFX9GISEL-NEXT:    s_mov_b64 exec, s[4:5]
+; GFX9GISEL-NEXT:    s_waitcnt vmcnt(0)
+; GFX9GISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX1064DAGISEL-LABEL: divergent_value_float_dpp:
+; GFX1064DAGISEL:       ; %bb.0: ; %entry
+; GFX1064DAGISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX1064DAGISEL-NEXT:    s_xor_saveexec_b64 s[4:5], -1
+; GFX1064DAGISEL-NEXT:    buffer_store_dword v3, off, s[0:3], s32 ; 4-byte Folded Spill
+; GFX1064DAGISEL-NEXT:    buffer_store_dword v4, off, s[0:3], s32 offset:4 ; 4-byte Folded Spill
+; GFX1064DAGISEL-NEXT:    buffer_store_dword v5, off, s[0:3], s32 offset:8 ; 4-byte Folded Spill
+; GFX1064DAGISEL-NEXT:    s_waitcnt_depctr depctr_vm_vsrc(0)
+; GFX1064DAGISEL-NEXT:    s_mov_b64 exec, s[4:5]
+; GFX1064DAGISEL-NEXT:    s_or_saveexec_b64 s[4:5], -1
+; GFX1064DAGISEL-NEXT:    v_cndmask_b32_e64 v3, 0, v2, s[4:5]
+; GFX1064DAGISEL-NEXT:    v_mbcnt_lo_u32_b32 v5, -1, 0
+; GFX1064DAGISEL-NEXT:    v_add_f32_dpp v3, v3, v3 row_shr:1 row_mask:0xf bank_mask:0xf
+; GFX1064DAGISEL-NEXT:    v_mbcnt_hi_u32_b32 v5, -1, v5
+; GFX1064DAGISEL-NEXT:    v_add_f32_dpp v3, v3, v3 row_shr:2 row_mask:0xf bank_mask:0xf
+; GFX1064DAGISEL-NEXT:    v_add_nc_u32_e32 v5, 32, v5
+; GFX1064DAGISEL-NEXT:    v_add_f32_dpp v3, v3, v3 row_shr:4 row_mask:0xf bank_mask:0xf
+; GFX1064DAGISEL-NEXT:    v_mul_lo_u32 v5, 4, v5
+; GFX1064DAGISEL-NEXT:    v_add_f32_dpp v3, v3, v3 row_shr:8 row_mask:0xf bank_mask:0xf
+; GFX1064DAGISEL-NEXT:    ds_swizzle_b32 v4, v3 offset:swizzle(BROADCAST,32,15)
+; GFX1064DAGISEL-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX1064DAGISEL-NEXT:    v_sub_f32_e32 v3, v3, v4
+; GFX1064DAGISEL-NEXT:    ds_permute_b32 v4, v5, v3
+; GFX1064DAGISEL-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX1064DAGISEL-NEXT:    v_sub_f32_e32 v3, v3, v4
+; GFX1064DAGISEL-NEXT:    v_sub_f32_e32 v3, 0, v3
+; GFX1064DAGISEL-NEXT:    v_readlane_b32 s6, v3, 63
+; GFX1064DAGISEL-NEXT:    s_mov_b64 exec, s[4:5]
+; GFX1064DAGISEL-NEXT:    v_mov_b32_e32 v2, s6
+; GFX1064DAGISEL-NEXT:    global_store_dword v[0:1], v2, off
+; GFX1064DAGISEL-NEXT:    s_xor_saveexec_b64 s[4:5], -1
+; GFX1064DAGISEL-NEXT:    s_clause 0x2 ; 12-byte Folded Reload
+; GFX1064DAGISEL-NEXT:    buffer_load_dword v3, off, s[0:3], s32
+; GFX1064DAGISEL-NEXT:    buffer_load_dword v4, off, s[0:3], s32 offset:4
+; GFX1064DAGISEL-NEXT:    buffer_load_dword v5, off, s[0:3], s32 offset:8
+; GFX1064DAGISEL-NEXT:    s_waitcnt_depctr depctr_vm_vsrc(0)
+; GFX1064DAGISEL-NEXT:    s_mov_b64 exec, s[4:5]
+; GFX1064DAGISEL-NEXT:    s_waitcnt vmcnt(0)
+; GFX1064DAGISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX1064GISEL-LABEL: divergent_value_float_dpp:
+; GFX1064GISEL:       ; %bb.0: ; %entry
+; GFX1064GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX1064GISEL-NEXT:    s_xor_saveexec_b64 s[4:5], -1
+; GFX1064GISEL-NEXT:    buffer_store_dword v3, off, s[0:3], s32 ; 4-byte Folded Spill
+; GFX1064GISEL-NEXT:    buffer_store_dword v4, off, s[0:3], s32 offset:4 ; 4-byte Folded Spill
+; GFX1064GISEL-NEXT:    buffer_store_dword v5, off, s[0:3], s32 offset:8 ; 4-byte Folded Spill
+; GFX1064GISEL-NEXT:    s_waitcnt_depctr depctr_vm_vsrc(0)
+; GFX1064GISEL-NEXT:    s_mov_b64 exec, s[4:5]
+; GFX1064GISEL-NEXT:    s_or_saveexec_b64 s[4:5], -1
+; GFX1064GISEL-NEXT:    v_cndmask_b32_e64 v3, 0, v2, s[4:5]
+; GFX1064GISEL-NEXT:    v_mbcnt_lo_u32_b32 v5, -1, 0
+; GFX1064GISEL-NEXT:    v_add_f32_dpp v3, v3, v3 row_shr:1 row_mask:0xf bank_mask:0xf
+; GFX1064GISEL-NEXT:    v_mbcnt_hi_u32_b32 v5, -1, v5
+; GFX1064GISEL-NEXT:    v_add_f32_dpp v3, v3, v3 row_shr:2 row_mask:0xf bank_mask:0xf
+; GFX1064GISEL-NEXT:    v_add_nc_u32_e32 v5, 32, v5
+; GFX1064GISEL-NEXT:    v_add_f32_dpp v3, v3, v3 row_shr:4 row_mask:0xf bank_mask:0xf
+; GFX1064GISEL-NEXT:    v_mul_lo_u32 v5, 4, v5
+; GFX1064GISEL-NEXT:    v_add_f32_dpp v3, v3, v3 row_shr:8 row_mask:0xf bank_mask:0xf
+; GFX1064GISEL-NEXT:    ds_swizzle_b32 v4, v3 offset:swizzle(BROADCAST,32,15)
+; GFX1064GISEL-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX1064GISEL-NEXT:    v_sub_f32_e32 v3, v3, v4
+; GFX1064GISEL-NEXT:    ds_permute_b32 v4, v5, v3
+; GFX1064GISEL-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX1064GISEL-NEXT:    v_sub_f32_e32 v3, v3, v4
+; GFX1064GISEL-NEXT:    v_sub_f32_e32 v3, 0, v3
+; GFX1064GISEL-NEXT:    v_readlane_b32 s6, v3, 63
+; GFX1064GISEL-NEXT:    s_mov_b64 exec, s[4:5]
+; GFX1064GISEL-NEXT:    v_mov_b32_e32 v2, s6
+; GFX1064GISEL-NEXT:    global_store_dword v[0:1], v2, off
+; GFX1064GISEL-NEXT:    s_xor_saveexec_b64 s[4:5], -1
+; GFX1064GISEL-NEXT:    s_clause 0x2 ; 12-byte Folded Reload
+; GFX1064GISEL-NEXT:    buffer_load_dword v3, off, s[0:3], s32
+; GFX1064GISEL-NEXT:    buffer_load_dword v4, off, s[0:3], s32 offset:4
+; GFX1064GISEL-NEXT:    buffer_load_dword v5, off, s[0:3], s32 offset:8
+; GFX1064GISEL-NEXT:    s_waitcnt_depctr depctr_vm_vsrc(0)
+; GFX1064GISEL-NEXT:    s_mov_b64 exec, s[4:5]
+; GFX1064GISEL-NEXT:    s_waitcnt vmcnt(0)
+; GFX1064GISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX1032DAGISEL-LABEL: divergent_value_float_dpp:
+; GFX1032DAGISEL:       ; %bb.0: ; %entry
+; GFX1032DAGISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX1032DAGISEL-NEXT:    s_xor_saveexec_b32 s4, -1
+; GFX1032DAGISEL-NEXT:    buffer_store_dword v3, off, s[0:3], s32 ; 4-byte Folded Spill
+; GFX1032DAGISEL-NEXT:    buffer_store_dword v4, off, s[0:3], s32 offset:4 ; 4-byte Folded Spill
+; GFX1032DAGISEL-NEXT:    s_waitcnt_depctr depctr_vm_vsrc(0)
+; GFX1032DAGISEL-NEXT:    s_mov_b32 exec_lo, s4
+; GFX1032DAGISEL-NEXT:    s_or_saveexec_b32 s4, -1
+; GFX1032DAGISEL-NEXT:    v_cndmask_b32_e64 v3, 0, v2, s4
+; GFX1032DAGISEL-NEXT:    v_add_f32_dpp v3, v3, v3 row_shr:1 row_mask:0xf bank_mask:0xf
+; GFX1032DAGISEL-NEXT:    v_add_f32_dpp v3, v3, v3 row_shr:2 row_mask:0xf bank_mask:0xf
+; GFX1032DAGISEL-NEXT:    v_add_f32_dpp v3, v3, v3 row_shr:4 row_mask:0xf bank_mask:0xf
+; GFX1032DAGISEL-NEXT:    v_add_f32_dpp v3, v3, v3 row_shr:8 row_mask:0xf bank_mask:0xf
+; GFX1032DAGISEL-NEXT:    ds_swizzle_b32 v4, v3 offset:swizzle(BROADCAST,32,15)
+; GFX1032DAGISEL-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX1032DAGISEL-NEXT:    v_sub_f32_e32 v3, v3, v4
+; GFX1032DAGISEL-NEXT:    v_sub_f32_e32 v3, 0, v3
+; GFX1032DAGISEL-NEXT:    v_readlane_b32 s5, v3, 31
+; GFX1032DAGISEL-NEXT:    s_mov_b32 exec_lo, s4
+; GFX1032DAGISEL-NEXT:    v_mov_b32_e32 v2, s5
+; GFX1032DAGISEL-NEXT:    global_store_dword v[0:1], v2, off
+; GFX1032DAGISEL-NEXT:    s_xor_saveexec_b32 s4, -1
+; GFX1032DAGISEL-NEXT:    s_clause 0x1 ; 8-byte Folded Reload
+; GFX1032DAGISEL-NEXT:    buffer_load_dword v3, off, s[0:3], s32
+; GFX1032DAGISEL-NEXT:    buffer_load_dword v4, off, s[0:3], s32 offset:4
+; GFX1032DAGISEL-NEXT:    s_waitcnt_depctr depctr_vm_vsrc(0)
+; GFX1032DAGISEL-NEXT:    s_mov_b32 exec_lo, s4
+; GFX1032DAGISEL-NEXT:    s_waitcnt vmcnt(0)
+; GFX1032DAGISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX1032GISEL-LABEL: divergent_value_float_dpp:
+; GFX1032GISEL:       ; %bb.0: ; %entry
+; GFX1032GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX1032GISEL-NEXT:    s_xor_saveexec_b32 s4, -1
+; GFX1032GISEL-NEXT:    buffer_store_dword v3, off, s[0:3], s32 ; 4-byte Folded Spill
+; GFX1032GISEL-NEXT:    buffer_store_dword v4, off, s[0:3], s32 offset:4 ; 4-byte Folded Spill
+; GFX1032GISEL-NEXT:    s_waitcnt_depctr depctr_vm_vsrc(0)
+; GFX1032GISEL-NEXT:    s_mov_b32 exec_lo, s4
+; GFX1032GISEL-NEXT:    s_or_saveexec_b32 s4, -1
+; GFX1032GISEL-NEXT:    v_cndmask_b32_e64 v3, 0, v2, s4
+; GFX1032GISEL-NEXT:    v_add_f32_dpp v3, v3, v3 row_shr:1 row_mask:0xf bank_mask:0xf
+; GFX1032GISEL-NEXT:    v_add_f32_dpp v3, v3, v3 row_shr:2 row_mask:0xf bank_mask:0xf
+; GFX1032GISEL-NEXT:    v_add_f32_dpp v3, v3, v3 row_shr:4 row_mask:0xf bank_mask:0xf
+; GFX1032GISEL-NEXT:    v_add_f32_dpp v3, v3, v3 row_shr:8 row_mask:0xf bank_mask:0xf
+; GFX1032GISEL-NEXT:    ds_swizzle_b32 v4, v3 offset:swizzle(BROADCAST,32,15)
+; GFX1032GISEL-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX1032GISEL-NEXT:    v_sub_f32_e32 v3, v3, v4
+; GFX1032GISEL-NEXT:    v_sub_f32_e32 v3, 0, v3
+; GFX1032GISEL-NEXT:    v_readlane_b32 s5, v3, 31
+; GFX1032GISEL-NEXT:    s_mov_b32 exec_lo, s4
+; GFX1032GISEL-NEXT:    v_mov_b32_e32 v2, s5
+; GFX1032GISEL-NEXT:    global_store_dword v[0:1], v2, off
+; GFX1032GISEL-NEXT:    s_xor_saveexec_b32 s4, -1
+; GFX1032GISEL-NEXT:    s_clause 0x1 ; 8-byte Folded Reload
+; GFX1032GISEL-NEXT:    buffer_load_dword v3, off, s[0:3], s32
+; GFX1032GISEL-NEXT:    buffer_load_dword v4, off, s[0:3], s32 offset:4
+; GFX1032GISEL-NEXT:    s_waitcnt_depctr depctr_vm_vsrc(0)
+; GFX1032GISEL-NEXT:    s_mov_b32 exec_lo, s4
+; GFX1032GISEL-NEXT:    s_waitcnt vmcnt(0)
+; GFX1032GISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX1164DAGISEL-LABEL: divergent_value_float_dpp:
+; GFX1164DAGISEL:       ; %bb.0: ; %entry
+; GFX1164DAGISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX1164DAGISEL-NEXT:    s_xor_saveexec_b64 s[0:1], -1
+; GFX1164DAGISEL-NEXT:    s_clause 0x2 ; 12-byte Folded Spill
+; GFX1164DAGISEL-NEXT:    scratch_store_b32 off, v3, s32
+; GFX1164DAGISEL-NEXT:    scratch_store_b32 off, v4, s32 offset:4
+; GFX1164DAGISEL-NEXT:    scratch_store_b32 off, v5, s32 offset:8
+; GFX1164DAGISEL-NEXT:    s_mov_b64 exec, s[0:1]
+; GFX1164DAGISEL-NEXT:    s_or_saveexec_b64 s[0:1], -1
+; GFX1164DAGISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_1) | instid1(VALU_DEP_2)
+; GFX1164DAGISEL-NEXT:    v_cndmask_b32_e64 v3, 0, v2, s[0:1]
+; GFX1164DAGISEL-NEXT:    v_mbcnt_lo_u32_b32 v5, -1, 0
+; GFX1164DAGISEL-NEXT:    v_add_f32_dpp v3, v3, v3 row_shr:1 row_mask:0xf bank_mask:0xf
+; GFX1164DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GFX1164DAGISEL-NEXT:    v_mbcnt_hi_u32_b32 v5, -1, v5
+; GFX1164DAGISEL-NEXT:    v_add_f32_dpp v3, v3, v3 row_shr:2 row_mask:0xf bank_mask:0xf
+; GFX1164DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GFX1164DAGISEL-NEXT:    v_add_nc_u32_e32 v5, 32, v5
+; GFX1164DAGISEL-NEXT:    v_add_f32_dpp v3, v3, v3 row_shr:4 row_mask:0xf bank_mask:0xf
+; GFX1164DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GFX1164DAGISEL-NEXT:    v_mul_lo_u32 v5, 4, v5
+; GFX1164DAGISEL-NEXT:    v_add_f32_dpp v3, v3, v3 row_shr:8 row_mask:0xf bank_mask:0xf
+; GFX1164DAGISEL-NEXT:    ds_swizzle_b32 v4, v3 offset:swizzle(BROADCAST,32,15)
+; GFX1164DAGISEL-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX1164DAGISEL-NEXT:    v_sub_f32_e32 v3, v3, v4
+; GFX1164DAGISEL-NEXT:    ds_permute_b32 v4, v5, v3
+; GFX1164DAGISEL-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX1164DAGISEL-NEXT:    v_sub_f32_e32 v3, v3, v4
+; GFX1164DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1164DAGISEL-NEXT:    v_sub_f32_e32 v3, 0, v3
+; GFX1164DAGISEL-NEXT:    v_readlane_b32 s2, v3, 63
+; GFX1164DAGISEL-NEXT:    s_mov_b64 exec, s[0:1]
+; GFX1164DAGISEL-NEXT:    v_mov_b32_e32 v2, s2
+; GFX1164DAGISEL-NEXT:    global_store_b32 v[0:1], v2, off
+; GFX1164DAGISEL-NEXT:    s_xor_saveexec_b64 s[0:1], -1
+; GFX1164DAGISEL-NEXT:    s_waitcnt_depctr depctr_sa_sdst(0)
+; GFX1164DAGISEL-NEXT:    s_clause 0x2 ; 12-byte Folded Reload
+; GFX1164DAGISEL-NEXT:    scratch_load_b32 v3, off, s32
+; GFX1164DAGISEL-NEXT:    scratch_load_b32 v4, off, s32 offset:4
+; GFX1164DAGISEL-NEXT:    scratch_load_b32 v5, off, s32 offset:8
+; GFX1164DAGISEL-NEXT:    s_mov_b64 exec, s[0:1]
+; GFX1164DAGISEL-NEXT:    s_waitcnt vmcnt(0)
+; GFX1164DAGISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX1164GISEL-LABEL: divergent_value_float_dpp:
+; GFX1164GISEL:       ; %bb.0: ; %entry
+; GFX1164GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX1164GISEL-NEXT:    s_xor_saveexec_b64 s[0:1], -1
+; GFX1164GISEL-NEXT:    s_clause 0x2 ; 12-byte Folded Spill
+; GFX1164GISEL-NEXT:    scratch_store_b32 off, v3, s32
+; GFX1164GISEL-NEXT:    scratch_store_b32 off, v4, s32 offset:4
+; GFX1164GISEL-NEXT:    scratch_store_b32 off, v5, s32 offset:8
+; GFX1164GISEL-NEXT:    s_mov_b64 exec, s[0:1]
+; GFX1164GISEL-NEXT:    s_or_saveexec_b64 s[0:1], -1
+; GFX1164GISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_1) | instid1(VALU_DEP_2)
+; GFX1164GISEL-NEXT:    v_cndmask_b32_e64 v3, 0, v2, s[0:1]
+; GFX1164GISEL-NEXT:    v_mbcnt_lo_u32_b32 v5, -1, 0
+; GFX1164GISEL-NEXT:    v_add_f32_dpp v3, v3, v3 row_shr:1 row_mask:0xf bank_mask:0xf
+; GFX1164GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GFX1164GISEL-NEXT:    v_mbcnt_hi_u32_b32 v5, -1, v5
+; GFX1164GISEL-NEXT:    v_add_f32_dpp v3, v3, v3 row_shr:2 row_mask:0xf bank_mask:0xf
+; GFX1164GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GFX1164GISEL-NEXT:    v_add_nc_u32_e32 v5, 32, v5
+; GFX1164GISEL-NEXT:    v_add_f32_dpp v3, v3, v3 row_shr:4 row_mask:0xf bank_mask:0xf
+; GFX1164GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GFX1164GISEL-NEXT:    v_mul_lo_u32 v5, 4, v5
+; GFX1164GISEL-NEXT:    v_add_f32_dpp v3, v3, v3 row_shr:8 row_mask:0xf bank_mask:0xf
+; GFX1164GISEL-NEXT:    ds_swizzle_b32 v4, v3 offset:swizzle(BROADCAST,32,15)
+; GFX1164GISEL-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX1164GISEL-NEXT:    v_sub_f32_e32 v3, v3, v4
+; GFX1164GISEL-NEXT:    ds_permute_b32 v4, v5, v3
+; GFX1164GISEL-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX1164GISEL-NEXT:    v_sub_f32_e32 v3, v3, v4
+; GFX1164GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1164GISEL-NEXT:    v_sub_f32_e32 v3, 0, v3
+; GFX1164GISEL-NEXT:    v_readlane_b32 s2, v3, 63
+; GFX1164GISEL-NEXT:    s_mov_b64 exec, s[0:1]
+; GFX1164GISEL-NEXT:    v_mov_b32_e32 v2, s2
+; GFX1164GISEL-NEXT:    global_store_b32 v[0:1], v2, off
+; GFX1164GISEL-NEXT:    s_xor_saveexec_b64 s[0:1], -1
+; GFX1164GISEL-NEXT:    s_waitcnt_depctr depctr_sa_sdst(0)
+; GFX1164GISEL-NEXT:    s_clause 0x2 ; 12-byte Folded Reload
+; GFX1164GISEL-NEXT:    scratch_load_b32 v3, off, s32
+; GFX1164GISEL-NEXT:    scratch_load_b32 v4, off, s32 offset:4
+; GFX1164GISEL-NEXT:    scratch_load_b32 v5, off, s32 offset:8
+; GFX1164GISEL-NEXT:    s_mov_b64 exec, s[0:1]
+; GFX1164GISEL-NEXT:    s_waitcnt vmcnt(0)
+; GFX1164GISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX1132DAGISEL-LABEL: divergent_value_float_dpp:
+; GFX1132DAGISEL:       ; %bb.0: ; %entry
+; GFX1132DAGISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX1132DAGISEL-NEXT:    s_xor_saveexec_b32 s0, -1
+; GFX1132DAGISEL-NEXT:    s_clause 0x1 ; 8-byte Folded Spill
+; GFX1132DAGISEL-NEXT:    scratch_store_b32 off, v3, s32
+; GFX1132DAGISEL-NEXT:    scratch_store_b32 off, v4, s32 offset:4
+; GFX1132DAGISEL-NEXT:    s_mov_b32 exec_lo, s0
+; GFX1132DAGISEL-NEXT:    s_or_saveexec_b32 s0, -1
+; GFX1132DAGISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1132DAGISEL-NEXT:    v_cndmask_b32_e64 v3, 0, v2, s0
+; GFX1132DAGISEL-NEXT:    v_add_f32_dpp v3, v3, v3 row_shr:1 row_mask:0xf bank_mask:0xf
+; GFX1132DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1132DAGISEL-NEXT:    v_add_f32_dpp v3, v3, v3 row_shr:2 row_mask:0xf bank_mask:0xf
+; GFX1132DAGISEL-NEXT:    v_add_f32_dpp v3, v3, v3 row_shr:4 row_mask:0xf bank_mask:0xf
+; GFX1132DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_3) | instid1(VALU_DEP_1)
+; GFX1132DAGISEL-NEXT:    v_add_f32_dpp v3, v3, v3 row_shr:8 row_mask:0xf bank_mask:0xf
+; GFX1132DAGISEL-NEXT:    ds_swizzle_b32 v4, v3 offset:swizzle(BROADCAST,32,15)
+; GFX1132DAGISEL-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX1132DAGISEL-NEXT:    v_sub_f32_e32 v3, v3, v4
+; GFX1132DAGISEL-NEXT:    v_sub_f32_e32 v3, 0, v3
+; GFX1132DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1132DAGISEL-NEXT:    v_readlane_b32 s1, v3, 31
+; GFX1132DAGISEL-NEXT:    s_mov_b32 exec_lo, s0
+; GFX1132DAGISEL-NEXT:    v_mov_b32_e32 v2, s1
+; GFX1132DAGISEL-NEXT:    global_store_b32 v[0:1], v2, off
+; GFX1132DAGISEL-NEXT:    s_xor_saveexec_b32 s0, -1
+; GFX1132DAGISEL-NEXT:    s_clause 0x1 ; 8-byte Folded Reload
+; GFX1132DAGISEL-NEXT:    scratch_load_b32 v3, off, s32
+; GFX1132DAGISEL-NEXT:    scratch_load_b32 v4, off, s32 offset:4
+; GFX1132DAGISEL-NEXT:    s_mov_b32 exec_lo, s0
+; GFX1132DAGISEL-NEXT:    s_waitcnt vmcnt(0)
+; GFX1132DAGISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX1132GISEL-LABEL: divergent_value_float_dpp:
+; GFX1132GISEL:       ; %bb.0: ; %entry
+; GFX1132GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX1132GISEL-NEXT:    s_xor_saveexec_b32 s0, -1
+; GFX1132GISEL-NEXT:    s_clause 0x1 ; 8-byte Folded Spill
+; GFX1132GISEL-NEXT:    scratch_store_b32 off, v3, s32
+; GFX1132GISEL-NEXT:    scratch_store_b32 off, v4, s32 offset:4
+; GFX1132GISEL-NEXT:    s_mov_b32 exec_lo, s0
+; GFX1132GISEL-NEXT:    s_or_saveexec_b32 s0, -1
+; GFX1132GISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1132GISEL-NEXT:    v_cndmask_b32_e64 v3, 0, v2, s0
+; GFX1132GISEL-NEXT:    v_add_f32_dpp v3, v3, v3 row_shr:1 row_mask:0xf bank_mask:0xf
+; GFX1132GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1132GISEL-NEXT:    v_add_f32_dpp v3, v3, v3 row_shr:2 row_mask:0xf bank_mask:0xf
+; GFX1132GISEL-NEXT:    v_add_f32_dpp v3, v3, v3 row_shr:4 row_mask:0xf bank_mask:0xf
+; GFX1132GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_3) | instid1(VALU_DEP_1)
+; GFX1132GISEL-NEXT:    v_add_f32_dpp v3, v3, v3 row_shr:8 row_mask:0xf bank_mask:0xf
+; GFX1132GISEL-NEXT:    ds_swizzle_b32 v4, v3 offset:swizzle(BROADCAST,32,15)
+; GFX1132GISEL-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX1132GISEL-NEXT:    v_sub_f32_e32 v3, v3, v4
+; GFX1132GISEL-NEXT:    v_sub_f32_e32 v3, 0, v3
+; GFX1132GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1132GISEL-NEXT:    v_readlane_b32 s1, v3, 31
+; GFX1132GISEL-NEXT:    s_mov_b32 exec_lo, s0
+; GFX1132GISEL-NEXT:    v_mov_b32_e32 v2, s1
+; GFX1132GISEL-NEXT:    global_store_b32 v[0:1], v2, off
+; GFX1132GISEL-NEXT:    s_xor_saveexec_b32 s0, -1
+; GFX1132GISEL-NEXT:    s_clause 0x1 ; 8-byte Folded Reload
+; GFX1132GISEL-NEXT:    scratch_load_b32 v3, off, s32
+; GFX1132GISEL-NEXT:    scratch_load_b32 v4, off, s32 offset:4
+; GFX1132GISEL-NEXT:    s_mov_b32 exec_lo, s0
+; GFX1132GISEL-NEXT:    s_waitcnt vmcnt(0)
+; GFX1132GISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12DAGISEL-LABEL: divergent_value_float_dpp:
+; GFX12DAGISEL:       ; %bb.0: ; %entry
+; GFX12DAGISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12DAGISEL-NEXT:    s_wait_expcnt 0x0
+; GFX12DAGISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX12DAGISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX12DAGISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX12DAGISEL-NEXT:    s_xor_saveexec_b32 s0, -1
+; GFX12DAGISEL-NEXT:    s_clause 0x1 ; 8-byte Folded Spill
+; GFX12DAGISEL-NEXT:    scratch_store_b32 off, v3, s32
+; GFX12DAGISEL-NEXT:    scratch_store_b32 off, v4, s32 offset:4
+; GFX12DAGISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12DAGISEL-NEXT:    s_mov_b32 exec_lo, s0
+; GFX12DAGISEL-NEXT:    s_or_saveexec_b32 s0, -1
+; GFX12DAGISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12DAGISEL-NEXT:    v_cndmask_b32_e64 v3, 0, v2, s0
+; GFX12DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX12DAGISEL-NEXT:    v_add_f32_dpp v3, v3, v3 row_shr:1 row_mask:0xf bank_mask:0xf
+; GFX12DAGISEL-NEXT:    v_add_f32_dpp v3, v3, v3 row_shr:2 row_mask:0xf bank_mask:0xf
+; GFX12DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX12DAGISEL-NEXT:    v_add_f32_dpp v3, v3, v3 row_shr:4 row_mask:0xf bank_mask:0xf
+; GFX12DAGISEL-NEXT:    v_add_f32_dpp v3, v3, v3 row_shr:8 row_mask:0xf bank_mask:0xf
+; GFX12DAGISEL-NEXT:    ds_swizzle_b32 v4, v3 offset:swizzle(BROADCAST,32,15)
+; GFX12DAGISEL-NEXT:    s_wait_dscnt 0x0
+; GFX12DAGISEL-NEXT:    v_sub_f32_e32 v3, v3, v4
+; GFX12DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX12DAGISEL-NEXT:    v_sub_f32_e32 v3, 0, v3
+; GFX12DAGISEL-NEXT:    v_readlane_b32 s1, v3, 31
+; GFX12DAGISEL-NEXT:    s_mov_b32 exec_lo, s0
+; GFX12DAGISEL-NEXT:    v_mov_b32_e32 v2, s1
+; GFX12DAGISEL-NEXT:    global_store_b32 v[0:1], v2, off
+; GFX12DAGISEL-NEXT:    s_xor_saveexec_b32 s0, -1
+; GFX12DAGISEL-NEXT:    s_clause 0x1 ; 8-byte Folded Reload
+; GFX12DAGISEL-NEXT:    scratch_load_b32 v3, off, s32
+; GFX12DAGISEL-NEXT:    scratch_load_b32 v4, off, s32 offset:4
+; GFX12DAGISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12DAGISEL-NEXT:    s_mov_b32 exec_lo, s0
+; GFX12DAGISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX12DAGISEL-NEXT:    s_setpc_b64 s[30:31]
+entry:
+  %result = call float @llvm.amdgcn.wave.reduce.fsub(float %id.x, i32 2)
+  store float %result, ptr addrspace(1) %out
+  ret void
+}
+
 define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in, float %in2) {
 ; GFX8DAGISEL-LABEL: divergent_cfg_float:
 ; GFX8DAGISEL:       ; %bb.0: ; %entry
@@ -499,7 +969,7 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX8DAGISEL-NEXT:    ; implicit-def: $sgpr6
 ; GFX8DAGISEL-NEXT:    s_and_saveexec_b64 s[2:3], vcc
 ; GFX8DAGISEL-NEXT:    s_xor_b64 s[2:3], exec, s[2:3]
-; GFX8DAGISEL-NEXT:    s_cbranch_execz .LBB2_2
+; GFX8DAGISEL-NEXT:    s_cbranch_execz .LBB3_2
 ; GFX8DAGISEL-NEXT:  ; %bb.1: ; %else
 ; GFX8DAGISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX8DAGISEL-NEXT:    s_bcnt1_i32_b64 s6, s[6:7]
@@ -507,11 +977,11 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX8DAGISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX8DAGISEL-NEXT:    v_mul_f32_e64 v0, -s0, v0
 ; GFX8DAGISEL-NEXT:    v_readfirstlane_b32 s6, v0
-; GFX8DAGISEL-NEXT:  .LBB2_2: ; %Flow
+; GFX8DAGISEL-NEXT:  .LBB3_2: ; %Flow
 ; GFX8DAGISEL-NEXT:    s_or_saveexec_b64 s[2:3], s[2:3]
 ; GFX8DAGISEL-NEXT:    v_mov_b32_e32 v0, s6
 ; GFX8DAGISEL-NEXT:    s_xor_b64 exec, exec, s[2:3]
-; GFX8DAGISEL-NEXT:    s_cbranch_execz .LBB2_4
+; GFX8DAGISEL-NEXT:    s_cbranch_execz .LBB3_4
 ; GFX8DAGISEL-NEXT:  ; %bb.3: ; %if
 ; GFX8DAGISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX8DAGISEL-NEXT:    s_waitcnt lgkmcnt(0)
@@ -520,7 +990,7 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX8DAGISEL-NEXT:    v_mul_f32_e64 v0, -s1, v0
 ; GFX8DAGISEL-NEXT:    v_readfirstlane_b32 s0, v0
 ; GFX8DAGISEL-NEXT:    v_mov_b32_e32 v0, s0
-; GFX8DAGISEL-NEXT:  .LBB2_4: ; %endif
+; GFX8DAGISEL-NEXT:  .LBB3_4: ; %endif
 ; GFX8DAGISEL-NEXT:    s_or_b64 exec, exec, s[2:3]
 ; GFX8DAGISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX8DAGISEL-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x24
@@ -537,7 +1007,7 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX8GISEL-NEXT:    ; implicit-def: $sgpr6
 ; GFX8GISEL-NEXT:    s_and_saveexec_b64 s[2:3], vcc
 ; GFX8GISEL-NEXT:    s_xor_b64 s[2:3], exec, s[2:3]
-; GFX8GISEL-NEXT:    s_cbranch_execz .LBB2_2
+; GFX8GISEL-NEXT:    s_cbranch_execz .LBB3_2
 ; GFX8GISEL-NEXT:  ; %bb.1: ; %else
 ; GFX8GISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX8GISEL-NEXT:    s_bcnt1_i32_b64 s6, s[6:7]
@@ -545,9 +1015,9 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX8GISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX8GISEL-NEXT:    v_mul_f32_e64 v0, -s0, v0
 ; GFX8GISEL-NEXT:    v_readfirstlane_b32 s6, v0
-; GFX8GISEL-NEXT:  .LBB2_2: ; %Flow
+; GFX8GISEL-NEXT:  .LBB3_2: ; %Flow
 ; GFX8GISEL-NEXT:    s_andn2_saveexec_b64 s[2:3], s[2:3]
-; GFX8GISEL-NEXT:    s_cbranch_execz .LBB2_4
+; GFX8GISEL-NEXT:    s_cbranch_execz .LBB3_4
 ; GFX8GISEL-NEXT:  ; %bb.3: ; %if
 ; GFX8GISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX8GISEL-NEXT:    s_waitcnt lgkmcnt(0)
@@ -555,7 +1025,7 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX8GISEL-NEXT:    v_cvt_f32_i32_e32 v0, s0
 ; GFX8GISEL-NEXT:    v_mul_f32_e64 v0, -s1, v0
 ; GFX8GISEL-NEXT:    v_readfirstlane_b32 s6, v0
-; GFX8GISEL-NEXT:  .LBB2_4: ; %endif
+; GFX8GISEL-NEXT:  .LBB3_4: ; %endif
 ; GFX8GISEL-NEXT:    s_or_b64 exec, exec, s[2:3]
 ; GFX8GISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX8GISEL-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x24
@@ -573,7 +1043,7 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX9DAGISEL-NEXT:    ; implicit-def: $sgpr6
 ; GFX9DAGISEL-NEXT:    s_and_saveexec_b64 s[2:3], vcc
 ; GFX9DAGISEL-NEXT:    s_xor_b64 s[2:3], exec, s[2:3]
-; GFX9DAGISEL-NEXT:    s_cbranch_execz .LBB2_2
+; GFX9DAGISEL-NEXT:    s_cbranch_execz .LBB3_2
 ; GFX9DAGISEL-NEXT:  ; %bb.1: ; %else
 ; GFX9DAGISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX9DAGISEL-NEXT:    s_bcnt1_i32_b64 s6, s[6:7]
@@ -581,11 +1051,11 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX9DAGISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX9DAGISEL-NEXT:    v_mul_f32_e64 v0, -s0, v0
 ; GFX9DAGISEL-NEXT:    v_readfirstlane_b32 s6, v0
-; GFX9DAGISEL-NEXT:  .LBB2_2: ; %Flow
+; GFX9DAGISEL-NEXT:  .LBB3_2: ; %Flow
 ; GFX9DAGISEL-NEXT:    s_or_saveexec_b64 s[2:3], s[2:3]
 ; GFX9DAGISEL-NEXT:    v_mov_b32_e32 v0, s6
 ; GFX9DAGISEL-NEXT:    s_xor_b64 exec, exec, s[2:3]
-; GFX9DAGISEL-NEXT:    s_cbranch_execz .LBB2_4
+; GFX9DAGISEL-NEXT:    s_cbranch_execz .LBB3_4
 ; GFX9DAGISEL-NEXT:  ; %bb.3: ; %if
 ; GFX9DAGISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX9DAGISEL-NEXT:    s_waitcnt lgkmcnt(0)
@@ -594,7 +1064,7 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX9DAGISEL-NEXT:    v_mul_f32_e64 v0, -s1, v0
 ; GFX9DAGISEL-NEXT:    v_readfirstlane_b32 s0, v0
 ; GFX9DAGISEL-NEXT:    v_mov_b32_e32 v0, s0
-; GFX9DAGISEL-NEXT:  .LBB2_4: ; %endif
+; GFX9DAGISEL-NEXT:  .LBB3_4: ; %endif
 ; GFX9DAGISEL-NEXT:    s_or_b64 exec, exec, s[2:3]
 ; GFX9DAGISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX9DAGISEL-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x24
@@ -610,7 +1080,7 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX9GISEL-NEXT:    ; implicit-def: $sgpr6
 ; GFX9GISEL-NEXT:    s_and_saveexec_b64 s[2:3], vcc
 ; GFX9GISEL-NEXT:    s_xor_b64 s[2:3], exec, s[2:3]
-; GFX9GISEL-NEXT:    s_cbranch_execz .LBB2_2
+; GFX9GISEL-NEXT:    s_cbranch_execz .LBB3_2
 ; GFX9GISEL-NEXT:  ; %bb.1: ; %else
 ; GFX9GISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX9GISEL-NEXT:    s_bcnt1_i32_b64 s6, s[6:7]
@@ -618,9 +1088,9 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX9GISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX9GISEL-NEXT:    v_mul_f32_e64 v0, -s0, v0
 ; GFX9GISEL-NEXT:    v_readfirstlane_b32 s6, v0
-; GFX9GISEL-NEXT:  .LBB2_2: ; %Flow
+; GFX9GISEL-NEXT:  .LBB3_2: ; %Flow
 ; GFX9GISEL-NEXT:    s_andn2_saveexec_b64 s[2:3], s[2:3]
-; GFX9GISEL-NEXT:    s_cbranch_execz .LBB2_4
+; GFX9GISEL-NEXT:    s_cbranch_execz .LBB3_4
 ; GFX9GISEL-NEXT:  ; %bb.3: ; %if
 ; GFX9GISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX9GISEL-NEXT:    s_waitcnt lgkmcnt(0)
@@ -628,7 +1098,7 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX9GISEL-NEXT:    v_cvt_f32_i32_e32 v0, s0
 ; GFX9GISEL-NEXT:    v_mul_f32_e64 v0, -s1, v0
 ; GFX9GISEL-NEXT:    v_readfirstlane_b32 s6, v0
-; GFX9GISEL-NEXT:  .LBB2_4: ; %endif
+; GFX9GISEL-NEXT:  .LBB3_4: ; %endif
 ; GFX9GISEL-NEXT:    s_or_b64 exec, exec, s[2:3]
 ; GFX9GISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX9GISEL-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x24
@@ -645,7 +1115,7 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX1064DAGISEL-NEXT:    ; implicit-def: $sgpr6
 ; GFX1064DAGISEL-NEXT:    s_and_saveexec_b64 s[2:3], vcc
 ; GFX1064DAGISEL-NEXT:    s_xor_b64 s[2:3], exec, s[2:3]
-; GFX1064DAGISEL-NEXT:    s_cbranch_execz .LBB2_2
+; GFX1064DAGISEL-NEXT:    s_cbranch_execz .LBB3_2
 ; GFX1064DAGISEL-NEXT:  ; %bb.1: ; %else
 ; GFX1064DAGISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX1064DAGISEL-NEXT:    s_bcnt1_i32_b64 s6, s[6:7]
@@ -653,11 +1123,11 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX1064DAGISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX1064DAGISEL-NEXT:    v_mul_f32_e64 v0, -s0, v0
 ; GFX1064DAGISEL-NEXT:    v_readfirstlane_b32 s6, v0
-; GFX1064DAGISEL-NEXT:  .LBB2_2: ; %Flow
+; GFX1064DAGISEL-NEXT:  .LBB3_2: ; %Flow
 ; GFX1064DAGISEL-NEXT:    s_or_saveexec_b64 s[2:3], s[2:3]
 ; GFX1064DAGISEL-NEXT:    v_mov_b32_e32 v0, s6
 ; GFX1064DAGISEL-NEXT:    s_xor_b64 exec, exec, s[2:3]
-; GFX1064DAGISEL-NEXT:    s_cbranch_execz .LBB2_4
+; GFX1064DAGISEL-NEXT:    s_cbranch_execz .LBB3_4
 ; GFX1064DAGISEL-NEXT:  ; %bb.3: ; %if
 ; GFX1064DAGISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX1064DAGISEL-NEXT:    s_waitcnt lgkmcnt(0)
@@ -666,7 +1136,7 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX1064DAGISEL-NEXT:    v_mul_f32_e64 v0, -s1, v0
 ; GFX1064DAGISEL-NEXT:    v_readfirstlane_b32 s0, v0
 ; GFX1064DAGISEL-NEXT:    v_mov_b32_e32 v0, s0
-; GFX1064DAGISEL-NEXT:  .LBB2_4: ; %endif
+; GFX1064DAGISEL-NEXT:  .LBB3_4: ; %endif
 ; GFX1064DAGISEL-NEXT:    s_or_b64 exec, exec, s[2:3]
 ; GFX1064DAGISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX1064DAGISEL-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x24
@@ -682,7 +1152,7 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX1064GISEL-NEXT:    ; implicit-def: $sgpr6
 ; GFX1064GISEL-NEXT:    s_and_saveexec_b64 s[2:3], vcc
 ; GFX1064GISEL-NEXT:    s_xor_b64 s[2:3], exec, s[2:3]
-; GFX1064GISEL-NEXT:    s_cbranch_execz .LBB2_2
+; GFX1064GISEL-NEXT:    s_cbranch_execz .LBB3_2
 ; GFX1064GISEL-NEXT:  ; %bb.1: ; %else
 ; GFX1064GISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX1064GISEL-NEXT:    s_bcnt1_i32_b64 s6, s[6:7]
@@ -690,9 +1160,9 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX1064GISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX1064GISEL-NEXT:    v_mul_f32_e64 v0, -s0, v0
 ; GFX1064GISEL-NEXT:    v_readfirstlane_b32 s6, v0
-; GFX1064GISEL-NEXT:  .LBB2_2: ; %Flow
+; GFX1064GISEL-NEXT:  .LBB3_2: ; %Flow
 ; GFX1064GISEL-NEXT:    s_andn2_saveexec_b64 s[2:3], s[2:3]
-; GFX1064GISEL-NEXT:    s_cbranch_execz .LBB2_4
+; GFX1064GISEL-NEXT:    s_cbranch_execz .LBB3_4
 ; GFX1064GISEL-NEXT:  ; %bb.3: ; %if
 ; GFX1064GISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX1064GISEL-NEXT:    s_waitcnt lgkmcnt(0)
@@ -700,7 +1170,7 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX1064GISEL-NEXT:    v_cvt_f32_i32_e32 v0, s0
 ; GFX1064GISEL-NEXT:    v_mul_f32_e64 v0, -s1, v0
 ; GFX1064GISEL-NEXT:    v_readfirstlane_b32 s6, v0
-; GFX1064GISEL-NEXT:  .LBB2_4: ; %endif
+; GFX1064GISEL-NEXT:  .LBB3_4: ; %endif
 ; GFX1064GISEL-NEXT:    s_or_b64 exec, exec, s[2:3]
 ; GFX1064GISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX1064GISEL-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x24
@@ -717,7 +1187,7 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX1032DAGISEL-NEXT:    ; implicit-def: $sgpr3
 ; GFX1032DAGISEL-NEXT:    s_and_saveexec_b32 s2, vcc_lo
 ; GFX1032DAGISEL-NEXT:    s_xor_b32 s2, exec_lo, s2
-; GFX1032DAGISEL-NEXT:    s_cbranch_execz .LBB2_2
+; GFX1032DAGISEL-NEXT:    s_cbranch_execz .LBB3_2
 ; GFX1032DAGISEL-NEXT:  ; %bb.1: ; %else
 ; GFX1032DAGISEL-NEXT:    s_mov_b32 s3, exec_lo
 ; GFX1032DAGISEL-NEXT:    s_bcnt1_i32_b32 s3, s3
@@ -725,12 +1195,12 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX1032DAGISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX1032DAGISEL-NEXT:    v_mul_f32_e64 v0, -s0, v0
 ; GFX1032DAGISEL-NEXT:    v_readfirstlane_b32 s3, v0
-; GFX1032DAGISEL-NEXT:  .LBB2_2: ; %Flow
+; GFX1032DAGISEL-NEXT:  .LBB3_2: ; %Flow
 ; GFX1032DAGISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX1032DAGISEL-NEXT:    s_or_saveexec_b32 s0, s2
 ; GFX1032DAGISEL-NEXT:    v_mov_b32_e32 v0, s3
 ; GFX1032DAGISEL-NEXT:    s_xor_b32 exec_lo, exec_lo, s0
-; GFX1032DAGISEL-NEXT:    s_cbranch_execz .LBB2_4
+; GFX1032DAGISEL-NEXT:    s_cbranch_execz .LBB3_4
 ; GFX1032DAGISEL-NEXT:  ; %bb.3: ; %if
 ; GFX1032DAGISEL-NEXT:    s_mov_b32 s2, exec_lo
 ; GFX1032DAGISEL-NEXT:    s_bcnt1_i32_b32 s2, s2
@@ -738,7 +1208,7 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX1032DAGISEL-NEXT:    v_mul_f32_e64 v0, -s1, v0
 ; GFX1032DAGISEL-NEXT:    v_readfirstlane_b32 s1, v0
 ; GFX1032DAGISEL-NEXT:    v_mov_b32_e32 v0, s1
-; GFX1032DAGISEL-NEXT:  .LBB2_4: ; %endif
+; GFX1032DAGISEL-NEXT:  .LBB3_4: ; %endif
 ; GFX1032DAGISEL-NEXT:    s_or_b32 exec_lo, exec_lo, s0
 ; GFX1032DAGISEL-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x24
 ; GFX1032DAGISEL-NEXT:    v_mov_b32_e32 v1, 0
@@ -753,7 +1223,7 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX1032GISEL-NEXT:    ; implicit-def: $sgpr2
 ; GFX1032GISEL-NEXT:    s_and_saveexec_b32 s3, vcc_lo
 ; GFX1032GISEL-NEXT:    s_xor_b32 s3, exec_lo, s3
-; GFX1032GISEL-NEXT:    s_cbranch_execz .LBB2_2
+; GFX1032GISEL-NEXT:    s_cbranch_execz .LBB3_2
 ; GFX1032GISEL-NEXT:  ; %bb.1: ; %else
 ; GFX1032GISEL-NEXT:    s_mov_b32 s2, exec_lo
 ; GFX1032GISEL-NEXT:    s_bcnt1_i32_b32 s2, s2
@@ -761,17 +1231,17 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX1032GISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX1032GISEL-NEXT:    v_mul_f32_e64 v0, -s0, v0
 ; GFX1032GISEL-NEXT:    v_readfirstlane_b32 s2, v0
-; GFX1032GISEL-NEXT:  .LBB2_2: ; %Flow
+; GFX1032GISEL-NEXT:  .LBB3_2: ; %Flow
 ; GFX1032GISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX1032GISEL-NEXT:    s_andn2_saveexec_b32 s0, s3
-; GFX1032GISEL-NEXT:    s_cbranch_execz .LBB2_4
+; GFX1032GISEL-NEXT:    s_cbranch_execz .LBB3_4
 ; GFX1032GISEL-NEXT:  ; %bb.3: ; %if
 ; GFX1032GISEL-NEXT:    s_mov_b32 s2, exec_lo
 ; GFX1032GISEL-NEXT:    s_bcnt1_i32_b32 s2, s2
 ; GFX1032GISEL-NEXT:    v_cvt_f32_i32_e32 v0, s2
 ; GFX1032GISEL-NEXT:    v_mul_f32_e64 v0, -s1, v0
 ; GFX1032GISEL-NEXT:    v_readfirstlane_b32 s2, v0
-; GFX1032GISEL-NEXT:  .LBB2_4: ; %endif
+; GFX1032GISEL-NEXT:  .LBB3_4: ; %endif
 ; GFX1032GISEL-NEXT:    s_or_b32 exec_lo, exec_lo, s0
 ; GFX1032GISEL-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x24
 ; GFX1032GISEL-NEXT:    v_mov_b32_e32 v0, s2
@@ -789,7 +1259,7 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX1164DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX1164DAGISEL-NEXT:    v_cmpx_lt_u32_e32 15, v0
 ; GFX1164DAGISEL-NEXT:    s_xor_b64 s[2:3], exec, s[2:3]
-; GFX1164DAGISEL-NEXT:    s_cbranch_execz .LBB2_2
+; GFX1164DAGISEL-NEXT:    s_cbranch_execz .LBB3_2
 ; GFX1164DAGISEL-NEXT:  ; %bb.1: ; %else
 ; GFX1164DAGISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX1164DAGISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
@@ -799,12 +1269,12 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX1164DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
 ; GFX1164DAGISEL-NEXT:    v_mul_f32_e64 v0, -s0, v0
 ; GFX1164DAGISEL-NEXT:    v_readfirstlane_b32 s6, v0
-; GFX1164DAGISEL-NEXT:  .LBB2_2: ; %Flow
+; GFX1164DAGISEL-NEXT:  .LBB3_2: ; %Flow
 ; GFX1164DAGISEL-NEXT:    s_or_saveexec_b64 s[2:3], s[2:3]
 ; GFX1164DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX1164DAGISEL-NEXT:    v_mov_b32_e32 v0, s6
 ; GFX1164DAGISEL-NEXT:    s_xor_b64 exec, exec, s[2:3]
-; GFX1164DAGISEL-NEXT:    s_cbranch_execz .LBB2_4
+; GFX1164DAGISEL-NEXT:    s_cbranch_execz .LBB3_4
 ; GFX1164DAGISEL-NEXT:  ; %bb.3: ; %if
 ; GFX1164DAGISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX1164DAGISEL-NEXT:    s_waitcnt lgkmcnt(0)
@@ -815,7 +1285,7 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX1164DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
 ; GFX1164DAGISEL-NEXT:    v_readfirstlane_b32 s0, v0
 ; GFX1164DAGISEL-NEXT:    v_mov_b32_e32 v0, s0
-; GFX1164DAGISEL-NEXT:  .LBB2_4: ; %endif
+; GFX1164DAGISEL-NEXT:  .LBB3_4: ; %endif
 ; GFX1164DAGISEL-NEXT:    s_or_b64 exec, exec, s[2:3]
 ; GFX1164DAGISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX1164DAGISEL-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24
@@ -833,7 +1303,7 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX1164GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX1164GISEL-NEXT:    v_cmpx_le_u32_e32 16, v0
 ; GFX1164GISEL-NEXT:    s_xor_b64 s[2:3], exec, s[2:3]
-; GFX1164GISEL-NEXT:    s_cbranch_execz .LBB2_2
+; GFX1164GISEL-NEXT:    s_cbranch_execz .LBB3_2
 ; GFX1164GISEL-NEXT:  ; %bb.1: ; %else
 ; GFX1164GISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX1164GISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
@@ -843,9 +1313,9 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX1164GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
 ; GFX1164GISEL-NEXT:    v_mul_f32_e64 v0, -s0, v0
 ; GFX1164GISEL-NEXT:    v_readfirstlane_b32 s6, v0
-; GFX1164GISEL-NEXT:  .LBB2_2: ; %Flow
+; GFX1164GISEL-NEXT:  .LBB3_2: ; %Flow
 ; GFX1164GISEL-NEXT:    s_and_not1_saveexec_b64 s[2:3], s[2:3]
-; GFX1164GISEL-NEXT:    s_cbranch_execz .LBB2_4
+; GFX1164GISEL-NEXT:    s_cbranch_execz .LBB3_4
 ; GFX1164GISEL-NEXT:  ; %bb.3: ; %if
 ; GFX1164GISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX1164GISEL-NEXT:    s_waitcnt lgkmcnt(0)
@@ -855,7 +1325,7 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX1164GISEL-NEXT:    v_mul_f32_e64 v0, -s1, v0
 ; GFX1164GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX1164GISEL-NEXT:    v_readfirstlane_b32 s6, v0
-; GFX1164GISEL-NEXT:  .LBB2_4: ; %endif
+; GFX1164GISEL-NEXT:  .LBB3_4: ; %endif
 ; GFX1164GISEL-NEXT:    s_or_b64 exec, exec, s[2:3]
 ; GFX1164GISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX1164GISEL-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24
@@ -875,7 +1345,7 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX1132DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX1132DAGISEL-NEXT:    v_cmpx_lt_u32_e32 15, v0
 ; GFX1132DAGISEL-NEXT:    s_xor_b32 s2, exec_lo, s2
-; GFX1132DAGISEL-NEXT:    s_cbranch_execz .LBB2_2
+; GFX1132DAGISEL-NEXT:    s_cbranch_execz .LBB3_2
 ; GFX1132DAGISEL-NEXT:  ; %bb.1: ; %else
 ; GFX1132DAGISEL-NEXT:    s_mov_b32 s3, exec_lo
 ; GFX1132DAGISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
@@ -885,13 +1355,13 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX1132DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
 ; GFX1132DAGISEL-NEXT:    v_mul_f32_e64 v0, -s0, v0
 ; GFX1132DAGISEL-NEXT:    v_readfirstlane_b32 s3, v0
-; GFX1132DAGISEL-NEXT:  .LBB2_2: ; %Flow
+; GFX1132DAGISEL-NEXT:  .LBB3_2: ; %Flow
 ; GFX1132DAGISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX1132DAGISEL-NEXT:    s_or_saveexec_b32 s0, s2
 ; GFX1132DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX1132DAGISEL-NEXT:    v_mov_b32_e32 v0, s3
 ; GFX1132DAGISEL-NEXT:    s_xor_b32 exec_lo, exec_lo, s0
-; GFX1132DAGISEL-NEXT:    s_cbranch_execz .LBB2_4
+; GFX1132DAGISEL-NEXT:    s_cbranch_execz .LBB3_4
 ; GFX1132DAGISEL-NEXT:  ; %bb.3: ; %if
 ; GFX1132DAGISEL-NEXT:    s_mov_b32 s2, exec_lo
 ; GFX1132DAGISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
@@ -902,7 +1372,7 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX1132DAGISEL-NEXT:    v_readfirstlane_b32 s1, v0
 ; GFX1132DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX1132DAGISEL-NEXT:    v_mov_b32_e32 v0, s1
-; GFX1132DAGISEL-NEXT:  .LBB2_4: ; %endif
+; GFX1132DAGISEL-NEXT:  .LBB3_4: ; %endif
 ; GFX1132DAGISEL-NEXT:    s_or_b32 exec_lo, exec_lo, s0
 ; GFX1132DAGISEL-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24
 ; GFX1132DAGISEL-NEXT:    v_mov_b32_e32 v1, 0
@@ -919,7 +1389,7 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX1132GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX1132GISEL-NEXT:    v_cmpx_le_u32_e32 16, v0
 ; GFX1132GISEL-NEXT:    s_xor_b32 s3, exec_lo, s3
-; GFX1132GISEL-NEXT:    s_cbranch_execz .LBB2_2
+; GFX1132GISEL-NEXT:    s_cbranch_execz .LBB3_2
 ; GFX1132GISEL-NEXT:  ; %bb.1: ; %else
 ; GFX1132GISEL-NEXT:    s_mov_b32 s2, exec_lo
 ; GFX1132GISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
@@ -929,10 +1399,10 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX1132GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
 ; GFX1132GISEL-NEXT:    v_mul_f32_e64 v0, -s0, v0
 ; GFX1132GISEL-NEXT:    v_readfirstlane_b32 s2, v0
-; GFX1132GISEL-NEXT:  .LBB2_2: ; %Flow
+; GFX1132GISEL-NEXT:  .LBB3_2: ; %Flow
 ; GFX1132GISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX1132GISEL-NEXT:    s_and_not1_saveexec_b32 s0, s3
-; GFX1132GISEL-NEXT:    s_cbranch_execz .LBB2_4
+; GFX1132GISEL-NEXT:    s_cbranch_execz .LBB3_4
 ; GFX1132GISEL-NEXT:  ; %bb.3: ; %if
 ; GFX1132GISEL-NEXT:    s_mov_b32 s2, exec_lo
 ; GFX1132GISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
@@ -941,7 +1411,7 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX1132GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
 ; GFX1132GISEL-NEXT:    v_mul_f32_e64 v0, -s1, v0
 ; GFX1132GISEL-NEXT:    v_readfirstlane_b32 s2, v0
-; GFX1132GISEL-NEXT:  .LBB2_4: ; %endif
+; GFX1132GISEL-NEXT:  .LBB3_4: ; %endif
 ; GFX1132GISEL-NEXT:    s_or_b32 exec_lo, exec_lo, s0
 ; GFX1132GISEL-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24
 ; GFX1132GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
@@ -959,7 +1429,7 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX12DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX12DAGISEL-NEXT:    v_cmpx_lt_u32_e32 15, v0
 ; GFX12DAGISEL-NEXT:    s_xor_b32 s2, exec_lo, s2
-; GFX12DAGISEL-NEXT:    s_cbranch_execz .LBB2_2
+; GFX12DAGISEL-NEXT:    s_cbranch_execz .LBB3_2
 ; GFX12DAGISEL-NEXT:  ; %bb.1: ; %else
 ; GFX12DAGISEL-NEXT:    s_mov_b32 s3, exec_lo
 ; GFX12DAGISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
@@ -969,14 +1439,14 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX12DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
 ; GFX12DAGISEL-NEXT:    v_mul_f32_e64 v0, -s0, v0
 ; GFX12DAGISEL-NEXT:    v_readfirstlane_b32 s3, v0
-; GFX12DAGISEL-NEXT:  .LBB2_2: ; %Flow
+; GFX12DAGISEL-NEXT:  .LBB3_2: ; %Flow
 ; GFX12DAGISEL-NEXT:    s_wait_kmcnt 0x0
 ; GFX12DAGISEL-NEXT:    s_or_saveexec_b32 s0, s2
 ; GFX12DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX12DAGISEL-NEXT:    v_mov_b32_e32 v0, s3
 ; GFX12DAGISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
 ; GFX12DAGISEL-NEXT:    s_xor_b32 exec_lo, exec_lo, s0
-; GFX12DAGISEL-NEXT:    s_cbranch_execz .LBB2_4
+; GFX12DAGISEL-NEXT:    s_cbranch_execz .LBB3_4
 ; GFX12DAGISEL-NEXT:  ; %bb.3: ; %if
 ; GFX12DAGISEL-NEXT:    s_mov_b32 s2, exec_lo
 ; GFX12DAGISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
@@ -989,7 +1459,7 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX12DAGISEL-NEXT:    s_wait_alu depctr_va_sdst(0)
 ; GFX12DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX12DAGISEL-NEXT:    v_mov_b32_e32 v0, s1
-; GFX12DAGISEL-NEXT:  .LBB2_4: ; %endif
+; GFX12DAGISEL-NEXT:  .LBB3_4: ; %endif
 ; GFX12DAGISEL-NEXT:    s_or_b32 exec_lo, exec_lo, s0
 ; GFX12DAGISEL-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24
 ; GFX12DAGISEL-NEXT:    v_mov_b32_e32 v1, 0
@@ -1250,7 +1720,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %id.x) {
 ; GFX8DAGISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX8DAGISEL-NEXT:    s_mov_b64 s[6:7], 0
 ; GFX8DAGISEL-NEXT:    s_mov_b64 s[4:5], exec
-; GFX8DAGISEL-NEXT:  .LBB4_1: ; =>This Inner Loop Header: Depth=1
+; GFX8DAGISEL-NEXT:  .LBB5_1: ; =>This Inner Loop Header: Depth=1
 ; GFX8DAGISEL-NEXT:    s_ff1_i32_b64 s10, s[4:5]
 ; GFX8DAGISEL-NEXT:    v_mov_b32_e32 v4, s6
 ; GFX8DAGISEL-NEXT:    v_readlane_b32 s8, v2, s10
@@ -1261,7 +1731,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %id.x) {
 ; GFX8DAGISEL-NEXT:    s_cmp_lg_u64 s[4:5], 0
 ; GFX8DAGISEL-NEXT:    v_readfirstlane_b32 s6, v4
 ; GFX8DAGISEL-NEXT:    v_readfirstlane_b32 s7, v5
-; GFX8DAGISEL-NEXT:    s_cbranch_scc1 .LBB4_1
+; GFX8DAGISEL-NEXT:    s_cbranch_scc1 .LBB5_1
 ; GFX8DAGISEL-NEXT:  ; %bb.2:
 ; GFX8DAGISEL-NEXT:    v_mov_b32_e32 v2, s6
 ; GFX8DAGISEL-NEXT:    v_mov_b32_e32 v3, s7
@@ -1274,7 +1744,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %id.x) {
 ; GFX8GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX8GISEL-NEXT:    s_mov_b64 s[6:7], 0
 ; GFX8GISEL-NEXT:    s_mov_b64 s[4:5], exec
-; GFX8GISEL-NEXT:  .LBB4_1: ; =>This Inner Loop Header: Depth=1
+; GFX8GISEL-NEXT:  .LBB5_1: ; =>This Inner Loop Header: Depth=1
 ; GFX8GISEL-NEXT:    s_ff1_i32_b64 s10, s[4:5]
 ; GFX8GISEL-NEXT:    v_mov_b32_e32 v4, s6
 ; GFX8GISEL-NEXT:    v_readlane_b32 s8, v2, s10
@@ -1285,7 +1755,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %id.x) {
 ; GFX8GISEL-NEXT:    s_cmp_lg_u64 s[4:5], 0
 ; GFX8GISEL-NEXT:    v_readfirstlane_b32 s6, v4
 ; GFX8GISEL-NEXT:    v_readfirstlane_b32 s7, v5
-; GFX8GISEL-NEXT:    s_cbranch_scc1 .LBB4_1
+; GFX8GISEL-NEXT:    s_cbranch_scc1 .LBB5_1
 ; GFX8GISEL-NEXT:  ; %bb.2:
 ; GFX8GISEL-NEXT:    v_mov_b32_e32 v2, s6
 ; GFX8GISEL-NEXT:    v_mov_b32_e32 v3, s7
@@ -1298,7 +1768,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %id.x) {
 ; GFX9DAGISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX9DAGISEL-NEXT:    s_mov_b64 s[6:7], 0
 ; GFX9DAGISEL-NEXT:    s_mov_b64 s[4:5], exec
-; GFX9DAGISEL-NEXT:  .LBB4_1: ; =>This Inner Loop Header: Depth=1
+; GFX9DAGISEL-NEXT:  .LBB5_1: ; =>This Inner Loop Header: Depth=1
 ; GFX9DAGISEL-NEXT:    s_ff1_i32_b64 s10, s[4:5]
 ; GFX9DAGISEL-NEXT:    v_mov_b32_e32 v4, s6
 ; GFX9DAGISEL-NEXT:    v_readlane_b32 s8, v2, s10
@@ -1309,7 +1779,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %id.x) {
 ; GFX9DAGISEL-NEXT:    s_cmp_lg_u64 s[4:5], 0
 ; GFX9DAGISEL-NEXT:    v_readfirstlane_b32 s6, v4
 ; GFX9DAGISEL-NEXT:    v_readfirstlane_b32 s7, v5
-; GFX9DAGISEL-NEXT:    s_cbranch_scc1 .LBB4_1
+; GFX9DAGISEL-NEXT:    s_cbranch_scc1 .LBB5_1
 ; GFX9DAGISEL-NEXT:  ; %bb.2:
 ; GFX9DAGISEL-NEXT:    v_mov_b32_e32 v2, s6
 ; GFX9DAGISEL-NEXT:    v_mov_b32_e32 v3, s7
@@ -1322,7 +1792,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %id.x) {
 ; GFX9GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX9GISEL-NEXT:    s_mov_b64 s[6:7], 0
 ; GFX9GISEL-NEXT:    s_mov_b64 s[4:5], exec
-; GFX9GISEL-NEXT:  .LBB4_1: ; =>This Inner Loop Header: Depth=1
+; GFX9GISEL-NEXT:  .LBB5_1: ; =>This Inner Loop Header: Depth=1
 ; GFX9GISEL-NEXT:    s_ff1_i32_b64 s10, s[4:5]
 ; GFX9GISEL-NEXT:    v_mov_b32_e32 v4, s6
 ; GFX9GISEL-NEXT:    v_readlane_b32 s8, v2, s10
@@ -1333,7 +1803,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %id.x) {
 ; GFX9GISEL-NEXT:    s_cmp_lg_u64 s[4:5], 0
 ; GFX9GISEL-NEXT:    v_readfirstlane_b32 s6, v4
 ; GFX9GISEL-NEXT:    v_readfirstlane_b32 s7, v5
-; GFX9GISEL-NEXT:    s_cbranch_scc1 .LBB4_1
+; GFX9GISEL-NEXT:    s_cbranch_scc1 .LBB5_1
 ; GFX9GISEL-NEXT:  ; %bb.2:
 ; GFX9GISEL-NEXT:    v_mov_b32_e32 v2, s6
 ; GFX9GISEL-NEXT:    v_mov_b32_e32 v3, s7
@@ -1346,7 +1816,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %id.x) {
 ; GFX1064DAGISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX1064DAGISEL-NEXT:    s_mov_b64 s[6:7], 0
 ; GFX1064DAGISEL-NEXT:    s_mov_b64 s[4:5], exec
-; GFX1064DAGISEL-NEXT:  .LBB4_1: ; =>This Inner Loop Header: Depth=1
+; GFX1064DAGISEL-NEXT:  .LBB5_1: ; =>This Inner Loop Header: Depth=1
 ; GFX1064DAGISEL-NEXT:    s_ff1_i32_b64 s10, s[4:5]
 ; GFX1064DAGISEL-NEXT:    v_readlane_b32 s8, v2, s10
 ; GFX1064DAGISEL-NEXT:    v_readlane_b32 s9, v3, s10
@@ -1355,7 +1825,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %id.x) {
 ; GFX1064DAGISEL-NEXT:    v_add_f64 v[4:5], -s[8:9], s[6:7]
 ; GFX1064DAGISEL-NEXT:    v_readfirstlane_b32 s6, v4
 ; GFX1064DAGISEL-NEXT:    v_readfirstlane_b32 s7, v5
-; GFX1064DAGISEL-NEXT:    s_cbranch_scc1 .LBB4_1
+; GFX1064DAGISEL-NEXT:    s_cbranch_scc1 .LBB5_1
 ; GFX1064DAGISEL-NEXT:  ; %bb.2:
 ; GFX1064DAGISEL-NEXT:    v_mov_b32_e32 v2, s6
 ; GFX1064DAGISEL-NEXT:    v_mov_b32_e32 v3, s7
@@ -1367,7 +1837,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %id.x) {
 ; GFX1064GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX1064GISEL-NEXT:    s_mov_b64 s[6:7], 0
 ; GFX1064GISEL-NEXT:    s_mov_b64 s[4:5], exec
-; GFX1064GISEL-NEXT:  .LBB4_1: ; =>This Inner Loop Header: Depth=1
+; GFX1064GISEL-NEXT:  .LBB5_1: ; =>This Inner Loop Header: Depth=1
 ; GFX1064GISEL-NEXT:    s_ff1_i32_b64 s10, s[4:5]
 ; GFX1064GISEL-NEXT:    v_readlane_b32 s8, v2, s10
 ; GFX1064GISEL-NEXT:    v_readlane_b32 s9, v3, s10
@@ -1376,7 +1846,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %id.x) {
 ; GFX1064GISEL-NEXT:    v_add_f64 v[4:5], -s[8:9], s[6:7]
 ; GFX1064GISEL-NEXT:    v_readfirstlane_b32 s6, v4
 ; GFX1064GISEL-NEXT:    v_readfirstlane_b32 s7, v5
-; GFX1064GISEL-NEXT:    s_cbranch_scc1 .LBB4_1
+; GFX1064GISEL-NEXT:    s_cbranch_scc1 .LBB5_1
 ; GFX1064GISEL-NEXT:  ; %bb.2:
 ; GFX1064GISEL-NEXT:    v_mov_b32_e32 v2, s6
 ; GFX1064GISEL-NEXT:    v_mov_b32_e32 v3, s7
@@ -1388,7 +1858,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %id.x) {
 ; GFX1032DAGISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX1032DAGISEL-NEXT:    s_mov_b64 s[4:5], 0
 ; GFX1032DAGISEL-NEXT:    s_mov_b32 s6, exec_lo
-; GFX1032DAGISEL-NEXT:  .LBB4_1: ; =>This Inner Loop Header: Depth=1
+; GFX1032DAGISEL-NEXT:  .LBB5_1: ; =>This Inner Loop Header: Depth=1
 ; GFX1032DAGISEL-NEXT:    s_ff1_i32_b32 s7, s6
 ; GFX1032DAGISEL-NEXT:    v_readlane_b32 s8, v2, s7
 ; GFX1032DAGISEL-NEXT:    v_readlane_b32 s9, v3, s7
@@ -1397,7 +1867,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %id.x) {
 ; GFX1032DAGISEL-NEXT:    v_add_f64 v[4:5], -s[8:9], s[4:5]
 ; GFX1032DAGISEL-NEXT:    v_readfirstlane_b32 s4, v4
 ; GFX1032DAGISEL-NEXT:    v_readfirstlane_b32 s5, v5
-; GFX1032DAGISEL-NEXT:    s_cbranch_scc1 .LBB4_1
+; GFX1032DAGISEL-NEXT:    s_cbranch_scc1 .LBB5_1
 ; GFX1032DAGISEL-NEXT:  ; %bb.2:
 ; GFX1032DAGISEL-NEXT:    v_mov_b32_e32 v2, s4
 ; GFX1032DAGISEL-NEXT:    v_mov_b32_e32 v3, s5
@@ -1409,7 +1879,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %id.x) {
 ; GFX1032GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX1032GISEL-NEXT:    s_mov_b64 s[4:5], 0
 ; GFX1032GISEL-NEXT:    s_mov_b32 s6, exec_lo
-; GFX1032GISEL-NEXT:  .LBB4_1: ; =>This Inner Loop Header: Depth=1
+; GFX1032GISEL-NEXT:  .LBB5_1: ; =>This Inner Loop Header: Depth=1
 ; GFX1032GISEL-NEXT:    s_ff1_i32_b32 s7, s6
 ; GFX1032GISEL-NEXT:    v_readlane_b32 s8, v2, s7
 ; GFX1032GISEL-NEXT:    v_readlane_b32 s9, v3, s7
@@ -1418,7 +1888,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %id.x) {
 ; GFX1032GISEL-NEXT:    v_add_f64 v[4:5], -s[8:9], s[4:5]
 ; GFX1032GISEL-NEXT:    v_readfirstlane_b32 s4, v4
 ; GFX1032GISEL-NEXT:    v_readfirstlane_b32 s5, v5
-; GFX1032GISEL-NEXT:    s_cbranch_scc1 .LBB4_1
+; GFX1032GISEL-NEXT:    s_cbranch_scc1 .LBB5_1
 ; GFX1032GISEL-NEXT:  ; %bb.2:
 ; GFX1032GISEL-NEXT:    v_mov_b32_e32 v2, s4
 ; GFX1032GISEL-NEXT:    v_mov_b32_e32 v3, s5
@@ -1430,7 +1900,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %id.x) {
 ; GFX1164DAGISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX1164DAGISEL-NEXT:    s_mov_b64 s[2:3], 0
 ; GFX1164DAGISEL-NEXT:    s_mov_b64 s[0:1], exec
-; GFX1164DAGISEL-NEXT:  .LBB4_1: ; =>This Inner Loop Header: Depth=1
+; GFX1164DAGISEL-NEXT:  .LBB5_1: ; =>This Inner Loop Header: Depth=1
 ; GFX1164DAGISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
 ; GFX1164DAGISEL-NEXT:    s_ctz_i32_b64 s6, s[0:1]
 ; GFX1164DAGISEL-NEXT:    v_readlane_b32 s4, v2, s6
@@ -1442,7 +1912,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %id.x) {
 ; GFX1164DAGISEL-NEXT:    v_readfirstlane_b32 s2, v4
 ; GFX1164DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2)
 ; GFX1164DAGISEL-NEXT:    v_readfirstlane_b32 s3, v5
-; GFX1164DAGISEL-NEXT:    s_cbranch_scc1 .LBB4_1
+; GFX1164DAGISEL-NEXT:    s_cbranch_scc1 .LBB5_1
 ; GFX1164DAGISEL-NEXT:  ; %bb.2:
 ; GFX1164DAGISEL-NEXT:    v_mov_b32_e32 v2, s2
 ; GFX1164DAGISEL-NEXT:    v_mov_b32_e32 v3, s3
@@ -1454,7 +1924,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %id.x) {
 ; GFX1164GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX1164GISEL-NEXT:    s_mov_b64 s[2:3], 0
 ; GFX1164GISEL-NEXT:    s_mov_b64 s[0:1], exec
-; GFX1164GISEL-NEXT:  .LBB4_1: ; =>This Inner Loop Header: Depth=1
+; GFX1164GISEL-NEXT:  .LBB5_1: ; =>This Inner Loop Header: Depth=1
 ; GFX1164GISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
 ; GFX1164GISEL-NEXT:    s_ctz_i32_b64 s6, s[0:1]
 ; GFX1164GISEL-NEXT:    v_readlane_b32 s4, v2, s6
@@ -1466,7 +1936,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %id.x) {
 ; GFX1164GISEL-NEXT:    v_readfirstlane_b32 s2, v4
 ; GFX1164GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2)
 ; GFX1164GISEL-NEXT:    v_readfirstlane_b32 s3, v5
-; GFX1164GISEL-NEXT:    s_cbranch_scc1 .LBB4_1
+; GFX1164GISEL-NEXT:    s_cbranch_scc1 .LBB5_1
 ; GFX1164GISEL-NEXT:  ; %bb.2:
 ; GFX1164GISEL-NEXT:    v_mov_b32_e32 v2, s2
 ; GFX1164GISEL-NEXT:    v_mov_b32_e32 v3, s3
@@ -1478,7 +1948,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %id.x) {
 ; GFX1132DAGISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX1132DAGISEL-NEXT:    s_mov_b64 s[0:1], 0
 ; GFX1132DAGISEL-NEXT:    s_mov_b32 s2, exec_lo
-; GFX1132DAGISEL-NEXT:  .LBB4_1: ; =>This Inner Loop Header: Depth=1
+; GFX1132DAGISEL-NEXT:  .LBB5_1: ; =>This Inner Loop Header: Depth=1
 ; GFX1132DAGISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
 ; GFX1132DAGISEL-NEXT:    s_ctz_i32_b32 s3, s2
 ; GFX1132DAGISEL-NEXT:    v_readlane_b32 s4, v2, s3
@@ -1490,7 +1960,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %id.x) {
 ; GFX1132DAGISEL-NEXT:    v_readfirstlane_b32 s0, v4
 ; GFX1132DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2)
 ; GFX1132DAGISEL-NEXT:    v_readfirstlane_b32 s1, v5
-; GFX1132DAGISEL-NEXT:    s_cbranch_scc1 .LBB4_1
+; GFX1132DAGISEL-NEXT:    s_cbranch_scc1 .LBB5_1
 ; GFX1132DAGISEL-NEXT:  ; %bb.2:
 ; GFX1132DAGISEL-NEXT:    v_dual_mov_b32 v3, s1 :: v_dual_mov_b32 v2, s0
 ; GFX1132DAGISEL-NEXT:    global_store_b64 v[0:1], v[2:3], off
@@ -1501,7 +1971,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %id.x) {
 ; GFX1132GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX1132GISEL-NEXT:    s_mov_b64 s[0:1], 0
 ; GFX1132GISEL-NEXT:    s_mov_b32 s2, exec_lo
-; GFX1132GISEL-NEXT:  .LBB4_1: ; =>This Inner Loop Header: Depth=1
+; GFX1132GISEL-NEXT:  .LBB5_1: ; =>This Inner Loop Header: Depth=1
 ; GFX1132GISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
 ; GFX1132GISEL-NEXT:    s_ctz_i32_b32 s3, s2
 ; GFX1132GISEL-NEXT:    v_readlane_b32 s4, v2, s3
@@ -1513,7 +1983,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %id.x) {
 ; GFX1132GISEL-NEXT:    v_readfirstlane_b32 s0, v4
 ; GFX1132GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2)
 ; GFX1132GISEL-NEXT:    v_readfirstlane_b32 s1, v5
-; GFX1132GISEL-NEXT:    s_cbranch_scc1 .LBB4_1
+; GFX1132GISEL-NEXT:    s_cbranch_scc1 .LBB5_1
 ; GFX1132GISEL-NEXT:  ; %bb.2:
 ; GFX1132GISEL-NEXT:    v_dual_mov_b32 v3, s1 :: v_dual_mov_b32 v2, s0
 ; GFX1132GISEL-NEXT:    global_store_b64 v[0:1], v[2:3], off
@@ -1528,7 +1998,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %id.x) {
 ; GFX12DAGISEL-NEXT:    s_wait_kmcnt 0x0
 ; GFX12DAGISEL-NEXT:    s_mov_b64 s[0:1], 0
 ; GFX12DAGISEL-NEXT:    s_mov_b32 s2, exec_lo
-; GFX12DAGISEL-NEXT:  .LBB4_1: ; =>This Inner Loop Header: Depth=1
+; GFX12DAGISEL-NEXT:  .LBB5_1: ; =>This Inner Loop Header: Depth=1
 ; GFX12DAGISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
 ; GFX12DAGISEL-NEXT:    s_ctz_i32_b32 s3, s2
 ; GFX12DAGISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
@@ -1541,7 +2011,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %id.x) {
 ; GFX12DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_2)
 ; GFX12DAGISEL-NEXT:    v_readfirstlane_b32 s0, v4
 ; GFX12DAGISEL-NEXT:    v_readfirstlane_b32 s1, v5
-; GFX12DAGISEL-NEXT:    s_cbranch_scc1 .LBB4_1
+; GFX12DAGISEL-NEXT:    s_cbranch_scc1 .LBB5_1
 ; GFX12DAGISEL-NEXT:  ; %bb.2:
 ; GFX12DAGISEL-NEXT:    s_wait_alu depctr_va_sdst(0)
 ; GFX12DAGISEL-NEXT:    v_dual_mov_b32 v3, s1 :: v_dual_mov_b32 v2, s0
@@ -1562,7 +2032,7 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX8DAGISEL-NEXT:    ; implicit-def: $sgpr6_sgpr7
 ; GFX8DAGISEL-NEXT:    s_and_saveexec_b64 s[8:9], vcc
 ; GFX8DAGISEL-NEXT:    s_xor_b64 s[8:9], exec, s[8:9]
-; GFX8DAGISEL-NEXT:    s_cbranch_execz .LBB5_2
+; GFX8DAGISEL-NEXT:    s_cbranch_execz .LBB6_2
 ; GFX8DAGISEL-NEXT:  ; %bb.1: ; %else
 ; GFX8DAGISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX8DAGISEL-NEXT:    s_bcnt1_i32_b64 s6, s[6:7]
@@ -1571,13 +2041,13 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX8DAGISEL-NEXT:    v_mul_f64 v[0:1], -s[2:3], v[0:1]
 ; GFX8DAGISEL-NEXT:    v_readfirstlane_b32 s6, v0
 ; GFX8DAGISEL-NEXT:    v_readfirstlane_b32 s7, v1
-; GFX8DAGISEL-NEXT:  .LBB5_2: ; %Flow
+; GFX8DAGISEL-NEXT:  .LBB6_2: ; %Flow
 ; GFX8DAGISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX8DAGISEL-NEXT:    s_or_saveexec_b64 s[2:3], s[8:9]
 ; GFX8DAGISEL-NEXT:    v_mov_b32_e32 v0, s6
 ; GFX8DAGISEL-NEXT:    v_mov_b32_e32 v1, s7
 ; GFX8DAGISEL-NEXT:    s_xor_b64 exec, exec, s[2:3]
-; GFX8DAGISEL-NEXT:    s_cbranch_execz .LBB5_4
+; GFX8DAGISEL-NEXT:    s_cbranch_execz .LBB6_4
 ; GFX8DAGISEL-NEXT:  ; %bb.3: ; %if
 ; GFX8DAGISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX8DAGISEL-NEXT:    s_bcnt1_i32_b64 s6, s[6:7]
@@ -1587,7 +2057,7 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX8DAGISEL-NEXT:    v_readfirstlane_b32 s5, v1
 ; GFX8DAGISEL-NEXT:    v_mov_b32_e32 v0, s4
 ; GFX8DAGISEL-NEXT:    v_mov_b32_e32 v1, s5
-; GFX8DAGISEL-NEXT:  .LBB5_4: ; %endif
+; GFX8DAGISEL-NEXT:  .LBB6_4: ; %endif
 ; GFX8DAGISEL-NEXT:    s_or_b64 exec, exec, s[2:3]
 ; GFX8DAGISEL-NEXT:    v_mov_b32_e32 v2, s0
 ; GFX8DAGISEL-NEXT:    v_mov_b32_e32 v3, s1
@@ -1601,7 +2071,7 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX8GISEL-NEXT:    ; implicit-def: $sgpr6_sgpr7
 ; GFX8GISEL-NEXT:    s_and_saveexec_b64 s[8:9], vcc
 ; GFX8GISEL-NEXT:    s_xor_b64 s[8:9], exec, s[8:9]
-; GFX8GISEL-NEXT:    s_cbranch_execz .LBB5_2
+; GFX8GISEL-NEXT:    s_cbranch_execz .LBB6_2
 ; GFX8GISEL-NEXT:  ; %bb.1: ; %else
 ; GFX8GISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX8GISEL-NEXT:    s_bcnt1_i32_b64 s6, s[6:7]
@@ -1610,10 +2080,10 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX8GISEL-NEXT:    v_mul_f64 v[0:1], -s[2:3], v[0:1]
 ; GFX8GISEL-NEXT:    v_readfirstlane_b32 s6, v0
 ; GFX8GISEL-NEXT:    v_readfirstlane_b32 s7, v1
-; GFX8GISEL-NEXT:  .LBB5_2: ; %Flow
+; GFX8GISEL-NEXT:  .LBB6_2: ; %Flow
 ; GFX8GISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX8GISEL-NEXT:    s_andn2_saveexec_b64 s[2:3], s[8:9]
-; GFX8GISEL-NEXT:    s_cbranch_execz .LBB5_4
+; GFX8GISEL-NEXT:    s_cbranch_execz .LBB6_4
 ; GFX8GISEL-NEXT:  ; %bb.3: ; %if
 ; GFX8GISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX8GISEL-NEXT:    s_load_dwordx2 s[4:5], s[4:5], 0x34
@@ -1623,7 +2093,7 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX8GISEL-NEXT:    v_mul_f64 v[0:1], -s[4:5], v[0:1]
 ; GFX8GISEL-NEXT:    v_readfirstlane_b32 s6, v0
 ; GFX8GISEL-NEXT:    v_readfirstlane_b32 s7, v1
-; GFX8GISEL-NEXT:  .LBB5_4: ; %endif
+; GFX8GISEL-NEXT:  .LBB6_4: ; %endif
 ; GFX8GISEL-NEXT:    s_or_b64 exec, exec, s[2:3]
 ; GFX8GISEL-NEXT:    v_mov_b32_e32 v0, s6
 ; GFX8GISEL-NEXT:    v_mov_b32_e32 v3, s1
@@ -1640,7 +2110,7 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX9DAGISEL-NEXT:    ; implicit-def: $sgpr4_sgpr5
 ; GFX9DAGISEL-NEXT:    s_and_saveexec_b64 s[8:9], vcc
 ; GFX9DAGISEL-NEXT:    s_xor_b64 s[8:9], exec, s[8:9]
-; GFX9DAGISEL-NEXT:    s_cbranch_execz .LBB5_2
+; GFX9DAGISEL-NEXT:    s_cbranch_execz .LBB6_2
 ; GFX9DAGISEL-NEXT:  ; %bb.1: ; %else
 ; GFX9DAGISEL-NEXT:    s_mov_b64 s[4:5], exec
 ; GFX9DAGISEL-NEXT:    s_bcnt1_i32_b64 s4, s[4:5]
@@ -1649,13 +2119,13 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX9DAGISEL-NEXT:    v_mul_f64 v[0:1], -s[2:3], v[0:1]
 ; GFX9DAGISEL-NEXT:    v_readfirstlane_b32 s4, v0
 ; GFX9DAGISEL-NEXT:    v_readfirstlane_b32 s5, v1
-; GFX9DAGISEL-NEXT:  .LBB5_2: ; %Flow
+; GFX9DAGISEL-NEXT:  .LBB6_2: ; %Flow
 ; GFX9DAGISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX9DAGISEL-NEXT:    s_or_saveexec_b64 s[2:3], s[8:9]
 ; GFX9DAGISEL-NEXT:    v_mov_b32_e32 v0, s4
 ; GFX9DAGISEL-NEXT:    v_mov_b32_e32 v1, s5
 ; GFX9DAGISEL-NEXT:    s_xor_b64 exec, exec, s[2:3]
-; GFX9DAGISEL-NEXT:    s_cbranch_execz .LBB5_4
+; GFX9DAGISEL-NEXT:    s_cbranch_execz .LBB6_4
 ; GFX9DAGISEL-NEXT:  ; %bb.3: ; %if
 ; GFX9DAGISEL-NEXT:    s_mov_b64 s[4:5], exec
 ; GFX9DAGISEL-NEXT:    s_bcnt1_i32_b64 s4, s[4:5]
@@ -1665,7 +2135,7 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX9DAGISEL-NEXT:    v_readfirstlane_b32 s5, v1
 ; GFX9DAGISEL-NEXT:    v_mov_b32_e32 v0, s4
 ; GFX9DAGISEL-NEXT:    v_mov_b32_e32 v1, s5
-; GFX9DAGISEL-NEXT:  .LBB5_4: ; %endif
+; GFX9DAGISEL-NEXT:  .LBB6_4: ; %endif
 ; GFX9DAGISEL-NEXT:    s_or_b64 exec, exec, s[2:3]
 ; GFX9DAGISEL-NEXT:    v_mov_b32_e32 v2, 0
 ; GFX9DAGISEL-NEXT:    global_store_dwordx2 v2, v[0:1], s[0:1]
@@ -1678,7 +2148,7 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX9GISEL-NEXT:    ; implicit-def: $sgpr6_sgpr7
 ; GFX9GISEL-NEXT:    s_and_saveexec_b64 s[8:9], vcc
 ; GFX9GISEL-NEXT:    s_xor_b64 s[8:9], exec, s[8:9]
-; GFX9GISEL-NEXT:    s_cbranch_execz .LBB5_2
+; GFX9GISEL-NEXT:    s_cbranch_execz .LBB6_2
 ; GFX9GISEL-NEXT:  ; %bb.1: ; %else
 ; GFX9GISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX9GISEL-NEXT:    s_bcnt1_i32_b64 s6, s[6:7]
@@ -1687,10 +2157,10 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX9GISEL-NEXT:    v_mul_f64 v[0:1], -s[2:3], v[0:1]
 ; GFX9GISEL-NEXT:    v_readfirstlane_b32 s6, v0
 ; GFX9GISEL-NEXT:    v_readfirstlane_b32 s7, v1
-; GFX9GISEL-NEXT:  .LBB5_2: ; %Flow
+; GFX9GISEL-NEXT:  .LBB6_2: ; %Flow
 ; GFX9GISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX9GISEL-NEXT:    s_andn2_saveexec_b64 s[2:3], s[8:9]
-; GFX9GISEL-NEXT:    s_cbranch_execz .LBB5_4
+; GFX9GISEL-NEXT:    s_cbranch_execz .LBB6_4
 ; GFX9GISEL-NEXT:  ; %bb.3: ; %if
 ; GFX9GISEL-NEXT:    s_load_dwordx2 s[6:7], s[4:5], 0x34
 ; GFX9GISEL-NEXT:    s_mov_b64 s[4:5], exec
@@ -1700,7 +2170,7 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX9GISEL-NEXT:    v_mul_f64 v[0:1], -s[6:7], v[0:1]
 ; GFX9GISEL-NEXT:    v_readfirstlane_b32 s6, v0
 ; GFX9GISEL-NEXT:    v_readfirstlane_b32 s7, v1
-; GFX9GISEL-NEXT:  .LBB5_4: ; %endif
+; GFX9GISEL-NEXT:  .LBB6_4: ; %endif
 ; GFX9GISEL-NEXT:    s_or_b64 exec, exec, s[2:3]
 ; GFX9GISEL-NEXT:    v_mov_b32_e32 v0, s6
 ; GFX9GISEL-NEXT:    v_mov_b32_e32 v1, s7
@@ -1717,7 +2187,7 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX1064DAGISEL-NEXT:    ; implicit-def: $sgpr8_sgpr9
 ; GFX1064DAGISEL-NEXT:    s_and_saveexec_b64 s[4:5], vcc
 ; GFX1064DAGISEL-NEXT:    s_xor_b64 s[4:5], exec, s[4:5]
-; GFX1064DAGISEL-NEXT:    s_cbranch_execz .LBB5_2
+; GFX1064DAGISEL-NEXT:    s_cbranch_execz .LBB6_2
 ; GFX1064DAGISEL-NEXT:  ; %bb.1: ; %else
 ; GFX1064DAGISEL-NEXT:    s_mov_b64 s[8:9], exec
 ; GFX1064DAGISEL-NEXT:    s_bcnt1_i32_b64 s8, s[8:9]
@@ -1726,13 +2196,13 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX1064DAGISEL-NEXT:    v_mul_f64 v[0:1], -s[2:3], v[0:1]
 ; GFX1064DAGISEL-NEXT:    v_readfirstlane_b32 s8, v0
 ; GFX1064DAGISEL-NEXT:    v_readfirstlane_b32 s9, v1
-; GFX1064DAGISEL-NEXT:  .LBB5_2: ; %Flow
+; GFX1064DAGISEL-NEXT:  .LBB6_2: ; %Flow
 ; GFX1064DAGISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX1064DAGISEL-NEXT:    s_or_saveexec_b64 s[2:3], s[4:5]
 ; GFX1064DAGISEL-NEXT:    v_mov_b32_e32 v0, s8
 ; GFX1064DAGISEL-NEXT:    v_mov_b32_e32 v1, s9
 ; GFX1064DAGISEL-NEXT:    s_xor_b64 exec, exec, s[2:3]
-; GFX1064DAGISEL-NEXT:    s_cbranch_execz .LBB5_4
+; GFX1064DAGISEL-NEXT:    s_cbranch_execz .LBB6_4
 ; GFX1064DAGISEL-NEXT:  ; %bb.3: ; %if
 ; GFX1064DAGISEL-NEXT:    s_mov_b64 s[4:5], exec
 ; GFX1064DAGISEL-NEXT:    s_bcnt1_i32_b64 s4, s[4:5]
@@ -1742,7 +2212,7 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX1064DAGISEL-NEXT:    v_readfirstlane_b32 s5, v1
 ; GFX1064DAGISEL-NEXT:    v_mov_b32_e32 v0, s4
 ; GFX1064DAGISEL-NEXT:    v_mov_b32_e32 v1, s5
-; GFX1064DAGISEL-NEXT:  .LBB5_4: ; %endif
+; GFX1064DAGISEL-NEXT:  .LBB6_4: ; %endif
 ; GFX1064DAGISEL-NEXT:    s_or_b64 exec, exec, s[2:3]
 ; GFX1064DAGISEL-NEXT:    v_mov_b32_e32 v2, 0
 ; GFX1064DAGISEL-NEXT:    global_store_dwordx2 v2, v[0:1], s[0:1]
@@ -1755,7 +2225,7 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX1064GISEL-NEXT:    ; implicit-def: $sgpr6_sgpr7
 ; GFX1064GISEL-NEXT:    s_and_saveexec_b64 s[8:9], vcc
 ; GFX1064GISEL-NEXT:    s_xor_b64 s[8:9], exec, s[8:9]
-; GFX1064GISEL-NEXT:    s_cbranch_execz .LBB5_2
+; GFX1064GISEL-NEXT:    s_cbranch_execz .LBB6_2
 ; GFX1064GISEL-NEXT:  ; %bb.1: ; %else
 ; GFX1064GISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX1064GISEL-NEXT:    s_bcnt1_i32_b64 s6, s[6:7]
@@ -1764,10 +2234,10 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX1064GISEL-NEXT:    v_mul_f64 v[0:1], -s[2:3], v[0:1]
 ; GFX1064GISEL-NEXT:    v_readfirstlane_b32 s6, v0
 ; GFX1064GISEL-NEXT:    v_readfirstlane_b32 s7, v1
-; GFX1064GISEL-NEXT:  .LBB5_2: ; %Flow
+; GFX1064GISEL-NEXT:  .LBB6_2: ; %Flow
 ; GFX1064GISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX1064GISEL-NEXT:    s_andn2_saveexec_b64 s[2:3], s[8:9]
-; GFX1064GISEL-NEXT:    s_cbranch_execz .LBB5_4
+; GFX1064GISEL-NEXT:    s_cbranch_execz .LBB6_4
 ; GFX1064GISEL-NEXT:  ; %bb.3: ; %if
 ; GFX1064GISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX1064GISEL-NEXT:    s_bcnt1_i32_b64 s6, s[6:7]
@@ -1777,7 +2247,7 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX1064GISEL-NEXT:    v_mul_f64 v[0:1], -s[6:7], v[0:1]
 ; GFX1064GISEL-NEXT:    v_readfirstlane_b32 s6, v0
 ; GFX1064GISEL-NEXT:    v_readfirstlane_b32 s7, v1
-; GFX1064GISEL-NEXT:  .LBB5_4: ; %endif
+; GFX1064GISEL-NEXT:  .LBB6_4: ; %endif
 ; GFX1064GISEL-NEXT:    s_or_b64 exec, exec, s[2:3]
 ; GFX1064GISEL-NEXT:    v_mov_b32_e32 v0, s6
 ; GFX1064GISEL-NEXT:    v_mov_b32_e32 v1, s7
@@ -1794,7 +2264,7 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX1032DAGISEL-NEXT:    ; implicit-def: $sgpr4_sgpr5
 ; GFX1032DAGISEL-NEXT:    s_and_saveexec_b32 s8, vcc_lo
 ; GFX1032DAGISEL-NEXT:    s_xor_b32 s8, exec_lo, s8
-; GFX1032DAGISEL-NEXT:    s_cbranch_execz .LBB5_2
+; GFX1032DAGISEL-NEXT:    s_cbranch_execz .LBB6_2
 ; GFX1032DAGISEL-NEXT:  ; %bb.1: ; %else
 ; GFX1032DAGISEL-NEXT:    s_mov_b32 s4, exec_lo
 ; GFX1032DAGISEL-NEXT:    s_bcnt1_i32_b32 s4, s4
@@ -1803,13 +2273,13 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX1032DAGISEL-NEXT:    v_mul_f64 v[0:1], -s[2:3], v[0:1]
 ; GFX1032DAGISEL-NEXT:    v_readfirstlane_b32 s4, v0
 ; GFX1032DAGISEL-NEXT:    v_readfirstlane_b32 s5, v1
-; GFX1032DAGISEL-NEXT:  .LBB5_2: ; %Flow
+; GFX1032DAGISEL-NEXT:  .LBB6_2: ; %Flow
 ; GFX1032DAGISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX1032DAGISEL-NEXT:    s_or_saveexec_b32 s2, s8
 ; GFX1032DAGISEL-NEXT:    v_mov_b32_e32 v0, s4
 ; GFX1032DAGISEL-NEXT:    v_mov_b32_e32 v1, s5
 ; GFX1032DAGISEL-NEXT:    s_xor_b32 exec_lo, exec_lo, s2
-; GFX1032DAGISEL-NEXT:    s_cbranch_execz .LBB5_4
+; GFX1032DAGISEL-NEXT:    s_cbranch_execz .LBB6_4
 ; GFX1032DAGISEL-NEXT:  ; %bb.3: ; %if
 ; GFX1032DAGISEL-NEXT:    s_mov_b32 s3, exec_lo
 ; GFX1032DAGISEL-NEXT:    s_bcnt1_i32_b32 s3, s3
@@ -1819,7 +2289,7 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX1032DAGISEL-NEXT:    v_readfirstlane_b32 s5, v1
 ; GFX1032DAGISEL-NEXT:    v_mov_b32_e32 v0, s4
 ; GFX1032DAGISEL-NEXT:    v_mov_b32_e32 v1, s5
-; GFX1032DAGISEL-NEXT:  .LBB5_4: ; %endif
+; GFX1032DAGISEL-NEXT:  .LBB6_4: ; %endif
 ; GFX1032DAGISEL-NEXT:    s_or_b32 exec_lo, exec_lo, s2
 ; GFX1032DAGISEL-NEXT:    v_mov_b32_e32 v2, 0
 ; GFX1032DAGISEL-NEXT:    global_store_dwordx2 v2, v[0:1], s[0:1]
@@ -1832,7 +2302,7 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX1032GISEL-NEXT:    ; implicit-def: $sgpr6_sgpr7
 ; GFX1032GISEL-NEXT:    s_and_saveexec_b32 s8, vcc_lo
 ; GFX1032GISEL-NEXT:    s_xor_b32 s8, exec_lo, s8
-; GFX1032GISEL-NEXT:    s_cbranch_execz .LBB5_2
+; GFX1032GISEL-NEXT:    s_cbranch_execz .LBB6_2
 ; GFX1032GISEL-NEXT:  ; %bb.1: ; %else
 ; GFX1032GISEL-NEXT:    s_mov_b32 s6, exec_lo
 ; GFX1032GISEL-NEXT:    s_bcnt1_i32_b32 s6, s6
@@ -1841,10 +2311,10 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX1032GISEL-NEXT:    v_mul_f64 v[0:1], -s[2:3], v[0:1]
 ; GFX1032GISEL-NEXT:    v_readfirstlane_b32 s6, v0
 ; GFX1032GISEL-NEXT:    v_readfirstlane_b32 s7, v1
-; GFX1032GISEL-NEXT:  .LBB5_2: ; %Flow
+; GFX1032GISEL-NEXT:  .LBB6_2: ; %Flow
 ; GFX1032GISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX1032GISEL-NEXT:    s_andn2_saveexec_b32 s2, s8
-; GFX1032GISEL-NEXT:    s_cbranch_execz .LBB5_4
+; GFX1032GISEL-NEXT:    s_cbranch_execz .LBB6_4
 ; GFX1032GISEL-NEXT:  ; %bb.3: ; %if
 ; GFX1032GISEL-NEXT:    s_mov_b32 s3, exec_lo
 ; GFX1032GISEL-NEXT:    s_load_dwordx2 s[6:7], s[4:5], 0x34
@@ -1854,7 +2324,7 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX1032GISEL-NEXT:    v_mul_f64 v[0:1], -s[6:7], v[0:1]
 ; GFX1032GISEL-NEXT:    v_readfirstlane_b32 s6, v0
 ; GFX1032GISEL-NEXT:    v_readfirstlane_b32 s7, v1
-; GFX1032GISEL-NEXT:  .LBB5_4: ; %endif
+; GFX1032GISEL-NEXT:  .LBB6_4: ; %endif
 ; GFX1032GISEL-NEXT:    s_or_b32 exec_lo, exec_lo, s2
 ; GFX1032GISEL-NEXT:    v_mov_b32_e32 v0, s6
 ; GFX1032GISEL-NEXT:    v_mov_b32_e32 v1, s7
@@ -1873,7 +2343,7 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX1164DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX1164DAGISEL-NEXT:    v_cmpx_lt_u32_e32 15, v0
 ; GFX1164DAGISEL-NEXT:    s_xor_b64 s[6:7], exec, s[6:7]
-; GFX1164DAGISEL-NEXT:    s_cbranch_execz .LBB5_2
+; GFX1164DAGISEL-NEXT:    s_cbranch_execz .LBB6_2
 ; GFX1164DAGISEL-NEXT:  ; %bb.1: ; %else
 ; GFX1164DAGISEL-NEXT:    s_mov_b64 s[8:9], exec
 ; GFX1164DAGISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
@@ -1885,14 +2355,14 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX1164DAGISEL-NEXT:    v_readfirstlane_b32 s8, v0
 ; GFX1164DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2)
 ; GFX1164DAGISEL-NEXT:    v_readfirstlane_b32 s9, v1
-; GFX1164DAGISEL-NEXT:  .LBB5_2: ; %Flow
+; GFX1164DAGISEL-NEXT:  .LBB6_2: ; %Flow
 ; GFX1164DAGISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX1164DAGISEL-NEXT:    s_or_saveexec_b64 s[2:3], s[6:7]
 ; GFX1164DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
 ; GFX1164DAGISEL-NEXT:    v_mov_b32_e32 v0, s8
 ; GFX1164DAGISEL-NEXT:    v_mov_b32_e32 v1, s9
 ; GFX1164DAGISEL-NEXT:    s_xor_b64 exec, exec, s[2:3]
-; GFX1164DAGISEL-NEXT:    s_cbranch_execz .LBB5_4
+; GFX1164DAGISEL-NEXT:    s_cbranch_execz .LBB6_4
 ; GFX1164DAGISEL-NEXT:  ; %bb.3: ; %if
 ; GFX1164DAGISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX1164DAGISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
@@ -1906,7 +2376,7 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX1164DAGISEL-NEXT:    v_mov_b32_e32 v0, s4
 ; GFX1164DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2)
 ; GFX1164DAGISEL-NEXT:    v_mov_b32_e32 v1, s5
-; GFX1164DAGISEL-NEXT:  .LBB5_4: ; %endif
+; GFX1164DAGISEL-NEXT:  .LBB6_4: ; %endif
 ; GFX1164DAGISEL-NEXT:    s_or_b64 exec, exec, s[2:3]
 ; GFX1164DAGISEL-NEXT:    v_mov_b32_e32 v2, 0
 ; GFX1164DAGISEL-NEXT:    global_store_b64 v2, v[0:1], s[0:1]
@@ -1921,7 +2391,7 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX1164GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX1164GISEL-NEXT:    v_cmpx_le_u32_e32 16, v0
 ; GFX1164GISEL-NEXT:    s_xor_b64 s[8:9], exec, s[8:9]
-; GFX1164GISEL-NEXT:    s_cbranch_execz .LBB5_2
+; GFX1164GISEL-NEXT:    s_cbranch_execz .LBB6_2
 ; GFX1164GISEL-NEXT:  ; %bb.1: ; %else
 ; GFX1164GISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX1164GISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
@@ -1933,10 +2403,10 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX1164GISEL-NEXT:    v_readfirstlane_b32 s6, v0
 ; GFX1164GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2)
 ; GFX1164GISEL-NEXT:    v_readfirstlane_b32 s7, v1
-; GFX1164GISEL-NEXT:  .LBB5_2: ; %Flow
+; GFX1164GISEL-NEXT:  .LBB6_2: ; %Flow
 ; GFX1164GISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX1164GISEL-NEXT:    s_and_not1_saveexec_b64 s[2:3], s[8:9]
-; GFX1164GISEL-NEXT:    s_cbranch_execz .LBB5_4
+; GFX1164GISEL-NEXT:    s_cbranch_execz .LBB6_4
 ; GFX1164GISEL-NEXT:  ; %bb.3: ; %if
 ; GFX1164GISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX1164GISEL-NEXT:    s_load_b64 s[4:5], s[4:5], 0x34
@@ -1948,7 +2418,7 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX1164GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_2)
 ; GFX1164GISEL-NEXT:    v_readfirstlane_b32 s6, v0
 ; GFX1164GISEL-NEXT:    v_readfirstlane_b32 s7, v1
-; GFX1164GISEL-NEXT:  .LBB5_4: ; %endif
+; GFX1164GISEL-NEXT:  .LBB6_4: ; %endif
 ; GFX1164GISEL-NEXT:    s_or_b64 exec, exec, s[2:3]
 ; GFX1164GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
 ; GFX1164GISEL-NEXT:    v_mov_b32_e32 v0, s6
@@ -1968,7 +2438,7 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX1132DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX1132DAGISEL-NEXT:    v_cmpx_lt_u32_e32 15, v0
 ; GFX1132DAGISEL-NEXT:    s_xor_b32 s8, exec_lo, s8
-; GFX1132DAGISEL-NEXT:    s_cbranch_execz .LBB5_2
+; GFX1132DAGISEL-NEXT:    s_cbranch_execz .LBB6_2
 ; GFX1132DAGISEL-NEXT:  ; %bb.1: ; %else
 ; GFX1132DAGISEL-NEXT:    s_mov_b32 s6, exec_lo
 ; GFX1132DAGISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
@@ -1980,13 +2450,13 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX1132DAGISEL-NEXT:    v_readfirstlane_b32 s6, v0
 ; GFX1132DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2)
 ; GFX1132DAGISEL-NEXT:    v_readfirstlane_b32 s7, v1
-; GFX1132DAGISEL-NEXT:  .LBB5_2: ; %Flow
+; GFX1132DAGISEL-NEXT:  .LBB6_2: ; %Flow
 ; GFX1132DAGISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX1132DAGISEL-NEXT:    s_or_saveexec_b32 s2, s8
 ; GFX1132DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX1132DAGISEL-NEXT:    v_dual_mov_b32 v0, s6 :: v_dual_mov_b32 v1, s7
 ; GFX1132DAGISEL-NEXT:    s_xor_b32 exec_lo, exec_lo, s2
-; GFX1132DAGISEL-NEXT:    s_cbranch_execz .LBB5_4
+; GFX1132DAGISEL-NEXT:    s_cbranch_execz .LBB6_4
 ; GFX1132DAGISEL-NEXT:  ; %bb.3: ; %if
 ; GFX1132DAGISEL-NEXT:    s_mov_b32 s3, exec_lo
 ; GFX1132DAGISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
@@ -1998,7 +2468,7 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX1132DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_1)
 ; GFX1132DAGISEL-NEXT:    v_readfirstlane_b32 s5, v1
 ; GFX1132DAGISEL-NEXT:    v_dual_mov_b32 v0, s4 :: v_dual_mov_b32 v1, s5
-; GFX1132DAGISEL-NEXT:  .LBB5_4: ; %endif
+; GFX1132DAGISEL-NEXT:  .LBB6_4: ; %endif
 ; GFX1132DAGISEL-NEXT:    s_or_b32 exec_lo, exec_lo, s2
 ; GFX1132DAGISEL-NEXT:    v_mov_b32_e32 v2, 0
 ; GFX1132DAGISEL-NEXT:    global_store_b64 v2, v[0:1], s[0:1]
@@ -2013,7 +2483,7 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX1132GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX1132GISEL-NEXT:    v_cmpx_le_u32_e32 16, v0
 ; GFX1132GISEL-NEXT:    s_xor_b32 s8, exec_lo, s8
-; GFX1132GISEL-NEXT:    s_cbranch_execz .LBB5_2
+; GFX1132GISEL-NEXT:    s_cbranch_execz .LBB6_2
 ; GFX1132GISEL-NEXT:  ; %bb.1: ; %else
 ; GFX1132GISEL-NEXT:    s_mov_b32 s6, exec_lo
 ; GFX1132GISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
@@ -2025,10 +2495,10 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX1132GISEL-NEXT:    v_readfirstlane_b32 s6, v0
 ; GFX1132GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2)
 ; GFX1132GISEL-NEXT:    v_readfirstlane_b32 s7, v1
-; GFX1132GISEL-NEXT:  .LBB5_2: ; %Flow
+; GFX1132GISEL-NEXT:  .LBB6_2: ; %Flow
 ; GFX1132GISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX1132GISEL-NEXT:    s_and_not1_saveexec_b32 s2, s8
-; GFX1132GISEL-NEXT:    s_cbranch_execz .LBB5_4
+; GFX1132GISEL-NEXT:    s_cbranch_execz .LBB6_4
 ; GFX1132GISEL-NEXT:  ; %bb.3: ; %if
 ; GFX1132GISEL-NEXT:    s_mov_b32 s3, exec_lo
 ; GFX1132GISEL-NEXT:    s_load_b64 s[4:5], s[4:5], 0x34
@@ -2040,7 +2510,7 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX1132GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_2)
 ; GFX1132GISEL-NEXT:    v_readfirstlane_b32 s6, v0
 ; GFX1132GISEL-NEXT:    v_readfirstlane_b32 s7, v1
-; GFX1132GISEL-NEXT:  .LBB5_4: ; %endif
+; GFX1132GISEL-NEXT:  .LBB6_4: ; %endif
 ; GFX1132GISEL-NEXT:    s_or_b32 exec_lo, exec_lo, s2
 ; GFX1132GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX1132GISEL-NEXT:    v_dual_mov_b32 v0, s6 :: v_dual_mov_b32 v1, s7
@@ -2059,7 +2529,7 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX12DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX12DAGISEL-NEXT:    v_cmpx_lt_u32_e32 15, v0
 ; GFX12DAGISEL-NEXT:    s_xor_b32 s8, exec_lo, s8
-; GFX12DAGISEL-NEXT:    s_cbranch_execz .LBB5_2
+; GFX12DAGISEL-NEXT:    s_cbranch_execz .LBB6_2
 ; GFX12DAGISEL-NEXT:  ; %bb.1: ; %else
 ; GFX12DAGISEL-NEXT:    s_mov_b32 s6, exec_lo
 ; GFX12DAGISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
@@ -2071,7 +2541,7 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX12DAGISEL-NEXT:    v_readfirstlane_b32 s6, v0
 ; GFX12DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2)
 ; GFX12DAGISEL-NEXT:    v_readfirstlane_b32 s7, v1
-; GFX12DAGISEL-NEXT:  .LBB5_2: ; %Flow
+; GFX12DAGISEL-NEXT:  .LBB6_2: ; %Flow
 ; GFX12DAGISEL-NEXT:    s_wait_kmcnt 0x0
 ; GFX12DAGISEL-NEXT:    s_or_saveexec_b32 s2, s8
 ; GFX12DAGISEL-NEXT:    s_wait_alu depctr_va_sdst(0)
@@ -2079,7 +2549,7 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX12DAGISEL-NEXT:    v_dual_mov_b32 v0, s6 :: v_dual_mov_b32 v1, s7
 ; GFX12DAGISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
 ; GFX12DAGISEL-NEXT:    s_xor_b32 exec_lo, exec_lo, s2
-; GFX12DAGISEL-NEXT:    s_cbranch_execz .LBB5_4
+; GFX12DAGISEL-NEXT:    s_cbranch_execz .LBB6_4
 ; GFX12DAGISEL-NEXT:  ; %bb.3: ; %if
 ; GFX12DAGISEL-NEXT:    s_mov_b32 s3, exec_lo
 ; GFX12DAGISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
@@ -2093,7 +2563,7 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX12DAGISEL-NEXT:    v_readfirstlane_b32 s5, v1
 ; GFX12DAGISEL-NEXT:    s_wait_alu depctr_va_sdst(0)
 ; GFX12DAGISEL-NEXT:    v_dual_mov_b32 v0, s4 :: v_dual_mov_b32 v1, s5
-; GFX12DAGISEL-NEXT:  .LBB5_4: ; %endif
+; GFX12DAGISEL-NEXT:  .LBB6_4: ; %endif
 ; GFX12DAGISEL-NEXT:    s_or_b32 exec_lo, exec_lo, s2
 ; GFX12DAGISEL-NEXT:    v_mov_b32_e32 v2, 0
 ; GFX12DAGISEL-NEXT:    global_store_b64 v2, v[0:1], s[0:1]


### PR DESCRIPTION
Add support for DPP wave reduction for floating
point numbers.
Supported Ops: `fmin`, `fmax`, `fadd`, `fsub`.