### PR TITLE
[VPlan] Use RPOT in CSE, fixing potential crash

### DIFF
--- a/llvm/lib/Transforms/Vectorize/VPlanTransforms.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanTransforms.cpp
@@ -2630,8 +2630,9 @@ void VPlanTransforms::cse(VPlan &Plan) {
   VPDominatorTree VPDT(Plan);
   DenseMap<VPSingleDefRecipe *, VPSingleDefRecipe *, VPCSEDenseMapInfo> CSEMap;
 
-  for (VPBasicBlock *VPBB : VPBlockUtils::blocksOnly<VPBasicBlock>(
-           vp_depth_first_deep(Plan.getEntry()))) {
+  ReversePostOrderTraversal<VPBlockDeepTraversalWrapper<VPBlockBase *>> RPOT(
+      Plan.getEntry());
+  for (VPBasicBlock *VPBB : VPBlockUtils::blocksOnly<VPBasicBlock>(RPOT)) {
     for (VPRecipeBase &R : *VPBB) {
       auto *Def = dyn_cast<VPSingleDefRecipe>(&R);
       if (!Def || !VPCSEDenseMapInfo::canHandle(Def))


### PR DESCRIPTION
A CSE crash is observed arising from outdated hash values unless we forbid replacements in successor phis in blocks that are not dominated by the def: the crash is observed when there is a block with CSE'able phis with CSE'able incoming values, with incoming values coming from a non-dominating block, under the condition that the block with the phis is visited before the non-dominating block. It is unfortunately impossible to write a test case showing a crash at present, but crashes do occur when attempting to CSE DerivedIV recipes. The root cause of the crash is visiting a non-dominated use before a def, and hence would be fixed by a reverse post-order traversal.

Fixes #187499.