### PR TITLE
[flang][openacc][cuda] Fix order of clause processing for host_data directive

### DIFF
--- a/flang/lib/Lower/OpenACC.cpp
+++ b/flang/lib/Lower/OpenACC.cpp
@@ -2832,35 +2832,13 @@ genACCHostDataOp(Fortran::lower::AbstractConverter &converter,
 
   fir::FirOpBuilder &builder = converter.getFirOpBuilder();
 
-  for (const Fortran::parser::AccClause &clause : accClauseList.v) {
-    mlir::Location clauseLocation = converter.genLocation(clause.source);
-    if (const auto *ifClause =
-            std::get_if<Fortran::parser::AccClause::If>(&clause.u)) {
-      genIfClause(converter, clauseLocation, ifClause, ifCond, stmtCtx);
-    } else if (std::get_if<Fortran::parser::AccClause::IfPresent>(&clause.u)) {
-      addIfPresentAttr = true;
-    }
-  }
-
-  if (ifCond) {
-    if (auto cst =
-            mlir::dyn_cast<mlir::arith::ConstantOp>(ifCond.getDefiningOp()))
-      if (auto boolAttr = mlir::dyn_cast<mlir::BoolAttr>(cst.getValue())) {
-        if (boolAttr.getValue()) {
-          // get rid of the if condition if it is always true.
-          ifCond = mlir::Value();
-        }
-      }
-  }
-
-  AccDataMap dataMap;
-  for (const Fortran::parser::AccClause &clause : accClauseList.v) {
-    if (const auto *useDevice =
-            std::get_if<Fortran::parser::AccClause::UseDevice>(&clause.u)) {
-      // When CUDA Fortran is enabled, extra symbols are used in the host_data
-      // region. Look for them and bind their values with the symbols in the
-      // outer scope.
-      if (semanticsContext.IsEnabled(Fortran::common::LanguageFeature::CUDA)) {
+  // When CUDA Fortran is enabled, extra symbols are created in the host_data
+  // scope for use_device objects. Bind them to the outer scope's symbols before
+  // processing any clauses, since the if clause may reference these symbols.
+  if (semanticsContext.IsEnabled(Fortran::common::LanguageFeature::CUDA)) {
+    for (const Fortran::parser::AccClause &clause : accClauseList.v) {
+      if (const auto *useDevice =
+              std::get_if<Fortran::parser::AccClause::UseDevice>(&clause.u)) {
         const Fortran::parser::AccObjectList &objectList{useDevice->v};
         for (const auto &accObject : objectList.v) {
           const Fortran::semantics::Symbol *newSym = nullptr;
@@ -2894,12 +2872,36 @@ genACCHostDataOp(Fortran::lower::AbstractConverter &converter,
           }
         }
       }
+    }
+  }
+
+  AccDataMap dataMap;
+  for (const Fortran::parser::AccClause &clause : accClauseList.v) {
+    mlir::Location clauseLocation = converter.genLocation(clause.source);
+    if (const auto *ifClause =
+            std::get_if<Fortran::parser::AccClause::If>(&clause.u)) {
+      genIfClause(converter, clauseLocation, ifClause, ifCond, stmtCtx);
+    } else if (std::get_if<Fortran::parser::AccClause::IfPresent>(&clause.u)) {
+      addIfPresentAttr = true;
+    } else if (const auto *useDevice =
+                   std::get_if<Fortran::parser::AccClause::UseDevice>(
+                       &clause.u)) {
       genDataOperandOperations<mlir::acc::UseDeviceOp>(
           useDevice->v, converter, semanticsContext, stmtCtx, dataOperands,
           mlir::acc::DataClause::acc_use_device,
           /*structured=*/true, /*implicit=*/false, /*async=*/{},
           /*asyncDeviceTypes=*/{}, /*asyncOnlyDeviceTypes=*/{},
           /*setDeclareAttr=*/false, &dataMap);
+    }
+  }
+
+  if (ifCond) {
+    if (auto cst =
+            mlir::dyn_cast<mlir::arith::ConstantOp>(ifCond.getDefiningOp())) {
+      if (auto boolAttr = mlir::dyn_cast<mlir::BoolAttr>(cst.getValue())) {
+        if (boolAttr.getValue()) // get rid of the if condition when true.
+          ifCond = mlir::Value();
+      }
     }
   }
 

--- a/flang/test/Lower/OpenACC/acc-host-data-cuda-device.f90
+++ b/flang/test/Lower/OpenACC/acc-host-data-cuda-device.f90
@@ -13,6 +13,14 @@ subroutine __host_sub(a)
     !dir$ ignore_tkr(c) a
 end
 end interface
+
+contains
+
+  subroutine vectoraddarray(a, b, n)
+    implicit none
+    integer :: n
+    real, dimension(1:n) :: a, b
+  end subroutine 
 end module
 
 program testex1
@@ -25,6 +33,7 @@ type :: t
   real(4), dimension(10,10,10) :: a
 end type
 type(t) :: b
+real, dimension(:), allocatable :: a2, b2
 
 
 !$acc enter data copyin(a)
@@ -58,6 +67,10 @@ block; use m
   end do
   !$acc end host_data
   end block
+ 
+  !$acc host_data use_device(a2, b2) if(allocated(a2))
+  call vectoraddarray(a2, b2, 10)
+  !$acc end host_data
 
 end
 

--- a/flang/test/Lower/OpenACC/acc-host-data.f90
+++ b/flang/test/Lower/OpenACC/acc-host-data.f90
@@ -33,9 +33,9 @@ subroutine acc_host_data()
   !$acc host_data use_device(a) if(ifCondition)
   !$acc end host_data
 
+! CHECK: %[[DA0:.*]] = acc.use_device varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10xf32>>) -> !fir.ref<!fir.array<10xf32>> {name = "a"}
 ! CHECK: %[[LOAD_IFCOND:.*]] = fir.load %[[DECLIFCOND]]#0 : !fir.ref<!fir.logical<4>>
 ! CHECK: %[[IFCOND_I1:.*]] = fir.convert %[[LOAD_IFCOND]] : (!fir.logical<4>) -> i1
-! CHECK: %[[DA0:.*]] = acc.use_device varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10xf32>>) -> !fir.ref<!fir.array<10xf32>> {name = "a"}
 ! CHECK: acc.host_data if(%[[IFCOND_I1]]) dataOperands(%[[DA0]] : !fir.ref<!fir.array<10xf32>>)
 
   !$acc host_data use_device(a) if(.true.)


### PR DESCRIPTION
This was crashing lowering with `not yet implemented: lowering symbol to HLFIR` because the symbol was not mapped correctly
