### PR TITLE
[M68k] Fix pipeline.ll test after CodeGenPrepare analysis change

### DIFF
--- a/llvm/test/CodeGen/M68k/pipeline.ll
+++ b/llvm/test/CodeGen/M68k/pipeline.ll
@@ -38,6 +38,9 @@
 ; CHECK-NEXT:      Scalarize Masked Memory Intrinsics
 ; CHECK-NEXT:      Expand reduction intrinsics
 ; CHECK-NEXT:      Natural Loop Information
+; CHECK-NEXT:      Post-Dominator Tree Construction
+; CHECK-NEXT:      Branch Probability Analysis
+; CHECK-NEXT:      Block Frequency Analysis
 ; CHECK-NEXT:      CodeGen Prepare
 ; CHECK-NEXT:      Dominator Tree Construction
 ; CHECK-NEXT:      Exception handling preparation


### PR DESCRIPTION
211279d11c36 added Post-Dominator Tree Construction, Branch Probability Analysis, and Block Frequency Analysis before CodeGen Prepare but missed updating the M68k pipeline test.