### PR TITLE
[mlir] Make MemoryEffectsOpInterface optional.

### DIFF
--- a/mlir/include/mlir-c/Interfaces.h
+++ b/mlir/include/mlir-c/Interfaces.h
@@ -113,6 +113,9 @@ typedef struct {
   /// Get memory effects callback.
   void (*getEffects)(MlirOperation op, MlirMemoryEffectInstancesList effects,
                      void *userData);
+  /// Callback that returns true iff the operation instance
+  /// can specify all its memory effects.
+  bool (*hasKnownMemoryEffects)(MlirOperation op);
   void *userData;
 } MlirMemoryEffectsOpInterfaceCallbacks;
 

--- a/mlir/include/mlir-c/Interfaces.h
+++ b/mlir/include/mlir-c/Interfaces.h
@@ -104,6 +104,11 @@ mlirInferShapedTypeOpInterfaceInferReturnTypes(
 /// Returns the interface TypeID of the MemoryEffectsOpInterface.
 MLIR_CAPI_EXPORTED MlirTypeID mlirMemoryEffectsOpInterfaceTypeID(void);
 
+/// Returns true if the operation implements MemoryEffectsOpInterface, taking
+/// into account instance-level conditions (e.g. hasKnownMemoryEffects).
+MLIR_CAPI_EXPORTED bool
+mlirOperationImplementsMemoryEffectsOpInterface(MlirOperation operation);
+
 /// Callbacks for implementing MemoryEffectsOpInterface from external code.
 typedef struct {
   /// Optional constructor for user data. Set to nullptr to disable it.
@@ -114,8 +119,8 @@ typedef struct {
   void (*getEffects)(MlirOperation op, MlirMemoryEffectInstancesList effects,
                      void *userData);
   /// Callback that returns true iff the operation instance
-  /// can specify all its memory effects.
-  bool (*hasKnownMemoryEffects)(MlirOperation op);
+  /// can specify all its memory effects. Set to nullptr to always return true.
+  bool (*hasKnownMemoryEffects)(MlirOperation op, void *userData);
   void *userData;
 } MlirMemoryEffectsOpInterfaceCallbacks;
 

--- a/mlir/include/mlir/Bindings/Python/IRInterfaces.h
+++ b/mlir/include/mlir/Bindings/Python/IRInterfaces.h
@@ -57,8 +57,7 @@ public:
     }
 
     if (operation != nullptr) {
-      if (!mlirOperationImplementsInterface(*operation,
-                                            ConcreteIface::getInterfaceID())) {
+      if (!ConcreteIface::implementsInterface(*operation)) {
         std::string msg = "the operation does not implement ";
         throw nanobind::value_error((msg + ConcreteIface::pyClassName).c_str());
       }
@@ -100,6 +99,14 @@ public:
 
   /// Hook for derived classes to add class-specific bindings.
   static void bindDerived(ClassTy &cls) {}
+
+  /// Returns true if the operation implements this interface. Derived classes
+  /// may override this to account for instance-level interface availability
+  /// (e.g., when extraClassOf logic makes the interface conditional).
+  static bool implementsInterface(MlirOperation operation) {
+    return mlirOperationImplementsInterface(operation,
+                                            ConcreteIface::getInterfaceID());
+  }
 
   /// Returns `true` if this object was constructed from a subclass of OpView
   /// rather than from an operation instance.

--- a/mlir/include/mlir/Interfaces/SideEffectInterfaces.td
+++ b/mlir/include/mlir/Interfaces/SideEffectInterfaces.td
@@ -31,6 +31,29 @@ def MemoryEffectsOpInterface
     an operation.
   }];
   let cppNamespace = "::mlir";
+
+  let append methods = [InterfaceMethod<
+                            [{
+      Returns true if the operation instance can specify all its memory effects.
+      The implementations may override this to make MemoryEffectsOpInterface
+      support conditional, e.g. when an operation may return conservative
+      "unknown" memory effects presenting itself as if it does not support
+      MemoryEffectsOpInterface at all.
+      By default, for all operations that are declared with
+      MemoryEffectsOpInterface support this method returns true.
+    }],
+                            /*retTy=*/"bool",
+                            /*methodName=*/"hasKnownMemoryEffects",
+                            /*args=*/(ins),
+                            /*methodBody=*/"",
+                            /*defaultImplementation=*/"return true;">,
+  ];
+
+  let extraClassOf = [{
+    // If hasKnownMemoryEffects() returns true, pretend that
+    // the operation instance does not implement MemoryEffectsOpInterface.
+    return $_op.hasKnownMemoryEffects();
+  }];
 }
 
 // The base class for defining specific memory effects.

--- a/mlir/lib/Bindings/Python/IRInterfaces.cpp
+++ b/mlir/lib/Bindings/Python/IRInterfaces.cpp
@@ -348,6 +348,12 @@ public:
   constexpr static GetTypeIDFunctionTy getInterfaceID =
       &mlirMemoryEffectsOpInterfaceTypeID;
 
+  /// Override to use isa<MemoryEffectOpInterface> which respects the
+  /// instance-level extraClassOf / hasKnownMemoryEffects check.
+  static bool implementsInterface(MlirOperation operation) {
+    return mlirOperationImplementsMemoryEffectsOpInterface(operation);
+  }
+
   /// Attach a new MemoryEffectsOpInterface FallbackModel to the named
   /// operation. The FallbackModel acts as a trampoline for callbacks on the
   /// Python class.
@@ -378,6 +384,24 @@ public:
       // Invoke `pyClass.get_effects(op, effects)`.
       pyGetEffects(opview, effectsWrapper);
     };
+
+    // Set hasKnownMemoryEffects callback if the Python class defines it.
+    if (nb::hasattr(target, "has_known_memory_effects")) {
+      callbacks.hasKnownMemoryEffects = [](MlirOperation op,
+                                           void *userData) -> bool {
+        nb::handle pyClass(static_cast<PyObject *>(userData));
+        auto pyHasKnown = nb::cast<nb::callable>(
+            nb::getattr(pyClass, "has_known_memory_effects"));
+
+        PyMlirContextRef context =
+            PyMlirContext::forContext(mlirOperationGetContext(op));
+        auto opview = PyOperation::forOperation(context, op)->createOpView();
+
+        return nb::cast<bool>(pyHasKnown(opview));
+      };
+    } else {
+      callbacks.hasKnownMemoryEffects = nullptr;
+    }
 
     mlirMemoryEffectsOpInterfaceAttachFallbackModel(
         ctx->get(), mlirStringRefCreate(opName.c_str(), opName.size()),

--- a/mlir/lib/CAPI/Interfaces/CMakeLists.txt
+++ b/mlir/lib/CAPI/Interfaces/CMakeLists.txt
@@ -2,4 +2,5 @@ add_mlir_upstream_c_api_library(MLIRCAPIInterfaces
   Interfaces.cpp
 
   LINK_LIBS PUBLIC
-  MLIRInferTypeOpInterface)
+  MLIRInferTypeOpInterface
+  MLIRSideEffectInterfaces)

--- a/mlir/lib/CAPI/Interfaces/Interfaces.cpp
+++ b/mlir/lib/CAPI/Interfaces/Interfaces.cpp
@@ -213,6 +213,12 @@ public:
     callbacks.getEffects(wrap(op), cEffects, callbacks.userData);
   }
 
+  bool hasKnownMemoryEffects(Operation *op) const {
+    if (callbacks.hasKnownMemoryEffects)
+      return callbacks.hasKnownMemoryEffects(wrap(op));
+    return true;
+  }
+
 private:
   MlirMemoryEffectsOpInterfaceCallbacks callbacks;
 };

--- a/mlir/lib/CAPI/Interfaces/Interfaces.cpp
+++ b/mlir/lib/CAPI/Interfaces/Interfaces.cpp
@@ -176,6 +176,10 @@ MlirTypeID mlirMemoryEffectsOpInterfaceTypeID() {
   return wrap(MemoryEffectOpInterface::getInterfaceID());
 }
 
+bool mlirOperationImplementsMemoryEffectsOpInterface(MlirOperation operation) {
+  return isa<MemoryEffectOpInterface>(unwrap(operation));
+}
+
 /// Fallback model for the MemoryEffectsOpInterface that uses C API callbacks.
 class MemoryEffectOpInterfaceFallbackModel
     : public mlir::MemoryEffectOpInterface::FallbackModel<
@@ -215,7 +219,7 @@ public:
 
   bool hasKnownMemoryEffects(Operation *op) const {
     if (callbacks.hasKnownMemoryEffects)
-      return callbacks.hasKnownMemoryEffects(wrap(op));
+      return callbacks.hasKnownMemoryEffects(wrap(op), callbacks.userData);
     return true;
   }
 

--- a/mlir/test/Analysis/test-alias-analysis-modref.mlir
+++ b/mlir/test/Analysis/test-alias-analysis-modref.mlir
@@ -89,3 +89,37 @@ func.func @addressable_write(%arg: memref<2xf32>) attributes {test.ptr = "func"}
   "test.side_effect_op"() {effects = [{effect="write"}], test.ptr = "side_effect_op"} : () -> i32
   return {test.ptr = "return"}
 }
+
+// -----
+
+// An op with known empty effects does not mod-ref any memory.
+// CHECK-LABEL: Testing : "optional_known_no_effects"
+// CHECK-DAG: optional_side_effect_op -> func.region0#0: NoModRef
+// CHECK-DAG: return -> func.region0#0: NoModRef
+func.func @optional_known_no_effects(%arg: memref<2xf32>) attributes {test.ptr = "func"} {
+  "test.optional_side_effect_op"() {effects = [], test.ptr = "optional_side_effect_op"} : () -> i32
+  return {test.ptr = "return"}
+}
+
+// -----
+
+// An op with unknown effects (no effects attr, hasKnownMemoryEffects = false)
+// is treated conservatively -> ModRef.
+// CHECK-LABEL: Testing : "optional_unknown_effects"
+// CHECK-DAG: optional_side_effect_op -> func.region0#0: ModRef
+// CHECK-DAG: return -> func.region0#0: NoModRef
+func.func @optional_unknown_effects(%arg: memref<2xf32>) attributes {test.ptr = "func"} {
+  "test.optional_side_effect_op"() {test.ptr = "optional_side_effect_op"} : () -> i32
+  return {test.ptr = "return"}
+}
+
+// -----
+
+// An op with a known read effect on an addressable resource -> Ref only.
+// CHECK-LABEL: Testing : "optional_known_read"
+// CHECK-DAG: optional_side_effect_op -> func.region0#0: Ref
+// CHECK-DAG: return -> func.region0#0: NoModRef
+func.func @optional_known_read(%arg: memref<2xf32>) attributes {test.ptr = "func"} {
+  "test.optional_side_effect_op"() {effects = [{effect="read"}], test.ptr = "optional_side_effect_op"} : () -> i32
+  return {test.ptr = "return"}
+}

--- a/mlir/test/IR/test-external-side-effects.mlir
+++ b/mlir/test/IR/test-external-side-effects.mlir
@@ -1,0 +1,22 @@
+// RUN: mlir-opt %s -test-external-side-effects -verify-diagnostics
+
+func.func @external_side_effects() {
+  // effects attr present but empty: hasKnownMemoryEffects = true, no effects.
+  // expected-remark@+2 {{implements MemoryEffectOpInterface: true}}
+  // expected-remark@+1 {{operation has no memory effects}}
+  %0 = "test.external_side_effect_op"() {effects = []} : () -> i32
+
+  // No effects attr: hasKnownMemoryEffects = false, isa<> returns false.
+  // expected-remark@+1 {{implements MemoryEffectOpInterface: false}}
+  %1 = "test.external_side_effect_op"() {} : () -> i32
+
+  // effects attr with read+write: hasKnownMemoryEffects = true, known effects.
+  // expected-remark@+3 {{implements MemoryEffectOpInterface: true}}
+  // expected-remark@+2 {{found an instance of 'read' on resource '<Default>'}}
+  // expected-remark@+1 {{found an instance of 'write' on resource '<Default>'}}
+  %2 = "test.external_side_effect_op"() {effects = [
+    {effect="read"}, {effect="write"}
+  ]} : () -> i32
+
+  func.return
+}

--- a/mlir/test/IR/test-side-effects.mlir
+++ b/mlir/test/IR/test-side-effects.mlir
@@ -56,5 +56,20 @@ func.func @side_effect(%arg : index) {
     test.region_yield %arg0 : index 
   } {effects = [ {effect="allocate", on_argument, test_resource} ]} : index -> index
 
+  // Known to have no memory effects (effects attr present but empty).
+  // expected-remark@+1 {{operation has no memory effects}}
+  %9 = "test.optional_side_effect_op"() {effects = []} : () -> i32
+
+  // Unknown effects (no effects attr) — the op does not cast to
+  // MemoryEffectOpInterface so the walk skips it; no diagnostic expected.
+  %10 = "test.optional_side_effect_op"() {} : () -> i32
+
+  // Known specific effects: read and write on <Default>.
+  // expected-remark@+2 {{found an instance of 'read' on resource '<Default>'}}
+  // expected-remark@+1 {{found an instance of 'write' on resource '<Default>'}}
+  %11 = "test.optional_side_effect_op"() {effects = [
+    {effect="read"}, {effect="write"}
+  ]} : () -> i32
+
   func.return 
 }

--- a/mlir/test/lib/Dialect/Test/TestOpDefs.cpp
+++ b/mlir/test/lib/Dialect/Test/TestOpDefs.cpp
@@ -501,6 +501,35 @@ void SideEffectOp::getEffects(
   testSideEffectOpGetEffect(getOperation(), effects);
 }
 
+//===----------------------------------------------------------------------===//
+// OptionalSideEffectOp
+//===----------------------------------------------------------------------===//
+
+bool OptionalSideEffectOp::hasKnownMemoryEffects() {
+  return (*this)->hasAttr("effects");
+}
+
+void OptionalSideEffectOp::getEffects(
+    SmallVectorImpl<MemoryEffects::EffectInstance> &effects) {
+  ArrayAttr effectsAttr = (*this)->getAttrOfType<ArrayAttr>("effects");
+  if (!effectsAttr)
+    return;
+
+  for (Attribute element : effectsAttr) {
+    DictionaryAttr effectElement = cast<DictionaryAttr>(element);
+
+    MemoryEffects::Effect *effect =
+        StringSwitch<MemoryEffects::Effect *>(
+            cast<StringAttr>(effectElement.get("effect")).getValue())
+            .Case("allocate", MemoryEffects::Allocate::get())
+            .Case("free", MemoryEffects::Free::get())
+            .Case("read", MemoryEffects::Read::get())
+            .Case("write", MemoryEffects::Write::get());
+
+    effects.emplace_back(effect, SideEffects::DefaultResource::get());
+  }
+}
+
 void SideEffectWithRegionOp::getEffects(
     SmallVectorImpl<MemoryEffects::EffectInstance> &effects) {
   // Check for an effects attribute on the op instance.

--- a/mlir/test/lib/Dialect/Test/TestOps.td
+++ b/mlir/test/lib/Dialect/Test/TestOps.td
@@ -2472,6 +2472,13 @@ def SideEffectOp : TEST_Op<"side_effect_op",
   let results = (outs AnyType:$result);
 }
 
+def OptionalSideEffectOp
+    : TEST_Op<"optional_side_effect_op",
+              [DeclareOpInterfaceMethods<
+                  MemoryEffectsOpInterface, ["hasKnownMemoryEffects"]>]> {
+  let results = (outs AnyType:$result);
+}
+
 def SideEffectWithRegionOp : TEST_Op<"side_effect_with_region_op",
     [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
      DeclareOpInterfaceMethods<TestEffectOpInterface>]> {

--- a/mlir/test/lib/Dialect/Test/TestOps.td
+++ b/mlir/test/lib/Dialect/Test/TestOps.td
@@ -2479,6 +2479,10 @@ def OptionalSideEffectOp
   let results = (outs AnyType:$result);
 }
 
+def ExternalSideEffectOp : TEST_Op<"external_side_effect_op"> {
+  let results = (outs AnyType:$result);
+}
+
 def SideEffectWithRegionOp : TEST_Op<"side_effect_with_region_op",
     [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
      DeclareOpInterfaceMethods<TestEffectOpInterface>]> {

--- a/mlir/test/lib/IR/TestSideEffects.cpp
+++ b/mlir/test/lib/IR/TestSideEffects.cpp
@@ -8,6 +8,7 @@
 
 #include "TestOps.h"
 #include "mlir/Pass/Pass.h"
+#include "llvm/ADT/StringSwitch.h"
 
 using namespace mlir;
 
@@ -80,8 +81,87 @@ struct SideEffectsPass
     });
   }
 };
+/// External model that attaches MemoryEffectOpInterface to
+/// ExternalSideEffectOp. The interface is optional: hasKnownMemoryEffects
+/// returns true only when the "effects" attribute is present.
+struct ExternalSideEffectModel
+    : public MemoryEffectOpInterface::ExternalModel<
+          ExternalSideEffectModel, test::ExternalSideEffectOp> {
+  void
+  getEffects(Operation *op,
+             SmallVectorImpl<MemoryEffects::EffectInstance> &effects) const {
+    ArrayAttr effectsAttr = op->getAttrOfType<ArrayAttr>("effects");
+    if (!effectsAttr)
+      return;
+    for (Attribute element : effectsAttr) {
+      DictionaryAttr effectElement = cast<DictionaryAttr>(element);
+      MemoryEffects::Effect *effect =
+          StringSwitch<MemoryEffects::Effect *>(
+              cast<StringAttr>(effectElement.get("effect")).getValue())
+              .Case("allocate", MemoryEffects::Allocate::get())
+              .Case("free", MemoryEffects::Free::get())
+              .Case("read", MemoryEffects::Read::get())
+              .Case("write", MemoryEffects::Write::get());
+      effects.emplace_back(effect, SideEffects::DefaultResource::get());
+    }
+  }
+
+  bool hasKnownMemoryEffects(Operation *op) const {
+    return op->hasAttr("effects");
+  }
+};
+
+struct ExternalSideEffectsPass
+    : public PassWrapper<ExternalSideEffectsPass, OperationPass<ModuleOp>> {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(ExternalSideEffectsPass)
+
+  StringRef getArgument() const final { return "test-external-side-effects"; }
+  StringRef getDescription() const final {
+    return "Test external model for MemoryEffectsOpInterface with "
+           "hasKnownMemoryEffects";
+  }
+  void runOnOperation() override {
+    auto module = getOperation();
+
+    // Attach the external model.
+    test::ExternalSideEffectOp::attachInterface<ExternalSideEffectModel>(
+        *module.getContext());
+
+    module.walk([&](Operation *op) {
+      if (op->hasTrait<OpTrait::IsTerminator>())
+        return;
+      if (!isa<test::ExternalSideEffectOp>(op))
+        return;
+
+      bool implements = isa<MemoryEffectOpInterface>(op);
+      op->emitRemark() << "implements MemoryEffectOpInterface: "
+                       << (implements ? "true" : "false");
+
+      if (implements) {
+        auto iface = cast<MemoryEffectOpInterface>(op);
+        SmallVector<MemoryEffects::EffectInstance, 8> effects;
+        iface.getEffects(effects);
+        if (effects.empty()) {
+          op->emitRemark() << "operation has no memory effects";
+        }
+        for (auto &instance : effects) {
+          auto diag = op->emitRemark() << "found an instance of ";
+          if (isa<MemoryEffects::Read>(instance.getEffect()))
+            diag << "'read'";
+          else if (isa<MemoryEffects::Write>(instance.getEffect()))
+            diag << "'write'";
+          diag << " on resource '" << instance.getResource()->getName() << "'";
+        }
+      }
+    });
+  }
+};
+
 } // namespace
 
 namespace mlir {
-void registerSideEffectTestPasses() { PassRegistration<SideEffectsPass>(); }
+void registerSideEffectTestPasses() {
+  PassRegistration<SideEffectsPass>();
+  PassRegistration<ExternalSideEffectsPass>();
+}
 } // namespace mlir

--- a/mlir/test/python/dialects/memory_effects_interface.py
+++ b/mlir/test/python/dialects/memory_effects_interface.py
@@ -45,9 +45,7 @@ def test_known_no_effects():
     and the interface is active."""
     with ir.Context() as ctx, ir.Location.unknown():
         TestMemEffectsDialect.load(reload=True)
-        OptionalMemoryEffectsModel.attach(
-            OptionalEffectsOp.OPERATION_NAME, context=ctx
-        )
+        OptionalMemoryEffectsModel.attach(OptionalEffectsOp.OPERATION_NAME, context=ctx)
 
         module = ir.Module.create()
         with ir.InsertionPoint(module.body):
@@ -65,9 +63,7 @@ def test_unknown_effects():
     and the interface is not active (the op pretends not to implement it)."""
     with ir.Context() as ctx, ir.Location.unknown():
         TestMemEffectsDialect.load(reload=True)
-        OptionalMemoryEffectsModel.attach(
-            OptionalEffectsOp.OPERATION_NAME, context=ctx
-        )
+        OptionalMemoryEffectsModel.attach(OptionalEffectsOp.OPERATION_NAME, context=ctx)
 
         module = ir.Module.create()
         with ir.InsertionPoint(module.body):

--- a/mlir/test/python/dialects/memory_effects_interface.py
+++ b/mlir/test/python/dialects/memory_effects_interface.py
@@ -1,0 +1,77 @@
+# RUN: %PYTHON %s | FileCheck %s
+
+from mlir import ir
+from mlir.dialects import ext
+
+
+class TestMemEffectsDialect(ext.Dialect, name="test_mem_effects"):
+    pass
+
+
+class OptionalEffectsOp(TestMemEffectsDialect.Operation, name="optional_effects"):
+    pass
+
+
+def run(f):
+    print("\nTEST:", f.__name__)
+    f()
+    return f
+
+
+class OptionalMemoryEffectsModel(ir.MemoryEffectsOpInterface):
+    """MemoryEffectsOpInterface that is only active when 'effects' attr is present."""
+
+    @staticmethod
+    def has_known_memory_effects(op):
+        return "effects" in op.attributes
+
+    @staticmethod
+    def get_effects(op, effects):
+        pass
+
+
+def implements_memory_effects(op):
+    try:
+        ir.MemoryEffectsOpInterface(op)
+        return True
+    except ValueError:
+        return False
+
+
+# CHECK-LABEL: TEST: test_known_no_effects
+@run
+def test_known_no_effects():
+    """When 'effects' attribute is present, hasKnownMemoryEffects returns true
+    and the interface is active."""
+    with ir.Context() as ctx, ir.Location.unknown():
+        TestMemEffectsDialect.load(reload=True)
+        OptionalMemoryEffectsModel.attach(
+            OptionalEffectsOp.OPERATION_NAME, context=ctx
+        )
+
+        module = ir.Module.create()
+        with ir.InsertionPoint(module.body):
+            op = ir.Operation.create("test_mem_effects.optional_effects")
+            op.attributes["effects"] = ir.UnitAttr.get()
+
+        # CHECK: implements MemoryEffectsOpInterface: True
+        print(f"implements MemoryEffectsOpInterface: {implements_memory_effects(op)}")
+
+
+# CHECK-LABEL: TEST: test_unknown_effects
+@run
+def test_unknown_effects():
+    """When 'effects' attribute is absent, hasKnownMemoryEffects returns false
+    and the interface is not active (the op pretends not to implement it)."""
+    with ir.Context() as ctx, ir.Location.unknown():
+        TestMemEffectsDialect.load(reload=True)
+        OptionalMemoryEffectsModel.attach(
+            OptionalEffectsOp.OPERATION_NAME, context=ctx
+        )
+
+        module = ir.Module.create()
+        with ir.InsertionPoint(module.body):
+            op = ir.Operation.create("test_mem_effects.optional_effects")
+
+        # CHECK: implements MemoryEffectsOpInterface: False
+        print(f"implements MemoryEffectsOpInterface: {implements_memory_effects(op)}")


### PR DESCRIPTION
For some instances of operations like calls it may be possible to report
specific memory effects and report "unknown" memory effects for other
instances. This patch makes MemoryEffectsOpInterface optional,
so that operations may implement it based on the particular instance.

RFC: https://discourse.llvm.org/t/rfc-mlir-memory-region-hierarchy-for-mlir-side-effects/89811/32