### PR TITLE
[libc] Define Annex K's errno_t in specified headers

### DIFF
--- a/libc/include/CMakeLists.txt
+++ b/libc/include/CMakeLists.txt
@@ -366,9 +366,9 @@ add_header_macro(
     .llvm-libc-macros.file_seek_macros
     .llvm-libc-macros.null_macro
     .llvm-libc-macros.stdio_macros
+    .llvm-libc-types.FILE
     .llvm-libc-types.cookie_io_functions_t
     .llvm-libc-types.errno_t
-    .llvm-libc-types.FILE
     .llvm-libc-types.off_t
     .llvm-libc-types.size_t
     .llvm-libc-types.ssize_t

--- a/libc/include/CMakeLists.txt
+++ b/libc/include/CMakeLists.txt
@@ -253,6 +253,7 @@ add_header_macro(
   DEPENDS
     .llvm_libc_common_h
     .llvm-libc-macros.null_macro
+    .llvm-libc-types.errno_t
     .llvm-libc-types.size_t
 )
 
@@ -288,6 +289,7 @@ add_header_macro(
     .llvm-libc-macros.null_macro
     .llvm-libc-macros.time_macros
     .llvm-libc-types.clock_t
+    .llvm-libc-types.errno_t
     .llvm-libc-types.time_t
     .llvm-libc-types.struct_tm
     .llvm-libc-types.struct_timespec
@@ -364,8 +366,9 @@ add_header_macro(
     .llvm-libc-macros.file_seek_macros
     .llvm-libc-macros.null_macro
     .llvm-libc-macros.stdio_macros
-    .llvm-libc-types.FILE
     .llvm-libc-types.cookie_io_functions_t
+    .llvm-libc-types.errno_t
+    .llvm-libc-types.FILE
     .llvm-libc-types.off_t
     .llvm-libc-types.size_t
     .llvm-libc-types.ssize_t
@@ -384,6 +387,7 @@ add_header_macro(
     .llvm-libc-types.__qsortrcompare_t
     .llvm-libc-types.__search_compare_t
     .llvm-libc-types.div_t
+    .llvm-libc-types.errno_t
     .llvm-libc-types.ldiv_t
     .llvm-libc-types.lldiv_t
     .llvm-libc-types.locale_t

--- a/libc/include/errno.h.def
+++ b/libc/include/errno.h.def
@@ -31,6 +31,8 @@
 
 #endif
 
+%%public_api()
+
 __BEGIN_C_DECLS
 
 int *__llvm_libc_errno(void) __NOEXCEPT;

--- a/libc/include/stdio.yaml
+++ b/libc/include/stdio.yaml
@@ -14,6 +14,7 @@ types:
   - type_name: off_t
   - type_name: cookie_io_functions_t
   - type_name: FILE
+  - type_name: errno_t
 enums: []
 objects:
   - object_name: stdin

--- a/libc/include/stdlib.yaml
+++ b/libc/include/stdlib.yaml
@@ -17,7 +17,8 @@ types:
   - type_name: lldiv_t
   - type_name: locale_t
   - type_name: size_t
-  - type_name: wchar_t  
+  - type_name: wchar_t
+  - type_name: errno_t
 enums: []
 objects: []
 functions:

--- a/libc/include/string.yaml
+++ b/libc/include/string.yaml
@@ -5,6 +5,7 @@ macros:
   - macro_name: "NULL"
     macro_header: null-macro.h
 types:
+  - type_name: errno_t
   - type_name: locale_t
   - type_name: size_t
 enums: []

--- a/libc/include/time.yaml
+++ b/libc/include/time.yaml
@@ -6,6 +6,7 @@ macros:
 types:
   - type_name: struct_timeval
   - type_name: clockid_t
+  - type_name: errno_t
   - type_name: struct_timespec
   - type_name: struct_tm
   - type_name: time_t


### PR DESCRIPTION
 - Change `errno.h.def` to include a placeholder where hdrgen emits the public API, which contains the `errno_t` definition.
 - Make headers `stdio.h`, `stdlib.h`, `string.h` and `time.h` also define `errno_t` as specified in the standard.