### PR TITLE
[lldb][bytecode] Swift output is conditional on >=6.3

### DIFF
--- a/lldb/examples/python/formatter_bytecode.py
+++ b/lldb/examples/python/formatter_bytecode.py
@@ -335,6 +335,7 @@ class BytecodeSection:
         print(
             textwrap.dedent(
                 """\
+                #if swift(>=6.3)
                 #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS) || os(visionOS)
                 @section("__DATA_CONST,__lldbformatters")
                 #else
@@ -354,6 +355,7 @@ class BytecodeSection:
             byte_list = ", ".join(f"0x{b:02x}" for b in bs)
             print(f"{indent}{byte_list},", file=output)
         print(")", file=output)
+        print("#endif", file=output)  # swift(>=6.3)
 
 
 def assemble_file(type_name: str, input: TextIO) -> BytecodeSection:

--- a/lldb/test/Shell/ScriptInterpreter/Python/Inputs/FormatterBytecode/RigidArrayLLDBFormatterSwift.txt
+++ b/lldb/test/Shell/ScriptInterpreter/Python/Inputs/FormatterBytecode/RigidArrayLLDBFormatterSwift.txt
@@ -1,3 +1,4 @@
+#if swift(>=6.3)
 #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS) || os(visionOS)
 @section("__DATA_CONST,__lldbformatters")
 #else
@@ -34,3 +35,4 @@ let _RigidArray_formatter: (UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UIn
     // program
     0x20, 0x01, 0x03, 0x20, 0x03, 0x03, 0x23, 0x11, 0x60, 0x13,
 )
+#endif


### PR DESCRIPTION
The `@section` and `@used` attributes are available in Swift 6.3 and later. See [SE-0492](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0492-section-control.md).

Prior to 6.3, these were available as `@_section` and `@_used`, however those require enabling the `SymbolLinkageMarkers ` experimental feature.