### PR TITLE
[orc-rt] Add ShutdownRequested flag to Service::onDetach.

### DIFF
--- a/orc-rt/include/orc-rt/Service.h
+++ b/orc-rt/include/orc-rt/Service.h
@@ -28,14 +28,22 @@ public:
 
   virtual ~Service();
 
-  /// The onDetach method will be called if the controller disconnects from the
-  /// session without shutting the session down.
+  /// The onDetach method will be called when the controller disconnects from
+  /// the session (or if the Session is shut down without a controller ever
+  /// being attached).
   ///
-  /// Since no further requests to the Service will be made, the Service may
-  /// discard any book-keeping data-structures that are only needed to serve
-  /// ongoing requests. E.g. a JIT memory manager may discard its free-list,
-  /// since no further JIT'd allocations will happen.
-  virtual void onDetach(OnCompleteFn OnComplete) = 0;
+  /// Once onDetach is called no further requests will be made to the Service
+  /// by the controller. Note that JIT'd code may continue to make requests to
+  /// the service concurrent with a call to onDetach.
+  ///
+  /// If ShutdownRequested is true then a Session shutdown is already pending,
+  /// and will proceed after all Services have been notified of the detach.
+  ///
+  /// onDetach provides an opportunity for Services to release any resources
+  /// that are only required while the Session is attached to the controller.
+  /// It is expected that many Services will implement this operation as a
+  /// no-op.
+  virtual void onDetach(OnCompleteFn OnComplete, bool ShutdownRequested) = 0;
 
   /// The onShutdown operation will be called at the end of the session.
   ///

--- a/orc-rt/include/orc-rt/SimpleNativeMemoryMap.h
+++ b/orc-rt/include/orc-rt/SimpleNativeMemoryMap.h
@@ -110,7 +110,8 @@ public:
   void deinitializeMultiple(OnDeinitializeCompleteFn &&OnComplete,
                             std::vector<void *> Bases);
 
-  void onDetach(Service::OnCompleteFn OnComplete) override;
+  void onDetach(Service::OnCompleteFn OnComplete,
+                bool ShutdownRequested) override;
   void onShutdown(Service::OnCompleteFn OnComplete) override;
 
 private:

--- a/orc-rt/lib/executor/SimpleNativeMemoryMap.cpp
+++ b/orc-rt/lib/executor/SimpleNativeMemoryMap.cpp
@@ -200,7 +200,8 @@ void SimpleNativeMemoryMap::deinitializeMultiple(
                    Error::success());
 }
 
-void SimpleNativeMemoryMap::onDetach(Service::OnCompleteFn OnComplete) {
+void SimpleNativeMemoryMap::onDetach(Service::OnCompleteFn OnComplete,
+                                     bool ShutdownRequested) {
   // Detach is a noop for now: we just retain all actions to run at shutdown
   // time.
   OnComplete();

--- a/orc-rt/unittests/SessionTest.cpp
+++ b/orc-rt/unittests/SessionTest.cpp
@@ -40,7 +40,7 @@ public:
       : DetachOpIdx(DetachOpIdx), ShutdownOpIdx(ShutdownOpIdx), OpIdx(OpIdx),
         GenResult(std::move(GenResult)) {}
 
-  void onDetach(OnCompleteFn OnComplete) override {
+  void onDetach(OnCompleteFn OnComplete, bool ShutdownRequested) override {
     DetachOpIdx = OpIdx++;
     GenResult(Op::Detach);
     OnComplete();
@@ -63,7 +63,9 @@ class ConfigurableService : public Service {
 public:
   ConfigurableService(int ConstructorOption) {}
 
-  void onDetach(OnCompleteFn OnComplete) override { OnComplete(); }
+  void onDetach(OnCompleteFn OnComplete, bool ShutdownRequested) override {
+    OnComplete();
+  }
 
   void onShutdown(OnCompleteFn OnComplete) override { OnComplete(); }
 

--- a/orc-rt/unittests/SimpleNativeMemoryMapSPSCITest.cpp
+++ b/orc-rt/unittests/SimpleNativeMemoryMapSPSCITest.cpp
@@ -313,7 +313,7 @@ TEST_F(SimpleNativeMemoryMapSPSCITest, ReserveInitializeDetachShutdown) {
   EXPECT_EQ(SentinelValue, 0U);
 
   std::future<void> DetachResult;
-  SNMM->onDetach(waitFor(DetachResult));
+  SNMM->onDetach(waitFor(DetachResult), /* ShutdownRequested */ false);
   DetachResult.get();
 
   EXPECT_EQ(SentinelValue, 0);

--- a/orc-rt/unittests/SimpleNativeMemoryMapTest.cpp
+++ b/orc-rt/unittests/SimpleNativeMemoryMapTest.cpp
@@ -317,7 +317,7 @@ TEST(SimpleNativeMemoryMapTest, ReserveInitializeDetachShutdown) {
   EXPECT_EQ(SentinelValue, 0U);
 
   std::future<void> DetachResult;
-  SNMM->onDetach(waitFor(DetachResult));
+  SNMM->onDetach(waitFor(DetachResult), /* ShutdownRequested */ false);
   DetachResult.get();
 
   EXPECT_EQ(SentinelValue, 0);


### PR DESCRIPTION
The ShutdownRequested flag indicates to Services whether a shutdown operation is already pending. Services may use this information to optimize their book-keeping: either preparing for a (potentially lengthy) detached state, or for an upcoming shutdown.

Session does not call onDetached yet: That (including setting the ShutdownRequested argument) will happen in a follow-up patch.