### PR TITLE
[flang][OpenACC] Fix crash on invalid clauses in WAIT and ATOMIC constructs

### DIFF
--- a/flang/lib/Semantics/resolve-directives.cpp
+++ b/flang/lib/Semantics/resolve-directives.cpp
@@ -239,6 +239,11 @@ public:
     GetContext().withinConstruct = true;
   }
 
+  bool Pre(const parser::OpenACCWaitConstruct &);
+  void Post(const parser::OpenACCWaitConstruct &) { PopContext(); }
+  bool Pre(const parser::OpenACCAtomicConstruct &);
+  void Post(const parser::OpenACCAtomicConstruct &) { PopContext(); }
+
   bool Pre(const parser::OpenACCCacheConstruct &);
   void Post(const parser::OpenACCCacheConstruct &) { PopContext(); }
 
@@ -1618,6 +1623,19 @@ void AccAttributeVisitor::AllowOnlyVariable(const parser::AccObject &object) {
           [&](const auto &name) {},
       },
       object.u);
+}
+
+bool AccAttributeVisitor::Pre(const parser::OpenACCWaitConstruct &x) {
+  const auto &verbatim{std::get<parser::Verbatim>(x.t)};
+  PushContext(verbatim.source, llvm::acc::Directive::ACCD_wait);
+  ClearDataSharingAttributeObjects();
+  return true;
+}
+
+bool AccAttributeVisitor::Pre(const parser::OpenACCAtomicConstruct &x) {
+  PushContext(x.source, llvm::acc::Directive::ACCD_atomic);
+  ClearDataSharingAttributeObjects();
+  return true;
 }
 
 bool AccAttributeVisitor::Pre(const parser::OpenACCCacheConstruct &x) {

--- a/flang/lib/Semantics/resolve-directives.cpp
+++ b/flang/lib/Semantics/resolve-directives.cpp
@@ -1633,7 +1633,19 @@ bool AccAttributeVisitor::Pre(const parser::OpenACCWaitConstruct &x) {
 }
 
 bool AccAttributeVisitor::Pre(const parser::OpenACCAtomicConstruct &x) {
-  PushContext(x.source, llvm::acc::Directive::ACCD_atomic);
+  const auto &verbatimSource = common::visit(
+      common::visitors{
+          [&](const parser::AccAtomicUpdate &atomic) {
+            const auto &optVerbatim =
+                std::get<std::optional<parser::Verbatim>>(atomic.t);
+            return optVerbatim ? optVerbatim->source : x.source;
+          },
+          [&](const auto &atomic) {
+            return std::get<parser::Verbatim>(atomic.t).source;
+          },
+      },
+      x.u);
+  PushContext(verbatimSource, llvm::acc::Directive::ACCD_atomic);
   ClearDataSharingAttributeObjects();
   return true;
 }

--- a/flang/test/Semantics/OpenACC/acc-atomic-validity.f90
+++ b/flang/test/Semantics/OpenACC/acc-atomic-validity.f90
@@ -105,6 +105,10 @@ program openacc_atomic_validity
 
   !$acc end parallel
 
+  !ERROR: COPY clause is not allowed on the ATOMIC UPDATE COPY(I)
+  !$acc atomic update copy(i)
+  c(i) = c(i) + 1
+
 end program openacc_atomic_validity
 
 subroutine capture_with_convert_f64_to_i32()

--- a/flang/test/Semantics/OpenACC/acc-wait-validity.f90
+++ b/flang/test/Semantics/OpenACC/acc-wait-validity.f90
@@ -39,4 +39,7 @@ program openacc_wait_validity
   !ERROR: At most one ASYNC clause can appear on the WAIT directive
   !$acc wait(1) if(.true.) async(1) async
 
+  !ERROR: COPY clause is not allowed on the WAIT directive
+  !$acc wait copy(ifCondition)
+
 end program openacc_wait_validity


### PR DESCRIPTION
`AccAttributeVisitor` lacked Pre/Post visitors for `OpenACCWaitConstruct` and `OpenACCAtomicConstruct`, which would lead to a crash. This commit adds them.

As of AI Usage: Gemini 3 is used for pre-commit reviewing.
Closes #140281