### PR TITLE
[GPUToLLVMSPV] Reject module-scope gpu.barrier during LLVM-SPIRV lowering

### DIFF
--- a/mlir/lib/Conversion/GPUToLLVMSPV/GPUToLLVMSPV.cpp
+++ b/mlir/lib/Conversion/GPUToLLVMSPV/GPUToLLVMSPV.cpp
@@ -115,7 +115,7 @@ struct GPUBarrierConversion final : ConvertOpToLLVMPattern<gpu::BarrierOp> {
 
     if (!op->getParentOfType<FunctionOpInterface>())
       return rewriter.notifyMatchFailure(
-    op, "must be nested in a function body before LLVM-SPIRV lowering");
+          op, "must be nested in a function body before LLVM-SPIRV lowering");
 
     Operation *moduleOp = op->getParentWithTrait<OpTrait::SymbolTable>();
     assert(moduleOp && "Expecting module");

--- a/mlir/lib/Conversion/GPUToLLVMSPV/GPUToLLVMSPV.cpp
+++ b/mlir/lib/Conversion/GPUToLLVMSPV/GPUToLLVMSPV.cpp
@@ -113,6 +113,10 @@ struct GPUBarrierConversion final : ConvertOpToLLVMPattern<gpu::BarrierOp> {
                   ConversionPatternRewriter &rewriter) const final {
     constexpr StringLiteral funcName = "_Z7barrierj";
 
+    if (!op->getParentOfType<FunctionOpInterface>())
+      return rewriter.notifyMatchFailure(
+    op, "must be nested in a function body before LLVM-SPIRV lowering");
+
     Operation *moduleOp = op->getParentWithTrait<OpTrait::SymbolTable>();
     assert(moduleOp && "Expecting module");
     Type flagTy = rewriter.getI32Type();

--- a/mlir/test/Conversion/GPUToLLVMSPV/gpu-to-llvm-spv-invalid.mlir
+++ b/mlir/test/Conversion/GPUToLLVMSPV/gpu-to-llvm-spv-invalid.mlir
@@ -1,0 +1,8 @@
+// RUN: mlir-opt -pass-pipeline="builtin.module(gpu.module(convert-gpu-to-llvm-spv))" -verify-diagnostics %s
+
+module attributes {gpu.container_module} {
+  gpu.module @kernels {
+    // expected-error @below {{failed to legalize operation 'gpu.barrier' that was explicitly marked illegal}}
+    gpu.barrier
+  }
+}


### PR DESCRIPTION
gpu.barrier only makes sense inside an executable function/kernel body, not directly under gpu.module.
Without that context, lowering could produce a top-level llvm.call @_Z7barrierj, which later crashes with a parentless instruction.
Add a guard in GPUBarrierConversion so this case fails legalization cleanly instead of generating invalid LLVM IR.
Fixes #186567