### PR TITLE
[llvm-dwarfdump] Support R_AARCH64_TLS_DTPREL64 in Object/RelocationResolver.cpp

### DIFF
--- a/llvm/lib/Object/RelocationResolver.cpp
+++ b/llvm/lib/Object/RelocationResolver.cpp
@@ -79,6 +79,7 @@ static bool supportsAArch64(uint64_t Type) {
   case ELF::R_AARCH64_PREL16:
   case ELF::R_AARCH64_PREL32:
   case ELF::R_AARCH64_PREL64:
+  case ELF::R_AARCH64_TLS_DTPREL64:
     return true;
   default:
     return false;
@@ -91,6 +92,7 @@ static uint64_t resolveAArch64(uint64_t Type, uint64_t Offset, uint64_t S,
   case ELF::R_AARCH64_ABS32:
     return (S + Addend) & 0xFFFFFFFF;
   case ELF::R_AARCH64_ABS64:
+  case ELF::R_AARCH64_TLS_DTPREL64:
     return S + Addend;
   case ELF::R_AARCH64_PREL16:
     return (S + Addend - Offset) & 0xFFFF;

--- a/llvm/test/DebugInfo/AArch64/tls-at-location.ll
+++ b/llvm/test/DebugInfo/AArch64/tls-at-location.ll
@@ -1,5 +1,5 @@
 ; RUN: llc -O0 -mtriple=aarch64 --aarch64-emit-debug-tls-location -filetype=obj < %s \
-; RUN:     | llvm-dwarfdump - | FileCheck %s --check-prefix=TLS
+; RUN:     | llvm-dwarfdump - 2>&1 | FileCheck %s --check-prefix=TLS --implicit-check-not=warning:
 
 ; RUN: llc -O0 -mtriple=aarch64 --aarch64-emit-debug-tls-location=false -filetype=obj < %s \
 ; RUN:     | llvm-dwarfdump - | FileCheck %s --check-prefix=NO-TLS


### PR DESCRIPTION
In patch https://github.com/llvm/llvm-project/pull/146572 we have plan to emit R_AARCH64_TLS_DTPREL64. This give us the warning while using llvm-dwarfdump for the object file which has tls variables -

warning: failed to compute relocation: R_AARCH64_TLS_DTPREL64, Invalid data was encountered while parsing the file

To fix this warning we have mark the relocation as supported however final absolute address of a TLS variable is determined at runtime, resolving to the symbol's section-relative offset in the object file is mitigate the warning.