### PR TITLE
[llvm-pdbutil] Hash type records in yaml2pdb

### DIFF
--- a/llvm/include/llvm/DebugInfo/PDB/Native/TpiStreamBuilder.h
+++ b/llvm/include/llvm/DebugInfo/PDB/Native/TpiStreamBuilder.h
@@ -46,8 +46,7 @@ public:
   TpiStreamBuilder &operator=(const TpiStreamBuilder &) = delete;
 
   LLVM_ABI void setVersionHeader(PdbRaw_TpiVer Version);
-  LLVM_ABI void addTypeRecord(ArrayRef<uint8_t> Type,
-                              std::optional<uint32_t> Hash);
+  LLVM_ABI void addTypeRecord(ArrayRef<uint8_t> Type, uint32_t Hash);
   LLVM_ABI void addTypeRecords(ArrayRef<uint8_t> Types,
                                ArrayRef<uint16_t> Sizes,
                                ArrayRef<uint32_t> Hashes);

--- a/llvm/lib/DebugInfo/PDB/Native/TpiStreamBuilder.cpp
+++ b/llvm/lib/DebugInfo/PDB/Native/TpiStreamBuilder.cpp
@@ -54,8 +54,7 @@ void TpiStreamBuilder::updateTypeIndexOffsets(ArrayRef<uint16_t> Sizes) {
   }
 }
 
-void TpiStreamBuilder::addTypeRecord(ArrayRef<uint8_t> Record,
-                                     std::optional<uint32_t> Hash) {
+void TpiStreamBuilder::addTypeRecord(ArrayRef<uint8_t> Record, uint32_t Hash) {
   assert(((Record.size() & 3) == 0) &&
          "The type record's size is not a multiple of 4 bytes which will "
          "cause misalignment in the output TPI stream!");
@@ -64,9 +63,7 @@ void TpiStreamBuilder::addTypeRecord(ArrayRef<uint8_t> Record,
   updateTypeIndexOffsets(ArrayRef(&OneSize, 1));
 
   TypeRecBuffers.push_back(Record);
-  // FIXME: Require it.
-  if (Hash)
-    TypeHashes.push_back(*Hash);
+  TypeHashes.push_back(Hash);
 }
 
 void TpiStreamBuilder::addTypeRecords(ArrayRef<uint8_t> Types,

--- a/llvm/test/DebugInfo/PDB/pdbdump-mergetypes.test
+++ b/llvm/test/DebugInfo/PDB/pdbdump-mergetypes.test
@@ -14,7 +14,7 @@ MERGED-NEXT:            referent = 0x0076 (__int64), mode = pointer, opts = None
 MERGED-NEXT:   0x1002 | LF_STRUCTURE [size = 48] `OnlyInMerge1`
 MERGED-NEXT:            unique name: `OnlyInMerge1`
 MERGED-NEXT:            vtable: <no type>, base list: <no type>, field list: <no type>
-MERGED-NEXT:            options: forward ref | has unique name
+MERGED-NEXT:            options: forward ref (= 0x1002) | has unique name
 MERGED-NEXT:   0x1003 | LF_POINTER [size = 12]
 MERGED-NEXT:            referent = 0x1000, mode = pointer, opts = None, kind = ptr32
 MERGED-NEXT:   0x1004 | LF_POINTER [size = 12]
@@ -31,4 +31,4 @@ MERGED-NEXT:            calling conv = cdecl, options = None
 MERGED-NEXT:   0x1008 | LF_STRUCTURE [size = 48] `OnlyInMerge2`
 MERGED-NEXT:            unique name: `OnlyInMerge2`
 MERGED-NEXT:            vtable: <no type>, base list: <no type>, field list: <no type>
-MERGED-NEXT:            options: forward ref | has unique name
+MERGED-NEXT:            options: forward ref (= 0x1008) | has unique name

--- a/llvm/test/tools/llvm-pdbutil/Inputs/forward-refs1.yaml
+++ b/llvm/test/tools/llvm-pdbutil/Inputs/forward-refs1.yaml
@@ -1,0 +1,63 @@
+---
+TpiStream:
+  Version:         VC80
+  Records:
+    - Kind:            LF_ARGLIST
+      ArgList:
+        ArgIndices:      [  ]
+    - Kind:            LF_PROCEDURE
+      Procedure:
+        ReturnType:      116
+        CallConv:        NearC
+        Options:         [ None ]
+        ParameterCount:  0
+        ArgumentList:    4096
+    - Kind:            LF_STRUCTURE
+      Class:
+        MemberCount:     0
+        Options:         [ None, ForwardReference, HasUniqueName ]
+        FieldList:       0
+        Name:            Foo
+        UniqueName:      '.?AUFoo@@'
+        DerivationList:  0
+        VTableShape:     0
+        Size:            0
+    - Kind:            LF_POINTER
+      Pointer:
+        ReferentType:    4098
+        Attrs:           65548
+    - Kind:            LF_MFUNCTION
+      MemberFunction:
+        ReturnType:      3
+        ClassType:       4098
+        ThisType:        4099
+        CallConv:        NearC
+        Options:         [ None, Constructor ]
+        ParameterCount:  0
+        ArgumentList:    4096
+        ThisPointerAdjustment: 0
+    - Kind:            LF_FIELDLIST
+      FieldList:
+        - Kind:            LF_MEMBER
+          DataMember:
+            Attrs:           3
+            Type:            116
+            FieldOffset:     0
+            Name:            a
+        - Kind:            LF_ONEMETHOD
+          OneMethod:
+            Type:            4100
+            Attrs:           259
+            VFTableOffset:   -1
+            Name:            Foo
+    - Kind:            LF_STRUCTURE
+      Class:
+        MemberCount:     2
+        Options:         [ None, HasConstructorOrDestructor, HasUniqueName ]
+        FieldList:       4101
+        Name:            Foo
+        UniqueName:      '.?AUFoo@@'
+        DerivationList:  0
+        VTableShape:     0
+        Size:            4
+...

--- a/llvm/test/tools/llvm-pdbutil/Inputs/forward-refs2.yaml
+++ b/llvm/test/tools/llvm-pdbutil/Inputs/forward-refs2.yaml
@@ -1,16 +1,5 @@
-# RUN: llvm-pdbutil yaml2pdb %s --pdb=%t.pdb
-# RUN: llvm-pdbutil dump --types %t.pdb | FileCheck %s
-
-# Test that forward references can be found (requires type hashes).
-
-# CHECK:       0x1002 | LF_STRUCTURE [size = 36] `Foo`
-# CHECK-NEXT:           unique name: `.?AUFoo@@`
-# CHECK-NEXT:           vtable: <no type>, base list: <no type>, field list: <no type>
-# CHECK-NEXT:           options: forward ref (-> 0x1006) | has unique name, sizeof 0
-# CHECK:       0x1006 | LF_STRUCTURE [size = 36] `Foo`
-# CHECK-NEXT:           unique name: `.?AUFoo@@`
-
 ---
+# Essentially the same as forward-refs1.yaml but with struct Bar { int b; };
 TpiStream:
   Version:         VC80
   Records:
@@ -29,8 +18,8 @@ TpiStream:
         MemberCount:     0
         Options:         [ None, ForwardReference, HasUniqueName ]
         FieldList:       0
-        Name:            Foo
-        UniqueName:      '.?AUFoo@@'
+        Name:            Bar
+        UniqueName:      '.?AUBar@@'
         DerivationList:  0
         VTableShape:     0
         Size:            0
@@ -55,20 +44,20 @@ TpiStream:
             Attrs:           3
             Type:            116
             FieldOffset:     0
-            Name:            a
+            Name:            b
         - Kind:            LF_ONEMETHOD
           OneMethod:
             Type:            4100
             Attrs:           259
             VFTableOffset:   -1
-            Name:            Foo
+            Name:            Bar
     - Kind:            LF_STRUCTURE
       Class:
         MemberCount:     2
         Options:         [ None, HasConstructorOrDestructor, HasUniqueName ]
         FieldList:       4101
-        Name:            Foo
-        UniqueName:      '.?AUFoo@@'
+        Name:            Bar
+        UniqueName:      '.?AUBar@@'
         DerivationList:  0
         VTableShape:     0
         Size:            4

--- a/llvm/test/tools/llvm-pdbutil/merged-forward-refs.test
+++ b/llvm/test/tools/llvm-pdbutil/merged-forward-refs.test
@@ -1,0 +1,35 @@
+# RUN: llvm-pdbutil yaml2pdb %p/Inputs/forward-refs1.yaml --pdb=%t.1.pdb
+# RUN: llvm-pdbutil yaml2pdb %p/Inputs/forward-refs2.yaml --pdb=%t.2.pdb
+# RUN: llvm-pdbutil merge %t.1.pdb %t.2.pdb --pdb=%t.pdb
+# RUN: llvm-pdbutil dump --types %t.1.pdb | FileCheck %s --check-prefix=ONE
+# RUN: llvm-pdbutil dump --types %t.2.pdb | FileCheck %s --check-prefix=TWO
+# RUN: llvm-pdbutil dump --types %t.pdb | FileCheck %s --check-prefix=MERGED
+
+# Test that forward references can be found after merging (requires type hashes).
+
+# ONE:       0x1002 | LF_STRUCTURE [size = 36] `Foo`
+# ONE-NEXT:           unique name: `.?AUFoo@@`
+# ONE-NEXT:           vtable: <no type>, base list: <no type>, field list: <no type>
+# ONE-NEXT:           options: forward ref (-> 0x1006) | has unique name, sizeof 0
+# ONE:       0x1006 | LF_STRUCTURE [size = 36] `Foo`
+# ONE-NEXT:           unique name: `.?AUFoo@@`
+
+# TWO:       0x1002 | LF_STRUCTURE [size = 36] `Bar`
+# TWO-NEXT:           unique name: `.?AUBar@@`
+# TWO-NEXT:           vtable: <no type>, base list: <no type>, field list: <no type>
+# TWO-NEXT:           options: forward ref (-> 0x1006) | has unique name, sizeof 0
+# TWO:       0x1006 | LF_STRUCTURE [size = 36] `Bar`
+# TWO-NEXT:           unique name: `.?AUBar@@`
+
+# MERGED:       0x1002 | LF_STRUCTURE [size = 36] `Foo`
+# MERGED-NEXT:           unique name: `.?AUFoo@@`
+# MERGED-NEXT:           vtable: <no type>, base list: <no type>, field list: <no type>
+# MERGED-NEXT:           options: forward ref (-> 0x1006) | has unique name, sizeof 0
+# MERGED:       0x1006 | LF_STRUCTURE [size = 36] `Foo`
+# MERGED-NEXT:           unique name: `.?AUFoo@@`
+# MERGED:       0x1007 | LF_STRUCTURE [size = 36] `Bar`
+# MERGED-NEXT:           unique name: `.?AUBar@@`
+# MERGED-NEXT:           vtable: <no type>, base list: <no type>, field list: <no type>
+# MERGED-NEXT:           options: forward ref (-> 0x100B) | has unique name, sizeof 0
+# MERGED:       0x100B | LF_STRUCTURE [size = 36] `Bar`
+# MERGED-NEXT:           unique name: `.?AUBar@@`

--- a/llvm/test/tools/llvm-pdbutil/yaml2pdb-forward-refs.test
+++ b/llvm/test/tools/llvm-pdbutil/yaml2pdb-forward-refs.test
@@ -1,0 +1,75 @@
+# RUN: llvm-pdbutil yaml2pdb %s --pdb=%t.pdb
+# RUN: llvm-pdbutil dump --types %t.pdb | FileCheck %s
+
+# Test that forward references can be found (requires type hashes).
+
+# CHECK:       0x1002 | LF_STRUCTURE [size = 36] `Foo`
+# CHECK-NEXT:           unique name: `.?AUFoo@@`
+# CHECK-NEXT:           vtable: <no type>, base list: <no type>, field list: <no type>
+# CHECK-NEXT:           options: forward ref (-> 0x1006) | has unique name, sizeof 0
+# CHECK:       0x1006 | LF_STRUCTURE [size = 36] `Foo`
+# CHECK-NEXT:           unique name: `.?AUFoo@@`
+
+---
+TpiStream:
+  Version:         VC80
+  Records:
+    - Kind:            LF_ARGLIST
+      ArgList:
+        ArgIndices:      [  ]
+    - Kind:            LF_PROCEDURE
+      Procedure:
+        ReturnType:      116
+        CallConv:        NearC
+        Options:         [ None ]
+        ParameterCount:  0
+        ArgumentList:    4096
+    - Kind:            LF_STRUCTURE
+      Class:
+        MemberCount:     0
+        Options:         [ None, ForwardReference, HasUniqueName ]
+        FieldList:       0
+        Name:            Foo
+        UniqueName:      '.?AUFoo@@'
+        DerivationList:  0
+        VTableShape:     0
+        Size:            0
+    - Kind:            LF_POINTER
+      Pointer:
+        ReferentType:    4098
+        Attrs:           65548
+    - Kind:            LF_MFUNCTION
+      MemberFunction:
+        ReturnType:      3
+        ClassType:       4098
+        ThisType:        4099
+        CallConv:        NearC
+        Options:         [ None, Constructor ]
+        ParameterCount:  0
+        ArgumentList:    4096
+        ThisPointerAdjustment: 0
+    - Kind:            LF_FIELDLIST
+      FieldList:
+        - Kind:            LF_MEMBER
+          DataMember:
+            Attrs:           3
+            Type:            116
+            FieldOffset:     0
+            Name:            a
+        - Kind:            LF_ONEMETHOD
+          OneMethod:
+            Type:            4100
+            Attrs:           259
+            VFTableOffset:   -1
+            Name:            Foo
+    - Kind:            LF_STRUCTURE
+      Class:
+        MemberCount:     2
+        Options:         [ None, HasConstructorOrDestructor, HasUniqueName ]
+        FieldList:       4101
+        Name:            Foo
+        UniqueName:      '.?AUFoo@@'
+        DerivationList:  0
+        VTableShape:     0
+        Size:            4
+...

--- a/llvm/tools/llvm-pdbutil/llvm-pdbutil.cpp
+++ b/llvm/tools/llvm-pdbutil/llvm-pdbutil.cpp
@@ -60,6 +60,7 @@
 #include "llvm/DebugInfo/PDB/Native/PDBStringTableBuilder.h"
 #include "llvm/DebugInfo/PDB/Native/RawConstants.h"
 #include "llvm/DebugInfo/PDB/Native/RawError.h"
+#include "llvm/DebugInfo/PDB/Native/TpiHashing.h"
 #include "llvm/DebugInfo/PDB/Native/TpiStream.h"
 #include "llvm/DebugInfo/PDB/Native/TpiStreamBuilder.h"
 #include "llvm/DebugInfo/PDB/PDB.h"
@@ -889,7 +890,8 @@ static void yamlToPdb(StringRef Path) {
   AppendingTypeTableBuilder TS(Allocator);
   for (const auto &R : Tpi.Records) {
     CVType Type = R.toCodeViewRecord(TS);
-    TpiBuilder.addTypeRecord(Type.RecordData, std::nullopt);
+    uint32_t Hash = ExitOnErr(llvm::pdb::hashTypeRecord(Type));
+    TpiBuilder.addTypeRecord(Type.RecordData, Hash);
   }
 
   const auto &Ipi = YamlObj.IpiStream.value_or(DefaultIpiStream);
@@ -897,7 +899,8 @@ static void yamlToPdb(StringRef Path) {
   IpiBuilder.setVersionHeader(Ipi.Version);
   for (const auto &R : Ipi.Records) {
     CVType Type = R.toCodeViewRecord(TS);
-    IpiBuilder.addTypeRecord(Type.RecordData, std::nullopt);
+    uint32_t Hash = ExitOnErr(llvm::pdb::hashTypeRecord(Type));
+    IpiBuilder.addTypeRecord(Type.RecordData, Hash);
   }
 
   if (YamlObj.PublicsStream) {

--- a/llvm/tools/llvm-pdbutil/llvm-pdbutil.cpp
+++ b/llvm/tools/llvm-pdbutil/llvm-pdbutil.cpp
@@ -1398,10 +1398,12 @@ static void mergePdbs() {
   auto &DestTpi = Builder.getTpiBuilder();
   auto &DestIpi = Builder.getIpiBuilder();
   MergedTpi.ForEachRecord([&DestTpi](TypeIndex TI, const CVType &Type) {
-    DestTpi.addTypeRecord(Type.RecordData, std::nullopt);
+    uint32_t Hash = ExitOnErr(llvm::pdb::hashTypeRecord(Type));
+    DestTpi.addTypeRecord(Type.RecordData, Hash);
   });
   MergedIpi.ForEachRecord([&DestIpi](TypeIndex TI, const CVType &Type) {
-    DestIpi.addTypeRecord(Type.RecordData, std::nullopt);
+    uint32_t Hash = ExitOnErr(llvm::pdb::hashTypeRecord(Type));
+    DestIpi.addTypeRecord(Type.RecordData, Hash);
   });
   Builder.getInfoBuilder().addFeature(PdbRaw_FeatureSig::VC140);
 


### PR DESCRIPTION
The TPI and IPI streams didn't include a hash map for the generated types, because the types never got hashes. A hash map is necessary to resolve forward references when dumping the PDB (checks for `TpiStream::supportsTypeLookup` which checks the hash map).

With this PR, the hashes are generated. There's no good test that we do this for the IPI stream as well, because it doesn't have forward references.