### PR TITLE
[SPIR-V] Emit OpLoopMerge for non-shader targets without SPV_INTEL_unstructured_loop_controls extension

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVEmitIntrinsics.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVEmitIntrinsics.cpp
@@ -3083,9 +3083,8 @@ void SPIRVEmitIntrinsics::emitUnstructuredLoopControls(Function &F,
       // Emit intrinsic: loop control mask + optional parameters.
       B.SetInsertPoint(Term);
       SmallVector<Value *, 4> IntrArgs;
-      IntrArgs.push_back(B.getInt32(LC));
-      for (unsigned I = 1; I < Ops.size(); ++I)
-        IntrArgs.push_back(B.getInt32(Ops[I]));
+      for (unsigned Op : Ops)
+        IntrArgs.push_back(B.getInt32(Op));
       B.CreateIntrinsic(Intrinsic::spv_loop_control_intel, IntrArgs);
     }
     return;
@@ -3118,7 +3117,7 @@ void SPIRVEmitIntrinsics::emitUnstructuredLoopControls(Function &F,
     auto *ContinueAddress = BlockAddress::get(&F, Latch);
     SmallVector<Value *, 4> Args = {MergeAddress, ContinueAddress};
     for (unsigned Imm : LoopControlOps)
-      Args.emplace_back(ConstantInt::get(B.getInt32Ty(), Imm));
+      Args.emplace_back(B.getInt32(Imm));
     B.CreateIntrinsic(Intrinsic::spv_loop_merge, {Args});
   }
 }

--- a/llvm/lib/Target/SPIRV/SPIRVEmitIntrinsics.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVEmitIntrinsics.cpp
@@ -18,6 +18,8 @@
 #include "SPIRVUtils.h"
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/StringSet.h"
+#include "llvm/Analysis/LoopInfo.h"
+#include "llvm/IR/Dominators.h"
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/InstIterator.h"
 #include "llvm/IR/InstVisitor.h"
@@ -3063,29 +3065,61 @@ void SPIRVEmitIntrinsics::emitUnstructuredLoopControls(Function &F,
   // Shaders use SPIRVStructurizer which emits OpLoopMerge via spv_loop_merge.
   if (ST->isShader())
     return;
-  if (!ST->canUseExtension(
-          SPIRV::Extension::SPV_INTEL_unstructured_loop_controls))
+
+  if (ST->canUseExtension(
+          SPIRV::Extension::SPV_INTEL_unstructured_loop_controls)) {
+    for (BasicBlock &BB : F) {
+      Instruction *Term = BB.getTerminator();
+      MDNode *LoopMD = Term->getMetadata(LLVMContext::MD_loop);
+      if (!LoopMD)
+        continue;
+
+      SmallVector<unsigned, 1> Ops =
+          getSpirvLoopControlOperandsFromLoopMetadata(LoopMD);
+      unsigned LC = Ops[0];
+      if (LC == SPIRV::LoopControl::None)
+        continue;
+
+      // Emit intrinsic: loop control mask + optional parameters.
+      B.SetInsertPoint(Term);
+      SmallVector<Value *, 4> IntrArgs;
+      IntrArgs.push_back(B.getInt32(LC));
+      for (unsigned I = 1; I < Ops.size(); ++I)
+        IntrArgs.push_back(B.getInt32(Ops[I]));
+      B.CreateIntrinsic(Intrinsic::spv_loop_control_intel, IntrArgs);
+    }
+    return;
+  }
+
+  // For non-shader targets without the Intel extension, emit OpLoopMerge
+  // using spv_loop_merge intrinsics, mirroring the structurizer approach.
+  DominatorTree DT(F);
+  LoopInfo LI(DT);
+  if (LI.empty())
     return;
 
-  for (BasicBlock &BB : F) {
-    Instruction *Term = BB.getTerminator();
-    MDNode *LoopMD = Term->getMetadata(LLVMContext::MD_loop);
-    if (!LoopMD)
+  for (Loop *L : LI.getLoopsInPreorder()) {
+    BasicBlock *Latch = L->getLoopLatch();
+    if (!Latch)
+      continue;
+    BasicBlock *MergeBlock = L->getUniqueExitBlock();
+    if (!MergeBlock)
       continue;
 
-    SmallVector<unsigned, 1> Ops =
-        getSpirvLoopControlOperandsFromLoopMetadata(LoopMD);
-    unsigned LC = Ops[0];
-    if (LC == SPIRV::LoopControl::None)
+    // Check for loop unroll metadata on the latch terminator.
+    SmallVector<unsigned, 1> LoopControlOps =
+        getSpirvLoopControlOperandsFromLoopMetadata(L);
+    if (LoopControlOps[0] == SPIRV::LoopControl::None)
       continue;
 
-    // Emit intrinsic: loop control mask + optional parameters.
-    B.SetInsertPoint(Term);
-    SmallVector<Value *, 4> IntrArgs;
-    IntrArgs.push_back(B.getInt32(LC));
-    for (unsigned I = 1; I < Ops.size(); ++I)
-      IntrArgs.push_back(B.getInt32(Ops[I]));
-    B.CreateIntrinsic(Intrinsic::spv_loop_control_intel, IntrArgs);
+    BasicBlock *Header = L->getHeader();
+    B.SetInsertPoint(Header->getTerminator());
+    auto *MergeAddress = BlockAddress::get(&F, MergeBlock);
+    auto *ContinueAddress = BlockAddress::get(&F, Latch);
+    SmallVector<Value *, 4> Args = {MergeAddress, ContinueAddress};
+    for (unsigned Imm : LoopControlOps)
+      Args.emplace_back(ConstantInt::get(B.getInt32Ty(), Imm));
+    B.CreateIntrinsic(Intrinsic::spv_loop_merge, {Args});
   }
 }
 

--- a/llvm/lib/Target/SPIRV/SPIRVTargetMachine.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVTargetMachine.cpp
@@ -220,6 +220,10 @@ void SPIRVPassConfig::addISelPrepare() {
     // 5. Reduce the amount of variables required by pushing some operations
     // back to virtual registers.
     addPass(createPromoteMemoryToRegisterPass());
+  } else {
+    // Canonicalize loops so they have a single latch and preheader.
+    // This enables OpLoopMerge emission for non-shader targets.
+    addPass(createLoopSimplifyPass());
   }
   SPIRVTargetMachine &TM = getTM<SPIRVTargetMachine>();
   addPass(createSPIRVStripConvergenceIntrinsicsPass());

--- a/llvm/test/CodeGen/SPIRV/llc-pipeline.ll
+++ b/llvm/test/CodeGen/SPIRV/llc-pipeline.ll
@@ -39,6 +39,9 @@
 ; SPIRV-O0-NEXT:    FunctionPass Manager
 ; SPIRV-O0-NEXT:      Lower invoke and unwind, for unwindless code generators
 ; SPIRV-O0-NEXT:      Remove unreachable blocks from the CFG
+; SPIRV-O0-NEXT:      Dominator Tree Construction
+; SPIRV-O0-NEXT:      Natural Loop Information
+; SPIRV-O0-NEXT:      Canonicalize natural loops
 ; SPIRV-O0-NEXT:      SPIRV strip convergent intrinsics
 ; SPIRV-O0-NEXT:    SPIRV Legalize Implicit Binding
 ; SPIRV-O0-NEXT:    SPIRV Legalize Zero-Size Arrays
@@ -151,6 +154,9 @@
 ; SPIRV-Opt-NEXT:      CodeGen Prepare
 ; SPIRV-Opt-NEXT:      Lower invoke and unwind, for unwindless code generators
 ; SPIRV-Opt-NEXT:      Remove unreachable blocks from the CFG
+; SPIRV-Opt-NEXT:      Dominator Tree Construction
+; SPIRV-Opt-NEXT:      Natural Loop Information
+; SPIRV-Opt-NEXT:      Canonicalize natural loops
 ; SPIRV-Opt-NEXT:      SPIRV strip convergent intrinsics
 ; SPIRV-Opt-NEXT:    SPIRV Legalize Implicit Binding
 ; SPIRV-Opt-NEXT:    SPIRV Legalize Zero-Size Arrays

--- a/llvm/test/CodeGen/SPIRV/llvm-intrinsics/memset.ll
+++ b/llvm/test/CodeGen/SPIRV/llvm-intrinsics/memset.ll
@@ -40,15 +40,21 @@
 
 ; CHECK: %[[#Entry:]] = OpLabel
 ; CHECK: %[[#IsNonZeroLen:]] = OpINotEqual %[[#]] %[[#Len]] %[[#Zero:]]
-; CHECK: OpBranchConditional %[[#IsNonZeroLen]] %[[#WhileBody:]] %[[#End:]]
+; CHECK: OpBranchConditional %[[#IsNonZeroLen]] %[[#Preheader:]] %[[#End:]]
+
+; CHECK: %[[#Preheader]] = OpLabel
+; CHECK: OpBranch %[[#WhileBody:]]
 
 ; CHECK: %[[#WhileBody]] = OpLabel
-; CHECK: %[[#Offset:]] = OpPhi %[[#]] %[[#Zero]] %[[#Entry]] %[[#OffsetInc:]] %[[#WhileBody]]
+; CHECK: %[[#Offset:]] = OpPhi %[[#]] %[[#OffsetInc:]] %[[#WhileBody]] %[[#Zero]] %[[#Preheader]]
 ; CHECK: %[[#Ptr:]] = OpInBoundsPtrAccessChain %[[#]] %[[#Dest]] %[[#Offset]]
 ; CHECK: OpStore %[[#Ptr]] %[[#Value]] Aligned 1
 ; CHECK: %[[#OffsetInc]] = OpIAdd %[[#]] %[[#Offset]] %[[#One:]]
 ; CHECK: %[[#NotEnd:]] = OpULessThan %[[#]] %[[#OffsetInc]] %[[#Len]]
-; CHECK: OpBranchConditional %[[#NotEnd]] %[[#WhileBody]] %[[#End]]
+; CHECK: OpBranchConditional %[[#NotEnd]] %[[#WhileBody]] %[[#LoopExit:]]
+
+; CHECK: %[[#LoopExit]] = OpLabel
+; CHECK: OpBranch %[[#End]]
 
 ; CHECK: %[[#End]] = OpLabel
 ; CHECK: OpReturn

--- a/llvm/test/CodeGen/SPIRV/loop-unroll-nonshader.ll
+++ b/llvm/test/CodeGen/SPIRV/loop-unroll-nonshader.ll
@@ -92,6 +92,65 @@ for.end:
   ret void
 }
 
+; Test 5: Loop with multiple latches.
+; The loop has two blocks branching back to the header; loop-simplify inserts
+; a dedicated latch block so that getLoopLatch() returns a unique latch.
+; CHECK: OpFunction
+; CHECK: OpLoopMerge %[[#]] %[[#]] Unroll
+; CHECK: OpFunctionEnd
+
+define spir_kernel void @test_multi_latch(ptr addrspace(1) %dst, i32 %flag) {
+entry:
+  br label %header
+
+header:
+  %i = phi i32 [ 0, %entry ], [ %inc, %latch1 ], [ %inc, %latch2 ]
+  %ptr = getelementptr inbounds i32, ptr addrspace(1) %dst, i32 %i
+  store i32 %i, ptr addrspace(1) %ptr, align 4
+  %inc = add nuw nsw i32 %i, 1
+  %cond = icmp eq i32 %flag, 0
+  br i1 %cond, label %latch1, label %latch2
+
+latch1:
+  %cmp1 = icmp ult i32 %inc, 10
+  br i1 %cmp1, label %header, label %exit, !llvm.loop !8
+
+latch2:
+  %cmp2 = icmp ult i32 %inc, 20
+  br i1 %cmp2, label %header, label %exit, !llvm.loop !8
+
+exit:
+  ret void
+}
+
+; Test 6: Loop with multiple exits.
+; The loop exits from two different blocks; loop-simplify inserts a dedicated
+; exit block so that getUniqueExitBlock() succeeds.
+; CHECK: OpFunction
+; CHECK: OpLoopMerge %[[#]] %[[#]] DontUnroll
+; CHECK: OpFunctionEnd
+
+define spir_kernel void @test_multi_exit(ptr addrspace(1) %dst, ptr addrspace(1) %cond_ptr) {
+entry:
+  br label %header
+
+header:
+  %i = phi i32 [ 0, %entry ], [ %inc, %latch ]
+  %ptr = getelementptr inbounds i32, ptr addrspace(1) %dst, i32 %i
+  store i32 %i, ptr addrspace(1) %ptr, align 4
+  %early_cond = load i32, ptr addrspace(1) %cond_ptr, align 4
+  %early_exit = icmp eq i32 %early_cond, 42
+  br i1 %early_exit, label %exit, label %latch
+
+latch:
+  %inc = add nuw nsw i32 %i, 1
+  %cmp = icmp ult i32 %inc, 10
+  br i1 %cmp, label %header, label %exit, !llvm.loop !9
+
+exit:
+  ret void
+}
+
 ; Check that no Intel extension is required.
 ; CHECK-NOT: OpExtension "SPV_INTEL_unstructured_loop_controls"
 ; CHECK-NOT: OpCapability UnstructuredLoopControlsINTEL
@@ -101,6 +160,8 @@ for.end:
 !1 = distinct !{!1, !5}
 !2 = distinct !{!2, !6}
 !3 = distinct !{!3, !7}
+!8 = distinct !{!8, !4}
+!9 = distinct !{!9, !5}
 
 !4 = !{!"llvm.loop.unroll.enable"}
 !5 = !{!"llvm.loop.unroll.disable"}

--- a/llvm/test/CodeGen/SPIRV/loop-unroll-nonshader.ll
+++ b/llvm/test/CodeGen/SPIRV/loop-unroll-nonshader.ll
@@ -1,0 +1,108 @@
+; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv64-unknown-unknown %s -o - | FileCheck %s
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv64-unknown-unknown %s -o - -filetype=obj | spirv-val %}
+
+; Test that OpLoopMerge is emitted for non-shader targets without requiring
+; SPV_INTEL_unstructured_loop_controls.
+
+; Test 1: llvm.loop.unroll.enable -> OpLoopMerge with Unroll.
+; CHECK: OpFunction
+; CHECK: OpLoopMerge %[[#]] %[[#]] Unroll
+; CHECK: OpBranchConditional
+; CHECK: OpFunctionEnd
+
+define spir_kernel void @test_unroll_enable(ptr addrspace(1) %dst) {
+entry:
+  br label %for.body
+
+for.body:
+  %i = phi i32 [ 0, %entry ], [ %inc, %for.body ]
+  %ptr = getelementptr inbounds i32, ptr addrspace(1) %dst, i32 %i
+  store i32 %i, ptr addrspace(1) %ptr, align 4
+  %inc = add nuw nsw i32 %i, 1
+  %cmp = icmp ult i32 %inc, 10
+  br i1 %cmp, label %for.body, label %for.end, !llvm.loop !0
+
+for.end:
+  ret void
+}
+
+; Test 2: llvm.loop.unroll.disable -> OpLoopMerge with DontUnroll.
+; CHECK: OpFunction
+; CHECK: OpLoopMerge %[[#]] %[[#]] DontUnroll
+; CHECK: OpBranchConditional
+; CHECK: OpFunctionEnd
+
+define spir_kernel void @test_unroll_disable(ptr addrspace(1) %dst) {
+entry:
+  br label %for.body
+
+for.body:
+  %i = phi i32 [ 0, %entry ], [ %inc, %for.body ]
+  %ptr = getelementptr inbounds i32, ptr addrspace(1) %dst, i32 %i
+  store i32 %i, ptr addrspace(1) %ptr, align 4
+  %inc = add nuw nsw i32 %i, 1
+  %cmp = icmp ult i32 %inc, 10
+  br i1 %cmp, label %for.body, label %for.end, !llvm.loop !1
+
+for.end:
+  ret void
+}
+
+; Test 3: llvm.loop.unroll.count N -> OpLoopMerge with PartialCount N.
+; CHECK: OpFunction
+; CHECK: OpLoopMerge %[[#]] %[[#]] PartialCount 4
+; CHECK: OpBranchConditional
+; CHECK: OpFunctionEnd
+
+define spir_kernel void @test_unroll_count(ptr addrspace(1) %dst) {
+entry:
+  br label %for.body
+
+for.body:
+  %i = phi i32 [ 0, %entry ], [ %inc, %for.body ]
+  %ptr = getelementptr inbounds i32, ptr addrspace(1) %dst, i32 %i
+  store i32 %i, ptr addrspace(1) %ptr, align 4
+  %inc = add nuw nsw i32 %i, 1
+  %cmp = icmp ult i32 %inc, 10
+  br i1 %cmp, label %for.body, label %for.end, !llvm.loop !2
+
+for.end:
+  ret void
+}
+
+; Test 4: llvm.loop.unroll.full -> OpLoopMerge with Unroll.
+; CHECK: OpFunction
+; CHECK: OpLoopMerge %[[#]] %[[#]] Unroll
+; CHECK: OpBranchConditional
+; CHECK: OpFunctionEnd
+
+define spir_kernel void @test_unroll_full(ptr addrspace(1) %dst) {
+entry:
+  br label %for.body
+
+for.body:
+  %i = phi i32 [ 0, %entry ], [ %inc, %for.body ]
+  %ptr = getelementptr inbounds i32, ptr addrspace(1) %dst, i32 %i
+  store i32 %i, ptr addrspace(1) %ptr, align 4
+  %inc = add nuw nsw i32 %i, 1
+  %cmp = icmp ult i32 %inc, 10
+  br i1 %cmp, label %for.body, label %for.end, !llvm.loop !3
+
+for.end:
+  ret void
+}
+
+; Check that no Intel extension is required.
+; CHECK-NOT: OpExtension "SPV_INTEL_unstructured_loop_controls"
+; CHECK-NOT: OpCapability UnstructuredLoopControlsINTEL
+; CHECK-NOT: OpLoopControlINTEL
+
+!0 = distinct !{!0, !4}
+!1 = distinct !{!1, !5}
+!2 = distinct !{!2, !6}
+!3 = distinct !{!3, !7}
+
+!4 = !{!"llvm.loop.unroll.enable"}
+!5 = !{!"llvm.loop.unroll.disable"}
+!6 = !{!"llvm.loop.unroll.count", i32 4}
+!7 = !{!"llvm.loop.unroll.full"}

--- a/llvm/test/CodeGen/SPIRV/pointers/phi-chain-types.ll
+++ b/llvm/test/CodeGen/SPIRV/pointers/phi-chain-types.ll
@@ -7,30 +7,35 @@
 ; CHECK-DAG: OpName %[[#Foo:]] "foo"
 ; CHECK-DAG: OpName %[[#Bar:]] "bar"
 
+; CHECK-DAG: %[[#Char:]] = OpTypeInt 8 0
+; CHECK-DAG: %[[#CharGenPtr:]] = OpTypePointer Generic %[[#Char]]
 ; CHECK-DAG: %[[#Short:]] = OpTypeInt 16 0
 ; CHECK-DAG: %[[#ShortGenPtr:]] = OpTypePointer Generic %[[#Short]]
 ; CHECK-DAG: %[[#ShortWrkPtr:]] = OpTypePointer Workgroup %[[#Short]]
 ; CHECK-DAG: %[[#G1:]] = OpVariable %[[#ShortWrkPtr]] Workgroup
 
 ; CHECK: %[[#Foo:]] = OpFunction %[[#]] None %[[#]]
-; CHECK: %[[#FooArgP:]] = OpFunctionParameter %[[#ShortGenPtr]]
+; CHECK: %[[#FooArgP:]] = OpFunctionParameter %[[#CharGenPtr]]
 ; CHECK: OpFunctionParameter
 ; CHECK: OpFunctionParameter
 ; CHECK: OpFunctionParameter
 ; CHECK: %[[#FooG1:]] = OpPtrCastToGeneric %[[#ShortGenPtr]] %[[#G1]]
-; CHECK: %[[#FooVal2:]] = OpPhi %[[#ShortGenPtr]] %[[#FooArgP]] %[[#]] %[[#FooVal3:]] %[[#]]
-; CHECK: %[[#FooVal1:]] = OpPhi %[[#ShortGenPtr]] %[[#FooG1]] %[[#]] %[[#FooVal2]] %[[#]]
-; CHECK: %[[#FooVal3]] = OpLoad %[[#ShortGenPtr]] %[[#]]
+; CHECK: %[[#FooG1Cast:]] = OpBitcast %[[#CharGenPtr]] %[[#FooG1]]
+; CHECK: %[[#FooVal2:]] = OpPhi %[[#CharGenPtr]] %[[#FooVal3:]] %[[#]] %[[#FooArgP]] %[[#]]
+; CHECK: %[[#FooVal1:]] = OpPhi %[[#CharGenPtr]] %[[#FooVal2]] %[[#]] %[[#FooG1Cast]] %[[#]]
+; CHECK: OpBitcast %[[#ShortGenPtr]] %[[#FooVal1]]
+; CHECK: %[[#FooVal3]] = OpLoad %[[#CharGenPtr]] %[[#]]
 
 ; CHECK: %[[#Bar:]] = OpFunction %[[#]] None %[[#]]
-; CHECK: %[[#BarArgP:]] = OpFunctionParameter %[[#ShortGenPtr]]
+; CHECK: %[[#BarArgP:]] = OpFunctionParameter %[[#CharGenPtr]]
 ; CHECK: OpFunctionParameter
 ; CHECK: OpFunctionParameter
 ; CHECK: OpFunctionParameter
-; CHECK: %[[#BarVal3:]] = OpLoad %[[#ShortGenPtr]] %[[#]]
+; CHECK: %[[#BarVal3:]] = OpLoad %[[#CharGenPtr]] %[[#]]
 ; CHECK: %[[#BarG1:]] = OpPtrCastToGeneric %[[#ShortGenPtr]] %[[#G1]]
-; CHECK: %[[#BarVal1:]] = OpPhi %[[#ShortGenPtr]] %[[#BarG1]] %[[#]] %[[#BarVal2:]] %[[#]]
-; CHECK: %[[#BarVal2]] = OpPhi %[[#ShortGenPtr]] %[[#BarArgP]] %[[#]] %[[#BarVal3]] %[[#]]
+; CHECK: %[[#BarVal1:]] = OpPhi %[[#ShortGenPtr]] %[[#BarVal2Cast:]] %[[#]] %[[#BarG1]] %[[#]]
+; CHECK: %[[#BarVal2:]] = OpPhi %[[#CharGenPtr]] %[[#BarVal3]] %[[#]] %[[#BarArgP]] %[[#]]
+; CHECK: %[[#BarVal2Cast]] = OpBitcast %[[#ShortGenPtr]] %[[#BarVal2]]
 
 @G1 = internal addrspace(3) global i16 undef, align 8
 @G2 = internal unnamed_addr addrspace(3) global ptr addrspace(4) undef, align 8


### PR DESCRIPTION
`OpLoopMerge` emission was not supported due to the fact that spirv structurizer is not being run for non-shader targets.

After enabling support for `SPV_INTEL_unstructured_loop_controls` in https://github.com/llvm/llvm-project/pull/178799 is started to preserve some information about unstructured control flow. This PR is intended to enable support for `OpLoopMerge` without extension.

Note: changes in `llvm/test/CodeGen/SPIRV/pointers/phi-chain-types.ll` and `llvm/test/CodeGen/SPIRV/llvm-intrinsics/memset.ll` are due to the fact that loop layout has changed after `loop-simplify` pass enabling