### PR TITLE
[CodeGen] Add simple oracle removal pass.

### DIFF
--- a/llvm/include/llvm/CodeGen/Passes.h
+++ b/llvm/include/llvm/CodeGen/Passes.h
@@ -493,6 +493,11 @@ LLVM_ABI FunctionPass *createInterleavedLoadCombinePass();
 ///
 LLVM_ABI ModulePass *createLowerEmuTLSPass();
 
+/// RemoveOracleFunctions - Remove unused functions with the "oracle-function"
+/// attribute. Runs right after ISel and prevents subsequent passes from
+/// processing oracle functions.
+LLVM_ABI MachineFunctionPass *createRemoveOracleFunctionsPass();
+
 LLVM_ABI ModulePass *createLibcallLoweringInfoWrapper();
 
 /// This pass lowers the \@llvm.load.relative and \@llvm.objc.* intrinsics to

--- a/llvm/include/llvm/InitializePasses.h
+++ b/llvm/include/llvm/InitializePasses.h
@@ -185,6 +185,7 @@ LLVM_ABI void initializeLoopTermFoldPass(PassRegistry &);
 LLVM_ABI void initializeLoopUnrollPass(PassRegistry &);
 LLVM_ABI void initializeLowerAtomicLegacyPassPass(PassRegistry &);
 LLVM_ABI void initializeLowerEmuTLSPass(PassRegistry &);
+LLVM_ABI void initializeRemoveOracleFunctionsPass(PassRegistry &);
 LLVM_ABI void initializeLowerGlobalDtorsLegacyPassPass(PassRegistry &);
 LLVM_ABI void initializeLowerIntrinsicsPass(PassRegistry &);
 LLVM_ABI void initializeLowerInvokeLegacyPassPass(PassRegistry &);

--- a/llvm/lib/CodeGen/CMakeLists.txt
+++ b/llvm/lib/CodeGen/CMakeLists.txt
@@ -208,6 +208,7 @@ add_llvm_component_library(LLVMCodeGen
   RegUsageInfoCollector.cpp
   RegUsageInfoPropagate.cpp
   RemoveLoadsIntoFakeUses.cpp
+  RemoveOracleFunctions.cpp
   ReplaceWithVeclib.cpp
   ResetMachineFunctionPass.cpp
   RegisterBank.cpp

--- a/llvm/lib/CodeGen/CodeGen.cpp
+++ b/llvm/lib/CodeGen/CodeGen.cpp
@@ -76,6 +76,7 @@ void llvm::initializeCodeGen(PassRegistry &Registry) {
   initializeLiveVariablesWrapperPassPass(Registry);
   initializeLocalStackSlotPassPass(Registry);
   initializeLowerEmuTLSPass(Registry);
+  initializeRemoveOracleFunctionsPass(Registry);
   initializeLowerGlobalDtorsLegacyPassPass(Registry);
   initializeLowerIntrinsicsPass(Registry);
   initializeMIRAddFSDiscriminatorsPass(Registry);

--- a/llvm/lib/CodeGen/RemoveOracleFunctions.cpp
+++ b/llvm/lib/CodeGen/RemoveOracleFunctions.cpp
@@ -1,0 +1,66 @@
+//===- RemoveOracleFunctions.cpp - Remove unused oracle functions ---------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This pass removes functions annotated with the "oracle-function" attribute by
+// changing their linkage to available_externally. Oracle functions must have no
+// uses by the time this pass runs (after ISel).
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/CodeGen/MachineFunction.h"
+#include "llvm/CodeGen/MachineFunctionPass.h"
+#include "llvm/CodeGen/Passes.h"
+#include "llvm/IR/Function.h"
+#include "llvm/InitializePasses.h"
+#include "llvm/Pass.h"
+
+using namespace llvm;
+
+#define DEBUG_TYPE "remove-oracle-functions"
+
+namespace {
+
+class RemoveOracleFunctions : public MachineFunctionPass {
+public:
+  static char ID;
+  RemoveOracleFunctions() : MachineFunctionPass(ID) {
+    initializeRemoveOracleFunctionsPass(*PassRegistry::getPassRegistry());
+  }
+
+  void getAnalysisUsage(AnalysisUsage &AU) const override {
+    AU.setPreservesAll();
+    MachineFunctionPass::getAnalysisUsage(AU);
+  }
+
+  bool runOnMachineFunction(MachineFunction &MF) override {
+    Function &F = MF.getFunction();
+    if (!F.hasFnAttribute("oracle-function"))
+      return false;
+
+    assert(F.use_empty() &&
+           "oracle-function must have no uses by the time it is removed");
+
+    // Change linkage to available_externally so that all subsequent
+    // MachineFunctionPasses skip this function (MachineFunctionPass::
+    // runOnFunction checks this). The AsmPrinter will also skip it,
+    // so the function produces no output.
+    F.setLinkage(GlobalValue::AvailableExternallyLinkage);
+    return true;
+  }
+};
+
+} // namespace
+
+char RemoveOracleFunctions::ID = 0;
+
+INITIALIZE_PASS(RemoveOracleFunctions, DEBUG_TYPE,
+                "Remove unused oracle functions", false, false)
+
+MachineFunctionPass *llvm::createRemoveOracleFunctionsPass() {
+  return new RemoveOracleFunctions();
+}

--- a/llvm/lib/CodeGen/TargetPassConfig.cpp
+++ b/llvm/lib/CodeGen/TargetPassConfig.cpp
@@ -1133,6 +1133,11 @@ static cl::opt<RegisterRegAlloc::FunctionPassCtor, false,
 void TargetPassConfig::addMachinePasses() {
   AddingMachinePasses = true;
 
+  // Remove oracle functions right after ISel. This changes their linkage to
+  // available_externally so all subsequent MachineFunctionPasses skip them,
+  // avoiding wasted compile time on post-ISel optimizations.
+  addPass(createRemoveOracleFunctionsPass());
+
   // Add passes that optimize machine instructions in SSA form.
   if (getOptLevel() != CodeGenOptLevel::None) {
     addMachineSSAOptimization();

--- a/llvm/test/CodeGen/AArch64/O0-pipeline.ll
+++ b/llvm/test/CodeGen/AArch64/O0-pipeline.ll
@@ -53,6 +53,7 @@
 ; CHECK-NEXT:       Assignment Tracking Analysis
 ; CHECK-NEXT:       AArch64 Instruction Selection
 ; CHECK-NEXT:       Finalize ISel and expand pseudo-instructions
+; CHECK-NEXT:       Remove unused oracle functions
 ; CHECK-NEXT:       Local Stack Slot Allocation
 ; CHECK-NEXT:       Bundle Machine CFG Edges
 ; CHECK-NEXT:       Lazy Machine Block Frequency Analysis

--- a/llvm/test/CodeGen/AArch64/O3-pipeline.ll
+++ b/llvm/test/CodeGen/AArch64/O3-pipeline.ll
@@ -142,6 +142,7 @@
 ; CHECK-NEXT:       MachineDominator Tree Construction
 ; CHECK-NEXT:       AArch64 Local Dynamic TLS Access Clean-up
 ; CHECK-NEXT:       Finalize ISel and expand pseudo-instructions
+; CHECK-NEXT:       Remove unused oracle functions
 ; CHECK-NEXT:       Bundle Machine CFG Edges
 ; CHECK-NEXT:       Lazy Machine Block Frequency Analysis
 ; CHECK-NEXT:       Machine Optimization Remark Emitter

--- a/llvm/test/CodeGen/AArch64/remove-oracle-functions.ll
+++ b/llvm/test/CodeGen/AArch64/remove-oracle-functions.ll
@@ -1,0 +1,63 @@
+; RUN: llc -mtriple=arm64-apple-macosx < %s | FileCheck %s
+
+; Oracle functions with no uses should be removed entirely.
+; CHECK-NOT: oracle_unused1
+; CHECK-NOT: oracle_unused2
+
+; A normal function should not be affected regardless of uses.
+; CHECK-LABEL: normal_unused:
+; CHECK:       ret
+
+; CHECK-LABEL: caller:
+; CHECK:       ret
+
+define void @oracle_unused1(ptr %p, i64 %n) #0 {
+entry:
+  br label %loop
+
+loop:
+  %i = phi i64 [ 0, %entry ], [ %i.next, %loop ]
+  %gep = getelementptr inbounds i32, ptr %p, i64 %i
+  %val = load i32, ptr %gep, align 4
+  %add = add nsw i32 %val, 42
+  store i32 %add, ptr %gep, align 4
+  %i.next = add nuw nsw i64 %i, 1
+  %cmp = icmp ult i64 %i.next, %n
+  br i1 %cmp, label %loop, label %exit
+
+exit:
+  ret void
+}
+
+define i64 @oracle_unused2(ptr %p, i64 %n) #0 {
+entry:
+  %cmp0 = icmp eq i64 %n, 0
+  br i1 %cmp0, label %exit, label %loop
+
+loop:
+  %i = phi i64 [ 0, %entry ], [ %i.next, %loop.latch ]
+  %sum = phi i64 [ 0, %entry ], [ %sum.next, %loop.latch ]
+  %gep = getelementptr inbounds i64, ptr %p, i64 %i
+  %val = load i64, ptr %gep, align 8
+  %sum.next = add i64 %sum, %val
+  br label %loop.latch
+
+loop.latch:
+  %i.next = add nuw nsw i64 %i, 1
+  %cmp = icmp ult i64 %i.next, %n
+  br i1 %cmp, label %loop, label %exit
+
+exit:
+  %result = phi i64 [ 0, %entry ], [ %sum.next, %loop.latch ]
+  ret i64 %result
+}
+
+define void @normal_unused() {
+  ret void
+}
+
+define void @caller() {
+  ret void
+}
+
+attributes #0 = { "oracle-function" }

--- a/llvm/test/CodeGen/AMDGPU/llc-pipeline.ll
+++ b/llvm/test/CodeGen/AMDGPU/llc-pipeline.ll
@@ -107,6 +107,7 @@
 ; GCN-O0-NEXT:        MachinePostDominator Tree Construction
 ; GCN-O0-NEXT:        SI Lower i1 Copies
 ; GCN-O0-NEXT:        Finalize ISel and expand pseudo-instructions
+; GCN-O0-NEXT:        Remove unused oracle functions
 ; GCN-O0-NEXT:        Local Stack Slot Allocation
 ; GCN-O0-NEXT:        Register Usage Information Propagation
 ; GCN-O0-NEXT:        Eliminate PHI nodes for register allocation
@@ -322,6 +323,7 @@
 ; GCN-O1-NEXT:        MachinePostDominator Tree Construction
 ; GCN-O1-NEXT:        SI Lower i1 Copies
 ; GCN-O1-NEXT:        Finalize ISel and expand pseudo-instructions
+; GCN-O1-NEXT:        Remove unused oracle functions
 ; GCN-O1-NEXT:        Lazy Machine Block Frequency Analysis
 ; GCN-O1-NEXT:        Early Tail Duplication
 ; GCN-O1-NEXT:        Optimize machine instruction PHIs
@@ -637,6 +639,7 @@
 ; GCN-O1-OPTS-NEXT:        MachinePostDominator Tree Construction
 ; GCN-O1-OPTS-NEXT:        SI Lower i1 Copies
 ; GCN-O1-OPTS-NEXT:        Finalize ISel and expand pseudo-instructions
+; GCN-O1-OPTS-NEXT:        Remove unused oracle functions
 ; GCN-O1-OPTS-NEXT:        Lazy Machine Block Frequency Analysis
 ; GCN-O1-OPTS-NEXT:        Early Tail Duplication
 ; GCN-O1-OPTS-NEXT:        Optimize machine instruction PHIs
@@ -963,6 +966,7 @@
 ; GCN-O2-NEXT:        MachinePostDominator Tree Construction
 ; GCN-O2-NEXT:        SI Lower i1 Copies
 ; GCN-O2-NEXT:        Finalize ISel and expand pseudo-instructions
+; GCN-O2-NEXT:        Remove unused oracle functions
 ; GCN-O2-NEXT:        Lazy Machine Block Frequency Analysis
 ; GCN-O2-NEXT:        Early Tail Duplication
 ; GCN-O2-NEXT:        Optimize machine instruction PHIs
@@ -1303,6 +1307,7 @@
 ; GCN-O3-NEXT:        MachinePostDominator Tree Construction
 ; GCN-O3-NEXT:        SI Lower i1 Copies
 ; GCN-O3-NEXT:        Finalize ISel and expand pseudo-instructions
+; GCN-O3-NEXT:        Remove unused oracle functions
 ; GCN-O3-NEXT:        Lazy Machine Block Frequency Analysis
 ; GCN-O3-NEXT:        Early Tail Duplication
 ; GCN-O3-NEXT:        Optimize machine instruction PHIs

--- a/llvm/test/CodeGen/ARM/O3-pipeline.ll
+++ b/llvm/test/CodeGen/ARM/O3-pipeline.ll
@@ -86,6 +86,7 @@
 ; CHECK-NEXT:      Lazy Block Frequency Analysis
 ; CHECK-NEXT:      ARM Instruction Selection
 ; CHECK-NEXT:      Finalize ISel and expand pseudo-instructions
+; CHECK-NEXT:      Remove unused oracle functions
 ; CHECK-NEXT:      Lazy Machine Block Frequency Analysis
 ; CHECK-NEXT:      Early Tail Duplication
 ; CHECK-NEXT:      Optimize machine instruction PHIs

--- a/llvm/test/CodeGen/LoongArch/O0-pipeline.ll
+++ b/llvm/test/CodeGen/LoongArch/O0-pipeline.ll
@@ -38,6 +38,7 @@
 ; CHECK-NEXT:       Assignment Tracking Analysis
 ; CHECK-NEXT:       LoongArch DAG->DAG Pattern Instruction Selection
 ; CHECK-NEXT:       Finalize ISel and expand pseudo-instructions
+; CHECK-NEXT:       Remove unused oracle functions
 ; CHECK-NEXT:       Local Stack Slot Allocation
 ; CHECK-NEXT:       LoongArch Pre-RA pseudo instruction expansion pass
 ; CHECK-NEXT:       Eliminate PHI nodes for register allocation

--- a/llvm/test/CodeGen/LoongArch/opt-pipeline.ll
+++ b/llvm/test/CodeGen/LoongArch/opt-pipeline.ll
@@ -93,6 +93,7 @@
 ; LAXX-NEXT:       Lazy Block Frequency Analysis
 ; LAXX-NEXT:       LoongArch DAG->DAG Pattern Instruction Selection
 ; LAXX-NEXT:       Finalize ISel and expand pseudo-instructions
+; LAXX-NEXT:       Remove unused oracle functions
 ; LAXX-NEXT:       Lazy Machine Block Frequency Analysis
 ; LAXX-NEXT:       Early Tail Duplication
 ; LAXX-NEXT:       Optimize machine instruction PHIs

--- a/llvm/test/CodeGen/PowerPC/O0-pipeline.ll
+++ b/llvm/test/CodeGen/PowerPC/O0-pipeline.ll
@@ -38,6 +38,7 @@
 ; CHECK-NEXT:       PowerPC DAG->DAG Pattern Instruction Selection
 ; CHECK-NEXT:       PowerPC VSX Copy Legalization
 ; CHECK-NEXT:       Finalize ISel and expand pseudo-instructions
+; CHECK-NEXT:       Remove unused oracle functions
 ; CHECK-NEXT:       Local Stack Slot Allocation
 ; CHECK-NEXT:       Remove unreachable machine basic blocks
 ; CHECK-NEXT:       Live Variable Analysis

--- a/llvm/test/CodeGen/PowerPC/O3-pipeline.ll
+++ b/llvm/test/CodeGen/PowerPC/O3-pipeline.ll
@@ -105,6 +105,7 @@
 ; CHECK-NEXT:       PowerPC CTR Loops Verify
 ; CHECK-NEXT:       PowerPC VSX Copy Legalization
 ; CHECK-NEXT:       Finalize ISel and expand pseudo-instructions
+; CHECK-NEXT:       Remove unused oracle functions
 ; CHECK-NEXT:       MachineDominator Tree Construction
 ; CHECK-NEXT:       Machine Natural Loop Construction
 ; CHECK-NEXT:       PowerPC CTR loops generation

--- a/llvm/test/CodeGen/RISCV/O0-pipeline.ll
+++ b/llvm/test/CodeGen/RISCV/O0-pipeline.ll
@@ -39,6 +39,7 @@
 ; CHECK-NEXT:       Assignment Tracking Analysis
 ; CHECK-NEXT:       RISC-V DAG->DAG Pattern Instruction Selection
 ; CHECK-NEXT:       Finalize ISel and expand pseudo-instructions
+; CHECK-NEXT:       Remove unused oracle functions
 ; CHECK-NEXT:       Local Stack Slot Allocation
 ; CHECK-NEXT:       RISC-V Pre-RA pseudo instruction expansion pass
 ; CHECK-NEXT:       RISC-V Insert Read/Write CSR Pass

--- a/llvm/test/CodeGen/RISCV/O3-pipeline.ll
+++ b/llvm/test/CodeGen/RISCV/O3-pipeline.ll
@@ -110,6 +110,7 @@
 ; CHECK-NEXT:       Lazy Block Frequency Analysis
 ; CHECK-NEXT:       RISC-V DAG->DAG Pattern Instruction Selection
 ; CHECK-NEXT:       Finalize ISel and expand pseudo-instructions
+; CHECK-NEXT:       Remove unused oracle functions
 ; CHECK-NEXT:       MachineDominator Tree Construction
 ; CHECK-NEXT:       RISC-V VL Optimizer
 ; CHECK-NEXT:       RISC-V Vector Peephole Optimization

--- a/llvm/test/CodeGen/SPIRV/llc-pipeline.ll
+++ b/llvm/test/CodeGen/SPIRV/llc-pipeline.ll
@@ -67,6 +67,7 @@
 ; SPIRV-O0-NEXT:      InstructionSelect
 ; SPIRV-O0-NEXT:      ResetMachineFunction
 ; SPIRV-O0-NEXT:      Finalize ISel and expand pseudo-instructions
+; SPIRV-O0-NEXT:      Remove unused oracle functions
 ; SPIRV-O0-NEXT:      Local Stack Slot Allocation
 ; SPIRV-O0-NEXT:      Remove Redundant DEBUG_VALUE analysis
 ; SPIRV-O0-NEXT:      Fixup Statepoint Caller Saved
@@ -186,6 +187,7 @@
 ; SPIRV-Opt-NEXT:      InstructionSelect
 ; SPIRV-Opt-NEXT:      ResetMachineFunction
 ; SPIRV-Opt-NEXT:      Finalize ISel and expand pseudo-instructions
+; SPIRV-Opt-NEXT:      Remove unused oracle functions
 ; SPIRV-Opt-NEXT:      Lazy Machine Block Frequency Analysis
 ; SPIRV-Opt-NEXT:      Early Tail Duplication
 ; SPIRV-Opt-NEXT:      Optimize machine instruction PHIs

--- a/llvm/test/CodeGen/X86/O0-pipeline.ll
+++ b/llvm/test/CodeGen/X86/O0-pipeline.ll
@@ -41,6 +41,7 @@
 ; CHECK-NEXT:       X86 PIC Global Base Reg Initialization
 ; CHECK-NEXT:       Argument Stack Rebase
 ; CHECK-NEXT:       Finalize ISel and expand pseudo-instructions
+; CHECK-NEXT:       Remove unused oracle functions
 ; CHECK-NEXT:       Local Stack Slot Allocation
 ; CHECK-NEXT:       X86 Suppress APX features for relocation
 ; CHECK-NEXT:       X86 speculative load hardening

--- a/llvm/test/CodeGen/X86/opt-pipeline.ll
+++ b/llvm/test/CodeGen/X86/opt-pipeline.ll
@@ -97,6 +97,7 @@
 ; CHECK-NEXT:       X86 PIC Global Base Reg Initialization
 ; CHECK-NEXT:       Argument Stack Rebase
 ; CHECK-NEXT:       Finalize ISel and expand pseudo-instructions
+; CHECK-NEXT:       Remove unused oracle functions
 ; CHECK-NEXT:       X86 Domain Reassignment Pass
 ; CHECK-NEXT:       Lazy Machine Block Frequency Analysis
 ; CHECK-NEXT:       Early Tail Duplication


### PR DESCRIPTION
Add a simple MachineFunction pass that marks functions for deletion, by adjusting the linkage to AvailableExternallyLinkage.

The intended use case is cleaning up dead oracle functions for speculative loads.