### PR TITLE
[orc-rt] Rename Session setController/detachFromController. NFC.

### DIFF
--- a/orc-rt/include/orc-rt/Session.h
+++ b/orc-rt/include/orc-rt/Session.h
@@ -166,10 +166,10 @@ public:
   }
 
   /// Set the ControllerAccess object.
-  void setController(std::shared_ptr<ControllerAccess> CA);
+  void attach(std::shared_ptr<ControllerAccess> CA);
 
   /// Disconnect the ControllerAccess object.
-  void detachFromController();
+  void detach();
 
   void callController(OnCallHandlerCompleteFn OnComplete, HandlerTag T,
                       WrapperFunctionBuffer ArgBytes) {

--- a/orc-rt/lib/executor/Session.cpp
+++ b/orc-rt/lib/executor/Session.cpp
@@ -28,7 +28,7 @@ void Session::shutdown(OnShutdownCompleteFn OnShutdownComplete) {
   assert(OnShutdownComplete && "OnShutdownComplete must be set");
 
   // Safe to call concurrently / redundantly.
-  detachFromController();
+  detach();
 
   {
     std::scoped_lock<std::mutex> Lock(M);
@@ -69,7 +69,7 @@ void Session::waitForShutdown() {
   F.get();
 }
 
-void Session::setController(std::shared_ptr<ControllerAccess> CA) {
+void Session::attach(std::shared_ptr<ControllerAccess> CA) {
   assert(CA && "Cannot attach null controller");
   std::scoped_lock<std::mutex> Lock(M);
   assert(!this->CA && "Cannot re-attach controller");
@@ -77,7 +77,7 @@ void Session::setController(std::shared_ptr<ControllerAccess> CA) {
   this->CA = std::move(CA);
 }
 
-void Session::detachFromController() {
+void Session::detach() {
   if (auto TmpCA = CA) {
     TmpCA->doDisconnect();
     CA = nullptr;

--- a/orc-rt/unittests/SessionTest.cpp
+++ b/orc-rt/unittests/SessionTest.cpp
@@ -393,7 +393,7 @@ TEST(ControllerAccessTest, Basics) {
   Session S(mockExecutorProcessInfo(),
             std::make_unique<EnqueueingDispatcher>(Tasks), noErrors);
   auto CA = std::make_shared<MockControllerAccess>(S);
-  S.setController(CA);
+  S.attach(CA);
 
   EnqueueingDispatcher::runTasksFromFront(Tasks);
 
@@ -416,7 +416,7 @@ TEST(ControllerAccessTest, ValidCallToController) {
   Session S(mockExecutorProcessInfo(),
             std::make_unique<EnqueueingDispatcher>(Tasks), noErrors);
   auto CA = std::make_shared<MockControllerAccess>(S);
-  S.setController(CA);
+  S.attach(CA);
 
   int32_t Result = 0;
   SPSWrapperFunction<int32_t(int32_t, int32_t)>::call(
@@ -456,9 +456,9 @@ TEST(ControllerAccessTest, CallToControllerAfterDetach) {
   Session S(mockExecutorProcessInfo(),
             std::make_unique<EnqueueingDispatcher>(Tasks), noErrors);
   auto CA = std::make_shared<MockControllerAccess>(S);
-  S.setController(CA);
+  S.attach(CA);
 
-  S.detachFromController();
+  S.detach();
 
   Error Err = Error::success();
   SPSWrapperFunction<int32_t(int32_t, int32_t)>::call(
@@ -480,7 +480,7 @@ TEST(ControllerAccessTest, CallFromController) {
   Session S(mockExecutorProcessInfo(),
             std::make_unique<EnqueueingDispatcher>(Tasks), noErrors);
   auto CA = std::make_shared<MockControllerAccess>(S);
-  S.setController(CA);
+  S.attach(CA);
 
   int32_t Result = 0;
   SPSWrapperFunction<int32_t(int32_t, int32_t)>::call(


### PR DESCRIPTION
These methods are renamed to attach and detach for simplicity.