### PR TITLE
[NVPTX] Do not emit .debug_pubnames and .debug_pubtypes for NVPTX backend

### DIFF
--- a/llvm/lib/CodeGen/AsmPrinter/DwarfCompileUnit.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/DwarfCompileUnit.cpp
@@ -1531,6 +1531,9 @@ void DwarfCompileUnit::emitHeader(bool UseOffsets) {
 }
 
 bool DwarfCompileUnit::hasDwarfPubSections() const {
+  if (!DD->shouldEmitDwarfPubSections())
+    return false;
+
   switch (CUNode->getNameTableKind()) {
   case DICompileUnit::DebugNameTableKind::None:
     return false;

--- a/llvm/lib/CodeGen/AsmPrinter/DwarfDebug.h
+++ b/llvm/lib/CodeGen/AsmPrinter/DwarfDebug.h
@@ -810,6 +810,9 @@ public:
     SymSize[Sym] = Size;
   }
 
+  /// Whether to emit .debug_pubnames / .debug_pubtypes. Default true;
+  virtual bool shouldEmitDwarfPubSections() const { return true; }
+
   /// Returns whether we should emit all DW_AT_[MIPS_]linkage_name.
   /// If not, we still might emit certain cases.
   bool useAllLinkageNames() const { return UseAllLinkageNames; }

--- a/llvm/lib/Target/NVPTX/NVPTXDwarfDebug.cpp
+++ b/llvm/lib/Target/NVPTX/NVPTXDwarfDebug.cpp
@@ -39,11 +39,13 @@ static cl::opt<bool> LineInfoWithInlinedAt(
 NVPTXDwarfDebug::NVPTXDwarfDebug(AsmPrinter *A) : DwarfDebug(A) {
   // PTX emits debug strings inline (no .debug_str section), does not support
   // .debug_ranges, and uses sections as references (no temp symbols inside
-  // DWARF sections).  DWARF v2 is the default for NVPTX.
+  // DWARF sections).  DWARF v2 is the default for NVPTX and does not support
+  // accelerator tables.
   setUseInlineStrings(true);
   setUseRangesSection(false);
   setUseSectionsAsReferences(true);
   Asm->OutStreamer->getContext().setDwarfVersion(2);
+  setTheAccelTableKind(AccelTableKind::None);
 }
 
 /// NVPTX-specific source line recording with inlined_at support.

--- a/llvm/lib/Target/NVPTX/NVPTXDwarfDebug.h
+++ b/llvm/lib/Target/NVPTX/NVPTXDwarfDebug.h
@@ -49,6 +49,7 @@ protected:
   void initializeTargetDebugInfo(const MachineFunction &MF) override;
   void recordTargetSourceLine(const DebugLoc &DL, unsigned Flags) override;
   bool shouldAttachCompileUnitRanges() const override;
+  bool shouldEmitDwarfPubSections() const override { return false; }
 };
 
 } // end namespace llvm

--- a/llvm/test/DebugInfo/NVPTX/debug-addr-space.ll
+++ b/llvm/test/DebugInfo/NVPTX/debug-addr-space.ll
@@ -6,7 +6,7 @@
 ; CHECK: .section .debug_info
 ; CHECK:      .b8 103                                 // DW_AT_name
 ; CHECK-NEXT: .b8 0
-; CHECK-NEXT: .b32 55                                 // DW_AT_type
+; CHECK-NEXT: .b32 54                                 // DW_AT_type
 ; CHECK-NEXT: .b8 1                                   // DW_AT_decl_file
 ; CHECK-NEXT: .b8 1                                   // DW_AT_decl_line
 ; CHECK-NEXT: .b8 8                                   // DW_AT_address_class

--- a/llvm/test/DebugInfo/NVPTX/debug-name-table.ll
+++ b/llvm/test/DebugInfo/NVPTX/debug-name-table.ll
@@ -1,24 +1,10 @@
 ; RUN: llc -mtriple=nvptx64-nvidia-cuda -mattr=+ptx75 < %s | FileCheck %s
 ; RUN: %if ptxas-isa-7.5 %{ llc -mtriple=nvptx64-nvidia-cuda -mattr=+ptx75 < %s | %ptxas-verify %}
 
-; DICompileUnit without 'nameTableKind: None' results in
-; debug_pubnames and debug_pubtypes sections in DWARF. These sections
-; use labels and label expressions, and ptxas requires PTX v7.5 to
-; support them.
+; NVPTX does not emit .debug_pubnames and .debug_pubtypes sections.
 
-; CHECK-LABEL: .section .debug_pubnames
-; CHECK-NEXT: {
-; CHECK-NEXT: .b32 $L__pubNames_end0-$L__pubNames_start0
-; CHECK-NEXT: $L__pubNames_start0:
-; CHECK:      $L__pubNames_end0:
-; CHECK-NEXT: }
-
-; CHECK-LABEL: .section .debug_pubtypes
-; CHECK-NEXT: {
-; CHECK-NEXT: .b32 $L__pubTypes_end0-$L__pubTypes_start0
-; CHECK-NEXT: $L__pubTypes_start0:
-; CHECK:      $L__pubTypes_end0:
-; CHECK-NEXT: }
+; CHECK-NOT: .section .debug_pubnames
+; CHECK-NOT: .section .debug_pubtypes
 
 ; Function Attrs: nounwind ssp uwtable
 define i32 @foo() #0 !dbg !4 {


### PR DESCRIPTION
This change adds a mechanism to stop emitting `.debug_pubname`, `.debug_pubtypes` sections for a particular target. 

This is particularly useful for cases where IR is generated by frontends that do not explicitly disable these sections (as `Clang` does for `NVPTX`), but still use `llc` for code generation.

Currently, only `NVPTX` uses this to disable these sections. 