### PR TITLE
[lldb] Skip file cleanup to avoid permission issue in API test

### DIFF
--- a/lldb/test/API/symstore/TestSymStoreLocal.py
+++ b/lldb/test/API/symstore/TestSymStoreLocal.py
@@ -15,15 +15,13 @@ currently.
 
 class MockedSymStore:
     """
-    Context Manager to populate a file structure equivalent to SymStore.exe in a
-    temporary directory.
+    Context Manager to populate a file structure equivalent to SymStore.exe
     """
 
     def __init__(self, test, exe, pdb):
         self._test = test
         self._exe = exe
         self._pdb = pdb
-        self._tmp = None
 
     def get_key_pdb(self, exe):
         """
@@ -48,20 +46,19 @@ class MockedSymStore:
         if self._test.getDebugInfo() == "pdb":
             key = self.get_key_pdb(self._exe)
         self._test.assertIsNotNone(key)
-        self._tmp = self._test.getBuildArtifact("tmp")
-        pdb_dir = os.path.join(self._tmp, self._pdb, key)
+        symstore_dir = self._test.getBuildArtifact("symstore")
+        pdb_dir = os.path.join(symstore_dir, self._pdb, key)
         os.makedirs(pdb_dir, exist_ok=True)
         shutil.move(
             self._test.getBuildArtifact(self._pdb),
             os.path.join(pdb_dir, self._pdb),
         )
-        return self._tmp
+        return symstore_dir
 
     def __exit__(self, *exc_info):
         """
-        Remove symstore and reset settings
+        Reset settings
         """
-        shutil.rmtree(self._tmp)
         self._test.runCmd("settings clear plugin.symbol-locator.symstore")
 
 


### PR DESCRIPTION
Deleting anything in the build directory of a test-case is causing an issue on one of the Windows bots. After the previous attempts in ca15db1cd509c236cd8138bcd098117d0106db56 and fdd2437af3cdc6d5fe199fcc9d991ccf503b55bd didn't help, we now skip the file cleanup altogether.