### PR TITLE
[TabelGen] Use ID{n-m} for outer let statements

### DIFF
--- a/llvm/docs/ReleaseNotes.md
+++ b/llvm/docs/ReleaseNotes.md
@@ -96,6 +96,9 @@ Changes to building LLVM
 Changes to TableGen
 -------------------
 
+* Outer let statements use ``ID{n-m}`` instead of ``ID<n-m>`` to be consistent
+  with inner let statements.
+
 Changes to Interprocedural Optimizations
 ----------------------------------------
 

--- a/llvm/docs/TableGen/ProgRef.rst
+++ b/llvm/docs/TableGen/ProgRef.rst
@@ -923,7 +923,7 @@ statements within the scope of the ``let``.
    Let:  "let" `LetList` "in" "{" `Statement`* "}"
       :| "let" `LetList` "in" `Statement`
    LetList: `LetItem` ("," `LetItem`)*
-   LetItem: [`LetMode`] `TokIdentifier` ["<" `RangeList` ">"] "=" `Value`
+   LetItem: [`LetMode`] `TokIdentifier` ["{" `RangeList` "}"] "=" `Value`
 
 The ``let`` statement establishes a scope, which is a sequence of statements
 in braces or a single statement with no braces. The bindings in the

--- a/llvm/docs/TableGen/ProgRef.rst
+++ b/llvm/docs/TableGen/ProgRef.rst
@@ -340,10 +340,10 @@ to an entity of type ``bits<4>``.
 .. productionlist::
    Value: `SimpleValue` `ValueSuffix`*
         :| `Value` "#" [`Value`]
-   ValueSuffix: "{" `RangeList` "}"
+   ValueSuffix: `RangeList`
               :| "[" `SliceElements` "]"
               :| "." `TokIdentifier`
-   RangeList: `RangePiece` ("," `RangePiece`)*
+   RangeList: "{" `RangePiece` ("," `RangePiece`)* "}"
    RangePiece: `TokInteger`
              :| `TokInteger` "..." `TokInteger`
              :| `TokInteger` "-" `TokInteger`
@@ -686,7 +686,7 @@ arguments.
 .. productionlist::
    Body: ";" | "{" `BodyItem`* "}"
    BodyItem: `Type` `TokIdentifier` ["=" `Value`] ";"
-           :| "let" [`LetMode`] `TokIdentifier` ["{" `RangeList` "}"] "=" `Value` ";"
+           :| "let" [`LetMode`] `TokIdentifier` [`RangeList`] "=" `Value` ";"
            :| "defvar" `TokIdentifier` "=" `Value` ";"
            :| `Assert`
    LetMode: "append" | "prepend"
@@ -923,7 +923,7 @@ statements within the scope of the ``let``.
    Let:  "let" `LetList` "in" "{" `Statement`* "}"
       :| "let" `LetList` "in" `Statement`
    LetList: `LetItem` ("," `LetItem`)*
-   LetItem: [`LetMode`] `TokIdentifier` ["{" `RangeList` "}"] "=" `Value`
+   LetItem: [`LetMode`] `TokIdentifier` [`RangeList`] "=" `Value`
 
 The ``let`` statement establishes a scope, which is a sequence of statements
 in braces or a single statement with no braces. The bindings in the
@@ -1321,7 +1321,7 @@ variable over a sequence of values.
 .. productionlist::
    Foreach: "foreach" `ForeachIterator` "in" "{" `Statement`* "}"
           :| "foreach" `ForeachIterator` "in" `Statement`
-   ForeachIterator: `TokIdentifier` "=" ("{" `RangeList` "}" | `RangePiece` | `Value`)
+   ForeachIterator: `TokIdentifier` "=" (`RangeList` | `RangePiece` | `Value`)
 
 The body of the ``foreach`` is a series of statements in braces or a
 single statement with no braces. The statements are re-evaluated once for

--- a/llvm/lib/TableGen/TGParser.cpp
+++ b/llvm/lib/TableGen/TGParser.cpp
@@ -1089,29 +1089,9 @@ void TGParser::ParseRangeList(SmallVectorImpl<unsigned> &Result) {
 }
 
 /// ParseOptionalRangeList - Parse either a range list in <>'s or nothing.
-///   OptionalRangeList ::= '<' RangeList '>'
+///   OptionalRangeList ::= '{' RangeList '}'
 ///   OptionalRangeList ::= /*empty*/
 bool TGParser::ParseOptionalRangeList(SmallVectorImpl<unsigned> &Ranges) {
-  SMLoc StartLoc = Lex.getLoc();
-  if (!consume(tgtok::less))
-    return false;
-
-  // Parse the range list.
-  ParseRangeList(Ranges);
-  if (Ranges.empty())
-    return true;
-
-  if (!consume(tgtok::greater)) {
-    TokError("expected '>' at end of range list");
-    return Error(StartLoc, "to match this '<'");
-  }
-  return false;
-}
-
-/// ParseOptionalBitList - Parse either a bit list in {}'s or nothing.
-///   OptionalBitList ::= '{' RangeList '}'
-///   OptionalBitList ::= /*empty*/
-bool TGParser::ParseOptionalBitList(SmallVectorImpl<unsigned> &Ranges) {
   SMLoc StartLoc = Lex.getLoc();
   if (!consume(tgtok::l_brace))
     return false;
@@ -3687,7 +3667,7 @@ LetModeAndName TGParser::ParseLetModeAndName() {
 /// ParseBodyItem - Parse a single item within the body of a def or class.
 ///
 ///   BodyItem ::= Declaration ';'
-///   BodyItem ::= LET [append|prepend] ID OptionalBitList '=' Value ';'
+///   BodyItem ::= LET [append|prepend] ID OptionalRangeList '=' Value ';'
 ///   BodyItem ::= Defvar
 ///   BodyItem ::= Dump
 ///   BodyItem ::= Assert
@@ -3721,7 +3701,7 @@ bool TGParser::ParseBodyItem(Record *CurRec) {
   const StringInit *FieldName = StringInit::get(Records, FieldNameStr);
 
   SmallVector<unsigned, 16> BitList;
-  if (ParseOptionalBitList(BitList))
+  if (ParseOptionalRangeList(BitList))
     return true;
   std::reverse(BitList.begin(), BitList.end());
 

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoXRivos.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoXRivos.td
@@ -62,7 +62,7 @@ class CustomRivosXVI<bits<6> funct6, RISCVVFormat opv, dag outs, dag ins,
 
 let Predicates = [HasVendorXRivosVizip], DecoderNamespace = "XRivos",
   Constraints = "@earlyclobber $vd", VS1VS2Constraint = Vrgather,
-  Inst<6-0> = OPC_CUSTOM_2.Value, ReadsPastVL = 1,
+  Inst{6-0} = OPC_CUSTOM_2.Value, ReadsPastVL = 1,
   ElementsDependOn = EltDepsNone in  {
 defm RI_VZIPEVEN_V : VALU_IV_V<"ri.vzipeven", 0b001100>;
 defm RI_VZIPODD_V : VALU_IV_V<"ri.vzipodd", 0b011100>;


### PR DESCRIPTION
I found this occasionally.

For outer let statements, if we want to override some bits, we specify
the range list in the form of `<n-m>`. But for inner let statements,
we use `{n-m}`.

This is inconsistent, and I can't find the reason why it is designed
as this. So here we make inner/outer let statements consistent and
remove the duplicated parsing functions.

There is only one in-tree usage so I think the impact is small.
