### PR TITLE
[libc][cmake] Disable unit tests on bare-metal

### DIFF
--- a/libc/CMakeLists.txt
+++ b/libc/CMakeLists.txt
@@ -271,6 +271,8 @@ endif()
 if(LIBC_TARGET_OS_IS_GPU)
   include(prepare_libc_gpu_build)
   set(LIBC_ENABLE_UNITTESTS OFF)
+elseif(LIBC_TARGET_OS_IS_BAREMETAL)
+  set(LIBC_ENABLE_UNITTESTS OFF)
 endif()
 
 include(LLVMLibCCheckMPFR)

--- a/libc/cmake/modules/LLVMLibCTestRules.cmake
+++ b/libc/cmake/modules/LLVMLibCTestRules.cmake
@@ -350,6 +350,9 @@ function(create_libc_unittest fq_target_name)
 endfunction(create_libc_unittest)
 
 function(add_libc_unittest target_name)
+  if(NOT LIBC_ENABLE_UNITTESTS)
+    return()
+  endif()
   add_target_with_flags(
     ${target_name}
     CREATE_TARGET create_libc_unittest
@@ -667,6 +670,7 @@ function(add_integration_test test_name)
     COMMENT "Running integration test ${fq_target_name}"
   )
   add_dependencies(${INTEGRATION_TEST_SUITE} ${fq_target_name})
+  add_dependencies(libc-integration-tests-build ${fq_build_target_name})
 endfunction(add_integration_test)
 
 # Rule to add a hermetic program. A hermetic program is one whose executable is fully

--- a/libc/test/CMakeLists.txt
+++ b/libc/test/CMakeLists.txt
@@ -13,6 +13,7 @@ add_custom_target(libc-long-running-tests)
 # Build-only targets for lit (don't run tests, just build executables)
 add_custom_target(libc-unit-tests-build)
 add_custom_target(libc-hermetic-tests-build)
+add_custom_target(libc-integration-tests-build)
 
 # Resolve the GPU loader executable path for the lit site config.
 if(TARGET libc.utils.gpu.loader)
@@ -35,10 +36,15 @@ configure_lit_site_cfg(
   "LIBC_GPU_LOADER_EXECUTABLE"
 )
 
+set(libc_lit_deps libc-hermetic-tests-build libc-integration-tests-build)
+if(LIBC_ENABLE_UNITTESTS)
+  list(APPEND libc_lit_deps libc-unit-tests-build)
+endif()
+
 add_lit_testsuite(check-libc-lit
   "Running libc tests via lit"
   ${LIBC_BUILD_DIR}/test
-  DEPENDS libc-unit-tests-build libc-hermetic-tests-build
+  DEPENDS ${libc_lit_deps}
 )
 
 add_subdirectory(UnitTest)

--- a/libc/test/include/CMakeLists.txt
+++ b/libc/test/include/CMakeLists.txt
@@ -1,6 +1,5 @@
 add_custom_target(libc_include_tests)
 add_dependencies(check-libc libc_include_tests)
-add_dependencies(check-libc-lit libc_include_tests)
 
 add_libc_test(
   assert_test

--- a/libc/test/integration/CMakeLists.txt
+++ b/libc/test/integration/CMakeLists.txt
@@ -1,6 +1,5 @@
 add_custom_target(libc-integration-tests)
 add_dependencies(check-libc libc-integration-tests)
-add_dependencies(check-libc-lit libc-integration-tests)
 
 function(add_libc_integration_test_suite name)
   add_custom_target(${name})


### PR DESCRIPTION
Disable unit tests on bare-metal targets where they fail to build and avoid trying to build unit tests implicitly through dependencies before lit is run.

Assisted-by: codex for initial fix and refinement, the changes were reviewed by me and tested with Arm Toolchain for Embedded.