### PR TITLE
[SPIRV][Matrix] fix boolean transpose by supporting nonstandard vector sizes

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
@@ -946,6 +946,40 @@ bool SPIRVInstructionSelector::spvSelect(Register ResVReg,
   case TargetOpcode::G_SPLAT_VECTOR:
     return selectSplatVector(ResVReg, ResType, I);
 
+  case TargetOpcode::G_CONCAT_VECTORS: {
+    // G_CONCAT_VECTORS with results exceeding valid SPIR-V OpTypeVector
+    // sizes (e.g., <9 x s32> from 3x3 matrix) are produced by fewerElements.
+    // Extract all scalar elements from source sub-vectors and construct
+    // the composite.
+    MachineBasicBlock &BB = *I.getParent();
+    SPIRVTypeInst ElemType = GR.getScalarOrVectorComponentType(ResType);
+    SmallVector<Register, 16> AllElems;
+    for (unsigned K = 1; K < I.getNumOperands(); ++K) {
+      Register SrcReg = I.getOperand(K).getReg();
+      SPIRVTypeInst SrcType = GR.getSPIRVTypeForVReg(SrcReg);
+      unsigned SrcNumElts = GR.getScalarOrVectorComponentCount(SrcType);
+      for (unsigned J = 0; J < SrcNumElts; ++J) {
+        Register ElemReg = MRI->createVirtualRegister(GR.getRegClass(ElemType));
+        BuildMI(BB, I, I.getDebugLoc(), TII.get(SPIRV::OpCompositeExtract))
+            .addDef(ElemReg)
+            .addUse(GR.getSPIRVTypeID(ElemType))
+            .addUse(SrcReg)
+            .addImm(J)
+            .constrainAllUses(TII, TRI, RBI);
+        AllElems.push_back(ElemReg);
+      }
+    }
+    MRI->setRegClass(ResVReg, GR.getRegClass(ResType));
+    auto MIB =
+        BuildMI(BB, I, I.getDebugLoc(), TII.get(SPIRV::OpCompositeConstruct))
+            .addDef(ResVReg)
+            .addUse(GR.getSPIRVTypeID(ResType));
+    for (Register R : AllElems)
+      MIB.addUse(R);
+    MIB.constrainAllUses(TII, TRI, RBI);
+    return true;
+  }
+
   case TargetOpcode::G_SHUFFLE_VECTOR: {
     MachineBasicBlock &BB = *I.getParent();
     auto MIB = BuildMI(BB, I, I.getDebugLoc(), TII.get(SPIRV::OpVectorShuffle))

--- a/llvm/lib/Target/SPIRV/SPIRVLegalizerInfo.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVLegalizerInfo.cpp
@@ -116,7 +116,7 @@ SPIRVLegalizerInfo::SPIRVLegalizerInfo(const SPIRVSubtarget &ST) {
                            v3s1, v3s8, v3s16, v3s32, v3s64,
                            v4s1, v4s8, v4s16, v4s32, v4s64};
 
-  auto allScalars = {s1, s8, s16, s32, s64};
+  auto allScalars = {s1, s8, s16, s32, s64, s128};
 
   auto allScalarsAndVectors = {
       s1,    s8,    s16,   s32,   s64,    s128,   v2s1,  v2s8,
@@ -261,9 +261,9 @@ SPIRVLegalizerInfo::SPIRVLegalizerInfo(const SPIRVSubtarget &ST) {
       .lowerIf(vectorElementCountIsGreaterThan(1, MaxVectorSize))
       .custom();
 
-  // If the result is still illegal, the combiner should be able to remove it.
+  // Because of 4x4 matrices the largest supported concat vector size is 16.
   getActionDefinitionsBuilder(G_CONCAT_VECTORS)
-      .legalForCartesianProduct(allowedVectorTypes, allowedVectorTypes);
+      .legalIf(vectorElementCountIsLessThanOrEqualTo(0, 16));
 
   getActionDefinitionsBuilder(G_SPLAT_VECTOR)
       .legalFor(allowedVectorTypes)
@@ -339,10 +339,40 @@ SPIRVLegalizerInfo::SPIRVLegalizerInfo(const SPIRVSubtarget &ST) {
       .legalForCartesianProduct(allIntScalarsAndVectors)
       .legalIf(extendedScalarsAndVectorsProduct);
 
-  // Extensions.
-  getActionDefinitionsBuilder({G_TRUNC, G_ZEXT, G_SEXT, G_ANYEXT})
+  getActionDefinitionsBuilder({G_TRUNC, G_SEXT, G_ANYEXT})
       .legalForCartesianProduct(allScalarsAndVectors)
       .legalIf(extendedScalarsAndVectorsProduct);
+
+  // Only vectors with valid SPIR-V OpTypeVector sizes are legal.
+  // Flattened matrix sizes (e.g., <9 x i1> from 3x3, <12 x i1> from 3x4)
+  // exceed valid OpTypeVector component counts. Use fewerElements to split
+  // into the largest valid SPIR-V vector divisor (e.g., 9->3x3, 12->3x4).
+  // The reassembly produces G_CONCAT_VECTORS with the original element count.
+  getActionDefinitionsBuilder(G_ZEXT)
+      .legalForCartesianProduct(allScalars)
+      .legalForCartesianProduct(allowedVectorTypes)
+      .legalIf(extendedScalarsAndVectorsProduct)
+      .fewerElementsIf(
+          [](const LegalityQuery &Query) {
+            const LLT Ty = Query.Types[0];
+            if (!Ty.isFixedVector())
+              return false;
+            unsigned NumElts = Ty.getNumElements();
+            return NumElts != 2 && NumElts != 3 && NumElts != 4 &&
+                   NumElts != 8 && NumElts != 16;
+          },
+          [](const LegalityQuery &Query) {
+            const LLT Ty = Query.Types[0];
+            unsigned NumElts = Ty.getNumElements();
+            // Valid SPIR-V vector sizes in descending order.
+            static const unsigned ValidSizes[] = {16, 8, 4, 3, 2};
+            for (unsigned D : ValidSizes) {
+              if (NumElts % D == 0)
+                return std::make_pair(
+                    0u, LLT::fixed_vector(D, Ty.getElementType()));
+            }
+            return std::make_pair(0u, Ty.getElementType());
+          });
 
   getActionDefinitionsBuilder(G_PHI)
       .legalFor(allPtrsScalarsAndVectors)

--- a/llvm/lib/Target/SPIRV/SPIRVPostLegalizer.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVPostLegalizer.cpp
@@ -49,7 +49,12 @@ static SPIRVTypeInst deduceIntTypeFromResult(Register ResVReg,
                                              MachineIRBuilder &MIB,
                                              SPIRVGlobalRegistry *GR) {
   const LLT &Ty = MIB.getMRI()->getType(ResVReg);
-  return GR->getOrCreateSPIRVIntegerType(Ty.getScalarSizeInBits(), MIB);
+  SPIRVTypeInst ScalarTy =
+      GR->getOrCreateSPIRVIntegerType(Ty.getScalarSizeInBits(), MIB);
+  if (Ty.isVector())
+    return GR->getOrCreateSPIRVVectorType(ScalarTy, Ty.getNumElements(), MIB,
+                                          false);
+  return ScalarTy;
 }
 
 static SPIRVTypeInst deduceTypeFromSingleOperand(MachineInstr *I,

--- a/llvm/test/CodeGen/SPIRV/legalization/legalize-bool-vec-shader.ll
+++ b/llvm/test/CodeGen/SPIRV/legalization/legalize-bool-vec-shader.ll
@@ -1,0 +1,65 @@
+; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv-unknown-vulkan %s -o - | FileCheck %s
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv-unknown-vulkan1.3-compute %s -o - -filetype=obj | spirv-val --target-env vulkan1.3 %}
+
+; Test that zext of boolean vectors with sizes that exceed valid SPIR-V
+; OpTypeVector component counts (9 from 3x3, 12 from 3x4 bool matrix
+; transpose) compile without errors in shader mode where MaxVectorSize is 4.
+; The bools are grouped into legal-sized sub-vectors (<3 x i1> or <4 x i1>),
+; zext is lowered to OpSelect, then the results are reassembled.
+; See https://github.com/llvm/llvm-project/issues/186864
+
+; CHECK-DAG: %[[#int:]] = OpTypeInt 32 0
+; CHECK-DAG: %[[#v9int:]] = OpTypeVector %[[#int]] 9
+; CHECK-DAG: %[[#bool:]] = OpTypeBool
+; CHECK-DAG: %[[#v3bool:]] = OpTypeVector %[[#bool]] 3
+; CHECK-DAG: %[[#v3int:]] = OpTypeVector %[[#int]] 3
+; CHECK-DAG: %[[#v12int:]] = OpTypeVector %[[#int]] 12
+; CHECK-DAG: %[[#v4bool:]] = OpTypeVector %[[#bool]] 4
+; CHECK-DAG: %[[#v4int:]] = OpTypeVector %[[#int]] 4
+; CHECK-DAG: %[[#const_0:]] = OpConstant %[[#int]] 0
+; CHECK-DAG: %[[#const_1:]] = OpConstant %[[#int]] 1
+; CHECK-DAG: %[[#v3zeros:]] = OpConstantComposite %[[#v3int]] %[[#const_0]] %[[#const_0]] %[[#const_0]]
+; CHECK-DAG: %[[#v3ones:]] = OpConstantComposite %[[#v3int]] %[[#const_1]] %[[#const_1]] %[[#const_1]]
+; CHECK-DAG: %[[#v4zeros:]] = OpConstantComposite %[[#v4int]] %[[#const_0]] %[[#const_0]] %[[#const_0]] %[[#const_0]]
+; CHECK-DAG: %[[#v4ones:]] = OpConstantComposite %[[#v4int]] %[[#const_1]] %[[#const_1]] %[[#const_1]] %[[#const_1]]
+
+define internal void @test_zext_v9i1(ptr addrspace(10) %out, ptr addrspace(10) %in) {
+; CHECK: OpFunction
+entry:
+; CHECK: %[[#grp0:]] = OpCompositeConstruct %[[#v3bool]]
+; CHECK: %[[#grp1:]] = OpCompositeConstruct %[[#v3bool]]
+; CHECK: %[[#grp2:]] = OpCompositeConstruct %[[#v3bool]]
+; CHECK: %[[#sel0:]] = OpSelect %[[#v3int]] %[[#grp0]] %[[#v3ones]] %[[#v3zeros]]
+; CHECK: %[[#sel1:]] = OpSelect %[[#v3int]] %[[#grp1]] %[[#v3ones]] %[[#v3zeros]]
+; CHECK: %[[#sel2:]] = OpSelect %[[#v3int]] %[[#grp2]] %[[#v3ones]] %[[#v3zeros]]
+; CHECK: %[[#res9:]] = OpCompositeConstruct %[[#v9int]]
+; CHECK: OpStore %{{.+}} %[[#res9]]
+  %src = load <9 x i1>, ptr addrspace(10) %in
+  %ext = zext <9 x i1> %src to <9 x i32>
+  store <9 x i32> %ext, ptr addrspace(10) %out
+  ret void
+}
+
+define internal void @test_zext_v12i1(ptr addrspace(10) %out, ptr addrspace(10) %in) {
+; CHECK: OpFunction
+entry:
+; CHECK: %[[#grp3:]] = OpCompositeConstruct %[[#v4bool]]
+; CHECK: %[[#grp4:]] = OpCompositeConstruct %[[#v4bool]]
+; CHECK: %[[#grp5:]] = OpCompositeConstruct %[[#v4bool]]
+; CHECK: %[[#sel3:]] = OpSelect %[[#v4int]] %[[#grp3]] %[[#v4ones]] %[[#v4zeros]]
+; CHECK: %[[#sel4:]] = OpSelect %[[#v4int]] %[[#grp4]] %[[#v4ones]] %[[#v4zeros]]
+; CHECK: %[[#sel5:]] = OpSelect %[[#v4int]] %[[#grp5]] %[[#v4ones]] %[[#v4zeros]]
+; CHECK: %[[#res12:]] = OpCompositeConstruct %[[#v12int]]
+; CHECK: OpStore %{{.+}} %[[#res12]]
+  %src = load <12 x i1>, ptr addrspace(10) %in
+  %ext = zext <12 x i1> %src to <12 x i32>
+  store <12 x i32> %ext, ptr addrspace(10) %out
+  ret void
+}
+
+define void @main() local_unnamed_addr #0 {
+entry:
+  ret void
+}
+
+attributes #0 = { "hlsl.numthreads"="1,1,1" "hlsl.shader"="compute" }


### PR DESCRIPTION
fixes #186864

HLSL boolean are converted from i1s to i32s
However the SPIRV backend does not support G_ZEXT for vectors of nonstandard sizes ie size 9 and 12 which are matrices of size 3x3 and 4x3\3x4.

This change legalizes G_ZEXT to map to smaller supported vector sizes. we then need to support G_CONCAT_VECTORS to reassemble the vector. and use propert type information