### PR TITLE
[IR][NFC] Mark BranchInst as deprecated

### DIFF
--- a/llvm/docs/ReleaseNotes.md
+++ b/llvm/docs/ReleaseNotes.md
@@ -86,6 +86,8 @@ Changes to LLVM infrastructure
 * The ``Br`` opcode was split into two opcodes separating unconditional
   (``UncondBr``) and conditional (``CondBr``) branches.
 
+* ``BranchInst`` was deprecated in favor of ``UncondBrInst`` and ``CondBrInst``.
+
 * The operand order of ``CondBr`` instructions was adjusted to match the
   successor order. This can cause subtle breakage when using ``getOperand`` or
   ``setOperand`` to access successors.

--- a/llvm/include/llvm/Analysis/IRSimilarityIdentifier.h
+++ b/llvm/include/llvm/Analysis/IRSimilarityIdentifier.h
@@ -525,7 +525,12 @@ struct IRInstructionMapper {
     InstructionClassification() = default;
 
     // TODO: Determine a scheme to resolve when the label is similar enough.
-    InstrType visitBranchInst(BranchInst &BI) {
+    InstrType visitUncondBrInst(UncondBrInst &BI) {
+      if (EnableBranches)
+        return Legal;
+      return Illegal;
+    }
+    InstrType visitCondBrInst(CondBrInst &BI) {
       if (EnableBranches)
         return Legal;
       return Illegal;

--- a/llvm/include/llvm/IR/InstVisitor.h
+++ b/llvm/include/llvm/IR/InstVisitor.h
@@ -227,9 +227,13 @@ public:
   RetTy visitCondBrInst(CondBrInst &I) {
     return static_cast<SubClass *>(this)->visitBranchInst(I);
   }
+  // Suppress warning for BranchInst. Replace with Instruction once BranchInst
+  // is removed.
+  LLVM_SUPPRESS_DEPRECATED_DECLARATIONS_PUSH
   RetTy visitBranchInst(BranchInst &I) {
     return static_cast<SubClass *>(this)->visitTerminator(I);
   }
+  LLVM_SUPPRESS_DEPRECATED_DECLARATIONS_POP
   RetTy visitSwitchInst(SwitchInst &I) {
     return static_cast<SubClass *>(this)->visitTerminator(I);
   }

--- a/llvm/include/llvm/IR/Instructions.h
+++ b/llvm/include/llvm/IR/Instructions.h
@@ -3072,16 +3072,19 @@ DEFINE_TRANSPARENT_OPERAND_ACCESSORS(ReturnInst, Value)
 //===---------------------------------------------------------------------------
 /// Conditional or Unconditional Branch instruction.
 ///
-class BranchInst : public Instruction {
+class LLVM_DEPRECATED("Use UncondBrInst/CondBrInst/Instruction instead", "")
+    BranchInst : public Instruction {
 protected:
   BranchInst(Type *Ty, unsigned Opcode, AllocInfo AllocInfo,
              InsertPosition InsertBefore = nullptr)
       : Instruction(Ty, Opcode, AllocInfo, InsertBefore) {}
 
 public:
+  LLVM_DEPRECATED("Use UncondBrInst::Create instead", "UncondBrInst::Create")
   static BranchInst *Create(BasicBlock *IfTrue,
                             InsertPosition InsertBefore = nullptr);
 
+  LLVM_DEPRECATED("Use CondBrInst::Create instead", "CondBrInst::Create")
   static BranchInst *Create(BasicBlock *IfTrue, BasicBlock *IfFalse,
                             Value *Cond, InsertPosition InsertBefore = nullptr);
 
@@ -3089,10 +3092,14 @@ public:
   DECLARE_TRANSPARENT_OPERAND_ACCESSORS(Value);
 
   // Defined out-of-line below to access CondBrInst.
+  LLVM_DEPRECATED("Use isa<UncondBrInst> instead", "isa<UncondBrInst>")
   bool isUnconditional() const;
+  LLVM_DEPRECATED("Use isa<CondBrInst> instead", "isa<CondBrInst>")
   bool isConditional() const;
 
+  LLVM_DEPRECATED("Cast to CondBrInst", "")
   Value *getCondition() const;
+  LLVM_DEPRECATED("Cast to CondBrInst", "")
   void setCondition(Value *V);
 
   /// Swap the successors of this branch instruction.
@@ -3100,6 +3107,7 @@ public:
   /// Swaps the successors of the branch instruction. This also swaps any
   /// branch weight metadata associated with the instruction so that it
   /// continues to map correctly to each operand.
+  LLVM_DEPRECATED("Cast to CondBrInst", "")
   void swapSuccessors();
 
   // Methods for support type inquiry through isa, cast, and dyn_cast:
@@ -3111,6 +3119,9 @@ public:
     return isa<Instruction>(V) && classof(cast<Instruction>(V));
   }
 };
+
+// Suppress deprecation warnings from BranchInst.
+LLVM_SUPPRESS_DEPRECATED_DECLARATIONS_PUSH
 
 template <>
 struct OperandTraits<BranchInst> : public VariadicOperandTraits<BranchInst> {};
@@ -3275,6 +3286,9 @@ struct OperandTraits<CondBrInst> : public FixedNumOperandTraits<CondBrInst, 3> {
 };
 
 DEFINE_TRANSPARENT_OPERAND_ACCESSORS(CondBrInst, Value)
+
+// Suppress deprecation warnings from BranchInst.
+LLVM_SUPPRESS_DEPRECATED_DECLARATIONS_POP
 
 //===----------------------------------------------------------------------===//
 //                     BranchInst Out-Of-Line Functions

--- a/llvm/lib/IR/Core.cpp
+++ b/llvm/lib/IR/Core.cpp
@@ -1169,7 +1169,10 @@ LLVMInstructionGetAllMetadataOtherThanDebugLoc(LLVMValueRef Value,
     return wrap(static_cast<Value*>(dyn_cast_or_null<name>(unwrap(Val)))); \
   }
 
+// Suppress warning for BranchInst.
+LLVM_SUPPRESS_DEPRECATED_DECLARATIONS_PUSH
 LLVM_FOR_EACH_VALUE_SUBCLASS(LLVM_DEFINE_VALUE_CAST)
+LLVM_SUPPRESS_DEPRECATED_DECLARATIONS_POP
 
 LLVMValueRef LLVMIsAMDNode(LLVMValueRef Val) {
   if (auto *MD = dyn_cast_or_null<MetadataAsValue>(unwrap(Val)))

--- a/llvm/unittests/IR/InstructionsTest.cpp
+++ b/llvm/unittests/IR/InstructionsTest.cpp
@@ -138,8 +138,10 @@ TEST(InstructionsTest, UncondBrInst) {
   const UncondBrInst *b0 = UncondBrInst::Create(bb0);
 
   // Test legacy BranchInst API.
+  LLVM_SUPPRESS_DEPRECATED_DECLARATIONS_PUSH
   EXPECT_TRUE(cast<BranchInst>(b0)->isUnconditional());
   EXPECT_FALSE(cast<BranchInst>(b0)->isConditional());
+  LLVM_SUPPRESS_DEPRECATED_DECLARATIONS_POP
 
   EXPECT_EQ(1U, b0->getNumSuccessors());
 
@@ -169,8 +171,10 @@ TEST(InstructionsTest, CondBrInst) {
   CondBrInst *b1 = CondBrInst::Create(One, bb0, bb1);
 
   // Test legacy BranchInst API.
+  LLVM_SUPPRESS_DEPRECATED_DECLARATIONS_PUSH
   EXPECT_FALSE(cast<BranchInst>(b1)->isUnconditional());
   EXPECT_TRUE(cast<BranchInst>(b1)->isConditional());
+  LLVM_SUPPRESS_DEPRECATED_DECLARATIONS_POP
 
   EXPECT_EQ(2U, b1->getNumSuccessors());
 


### PR DESCRIPTION
All in-tree uses of BranchInst are eliminated, so mark as deprecated as per the RFC.

https://discourse.llvm.org/t/rfc-split-branchinst-into-uncondbr-and-condbr/90022
