### PR TITLE
[LV] Explain why a less profitable VF was chosen (NFCI)

### DIFF
--- a/llvm/lib/Transforms/Vectorize/LoopVectorize.cpp
+++ b/llvm/lib/Transforms/Vectorize/LoopVectorize.cpp
@@ -3978,7 +3978,7 @@ bool LoopVectorizationPlanner::isMoreProfitable(const VectorizationFactor &A,
            << " has lower cost than VF "
            << (LowerCostWithTC ? B.Width : A.Width)
            << " when taking the cost of the remaining scalar loop iterations "
-              "into consideration for a trip count of "
+              "into consideration for a maximum trip count of "
            << MaxTripCount << ".\n";
   });
   return LowerCostWithTC;

--- a/llvm/lib/Transforms/Vectorize/LoopVectorize.cpp
+++ b/llvm/lib/Transforms/Vectorize/LoopVectorize.cpp
@@ -3948,8 +3948,10 @@ bool LoopVectorizationPlanner::isMoreProfitable(const VectorizationFactor &A,
   // To avoid the need for FP division:
   //      (CostA / EstimatedWidthA) < (CostB / EstimatedWidthB)
   // <=>  (CostA * EstimatedWidthB) < (CostB * EstimatedWidthA)
+  bool GenerallyLowerCost =
+      CmpFn(CostA * EstimatedWidthB, CostB * EstimatedWidthA);
   if (!MaxTripCount)
-    return CmpFn(CostA * EstimatedWidthB, CostB * EstimatedWidthA);
+    return GenerallyLowerCost;
 
   auto GetCostForTC = [MaxTripCount, HasTail](unsigned VF,
                                               InstructionCost VectorCost,
@@ -3970,7 +3972,14 @@ bool LoopVectorizationPlanner::isMoreProfitable(const VectorizationFactor &A,
 
   auto RTCostA = GetCostForTC(EstimatedWidthA, CostA, A.ScalarCost);
   auto RTCostB = GetCostForTC(EstimatedWidthB, CostB, B.ScalarCost);
-  return CmpFn(RTCostA, RTCostB);
+  bool LowerCost = CmpFn(RTCostA, RTCostB);
+  LLVM_DEBUG(if (LowerCost != GenerallyLowerCost) {
+    dbgs() << "LV: VF " << (LowerCost ? A.Width : B.Width)
+           << " has lower cost than VF " << (LowerCost ? B.Width : A.Width)
+           << " when taking the loop trip count of " << MaxTripCount
+           << " into consideration.\n";
+  });
+  return LowerCost;
 }
 
 bool LoopVectorizationPlanner::isMoreProfitable(const VectorizationFactor &A,

--- a/llvm/lib/Transforms/Vectorize/LoopVectorize.cpp
+++ b/llvm/lib/Transforms/Vectorize/LoopVectorize.cpp
@@ -3948,10 +3948,10 @@ bool LoopVectorizationPlanner::isMoreProfitable(const VectorizationFactor &A,
   // To avoid the need for FP division:
   //      (CostA / EstimatedWidthA) < (CostB / EstimatedWidthB)
   // <=>  (CostA * EstimatedWidthB) < (CostB * EstimatedWidthA)
-  bool GenerallyLowerCost =
+  bool LowerCostWithoutTC =
       CmpFn(CostA * EstimatedWidthB, CostB * EstimatedWidthA);
   if (!MaxTripCount)
-    return GenerallyLowerCost;
+    return LowerCostWithoutTC;
 
   auto GetCostForTC = [MaxTripCount, HasTail](unsigned VF,
                                               InstructionCost VectorCost,
@@ -3972,14 +3972,16 @@ bool LoopVectorizationPlanner::isMoreProfitable(const VectorizationFactor &A,
 
   auto RTCostA = GetCostForTC(EstimatedWidthA, CostA, A.ScalarCost);
   auto RTCostB = GetCostForTC(EstimatedWidthB, CostB, B.ScalarCost);
-  bool LowerCost = CmpFn(RTCostA, RTCostB);
-  LLVM_DEBUG(if (LowerCost != GenerallyLowerCost) {
-    dbgs() << "LV: VF " << (LowerCost ? A.Width : B.Width)
-           << " has lower cost than VF " << (LowerCost ? B.Width : A.Width)
-           << " when taking the loop trip count of " << MaxTripCount
-           << " into consideration.\n";
+  bool LowerCostWithTC = CmpFn(RTCostA, RTCostB);
+  LLVM_DEBUG(if (LowerCostWithTC != LowerCostWithoutTC) {
+    dbgs() << "LV: VF " << (LowerCostWithTC ? A.Width : B.Width)
+           << " has lower cost than VF "
+           << (LowerCostWithTC ? B.Width : A.Width)
+           << " when taking the cost of the remaining scalar loop iterations "
+              "into consideration for a trip count of "
+           << MaxTripCount << ".\n";
   });
-  return LowerCost;
+  return LowerCostWithTC;
 }
 
 bool LoopVectorizationPlanner::isMoreProfitable(const VectorizationFactor &A,

--- a/llvm/test/Transforms/LoopVectorize/AArch64/select-best-vf-tripcount.ll
+++ b/llvm/test/Transforms/LoopVectorize/AArch64/select-best-vf-tripcount.ll
@@ -8,7 +8,7 @@ target triple = "aarch64"
 ; CHECK: Cost for VF 4: 9 (Estimated cost per lane: 2.2)
 ; CHECK: Cost for VF 8: 6 (Estimated cost per lane: 0.8)
 ; CHECK: Cost for VF 16: 6 (Estimated cost per lane: 0.4)
-; CHECK: LV: VF 8 has lower cost than VF 16 when taking the cost of the remaining scalar loop iterations into consideration for a trip count of 24.
+; CHECK: LV: VF 8 has lower cost than VF 16 when taking the cost of the remaining scalar loop iterations into consideration for a maximum trip count of 24.
 ; CHECK: LV: Selecting VF: 8.
 
 define void @test_vf_8_better_vf_than_16_given_tripcount_of_24(ptr %a, ptr %b){

--- a/llvm/test/Transforms/LoopVectorize/AArch64/select-best-vf-tripcount.ll
+++ b/llvm/test/Transforms/LoopVectorize/AArch64/select-best-vf-tripcount.ll
@@ -1,0 +1,35 @@
+; REQUIRES: asserts
+; RUN: opt -S -passes='loop-vectorize' -vectorizer-maximize-bandwidth -enable-epilogue-vectorization=false -debug-only=loop-vectorize 2>&1 < %s | FileCheck %s
+
+target triple = "aarch64"
+
+; CHECK: LV: Checking a loop in 'test_vf_8_better_vf_than_16_given_tripcount_of_24'
+; CHECK: Cost for VF 2: 15 (Estimated cost per lane: 7.5)
+; CHECK: Cost for VF 4: 9 (Estimated cost per lane: 2.2)
+; CHECK: Cost for VF 8: 6 (Estimated cost per lane: 0.8)
+; CHECK: Cost for VF 16: 6 (Estimated cost per lane: 0.4)
+; CHECK: LV: VF 8 has lower cost than VF 16 when taking a loop trip count of 24 into consideration.
+; CHECK: LV: Selecting VF: 8.
+
+define void @test_vf_8_better_vf_than_16_given_tripcount_of_24(ptr %a, ptr %b){
+entry:
+  br label %for.body
+
+for.body:                                         ; preds = %entry, %for.body
+  %iv = phi i64 [ 0, %entry ], [ %iv.next, %for.body ]
+  %a.iv = getelementptr inbounds nuw i8, ptr %a, i64 %iv
+  %a.ld = load i8, ptr %a.iv
+  %a.ld.zext = zext i8 %a.ld to i32
+  %b.iv = getelementptr inbounds nuw i8, ptr %b, i64 %iv
+  %b.ld = load i8, ptr %b.iv
+  %b.ld.zext = zext i8 %b.ld to i32
+  %a.plus.b = add i32 %a.ld.zext, %b.ld.zext
+  %a.plus.b.trunc = trunc i32 %a.plus.b to i8
+  store i8 %a.plus.b.trunc, ptr %a.iv
+  %iv.next = add nuw nsw i64 %iv, 1
+  %exitcond.not = icmp eq i64 %iv.next, 24
+  br i1 %exitcond.not, label %exit, label %for.body
+
+exit:                                 ; preds = %for.body
+  ret void
+}

--- a/llvm/test/Transforms/LoopVectorize/AArch64/select-best-vf-tripcount.ll
+++ b/llvm/test/Transforms/LoopVectorize/AArch64/select-best-vf-tripcount.ll
@@ -8,7 +8,7 @@ target triple = "aarch64"
 ; CHECK: Cost for VF 4: 9 (Estimated cost per lane: 2.2)
 ; CHECK: Cost for VF 8: 6 (Estimated cost per lane: 0.8)
 ; CHECK: Cost for VF 16: 6 (Estimated cost per lane: 0.4)
-; CHECK: LV: VF 8 has lower cost than VF 16 when taking the loop trip count of 24 into consideration.
+; CHECK: LV: VF 8 has lower cost than VF 16 when taking the cost of the remaining scalar loop iterations into consideration for a trip count of 24.
 ; CHECK: LV: Selecting VF: 8.
 
 define void @test_vf_8_better_vf_than_16_given_tripcount_of_24(ptr %a, ptr %b){

--- a/llvm/test/Transforms/LoopVectorize/AArch64/select-best-vf-tripcount.ll
+++ b/llvm/test/Transforms/LoopVectorize/AArch64/select-best-vf-tripcount.ll
@@ -8,7 +8,7 @@ target triple = "aarch64"
 ; CHECK: Cost for VF 4: 9 (Estimated cost per lane: 2.2)
 ; CHECK: Cost for VF 8: 6 (Estimated cost per lane: 0.8)
 ; CHECK: Cost for VF 16: 6 (Estimated cost per lane: 0.4)
-; CHECK: LV: VF 8 has lower cost than VF 16 when taking a loop trip count of 24 into consideration.
+; CHECK: LV: VF 8 has lower cost than VF 16 when taking the loop trip count of 24 into consideration.
 ; CHECK: LV: Selecting VF: 8.
 
 define void @test_vf_8_better_vf_than_16_given_tripcount_of_24(ptr %a, ptr %b){


### PR DESCRIPTION
I was very puzzled the other day when it showed that VF 8 had a cost of X and VF 16 had a cost of X/2, yet it still choose VF 8. This PR adds some extra debug output to explain why this happens.