### PR TITLE
[lldb][PrefixMap] follow up fixes to #187145

### DIFF
--- a/lldb/source/Core/Module.cpp
+++ b/lldb/source/Core/Module.cpp
@@ -1575,7 +1575,7 @@ void Module::LoadPrefixMapsIfNeeded() {
   if (m_prefix_map_search_dirs.empty())
     return;
 
-  Log *log = GetLog(LLDBLog::Symbols);
+  Log *log = GetLog(LLDBLog::Object | LLDBLog::Modules);
   llvm::vfs::FileSystem &vfs = *llvm::vfs::getRealFileSystem();
   // Track visited directories so two starting paths that share ancestors
   // don't redundantly walk the same directory.
@@ -1597,17 +1597,19 @@ void Module::LoadPrefixMapsIfNeeded() {
         if (buf && *buf) {
           llvm::Expected<llvm::json::Value> val =
               llvm::json::parse((*buf)->getBuffer());
-          if (val) {
-            if (llvm::json::Object *obj = val->getAsObject()) {
-              for (const llvm::json::Object::value_type &kv : *obj)
-                if (std::optional<llvm::StringRef> to =
-                        kv.second.getAsString()) {
-                  LLDB_LOG(log, "applying prefix map: '{0}' -> '{1}'", kv.first,
-                           *to);
-                  m_source_mappings.AppendUnique(kv.first.str(), to->str(),
-                                                 /*notify=*/false);
-                }
-            }
+          if (!val) {
+            LLDB_LOG_ERROR(log, val.takeError(), "failed to parse {1}: {0}",
+                           map_file.GetPath());
+            continue;
+          }
+          if (llvm::json::Object *obj = val->getAsObject()) {
+            for (const llvm::json::Object::value_type &kv : *obj)
+              if (std::optional<llvm::StringRef> to = kv.second.getAsString()) {
+                LLDB_LOG(log, "applying prefix map: '{0}' -> '{1}'", kv.first,
+                         *to);
+                m_source_mappings.AppendUnique(kv.first.str(), to->str(),
+                                               /*notify=*/false);
+              }
           }
         }
         break;

--- a/lldb/test/API/functionalities/compilation-prefix-map/TestCompilationPrefixMap.py
+++ b/lldb/test/API/functionalities/compilation-prefix-map/TestCompilationPrefixMap.py
@@ -18,6 +18,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestCompilationPrefixMap(TestBase):
     @skipIfWindows
+    @skipIfHostIncompatibleWithTarget
     def test_compilation_prefix_map(self):
         """
         Build a binary with -fdebug-prefix-map remapping the source directory
@@ -30,8 +31,8 @@ class TestCompilationPrefixMap(TestBase):
 
         src_dir = self.getSourceDir()
 
-        log = self.getBuildArtifact("symbol.log")
-        self.runCmd('log enable lldb symbol -f "%s"' % log)
+        log = self.getBuildArtifact("module.log")
+        self.runCmd('log enable lldb module -f "%s"' % log)
 
         source_spec = lldb.SBFileSpec(os.path.join(src_dir, "main.c"))
         lldbutil.run_to_source_breakpoint(self, "return x", source_spec)


### PR DESCRIPTION
Fix and improve #187145 for following issues:
* Fix unhandled error.
* Align the log type with the file where it contains.
* The added test doesn't work on windows host for remote debugging, add
  decorator to skip when host and target do not match.
