### PR TITLE
[mlir][CAPI] Add C API for creating dynamic dialects, ops, types, and attrs

### DIFF
--- a/mlir/include/mlir-c/ExtensibleDialect.h
+++ b/mlir/include/mlir-c/ExtensibleDialect.h
@@ -31,11 +31,136 @@ extern "C" {
   };                                                                           \
   typedef struct name name
 
+DEFINE_C_API_STRUCT(MlirDynamicDialect, void);
+DEFINE_C_API_STRUCT(MlirDynamicOpDefinition, void);
 DEFINE_C_API_STRUCT(MlirDynamicOpTrait, void);
 DEFINE_C_API_STRUCT(MlirDynamicTypeDefinition, void);
 DEFINE_C_API_STRUCT(MlirDynamicAttrDefinition, void);
 
 #undef DEFINE_C_API_STRUCT
+
+//===----------------------------------------------------------------------===//
+/// Dynamic dialect creation
+//===----------------------------------------------------------------------===//
+
+/// Create a new dynamic dialect with the given name and register it with the
+/// context. If a dialect with the same name already exists, returns the
+/// existing one. The context takes ownership of the dialect. The returned
+/// handle is valid as long as the context is alive and must not be freed.
+MLIR_CAPI_EXPORTED MlirDynamicDialect
+mlirDynamicDialectCreate(MlirContext ctx, MlirStringRef name);
+
+/// Get the underlying MlirDialect from a MlirDynamicDialect.
+MLIR_CAPI_EXPORTED MlirDialect
+mlirDynamicDialectAsDialect(MlirDynamicDialect dialect);
+
+//===----------------------------------------------------------------------===//
+/// Dynamic op definition creation
+//===----------------------------------------------------------------------===//
+
+/// Callbacks for a dynamic op definition. All fields may be NULL, in which
+/// case the corresponding action is a no-op / always succeeds.
+typedef struct {
+  /// The callback function to verify the operation.
+  MlirLogicalResult (*verify)(MlirOperation op, void *userData);
+  /// The callback function to verify the operation with access to regions.
+  MlirLogicalResult (*verifyRegion)(MlirOperation op, void *userData);
+} MlirDynamicOpDefinitionCallbacks;
+
+/// Create a dynamic op definition with the given name and callbacks.
+/// The name should be the bare op name (e.g. "constant"), not the
+/// dialect-qualified name. The definition is NOT yet registered with the
+/// dialect; call mlirDynamicDialectRegisterOp to register it.
+/// \p userData is shared between all callbacks.
+/// If the definition is not registered, it must be destroyed with
+/// mlirDynamicOpDefinitionDestroy to avoid a memory leak.
+MLIR_CAPI_EXPORTED MlirDynamicOpDefinition mlirDynamicOpDefinitionCreate(
+    MlirDynamicDialect dialect, MlirStringRef name,
+    MlirDynamicOpDefinitionCallbacks callbacks, void *userData);
+
+/// Destroy a dynamic op definition that was not registered with a dialect.
+MLIR_CAPI_EXPORTED void
+mlirDynamicOpDefinitionDestroy(MlirDynamicOpDefinition opDef);
+
+/// Register a dynamic op definition with its parent dialect.
+/// This transfers ownership of the definition to the dialect.
+/// After this call, ops with this name can be created using
+/// mlirOperationCreate with the dialect-qualified name.
+MLIR_CAPI_EXPORTED void
+mlirDynamicDialectRegisterOp(MlirDynamicDialect dialect,
+                             MlirDynamicOpDefinition opDef);
+
+//===----------------------------------------------------------------------===//
+/// Dynamic type definition creation
+//===----------------------------------------------------------------------===//
+
+/// Callbacks for a dynamic type definition. All fields may be NULL, in which
+/// case the corresponding action is a no-op / always succeeds.
+typedef struct {
+  /// The callback function to verify the type's parameters.
+  MlirLogicalResult (*verify)(intptr_t nParams, MlirAttribute const *params,
+                              void *userData);
+} MlirDynamicTypeDefinitionCallbacks;
+
+/// Create a dynamic type definition with the given name and callbacks.
+/// The name should be the bare type name (e.g. "mystruct"), not the
+/// dialect-qualified name. The definition is NOT yet registered with the
+/// dialect; call mlirDynamicDialectRegisterType to register it.
+/// Note: the verifier callback does not receive diagnostic context; failures
+/// are reported without a custom error message.
+/// If the definition is not registered, it must be destroyed with
+/// mlirDynamicTypeDefinitionDestroy to avoid a memory leak.
+MLIR_CAPI_EXPORTED MlirDynamicTypeDefinition mlirDynamicTypeDefinitionCreate(
+    MlirDynamicDialect dialect, MlirStringRef name,
+    MlirDynamicTypeDefinitionCallbacks callbacks, void *userData);
+
+/// Destroy a dynamic type definition that was not registered with a dialect.
+MLIR_CAPI_EXPORTED void
+mlirDynamicTypeDefinitionDestroy(MlirDynamicTypeDefinition typeDef);
+
+/// Register a dynamic type definition with its parent dialect.
+/// This transfers ownership of the definition to the dialect.
+MLIR_CAPI_EXPORTED void
+mlirDynamicDialectRegisterType(MlirDynamicDialect dialect,
+                               MlirDynamicTypeDefinition typeDef);
+
+//===----------------------------------------------------------------------===//
+/// Dynamic attribute definition creation
+//===----------------------------------------------------------------------===//
+
+/// Callbacks for a dynamic attribute definition. All fields may be NULL, in
+/// which case the corresponding action is a no-op / always succeeds.
+typedef struct {
+  /// The callback function to verify the attribute's parameters.
+  MlirLogicalResult (*verify)(intptr_t nParams, MlirAttribute const *params,
+                              void *userData);
+} MlirDynamicAttrDefinitionCallbacks;
+
+/// Create a dynamic attribute definition with the given name and callbacks.
+/// The name should be the bare attr name, not the dialect-qualified name.
+/// The definition is NOT yet registered with the dialect; call
+/// mlirDynamicDialectRegisterAttr to register it.
+/// Note: the verifier callback does not receive diagnostic context; failures
+/// are reported without a custom error message.
+/// If the definition is not registered, it must be destroyed with
+/// mlirDynamicAttrDefinitionDestroy to avoid a memory leak.
+MLIR_CAPI_EXPORTED MlirDynamicAttrDefinition mlirDynamicAttrDefinitionCreate(
+    MlirDynamicDialect dialect, MlirStringRef name,
+    MlirDynamicAttrDefinitionCallbacks callbacks, void *userData);
+
+/// Destroy a dynamic attr definition that was not registered with a dialect.
+MLIR_CAPI_EXPORTED void
+mlirDynamicAttrDefinitionDestroy(MlirDynamicAttrDefinition attrDef);
+
+/// Register a dynamic attribute definition with its parent dialect.
+/// This transfers ownership of the definition to the dialect.
+MLIR_CAPI_EXPORTED void
+mlirDynamicDialectRegisterAttr(MlirDynamicDialect dialect,
+                               MlirDynamicAttrDefinition attrDef);
+
+//===----------------------------------------------------------------------===//
+/// Dynamic op trait APIs
+//===----------------------------------------------------------------------===//
 
 /// Attach a dynamic op trait to the given operation name.
 /// Note that the operation name must be modeled by dynamic dialect and must be

--- a/mlir/lib/CAPI/IR/ExtensibleDialect.cpp
+++ b/mlir/lib/CAPI/IR/ExtensibleDialect.cpp
@@ -9,14 +9,142 @@
 #include "mlir-c/ExtensibleDialect.h"
 #include "mlir/CAPI/IR.h"
 #include "mlir/CAPI/Support.h"
+#include "mlir/CAPI/Wrap.h"
 #include "mlir/IR/ExtensibleDialect.h"
+#include "mlir/IR/MLIRContext.h"
 #include "mlir/IR/OperationSupport.h"
 
 using namespace mlir;
 
+DEFINE_C_API_PTR_METHODS(MlirDynamicDialect, DynamicDialect)
+DEFINE_C_API_PTR_METHODS(MlirDynamicOpDefinition, DynamicOpDefinition)
 DEFINE_C_API_PTR_METHODS(MlirDynamicOpTrait, DynamicOpTrait)
 DEFINE_C_API_PTR_METHODS(MlirDynamicTypeDefinition, DynamicTypeDefinition)
 DEFINE_C_API_PTR_METHODS(MlirDynamicAttrDefinition, DynamicAttrDefinition)
+
+//===----------------------------------------------------------------------===//
+// Dynamic dialect creation
+//===----------------------------------------------------------------------===//
+
+MlirDynamicDialect mlirDynamicDialectCreate(MlirContext ctx,
+                                            MlirStringRef name) {
+  DynamicDialect *dialect = unwrap(ctx)->getOrLoadDynamicDialect(
+      unwrap(name), [](DynamicDialect *) {});
+  return wrap(dialect);
+}
+
+MlirDialect mlirDynamicDialectAsDialect(MlirDynamicDialect dialect) {
+  return wrap(static_cast<Dialect *>(unwrap(dialect)));
+}
+
+//===----------------------------------------------------------------------===//
+// Dynamic op definition creation
+//===----------------------------------------------------------------------===//
+
+MlirDynamicOpDefinition
+mlirDynamicOpDefinitionCreate(MlirDynamicDialect dialect, MlirStringRef name,
+                              MlirDynamicOpDefinitionCallbacks callbacks,
+                              void *userData) {
+  auto cppVerifyFn = [callbacks, userData](Operation *op) -> LogicalResult {
+    if (!callbacks.verify)
+      return success();
+    return unwrap(callbacks.verify(wrap(op), userData));
+  };
+  auto cppVerifyRegionFn = [callbacks,
+                            userData](Operation *op) -> LogicalResult {
+    if (!callbacks.verifyRegion)
+      return success();
+    return unwrap(callbacks.verifyRegion(wrap(op), userData));
+  };
+  std::unique_ptr<DynamicOpDefinition> opDef = DynamicOpDefinition::get(
+      unwrap(name), unwrap(dialect), std::move(cppVerifyFn),
+      std::move(cppVerifyRegionFn));
+  return wrap(opDef.release());
+}
+
+void mlirDynamicOpDefinitionDestroy(MlirDynamicOpDefinition opDef) {
+  delete unwrap(opDef);
+}
+
+void mlirDynamicDialectRegisterOp(MlirDynamicDialect dialect,
+                                  MlirDynamicOpDefinition opDef) {
+  unwrap(dialect)->registerDynamicOp(
+      std::unique_ptr<DynamicOpDefinition>(unwrap(opDef)));
+}
+
+//===----------------------------------------------------------------------===//
+// Dynamic type definition creation
+//===----------------------------------------------------------------------===//
+
+MlirDynamicTypeDefinition
+mlirDynamicTypeDefinitionCreate(MlirDynamicDialect dialect, MlirStringRef name,
+                                MlirDynamicTypeDefinitionCallbacks callbacks,
+                                void *userData) {
+  auto cppVerifyFn = [callbacks,
+                      userData](function_ref<InFlightDiagnostic()> emitError,
+                                ArrayRef<Attribute> params) -> LogicalResult {
+    if (!callbacks.verify)
+      return success();
+    SmallVector<MlirAttribute> cParams;
+    cParams.reserve(params.size());
+    for (Attribute p : params)
+      cParams.push_back(wrap(p));
+    return unwrap(callbacks.verify(static_cast<intptr_t>(cParams.size()),
+                                   cParams.data(), userData));
+  };
+  std::unique_ptr<DynamicTypeDefinition> typeDef = DynamicTypeDefinition::get(
+      unwrap(name), unwrap(dialect), std::move(cppVerifyFn));
+  return wrap(typeDef.release());
+}
+
+void mlirDynamicTypeDefinitionDestroy(MlirDynamicTypeDefinition typeDef) {
+  delete unwrap(typeDef);
+}
+
+void mlirDynamicDialectRegisterType(MlirDynamicDialect dialect,
+                                    MlirDynamicTypeDefinition typeDef) {
+  unwrap(dialect)->registerDynamicType(
+      std::unique_ptr<DynamicTypeDefinition>(unwrap(typeDef)));
+}
+
+//===----------------------------------------------------------------------===//
+// Dynamic attribute definition creation
+//===----------------------------------------------------------------------===//
+
+MlirDynamicAttrDefinition
+mlirDynamicAttrDefinitionCreate(MlirDynamicDialect dialect, MlirStringRef name,
+                                MlirDynamicAttrDefinitionCallbacks callbacks,
+                                void *userData) {
+  auto cppVerifyFn = [callbacks,
+                      userData](function_ref<InFlightDiagnostic()> emitError,
+                                ArrayRef<Attribute> params) -> LogicalResult {
+    if (!callbacks.verify)
+      return success();
+    SmallVector<MlirAttribute> cParams;
+    cParams.reserve(params.size());
+    for (Attribute p : params)
+      cParams.push_back(wrap(p));
+    return unwrap(callbacks.verify(static_cast<intptr_t>(cParams.size()),
+                                   cParams.data(), userData));
+  };
+  std::unique_ptr<DynamicAttrDefinition> attrDef = DynamicAttrDefinition::get(
+      unwrap(name), unwrap(dialect), std::move(cppVerifyFn));
+  return wrap(attrDef.release());
+}
+
+void mlirDynamicAttrDefinitionDestroy(MlirDynamicAttrDefinition attrDef) {
+  delete unwrap(attrDef);
+}
+
+void mlirDynamicDialectRegisterAttr(MlirDynamicDialect dialect,
+                                    MlirDynamicAttrDefinition attrDef) {
+  unwrap(dialect)->registerDynamicAttr(
+      std::unique_ptr<DynamicAttrDefinition>(unwrap(attrDef)));
+}
+
+//===----------------------------------------------------------------------===//
+// Dynamic op trait APIs
+//===----------------------------------------------------------------------===//
 
 bool mlirDynamicOpTraitAttach(MlirDynamicOpTrait dynamicOpTrait,
                               MlirStringRef opName, MlirContext context) {

--- a/mlir/test/CAPI/CMakeLists.txt
+++ b/mlir/test/CAPI/CMakeLists.txt
@@ -48,6 +48,12 @@ _add_capi_test_executable(mlir-capi-ir-test
     MLIRCAPIRegisterEverything
 )
 
+_add_capi_test_executable(mlir-capi-extensible-dialect-test
+  extensible_dialect.c
+  LINK_LIBS PRIVATE
+    MLIRCAPIIR
+)
+
 _add_capi_test_executable(mlir-capi-irdl-test
   irdl.c
   LINK_LIBS PRIVATE

--- a/mlir/test/CAPI/extensible_dialect.c
+++ b/mlir/test/CAPI/extensible_dialect.c
@@ -1,0 +1,179 @@
+//===- extensible_dialect.c - Test C API for extensible dialect creation
+//---===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM
+// Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+/* RUN: mlir-capi-extensible-dialect-test 2>&1 | FileCheck %s
+ */
+
+#include "mlir-c/BuiltinAttributes.h"
+#include "mlir-c/BuiltinTypes.h"
+#include "mlir-c/ExtensibleDialect.h"
+#include "mlir-c/IR.h"
+#include "mlir-c/Support.h"
+
+#include <stdio.h>
+
+static MlirStringRef strref(const char *s) {
+  return mlirStringRefCreateFromCString(s);
+}
+
+static MlirLogicalResult successTypeVerify(intptr_t nParams,
+                                           MlirAttribute const *params,
+                                           void *userData) {
+  (void)nParams;
+  (void)params;
+  (void)userData;
+  return mlirLogicalResultSuccess();
+}
+
+static MlirLogicalResult successAttrVerify(intptr_t nParams,
+                                           MlirAttribute const *params,
+                                           void *userData) {
+  (void)nParams;
+  (void)params;
+  (void)userData;
+  return mlirLogicalResultSuccess();
+}
+
+void testDynamicDialectCreation(MlirContext ctx) {
+  // Create a dynamic dialect.
+  MlirDynamicDialect testDialect =
+      mlirDynamicDialectCreate(ctx, strref("test_dyn"));
+  MlirDialect dialect = mlirDynamicDialectAsDialect(testDialect);
+
+  // CHECK: test_dyn is extensible: 1
+  fprintf(stderr, "test_dyn is extensible: %d\n",
+          mlirDialectIsAExtensibleDialect(dialect));
+}
+
+void testDynamicOpCreation(MlirContext ctx) {
+  MlirDynamicDialect testDialect =
+      mlirDynamicDialectCreate(ctx, strref("testop"));
+
+  // Define and register a simple op with no callbacks.
+  MlirDynamicOpDefinitionCallbacks opCallbacks = {NULL, NULL, NULL, NULL};
+  MlirDynamicOpDefinition opDef = mlirDynamicOpDefinitionCreate(
+      testDialect, strref("my_op"), opCallbacks, NULL);
+  mlirDynamicDialectRegisterOp(testDialect, opDef);
+
+  // Parse and dump IR that uses this op.
+  const char *irStr = "module { \"testop.my_op\"() : () -> () }";
+  MlirModule module = mlirModuleCreateParse(ctx, strref(irStr));
+  if (mlirModuleIsNull(module)) {
+    fprintf(stderr, "failed to parse module\n");
+    return;
+  }
+
+  // CHECK:      module {
+  // CHECK-NEXT:   "testop.my_op"() : () -> ()
+  // CHECK-NEXT: }
+  mlirOperationDump(mlirModuleGetOperation(module));
+  mlirModuleDestroy(module);
+}
+
+void testDynamicTypeCreation(MlirContext ctx) {
+  MlirDynamicDialect testDialect =
+      mlirDynamicDialectCreate(ctx, strref("testtype"));
+
+  // Define and register a dynamic type.
+  MlirDynamicTypeDefinitionCallbacks typeCallbacks = {NULL, NULL,
+                                                      successTypeVerify};
+  MlirDynamicTypeDefinition typeDef = mlirDynamicTypeDefinitionCreate(
+      testDialect, strref("my_type"), typeCallbacks, NULL);
+  mlirDynamicDialectRegisterType(testDialect, typeDef);
+
+  // Look it up to verify registration worked.
+  MlirDialect dialect = mlirDynamicDialectAsDialect(testDialect);
+  MlirDynamicTypeDefinition lookedUp =
+      mlirExtensibleDialectLookupTypeDefinition(dialect, strref("my_type"));
+
+  // CHECK: type lookup succeeded: 1
+  fprintf(stderr, "type lookup succeeded: %d\n", lookedUp.ptr != NULL);
+
+  // Create an instance with no parameters.
+  MlirType dynType = mlirDynamicTypeGet(lookedUp, NULL, 0);
+
+  // CHECK: is dynamic type: 1
+  fprintf(stderr, "is dynamic type: %d\n", mlirTypeIsADynamicType(dynType));
+
+  // CHECK: dynamic type num params: 0
+  fprintf(stderr, "dynamic type num params: %ld\n",
+          (long)mlirDynamicTypeGetNumParams(dynType));
+}
+
+void testDynamicAttrCreation(MlirContext ctx) {
+  MlirDynamicDialect testDialect =
+      mlirDynamicDialectCreate(ctx, strref("testattr"));
+
+  // Define and register a dynamic attribute.
+  MlirDynamicAttrDefinitionCallbacks attrCallbacks = {NULL, NULL,
+                                                      successAttrVerify};
+  MlirDynamicAttrDefinition attrDef = mlirDynamicAttrDefinitionCreate(
+      testDialect, strref("my_attr"), attrCallbacks, NULL);
+  mlirDynamicDialectRegisterAttr(testDialect, attrDef);
+
+  // Look it up to verify registration worked.
+  MlirDialect dialect = mlirDynamicDialectAsDialect(testDialect);
+  MlirDynamicAttrDefinition lookedUp =
+      mlirExtensibleDialectLookupAttrDefinition(dialect, strref("my_attr"));
+
+  // CHECK: attr lookup succeeded: 1
+  fprintf(stderr, "attr lookup succeeded: %d\n", lookedUp.ptr != NULL);
+
+  // Create an instance with no parameters.
+  MlirAttribute dynAttr = mlirDynamicAttrGet(lookedUp, NULL, 0);
+
+  // CHECK: is dynamic attr: 1
+  fprintf(stderr, "is dynamic attr: %d\n",
+          mlirAttributeIsADynamicAttr(dynAttr));
+
+  // CHECK: dynamic attr num params: 0
+  fprintf(stderr, "dynamic attr num params: %ld\n",
+          (long)mlirDynamicAttrGetNumParams(dynAttr));
+}
+
+void testDynamicTypeWithParams(MlirContext ctx) {
+  MlirDynamicDialect testDialect =
+      mlirDynamicDialectCreate(ctx, strref("testparams"));
+
+  // Define and register a parameterized type.
+  MlirDynamicTypeDefinitionCallbacks typeCallbacks = {NULL, NULL,
+                                                      successTypeVerify};
+  MlirDynamicTypeDefinition typeDef = mlirDynamicTypeDefinitionCreate(
+      testDialect, strref("pair"), typeCallbacks, NULL);
+  mlirDynamicDialectRegisterType(testDialect, typeDef);
+
+  MlirDialect dialect = mlirDynamicDialectAsDialect(testDialect);
+  MlirDynamicTypeDefinition lookedUp =
+      mlirExtensibleDialectLookupTypeDefinition(dialect, strref("pair"));
+
+  // Create an instance with two integer attribute parameters.
+  MlirAttribute params[2];
+  params[0] = mlirIntegerAttrGet(mlirIntegerTypeGet(ctx, 32), 42);
+  params[1] = mlirIntegerAttrGet(mlirIntegerTypeGet(ctx, 32), 7);
+  MlirType dynType = mlirDynamicTypeGet(lookedUp, params, 2);
+
+  // CHECK: parameterized type num params: 2
+  fprintf(stderr, "parameterized type num params: %ld\n",
+          (long)mlirDynamicTypeGetNumParams(dynType));
+}
+
+int main(void) {
+  MlirContext ctx = mlirContextCreate();
+  mlirContextSetAllowUnregisteredDialects(ctx, true);
+
+  testDynamicDialectCreation(ctx);
+  testDynamicOpCreation(ctx);
+  testDynamicTypeCreation(ctx);
+  testDynamicAttrCreation(ctx);
+  testDynamicTypeWithParams(ctx);
+
+  mlirContextDestroy(ctx);
+  return 0;
+}

--- a/mlir/test/CMakeLists.txt
+++ b/mlir/test/CMakeLists.txt
@@ -102,6 +102,7 @@ configure_lit_site_cfg(
   )
 
 set(MLIR_TEST_DEPENDS
+  mlir-capi-extensible-dialect-test
   mlir-capi-ir-test
   mlir-capi-irdl-test
   mlir-capi-llvm-test


### PR DESCRIPTION
~~Previously there was no way to create a DynamicDialect, register dynamic ops/types/attrs, or obtain a MlirDialect handle from C code.~~

The create functions take optional verifier callbacks with a shared userData pointer. Ownership transfers to the dialect on registration via the mlirDynamicDialectRegister{Op,Type,Attr} calls.

Op definitions accept C callback functions for verify and verifyRegion. Type and attribute definitions accept C callback functions for parameter verification.

This enables languages with C FFI (i'm mainly interested in https://github.com/mlir-rs/melior) to define MLIR dialects.