### PR TITLE
[mlir] Accept OpaqueAttr as a valid memory space if the context allows unregistered dialects

### DIFF
--- a/mlir/lib/IR/BuiltinTypes.cpp
+++ b/mlir/lib/IR/BuiltinTypes.cpp
@@ -616,6 +616,12 @@ bool mlir::detail::isSupportedMemorySpace(Attribute memorySpace) {
   if (llvm::isa<IntegerAttr, StringAttr, DictionaryAttr>(memorySpace))
     return true;
 
+  // Allow opaque attributes if unregistered dialects are allowed.
+  // They hold unregistered custom dialect attributes.
+  if (memorySpace.getContext()->allowsUnregisteredDialects() &&
+      isa<OpaqueAttr>(memorySpace))
+    return true;
+
   // Allow custom dialect attributes.
   if (!isa<BuiltinDialect>(memorySpace.getDialect()))
     return true;

--- a/mlir/test/IR/parser.mlir
+++ b/mlir/test/IR/parser.mlir
@@ -127,6 +127,12 @@ func.func private @memrefs_nomap_dictspace(memref<5x6x7xf32, {memSpace = "specia
 // CHECK: func private @memrefs_map_dictspace(memref<5x6x7xf32, #map{{[0-9]*}}, {memSpace = "special", subIndex = 3 : i64}>)
 func.func private @memrefs_map_dictspace(memref<5x6x7xf32, #map3, {memSpace = "special", subIndex = 3}>)
 
+// CHECK: func private @memrefs_nomap_opaquespace(memref<5x6x7xf32, #unknown_dialect.unknown_attr>)
+func.func private @memrefs_nomap_opaquespace(memref<5x6x7xf32, #unknown_dialect.unknown_attr>)
+
+// CHECK: func private @memrefs_map_opaquespace(memref<5x6x7xf32, #map{{[0-9]*}}, #unknown_dialect.unknown_attr>)
+func.func private @memrefs_map_opaquespace(memref<5x6x7xf32, #map3, #unknown_dialect.unknown_attr>)
+
 // CHECK: func private @complex_types(complex<i1>) -> complex<f32>
 func.func private @complex_types(complex<i1>) -> complex<f32>
 


### PR DESCRIPTION
When a context allows unregistered dialects and an unknown attribute is encountered, it is wrapped in OpaqueAttr from the builtin dialect.