### PR TITLE
[mlir][tosa] Fix crash in slice op folder when input values are not iterable

### DIFF
--- a/mlir/lib/Dialect/Tosa/IR/TosaCanonicalizations.cpp
+++ b/mlir/lib/Dialect/Tosa/IR/TosaCanonicalizations.cpp
@@ -1835,8 +1835,8 @@ OpFoldResult SliceOp::fold(FoldAdaptor adaptor) {
       outputTy.getNumElements() == 1) {
     llvm::SmallVector<uint64_t> indices =
         llvm::to_vector(startElems.getValues<uint64_t>());
-    auto value = operand.getValues<Attribute>()[indices];
-    return SplatElementsAttr::get(outputTy, value);
+    if (auto values = operand.tryGetValues<Attribute>())
+      return SplatElementsAttr::get(outputTy, (*values)[indices]);
   }
 
   return {};

--- a/mlir/test/Dialect/Tosa/constant_folding.mlir
+++ b/mlir/test/Dialect/Tosa/constant_folding.mlir
@@ -820,6 +820,26 @@ func.func @slice_singleton() -> tensor<1x1xi32> {
 
 // -----
 
+// CHECK-LABEL: @test_slice_resource_no_fold
+func.func @test_slice_resource_no_fold() -> tensor<1x1xi32> {
+  %input = "tosa.const"() {values = dense_resource<slice_resource> : tensor<3x4xi32>} : () -> tensor<3x4xi32>
+  %start = tosa.const_shape {values = dense<[1, 2]> : tensor<2xindex>} : () -> !tosa.shape<2>
+  %size = tosa.const_shape {values = dense<[1, 1]> : tensor<2xindex>} : () -> !tosa.shape<2>
+  // CHECK: tosa.slice
+  %slice= tosa.slice %input, %start, %size : (tensor<3x4xi32>, !tosa.shape<2>, !tosa.shape<2>) -> tensor<1x1xi32>
+  return %slice : tensor<1x1xi32>
+}
+
+{-#
+  dialect_resources: {
+    builtin: {
+      slice_resource: "0x040000000700000000000000000000000000000000000000000000000900000000000000000000000000000000000000"
+    }
+  }
+#-}
+
+// -----
+
 // CHECK: func.func @cast_float_to_float
 func.func @cast_float_to_float() -> tensor<f16> {
   %splat = "tosa.const"() {values = dense<42.0> : tensor<f32>} : () -> tensor<f32>


### PR DESCRIPTION
A crash was encountered in the slice op folder when the input was a constant with dense resource values. The folder was trying to iterate over the input values, which is not possible for resource values. This change fixes the crash and adds a test.