### PR TITLE
[clang] deduplicate target-features for modules

### DIFF
--- a/clang/lib/Serialization/ASTReader.cpp
+++ b/clang/lib/Serialization/ASTReader.cpp
@@ -495,7 +495,10 @@ static bool checkTargetOptions(const TargetOptions &TargetOpts,
   SmallVector<StringRef, 4> ReadFeatures(TargetOpts.FeaturesAsWritten.begin(),
                                          TargetOpts.FeaturesAsWritten.end());
   llvm::sort(ExistingFeatures);
+  ExistingFeatures.erase(llvm::unique(ExistingFeatures),
+                         ExistingFeatures.end());
   llvm::sort(ReadFeatures);
+  ReadFeatures.erase(llvm::unique(ReadFeatures), ReadFeatures.end());
 
   // We compute the set difference in both directions explicitly so that we can
   // diagnose the differences differently.

--- a/clang/test/Modules/merge-target-features.cpp
+++ b/clang/test/Modules/merge-target-features.cpp
@@ -10,6 +10,15 @@
 // RUN:   -target-cpu i386 -target-feature +sse2 \
 // RUN:   Inputs/merge-target-features/module.modulemap
 //
+// RUN: %clang_cc1 -fmodules -x c++ -fmodules-cache-path=%t \
+// RUN:   -iquote Inputs/merge-target-features \
+// RUN:   -fno-implicit-modules \
+// RUN:   -fmodule-map-file-home-is-cwd \
+// RUN:   -emit-module -fmodule-name=foo -o %t/foo-double.pcm \
+// RUN:   -triple i386-unknown-unknown \
+// RUN:   -target-cpu i386 -target-feature +sse2 -target-feature +sse2 \
+// RUN:   Inputs/merge-target-features/module.modulemap
+//
 // RUN: not %clang_cc1 -fmodules -x c++ -fmodules-cache-path=%t \
 // RUN:   -iquote Inputs/merge-target-features \
 // RUN:   -fno-implicit-modules \
@@ -60,6 +69,18 @@
 // MISMATCH: error: precompiled file '{{.*}}foo.pcm' was compiled with the target feature '+sse2' but the current translation unit is not
 // MISMATCH: error: current translation unit is compiled with the target feature '+cx16' but the precompiled file '{{.*}}foo.pcm' was not
 // MISMATCH: error: {{.*}} configuration mismatch
+//
+// RUN: %clang_cc1 -fmodules -x c++ -fmodules-cache-path=%t \
+// RUN:   -iquote Inputs/merge-target-features \
+// RUN:   -fno-implicit-modules \
+// RUN:   -fmodule-map-file-home-is-cwd \
+// RUN:   -fmodule-map-file=Inputs/merge-target-features/module.modulemap \
+// RUN:   -fmodule-file=%t/foo-double.pcm \
+// RUN:   -triple i386-unknown-unknown \
+// RUN:   -target-cpu i386 -target-feature +sse2 \
+// RUN:   -fsyntax-only merge-target-features.cpp 2>&1 \
+// RUN:   | FileCheck --allow-empty --check-prefix=DOUBLE %s
+// DOUBLE-NOT: error:
 
 #include "foo.h"
 


### PR DESCRIPTION
Previously, double passing a target feature would make the module
incompatible with a compilation unit that only passes it once.

The motivating problem is, when we pass -target-features +tagged-globals
as well as -fsanitize=hwaddress, which adds a second copy, the module
is incompatible with one built with only one `-target-features
+tagged-globals`.
