### PR TITLE
[clang-tidy] Fix "effective" -> "efficient".

### DIFF
--- a/clang-tools-extra/clang-tidy/performance/FasterStringFindCheck.cpp
+++ b/clang-tools-extra/clang-tidy/performance/FasterStringFindCheck.cpp
@@ -88,7 +88,7 @@ void FasterStringFindCheck::check(const MatchFinder::MatchResult &Result) {
 
   diag(Literal->getBeginLoc(), "%0 called with a string literal consisting of "
                                "a single character; consider using the more "
-                               "effective overload accepting a character")
+                               "efficient overload accepting a character")
       << FindFunc
       << FixItHint::CreateReplacement(Literal->getSourceRange(), *Replacement);
 }

--- a/clang-tools-extra/test/clang-tidy/checkers/performance/faster-string-find.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/performance/faster-string-find.cpp
@@ -23,7 +23,7 @@ void StringFind() {
   std::string Str;
 
   Str.find("a");
-  // CHECK-MESSAGES: [[@LINE-1]]:12: warning: 'find' called with a string literal consisting of a single character; consider using the more effective overload accepting a character [performance-faster-string-find]
+  // CHECK-MESSAGES: [[@LINE-1]]:12: warning: 'find' called with a string literal consisting of a single character; consider using the more efficient overload accepting a character [performance-faster-string-find]
   // CHECK-FIXES: Str.find('a');
 
   // Works with the pos argument.


### PR DESCRIPTION
"Effective" is the wrong word: Both overloads are effective; they do what they're supposed to do. But the character overload does less work.