### PR TITLE
[NFC][Support] Minor code cleanup in APFloat.cpp

### DIFF
--- a/llvm/lib/Support/APFloat.cpp
+++ b/llvm/lib/Support/APFloat.cpp
@@ -325,31 +325,26 @@ decDigitValue(unsigned int c)
    appropriate sign.  */
 static Expected<int> readExponent(StringRef::iterator begin,
                                   StringRef::iterator end) {
-  bool isNegative;
-  unsigned int absExponent;
   const unsigned int overlargeExponent = 24000;  /* FIXME.  */
   StringRef::iterator p = begin;
 
   // Treat no exponent as 0 to match binutils
-  if (p == end || ((*p == '-' || *p == '+') && (p + 1) == end)) {
+  if (p == end || ((*p == '-' || *p == '+') && (p + 1) == end))
     return 0;
-  }
 
-  isNegative = (*p == '-');
+  bool isNegative = *p == '-';
   if (*p == '-' || *p == '+') {
     p++;
     if (p == end)
       return createError("Exponent has no digits");
   }
 
-  absExponent = decDigitValue(*p++);
+  unsigned absExponent = decDigitValue(*p++);
   if (absExponent >= 10U)
     return createError("Invalid character in exponent");
 
   for (; p != end; ++p) {
-    unsigned int value;
-
-    value = decDigitValue(*p);
+    unsigned value = decDigitValue(*p);
     if (value >= 10U)
       return createError("Invalid character in exponent");
 
@@ -371,22 +366,20 @@ static Expected<int> readExponent(StringRef::iterator begin,
 static Expected<int> totalExponent(StringRef::iterator p,
                                    StringRef::iterator end,
                                    int exponentAdjustment) {
-  int unsignedExponent;
-  bool negative, overflow;
   int exponent = 0;
 
   if (p == end)
     return createError("Exponent has no digits");
 
-  negative = *p == '-';
+  bool negative = *p == '-';
   if (*p == '-' || *p == '+') {
     p++;
     if (p == end)
       return createError("Exponent has no digits");
   }
 
-  unsignedExponent = 0;
-  overflow = false;
+  int unsignedExponent = 0;
+  bool overflow = false;
   for (; p != end; ++p) {
     unsigned int value;
 
@@ -532,8 +525,6 @@ static Error interpretDecimal(StringRef::iterator begin,
 static Expected<lostFraction>
 trailingHexadecimalFraction(StringRef::iterator p, StringRef::iterator end,
                             unsigned int digitValue) {
-  unsigned int hexDigit;
-
   /* If the first trailing digit isn't 0 or 8 we can work out the
      fraction immediately.  */
   if (digitValue > 8)
@@ -548,7 +539,7 @@ trailingHexadecimalFraction(StringRef::iterator p, StringRef::iterator end,
   if (p == end)
     return createError("Invalid trailing hexadecimal fraction!");
 
-  hexDigit = hexDigitValue(*p);
+  unsigned hexDigit = hexDigitValue(*p);
 
   /* If we ran off the end it is exactly zero or one-half, otherwise
      a little more.  */
@@ -565,9 +556,7 @@ lostFractionThroughTruncation(const APFloatBase::integerPart *parts,
                               unsigned int partCount,
                               unsigned int bits)
 {
-  unsigned int lsb;
-
-  lsb = APInt::tcLSB(parts, partCount);
+  unsigned lsb = APInt::tcLSB(parts, partCount);
 
   /* Note this is guaranteed true if bits == 0, or LSB == UINT_MAX.  */
   if (bits <= lsb)
@@ -585,9 +574,7 @@ lostFractionThroughTruncation(const APFloatBase::integerPart *parts,
 static lostFraction
 shiftRight(APFloatBase::integerPart *dst, unsigned int parts, unsigned int bits)
 {
-  lostFraction lost_fraction;
-
-  lost_fraction = lostFractionThroughTruncation(dst, parts, bits);
+  lostFraction lost_fraction = lostFractionThroughTruncation(dst, parts, bits);
 
   APInt::tcShiftRight(dst, parts, bits);
 
@@ -633,17 +620,17 @@ HUerrBound(bool inexactMultiply, unsigned int HUerr1, unsigned int HUerr2)
 static APFloatBase::integerPart
 ulpsFromBoundary(const APFloatBase::integerPart *parts, unsigned int bits,
                  bool isNearest) {
-  unsigned int count, partBits;
-  APFloatBase::integerPart part, boundary;
-
   assert(bits != 0);
 
   bits--;
-  count = bits / APFloatBase::integerPartWidth;
-  partBits = bits % APFloatBase::integerPartWidth + 1;
+  unsigned count = bits / APFloatBase::integerPartWidth;
+  unsigned partBits = bits % APFloatBase::integerPartWidth + 1;
 
-  part = parts[count] & (~(APFloatBase::integerPart) 0 >> (APFloatBase::integerPartWidth - partBits));
+  APFloatBase::integerPart part =
+      parts[count] & (~(APFloatBase::integerPart)0 >>
+                      (APFloatBase::integerPartWidth - partBits));
 
+  APFloatBase::integerPart boundary;
   if (isNearest)
     boundary = (APFloatBase::integerPart) 1 << (partBits - 1);
   else
@@ -683,7 +670,6 @@ powerOf5(APFloatBase::integerPart *dst, unsigned int power) {
 
   unsigned int partsCount = 1;
   APFloatBase::integerPart scratch[maxPowerOfFiveParts], *p1, *p2, *pow5;
-  unsigned int result;
   assert(power <= maxExponent);
 
   p1 = dst;
@@ -692,7 +678,7 @@ powerOf5(APFloatBase::integerPart *dst, unsigned int power) {
   *p1 = firstEightPowers[power & 7];
   power >>= 3;
 
-  result = 1;
+  unsigned result = 1;
   pow5 = pow5s;
 
   for (unsigned int n = 0; power; power >>= 1, n++) {
@@ -759,9 +745,7 @@ partAsHex (char *dst, APFloatBase::integerPart part, unsigned int count,
 }
 
 /* Write out an unsigned decimal integer.  */
-static char *
-writeUnsignedDecimal (char *dst, unsigned int n)
-{
+static char *writeUnsignedDecimal(char *dst, unsigned int n) {
   char buff[40], *p;
 
   p = buff;
@@ -777,9 +761,7 @@ writeUnsignedDecimal (char *dst, unsigned int n)
 }
 
 /* Write out a signed decimal integer.  */
-static char *
-writeSignedDecimal (char *dst, int value)
-{
+static char *writeSignedDecimal(char *dst, int value) {
   if (value < 0) {
     *dst++ = '-';
     dst = writeUnsignedDecimal(dst, -(unsigned) value);
@@ -817,10 +799,8 @@ static APFloat harrisonUlp(const APFloat &X) {
 namespace detail {
 /* Constructors.  */
 void IEEEFloat::initialize(const fltSemantics *ourSemantics) {
-  unsigned int count;
-
   semantics = ourSemantics;
-  count = partCount();
+  unsigned count = partCount();
   if (count > 1)
     significand.parts = new integerPart[count];
 }
@@ -1164,20 +1144,16 @@ void IEEEFloat::zeroSignificand() {
 
 /* Increment an fcNormal floating point number's significand.  */
 void IEEEFloat::incrementSignificand() {
-  integerPart carry;
-
-  carry = APInt::tcIncrement(significandParts(), partCount());
+  [[maybe_unused]] integerPart carry =
+      APInt::tcIncrement(significandParts(), partCount());
 
   /* Our callers should never cause us to overflow.  */
   assert(carry == 0);
-  (void)carry;
 }
 
 /* Add the significand of the RHS.  Returns the carry flag.  */
 APFloat::integerPart IEEEFloat::addSignificand(const IEEEFloat &rhs) {
-  integerPart *parts;
-
-  parts = significandParts();
+  integerPart *parts = significandParts();
 
   assert(semantics == rhs.semantics);
   assert(exponent == rhs.exponent);
@@ -1189,9 +1165,7 @@ APFloat::integerPart IEEEFloat::addSignificand(const IEEEFloat &rhs) {
    the borrow flag.  */
 APFloat::integerPart IEEEFloat::subtractSignificand(const IEEEFloat &rhs,
                                                     integerPart borrow) {
-  integerPart *parts;
-
-  parts = significandParts();
+  integerPart *parts = significandParts();
 
   assert(semantics == rhs.semantics);
   assert(exponent == rhs.exponent);
@@ -1206,35 +1180,30 @@ APFloat::integerPart IEEEFloat::subtractSignificand(const IEEEFloat &rhs,
 lostFraction IEEEFloat::multiplySignificand(const IEEEFloat &rhs,
                                             IEEEFloat addend,
                                             bool ignoreAddend) {
-  unsigned int omsb;        // One, not zero, based MSB.
-  unsigned int partsCount, newPartsCount, precision;
-  integerPart *lhsSignificand;
   integerPart scratch[4];
-  integerPart *fullSignificand;
-  lostFraction lost_fraction;
   bool ignored;
 
   assert(semantics == rhs.semantics);
 
-  precision = semantics->precision;
+  unsigned precision = semantics->precision;
 
   // Allocate space for twice as many bits as the original significand, plus one
   // extra bit for the addition to overflow into.
-  newPartsCount = partCountForBits(precision * 2 + 1);
+  unsigned newPartsCount = partCountForBits(precision * 2 + 1);
 
-  if (newPartsCount > 4)
-    fullSignificand = new integerPart[newPartsCount];
-  else
-    fullSignificand = scratch;
+  // FIXME: Replace with SmallVector<4>.
+  integerPart *fullSignificand =
+      newPartsCount > 4 ? new integerPart[newPartsCount] : scratch;
 
-  lhsSignificand = significandParts();
-  partsCount = partCount();
+  integerPart *lhsSignificand = significandParts();
+  unsigned partsCount = partCount();
 
   APInt::tcFullMultiply(fullSignificand, lhsSignificand,
                         rhs.significandParts(), partsCount, partsCount);
 
-  lost_fraction = lfExactlyZero;
-  omsb = APInt::tcMSB(fullSignificand, newPartsCount) + 1;
+  lostFraction lost_fraction = lfExactlyZero;
+  // One, not zero, based MSB.
+  unsigned omsb = APInt::tcMSB(fullSignificand, newPartsCount) + 1;
   exponent += rhs.exponent;
 
   // Assume the operands involved in the multiplication are single-precision
@@ -1255,12 +1224,9 @@ lostFraction IEEEFloat::multiplySignificand(const IEEEFloat &rhs,
     //
     Significand savedSignificand = significand;
     const fltSemantics *savedSemantics = semantics;
-    fltSemantics extendedSemantics;
-    opStatus status;
-    unsigned int extendedPrecision;
 
     // Normalize our MSB to one below the top bit to allow for overflow.
-    extendedPrecision = 2 * precision + 1;
+    unsigned extendedPrecision = 2 * precision + 1;
     if (omsb != extendedPrecision - 1) {
       assert(extendedPrecision > omsb);
       APInt::tcShiftLeft(fullSignificand, newPartsCount,
@@ -1269,7 +1235,7 @@ lostFraction IEEEFloat::multiplySignificand(const IEEEFloat &rhs,
     }
 
     /* Create new semantics.  */
-    extendedSemantics = *semantics;
+    fltSemantics extendedSemantics = *semantics;
     extendedSemantics.precision = extendedPrecision;
 
     if (newPartsCount == 1)
@@ -1282,10 +1248,9 @@ lostFraction IEEEFloat::multiplySignificand(const IEEEFloat &rhs,
     // Note that we cannot convert the addend directly, as the extendedSemantics
     // is a local variable (which we take a reference to).
     IEEEFloat extendedAddend(addend);
-    status = extendedAddend.convert(extendedSemantics, APFloat::rmTowardZero,
-                                    &ignored);
+    [[maybe_unused]] opStatus status = extendedAddend.convert(
+        extendedSemantics, APFloat::rmTowardZero, &ignored);
     assert(status == APFloat::opOK);
-    (void)status;
 
     // Shift the significand of the addend right by one bit. This guarantees
     // that the high bit of the significand is zero (same as fullSignificand),
@@ -1348,27 +1313,20 @@ lostFraction IEEEFloat::multiplySignificand(const IEEEFloat &rhs) {
 
 /* Multiply the significands of LHS and RHS to DST.  */
 lostFraction IEEEFloat::divideSignificand(const IEEEFloat &rhs) {
-  unsigned int bit, i, partsCount;
-  const integerPart *rhsSignificand;
-  integerPart *lhsSignificand, *dividend, *divisor;
   integerPart scratch[4];
-  lostFraction lost_fraction;
 
   assert(semantics == rhs.semantics);
 
-  lhsSignificand = significandParts();
-  rhsSignificand = rhs.significandParts();
-  partsCount = partCount();
+  integerPart *lhsSignificand = significandParts();
+  const integerPart *rhsSignificand = rhs.significandParts();
+  unsigned partsCount = partCount();
 
-  if (partsCount > 2)
-    dividend = new integerPart[partsCount * 2];
-  else
-    dividend = scratch;
-
-  divisor = dividend + partsCount;
+  integerPart *dividend =
+      partsCount > 2 ? new integerPart[partsCount * 2] : scratch;
+  integerPart *divisor = dividend + partsCount;
 
   /* Copy the dividend and divisor as they will be modified in-place.  */
-  for (i = 0; i < partsCount; i++) {
+  for (unsigned i = 0; i < partsCount; i++) {
     dividend[i] = lhsSignificand[i];
     divisor[i] = rhsSignificand[i];
     lhsSignificand[i] = 0;
@@ -1379,7 +1337,7 @@ lostFraction IEEEFloat::divideSignificand(const IEEEFloat &rhs) {
   unsigned int precision = semantics->precision;
 
   /* Normalize the divisor.  */
-  bit = precision - APInt::tcMSB(divisor, partsCount) - 1;
+  unsigned bit = precision - APInt::tcMSB(divisor, partsCount) - 1;
   if (bit) {
     exponent += bit;
     APInt::tcShiftLeft(divisor, partsCount, bit);
@@ -1414,6 +1372,7 @@ lostFraction IEEEFloat::divideSignificand(const IEEEFloat &rhs) {
   /* Figure out the lost fraction.  */
   int cmp = APInt::tcCompare(dividend, divisor, partsCount);
 
+  lostFraction lost_fraction;
   if (cmp > 0)
     lost_fraction = lfMoreThanHalf;
   else if (cmp == 0)
@@ -1463,13 +1422,11 @@ void IEEEFloat::shiftSignificandLeft(unsigned int bits) {
 }
 
 APFloat::cmpResult IEEEFloat::compareAbsoluteValue(const IEEEFloat &rhs) const {
-  int compare;
-
   assert(semantics == rhs.semantics);
   assert(isFiniteNonZero());
   assert(rhs.isFiniteNonZero());
 
-  compare = exponent - rhs.exponent;
+  int compare = exponent - rhs.exponent;
 
   /* If exponents are equal, do an unsigned bignum comparison of the
      significands.  */
@@ -1576,21 +1533,19 @@ bool IEEEFloat::roundAwayFromZero(roundingMode rounding_mode,
 
 APFloat::opStatus IEEEFloat::normalize(roundingMode rounding_mode,
                                        lostFraction lost_fraction) {
-  unsigned int omsb;                /* One, not zero, based MSB.  */
-  int exponentChange;
-
   if (!isFiniteNonZero())
     return opOK;
 
   /* Before rounding normalize the exponent of fcNormal numbers.  */
-  omsb = significandMSB() + 1;
+  /* One, not zero, based MSB.  */
+  unsigned omsb = significandMSB() + 1;
 
   // Only skip this `if` if the value is exactly zero.
   if (omsb || lost_fraction != lfExactlyZero) {
     /* OMSB is numbered from 1.  We want to place it in the integer
        bit numbered PRECISION if possible, with a compensating change in
        the exponent.  */
-    exponentChange = omsb - semantics->precision;
+    int exponentChange = omsb - semantics->precision;
 
     /* If the resulting exponent is too high, overflow according to
        the rounding mode.  */
@@ -1768,16 +1723,15 @@ APFloat::opStatus IEEEFloat::addOrSubtractSpecials(const IEEEFloat &rhs,
 /* Add or subtract two normal numbers.  */
 lostFraction IEEEFloat::addOrSubtractSignificand(const IEEEFloat &rhs,
                                                  bool subtract) {
-  integerPart carry = 0;
+  [[maybe_unused]] integerPart carry = 0;
   lostFraction lost_fraction;
-  int bits;
 
   /* Determine if the operation on the absolute values is effectively
      an addition or subtraction.  */
   subtract ^= static_cast<bool>(sign ^ rhs.sign);
 
   /* Are we bigger exponent-wise than the RHS?  */
-  bits = exponent - rhs.exponent;
+  int bits = exponent - rhs.exponent;
 
   /* Subtraction is more subtle than one might naively expect.  */
   if (subtract) {
@@ -1837,7 +1791,6 @@ lostFraction IEEEFloat::addOrSubtractSignificand(const IEEEFloat &rhs,
     /* The code above is intended to ensure that no borrow is
        necessary.  */
     assert(!carry);
-    (void)carry;
   } else {
     if (bits > 0) {
       IEEEFloat temp_rhs(rhs);
@@ -1851,7 +1804,6 @@ lostFraction IEEEFloat::addOrSubtractSignificand(const IEEEFloat &rhs,
 
     /* We have a guard bit; generating a carry cannot happen.  */
     assert(!carry);
-    (void)carry;
   }
 
   return lost_fraction;
@@ -2041,9 +1993,7 @@ void IEEEFloat::changeSign() {
 APFloat::opStatus IEEEFloat::addOrSubtract(const IEEEFloat &rhs,
                                            roundingMode rounding_mode,
                                            bool subtract) {
-  opStatus fs;
-
-  fs = addOrSubtractSpecials(rhs, subtract);
+  opStatus fs = addOrSubtractSpecials(rhs, subtract);
 
   /* This return code means it was not a simple case.  */
   if (fs == opDivByZero) {
@@ -2085,10 +2035,8 @@ APFloat::opStatus IEEEFloat::subtract(const IEEEFloat &rhs,
 /* Normalized multiply.  */
 APFloat::opStatus IEEEFloat::multiply(const IEEEFloat &rhs,
                                       roundingMode rounding_mode) {
-  opStatus fs;
-
   sign ^= rhs.sign;
-  fs = multiplySpecials(rhs);
+  opStatus fs = multiplySpecials(rhs);
 
   if (isZero() && semantics->nanEncoding == fltNanEncoding::NegativeZero)
     sign = false;
@@ -2105,10 +2053,8 @@ APFloat::opStatus IEEEFloat::multiply(const IEEEFloat &rhs,
 /* Normalized divide.  */
 APFloat::opStatus IEEEFloat::divide(const IEEEFloat &rhs,
                                     roundingMode rounding_mode) {
-  opStatus fs;
-
   sign ^= rhs.sign;
-  fs = divideSpecials(rhs);
+  opStatus fs = divideSpecials(rhs);
 
   if (isZero() && semantics->nanEncoding == fltNanEncoding::NegativeZero)
     sign = false;
@@ -2124,11 +2070,10 @@ APFloat::opStatus IEEEFloat::divide(const IEEEFloat &rhs,
 
 /* Normalized remainder.  */
 APFloat::opStatus IEEEFloat::remainder(const IEEEFloat &rhs) {
-  opStatus fs;
   unsigned int origSign = sign;
 
   // First handle the special cases.
-  fs = remainderSpecials(rhs);
+  opStatus fs = remainderSpecials(rhs);
   if (fs != opDivByZero)
     return fs;
 
@@ -2225,17 +2170,15 @@ APFloat::opStatus IEEEFloat::remainder(const IEEEFloat &rhs) {
     if (semantics->nanEncoding == fltNanEncoding::NegativeZero)
       // But some 8-bit floats only have positive 0.
       sign = false;
-  }
-
-  else
+  } else {
     sign ^= origSign;
+  }
   return fs;
 }
 
 /* Normalized llvm frem (C fmod). */
 APFloat::opStatus IEEEFloat::mod(const IEEEFloat &rhs) {
-  opStatus fs;
-  fs = modSpecials(rhs);
+  opStatus fs = modSpecials(rhs);
   unsigned int origSign = sign;
 
   while (isFiniteNonZero() && rhs.isFiniteNonZero() &&
@@ -2318,8 +2261,6 @@ APFloat::opStatus IEEEFloat::fusedMultiplyAdd(const IEEEFloat &multiplicand,
 
 /* Rounding-mode correct round to integral value.  */
 APFloat::opStatus IEEEFloat::roundToIntegral(roundingMode rounding_mode) {
-  opStatus fs;
-
   if (isInfinity())
     // [IEEE Std 754-2008 6.1]:
     // The behavior of infinity in floating-point arithmetic is derived from the
@@ -2381,8 +2322,8 @@ APFloat::opStatus IEEEFloat::roundToIntegral(roundingMode rounding_mode) {
                         1);
   IntegerConstant <<= APFloat::semanticsPrecision(*semantics) - 1;
   IEEEFloat MagicConstant(*semantics);
-  fs = MagicConstant.convertFromAPInt(IntegerConstant, false,
-                                      rmNearestTiesToEven);
+  opStatus fs = MagicConstant.convertFromAPInt(IntegerConstant, false,
+                                               rmNearestTiesToEven);
   assert(fs == opOK);
   MagicConstant.sign = sign;
 
@@ -2405,8 +2346,6 @@ APFloat::opStatus IEEEFloat::roundToIntegral(roundingMode rounding_mode) {
 
 /* Comparison requires normalized numbers.  */
 APFloat::cmpResult IEEEFloat::compare(const IEEEFloat &rhs) const {
-  cmpResult result;
-
   assert(semantics == rhs.semantics);
 
   switch (PackCategoriesIntoKey(category, rhs.category)) {
@@ -2453,6 +2392,7 @@ APFloat::cmpResult IEEEFloat::compare(const IEEEFloat &rhs) const {
     break;
   }
 
+  cmpResult result;
   /* Two normal numbers.  Do they have the same sign?  */
   if (sign != rhs.sign) {
     if (sign)
@@ -2484,17 +2424,14 @@ APFloat::cmpResult IEEEFloat::compare(const IEEEFloat &rhs) const {
 APFloat::opStatus IEEEFloat::convert(const fltSemantics &toSemantics,
                                      roundingMode rounding_mode,
                                      bool *losesInfo) {
-  lostFraction lostFraction;
-  unsigned int newPartCount, oldPartCount;
   opStatus fs;
-  int shift;
   const fltSemantics &fromSemantics = *semantics;
   bool is_signaling = isSignaling();
 
-  lostFraction = lfExactlyZero;
-  newPartCount = partCountForBits(toSemantics.precision + 1);
-  oldPartCount = partCount();
-  shift = toSemantics.precision - fromSemantics.precision;
+  lostFraction lostFraction = lfExactlyZero;
+  unsigned newPartCount = partCountForBits(toSemantics.precision + 1);
+  unsigned oldPartCount = partCount();
+  int shift = toSemantics.precision - fromSemantics.precision;
 
   bool X86SpecialNan = false;
   if (&fromSemantics == &APFloatBase::semX87DoubleExtended &&
@@ -2631,17 +2568,13 @@ APFloat::opStatus IEEEFloat::convert(const fltSemantics &toSemantics,
 APFloat::opStatus IEEEFloat::convertToSignExtendedInteger(
     MutableArrayRef<integerPart> parts, unsigned int width, bool isSigned,
     roundingMode rounding_mode, bool *isExact) const {
-  lostFraction lost_fraction;
-  const integerPart *src;
-  unsigned int dstPartsCount, truncatedBits;
-
   *isExact = false;
 
   /* Handle the three special cases first.  */
   if (category == fcInfinity || category == fcNaN)
     return opInvalidOp;
 
-  dstPartsCount = partCountForBits(width);
+  unsigned dstPartsCount = partCountForBits(width);
   assert(dstPartsCount <= parts.size() && "Integer too big");
 
   if (category == fcZero) {
@@ -2651,8 +2584,9 @@ APFloat::opStatus IEEEFloat::convertToSignExtendedInteger(
     return opOK;
   }
 
-  src = significandParts();
+  const integerPart *src = significandParts();
 
+  unsigned truncatedBits;
   /* Step 1: place our absolute value, with any fraction truncated, in
      the destination.  */
   if (exponent < 0) {
@@ -2686,6 +2620,7 @@ APFloat::opStatus IEEEFloat::convertToSignExtendedInteger(
 
   /* Step 2: work out any lost fraction, and increment the absolute
      value if we would round away from zero.  */
+  lostFraction lost_fraction;
   if (truncatedBits) {
     lost_fraction = lostFractionThroughTruncation(src, partCount(),
                                                   truncatedBits);
@@ -2745,10 +2680,8 @@ APFloat::opStatus
 IEEEFloat::convertToInteger(MutableArrayRef<integerPart> parts,
                             unsigned int width, bool isSigned,
                             roundingMode rounding_mode, bool *isExact) const {
-  opStatus fs;
-
-  fs = convertToSignExtendedInteger(parts, width, isSigned, rounding_mode,
-                                    isExact);
+  opStatus fs = convertToSignExtendedInteger(parts, width, isSigned,
+                                             rounding_mode, isExact);
 
   if (fs == opInvalidOp) {
     unsigned int bits, dstPartsCount;
@@ -2776,18 +2709,15 @@ IEEEFloat::convertToInteger(MutableArrayRef<integerPart> parts,
    point number is not modified.  */
 APFloat::opStatus IEEEFloat::convertFromUnsignedParts(
     const integerPart *src, unsigned int srcCount, roundingMode rounding_mode) {
-  unsigned int omsb, precision, dstCount;
-  integerPart *dst;
-  lostFraction lost_fraction;
-
   category = fcNormal;
-  omsb = APInt::tcMSB(src, srcCount) + 1;
-  dst = significandParts();
-  dstCount = partCount();
-  precision = semantics->precision;
+  unsigned omsb = APInt::tcMSB(src, srcCount) + 1;
+  integerPart *dst = significandParts();
+  unsigned dstCount = partCount();
+  unsigned precision = semantics->precision;
 
   /* We want the most significant PRECISION bits of SRC.  There may not
      be that many; extract what we can.  */
+  lostFraction lost_fraction;
   if (precision <= omsb) {
     exponent = omsb - 1;
     lost_fraction = lostFractionThroughTruncation(src, srcCount,
@@ -2914,18 +2844,16 @@ APFloat::opStatus
 IEEEFloat::roundSignificandWithExponent(const integerPart *decSigParts,
                                         unsigned sigPartCount, int exp,
                                         roundingMode rounding_mode) {
-  unsigned int parts, pow5PartCount;
   fltSemantics calcSemantics = { 32767, -32767, 0, 0 };
   integerPart pow5Parts[maxPowerOfFiveParts];
-  bool isNearest;
 
-  isNearest = (rounding_mode == rmNearestTiesToEven ||
-               rounding_mode == rmNearestTiesToAway);
+  bool isNearest = rounding_mode == rmNearestTiesToEven ||
+                   rounding_mode == rmNearestTiesToAway;
 
-  parts = partCountForBits(semantics->precision + 11);
+  unsigned parts = partCountForBits(semantics->precision + 11);
 
   /* Calculate pow(5, abs(exp)).  */
-  pow5PartCount = powerOf5(pow5Parts, exp >= 0 ? exp: -exp);
+  unsigned pow5PartCount = powerOf5(pow5Parts, exp >= 0 ? exp : -exp);
 
   for (;; parts *= 2) {
     opStatus sigStatus, powStatus;
@@ -3247,9 +3175,7 @@ IEEEFloat::convertFromString(StringRef str, roundingMode rounding_mode) {
 unsigned int IEEEFloat::convertToHexString(char *dst, unsigned int hexDigits,
                                            bool upperCase,
                                            roundingMode rounding_mode) const {
-  char *p;
-
-  p = dst;
+  char *p = dst;
   if (sign)
     *dst++ = '-';
 
@@ -3294,29 +3220,23 @@ unsigned int IEEEFloat::convertToHexString(char *dst, unsigned int hexDigits,
 char *IEEEFloat::convertNormalToHexString(char *dst, unsigned int hexDigits,
                                           bool upperCase,
                                           roundingMode rounding_mode) const {
-  unsigned int count, valueBits, shift, partsCount, outputDigits;
-  const char *hexDigitChars;
-  const integerPart *significand;
-  char *p;
-  bool roundUp;
-
   *dst++ = '0';
   *dst++ = upperCase ? 'X': 'x';
 
-  roundUp = false;
-  hexDigitChars = upperCase ? hexDigitsUpper: hexDigitsLower;
+  bool roundUp = false;
+  const char *hexDigitChars = upperCase ? hexDigitsUpper : hexDigitsLower;
 
-  significand = significandParts();
-  partsCount = partCount();
+  const integerPart *significand = significandParts();
+  unsigned partsCount = partCount();
 
   /* +3 because the first digit only uses the single integer bit, so
      we have 3 virtual zero most-significant-bits.  */
-  valueBits = semantics->precision + 3;
-  shift = integerPartWidth - valueBits % integerPartWidth;
+  unsigned valueBits = semantics->precision + 3;
+  unsigned shift = integerPartWidth - valueBits % integerPartWidth;
 
   /* The natural number of digits required ignoring trailing
      insignificant zeroes.  */
-  outputDigits = (valueBits - significandLSB () + 3) / 4;
+  unsigned outputDigits = (valueBits - significandLSB() + 3) / 4;
 
   /* hexDigits of zero means use the required number for the
      precision.  Otherwise, see if we are truncating.  If we are,
@@ -3338,9 +3258,9 @@ char *IEEEFloat::convertNormalToHexString(char *dst, unsigned int hexDigits,
   /* Write the digits consecutively, and start writing in the location
      of the hexadecimal point.  We move the most significant digit
      left and add the hexadecimal point later.  */
-  p = ++dst;
+  char *p = ++dst;
 
-  count = (valueBits + integerPartWidth - 1) / integerPartWidth;
+  unsigned count = (valueBits + integerPartWidth - 1) / integerPartWidth;
 
   while (outputDigits && count) {
     integerPart part;
@@ -3453,7 +3373,6 @@ APInt IEEEFloat::convertPPCDoubleDoubleLegacyAPFloatToAPInt() const {
   assert(partCount()==2);
 
   uint64_t words[2];
-  opStatus fs;
   bool losesInfo;
 
   // Convert number to double.  To avoid spurious underflows, we re-
@@ -3465,14 +3384,13 @@ APInt IEEEFloat::convertPPCDoubleDoubleLegacyAPFloatToAPInt() const {
   fltSemantics extendedSemantics = *semantics;
   extendedSemantics.minExponent = APFloatBase::semIEEEdouble.minExponent;
   IEEEFloat extended(*this);
-  fs = extended.convert(extendedSemantics, rmNearestTiesToEven, &losesInfo);
+  [[maybe_unused]] opStatus fs =
+      extended.convert(extendedSemantics, rmNearestTiesToEven, &losesInfo);
   assert(fs == opOK && !losesInfo);
-  (void)fs;
 
   IEEEFloat u(extended);
   fs = u.convert(APFloatBase::semIEEEdouble, rmNearestTiesToEven, &losesInfo);
   assert(fs == opOK || fs == opInexact);
-  (void)fs;
   words[0] = *u.convertDoubleAPFloatToAPInt().getRawData();
 
   // If conversion was exact or resulted in a special case, we're done;
@@ -3482,13 +3400,11 @@ APInt IEEEFloat::convertPPCDoubleDoubleLegacyAPFloatToAPInt() const {
   if (u.isFiniteNonZero() && losesInfo) {
     fs = u.convert(extendedSemantics, rmNearestTiesToEven, &losesInfo);
     assert(fs == opOK && !losesInfo);
-    (void)fs;
 
     IEEEFloat v(extended);
     v.subtract(u, rmNearestTiesToEven);
     fs = v.convert(APFloatBase::semIEEEdouble, rmNearestTiesToEven, &losesInfo);
     assert(fs == opOK && !losesInfo);
-    (void)fs;
     words[1] = *v.convertDoubleAPFloatToAPInt().getRawData();
   } else {
     words[1] = 0;
@@ -3781,15 +3697,13 @@ void IEEEFloat::initFromF80LongDoubleAPInt(const APInt &api) {
 void IEEEFloat::initFromPPCDoubleDoubleLegacyAPInt(const APInt &api) {
   uint64_t i1 = api.getRawData()[0];
   uint64_t i2 = api.getRawData()[1];
-  opStatus fs;
   bool losesInfo;
 
   // Get the first double and convert to our format.
   initFromDoubleAPInt(APInt(64, i1));
-  fs = convert(APFloatBase::semPPCDoubleDoubleLegacy, rmNearestTiesToEven,
-               &losesInfo);
+  [[maybe_unused]] opStatus fs = convert(APFloatBase::semPPCDoubleDoubleLegacy,
+                                         rmNearestTiesToEven, &losesInfo);
   assert(fs == opOK && !losesInfo);
-  (void)fs;
 
   // Unless we have a special case, add in second double.
   if (isFiniteNonZero()) {
@@ -3797,7 +3711,6 @@ void IEEEFloat::initFromPPCDoubleDoubleLegacyAPInt(const APInt &api) {
     fs = v.convert(APFloatBase::semPPCDoubleDoubleLegacy, rmNearestTiesToEven,
                    &losesInfo);
     assert(fs == opOK && !losesInfo);
-    (void)fs;
 
     add(v, rmNearestTiesToEven);
   }
@@ -3811,7 +3724,7 @@ void IEEEFloat::initFromPPCDoubleDoubleLegacyAPInt(const APInt &api) {
 void IEEEFloat::initFromFloat8E8M0FNUAPInt(const APInt &api) {
   const uint64_t exponent_mask = 0xff;
   uint64_t val = api.getRawData()[0];
-  uint64_t myexponent = (val & exponent_mask);
+  uint64_t myexponent = val & exponent_mask;
 
   initialize(&APFloatBase::semFloat8E8M0FNU);
   assert(partCount() == 1);
@@ -3836,6 +3749,7 @@ void IEEEFloat::initFromFloat8E8M0FNUAPInt(const APInt &api) {
   category = fcNormal;
   exponent = myexponent - 127; // 127 is bias
 }
+
 template <const fltSemantics &S>
 void IEEEFloat::initFromIEEEAPInt(const APInt &api) {
   assert(api.getBitWidth() == S.sizeInBits);
@@ -4290,9 +4204,9 @@ namespace {
 
     // Check whether we should use scientific notation.
     bool FormatScientific;
-    if (!FormatMaxPadding)
+    if (!FormatMaxPadding) {
       FormatScientific = true;
-    else {
+    } else {
       if (exp >= 0) {
         // 765e3 --> 765000
         //              ^^^
@@ -6033,48 +5947,43 @@ APFloat::opStatus APFloat::convertToInteger(APSInt &result,
 }
 
 double APFloat::convertToDouble() const {
-  if (&getSemantics() ==
-      (const llvm::fltSemantics *)&APFloatBase::semIEEEdouble)
+  if (&getSemantics() == &APFloatBase::semIEEEdouble)
     return getIEEE().convertToDouble();
   assert(isRepresentableBy(getSemantics(), semIEEEdouble) &&
          "Float semantics is not representable by IEEEdouble");
   APFloat Temp = *this;
   bool LosesInfo;
-  opStatus St =
+  [[maybe_unused]] opStatus St =
       Temp.convert(APFloatBase::semIEEEdouble, rmNearestTiesToEven, &LosesInfo);
   assert(!(St & opInexact) && !LosesInfo && "Unexpected imprecision");
-  (void)St;
   return Temp.getIEEE().convertToDouble();
 }
 
 #ifdef HAS_IEE754_FLOAT128
 float128 APFloat::convertToQuad() const {
-  if (&getSemantics() == (const llvm::fltSemantics *)&APFloatBase::semIEEEquad)
+  if (&getSemantics() == &APFloatBase::semIEEEquad)
     return getIEEE().convertToQuad();
   assert(isRepresentableBy(getSemantics(), semIEEEquad) &&
          "Float semantics is not representable by IEEEquad");
   APFloat Temp = *this;
   bool LosesInfo;
-  opStatus St =
+  [[maybe_unused]] opStatus St =
       Temp.convert(APFloatBase::semIEEEquad, rmNearestTiesToEven, &LosesInfo);
   assert(!(St & opInexact) && !LosesInfo && "Unexpected imprecision");
-  (void)St;
   return Temp.getIEEE().convertToQuad();
 }
 #endif
 
 float APFloat::convertToFloat() const {
-  if (&getSemantics() ==
-      (const llvm::fltSemantics *)&APFloatBase::semIEEEsingle)
+  if (&getSemantics() == &APFloatBase::semIEEEsingle)
     return getIEEE().convertToFloat();
   assert(isRepresentableBy(getSemantics(), semIEEEsingle) &&
          "Float semantics is not representable by IEEEsingle");
   APFloat Temp = *this;
   bool LosesInfo;
-  opStatus St =
+  [[maybe_unused]] opStatus St =
       Temp.convert(APFloatBase::semIEEEsingle, rmNearestTiesToEven, &LosesInfo);
   assert(!(St & opInexact) && !LosesInfo && "Unexpected imprecision");
-  (void)St;
   return Temp.getIEEE().convertToFloat();
 }
 


### PR DESCRIPTION
Minor code cleanup: define variables at their first assignment as opposed to at the start of functions, and use `[[maybe_unused]]` for variables used in assert only.