### PR TITLE
[HLSL][DXIL][SPIRV] QuadReadAcrossY intrinsic support

### DIFF
--- a/clang/include/clang/Basic/Builtins.td
+++ b/clang/include/clang/Basic/Builtins.td
@@ -5276,6 +5276,12 @@ def HLSLQuadReadAcrossX : LangBuiltin<"HLSL_LANG"> {
   let Prototype = "void(...)";
 }
 
+def HLSLQuadReadAcrossY : LangBuiltin<"HLSL_LANG"> {
+  let Spellings = ["__builtin_hlsl_quad_read_across_y"];
+  let Attributes = [NoThrow, Const];
+  let Prototype = "void(...)";
+}
+
 def HLSLClamp : LangBuiltin<"HLSL_LANG"> {
   let Spellings = ["__builtin_hlsl_elementwise_clamp"];
   let Attributes = [NoThrow, Const, CustomTypeChecking];

--- a/clang/lib/CodeGen/CGHLSLBuiltins.cpp
+++ b/clang/lib/CodeGen/CGHLSLBuiltins.cpp
@@ -1437,6 +1437,13 @@ Value *CodeGenFunction::EmitHLSLBuiltinExpr(unsigned BuiltinID,
                                &CGM.getModule(), ID, {OpExpr->getType()}),
                            ArrayRef{OpExpr}, "hlsl.quad.read.across.x");
   }
+  case Builtin::BI__builtin_hlsl_quad_read_across_y: {
+    Value *OpExpr = EmitScalarExpr(E->getArg(0));
+    Intrinsic::ID ID = CGM.getHLSLRuntime().getQuadReadAcrossYIntrinsic();
+    return EmitRuntimeCall(Intrinsic::getOrInsertDeclaration(
+                               &CGM.getModule(), ID, {OpExpr->getType()}),
+                           ArrayRef{OpExpr}, "hlsl.quad.read.across.y");
+  }
   case Builtin::BI__builtin_hlsl_elementwise_sign: {
     auto *Arg0 = E->getArg(0);
     Value *Op0 = EmitScalarExpr(Arg0);

--- a/clang/lib/CodeGen/CGHLSLRuntime.h
+++ b/clang/lib/CodeGen/CGHLSLRuntime.h
@@ -158,6 +158,7 @@ public:
   GENERATE_HLSL_INTRINSIC_FUNCTION(WaveGetLaneCount, wave_get_lane_count)
   GENERATE_HLSL_INTRINSIC_FUNCTION(WaveReadLaneAt, wave_readlane)
   GENERATE_HLSL_INTRINSIC_FUNCTION(QuadReadAcrossX, quad_read_across_x)
+  GENERATE_HLSL_INTRINSIC_FUNCTION(QuadReadAcrossY, quad_read_across_y)
   GENERATE_HLSL_INTRINSIC_FUNCTION(FirstBitUHigh, firstbituhigh)
   GENERATE_HLSL_INTRINSIC_FUNCTION(FirstBitSHigh, firstbitshigh)
   GENERATE_HLSL_INTRINSIC_FUNCTION(FirstBitLow, firstbitlow)

--- a/clang/lib/Headers/hlsl/hlsl_alias_intrinsics.h
+++ b/clang/lib/Headers/hlsl/hlsl_alias_intrinsics.h
@@ -3605,6 +3605,105 @@ _HLSL_BUILTIN_ALIAS(__builtin_hlsl_quad_read_across_x)
 __attribute__((convergent)) double4 QuadReadAcrossX(double4);
 
 //===----------------------------------------------------------------------===//
+// QuadReadAcrossY builtins
+//===----------------------------------------------------------------------===//
+
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
+_HLSL_BUILTIN_ALIAS(__builtin_hlsl_quad_read_across_y)
+__attribute__((convergent)) half QuadReadAcrossY(half);
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
+_HLSL_BUILTIN_ALIAS(__builtin_hlsl_quad_read_across_y)
+__attribute__((convergent)) half2 QuadReadAcrossY(half2);
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
+_HLSL_BUILTIN_ALIAS(__builtin_hlsl_quad_read_across_y)
+__attribute__((convergent)) half3 QuadReadAcrossY(half3);
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
+_HLSL_BUILTIN_ALIAS(__builtin_hlsl_quad_read_across_y)
+__attribute__((convergent)) half4 QuadReadAcrossY(half4);
+
+#ifdef __HLSL_ENABLE_16_BIT
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
+_HLSL_BUILTIN_ALIAS(__builtin_hlsl_quad_read_across_y)
+__attribute__((convergent)) int16_t QuadReadAcrossY(int16_t);
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
+_HLSL_BUILTIN_ALIAS(__builtin_hlsl_quad_read_across_y)
+__attribute__((convergent)) int16_t2 QuadReadAcrossY(int16_t2);
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
+_HLSL_BUILTIN_ALIAS(__builtin_hlsl_quad_read_across_y)
+__attribute__((convergent)) int16_t3 QuadReadAcrossY(int16_t3);
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
+_HLSL_BUILTIN_ALIAS(__builtin_hlsl_quad_read_across_y)
+__attribute__((convergent)) int16_t4 QuadReadAcrossY(int16_t4);
+
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
+_HLSL_BUILTIN_ALIAS(__builtin_hlsl_quad_read_across_y)
+__attribute__((convergent)) uint16_t QuadReadAcrossY(uint16_t);
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
+_HLSL_BUILTIN_ALIAS(__builtin_hlsl_quad_read_across_y)
+__attribute__((convergent)) uint16_t2 QuadReadAcrossY(uint16_t2);
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
+_HLSL_BUILTIN_ALIAS(__builtin_hlsl_quad_read_across_y)
+__attribute__((convergent)) uint16_t3 QuadReadAcrossY(uint16_t3);
+_HLSL_16BIT_AVAILABILITY_SHADERMODEL_DEFAULT()
+_HLSL_BUILTIN_ALIAS(__builtin_hlsl_quad_read_across_y)
+__attribute__((convergent)) uint16_t4 QuadReadAcrossY(uint16_t4);
+#endif
+
+_HLSL_BUILTIN_ALIAS(__builtin_hlsl_quad_read_across_y)
+__attribute__((convergent)) int QuadReadAcrossY(int);
+_HLSL_BUILTIN_ALIAS(__builtin_hlsl_quad_read_across_y)
+__attribute__((convergent)) int2 QuadReadAcrossY(int2);
+_HLSL_BUILTIN_ALIAS(__builtin_hlsl_quad_read_across_y)
+__attribute__((convergent)) int3 QuadReadAcrossY(int3);
+_HLSL_BUILTIN_ALIAS(__builtin_hlsl_quad_read_across_y)
+__attribute__((convergent)) int4 QuadReadAcrossY(int4);
+
+_HLSL_BUILTIN_ALIAS(__builtin_hlsl_quad_read_across_y)
+__attribute__((convergent)) uint QuadReadAcrossY(uint);
+_HLSL_BUILTIN_ALIAS(__builtin_hlsl_quad_read_across_y)
+__attribute__((convergent)) uint2 QuadReadAcrossY(uint2);
+_HLSL_BUILTIN_ALIAS(__builtin_hlsl_quad_read_across_y)
+__attribute__((convergent)) uint3 QuadReadAcrossY(uint3);
+_HLSL_BUILTIN_ALIAS(__builtin_hlsl_quad_read_across_y)
+__attribute__((convergent)) uint4 QuadReadAcrossY(uint4);
+
+_HLSL_BUILTIN_ALIAS(__builtin_hlsl_quad_read_across_y)
+__attribute__((convergent)) int64_t QuadReadAcrossY(int64_t);
+_HLSL_BUILTIN_ALIAS(__builtin_hlsl_quad_read_across_y)
+__attribute__((convergent)) int64_t2 QuadReadAcrossY(int64_t2);
+_HLSL_BUILTIN_ALIAS(__builtin_hlsl_quad_read_across_y)
+__attribute__((convergent)) int64_t3 QuadReadAcrossY(int64_t3);
+_HLSL_BUILTIN_ALIAS(__builtin_hlsl_quad_read_across_y)
+__attribute__((convergent)) int64_t4 QuadReadAcrossY(int64_t4);
+
+_HLSL_BUILTIN_ALIAS(__builtin_hlsl_quad_read_across_y)
+__attribute__((convergent)) uint64_t QuadReadAcrossY(uint64_t);
+_HLSL_BUILTIN_ALIAS(__builtin_hlsl_quad_read_across_y)
+__attribute__((convergent)) uint64_t2 QuadReadAcrossY(uint64_t2);
+_HLSL_BUILTIN_ALIAS(__builtin_hlsl_quad_read_across_y)
+__attribute__((convergent)) uint64_t3 QuadReadAcrossY(uint64_t3);
+_HLSL_BUILTIN_ALIAS(__builtin_hlsl_quad_read_across_y)
+__attribute__((convergent)) uint64_t4 QuadReadAcrossY(uint64_t4);
+
+_HLSL_BUILTIN_ALIAS(__builtin_hlsl_quad_read_across_y)
+__attribute__((convergent)) float QuadReadAcrossY(float);
+_HLSL_BUILTIN_ALIAS(__builtin_hlsl_quad_read_across_y)
+__attribute__((convergent)) float2 QuadReadAcrossY(float2);
+_HLSL_BUILTIN_ALIAS(__builtin_hlsl_quad_read_across_y)
+__attribute__((convergent)) float3 QuadReadAcrossY(float3);
+_HLSL_BUILTIN_ALIAS(__builtin_hlsl_quad_read_across_y)
+__attribute__((convergent)) float4 QuadReadAcrossY(float4);
+
+_HLSL_BUILTIN_ALIAS(__builtin_hlsl_quad_read_across_y)
+__attribute__((convergent)) double QuadReadAcrossY(double);
+_HLSL_BUILTIN_ALIAS(__builtin_hlsl_quad_read_across_y)
+__attribute__((convergent)) double2 QuadReadAcrossY(double2);
+_HLSL_BUILTIN_ALIAS(__builtin_hlsl_quad_read_across_y)
+__attribute__((convergent)) double3 QuadReadAcrossY(double3);
+_HLSL_BUILTIN_ALIAS(__builtin_hlsl_quad_read_across_y)
+__attribute__((convergent)) double4 QuadReadAcrossY(double4);
+
+//===----------------------------------------------------------------------===//
 // sign builtins
 //===----------------------------------------------------------------------===//
 

--- a/clang/lib/Sema/SemaHLSL.cpp
+++ b/clang/lib/Sema/SemaHLSL.cpp
@@ -4298,7 +4298,8 @@ bool SemaHLSL::CheckBuiltinFunctionCall(unsigned BuiltinID, CallExpr *TheCall) {
     TheCall->setType(ArgTyExpr);
     break;
   }
-  case Builtin::BI__builtin_hlsl_quad_read_across_x: {
+  case Builtin::BI__builtin_hlsl_quad_read_across_x:
+  case Builtin::BI__builtin_hlsl_quad_read_across_y: {
     if (SemaRef.checkArgCount(TheCall, 1))
       return true;
 

--- a/clang/test/CodeGenHLSL/builtins/QuadReadAcrossY.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/QuadReadAcrossY.hlsl
@@ -1,46 +1,171 @@
-// RUN: %clang_cc1 -std=hlsl2021 -finclude-default-header -triple \
-// RUN:   dxil-pc-shadermodel6.3-compute %s -emit-llvm -disable-llvm-passes -o - | \
-// RUN:   FileCheck %s --check-prefixes=CHECK,CHECK-DXIL
-// RUN: %clang_cc1 -std=hlsl2021 -finclude-default-header -triple \
-// RUN:   spirv-pc-vulkan-compute %s -emit-llvm -disable-llvm-passes -o - | \
-// RUN:   FileCheck %s --check-prefixes=CHECK,CHECK-SPIRV
+// RUN: %clang_cc1 -finclude-default-header -x hlsl -triple \
+// RUN:   dxil-pc-shadermodel6.3-compute %s -fnative-half-type -fnative-int16-type \
+// RUN:   -emit-llvm -disable-llvm-passes -o - | FileCheck %s \
+// RUN:   --check-prefixes=CHECK,CHECK-DXIL,CHECK-NATIVE_HALF
+// RUN: %clang_cc1 -finclude-default-header -x hlsl -triple \
+// RUN:   dxil-pc-shadermodel6.3-compute %s -emit-llvm -disable-llvm-passes \
+// RUN:   -o - | FileCheck %s --check-prefixes=CHECK,CHECK-DXIL,CHECK-NO_HALF
 
-// Test basic lowering to runtime function call.
+// RUN: %clang_cc1 -finclude-default-header -x hlsl -triple \
+// RUN:   spirv-unknown-vulkan-compute %s -fnative-half-type -fnative-int16-type \
+// RUN:   -emit-llvm -disable-llvm-passes -o - | FileCheck %s \
+// RUN:   --check-prefixes=CHECK,CHECK-SPIRV,CHECK-NATIVE_HALF
+// RUN: %clang_cc1 -finclude-default-header -x hlsl -triple \
+// RUN:   spirv-unknown-vulkan-compute %s -emit-llvm -disable-llvm-passes \
+// RUN:   -o - | FileCheck %s --check-prefixes=CHECK,CHECK-SPIRV,CHECK-NO_HALF
 
-// CHECK-LABEL: test_int
-int test_int(int expr) {
-  // CHECK-SPIRV:  %[[RET:.*]] = call spir_func [[TY:.*]] @llvm.spv.quad.read.across.y.i32([[TY]] %[[#]])
-  // CHECK-DXIL:  %[[RET:.*]] = call [[TY:.*]] @llvm.dx.quad.read.across.y.i32([[TY]] %[[#]])
-  // CHECK:  ret [[TY]] %[[RET]]
-  return QuadReadAcrossY(expr);
-}
+// Capture the expected interchange format so not every check needs to be duplicated
+// CHECK-DXIL: %[[RET:.*]] = call [[CC:]]i32 @llvm.[[ICF:dx]].quad.read.across.y.i32(i32 %[[#]])
+// CHECK-SPIRV: %[[RET:.*]] = call [[CC:spir_func ]]i32 @llvm.[[ICF:spv]].quad.read.across.y.i32(i32 %[[#]])
+// CHECK: ret i32 %[[RET]]
+int test_int(int expr) { return QuadReadAcrossY(expr); }
 
-// CHECK-DXIL: declare [[TY]] @llvm.dx.quad.read.across.y.i32([[TY]]) #[[#attr:]]
-// CHECK-SPIRV: declare [[TY]] @llvm.spv.quad.read.across.y.i32([[TY]]) #[[#attr:]]
+// CHECK: %[[RET:.*]] = call [[CC]]<2 x i32> @llvm.[[ICF]].quad.read.across.y.v2i32(<2 x i32> %[[#]])
+// CHECK: ret <2 x i32> %[[RET]]
+int2 test_int2(int2 expr) { return QuadReadAcrossY(expr); }
 
-// CHECK-LABEL: test_uint64_t
-uint64_t test_uint64_t(uint64_t expr) {
-  // CHECK-SPIRV:  %[[RET:.*]] = call spir_func [[TY:.*]] @llvm.spv.quad.read.across.y.i64([[TY]] %[[#]])
-  // CHECK-DXIL:  %[[RET:.*]] = call [[TY:.*]] @llvm.dx.quad.read.across.y.i64([[TY]] %[[#]])
-  // CHECK:  ret [[TY]] %[[RET]]
-  return QuadReadAcrossY(expr);
-}
+// CHECK: %[[RET:.*]] = call [[CC]]<3 x i32> @llvm.[[ICF]].quad.read.across.y.v3i32(<3 x i32> %[[#]])
+// CHECK: ret <3 x i32> %[[RET]]
+int3 test_int3(int3 expr) { return QuadReadAcrossY(expr); }
 
-// CHECK-DXIL: declare [[TY]] @llvm.dx.quad.read.across.y.i64([[TY]]) #[[#attr:]]
-// CHECK-SPIRV: declare [[TY]] @llvm.spv.quad.read.across.y.i64([[TY]]) #[[#attr:]]
+// CHECK: %[[RET:.*]] = call [[CC]]<4 x i32> @llvm.[[ICF]].quad.read.across.y.v4i32(<4 x i32> %[[#]])
+// CHECK: ret <4 x i32> %[[RET]]
+int4 test_int4(int4 expr) { return QuadReadAcrossY(expr); }
 
-// Test basic lowering to runtime function call with array and float value.
+// CHECK: %[[RET:.*]] = call [[CC]]i32 @llvm.[[ICF]].quad.read.across.y.i32(i32 %[[#]])
+// CHECK: ret i32 %[[RET]]
+uint test_uint(uint expr) { return QuadReadAcrossY(expr); }
 
-// CHECK-LABEL: test_floatv4
-float4 test_floatv4(float4 expr) {
-  // CHECK-SPIRV:  %[[RET1:.*]] = call reassoc nnan ninf nsz arcp afn spir_func [[TY1:.*]] @llvm.spv.quad.read.across.y.v4f32([[TY1]] %[[#]]
-  // CHECK-DXIL:  %[[RET1:.*]] = call reassoc nnan ninf nsz arcp afn [[TY1:.*]] @llvm.dx.quad.read.across.y.v4f32([[TY1]] %[[#]])
-  // CHECK:  ret [[TY1]] %[[RET1]]
-  return QuadReadAcrossY(expr);
-}
+// CHECK: %[[RET:.*]] = call [[CC]]<2 x i32> @llvm.[[ICF]].quad.read.across.y.v2i32(<2 x i32> %[[#]])
+// CHECK: ret <2 x i32> %[[RET]]
+uint2 test_uint2(uint2 expr) { return QuadReadAcrossY(expr); }
 
-// CHECK-DXIL: declare [[TY1]] @llvm.dx.quad.read.across.y.v4f32([[TY1]]) #[[#attr]]
-// CHECK-SPIRV: declare [[TY1]] @llvm.spv.quad.read.across.y.v4f32([[TY1]]) #[[#attr]]
+// CHECK: %[[RET:.*]] = call [[CC]]<3 x i32> @llvm.[[ICF]].quad.read.across.y.v3i32(<3 x i32> %[[#]])
+// CHECK: ret <3 x i32> %[[RET]]
+uint3 test_uint3(uint3 expr) { return QuadReadAcrossY(expr); }
 
-// CHECK: attributes #[[#attr]] = {{{.*}} convergent {{.*}}}
+// CHECK: %[[RET:.*]] = call [[CC]]<4 x i32> @llvm.[[ICF]].quad.read.across.y.v4i32(<4 x i32> %[[#]])
+// CHECK: ret <4 x i32> %[[RET]]
+uint4 test_uint4(uint4 expr) { return QuadReadAcrossY(expr); }
 
+// CHECK: %[[RET:.*]] = call [[CC]]i64 @llvm.[[ICF]].quad.read.across.y.i64(i64 %[[#]])
+// CHECK: ret i64 %[[RET]]
+int64_t test_int64_t(int64_t expr) { return QuadReadAcrossY(expr); }
+
+// CHECK: %[[RET:.*]] = call [[CC]]<2 x i64> @llvm.[[ICF]].quad.read.across.y.v2i64(<2 x i64> %[[#]])
+// CHECK: ret <2 x i64> %[[RET]]
+int64_t2 test_int64_t2(int64_t2 expr) { return QuadReadAcrossY(expr); }
+
+// CHECK: %[[RET:.*]] = call [[CC]]<3 x i64> @llvm.[[ICF]].quad.read.across.y.v3i64(<3 x i64> %[[#]])
+// CHECK: ret <3 x i64> %[[RET]]
+int64_t3 test_int64_t3(int64_t3 expr) { return QuadReadAcrossY(expr); }
+
+// CHECK: %[[RET:.*]] = call [[CC]]<4 x i64> @llvm.[[ICF]].quad.read.across.y.v4i64(<4 x i64> %[[#]])
+// CHECK: ret <4 x i64> %[[RET]]
+int64_t4 test_int64_t4(int64_t4 expr) { return QuadReadAcrossY(expr); }
+
+// CHECK: %[[RET:.*]] = call [[CC]]i64 @llvm.[[ICF]].quad.read.across.y.i64(i64 %[[#]])
+// CHECK: ret i64 %[[RET]]
+uint64_t test_uint64_t(uint64_t expr) { return QuadReadAcrossY(expr); }
+
+// CHECK: %[[RET:.*]] = call [[CC]]<2 x i64> @llvm.[[ICF]].quad.read.across.y.v2i64(<2 x i64> %[[#]])
+// CHECK: ret <2 x i64> %[[RET]]
+uint64_t2 test_uint64_t2(uint64_t2 expr) { return QuadReadAcrossY(expr); }
+
+// CHECK: %[[RET:.*]] = call [[CC]]<3 x i64> @llvm.[[ICF]].quad.read.across.y.v3i64(<3 x i64> %[[#]])
+// CHECK: ret <3 x i64> %[[RET]]
+uint64_t3 test_uint64_t3(uint64_t3 expr) { return QuadReadAcrossY(expr); }
+
+// CHECK: %[[RET:.*]] = call [[CC]]<4 x i64> @llvm.[[ICF]].quad.read.across.y.v4i64(<4 x i64> %[[#]])
+// CHECK: ret <4 x i64> %[[RET]]
+uint64_t4 test_uint64_t4(uint64_t4 expr) { return QuadReadAcrossY(expr); }
+
+// CHECK: %[[RET:.*]] = call reassoc nnan ninf nsz arcp afn [[CC]]float @llvm.[[ICF]].quad.read.across.y.f32(float %[[#]])
+// CHECK: ret float %[[RET]]
+float test_float(float expr) { return QuadReadAcrossY(expr); }
+
+// CHECK: %[[RET:.*]] = call reassoc nnan ninf nsz arcp afn [[CC]]<2 x float> @llvm.[[ICF]].quad.read.across.y.v2f32(<2 x float> %[[#]])
+// CHECK: ret <2 x float> %[[RET]]
+float2 test_float2(float2 expr) { return QuadReadAcrossY(expr); }
+
+// CHECK: %[[RET:.*]] = call reassoc nnan ninf nsz arcp afn [[CC]]<3 x float> @llvm.[[ICF]].quad.read.across.y.v3f32(<3 x float> %[[#]])
+// CHECK: ret <3 x float> %[[RET]]
+float3 test_float3(float3 expr) { return QuadReadAcrossY(expr); }
+
+// CHECK: %[[RET:.*]] = call reassoc nnan ninf nsz arcp afn [[CC]]<4 x float> @llvm.[[ICF]].quad.read.across.y.v4f32(<4 x float> %[[#]])
+// CHECK: ret <4 x float> %[[RET]]
+float4 test_float4(float4 expr) { return QuadReadAcrossY(expr); }
+
+// CHECK: %[[RET:.*]] = call reassoc nnan ninf nsz arcp afn [[CC]]double @llvm.[[ICF]].quad.read.across.y.f64(double %[[#]])
+// CHECK: ret double %[[RET]]
+double test_double(double expr) { return QuadReadAcrossY(expr); }
+
+// CHECK: %[[RET:.*]] = call reassoc nnan ninf nsz arcp afn [[CC]]<2 x double> @llvm.[[ICF]].quad.read.across.y.v2f64(<2 x double> %[[#]])
+// CHECK: ret <2 x double> %[[RET]]
+double2 test_double2(double2 expr) { return QuadReadAcrossY(expr); }
+
+// CHECK: %[[RET:.*]] = call reassoc nnan ninf nsz arcp afn [[CC]]<3 x double> @llvm.[[ICF]].quad.read.across.y.v3f64(<3 x double> %[[#]])
+// CHECK: ret <3 x double> %[[RET]]
+double3 test_double3(double3 expr) { return QuadReadAcrossY(expr); }
+
+// CHECK: %[[RET:.*]] = call reassoc nnan ninf nsz arcp afn [[CC]]<4 x double> @llvm.[[ICF]].quad.read.across.y.v4f64(<4 x double> %[[#]])
+// CHECK: ret <4 x double> %[[RET]]
+double4 test_double4(double4 expr) { return QuadReadAcrossY(expr); }
+
+// CHECK-NATIVE_HALF: %[[RET:.*]] = call reassoc nnan ninf nsz arcp afn [[CC]]half @llvm.[[ICF]].quad.read.across.y.f16(half %[[#]])
+// CHECK-NATIVE_HALF: ret half %[[RET]]
+// CHECK-NO_HALF: %[[RET:.*]] = call reassoc nnan ninf nsz arcp afn [[CC]]float @llvm.[[ICF]].quad.read.across.y.f32(float %[[#]])
+// CHECK-NO_HALF: ret float %[[RET]]
+half test_half(half expr) { return QuadReadAcrossY(expr); }
+
+// CHECK-NATIVE_HALF: %[[RET:.*]] = call reassoc nnan ninf nsz arcp afn [[CC]]<2 x half> @llvm.[[ICF]].quad.read.across.y.v2f16(<2 x half> %[[#]])
+// CHECK-NATIVE_HALF: ret <2 x half> %[[RET]]
+// CHECK-NO_HALF: %[[RET:.*]] = call reassoc nnan ninf nsz arcp afn [[CC]]<2 x float> @llvm.[[ICF]].quad.read.across.y.v2f32(<2 x float> %[[#]])
+// CHECK-NO_HALF: ret <2 x float> %[[RET]]
+half2 test_half2(half2 expr) { return QuadReadAcrossY(expr); }
+
+// CHECK-NATIVE_HALF: %[[RET:.*]] = call reassoc nnan ninf nsz arcp afn [[CC]]<3 x half> @llvm.[[ICF]].quad.read.across.y.v3f16(<3 x half> %[[#]])
+// CHECK-NATIVE_HALF: ret <3 x half> %[[RET]]
+// CHECK-NO_HALF: %[[RET:.*]] = call reassoc nnan ninf nsz arcp afn [[CC]]<3 x float> @llvm.[[ICF]].quad.read.across.y.v3f32(<3 x float> %[[#]])
+// CHECK-NO_HALF: ret <3 x float> %[[RET]]
+half3 test_half3(half3 expr) { return QuadReadAcrossY(expr); }
+
+// CHECK-NATIVE_HALF: %[[RET:.*]] = call reassoc nnan ninf nsz arcp afn [[CC]]<4 x half> @llvm.[[ICF]].quad.read.across.y.v4f16(<4 x half> %[[#]])
+// CHECK-NATIVE_HALF: ret <4 x half> %[[RET]]
+// CHECK-NO_HALF: %[[RET:.*]] = call reassoc nnan ninf nsz arcp afn [[CC]]<4 x float> @llvm.[[ICF]].quad.read.across.y.v4f32(<4 x float> %[[#]])
+// CHECK-NO_HALF: ret <4 x float> %[[RET]]
+half4 test_half4(half4 expr) { return QuadReadAcrossY(expr); }
+
+#ifdef __HLSL_ENABLE_16_BIT
+// CHECK-NATIVE_HALF: %[[RET:.*]] = call [[CC]]i16 @llvm.[[ICF]].quad.read.across.y.i16(i16 %[[#]])
+// CHECK-NATIVE_HALF: ret i16 %[[RET]]
+int16_t test_int16_t(int16_t expr) { return QuadReadAcrossY(expr); }
+
+// CHECK-NATIVE_HALF: %[[RET:.*]] = call [[CC]]<2 x i16> @llvm.[[ICF]].quad.read.across.y.v2i16(<2 x i16> %[[#]])
+// CHECK-NATIVE_HALF: ret <2 x i16> %[[RET]]
+int16_t2 test_int16_t2(int16_t2 expr) { return QuadReadAcrossY(expr); }
+
+// CHECK-NATIVE_HALF: %[[RET:.*]] = call [[CC]]<3 x i16> @llvm.[[ICF]].quad.read.across.y.v3i16(<3 x i16> %[[#]])
+// CHECK-NATIVE_HALF: ret <3 x i16> %[[RET]]
+int16_t3 test_int16_t3(int16_t3 expr) { return QuadReadAcrossY(expr); }
+
+// CHECK-NATIVE_HALF: %[[RET:.*]] = call [[CC]]<4 x i16> @llvm.[[ICF]].quad.read.across.y.v4i16(<4 x i16> %[[#]])
+// CHECK-NATIVE_HALF: ret <4 x i16> %[[RET]]
+int16_t4 test_int16_t4(int16_t4 expr) { return QuadReadAcrossY(expr); }
+
+// CHECK-NATIVE_HALF: %[[RET:.*]] = call [[CC]]i16 @llvm.[[ICF]].quad.read.across.y.i16(i16 %[[#]])
+// CHECK-NATIVE_HALF: ret i16 %[[RET]]
+uint16_t test_uint16_t(uint16_t expr) { return QuadReadAcrossY(expr); }
+
+// CHECK-NATIVE_HALF: %[[RET:.*]] = call [[CC]]<2 x i16> @llvm.[[ICF]].quad.read.across.y.v2i16(<2 x i16> %[[#]])
+// CHECK-NATIVE_HALF: ret <2 x i16> %[[RET]]
+uint16_t2 test_uint16_t2(uint16_t2 expr) { return QuadReadAcrossY(expr); }
+
+// CHECK-NATIVE_HALF: %[[RET:.*]] = call [[CC]]<3 x i16> @llvm.[[ICF]].quad.read.across.y.v3i16(<3 x i16> %[[#]])
+// CHECK-NATIVE_HALF: ret <3 x i16> %[[RET]]
+uint16_t3 test_uint16_t3(uint16_t3 expr) { return QuadReadAcrossY(expr); }
+
+// CHECK-NATIVE_HALF: %[[RET:.*]] = call [[CC]]<4 x i16> @llvm.[[ICF]].quad.read.across.y.v4i16(<4 x i16> %[[#]])
+// CHECK-NATIVE_HALF: ret <4 x i16> %[[RET]]
+uint16_t4 test_uint16_t4(uint16_t4 expr) { return QuadReadAcrossY(expr); }
+#endif

--- a/clang/test/CodeGenHLSL/builtins/QuadReadAcrossY.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/QuadReadAcrossY.hlsl
@@ -1,0 +1,46 @@
+// RUN: %clang_cc1 -std=hlsl2021 -finclude-default-header -triple \
+// RUN:   dxil-pc-shadermodel6.3-compute %s -emit-llvm -disable-llvm-passes -o - | \
+// RUN:   FileCheck %s --check-prefixes=CHECK,CHECK-DXIL
+// RUN: %clang_cc1 -std=hlsl2021 -finclude-default-header -triple \
+// RUN:   spirv-pc-vulkan-compute %s -emit-llvm -disable-llvm-passes -o - | \
+// RUN:   FileCheck %s --check-prefixes=CHECK,CHECK-SPIRV
+
+// Test basic lowering to runtime function call.
+
+// CHECK-LABEL: test_int
+int test_int(int expr) {
+  // CHECK-SPIRV:  %[[RET:.*]] = call spir_func [[TY:.*]] @llvm.spv.quad.read.across.y.i32([[TY]] %[[#]])
+  // CHECK-DXIL:  %[[RET:.*]] = call [[TY:.*]] @llvm.dx.quad.read.across.y.i32([[TY]] %[[#]])
+  // CHECK:  ret [[TY]] %[[RET]]
+  return QuadReadAcrossY(expr);
+}
+
+// CHECK-DXIL: declare [[TY]] @llvm.dx.quad.read.across.y.i32([[TY]]) #[[#attr:]]
+// CHECK-SPIRV: declare [[TY]] @llvm.spv.quad.read.across.y.i32([[TY]]) #[[#attr:]]
+
+// CHECK-LABEL: test_uint64_t
+uint64_t test_uint64_t(uint64_t expr) {
+  // CHECK-SPIRV:  %[[RET:.*]] = call spir_func [[TY:.*]] @llvm.spv.quad.read.across.y.i64([[TY]] %[[#]])
+  // CHECK-DXIL:  %[[RET:.*]] = call [[TY:.*]] @llvm.dx.quad.read.across.y.i64([[TY]] %[[#]])
+  // CHECK:  ret [[TY]] %[[RET]]
+  return QuadReadAcrossY(expr);
+}
+
+// CHECK-DXIL: declare [[TY]] @llvm.dx.quad.read.across.y.i64([[TY]]) #[[#attr:]]
+// CHECK-SPIRV: declare [[TY]] @llvm.spv.quad.read.across.y.i64([[TY]]) #[[#attr:]]
+
+// Test basic lowering to runtime function call with array and float value.
+
+// CHECK-LABEL: test_floatv4
+float4 test_floatv4(float4 expr) {
+  // CHECK-SPIRV:  %[[RET1:.*]] = call reassoc nnan ninf nsz arcp afn spir_func [[TY1:.*]] @llvm.spv.quad.read.across.y.v4f32([[TY1]] %[[#]]
+  // CHECK-DXIL:  %[[RET1:.*]] = call reassoc nnan ninf nsz arcp afn [[TY1:.*]] @llvm.dx.quad.read.across.y.v4f32([[TY1]] %[[#]])
+  // CHECK:  ret [[TY1]] %[[RET1]]
+  return QuadReadAcrossY(expr);
+}
+
+// CHECK-DXIL: declare [[TY1]] @llvm.dx.quad.read.across.y.v4f32([[TY1]]) #[[#attr]]
+// CHECK-SPIRV: declare [[TY1]] @llvm.spv.quad.read.across.y.v4f32([[TY1]]) #[[#attr]]
+
+// CHECK: attributes #[[#attr]] = {{{.*}} convergent {{.*}}}
+

--- a/clang/test/SemaHLSL/BuiltIns/QuadReadAcrossY-errors.hlsl
+++ b/clang/test/SemaHLSL/BuiltIns/QuadReadAcrossY-errors.hlsl
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -finclude-default-header -triple dxil-pc-shadermodel6.6-library %s -emit-llvm-only -disable-llvm-passes -verify
+// RUN: %clang_cc1 -finclude-default-header -triple dxil-pc-shadermodel6.6-library %s -verify
 
 int test_too_few_arg() {
   return __builtin_hlsl_quad_read_across_y();

--- a/clang/test/SemaHLSL/BuiltIns/QuadReadAcrossY-errors.hlsl
+++ b/clang/test/SemaHLSL/BuiltIns/QuadReadAcrossY-errors.hlsl
@@ -1,0 +1,28 @@
+// RUN: %clang_cc1 -finclude-default-header -triple dxil-pc-shadermodel6.6-library %s -emit-llvm-only -disable-llvm-passes -verify
+
+int test_too_few_arg() {
+  return __builtin_hlsl_quad_read_across_y();
+  // expected-error@-1 {{too few arguments to function call, expected 1, have 0}}
+}
+
+float2 test_too_many_arg(float2 p0) {
+  return __builtin_hlsl_quad_read_across_y(p0, p0);
+  // expected-error@-1 {{too many arguments to function call, expected 1, have 2}}
+}
+
+bool test_expr_bool_type_check(bool p0) {
+  return __builtin_hlsl_quad_read_across_y(p0);
+  // expected-error@-1 {{invalid operand of type 'bool'}}
+}
+
+bool2 test_expr_bool_vec_type_check(bool2 p0) {
+  return __builtin_hlsl_quad_read_across_y(p0);
+  // expected-error@-1 {{invalid operand of type 'bool2' (aka 'vector<bool, 2>')}}
+}
+
+struct S { float f; };
+
+S test_expr_struct_type_check(S p0) {
+  return __builtin_hlsl_quad_read_across_y(p0);
+  // expected-error@-1 {{invalid operand of type 'S' where a scalar or vector is required}}
+}

--- a/llvm/include/llvm/IR/IntrinsicsDirectX.td
+++ b/llvm/include/llvm/IR/IntrinsicsDirectX.td
@@ -255,6 +255,7 @@ def int_dx_wave_prefix_usum : DefaultAttrsIntrinsic<[llvm_anyint_ty], [LLVMMatch
 def int_dx_wave_prefix_product : DefaultAttrsIntrinsic<[llvm_any_ty], [LLVMMatchType<0>], [IntrConvergent, IntrNoMem]>;
 def int_dx_wave_prefix_uproduct : DefaultAttrsIntrinsic<[llvm_anyint_ty], [LLVMMatchType<0>], [IntrConvergent, IntrNoMem]>;
 def int_dx_quad_read_across_x : DefaultAttrsIntrinsic<[llvm_any_ty], [LLVMMatchType<0>], [IntrConvergent, IntrNoMem]>;
+def int_dx_quad_read_across_y : DefaultAttrsIntrinsic<[llvm_any_ty], [LLVMMatchType<0>], [IntrConvergent, IntrNoMem]>;
 def int_dx_sign : DefaultAttrsIntrinsic<[LLVMScalarOrSameVectorWidth<0, llvm_i32_ty>], [llvm_any_ty], [IntrNoMem]>;
 def int_dx_step : DefaultAttrsIntrinsic<[LLVMMatchType<0>], [llvm_anyfloat_ty, LLVMMatchType<0>], [IntrNoMem]>;
 def int_dx_splitdouble : DefaultAttrsIntrinsic<[llvm_anyint_ty, LLVMMatchType<0>],

--- a/llvm/include/llvm/IR/IntrinsicsSPIRV.td
+++ b/llvm/include/llvm/IR/IntrinsicsSPIRV.td
@@ -153,6 +153,7 @@ def int_spv_rsqrt : DefaultAttrsIntrinsic<[LLVMMatchType<0>], [llvm_anyfloat_ty]
   def int_spv_wave_prefix_sum : DefaultAttrsIntrinsic<[llvm_any_ty], [LLVMMatchType<0>], [IntrConvergent, IntrNoMem]>;
   def int_spv_wave_prefix_product : DefaultAttrsIntrinsic<[llvm_any_ty], [LLVMMatchType<0>], [IntrConvergent, IntrNoMem]>;
   def int_spv_quad_read_across_x : DefaultAttrsIntrinsic<[llvm_any_ty], [LLVMMatchType<0>], [IntrConvergent, IntrNoMem]>;
+  def int_spv_quad_read_across_y : DefaultAttrsIntrinsic<[llvm_any_ty], [LLVMMatchType<0>], [IntrConvergent, IntrNoMem]>;
   def int_spv_sign : DefaultAttrsIntrinsic<[LLVMScalarOrSameVectorWidth<0, llvm_i32_ty>], [llvm_any_ty], [IntrNoMem]>;
   def int_spv_radians : DefaultAttrsIntrinsic<[LLVMMatchType<0>], [llvm_anyfloat_ty], [IntrNoMem]>;
   def int_spv_group_memory_barrier_with_group_sync : ClangBuiltin<"__builtin_spirv_group_barrier">,

--- a/llvm/lib/Target/DirectX/DXIL.td
+++ b/llvm/lib/Target/DirectX/DXIL.td
@@ -1214,6 +1214,10 @@ def QuadOp : DXILOp<123, quadOp> {
                  [
                    IntrinArgIndex<0>, IntrinArgI8<QuadOpKind_ReadAcrossX>
                  ]>,
+    IntrinSelect<int_dx_quad_read_across_y,
+                 [
+                   IntrinArgIndex<0>, IntrinArgI8<QuadOpKind_ReadAcrossY>
+                 ]>,
   ];
 
   let arguments = [OverloadTy, Int8Ty];

--- a/llvm/lib/Target/DirectX/DXILShaderFlags.cpp
+++ b/llvm/lib/Target/DirectX/DXILShaderFlags.cpp
@@ -107,6 +107,7 @@ static bool checkWaveOps(Intrinsic::ID IID) {
   case Intrinsic::dx_wave_prefix_uproduct:
     // Quad Op Variants
   case Intrinsic::dx_quad_read_across_x:
+  case Intrinsic::dx_quad_read_across_y:
     return true;
   }
 }

--- a/llvm/lib/Target/DirectX/DirectXTargetTransformInfo.cpp
+++ b/llvm/lib/Target/DirectX/DirectXTargetTransformInfo.cpp
@@ -77,6 +77,7 @@ bool DirectXTTIImpl::isTargetIntrinsicTriviallyScalarizable(
   case Intrinsic::dx_wave_prefix_usum:
   case Intrinsic::dx_wave_prefix_uproduct:
   case Intrinsic::dx_quad_read_across_x:
+  case Intrinsic::dx_quad_read_across_y:
   case Intrinsic::dx_imad:
   case Intrinsic::dx_umad:
   case Intrinsic::dx_ddx_coarse:

--- a/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
@@ -4471,6 +4471,9 @@ bool SPIRVInstructionSelector::selectIntrinsic(Register ResVReg,
   case Intrinsic::spv_quad_read_across_x: {
     return selectQuadSwap(ResVReg, ResType, I, /*Direction*/ 0);
   }
+  case Intrinsic::spv_quad_read_across_y: {
+    return selectQuadSwap(ResVReg, ResType, I, /*Direction*/ 1);
+  }
   case Intrinsic::spv_step:
     return selectExtInst(ResVReg, ResType, I, CL::step, GL::Step);
   case Intrinsic::spv_radians:

--- a/llvm/test/CodeGen/DirectX/QuadReadAcrossY.ll
+++ b/llvm/test/CodeGen/DirectX/QuadReadAcrossY.ll
@@ -1,0 +1,87 @@
+; RUN: opt -S -scalarizer -dxil-op-lower -mtriple=dxil-pc-shadermodel6.3-library < %s | FileCheck %s
+
+; Test that for scalar values, QuadReadAcrossY maps down to the DirectX op
+
+define noundef half @quad_read_across_y_half(half noundef %expr) {
+entry:
+; CHECK: call half @dx.op.quadOp.f16(i32 123, half %expr, i8 1)
+  %ret = call half @llvm.dx.quad.read.across.y.f16(half %expr)
+  ret half %ret
+}
+
+define noundef float @quad_read_across_y_float(float noundef %expr) {
+entry:
+; CHECK: call float @dx.op.quadOp.f32(i32 123, float %expr, i8 1)
+  %ret = call float @llvm.dx.quad.read.across.y.f32(float %expr)
+  ret float %ret
+}
+
+define noundef double @quad_read_across_y_double(double noundef %expr) {
+entry:
+; CHECK: call double @dx.op.quadOp.f64(i32 123, double %expr, i8 1)
+  %ret = call double @llvm.dx.quad.read.across.y.f64(double %expr)
+  ret double %ret
+}
+
+define noundef i16 @quad_read_across_y_i16(i16 noundef %expr) {
+entry:
+; CHECK: call i16 @dx.op.quadOp.i16(i32 123, i16 %expr, i8 1)
+  %ret = call i16 @llvm.dx.quad.read.across.y.i16(i16 %expr)
+  ret i16 %ret
+}
+
+define noundef i32 @quad_read_across_y_i32(i32 noundef %expr) {
+entry:
+; CHECK: call i32 @dx.op.quadOp.i32(i32 123, i32 %expr, i8 1)
+  %ret = call i32 @llvm.dx.quad.read.across.y.i32(i32 %expr)
+  ret i32 %ret
+}
+
+define noundef i64 @quad_read_across_y_i64(i64 noundef %expr) {
+entry:
+; CHECK: call i64 @dx.op.quadOp.i64(i32 123, i64 %expr, i8 1)
+  %ret = call i64 @llvm.dx.quad.read.across.y.i64(i64 %expr)
+  ret i64 %ret
+}
+
+declare half @llvm.dx.quad.read.across.y.f16(half)
+declare float @llvm.dx.quad.read.across.y.f32(float)
+declare double @llvm.dx.quad.read.across.y.f64(double)
+
+declare i16 @llvm.dx.quad.read.across.y.i16(i16)
+declare i32 @llvm.dx.quad.read.across.y.i32(i32)
+declare i64 @llvm.dx.quad.read.across.y.i64(i64)
+
+; Test that for vector values, QuadReadAcrossY scalarizes and maps down to the
+; DirectX op
+
+define noundef <2 x half> @quad_read_across_y_v2half(<2 x half> noundef %expr) {
+entry:
+; CHECK: call half @dx.op.quadOp.f16(i32 123, half %expr.i0, i8 1)
+; CHECK: call half @dx.op.quadOp.f16(i32 123, half %expr.i1, i8 1)
+  %ret = call <2 x half> @llvm.dx.quad.read.across.y.v2f16(<2 x half> %expr)
+  ret <2 x half> %ret
+}
+
+define noundef <3 x i32> @quad_read_across_y_v3i32(<3 x i32> noundef %expr) {
+entry:
+; CHECK: call i32 @dx.op.quadOp.i32(i32 123, i32 %expr.i0, i8 1)
+; CHECK: call i32 @dx.op.quadOp.i32(i32 123, i32 %expr.i1, i8 1)
+; CHECK: call i32 @dx.op.quadOp.i32(i32 123, i32 %expr.i2, i8 1)
+  %ret = call <3 x i32> @llvm.dx.quad.read.across.y.v3i32(<3 x i32> %expr)
+  ret <3 x i32> %ret
+}
+
+define noundef <4 x double> @quad_read_across_y_v4f64(<4 x double> noundef %expr) {
+entry:
+; CHECK: call double @dx.op.quadOp.f64(i32 123, double %expr.i0, i8 1)
+; CHECK: call double @dx.op.quadOp.f64(i32 123, double %expr.i1, i8 1)
+; CHECK: call double @dx.op.quadOp.f64(i32 123, double %expr.i2, i8 1)
+; CHECK: call double @dx.op.quadOp.f64(i32 123, double %expr.i3, i8 1)
+  %ret = call <4 x double> @llvm.dx.quad.read.across.y.v464(<4 x double> %expr)
+  ret <4 x double> %ret
+}
+
+declare <2 x half> @llvm.dx.quad.read.across.y.v2f16(<2 x half>)
+declare <3 x i32> @llvm.dx.quad.read.across.y.v3i32(<3 x i32>)
+declare <4 x double> @llvm.dx.quad.read.across.y.v4f64(<4 x double>)

--- a/llvm/test/CodeGen/DirectX/ShaderFlags/wave-ops.ll
+++ b/llvm/test/CodeGen/DirectX/ShaderFlags/wave-ops.ll
@@ -181,3 +181,10 @@ entry:
   %ret = call i32 @llvm.dx.quad.read.across.x.i32(i32 %expr)
   ret i32 %ret
 }
+
+define noundef i32 @quad_read_across_y_i32(i32 noundef %expr) {
+entry:
+  ; CHECK: Function quad_read_across_y_i32 : [[WAVE_FLAG]]
+  %ret = call i32 @llvm.dx.quad.read.across.y.i32(i32 %expr)
+  ret i32 %ret
+}

--- a/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/QuadReadAcrossY.ll
+++ b/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/QuadReadAcrossY.ll
@@ -1,0 +1,44 @@
+; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv-vulkan-unknown %s -o - | FileCheck %s
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv-vulkan-unknown %s -o - -filetype=obj | spirv-val %}
+
+; Test lowering to spir-v backend for various types and scalar/vector
+
+; CHECK: OpCapability GroupNonUniformQuad
+
+; CHECK-DAG:   %[[#f16:]] = OpTypeFloat 16
+; CHECK-DAG:   %[[#f32:]] = OpTypeFloat 32
+; CHECK-DAG:   %[[#uint:]] = OpTypeInt 32 0
+; CHECK-DAG:   %[[#v4_half:]] = OpTypeVector %[[#f16]] 4
+; CHECK-DAG:   %[[#scope:]] = OpConstant %[[#uint]] 3
+; CHECK-DAG:   %[[#direction:]] = OpConstant %[[#uint]] 1
+
+; CHECK-LABEL: Begin function test_float
+; CHECK:   %[[#fexpr:]] = OpFunctionParameter %[[#f32]]
+define float @test_float(float %fexpr) {
+entry:
+; CHECK:   %[[#fret:]] = OpGroupNonUniformQuadSwap %[[#f32]] %[[#scope]] %[[#fexpr]] %[[#direction]]
+  %0 = call float @llvm.spv.quad.read.across.y.f32(float %fexpr)
+  ret float %0
+}
+
+; CHECK-LABEL: Begin function test_int
+; CHECK:   %[[#iexpr:]] = OpFunctionParameter %[[#uint]]
+define i32 @test_int(i32 %iexpr) {
+entry:
+; CHECK:   %[[#iret:]] = OpGroupNonUniformQuadSwap %[[#uint]] %[[#scope]] %[[#iexpr]] %[[#direction]]
+  %0 = call i32 @llvm.spv.quad.read.across.y.i32(i32 %iexpr)
+  ret i32 %0
+}
+
+; CHECK-LABEL: Begin function test_vhalf
+; CHECK:   %[[#vbexpr:]] = OpFunctionParameter %[[#v4_half]]
+define <4 x half> @test_vhalf(<4 x half> %vbexpr) {
+entry:
+; CHECK:   %[[#vhalfret:]] = OpGroupNonUniformQuadSwap %[[#v4_half]] %[[#scope]] %[[#vbexpr]] %[[#direction]]
+  %0 = call <4 x half> @llvm.spv.quad.read.across.y.v4half(<4 x half> %vbexpr)
+  ret <4 x half> %0
+}
+
+declare float @llvm.spv.quad.read.across.y.f32(float)
+declare i32 @llvm.spv.quad.read.across.y.i32(i32)
+declare <4 x half> @llvm.spv.quad.read.across.y.v4half(<4 x half>)


### PR DESCRIPTION
This PR adds QuadReadAcrossY intrinsic support in HLSL with codegen for both DirectX and SPIRV backends. Resolves https://github.com/llvm/llvm-project/issues/99176.

- [x] Implement `QuadReadAcrossY` clang builtin,
- [x] Link `QuadReadAcrossY` clang builtin with `hlsl_intrinsics.h`
- [x]  Add sema checks for `QuadReadAcrossY` to `CheckHLSLBuiltinFunctionCall` in `SemaChecking.cpp`
- [x]  Add codegen for `QuadReadAcrossY` to `EmitHLSLBuiltinExpr` in `CGBuiltin.cpp`
- [x]  Add codegen tests to `clang/test/CodeGenHLSL/builtins/QuadReadAcrossY.hlsl`
- [x]  Add sema tests to `clang/test/SemaHLSL/BuiltIns/QuadReadAcrossY-errors.hlsl`
- [x]  Create the `int_dx_QuadReadAcrossY` intrinsic in `IntrinsicsDirectX.td`
- [x]  Create the `DXILOpMapping` of `int_dx_QuadReadAcrossY` to  `123` in `DXIL.td`
- [x]  Create the  `QuadReadAcrossY.ll` and `QuadReadAcrossY_errors.ll` tests in `llvm/test/CodeGen/DirectX/`
- [x]  Create the `int_spv_QuadReadAcrossY` intrinsic in `IntrinsicsSPIRV.td`
- [x]  In SPIRVInstructionSelector.cpp create the `QuadReadAcrossY` lowering and map  it to `int_spv_QuadReadAcrossY` in `SPIRVInstructionSelector::selectIntrinsic`.
- [x]  Create SPIR-V backend test case in `llvm/test/CodeGen/SPIRV/hlsl-intrinsics/QuadReadAcrossY.ll`