### PR TITLE
release/22.x: Backport workarounds for certain addMatcher overloads ignoring traversal kind

### DIFF
--- a/clang-tools-extra/clang-tidy/modernize/TypeTraitsCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/TypeTraitsCheck.cpp
@@ -195,7 +195,9 @@ void TypeTraitsCheck::registerMatchers(MatchFinder *Finder) {
                            .bind(Bind),
                        this);
   }
-  Finder->addMatcher(typeLoc(isType()).bind(Bind), this);
+  Finder->addMatcher(
+      traverse(TK_IgnoreUnlessSpelledInSource, typeLoc(isType()).bind(Bind)),
+      this);
 }
 
 static bool isNamedDeclInStdTraitsSet(const NamedDecl *ND,

--- a/clang-tools-extra/clang-tidy/readability/RedundantTypenameCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/RedundantTypenameCheck.cpp
@@ -19,7 +19,7 @@ namespace clang::tidy::readability {
 
 void RedundantTypenameCheck::registerMatchers(MatchFinder *Finder) {
   Finder->addMatcher(
-      typeLoc(unless(hasAncestor(decl(isInstantiated())))).bind("typeLoc"),
+      traverse(TK_IgnoreUnlessSpelledInSource, typeLoc().bind("typeLoc")),
       this);
 
   if (!getLangOpts().CPlusPlus20)

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/type-traits.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/type-traits.cpp
@@ -150,3 +150,17 @@ struct ImplicitlyInstantiatedConstructor {
 const ImplicitlyInstantiatedConstructor<int> ImplicitInstantiation(std::remove_reference<int>::type(123));
 // CHECK-MESSAGES: :[[@LINE-1]]:68: warning: use c++14 style type templates
 // CHECK-FIXES: const ImplicitlyInstantiatedConstructor<int> ImplicitInstantiation(std::remove_reference_t<int>(123));
+
+#if __cplusplus >= 202002L
+
+template <typename T>
+struct S {
+  typename std::remove_reference<T>::type a; // NOLINT
+};
+
+void f() {
+  auto [a] = S<int>{};
+  [&] { a; }; // This used to cause a false positive.
+}
+
+#endif // __cplusplus >= 202002L


### PR DESCRIPTION
Backporting #184039 was considered too risky, so this PR is a more conservative second attempt. It doesn't touch any user-facing APIs, only individual checks.