### PR TITLE
[AMDGPU] Saturate at i16 for f16 to i1/i8 conversion

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUISelLowering.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUISelLowering.cpp
@@ -3905,53 +3905,70 @@ SDValue AMDGPUTargetLowering::LowerFP_TO_INT_SAT(const SDValue Op,
   if (DstVT == MVT::i16 && SatWidth == DstWidth && SrcVT == MVT::f16)
     return Op;
 
-  const SDValue Int32VTOp = DAG.getValueType(MVT::i32);
-
-  // Perform all saturation at i32 and truncate
+  // Perform all saturation at selected width (i16 or i32) and truncate
   if (SatWidth < DstWidth && SatWidth <= 32) {
-    const uint64_t Int32Width = 32;
-    SDValue FpToInt32 = DAG.getNode(OpOpcode, DL, MVT::i32, Src, Int32VTOp);
-    SDValue Int32SatVal;
+    // For f16 conversion with sub-i16 saturation perform saturation
+    // at i16, if available in the target. This removes the need for extra f16
+    // to f32 conversion. For all the others use i32.
+    MVT ResultVT;
+    if (Subtarget->has16BitInsts() && SrcVT == MVT::f16 && SatWidth < 16)
+      ResultVT = MVT::i16;
+    else
+      ResultVT = MVT::i32;
 
+    const SDValue ResultVTOp = DAG.getValueType(ResultVT);
+    const uint64_t ResultWidth = ResultVT.getScalarSizeInBits();
+
+    // First, convert input float into selected integer (i16 or i32)
+    SDValue FpToInt = DAG.getNode(OpOpcode, DL, ResultVT, Src, ResultVTOp);
+    SDValue IntSatVal;
+
+    // Then, clamp at the saturation width using either i16 or i32 instructions
     if (Op.getOpcode() == ISD::FP_TO_SINT_SAT) {
       SDValue MinConst = DAG.getConstant(
-          APInt::getSignedMaxValue(SatWidth).sext(Int32Width), DL, MVT::i32);
+          APInt::getSignedMaxValue(SatWidth).sext(ResultWidth), DL, ResultVT);
       SDValue MaxConst = DAG.getConstant(
-          APInt::getSignedMinValue(SatWidth).sext(Int32Width), DL, MVT::i32);
-      SDValue MinVal =
-          DAG.getNode(ISD::SMIN, DL, MVT::i32, FpToInt32, MinConst);
-      Int32SatVal = DAG.getNode(ISD::SMAX, DL, MVT::i32, MinVal, MaxConst);
+          APInt::getSignedMinValue(SatWidth).sext(ResultWidth), DL, ResultVT);
+      SDValue MinVal = DAG.getNode(ISD::SMIN, DL, ResultVT, FpToInt, MinConst);
+      IntSatVal = DAG.getNode(ISD::SMAX, DL, ResultVT, MinVal, MaxConst);
     } else {
       SDValue MinConst = DAG.getConstant(
-          APInt::getMaxValue(SatWidth).zext(Int32Width), DL, MVT::i32);
-      Int32SatVal = DAG.getNode(ISD::UMIN, DL, MVT::i32, FpToInt32, MinConst);
+          APInt::getMaxValue(SatWidth).zext(ResultWidth), DL, ResultVT);
+      IntSatVal = DAG.getNode(ISD::UMIN, DL, ResultVT, FpToInt, MinConst);
     }
 
-    return DAG.getExtOrTrunc(OpOpcode == ISD::FP_TO_SINT_SAT, Int32SatVal, DL,
+    // Finally, after saturating at i16 or i32 fit into the destination type
+    return DAG.getExtOrTrunc(OpOpcode == ISD::FP_TO_SINT_SAT, IntSatVal, DL,
                              DstVT);
   }
 
   // SatWidth == DstWidth
 
-  // Saturate at i32 for i64 dst and 16b src (will invoke f16 promotion below)
+  // Saturate at i32 for i64 dst and f16/bf16 src (will invoke f16 promotion
+  // below)
   if (DstVT == MVT::i64 &&
       (SrcVT == MVT::f16 || SrcVT == MVT::bf16 ||
        (SrcVT == MVT::f32 && Src.getOpcode() == ISD::FP16_TO_FP))) {
+    const SDValue Int32VTOp = DAG.getValueType(MVT::i32);
     return DAG.getNode(OpOpcode, DL, DstVT, Src, Int32VTOp);
   }
 
-  // Promote f16/bf16 src to f32
-  if (SrcVT == MVT::f16 || SrcVT == MVT::bf16) {
+  // Promote f16/bf16 src to f32 for i32 conversion
+  if (DstVT == MVT::i32 && (SrcVT == MVT::f16 || SrcVT == MVT::bf16)) {
     SDValue PromotedSrc = DAG.getNode(ISD::FP_EXTEND, DL, MVT::f32, Src);
     return DAG.getNode(Op.getOpcode(), DL, DstVT, PromotedSrc, SatVTOp);
   }
 
-  // Promote sub-i32 dst to i32 with sub-i32 saturation
+  // For DstWidth < 16, promote i1 and i8 dst to i16 (if legal) with sub-i16
+  // saturation. For DstWidth == 16, promote i16 dst to i32 with sub-i32
+  // saturation; this covers i16.f32 and i16.f64
   if (DstWidth < 32) {
     // Note: this triggers SatWidth < DstWidth above to generate saturated
-    // truncate by requesting MVT::i32 destination with SatWidth < 32.
-    SDValue FpToInt32 = DAG.getNode(OpOpcode, DL, MVT::i32, Src, SatVTOp);
-    return DAG.getNode(ISD::TRUNCATE, DL, DstVT, FpToInt32);
+    // truncate by requesting MVT::i16/i32 destination with SatWidth < 16/32.
+    MVT PromoteVT =
+        (DstWidth < 16 && Subtarget->has16BitInsts()) ? MVT::i16 : MVT::i32;
+    SDValue FpToInt = DAG.getNode(OpOpcode, DL, PromoteVT, Src, SatVTOp);
+    return DAG.getNode(ISD::TRUNCATE, DL, DstVT, FpToInt);
   }
 
   // TODO: can we implement i64 dst for f32/f64?

--- a/llvm/lib/Target/AMDGPU/AMDGPUISelLowering.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUISelLowering.cpp
@@ -3910,11 +3910,10 @@ SDValue AMDGPUTargetLowering::LowerFP_TO_INT_SAT(const SDValue Op,
     // For f16 conversion with sub-i16 saturation perform saturation
     // at i16, if available in the target. This removes the need for extra f16
     // to f32 conversion. For all the others use i32.
-    MVT ResultVT;
-    if (Subtarget->has16BitInsts() && SrcVT == MVT::f16 && SatWidth < 16)
-      ResultVT = MVT::i16;
-    else
-      ResultVT = MVT::i32;
+    MVT ResultVT =
+        Subtarget->has16BitInsts() && SrcVT == MVT::f16 && SatWidth < 16
+            ? MVT::i16
+            : MVT::i32;
 
     const SDValue ResultVTOp = DAG.getValueType(ResultVT);
     const uint64_t ResultWidth = ResultVT.getScalarSizeInBits();

--- a/llvm/test/CodeGen/AMDGPU/fptosi-sat-scalar.ll
+++ b/llvm/test/CodeGen/AMDGPU/fptosi-sat-scalar.ll
@@ -801,25 +801,22 @@ define i1 @test_signed_i1_f16(half %f) nounwind {
 ; GFX9-LABEL: test_signed_i1_f16:
 ; GFX9:       ; %bb.0:
 ; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX9-NEXT:    v_cvt_f32_f16_e32 v0, v0
-; GFX9-NEXT:    v_cvt_i32_f32_e32 v0, v0
-; GFX9-NEXT:    v_med3_i32 v0, v0, -1, 0
+; GFX9-NEXT:    v_cvt_i16_f16_e32 v0, v0
+; GFX9-NEXT:    v_med3_i16 v0, v0, -1, 0
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-FAKE16-LABEL: test_signed_i1_f16:
 ; GFX11-FAKE16:       ; %bb.0:
 ; GFX11-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX11-FAKE16-NEXT:    v_cvt_f32_f16_e32 v0, v0
-; GFX11-FAKE16-NEXT:    v_cvt_i32_f32_e32 v0, v0
-; GFX11-FAKE16-NEXT:    v_med3_i32 v0, v0, -1, 0
+; GFX11-FAKE16-NEXT:    v_cvt_i16_f16_e32 v0, v0
+; GFX11-FAKE16-NEXT:    v_med3_i16 v0, v0, -1, 0
 ; GFX11-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-TRUE16-LABEL: test_signed_i1_f16:
 ; GFX11-TRUE16:       ; %bb.0:
 ; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX11-TRUE16-NEXT:    v_cvt_f32_f16_e32 v0, v0.l
-; GFX11-TRUE16-NEXT:    v_cvt_i32_f32_e32 v0, v0
-; GFX11-TRUE16-NEXT:    v_med3_i32 v0, v0, -1, 0
+; GFX11-TRUE16-NEXT:    v_cvt_i16_f16_e32 v0.l, v0.l
+; GFX11-TRUE16-NEXT:    v_med3_i16 v0.l, v0.l, -1, 0
 ; GFX11-TRUE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX12-FAKE16-LABEL: test_signed_i1_f16:
@@ -829,9 +826,8 @@ define i1 @test_signed_i1_f16(half %f) nounwind {
 ; GFX12-FAKE16-NEXT:    s_wait_samplecnt 0x0
 ; GFX12-FAKE16-NEXT:    s_wait_bvhcnt 0x0
 ; GFX12-FAKE16-NEXT:    s_wait_kmcnt 0x0
-; GFX12-FAKE16-NEXT:    v_cvt_f32_f16_e32 v0, v0
-; GFX12-FAKE16-NEXT:    v_cvt_i32_f32_e32 v0, v0
-; GFX12-FAKE16-NEXT:    v_med3_i32 v0, v0, -1, 0
+; GFX12-FAKE16-NEXT:    v_cvt_i16_f16_e32 v0, v0
+; GFX12-FAKE16-NEXT:    v_med3_i16 v0, v0, -1, 0
 ; GFX12-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX12-TRUE16-LABEL: test_signed_i1_f16:
@@ -841,9 +837,8 @@ define i1 @test_signed_i1_f16(half %f) nounwind {
 ; GFX12-TRUE16-NEXT:    s_wait_samplecnt 0x0
 ; GFX12-TRUE16-NEXT:    s_wait_bvhcnt 0x0
 ; GFX12-TRUE16-NEXT:    s_wait_kmcnt 0x0
-; GFX12-TRUE16-NEXT:    v_cvt_f32_f16_e32 v0, v0.l
-; GFX12-TRUE16-NEXT:    v_cvt_i32_f32_e32 v0, v0
-; GFX12-TRUE16-NEXT:    v_med3_i32 v0, v0, -1, 0
+; GFX12-TRUE16-NEXT:    v_cvt_i16_f16_e32 v0.l, v0.l
+; GFX12-TRUE16-NEXT:    v_med3_i16 v0.l, v0.l, -1, 0
 ; GFX12-TRUE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX12-GI-LABEL: test_signed_i1_f16:
@@ -885,29 +880,26 @@ define i8 @test_signed_i8_f16(half %f) nounwind {
 ; GFX9-LABEL: test_signed_i8_f16:
 ; GFX9:       ; %bb.0:
 ; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX9-NEXT:    v_cvt_f32_f16_e32 v0, v0
+; GFX9-NEXT:    v_cvt_i16_f16_e32 v0, v0
 ; GFX9-NEXT:    s_movk_i32 s4, 0xff80
 ; GFX9-NEXT:    v_mov_b32_e32 v1, 0x7f
-; GFX9-NEXT:    v_cvt_i32_f32_e32 v0, v0
-; GFX9-NEXT:    v_med3_i32 v0, v0, s4, v1
+; GFX9-NEXT:    v_med3_i16 v0, v0, s4, v1
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-FAKE16-LABEL: test_signed_i8_f16:
 ; GFX11-FAKE16:       ; %bb.0:
 ; GFX11-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX11-FAKE16-NEXT:    v_cvt_f32_f16_e32 v0, v0
+; GFX11-FAKE16-NEXT:    v_cvt_i16_f16_e32 v0, v0
 ; GFX11-FAKE16-NEXT:    s_movk_i32 s0, 0xff80
-; GFX11-FAKE16-NEXT:    v_cvt_i32_f32_e32 v0, v0
-; GFX11-FAKE16-NEXT:    v_med3_i32 v0, v0, s0, 0x7f
+; GFX11-FAKE16-NEXT:    v_med3_i16 v0, v0, s0, 0x7f
 ; GFX11-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-TRUE16-LABEL: test_signed_i8_f16:
 ; GFX11-TRUE16:       ; %bb.0:
 ; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX11-TRUE16-NEXT:    v_cvt_f32_f16_e32 v0, v0.l
-; GFX11-TRUE16-NEXT:    s_movk_i32 s0, 0xff80
-; GFX11-TRUE16-NEXT:    v_cvt_i32_f32_e32 v0, v0
-; GFX11-TRUE16-NEXT:    v_med3_i32 v0, v0, s0, 0x7f
+; GFX11-TRUE16-NEXT:    v_cvt_i16_f16_e32 v0.l, v0.l
+; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v0.h, 0xff80
+; GFX11-TRUE16-NEXT:    v_med3_i16 v0.l, v0.l, v0.h, 0x7f
 ; GFX11-TRUE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX12-FAKE16-LABEL: test_signed_i8_f16:
@@ -917,11 +909,10 @@ define i8 @test_signed_i8_f16(half %f) nounwind {
 ; GFX12-FAKE16-NEXT:    s_wait_samplecnt 0x0
 ; GFX12-FAKE16-NEXT:    s_wait_bvhcnt 0x0
 ; GFX12-FAKE16-NEXT:    s_wait_kmcnt 0x0
-; GFX12-FAKE16-NEXT:    v_cvt_f32_f16_e32 v0, v0
+; GFX12-FAKE16-NEXT:    v_cvt_i16_f16_e32 v0, v0
 ; GFX12-FAKE16-NEXT:    s_movk_i32 s0, 0xff80
-; GFX12-FAKE16-NEXT:    v_cvt_i32_f32_e32 v0, v0
 ; GFX12-FAKE16-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX12-FAKE16-NEXT:    v_med3_i32 v0, v0, s0, 0x7f
+; GFX12-FAKE16-NEXT:    v_med3_i16 v0, v0, s0, 0x7f
 ; GFX12-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX12-TRUE16-LABEL: test_signed_i8_f16:
@@ -931,11 +922,9 @@ define i8 @test_signed_i8_f16(half %f) nounwind {
 ; GFX12-TRUE16-NEXT:    s_wait_samplecnt 0x0
 ; GFX12-TRUE16-NEXT:    s_wait_bvhcnt 0x0
 ; GFX12-TRUE16-NEXT:    s_wait_kmcnt 0x0
-; GFX12-TRUE16-NEXT:    v_cvt_f32_f16_e32 v0, v0.l
-; GFX12-TRUE16-NEXT:    s_movk_i32 s0, 0xff80
-; GFX12-TRUE16-NEXT:    v_cvt_i32_f32_e32 v0, v0
-; GFX12-TRUE16-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX12-TRUE16-NEXT:    v_med3_i32 v0, v0, s0, 0x7f
+; GFX12-TRUE16-NEXT:    v_cvt_i16_f16_e32 v0.l, v0.l
+; GFX12-TRUE16-NEXT:    v_mov_b16_e32 v0.h, 0xff80
+; GFX12-TRUE16-NEXT:    v_med3_i16 v0.l, v0.l, v0.h, 0x7f
 ; GFX12-TRUE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX12-GI-LABEL: test_signed_i8_f16:

--- a/llvm/test/CodeGen/AMDGPU/fptosi-sat-vector.ll
+++ b/llvm/test/CodeGen/AMDGPU/fptosi-sat-vector.ll
@@ -1292,18 +1292,16 @@ define <4 x i1> @test_signed_v4f16_v4i1(<4 x half> %f) {
 ; GFX9-LABEL: test_signed_v4f16_v4i1:
 ; GFX9:       ; %bb.0:
 ; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX9-NEXT:    v_cvt_f32_f16_e32 v2, v1
-; GFX9-NEXT:    v_cvt_f32_f16_e32 v3, v0
-; GFX9-NEXT:    v_cvt_f32_f16_sdwa v1, v1 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1
-; GFX9-NEXT:    v_cvt_f32_f16_sdwa v0, v0 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1
-; GFX9-NEXT:    v_cvt_i32_f32_e32 v2, v2
-; GFX9-NEXT:    v_cvt_i32_f32_e32 v3, v3
-; GFX9-NEXT:    v_cvt_i32_f32_e32 v1, v1
-; GFX9-NEXT:    v_cvt_i32_f32_e32 v4, v0
-; GFX9-NEXT:    v_med3_i32 v2, v2, -1, 0
-; GFX9-NEXT:    v_med3_i32 v0, v3, -1, 0
-; GFX9-NEXT:    v_med3_i32 v3, v1, -1, 0
-; GFX9-NEXT:    v_med3_i32 v1, v4, -1, 0
+; GFX9-NEXT:    v_cvt_i16_f16_e32 v2, v0
+; GFX9-NEXT:    v_cvt_i16_f16_sdwa v0, v0 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1
+; GFX9-NEXT:    v_med3_i16 v5, v2, -1, 0
+; GFX9-NEXT:    v_cvt_i16_f16_e32 v2, v1
+; GFX9-NEXT:    v_med3_i16 v4, v0, -1, 0
+; GFX9-NEXT:    v_cvt_i16_f16_sdwa v0, v1 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1
+; GFX9-NEXT:    v_med3_i16 v2, v2, -1, 0
+; GFX9-NEXT:    v_med3_i16 v3, v0, -1, 0
+; GFX9-NEXT:    v_mov_b32_e32 v0, v5
+; GFX9-NEXT:    v_mov_b32_e32 v1, v4
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-FAKE16-LABEL: test_signed_v4f16_v4i1:
@@ -1311,35 +1309,27 @@ define <4 x i1> @test_signed_v4f16_v4i1(<4 x half> %f) {
 ; GFX11-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v2, 16, v0
 ; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v3, 16, v1
-; GFX11-FAKE16-NEXT:    v_cvt_f32_f16_e32 v0, v0
-; GFX11-FAKE16-NEXT:    v_cvt_f32_f16_e32 v1, v1
-; GFX11-FAKE16-NEXT:    v_cvt_f32_f16_e32 v2, v2
-; GFX11-FAKE16-NEXT:    v_cvt_f32_f16_e32 v3, v3
-; GFX11-FAKE16-NEXT:    v_cvt_i32_f32_e32 v0, v0
-; GFX11-FAKE16-NEXT:    v_cvt_i32_f32_e32 v1, v1
-; GFX11-FAKE16-NEXT:    v_cvt_i32_f32_e32 v4, v2
-; GFX11-FAKE16-NEXT:    v_cvt_i32_f32_e32 v3, v3
-; GFX11-FAKE16-NEXT:    v_med3_i32 v0, v0, -1, 0
-; GFX11-FAKE16-NEXT:    v_med3_i32 v2, v1, -1, 0
-; GFX11-FAKE16-NEXT:    v_med3_i32 v1, v4, -1, 0
-; GFX11-FAKE16-NEXT:    v_med3_i32 v3, v3, -1, 0
+; GFX11-FAKE16-NEXT:    v_cvt_i16_f16_e32 v0, v0
+; GFX11-FAKE16-NEXT:    v_cvt_i16_f16_e32 v1, v1
+; GFX11-FAKE16-NEXT:    v_cvt_i16_f16_e32 v4, v2
+; GFX11-FAKE16-NEXT:    v_cvt_i16_f16_e32 v3, v3
+; GFX11-FAKE16-NEXT:    v_med3_i16 v0, v0, -1, 0
+; GFX11-FAKE16-NEXT:    v_med3_i16 v2, v1, -1, 0
+; GFX11-FAKE16-NEXT:    v_med3_i16 v1, v4, -1, 0
+; GFX11-FAKE16-NEXT:    v_med3_i16 v3, v3, -1, 0
 ; GFX11-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-TRUE16-LABEL: test_signed_v4f16_v4i1:
 ; GFX11-TRUE16:       ; %bb.0:
 ; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX11-TRUE16-NEXT:    v_cvt_f32_f16_e32 v2, v0.l
-; GFX11-TRUE16-NEXT:    v_cvt_f32_f16_e32 v0, v0.h
-; GFX11-TRUE16-NEXT:    v_cvt_f32_f16_e32 v3, v1.l
-; GFX11-TRUE16-NEXT:    v_cvt_f32_f16_e32 v1, v1.h
-; GFX11-TRUE16-NEXT:    v_cvt_i32_f32_e32 v2, v2
-; GFX11-TRUE16-NEXT:    v_cvt_i32_f32_e32 v4, v0
-; GFX11-TRUE16-NEXT:    v_cvt_i32_f32_e32 v3, v3
-; GFX11-TRUE16-NEXT:    v_cvt_i32_f32_e32 v5, v1
-; GFX11-TRUE16-NEXT:    v_med3_i32 v0, v2, -1, 0
-; GFX11-TRUE16-NEXT:    v_med3_i32 v1, v4, -1, 0
-; GFX11-TRUE16-NEXT:    v_med3_i32 v2, v3, -1, 0
-; GFX11-TRUE16-NEXT:    v_med3_i32 v3, v5, -1, 0
+; GFX11-TRUE16-NEXT:    v_cvt_i16_f16_e32 v0.l, v0.l
+; GFX11-TRUE16-NEXT:    v_cvt_i16_f16_e32 v0.h, v0.h
+; GFX11-TRUE16-NEXT:    v_cvt_i16_f16_e32 v2.l, v1.l
+; GFX11-TRUE16-NEXT:    v_cvt_i16_f16_e32 v1.h, v1.h
+; GFX11-TRUE16-NEXT:    v_med3_i16 v0.l, v0.l, -1, 0
+; GFX11-TRUE16-NEXT:    v_med3_i16 v1.l, v0.h, -1, 0
+; GFX11-TRUE16-NEXT:    v_med3_i16 v2.l, v2.l, -1, 0
+; GFX11-TRUE16-NEXT:    v_med3_i16 v3.l, v1.h, -1, 0
 ; GFX11-TRUE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX12-FAKE16-LABEL: test_signed_v4f16_v4i1:
@@ -1351,18 +1341,14 @@ define <4 x i1> @test_signed_v4f16_v4i1(<4 x half> %f) {
 ; GFX12-FAKE16-NEXT:    s_wait_kmcnt 0x0
 ; GFX12-FAKE16-NEXT:    v_lshrrev_b32_e32 v2, 16, v0
 ; GFX12-FAKE16-NEXT:    v_lshrrev_b32_e32 v3, 16, v1
-; GFX12-FAKE16-NEXT:    v_cvt_f32_f16_e32 v0, v0
-; GFX12-FAKE16-NEXT:    v_cvt_f32_f16_e32 v1, v1
-; GFX12-FAKE16-NEXT:    v_cvt_f32_f16_e32 v2, v2
-; GFX12-FAKE16-NEXT:    v_cvt_f32_f16_e32 v3, v3
-; GFX12-FAKE16-NEXT:    v_cvt_i32_f32_e32 v0, v0
-; GFX12-FAKE16-NEXT:    v_cvt_i32_f32_e32 v1, v1
-; GFX12-FAKE16-NEXT:    v_cvt_i32_f32_e32 v4, v2
-; GFX12-FAKE16-NEXT:    v_cvt_i32_f32_e32 v3, v3
-; GFX12-FAKE16-NEXT:    v_med3_i32 v0, v0, -1, 0
-; GFX12-FAKE16-NEXT:    v_med3_i32 v2, v1, -1, 0
-; GFX12-FAKE16-NEXT:    v_med3_i32 v1, v4, -1, 0
-; GFX12-FAKE16-NEXT:    v_med3_i32 v3, v3, -1, 0
+; GFX12-FAKE16-NEXT:    v_cvt_i16_f16_e32 v0, v0
+; GFX12-FAKE16-NEXT:    v_cvt_i16_f16_e32 v1, v1
+; GFX12-FAKE16-NEXT:    v_cvt_i16_f16_e32 v4, v2
+; GFX12-FAKE16-NEXT:    v_cvt_i16_f16_e32 v3, v3
+; GFX12-FAKE16-NEXT:    v_med3_i16 v0, v0, -1, 0
+; GFX12-FAKE16-NEXT:    v_med3_i16 v2, v1, -1, 0
+; GFX12-FAKE16-NEXT:    v_med3_i16 v1, v4, -1, 0
+; GFX12-FAKE16-NEXT:    v_med3_i16 v3, v3, -1, 0
 ; GFX12-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX12-TRUE16-LABEL: test_signed_v4f16_v4i1:
@@ -1372,18 +1358,14 @@ define <4 x i1> @test_signed_v4f16_v4i1(<4 x half> %f) {
 ; GFX12-TRUE16-NEXT:    s_wait_samplecnt 0x0
 ; GFX12-TRUE16-NEXT:    s_wait_bvhcnt 0x0
 ; GFX12-TRUE16-NEXT:    s_wait_kmcnt 0x0
-; GFX12-TRUE16-NEXT:    v_cvt_f32_f16_e32 v2, v0.l
-; GFX12-TRUE16-NEXT:    v_cvt_f32_f16_e32 v0, v0.h
-; GFX12-TRUE16-NEXT:    v_cvt_f32_f16_e32 v3, v1.l
-; GFX12-TRUE16-NEXT:    v_cvt_f32_f16_e32 v1, v1.h
-; GFX12-TRUE16-NEXT:    v_cvt_i32_f32_e32 v2, v2
-; GFX12-TRUE16-NEXT:    v_cvt_i32_f32_e32 v4, v0
-; GFX12-TRUE16-NEXT:    v_cvt_i32_f32_e32 v3, v3
-; GFX12-TRUE16-NEXT:    v_cvt_i32_f32_e32 v5, v1
-; GFX12-TRUE16-NEXT:    v_med3_i32 v0, v2, -1, 0
-; GFX12-TRUE16-NEXT:    v_med3_i32 v1, v4, -1, 0
-; GFX12-TRUE16-NEXT:    v_med3_i32 v2, v3, -1, 0
-; GFX12-TRUE16-NEXT:    v_med3_i32 v3, v5, -1, 0
+; GFX12-TRUE16-NEXT:    v_cvt_i16_f16_e32 v0.l, v0.l
+; GFX12-TRUE16-NEXT:    v_cvt_i16_f16_e32 v0.h, v0.h
+; GFX12-TRUE16-NEXT:    v_cvt_i16_f16_e32 v2.l, v1.l
+; GFX12-TRUE16-NEXT:    v_cvt_i16_f16_e32 v1.h, v1.h
+; GFX12-TRUE16-NEXT:    v_med3_i16 v0.l, v0.l, -1, 0
+; GFX12-TRUE16-NEXT:    v_med3_i16 v1.l, v0.h, -1, 0
+; GFX12-TRUE16-NEXT:    v_med3_i16 v2.l, v2.l, -1, 0
+; GFX12-TRUE16-NEXT:    v_med3_i16 v3.l, v1.h, -1, 0
 ; GFX12-TRUE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX12-GI-LABEL: test_signed_v4f16_v4i1:
@@ -1468,26 +1450,22 @@ define <4 x i8> @test_signed_v4f16_v4i8(<4 x half> %f) {
 ; GFX9-LABEL: test_signed_v4f16_v4i8:
 ; GFX9:       ; %bb.0:
 ; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX9-NEXT:    v_cvt_f32_f16_e32 v2, v0
-; GFX9-NEXT:    v_cvt_f32_f16_sdwa v0, v0 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1
-; GFX9-NEXT:    v_cvt_f32_f16_e32 v4, v1
-; GFX9-NEXT:    v_cvt_f32_f16_sdwa v1, v1 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1
-; GFX9-NEXT:    v_cvt_i32_f32_e32 v2, v2
-; GFX9-NEXT:    v_cvt_i32_f32_e32 v0, v0
-; GFX9-NEXT:    v_cvt_i32_f32_e32 v4, v4
-; GFX9-NEXT:    v_cvt_i32_f32_e32 v1, v1
+; GFX9-NEXT:    v_cvt_i16_f16_e32 v2, v0
 ; GFX9-NEXT:    s_movk_i32 s4, 0xff80
 ; GFX9-NEXT:    v_mov_b32_e32 v3, 0x7f
-; GFX9-NEXT:    v_med3_i32 v0, v0, s4, v3
-; GFX9-NEXT:    v_med3_i32 v2, v2, s4, v3
-; GFX9-NEXT:    v_lshlrev_b16_e32 v5, 8, v0
-; GFX9-NEXT:    v_med3_i32 v1, v1, s4, v3
-; GFX9-NEXT:    v_or_b32_sdwa v0, v2, v5 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:BYTE_0 src1_sel:DWORD
-; GFX9-NEXT:    v_med3_i32 v2, v4, s4, v3
+; GFX9-NEXT:    v_cvt_i16_f16_sdwa v0, v0 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1
+; GFX9-NEXT:    v_med3_i16 v0, v0, s4, v3
+; GFX9-NEXT:    v_med3_i16 v2, v2, s4, v3
+; GFX9-NEXT:    v_lshlrev_b16_e32 v4, 8, v0
+; GFX9-NEXT:    v_or_b32_sdwa v0, v2, v4 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:BYTE_0 src1_sel:DWORD
+; GFX9-NEXT:    v_cvt_i16_f16_e32 v2, v1
+; GFX9-NEXT:    v_cvt_i16_f16_sdwa v1, v1 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1
+; GFX9-NEXT:    v_med3_i16 v1, v1, s4, v3
+; GFX9-NEXT:    v_med3_i16 v2, v2, s4, v3
 ; GFX9-NEXT:    v_lshlrev_b16_e32 v1, 8, v1
 ; GFX9-NEXT:    v_or_b32_sdwa v2, v2, v1 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:BYTE_0 src1_sel:DWORD
 ; GFX9-NEXT:    v_lshlrev_b32_e32 v1, 16, v2
-; GFX9-NEXT:    v_or_b32_e32 v4, v5, v1
+; GFX9-NEXT:    v_or_b32_e32 v4, v4, v1
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v3, 24, v1
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v1, 8, v4
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
@@ -1497,19 +1475,15 @@ define <4 x i8> @test_signed_v4f16_v4i8(<4 x half> %f) {
 ; GFX11-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v2, 16, v1
 ; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v3, 16, v0
-; GFX11-FAKE16-NEXT:    v_cvt_f32_f16_e32 v1, v1
+; GFX11-FAKE16-NEXT:    v_cvt_i16_f16_e32 v1, v1
 ; GFX11-FAKE16-NEXT:    s_movk_i32 s0, 0xff80
-; GFX11-FAKE16-NEXT:    v_cvt_f32_f16_e32 v0, v0
-; GFX11-FAKE16-NEXT:    v_cvt_f32_f16_e32 v2, v2
-; GFX11-FAKE16-NEXT:    v_cvt_f32_f16_e32 v3, v3
-; GFX11-FAKE16-NEXT:    v_cvt_i32_f32_e32 v1, v1
-; GFX11-FAKE16-NEXT:    v_cvt_i32_f32_e32 v0, v0
-; GFX11-FAKE16-NEXT:    v_cvt_i32_f32_e32 v2, v2
-; GFX11-FAKE16-NEXT:    v_cvt_i32_f32_e32 v3, v3
-; GFX11-FAKE16-NEXT:    v_med3_i32 v1, v1, s0, 0x7f
-; GFX11-FAKE16-NEXT:    v_med3_i32 v0, v0, s0, 0x7f
-; GFX11-FAKE16-NEXT:    v_med3_i32 v2, v2, s0, 0x7f
-; GFX11-FAKE16-NEXT:    v_med3_i32 v3, v3, s0, 0x7f
+; GFX11-FAKE16-NEXT:    v_cvt_i16_f16_e32 v0, v0
+; GFX11-FAKE16-NEXT:    v_cvt_i16_f16_e32 v2, v2
+; GFX11-FAKE16-NEXT:    v_cvt_i16_f16_e32 v3, v3
+; GFX11-FAKE16-NEXT:    v_med3_i16 v1, v1, s0, 0x7f
+; GFX11-FAKE16-NEXT:    v_med3_i16 v0, v0, s0, 0x7f
+; GFX11-FAKE16-NEXT:    v_med3_i16 v2, v2, s0, 0x7f
+; GFX11-FAKE16-NEXT:    v_med3_i16 v3, v3, s0, 0x7f
 ; GFX11-FAKE16-NEXT:    v_and_b32_e32 v1, 0xff, v1
 ; GFX11-FAKE16-NEXT:    v_and_b32_e32 v0, 0xff, v0
 ; GFX11-FAKE16-NEXT:    v_lshlrev_b16 v2, 8, v2
@@ -1526,30 +1500,26 @@ define <4 x i8> @test_signed_v4f16_v4i8(<4 x half> %f) {
 ; GFX11-TRUE16-LABEL: test_signed_v4f16_v4i8:
 ; GFX11-TRUE16:       ; %bb.0:
 ; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX11-TRUE16-NEXT:    v_cvt_f32_f16_e32 v2, v1.l
-; GFX11-TRUE16-NEXT:    v_cvt_f32_f16_e32 v1, v1.h
-; GFX11-TRUE16-NEXT:    s_movk_i32 s0, 0xff80
-; GFX11-TRUE16-NEXT:    v_cvt_f32_f16_e32 v3, v0.l
-; GFX11-TRUE16-NEXT:    v_cvt_f32_f16_e32 v0, v0.h
-; GFX11-TRUE16-NEXT:    v_cvt_i32_f32_e32 v2, v2
-; GFX11-TRUE16-NEXT:    v_cvt_i32_f32_e32 v1, v1
-; GFX11-TRUE16-NEXT:    v_cvt_i32_f32_e32 v3, v3
-; GFX11-TRUE16-NEXT:    v_cvt_i32_f32_e32 v4, v0
-; GFX11-TRUE16-NEXT:    v_med3_i32 v2, v2, s0, 0x7f
-; GFX11-TRUE16-NEXT:    v_med3_i32 v1, v1, s0, 0x7f
-; GFX11-TRUE16-NEXT:    v_and_b16 v0.l, 0xff, v2.l
-; GFX11-TRUE16-NEXT:    v_lshlrev_b16 v0.h, 8, v1.l
-; GFX11-TRUE16-NEXT:    v_med3_i32 v2, v4, s0, 0x7f
-; GFX11-TRUE16-NEXT:    v_med3_i32 v1, v3, s0, 0x7f
-; GFX11-TRUE16-NEXT:    v_or_b16 v2.h, v0.l, v0.h
-; GFX11-TRUE16-NEXT:    v_and_b16 v0.l, 0xff, v1.l
-; GFX11-TRUE16-NEXT:    v_lshlrev_b16 v1.l, 8, v2.l
+; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v2.l, 0xff80
+; GFX11-TRUE16-NEXT:    v_cvt_i16_f16_e32 v1.l, v1.l
+; GFX11-TRUE16-NEXT:    v_cvt_i16_f16_e32 v1.h, v1.h
+; GFX11-TRUE16-NEXT:    v_cvt_i16_f16_e32 v0.l, v0.l
+; GFX11-TRUE16-NEXT:    v_cvt_i16_f16_e32 v0.h, v0.h
+; GFX11-TRUE16-NEXT:    v_med3_i16 v1.l, v1.l, v2.l, 0x7f
+; GFX11-TRUE16-NEXT:    v_med3_i16 v1.h, v1.h, v2.l, 0x7f
+; GFX11-TRUE16-NEXT:    v_med3_i16 v0.l, v0.l, v2.l, 0x7f
+; GFX11-TRUE16-NEXT:    v_med3_i16 v0.h, v0.h, v2.l, 0x7f
 ; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v2.l, 0
+; GFX11-TRUE16-NEXT:    v_and_b16 v1.l, 0xff, v1.l
+; GFX11-TRUE16-NEXT:    v_lshlrev_b16 v1.h, 8, v1.h
+; GFX11-TRUE16-NEXT:    v_and_b16 v0.l, 0xff, v0.l
+; GFX11-TRUE16-NEXT:    v_or_b16 v2.h, v1.l, v1.h
+; GFX11-TRUE16-NEXT:    v_lshlrev_b16 v1.l, 8, v0.h
 ; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v1.h, v2.h
 ; GFX11-TRUE16-NEXT:    v_or_b16 v0.l, v0.l, v1.l
 ; GFX11-TRUE16-NEXT:    v_lshrrev_b32_e32 v3, 24, v2
-; GFX11-TRUE16-NEXT:    v_lshrrev_b32_e32 v1, 8, v1
 ; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v2.l, v2.h
+; GFX11-TRUE16-NEXT:    v_lshrrev_b32_e32 v1, 8, v1
 ; GFX11-TRUE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX12-FAKE16-LABEL: test_signed_v4f16_v4i8:
@@ -1561,20 +1531,16 @@ define <4 x i8> @test_signed_v4f16_v4i8(<4 x half> %f) {
 ; GFX12-FAKE16-NEXT:    s_wait_kmcnt 0x0
 ; GFX12-FAKE16-NEXT:    v_lshrrev_b32_e32 v2, 16, v1
 ; GFX12-FAKE16-NEXT:    v_lshrrev_b32_e32 v3, 16, v0
-; GFX12-FAKE16-NEXT:    v_cvt_f32_f16_e32 v1, v1
+; GFX12-FAKE16-NEXT:    v_cvt_i16_f16_e32 v1, v1
 ; GFX12-FAKE16-NEXT:    s_movk_i32 s0, 0xff80
-; GFX12-FAKE16-NEXT:    v_cvt_f32_f16_e32 v0, v0
-; GFX12-FAKE16-NEXT:    v_cvt_f32_f16_e32 v2, v2
-; GFX12-FAKE16-NEXT:    v_cvt_f32_f16_e32 v3, v3
-; GFX12-FAKE16-NEXT:    v_cvt_i32_f32_e32 v1, v1
-; GFX12-FAKE16-NEXT:    v_cvt_i32_f32_e32 v0, v0
-; GFX12-FAKE16-NEXT:    v_cvt_i32_f32_e32 v2, v2
-; GFX12-FAKE16-NEXT:    v_cvt_i32_f32_e32 v3, v3
+; GFX12-FAKE16-NEXT:    v_cvt_i16_f16_e32 v0, v0
+; GFX12-FAKE16-NEXT:    v_cvt_i16_f16_e32 v2, v2
+; GFX12-FAKE16-NEXT:    v_cvt_i16_f16_e32 v3, v3
 ; GFX12-FAKE16-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX12-FAKE16-NEXT:    v_med3_i32 v1, v1, s0, 0x7f
-; GFX12-FAKE16-NEXT:    v_med3_i32 v0, v0, s0, 0x7f
-; GFX12-FAKE16-NEXT:    v_med3_i32 v2, v2, s0, 0x7f
-; GFX12-FAKE16-NEXT:    v_med3_i32 v3, v3, s0, 0x7f
+; GFX12-FAKE16-NEXT:    v_med3_i16 v1, v1, s0, 0x7f
+; GFX12-FAKE16-NEXT:    v_med3_i16 v0, v0, s0, 0x7f
+; GFX12-FAKE16-NEXT:    v_med3_i16 v2, v2, s0, 0x7f
+; GFX12-FAKE16-NEXT:    v_med3_i16 v3, v3, s0, 0x7f
 ; GFX12-FAKE16-NEXT:    v_and_b32_e32 v1, 0xff, v1
 ; GFX12-FAKE16-NEXT:    v_and_b32_e32 v0, 0xff, v0
 ; GFX12-FAKE16-NEXT:    v_lshlrev_b16 v2, 8, v2
@@ -1595,31 +1561,26 @@ define <4 x i8> @test_signed_v4f16_v4i8(<4 x half> %f) {
 ; GFX12-TRUE16-NEXT:    s_wait_samplecnt 0x0
 ; GFX12-TRUE16-NEXT:    s_wait_bvhcnt 0x0
 ; GFX12-TRUE16-NEXT:    s_wait_kmcnt 0x0
-; GFX12-TRUE16-NEXT:    v_cvt_f32_f16_e32 v2, v1.l
-; GFX12-TRUE16-NEXT:    v_cvt_f32_f16_e32 v1, v1.h
-; GFX12-TRUE16-NEXT:    s_movk_i32 s0, 0xff80
-; GFX12-TRUE16-NEXT:    v_cvt_f32_f16_e32 v3, v0.l
-; GFX12-TRUE16-NEXT:    v_cvt_f32_f16_e32 v0, v0.h
-; GFX12-TRUE16-NEXT:    v_cvt_i32_f32_e32 v2, v2
-; GFX12-TRUE16-NEXT:    v_cvt_i32_f32_e32 v1, v1
-; GFX12-TRUE16-NEXT:    v_cvt_i32_f32_e32 v3, v3
-; GFX12-TRUE16-NEXT:    v_cvt_i32_f32_e32 v4, v0
-; GFX12-TRUE16-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX12-TRUE16-NEXT:    v_med3_i32 v2, v2, s0, 0x7f
-; GFX12-TRUE16-NEXT:    v_med3_i32 v1, v1, s0, 0x7f
-; GFX12-TRUE16-NEXT:    v_and_b16 v0.l, 0xff, v2.l
-; GFX12-TRUE16-NEXT:    v_lshlrev_b16 v0.h, 8, v1.l
-; GFX12-TRUE16-NEXT:    v_med3_i32 v2, v4, s0, 0x7f
-; GFX12-TRUE16-NEXT:    v_med3_i32 v1, v3, s0, 0x7f
-; GFX12-TRUE16-NEXT:    v_or_b16 v2.h, v0.l, v0.h
-; GFX12-TRUE16-NEXT:    v_and_b16 v0.l, 0xff, v1.l
-; GFX12-TRUE16-NEXT:    v_lshlrev_b16 v1.l, 8, v2.l
+; GFX12-TRUE16-NEXT:    v_mov_b16_e32 v2.l, 0xff80
+; GFX12-TRUE16-NEXT:    v_cvt_i16_f16_e32 v1.l, v1.l
+; GFX12-TRUE16-NEXT:    v_cvt_i16_f16_e32 v1.h, v1.h
+; GFX12-TRUE16-NEXT:    v_cvt_i16_f16_e32 v0.l, v0.l
+; GFX12-TRUE16-NEXT:    v_cvt_i16_f16_e32 v0.h, v0.h
+; GFX12-TRUE16-NEXT:    v_med3_i16 v1.l, v1.l, v2.l, 0x7f
+; GFX12-TRUE16-NEXT:    v_med3_i16 v1.h, v1.h, v2.l, 0x7f
+; GFX12-TRUE16-NEXT:    v_med3_i16 v0.l, v0.l, v2.l, 0x7f
+; GFX12-TRUE16-NEXT:    v_med3_i16 v0.h, v0.h, v2.l, 0x7f
 ; GFX12-TRUE16-NEXT:    v_mov_b16_e32 v2.l, 0
+; GFX12-TRUE16-NEXT:    v_and_b16 v1.l, 0xff, v1.l
+; GFX12-TRUE16-NEXT:    v_lshlrev_b16 v1.h, 8, v1.h
+; GFX12-TRUE16-NEXT:    v_and_b16 v0.l, 0xff, v0.l
+; GFX12-TRUE16-NEXT:    v_or_b16 v2.h, v1.l, v1.h
+; GFX12-TRUE16-NEXT:    v_lshlrev_b16 v1.l, 8, v0.h
 ; GFX12-TRUE16-NEXT:    v_mov_b16_e32 v1.h, v2.h
 ; GFX12-TRUE16-NEXT:    v_or_b16 v0.l, v0.l, v1.l
 ; GFX12-TRUE16-NEXT:    v_lshrrev_b32_e32 v3, 24, v2
-; GFX12-TRUE16-NEXT:    v_lshrrev_b32_e32 v1, 8, v1
 ; GFX12-TRUE16-NEXT:    v_mov_b16_e32 v2.l, v2.h
+; GFX12-TRUE16-NEXT:    v_lshrrev_b32_e32 v1, 8, v1
 ; GFX12-TRUE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX12-GI-LABEL: test_signed_v4f16_v4i8:
@@ -2153,96 +2114,73 @@ define <8 x i1> @test_signed_v8f16_v8i1(<8 x half> %f) {
 ; GFX9-LABEL: test_signed_v8f16_v8i1:
 ; GFX9:       ; %bb.0:
 ; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX9-NEXT:    v_cvt_f32_f16_e32 v6, v1
-; GFX9-NEXT:    v_cvt_f32_f16_e32 v7, v0
-; GFX9-NEXT:    v_cvt_f32_f16_e32 v4, v3
-; GFX9-NEXT:    v_cvt_f32_f16_e32 v5, v2
-; GFX9-NEXT:    v_cvt_f32_f16_sdwa v3, v3 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1
-; GFX9-NEXT:    v_cvt_f32_f16_sdwa v2, v2 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1
-; GFX9-NEXT:    v_cvt_f32_f16_sdwa v1, v1 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1
-; GFX9-NEXT:    v_cvt_f32_f16_sdwa v0, v0 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1
-; GFX9-NEXT:    v_cvt_i32_f32_e32 v8, v6
-; GFX9-NEXT:    v_cvt_i32_f32_e32 v7, v7
-; GFX9-NEXT:    v_cvt_i32_f32_e32 v4, v4
-; GFX9-NEXT:    v_cvt_i32_f32_e32 v5, v5
-; GFX9-NEXT:    v_cvt_i32_f32_e32 v3, v3
-; GFX9-NEXT:    v_cvt_i32_f32_e32 v2, v2
-; GFX9-NEXT:    v_cvt_i32_f32_e32 v1, v1
-; GFX9-NEXT:    v_cvt_i32_f32_e32 v0, v0
-; GFX9-NEXT:    v_med3_i32 v9, v8, -1, 0
-; GFX9-NEXT:    v_med3_i32 v8, v7, -1, 0
-; GFX9-NEXT:    v_med3_i32 v6, v4, -1, 0
-; GFX9-NEXT:    v_med3_i32 v4, v5, -1, 0
-; GFX9-NEXT:    v_med3_i32 v7, v3, -1, 0
-; GFX9-NEXT:    v_med3_i32 v5, v2, -1, 0
-; GFX9-NEXT:    v_med3_i32 v3, v1, -1, 0
-; GFX9-NEXT:    v_med3_i32 v1, v0, -1, 0
-; GFX9-NEXT:    v_mov_b32_e32 v0, v8
-; GFX9-NEXT:    v_mov_b32_e32 v2, v9
+; GFX9-NEXT:    v_cvt_i16_f16_e32 v4, v0
+; GFX9-NEXT:    v_cvt_i16_f16_sdwa v0, v0 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1
+; GFX9-NEXT:    v_med3_i16 v8, v0, -1, 0
+; GFX9-NEXT:    v_cvt_i16_f16_sdwa v0, v1 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1
+; GFX9-NEXT:    v_med3_i16 v11, v4, -1, 0
+; GFX9-NEXT:    v_cvt_i16_f16_e32 v4, v1
+; GFX9-NEXT:    v_cvt_i16_f16_e32 v5, v3
+; GFX9-NEXT:    v_med3_i16 v9, v0, -1, 0
+; GFX9-NEXT:    v_cvt_i16_f16_sdwa v0, v2 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1
+; GFX9-NEXT:    v_med3_i16 v10, v4, -1, 0
+; GFX9-NEXT:    v_cvt_i16_f16_e32 v4, v2
+; GFX9-NEXT:    v_med3_i16 v6, v5, -1, 0
+; GFX9-NEXT:    v_med3_i16 v5, v0, -1, 0
+; GFX9-NEXT:    v_cvt_i16_f16_sdwa v0, v3 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1
+; GFX9-NEXT:    v_med3_i16 v4, v4, -1, 0
+; GFX9-NEXT:    v_med3_i16 v7, v0, -1, 0
+; GFX9-NEXT:    v_mov_b32_e32 v0, v11
+; GFX9-NEXT:    v_mov_b32_e32 v1, v8
+; GFX9-NEXT:    v_mov_b32_e32 v2, v10
+; GFX9-NEXT:    v_mov_b32_e32 v3, v9
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-FAKE16-LABEL: test_signed_v8f16_v8i1:
 ; GFX11-FAKE16:       ; %bb.0:
 ; GFX11-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX11-FAKE16-NEXT:    v_cvt_f32_f16_e32 v4, v3
-; GFX11-FAKE16-NEXT:    v_cvt_f32_f16_e32 v5, v2
-; GFX11-FAKE16-NEXT:    v_cvt_f32_f16_e32 v6, v1
-; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v3, 16, v3
+; GFX11-FAKE16-NEXT:    v_cvt_i16_f16_e32 v5, v1
+; GFX11-FAKE16-NEXT:    v_cvt_i16_f16_e32 v6, v2
+; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v7, 16, v0
 ; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v1, 16, v1
-; GFX11-FAKE16-NEXT:    v_cvt_i32_f32_e32 v4, v4
-; GFX11-FAKE16-NEXT:    v_cvt_i32_f32_e32 v5, v5
-; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v9, 16, v0
 ; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v2, 16, v2
-; GFX11-FAKE16-NEXT:    v_cvt_i32_f32_e32 v7, v6
-; GFX11-FAKE16-NEXT:    v_med3_i32 v6, v4, -1, 0
-; GFX11-FAKE16-NEXT:    v_med3_i32 v4, v5, -1, 0
-; GFX11-FAKE16-NEXT:    v_cvt_f32_f16_e32 v0, v0
-; GFX11-FAKE16-NEXT:    v_cvt_f32_f16_e32 v5, v9
-; GFX11-FAKE16-NEXT:    v_cvt_f32_f16_e32 v3, v3
-; GFX11-FAKE16-NEXT:    v_cvt_f32_f16_e32 v1, v1
-; GFX11-FAKE16-NEXT:    v_cvt_f32_f16_e32 v2, v2
-; GFX11-FAKE16-NEXT:    v_med3_i32 v8, v7, -1, 0
-; GFX11-FAKE16-NEXT:    v_cvt_i32_f32_e32 v0, v0
-; GFX11-FAKE16-NEXT:    v_cvt_i32_f32_e32 v5, v5
-; GFX11-FAKE16-NEXT:    v_cvt_i32_f32_e32 v3, v3
-; GFX11-FAKE16-NEXT:    v_cvt_i32_f32_e32 v9, v1
-; GFX11-FAKE16-NEXT:    v_cvt_i32_f32_e32 v2, v2
-; GFX11-FAKE16-NEXT:    v_med3_i32 v0, v0, -1, 0
-; GFX11-FAKE16-NEXT:    v_med3_i32 v1, v5, -1, 0
-; GFX11-FAKE16-NEXT:    v_med3_i32 v7, v3, -1, 0
-; GFX11-FAKE16-NEXT:    v_med3_i32 v3, v9, -1, 0
-; GFX11-FAKE16-NEXT:    v_med3_i32 v5, v2, -1, 0
+; GFX11-FAKE16-NEXT:    v_med3_i16 v8, v5, -1, 0
+; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v5, 16, v3
+; GFX11-FAKE16-NEXT:    v_cvt_i16_f16_e32 v4, v0
+; GFX11-FAKE16-NEXT:    v_cvt_i16_f16_e32 v3, v3
+; GFX11-FAKE16-NEXT:    v_cvt_i16_f16_e32 v7, v7
+; GFX11-FAKE16-NEXT:    v_cvt_i16_f16_e32 v9, v1
+; GFX11-FAKE16-NEXT:    v_cvt_i16_f16_e32 v2, v2
+; GFX11-FAKE16-NEXT:    v_cvt_i16_f16_e32 v10, v5
+; GFX11-FAKE16-NEXT:    v_med3_i16 v0, v4, -1, 0
+; GFX11-FAKE16-NEXT:    v_med3_i16 v4, v6, -1, 0
+; GFX11-FAKE16-NEXT:    v_med3_i16 v6, v3, -1, 0
+; GFX11-FAKE16-NEXT:    v_med3_i16 v1, v7, -1, 0
+; GFX11-FAKE16-NEXT:    v_med3_i16 v3, v9, -1, 0
+; GFX11-FAKE16-NEXT:    v_med3_i16 v5, v2, -1, 0
+; GFX11-FAKE16-NEXT:    v_med3_i16 v7, v10, -1, 0
 ; GFX11-FAKE16-NEXT:    v_mov_b32_e32 v2, v8
 ; GFX11-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-TRUE16-LABEL: test_signed_v8f16_v8i1:
 ; GFX11-TRUE16:       ; %bb.0:
 ; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX11-TRUE16-NEXT:    v_cvt_f32_f16_e32 v4, v3.l
-; GFX11-TRUE16-NEXT:    v_cvt_f32_f16_e32 v5, v2.l
-; GFX11-TRUE16-NEXT:    v_cvt_f32_f16_e32 v6, v1.l
-; GFX11-TRUE16-NEXT:    v_cvt_f32_f16_e32 v7, v0.l
-; GFX11-TRUE16-NEXT:    v_cvt_f32_f16_e32 v3, v3.h
-; GFX11-TRUE16-NEXT:    v_cvt_i32_f32_e32 v4, v4
-; GFX11-TRUE16-NEXT:    v_cvt_i32_f32_e32 v5, v5
-; GFX11-TRUE16-NEXT:    v_cvt_i32_f32_e32 v8, v6
-; GFX11-TRUE16-NEXT:    v_cvt_f32_f16_e32 v0, v0.h
-; GFX11-TRUE16-NEXT:    v_cvt_f32_f16_e32 v1, v1.h
-; GFX11-TRUE16-NEXT:    v_cvt_f32_f16_e32 v2, v2.h
-; GFX11-TRUE16-NEXT:    v_med3_i32 v6, v4, -1, 0
-; GFX11-TRUE16-NEXT:    v_med3_i32 v4, v5, -1, 0
-; GFX11-TRUE16-NEXT:    v_med3_i32 v8, v8, -1, 0
-; GFX11-TRUE16-NEXT:    v_cvt_i32_f32_e32 v5, v7
-; GFX11-TRUE16-NEXT:    v_cvt_i32_f32_e32 v7, v0
-; GFX11-TRUE16-NEXT:    v_cvt_i32_f32_e32 v3, v3
-; GFX11-TRUE16-NEXT:    v_cvt_i32_f32_e32 v9, v1
-; GFX11-TRUE16-NEXT:    v_cvt_i32_f32_e32 v2, v2
-; GFX11-TRUE16-NEXT:    v_med3_i32 v0, v5, -1, 0
-; GFX11-TRUE16-NEXT:    v_med3_i32 v1, v7, -1, 0
-; GFX11-TRUE16-NEXT:    v_med3_i32 v7, v3, -1, 0
-; GFX11-TRUE16-NEXT:    v_med3_i32 v3, v9, -1, 0
-; GFX11-TRUE16-NEXT:    v_med3_i32 v5, v2, -1, 0
-; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v2.l, v8.l
+; GFX11-TRUE16-NEXT:    v_cvt_i16_f16_e32 v0.l, v0.l
+; GFX11-TRUE16-NEXT:    v_cvt_i16_f16_e32 v1.l, v1.l
+; GFX11-TRUE16-NEXT:    v_cvt_i16_f16_e32 v4.l, v2.l
+; GFX11-TRUE16-NEXT:    v_cvt_i16_f16_e32 v3.l, v3.l
+; GFX11-TRUE16-NEXT:    v_cvt_i16_f16_e32 v0.h, v0.h
+; GFX11-TRUE16-NEXT:    v_cvt_i16_f16_e32 v1.h, v1.h
+; GFX11-TRUE16-NEXT:    v_cvt_i16_f16_e32 v2.h, v2.h
+; GFX11-TRUE16-NEXT:    v_cvt_i16_f16_e32 v3.h, v3.h
+; GFX11-TRUE16-NEXT:    v_med3_i16 v0.l, v0.l, -1, 0
+; GFX11-TRUE16-NEXT:    v_med3_i16 v2.l, v1.l, -1, 0
+; GFX11-TRUE16-NEXT:    v_med3_i16 v4.l, v4.l, -1, 0
+; GFX11-TRUE16-NEXT:    v_med3_i16 v6.l, v3.l, -1, 0
+; GFX11-TRUE16-NEXT:    v_med3_i16 v1.l, v0.h, -1, 0
+; GFX11-TRUE16-NEXT:    v_med3_i16 v3.l, v1.h, -1, 0
+; GFX11-TRUE16-NEXT:    v_med3_i16 v5.l, v2.h, -1, 0
+; GFX11-TRUE16-NEXT:    v_med3_i16 v7.l, v3.h, -1, 0
 ; GFX11-TRUE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX12-FAKE16-LABEL: test_signed_v8f16_v8i1:
@@ -2252,34 +2190,26 @@ define <8 x i1> @test_signed_v8f16_v8i1(<8 x half> %f) {
 ; GFX12-FAKE16-NEXT:    s_wait_samplecnt 0x0
 ; GFX12-FAKE16-NEXT:    s_wait_bvhcnt 0x0
 ; GFX12-FAKE16-NEXT:    s_wait_kmcnt 0x0
-; GFX12-FAKE16-NEXT:    v_cvt_f32_f16_e32 v4, v3
-; GFX12-FAKE16-NEXT:    v_cvt_f32_f16_e32 v5, v2
-; GFX12-FAKE16-NEXT:    v_cvt_f32_f16_e32 v6, v1
-; GFX12-FAKE16-NEXT:    v_lshrrev_b32_e32 v3, 16, v3
+; GFX12-FAKE16-NEXT:    v_cvt_i16_f16_e32 v5, v1
+; GFX12-FAKE16-NEXT:    v_cvt_i16_f16_e32 v6, v2
+; GFX12-FAKE16-NEXT:    v_lshrrev_b32_e32 v7, 16, v0
 ; GFX12-FAKE16-NEXT:    v_lshrrev_b32_e32 v1, 16, v1
-; GFX12-FAKE16-NEXT:    v_cvt_i32_f32_e32 v4, v4
-; GFX12-FAKE16-NEXT:    v_cvt_i32_f32_e32 v5, v5
-; GFX12-FAKE16-NEXT:    v_lshrrev_b32_e32 v9, 16, v0
 ; GFX12-FAKE16-NEXT:    v_lshrrev_b32_e32 v2, 16, v2
-; GFX12-FAKE16-NEXT:    v_cvt_i32_f32_e32 v7, v6
-; GFX12-FAKE16-NEXT:    v_med3_i32 v6, v4, -1, 0
-; GFX12-FAKE16-NEXT:    v_med3_i32 v4, v5, -1, 0
-; GFX12-FAKE16-NEXT:    v_cvt_f32_f16_e32 v0, v0
-; GFX12-FAKE16-NEXT:    v_cvt_f32_f16_e32 v5, v9
-; GFX12-FAKE16-NEXT:    v_cvt_f32_f16_e32 v3, v3
-; GFX12-FAKE16-NEXT:    v_cvt_f32_f16_e32 v1, v1
-; GFX12-FAKE16-NEXT:    v_cvt_f32_f16_e32 v2, v2
-; GFX12-FAKE16-NEXT:    v_med3_i32 v8, v7, -1, 0
-; GFX12-FAKE16-NEXT:    v_cvt_i32_f32_e32 v0, v0
-; GFX12-FAKE16-NEXT:    v_cvt_i32_f32_e32 v5, v5
-; GFX12-FAKE16-NEXT:    v_cvt_i32_f32_e32 v3, v3
-; GFX12-FAKE16-NEXT:    v_cvt_i32_f32_e32 v9, v1
-; GFX12-FAKE16-NEXT:    v_cvt_i32_f32_e32 v2, v2
-; GFX12-FAKE16-NEXT:    v_med3_i32 v0, v0, -1, 0
-; GFX12-FAKE16-NEXT:    v_med3_i32 v1, v5, -1, 0
-; GFX12-FAKE16-NEXT:    v_med3_i32 v7, v3, -1, 0
-; GFX12-FAKE16-NEXT:    v_med3_i32 v3, v9, -1, 0
-; GFX12-FAKE16-NEXT:    v_med3_i32 v5, v2, -1, 0
+; GFX12-FAKE16-NEXT:    v_med3_i16 v8, v5, -1, 0
+; GFX12-FAKE16-NEXT:    v_lshrrev_b32_e32 v5, 16, v3
+; GFX12-FAKE16-NEXT:    v_cvt_i16_f16_e32 v4, v0
+; GFX12-FAKE16-NEXT:    v_cvt_i16_f16_e32 v3, v3
+; GFX12-FAKE16-NEXT:    v_cvt_i16_f16_e32 v7, v7
+; GFX12-FAKE16-NEXT:    v_cvt_i16_f16_e32 v9, v1
+; GFX12-FAKE16-NEXT:    v_cvt_i16_f16_e32 v2, v2
+; GFX12-FAKE16-NEXT:    v_cvt_i16_f16_e32 v10, v5
+; GFX12-FAKE16-NEXT:    v_med3_i16 v0, v4, -1, 0
+; GFX12-FAKE16-NEXT:    v_med3_i16 v4, v6, -1, 0
+; GFX12-FAKE16-NEXT:    v_med3_i16 v6, v3, -1, 0
+; GFX12-FAKE16-NEXT:    v_med3_i16 v1, v7, -1, 0
+; GFX12-FAKE16-NEXT:    v_med3_i16 v3, v9, -1, 0
+; GFX12-FAKE16-NEXT:    v_med3_i16 v5, v2, -1, 0
+; GFX12-FAKE16-NEXT:    v_med3_i16 v7, v10, -1, 0
 ; GFX12-FAKE16-NEXT:    v_mov_b32_e32 v2, v8
 ; GFX12-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -2290,31 +2220,22 @@ define <8 x i1> @test_signed_v8f16_v8i1(<8 x half> %f) {
 ; GFX12-TRUE16-NEXT:    s_wait_samplecnt 0x0
 ; GFX12-TRUE16-NEXT:    s_wait_bvhcnt 0x0
 ; GFX12-TRUE16-NEXT:    s_wait_kmcnt 0x0
-; GFX12-TRUE16-NEXT:    v_cvt_f32_f16_e32 v4, v3.l
-; GFX12-TRUE16-NEXT:    v_cvt_f32_f16_e32 v5, v2.l
-; GFX12-TRUE16-NEXT:    v_cvt_f32_f16_e32 v6, v1.l
-; GFX12-TRUE16-NEXT:    v_cvt_f32_f16_e32 v7, v0.l
-; GFX12-TRUE16-NEXT:    v_cvt_f32_f16_e32 v3, v3.h
-; GFX12-TRUE16-NEXT:    v_cvt_i32_f32_e32 v4, v4
-; GFX12-TRUE16-NEXT:    v_cvt_i32_f32_e32 v5, v5
-; GFX12-TRUE16-NEXT:    v_cvt_i32_f32_e32 v8, v6
-; GFX12-TRUE16-NEXT:    v_cvt_f32_f16_e32 v0, v0.h
-; GFX12-TRUE16-NEXT:    v_cvt_f32_f16_e32 v1, v1.h
-; GFX12-TRUE16-NEXT:    v_cvt_f32_f16_e32 v2, v2.h
-; GFX12-TRUE16-NEXT:    v_med3_i32 v6, v4, -1, 0
-; GFX12-TRUE16-NEXT:    v_med3_i32 v4, v5, -1, 0
-; GFX12-TRUE16-NEXT:    v_med3_i32 v8, v8, -1, 0
-; GFX12-TRUE16-NEXT:    v_cvt_i32_f32_e32 v5, v7
-; GFX12-TRUE16-NEXT:    v_cvt_i32_f32_e32 v7, v0
-; GFX12-TRUE16-NEXT:    v_cvt_i32_f32_e32 v3, v3
-; GFX12-TRUE16-NEXT:    v_cvt_i32_f32_e32 v9, v1
-; GFX12-TRUE16-NEXT:    v_cvt_i32_f32_e32 v2, v2
-; GFX12-TRUE16-NEXT:    v_med3_i32 v0, v5, -1, 0
-; GFX12-TRUE16-NEXT:    v_med3_i32 v1, v7, -1, 0
-; GFX12-TRUE16-NEXT:    v_med3_i32 v7, v3, -1, 0
-; GFX12-TRUE16-NEXT:    v_med3_i32 v3, v9, -1, 0
-; GFX12-TRUE16-NEXT:    v_med3_i32 v5, v2, -1, 0
-; GFX12-TRUE16-NEXT:    v_mov_b16_e32 v2.l, v8.l
+; GFX12-TRUE16-NEXT:    v_cvt_i16_f16_e32 v0.l, v0.l
+; GFX12-TRUE16-NEXT:    v_cvt_i16_f16_e32 v1.l, v1.l
+; GFX12-TRUE16-NEXT:    v_cvt_i16_f16_e32 v4.l, v2.l
+; GFX12-TRUE16-NEXT:    v_cvt_i16_f16_e32 v3.l, v3.l
+; GFX12-TRUE16-NEXT:    v_cvt_i16_f16_e32 v0.h, v0.h
+; GFX12-TRUE16-NEXT:    v_cvt_i16_f16_e32 v1.h, v1.h
+; GFX12-TRUE16-NEXT:    v_cvt_i16_f16_e32 v2.h, v2.h
+; GFX12-TRUE16-NEXT:    v_cvt_i16_f16_e32 v3.h, v3.h
+; GFX12-TRUE16-NEXT:    v_med3_i16 v0.l, v0.l, -1, 0
+; GFX12-TRUE16-NEXT:    v_med3_i16 v2.l, v1.l, -1, 0
+; GFX12-TRUE16-NEXT:    v_med3_i16 v4.l, v4.l, -1, 0
+; GFX12-TRUE16-NEXT:    v_med3_i16 v6.l, v3.l, -1, 0
+; GFX12-TRUE16-NEXT:    v_med3_i16 v1.l, v0.h, -1, 0
+; GFX12-TRUE16-NEXT:    v_med3_i16 v3.l, v1.h, -1, 0
+; GFX12-TRUE16-NEXT:    v_med3_i16 v5.l, v2.h, -1, 0
+; GFX12-TRUE16-NEXT:    v_med3_i16 v7.l, v3.h, -1, 0
 ; GFX12-TRUE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX12-GI-LABEL: test_signed_v8f16_v8i1:
@@ -2453,41 +2374,33 @@ define <8 x i8> @test_signed_v8f16_v8i8(<8 x half> %f) {
 ; GFX9-LABEL: test_signed_v8f16_v8i8:
 ; GFX9:       ; %bb.0:
 ; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX9-NEXT:    v_cvt_f32_f16_e32 v4, v2
-; GFX9-NEXT:    v_cvt_f32_f16_sdwa v2, v2 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1
-; GFX9-NEXT:    v_cvt_f32_f16_e32 v5, v3
-; GFX9-NEXT:    v_cvt_f32_f16_sdwa v3, v3 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1
-; GFX9-NEXT:    v_cvt_i32_f32_e32 v4, v4
-; GFX9-NEXT:    v_cvt_i32_f32_e32 v2, v2
+; GFX9-NEXT:    v_cvt_i16_f16_e32 v4, v2
 ; GFX9-NEXT:    s_movk_i32 s4, 0xff80
 ; GFX9-NEXT:    v_mov_b32_e32 v7, 0x7f
-; GFX9-NEXT:    v_med3_i32 v4, v4, s4, v7
-; GFX9-NEXT:    v_med3_i32 v2, v2, s4, v7
-; GFX9-NEXT:    v_cvt_i32_f32_e32 v3, v3
+; GFX9-NEXT:    v_cvt_i16_f16_sdwa v2, v2 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1
+; GFX9-NEXT:    v_med3_i16 v2, v2, s4, v7
+; GFX9-NEXT:    v_med3_i16 v4, v4, s4, v7
 ; GFX9-NEXT:    v_lshlrev_b16_e32 v2, 8, v2
-; GFX9-NEXT:    v_cvt_i32_f32_e32 v5, v5
 ; GFX9-NEXT:    v_or_b32_sdwa v8, v4, v2 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:BYTE_0 src1_sel:DWORD
-; GFX9-NEXT:    v_cvt_f32_f16_e32 v4, v1
-; GFX9-NEXT:    v_cvt_f32_f16_sdwa v1, v1 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1
-; GFX9-NEXT:    v_med3_i32 v3, v3, s4, v7
-; GFX9-NEXT:    v_med3_i32 v2, v5, s4, v7
+; GFX9-NEXT:    v_cvt_i16_f16_e32 v2, v3
+; GFX9-NEXT:    v_cvt_i16_f16_sdwa v3, v3 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1
+; GFX9-NEXT:    v_med3_i16 v3, v3, s4, v7
+; GFX9-NEXT:    v_med3_i16 v2, v2, s4, v7
 ; GFX9-NEXT:    v_lshlrev_b16_e32 v3, 8, v3
-; GFX9-NEXT:    v_cvt_i32_f32_e32 v1, v1
 ; GFX9-NEXT:    v_or_b32_sdwa v6, v2, v3 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:BYTE_0 src1_sel:DWORD
-; GFX9-NEXT:    v_cvt_i32_f32_e32 v2, v4
-; GFX9-NEXT:    v_cvt_f32_f16_e32 v3, v0
-; GFX9-NEXT:    v_cvt_f32_f16_sdwa v0, v0 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1
-; GFX9-NEXT:    v_med3_i32 v1, v1, s4, v7
-; GFX9-NEXT:    v_med3_i32 v2, v2, s4, v7
+; GFX9-NEXT:    v_cvt_i16_f16_e32 v2, v1
+; GFX9-NEXT:    v_cvt_i16_f16_sdwa v1, v1 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1
+; GFX9-NEXT:    v_med3_i16 v1, v1, s4, v7
+; GFX9-NEXT:    v_med3_i16 v2, v2, s4, v7
 ; GFX9-NEXT:    v_lshlrev_b16_e32 v1, 8, v1
-; GFX9-NEXT:    v_cvt_i32_f32_e32 v0, v0
 ; GFX9-NEXT:    v_or_b32_sdwa v2, v2, v1 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:BYTE_0 src1_sel:DWORD
-; GFX9-NEXT:    v_cvt_i32_f32_e32 v1, v3
+; GFX9-NEXT:    v_cvt_i16_f16_e32 v1, v0
+; GFX9-NEXT:    v_cvt_i16_f16_sdwa v0, v0 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1
 ; GFX9-NEXT:    v_lshlrev_b32_e32 v9, 16, v6
-; GFX9-NEXT:    v_med3_i32 v0, v0, s4, v7
+; GFX9-NEXT:    v_med3_i16 v0, v0, s4, v7
 ; GFX9-NEXT:    v_or_b32_sdwa v4, v8, v9 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
 ; GFX9-NEXT:    v_lshlrev_b32_e32 v3, 16, v2
-; GFX9-NEXT:    v_med3_i32 v1, v1, s4, v7
+; GFX9-NEXT:    v_med3_i16 v1, v1, s4, v7
 ; GFX9-NEXT:    v_lshlrev_b16_e32 v7, 8, v0
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v5, 8, v4
 ; GFX9-NEXT:    v_or_b32_sdwa v0, v1, v7 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:BYTE_0 src1_sel:DWORD
@@ -2502,55 +2415,47 @@ define <8 x i8> @test_signed_v8f16_v8i8(<8 x half> %f) {
 ; GFX11-FAKE16:       ; %bb.0:
 ; GFX11-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v4, 16, v2
-; GFX11-FAKE16-NEXT:    v_cvt_f32_f16_e32 v2, v2
-; GFX11-FAKE16-NEXT:    v_cvt_f32_f16_e32 v5, v3
+; GFX11-FAKE16-NEXT:    v_cvt_i16_f16_e32 v2, v2
+; GFX11-FAKE16-NEXT:    v_cvt_i16_f16_e32 v5, v3
 ; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v3, 16, v3
-; GFX11-FAKE16-NEXT:    v_cvt_f32_f16_e32 v6, v1
-; GFX11-FAKE16-NEXT:    v_cvt_f32_f16_e32 v4, v4
-; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v1, 16, v1
-; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v7, 16, v0
-; GFX11-FAKE16-NEXT:    v_cvt_i32_f32_e32 v2, v2
-; GFX11-FAKE16-NEXT:    v_cvt_f32_f16_e32 v3, v3
-; GFX11-FAKE16-NEXT:    v_cvt_i32_f32_e32 v4, v4
-; GFX11-FAKE16-NEXT:    v_cvt_f32_f16_e32 v1, v1
+; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v6, 16, v1
+; GFX11-FAKE16-NEXT:    v_cvt_i16_f16_e32 v4, v4
 ; GFX11-FAKE16-NEXT:    s_movk_i32 s0, 0xff80
-; GFX11-FAKE16-NEXT:    v_cvt_i32_f32_e32 v5, v5
-; GFX11-FAKE16-NEXT:    v_cvt_i32_f32_e32 v6, v6
-; GFX11-FAKE16-NEXT:    v_med3_i32 v2, v2, s0, 0x7f
-; GFX11-FAKE16-NEXT:    v_med3_i32 v4, v4, s0, 0x7f
-; GFX11-FAKE16-NEXT:    v_cvt_f32_f16_e32 v7, v7
-; GFX11-FAKE16-NEXT:    v_cvt_i32_f32_e32 v1, v1
-; GFX11-FAKE16-NEXT:    v_cvt_i32_f32_e32 v3, v3
-; GFX11-FAKE16-NEXT:    v_med3_i32 v5, v5, s0, 0x7f
+; GFX11-FAKE16-NEXT:    v_cvt_i16_f16_e32 v1, v1
+; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v7, 16, v0
+; GFX11-FAKE16-NEXT:    v_med3_i16 v2, v2, s0, 0x7f
+; GFX11-FAKE16-NEXT:    v_cvt_i16_f16_e32 v6, v6
+; GFX11-FAKE16-NEXT:    v_med3_i16 v4, v4, s0, 0x7f
+; GFX11-FAKE16-NEXT:    v_cvt_i16_f16_e32 v3, v3
+; GFX11-FAKE16-NEXT:    v_med3_i16 v1, v1, s0, 0x7f
 ; GFX11-FAKE16-NEXT:    v_and_b32_e32 v2, 0xff, v2
+; GFX11-FAKE16-NEXT:    v_med3_i16 v6, v6, s0, 0x7f
 ; GFX11-FAKE16-NEXT:    v_lshlrev_b16 v4, 8, v4
-; GFX11-FAKE16-NEXT:    v_med3_i32 v6, v6, s0, 0x7f
-; GFX11-FAKE16-NEXT:    v_med3_i32 v1, v1, s0, 0x7f
-; GFX11-FAKE16-NEXT:    v_cvt_i32_f32_e32 v7, v7
-; GFX11-FAKE16-NEXT:    v_med3_i32 v3, v3, s0, 0x7f
+; GFX11-FAKE16-NEXT:    v_med3_i16 v5, v5, s0, 0x7f
+; GFX11-FAKE16-NEXT:    v_cvt_i16_f16_e32 v7, v7
+; GFX11-FAKE16-NEXT:    v_med3_i16 v3, v3, s0, 0x7f
+; GFX11-FAKE16-NEXT:    v_lshlrev_b16 v6, 8, v6
 ; GFX11-FAKE16-NEXT:    v_or_b32_e32 v8, v2, v4
+; GFX11-FAKE16-NEXT:    v_and_b32_e32 v1, 0xff, v1
 ; GFX11-FAKE16-NEXT:    v_and_b32_e32 v5, 0xff, v5
-; GFX11-FAKE16-NEXT:    v_and_b32_e32 v6, 0xff, v6
-; GFX11-FAKE16-NEXT:    v_lshlrev_b16 v1, 8, v1
-; GFX11-FAKE16-NEXT:    v_med3_i32 v7, v7, s0, 0x7f
+; GFX11-FAKE16-NEXT:    v_med3_i16 v7, v7, s0, 0x7f
 ; GFX11-FAKE16-NEXT:    v_lshlrev_b16 v3, 8, v3
-; GFX11-FAKE16-NEXT:    v_cvt_f32_f16_e32 v0, v0
-; GFX11-FAKE16-NEXT:    v_or_b32_e32 v2, v6, v1
+; GFX11-FAKE16-NEXT:    v_cvt_i16_f16_e32 v0, v0
+; GFX11-FAKE16-NEXT:    v_or_b32_e32 v2, v1, v6
 ; GFX11-FAKE16-NEXT:    v_lshlrev_b16 v1, 8, v7
 ; GFX11-FAKE16-NEXT:    v_or_b32_e32 v6, v5, v3
-; GFX11-FAKE16-NEXT:    v_cvt_i32_f32_e32 v0, v0
 ; GFX11-FAKE16-NEXT:    v_and_b32_e32 v3, 0xffff, v8
 ; GFX11-FAKE16-NEXT:    v_lshlrev_b32_e32 v4, 16, v2
+; GFX11-FAKE16-NEXT:    v_med3_i16 v0, v0, s0, 0x7f
 ; GFX11-FAKE16-NEXT:    v_and_b32_e32 v5, 0xffff, v1
 ; GFX11-FAKE16-NEXT:    v_lshlrev_b32_e32 v7, 16, v6
-; GFX11-FAKE16-NEXT:    v_med3_i32 v0, v0, s0, 0x7f
+; GFX11-FAKE16-NEXT:    v_and_b32_e32 v0, 0xff, v0
 ; GFX11-FAKE16-NEXT:    v_or_b32_e32 v9, v5, v4
 ; GFX11-FAKE16-NEXT:    v_or_b32_e32 v5, v3, v7
-; GFX11-FAKE16-NEXT:    v_and_b32_e32 v0, 0xff, v0
 ; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v7, 24, v7
-; GFX11-FAKE16-NEXT:    v_lshrrev_b64 v[3:4], 24, v[4:5]
 ; GFX11-FAKE16-NEXT:    v_or_b32_e32 v0, v0, v1
 ; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v1, 8, v9
+; GFX11-FAKE16-NEXT:    v_lshrrev_b64 v[3:4], 24, v[4:5]
 ; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v5, 8, v5
 ; GFX11-FAKE16-NEXT:    v_mov_b32_e32 v4, v8
 ; GFX11-FAKE16-NEXT:    s_setpc_b64 s[30:31]
@@ -2558,54 +2463,46 @@ define <8 x i8> @test_signed_v8f16_v8i8(<8 x half> %f) {
 ; GFX11-TRUE16-LABEL: test_signed_v8f16_v8i8:
 ; GFX11-TRUE16:       ; %bb.0:
 ; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX11-TRUE16-NEXT:    v_cvt_f32_f16_e32 v4, v3.l
-; GFX11-TRUE16-NEXT:    v_cvt_f32_f16_e32 v3, v3.h
-; GFX11-TRUE16-NEXT:    v_cvt_f32_f16_e32 v6, v1.l
-; GFX11-TRUE16-NEXT:    v_cvt_f32_f16_e32 v1, v1.h
-; GFX11-TRUE16-NEXT:    s_movk_i32 s0, 0xff80
-; GFX11-TRUE16-NEXT:    v_cvt_i32_f32_e32 v4, v4
-; GFX11-TRUE16-NEXT:    v_cvt_i32_f32_e32 v3, v3
-; GFX11-TRUE16-NEXT:    v_cvt_f32_f16_e32 v5, v2.l
-; GFX11-TRUE16-NEXT:    v_cvt_i32_f32_e32 v6, v6
-; GFX11-TRUE16-NEXT:    v_cvt_i32_f32_e32 v7, v1
-; GFX11-TRUE16-NEXT:    v_med3_i32 v4, v4, s0, 0x7f
-; GFX11-TRUE16-NEXT:    v_med3_i32 v3, v3, s0, 0x7f
-; GFX11-TRUE16-NEXT:    v_cvt_f32_f16_e32 v2, v2.h
-; GFX11-TRUE16-NEXT:    v_cvt_i32_f32_e32 v5, v5
-; GFX11-TRUE16-NEXT:    v_med3_i32 v7, v7, s0, 0x7f
-; GFX11-TRUE16-NEXT:    v_and_b16 v1.l, 0xff, v4.l
-; GFX11-TRUE16-NEXT:    v_lshlrev_b16 v1.h, 8, v3.l
-; GFX11-TRUE16-NEXT:    v_med3_i32 v3, v6, s0, 0x7f
-; GFX11-TRUE16-NEXT:    v_cvt_f32_f16_e32 v4, v0.l
-; GFX11-TRUE16-NEXT:    v_cvt_f32_f16_e32 v6, v0.h
-; GFX11-TRUE16-NEXT:    v_cvt_i32_f32_e32 v2, v2
-; GFX11-TRUE16-NEXT:    v_med3_i32 v5, v5, s0, 0x7f
-; GFX11-TRUE16-NEXT:    v_and_b16 v0.l, 0xff, v3.l
-; GFX11-TRUE16-NEXT:    v_cvt_i32_f32_e32 v3, v4
-; GFX11-TRUE16-NEXT:    v_cvt_i32_f32_e32 v4, v6
-; GFX11-TRUE16-NEXT:    v_lshlrev_b16 v0.h, 8, v7.l
-; GFX11-TRUE16-NEXT:    v_med3_i32 v6, v2, s0, 0x7f
-; GFX11-TRUE16-NEXT:    v_and_b16 v2.l, 0xff, v5.l
+; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v4.l, 0xff80
+; GFX11-TRUE16-NEXT:    v_cvt_i16_f16_e32 v1.l, v1.l
+; GFX11-TRUE16-NEXT:    v_cvt_i16_f16_e32 v1.h, v1.h
+; GFX11-TRUE16-NEXT:    v_cvt_i16_f16_e32 v3.l, v3.l
+; GFX11-TRUE16-NEXT:    v_cvt_i16_f16_e32 v3.h, v3.h
+; GFX11-TRUE16-NEXT:    v_cvt_i16_f16_e32 v2.l, v2.l
+; GFX11-TRUE16-NEXT:    v_med3_i16 v1.l, v1.l, v4.l, 0x7f
+; GFX11-TRUE16-NEXT:    v_med3_i16 v1.h, v1.h, v4.l, 0x7f
+; GFX11-TRUE16-NEXT:    v_cvt_i16_f16_e32 v2.h, v2.h
+; GFX11-TRUE16-NEXT:    v_med3_i16 v3.l, v3.l, v4.l, 0x7f
+; GFX11-TRUE16-NEXT:    v_med3_i16 v3.h, v3.h, v4.l, 0x7f
+; GFX11-TRUE16-NEXT:    v_med3_i16 v2.l, v2.l, v4.l, 0x7f
+; GFX11-TRUE16-NEXT:    v_and_b16 v1.l, 0xff, v1.l
+; GFX11-TRUE16-NEXT:    v_cvt_i16_f16_e32 v0.l, v0.l
+; GFX11-TRUE16-NEXT:    v_cvt_i16_f16_e32 v0.h, v0.h
+; GFX11-TRUE16-NEXT:    v_lshlrev_b16 v1.h, 8, v1.h
+; GFX11-TRUE16-NEXT:    v_med3_i16 v2.h, v2.h, v4.l, 0x7f
+; GFX11-TRUE16-NEXT:    v_and_b16 v3.l, 0xff, v3.l
+; GFX11-TRUE16-NEXT:    v_lshlrev_b16 v3.h, 8, v3.h
+; GFX11-TRUE16-NEXT:    v_and_b16 v2.l, 0xff, v2.l
+; GFX11-TRUE16-NEXT:    v_med3_i16 v0.l, v0.l, v4.l, 0x7f
+; GFX11-TRUE16-NEXT:    v_med3_i16 v0.h, v0.h, v4.l, 0x7f
+; GFX11-TRUE16-NEXT:    v_or_b16 v8.h, v1.l, v1.h
+; GFX11-TRUE16-NEXT:    v_lshlrev_b16 v1.l, 8, v2.h
 ; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v8.l, 0
-; GFX11-TRUE16-NEXT:    v_med3_i32 v3, v3, s0, 0x7f
-; GFX11-TRUE16-NEXT:    v_or_b16 v8.h, v0.l, v0.h
-; GFX11-TRUE16-NEXT:    v_lshlrev_b16 v0.l, 8, v6.l
-; GFX11-TRUE16-NEXT:    v_med3_i32 v4, v4, s0, 0x7f
-; GFX11-TRUE16-NEXT:    v_or_b16 v9.h, v1.l, v1.h
-; GFX11-TRUE16-NEXT:    v_and_b16 v0.h, 0xff, v3.l
-; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v1.h, v8.h
-; GFX11-TRUE16-NEXT:    v_or_b16 v9.l, v2.l, v0.l
-; GFX11-TRUE16-NEXT:    v_lshlrev_b16 v1.l, 8, v4.l
+; GFX11-TRUE16-NEXT:    v_or_b16 v9.h, v3.l, v3.h
+; GFX11-TRUE16-NEXT:    v_and_b16 v0.l, 0xff, v0.l
+; GFX11-TRUE16-NEXT:    v_lshlrev_b16 v3.l, 8, v0.h
+; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v3.h, v8.h
+; GFX11-TRUE16-NEXT:    v_or_b16 v9.l, v2.l, v1.l
 ; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v2.l, v8.l
 ; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v2.h, v9.h
-; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v6.l, v9.h
+; GFX11-TRUE16-NEXT:    v_or_b16 v0.l, v0.l, v3.l
+; GFX11-TRUE16-NEXT:    v_lshrrev_b32_e32 v1, 8, v3
 ; GFX11-TRUE16-NEXT:    v_lshrrev_b64 v[3:4], 24, v[8:9]
-; GFX11-TRUE16-NEXT:    v_or_b16 v0.l, v0.h, v1.l
-; GFX11-TRUE16-NEXT:    v_lshrrev_b32_e32 v1, 8, v1
 ; GFX11-TRUE16-NEXT:    v_lshrrev_b32_e32 v5, 8, v9
 ; GFX11-TRUE16-NEXT:    v_lshrrev_b32_e32 v7, 24, v2
 ; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v2.l, v8.h
 ; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v4.l, v9.l
+; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v6.l, v9.h
 ; GFX11-TRUE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX12-FAKE16-LABEL: test_signed_v8f16_v8i8:
@@ -2616,56 +2513,48 @@ define <8 x i8> @test_signed_v8f16_v8i8(<8 x half> %f) {
 ; GFX12-FAKE16-NEXT:    s_wait_bvhcnt 0x0
 ; GFX12-FAKE16-NEXT:    s_wait_kmcnt 0x0
 ; GFX12-FAKE16-NEXT:    v_lshrrev_b32_e32 v4, 16, v2
-; GFX12-FAKE16-NEXT:    v_cvt_f32_f16_e32 v2, v2
-; GFX12-FAKE16-NEXT:    v_cvt_f32_f16_e32 v5, v3
+; GFX12-FAKE16-NEXT:    v_cvt_i16_f16_e32 v2, v2
+; GFX12-FAKE16-NEXT:    v_cvt_i16_f16_e32 v5, v3
 ; GFX12-FAKE16-NEXT:    v_lshrrev_b32_e32 v3, 16, v3
-; GFX12-FAKE16-NEXT:    v_cvt_f32_f16_e32 v6, v1
-; GFX12-FAKE16-NEXT:    v_cvt_f32_f16_e32 v4, v4
-; GFX12-FAKE16-NEXT:    v_lshrrev_b32_e32 v1, 16, v1
-; GFX12-FAKE16-NEXT:    v_lshrrev_b32_e32 v7, 16, v0
-; GFX12-FAKE16-NEXT:    v_cvt_i32_f32_e32 v2, v2
-; GFX12-FAKE16-NEXT:    v_cvt_f32_f16_e32 v3, v3
-; GFX12-FAKE16-NEXT:    v_cvt_i32_f32_e32 v4, v4
-; GFX12-FAKE16-NEXT:    v_cvt_f32_f16_e32 v1, v1
+; GFX12-FAKE16-NEXT:    v_lshrrev_b32_e32 v6, 16, v1
+; GFX12-FAKE16-NEXT:    v_cvt_i16_f16_e32 v4, v4
 ; GFX12-FAKE16-NEXT:    s_movk_i32 s0, 0xff80
-; GFX12-FAKE16-NEXT:    v_cvt_i32_f32_e32 v5, v5
-; GFX12-FAKE16-NEXT:    v_cvt_i32_f32_e32 v6, v6
+; GFX12-FAKE16-NEXT:    v_cvt_i16_f16_e32 v1, v1
+; GFX12-FAKE16-NEXT:    v_lshrrev_b32_e32 v7, 16, v0
 ; GFX12-FAKE16-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX12-FAKE16-NEXT:    v_med3_i32 v2, v2, s0, 0x7f
-; GFX12-FAKE16-NEXT:    v_med3_i32 v4, v4, s0, 0x7f
-; GFX12-FAKE16-NEXT:    v_cvt_f32_f16_e32 v7, v7
-; GFX12-FAKE16-NEXT:    v_cvt_i32_f32_e32 v1, v1
-; GFX12-FAKE16-NEXT:    v_cvt_i32_f32_e32 v3, v3
-; GFX12-FAKE16-NEXT:    v_med3_i32 v5, v5, s0, 0x7f
+; GFX12-FAKE16-NEXT:    v_med3_i16 v2, v2, s0, 0x7f
+; GFX12-FAKE16-NEXT:    v_cvt_i16_f16_e32 v6, v6
+; GFX12-FAKE16-NEXT:    v_med3_i16 v4, v4, s0, 0x7f
+; GFX12-FAKE16-NEXT:    v_cvt_i16_f16_e32 v3, v3
+; GFX12-FAKE16-NEXT:    v_med3_i16 v1, v1, s0, 0x7f
 ; GFX12-FAKE16-NEXT:    v_and_b32_e32 v2, 0xff, v2
+; GFX12-FAKE16-NEXT:    v_med3_i16 v6, v6, s0, 0x7f
 ; GFX12-FAKE16-NEXT:    v_lshlrev_b16 v4, 8, v4
-; GFX12-FAKE16-NEXT:    v_med3_i32 v6, v6, s0, 0x7f
-; GFX12-FAKE16-NEXT:    v_med3_i32 v1, v1, s0, 0x7f
-; GFX12-FAKE16-NEXT:    v_cvt_i32_f32_e32 v7, v7
-; GFX12-FAKE16-NEXT:    v_med3_i32 v3, v3, s0, 0x7f
+; GFX12-FAKE16-NEXT:    v_med3_i16 v5, v5, s0, 0x7f
+; GFX12-FAKE16-NEXT:    v_cvt_i16_f16_e32 v7, v7
+; GFX12-FAKE16-NEXT:    v_med3_i16 v3, v3, s0, 0x7f
+; GFX12-FAKE16-NEXT:    v_lshlrev_b16 v6, 8, v6
 ; GFX12-FAKE16-NEXT:    v_or_b32_e32 v8, v2, v4
+; GFX12-FAKE16-NEXT:    v_and_b32_e32 v1, 0xff, v1
 ; GFX12-FAKE16-NEXT:    v_and_b32_e32 v5, 0xff, v5
-; GFX12-FAKE16-NEXT:    v_and_b32_e32 v6, 0xff, v6
-; GFX12-FAKE16-NEXT:    v_lshlrev_b16 v1, 8, v1
-; GFX12-FAKE16-NEXT:    v_med3_i32 v7, v7, s0, 0x7f
+; GFX12-FAKE16-NEXT:    v_med3_i16 v7, v7, s0, 0x7f
 ; GFX12-FAKE16-NEXT:    v_lshlrev_b16 v3, 8, v3
-; GFX12-FAKE16-NEXT:    v_cvt_f32_f16_e32 v0, v0
-; GFX12-FAKE16-NEXT:    v_or_b32_e32 v2, v6, v1
+; GFX12-FAKE16-NEXT:    v_cvt_i16_f16_e32 v0, v0
+; GFX12-FAKE16-NEXT:    v_or_b32_e32 v2, v1, v6
 ; GFX12-FAKE16-NEXT:    v_lshlrev_b16 v1, 8, v7
 ; GFX12-FAKE16-NEXT:    v_or_b32_e32 v6, v5, v3
-; GFX12-FAKE16-NEXT:    v_cvt_i32_f32_e32 v0, v0
 ; GFX12-FAKE16-NEXT:    v_and_b32_e32 v3, 0xffff, v8
 ; GFX12-FAKE16-NEXT:    v_lshlrev_b32_e32 v4, 16, v2
+; GFX12-FAKE16-NEXT:    v_med3_i16 v0, v0, s0, 0x7f
 ; GFX12-FAKE16-NEXT:    v_and_b32_e32 v5, 0xffff, v1
 ; GFX12-FAKE16-NEXT:    v_lshlrev_b32_e32 v7, 16, v6
-; GFX12-FAKE16-NEXT:    v_med3_i32 v0, v0, s0, 0x7f
+; GFX12-FAKE16-NEXT:    v_and_b32_e32 v0, 0xff, v0
 ; GFX12-FAKE16-NEXT:    v_or_b32_e32 v9, v5, v4
 ; GFX12-FAKE16-NEXT:    v_or_b32_e32 v5, v3, v7
-; GFX12-FAKE16-NEXT:    v_and_b32_e32 v0, 0xff, v0
 ; GFX12-FAKE16-NEXT:    v_lshrrev_b32_e32 v7, 24, v7
-; GFX12-FAKE16-NEXT:    v_lshrrev_b64 v[3:4], 24, v[4:5]
 ; GFX12-FAKE16-NEXT:    v_or_b32_e32 v0, v0, v1
 ; GFX12-FAKE16-NEXT:    v_lshrrev_b32_e32 v1, 8, v9
+; GFX12-FAKE16-NEXT:    v_lshrrev_b64 v[3:4], 24, v[4:5]
 ; GFX12-FAKE16-NEXT:    v_lshrrev_b32_e32 v5, 8, v5
 ; GFX12-FAKE16-NEXT:    v_mov_b32_e32 v4, v8
 ; GFX12-FAKE16-NEXT:    s_setpc_b64 s[30:31]
@@ -2677,55 +2566,46 @@ define <8 x i8> @test_signed_v8f16_v8i8(<8 x half> %f) {
 ; GFX12-TRUE16-NEXT:    s_wait_samplecnt 0x0
 ; GFX12-TRUE16-NEXT:    s_wait_bvhcnt 0x0
 ; GFX12-TRUE16-NEXT:    s_wait_kmcnt 0x0
-; GFX12-TRUE16-NEXT:    v_cvt_f32_f16_e32 v4, v3.l
-; GFX12-TRUE16-NEXT:    v_cvt_f32_f16_e32 v3, v3.h
-; GFX12-TRUE16-NEXT:    v_cvt_f32_f16_e32 v6, v1.l
-; GFX12-TRUE16-NEXT:    v_cvt_f32_f16_e32 v1, v1.h
-; GFX12-TRUE16-NEXT:    s_movk_i32 s0, 0xff80
-; GFX12-TRUE16-NEXT:    v_cvt_i32_f32_e32 v4, v4
-; GFX12-TRUE16-NEXT:    v_cvt_i32_f32_e32 v3, v3
-; GFX12-TRUE16-NEXT:    v_cvt_f32_f16_e32 v5, v2.l
-; GFX12-TRUE16-NEXT:    v_cvt_i32_f32_e32 v6, v6
-; GFX12-TRUE16-NEXT:    v_cvt_i32_f32_e32 v7, v1
-; GFX12-TRUE16-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX12-TRUE16-NEXT:    v_med3_i32 v4, v4, s0, 0x7f
-; GFX12-TRUE16-NEXT:    v_med3_i32 v3, v3, s0, 0x7f
-; GFX12-TRUE16-NEXT:    v_cvt_f32_f16_e32 v2, v2.h
-; GFX12-TRUE16-NEXT:    v_cvt_i32_f32_e32 v5, v5
-; GFX12-TRUE16-NEXT:    v_med3_i32 v7, v7, s0, 0x7f
-; GFX12-TRUE16-NEXT:    v_and_b16 v1.l, 0xff, v4.l
-; GFX12-TRUE16-NEXT:    v_lshlrev_b16 v1.h, 8, v3.l
-; GFX12-TRUE16-NEXT:    v_med3_i32 v3, v6, s0, 0x7f
-; GFX12-TRUE16-NEXT:    v_cvt_f32_f16_e32 v4, v0.l
-; GFX12-TRUE16-NEXT:    v_cvt_f32_f16_e32 v6, v0.h
-; GFX12-TRUE16-NEXT:    v_cvt_i32_f32_e32 v2, v2
-; GFX12-TRUE16-NEXT:    v_med3_i32 v5, v5, s0, 0x7f
-; GFX12-TRUE16-NEXT:    v_and_b16 v0.l, 0xff, v3.l
-; GFX12-TRUE16-NEXT:    v_cvt_i32_f32_e32 v3, v4
-; GFX12-TRUE16-NEXT:    v_cvt_i32_f32_e32 v4, v6
-; GFX12-TRUE16-NEXT:    v_lshlrev_b16 v0.h, 8, v7.l
-; GFX12-TRUE16-NEXT:    v_med3_i32 v6, v2, s0, 0x7f
-; GFX12-TRUE16-NEXT:    v_and_b16 v2.l, 0xff, v5.l
+; GFX12-TRUE16-NEXT:    v_mov_b16_e32 v4.l, 0xff80
+; GFX12-TRUE16-NEXT:    v_cvt_i16_f16_e32 v1.l, v1.l
+; GFX12-TRUE16-NEXT:    v_cvt_i16_f16_e32 v1.h, v1.h
+; GFX12-TRUE16-NEXT:    v_cvt_i16_f16_e32 v3.l, v3.l
+; GFX12-TRUE16-NEXT:    v_cvt_i16_f16_e32 v3.h, v3.h
+; GFX12-TRUE16-NEXT:    v_cvt_i16_f16_e32 v2.l, v2.l
+; GFX12-TRUE16-NEXT:    v_med3_i16 v1.l, v1.l, v4.l, 0x7f
+; GFX12-TRUE16-NEXT:    v_med3_i16 v1.h, v1.h, v4.l, 0x7f
+; GFX12-TRUE16-NEXT:    v_cvt_i16_f16_e32 v2.h, v2.h
+; GFX12-TRUE16-NEXT:    v_med3_i16 v3.l, v3.l, v4.l, 0x7f
+; GFX12-TRUE16-NEXT:    v_med3_i16 v3.h, v3.h, v4.l, 0x7f
+; GFX12-TRUE16-NEXT:    v_med3_i16 v2.l, v2.l, v4.l, 0x7f
+; GFX12-TRUE16-NEXT:    v_and_b16 v1.l, 0xff, v1.l
+; GFX12-TRUE16-NEXT:    v_cvt_i16_f16_e32 v0.l, v0.l
+; GFX12-TRUE16-NEXT:    v_cvt_i16_f16_e32 v0.h, v0.h
+; GFX12-TRUE16-NEXT:    v_lshlrev_b16 v1.h, 8, v1.h
+; GFX12-TRUE16-NEXT:    v_med3_i16 v2.h, v2.h, v4.l, 0x7f
+; GFX12-TRUE16-NEXT:    v_and_b16 v3.l, 0xff, v3.l
+; GFX12-TRUE16-NEXT:    v_lshlrev_b16 v3.h, 8, v3.h
+; GFX12-TRUE16-NEXT:    v_and_b16 v2.l, 0xff, v2.l
+; GFX12-TRUE16-NEXT:    v_med3_i16 v0.l, v0.l, v4.l, 0x7f
+; GFX12-TRUE16-NEXT:    v_med3_i16 v0.h, v0.h, v4.l, 0x7f
+; GFX12-TRUE16-NEXT:    v_or_b16 v8.h, v1.l, v1.h
+; GFX12-TRUE16-NEXT:    v_lshlrev_b16 v1.l, 8, v2.h
 ; GFX12-TRUE16-NEXT:    v_mov_b16_e32 v8.l, 0
-; GFX12-TRUE16-NEXT:    v_med3_i32 v3, v3, s0, 0x7f
-; GFX12-TRUE16-NEXT:    v_or_b16 v8.h, v0.l, v0.h
-; GFX12-TRUE16-NEXT:    v_lshlrev_b16 v0.l, 8, v6.l
-; GFX12-TRUE16-NEXT:    v_med3_i32 v4, v4, s0, 0x7f
-; GFX12-TRUE16-NEXT:    v_or_b16 v9.h, v1.l, v1.h
-; GFX12-TRUE16-NEXT:    v_and_b16 v0.h, 0xff, v3.l
-; GFX12-TRUE16-NEXT:    v_mov_b16_e32 v1.h, v8.h
-; GFX12-TRUE16-NEXT:    v_or_b16 v9.l, v2.l, v0.l
-; GFX12-TRUE16-NEXT:    v_lshlrev_b16 v1.l, 8, v4.l
+; GFX12-TRUE16-NEXT:    v_or_b16 v9.h, v3.l, v3.h
+; GFX12-TRUE16-NEXT:    v_and_b16 v0.l, 0xff, v0.l
+; GFX12-TRUE16-NEXT:    v_lshlrev_b16 v3.l, 8, v0.h
+; GFX12-TRUE16-NEXT:    v_mov_b16_e32 v3.h, v8.h
+; GFX12-TRUE16-NEXT:    v_or_b16 v9.l, v2.l, v1.l
 ; GFX12-TRUE16-NEXT:    v_mov_b16_e32 v2.l, v8.l
 ; GFX12-TRUE16-NEXT:    v_mov_b16_e32 v2.h, v9.h
-; GFX12-TRUE16-NEXT:    v_mov_b16_e32 v6.l, v9.h
+; GFX12-TRUE16-NEXT:    v_or_b16 v0.l, v0.l, v3.l
+; GFX12-TRUE16-NEXT:    v_lshrrev_b32_e32 v1, 8, v3
 ; GFX12-TRUE16-NEXT:    v_lshrrev_b64 v[3:4], 24, v[8:9]
-; GFX12-TRUE16-NEXT:    v_or_b16 v0.l, v0.h, v1.l
-; GFX12-TRUE16-NEXT:    v_lshrrev_b32_e32 v1, 8, v1
 ; GFX12-TRUE16-NEXT:    v_lshrrev_b32_e32 v5, 8, v9
 ; GFX12-TRUE16-NEXT:    v_lshrrev_b32_e32 v7, 24, v2
 ; GFX12-TRUE16-NEXT:    v_mov_b16_e32 v2.l, v8.h
 ; GFX12-TRUE16-NEXT:    v_mov_b16_e32 v4.l, v9.l
+; GFX12-TRUE16-NEXT:    v_mov_b16_e32 v6.l, v9.h
 ; GFX12-TRUE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX12-GI-LABEL: test_signed_v8f16_v8i8:

--- a/llvm/test/CodeGen/AMDGPU/fptoui-sat-scalar.ll
+++ b/llvm/test/CodeGen/AMDGPU/fptoui-sat-scalar.ll
@@ -595,25 +595,22 @@ define i1 @test_unsigned_i1_f16(half %f) nounwind {
 ; GFX9-LABEL: test_unsigned_i1_f16:
 ; GFX9:       ; %bb.0:
 ; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX9-NEXT:    v_cvt_f32_f16_e32 v0, v0
-; GFX9-NEXT:    v_cvt_u32_f32_e32 v0, v0
-; GFX9-NEXT:    v_min_u32_e32 v0, 1, v0
+; GFX9-NEXT:    v_cvt_u16_f16_e32 v0, v0
+; GFX9-NEXT:    v_min_u16_e32 v0, 1, v0
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-FAKE16-LABEL: test_unsigned_i1_f16:
 ; GFX11-FAKE16:       ; %bb.0:
 ; GFX11-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX11-FAKE16-NEXT:    v_cvt_f32_f16_e32 v0, v0
-; GFX11-FAKE16-NEXT:    v_cvt_u32_f32_e32 v0, v0
-; GFX11-FAKE16-NEXT:    v_min_u32_e32 v0, 1, v0
+; GFX11-FAKE16-NEXT:    v_cvt_u16_f16_e32 v0, v0
+; GFX11-FAKE16-NEXT:    v_min_u16 v0, v0, 1
 ; GFX11-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-TRUE16-LABEL: test_unsigned_i1_f16:
 ; GFX11-TRUE16:       ; %bb.0:
 ; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX11-TRUE16-NEXT:    v_cvt_f32_f16_e32 v0, v0.l
-; GFX11-TRUE16-NEXT:    v_cvt_u32_f32_e32 v0, v0
-; GFX11-TRUE16-NEXT:    v_min_u32_e32 v0, 1, v0
+; GFX11-TRUE16-NEXT:    v_cvt_u16_f16_e32 v0.l, v0.l
+; GFX11-TRUE16-NEXT:    v_min_u16 v0.l, v0.l, 1
 ; GFX11-TRUE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX12-FAKE16-LABEL: test_unsigned_i1_f16:
@@ -623,9 +620,8 @@ define i1 @test_unsigned_i1_f16(half %f) nounwind {
 ; GFX12-FAKE16-NEXT:    s_wait_samplecnt 0x0
 ; GFX12-FAKE16-NEXT:    s_wait_bvhcnt 0x0
 ; GFX12-FAKE16-NEXT:    s_wait_kmcnt 0x0
-; GFX12-FAKE16-NEXT:    v_cvt_f32_f16_e32 v0, v0
-; GFX12-FAKE16-NEXT:    v_cvt_u32_f32_e32 v0, v0
-; GFX12-FAKE16-NEXT:    v_min_u32_e32 v0, 1, v0
+; GFX12-FAKE16-NEXT:    v_cvt_u16_f16_e32 v0, v0
+; GFX12-FAKE16-NEXT:    v_min_u16 v0, v0, 1
 ; GFX12-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX12-TRUE16-LABEL: test_unsigned_i1_f16:
@@ -635,9 +631,8 @@ define i1 @test_unsigned_i1_f16(half %f) nounwind {
 ; GFX12-TRUE16-NEXT:    s_wait_samplecnt 0x0
 ; GFX12-TRUE16-NEXT:    s_wait_bvhcnt 0x0
 ; GFX12-TRUE16-NEXT:    s_wait_kmcnt 0x0
-; GFX12-TRUE16-NEXT:    v_cvt_f32_f16_e32 v0, v0.l
-; GFX12-TRUE16-NEXT:    v_cvt_u32_f32_e32 v0, v0
-; GFX12-TRUE16-NEXT:    v_min_u32_e32 v0, 1, v0
+; GFX12-TRUE16-NEXT:    v_cvt_u16_f16_e32 v0.l, v0.l
+; GFX12-TRUE16-NEXT:    v_min_u16 v0.l, v0.l, 1
 ; GFX12-TRUE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX12-GI-LABEL: test_unsigned_i1_f16:
@@ -667,25 +662,22 @@ define i8 @test_unsigned_i8_f16(half %f) nounwind {
 ; GFX9-LABEL: test_unsigned_i8_f16:
 ; GFX9:       ; %bb.0:
 ; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX9-NEXT:    v_cvt_f32_f16_e32 v0, v0
-; GFX9-NEXT:    v_cvt_u32_f32_e32 v0, v0
-; GFX9-NEXT:    v_min_u32_e32 v0, 0xff, v0
+; GFX9-NEXT:    v_cvt_u16_f16_e32 v0, v0
+; GFX9-NEXT:    v_min_u16_e32 v0, 0xff, v0
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-FAKE16-LABEL: test_unsigned_i8_f16:
 ; GFX11-FAKE16:       ; %bb.0:
 ; GFX11-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX11-FAKE16-NEXT:    v_cvt_f32_f16_e32 v0, v0
-; GFX11-FAKE16-NEXT:    v_cvt_u32_f32_e32 v0, v0
-; GFX11-FAKE16-NEXT:    v_min_u32_e32 v0, 0xff, v0
+; GFX11-FAKE16-NEXT:    v_cvt_u16_f16_e32 v0, v0
+; GFX11-FAKE16-NEXT:    v_min_u16 v0, 0xff, v0
 ; GFX11-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-TRUE16-LABEL: test_unsigned_i8_f16:
 ; GFX11-TRUE16:       ; %bb.0:
 ; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX11-TRUE16-NEXT:    v_cvt_f32_f16_e32 v0, v0.l
-; GFX11-TRUE16-NEXT:    v_cvt_u32_f32_e32 v0, v0
-; GFX11-TRUE16-NEXT:    v_min_u32_e32 v0, 0xff, v0
+; GFX11-TRUE16-NEXT:    v_cvt_u16_f16_e32 v0.l, v0.l
+; GFX11-TRUE16-NEXT:    v_min_u16 v0.l, 0xff, v0.l
 ; GFX11-TRUE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX12-FAKE16-LABEL: test_unsigned_i8_f16:
@@ -695,9 +687,8 @@ define i8 @test_unsigned_i8_f16(half %f) nounwind {
 ; GFX12-FAKE16-NEXT:    s_wait_samplecnt 0x0
 ; GFX12-FAKE16-NEXT:    s_wait_bvhcnt 0x0
 ; GFX12-FAKE16-NEXT:    s_wait_kmcnt 0x0
-; GFX12-FAKE16-NEXT:    v_cvt_f32_f16_e32 v0, v0
-; GFX12-FAKE16-NEXT:    v_cvt_u32_f32_e32 v0, v0
-; GFX12-FAKE16-NEXT:    v_min_u32_e32 v0, 0xff, v0
+; GFX12-FAKE16-NEXT:    v_cvt_u16_f16_e32 v0, v0
+; GFX12-FAKE16-NEXT:    v_min_u16 v0, 0xff, v0
 ; GFX12-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX12-TRUE16-LABEL: test_unsigned_i8_f16:
@@ -707,9 +698,8 @@ define i8 @test_unsigned_i8_f16(half %f) nounwind {
 ; GFX12-TRUE16-NEXT:    s_wait_samplecnt 0x0
 ; GFX12-TRUE16-NEXT:    s_wait_bvhcnt 0x0
 ; GFX12-TRUE16-NEXT:    s_wait_kmcnt 0x0
-; GFX12-TRUE16-NEXT:    v_cvt_f32_f16_e32 v0, v0.l
-; GFX12-TRUE16-NEXT:    v_cvt_u32_f32_e32 v0, v0
-; GFX12-TRUE16-NEXT:    v_min_u32_e32 v0, 0xff, v0
+; GFX12-TRUE16-NEXT:    v_cvt_u16_f16_e32 v0.l, v0.l
+; GFX12-TRUE16-NEXT:    v_min_u16 v0.l, 0xff, v0.l
 ; GFX12-TRUE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX12-GI-LABEL: test_unsigned_i8_f16:

--- a/llvm/test/CodeGen/AMDGPU/fptoui-sat-vector.ll
+++ b/llvm/test/CodeGen/AMDGPU/fptoui-sat-vector.ll
@@ -1193,18 +1193,16 @@ define <4 x i1> @test_unsigned_v4f16_v4i1(<4 x half> %f) {
 ; GFX9-LABEL: test_unsigned_v4f16_v4i1:
 ; GFX9:       ; %bb.0:
 ; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX9-NEXT:    v_cvt_f32_f16_sdwa v2, v1 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1
-; GFX9-NEXT:    v_cvt_f32_f16_sdwa v3, v0 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1
-; GFX9-NEXT:    v_cvt_f32_f16_e32 v1, v1
-; GFX9-NEXT:    v_cvt_f32_f16_e32 v0, v0
-; GFX9-NEXT:    v_cvt_u32_f32_e32 v2, v2
-; GFX9-NEXT:    v_cvt_u32_f32_e32 v4, v3
-; GFX9-NEXT:    v_cvt_u32_f32_e32 v5, v1
-; GFX9-NEXT:    v_cvt_u32_f32_e32 v0, v0
-; GFX9-NEXT:    v_min_u32_e32 v3, 1, v2
-; GFX9-NEXT:    v_min_u32_e32 v1, 1, v4
-; GFX9-NEXT:    v_min_u32_e32 v2, 1, v5
-; GFX9-NEXT:    v_min_u32_e32 v0, 1, v0
+; GFX9-NEXT:    v_cvt_u16_f16_e32 v2, v0
+; GFX9-NEXT:    v_cvt_u16_f16_sdwa v0, v0 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1
+; GFX9-NEXT:    v_min_u16_e32 v5, 1, v2
+; GFX9-NEXT:    v_cvt_u16_f16_e32 v2, v1
+; GFX9-NEXT:    v_min_u16_e32 v4, 1, v0
+; GFX9-NEXT:    v_cvt_u16_f16_sdwa v0, v1 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1
+; GFX9-NEXT:    v_min_u16_e32 v2, 1, v2
+; GFX9-NEXT:    v_min_u16_e32 v3, 1, v0
+; GFX9-NEXT:    v_mov_b32_e32 v0, v5
+; GFX9-NEXT:    v_mov_b32_e32 v1, v4
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-FAKE16-LABEL: test_unsigned_v4f16_v4i1:
@@ -1212,35 +1210,27 @@ define <4 x i1> @test_unsigned_v4f16_v4i1(<4 x half> %f) {
 ; GFX11-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v2, 16, v0
 ; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v3, 16, v1
-; GFX11-FAKE16-NEXT:    v_cvt_f32_f16_e32 v0, v0
-; GFX11-FAKE16-NEXT:    v_cvt_f32_f16_e32 v1, v1
-; GFX11-FAKE16-NEXT:    v_cvt_f32_f16_e32 v2, v2
-; GFX11-FAKE16-NEXT:    v_cvt_f32_f16_e32 v3, v3
-; GFX11-FAKE16-NEXT:    v_cvt_u32_f32_e32 v0, v0
-; GFX11-FAKE16-NEXT:    v_cvt_u32_f32_e32 v1, v1
-; GFX11-FAKE16-NEXT:    v_cvt_u32_f32_e32 v4, v2
-; GFX11-FAKE16-NEXT:    v_cvt_u32_f32_e32 v3, v3
-; GFX11-FAKE16-NEXT:    v_min_u32_e32 v0, 1, v0
-; GFX11-FAKE16-NEXT:    v_min_u32_e32 v2, 1, v1
-; GFX11-FAKE16-NEXT:    v_min_u32_e32 v1, 1, v4
-; GFX11-FAKE16-NEXT:    v_min_u32_e32 v3, 1, v3
+; GFX11-FAKE16-NEXT:    v_cvt_u16_f16_e32 v0, v0
+; GFX11-FAKE16-NEXT:    v_cvt_u16_f16_e32 v1, v1
+; GFX11-FAKE16-NEXT:    v_cvt_u16_f16_e32 v4, v2
+; GFX11-FAKE16-NEXT:    v_cvt_u16_f16_e32 v3, v3
+; GFX11-FAKE16-NEXT:    v_min_u16 v0, v0, 1
+; GFX11-FAKE16-NEXT:    v_min_u16 v2, v1, 1
+; GFX11-FAKE16-NEXT:    v_min_u16 v1, v4, 1
+; GFX11-FAKE16-NEXT:    v_min_u16 v3, v3, 1
 ; GFX11-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-TRUE16-LABEL: test_unsigned_v4f16_v4i1:
 ; GFX11-TRUE16:       ; %bb.0:
 ; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX11-TRUE16-NEXT:    v_cvt_f32_f16_e32 v2, v0.l
-; GFX11-TRUE16-NEXT:    v_cvt_f32_f16_e32 v0, v0.h
-; GFX11-TRUE16-NEXT:    v_cvt_f32_f16_e32 v3, v1.l
-; GFX11-TRUE16-NEXT:    v_cvt_f32_f16_e32 v1, v1.h
-; GFX11-TRUE16-NEXT:    v_cvt_u32_f32_e32 v2, v2
-; GFX11-TRUE16-NEXT:    v_cvt_u32_f32_e32 v4, v0
-; GFX11-TRUE16-NEXT:    v_cvt_u32_f32_e32 v3, v3
-; GFX11-TRUE16-NEXT:    v_cvt_u32_f32_e32 v5, v1
-; GFX11-TRUE16-NEXT:    v_min_u32_e32 v0, 1, v2
-; GFX11-TRUE16-NEXT:    v_min_u32_e32 v1, 1, v4
-; GFX11-TRUE16-NEXT:    v_min_u32_e32 v2, 1, v3
-; GFX11-TRUE16-NEXT:    v_min_u32_e32 v3, 1, v5
+; GFX11-TRUE16-NEXT:    v_cvt_u16_f16_e32 v0.l, v0.l
+; GFX11-TRUE16-NEXT:    v_cvt_u16_f16_e32 v0.h, v0.h
+; GFX11-TRUE16-NEXT:    v_cvt_u16_f16_e32 v2.l, v1.l
+; GFX11-TRUE16-NEXT:    v_cvt_u16_f16_e32 v1.h, v1.h
+; GFX11-TRUE16-NEXT:    v_min_u16 v0.l, v0.l, 1
+; GFX11-TRUE16-NEXT:    v_min_u16 v1.l, v0.h, 1
+; GFX11-TRUE16-NEXT:    v_min_u16 v2.l, v2.l, 1
+; GFX11-TRUE16-NEXT:    v_min_u16 v3.l, v1.h, 1
 ; GFX11-TRUE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX12-FAKE16-LABEL: test_unsigned_v4f16_v4i1:
@@ -1252,18 +1242,14 @@ define <4 x i1> @test_unsigned_v4f16_v4i1(<4 x half> %f) {
 ; GFX12-FAKE16-NEXT:    s_wait_kmcnt 0x0
 ; GFX12-FAKE16-NEXT:    v_lshrrev_b32_e32 v2, 16, v0
 ; GFX12-FAKE16-NEXT:    v_lshrrev_b32_e32 v3, 16, v1
-; GFX12-FAKE16-NEXT:    v_cvt_f32_f16_e32 v0, v0
-; GFX12-FAKE16-NEXT:    v_cvt_f32_f16_e32 v1, v1
-; GFX12-FAKE16-NEXT:    v_cvt_f32_f16_e32 v2, v2
-; GFX12-FAKE16-NEXT:    v_cvt_f32_f16_e32 v3, v3
-; GFX12-FAKE16-NEXT:    v_cvt_u32_f32_e32 v0, v0
-; GFX12-FAKE16-NEXT:    v_cvt_u32_f32_e32 v1, v1
-; GFX12-FAKE16-NEXT:    v_cvt_u32_f32_e32 v4, v2
-; GFX12-FAKE16-NEXT:    v_cvt_u32_f32_e32 v3, v3
-; GFX12-FAKE16-NEXT:    v_min_u32_e32 v0, 1, v0
-; GFX12-FAKE16-NEXT:    v_min_u32_e32 v2, 1, v1
-; GFX12-FAKE16-NEXT:    v_min_u32_e32 v1, 1, v4
-; GFX12-FAKE16-NEXT:    v_min_u32_e32 v3, 1, v3
+; GFX12-FAKE16-NEXT:    v_cvt_u16_f16_e32 v0, v0
+; GFX12-FAKE16-NEXT:    v_cvt_u16_f16_e32 v1, v1
+; GFX12-FAKE16-NEXT:    v_cvt_u16_f16_e32 v4, v2
+; GFX12-FAKE16-NEXT:    v_cvt_u16_f16_e32 v3, v3
+; GFX12-FAKE16-NEXT:    v_min_u16 v0, v0, 1
+; GFX12-FAKE16-NEXT:    v_min_u16 v2, v1, 1
+; GFX12-FAKE16-NEXT:    v_min_u16 v1, v4, 1
+; GFX12-FAKE16-NEXT:    v_min_u16 v3, v3, 1
 ; GFX12-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX12-TRUE16-LABEL: test_unsigned_v4f16_v4i1:
@@ -1273,18 +1259,14 @@ define <4 x i1> @test_unsigned_v4f16_v4i1(<4 x half> %f) {
 ; GFX12-TRUE16-NEXT:    s_wait_samplecnt 0x0
 ; GFX12-TRUE16-NEXT:    s_wait_bvhcnt 0x0
 ; GFX12-TRUE16-NEXT:    s_wait_kmcnt 0x0
-; GFX12-TRUE16-NEXT:    v_cvt_f32_f16_e32 v2, v0.l
-; GFX12-TRUE16-NEXT:    v_cvt_f32_f16_e32 v0, v0.h
-; GFX12-TRUE16-NEXT:    v_cvt_f32_f16_e32 v3, v1.l
-; GFX12-TRUE16-NEXT:    v_cvt_f32_f16_e32 v1, v1.h
-; GFX12-TRUE16-NEXT:    v_cvt_u32_f32_e32 v2, v2
-; GFX12-TRUE16-NEXT:    v_cvt_u32_f32_e32 v4, v0
-; GFX12-TRUE16-NEXT:    v_cvt_u32_f32_e32 v3, v3
-; GFX12-TRUE16-NEXT:    v_cvt_u32_f32_e32 v5, v1
-; GFX12-TRUE16-NEXT:    v_min_u32_e32 v0, 1, v2
-; GFX12-TRUE16-NEXT:    v_min_u32_e32 v1, 1, v4
-; GFX12-TRUE16-NEXT:    v_min_u32_e32 v2, 1, v3
-; GFX12-TRUE16-NEXT:    v_min_u32_e32 v3, 1, v5
+; GFX12-TRUE16-NEXT:    v_cvt_u16_f16_e32 v0.l, v0.l
+; GFX12-TRUE16-NEXT:    v_cvt_u16_f16_e32 v0.h, v0.h
+; GFX12-TRUE16-NEXT:    v_cvt_u16_f16_e32 v2.l, v1.l
+; GFX12-TRUE16-NEXT:    v_cvt_u16_f16_e32 v1.h, v1.h
+; GFX12-TRUE16-NEXT:    v_min_u16 v0.l, v0.l, 1
+; GFX12-TRUE16-NEXT:    v_min_u16 v1.l, v0.h, 1
+; GFX12-TRUE16-NEXT:    v_min_u16 v2.l, v2.l, 1
+; GFX12-TRUE16-NEXT:    v_min_u16 v3.l, v1.h, 1
 ; GFX12-TRUE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX12-GI-LABEL: test_unsigned_v4f16_v4i1:
@@ -1361,23 +1343,19 @@ define <4 x i8> @test_unsigned_v4f16_v4i8(<4 x half> %f) {
 ; GFX9-LABEL: test_unsigned_v4f16_v4i8:
 ; GFX9:       ; %bb.0:
 ; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX9-NEXT:    v_cvt_f32_f16_sdwa v2, v0 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1
-; GFX9-NEXT:    v_cvt_f32_f16_sdwa v3, v1 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1
-; GFX9-NEXT:    v_cvt_f32_f16_e32 v1, v1
-; GFX9-NEXT:    v_cvt_f32_f16_e32 v0, v0
-; GFX9-NEXT:    v_cvt_u32_f32_e32 v2, v2
+; GFX9-NEXT:    v_cvt_u16_f16_e32 v2, v0
 ; GFX9-NEXT:    s_movk_i32 s4, 0xff
-; GFX9-NEXT:    v_cvt_u32_f32_e32 v1, v1
-; GFX9-NEXT:    v_cvt_u32_f32_e32 v0, v0
-; GFX9-NEXT:    v_min_u32_sdwa v4, v2, s4 dst_sel:BYTE_1 dst_unused:UNUSED_PAD src0_sel:DWORD src1_sel:DWORD
-; GFX9-NEXT:    v_cvt_u32_f32_e32 v2, v3
-; GFX9-NEXT:    v_min_u32_e32 v1, 0xff, v1
-; GFX9-NEXT:    v_min_u32_e32 v0, 0xff, v0
-; GFX9-NEXT:    v_or_b32_e32 v0, v0, v4
-; GFX9-NEXT:    v_min_u32_sdwa v2, v2, s4 dst_sel:BYTE_1 dst_unused:UNUSED_PAD src0_sel:DWORD src1_sel:DWORD
-; GFX9-NEXT:    v_or_b32_e32 v2, v1, v2
+; GFX9-NEXT:    v_cvt_u16_f16_sdwa v0, v0 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1
+; GFX9-NEXT:    v_min_u16_e32 v2, 0xff, v2
+; GFX9-NEXT:    v_min_u16_sdwa v3, v0, s4 dst_sel:BYTE_1 dst_unused:UNUSED_PAD src0_sel:DWORD src1_sel:DWORD
+; GFX9-NEXT:    v_or_b32_e32 v0, v2, v3
+; GFX9-NEXT:    v_cvt_u16_f16_e32 v2, v1
+; GFX9-NEXT:    v_cvt_u16_f16_sdwa v1, v1 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1
+; GFX9-NEXT:    v_min_u16_e32 v2, 0xff, v2
+; GFX9-NEXT:    v_min_u16_sdwa v1, v1, s4 dst_sel:BYTE_1 dst_unused:UNUSED_PAD src0_sel:DWORD src1_sel:DWORD
+; GFX9-NEXT:    v_or_b32_e32 v2, v2, v1
 ; GFX9-NEXT:    v_lshlrev_b32_e32 v1, 16, v2
-; GFX9-NEXT:    v_or_b32_e32 v4, v4, v1
+; GFX9-NEXT:    v_or_b32_e32 v4, v3, v1
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v3, 24, v1
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v1, 8, v4
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
@@ -1387,18 +1365,14 @@ define <4 x i8> @test_unsigned_v4f16_v4i8(<4 x half> %f) {
 ; GFX11-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v2, 16, v1
 ; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v3, 16, v0
-; GFX11-FAKE16-NEXT:    v_cvt_f32_f16_e32 v1, v1
-; GFX11-FAKE16-NEXT:    v_cvt_f32_f16_e32 v0, v0
-; GFX11-FAKE16-NEXT:    v_cvt_f32_f16_e32 v2, v2
-; GFX11-FAKE16-NEXT:    v_cvt_f32_f16_e32 v3, v3
-; GFX11-FAKE16-NEXT:    v_cvt_u32_f32_e32 v1, v1
-; GFX11-FAKE16-NEXT:    v_cvt_u32_f32_e32 v0, v0
-; GFX11-FAKE16-NEXT:    v_cvt_u32_f32_e32 v2, v2
-; GFX11-FAKE16-NEXT:    v_cvt_u32_f32_e32 v3, v3
-; GFX11-FAKE16-NEXT:    v_min_u32_e32 v1, 0xff, v1
-; GFX11-FAKE16-NEXT:    v_min_u32_e32 v0, 0xff, v0
-; GFX11-FAKE16-NEXT:    v_min_u32_e32 v2, 0xff, v2
-; GFX11-FAKE16-NEXT:    v_min_u32_e32 v3, 0xff, v3
+; GFX11-FAKE16-NEXT:    v_cvt_u16_f16_e32 v1, v1
+; GFX11-FAKE16-NEXT:    v_cvt_u16_f16_e32 v0, v0
+; GFX11-FAKE16-NEXT:    v_cvt_u16_f16_e32 v2, v2
+; GFX11-FAKE16-NEXT:    v_cvt_u16_f16_e32 v3, v3
+; GFX11-FAKE16-NEXT:    v_min_u16 v1, 0xff, v1
+; GFX11-FAKE16-NEXT:    v_min_u16 v0, 0xff, v0
+; GFX11-FAKE16-NEXT:    v_min_u16 v2, 0xff, v2
+; GFX11-FAKE16-NEXT:    v_min_u16 v3, 0xff, v3
 ; GFX11-FAKE16-NEXT:    v_lshlrev_b16 v2, 8, v2
 ; GFX11-FAKE16-NEXT:    v_lshlrev_b16 v3, 8, v3
 ; GFX11-FAKE16-NEXT:    v_or_b32_e32 v2, v1, v2
@@ -1413,22 +1387,18 @@ define <4 x i8> @test_unsigned_v4f16_v4i8(<4 x half> %f) {
 ; GFX11-TRUE16-LABEL: test_unsigned_v4f16_v4i8:
 ; GFX11-TRUE16:       ; %bb.0:
 ; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX11-TRUE16-NEXT:    v_cvt_f32_f16_e32 v2, v1.h
-; GFX11-TRUE16-NEXT:    v_cvt_f32_f16_e32 v1, v1.l
-; GFX11-TRUE16-NEXT:    v_cvt_f32_f16_e32 v3, v0.h
-; GFX11-TRUE16-NEXT:    v_cvt_f32_f16_e32 v4, v0.l
-; GFX11-TRUE16-NEXT:    v_cvt_u32_f32_e32 v2, v2
-; GFX11-TRUE16-NEXT:    v_cvt_u32_f32_e32 v1, v1
-; GFX11-TRUE16-NEXT:    v_cvt_u32_f32_e32 v3, v3
-; GFX11-TRUE16-NEXT:    v_cvt_u32_f32_e32 v4, v4
-; GFX11-TRUE16-NEXT:    v_min_u32_e32 v2, 0xff, v2
-; GFX11-TRUE16-NEXT:    v_min_u32_e32 v1, 0xff, v1
-; GFX11-TRUE16-NEXT:    v_lshlrev_b16 v0.l, 8, v2.l
-; GFX11-TRUE16-NEXT:    v_min_u32_e32 v2, 0xff, v3
-; GFX11-TRUE16-NEXT:    v_or_b16 v2.h, v1.l, v0.l
-; GFX11-TRUE16-NEXT:    v_min_u32_e32 v0, 0xff, v4
-; GFX11-TRUE16-NEXT:    v_lshlrev_b16 v1.l, 8, v2.l
+; GFX11-TRUE16-NEXT:    v_cvt_u16_f16_e32 v1.h, v1.h
+; GFX11-TRUE16-NEXT:    v_cvt_u16_f16_e32 v1.l, v1.l
+; GFX11-TRUE16-NEXT:    v_cvt_u16_f16_e32 v0.h, v0.h
+; GFX11-TRUE16-NEXT:    v_cvt_u16_f16_e32 v0.l, v0.l
 ; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v2.l, 0
+; GFX11-TRUE16-NEXT:    v_min_u16 v1.h, 0xff, v1.h
+; GFX11-TRUE16-NEXT:    v_min_u16 v1.l, 0xff, v1.l
+; GFX11-TRUE16-NEXT:    v_min_u16 v0.h, 0xff, v0.h
+; GFX11-TRUE16-NEXT:    v_min_u16 v0.l, 0xff, v0.l
+; GFX11-TRUE16-NEXT:    v_lshlrev_b16 v1.h, 8, v1.h
+; GFX11-TRUE16-NEXT:    v_or_b16 v2.h, v1.l, v1.h
+; GFX11-TRUE16-NEXT:    v_lshlrev_b16 v1.l, 8, v0.h
 ; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v1.h, v2.h
 ; GFX11-TRUE16-NEXT:    v_or_b16 v0.l, v0.l, v1.l
 ; GFX11-TRUE16-NEXT:    v_lshrrev_b32_e32 v3, 24, v2
@@ -1445,18 +1415,14 @@ define <4 x i8> @test_unsigned_v4f16_v4i8(<4 x half> %f) {
 ; GFX12-FAKE16-NEXT:    s_wait_kmcnt 0x0
 ; GFX12-FAKE16-NEXT:    v_lshrrev_b32_e32 v2, 16, v1
 ; GFX12-FAKE16-NEXT:    v_lshrrev_b32_e32 v3, 16, v0
-; GFX12-FAKE16-NEXT:    v_cvt_f32_f16_e32 v1, v1
-; GFX12-FAKE16-NEXT:    v_cvt_f32_f16_e32 v0, v0
-; GFX12-FAKE16-NEXT:    v_cvt_f32_f16_e32 v2, v2
-; GFX12-FAKE16-NEXT:    v_cvt_f32_f16_e32 v3, v3
-; GFX12-FAKE16-NEXT:    v_cvt_u32_f32_e32 v1, v1
-; GFX12-FAKE16-NEXT:    v_cvt_u32_f32_e32 v0, v0
-; GFX12-FAKE16-NEXT:    v_cvt_u32_f32_e32 v2, v2
-; GFX12-FAKE16-NEXT:    v_cvt_u32_f32_e32 v3, v3
-; GFX12-FAKE16-NEXT:    v_min_u32_e32 v1, 0xff, v1
-; GFX12-FAKE16-NEXT:    v_min_u32_e32 v0, 0xff, v0
-; GFX12-FAKE16-NEXT:    v_min_u32_e32 v2, 0xff, v2
-; GFX12-FAKE16-NEXT:    v_min_u32_e32 v3, 0xff, v3
+; GFX12-FAKE16-NEXT:    v_cvt_u16_f16_e32 v1, v1
+; GFX12-FAKE16-NEXT:    v_cvt_u16_f16_e32 v0, v0
+; GFX12-FAKE16-NEXT:    v_cvt_u16_f16_e32 v2, v2
+; GFX12-FAKE16-NEXT:    v_cvt_u16_f16_e32 v3, v3
+; GFX12-FAKE16-NEXT:    v_min_u16 v1, 0xff, v1
+; GFX12-FAKE16-NEXT:    v_min_u16 v0, 0xff, v0
+; GFX12-FAKE16-NEXT:    v_min_u16 v2, 0xff, v2
+; GFX12-FAKE16-NEXT:    v_min_u16 v3, 0xff, v3
 ; GFX12-FAKE16-NEXT:    v_lshlrev_b16 v2, 8, v2
 ; GFX12-FAKE16-NEXT:    v_lshlrev_b16 v3, 8, v3
 ; GFX12-FAKE16-NEXT:    v_or_b32_e32 v2, v1, v2
@@ -1475,22 +1441,18 @@ define <4 x i8> @test_unsigned_v4f16_v4i8(<4 x half> %f) {
 ; GFX12-TRUE16-NEXT:    s_wait_samplecnt 0x0
 ; GFX12-TRUE16-NEXT:    s_wait_bvhcnt 0x0
 ; GFX12-TRUE16-NEXT:    s_wait_kmcnt 0x0
-; GFX12-TRUE16-NEXT:    v_cvt_f32_f16_e32 v2, v1.h
-; GFX12-TRUE16-NEXT:    v_cvt_f32_f16_e32 v1, v1.l
-; GFX12-TRUE16-NEXT:    v_cvt_f32_f16_e32 v3, v0.h
-; GFX12-TRUE16-NEXT:    v_cvt_f32_f16_e32 v4, v0.l
-; GFX12-TRUE16-NEXT:    v_cvt_u32_f32_e32 v2, v2
-; GFX12-TRUE16-NEXT:    v_cvt_u32_f32_e32 v1, v1
-; GFX12-TRUE16-NEXT:    v_cvt_u32_f32_e32 v3, v3
-; GFX12-TRUE16-NEXT:    v_cvt_u32_f32_e32 v4, v4
-; GFX12-TRUE16-NEXT:    v_min_u32_e32 v2, 0xff, v2
-; GFX12-TRUE16-NEXT:    v_min_u32_e32 v1, 0xff, v1
-; GFX12-TRUE16-NEXT:    v_lshlrev_b16 v0.l, 8, v2.l
-; GFX12-TRUE16-NEXT:    v_min_u32_e32 v2, 0xff, v3
-; GFX12-TRUE16-NEXT:    v_or_b16 v2.h, v1.l, v0.l
-; GFX12-TRUE16-NEXT:    v_min_u32_e32 v0, 0xff, v4
-; GFX12-TRUE16-NEXT:    v_lshlrev_b16 v1.l, 8, v2.l
+; GFX12-TRUE16-NEXT:    v_cvt_u16_f16_e32 v1.h, v1.h
+; GFX12-TRUE16-NEXT:    v_cvt_u16_f16_e32 v1.l, v1.l
+; GFX12-TRUE16-NEXT:    v_cvt_u16_f16_e32 v0.h, v0.h
+; GFX12-TRUE16-NEXT:    v_cvt_u16_f16_e32 v0.l, v0.l
 ; GFX12-TRUE16-NEXT:    v_mov_b16_e32 v2.l, 0
+; GFX12-TRUE16-NEXT:    v_min_u16 v1.h, 0xff, v1.h
+; GFX12-TRUE16-NEXT:    v_min_u16 v1.l, 0xff, v1.l
+; GFX12-TRUE16-NEXT:    v_min_u16 v0.h, 0xff, v0.h
+; GFX12-TRUE16-NEXT:    v_min_u16 v0.l, 0xff, v0.l
+; GFX12-TRUE16-NEXT:    v_lshlrev_b16 v1.h, 8, v1.h
+; GFX12-TRUE16-NEXT:    v_or_b16 v2.h, v1.l, v1.h
+; GFX12-TRUE16-NEXT:    v_lshlrev_b16 v1.l, 8, v0.h
 ; GFX12-TRUE16-NEXT:    v_mov_b16_e32 v1.h, v2.h
 ; GFX12-TRUE16-NEXT:    v_or_b16 v0.l, v0.l, v1.l
 ; GFX12-TRUE16-NEXT:    v_lshrrev_b32_e32 v3, 24, v2
@@ -2018,95 +1980,73 @@ define <8 x i1> @test_unsigned_v8f16_v8i1(<8 x half> %f) {
 ; GFX9-LABEL: test_unsigned_v8f16_v8i1:
 ; GFX9:       ; %bb.0:
 ; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX9-NEXT:    v_cvt_f32_f16_sdwa v6, v1 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1
-; GFX9-NEXT:    v_cvt_f32_f16_sdwa v7, v0 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1
-; GFX9-NEXT:    v_cvt_f32_f16_sdwa v4, v3 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1
-; GFX9-NEXT:    v_cvt_f32_f16_sdwa v5, v2 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1
-; GFX9-NEXT:    v_cvt_f32_f16_e32 v3, v3
-; GFX9-NEXT:    v_cvt_f32_f16_e32 v2, v2
-; GFX9-NEXT:    v_cvt_f32_f16_e32 v1, v1
-; GFX9-NEXT:    v_cvt_f32_f16_e32 v0, v0
-; GFX9-NEXT:    v_cvt_u32_f32_e32 v6, v6
-; GFX9-NEXT:    v_cvt_u32_f32_e32 v8, v7
-; GFX9-NEXT:    v_cvt_u32_f32_e32 v4, v4
-; GFX9-NEXT:    v_cvt_u32_f32_e32 v5, v5
-; GFX9-NEXT:    v_cvt_u32_f32_e32 v3, v3
-; GFX9-NEXT:    v_cvt_u32_f32_e32 v2, v2
-; GFX9-NEXT:    v_cvt_u32_f32_e32 v1, v1
-; GFX9-NEXT:    v_cvt_u32_f32_e32 v0, v0
-; GFX9-NEXT:    v_min_u32_e32 v9, 1, v6
-; GFX9-NEXT:    v_min_u32_e32 v8, 1, v8
-; GFX9-NEXT:    v_min_u32_e32 v7, 1, v4
-; GFX9-NEXT:    v_min_u32_e32 v5, 1, v5
-; GFX9-NEXT:    v_min_u32_e32 v6, 1, v3
-; GFX9-NEXT:    v_min_u32_e32 v4, 1, v2
-; GFX9-NEXT:    v_min_u32_e32 v2, 1, v1
-; GFX9-NEXT:    v_min_u32_e32 v0, 1, v0
+; GFX9-NEXT:    v_cvt_u16_f16_e32 v4, v0
+; GFX9-NEXT:    v_cvt_u16_f16_sdwa v0, v0 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1
+; GFX9-NEXT:    v_min_u16_e32 v8, 1, v0
+; GFX9-NEXT:    v_cvt_u16_f16_sdwa v0, v1 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1
+; GFX9-NEXT:    v_min_u16_e32 v11, 1, v4
+; GFX9-NEXT:    v_cvt_u16_f16_e32 v4, v1
+; GFX9-NEXT:    v_cvt_u16_f16_e32 v5, v3
+; GFX9-NEXT:    v_min_u16_e32 v9, 1, v0
+; GFX9-NEXT:    v_cvt_u16_f16_sdwa v0, v2 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1
+; GFX9-NEXT:    v_min_u16_e32 v10, 1, v4
+; GFX9-NEXT:    v_cvt_u16_f16_e32 v4, v2
+; GFX9-NEXT:    v_min_u16_e32 v6, 1, v5
+; GFX9-NEXT:    v_min_u16_e32 v5, 1, v0
+; GFX9-NEXT:    v_cvt_u16_f16_sdwa v0, v3 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1
+; GFX9-NEXT:    v_min_u16_e32 v4, 1, v4
+; GFX9-NEXT:    v_min_u16_e32 v7, 1, v0
+; GFX9-NEXT:    v_mov_b32_e32 v0, v11
 ; GFX9-NEXT:    v_mov_b32_e32 v1, v8
+; GFX9-NEXT:    v_mov_b32_e32 v2, v10
 ; GFX9-NEXT:    v_mov_b32_e32 v3, v9
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-FAKE16-LABEL: test_unsigned_v8f16_v8i1:
 ; GFX11-FAKE16:       ; %bb.0:
 ; GFX11-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v4, 16, v3
-; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v5, 16, v2
-; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v6, 16, v1
+; GFX11-FAKE16-NEXT:    v_cvt_u16_f16_e32 v5, v1
+; GFX11-FAKE16-NEXT:    v_cvt_u16_f16_e32 v6, v2
 ; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v7, 16, v0
-; GFX11-FAKE16-NEXT:    v_cvt_f32_f16_e32 v8, v3
-; GFX11-FAKE16-NEXT:    v_cvt_f32_f16_e32 v4, v4
-; GFX11-FAKE16-NEXT:    v_cvt_f32_f16_e32 v5, v5
-; GFX11-FAKE16-NEXT:    v_cvt_f32_f16_e32 v6, v6
-; GFX11-FAKE16-NEXT:    v_cvt_f32_f16_e32 v1, v1
-; GFX11-FAKE16-NEXT:    v_cvt_f32_f16_e32 v0, v0
-; GFX11-FAKE16-NEXT:    v_cvt_u32_f32_e32 v3, v4
-; GFX11-FAKE16-NEXT:    v_cvt_u32_f32_e32 v4, v5
-; GFX11-FAKE16-NEXT:    v_cvt_u32_f32_e32 v6, v6
-; GFX11-FAKE16-NEXT:    v_cvt_f32_f16_e32 v9, v7
-; GFX11-FAKE16-NEXT:    v_cvt_f32_f16_e32 v2, v2
-; GFX11-FAKE16-NEXT:    v_min_u32_e32 v7, 1, v3
-; GFX11-FAKE16-NEXT:    v_min_u32_e32 v5, 1, v4
-; GFX11-FAKE16-NEXT:    v_min_u32_e32 v3, 1, v6
-; GFX11-FAKE16-NEXT:    v_cvt_u32_f32_e32 v0, v0
-; GFX11-FAKE16-NEXT:    v_cvt_u32_f32_e32 v4, v9
-; GFX11-FAKE16-NEXT:    v_cvt_u32_f32_e32 v6, v1
-; GFX11-FAKE16-NEXT:    v_cvt_u32_f32_e32 v8, v8
-; GFX11-FAKE16-NEXT:    v_cvt_u32_f32_e32 v9, v2
-; GFX11-FAKE16-NEXT:    v_min_u32_e32 v0, 1, v0
-; GFX11-FAKE16-NEXT:    v_min_u32_e32 v1, 1, v4
-; GFX11-FAKE16-NEXT:    v_min_u32_e32 v2, 1, v6
-; GFX11-FAKE16-NEXT:    v_min_u32_e32 v6, 1, v8
-; GFX11-FAKE16-NEXT:    v_min_u32_e32 v4, 1, v9
+; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v1, 16, v1
+; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v2, 16, v2
+; GFX11-FAKE16-NEXT:    v_min_u16 v8, v5, 1
+; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v5, 16, v3
+; GFX11-FAKE16-NEXT:    v_cvt_u16_f16_e32 v4, v0
+; GFX11-FAKE16-NEXT:    v_cvt_u16_f16_e32 v3, v3
+; GFX11-FAKE16-NEXT:    v_cvt_u16_f16_e32 v7, v7
+; GFX11-FAKE16-NEXT:    v_cvt_u16_f16_e32 v9, v1
+; GFX11-FAKE16-NEXT:    v_cvt_u16_f16_e32 v2, v2
+; GFX11-FAKE16-NEXT:    v_cvt_u16_f16_e32 v10, v5
+; GFX11-FAKE16-NEXT:    v_min_u16 v0, v4, 1
+; GFX11-FAKE16-NEXT:    v_min_u16 v4, v6, 1
+; GFX11-FAKE16-NEXT:    v_min_u16 v6, v3, 1
+; GFX11-FAKE16-NEXT:    v_min_u16 v1, v7, 1
+; GFX11-FAKE16-NEXT:    v_min_u16 v3, v9, 1
+; GFX11-FAKE16-NEXT:    v_min_u16 v5, v2, 1
+; GFX11-FAKE16-NEXT:    v_min_u16 v7, v10, 1
+; GFX11-FAKE16-NEXT:    v_mov_b32_e32 v2, v8
 ; GFX11-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-TRUE16-LABEL: test_unsigned_v8f16_v8i1:
 ; GFX11-TRUE16:       ; %bb.0:
 ; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX11-TRUE16-NEXT:    v_cvt_f32_f16_e32 v4, v3.h
-; GFX11-TRUE16-NEXT:    v_cvt_f32_f16_e32 v6, v1.h
-; GFX11-TRUE16-NEXT:    v_cvt_f32_f16_e32 v5, v2.h
-; GFX11-TRUE16-NEXT:    v_cvt_f32_f16_e32 v9, v0.h
-; GFX11-TRUE16-NEXT:    v_cvt_f32_f16_e32 v1, v1.l
-; GFX11-TRUE16-NEXT:    v_cvt_u32_f32_e32 v4, v4
-; GFX11-TRUE16-NEXT:    v_cvt_u32_f32_e32 v6, v6
-; GFX11-TRUE16-NEXT:    v_cvt_f32_f16_e32 v0, v0.l
-; GFX11-TRUE16-NEXT:    v_cvt_f32_f16_e32 v3, v3.l
-; GFX11-TRUE16-NEXT:    v_cvt_f32_f16_e32 v2, v2.l
-; GFX11-TRUE16-NEXT:    v_cvt_u32_f32_e32 v5, v5
-; GFX11-TRUE16-NEXT:    v_min_u32_e32 v7, 1, v4
-; GFX11-TRUE16-NEXT:    v_min_u32_e32 v8, 1, v6
-; GFX11-TRUE16-NEXT:    v_cvt_u32_f32_e32 v0, v0
-; GFX11-TRUE16-NEXT:    v_cvt_u32_f32_e32 v4, v9
-; GFX11-TRUE16-NEXT:    v_cvt_u32_f32_e32 v6, v1
-; GFX11-TRUE16-NEXT:    v_cvt_u32_f32_e32 v3, v3
-; GFX11-TRUE16-NEXT:    v_cvt_u32_f32_e32 v9, v2
-; GFX11-TRUE16-NEXT:    v_min_u32_e32 v5, 1, v5
-; GFX11-TRUE16-NEXT:    v_min_u32_e32 v0, 1, v0
-; GFX11-TRUE16-NEXT:    v_min_u32_e32 v1, 1, v4
-; GFX11-TRUE16-NEXT:    v_min_u32_e32 v2, 1, v6
-; GFX11-TRUE16-NEXT:    v_min_u32_e32 v6, 1, v3
-; GFX11-TRUE16-NEXT:    v_min_u32_e32 v4, 1, v9
-; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v3.l, v8.l
+; GFX11-TRUE16-NEXT:    v_cvt_u16_f16_e32 v0.l, v0.l
+; GFX11-TRUE16-NEXT:    v_cvt_u16_f16_e32 v1.l, v1.l
+; GFX11-TRUE16-NEXT:    v_cvt_u16_f16_e32 v4.l, v2.l
+; GFX11-TRUE16-NEXT:    v_cvt_u16_f16_e32 v3.l, v3.l
+; GFX11-TRUE16-NEXT:    v_cvt_u16_f16_e32 v0.h, v0.h
+; GFX11-TRUE16-NEXT:    v_cvt_u16_f16_e32 v1.h, v1.h
+; GFX11-TRUE16-NEXT:    v_cvt_u16_f16_e32 v2.h, v2.h
+; GFX11-TRUE16-NEXT:    v_cvt_u16_f16_e32 v3.h, v3.h
+; GFX11-TRUE16-NEXT:    v_min_u16 v0.l, v0.l, 1
+; GFX11-TRUE16-NEXT:    v_min_u16 v2.l, v1.l, 1
+; GFX11-TRUE16-NEXT:    v_min_u16 v4.l, v4.l, 1
+; GFX11-TRUE16-NEXT:    v_min_u16 v6.l, v3.l, 1
+; GFX11-TRUE16-NEXT:    v_min_u16 v1.l, v0.h, 1
+; GFX11-TRUE16-NEXT:    v_min_u16 v3.l, v1.h, 1
+; GFX11-TRUE16-NEXT:    v_min_u16 v5.l, v2.h, 1
+; GFX11-TRUE16-NEXT:    v_min_u16 v7.l, v3.h, 1
 ; GFX11-TRUE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX12-FAKE16-LABEL: test_unsigned_v8f16_v8i1:
@@ -2116,34 +2056,27 @@ define <8 x i1> @test_unsigned_v8f16_v8i1(<8 x half> %f) {
 ; GFX12-FAKE16-NEXT:    s_wait_samplecnt 0x0
 ; GFX12-FAKE16-NEXT:    s_wait_bvhcnt 0x0
 ; GFX12-FAKE16-NEXT:    s_wait_kmcnt 0x0
-; GFX12-FAKE16-NEXT:    v_lshrrev_b32_e32 v4, 16, v3
-; GFX12-FAKE16-NEXT:    v_lshrrev_b32_e32 v5, 16, v2
-; GFX12-FAKE16-NEXT:    v_lshrrev_b32_e32 v6, 16, v1
+; GFX12-FAKE16-NEXT:    v_cvt_u16_f16_e32 v5, v1
+; GFX12-FAKE16-NEXT:    v_cvt_u16_f16_e32 v6, v2
 ; GFX12-FAKE16-NEXT:    v_lshrrev_b32_e32 v7, 16, v0
-; GFX12-FAKE16-NEXT:    v_cvt_f32_f16_e32 v8, v3
-; GFX12-FAKE16-NEXT:    v_cvt_f32_f16_e32 v4, v4
-; GFX12-FAKE16-NEXT:    v_cvt_f32_f16_e32 v5, v5
-; GFX12-FAKE16-NEXT:    v_cvt_f32_f16_e32 v6, v6
-; GFX12-FAKE16-NEXT:    v_cvt_f32_f16_e32 v1, v1
-; GFX12-FAKE16-NEXT:    v_cvt_f32_f16_e32 v0, v0
-; GFX12-FAKE16-NEXT:    v_cvt_u32_f32_e32 v3, v4
-; GFX12-FAKE16-NEXT:    v_cvt_u32_f32_e32 v4, v5
-; GFX12-FAKE16-NEXT:    v_cvt_u32_f32_e32 v6, v6
-; GFX12-FAKE16-NEXT:    v_cvt_f32_f16_e32 v9, v7
-; GFX12-FAKE16-NEXT:    v_cvt_f32_f16_e32 v2, v2
-; GFX12-FAKE16-NEXT:    v_min_u32_e32 v7, 1, v3
-; GFX12-FAKE16-NEXT:    v_min_u32_e32 v5, 1, v4
-; GFX12-FAKE16-NEXT:    v_min_u32_e32 v3, 1, v6
-; GFX12-FAKE16-NEXT:    v_cvt_u32_f32_e32 v0, v0
-; GFX12-FAKE16-NEXT:    v_cvt_u32_f32_e32 v4, v9
-; GFX12-FAKE16-NEXT:    v_cvt_u32_f32_e32 v6, v1
-; GFX12-FAKE16-NEXT:    v_cvt_u32_f32_e32 v8, v8
-; GFX12-FAKE16-NEXT:    v_cvt_u32_f32_e32 v9, v2
-; GFX12-FAKE16-NEXT:    v_min_u32_e32 v0, 1, v0
-; GFX12-FAKE16-NEXT:    v_min_u32_e32 v1, 1, v4
-; GFX12-FAKE16-NEXT:    v_min_u32_e32 v2, 1, v6
-; GFX12-FAKE16-NEXT:    v_min_u32_e32 v6, 1, v8
-; GFX12-FAKE16-NEXT:    v_min_u32_e32 v4, 1, v9
+; GFX12-FAKE16-NEXT:    v_lshrrev_b32_e32 v1, 16, v1
+; GFX12-FAKE16-NEXT:    v_lshrrev_b32_e32 v2, 16, v2
+; GFX12-FAKE16-NEXT:    v_min_u16 v8, v5, 1
+; GFX12-FAKE16-NEXT:    v_lshrrev_b32_e32 v5, 16, v3
+; GFX12-FAKE16-NEXT:    v_cvt_u16_f16_e32 v4, v0
+; GFX12-FAKE16-NEXT:    v_cvt_u16_f16_e32 v3, v3
+; GFX12-FAKE16-NEXT:    v_cvt_u16_f16_e32 v7, v7
+; GFX12-FAKE16-NEXT:    v_cvt_u16_f16_e32 v9, v1
+; GFX12-FAKE16-NEXT:    v_cvt_u16_f16_e32 v2, v2
+; GFX12-FAKE16-NEXT:    v_cvt_u16_f16_e32 v10, v5
+; GFX12-FAKE16-NEXT:    v_min_u16 v0, v4, 1
+; GFX12-FAKE16-NEXT:    v_min_u16 v4, v6, 1
+; GFX12-FAKE16-NEXT:    v_min_u16 v6, v3, 1
+; GFX12-FAKE16-NEXT:    v_min_u16 v1, v7, 1
+; GFX12-FAKE16-NEXT:    v_min_u16 v3, v9, 1
+; GFX12-FAKE16-NEXT:    v_min_u16 v5, v2, 1
+; GFX12-FAKE16-NEXT:    v_min_u16 v7, v10, 1
+; GFX12-FAKE16-NEXT:    v_mov_b32_e32 v2, v8
 ; GFX12-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX12-TRUE16-LABEL: test_unsigned_v8f16_v8i1:
@@ -2153,31 +2086,22 @@ define <8 x i1> @test_unsigned_v8f16_v8i1(<8 x half> %f) {
 ; GFX12-TRUE16-NEXT:    s_wait_samplecnt 0x0
 ; GFX12-TRUE16-NEXT:    s_wait_bvhcnt 0x0
 ; GFX12-TRUE16-NEXT:    s_wait_kmcnt 0x0
-; GFX12-TRUE16-NEXT:    v_cvt_f32_f16_e32 v4, v3.h
-; GFX12-TRUE16-NEXT:    v_cvt_f32_f16_e32 v6, v1.h
-; GFX12-TRUE16-NEXT:    v_cvt_f32_f16_e32 v5, v2.h
-; GFX12-TRUE16-NEXT:    v_cvt_f32_f16_e32 v9, v0.h
-; GFX12-TRUE16-NEXT:    v_cvt_f32_f16_e32 v1, v1.l
-; GFX12-TRUE16-NEXT:    v_cvt_u32_f32_e32 v4, v4
-; GFX12-TRUE16-NEXT:    v_cvt_u32_f32_e32 v6, v6
-; GFX12-TRUE16-NEXT:    v_cvt_f32_f16_e32 v0, v0.l
-; GFX12-TRUE16-NEXT:    v_cvt_f32_f16_e32 v3, v3.l
-; GFX12-TRUE16-NEXT:    v_cvt_f32_f16_e32 v2, v2.l
-; GFX12-TRUE16-NEXT:    v_cvt_u32_f32_e32 v5, v5
-; GFX12-TRUE16-NEXT:    v_min_u32_e32 v7, 1, v4
-; GFX12-TRUE16-NEXT:    v_min_u32_e32 v8, 1, v6
-; GFX12-TRUE16-NEXT:    v_cvt_u32_f32_e32 v0, v0
-; GFX12-TRUE16-NEXT:    v_cvt_u32_f32_e32 v4, v9
-; GFX12-TRUE16-NEXT:    v_cvt_u32_f32_e32 v6, v1
-; GFX12-TRUE16-NEXT:    v_cvt_u32_f32_e32 v3, v3
-; GFX12-TRUE16-NEXT:    v_cvt_u32_f32_e32 v9, v2
-; GFX12-TRUE16-NEXT:    v_min_u32_e32 v5, 1, v5
-; GFX12-TRUE16-NEXT:    v_min_u32_e32 v0, 1, v0
-; GFX12-TRUE16-NEXT:    v_min_u32_e32 v1, 1, v4
-; GFX12-TRUE16-NEXT:    v_min_u32_e32 v2, 1, v6
-; GFX12-TRUE16-NEXT:    v_min_u32_e32 v6, 1, v3
-; GFX12-TRUE16-NEXT:    v_min_u32_e32 v4, 1, v9
-; GFX12-TRUE16-NEXT:    v_mov_b16_e32 v3.l, v8.l
+; GFX12-TRUE16-NEXT:    v_cvt_u16_f16_e32 v0.l, v0.l
+; GFX12-TRUE16-NEXT:    v_cvt_u16_f16_e32 v1.l, v1.l
+; GFX12-TRUE16-NEXT:    v_cvt_u16_f16_e32 v4.l, v2.l
+; GFX12-TRUE16-NEXT:    v_cvt_u16_f16_e32 v3.l, v3.l
+; GFX12-TRUE16-NEXT:    v_cvt_u16_f16_e32 v0.h, v0.h
+; GFX12-TRUE16-NEXT:    v_cvt_u16_f16_e32 v1.h, v1.h
+; GFX12-TRUE16-NEXT:    v_cvt_u16_f16_e32 v2.h, v2.h
+; GFX12-TRUE16-NEXT:    v_cvt_u16_f16_e32 v3.h, v3.h
+; GFX12-TRUE16-NEXT:    v_min_u16 v0.l, v0.l, 1
+; GFX12-TRUE16-NEXT:    v_min_u16 v2.l, v1.l, 1
+; GFX12-TRUE16-NEXT:    v_min_u16 v4.l, v4.l, 1
+; GFX12-TRUE16-NEXT:    v_min_u16 v6.l, v3.l, 1
+; GFX12-TRUE16-NEXT:    v_min_u16 v1.l, v0.h, 1
+; GFX12-TRUE16-NEXT:    v_min_u16 v3.l, v1.h, 1
+; GFX12-TRUE16-NEXT:    v_min_u16 v5.l, v2.h, 1
+; GFX12-TRUE16-NEXT:    v_min_u16 v7.l, v3.h, 1
 ; GFX12-TRUE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX12-GI-LABEL: test_unsigned_v8f16_v8i1:
@@ -2305,40 +2229,32 @@ define <8 x i8> @test_unsigned_v8f16_v8i8(<8 x half> %f) {
 ; GFX9-LABEL: test_unsigned_v8f16_v8i8:
 ; GFX9:       ; %bb.0:
 ; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX9-NEXT:    v_cvt_f32_f16_sdwa v4, v2 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1
-; GFX9-NEXT:    v_cvt_f32_f16_e32 v2, v2
-; GFX9-NEXT:    v_cvt_f32_f16_sdwa v5, v3 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1
-; GFX9-NEXT:    v_cvt_f32_f16_e32 v3, v3
-; GFX9-NEXT:    v_cvt_u32_f32_e32 v4, v4
-; GFX9-NEXT:    v_cvt_u32_f32_e32 v2, v2
+; GFX9-NEXT:    v_cvt_u16_f16_e32 v4, v2
 ; GFX9-NEXT:    s_movk_i32 s4, 0xff
-; GFX9-NEXT:    v_cvt_u32_f32_e32 v5, v5
-; GFX9-NEXT:    v_min_u32_sdwa v4, v4, s4 dst_sel:BYTE_1 dst_unused:UNUSED_PAD src0_sel:DWORD src1_sel:DWORD
-; GFX9-NEXT:    v_min_u32_e32 v2, 0xff, v2
-; GFX9-NEXT:    v_cvt_u32_f32_e32 v3, v3
-; GFX9-NEXT:    v_or_b32_e32 v8, v2, v4
-; GFX9-NEXT:    v_cvt_f32_f16_sdwa v4, v1 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1
-; GFX9-NEXT:    v_cvt_f32_f16_e32 v1, v1
-; GFX9-NEXT:    v_min_u32_sdwa v2, v5, s4 dst_sel:BYTE_1 dst_unused:UNUSED_PAD src0_sel:DWORD src1_sel:DWORD
-; GFX9-NEXT:    v_min_u32_e32 v3, 0xff, v3
-; GFX9-NEXT:    v_or_b32_e32 v6, v3, v2
-; GFX9-NEXT:    v_cvt_u32_f32_e32 v2, v4
-; GFX9-NEXT:    v_cvt_u32_f32_e32 v1, v1
-; GFX9-NEXT:    v_cvt_f32_f16_sdwa v3, v0 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1
-; GFX9-NEXT:    v_cvt_f32_f16_e32 v0, v0
-; GFX9-NEXT:    v_min_u32_sdwa v2, v2, s4 dst_sel:BYTE_1 dst_unused:UNUSED_PAD src0_sel:DWORD src1_sel:DWORD
-; GFX9-NEXT:    v_min_u32_e32 v1, 0xff, v1
-; GFX9-NEXT:    v_or_b32_e32 v2, v1, v2
-; GFX9-NEXT:    v_cvt_u32_f32_e32 v1, v3
-; GFX9-NEXT:    v_cvt_u32_f32_e32 v0, v0
+; GFX9-NEXT:    v_cvt_u16_f16_sdwa v2, v2 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1
+; GFX9-NEXT:    v_min_u16_e32 v4, 0xff, v4
+; GFX9-NEXT:    v_min_u16_sdwa v2, v2, s4 dst_sel:BYTE_1 dst_unused:UNUSED_PAD src0_sel:DWORD src1_sel:DWORD
+; GFX9-NEXT:    v_or_b32_e32 v8, v4, v2
+; GFX9-NEXT:    v_cvt_u16_f16_e32 v2, v3
+; GFX9-NEXT:    v_cvt_u16_f16_sdwa v3, v3 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1
+; GFX9-NEXT:    v_min_u16_e32 v2, 0xff, v2
+; GFX9-NEXT:    v_min_u16_sdwa v3, v3, s4 dst_sel:BYTE_1 dst_unused:UNUSED_PAD src0_sel:DWORD src1_sel:DWORD
+; GFX9-NEXT:    v_or_b32_e32 v6, v2, v3
+; GFX9-NEXT:    v_cvt_u16_f16_e32 v2, v1
+; GFX9-NEXT:    v_cvt_u16_f16_sdwa v1, v1 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1
+; GFX9-NEXT:    v_min_u16_e32 v2, 0xff, v2
+; GFX9-NEXT:    v_min_u16_sdwa v1, v1, s4 dst_sel:BYTE_1 dst_unused:UNUSED_PAD src0_sel:DWORD src1_sel:DWORD
 ; GFX9-NEXT:    v_lshlrev_b32_e32 v7, 16, v6
+; GFX9-NEXT:    v_or_b32_e32 v2, v2, v1
+; GFX9-NEXT:    v_cvt_u16_f16_e32 v1, v0
+; GFX9-NEXT:    v_cvt_u16_f16_sdwa v0, v0 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1
 ; GFX9-NEXT:    v_or_b32_sdwa v4, v8, v7 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
 ; GFX9-NEXT:    v_lshlrev_b32_e32 v3, 16, v2
-; GFX9-NEXT:    v_min_u32_sdwa v1, v1, s4 dst_sel:BYTE_1 dst_unused:UNUSED_PAD src0_sel:DWORD src1_sel:DWORD
-; GFX9-NEXT:    v_min_u32_e32 v0, 0xff, v0
+; GFX9-NEXT:    v_min_u16_e32 v1, 0xff, v1
+; GFX9-NEXT:    v_min_u16_sdwa v9, v0, s4 dst_sel:BYTE_1 dst_unused:UNUSED_PAD src0_sel:DWORD src1_sel:DWORD
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v5, 8, v4
-; GFX9-NEXT:    v_or_b32_e32 v0, v0, v1
-; GFX9-NEXT:    v_or_b32_e32 v1, v1, v3
+; GFX9-NEXT:    v_or_b32_e32 v0, v1, v9
+; GFX9-NEXT:    v_or_b32_e32 v1, v9, v3
 ; GFX9-NEXT:    v_lshrrev_b64 v[3:4], 24, v[3:4]
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v7, 24, v7
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v1, 8, v1
@@ -2348,98 +2264,82 @@ define <8 x i8> @test_unsigned_v8f16_v8i8(<8 x half> %f) {
 ; GFX11-FAKE16-LABEL: test_unsigned_v8f16_v8i8:
 ; GFX11-FAKE16:       ; %bb.0:
 ; GFX11-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v4, 16, v2
+; GFX11-FAKE16-NEXT:    v_cvt_u16_f16_e32 v4, v2
+; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v2, 16, v2
 ; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v5, 16, v3
 ; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v6, 16, v1
 ; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v7, 16, v0
-; GFX11-FAKE16-NEXT:    v_cvt_f32_f16_e32 v2, v2
-; GFX11-FAKE16-NEXT:    v_cvt_f32_f16_e32 v4, v4
-; GFX11-FAKE16-NEXT:    v_cvt_f32_f16_e32 v5, v5
-; GFX11-FAKE16-NEXT:    v_cvt_f32_f16_e32 v6, v6
-; GFX11-FAKE16-NEXT:    v_cvt_f32_f16_e32 v3, v3
-; GFX11-FAKE16-NEXT:    v_cvt_f32_f16_e32 v1, v1
-; GFX11-FAKE16-NEXT:    v_cvt_u32_f32_e32 v4, v4
-; GFX11-FAKE16-NEXT:    v_cvt_f32_f16_e32 v7, v7
-; GFX11-FAKE16-NEXT:    v_cvt_u32_f32_e32 v6, v6
-; GFX11-FAKE16-NEXT:    v_cvt_u32_f32_e32 v5, v5
-; GFX11-FAKE16-NEXT:    v_cvt_u32_f32_e32 v2, v2
-; GFX11-FAKE16-NEXT:    v_cvt_u32_f32_e32 v1, v1
-; GFX11-FAKE16-NEXT:    v_min_u32_e32 v4, 0xff, v4
-; GFX11-FAKE16-NEXT:    v_min_u32_e32 v6, 0xff, v6
-; GFX11-FAKE16-NEXT:    v_cvt_u32_f32_e32 v7, v7
-; GFX11-FAKE16-NEXT:    v_min_u32_e32 v5, 0xff, v5
-; GFX11-FAKE16-NEXT:    v_cvt_u32_f32_e32 v3, v3
-; GFX11-FAKE16-NEXT:    v_min_u32_e32 v2, 0xff, v2
-; GFX11-FAKE16-NEXT:    v_lshlrev_b16 v4, 8, v4
-; GFX11-FAKE16-NEXT:    v_lshlrev_b16 v6, 8, v6
-; GFX11-FAKE16-NEXT:    v_min_u32_e32 v1, 0xff, v1
+; GFX11-FAKE16-NEXT:    v_cvt_u16_f16_e32 v3, v3
+; GFX11-FAKE16-NEXT:    v_cvt_u16_f16_e32 v2, v2
+; GFX11-FAKE16-NEXT:    v_cvt_u16_f16_e32 v5, v5
+; GFX11-FAKE16-NEXT:    v_cvt_u16_f16_e32 v6, v6
+; GFX11-FAKE16-NEXT:    v_cvt_u16_f16_e32 v1, v1
+; GFX11-FAKE16-NEXT:    v_cvt_u16_f16_e32 v7, v7
+; GFX11-FAKE16-NEXT:    v_min_u16 v2, 0xff, v2
+; GFX11-FAKE16-NEXT:    v_min_u16 v5, 0xff, v5
+; GFX11-FAKE16-NEXT:    v_min_u16 v6, 0xff, v6
+; GFX11-FAKE16-NEXT:    v_min_u16 v4, 0xff, v4
+; GFX11-FAKE16-NEXT:    v_min_u16 v3, 0xff, v3
+; GFX11-FAKE16-NEXT:    v_lshlrev_b16 v2, 8, v2
 ; GFX11-FAKE16-NEXT:    v_lshlrev_b16 v5, 8, v5
-; GFX11-FAKE16-NEXT:    v_min_u32_e32 v7, 0xff, v7
-; GFX11-FAKE16-NEXT:    v_min_u32_e32 v3, 0xff, v3
-; GFX11-FAKE16-NEXT:    v_or_b32_e32 v8, v2, v4
-; GFX11-FAKE16-NEXT:    v_or_b32_e32 v2, v1, v6
-; GFX11-FAKE16-NEXT:    v_cvt_f32_f16_e32 v0, v0
-; GFX11-FAKE16-NEXT:    v_lshlrev_b16 v1, 8, v7
+; GFX11-FAKE16-NEXT:    v_min_u16 v1, 0xff, v1
+; GFX11-FAKE16-NEXT:    v_lshlrev_b16 v9, 8, v6
+; GFX11-FAKE16-NEXT:    v_min_u16 v7, 0xff, v7
+; GFX11-FAKE16-NEXT:    v_or_b32_e32 v8, v4, v2
 ; GFX11-FAKE16-NEXT:    v_or_b32_e32 v6, v3, v5
+; GFX11-FAKE16-NEXT:    v_cvt_u16_f16_e32 v0, v0
+; GFX11-FAKE16-NEXT:    v_or_b32_e32 v2, v1, v9
+; GFX11-FAKE16-NEXT:    v_lshlrev_b16 v1, 8, v7
 ; GFX11-FAKE16-NEXT:    v_and_b32_e32 v3, 0xffff, v8
-; GFX11-FAKE16-NEXT:    v_lshlrev_b32_e32 v4, 16, v2
-; GFX11-FAKE16-NEXT:    v_cvt_u32_f32_e32 v0, v0
-; GFX11-FAKE16-NEXT:    v_and_b32_e32 v5, 0xffff, v1
 ; GFX11-FAKE16-NEXT:    v_lshlrev_b32_e32 v7, 16, v6
-; GFX11-FAKE16-NEXT:    v_min_u32_e32 v0, 0xff, v0
-; GFX11-FAKE16-NEXT:    v_or_b32_e32 v9, v5, v4
+; GFX11-FAKE16-NEXT:    v_min_u16 v0, 0xff, v0
+; GFX11-FAKE16-NEXT:    v_lshlrev_b32_e32 v4, 16, v2
+; GFX11-FAKE16-NEXT:    v_and_b32_e32 v9, 0xffff, v1
 ; GFX11-FAKE16-NEXT:    v_or_b32_e32 v5, v3, v7
-; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v7, 24, v7
 ; GFX11-FAKE16-NEXT:    v_or_b32_e32 v0, v0, v1
-; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v1, 8, v9
+; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v7, 24, v7
+; GFX11-FAKE16-NEXT:    v_or_b32_e32 v9, v9, v4
 ; GFX11-FAKE16-NEXT:    v_lshrrev_b64 v[3:4], 24, v[4:5]
 ; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v5, 8, v5
 ; GFX11-FAKE16-NEXT:    v_mov_b32_e32 v4, v8
+; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v1, 8, v9
 ; GFX11-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-TRUE16-LABEL: test_unsigned_v8f16_v8i8:
 ; GFX11-TRUE16:       ; %bb.0:
 ; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX11-TRUE16-NEXT:    v_cvt_f32_f16_e32 v4, v3.h
-; GFX11-TRUE16-NEXT:    v_cvt_f32_f16_e32 v5, v1.h
-; GFX11-TRUE16-NEXT:    v_cvt_f32_f16_e32 v6, v2.h
-; GFX11-TRUE16-NEXT:    v_cvt_f32_f16_e32 v1, v1.l
-; GFX11-TRUE16-NEXT:    v_cvt_f32_f16_e32 v3, v3.l
-; GFX11-TRUE16-NEXT:    v_cvt_u32_f32_e32 v4, v4
-; GFX11-TRUE16-NEXT:    v_cvt_u32_f32_e32 v5, v5
-; GFX11-TRUE16-NEXT:    v_cvt_f32_f16_e32 v7, v0.h
-; GFX11-TRUE16-NEXT:    v_cvt_u32_f32_e32 v6, v6
-; GFX11-TRUE16-NEXT:    v_cvt_u32_f32_e32 v9, v1
-; GFX11-TRUE16-NEXT:    v_min_u32_e32 v4, 0xff, v4
-; GFX11-TRUE16-NEXT:    v_min_u32_e32 v1, 0xff, v5
-; GFX11-TRUE16-NEXT:    v_cvt_f32_f16_e32 v2, v2.l
-; GFX11-TRUE16-NEXT:    v_cvt_u32_f32_e32 v3, v3
-; GFX11-TRUE16-NEXT:    v_min_u32_e32 v5, 0xff, v6
-; GFX11-TRUE16-NEXT:    v_lshlrev_b16 v0.h, 8, v4.l
-; GFX11-TRUE16-NEXT:    v_lshlrev_b16 v1.l, 8, v1.l
-; GFX11-TRUE16-NEXT:    v_cvt_u32_f32_e32 v4, v7
-; GFX11-TRUE16-NEXT:    v_cvt_f32_f16_e32 v6, v0.l
-; GFX11-TRUE16-NEXT:    v_min_u32_e32 v7, 0xff, v9
-; GFX11-TRUE16-NEXT:    v_cvt_u32_f32_e32 v2, v2
-; GFX11-TRUE16-NEXT:    v_min_u32_e32 v3, 0xff, v3
-; GFX11-TRUE16-NEXT:    v_lshlrev_b16 v0.l, 8, v5.l
-; GFX11-TRUE16-NEXT:    v_min_u32_e32 v4, 0xff, v4
-; GFX11-TRUE16-NEXT:    v_cvt_u32_f32_e32 v5, v6
-; GFX11-TRUE16-NEXT:    v_or_b16 v8.h, v7.l, v1.l
-; GFX11-TRUE16-NEXT:    v_min_u32_e32 v1, 0xff, v2
+; GFX11-TRUE16-NEXT:    v_cvt_u16_f16_e32 v1.h, v1.h
+; GFX11-TRUE16-NEXT:    v_cvt_u16_f16_e32 v3.h, v3.h
+; GFX11-TRUE16-NEXT:    v_cvt_u16_f16_e32 v1.l, v1.l
+; GFX11-TRUE16-NEXT:    v_cvt_u16_f16_e32 v2.h, v2.h
+; GFX11-TRUE16-NEXT:    v_cvt_u16_f16_e32 v3.l, v3.l
+; GFX11-TRUE16-NEXT:    v_min_u16 v1.h, 0xff, v1.h
+; GFX11-TRUE16-NEXT:    v_min_u16 v3.h, 0xff, v3.h
+; GFX11-TRUE16-NEXT:    v_cvt_u16_f16_e32 v2.l, v2.l
+; GFX11-TRUE16-NEXT:    v_min_u16 v1.l, 0xff, v1.l
+; GFX11-TRUE16-NEXT:    v_cvt_u16_f16_e32 v0.h, v0.h
+; GFX11-TRUE16-NEXT:    v_lshlrev_b16 v1.h, 8, v1.h
+; GFX11-TRUE16-NEXT:    v_min_u16 v2.h, 0xff, v2.h
+; GFX11-TRUE16-NEXT:    v_min_u16 v3.l, 0xff, v3.l
+; GFX11-TRUE16-NEXT:    v_lshlrev_b16 v3.h, 8, v3.h
+; GFX11-TRUE16-NEXT:    v_min_u16 v2.l, 0xff, v2.l
+; GFX11-TRUE16-NEXT:    v_cvt_u16_f16_e32 v0.l, v0.l
+; GFX11-TRUE16-NEXT:    v_min_u16 v0.h, 0xff, v0.h
+; GFX11-TRUE16-NEXT:    v_or_b16 v8.h, v1.l, v1.h
+; GFX11-TRUE16-NEXT:    v_lshlrev_b16 v1.l, 8, v2.h
 ; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v8.l, 0
-; GFX11-TRUE16-NEXT:    v_or_b16 v9.h, v3.l, v0.h
-; GFX11-TRUE16-NEXT:    v_lshlrev_b16 v2.l, 8, v4.l
-; GFX11-TRUE16-NEXT:    v_min_u32_e32 v3, 0xff, v5
-; GFX11-TRUE16-NEXT:    v_or_b16 v9.l, v1.l, v0.l
-; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v2.h, v8.h
-; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v6.l, v8.l
-; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v6.h, v9.h
-; GFX11-TRUE16-NEXT:    v_or_b16 v0.l, v3.l, v2.l
+; GFX11-TRUE16-NEXT:    v_or_b16 v9.h, v3.l, v3.h
+; GFX11-TRUE16-NEXT:    v_min_u16 v0.l, 0xff, v0.l
+; GFX11-TRUE16-NEXT:    v_lshlrev_b16 v3.l, 8, v0.h
+; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v3.h, v8.h
+; GFX11-TRUE16-NEXT:    v_or_b16 v9.l, v2.l, v1.l
+; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v2.l, v8.l
+; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v2.h, v9.h
+; GFX11-TRUE16-NEXT:    v_or_b16 v0.l, v0.l, v3.l
+; GFX11-TRUE16-NEXT:    v_lshrrev_b32_e32 v1, 8, v3
 ; GFX11-TRUE16-NEXT:    v_lshrrev_b64 v[3:4], 24, v[8:9]
-; GFX11-TRUE16-NEXT:    v_lshrrev_b32_e32 v1, 8, v2
 ; GFX11-TRUE16-NEXT:    v_lshrrev_b32_e32 v5, 8, v9
-; GFX11-TRUE16-NEXT:    v_lshrrev_b32_e32 v7, 24, v6
+; GFX11-TRUE16-NEXT:    v_lshrrev_b32_e32 v7, 24, v2
 ; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v2.l, v8.h
 ; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v4.l, v9.l
 ; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v6.l, v9.h
@@ -2452,53 +2352,45 @@ define <8 x i8> @test_unsigned_v8f16_v8i8(<8 x half> %f) {
 ; GFX12-FAKE16-NEXT:    s_wait_samplecnt 0x0
 ; GFX12-FAKE16-NEXT:    s_wait_bvhcnt 0x0
 ; GFX12-FAKE16-NEXT:    s_wait_kmcnt 0x0
-; GFX12-FAKE16-NEXT:    v_lshrrev_b32_e32 v4, 16, v2
+; GFX12-FAKE16-NEXT:    v_cvt_u16_f16_e32 v4, v2
+; GFX12-FAKE16-NEXT:    v_lshrrev_b32_e32 v2, 16, v2
 ; GFX12-FAKE16-NEXT:    v_lshrrev_b32_e32 v5, 16, v3
 ; GFX12-FAKE16-NEXT:    v_lshrrev_b32_e32 v6, 16, v1
 ; GFX12-FAKE16-NEXT:    v_lshrrev_b32_e32 v7, 16, v0
-; GFX12-FAKE16-NEXT:    v_cvt_f32_f16_e32 v2, v2
-; GFX12-FAKE16-NEXT:    v_cvt_f32_f16_e32 v4, v4
-; GFX12-FAKE16-NEXT:    v_cvt_f32_f16_e32 v5, v5
-; GFX12-FAKE16-NEXT:    v_cvt_f32_f16_e32 v6, v6
-; GFX12-FAKE16-NEXT:    v_cvt_f32_f16_e32 v3, v3
-; GFX12-FAKE16-NEXT:    v_cvt_f32_f16_e32 v1, v1
-; GFX12-FAKE16-NEXT:    v_cvt_u32_f32_e32 v4, v4
-; GFX12-FAKE16-NEXT:    v_cvt_f32_f16_e32 v7, v7
-; GFX12-FAKE16-NEXT:    v_cvt_u32_f32_e32 v6, v6
-; GFX12-FAKE16-NEXT:    v_cvt_u32_f32_e32 v5, v5
-; GFX12-FAKE16-NEXT:    v_cvt_u32_f32_e32 v2, v2
-; GFX12-FAKE16-NEXT:    v_cvt_u32_f32_e32 v1, v1
-; GFX12-FAKE16-NEXT:    v_min_u32_e32 v4, 0xff, v4
-; GFX12-FAKE16-NEXT:    v_min_u32_e32 v6, 0xff, v6
-; GFX12-FAKE16-NEXT:    v_cvt_u32_f32_e32 v7, v7
-; GFX12-FAKE16-NEXT:    v_min_u32_e32 v5, 0xff, v5
-; GFX12-FAKE16-NEXT:    v_cvt_u32_f32_e32 v3, v3
-; GFX12-FAKE16-NEXT:    v_min_u32_e32 v2, 0xff, v2
-; GFX12-FAKE16-NEXT:    v_lshlrev_b16 v4, 8, v4
-; GFX12-FAKE16-NEXT:    v_lshlrev_b16 v6, 8, v6
-; GFX12-FAKE16-NEXT:    v_min_u32_e32 v1, 0xff, v1
+; GFX12-FAKE16-NEXT:    v_cvt_u16_f16_e32 v3, v3
+; GFX12-FAKE16-NEXT:    v_cvt_u16_f16_e32 v2, v2
+; GFX12-FAKE16-NEXT:    v_cvt_u16_f16_e32 v5, v5
+; GFX12-FAKE16-NEXT:    v_cvt_u16_f16_e32 v6, v6
+; GFX12-FAKE16-NEXT:    v_cvt_u16_f16_e32 v1, v1
+; GFX12-FAKE16-NEXT:    v_cvt_u16_f16_e32 v7, v7
+; GFX12-FAKE16-NEXT:    v_min_u16 v2, 0xff, v2
+; GFX12-FAKE16-NEXT:    v_min_u16 v5, 0xff, v5
+; GFX12-FAKE16-NEXT:    v_min_u16 v6, 0xff, v6
+; GFX12-FAKE16-NEXT:    v_min_u16 v4, 0xff, v4
+; GFX12-FAKE16-NEXT:    v_min_u16 v3, 0xff, v3
+; GFX12-FAKE16-NEXT:    v_lshlrev_b16 v2, 8, v2
 ; GFX12-FAKE16-NEXT:    v_lshlrev_b16 v5, 8, v5
-; GFX12-FAKE16-NEXT:    v_min_u32_e32 v7, 0xff, v7
-; GFX12-FAKE16-NEXT:    v_min_u32_e32 v3, 0xff, v3
-; GFX12-FAKE16-NEXT:    v_or_b32_e32 v8, v2, v4
-; GFX12-FAKE16-NEXT:    v_or_b32_e32 v2, v1, v6
-; GFX12-FAKE16-NEXT:    v_cvt_f32_f16_e32 v0, v0
-; GFX12-FAKE16-NEXT:    v_lshlrev_b16 v1, 8, v7
+; GFX12-FAKE16-NEXT:    v_min_u16 v1, 0xff, v1
+; GFX12-FAKE16-NEXT:    v_lshlrev_b16 v9, 8, v6
+; GFX12-FAKE16-NEXT:    v_min_u16 v7, 0xff, v7
+; GFX12-FAKE16-NEXT:    v_or_b32_e32 v8, v4, v2
 ; GFX12-FAKE16-NEXT:    v_or_b32_e32 v6, v3, v5
+; GFX12-FAKE16-NEXT:    v_cvt_u16_f16_e32 v0, v0
+; GFX12-FAKE16-NEXT:    v_or_b32_e32 v2, v1, v9
+; GFX12-FAKE16-NEXT:    v_lshlrev_b16 v1, 8, v7
 ; GFX12-FAKE16-NEXT:    v_and_b32_e32 v3, 0xffff, v8
-; GFX12-FAKE16-NEXT:    v_lshlrev_b32_e32 v4, 16, v2
-; GFX12-FAKE16-NEXT:    v_cvt_u32_f32_e32 v0, v0
-; GFX12-FAKE16-NEXT:    v_and_b32_e32 v5, 0xffff, v1
 ; GFX12-FAKE16-NEXT:    v_lshlrev_b32_e32 v7, 16, v6
-; GFX12-FAKE16-NEXT:    v_min_u32_e32 v0, 0xff, v0
-; GFX12-FAKE16-NEXT:    v_or_b32_e32 v9, v5, v4
+; GFX12-FAKE16-NEXT:    v_min_u16 v0, 0xff, v0
+; GFX12-FAKE16-NEXT:    v_lshlrev_b32_e32 v4, 16, v2
+; GFX12-FAKE16-NEXT:    v_and_b32_e32 v9, 0xffff, v1
 ; GFX12-FAKE16-NEXT:    v_or_b32_e32 v5, v3, v7
-; GFX12-FAKE16-NEXT:    v_lshrrev_b32_e32 v7, 24, v7
 ; GFX12-FAKE16-NEXT:    v_or_b32_e32 v0, v0, v1
-; GFX12-FAKE16-NEXT:    v_lshrrev_b32_e32 v1, 8, v9
+; GFX12-FAKE16-NEXT:    v_lshrrev_b32_e32 v7, 24, v7
+; GFX12-FAKE16-NEXT:    v_or_b32_e32 v9, v9, v4
 ; GFX12-FAKE16-NEXT:    v_lshrrev_b64 v[3:4], 24, v[4:5]
 ; GFX12-FAKE16-NEXT:    v_lshrrev_b32_e32 v5, 8, v5
 ; GFX12-FAKE16-NEXT:    v_mov_b32_e32 v4, v8
+; GFX12-FAKE16-NEXT:    v_lshrrev_b32_e32 v1, 8, v9
 ; GFX12-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX12-TRUE16-LABEL: test_unsigned_v8f16_v8i8:
@@ -2508,46 +2400,38 @@ define <8 x i8> @test_unsigned_v8f16_v8i8(<8 x half> %f) {
 ; GFX12-TRUE16-NEXT:    s_wait_samplecnt 0x0
 ; GFX12-TRUE16-NEXT:    s_wait_bvhcnt 0x0
 ; GFX12-TRUE16-NEXT:    s_wait_kmcnt 0x0
-; GFX12-TRUE16-NEXT:    v_cvt_f32_f16_e32 v4, v3.h
-; GFX12-TRUE16-NEXT:    v_cvt_f32_f16_e32 v5, v1.h
-; GFX12-TRUE16-NEXT:    v_cvt_f32_f16_e32 v6, v2.h
-; GFX12-TRUE16-NEXT:    v_cvt_f32_f16_e32 v1, v1.l
-; GFX12-TRUE16-NEXT:    v_cvt_f32_f16_e32 v3, v3.l
-; GFX12-TRUE16-NEXT:    v_cvt_u32_f32_e32 v4, v4
-; GFX12-TRUE16-NEXT:    v_cvt_u32_f32_e32 v5, v5
-; GFX12-TRUE16-NEXT:    v_cvt_f32_f16_e32 v7, v0.h
-; GFX12-TRUE16-NEXT:    v_cvt_u32_f32_e32 v6, v6
-; GFX12-TRUE16-NEXT:    v_cvt_u32_f32_e32 v9, v1
-; GFX12-TRUE16-NEXT:    v_min_u32_e32 v4, 0xff, v4
-; GFX12-TRUE16-NEXT:    v_min_u32_e32 v1, 0xff, v5
-; GFX12-TRUE16-NEXT:    v_cvt_f32_f16_e32 v2, v2.l
-; GFX12-TRUE16-NEXT:    v_cvt_u32_f32_e32 v3, v3
-; GFX12-TRUE16-NEXT:    v_min_u32_e32 v5, 0xff, v6
-; GFX12-TRUE16-NEXT:    v_lshlrev_b16 v0.h, 8, v4.l
-; GFX12-TRUE16-NEXT:    v_lshlrev_b16 v1.l, 8, v1.l
-; GFX12-TRUE16-NEXT:    v_cvt_u32_f32_e32 v4, v7
-; GFX12-TRUE16-NEXT:    v_cvt_f32_f16_e32 v6, v0.l
-; GFX12-TRUE16-NEXT:    v_min_u32_e32 v7, 0xff, v9
-; GFX12-TRUE16-NEXT:    v_cvt_u32_f32_e32 v2, v2
-; GFX12-TRUE16-NEXT:    v_min_u32_e32 v3, 0xff, v3
-; GFX12-TRUE16-NEXT:    v_lshlrev_b16 v0.l, 8, v5.l
-; GFX12-TRUE16-NEXT:    v_min_u32_e32 v4, 0xff, v4
-; GFX12-TRUE16-NEXT:    v_cvt_u32_f32_e32 v5, v6
-; GFX12-TRUE16-NEXT:    v_or_b16 v8.h, v7.l, v1.l
-; GFX12-TRUE16-NEXT:    v_min_u32_e32 v1, 0xff, v2
+; GFX12-TRUE16-NEXT:    v_cvt_u16_f16_e32 v1.h, v1.h
+; GFX12-TRUE16-NEXT:    v_cvt_u16_f16_e32 v3.h, v3.h
+; GFX12-TRUE16-NEXT:    v_cvt_u16_f16_e32 v1.l, v1.l
+; GFX12-TRUE16-NEXT:    v_cvt_u16_f16_e32 v2.h, v2.h
+; GFX12-TRUE16-NEXT:    v_cvt_u16_f16_e32 v3.l, v3.l
+; GFX12-TRUE16-NEXT:    v_min_u16 v1.h, 0xff, v1.h
+; GFX12-TRUE16-NEXT:    v_min_u16 v3.h, 0xff, v3.h
+; GFX12-TRUE16-NEXT:    v_cvt_u16_f16_e32 v2.l, v2.l
+; GFX12-TRUE16-NEXT:    v_min_u16 v1.l, 0xff, v1.l
+; GFX12-TRUE16-NEXT:    v_cvt_u16_f16_e32 v0.h, v0.h
+; GFX12-TRUE16-NEXT:    v_lshlrev_b16 v1.h, 8, v1.h
+; GFX12-TRUE16-NEXT:    v_min_u16 v2.h, 0xff, v2.h
+; GFX12-TRUE16-NEXT:    v_min_u16 v3.l, 0xff, v3.l
+; GFX12-TRUE16-NEXT:    v_lshlrev_b16 v3.h, 8, v3.h
+; GFX12-TRUE16-NEXT:    v_min_u16 v2.l, 0xff, v2.l
+; GFX12-TRUE16-NEXT:    v_cvt_u16_f16_e32 v0.l, v0.l
+; GFX12-TRUE16-NEXT:    v_min_u16 v0.h, 0xff, v0.h
+; GFX12-TRUE16-NEXT:    v_or_b16 v8.h, v1.l, v1.h
+; GFX12-TRUE16-NEXT:    v_lshlrev_b16 v1.l, 8, v2.h
 ; GFX12-TRUE16-NEXT:    v_mov_b16_e32 v8.l, 0
-; GFX12-TRUE16-NEXT:    v_or_b16 v9.h, v3.l, v0.h
-; GFX12-TRUE16-NEXT:    v_lshlrev_b16 v2.l, 8, v4.l
-; GFX12-TRUE16-NEXT:    v_min_u32_e32 v3, 0xff, v5
-; GFX12-TRUE16-NEXT:    v_or_b16 v9.l, v1.l, v0.l
-; GFX12-TRUE16-NEXT:    v_mov_b16_e32 v2.h, v8.h
-; GFX12-TRUE16-NEXT:    v_mov_b16_e32 v6.l, v8.l
-; GFX12-TRUE16-NEXT:    v_mov_b16_e32 v6.h, v9.h
-; GFX12-TRUE16-NEXT:    v_or_b16 v0.l, v3.l, v2.l
+; GFX12-TRUE16-NEXT:    v_or_b16 v9.h, v3.l, v3.h
+; GFX12-TRUE16-NEXT:    v_min_u16 v0.l, 0xff, v0.l
+; GFX12-TRUE16-NEXT:    v_lshlrev_b16 v3.l, 8, v0.h
+; GFX12-TRUE16-NEXT:    v_mov_b16_e32 v3.h, v8.h
+; GFX12-TRUE16-NEXT:    v_or_b16 v9.l, v2.l, v1.l
+; GFX12-TRUE16-NEXT:    v_mov_b16_e32 v2.l, v8.l
+; GFX12-TRUE16-NEXT:    v_mov_b16_e32 v2.h, v9.h
+; GFX12-TRUE16-NEXT:    v_or_b16 v0.l, v0.l, v3.l
+; GFX12-TRUE16-NEXT:    v_lshrrev_b32_e32 v1, 8, v3
 ; GFX12-TRUE16-NEXT:    v_lshrrev_b64 v[3:4], 24, v[8:9]
-; GFX12-TRUE16-NEXT:    v_lshrrev_b32_e32 v1, 8, v2
 ; GFX12-TRUE16-NEXT:    v_lshrrev_b32_e32 v5, 8, v9
-; GFX12-TRUE16-NEXT:    v_lshrrev_b32_e32 v7, 24, v6
+; GFX12-TRUE16-NEXT:    v_lshrrev_b32_e32 v7, 24, v2
 ; GFX12-TRUE16-NEXT:    v_mov_b16_e32 v2.l, v8.h
 ; GFX12-TRUE16-NEXT:    v_mov_b16_e32 v4.l, v9.l
 ; GFX12-TRUE16-NEXT:    v_mov_b16_e32 v6.l, v9.h


### PR DESCRIPTION
By using a native `v_cvt_i16/u16_f16` conversion and saturation at `i16` we avoid additional `f16` to `f32` conversion that is required to perform saturation at `i32`. It also allows to perform clamping using `i16` instructions, reducing number of registers needed in *true16* mode in some of the lit tests. The behavior is disabled for pre-gfx8 targets by checking `has16BitInsts()`.