### PR TITLE
[clang][headers][endian.h] include_next in freestanding

### DIFF
--- a/clang/lib/Headers/endian.h
+++ b/clang/lib/Headers/endian.h
@@ -10,7 +10,7 @@
 #define __CLANG_ENDIAN_H
 
 // If the system has an endian.h, let's use that instead.
-#if __STDC_HOSTED__ && __has_include_next(<endian.h>)
+#if __has_include_next(<endian.h>)
 #include_next <endian.h>
 #else
 


### PR DESCRIPTION
Remove the `__STDC_HOSTED__` check to allow us to also include the platform header instead in freestanding mode (as suggested in https://github.com/llvm/llvm-project/pull/186032/changes#r2946278425)

