### PR TITLE
Remove LLVM_ABI annotations from llvm/lib/Analysis/BranchProbabilityInfo.cpp which cause build errors

### DIFF
--- a/llvm/lib/Analysis/BranchProbabilityInfo.cpp
+++ b/llvm/lib/Analysis/BranchProbabilityInfo.cpp
@@ -246,12 +246,12 @@ private:
     SccBlockTypeMaps SccBlocks;
 
   public:
-    LLVM_ABI explicit SccInfo(const Function &F);
+    explicit SccInfo(const Function &F);
 
     /// If \p BB belongs to some SCC then ID of that SCC is returned, otherwise
     /// -1 is returned. If \p BB belongs to more than one SCC at the same time
     /// result is undefined.
-    LLVM_ABI int getSCCNum(const BasicBlock *BB) const;
+    int getSCCNum(const BasicBlock *BB) const;
     /// Returns true if \p BB is a 'header' block in SCC with \p SccNum ID,
     /// false otherwise.
     bool isSCCHeader(const BasicBlock *BB, int SccNum) const {
@@ -265,18 +265,18 @@ private:
     /// Fills in \p Enters vector with all such blocks that don't belong to
     /// SCC with \p SccNum ID but there is an edge to a block belonging to the
     /// SCC.
-    LLVM_ABI void
-    getSccEnterBlocks(int SccNum, SmallVectorImpl<BasicBlock *> &Enters) const;
+    void getSccEnterBlocks(int SccNum,
+                           SmallVectorImpl<BasicBlock *> &Enters) const;
     /// Fills in \p Exits vector with all such blocks that don't belong to
     /// SCC with \p SccNum ID but there is an edge from a block belonging to the
     /// SCC.
-    LLVM_ABI void getSccExitBlocks(int SccNum,
-                                   SmallVectorImpl<BasicBlock *> &Exits) const;
+    void getSccExitBlocks(int SccNum,
+                          SmallVectorImpl<BasicBlock *> &Exits) const;
 
   private:
     /// Returns \p BB's type according to classification given by SccBlockType
     /// enum. Please note that \p BB must belong to SSC with \p SccNum ID.
-    LLVM_ABI uint32_t getSccBlockType(const BasicBlock *BB, int SccNum) const;
+    uint32_t getSccBlockType(const BasicBlock *BB, int SccNum) const;
     /// Calculates \p BB's type and stores it in internal data structures for
     /// future use. Please note that \p BB must belong to SSC with \p SccNum ID.
     void calculateSccBlockType(const BasicBlock *BB, int SccNum);
@@ -288,8 +288,8 @@ private:
   /// Helper class to keep basic block along with its loop data information.
   class LoopBlock {
   public:
-    LLVM_ABI explicit LoopBlock(const BasicBlock *BB, const LoopInfo &LI,
-                                const SccInfo &SccI);
+    explicit LoopBlock(const BasicBlock *BB, const LoopInfo &LI,
+                       const SccInfo &SccI);
 
     const BasicBlock *getBlock() const { return BB; }
     BasicBlock *getBlock() { return const_cast<BasicBlock *>(BB); }


### PR DESCRIPTION
In llvm/lib/Analysis/BranchProbabilityInfo.cpp several LLVM_ABI annotations were added which cause build errors, when trying to build LLVM and Clang as a shared library on windows (see https://github.com/compiler-research/ci-workflows/actions/runs/22754706570/job/67436382142#step:6:1141 for some of the errors) . With the changes in this PR these build errors are fixed. 

After this patch this is how far you get with the build https://github.com/compiler-research/ci-workflows/actions/runs/23257495426/job/67635570161#step:6:4601.  These errors were introduced sometime in the last month, but I couldn't work out how to fix them.