### PR TITLE
[clang] Unify python shebangs

### DIFF
--- a/clang/bindings/python/examples/cindex/cindex-dump.py
+++ b/clang/bindings/python/examples/cindex/cindex-dump.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # ===- cindex-dump.py - cindex/Python Source Dump -------------*- python -*--===#
 #

--- a/clang/bindings/python/examples/cindex/cindex-includes.py
+++ b/clang/bindings/python/examples/cindex/cindex-includes.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # ===- cindex-includes.py - cindex/Python Inclusion Graph -----*- python -*--===#
 #

--- a/clang/docs/tools/generate_formatted_state.py
+++ b/clang/docs/tools/generate_formatted_state.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # A tool to parse creates a document outlining how clang formatted the
 # LLVM project is.
 

--- a/clang/test/Analysis/check-analyzer-fixit.py
+++ b/clang/test/Analysis/check-analyzer-fixit.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # ===- check-analyzer-fixit.py - Static Analyzer test helper ---*- python -*-===#
 #

--- a/clang/test/Analysis/csv2json.py
+++ b/clang/test/Analysis/csv2json.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # ===- csv2json.py - Static Analyzer test helper ---*- python -*-===#
 #

--- a/clang/test/Driver/ftime-trace-sections.py
+++ b/clang/test/Driver/ftime-trace-sections.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import json, sys, time
 

--- a/clang/tools/include-mapping/test.py
+++ b/clang/tools/include-mapping/test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # ===- test.py -  ---------------------------------------------*- python -*--===#
 #
 # Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/clang/tools/scan-build/bin/set-xcode-analyzer
+++ b/clang/tools/scan-build/bin/set-xcode-analyzer
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # [PR 11661] Note that we hardwire to /usr/bin/python because we
 # want to the use the system version of Python on Mac OS X.

--- a/clang/tools/scan-view/bin/scan-view
+++ b/clang/tools/scan-view/bin/scan-view
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from __future__ import print_function
 

--- a/clang/tools/scan-view/share/Reporter.py
+++ b/clang/tools/scan-view/share/Reporter.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 """Methods for reporting bugs."""

--- a/clang/tools/scan-view/share/startfile.py
+++ b/clang/tools/scan-view/share/startfile.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 """Utility for opening a file using the default application in a cross-platform

--- a/clang/utils/ABITest/ABITestGen.py
+++ b/clang/utils/ABITest/ABITestGen.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from __future__ import absolute_import, division, print_function
 from pprint import pprint

--- a/clang/utils/CIndex/completion_logger_server.py
+++ b/clang/utils/CIndex/completion_logger_server.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 from __future__ import absolute_import, division, print_function
 import sys
 from socket import *

--- a/clang/utils/CaptureCmd
+++ b/clang/utils/CaptureCmd
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """CaptureCmd - A generic tool for capturing information about the
 invocations of another program.

--- a/clang/utils/CmpDriver
+++ b/clang/utils/CmpDriver
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
 A simple utility that compares tool invocations and exit codes issued by

--- a/clang/utils/FindSpecRefs
+++ b/clang/utils/FindSpecRefs
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os
 import re

--- a/clang/utils/FuzzTest
+++ b/clang/utils/FuzzTest
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
 This is a generic fuzz testing tool, see --help for more information.

--- a/clang/utils/TestUtils/deep-stack.py
+++ b/clang/utils/TestUtils/deep-stack.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from __future__ import absolute_import, division, print_function
 

--- a/clang/utils/analyzer/CmpRuns.py
+++ b/clang/utils/analyzer/CmpRuns.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
 CmpRuns - A simple tool for comparing two static analyzer runs to determine

--- a/clang/utils/analyzer/SATest.py
+++ b/clang/utils/analyzer/SATest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import argparse
 import sys

--- a/clang/utils/analyzer/SATestAdd.py
+++ b/clang/utils/analyzer/SATestAdd.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
 Static Analyzer qualification infrastructure: adding a new project to

--- a/clang/utils/analyzer/SATestBuild.py
+++ b/clang/utils/analyzer/SATestBuild.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
 Static Analyzer qualification infrastructure.

--- a/clang/utils/analyzer/SATestUpdateDiffs.py
+++ b/clang/utils/analyzer/SATestUpdateDiffs.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
 Update reference results for static analyzer.

--- a/clang/utils/analyzer/SumTimerInfo.py
+++ b/clang/utils/analyzer/SumTimerInfo.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
 Script to Summarize statistics in the scan-build output.

--- a/clang/utils/analyzer/exploded-graph-rewriter.py
+++ b/clang/utils/analyzer/exploded-graph-rewriter.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # ===- exploded-graph-rewriter.py - ExplodedGraph dump tool -----*- python -*--#
 #

--- a/clang/utils/check_cfc/check_cfc.py
+++ b/clang/utils/check_cfc/check_cfc.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """Check CFC - Check Compile Flow Consistency
 

--- a/clang/utils/check_cfc/obj_diff.py
+++ b/clang/utils/check_cfc/obj_diff.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from __future__ import absolute_import, division, print_function
 

--- a/clang/utils/check_cfc/test_check_cfc.py
+++ b/clang/utils/check_cfc/test_check_cfc.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """Test internal functions within check_cfc.py."""
 

--- a/clang/utils/clangdiag.py
+++ b/clang/utils/clangdiag.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # ----------------------------------------------------------------------
 # Be sure to add the python path that points to the LLDB shared library.

--- a/clang/utils/modfuzz.py
+++ b/clang/utils/modfuzz.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # To use:
 #  1) Update the 'decls' list below with your fuzzing configuration.

--- a/clang/utils/token-delta.py
+++ b/clang/utils/token-delta.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from __future__ import absolute_import, division, print_function
 import os

--- a/clang/www/builtins.py
+++ b/clang/www/builtins.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys, fileinput
 


### PR DESCRIPTION
As per PEP-0394[1], there is no real concensus over what binary names Python has, specifically 'python' could be Python 3, Python 2, or not exist.

However, everyone has a python3 interpreter and the scripts are all written for Python 3.  Unify the shebangs so that the ~50% of shebangs that use python now use python3.

[1] https://peps.python.org/pep-0394/