### PR TITLE
libclc: Use select function instead of ?: for some fp selects

### DIFF
--- a/libclc/clc/lib/generic/math/clc_cos.inc
+++ b/libclc/clc/lib/generic/math/clc_cos.inc
@@ -9,8 +9,7 @@
 #if __CLC_FPSIZE == 32
 
 _CLC_OVERLOAD _CLC_DEF __CLC_FLOATN __clc_cos(__CLC_FLOATN x) {
-  x = __clc_isinf(x) ? __CLC_GENTYPE_NAN : x;
-
+  x = __clc_select(x, __CLC_GENTYPE_NAN, __clc_isinf(x));
   __CLC_FLOATN absx = __clc_fabs(x);
 
   __CLC_FLOATN r0, r1;
@@ -32,7 +31,8 @@ _CLC_OVERLOAD _CLC_DEF __CLC_GENTYPE __clc_cos(__CLC_GENTYPE x) {
 #elif __CLC_FPSIZE == 64
 
 _CLC_OVERLOAD _CLC_DEF __CLC_GENTYPE __clc_cos(__CLC_GENTYPE x) {
-  x = __clc_isinf(x) ? __CLC_GENTYPE_NAN : x;
+  x = __clc_select(x, __CLC_GENTYPE_NAN,
+                   __CLC_CONVERT_S_GENTYPE(__clc_isinf(x)));
 
   __CLC_GENTYPE absx = __clc_fabs(x);
 

--- a/libclc/clc/lib/generic/math/clc_sin.inc
+++ b/libclc/clc/lib/generic/math/clc_sin.inc
@@ -9,7 +9,7 @@
 #if __CLC_FPSIZE == 32
 
 _CLC_OVERLOAD _CLC_DEF __CLC_FLOATN __clc_sin(__CLC_FLOATN x) {
-  x = __clc_isinf(x) ? __CLC_GENTYPE_NAN : x;
+  x = __clc_select(x, __CLC_GENTYPE_NAN, __clc_isinf(x));
 
   __CLC_FLOATN absx = __clc_fabs(x);
 
@@ -33,7 +33,8 @@ _CLC_OVERLOAD _CLC_DEF __CLC_GENTYPE __clc_sin(__CLC_GENTYPE x) {
 #elif __CLC_FPSIZE == 64
 
 _CLC_OVERLOAD _CLC_DEF __CLC_GENTYPE __clc_sin(__CLC_GENTYPE x) {
-  x = __clc_isinf(x) ? __CLC_GENTYPE_NAN : x;
+  x = __clc_select(x, __CLC_GENTYPE_NAN,
+                   __CLC_CONVERT_S_GENTYPE(__clc_isinf(x)));
 
   __CLC_GENTYPE absx = __clc_fabs(x);
 

--- a/libclc/clc/lib/generic/math/clc_tan.inc
+++ b/libclc/clc/lib/generic/math/clc_tan.inc
@@ -9,7 +9,7 @@
 #if __CLC_FPSIZE == 32
 
 _CLC_DEF _CLC_OVERLOAD __CLC_GENTYPE __clc_tan(__CLC_GENTYPE x) {
-  x = __clc_isinf(x) ? __CLC_GENTYPE_NAN : x;
+  x = __clc_select(x, __CLC_GENTYPE_NAN, __clc_isinf(x));
 
   __CLC_GENTYPE absx = __clc_fabs(x);
   __CLC_UINTN x_signbit = __CLC_AS_UINTN(x) & SIGNBIT_SP32;
@@ -24,7 +24,8 @@ _CLC_DEF _CLC_OVERLOAD __CLC_GENTYPE __clc_tan(__CLC_GENTYPE x) {
 #elif __CLC_FPSIZE == 64
 
 _CLC_DEF _CLC_OVERLOAD __CLC_GENTYPE __clc_tan(__CLC_GENTYPE x) {
-  x = __clc_isinf(x) ? __CLC_GENTYPE_NAN : x;
+  x = __clc_select(x, __CLC_GENTYPE_NAN,
+                   __CLC_CONVERT_S_GENTYPE(__clc_isinf(x)));
 
   __CLC_GENTYPE y = __clc_fabs(x);
 


### PR DESCRIPTION
It seems that ?: is not quite equivalent to select for floating-point
vectors. With ?:, the resulting IR involves integer bitcasts and
integer vector typed select. Use select so this is an fp-select. This
enables finite math only contexts to optimize out the select.

This feels like it's a clang bug though.