### PR TITLE
[mlir][quant] Print actual quant storage type when signed

### DIFF
--- a/mlir/include/mlir/IR/BuiltinTypes.td
+++ b/mlir/include/mlir/IR/BuiltinTypes.td
@@ -680,7 +680,13 @@ def Builtin_Integer : Builtin_Type<"Integer", "integer",
 
     /// Get the storage type as a string.
     std::string getStorageTypeName(bool isSigned) const {
-      return (isSigned ? "i" : "u") + std::to_string(getWidth());
+      if (isSignless()) {
+        return (isSigned ? "i" : "u") + std::to_string(getWidth());
+      } else {
+        std::string s;
+        llvm::raw_string_ostream(s) << *this;
+        return s;
+      }
     }
 
     /// Check if this integer type uses packed representation.

--- a/mlir/test/Dialect/Quant/Bytecode/types.mlir
+++ b/mlir/test/Dialect/Quant/Bytecode/types.mlir
@@ -10,6 +10,18 @@ module @parseAnyFullySpecified attributes {
   bytecode.test = !quant.any<i8<-8:7>:f32>
 } {}
 
+// CHECK-LABEL: parseAnyFullySpecifiedUi8
+module @parseAnyFullySpecifiedUi8 attributes {
+  // CHECK: bytecode.test = !quant.any<ui8<0:7>:f32>
+  bytecode.test = !quant.any<ui8<0:7>:f32>
+} {}
+
+// CHECK-LABEL: parseAnyFullySpecifiedSi8
+module @parseAnyFullySpecifiedSi8 attributes {
+  // CHECK: bytecode.test = !quant.any<si8<-8:7>:f32>
+  bytecode.test = !quant.any<si8<-8:7>:f32>
+} {}
+
 // CHECK-LABEL: parseAnyNoExpressedType
 module @parseAnyNoExpressedType attributes {
   // CHECK: bytecode.test = !quant.any<i8<-8:7>>

--- a/mlir/test/Dialect/Quant/parse-uniform.mlir
+++ b/mlir/test/Dialect/Quant/parse-uniform.mlir
@@ -129,6 +129,24 @@ func.func @parse() -> !qalias {
 }
 
 // -----
+// Storage type: ui8 (explicit unsigned)
+// CHECK: !quant.uniform<ui8:f32, 1.000000e+00>
+!qalias = !quant.uniform<ui8:f32, 1.0>
+func.func @parse() -> !qalias {
+  %0 = "foo"() : () -> !qalias
+  return %0 : !qalias
+}
+
+// -----
+// Storage type: si8 (explicit signed)
+// CHECK: !quant.uniform<si8:f32, 1.000000e+00>
+!qalias = !quant.uniform<si8:f32, 1.0>
+func.func @parse() -> !qalias {
+  %0 = "foo"() : () -> !qalias
+  return %0 : !qalias
+}
+
+// -----
 // Per-axis scales and zero points (affine)
 // CHECK: !quant.uniform<u8:f32:1, {2.000000e+02:-120,9.987200e-01:127}>
 !qalias = !quant.uniform<u8:f32:1, {2.0e+2:-120,0.99872:127}>


### PR DESCRIPTION
Without the fix, bytecode serialization roundtrip breaks for types that don't have custom bytecode serializers and contain quant types, since the fallback mechanism prints the type and the quant printer coerces signed to signless types.  E.g.  `!custom<!quant.uniform<ui8:f32, 0.1>>` will print as `u8` when serializing and later be created as a signless `i8` when deserializing.