### PR TITLE
[libc++] Switch to Xcode 26.3 in libc++'s macOS runners

### DIFF
--- a/.github/workflows/libcxx-build-and-test.yaml
+++ b/.github/workflows/libcxx-build-and-test.yaml
@@ -206,7 +206,7 @@ jobs:
       - uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
         with:
           # https://github.com/actions/runner-images/blob/main/images/macos/macos-15-Readme.md
-          xcode-version: '26.0'
+          xcode-version: '26.3'
       - uses: seanmiddleditch/gha-setup-ninja@3b1f8f94a2f8254bd26914c4ab9474d4f0015f67 # v6
       - name: Build and test
         run: |


### PR DESCRIPTION
The macos-15 Github runners don't seem to provide Xcode 26.0 anymore, which seems to result in the fallback Homebrew Clang 18 being used. Since Clang 18 is not supported by libc++, this fails.

Instead, use Xcode 26.3 which is now available and is the latest supported version of Xcode.