### PR TITLE
[AMDGPU] Use empty() instead of size() comparisons. NFC.

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUIGroupLP.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUIGroupLP.cpp
@@ -345,7 +345,7 @@ public:
         SyncedSchedGroups(SyncedSchedGroups), IsBottomUp(IsBottomUp) {
 
     for (auto &PipelineInstrs : SyncedInstrs) {
-      if (PipelineInstrs.second.size() > 0) {
+      if (!PipelineInstrs.second.empty()) {
         NeedsSolver = true;
         break;
       }
@@ -359,7 +359,7 @@ public:
     CurrPipeline = BestPipeline;
 
     while (static_cast<size_t>(BeginSyncGroupIdx) < PipelineInstrs.size() &&
-           PipelineInstrs[BeginSyncGroupIdx].size() == 0)
+           PipelineInstrs[BeginSyncGroupIdx].empty())
       ++BeginSyncGroupIdx;
 
     if (static_cast<size_t>(BeginSyncGroupIdx) >= PipelineInstrs.size())
@@ -395,7 +395,7 @@ void PipelineSolver::convertSyncMapsToArrays() {
   PipelineInstrs.resize(SyncedInstrs.size());
   for (auto &SyncInstrMap : SyncedInstrs) {
     for (auto &SUsToCandSGs : SyncInstrMap.second) {
-      if (PipelineInstrs[PipelineIDx].size() == 0) {
+      if (PipelineInstrs[PipelineIDx].empty()) {
         PipelineInstrs[PipelineIDx].push_back(
             std::pair(SUsToCandSGs.first, SUsToCandSGs.second));
         continue;
@@ -511,7 +511,7 @@ void PipelineSolver::advancePosition() {
     ++CurrSyncGroupIdx;
     // Advance to next non-trivial pipeline
     while (static_cast<size_t>(CurrSyncGroupIdx) < PipelineInstrs.size() &&
-           PipelineInstrs[CurrSyncGroupIdx].size() == 0)
+           PipelineInstrs[CurrSyncGroupIdx].empty())
       ++CurrSyncGroupIdx;
   }
 }
@@ -533,7 +533,7 @@ void PipelineSolver::retreatPosition() {
 
     --CurrSyncGroupIdx;
     // Go to previous non-trivial pipeline
-    while (PipelineInstrs[CurrSyncGroupIdx].size() == 0)
+    while (PipelineInstrs[CurrSyncGroupIdx].empty())
       --CurrSyncGroupIdx;
 
     CurrConflInstNo = PipelineInstrs[CurrSyncGroupIdx].size() - 1;

--- a/llvm/lib/Target/AMDGPU/AMDGPULowerModuleLDSPass.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPULowerModuleLDSPass.cpp
@@ -605,7 +605,7 @@ public:
 
       GlobalVariable *GV = K.first;
       assert(AMDGPU::isLDSVariableToLower(*GV));
-      assert(K.second.size() != 0);
+      assert(!K.second.empty());
 
       if (AMDGPU::isDynamicLDS(*GV)) {
         DynamicVariables.insert(GV);

--- a/llvm/lib/Target/AMDGPU/AMDGPURegBankLegalizeHelper.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPURegBankLegalizeHelper.cpp
@@ -60,12 +60,12 @@ bool RegBankLegalizeHelper::findRuleAndApplyMapping(MachineInstr &MI) {
 
   WaterfallInfo WFI;
   unsigned OpIdx = 0;
-  if (Mapping->DstOpMapping.size() > 0) {
+  if (!Mapping->DstOpMapping.empty()) {
     B.setInsertPt(*MI.getParent(), std::next(MI.getIterator()));
     if (!applyMappingDst(MI, OpIdx, Mapping->DstOpMapping))
       return false;
   }
-  if (Mapping->SrcOpMapping.size() > 0) {
+  if (!Mapping->SrcOpMapping.empty()) {
     B.setInstr(MI);
     if (!applyMappingSrc(MI, OpIdx, Mapping->SrcOpMapping, WFI))
       return false;

--- a/llvm/lib/Target/AMDGPU/R600MachineCFGStructurizer.cpp
+++ b/llvm/lib/Target/AMDGPU/R600MachineCFGStructurizer.cpp
@@ -685,7 +685,7 @@ bool R600MachineCFGStructurizer::prepare() {
     MBBVector ExitingMBBs;
     LoopRep->getExitingBlocks(ExitingMBBs);
 
-    if (ExitingMBBs.size() == 0) {
+    if (ExitingMBBs.empty()) {
       MachineBasicBlock* DummyExitBlk = normalizeInfiniteLoopExit(LoopRep);
       if (DummyExitBlk)
         RetBlks.push_back(DummyExitBlk);

--- a/llvm/lib/Target/AMDGPU/SIMachineScheduler.cpp
+++ b/llvm/lib/Target/AMDGPU/SIMachineScheduler.cpp
@@ -971,7 +971,7 @@ void SIScheduleBlockCreator::colorMergeConstantLoadsNextGroup() {
 
     // No predecessor: Vgpr constant loading.
     // Low latency instructions usually have a predecessor (the address)
-    if (SU->Preds.size() > 0 && !DAG->IsLowLatencySU[SU->NodeNum])
+    if (!SU->Preds.empty() && !DAG->IsLowLatencySU[SU->NodeNum])
       continue;
 
     for (SDep& SuccDep : SU->Succs) {


### PR DESCRIPTION
Replace `.size() == 0`, `.size() != 0`, and `.size() > 0` with `.empty()` / `!.empty()` across the AMDGPU backend. No functional change.