### PR TITLE
[orc-rt] Add Session::tryCreateService convenience function.

### DIFF
--- a/orc-rt/include/orc-rt/Session.h
+++ b/orc-rt/include/orc-rt/Session.h
@@ -191,6 +191,20 @@ public:
     return addService(std::make_unique<ServiceT>(std::forward<ArgTs>(Args)...));
   }
 
+  /// Try to create an instance of ServiceT by forwarding the given arguments
+  /// to ServiceT::Create method, which must return an
+  /// Expected<std::unique_ptr<ServiceT>>.
+  ///
+  /// On success, adds the service and returns a reference to it.
+  /// On failure returns the Error produced by ServiceT::Create.
+  template <typename ServiceT, typename... ArgTs>
+  Expected<ServiceT &> tryCreateService(ArgTs &&...Args) {
+    auto Srv = ServiceT::Create(std::forward<ArgTs>(Args)...);
+    if (!Srv)
+      return Srv.takeError();
+    return addService(std::move(*Srv));
+  }
+
   /// Initiate connection with controller, using the given BootstrapInfo.
   ///
   /// Upon first call, assuming that the Session has not already been detached

--- a/orc-rt/unittests/SessionTest.cpp
+++ b/orc-rt/unittests/SessionTest.cpp
@@ -63,6 +63,13 @@ class ConfigurableService : public Service {
 public:
   ConfigurableService(int ConstructorOption) {}
 
+  /// Fallible named constructor for testing tryCreateService.
+  static Expected<std::unique_ptr<ConfigurableService>> Create(bool Fail) {
+    if (Fail)
+      return make_error<StringError>("failed to create service");
+    return std::make_unique<ConfigurableService>(42);
+  }
+
   void onDetach(OnCompleteFn OnComplete, bool ShutdownRequested) override {
     OnComplete();
   }
@@ -397,6 +404,26 @@ TEST(SessionTest, CreateServiceAndUseRef) {
             noErrors);
   auto &CS = S.createService<ConfigurableService>(42);
   CS.doMoreConfig(1);
+}
+
+TEST(SessionTest, TryCreateServiceSuccess) {
+  Session S(mockExecutorProcessInfo(), std::make_unique<NoDispatcher>(),
+            noErrors);
+  auto CS = S.tryCreateService<ConfigurableService>(false);
+  if (auto Err = CS.takeError()) {
+    ADD_FAILURE() << "expected service creation to succeed";
+    consumeError(std::move(Err));
+  }
+}
+
+TEST(SessionTest, TryCreateServiceFailure) {
+  Session S(mockExecutorProcessInfo(), std::make_unique<NoDispatcher>(),
+            noErrors);
+  auto CS = S.tryCreateService<ConfigurableService>(true);
+  if (auto Err = CS.takeError())
+    consumeError(std::move(Err));
+  else
+    ADD_FAILURE() << "expected service creation to fail";
 }
 
 TEST(ControllerAccessTest, Basics) {


### PR DESCRIPTION
Session::tryCreateService will try to create an instance of ServiceT by forwarding the given arguments to the ServiceT::Create method, which must return an Expected<std::unique_ptr<ServiceT>>.

This enables one-line construction and registration of Services with fallible constructors (which are expected to be common).