### PR TITLE
Add build option CLANG_INCLUDE_EXAMPLES

### DIFF
--- a/clang/CMakeLists.txt
+++ b/clang/CMakeLists.txt
@@ -508,7 +508,12 @@ add_subdirectory(tools)
 add_subdirectory(runtime)
 
 option(CLANG_BUILD_EXAMPLES "Build CLANG example programs by default." OFF)
-add_subdirectory(examples)
+option(CLANG_INCLUDE_EXAMPLES
+       "Generate build targets for the Clang examples."
+       ${LLVM_INCLUDE_EXAMPLES})
+if (CLANG_INCLUDE_EXAMPLES)
+  add_subdirectory(examples)
+endif()
 
 if(APPLE)
   # this line is needed as a cleanup to ensure that any CMakeCaches with the old


### PR DESCRIPTION
Adds a new build option for clang, CLANG_INCLUDE_EXAMPLES, which controls if the examples directory is included in the build. It defaults to the value for LLVM_INCLUDE_EXAMPLES (same as CLANG_INCLUDE_DOCS and CLANG_INCLUDE_TESTS)