### PR TITLE
[CIR] Implement handling of cleanups with active flag

### DIFF
--- a/clang/include/clang/CIR/MissingFeatures.h
+++ b/clang/include/clang/CIR/MissingFeatures.h
@@ -254,7 +254,6 @@ struct MissingFeatures {
   static bool devirtualizeDestructor() { return false; }
   static bool devirtualizeMemberFunction() { return false; }
   static bool dtorCleanups() { return false; }
-  static bool ehCleanupActiveFlag() { return false; }
   static bool ehCleanupScope() { return false; }
   static bool ehCleanupScopeRequiresEHCleanup() { return false; }
   static bool ehScopeFilter() { return false; }

--- a/clang/lib/CIR/CodeGen/CIRGenCleanup.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenCleanup.cpp
@@ -192,6 +192,55 @@ bool EHScopeStack::requiresCatchOrCleanup() const {
   return false;
 }
 
+/// The given cleanup block is being deactivated. Configure a cleanup variable
+/// if necessary.
+static void setupCleanupBlockDeactivation(CIRGenFunction &cgf,
+                                          EHScopeStack::stable_iterator c,
+                                          mlir::Operation *dominatingIP) {
+  EHCleanupScope &scope = cast<EHCleanupScope>(*cgf.ehStack.find(c));
+
+  assert((scope.isNormalCleanup() || scope.isEHCleanup()) &&
+         "cleanup block is neither normal nor EH?");
+
+  if (scope.isNormalCleanup())
+    scope.setTestFlagInNormalCleanup();
+
+  if (scope.isEHCleanup())
+    scope.setTestFlagInEHCleanup();
+
+  // If the cleanup block doesn't exist yet, create it and set its initial
+  // value to `true`. If we are inside a conditional branch, the value must be
+  // initialized before the conditional branch begins.
+  Address var = scope.getActiveFlag();
+  if (!var.isValid()) {
+    CIRGenBuilderTy &builder = cgf.getBuilder();
+    mlir::Location loc = builder.getUnknownLoc();
+    cir::BoolType boolTy = builder.getBoolTy();
+
+    var = cgf.createTempAllocaWithoutCast(boolTy, CharUnits::One(), loc,
+                                          "cleanup.isactive");
+    scope.setActiveFlag(var);
+
+    assert(dominatingIP && "no existing variable and no dominating IP!");
+
+    if (cgf.isInConditionalBranch()) {
+      mlir::Value val = builder.getBool(true, loc);
+      cgf.setBeforeOutermostConditional(val, var);
+    } else {
+      mlir::OpBuilder::InsertionGuard guard(builder);
+      builder.setInsertionPoint(dominatingIP);
+      builder.createFlagStore(loc, true, var.getPointer());
+    }
+  }
+
+  // The code above sets the `isActive` flag to `true` as its initial state
+  // at the point where the variable is created. The code below sets it to
+  // `false` at the point where the cleanup is deactivated.
+  CIRGenBuilderTy &builder = cgf.getBuilder();
+  mlir::Location loc = builder.getUnknownLoc();
+  builder.createFlagStore(loc, false, var.getPointer());
+}
+
 /// Deactive a cleanup that was created in an active state.
 void CIRGenFunction::deactivateCleanupBlock(EHScopeStack::stable_iterator c,
                                             mlir::Operation *dominatingIP) {
@@ -208,12 +257,15 @@ void CIRGenFunction::deactivateCleanupBlock(EHScopeStack::stable_iterator c,
   }
 
   // Otherwise, follow the general case.
-  cgm.errorNYI("deactivateCleanupBlock: setupCleanupBlockActivation");
+  setupCleanupBlockDeactivation(*this, c, dominatingIP);
+
+  scope.setActive(false);
 }
 
 static void emitCleanup(CIRGenFunction &cgf, cir::CleanupScopeOp cleanupScope,
                         EHScopeStack::Cleanup *cleanup,
-                        EHScopeStack::Cleanup::Flags flags) {
+                        EHScopeStack::Cleanup::Flags flags,
+                        Address activeFlag) {
   CIRGenBuilderTy &builder = cgf.getBuilder();
   mlir::Block &block = cleanupScope.getCleanupRegion().back();
 
@@ -222,9 +274,23 @@ static void emitCleanup(CIRGenFunction &cgf, cir::CleanupScopeOp cleanupScope,
 
   // Ask the cleanup to emit itself.
   assert(cgf.haveInsertPoint() && "expected insertion point");
-  assert(!cir::MissingFeatures::ehCleanupActiveFlag());
-  cleanup->emit(cgf, flags);
-  assert(cgf.haveInsertPoint() && "cleanup ended with no insertion point?");
+
+  if (activeFlag.isValid()) {
+    mlir::Location loc = cleanupScope.getLoc();
+    mlir::Value isActive = builder.createFlagLoad(loc, activeFlag.getPointer());
+    cir::IfOp::create(builder, loc, isActive,
+                      /*withElseRegion=*/false,
+                      /*thenBuilder=*/
+                      [&](mlir::OpBuilder &, mlir::Location) {
+                        cleanup->emit(cgf, flags);
+                        assert(cgf.haveInsertPoint() &&
+                               "cleanup ended with no insertion point?");
+                        builder.createYield(loc);
+                      });
+  } else {
+    cleanup->emit(cgf, flags);
+    assert(cgf.haveInsertPoint() && "cleanup ended with no insertion point?");
+  }
 
   mlir::Block &cleanupRegionLastBlock = cleanupScope.getCleanupRegion().back();
   if (cleanupRegionLastBlock.empty() ||
@@ -257,6 +323,12 @@ void CIRGenFunction::popCleanupBlock() {
 
   // Remember activation information.
   bool isActive = scope.isActive();
+  Address normalActiveFlag = scope.shouldTestFlagInNormalCleanup()
+                                 ? scope.getActiveFlag()
+                                 : Address::invalid();
+  Address ehActiveFlag = scope.shouldTestFlagInEHCleanup()
+                             ? scope.getActiveFlag()
+                             : Address::invalid();
 
   // - whether there's a fallthrough
   mlir::Block *fallthroughSource = builder.getInsertionBlock();
@@ -265,9 +337,14 @@ void CIRGenFunction::popCleanupBlock() {
   bool requiresNormalCleanup = scope.isNormalCleanup() && hasFallthrough;
   bool requiresEHCleanup = scope.isEHCleanup() && hasFallthrough;
 
+  // Even if we don't need the normal cleanup, we still need to emit the
+  // cleanup code if there's an active flag, since the EH path may still
+  // need to conditionally execute it.
+  bool hasActiveFlag = normalActiveFlag.isValid() || ehActiveFlag.isValid();
+
   // If we don't need the cleanup at all, we're done.
   assert(!cir::MissingFeatures::ehCleanupScopeRequiresEHCleanup());
-  if (!requiresNormalCleanup && !requiresEHCleanup) {
+  if (!requiresNormalCleanup && !requiresEHCleanup && !hasActiveFlag) {
     ehStack.popCleanup();
     return;
   }
@@ -302,13 +379,24 @@ void CIRGenFunction::popCleanupBlock() {
   if (scope.isEHCleanup())
     cleanupFlags.setIsEHCleanupKind();
 
+  // Determine the active flag for the cleanup handler.
+  Address cleanupActiveFlag = normalActiveFlag.isValid() ? normalActiveFlag
+                              : ehActiveFlag.isValid()   ? ehActiveFlag
+                                                         : Address::invalid();
+
   // If we have a fallthrough and no other need for the cleanup,
   // emit it directly.
   if (hasFallthrough) {
     assert(!cir::MissingFeatures::ehCleanupScopeRequiresEHCleanup());
     ehStack.popCleanup();
     scope.markEmitted();
-    emitCleanup(*this, cleanupScope, cleanup, cleanupFlags);
+    emitCleanup(*this, cleanupScope, cleanup, cleanupFlags, cleanupActiveFlag);
+  } else if (!requiresNormalCleanup && !requiresEHCleanup) {
+    // The cleanup is inactive but has an active flag. We still need to emit
+    // the cleanup handler guarded by the flag, since the EH path may need it.
+    ehStack.popCleanup();
+    scope.markEmitted();
+    emitCleanup(*this, cleanupScope, cleanup, cleanupFlags, cleanupActiveFlag);
   } else {
     // Otherwise, the best approach is to thread everything through
     // the cleanup block and then try to clean up after ourselves.
@@ -364,7 +452,7 @@ void CIRGenFunction::popCleanupBlock() {
     scope.markEmitted();
     ehStack.popCleanup();
     assert(ehStack.hasNormalCleanups() == hasEnclosingCleanups);
-    emitCleanup(*this, cleanupScope, cleanup, cleanupFlags);
+    emitCleanup(*this, cleanupScope, cleanup, cleanupFlags, cleanupActiveFlag);
 
     // Append the prepared cleanup prologue from above.
     assert(!cir::MissingFeatures::cleanupAppendInsts());

--- a/clang/lib/CIR/CodeGen/CIRGenCleanup.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenCleanup.cpp
@@ -208,17 +208,17 @@ static void setupCleanupBlockDeactivation(CIRGenFunction &cgf,
   if (scope.isEHCleanup())
     scope.setTestFlagInEHCleanup();
 
+  CIRGenBuilderTy &builder = cgf.getBuilder();
+
   // If the cleanup block doesn't exist yet, create it and set its initial
   // value to `true`. If we are inside a conditional branch, the value must be
   // initialized before the conditional branch begins.
   Address var = scope.getActiveFlag();
   if (!var.isValid()) {
-    CIRGenBuilderTy &builder = cgf.getBuilder();
     mlir::Location loc = builder.getUnknownLoc();
-    cir::BoolType boolTy = builder.getBoolTy();
 
-    var = cgf.createTempAllocaWithoutCast(boolTy, CharUnits::One(), loc,
-                                          "cleanup.isactive");
+    var = cgf.createTempAllocaWithoutCast(builder.getBoolTy(), CharUnits::One(),
+                                          loc, "cleanup.isactive");
     scope.setActiveFlag(var);
 
     assert(dominatingIP && "no existing variable and no dominating IP!");
@@ -236,7 +236,6 @@ static void setupCleanupBlockDeactivation(CIRGenFunction &cgf,
   // The code above sets the `isActive` flag to `true` as its initial state
   // at the point where the variable is created. The code below sets it to
   // `false` at the point where the cleanup is deactivated.
-  CIRGenBuilderTy &builder = cgf.getBuilder();
   mlir::Location loc = builder.getUnknownLoc();
   builder.createFlagStore(loc, false, var.getPointer());
 }

--- a/clang/lib/CIR/CodeGen/CIRGenCleanup.h
+++ b/clang/lib/CIR/CodeGen/CIRGenCleanup.h
@@ -108,6 +108,10 @@ class alignas(EHScopeStack::ScopeStackAlignment) EHCleanupScope
   /// created if needed before the cleanup is popped.
   mlir::Block *normalBlock = nullptr;
 
+  /// An optional boolean variable indicating whether this cleanup has been
+  /// activated yet.
+  Address activeFlag = Address::invalid();
+
   /// Cleanup scope op that represent the current scope in CIR
   cir::CleanupScopeOp cleanupScopeOp;
 
@@ -153,6 +157,22 @@ public:
   void setActive(bool isActive) { cleanupBits.isActive = isActive; }
 
   bool isLifetimeMarker() const { return cleanupBits.isLifetimeMarker; }
+
+  bool hasActiveFlag() const { return activeFlag.isValid(); }
+  Address getActiveFlag() const { return activeFlag; }
+  void setActiveFlag(Address var) { activeFlag = var; }
+
+  void setTestFlagInNormalCleanup() {
+    cleanupBits.testFlagInNormalCleanup = true;
+  }
+  bool shouldTestFlagInNormalCleanup() const {
+    return cleanupBits.testFlagInNormalCleanup;
+  }
+
+  void setTestFlagInEHCleanup() { cleanupBits.testFlagInEHCleanup = true; }
+  bool shouldTestFlagInEHCleanup() const {
+    return cleanupBits.testFlagInEHCleanup;
+  }
 
   EHScopeStack::stable_iterator getEnclosingNormalCleanup() const {
     return enclosingNormal;

--- a/clang/test/CIR/CodeGen/new-delete-deactivation.cpp
+++ b/clang/test/CIR/CodeGen/new-delete-deactivation.cpp
@@ -1,0 +1,374 @@
+// RUN: %clang_cc1 -no-enable-noundef-analysis %s -triple=x86_64-linux-gnu -fclangir -emit-cir -std=c++11 -fcxx-exceptions -fexceptions -o %t.cir
+// RUN: FileCheck -check-prefixes=CIR --input-file=%t.cir %s
+// RUN: %clang_cc1 -no-enable-noundef-analysis %s -triple=x86_64-linux-gnu -fclangir -emit-llvm -std=c++11 -fcxx-exceptions -fexceptions -o %t-cir.ll
+// RUN: FileCheck -check-prefixes=LLVM --input-file=%t-cir.ll %s
+// RUN: %clang_cc1 -no-enable-noundef-analysis %s -triple=x86_64-linux-gnu -emit-llvm -std=c++11 -fcxx-exceptions -fexceptions -o %t.ll
+// RUN: FileCheck -check-prefixes=OGCG --input-file=%t.ll %s
+
+struct A {
+  A(int);
+  ~A();
+};
+
+struct B {
+  B();
+  ~B();
+  operator int();
+  int x;
+};
+
+B makeB();
+
+A *deact_simple() { return new A(makeB()); }
+
+// CIR-LABEL: cir.func {{.*}} @_Z12deact_simplev() -> !cir.ptr<!rec_A> {
+// CIR:   %[[RETVAL:.*]] = cir.alloca !cir.ptr<!rec_A>, !cir.ptr<!cir.ptr<!rec_A>>, ["__retval"]
+// CIR:   cir.scope {
+// CIR:     %[[NEW_RESULT:.*]] = cir.alloca !cir.ptr<!rec_A>, !cir.ptr<!cir.ptr<!rec_A>>, ["__new_result"]
+// CIR:     %[[TMP:.*]] = cir.alloca !rec_B, !cir.ptr<!rec_B>, ["ref.tmp0"]
+// CIR:     %[[ACTIVE:.*]] = cir.alloca !cir.bool, !cir.ptr<!cir.bool>, ["cleanup.isactive"]
+// CIR:     %[[PTR:.*]] = cir.call @_Znwm({{.*}}) {{{.*}}builtin}
+// CIR:     cir.cleanup.scope {
+// CIR:       %[[TRUE:.*]] = cir.const #true
+// CIR:       cir.store %[[TRUE]], %[[ACTIVE]] : !cir.bool, !cir.ptr<!cir.bool>
+// CIR:       %[[MAKEB:.*]] = cir.call @_Z5makeBv() : () -> !rec_B
+// CIR:       cir.store{{.*}} %[[MAKEB]], %[[TMP]] : !rec_B, !cir.ptr<!rec_B>
+// CIR:       cir.cleanup.scope {
+// CIR:         %[[CONV:.*]] = cir.call @_ZN1BcviEv(%[[TMP]])
+// CIR:         cir.call @_ZN1AC1Ei({{.*}})
+// CIR:         %[[FALSE:.*]] = cir.const #false
+// CIR:         cir.store %[[FALSE]], %[[ACTIVE]] : !cir.bool, !cir.ptr<!cir.bool>
+// CIR:       } cleanup all {
+// CIR:         cir.call @_ZN1BD1Ev(%[[TMP]]) nothrow
+// CIR:       }
+// CIR:     } cleanup eh {
+// CIR:       %[[IS_ACTIVE:.*]] = cir.load{{.*}} %[[ACTIVE]] : !cir.ptr<!cir.bool>, !cir.bool
+// CIR:       cir.if %[[IS_ACTIVE]] {
+// CIR:         cir.call @_ZdlPv(%[[PTR]]) nothrow {builtin}
+// CIR:       }
+// CIR:     }
+
+// LLVM-LABEL: define dso_local ptr @_Z12deact_simplev() {{.*}} personality ptr @__gxx_personality_v0 {
+// LLVM:   %[[TMP:.*]] = alloca %struct.B
+// LLVM:   %[[ACTIVE:.*]] = alloca i8
+// LLVM:   %[[PTR:.*]] = call ptr @_Znwm(i64 1) #[[ATTR_BUILTIN_NEW:.*]]
+// LLVM:   store i8 1, ptr %[[ACTIVE]]
+// LLVM:   %[[MAKEB:.*]] = invoke %struct.B @_Z5makeBv()
+// LLVM:           to label %[[INVOKE_CONT:.*]] unwind label %[[UNWIND_OUTER:.*]]
+// LLVM: [[INVOKE_CONT]]:
+// LLVM:   invoke void @_ZN1AC1Ei(ptr {{.*}} %[[PTR]], i32 {{.*}})
+// LLVM:           to label %[[INVOKE_CONT2:.*]] unwind label %[[UNWIND_INNER:.*]]
+// LLVM: [[INVOKE_CONT2]]:
+// LLVM:   store i8 0, ptr %[[ACTIVE]]
+// LLVM:   call void @_ZN1BD1Ev(ptr {{.*}} %[[TMP]]) #[[ATTR_NOUNWIND:.*]]
+// LLVM: [[UNWIND_INNER]]:
+// LLVM:   %[[EXN_INNER:.*]] = landingpad { ptr, i32 }
+// LLVM:          cleanup
+// LLVM:   call void @_ZN1BD1Ev(ptr {{.*}} %[[TMP]]) #[[ATTR_NOUNWIND]]
+// LLVM: [[UNWIND_OUTER]]:
+// LLVM:   %[[EXN_OUTER:.*]] = landingpad { ptr, i32 }
+// LLVM:          cleanup
+// LLVM: [[EH_CLEANUP:.*]]:
+// LLVM:   %[[IS_ACTIVE_I8:.*]] = load i8, ptr %[[ACTIVE]]
+// LLVM:   %[[IS_ACTIVE:.*]] = trunc i8 %[[IS_ACTIVE_I8]] to i1
+// LLVM:   br i1 %[[IS_ACTIVE]], label %[[DO_DELETE:.*]], label %[[SKIP_DELETE:.*]]
+// LLVM: [[DO_DELETE]]:
+// LLVM:   call void @_ZdlPv(ptr %[[PTR]]) #[[ATTR_BUILTIN_DEL:.*]]
+
+// OGCG-LABEL: define dso_local ptr @_Z12deact_simplev() {{.*}} personality ptr @__gxx_personality_v0 {
+// OGCG: entry:
+// OGCG:   %[[TMP:.*]] = alloca %struct.B
+// OGCG:   %[[EXN_SLOT:.*]] = alloca ptr
+// OGCG:   %[[EHSEL_SLOT:.*]] = alloca i32
+// OGCG:   %[[ACTIVE:.*]] = alloca i1
+// OGCG:   %[[PTR:.*]] = call {{.*}} ptr @_Znwm(i64 1) #[[OGCG_ATTR_BUILTIN_NEW:.*]]
+// OGCG:   store i1 true, ptr %[[ACTIVE]]
+// OGCG:   invoke void @_Z5makeBv(ptr {{.*}} %[[TMP]])
+// OGCG:           to label %[[INVOKE_CONT:.*]] unwind label %[[LPAD_OUTER:.*]]
+// OGCG: [[INVOKE_CONT]]:
+// OGCG:   invoke void @_ZN1AC1Ei(ptr {{.*}} %[[PTR]], i32 {{.*}})
+// OGCG:           to label %[[INVOKE_CONT2:.*]] unwind label %[[LPAD_INNER:.*]]
+// OGCG: [[INVOKE_CONT2]]:
+// OGCG:   store i1 false, ptr %[[ACTIVE]]
+// OGCG:   call void @_ZN1BD1Ev(ptr {{.*}} %[[TMP]]) #[[OGCG_ATTR_NOUNWIND:.*]]
+// OGCG: [[LPAD_INNER]]:
+// OGCG:   call void @_ZN1BD1Ev(ptr {{.*}} %[[TMP]]) #[[OGCG_ATTR_NOUNWIND]]
+// OGCG: [[EH_CLEANUP:.*]]:
+// OGCG:   %[[IS_ACTIVE:.*]] = load i1, ptr %[[ACTIVE]]
+// OGCG:   br i1 %[[IS_ACTIVE]], label %[[DO_DELETE:.*]], label %[[SKIP_DELETE:.*]]
+// OGCG: [[DO_DELETE]]:
+// OGCG:   call void @_ZdlPv(ptr %[[PTR]]) #[[OGCG_ATTR_BUILTIN_DEL:.*]]
+
+A *deact_if(bool cond) {
+  if (cond)
+    return new A(makeB());
+  return 0;
+}
+
+// CIR-LABEL: cir.func {{.*}} @_Z8deact_ifb
+// CIR:   cir.if {{.*}} {
+// CIR:     cir.scope {
+// CIR:       %[[ACTIVE:.*]] = cir.alloca !cir.bool, !cir.ptr<!cir.bool>, ["cleanup.isactive"]
+// CIR:       %[[PTR:.*]] = cir.call @_Znwm({{.*}}) {{{.*}}builtin}
+// CIR:       cir.cleanup.scope {
+// CIR:         %[[TRUE:.*]] = cir.const #true
+// CIR:         cir.store %[[TRUE]], %[[ACTIVE]] : !cir.bool, !cir.ptr<!cir.bool>
+// CIR:         cir.call @_ZN1AC1Ei({{.*}})
+// CIR:         %[[FALSE:.*]] = cir.const #false
+// CIR:         cir.store %[[FALSE]], %[[ACTIVE]] : !cir.bool, !cir.ptr<!cir.bool>
+// CIR:       } cleanup eh {
+// CIR:         %[[IS_ACTIVE:.*]] = cir.load{{.*}} %[[ACTIVE]] : !cir.ptr<!cir.bool>, !cir.bool
+// CIR:         cir.if %[[IS_ACTIVE]] {
+// CIR:           cir.call @_ZdlPv(%[[PTR]]) nothrow {builtin}
+// CIR:         }
+// CIR:       }
+// CIR:     }
+// CIR:   }
+
+// LLVM-LABEL: define dso_local ptr @_Z8deact_ifb(i1 %0) {{.*}} personality ptr @__gxx_personality_v0 {
+// LLVM:   br i1 %{{.*}}, label %[[THEN:.*]], label %[[END:.*]]
+// LLVM: [[THEN]]:
+// LLVM:   %[[PTR:.*]] = call ptr @_Znwm(i64 1) #[[ATTR_BUILTIN_NEW]]
+// LLVM:   store i8 1, ptr %[[ACTIVE:.*]]
+// LLVM:   invoke void @_ZN1AC1Ei(ptr {{.*}} %[[PTR]], i32 {{.*}})
+// LLVM:           to label %[[CONT:.*]] unwind label %[[UNWIND_INNER:.*]]
+// LLVM: [[CONT]]:
+// LLVM:   store i8 0, ptr %[[ACTIVE]]
+// LLVM: [[UNWIND_INNER]]:
+// LLVM:   landingpad { ptr, i32 }
+// LLVM:          cleanup
+// LLVM: [[EH_CLEANUP:.*]]:
+// LLVM:   %[[ACTIVE_I8:.*]] = load i8, ptr %[[ACTIVE]]
+// LLVM:   %[[ACTIVE_I1:.*]] = trunc i8 %[[ACTIVE_I8]] to i1
+// LLVM:   br i1 %[[ACTIVE_I1]], label %[[DO_DELETE:.*]], label %[[SKIP_DELETE:.*]]
+// LLVM: [[DO_DELETE]]:
+// LLVM:   call void @_ZdlPv(ptr %[[PTR]])
+// LLVM: [[END]]:
+
+// OGCG-LABEL: define dso_local ptr @_Z8deact_ifb(i1 zeroext %cond) {{.*}} personality ptr @__gxx_personality_v0 {
+// OGCG: if.then:
+// OGCG:   %[[PTR:.*]] = call {{.*}} ptr @_Znwm(i64 1) #[[OGCG_ATTR_BUILTIN_NEW]]
+// OGCG:   store i1 true, ptr %[[ACTIVE:.*]]
+// OGCG:   invoke void @_ZN1AC1Ei(ptr {{.*}} %[[PTR]], i32 {{.*}})
+// OGCG:           to label %[[CONT:.*]] unwind label %[[LPAD_INNER:.*]]
+// OGCG: [[CONT]]:
+// OGCG:   store i1 false, ptr %[[ACTIVE]]
+// OGCG: [[LPAD_INNER]]:
+// OGCG:   landingpad { ptr, i32 }
+// OGCG:          cleanup
+// OGCG: [[EH_CLEANUP:.*]]:
+// OGCG:   %[[IS_ACTIVE:.*]] = load i1, ptr %[[ACTIVE]]
+// OGCG:   br i1 %[[IS_ACTIVE]], label %[[DO_DELETE:.*]], label %[[SKIP_DELETE:.*]]
+// OGCG: [[DO_DELETE]]:
+// OGCG:   call void @_ZdlPv(ptr %[[PTR]])
+
+A *deact_ternary(bool cond) { return (new A(makeB()), cond) ? nullptr : nullptr; }
+
+// CIR-LABEL: cir.func {{.*}} @_Z13deact_ternaryb
+// CIR:   cir.scope {
+// CIR:     %[[ACTIVE:.*]] = cir.alloca !cir.bool, !cir.ptr<!cir.bool>, ["cleanup.isactive"]
+// CIR:     %[[PTR:.*]] = cir.call @_Znwm({{.*}}) {{{.*}}builtin}
+// CIR:     cir.cleanup.scope {
+// CIR:       %[[TRUE:.*]] = cir.const #true
+// CIR:       cir.store %[[TRUE]], %[[ACTIVE]] : !cir.bool, !cir.ptr<!cir.bool>
+// CIR:       cir.call @_ZN1AC1Ei({{.*}})
+// CIR:       %[[FALSE:.*]] = cir.const #false
+// CIR:       cir.store %[[FALSE]], %[[ACTIVE]] : !cir.bool, !cir.ptr<!cir.bool>
+// CIR:     } cleanup eh {
+// CIR:       %[[IS_ACTIVE:.*]] = cir.load{{.*}} %[[ACTIVE]] : !cir.ptr<!cir.bool>, !cir.bool
+// CIR:       cir.if %[[IS_ACTIVE]] {
+// CIR:         cir.call @_ZdlPv(%[[PTR]]) nothrow {builtin}
+// CIR:       }
+// CIR:     }
+// CIR:   }
+
+// LLVM-LABEL: define dso_local ptr @_Z13deact_ternaryb(i1 %0) {{.*}} personality ptr @__gxx_personality_v0 {
+// LLVM:   %[[PTR:.*]] = call ptr @_Znwm(i64 1) #[[ATTR_BUILTIN_NEW]]
+// LLVM:   store i8 1, ptr %[[ACTIVE:.*]]
+// LLVM:   invoke void @_ZN1AC1Ei(ptr {{.*}} %[[PTR]], i32 {{.*}})
+// LLVM:           to label %[[CONT:.*]] unwind label %[[UNWIND_INNER:.*]]
+// LLVM: [[CONT]]:
+// LLVM:   store i8 0, ptr %[[ACTIVE]]
+// LLVM: [[UNWIND_INNER]]:
+// LLVM:   landingpad { ptr, i32 }
+// LLVM:          cleanup
+// LLVM: [[EH_CLEANUP:.*]]:
+// LLVM:   %[[ACTIVE_I8:.*]] = load i8, ptr %[[ACTIVE]]
+// LLVM:   %[[ACTIVE_I1:.*]] = trunc i8 %[[ACTIVE_I8]] to i1
+// LLVM:   br i1 %[[ACTIVE_I1]], label %[[DO_DELETE:.*]], label %[[SKIP_DELETE:.*]]
+// LLVM: [[DO_DELETE]]:
+// LLVM:   call void @_ZdlPv(ptr %[[PTR]])
+
+// OGCG-LABEL: define dso_local ptr @_Z13deact_ternaryb(i1 zeroext %cond) {{.*}} personality ptr @__gxx_personality_v0 {
+// OGCG: entry:
+// OGCG:   %[[PTR:.*]] = call {{.*}} ptr @_Znwm(i64 1) #[[OGCG_ATTR_BUILTIN_NEW]]
+// OGCG:   store i1 true, ptr %[[ACTIVE:.*]]
+// OGCG:   invoke void @_ZN1AC1Ei(ptr {{.*}} %[[PTR]], i32 {{.*}})
+// OGCG:           to label %[[CONT:.*]] unwind label %[[LPAD_INNER:.*]]
+// OGCG: [[CONT]]:
+// OGCG:   store i1 false, ptr %[[ACTIVE]]
+// OGCG: [[LPAD_INNER]]:
+// OGCG:   landingpad { ptr, i32 }
+// OGCG:          cleanup
+// OGCG: [[EH_CLEANUP:.*]]:
+// OGCG:   %[[IS_ACTIVE:.*]] = load i1, ptr %[[ACTIVE]]
+// OGCG:   br i1 %[[IS_ACTIVE]], label %[[DO_DELETE:.*]], label %[[SKIP_DELETE:.*]]
+// OGCG: [[DO_DELETE]]:
+// OGCG:   call void @_ZdlPv(ptr %[[PTR]])
+
+A *deact_while_cond(int n) {
+  while ((new A(makeB()), n > 0))
+    --n;
+  return 0;
+}
+
+// CIR-LABEL: cir.func {{.*}} @_Z16deact_while_condi
+// CIR:   %[[ACTIVE:.*]] = cir.alloca !cir.bool, !cir.ptr<!cir.bool>, ["cleanup.isactive"]
+// CIR:   cir.while {
+// CIR:     %[[PTR:.*]] = cir.call @_Znwm({{.*}}) {{{.*}}builtin}
+// CIR:     cir.cleanup.scope {
+// CIR:       %[[TRUE:.*]] = cir.const #true
+// CIR:       cir.store %[[TRUE]], %[[ACTIVE]] : !cir.bool, !cir.ptr<!cir.bool>
+// CIR:       cir.call @_ZN1AC1Ei({{.*}})
+// CIR:       %[[FALSE:.*]] = cir.const #false
+// CIR:       cir.store %[[FALSE]], %[[ACTIVE]] : !cir.bool, !cir.ptr<!cir.bool>
+// CIR:     } cleanup eh {
+// CIR:       %[[IS_ACTIVE:.*]] = cir.load{{.*}} %[[ACTIVE]] : !cir.ptr<!cir.bool>, !cir.bool
+// CIR:       cir.if %[[IS_ACTIVE]] {
+// CIR:         cir.call @_ZdlPv(%[[PTR]]) nothrow {builtin}
+// CIR:       }
+// CIR:     }
+// CIR:     cir.condition({{.*}})
+// CIR:   } do {
+
+// LLVM-LABEL: define dso_local ptr @_Z16deact_while_condi(i32 %0) {{.*}} personality ptr @__gxx_personality_v0 {
+// LLVM:   %[[TMP:.*]] = alloca %struct.B
+// LLVM:   %[[ACTIVE:.*]] = alloca i8
+// LLVM:   br label %[[WHILE_COND:.*]]
+// LLVM: [[WHILE_COND]]:
+// LLVM:   %[[PTR:.*]] = call ptr @_Znwm(i64 1) #[[ATTR_BUILTIN_NEW]]
+// LLVM:   store i8 1, ptr %[[ACTIVE]]
+// LLVM:   invoke %struct.B @_Z5makeBv()
+// LLVM:           to label %[[INVOKE_CONT:.*]] unwind label %[[UNWIND_OUTER:.*]]
+// LLVM: [[INVOKE_CONT]]:
+// LLVM:   invoke void @_ZN1AC1Ei(ptr {{.*}} %[[PTR]], i32 {{.*}})
+// LLVM:           to label %[[INVOKE_CONT2:.*]] unwind label %[[UNWIND_INNER:.*]]
+// LLVM: [[INVOKE_CONT2]]:
+// LLVM:   store i8 0, ptr %[[ACTIVE]]
+// LLVM:   br label %[[NORMAL_CLEANUP:.*]]
+// LLVM: [[NORMAL_CLEANUP]]:
+// LLVM:   call void @_ZN1BD1Ev(ptr {{.*}} %[[TMP]]) #[[ATTR_NOUNWIND]]
+// LLVM: [[UNWIND_INNER]]:
+// LLVM:   landingpad { ptr, i32 }
+// LLVM:          cleanup
+// LLVM:   call void @_ZN1BD1Ev(ptr {{.*}} %[[TMP]]) #[[ATTR_NOUNWIND]]
+// LLVM: [[UNWIND_OUTER]]:
+// LLVM:   landingpad { ptr, i32 }
+// LLVM:          cleanup
+// LLVM: [[EH_CLEANUP:.*]]:
+// LLVM:   %[[IS_ACTIVE_I8:.*]] = load i8, ptr %[[ACTIVE]]
+// LLVM:   %[[IS_ACTIVE:.*]] = trunc i8 %[[IS_ACTIVE_I8]] to i1
+// LLVM:   br i1 %[[IS_ACTIVE]], label %[[DO_DELETE:.*]], label %[[SKIP_DELETE:.*]]
+// LLVM: [[DO_DELETE]]:
+// LLVM:   call void @_ZdlPv(ptr %[[PTR]]) #[[ATTR_BUILTIN_DEL]]
+// LLVM: [[SKIP_DELETE]]:
+// LLVM:   resume { ptr, i32 } {{.*}}
+
+// OGCG-LABEL: define dso_local ptr @_Z16deact_while_condi(i32 %n) {{.*}} personality ptr @__gxx_personality_v0 {
+// OGCG: while.cond:
+// OGCG:   %[[PTR:.*]] = call {{.*}} ptr @_Znwm(i64 1) #[[OGCG_ATTR_BUILTIN_NEW]]
+// OGCG:   store i1 true, ptr %[[ACTIVE:.*]]
+// OGCG:   invoke void @_ZN1AC1Ei(ptr {{.*}} %[[PTR]], i32 {{.*}})
+// OGCG:           to label %[[CONT:.*]] unwind label %[[LPAD_INNER:.*]]
+// OGCG: [[CONT]]:
+// OGCG:   store i1 false, ptr %[[ACTIVE]]
+// OGCG:   br i1 %{{.*}}, label %[[BODY:.*]], label %[[END:.*]]
+// OGCG: [[LPAD_INNER]]:
+// OGCG:   landingpad { ptr, i32 }
+// OGCG:          cleanup
+// OGCG: [[EH_CLEANUP:.*]]:
+// OGCG:   %[[IS_ACTIVE:.*]] = load i1, ptr %[[ACTIVE]]
+// OGCG:   br i1 %[[IS_ACTIVE]], label %[[DO_DELETE:.*]], label %[[SKIP_DELETE:.*]]
+// OGCG: [[DO_DELETE]]:
+// OGCG:   call void @_ZdlPv(ptr %[[PTR]])
+
+A *deact_switch(int kind) {
+  switch (kind) {
+  case 1:
+    return new A(makeB());
+  default:
+    return 0;
+  }
+}
+
+// CIR-LABEL: cir.func {{.*}} @_Z12deact_switchi
+// CIR:   cir.switch({{.*}}) {
+// CIR:     cir.case(equal, [#cir.int<1> : !s32i]) {
+// CIR:       cir.scope {
+// CIR:         %[[ACTIVE:.*]] = cir.alloca !cir.bool, !cir.ptr<!cir.bool>, ["cleanup.isactive"]
+// CIR:         %[[PTR:.*]] = cir.call @_Znwm({{.*}}) {{{.*}}builtin}
+// CIR:         cir.cleanup.scope {
+// CIR:           %[[TRUE:.*]] = cir.const #true
+// CIR:           cir.store %[[TRUE]], %[[ACTIVE]] : !cir.bool, !cir.ptr<!cir.bool>
+// CIR:           cir.call @_ZN1AC1Ei({{.*}})
+// CIR:           %[[FALSE:.*]] = cir.const #false
+// CIR:           cir.store %[[FALSE]], %[[ACTIVE]] : !cir.bool, !cir.ptr<!cir.bool>
+// CIR:         } cleanup eh {
+// CIR:           %[[IS_ACTIVE:.*]] = cir.load{{.*}} %[[ACTIVE]] : !cir.ptr<!cir.bool>, !cir.bool
+// CIR:           cir.if %[[IS_ACTIVE]] {
+// CIR:             cir.call @_ZdlPv(%[[PTR]]) nothrow {builtin}
+// CIR:           }
+// CIR:         }
+// CIR:       }
+// CIR:     }
+// CIR:   }
+
+// LLVM-LABEL: define dso_local ptr @_Z12deact_switchi(i32 %0) {{.*}} personality ptr @__gxx_personality_v0 {
+// LLVM:   switch i32 %{{.*}}, label %[[DEFAULT:.*]] [
+// LLVM:     i32 1, label %[[CASE1:.*]]
+// LLVM:   ]
+// LLVM: [[CASE1]]:
+// LLVM:   %[[PTR:.*]] = call ptr @_Znwm(i64 1) #[[ATTR_BUILTIN_NEW]]
+// LLVM:   store i8 1, ptr %[[ACTIVE:.*]]
+// LLVM:   invoke void @_ZN1AC1Ei(ptr {{.*}} %[[PTR]], i32 {{.*}})
+// LLVM:           to label %[[CONT:.*]] unwind label %[[UNWIND_INNER:.*]]
+// LLVM: [[CONT]]:
+// LLVM:   store i8 0, ptr %[[ACTIVE]]
+// LLVM: [[UNWIND_INNER]]:
+// LLVM:   landingpad { ptr, i32 }
+// LLVM:          cleanup
+// LLVM: [[EH_CLEANUP:.*]]:
+// LLVM:   %[[ACTIVE_I8:.*]] = load i8, ptr %[[ACTIVE]]
+// LLVM:   %[[ACTIVE_I1:.*]] = trunc i8 %[[ACTIVE_I8]] to i1
+// LLVM:   br i1 %[[ACTIVE_I1]], label %[[DO_DELETE:.*]], label %[[SKIP_DELETE:.*]]
+// LLVM: [[DO_DELETE]]:
+// LLVM:   call void @_ZdlPv(ptr %[[PTR]])
+// LLVM: [[DEFAULT]]:
+
+// OGCG-LABEL: define dso_local ptr @_Z12deact_switchi(i32 %kind) {{.*}} personality ptr @__gxx_personality_v0 {
+// OGCG: entry:
+// OGCG:   switch i32 %{{.*}}, label %[[DEFAULT:.*]] [
+// OGCG:     i32 1, label %[[CASE1:.*]]
+// OGCG:   ]
+// OGCG: [[CASE1]]:
+// OGCG:   %[[PTR:.*]] = call {{.*}} ptr @_Znwm(i64 1) #[[OGCG_ATTR_BUILTIN_NEW]]
+// OGCG:   store i1 true, ptr %[[ACTIVE:.*]]
+// OGCG:   invoke void @_ZN1AC1Ei(ptr {{.*}} %[[PTR]], i32 {{.*}})
+// OGCG:           to label %[[CONT:.*]] unwind label %[[LPAD_INNER:.*]]
+// OGCG: [[CONT]]:
+// OGCG:   store i1 false, ptr %[[ACTIVE]]
+// OGCG: [[LPAD_INNER]]:
+// OGCG:   landingpad { ptr, i32 }
+// OGCG:          cleanup
+// OGCG: [[EH_CLEANUP:.*]]:
+// OGCG:   %[[IS_ACTIVE:.*]] = load i1, ptr %[[ACTIVE]]
+// OGCG:   br i1 %[[IS_ACTIVE]], label %[[DO_DELETE:.*]], label %[[SKIP_DELETE:.*]]
+// OGCG: [[DO_DELETE]]:
+// OGCG:   call void @_ZdlPv(ptr %[[PTR]])
+
+// LLVM-DAG: attributes #[[ATTR_BUILTIN_NEW]] = {{{.*}}builtin{{.*}}}
+// LLVM-DAG: attributes #[[ATTR_BUILTIN_DEL]] = {{{.*}}builtin{{.*}}}
+// LLVM-DAG: attributes #[[ATTR_NOUNWIND]] = {{{.*}}nounwind{{.*}}}
+// OGCG-DAG: attributes #[[OGCG_ATTR_BUILTIN_NEW]] = {{{.*}}builtin{{.*}}}
+// OGCG-DAG: attributes #[[OGCG_ATTR_BUILTIN_DEL]] = {{{.*}}builtin{{.*}}}
+// OGCG-DAG: attributes #[[OGCG_ATTR_NOUNWIND]] = {{{.*}}nounwind{{.*}}}


### PR DESCRIPTION
This implements handling of cleanup scopes in cases where a flag is needed to indicate whether or not the cleanup is active. This happens in cases where a cleanup is no longer required, but it isn't at the top of the cleanup stack so it can't be popped. A temporary variable is used to set the cleanup to an inactive state when it is no longer needed.

Assisted-by: Cursor / claude-4.6-opus-high (implementation)
Assisted-by: Cursor / gpt-5.3-codex (tests)