### PR TITLE
[AsmPrinter] Add generic support for verifying instruction sizes

### DIFF
--- a/llvm/include/llvm/CodeGen/TargetInstrInfo.h
+++ b/llvm/include/llvm/CodeGen/TargetInstrInfo.h
@@ -428,6 +428,12 @@ public:
     return ~0U;
   }
 
+  /// Whether the correctness of the instruction size returned by
+  /// getInstSizeInBytes() should be verified.
+  virtual bool shouldVerifyInstSize(const MachineInstr &MI) const {
+    return false;
+  }
+
   /// Return true if the instruction is as cheap as a move instruction.
   ///
   /// Targets for different archs need to override this, and different

--- a/llvm/include/llvm/CodeGen/TargetInstrInfo.h
+++ b/llvm/include/llvm/CodeGen/TargetInstrInfo.h
@@ -428,10 +428,20 @@ public:
     return ~0U;
   }
 
-  /// Whether the correctness of the instruction size returned by
+  enum class InstSizeVerifyMode {
+    /// Do not verify instruction size.
+    NoVerify,
+    /// Check that the instruction size matches exactly.
+    ExactSize,
+    /// Allow the reported instruction size to be larger than the actual size.
+    AllowOverEstimate,
+  };
+
+  /// Determine whether/how the instruction size returned by
   /// getInstSizeInBytes() should be verified.
-  virtual bool shouldVerifyInstSize(const MachineInstr &MI) const {
-    return false;
+  virtual InstSizeVerifyMode
+  getInstSizeVerifyMode(const MachineInstr &MI) const {
+    return InstSizeVerifyMode::NoVerify;
   }
 
   /// Return true if the instruction is as cheap as a move instruction.

--- a/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
@@ -2277,13 +2277,18 @@ void AsmPrinter::emitFunctionBody() {
       if (OutStreamer->isObj()) {
         const TargetInstrInfo *TII = MF->getSubtarget().getInstrInfo();
         MCFragment *NewFragment = OutStreamer->getCurrentFragment();
+        TargetInstrInfo::InstSizeVerifyMode Mode =
+            TII->getInstSizeVerifyMode(MI);
         // Don't try to handle fragment splitting cases.
-        if (NewFragment == OldFragment && TII->shouldVerifyInstSize(MI)) {
+        if (NewFragment == OldFragment &&
+            Mode != TargetInstrInfo::InstSizeVerifyMode::NoVerify) {
           unsigned ExpectedSize = TII->getInstSizeInBytes(MI);
           unsigned ActualSize = NewFragment->getFixedSize() - OldFragSize;
-          // FIXME: InstrInfo currently over-estimates the size of STACKMAP.
-          if (ActualSize != ExpectedSize &&
-              MI.getOpcode() != TargetOpcode::STACKMAP) {
+          bool Valid =
+              Mode == TargetInstrInfo::InstSizeVerifyMode::AllowOverEstimate
+                  ? ActualSize <= ExpectedSize
+                  : ActualSize == ExpectedSize;
+          if (!Valid) {
             dbgs() << "Size mismatch for: " << MI << "\n";
             dbgs() << "Expected size: " << ExpectedSize << "\n";
             dbgs() << "Actual size: " << ActualSize << "\n";

--- a/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
@@ -2147,6 +2147,11 @@ void AsmPrinter::emitFunctionBody() {
       if (isVerbose())
         emitComments(MI, STI, OutStreamer->getCommentOS());
 
+#ifndef NDEBUG
+      MCFragment *OldFragment = OutStreamer->getCurrentFragment();
+      size_t OldFragSize = OldFragment->getFixedSize();
+#endif
+
       switch (MI.getOpcode()) {
       case TargetOpcode::CFI_INSTRUCTION:
         emitCFIInstruction(MI);
@@ -2264,6 +2269,29 @@ void AsmPrinter::emitFunctionBody() {
         }
         break;
       }
+
+#ifndef NDEBUG
+      // Verify that the instruction size reported by InstrInfo matches the
+      // actually emitted size. Many backends performing branch relaxation
+      // on the MIR level rely on this for correctness.
+      if (OutStreamer->isObj()) {
+        const TargetInstrInfo *TII = MF->getSubtarget().getInstrInfo();
+        MCFragment *NewFragment = OutStreamer->getCurrentFragment();
+        // Don't try to handle fragment splitting cases.
+        if (NewFragment == OldFragment && TII->shouldVerifyInstSize(MI)) {
+          unsigned ExpectedSize = TII->getInstSizeInBytes(MI);
+          unsigned ActualSize = NewFragment->getFixedSize() - OldFragSize;
+          // FIXME: InstrInfo currently over-estimates the size of STACKMAP.
+          if (ActualSize != ExpectedSize &&
+              MI.getOpcode() != TargetOpcode::STACKMAP) {
+            dbgs() << "Size mismatch for: " << MI << "\n";
+            dbgs() << "Expected size: " << ExpectedSize << "\n";
+            dbgs() << "Actual size: " << ActualSize << "\n";
+            abort();
+          }
+        }
+      }
+#endif
 
       if (MI.isCall()) {
         if (MF->getTarget().Options.BBAddrMap)

--- a/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
@@ -2284,13 +2284,15 @@ void AsmPrinter::emitFunctionBody() {
             Mode != TargetInstrInfo::InstSizeVerifyMode::NoVerify) {
           unsigned ExpectedSize = TII->getInstSizeInBytes(MI);
           unsigned ActualSize = NewFragment->getFixedSize() - OldFragSize;
-          bool Valid =
-              Mode == TargetInstrInfo::InstSizeVerifyMode::AllowOverEstimate
-                  ? ActualSize <= ExpectedSize
-                  : ActualSize == ExpectedSize;
+          bool AllowOverEstimate =
+              Mode == TargetInstrInfo::InstSizeVerifyMode::AllowOverEstimate;
+          bool Valid = AllowOverEstimate ? ActualSize <= ExpectedSize
+                                         : ActualSize == ExpectedSize;
           if (!Valid) {
-            dbgs() << "Size mismatch for: " << MI << "\n";
-            dbgs() << "Expected size: " << ExpectedSize << "\n";
+            dbgs() << "In function: " << MF->getName() << "\n";
+            dbgs() << "Size mismatch for: " << MI;
+            dbgs() << "Expected " << (AllowOverEstimate ? "maximum" : "exact")
+                   << " size: " << ExpectedSize << "\n";
             dbgs() << "Actual size: " << ActualSize << "\n";
             abort();
           }

--- a/llvm/lib/Target/PowerPC/PPCAsmPrinter.cpp
+++ b/llvm/lib/Target/PowerPC/PPCAsmPrinter.cpp
@@ -27,7 +27,6 @@
 #include "PPCTargetMachine.h"
 #include "TargetInfo/PowerPCTargetInfo.h"
 #include "llvm/ADT/MapVector.h"
-#include "llvm/ADT/ScopeExit.h"
 #include "llvm/ADT/SetVector.h"
 #include "llvm/ADT/Statistic.h"
 #include "llvm/ADT/StringExtras.h"
@@ -945,31 +944,6 @@ void PPCAsmPrinter::emitInstruction(const MachineInstr *MI) {
       return PPC::S_AIX_TLSML;
     return PPC::S_None;
   };
-
-#ifndef NDEBUG
-  // Instruction sizes must be correct for PPCBranchSelector to pick the
-  // right branch kind. Verify that the reported sizes and the actually
-  // emitted sizes match.
-  unsigned ExpectedSize = Subtarget->getInstrInfo()->getInstSizeInBytes(*MI);
-  MCFragment *OldFragment = OutStreamer->getCurrentFragment();
-  size_t OldFragSize = OldFragment->getFixedSize();
-  scope_exit VerifyInstSize([&]() {
-    if (!OutStreamer->isObj())
-      return; // Can only verify size when streaming to object.
-    MCFragment *NewFragment = OutStreamer->getCurrentFragment();
-    if (NewFragment != OldFragment)
-      return; // Don't try to handle fragment splitting cases.
-    unsigned ActualSize = NewFragment->getFixedSize() - OldFragSize;
-    // FIXME: InstrInfo currently over-estimates the size of STACKMAP.
-    if (ActualSize != ExpectedSize &&
-        MI->getOpcode() != TargetOpcode::STACKMAP) {
-      dbgs() << "Size mismatch for: " << *MI << "\n";
-      dbgs() << "Expected size: " << ExpectedSize << "\n";
-      dbgs() << "Actual size: " << ActualSize << "\n";
-      abort();
-    }
-  });
-#endif
 
   // Lower multi-instruction pseudo operations.
   switch (MI->getOpcode()) {

--- a/llvm/lib/Target/PowerPC/PPCInstrInfo.cpp
+++ b/llvm/lib/Target/PowerPC/PPCInstrInfo.cpp
@@ -3034,6 +3034,11 @@ unsigned PPCInstrInfo::getInstSizeInBytes(const MachineInstr &MI) const {
   }
 }
 
+bool PPCInstrInfo::shouldVerifyInstSize(const MachineInstr &MI) const {
+  // FIXME: The size of STACKMAP is currently over-estimated.
+  return MI.getOpcode() != TargetOpcode::STACKMAP;
+}
+
 std::pair<unsigned, unsigned>
 PPCInstrInfo::decomposeMachineOperandsTargetFlags(unsigned TF) const {
   // PPC always uses a direct mask.

--- a/llvm/lib/Target/PowerPC/PPCInstrInfo.cpp
+++ b/llvm/lib/Target/PowerPC/PPCInstrInfo.cpp
@@ -3034,9 +3034,12 @@ unsigned PPCInstrInfo::getInstSizeInBytes(const MachineInstr &MI) const {
   }
 }
 
-bool PPCInstrInfo::shouldVerifyInstSize(const MachineInstr &MI) const {
+TargetInstrInfo::InstSizeVerifyMode
+PPCInstrInfo::getInstSizeVerifyMode(const MachineInstr &MI) const {
   // FIXME: The size of STACKMAP is currently over-estimated.
-  return MI.getOpcode() != TargetOpcode::STACKMAP;
+  return MI.getOpcode() != TargetOpcode::STACKMAP
+             ? InstSizeVerifyMode::AllowOverEstimate
+             : InstSizeVerifyMode::ExactSize;
 }
 
 std::pair<unsigned, unsigned>

--- a/llvm/lib/Target/PowerPC/PPCInstrInfo.h
+++ b/llvm/lib/Target/PowerPC/PPCInstrInfo.h
@@ -700,6 +700,8 @@ public:
   ///
   unsigned getInstSizeInBytes(const MachineInstr &MI) const override;
 
+  bool shouldVerifyInstSize(const MachineInstr &MI) const override;
+
   MCInst getNop() const override;
 
   std::pair<unsigned, unsigned>

--- a/llvm/lib/Target/PowerPC/PPCInstrInfo.h
+++ b/llvm/lib/Target/PowerPC/PPCInstrInfo.h
@@ -700,7 +700,8 @@ public:
   ///
   unsigned getInstSizeInBytes(const MachineInstr &MI) const override;
 
-  bool shouldVerifyInstSize(const MachineInstr &MI) const override;
+  InstSizeVerifyMode
+  getInstSizeVerifyMode(const MachineInstr &MI) const override;
 
   MCInst getNop() const override;
 


### PR DESCRIPTION
Many backends rely on TII reporting correct instruction sizes for MIR level branch relaxation passes. Reporting a too small size can result in MC fixup failures (or silent miscompiles for unvalidated fixups).

Some time ago I added validation to the PPC asm printer to verify that the TII instruction size matches the actually emitted size. This was very helpful to systematically fix all incorrectly reported instruction sizes.

However, the same problem also exists in lots of other backends, so this moves the validation into AsmPrinter, controlled by a new shouldVerifyInstSize() hook in TII, which is disabled by default.

The intention here is to gradually enable this validation for more backends (which requires fixing them first).