### PR TITLE
[BOLT] Remove outdated assertion from local symtab update logic

### DIFF
--- a/bolt/lib/Rewrite/RewriteInstance.cpp
+++ b/bolt/lib/Rewrite/RewriteInstance.cpp
@@ -5396,9 +5396,6 @@ void RewriteInstance::updateELFSymbolTable(
              "Local label inside ICF-folded function");
 
       if (Function && Function->isEmitted()) {
-        assert(Function->getLayout().isHotColdSplit() &&
-               "Adding symbols based on cold fragment when there are more than "
-               "2 fragments");
         const uint64_t OutputAddress =
             Function->translateInputToOutputAddress(Symbol.st_value);
 


### PR DESCRIPTION
The assert condition (splitting not happening to the function or
the function not split into more than two fragments) is not always
true now that we will emit more local symbols due to #184074.