### PR TITLE
[CycleInfo] Don't store top-level cycle per block

### DIFF
--- a/llvm/include/llvm/ADT/GenericCycleImpl.h
+++ b/llvm/include/llvm/ADT/GenericCycleImpl.h
@@ -220,6 +220,11 @@ void GenericCycle<ContextT>::verifyCycleNest() const {
   if (ParentCycle) {
     assert(is_contained(ParentCycle->children(), this) &&
            "Cycle is not a subcycle of its parent!");
+    assert(ParentCycle->TopLevelCycle == TopLevelCycle &&
+           "Top level cycle of parent cycle must be the same");
+  } else {
+    assert(TopLevelCycle == this &&
+           "Cycle without parent must be top-level cycle");
   }
 #endif
 }
@@ -280,19 +285,8 @@ private:
 template <typename ContextT>
 auto GenericCycleInfo<ContextT>::getTopLevelParentCycle(BlockT *Block)
     -> CycleT * {
-  auto Cycle = BlockMapTopLevel.find(Block);
-  if (Cycle != BlockMapTopLevel.end())
-    return Cycle->second;
-
-  auto MapIt = BlockMap.find(Block);
-  if (MapIt == BlockMap.end())
-    return nullptr;
-
-  auto *C = MapIt->second;
-  while (C->ParentCycle)
-    C = C->ParentCycle;
-  BlockMapTopLevel.try_emplace(Block, C);
-  return C;
+  CycleT *Cycle = getCycle(Block);
+  return Cycle ? Cycle->TopLevelCycle : nullptr;
 }
 
 template <typename ContextT>
@@ -310,12 +304,11 @@ void GenericCycleInfo<ContextT>::moveTopLevelCycleToNewParent(CycleT *NewParent,
   *Pos = std::move(CurrentContainer.back());
   CurrentContainer.pop_back();
   Child->ParentCycle = NewParent;
+  Child->TopLevelCycle = NewParent;
+  for (CycleT *Cycle : depth_first(Child))
+    Cycle->TopLevelCycle = NewParent;
 
   NewParent->Blocks.insert_range(Child->blocks());
-
-  for (auto &It : BlockMapTopLevel)
-    if (It.second == Child)
-      It.second = NewParent;
   NewParent->clearCache();
   Child->clearCache();
 }
@@ -335,7 +328,6 @@ void GenericCycleInfo<ContextT>::addBlockToCycle(BlockT *Block, CycleT *Cycle) {
     ParentCycle = Cycle->getParentCycle();
   }
 
-  BlockMapTopLevel.try_emplace(Block, Cycle);
   Cycle->clearCache();
 }
 
@@ -429,7 +421,6 @@ void GenericCycleInfoCompute<ContextT>::run(FunctionT *F) {
         assert(!is_contained(NewCycle->Blocks, Block));
         NewCycle->Blocks.insert(Block);
         ProcessPredecessors(Block);
-        Info.BlockMapTopLevel.try_emplace(Block, NewCycle.get());
       }
     } while (!Worklist.empty());
 
@@ -510,7 +501,6 @@ void GenericCycleInfoCompute<ContextT>::dfs(FunctionT *F, BlockT *EntryBlock) {
 template <typename ContextT> void GenericCycleInfo<ContextT>::clear() {
   TopLevelCycles.clear();
   BlockMap.clear();
-  BlockMapTopLevel.clear();
 }
 
 /// \brief Compute the cycle info for a function.

--- a/llvm/include/llvm/ADT/GenericCycleInfo.h
+++ b/llvm/include/llvm/ADT/GenericCycleInfo.h
@@ -54,6 +54,10 @@ private:
   /// at the root.
   GenericCycle *ParentCycle = nullptr;
 
+  /// The top-level cycle this cycle is part of. Points to itself if this is
+  /// a top-level cycle.
+  GenericCycle *TopLevelCycle;
+
   /// The entry block(s) of the cycle. The header is the only entry if
   /// this is a loop. Is empty for the root "cycle", to avoid
   /// unnecessary memory use.
@@ -103,7 +107,7 @@ private:
   GenericCycle &operator=(GenericCycle &&Rhs) = delete;
 
 public:
-  GenericCycle() = default;
+  GenericCycle() : TopLevelCycle(this) {}
 
   /// \brief Whether the cycle is a natural loop.
   bool isReducible() const { return Entries.size() == 1; }
@@ -265,9 +269,6 @@ private:
 
   /// Map basic blocks to their inner-most containing cycle.
   DenseMap<BlockT *, CycleT *> BlockMap;
-
-  /// Map basic blocks to their top level containing cycle.
-  DenseMap<BlockT *, CycleT *> BlockMapTopLevel;
 
   /// Top-level cycles discovered by any DFS.
   ///


### PR DESCRIPTION
CycleInfo currently has a second map, that stores the top-level cycle for a block. I don't think storing this per-block makes a lot of sense, because the top-level cycle is always the same for all blocks in a cycle.

So instead store it as a member of the cycle.