### PR TITLE
libclc: Invert subnormal checks

### DIFF
--- a/libclc/clc/include/clc/math/clc_subnormal_config.h
+++ b/libclc/clc/include/clc/math/clc_subnormal_config.h
@@ -10,9 +10,8 @@
 
 #include "clc/clcfunc.h"
 
-_CLC_DECL bool __clc_subnormals_disabled();
-_CLC_DECL bool __clc_fp16_subnormals_supported();
-_CLC_DECL bool __clc_fp32_subnormals_supported();
-_CLC_DECL bool __clc_fp64_subnormals_supported();
+_CLC_DECL bool __clc_denormals_are_zero_fp16();
+_CLC_DECL bool __clc_denormals_are_zero_fp32();
+_CLC_DECL bool __clc_denormals_are_zero_fp64();
 
 #endif // __CLC_MATH_CLC_SUBNORMAL_CONFIG_H__

--- a/libclc/clc/include/clc/math/math.h
+++ b/libclc/clc/include/clc/math/math.h
@@ -60,7 +60,7 @@
 
 _CLC_OVERLOAD _CLC_INLINE float __clc_flush_denormal_if_not_supported(float x) {
   int ix = __clc_as_int(x);
-  if (!__clc_fp32_subnormals_supported() && ((ix & EXPBITS_SP32) == 0) &&
+  if (__clc_denormals_are_zero_fp32() && ((ix & EXPBITS_SP32) == 0) &&
       ((ix & MANTBITS_SP32) != 0)) {
     ix &= SIGNBIT_SP32;
     x = __clc_as_float(ix);

--- a/libclc/clc/lib/generic/math/clc_ldexp.cl
+++ b/libclc/clc/lib/generic/math/clc_ldexp.cl
@@ -16,7 +16,7 @@
 
 _CLC_DEF _CLC_OVERLOAD float __clc_ldexp(float x, int n) {
 
-  if (!__clc_fp32_subnormals_supported()) {
+  if (__clc_denormals_are_zero_fp32()) {
     // This treats subnormals as zeros
     int i = __clc_as_int(x);
     int e = (i >> 23) & 0xff;

--- a/libclc/clc/lib/generic/subnormal_config.cl
+++ b/libclc/clc/lib/generic/subnormal_config.cl
@@ -8,14 +8,6 @@
 
 #include "clc/math/clc_subnormal_config.h"
 
-_CLC_DEF bool __clc_fp16_subnormals_supported() { return false; }
-
-_CLC_DEF bool __clc_fp32_subnormals_supported() { return false; }
-
-_CLC_DEF bool __clc_fp64_subnormals_supported() {
-#if defined(CLC_SPIRV) || defined(CLC_CLSPV)
-  return false;
-#else
-  return true;
-#endif
-}
+_CLC_DEF bool __clc_denormals_are_zero_fp16() { return false; }
+_CLC_DEF bool __clc_denormals_are_zero_fp32() { return true; }
+_CLC_DEF bool __clc_denormals_are_zero_fp64() { return false; }


### PR DESCRIPTION
The base case is correct denormal handling, not flushing. This
also matches the spec controls, which starts at IEEE and
flushing is enabled with -cl-denorms-are-zero.

Also fix wrong defaults for half and double. Denormal support is
not optional for these.