### PR TITLE
[LLVM][AArch64] Prefer zip(0,A) over shll(A) when promoting bfloat vectors.

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64InstrInfo.td
+++ b/llvm/lib/Target/AArch64/AArch64InstrInfo.td
@@ -11683,9 +11683,9 @@ multiclass PromoteUnaryv8f16Tov4f32<SDPatternOperator InOp, Instruction OutInst>
   def : Pat<(InOp (v8bf16 V128:$Rn)),
             (UZP2v8i16
               (round_v4fp32_to_v4bf16 (v4f32 (OutInst
-                  (v4f32 (SHLLv4i16 (v4i16 (EXTRACT_SUBREG V128:$Rn, dsub))))))),
+                  (v4f32 (ZIP1v8i16 (MOVIv2d_ns (i32 0)), V128:$Rn))))),
               (round_v4fp32_to_v4bf16 (v4f32 (OutInst
-                  (v4f32 (SHLLv8i16 V128:$Rn))))))>;
+                  (v4f32 (ZIP2v8i16 (MOVIv2d_ns (i32 0)), V128:$Rn))))))>;
 }
 defm : PromoteUnaryv8f16Tov4f32<any_fceil,  	FRINTPv4f32>;
 defm : PromoteUnaryv8f16Tov4f32<any_ffloor, 	FRINTMv4f32>;
@@ -11714,21 +11714,21 @@ multiclass PromoteBinaryv8f16Tov4f32<SDPatternOperator InOp, Instruction OutInst
               (INSERT_SUBREG (IMPLICIT_DEF),
                 (v4bf16 (BFCVTN
                   (v4f32 (OutInst
-                    (v4f32 (SHLLv4i16 (v4i16 (EXTRACT_SUBREG V128:$Rn, dsub)))),
-                    (v4f32 (SHLLv4i16 (v4i16 (EXTRACT_SUBREG V128:$Rm, dsub)))))))),
+                    (v4f32 (ZIP1v8i16 (MOVIv2d_ns (i32 0)), V128:$Rn)),
+                    (v4f32 (ZIP1v8i16 (MOVIv2d_ns (i32 0)), V128:$Rm)))))),
                 dsub),
-              (v4f32 (OutInst (v4f32 (SHLLv8i16 V128:$Rn)),
-                              (v4f32 (SHLLv8i16 V128:$Rm))))))>;
+              (v4f32 (OutInst (v4f32 (ZIP2v8i16 (MOVIv2d_ns (i32 0)), V128:$Rn)),
+                              (v4f32 (ZIP2v8i16 (MOVIv2d_ns (i32 0)), V128:$Rm))))))>;
 
   let Predicates = [HasNoBF16] in
   def : Pat<(InOp (v8bf16 V128:$Rn), (v8bf16 V128:$Rm)),
             (UZP2v8i16
               (round_v4fp32_to_v4bf16 (v4f32 (OutInst
-                  (v4f32 (SHLLv4i16 (v4i16 (EXTRACT_SUBREG V128:$Rn, dsub)))),
-                  (v4f32 (SHLLv4i16 (v4i16 (EXTRACT_SUBREG V128:$Rm, dsub))))))),
+                  (v4f32 (ZIP1v8i16 (MOVIv2d_ns (i32 0)), V128:$Rn)),
+                  (v4f32 (ZIP1v8i16 (MOVIv2d_ns (i32 0)), V128:$Rm))))),
               (round_v4fp32_to_v4bf16 (v4f32 (OutInst
-                  (v4f32 (SHLLv8i16 V128:$Rn)),
-                  (v4f32 (SHLLv8i16 V128:$Rm))))))>;
+                  (v4f32 (ZIP2v8i16 (MOVIv2d_ns (i32 0)), V128:$Rn)),
+                  (v4f32 (ZIP2v8i16 (MOVIv2d_ns (i32 0)), V128:$Rm))))))>;
 }
 defm : PromoteBinaryv8f16Tov4f32<any_fadd, FADDv4f32>;
 defm : PromoteBinaryv8f16Tov4f32<any_fdiv, FDIVv4f32>;

--- a/llvm/test/CodeGen/AArch64/bf16-v8-instructions.ll
+++ b/llvm/test/CodeGen/AArch64/bf16-v8-instructions.ll
@@ -6,37 +6,37 @@
 define <8 x bfloat> @add_h(<8 x bfloat> %a, <8 x bfloat> %b) {
 ; CHECK-CVT-LABEL: add_h:
 ; CHECK-CVT:       // %bb.0: // %entry
-; CHECK-CVT-NEXT:    shll2 v3.4s, v1.8h, #16
-; CHECK-CVT-NEXT:    shll2 v4.4s, v0.8h, #16
-; CHECK-CVT-NEXT:    movi v2.4s, #1
-; CHECK-CVT-NEXT:    ushr v5.4s, v0.4s, #16
-; CHECK-CVT-NEXT:    shll v1.4s, v1.4h, #16
-; CHECK-CVT-NEXT:    shll v0.4s, v0.4h, #16
-; CHECK-CVT-NEXT:    fadd v3.4s, v4.4s, v3.4s
+; CHECK-CVT-NEXT:    movi v2.2d, #0000000000000000
+; CHECK-CVT-NEXT:    movi v3.4s, #1
+; CHECK-CVT-NEXT:    ushr v4.4s, v0.4s, #16
+; CHECK-CVT-NEXT:    zip2 v5.8h, v2.8h, v1.8h
+; CHECK-CVT-NEXT:    zip2 v6.8h, v2.8h, v0.8h
+; CHECK-CVT-NEXT:    zip1 v1.8h, v2.8h, v1.8h
+; CHECK-CVT-NEXT:    zip1 v0.8h, v2.8h, v0.8h
+; CHECK-CVT-NEXT:    movi v2.4s, #127, msl #8
+; CHECK-CVT-NEXT:    and v3.16b, v4.16b, v3.16b
+; CHECK-CVT-NEXT:    fadd v4.4s, v6.4s, v5.4s
 ; CHECK-CVT-NEXT:    fadd v0.4s, v0.4s, v1.4s
-; CHECK-CVT-NEXT:    and v2.16b, v5.16b, v2.16b
-; CHECK-CVT-NEXT:    movi v1.4s, #127, msl #8
-; CHECK-CVT-NEXT:    fcmeq v5.4s, v3.4s, v3.4s
-; CHECK-CVT-NEXT:    add v4.4s, v3.4s, v2.4s
-; CHECK-CVT-NEXT:    orr v3.4s, #64, lsl #16
-; CHECK-CVT-NEXT:    add v2.4s, v0.4s, v2.4s
-; CHECK-CVT-NEXT:    fcmeq v6.4s, v0.4s, v0.4s
+; CHECK-CVT-NEXT:    add v1.4s, v3.4s, v2.4s
+; CHECK-CVT-NEXT:    fcmeq v3.4s, v4.4s, v4.4s
+; CHECK-CVT-NEXT:    add v2.4s, v4.4s, v1.4s
+; CHECK-CVT-NEXT:    orr v4.4s, #64, lsl #16
+; CHECK-CVT-NEXT:    fcmeq v5.4s, v0.4s, v0.4s
+; CHECK-CVT-NEXT:    add v1.4s, v0.4s, v1.4s
 ; CHECK-CVT-NEXT:    orr v0.4s, #64, lsl #16
-; CHECK-CVT-NEXT:    add v4.4s, v4.4s, v1.4s
-; CHECK-CVT-NEXT:    add v1.4s, v2.4s, v1.4s
-; CHECK-CVT-NEXT:    mov v2.16b, v5.16b
-; CHECK-CVT-NEXT:    bsl v2.16b, v4.16b, v3.16b
-; CHECK-CVT-NEXT:    bit v0.16b, v1.16b, v6.16b
+; CHECK-CVT-NEXT:    bif v2.16b, v4.16b, v3.16b
+; CHECK-CVT-NEXT:    bit v0.16b, v1.16b, v5.16b
 ; CHECK-CVT-NEXT:    uzp2 v0.8h, v0.8h, v2.8h
 ; CHECK-CVT-NEXT:    ret
 ;
 ; CHECK-BF16-LABEL: add_h:
 ; CHECK-BF16:       // %bb.0: // %entry
-; CHECK-BF16-NEXT:    shll v2.4s, v1.4h, #16
-; CHECK-BF16-NEXT:    shll v3.4s, v0.4h, #16
-; CHECK-BF16-NEXT:    shll2 v1.4s, v1.8h, #16
-; CHECK-BF16-NEXT:    shll2 v0.4s, v0.8h, #16
-; CHECK-BF16-NEXT:    fadd v2.4s, v3.4s, v2.4s
+; CHECK-BF16-NEXT:    movi v2.2d, #0000000000000000
+; CHECK-BF16-NEXT:    zip1 v3.8h, v2.8h, v1.8h
+; CHECK-BF16-NEXT:    zip1 v4.8h, v2.8h, v0.8h
+; CHECK-BF16-NEXT:    zip2 v1.8h, v2.8h, v1.8h
+; CHECK-BF16-NEXT:    zip2 v0.8h, v2.8h, v0.8h
+; CHECK-BF16-NEXT:    fadd v2.4s, v4.4s, v3.4s
 ; CHECK-BF16-NEXT:    fadd v1.4s, v0.4s, v1.4s
 ; CHECK-BF16-NEXT:    bfcvtn v0.4h, v2.4s
 ; CHECK-BF16-NEXT:    bfcvtn2 v0.8h, v1.4s
@@ -50,37 +50,37 @@ entry:
 define <8 x bfloat> @sub_h(<8 x bfloat> %a, <8 x bfloat> %b) {
 ; CHECK-CVT-LABEL: sub_h:
 ; CHECK-CVT:       // %bb.0: // %entry
-; CHECK-CVT-NEXT:    shll2 v3.4s, v1.8h, #16
-; CHECK-CVT-NEXT:    shll2 v4.4s, v0.8h, #16
-; CHECK-CVT-NEXT:    movi v2.4s, #1
-; CHECK-CVT-NEXT:    ushr v5.4s, v0.4s, #16
-; CHECK-CVT-NEXT:    shll v1.4s, v1.4h, #16
-; CHECK-CVT-NEXT:    shll v0.4s, v0.4h, #16
-; CHECK-CVT-NEXT:    fsub v3.4s, v4.4s, v3.4s
+; CHECK-CVT-NEXT:    movi v2.2d, #0000000000000000
+; CHECK-CVT-NEXT:    movi v3.4s, #1
+; CHECK-CVT-NEXT:    ushr v4.4s, v0.4s, #16
+; CHECK-CVT-NEXT:    zip2 v5.8h, v2.8h, v1.8h
+; CHECK-CVT-NEXT:    zip2 v6.8h, v2.8h, v0.8h
+; CHECK-CVT-NEXT:    zip1 v1.8h, v2.8h, v1.8h
+; CHECK-CVT-NEXT:    zip1 v0.8h, v2.8h, v0.8h
+; CHECK-CVT-NEXT:    movi v2.4s, #127, msl #8
+; CHECK-CVT-NEXT:    and v3.16b, v4.16b, v3.16b
+; CHECK-CVT-NEXT:    fsub v4.4s, v6.4s, v5.4s
 ; CHECK-CVT-NEXT:    fsub v0.4s, v0.4s, v1.4s
-; CHECK-CVT-NEXT:    and v2.16b, v5.16b, v2.16b
-; CHECK-CVT-NEXT:    movi v1.4s, #127, msl #8
-; CHECK-CVT-NEXT:    fcmeq v5.4s, v3.4s, v3.4s
-; CHECK-CVT-NEXT:    add v4.4s, v3.4s, v2.4s
-; CHECK-CVT-NEXT:    orr v3.4s, #64, lsl #16
-; CHECK-CVT-NEXT:    add v2.4s, v0.4s, v2.4s
-; CHECK-CVT-NEXT:    fcmeq v6.4s, v0.4s, v0.4s
+; CHECK-CVT-NEXT:    add v1.4s, v3.4s, v2.4s
+; CHECK-CVT-NEXT:    fcmeq v3.4s, v4.4s, v4.4s
+; CHECK-CVT-NEXT:    add v2.4s, v4.4s, v1.4s
+; CHECK-CVT-NEXT:    orr v4.4s, #64, lsl #16
+; CHECK-CVT-NEXT:    fcmeq v5.4s, v0.4s, v0.4s
+; CHECK-CVT-NEXT:    add v1.4s, v0.4s, v1.4s
 ; CHECK-CVT-NEXT:    orr v0.4s, #64, lsl #16
-; CHECK-CVT-NEXT:    add v4.4s, v4.4s, v1.4s
-; CHECK-CVT-NEXT:    add v1.4s, v2.4s, v1.4s
-; CHECK-CVT-NEXT:    mov v2.16b, v5.16b
-; CHECK-CVT-NEXT:    bsl v2.16b, v4.16b, v3.16b
-; CHECK-CVT-NEXT:    bit v0.16b, v1.16b, v6.16b
+; CHECK-CVT-NEXT:    bif v2.16b, v4.16b, v3.16b
+; CHECK-CVT-NEXT:    bit v0.16b, v1.16b, v5.16b
 ; CHECK-CVT-NEXT:    uzp2 v0.8h, v0.8h, v2.8h
 ; CHECK-CVT-NEXT:    ret
 ;
 ; CHECK-BF16-LABEL: sub_h:
 ; CHECK-BF16:       // %bb.0: // %entry
-; CHECK-BF16-NEXT:    shll v2.4s, v1.4h, #16
-; CHECK-BF16-NEXT:    shll v3.4s, v0.4h, #16
-; CHECK-BF16-NEXT:    shll2 v1.4s, v1.8h, #16
-; CHECK-BF16-NEXT:    shll2 v0.4s, v0.8h, #16
-; CHECK-BF16-NEXT:    fsub v2.4s, v3.4s, v2.4s
+; CHECK-BF16-NEXT:    movi v2.2d, #0000000000000000
+; CHECK-BF16-NEXT:    zip1 v3.8h, v2.8h, v1.8h
+; CHECK-BF16-NEXT:    zip1 v4.8h, v2.8h, v0.8h
+; CHECK-BF16-NEXT:    zip2 v1.8h, v2.8h, v1.8h
+; CHECK-BF16-NEXT:    zip2 v0.8h, v2.8h, v0.8h
+; CHECK-BF16-NEXT:    fsub v2.4s, v4.4s, v3.4s
 ; CHECK-BF16-NEXT:    fsub v1.4s, v0.4s, v1.4s
 ; CHECK-BF16-NEXT:    bfcvtn v0.4h, v2.4s
 ; CHECK-BF16-NEXT:    bfcvtn2 v0.8h, v1.4s
@@ -94,37 +94,37 @@ entry:
 define <8 x bfloat> @mul_h(<8 x bfloat> %a, <8 x bfloat> %b) {
 ; CHECK-CVT-LABEL: mul_h:
 ; CHECK-CVT:       // %bb.0: // %entry
-; CHECK-CVT-NEXT:    shll2 v3.4s, v1.8h, #16
-; CHECK-CVT-NEXT:    shll2 v4.4s, v0.8h, #16
-; CHECK-CVT-NEXT:    movi v2.4s, #1
-; CHECK-CVT-NEXT:    ushr v5.4s, v0.4s, #16
-; CHECK-CVT-NEXT:    shll v1.4s, v1.4h, #16
-; CHECK-CVT-NEXT:    shll v0.4s, v0.4h, #16
-; CHECK-CVT-NEXT:    fmul v3.4s, v4.4s, v3.4s
+; CHECK-CVT-NEXT:    movi v2.2d, #0000000000000000
+; CHECK-CVT-NEXT:    movi v3.4s, #1
+; CHECK-CVT-NEXT:    ushr v4.4s, v0.4s, #16
+; CHECK-CVT-NEXT:    zip2 v5.8h, v2.8h, v1.8h
+; CHECK-CVT-NEXT:    zip2 v6.8h, v2.8h, v0.8h
+; CHECK-CVT-NEXT:    zip1 v1.8h, v2.8h, v1.8h
+; CHECK-CVT-NEXT:    zip1 v0.8h, v2.8h, v0.8h
+; CHECK-CVT-NEXT:    movi v2.4s, #127, msl #8
+; CHECK-CVT-NEXT:    and v3.16b, v4.16b, v3.16b
+; CHECK-CVT-NEXT:    fmul v4.4s, v6.4s, v5.4s
 ; CHECK-CVT-NEXT:    fmul v0.4s, v0.4s, v1.4s
-; CHECK-CVT-NEXT:    and v2.16b, v5.16b, v2.16b
-; CHECK-CVT-NEXT:    movi v1.4s, #127, msl #8
-; CHECK-CVT-NEXT:    fcmeq v5.4s, v3.4s, v3.4s
-; CHECK-CVT-NEXT:    add v4.4s, v3.4s, v2.4s
-; CHECK-CVT-NEXT:    orr v3.4s, #64, lsl #16
-; CHECK-CVT-NEXT:    add v2.4s, v0.4s, v2.4s
-; CHECK-CVT-NEXT:    fcmeq v6.4s, v0.4s, v0.4s
+; CHECK-CVT-NEXT:    add v1.4s, v3.4s, v2.4s
+; CHECK-CVT-NEXT:    fcmeq v3.4s, v4.4s, v4.4s
+; CHECK-CVT-NEXT:    add v2.4s, v4.4s, v1.4s
+; CHECK-CVT-NEXT:    orr v4.4s, #64, lsl #16
+; CHECK-CVT-NEXT:    fcmeq v5.4s, v0.4s, v0.4s
+; CHECK-CVT-NEXT:    add v1.4s, v0.4s, v1.4s
 ; CHECK-CVT-NEXT:    orr v0.4s, #64, lsl #16
-; CHECK-CVT-NEXT:    add v4.4s, v4.4s, v1.4s
-; CHECK-CVT-NEXT:    add v1.4s, v2.4s, v1.4s
-; CHECK-CVT-NEXT:    mov v2.16b, v5.16b
-; CHECK-CVT-NEXT:    bsl v2.16b, v4.16b, v3.16b
-; CHECK-CVT-NEXT:    bit v0.16b, v1.16b, v6.16b
+; CHECK-CVT-NEXT:    bif v2.16b, v4.16b, v3.16b
+; CHECK-CVT-NEXT:    bit v0.16b, v1.16b, v5.16b
 ; CHECK-CVT-NEXT:    uzp2 v0.8h, v0.8h, v2.8h
 ; CHECK-CVT-NEXT:    ret
 ;
 ; CHECK-NOSVE-BF16-LABEL: mul_h:
 ; CHECK-NOSVE-BF16:       // %bb.0: // %entry
-; CHECK-NOSVE-BF16-NEXT:    shll v2.4s, v1.4h, #16
-; CHECK-NOSVE-BF16-NEXT:    shll v3.4s, v0.4h, #16
-; CHECK-NOSVE-BF16-NEXT:    shll2 v1.4s, v1.8h, #16
-; CHECK-NOSVE-BF16-NEXT:    shll2 v0.4s, v0.8h, #16
-; CHECK-NOSVE-BF16-NEXT:    fmul v2.4s, v3.4s, v2.4s
+; CHECK-NOSVE-BF16-NEXT:    movi v2.2d, #0000000000000000
+; CHECK-NOSVE-BF16-NEXT:    zip1 v3.8h, v2.8h, v1.8h
+; CHECK-NOSVE-BF16-NEXT:    zip1 v4.8h, v2.8h, v0.8h
+; CHECK-NOSVE-BF16-NEXT:    zip2 v1.8h, v2.8h, v1.8h
+; CHECK-NOSVE-BF16-NEXT:    zip2 v0.8h, v2.8h, v0.8h
+; CHECK-NOSVE-BF16-NEXT:    fmul v2.4s, v4.4s, v3.4s
 ; CHECK-NOSVE-BF16-NEXT:    fmul v1.4s, v0.4s, v1.4s
 ; CHECK-NOSVE-BF16-NEXT:    bfcvtn v0.4h, v2.4s
 ; CHECK-NOSVE-BF16-NEXT:    bfcvtn2 v0.8h, v1.4s
@@ -150,37 +150,39 @@ entry:
 define <8 x bfloat> @div_h(<8 x bfloat> %a, <8 x bfloat> %b) {
 ; CHECK-CVT-LABEL: div_h:
 ; CHECK-CVT:       // %bb.0: // %entry
-; CHECK-CVT-NEXT:    shll2 v2.4s, v1.8h, #16
-; CHECK-CVT-NEXT:    shll2 v3.4s, v0.8h, #16
-; CHECK-CVT-NEXT:    shll v1.4s, v1.4h, #16
-; CHECK-CVT-NEXT:    movi v4.4s, #127, msl #8
-; CHECK-CVT-NEXT:    fdiv v2.4s, v3.4s, v2.4s
-; CHECK-CVT-NEXT:    shll v3.4s, v0.4h, #16
+; CHECK-CVT-NEXT:    movi v2.2d, #0000000000000000
+; CHECK-CVT-NEXT:    zip2 v3.8h, v2.8h, v1.8h
+; CHECK-CVT-NEXT:    zip2 v4.8h, v2.8h, v0.8h
+; CHECK-CVT-NEXT:    zip1 v1.8h, v2.8h, v1.8h
+; CHECK-CVT-NEXT:    zip1 v2.8h, v2.8h, v0.8h
 ; CHECK-CVT-NEXT:    ushr v0.4s, v0.4s, #16
-; CHECK-CVT-NEXT:    fdiv v1.4s, v3.4s, v1.4s
-; CHECK-CVT-NEXT:    movi v3.4s, #1
-; CHECK-CVT-NEXT:    and v0.16b, v0.16b, v3.16b
+; CHECK-CVT-NEXT:    fdiv v3.4s, v4.4s, v3.4s
+; CHECK-CVT-NEXT:    movi v4.4s, #127, msl #8
+; CHECK-CVT-NEXT:    fdiv v1.4s, v2.4s, v1.4s
+; CHECK-CVT-NEXT:    movi v2.4s, #1
+; CHECK-CVT-NEXT:    and v0.16b, v0.16b, v2.16b
 ; CHECK-CVT-NEXT:    add v0.4s, v0.4s, v4.4s
-; CHECK-CVT-NEXT:    fcmeq v4.4s, v2.4s, v2.4s
-; CHECK-CVT-NEXT:    add v3.4s, v2.4s, v0.4s
-; CHECK-CVT-NEXT:    orr v2.4s, #64, lsl #16
+; CHECK-CVT-NEXT:    fcmeq v4.4s, v3.4s, v3.4s
+; CHECK-CVT-NEXT:    add v2.4s, v3.4s, v0.4s
+; CHECK-CVT-NEXT:    orr v3.4s, #64, lsl #16
 ; CHECK-CVT-NEXT:    fcmeq v5.4s, v1.4s, v1.4s
 ; CHECK-CVT-NEXT:    add v0.4s, v1.4s, v0.4s
 ; CHECK-CVT-NEXT:    orr v1.4s, #64, lsl #16
-; CHECK-CVT-NEXT:    bit v2.16b, v3.16b, v4.16b
+; CHECK-CVT-NEXT:    bif v2.16b, v3.16b, v4.16b
 ; CHECK-CVT-NEXT:    bif v0.16b, v1.16b, v5.16b
 ; CHECK-CVT-NEXT:    uzp2 v0.8h, v0.8h, v2.8h
 ; CHECK-CVT-NEXT:    ret
 ;
 ; CHECK-BF16-LABEL: div_h:
 ; CHECK-BF16:       // %bb.0: // %entry
-; CHECK-BF16-NEXT:    shll v2.4s, v1.4h, #16
-; CHECK-BF16-NEXT:    shll v3.4s, v0.4h, #16
-; CHECK-BF16-NEXT:    shll2 v1.4s, v1.8h, #16
-; CHECK-BF16-NEXT:    shll2 v0.4s, v0.8h, #16
-; CHECK-BF16-NEXT:    fdiv v2.4s, v3.4s, v2.4s
+; CHECK-BF16-NEXT:    movi v2.2d, #0000000000000000
+; CHECK-BF16-NEXT:    zip1 v3.8h, v2.8h, v1.8h
+; CHECK-BF16-NEXT:    zip1 v4.8h, v2.8h, v0.8h
+; CHECK-BF16-NEXT:    zip2 v1.8h, v2.8h, v1.8h
+; CHECK-BF16-NEXT:    zip2 v0.8h, v2.8h, v0.8h
+; CHECK-BF16-NEXT:    fdiv v3.4s, v4.4s, v3.4s
 ; CHECK-BF16-NEXT:    fdiv v1.4s, v0.4s, v1.4s
-; CHECK-BF16-NEXT:    bfcvtn v0.4h, v2.4s
+; CHECK-BF16-NEXT:    bfcvtn v0.4h, v3.4s
 ; CHECK-BF16-NEXT:    bfcvtn2 v0.8h, v1.4s
 ; CHECK-BF16-NEXT:    ret
 entry:

--- a/llvm/test/CodeGen/AArch64/fixed-length-bf16-arith.ll
+++ b/llvm/test/CodeGen/AArch64/fixed-length-bf16-arith.ll
@@ -54,11 +54,12 @@ define <4 x bfloat> @fadd_v4bf16(<4 x bfloat> %a, <4 x bfloat> %b) {
 define <8 x bfloat> @fadd_v8bf16(<8 x bfloat> %a, <8 x bfloat> %b) {
 ; NOB16B16-LABEL: fadd_v8bf16:
 ; NOB16B16:       // %bb.0:
-; NOB16B16-NEXT:    shll v2.4s, v1.4h, #16
-; NOB16B16-NEXT:    shll v3.4s, v0.4h, #16
-; NOB16B16-NEXT:    shll2 v1.4s, v1.8h, #16
-; NOB16B16-NEXT:    shll2 v0.4s, v0.8h, #16
-; NOB16B16-NEXT:    fadd v2.4s, v3.4s, v2.4s
+; NOB16B16-NEXT:    movi v2.2d, #0000000000000000
+; NOB16B16-NEXT:    zip1 v3.8h, v2.8h, v1.8h
+; NOB16B16-NEXT:    zip1 v4.8h, v2.8h, v0.8h
+; NOB16B16-NEXT:    zip2 v1.8h, v2.8h, v1.8h
+; NOB16B16-NEXT:    zip2 v0.8h, v2.8h, v0.8h
+; NOB16B16-NEXT:    fadd v2.4s, v4.4s, v3.4s
 ; NOB16B16-NEXT:    fadd v1.4s, v0.4s, v1.4s
 ; NOB16B16-NEXT:    bfcvtn v0.4h, v2.4s
 ; NOB16B16-NEXT:    bfcvtn2 v0.8h, v1.4s
@@ -95,13 +96,14 @@ define <4 x bfloat> @fdiv_v4bf16(<4 x bfloat> %a, <4 x bfloat> %b) {
 define <8 x bfloat> @fdiv_v8bf16(<8 x bfloat> %a, <8 x bfloat> %b) {
 ; CHECK-LABEL: fdiv_v8bf16:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    shll v2.4s, v1.4h, #16
-; CHECK-NEXT:    shll v3.4s, v0.4h, #16
-; CHECK-NEXT:    shll2 v1.4s, v1.8h, #16
-; CHECK-NEXT:    shll2 v0.4s, v0.8h, #16
-; CHECK-NEXT:    fdiv v2.4s, v3.4s, v2.4s
+; CHECK-NEXT:    movi v2.2d, #0000000000000000
+; CHECK-NEXT:    zip1 v3.8h, v2.8h, v1.8h
+; CHECK-NEXT:    zip1 v4.8h, v2.8h, v0.8h
+; CHECK-NEXT:    zip2 v1.8h, v2.8h, v1.8h
+; CHECK-NEXT:    zip2 v0.8h, v2.8h, v0.8h
+; CHECK-NEXT:    fdiv v3.4s, v4.4s, v3.4s
 ; CHECK-NEXT:    fdiv v1.4s, v0.4s, v1.4s
-; CHECK-NEXT:    bfcvtn v0.4h, v2.4s
+; CHECK-NEXT:    bfcvtn v0.4h, v3.4s
 ; CHECK-NEXT:    bfcvtn2 v0.8h, v1.4s
 ; CHECK-NEXT:    ret
   %res = fdiv <8 x bfloat> %a, %b
@@ -943,11 +945,12 @@ define <4 x bfloat> @fsub_v4bf16(<4 x bfloat> %a, <4 x bfloat> %b) {
 define <8 x bfloat> @fsub_v8bf16(<8 x bfloat> %a, <8 x bfloat> %b) {
 ; NOB16B16-LABEL: fsub_v8bf16:
 ; NOB16B16:       // %bb.0:
-; NOB16B16-NEXT:    shll v2.4s, v1.4h, #16
-; NOB16B16-NEXT:    shll v3.4s, v0.4h, #16
-; NOB16B16-NEXT:    shll2 v1.4s, v1.8h, #16
-; NOB16B16-NEXT:    shll2 v0.4s, v0.8h, #16
-; NOB16B16-NEXT:    fsub v2.4s, v3.4s, v2.4s
+; NOB16B16-NEXT:    movi v2.2d, #0000000000000000
+; NOB16B16-NEXT:    zip1 v3.8h, v2.8h, v1.8h
+; NOB16B16-NEXT:    zip1 v4.8h, v2.8h, v0.8h
+; NOB16B16-NEXT:    zip2 v1.8h, v2.8h, v1.8h
+; NOB16B16-NEXT:    zip2 v0.8h, v2.8h, v0.8h
+; NOB16B16-NEXT:    fsub v2.4s, v4.4s, v3.4s
 ; NOB16B16-NEXT:    fsub v1.4s, v0.4s, v1.4s
 ; NOB16B16-NEXT:    bfcvtn v0.4h, v2.4s
 ; NOB16B16-NEXT:    bfcvtn2 v0.8h, v1.4s


### PR DESCRIPTION
This follows on from similar work done for SVE.  That work was a clear cut win whereas here there's a reliance on ZIP having the same latency but higher bandwidth than SHLL. For this reason I've limited the change to patterns that specifically emit pairs of SHLL instructions and thus more likely to become bandwidth limited.  Using add_h from bf16-v8-instructions.ll I've collected llvm-mca results across a range of cores:

```
[Cortext A57 - SHLL / ZIP / ZIP with zeroing instruction removed]
Iterations:        100
Instructions:      2300 / 2200 / 2100
Total Cycles:      2503 / 2708 / 2804
Total uOps:        3100 / 3800 / 3700

[Corext A510 - SHLL / ZIP / ZIP with zeroing instruction removed]
Iterations:        100
Instructions:      2300 / 2200 / 2100
Total Cycles:      2402 / 2502 / 2302
Total uOps:        2300 / 2200 / 2100

[Corext A710 - SHLL / ZIP / ZIP with zeroing instruction removed]
Iterations:        100
Instructions:      2300 / 2200 / 2100
Total Cycles:      1405 / 1304 / 1304
Total uOps:        2300 / 2200 / 2100

[Neoverse V2 - SHLL / ZIP / ZIP with zeroing instruction removed]
Iterations:        100
Instructions:      2300 / 2200 / 2100
Total Cycles:      1304 / 1203 / 1203
Total uOps:        2300 / 2200 / 2100
```
A510 looks worse but then better when ignoring the hoist able zeroing instruction. A57 looks worse and seems to get worse as more instructions are removed, which I don't understand.  I can hide this behind a feature flag and maintain both sets of isel patterns but figured it better to wait for feedback as to whether that's necessary.