### PR TITLE
[Utils] Add ability to configure git-llvm-push from .gitconfig

### DIFF
--- a/llvm/utils/git-llvm-push
+++ b/llvm/utils/git-llvm-push
@@ -28,6 +28,8 @@ LLVM_GITHUB_TOKEN_VAR = "LLVM_GITHUB_TOKEN"
 LLVM_REPO = "llvm/llvm-project"
 GITHUB_API = "https://api.github.com"
 
+GIT_CONFIG_PREFIX = "git-llvm-push."
+
 MERGE_MAX_RETRIES = 10
 MERGE_RETRY_DELAY = 5  # seconds
 REQUEST_TIMEOUT = 30  # seconds
@@ -613,9 +615,13 @@ def get_git_config_options() -> argparse.Namespace:
         )
         args = argparse.Namespace()
         for line in process.stdout.decode("utf-8").split("\n"):
-            if line.startswith("git-llvm-push."):
+            if line.startswith(GIT_CONFIG_PREFIX):
                 line_parts = line.split("=")
-                setattr(args, line_parts[0][14:].replace("-", "_"), line_parts[1])
+                setattr(
+                    args,
+                    line_parts[0][len(GIT_CONFIG_PREFIX) :].replace("-", "_"),
+                    line_parts[1],
+                )
         return args
     except:
         return argparse.Namespace()

--- a/llvm/utils/git-llvm-push
+++ b/llvm/utils/git-llvm-push
@@ -604,6 +604,23 @@ def get_token_from_cli(runner: CommandRunner) -> str:
     return result.stdout.strip().decode("utf-8")
 
 
+def get_git_config_options() -> argparse.Namespace:
+    # We do not use a runner here as we need to run this before we know what
+    # flags we want to pass to the runner.
+    try:
+        process = subprocess.run(
+            ["git", "config", "--list"], stdout=subprocess.PIPE, stderr=subprocess.PIPE
+        )
+        args = argparse.Namespace()
+        for line in process.stdout.decode("utf-8").split("\n"):
+            if line.startswith("git-llvm-push."):
+                line_parts = line.split("=")
+                setattr(args, line_parts[0][14:].replace("-", "_"), line_parts[1])
+        return args
+    except:
+        return argparse.Namespace()
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(
         description="Create and land a stack of Pull Requests."
@@ -671,7 +688,8 @@ def main() -> None:
         help="Print only essential output and errors.",
     )
 
-    args = parser.parse_args()
+    git_config_args = get_git_config_options()
+    args = parser.parse_args(None, git_config_args)
 
     command_runner = CommandRunner(
         dry_run=args.dry_run, verbose=args.verbose, quiet=args.quiet

--- a/llvm/utils/git-llvm-push.md
+++ b/llvm/utils/git-llvm-push.md
@@ -54,6 +54,22 @@ Regardless of success or failure, the script performs the following cleanup step
 1.  **Checkout Original Branch:** The script will check out the branch you were on when you started the script.
 2.  **Delete Temporary Remote Branches:** Any temporary branches created on your fork (e.g., `users/johndoe/my-feature-1`) will be deleted from the remote. This prevents clutter in your fork.
 
+## Configuration
+
+In addition to accepting command line flags, `git-llvm-push` can also be configured
+through the git config. To do this, edit your git config (using a command like
+`git config --edit` to edit your repo specific configuration) and add the following
+section header:
+
+```
+[git-llvm-push]
+    <flag> = <flag value>
+```
+
+The flags are spelled the exact same as they are on the command line. All flags
+are supported, although `--verbose` and `--dry-run` will not have an impact on
+the git invocation to read the configuration.
+
 ## Examples
 
 ### Dry Run (Safe Mode)


### PR DESCRIPTION
This lets someone set git config options at whatever scope (per-repo, global, etc.) for the options that they care about. This provides similar functionality to just wrapping the script in a shell script with one's desired options without the need to do that.

We need to be careful about how when we get the flags and how to execute the git command to get the flags. For now, we do this before normal argument parsing and fail silently to avoid printing output if someone passes something like --quiet through the git config. This means options like --verbose and --dry-run don't work for this specific command, but I think that is a reasonable tradeoff.