### PR TITLE
[UniformityAnalysis] Add CallbackVH tracking to keep UniformValues consistent on IR deletion

### DIFF
--- a/llvm/include/llvm/ADT/GenericUniformityImpl.h
+++ b/llvm/include/llvm/ADT/GenericUniformityImpl.h
@@ -57,6 +57,12 @@
 
 namespace llvm {
 
+/// Interface for keeping UniformValues in sync when IR values are deleted.
+/// IR specialization installs a concrete CallbackVH-based implementation.
+struct UniformValueCallbackManager {
+  virtual ~UniformValueCallbackManager() = default;
+};
+
 // Forward decl from llvm/CodeGen/MachineInstr.h
 class MachineInstr;
 
@@ -376,6 +382,10 @@ public:
   /// Divergence is seeded by calls to \p markDivergent.
   void compute();
 
+  /// \brief Register callbacks (e.g., CallbackVH for IR) to keep
+  /// UniformValues in sync when values are deleted after analysis.
+  void registerCallbacks();
+
   /// \brief Whether \p Val will always return a uniform value regardless of its
   /// operands
   bool isAlwaysUniform(const InstructionT &Instr) const;
@@ -446,6 +456,10 @@ protected:
   // then values are removed as divergence is propagated. After analysis,
   // values not in this set are conservatively treated as divergent.
   DenseSet<ConstValueRefT> UniformValues;
+
+  // For IR: callbacks to remove from UniformValues on value deletion,
+  // avoiding stale pointers when addresses are reused.
+  std::unique_ptr<UniformValueCallbackManager> UniformValueCallbacks;
 
   // Internal worklist for divergence propagation.
   std::vector<const InstructionT *> Worklist;

--- a/llvm/include/llvm/ADT/GenericUniformityInfo.h
+++ b/llvm/include/llvm/ADT/GenericUniformityInfo.h
@@ -52,6 +52,7 @@ public:
   void compute() {
     DA->initialize();
     DA->compute();
+    DA->registerCallbacks();
   }
 
   /// The GPU kernel this analysis result is for

--- a/llvm/lib/Analysis/UniformityAnalysis.cpp
+++ b/llvm/lib/Analysis/UniformityAnalysis.cpp
@@ -14,9 +14,45 @@
 #include "llvm/IR/Dominators.h"
 #include "llvm/IR/InstIterator.h"
 #include "llvm/IR/Instructions.h"
+#include "llvm/IR/ValueHandle.h"
 #include "llvm/InitializePasses.h"
 
 using namespace llvm;
+
+namespace {
+
+/// CallbackVH that removes the value from UniformValues on deletion.
+/// Prevents stale pointers when a deleted value's address is reused.
+class UniformValueHandle : public CallbackVH {
+  DenseSet<const Value *> &UniformSet;
+
+public:
+  UniformValueHandle(Value *V, DenseSet<const Value *> &S)
+      : CallbackVH(V), UniformSet(S) {}
+  virtual ~UniformValueHandle() = default;
+
+  void deleted() override {
+    UniformSet.erase(getValPtr());
+    CallbackVH::deleted();
+  }
+};
+
+/// IR implementation: registers CallbackVH for each uniform value.
+class IRUniformValueCallbackManager : public UniformValueCallbackManager {
+  DenseSet<const Value *> &UniformSet;
+  std::vector<std::unique_ptr<UniformValueHandle>> Handles;
+
+public:
+  explicit IRUniformValueCallbackManager(DenseSet<const Value *> &S)
+      : UniformSet(S) {}
+
+  void registerValue(const Value *V) {
+    Handles.push_back(std::make_unique<UniformValueHandle>(
+        const_cast<Value *>(V), UniformSet));
+  }
+};
+
+} // namespace
 
 template <>
 bool llvm::GenericUniformityAnalysisImpl<SSAContext>::hasDivergentDefs(
@@ -105,6 +141,15 @@ template <> void llvm::GenericUniformityAnalysisImpl<SSAContext>::initialize() {
   // inside pushUsers) can successfully erase user instructions from the set.
   for (const Value *Arg : DivergentArgs)
     pushUsers(Arg);
+}
+
+template <>
+void llvm::GenericUniformityAnalysisImpl<SSAContext>::registerCallbacks() {
+  IRUniformValueCallbackManager *Manager =
+      new IRUniformValueCallbackManager(UniformValues);
+  for (const Value *V : UniformValues)
+    Manager->registerValue(V);
+  UniformValueCallbacks.reset(Manager);
 }
 
 template <>

--- a/llvm/lib/Analysis/UniformityAnalysis.cpp
+++ b/llvm/lib/Analysis/UniformityAnalysis.cpp
@@ -145,11 +145,11 @@ template <> void llvm::GenericUniformityAnalysisImpl<SSAContext>::initialize() {
 
 template <>
 void llvm::GenericUniformityAnalysisImpl<SSAContext>::registerCallbacks() {
-  IRUniformValueCallbackManager *Manager =
-      new IRUniformValueCallbackManager(UniformValues);
+  std::unique_ptr<IRUniformValueCallbackManager> Manager =
+      std::make_unique<IRUniformValueCallbackManager>(UniformValues);
   for (const Value *V : UniformValues)
     Manager->registerValue(V);
-  UniformValueCallbacks.reset(Manager);
+  UniformValueCallbacks = std::move(Manager);
 }
 
 template <>

--- a/llvm/lib/CodeGen/MachineUniformityAnalysis.cpp
+++ b/llvm/lib/CodeGen/MachineUniformityAnalysis.cpp
@@ -85,6 +85,10 @@ void llvm::GenericUniformityAnalysisImpl<MachineSSAContext>::initialize() {
 }
 
 template <>
+void llvm::GenericUniformityAnalysisImpl<
+    MachineSSAContext>::registerCallbacks() {}
+
+template <>
 void llvm::GenericUniformityAnalysisImpl<MachineSSAContext>::pushUsers(
     Register Reg) {
   assert(isDivergent(Reg));

--- a/llvm/unittests/Target/AMDGPU/UniformityAnalysisTest.cpp
+++ b/llvm/unittests/Target/AMDGPU/UniformityAnalysisTest.cpp
@@ -93,3 +93,46 @@ TEST(UniformityAnalysis, NewValueIsConservativelyDivergent) {
   EXPECT_TRUE(UI.isDivergent(NewInst))
       << "New instruction created after analysis must be reported divergent";
 }
+
+TEST(UniformityAnalysis, DeletionCallbackMakesNewInstDivergent) {
+  // Delete a uniform instruction. CallbackVH::deleted() removes it from
+  // UniformValues during eraseFromParent(). A newly created instruction is
+  // not in UniformValues and must be conservatively reported as divergent.
+  LLVMInitializeAMDGPUTargetInfo();
+  LLVMInitializeAMDGPUTarget();
+  LLVMInitializeAMDGPUTargetMC();
+
+  StringRef ModuleString = R"(
+  target triple = "amdgcn-unknown-amdhsa"
+  define amdgpu_kernel void @test(i32 inreg %a, i32 inreg %b) {
+    %add = add i32 %a, %b
+    ret void
+  }
+  )";
+  LLVMContext Context;
+  SMDiagnostic Err;
+  std::unique_ptr<Module> M = parseAssemblyString(ModuleString, Err, Context);
+  ASSERT_TRUE(M) << Err.getMessage();
+
+  Function *F = M->getFunction("test");
+  ASSERT_TRUE(F);
+
+  std::unique_ptr<TargetMachine> TM =
+      createAMDGPUTargetMachine("amdgcn-amd-", "gfx1010", "+wavefrontsize32");
+  ASSERT_TRUE(TM);
+  TargetTransformInfo TTI = TM->getTargetTransformInfo(*F);
+
+  UniformityInfo UI = computeUniformity(&TTI, F);
+
+  Instruction *AddInst = &*F->getEntryBlock().begin();
+  ASSERT_TRUE(isa<BinaryOperator>(AddInst));
+  EXPECT_FALSE(UI.isDivergent(AddInst)) << "%add should be uniform";
+
+  AddInst->eraseFromParent();
+
+  IRBuilder<> Builder(&F->getEntryBlock(), F->getEntryBlock().begin());
+  Value *NewInst = Builder.CreateAdd(F->getArg(0), F->getArg(1), "new_add");
+
+  EXPECT_TRUE(UI.isDivergent(NewInst))
+      << "New instruction after deletion must be reported divergent";
+}


### PR DESCRIPTION
Follow-up to #180509. When a value in the UniformValues set is deleted, its address can be reused by a new instruction, which would then be incorrectly reported as uniform.

This patch installs a CallbackVH for each uniform value after analysis. When a value is deleted via eraseFromParent(), the callback automatically removes it from the UniformValues set implicitly. The MIR specialization is a no-op since register values are not subject to address reuse.