### PR TITLE
[flang][acc] Add missing dependency for checking CUF attributes

### DIFF
--- a/flang/lib/Optimizer/OpenACC/Analysis/CMakeLists.txt
+++ b/flang/lib/Optimizer/OpenACC/Analysis/CMakeLists.txt
@@ -2,12 +2,16 @@ add_flang_library(FIROpenACCAnalysis
   FIROpenACCSupportAnalysis.cpp
 
   DEPENDS
+  CUFAttrs
+  CUFDialect
   FIRAnalysis
   FIRDialect
   FIROpenACCSupport
   HLFIRDialect
 
   LINK_LIBS
+  CUFAttrs
+  CUFDialect
   FIRAnalysis
   FIRDialect
   FIROpenACCSupport


### PR DESCRIPTION
PR https://github.com/llvm/llvm-project/pull/187161 introduced some logic which checks CUF attributes. But this wasn't added properly to the dependencies.