### PR TITLE
Move the call frame edges log messages to the verbose channel.

### DIFF
--- a/lldb/source/Target/StackFrameList.cpp
+++ b/lldb/source/Target/StackFrameList.cpp
@@ -211,17 +211,17 @@ static void FindInterveningFrames(Function &begin, Function &end,
                                   addr_t return_pc, CallSequence &path,
                                   ModuleList &images, Log *log) {
   LLDB_LOGV(log, "Finding frames between {0} and {1}, retn-pc={2:x}",
-           begin.GetDisplayName(), end.GetDisplayName(), return_pc);
+            begin.GetDisplayName(), end.GetDisplayName(), return_pc);
 
   // Find a non-tail calling edge with the correct return PC.
   if (log)
     for (const auto &edge : begin.GetCallEdges())
       LLDB_LOGV(log, "FindInterveningFrames: found call with retn-PC = {0:x}",
-               edge->GetReturnPCAddress(begin, target));
+                edge->GetReturnPCAddress(begin, target));
   CallEdge *first_edge = begin.GetCallEdgeForReturnAddress(return_pc, target);
   if (!first_edge) {
     LLDB_LOGV(log, "No call edge outgoing from {0} with retn-PC == {1:x}",
-             begin.GetDisplayName(), return_pc);
+              begin.GetDisplayName(), return_pc);
     return;
   }
 
@@ -232,8 +232,9 @@ static void FindInterveningFrames(Function &begin, Function &end,
     return;
   }
   if (first_callee == &end) {
-    LLDB_LOGV(log, "Not searching further, first callee is {0} (retn-PC: {1:x})",
-             end.GetDisplayName(), return_pc);
+    LLDB_LOGV(log,
+              "Not searching further, first callee is {0} (retn-PC: {1:x})",
+              end.GetDisplayName(), return_pc);
     return;
   }
 

--- a/lldb/source/Target/StackFrameList.cpp
+++ b/lldb/source/Target/StackFrameList.cpp
@@ -210,17 +210,17 @@ static void FindInterveningFrames(Function &begin, Function &end,
                                   ExecutionContext &exe_ctx, Target &target,
                                   addr_t return_pc, CallSequence &path,
                                   ModuleList &images, Log *log) {
-  LLDB_LOG(log, "Finding frames between {0} and {1}, retn-pc={2:x}",
+  LLDB_LOGV(log, "Finding frames between {0} and {1}, retn-pc={2:x}",
            begin.GetDisplayName(), end.GetDisplayName(), return_pc);
 
   // Find a non-tail calling edge with the correct return PC.
   if (log)
     for (const auto &edge : begin.GetCallEdges())
-      LLDB_LOG(log, "FindInterveningFrames: found call with retn-PC = {0:x}",
+      LLDB_LOGV(log, "FindInterveningFrames: found call with retn-PC = {0:x}",
                edge->GetReturnPCAddress(begin, target));
   CallEdge *first_edge = begin.GetCallEdgeForReturnAddress(return_pc, target);
   if (!first_edge) {
-    LLDB_LOG(log, "No call edge outgoing from {0} with retn-PC == {1:x}",
+    LLDB_LOGV(log, "No call edge outgoing from {0} with retn-PC == {1:x}",
              begin.GetDisplayName(), return_pc);
     return;
   }
@@ -228,11 +228,11 @@ static void FindInterveningFrames(Function &begin, Function &end,
   // The first callee may not be resolved, or there may be nothing to fill in.
   Function *first_callee = first_edge->GetCallee(images, exe_ctx);
   if (!first_callee) {
-    LLDB_LOG(log, "Could not resolve callee");
+    LLDB_LOGV(log, "Could not resolve callee");
     return;
   }
   if (first_callee == &end) {
-    LLDB_LOG(log, "Not searching further, first callee is {0} (retn-PC: {1:x})",
+    LLDB_LOGV(log, "Not searching further, first callee is {0} (retn-PC: {1:x})",
              end.GetDisplayName(), return_pc);
     return;
   }


### PR DESCRIPTION
The messages about searching for call edges can be really verbose and they are only useful if you are explicitly debugging the call edges feature.  Most of the time they are irrelevant and just make the step log output hard to read.