### PR TITLE
[SPIR-V] Update tests for opaque pointer migration

### DIFF
--- a/llvm/test/CodeGen/SPIRV/linked-list.ll
+++ b/llvm/test/CodeGen/SPIRV/linked-list.ll
@@ -1,11 +1,18 @@
 ; RUN: llc -O0 -mtriple=spirv32-unknown-unknown %s -o - | FileCheck %s
 
-; TODO(#60133): Requires updates following opaque pointer migration.
-; XFAIL: *
-
 %struct.Node = type { ptr addrspace(1) }
-; CHECK: %[[#]] = OpTypeOpaque "struct.Node.0"
 %struct.Node.0 = type opaque
+
+; With opaque pointers, parameters are lowered to generic pointer-to-i8.
+; CHECK-DAG: %[[#I8:]] = OpTypeInt 8
+; CHECK-DAG: %[[#PTR:]] = OpTypePointer CrossWorkgroup %[[#I8]]
+; CHECK-DAG: %[[#I32:]] = OpTypeInt 32
+; CHECK-DAG: %[[#VOID:]] = OpTypeVoid
+; CHECK-DAG: %[[#FNTY:]] = OpTypeFunction %[[#VOID]] %[[#PTR]] %[[#PTR]] %[[#I32]]
+; CHECK:     %[[#]] = OpFunction %[[#VOID]] None %[[#FNTY]]
+; CHECK:     OpFunctionParameter %[[#PTR]]
+; CHECK:     OpFunctionParameter %[[#PTR]]
+; CHECK:     OpFunctionParameter %[[#I32]]
 
 define spir_kernel void @create_linked_lists(ptr addrspace(1) nocapture %pNodes, ptr addrspace(1) nocapture %allocation_index, i32 %list_length) {
 entry:

--- a/llvm/test/CodeGen/SPIRV/pstruct.ll
+++ b/llvm/test/CodeGen/SPIRV/pstruct.ll
@@ -1,124 +1,118 @@
 ; RUN: llc -O0 -mtriple=spirv64-unknown-unknown %s -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 
-; TODO(#60133): Requires updates following opaque pointer migration.
-; XFAIL: *
-
 %struct.ST = type { i32, i32, i32 }
 
-; CHECK-SPIRV: OpName %[[#struct:]] "struct.ST"
-; CHECK-SPIRV: %[[#int:]] = OpTypeInt 32 0
-; CHECK-SPIRV: %[[#intP:]] = OpTypePointer Function %[[#int]]
-; CHECK-SPIRV: %[[#struct]] = OpTypeStruct %[[#int]] %[[#int]] %[[#int]]
-; CHECK-SPIRV: %[[#structP:]] = OpTypePointer Function %[[#struct]]
-; CHECK-SPIRV: %[[#structPP:]] = OpTypePointer Function %[[#structP]]
-; CHECK-SPIRV: %[[#zero:]] = OpConstantNull %[[#int]]
-; CHECK-SPIRV: %[[#one:]] = OpConstant %[[#int]] 1{{$}}
-; CHECK-SPIRV: %[[#two:]] = OpConstant %[[#int]] 2{{$}}
+; CHECK-SPIRV-DAG: OpName %[[#struct:]] "struct.ST"
+; CHECK-SPIRV-DAG: %[[#int:]] = OpTypeInt 32 0
+; CHECK-SPIRV-DAG: %[[#intP:]] = OpTypePointer Function %[[#int]]
+; CHECK-SPIRV-DAG: %[[#struct]] = OpTypeStruct %[[#int]] %[[#int]] %[[#int]]
+; CHECK-SPIRV-DAG: %[[#structP:]] = OpTypePointer Function %[[#struct]]
+; CHECK-SPIRV-DAG: %[[#structPP:]] = OpTypePointer Function %[[#structP]]
+; CHECK-SPIRV-DAG: %[[#zero:]] = OpConstantNull %[[#int]]
+; CHECK-SPIRV-DAG: %[[#one:]] = OpConstant %[[#int]] 1{{$}}
+; CHECK-SPIRV-DAG: %[[#two:]] = OpConstant %[[#int]] 2{{$}}
 
-define dso_local spir_func i32 @cmp_func(i8* %p1, i8* %p2) {
+define dso_local spir_func i32 @cmp_func(ptr %p1, ptr %p2) {
 entry:
+; CHECK-SPIRV: %[[#retval:]] = OpVariable %[[#intP]] Function
+; CHECK-SPIRV: %[[#p1_addr:]] = OpVariable %[[#ptrPtrTy:]] Function
+; CHECK-SPIRV: %[[#p2_addr:]] = OpVariable %[[#ptrPtrTy]] Function
+; CHECK-SPIRV: %[[#s1:]] = OpVariable %[[#ptrPtrTy]] Function
+; CHECK-SPIRV: %[[#s2:]] = OpVariable %[[#ptrPtrTy]] Function
   %retval = alloca i32, align 4
-  %p1.addr = alloca i8*, align 8
-  %p2.addr = alloca i8*, align 8
-; CHECK-SPIRV: %[[#s1:]] = OpVariable %[[#structPP]]
-; CHECK-SPIRV: %[[#s2:]] = OpVariable %[[#structPP]]
-  %s1 = alloca %struct.ST*, align 8
-  %s2 = alloca %struct.ST*, align 8
-  store i8* %p1, i8** %p1.addr, align 8
-  store i8* %p2, i8** %p2.addr, align 8
-  %0 = load i8*, i8** %p1.addr, align 8
-; CHECK-SPIRV: %[[#t1:]] = OpBitcast %[[#structP]]
-; CHECK-SPIRV: OpStore %[[#s1]] %[[#t1]]
-  %1 = bitcast i8* %0 to %struct.ST*
-  store %struct.ST* %1, %struct.ST** %s1, align 8
-  %2 = load i8*, i8** %p2.addr, align 8
-; CHECK-SPIRV: %[[#t2:]] = OpBitcast %[[#structP]]
-; CHECK-SPIRV: OpStore %[[#s2]] %[[#t2]]
-  %3 = bitcast i8* %2 to %struct.ST*
-  store %struct.ST* %3, %struct.ST** %s2, align 8
-; CHECK-SPIRV: %[[#t3:]] = OpLoad %[[#structP]] %[[#s1]]
+  %p1.addr = alloca ptr, align 8
+  %p2.addr = alloca ptr, align 8
+  %s1 = alloca ptr, align 8
+  %s2 = alloca ptr, align 8
+; CHECK-SPIRV: OpStore %[[#p1_addr]] %[[#p1:]] Aligned 8
+  store ptr %p1, ptr %p1.addr, align 8
+; CHECK-SPIRV: OpStore %[[#p2_addr]] %[[#p2:]] Aligned 8
+  store ptr %p2, ptr %p2.addr, align 8
+; CHECK-SPIRV: %[[#val0:]] = OpLoad %[[#ptrTy:]] %[[#p1_addr]] Aligned 8
+  %0 = load ptr, ptr %p1.addr, align 8
+; CHECK-SPIRV: OpStore %[[#s1]] %[[#val0]] Aligned 8
+  store ptr %0, ptr %s1, align 8
+; CHECK-SPIRV: %[[#val1:]] = OpLoad %[[#ptrTy]] %[[#p2_addr]] Aligned 8
+  %2 = load ptr, ptr %p2.addr, align 8
+; CHECK-SPIRV: OpStore %[[#s2]] %[[#val1]] Aligned 8
+  store ptr %2, ptr %s2, align 8
+; CHECK-SPIRV: %[[#]] = OpBitcast %[[#structPP]]
+; CHECK-SPIRV: %[[#t3:]] = OpLoad %[[#structP]]
 ; CHECK-SPIRV: %[[#a1:]] = OpInBoundsPtrAccessChain %[[#intP]] %[[#t3]] %[[#zero]] %[[#zero]]
 ; CHECK-SPIRV: %[[#]] = OpLoad %[[#int]] %[[#a1]]
-  %4 = load %struct.ST*, %struct.ST** %s1, align 8
-  %a = getelementptr inbounds %struct.ST, %struct.ST* %4, i32 0, i32 0
-  %5 = load i32, i32* %a, align 4
-; CHECK-SPIRV: %[[#t4:]] = OpLoad %[[#structP]] %[[#s2]]
+  %4 = load ptr, ptr %s1, align 8
+  %a = getelementptr inbounds %struct.ST, ptr %4, i32 0, i32 0
+  %5 = load i32, ptr %a, align 4
+; CHECK-SPIRV: %[[#]] = OpBitcast %[[#structPP]]
+; CHECK-SPIRV: %[[#t4:]] = OpLoad %[[#structP]]
 ; CHECK-SPIRV: %[[#a2:]] = OpInBoundsPtrAccessChain %[[#intP]] %[[#t4]] %[[#zero]] %[[#zero]]
 ; CHECK-SPIRV: %[[#]] = OpLoad %[[#int]] %[[#a2]]
-  %6 = load %struct.ST*, %struct.ST** %s2, align 8
-  %a1 = getelementptr inbounds %struct.ST, %struct.ST* %6, i32 0, i32 0
-  %7 = load i32, i32* %a1, align 4
+  %6 = load ptr, ptr %s2, align 8
+  %a1 = getelementptr inbounds %struct.ST, ptr %6, i32 0, i32 0
+  %7 = load i32, ptr %a1, align 4
   %cmp = icmp ne i32 %5, %7
   br i1 %cmp, label %if.then, label %if.end
 
 if.then:                                          ; preds = %entry
-; CHECK-SPIRV: %[[#t5:]] = OpLoad %[[#structP]] %[[#s1]]
-; CHECK-SPIRV: %[[#a_1:]] = OpInBoundsPtrAccessChain %[[#intP]] %[[#t5]] %[[#zero]] %[[#zero]]
-; CHECK-SPIRV: %[[#]] = OpLoad %[[#int]] %[[#a_1]]
-  %8 = load %struct.ST*, %struct.ST** %s1, align 8
-  %a2 = getelementptr inbounds %struct.ST, %struct.ST* %8, i32 0, i32 0
-  %9 = load i32, i32* %a2, align 4
-; CHECK-SPIRV: %[[#t6:]] = OpLoad %[[#structP]] %[[#s2]]
-; CHECK-SPIRV: %[[#a_2:]] = OpInBoundsPtrAccessChain %[[#intP]] %[[#t6]] %[[#zero]] %[[#zero]]
-; CHECK-SPIRV: %[[#]] = OpLoad %[[#int]] %[[#a_2]]
-  %10 = load %struct.ST*, %struct.ST** %s2, align 8
-  %a3 = getelementptr inbounds %struct.ST, %struct.ST* %10, i32 0, i32 0
-  %11 = load i32, i32* %a3, align 4
+  %8 = load ptr, ptr %s1, align 8
+  %a2 = getelementptr inbounds %struct.ST, ptr %8, i32 0, i32 0
+  %9 = load i32, ptr %a2, align 4
+  %10 = load ptr, ptr %s2, align 8
+  %a3 = getelementptr inbounds %struct.ST, ptr %10, i32 0, i32 0
+  %11 = load i32, ptr %a3, align 4
   %sub = sub nsw i32 %9, %11
-  store i32 %sub, i32* %retval, align 4
+  store i32 %sub, ptr %retval, align 4
   br label %return
 
 if.end:                                           ; preds = %entry
-; CHECK-SPIRV: %[[#t7:]] = OpLoad %[[#structP]] %[[#s1]]
+; CHECK-SPIRV: %[[#]] = OpBitcast %[[#structPP]]
+; CHECK-SPIRV: %[[#t7:]] = OpLoad %[[#structP]]
 ; CHECK-SPIRV: %[[#b1:]] = OpInBoundsPtrAccessChain %[[#intP]] %[[#t7]] %[[#zero]] %[[#one]]
 ; CHECK-SPIRV: %[[#]] = OpLoad %[[#int]] %[[#b1]]
-  %12 = load %struct.ST*, %struct.ST** %s1, align 8
-  %b = getelementptr inbounds %struct.ST, %struct.ST* %12, i32 0, i32 1
-  %13 = load i32, i32* %b, align 4
-; CHECK-SPIRV: %[[#t8:]] = OpLoad %[[#structP]] %[[#s2]]
+  %12 = load ptr, ptr %s1, align 8
+  %b = getelementptr inbounds %struct.ST, ptr %12, i32 0, i32 1
+  %13 = load i32, ptr %b, align 4
+; CHECK-SPIRV: %[[#]] = OpBitcast %[[#structPP]]
+; CHECK-SPIRV: %[[#t8:]] = OpLoad %[[#structP]]
 ; CHECK-SPIRV: %[[#b2:]] = OpInBoundsPtrAccessChain %[[#intP]] %[[#t8]] %[[#zero]] %[[#one]]
 ; CHECK-SPIRV: %[[#]] = OpLoad %[[#int]] %[[#b2]]
-  %14 = load %struct.ST*, %struct.ST** %s2, align 8
-  %b4 = getelementptr inbounds %struct.ST, %struct.ST* %14, i32 0, i32 1
-  %15 = load i32, i32* %b4, align 4
+  %14 = load ptr, ptr %s2, align 8
+  %b4 = getelementptr inbounds %struct.ST, ptr %14, i32 0, i32 1
+  %15 = load i32, ptr %b4, align 4
   %cmp5 = icmp ne i32 %13, %15
   br i1 %cmp5, label %if.then6, label %if.end10
 
 if.then6:                                         ; preds = %if.end
-; CHECK-SPIRV: %[[#t9:]] = OpLoad %[[#structP]] %[[#s1]]
-; CHECK-SPIRV: %[[#b_1:]] = OpInBoundsPtrAccessChain %[[#intP]] %[[#t9]] %[[#zero]] %[[#one]]
-; CHECK-SPIRV: %[[#]] = OpLoad %[[#int]] %[[#b_1]]
-  %16 = load %struct.ST*, %struct.ST** %s1, align 8
-  %b7 = getelementptr inbounds %struct.ST, %struct.ST* %16, i32 0, i32 1
-  %17 = load i32, i32* %b7, align 4
-; CHECK-SPIRV: %[[#t10:]] = OpLoad %[[#structP]] %[[#s2]]
-; CHECK-SPIRV: %[[#b_2:]] = OpInBoundsPtrAccessChain %[[#intP]] %[[#t10]] %[[#zero]] %[[#one]]
-; CHECK-SPIRV: %[[#]] = OpLoad %[[#int]] %[[#b_2]]
-  %18 = load %struct.ST*, %struct.ST** %s2, align 8
-  %b8 = getelementptr inbounds %struct.ST, %struct.ST* %18, i32 0, i32 1
-  %19 = load i32, i32* %b8, align 4
+  %16 = load ptr, ptr %s1, align 8
+  %b7 = getelementptr inbounds %struct.ST, ptr %16, i32 0, i32 1
+  %17 = load i32, ptr %b7, align 4
+  %18 = load ptr, ptr %s2, align 8
+  %b8 = getelementptr inbounds %struct.ST, ptr %18, i32 0, i32 1
+  %19 = load i32, ptr %b8, align 4
   %sub9 = sub nsw i32 %17, %19
-  store i32 %sub9, i32* %retval, align 4
+  store i32 %sub9, ptr %retval, align 4
   br label %return
 
 if.end10:                                         ; preds = %if.end
-; CHECK-SPIRV: %[[#t11:]] = OpLoad %[[#structP]] %[[#s1]]
+; CHECK-SPIRV: %[[#]] = OpBitcast %[[#structPP]]
+; CHECK-SPIRV: %[[#t11:]] = OpLoad %[[#structP]]
 ; CHECK-SPIRV: %[[#c1:]] = OpInBoundsPtrAccessChain %[[#intP]] %[[#t11]] %[[#zero]] %[[#two]]
 ; CHECK-SPIRV: %[[#]] = OpLoad %[[#int]] %[[#c1]]
-  %20 = load %struct.ST*, %struct.ST** %s1, align 8
-  %c = getelementptr inbounds %struct.ST, %struct.ST* %20, i32 0, i32 2
-  %21 = load i32, i32* %c, align 4
-; CHECK-SPIRV: %[[#t12:]] = OpLoad %[[#structP]] %[[#s2]]
+  %20 = load ptr, ptr %s1, align 8
+  %c = getelementptr inbounds %struct.ST, ptr %20, i32 0, i32 2
+  %21 = load i32, ptr %c, align 4
+; CHECK-SPIRV: %[[#]] = OpBitcast %[[#structPP]]
+; CHECK-SPIRV: %[[#t12:]] = OpLoad %[[#structP]]
 ; CHECK-SPIRV: %[[#c2:]] = OpInBoundsPtrAccessChain %[[#intP]] %[[#t12]] %[[#zero]] %[[#two]]
 ; CHECK-SPIRV: %[[#]] = OpLoad %[[#int]] %[[#c2]]
-  %22 = load %struct.ST*, %struct.ST** %s2, align 8
-  %c11 = getelementptr inbounds %struct.ST, %struct.ST* %22, i32 0, i32 2
-  %23 = load i32, i32* %c11, align 4
+  %22 = load ptr, ptr %s2, align 8
+  %c11 = getelementptr inbounds %struct.ST, ptr %22, i32 0, i32 2
+  %23 = load i32, ptr %c11, align 4
   %sub12 = sub nsw i32 %21, %23
-  store i32 %sub12, i32* %retval, align 4
+  store i32 %sub12, ptr %retval, align 4
   br label %return
 
 return:                                           ; preds = %if.end10, %if.then6, %if.then
-  %24 = load i32, i32* %retval, align 4
+  %24 = load i32, ptr %retval, align 4
   ret i32 %24
 }

--- a/llvm/test/CodeGen/SPIRV/transcoding/extract_insert_value.ll
+++ b/llvm/test/CodeGen/SPIRV/transcoding/extract_insert_value.ll
@@ -1,26 +1,23 @@
 ; RUN: llc -O0 -mtriple=spirv32-unknown-unknown %s -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 ; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv32-unknown-unknown %s -o - -filetype=obj | spirv-val %}
 
-; TODO(#60133): Requires updates following opaque pointer migration.
-; XFAIL: *
-
 ;; Check 'LLVM ==> SPIR-V' conversion of extractvalue/insertvalue.
 
 %struct.arr = type { [7 x float] }
 %struct.st = type { %struct.inner }
 %struct.inner = type { float }
 
-; CHECK-SPIRV:     %[[#float_ty:]] = OpTypeFloat 32
-; CHECK-SPIRV:     %[[#int_ty:]] = OpTypeInt 32
-; CHECK-SPIRV:     %[[#arr_size:]] = OpConstant %[[#int_ty]] 7
-; CHECK-SPIRV:     %[[#array_ty:]] = OpTypeArray %[[#float_ty]] %[[#arr_size]]
-; CHECK-SPIRV:     %[[#struct_ty:]] = OpTypeStruct %[[#array_ty]]
-; CHECK-SPIRV:     %[[#struct_ptr_ty:]] = OpTypePointer CrossWorkgroup %[[#struct_ty]]
-; CHECK-SPIRV:     %[[#array_ptr_ty:]] = OpTypePointer CrossWorkgroup %[[#array_ty]]
-; CHECK-SPIRV:     %[[#struct1_in_ty:]] = OpTypeStruct %[[#float_ty]]
-; CHECK-SPIRV:     %[[#struct1_ty:]] = OpTypeStruct %[[#struct1_in_ty]]
-; CHECK-SPIRV:     %[[#struct1_ptr_ty:]] = OpTypePointer CrossWorkgroup %[[#struct1_ty]]
-; CHECK-SPIRV:     %[[#struct1_in_ptr_ty:]] = OpTypePointer CrossWorkgroup %[[#struct1_in_ty]]
+; CHECK-SPIRV-DAG: %[[#int_ty:]] = OpTypeInt 32
+; CHECK-SPIRV-DAG: %[[#float_ty:]] = OpTypeFloat 32
+; CHECK-SPIRV-DAG: %[[#arr_size:]] = OpConstant %[[#int_ty]] 7
+; CHECK-SPIRV-DAG: %[[#array_ty:]] = OpTypeArray %[[#float_ty]] %[[#arr_size]]
+; CHECK-SPIRV-DAG: %[[#struct_ty:]] = OpTypeStruct %[[#array_ty]]
+; CHECK-SPIRV-DAG: %[[#struct_ptr_ty:]] = OpTypePointer CrossWorkgroup %[[#struct_ty]]
+; CHECK-SPIRV-DAG: %[[#array_ptr_ty:]] = OpTypePointer CrossWorkgroup %[[#array_ty]]
+; CHECK-SPIRV-DAG: %[[#struct1_in_ty:]] = OpTypeStruct %[[#float_ty]]
+; CHECK-SPIRV-DAG: %[[#struct1_ty:]] = OpTypeStruct %[[#struct1_in_ty]]
+; CHECK-SPIRV-DAG: %[[#struct1_ptr_ty:]] = OpTypePointer CrossWorkgroup %[[#struct1_ty]]
+; CHECK-SPIRV-DAG: %[[#struct1_in_ptr_ty:]] = OpTypePointer CrossWorkgroup %[[#struct1_in_ty]]
 ; CHECK-SPIRV-NOT: OpConstant %{{.*}} 2
 ; CHECK-SPIRV-NOT: OpConstant %{{.*}} 4
 ; CHECK-SPIRV-NOT: OpConstant %{{.*}} 5
@@ -55,7 +52,9 @@ entry:
 ; CHECK-SPIRV:        %[[#elem:]] = OpCompositeExtract %[[#float_ty]] %[[#extracted_struct]] 0
 ; CHECK-SPIRV:        %[[#add:]] = OpFAdd %[[#float_ty]] %[[#elem]] %[[#]]
 ; CHECK-SPIRV:        %[[#inserted_struct:]] = OpCompositeInsert %[[#struct1_in_ty]] %[[#add]] %[[#extracted_struct]] 0
-; CHECK-SPIRV:        OpStore %[[#store1_ptr]] %[[#inserted_struct]]
+; CHECK-SPIRV:        %[[#bitcast1:]] = OpBitcast %[[#]] %[[#store1_ptr]]
+; CHECK-SPIRV:        %[[#store1_dst:]] = OpBitcast %[[#struct1_in_ptr_ty]] %[[#bitcast1]]
+; CHECK-SPIRV:        OpStore %[[#store1_dst]] %[[#inserted_struct]] Aligned 4
 ; CHECK-SPIRV-LABEL:  OpFunctionEnd
 
 define spir_func void @struct_test(ptr addrspace(1) %object) {


### PR DESCRIPTION
Enable tests `linked-list.ll`, `pstruct.ll`, and `extract_insert_value.ll` where additional code changes are not required

related to #60133 