### PR TITLE
[AsmPrinter] Only warn about unsupported remarks section if requested

### DIFF
--- a/llvm/include/llvm/Remarks/RemarkStreamer.h
+++ b/llvm/include/llvm/Remarks/RemarkStreamer.h
@@ -75,8 +75,10 @@ public:
   Error setFilter(StringRef Filter);
   /// Check wether the string matches the filter.
   bool matchesFilter(StringRef Str);
-  /// Check if the remarks also need to have associated metadata in a section.
+  /// Check if the remarks NEED to have metadata in an object section
   bool needsSection() const;
+  /// Check if the remarks should store associated metadata if suppported
+  bool wantsSection() const;
 };
 } // end namespace remarks
 } // end namespace llvm

--- a/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
@@ -2716,19 +2716,19 @@ void AsmPrinter::emitGlobalIFunc(Module &M, const GlobalIFunc &GI) {
 }
 
 void AsmPrinter::emitRemarksSection(remarks::RemarkStreamer &RS) {
-  if (!RS.needsSection())
+  if (!RS.wantsSection())
     return;
   if (!RS.getFilename())
     return;
 
   MCSection *RemarksSection =
       OutContext.getObjectFileInfo()->getRemarksSection();
-  if (!RemarksSection) {
+  if (!RemarksSection && RS.needsSection()) {
     OutContext.reportWarning(SMLoc(), "Current object file format does not "
-                                      "support remarks sections. Use the yaml "
-                                      "remark format instead.");
-    return;
+                                      "support remarks sections.");
   }
+  if (!RemarksSection)
+    return;
 
   SmallString<128> Filename = *RS.getFilename();
   sys::fs::make_absolute(Filename);

--- a/llvm/lib/Remarks/RemarkStreamer.cpp
+++ b/llvm/lib/Remarks/RemarkStreamer.cpp
@@ -58,15 +58,14 @@ bool RemarkStreamer::matchesFilter(StringRef Str) {
 }
 
 bool RemarkStreamer::needsSection() const {
-  if (EnableRemarksSection == cl::BOU_TRUE)
-    return true;
+  return EnableRemarksSection == cl::BOU_TRUE;
+}
 
+bool RemarkStreamer::wantsSection() const {
   if (EnableRemarksSection == cl::BOU_FALSE)
     return false;
-
-  assert(EnableRemarksSection == cl::BOU_UNSET);
-
   // Enable remark sections by default for bitstream remarks (so dsymutil can
   // find all remarks for a linked binary)
-  return RemarkSerializer->SerializerFormat == Format::Bitstream;
+  return needsSection() ||
+         RemarkSerializer->SerializerFormat == Format::Bitstream;
 }

--- a/llvm/test/CodeGen/X86/remarks-section.ll
+++ b/llvm/test/CodeGen/X86/remarks-section.ll
@@ -5,7 +5,7 @@
 ; RUN: llc < %s -mtriple=x86_64-darwin --pass-remarks-format=bitstream -remarks-section=false -pass-remarks-output=%/t.yaml | FileCheck --check-prefix=CHECK-DARWIN-OVERRIDE-BITSTREAM %s
 ; RUN: llc < %s -mtriple=x86_64-darwin --pass-remarks-format=yaml -remarks-section=true -pass-remarks-output=%/t.yaml | FileCheck --check-prefix=CHECK-DARWIN-OVERRIDE-YAML %s
 
-; RUN: llc < %s -mtriple=x86_64-unknown-linux-gnu --pass-remarks-format=bitstream -pass-remarks-output=%/t.yaml 2>&1 | FileCheck --check-prefix=CHECK-LINUX-DEFAULT-BITSTREAM %s
+; RUN: llc < %s -mtriple=x86_64-unknown-linux-gnu --pass-remarks-format=bitstream -remarks-section -pass-remarks-output=%/t.yaml 2>&1 | FileCheck --check-prefix=CHECK-LINUX-DEFAULT-BITSTREAM %s
 
 ; CHECK-DARWIN: .section __LLVM,__remarks,regular,debug
 ; CHECK-DARWIN-NEXT: .byte
@@ -25,5 +25,5 @@ define void @func1() {
   ret void
 }
 
-; Currently no ELF support for bitstream remarks
-; CHECK-LINUX-DEFAULT-BITSTREAM: warning: Current object file format does not support remarks sections. Use the yaml remark format instead.
+; Currently no ELF support for storing optional/additional metadata in the object file
+; CHECK-LINUX-DEFAULT-BITSTREAM: warning: Current object file format does not support remarks sections.


### PR DESCRIPTION
Remarks sections are no longer necessary for basic functioning of
bitstream remarks, so only fire a warning if remarks sections are
force-enabled.
