### PR TITLE
[lldb] Support PointerAuthAuthTraps in the expression evaluator

### DIFF
--- a/lldb/source/Plugins/ExpressionParser/Clang/ClangExpressionParser.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ClangExpressionParser.cpp
@@ -729,6 +729,7 @@ static void SetPointerAuthOptionsForArm64e(LangOptions &lang_opts) {
   lang_opts.PointerAuthIntrinsics = true;
   lang_opts.PointerAuthCalls = true;
   lang_opts.PointerAuthReturns = true;
+  lang_opts.PointerAuthAuthTraps = true;
 }
 
 ClangExpressionParser::ClangExpressionParser(

--- a/lldb/test/API/commands/expression/ptrauth-auth-traps/Makefile
+++ b/lldb/test/API/commands/expression/ptrauth-auth-traps/Makefile
@@ -1,0 +1,5 @@
+C_SOURCES := main.c
+
+override ARCH := arm64e
+
+include Makefile.rules

--- a/lldb/test/API/commands/expression/ptrauth-auth-traps/TestPtrAuthAuthTraps.py
+++ b/lldb/test/API/commands/expression/ptrauth-auth-traps/TestPtrAuthAuthTraps.py
@@ -1,0 +1,48 @@
+"""
+Tests that the expression evaluator traps on ptrauth authentication failures
+when -fptrauth-auth-traps is enabled.  Auth traps cause aut* instructions to
+be followed by a brk trap that fires on authentication failure.
+"""
+
+import lldb
+from lldbsuite.test.decorators import *
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test import lldbutil
+
+
+class TestPtrAuthAuthTraps(TestBase):
+    NO_DEBUG_INFO_TESTCASE = True
+
+    @skipUnlessArm64eSupported
+    def test_static_function_pointer(self):
+        self.build()
+        lldbutil.run_to_source_breakpoint(
+            self, "// break here", lldb.SBFileSpec("main.c", False)
+        )
+
+        self.expect(
+            "expression -- "
+            "static int (*bad)(int, int) = "
+            "(int (*)(int, int))__builtin_ptrauth_sign_unauthenticated("
+            "__builtin_ptrauth_strip((void *)&add, 0), 0, 42); "
+            "bad(5, 6)",
+            error=True,
+            substrs=["execution was interrupted"],
+        )
+
+    @skipUnlessArm64eSupported
+    def test_indirect_call_through_caller(self):
+        self.build()
+        lldbutil.run_to_source_breakpoint(
+            self, "// break here", lldb.SBFileSpec("main.c", False)
+        )
+
+        self.expect(
+            "expression -- "
+            "int (*bad)(int, int) = "
+            "(int (*)(int, int))__builtin_ptrauth_sign_unauthenticated("
+            "__builtin_ptrauth_strip((void *)&add, 0), 0, 42); "
+            "caller(bad, 2, 3)",
+            error=True,
+            substrs=["execution was interrupted"],
+        )

--- a/lldb/test/API/commands/expression/ptrauth-auth-traps/main.c
+++ b/lldb/test/API/commands/expression/ptrauth-auth-traps/main.c
@@ -1,0 +1,11 @@
+#include <ptrauth.h>
+
+int add(int a, int b) { return a + b; }
+
+// Forces a genuine indirect call, preventing the compiler from folding the
+// function pointer call into a direct call in the expression evaluator.
+int caller(int (*fn)(int, int), int a, int b) { return fn(a, b); }
+
+int main(void) {
+  return 0; // break here
+}


### PR DESCRIPTION
Enable and test PointerAuthAuthTraps, which ensures that we trap after an authentication failures.