### PR TITLE
[ExpandMemCmp] Remove unused TM/TLI dependency

### DIFF
--- a/llvm/include/llvm/CodeGen/ExpandMemCmp.h
+++ b/llvm/include/llvm/CodeGen/ExpandMemCmp.h
@@ -16,11 +16,7 @@ namespace llvm {
 class TargetMachine;
 
 class ExpandMemCmpPass : public PassInfoMixin<ExpandMemCmpPass> {
-  const TargetMachine *TM;
-
 public:
-  explicit ExpandMemCmpPass(const TargetMachine &TM_) : TM(&TM_) {}
-
   PreservedAnalyses run(Function &F, FunctionAnalysisManager &FAM);
 };
 

--- a/llvm/include/llvm/Passes/CodeGenPassBuilder.h
+++ b/llvm/include/llvm/Passes/CodeGenPassBuilder.h
@@ -737,7 +737,7 @@ void CodeGenPassBuilder<Derived, TargetMachineT>::addIRPasses(
     // target lowering hook.
     if (!Opt.DisableMergeICmps)
       addFunctionPass(MergeICmpsPass(), PMW);
-    addFunctionPass(ExpandMemCmpPass(TM), PMW);
+    addFunctionPass(ExpandMemCmpPass(), PMW);
   }
 
   // Run GC lowering passes for builtin collectors

--- a/llvm/lib/CodeGen/ExpandMemCmp.cpp
+++ b/llvm/lib/CodeGen/ExpandMemCmp.cpp
@@ -27,7 +27,6 @@
 #include "llvm/IR/PatternMatch.h"
 #include "llvm/IR/ProfDataUtils.h"
 #include "llvm/InitializePasses.h"
-#include "llvm/Target/TargetMachine.h"
 #include "llvm/Transforms/Utils/BasicBlockUtils.h"
 #include "llvm/Transforms/Utils/Local.h"
 #include "llvm/Transforms/Utils/SizeOpts.h"
@@ -35,10 +34,6 @@
 
 using namespace llvm;
 using namespace llvm::PatternMatch;
-
-namespace llvm {
-class TargetLowering;
-}
 
 #define DEBUG_TYPE "expand-memcmp"
 
@@ -828,9 +823,9 @@ Value *MemCmpExpansion::getMemCmpExpansion() {
 ///  %phi.res = phi i32 [ %48, %loadbb3 ], [ %11, %res_block ]
 ///  ret i32 %phi.res
 static bool expandMemCmp(CallInst *CI, const TargetTransformInfo *TTI,
-                         const TargetLowering *TLI, const DataLayout *DL,
-                         ProfileSummaryInfo *PSI, BlockFrequencyInfo *BFI,
-                         DomTreeUpdater *DTU, const bool IsBCmp) {
+                         const DataLayout *DL, ProfileSummaryInfo *PSI,
+                         BlockFrequencyInfo *BFI, DomTreeUpdater *DTU,
+                         const bool IsBCmp) {
   NumMemCmpCalls++;
 
   // Early exit from expansion if -Oz.
@@ -888,13 +883,12 @@ static bool expandMemCmp(CallInst *CI, const TargetTransformInfo *TTI,
 
 // Returns true if a change was made.
 static bool runOnBlock(BasicBlock &BB, const TargetLibraryInfo *TLI,
-                       const TargetTransformInfo *TTI, const TargetLowering *TL,
-                       const DataLayout &DL, ProfileSummaryInfo *PSI,
-                       BlockFrequencyInfo *BFI, DomTreeUpdater *DTU);
+                       const TargetTransformInfo *TTI, const DataLayout &DL,
+                       ProfileSummaryInfo *PSI, BlockFrequencyInfo *BFI,
+                       DomTreeUpdater *DTU);
 
 static PreservedAnalyses runImpl(Function &F, const TargetLibraryInfo *TLI,
                                  const TargetTransformInfo *TTI,
-                                 const TargetLowering *TL,
                                  ProfileSummaryInfo *PSI,
                                  BlockFrequencyInfo *BFI, DominatorTree *DT);
 
@@ -911,8 +905,6 @@ public:
     if (!TPC) {
       return false;
     }
-    const TargetLowering* TL =
-        TPC->getTM<TargetMachine>().getSubtargetImpl(F)->getTargetLowering();
 
     const TargetLibraryInfo *TLI =
         &getAnalysis<TargetLibraryInfoWrapperPass>().getTLI(F);
@@ -925,7 +917,7 @@ public:
     DominatorTree *DT = nullptr;
     if (auto *DTWP = getAnalysisIfAvailable<DominatorTreeWrapperPass>())
       DT = &DTWP->getDomTree();
-    auto PA = runImpl(F, TLI, TTI, TL, PSI, BFI, DT);
+    auto PA = runImpl(F, TLI, TTI, PSI, BFI, DT);
     return !PA.areAllPreserved();
   }
 
@@ -941,9 +933,9 @@ private:
 };
 
 bool runOnBlock(BasicBlock &BB, const TargetLibraryInfo *TLI,
-                const TargetTransformInfo *TTI, const TargetLowering *TL,
-                const DataLayout &DL, ProfileSummaryInfo *PSI,
-                BlockFrequencyInfo *BFI, DomTreeUpdater *DTU) {
+                const TargetTransformInfo *TTI, const DataLayout &DL,
+                ProfileSummaryInfo *PSI, BlockFrequencyInfo *BFI,
+                DomTreeUpdater *DTU) {
   for (Instruction &I : BB) {
     CallInst *CI = dyn_cast<CallInst>(&I);
     if (!CI) {
@@ -952,7 +944,7 @@ bool runOnBlock(BasicBlock &BB, const TargetLibraryInfo *TLI,
     LibFunc Func;
     if (TLI->getLibFunc(*CI, Func) &&
         (Func == LibFunc_memcmp || Func == LibFunc_bcmp) &&
-        expandMemCmp(CI, TTI, TL, &DL, PSI, BFI, DTU, Func == LibFunc_bcmp)) {
+        expandMemCmp(CI, TTI, &DL, PSI, BFI, DTU, Func == LibFunc_bcmp)) {
       return true;
     }
   }
@@ -961,8 +953,8 @@ bool runOnBlock(BasicBlock &BB, const TargetLibraryInfo *TLI,
 
 PreservedAnalyses runImpl(Function &F, const TargetLibraryInfo *TLI,
                           const TargetTransformInfo *TTI,
-                          const TargetLowering *TL, ProfileSummaryInfo *PSI,
-                          BlockFrequencyInfo *BFI, DominatorTree *DT) {
+                          ProfileSummaryInfo *PSI, BlockFrequencyInfo *BFI,
+                          DominatorTree *DT) {
   std::optional<DomTreeUpdater> DTU;
   if (DT)
     DTU.emplace(DT, DomTreeUpdater::UpdateStrategy::Lazy);
@@ -970,7 +962,7 @@ PreservedAnalyses runImpl(Function &F, const TargetLibraryInfo *TLI,
   const DataLayout& DL = F.getDataLayout();
   bool MadeChanges = false;
   for (auto BBIt = F.begin(); BBIt != F.end();) {
-    if (runOnBlock(*BBIt, TLI, TTI, TL, DL, PSI, BFI, DTU ? &*DTU : nullptr)) {
+    if (runOnBlock(*BBIt, TLI, TTI, DL, PSI, BFI, DTU ? &*DTU : nullptr)) {
       MadeChanges = true;
       // If changes were made, restart the function from the beginning, since
       // the structure of the function was changed.
@@ -993,7 +985,6 @@ PreservedAnalyses runImpl(Function &F, const TargetLibraryInfo *TLI,
 
 PreservedAnalyses ExpandMemCmpPass::run(Function &F,
                                         FunctionAnalysisManager &FAM) {
-  const auto *TL = TM->getSubtargetImpl(F)->getTargetLowering();
   const auto &TLI = FAM.getResult<TargetLibraryAnalysis>(F);
   const auto &TTI = FAM.getResult<TargetIRAnalysis>(F);
   auto *PSI = FAM.getResult<ModuleAnalysisManagerFunctionProxy>(F)
@@ -1003,7 +994,7 @@ PreservedAnalyses ExpandMemCmpPass::run(Function &F,
                                 : nullptr;
   auto *DT = FAM.getCachedResult<DominatorTreeAnalysis>(F);
 
-  return runImpl(F, &TLI, &TTI, TL, PSI, BFI, DT);
+  return runImpl(F, &TLI, &TTI, PSI, BFI, DT);
 }
 
 char ExpandMemCmpLegacyPass::ID = 0;

--- a/llvm/lib/Passes/PassRegistry.def
+++ b/llvm/lib/Passes/PassRegistry.def
@@ -432,7 +432,7 @@ FUNCTION_PASS("dot-post-dom", PostDomPrinter())
 FUNCTION_PASS("dot-post-dom-only", PostDomOnlyPrinter())
 FUNCTION_PASS("dse", DSEPass())
 FUNCTION_PASS("dwarf-eh-prepare", DwarfEHPreparePass(*TM))
-FUNCTION_PASS("expand-memcmp", ExpandMemCmpPass(*TM))
+FUNCTION_PASS("expand-memcmp", ExpandMemCmpPass())
 FUNCTION_PASS("expand-reductions", ExpandReductionsPass())
 FUNCTION_PASS("extra-vector-passes",
               ExtraFunctionPassManager<ShouldRunExtraVectorPasses>())

--- a/llvm/test/tools/opt/no-target-machine.ll
+++ b/llvm/test/tools/opt/no-target-machine.ll
@@ -4,7 +4,6 @@
 ; RUN: not opt -passes=complex-deinterleaving -disable-output %s 2>&1 | FileCheck %s
 ; RUN: not opt -passes=dwarf-eh-prepare -disable-output %s 2>&1 | FileCheck %s
 ; RUN: not opt -passes=expand-ir-insts -disable-output %s 2>&1 | FileCheck %s
-; RUN: not opt -passes=expand-memcmp -disable-output %s 2>&1 | FileCheck %s
 ; RUN: not opt -passes=indirectbr-expand -disable-output %s 2>&1 | FileCheck %s
 ; RUN: not opt -passes=interleaved-access -disable-output %s 2>&1 | FileCheck %s
 ; RUN: not opt -passes=interleaved-load-combine -disable-output %s 2>&1 | FileCheck %s


### PR DESCRIPTION
This pass does not actually use TargetMachine/TargetLoweringInfo.