### PR TITLE
[CIR] Fix missing terminators in regions with cleanup

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
@@ -2280,9 +2280,15 @@ cir::IfOp CIRGenFunction::emitIfOnBoolExpr(
 
   // Emit the code with the fully general case.
   mlir::Value condV = emitOpOnBoolExpr(loc, cond);
-  return cir::IfOp::create(builder, loc, condV, elseLoc.has_value(),
-                           /*thenBuilder=*/thenBuilder,
-                           /*elseBuilder=*/elseBuilder);
+  cir::IfOp ifOp = cir::IfOp::create(builder, loc, condV, elseLoc.has_value(),
+                                     /*thenBuilder=*/thenBuilder,
+                                     /*elseBuilder=*/elseBuilder);
+  terminateStructuredRegionBody(ifOp.getThenRegion(), thenLoc);
+  assert((elseLoc.has_value() || ifOp.getElseRegion().empty()) &&
+         "else region created with no else location");
+  if (elseLoc.has_value())
+    terminateStructuredRegionBody(ifOp.getElseRegion(), *elseLoc);
+  return ifOp;
 }
 
 /// TODO(cir): see EmitBranchOnBoolExpr for extra ideas).

--- a/clang/lib/CIR/CodeGen/CIRGenFunction.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.cpp
@@ -344,12 +344,22 @@ void CIRGenFunction::LexicalScope::cleanup() {
     return;
 
   // Get rid of any empty block at the end of the scope.
-  bool entryBlock = builder.getInsertionBlock()->isEntryBlock();
-  if (!entryBlock && curBlock->empty()) {
+  bool isEntryBlock = builder.getInsertionBlock()->isEntryBlock();
+  if (!isEntryBlock && curBlock->empty()) {
     curBlock->erase();
     for (mlir::Block *retBlock : retBlocks) {
       if (retBlock->getUses().empty())
         retBlock->erase();
+    }
+    // The empty block was created by a terminator (return/break/continue)
+    // and is now erased. If there are pending cleanup scopes (from variables
+    // with destructors), we need to pop them and ensure the containing scope
+    // block gets a proper terminator (e.g. cir.yield). Without this, the
+    // cleanup-scope-op popping that would otherwise happen in
+    // ~RunCleanupsScope leaves the scope block without a terminator.
+    if (hasPendingCleanups()) {
+      builder.setInsertionPointToEnd(entryBlock);
+      insertCleanupAndLeave(entryBlock);
     }
     return;
   }

--- a/clang/lib/CIR/CodeGen/CIRGenFunction.h
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.h
@@ -972,6 +972,8 @@ public:
                         ArrayRef<mlir::Value *> valuesToReload = {});
   void popCleanupBlock();
 
+  void terminateStructuredRegionBody(mlir::Region &r, mlir::Location loc);
+
   /// Deactivates the given cleanup block. The block cannot be reactivated. Pops
   /// it if it's the top of the stack.
   ///

--- a/clang/lib/CIR/CodeGen/CIRGenFunction.h
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.h
@@ -1039,6 +1039,12 @@ public:
       performCleanup = false;
       cgf.currentCleanupStackDepth = oldCleanupStackDepth;
     }
+
+    /// Whether there are any pending cleanups that have been pushed since
+    /// this scope was entered.
+    bool hasPendingCleanups() const {
+      return cgf.ehStack.stable_begin() != cleanupStackDepth;
+    }
   };
 
   // Cleanup stack depth of the RunCleanupsScope that was pushed most recently.

--- a/clang/lib/CIR/CodeGen/CIRGenStmt.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenStmt.cpp
@@ -488,8 +488,8 @@ mlir::LogicalResult CIRGenFunction::emitLabelStmt(const clang::LabelStmt &s) {
 }
 
 // Add a terminating yield on a body region if no other terminators are used.
-static void terminateBody(CIRGenBuilderTy &builder, mlir::Region &r,
-                          mlir::Location loc) {
+void CIRGenFunction::terminateStructuredRegionBody(mlir::Region &r,
+                                                   mlir::Location loc) {
   if (r.empty())
     return;
 
@@ -979,7 +979,7 @@ CIRGenFunction::emitCXXForRangeStmt(const CXXForRangeStmt &s,
   if (res.failed())
     return res;
 
-  terminateBody(builder, forOp.getBody(), getLoc(s.getEndLoc()));
+  terminateStructuredRegionBody(forOp.getBody(), getLoc(s.getEndLoc()));
   return mlir::success();
 }
 
@@ -1051,7 +1051,7 @@ mlir::LogicalResult CIRGenFunction::emitForStmt(const ForStmt &s) {
   if (res.failed())
     return res;
 
-  terminateBody(builder, forOp.getBody(), getLoc(s.getEndLoc()));
+  terminateStructuredRegionBody(forOp.getBody(), getLoc(s.getEndLoc()));
   return mlir::success();
 }
 
@@ -1102,7 +1102,7 @@ mlir::LogicalResult CIRGenFunction::emitDoStmt(const DoStmt &s) {
   if (res.failed())
     return res;
 
-  terminateBody(builder, doWhileOp.getBody(), getLoc(s.getEndLoc()));
+  terminateStructuredRegionBody(doWhileOp.getBody(), getLoc(s.getEndLoc()));
   return mlir::success();
 }
 
@@ -1158,7 +1158,7 @@ mlir::LogicalResult CIRGenFunction::emitWhileStmt(const WhileStmt &s) {
   if (res.failed())
     return res;
 
-  terminateBody(builder, whileOp.getBody(), getLoc(s.getEndLoc()));
+  terminateStructuredRegionBody(whileOp.getBody(), getLoc(s.getEndLoc()));
   return mlir::success();
 }
 
@@ -1253,8 +1253,8 @@ mlir::LogicalResult CIRGenFunction::emitSwitchStmt(const clang::SwitchStmt &s) {
   llvm::SmallVector<CaseOp> cases;
   swop.collectCases(cases);
   for (auto caseOp : cases)
-    terminateBody(builder, caseOp.getCaseRegion(), caseOp.getLoc());
-  terminateBody(builder, swop.getBody(), swop.getLoc());
+    terminateStructuredRegionBody(caseOp.getCaseRegion(), caseOp.getLoc());
+  terminateStructuredRegionBody(swop.getBody(), swop.getLoc());
 
   swop.setAllEnumCasesCovered(s.isAllEnumCasesCovered());
 

--- a/clang/test/CIR/CodeGen/cleanup-scope-return-in-loop.cpp
+++ b/clang/test/CIR/CodeGen/cleanup-scope-return-in-loop.cpp
@@ -1,0 +1,58 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o %t.cir
+// RUN: FileCheck --input-file=%t.cir %s -check-prefix=CIR
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o %t.ll
+// RUN: FileCheck --input-file=%t.ll %s -check-prefix=LLVM
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -emit-llvm %s -o %t.ll
+// RUN: FileCheck --input-file=%t.ll %s -check-prefix=LLVM
+
+struct Struk {
+  ~Struk();
+  bool check();
+};
+
+// Test that a for-loop body containing a local variable with a destructor
+// followed by 'continue' and 'return' produces a properly terminated
+// cir.scope. This exercises the interaction between LexicalScope cleanup,
+// CleanupScopeOp popping, and empty-block erasure.
+
+int test_cleanup_return_in_loop(int n) {
+  for (int i = 0; i < n; i++) {
+    Struk s;
+    if (s.check())
+      continue;
+    return i;
+  }
+  return -1;
+}
+
+// CIR: cir.func {{.*}} @_Z27test_cleanup_return_in_loopi
+// CIR:       cir.scope {
+// CIR:         cir.for : cond {
+// CIR:         } body {
+// CIR:           cir.scope {
+// CIR:             cir.cleanup.scope {
+// CIR:               cir.continue
+// CIR:               cir.return
+// CIR:             } cleanup normal {
+// CIR:               cir.call @_ZN5StrukD1Ev
+// CIR:               cir.yield
+// CIR:         cir.yield
+// CIR:         } step {
+// CIR:       cir.return
+
+// LLVM: define dso_local noundef i32 @_Z27test_cleanup_return_in_loopi(i32 noundef %{{.*}})
+// LLVM: [[LOOP_COND:.*]]:
+// LLVM:     %[[ICMP:.*]] = icmp slt i32
+// LLVM-NEXT: br i1 %[[ICMP]]
+// LLVM: [[LOOP_BODY:.*]]:
+// LLVM:     %[[CALL:.*]] = call noundef {{.*}} @_ZN5Struk5checkEv(
+// LLVM-NEXT: br i1 %[[CALL]]
+// LLVM: [[CLEANUP:.*]]:
+// LLVM:     call void @_ZN5StrukD1Ev(
+// LLVM:     switch i32 %{{.*}}, label %{{.*}} [
+// LLVM:     ]
+// LLVM: [[LOOP_STEP:.*]]:
+// LLVM:     add nsw i32 %{{.*}}, 1
+// LLVM: [[POST_LOOP:.*]]:
+// LLVM:     store i32 -1, ptr %{{.*}}, align 4
+// LLVM:     ret i32

--- a/clang/test/CIR/CodeGen/return-in-if-with-cleanups.cpp
+++ b/clang/test/CIR/CodeGen/return-in-if-with-cleanups.cpp
@@ -1,0 +1,23 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o %t.cir
+// RUN: FileCheck --input-file=%t.cir %s
+
+// Out-of-line member + `if` + EH cleanups + early `return` used to emit a
+// `cir.if` "then" region whose block ended on `cir.cleanup.scope` with no
+// following `cir.yield`, tripping MLIR's "block with no terminator" verifier.
+
+struct S {
+  ~S();
+};
+
+int f(bool b) {
+  if (b) {
+    S temp;
+    return 1;
+  }
+  return 0;
+}
+
+// CHECK-LABEL: cir.func{{.*}} @_Z1fb
+// CHECK: cir.if
+// CHECK: cir.cleanup.scope
+// CHECK: cir.yield


### PR DESCRIPTION
When a cleanup scope was created within an if operation's then or else region and the source scope ended with a return, we would fail to terminate the region following the cleanup scope, which surrounded the return operation, resulting in an MLIR verification error. This change forces the addition of terminators in the if's then and else regions.