### PR TITLE
[libclc] Fix Unix Makefiles race condition in add_libclc_builtin_library

### DIFF
--- a/libclc/cmake/modules/AddLibclc.cmake
+++ b/libclc/cmake/modules/AddLibclc.cmake
@@ -57,7 +57,7 @@ function(add_libclc_builtin_library target_name)
   endforeach()
   list(REMOVE_DUPLICATES _inc_dirs)
 
-  add_library(${target_name} STATIC ${ARG_SOURCES})
+  add_library(${target_name} STATIC EXCLUDE_FROM_ALL ${ARG_SOURCES})
   target_compile_options(${target_name} PRIVATE ${ARG_COMPILE_OPTIONS})
   target_include_directories(${target_name} PRIVATE
     ${ARG_INCLUDE_DIRS} ${_inc_dirs}


### PR DESCRIPTION
When `Unix Makefiles` generator is used, there is race condition as both 
`libclc-${t}_clc_builtins` and `libclc-${t}` are listed in ALL targets.
The latter depends on the former, and the former is reachable from both
libclc/all and `libclc-${t}`. The former target could be built twice and
then output library packs the same .o file twice.

Fix the race condition by adding EXCLUDE_FROM_ALL to add_library as its output is currently only used as intermediate libraries.

Ninja generator doesn't have this race condition. This fix has no impact on Ninja.