### PR TITLE
HIPSPV: a fix for Assertion `isFilename() && "Invalid accessor."' failed

### DIFF
--- a/clang/lib/Driver/ToolChains/HIPSPV.cpp
+++ b/clang/lib/Driver/ToolChains/HIPSPV.cpp
@@ -60,7 +60,8 @@ void HIPSPV::Linker::constructLinkAndEmitSpirvCommand(
   ArgStringList LinkArgs{};
 
   for (auto Input : Inputs)
-    LinkArgs.push_back(Input.getFilename());
+    if (Input.isFilename())
+      LinkArgs.push_back(Input.getFilename());
 
   // Add static device libraries using the common helper function.
   // This handles unbundling archives (.a) containing bitcode bundles.

--- a/clang/test/Driver/hipspv-toolchain.hip
+++ b/clang/test/Driver/hipspv-toolchain.hip
@@ -104,6 +104,13 @@
 // CHIPSTAR-SUBARCH-SAME: "--spirv-ext=-all,+SPV_INTEL_function_pointers,+SPV_INTEL_subgroups"
 // CHIPSTAR-SUBARCH-SAME: [[LOWER_BC]] "-o" "[[SPIRV_OUT:.*img]]"
 
+// Check unknown linker options are ignored - such as ones that are targeted at
+// spirv-link. HIPSPV toolchain does linking via llvm-link.
+// RUN: %clang -### --no-default-config -o %t.dummy.img \
+// RUN:   --target=spirv64-unknown-chipstar %t.dummy.o \
+// RUN:   --hip-path="%S/Inputs/hipspv" -Xlinker foobar \
+// RUN: 2>&1 | FileCheck %s --check-prefix=CHIPSTAR -DHIP_PATH=%S/Inputs/hipspv
+
 //-----------------------------------------------------------------------------
 // Check llvm-spirv-<LLVM_VERSION_MAJOR> is used if it is found in PATH.
 // RUN: mkdir -p %t/versioned


### PR DESCRIPTION
AFAICT, this assertion failure was introduced by #181870 and #182930. These PRs introduced linker options that got passed down to HIPSPV::Linker which wasn't prepared for any non-file inputs.

Fixed by ignoring non-file arguments.