### PR TITLE
[mlir][CAPI] Add MlirOpFoldResult type to C API

### DIFF
--- a/mlir/include/mlir-c/IR.h
+++ b/mlir/include/mlir-c/IR.h
@@ -64,6 +64,7 @@ DEFINE_C_API_STRUCT(MlirAttribute, const void);
 DEFINE_C_API_STRUCT(MlirIdentifier, const void);
 DEFINE_C_API_STRUCT(MlirLocation, const void);
 DEFINE_C_API_STRUCT(MlirModule, const void);
+DEFINE_C_API_STRUCT(MlirOpFoldResult, const void);
 DEFINE_C_API_STRUCT(MlirType, const void);
 DEFINE_C_API_STRUCT(MlirValue, const void);
 
@@ -1210,6 +1211,37 @@ MLIR_CAPI_EXPORTED void mlirAttributeDump(MlirAttribute attr);
 /// Associates an attribute with the name. Takes ownership of neither.
 MLIR_CAPI_EXPORTED MlirNamedAttribute mlirNamedAttributeGet(MlirIdentifier name,
                                                             MlirAttribute attr);
+
+//===----------------------------------------------------------------------===//
+// OpFoldResult API.
+//===----------------------------------------------------------------------===//
+
+/// Returns true if the given OpFoldResult is null.
+static inline bool mlirOpFoldResultIsNull(MlirOpFoldResult result) {
+  return !result.ptr;
+}
+
+/// Creates an OpFoldResult from an attribute.
+MLIR_CAPI_EXPORTED MlirOpFoldResult
+mlirOpFoldResultFromAttribute(MlirAttribute attr);
+
+/// Creates an OpFoldResult from a value.
+MLIR_CAPI_EXPORTED MlirOpFoldResult mlirOpFoldResultFromValue(MlirValue value);
+
+/// Returns true if the OpFoldResult contains an attribute.
+MLIR_CAPI_EXPORTED bool mlirOpFoldResultIsAttribute(MlirOpFoldResult result);
+
+/// Returns true if the OpFoldResult contains a value.
+MLIR_CAPI_EXPORTED bool mlirOpFoldResultIsValue(MlirOpFoldResult result);
+
+/// Returns the attribute contained in the OpFoldResult. Asserts if the
+/// OpFoldResult does not contain an attribute.
+MLIR_CAPI_EXPORTED MlirAttribute
+mlirOpFoldResultGetAttribute(MlirOpFoldResult result);
+
+/// Returns the value contained in the OpFoldResult. Asserts if the
+/// OpFoldResult does not contain a value.
+MLIR_CAPI_EXPORTED MlirValue mlirOpFoldResultGetValue(MlirOpFoldResult result);
 
 //===----------------------------------------------------------------------===//
 // Identifier API.

--- a/mlir/include/mlir/CAPI/IR.h
+++ b/mlir/include/mlir/CAPI/IR.h
@@ -19,6 +19,7 @@
 #include "mlir/CAPI/Wrap.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/MLIRContext.h"
+#include "mlir/IR/OpDefinition.h"
 #include "mlir/IR/Operation.h"
 
 DEFINE_C_API_PTR_METHODS(MlirAsmState, mlir::AsmState)
@@ -39,5 +40,12 @@ DEFINE_C_API_METHODS(MlirLocation, mlir::Location)
 DEFINE_C_API_METHODS(MlirModule, mlir::ModuleOp)
 DEFINE_C_API_METHODS(MlirType, mlir::Type)
 DEFINE_C_API_METHODS(MlirValue, mlir::Value)
+static inline MlirOpFoldResult wrap(mlir::OpFoldResult ofr) {
+  return MlirOpFoldResult{ofr.getOpaqueValue()};
+}
+static inline mlir::OpFoldResult unwrap(MlirOpFoldResult result) {
+  return static_cast<mlir::OpFoldResult &&>(
+      mlir::OpFoldResult::getFromOpaqueValue(const_cast<void *>(result.ptr)));
+}
 
 #endif // MLIR_CAPI_IR_H

--- a/mlir/lib/CAPI/IR/IR.cpp
+++ b/mlir/lib/CAPI/IR/IR.cpp
@@ -1318,6 +1318,34 @@ MlirNamedAttribute mlirNamedAttributeGet(MlirIdentifier name,
 }
 
 //===----------------------------------------------------------------------===//
+// OpFoldResult API.
+//===----------------------------------------------------------------------===//
+
+MlirOpFoldResult mlirOpFoldResultFromAttribute(MlirAttribute attr) {
+  return wrap(OpFoldResult(unwrap(attr)));
+}
+
+MlirOpFoldResult mlirOpFoldResultFromValue(MlirValue value) {
+  return wrap(OpFoldResult(unwrap(value)));
+}
+
+bool mlirOpFoldResultIsAttribute(MlirOpFoldResult result) {
+  return llvm::isa<Attribute>(unwrap(result));
+}
+
+bool mlirOpFoldResultIsValue(MlirOpFoldResult result) {
+  return llvm::isa<Value>(unwrap(result));
+}
+
+MlirAttribute mlirOpFoldResultGetAttribute(MlirOpFoldResult result) {
+  return wrap(llvm::cast<Attribute>(unwrap(result)));
+}
+
+MlirValue mlirOpFoldResultGetValue(MlirOpFoldResult result) {
+  return wrap(llvm::cast<Value>(unwrap(result)));
+}
+
+//===----------------------------------------------------------------------===//
 // Identifier API.
 //===----------------------------------------------------------------------===//
 

--- a/mlir/test/CAPI/ir.c
+++ b/mlir/test/CAPI/ir.c
@@ -2508,6 +2508,46 @@ int testBlockPredecessorsSuccessors(MlirContext ctx) {
   return 0;
 }
 
+void testOpFoldResult(MlirContext ctx) {
+  fprintf(stderr, "@testOpFoldResult\n");
+  // CHECK-LABEL: @testOpFoldResult
+
+  // Test OpFoldResult from attribute.
+  MlirAttribute attr = mlirIntegerAttrGet(mlirIntegerTypeGet(ctx, 32), 42);
+  MlirOpFoldResult ofrAttr = mlirOpFoldResultFromAttribute(attr);
+
+  // CHECK: ofrAttr isAttribute: 1
+  fprintf(stderr, "ofrAttr isAttribute: %d\n",
+          mlirOpFoldResultIsAttribute(ofrAttr));
+  // CHECK: ofrAttr isValue: 0
+  fprintf(stderr, "ofrAttr isValue: %d\n", mlirOpFoldResultIsValue(ofrAttr));
+
+  // Round-trip: extract the attribute back.
+  MlirAttribute extracted = mlirOpFoldResultGetAttribute(ofrAttr);
+  // CHECK: attr round-trip: 1
+  fprintf(stderr, "attr round-trip: %d\n", mlirAttributeEqual(attr, extracted));
+
+  // Test OpFoldResult from value (using a block argument).
+  MlirType i32 = mlirIntegerTypeGet(ctx, 32);
+  MlirLocation loc = mlirLocationUnknownGet(ctx);
+  MlirBlock block = mlirBlockCreate(1, &i32, &loc);
+  MlirValue arg = mlirBlockGetArgument(block, 0);
+  MlirOpFoldResult ofrValue = mlirOpFoldResultFromValue(arg);
+
+  // CHECK: ofrValue isValue: 1
+  fprintf(stderr, "ofrValue isValue: %d\n", mlirOpFoldResultIsValue(ofrValue));
+  // CHECK: ofrValue isAttribute: 0
+  fprintf(stderr, "ofrValue isAttribute: %d\n",
+          mlirOpFoldResultIsAttribute(ofrValue));
+
+  // Round-trip: extract the value back.
+  MlirValue extractedVal = mlirOpFoldResultGetValue(ofrValue);
+  // CHECK: value round-trip: 1
+  fprintf(stderr, "value round-trip: %d\n", mlirValueEqual(arg, extractedVal));
+
+  mlirBlockDestroy(block);
+}
+
 int main(void) {
   MlirContext ctx = mlirContextCreate();
   registerAllUpstreamDialects(ctx);
@@ -2556,6 +2596,8 @@ int main(void) {
 
   if (testBlockPredecessorsSuccessors(ctx))
     return 17;
+
+  testOpFoldResult(ctx);
 
   // CHECK: DESTROY MAIN CONTEXT
   // CHECK: reportResourceDelete: resource_i64_blob


### PR DESCRIPTION
Exposes OpFoldResult to the C API. This type is needed for fold callbacks on dynamic operations.