### PR TITLE
[libc++] Fix negate and bit_xor in C++03 frozen headers

### DIFF
--- a/libcxx/include/__cxx03/__functional/operations.h
+++ b/libcxx/include/__cxx03/__functional/operations.h
@@ -67,7 +67,7 @@ struct _LIBCPP_TEMPLATE_VIS modulus : __binary_function<_Tp, _Tp, _Tp> {
 };
 _LIBCPP_CTAD_SUPPORTED_FOR_TYPE(modulus);
 
-template <class _Tp = void>
+template <class _Tp>
 struct _LIBCPP_TEMPLATE_VIS negate : __unary_function<_Tp, _Tp> {
   typedef _Tp __result_type; // used by valarray
   _LIBCPP_HIDE_FROM_ABI _Tp operator()(const _Tp& __x) const { return -__x; }
@@ -90,7 +90,7 @@ struct _LIBCPP_TEMPLATE_VIS bit_or : __binary_function<_Tp, _Tp, _Tp> {
 };
 _LIBCPP_CTAD_SUPPORTED_FOR_TYPE(bit_or);
 
-template <class _Tp = void>
+template <class _Tp>
 struct _LIBCPP_TEMPLATE_VIS bit_xor : __binary_function<_Tp, _Tp, _Tp> {
   typedef _Tp __result_type; // used by valarray
   _LIBCPP_HIDE_FROM_ABI _Tp operator()(const _Tp& __x, const _Tp& __y) const { return __x ^ __y; }


### PR DESCRIPTION
An unintended change in #134045 gave them a default template argument, which is supposed to be from C++14 onwards.

I considered adding a test for this but it is really awkward to test that we don't support passing no template argument in C++03 mode and that provides little value, so I decided against it.