### PR TITLE
[clang][headers][endian.h] add some common extensions

### DIFF
--- a/clang/lib/Headers/endian.h
+++ b/clang/lib/Headers/endian.h
@@ -28,6 +28,21 @@
 #define PDP_ENDIAN __ORDER_PDP_ENDIAN__
 #define BYTE_ORDER __BYTE_ORDER__
 
+
+// Define some compatibility macros if they are not defined.
+#ifndef __BYTE_ORDER
+#define __BYTE_ORDER BYTE_ORDER
+#endif
+#ifndef __LITTLE_ENDIAN
+#define __LITTLE_ENDIAN LITTLE_ENDIAN
+#endif
+#ifndef __BIG_ENDIAN
+#define __BIG_ENDIAN BIG_ENDIAN
+#endif
+#ifndef __PDP_ENDIAN
+#define __PDP_ENDIAN PDP_ENDIAN
+#endif
+
 #if BYTE_ORDER == LITTLE_ENDIAN
 
 #define htobe16(x)                                                             \

--- a/clang/lib/Headers/endian.h
+++ b/clang/lib/Headers/endian.h
@@ -28,7 +28,6 @@
 #define PDP_ENDIAN __ORDER_PDP_ENDIAN__
 #define BYTE_ORDER __BYTE_ORDER__
 
-
 // Define some compatibility macros if they are not defined.
 #ifndef __BYTE_ORDER
 #define __BYTE_ORDER BYTE_ORDER

--- a/clang/lib/Headers/endian.h
+++ b/clang/lib/Headers/endian.h
@@ -25,6 +25,7 @@
 
 #define LITTLE_ENDIAN __ORDER_LITTLE_ENDIAN__
 #define BIG_ENDIAN __ORDER_BIG_ENDIAN__
+#define PDP_ENDIAN __ORDER_PDP_ENDIAN__
 #define BYTE_ORDER __BYTE_ORDER__
 
 #if BYTE_ORDER == LITTLE_ENDIAN
@@ -48,7 +49,7 @@
 #define le32toh(x) __CLANG_ENDIAN_CAST(static_cast, uint32_t, x)
 #define le64toh(x) __CLANG_ENDIAN_CAST(static_cast, uint64_t, x)
 
-#else
+#elif BYTE_ORDER == BIG_ENDIAN
 
 #define htobe16(x) __CLANG_ENDIAN_CAST(static_cast, uint16_t, x)
 #define htobe32(x) __CLANG_ENDIAN_CAST(static_cast, uint32_t, x)
@@ -69,6 +70,8 @@
 #define le64toh(x)                                                             \
   __builtin_bswap64(__CLANG_ENDIAN_CAST(static_cast, uint64_t, x))
 
+#else
+#error "Unsupported endianness"
 #endif
 #endif // __has_include_next
 #endif // __CLANG_ENDIAN_H

--- a/clang/test/Headers/endian.c
+++ b/clang/test/Headers/endian.c
@@ -6,6 +6,9 @@
 
 #include <endian.h>
 
+_Static_assert(__LITTLE_ENDIAN == __ORDER_LITTLE_ENDIAN__, "");
+_Static_assert(__BIG_ENDIAN == __ORDER_BIG_ENDIAN__, "");
+_Static_assert(__PDP_ENDIAN == __ORDER_PDP_ENDIAN__, "");
 
 #if BYTE_ORDER == BIG_ENDIAN
 


### PR DESCRIPTION
This PR adds two common extensions to `endian.h` found in some implementations which we've encountered usages of existing code (which are allowable under POSIX), namely:

- double underscore versions of the byte order macros
- PDP endianness macros  

(note: we don't attempt to implement the actual conversion helpers for PDP endianness, as LLVM doesn't support these targeting platforms with this endianness, we just provide the macro so code checking against them on other targets will compile)