### PR TITLE
[compiler-rt] Unify python shebangs

### DIFF
--- a/compiler-rt/lib/asan/scripts/asan_symbolize.py
+++ b/compiler-rt/lib/asan/scripts/asan_symbolize.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # ===- lib/asan/scripts/asan_symbolize.py -----------------------------------===#
 #
 # Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/compiler-rt/lib/fuzzer/scripts/unbalanced_allocs.py
+++ b/compiler-rt/lib/fuzzer/scripts/unbalanced_allocs.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # ===- lib/fuzzer/scripts/unbalanced_allocs.py ------------------------------===#
 #
 # Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/compiler-rt/lib/sanitizer_common/scripts/gen_dynamic_list.py
+++ b/compiler-rt/lib/sanitizer_common/scripts/gen_dynamic_list.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # ===- lib/sanitizer_common/scripts/gen_dynamic_list.py ---------------------===#
 #
 # Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/compiler-rt/lib/sanitizer_common/scripts/sancov.py
+++ b/compiler-rt/lib/sanitizer_common/scripts/sancov.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Merge or print the coverage data collected by asan's coverage.
 # Input files are sequences of 4-byte integers.
 # We need to merge these integers into a set and then


### PR DESCRIPTION
As per PEP-0394[1], there is no real concensus over what binary names Python has, specifically 'python' could be Python 3, Python 2, or not exist.

However, everyone has a python3 interpreter and the scripts are all written for Python 3.  Unify the shebangs so that the ~50% of shebangs that use python now use python3.

[1] https://peps.python.org/pep-0394/