### PR TITLE
[llvm] Restrict llvm-debginfod-find test to localhost to fix winhttp case

### DIFF
--- a/llvm/test/tools/llvm-debuginfod-find/Inputs/capture_req.py
+++ b/llvm/test/tools/llvm-debuginfod-find/Inputs/capture_req.py
@@ -14,7 +14,7 @@ class TrivialHandler(http.server.BaseHTTPRequestHandler):
         print(self.headers)
 
 
-httpd = http.server.HTTPServer(("", 0), TrivialHandler)
+httpd = http.server.HTTPServer(("localhost", 0), TrivialHandler)
 port = httpd.socket.getsockname()[1]
 
 try:


### PR DESCRIPTION
Listening on all interfaces is probably not permitted on the bots and causes failures of llvm-debuginfod-find/headers-winhttp.test after 39d6bb21804d21abe2fa0ec019919d72104827ac. Restricting them to localhost should fix that.