### PR TITLE
[clang] Add -mlarge-eh-encoding driver flag

### DIFF
--- a/clang/include/clang/Basic/CodeGenOptions.def
+++ b/clang/include/clang/Basic/CodeGenOptions.def
@@ -257,6 +257,7 @@ VALUE_CODEGENOPT(MCDCMaxTVs, 32, 0x7FFFFFFE, Benign) ///< MC/DC Maximum test vec
   /// If -fpcc-struct-return or -freg-struct-return is specified.
 ENUM_CODEGENOPT(StructReturnConvention, StructReturnConventionKind, 2, SRCK_Default, Benign)
 
+CODEGENOPT(LargeEHEncoding   , 1, 0, Benign) ///< Use 8-byte pointer size for EH encodings.
 CODEGENOPT(RelaxAll          , 1, 0, Benign) ///< Relax all machine code instructions.
 CODEGENOPT(RelaxedAliasing   , 1, 0, Benign) ///< Set when -fno-strict-aliasing is enabled.
 CODEGENOPT(PointerTBAA       , 1, 1, Benign) ///< Whether or not to use distinct TBAA tags for pointers.

--- a/clang/include/clang/Options/Options.td
+++ b/clang/include/clang/Options/Options.td
@@ -6120,6 +6120,13 @@ def mred_zone : Flag<["-"], "mred-zone">, Group<m_Group>;
 def mtls_direct_seg_refs : Flag<["-"], "mtls-direct-seg-refs">, Group<m_Group>,
   HelpText<"Enable direct TLS access through segment registers (default)">;
 def mregparm_EQ : Joined<["-"], "mregparm=">, Group<m_Group>;
+def mlarge_eh_encoding : Flag<["-"], "mlarge-eh-encoding">, Group<m_Group>,
+  Visibility<[ClangOption, CC1Option, CC1AsOption]>,
+  HelpText<"Force 8-byte pointer size for all ELF EH encodings">,
+  MarshallingInfoFlag<CodeGenOpts<"LargeEHEncoding">>;
+def mno_large_eh_encoding : Flag<["-"], "mno-large-eh-encoding">, Group<m_Group>,
+  Visibility<[ClangOption, CC1Option, CC1AsOption]>,
+  HelpText<"Do not force 8-byte pointer size for all ELF EH encodings (default)">;
 def mrelax_all : Flag<["-"], "mrelax-all">, Group<m_Group>,
   Visibility<[ClangOption, CC1Option, CC1AsOption]>,
   HelpText<"(integrated-as) Relax all machine instructions">,

--- a/clang/lib/CodeGen/BackendUtil.cpp
+++ b/clang/lib/CodeGen/BackendUtil.cpp
@@ -526,6 +526,7 @@ static bool initTargetOptions(const CompilerInstance &CI,
   Options.MCOptions.RelocSectionSym = CodeGenOpts.getRelocSectionSym();
   Options.MCOptions.ImplicitMapSyms = CodeGenOpts.ImplicitMapSyms;
   Options.MCOptions.X86RelaxRelocations = CodeGenOpts.X86RelaxRelocations;
+  Options.MCOptions.LargeEHEncoding = CodeGenOpts.LargeEHEncoding;
   Options.MCOptions.CompressDebugSections =
       CodeGenOpts.getCompressDebugSections();
   if (CodeGenOpts.OutputAsmVariant != 3) // 3 (default): not specified

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -2561,6 +2561,9 @@ static void CollectArgsForIntegratedAssembler(Compilation &C,
   Args.AddLastArg(CmdArgs, options::OPT_mincremental_linker_compatible,
                   options::OPT_mno_incremental_linker_compatible);
 
+  Args.addOptInFlag(CmdArgs, options::OPT_mlarge_eh_encoding,
+                    options::OPT_mno_large_eh_encoding);
+
   Args.AddLastArg(CmdArgs, options::OPT_femit_dwarf_unwind_EQ);
 
   Args.addOptInFlag(CmdArgs, options::OPT_femit_compact_unwind_non_canonical,
@@ -5391,6 +5394,8 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
     if (TC.useIntegratedAs()) {
       Args.ClaimAllArgs(options::OPT_mrelax_all);
       Args.ClaimAllArgs(options::OPT_mno_relax_all);
+      Args.ClaimAllArgs(options::OPT_mlarge_eh_encoding);
+      Args.ClaimAllArgs(options::OPT_mno_large_eh_encoding);
       Args.ClaimAllArgs(options::OPT_mincremental_linker_compatible);
       Args.ClaimAllArgs(options::OPT_mno_incremental_linker_compatible);
       switch (C.getDefaultToolChain().getArch()) {
@@ -5639,6 +5644,8 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
         options::OPT_fno_dwarf_directory_asm,
         options::OPT_mrelax_all,
         options::OPT_mno_relax_all,
+        options::OPT_mlarge_eh_encoding,
+        options::OPT_mno_large_eh_encoding,
         options::OPT_ftrap_function_EQ,
         options::OPT_ffixed_r9,
         options::OPT_mfix_cortex_a53_835769,

--- a/clang/lib/Driver/ToolChains/CommonArgs.cpp
+++ b/clang/lib/Driver/ToolChains/CommonArgs.cpp
@@ -1270,6 +1270,13 @@ void tools::addLTOOptions(const ToolChain &ToolChain, const ArgList &Args,
     }
   }
 
+  // Forward -mlarge-eh-encoding to the LTO plugin so LLD uses sdata8 EH
+  // encodings during LTO code generation.
+  if (Args.hasFlag(options::OPT_mlarge_eh_encoding,
+                   options::OPT_mno_large_eh_encoding, false))
+    CmdArgs.push_back(
+        Args.MakeArgString(Twine(PluginOptPrefix) + "-large-eh-encoding"));
+
   // Pass an option to enable split machine functions.
   if (auto *A = Args.getLastArg(options::OPT_fsplit_machine_functions,
                                 options::OPT_fno_split_machine_functions)) {

--- a/clang/test/Driver/mlarge-eh-encoding.c
+++ b/clang/test/Driver/mlarge-eh-encoding.c
@@ -1,0 +1,14 @@
+// Test -mlarge-eh-encoding flag forwarding to cc1 and LTO plugin-opt.
+
+// RUN: %clang -### --target=x86_64-unknown-linux -mlarge-eh-encoding %s 2>&1 | FileCheck %s --check-prefixes=CC1,LTO-NEG
+// RUN: %clang -### --target=x86_64-unknown-linux -mlarge-eh-encoding -mno-large-eh-encoding %s 2>&1 | FileCheck %s --check-prefix=CC1-NEG
+
+// CC1:         "-mlarge-eh-encoding"
+// CC1-NEG-NOT: "-mlarge-eh-encoding"
+
+// RUN: %clang -### --target=x86_64-unknown-linux -flto -mlarge-eh-encoding %s 2>&1 | FileCheck %s --check-prefix=LTO
+// RUN: %clang -### --target=x86_64-unknown-linux -flto=thin -mlarge-eh-encoding %s 2>&1 | FileCheck %s --check-prefix=LTO
+// RUN: %clang -### --target=x86_64-unknown-linux -flto -mlarge-eh-encoding -mno-large-eh-encoding %s 2>&1 | FileCheck %s --check-prefix=LTO-NEG
+
+// LTO:         "-plugin-opt=-large-eh-encoding"
+// LTO-NEG-NOT: "-plugin-opt=-large-eh-encoding"

--- a/clang/tools/driver/cc1as_main.cpp
+++ b/clang/tools/driver/cc1as_main.cpp
@@ -176,6 +176,8 @@ struct AssemblerInvocation {
   unsigned X86RelaxRelocations : 1;
   LLVM_PREFERRED_TYPE(bool)
   unsigned X86Sse2Avx : 1;
+  LLVM_PREFERRED_TYPE(bool)
+  unsigned LargeEHEncoding : 1;
 
   RelocSectionSymType RelocSectionSym = RelocSectionSymType::All;
 
@@ -226,6 +228,7 @@ public:
     ImplicitMapsyms = 0;
     X86RelaxRelocations = 0;
     X86Sse2Avx = 0;
+    LargeEHEncoding = 0;
   }
 
   static bool CreateFromArgs(AssemblerInvocation &Res,
@@ -406,6 +409,7 @@ bool AssemblerInvocation::CreateFromArgs(AssemblerInvocation &Opts,
   Opts.ImplicitMapsyms = Args.hasArg(OPT_mmapsyms_implicit);
   Opts.X86RelaxRelocations = !Args.hasArg(OPT_mrelax_relocations_no);
   Opts.X86Sse2Avx = Args.hasArg(OPT_msse2avx);
+  Opts.LargeEHEncoding = Args.hasArg(OPT_mlarge_eh_encoding);
 
   Opts.AsSecureLogFile = Args.getLastArgValue(OPT_as_secure_log_file);
 
@@ -475,6 +479,7 @@ static bool ExecuteAssemblerImpl(AssemblerInvocation &Opts,
   MCOptions.X86RelaxRelocations = Opts.X86RelaxRelocations;
   MCOptions.X86Sse2Avx = Opts.X86Sse2Avx;
   MCOptions.MCNoExecStack = Opts.NoExecStack;
+  MCOptions.LargeEHEncoding = Opts.LargeEHEncoding;
   MCOptions.CompressDebugSections = Opts.CompressDebugSections;
   MCOptions.AsSecureLogFile = Opts.AsSecureLogFile;
 


### PR DESCRIPTION
Wire the LLVM MCTargetOptions::LargeEHEncoding option through clang's driver as -mlarge-eh-encoding / -mno-large-eh-encoding.

This adds:
- CodeGenOpts.LargeEHEncoding in CodeGenOptions.def
- -mlarge-eh-encoding / -mno-large-eh-encoding in Options.td
- Wiring in BackendUtil.cpp (cc1 codegen path)
- Wiring in cc1as_main.cpp (integrated assembler path)
- Driver forwarding in Clang.cpp" --pager no

This PR builds on-top of https://github.com/llvm/llvm-project/pull/174508 exposing the functionality through Clang.

This has also been proposed to GCC https://gcc.gnu.org/pipermail/gcc-patches/2026-July/723953.html