### PR TITLE
[llc] Flatten SkipModule branch and sink defs to their use(NFC)

### DIFF
--- a/llvm/tools/llc/llc.cpp
+++ b/llvm/tools/llc/llc.cpp
@@ -675,7 +675,6 @@ static int compileModule(char **argv, SmallVectorImpl<PassPlugin> &PluginList,
   if (std::optional<uint64_t> LDT = codegen::getExplicitLargeDataThreshold())
     Target->setLargeDataThreshold(*LDT);
 
-  assert(M && "Should have exited if we didn't have a module!");
   if (codegen::getFloatABIForCalls() != FloatABI::Default)
     Target->Options.FloatABIType = codegen::getFloatABIForCalls();
 

--- a/llvm/tools/llc/llc.cpp
+++ b/llvm/tools/llc/llc.cpp
@@ -512,10 +512,6 @@ static int compileModule(char **argv, SmallVectorImpl<PassPlugin> &PluginList,
     codegen::setFunctionAttributes(F, CPUStr, FeaturesStr, TuneCPUStr);
   };
 
-  auto MAttrs = codegen::getMAttrs();
-  bool SkipModule =
-      CPUStr == "help" || TuneCPUStr == "help" || is_contained(MAttrs, "help");
-
   CodeGenOptLevel OLvl;
   if (auto Level = CodeGenOpt::parseLevel(OptLevel)) {
     OLvl = *Level;
@@ -596,58 +592,10 @@ static int compileModule(char **argv, SmallVectorImpl<PassPlugin> &PluginList,
   std::unique_ptr<TargetMachine> Target;
 
   // If user just wants to list available options, skip module loading
-  if (!SkipModule) {
-    auto SetDataLayout = [&](StringRef DataLayoutTargetTriple,
-                             StringRef OldDLStr) -> std::optional<std::string> {
-      // If we are supposed to override the target triple, do so now.
-      std::string IRTargetTriple = DataLayoutTargetTriple.str();
-      if (!TargetTriple.empty())
-        IRTargetTriple = Triple::normalize(TargetTriple);
-      TheTriple = Triple(IRTargetTriple);
-      if (TheTriple.getTriple().empty())
-        TheTriple.setTriple(sys::getDefaultTargetTriple());
-
-      std::string Error;
-      TheTarget =
-          TargetRegistry::lookupTarget(codegen::getMArch(), TheTriple, Error);
-      if (!TheTarget) {
-        WithColor::error(errs(), argv[0]) << Error << "\n";
-        exit(1);
-      }
-
-      InitializeOptions(TheTriple);
-      Target = std::unique_ptr<TargetMachine>(TheTarget->createTargetMachine(
-          TheTriple, CPUStr, FeaturesStr, Options, RM, CM, OLvl));
-      assert(Target && "Could not allocate target machine!");
-
-      // Set PGO options based on command line flags
-      setPGOOptions(*Target);
-
-      return Target->createDataLayout().getStringRepresentation();
-    };
-    if (InputLanguage == "mir" ||
-        (InputLanguage == "" && StringRef(InputFilename).ends_with(".mir"))) {
-      MIR = createMIRParserFromFile(InputFilename, Err, Context,
-                                    setMIRFunctionAttributes);
-      if (MIR)
-        M = MIR->parseIRModule(SetDataLayout);
-    } else {
-      M = parseIRFile(InputFilename, Err, Context,
-                      ParserCallbacks(SetDataLayout));
-    }
-    if (!M) {
-      Err.print(argv[0], WithColor::error(errs(), argv[0]));
-      return 1;
-    }
-    if (!TargetTriple.empty())
-      M->setTargetTriple(Triple(Triple::normalize(TargetTriple)));
-
-    std::optional<CodeModel::Model> CM_IR = M->getCodeModel();
-    if (!CM && CM_IR)
-      Target->setCodeModel(*CM_IR);
-    if (std::optional<uint64_t> LDT = codegen::getExplicitLargeDataThreshold())
-      Target->setLargeDataThreshold(*LDT);
-  } else {
+  auto MAttrs = codegen::getMAttrs();
+  bool SkipModule =
+      CPUStr == "help" || TuneCPUStr == "help" || is_contained(MAttrs, "help");
+  if (SkipModule) {
     TheTriple = Triple(Triple::normalize(TargetTriple));
     if (TheTriple.getTriple().empty())
       TheTriple.setTriple(sys::getDefaultTargetTriple());
@@ -664,18 +612,68 @@ static int compileModule(char **argv, SmallVectorImpl<PassPlugin> &PluginList,
     InitializeOptions(TheTriple);
     // Pass "help" as CPU for -mtune=help
     std::string SkipModuleCPU = (TuneCPUStr == "help" ? "help" : CPUStr);
+    // Create the target machine just to print the help info. Use unique_ptr
+    // to avoid a memory leak.
     Target = std::unique_ptr<TargetMachine>(TheTarget->createTargetMachine(
         TheTriple, SkipModuleCPU, FeaturesStr, Options, RM, CM, OLvl));
     assert(Target && "Could not allocate target machine!");
-
-    // Set PGO options based on command line flags
-    setPGOOptions(*Target);
 
     // If we don't have a module then just exit now. We do this down
     // here since the CPU/Feature help is underneath the target machine
     // creation.
     return 0;
   }
+
+  auto SetDataLayout = [&](StringRef DataLayoutTargetTriple,
+                           StringRef OldDLStr) -> std::optional<std::string> {
+    // If we are supposed to override the target triple, do so now.
+    std::string IRTargetTriple = DataLayoutTargetTriple.str();
+    if (!TargetTriple.empty())
+      IRTargetTriple = Triple::normalize(TargetTriple);
+    TheTriple = Triple(IRTargetTriple);
+    if (TheTriple.getTriple().empty())
+      TheTriple.setTriple(sys::getDefaultTargetTriple());
+
+    std::string Error;
+    TheTarget =
+        TargetRegistry::lookupTarget(codegen::getMArch(), TheTriple, Error);
+    if (!TheTarget) {
+      WithColor::error(errs(), argv[0]) << Error << "\n";
+      exit(1);
+    }
+
+    InitializeOptions(TheTriple);
+    Target = std::unique_ptr<TargetMachine>(TheTarget->createTargetMachine(
+        TheTriple, CPUStr, FeaturesStr, Options, RM, CM, OLvl));
+    assert(Target && "Could not allocate target machine!");
+
+    // Set PGO options based on command line flags
+    setPGOOptions(*Target);
+
+    return Target->createDataLayout().getStringRepresentation();
+  };
+  if (InputLanguage == "mir" ||
+      (InputLanguage == "" && StringRef(InputFilename).ends_with(".mir"))) {
+    MIR = createMIRParserFromFile(InputFilename, Err, Context,
+                                  setMIRFunctionAttributes);
+    if (MIR)
+      M = MIR->parseIRModule(SetDataLayout);
+  } else {
+    M = parseIRFile(InputFilename, Err, Context,
+                    ParserCallbacks(SetDataLayout));
+  }
+  if (!M) {
+    Err.print(argv[0], WithColor::error(errs(), argv[0]));
+    return 1;
+  }
+  if (!TargetTriple.empty())
+    M->setTargetTriple(Triple(Triple::normalize(TargetTriple)));
+
+  std::optional<CodeModel::Model> CM_IR = M->getCodeModel();
+  if (!CM && CM_IR)
+    Target->setCodeModel(*CM_IR);
+  if (std::optional<uint64_t> LDT = codegen::getExplicitLargeDataThreshold())
+    Target->setLargeDataThreshold(*LDT);
 
   assert(M && "Should have exited if we didn't have a module!");
   if (codegen::getFloatABIForCalls() != FloatABI::Default)


### PR DESCRIPTION
- Invert the condition to make the code more straight and sink single-use variables there.
- Add a comment about on `createTargetMachine` side effects for `-mcpu=help`.
- Remove redundant call to `setPGOOptions`