### PR TITLE
fail if requested architecture is not supported by builtins

### DIFF
--- a/compiler-rt/cmake/builtin-config-ix.cmake
+++ b/compiler-rt/cmake/builtin-config-ix.cmake
@@ -297,4 +297,7 @@ else()
   set(COMPILER_RT_HAS_CRT FALSE)
 endif()
 
+if (NOT BUILTIN_SUPPORTED_ARCH)
+  message(FATAL_ERROR "Requested architecture is not supported by compiler-rt builtins")
+endif()
 message(STATUS "Builtin supported architectures: ${BUILTIN_SUPPORTED_ARCH}")


### PR DESCRIPTION
If a target not supported by compiler-rt builtins is requested, CMake will continue configuration but later stages will fail due to builtins not existing.

If builtins are not supported by the requested target architecture, fail immediately.

### Steps to reproduce

```
cmake -S runtimes -B build \
  -DCMAKE_C_COMPILER=clang \
  -DCMAKE_CXX_COMPILER=clang++ \
  -DLLVM_DEFAULT_TARGET_TRIPLE=z80-unknown-linux-gnueabihf  \
  -DLLVM_ENABLE_RUNTIMES=compiler-rt  \
  -DCOMPILER_RT_BUILD_SANITIZERS=OFF  \
  -DCOMPILER_RT_BUILD_SANITIZERS=OFF  \
  -DCOMPILER_RT_BUILD_LIBFUZZER=OFF \
  -DCOMPILER_RT_BUILD_MEMPROF=OFF \
  -DCOMPILER_RT_BUILD_ORC=OFF \
  -DCOMPILER_RT_BUILD_PROFILE=OFF \
  -DCOMPILER_RT_BUILD_CTX_PROFILE=OFF \
  -DCOMPILER_RT_BUILD_XRAY=OFF \
  -DCOMPILER_RT_BUILD_GWP_ASAN=OFF 
```

### Current Behaviour
A status message is output:
```
-- Builtin supported architectures: 
-- check-runtimes does nothing.
```

No builtin targets are created and the message is easy to miss in a large project configuration.

### New Behaviour

Configuration fails immediately with:
```
CMake Error at ... llvm-project/compiler-rt/cmake/builtin-config-ix.cmake:301 (message):
  Requested architecture is not supported by compiler-rt builtins
Call Stack (most recent call first):
 ... llvm-project/compiler-rt/lib/builtins/CMakeLists.txt:60 (include)
```