### PR TITLE
[AMDGPU] Use count() for set/map membership tests. NFC.

### DIFF
--- a/llvm/lib/Target/AMDGPU/AsmParser/AMDGPUAsmParser.cpp
+++ b/llvm/lib/Target/AMDGPU/AsmParser/AMDGPUAsmParser.cpp
@@ -7769,7 +7769,7 @@ void AMDGPUAsmParser::cvtExp(MCInst &Inst, const OperandVector &Operands) {
   assert(SrcIdx == 4);
 
   bool Compr = false;
-  if (OptionalIdx.find(AMDGPUOperand::ImmTyExpCompr) != OptionalIdx.end()) {
+  if (OptionalIdx.count(AMDGPUOperand::ImmTyExpCompr)) {
     Compr = true;
     Inst.getOperand(OperandIdx[1]) = Inst.getOperand(OperandIdx[2]);
     Inst.getOperand(OperandIdx[2]).setReg(MCRegister());

--- a/llvm/lib/Target/AMDGPU/R600ControlFlowFinalizer.cpp
+++ b/llvm/lib/Target/AMDGPU/R600ControlFlowFinalizer.cpp
@@ -289,7 +289,7 @@ private:
               &R600::R600_Reg128RegClass);
       }
     }
-    if ((DstRegs.find(SrcMI) == DstRegs.end())) {
+    if (!DstRegs.count(SrcMI)) {
       DstRegs.insert(DstMI);
       return true;
     }

--- a/llvm/lib/Target/AMDGPU/SIMachineScheduler.cpp
+++ b/llvm/lib/Target/AMDGPU/SIMachineScheduler.cpp
@@ -949,7 +949,7 @@ void SIScheduleBlockCreator::colorForceConsecutiveOrderInGroup() {
     if (CurrentColoring[SU->NodeNum] <= (int)DAGSize)
       continue;
 
-    if (SeenColors.find(CurrentColor) == SeenColors.end())
+    if (!SeenColors.count(CurrentColor))
       continue;
 
     if (PreviousColorSave != CurrentColor)
@@ -1461,7 +1461,7 @@ SIScheduleBlockScheduler::SIScheduleBlockScheduler(SIScheduleDAGMI *DAG,
       const std::set<Register> &OutRegs = Block->getOutRegs();
 
       if (!VRegOrUnit.isVirtualReg() ||
-          OutRegs.find(VRegOrUnit.asVirtualReg()) == OutRegs.end())
+          !OutRegs.count(VRegOrUnit.asVirtualReg()))
         continue;
 
       ++LiveOutRegsNumUsages[ID][VRegOrUnit.asVirtualReg()];
@@ -1645,9 +1645,8 @@ void SIScheduleBlockScheduler::decreaseLiveRegs(SIScheduleBlock *Block,
   for (Register Reg : Regs) {
     // For now only track virtual registers.
     std::set<Register>::iterator Pos = LiveRegs.find(Reg);
-    assert (Pos != LiveRegs.end() && // Reg must be live.
-               LiveRegsConsumers.find(Reg) != LiveRegsConsumers.end() &&
-               LiveRegsConsumers[Reg] >= 1);
+    assert(Pos != LiveRegs.end() && // Reg must be live.
+           LiveRegsConsumers.count(Reg) && LiveRegsConsumers[Reg] >= 1);
     --LiveRegsConsumers[Reg];
     if (LiveRegsConsumers[Reg] == 0)
       LiveRegs.erase(Pos);
@@ -1671,7 +1670,7 @@ void SIScheduleBlockScheduler::blockScheduled(SIScheduleBlock *Block) {
   releaseBlockSuccs(Block);
   for (const auto &RegP : LiveOutRegsNumUsages[Block->getID()]) {
     // We produce this register, thus it must not be previously alive.
-    assert(LiveRegsConsumers.find(RegP.first) == LiveRegsConsumers.end() ||
+    assert(!LiveRegsConsumers.count(RegP.first) ||
            LiveRegsConsumers[RegP.first] == 0);
     LiveRegsConsumers[RegP.first] += RegP.second;
   }


### PR DESCRIPTION
Simplify container membership checks by using count() instead of find() == end() in SIMachineScheduler, R600ControlFlowFinalizer, and AMDGPUAsmParser.