### PR TITLE
[Clang][PowerPC] Add missing _mm_loadu_si64 to ppc_wrappers/emmintrin.h

### DIFF
--- a/clang/lib/Headers/ppc_wrappers/emmintrin.h
+++ b/clang/lib/Headers/ppc_wrappers/emmintrin.h
@@ -764,6 +764,12 @@ extern __inline __m128i
 
 extern __inline __m128i
     __attribute__((__gnu_inline__, __always_inline__, __artificial__))
+    _mm_loadu_si64(void const *__P) {
+  return _mm_set_epi64((__m64)0LL, *(__m64 *)__P);
+}
+
+extern __inline __m128i
+    __attribute__((__gnu_inline__, __always_inline__, __artificial__))
     _mm_loadl_epi64(__m128i_u const *__P) {
   return _mm_set_epi64((__m64)0LL, *(__m64 *)__P);
 }

--- a/clang/lib/Headers/ppc_wrappers/emmintrin.h
+++ b/clang/lib/Headers/ppc_wrappers/emmintrin.h
@@ -765,7 +765,11 @@ extern __inline __m128i
 extern __inline __m128i
     __attribute__((__gnu_inline__, __always_inline__, __artificial__))
     _mm_loadu_si64(void const *__P) {
-  return _mm_set_epi64((__m64)0LL, *(__m64 *)__P);
+  struct __loadu_si64 {
+    long long __v;
+  } __attribute__((__packed__, __may_alias__));
+  long long __u = ((const struct __loadu_si64 *)__P)->__v;
+  return _mm_set_epi64x(0LL, __u);
 }
 
 extern __inline __m128i

--- a/clang/test/CodeGen/PowerPC/ppc-emmintrin.c
+++ b/clang/test/CodeGen/PowerPC/ppc-emmintrin.c
@@ -607,6 +607,7 @@ test_load() {
   resd = _mm_loadl_pd(md1, dp);
   resd = _mm_loadr_pd(dp);
   resd = _mm_loadu_pd(dp);
+  resi = _mm_loadu_si64(mip);
   resi = _mm_loadu_si128(mip);
 }
 
@@ -653,6 +654,9 @@ test_load() {
 // CHECK-LABEL: define available_externally <2 x double> @_mm_loadu_pd
 // CHECK: %[[ADDR:[0-9a-zA-Z_.]+]] = load ptr, ptr %{{[0-9a-zA-Z_.]+}}, align 8
 // CHECK: call <2 x double> @vec_vsx_ld(int, double const*)(i32 noundef signext 0, ptr noundef %[[ADDR]])
+
+// CHECK-LABEL: define available_externally <2 x i64> @_mm_loadu_si64
+// CHECK: call <2 x i64> @_mm_set_epi64(i64 noundef 0, i64 noundef %{{[0-9a-zA-Z_.]+}})
 
 // CHECK-LABEL: define available_externally <2 x i64> @_mm_loadu_si128
 // CHECK: load ptr, ptr %{{[0-9a-zA-Z_.]+}}, align 8

--- a/clang/test/CodeGen/PowerPC/ppc-emmintrin.c
+++ b/clang/test/CodeGen/PowerPC/ppc-emmintrin.c
@@ -656,7 +656,8 @@ test_load() {
 // CHECK: call <2 x double> @vec_vsx_ld(int, double const*)(i32 noundef signext 0, ptr noundef %[[ADDR]])
 
 // CHECK-LABEL: define available_externally <2 x i64> @_mm_loadu_si64
-// CHECK: call <2 x i64> @_mm_set_epi64(i64 noundef 0, i64 noundef %{{[0-9a-zA-Z_.]+}})
+// CHECK: load i64, ptr %{{[0-9a-zA-Z_.]+}}, align 1
+// CHECK: call <2 x i64> @_mm_set_epi64x(i64 noundef 0, i64 noundef %{{[0-9a-zA-Z_.]+}})
 
 // CHECK-LABEL: define available_externally <2 x i64> @_mm_loadu_si128
 // CHECK: load ptr, ptr %{{[0-9a-zA-Z_.]+}}, align 8


### PR DESCRIPTION
This PR is LLM-assisted. Most of it was written with Claude (Anthropic), per the [LLVM AI Tool Policy](https://llvm.org/docs/AIToolPolicy.html#policy). I reviewed it and I'm responsible for it.

Add `_mm_loadu_si64` to `clang/lib/Headers/ppc_wrappers/emmintrin.h`. It loads 64 bits from a possibly unaligned address into the low half of an `__m128i` and zeroes the high half, matching the x86 intrinsic of the same name. SSE2 code using it currently fails to build on PowerPC through the compatibility layer.

Closes #91247

The implementation uses the same packed struct idiom as clang's own x86 `_mm_loadu_si64` in `clang/lib/Headers/emmintrin.h`, so the load carries `align 1`.

The shorter spelling `_mm_set_epi64((__m64)0LL, *(__m64 *)__P)`, which is what #91247 suggests and what this PR originally used, does work on POWER7 and later. But `__m64` in ppc_wrappers is declared `__attribute__((__aligned__(8)))`, so that form asserts 8 byte alignment on a pointer whose whole purpose is not to require it, and it casts away const. The packed struct form avoids both for no cost: the two spellings produce identical code at -O2, and only the packed one is clean under `-fsanitize=alignment`.

## Test plan

`clang/test/CodeGen/PowerPC/ppc-emmintrin.c` gains the call and CHECK lines, including a check on the `align 1` load so the unaligned semantics cannot regress silently.

Assisted-by: Claude (Anthropic)

