### PR TITLE
[PowerPC] Enable custom lowering for bswap64 builtin on Power8 64 bits with improved parallelism

### DIFF
--- a/llvm/lib/Target/PowerPC/PPCISelLowering.cpp
+++ b/llvm/lib/Target/PowerPC/PPCISelLowering.cpp
@@ -489,8 +489,11 @@ PPCTargetLowering::PPCTargetLowering(const PPCTargetMachine &TM,
     setOperationAction(ISD::BSWAP, MVT::i64, Legal);
   } else {
     setOperationAction(ISD::BSWAP, MVT::i32, Expand);
-    setOperationAction(ISD::BSWAP, MVT::i64,
-                       (Subtarget.hasP9Vector() && isPPC64) ? Custom : Expand);
+    setOperationAction(
+        ISD::BSWAP, MVT::i64,
+        ((Subtarget.hasP9Vector() || Subtarget.hasP8Vector()) && isPPC64)
+            ? Custom
+            : Expand);
   }
 
   // CTPOP or CTTZ were introduced in P8/P9 respectively
@@ -11616,6 +11619,60 @@ SDValue PPCTargetLowering::LowerBSWAP(SDValue Op, SelectionDAG &DAG) const {
   SDLoc dl(Op);
   if (!Subtarget.isPPC64())
     return Op;
+
+  // Apply the optimization to Power8 and 64-bits which allows parallelism for
+  // rotate instructions which should make the bswap64 builtin faster.
+  if (Subtarget.hasP8Vector() && !Subtarget.hasP9Vector()) {
+    SDValue Input = Op.getOperand(0);
+
+    // Extract high and low 32 bits
+    SDValue Hi32 = DAG.getNode(ISD::TRUNCATE, dl, MVT::i32,
+                               DAG.getNode(ISD::SRL, dl, MVT::i64, Input,
+                                           DAG.getConstant(32, dl, MVT::i64)));
+    SDValue Lo32 = DAG.getNode(ISD::TRUNCATE, dl, MVT::i32, Input);
+
+    // Swap high 32 bits using: rotl + 2x rlwimi
+    SDValue HiRot = DAG.getNode(ISD::ROTL, dl, MVT::i32, Hi32,
+                                DAG.getConstant(8, dl, MVT::i32));
+    SDValue HiSwap =
+        SDValue(DAG.getMachineNode(PPC::RLWIMI, dl, MVT::i32,
+                                   {HiRot, Hi32,
+                                    DAG.getTargetConstant(24, dl, MVT::i32),
+                                    DAG.getTargetConstant(0, dl, MVT::i32),
+                                    DAG.getTargetConstant(7, dl, MVT::i32)}),
+                0);
+    HiSwap = SDValue(DAG.getMachineNode(
+                         PPC::RLWIMI, dl, MVT::i32,
+                         {HiSwap, Hi32, DAG.getTargetConstant(24, dl, MVT::i32),
+                          DAG.getTargetConstant(16, dl, MVT::i32),
+                          DAG.getTargetConstant(23, dl, MVT::i32)}),
+                     0);
+
+    SDValue LoRot = DAG.getNode(ISD::ROTL, dl, MVT::i32, Lo32,
+                                DAG.getConstant(8, dl, MVT::i32));
+    SDValue LoSwap =
+        SDValue(DAG.getMachineNode(PPC::RLWIMI, dl, MVT::i32,
+                                   {LoRot, Lo32,
+                                    DAG.getTargetConstant(24, dl, MVT::i32),
+                                    DAG.getTargetConstant(0, dl, MVT::i32),
+                                    DAG.getTargetConstant(7, dl, MVT::i32)}),
+                0);
+    LoSwap = SDValue(DAG.getMachineNode(
+                         PPC::RLWIMI, dl, MVT::i32,
+                         {LoSwap, Lo32, DAG.getTargetConstant(24, dl, MVT::i32),
+                          DAG.getTargetConstant(16, dl, MVT::i32),
+                          DAG.getTargetConstant(23, dl, MVT::i32)}),
+                     0);
+
+    // Combine: (LoSwap << 32) | HiSwap using rldimi
+    HiSwap = DAG.getNode(ISD::ZERO_EXTEND, dl, MVT::i64, HiSwap);
+    LoSwap = DAG.getNode(ISD::ZERO_EXTEND, dl, MVT::i64, LoSwap);
+    return SDValue(DAG.getMachineNode(PPC::RLDIMI, dl, MVT::i64,
+                                      {HiSwap, LoSwap,
+                                       DAG.getTargetConstant(32, dl, MVT::i32),
+                                       DAG.getTargetConstant(0, dl, MVT::i32)}),
+                   0);
+  }
   // MTVSRDD
   Op = DAG.getNode(ISD::BUILD_VECTOR, dl, MVT::v2i64, Op.getOperand(0),
                    Op.getOperand(0));

--- a/llvm/lib/Target/PowerPC/PPCISelLowering.cpp
+++ b/llvm/lib/Target/PowerPC/PPCISelLowering.cpp
@@ -489,11 +489,9 @@ PPCTargetLowering::PPCTargetLowering(const PPCTargetMachine &TM,
     setOperationAction(ISD::BSWAP, MVT::i64, Legal);
   } else {
     setOperationAction(ISD::BSWAP, MVT::i32, Expand);
-    setOperationAction(
-        ISD::BSWAP, MVT::i64,
-        ((Subtarget.hasP9Vector() || Subtarget.hasP8Vector()) && isPPC64)
-            ? Custom
-            : Expand);
+    setOperationAction(ISD::BSWAP, MVT::i64,
+                       ((Subtarget.hasP8Vector()) && isPPC64) ? Custom
+                                                              : Expand);
   }
 
   // CTPOP or CTTZ were introduced in P8/P9 respectively
@@ -11622,7 +11620,7 @@ SDValue PPCTargetLowering::LowerBSWAP(SDValue Op, SelectionDAG &DAG) const {
 
   // Apply the optimization to Power8 and 64-bits which allows parallelism for
   // rotate instructions which should make the bswap64 builtin faster.
-  if (Subtarget.hasP8Vector() && !Subtarget.hasP9Vector()) {
+  if (!Subtarget.hasP9Vector()) {
     SDValue Input = Op.getOperand(0);
 
     auto Swap32 = [&](SDValue Val32) -> SDValue {

--- a/llvm/lib/Target/PowerPC/PPCISelLowering.cpp
+++ b/llvm/lib/Target/PowerPC/PPCISelLowering.cpp
@@ -11618,44 +11618,47 @@ SDValue PPCTargetLowering::LowerBSWAP(SDValue Op, SelectionDAG &DAG) const {
   if (!Subtarget.isPPC64())
     return Op;
 
-  // Apply the optimization to Power8 and 64-bits which allows parallelism for
-  // rotate instructions which should make the bswap64 builtin faster.
+  // Apply the optimization to Power8 and 64-bits which allows parallelism
+  // for rotate instructions which should make the bswap64 builtin faster.
   if (!Subtarget.hasP9Vector()) {
     SDValue Input = Op.getOperand(0);
+    // Helper lambda for rotate-and-insert operations (RLWIMI/RLDIMI)
+    auto CreateRotateInsert =
+        [&](unsigned Opcode, MVT VT, SDValue Dest, SDValue Src, unsigned RotAmt,
+            unsigned MaskBegin,
+            std::optional<unsigned> MaskEnd = std::nullopt) -> SDValue {
+      SmallVector<SDValue, 5> Ops = {
+          Dest, Src, DAG.getTargetConstant(RotAmt, dl, MVT::i32),
+          DAG.getTargetConstant(MaskBegin, dl, MVT::i32)};
+      if (MaskEnd.has_value())
+        Ops.push_back(DAG.getTargetConstant(*MaskEnd, dl, MVT::i32));
 
+      return SDValue(DAG.getMachineNode(Opcode, dl, VT, Ops), 0);
+    };
+
+    // Helper lambda to perform 32-bit byte swap: rotl(8) + 2x rlwimi
     auto Swap32 = [&](SDValue Val32) -> SDValue {
       SDValue Rot = DAG.getNode(ISD::ROTL, dl, MVT::i32, Val32,
                                 DAG.getConstant(8, dl, MVT::i32));
-      SDValue Swap =
-          SDValue(DAG.getMachineNode(PPC::RLWIMI, dl, MVT::i32,
-                                     {Rot, Val32,
-                                      DAG.getTargetConstant(24, dl, MVT::i32),
-                                      DAG.getTargetConstant(0, dl, MVT::i32),
-                                      DAG.getTargetConstant(7, dl, MVT::i32)}),
-                  0);
-      return SDValue(DAG.getMachineNode(
-                         PPC::RLWIMI, dl, MVT::i32,
-                         {Swap, Val32, DAG.getTargetConstant(24, dl, MVT::i32),
-                          DAG.getTargetConstant(16, dl, MVT::i32),
-                          DAG.getTargetConstant(23, dl, MVT::i32)}),
-                     0);
+      // Insert bits [24:31] from Val32 into Rot at position [0:7]
+      SDValue Swap =          CreateRotateInsert(PPC::RLWIMI, MVT::i32, Rot, Val32, 24, 0, 7);
+      // Insert bits [16:23] from Val32 into Swap at position [16:23]
+      return CreateRotateInsert(PPC::RLWIMI, MVT::i32, Swap, Val32, 24, 16, 23);
     };
-
+    // Extract and swap high and low 32 bits independently (enables parallelism)
     SDValue Hi32 = DAG.getNode(ISD::TRUNCATE, dl, MVT::i32,
                                DAG.getNode(ISD::SRL, dl, MVT::i64, Input,
                                            DAG.getConstant(32, dl, MVT::i64)));
     SDValue Lo32 = DAG.getNode(ISD::TRUNCATE, dl, MVT::i32, Input);
 
-    SDValue HiSwap = Swap32(Hi32);
-    SDValue LoSwap = Swap32(Lo32);
+    // Combine swapped halves using rldimi: rotate LoSwap left by 32 to place it
+    // in the upper 32 bits, inserting into HiSwap which occupies the lower 32
+    // bits. This swaps the two halves' positions, completing the 64-bit
+    // reversal.
+    SDValue HiSwap = DAG.getNode(ISD::ZERO_EXTEND, dl, MVT::i64, Swap32(Hi32));
+    SDValue LoSwap = DAG.getNode(ISD::ZERO_EXTEND, dl, MVT::i64, Swap32(Lo32));
 
-    HiSwap = DAG.getNode(ISD::ZERO_EXTEND, dl, MVT::i64, HiSwap);
-    LoSwap = DAG.getNode(ISD::ZERO_EXTEND, dl, MVT::i64, LoSwap);
-    return SDValue(DAG.getMachineNode(PPC::RLDIMI, dl, MVT::i64,
-                                      {HiSwap, LoSwap,
-                                       DAG.getTargetConstant(32, dl, MVT::i32),
-                                       DAG.getTargetConstant(0, dl, MVT::i32)}),
-                   0);
+    return CreateRotateInsert(PPC::RLDIMI, MVT::i64, HiSwap, LoSwap, 32, 0);
   }
   // MTVSRDD
   Op = DAG.getNode(ISD::BUILD_VECTOR, dl, MVT::v2i64, Op.getOperand(0),

--- a/llvm/lib/Target/PowerPC/PPCISelLowering.cpp
+++ b/llvm/lib/Target/PowerPC/PPCISelLowering.cpp
@@ -11618,61 +11618,59 @@ SDValue PPCTargetLowering::LowerBSWAP(SDValue Op, SelectionDAG &DAG) const {
   if (!Subtarget.isPPC64())
     return Op;
 
-  // Apply the optimization to Power8 and 64-bits which allows parallelism
-  // for rotate instructions which should make the bswap64 builtin faster.
-  if (!Subtarget.hasP9Vector()) {
-    SDValue Input = Op.getOperand(0);
-    // Helper lambda for rotate-and-insert operations (RLWIMI/RLDIMI)
-    auto CreateRotateInsert =
-        [&](unsigned Opcode, MVT VT, SDValue Dest, SDValue Src, unsigned RotAmt,
-            unsigned MaskBegin,
-            std::optional<unsigned> MaskEnd = std::nullopt) -> SDValue {
-      SmallVector<SDValue, 5> Ops = {
-          Dest, Src, DAG.getTargetConstant(RotAmt, dl, MVT::i32),
-          DAG.getTargetConstant(MaskBegin, dl, MVT::i32)};
-      if (MaskEnd.has_value())
-        Ops.push_back(DAG.getTargetConstant(*MaskEnd, dl, MVT::i32));
-
-      return SDValue(DAG.getMachineNode(Opcode, dl, VT, Ops), 0);
-    };
-
-    // Helper lambda to perform 32-bit byte swap: rotl(8) + 2x rlwimi
-    auto Swap32 = [&](SDValue Val32) -> SDValue {
-      SDValue Rot = DAG.getNode(ISD::ROTL, dl, MVT::i32, Val32,
-                                DAG.getConstant(8, dl, MVT::i32));
-      // Insert bits [24:31] from Val32 into Rot at position [0:7]
-      SDValue Swap =
-          CreateRotateInsert(PPC::RLWIMI, MVT::i32, Rot, Val32, 24, 0, 7);
-      // Insert bits [16:23] from Val32 into Swap at position [16:23]
-      return CreateRotateInsert(PPC::RLWIMI, MVT::i32, Swap, Val32, 24, 16, 23);
-    };
-    // Extract and swap high and low 32 bits independently (enables parallelism)
-    SDValue Hi32 = DAG.getNode(ISD::TRUNCATE, dl, MVT::i32,
-                               DAG.getNode(ISD::SRL, dl, MVT::i64, Input,
-                                           DAG.getConstant(32, dl, MVT::i64)));
-    SDValue Lo32 = DAG.getNode(ISD::TRUNCATE, dl, MVT::i32, Input);
-
-    // Combine swapped halves using rldimi: rotate LoSwap left by 32 to place it
-    // in the upper 32 bits, inserting into HiSwap which occupies the lower 32
-    // bits. This swaps the two halves' positions, completing the 64-bit
-    // reversal.
-    SDValue HiSwap = DAG.getNode(ISD::ZERO_EXTEND, dl, MVT::i64, Swap32(Hi32));
-    SDValue LoSwap = DAG.getNode(ISD::ZERO_EXTEND, dl, MVT::i64, Swap32(Lo32));
-
-    return CreateRotateInsert(PPC::RLDIMI, MVT::i64, HiSwap, LoSwap, 32, 0);
+  if (Subtarget.hasP9Vector()) {
+    // MTVSRDD
+    Op = DAG.getNode(ISD::BUILD_VECTOR, dl, MVT::v2i64, Op.getOperand(0),
+                     Op.getOperand(0));
+    // XXBRD
+    Op = DAG.getNode(ISD::BSWAP, dl, MVT::v2i64, Op);
+    // MFVSRD
+    int VectorIndex = 0;
+    if (Subtarget.isLittleEndian())
+      VectorIndex = 1;
+    Op = DAG.getNode(ISD::EXTRACT_VECTOR_ELT, dl, MVT::i64, Op,
+                     DAG.getTargetConstant(VectorIndex, dl, MVT::i32));
+    return Op;
   }
-  // MTVSRDD
-  Op = DAG.getNode(ISD::BUILD_VECTOR, dl, MVT::v2i64, Op.getOperand(0),
-                   Op.getOperand(0));
-  // XXBRD
-  Op = DAG.getNode(ISD::BSWAP, dl, MVT::v2i64, Op);
-  // MFVSRD
-  int VectorIndex = 0;
-  if (Subtarget.isLittleEndian())
-    VectorIndex = 1;
-  Op = DAG.getNode(ISD::EXTRACT_VECTOR_ELT, dl, MVT::i64, Op,
-                   DAG.getTargetConstant(VectorIndex, dl, MVT::i32));
-  return Op;
+
+  // For Power8, use parallel rotate instructions for faster bswap64.
+  SDValue Input = Op.getOperand(0);
+  // Helper to create rotate-and-insert operations (RLWIMI/RLDIMI).
+  auto CreateRotateInsert =
+      [&](unsigned Opcode, MVT VT, SDValue Dest, SDValue Src, unsigned RotAmt,
+          unsigned MaskBegin,
+          std::optional<unsigned> MaskEnd = std::nullopt) -> SDValue {
+    SmallVector<SDValue, 5> Ops = {
+        Dest, Src, DAG.getTargetConstant(RotAmt, dl, MVT::i32),
+        DAG.getTargetConstant(MaskBegin, dl, MVT::i32)};
+    if (MaskEnd.has_value())
+      Ops.push_back(DAG.getTargetConstant(*MaskEnd, dl, MVT::i32));
+
+    return SDValue(DAG.getMachineNode(Opcode, dl, VT, Ops), 0);
+  };
+
+  // Helper to perform 32-bit byte swap using rotl(8) + 2x rlwimi.
+  auto Swap32 = [&](SDValue Val32) -> SDValue {
+    SDValue Rot = DAG.getNode(ISD::ROTL, dl, MVT::i32, Val32,
+                              DAG.getConstant(8, dl, MVT::i32));
+    // Insert bits [24:31] from Val32 into Rot at position [0:7].
+    SDValue Swap =
+        CreateRotateInsert(PPC::RLWIMI, MVT::i32, Rot, Val32, 24, 0, 7);
+    // Insert bits [16:23] from Val32 into Swap at position [16:23].
+    return CreateRotateInsert(PPC::RLWIMI, MVT::i32, Swap, Val32, 24, 16, 23);
+  };
+  // Extract and swap high and low 32-bit halves independently for parallelism.
+  SDValue Hi32 = DAG.getNode(ISD::TRUNCATE, dl, MVT::i32,
+                             DAG.getNode(ISD::SRL, dl, MVT::i64, Input,
+                                         DAG.getConstant(32, dl, MVT::i64)));
+  SDValue Lo32 = DAG.getNode(ISD::TRUNCATE, dl, MVT::i32, Input);
+
+  // Combine swapped halves: rotate LoSwap left by 32 bits and insert into
+  // HiSwap to swap their positions, completing the 64-bit byte reversal.
+  SDValue HiSwap = DAG.getNode(ISD::ZERO_EXTEND, dl, MVT::i64, Swap32(Hi32));
+  SDValue LoSwap = DAG.getNode(ISD::ZERO_EXTEND, dl, MVT::i64, Swap32(Lo32));
+
+  return CreateRotateInsert(PPC::RLDIMI, MVT::i64, HiSwap, LoSwap, 32, 0);
 }
 
 // ATOMIC_CMP_SWAP for i8/i16 needs to zero-extend its input since it will be

--- a/llvm/lib/Target/PowerPC/PPCISelLowering.cpp
+++ b/llvm/lib/Target/PowerPC/PPCISelLowering.cpp
@@ -11641,7 +11641,8 @@ SDValue PPCTargetLowering::LowerBSWAP(SDValue Op, SelectionDAG &DAG) const {
       SDValue Rot = DAG.getNode(ISD::ROTL, dl, MVT::i32, Val32,
                                 DAG.getConstant(8, dl, MVT::i32));
       // Insert bits [24:31] from Val32 into Rot at position [0:7]
-      SDValue Swap =          CreateRotateInsert(PPC::RLWIMI, MVT::i32, Rot, Val32, 24, 0, 7);
+      SDValue Swap =
+          CreateRotateInsert(PPC::RLWIMI, MVT::i32, Rot, Val32, 24, 0, 7);
       // Insert bits [16:23] from Val32 into Swap at position [16:23]
       return CreateRotateInsert(PPC::RLWIMI, MVT::i32, Swap, Val32, 24, 16, 23);
     };

--- a/llvm/lib/Target/PowerPC/PPCISelLowering.cpp
+++ b/llvm/lib/Target/PowerPC/PPCISelLowering.cpp
@@ -11625,46 +11625,32 @@ SDValue PPCTargetLowering::LowerBSWAP(SDValue Op, SelectionDAG &DAG) const {
   if (Subtarget.hasP8Vector() && !Subtarget.hasP9Vector()) {
     SDValue Input = Op.getOperand(0);
 
-    // Extract high and low 32 bits
+    auto Swap32 = [&](SDValue Val32) -> SDValue {
+      SDValue Rot = DAG.getNode(ISD::ROTL, dl, MVT::i32, Val32,
+                                DAG.getConstant(8, dl, MVT::i32));
+      SDValue Swap =
+          SDValue(DAG.getMachineNode(PPC::RLWIMI, dl, MVT::i32,
+                                     {Rot, Val32,
+                                      DAG.getTargetConstant(24, dl, MVT::i32),
+                                      DAG.getTargetConstant(0, dl, MVT::i32),
+                                      DAG.getTargetConstant(7, dl, MVT::i32)}),
+                  0);
+      return SDValue(DAG.getMachineNode(
+                         PPC::RLWIMI, dl, MVT::i32,
+                         {Swap, Val32, DAG.getTargetConstant(24, dl, MVT::i32),
+                          DAG.getTargetConstant(16, dl, MVT::i32),
+                          DAG.getTargetConstant(23, dl, MVT::i32)}),
+                     0);
+    };
+
     SDValue Hi32 = DAG.getNode(ISD::TRUNCATE, dl, MVT::i32,
                                DAG.getNode(ISD::SRL, dl, MVT::i64, Input,
                                            DAG.getConstant(32, dl, MVT::i64)));
     SDValue Lo32 = DAG.getNode(ISD::TRUNCATE, dl, MVT::i32, Input);
 
-    // Swap high 32 bits using: rotl + 2x rlwimi
-    SDValue HiRot = DAG.getNode(ISD::ROTL, dl, MVT::i32, Hi32,
-                                DAG.getConstant(8, dl, MVT::i32));
-    SDValue HiSwap =
-        SDValue(DAG.getMachineNode(PPC::RLWIMI, dl, MVT::i32,
-                                   {HiRot, Hi32,
-                                    DAG.getTargetConstant(24, dl, MVT::i32),
-                                    DAG.getTargetConstant(0, dl, MVT::i32),
-                                    DAG.getTargetConstant(7, dl, MVT::i32)}),
-                0);
-    HiSwap = SDValue(DAG.getMachineNode(
-                         PPC::RLWIMI, dl, MVT::i32,
-                         {HiSwap, Hi32, DAG.getTargetConstant(24, dl, MVT::i32),
-                          DAG.getTargetConstant(16, dl, MVT::i32),
-                          DAG.getTargetConstant(23, dl, MVT::i32)}),
-                     0);
+    SDValue HiSwap = Swap32(Hi32);
+    SDValue LoSwap = Swap32(Lo32);
 
-    SDValue LoRot = DAG.getNode(ISD::ROTL, dl, MVT::i32, Lo32,
-                                DAG.getConstant(8, dl, MVT::i32));
-    SDValue LoSwap =
-        SDValue(DAG.getMachineNode(PPC::RLWIMI, dl, MVT::i32,
-                                   {LoRot, Lo32,
-                                    DAG.getTargetConstant(24, dl, MVT::i32),
-                                    DAG.getTargetConstant(0, dl, MVT::i32),
-                                    DAG.getTargetConstant(7, dl, MVT::i32)}),
-                0);
-    LoSwap = SDValue(DAG.getMachineNode(
-                         PPC::RLWIMI, dl, MVT::i32,
-                         {LoSwap, Lo32, DAG.getTargetConstant(24, dl, MVT::i32),
-                          DAG.getTargetConstant(16, dl, MVT::i32),
-                          DAG.getTargetConstant(23, dl, MVT::i32)}),
-                     0);
-
-    // Combine: (LoSwap << 32) | HiSwap using rldimi
     HiSwap = DAG.getNode(ISD::ZERO_EXTEND, dl, MVT::i64, HiSwap);
     LoSwap = DAG.getNode(ISD::ZERO_EXTEND, dl, MVT::i64, LoSwap);
     return SDValue(DAG.getMachineNode(PPC::RLDIMI, dl, MVT::i64,

--- a/llvm/test/CodeGen/PowerPC/bswap64.ll
+++ b/llvm/test/CodeGen/PowerPC/bswap64.ll
@@ -14,25 +14,19 @@
 
 declare i64 @llvm.bswap.i64(i64)
 
-; For now both the set of instructions for P8 are unoptimized versions.
-; A future patch will leverage parallelism and improve the
-; efficiency and performance.
+; This patch verifies that the compiler generates optimized assembly for Power 8 64-bit
+; byte swap operations that enables instruction-level parallelism.
 define i64 @bswap64(i64 %x) {
 ; POWER-8-LABEL: bswap64:
 ; POWER-8:       # %bb.0: # %entry
-; POWER-8-NEXT:    rotldi 5, 3, 16
-; POWER-8-NEXT:    rotldi 4, 3, 8
-; POWER-8-NEXT:    rldimi 4, 5, 8, 48
-; POWER-8-NEXT:    rotldi 5, 3, 24
-; POWER-8-NEXT:    rldimi 4, 5, 16, 40
-; POWER-8-NEXT:    rotldi 5, 3, 32
-; POWER-8-NEXT:    rldimi 4, 5, 24, 32
-; POWER-8-NEXT:    rotldi 5, 3, 48
-; POWER-8-NEXT:    rldimi 4, 5, 40, 16
-; POWER-8-NEXT:    rotldi 5, 3, 56
-; POWER-8-NEXT:    rldimi 4, 5, 48, 8
-; POWER-8-NEXT:    rldimi 4, 3, 56, 0
-; POWER-8-NEXT:    mr 3, 4
+; POWER-8-NEXT:    rotlwi 4, 3, 8
+; POWER-8-NEXT:    rldicl 5, 3, 32, 32
+; POWER-8-NEXT:    rlwimi 4, 3, 24, 0, 7
+; POWER-8-NEXT:    rlwimi 4, 3, 24, 16, 23
+; POWER-8-NEXT:    rotlwi 3, 5, 8
+; POWER-8-NEXT:    rlwimi 3, 5, 24, 0, 7
+; POWER-8-NEXT:    rlwimi 3, 5, 24, 16, 23
+; POWER-8-NEXT:    rldimi 3, 4, 32, 0
 ; POWER-8-NEXT:    blr
 ;
 ; POWER-8-NO-ALTIVEC-LABEL: bswap64:

--- a/llvm/test/CodeGen/PowerPC/pr35402.ll
+++ b/llvm/test/CodeGen/PowerPC/pr35402.ll
@@ -5,17 +5,17 @@ target triple = "powerpc64le-linux-gnu"
 define void @test(ptr %p, i64 %data) {
 ; CHECK-LABEL: test:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    rotldi 5, 4, 16
-; CHECK-NEXT:    rldicl 6, 4, 8, 56
-; CHECK-NEXT:    rldimi 6, 5, 8, 48
-; CHECK-NEXT:    rotldi 5, 4, 24
-; CHECK-NEXT:    rldimi 6, 5, 16, 40
-; CHECK-NEXT:    rotldi 5, 4, 32
-; CHECK-NEXT:    rldimi 6, 5, 24, 32
-; CHECK-NEXT:    rlwinm 5, 4, 8, 24, 31
+; CHECK-NEXT:    rotlwi 5, 4, 8
+; CHECK-NEXT:    rlwimi 5, 4, 24, 0, 7
 ; CHECK-NEXT:    rlwimi 5, 4, 24, 16, 23
+; CHECK-NEXT:    rldicl 4, 4, 32, 32
+; CHECK-NEXT:    rotlwi 6, 4, 8
+; CHECK-NEXT:    rlwimi 6, 4, 24, 0, 7
+; CHECK-NEXT:    rlwimi 6, 4, 24, 16, 23
+; CHECK-NEXT:    rldimi 6, 5, 32, 0
+; CHECK-NEXT:    rldicl 4, 6, 32, 32
 ; CHECK-NEXT:    stw 6, 0(3)
-; CHECK-NEXT:    sth 5, 4(3)
+; CHECK-NEXT:    sth 4, 4(3)
 ; CHECK-NEXT:    blr
 entry:
   %0 = tail call i64 @llvm.bswap.i64(i64 %data)


### PR DESCRIPTION
The current implementation for `__builtin_bswap64` does not do many things in parallel. This patch splits the 64 bit swaps into 32 bit swaps as high and low 32-bit swaps are independent and can execute simultaneously. 

Compared to the sequential approach, there are fewer instructions. These changes should not alter the current assembly and there is default fall-through for power9+.