### PR TITLE
[lldb][debugserver] Get the size of the shared cache in mapped VM

### DIFF
--- a/lldb/include/lldb/Target/DynamicLoader.h
+++ b/lldb/include/lldb/Target/DynamicLoader.h
@@ -317,16 +317,16 @@ public:
   /// \return
   ///     Returns false if this DynamicLoader cannot gather information
   ///     about the shared cache / has no concept of a shared cache.
-  virtual bool
-  GetSharedCacheInformation(lldb::addr_t &base_address, UUID &uuid,
-                            LazyBool &using_shared_cache,
-                            LazyBool &private_shared_cache,
-                            lldb_private::FileSpec &shared_cache_path) {
+  virtual bool GetSharedCacheInformation(
+      lldb::addr_t &base_address, UUID &uuid, LazyBool &using_shared_cache,
+      LazyBool &private_shared_cache, lldb_private::FileSpec &shared_cache_path,
+      std::optional<uint64_t> &size) {
     base_address = LLDB_INVALID_ADDRESS;
     uuid.Clear();
     using_shared_cache = eLazyBoolCalculate;
     private_shared_cache = eLazyBoolCalculate;
     shared_cache_path.Clear();
+    size.reset();
     return false;
   }
 

--- a/lldb/source/Plugins/DynamicLoader/MacOSX-DYLD/DynamicLoaderDarwin.cpp
+++ b/lldb/source/Plugins/DynamicLoader/MacOSX-DYLD/DynamicLoaderDarwin.cpp
@@ -142,10 +142,11 @@ ModuleSP DynamicLoaderDarwin::FindTargetModuleForImageInfo(
     LazyBool using_sc;
     LazyBool private_sc;
     FileSpec sc_path;
+    std::optional<uint64_t> size;
     SymbolSharedCacheUse sc_mode = ModuleList::GetGlobalModuleListProperties()
                                        .GetSharedCacheBinaryLoading();
     if (GetSharedCacheInformation(sc_base_addr, sc_uuid, using_sc, private_sc,
-                                  sc_path) &&
+                                  sc_path, size) &&
         sc_uuid) {
       if (module_spec.GetUUID())
         image_info = HostInfo::GetSharedCacheImageInfo(module_spec.GetUUID(),

--- a/lldb/source/Plugins/DynamicLoader/MacOSX-DYLD/DynamicLoaderMacOS.cpp
+++ b/lldb/source/Plugins/DynamicLoader/MacOSX-DYLD/DynamicLoaderMacOS.cpp
@@ -691,11 +691,13 @@ Status DynamicLoaderMacOS::CanLoadImage() {
 
 bool DynamicLoaderMacOS::GetSharedCacheInformation(
     lldb::addr_t &base_address, UUID &uuid, LazyBool &using_shared_cache,
-    LazyBool &private_shared_cache, FileSpec &shared_cache_path) {
+    LazyBool &private_shared_cache, FileSpec &shared_cache_path,
+    std::optional<uint64_t> &size) {
   base_address = LLDB_INVALID_ADDRESS;
   uuid.Clear();
   using_shared_cache = eLazyBoolCalculate;
   private_shared_cache = eLazyBoolCalculate;
+  size.reset();
 
   if (m_process) {
     StructuredData::ObjectSP info = m_process->GetSharedCacheInfo();
@@ -704,9 +706,13 @@ bool DynamicLoaderMacOS::GetSharedCacheInformation(
       info_dict = info->GetAsDictionary();
     }
 
-    // {"shared_cache_base_address":140735683125248,"shared_cache_uuid
-    // ":"DDB8D70C-
-    // C9A2-3561-B2C8-BE48A4F33F96","no_shared_cache":false,"shared_cache_private_cache":false}
+    // { "shared_cache_base_address":6580879360,
+    //   "shared_cache_uuid":"71E62C65-D8D9-32D0-9A0B-7F5154C8049F",
+    //   "no_shared_cache":false,
+    //   "shared_cache_private_cache":false,
+    //   "shared_cache_path":"/S/V/P/C/OS/Sm/L/dyld/dyld_shared_cache_arm64e",
+    //   "shared_cache_size":6012010496
+    // }
 
     if (info_dict && info_dict->HasKey("shared_cache_uuid") &&
         info_dict->HasKey("no_shared_cache") &&
@@ -731,6 +737,12 @@ bool DynamicLoaderMacOS::GetSharedCacheInformation(
         llvm::StringRef filepath =
             info_dict->GetValueForKey("shared_cache_path")->GetStringValue();
         shared_cache_path.SetPath(filepath);
+      }
+      if (info_dict->HasKey("shared_cache_size")) {
+        uint64_t val = info_dict->GetValueForKey("shared_cache_size")
+                           ->GetUnsignedIntegerValue(LLDB_INVALID_ADDRESS);
+        if (val != LLDB_INVALID_ADDRESS)
+          size = val;
       }
       return true;
     }

--- a/lldb/source/Plugins/DynamicLoader/MacOSX-DYLD/DynamicLoaderMacOS.h
+++ b/lldb/source/Plugins/DynamicLoader/MacOSX-DYLD/DynamicLoaderMacOS.h
@@ -54,12 +54,12 @@ public:
 
   lldb_private::Status CanLoadImage() override;
 
-  bool
-  GetSharedCacheInformation(lldb::addr_t &base_address,
-                            lldb_private::UUID &uuid,
-                            lldb_private::LazyBool &using_shared_cache,
-                            lldb_private::LazyBool &private_shared_cache,
-                            lldb_private::FileSpec &shared_cache_path) override;
+  bool GetSharedCacheInformation(lldb::addr_t &base_address,
+                                 lldb_private::UUID &uuid,
+                                 lldb_private::LazyBool &using_shared_cache,
+                                 lldb_private::LazyBool &private_shared_cache,
+                                 lldb_private::FileSpec &shared_cache_path,
+                                 std::optional<uint64_t> &size) override;
 
   // PluginInterface protocol
   llvm::StringRef GetPluginName() override { return GetPluginNameStatic(); }

--- a/lldb/source/Plugins/DynamicLoader/MacOSX-DYLD/DynamicLoaderMacOSXDYLD.cpp
+++ b/lldb/source/Plugins/DynamicLoader/MacOSX-DYLD/DynamicLoaderMacOSXDYLD.cpp
@@ -1071,11 +1071,13 @@ Status DynamicLoaderMacOSXDYLD::CanLoadImage() {
 
 bool DynamicLoaderMacOSXDYLD::GetSharedCacheInformation(
     lldb::addr_t &base_address, UUID &uuid, LazyBool &using_shared_cache,
-    LazyBool &private_shared_cache, FileSpec &shared_cache_filepath) {
+    LazyBool &private_shared_cache, FileSpec &shared_cache_filepath,
+    std::optional<uint64_t> &size) {
   base_address = LLDB_INVALID_ADDRESS;
   uuid.Clear();
   using_shared_cache = eLazyBoolCalculate;
   private_shared_cache = eLazyBoolCalculate;
+  size.reset();
 
   if (m_process) {
     addr_t all_image_infos = m_process->GetImageInfoAddress();

--- a/lldb/source/Plugins/DynamicLoader/MacOSX-DYLD/DynamicLoaderMacOSXDYLD.h
+++ b/lldb/source/Plugins/DynamicLoader/MacOSX-DYLD/DynamicLoaderMacOSXDYLD.h
@@ -58,11 +58,12 @@ public:
 
   lldb_private::Status CanLoadImage() override;
 
-  bool GetSharedCacheInformation(
-      lldb::addr_t &base_address, lldb_private::UUID &uuid,
-      lldb_private::LazyBool &using_shared_cache,
-      lldb_private::LazyBool &private_shared_cache,
-      lldb_private::FileSpec &shared_cache_filepath) override;
+  bool GetSharedCacheInformation(lldb::addr_t &base_address,
+                                 lldb_private::UUID &uuid,
+                                 lldb_private::LazyBool &using_shared_cache,
+                                 lldb_private::LazyBool &private_shared_cache,
+                                 lldb_private::FileSpec &shared_cache_filepath,
+                                 std::optional<uint64_t> &size) override;
 
   // PluginInterface protocol
   llvm::StringRef GetPluginName() override { return GetPluginNameStatic(); }

--- a/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.cpp
+++ b/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.cpp
@@ -5738,8 +5738,9 @@ void ObjectFileMachO::GetProcessSharedCacheUUID(Process *process,
     LazyBool using_shared_cache;
     LazyBool private_shared_cache;
     FileSpec sc_filepath;
+    std::optional<uint64_t> size;
     dl->GetSharedCacheInformation(base_addr, uuid, using_shared_cache,
-                                  private_shared_cache, sc_filepath);
+                                  private_shared_cache, sc_filepath, size);
   }
   Log *log(GetLog(LLDBLog::Symbols | LLDBLog::Process));
   LLDB_LOGF(

--- a/lldb/source/Plugins/Platform/MacOSX/PlatformDarwin.cpp
+++ b/lldb/source/Plugins/Platform/MacOSX/PlatformDarwin.cpp
@@ -485,8 +485,9 @@ Status PlatformDarwin::GetModuleFromSharedCaches(
     UUID sc_uuid;
     LazyBool using_sc, private_sc;
     FileSpec sc_path;
+    std::optional<uint64_t> size;
     if (process->GetDynamicLoader()->GetSharedCacheInformation(
-            sc_base_addr, sc_uuid, using_sc, private_sc, sc_path)) {
+            sc_base_addr, sc_uuid, using_sc, private_sc, sc_path, size)) {
       if (module_spec.GetUUID())
         image_info = HostInfo::GetSharedCacheImageInfo(module_spec.GetUUID(),
                                                        sc_uuid, sc_mode);

--- a/lldb/test/API/macosx/shared-cache-vm-range/Makefile
+++ b/lldb/test/API/macosx/shared-cache-vm-range/Makefile
@@ -1,0 +1,4 @@
+C_SOURCES := main.c
+MAKE_DSYM := NO
+
+include Makefile.rules

--- a/lldb/test/API/macosx/shared-cache-vm-range/TestSharedCacheVMRange.py
+++ b/lldb/test/API/macosx/shared-cache-vm-range/TestSharedCacheVMRange.py
@@ -29,8 +29,8 @@ class SharedCacheVMRangeTestCase(TestBase):
 
         ci.HandleCommand("process plugin packet send jGetSharedCacheInfo:{}", res)
 
-        # packet: jGetSharedCacheInfo:{} 
-        # response: 
+        # packet: jGetSharedCacheInfo:{}
+        # response:
         # {
         #   "shared_cache_base_address": 6572900352,
         #   "shared_cache_uuid": "674DB25A-34B2-3C56-8BD4-7D78005B2F2E",
@@ -55,7 +55,7 @@ class SharedCacheVMRangeTestCase(TestBase):
         sym = symctx.GetSymbol()
         self.assertTrue(sym.IsValid())
         addr = sym.GetStartAddress()
-        load_addr = addr.GetLoadAddress(target)
+        printf_load_addr = addr.GetLoadAddress(target)
 
-        self.assertGreater(load_addr, start)
-        self.assertLess(load_addr, end)
+        self.assertGreater(printf_load_addr, start)
+        self.assertLess(printf_load_addr, end)

--- a/lldb/test/API/macosx/shared-cache-vm-range/TestSharedCacheVMRange.py
+++ b/lldb/test/API/macosx/shared-cache-vm-range/TestSharedCacheVMRange.py
@@ -1,0 +1,52 @@
+"""
+Test that we can get the vm range of the shared cache.
+"""
+
+import lldb
+import re
+import json
+from lldbsuite.test.decorators import *
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test import lldbutil
+
+
+class SharedCacheVMRangeTestCase(TestBase):
+    NO_DEBUG_INFO_TESTCASE = True
+
+    @skipIfRemote
+    @skipUnlessDarwin
+    @skipIfOutOfTreeDebugserver  # debugserver returns shared_cache_size
+    def test_shared_cache_vm_range(self):
+        """Test that the shared cache VM range contains a known libc function"""
+        self.build()
+        target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(
+            self, "// break here", lldb.SBFileSpec("main.c")
+        )
+
+        res = lldb.SBCommandReturnObject()
+        ci = self.dbg.GetCommandInterpreter()
+        self.assertTrue(ci, VALID_COMMAND_INTERPRETER)
+
+        ci.HandleCommand("process plugin packet send jGetSharedCacheInfo:{}", res)
+
+        # 'packet: jGetSharedCacheInfo:{} response: {"shared_cache_base_address":6572900352,"shared_cache_uuid":"674DB25A-34B2-3C56-8BD4-7D78005B2F2E","no_shared_cache":false,"shared_cache_private_cache":false,"shared_cache_path":"/System/Volumes/Preboot/Cryptexes/OS/System/Library/dyld/dyld_shared_cache_arm64e","shared_cache_size":5820792832}'
+
+        self.assertTrue("response: " in res.GetOutput())
+        response = re.search("response: (.+)", res.GetOutput()).group(1)
+        json_response = json.loads(response)
+        self.assertTrue("shared_cache_base_address" in json_response)
+        self.assertTrue("shared_cache_size" in json_response)
+        start = json_response["shared_cache_base_address"]
+        end = start + json_response["shared_cache_size"]
+
+        symctx_list = target.FindSymbols("printf", lldb.eSymbolTypeCode)
+        self.assertGreater(symctx_list.GetSize(), 0)
+
+        symctx = symctx_list.GetContextAtIndex(0)
+        sym = symctx.GetSymbol()
+        self.assertTrue(sym.IsValid())
+        addr = sym.GetStartAddress()
+        load_addr = addr.GetLoadAddress(target)
+
+        self.assertGreater(load_addr, start)
+        self.assertLess(load_addr, end)

--- a/lldb/test/API/macosx/shared-cache-vm-range/TestSharedCacheVMRange.py
+++ b/lldb/test/API/macosx/shared-cache-vm-range/TestSharedCacheVMRange.py
@@ -29,7 +29,16 @@ class SharedCacheVMRangeTestCase(TestBase):
 
         ci.HandleCommand("process plugin packet send jGetSharedCacheInfo:{}", res)
 
-        # 'packet: jGetSharedCacheInfo:{} response: {"shared_cache_base_address":6572900352,"shared_cache_uuid":"674DB25A-34B2-3C56-8BD4-7D78005B2F2E","no_shared_cache":false,"shared_cache_private_cache":false,"shared_cache_path":"/System/Volumes/Preboot/Cryptexes/OS/System/Library/dyld/dyld_shared_cache_arm64e","shared_cache_size":5820792832}'
+        # packet: jGetSharedCacheInfo:{} 
+        # response: 
+        # {
+        #   "shared_cache_base_address": 6572900352,
+        #   "shared_cache_uuid": "674DB25A-34B2-3C56-8BD4-7D78005B2F2E",
+        #   "no_shared_cache": false,
+        #   "shared_cache_private_cache": false,
+        #   "shared_cache_path": "/System/Volumes/Preboot/Cryptexes/OS/System/Library/dyld/dyld_shared_cache_arm64e",
+        #   "shared_cache_size": 5820792832
+        # }
 
         self.assertTrue("response: " in res.GetOutput())
         response = re.search("response: (.+)", res.GetOutput()).group(1)

--- a/lldb/test/API/macosx/shared-cache-vm-range/main.c
+++ b/lldb/test/API/macosx/shared-cache-vm-range/main.c
@@ -1,0 +1,4 @@
+#include <stdio.h>
+int main() {
+  printf("hi\n"); // break here
+}

--- a/lldb/tools/debugserver/source/MacOSX/MachProcess.h
+++ b/lldb/tools/debugserver/source/MacOSX/MachProcess.h
@@ -285,7 +285,8 @@ public:
                              bool fetch_report_load_commands);
   bool GetDebugserverSharedCacheInfo(uuid_t &uuid,
                                      std::string &shared_cache_path);
-  bool GetInferiorSharedCacheFilepath(std::string &inferior_sc_path);
+  bool GetInferiorSharedCacheFilepathAndSize(std::string &inferior_sc_path,
+                                             uint64_t &size);
   JSONGenerator::ObjectSP GetInferiorSharedCacheInfo(nub_process_t pid);
 
   nub_size_t GetNumThreads() const;
@@ -483,6 +484,7 @@ private:
   void *(*m_dyld_process_snapshot_get_shared_cache)(void *snapshot);
   void (*m_dyld_shared_cache_for_each_file)(
       void *cache, void (^block)(const char *file_path));
+  uint64_t (*m_dyld_shared_cache_get_mapped_size)(void *cache);
   void (*m_dyld_process_snapshot_dispose)(void *snapshot);
   void (*m_dyld_process_dispose)(void *process);
   void (*m_dyld_process_info_for_each_image)(

--- a/lldb/tools/debugserver/source/MacOSX/MachProcess.mm
+++ b/lldb/tools/debugserver/source/MacOSX/MachProcess.mm
@@ -538,6 +538,7 @@ MachProcess::MachProcess()
       m_dyld_process_snapshot_create_for_process(nullptr),
       m_dyld_process_snapshot_get_shared_cache(nullptr),
       m_dyld_shared_cache_for_each_file(nullptr),
+      m_dyld_shared_cache_get_mapped_size(nullptr),
       m_dyld_process_snapshot_dispose(nullptr), m_dyld_process_dispose(nullptr),
       m_dyld_process_info_for_each_image(nullptr),
       m_dyld_process_info_release(nullptr),
@@ -559,6 +560,8 @@ MachProcess::MachProcess()
   m_dyld_shared_cache_for_each_file =
       (void (*)(void *, void (^)(const char *)))dlsym(
           RTLD_DEFAULT, "dyld_shared_cache_for_each_file");
+  m_dyld_shared_cache_get_mapped_size = (uint64_t(*)(void *))dlsym(
+      RTLD_DEFAULT, "dyld_shared_cache_get_mapped_size");
   m_dyld_process_snapshot_dispose =
       (void (*)(void *))dlsym(RTLD_DEFAULT, "dyld_process_snapshot_dispose");
   m_dyld_process_dispose =
@@ -1229,15 +1232,15 @@ bool MachProcess::GetDebugserverSharedCacheInfo(
   return false;
 }
 
-bool MachProcess::GetInferiorSharedCacheFilepath(
-    std::string &inferior_sc_path) {
+bool MachProcess::GetInferiorSharedCacheFilepathAndSize(
+    std::string &inferior_sc_path, uint64_t &size) {
   inferior_sc_path.clear();
 
   if (!m_dyld_process_create_for_task ||
       !m_dyld_process_snapshot_create_for_process ||
       !m_dyld_process_snapshot_get_shared_cache ||
       !m_dyld_shared_cache_for_each_file || !m_dyld_process_snapshot_dispose ||
-      !m_dyld_process_dispose)
+      !m_dyld_shared_cache_get_mapped_size || !m_dyld_process_dispose)
     return false;
 
   __block std::string sc_path;
@@ -1261,6 +1264,8 @@ bool MachProcess::GetInferiorSharedCacheFilepath(
     done = true;
     sc_path = path;
   });
+  size = m_dyld_shared_cache_get_mapped_size(cache);
+
   m_dyld_process_snapshot_dispose(snapshot);
   m_dyld_process_dispose(process);
 
@@ -1301,26 +1306,28 @@ MachProcess::GetInferiorSharedCacheInfo(nub_process_t pid) {
     }
   }
 
-  // If debugserver and the inferior are have the same cache UUID,
-  // use the simple call to get the filepath to debugserver's shared
-  // cache, return that.
-  uuid_t debugserver_sc_uuid;
-  std::string debugserver_sc_path;
-  bool found_sc_filepath = false;
-  if (GetDebugserverSharedCacheInfo(debugserver_sc_uuid, debugserver_sc_path)) {
-    if (uuid_compare(inferior_sc_uuid, debugserver_sc_uuid) == 0 &&
-        !debugserver_sc_path.empty()) {
-      reply_sp->AddStringItem("shared_cache_path", debugserver_sc_path);
-      found_sc_filepath = true;
-    }
-  }
 
   // Use SPI that are only available on newer OSes to fetch the
   // filepath of the shared cache of the inferior, if available.
-  if (!found_sc_filepath) {
-    std::string inferior_sc_path;
-    if (GetInferiorSharedCacheFilepath(inferior_sc_path))
-      reply_sp->AddStringItem("shared_cache_path", inferior_sc_path);
+  std::string inferior_sc_path;
+  uint64_t size;
+  if (GetInferiorSharedCacheFilepathAndSize(inferior_sc_path, size)) {
+    reply_sp->AddStringItem("shared_cache_path", inferior_sc_path);
+    reply_sp->AddIntegerItem("shared_cache_size", size);
+  } else {
+    // If debugserver and the inferior are have the same cache UUID,
+    // use the simple call to get the filepath to debugserver's shared
+    // cache, return that.  Can't get the shared cache size this way,
+    // currently.
+    uuid_t debugserver_sc_uuid;
+    std::string debugserver_sc_path;
+    if (GetDebugserverSharedCacheInfo(debugserver_sc_uuid,
+                                      debugserver_sc_path)) {
+      if (uuid_compare(inferior_sc_uuid, debugserver_sc_uuid) == 0 &&
+          !debugserver_sc_path.empty()) {
+        reply_sp->AddStringItem("shared_cache_path", debugserver_sc_path);
+      }
+    }
   }
 
   return reply_sp;


### PR DESCRIPTION
Fetch the size of the shared cache address range in VM in the inferior process and return it, if possible.  This allows for a simple call to DynamicLoader::GetSharedCacheInformation to get the virtual address extent of the shared cache in the inferior.  It's a minor addition to the method that fetches the shared cache filepath from the inferior, plus piping it up through lldb's layers.