### PR TITLE
[libc][stdio] Fix standard streams in overlay mode.

### DIFF
--- a/libc/src/stdio/linux/stderr.cpp
+++ b/libc/src/stdio/linux/stderr.cpp
@@ -9,6 +9,9 @@
 #include "src/stdio/stderr.h"
 
 #include "hdr/types/FILE.h"
+
+#ifdef LIBC_FULL_BUILD
+
 #include "src/__support/File/linux/file.h"
 #include "src/__support/common.h"
 #include "src/__support/macros/config.h"
@@ -22,3 +25,9 @@ static LinuxFile StdErr(2, nullptr, STDERR_BUFFER_SIZE, _IONBF, false,
 LLVM_LIBC_VARIABLE(FILE *, stderr) = reinterpret_cast<FILE *>(&StdErr);
 
 } // namespace LIBC_NAMESPACE_DECL
+
+#else // overlay mode
+
+extern "C" FILE *stderr;
+
+#endif // LIBC_FULL_BUILD

--- a/libc/src/stdio/linux/stdin.cpp
+++ b/libc/src/stdio/linux/stdin.cpp
@@ -9,6 +9,9 @@
 #include "src/stdio/stdin.h"
 
 #include "hdr/types/FILE.h"
+
+#ifdef LIBC_FULL_BUILD
+
 #include "src/__support/File/linux/file.h"
 #include "src/__support/common.h"
 #include "src/__support/macros/config.h"
@@ -23,3 +26,9 @@ static LinuxFile StdIn(0, stdin_buffer, STDIN_BUFFER_SIZE, _IOFBF, false,
 LLVM_LIBC_VARIABLE(FILE *, stdin) = reinterpret_cast<FILE *>(&StdIn);
 
 } // namespace LIBC_NAMESPACE_DECL
+
+#else // overlay mode
+
+extern "C" FILE *stderr;
+
+#endif // LIBC_FULL_BUILD

--- a/libc/src/stdio/linux/stdout.cpp
+++ b/libc/src/stdio/linux/stdout.cpp
@@ -9,6 +9,9 @@
 #include "src/stdio/stdout.h"
 
 #include "hdr/types/FILE.h"
+
+#ifdef LIBC_FULL_BUILD
+
 #include "src/__support/File/linux/file.h"
 #include "src/__support/common.h"
 #include "src/__support/macros/config.h"
@@ -23,3 +26,9 @@ static LinuxFile StdOut(1, stdout_buffer, STDOUT_BUFFER_SIZE, _IOLBF, false,
 LLVM_LIBC_VARIABLE(FILE *, stdout) = reinterpret_cast<FILE *>(&StdOut);
 
 } // namespace LIBC_NAMESPACE_DECL
+
+#else // overlay mode
+
+extern "C" FILE *stderr;
+
+#endif // LIBC_FULL_BUILD


### PR DESCRIPTION
https://github.com/llvm/llvm-project/pull/184669 changed the behavior of standard streams in overlay mode, bringing in some symbols that are only available in full build mode.