### PR TITLE
[CIR] Add missing MLIR TableGen dependencies to CIR CMake targets

### DIFF
--- a/clang/lib/CIR/CodeGen/CMakeLists.txt
+++ b/clang/lib/CIR/CodeGen/CMakeLists.txt
@@ -55,6 +55,8 @@ add_clang_library(clangCIR
   DEPENDS
   MLIRCIR
   MLIRCIROpInterfacesIncGen
+  MLIRBuiltinLocationAttributesIncGen
+  MLIRBytecodeOpInterfaceIncGen
   ${dialect_libs}
 
   LINK_LIBS

--- a/clang/lib/CIR/Dialect/IR/CMakeLists.txt
+++ b/clang/lib/CIR/Dialect/IR/CMakeLists.txt
@@ -11,6 +11,8 @@ add_clang_library(MLIRCIR
   MLIRCIREnumsGen
   MLIRCIROpInterfacesIncGen
   MLIRCIRLoopOpInterfaceIncGen
+  MLIRBuiltinLocationAttributesIncGen
+  MLIRBytecodeOpInterfaceIncGen
 
   LINK_LIBS PUBLIC
   MLIRIR

--- a/clang/lib/CIR/Dialect/OpenACC/CMakeLists.txt
+++ b/clang/lib/CIR/Dialect/OpenACC/CMakeLists.txt
@@ -4,6 +4,8 @@ add_clang_library(CIROpenACCSupport
 
   DEPENDS
   MLIRCIRTypeConstraintsIncGen
+  MLIRBuiltinLocationAttributesIncGen
+  MLIRBytecodeOpInterfaceIncGen
 
   LINK_LIBS PUBLIC
   MLIRIR

--- a/clang/lib/CIR/Dialect/Transforms/CMakeLists.txt
+++ b/clang/lib/CIR/Dialect/Transforms/CMakeLists.txt
@@ -14,6 +14,8 @@ add_clang_library(MLIRCIRTransforms
 
   DEPENDS
   MLIRCIRPassIncGen
+  MLIRBuiltinLocationAttributesIncGen
+  MLIRBytecodeOpInterfaceIncGen
 
   LINK_LIBS PUBLIC
   clangAST

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/CMakeLists.txt
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/CMakeLists.txt
@@ -6,6 +6,8 @@ add_clang_library(MLIRCIRTargetLowering
 
   DEPENDS
   clangBasic
+  MLIRBuiltinLocationAttributesIncGen
+  MLIRBytecodeOpInterfaceIncGen
 
   LINK_COMPONENTS
   TargetParser

--- a/clang/lib/CIR/FrontendAction/CMakeLists.txt
+++ b/clang/lib/CIR/FrontendAction/CMakeLists.txt
@@ -11,6 +11,8 @@ add_clang_library(clangCIRFrontendAction
   DEPENDS
   MLIRCIROpsIncGen
   MLIRCIROpInterfacesIncGen
+  MLIRBuiltinLocationAttributesIncGen
+  MLIRBytecodeOpInterfaceIncGen
   MLIRBuiltinOpsIncGen
 
   LINK_LIBS

--- a/clang/lib/CIR/Interfaces/CMakeLists.txt
+++ b/clang/lib/CIR/Interfaces/CMakeLists.txt
@@ -13,6 +13,8 @@ add_clang_library(MLIRCIRInterfaces
   MLIRCIRTypeInterfacesIncGen
   MLIRCIRLoopOpInterfaceIncGen
   MLIRCIROpInterfacesIncGen
+  MLIRBuiltinLocationAttributesIncGen
+  MLIRBytecodeOpInterfaceIncGen
 
   LINK_LIBS
   ${dialect_libs}

--- a/clang/lib/CIR/Lowering/CMakeLists.txt
+++ b/clang/lib/CIR/Lowering/CMakeLists.txt
@@ -9,6 +9,10 @@ add_clang_library(clangCIRLoweringCommon
   CIRPasses.cpp
   LoweringHelpers.cpp
 
+  DEPENDS
+  MLIRBuiltinLocationAttributesIncGen
+  MLIRBytecodeOpInterfaceIncGen
+
   LINK_LIBS
   clangCIR
   ${dialect_libs}

--- a/clang/lib/CIR/Lowering/DirectToLLVM/CMakeLists.txt
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/CMakeLists.txt
@@ -12,6 +12,8 @@ add_clang_library(clangCIRLoweringDirectToLLVM
   DEPENDS
   MLIRCIREnumsGen
   MLIRCIROpsIncGen
+  MLIRBuiltinLocationAttributesIncGen
+  MLIRBytecodeOpInterfaceIncGen
   MLIRCIROpInterfacesIncGen
 
   LINK_LIBS


### PR DESCRIPTION
CIR targets include MLIR headers that depend on TableGen-generated .inc files (BuiltinLocationAttributes.h.inc, BytecodeOpInterface.h.inc), but do not declare build dependencies on the corresponding TableGen targets. This causes intermittent build failures with parallel builds when the .inc files have not yet been generated by the time CIR sources compile.

Add MLIRBuiltinLocationAttributesIncGen and MLIRBytecodeOpInterfaceIncGen to DEPENDS in all affected CIR CMake targets:
- clangCIRLoweringCommon
- clangCIRLoweringDirectToLLVM
- clangCIRFrontendAction
- MLIRCIRInterfaces
- MLIRCIR (Dialect/IR)
- MLIRCIRTransforms
- MLIRCIRTargetLowering
- CIROpenACCSupport
- clangCIR (CodeGen)