### PR TITLE
[ACC] Use ExistingOps strictness in ACCSpecializeForDevice for non-specialized functions

### DIFF
--- a/mlir/lib/Dialect/OpenACC/Transforms/ACCSpecializeForDevice.cpp
+++ b/mlir/lib/Dialect/OpenACC/Transforms/ACCSpecializeForDevice.cpp
@@ -95,6 +95,11 @@ public:
     } else {
       // For non-specialized functions, apply patterns only to ACC operations
       // inside compute constructs (not to the compute constructs themselves).
+      // Use ExistingOps strictness so the greedy driver does not expand the
+      // worklist to parent ops, which would accidentally unwrap the compute
+      // construct (e.g. after inlining acc routines with their own data
+      // regions).
+      config.setStrictness(GreedyRewriteStrictness::ExistingOps);
       SmallVector<Operation *> opsToTransform;
       func.walk([&](Operation *op) {
         if (isa<ACC_COMPUTE_CONSTRUCT_OPS>(op)) {

--- a/mlir/test/Dialect/OpenACC/acc-specialize-for-device.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-specialize-for-device.mlir
@@ -80,6 +80,34 @@ func.func @copyin_outside_parallel(%arg0 : memref<i32>) {
 }
 
 //===----------------------------------------------------------------------===//
+// Nested data constructs inside compute construct (non-specialized function).
+// After inlining an acc routine that has its own data region into a parallel
+// loop body, the inlined acc.data/acc.copyin end up inside acc.parallel.
+// The outer acc.parallel must NOT be unwrapped even though the inner data
+// ops are stripped. Regression test for greedy driver worklist expansion.
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: func.func @nested_data_inside_parallel
+// CHECK:       acc.copyin
+// CHECK:       acc.parallel
+// CHECK-NOT:   acc.data
+// CHECK-NOT:   acc.copyin
+// CHECK:       acc.yield
+func.func @nested_data_inside_parallel(%arg0 : memref<i32>, %arg1 : memref<i32>) {
+  %c0 = arith.constant 0 : i32
+  %0 = acc.copyin varPtr(%arg0 : memref<i32>) -> memref<i32>
+  acc.parallel dataOperands(%0 : memref<i32>) {
+    %1 = acc.copyin varPtr(%arg1 : memref<i32>) -> memref<i32>
+    acc.data dataOperands(%1 : memref<i32>) {
+      memref.store %c0, %arg1[] : memref<i32>
+      acc.terminator
+    }
+    acc.yield
+  }
+  return
+}
+
+//===----------------------------------------------------------------------===//
 // Data exit ops in specialized routines
 //===----------------------------------------------------------------------===//
 


### PR DESCRIPTION
For non-specialized functions, ACCSpecializeForDevice collects ACC ops inside compute constructs and applies device specialization patterns via applyOpPatternsGreedily. With the default AnyOp strictness, the greedy driver expands the worklist to parent ops when inner ops are modified, accidentally unwrapping the parent acc.parallel via ACCRegionUnwrapConversion. This leaves orphaned acc.loop combined(parallel) ops that lose their parallelism and reduction information downstream.

Set GreedyRewriteStrictness::ExistingOps so the greedy driver only processes the initially collected inner ops, preserving the parent compute construct for ACCComputeLowering to handle.
