### PR TITLE
[libclang/python] Deprecate _CXUnsavedFile, introduce UnsavedFile instead

### DIFF
--- a/clang/bindings/python/clang/cindex.py
+++ b/clang/bindings/python/clang/cindex.py
@@ -3091,7 +3091,7 @@ class _CXUnsavedFile(UnsavedFile):
             "'UnsavedFile' is already available to use and existing uses should "
             "be adapted to refer to it instead. '_CXUnsavedFile' will be "
             "removed in a future release.",
-            DeprecationWarning
+            DeprecationWarning,
         )
         return super().__getattribute__(attr)
 

--- a/clang/bindings/python/clang/cindex.py
+++ b/clang/bindings/python/clang/cindex.py
@@ -3071,10 +3071,29 @@ class CompletionChunkKind(BaseEnumeration):
     VERTICAL_SPACE = 20
 
 
-class _CXUnsavedFile(Structure):
+class UnsavedFile(Structure):
     """Helper for passing unsaved file arguments."""
 
     _fields_ = [("name", c_char_p), ("contents", c_char_p), ("length", c_ulong)]
+
+
+class _CXUnsavedFile(UnsavedFile):
+    """
+    _CXUnsavedFile acts as an alias to UnsavedFile.
+    This will be removed  in a future release.
+    All existing usage should be replaced directly with UnsavedFile.
+    No other changes are required.
+    """
+
+    def __getattribute__(self, attr):
+        warnings.warn(
+            "'_CXUnsavedFile' will be renamed to 'UnsavedFile' for consistency. "
+            "'UnsavedFile' is already available to use and existing uses should "
+            "be adapted to refer to it instead. '_CXUnsavedFile' will be "
+            "removed in a future release.",
+            DeprecationWarning
+        )
+        return super().__getattribute__(attr)
 
 
 class CompletionChunk:
@@ -3464,10 +3483,10 @@ class TranslationUnit(ClangObject):
     @staticmethod
     def process_unsaved_files(
         unsaved_files: list[InMemoryFile],
-    ) -> Array[_CXUnsavedFile] | None:
+    ) -> Array[UnsavedFile] | None:
         unsaved_array = None
         if len(unsaved_files):
-            unsaved_array = (_CXUnsavedFile * len(unsaved_files))()
+            unsaved_array = (UnsavedFile * len(unsaved_files))()
             for i, (name, contents) in enumerate(unsaved_files):
                 if hasattr(contents, "read"):
                     contents = contents.read()

--- a/clang/bindings/python/tests/cindex/test_file.py
+++ b/clang/bindings/python/tests/cindex/test_file.py
@@ -69,6 +69,7 @@ int b[] = {
         self.assertNotEqual(main_file, b_file)
         self.assertNotEqual(main_file, "a.inc")
 
+
 class TestUnsavedFile(unittest.TestCase):
     def test_deprecation_warning(self):
         unsaved_file = _CXUnsavedFile()

--- a/clang/bindings/python/tests/cindex/test_file.py
+++ b/clang/bindings/python/tests/cindex/test_file.py
@@ -1,9 +1,10 @@
 import os
 
-from clang.cindex import File, Index, TranslationUnit
+from clang.cindex import _CXUnsavedFile, File, Index, TranslationUnit
 
 
 import unittest
+import warnings
 
 inputs_dir = os.path.join(os.path.dirname(__file__), "INPUTS")
 
@@ -67,3 +68,12 @@ int b[] = {
         self.assertNotEqual(main_file, a_file)
         self.assertNotEqual(main_file, b_file)
         self.assertNotEqual(main_file, "a.inc")
+
+class TestUnsavedFile(unittest.TestCase):
+    def test_deprecation_warning(self):
+        unsaved_file = _CXUnsavedFile()
+        with warnings.catch_warnings(record=True) as log:
+            unsaved_file.name
+            self.assertEqual(len(log), 1)
+            for warning in log:
+                self.assertIsInstance(warning.message, DeprecationWarning)

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -108,6 +108,10 @@ Clang Python Bindings Potentially Breaking Changes
   with objects of other classes.
 - ``TranslationUnit.get_tokens`` now throws an error if both the ``extent`` and
   ``locations`` argument are passed. Previousy, ``locations`` took precedence.
+- ``_CXUnsavedFile`` will be renamed to ``UnsavedFile`` for consistency.
+  ``UnsavedFile`` is already available to use and existing uses should
+  be adapted to refer to it instead. ``_CXUnsavedFile`` will be removed in a 
+  future release.
 
 What's New in Clang |release|?
 ==============================


### PR DESCRIPTION
To maintain consistency with other classes mirrored from libclang, the `_CX` prefix should be removed. 
The old name is introduced as a subclass of the renamed class, and deprecation warnings are added on every attribute access.