### PR TITLE
Fix a crash when a lambda capturing a local array is used in an invalid templated constructor

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -366,6 +366,7 @@ Bug Fixes to C++ Support
 - Fixed a crash when `explicit(bool)` is used with an incomplete enumeration. (#GH183887)
 - Fixed a crash on ``typeid`` of incomplete local types during template instantiation. (#GH63242), (#GH176397)
 - Fixed a crash when an immediate-invoked ``consteval`` lambda is used as an invalid initializer. (#GH185270)
+- Fixed a crash when a lambda expression capturing local array is used in an invalid template constructor. (#GH187183)
 - Fixed an assertion failure when using a global destructor with a target with a non-default program address space. (#GH186484)
 
 - Inherited constructors in ``dllexport`` classes are now exported for ABI-compatible cases, matching 

--- a/clang/lib/Sema/SemaExprCXX.cpp
+++ b/clang/lib/Sema/SemaExprCXX.cpp
@@ -7812,8 +7812,15 @@ ExprResult Sema::ActOnFinishFullExpr(Expr *FE, SourceLocation CC,
   while (isa_and_nonnull<CapturedDecl>(DC))
     DC = DC->getParent();
   const bool IsInLambdaDeclContext = isLambdaCallOperator(DC);
+
+  // Do not check for potential captures if the function in which the lambda
+  // is defined does not have a valid decl. (GH187183)
+  FunctionDecl *FD = getCurFunctionDecl();
+  bool IsValidParentFunc = !FD || !FD->isInvalidDecl();
+
   if (IsInLambdaDeclContext && CurrentLSI &&
-      CurrentLSI->hasPotentialCaptures() && !FullExpr.isInvalid())
+      CurrentLSI->hasPotentialCaptures() && !FullExpr.isInvalid() &&
+      IsValidParentFunc)
     CheckIfAnyEnclosingLambdasMustCaptureAnyPotentialCaptures(FE, CurrentLSI,
                                                               *this);
   return MaybeCreateExprWithCleanups(FullExpr);

--- a/clang/test/SemaCXX/GH187183.cpp
+++ b/clang/test/SemaCXX/GH187183.cpp
@@ -1,0 +1,16 @@
+// RUN: %clang_cc1 -fsyntax-only -verify %s
+
+namespace GH187183 {
+    template<int T>
+    struct S {
+        S();
+    };
+
+    using X = S<0>;
+
+    template<int T> // expected-error {{template parameter list matching the non-templated nested type 'GH187183::S<0>' should be empty ('template<>')}}
+    S<0>::S() {
+        int e[1];
+        test([&e]() { return e[0]; });
+    }
+}


### PR DESCRIPTION
Fix by preventing the check for potential captures if the function in which the lambda is defined has an invalid decl.

Fixes #187183.