### PR TITLE
[CodeGen] Add MustReduceLatency MC objective

### DIFF
--- a/llvm/include/llvm/CodeGen/MachineCombinerPattern.h
+++ b/llvm/include/llvm/CodeGen/MachineCombinerPattern.h
@@ -21,6 +21,7 @@ namespace llvm {
 enum class CombinerObjective {
   MustReduceDepth,            // The data dependency chain must be improved.
   MustReduceRegisterPressure, // The register pressure must be reduced.
+  MustReduceLatency,          // The new pattern must have lower latency.
   Default                     // The critical path must not be lengthened.
 };
 

--- a/llvm/lib/CodeGen/MachineCombiner.cpp
+++ b/llvm/lib/CodeGen/MachineCombiner.cpp
@@ -396,13 +396,22 @@ bool MachineCombiner::improvesCriticalPathLen(
                     << "\n\tNewRootDepth + NewRootLatency = " << NewCycleCount
                     << "\n\tRootDepth + RootLatency + RootSlack = "
                     << OldCycleCount);
-  LLVM_DEBUG(NewCycleCount <= OldCycleCount
-                 ? dbgs() << "\n\t  It IMPROVES PathLen because"
-                 : dbgs() << "\n\t  It DOES NOT improve PathLen because");
+
+  bool IsStrictImprovementRequired =
+      getCombinerObjective(Pattern) == CombinerObjective::MustReduceLatency;
+  bool Improves = IsStrictImprovementRequired ? NewCycleCount < OldCycleCount
+                                              : NewCycleCount <= OldCycleCount;
+
+  if (IsStrictImprovementRequired)
+    LLVM_DEBUG(
+        dbgs() << "\n\t  (MustReduceLatency: strict improvement required)");
+
+  LLVM_DEBUG(Improves ? dbgs() << "\n\t  It IMPROVES PathLen because"
+                      : dbgs() << "\n\t  It DOES NOT improve PathLen because");
   LLVM_DEBUG(dbgs() << "\n\t\tNewCycleCount = " << NewCycleCount
                     << ", OldCycleCount = " << OldCycleCount << "\n");
 
-  return NewCycleCount <= OldCycleCount;
+  return Improves;
 }
 
 /// helper routine to convert instructions into SC


### PR DESCRIPTION
Currently, no combiner objective covers the case where a rewrite should only be accepted if it is strictly beneficial. For example, rewriting a slow instruction to a sequence of faster ones might only make sense when there is a strict improvement. A non-strict check would allow neutral rewrites that increase code size or register pressure for no gain in latency. This patch adds such pattern.