### PR TITLE
[AArch64][SVE] Prefer FMOV for scalar insert into first element of zero.

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64SVEInstrInfo.td
+++ b/llvm/lib/Target/AArch64/AArch64SVEInstrInfo.td
@@ -3467,9 +3467,23 @@ let Predicates = [HasSVE_or_SME] in {
             (SEL_ZPZZ_D (PTRUE_D 1), (INSERT_SUBREG (IMPLICIT_DEF), FPR64:$src, dsub), ZPR:$vec)>;
 
   // Prefer FMOV when the vector is zero.
-  let Predicates = [HasFullFP16] in
+  let Predicates = [HasFullFP16] in {
     def : Pat<(nxv8i16 (vector_insert (SVEDup0), (i32 GPR32:$src), 0)),
               (SUBREG_TO_REG (FMOVWHr GPR32:$src), hsub)>;
+
+    def : Pat<(nxv8f16 (vector_insert (SVEDup0), (f16 FPR16:$src), 0)),
+              (SUBREG_TO_REG (FMOVHr FPR16:$src), hsub)>;
+    def : Pat<(nxv4f16 (vector_insert (SVEDup0), (f16 FPR16:$src), 0)),
+              (SUBREG_TO_REG (FMOVHr FPR16:$src), hsub)>;
+    def : Pat<(nxv2f16 (vector_insert (SVEDup0), (f16 FPR16:$src), 0)),
+              (SUBREG_TO_REG (FMOVHr FPR16:$src), hsub)>;
+    def : Pat<(nxv8bf16 (vector_insert (SVEDup0), (bf16 FPR16:$src), 0)),
+              (SUBREG_TO_REG (FMOVHr FPR16:$src), hsub)>;
+    def : Pat<(nxv4bf16 (vector_insert (SVEDup0), (bf16 FPR16:$src), 0)),
+              (SUBREG_TO_REG (FMOVHr FPR16:$src), hsub)>;
+    def : Pat<(nxv2bf16 (vector_insert (SVEDup0), (bf16 FPR16:$src), 0)),
+              (SUBREG_TO_REG (FMOVHr FPR16:$src), hsub)>;
+  }
   let Predicates = [HasFPARMv8] in {
     def : Pat<(nxv4i32 (vector_insert (SVEDup0), (i32 GPR32:$src), 0)),
               (SUBREG_TO_REG (FMOVWSr GPR32:$src), ssub)>;
@@ -3477,6 +3491,8 @@ let Predicates = [HasSVE_or_SME] in {
               (SUBREG_TO_REG (FMOVXDr GPR64:$src), dsub)>;
 
     def : Pat<(nxv4f32 (vector_insert (SVEDup0), (f32 FPR32:$src), 0)),
+              (SUBREG_TO_REG (FMOVSr FPR32:$src), ssub)>;
+    def : Pat<(nxv2f32 (vector_insert (SVEDup0), (f32 FPR32:$src), 0)),
               (SUBREG_TO_REG (FMOVSr FPR32:$src), ssub)>;
     def : Pat<(nxv2f64 (vector_insert (SVEDup0), (f64 FPR64:$src), 0)),
               (SUBREG_TO_REG (FMOVDr FPR64:$src), dsub)>;

--- a/llvm/lib/Target/AArch64/AArch64SVEInstrInfo.td
+++ b/llvm/lib/Target/AArch64/AArch64SVEInstrInfo.td
@@ -3466,6 +3466,22 @@ let Predicates = [HasSVE_or_SME] in {
   def : Pat<(nxv2f64 (vector_insert nxv2f64:$vec, (f64 FPR64:$src), 0)),
             (SEL_ZPZZ_D (PTRUE_D 1), (INSERT_SUBREG (IMPLICIT_DEF), FPR64:$src, dsub), ZPR:$vec)>;
 
+  // Prefer FMOV when the vector is zero.
+  let Predicates = [HasFullFP16] in
+    def : Pat<(nxv8i16 (vector_insert (SVEDup0), (i32 GPR32:$src), 0)),
+              (SUBREG_TO_REG (FMOVWHr GPR32:$src), hsub)>;
+  let Predicates = [HasFPARMv8] in {
+    def : Pat<(nxv4i32 (vector_insert (SVEDup0), (i32 GPR32:$src), 0)),
+              (SUBREG_TO_REG (FMOVWSr GPR32:$src), ssub)>;
+    def : Pat<(nxv2i64 (vector_insert (SVEDup0), (i64 GPR64:$src), 0)),
+              (SUBREG_TO_REG (FMOVXDr GPR64:$src), dsub)>;
+
+    def : Pat<(nxv4f32 (vector_insert (SVEDup0), (f32 FPR32:$src), 0)),
+              (SUBREG_TO_REG (FMOVSr FPR32:$src), ssub)>;
+    def : Pat<(nxv2f64 (vector_insert (SVEDup0), (f64 FPR64:$src), 0)),
+              (SUBREG_TO_REG (FMOVDr FPR64:$src), dsub)>;
+  }
+
   // Insert scalar into vector with scalar index
   def : Pat<(nxv16i8 (vector_insert nxv16i8:$vec, GPR32:$src, GPR64:$index)),
             (CPY_ZPmR_B ZPR:$vec,

--- a/llvm/test/CodeGen/AArch64/complex-deinterleaving-reductions-scalable.ll
+++ b/llvm/test/CodeGen/AArch64/complex-deinterleaving-reductions-scalable.ll
@@ -97,18 +97,14 @@ exit.block:                                     ; preds = %vector.body
 define %"class.std::complex" @complex_mul_nonzero_init_v2f64(ptr %a, ptr %b) {
 ; CHECK-LABEL: complex_mul_nonzero_init_v2f64:
 ; CHECK:       // %bb.0: // %entry
-; CHECK-NEXT:    movi v0.2d, #0000000000000000
 ; CHECK-NEXT:    fmov d1, #1.00000000
-; CHECK-NEXT:    cntd x8
 ; CHECK-NEXT:    fmov d2, #2.00000000
-; CHECK-NEXT:    ptrue p0.d, vl1
+; CHECK-NEXT:    cntd x8
 ; CHECK-NEXT:    neg x9, x8
 ; CHECK-NEXT:    mov w10, #100 // =0x64
+; CHECK-NEXT:    ptrue p0.d
 ; CHECK-NEXT:    and x9, x9, x10
 ; CHECK-NEXT:    rdvl x10, #2
-; CHECK-NEXT:    sel z1.d, p0, z1.d, z0.d
-; CHECK-NEXT:    sel z2.d, p0, z2.d, z0.d
-; CHECK-NEXT:    ptrue p0.d
 ; CHECK-NEXT:    zip2 z0.d, z2.d, z1.d
 ; CHECK-NEXT:    zip1 z1.d, z2.d, z1.d
 ; CHECK-NEXT:  .LBB1_1: // %vector.body

--- a/llvm/test/CodeGen/AArch64/load-insert-zero.ll
+++ b/llvm/test/CodeGen/AArch64/load-insert-zero.ll
@@ -995,14 +995,8 @@ define <vscale x 2 x i64> @loadnxv2i64(ptr %p) {
 define <vscale x 4 x half> @loadnxv4f16(ptr %p) {
 ; CHECK-LABEL: loadnxv4f16:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    mov w8, wzr
-; CHECK-NEXT:    index z0.s, #0, #1
-; CHECK-NEXT:    ptrue p0.s
-; CHECK-NEXT:    mov z1.s, w8
-; CHECK-NEXT:    cmpeq p0.s, p0/z, z0.s, z1.s
-; CHECK-NEXT:    movi v0.2d, #0000000000000000
-; CHECK-NEXT:    ldr h1, [x0]
-; CHECK-NEXT:    mov z0.h, p0/m, h1
+; CHECK-NEXT:    ldr h0, [x0]
+; CHECK-NEXT:    fmov h0, h0
 ; CHECK-NEXT:    ret
   %l = load half, ptr %p
   %v = insertelement <vscale x 4 x half> zeroinitializer, half %l, i32 0
@@ -1022,14 +1016,8 @@ define <vscale x 8 x half> @loadnxv8f16(ptr %p) {
 define <vscale x 4 x bfloat> @loadnxv4bf16(ptr %p) {
 ; CHECK-LABEL: loadnxv4bf16:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    mov w8, wzr
-; CHECK-NEXT:    index z0.s, #0, #1
-; CHECK-NEXT:    ptrue p0.s
-; CHECK-NEXT:    mov z1.s, w8
-; CHECK-NEXT:    cmpeq p0.s, p0/z, z0.s, z1.s
-; CHECK-NEXT:    movi v0.2d, #0000000000000000
-; CHECK-NEXT:    ldr h1, [x0]
-; CHECK-NEXT:    mov z0.h, p0/m, h1
+; CHECK-NEXT:    ldr h0, [x0]
+; CHECK-NEXT:    fmov h0, h0
 ; CHECK-NEXT:    ret
   %l = load bfloat, ptr %p
   %v = insertelement <vscale x 4 x bfloat> zeroinitializer, bfloat %l, i32 0
@@ -1049,14 +1037,8 @@ define <vscale x 8 x bfloat> @loadnxv8bf16(ptr %p) {
 define <vscale x 2 x float> @loadnxv2f32(ptr %p) {
 ; CHECK-LABEL: loadnxv2f32:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    mov x8, xzr
-; CHECK-NEXT:    index z0.d, #0, #1
-; CHECK-NEXT:    ptrue p0.d
-; CHECK-NEXT:    mov z1.d, x8
-; CHECK-NEXT:    cmpeq p0.d, p0/z, z0.d, z1.d
-; CHECK-NEXT:    movi v0.2d, #0000000000000000
-; CHECK-NEXT:    ldr s1, [x0]
-; CHECK-NEXT:    mov z0.s, p0/m, s1
+; CHECK-NEXT:    ldr s0, [x0]
+; CHECK-NEXT:    fmov s0, s0
 ; CHECK-NEXT:    ret
   %l = load float, ptr %p
   %v = insertelement <vscale x 2 x float> zeroinitializer, float %l, i32 0
@@ -1170,14 +1152,8 @@ define <vscale x 2 x i64> @loadnxv2i64_offset(ptr %p) {
 define <vscale x 4 x half> @loadnxv4f16_offset(ptr %p) {
 ; CHECK-LABEL: loadnxv4f16_offset:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    mov w8, wzr
-; CHECK-NEXT:    index z0.s, #0, #1
-; CHECK-NEXT:    ptrue p0.s
-; CHECK-NEXT:    mov z1.s, w8
-; CHECK-NEXT:    cmpeq p0.s, p0/z, z0.s, z1.s
-; CHECK-NEXT:    movi v0.2d, #0000000000000000
-; CHECK-NEXT:    ldur h1, [x0, #1]
-; CHECK-NEXT:    mov z0.h, p0/m, h1
+; CHECK-NEXT:    ldur h0, [x0, #1]
+; CHECK-NEXT:    fmov h0, h0
 ; CHECK-NEXT:    ret
   %g = getelementptr inbounds i8, ptr %p, i64 1
   %l = load half, ptr %g
@@ -1199,14 +1175,8 @@ define <vscale x 8 x half> @loadnxv8f16_offset(ptr %p) {
 define <vscale x 4 x bfloat> @loadnxv4bf16_offset(ptr %p) {
 ; CHECK-LABEL: loadnxv4bf16_offset:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    mov w8, wzr
-; CHECK-NEXT:    index z0.s, #0, #1
-; CHECK-NEXT:    ptrue p0.s
-; CHECK-NEXT:    mov z1.s, w8
-; CHECK-NEXT:    cmpeq p0.s, p0/z, z0.s, z1.s
-; CHECK-NEXT:    movi v0.2d, #0000000000000000
-; CHECK-NEXT:    ldur h1, [x0, #1]
-; CHECK-NEXT:    mov z0.h, p0/m, h1
+; CHECK-NEXT:    ldur h0, [x0, #1]
+; CHECK-NEXT:    fmov h0, h0
 ; CHECK-NEXT:    ret
   %g = getelementptr inbounds i8, ptr %p, i64 1
   %l = load bfloat, ptr %g
@@ -1228,14 +1198,8 @@ define <vscale x 8 x bfloat> @loadnxv8bf16_offset(ptr %p) {
 define <vscale x 2 x float> @loadnxv2f32_offset(ptr %p) {
 ; CHECK-LABEL: loadnxv2f32_offset:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    mov x8, xzr
-; CHECK-NEXT:    index z0.d, #0, #1
-; CHECK-NEXT:    ptrue p0.d
-; CHECK-NEXT:    mov z1.d, x8
-; CHECK-NEXT:    cmpeq p0.d, p0/z, z0.d, z1.d
-; CHECK-NEXT:    movi v0.2d, #0000000000000000
-; CHECK-NEXT:    ldur s1, [x0, #1]
-; CHECK-NEXT:    mov z0.s, p0/m, s1
+; CHECK-NEXT:    ldur s0, [x0, #1]
+; CHECK-NEXT:    fmov s0, s0
 ; CHECK-NEXT:    ret
   %g = getelementptr inbounds i8, ptr %p, i64 1
   %l = load float, ptr %g

--- a/llvm/test/CodeGen/AArch64/load-insert-zero.ll
+++ b/llvm/test/CodeGen/AArch64/load-insert-zero.ll
@@ -921,10 +921,8 @@ define void @predictor_4x4_neon_new(ptr nocapture noundef writeonly %0, i64 noun
 define <vscale x 8 x i8> @loadnxv8i8(ptr %p) {
 ; CHECK-LABEL: loadnxv8i8:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    movi v0.2d, #0000000000000000
 ; CHECK-NEXT:    ldrb w8, [x0]
-; CHECK-NEXT:    ptrue p0.h, vl1
-; CHECK-NEXT:    mov z0.h, p0/m, w8
+; CHECK-NEXT:    fmov h0, w8
 ; CHECK-NEXT:    ret
   %l = load i8, ptr %p
   %v = insertelement <vscale x 8 x i8> zeroinitializer, i8 %l, i32 0
@@ -944,10 +942,8 @@ define <vscale x 16 x i8> @loadnxv16i8(ptr %p) {
 define <vscale x 4 x i16> @loadnxv4i16(ptr %p) {
 ; CHECK-LABEL: loadnxv4i16:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    movi v0.2d, #0000000000000000
 ; CHECK-NEXT:    ldrh w8, [x0]
-; CHECK-NEXT:    ptrue p0.s, vl1
-; CHECK-NEXT:    mov z0.s, p0/m, w8
+; CHECK-NEXT:    fmov s0, w8
 ; CHECK-NEXT:    ret
   %l = load i16, ptr %p
   %v = insertelement <vscale x 4 x i16> zeroinitializer, i16 %l, i32 0
@@ -967,10 +963,8 @@ define <vscale x 8 x i16> @loadnxv8i16(ptr %p) {
 define <vscale x 2 x i32> @loadnxv2i32(ptr %p) {
 ; CHECK-LABEL: loadnxv2i32:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    movi v0.2d, #0000000000000000
 ; CHECK-NEXT:    ldr w8, [x0]
-; CHECK-NEXT:    ptrue p0.d, vl1
-; CHECK-NEXT:    mov z0.d, p0/m, x8
+; CHECK-NEXT:    fmov d0, x8
 ; CHECK-NEXT:    ret
   %l = load i32, ptr %p
   %v = insertelement <vscale x 2 x i32> zeroinitializer, i32 %l, i32 0
@@ -1095,10 +1089,8 @@ define <vscale x 2 x double> @loadnxv2f64(ptr %p) {
 define <vscale x 8 x i8> @loadnxv8i8_offset(ptr %p) {
 ; CHECK-LABEL: loadnxv8i8_offset:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    movi v0.2d, #0000000000000000
 ; CHECK-NEXT:    ldrb w8, [x0, #1]
-; CHECK-NEXT:    ptrue p0.h, vl1
-; CHECK-NEXT:    mov z0.h, p0/m, w8
+; CHECK-NEXT:    fmov h0, w8
 ; CHECK-NEXT:    ret
   %g = getelementptr inbounds i8, ptr %p, i64 1
   %l = load i8, ptr %g
@@ -1120,10 +1112,8 @@ define <vscale x 16 x i8> @loadnxv16i8_offset(ptr %p) {
 define <vscale x 4 x i16> @loadnxv4i16_offset(ptr %p) {
 ; CHECK-LABEL: loadnxv4i16_offset:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    movi v0.2d, #0000000000000000
 ; CHECK-NEXT:    ldurh w8, [x0, #1]
-; CHECK-NEXT:    ptrue p0.s, vl1
-; CHECK-NEXT:    mov z0.s, p0/m, w8
+; CHECK-NEXT:    fmov s0, w8
 ; CHECK-NEXT:    ret
   %g = getelementptr inbounds i8, ptr %p, i64 1
   %l = load i16, ptr %g
@@ -1145,10 +1135,8 @@ define <vscale x 8 x i16> @loadnxv8i16_offset(ptr %p) {
 define <vscale x 2 x i32> @loadnxv2i32_offset(ptr %p) {
 ; CHECK-LABEL: loadnxv2i32_offset:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    movi v0.2d, #0000000000000000
 ; CHECK-NEXT:    ldur w8, [x0, #1]
-; CHECK-NEXT:    ptrue p0.d, vl1
-; CHECK-NEXT:    mov z0.d, p0/m, x8
+; CHECK-NEXT:    fmov d0, x8
 ; CHECK-NEXT:    ret
   %g = getelementptr inbounds i8, ptr %p, i64 1
   %l = load i32, ptr %g

--- a/llvm/test/CodeGen/AArch64/sve-implicit-zero-filling.ll
+++ b/llvm/test/CodeGen/AArch64/sve-implicit-zero-filling.ll
@@ -211,11 +211,8 @@ define <vscale x 2 x i64> @zero_fill_no_zero_upper_lanes(<vscale x 2 x i1> %pg, 
 ; CHECK-LABEL: zero_fill_no_zero_upper_lanes:
 ; CHECK:       // %bb.0:
 ; CHECK-NEXT:    umin z0.d, p0/m, z0.d, z0.d
-; CHECK-NEXT:    movi v1.2d, #0000000000000000
-; CHECK-NEXT:    ptrue p0.d, vl1
 ; CHECK-NEXT:    fmov x8, d0
-; CHECK-NEXT:    mov z1.d, p0/m, x8
-; CHECK-NEXT:    mov z0.d, z1.d
+; CHECK-NEXT:    fmov d0, x8
 ; CHECK-NEXT:    ret
   %t1 = call <vscale x 2 x i64> @llvm.aarch64.sve.umin.nxv2i64(<vscale x 2 x i1> %pg, <vscale x 2 x i64> %a, <vscale x 2 x i64> %a)
   %t2 = extractelement <vscale x 2 x i64> %t1, i64 0

--- a/llvm/test/CodeGen/AArch64/sve-insert-element.ll
+++ b/llvm/test/CodeGen/AArch64/sve-insert-element.ll
@@ -652,6 +652,94 @@ define <vscale x 2 x i64> @test_insert_first_into_zero_nxv2i64(i64 %x) {
   ret <vscale x 2 x i64> %res
 }
 
+define <vscale x 8 x half> @test_insert_first_into_zero_nxv8f16(half %x) {
+; CHECK-LABEL: test_insert_first_into_zero_nxv8f16:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    movi v1.2d, #0000000000000000
+; CHECK-NEXT:    ptrue p0.h, vl1
+; CHECK-NEXT:    // kill: def $h0 killed $h0 def $z0
+; CHECK-NEXT:    sel z0.h, p0, z0.h, z1.h
+; CHECK-NEXT:    ret
+  %res = insertelement <vscale x 8 x half> zeroinitializer, half %x, i64 0
+  ret <vscale x 8 x half> %res
+}
+
+define <vscale x 4 x half> @test_insert_first_into_zero_nxv4f16(half %x) {
+; CHECK-LABEL: test_insert_first_into_zero_nxv4f16:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    mov w8, wzr
+; CHECK-NEXT:    index z1.s, #0, #1
+; CHECK-NEXT:    ptrue p0.s
+; CHECK-NEXT:    mov z2.s, w8
+; CHECK-NEXT:    cmpeq p0.s, p0/z, z1.s, z2.s
+; CHECK-NEXT:    movi v1.2d, #0000000000000000
+; CHECK-NEXT:    mov z1.h, p0/m, h0
+; CHECK-NEXT:    mov z0.d, z1.d
+; CHECK-NEXT:    ret
+  %res = insertelement <vscale x 4 x half> zeroinitializer, half %x, i32 0
+  ret <vscale x 4 x half> %res
+}
+
+define <vscale x 2 x half> @test_insert_first_into_zero_nxv2f16(half %x) {
+; CHECK-LABEL: test_insert_first_into_zero_nxv2f16:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    mov x8, xzr
+; CHECK-NEXT:    index z1.d, #0, #1
+; CHECK-NEXT:    ptrue p0.d
+; CHECK-NEXT:    mov z2.d, x8
+; CHECK-NEXT:    cmpeq p0.d, p0/z, z1.d, z2.d
+; CHECK-NEXT:    movi v1.2d, #0000000000000000
+; CHECK-NEXT:    mov z1.h, p0/m, h0
+; CHECK-NEXT:    mov z0.d, z1.d
+; CHECK-NEXT:    ret
+  %res = insertelement <vscale x 2 x half> zeroinitializer, half %x, i32 0
+  ret <vscale x 2 x half> %res
+}
+
+define <vscale x 8 x bfloat> @test_insert_first_into_zero_nxv8bf16(bfloat %x) {
+; CHECK-LABEL: test_insert_first_into_zero_nxv8bf16:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    movi v1.2d, #0000000000000000
+; CHECK-NEXT:    ptrue p0.h, vl1
+; CHECK-NEXT:    // kill: def $h0 killed $h0 def $z0
+; CHECK-NEXT:    sel z0.h, p0, z0.h, z1.h
+; CHECK-NEXT:    ret
+  %res = insertelement <vscale x 8 x bfloat> zeroinitializer, bfloat %x, i64 0
+  ret <vscale x 8 x bfloat> %res
+}
+
+define <vscale x 4 x bfloat> @test_insert_first_into_zero_nxv4bf16(bfloat %x) {
+; CHECK-LABEL: test_insert_first_into_zero_nxv4bf16:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    mov w8, wzr
+; CHECK-NEXT:    index z1.s, #0, #1
+; CHECK-NEXT:    ptrue p0.s
+; CHECK-NEXT:    mov z2.s, w8
+; CHECK-NEXT:    cmpeq p0.s, p0/z, z1.s, z2.s
+; CHECK-NEXT:    movi v1.2d, #0000000000000000
+; CHECK-NEXT:    mov z1.h, p0/m, h0
+; CHECK-NEXT:    mov z0.d, z1.d
+; CHECK-NEXT:    ret
+  %res = insertelement <vscale x 4 x bfloat> zeroinitializer, bfloat %x, i32 0
+  ret <vscale x 4 x bfloat> %res
+}
+
+define <vscale x 2 x bfloat> @test_insert_first_into_zero_nxv2bf16(bfloat %x) {
+; CHECK-LABEL: test_insert_first_into_zero_nxv2bf16:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    mov x8, xzr
+; CHECK-NEXT:    index z1.d, #0, #1
+; CHECK-NEXT:    ptrue p0.d
+; CHECK-NEXT:    mov z2.d, x8
+; CHECK-NEXT:    cmpeq p0.d, p0/z, z1.d, z2.d
+; CHECK-NEXT:    movi v1.2d, #0000000000000000
+; CHECK-NEXT:    mov z1.h, p0/m, h0
+; CHECK-NEXT:    mov z0.d, z1.d
+; CHECK-NEXT:    ret
+  %res = insertelement <vscale x 2 x bfloat> zeroinitializer, bfloat %x, i32 0
+  ret <vscale x 2 x bfloat> %res
+}
+
 define <vscale x 4 x float> @test_insert_first_into_zero_nxv4f32(float %x) {
 ; CHECK-LABEL: test_insert_first_into_zero_nxv4f32:
 ; CHECK:       // %bb.0:
@@ -659,6 +747,22 @@ define <vscale x 4 x float> @test_insert_first_into_zero_nxv4f32(float %x) {
 ; CHECK-NEXT:    ret
   %res = insertelement <vscale x 4 x float> zeroinitializer, float %x, i64 0
   ret <vscale x 4 x float> %res
+}
+
+define <vscale x 2 x float> @test_insert_first_into_zero_nxv2f32(float %x) {
+; CHECK-LABEL: test_insert_first_into_zero_nxv2f32:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    mov x8, xzr
+; CHECK-NEXT:    index z1.d, #0, #1
+; CHECK-NEXT:    ptrue p0.d
+; CHECK-NEXT:    mov z2.d, x8
+; CHECK-NEXT:    cmpeq p0.d, p0/z, z1.d, z2.d
+; CHECK-NEXT:    movi v1.2d, #0000000000000000
+; CHECK-NEXT:    mov z1.s, p0/m, s0
+; CHECK-NEXT:    mov z0.d, z1.d
+; CHECK-NEXT:    ret
+  %res = insertelement <vscale x 2 x float> zeroinitializer, float %x, i32 0
+  ret <vscale x 2 x float> %res
 }
 
 define <vscale x 2 x double> @test_insert_first_into_zero_nxv2f64(double %x) {

--- a/llvm/test/CodeGen/AArch64/sve-insert-element.ll
+++ b/llvm/test/CodeGen/AArch64/sve-insert-element.ll
@@ -628,9 +628,7 @@ define <vscale x 32 x i1> @test_predicate_insert_32xi1(<vscale x 32 x i1> %val, 
 define <vscale x 8 x i16> @test_insert_first_into_zero_nxv8i16(i16 %x) {
 ; CHECK-LABEL: test_insert_first_into_zero_nxv8i16:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    movi v0.2d, #0000000000000000
-; CHECK-NEXT:    ptrue p0.h, vl1
-; CHECK-NEXT:    mov z0.h, p0/m, w0
+; CHECK-NEXT:    fmov h0, w0
 ; CHECK-NEXT:    ret
   %res = insertelement <vscale x 8 x i16> zeroinitializer, i16 %x, i64 0
   ret <vscale x 8 x i16> %res
@@ -639,9 +637,7 @@ define <vscale x 8 x i16> @test_insert_first_into_zero_nxv8i16(i16 %x) {
 define <vscale x 4 x i32> @test_insert_first_into_zero_nxv4i32(i32 %x) {
 ; CHECK-LABEL: test_insert_first_into_zero_nxv4i32:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    movi v0.2d, #0000000000000000
-; CHECK-NEXT:    ptrue p0.s, vl1
-; CHECK-NEXT:    mov z0.s, p0/m, w0
+; CHECK-NEXT:    fmov s0, w0
 ; CHECK-NEXT:    ret
   %res = insertelement <vscale x 4 x i32> zeroinitializer, i32 %x, i64 0
   ret <vscale x 4 x i32> %res
@@ -650,9 +646,7 @@ define <vscale x 4 x i32> @test_insert_first_into_zero_nxv4i32(i32 %x) {
 define <vscale x 2 x i64> @test_insert_first_into_zero_nxv2i64(i64 %x) {
 ; CHECK-LABEL: test_insert_first_into_zero_nxv2i64:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    movi v0.2d, #0000000000000000
-; CHECK-NEXT:    ptrue p0.d, vl1
-; CHECK-NEXT:    mov z0.d, p0/m, x0
+; CHECK-NEXT:    fmov d0, x0
 ; CHECK-NEXT:    ret
   %res = insertelement <vscale x 2 x i64> zeroinitializer, i64 %x, i64 0
   ret <vscale x 2 x i64> %res
@@ -661,10 +655,7 @@ define <vscale x 2 x i64> @test_insert_first_into_zero_nxv2i64(i64 %x) {
 define <vscale x 4 x float> @test_insert_first_into_zero_nxv4f32(float %x) {
 ; CHECK-LABEL: test_insert_first_into_zero_nxv4f32:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    movi v1.2d, #0000000000000000
-; CHECK-NEXT:    ptrue p0.s, vl1
-; CHECK-NEXT:    // kill: def $s0 killed $s0 def $z0
-; CHECK-NEXT:    sel z0.s, p0, z0.s, z1.s
+; CHECK-NEXT:    fmov s0, s0
 ; CHECK-NEXT:    ret
   %res = insertelement <vscale x 4 x float> zeroinitializer, float %x, i64 0
   ret <vscale x 4 x float> %res
@@ -673,10 +664,7 @@ define <vscale x 4 x float> @test_insert_first_into_zero_nxv4f32(float %x) {
 define <vscale x 2 x double> @test_insert_first_into_zero_nxv2f64(double %x) {
 ; CHECK-LABEL: test_insert_first_into_zero_nxv2f64:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    movi v1.2d, #0000000000000000
-; CHECK-NEXT:    ptrue p0.d, vl1
-; CHECK-NEXT:    // kill: def $d0 killed $d0 def $z0
-; CHECK-NEXT:    sel z0.d, p0, z0.d, z1.d
+; CHECK-NEXT:    fmov d0, d0
 ; CHECK-NEXT:    ret
   %res = insertelement <vscale x 2 x double> zeroinitializer, double %x, i64 0
   ret <vscale x 2 x double> %res

--- a/llvm/test/CodeGen/AArch64/sve-insert-element.ll
+++ b/llvm/test/CodeGen/AArch64/sve-insert-element.ll
@@ -655,10 +655,7 @@ define <vscale x 2 x i64> @test_insert_first_into_zero_nxv2i64(i64 %x) {
 define <vscale x 8 x half> @test_insert_first_into_zero_nxv8f16(half %x) {
 ; CHECK-LABEL: test_insert_first_into_zero_nxv8f16:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    movi v1.2d, #0000000000000000
-; CHECK-NEXT:    ptrue p0.h, vl1
-; CHECK-NEXT:    // kill: def $h0 killed $h0 def $z0
-; CHECK-NEXT:    sel z0.h, p0, z0.h, z1.h
+; CHECK-NEXT:    fmov h0, h0
 ; CHECK-NEXT:    ret
   %res = insertelement <vscale x 8 x half> zeroinitializer, half %x, i64 0
   ret <vscale x 8 x half> %res
@@ -667,14 +664,7 @@ define <vscale x 8 x half> @test_insert_first_into_zero_nxv8f16(half %x) {
 define <vscale x 4 x half> @test_insert_first_into_zero_nxv4f16(half %x) {
 ; CHECK-LABEL: test_insert_first_into_zero_nxv4f16:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    mov w8, wzr
-; CHECK-NEXT:    index z1.s, #0, #1
-; CHECK-NEXT:    ptrue p0.s
-; CHECK-NEXT:    mov z2.s, w8
-; CHECK-NEXT:    cmpeq p0.s, p0/z, z1.s, z2.s
-; CHECK-NEXT:    movi v1.2d, #0000000000000000
-; CHECK-NEXT:    mov z1.h, p0/m, h0
-; CHECK-NEXT:    mov z0.d, z1.d
+; CHECK-NEXT:    fmov h0, h0
 ; CHECK-NEXT:    ret
   %res = insertelement <vscale x 4 x half> zeroinitializer, half %x, i32 0
   ret <vscale x 4 x half> %res
@@ -683,14 +673,7 @@ define <vscale x 4 x half> @test_insert_first_into_zero_nxv4f16(half %x) {
 define <vscale x 2 x half> @test_insert_first_into_zero_nxv2f16(half %x) {
 ; CHECK-LABEL: test_insert_first_into_zero_nxv2f16:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    mov x8, xzr
-; CHECK-NEXT:    index z1.d, #0, #1
-; CHECK-NEXT:    ptrue p0.d
-; CHECK-NEXT:    mov z2.d, x8
-; CHECK-NEXT:    cmpeq p0.d, p0/z, z1.d, z2.d
-; CHECK-NEXT:    movi v1.2d, #0000000000000000
-; CHECK-NEXT:    mov z1.h, p0/m, h0
-; CHECK-NEXT:    mov z0.d, z1.d
+; CHECK-NEXT:    fmov h0, h0
 ; CHECK-NEXT:    ret
   %res = insertelement <vscale x 2 x half> zeroinitializer, half %x, i32 0
   ret <vscale x 2 x half> %res
@@ -699,10 +682,7 @@ define <vscale x 2 x half> @test_insert_first_into_zero_nxv2f16(half %x) {
 define <vscale x 8 x bfloat> @test_insert_first_into_zero_nxv8bf16(bfloat %x) {
 ; CHECK-LABEL: test_insert_first_into_zero_nxv8bf16:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    movi v1.2d, #0000000000000000
-; CHECK-NEXT:    ptrue p0.h, vl1
-; CHECK-NEXT:    // kill: def $h0 killed $h0 def $z0
-; CHECK-NEXT:    sel z0.h, p0, z0.h, z1.h
+; CHECK-NEXT:    fmov h0, h0
 ; CHECK-NEXT:    ret
   %res = insertelement <vscale x 8 x bfloat> zeroinitializer, bfloat %x, i64 0
   ret <vscale x 8 x bfloat> %res
@@ -711,14 +691,7 @@ define <vscale x 8 x bfloat> @test_insert_first_into_zero_nxv8bf16(bfloat %x) {
 define <vscale x 4 x bfloat> @test_insert_first_into_zero_nxv4bf16(bfloat %x) {
 ; CHECK-LABEL: test_insert_first_into_zero_nxv4bf16:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    mov w8, wzr
-; CHECK-NEXT:    index z1.s, #0, #1
-; CHECK-NEXT:    ptrue p0.s
-; CHECK-NEXT:    mov z2.s, w8
-; CHECK-NEXT:    cmpeq p0.s, p0/z, z1.s, z2.s
-; CHECK-NEXT:    movi v1.2d, #0000000000000000
-; CHECK-NEXT:    mov z1.h, p0/m, h0
-; CHECK-NEXT:    mov z0.d, z1.d
+; CHECK-NEXT:    fmov h0, h0
 ; CHECK-NEXT:    ret
   %res = insertelement <vscale x 4 x bfloat> zeroinitializer, bfloat %x, i32 0
   ret <vscale x 4 x bfloat> %res
@@ -727,14 +700,7 @@ define <vscale x 4 x bfloat> @test_insert_first_into_zero_nxv4bf16(bfloat %x) {
 define <vscale x 2 x bfloat> @test_insert_first_into_zero_nxv2bf16(bfloat %x) {
 ; CHECK-LABEL: test_insert_first_into_zero_nxv2bf16:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    mov x8, xzr
-; CHECK-NEXT:    index z1.d, #0, #1
-; CHECK-NEXT:    ptrue p0.d
-; CHECK-NEXT:    mov z2.d, x8
-; CHECK-NEXT:    cmpeq p0.d, p0/z, z1.d, z2.d
-; CHECK-NEXT:    movi v1.2d, #0000000000000000
-; CHECK-NEXT:    mov z1.h, p0/m, h0
-; CHECK-NEXT:    mov z0.d, z1.d
+; CHECK-NEXT:    fmov h0, h0
 ; CHECK-NEXT:    ret
   %res = insertelement <vscale x 2 x bfloat> zeroinitializer, bfloat %x, i32 0
   ret <vscale x 2 x bfloat> %res
@@ -752,14 +718,7 @@ define <vscale x 4 x float> @test_insert_first_into_zero_nxv4f32(float %x) {
 define <vscale x 2 x float> @test_insert_first_into_zero_nxv2f32(float %x) {
 ; CHECK-LABEL: test_insert_first_into_zero_nxv2f32:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    mov x8, xzr
-; CHECK-NEXT:    index z1.d, #0, #1
-; CHECK-NEXT:    ptrue p0.d
-; CHECK-NEXT:    mov z2.d, x8
-; CHECK-NEXT:    cmpeq p0.d, p0/z, z1.d, z2.d
-; CHECK-NEXT:    movi v1.2d, #0000000000000000
-; CHECK-NEXT:    mov z1.s, p0/m, s0
-; CHECK-NEXT:    mov z0.d, z1.d
+; CHECK-NEXT:    fmov s0, s0
 ; CHECK-NEXT:    ret
   %res = insertelement <vscale x 2 x float> zeroinitializer, float %x, i32 0
   ret <vscale x 2 x float> %res

--- a/llvm/test/CodeGen/AArch64/sve-insert-element.ll
+++ b/llvm/test/CodeGen/AArch64/sve-insert-element.ll
@@ -624,3 +624,60 @@ define <vscale x 32 x i1> @test_predicate_insert_32xi1(<vscale x 32 x i1> %val, 
   %res = insertelement <vscale x 32 x i1> %val, i1 %elt, i32 %idx
   ret <vscale x 32 x i1> %res
 }
+
+define <vscale x 8 x i16> @test_insert_first_into_zero_nxv8i16(i16 %x) {
+; CHECK-LABEL: test_insert_first_into_zero_nxv8i16:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    movi v0.2d, #0000000000000000
+; CHECK-NEXT:    ptrue p0.h, vl1
+; CHECK-NEXT:    mov z0.h, p0/m, w0
+; CHECK-NEXT:    ret
+  %res = insertelement <vscale x 8 x i16> zeroinitializer, i16 %x, i64 0
+  ret <vscale x 8 x i16> %res
+}
+
+define <vscale x 4 x i32> @test_insert_first_into_zero_nxv4i32(i32 %x) {
+; CHECK-LABEL: test_insert_first_into_zero_nxv4i32:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    movi v0.2d, #0000000000000000
+; CHECK-NEXT:    ptrue p0.s, vl1
+; CHECK-NEXT:    mov z0.s, p0/m, w0
+; CHECK-NEXT:    ret
+  %res = insertelement <vscale x 4 x i32> zeroinitializer, i32 %x, i64 0
+  ret <vscale x 4 x i32> %res
+}
+
+define <vscale x 2 x i64> @test_insert_first_into_zero_nxv2i64(i64 %x) {
+; CHECK-LABEL: test_insert_first_into_zero_nxv2i64:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    movi v0.2d, #0000000000000000
+; CHECK-NEXT:    ptrue p0.d, vl1
+; CHECK-NEXT:    mov z0.d, p0/m, x0
+; CHECK-NEXT:    ret
+  %res = insertelement <vscale x 2 x i64> zeroinitializer, i64 %x, i64 0
+  ret <vscale x 2 x i64> %res
+}
+
+define <vscale x 4 x float> @test_insert_first_into_zero_nxv4f32(float %x) {
+; CHECK-LABEL: test_insert_first_into_zero_nxv4f32:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    movi v1.2d, #0000000000000000
+; CHECK-NEXT:    ptrue p0.s, vl1
+; CHECK-NEXT:    // kill: def $s0 killed $s0 def $z0
+; CHECK-NEXT:    sel z0.s, p0, z0.s, z1.s
+; CHECK-NEXT:    ret
+  %res = insertelement <vscale x 4 x float> zeroinitializer, float %x, i64 0
+  ret <vscale x 4 x float> %res
+}
+
+define <vscale x 2 x double> @test_insert_first_into_zero_nxv2f64(double %x) {
+; CHECK-LABEL: test_insert_first_into_zero_nxv2f64:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    movi v1.2d, #0000000000000000
+; CHECK-NEXT:    ptrue p0.d, vl1
+; CHECK-NEXT:    // kill: def $d0 killed $d0 def $z0
+; CHECK-NEXT:    sel z0.d, p0, z0.d, z1.d
+; CHECK-NEXT:    ret
+  %res = insertelement <vscale x 2 x double> zeroinitializer, double %x, i64 0
+  ret <vscale x 2 x double> %res
+}

--- a/llvm/test/CodeGen/AArch64/sve-pr92779.ll
+++ b/llvm/test/CodeGen/AArch64/sve-pr92779.ll
@@ -8,11 +8,11 @@ define void @main(ptr %0) {
 ; CHECK-NEXT:    ptrue p0.d, vl1
 ; CHECK-NEXT:    movprfx z1, z0
 ; CHECK-NEXT:    ext z1.b, z1.b, z0.b, #8
-; CHECK-NEXT:    uzp1 v1.2s, v0.2s, v1.2s
-; CHECK-NEXT:    neg v1.2s, v1.2s
-; CHECK-NEXT:    smov x8, v1.s[0]
-; CHECK-NEXT:    smov x9, v1.s[1]
-; CHECK-NEXT:    mov z0.d, p0/m, x8
+; CHECK-NEXT:    uzp1 v0.2s, v0.2s, v1.2s
+; CHECK-NEXT:    neg v0.2s, v0.2s
+; CHECK-NEXT:    smov x8, v0.s[0]
+; CHECK-NEXT:    smov x9, v0.s[1]
+; CHECK-NEXT:    fmov d0, x8
 ; CHECK-NEXT:    mov z0.d, p0/m, x9
 ; CHECK-NEXT:    str z0, [x0]
 ; CHECK-NEXT:    ret


### PR DESCRIPTION
Currently, when inserting a scalar into the first element of a zero-initialised scalable vector, we zero the register explicitly and emit a predicated move. However, an FMOV should be preferable as it implicitly zeros the upper bits of the destination.