### PR TITLE
[NFC] [clang] swap parameters to checkTargetOptions

### DIFF
--- a/clang/lib/Serialization/ASTReader.cpp
+++ b/clang/lib/Serialization/ASTReader.cpp
@@ -5880,7 +5880,7 @@ namespace {
     bool ReadTargetOptions(const TargetOptions &TargetOpts,
                            StringRef ModuleFilename, bool Complain,
                            bool AllowCompatibleDifferences) override {
-      return checkTargetOptions(ExistingTargetOpts, TargetOpts, ModuleFilename,
+      return checkTargetOptions(TargetOpts, ExistingTargetOpts, ModuleFilename,
                                 nullptr, AllowCompatibleDifferences);
     }
 


### PR DESCRIPTION
This is the correct order according to the function prototype.

This should be NFC, because for PCH, AllowCompatibleDifferences
is always false: it is only used in isAcceptableASTFile, which
calls readASTFileControlBlock, which explicitely passes false.

We explicitely pass in `nullptr` for Diag, so the incorrect error
message isn't printed.
