### PR TITLE
[NFC] Remove fractional part of costs in maxbandwidth-regpressure.ll

### DIFF
--- a/llvm/test/Transforms/LoopVectorize/AArch64/maxbandwidth-regpressure.ll
+++ b/llvm/test/Transforms/LoopVectorize/AArch64/maxbandwidth-regpressure.ll
@@ -12,19 +12,19 @@ target triple = "aarch64-none-unknown-elf"
 define i32 @dotp(ptr %a, ptr %b) #0 {
 ; CHECK-LABEL: LV: Checking a loop in 'dotp'
 ;
-; CHECK-NOMAX: Cost for VF vscale x 4: 6 (Estimated cost per lane: 1.5)
+; CHECK-NOMAX: Cost for VF vscale x 4: 6 (Estimated cost per lane: 1.
 ; CHECK-NOMAX: LV: Selecting VF: vscale x 4.
 ;
-; CHECK-REGS-VP: Cost for VF vscale x 4: 6 (Estimated cost per lane: 1.5)
-; CHECK-REGS-VP: Cost for VF vscale x 8: 6 (Estimated cost per lane: 0.8)
-; CHECK-REGS-VP: Cost for VF vscale x 16: 5 (Estimated cost per lane: 0.3)
+; CHECK-REGS-VP: Cost for VF vscale x 4: 6 (Estimated cost per lane: 1.
+; CHECK-REGS-VP: Cost for VF vscale x 8: 6 (Estimated cost per lane: 0.
+; CHECK-REGS-VP: Cost for VF vscale x 16: 5 (Estimated cost per lane: 0.
 ; CHECK-REGS-VP: LV: Selecting VF: vscale x 16.
 ;
-; CHECK-NOREGS-VP: Cost for VF vscale x 4: 6 (Estimated cost per lane: 1.5)
+; CHECK-NOREGS-VP: Cost for VF vscale x 4: 6 (Estimated cost per lane: 1.
 ; CHECK-NOREGS-VP: LV(REG): Cost of 4 from 2 spills of Generic::VectorRC
-; CHECK-NOREGS-VP-NEXT: Cost for VF vscale x 8: 14 (Estimated cost per lane: 1.8)
+; CHECK-NOREGS-VP-NEXT: Cost for VF vscale x 8: 14 (Estimated cost per lane: 1.
 ; CHECK-NOREGS-VP: LV(REG): Cost of 4 from 2 spills of Generic::VectorRC
-; CHECK-NOREGS-VP-NEXT: Cost for VF vscale x 16: 13 (Estimated cost per lane: 0.8)
+; CHECK-NOREGS-VP-NEXT: Cost for VF vscale x 16: 13 (Estimated cost per lane: 0.
 ; CHECK-NOREGS-VP: LV: Selecting VF: vscale x 16.
 entry:
   br label %for.body
@@ -52,9 +52,9 @@ for.exit:                        ; preds = %for.body
 ; VFs and maximize-bandwidth does nothing.
 define void @type_too_small(ptr %a, ptr %b) #0 {
 ; CHECK-LABEL: LV: Checking a loop in 'type_too_small'
-; CHECK: Cost for VF vscale x 4: 6 (Estimated cost per lane: 1.5)
-; CHECK: Cost for VF vscale x 8: 6 (Estimated cost per lane: 0.8)
-; CHECK: Cost for VF vscale x 16: 6 (Estimated cost per lane: 0.4)
+; CHECK: Cost for VF vscale x 4: 6 (Estimated cost per lane: 1.
+; CHECK: Cost for VF vscale x 8: 6 (Estimated cost per lane: 0.
+; CHECK: Cost for VF vscale x 16: 6 (Estimated cost per lane: 0.
 ; CHECK: LV: Selecting VF: vscale x 16.
 entry:
   br label %loop
@@ -80,19 +80,19 @@ exit:
 define void @high_pressure(ptr %a, ptr %b) #0 {
 ; CHECK-LABEL: LV: Checking a loop in 'high_pressure'
 ;
-; CHECK-NOMAX: Cost for VF vscale x 4: 6 (Estimated cost per lane: 1.5)
+; CHECK-NOMAX: Cost for VF vscale x 4: 6 (Estimated cost per lane: 1.
 ; CHECK-NOMAX: LV: Selecting VF: vscale x 4.
 ;
-; CHECK-REGS-VP: Cost for VF vscale x 4: 6 (Estimated cost per lane: 1.5)
-; CHECK-REGS-VP: Cost for VF vscale x 8: 10 (Estimated cost per lane: 1.2)
-; CHECK-REGS-VP: Cost for VF vscale x 16: 21 (Estimated cost per lane: 1.3)
+; CHECK-REGS-VP: Cost for VF vscale x 4: 6 (Estimated cost per lane: 1.
+; CHECK-REGS-VP: Cost for VF vscale x 8: 10 (Estimated cost per lane: 1.
+; CHECK-REGS-VP: Cost for VF vscale x 16: 21 (Estimated cost per lane: 1.
 ; CHECK-REGS-VP: LV: Selecting VF: vscale x 8.
 
-; CHECK-NOREGS-VP: Cost for VF vscale x 4: 6 (Estimated cost per lane: 1.5)
+; CHECK-NOREGS-VP: Cost for VF vscale x 4: 6 (Estimated cost per lane: 1.
 ; CHECK-NOREGS-VP: LV(REG): Cost of 6 from 3 spills of Generic::VectorRC
-; CHECK-NOREGS-VP-NEXT: Cost for VF vscale x 8: 20 (Estimated cost per lane: 2.5)
+; CHECK-NOREGS-VP-NEXT: Cost for VF vscale x 8: 20 (Estimated cost per lane: 2.
 ; CHECK-NOREGS-VP: LV(REG): Cost of 14 from 7 spills of Generic::VectorRC
-; CHECK-NOREGS-VP-NEXT: Cost for VF vscale x 16: 39 (Estimated cost per lane: 2.4)
+; CHECK-NOREGS-VP-NEXT: Cost for VF vscale x 16: 39 (Estimated cost per lane: 2.
 ; CHECK-NOREGS-VP: LV: Selecting VF: vscale x 4.
 entry:
   br label %loop


### PR DESCRIPTION
This test is failing on the llvm-clang-x-aarch64 buildbot due to what looks like a difference in rounding behaviour when printing estimated cost per lane. Solve this by removing the fractional part, which is what we've done in the past when this has happened (e.g. commit aeb88f677).