### PR TITLE
[clang-format] Fix an AllowShortNamespacesOnASingleLine bug

### DIFF
--- a/clang/lib/Format/UnwrappedLineFormatter.cpp
+++ b/clang/lib/Format/UnwrappedLineFormatter.cpp
@@ -706,16 +706,14 @@ private:
     Limit = limitConsideringMacros(I + 1, E, Limit);
 
     const auto LinesToBeMerged = OpenBraceWrapped + 2;
-    if (!nextNLinesFitInto(I, I + LinesToBeMerged, Limit))
-      return 0;
 
     // Check if it's a namespace inside a namespace, and call recursively if so.
     // '3' is the sizes of the whitespace and closing brace for " _inner_ }".
     if (L1.First->is(tok::kw_namespace)) {
       if (L1.Last->is(tok::comment) || !Style.CompactNamespaces)
         return 0;
-
-      assert(Limit >= L1.Last->TotalLength + 3);
+      if (Limit < L1.Last->TotalLength + 3)
+        return 0;
       const auto InnerLimit = Limit - L1.Last->TotalLength - 3;
       const auto MergedLines =
           tryMergeNamespace(BraceOpenLine + 1, E, InnerLimit);
@@ -749,7 +747,9 @@ private:
     if (L2.First->isNot(TT_NamespaceRBrace) || L2.First->MustBreakBefore)
       return 0;
 
-    // If so, merge all lines.
+    if (!nextTwoLinesFitInto(I, Limit))
+      return 0;
+
     return LinesToBeMerged;
   }
 

--- a/clang/unittests/Format/FormatTest.cpp
+++ b/clang/unittests/Format/FormatTest.cpp
@@ -29361,8 +29361,15 @@ TEST_F(FormatTest, KeepFormFeed) {
 }
 
 TEST_F(FormatTest, ShortNamespacesOption) {
-  auto Style = getLLVMStyle();
+  auto Style = getLLVMStyleWithColumns(60);
   Style.AllowShortNamespacesOnASingleLine = true;
+
+  verifyFormat("namespace {\n"
+               "void xxxxx(nnn::TTTTT *mmm, YYYYY &yyyyy);\n"
+               "} // namespace",
+               Style);
+
+  Style.ColumnLimit = 80;
   Style.CompactNamespaces = true;
   Style.FixNamespaceComments = false;
 


### PR DESCRIPTION
It erroneously merged the closing brace even when breaking after the opening brace.

Fixes #187444