### PR TITLE
[orc-rt] Add BootstrapInfo argument to ControllerAccess::connect.

### DIFF
--- a/orc-rt/include/orc-rt/Session.h
+++ b/orc-rt/include/orc-rt/Session.h
@@ -13,6 +13,7 @@
 #ifndef ORC_RT_SESSION_H
 #define ORC_RT_SESSION_H
 
+#include "orc-rt/BootstrapInfo.h"
 #include "orc-rt/Error.h"
 #include "orc-rt/ExecutorProcessInfo.h"
 #include "orc-rt/LockedAccess.h"
@@ -83,7 +84,7 @@ public:
     /// If connect fails to establish communication with the controller,
     /// ControllerAccess implementations must call notifyDisconnected before
     /// returning from connect.
-    virtual void connect() = 0;
+    virtual void connect(BootstrapInfo BI) = 0;
 
     /// Initiate disconnection from the controller.
     ///
@@ -190,7 +191,7 @@ public:
     return addService(std::make_unique<ServiceT>(std::forward<ArgTs>(Args)...));
   }
 
-  /// Initiate connection with controller.
+  /// Initiate connection with controller, using the given BootstrapInfo.
   ///
   /// Upon first call, assuming that the Session has not already been detached
   /// or shutdown, this will take (shared) ownership of CA and call its connect
@@ -198,7 +199,7 @@ public:
   ///
   /// If detach or shutdown have already been called then this method will not
   /// take ownership of CA or call its connect method.
-  void attach(std::shared_ptr<ControllerAccess> CA);
+  void attach(std::shared_ptr<ControllerAccess> CA, BootstrapInfo BI);
 
   /// Initiate detach from the controller.
   ///

--- a/orc-rt/lib/executor/Session.cpp
+++ b/orc-rt/lib/executor/Session.cpp
@@ -58,7 +58,7 @@ Session::Session(ExecutorProcessInfo EPI,
 
 Session::~Session() { waitForShutdown(); }
 
-void Session::attach(std::shared_ptr<ControllerAccess> CA) {
+void Session::attach(std::shared_ptr<ControllerAccess> CA, BootstrapInfo BI) {
   assert(CA && "attach called with null CA object");
 
   {
@@ -73,7 +73,7 @@ void Session::attach(std::shared_ptr<ControllerAccess> CA) {
     TargetState = State::Attached;
   }
 
-  CA->connect();
+  CA->connect(std::move(BI));
 
   {
     std::scoped_lock<std::mutex> Lock(M);

--- a/orc-rt/unittests/SessionTest.cpp
+++ b/orc-rt/unittests/SessionTest.cpp
@@ -110,9 +110,18 @@ private:
 
 class MockControllerAccess : public Session::ControllerAccess {
 public:
+  using OnConnectFn = move_only_function<void(BootstrapInfo &BI)>;
+
   MockControllerAccess(Session &SS) : Session::ControllerAccess(SS), SS(SS) {}
 
-  void connect() override {}
+  void setOnConnect(OnConnectFn OnConnect) {
+    this->OnConnect = std::move(OnConnect);
+  }
+
+  void connect(BootstrapInfo BI) override {
+    if (OnConnect)
+      OnConnect(BI);
+  }
 
   void disconnect() override {
     std::unique_lock<std::mutex> Lock(M);
@@ -251,6 +260,7 @@ private:
   size_t CallId = 0;
   std::unordered_map<size_t, OnCallHandlerCompleteFn> Pending;
   std::condition_variable ShutdownCV;
+  OnConnectFn OnConnect;
 };
 
 class CallViaMockControllerAccess {
@@ -396,7 +406,7 @@ TEST(ControllerAccessTest, Basics) {
   Session S(mockExecutorProcessInfo(),
             std::make_unique<EnqueueingDispatcher>(Tasks), noErrors);
   auto CA = std::make_shared<MockControllerAccess>(S);
-  S.attach(CA);
+  S.attach(CA, BootstrapInfo(S));
 
   EnqueueingDispatcher::runTasksFromFront(Tasks);
 
@@ -419,7 +429,7 @@ TEST(ControllerAccessTest, ValidCallToController) {
   Session S(mockExecutorProcessInfo(),
             std::make_unique<EnqueueingDispatcher>(Tasks), noErrors);
   auto CA = std::make_shared<MockControllerAccess>(S);
-  S.attach(CA);
+  S.attach(CA, BootstrapInfo(S));
 
   int32_t Result = 0;
   SPSWrapperFunction<int32_t(int32_t, int32_t)>::call(
@@ -459,7 +469,7 @@ TEST(ControllerAccessTest, CallToControllerAfterDetach) {
   Session S(mockExecutorProcessInfo(),
             std::make_unique<EnqueueingDispatcher>(Tasks), noErrors);
   auto CA = std::make_shared<MockControllerAccess>(S);
-  S.attach(CA);
+  S.attach(CA, BootstrapInfo(S));
 
   S.detach();
 
@@ -483,7 +493,7 @@ TEST(ControllerAccessTest, CallFromController) {
   Session S(mockExecutorProcessInfo(),
             std::make_unique<EnqueueingDispatcher>(Tasks), noErrors);
   auto CA = std::make_shared<MockControllerAccess>(S);
-  S.attach(CA);
+  S.attach(CA, BootstrapInfo(S));
 
   int32_t Result = 0;
   SPSWrapperFunction<int32_t(int32_t, int32_t)>::call(
@@ -507,4 +517,35 @@ TEST(ControllerAccessTest, RedundantAsyncShutdown) {
   bool RedundantCallbackRan = false;
   S.shutdown([&]() { RedundantCallbackRan = true; });
   EXPECT_TRUE(RedundantCallbackRan);
+}
+
+TEST(ControllerAccessTest, BootstrapInfoPassedToConnect) {
+  Session S(mockExecutorProcessInfo(), std::make_unique<NoDispatcher>(),
+            noErrors);
+
+  // Test values.
+  constexpr const char *SymName = "test_sym";
+  const char Sym = '.';
+  constexpr const char *SecretKey = "luggage_combo";
+  constexpr const char *SecretValue = "12345";
+
+  // Build a BootstrapInfo with custom symbols and values.
+  BootstrapInfo BI(S);
+  std::pair<const char *, const void *> TestSyms[] = {
+      {SymName, static_cast<const void *>(&Sym)}};
+  cantFail(BI.symbols().addUnique(TestSyms));
+  BI.values()[SecretKey] = SecretValue;
+
+  bool OnConnectRan = false;
+  auto CA = std::make_shared<MockControllerAccess>(S);
+  CA->setOnConnect([&](BootstrapInfo &BI) {
+    EXPECT_EQ(BI.symbols().at(SymName), static_cast<const void *>(&Sym));
+    EXPECT_EQ(BI.values().at(SecretKey), SecretValue);
+    OnConnectRan = true;
+  });
+  S.attach(CA, std::move(BI));
+
+  ASSERT_TRUE(OnConnectRan);
+
+  S.waitForShutdown();
 }


### PR DESCRIPTION
This argument should be used by ControllerAccess implementations to pass bootstrap information (process triple, page size, initial symbols and values) to the controller.