### PR TITLE
[C23] Downgrade WG14 N3037 implementation status to partial

### DIFF
--- a/clang/www/c_status.html
+++ b/clang/www/c_status.html
@@ -997,7 +997,14 @@ conformance.</p>
     <tr>
       <td>Improved tag compatibility</td>
       <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n3037.pdf">N3037</a></td>
-      <td class="full" align="center">Clang 21</td>
+      <td class="partial" align="center">
+        <details><summary>Partial</summary>
+          Clang supports much of this feature starting with Clang 21, but there
+          are implementation bugs and open questions around handling of
+          attributes or other compiler extensions. As a result, some structure
+          definitions may be incorrectly accepted or rejected and so there is a
+          potential for breaking changes in the future.
+        </details>
     </tr>
     <tr>
       <td>#embed</td>


### PR DESCRIPTION
In discussion of #186196, it started to become clear that claiming full conformance to this feature was premature because there are still outstanding implementation issues and standards questions with the feature. Claiming full conformance gives users a false impression that we think the implementation is production quality and that we don't expect to change our implementation in breaking ways, but I believe that we want some flexibility here and it's more accurate to say we only partially support the feature at the moment.

Note, this is not saying we expect to break the code from that issue, just listing where the discussion took place that led to this patch.