### PR TITLE
Exclude polly/lib/External from reformatting

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,7 @@
 extend-exclude = '''
 (
   third-party/
+  polly/lib/External
 )
 '''
 


### PR DESCRIPTION
polly/lib/External contains a mirror of the isl repository, so don't try to reformat it.