### PR TITLE
[lldb] Bring Debuginfod's StreamedHTTPResponseHandler to SymbolLocatorSymStore

### DIFF
--- a/lldb/source/Plugins/SymbolLocator/SymStore/SymbolLocatorSymStore.cpp
+++ b/lldb/source/Plugins/SymbolLocator/SymStore/SymbolLocatorSymStore.cpp
@@ -18,11 +18,14 @@
 #include "lldb/Utility/UUID.h"
 
 #include "llvm/ADT/StringExtras.h"
+#include "llvm/Support/Caching.h"
 #include "llvm/Support/Endian.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/FormatVariadic.h"
 #include "llvm/Support/HTTP/HTTPClient.h"
+#include "llvm/Support/HTTP/StreamedHTTPResponseHandler.h"
 #include "llvm/Support/Path.h"
+#include "llvm/Support/raw_ostream.h"
 
 using namespace lldb;
 using namespace lldb_private;
@@ -107,64 +110,14 @@ namespace {
 // SymStore key is a string with no separators and age as decimal:
 //   12345678123456789ABCDEF0123456781
 //
-std::string formatSymStoreKey(const UUID &uuid) {
+std::string FormatSymStoreKey(const UUID &uuid) {
   llvm::ArrayRef<uint8_t> bytes = uuid.GetBytes();
   uint32_t age = llvm::support::endian::read32be(bytes.data() + 16);
-  constexpr bool LowerCase = false;
-  return llvm::toHex(bytes.slice(0, 16), LowerCase) + std::to_string(age);
+  constexpr bool lower_case = false;
+  return llvm::toHex(bytes.slice(0, 16), lower_case) + std::to_string(age);
 }
 
-// This is a simple version of Debuginfod's StreamedHTTPResponseHandler. We
-// should consider reusing that once we introduce caching.
-class FileDownloadHandler : public llvm::HTTPResponseHandler {
-private:
-  std::error_code m_ec;
-  llvm::raw_fd_ostream m_stream;
-
-public:
-  FileDownloadHandler(llvm::StringRef file) : m_stream(file.str(), m_ec) {}
-  virtual ~FileDownloadHandler() = default;
-
-  llvm::Error handleBodyChunk(llvm::StringRef data) override {
-    // Propagate error from ctor.
-    if (m_ec)
-      return llvm::createStringError(m_ec, "Failed to open file for writing");
-    m_stream.write(data.data(), data.size());
-    if (std::error_code ec = m_stream.error())
-      return llvm::createStringError(ec, "Error writing to file");
-
-    return llvm::Error::success();
-  }
-};
-
-llvm::Error downloadFileHTTP(llvm::StringRef url, FileDownloadHandler dest) {
-  if (!llvm::HTTPClient::isAvailable())
-    return llvm::createStringError(
-        std::make_error_code(std::errc::not_supported),
-        "HTTP client is not available");
-  llvm::HTTPRequest Request(url);
-  Request.FollowRedirects = true;
-
-  llvm::HTTPClient Client;
-
-  // TODO: Since PDBs can be huge, we should distinguish between resolve,
-  // connect, send and receive.
-  Client.setTimeout(std::chrono::seconds(60));
-
-  if (llvm::Error Err = Client.perform(Request, dest))
-    return Err;
-
-  unsigned ResponseCode = Client.responseCode();
-  if (ResponseCode != 200) {
-    return llvm::createStringError(std::make_error_code(std::errc::io_error),
-                                   "HTTP request failed with status code " +
-                                       std::to_string(ResponseCode));
-  }
-
-  return llvm::Error::success();
-}
-
-bool has_unsafe_characters(llvm::StringRef s) {
+bool HasUnsafeCharacters(llvm::StringRef s) {
   for (unsigned char c : s) {
     // RFC 3986 unreserved characters are safe for file names and URLs.
     if ((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') ||
@@ -180,17 +133,15 @@ bool has_unsafe_characters(llvm::StringRef s) {
   return s == "." || s == "..";
 }
 
-// TODO: This is a dump initial implementation: It always downloads the file, it
-// doesn't validate the result, it doesn't employ proper buffering for large
-// files.
+// TODO: This is a dumb initial implementation: It always downloads the file and
+// doesn't validate the result.
 std::optional<FileSpec>
-requestFileFromSymStoreServerHTTP(llvm::StringRef base_url, llvm::StringRef key,
+RequestFileFromSymStoreServerHTTP(llvm::StringRef base_url, llvm::StringRef key,
                                   llvm::StringRef pdb_name) {
   using namespace llvm::sys;
-  Log *log = GetLog(LLDBLog::Symbols);
 
   // Make sure URL will be valid, portable, and compatible with symbol servers.
-  if (has_unsafe_characters(pdb_name)) {
+  if (HasUnsafeCharacters(pdb_name)) {
     Debugger::ReportWarning(llvm::formatv(
         "rejecting HTTP lookup for PDB file due to unsafe characters in "
         "name: {0}",
@@ -209,16 +160,57 @@ requestFileFromSymStoreServerHTTP(llvm::StringRef base_url, llvm::StringRef key,
   // Server has SymStore directory structure with forward slashes as separators.
   std::string source_url =
       llvm::formatv("{0}/{1}/{2}/{1}", base_url, pdb_name, key);
-  if (llvm::Error err = downloadFileHTTP(source_url, tmp_file.str())) {
-    LLDB_LOG_ERROR(log, std::move(err),
-                   "Failed to download from SymStore '{1}': {0}", source_url);
+
+  if (!llvm::HTTPClient::isAvailable()) {
+    Debugger::ReportWarning("HTTP client is not available for SymStore download");
     return {};
   }
 
-  return FileSpec(tmp_file.str());
+  llvm::HTTPClient client;
+  // TODO: Since PDBs can be huge, we should distinguish between resolve,
+  // connect, send and receive.
+  client.setTimeout(std::chrono::seconds(60));
+
+  llvm::StreamedHTTPResponseHandler Handler(
+      [dest = tmp_file.str().str()]()
+          -> llvm::Expected<std::unique_ptr<llvm::CachedFileStream>> {
+        std::error_code ec;
+        auto os = std::make_unique<llvm::raw_fd_ostream>(dest, ec);
+        if (ec)
+          return llvm::createStringError(ec, "Failed to open file for writing");
+        return std::make_unique<llvm::CachedFileStream>(std::move(os), dest);
+      },
+      client);
+
+  llvm::HTTPRequest request(source_url);
+  if (llvm::Error Err = client.perform(request, Handler)) {
+    Debugger::ReportWarning(
+        llvm::formatv("failed to download from SymStore '{0}': {1}", source_url,
+                      llvm::toString(std::move(Err))));
+    return {};
+  }
+  if (llvm::Error Err = Handler.commit()) {
+    Debugger::ReportWarning(
+        llvm::formatv("failed to download from SymStore '{0}': {1}", source_url,
+                      llvm::toString(std::move(Err))));
+    return {};
+  }
+
+  unsigned responseCode = client.responseCode();
+  switch (responseCode) {
+  case 404:
+    return {}; // file not found
+  case 200:
+    return FileSpec(tmp_file.str()); // success
+  default:
+    Debugger::ReportWarning(llvm::formatv(
+        "failed to download from SymStore '{0}': response code {1}", source_url,
+        responseCode));
+    return {};
+  }
 }
 
-std::optional<FileSpec> findFileInLocalSymStore(llvm::StringRef root_dir,
+std::optional<FileSpec> FindFileInLocalSymStore(llvm::StringRef root_dir,
                                                 llvm::StringRef key,
                                                 llvm::StringRef pdb_name) {
   llvm::SmallString<256> path;
@@ -230,16 +222,16 @@ std::optional<FileSpec> findFileInLocalSymStore(llvm::StringRef root_dir,
   return spec;
 }
 
-std::optional<FileSpec> locateSymStoreEntry(llvm::StringRef base_url,
+std::optional<FileSpec> LocateSymStoreEntry(llvm::StringRef base_url,
                                             llvm::StringRef key,
                                             llvm::StringRef pdb_name) {
   if (base_url.starts_with("http://") || base_url.starts_with("https://"))
-    return requestFileFromSymStoreServerHTTP(base_url, key, pdb_name);
+    return RequestFileFromSymStoreServerHTTP(base_url, key, pdb_name);
 
   if (base_url.starts_with("file://"))
     base_url = base_url.drop_front(7);
 
-  return findFileInLocalSymStore(base_url, key, pdb_name);
+  return FindFileInLocalSymStore(base_url, key, pdb_name);
 }
 
 } // namespace
@@ -267,10 +259,10 @@ std::optional<FileSpec> SymbolLocatorSymStore::LocateExecutableSymbolFile(
     return {};
   }
 
-  std::string key = formatSymStoreKey(uuid);
+  std::string key = FormatSymStoreKey(uuid);
   Args sym_store_urls = GetGlobalPluginProperties().GetURLs();
   for (const Args::ArgEntry &url : sym_store_urls) {
-    if (auto spec = locateSymStoreEntry(url.ref(), key, pdb_name)) {
+    if (auto spec = LocateSymStoreEntry(url.ref(), key, pdb_name)) {
       LLDB_LOG_VERBOSE(log, "Found {0} in SymStore {1}", pdb_name, url.ref());
       return *spec;
     }

--- a/lldb/source/Plugins/SymbolLocator/SymStore/SymbolLocatorSymStore.cpp
+++ b/lldb/source/Plugins/SymbolLocator/SymStore/SymbolLocatorSymStore.cpp
@@ -162,7 +162,8 @@ RequestFileFromSymStoreServerHTTP(llvm::StringRef base_url, llvm::StringRef key,
       llvm::formatv("{0}/{1}/{2}/{1}", base_url, pdb_name, key);
 
   if (!llvm::HTTPClient::isAvailable()) {
-    Debugger::ReportWarning("HTTP client is not available for SymStore download");
+    Debugger::ReportWarning(
+        "HTTP client is not available for SymStore download");
     return {};
   }
 

--- a/lldb/test/API/symstore/TestSymStore.py
+++ b/lldb/test/API/symstore/TestSymStore.py
@@ -140,6 +140,24 @@ class SymStoreTests(TestBase):
             self.runCmd(f"settings set plugin.symbol-locator.symstore.urls {dir}")
             self.try_breakpoint(exe, should_have_loc=True)
 
+    def test_http_not_found(self):
+        """
+        Check that we don't issue a warning for a 404 response from a symbol server.
+        """
+        exe, sym = self.build_inferior()
+        with MockedSymStore(self, exe, sym) as symstore_dir:
+            os.makedirs(f"{symstore_dir}_empty", exist_ok=False)
+            with HTTPServer(f"{symstore_dir}_empty") as url:
+                self.runCmd(f"settings set plugin.symbol-locator.symstore.urls {url}")
+                warnings = ""
+                with open(self.getBuildArtifact("stderr.txt"), "w+b") as err_file:
+                    self.dbg.SetErrorFileHandle(err_file, False)
+                    self.try_breakpoint(exe, should_have_loc=False)
+                    self.dbg.SetErrorFileHandle(sys.stderr, False)
+                    err_file.seek(0)
+                    warnings = err_file.read().decode()
+                self.assertEqual(warnings, "")
+
     # TODO: Add test coverage for common HTTPS security scenarios, e.g. self-signed
     # certs, non-HTTPS redirects, etc.
     def test_http(self):

--- a/llvm/include/llvm/Support/HTTP/StreamedHTTPResponseHandler.h
+++ b/llvm/include/llvm/Support/HTTP/StreamedHTTPResponseHandler.h
@@ -1,0 +1,49 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// An HTTPResponseHandler that streams the response body to a CachedFileStream.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_SUPPORT_HTTP_STREAMEDHTTPRESPONSEHANDLER_H
+#define LLVM_SUPPORT_HTTP_STREAMEDHTTPRESPONSEHANDLER_H
+
+#include "llvm/Support/Caching.h"
+#include "llvm/Support/Error.h"
+#include "llvm/Support/HTTP/HTTPClient.h"
+#include <functional>
+#include <memory>
+
+namespace llvm {
+
+/// A handler which streams the returned data to a CachedFileStream. The cache
+/// file is only created if a 200 OK status is observed.
+class StreamedHTTPResponseHandler : public HTTPResponseHandler {
+  using CreateStreamFn =
+      std::function<Expected<std::unique_ptr<CachedFileStream>>()>;
+  CreateStreamFn CreateStream;
+  HTTPClient &Client;
+  std::unique_ptr<CachedFileStream> FileStream;
+
+public:
+  StreamedHTTPResponseHandler(CreateStreamFn CreateStream, HTTPClient &Client)
+      : CreateStream(std::move(CreateStream)), Client(Client) {}
+
+  /// Must be called exactly once after the writes have been completed
+  /// but before the StreamedHTTPResponseHandler object is destroyed.
+  Error commit();
+
+  virtual ~StreamedHTTPResponseHandler() = default;
+
+  Error handleBodyChunk(StringRef BodyChunk) override;
+};
+
+} // end namespace llvm
+
+#endif // LLVM_SUPPORT_HTTP_STREAMEDHTTPRESPONSEHANDLER_H

--- a/llvm/lib/Debuginfod/Debuginfod.cpp
+++ b/llvm/lib/Debuginfod/Debuginfod.cpp
@@ -35,6 +35,7 @@
 #include "llvm/Support/Error.h"
 #include "llvm/Support/FileUtilities.h"
 #include "llvm/Support/HTTP/HTTPClient.h"
+#include "llvm/Support/HTTP/StreamedHTTPResponseHandler.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/Path.h"
 #include "llvm/Support/ThreadPool.h"
@@ -172,53 +173,6 @@ Expected<std::string> getCachedOrDownloadArtifact(StringRef UniqueKey,
   return getCachedOrDownloadArtifact(UniqueKey, UrlPath, CacheDir,
                                      getDefaultDebuginfodUrls(),
                                      getDefaultDebuginfodTimeout());
-}
-
-namespace {
-
-/// A simple handler which streams the returned data to a cache file. The cache
-/// file is only created if a 200 OK status is observed.
-class StreamedHTTPResponseHandler : public HTTPResponseHandler {
-  using CreateStreamFn =
-      std::function<Expected<std::unique_ptr<CachedFileStream>>()>;
-  CreateStreamFn CreateStream;
-  HTTPClient &Client;
-  std::unique_ptr<CachedFileStream> FileStream;
-
-public:
-  StreamedHTTPResponseHandler(CreateStreamFn CreateStream, HTTPClient &Client)
-      : CreateStream(CreateStream), Client(Client) {}
-
-  /// Must be called exactly once after the writes have been completed
-  /// but before the StreamedHTTPResponseHandler object is destroyed.
-  Error commit();
-
-  virtual ~StreamedHTTPResponseHandler() = default;
-
-  Error handleBodyChunk(StringRef BodyChunk) override;
-};
-
-} // namespace
-
-Error StreamedHTTPResponseHandler::handleBodyChunk(StringRef BodyChunk) {
-  if (!FileStream) {
-    unsigned Code = Client.responseCode();
-    if (Code && Code != 200)
-      return Error::success();
-    Expected<std::unique_ptr<CachedFileStream>> FileStreamOrError =
-        CreateStream();
-    if (!FileStreamOrError)
-      return FileStreamOrError.takeError();
-    FileStream = std::move(*FileStreamOrError);
-  }
-  *FileStream->OS << BodyChunk;
-  return Error::success();
-}
-
-Error StreamedHTTPResponseHandler::commit() {
-  if (FileStream)
-    return FileStream->commit();
-  return Error::success();
 }
 
 // An over-accepting simplification of the HTTP RFC 7230 spec.

--- a/llvm/lib/Support/HTTP/CMakeLists.txt
+++ b/llvm/lib/Support/HTTP/CMakeLists.txt
@@ -16,6 +16,7 @@ endif()
 add_llvm_component_library(LLVMSupportHTTP
   HTTPClient.cpp
   HTTPServer.cpp
+  StreamedHTTPResponseHandler.cpp
 
   LINK_LIBS
   ${imported_libs}

--- a/llvm/lib/Support/HTTP/StreamedHTTPResponseHandler.cpp
+++ b/llvm/lib/Support/HTTP/StreamedHTTPResponseHandler.cpp
@@ -1,0 +1,34 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/Support/HTTP/StreamedHTTPResponseHandler.h"
+
+namespace llvm {
+
+Error StreamedHTTPResponseHandler::handleBodyChunk(StringRef BodyChunk) {
+  if (!FileStream) {
+    unsigned Code = Client.responseCode();
+    if (Code && Code != 200)
+      return Error::success();
+    Expected<std::unique_ptr<CachedFileStream>> FileStreamOrError =
+        CreateStream();
+    if (!FileStreamOrError)
+      return FileStreamOrError.takeError();
+    FileStream = std::move(*FileStreamOrError);
+  }
+  *FileStream->OS << BodyChunk;
+  return Error::success();
+}
+
+Error StreamedHTTPResponseHandler::commit() {
+  if (FileStream)
+    return FileStream->commit();
+  return Error::success();
+}
+
+} // namespace llvm


### PR DESCRIPTION
SymbolLocatorSymStore used a simple local implementation of HTTPResponseHandler so far. That was fine for basic usage, but it would cause issues down the line. This patch hoists the StreamedHTTPResponseHandler class from libDebuginfod to SupportHTTP and integrates it in SymbolLocatorSymStore. PDB file downloads will now be buffered on disk, which is necessary since they can be huge.

We use the opportunity an stop logging 404 responses (file not found on server) and print warnings for all other erroneous HTTP responses. It was more complicated before, because the old response handler created the underlying file in any case. The new one does that only one the first content package comes in.