### PR TITLE
[lldb] Do not use mkdir -p in makefile on Windows

### DIFF
--- a/lldb/test/API/lang/cpp/incomplete-types/Makefile
+++ b/lldb/test/API/lang/cpp/incomplete-types/Makefile
@@ -15,7 +15,7 @@ main.o: NO_LIMIT_DEBUG_INFO_FLAGS = ""
 main.o: CFLAGS_EXTRAS = -flimit-debug-info
 
 limit: a.o main.o
-	mkdir build_limit
+	$(call MKDIR_P,build_limit)
 	"$(MAKE)" -C $(BUILDDIR)/build_limit -f $(MAKEFILE_RULES) \
 		EXE=../limit CXX_SOURCES="length.cpp ../a.o ../main.o" \
 		CFLAGS_EXTRAS=-flimit-debug-info NO_LIMIT_DEBUG_INFO_FLAGS=""

--- a/lldb/test/API/lang/cpp/incomplete-types/Makefile
+++ b/lldb/test/API/lang/cpp/incomplete-types/Makefile
@@ -15,7 +15,7 @@ main.o: NO_LIMIT_DEBUG_INFO_FLAGS = ""
 main.o: CFLAGS_EXTRAS = -flimit-debug-info
 
 limit: a.o main.o
-	mkdir -p build_limit
+	mkdir build_limit
 	"$(MAKE)" -C $(BUILDDIR)/build_limit -f $(MAKEFILE_RULES) \
 		EXE=../limit CXX_SOURCES="length.cpp ../a.o ../main.o" \
 		CFLAGS_EXTRAS=-flimit-debug-info NO_LIMIT_DEBUG_INFO_FLAGS=""


### PR DESCRIPTION
`Make` uses systems's `mkdir` on Windows even if Git's mkdir.exe is present in PATH. Windows's mkdir does not support the parameter `-p` and creates the directory `-p` instead. Few other tests also use `mkdir -p` but they are linux, objc or macosx related.