### PR TITLE
[AArch64][GlobalISel] Remove fallback for scalar usqadd/suqadd intrinsics

### DIFF
--- a/llvm/lib/Target/AArch64/GISel/AArch64RegisterBankInfo.cpp
+++ b/llvm/lib/Target/AArch64/GISel/AArch64RegisterBankInfo.cpp
@@ -619,6 +619,8 @@ static bool isFPIntrinsic(const MachineRegisterInfo &MRI,
   case Intrinsic::aarch64_neon_sqrdmlah:
   case Intrinsic::aarch64_neon_sqrdmlsh:
   case Intrinsic::aarch64_neon_sqrdmulh:
+  case Intrinsic::aarch64_neon_suqadd:
+  case Intrinsic::aarch64_neon_usqadd:
   case Intrinsic::aarch64_neon_uqadd:
   case Intrinsic::aarch64_neon_sqadd:
   case Intrinsic::aarch64_neon_uqsub:

--- a/llvm/test/CodeGen/AArch64/arm64-int-neon.ll
+++ b/llvm/test/CodeGen/AArch64/arm64-int-neon.ll
@@ -2,11 +2,7 @@
 ; RUN: llc < %s -mtriple aarch64-unknown-unknown -mattr=+fprcvt,+fullfp16 | FileCheck %s --check-prefixes=CHECK,CHECK-SD
 ; RUN: llc < %s -mtriple aarch64-unknown-unknown -global-isel -global-isel-abort=2 -mattr=+fprcvt,+fullfp16 2>&1 | FileCheck %s --check-prefixes=CHECK,CHECK-GI
 
-; CHECK-GI:         warning: Instruction selection used fallback path for test_suqadd_s32
-; CHECK-GI-NEXT:    warning: Instruction selection used fallback path for test_suqadd_s64
-; CHECK-GI-NEXT:    warning: Instruction selection used fallback path for test_usqadd_s32
-; CHECK-GI-NEXT:    warning: Instruction selection used fallback path for test_usqadd_s64
-; CHECK-GI-NEXT:    warning: Instruction selection used fallback path for test_sqdmulls_scalar
+; CHECK-GI:    warning: Instruction selection used fallback path for test_sqdmulls_scalar
 ; CHECK-GI-NEXT:    warning: Instruction selection used fallback path for test_sqdmulh_scalar
 ; CHECK-GI-NEXT:    warning: Instruction selection used fallback path for test_sqabs_s32
 ; CHECK-GI-NEXT:    warning: Instruction selection used fallback path for test_sqabs_s64


### PR DESCRIPTION
Previously, GlobalISel was failing to select these intrinsics when given scalar operands, as RegBankSelect would place these on GPR banks. Fixing this enables GlobalISel to lower correctly, as in Instruction Selection the intrinsic matches the SIMD patterns in AArch64InstrInfo.td.