### PR TITLE
[IR][NFC] Fix MSVC deprecation warnings about BranchInst

### DIFF
--- a/llvm/include/llvm/IR/Instructions.h
+++ b/llvm/include/llvm/IR/Instructions.h
@@ -3287,9 +3287,6 @@ struct OperandTraits<CondBrInst> : public FixedNumOperandTraits<CondBrInst, 3> {
 
 DEFINE_TRANSPARENT_OPERAND_ACCESSORS(CondBrInst, Value)
 
-// Suppress deprecation warnings from BranchInst.
-LLVM_SUPPRESS_DEPRECATED_DECLARATIONS_POP
-
 //===----------------------------------------------------------------------===//
 //                     BranchInst Out-Of-Line Functions
 //===----------------------------------------------------------------------===//
@@ -3320,6 +3317,9 @@ inline void BranchInst::setCondition(Value *V) {
 inline void BranchInst::swapSuccessors() {
   cast<CondBrInst>(this)->swapSuccessors();
 }
+
+// Suppress deprecation warnings from BranchInst.
+LLVM_SUPPRESS_DEPRECATED_DECLARATIONS_POP
 
 //===----------------------------------------------------------------------===//
 //                               SwitchInst Class

--- a/llvm/lib/IR/Instructions.cpp
+++ b/llvm/lib/IR/Instructions.cpp
@@ -1189,6 +1189,9 @@ UnreachableInst::UnreachableInst(LLVMContext &Context,
 //                        UncondBrInst Implementation
 //===----------------------------------------------------------------------===//
 
+// Suppress deprecation warnings from BranchInst.
+LLVM_SUPPRESS_DEPRECATED_DECLARATIONS_PUSH
+
 UncondBrInst::UncondBrInst(BasicBlock *IfTrue, InsertPosition InsertBefore)
     : BranchInst(Type::getVoidTy(IfTrue->getContext()), Instruction::UncondBr,
                  AllocMarker, InsertBefore) {
@@ -1242,6 +1245,9 @@ void CondBrInst::swapSuccessors() {
   // expectations.
   swapProfMetadata();
 }
+
+// Suppress deprecation warnings from BranchInst.
+LLVM_SUPPRESS_DEPRECATED_DECLARATIONS_POP
 
 //===----------------------------------------------------------------------===//
 //                        AllocaInst Implementation


### PR DESCRIPTION
MSVC apparently also warns about deprecation at the implementation
of deprecated functions...
