### PR TITLE
[CompilationDatabase] Treat .cppm file as C++ in InterpolatingCompilationDatabase

### DIFF
--- a/clang/lib/Tooling/InterpolatingCompilationDatabase.cpp
+++ b/clang/lib/Tooling/InterpolatingCompilationDatabase.cpp
@@ -111,6 +111,8 @@ static types::ID foldType(types::ID Lang) {
     return types::TY_ObjC;
   case types::TY_CXX:
   case types::TY_CXXHeader:
+  case types::TY_CXXModule:
+  case types::TY_PP_CXXModule:
     return types::TY_CXX;
   case types::TY_ObjCXX:
   case types::TY_ObjCXXHeader:

--- a/clang/unittests/Tooling/CompilationDatabaseTest.cpp
+++ b/clang/unittests/Tooling/CompilationDatabaseTest.cpp
@@ -847,6 +847,11 @@ TEST_F(InterpolateTest, Language) {
             "clang -D dir/aux.cpp -x objective-c++-header -std=c++17");
 }
 
+TEST_F(InterpolateTest, CXX20Modules) {
+  add("dir/foo.cpp", "-std=c++20");
+  EXPECT_EQ(getCommand("dir/foo.cppm"), "clang -D dir/foo.cpp -std=c++20");
+}
+
 TEST_F(InterpolateTest, Strip) {
   add("dir/foo.cpp", "-o foo.o -Wall");
   // the -o option and the input file are removed, but -Wall is preserved.


### PR DESCRIPTION
Inspired by https://github.com/clangd/clangd/issues/2589

it seems like we lost the flag for "-std=c++26" there and we meet odd error messgae like the std ver is not correct. and it turns out we simply didn't interpret .cppm file as C++ in some corner of the codebase.