### PR TITLE
[OFFLOAD][L0] Add support to run ctor/dtor code

### DIFF
--- a/offload/plugins-nextgen/level_zero/include/L0Device.h
+++ b/offload/plugins-nextgen/level_zero/include/L0Device.h
@@ -645,10 +645,10 @@ public:
   Expected<GenericKernelTy &> constructKernel(const char *Name) override;
 
   Error callGlobalConstructors(GenericPluginTy &Plugin,
-                                DeviceImageTy &Image) override;
+                               DeviceImageTy &Image) override;
 
   Error callGlobalDestructors(GenericPluginTy &Plugin,
-                               DeviceImageTy &Image) override;
+                              DeviceImageTy &Image) override;
 
   Error setDeviceStackSize(uint64_t V) override { return Plugin::success(); }
 

--- a/offload/plugins-nextgen/level_zero/include/L0Device.h
+++ b/offload/plugins-nextgen/level_zero/include/L0Device.h
@@ -238,6 +238,10 @@ class L0DeviceTy final : public GenericDeviceTy {
   /// Get copy command queue group ordinal. Returns Ordinal-NumQueues pair.
   std::pair<uint32_t, uint32_t> findCopyOrdinal(bool LinkCopy = false);
 
+  /// Helper function to call global constructors or destructors.
+  Error callGlobalCtorDtorCommon(GenericPluginTy &Plugin, DeviceImageTy &Image,
+                                 bool IsCtor);
+
 public:
   L0DeviceTy(GenericPluginTy &Plugin, int32_t DeviceId, int32_t NumDevices,
              ze_device_handle_t zeDevice, L0ContextTy &DriverInfo,
@@ -639,6 +643,12 @@ public:
     return Plugin::success();
   }
   Expected<GenericKernelTy &> constructKernel(const char *Name) override;
+
+  Error callGlobalConstructors(GenericPluginTy &Plugin,
+                                DeviceImageTy &Image) override;
+
+  Error callGlobalDestructors(GenericPluginTy &Plugin,
+                               DeviceImageTy &Image) override;
 
   Error setDeviceStackSize(uint64_t V) override { return Plugin::success(); }
 

--- a/offload/plugins-nextgen/level_zero/src/L0Device.cpp
+++ b/offload/plugins-nextgen/level_zero/src/L0Device.cpp
@@ -1268,9 +1268,9 @@ Error L0DeviceTy::callGlobalCtorDtorCommon(GenericPluginTy &Plugin,
 
   KernelArgsTy KernelArgs{};
   uint32_t NumBlocksAndThreads[3] = {1u, 1u, 1u};
-  auto Err = L0Kernel.launchImpl(*this, NumBlocksAndThreads,
-                                     NumBlocksAndThreads, 0, KernelArgs,
-                                     KernelLaunchParamsTy{}, AsyncInfoWrapper);
+  auto Err =
+      L0Kernel.launchImpl(*this, NumBlocksAndThreads, NumBlocksAndThreads, 0,
+                          KernelArgs, KernelLaunchParamsTy{}, AsyncInfoWrapper);
 
   AsyncInfoWrapper.finalize(Err);
   if (Err)

--- a/offload/plugins-nextgen/level_zero/src/L0Device.cpp
+++ b/offload/plugins-nextgen/level_zero/src/L0Device.cpp
@@ -1222,6 +1222,13 @@ Error L0DeviceTy::callGlobalCtorDtorCommon(GenericPluginTy &Plugin,
         "failed to allocate memory for global buffer to run %s",
         IsCtor ? "constructors" : "destructors");
 
+  auto CleanupBufferAndErr = [&](Error RetErr) {
+    if (auto Err = free(Buffer, TARGET_ALLOC_DEVICE)) {
+      return joinErrors(std::move(RetErr), std::move(Err));
+    }
+    return std::move(RetErr);
+  };
+
   auto *GlobalPtrStart = reinterpret_cast<uintptr_t *>(Buffer);
   auto *GlobalPtrStop = reinterpret_cast<uintptr_t *>(Buffer) + Funcs.size();
 
@@ -1230,32 +1237,32 @@ Error L0DeviceTy::callGlobalCtorDtorCommon(GenericPluginTy &Plugin,
   for (auto [Name, Priority] : Funcs) {
     GlobalTy FunctionAddr(Name.str(), sizeof(void *), &FunctionPtrs[Idx++]);
     if (auto Err = Handler.readGlobalFromDevice(*this, Image, FunctionAddr))
-      return HandleErr(std::move(Err));
+      return CleanupBufferAndErr(std::move(Err));
   }
 
   if (auto Err = dataSubmit(GlobalPtrStart, FunctionPtrs.data(),
                             FunctionPtrs.size() * sizeof(void *),
                             /*AsyncInfo=*/nullptr))
-    return HandleErr(std::move(Err));
+    return CleanupBufferAndErr(std::move(Err));
 
   GlobalTy StartGlobal(IsCtor ? "__init_array_start" : "__fini_array_start",
                        sizeof(void *), &GlobalPtrStart);
   if (auto Err = Handler.writeGlobalToDevice(*this, Image, StartGlobal))
-    return HandleErr(std::move(Err));
+    return CleanupBufferAndErr(std::move(Err));
 
   GlobalTy StopGlobal(IsCtor ? "__init_array_end" : "__fini_array_end",
                       sizeof(void *), &GlobalPtrStop);
   if (auto Err = Handler.writeGlobalToDevice(*this, Image, StopGlobal))
-    return HandleErr(std::move(Err));
+    return CleanupBufferAndErr(std::move(Err));
 
   // Call the generated kernel to execute the constructors or destructors.
   auto KernelOrErr = constructKernel(KernelName);
   if (!KernelOrErr)
-    return HandleErr(KernelOrErr.takeError());
+    return CleanupBufferAndErr(KernelOrErr.takeError());
 
   GenericKernelTy &L0Kernel = *KernelOrErr;
   if (auto Err = L0Kernel.init(*this, Image))
-    return HandleErr(std::move(Err));
+    return CleanupBufferAndErr(std::move(Err));
 
   AsyncInfoWrapperTy AsyncInfoWrapper(*this, /*AsyncInfoPtr=*/nullptr);
 
@@ -1267,11 +1274,9 @@ Error L0DeviceTy::callGlobalCtorDtorCommon(GenericPluginTy &Plugin,
 
   AsyncInfoWrapper.finalize(Err);
   if (Err)
-    return HandleErr(std::move(Err));
-  if (auto Err = free(Buffer, TARGET_ALLOC_DEVICE))
-    return HandleErr(std::move(Err));
+    return CleanupBufferAndErr(std::move(Err));
 
-  return Plugin::success();
+  return CleanupBufferAndErr(Plugin::success());
 }
 
 } // namespace llvm::omp::target::plugin

--- a/offload/plugins-nextgen/level_zero/src/L0Device.cpp
+++ b/offload/plugins-nextgen/level_zero/src/L0Device.cpp
@@ -1169,11 +1169,6 @@ Error L0DeviceTy::callGlobalCtorDtorCommon(GenericPluginTy &Plugin,
     return Plugin::error(ErrorCode::INVALID_BINARY, std::move(Err),
                          Buffer.c_str());
   };
-  auto HandleErrStr = [&](const std::string &Msg) {
-    return Plugin::error(ErrorCode::INVALID_BINARY,
-                         "failed to call global %s in the image: %s",
-                         IsCtor ? "constructors" : "destructors", Msg.c_str());
-  };
 
   // The SPIR-V backend cannot handle creating the ctor / dtor array
   // automatically so we must create it ourselves. The backend will emit
@@ -1196,7 +1191,10 @@ Error L0DeviceTy::callGlobalCtorDtorCommon(GenericPluginTy &Plugin,
 
     uint16_t Priority;
     if (NameOrErr->rsplit('_').second.getAsInteger(10, Priority))
-      return HandleErrStr("invalid priority for constructor or destructor");
+      return Plugin::error(
+          ErrorCode::INVALID_BINARY,
+          "failed to call global %s in the image: invalid priority",
+          IsCtor ? "constructors" : "destructors");
 
     Funcs.emplace_back(*NameOrErr, Priority);
   }
@@ -1263,12 +1261,10 @@ Error L0DeviceTy::callGlobalCtorDtorCommon(GenericPluginTy &Plugin,
 
   KernelArgsTy KernelArgs{};
   uint32_t NumBlocksAndThreads[3] = {1u, 1u, 1u};
-  if (auto Err = L0Kernel.launchImpl(*this, NumBlocksAndThreads,
+  auto Err = L0Kernel.launchImpl(*this, NumBlocksAndThreads,
                                      NumBlocksAndThreads, 0, KernelArgs,
-                                     KernelLaunchParamsTy{}, AsyncInfoWrapper))
-    return HandleErr(std::move(Err));
+                                     KernelLaunchParamsTy{}, AsyncInfoWrapper);
 
-  Error Err = Plugin::success();
   AsyncInfoWrapper.finalize(Err);
   if (Err)
     return HandleErr(std::move(Err));

--- a/offload/plugins-nextgen/level_zero/src/L0Device.cpp
+++ b/offload/plugins-nextgen/level_zero/src/L0Device.cpp
@@ -1210,7 +1210,7 @@ Error L0DeviceTy::callGlobalCtorDtorCommon(GenericPluginTy &Plugin,
 
   // Sort the created array to be in priority order.
   llvm::sort(Funcs,
-             [=](const auto &X, const auto &Y) { return X.second < Y.second; });
+             [](const auto &X, const auto &Y) { return X.second < Y.second; });
 
   auto BufferOrErr = allocate(Funcs.size() * sizeof(void *),
                               /*HostPtr=*/nullptr, TARGET_ALLOC_DEVICE);

--- a/offload/plugins-nextgen/level_zero/src/L0Device.cpp
+++ b/offload/plugins-nextgen/level_zero/src/L0Device.cpp
@@ -1226,7 +1226,7 @@ Error L0DeviceTy::callGlobalCtorDtorCommon(GenericPluginTy &Plugin,
     if (auto Err = free(Buffer, TARGET_ALLOC_DEVICE)) {
       return joinErrors(std::move(RetErr), std::move(Err));
     }
-    return std::move(RetErr);
+    return RetErr;
   };
 
   auto *GlobalPtrStart = reinterpret_cast<uintptr_t *>(Buffer);

--- a/offload/plugins-nextgen/level_zero/src/L0Device.cpp
+++ b/offload/plugins-nextgen/level_zero/src/L0Device.cpp
@@ -17,6 +17,9 @@
 #include "L0Program.h"
 #include "L0Trace.h"
 
+#include "GlobalHandler.h"
+#include "llvm/Object/ELF.h"
+
 namespace llvm::omp::target::plugin {
 
 L0DeviceTLSTy &L0DeviceTy::getTLS() {
@@ -1134,6 +1137,142 @@ Expected<bool> L0DeviceTy::isAccessiblePtrImpl(const void *Ptr, size_t Size) {
                          "Invalid input to %s (Ptr = %p, Size = %zu)", __func__,
                          Ptr, Size);
   return getMemAllocator(Ptr).contains(Ptr, Size);
+}
+
+Error L0DeviceTy::callGlobalConstructors(GenericPluginTy &Plugin,
+                                         DeviceImageTy &Image) {
+  return callGlobalCtorDtorCommon(Plugin, Image, /*IsCtor=*/true);
+}
+
+Error L0DeviceTy::callGlobalDestructors(GenericPluginTy &Plugin,
+                                        DeviceImageTy &Image) {
+  return callGlobalCtorDtorCommon(Plugin, Image, /*IsCtor=*/false);
+}
+
+Error L0DeviceTy::callGlobalCtorDtorCommon(GenericPluginTy &Plugin,
+                                           DeviceImageTy &Image, bool IsCtor) {
+  const char *KernelName = IsCtor ? "spirv$device$init" : "spirv$device$fini";
+
+  // Check if a kernel was generated to run constructor or destructors.
+  // It should be created by the 'spirv-lower-ctor-dtor' pass.
+  GenericGlobalHandlerTy &Handler = Plugin.getGlobalHandler();
+  if (!Handler.isSymbolInImage(*this, Image, KernelName))
+    return Plugin::success();
+
+  // Instead of returning errors directly, we capture them and provide
+  // more of context about this routine.
+  auto handleErr = [&](Error Err) {
+    std::string Buffer;
+    llvm::raw_string_ostream(Buffer) << "failed to call global "
+                                     << (IsCtor ? "constructors" : "destructors")
+                                     << " in the image";
+    return Plugin::error(ErrorCode::INVALID_BINARY, std::move(Err),
+                         Buffer.c_str());
+  };
+  auto handleErrStr = [&](const std::string &Msg) {
+    return Plugin::error(ErrorCode::INVALID_BINARY,
+                         "failed to call global %s in the image: %s",
+                         IsCtor ? "constructors" : "destructors", Msg.c_str());
+  };
+
+  // The SPIR-V backend cannot handle creating the ctor / dtor array
+  // automatically so we must create it ourselves. The backend will emit
+  // several globals that contain function pointers we can call. These are
+  // prefixed with a __init_array_object_ or __fini_array_object_.
+  auto ELFObjOrErr = Handler.getELFObjectFile(Image);
+  if (!ELFObjOrErr)
+    return handleErr(ELFObjOrErr.takeError());
+
+  SmallVector<std::pair<StringRef, uint16_t>> Funcs;
+  for (ELFSymbolRef Sym : (*ELFObjOrErr)->symbols()) {
+    auto NameOrErr = Sym.getName();
+    if (!NameOrErr)
+      return handleErr(NameOrErr.takeError());
+
+    if (!NameOrErr->starts_with(IsCtor ? "__init_array_object_"
+                                       : "__fini_array_object_"))
+      continue;
+
+    uint16_t Priority;
+    if (NameOrErr->rsplit('_').second.getAsInteger(10, Priority))
+      return handleErrStr("invalid priority for constructor or destructor");
+
+    Funcs.emplace_back(*NameOrErr, Priority);
+  }
+
+  if (Funcs.empty()) {
+    ODBG(OLDT_Module) << KernelName << " found in the image but no "
+                      << (IsCtor ? "constructors" : "destructors")
+                      << " found in the image.";
+    return Plugin::success();
+  }
+
+  // Sort the created array to be in priority order.
+  llvm::sort(Funcs, [=](auto X, auto Y) { return X.second < Y.second; });
+
+  auto BufferOrErr =
+      allocate(Funcs.size() * sizeof(void *), nullptr, TARGET_ALLOC_DEVICE);
+  if (!BufferOrErr)
+    return handleErr(BufferOrErr.takeError());
+
+  void *Buffer = *BufferOrErr;
+  if (!Buffer)
+    return Plugin::error(
+        ErrorCode::OUT_OF_RESOURCES,
+        "failed to allocate memory for global buffer to run %s",
+        IsCtor ? "constructors" : "destructors");
+
+  auto *GlobalPtrStart = reinterpret_cast<uintptr_t *>(Buffer);
+  auto *GlobalPtrStop = reinterpret_cast<uintptr_t *>(Buffer) + Funcs.size();
+
+  SmallVector<void *> FunctionPtrs(Funcs.size());
+  std::size_t Idx = 0;
+  for (auto [Name, Priority] : Funcs) {
+    GlobalTy FunctionAddr(Name.str(), sizeof(void *), &FunctionPtrs[Idx++]);
+    if (auto Err = Handler.readGlobalFromDevice(*this, Image, FunctionAddr))
+      return handleErr(std::move(Err));
+  }
+
+  if (auto Err = dataSubmit(GlobalPtrStart, FunctionPtrs.data(),
+                            FunctionPtrs.size() * sizeof(void *), nullptr))
+    return handleErr(std::move(Err));
+
+  GlobalTy StartGlobal(IsCtor ? "__init_array_start" : "__fini_array_start",
+                       sizeof(void *), &GlobalPtrStart);
+  if (auto Err = Handler.writeGlobalToDevice(*this, Image, StartGlobal))
+    return handleErr(std::move(Err));
+
+  GlobalTy StopGlobal(IsCtor ? "__init_array_end" : "__fini_array_end",
+                      sizeof(void *), &GlobalPtrStop);
+  if (auto Err = Handler.writeGlobalToDevice(*this, Image, StopGlobal))
+    return handleErr(std::move(Err));
+
+  // Call the generated kernel to execute the constructors or destructors.
+  auto KernelOrErr = constructKernel(KernelName);
+  if (!KernelOrErr)
+    return handleErr(KernelOrErr.takeError());
+
+  GenericKernelTy &L0Kernel = *KernelOrErr;
+  if (auto Err = L0Kernel.init(*this, Image))
+    return handleErr(std::move(Err));
+
+  AsyncInfoWrapperTy AsyncInfoWrapper(*this, nullptr);
+
+  KernelArgsTy KernelArgs{};
+  uint32_t NumBlocksAndThreads[3] = {1u, 1u, 1u};
+  if (auto Err = L0Kernel.launchImpl(*this, NumBlocksAndThreads,
+                                     NumBlocksAndThreads, 0, KernelArgs,
+                                     KernelLaunchParamsTy{}, AsyncInfoWrapper))
+    return handleErr(std::move(Err));
+
+  Error Err = Plugin::success();
+  AsyncInfoWrapper.finalize(Err);
+  if (Err)
+    return handleErr(std::move(Err));
+  if (auto Err = free(Buffer, TARGET_ALLOC_DEVICE))
+    return handleErr(std::move(Err));
+
+  return Plugin::success();
 }
 
 } // namespace llvm::omp::target::plugin

--- a/offload/plugins-nextgen/level_zero/src/L0Device.cpp
+++ b/offload/plugins-nextgen/level_zero/src/L0Device.cpp
@@ -1183,10 +1183,8 @@ Error L0DeviceTy::callGlobalCtorDtorCommon(GenericPluginTy &Plugin,
   if (!ELFObjOrErr)
     return HandleErr(ELFObjOrErr.takeError());
 
-  /*Each array object represents the name of a constructor or destructor
-    function along with its priority.*/
-  using ArrayObject = std::pair<StringRef, uint16_t>;
-  SmallVector<ArrayObject> Funcs;
+  using FuncNameAndPriority = std::pair<StringRef, uint16_t>;
+  SmallVector<FuncNameAndPriority> Funcs;
   for (ELFSymbolRef Sym : (*ELFObjOrErr)->symbols()) {
     auto NameOrErr = Sym.getName();
     if (!NameOrErr)
@@ -1211,10 +1209,11 @@ Error L0DeviceTy::callGlobalCtorDtorCommon(GenericPluginTy &Plugin,
   }
 
   // Sort the created array to be in priority order.
-  llvm::sort(Funcs, [=](auto X, auto Y) { return X.second < Y.second; });
+  llvm::sort(Funcs,
+             [=](const auto &X, const auto &Y) { return X.second < Y.second; });
 
-  auto BufferOrErr =
-      allocate(Funcs.size() * sizeof(void *), nullptr, TARGET_ALLOC_DEVICE);
+  auto BufferOrErr = allocate(Funcs.size() * sizeof(void *),
+                              /*HostPtr=*/nullptr, TARGET_ALLOC_DEVICE);
   if (!BufferOrErr)
     return HandleErr(BufferOrErr.takeError());
 
@@ -1229,7 +1228,7 @@ Error L0DeviceTy::callGlobalCtorDtorCommon(GenericPluginTy &Plugin,
   auto *GlobalPtrStop = reinterpret_cast<uintptr_t *>(Buffer) + Funcs.size();
 
   SmallVector<void *> FunctionPtrs(Funcs.size());
-  std::size_t Idx = 0;
+  size_t Idx = 0;
   for (auto [Name, Priority] : Funcs) {
     GlobalTy FunctionAddr(Name.str(), sizeof(void *), &FunctionPtrs[Idx++]);
     if (auto Err = Handler.readGlobalFromDevice(*this, Image, FunctionAddr))

--- a/offload/plugins-nextgen/level_zero/src/L0Device.cpp
+++ b/offload/plugins-nextgen/level_zero/src/L0Device.cpp
@@ -1163,9 +1163,9 @@ Error L0DeviceTy::callGlobalCtorDtorCommon(GenericPluginTy &Plugin,
   // more of context about this routine.
   auto handleErr = [&](Error Err) {
     std::string Buffer;
-    llvm::raw_string_ostream(Buffer) << "failed to call global "
-                                     << (IsCtor ? "constructors" : "destructors")
-                                     << " in the image";
+    llvm::raw_string_ostream(Buffer)
+        << "failed to call global " << (IsCtor ? "constructors" : "destructors")
+        << " in the image";
     return Plugin::error(ErrorCode::INVALID_BINARY, std::move(Err),
                          Buffer.c_str());
   };

--- a/offload/plugins-nextgen/level_zero/src/L0Device.cpp
+++ b/offload/plugins-nextgen/level_zero/src/L0Device.cpp
@@ -1161,7 +1161,7 @@ Error L0DeviceTy::callGlobalCtorDtorCommon(GenericPluginTy &Plugin,
 
   // Instead of returning errors directly, we capture them and provide
   // more of context about this routine.
-  auto handleErr = [&](Error Err) {
+  auto HandleErr = [&](Error Err) {
     std::string Buffer;
     llvm::raw_string_ostream(Buffer)
         << "failed to call global " << (IsCtor ? "constructors" : "destructors")
@@ -1169,7 +1169,7 @@ Error L0DeviceTy::callGlobalCtorDtorCommon(GenericPluginTy &Plugin,
     return Plugin::error(ErrorCode::INVALID_BINARY, std::move(Err),
                          Buffer.c_str());
   };
-  auto handleErrStr = [&](const std::string &Msg) {
+  auto HandleErrStr = [&](const std::string &Msg) {
     return Plugin::error(ErrorCode::INVALID_BINARY,
                          "failed to call global %s in the image: %s",
                          IsCtor ? "constructors" : "destructors", Msg.c_str());
@@ -1181,13 +1181,16 @@ Error L0DeviceTy::callGlobalCtorDtorCommon(GenericPluginTy &Plugin,
   // prefixed with a __init_array_object_ or __fini_array_object_.
   auto ELFObjOrErr = Handler.getELFObjectFile(Image);
   if (!ELFObjOrErr)
-    return handleErr(ELFObjOrErr.takeError());
+    return HandleErr(ELFObjOrErr.takeError());
 
-  SmallVector<std::pair<StringRef, uint16_t>> Funcs;
+  /*Each array object represents the name of a constructor or destructor
+    function along with its priority.*/
+  using ArrayObject = std::pair<StringRef, uint16_t>;
+  SmallVector<ArrayObject> Funcs;
   for (ELFSymbolRef Sym : (*ELFObjOrErr)->symbols()) {
     auto NameOrErr = Sym.getName();
     if (!NameOrErr)
-      return handleErr(NameOrErr.takeError());
+      return HandleErr(NameOrErr.takeError());
 
     if (!NameOrErr->starts_with(IsCtor ? "__init_array_object_"
                                        : "__fini_array_object_"))
@@ -1195,7 +1198,7 @@ Error L0DeviceTy::callGlobalCtorDtorCommon(GenericPluginTy &Plugin,
 
     uint16_t Priority;
     if (NameOrErr->rsplit('_').second.getAsInteger(10, Priority))
-      return handleErrStr("invalid priority for constructor or destructor");
+      return HandleErrStr("invalid priority for constructor or destructor");
 
     Funcs.emplace_back(*NameOrErr, Priority);
   }
@@ -1213,7 +1216,7 @@ Error L0DeviceTy::callGlobalCtorDtorCommon(GenericPluginTy &Plugin,
   auto BufferOrErr =
       allocate(Funcs.size() * sizeof(void *), nullptr, TARGET_ALLOC_DEVICE);
   if (!BufferOrErr)
-    return handleErr(BufferOrErr.takeError());
+    return HandleErr(BufferOrErr.takeError());
 
   void *Buffer = *BufferOrErr;
   if (!Buffer)
@@ -1234,43 +1237,44 @@ Error L0DeviceTy::callGlobalCtorDtorCommon(GenericPluginTy &Plugin,
   }
 
   if (auto Err = dataSubmit(GlobalPtrStart, FunctionPtrs.data(),
-                            FunctionPtrs.size() * sizeof(void *), nullptr))
-    return handleErr(std::move(Err));
+                            FunctionPtrs.size() * sizeof(void *),
+                            /*AsyncInfo=*/nullptr))
+    return HandleErr(std::move(Err));
 
   GlobalTy StartGlobal(IsCtor ? "__init_array_start" : "__fini_array_start",
                        sizeof(void *), &GlobalPtrStart);
   if (auto Err = Handler.writeGlobalToDevice(*this, Image, StartGlobal))
-    return handleErr(std::move(Err));
+    return HandleErr(std::move(Err));
 
   GlobalTy StopGlobal(IsCtor ? "__init_array_end" : "__fini_array_end",
                       sizeof(void *), &GlobalPtrStop);
   if (auto Err = Handler.writeGlobalToDevice(*this, Image, StopGlobal))
-    return handleErr(std::move(Err));
+    return HandleErr(std::move(Err));
 
   // Call the generated kernel to execute the constructors or destructors.
   auto KernelOrErr = constructKernel(KernelName);
   if (!KernelOrErr)
-    return handleErr(KernelOrErr.takeError());
+    return HandleErr(KernelOrErr.takeError());
 
   GenericKernelTy &L0Kernel = *KernelOrErr;
   if (auto Err = L0Kernel.init(*this, Image))
-    return handleErr(std::move(Err));
+    return HandleErr(std::move(Err));
 
-  AsyncInfoWrapperTy AsyncInfoWrapper(*this, nullptr);
+  AsyncInfoWrapperTy AsyncInfoWrapper(*this, /*AsyncInfoPtr=*/nullptr);
 
   KernelArgsTy KernelArgs{};
   uint32_t NumBlocksAndThreads[3] = {1u, 1u, 1u};
   if (auto Err = L0Kernel.launchImpl(*this, NumBlocksAndThreads,
                                      NumBlocksAndThreads, 0, KernelArgs,
                                      KernelLaunchParamsTy{}, AsyncInfoWrapper))
-    return handleErr(std::move(Err));
+    return HandleErr(std::move(Err));
 
   Error Err = Plugin::success();
   AsyncInfoWrapper.finalize(Err);
   if (Err)
-    return handleErr(std::move(Err));
+    return HandleErr(std::move(Err));
   if (auto Err = free(Buffer, TARGET_ALLOC_DEVICE))
-    return handleErr(std::move(Err));
+    return HandleErr(std::move(Err));
 
   return Plugin::success();
 }

--- a/offload/plugins-nextgen/level_zero/src/L0Device.cpp
+++ b/offload/plugins-nextgen/level_zero/src/L0Device.cpp
@@ -1233,7 +1233,7 @@ Error L0DeviceTy::callGlobalCtorDtorCommon(GenericPluginTy &Plugin,
   for (auto [Name, Priority] : Funcs) {
     GlobalTy FunctionAddr(Name.str(), sizeof(void *), &FunctionPtrs[Idx++]);
     if (auto Err = Handler.readGlobalFromDevice(*this, Image, FunctionAddr))
-      return handleErr(std::move(Err));
+      return HandleErr(std::move(Err));
   }
 
   if (auto Err = dataSubmit(GlobalPtrStart, FunctionPtrs.data(),


### PR DESCRIPTION
This PR adds support in the Level Zero plugin to execute constructors/destructors on the device code. As spirv-link has some limitations, it mimics the CUDA plugin behavior where the RTL constructs the device side tables before invoking the kernel that will execute them.

The kernel and other necessary symbols to create the device tables are created by the SPIRVCtorDtorLowering pass to be added in #187509