### PR TITLE
[CIR][CUDA] Global emission for fatbin symbols

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIRCUDAAttrs.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRCUDAAttrs.td
@@ -64,7 +64,7 @@ def CIR_CUDABinaryHandleAttr : CIR_Attr<
     and then generate various registration functions.
   }];
 
-  let parameters = (ins "std::string":$name);
+  let parameters = (ins "mlir::StringAttr":$name);
   let assemblyFormat = "`<` $name `>`";
 }
 

--- a/clang/include/clang/CIR/Dialect/IR/CIRCUDAAttrs.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRCUDAAttrs.td
@@ -32,7 +32,7 @@ def CIR_CUDAKernelNameAttr : CIR_Attr<"CUDAKernelName", "cu.kernel_name"> {
     respective function runtime registration on the host.
   }];
 
-  let parameters = (ins "std::string":$kernel_name);
+  let parameters = (ins "mlir::StringAttr":$kernel_name);
   let assemblyFormat = "`<` $kernel_name `>`";
   let canHaveIllegalCXXABIType = 0;
 }

--- a/clang/include/clang/CIR/Dialect/IR/CIRCUDAAttrs.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRCUDAAttrs.td
@@ -50,5 +50,22 @@ def CUDAExternallyInitializedAttr : CIR_Attr<"CUDAExternallyInitialized",
   }];
   let canHaveIllegalCXXABIType = 0;
 }
+def CIR_CUDABinaryHandleAttr : CIR_Attr<
+  "CUDABinaryHandle", "cu.binary_handle"
+> {
+  let summary = "Fat binary handle for device code.";
+  let description =
+  [{
+    This attribute is attached to the ModuleOp and records the binary file
+    name passed to host.
+
+    CUDA first compiles device-side code into a fat binary file. The file
+    name is then passed into host-side code, which is used to create a handle
+    and then generate various registration functions.
+  }];
+
+  let parameters = (ins "std::string":$name);
+  let assemblyFormat = "`<` $name `>`";
+}
 
 #endif // CLANG_CIR_DIALECT_IR_CIRCUDAATTRS_TD

--- a/clang/include/clang/CIR/Dialect/IR/CIRDialect.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRDialect.td
@@ -76,6 +76,7 @@ def CIR_Dialect : Dialect {
     static llvm::StringRef getResAttrsAttrName() { return "res_attrs"; }
     static llvm::StringRef getArgAttrsAttrName() { return "arg_attrs"; }
     static llvm::StringRef getRecordLayoutsAttrName() { return "cir.record_layouts"; }
+    static llvm::StringRef getCUDABinaryHandleAttrName() { return "cir.cu.binary_handle"; }
 
     static llvm::StringRef getAMDGPUCodeObjectVersionAttrName() { return "cir.amdhsa_code_object_version"; }
     static llvm::StringRef getAMDGPUPrintfKindAttrName() { return "cir.amdgpu_printf_kind"; }

--- a/clang/include/clang/CIR/MissingFeatures.h
+++ b/clang/include/clang/CIR/MissingFeatures.h
@@ -244,6 +244,8 @@ struct MissingFeatures {
   static bool ctorConstLvalueToRvalueConversion() { return false; }
   static bool ctorMemcpyizer() { return false; }
   static bool cudaSupport() { return false; }
+  static bool hipModuleCtor() { return false; }
+  static bool globalRegistration() { return false; }
   static bool dataLayoutTypeIsSized() { return false; }
   static bool dataLayoutTypeAllocSize() { return false; }
   static bool dataLayoutTypeStoreSize() { return false; }

--- a/clang/lib/CIR/CodeGen/CIRGenCall.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenCall.cpp
@@ -16,6 +16,7 @@
 #include "CIRGenFunction.h"
 #include "CIRGenFunctionInfo.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/IR/Attributes.h"
 #include "clang/CIR/ABIArgInfo.h"
 #include "clang/CIR/MissingFeatures.h"
 #include "llvm/Support/TypeSize.h"
@@ -421,8 +422,9 @@ void CIRGenModule::constructAttributeList(
       GlobalDecl kernel(calleeInfo.getCalleeDecl());
       llvm::StringRef kernelName = getMangledName(
           kernel.getWithKernelReferenceKind(KernelReferenceKind::Kernel));
-      auto attr =
-          cir::CUDAKernelNameAttr::get(&getMLIRContext(), kernelName.str());
+      auto attr = cir::CUDAKernelNameAttr::get(
+          &getMLIRContext(),
+          mlir::StringAttr::get(&getMLIRContext(), kernelName));
       attrs.set(attr.getMnemonic(), attr);
     }
 

--- a/clang/lib/CIR/CodeGen/CIRGenModule.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.cpp
@@ -32,10 +32,12 @@
 #include "clang/CIR/Dialect/IR/CIRTypes.h"
 #include "clang/CIR/Interfaces/CIROpInterfaces.h"
 #include "clang/CIR/MissingFeatures.h"
+#include "llvm/ADT/StringRef.h"
 
 #include "CIRGenFunctionInfo.h"
 #include "TargetInfo.h"
 #include "mlir/Dialect/Ptr/IR/MemorySpaceInterfaces.h"
+#include "mlir/IR/Attributes.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/Location.h"
 #include "mlir/IR/MLIRContext.h"
@@ -165,11 +167,12 @@ CIRGenModule::CIRGenModule(mlir::MLIRContext &mlirContext,
 
   // Set CUDA GPU binary handle.
   if (langOpts.CUDA) {
-    std::string cudaBinaryName = codeGenOpts.CudaGpuBinaryFileName;
+    llvm::StringRef cudaBinaryName = codeGenOpts.CudaGpuBinaryFileName;
     if (!cudaBinaryName.empty()) {
-      theModule->setAttr(
-          cir::CIRDialect::getCUDABinaryHandleAttrName(),
-          cir::CUDABinaryHandleAttr::get(&mlirContext, cudaBinaryName));
+      theModule->setAttr(cir::CIRDialect::getCUDABinaryHandleAttrName(),
+                         cir::CUDABinaryHandleAttr::get(
+                             &mlirContext, mlir::StringAttr::get(
+                                               &mlirContext, cudaBinaryName)));
     }
   }
 }

--- a/clang/lib/CIR/CodeGen/CIRGenModule.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.cpp
@@ -162,6 +162,16 @@ CIRGenModule::CIRGenModule(mlir::MLIRContext &mlirContext,
                                                 /*line=*/0,
                                                 /*column=*/0));
   }
+
+  // Set CUDA GPU binary handle.
+  if (langOpts.CUDA) {
+    std::string cudaBinaryName = codeGenOpts.CudaGpuBinaryFileName;
+    if (!cudaBinaryName.empty()) {
+      theModule->setAttr(
+          cir::CIRDialect::getCUDABinaryHandleAttrName(),
+          cir::CUDABinaryHandleAttr::get(&mlirContext, cudaBinaryName));
+    }
+  }
 }
 
 CIRGenModule::~CIRGenModule() = default;

--- a/clang/lib/CIR/Dialect/Transforms/LoweringPrepare.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/LoweringPrepare.cpp
@@ -109,7 +109,6 @@ struct LoweringPreparePass
       cir::GlobalLinkageKind linkage = cir::GlobalLinkageKind::ExternalLinkage,
       cir::VisibilityKind visibility = cir::VisibilityKind::Default);
 
-
   /// ------------
   /// CUDA registration related
   /// ------------

--- a/clang/lib/CIR/Dialect/Transforms/LoweringPrepare.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/LoweringPrepare.cpp
@@ -8,8 +8,8 @@
 
 #include "PassDetail.h"
 #include "mlir/IR/Attributes.h"
-#include "mlir/IR/IRMapping.h"
 #include "mlir/IR/BuiltinAttributeInterfaces.h"
+#include "mlir/IR/IRMapping.h"
 #include "clang/AST/ASTContext.h"
 #include "clang/AST/Attrs.inc"
 #include "clang/AST/Mangle.h"

--- a/clang/lib/CIR/Dialect/Transforms/LoweringPrepare.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/LoweringPrepare.cpp
@@ -11,7 +11,6 @@
 #include "mlir/IR/BuiltinAttributeInterfaces.h"
 #include "mlir/IR/IRMapping.h"
 #include "clang/AST/ASTContext.h"
-#include "clang/AST/Attrs.inc"
 #include "clang/AST/Mangle.h"
 #include "clang/Basic/Module.h"
 #include "clang/Basic/Specifiers.h"

--- a/clang/lib/CIR/Dialect/Transforms/LoweringPrepare.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/LoweringPrepare.cpp
@@ -27,6 +27,7 @@
 #include "clang/CIR/MissingFeatures.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/TypeSwitch.h"
+#include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/Path.h"
 
 #include <memory>

--- a/clang/lib/CIR/Dialect/Transforms/LoweringPrepare.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/LoweringPrepare.cpp
@@ -1727,9 +1727,10 @@ void LoweringPreparePass::runOnOp(mlir::Operation *op) {
     else if (auto globalDtor = fnOp.getGlobalDtorPriority())
       globalDtorList.emplace_back(fnOp.getName(), globalDtor.value());
 
-    if (mlir::Attribute attr = fnOp->getAttr(cir::CUDAKernelNameAttr::getMnemonic())) {
+    if (mlir::Attribute attr =
+            fnOp->getAttr(cir::CUDAKernelNameAttr::getMnemonic())) {
       auto kernelNameAttr = dyn_cast<CUDAKernelNameAttr>(attr);
-      std::string kernelName = kernelNameAttr.getKernelName();
+      llvm::StringRef kernelName = kernelNameAttr.getKernelName();
       cudaKernelMap[kernelName] = fnOp;
     }
   } else if (auto threeWayCmp = dyn_cast<cir::CmpThreeWayOp>(op)) {
@@ -1785,7 +1786,7 @@ void LoweringPreparePass::buildCUDAModuleCtor() {
   mlir::Attribute cudaBinaryHandleAttr =
       mlirModule->getAttr(CIRDialect::getCUDABinaryHandleAttrName());
   if (!cudaBinaryHandleAttr) {
-    if (astCtx->getLangOpts().HIP)
+    if (isHIP)
       assert(!cir::MissingFeatures::hipModuleCtor());
     return;
   }

--- a/clang/lib/CIR/Dialect/Transforms/LoweringPrepare.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/LoweringPrepare.cpp
@@ -1744,9 +1744,9 @@ static llvm::StringRef getCUDAPrefix(clang::ASTContext *astCtx) {
   return "cuda";
 }
 
-static llvm::StringRef addUnderscoredPrefix(llvm::StringRef prefix,
+static std::string addUnderscoredPrefix(llvm::StringRef prefix,
                                         llvm::StringRef name) {
-  return ("__" + prefix + name).getSingleStringRef();
+  return ("__" + prefix + name).str();
 }
 
 /// Creates a global constructor function for the module:
@@ -1824,8 +1824,7 @@ void LoweringPreparePass::buildCUDAModuleCtor() {
   // Create the fatbin string constant with GPU binary contents.
   auto fatbinType =
       ArrayType::get(&getContext(), charTy, gpuBinary->getBuffer().size());
-  llvm::StringRef fatbinStrName =
-      addUnderscoredPrefix(cudaPrefix, "_fatbin_str");
+  std::string fatbinStrName = addUnderscoredPrefix(cudaPrefix, "_fatbin_str");
   GlobalOp fatbinStr = GlobalOp::create(builder, loc, fatbinStrName, fatbinType,
                                         /*isConstant=*/true, {},
                                         GlobalLinkageKind::PrivateLinkage);
@@ -1840,7 +1839,7 @@ void LoweringPreparePass::buildCUDAModuleCtor() {
   auto fatbinWrapperType = RecordType::get(
       &getContext(), {intTy, intTy, voidPtrTy, voidPtrTy},
       /*packed=*/false, /*padded=*/false, RecordType::RecordKind::Struct);
-  llvm::StringRef fatbinWrapperName =
+  std::string fatbinWrapperName =
       addUnderscoredPrefix(cudaPrefix, "_fatbin_wrapper");
   GlobalOp fatbinWrapper = GlobalOp::create(
       builder, loc, fatbinWrapperName, fatbinWrapperType,
@@ -1862,7 +1861,7 @@ void LoweringPreparePass::buildCUDAModuleCtor() {
                            {magicInit, versionInit, fatbinInit, unusedInit})));
 
   // Create the GPU binary handle global variable.
-  llvm::StringRef gpubinHandleName =
+  std::string gpubinHandleName =
       addUnderscoredPrefix(cudaPrefix, "_gpubin_handle");
 
   GlobalOp gpuBinHandle = GlobalOp::create(

--- a/clang/lib/CIR/Dialect/Transforms/LoweringPrepare.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/LoweringPrepare.cpp
@@ -13,6 +13,7 @@
 #include "clang/AST/ASTContext.h"
 #include "clang/AST/Mangle.h"
 #include "clang/Basic/Module.h"
+#include "clang/Basic/SourceManager.h"
 #include "clang/Basic/Specifiers.h"
 #include "clang/Basic/TargetCXXABI.h"
 #include "clang/Basic/TargetInfo.h"
@@ -27,8 +28,8 @@
 #include "clang/CIR/MissingFeatures.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/TypeSwitch.h"
-#include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/Path.h"
+#include "llvm/Support/VirtualFileSystem.h"
 
 #include <memory>
 
@@ -1796,8 +1797,10 @@ void LoweringPreparePass::buildCUDAModuleCtor() {
           .getName()
           .getValue();
 
+  llvm::vfs::FileSystem &vfs =
+      astCtx->getSourceManager().getFileManager().getVirtualFileSystem();
   llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>> gpuBinaryOrErr =
-      llvm::MemoryBuffer::getFile(cudaGPUBinaryName);
+      vfs.getBufferForFile(cudaGPUBinaryName);
   if (std::error_code ec = gpuBinaryOrErr.getError()) {
     mlirModule->emitError("cannot open GPU binary file: " + cudaGPUBinaryName +
                           ": " + ec.message());

--- a/clang/lib/CIR/Dialect/Transforms/LoweringPrepare.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/LoweringPrepare.cpp
@@ -1812,7 +1812,6 @@ void LoweringPreparePass::buildCUDAModuleCtor() {
   CIRBaseBuilderTy builder(getContext());
   builder.setInsertionPointToStart(mlirModule.getBody());
 
-  VoidType voidTy = builder.getVoidTy();
   PointerType voidPtrTy = builder.getVoidPtrTy();
   PointerType voidPtrPtrTy = builder.getPointerTo(voidPtrTy);
   IntType intTy = builder.getSIntNTy(32);

--- a/clang/lib/CIR/Dialect/Transforms/LoweringPrepare.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/LoweringPrepare.cpp
@@ -9,6 +9,7 @@
 #include "PassDetail.h"
 #include "mlir/IR/Attributes.h"
 #include "mlir/IR/IRMapping.h"
+#include "mlir/IR/BuiltinAttributeInterfaces.h"
 #include "clang/AST/ASTContext.h"
 #include "clang/AST/Attrs.inc"
 #include "clang/AST/Mangle.h"
@@ -21,9 +22,11 @@
 #include "clang/CIR/Dialect/IR/CIRDataLayout.h"
 #include "clang/CIR/Dialect/IR/CIRDialect.h"
 #include "clang/CIR/Dialect/IR/CIROpsEnums.h"
+#include "clang/CIR/Dialect/IR/CIRTypes.h"
 #include "clang/CIR/Dialect/Passes.h"
 #include "clang/CIR/Interfaces/ASTAttrInterfaces.h"
 #include "clang/CIR/MissingFeatures.h"
+#include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/TypeSwitch.h"
 #include "llvm/Support/Path.h"
 
@@ -1724,7 +1727,7 @@ void LoweringPreparePass::runOnOp(mlir::Operation *op) {
     else if (auto globalDtor = fnOp.getGlobalDtorPriority())
       globalDtorList.emplace_back(fnOp.getName(), globalDtor.value());
 
-    if (auto attr = fnOp->getAttr(cir::CUDAKernelNameAttr::getMnemonic())) {
+    if (mlir::Attribute attr = fnOp->getAttr(cir::CUDAKernelNameAttr::getMnemonic())) {
       auto kernelNameAttr = dyn_cast<CUDAKernelNameAttr>(attr);
       std::string kernelName = kernelNameAttr.getKernelName();
       cudaKernelMap[kernelName] = fnOp;
@@ -1734,15 +1737,15 @@ void LoweringPreparePass::runOnOp(mlir::Operation *op) {
   }
 }
 
-static std::string getCUDAPrefix(clang::ASTContext *astCtx) {
+static llvm::StringRef getCUDAPrefix(clang::ASTContext *astCtx) {
   if (astCtx->getLangOpts().HIP)
     return "hip";
   return "cuda";
 }
 
-static std::string addUnderscoredPrefix(llvm::StringRef prefix,
+static llvm::StringRef addUnderscoredPrefix(llvm::StringRef prefix,
                                         llvm::StringRef name) {
-  return ("__" + prefix + name).str();
+  return ("__" + prefix + name).getSingleStringRef();
 }
 
 /// Creates a global constructor function for the module:
@@ -1787,8 +1790,10 @@ void LoweringPreparePass::buildCUDAModuleCtor() {
     return;
   }
 
-  std::string cudaGPUBinaryName =
-      mlir::cast<CUDABinaryHandleAttr>(cudaBinaryHandleAttr).getName();
+  llvm::StringRef cudaGPUBinaryName =
+      mlir::cast<CUDABinaryHandleAttr>(cudaBinaryHandleAttr)
+          .getName()
+          .getValue();
 
   llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>> gpuBinaryOrErr =
       llvm::MemoryBuffer::getFile(cudaGPUBinaryName);
@@ -1801,24 +1806,25 @@ void LoweringPreparePass::buildCUDAModuleCtor() {
       std::move(gpuBinaryOrErr.get());
 
   // Set up common types and builder.
-  std::string cudaPrefix = getCUDAPrefix(astCtx);
+  llvm::StringRef cudaPrefix = getCUDAPrefix(astCtx);
   mlir::Location loc = mlirModule->getLoc();
   CIRBaseBuilderTy builder(getContext());
   builder.setInsertionPointToStart(mlirModule.getBody());
 
-  auto voidTy = builder.getVoidTy();
-  auto voidPtrTy = builder.getVoidPtrTy();
-  auto voidPtrPtrTy = builder.getPointerTo(voidPtrTy);
-  auto intTy = builder.getSIntNTy(32);
-  auto charTy = cir::IntType::get(&getContext(), astCtx->getCharWidth(),
-                                  /*isSigned=*/false);
+  VoidType voidTy = builder.getVoidTy();
+  PointerType voidPtrTy = builder.getVoidPtrTy();
+  PointerType voidPtrPtrTy = builder.getPointerTo(voidPtrTy);
+  IntType intTy = builder.getSIntNTy(32);
+  IntType charTy = cir::IntType::get(&getContext(), astCtx->getCharWidth(),
+                                     /*isSigned=*/false);
 
   // --- Create fatbin globals ---
 
   // Create the fatbin string constant with GPU binary contents.
   auto fatbinType =
       ArrayType::get(&getContext(), charTy, gpuBinary->getBuffer().size());
-  std::string fatbinStrName = addUnderscoredPrefix(cudaPrefix, "_fatbin_str");
+  llvm::StringRef fatbinStrName =
+      addUnderscoredPrefix(cudaPrefix, "_fatbin_str");
   GlobalOp fatbinStr = GlobalOp::create(builder, loc, fatbinStrName, fatbinType,
                                         /*isConstant=*/true, {},
                                         GlobalLinkageKind::PrivateLinkage);
@@ -1833,7 +1839,7 @@ void LoweringPreparePass::buildCUDAModuleCtor() {
   auto fatbinWrapperType = RecordType::get(
       &getContext(), {intTy, intTy, voidPtrTy, voidPtrTy},
       /*packed=*/false, /*padded=*/false, RecordType::RecordKind::Struct);
-  std::string fatbinWrapperName =
+  llvm::StringRef fatbinWrapperName =
       addUnderscoredPrefix(cudaPrefix, "_fatbin_wrapper");
   GlobalOp fatbinWrapper = GlobalOp::create(
       builder, loc, fatbinWrapperName, fatbinWrapperType,
@@ -1848,14 +1854,14 @@ void LoweringPreparePass::buildCUDAModuleCtor() {
   auto fatbinStrSymbol =
       mlir::FlatSymbolRefAttr::get(fatbinStr.getSymNameAttr());
   auto fatbinInit = GlobalViewAttr::get(voidPtrTy, fatbinStrSymbol);
-  auto unusedInit = builder.getConstNullPtrAttr(voidPtrTy);
+  mlir::TypedAttr unusedInit = builder.getConstNullPtrAttr(voidPtrTy);
   fatbinWrapper.setInitialValueAttr(cir::ConstRecordAttr::get(
       fatbinWrapperType,
       mlir::ArrayAttr::get(&getContext(),
                            {magicInit, versionInit, fatbinInit, unusedInit})));
 
   // Create the GPU binary handle global variable.
-  std::string gpubinHandleName =
+  llvm::StringRef gpubinHandleName =
       addUnderscoredPrefix(cudaPrefix, "_gpubin_handle");
 
   GlobalOp gpuBinHandle = GlobalOp::create(

--- a/clang/lib/CIR/Dialect/Transforms/LoweringPrepare.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/LoweringPrepare.cpp
@@ -1819,9 +1819,9 @@ void LoweringPreparePass::buildCUDAModuleCtor() {
   auto fatbinType =
       ArrayType::get(&getContext(), charTy, gpuBinary->getBuffer().size());
   std::string fatbinStrName = addUnderscoredPrefix(cudaPrefix, "_fatbin_str");
-  GlobalOp fatbinStr =
-      GlobalOp::create(builder, loc, fatbinStrName, fatbinType,
-                       /*isConstant=*/true, GlobalLinkageKind::PrivateLinkage);
+  GlobalOp fatbinStr = GlobalOp::create(builder, loc, fatbinStrName, fatbinType,
+                                        /*isConstant=*/true, {},
+                                        GlobalLinkageKind::PrivateLinkage);
   fatbinStr.setAlignment(8);
   fatbinStr.setInitialValueAttr(cir::ConstArrayAttr::get(
       fatbinType, builder.getStringAttr(gpuBinary->getBuffer())));
@@ -1835,9 +1835,9 @@ void LoweringPreparePass::buildCUDAModuleCtor() {
       /*packed=*/false, /*padded=*/false, RecordType::RecordKind::Struct);
   std::string fatbinWrapperName =
       addUnderscoredPrefix(cudaPrefix, "_fatbin_wrapper");
-  GlobalOp fatbinWrapper =
-      GlobalOp::create(builder, loc, fatbinWrapperName, fatbinWrapperType,
-                       /*isConstant=*/true, GlobalLinkageKind::PrivateLinkage);
+  GlobalOp fatbinWrapper = GlobalOp::create(
+      builder, loc, fatbinWrapperName, fatbinWrapperType,
+      /*isConstant=*/true, {}, GlobalLinkageKind::PrivateLinkage);
 
   constexpr unsigned cudaFatMagic = 0x466243b1;
   constexpr unsigned hipFatMagic = 0x48495046;
@@ -1857,9 +1857,10 @@ void LoweringPreparePass::buildCUDAModuleCtor() {
   // Create the GPU binary handle global variable.
   std::string gpubinHandleName =
       addUnderscoredPrefix(cudaPrefix, "_gpubin_handle");
+
   GlobalOp gpuBinHandle = GlobalOp::create(
       builder, loc, gpubinHandleName, voidPtrPtrTy,
-      /*isConstant=*/false, GlobalLinkageKind::InternalLinkage);
+      /*isConstant=*/false, {}, cir::GlobalLinkageKind::InternalLinkage);
   gpuBinHandle.setInitialValueAttr(builder.getConstNullPtrAttr(voidPtrPtrTy));
   gpuBinHandle.setPrivate();
 

--- a/clang/lib/CIR/Dialect/Transforms/LoweringPrepare.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/LoweringPrepare.cpp
@@ -10,6 +10,7 @@
 #include "mlir/IR/Attributes.h"
 #include "mlir/IR/IRMapping.h"
 #include "clang/AST/ASTContext.h"
+#include "clang/AST/Attrs.inc"
 #include "clang/AST/Mangle.h"
 #include "clang/Basic/Module.h"
 #include "clang/Basic/Specifiers.h"
@@ -107,6 +108,17 @@ struct LoweringPreparePass
       mlir::Type type,
       cir::GlobalLinkageKind linkage = cir::GlobalLinkageKind::ExternalLinkage,
       cir::VisibilityKind visibility = cir::VisibilityKind::Default);
+
+
+  /// ------------
+  /// CUDA registration related
+  /// ------------
+
+  llvm::StringMap<FuncOp> cudaKernelMap;
+
+  /// Build the CUDA module constructor that registers the fat binary
+  /// with the CUDA runtime.
+  void buildCUDAModuleCtor();
 
   /// Handle static local variable initialization with guard variables.
   void handleStaticLocal(cir::GlobalOp globalOp, cir::GetGlobalOp getGlobalOp);
@@ -1712,9 +1724,148 @@ void LoweringPreparePass::runOnOp(mlir::Operation *op) {
       globalCtorList.emplace_back(fnOp.getName(), globalCtor.value());
     else if (auto globalDtor = fnOp.getGlobalDtorPriority())
       globalDtorList.emplace_back(fnOp.getName(), globalDtor.value());
+
+    if (auto attr = fnOp->getAttr(cir::CUDAKernelNameAttr::getMnemonic())) {
+      auto kernelNameAttr = dyn_cast<CUDAKernelNameAttr>(attr);
+      std::string kernelName = kernelNameAttr.getKernelName();
+      cudaKernelMap[kernelName] = fnOp;
+    }
   } else if (auto threeWayCmp = dyn_cast<cir::CmpThreeWayOp>(op)) {
     lowerThreeWayCmpOp(threeWayCmp);
   }
+}
+
+static std::string getCUDAPrefix(clang::ASTContext *astCtx) {
+  if (astCtx->getLangOpts().HIP)
+    return "hip";
+  return "cuda";
+}
+
+static std::string addUnderscoredPrefix(llvm::StringRef prefix,
+                                        llvm::StringRef name) {
+  return ("__" + prefix + name).str();
+}
+
+/// Creates a global constructor function for the module:
+///
+/// For CUDA:
+/// \code
+/// void __cuda_module_ctor() {
+///     Handle = __cudaRegisterFatBinary(GpuBinaryBlob);
+///     __cuda_register_globals(Handle);
+/// }
+/// \endcode
+///
+/// For HIP:
+/// \code
+/// void __hip_module_ctor() {
+///     if (__hip_gpubin_handle == 0) {
+///         __hip_gpubin_handle  = __hipRegisterFatBinary(GpuBinaryBlob);
+///         __hip_register_globals(__hip_gpubin_handle);
+///     }
+/// }
+/// \endcode
+void LoweringPreparePass::buildCUDAModuleCtor() {
+  bool isHIP = astCtx->getLangOpts().HIP;
+
+  if (isHIP)
+    assert(!cir::MissingFeatures::hipModuleCtor());
+  if (astCtx->getLangOpts().GPURelocatableDeviceCode)
+    llvm_unreachable("GPU RDC NYI");
+
+  // For CUDA without -fgpu-rdc, it's safe to stop generating ctor
+  // if there's nothing to register.
+  if (cudaKernelMap.empty())
+    return;
+
+  // There's no device-side binary, so no need to proceed for CUDA.
+  // HIP has to create an external symbol in this case, which is NYI.
+  mlir::Attribute cudaBinaryHandleAttr =
+      mlirModule->getAttr(CIRDialect::getCUDABinaryHandleAttrName());
+  if (!cudaBinaryHandleAttr) {
+    if (astCtx->getLangOpts().HIP)
+      assert(!cir::MissingFeatures::hipModuleCtor());
+    return;
+  }
+
+  std::string cudaGPUBinaryName =
+      mlir::cast<CUDABinaryHandleAttr>(cudaBinaryHandleAttr).getName();
+
+  llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>> gpuBinaryOrErr =
+      llvm::MemoryBuffer::getFile(cudaGPUBinaryName);
+  if (std::error_code ec = gpuBinaryOrErr.getError()) {
+    mlirModule->emitError("cannot open GPU binary file: " + cudaGPUBinaryName +
+                          ": " + ec.message());
+    return;
+  }
+  std::unique_ptr<llvm::MemoryBuffer> gpuBinary =
+      std::move(gpuBinaryOrErr.get());
+
+  // Set up common types and builder.
+  std::string cudaPrefix = getCUDAPrefix(astCtx);
+  mlir::Location loc = mlirModule->getLoc();
+  CIRBaseBuilderTy builder(getContext());
+  builder.setInsertionPointToStart(mlirModule.getBody());
+
+  auto voidTy = builder.getVoidTy();
+  auto voidPtrTy = builder.getVoidPtrTy();
+  auto voidPtrPtrTy = builder.getPointerTo(voidPtrTy);
+  auto intTy = builder.getSIntNTy(32);
+  auto charTy = cir::IntType::get(&getContext(), astCtx->getCharWidth(),
+                                  /*isSigned=*/false);
+
+  // --- Create fatbin globals ---
+
+  // Create the fatbin string constant with GPU binary contents.
+  auto fatbinType =
+      ArrayType::get(&getContext(), charTy, gpuBinary->getBuffer().size());
+  std::string fatbinStrName = addUnderscoredPrefix(cudaPrefix, "_fatbin_str");
+  GlobalOp fatbinStr =
+      GlobalOp::create(builder, loc, fatbinStrName, fatbinType,
+                       /*isConstant=*/true, GlobalLinkageKind::PrivateLinkage);
+  fatbinStr.setAlignment(8);
+  fatbinStr.setInitialValueAttr(cir::ConstArrayAttr::get(
+      fatbinType, builder.getStringAttr(gpuBinary->getBuffer())));
+  assert(!cir::MissingFeatures::opGlobalSection());
+  fatbinStr.setPrivate();
+
+  // Create the fatbin wrapper struct:
+  //    struct { int magic; int version; void *fatbin; void *unused; };
+  auto fatbinWrapperType = RecordType::get(
+      &getContext(), {intTy, intTy, voidPtrTy, voidPtrTy},
+      /*packed=*/false, /*padded=*/false, RecordType::RecordKind::Struct);
+  std::string fatbinWrapperName =
+      addUnderscoredPrefix(cudaPrefix, "_fatbin_wrapper");
+  GlobalOp fatbinWrapper =
+      GlobalOp::create(builder, loc, fatbinWrapperName, fatbinWrapperType,
+                       /*isConstant=*/true, GlobalLinkageKind::PrivateLinkage);
+
+  constexpr unsigned cudaFatMagic = 0x466243b1;
+  constexpr unsigned hipFatMagic = 0x48495046;
+  unsigned fatMagic = isHIP ? hipFatMagic : cudaFatMagic;
+
+  auto magicInit = IntAttr::get(intTy, fatMagic);
+  auto versionInit = IntAttr::get(intTy, 1);
+  auto fatbinStrSymbol =
+      mlir::FlatSymbolRefAttr::get(fatbinStr.getSymNameAttr());
+  auto fatbinInit = GlobalViewAttr::get(voidPtrTy, fatbinStrSymbol);
+  auto unusedInit = builder.getConstNullPtrAttr(voidPtrTy);
+  fatbinWrapper.setInitialValueAttr(cir::ConstRecordAttr::get(
+      fatbinWrapperType,
+      mlir::ArrayAttr::get(&getContext(),
+                           {magicInit, versionInit, fatbinInit, unusedInit})));
+
+  // Create the GPU binary handle global variable.
+  std::string gpubinHandleName =
+      addUnderscoredPrefix(cudaPrefix, "_gpubin_handle");
+  GlobalOp gpuBinHandle = GlobalOp::create(
+      builder, loc, gpubinHandleName, voidPtrPtrTy,
+      /*isConstant=*/false, GlobalLinkageKind::InternalLinkage);
+  gpuBinHandle.setInitialValueAttr(builder.getConstNullPtrAttr(voidPtrPtrTy));
+  gpuBinHandle.setPrivate();
+
+  // TODO: ctor/dtor/register_globals
+  assert(!cir::MissingFeatures::globalRegistration());
 }
 
 void LoweringPreparePass::runOnOperation() {
@@ -1737,6 +1888,9 @@ void LoweringPreparePass::runOnOperation() {
     runOnOp(o);
 
   buildCXXGlobalInitFunc();
+  if (astCtx->getLangOpts().CUDA && !astCtx->getLangOpts().CUDAIsDevice)
+    buildCUDAModuleCtor();
+
   buildGlobalCtorDtorList();
 }
 

--- a/clang/lib/CIR/Dialect/Transforms/LoweringPrepare.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/LoweringPrepare.cpp
@@ -1821,6 +1821,13 @@ void LoweringPreparePass::buildCUDAModuleCtor() {
 
   // --- Create fatbin globals ---
 
+  // The section names are different for MAC OS X.
+  llvm::StringRef fatbinConstName =
+      astCtx->getLangOpts().HIP ? ".hip_fatbin" : ".nv_fatbin";
+
+  llvm::StringRef fatbinSectionName =
+      astCtx->getLangOpts().HIP ? ".hipFatBinSegment" : ".nvFatBinSegment";
+
   // Create the fatbin string constant with GPU binary contents.
   auto fatbinType =
       ArrayType::get(&getContext(), charTy, gpuBinary->getBuffer().size());
@@ -1831,7 +1838,7 @@ void LoweringPreparePass::buildCUDAModuleCtor() {
   fatbinStr.setAlignment(8);
   fatbinStr.setInitialValueAttr(cir::ConstArrayAttr::get(
       fatbinType, builder.getStringAttr(gpuBinary->getBuffer())));
-  assert(!cir::MissingFeatures::opGlobalSection());
+  fatbinStr.setSection(fatbinConstName);
   fatbinStr.setPrivate();
 
   // Create the fatbin wrapper struct:
@@ -1844,6 +1851,7 @@ void LoweringPreparePass::buildCUDAModuleCtor() {
   GlobalOp fatbinWrapper = GlobalOp::create(
       builder, loc, fatbinWrapperName, fatbinWrapperType,
       /*isConstant=*/true, {}, GlobalLinkageKind::PrivateLinkage);
+  fatbinWrapper.setSection(fatbinSectionName);
 
   constexpr unsigned cudaFatMagic = 0x466243b1;
   constexpr unsigned hipFatMagic = 0x48495046;

--- a/clang/test/CIR/CodeGenCUDA/device-stub.cu
+++ b/clang/test/CIR/CodeGenCUDA/device-stub.cu
@@ -3,17 +3,14 @@
 // Create a dummy GPU binary file for registration.
 // RUN: echo -n "GPU binary would be here." > %t
 
-// CIR output — check fatbin globals are created correctly.
 // RUN: %clang_cc1 -triple x86_64-linux-gnu -emit-cir %s -x cuda \
 // RUN:   -target-sdk-version=12.3 -fcuda-include-gpubinary %t -o %t.cir
 // RUN: FileCheck --input-file=%t.cir %s --check-prefix=CIR
 
-// OGCG output — check LLVM IR parity with original codegen.
 // RUN: %clang_cc1 -triple x86_64-linux-gnu -emit-llvm %s -x cuda \
 // RUN:   -target-sdk-version=12.3 -fcuda-include-gpubinary %t -o %t.ll
 // RUN: FileCheck --input-file=%t.ll %s --check-prefix=OGCG
 
-// No GPU binary — nothing should be generated.
 // RUN: %clang_cc1 -triple x86_64-linux-gnu -emit-cir %s -x cuda \
 // RUN:   -target-sdk-version=12.3 -o %t.nogpu.cir
 // RUN: FileCheck --input-file=%t.nogpu.cir %s --check-prefix=NOGPUBIN

--- a/clang/test/CIR/CodeGenCUDA/device-stub.cu
+++ b/clang/test/CIR/CodeGenCUDA/device-stub.cu
@@ -1,0 +1,50 @@
+// Based on clang/test/CodeGenCUDA/device-stub.cu (incubator).
+
+// Create a dummy GPU binary file for registration.
+// RUN: echo -n "GPU binary would be here." > %t
+
+// CIR output — check fatbin globals are created correctly.
+// RUN: %clang_cc1 -triple x86_64-linux-gnu -emit-cir %s -x cuda \
+// RUN:   -target-sdk-version=12.3 -fcuda-include-gpubinary %t -o %t.cir
+// RUN: FileCheck --input-file=%t.cir %s --check-prefix=CIR
+
+// OGCG output — check LLVM IR parity with original codegen.
+// RUN: %clang_cc1 -triple x86_64-linux-gnu -emit-llvm %s -x cuda \
+// RUN:   -target-sdk-version=12.3 -fcuda-include-gpubinary %t -o %t.ll
+// RUN: FileCheck --input-file=%t.ll %s --check-prefix=OGCG
+
+// No GPU binary — nothing should be generated.
+// RUN: %clang_cc1 -triple x86_64-linux-gnu -emit-cir %s -x cuda \
+// RUN:   -target-sdk-version=12.3 -o %t.nogpu.cir
+// RUN: FileCheck --input-file=%t.nogpu.cir %s --check-prefix=NOGPUBIN
+
+#include "Inputs/cuda.h"
+
+__global__ void kernelfunc(int i, int j, int k) {}
+
+void hostfunc(void) { kernelfunc<<<1, 1>>>(1, 1, 1); }
+
+// Check the fatbin string constant with GPU binary contents.
+// CIR: cir.global "private" constant cir_private @__cuda_fatbin_str = #cir.const_array<"GPU binary would be here."> : !cir.array<!u8i x 25> {alignment = 8 : i64}
+
+// Check the fatbin wrapper struct: { magic, version, ptr to fatbin, null }.
+// CIR: cir.global constant cir_private @__cuda_fatbin_wrapper = #cir.const_record<{
+// CIR-SAME: #cir.int<1180844977> : !s32i,
+// CIR-SAME: #cir.int<1> : !s32i,
+// CIR-SAME: #cir.global_view<@__cuda_fatbin_str> : !cir.ptr<!void>,
+// CIR-SAME: #cir.ptr<null> : !cir.ptr<!void>
+// CIR-SAME: }>
+
+// Check the GPU binary handle global.
+// CIR: cir.global "private" internal @__cuda_gpubin_handle = #cir.ptr<null> : !cir.ptr<!cir.ptr<!void>>
+
+// OGCG: constant [25 x i8] c"GPU binary would be here.", section ".nv_fatbin", align 8
+// OGCG: @__cuda_fatbin_wrapper = internal constant { i32, i32, ptr, ptr } { i32 1180844977, i32 1, ptr @{{.*}}, ptr null }, section ".nvFatBinSegment"
+// OGCG: @__cuda_gpubin_handle = internal global ptr null
+
+// No GPU binary — no registration infrastructure at all.
+// NOGPUBIN-NOT: fatbin
+// NOGPUBIN-NOT: gpubin
+// NOGPUBIN-NOT: __cuda_register_globals
+// NOGPUBIN-NOT: __cuda_module_ctor
+// NOGPUBIN-NOT: __cuda_module_dtor

--- a/clang/test/CIR/CodeGenCUDA/device-stub.cu
+++ b/clang/test/CIR/CodeGenCUDA/device-stub.cu
@@ -21,16 +21,15 @@ __global__ void kernelfunc(int i, int j, int k) {}
 
 void hostfunc(void) { kernelfunc<<<1, 1>>>(1, 1, 1); }
 
-// Check the fatbin string constant with GPU binary contents.
-// CIR: cir.global "private" constant cir_private @__cuda_fatbin_str = #cir.const_array<"GPU binary would be here."> : !cir.array<!u8i x 25> {alignment = 8 : i64}
+// CIR: cir.global "private" constant cir_private @__cuda_fatbin_str = #cir.const_array<"GPU binary would be here."> : !cir.array<!u8i x 25> {alignment = 8 : i64, section = ".nv_fatbin"}
 
-// Check the fatbin wrapper struct: { magic, version, ptr to fatbin, null }.
+// Check the fatbin wrapper struct: { magic, version, ptr to fatbin, null }, with section.
 // CIR: cir.global constant cir_private @__cuda_fatbin_wrapper = #cir.const_record<{
 // CIR-SAME: #cir.int<1180844977> : !s32i,
 // CIR-SAME: #cir.int<1> : !s32i,
 // CIR-SAME: #cir.global_view<@__cuda_fatbin_str> : !cir.ptr<!void>,
 // CIR-SAME: #cir.ptr<null> : !cir.ptr<!void>
-// CIR-SAME: }>
+// CIR-SAME: }> : !rec_anon_struct {section = ".nvFatBinSegment"}
 
 // Check the GPU binary handle global.
 // CIR: cir.global "private" internal @__cuda_gpubin_handle = #cir.ptr<null> : !cir.ptr<!cir.ptr<!void>>

--- a/clang/test/CIR/CodeGenCUDA/kernel-call.cu
+++ b/clang/test/CIR/CodeGenCUDA/kernel-call.cu
@@ -118,13 +118,13 @@ int main(void) {
   // CUDA-NEW: } else {
   // CUDA-NEW:   cir.const #cir.int<42> : !s32i
   // CUDA-NEW:   cir.const #cir.fp<1.000000e+00> : !cir.float
-  // CUDA-NEW:   cir.call @_Z21__device_stub__kernelif({{.*}}) {cu.kernel_name = #cir.cu.kernel_name<_Z6kernelif>} : (!s32i {llvm.noundef}, !cir.float {llvm.noundef}) -> ()
+  // CUDA-NEW:   cir.call @_Z21__device_stub__kernelif({{.*}}) {cu.kernel_name = #cir.cu.kernel_name<"_Z6kernelif">} : (!s32i {llvm.noundef}, !cir.float {llvm.noundef}) -> ()
   // CUDA-NEW: }
   // HIP-NEW: cir.if %{{.*}} {
   // HIP-NEW: } else {
   // HIP-NEW:   cir.const #cir.int<42> : !s32i
   // HIP-NEW:   cir.const #cir.fp<1.000000e+00> : !cir.float
-  // HIP-NEW:   cir.call @_Z21__device_stub__kernelif({{.*}}) {cu.kernel_name = #cir.cu.kernel_name<_Z6kernelif>} : (!s32i {llvm.noundef}, !cir.float {llvm.noundef}) -> ()
+  // HIP-NEW:   cir.call @_Z21__device_stub__kernelif({{.*}}) {cu.kernel_name = #cir.cu.kernel_name<"_Z6kernelif">} : (!s32i {llvm.noundef}, !cir.float {llvm.noundef}) -> ()
   // HIP-NEW: }
   kernel<<<1, 1>>>(42, 1.0f);
 }

--- a/clang/test/CIR/CodeGenCUDA/kernel-stub-name.cu
+++ b/clang/test/CIR/CodeGenCUDA/kernel-stub-name.cu
@@ -6,17 +6,17 @@
 
 #include "Inputs/cuda.h"
 
-// CHECK: cir.func {{.*}} @[[CSTUB:__device_stub__ckernel]]() attributes {cu.kernel_name = #cir.cu.kernel_name<ckernel>{{.*}}}
+// CHECK: cir.func {{.*}} @[[CSTUB:__device_stub__ckernel]]() attributes {cu.kernel_name = #cir.cu.kernel_name<"ckernel">{{.*}}}
 // CHECK: cir.return
 // CHECK-NEXT: }
 extern "C" __global__ void ckernel() {}
 
-// CHECK: cir.func {{.*}} @_ZN2ns23__device_stub__nskernelEv() attributes {cu.kernel_name = #cir.cu.kernel_name<_ZN2ns8nskernelEv>{{.*}}}
+// CHECK: cir.func {{.*}} @_ZN2ns23__device_stub__nskernelEv() attributes {cu.kernel_name = #cir.cu.kernel_name<"_ZN2ns8nskernelEv">{{.*}}}
 namespace ns {
 __global__ void nskernel() {}
 } // namespace ns
 
-// CHECK: cir.func {{.*}} @_Z25__device_stub__kernelfuncIiEvv() attributes {cu.kernel_name = #cir.cu.kernel_name<_Z10kernelfuncIiEvv>{{.*}}}
+// CHECK: cir.func {{.*}} @_Z25__device_stub__kernelfuncIiEvv() attributes {cu.kernel_name = #cir.cu.kernel_name<"_Z10kernelfuncIiEvv">{{.*}}}
 template <class T>
 __global__ void kernelfunc() {}
 template __global__ void kernelfunc<int>();

--- a/clang/test/CIR/CodeGenHIP/simple.cpp
+++ b/clang/test/CIR/CodeGenHIP/simple.cpp
@@ -42,7 +42,7 @@ __global__ void global_fn(int a) {}
 // CIR-DEVICE: cir.func {{.*}}{{.*}} @_Z9global_fni
 // OGCG-DEVICE: define protected amdgpu_kernel void @_Z9global_fni
 
-// CIR-HOST: @_Z24__device_stub__global_fni{{.*}}attributes {cu.kernel_name = #cir.cu.kernel_name<_Z9global_fni>{{.*}}}
+// CIR-HOST: @_Z24__device_stub__global_fni{{.*}}attributes {cu.kernel_name = #cir.cu.kernel_name<"_Z9global_fni">{{.*}}}
 // CIR-HOST: %[[#CIRKernelArgs:]] = cir.alloca {{.*}}"kernel_args"
 // CIR-HOST: %[[#Decayed:]] = cir.cast array_to_ptrdecay %[[#CIRKernelArgs]]
 // CIR-HOST: cir.call @__hipPopCallConfiguration


### PR DESCRIPTION
Related: https://github.com/issues/assigned?issue=llvm%7Cllvm-project%7C179278, https://github.com/llvm/llvm-project/issues/175871

This officially kickstarts the foundation for Registration which is a pretty large peace of CUDA/HIP support. These fatbin symbols are involved widely throughout this component to register globals. This whole effort will be tackled incrementally in the next set of patches. 

Also note:

Lowering to LLVM IR is deferred since I was getting crashes when lowering `__cuda_fatbin_str` which holds `!cir.array<!u8i x 25>`.

```
Assertion failed: (arrayTy && "String attribute must have an array type"), function visitCirAttr, file LowerToLLVM.cpp, line 601.
PLEASE submit a bug report to https://github.com/llvm/llvm-project/issues/ and include the crash backtrace, preprocessed source, and associated run script.
Stack dump:
0.      Program arguments: /Users/davidfeliperiveraguerra/dev/llvm-upstream/build/bin/clang -cc1 -triple x86_64-linux-gnu -fclangir -emit-llvm -target-sdk-version=12.3 -internal-isystem /Users/davidfeliperiveraguerra/dev/llvm-upstream/build/lib/clang/23/include -fcuda-include-gpubinary /tmp/test.fatbin -I /Users/davidfeliperiveraguerra/dev/llvm-upstream/clang/test/CIR/CodeGenCUDA/Inputs/ /tmp/test_reg.cu -o -
1.      <eof> parser at end of file
 #0 0x00000001029cd5d0 llvm::sys::PrintStackTrace(llvm::raw_ostream&, int) (/Users/davidfeliperiveraguerra/dev/llvm-upstream/build/bin/clang-23+0x1024e95d0)
 #1 0x00000001029cdb90 PrintStackTraceSignalHandler(void*) (/Users/davidfeliperiveraguerra/dev/llvm-upstream/build/bin/clang-23+0x1024e9b90)
 #2 0x00000001029cb480 llvm::sys::RunSignalHandlers() (/Users/davidfeliperiveraguerra/dev/llvm-upstream/build/bin/clang-23+0x1024e7480)
 #3 0x00000001029cf658 SignalHandler(int, __siginfo*, void*) (/Users/davidfeliperiveraguerra/dev/llvm-upstream/build/bin/clang-23+0x1024eb658)
 #4 0x00000001029cf52c SignalHandlerTerminate(int, __siginfo*, void*) (/Users/davidfeliperiveraguerra/dev/llvm-upstream/build/bin/clang-23+0x1024eb52c)
 #5 0x000000018372b744 (/usr/lib/system/libsystem_platform.dylib+0x1804e3744)
 #6 0x0000000183721888 (/usr/lib/system/libsystem_pthread.dylib+0x1804d9888)
 #7 0x0000000183626850 (/usr/lib/system/libsystem_c.dylib+0x1803de850)
 #8 0x0000000183625a84 (/usr/lib/system/libsystem_c.dylib+0x1803dda84)
 #9 0x0000000104dfcfe0 cir::direct::CIRAttrToValue::visitCirAttr(cir::ConstArrayAttr) (/Users/davidfeliperiveraguerra/dev/llvm-upstream/build/bin/clang-23+0x104918fe0)
#10 0x0000000104e41ca8 auto cir::direct::CIRAttrToValue::visit(mlir::Attribute)::'lambda'(auto)::operator()<cir::ConstArrayAttr>(auto) const (/Users/davidfeliperiveraguerra/dev/llvm-upstream/build/bin/clang-23+0x10495dca8)
#11 0x0000000104e41c1c llvm::TypeSwitch<mlir::Attribute, mlir::Value>& llvm::TypeSwitch<mlir::Attribute, mlir::Value>::Case<cir::ConstArrayAttr, cir::direct::CIRAttrToValue::visit(mlir::Attribute)::'lambda'(auto)&>(cir::direct::CIRAttrToValue::visit(mlir::Attribute)::'lambda'(auto)&) (/Users/davidfeliperiveraguerra/dev/llvm-upstream/build/bin/clang-23+0x10495dc1c)
#12 0x0000000104dfb7d0 cir::direct::CIRAttrToValue::visit(mlir::Attribute) (/Users/davidfeliperiveraguerra/dev/llvm-upstream/build/bin/clang-23+0x1049177d0)
#13 0x0000000104e13724 cir::direct::CIRToLLVMGlobalOpLowering::matchAndRewriteRegionInitializedGlobal(cir::GlobalOp, mlir::Attribute, mlir::ConversionPatternRewriter&) const (/Users/davidfeliperiveraguerra/dev/llvm-upstream/build/bin/clang-23+0x10492f724)
```

Might need to investigate this crash further.