### PR TITLE
[SPARC][IAS] Make 64-bit instructions available in 32-bit mode on V9

### DIFF
--- a/llvm/lib/Target/Sparc/Sparc.td
+++ b/llvm/lib/Target/Sparc/Sparc.td
@@ -20,6 +20,30 @@ include "llvm/TableGen/SearchableTable.td"
 // SPARC Subtarget features.
 //
 
+// Some words about SPARC ISA versions and feature levels:
+// - V7: The first public version, used in some early Sun 4 models. Lacks integer
+//       multiply and divide in hardware, and doesn't have a formal memory model,
+//       though in practice the few multiprocessor machines that do exist
+//       are sequentially consistent.
+// - V8: Adds hardware multiply and divide, and formally defines TSO and PSO
+//       memory models. Most 32-bit chips currently used are of this version.
+// - V9: Adds 64-bit capability and RMO memory model, aside from new instructions.
+//       Note that unlike most other architectures, instructions that operate
+//       on 64-bit registers (e.g casx) are still available even in 32-bit ILP32
+//       mode - the G/O registers are always 64-bit regardless of runtime bitness.
+//       To let compilers take advantage of this feature, Sun defined an extension
+//       to the 32-bit ABI called V8+. It's still possible, though, to compile for
+//       V9 ISA level while not emitting any of the 64-bit instructions, that is
+//       why -mv8plus is defined separately from the usual -mcpu flags.
+//       (OTOH, the combination of `-mcpu=v8 -mv8plus` is effectively a no-op)
+//
+// As for memory models, the ordering from weakest to strongest is as follows:
+// (weaker) RMO -> PSO -> TSO -> SC (stronger)
+// Those are defined in such a way that code compiled for a weaker model will
+// run fine on processors that only implements a stronger model.
+// This is the route that we take in LLVM; compile for RMO when targeting v9,
+// and PSO when targeting v7/v8.
+
 def FeatureSoftMulDiv
   : SubtargetFeature<"soft-mul-div", "UseSoftMulDiv", "true",
                      "Use software emulation for integer multiply and divide">;

--- a/llvm/lib/Target/Sparc/Sparc.td
+++ b/llvm/lib/Target/Sparc/Sparc.td
@@ -43,6 +43,14 @@ include "llvm/TableGen/SearchableTable.td"
 // run fine on processors that only implements a stronger model.
 // This is the route that we take in LLVM; compile for RMO when targeting v9,
 // and PSO when targeting v7/v8.
+//
+// As for triples, Linux/BSD and Solaris follows different conventions:
+// Linux/BSD name | Solaris name | Meaning
+// ---------------|--------------|-------------
+// sparc-*-*      | sparc-*-*    | 32-bit SPARC
+// sparc64-*-*    | sparcv9-*-*  | 64-bit SPARC
+// Rather confusingly, Solaris calls the 64-bit triple "sparcv9".
+// LLVM accepts both sparc64- and sparcv9- forms for triples.
 
 def FeatureSoftMulDiv
   : SubtargetFeature<"soft-mul-div", "UseSoftMulDiv", "true",

--- a/llvm/lib/Target/Sparc/Sparc.td
+++ b/llvm/lib/Target/Sparc/Sparc.td
@@ -41,8 +41,8 @@ include "llvm/TableGen/SearchableTable.td"
 // (weaker) RMO -> PSO -> TSO -> SC (stronger)
 // Those are defined in such a way that code compiled for a weaker model will
 // run fine on processors that only implements a stronger model.
-// This is the route that we take in LLVM; compile for RMO when targeting v9,
-// and PSO when targeting v7/v8.
+// For simplcity, LLVM targets the weakest model available in a particular
+// ISA version: RMO for v9, and PSO for v7/v8.
 //
 // As for triples, Linux/BSD and Solaris follows different conventions:
 // Linux/BSD name | Solaris name | Meaning
@@ -50,7 +50,7 @@ include "llvm/TableGen/SearchableTable.td"
 // sparc-*-*      | sparc-*-*    | 32-bit SPARC
 // sparc64-*-*    | sparcv9-*-*  | 64-bit SPARC
 // Rather confusingly, Solaris calls the 64-bit triple "sparcv9".
-// LLVM accepts both sparc64- and sparcv9- forms for triples.
+// LLVM accepts both sparc64- and sparcv9- forms for 64-bit triples.
 
 def FeatureSoftMulDiv
   : SubtargetFeature<"soft-mul-div", "UseSoftMulDiv", "true",

--- a/llvm/lib/Target/Sparc/SparcInstr64Bit.td
+++ b/llvm/lib/Target/Sparc/SparcInstr64Bit.td
@@ -317,7 +317,7 @@ def FMOVD_XCC : F4_3<0b110101, 0b000010, (outs DFPRegs:$rd),
                       "fmovd$cond %xcc, $rs2, $rd",
                       [(set f64:$rd,
                        (SPselectxcc f64:$rs2, f64:$f, imm:$cond))]>;
-let Predicates = [Is64Bit, HasHardQuad] in
+let append Predicates = [HasHardQuad] in
 def FMOVQ_XCC : F4_3<0b110101, 0b000011, (outs QFPRegs:$rd),
                       (ins QFPRegs:$rs2, QFPRegs:$f, CCOp:$cond),
                       "fmovq$cond %xcc, $rs2, $rd",
@@ -374,7 +374,7 @@ let Predicates = [HasV9], Constraints = "$f = $rd" in {
                 (outs DFPRegs:$rd), (ins I64Regs:$rs1, DFPRegs:$rs2, DFPRegs:$f, RegCCOp:$rcond),
                 "fmovrd$rcond $rs1, $rs2, $rd",
                 [(set f64:$rd, (SPselectreg f64:$rs2, f64:$f, imm:$rcond, i64:$rs1))]>;
-  let Predicates = [HasHardQuad] in
+  let append Predicates = [HasHardQuad] in
   def FMOVRQ : F4_4r<0b110101, 0b00111,
                 (outs QFPRegs:$rd), (ins I64Regs:$rs1, QFPRegs:$rs2, QFPRegs:$f, RegCCOp:$rcond),
                 "fmovrq$rcond $rs1, $rs2, $rd",
@@ -395,7 +395,7 @@ def FXTOD : F3_3u<2, 0b110100, 0b010001000,
                  (outs DFPRegs:$rd), (ins DFPRegs:$rs2),
                  "fxtod $rs2, $rd",
                  [(set DFPRegs:$rd, (SPxtof DFPRegs:$rs2))]>;
-let Predicates = [HasHardQuad] in
+let append Predicates = [HasHardQuad] in
 def FXTOQ : F3_3u<2, 0b110100, 0b010001100,
                  (outs QFPRegs:$rd), (ins DFPRegs:$rs2),
                  "fxtoq $rs2, $rd",
@@ -409,7 +409,7 @@ def FDTOX : F3_3u<2, 0b110100, 0b010000010,
                  (outs DFPRegs:$rd), (ins DFPRegs:$rs2),
                  "fdtox $rs2, $rd",
                  [(set DFPRegs:$rd, (SPftox DFPRegs:$rs2))]>;
-let Predicates = [HasHardQuad] in
+let append Predicates = [HasHardQuad] in
 def FQTOX : F3_3u<2, 0b110100, 0b010000011,
                  (outs DFPRegs:$rd), (ins QFPRegs:$rs2),
                  "fqtox $rs2, $rd",

--- a/llvm/lib/Target/Sparc/SparcInstr64Bit.td
+++ b/llvm/lib/Target/Sparc/SparcInstr64Bit.td
@@ -230,7 +230,7 @@ defm LDSW   : LoadA<"ldsw", 0b001000, 0b011000, sextloadi32, I64Regs, i64>;
 // 64-bit stores.
 defm STX    : StoreA<"stx", 0b001110, 0b011110, store, I64Regs, i64>;
 
-} // Predicates = [Is64Bit]
+} // Predicates = [HasV9]
 
 let Predicates = [Is64Bit] in {
 

--- a/llvm/lib/Target/Sparc/SparcInstr64Bit.td
+++ b/llvm/lib/Target/Sparc/SparcInstr64Bit.td
@@ -286,6 +286,48 @@ def : Pat<(store (i64 0), ADDRri:$dst), (STXri ADDRri:$dst, (i64 G0))>;
 // We reuse CMPICC SDNodes for compares, but use new BPXCC branch nodes for
 // 64-bit compares. See LowerBR_CC.
 
+let Predicates = [Is64Bit] in {
+
+let Uses = [ICC], cc = 0b10 in
+  defm BPX : IPredBranch<"%xcc", [(SPbpxcc bb:$imm19, imm:$cond)]>;
+
+// Conditional moves on %xcc.
+let Uses = [ICC], Constraints = "$f = $rd" in {
+let intcc = 1, cc = 0b10 in {
+def MOVXCCrr : F4_1<0b101100, (outs IntRegs:$rd),
+                      (ins IntRegs:$rs2, IntRegs:$f, CCOp:$cond),
+                      "mov$cond %xcc, $rs2, $rd",
+                      [(set i32:$rd,
+                       (SPselectxcc i32:$rs2, i32:$f, imm:$cond))]>;
+def MOVXCCri : F4_2<0b101100, (outs IntRegs:$rd),
+                      (ins i32imm:$simm11, IntRegs:$f, CCOp:$cond),
+                      "mov$cond %xcc, $simm11, $rd",
+                      [(set i32:$rd,
+                       (SPselectxcc simm11:$simm11, i32:$f, imm:$cond))]>;
+} // cc
+
+let intcc = 1, opf_cc = 0b10 in {
+def FMOVS_XCC : F4_3<0b110101, 0b000001, (outs FPRegs:$rd),
+                      (ins FPRegs:$rs2, FPRegs:$f, CCOp:$cond),
+                      "fmovs$cond %xcc, $rs2, $rd",
+                      [(set f32:$rd,
+                       (SPselectxcc f32:$rs2, f32:$f, imm:$cond))]>;
+def FMOVD_XCC : F4_3<0b110101, 0b000010, (outs DFPRegs:$rd),
+                      (ins DFPRegs:$rs2, DFPRegs:$f, CCOp:$cond),
+                      "fmovd$cond %xcc, $rs2, $rd",
+                      [(set f64:$rd,
+                       (SPselectxcc f64:$rs2, f64:$f, imm:$cond))]>;
+let Predicates = [Is64Bit, HasHardQuad] in
+def FMOVQ_XCC : F4_3<0b110101, 0b000011, (outs QFPRegs:$rd),
+                      (ins QFPRegs:$rs2, QFPRegs:$f, CCOp:$cond),
+                      "fmovq$cond %xcc, $rs2, $rd",
+                      [(set f128:$rd,
+                       (SPselectxcc f128:$rs2, f128:$f, imm:$cond))]>;
+} // opf_cc
+} // Uses, Constraints
+
+} // Predicates = [Is64Bit]
+
 // Branch On integer register with Prediction (BPr).
 let isBranch = 1, isTerminator = 1, hasDelaySlot = 1 in
 multiclass BranchOnReg<list<dag> CCPattern> {
@@ -339,68 +381,6 @@ let Predicates = [HasV9], Constraints = "$f = $rd" in {
                 [(set f128:$rd, (SPselectreg f128:$rs2, f128:$f, imm:$rcond, i64:$rs1))]>;
 }
 
-let Predicates = [Is64Bit] in {
-
-let Uses = [ICC], cc = 0b10 in
-  defm BPX : IPredBranch<"%xcc", [(SPbpxcc bb:$imm19, imm:$cond)]>;
-
-// Conditional moves on %xcc.
-let Uses = [ICC], Constraints = "$f = $rd" in {
-let intcc = 1, cc = 0b10 in {
-def MOVXCCrr : F4_1<0b101100, (outs IntRegs:$rd),
-                      (ins IntRegs:$rs2, IntRegs:$f, CCOp:$cond),
-                      "mov$cond %xcc, $rs2, $rd",
-                      [(set i32:$rd,
-                       (SPselectxcc i32:$rs2, i32:$f, imm:$cond))]>;
-def MOVXCCri : F4_2<0b101100, (outs IntRegs:$rd),
-                      (ins i32imm:$simm11, IntRegs:$f, CCOp:$cond),
-                      "mov$cond %xcc, $simm11, $rd",
-                      [(set i32:$rd,
-                       (SPselectxcc simm11:$simm11, i32:$f, imm:$cond))]>;
-} // cc
-
-let intcc = 1, opf_cc = 0b10 in {
-def FMOVS_XCC : F4_3<0b110101, 0b000001, (outs FPRegs:$rd),
-                      (ins FPRegs:$rs2, FPRegs:$f, CCOp:$cond),
-                      "fmovs$cond %xcc, $rs2, $rd",
-                      [(set f32:$rd,
-                       (SPselectxcc f32:$rs2, f32:$f, imm:$cond))]>;
-def FMOVD_XCC : F4_3<0b110101, 0b000010, (outs DFPRegs:$rd),
-                      (ins DFPRegs:$rs2, DFPRegs:$f, CCOp:$cond),
-                      "fmovd$cond %xcc, $rs2, $rd",
-                      [(set f64:$rd,
-                       (SPselectxcc f64:$rs2, f64:$f, imm:$cond))]>;
-let Predicates = [Is64Bit, HasHardQuad] in
-def FMOVQ_XCC : F4_3<0b110101, 0b000011, (outs QFPRegs:$rd),
-                      (ins QFPRegs:$rs2, QFPRegs:$f, CCOp:$cond),
-                      "fmovq$cond %xcc, $rs2, $rd",
-                      [(set f128:$rd,
-                       (SPselectxcc f128:$rs2, f128:$f, imm:$cond))]>;
-} // opf_cc
-} // Uses, Constraints
-
-def : Pat<(SPselectxcc i64:$t, i64:$f, imm:$cond),
-          (MOVXCCrr $t, $f, imm:$cond)>;
-def : Pat<(SPselectxcc (i64 simm11:$t), i64:$f, imm:$cond),
-          (MOVXCCri (as_i32imm $t), $f, imm:$cond)>;
-
-def : Pat<(SPselecticc i64:$t, i64:$f, imm:$cond),
-          (MOVICCrr $t, $f, imm:$cond)>;
-def : Pat<(SPselecticc (i64 simm11:$t), i64:$f, imm:$cond),
-          (MOVICCri (as_i32imm $t), $f, imm:$cond)>;
-
-def : Pat<(SPselectfcc i64:$t, i64:$f, imm:$cond),
-          (MOVFCCrr $t, $f, imm:$cond)>;
-def : Pat<(SPselectfcc (i64 simm11:$t), i64:$f, imm:$cond),
-          (MOVFCCri (as_i32imm $t), $f, imm:$cond)>;
-
-def : Pat<(SPselectreg i64:$t, i64:$f, imm:$rcond, i64:$rs1),
-          (MOVRrr $rs1, $t, $f, imm:$rcond)>;
-def : Pat<(SPselectreg (i64 simm10:$t), i64:$f, imm:$rcond, i64:$rs1),
-          (MOVRri $rs1, (as_i32imm $t), $f, imm:$rcond)>;
-
-} // Predicates = [Is64Bit]
-
 //===----------------------------------------------------------------------===//
 // 64-bit Floating Point Conversions.
 //===----------------------------------------------------------------------===//
@@ -436,6 +416,29 @@ def FQTOX : F3_3u<2, 0b110100, 0b010000011,
                  [(set DFPRegs:$rd, (SPftox QFPRegs:$rs2))]>;
 
 } // Predicates = [HasV9]
+
+// Conditional move patterns.
+let Predicates = [Is64Bit] in {
+def : Pat<(SPselectxcc i64:$t, i64:$f, imm:$cond),
+          (MOVXCCrr $t, $f, imm:$cond)>;
+def : Pat<(SPselectxcc (i64 simm11:$t), i64:$f, imm:$cond),
+          (MOVXCCri (as_i32imm $t), $f, imm:$cond)>;
+
+def : Pat<(SPselecticc i64:$t, i64:$f, imm:$cond),
+          (MOVICCrr $t, $f, imm:$cond)>;
+def : Pat<(SPselecticc (i64 simm11:$t), i64:$f, imm:$cond),
+          (MOVICCri (as_i32imm $t), $f, imm:$cond)>;
+
+def : Pat<(SPselectfcc i64:$t, i64:$f, imm:$cond),
+          (MOVFCCrr $t, $f, imm:$cond)>;
+def : Pat<(SPselectfcc (i64 simm11:$t), i64:$f, imm:$cond),
+          (MOVFCCri (as_i32imm $t), $f, imm:$cond)>;
+
+def : Pat<(SPselectreg i64:$t, i64:$f, imm:$rcond, i64:$rs1),
+          (MOVRrr $rs1, $t, $f, imm:$rcond)>;
+def : Pat<(SPselectreg (i64 simm10:$t), i64:$f, imm:$rcond, i64:$rs1),
+          (MOVRri $rs1, (as_i32imm $t), $f, imm:$rcond)>;
+} // Predicates = [Is64Bit]
 
 // ATOMICS.
 let Predicates = [HasV9], Constraints = "$swap = $rd" in {

--- a/llvm/lib/Target/Sparc/SparcInstr64Bit.td
+++ b/llvm/lib/Target/Sparc/SparcInstr64Bit.td
@@ -42,12 +42,15 @@ def : Pat<(i64 (sext i32:$val)), (SRAri $val, 0)>;
 def : Pat<(i64 (and i64:$val, 0xffffffff)), (SRLri $val, 0)>;
 def : Pat<(i64 (sext_inreg i64:$val, i32)), (SRAri $val, 0)>;
 
+} // Predicates = [Is64Bit]
+
+let Predicates = [HasV9] in {
+
 defm SLLX : F3_S<"sllx", 0b100101, 1, shl, i64, shift_imm6, I64Regs>;
 defm SRLX : F3_S<"srlx", 0b100110, 1, srl, i64, shift_imm6, I64Regs>;
 defm SRAX : F3_S<"srax", 0b100111, 1, sra, i64, shift_imm6, I64Regs>;
 
-} // Predicates = [Is64Bit]
-
+} // Predicates = [HasV9]
 
 //===----------------------------------------------------------------------===//
 // 64-bit Immediates.
@@ -179,7 +182,7 @@ def : Pat<(i64 (ctpop i64:$src)), (POPCrr $src)>;
 // 64-bit Integer Multiply and Divide.
 //===----------------------------------------------------------------------===//
 
-let Predicates = [Is64Bit] in {
+let Predicates = [HasV9] in {
 defm MULX    : F3_12<"mulx", 0b001001, mul, I64Regs, i64, i64imm>;
 
 // Division can trap.
@@ -187,7 +190,7 @@ let hasSideEffects = 1 in {
 defm SDIVX    : F3_12<"sdivx", 0b101101, sdiv, I64Regs, i64, i64imm>;
 defm UDIVX    : F3_12<"udivx", 0b001101, udiv, I64Regs, i64, i64imm>;
 } // hasSideEffects = 1
-} // Predicates = [Is64Bit]
+} // Predicates = [HasV9]
 
 
 //===----------------------------------------------------------------------===//
@@ -201,7 +204,7 @@ defm UDIVX    : F3_12<"udivx", 0b001101, udiv, I64Regs, i64, i64imm>;
 //
 // SPARC v9 adds 64-bit loads as well as a sign-extending ldsw i32 loads.
 
-let Predicates = [Is64Bit] in {
+let Predicates = [HasV9] in {
 
 // 64-bit loads.
 defm LDX   : LoadA<"ldx", 0b001011, 0b011011, load, I64Regs, i64>;
@@ -220,6 +223,16 @@ let mayLoad = 1, isAsmParserOnly = 1 in {
                        [(set i64:$rd,
                            (load_gdop ADDRrr:$addr, tglobaladdr:$sym))]>;
 }
+
+// Sign-extending load of i32 into i64 is a new SPARC v9 instruction.
+defm LDSW   : LoadA<"ldsw", 0b001000, 0b011000, sextloadi32, I64Regs, i64>;
+
+// 64-bit stores.
+defm STX    : StoreA<"stx", 0b001110, 0b011110, store, I64Regs, i64>;
+
+} // Predicates = [Is64Bit]
+
+let Predicates = [Is64Bit] in {
 
 // Extending loads to i64.
 def : Pat<(i64 (zextloadi1 ADDRrr:$addr)), (LDUBrr ADDRrr:$addr)>;
@@ -245,12 +258,6 @@ def : Pat<(i64 (zextloadi32 ADDRrr:$addr)), (LDrr ADDRrr:$addr)>;
 def : Pat<(i64 (zextloadi32 ADDRri:$addr)), (LDri ADDRri:$addr)>;
 def : Pat<(i64 (extloadi32 ADDRrr:$addr)),  (LDrr ADDRrr:$addr)>;
 def : Pat<(i64 (extloadi32 ADDRri:$addr)),  (LDri ADDRri:$addr)>;
-
-// Sign-extending load of i32 into i64 is a new SPARC v9 instruction.
-defm LDSW   : LoadA<"ldsw", 0b001000, 0b011000, sextloadi32, I64Regs, i64>;
-
-// 64-bit stores.
-defm STX    : StoreA<"stx", 0b001110, 0b011110, store, I64Regs, i64>;
 
 // Truncating stores from i64 are identical to the i32 stores.
 def : Pat<(truncstorei8  i64:$src, ADDRrr:$addr), (STBrr ADDRrr:$addr, $src)>;
@@ -278,6 +285,59 @@ def : Pat<(store (i64 0), ADDRri:$dst), (STXri ADDRri:$dst, (i64 G0))>;
 //
 // We reuse CMPICC SDNodes for compares, but use new BPXCC branch nodes for
 // 64-bit compares. See LowerBR_CC.
+
+// Branch On integer register with Prediction (BPr).
+let isBranch = 1, isTerminator = 1, hasDelaySlot = 1 in
+multiclass BranchOnReg<list<dag> CCPattern> {
+  def R    : F2_4<0, 1, (outs), (ins bprtarget16:$imm16, RegCCOp:$rcond, I64Regs:$rs1),
+             "br$rcond $rs1, $imm16", CCPattern>;
+  def RA   : F2_4<1, 1, (outs), (ins bprtarget16:$imm16, RegCCOp:$rcond, I64Regs:$rs1),
+             "br$rcond,a $rs1, $imm16", []>;
+  def RNT  : F2_4<0, 0, (outs), (ins bprtarget16:$imm16, RegCCOp:$rcond, I64Regs:$rs1),
+             "br$rcond,pn $rs1, $imm16", []>;
+  def RANT : F2_4<1, 0, (outs), (ins bprtarget16:$imm16, RegCCOp:$rcond, I64Regs:$rs1),
+             "br$rcond,a,pn $rs1, $imm16", []>;
+}
+
+multiclass bpr_alias<string OpcStr, Instruction NAPT, Instruction APT> {
+  def : InstAlias<!strconcat(OpcStr, ",pt $rs1, $imm16"),
+                  (NAPT I64Regs:$rs1, bprtarget16:$imm16), 0>;
+  def : InstAlias<!strconcat(OpcStr, ",a,pt $rs1, $imm16"),
+                  (APT I64Regs:$rs1, bprtarget16:$imm16), 0>;
+}
+
+let Predicates = [HasV9] in
+  defm BP : BranchOnReg<[(SPbrreg bb:$imm16, imm:$rcond, i64:$rs1)]>;
+
+// Move integer register on register condition (MOVr).
+let Predicates = [HasV9], Constraints = "$f = $rd" in {
+  def MOVRrr : F4_4r<0b101111, 0b00000, (outs IntRegs:$rd),
+                   (ins I64Regs:$rs1, IntRegs:$rs2, IntRegs:$f, RegCCOp:$rcond),
+                   "movr$rcond $rs1, $rs2, $rd",
+                   [(set i32:$rd, (SPselectreg i32:$rs2, i32:$f, imm:$rcond, i64:$rs1))]>;
+
+  def MOVRri : F4_4i<0b101111, (outs IntRegs:$rd),
+                   (ins I64Regs:$rs1, i32imm:$simm10, IntRegs:$f, RegCCOp:$rcond),
+                   "movr$rcond $rs1, $simm10, $rd",
+                   [(set i32:$rd, (SPselectreg simm10:$simm10, i32:$f, imm:$rcond, i64:$rs1))]>;
+}
+
+// Move FP register on integer register condition (FMOVr).
+let Predicates = [HasV9], Constraints = "$f = $rd" in {
+  def FMOVRS : F4_4r<0b110101, 0b00101,
+                (outs FPRegs:$rd), (ins I64Regs:$rs1, FPRegs:$rs2, FPRegs:$f,  RegCCOp:$rcond),
+                "fmovrs$rcond $rs1, $rs2, $rd",
+                [(set f32:$rd, (SPselectreg f32:$rs2, f32:$f, imm:$rcond, i64:$rs1))]>;
+  def FMOVRD : F4_4r<0b110101, 0b00110,
+                (outs DFPRegs:$rd), (ins I64Regs:$rs1, DFPRegs:$rs2, DFPRegs:$f, RegCCOp:$rcond),
+                "fmovrd$rcond $rs1, $rs2, $rd",
+                [(set f64:$rd, (SPselectreg f64:$rs2, f64:$f, imm:$rcond, i64:$rs1))]>;
+  let Predicates = [HasHardQuad] in
+  def FMOVRQ : F4_4r<0b110101, 0b00111,
+                (outs QFPRegs:$rd), (ins I64Regs:$rs1, QFPRegs:$rs2, QFPRegs:$f, RegCCOp:$rcond),
+                "fmovrq$rcond $rs1, $rs2, $rd",
+                [(set f128:$rd, (SPselectreg f128:$rs2, f128:$f, imm:$rcond, i64:$rs1))]>;
+}
 
 let Predicates = [Is64Bit] in {
 
@@ -319,95 +379,6 @@ def FMOVQ_XCC : F4_3<0b110101, 0b000011, (outs QFPRegs:$rd),
 } // opf_cc
 } // Uses, Constraints
 
-// Branch On integer register with Prediction (BPr).
-let isBranch = 1, isTerminator = 1, hasDelaySlot = 1 in
-multiclass BranchOnReg<list<dag> CCPattern> {
-  def R    : F2_4<0, 1, (outs), (ins bprtarget16:$imm16, RegCCOp:$rcond, I64Regs:$rs1),
-             "br$rcond $rs1, $imm16", CCPattern>;
-  def RA   : F2_4<1, 1, (outs), (ins bprtarget16:$imm16, RegCCOp:$rcond, I64Regs:$rs1),
-             "br$rcond,a $rs1, $imm16", []>;
-  def RNT  : F2_4<0, 0, (outs), (ins bprtarget16:$imm16, RegCCOp:$rcond, I64Regs:$rs1),
-             "br$rcond,pn $rs1, $imm16", []>;
-  def RANT : F2_4<1, 0, (outs), (ins bprtarget16:$imm16, RegCCOp:$rcond, I64Regs:$rs1),
-             "br$rcond,a,pn $rs1, $imm16", []>;
-}
-
-multiclass bpr_alias<string OpcStr, Instruction NAPT, Instruction APT> {
-  def : InstAlias<!strconcat(OpcStr, ",pt $rs1, $imm16"),
-                  (NAPT I64Regs:$rs1, bprtarget16:$imm16), 0>;
-  def : InstAlias<!strconcat(OpcStr, ",a,pt $rs1, $imm16"),
-                  (APT I64Regs:$rs1, bprtarget16:$imm16), 0>;
-}
-
-let Predicates = [Is64Bit] in
-  defm BP : BranchOnReg<[(SPbrreg bb:$imm16, imm:$rcond, i64:$rs1)]>;
-
-// Move integer register on register condition (MOVr).
-let Predicates = [Is64Bit], Constraints = "$f = $rd" in {
-  def MOVRrr : F4_4r<0b101111, 0b00000, (outs IntRegs:$rd),
-                   (ins I64Regs:$rs1, IntRegs:$rs2, IntRegs:$f, RegCCOp:$rcond),
-                   "movr$rcond $rs1, $rs2, $rd",
-                   [(set i32:$rd, (SPselectreg i32:$rs2, i32:$f, imm:$rcond, i64:$rs1))]>;
-
-  def MOVRri : F4_4i<0b101111, (outs IntRegs:$rd),
-                   (ins I64Regs:$rs1, i32imm:$simm10, IntRegs:$f, RegCCOp:$rcond),
-                   "movr$rcond $rs1, $simm10, $rd",
-                   [(set i32:$rd, (SPselectreg simm10:$simm10, i32:$f, imm:$rcond, i64:$rs1))]>;
-}
-
-// Move FP register on integer register condition (FMOVr).
-let Predicates = [Is64Bit], Constraints = "$f = $rd" in {
-  def FMOVRS : F4_4r<0b110101, 0b00101,
-                (outs FPRegs:$rd), (ins I64Regs:$rs1, FPRegs:$rs2, FPRegs:$f,  RegCCOp:$rcond),
-                "fmovrs$rcond $rs1, $rs2, $rd",
-                [(set f32:$rd, (SPselectreg f32:$rs2, f32:$f, imm:$rcond, i64:$rs1))]>;
-  def FMOVRD : F4_4r<0b110101, 0b00110,
-                (outs DFPRegs:$rd), (ins I64Regs:$rs1, DFPRegs:$rs2, DFPRegs:$f, RegCCOp:$rcond),
-                "fmovrd$rcond $rs1, $rs2, $rd",
-                [(set f64:$rd, (SPselectreg f64:$rs2, f64:$f, imm:$rcond, i64:$rs1))]>;
-  let Predicates = [HasHardQuad] in
-  def FMOVRQ : F4_4r<0b110101, 0b00111,
-                (outs QFPRegs:$rd), (ins I64Regs:$rs1, QFPRegs:$rs2, QFPRegs:$f, RegCCOp:$rcond),
-                "fmovrq$rcond $rs1, $rs2, $rd",
-                [(set f128:$rd, (SPselectreg f128:$rs2, f128:$f, imm:$rcond, i64:$rs1))]>;
-}
-
-//===----------------------------------------------------------------------===//
-// 64-bit Floating Point Conversions.
-//===----------------------------------------------------------------------===//
-
-let Predicates = [Is64Bit] in {
-
-def FXTOS : F3_3u<2, 0b110100, 0b010000100,
-                 (outs FPRegs:$rd), (ins DFPRegs:$rs2),
-                 "fxtos $rs2, $rd",
-                 [(set FPRegs:$rd, (SPxtof DFPRegs:$rs2))]>;
-def FXTOD : F3_3u<2, 0b110100, 0b010001000,
-                 (outs DFPRegs:$rd), (ins DFPRegs:$rs2),
-                 "fxtod $rs2, $rd",
-                 [(set DFPRegs:$rd, (SPxtof DFPRegs:$rs2))]>;
-let Predicates = [Is64Bit, HasHardQuad] in
-def FXTOQ : F3_3u<2, 0b110100, 0b010001100,
-                 (outs QFPRegs:$rd), (ins DFPRegs:$rs2),
-                 "fxtoq $rs2, $rd",
-                 [(set QFPRegs:$rd, (SPxtof DFPRegs:$rs2))]>;
-
-def FSTOX : F3_3u<2, 0b110100, 0b010000001,
-                 (outs DFPRegs:$rd), (ins FPRegs:$rs2),
-                 "fstox $rs2, $rd",
-                 [(set DFPRegs:$rd, (SPftox FPRegs:$rs2))]>;
-def FDTOX : F3_3u<2, 0b110100, 0b010000010,
-                 (outs DFPRegs:$rd), (ins DFPRegs:$rs2),
-                 "fdtox $rs2, $rd",
-                 [(set DFPRegs:$rd, (SPftox DFPRegs:$rs2))]>;
-let Predicates = [Is64Bit, HasHardQuad] in
-def FQTOX : F3_3u<2, 0b110100, 0b010000011,
-                 (outs DFPRegs:$rd), (ins QFPRegs:$rs2),
-                 "fqtox $rs2, $rd",
-                 [(set DFPRegs:$rd, (SPftox QFPRegs:$rs2))]>;
-
-} // Predicates = [Is64Bit]
-
 def : Pat<(SPselectxcc i64:$t, i64:$f, imm:$cond),
           (MOVXCCrr $t, $f, imm:$cond)>;
 def : Pat<(SPselectxcc (i64 simm11:$t), i64:$f, imm:$cond),
@@ -430,8 +401,44 @@ def : Pat<(SPselectreg (i64 simm10:$t), i64:$f, imm:$rcond, i64:$rs1),
 
 } // Predicates = [Is64Bit]
 
+//===----------------------------------------------------------------------===//
+// 64-bit Floating Point Conversions.
+//===----------------------------------------------------------------------===//
+
+let Predicates = [HasV9] in {
+
+def FXTOS : F3_3u<2, 0b110100, 0b010000100,
+                 (outs FPRegs:$rd), (ins DFPRegs:$rs2),
+                 "fxtos $rs2, $rd",
+                 [(set FPRegs:$rd, (SPxtof DFPRegs:$rs2))]>;
+def FXTOD : F3_3u<2, 0b110100, 0b010001000,
+                 (outs DFPRegs:$rd), (ins DFPRegs:$rs2),
+                 "fxtod $rs2, $rd",
+                 [(set DFPRegs:$rd, (SPxtof DFPRegs:$rs2))]>;
+let Predicates = [HasHardQuad] in
+def FXTOQ : F3_3u<2, 0b110100, 0b010001100,
+                 (outs QFPRegs:$rd), (ins DFPRegs:$rs2),
+                 "fxtoq $rs2, $rd",
+                 [(set QFPRegs:$rd, (SPxtof DFPRegs:$rs2))]>;
+
+def FSTOX : F3_3u<2, 0b110100, 0b010000001,
+                 (outs DFPRegs:$rd), (ins FPRegs:$rs2),
+                 "fstox $rs2, $rd",
+                 [(set DFPRegs:$rd, (SPftox FPRegs:$rs2))]>;
+def FDTOX : F3_3u<2, 0b110100, 0b010000010,
+                 (outs DFPRegs:$rd), (ins DFPRegs:$rs2),
+                 "fdtox $rs2, $rd",
+                 [(set DFPRegs:$rd, (SPftox DFPRegs:$rs2))]>;
+let Predicates = [HasHardQuad] in
+def FQTOX : F3_3u<2, 0b110100, 0b010000011,
+                 (outs DFPRegs:$rd), (ins QFPRegs:$rs2),
+                 "fqtox $rs2, $rd",
+                 [(set DFPRegs:$rd, (SPftox QFPRegs:$rs2))]>;
+
+} // Predicates = [HasV9]
+
 // ATOMICS.
-let Predicates = [Is64Bit, HasV9], Constraints = "$swap = $rd" in {
+let Predicates = [HasV9], Constraints = "$swap = $rd" in {
   def CASXArr: F3_1_asi<3, 0b111110,
                 (outs I64Regs:$rd), (ins I64Regs:$rs1, I64Regs:$rs2,
                                      I64Regs:$swap, ASITag:$asi),

--- a/llvm/test/MC/Sparc/sparc64-alu-instructions.s
+++ b/llvm/test/MC/Sparc/sparc64-alu-instructions.s
@@ -1,7 +1,8 @@
 ! RUN: llvm-mc %s -triple=sparc -mcpu=v9 -show-encoding | FileCheck %s
 ! RUN: llvm-mc %s -triple=sparc64-unknown-linux-gnu -show-encoding | FileCheck %s
 
-!! 64-bit instructions should still work on 32-bit mode when CPU is set to V9.
+!! All V9 instructions, including 64-bit ones, should be available in 32-bit
+!! mode when CPU is set to V9.
 
         ! CHECK: sllx %g1, %i2, %i0  ! encoding: [0xb1,0x28,0x50,0x1a]
         sllx %g1, %i2, %i0

--- a/llvm/test/MC/Sparc/sparc64-alu-instructions.s
+++ b/llvm/test/MC/Sparc/sparc64-alu-instructions.s
@@ -1,4 +1,7 @@
+! RUN: llvm-mc %s -triple=sparc -mcpu=v9 -show-encoding | FileCheck %s
 ! RUN: llvm-mc %s -triple=sparc64-unknown-linux-gnu -show-encoding | FileCheck %s
+
+!! 64-bit instructions should still work on 32-bit mode when CPU is set to V9.
 
         ! CHECK: sllx %g1, %i2, %i0  ! encoding: [0xb1,0x28,0x50,0x1a]
         sllx %g1, %i2, %i0
@@ -35,4 +38,3 @@
 
         ! CHECK: udivx %g1, 63, %i0  ! encoding: [0xb0,0x68,0x60,0x3f]
         udivx %g1, 63, %i0
-


### PR DESCRIPTION
When the ISA level is V9, 64-bit instruction definitions should be available even if currently it's not used by any patterns.

This should allow usage of 64-bit instructions, like `sllx`/`srlx`, in inline assembly snippets in a source file otherwise intended to target V9 processors running in 32-bit mode, as done in, for example, the Linux kernel.