### PR TITLE
[clang]fix ppcaching assertion gh186582

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -327,6 +327,8 @@ SystemZ Support
 - Add support for `#pragma export` for z/OS.  This is a pragma used to export functions and variables
   with external linkage from shared libraries.  It provides compatibility with the IBM XL C/C++
   compiler.
+- Fixed an assertion failure in the preprocessor when encountering ``::template operator`` during tentative parsing. (#GH186582)
+
 
 DWARF Support in Clang
 ----------------------

--- a/clang/lib/Parse/ParseExprCXX.cpp
+++ b/clang/lib/Parse/ParseExprCXX.cpp
@@ -287,7 +287,8 @@ bool Parser::ParseOptionalCXXScopeSpecifier(
         if (ParseUnqualifiedIdOperator(SS, EnteringContext, ObjectType,
                                        TemplateName)) {
           TPA.Revert();
-          break;
+          ConsumeToken();
+          return true;
         }
 
         if (TemplateName.getKind() != UnqualifiedIdKind::IK_OperatorFunctionId &&
@@ -296,7 +297,8 @@ bool Parser::ParseOptionalCXXScopeSpecifier(
                diag::err_id_after_template_in_nested_name_spec)
             << TemplateName.getSourceRange();
           TPA.Revert();
-          break;
+          ConsumeToken();
+          return true;
         }
       } else {
         TPA.Revert();

--- a/clang/lib/Parse/ParseExprCXX.cpp
+++ b/clang/lib/Parse/ParseExprCXX.cpp
@@ -286,7 +286,7 @@ bool Parser::ParseOptionalCXXScopeSpecifier(
         // we already annotated the template-id.
         if (ParseUnqualifiedIdOperator(SS, EnteringContext, ObjectType,
                                        TemplateName)) {
-          TPA.Commit();
+          TPA.Revert();
           break;
         }
 
@@ -295,7 +295,7 @@ bool Parser::ParseOptionalCXXScopeSpecifier(
           Diag(TemplateName.getSourceRange().getBegin(),
                diag::err_id_after_template_in_nested_name_spec)
             << TemplateName.getSourceRange();
-          TPA.Commit();
+          TPA.Revert();
           break;
         }
       } else {

--- a/clang/test/Parser/gh186582.cpp
+++ b/clang/test/Parser/gh186582.cpp
@@ -1,6 +1,7 @@
-// RUN: %clang_cc1 -fsyntax-only -std=c++23 -verify %s
-
-a(   ::template operator // expected-error {{a type specifier is required for all declarations}} \
+// RUN: %clang_cc1 -fsyntax-only -verify %s
+a(   ::template operator // expected-error 2 {{expected a type}} \
+                         // expected-error {{a type specifier is required for all declarations}} \
                          // expected-error {{expected ';' after top level declarator}}
-// expected-error@* {{expected a type}}
-// expected-error@* {{expected unqualified-id}}
+
+
+

--- a/clang/test/Parser/gh186582.cpp
+++ b/clang/test/Parser/gh186582.cpp
@@ -1,0 +1,6 @@
+// RUN: %clang_cc1 -fsyntax-only -std=c++23 -verify %s
+
+a(   ::template operator // expected-error {{a type specifier is required for all declarations}} \
+                         // expected-error {{expected ';' after top level declarator}}
+// expected-error@* {{expected a type}}
+// expected-error@* {{expected unqualified-id}}

--- a/clang/test/Parser/gh186582.cpp
+++ b/clang/test/Parser/gh186582.cpp
@@ -1,6 +1,3 @@
 // RUN: %clang_cc1 -fsyntax-only -std=c++23 -verify %s
 
-a(   ::template operator; 
-// expected-error@3 {{expected a type}}
-// expected-error@3 {{a type specifier is required for all declarations}}
-// expected-error@3 {{expected unqualified-id}}
+a(   ::template operator // expected-error {{expected a type}} expected-error {{unknown type name 'a'}} expected-error {{expected ')'}} expected-note {{to match this '('}} expected-error {{expected unqualified-id}}

--- a/clang/test/Parser/gh186582.cpp
+++ b/clang/test/Parser/gh186582.cpp
@@ -1,7 +1,6 @@
-// RUN: %clang_cc1 -fsyntax-only -verify %s
-a(   ::template operator // expected-error 2 {{expected a type}} \
-                         // expected-error {{a type specifier is required for all declarations}} \
-                         // expected-error {{expected ';' after top level declarator}}
+// RUN: %clang_cc1 -fsyntax-only -std=c++23 -verify %s
 
-
-
+a(   ::template operator; 
+// expected-error@3 {{expected a type}}
+// expected-error@3 {{a type specifier is required for all declarations}}
+// expected-error@3 {{expected unqualified-id}}


### PR DESCRIPTION
Revert tentative action if 'operator' does not form a valid template-id. This ensures cached tokens match the scope range. fixes #186582.
AI was used for ci debugging