### PR TITLE
[llc] Enable -mattr=help regardless of -mattr order

### DIFF
--- a/llvm/test/tools/llc/mattr-mcpu-help.ll
+++ b/llvm/test/tools/llc/mattr-mcpu-help.ll
@@ -1,0 +1,35 @@
+; REQUIRES: aarch64-registered-target
+
+;; Test -mattr=help
+; RUN: llc -mtriple=aarch64 -mattr=help 2>&1 | FileCheck %s --check-prefixes=CHECK,CHECK-NO-COMPILE
+; RUN: llc -mtriple=aarch64 -mattr=help -o %t.s 2>&1 | FileCheck %s --check-prefixes=CHECK,CHECK-NO-COMPILE
+; RUN: llc < %s -mtriple=aarch64 -mattr=help 2>&1 | FileCheck %s --check-prefixes=CHECK,CHECK-NO-COMPILE
+; RUN: llc < %s -mtriple=aarch64 -mattr=help -o %t.s 2>&1 | FileCheck %s --check-prefixes=CHECK,CHECK-NO-COMPILE
+
+;; -mattr=help doesn't have to be first
+; RUN: llc -mtriple=aarch64 -mattr=+zcm-fpr64 -mattr=help 2>&1 | FileCheck %s --check-prefixes=CHECK,CHECK-NO-COMPILE
+
+;; Missing target triple for -mattr=help
+; RUN: not llc -mattr=help 2>&1 | FileCheck %s --check-prefixes=CHECK-MISSING-TRIPLE
+; RUN: not llc < %s -mattr=help 2>&1 | FileCheck %s --check-prefixes=CHECK-MISSING-TRIPLE
+
+;; Test -mcpu=help
+; RUN: llc -mtriple=aarch64 -mcpu=help 2>&1 | FileCheck %s --check-prefixes=CHECK,CHECK-NO-COMPILE
+; RUN: llc -mtriple=aarch64 -mcpu=help -o %t.s 2>&1 | FileCheck %s --check-prefixes=CHECK,CHECK-NO-COMPILE
+; RUN: llc < %s -mtriple=aarch64 -mcpu=help 2>&1 | FileCheck %s --check-prefixes=CHECK,CHECK-NO-COMPILE
+; RUN: llc < %s -mtriple=aarch64 -mcpu=help -o %t.s 2>&1 | FileCheck %s --check-prefixes=CHECK,CHECK-NO-COMPILE
+
+;; Missing target triple for -mcpu=help
+; RUN: not llc -mcpu=help 2>&1 | FileCheck %s --check-prefixes=CHECK-MISSING-TRIPLE
+; RUN: not llc < %s -mcpu=help 2>&1 | FileCheck %s --check-prefixes=CHECK-MISSING-TRIPLE
+
+; CHECK: Available CPUs for this target:
+; CHECK: Available features for this target:
+
+; CHECK-MISSING-TRIPLE: error: unable to get target for 'unknown', see --version and --triple.
+
+;; To check we dont compile the file
+; CHECK-NO-COMPILE-NOT: foo
+define i32 @foo() {
+  ret i32 0
+}

--- a/llvm/tools/llc/llc.cpp
+++ b/llvm/tools/llc/llc.cpp
@@ -510,8 +510,7 @@ static int compileModule(char **argv, SmallVectorImpl<PassPlugin> &PluginList,
   };
 
   auto MAttrs = codegen::getMAttrs();
-  bool SkipModule =
-      CPUStr == "help" || (!MAttrs.empty() && MAttrs.front() == "help");
+  bool SkipModule = CPUStr == "help" || is_contained(MAttrs, "help");
 
   CodeGenOptLevel OLvl;
   if (auto Level = CodeGenOpt::parseLevel(OptLevel)) {


### PR DESCRIPTION
Previously a command like `llc -mtriple=aarch64 -mattr=+zcm-fpr64 -mattr=help` would hang, instead of printing help text and exiting. This patch provides a fix by relaxing the previous constraint where `-mattr=help` must have been first among attrs. It can now appear anywhere.

Includes a test to cover both `-mcpu=help` and `-mattr=help` for llc.