### PR TITLE
[NFC][analyzer] Eliminate IndirectGotoNodeBuilder

### DIFF
--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/CoreEngine.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/CoreEngine.h
@@ -49,7 +49,6 @@ class ExprEngine;
 /// It traverses the CFG and generates the ExplodedGraph.
 class CoreEngine {
   friend class ExprEngine;
-  friend class IndirectGotoNodeBuilder;
   friend class NodeBuilder;
   friend class NodeBuilderContext;
   friend class SwitchNodeBuilder;
@@ -331,28 +330,6 @@ public:
 
   ExplodedNode *generateNode(ProgramStateRef State, bool branch,
                              ExplodedNode *Pred);
-};
-
-class IndirectGotoNodeBuilder : public NodeBuilder {
-  const CFGBlock &DispatchBlock;
-  const Expr *Target;
-
-public:
-  IndirectGotoNodeBuilder(ExplodedNodeSet &DstSet,
-                          const NodeBuilderContext &Ctx, const Expr *Tgt,
-                          const CFGBlock *Dispatch)
-      : NodeBuilder(DstSet, Ctx), DispatchBlock(*Dispatch), Target(Tgt) {}
-
-  using iterator = CFGBlock::const_succ_iterator;
-
-  iterator begin() { return DispatchBlock.succ_begin(); }
-  iterator end() { return DispatchBlock.succ_end(); }
-
-  const Expr *getTarget() const { return Target; }
-
-  const LocationContext *getLocationContext() const {
-    return C.getLocationContext();
-  }
 };
 
 class SwitchNodeBuilder : public NodeBuilder {

--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/CoreEngine.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/CoreEngine.h
@@ -348,11 +348,6 @@ public:
   iterator begin() { return DispatchBlock.succ_begin(); }
   iterator end() { return DispatchBlock.succ_end(); }
 
-  using NodeBuilder::generateNode;
-
-  ExplodedNode *generateNode(const CFGBlock *Block, ProgramStateRef State,
-                             ExplodedNode *Pred);
-
   const Expr *getTarget() const { return Target; }
 
   const LocationContext *getLocationContext() const {

--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/ExplodedGraph.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/ExplodedGraph.h
@@ -67,7 +67,6 @@ class ExplodedNode : public llvm::FoldingSetNode {
   friend class BranchNodeBuilder;
   friend class CoreEngine;
   friend class ExplodedGraph;
-  friend class IndirectGotoNodeBuilder;
   friend class NodeBuilder;
   friend class SwitchNodeBuilder;
 

--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/ExprEngine.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/ExprEngine.h
@@ -421,7 +421,7 @@ public:
 
   /// processIndirectGoto - Called by CoreEngine.  Used to generate successor
   ///  nodes by processing the 'effects' of a computed goto jump.
-  void processIndirectGoto(ExplodedNodeSet &DstSet, const Expr *Tgt,
+  void processIndirectGoto(ExplodedNodeSet &Dst, const Expr *Tgt,
                            const CFGBlock *Dispatch, ExplodedNode *Pred);
 
   /// ProcessSwitch - Called by CoreEngine.  Used to generate successor

--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/ExprEngine.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/ExprEngine.h
@@ -422,8 +422,8 @@ public:
 
   /// processIndirectGoto - Called by CoreEngine.  Used to generate successor
   ///  nodes by processing the 'effects' of a computed goto jump.
-  void processIndirectGoto(IndirectGotoNodeBuilder &Builder,
-                           ExplodedNode *Pred);
+  void processIndirectGoto(ExplodedNodeSet &DstSet, const Expr *Tgt,
+                           const CFGBlock *Dispatch, ExplodedNode *Pred);
 
   /// ProcessSwitch - Called by CoreEngine.  Used to generate successor
   ///  nodes by processing the 'effects' of a switch statement.

--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/ExprEngine.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/ExprEngine.h
@@ -83,7 +83,6 @@ class CheckerManager;
 class ConstraintManager;
 class ExplodedNodeSet;
 class ExplodedNode;
-class IndirectGotoNodeBuilder;
 class MemRegion;
 class NodeBuilderContext;
 class ProgramState;

--- a/clang/lib/StaticAnalyzer/Core/CoreEngine.cpp
+++ b/clang/lib/StaticAnalyzer/Core/CoreEngine.cpp
@@ -436,12 +436,9 @@ void CoreEngine::HandleBlockExit(const CFGBlock * B, ExplodedNode *Pred) {
         // Only 1 successor: the indirect goto dispatch block.
         assert(B->succ_size() == 1);
         ExplodedNodeSet Dst;
-        IndirectGotoNodeBuilder Builder(
-            Dst, ExprEng.getBuilderContext(),
-            cast<IndirectGotoStmt>(Term)->getTarget(), *(B->succ_begin()));
-
-        ExprEng.processIndirectGoto(Builder, Pred);
-        // Enqueue the new frontier onto the worklist.
+        ExprEng.processIndirectGoto(Dst,
+                                    cast<IndirectGotoStmt>(Term)->getTarget(),
+                                    *(B->succ_begin()), Pred);
         enqueue(Dst);
         return;
       }

--- a/clang/lib/StaticAnalyzer/Core/CoreEngine.cpp
+++ b/clang/lib/StaticAnalyzer/Core/CoreEngine.cpp
@@ -711,13 +711,6 @@ ExplodedNode *BranchNodeBuilder::generateNode(ProgramStateRef State,
   return Succ;
 }
 
-ExplodedNode *IndirectGotoNodeBuilder::generateNode(const CFGBlock *Block,
-                                                    ProgramStateRef St,
-                                                    ExplodedNode *Pred) {
-  BlockEdge BE(C.getBlock(), Block, Pred->getLocationContext());
-  return generateNode(BE, St, Pred);
-}
-
 ExplodedNode *SwitchNodeBuilder::generateCaseStmtNode(const CFGBlock *Block,
                                                       ProgramStateRef St,
                                                       ExplodedNode *Pred) {

--- a/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
@@ -2978,6 +2978,12 @@ void ExprEngine::processIndirectGoto(IndirectGotoNodeBuilder &Builder,
   ProgramStateRef State = Pred->getState();
   SVal V = State->getSVal(Builder.getTarget(), Builder.getLocationContext());
 
+  // We cannot dispatch anywhere if the label is undefined, NULL or some other
+  // concrete number.
+  // FIXME: Emit a warning in this situation.
+  if (isa<UndefinedVal, loc::ConcreteInt>(V))
+    return;
+
   // Case 1: We know the computed label.
   if (std::optional<loc::GotoLabel> LV = V.getAs<loc::GotoLabel>()) {
     const LabelDecl *L = LV->getLabel();
@@ -2992,13 +2998,7 @@ void ExprEngine::processIndirectGoto(IndirectGotoNodeBuilder &Builder,
     llvm_unreachable("No block with label.");
   }
 
-  // Case 2: The label is NULL (or some other constant), or Undefined.
-  if (isa<UndefinedVal, loc::ConcreteInt>(V)) {
-    // FIXME: Emit warnings when the jump target is undefined or numerical.
-    return;
-  }
-
-  // Case 3: We have no clue about the label.  Dispatch to all targets.
+  // Case 2: We have no clue about the label.  Dispatch to all targets.
   // FIXME: Implement dispatch for symbolic pointers.
   for (const CFGBlock *Succ : Builder)
     Builder.generateNode(Succ, State, Pred);

--- a/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
@@ -2976,7 +2976,6 @@ void ExprEngine::processStaticInitializer(const DeclStmt *DS,
 void ExprEngine::processIndirectGoto(ExplodedNodeSet &DstSet, const Expr *Tgt,
                                      const CFGBlock *Dispatch,
                                      ExplodedNode *Pred) {
-  NodeBuilder Builder(DstSet, getBuilderContext());
   ProgramStateRef State = Pred->getState();
   SVal V = State->getSVal(Tgt, getCurrLocationContext());
 
@@ -3000,7 +2999,7 @@ void ExprEngine::processIndirectGoto(ExplodedNodeSet &DstSet, const Expr *Tgt,
       // FIXME: If 'V' was a symbolic value, then record that on this execution
       // path it is equal to the address of the label leading to 'Succ'.
       BlockEdge BE(getCurrBlock(), Succ, Pred->getLocationContext());
-      Builder.generateNode(BE, State, Pred);
+      DstSet.Add(Engine.makeNode(BE, State, Pred));
     }
   }
 }

--- a/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
@@ -2973,7 +2973,7 @@ void ExprEngine::processStaticInitializer(const DeclStmt *DS,
 
 /// processIndirectGoto - Called by CoreEngine.  Used to generate successor
 ///  nodes by processing the 'effects' of a computed goto jump.
-void ExprEngine::processIndirectGoto(ExplodedNodeSet &DstSet, const Expr *Tgt,
+void ExprEngine::processIndirectGoto(ExplodedNodeSet &Dst, const Expr *Tgt,
                                      const CFGBlock *Dispatch,
                                      ExplodedNode *Pred) {
   ProgramStateRef State = Pred->getState();
@@ -2999,7 +2999,7 @@ void ExprEngine::processIndirectGoto(ExplodedNodeSet &DstSet, const Expr *Tgt,
       // FIXME: If 'V' was a symbolic value, then record that on this execution
       // path it is equal to the address of the label leading to 'Succ'.
       BlockEdge BE(getCurrBlock(), Succ, Pred->getLocationContext());
-      DstSet.Add(Engine.makeNode(BE, State, Pred));
+      Dst.Add(Engine.makeNode(BE, State, Pred));
     }
   }
 }

--- a/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
@@ -2976,10 +2976,9 @@ void ExprEngine::processStaticInitializer(const DeclStmt *DS,
 void ExprEngine::processIndirectGoto(ExplodedNodeSet &DstSet, const Expr *Tgt,
                                      const CFGBlock *Dispatch,
                                      ExplodedNode *Pred) {
-
-  IndirectGotoNodeBuilder Builder(DstSet, getBuilderContext(), Tgt, Dispatch);
+  NodeBuilder Builder(DstSet, getBuilderContext());
   ProgramStateRef State = Pred->getState();
-  SVal V = State->getSVal(Builder.getTarget(), Builder.getLocationContext());
+  SVal V = State->getSVal(Tgt, getCurrLocationContext());
 
   // We cannot dispatch anywhere if the label is undefined, NULL or some other
   // concrete number.
@@ -2996,7 +2995,7 @@ void ExprEngine::processIndirectGoto(ExplodedNodeSet &DstSet, const Expr *Tgt,
     L = LV->getLabel();
 
   // Dispatch to the label 'L' or to all labels if 'L' is null.
-  for (const CFGBlock *Succ : Builder) {
+  for (const CFGBlock *Succ : Dispatch->succs()) {
     if (!L || cast<LabelStmt>(Succ->getLabel())->getDecl() == L) {
       // FIXME: If 'V' was a symbolic value, then record that on this execution
       // path it is equal to the address of the label leading to 'Succ'.

--- a/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
@@ -2973,8 +2973,11 @@ void ExprEngine::processStaticInitializer(const DeclStmt *DS,
 
 /// processIndirectGoto - Called by CoreEngine.  Used to generate successor
 ///  nodes by processing the 'effects' of a computed goto jump.
-void ExprEngine::processIndirectGoto(IndirectGotoNodeBuilder &Builder,
+void ExprEngine::processIndirectGoto(ExplodedNodeSet &DstSet, const Expr *Tgt,
+                                     const CFGBlock *Dispatch,
                                      ExplodedNode *Pred) {
+
+  IndirectGotoNodeBuilder Builder(DstSet, getBuilderContext(), Tgt, Dispatch);
   ProgramStateRef State = Pred->getState();
   SVal V = State->getSVal(Builder.getTarget(), Builder.getLocationContext());
 

--- a/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
@@ -2988,7 +2988,7 @@ void ExprEngine::processIndirectGoto(ExplodedNodeSet &Dst, const Expr *Tgt,
   // If 'V' is the address of a concrete goto label (on this execution path),
   // then only transition along the edge to that label.
   // FIXME: Implement dispatch for symbolic pointers, utilizing information
-  // that they are equal or not equal to pointers to certain goto label.
+  // that they are equal or not equal to pointers to a certain goto label.
   const LabelDecl *L = nullptr;
   if (auto LV = V.getAs<loc::GotoLabel>())
     L = LV->getLabel();

--- a/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
@@ -2984,24 +2984,22 @@ void ExprEngine::processIndirectGoto(IndirectGotoNodeBuilder &Builder,
   if (isa<UndefinedVal, loc::ConcreteInt>(V))
     return;
 
-  // Case 1: We know the computed label.
-  if (std::optional<loc::GotoLabel> LV = V.getAs<loc::GotoLabel>()) {
-    const LabelDecl *L = LV->getLabel();
+  // If 'V' is the address of a concrete goto label (on this execution path),
+  // then only transition along the edge to that label.
+  // FIXME: Implement dispatch for symbolic pointers, utilizing information
+  // that they are equal or not equal to pointers to certain goto label.
+  const LabelDecl *L = nullptr;
+  if (auto LV = V.getAs<loc::GotoLabel>())
+    L = LV->getLabel();
 
-    for (const CFGBlock *Succ : Builder) {
-      if (cast<LabelStmt>(Succ->getLabel())->getDecl() == L) {
-        Builder.generateNode(Succ, State, Pred);
-        return;
-      }
+  // Dispatch to the label 'L' or to all labels if 'L' is null.
+  for (const CFGBlock *Succ : Builder) {
+    if (!L || cast<LabelStmt>(Succ->getLabel())->getDecl() == L) {
+      // FIXME: If 'V' was a symbolic value, then record that on this execution
+      // path it is equal to the address of the label leading to 'Succ'.
+      Builder.generateNode(Succ, State, Pred);
     }
-
-    llvm_unreachable("No block with label.");
   }
-
-  // Case 2: We have no clue about the label.  Dispatch to all targets.
-  // FIXME: Implement dispatch for symbolic pointers.
-  for (const CFGBlock *Succ : Builder)
-    Builder.generateNode(Succ, State, Pred);
 }
 
 void ExprEngine::processBeginOfFunction(ExplodedNode *Pred,

--- a/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
@@ -2997,7 +2997,8 @@ void ExprEngine::processIndirectGoto(IndirectGotoNodeBuilder &Builder,
     if (!L || cast<LabelStmt>(Succ->getLabel())->getDecl() == L) {
       // FIXME: If 'V' was a symbolic value, then record that on this execution
       // path it is equal to the address of the label leading to 'Succ'.
-      Builder.generateNode(Succ, State, Pred);
+      BlockEdge BE(getCurrBlock(), Succ, Pred->getLocationContext());
+      Builder.generateNode(BE, State, Pred);
     }
   }
 }

--- a/clang/test/Analysis/indirect-goto-basics.c
+++ b/clang/test/Analysis/indirect-goto-basics.c
@@ -1,7 +1,6 @@
 // RUN: %clang_analyze_cc1 -verify %s -analyzer-checker=core
 
-// This file tests ExprEngine::processIndirectGoto and the class
-// IndirectGotoNodeBuilder.
+// This file tests ExprEngine::processIndirectGoto.
 
 int goto_known_label_1(int x) {
   // In this example the ternary operator splits the state, the analyzer can


### PR DESCRIPTION
This commit removes the class `IndirectGotoNodeBuilder` because it was an abstraction that just complicated and obscured the underlying logic without any practical advantage.

Incidentally, this PR also prepares the ground for dispatch based on symbolic pointers in indirect goto statements. (If somebody would need it, I could implement it reasonably quickly.)