### PR TITLE
[CIR] Add lowering for bool attributes

### DIFF
--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -386,7 +386,7 @@ public:
 
   mlir::Value visit(mlir::Attribute attr) {
     return llvm::TypeSwitch<mlir::Attribute, mlir::Value>(attr)
-        .Case<cir::IntAttr, cir::FPAttr, cir::ConstComplexAttr,
+        .Case<cir::BoolAttr, cir::IntAttr, cir::FPAttr, cir::ConstComplexAttr,
               cir::ConstArrayAttr, cir::ConstRecordAttr, cir::ConstVectorAttr,
               cir::ConstPtrAttr, cir::GlobalViewAttr, cir::TypeInfoAttr,
               cir::UndefAttr, cir::VTableAttr, cir::ZeroAttr>(
@@ -394,6 +394,7 @@ public:
         .Default([&](auto attrT) { return mlir::Value(); });
   }
 
+  mlir::Value visitCirAttr(cir::BoolAttr boolAttr);
   mlir::Value visitCirAttr(cir::IntAttr intAttr);
   mlir::Value visitCirAttr(cir::FPAttr fltAttr);
   mlir::Value visitCirAttr(cir::ConstComplexAttr complexAttr);
@@ -509,6 +510,16 @@ mlir::LogicalResult CIRToLLVMLLVMIntrinsicCallOpLowering::matchAndRewrite(
   replaceOpWithCallLLVMIntrinsicOp(rewriter, op, "llvm." + name, llvmResTy,
                                    adaptor.getOperands());
   return mlir::success();
+}
+
+/// BoolAttr visitor.
+mlir::Value CIRAttrToValue::visitCirAttr(cir::BoolAttr boolAttr) {
+  mlir::Location loc = parentOp->getLoc();
+  mlir::DataLayout layout(parentOp->getParentOfType<mlir::ModuleOp>());
+  mlir::Value boolVal = mlir::LLVM::ConstantOp::create(
+      rewriter, loc, converter->convertType(boolAttr.getType()),
+      boolAttr.getValue());
+  return emitToMemory(rewriter, layout, boolAttr.getType(), boolVal);
 }
 
 /// IntAttr visitor.

--- a/clang/test/CIR/CodeGen/globals.cpp
+++ b/clang/test/CIR/CodeGen/globals.cpp
@@ -41,3 +41,9 @@ bool bool_global = true;
 // CIR: cir.global external @bool_global = #true {alignment = 1 : i64}
 // LLVM: @bool_global = global i8 1, align 1
 // OGCG: @bool_global = global i8 1, align 1
+
+bool boolArr_global[4] = {true, false, true, false};
+
+// CIR: cir.global external @boolArr_global = #cir.const_array<[#true, #false, #true, #false]> : !cir.array<!cir.bool x 4>
+// LLVM: @boolArr_global = global [4 x i8] c"\01\00\01\00", align 1
+// OGCG: @boolArr_global = global [4 x i8] c"\01\00\01\00", align 1

--- a/clang/test/CIR/CodeGen/struct-init.cpp
+++ b/clang/test/CIR/CodeGen/struct-init.cpp
@@ -60,6 +60,19 @@ StructWithFieldInitFromConst swfifc2 = { 2 };
 // LLVM: @swfifc2 = global { i8, i8, i32 } { i8 2, i8 0, i32 2 }, align 4
 // OGCG: @swfifc2 = global { i8, i8, i32 } { i8 2, i8 0, i32 2 }, align 4
 
+
+struct StructWithBoolField {
+  int a;
+  bool b;
+  int c;
+};
+
+StructWithBoolField sbf = {1, true, 3};
+
+// CIR: cir.global external @sbf = #cir.const_record<{#cir.int<1> : !s32i, #true, #cir.int<3> : !s32i}> : !rec_StructWithBoolField
+// LLVM: @sbf = global %struct.StructWithBoolField { i32 1, i8 1, i32 3 }, align 4
+// OGCG: @sbf = global %struct.StructWithBoolField { i32 1, i8 1, i32 3 }, align 4
+
 void init() {
   S s1 = {1, 2, 3};
   S s2 = {4, 5};


### PR DESCRIPTION
When a boolean attribute was encountered in a constant global record or constant global array, we were going to the default handler, which returned a null value, and then trying to insert this null value in an LLVM structure, which crashes.

This adds proper lowering for boolean attributes.