### PR TITLE
[tools][examples][NFC] Drop remaining uses of BranchInst

### DIFF
--- a/llvm/docs/BranchWeightMetadata.rst
+++ b/llvm/docs/BranchWeightMetadata.rst
@@ -93,7 +93,7 @@ and used in SamplePGO mode only as described for the call instruction. If both
 weights are specified then the second weight contains the count of unwind branch
 taken and the first weight contains the execution count of the call minus
 the count of unwind branch taken. Both weights specified are used to calculate
-BranchProbability as for BranchInst and for SamplePGO the sum of both weights
+BranchProbability as for CondBrInst and for SamplePGO the sum of both weights
 is used.
 
 .. code-block:: none

--- a/llvm/examples/BrainF/BrainF.cpp
+++ b/llvm/examples/BrainF/BrainF.cpp
@@ -160,7 +160,7 @@ void BrainF::header(LLVMContext& C) {
     puts_call->setTailCall(false);
 
     //br label %brainf.end
-    BranchInst::Create(endbb, aberrorbb);
+    UncondBrInst::Create(endbb, aberrorbb);
   }
 }
 
@@ -425,7 +425,7 @@ void BrainF::readloop(PHINode *phi, BasicBlock *oldbb, BasicBlock *testbb,
 
       //br i1 %test.%d, label %main.%d, label %main.%d
       BasicBlock *bb_0 = BasicBlock::Create(C, label, brainf_func);
-      BranchInst::Create(bb_0, oldbb, test_0, testbb);
+      CondBrInst::Create(test_0, bb_0, oldbb, testbb);
 
       //main.%d:
       builder->SetInsertPoint(bb_0);

--- a/llvm/examples/Fibonacci/fibonacci.cpp
+++ b/llvm/examples/Fibonacci/fibonacci.cpp
@@ -74,7 +74,7 @@ static Function *CreateFibFunction(Module *M, LLVMContext &Context) {
 
   // Create the "if (arg <= 2) goto exitbb"
   Value *CondInst = new ICmpInst(BB, ICmpInst::ICMP_SLE, ArgX, Two, "cond");
-  BranchInst::Create(RetBB, RecurseBB, CondInst, BB);
+  CondBrInst::Create(CondInst, RetBB, RecurseBB, BB);
 
   // Create: ret int 1
   ReturnInst::Create(Context, One, RetBB);

--- a/llvm/examples/IRTransforms/SimplifyCFG.cpp
+++ b/llvm/examples/IRTransforms/SimplifyCFG.cpp
@@ -140,8 +140,8 @@ static bool eliminateCondBranches_v1(Function &F) {
   // Eliminate branches with constant conditionals.
   for (BasicBlock &BB : F) {
     // Skip blocks without conditional branches as terminators.
-    BranchInst *BI = dyn_cast<BranchInst>(BB.getTerminator());
-    if (!BI || !BI->isConditional())
+    CondBrInst *BI = dyn_cast<CondBrInst>(BB.getTerminator());
+    if (!BI)
       continue;
 
     // Skip blocks with conditional branches without ConstantInt conditions.
@@ -158,7 +158,7 @@ static bool eliminateCondBranches_v1(Function &F) {
     // Replace the conditional branch with an unconditional one, by creating
     // a new unconditional branch to the selected successor and removing the
     // conditional one.
-    BranchInst::Create(BI->getSuccessor(CI->isZero()), BI->getIterator());
+    UncondBrInst::Create(BI->getSuccessor(CI->isZero()), BI->getIterator());
     BI->eraseFromParent();
     Changed = true;
   }
@@ -176,8 +176,8 @@ static bool eliminateCondBranches_v2(Function &F, DominatorTree &DT) {
   // Eliminate branches with constant conditionals.
   for (BasicBlock &BB : F) {
     // Skip blocks without conditional branches as terminators.
-    BranchInst *BI = dyn_cast<BranchInst>(BB.getTerminator());
-    if (!BI || !BI->isConditional())
+    CondBrInst *BI = dyn_cast<CondBrInst>(BB.getTerminator());
+    if (!BI)
       continue;
 
     // Skip blocks with conditional branches without ConstantInt conditions.
@@ -194,8 +194,8 @@ static bool eliminateCondBranches_v2(Function &F, DominatorTree &DT) {
     // Replace the conditional branch with an unconditional one, by creating
     // a new unconditional branch to the selected successor and removing the
     // conditional one.
-    BranchInst *NewBranch =
-        BranchInst::Create(BI->getSuccessor(CI->isZero()), BI->getIterator());
+    UncondBrInst *NewBranch =
+        UncondBrInst::Create(BI->getSuccessor(CI->isZero()), BI->getIterator());
     BI->eraseFromParent();
 
     // Delete the edge between BB and RemovedSucc in the DominatorTree, iff
@@ -242,8 +242,8 @@ static bool eliminateCondBranches_v3(Function &F, DominatorTree &DT) {
     // a new unconditional branch to the selected successor and removing the
     // conditional one.
 
-    BranchInst *NewBranch =
-        BranchInst::Create(TakenSucc, BB.getTerminator()->getIterator());
+    UncondBrInst *NewBranch =
+        UncondBrInst::Create(TakenSucc, BB.getTerminator()->getIterator());
     BB.getTerminator()->eraseFromParent();
 
     // Delete the edge between BB and RemovedSucc in the DominatorTree, iff

--- a/llvm/examples/ParallelJIT/ParallelJIT.cpp
+++ b/llvm/examples/ParallelJIT/ParallelJIT.cpp
@@ -105,7 +105,7 @@ static Function *CreateFibFunction(Module *M) {
 
   // Create the "if (arg < 2) goto exitbb"
   Value *CondInst = new ICmpInst(BB, ICmpInst::ICMP_SLE, ArgX, Two, "cond");
-  BranchInst::Create(RetBB, RecurseBB, CondInst, BB);
+  CondBrInst::Create(CondInst, RetBB, RecurseBB, BB);
 
   // Create: ret int 1
   ReturnInst::Create(Context, One, RetBB);

--- a/llvm/lib/Frontend/OpenMP/OMPIRBuilder.cpp
+++ b/llvm/lib/Frontend/OpenMP/OMPIRBuilder.cpp
@@ -11625,9 +11625,8 @@ OpenMPIRBuilder::InsertPointOrErrorTy OpenMPIRBuilder::createIteratorLoop(
 
   // Body must either fallthrough to the latch or branch directly to it.
   if (Instruction *BodyTerminator = CLI->getBody()->getTerminator()) {
-    auto *BodyBr = dyn_cast<BranchInst>(BodyTerminator);
-    if (!BodyBr || !BodyBr->isUnconditional() ||
-        BodyBr->getSuccessor(0) != CLI->getLatch()) {
+    auto *BodyBr = dyn_cast<UncondBrInst>(BodyTerminator);
+    if (!BodyBr || BodyBr->getSuccessor() != CLI->getLatch()) {
       return make_error<StringError>(
           "iterator bodygen must terminate the canonical body with an "
           "unconditional branch to the loop latch",

--- a/llvm/tools/llubi/lib/Interpreter.cpp
+++ b/llvm/tools/llubi/lib/Interpreter.cpp
@@ -430,21 +430,20 @@ public:
     Status &= Handler.onInstructionExecuted(RI, None);
   }
 
-  void visitBranchInst(BranchInst &BI) {
-    if (BI.isConditional()) {
-      switch (getValue(BI.getCondition()).asBoolean()) {
-      case BooleanKind::True:
-        jumpTo(BI, BI.getSuccessor(0));
-        return;
-      case BooleanKind::False:
-        jumpTo(BI, BI.getSuccessor(1));
-        return;
-      case BooleanKind::Poison:
-        reportImmediateUB("Branch on poison condition.");
-        return;
-      }
+  void visitUncondBrInst(UncondBrInst &BI) { jumpTo(BI, BI.getSuccessor()); }
+
+  void visitCondBrInst(CondBrInst &BI) {
+    switch (getValue(BI.getCondition()).asBoolean()) {
+    case BooleanKind::True:
+      jumpTo(BI, BI.getSuccessor(0));
+      return;
+    case BooleanKind::False:
+      jumpTo(BI, BI.getSuccessor(1));
+      return;
+    case BooleanKind::Poison:
+      reportImmediateUB("Branch on poison condition.");
+      return;
     }
-    jumpTo(BI, BI.getSuccessor(0));
   }
 
   void visitSwitchInst(SwitchInst &SI) {

--- a/llvm/tools/llvm-diff/lib/DifferenceEngine.cpp
+++ b/llvm/tools/llvm-diff/lib/DifferenceEngine.cpp
@@ -451,21 +451,21 @@ class FunctionDifferenceEngine {
         tryUnify(LI.getDefaultDest(), RI.getDefaultDest());
       return false;
 
-    } else if (isa<BranchInst>(L)) {
-      const BranchInst *LI = cast<BranchInst>(L);
-      const BranchInst *RI = cast<BranchInst>(R);
-      if (LI->isConditional() != RI->isConditional()) {
-        if (Complain) Engine.log("branch conditionality differs");
+    } else if (isa<UncondBrInst>(L)) {
+      if (TryUnify)
+        tryUnify(L->getSuccessor(0), R->getSuccessor(0));
+      return false;
+
+    } else if (isa<CondBrInst>(L)) {
+      const CondBrInst *LI = cast<CondBrInst>(L);
+      const CondBrInst *RI = cast<CondBrInst>(R);
+      if (!equivalentAsOperands(LI->getCondition(), RI->getCondition(), AC)) {
+        if (Complain)
+          Engine.log("branch conditions differ");
         return true;
       }
-
-      if (LI->isConditional()) {
-        if (!equivalentAsOperands(LI->getCondition(), RI->getCondition(), AC)) {
-          if (Complain) Engine.log("branch conditions differ");
-          return true;
-        }
-        if (TryUnify) tryUnify(LI->getSuccessor(1), RI->getSuccessor(1));
-      }
+      if (TryUnify)
+        tryUnify(LI->getSuccessor(1), RI->getSuccessor(1));
       if (TryUnify) tryUnify(LI->getSuccessor(0), RI->getSuccessor(0));
       return false;
 
@@ -910,8 +910,7 @@ void FunctionDifferenceEngine::runBlockDiff(BasicBlock::const_iterator LStart,
   // the results and the destinations.
   const Instruction *LTerm = LStart->getParent()->getTerminator();
   const Instruction *RTerm = RStart->getParent()->getTerminator();
-  if (isa<BranchInst>(LTerm) && isa<InvokeInst>(RTerm)) {
-    if (cast<BranchInst>(LTerm)->isConditional()) return;
+  if (isa<UncondBrInst>(LTerm) && isa<InvokeInst>(RTerm)) {
     BasicBlock::const_iterator I = LTerm->getIterator();
     if (I == LStart->getParent()->begin()) return;
     --I;
@@ -924,8 +923,7 @@ void FunctionDifferenceEngine::runBlockDiff(BasicBlock::const_iterator LStart,
     if (!LCall->use_empty())
       Values[LCall] = RInvoke;
     tryUnify(LTerm->getSuccessor(0), RInvoke->getNormalDest());
-  } else if (isa<InvokeInst>(LTerm) && isa<BranchInst>(RTerm)) {
-    if (cast<BranchInst>(RTerm)->isConditional()) return;
+  } else if (isa<InvokeInst>(LTerm) && isa<UncondBrInst>(RTerm)) {
     BasicBlock::const_iterator I = RTerm->getIterator();
     if (I == RStart->getParent()->begin()) return;
     --I;

--- a/llvm/tools/llvm-reduce/deltas/ReduceBasicBlocks.cpp
+++ b/llvm/tools/llvm-reduce/deltas/ReduceBasicBlocks.cpp
@@ -49,7 +49,7 @@ static void replaceBranchTerminator(BasicBlock &BB,
   if (isa<CatchSwitchInst>(Term))
     return;
 
-  bool IsBranch = isa<BranchInst>(Term) || isa<CallBrInst>(Term);
+  bool IsBranch = isa<UncondBrInst, CondBrInst, CallBrInst>(Term);
   if (InvokeInst *Invoke = dyn_cast<InvokeInst>(Term)) {
     BasicBlock *UnwindDest = Invoke->getUnwindDest();
     BasicBlock::iterator LP = UnwindDest->getFirstNonPHIIt();
@@ -91,7 +91,7 @@ static void replaceBranchTerminator(BasicBlock &BB,
   }
 
   if (IsBranch)
-    BranchInst::Create(ChunkSuccessors[0], &BB);
+    UncondBrInst::Create(ChunkSuccessors[0], &BB);
 
   if (Address) {
     auto *NewIndBI =

--- a/llvm/tools/llvm-reduce/deltas/ReduceUsingSimplifyCFG.cpp
+++ b/llvm/tools/llvm-reduce/deltas/ReduceUsingSimplifyCFG.cpp
@@ -48,9 +48,8 @@ static void reduceConditionals(Oracle &O, ReducerWorkItem &WorkItem,
     SmallVector<BasicBlock *, 16> ToSimplify;
 
     for (auto &BB : F) {
-      auto *BR = dyn_cast<BranchInst>(BB.getTerminator());
-      if (!BR || !BR->isConditional() || BR->getCondition() == ConstValToSet ||
-          O.shouldKeep())
+      auto *BR = dyn_cast<CondBrInst>(BB.getTerminator());
+      if (!BR || BR->getCondition() == ConstValToSet || O.shouldKeep())
         continue;
 
       BR->setCondition(ConstValToSet);
@@ -89,14 +88,14 @@ void llvm::reduceUnconditionalBranchDeltaPass(Oracle &O,
     Type *RetTy = F.getReturnType();
 
     for (auto &BB : F) {
-      auto *BR = dyn_cast<BranchInst>(BB.getTerminator());
-      if (!BR || !BR->isUnconditional())
+      auto *BR = dyn_cast<UncondBrInst>(BB.getTerminator());
+      if (!BR)
         continue;
 
       if (O.shouldKeep())
         continue;
 
-      BasicBlock *Succ = BR->getSuccessor(0);
+      BasicBlock *Succ = BR->getSuccessor();
       Succ->removePredecessor(&BB, /*KeepOneInputPHIs=*/true);
       BR->eraseFromParent();
       ToSimplify.push_back(&BB);

--- a/llvm/tools/llvm-stress/llvm-stress.cpp
+++ b/llvm/tools/llvm-stress/llvm-stress.cpp
@@ -709,7 +709,7 @@ static void IntroduceControlFlow(Function *F, Random &R) {
     BasicBlock *Next = Curr->splitBasicBlock(Loc, "CF");
     Instr->moveBefore(Curr->getTerminator()->getIterator());
     if (Curr != &F->getEntryBlock()) {
-      BranchInst::Create(Curr, Next, Instr,
+      CondBrInst::Create(Instr, Curr, Next,
                          Curr->getTerminator()->getIterator());
       Curr->getTerminator()->eraseFromParent();
     }

--- a/llvm/unittests/Frontend/OpenMPIRBuilderTest.cpp
+++ b/llvm/unittests/Frontend/OpenMPIRBuilderTest.cpp
@@ -7674,10 +7674,9 @@ TEST_F(OpenMPIRBuilderTest, CreateIteratorLoop) {
                                                        BodyGenCB, "iterator"));
 
     EXPECT_EQ(AfterIP.getBlock()->getName(), "omp.it.cont");
-    auto *ContBr = dyn_cast<BranchInst>(AfterIP.getBlock()->getTerminator());
+    auto *ContBr = dyn_cast<UncondBrInst>(AfterIP.getBlock()->getTerminator());
     ASSERT_NE(ContBr, nullptr);
-    ASSERT_FALSE(ContBr->isConditional());
-    EXPECT_EQ(ContBr->getSuccessor(0), OrigSucc);
+    EXPECT_EQ(ContBr->getSuccessor(), OrigSucc);
 
     Builder.SetInsertPoint(OrigSucc);
     Builder.CreateRetVoid();


### PR DESCRIPTION
This only leaves SandboxIR/SandboxVectorizer, MLIR and Polly before we can mark BranchInst as deprecated.

Also fix recent introductions from #182223.