### PR TITLE
[AMDGPU][SIInsertWaitcnts][NFC] Common InstCounterType printer

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUWaitcntUtils.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUWaitcntUtils.cpp
@@ -50,8 +50,7 @@ StringLiteral getInstCounterName(InstCounterType T, bool HasExtendedWaitcnts) {
 
 #if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 void Waitcnt::dump(bool HasExtendedWaitcnts) const {
-  print(dbgs(), HasExtendedWaitcnts);
-  dbgs() << '\n';
+  dbgs() << getPrintable(dbgs(), HasExtendedWaitcnts) << '\n';
 }
 #endif
 

--- a/llvm/lib/Target/AMDGPU/AMDGPUWaitcntUtils.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUWaitcntUtils.cpp
@@ -15,16 +15,19 @@ iota_range<InstCounterType> inst_counter_types(InstCounterType MaxCounter) {
   return enum_seq(LOAD_CNT, MaxCounter);
 }
 
-StringLiteral getInstCounterName(InstCounterType T) {
+StringLiteral getInstCounterName(InstCounterType T, bool HasExtendedWaitcnts) {
   switch (T) {
   case LOAD_CNT:
-    return "LOAD_CNT";
+    return HasExtendedWaitcnts ? StringLiteral("LOAD_CNT")
+                               : StringLiteral("VM_CNT");
   case DS_CNT:
-    return "DS_CNT";
+    return HasExtendedWaitcnts ? StringLiteral("DS_CNT")
+                               : StringLiteral("LGKM_CNT");
   case EXP_CNT:
     return "EXP_CNT";
   case STORE_CNT:
-    return "STORE_CNT";
+    return HasExtendedWaitcnts ? StringLiteral("STORE_CNT")
+                               : StringLiteral("VS_CNT");
   case SAMPLE_CNT:
     return "SAMPLE_CNT";
   case BVH_CNT:
@@ -46,7 +49,10 @@ StringLiteral getInstCounterName(InstCounterType T) {
 }
 
 #if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
-void Waitcnt::dump() const { dbgs() << *this << '\n'; }
+void Waitcnt::dump(bool HasExtendedWaitcnts) const {
+  print(dbgs(), HasExtendedWaitcnts);
+  dbgs() << '\n';
+}
 #endif
 
 Waitcnt decodeWaitcnt(const IsaVersion &Version, unsigned Encoded) {

--- a/llvm/lib/Target/AMDGPU/AMDGPUWaitcntUtils.h
+++ b/llvm/lib/Target/AMDGPU/AMDGPUWaitcntUtils.h
@@ -37,7 +37,7 @@ enum InstCounterType {
   NUM_INST_CNTS = NUM_EXPERT_INST_CNTS
 };
 
-StringLiteral getInstCounterName(InstCounterType T);
+StringLiteral getInstCounterName(InstCounterType T, bool HasExtendedWaitcnts);
 
 // Return an iterator over all counters between LOAD_CNT (the first counter)
 // and \c MaxCounter (exclusive, default value yields an enumeration over
@@ -121,23 +121,18 @@ public:
     return Wait;
   }
 
-  void print(raw_ostream &OS) const {
+  void print(raw_ostream &OS, bool HasExtendedWaitcnts) const {
     ListSeparator LS;
     for (InstCounterType T : inst_counter_types())
-      OS << LS << getInstCounterName(T) << ": " << Cnt[T];
+      OS << LS << getInstCounterName(T, HasExtendedWaitcnts) << ": " << Cnt[T];
     if (LS.unused())
       OS << "none";
     OS << '\n';
   }
 
 #if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
-  LLVM_DUMP_METHOD void dump() const;
+  LLVM_DUMP_METHOD void dump(bool HasExtendedWaitcnts) const;
 #endif
-
-  friend raw_ostream &operator<<(raw_ostream &OS, const AMDGPU::Waitcnt &Wait) {
-    Wait.print(OS);
-    return OS;
-  }
 };
 
 Waitcnt decodeWaitcnt(const IsaVersion &Version, unsigned Encoded);

--- a/llvm/lib/Target/AMDGPU/AMDGPUWaitcntUtils.h
+++ b/llvm/lib/Target/AMDGPU/AMDGPUWaitcntUtils.h
@@ -12,6 +12,7 @@
 #include "llvm/ADT/Sequence.h"
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/Support/Debug.h"
+#include "llvm/Support/Printable.h"
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/TargetParser/TargetParser.h"
 
@@ -121,13 +122,20 @@ public:
     return Wait;
   }
 
+  Printable getPrintable(raw_ostream &OS, bool HasExtendedWaitcnts) const {
+    return Printable([HasExtendedWaitcnts, this](raw_ostream &OS) {
+      ListSeparator LS;
+      for (InstCounterType T : inst_counter_types())
+        OS << LS << getInstCounterName(T, HasExtendedWaitcnts) << ": "
+           << Cnt[T];
+      if (LS.unused())
+        OS << "none";
+      OS << '\n';
+    });
+  }
+
   void print(raw_ostream &OS, bool HasExtendedWaitcnts) const {
-    ListSeparator LS;
-    for (InstCounterType T : inst_counter_types())
-      OS << LS << getInstCounterName(T, HasExtendedWaitcnts) << ": " << Cnt[T];
-    if (LS.unused())
-      OS << "none";
-    OS << '\n';
+    OS << getPrintable(OS, HasExtendedWaitcnts);
   }
 
 #if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)

--- a/llvm/lib/Target/AMDGPU/SIInsertWaitcnts.cpp
+++ b/llvm/lib/Target/AMDGPU/SIInsertWaitcnts.cpp
@@ -1552,8 +1552,9 @@ AMDGPU::Waitcnt WaitcntBrackets::determineAsyncWait(unsigned N) {
   });
   AsyncMarks.erase(AsyncMarks.begin(), AsyncMarks.begin() + MarkIndex + 1);
 
-  LLVM_DEBUG(dbgs() << "Waits to add: ";
-             Wait.print(dbgs(), Context->ST.hasExtendedWaitCounts()););
+  LLVM_DEBUG(
+      dbgs() << "Waits to add: "
+             << Wait.getPrintable(dbgs(), Context->ST.hasExtendedWaitCounts()));
   return Wait;
 }
 
@@ -1776,13 +1777,15 @@ bool WaitcntGeneratorPreGFX12::applyPreexistingWaitcnt(
     } else if (Opcode == AMDGPU::S_WAITCNT_lds_direct) {
       assert(ST.hasVMemToLDSLoad());
       LLVM_DEBUG(
-          dbgs() << "Processing S_WAITCNT_lds_direct: " << II << "Before: ";
-          Wait.print(dbgs(), /*HasExtendedWaitcnts=*/false); dbgs() << '\n';);
+          dbgs() << "Processing S_WAITCNT_lds_direct: " << II << "Before: "
+                 << Wait.getPrintable(dbgs(), /*HasExtendedWaitcnts=*/false)
+                 << '\n');
       ScoreBrackets.determineWaitForLDSDMA(AMDGPU::LOAD_CNT, LDSDMA_BEGIN,
                                            Wait);
-      LLVM_DEBUG(dbgs() << "After: ";
-                 Wait.print(dbgs(), /*HasExtendedWaitcnts=*/false);
-                 dbgs() << '\n';);
+      LLVM_DEBUG(
+          dbgs() << "After: "
+                 << Wait.getPrintable(dbgs(), /*HasExtendedWaitcnts=*/false)
+                 << '\n');
 
       // It is possible (but unlikely) that this is the only wait instruction,
       // in which case, we exit this loop without a WaitcntInstr to consume

--- a/llvm/lib/Target/AMDGPU/SIInsertWaitcnts.cpp
+++ b/llvm/lib/Target/AMDGPU/SIInsertWaitcnts.cpp
@@ -1329,47 +1329,8 @@ void WaitcntBrackets::print(raw_ostream &OS) const {
 
   for (auto T : inst_counter_types(Context->MaxCounter)) {
     unsigned SR = getScoreRange(T);
-    switch (T) {
-    case AMDGPU::LOAD_CNT:
-      OS << "    " << (ST.hasExtendedWaitCounts() ? "LOAD" : "VM") << "_CNT("
-         << SR << "):";
-      break;
-    case AMDGPU::DS_CNT:
-      OS << "    " << (ST.hasExtendedWaitCounts() ? "DS" : "LGKM") << "_CNT("
-         << SR << "):";
-      break;
-    case AMDGPU::EXP_CNT:
-      OS << "    EXP_CNT(" << SR << "):";
-      break;
-    case AMDGPU::STORE_CNT:
-      OS << "    " << (ST.hasExtendedWaitCounts() ? "STORE" : "VS") << "_CNT("
-         << SR << "):";
-      break;
-    case AMDGPU::SAMPLE_CNT:
-      OS << "    SAMPLE_CNT(" << SR << "):";
-      break;
-    case AMDGPU::BVH_CNT:
-      OS << "    BVH_CNT(" << SR << "):";
-      break;
-    case AMDGPU::KM_CNT:
-      OS << "    KM_CNT(" << SR << "):";
-      break;
-    case AMDGPU::X_CNT:
-      OS << "    X_CNT(" << SR << "):";
-      break;
-    case AMDGPU::ASYNC_CNT:
-      OS << "    ASYNC_CNT(" << SR << "):";
-      break;
-    case AMDGPU::VA_VDST:
-      OS << "    VA_VDST(" << SR << "): ";
-      break;
-    case AMDGPU::VM_VSRC:
-      OS << "    VM_VSRC(" << SR << "): ";
-      break;
-    default:
-      OS << "    UNKNOWN(" << SR << "):";
-      break;
-    }
+    OS << "    " << getInstCounterName(T, ST.hasExtendedWaitCounts()) << "("
+       << SR << "):";
 
     if (SR != 0) {
       // Print vgpr scores.
@@ -1436,41 +1397,7 @@ void WaitcntBrackets::print(raw_ostream &OS) const {
   for (const auto &Mark : AsyncMarks) {
     for (auto T : AMDGPU::inst_counter_types()) {
       unsigned MarkedScore = Mark[T];
-      switch (T) {
-      case AMDGPU::LOAD_CNT:
-        OS << "  " << (ST.hasExtendedWaitCounts() ? "LOAD" : "VM")
-           << "_CNT: " << MarkedScore;
-        break;
-      case AMDGPU::DS_CNT:
-        OS << "  " << (ST.hasExtendedWaitCounts() ? "DS" : "LGKM")
-           << "_CNT: " << MarkedScore;
-        break;
-      case AMDGPU::EXP_CNT:
-        OS << "  EXP_CNT: " << MarkedScore;
-        break;
-      case AMDGPU::STORE_CNT:
-        OS << "  " << (ST.hasExtendedWaitCounts() ? "STORE" : "VS")
-           << "_CNT: " << MarkedScore;
-        break;
-      case AMDGPU::SAMPLE_CNT:
-        OS << "  SAMPLE_CNT: " << MarkedScore;
-        break;
-      case AMDGPU::BVH_CNT:
-        OS << "  BVH_CNT: " << MarkedScore;
-        break;
-      case AMDGPU::KM_CNT:
-        OS << "  KM_CNT: " << MarkedScore;
-        break;
-      case AMDGPU::X_CNT:
-        OS << "  X_CNT: " << MarkedScore;
-        break;
-      case AMDGPU::ASYNC_CNT:
-        OS << "  ASYNC_CNT: " << MarkedScore;
-        break;
-      default:
-        OS << "  UNKNOWN: " << MarkedScore;
-        break;
-      }
+      OS << getInstCounterName(T, ST.hasExtendedWaitCounts()) << MarkedScore;
     }
     OS << '\n';
   }
@@ -1625,7 +1552,8 @@ AMDGPU::Waitcnt WaitcntBrackets::determineAsyncWait(unsigned N) {
   });
   AsyncMarks.erase(AsyncMarks.begin(), AsyncMarks.begin() + MarkIndex + 1);
 
-  LLVM_DEBUG(dbgs() << "Waits to add: " << Wait);
+  LLVM_DEBUG(dbgs() << "Waits to add: ";
+             Wait.print(dbgs(), Context->ST.hasExtendedWaitCounts()););
   return Wait;
 }
 
@@ -1847,11 +1775,14 @@ bool WaitcntGeneratorPreGFX12::applyPreexistingWaitcnt(
         WaitcntInstr = &II;
     } else if (Opcode == AMDGPU::S_WAITCNT_lds_direct) {
       assert(ST.hasVMemToLDSLoad());
-      LLVM_DEBUG(dbgs() << "Processing S_WAITCNT_lds_direct: " << II
-                        << "Before: " << Wait << '\n';);
+      LLVM_DEBUG(
+          dbgs() << "Processing S_WAITCNT_lds_direct: " << II << "Before: ";
+          Wait.print(dbgs(), /*HasExtendedWaitcnts=*/false); dbgs() << '\n';);
       ScoreBrackets.determineWaitForLDSDMA(AMDGPU::LOAD_CNT, LDSDMA_BEGIN,
                                            Wait);
-      LLVM_DEBUG(dbgs() << "After: " << Wait << '\n';);
+      LLVM_DEBUG(dbgs() << "After: ";
+                 Wait.print(dbgs(), /*HasExtendedWaitcnts=*/false);
+                 dbgs() << '\n';);
 
       // It is possible (but unlikely) that this is the only wait instruction,
       // in which case, we exit this loop without a WaitcntInstr to consume


### PR DESCRIPTION
This patch extends the functionality of the InstCounterType printer by adding a `HasExtendedWaitcnts` argument and printing the correct counter names accordingly.

This change helps us reuse this printer in a couple of places in the code.