### PR TITLE
[mlir] Unify python shebangs

### DIFF
--- a/mlir/utils/lldb-scripts/action_debugging.py
+++ b/mlir/utils/lldb-scripts/action_debugging.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # ---------------------------------------------------------------------
 # Be sure to add the python path that points to the LLDB shared library.


### PR DESCRIPTION
As per PEP-0394[1], there is no real concensus over what binary names Python has, specifically 'python' could be Python 3, Python 2, or not exist.

However, everyone has a python3 interpreter and the scripts are all written for Python 3.  Unify the shebangs so that the ~50% of shebangs that use python now use python3.

[1] https://peps.python.org/pep-0394/