### PR TITLE
[MachineScheduler] Improve handling of phys regs in GenericScheduler() (NFC).

### DIFF
--- a/llvm/include/llvm/CodeGen/MachineScheduler.h
+++ b/llvm/include/llvm/CodeGen/MachineScheduler.h
@@ -1252,8 +1252,12 @@ LLVM_ABI bool tryPressure(const PressureChange &TryP,
                           GenericSchedulerBase::CandReason Reason,
                           const TargetRegisterInfo *TRI,
                           const MachineFunction &MF);
+LLVM_ABI bool tryBiasPhysRegs(GenericSchedulerBase::SchedCandidate &TryCand,
+                              GenericSchedulerBase::SchedCandidate &Cand,
+                              SchedBoundary *Zone, bool BiasPRegsExtra);
 LLVM_ABI unsigned getWeakLeft(const SUnit *SU, bool isTop);
-LLVM_ABI int biasPhysReg(const SUnit *SU, bool isTop);
+LLVM_ABI int biasPhysReg(const SUnit *SU, bool isTop,
+                         bool BiasPRegsExtra = false);
 
 /// GenericScheduler shrinks the unscheduled zone using heuristics to balance
 /// the schedule.

--- a/llvm/include/llvm/CodeGen/MachineScheduler.h
+++ b/llvm/include/llvm/CodeGen/MachineScheduler.h
@@ -218,6 +218,9 @@ struct MachineSchedPolicy {
   // Compute DFSResult for use in scheduling heuristics.
   bool ComputeDFSResult = false;
 
+  // If enabled, some extra cases of physreg defs will be biased towards user.
+  bool BiasPRegsExtra = false;
+
   MachineSchedPolicy() = default;
 };
 

--- a/llvm/include/llvm/CodeGen/TargetInstrInfo.h
+++ b/llvm/include/llvm/CodeGen/TargetInstrInfo.h
@@ -1664,6 +1664,10 @@ public:
     llvm_unreachable("target did not implement shouldClusterMemOps()");
   }
 
+  // GenericScheduler: Handle non COPY/immLoad physreg defs, and maintain
+  // input order if both are biased same way.
+  virtual bool biasPRegsExtra() const { return false; }
+
   /// Reverses the branch condition of the specified condition list,
   /// returning false on success and true if it cannot be reversed.
   virtual bool

--- a/llvm/include/llvm/CodeGen/TargetInstrInfo.h
+++ b/llvm/include/llvm/CodeGen/TargetInstrInfo.h
@@ -1664,10 +1664,6 @@ public:
     llvm_unreachable("target did not implement shouldClusterMemOps()");
   }
 
-  // GenericScheduler: Handle non COPY/immLoad physreg defs, and maintain
-  // input order if both are biased same way.
-  virtual bool biasPRegsExtra() const { return false; }
-
   /// Reverses the branch condition of the specified condition list,
   /// returning false on success and true if it cannot be reversed.
   virtual bool

--- a/llvm/lib/CodeGen/MachineScheduler.cpp
+++ b/llvm/lib/CodeGen/MachineScheduler.cpp
@@ -3837,7 +3837,7 @@ unsigned llvm::getWeakLeft(const SUnit *SU, bool isTop) {
 /// copies which can be prescheduled. The rest (e.g. x86 MUL) could be bundled
 /// with the operation that produces or consumes the physreg. We'll do this when
 /// regalloc has support for parallel copies.
-int llvm::biasPhysReg(const SUnit *SU, bool isTop) {
+int llvm::biasPhysReg(const SUnit *SU, bool isTop, bool BiasPRegsExtra) {
   const MachineInstr *MI = SU->getInstr();
 
   if (MI->isCopy()) {
@@ -3870,7 +3870,36 @@ int llvm::biasPhysReg(const SUnit *SU, bool isTop) {
       return isTop ? -1 : 1;
   }
 
+  if (BiasPRegsExtra && !isTop && MI->getNumOperands()) {
+    // Register coalescer will create cases of e.g. Load Address of a frame
+    // index directly into a physreg.
+    const MachineOperand &DefMO = MI->getOperand(0);
+    return DefMO.isReg() && DefMO.isDef() && DefMO.getReg().isPhysical();
+  }
+
   return 0;
+}
+
+bool llvm::tryBiasPhysRegs(GenericSchedulerBase::SchedCandidate &TryCand,
+                           GenericSchedulerBase::SchedCandidate &Cand,
+                           SchedBoundary *Zone, bool BiasPRegsExtra) {
+  int TryCandPRegBias = biasPhysReg(TryCand.SU, TryCand.AtTop, BiasPRegsExtra);
+  int CandPRegBias = biasPhysReg(Cand.SU, Cand.AtTop, BiasPRegsExtra);
+  if (tryGreater(TryCandPRegBias, CandPRegBias, TryCand, Cand,
+                 GenericSchedulerBase::PhysReg))
+    return true;
+  if (BiasPRegsExtra && Zone != nullptr && TryCandPRegBias &&
+      TryCandPRegBias == CandPRegBias) {
+    // Both biased same way - maintain their input order.
+    if (Zone->isTop())
+      tryLess(TryCand.SU->NodeNum, Cand.SU->NodeNum, TryCand, Cand,
+              GenericSchedulerBase::NodeOrder);
+    else
+      tryGreater(TryCand.SU->NodeNum, Cand.SU->NodeNum, TryCand, Cand,
+                 GenericSchedulerBase::NodeOrder);
+    return true;
+  }
+  return false;
 }
 
 void GenericScheduler::initCandidate(SchedCandidate &Cand, SUnit *SU,
@@ -3931,8 +3960,7 @@ bool GenericScheduler::tryCandidate(SchedCandidate &Cand,
   }
 
   // Bias PhysReg Defs and copies to their uses and defined respectively.
-  if (tryGreater(biasPhysReg(TryCand.SU, TryCand.AtTop),
-                 biasPhysReg(Cand.SU, Cand.AtTop), TryCand, Cand, PhysReg))
+  if (tryBiasPhysRegs(TryCand, Cand, Zone, DAG->TII->biasPRegsExtra()))
     return TryCand.Reason != NoCand;
 
   // Avoid exceeding the target's limit.

--- a/llvm/lib/CodeGen/MachineScheduler.cpp
+++ b/llvm/lib/CodeGen/MachineScheduler.cpp
@@ -3870,12 +3870,10 @@ int llvm::biasPhysReg(const SUnit *SU, bool isTop, bool BiasPRegsExtra) {
       return isTop ? -1 : 1;
   }
 
-  if (BiasPRegsExtra && !isTop && MI->getNumOperands()) {
+  if (BiasPRegsExtra && !isTop && MI->getNumExplicitDefs() == 1)
     // Register coalescer will create cases of e.g. Load Address of a frame
     // index directly into a physreg.
-    const MachineOperand &DefMO = MI->getOperand(0);
-    return DefMO.isReg() && DefMO.isDef() && DefMO.getReg().isPhysical();
-  }
+    return MI->getOperand(0).getReg().isPhysical();
 
   return 0;
 }

--- a/llvm/lib/CodeGen/MachineScheduler.cpp
+++ b/llvm/lib/CodeGen/MachineScheduler.cpp
@@ -3958,7 +3958,7 @@ bool GenericScheduler::tryCandidate(SchedCandidate &Cand,
   }
 
   // Bias PhysReg Defs and copies to their uses and defined respectively.
-  if (tryBiasPhysRegs(TryCand, Cand, Zone, DAG->TII->biasPRegsExtra()))
+  if (tryBiasPhysRegs(TryCand, Cand, Zone, RegionPolicy.BiasPRegsExtra))
     return TryCand.Reason != NoCand;
 
   // Avoid exceeding the target's limit.

--- a/llvm/lib/Target/SystemZ/SystemZMachineScheduler.cpp
+++ b/llvm/lib/Target/SystemZ/SystemZMachineScheduler.cpp
@@ -83,16 +83,6 @@ bool SystemZPreRASchedStrategy::definesCmp0Src(const MachineInstr *MI,
   return false;
 }
 
-static int biasPhysRegExtra(const SUnit *SU) {
-  if (int Res = biasPhysReg(SU, /*isTop=*/false))
-    return Res;
-
-  // Also recognize Load Address. Most of these are with an FI operand.
-  const MachineInstr *MI = SU->getInstr();
-  return MI->getNumOperands() && !MI->isCopy() &&
-         isPhysRegDef(MI->getOperand(0));
-}
-
 bool SystemZPreRASchedStrategy::tryCandidate(SchedCandidate &Cand,
                                              SchedCandidate &TryCand,
                                              SchedBoundary *Zone) const {
@@ -105,15 +95,8 @@ bool SystemZPreRASchedStrategy::tryCandidate(SchedCandidate &Cand,
   }
 
   // Bias physreg defs and copies to their uses and definitions respectively.
-  int TryCandPRegBias = biasPhysRegExtra(TryCand.SU);
-  int CandPRegBias = biasPhysRegExtra(Cand.SU);
-  if (tryGreater(TryCandPRegBias, CandPRegBias, TryCand, Cand, PhysReg))
+  if (tryBiasPhysRegs(TryCand, Cand, Zone, /*BiasPRegsExtra=*/true))
     return TryCand.Reason != NoCand;
-  if (TryCandPRegBias && CandPRegBias) {
-    // Both biased same way.
-    tryGreater(TryCand.SU->NodeNum, Cand.SU->NodeNum, TryCand, Cand, NodeOrder);
-    return TryCand.Reason != NoCand;
-  }
 
   // Don't extend the scheduled latency in regions with many nodes in data
   // sequences, or for (single block loop) regions that are acyclically

--- a/llvm/lib/Target/SystemZ/SystemZMachineScheduler.cpp
+++ b/llvm/lib/Target/SystemZ/SystemZMachineScheduler.cpp
@@ -19,10 +19,6 @@ static bool isRegDef(const MachineOperand &MO) {
   return MO.isReg() && MO.isDef();
 }
 
-static bool isPhysRegDef(const MachineOperand &MO) {
-  return isRegDef(MO) && MO.getReg().isPhysical();
-}
-
 void SystemZPreRASchedStrategy::initializeLatencyReduction() {
   // Enable latency reduction for a region that has a considerable amount of
   // data sequences that should be interlaved. These are SUs that only have


### PR DESCRIPTION
Factor out the handling of coalesced preg COPYs from SystemZMachineScheduler.cpp into MachineScheduler.cpp as this should be generally beneficial.

This extends the handling to other types of instructions than COPY or immediate loads, such as Load Address and takes care of maintaining the original input order if both SUs are biased the same way in the same zone.

This seems to be the best behavior on SystemZ at least and I don't know any reason to move these physreg defs around just because they are not COPYs or immloads.

When I enabled this by default a lot of tests on other targets failed which need updating. Therefore I have suggested wrapping this under a TII hook for now, returning false by default: biasPRegsExtra().

@atrick @arsenm @jrbyrnes @topperc @lucas-rami @uweigand 