### PR TITLE
[clang-tidy] Fix false positive in cert-ctr56-cpp(PointerArithmeticOnPolymorphicObjectCheck)

### DIFF
--- a/clang-tools-extra/clang-tidy/bugprone/PointerArithmeticOnPolymorphicObjectCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/PointerArithmeticOnPolymorphicObjectCheck.cpp
@@ -53,7 +53,8 @@ void PointerArithmeticOnPolymorphicObjectCheck::registerMatchers(
                                        ? PointerExprWithVirtualMethod
                                        : PolymorphicPointerExpr;
 
-  const auto ArraySubscript = arraySubscriptExpr(hasBase(SelectedPointerExpr));
+  const auto ArraySubscript = expr(arraySubscriptExpr(hasBase(SelectedPointerExpr)),
+                                   unless(isInstantiationDependent()));
 
   const auto BinaryOperators =
       binaryOperator(hasAnyOperatorName("+", "-", "+=", "-="),

--- a/clang-tools-extra/clang-tidy/bugprone/PointerArithmeticOnPolymorphicObjectCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/PointerArithmeticOnPolymorphicObjectCheck.cpp
@@ -53,8 +53,9 @@ void PointerArithmeticOnPolymorphicObjectCheck::registerMatchers(
                                        ? PointerExprWithVirtualMethod
                                        : PolymorphicPointerExpr;
 
-  const auto ArraySubscript = expr(arraySubscriptExpr(hasBase(SelectedPointerExpr)),
-                                   unless(isInstantiationDependent()));
+  const auto ArraySubscript =
+      expr(arraySubscriptExpr(hasBase(SelectedPointerExpr)),
+           unless(isInstantiationDependent()));
 
   const auto BinaryOperators =
       binaryOperator(hasAnyOperatorName("+", "-", "+=", "-="),

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -223,6 +223,10 @@ Changes in existing checks
   <clang-tidy/checks/bugprone/macro-parentheses>` check by printing the macro
   definition in the warning message if the macro is defined on command line.
 
+- Improved :doc:`bugprone-pointer-arithmetic-on-polymorphic-object
+  <clang-tidy/checks/bugprone/pointer-arithmetic-on-polymorphic-object>` check
+  by fixing a false positive when ``operator[]`` is used in a dependent context.
+
 - Improved :doc:`bugprone-std-namespace-modification
   <clang-tidy/checks/bugprone/std-namespace-modification>` check by fixing
   false positives when extending the standard library with a specialization of

--- a/clang-tools-extra/test/clang-tidy/checkers/bugprone/pointer-arithmetic-on-polymorphic-object-all.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/bugprone/pointer-arithmetic-on-polymorphic-object-all.cpp
@@ -1,5 +1,7 @@
 // RUN: %check_clang_tidy %s bugprone-pointer-arithmetic-on-polymorphic-object %t --
 
+#include <map>
+
 class Base {
 public:  
   virtual ~Base() {}
@@ -138,3 +140,13 @@ void typeAliases(BaseAlias *b, DerivedAlias *d, FinalDerivedAlias *fd,
   fdp += 1;
   // no-warning
 }
+
+template <typename T>
+struct TemplateHolder : Base {
+  std::map<Base *, T> _map;
+  void test() {
+    auto &x = _map[this];
+    // no-warning
+    (void)x;
+  }
+};


### PR DESCRIPTION
## Summary
This change adds `unless(isInstantiationDependent())` to the `ArraySubscript` matcher.

## Motivation
In template code, some array subscript expressions are not fully resolved yet.
Because of this, the matcher may treat them incorrectly and produce false positives.

## Change
This patch skips instantiation-dependent expressions in templates. 
It helps the matcher work only on resolved expressions.

Closes https://github.com/llvm/llvm-project/issues/187009.