### PR TITLE
fix cmake config error in llvm-libgcc

### DIFF
--- a/libcxxabi/CMakeLists.txt
+++ b/libcxxabi/CMakeLists.txt
@@ -53,7 +53,7 @@ option(LIBCXXABI_ENABLE_ASSERTIONS "Enable assertions independent of build mode.
 option(LIBCXXABI_ENABLE_PEDANTIC "Compile with pedantic enabled." OFF)
 option(LIBCXXABI_ENABLE_WERROR "Fail and stop if a warning is triggered." OFF)
 option(LIBCXXABI_USE_LLVM_UNWINDER "Build and use the LLVM unwinder." ON)
-if (LIBCXXABI_USE_LLVM_UNWINDER AND NOT "libunwind" IN_LIST LLVM_ENABLE_RUNTIMES)
+if (LIBCXXABI_USE_LLVM_UNWINDER AND (NOT "libunwind" IN_LIST LLVM_ENABLE_RUNTIMES AND NOT LLVM_LIBGCC_EXPLICIT_OPT_IN))
   message(FATAL_ERROR "LIBCXXABI_USE_LLVM_UNWINDER is set to ON, but libunwind is not specified in LLVM_ENABLE_RUNTIMES.")
 endif()
 option(LIBCXXABI_ENABLE_STATIC_UNWINDER "Statically link the LLVM unwinder." OFF)


### PR DESCRIPTION
Allow libcxxabi to build with libunwind enabled if libunwind is not present in `LLVM_ENABLE_RUNTIMES`, provided `llvm-libgcc` is enabled.

Closes #100888 