### PR TITLE
[clang-tidy][NFC] Compare nodes by pointer instead of by ID in `readability-else-after-return`

### DIFF
--- a/clang-tools-extra/clang-tidy/readability/ElseAfterReturnCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/ElseAfterReturnCheck.cpp
@@ -67,32 +67,30 @@ static constexpr char WarnOnUnfixableStr[] = "WarnOnUnfixable";
 static constexpr char WarnOnConditionVariablesStr[] =
     "WarnOnConditionVariables";
 
-static const DeclRefExpr *findUsage(const Stmt *Node, int64_t DeclIdentifier) {
+static const DeclRefExpr *findUsage(const Stmt *Node, const Decl *D) {
   if (!Node)
     return nullptr;
   if (const auto *DeclRef = dyn_cast<DeclRefExpr>(Node)) {
-    if (DeclRef->getDecl()->getID() == DeclIdentifier)
+    if (DeclRef->getDecl() == D)
       return DeclRef;
   } else {
     for (const Stmt *ChildNode : Node->children())
-      if (const DeclRefExpr *Result = findUsage(ChildNode, DeclIdentifier))
+      if (const DeclRefExpr *Result = findUsage(ChildNode, D))
         return Result;
   }
   return nullptr;
 }
 
-static const DeclRefExpr *
-findUsageRange(const Stmt *Node,
-               const llvm::ArrayRef<int64_t> &DeclIdentifiers) {
+static const DeclRefExpr *findUsageRange(const Stmt *Node,
+                                         DeclStmt::decl_const_range Decls) {
   if (!Node)
     return nullptr;
   if (const auto *DeclRef = dyn_cast<DeclRefExpr>(Node)) {
-    if (llvm::is_contained(DeclIdentifiers, DeclRef->getDecl()->getID()))
+    if (llvm::is_contained(Decls, DeclRef->getDecl()))
       return DeclRef;
   } else {
     for (const Stmt *ChildNode : Node->children())
-      if (const DeclRefExpr *Result =
-              findUsageRange(ChildNode, DeclIdentifiers))
+      if (const DeclRefExpr *Result = findUsageRange(ChildNode, Decls))
         return Result;
   }
   return nullptr;
@@ -105,19 +103,14 @@ static const DeclRefExpr *checkInitDeclUsageInElse(const IfStmt *If) {
   if (InitDeclStmt->isSingleDecl()) {
     const Decl *InitDecl = InitDeclStmt->getSingleDecl();
     assert(isa<VarDecl>(InitDecl) && "SingleDecl must be a VarDecl");
-    return findUsage(If->getElse(), InitDecl->getID());
+    return findUsage(If->getElse(), InitDecl);
   }
-  SmallVector<int64_t, 4> DeclIdentifiers;
-  for (const Decl *ChildDecl : InitDeclStmt->decls()) {
-    assert(isa<VarDecl>(ChildDecl) && "Init Decls must be a VarDecl");
-    DeclIdentifiers.push_back(ChildDecl->getID());
-  }
-  return findUsageRange(If->getElse(), DeclIdentifiers);
+  return findUsageRange(If->getElse(), InitDeclStmt->decls());
 }
 
 static const DeclRefExpr *checkConditionVarUsageInElse(const IfStmt *If) {
   if (const VarDecl *CondVar = If->getConditionVariable())
-    return findUsage(If->getElse(), CondVar->getID());
+    return findUsage(If->getElse(), CondVar);
   return nullptr;
 }
 


### PR DESCRIPTION
Node IDs are designed to be stable *across different runs of the compiler*. This check doesn't need such a strong guarantee, so using them here introduces unnecessary cost and complexity.