### PR TITLE
[AMDGPU] Use s_cvt_i32/u32_f32 instructions for saturated uniform conversions

### DIFF
--- a/llvm/lib/Target/AMDGPU/SOPInstructions.td
+++ b/llvm/lib/Target/AMDGPU/SOPInstructions.td
@@ -488,6 +488,17 @@ let SubtargetPredicate = HasSALUFloatInsts, AddedComplexity = 9 in {
                  (S_CVT_F16_F32 (S_CVT_F32_I32 $src0))>;
     def : GCNPat<(f16 (UniformUnaryFrag<uint_to_fp> i32:$src0)),
                  (S_CVT_F16_F32 (S_CVT_F32_U32 $src0))>;
+
+    // f32 -> i32 saturated conversions
+    def : GCNPat<(i32 (UniformBinFrag<fp_to_sint_sat> f32:$src0, i32)),
+                 (S_CVT_I32_F32 (f32 $src0))>;
+    def : GCNPat<(i32 (UniformBinFrag<fp_to_uint_sat> f32:$src0, i32)),
+                 (S_CVT_U32_F32 (f32 $src0))>;
+
+    def : GCNPat<(i32 (UniformUnaryFrag<fp_to_sint_sat_gi> f32:$src0)),
+                 (S_CVT_I32_F32 (f32 $src0))>;
+    def : GCNPat<(i32 (UniformUnaryFrag<fp_to_uint_sat_gi> f32:$src0)),
+                 (S_CVT_U32_F32 (f32 $src0))>;
 }
 
 let hasSideEffects = 1 in {

--- a/llvm/test/CodeGen/AMDGPU/fptosi-sat-scalar.ll
+++ b/llvm/test/CodeGen/AMDGPU/fptosi-sat-scalar.ll
@@ -402,6 +402,463 @@ define i64 @test_signed_i64_f32(float %f) nounwind {
     ret i64 %x
 }
 
+define i1 @test_s_signed_i1_f32(float inreg %f) nounwind {
+; GFX7-LABEL: test_s_signed_i1_f32:
+; GFX7:       ; %bb.0:
+; GFX7-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-NEXT:    v_cvt_i32_f32_e32 v0, s16
+; GFX7-NEXT:    v_med3_i32 v0, v0, -1, 0
+; GFX7-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX9-LABEL: test_s_signed_i1_f32:
+; GFX9:       ; %bb.0:
+; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    v_cvt_i32_f32_e32 v0, s16
+; GFX9-NEXT:    v_med3_i32 v0, v0, -1, 0
+; GFX9-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11-LABEL: test_s_signed_i1_f32:
+; GFX11:       ; %bb.0:
+; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-NEXT:    v_cvt_i32_f32_e32 v0, s0
+; GFX11-NEXT:    v_med3_i32 v0, v0, -1, 0
+; GFX11-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-ISEL-LABEL: test_s_signed_i1_f32:
+; GFX12-ISEL:       ; %bb.0:
+; GFX12-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX12-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX12-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX12-ISEL-NEXT:    s_cvt_i32_f32 s0, s0
+; GFX12-ISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-ISEL-NEXT:    v_med3_i32 v0, s0, -1, 0
+; GFX12-ISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-GI-LABEL: test_s_signed_i1_f32:
+; GFX12-GI:       ; %bb.0:
+; GFX12-GI-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-GI-NEXT:    s_wait_expcnt 0x0
+; GFX12-GI-NEXT:    s_wait_samplecnt 0x0
+; GFX12-GI-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-GI-NEXT:    s_wait_kmcnt 0x0
+; GFX12-GI-NEXT:    s_cvt_i32_f32 s0, s0
+; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-GI-NEXT:    s_min_i32 s0, s0, 0
+; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-GI-NEXT:    s_max_i32 s0, s0, -1
+; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-GI-NEXT:    v_mov_b32_e32 v0, s0
+; GFX12-GI-NEXT:    s_setpc_b64 s[30:31]
+    %x = call i1 @llvm.fptosi.sat.i1.f32(float %f)
+    ret i1 %x
+}
+
+define i8 @test_s_signed_i8_f32(float inreg %f) nounwind {
+; GFX7-ISEL-LABEL: test_s_signed_i8_f32:
+; GFX7-ISEL:       ; %bb.0:
+; GFX7-ISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-ISEL-NEXT:    v_cvt_i32_f32_e32 v0, s16
+; GFX7-ISEL-NEXT:    s_movk_i32 s4, 0xff80
+; GFX7-ISEL-NEXT:    v_mov_b32_e32 v1, 0x7f
+; GFX7-ISEL-NEXT:    v_med3_i32 v0, v0, s4, v1
+; GFX7-ISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX7-GI-LABEL: test_s_signed_i8_f32:
+; GFX7-GI:       ; %bb.0:
+; GFX7-GI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-GI-NEXT:    v_cvt_i32_f32_e32 v0, s16
+; GFX7-GI-NEXT:    v_mov_b32_e32 v1, 0x7f
+; GFX7-GI-NEXT:    v_mov_b32_e32 v2, 0xffffff80
+; GFX7-GI-NEXT:    v_med3_i32 v0, v0, v2, v1
+; GFX7-GI-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX9-LABEL: test_s_signed_i8_f32:
+; GFX9:       ; %bb.0:
+; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    v_cvt_i32_f32_e32 v0, s16
+; GFX9-NEXT:    s_movk_i32 s4, 0xff80
+; GFX9-NEXT:    v_mov_b32_e32 v1, 0x7f
+; GFX9-NEXT:    v_med3_i32 v0, v0, s4, v1
+; GFX9-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11-LABEL: test_s_signed_i8_f32:
+; GFX11:       ; %bb.0:
+; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-NEXT:    v_cvt_i32_f32_e32 v0, s0
+; GFX11-NEXT:    s_movk_i32 s0, 0xff80
+; GFX11-NEXT:    v_med3_i32 v0, v0, s0, 0x7f
+; GFX11-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-ISEL-LABEL: test_s_signed_i8_f32:
+; GFX12-ISEL:       ; %bb.0:
+; GFX12-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX12-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX12-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX12-ISEL-NEXT:    v_mov_b32_e32 v0, 0x7f
+; GFX12-ISEL-NEXT:    s_cvt_i32_f32 s0, s0
+; GFX12-ISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-ISEL-NEXT:    v_med3_i32 v0, 0xffffff80, s0, v0
+; GFX12-ISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-GI-LABEL: test_s_signed_i8_f32:
+; GFX12-GI:       ; %bb.0:
+; GFX12-GI-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-GI-NEXT:    s_wait_expcnt 0x0
+; GFX12-GI-NEXT:    s_wait_samplecnt 0x0
+; GFX12-GI-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-GI-NEXT:    s_wait_kmcnt 0x0
+; GFX12-GI-NEXT:    s_cvt_i32_f32 s0, s0
+; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-GI-NEXT:    s_min_i32 s0, s0, 0x7f
+; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-GI-NEXT:    s_max_i32 s0, s0, 0xffffff80
+; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-GI-NEXT:    v_mov_b32_e32 v0, s0
+; GFX12-GI-NEXT:    s_setpc_b64 s[30:31]
+    %x = call i8 @llvm.fptosi.sat.i8.f32(float %f)
+    ret i8 %x
+}
+
+define i16 @test_s_signed_i16_f32(float inreg %f) nounwind {
+; GFX7-ISEL-LABEL: test_s_signed_i16_f32:
+; GFX7-ISEL:       ; %bb.0:
+; GFX7-ISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-ISEL-NEXT:    v_cvt_i32_f32_e32 v0, s16
+; GFX7-ISEL-NEXT:    s_movk_i32 s4, 0x8000
+; GFX7-ISEL-NEXT:    v_mov_b32_e32 v1, 0x7fff
+; GFX7-ISEL-NEXT:    v_med3_i32 v0, v0, s4, v1
+; GFX7-ISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX7-GI-LABEL: test_s_signed_i16_f32:
+; GFX7-GI:       ; %bb.0:
+; GFX7-GI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-GI-NEXT:    v_cvt_i32_f32_e32 v0, s16
+; GFX7-GI-NEXT:    v_mov_b32_e32 v1, 0x7fff
+; GFX7-GI-NEXT:    v_mov_b32_e32 v2, 0xffff8000
+; GFX7-GI-NEXT:    v_med3_i32 v0, v0, v2, v1
+; GFX7-GI-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX9-LABEL: test_s_signed_i16_f32:
+; GFX9:       ; %bb.0:
+; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    v_cvt_i32_f32_e32 v0, s16
+; GFX9-NEXT:    s_movk_i32 s4, 0x8000
+; GFX9-NEXT:    v_mov_b32_e32 v1, 0x7fff
+; GFX9-NEXT:    v_med3_i32 v0, v0, s4, v1
+; GFX9-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11-LABEL: test_s_signed_i16_f32:
+; GFX11:       ; %bb.0:
+; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-NEXT:    v_cvt_i32_f32_e32 v0, s0
+; GFX11-NEXT:    s_movk_i32 s0, 0x8000
+; GFX11-NEXT:    v_med3_i32 v0, v0, s0, 0x7fff
+; GFX11-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-ISEL-LABEL: test_s_signed_i16_f32:
+; GFX12-ISEL:       ; %bb.0:
+; GFX12-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX12-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX12-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX12-ISEL-NEXT:    v_mov_b32_e32 v0, 0x7fff
+; GFX12-ISEL-NEXT:    s_cvt_i32_f32 s0, s0
+; GFX12-ISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-ISEL-NEXT:    v_med3_i32 v0, 0xffff8000, s0, v0
+; GFX12-ISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-GI-LABEL: test_s_signed_i16_f32:
+; GFX12-GI:       ; %bb.0:
+; GFX12-GI-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-GI-NEXT:    s_wait_expcnt 0x0
+; GFX12-GI-NEXT:    s_wait_samplecnt 0x0
+; GFX12-GI-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-GI-NEXT:    s_wait_kmcnt 0x0
+; GFX12-GI-NEXT:    s_cvt_i32_f32 s0, s0
+; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-GI-NEXT:    s_min_i32 s0, s0, 0x7fff
+; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-GI-NEXT:    s_max_i32 s0, s0, 0xffff8000
+; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-GI-NEXT:    v_mov_b32_e32 v0, s0
+; GFX12-GI-NEXT:    s_setpc_b64 s[30:31]
+    %x = call i16 @llvm.fptosi.sat.i16.f32(float %f)
+    ret i16 %x
+}
+
+define i32 @test_s_signed_i32_f32(float inreg %f) nounwind {
+; GFX7-LABEL: test_s_signed_i32_f32:
+; GFX7:       ; %bb.0:
+; GFX7-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-NEXT:    v_cvt_i32_f32_e32 v0, s16
+; GFX7-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX9-LABEL: test_s_signed_i32_f32:
+; GFX9:       ; %bb.0:
+; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    v_cvt_i32_f32_e32 v0, s16
+; GFX9-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11-LABEL: test_s_signed_i32_f32:
+; GFX11:       ; %bb.0:
+; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-NEXT:    v_cvt_i32_f32_e32 v0, s0
+; GFX11-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-LABEL: test_s_signed_i32_f32:
+; GFX12:       ; %bb.0:
+; GFX12-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-NEXT:    s_wait_expcnt 0x0
+; GFX12-NEXT:    s_wait_samplecnt 0x0
+; GFX12-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-NEXT:    s_wait_kmcnt 0x0
+; GFX12-NEXT:    s_cvt_i32_f32 s0, s0
+; GFX12-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-NEXT:    v_mov_b32_e32 v0, s0
+; GFX12-NEXT:    s_setpc_b64 s[30:31]
+    %x = call i32 @llvm.fptosi.sat.i32.f32(float %f)
+    ret i32 %x
+}
+
+define i64 @test_s_signed_i64_f32(float inreg %f) nounwind {
+; GFX7-ISEL-LABEL: test_s_signed_i64_f32:
+; GFX7-ISEL:       ; %bb.0:
+; GFX7-ISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-ISEL-NEXT:    v_trunc_f32_e32 v0, s16
+; GFX7-ISEL-NEXT:    s_mov_b32 s4, 0x2f800000
+; GFX7-ISEL-NEXT:    v_mul_f32_e64 v1, |v0|, s4
+; GFX7-ISEL-NEXT:    v_floor_f32_e32 v1, v1
+; GFX7-ISEL-NEXT:    s_mov_b32 s4, 0xcf800000
+; GFX7-ISEL-NEXT:    v_fma_f32 v2, v1, s4, |v0|
+; GFX7-ISEL-NEXT:    v_cvt_u32_f32_e32 v2, v2
+; GFX7-ISEL-NEXT:    v_cvt_u32_f32_e32 v1, v1
+; GFX7-ISEL-NEXT:    v_readfirstlane_b32 s6, v0
+; GFX7-ISEL-NEXT:    s_ashr_i32 s6, s6, 31
+; GFX7-ISEL-NEXT:    v_readfirstlane_b32 s4, v2
+; GFX7-ISEL-NEXT:    v_readfirstlane_b32 s5, v1
+; GFX7-ISEL-NEXT:    s_mov_b32 s7, s6
+; GFX7-ISEL-NEXT:    s_xor_b64 s[4:5], s[4:5], s[6:7]
+; GFX7-ISEL-NEXT:    s_sub_u32 s7, s4, s6
+; GFX7-ISEL-NEXT:    v_mov_b32_e32 v0, 0xdf000000
+; GFX7-ISEL-NEXT:    s_subb_u32 s10, s5, s6
+; GFX7-ISEL-NEXT:    v_cmp_nge_f32_e32 vcc, s16, v0
+; GFX7-ISEL-NEXT:    s_and_b64 s[4:5], vcc, exec
+; GFX7-ISEL-NEXT:    v_mov_b32_e32 v0, 0x5effffff
+; GFX7-ISEL-NEXT:    v_cmp_gt_f32_e64 s[4:5], s16, v0
+; GFX7-ISEL-NEXT:    s_cselect_b32 s8, 0, s7
+; GFX7-ISEL-NEXT:    s_and_b64 s[6:7], s[4:5], exec
+; GFX7-ISEL-NEXT:    v_cmp_u_f32_e64 s[6:7], s16, s16
+; GFX7-ISEL-NEXT:    s_cselect_b32 s11, -1, s8
+; GFX7-ISEL-NEXT:    s_and_b64 s[8:9], s[6:7], exec
+; GFX7-ISEL-NEXT:    s_cselect_b32 s11, 0, s11
+; GFX7-ISEL-NEXT:    s_and_b64 s[8:9], vcc, exec
+; GFX7-ISEL-NEXT:    s_cselect_b32 s8, 0x80000000, s10
+; GFX7-ISEL-NEXT:    s_and_b64 s[4:5], s[4:5], exec
+; GFX7-ISEL-NEXT:    s_cselect_b32 s8, 0x7fffffff, s8
+; GFX7-ISEL-NEXT:    s_and_b64 s[4:5], s[6:7], exec
+; GFX7-ISEL-NEXT:    s_cselect_b32 s4, 0, s8
+; GFX7-ISEL-NEXT:    v_mov_b32_e32 v0, s11
+; GFX7-ISEL-NEXT:    v_mov_b32_e32 v1, s4
+; GFX7-ISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX7-GI-LABEL: test_s_signed_i64_f32:
+; GFX7-GI:       ; %bb.0:
+; GFX7-GI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-GI-NEXT:    v_trunc_f32_e32 v0, s16
+; GFX7-GI-NEXT:    v_mov_b32_e32 v1, 0x2f800000
+; GFX7-GI-NEXT:    v_mul_f32_e64 v1, |v0|, v1
+; GFX7-GI-NEXT:    v_floor_f32_e32 v1, v1
+; GFX7-GI-NEXT:    v_mov_b32_e32 v2, 0xcf800000
+; GFX7-GI-NEXT:    v_fma_f32 v0, v1, v2, |v0|
+; GFX7-GI-NEXT:    v_cvt_u32_f32_e32 v0, v0
+; GFX7-GI-NEXT:    v_cvt_u32_f32_e32 v1, v1
+; GFX7-GI-NEXT:    s_ashr_i32 s4, s16, 31
+; GFX7-GI-NEXT:    v_mov_b32_e32 v2, s4
+; GFX7-GI-NEXT:    v_xor_b32_e32 v0, s4, v0
+; GFX7-GI-NEXT:    v_xor_b32_e32 v1, s4, v1
+; GFX7-GI-NEXT:    v_subrev_i32_e32 v0, vcc, s4, v0
+; GFX7-GI-NEXT:    v_subb_u32_e32 v1, vcc, v1, v2, vcc
+; GFX7-GI-NEXT:    v_mov_b32_e32 v2, 0xdf000000
+; GFX7-GI-NEXT:    v_bfrev_b32_e32 v3, 1
+; GFX7-GI-NEXT:    v_cmp_nge_f32_e32 vcc, s16, v2
+; GFX7-GI-NEXT:    v_mov_b32_e32 v2, 0x5effffff
+; GFX7-GI-NEXT:    v_cndmask_b32_e64 v0, v0, 0, vcc
+; GFX7-GI-NEXT:    v_cndmask_b32_e32 v1, v1, v3, vcc
+; GFX7-GI-NEXT:    v_bfrev_b32_e32 v3, -2
+; GFX7-GI-NEXT:    v_cmp_gt_f32_e32 vcc, s16, v2
+; GFX7-GI-NEXT:    v_cndmask_b32_e64 v0, v0, -1, vcc
+; GFX7-GI-NEXT:    v_cndmask_b32_e32 v1, v1, v3, vcc
+; GFX7-GI-NEXT:    v_cmp_u_f32_e64 s[4:5], s16, s16
+; GFX7-GI-NEXT:    v_cndmask_b32_e64 v0, v0, 0, s[4:5]
+; GFX7-GI-NEXT:    v_cndmask_b32_e64 v1, v1, 0, s[4:5]
+; GFX7-GI-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX9-LABEL: test_s_signed_i64_f32:
+; GFX9:       ; %bb.0:
+; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    v_trunc_f32_e32 v0, s16
+; GFX9-NEXT:    s_mov_b32 s4, 0x2f800000
+; GFX9-NEXT:    v_mul_f32_e64 v1, |v0|, s4
+; GFX9-NEXT:    v_floor_f32_e32 v1, v1
+; GFX9-NEXT:    s_mov_b32 s4, 0xcf800000
+; GFX9-NEXT:    v_fma_f32 v2, v1, s4, |v0|
+; GFX9-NEXT:    v_cvt_u32_f32_e32 v2, v2
+; GFX9-NEXT:    v_cvt_u32_f32_e32 v1, v1
+; GFX9-NEXT:    v_readfirstlane_b32 s6, v0
+; GFX9-NEXT:    s_ashr_i32 s6, s6, 31
+; GFX9-NEXT:    v_readfirstlane_b32 s4, v2
+; GFX9-NEXT:    v_readfirstlane_b32 s5, v1
+; GFX9-NEXT:    s_mov_b32 s7, s6
+; GFX9-NEXT:    s_xor_b64 s[4:5], s[4:5], s[6:7]
+; GFX9-NEXT:    s_sub_u32 s7, s4, s6
+; GFX9-NEXT:    v_mov_b32_e32 v0, 0xdf000000
+; GFX9-NEXT:    s_subb_u32 s10, s5, s6
+; GFX9-NEXT:    v_cmp_nge_f32_e32 vcc, s16, v0
+; GFX9-NEXT:    s_and_b64 s[4:5], vcc, exec
+; GFX9-NEXT:    v_mov_b32_e32 v0, 0x5effffff
+; GFX9-NEXT:    v_cmp_gt_f32_e64 s[4:5], s16, v0
+; GFX9-NEXT:    s_cselect_b32 s8, 0, s7
+; GFX9-NEXT:    s_and_b64 s[6:7], s[4:5], exec
+; GFX9-NEXT:    v_cmp_u_f32_e64 s[6:7], s16, s16
+; GFX9-NEXT:    s_cselect_b32 s11, -1, s8
+; GFX9-NEXT:    s_and_b64 s[8:9], s[6:7], exec
+; GFX9-NEXT:    s_cselect_b32 s11, 0, s11
+; GFX9-NEXT:    s_and_b64 s[8:9], vcc, exec
+; GFX9-NEXT:    s_cselect_b32 s8, 0x80000000, s10
+; GFX9-NEXT:    s_and_b64 s[4:5], s[4:5], exec
+; GFX9-NEXT:    s_cselect_b32 s8, 0x7fffffff, s8
+; GFX9-NEXT:    s_and_b64 s[4:5], s[6:7], exec
+; GFX9-NEXT:    s_cselect_b32 s4, 0, s8
+; GFX9-NEXT:    v_mov_b32_e32 v0, s11
+; GFX9-NEXT:    v_mov_b32_e32 v1, s4
+; GFX9-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11-LABEL: test_s_signed_i64_f32:
+; GFX11:       ; %bb.0:
+; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-NEXT:    v_trunc_f32_e32 v0, s0
+; GFX11-NEXT:    v_cmp_lt_f32_e64 s6, 0x5effffff, s0
+; GFX11-NEXT:    v_mul_f32_e64 v1, 0x2f800000, |v0|
+; GFX11-NEXT:    v_readfirstlane_b32 s1, v0
+; GFX11-NEXT:    v_floor_f32_e32 v1, v1
+; GFX11-NEXT:    s_ashr_i32 s4, s1, 31
+; GFX11-NEXT:    v_cmp_nle_f32_e64 s1, 0xdf000000, s0
+; GFX11-NEXT:    s_mov_b32 s5, s4
+; GFX11-NEXT:    v_cmp_u_f32_e64 s0, s0, s0
+; GFX11-NEXT:    v_fma_f32 v2, 0xcf800000, v1, |v0|
+; GFX11-NEXT:    v_cvt_u32_f32_e32 v1, v1
+; GFX11-NEXT:    v_cvt_u32_f32_e32 v2, v2
+; GFX11-NEXT:    v_readfirstlane_b32 s3, v1
+; GFX11-NEXT:    v_readfirstlane_b32 s2, v2
+; GFX11-NEXT:    s_xor_b64 s[2:3], s[2:3], s[4:5]
+; GFX11-NEXT:    s_sub_u32 s2, s2, s4
+; GFX11-NEXT:    s_subb_u32 s3, s3, s4
+; GFX11-NEXT:    s_and_b32 s4, s1, exec_lo
+; GFX11-NEXT:    s_cselect_b32 s2, 0, s2
+; GFX11-NEXT:    s_and_b32 s4, s6, exec_lo
+; GFX11-NEXT:    s_cselect_b32 s2, -1, s2
+; GFX11-NEXT:    s_and_b32 s4, s0, exec_lo
+; GFX11-NEXT:    s_cselect_b32 s2, 0, s2
+; GFX11-NEXT:    s_and_b32 s1, s1, exec_lo
+; GFX11-NEXT:    s_cselect_b32 s1, 0x80000000, s3
+; GFX11-NEXT:    s_and_b32 s3, s6, exec_lo
+; GFX11-NEXT:    s_cselect_b32 s1, 0x7fffffff, s1
+; GFX11-NEXT:    s_and_b32 s0, s0, exec_lo
+; GFX11-NEXT:    s_cselect_b32 s0, 0, s1
+; GFX11-NEXT:    v_dual_mov_b32 v0, s2 :: v_dual_mov_b32 v1, s0
+; GFX11-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-ISEL-LABEL: test_s_signed_i64_f32:
+; GFX12-ISEL:       ; %bb.0:
+; GFX12-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX12-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX12-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX12-ISEL-NEXT:    s_trunc_f32 s1, s0
+; GFX12-ISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-ISEL-NEXT:    s_and_b32 s3, s1, 0x7fffffff
+; GFX12-ISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-ISEL-NEXT:    s_mul_f32 s2, s3, 0x2f800000
+; GFX12-ISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-ISEL-NEXT:    s_floor_f32 s4, s2
+; GFX12-ISEL-NEXT:    s_ashr_i32 s2, s1, 31
+; GFX12-ISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-ISEL-NEXT:    s_fmac_f32 s3, s4, 0xcf800000
+; GFX12-ISEL-NEXT:    s_cvt_u32_f32 s5, s4
+; GFX12-ISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-ISEL-NEXT:    s_cvt_u32_f32 s4, s3
+; GFX12-ISEL-NEXT:    s_mov_b32 s3, s2
+; GFX12-ISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-ISEL-NEXT:    s_xor_b64 s[4:5], s[4:5], s[2:3]
+; GFX12-ISEL-NEXT:    s_cmp_nge_f32 s0, 0xdf000000
+; GFX12-ISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-ISEL-NEXT:    s_sub_nc_u64 s[2:3], s[4:5], s[2:3]
+; GFX12-ISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-ISEL-NEXT:    s_cselect_b32 s1, 0, s2
+; GFX12-ISEL-NEXT:    s_cselect_b32 s2, 0x80000000, s3
+; GFX12-ISEL-NEXT:    s_cmp_gt_f32 s0, 0x5effffff
+; GFX12-ISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-ISEL-NEXT:    s_cselect_b32 s2, 0x7fffffff, s2
+; GFX12-ISEL-NEXT:    s_cselect_b32 s1, -1, s1
+; GFX12-ISEL-NEXT:    s_cmp_u_f32 s0, s0
+; GFX12-ISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-ISEL-NEXT:    s_cselect_b32 s0, 0, s1
+; GFX12-ISEL-NEXT:    s_cselect_b32 s1, 0, s2
+; GFX12-ISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-ISEL-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
+; GFX12-ISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-GI-LABEL: test_s_signed_i64_f32:
+; GFX12-GI:       ; %bb.0:
+; GFX12-GI-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-GI-NEXT:    s_wait_expcnt 0x0
+; GFX12-GI-NEXT:    s_wait_samplecnt 0x0
+; GFX12-GI-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-GI-NEXT:    s_wait_kmcnt 0x0
+; GFX12-GI-NEXT:    s_trunc_f32 s1, s0
+; GFX12-GI-NEXT:    s_mov_b32 s6, 0
+; GFX12-GI-NEXT:    s_brev_b32 s7, 1
+; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-GI-NEXT:    s_bitset0_b32 s1, 31
+; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-GI-NEXT:    s_mul_f32 s2, s1, 0x2f800000
+; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-GI-NEXT:    s_floor_f32 s3, s2
+; GFX12-GI-NEXT:    s_ashr_i32 s2, s0, 31
+; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-GI-NEXT:    s_fmac_f32 s1, s3, 0xcf800000
+; GFX12-GI-NEXT:    s_cvt_u32_f32 s5, s3
+; GFX12-GI-NEXT:    s_mov_b32 s3, s2
+; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-GI-NEXT:    s_cvt_u32_f32 s4, s1
+; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-GI-NEXT:    s_xor_b64 s[4:5], s[4:5], s[2:3]
+; GFX12-GI-NEXT:    s_cmp_nge_f32 s0, 0xdf000000
+; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-GI-NEXT:    s_sub_nc_u64 s[2:3], s[4:5], s[2:3]
+; GFX12-GI-NEXT:    s_mov_b32 s4, -1
+; GFX12-GI-NEXT:    s_brev_b32 s5, -2
+; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-GI-NEXT:    s_cselect_b64 s[2:3], s[6:7], s[2:3]
+; GFX12-GI-NEXT:    s_cmp_gt_f32 s0, 0x5effffff
+; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-GI-NEXT:    s_cselect_b64 s[2:3], s[4:5], s[2:3]
+; GFX12-GI-NEXT:    s_cmp_u_f32 s0, s0
+; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-GI-NEXT:    s_cselect_b64 s[0:1], 0, s[2:3]
+; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-GI-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
+; GFX12-GI-NEXT:    s_setpc_b64 s[30:31]
+    %x = call i64 @llvm.fptosi.sat.i64.f32(float %f)
+    ret i64 %x
+}
+
 ;
 ; 64-bit float to signed integer
 ;
@@ -774,6 +1231,372 @@ define i64 @test_signed_i64_f64(double %f) nounwind {
 ; GFX12-GI-NEXT:    v_cndmask_b32_e64 v1, v0, 0x7fffffff, s0
 ; GFX12-GI-NEXT:    v_cndmask_b32_e64 v0, v2, 0, s1
 ; GFX12-GI-NEXT:    v_cndmask_b32_e64 v1, v1, 0, s1
+; GFX12-GI-NEXT:    s_setpc_b64 s[30:31]
+    %x = call i64 @llvm.fptosi.sat.i64.f64(double %f)
+    ret i64 %x
+}
+
+define i1 @test_s_signed_i1_f64(double inreg %f) nounwind {
+; GFX7-LABEL: test_s_signed_i1_f64:
+; GFX7:       ; %bb.0:
+; GFX7-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-NEXT:    v_cvt_i32_f64_e32 v0, s[16:17]
+; GFX7-NEXT:    v_med3_i32 v0, v0, -1, 0
+; GFX7-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX9-LABEL: test_s_signed_i1_f64:
+; GFX9:       ; %bb.0:
+; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    v_cvt_i32_f64_e32 v0, s[16:17]
+; GFX9-NEXT:    v_med3_i32 v0, v0, -1, 0
+; GFX9-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11-LABEL: test_s_signed_i1_f64:
+; GFX11:       ; %bb.0:
+; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-NEXT:    v_cvt_i32_f64_e32 v0, s[0:1]
+; GFX11-NEXT:    v_med3_i32 v0, v0, -1, 0
+; GFX11-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-LABEL: test_s_signed_i1_f64:
+; GFX12:       ; %bb.0:
+; GFX12-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-NEXT:    s_wait_expcnt 0x0
+; GFX12-NEXT:    s_wait_samplecnt 0x0
+; GFX12-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-NEXT:    s_wait_kmcnt 0x0
+; GFX12-NEXT:    v_cvt_i32_f64_e32 v0, s[0:1]
+; GFX12-NEXT:    v_med3_i32 v0, v0, -1, 0
+; GFX12-NEXT:    s_setpc_b64 s[30:31]
+    %x = call i1 @llvm.fptosi.sat.i1.f64(double %f)
+    ret i1 %x
+}
+
+define i8 @test_s_signed_i8_f64(double inreg %f) nounwind {
+; GFX7-ISEL-LABEL: test_s_signed_i8_f64:
+; GFX7-ISEL:       ; %bb.0:
+; GFX7-ISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-ISEL-NEXT:    v_cvt_i32_f64_e32 v0, s[16:17]
+; GFX7-ISEL-NEXT:    s_movk_i32 s4, 0xff80
+; GFX7-ISEL-NEXT:    v_mov_b32_e32 v1, 0x7f
+; GFX7-ISEL-NEXT:    v_med3_i32 v0, v0, s4, v1
+; GFX7-ISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX7-GI-LABEL: test_s_signed_i8_f64:
+; GFX7-GI:       ; %bb.0:
+; GFX7-GI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-GI-NEXT:    v_cvt_i32_f64_e32 v0, s[16:17]
+; GFX7-GI-NEXT:    v_mov_b32_e32 v1, 0x7f
+; GFX7-GI-NEXT:    v_mov_b32_e32 v2, 0xffffff80
+; GFX7-GI-NEXT:    v_med3_i32 v0, v0, v2, v1
+; GFX7-GI-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX9-LABEL: test_s_signed_i8_f64:
+; GFX9:       ; %bb.0:
+; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    v_cvt_i32_f64_e32 v0, s[16:17]
+; GFX9-NEXT:    s_movk_i32 s4, 0xff80
+; GFX9-NEXT:    v_mov_b32_e32 v1, 0x7f
+; GFX9-NEXT:    v_med3_i32 v0, v0, s4, v1
+; GFX9-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11-LABEL: test_s_signed_i8_f64:
+; GFX11:       ; %bb.0:
+; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-NEXT:    v_cvt_i32_f64_e32 v0, s[0:1]
+; GFX11-NEXT:    s_movk_i32 s0, 0xff80
+; GFX11-NEXT:    v_med3_i32 v0, v0, s0, 0x7f
+; GFX11-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-ISEL-LABEL: test_s_signed_i8_f64:
+; GFX12-ISEL:       ; %bb.0:
+; GFX12-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX12-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX12-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX12-ISEL-NEXT:    v_cvt_i32_f64_e32 v0, s[0:1]
+; GFX12-ISEL-NEXT:    s_movk_i32 s0, 0xff80
+; GFX12-ISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-ISEL-NEXT:    v_med3_i32 v0, v0, s0, 0x7f
+; GFX12-ISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-GI-LABEL: test_s_signed_i8_f64:
+; GFX12-GI:       ; %bb.0:
+; GFX12-GI-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-GI-NEXT:    s_wait_expcnt 0x0
+; GFX12-GI-NEXT:    s_wait_samplecnt 0x0
+; GFX12-GI-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-GI-NEXT:    s_wait_kmcnt 0x0
+; GFX12-GI-NEXT:    v_cvt_i32_f64_e32 v0, s[0:1]
+; GFX12-GI-NEXT:    v_mov_b32_e32 v1, 0xffffff80
+; GFX12-GI-NEXT:    v_med3_i32 v0, v0, v1, 0x7f
+; GFX12-GI-NEXT:    s_setpc_b64 s[30:31]
+    %x = call i8 @llvm.fptosi.sat.i8.f64(double %f)
+    ret i8 %x
+}
+
+define i16 @test_s_signed_i16_f64(double inreg %f) nounwind {
+; GFX7-ISEL-LABEL: test_s_signed_i16_f64:
+; GFX7-ISEL:       ; %bb.0:
+; GFX7-ISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-ISEL-NEXT:    v_cvt_i32_f64_e32 v0, s[16:17]
+; GFX7-ISEL-NEXT:    s_movk_i32 s4, 0x8000
+; GFX7-ISEL-NEXT:    v_mov_b32_e32 v1, 0x7fff
+; GFX7-ISEL-NEXT:    v_med3_i32 v0, v0, s4, v1
+; GFX7-ISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX7-GI-LABEL: test_s_signed_i16_f64:
+; GFX7-GI:       ; %bb.0:
+; GFX7-GI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-GI-NEXT:    v_cvt_i32_f64_e32 v0, s[16:17]
+; GFX7-GI-NEXT:    v_mov_b32_e32 v1, 0x7fff
+; GFX7-GI-NEXT:    v_mov_b32_e32 v2, 0xffff8000
+; GFX7-GI-NEXT:    v_med3_i32 v0, v0, v2, v1
+; GFX7-GI-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX9-LABEL: test_s_signed_i16_f64:
+; GFX9:       ; %bb.0:
+; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    v_cvt_i32_f64_e32 v0, s[16:17]
+; GFX9-NEXT:    s_movk_i32 s4, 0x8000
+; GFX9-NEXT:    v_mov_b32_e32 v1, 0x7fff
+; GFX9-NEXT:    v_med3_i32 v0, v0, s4, v1
+; GFX9-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11-LABEL: test_s_signed_i16_f64:
+; GFX11:       ; %bb.0:
+; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-NEXT:    v_cvt_i32_f64_e32 v0, s[0:1]
+; GFX11-NEXT:    s_movk_i32 s0, 0x8000
+; GFX11-NEXT:    v_med3_i32 v0, v0, s0, 0x7fff
+; GFX11-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-ISEL-LABEL: test_s_signed_i16_f64:
+; GFX12-ISEL:       ; %bb.0:
+; GFX12-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX12-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX12-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX12-ISEL-NEXT:    v_cvt_i32_f64_e32 v0, s[0:1]
+; GFX12-ISEL-NEXT:    s_movk_i32 s0, 0x8000
+; GFX12-ISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-ISEL-NEXT:    v_med3_i32 v0, v0, s0, 0x7fff
+; GFX12-ISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-GI-LABEL: test_s_signed_i16_f64:
+; GFX12-GI:       ; %bb.0:
+; GFX12-GI-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-GI-NEXT:    s_wait_expcnt 0x0
+; GFX12-GI-NEXT:    s_wait_samplecnt 0x0
+; GFX12-GI-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-GI-NEXT:    s_wait_kmcnt 0x0
+; GFX12-GI-NEXT:    v_cvt_i32_f64_e32 v0, s[0:1]
+; GFX12-GI-NEXT:    v_mov_b32_e32 v1, 0xffff8000
+; GFX12-GI-NEXT:    v_med3_i32 v0, v0, v1, 0x7fff
+; GFX12-GI-NEXT:    s_setpc_b64 s[30:31]
+    %x = call i16 @llvm.fptosi.sat.i16.f64(double %f)
+    ret i16 %x
+}
+
+define i32 @test_s_signed_i32_f64(double inreg %f) nounwind {
+; GFX7-LABEL: test_s_signed_i32_f64:
+; GFX7:       ; %bb.0:
+; GFX7-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-NEXT:    v_cvt_i32_f64_e32 v0, s[16:17]
+; GFX7-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX9-LABEL: test_s_signed_i32_f64:
+; GFX9:       ; %bb.0:
+; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    v_cvt_i32_f64_e32 v0, s[16:17]
+; GFX9-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11-LABEL: test_s_signed_i32_f64:
+; GFX11:       ; %bb.0:
+; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-NEXT:    v_cvt_i32_f64_e32 v0, s[0:1]
+; GFX11-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-LABEL: test_s_signed_i32_f64:
+; GFX12:       ; %bb.0:
+; GFX12-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-NEXT:    s_wait_expcnt 0x0
+; GFX12-NEXT:    s_wait_samplecnt 0x0
+; GFX12-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-NEXT:    s_wait_kmcnt 0x0
+; GFX12-NEXT:    v_cvt_i32_f64_e32 v0, s[0:1]
+; GFX12-NEXT:    s_setpc_b64 s[30:31]
+    %x = call i32 @llvm.fptosi.sat.i32.f64(double %f)
+    ret i32 %x
+}
+
+define i64 @test_s_signed_i64_f64(double inreg %f) nounwind {
+; GFX7-ISEL-LABEL: test_s_signed_i64_f64:
+; GFX7-ISEL:       ; %bb.0:
+; GFX7-ISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-ISEL-NEXT:    v_trunc_f64_e32 v[0:1], s[16:17]
+; GFX7-ISEL-NEXT:    s_movk_i32 s4, 0xffe0
+; GFX7-ISEL-NEXT:    v_mov_b32_e32 v4, 0
+; GFX7-ISEL-NEXT:    v_mov_b32_e32 v5, 0xc3e00000
+; GFX7-ISEL-NEXT:    v_mov_b32_e32 v6, -1
+; GFX7-ISEL-NEXT:    v_mov_b32_e32 v7, 0x43dfffff
+; GFX7-ISEL-NEXT:    v_cmp_nge_f64_e32 vcc, s[16:17], v[4:5]
+; GFX7-ISEL-NEXT:    v_cmp_u_f64_e64 s[6:7], s[16:17], s[16:17]
+; GFX7-ISEL-NEXT:    v_ldexp_f64 v[2:3], v[0:1], s4
+; GFX7-ISEL-NEXT:    s_mov_b32 s4, 0
+; GFX7-ISEL-NEXT:    s_mov_b32 s5, 0xc1f00000
+; GFX7-ISEL-NEXT:    v_bfrev_b32_e32 v8, 1
+; GFX7-ISEL-NEXT:    v_floor_f64_e32 v[2:3], v[2:3]
+; GFX7-ISEL-NEXT:    v_fma_f64 v[0:1], v[2:3], s[4:5], v[0:1]
+; GFX7-ISEL-NEXT:    v_cmp_gt_f64_e64 s[4:5], s[16:17], v[6:7]
+; GFX7-ISEL-NEXT:    v_cvt_i32_f64_e32 v9, v[2:3]
+; GFX7-ISEL-NEXT:    v_bfrev_b32_e32 v2, -2
+; GFX7-ISEL-NEXT:    v_cndmask_b32_e32 v3, v9, v8, vcc
+; GFX7-ISEL-NEXT:    v_cvt_u32_f64_e32 v0, v[0:1]
+; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v2, v3, v2, s[4:5]
+; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v1, v2, 0, s[6:7]
+; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v0, v0, 0, vcc
+; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v0, v0, -1, s[4:5]
+; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v0, v0, 0, s[6:7]
+; GFX7-ISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX7-GI-LABEL: test_s_signed_i64_f64:
+; GFX7-GI:       ; %bb.0:
+; GFX7-GI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-GI-NEXT:    v_trunc_f64_e32 v[0:1], s[16:17]
+; GFX7-GI-NEXT:    v_mov_b32_e32 v2, 0
+; GFX7-GI-NEXT:    v_mov_b32_e32 v3, 0x3df00000
+; GFX7-GI-NEXT:    v_mov_b32_e32 v4, 0
+; GFX7-GI-NEXT:    v_mov_b32_e32 v5, 0xc1f00000
+; GFX7-GI-NEXT:    v_cmp_u_f64_e64 s[6:7], s[16:17], s[16:17]
+; GFX7-GI-NEXT:    v_mul_f64 v[2:3], v[0:1], v[2:3]
+; GFX7-GI-NEXT:    v_floor_f64_e32 v[2:3], v[2:3]
+; GFX7-GI-NEXT:    v_fma_f64 v[0:1], v[2:3], v[4:5], v[0:1]
+; GFX7-GI-NEXT:    v_mov_b32_e32 v4, -1
+; GFX7-GI-NEXT:    v_mov_b32_e32 v5, 0x43dfffff
+; GFX7-GI-NEXT:    v_cmp_gt_f64_e64 s[4:5], s[16:17], v[4:5]
+; GFX7-GI-NEXT:    v_cvt_u32_f64_e32 v6, v[0:1]
+; GFX7-GI-NEXT:    v_mov_b32_e32 v0, 0
+; GFX7-GI-NEXT:    v_mov_b32_e32 v1, 0xc3e00000
+; GFX7-GI-NEXT:    v_cmp_nge_f64_e32 vcc, s[16:17], v[0:1]
+; GFX7-GI-NEXT:    v_cvt_i32_f64_e32 v1, v[2:3]
+; GFX7-GI-NEXT:    v_bfrev_b32_e32 v2, 1
+; GFX7-GI-NEXT:    v_bfrev_b32_e32 v3, -2
+; GFX7-GI-NEXT:    v_cndmask_b32_e64 v0, v6, 0, vcc
+; GFX7-GI-NEXT:    v_cndmask_b32_e32 v1, v1, v2, vcc
+; GFX7-GI-NEXT:    v_cndmask_b32_e64 v0, v0, -1, s[4:5]
+; GFX7-GI-NEXT:    v_cndmask_b32_e64 v1, v1, v3, s[4:5]
+; GFX7-GI-NEXT:    v_cndmask_b32_e64 v0, v0, 0, s[6:7]
+; GFX7-GI-NEXT:    v_cndmask_b32_e64 v1, v1, 0, s[6:7]
+; GFX7-GI-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX9-LABEL: test_s_signed_i64_f64:
+; GFX9:       ; %bb.0:
+; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    v_trunc_f64_e32 v[0:1], s[16:17]
+; GFX9-NEXT:    s_movk_i32 s4, 0xffe0
+; GFX9-NEXT:    v_mov_b32_e32 v4, 0
+; GFX9-NEXT:    v_mov_b32_e32 v5, 0xc3e00000
+; GFX9-NEXT:    v_mov_b32_e32 v6, -1
+; GFX9-NEXT:    v_mov_b32_e32 v7, 0x43dfffff
+; GFX9-NEXT:    v_cmp_nge_f64_e32 vcc, s[16:17], v[4:5]
+; GFX9-NEXT:    v_cmp_u_f64_e64 s[6:7], s[16:17], s[16:17]
+; GFX9-NEXT:    v_ldexp_f64 v[2:3], v[0:1], s4
+; GFX9-NEXT:    s_mov_b32 s4, 0
+; GFX9-NEXT:    s_mov_b32 s5, 0xc1f00000
+; GFX9-NEXT:    v_bfrev_b32_e32 v8, 1
+; GFX9-NEXT:    v_floor_f64_e32 v[2:3], v[2:3]
+; GFX9-NEXT:    v_fma_f64 v[0:1], v[2:3], s[4:5], v[0:1]
+; GFX9-NEXT:    v_cmp_gt_f64_e64 s[4:5], s[16:17], v[6:7]
+; GFX9-NEXT:    v_cvt_i32_f64_e32 v9, v[2:3]
+; GFX9-NEXT:    v_bfrev_b32_e32 v2, -2
+; GFX9-NEXT:    v_cndmask_b32_e32 v3, v9, v8, vcc
+; GFX9-NEXT:    v_cvt_u32_f64_e32 v0, v[0:1]
+; GFX9-NEXT:    v_cndmask_b32_e64 v2, v3, v2, s[4:5]
+; GFX9-NEXT:    v_cndmask_b32_e64 v1, v2, 0, s[6:7]
+; GFX9-NEXT:    v_cndmask_b32_e64 v0, v0, 0, vcc
+; GFX9-NEXT:    v_cndmask_b32_e64 v0, v0, -1, s[4:5]
+; GFX9-NEXT:    v_cndmask_b32_e64 v0, v0, 0, s[6:7]
+; GFX9-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11-LABEL: test_s_signed_i64_f64:
+; GFX11:       ; %bb.0:
+; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-NEXT:    v_trunc_f64_e32 v[0:1], s[0:1]
+; GFX11-NEXT:    v_cmp_nle_f64_e64 s4, 0xc3e00000, s[0:1]
+; GFX11-NEXT:    s_mov_b32 s2, -1
+; GFX11-NEXT:    s_mov_b32 s3, 0x43dfffff
+; GFX11-NEXT:    v_cmp_gt_f64_e64 s2, s[0:1], s[2:3]
+; GFX11-NEXT:    v_cmp_u_f64_e64 s0, s[0:1], s[0:1]
+; GFX11-NEXT:    v_ldexp_f64 v[2:3], v[0:1], 0xffffffe0
+; GFX11-NEXT:    v_floor_f64_e32 v[2:3], v[2:3]
+; GFX11-NEXT:    v_fma_f64 v[0:1], 0xc1f00000, v[2:3], v[0:1]
+; GFX11-NEXT:    v_cvt_i32_f64_e32 v2, v[2:3]
+; GFX11-NEXT:    v_cvt_u32_f64_e32 v0, v[0:1]
+; GFX11-NEXT:    v_cndmask_b32_e64 v1, v2, 0x80000000, s4
+; GFX11-NEXT:    v_cndmask_b32_e64 v1, v1, 0x7fffffff, s2
+; GFX11-NEXT:    v_cndmask_b32_e64 v1, v1, 0, s0
+; GFX11-NEXT:    v_cndmask_b32_e64 v0, v0, 0, s4
+; GFX11-NEXT:    v_cndmask_b32_e64 v0, v0, -1, s2
+; GFX11-NEXT:    v_cndmask_b32_e64 v0, v0, 0, s0
+; GFX11-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-ISEL-LABEL: test_s_signed_i64_f64:
+; GFX12-ISEL:       ; %bb.0:
+; GFX12-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX12-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX12-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX12-ISEL-NEXT:    v_trunc_f64_e32 v[0:1], s[0:1]
+; GFX12-ISEL-NEXT:    v_cmp_nle_f64_e64 s4, 0xc3e00000, s[0:1]
+; GFX12-ISEL-NEXT:    s_mov_b32 s2, -1
+; GFX12-ISEL-NEXT:    s_mov_b32 s3, 0x43dfffff
+; GFX12-ISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-ISEL-NEXT:    v_cmp_gt_f64_e64 s2, s[0:1], s[2:3]
+; GFX12-ISEL-NEXT:    v_cmp_u_f64_e64 s0, s[0:1], s[0:1]
+; GFX12-ISEL-NEXT:    v_ldexp_f64 v[2:3], v[0:1], 0xffffffe0
+; GFX12-ISEL-NEXT:    v_floor_f64_e32 v[2:3], v[2:3]
+; GFX12-ISEL-NEXT:    v_fma_f64 v[0:1], 0xc1f00000, v[2:3], v[0:1]
+; GFX12-ISEL-NEXT:    v_cvt_i32_f64_e32 v2, v[2:3]
+; GFX12-ISEL-NEXT:    v_cvt_u32_f64_e32 v0, v[0:1]
+; GFX12-ISEL-NEXT:    s_wait_alu depctr_va_sdst(0)
+; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v1, v2, 0x80000000, s4
+; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v1, v1, 0x7fffffff, s2
+; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v1, v1, 0, s0
+; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v0, v0, 0, s4
+; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v0, v0, -1, s2
+; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v0, v0, 0, s0
+; GFX12-ISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-GI-LABEL: test_s_signed_i64_f64:
+; GFX12-GI:       ; %bb.0:
+; GFX12-GI-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-GI-NEXT:    s_wait_expcnt 0x0
+; GFX12-GI-NEXT:    s_wait_samplecnt 0x0
+; GFX12-GI-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-GI-NEXT:    s_wait_kmcnt 0x0
+; GFX12-GI-NEXT:    v_trunc_f64_e32 v[0:1], s[0:1]
+; GFX12-GI-NEXT:    v_cmp_nle_f64_e64 s2, 0xc3e00000, s[0:1]
+; GFX12-GI-NEXT:    v_mul_f64_e32 v[2:3], 0x3df00000, v[0:1]
+; GFX12-GI-NEXT:    v_floor_f64_e32 v[2:3], v[2:3]
+; GFX12-GI-NEXT:    v_fma_f64 v[0:1], 0xc1f00000, v[2:3], v[0:1]
+; GFX12-GI-NEXT:    v_cvt_i32_f64_e32 v2, v[2:3]
+; GFX12-GI-NEXT:    v_cvt_u32_f64_e32 v4, v[0:1]
+; GFX12-GI-NEXT:    v_mov_b32_e32 v0, -1
+; GFX12-GI-NEXT:    v_mov_b32_e32 v1, 0x43dfffff
+; GFX12-GI-NEXT:    v_cmp_gt_f64_e32 vcc_lo, s[0:1], v[0:1]
+; GFX12-GI-NEXT:    v_cmp_u_f64_e64 s0, s[0:1], s[0:1]
+; GFX12-GI-NEXT:    s_wait_alu depctr_va_sdst(0)
+; GFX12-GI-NEXT:    v_cndmask_b32_e64 v1, v2, 0x80000000, s2
+; GFX12-GI-NEXT:    v_cndmask_b32_e64 v3, v4, 0, s2
+; GFX12-GI-NEXT:    s_wait_alu depctr_va_vcc(0)
+; GFX12-GI-NEXT:    v_cndmask_b32_e64 v0, v3, -1, vcc_lo
+; GFX12-GI-NEXT:    v_cndmask_b32_e64 v1, v1, 0x7fffffff, vcc_lo
+; GFX12-GI-NEXT:    v_cndmask_b32_e64 v0, v0, 0, s0
+; GFX12-GI-NEXT:    v_cndmask_b32_e64 v1, v1, 0, s0
 ; GFX12-GI-NEXT:    s_setpc_b64 s[30:31]
     %x = call i64 @llvm.fptosi.sat.i64.f64(double %f)
     ret i64 %x
@@ -1155,6 +1978,360 @@ define i64 @test_signed_i64_f16(half %f) nounwind {
 ; GFX12-GI-NEXT:    v_cvt_f32_f16_e32 v0, v0.l
 ; GFX12-GI-NEXT:    v_mov_b32_e32 v1, 0
 ; GFX12-GI-NEXT:    v_cvt_i32_f32_e32 v0, v0
+; GFX12-GI-NEXT:    s_setpc_b64 s[30:31]
+    %x = call i64 @llvm.fptosi.sat.i64.f16(half %f)
+    ret i64 %x
+}
+
+define i1 @test_s_signed_i1_f16(half inreg %f) nounwind {
+; GFX7-LABEL: test_s_signed_i1_f16:
+; GFX7:       ; %bb.0:
+; GFX7-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-NEXT:    v_cvt_f32_f16_e32 v0, s16
+; GFX7-NEXT:    v_cvt_i32_f32_e32 v0, v0
+; GFX7-NEXT:    v_med3_i32 v0, v0, -1, 0
+; GFX7-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX9-LABEL: test_s_signed_i1_f16:
+; GFX9:       ; %bb.0:
+; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    v_cvt_i16_f16_e32 v0, s16
+; GFX9-NEXT:    v_bfe_i32 v0, v0, 0, 16
+; GFX9-NEXT:    v_med3_i32 v0, v0, -1, 0
+; GFX9-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11-FAKE16-LABEL: test_s_signed_i1_f16:
+; GFX11-FAKE16:       ; %bb.0:
+; GFX11-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-FAKE16-NEXT:    v_cvt_i16_f16_e32 v0, s0
+; GFX11-FAKE16-NEXT:    v_bfe_i32 v0, v0, 0, 16
+; GFX11-FAKE16-NEXT:    v_med3_i32 v0, v0, -1, 0
+; GFX11-FAKE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11-TRUE16-LABEL: test_s_signed_i1_f16:
+; GFX11-TRUE16:       ; %bb.0:
+; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-TRUE16-NEXT:    v_cvt_i16_f16_e32 v0.l, s0
+; GFX11-TRUE16-NEXT:    v_bfe_i32 v0, v0, 0, 16
+; GFX11-TRUE16-NEXT:    v_med3_i32 v0, v0, -1, 0
+; GFX11-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-FAKE16-LABEL: test_s_signed_i1_f16:
+; GFX12-FAKE16:       ; %bb.0:
+; GFX12-FAKE16-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-FAKE16-NEXT:    s_wait_expcnt 0x0
+; GFX12-FAKE16-NEXT:    s_wait_samplecnt 0x0
+; GFX12-FAKE16-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-FAKE16-NEXT:    s_wait_kmcnt 0x0
+; GFX12-FAKE16-NEXT:    v_cvt_i16_f16_e32 v0, s0
+; GFX12-FAKE16-NEXT:    v_bfe_i32 v0, v0, 0, 16
+; GFX12-FAKE16-NEXT:    v_med3_i32 v0, v0, -1, 0
+; GFX12-FAKE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-TRUE16-LABEL: test_s_signed_i1_f16:
+; GFX12-TRUE16:       ; %bb.0:
+; GFX12-TRUE16-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-TRUE16-NEXT:    s_wait_expcnt 0x0
+; GFX12-TRUE16-NEXT:    s_wait_samplecnt 0x0
+; GFX12-TRUE16-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-TRUE16-NEXT:    s_wait_kmcnt 0x0
+; GFX12-TRUE16-NEXT:    v_cvt_i16_f16_e32 v0.l, s0
+; GFX12-TRUE16-NEXT:    v_bfe_i32 v0, v0, 0, 16
+; GFX12-TRUE16-NEXT:    v_med3_i32 v0, v0, -1, 0
+; GFX12-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-GI-LABEL: test_s_signed_i1_f16:
+; GFX12-GI:       ; %bb.0:
+; GFX12-GI-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-GI-NEXT:    s_wait_expcnt 0x0
+; GFX12-GI-NEXT:    s_wait_samplecnt 0x0
+; GFX12-GI-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-GI-NEXT:    s_wait_kmcnt 0x0
+; GFX12-GI-NEXT:    s_cvt_f32_f16 s0, s0
+; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-GI-NEXT:    s_cvt_i32_f32 s0, s0
+; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-GI-NEXT:    s_min_i32 s0, s0, 0
+; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-GI-NEXT:    s_max_i32 s0, s0, -1
+; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-GI-NEXT:    v_mov_b32_e32 v0, s0
+; GFX12-GI-NEXT:    s_setpc_b64 s[30:31]
+    %x = call i1 @llvm.fptosi.sat.i1.f16(half %f)
+    ret i1 %x
+}
+
+define i8 @test_s_signed_i8_f16(half inreg %f) nounwind {
+; GFX7-ISEL-LABEL: test_s_signed_i8_f16:
+; GFX7-ISEL:       ; %bb.0:
+; GFX7-ISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-ISEL-NEXT:    v_cvt_f32_f16_e32 v0, s16
+; GFX7-ISEL-NEXT:    s_movk_i32 s4, 0xff80
+; GFX7-ISEL-NEXT:    v_mov_b32_e32 v1, 0x7f
+; GFX7-ISEL-NEXT:    v_cvt_i32_f32_e32 v0, v0
+; GFX7-ISEL-NEXT:    v_med3_i32 v0, v0, s4, v1
+; GFX7-ISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX7-GI-LABEL: test_s_signed_i8_f16:
+; GFX7-GI:       ; %bb.0:
+; GFX7-GI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-GI-NEXT:    v_cvt_f32_f16_e32 v0, s16
+; GFX7-GI-NEXT:    v_mov_b32_e32 v1, 0x7f
+; GFX7-GI-NEXT:    v_mov_b32_e32 v2, 0xffffff80
+; GFX7-GI-NEXT:    v_cvt_i32_f32_e32 v0, v0
+; GFX7-GI-NEXT:    v_med3_i32 v0, v0, v2, v1
+; GFX7-GI-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX9-LABEL: test_s_signed_i8_f16:
+; GFX9:       ; %bb.0:
+; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    v_cvt_i16_f16_e32 v0, s16
+; GFX9-NEXT:    v_bfe_i32 v0, v0, 0, 16
+; GFX9-NEXT:    s_movk_i32 s4, 0xff80
+; GFX9-NEXT:    v_mov_b32_e32 v1, 0x7f
+; GFX9-NEXT:    v_med3_i32 v0, v0, s4, v1
+; GFX9-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11-FAKE16-LABEL: test_s_signed_i8_f16:
+; GFX11-FAKE16:       ; %bb.0:
+; GFX11-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-FAKE16-NEXT:    v_cvt_i16_f16_e32 v0, s0
+; GFX11-FAKE16-NEXT:    s_movk_i32 s0, 0xff80
+; GFX11-FAKE16-NEXT:    v_bfe_i32 v0, v0, 0, 16
+; GFX11-FAKE16-NEXT:    v_med3_i32 v0, v0, s0, 0x7f
+; GFX11-FAKE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11-TRUE16-LABEL: test_s_signed_i8_f16:
+; GFX11-TRUE16:       ; %bb.0:
+; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-TRUE16-NEXT:    v_cvt_i16_f16_e32 v0.l, s0
+; GFX11-TRUE16-NEXT:    s_movk_i32 s0, 0xff80
+; GFX11-TRUE16-NEXT:    v_bfe_i32 v0, v0, 0, 16
+; GFX11-TRUE16-NEXT:    v_med3_i32 v0, v0, s0, 0x7f
+; GFX11-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-FAKE16-LABEL: test_s_signed_i8_f16:
+; GFX12-FAKE16:       ; %bb.0:
+; GFX12-FAKE16-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-FAKE16-NEXT:    s_wait_expcnt 0x0
+; GFX12-FAKE16-NEXT:    s_wait_samplecnt 0x0
+; GFX12-FAKE16-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-FAKE16-NEXT:    s_wait_kmcnt 0x0
+; GFX12-FAKE16-NEXT:    v_cvt_i16_f16_e32 v0, s0
+; GFX12-FAKE16-NEXT:    s_movk_i32 s0, 0xff80
+; GFX12-FAKE16-NEXT:    v_bfe_i32 v0, v0, 0, 16
+; GFX12-FAKE16-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-FAKE16-NEXT:    v_med3_i32 v0, v0, s0, 0x7f
+; GFX12-FAKE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-TRUE16-LABEL: test_s_signed_i8_f16:
+; GFX12-TRUE16:       ; %bb.0:
+; GFX12-TRUE16-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-TRUE16-NEXT:    s_wait_expcnt 0x0
+; GFX12-TRUE16-NEXT:    s_wait_samplecnt 0x0
+; GFX12-TRUE16-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-TRUE16-NEXT:    s_wait_kmcnt 0x0
+; GFX12-TRUE16-NEXT:    v_cvt_i16_f16_e32 v0.l, s0
+; GFX12-TRUE16-NEXT:    s_movk_i32 s0, 0xff80
+; GFX12-TRUE16-NEXT:    v_bfe_i32 v0, v0, 0, 16
+; GFX12-TRUE16-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-TRUE16-NEXT:    v_med3_i32 v0, v0, s0, 0x7f
+; GFX12-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-GI-LABEL: test_s_signed_i8_f16:
+; GFX12-GI:       ; %bb.0:
+; GFX12-GI-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-GI-NEXT:    s_wait_expcnt 0x0
+; GFX12-GI-NEXT:    s_wait_samplecnt 0x0
+; GFX12-GI-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-GI-NEXT:    s_wait_kmcnt 0x0
+; GFX12-GI-NEXT:    s_cvt_f32_f16 s0, s0
+; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-GI-NEXT:    s_cvt_i32_f32 s0, s0
+; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-GI-NEXT:    s_min_i32 s0, s0, 0x7f
+; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-GI-NEXT:    s_max_i32 s0, s0, 0xffffff80
+; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-GI-NEXT:    v_mov_b32_e32 v0, s0
+; GFX12-GI-NEXT:    s_setpc_b64 s[30:31]
+    %x = call i8 @llvm.fptosi.sat.i8.f16(half %f)
+    ret i8 %x
+}
+
+define i16 @test_s_signed_i16_f16(half inreg %f) nounwind {
+; GFX7-ISEL-LABEL: test_s_signed_i16_f16:
+; GFX7-ISEL:       ; %bb.0:
+; GFX7-ISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-ISEL-NEXT:    v_cvt_f32_f16_e32 v0, s16
+; GFX7-ISEL-NEXT:    s_movk_i32 s4, 0x8000
+; GFX7-ISEL-NEXT:    v_mov_b32_e32 v1, 0x7fff
+; GFX7-ISEL-NEXT:    v_cvt_i32_f32_e32 v0, v0
+; GFX7-ISEL-NEXT:    v_med3_i32 v0, v0, s4, v1
+; GFX7-ISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX7-GI-LABEL: test_s_signed_i16_f16:
+; GFX7-GI:       ; %bb.0:
+; GFX7-GI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-GI-NEXT:    v_cvt_f32_f16_e32 v0, s16
+; GFX7-GI-NEXT:    v_mov_b32_e32 v1, 0x7fff
+; GFX7-GI-NEXT:    v_mov_b32_e32 v2, 0xffff8000
+; GFX7-GI-NEXT:    v_cvt_i32_f32_e32 v0, v0
+; GFX7-GI-NEXT:    v_med3_i32 v0, v0, v2, v1
+; GFX7-GI-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX9-LABEL: test_s_signed_i16_f16:
+; GFX9:       ; %bb.0:
+; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    v_cvt_i16_f16_e32 v0, s16
+; GFX9-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11-FAKE16-LABEL: test_s_signed_i16_f16:
+; GFX11-FAKE16:       ; %bb.0:
+; GFX11-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-FAKE16-NEXT:    v_cvt_i16_f16_e32 v0, s0
+; GFX11-FAKE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11-TRUE16-LABEL: test_s_signed_i16_f16:
+; GFX11-TRUE16:       ; %bb.0:
+; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-TRUE16-NEXT:    v_cvt_i16_f16_e32 v0.l, s0
+; GFX11-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-FAKE16-LABEL: test_s_signed_i16_f16:
+; GFX12-FAKE16:       ; %bb.0:
+; GFX12-FAKE16-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-FAKE16-NEXT:    s_wait_expcnt 0x0
+; GFX12-FAKE16-NEXT:    s_wait_samplecnt 0x0
+; GFX12-FAKE16-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-FAKE16-NEXT:    s_wait_kmcnt 0x0
+; GFX12-FAKE16-NEXT:    v_cvt_i16_f16_e32 v0, s0
+; GFX12-FAKE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-TRUE16-LABEL: test_s_signed_i16_f16:
+; GFX12-TRUE16:       ; %bb.0:
+; GFX12-TRUE16-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-TRUE16-NEXT:    s_wait_expcnt 0x0
+; GFX12-TRUE16-NEXT:    s_wait_samplecnt 0x0
+; GFX12-TRUE16-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-TRUE16-NEXT:    s_wait_kmcnt 0x0
+; GFX12-TRUE16-NEXT:    v_cvt_i16_f16_e32 v0.l, s0
+; GFX12-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-GI-LABEL: test_s_signed_i16_f16:
+; GFX12-GI:       ; %bb.0:
+; GFX12-GI-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-GI-NEXT:    s_wait_expcnt 0x0
+; GFX12-GI-NEXT:    s_wait_samplecnt 0x0
+; GFX12-GI-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-GI-NEXT:    s_wait_kmcnt 0x0
+; GFX12-GI-NEXT:    v_cvt_i16_f16_e32 v0.l, s0
+; GFX12-GI-NEXT:    s_setpc_b64 s[30:31]
+    %x = call i16 @llvm.fptosi.sat.i16.f16(half %f)
+    ret i16 %x
+}
+
+define i32 @test_s_signed_i32_f16(half inreg %f) nounwind {
+; GFX7-LABEL: test_s_signed_i32_f16:
+; GFX7:       ; %bb.0:
+; GFX7-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-NEXT:    v_cvt_f32_f16_e32 v0, s16
+; GFX7-NEXT:    v_cvt_i32_f32_e32 v0, v0
+; GFX7-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX9-LABEL: test_s_signed_i32_f16:
+; GFX9:       ; %bb.0:
+; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    v_cvt_f32_f16_e32 v0, s16
+; GFX9-NEXT:    v_cvt_i32_f32_e32 v0, v0
+; GFX9-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11-LABEL: test_s_signed_i32_f16:
+; GFX11:       ; %bb.0:
+; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-NEXT:    v_cvt_f32_f16_e32 v0, s0
+; GFX11-NEXT:    v_cvt_i32_f32_e32 v0, v0
+; GFX11-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-LABEL: test_s_signed_i32_f16:
+; GFX12:       ; %bb.0:
+; GFX12-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-NEXT:    s_wait_expcnt 0x0
+; GFX12-NEXT:    s_wait_samplecnt 0x0
+; GFX12-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-NEXT:    s_wait_kmcnt 0x0
+; GFX12-NEXT:    s_cvt_f32_f16 s0, s0
+; GFX12-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-NEXT:    s_cvt_i32_f32 s0, s0
+; GFX12-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-NEXT:    v_mov_b32_e32 v0, s0
+; GFX12-NEXT:    s_setpc_b64 s[30:31]
+    %x = call i32 @llvm.fptosi.sat.i32.f16(half %f)
+    ret i32 %x
+}
+
+define i64 @test_s_signed_i64_f16(half inreg %f) nounwind {
+; GFX7-ISEL-LABEL: test_s_signed_i64_f16:
+; GFX7-ISEL:       ; %bb.0:
+; GFX7-ISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-ISEL-NEXT:    v_cvt_f32_f16_e32 v0, s16
+; GFX7-ISEL-NEXT:    v_cvt_i32_f32_e32 v0, v0
+; GFX7-ISEL-NEXT:    v_ashrrev_i32_e32 v1, 31, v0
+; GFX7-ISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX7-GI-LABEL: test_s_signed_i64_f16:
+; GFX7-GI:       ; %bb.0:
+; GFX7-GI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-GI-NEXT:    v_cvt_f32_f16_e32 v0, s16
+; GFX7-GI-NEXT:    v_mov_b32_e32 v1, 0
+; GFX7-GI-NEXT:    v_cvt_i32_f32_e32 v0, v0
+; GFX7-GI-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX9-LABEL: test_s_signed_i64_f16:
+; GFX9:       ; %bb.0:
+; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    v_cvt_f32_f16_e32 v0, s16
+; GFX9-NEXT:    v_cvt_i32_f32_e32 v0, v0
+; GFX9-NEXT:    v_ashrrev_i32_e32 v1, 31, v0
+; GFX9-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11-LABEL: test_s_signed_i64_f16:
+; GFX11:       ; %bb.0:
+; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-NEXT:    v_cvt_f32_f16_e32 v0, s0
+; GFX11-NEXT:    v_cvt_i32_f32_e32 v0, v0
+; GFX11-NEXT:    v_ashrrev_i32_e32 v1, 31, v0
+; GFX11-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-ISEL-LABEL: test_s_signed_i64_f16:
+; GFX12-ISEL:       ; %bb.0:
+; GFX12-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX12-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX12-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX12-ISEL-NEXT:    s_cvt_f32_f16 s0, s0
+; GFX12-ISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-ISEL-NEXT:    s_cvt_i32_f32 s0, s0
+; GFX12-ISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-ISEL-NEXT:    s_ashr_i32 s1, s0, 31
+; GFX12-ISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-ISEL-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
+; GFX12-ISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-GI-LABEL: test_s_signed_i64_f16:
+; GFX12-GI:       ; %bb.0:
+; GFX12-GI-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-GI-NEXT:    s_wait_expcnt 0x0
+; GFX12-GI-NEXT:    s_wait_samplecnt 0x0
+; GFX12-GI-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-GI-NEXT:    s_wait_kmcnt 0x0
+; GFX12-GI-NEXT:    s_cvt_f32_f16 s0, s0
+; GFX12-GI-NEXT:    v_mov_b32_e32 v1, 0
+; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-GI-NEXT:    s_cvt_i32_f32 s0, s0
+; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-GI-NEXT:    v_mov_b32_e32 v0, s0
 ; GFX12-GI-NEXT:    s_setpc_b64 s[30:31]
     %x = call i64 @llvm.fptosi.sat.i64.f16(half %f)
     ret i64 %x

--- a/llvm/test/CodeGen/AMDGPU/fptosi-sat-vector.ll
+++ b/llvm/test/CodeGen/AMDGPU/fptosi-sat-vector.ll
@@ -389,6 +389,402 @@ define <8 x i32> @test_signed_v8f32_v8i32(<8 x float> %f) {
     ret <8 x i32> %x
 }
 
+define <1 x i32> @test_s_signed_v1f32_v1i32(<1 x float> inreg %f) {
+; GFX7-LABEL: test_s_signed_v1f32_v1i32:
+; GFX7:       ; %bb.0:
+; GFX7-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-NEXT:    v_cvt_i32_f32_e32 v0, s16
+; GFX7-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX9-LABEL: test_s_signed_v1f32_v1i32:
+; GFX9:       ; %bb.0:
+; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    v_cvt_i32_f32_e32 v0, s16
+; GFX9-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11-LABEL: test_s_signed_v1f32_v1i32:
+; GFX11:       ; %bb.0:
+; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-NEXT:    v_cvt_i32_f32_e32 v0, s0
+; GFX11-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-LABEL: test_s_signed_v1f32_v1i32:
+; GFX12:       ; %bb.0:
+; GFX12-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-NEXT:    s_wait_expcnt 0x0
+; GFX12-NEXT:    s_wait_samplecnt 0x0
+; GFX12-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-NEXT:    s_wait_kmcnt 0x0
+; GFX12-NEXT:    s_cvt_i32_f32 s0, s0
+; GFX12-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-NEXT:    v_mov_b32_e32 v0, s0
+; GFX12-NEXT:    s_setpc_b64 s[30:31]
+    %x = call <1 x i32> @llvm.fptosi.sat.v1f32.v1i32(<1 x float> %f)
+    ret <1 x i32> %x
+}
+
+define <2 x i32> @test_s_signed_v2f32_v2i32(<2 x float> inreg %f) {
+; GFX7-LABEL: test_s_signed_v2f32_v2i32:
+; GFX7:       ; %bb.0:
+; GFX7-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-NEXT:    v_cvt_i32_f32_e32 v0, s16
+; GFX7-NEXT:    v_cvt_i32_f32_e32 v1, s17
+; GFX7-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX9-LABEL: test_s_signed_v2f32_v2i32:
+; GFX9:       ; %bb.0:
+; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    v_cvt_i32_f32_e32 v0, s16
+; GFX9-NEXT:    v_cvt_i32_f32_e32 v1, s17
+; GFX9-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11-LABEL: test_s_signed_v2f32_v2i32:
+; GFX11:       ; %bb.0:
+; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-NEXT:    v_cvt_i32_f32_e32 v0, s0
+; GFX11-NEXT:    v_cvt_i32_f32_e32 v1, s1
+; GFX11-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-LABEL: test_s_signed_v2f32_v2i32:
+; GFX12:       ; %bb.0:
+; GFX12-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-NEXT:    s_wait_expcnt 0x0
+; GFX12-NEXT:    s_wait_samplecnt 0x0
+; GFX12-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-NEXT:    s_wait_kmcnt 0x0
+; GFX12-NEXT:    s_cvt_i32_f32 s0, s0
+; GFX12-NEXT:    s_cvt_i32_f32 s1, s1
+; GFX12-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
+; GFX12-NEXT:    s_setpc_b64 s[30:31]
+    %x = call <2 x i32> @llvm.fptosi.sat.v2f32.v2i32(<2 x float> %f)
+    ret <2 x i32> %x
+}
+
+define <3 x i32> @test_s_signed_v3f32_v3i32(<3 x float> inreg %f) {
+; GFX7-LABEL: test_s_signed_v3f32_v3i32:
+; GFX7:       ; %bb.0:
+; GFX7-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-NEXT:    v_cvt_i32_f32_e32 v0, s16
+; GFX7-NEXT:    v_cvt_i32_f32_e32 v1, s17
+; GFX7-NEXT:    v_cvt_i32_f32_e32 v2, s18
+; GFX7-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX9-LABEL: test_s_signed_v3f32_v3i32:
+; GFX9:       ; %bb.0:
+; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    v_cvt_i32_f32_e32 v0, s16
+; GFX9-NEXT:    v_cvt_i32_f32_e32 v1, s17
+; GFX9-NEXT:    v_cvt_i32_f32_e32 v2, s18
+; GFX9-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11-LABEL: test_s_signed_v3f32_v3i32:
+; GFX11:       ; %bb.0:
+; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-NEXT:    v_cvt_i32_f32_e32 v0, s0
+; GFX11-NEXT:    v_cvt_i32_f32_e32 v1, s1
+; GFX11-NEXT:    v_cvt_i32_f32_e32 v2, s2
+; GFX11-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-LABEL: test_s_signed_v3f32_v3i32:
+; GFX12:       ; %bb.0:
+; GFX12-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-NEXT:    s_wait_expcnt 0x0
+; GFX12-NEXT:    s_wait_samplecnt 0x0
+; GFX12-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-NEXT:    s_wait_kmcnt 0x0
+; GFX12-NEXT:    s_cvt_i32_f32 s0, s0
+; GFX12-NEXT:    s_cvt_i32_f32 s1, s1
+; GFX12-NEXT:    s_cvt_i32_f32 s2, s2
+; GFX12-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
+; GFX12-NEXT:    v_mov_b32_e32 v2, s2
+; GFX12-NEXT:    s_setpc_b64 s[30:31]
+    %x = call <3 x i32> @llvm.fptosi.sat.v3f32.v3i32(<3 x float> %f)
+    ret <3 x i32> %x
+}
+
+define <4 x i32> @test_s_signed_v4f32_v4i32(<4 x float> inreg %f) {
+; GFX7-LABEL: test_s_signed_v4f32_v4i32:
+; GFX7:       ; %bb.0:
+; GFX7-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-NEXT:    v_cvt_i32_f32_e32 v0, s16
+; GFX7-NEXT:    v_cvt_i32_f32_e32 v1, s17
+; GFX7-NEXT:    v_cvt_i32_f32_e32 v2, s18
+; GFX7-NEXT:    v_cvt_i32_f32_e32 v3, s19
+; GFX7-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX9-LABEL: test_s_signed_v4f32_v4i32:
+; GFX9:       ; %bb.0:
+; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    v_cvt_i32_f32_e32 v0, s16
+; GFX9-NEXT:    v_cvt_i32_f32_e32 v1, s17
+; GFX9-NEXT:    v_cvt_i32_f32_e32 v2, s18
+; GFX9-NEXT:    v_cvt_i32_f32_e32 v3, s19
+; GFX9-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11-LABEL: test_s_signed_v4f32_v4i32:
+; GFX11:       ; %bb.0:
+; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-NEXT:    v_cvt_i32_f32_e32 v0, s0
+; GFX11-NEXT:    v_cvt_i32_f32_e32 v1, s1
+; GFX11-NEXT:    v_cvt_i32_f32_e32 v2, s2
+; GFX11-NEXT:    v_cvt_i32_f32_e32 v3, s3
+; GFX11-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-LABEL: test_s_signed_v4f32_v4i32:
+; GFX12:       ; %bb.0:
+; GFX12-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-NEXT:    s_wait_expcnt 0x0
+; GFX12-NEXT:    s_wait_samplecnt 0x0
+; GFX12-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-NEXT:    s_wait_kmcnt 0x0
+; GFX12-NEXT:    s_cvt_i32_f32 s0, s0
+; GFX12-NEXT:    s_cvt_i32_f32 s1, s1
+; GFX12-NEXT:    s_cvt_i32_f32 s2, s2
+; GFX12-NEXT:    s_cvt_i32_f32 s3, s3
+; GFX12-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
+; GFX12-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s3
+; GFX12-NEXT:    s_setpc_b64 s[30:31]
+    %x = call <4 x i32> @llvm.fptosi.sat.v4f32.v4i32(<4 x float> %f)
+    ret <4 x i32> %x
+}
+
+define <5 x i32> @test_s_signed_v5f32_v5i32(<5 x float> inreg %f) {
+; GFX7-LABEL: test_s_signed_v5f32_v5i32:
+; GFX7:       ; %bb.0:
+; GFX7-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-NEXT:    v_cvt_i32_f32_e32 v0, s16
+; GFX7-NEXT:    v_cvt_i32_f32_e32 v1, s17
+; GFX7-NEXT:    v_cvt_i32_f32_e32 v2, s18
+; GFX7-NEXT:    v_cvt_i32_f32_e32 v3, s19
+; GFX7-NEXT:    v_cvt_i32_f32_e32 v4, s20
+; GFX7-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX9-LABEL: test_s_signed_v5f32_v5i32:
+; GFX9:       ; %bb.0:
+; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    v_cvt_i32_f32_e32 v0, s16
+; GFX9-NEXT:    v_cvt_i32_f32_e32 v1, s17
+; GFX9-NEXT:    v_cvt_i32_f32_e32 v2, s18
+; GFX9-NEXT:    v_cvt_i32_f32_e32 v3, s19
+; GFX9-NEXT:    v_cvt_i32_f32_e32 v4, s20
+; GFX9-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11-LABEL: test_s_signed_v5f32_v5i32:
+; GFX11:       ; %bb.0:
+; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-NEXT:    v_cvt_i32_f32_e32 v0, s0
+; GFX11-NEXT:    v_cvt_i32_f32_e32 v1, s1
+; GFX11-NEXT:    v_cvt_i32_f32_e32 v2, s2
+; GFX11-NEXT:    v_cvt_i32_f32_e32 v3, s3
+; GFX11-NEXT:    v_cvt_i32_f32_e32 v4, s16
+; GFX11-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-LABEL: test_s_signed_v5f32_v5i32:
+; GFX12:       ; %bb.0:
+; GFX12-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-NEXT:    s_wait_expcnt 0x0
+; GFX12-NEXT:    s_wait_samplecnt 0x0
+; GFX12-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-NEXT:    s_wait_kmcnt 0x0
+; GFX12-NEXT:    s_cvt_i32_f32 s0, s0
+; GFX12-NEXT:    s_cvt_i32_f32 s1, s1
+; GFX12-NEXT:    s_cvt_i32_f32 s2, s2
+; GFX12-NEXT:    s_cvt_i32_f32 s3, s3
+; GFX12-NEXT:    s_cvt_i32_f32 s4, s16
+; GFX12-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
+; GFX12-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s3
+; GFX12-NEXT:    v_mov_b32_e32 v4, s4
+; GFX12-NEXT:    s_setpc_b64 s[30:31]
+    %x = call <5 x i32> @llvm.fptosi.sat.v5f32.v5i32(<5 x float> %f)
+    ret <5 x i32> %x
+}
+
+define <6 x i32> @test_s_signed_v6f32_v6i32(<6 x float> inreg %f) {
+; GFX7-LABEL: test_s_signed_v6f32_v6i32:
+; GFX7:       ; %bb.0:
+; GFX7-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-NEXT:    v_cvt_i32_f32_e32 v0, s16
+; GFX7-NEXT:    v_cvt_i32_f32_e32 v1, s17
+; GFX7-NEXT:    v_cvt_i32_f32_e32 v2, s18
+; GFX7-NEXT:    v_cvt_i32_f32_e32 v3, s19
+; GFX7-NEXT:    v_cvt_i32_f32_e32 v4, s20
+; GFX7-NEXT:    v_cvt_i32_f32_e32 v5, s21
+; GFX7-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX9-LABEL: test_s_signed_v6f32_v6i32:
+; GFX9:       ; %bb.0:
+; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    v_cvt_i32_f32_e32 v0, s16
+; GFX9-NEXT:    v_cvt_i32_f32_e32 v1, s17
+; GFX9-NEXT:    v_cvt_i32_f32_e32 v2, s18
+; GFX9-NEXT:    v_cvt_i32_f32_e32 v3, s19
+; GFX9-NEXT:    v_cvt_i32_f32_e32 v4, s20
+; GFX9-NEXT:    v_cvt_i32_f32_e32 v5, s21
+; GFX9-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11-LABEL: test_s_signed_v6f32_v6i32:
+; GFX11:       ; %bb.0:
+; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-NEXT:    v_cvt_i32_f32_e32 v0, s0
+; GFX11-NEXT:    v_cvt_i32_f32_e32 v1, s1
+; GFX11-NEXT:    v_cvt_i32_f32_e32 v2, s2
+; GFX11-NEXT:    v_cvt_i32_f32_e32 v3, s3
+; GFX11-NEXT:    v_cvt_i32_f32_e32 v4, s16
+; GFX11-NEXT:    v_cvt_i32_f32_e32 v5, s17
+; GFX11-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-LABEL: test_s_signed_v6f32_v6i32:
+; GFX12:       ; %bb.0:
+; GFX12-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-NEXT:    s_wait_expcnt 0x0
+; GFX12-NEXT:    s_wait_samplecnt 0x0
+; GFX12-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-NEXT:    s_wait_kmcnt 0x0
+; GFX12-NEXT:    s_cvt_i32_f32 s0, s0
+; GFX12-NEXT:    s_cvt_i32_f32 s1, s1
+; GFX12-NEXT:    s_cvt_i32_f32 s2, s2
+; GFX12-NEXT:    s_cvt_i32_f32 s3, s3
+; GFX12-NEXT:    s_cvt_i32_f32 s4, s16
+; GFX12-NEXT:    s_cvt_i32_f32 s5, s17
+; GFX12-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
+; GFX12-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s3
+; GFX12-NEXT:    v_dual_mov_b32 v4, s4 :: v_dual_mov_b32 v5, s5
+; GFX12-NEXT:    s_setpc_b64 s[30:31]
+    %x = call <6 x i32> @llvm.fptosi.sat.v6f32.v6i32(<6 x float> %f)
+    ret <6 x i32> %x
+}
+
+define <7 x i32> @test_s_signed_v7f32_v7i32(<7 x float> inreg %f) {
+; GFX7-LABEL: test_s_signed_v7f32_v7i32:
+; GFX7:       ; %bb.0:
+; GFX7-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-NEXT:    v_cvt_i32_f32_e32 v0, s16
+; GFX7-NEXT:    v_cvt_i32_f32_e32 v1, s17
+; GFX7-NEXT:    v_cvt_i32_f32_e32 v2, s18
+; GFX7-NEXT:    v_cvt_i32_f32_e32 v3, s19
+; GFX7-NEXT:    v_cvt_i32_f32_e32 v4, s20
+; GFX7-NEXT:    v_cvt_i32_f32_e32 v5, s21
+; GFX7-NEXT:    v_cvt_i32_f32_e32 v6, s22
+; GFX7-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX9-LABEL: test_s_signed_v7f32_v7i32:
+; GFX9:       ; %bb.0:
+; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    v_cvt_i32_f32_e32 v0, s16
+; GFX9-NEXT:    v_cvt_i32_f32_e32 v1, s17
+; GFX9-NEXT:    v_cvt_i32_f32_e32 v2, s18
+; GFX9-NEXT:    v_cvt_i32_f32_e32 v3, s19
+; GFX9-NEXT:    v_cvt_i32_f32_e32 v4, s20
+; GFX9-NEXT:    v_cvt_i32_f32_e32 v5, s21
+; GFX9-NEXT:    v_cvt_i32_f32_e32 v6, s22
+; GFX9-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11-LABEL: test_s_signed_v7f32_v7i32:
+; GFX11:       ; %bb.0:
+; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-NEXT:    v_cvt_i32_f32_e32 v0, s0
+; GFX11-NEXT:    v_cvt_i32_f32_e32 v1, s1
+; GFX11-NEXT:    v_cvt_i32_f32_e32 v2, s2
+; GFX11-NEXT:    v_cvt_i32_f32_e32 v3, s3
+; GFX11-NEXT:    v_cvt_i32_f32_e32 v4, s16
+; GFX11-NEXT:    v_cvt_i32_f32_e32 v5, s17
+; GFX11-NEXT:    v_cvt_i32_f32_e32 v6, s18
+; GFX11-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-LABEL: test_s_signed_v7f32_v7i32:
+; GFX12:       ; %bb.0:
+; GFX12-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-NEXT:    s_wait_expcnt 0x0
+; GFX12-NEXT:    s_wait_samplecnt 0x0
+; GFX12-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-NEXT:    s_wait_kmcnt 0x0
+; GFX12-NEXT:    s_cvt_i32_f32 s0, s0
+; GFX12-NEXT:    s_cvt_i32_f32 s1, s1
+; GFX12-NEXT:    s_cvt_i32_f32 s2, s2
+; GFX12-NEXT:    s_cvt_i32_f32 s3, s3
+; GFX12-NEXT:    s_cvt_i32_f32 s4, s16
+; GFX12-NEXT:    s_cvt_i32_f32 s5, s17
+; GFX12-NEXT:    s_cvt_i32_f32 s6, s18
+; GFX12-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
+; GFX12-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s3
+; GFX12-NEXT:    v_dual_mov_b32 v4, s4 :: v_dual_mov_b32 v5, s5
+; GFX12-NEXT:    v_mov_b32_e32 v6, s6
+; GFX12-NEXT:    s_setpc_b64 s[30:31]
+    %x = call <7 x i32> @llvm.fptosi.sat.v7f32.v7i32(<7 x float> %f)
+    ret <7 x i32> %x
+}
+
+define <8 x i32> @test_s_signed_v8f32_v8i32(<8 x float> inreg %f) {
+; GFX7-LABEL: test_s_signed_v8f32_v8i32:
+; GFX7:       ; %bb.0:
+; GFX7-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-NEXT:    v_cvt_i32_f32_e32 v0, s16
+; GFX7-NEXT:    v_cvt_i32_f32_e32 v1, s17
+; GFX7-NEXT:    v_cvt_i32_f32_e32 v2, s18
+; GFX7-NEXT:    v_cvt_i32_f32_e32 v3, s19
+; GFX7-NEXT:    v_cvt_i32_f32_e32 v4, s20
+; GFX7-NEXT:    v_cvt_i32_f32_e32 v5, s21
+; GFX7-NEXT:    v_cvt_i32_f32_e32 v6, s22
+; GFX7-NEXT:    v_cvt_i32_f32_e32 v7, s23
+; GFX7-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX9-LABEL: test_s_signed_v8f32_v8i32:
+; GFX9:       ; %bb.0:
+; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    v_cvt_i32_f32_e32 v0, s16
+; GFX9-NEXT:    v_cvt_i32_f32_e32 v1, s17
+; GFX9-NEXT:    v_cvt_i32_f32_e32 v2, s18
+; GFX9-NEXT:    v_cvt_i32_f32_e32 v3, s19
+; GFX9-NEXT:    v_cvt_i32_f32_e32 v4, s20
+; GFX9-NEXT:    v_cvt_i32_f32_e32 v5, s21
+; GFX9-NEXT:    v_cvt_i32_f32_e32 v6, s22
+; GFX9-NEXT:    v_cvt_i32_f32_e32 v7, s23
+; GFX9-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11-LABEL: test_s_signed_v8f32_v8i32:
+; GFX11:       ; %bb.0:
+; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-NEXT:    v_cvt_i32_f32_e32 v0, s0
+; GFX11-NEXT:    v_cvt_i32_f32_e32 v1, s1
+; GFX11-NEXT:    v_cvt_i32_f32_e32 v2, s2
+; GFX11-NEXT:    v_cvt_i32_f32_e32 v3, s3
+; GFX11-NEXT:    v_cvt_i32_f32_e32 v4, s16
+; GFX11-NEXT:    v_cvt_i32_f32_e32 v5, s17
+; GFX11-NEXT:    v_cvt_i32_f32_e32 v6, s18
+; GFX11-NEXT:    v_cvt_i32_f32_e32 v7, s19
+; GFX11-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-LABEL: test_s_signed_v8f32_v8i32:
+; GFX12:       ; %bb.0:
+; GFX12-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-NEXT:    s_wait_expcnt 0x0
+; GFX12-NEXT:    s_wait_samplecnt 0x0
+; GFX12-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-NEXT:    s_wait_kmcnt 0x0
+; GFX12-NEXT:    s_cvt_i32_f32 s0, s0
+; GFX12-NEXT:    s_cvt_i32_f32 s1, s1
+; GFX12-NEXT:    s_cvt_i32_f32 s2, s2
+; GFX12-NEXT:    s_cvt_i32_f32 s3, s3
+; GFX12-NEXT:    s_cvt_i32_f32 s4, s16
+; GFX12-NEXT:    s_cvt_i32_f32 s5, s17
+; GFX12-NEXT:    s_cvt_i32_f32 s6, s18
+; GFX12-NEXT:    s_cvt_i32_f32 s7, s19
+; GFX12-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
+; GFX12-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s3
+; GFX12-NEXT:    v_dual_mov_b32 v4, s4 :: v_dual_mov_b32 v5, s5
+; GFX12-NEXT:    v_dual_mov_b32 v6, s6 :: v_dual_mov_b32 v7, s7
+; GFX12-NEXT:    s_setpc_b64 s[30:31]
+    %x = call <8 x i32> @llvm.fptosi.sat.v8f32.v8i32(<8 x float> %f)
+    ret <8 x i32> %x
+}
+
 ;
 ; Double to signed 32-bit -- Vector size variation
 ;
@@ -647,6 +1043,258 @@ define <6 x i32> @test_signed_v6f64_v6i32(<6 x double> %f) {
 ; GFX12-NEXT:    v_cvt_i32_f64_e32 v3, v[6:7]
 ; GFX12-NEXT:    v_cvt_i32_f64_e32 v4, v[8:9]
 ; GFX12-NEXT:    v_cvt_i32_f64_e32 v5, v[10:11]
+; GFX12-NEXT:    s_setpc_b64 s[30:31]
+    %x = call <6 x i32> @llvm.fptosi.sat.v6f64.v6i32(<6 x double> %f)
+    ret <6 x i32> %x
+}
+
+define <1 x i32> @test_s_signed_v1f64_v1i32(<1 x double> inreg %f) {
+; GFX7-LABEL: test_s_signed_v1f64_v1i32:
+; GFX7:       ; %bb.0:
+; GFX7-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-NEXT:    v_cvt_i32_f64_e32 v0, s[16:17]
+; GFX7-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX9-LABEL: test_s_signed_v1f64_v1i32:
+; GFX9:       ; %bb.0:
+; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    v_cvt_i32_f64_e32 v0, s[16:17]
+; GFX9-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11-LABEL: test_s_signed_v1f64_v1i32:
+; GFX11:       ; %bb.0:
+; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-NEXT:    v_cvt_i32_f64_e32 v0, s[0:1]
+; GFX11-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-LABEL: test_s_signed_v1f64_v1i32:
+; GFX12:       ; %bb.0:
+; GFX12-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-NEXT:    s_wait_expcnt 0x0
+; GFX12-NEXT:    s_wait_samplecnt 0x0
+; GFX12-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-NEXT:    s_wait_kmcnt 0x0
+; GFX12-NEXT:    v_cvt_i32_f64_e32 v0, s[0:1]
+; GFX12-NEXT:    s_setpc_b64 s[30:31]
+    %x = call <1 x i32> @llvm.fptosi.sat.v1f64.v1i32(<1 x double> %f)
+    ret <1 x i32> %x
+}
+
+define <2 x i32> @test_s_signed_v2f64_v2i32(<2 x double> inreg %f) {
+; GFX7-LABEL: test_s_signed_v2f64_v2i32:
+; GFX7:       ; %bb.0:
+; GFX7-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-NEXT:    v_cvt_i32_f64_e32 v0, s[16:17]
+; GFX7-NEXT:    v_cvt_i32_f64_e32 v1, s[18:19]
+; GFX7-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX9-LABEL: test_s_signed_v2f64_v2i32:
+; GFX9:       ; %bb.0:
+; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    v_cvt_i32_f64_e32 v0, s[16:17]
+; GFX9-NEXT:    v_cvt_i32_f64_e32 v1, s[18:19]
+; GFX9-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11-LABEL: test_s_signed_v2f64_v2i32:
+; GFX11:       ; %bb.0:
+; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-NEXT:    v_cvt_i32_f64_e32 v0, s[0:1]
+; GFX11-NEXT:    v_cvt_i32_f64_e32 v1, s[2:3]
+; GFX11-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-LABEL: test_s_signed_v2f64_v2i32:
+; GFX12:       ; %bb.0:
+; GFX12-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-NEXT:    s_wait_expcnt 0x0
+; GFX12-NEXT:    s_wait_samplecnt 0x0
+; GFX12-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-NEXT:    s_wait_kmcnt 0x0
+; GFX12-NEXT:    v_cvt_i32_f64_e32 v0, s[0:1]
+; GFX12-NEXT:    v_cvt_i32_f64_e32 v1, s[2:3]
+; GFX12-NEXT:    s_setpc_b64 s[30:31]
+    %x = call <2 x i32> @llvm.fptosi.sat.v2f64.v2i32(<2 x double> %f)
+    ret <2 x i32> %x
+}
+
+define <3 x i32> @test_s_signed_v3f64_v3i32(<3 x double> inreg %f) {
+; GFX7-LABEL: test_s_signed_v3f64_v3i32:
+; GFX7:       ; %bb.0:
+; GFX7-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-NEXT:    v_cvt_i32_f64_e32 v0, s[16:17]
+; GFX7-NEXT:    v_cvt_i32_f64_e32 v1, s[18:19]
+; GFX7-NEXT:    v_cvt_i32_f64_e32 v2, s[20:21]
+; GFX7-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX9-LABEL: test_s_signed_v3f64_v3i32:
+; GFX9:       ; %bb.0:
+; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    v_cvt_i32_f64_e32 v0, s[16:17]
+; GFX9-NEXT:    v_cvt_i32_f64_e32 v1, s[18:19]
+; GFX9-NEXT:    v_cvt_i32_f64_e32 v2, s[20:21]
+; GFX9-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11-LABEL: test_s_signed_v3f64_v3i32:
+; GFX11:       ; %bb.0:
+; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-NEXT:    v_cvt_i32_f64_e32 v0, s[0:1]
+; GFX11-NEXT:    v_cvt_i32_f64_e32 v1, s[2:3]
+; GFX11-NEXT:    v_cvt_i32_f64_e32 v2, s[16:17]
+; GFX11-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-LABEL: test_s_signed_v3f64_v3i32:
+; GFX12:       ; %bb.0:
+; GFX12-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-NEXT:    s_wait_expcnt 0x0
+; GFX12-NEXT:    s_wait_samplecnt 0x0
+; GFX12-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-NEXT:    s_wait_kmcnt 0x0
+; GFX12-NEXT:    v_cvt_i32_f64_e32 v0, s[0:1]
+; GFX12-NEXT:    v_cvt_i32_f64_e32 v1, s[2:3]
+; GFX12-NEXT:    v_cvt_i32_f64_e32 v2, s[16:17]
+; GFX12-NEXT:    s_setpc_b64 s[30:31]
+    %x = call <3 x i32> @llvm.fptosi.sat.v3f64.v3i32(<3 x double> %f)
+    ret <3 x i32> %x
+}
+
+define <4 x i32> @test_s_signed_v4f64_v4i32(<4 x double> inreg %f) {
+; GFX7-LABEL: test_s_signed_v4f64_v4i32:
+; GFX7:       ; %bb.0:
+; GFX7-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-NEXT:    v_cvt_i32_f64_e32 v0, s[16:17]
+; GFX7-NEXT:    v_cvt_i32_f64_e32 v1, s[18:19]
+; GFX7-NEXT:    v_cvt_i32_f64_e32 v2, s[20:21]
+; GFX7-NEXT:    v_cvt_i32_f64_e32 v3, s[22:23]
+; GFX7-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX9-LABEL: test_s_signed_v4f64_v4i32:
+; GFX9:       ; %bb.0:
+; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    v_cvt_i32_f64_e32 v0, s[16:17]
+; GFX9-NEXT:    v_cvt_i32_f64_e32 v1, s[18:19]
+; GFX9-NEXT:    v_cvt_i32_f64_e32 v2, s[20:21]
+; GFX9-NEXT:    v_cvt_i32_f64_e32 v3, s[22:23]
+; GFX9-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11-LABEL: test_s_signed_v4f64_v4i32:
+; GFX11:       ; %bb.0:
+; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-NEXT:    v_cvt_i32_f64_e32 v0, s[0:1]
+; GFX11-NEXT:    v_cvt_i32_f64_e32 v1, s[2:3]
+; GFX11-NEXT:    v_cvt_i32_f64_e32 v2, s[16:17]
+; GFX11-NEXT:    v_cvt_i32_f64_e32 v3, s[18:19]
+; GFX11-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-LABEL: test_s_signed_v4f64_v4i32:
+; GFX12:       ; %bb.0:
+; GFX12-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-NEXT:    s_wait_expcnt 0x0
+; GFX12-NEXT:    s_wait_samplecnt 0x0
+; GFX12-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-NEXT:    s_wait_kmcnt 0x0
+; GFX12-NEXT:    v_cvt_i32_f64_e32 v0, s[0:1]
+; GFX12-NEXT:    v_cvt_i32_f64_e32 v1, s[2:3]
+; GFX12-NEXT:    v_cvt_i32_f64_e32 v2, s[16:17]
+; GFX12-NEXT:    v_cvt_i32_f64_e32 v3, s[18:19]
+; GFX12-NEXT:    s_setpc_b64 s[30:31]
+    %x = call <4 x i32> @llvm.fptosi.sat.v4f64.v4i32(<4 x double> %f)
+    ret <4 x i32> %x
+}
+
+define <5 x i32> @test_s_signed_v5f64_v5i32(<5 x double> inreg %f) {
+; GFX7-LABEL: test_s_signed_v5f64_v5i32:
+; GFX7:       ; %bb.0:
+; GFX7-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-NEXT:    v_cvt_i32_f64_e32 v0, s[16:17]
+; GFX7-NEXT:    v_cvt_i32_f64_e32 v1, s[18:19]
+; GFX7-NEXT:    v_cvt_i32_f64_e32 v2, s[20:21]
+; GFX7-NEXT:    v_cvt_i32_f64_e32 v3, s[22:23]
+; GFX7-NEXT:    v_cvt_i32_f64_e32 v4, s[24:25]
+; GFX7-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX9-LABEL: test_s_signed_v5f64_v5i32:
+; GFX9:       ; %bb.0:
+; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    v_cvt_i32_f64_e32 v0, s[16:17]
+; GFX9-NEXT:    v_cvt_i32_f64_e32 v1, s[18:19]
+; GFX9-NEXT:    v_cvt_i32_f64_e32 v2, s[20:21]
+; GFX9-NEXT:    v_cvt_i32_f64_e32 v3, s[22:23]
+; GFX9-NEXT:    v_cvt_i32_f64_e32 v4, s[24:25]
+; GFX9-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11-LABEL: test_s_signed_v5f64_v5i32:
+; GFX11:       ; %bb.0:
+; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-NEXT:    v_cvt_i32_f64_e32 v0, s[0:1]
+; GFX11-NEXT:    v_cvt_i32_f64_e32 v1, s[2:3]
+; GFX11-NEXT:    v_cvt_i32_f64_e32 v2, s[16:17]
+; GFX11-NEXT:    v_cvt_i32_f64_e32 v3, s[18:19]
+; GFX11-NEXT:    v_cvt_i32_f64_e32 v4, s[20:21]
+; GFX11-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-LABEL: test_s_signed_v5f64_v5i32:
+; GFX12:       ; %bb.0:
+; GFX12-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-NEXT:    s_wait_expcnt 0x0
+; GFX12-NEXT:    s_wait_samplecnt 0x0
+; GFX12-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-NEXT:    s_wait_kmcnt 0x0
+; GFX12-NEXT:    v_cvt_i32_f64_e32 v0, s[0:1]
+; GFX12-NEXT:    v_cvt_i32_f64_e32 v1, s[2:3]
+; GFX12-NEXT:    v_cvt_i32_f64_e32 v2, s[16:17]
+; GFX12-NEXT:    v_cvt_i32_f64_e32 v3, s[18:19]
+; GFX12-NEXT:    v_cvt_i32_f64_e32 v4, s[20:21]
+; GFX12-NEXT:    s_setpc_b64 s[30:31]
+    %x = call <5 x i32> @llvm.fptosi.sat.v5f64.v5i32(<5 x double> %f)
+    ret <5 x i32> %x
+}
+
+define <6 x i32> @test_s_signed_v6f64_v6i32(<6 x double> inreg %f) {
+; GFX7-LABEL: test_s_signed_v6f64_v6i32:
+; GFX7:       ; %bb.0:
+; GFX7-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-NEXT:    v_cvt_i32_f64_e32 v0, s[16:17]
+; GFX7-NEXT:    v_cvt_i32_f64_e32 v1, s[18:19]
+; GFX7-NEXT:    v_cvt_i32_f64_e32 v2, s[20:21]
+; GFX7-NEXT:    v_cvt_i32_f64_e32 v3, s[22:23]
+; GFX7-NEXT:    v_cvt_i32_f64_e32 v4, s[24:25]
+; GFX7-NEXT:    v_cvt_i32_f64_e32 v5, s[26:27]
+; GFX7-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX9-LABEL: test_s_signed_v6f64_v6i32:
+; GFX9:       ; %bb.0:
+; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    v_cvt_i32_f64_e32 v0, s[16:17]
+; GFX9-NEXT:    v_cvt_i32_f64_e32 v1, s[18:19]
+; GFX9-NEXT:    v_cvt_i32_f64_e32 v2, s[20:21]
+; GFX9-NEXT:    v_cvt_i32_f64_e32 v3, s[22:23]
+; GFX9-NEXT:    v_cvt_i32_f64_e32 v4, s[24:25]
+; GFX9-NEXT:    v_cvt_i32_f64_e32 v5, s[26:27]
+; GFX9-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11-LABEL: test_s_signed_v6f64_v6i32:
+; GFX11:       ; %bb.0:
+; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-NEXT:    v_cvt_i32_f64_e32 v0, s[0:1]
+; GFX11-NEXT:    v_cvt_i32_f64_e32 v1, s[2:3]
+; GFX11-NEXT:    v_cvt_i32_f64_e32 v2, s[16:17]
+; GFX11-NEXT:    v_cvt_i32_f64_e32 v3, s[18:19]
+; GFX11-NEXT:    v_cvt_i32_f64_e32 v4, s[20:21]
+; GFX11-NEXT:    v_cvt_i32_f64_e32 v5, s[22:23]
+; GFX11-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-LABEL: test_s_signed_v6f64_v6i32:
+; GFX12:       ; %bb.0:
+; GFX12-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-NEXT:    s_wait_expcnt 0x0
+; GFX12-NEXT:    s_wait_samplecnt 0x0
+; GFX12-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-NEXT:    s_wait_kmcnt 0x0
+; GFX12-NEXT:    v_cvt_i32_f64_e32 v0, s[0:1]
+; GFX12-NEXT:    v_cvt_i32_f64_e32 v1, s[2:3]
+; GFX12-NEXT:    v_cvt_i32_f64_e32 v2, s[16:17]
+; GFX12-NEXT:    v_cvt_i32_f64_e32 v3, s[18:19]
+; GFX12-NEXT:    v_cvt_i32_f64_e32 v4, s[20:21]
+; GFX12-NEXT:    v_cvt_i32_f64_e32 v5, s[22:23]
 ; GFX12-NEXT:    s_setpc_b64 s[30:31]
     %x = call <6 x i32> @llvm.fptosi.sat.v6f64.v6i32(<6 x double> %f)
     ret <6 x i32> %x
@@ -1236,6 +1884,522 @@ define <2 x i64> @test_signed_v2f64_v2i64(<2 x double> %f) {
 ; GFX12-GI-NEXT:    v_cndmask_b32_e64 v2, v1, 0, s4
 ; GFX12-GI-NEXT:    v_cndmask_b32_e64 v1, v3, 0, s3
 ; GFX12-GI-NEXT:    v_cndmask_b32_e64 v3, v5, 0, s4
+; GFX12-GI-NEXT:    s_setpc_b64 s[30:31]
+    %x = call <2 x i64> @llvm.fptosi.sat.v2f64.v2i64(<2 x double> %f)
+    ret <2 x i64> %x
+}
+
+define <2 x i1> @test_s_signed_v2f64_v2i1(<2 x double> inreg %f) {
+; GFX7-LABEL: test_s_signed_v2f64_v2i1:
+; GFX7:       ; %bb.0:
+; GFX7-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-NEXT:    v_cvt_i32_f64_e32 v0, s[16:17]
+; GFX7-NEXT:    v_cvt_i32_f64_e32 v1, s[18:19]
+; GFX7-NEXT:    v_med3_i32 v0, v0, -1, 0
+; GFX7-NEXT:    v_med3_i32 v1, v1, -1, 0
+; GFX7-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX9-LABEL: test_s_signed_v2f64_v2i1:
+; GFX9:       ; %bb.0:
+; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    v_cvt_i32_f64_e32 v0, s[18:19]
+; GFX9-NEXT:    v_cvt_i32_f64_e32 v2, s[16:17]
+; GFX9-NEXT:    v_med3_i32 v1, v0, -1, 0
+; GFX9-NEXT:    v_med3_i32 v0, v2, -1, 0
+; GFX9-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11-LABEL: test_s_signed_v2f64_v2i1:
+; GFX11:       ; %bb.0:
+; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-NEXT:    v_cvt_i32_f64_e32 v0, s[0:1]
+; GFX11-NEXT:    v_cvt_i32_f64_e32 v1, s[2:3]
+; GFX11-NEXT:    v_med3_i32 v0, v0, -1, 0
+; GFX11-NEXT:    v_med3_i32 v1, v1, -1, 0
+; GFX11-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-LABEL: test_s_signed_v2f64_v2i1:
+; GFX12:       ; %bb.0:
+; GFX12-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-NEXT:    s_wait_expcnt 0x0
+; GFX12-NEXT:    s_wait_samplecnt 0x0
+; GFX12-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-NEXT:    s_wait_kmcnt 0x0
+; GFX12-NEXT:    v_cvt_i32_f64_e32 v0, s[0:1]
+; GFX12-NEXT:    v_cvt_i32_f64_e32 v1, s[2:3]
+; GFX12-NEXT:    v_med3_i32 v0, v0, -1, 0
+; GFX12-NEXT:    v_med3_i32 v1, v1, -1, 0
+; GFX12-NEXT:    s_setpc_b64 s[30:31]
+    %x = call <2 x i1> @llvm.fptosi.sat.v2f64.v2i1(<2 x double> %f)
+    ret <2 x i1> %x
+}
+
+define <2 x i8> @test_s_signed_v2f64_v2i8(<2 x double> inreg %f) {
+; GFX7-ISEL-LABEL: test_s_signed_v2f64_v2i8:
+; GFX7-ISEL:       ; %bb.0:
+; GFX7-ISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-ISEL-NEXT:    v_cvt_i32_f64_e32 v0, s[18:19]
+; GFX7-ISEL-NEXT:    v_cvt_i32_f64_e32 v1, s[16:17]
+; GFX7-ISEL-NEXT:    s_movk_i32 s4, 0xff80
+; GFX7-ISEL-NEXT:    v_mov_b32_e32 v2, 0x7f
+; GFX7-ISEL-NEXT:    v_med3_i32 v3, v0, s4, v2
+; GFX7-ISEL-NEXT:    v_med3_i32 v1, v1, s4, v2
+; GFX7-ISEL-NEXT:    v_lshlrev_b32_e32 v0, 8, v3
+; GFX7-ISEL-NEXT:    v_and_b32_e32 v1, 0xff, v1
+; GFX7-ISEL-NEXT:    v_or_b32_e32 v0, v1, v0
+; GFX7-ISEL-NEXT:    v_and_b32_e32 v1, 0xff, v3
+; GFX7-ISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX7-GI-LABEL: test_s_signed_v2f64_v2i8:
+; GFX7-GI:       ; %bb.0:
+; GFX7-GI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-GI-NEXT:    v_cvt_i32_f64_e32 v0, s[16:17]
+; GFX7-GI-NEXT:    v_cvt_i32_f64_e32 v1, s[18:19]
+; GFX7-GI-NEXT:    v_mov_b32_e32 v2, 0x7f
+; GFX7-GI-NEXT:    v_mov_b32_e32 v3, 0xffffff80
+; GFX7-GI-NEXT:    v_med3_i32 v0, v0, v3, v2
+; GFX7-GI-NEXT:    v_med3_i32 v1, v1, v3, v2
+; GFX7-GI-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX9-LABEL: test_s_signed_v2f64_v2i8:
+; GFX9:       ; %bb.0:
+; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    v_cvt_i32_f64_e32 v0, s[18:19]
+; GFX9-NEXT:    v_cvt_i32_f64_e32 v1, s[16:17]
+; GFX9-NEXT:    s_movk_i32 s4, 0xff80
+; GFX9-NEXT:    v_mov_b32_e32 v2, 0x7f
+; GFX9-NEXT:    v_med3_i32 v3, v0, s4, v2
+; GFX9-NEXT:    v_lshlrev_b32_e32 v0, 8, v3
+; GFX9-NEXT:    v_med3_i32 v1, v1, s4, v2
+; GFX9-NEXT:    v_or_b32_sdwa v0, v1, v0 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:BYTE_0 src1_sel:DWORD
+; GFX9-NEXT:    v_and_b32_e32 v1, 0xff, v3
+; GFX9-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11-LABEL: test_s_signed_v2f64_v2i8:
+; GFX11:       ; %bb.0:
+; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-NEXT:    v_cvt_i32_f64_e32 v0, s[2:3]
+; GFX11-NEXT:    v_cvt_i32_f64_e32 v1, s[0:1]
+; GFX11-NEXT:    s_movk_i32 s0, 0xff80
+; GFX11-NEXT:    v_med3_i32 v2, v0, s0, 0x7f
+; GFX11-NEXT:    v_med3_i32 v0, v1, s0, 0x7f
+; GFX11-NEXT:    v_lshlrev_b32_e32 v1, 8, v2
+; GFX11-NEXT:    v_and_b32_e32 v0, 0xff, v0
+; GFX11-NEXT:    v_or_b32_e32 v0, v0, v1
+; GFX11-NEXT:    v_and_b32_e32 v1, 0xff, v2
+; GFX11-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-ISEL-LABEL: test_s_signed_v2f64_v2i8:
+; GFX12-ISEL:       ; %bb.0:
+; GFX12-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX12-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX12-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX12-ISEL-NEXT:    v_cvt_i32_f64_e32 v0, s[2:3]
+; GFX12-ISEL-NEXT:    v_cvt_i32_f64_e32 v1, s[0:1]
+; GFX12-ISEL-NEXT:    s_movk_i32 s0, 0xff80
+; GFX12-ISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-ISEL-NEXT:    v_med3_i32 v2, v0, s0, 0x7f
+; GFX12-ISEL-NEXT:    v_med3_i32 v0, v1, s0, 0x7f
+; GFX12-ISEL-NEXT:    v_lshlrev_b32_e32 v1, 8, v2
+; GFX12-ISEL-NEXT:    v_and_b32_e32 v0, 0xff, v0
+; GFX12-ISEL-NEXT:    v_or_b32_e32 v0, v0, v1
+; GFX12-ISEL-NEXT:    v_and_b32_e32 v1, 0xff, v2
+; GFX12-ISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-GI-LABEL: test_s_signed_v2f64_v2i8:
+; GFX12-GI:       ; %bb.0:
+; GFX12-GI-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-GI-NEXT:    s_wait_expcnt 0x0
+; GFX12-GI-NEXT:    s_wait_samplecnt 0x0
+; GFX12-GI-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-GI-NEXT:    s_wait_kmcnt 0x0
+; GFX12-GI-NEXT:    v_cvt_i32_f64_e32 v0, s[0:1]
+; GFX12-GI-NEXT:    v_cvt_i32_f64_e32 v1, s[2:3]
+; GFX12-GI-NEXT:    v_mov_b32_e32 v2, 0xffffff80
+; GFX12-GI-NEXT:    v_med3_i32 v0, v0, v2, 0x7f
+; GFX12-GI-NEXT:    v_med3_i32 v1, v1, v2, 0x7f
+; GFX12-GI-NEXT:    s_setpc_b64 s[30:31]
+    %x = call <2 x i8> @llvm.fptosi.sat.v2f64.v2i8(<2 x double> %f)
+    ret <2 x i8> %x
+}
+
+define <2 x i16> @test_s_signed_v2f64_v2i16(<2 x double> inreg %f) {
+; GFX7-ISEL-LABEL: test_s_signed_v2f64_v2i16:
+; GFX7-ISEL:       ; %bb.0:
+; GFX7-ISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-ISEL-NEXT:    v_cvt_i32_f64_e32 v0, s[18:19]
+; GFX7-ISEL-NEXT:    v_cvt_i32_f64_e32 v1, s[16:17]
+; GFX7-ISEL-NEXT:    s_movk_i32 s4, 0x8000
+; GFX7-ISEL-NEXT:    v_mov_b32_e32 v2, 0x7fff
+; GFX7-ISEL-NEXT:    v_med3_i32 v0, v0, s4, v2
+; GFX7-ISEL-NEXT:    v_med3_i32 v1, v1, s4, v2
+; GFX7-ISEL-NEXT:    v_lshlrev_b32_e32 v0, 16, v0
+; GFX7-ISEL-NEXT:    v_and_b32_e32 v1, 0xffff, v1
+; GFX7-ISEL-NEXT:    v_or_b32_e32 v0, v1, v0
+; GFX7-ISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX7-GI-LABEL: test_s_signed_v2f64_v2i16:
+; GFX7-GI:       ; %bb.0:
+; GFX7-GI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-GI-NEXT:    v_cvt_i32_f64_e32 v1, s[18:19]
+; GFX7-GI-NEXT:    v_cvt_i32_f64_e32 v0, s[16:17]
+; GFX7-GI-NEXT:    v_mov_b32_e32 v2, 0x7fff
+; GFX7-GI-NEXT:    v_mov_b32_e32 v3, 0xffff8000
+; GFX7-GI-NEXT:    v_med3_i32 v1, v1, v3, v2
+; GFX7-GI-NEXT:    v_med3_i32 v0, v0, v3, v2
+; GFX7-GI-NEXT:    v_and_b32_e32 v1, 0xffff, v1
+; GFX7-GI-NEXT:    v_and_b32_e32 v0, 0xffff, v0
+; GFX7-GI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; GFX7-GI-NEXT:    v_or_b32_e32 v0, v0, v1
+; GFX7-GI-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX9-LABEL: test_s_signed_v2f64_v2i16:
+; GFX9:       ; %bb.0:
+; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    v_cvt_i32_f64_e32 v1, s[16:17]
+; GFX9-NEXT:    v_cvt_i32_f64_e32 v0, s[18:19]
+; GFX9-NEXT:    s_movk_i32 s4, 0x8000
+; GFX9-NEXT:    v_mov_b32_e32 v2, 0x7fff
+; GFX9-NEXT:    v_med3_i32 v1, v1, s4, v2
+; GFX9-NEXT:    v_med3_i32 v0, v0, s4, v2
+; GFX9-NEXT:    v_and_b32_e32 v1, 0xffff, v1
+; GFX9-NEXT:    v_lshl_or_b32 v0, v0, 16, v1
+; GFX9-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11-FAKE16-LABEL: test_s_signed_v2f64_v2i16:
+; GFX11-FAKE16:       ; %bb.0:
+; GFX11-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-FAKE16-NEXT:    v_cvt_i32_f64_e32 v0, s[0:1]
+; GFX11-FAKE16-NEXT:    v_cvt_i32_f64_e32 v1, s[2:3]
+; GFX11-FAKE16-NEXT:    s_movk_i32 s0, 0x8000
+; GFX11-FAKE16-NEXT:    v_med3_i32 v0, v0, s0, 0x7fff
+; GFX11-FAKE16-NEXT:    v_med3_i32 v1, v1, s0, 0x7fff
+; GFX11-FAKE16-NEXT:    v_and_b32_e32 v0, 0xffff, v0
+; GFX11-FAKE16-NEXT:    v_lshl_or_b32 v0, v1, 16, v0
+; GFX11-FAKE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11-TRUE16-LABEL: test_s_signed_v2f64_v2i16:
+; GFX11-TRUE16:       ; %bb.0:
+; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-TRUE16-NEXT:    v_cvt_i32_f64_e32 v0, s[2:3]
+; GFX11-TRUE16-NEXT:    v_cvt_i32_f64_e32 v1, s[0:1]
+; GFX11-TRUE16-NEXT:    s_movk_i32 s0, 0x8000
+; GFX11-TRUE16-NEXT:    v_med3_i32 v2, v0, s0, 0x7fff
+; GFX11-TRUE16-NEXT:    v_med3_i32 v0, v1, s0, 0x7fff
+; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v0.h, v2.l
+; GFX11-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-FAKE16-LABEL: test_s_signed_v2f64_v2i16:
+; GFX12-FAKE16:       ; %bb.0:
+; GFX12-FAKE16-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-FAKE16-NEXT:    s_wait_expcnt 0x0
+; GFX12-FAKE16-NEXT:    s_wait_samplecnt 0x0
+; GFX12-FAKE16-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-FAKE16-NEXT:    s_wait_kmcnt 0x0
+; GFX12-FAKE16-NEXT:    v_cvt_i32_f64_e32 v0, s[0:1]
+; GFX12-FAKE16-NEXT:    v_cvt_i32_f64_e32 v1, s[2:3]
+; GFX12-FAKE16-NEXT:    s_movk_i32 s0, 0x8000
+; GFX12-FAKE16-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-FAKE16-NEXT:    v_med3_i32 v0, v0, s0, 0x7fff
+; GFX12-FAKE16-NEXT:    v_med3_i32 v1, v1, s0, 0x7fff
+; GFX12-FAKE16-NEXT:    v_and_b32_e32 v0, 0xffff, v0
+; GFX12-FAKE16-NEXT:    v_lshl_or_b32 v0, v1, 16, v0
+; GFX12-FAKE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-TRUE16-LABEL: test_s_signed_v2f64_v2i16:
+; GFX12-TRUE16:       ; %bb.0:
+; GFX12-TRUE16-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-TRUE16-NEXT:    s_wait_expcnt 0x0
+; GFX12-TRUE16-NEXT:    s_wait_samplecnt 0x0
+; GFX12-TRUE16-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-TRUE16-NEXT:    s_wait_kmcnt 0x0
+; GFX12-TRUE16-NEXT:    v_cvt_i32_f64_e32 v0, s[2:3]
+; GFX12-TRUE16-NEXT:    v_cvt_i32_f64_e32 v1, s[0:1]
+; GFX12-TRUE16-NEXT:    s_movk_i32 s0, 0x8000
+; GFX12-TRUE16-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-TRUE16-NEXT:    v_med3_i32 v2, v0, s0, 0x7fff
+; GFX12-TRUE16-NEXT:    v_med3_i32 v0, v1, s0, 0x7fff
+; GFX12-TRUE16-NEXT:    v_mov_b16_e32 v0.h, v2.l
+; GFX12-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-GI-LABEL: test_s_signed_v2f64_v2i16:
+; GFX12-GI:       ; %bb.0:
+; GFX12-GI-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-GI-NEXT:    s_wait_expcnt 0x0
+; GFX12-GI-NEXT:    s_wait_samplecnt 0x0
+; GFX12-GI-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-GI-NEXT:    s_wait_kmcnt 0x0
+; GFX12-GI-NEXT:    v_cvt_i32_f64_e32 v0, s[2:3]
+; GFX12-GI-NEXT:    v_cvt_i32_f64_e32 v1, s[0:1]
+; GFX12-GI-NEXT:    v_mov_b32_e32 v2, 0xffff8000
+; GFX12-GI-NEXT:    v_med3_i32 v3, v0, v2, 0x7fff
+; GFX12-GI-NEXT:    v_med3_i32 v0, v1, v2, 0x7fff
+; GFX12-GI-NEXT:    v_mov_b16_e32 v0.h, v3.l
+; GFX12-GI-NEXT:    s_setpc_b64 s[30:31]
+    %x = call <2 x i16> @llvm.fptosi.sat.v2f64.v2i16(<2 x double> %f)
+    ret <2 x i16> %x
+}
+
+define <2 x i64> @test_s_signed_v2f64_v2i64(<2 x double> inreg %f) {
+; GFX7-ISEL-LABEL: test_s_signed_v2f64_v2i64:
+; GFX7-ISEL:       ; %bb.0:
+; GFX7-ISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-ISEL-NEXT:    v_trunc_f64_e32 v[0:1], s[16:17]
+; GFX7-ISEL-NEXT:    v_trunc_f64_e32 v[2:3], s[18:19]
+; GFX7-ISEL-NEXT:    s_movk_i32 s4, 0xffe0
+; GFX7-ISEL-NEXT:    v_mov_b32_e32 v8, 0
+; GFX7-ISEL-NEXT:    v_mov_b32_e32 v9, 0xc3e00000
+; GFX7-ISEL-NEXT:    s_mov_b32 s6, 0
+; GFX7-ISEL-NEXT:    s_mov_b32 s7, 0xc1f00000
+; GFX7-ISEL-NEXT:    v_cmp_nge_f64_e32 vcc, s[16:17], v[8:9]
+; GFX7-ISEL-NEXT:    v_ldexp_f64 v[4:5], v[0:1], s4
+; GFX7-ISEL-NEXT:    v_ldexp_f64 v[6:7], v[2:3], s4
+; GFX7-ISEL-NEXT:    s_mov_b32 s4, -1
+; GFX7-ISEL-NEXT:    s_mov_b32 s5, 0x43dfffff
+; GFX7-ISEL-NEXT:    v_mov_b32_e32 v11, s5
+; GFX7-ISEL-NEXT:    v_mov_b32_e32 v10, s4
+; GFX7-ISEL-NEXT:    v_cmp_nge_f64_e64 s[4:5], s[18:19], v[8:9]
+; GFX7-ISEL-NEXT:    v_cmp_gt_f64_e64 s[8:9], s[18:19], v[10:11]
+; GFX7-ISEL-NEXT:    v_floor_f64_e32 v[4:5], v[4:5]
+; GFX7-ISEL-NEXT:    v_floor_f64_e32 v[6:7], v[6:7]
+; GFX7-ISEL-NEXT:    v_cmp_u_f64_e64 s[10:11], s[16:17], s[16:17]
+; GFX7-ISEL-NEXT:    v_cmp_u_f64_e64 s[12:13], s[18:19], s[18:19]
+; GFX7-ISEL-NEXT:    v_bfrev_b32_e32 v12, 1
+; GFX7-ISEL-NEXT:    v_bfrev_b32_e32 v13, -2
+; GFX7-ISEL-NEXT:    v_cvt_i32_f64_e32 v14, v[4:5]
+; GFX7-ISEL-NEXT:    v_cvt_i32_f64_e32 v15, v[6:7]
+; GFX7-ISEL-NEXT:    v_fma_f64 v[4:5], v[4:5], s[6:7], v[0:1]
+; GFX7-ISEL-NEXT:    v_fma_f64 v[6:7], v[6:7], s[6:7], v[2:3]
+; GFX7-ISEL-NEXT:    v_cmp_gt_f64_e64 s[6:7], s[16:17], v[10:11]
+; GFX7-ISEL-NEXT:    v_cndmask_b32_e32 v0, v14, v12, vcc
+; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v1, v15, v12, s[4:5]
+; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v2, v1, v13, s[8:9]
+; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v3, v2, 0, s[12:13]
+; GFX7-ISEL-NEXT:    v_cvt_u32_f64_e32 v2, v[6:7]
+; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v0, v0, v13, s[6:7]
+; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v1, v0, 0, s[10:11]
+; GFX7-ISEL-NEXT:    v_cvt_u32_f64_e32 v0, v[4:5]
+; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v2, v2, 0, s[4:5]
+; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v2, v2, -1, s[8:9]
+; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v2, v2, 0, s[12:13]
+; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v0, v0, 0, vcc
+; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v0, v0, -1, s[6:7]
+; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v0, v0, 0, s[10:11]
+; GFX7-ISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX7-GI-LABEL: test_s_signed_v2f64_v2i64:
+; GFX7-GI:       ; %bb.0:
+; GFX7-GI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-GI-NEXT:    v_trunc_f64_e32 v[0:1], s[16:17]
+; GFX7-GI-NEXT:    v_trunc_f64_e32 v[2:3], s[18:19]
+; GFX7-GI-NEXT:    v_mov_b32_e32 v4, 0
+; GFX7-GI-NEXT:    v_mov_b32_e32 v5, 0x3df00000
+; GFX7-GI-NEXT:    v_mov_b32_e32 v8, 0
+; GFX7-GI-NEXT:    v_mov_b32_e32 v9, 0xc1f00000
+; GFX7-GI-NEXT:    v_mov_b32_e32 v10, -1
+; GFX7-GI-NEXT:    v_mov_b32_e32 v11, 0x43dfffff
+; GFX7-GI-NEXT:    v_mul_f64 v[6:7], v[0:1], v[4:5]
+; GFX7-GI-NEXT:    v_mul_f64 v[4:5], v[2:3], v[4:5]
+; GFX7-GI-NEXT:    v_cmp_gt_f64_e64 s[6:7], s[16:17], v[10:11]
+; GFX7-GI-NEXT:    v_cmp_gt_f64_e64 s[8:9], s[18:19], v[10:11]
+; GFX7-GI-NEXT:    v_cmp_u_f64_e64 s[10:11], s[16:17], s[16:17]
+; GFX7-GI-NEXT:    v_cmp_u_f64_e64 s[12:13], s[18:19], s[18:19]
+; GFX7-GI-NEXT:    v_bfrev_b32_e32 v12, 1
+; GFX7-GI-NEXT:    v_bfrev_b32_e32 v13, -2
+; GFX7-GI-NEXT:    v_floor_f64_e32 v[6:7], v[6:7]
+; GFX7-GI-NEXT:    v_floor_f64_e32 v[4:5], v[4:5]
+; GFX7-GI-NEXT:    v_fma_f64 v[0:1], v[6:7], v[8:9], v[0:1]
+; GFX7-GI-NEXT:    v_fma_f64 v[2:3], v[4:5], v[8:9], v[2:3]
+; GFX7-GI-NEXT:    v_mov_b32_e32 v8, 0
+; GFX7-GI-NEXT:    v_mov_b32_e32 v9, 0xc3e00000
+; GFX7-GI-NEXT:    v_cmp_nge_f64_e32 vcc, s[16:17], v[8:9]
+; GFX7-GI-NEXT:    v_cmp_nge_f64_e64 s[4:5], s[18:19], v[8:9]
+; GFX7-GI-NEXT:    v_cvt_i32_f64_e32 v6, v[6:7]
+; GFX7-GI-NEXT:    v_cvt_u32_f64_e32 v0, v[0:1]
+; GFX7-GI-NEXT:    v_cvt_i32_f64_e32 v1, v[4:5]
+; GFX7-GI-NEXT:    v_cvt_u32_f64_e32 v2, v[2:3]
+; GFX7-GI-NEXT:    v_cndmask_b32_e32 v3, v6, v12, vcc
+; GFX7-GI-NEXT:    v_cndmask_b32_e64 v0, v0, 0, vcc
+; GFX7-GI-NEXT:    v_cndmask_b32_e64 v2, v2, 0, s[4:5]
+; GFX7-GI-NEXT:    v_cndmask_b32_e64 v1, v1, v12, s[4:5]
+; GFX7-GI-NEXT:    v_cndmask_b32_e64 v0, v0, -1, s[6:7]
+; GFX7-GI-NEXT:    v_cndmask_b32_e64 v2, v2, -1, s[8:9]
+; GFX7-GI-NEXT:    v_cndmask_b32_e64 v3, v3, v13, s[6:7]
+; GFX7-GI-NEXT:    v_cndmask_b32_e64 v4, v1, v13, s[8:9]
+; GFX7-GI-NEXT:    v_cndmask_b32_e64 v0, v0, 0, s[10:11]
+; GFX7-GI-NEXT:    v_cndmask_b32_e64 v2, v2, 0, s[12:13]
+; GFX7-GI-NEXT:    v_cndmask_b32_e64 v1, v3, 0, s[10:11]
+; GFX7-GI-NEXT:    v_cndmask_b32_e64 v3, v4, 0, s[12:13]
+; GFX7-GI-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX9-LABEL: test_s_signed_v2f64_v2i64:
+; GFX9:       ; %bb.0:
+; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    v_trunc_f64_e32 v[0:1], s[16:17]
+; GFX9-NEXT:    v_trunc_f64_e32 v[2:3], s[18:19]
+; GFX9-NEXT:    s_movk_i32 s4, 0xffe0
+; GFX9-NEXT:    v_mov_b32_e32 v8, 0
+; GFX9-NEXT:    v_mov_b32_e32 v9, 0xc3e00000
+; GFX9-NEXT:    s_mov_b32 s6, 0
+; GFX9-NEXT:    s_mov_b32 s7, 0xc1f00000
+; GFX9-NEXT:    v_cmp_nge_f64_e32 vcc, s[16:17], v[8:9]
+; GFX9-NEXT:    v_ldexp_f64 v[4:5], v[0:1], s4
+; GFX9-NEXT:    v_ldexp_f64 v[6:7], v[2:3], s4
+; GFX9-NEXT:    s_mov_b32 s4, -1
+; GFX9-NEXT:    s_mov_b32 s5, 0x43dfffff
+; GFX9-NEXT:    v_mov_b32_e32 v11, s5
+; GFX9-NEXT:    v_mov_b32_e32 v10, s4
+; GFX9-NEXT:    v_cmp_nge_f64_e64 s[4:5], s[18:19], v[8:9]
+; GFX9-NEXT:    v_cmp_gt_f64_e64 s[8:9], s[18:19], v[10:11]
+; GFX9-NEXT:    v_floor_f64_e32 v[4:5], v[4:5]
+; GFX9-NEXT:    v_floor_f64_e32 v[6:7], v[6:7]
+; GFX9-NEXT:    v_cmp_u_f64_e64 s[10:11], s[16:17], s[16:17]
+; GFX9-NEXT:    v_cmp_u_f64_e64 s[12:13], s[18:19], s[18:19]
+; GFX9-NEXT:    v_bfrev_b32_e32 v12, 1
+; GFX9-NEXT:    v_bfrev_b32_e32 v13, -2
+; GFX9-NEXT:    v_cvt_i32_f64_e32 v14, v[4:5]
+; GFX9-NEXT:    v_cvt_i32_f64_e32 v15, v[6:7]
+; GFX9-NEXT:    v_fma_f64 v[4:5], v[4:5], s[6:7], v[0:1]
+; GFX9-NEXT:    v_fma_f64 v[6:7], v[6:7], s[6:7], v[2:3]
+; GFX9-NEXT:    v_cmp_gt_f64_e64 s[6:7], s[16:17], v[10:11]
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, v14, v12, vcc
+; GFX9-NEXT:    v_cndmask_b32_e64 v1, v15, v12, s[4:5]
+; GFX9-NEXT:    v_cndmask_b32_e64 v2, v1, v13, s[8:9]
+; GFX9-NEXT:    v_cndmask_b32_e64 v3, v2, 0, s[12:13]
+; GFX9-NEXT:    v_cvt_u32_f64_e32 v2, v[6:7]
+; GFX9-NEXT:    v_cndmask_b32_e64 v0, v0, v13, s[6:7]
+; GFX9-NEXT:    v_cndmask_b32_e64 v1, v0, 0, s[10:11]
+; GFX9-NEXT:    v_cvt_u32_f64_e32 v0, v[4:5]
+; GFX9-NEXT:    v_cndmask_b32_e64 v2, v2, 0, s[4:5]
+; GFX9-NEXT:    v_cndmask_b32_e64 v2, v2, -1, s[8:9]
+; GFX9-NEXT:    v_cndmask_b32_e64 v2, v2, 0, s[12:13]
+; GFX9-NEXT:    v_cndmask_b32_e64 v0, v0, 0, vcc
+; GFX9-NEXT:    v_cndmask_b32_e64 v0, v0, -1, s[6:7]
+; GFX9-NEXT:    v_cndmask_b32_e64 v0, v0, 0, s[10:11]
+; GFX9-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11-LABEL: test_s_signed_v2f64_v2i64:
+; GFX11:       ; %bb.0:
+; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-NEXT:    v_trunc_f64_e32 v[0:1], s[0:1]
+; GFX11-NEXT:    v_trunc_f64_e32 v[2:3], s[2:3]
+; GFX11-NEXT:    v_cmp_nle_f64_e64 s6, 0xc3e00000, s[0:1]
+; GFX11-NEXT:    v_cmp_nle_f64_e64 s7, 0xc3e00000, s[2:3]
+; GFX11-NEXT:    s_mov_b32 s4, -1
+; GFX11-NEXT:    s_mov_b32 s5, 0x43dfffff
+; GFX11-NEXT:    v_cmp_gt_f64_e64 s8, s[0:1], s[4:5]
+; GFX11-NEXT:    v_cmp_gt_f64_e64 s4, s[2:3], s[4:5]
+; GFX11-NEXT:    v_cmp_u_f64_e64 s0, s[0:1], s[0:1]
+; GFX11-NEXT:    v_cmp_u_f64_e64 s1, s[2:3], s[2:3]
+; GFX11-NEXT:    v_ldexp_f64 v[4:5], v[0:1], 0xffffffe0
+; GFX11-NEXT:    v_ldexp_f64 v[6:7], v[2:3], 0xffffffe0
+; GFX11-NEXT:    v_floor_f64_e32 v[4:5], v[4:5]
+; GFX11-NEXT:    v_floor_f64_e32 v[6:7], v[6:7]
+; GFX11-NEXT:    v_fma_f64 v[0:1], 0xc1f00000, v[4:5], v[0:1]
+; GFX11-NEXT:    v_fma_f64 v[2:3], 0xc1f00000, v[6:7], v[2:3]
+; GFX11-NEXT:    v_cvt_i32_f64_e32 v4, v[4:5]
+; GFX11-NEXT:    v_cvt_i32_f64_e32 v5, v[6:7]
+; GFX11-NEXT:    v_cvt_u32_f64_e32 v0, v[0:1]
+; GFX11-NEXT:    v_cvt_u32_f64_e32 v1, v[2:3]
+; GFX11-NEXT:    v_cndmask_b32_e64 v2, v4, 0x80000000, s6
+; GFX11-NEXT:    v_cndmask_b32_e64 v3, v5, 0x80000000, s7
+; GFX11-NEXT:    v_cndmask_b32_e64 v2, v2, 0x7fffffff, s8
+; GFX11-NEXT:    v_cndmask_b32_e64 v3, v3, 0x7fffffff, s4
+; GFX11-NEXT:    v_cndmask_b32_e64 v3, v3, 0, s1
+; GFX11-NEXT:    v_cndmask_b32_e64 v0, v0, 0, s6
+; GFX11-NEXT:    v_cndmask_b32_e64 v1, v1, 0, s7
+; GFX11-NEXT:    v_cndmask_b32_e64 v0, v0, -1, s8
+; GFX11-NEXT:    v_cndmask_b32_e64 v4, v1, -1, s4
+; GFX11-NEXT:    v_cndmask_b32_e64 v1, v2, 0, s0
+; GFX11-NEXT:    v_cndmask_b32_e64 v0, v0, 0, s0
+; GFX11-NEXT:    v_cndmask_b32_e64 v2, v4, 0, s1
+; GFX11-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-ISEL-LABEL: test_s_signed_v2f64_v2i64:
+; GFX12-ISEL:       ; %bb.0:
+; GFX12-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX12-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX12-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX12-ISEL-NEXT:    v_trunc_f64_e32 v[0:1], s[0:1]
+; GFX12-ISEL-NEXT:    v_trunc_f64_e32 v[2:3], s[2:3]
+; GFX12-ISEL-NEXT:    v_cmp_nle_f64_e64 s6, 0xc3e00000, s[0:1]
+; GFX12-ISEL-NEXT:    v_cmp_nle_f64_e64 s7, 0xc3e00000, s[2:3]
+; GFX12-ISEL-NEXT:    s_mov_b32 s4, -1
+; GFX12-ISEL-NEXT:    s_mov_b32 s5, 0x43dfffff
+; GFX12-ISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-ISEL-NEXT:    v_cmp_gt_f64_e64 s8, s[0:1], s[4:5]
+; GFX12-ISEL-NEXT:    v_cmp_gt_f64_e64 s4, s[2:3], s[4:5]
+; GFX12-ISEL-NEXT:    v_cmp_u_f64_e64 s0, s[0:1], s[0:1]
+; GFX12-ISEL-NEXT:    v_cmp_u_f64_e64 s1, s[2:3], s[2:3]
+; GFX12-ISEL-NEXT:    v_ldexp_f64 v[4:5], v[0:1], 0xffffffe0
+; GFX12-ISEL-NEXT:    v_ldexp_f64 v[6:7], v[2:3], 0xffffffe0
+; GFX12-ISEL-NEXT:    v_floor_f64_e32 v[4:5], v[4:5]
+; GFX12-ISEL-NEXT:    v_floor_f64_e32 v[6:7], v[6:7]
+; GFX12-ISEL-NEXT:    v_fma_f64 v[0:1], 0xc1f00000, v[4:5], v[0:1]
+; GFX12-ISEL-NEXT:    v_fma_f64 v[2:3], 0xc1f00000, v[6:7], v[2:3]
+; GFX12-ISEL-NEXT:    v_cvt_i32_f64_e32 v4, v[4:5]
+; GFX12-ISEL-NEXT:    v_cvt_i32_f64_e32 v5, v[6:7]
+; GFX12-ISEL-NEXT:    v_cvt_u32_f64_e32 v0, v[0:1]
+; GFX12-ISEL-NEXT:    v_cvt_u32_f64_e32 v1, v[2:3]
+; GFX12-ISEL-NEXT:    s_wait_alu depctr_va_sdst(0)
+; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v2, v4, 0x80000000, s6
+; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v3, v5, 0x80000000, s7
+; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v2, v2, 0x7fffffff, s8
+; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v3, v3, 0x7fffffff, s4
+; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v3, v3, 0, s1
+; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v0, v0, 0, s6
+; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v1, v1, 0, s7
+; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v0, v0, -1, s8
+; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v4, v1, -1, s4
+; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v1, v2, 0, s0
+; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v0, v0, 0, s0
+; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v2, v4, 0, s1
+; GFX12-ISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-GI-LABEL: test_s_signed_v2f64_v2i64:
+; GFX12-GI:       ; %bb.0:
+; GFX12-GI-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-GI-NEXT:    s_wait_expcnt 0x0
+; GFX12-GI-NEXT:    s_wait_samplecnt 0x0
+; GFX12-GI-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-GI-NEXT:    s_wait_kmcnt 0x0
+; GFX12-GI-NEXT:    v_trunc_f64_e32 v[0:1], s[0:1]
+; GFX12-GI-NEXT:    v_trunc_f64_e32 v[2:3], s[2:3]
+; GFX12-GI-NEXT:    v_cmp_nle_f64_e64 s6, 0xc3e00000, s[2:3]
+; GFX12-GI-NEXT:    v_cmp_nle_f64_e64 s5, 0xc3e00000, s[0:1]
+; GFX12-GI-NEXT:    v_mul_f64_e32 v[4:5], 0x3df00000, v[0:1]
+; GFX12-GI-NEXT:    v_mul_f64_e32 v[6:7], 0x3df00000, v[2:3]
+; GFX12-GI-NEXT:    v_floor_f64_e32 v[4:5], v[4:5]
+; GFX12-GI-NEXT:    v_floor_f64_e32 v[6:7], v[6:7]
+; GFX12-GI-NEXT:    v_fma_f64 v[0:1], 0xc1f00000, v[4:5], v[0:1]
+; GFX12-GI-NEXT:    v_fma_f64 v[2:3], 0xc1f00000, v[6:7], v[2:3]
+; GFX12-GI-NEXT:    v_cvt_u32_f64_e32 v8, v[0:1]
+; GFX12-GI-NEXT:    v_mov_b32_e32 v0, -1
+; GFX12-GI-NEXT:    v_cvt_u32_f64_e32 v2, v[2:3]
+; GFX12-GI-NEXT:    v_mov_b32_e32 v1, 0x43dfffff
+; GFX12-GI-NEXT:    v_cvt_i32_f64_e32 v3, v[4:5]
+; GFX12-GI-NEXT:    v_cvt_i32_f64_e32 v4, v[6:7]
+; GFX12-GI-NEXT:    v_cmp_gt_f64_e64 s4, s[2:3], v[0:1]
+; GFX12-GI-NEXT:    v_cmp_gt_f64_e32 vcc_lo, s[0:1], v[0:1]
+; GFX12-GI-NEXT:    v_cmp_u_f64_e64 s0, s[0:1], s[0:1]
+; GFX12-GI-NEXT:    v_cmp_u_f64_e64 s1, s[2:3], s[2:3]
+; GFX12-GI-NEXT:    s_wait_alu depctr_va_sdst(0)
+; GFX12-GI-NEXT:    v_cndmask_b32_e64 v5, v8, 0, s5
+; GFX12-GI-NEXT:    v_cndmask_b32_e64 v2, v2, 0, s6
+; GFX12-GI-NEXT:    v_cndmask_b32_e64 v1, v2, -1, s4
+; GFX12-GI-NEXT:    v_cndmask_b32_e64 v2, v3, 0x80000000, s5
+; GFX12-GI-NEXT:    v_cndmask_b32_e64 v3, v4, 0x80000000, s6
+; GFX12-GI-NEXT:    s_wait_alu depctr_va_vcc(0)
+; GFX12-GI-NEXT:    v_cndmask_b32_e64 v0, v5, -1, vcc_lo
+; GFX12-GI-NEXT:    v_cndmask_b32_e64 v4, v2, 0x7fffffff, vcc_lo
+; GFX12-GI-NEXT:    v_cndmask_b32_e64 v3, v3, 0x7fffffff, s4
+; GFX12-GI-NEXT:    v_cndmask_b32_e64 v0, v0, 0, s0
+; GFX12-GI-NEXT:    v_cndmask_b32_e64 v2, v1, 0, s1
+; GFX12-GI-NEXT:    v_cndmask_b32_e64 v1, v4, 0, s0
+; GFX12-GI-NEXT:    v_cndmask_b32_e64 v3, v3, 0, s1
 ; GFX12-GI-NEXT:    s_setpc_b64 s[30:31]
     %x = call <2 x i64> @llvm.fptosi.sat.v2f64.v2i64(<2 x double> %f)
     ret <2 x i64> %x
@@ -2028,6 +3192,705 @@ define <4 x i64> @test_signed_v4f16_v4i64(<4 x half> %f) {
 ; GFX12-GI-NEXT:    v_mov_b32_e32 v1, 0
 ; GFX12-GI-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX12-GI-NEXT:    v_mov_b32_e32 v7, 0
+; GFX12-GI-NEXT:    s_setpc_b64 s[30:31]
+    %x = call <4 x i64> @llvm.fptosi.sat.v4f16.v4i64(<4 x half> %f)
+    ret <4 x i64> %x
+}
+
+define <4 x i1> @test_s_signed_v4f16_v4i1(<4 x half> inreg %f) {
+; GFX7-ISEL-LABEL: test_s_signed_v4f16_v4i1:
+; GFX7-ISEL:       ; %bb.0:
+; GFX7-ISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-ISEL-NEXT:    s_lshr_b32 s4, s17, 16
+; GFX7-ISEL-NEXT:    s_lshr_b32 s5, s16, 16
+; GFX7-ISEL-NEXT:    v_cvt_f32_f16_e32 v0, s16
+; GFX7-ISEL-NEXT:    v_cvt_f32_f16_e32 v1, s17
+; GFX7-ISEL-NEXT:    v_cvt_f32_f16_e32 v2, s5
+; GFX7-ISEL-NEXT:    v_cvt_f32_f16_e32 v3, s4
+; GFX7-ISEL-NEXT:    v_cvt_i32_f32_e32 v0, v0
+; GFX7-ISEL-NEXT:    v_cvt_i32_f32_e32 v1, v1
+; GFX7-ISEL-NEXT:    v_cvt_i32_f32_e32 v4, v2
+; GFX7-ISEL-NEXT:    v_cvt_i32_f32_e32 v3, v3
+; GFX7-ISEL-NEXT:    v_med3_i32 v0, v0, -1, 0
+; GFX7-ISEL-NEXT:    v_med3_i32 v2, v1, -1, 0
+; GFX7-ISEL-NEXT:    v_med3_i32 v1, v4, -1, 0
+; GFX7-ISEL-NEXT:    v_med3_i32 v3, v3, -1, 0
+; GFX7-ISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX7-GI-LABEL: test_s_signed_v4f16_v4i1:
+; GFX7-GI:       ; %bb.0:
+; GFX7-GI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-GI-NEXT:    s_lshr_b32 s4, s16, 16
+; GFX7-GI-NEXT:    s_lshr_b32 s5, s17, 16
+; GFX7-GI-NEXT:    v_cvt_f32_f16_e32 v0, s16
+; GFX7-GI-NEXT:    v_cvt_f32_f16_e32 v1, s4
+; GFX7-GI-NEXT:    v_cvt_f32_f16_e32 v2, s17
+; GFX7-GI-NEXT:    v_cvt_f32_f16_e32 v3, s5
+; GFX7-GI-NEXT:    v_cvt_i32_f32_e32 v0, v0
+; GFX7-GI-NEXT:    v_cvt_i32_f32_e32 v1, v1
+; GFX7-GI-NEXT:    v_cvt_i32_f32_e32 v2, v2
+; GFX7-GI-NEXT:    v_cvt_i32_f32_e32 v3, v3
+; GFX7-GI-NEXT:    v_med3_i32 v0, v0, -1, 0
+; GFX7-GI-NEXT:    v_med3_i32 v1, v1, -1, 0
+; GFX7-GI-NEXT:    v_med3_i32 v2, v2, -1, 0
+; GFX7-GI-NEXT:    v_med3_i32 v3, v3, -1, 0
+; GFX7-GI-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX9-LABEL: test_s_signed_v4f16_v4i1:
+; GFX9:       ; %bb.0:
+; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    s_lshr_b32 s4, s17, 16
+; GFX9-NEXT:    v_cvt_i16_f16_e32 v0, s17
+; GFX9-NEXT:    v_cvt_i16_f16_e32 v1, s4
+; GFX9-NEXT:    v_bfe_i32 v0, v0, 0, 16
+; GFX9-NEXT:    v_bfe_i32 v1, v1, 0, 16
+; GFX9-NEXT:    s_lshr_b32 s4, s16, 16
+; GFX9-NEXT:    v_med3_i32 v2, v0, -1, 0
+; GFX9-NEXT:    v_cvt_i16_f16_e32 v0, s16
+; GFX9-NEXT:    v_med3_i32 v3, v1, -1, 0
+; GFX9-NEXT:    v_cvt_i16_f16_e32 v1, s4
+; GFX9-NEXT:    v_bfe_i32 v0, v0, 0, 16
+; GFX9-NEXT:    v_bfe_i32 v1, v1, 0, 16
+; GFX9-NEXT:    v_med3_i32 v0, v0, -1, 0
+; GFX9-NEXT:    v_med3_i32 v1, v1, -1, 0
+; GFX9-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11-FAKE16-LABEL: test_s_signed_v4f16_v4i1:
+; GFX11-FAKE16:       ; %bb.0:
+; GFX11-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-FAKE16-NEXT:    v_cvt_i16_f16_e32 v0, s1
+; GFX11-FAKE16-NEXT:    v_cvt_i16_f16_e32 v1, s0
+; GFX11-FAKE16-NEXT:    s_lshr_b32 s0, s0, 16
+; GFX11-FAKE16-NEXT:    s_lshr_b32 s1, s1, 16
+; GFX11-FAKE16-NEXT:    v_cvt_i16_f16_e32 v2, s0
+; GFX11-FAKE16-NEXT:    v_cvt_i16_f16_e32 v3, s1
+; GFX11-FAKE16-NEXT:    v_bfe_i32 v1, v1, 0, 16
+; GFX11-FAKE16-NEXT:    v_bfe_i32 v4, v0, 0, 16
+; GFX11-FAKE16-NEXT:    v_bfe_i32 v5, v2, 0, 16
+; GFX11-FAKE16-NEXT:    v_bfe_i32 v3, v3, 0, 16
+; GFX11-FAKE16-NEXT:    v_med3_i32 v0, v1, -1, 0
+; GFX11-FAKE16-NEXT:    v_med3_i32 v2, v4, -1, 0
+; GFX11-FAKE16-NEXT:    v_med3_i32 v1, v5, -1, 0
+; GFX11-FAKE16-NEXT:    v_med3_i32 v3, v3, -1, 0
+; GFX11-FAKE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11-TRUE16-LABEL: test_s_signed_v4f16_v4i1:
+; GFX11-TRUE16:       ; %bb.0:
+; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-TRUE16-NEXT:    v_cvt_i16_f16_e32 v0.l, s1
+; GFX11-TRUE16-NEXT:    v_cvt_i16_f16_e32 v1.l, s0
+; GFX11-TRUE16-NEXT:    s_lshr_b32 s0, s0, 16
+; GFX11-TRUE16-NEXT:    s_lshr_b32 s1, s1, 16
+; GFX11-TRUE16-NEXT:    v_cvt_i16_f16_e32 v2.l, s0
+; GFX11-TRUE16-NEXT:    v_cvt_i16_f16_e32 v3.l, s1
+; GFX11-TRUE16-NEXT:    v_bfe_i32 v1, v1, 0, 16
+; GFX11-TRUE16-NEXT:    v_bfe_i32 v4, v0, 0, 16
+; GFX11-TRUE16-NEXT:    v_bfe_i32 v5, v2, 0, 16
+; GFX11-TRUE16-NEXT:    v_bfe_i32 v3, v3, 0, 16
+; GFX11-TRUE16-NEXT:    v_med3_i32 v0, v1, -1, 0
+; GFX11-TRUE16-NEXT:    v_med3_i32 v2, v4, -1, 0
+; GFX11-TRUE16-NEXT:    v_med3_i32 v1, v5, -1, 0
+; GFX11-TRUE16-NEXT:    v_med3_i32 v3, v3, -1, 0
+; GFX11-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-FAKE16-LABEL: test_s_signed_v4f16_v4i1:
+; GFX12-FAKE16:       ; %bb.0:
+; GFX12-FAKE16-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-FAKE16-NEXT:    s_wait_expcnt 0x0
+; GFX12-FAKE16-NEXT:    s_wait_samplecnt 0x0
+; GFX12-FAKE16-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-FAKE16-NEXT:    s_wait_kmcnt 0x0
+; GFX12-FAKE16-NEXT:    v_cvt_i16_f16_e32 v0, s1
+; GFX12-FAKE16-NEXT:    v_cvt_i16_f16_e32 v1, s0
+; GFX12-FAKE16-NEXT:    s_lshr_b32 s0, s0, 16
+; GFX12-FAKE16-NEXT:    s_lshr_b32 s1, s1, 16
+; GFX12-FAKE16-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-FAKE16-NEXT:    v_cvt_i16_f16_e32 v2, s0
+; GFX12-FAKE16-NEXT:    v_cvt_i16_f16_e32 v3, s1
+; GFX12-FAKE16-NEXT:    v_bfe_i32 v1, v1, 0, 16
+; GFX12-FAKE16-NEXT:    v_bfe_i32 v4, v0, 0, 16
+; GFX12-FAKE16-NEXT:    v_bfe_i32 v5, v2, 0, 16
+; GFX12-FAKE16-NEXT:    v_bfe_i32 v3, v3, 0, 16
+; GFX12-FAKE16-NEXT:    v_med3_i32 v0, v1, -1, 0
+; GFX12-FAKE16-NEXT:    v_med3_i32 v2, v4, -1, 0
+; GFX12-FAKE16-NEXT:    v_med3_i32 v1, v5, -1, 0
+; GFX12-FAKE16-NEXT:    v_med3_i32 v3, v3, -1, 0
+; GFX12-FAKE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-TRUE16-LABEL: test_s_signed_v4f16_v4i1:
+; GFX12-TRUE16:       ; %bb.0:
+; GFX12-TRUE16-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-TRUE16-NEXT:    s_wait_expcnt 0x0
+; GFX12-TRUE16-NEXT:    s_wait_samplecnt 0x0
+; GFX12-TRUE16-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-TRUE16-NEXT:    s_wait_kmcnt 0x0
+; GFX12-TRUE16-NEXT:    v_cvt_i16_f16_e32 v0.l, s1
+; GFX12-TRUE16-NEXT:    v_cvt_i16_f16_e32 v1.l, s0
+; GFX12-TRUE16-NEXT:    s_lshr_b32 s0, s0, 16
+; GFX12-TRUE16-NEXT:    s_lshr_b32 s1, s1, 16
+; GFX12-TRUE16-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-TRUE16-NEXT:    v_cvt_i16_f16_e32 v2.l, s0
+; GFX12-TRUE16-NEXT:    v_cvt_i16_f16_e32 v3.l, s1
+; GFX12-TRUE16-NEXT:    v_bfe_i32 v1, v1, 0, 16
+; GFX12-TRUE16-NEXT:    v_bfe_i32 v4, v0, 0, 16
+; GFX12-TRUE16-NEXT:    v_bfe_i32 v5, v2, 0, 16
+; GFX12-TRUE16-NEXT:    v_bfe_i32 v3, v3, 0, 16
+; GFX12-TRUE16-NEXT:    v_med3_i32 v0, v1, -1, 0
+; GFX12-TRUE16-NEXT:    v_med3_i32 v2, v4, -1, 0
+; GFX12-TRUE16-NEXT:    v_med3_i32 v1, v5, -1, 0
+; GFX12-TRUE16-NEXT:    v_med3_i32 v3, v3, -1, 0
+; GFX12-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-GI-LABEL: test_s_signed_v4f16_v4i1:
+; GFX12-GI:       ; %bb.0:
+; GFX12-GI-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-GI-NEXT:    s_wait_expcnt 0x0
+; GFX12-GI-NEXT:    s_wait_samplecnt 0x0
+; GFX12-GI-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-GI-NEXT:    s_wait_kmcnt 0x0
+; GFX12-GI-NEXT:    s_cvt_f32_f16 s0, s0
+; GFX12-GI-NEXT:    s_cvt_f32_f16 s1, s1
+; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-GI-NEXT:    s_cvt_i32_f32 s0, s0
+; GFX12-GI-NEXT:    s_cvt_i32_f32 s1, s1
+; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-GI-NEXT:    s_min_i32 s0, s0, 0
+; GFX12-GI-NEXT:    s_min_i32 s1, s1, 0
+; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-GI-NEXT:    s_max_i32 s0, s0, -1
+; GFX12-GI-NEXT:    s_max_i32 s1, s1, -1
+; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-GI-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s0
+; GFX12-GI-NEXT:    v_dual_mov_b32 v2, s1 :: v_dual_mov_b32 v3, s1
+; GFX12-GI-NEXT:    s_setpc_b64 s[30:31]
+    %x = call <4 x i1> @llvm.fptosi.sat.v4f16.v4i1(<4 x half> %f)
+    ret <4 x i1> %x
+}
+
+define <4 x i8> @test_s_signed_v4f16_v4i8(<4 x half> inreg %f) {
+; GFX7-ISEL-LABEL: test_s_signed_v4f16_v4i8:
+; GFX7-ISEL:       ; %bb.0:
+; GFX7-ISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-ISEL-NEXT:    s_lshr_b32 s5, s17, 16
+; GFX7-ISEL-NEXT:    v_cvt_f32_f16_e32 v0, s17
+; GFX7-ISEL-NEXT:    v_cvt_f32_f16_e32 v1, s5
+; GFX7-ISEL-NEXT:    s_lshr_b32 s4, s16, 16
+; GFX7-ISEL-NEXT:    v_cvt_f32_f16_e32 v3, s16
+; GFX7-ISEL-NEXT:    v_cvt_i32_f32_e32 v0, v0
+; GFX7-ISEL-NEXT:    v_cvt_i32_f32_e32 v1, v1
+; GFX7-ISEL-NEXT:    v_cvt_f32_f16_e32 v4, s4
+; GFX7-ISEL-NEXT:    s_movk_i32 s5, 0xff80
+; GFX7-ISEL-NEXT:    v_mov_b32_e32 v2, 0x7f
+; GFX7-ISEL-NEXT:    v_med3_i32 v0, v0, s5, v2
+; GFX7-ISEL-NEXT:    v_med3_i32 v1, v1, s5, v2
+; GFX7-ISEL-NEXT:    v_and_b32_e32 v0, 0xff, v0
+; GFX7-ISEL-NEXT:    v_lshlrev_b32_e32 v1, 8, v1
+; GFX7-ISEL-NEXT:    v_cvt_i32_f32_e32 v3, v3
+; GFX7-ISEL-NEXT:    v_or_b32_e32 v5, v0, v1
+; GFX7-ISEL-NEXT:    v_cvt_i32_f32_e32 v0, v4
+; GFX7-ISEL-NEXT:    v_lshlrev_b32_e32 v1, 16, v5
+; GFX7-ISEL-NEXT:    v_med3_i32 v3, v3, s5, v2
+; GFX7-ISEL-NEXT:    v_and_b32_e32 v3, 0xff, v3
+; GFX7-ISEL-NEXT:    v_med3_i32 v0, v0, s5, v2
+; GFX7-ISEL-NEXT:    v_lshlrev_b32_e32 v0, 8, v0
+; GFX7-ISEL-NEXT:    v_or_b32_e32 v0, v3, v0
+; GFX7-ISEL-NEXT:    v_and_b32_e32 v0, 0xffff, v0
+; GFX7-ISEL-NEXT:    v_or_b32_e32 v0, v0, v1
+; GFX7-ISEL-NEXT:    v_lshrrev_b32_e32 v1, 8, v0
+; GFX7-ISEL-NEXT:    v_and_b32_e32 v2, 0xffff, v5
+; GFX7-ISEL-NEXT:    v_bfe_u32 v3, v5, 8, 8
+; GFX7-ISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX7-GI-LABEL: test_s_signed_v4f16_v4i8:
+; GFX7-GI:       ; %bb.0:
+; GFX7-GI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-GI-NEXT:    s_lshr_b32 s4, s16, 16
+; GFX7-GI-NEXT:    s_lshr_b32 s5, s17, 16
+; GFX7-GI-NEXT:    v_cvt_f32_f16_e32 v0, s16
+; GFX7-GI-NEXT:    v_cvt_f32_f16_e32 v1, s4
+; GFX7-GI-NEXT:    v_cvt_f32_f16_e32 v2, s17
+; GFX7-GI-NEXT:    v_cvt_f32_f16_e32 v4, s5
+; GFX7-GI-NEXT:    v_cvt_i32_f32_e32 v0, v0
+; GFX7-GI-NEXT:    v_cvt_i32_f32_e32 v1, v1
+; GFX7-GI-NEXT:    v_cvt_i32_f32_e32 v2, v2
+; GFX7-GI-NEXT:    v_cvt_i32_f32_e32 v4, v4
+; GFX7-GI-NEXT:    v_mov_b32_e32 v3, 0x7f
+; GFX7-GI-NEXT:    v_mov_b32_e32 v5, 0xffffff80
+; GFX7-GI-NEXT:    v_med3_i32 v0, v0, v5, v3
+; GFX7-GI-NEXT:    v_med3_i32 v1, v1, v5, v3
+; GFX7-GI-NEXT:    v_med3_i32 v2, v2, v5, v3
+; GFX7-GI-NEXT:    v_med3_i32 v3, v4, v5, v3
+; GFX7-GI-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX9-LABEL: test_s_signed_v4f16_v4i8:
+; GFX9:       ; %bb.0:
+; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    s_lshr_b32 s5, s16, 16
+; GFX9-NEXT:    v_cvt_i16_f16_e32 v2, s5
+; GFX9-NEXT:    s_movk_i32 s4, 0xff80
+; GFX9-NEXT:    v_mov_b32_e32 v1, 0x7f
+; GFX9-NEXT:    v_bfe_i32 v2, v2, 0, 16
+; GFX9-NEXT:    v_med3_i32 v2, v2, s4, v1
+; GFX9-NEXT:    s_lshr_b32 s5, s17, 16
+; GFX9-NEXT:    v_cvt_i16_f16_e32 v0, s16
+; GFX9-NEXT:    v_lshlrev_b32_e32 v3, 8, v2
+; GFX9-NEXT:    v_cvt_i16_f16_e32 v2, s17
+; GFX9-NEXT:    v_cvt_i16_f16_e32 v4, s5
+; GFX9-NEXT:    v_bfe_i32 v0, v0, 0, 16
+; GFX9-NEXT:    v_bfe_i32 v2, v2, 0, 16
+; GFX9-NEXT:    v_bfe_i32 v4, v4, 0, 16
+; GFX9-NEXT:    v_med3_i32 v0, v0, s4, v1
+; GFX9-NEXT:    v_med3_i32 v2, v2, s4, v1
+; GFX9-NEXT:    v_med3_i32 v1, v4, s4, v1
+; GFX9-NEXT:    v_lshlrev_b32_e32 v1, 8, v1
+; GFX9-NEXT:    v_or_b32_sdwa v2, v2, v1 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:BYTE_0 src1_sel:DWORD
+; GFX9-NEXT:    v_or_b32_sdwa v0, v0, v3 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:BYTE_0 src1_sel:DWORD
+; GFX9-NEXT:    v_lshlrev_b32_e32 v1, 16, v2
+; GFX9-NEXT:    v_and_b32_e32 v3, 0xff00, v3
+; GFX9-NEXT:    v_or_b32_e32 v4, v3, v1
+; GFX9-NEXT:    v_lshrrev_b32_e32 v3, 24, v1
+; GFX9-NEXT:    v_lshrrev_b32_e32 v1, 8, v4
+; GFX9-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11-FAKE16-LABEL: test_s_signed_v4f16_v4i8:
+; GFX11-FAKE16:       ; %bb.0:
+; GFX11-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-FAKE16-NEXT:    s_lshr_b32 s2, s1, 16
+; GFX11-FAKE16-NEXT:    v_cvt_i16_f16_e32 v0, s1
+; GFX11-FAKE16-NEXT:    v_cvt_i16_f16_e32 v1, s2
+; GFX11-FAKE16-NEXT:    s_lshr_b32 s1, s0, 16
+; GFX11-FAKE16-NEXT:    v_cvt_i16_f16_e32 v3, s0
+; GFX11-FAKE16-NEXT:    v_cvt_i16_f16_e32 v2, s1
+; GFX11-FAKE16-NEXT:    v_bfe_i32 v0, v0, 0, 16
+; GFX11-FAKE16-NEXT:    v_bfe_i32 v1, v1, 0, 16
+; GFX11-FAKE16-NEXT:    s_movk_i32 s1, 0xff80
+; GFX11-FAKE16-NEXT:    v_bfe_i32 v3, v3, 0, 16
+; GFX11-FAKE16-NEXT:    v_bfe_i32 v2, v2, 0, 16
+; GFX11-FAKE16-NEXT:    v_med3_i32 v0, v0, s1, 0x7f
+; GFX11-FAKE16-NEXT:    v_med3_i32 v1, v1, s1, 0x7f
+; GFX11-FAKE16-NEXT:    v_med3_i32 v2, v2, s1, 0x7f
+; GFX11-FAKE16-NEXT:    v_and_b32_e32 v0, 0xff, v0
+; GFX11-FAKE16-NEXT:    v_lshlrev_b32_e32 v1, 8, v1
+; GFX11-FAKE16-NEXT:    v_lshlrev_b32_e32 v4, 8, v2
+; GFX11-FAKE16-NEXT:    v_or_b32_e32 v2, v0, v1
+; GFX11-FAKE16-NEXT:    v_med3_i32 v0, v3, s1, 0x7f
+; GFX11-FAKE16-NEXT:    v_and_b32_e32 v1, 0xff00, v4
+; GFX11-FAKE16-NEXT:    v_lshlrev_b32_e32 v3, 16, v2
+; GFX11-FAKE16-NEXT:    v_and_b32_e32 v0, 0xff, v0
+; GFX11-FAKE16-NEXT:    v_or_b32_e32 v1, v1, v3
+; GFX11-FAKE16-NEXT:    v_or_b32_e32 v0, v0, v4
+; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v3, 24, v3
+; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v1, 8, v1
+; GFX11-FAKE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11-TRUE16-LABEL: test_s_signed_v4f16_v4i8:
+; GFX11-TRUE16:       ; %bb.0:
+; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-TRUE16-NEXT:    s_lshr_b32 s2, s1, 16
+; GFX11-TRUE16-NEXT:    v_cvt_i16_f16_e32 v0.l, s1
+; GFX11-TRUE16-NEXT:    v_cvt_i16_f16_e32 v1.l, s2
+; GFX11-TRUE16-NEXT:    s_lshr_b32 s1, s0, 16
+; GFX11-TRUE16-NEXT:    v_cvt_i16_f16_e32 v3.l, s0
+; GFX11-TRUE16-NEXT:    v_cvt_i16_f16_e32 v2.l, s1
+; GFX11-TRUE16-NEXT:    v_bfe_i32 v0, v0, 0, 16
+; GFX11-TRUE16-NEXT:    v_bfe_i32 v1, v1, 0, 16
+; GFX11-TRUE16-NEXT:    s_movk_i32 s1, 0xff80
+; GFX11-TRUE16-NEXT:    v_bfe_i32 v3, v3, 0, 16
+; GFX11-TRUE16-NEXT:    v_bfe_i32 v2, v2, 0, 16
+; GFX11-TRUE16-NEXT:    v_med3_i32 v0, v0, s1, 0x7f
+; GFX11-TRUE16-NEXT:    v_med3_i32 v1, v1, s1, 0x7f
+; GFX11-TRUE16-NEXT:    v_med3_i32 v2, v2, s1, 0x7f
+; GFX11-TRUE16-NEXT:    v_and_b32_e32 v0, 0xff, v0
+; GFX11-TRUE16-NEXT:    v_lshlrev_b32_e32 v1, 8, v1
+; GFX11-TRUE16-NEXT:    v_lshlrev_b32_e32 v4, 8, v2
+; GFX11-TRUE16-NEXT:    v_or_b32_e32 v2, v0, v1
+; GFX11-TRUE16-NEXT:    v_med3_i32 v0, v3, s1, 0x7f
+; GFX11-TRUE16-NEXT:    v_and_b32_e32 v1, 0xff00, v4
+; GFX11-TRUE16-NEXT:    v_lshlrev_b32_e32 v3, 16, v2
+; GFX11-TRUE16-NEXT:    v_and_b32_e32 v0, 0xff, v0
+; GFX11-TRUE16-NEXT:    v_or_b32_e32 v1, v1, v3
+; GFX11-TRUE16-NEXT:    v_or_b32_e32 v0, v0, v4
+; GFX11-TRUE16-NEXT:    v_lshrrev_b32_e32 v3, 24, v3
+; GFX11-TRUE16-NEXT:    v_lshrrev_b32_e32 v1, 8, v1
+; GFX11-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-FAKE16-LABEL: test_s_signed_v4f16_v4i8:
+; GFX12-FAKE16:       ; %bb.0:
+; GFX12-FAKE16-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-FAKE16-NEXT:    s_wait_expcnt 0x0
+; GFX12-FAKE16-NEXT:    s_wait_samplecnt 0x0
+; GFX12-FAKE16-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-FAKE16-NEXT:    s_wait_kmcnt 0x0
+; GFX12-FAKE16-NEXT:    s_lshr_b32 s2, s1, 16
+; GFX12-FAKE16-NEXT:    v_cvt_i16_f16_e32 v0, s1
+; GFX12-FAKE16-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-FAKE16-NEXT:    v_cvt_i16_f16_e32 v1, s2
+; GFX12-FAKE16-NEXT:    s_lshr_b32 s1, s0, 16
+; GFX12-FAKE16-NEXT:    v_cvt_i16_f16_e32 v3, s0
+; GFX12-FAKE16-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-FAKE16-NEXT:    v_cvt_i16_f16_e32 v2, s1
+; GFX12-FAKE16-NEXT:    v_bfe_i32 v0, v0, 0, 16
+; GFX12-FAKE16-NEXT:    v_bfe_i32 v1, v1, 0, 16
+; GFX12-FAKE16-NEXT:    s_movk_i32 s1, 0xff80
+; GFX12-FAKE16-NEXT:    v_bfe_i32 v3, v3, 0, 16
+; GFX12-FAKE16-NEXT:    v_bfe_i32 v2, v2, 0, 16
+; GFX12-FAKE16-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-FAKE16-NEXT:    v_med3_i32 v0, v0, s1, 0x7f
+; GFX12-FAKE16-NEXT:    v_med3_i32 v1, v1, s1, 0x7f
+; GFX12-FAKE16-NEXT:    v_med3_i32 v2, v2, s1, 0x7f
+; GFX12-FAKE16-NEXT:    v_and_b32_e32 v0, 0xff, v0
+; GFX12-FAKE16-NEXT:    v_lshlrev_b32_e32 v1, 8, v1
+; GFX12-FAKE16-NEXT:    v_lshlrev_b32_e32 v4, 8, v2
+; GFX12-FAKE16-NEXT:    v_or_b32_e32 v2, v0, v1
+; GFX12-FAKE16-NEXT:    v_med3_i32 v0, v3, s1, 0x7f
+; GFX12-FAKE16-NEXT:    v_and_b32_e32 v1, 0xff00, v4
+; GFX12-FAKE16-NEXT:    v_lshlrev_b32_e32 v3, 16, v2
+; GFX12-FAKE16-NEXT:    v_and_b32_e32 v0, 0xff, v0
+; GFX12-FAKE16-NEXT:    v_or_b32_e32 v1, v1, v3
+; GFX12-FAKE16-NEXT:    v_or_b32_e32 v0, v0, v4
+; GFX12-FAKE16-NEXT:    v_lshrrev_b32_e32 v3, 24, v3
+; GFX12-FAKE16-NEXT:    v_lshrrev_b32_e32 v1, 8, v1
+; GFX12-FAKE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-TRUE16-LABEL: test_s_signed_v4f16_v4i8:
+; GFX12-TRUE16:       ; %bb.0:
+; GFX12-TRUE16-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-TRUE16-NEXT:    s_wait_expcnt 0x0
+; GFX12-TRUE16-NEXT:    s_wait_samplecnt 0x0
+; GFX12-TRUE16-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-TRUE16-NEXT:    s_wait_kmcnt 0x0
+; GFX12-TRUE16-NEXT:    s_lshr_b32 s2, s1, 16
+; GFX12-TRUE16-NEXT:    v_cvt_i16_f16_e32 v0.l, s1
+; GFX12-TRUE16-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-TRUE16-NEXT:    v_cvt_i16_f16_e32 v1.l, s2
+; GFX12-TRUE16-NEXT:    s_lshr_b32 s1, s0, 16
+; GFX12-TRUE16-NEXT:    v_cvt_i16_f16_e32 v3.l, s0
+; GFX12-TRUE16-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-TRUE16-NEXT:    v_cvt_i16_f16_e32 v2.l, s1
+; GFX12-TRUE16-NEXT:    v_bfe_i32 v0, v0, 0, 16
+; GFX12-TRUE16-NEXT:    v_bfe_i32 v1, v1, 0, 16
+; GFX12-TRUE16-NEXT:    s_movk_i32 s1, 0xff80
+; GFX12-TRUE16-NEXT:    v_bfe_i32 v3, v3, 0, 16
+; GFX12-TRUE16-NEXT:    v_bfe_i32 v2, v2, 0, 16
+; GFX12-TRUE16-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-TRUE16-NEXT:    v_med3_i32 v0, v0, s1, 0x7f
+; GFX12-TRUE16-NEXT:    v_med3_i32 v1, v1, s1, 0x7f
+; GFX12-TRUE16-NEXT:    v_med3_i32 v2, v2, s1, 0x7f
+; GFX12-TRUE16-NEXT:    v_and_b32_e32 v0, 0xff, v0
+; GFX12-TRUE16-NEXT:    v_lshlrev_b32_e32 v1, 8, v1
+; GFX12-TRUE16-NEXT:    v_lshlrev_b32_e32 v4, 8, v2
+; GFX12-TRUE16-NEXT:    v_or_b32_e32 v2, v0, v1
+; GFX12-TRUE16-NEXT:    v_med3_i32 v0, v3, s1, 0x7f
+; GFX12-TRUE16-NEXT:    v_and_b32_e32 v1, 0xff00, v4
+; GFX12-TRUE16-NEXT:    v_lshlrev_b32_e32 v3, 16, v2
+; GFX12-TRUE16-NEXT:    v_and_b32_e32 v0, 0xff, v0
+; GFX12-TRUE16-NEXT:    v_or_b32_e32 v1, v1, v3
+; GFX12-TRUE16-NEXT:    v_or_b32_e32 v0, v0, v4
+; GFX12-TRUE16-NEXT:    v_lshrrev_b32_e32 v3, 24, v3
+; GFX12-TRUE16-NEXT:    v_lshrrev_b32_e32 v1, 8, v1
+; GFX12-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-GI-LABEL: test_s_signed_v4f16_v4i8:
+; GFX12-GI:       ; %bb.0:
+; GFX12-GI-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-GI-NEXT:    s_wait_expcnt 0x0
+; GFX12-GI-NEXT:    s_wait_samplecnt 0x0
+; GFX12-GI-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-GI-NEXT:    s_wait_kmcnt 0x0
+; GFX12-GI-NEXT:    s_cvt_f32_f16 s0, s0
+; GFX12-GI-NEXT:    s_cvt_f32_f16 s1, s1
+; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-GI-NEXT:    s_cvt_i32_f32 s0, s0
+; GFX12-GI-NEXT:    s_cvt_i32_f32 s1, s1
+; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-GI-NEXT:    s_min_i32 s0, s0, 0x7f
+; GFX12-GI-NEXT:    s_min_i32 s1, s1, 0x7f
+; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-GI-NEXT:    s_max_i32 s0, s0, 0xffffff80
+; GFX12-GI-NEXT:    s_max_i32 s1, s1, 0xffffff80
+; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-GI-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s0
+; GFX12-GI-NEXT:    v_dual_mov_b32 v2, s1 :: v_dual_mov_b32 v3, s1
+; GFX12-GI-NEXT:    s_setpc_b64 s[30:31]
+    %x = call <4 x i8> @llvm.fptosi.sat.v4f16.v4i8(<4 x half> %f)
+    ret <4 x i8> %x
+}
+
+define <4 x i16> @test_s_signed_v4f16_v4i16(<4 x half> inreg %f) {
+; GFX7-ISEL-LABEL: test_s_signed_v4f16_v4i16:
+; GFX7-ISEL:       ; %bb.0:
+; GFX7-ISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-ISEL-NEXT:    v_cvt_f32_f16_e32 v0, s17
+; GFX7-ISEL-NEXT:    s_lshr_b32 s4, s16, 16
+; GFX7-ISEL-NEXT:    s_lshr_b32 s5, s17, 16
+; GFX7-ISEL-NEXT:    v_cvt_f32_f16_e32 v1, s16
+; GFX7-ISEL-NEXT:    v_cvt_i32_f32_e32 v0, v0
+; GFX7-ISEL-NEXT:    v_cvt_f32_f16_e32 v4, s4
+; GFX7-ISEL-NEXT:    v_cvt_f32_f16_e32 v2, s5
+; GFX7-ISEL-NEXT:    s_movk_i32 s6, 0x8000
+; GFX7-ISEL-NEXT:    v_mov_b32_e32 v3, 0x7fff
+; GFX7-ISEL-NEXT:    v_cvt_i32_f32_e32 v1, v1
+; GFX7-ISEL-NEXT:    v_med3_i32 v5, v0, s6, v3
+; GFX7-ISEL-NEXT:    v_cvt_i32_f32_e32 v0, v4
+; GFX7-ISEL-NEXT:    v_cvt_i32_f32_e32 v2, v2
+; GFX7-ISEL-NEXT:    v_med3_i32 v1, v1, s6, v3
+; GFX7-ISEL-NEXT:    v_and_b32_e32 v1, 0xffff, v1
+; GFX7-ISEL-NEXT:    v_med3_i32 v0, v0, s6, v3
+; GFX7-ISEL-NEXT:    v_med3_i32 v2, v2, s6, v3
+; GFX7-ISEL-NEXT:    v_lshlrev_b32_e32 v0, 16, v0
+; GFX7-ISEL-NEXT:    v_lshlrev_b32_e32 v2, 16, v2
+; GFX7-ISEL-NEXT:    v_or_b32_e32 v0, v1, v0
+; GFX7-ISEL-NEXT:    v_and_b32_e32 v1, 0xffff, v5
+; GFX7-ISEL-NEXT:    v_or_b32_e32 v1, v1, v2
+; GFX7-ISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX7-GI-LABEL: test_s_signed_v4f16_v4i16:
+; GFX7-GI:       ; %bb.0:
+; GFX7-GI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-GI-NEXT:    s_lshr_b32 s4, s16, 16
+; GFX7-GI-NEXT:    s_lshr_b32 s5, s17, 16
+; GFX7-GI-NEXT:    v_cvt_f32_f16_e32 v2, s4
+; GFX7-GI-NEXT:    v_cvt_f32_f16_e32 v0, s16
+; GFX7-GI-NEXT:    v_cvt_f32_f16_e32 v3, s17
+; GFX7-GI-NEXT:    v_cvt_f32_f16_e32 v4, s5
+; GFX7-GI-NEXT:    v_cvt_i32_f32_e32 v2, v2
+; GFX7-GI-NEXT:    v_cvt_i32_f32_e32 v0, v0
+; GFX7-GI-NEXT:    v_cvt_i32_f32_e32 v3, v3
+; GFX7-GI-NEXT:    v_cvt_i32_f32_e32 v4, v4
+; GFX7-GI-NEXT:    v_mov_b32_e32 v1, 0x7fff
+; GFX7-GI-NEXT:    v_mov_b32_e32 v5, 0xffff8000
+; GFX7-GI-NEXT:    v_med3_i32 v2, v2, v5, v1
+; GFX7-GI-NEXT:    v_med3_i32 v0, v0, v5, v1
+; GFX7-GI-NEXT:    v_med3_i32 v3, v3, v5, v1
+; GFX7-GI-NEXT:    v_med3_i32 v1, v4, v5, v1
+; GFX7-GI-NEXT:    v_and_b32_e32 v2, 0xffff, v2
+; GFX7-GI-NEXT:    v_and_b32_e32 v0, 0xffff, v0
+; GFX7-GI-NEXT:    v_lshlrev_b32_e32 v2, 16, v2
+; GFX7-GI-NEXT:    v_and_b32_e32 v1, 0xffff, v1
+; GFX7-GI-NEXT:    v_or_b32_e32 v0, v0, v2
+; GFX7-GI-NEXT:    v_and_b32_e32 v2, 0xffff, v3
+; GFX7-GI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; GFX7-GI-NEXT:    v_or_b32_e32 v1, v2, v1
+; GFX7-GI-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX9-LABEL: test_s_signed_v4f16_v4i16:
+; GFX9:       ; %bb.0:
+; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    s_lshr_b32 s4, s17, 16
+; GFX9-NEXT:    v_cvt_i16_f16_e32 v1, s4
+; GFX9-NEXT:    s_lshr_b32 s4, s16, 16
+; GFX9-NEXT:    v_cvt_i16_f16_e32 v2, s17
+; GFX9-NEXT:    v_cvt_i16_f16_e32 v3, s16
+; GFX9-NEXT:    v_cvt_i16_f16_e32 v0, s4
+; GFX9-NEXT:    v_and_b32_e32 v3, 0xffff, v3
+; GFX9-NEXT:    v_and_b32_e32 v2, 0xffff, v2
+; GFX9-NEXT:    v_lshl_or_b32 v0, v0, 16, v3
+; GFX9-NEXT:    v_lshl_or_b32 v1, v1, 16, v2
+; GFX9-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11-FAKE16-LABEL: test_s_signed_v4f16_v4i16:
+; GFX11-FAKE16:       ; %bb.0:
+; GFX11-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-FAKE16-NEXT:    v_cvt_i16_f16_e32 v0, s0
+; GFX11-FAKE16-NEXT:    v_cvt_i16_f16_e32 v1, s1
+; GFX11-FAKE16-NEXT:    s_lshr_b32 s2, s1, 16
+; GFX11-FAKE16-NEXT:    s_lshr_b32 s0, s0, 16
+; GFX11-FAKE16-NEXT:    v_cvt_i16_f16_e32 v2, s2
+; GFX11-FAKE16-NEXT:    v_cvt_i16_f16_e32 v3, s0
+; GFX11-FAKE16-NEXT:    v_and_b32_e32 v0, 0xffff, v0
+; GFX11-FAKE16-NEXT:    v_and_b32_e32 v1, 0xffff, v1
+; GFX11-FAKE16-NEXT:    v_lshl_or_b32 v0, v3, 16, v0
+; GFX11-FAKE16-NEXT:    v_lshl_or_b32 v1, v2, 16, v1
+; GFX11-FAKE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11-TRUE16-LABEL: test_s_signed_v4f16_v4i16:
+; GFX11-TRUE16:       ; %bb.0:
+; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-TRUE16-NEXT:    s_lshr_b32 s2, s0, 16
+; GFX11-TRUE16-NEXT:    s_lshr_b32 s3, s1, 16
+; GFX11-TRUE16-NEXT:    v_cvt_i16_f16_e32 v0.h, s2
+; GFX11-TRUE16-NEXT:    v_cvt_i16_f16_e32 v1.l, s1
+; GFX11-TRUE16-NEXT:    v_cvt_i16_f16_e32 v0.l, s0
+; GFX11-TRUE16-NEXT:    v_cvt_i16_f16_e32 v1.h, s3
+; GFX11-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-FAKE16-LABEL: test_s_signed_v4f16_v4i16:
+; GFX12-FAKE16:       ; %bb.0:
+; GFX12-FAKE16-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-FAKE16-NEXT:    s_wait_expcnt 0x0
+; GFX12-FAKE16-NEXT:    s_wait_samplecnt 0x0
+; GFX12-FAKE16-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-FAKE16-NEXT:    s_wait_kmcnt 0x0
+; GFX12-FAKE16-NEXT:    v_cvt_i16_f16_e32 v0, s0
+; GFX12-FAKE16-NEXT:    v_cvt_i16_f16_e32 v1, s1
+; GFX12-FAKE16-NEXT:    s_lshr_b32 s2, s1, 16
+; GFX12-FAKE16-NEXT:    s_lshr_b32 s0, s0, 16
+; GFX12-FAKE16-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-FAKE16-NEXT:    v_cvt_i16_f16_e32 v2, s2
+; GFX12-FAKE16-NEXT:    v_cvt_i16_f16_e32 v3, s0
+; GFX12-FAKE16-NEXT:    v_and_b32_e32 v0, 0xffff, v0
+; GFX12-FAKE16-NEXT:    v_and_b32_e32 v1, 0xffff, v1
+; GFX12-FAKE16-NEXT:    v_lshl_or_b32 v0, v3, 16, v0
+; GFX12-FAKE16-NEXT:    v_lshl_or_b32 v1, v2, 16, v1
+; GFX12-FAKE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-TRUE16-LABEL: test_s_signed_v4f16_v4i16:
+; GFX12-TRUE16:       ; %bb.0:
+; GFX12-TRUE16-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-TRUE16-NEXT:    s_wait_expcnt 0x0
+; GFX12-TRUE16-NEXT:    s_wait_samplecnt 0x0
+; GFX12-TRUE16-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-TRUE16-NEXT:    s_wait_kmcnt 0x0
+; GFX12-TRUE16-NEXT:    s_lshr_b32 s2, s0, 16
+; GFX12-TRUE16-NEXT:    s_lshr_b32 s3, s1, 16
+; GFX12-TRUE16-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-TRUE16-NEXT:    v_cvt_i16_f16_e32 v0.h, s2
+; GFX12-TRUE16-NEXT:    v_cvt_i16_f16_e32 v1.l, s1
+; GFX12-TRUE16-NEXT:    v_cvt_i16_f16_e32 v0.l, s0
+; GFX12-TRUE16-NEXT:    v_cvt_i16_f16_e32 v1.h, s3
+; GFX12-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-GI-LABEL: test_s_signed_v4f16_v4i16:
+; GFX12-GI:       ; %bb.0:
+; GFX12-GI-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-GI-NEXT:    s_wait_expcnt 0x0
+; GFX12-GI-NEXT:    s_wait_samplecnt 0x0
+; GFX12-GI-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-GI-NEXT:    s_wait_kmcnt 0x0
+; GFX12-GI-NEXT:    v_cvt_i16_f16_e32 v0.l, s0
+; GFX12-GI-NEXT:    v_cvt_i16_f16_e32 v1.l, s1
+; GFX12-GI-NEXT:    v_mov_b16_e32 v0.h, v0.l
+; GFX12-GI-NEXT:    v_mov_b16_e32 v1.h, v1.l
+; GFX12-GI-NEXT:    s_setpc_b64 s[30:31]
+    %x = call <4 x i16> @llvm.fptosi.sat.v4f16.v4i16(<4 x half> %f)
+    ret <4 x i16> %x
+}
+
+define <4 x i64> @test_s_signed_v4f16_v4i64(<4 x half> inreg %f) {
+; GFX7-ISEL-LABEL: test_s_signed_v4f16_v4i64:
+; GFX7-ISEL:       ; %bb.0:
+; GFX7-ISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-ISEL-NEXT:    s_lshr_b32 s4, s17, 16
+; GFX7-ISEL-NEXT:    s_lshr_b32 s5, s16, 16
+; GFX7-ISEL-NEXT:    v_cvt_f32_f16_e32 v0, s5
+; GFX7-ISEL-NEXT:    v_cvt_f32_f16_e32 v1, s4
+; GFX7-ISEL-NEXT:    v_cvt_f32_f16_e32 v3, s16
+; GFX7-ISEL-NEXT:    v_cvt_f32_f16_e32 v4, s17
+; GFX7-ISEL-NEXT:    v_cvt_i32_f32_e32 v2, v0
+; GFX7-ISEL-NEXT:    v_cvt_i32_f32_e32 v6, v1
+; GFX7-ISEL-NEXT:    v_cvt_i32_f32_e32 v0, v3
+; GFX7-ISEL-NEXT:    v_cvt_i32_f32_e32 v4, v4
+; GFX7-ISEL-NEXT:    v_ashrrev_i32_e32 v3, 31, v2
+; GFX7-ISEL-NEXT:    v_ashrrev_i32_e32 v7, 31, v6
+; GFX7-ISEL-NEXT:    v_ashrrev_i32_e32 v1, 31, v0
+; GFX7-ISEL-NEXT:    v_ashrrev_i32_e32 v5, 31, v4
+; GFX7-ISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX7-GI-LABEL: test_s_signed_v4f16_v4i64:
+; GFX7-GI:       ; %bb.0:
+; GFX7-GI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-GI-NEXT:    s_lshr_b32 s4, s16, 16
+; GFX7-GI-NEXT:    s_lshr_b32 s5, s17, 16
+; GFX7-GI-NEXT:    v_cvt_f32_f16_e32 v0, s16
+; GFX7-GI-NEXT:    v_cvt_f32_f16_e32 v1, s4
+; GFX7-GI-NEXT:    v_cvt_f32_f16_e32 v3, s17
+; GFX7-GI-NEXT:    v_cvt_f32_f16_e32 v5, s5
+; GFX7-GI-NEXT:    v_cvt_i32_f32_e32 v0, v0
+; GFX7-GI-NEXT:    v_cvt_i32_f32_e32 v2, v1
+; GFX7-GI-NEXT:    v_cvt_i32_f32_e32 v4, v3
+; GFX7-GI-NEXT:    v_cvt_i32_f32_e32 v6, v5
+; GFX7-GI-NEXT:    v_mov_b32_e32 v1, 0
+; GFX7-GI-NEXT:    v_mov_b32_e32 v3, 0
+; GFX7-GI-NEXT:    v_mov_b32_e32 v5, 0
+; GFX7-GI-NEXT:    v_mov_b32_e32 v7, 0
+; GFX7-GI-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX9-LABEL: test_s_signed_v4f16_v4i64:
+; GFX9:       ; %bb.0:
+; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    s_lshr_b32 s4, s16, 16
+; GFX9-NEXT:    v_cvt_f32_f16_e32 v0, s4
+; GFX9-NEXT:    s_lshr_b32 s4, s17, 16
+; GFX9-NEXT:    v_cvt_f32_f16_e32 v1, s4
+; GFX9-NEXT:    v_cvt_f32_f16_e32 v3, s16
+; GFX9-NEXT:    v_cvt_f32_f16_e32 v4, s17
+; GFX9-NEXT:    v_cvt_i32_f32_e32 v2, v0
+; GFX9-NEXT:    v_cvt_i32_f32_e32 v6, v1
+; GFX9-NEXT:    v_cvt_i32_f32_e32 v0, v3
+; GFX9-NEXT:    v_cvt_i32_f32_e32 v4, v4
+; GFX9-NEXT:    v_ashrrev_i32_e32 v3, 31, v2
+; GFX9-NEXT:    v_ashrrev_i32_e32 v7, 31, v6
+; GFX9-NEXT:    v_ashrrev_i32_e32 v1, 31, v0
+; GFX9-NEXT:    v_ashrrev_i32_e32 v5, 31, v4
+; GFX9-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11-LABEL: test_s_signed_v4f16_v4i64:
+; GFX11:       ; %bb.0:
+; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-NEXT:    s_lshr_b32 s2, s0, 16
+; GFX11-NEXT:    s_lshr_b32 s3, s1, 16
+; GFX11-NEXT:    v_cvt_f32_f16_e32 v0, s0
+; GFX11-NEXT:    v_cvt_f32_f16_e32 v1, s1
+; GFX11-NEXT:    v_cvt_f32_f16_e32 v2, s2
+; GFX11-NEXT:    v_cvt_f32_f16_e32 v3, s3
+; GFX11-NEXT:    v_cvt_i32_f32_e32 v0, v0
+; GFX11-NEXT:    v_cvt_i32_f32_e32 v4, v1
+; GFX11-NEXT:    v_cvt_i32_f32_e32 v2, v2
+; GFX11-NEXT:    v_cvt_i32_f32_e32 v6, v3
+; GFX11-NEXT:    v_ashrrev_i32_e32 v1, 31, v0
+; GFX11-NEXT:    v_ashrrev_i32_e32 v5, 31, v4
+; GFX11-NEXT:    v_ashrrev_i32_e32 v3, 31, v2
+; GFX11-NEXT:    v_ashrrev_i32_e32 v7, 31, v6
+; GFX11-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-ISEL-LABEL: test_s_signed_v4f16_v4i64:
+; GFX12-ISEL:       ; %bb.0:
+; GFX12-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX12-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX12-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX12-ISEL-NEXT:    s_cvt_hi_f32_f16 s2, s0
+; GFX12-ISEL-NEXT:    s_cvt_hi_f32_f16 s3, s1
+; GFX12-ISEL-NEXT:    s_cvt_f32_f16 s0, s0
+; GFX12-ISEL-NEXT:    s_cvt_f32_f16 s1, s1
+; GFX12-ISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-ISEL-NEXT:    s_cvt_i32_f32 s2, s2
+; GFX12-ISEL-NEXT:    s_cvt_i32_f32 s3, s3
+; GFX12-ISEL-NEXT:    s_cvt_i32_f32 s0, s0
+; GFX12-ISEL-NEXT:    s_cvt_i32_f32 s1, s1
+; GFX12-ISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-ISEL-NEXT:    s_ashr_i32 s4, s2, 31
+; GFX12-ISEL-NEXT:    s_ashr_i32 s5, s3, 31
+; GFX12-ISEL-NEXT:    s_ashr_i32 s6, s0, 31
+; GFX12-ISEL-NEXT:    s_ashr_i32 s7, s1, 31
+; GFX12-ISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-ISEL-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s6
+; GFX12-ISEL-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s4
+; GFX12-ISEL-NEXT:    v_dual_mov_b32 v4, s1 :: v_dual_mov_b32 v5, s7
+; GFX12-ISEL-NEXT:    v_dual_mov_b32 v6, s3 :: v_dual_mov_b32 v7, s5
+; GFX12-ISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-GI-LABEL: test_s_signed_v4f16_v4i64:
+; GFX12-GI:       ; %bb.0:
+; GFX12-GI-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-GI-NEXT:    s_wait_expcnt 0x0
+; GFX12-GI-NEXT:    s_wait_samplecnt 0x0
+; GFX12-GI-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-GI-NEXT:    s_wait_kmcnt 0x0
+; GFX12-GI-NEXT:    s_cvt_f32_f16 s0, s0
+; GFX12-GI-NEXT:    s_cvt_f32_f16 s1, s1
+; GFX12-GI-NEXT:    v_mov_b32_e32 v5, 0
+; GFX12-GI-NEXT:    v_mov_b32_e32 v7, 0
+; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-GI-NEXT:    s_cvt_i32_f32 s0, s0
+; GFX12-GI-NEXT:    s_cvt_i32_f32 s1, s1
+; GFX12-GI-NEXT:    v_mov_b32_e32 v1, 0
+; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-GI-NEXT:    v_dual_mov_b32 v3, 0 :: v_dual_mov_b32 v2, s0
+; GFX12-GI-NEXT:    v_mov_b32_e32 v0, s0
+; GFX12-GI-NEXT:    v_mov_b32_e32 v4, s1
+; GFX12-GI-NEXT:    v_mov_b32_e32 v6, s1
 ; GFX12-GI-NEXT:    s_setpc_b64 s[30:31]
     %x = call <4 x i64> @llvm.fptosi.sat.v4f16.v4i64(<4 x half> %f)
     ret <4 x i64> %x
@@ -3347,6 +5210,1164 @@ define <8 x i64> @test_signed_v8f16_v8i64(<8 x half> %f) {
     ret <8 x i64> %x
 }
 
+define <8 x i1> @test_s_signed_v8f16_v8i1(<8 x half> inreg %f) {
+; GFX7-ISEL-LABEL: test_s_signed_v8f16_v8i1:
+; GFX7-ISEL:       ; %bb.0:
+; GFX7-ISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-ISEL-NEXT:    v_cvt_f32_f16_e32 v1, s17
+; GFX7-ISEL-NEXT:    v_cvt_f32_f16_e32 v3, s19
+; GFX7-ISEL-NEXT:    v_cvt_f32_f16_e32 v2, s18
+; GFX7-ISEL-NEXT:    s_lshr_b32 s4, s19, 16
+; GFX7-ISEL-NEXT:    v_cvt_i32_f32_e32 v1, v1
+; GFX7-ISEL-NEXT:    v_cvt_i32_f32_e32 v3, v3
+; GFX7-ISEL-NEXT:    s_lshr_b32 s5, s18, 16
+; GFX7-ISEL-NEXT:    s_lshr_b32 s6, s17, 16
+; GFX7-ISEL-NEXT:    s_lshr_b32 s7, s16, 16
+; GFX7-ISEL-NEXT:    v_cvt_f32_f16_e32 v0, s16
+; GFX7-ISEL-NEXT:    v_cvt_i32_f32_e32 v4, v2
+; GFX7-ISEL-NEXT:    v_med3_i32 v2, v1, -1, 0
+; GFX7-ISEL-NEXT:    v_med3_i32 v6, v3, -1, 0
+; GFX7-ISEL-NEXT:    v_cvt_f32_f16_e32 v1, s7
+; GFX7-ISEL-NEXT:    v_cvt_f32_f16_e32 v3, s6
+; GFX7-ISEL-NEXT:    v_cvt_f32_f16_e32 v5, s5
+; GFX7-ISEL-NEXT:    v_cvt_f32_f16_e32 v7, s4
+; GFX7-ISEL-NEXT:    v_cvt_i32_f32_e32 v0, v0
+; GFX7-ISEL-NEXT:    v_cvt_i32_f32_e32 v1, v1
+; GFX7-ISEL-NEXT:    v_cvt_i32_f32_e32 v3, v3
+; GFX7-ISEL-NEXT:    v_cvt_i32_f32_e32 v5, v5
+; GFX7-ISEL-NEXT:    v_cvt_i32_f32_e32 v7, v7
+; GFX7-ISEL-NEXT:    v_med3_i32 v0, v0, -1, 0
+; GFX7-ISEL-NEXT:    v_med3_i32 v4, v4, -1, 0
+; GFX7-ISEL-NEXT:    v_med3_i32 v1, v1, -1, 0
+; GFX7-ISEL-NEXT:    v_med3_i32 v3, v3, -1, 0
+; GFX7-ISEL-NEXT:    v_med3_i32 v5, v5, -1, 0
+; GFX7-ISEL-NEXT:    v_med3_i32 v7, v7, -1, 0
+; GFX7-ISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX7-GI-LABEL: test_s_signed_v8f16_v8i1:
+; GFX7-GI:       ; %bb.0:
+; GFX7-GI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-GI-NEXT:    s_lshr_b32 s4, s16, 16
+; GFX7-GI-NEXT:    s_lshr_b32 s5, s17, 16
+; GFX7-GI-NEXT:    s_lshr_b32 s6, s18, 16
+; GFX7-GI-NEXT:    s_lshr_b32 s7, s19, 16
+; GFX7-GI-NEXT:    v_cvt_f32_f16_e32 v0, s16
+; GFX7-GI-NEXT:    v_cvt_f32_f16_e32 v1, s4
+; GFX7-GI-NEXT:    v_cvt_f32_f16_e32 v2, s17
+; GFX7-GI-NEXT:    v_cvt_f32_f16_e32 v3, s5
+; GFX7-GI-NEXT:    v_cvt_f32_f16_e32 v4, s18
+; GFX7-GI-NEXT:    v_cvt_f32_f16_e32 v5, s6
+; GFX7-GI-NEXT:    v_cvt_f32_f16_e32 v6, s19
+; GFX7-GI-NEXT:    v_cvt_f32_f16_e32 v7, s7
+; GFX7-GI-NEXT:    v_cvt_i32_f32_e32 v0, v0
+; GFX7-GI-NEXT:    v_cvt_i32_f32_e32 v1, v1
+; GFX7-GI-NEXT:    v_cvt_i32_f32_e32 v2, v2
+; GFX7-GI-NEXT:    v_cvt_i32_f32_e32 v3, v3
+; GFX7-GI-NEXT:    v_cvt_i32_f32_e32 v4, v4
+; GFX7-GI-NEXT:    v_cvt_i32_f32_e32 v5, v5
+; GFX7-GI-NEXT:    v_cvt_i32_f32_e32 v6, v6
+; GFX7-GI-NEXT:    v_cvt_i32_f32_e32 v7, v7
+; GFX7-GI-NEXT:    v_med3_i32 v0, v0, -1, 0
+; GFX7-GI-NEXT:    v_med3_i32 v1, v1, -1, 0
+; GFX7-GI-NEXT:    v_med3_i32 v2, v2, -1, 0
+; GFX7-GI-NEXT:    v_med3_i32 v3, v3, -1, 0
+; GFX7-GI-NEXT:    v_med3_i32 v4, v4, -1, 0
+; GFX7-GI-NEXT:    v_med3_i32 v5, v5, -1, 0
+; GFX7-GI-NEXT:    v_med3_i32 v6, v6, -1, 0
+; GFX7-GI-NEXT:    v_med3_i32 v7, v7, -1, 0
+; GFX7-GI-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX9-LABEL: test_s_signed_v8f16_v8i1:
+; GFX9:       ; %bb.0:
+; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    s_lshr_b32 s4, s19, 16
+; GFX9-NEXT:    v_cvt_i16_f16_e32 v0, s19
+; GFX9-NEXT:    v_cvt_i16_f16_e32 v1, s4
+; GFX9-NEXT:    v_bfe_i32 v0, v0, 0, 16
+; GFX9-NEXT:    v_bfe_i32 v1, v1, 0, 16
+; GFX9-NEXT:    s_lshr_b32 s4, s18, 16
+; GFX9-NEXT:    v_med3_i32 v6, v0, -1, 0
+; GFX9-NEXT:    v_cvt_i16_f16_e32 v0, s18
+; GFX9-NEXT:    v_med3_i32 v7, v1, -1, 0
+; GFX9-NEXT:    v_cvt_i16_f16_e32 v1, s4
+; GFX9-NEXT:    v_bfe_i32 v0, v0, 0, 16
+; GFX9-NEXT:    v_bfe_i32 v1, v1, 0, 16
+; GFX9-NEXT:    s_lshr_b32 s4, s17, 16
+; GFX9-NEXT:    v_med3_i32 v4, v0, -1, 0
+; GFX9-NEXT:    v_cvt_i16_f16_e32 v0, s17
+; GFX9-NEXT:    v_med3_i32 v5, v1, -1, 0
+; GFX9-NEXT:    v_cvt_i16_f16_e32 v1, s4
+; GFX9-NEXT:    v_bfe_i32 v0, v0, 0, 16
+; GFX9-NEXT:    v_bfe_i32 v1, v1, 0, 16
+; GFX9-NEXT:    s_lshr_b32 s4, s16, 16
+; GFX9-NEXT:    v_med3_i32 v2, v0, -1, 0
+; GFX9-NEXT:    v_cvt_i16_f16_e32 v0, s16
+; GFX9-NEXT:    v_med3_i32 v3, v1, -1, 0
+; GFX9-NEXT:    v_cvt_i16_f16_e32 v1, s4
+; GFX9-NEXT:    v_bfe_i32 v0, v0, 0, 16
+; GFX9-NEXT:    v_bfe_i32 v1, v1, 0, 16
+; GFX9-NEXT:    v_med3_i32 v0, v0, -1, 0
+; GFX9-NEXT:    v_med3_i32 v1, v1, -1, 0
+; GFX9-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11-FAKE16-LABEL: test_s_signed_v8f16_v8i1:
+; GFX11-FAKE16:       ; %bb.0:
+; GFX11-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-FAKE16-NEXT:    v_cvt_i16_f16_e32 v0, s3
+; GFX11-FAKE16-NEXT:    v_cvt_i16_f16_e32 v1, s2
+; GFX11-FAKE16-NEXT:    v_cvt_i16_f16_e32 v2, s1
+; GFX11-FAKE16-NEXT:    s_lshr_b32 s3, s3, 16
+; GFX11-FAKE16-NEXT:    s_lshr_b32 s1, s1, 16
+; GFX11-FAKE16-NEXT:    v_bfe_i32 v0, v0, 0, 16
+; GFX11-FAKE16-NEXT:    v_bfe_i32 v1, v1, 0, 16
+; GFX11-FAKE16-NEXT:    v_cvt_i16_f16_e32 v5, s1
+; GFX11-FAKE16-NEXT:    v_bfe_i32 v2, v2, 0, 16
+; GFX11-FAKE16-NEXT:    v_med3_i32 v6, v0, -1, 0
+; GFX11-FAKE16-NEXT:    v_cvt_i16_f16_e32 v0, s0
+; GFX11-FAKE16-NEXT:    s_lshr_b32 s0, s0, 16
+; GFX11-FAKE16-NEXT:    v_med3_i32 v4, v1, -1, 0
+; GFX11-FAKE16-NEXT:    v_cvt_i16_f16_e32 v3, s0
+; GFX11-FAKE16-NEXT:    s_lshr_b32 s0, s2, 16
+; GFX11-FAKE16-NEXT:    v_cvt_i16_f16_e32 v1, s3
+; GFX11-FAKE16-NEXT:    v_cvt_i16_f16_e32 v7, s0
+; GFX11-FAKE16-NEXT:    v_bfe_i32 v0, v0, 0, 16
+; GFX11-FAKE16-NEXT:    v_bfe_i32 v3, v3, 0, 16
+; GFX11-FAKE16-NEXT:    v_bfe_i32 v5, v5, 0, 16
+; GFX11-FAKE16-NEXT:    v_bfe_i32 v8, v1, 0, 16
+; GFX11-FAKE16-NEXT:    v_bfe_i32 v9, v7, 0, 16
+; GFX11-FAKE16-NEXT:    v_med3_i32 v2, v2, -1, 0
+; GFX11-FAKE16-NEXT:    v_med3_i32 v0, v0, -1, 0
+; GFX11-FAKE16-NEXT:    v_med3_i32 v1, v3, -1, 0
+; GFX11-FAKE16-NEXT:    v_med3_i32 v7, v8, -1, 0
+; GFX11-FAKE16-NEXT:    v_med3_i32 v3, v5, -1, 0
+; GFX11-FAKE16-NEXT:    v_med3_i32 v5, v9, -1, 0
+; GFX11-FAKE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11-TRUE16-LABEL: test_s_signed_v8f16_v8i1:
+; GFX11-TRUE16:       ; %bb.0:
+; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-TRUE16-NEXT:    v_cvt_i16_f16_e32 v0.l, s3
+; GFX11-TRUE16-NEXT:    v_cvt_i16_f16_e32 v1.l, s2
+; GFX11-TRUE16-NEXT:    v_cvt_i16_f16_e32 v2.l, s1
+; GFX11-TRUE16-NEXT:    s_lshr_b32 s3, s3, 16
+; GFX11-TRUE16-NEXT:    s_lshr_b32 s1, s1, 16
+; GFX11-TRUE16-NEXT:    v_bfe_i32 v0, v0, 0, 16
+; GFX11-TRUE16-NEXT:    v_bfe_i32 v1, v1, 0, 16
+; GFX11-TRUE16-NEXT:    v_cvt_i16_f16_e32 v5.l, s1
+; GFX11-TRUE16-NEXT:    v_bfe_i32 v2, v2, 0, 16
+; GFX11-TRUE16-NEXT:    v_med3_i32 v6, v0, -1, 0
+; GFX11-TRUE16-NEXT:    v_cvt_i16_f16_e32 v0.l, s0
+; GFX11-TRUE16-NEXT:    s_lshr_b32 s0, s0, 16
+; GFX11-TRUE16-NEXT:    v_med3_i32 v4, v1, -1, 0
+; GFX11-TRUE16-NEXT:    v_cvt_i16_f16_e32 v3.l, s0
+; GFX11-TRUE16-NEXT:    s_lshr_b32 s0, s2, 16
+; GFX11-TRUE16-NEXT:    v_cvt_i16_f16_e32 v1.l, s3
+; GFX11-TRUE16-NEXT:    v_cvt_i16_f16_e32 v7.l, s0
+; GFX11-TRUE16-NEXT:    v_bfe_i32 v0, v0, 0, 16
+; GFX11-TRUE16-NEXT:    v_bfe_i32 v3, v3, 0, 16
+; GFX11-TRUE16-NEXT:    v_bfe_i32 v5, v5, 0, 16
+; GFX11-TRUE16-NEXT:    v_bfe_i32 v8, v1, 0, 16
+; GFX11-TRUE16-NEXT:    v_bfe_i32 v9, v7, 0, 16
+; GFX11-TRUE16-NEXT:    v_med3_i32 v2, v2, -1, 0
+; GFX11-TRUE16-NEXT:    v_med3_i32 v0, v0, -1, 0
+; GFX11-TRUE16-NEXT:    v_med3_i32 v1, v3, -1, 0
+; GFX11-TRUE16-NEXT:    v_med3_i32 v7, v8, -1, 0
+; GFX11-TRUE16-NEXT:    v_med3_i32 v3, v5, -1, 0
+; GFX11-TRUE16-NEXT:    v_med3_i32 v5, v9, -1, 0
+; GFX11-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-FAKE16-LABEL: test_s_signed_v8f16_v8i1:
+; GFX12-FAKE16:       ; %bb.0:
+; GFX12-FAKE16-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-FAKE16-NEXT:    s_wait_expcnt 0x0
+; GFX12-FAKE16-NEXT:    s_wait_samplecnt 0x0
+; GFX12-FAKE16-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-FAKE16-NEXT:    s_wait_kmcnt 0x0
+; GFX12-FAKE16-NEXT:    v_cvt_i16_f16_e32 v0, s3
+; GFX12-FAKE16-NEXT:    v_cvt_i16_f16_e32 v1, s2
+; GFX12-FAKE16-NEXT:    v_cvt_i16_f16_e32 v2, s1
+; GFX12-FAKE16-NEXT:    s_lshr_b32 s3, s3, 16
+; GFX12-FAKE16-NEXT:    s_lshr_b32 s1, s1, 16
+; GFX12-FAKE16-NEXT:    v_bfe_i32 v0, v0, 0, 16
+; GFX12-FAKE16-NEXT:    v_bfe_i32 v1, v1, 0, 16
+; GFX12-FAKE16-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-FAKE16-NEXT:    v_cvt_i16_f16_e32 v5, s1
+; GFX12-FAKE16-NEXT:    v_bfe_i32 v2, v2, 0, 16
+; GFX12-FAKE16-NEXT:    v_med3_i32 v6, v0, -1, 0
+; GFX12-FAKE16-NEXT:    v_cvt_i16_f16_e32 v0, s0
+; GFX12-FAKE16-NEXT:    s_lshr_b32 s0, s0, 16
+; GFX12-FAKE16-NEXT:    v_med3_i32 v4, v1, -1, 0
+; GFX12-FAKE16-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-FAKE16-NEXT:    v_cvt_i16_f16_e32 v3, s0
+; GFX12-FAKE16-NEXT:    s_lshr_b32 s0, s2, 16
+; GFX12-FAKE16-NEXT:    v_cvt_i16_f16_e32 v1, s3
+; GFX12-FAKE16-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-FAKE16-NEXT:    v_cvt_i16_f16_e32 v7, s0
+; GFX12-FAKE16-NEXT:    v_bfe_i32 v0, v0, 0, 16
+; GFX12-FAKE16-NEXT:    v_bfe_i32 v3, v3, 0, 16
+; GFX12-FAKE16-NEXT:    v_bfe_i32 v5, v5, 0, 16
+; GFX12-FAKE16-NEXT:    v_bfe_i32 v8, v1, 0, 16
+; GFX12-FAKE16-NEXT:    v_bfe_i32 v9, v7, 0, 16
+; GFX12-FAKE16-NEXT:    v_med3_i32 v2, v2, -1, 0
+; GFX12-FAKE16-NEXT:    v_med3_i32 v0, v0, -1, 0
+; GFX12-FAKE16-NEXT:    v_med3_i32 v1, v3, -1, 0
+; GFX12-FAKE16-NEXT:    v_med3_i32 v7, v8, -1, 0
+; GFX12-FAKE16-NEXT:    v_med3_i32 v3, v5, -1, 0
+; GFX12-FAKE16-NEXT:    v_med3_i32 v5, v9, -1, 0
+; GFX12-FAKE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-TRUE16-LABEL: test_s_signed_v8f16_v8i1:
+; GFX12-TRUE16:       ; %bb.0:
+; GFX12-TRUE16-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-TRUE16-NEXT:    s_wait_expcnt 0x0
+; GFX12-TRUE16-NEXT:    s_wait_samplecnt 0x0
+; GFX12-TRUE16-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-TRUE16-NEXT:    s_wait_kmcnt 0x0
+; GFX12-TRUE16-NEXT:    v_cvt_i16_f16_e32 v0.l, s3
+; GFX12-TRUE16-NEXT:    v_cvt_i16_f16_e32 v1.l, s2
+; GFX12-TRUE16-NEXT:    v_cvt_i16_f16_e32 v2.l, s1
+; GFX12-TRUE16-NEXT:    s_lshr_b32 s3, s3, 16
+; GFX12-TRUE16-NEXT:    s_lshr_b32 s1, s1, 16
+; GFX12-TRUE16-NEXT:    v_bfe_i32 v0, v0, 0, 16
+; GFX12-TRUE16-NEXT:    v_bfe_i32 v1, v1, 0, 16
+; GFX12-TRUE16-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-TRUE16-NEXT:    v_cvt_i16_f16_e32 v5.l, s1
+; GFX12-TRUE16-NEXT:    v_bfe_i32 v2, v2, 0, 16
+; GFX12-TRUE16-NEXT:    v_med3_i32 v6, v0, -1, 0
+; GFX12-TRUE16-NEXT:    v_cvt_i16_f16_e32 v0.l, s0
+; GFX12-TRUE16-NEXT:    s_lshr_b32 s0, s0, 16
+; GFX12-TRUE16-NEXT:    v_med3_i32 v4, v1, -1, 0
+; GFX12-TRUE16-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-TRUE16-NEXT:    v_cvt_i16_f16_e32 v3.l, s0
+; GFX12-TRUE16-NEXT:    s_lshr_b32 s0, s2, 16
+; GFX12-TRUE16-NEXT:    v_cvt_i16_f16_e32 v1.l, s3
+; GFX12-TRUE16-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-TRUE16-NEXT:    v_cvt_i16_f16_e32 v7.l, s0
+; GFX12-TRUE16-NEXT:    v_bfe_i32 v0, v0, 0, 16
+; GFX12-TRUE16-NEXT:    v_bfe_i32 v3, v3, 0, 16
+; GFX12-TRUE16-NEXT:    v_bfe_i32 v5, v5, 0, 16
+; GFX12-TRUE16-NEXT:    v_bfe_i32 v8, v1, 0, 16
+; GFX12-TRUE16-NEXT:    v_bfe_i32 v9, v7, 0, 16
+; GFX12-TRUE16-NEXT:    v_med3_i32 v2, v2, -1, 0
+; GFX12-TRUE16-NEXT:    v_med3_i32 v0, v0, -1, 0
+; GFX12-TRUE16-NEXT:    v_med3_i32 v1, v3, -1, 0
+; GFX12-TRUE16-NEXT:    v_med3_i32 v7, v8, -1, 0
+; GFX12-TRUE16-NEXT:    v_med3_i32 v3, v5, -1, 0
+; GFX12-TRUE16-NEXT:    v_med3_i32 v5, v9, -1, 0
+; GFX12-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-GI-LABEL: test_s_signed_v8f16_v8i1:
+; GFX12-GI:       ; %bb.0:
+; GFX12-GI-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-GI-NEXT:    s_wait_expcnt 0x0
+; GFX12-GI-NEXT:    s_wait_samplecnt 0x0
+; GFX12-GI-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-GI-NEXT:    s_wait_kmcnt 0x0
+; GFX12-GI-NEXT:    s_cvt_f32_f16 s0, s0
+; GFX12-GI-NEXT:    s_cvt_f32_f16 s1, s1
+; GFX12-GI-NEXT:    s_cvt_f32_f16 s2, s2
+; GFX12-GI-NEXT:    s_cvt_f32_f16 s3, s3
+; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-GI-NEXT:    s_cvt_i32_f32 s0, s0
+; GFX12-GI-NEXT:    s_cvt_i32_f32 s1, s1
+; GFX12-GI-NEXT:    s_cvt_i32_f32 s2, s2
+; GFX12-GI-NEXT:    s_cvt_i32_f32 s3, s3
+; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-GI-NEXT:    s_min_i32 s0, s0, 0
+; GFX12-GI-NEXT:    s_min_i32 s1, s1, 0
+; GFX12-GI-NEXT:    s_min_i32 s2, s2, 0
+; GFX12-GI-NEXT:    s_min_i32 s3, s3, 0
+; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-GI-NEXT:    s_max_i32 s0, s0, -1
+; GFX12-GI-NEXT:    s_max_i32 s1, s1, -1
+; GFX12-GI-NEXT:    s_max_i32 s2, s2, -1
+; GFX12-GI-NEXT:    s_max_i32 s3, s3, -1
+; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-GI-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s0
+; GFX12-GI-NEXT:    v_dual_mov_b32 v2, s1 :: v_dual_mov_b32 v3, s1
+; GFX12-GI-NEXT:    v_dual_mov_b32 v4, s2 :: v_dual_mov_b32 v5, s2
+; GFX12-GI-NEXT:    v_dual_mov_b32 v6, s3 :: v_dual_mov_b32 v7, s3
+; GFX12-GI-NEXT:    s_setpc_b64 s[30:31]
+    %x = call <8 x i1> @llvm.fptosi.sat.v8f16.v8i1(<8 x half> %f)
+    ret <8 x i1> %x
+}
+
+define <8 x i8> @test_s_signed_v8f16_v8i8(<8 x half> inreg %f) {
+; GFX7-ISEL-LABEL: test_s_signed_v8f16_v8i8:
+; GFX7-ISEL:       ; %bb.0:
+; GFX7-ISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-ISEL-NEXT:    s_lshr_b32 s7, s19, 16
+; GFX7-ISEL-NEXT:    v_cvt_f32_f16_e32 v1, s7
+; GFX7-ISEL-NEXT:    v_cvt_f32_f16_e32 v0, s19
+; GFX7-ISEL-NEXT:    s_lshr_b32 s6, s18, 16
+; GFX7-ISEL-NEXT:    s_movk_i32 s7, 0xff80
+; GFX7-ISEL-NEXT:    v_cvt_i32_f32_e32 v1, v1
+; GFX7-ISEL-NEXT:    v_cvt_i32_f32_e32 v0, v0
+; GFX7-ISEL-NEXT:    v_mov_b32_e32 v2, 0x7f
+; GFX7-ISEL-NEXT:    v_cvt_f32_f16_e32 v3, s18
+; GFX7-ISEL-NEXT:    v_med3_i32 v7, v1, s7, v2
+; GFX7-ISEL-NEXT:    v_cvt_f32_f16_e32 v1, s6
+; GFX7-ISEL-NEXT:    v_med3_i32 v0, v0, s7, v2
+; GFX7-ISEL-NEXT:    v_and_b32_e32 v0, 0xff, v0
+; GFX7-ISEL-NEXT:    v_cvt_i32_f32_e32 v3, v3
+; GFX7-ISEL-NEXT:    v_cvt_i32_f32_e32 v1, v1
+; GFX7-ISEL-NEXT:    v_lshlrev_b32_e32 v0, 16, v0
+; GFX7-ISEL-NEXT:    v_lshlrev_b32_e32 v4, 24, v7
+; GFX7-ISEL-NEXT:    v_or_b32_e32 v0, v4, v0
+; GFX7-ISEL-NEXT:    v_cvt_f32_f16_e32 v4, s17
+; GFX7-ISEL-NEXT:    v_med3_i32 v3, v3, s7, v2
+; GFX7-ISEL-NEXT:    v_med3_i32 v1, v1, s7, v2
+; GFX7-ISEL-NEXT:    s_lshr_b32 s5, s17, 16
+; GFX7-ISEL-NEXT:    v_and_b32_e32 v3, 0xff, v3
+; GFX7-ISEL-NEXT:    v_lshlrev_b32_e32 v1, 8, v1
+; GFX7-ISEL-NEXT:    v_or_b32_e32 v1, v3, v1
+; GFX7-ISEL-NEXT:    v_cvt_i32_f32_e32 v3, v4
+; GFX7-ISEL-NEXT:    v_cvt_f32_f16_e32 v4, s5
+; GFX7-ISEL-NEXT:    s_lshr_b32 s4, s16, 16
+; GFX7-ISEL-NEXT:    v_and_b32_e32 v1, 0xffff, v1
+; GFX7-ISEL-NEXT:    v_or_b32_e32 v9, v1, v0
+; GFX7-ISEL-NEXT:    v_med3_i32 v1, v3, s7, v2
+; GFX7-ISEL-NEXT:    v_cvt_i32_f32_e32 v3, v4
+; GFX7-ISEL-NEXT:    v_cvt_f32_f16_e32 v4, s16
+; GFX7-ISEL-NEXT:    v_cvt_f32_f16_e32 v5, s4
+; GFX7-ISEL-NEXT:    v_and_b32_e32 v1, 0xff, v1
+; GFX7-ISEL-NEXT:    v_med3_i32 v3, v3, s7, v2
+; GFX7-ISEL-NEXT:    v_cvt_i32_f32_e32 v4, v4
+; GFX7-ISEL-NEXT:    v_cvt_i32_f32_e32 v5, v5
+; GFX7-ISEL-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; GFX7-ISEL-NEXT:    v_lshlrev_b32_e32 v3, 24, v3
+; GFX7-ISEL-NEXT:    v_or_b32_e32 v1, v3, v1
+; GFX7-ISEL-NEXT:    v_med3_i32 v3, v4, s7, v2
+; GFX7-ISEL-NEXT:    v_med3_i32 v2, v5, s7, v2
+; GFX7-ISEL-NEXT:    v_and_b32_e32 v3, 0xff, v3
+; GFX7-ISEL-NEXT:    v_lshlrev_b32_e32 v2, 8, v2
+; GFX7-ISEL-NEXT:    v_or_b32_e32 v2, v3, v2
+; GFX7-ISEL-NEXT:    v_and_b32_e32 v2, 0xffff, v2
+; GFX7-ISEL-NEXT:    v_or_b32_e32 v8, v2, v1
+; GFX7-ISEL-NEXT:    v_lshr_b64 v[1:2], v[8:9], 8
+; GFX7-ISEL-NEXT:    v_lshr_b64 v[2:3], v[8:9], 16
+; GFX7-ISEL-NEXT:    v_lshr_b64 v[3:4], v[8:9], 24
+; GFX7-ISEL-NEXT:    v_lshrrev_b32_e32 v5, 8, v9
+; GFX7-ISEL-NEXT:    v_lshrrev_b32_e32 v6, 16, v0
+; GFX7-ISEL-NEXT:    v_and_b32_e32 v7, 0xff, v7
+; GFX7-ISEL-NEXT:    v_mov_b32_e32 v0, v8
+; GFX7-ISEL-NEXT:    v_mov_b32_e32 v4, v9
+; GFX7-ISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX7-GI-LABEL: test_s_signed_v8f16_v8i8:
+; GFX7-GI:       ; %bb.0:
+; GFX7-GI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-GI-NEXT:    s_lshr_b32 s4, s16, 16
+; GFX7-GI-NEXT:    s_lshr_b32 s5, s17, 16
+; GFX7-GI-NEXT:    s_lshr_b32 s6, s18, 16
+; GFX7-GI-NEXT:    s_lshr_b32 s7, s19, 16
+; GFX7-GI-NEXT:    v_cvt_f32_f16_e32 v0, s16
+; GFX7-GI-NEXT:    v_cvt_f32_f16_e32 v1, s4
+; GFX7-GI-NEXT:    v_cvt_f32_f16_e32 v2, s17
+; GFX7-GI-NEXT:    v_cvt_f32_f16_e32 v3, s5
+; GFX7-GI-NEXT:    v_cvt_f32_f16_e32 v4, s18
+; GFX7-GI-NEXT:    v_cvt_f32_f16_e32 v5, s6
+; GFX7-GI-NEXT:    v_cvt_f32_f16_e32 v6, s19
+; GFX7-GI-NEXT:    v_cvt_f32_f16_e32 v9, s7
+; GFX7-GI-NEXT:    v_cvt_i32_f32_e32 v0, v0
+; GFX7-GI-NEXT:    v_cvt_i32_f32_e32 v1, v1
+; GFX7-GI-NEXT:    v_cvt_i32_f32_e32 v2, v2
+; GFX7-GI-NEXT:    v_cvt_i32_f32_e32 v3, v3
+; GFX7-GI-NEXT:    v_cvt_i32_f32_e32 v4, v4
+; GFX7-GI-NEXT:    v_cvt_i32_f32_e32 v5, v5
+; GFX7-GI-NEXT:    v_cvt_i32_f32_e32 v6, v6
+; GFX7-GI-NEXT:    v_cvt_i32_f32_e32 v9, v9
+; GFX7-GI-NEXT:    v_mov_b32_e32 v7, 0x7f
+; GFX7-GI-NEXT:    v_mov_b32_e32 v8, 0xffffff80
+; GFX7-GI-NEXT:    v_med3_i32 v0, v0, v8, v7
+; GFX7-GI-NEXT:    v_med3_i32 v1, v1, v8, v7
+; GFX7-GI-NEXT:    v_med3_i32 v2, v2, v8, v7
+; GFX7-GI-NEXT:    v_med3_i32 v3, v3, v8, v7
+; GFX7-GI-NEXT:    v_med3_i32 v4, v4, v8, v7
+; GFX7-GI-NEXT:    v_med3_i32 v5, v5, v8, v7
+; GFX7-GI-NEXT:    v_med3_i32 v6, v6, v8, v7
+; GFX7-GI-NEXT:    v_med3_i32 v7, v9, v8, v7
+; GFX7-GI-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX9-LABEL: test_s_signed_v8f16_v8i8:
+; GFX9:       ; %bb.0:
+; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    s_lshr_b32 s5, s18, 16
+; GFX9-NEXT:    v_cvt_i16_f16_e32 v2, s5
+; GFX9-NEXT:    v_cvt_i16_f16_e32 v0, s18
+; GFX9-NEXT:    s_movk_i32 s4, 0xff80
+; GFX9-NEXT:    v_mov_b32_e32 v1, 0x7f
+; GFX9-NEXT:    v_bfe_i32 v2, v2, 0, 16
+; GFX9-NEXT:    v_bfe_i32 v0, v0, 0, 16
+; GFX9-NEXT:    v_med3_i32 v2, v2, s4, v1
+; GFX9-NEXT:    v_med3_i32 v0, v0, s4, v1
+; GFX9-NEXT:    v_lshlrev_b32_e32 v2, 8, v2
+; GFX9-NEXT:    s_lshr_b32 s5, s19, 16
+; GFX9-NEXT:    v_or_b32_sdwa v8, v0, v2 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:BYTE_0 src1_sel:DWORD
+; GFX9-NEXT:    v_cvt_i16_f16_e32 v2, s5
+; GFX9-NEXT:    v_cvt_i16_f16_e32 v0, s19
+; GFX9-NEXT:    v_bfe_i32 v2, v2, 0, 16
+; GFX9-NEXT:    v_bfe_i32 v0, v0, 0, 16
+; GFX9-NEXT:    v_med3_i32 v2, v2, s4, v1
+; GFX9-NEXT:    v_med3_i32 v0, v0, s4, v1
+; GFX9-NEXT:    v_lshlrev_b32_e32 v2, 8, v2
+; GFX9-NEXT:    s_lshr_b32 s5, s17, 16
+; GFX9-NEXT:    v_or_b32_sdwa v6, v0, v2 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:BYTE_0 src1_sel:DWORD
+; GFX9-NEXT:    v_cvt_i16_f16_e32 v2, s5
+; GFX9-NEXT:    v_cvt_i16_f16_e32 v0, s17
+; GFX9-NEXT:    v_bfe_i32 v2, v2, 0, 16
+; GFX9-NEXT:    v_bfe_i32 v0, v0, 0, 16
+; GFX9-NEXT:    v_med3_i32 v2, v2, s4, v1
+; GFX9-NEXT:    v_med3_i32 v0, v0, s4, v1
+; GFX9-NEXT:    v_lshlrev_b32_e32 v2, 8, v2
+; GFX9-NEXT:    s_lshr_b32 s5, s16, 16
+; GFX9-NEXT:    v_or_b32_sdwa v2, v0, v2 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:BYTE_0 src1_sel:DWORD
+; GFX9-NEXT:    v_cvt_i16_f16_e32 v0, s16
+; GFX9-NEXT:    v_cvt_i16_f16_e32 v9, s5
+; GFX9-NEXT:    v_bfe_i32 v0, v0, 0, 16
+; GFX9-NEXT:    v_bfe_i32 v9, v9, 0, 16
+; GFX9-NEXT:    v_med3_i32 v0, v0, s4, v1
+; GFX9-NEXT:    v_med3_i32 v1, v9, s4, v1
+; GFX9-NEXT:    v_lshlrev_b32_e32 v7, 16, v6
+; GFX9-NEXT:    v_lshlrev_b32_e32 v1, 8, v1
+; GFX9-NEXT:    v_or_b32_sdwa v4, v8, v7 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
+; GFX9-NEXT:    v_lshlrev_b32_e32 v3, 16, v2
+; GFX9-NEXT:    v_or_b32_sdwa v0, v0, v1 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:BYTE_0 src1_sel:DWORD
+; GFX9-NEXT:    v_and_b32_e32 v1, 0xff00, v1
+; GFX9-NEXT:    v_lshrrev_b32_e32 v5, 8, v4
+; GFX9-NEXT:    v_or_b32_e32 v1, v1, v3
+; GFX9-NEXT:    v_lshrrev_b64 v[3:4], 24, v[3:4]
+; GFX9-NEXT:    v_lshrrev_b32_e32 v7, 24, v7
+; GFX9-NEXT:    v_lshrrev_b32_e32 v1, 8, v1
+; GFX9-NEXT:    v_mov_b32_e32 v4, v8
+; GFX9-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11-FAKE16-LABEL: test_s_signed_v8f16_v8i8:
+; GFX11-FAKE16:       ; %bb.0:
+; GFX11-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-FAKE16-NEXT:    v_cvt_i16_f16_e32 v2, s3
+; GFX11-FAKE16-NEXT:    s_lshr_b32 s4, s2, 16
+; GFX11-FAKE16-NEXT:    s_lshr_b32 s3, s3, 16
+; GFX11-FAKE16-NEXT:    v_cvt_i16_f16_e32 v1, s4
+; GFX11-FAKE16-NEXT:    s_lshr_b32 s4, s1, 16
+; GFX11-FAKE16-NEXT:    v_cvt_i16_f16_e32 v0, s2
+; GFX11-FAKE16-NEXT:    v_cvt_i16_f16_e32 v3, s1
+; GFX11-FAKE16-NEXT:    v_cvt_i16_f16_e32 v4, s4
+; GFX11-FAKE16-NEXT:    v_bfe_i32 v2, v2, 0, 16
+; GFX11-FAKE16-NEXT:    v_cvt_i16_f16_e32 v5, s3
+; GFX11-FAKE16-NEXT:    s_movk_i32 s2, 0xff80
+; GFX11-FAKE16-NEXT:    s_lshr_b32 s1, s0, 16
+; GFX11-FAKE16-NEXT:    v_bfe_i32 v0, v0, 0, 16
+; GFX11-FAKE16-NEXT:    v_bfe_i32 v1, v1, 0, 16
+; GFX11-FAKE16-NEXT:    v_bfe_i32 v3, v3, 0, 16
+; GFX11-FAKE16-NEXT:    v_bfe_i32 v4, v4, 0, 16
+; GFX11-FAKE16-NEXT:    v_med3_i32 v2, v2, s2, 0x7f
+; GFX11-FAKE16-NEXT:    v_cvt_i16_f16_e32 v6, s1
+; GFX11-FAKE16-NEXT:    v_bfe_i32 v5, v5, 0, 16
+; GFX11-FAKE16-NEXT:    v_med3_i32 v0, v0, s2, 0x7f
+; GFX11-FAKE16-NEXT:    v_med3_i32 v1, v1, s2, 0x7f
+; GFX11-FAKE16-NEXT:    v_med3_i32 v3, v3, s2, 0x7f
+; GFX11-FAKE16-NEXT:    v_med3_i32 v4, v4, s2, 0x7f
+; GFX11-FAKE16-NEXT:    v_and_b32_e32 v7, 0xff, v2
+; GFX11-FAKE16-NEXT:    v_bfe_i32 v2, v6, 0, 16
+; GFX11-FAKE16-NEXT:    v_med3_i32 v5, v5, s2, 0x7f
+; GFX11-FAKE16-NEXT:    v_and_b32_e32 v0, 0xff, v0
+; GFX11-FAKE16-NEXT:    v_lshlrev_b32_e32 v1, 8, v1
+; GFX11-FAKE16-NEXT:    v_and_b32_e32 v3, 0xff, v3
+; GFX11-FAKE16-NEXT:    v_lshlrev_b32_e32 v4, 8, v4
+; GFX11-FAKE16-NEXT:    v_cvt_i16_f16_e32 v6, s0
+; GFX11-FAKE16-NEXT:    v_med3_i32 v9, v2, s2, 0x7f
+; GFX11-FAKE16-NEXT:    v_lshlrev_b32_e32 v5, 8, v5
+; GFX11-FAKE16-NEXT:    v_or_b32_e32 v8, v0, v1
+; GFX11-FAKE16-NEXT:    v_or_b32_e32 v2, v3, v4
+; GFX11-FAKE16-NEXT:    v_bfe_i32 v0, v6, 0, 16
+; GFX11-FAKE16-NEXT:    v_lshlrev_b32_e32 v1, 8, v9
+; GFX11-FAKE16-NEXT:    v_or_b32_e32 v6, v7, v5
+; GFX11-FAKE16-NEXT:    v_and_b32_e32 v3, 0xffff, v8
+; GFX11-FAKE16-NEXT:    v_lshlrev_b32_e32 v4, 16, v2
+; GFX11-FAKE16-NEXT:    v_med3_i32 v0, v0, s2, 0x7f
+; GFX11-FAKE16-NEXT:    v_and_b32_e32 v5, 0xff00, v1
+; GFX11-FAKE16-NEXT:    v_lshlrev_b32_e32 v7, 16, v6
+; GFX11-FAKE16-NEXT:    v_and_b32_e32 v0, 0xff, v0
+; GFX11-FAKE16-NEXT:    v_or_b32_e32 v9, v5, v4
+; GFX11-FAKE16-NEXT:    v_or_b32_e32 v5, v3, v7
+; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v7, 24, v7
+; GFX11-FAKE16-NEXT:    v_or_b32_e32 v0, v0, v1
+; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v1, 8, v9
+; GFX11-FAKE16-NEXT:    v_lshrrev_b64 v[3:4], 24, v[4:5]
+; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v5, 8, v5
+; GFX11-FAKE16-NEXT:    v_mov_b32_e32 v4, v8
+; GFX11-FAKE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11-TRUE16-LABEL: test_s_signed_v8f16_v8i8:
+; GFX11-TRUE16:       ; %bb.0:
+; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-TRUE16-NEXT:    v_cvt_i16_f16_e32 v2.l, s3
+; GFX11-TRUE16-NEXT:    s_lshr_b32 s4, s2, 16
+; GFX11-TRUE16-NEXT:    s_lshr_b32 s3, s3, 16
+; GFX11-TRUE16-NEXT:    v_cvt_i16_f16_e32 v1.l, s4
+; GFX11-TRUE16-NEXT:    s_lshr_b32 s4, s1, 16
+; GFX11-TRUE16-NEXT:    v_cvt_i16_f16_e32 v0.l, s2
+; GFX11-TRUE16-NEXT:    v_cvt_i16_f16_e32 v3.l, s1
+; GFX11-TRUE16-NEXT:    v_cvt_i16_f16_e32 v4.l, s4
+; GFX11-TRUE16-NEXT:    v_bfe_i32 v2, v2, 0, 16
+; GFX11-TRUE16-NEXT:    v_cvt_i16_f16_e32 v5.l, s3
+; GFX11-TRUE16-NEXT:    s_movk_i32 s2, 0xff80
+; GFX11-TRUE16-NEXT:    s_lshr_b32 s1, s0, 16
+; GFX11-TRUE16-NEXT:    v_bfe_i32 v0, v0, 0, 16
+; GFX11-TRUE16-NEXT:    v_bfe_i32 v1, v1, 0, 16
+; GFX11-TRUE16-NEXT:    v_bfe_i32 v3, v3, 0, 16
+; GFX11-TRUE16-NEXT:    v_bfe_i32 v4, v4, 0, 16
+; GFX11-TRUE16-NEXT:    v_med3_i32 v2, v2, s2, 0x7f
+; GFX11-TRUE16-NEXT:    v_cvt_i16_f16_e32 v6.l, s1
+; GFX11-TRUE16-NEXT:    v_bfe_i32 v5, v5, 0, 16
+; GFX11-TRUE16-NEXT:    v_med3_i32 v0, v0, s2, 0x7f
+; GFX11-TRUE16-NEXT:    v_med3_i32 v1, v1, s2, 0x7f
+; GFX11-TRUE16-NEXT:    v_med3_i32 v3, v3, s2, 0x7f
+; GFX11-TRUE16-NEXT:    v_med3_i32 v4, v4, s2, 0x7f
+; GFX11-TRUE16-NEXT:    v_and_b32_e32 v7, 0xff, v2
+; GFX11-TRUE16-NEXT:    v_bfe_i32 v2, v6, 0, 16
+; GFX11-TRUE16-NEXT:    v_med3_i32 v5, v5, s2, 0x7f
+; GFX11-TRUE16-NEXT:    v_and_b32_e32 v0, 0xff, v0
+; GFX11-TRUE16-NEXT:    v_lshlrev_b32_e32 v1, 8, v1
+; GFX11-TRUE16-NEXT:    v_and_b32_e32 v3, 0xff, v3
+; GFX11-TRUE16-NEXT:    v_lshlrev_b32_e32 v4, 8, v4
+; GFX11-TRUE16-NEXT:    v_cvt_i16_f16_e32 v6.l, s0
+; GFX11-TRUE16-NEXT:    v_med3_i32 v9, v2, s2, 0x7f
+; GFX11-TRUE16-NEXT:    v_lshlrev_b32_e32 v5, 8, v5
+; GFX11-TRUE16-NEXT:    v_or_b32_e32 v8, v0, v1
+; GFX11-TRUE16-NEXT:    v_or_b32_e32 v2, v3, v4
+; GFX11-TRUE16-NEXT:    v_bfe_i32 v0, v6, 0, 16
+; GFX11-TRUE16-NEXT:    v_lshlrev_b32_e32 v1, 8, v9
+; GFX11-TRUE16-NEXT:    v_or_b32_e32 v6, v7, v5
+; GFX11-TRUE16-NEXT:    v_and_b32_e32 v3, 0xffff, v8
+; GFX11-TRUE16-NEXT:    v_lshlrev_b32_e32 v4, 16, v2
+; GFX11-TRUE16-NEXT:    v_med3_i32 v0, v0, s2, 0x7f
+; GFX11-TRUE16-NEXT:    v_and_b32_e32 v5, 0xff00, v1
+; GFX11-TRUE16-NEXT:    v_lshlrev_b32_e32 v7, 16, v6
+; GFX11-TRUE16-NEXT:    v_and_b32_e32 v0, 0xff, v0
+; GFX11-TRUE16-NEXT:    v_or_b32_e32 v9, v5, v4
+; GFX11-TRUE16-NEXT:    v_or_b32_e32 v5, v3, v7
+; GFX11-TRUE16-NEXT:    v_lshrrev_b32_e32 v7, 24, v7
+; GFX11-TRUE16-NEXT:    v_or_b32_e32 v0, v0, v1
+; GFX11-TRUE16-NEXT:    v_lshrrev_b32_e32 v1, 8, v9
+; GFX11-TRUE16-NEXT:    v_lshrrev_b64 v[3:4], 24, v[4:5]
+; GFX11-TRUE16-NEXT:    v_lshrrev_b32_e32 v5, 8, v5
+; GFX11-TRUE16-NEXT:    v_mov_b32_e32 v4, v8
+; GFX11-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-FAKE16-LABEL: test_s_signed_v8f16_v8i8:
+; GFX12-FAKE16:       ; %bb.0:
+; GFX12-FAKE16-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-FAKE16-NEXT:    s_wait_expcnt 0x0
+; GFX12-FAKE16-NEXT:    s_wait_samplecnt 0x0
+; GFX12-FAKE16-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-FAKE16-NEXT:    s_wait_kmcnt 0x0
+; GFX12-FAKE16-NEXT:    v_cvt_i16_f16_e32 v2, s3
+; GFX12-FAKE16-NEXT:    s_lshr_b32 s4, s2, 16
+; GFX12-FAKE16-NEXT:    s_lshr_b32 s3, s3, 16
+; GFX12-FAKE16-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-FAKE16-NEXT:    v_cvt_i16_f16_e32 v1, s4
+; GFX12-FAKE16-NEXT:    s_lshr_b32 s4, s1, 16
+; GFX12-FAKE16-NEXT:    v_cvt_i16_f16_e32 v0, s2
+; GFX12-FAKE16-NEXT:    v_cvt_i16_f16_e32 v3, s1
+; GFX12-FAKE16-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-FAKE16-NEXT:    v_cvt_i16_f16_e32 v4, s4
+; GFX12-FAKE16-NEXT:    v_bfe_i32 v2, v2, 0, 16
+; GFX12-FAKE16-NEXT:    v_cvt_i16_f16_e32 v5, s3
+; GFX12-FAKE16-NEXT:    s_movk_i32 s2, 0xff80
+; GFX12-FAKE16-NEXT:    s_lshr_b32 s1, s0, 16
+; GFX12-FAKE16-NEXT:    v_bfe_i32 v0, v0, 0, 16
+; GFX12-FAKE16-NEXT:    v_bfe_i32 v1, v1, 0, 16
+; GFX12-FAKE16-NEXT:    v_bfe_i32 v3, v3, 0, 16
+; GFX12-FAKE16-NEXT:    v_bfe_i32 v4, v4, 0, 16
+; GFX12-FAKE16-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-FAKE16-NEXT:    v_med3_i32 v2, v2, s2, 0x7f
+; GFX12-FAKE16-NEXT:    v_cvt_i16_f16_e32 v6, s1
+; GFX12-FAKE16-NEXT:    v_bfe_i32 v5, v5, 0, 16
+; GFX12-FAKE16-NEXT:    v_med3_i32 v0, v0, s2, 0x7f
+; GFX12-FAKE16-NEXT:    v_med3_i32 v1, v1, s2, 0x7f
+; GFX12-FAKE16-NEXT:    v_med3_i32 v3, v3, s2, 0x7f
+; GFX12-FAKE16-NEXT:    v_med3_i32 v4, v4, s2, 0x7f
+; GFX12-FAKE16-NEXT:    v_and_b32_e32 v7, 0xff, v2
+; GFX12-FAKE16-NEXT:    v_bfe_i32 v2, v6, 0, 16
+; GFX12-FAKE16-NEXT:    v_med3_i32 v5, v5, s2, 0x7f
+; GFX12-FAKE16-NEXT:    v_and_b32_e32 v0, 0xff, v0
+; GFX12-FAKE16-NEXT:    v_lshlrev_b32_e32 v1, 8, v1
+; GFX12-FAKE16-NEXT:    v_and_b32_e32 v3, 0xff, v3
+; GFX12-FAKE16-NEXT:    v_lshlrev_b32_e32 v4, 8, v4
+; GFX12-FAKE16-NEXT:    v_cvt_i16_f16_e32 v6, s0
+; GFX12-FAKE16-NEXT:    v_med3_i32 v9, v2, s2, 0x7f
+; GFX12-FAKE16-NEXT:    v_lshlrev_b32_e32 v5, 8, v5
+; GFX12-FAKE16-NEXT:    v_or_b32_e32 v8, v0, v1
+; GFX12-FAKE16-NEXT:    v_or_b32_e32 v2, v3, v4
+; GFX12-FAKE16-NEXT:    v_bfe_i32 v0, v6, 0, 16
+; GFX12-FAKE16-NEXT:    v_lshlrev_b32_e32 v1, 8, v9
+; GFX12-FAKE16-NEXT:    v_or_b32_e32 v6, v7, v5
+; GFX12-FAKE16-NEXT:    v_and_b32_e32 v3, 0xffff, v8
+; GFX12-FAKE16-NEXT:    v_lshlrev_b32_e32 v4, 16, v2
+; GFX12-FAKE16-NEXT:    v_med3_i32 v0, v0, s2, 0x7f
+; GFX12-FAKE16-NEXT:    v_and_b32_e32 v5, 0xff00, v1
+; GFX12-FAKE16-NEXT:    v_lshlrev_b32_e32 v7, 16, v6
+; GFX12-FAKE16-NEXT:    v_and_b32_e32 v0, 0xff, v0
+; GFX12-FAKE16-NEXT:    v_or_b32_e32 v9, v5, v4
+; GFX12-FAKE16-NEXT:    v_or_b32_e32 v5, v3, v7
+; GFX12-FAKE16-NEXT:    v_lshrrev_b32_e32 v7, 24, v7
+; GFX12-FAKE16-NEXT:    v_or_b32_e32 v0, v0, v1
+; GFX12-FAKE16-NEXT:    v_lshrrev_b32_e32 v1, 8, v9
+; GFX12-FAKE16-NEXT:    v_lshrrev_b64 v[3:4], 24, v[4:5]
+; GFX12-FAKE16-NEXT:    v_lshrrev_b32_e32 v5, 8, v5
+; GFX12-FAKE16-NEXT:    v_mov_b32_e32 v4, v8
+; GFX12-FAKE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-TRUE16-LABEL: test_s_signed_v8f16_v8i8:
+; GFX12-TRUE16:       ; %bb.0:
+; GFX12-TRUE16-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-TRUE16-NEXT:    s_wait_expcnt 0x0
+; GFX12-TRUE16-NEXT:    s_wait_samplecnt 0x0
+; GFX12-TRUE16-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-TRUE16-NEXT:    s_wait_kmcnt 0x0
+; GFX12-TRUE16-NEXT:    v_cvt_i16_f16_e32 v2.l, s3
+; GFX12-TRUE16-NEXT:    s_lshr_b32 s4, s2, 16
+; GFX12-TRUE16-NEXT:    s_lshr_b32 s3, s3, 16
+; GFX12-TRUE16-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-TRUE16-NEXT:    v_cvt_i16_f16_e32 v1.l, s4
+; GFX12-TRUE16-NEXT:    s_lshr_b32 s4, s1, 16
+; GFX12-TRUE16-NEXT:    v_cvt_i16_f16_e32 v0.l, s2
+; GFX12-TRUE16-NEXT:    v_cvt_i16_f16_e32 v3.l, s1
+; GFX12-TRUE16-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-TRUE16-NEXT:    v_cvt_i16_f16_e32 v4.l, s4
+; GFX12-TRUE16-NEXT:    v_bfe_i32 v2, v2, 0, 16
+; GFX12-TRUE16-NEXT:    v_cvt_i16_f16_e32 v5.l, s3
+; GFX12-TRUE16-NEXT:    s_movk_i32 s2, 0xff80
+; GFX12-TRUE16-NEXT:    s_lshr_b32 s1, s0, 16
+; GFX12-TRUE16-NEXT:    v_bfe_i32 v0, v0, 0, 16
+; GFX12-TRUE16-NEXT:    v_bfe_i32 v1, v1, 0, 16
+; GFX12-TRUE16-NEXT:    v_bfe_i32 v3, v3, 0, 16
+; GFX12-TRUE16-NEXT:    v_bfe_i32 v4, v4, 0, 16
+; GFX12-TRUE16-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-TRUE16-NEXT:    v_med3_i32 v2, v2, s2, 0x7f
+; GFX12-TRUE16-NEXT:    v_cvt_i16_f16_e32 v6.l, s1
+; GFX12-TRUE16-NEXT:    v_bfe_i32 v5, v5, 0, 16
+; GFX12-TRUE16-NEXT:    v_med3_i32 v0, v0, s2, 0x7f
+; GFX12-TRUE16-NEXT:    v_med3_i32 v1, v1, s2, 0x7f
+; GFX12-TRUE16-NEXT:    v_med3_i32 v3, v3, s2, 0x7f
+; GFX12-TRUE16-NEXT:    v_med3_i32 v4, v4, s2, 0x7f
+; GFX12-TRUE16-NEXT:    v_and_b32_e32 v7, 0xff, v2
+; GFX12-TRUE16-NEXT:    v_bfe_i32 v2, v6, 0, 16
+; GFX12-TRUE16-NEXT:    v_med3_i32 v5, v5, s2, 0x7f
+; GFX12-TRUE16-NEXT:    v_and_b32_e32 v0, 0xff, v0
+; GFX12-TRUE16-NEXT:    v_lshlrev_b32_e32 v1, 8, v1
+; GFX12-TRUE16-NEXT:    v_and_b32_e32 v3, 0xff, v3
+; GFX12-TRUE16-NEXT:    v_lshlrev_b32_e32 v4, 8, v4
+; GFX12-TRUE16-NEXT:    v_cvt_i16_f16_e32 v6.l, s0
+; GFX12-TRUE16-NEXT:    v_med3_i32 v9, v2, s2, 0x7f
+; GFX12-TRUE16-NEXT:    v_lshlrev_b32_e32 v5, 8, v5
+; GFX12-TRUE16-NEXT:    v_or_b32_e32 v8, v0, v1
+; GFX12-TRUE16-NEXT:    v_or_b32_e32 v2, v3, v4
+; GFX12-TRUE16-NEXT:    v_bfe_i32 v0, v6, 0, 16
+; GFX12-TRUE16-NEXT:    v_lshlrev_b32_e32 v1, 8, v9
+; GFX12-TRUE16-NEXT:    v_or_b32_e32 v6, v7, v5
+; GFX12-TRUE16-NEXT:    v_and_b32_e32 v3, 0xffff, v8
+; GFX12-TRUE16-NEXT:    v_lshlrev_b32_e32 v4, 16, v2
+; GFX12-TRUE16-NEXT:    v_med3_i32 v0, v0, s2, 0x7f
+; GFX12-TRUE16-NEXT:    v_and_b32_e32 v5, 0xff00, v1
+; GFX12-TRUE16-NEXT:    v_lshlrev_b32_e32 v7, 16, v6
+; GFX12-TRUE16-NEXT:    v_and_b32_e32 v0, 0xff, v0
+; GFX12-TRUE16-NEXT:    v_or_b32_e32 v9, v5, v4
+; GFX12-TRUE16-NEXT:    v_or_b32_e32 v5, v3, v7
+; GFX12-TRUE16-NEXT:    v_lshrrev_b32_e32 v7, 24, v7
+; GFX12-TRUE16-NEXT:    v_or_b32_e32 v0, v0, v1
+; GFX12-TRUE16-NEXT:    v_lshrrev_b32_e32 v1, 8, v9
+; GFX12-TRUE16-NEXT:    v_lshrrev_b64 v[3:4], 24, v[4:5]
+; GFX12-TRUE16-NEXT:    v_lshrrev_b32_e32 v5, 8, v5
+; GFX12-TRUE16-NEXT:    v_mov_b32_e32 v4, v8
+; GFX12-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-GI-LABEL: test_s_signed_v8f16_v8i8:
+; GFX12-GI:       ; %bb.0:
+; GFX12-GI-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-GI-NEXT:    s_wait_expcnt 0x0
+; GFX12-GI-NEXT:    s_wait_samplecnt 0x0
+; GFX12-GI-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-GI-NEXT:    s_wait_kmcnt 0x0
+; GFX12-GI-NEXT:    s_cvt_f32_f16 s0, s0
+; GFX12-GI-NEXT:    s_cvt_f32_f16 s1, s1
+; GFX12-GI-NEXT:    s_cvt_f32_f16 s2, s2
+; GFX12-GI-NEXT:    s_cvt_f32_f16 s3, s3
+; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-GI-NEXT:    s_cvt_i32_f32 s0, s0
+; GFX12-GI-NEXT:    s_cvt_i32_f32 s1, s1
+; GFX12-GI-NEXT:    s_cvt_i32_f32 s2, s2
+; GFX12-GI-NEXT:    s_cvt_i32_f32 s3, s3
+; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-GI-NEXT:    s_min_i32 s0, s0, 0x7f
+; GFX12-GI-NEXT:    s_min_i32 s1, s1, 0x7f
+; GFX12-GI-NEXT:    s_min_i32 s2, s2, 0x7f
+; GFX12-GI-NEXT:    s_min_i32 s3, s3, 0x7f
+; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-GI-NEXT:    s_max_i32 s0, s0, 0xffffff80
+; GFX12-GI-NEXT:    s_max_i32 s1, s1, 0xffffff80
+; GFX12-GI-NEXT:    s_max_i32 s2, s2, 0xffffff80
+; GFX12-GI-NEXT:    s_max_i32 s3, s3, 0xffffff80
+; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-GI-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s0
+; GFX12-GI-NEXT:    v_dual_mov_b32 v2, s1 :: v_dual_mov_b32 v3, s1
+; GFX12-GI-NEXT:    v_dual_mov_b32 v4, s2 :: v_dual_mov_b32 v5, s2
+; GFX12-GI-NEXT:    v_dual_mov_b32 v6, s3 :: v_dual_mov_b32 v7, s3
+; GFX12-GI-NEXT:    s_setpc_b64 s[30:31]
+    %x = call <8 x i8> @llvm.fptosi.sat.v8f16.v8i8(<8 x half> %f)
+    ret <8 x i8> %x
+}
+
+define <8 x i16> @test_s_signed_v8f16_v8i16(<8 x half> inreg %f) {
+; GFX7-ISEL-LABEL: test_s_signed_v8f16_v8i16:
+; GFX7-ISEL:       ; %bb.0:
+; GFX7-ISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-ISEL-NEXT:    v_cvt_f32_f16_e32 v0, s19
+; GFX7-ISEL-NEXT:    s_lshr_b32 s4, s16, 16
+; GFX7-ISEL-NEXT:    s_lshr_b32 s5, s17, 16
+; GFX7-ISEL-NEXT:    s_lshr_b32 s6, s18, 16
+; GFX7-ISEL-NEXT:    v_cvt_i32_f32_e32 v0, v0
+; GFX7-ISEL-NEXT:    s_lshr_b32 s7, s19, 16
+; GFX7-ISEL-NEXT:    s_movk_i32 s8, 0x8000
+; GFX7-ISEL-NEXT:    v_mov_b32_e32 v1, 0x7fff
+; GFX7-ISEL-NEXT:    v_cvt_f32_f16_e32 v2, s18
+; GFX7-ISEL-NEXT:    v_cvt_f32_f16_e32 v3, s17
+; GFX7-ISEL-NEXT:    v_med3_i32 v4, v0, s8, v1
+; GFX7-ISEL-NEXT:    v_cvt_f32_f16_e32 v0, s16
+; GFX7-ISEL-NEXT:    v_cvt_f32_f16_e32 v5, s7
+; GFX7-ISEL-NEXT:    v_cvt_f32_f16_e32 v6, s6
+; GFX7-ISEL-NEXT:    v_cvt_f32_f16_e32 v7, s5
+; GFX7-ISEL-NEXT:    v_cvt_f32_f16_e32 v8, s4
+; GFX7-ISEL-NEXT:    v_cvt_i32_f32_e32 v2, v2
+; GFX7-ISEL-NEXT:    v_cvt_i32_f32_e32 v3, v3
+; GFX7-ISEL-NEXT:    v_cvt_i32_f32_e32 v0, v0
+; GFX7-ISEL-NEXT:    v_cvt_i32_f32_e32 v5, v5
+; GFX7-ISEL-NEXT:    v_cvt_i32_f32_e32 v6, v6
+; GFX7-ISEL-NEXT:    v_cvt_i32_f32_e32 v7, v7
+; GFX7-ISEL-NEXT:    v_cvt_i32_f32_e32 v8, v8
+; GFX7-ISEL-NEXT:    v_med3_i32 v2, v2, s8, v1
+; GFX7-ISEL-NEXT:    v_med3_i32 v3, v3, s8, v1
+; GFX7-ISEL-NEXT:    v_med3_i32 v0, v0, s8, v1
+; GFX7-ISEL-NEXT:    v_med3_i32 v5, v5, s8, v1
+; GFX7-ISEL-NEXT:    v_med3_i32 v6, v6, s8, v1
+; GFX7-ISEL-NEXT:    v_med3_i32 v7, v7, s8, v1
+; GFX7-ISEL-NEXT:    v_med3_i32 v1, v8, s8, v1
+; GFX7-ISEL-NEXT:    v_and_b32_e32 v0, 0xffff, v0
+; GFX7-ISEL-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; GFX7-ISEL-NEXT:    v_or_b32_e32 v0, v0, v1
+; GFX7-ISEL-NEXT:    v_and_b32_e32 v1, 0xffff, v3
+; GFX7-ISEL-NEXT:    v_and_b32_e32 v2, 0xffff, v2
+; GFX7-ISEL-NEXT:    v_lshlrev_b32_e32 v3, 16, v6
+; GFX7-ISEL-NEXT:    v_lshlrev_b32_e32 v5, 16, v5
+; GFX7-ISEL-NEXT:    v_lshlrev_b32_e32 v7, 16, v7
+; GFX7-ISEL-NEXT:    v_or_b32_e32 v2, v2, v3
+; GFX7-ISEL-NEXT:    v_and_b32_e32 v3, 0xffff, v4
+; GFX7-ISEL-NEXT:    v_or_b32_e32 v1, v1, v7
+; GFX7-ISEL-NEXT:    v_or_b32_e32 v3, v3, v5
+; GFX7-ISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX7-GI-LABEL: test_s_signed_v8f16_v8i16:
+; GFX7-GI:       ; %bb.0:
+; GFX7-GI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-GI-NEXT:    s_lshr_b32 s4, s16, 16
+; GFX7-GI-NEXT:    s_lshr_b32 s5, s17, 16
+; GFX7-GI-NEXT:    s_lshr_b32 s6, s18, 16
+; GFX7-GI-NEXT:    s_lshr_b32 s7, s19, 16
+; GFX7-GI-NEXT:    v_cvt_f32_f16_e32 v2, s4
+; GFX7-GI-NEXT:    v_cvt_f32_f16_e32 v0, s16
+; GFX7-GI-NEXT:    v_cvt_f32_f16_e32 v3, s17
+; GFX7-GI-NEXT:    v_cvt_f32_f16_e32 v4, s5
+; GFX7-GI-NEXT:    v_cvt_f32_f16_e32 v6, s18
+; GFX7-GI-NEXT:    v_cvt_f32_f16_e32 v7, s6
+; GFX7-GI-NEXT:    v_cvt_f32_f16_e32 v8, s19
+; GFX7-GI-NEXT:    v_cvt_f32_f16_e32 v9, s7
+; GFX7-GI-NEXT:    v_cvt_i32_f32_e32 v2, v2
+; GFX7-GI-NEXT:    v_cvt_i32_f32_e32 v0, v0
+; GFX7-GI-NEXT:    v_cvt_i32_f32_e32 v3, v3
+; GFX7-GI-NEXT:    v_cvt_i32_f32_e32 v4, v4
+; GFX7-GI-NEXT:    v_cvt_i32_f32_e32 v6, v6
+; GFX7-GI-NEXT:    v_cvt_i32_f32_e32 v7, v7
+; GFX7-GI-NEXT:    v_cvt_i32_f32_e32 v8, v8
+; GFX7-GI-NEXT:    v_cvt_i32_f32_e32 v9, v9
+; GFX7-GI-NEXT:    v_mov_b32_e32 v1, 0x7fff
+; GFX7-GI-NEXT:    v_mov_b32_e32 v5, 0xffff8000
+; GFX7-GI-NEXT:    v_med3_i32 v2, v2, v5, v1
+; GFX7-GI-NEXT:    v_med3_i32 v0, v0, v5, v1
+; GFX7-GI-NEXT:    v_med3_i32 v3, v3, v5, v1
+; GFX7-GI-NEXT:    v_med3_i32 v4, v4, v5, v1
+; GFX7-GI-NEXT:    v_med3_i32 v6, v6, v5, v1
+; GFX7-GI-NEXT:    v_med3_i32 v7, v7, v5, v1
+; GFX7-GI-NEXT:    v_med3_i32 v8, v8, v5, v1
+; GFX7-GI-NEXT:    v_med3_i32 v5, v9, v5, v1
+; GFX7-GI-NEXT:    v_and_b32_e32 v1, 0xffff, v2
+; GFX7-GI-NEXT:    v_and_b32_e32 v0, 0xffff, v0
+; GFX7-GI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; GFX7-GI-NEXT:    v_and_b32_e32 v2, 0xffff, v4
+; GFX7-GI-NEXT:    v_or_b32_e32 v0, v0, v1
+; GFX7-GI-NEXT:    v_and_b32_e32 v1, 0xffff, v3
+; GFX7-GI-NEXT:    v_lshlrev_b32_e32 v2, 16, v2
+; GFX7-GI-NEXT:    v_and_b32_e32 v3, 0xffff, v7
+; GFX7-GI-NEXT:    v_or_b32_e32 v1, v1, v2
+; GFX7-GI-NEXT:    v_and_b32_e32 v2, 0xffff, v6
+; GFX7-GI-NEXT:    v_lshlrev_b32_e32 v3, 16, v3
+; GFX7-GI-NEXT:    v_and_b32_e32 v4, 0xffff, v5
+; GFX7-GI-NEXT:    v_or_b32_e32 v2, v2, v3
+; GFX7-GI-NEXT:    v_and_b32_e32 v3, 0xffff, v8
+; GFX7-GI-NEXT:    v_lshlrev_b32_e32 v4, 16, v4
+; GFX7-GI-NEXT:    v_or_b32_e32 v3, v3, v4
+; GFX7-GI-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX9-LABEL: test_s_signed_v8f16_v8i16:
+; GFX9:       ; %bb.0:
+; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    s_lshr_b32 s4, s19, 16
+; GFX9-NEXT:    v_cvt_i16_f16_e32 v3, s4
+; GFX9-NEXT:    s_lshr_b32 s4, s18, 16
+; GFX9-NEXT:    v_cvt_i16_f16_e32 v2, s4
+; GFX9-NEXT:    s_lshr_b32 s4, s17, 16
+; GFX9-NEXT:    v_cvt_i16_f16_e32 v1, s4
+; GFX9-NEXT:    s_lshr_b32 s4, s16, 16
+; GFX9-NEXT:    v_cvt_i16_f16_e32 v4, s19
+; GFX9-NEXT:    v_cvt_i16_f16_e32 v5, s18
+; GFX9-NEXT:    v_cvt_i16_f16_e32 v6, s17
+; GFX9-NEXT:    v_cvt_i16_f16_e32 v7, s16
+; GFX9-NEXT:    v_cvt_i16_f16_e32 v0, s4
+; GFX9-NEXT:    v_and_b32_e32 v7, 0xffff, v7
+; GFX9-NEXT:    v_and_b32_e32 v6, 0xffff, v6
+; GFX9-NEXT:    v_and_b32_e32 v5, 0xffff, v5
+; GFX9-NEXT:    v_and_b32_e32 v4, 0xffff, v4
+; GFX9-NEXT:    v_lshl_or_b32 v0, v0, 16, v7
+; GFX9-NEXT:    v_lshl_or_b32 v1, v1, 16, v6
+; GFX9-NEXT:    v_lshl_or_b32 v2, v2, 16, v5
+; GFX9-NEXT:    v_lshl_or_b32 v3, v3, 16, v4
+; GFX9-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11-FAKE16-LABEL: test_s_signed_v8f16_v8i16:
+; GFX11-FAKE16:       ; %bb.0:
+; GFX11-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-FAKE16-NEXT:    s_lshr_b32 s4, s3, 16
+; GFX11-FAKE16-NEXT:    v_cvt_i16_f16_e32 v0, s0
+; GFX11-FAKE16-NEXT:    v_cvt_i16_f16_e32 v4, s1
+; GFX11-FAKE16-NEXT:    v_cvt_i16_f16_e32 v5, s2
+; GFX11-FAKE16-NEXT:    v_cvt_i16_f16_e32 v6, s3
+; GFX11-FAKE16-NEXT:    v_cvt_i16_f16_e32 v3, s4
+; GFX11-FAKE16-NEXT:    s_lshr_b32 s4, s2, 16
+; GFX11-FAKE16-NEXT:    s_lshr_b32 s5, s1, 16
+; GFX11-FAKE16-NEXT:    v_cvt_i16_f16_e32 v2, s4
+; GFX11-FAKE16-NEXT:    s_lshr_b32 s4, s0, 16
+; GFX11-FAKE16-NEXT:    v_cvt_i16_f16_e32 v1, s5
+; GFX11-FAKE16-NEXT:    v_cvt_i16_f16_e32 v7, s4
+; GFX11-FAKE16-NEXT:    v_and_b32_e32 v0, 0xffff, v0
+; GFX11-FAKE16-NEXT:    v_and_b32_e32 v4, 0xffff, v4
+; GFX11-FAKE16-NEXT:    v_and_b32_e32 v5, 0xffff, v5
+; GFX11-FAKE16-NEXT:    v_and_b32_e32 v6, 0xffff, v6
+; GFX11-FAKE16-NEXT:    v_lshl_or_b32 v0, v7, 16, v0
+; GFX11-FAKE16-NEXT:    v_lshl_or_b32 v1, v1, 16, v4
+; GFX11-FAKE16-NEXT:    v_lshl_or_b32 v2, v2, 16, v5
+; GFX11-FAKE16-NEXT:    v_lshl_or_b32 v3, v3, 16, v6
+; GFX11-FAKE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11-TRUE16-LABEL: test_s_signed_v8f16_v8i16:
+; GFX11-TRUE16:       ; %bb.0:
+; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-TRUE16-NEXT:    s_lshr_b32 s4, s3, 16
+; GFX11-TRUE16-NEXT:    s_lshr_b32 s5, s2, 16
+; GFX11-TRUE16-NEXT:    v_cvt_i16_f16_e32 v3.h, s4
+; GFX11-TRUE16-NEXT:    v_cvt_i16_f16_e32 v2.h, s5
+; GFX11-TRUE16-NEXT:    s_lshr_b32 s4, s1, 16
+; GFX11-TRUE16-NEXT:    s_lshr_b32 s5, s0, 16
+; GFX11-TRUE16-NEXT:    v_cvt_i16_f16_e32 v1.h, s4
+; GFX11-TRUE16-NEXT:    v_cvt_i16_f16_e32 v0.h, s5
+; GFX11-TRUE16-NEXT:    v_cvt_i16_f16_e32 v0.l, s0
+; GFX11-TRUE16-NEXT:    v_cvt_i16_f16_e32 v1.l, s1
+; GFX11-TRUE16-NEXT:    v_cvt_i16_f16_e32 v2.l, s2
+; GFX11-TRUE16-NEXT:    v_cvt_i16_f16_e32 v3.l, s3
+; GFX11-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-FAKE16-LABEL: test_s_signed_v8f16_v8i16:
+; GFX12-FAKE16:       ; %bb.0:
+; GFX12-FAKE16-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-FAKE16-NEXT:    s_wait_expcnt 0x0
+; GFX12-FAKE16-NEXT:    s_wait_samplecnt 0x0
+; GFX12-FAKE16-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-FAKE16-NEXT:    s_wait_kmcnt 0x0
+; GFX12-FAKE16-NEXT:    s_lshr_b32 s4, s3, 16
+; GFX12-FAKE16-NEXT:    v_cvt_i16_f16_e32 v0, s0
+; GFX12-FAKE16-NEXT:    v_cvt_i16_f16_e32 v4, s1
+; GFX12-FAKE16-NEXT:    v_cvt_i16_f16_e32 v5, s2
+; GFX12-FAKE16-NEXT:    v_cvt_i16_f16_e32 v6, s3
+; GFX12-FAKE16-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-FAKE16-NEXT:    v_cvt_i16_f16_e32 v3, s4
+; GFX12-FAKE16-NEXT:    s_lshr_b32 s4, s2, 16
+; GFX12-FAKE16-NEXT:    s_lshr_b32 s5, s1, 16
+; GFX12-FAKE16-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-FAKE16-NEXT:    v_cvt_i16_f16_e32 v2, s4
+; GFX12-FAKE16-NEXT:    s_lshr_b32 s4, s0, 16
+; GFX12-FAKE16-NEXT:    v_cvt_i16_f16_e32 v1, s5
+; GFX12-FAKE16-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-FAKE16-NEXT:    v_cvt_i16_f16_e32 v7, s4
+; GFX12-FAKE16-NEXT:    v_and_b32_e32 v0, 0xffff, v0
+; GFX12-FAKE16-NEXT:    v_and_b32_e32 v4, 0xffff, v4
+; GFX12-FAKE16-NEXT:    v_and_b32_e32 v5, 0xffff, v5
+; GFX12-FAKE16-NEXT:    v_and_b32_e32 v6, 0xffff, v6
+; GFX12-FAKE16-NEXT:    v_lshl_or_b32 v0, v7, 16, v0
+; GFX12-FAKE16-NEXT:    v_lshl_or_b32 v1, v1, 16, v4
+; GFX12-FAKE16-NEXT:    v_lshl_or_b32 v2, v2, 16, v5
+; GFX12-FAKE16-NEXT:    v_lshl_or_b32 v3, v3, 16, v6
+; GFX12-FAKE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-TRUE16-LABEL: test_s_signed_v8f16_v8i16:
+; GFX12-TRUE16:       ; %bb.0:
+; GFX12-TRUE16-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-TRUE16-NEXT:    s_wait_expcnt 0x0
+; GFX12-TRUE16-NEXT:    s_wait_samplecnt 0x0
+; GFX12-TRUE16-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-TRUE16-NEXT:    s_wait_kmcnt 0x0
+; GFX12-TRUE16-NEXT:    s_lshr_b32 s4, s3, 16
+; GFX12-TRUE16-NEXT:    s_lshr_b32 s5, s2, 16
+; GFX12-TRUE16-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-TRUE16-NEXT:    v_cvt_i16_f16_e32 v3.h, s4
+; GFX12-TRUE16-NEXT:    v_cvt_i16_f16_e32 v2.h, s5
+; GFX12-TRUE16-NEXT:    s_lshr_b32 s4, s1, 16
+; GFX12-TRUE16-NEXT:    s_lshr_b32 s5, s0, 16
+; GFX12-TRUE16-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-TRUE16-NEXT:    v_cvt_i16_f16_e32 v1.h, s4
+; GFX12-TRUE16-NEXT:    v_cvt_i16_f16_e32 v0.h, s5
+; GFX12-TRUE16-NEXT:    v_cvt_i16_f16_e32 v0.l, s0
+; GFX12-TRUE16-NEXT:    v_cvt_i16_f16_e32 v1.l, s1
+; GFX12-TRUE16-NEXT:    v_cvt_i16_f16_e32 v2.l, s2
+; GFX12-TRUE16-NEXT:    v_cvt_i16_f16_e32 v3.l, s3
+; GFX12-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-GI-LABEL: test_s_signed_v8f16_v8i16:
+; GFX12-GI:       ; %bb.0:
+; GFX12-GI-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-GI-NEXT:    s_wait_expcnt 0x0
+; GFX12-GI-NEXT:    s_wait_samplecnt 0x0
+; GFX12-GI-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-GI-NEXT:    s_wait_kmcnt 0x0
+; GFX12-GI-NEXT:    v_cvt_i16_f16_e32 v0.l, s0
+; GFX12-GI-NEXT:    v_cvt_i16_f16_e32 v1.l, s1
+; GFX12-GI-NEXT:    v_cvt_i16_f16_e32 v2.l, s2
+; GFX12-GI-NEXT:    v_cvt_i16_f16_e32 v3.l, s3
+; GFX12-GI-NEXT:    v_mov_b16_e32 v0.h, v0.l
+; GFX12-GI-NEXT:    v_mov_b16_e32 v1.h, v1.l
+; GFX12-GI-NEXT:    v_mov_b16_e32 v2.h, v2.l
+; GFX12-GI-NEXT:    v_mov_b16_e32 v3.h, v3.l
+; GFX12-GI-NEXT:    s_setpc_b64 s[30:31]
+    %x = call <8 x i16> @llvm.fptosi.sat.v8f16.v8i16(<8 x half> %f)
+    ret <8 x i16> %x
+}
+
+define <8 x i64> @test_s_signed_v8f16_v8i64(<8 x half> inreg %f) {
+; GFX7-ISEL-LABEL: test_s_signed_v8f16_v8i64:
+; GFX7-ISEL:       ; %bb.0:
+; GFX7-ISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-ISEL-NEXT:    s_lshr_b32 s6, s17, 16
+; GFX7-ISEL-NEXT:    s_lshr_b32 s7, s16, 16
+; GFX7-ISEL-NEXT:    v_cvt_f32_f16_e32 v0, s7
+; GFX7-ISEL-NEXT:    v_cvt_f32_f16_e32 v1, s6
+; GFX7-ISEL-NEXT:    s_lshr_b32 s4, s19, 16
+; GFX7-ISEL-NEXT:    s_lshr_b32 s5, s18, 16
+; GFX7-ISEL-NEXT:    v_cvt_f32_f16_e32 v3, s5
+; GFX7-ISEL-NEXT:    v_cvt_f32_f16_e32 v4, s4
+; GFX7-ISEL-NEXT:    v_cvt_i32_f32_e32 v2, v0
+; GFX7-ISEL-NEXT:    v_cvt_i32_f32_e32 v6, v1
+; GFX7-ISEL-NEXT:    v_cvt_f32_f16_e32 v0, s16
+; GFX7-ISEL-NEXT:    v_cvt_f32_f16_e32 v1, s17
+; GFX7-ISEL-NEXT:    v_cvt_f32_f16_e32 v5, s18
+; GFX7-ISEL-NEXT:    v_cvt_f32_f16_e32 v9, s19
+; GFX7-ISEL-NEXT:    v_cvt_i32_f32_e32 v10, v3
+; GFX7-ISEL-NEXT:    v_cvt_i32_f32_e32 v14, v4
+; GFX7-ISEL-NEXT:    v_cvt_i32_f32_e32 v0, v0
+; GFX7-ISEL-NEXT:    v_cvt_i32_f32_e32 v4, v1
+; GFX7-ISEL-NEXT:    v_cvt_i32_f32_e32 v8, v5
+; GFX7-ISEL-NEXT:    v_cvt_i32_f32_e32 v12, v9
+; GFX7-ISEL-NEXT:    v_ashrrev_i32_e32 v3, 31, v2
+; GFX7-ISEL-NEXT:    v_ashrrev_i32_e32 v7, 31, v6
+; GFX7-ISEL-NEXT:    v_ashrrev_i32_e32 v11, 31, v10
+; GFX7-ISEL-NEXT:    v_ashrrev_i32_e32 v15, 31, v14
+; GFX7-ISEL-NEXT:    v_ashrrev_i32_e32 v1, 31, v0
+; GFX7-ISEL-NEXT:    v_ashrrev_i32_e32 v5, 31, v4
+; GFX7-ISEL-NEXT:    v_ashrrev_i32_e32 v9, 31, v8
+; GFX7-ISEL-NEXT:    v_ashrrev_i32_e32 v13, 31, v12
+; GFX7-ISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX7-GI-LABEL: test_s_signed_v8f16_v8i64:
+; GFX7-GI:       ; %bb.0:
+; GFX7-GI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-GI-NEXT:    s_lshr_b32 s4, s16, 16
+; GFX7-GI-NEXT:    s_lshr_b32 s5, s17, 16
+; GFX7-GI-NEXT:    v_cvt_f32_f16_e32 v1, s4
+; GFX7-GI-NEXT:    v_cvt_f32_f16_e32 v3, s17
+; GFX7-GI-NEXT:    v_cvt_f32_f16_e32 v5, s5
+; GFX7-GI-NEXT:    s_lshr_b32 s6, s18, 16
+; GFX7-GI-NEXT:    s_lshr_b32 s7, s19, 16
+; GFX7-GI-NEXT:    v_cvt_f32_f16_e32 v0, s16
+; GFX7-GI-NEXT:    v_cvt_i32_f32_e32 v2, v1
+; GFX7-GI-NEXT:    v_cvt_i32_f32_e32 v4, v3
+; GFX7-GI-NEXT:    v_cvt_i32_f32_e32 v6, v5
+; GFX7-GI-NEXT:    v_cvt_f32_f16_e32 v1, s18
+; GFX7-GI-NEXT:    v_cvt_f32_f16_e32 v3, s6
+; GFX7-GI-NEXT:    v_cvt_f32_f16_e32 v5, s19
+; GFX7-GI-NEXT:    v_cvt_f32_f16_e32 v7, s7
+; GFX7-GI-NEXT:    v_cvt_i32_f32_e32 v0, v0
+; GFX7-GI-NEXT:    v_cvt_i32_f32_e32 v8, v1
+; GFX7-GI-NEXT:    v_cvt_i32_f32_e32 v10, v3
+; GFX7-GI-NEXT:    v_cvt_i32_f32_e32 v12, v5
+; GFX7-GI-NEXT:    v_cvt_i32_f32_e32 v14, v7
+; GFX7-GI-NEXT:    v_mov_b32_e32 v1, 0
+; GFX7-GI-NEXT:    v_mov_b32_e32 v3, 0
+; GFX7-GI-NEXT:    v_mov_b32_e32 v5, 0
+; GFX7-GI-NEXT:    v_mov_b32_e32 v7, 0
+; GFX7-GI-NEXT:    v_mov_b32_e32 v9, 0
+; GFX7-GI-NEXT:    v_mov_b32_e32 v11, 0
+; GFX7-GI-NEXT:    v_mov_b32_e32 v13, 0
+; GFX7-GI-NEXT:    v_mov_b32_e32 v15, 0
+; GFX7-GI-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX9-LABEL: test_s_signed_v8f16_v8i64:
+; GFX9:       ; %bb.0:
+; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    s_lshr_b32 s4, s16, 16
+; GFX9-NEXT:    v_cvt_f32_f16_e32 v0, s4
+; GFX9-NEXT:    s_lshr_b32 s4, s17, 16
+; GFX9-NEXT:    v_cvt_f32_f16_e32 v1, s4
+; GFX9-NEXT:    s_lshr_b32 s4, s18, 16
+; GFX9-NEXT:    v_cvt_f32_f16_e32 v3, s4
+; GFX9-NEXT:    s_lshr_b32 s4, s19, 16
+; GFX9-NEXT:    v_cvt_f32_f16_e32 v4, s4
+; GFX9-NEXT:    v_cvt_i32_f32_e32 v2, v0
+; GFX9-NEXT:    v_cvt_i32_f32_e32 v6, v1
+; GFX9-NEXT:    v_cvt_f32_f16_e32 v0, s16
+; GFX9-NEXT:    v_cvt_f32_f16_e32 v1, s17
+; GFX9-NEXT:    v_cvt_f32_f16_e32 v5, s18
+; GFX9-NEXT:    v_cvt_f32_f16_e32 v9, s19
+; GFX9-NEXT:    v_cvt_i32_f32_e32 v10, v3
+; GFX9-NEXT:    v_cvt_i32_f32_e32 v14, v4
+; GFX9-NEXT:    v_cvt_i32_f32_e32 v0, v0
+; GFX9-NEXT:    v_cvt_i32_f32_e32 v4, v1
+; GFX9-NEXT:    v_cvt_i32_f32_e32 v8, v5
+; GFX9-NEXT:    v_cvt_i32_f32_e32 v12, v9
+; GFX9-NEXT:    v_ashrrev_i32_e32 v3, 31, v2
+; GFX9-NEXT:    v_ashrrev_i32_e32 v7, 31, v6
+; GFX9-NEXT:    v_ashrrev_i32_e32 v11, 31, v10
+; GFX9-NEXT:    v_ashrrev_i32_e32 v15, 31, v14
+; GFX9-NEXT:    v_ashrrev_i32_e32 v1, 31, v0
+; GFX9-NEXT:    v_ashrrev_i32_e32 v5, 31, v4
+; GFX9-NEXT:    v_ashrrev_i32_e32 v9, 31, v8
+; GFX9-NEXT:    v_ashrrev_i32_e32 v13, 31, v12
+; GFX9-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11-LABEL: test_s_signed_v8f16_v8i64:
+; GFX11:       ; %bb.0:
+; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-NEXT:    s_lshr_b32 s4, s0, 16
+; GFX11-NEXT:    s_lshr_b32 s5, s1, 16
+; GFX11-NEXT:    v_cvt_f32_f16_e32 v0, s4
+; GFX11-NEXT:    v_cvt_f32_f16_e32 v1, s5
+; GFX11-NEXT:    s_lshr_b32 s4, s2, 16
+; GFX11-NEXT:    v_cvt_f32_f16_e32 v4, s1
+; GFX11-NEXT:    v_cvt_f32_f16_e32 v3, s4
+; GFX11-NEXT:    s_lshr_b32 s4, s3, 16
+; GFX11-NEXT:    v_cvt_i32_f32_e32 v2, v0
+; GFX11-NEXT:    v_cvt_i32_f32_e32 v6, v1
+; GFX11-NEXT:    v_cvt_f32_f16_e32 v0, s4
+; GFX11-NEXT:    v_cvt_f32_f16_e32 v1, s0
+; GFX11-NEXT:    v_cvt_f32_f16_e32 v5, s2
+; GFX11-NEXT:    v_cvt_f32_f16_e32 v9, s3
+; GFX11-NEXT:    v_cvt_i32_f32_e32 v10, v3
+; GFX11-NEXT:    v_cvt_i32_f32_e32 v14, v0
+; GFX11-NEXT:    v_cvt_i32_f32_e32 v0, v1
+; GFX11-NEXT:    v_cvt_i32_f32_e32 v4, v4
+; GFX11-NEXT:    v_cvt_i32_f32_e32 v8, v5
+; GFX11-NEXT:    v_cvt_i32_f32_e32 v12, v9
+; GFX11-NEXT:    v_ashrrev_i32_e32 v3, 31, v2
+; GFX11-NEXT:    v_ashrrev_i32_e32 v7, 31, v6
+; GFX11-NEXT:    v_ashrrev_i32_e32 v11, 31, v10
+; GFX11-NEXT:    v_ashrrev_i32_e32 v15, 31, v14
+; GFX11-NEXT:    v_ashrrev_i32_e32 v1, 31, v0
+; GFX11-NEXT:    v_ashrrev_i32_e32 v5, 31, v4
+; GFX11-NEXT:    v_ashrrev_i32_e32 v9, 31, v8
+; GFX11-NEXT:    v_ashrrev_i32_e32 v13, 31, v12
+; GFX11-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-ISEL-LABEL: test_s_signed_v8f16_v8i64:
+; GFX12-ISEL:       ; %bb.0:
+; GFX12-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX12-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX12-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX12-ISEL-NEXT:    s_cvt_hi_f32_f16 s4, s0
+; GFX12-ISEL-NEXT:    s_cvt_hi_f32_f16 s5, s1
+; GFX12-ISEL-NEXT:    s_cvt_hi_f32_f16 s6, s2
+; GFX12-ISEL-NEXT:    s_cvt_hi_f32_f16 s7, s3
+; GFX12-ISEL-NEXT:    s_cvt_f32_f16 s0, s0
+; GFX12-ISEL-NEXT:    s_cvt_f32_f16 s1, s1
+; GFX12-ISEL-NEXT:    s_cvt_f32_f16 s2, s2
+; GFX12-ISEL-NEXT:    s_cvt_f32_f16 s3, s3
+; GFX12-ISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-ISEL-NEXT:    s_cvt_i32_f32 s4, s4
+; GFX12-ISEL-NEXT:    s_cvt_i32_f32 s5, s5
+; GFX12-ISEL-NEXT:    s_cvt_i32_f32 s6, s6
+; GFX12-ISEL-NEXT:    s_cvt_i32_f32 s7, s7
+; GFX12-ISEL-NEXT:    s_cvt_i32_f32 s0, s0
+; GFX12-ISEL-NEXT:    s_cvt_i32_f32 s1, s1
+; GFX12-ISEL-NEXT:    s_cvt_i32_f32 s2, s2
+; GFX12-ISEL-NEXT:    s_cvt_i32_f32 s3, s3
+; GFX12-ISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-ISEL-NEXT:    s_ashr_i32 s8, s4, 31
+; GFX12-ISEL-NEXT:    s_ashr_i32 s9, s5, 31
+; GFX12-ISEL-NEXT:    s_ashr_i32 s10, s6, 31
+; GFX12-ISEL-NEXT:    s_ashr_i32 s11, s7, 31
+; GFX12-ISEL-NEXT:    s_ashr_i32 s12, s0, 31
+; GFX12-ISEL-NEXT:    s_ashr_i32 s13, s1, 31
+; GFX12-ISEL-NEXT:    s_ashr_i32 s14, s2, 31
+; GFX12-ISEL-NEXT:    s_ashr_i32 s15, s3, 31
+; GFX12-ISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-ISEL-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s12
+; GFX12-ISEL-NEXT:    v_dual_mov_b32 v2, s4 :: v_dual_mov_b32 v3, s8
+; GFX12-ISEL-NEXT:    v_dual_mov_b32 v4, s1 :: v_dual_mov_b32 v5, s13
+; GFX12-ISEL-NEXT:    v_dual_mov_b32 v6, s5 :: v_dual_mov_b32 v7, s9
+; GFX12-ISEL-NEXT:    v_dual_mov_b32 v8, s2 :: v_dual_mov_b32 v9, s14
+; GFX12-ISEL-NEXT:    v_dual_mov_b32 v10, s6 :: v_dual_mov_b32 v11, s10
+; GFX12-ISEL-NEXT:    v_dual_mov_b32 v12, s3 :: v_dual_mov_b32 v13, s15
+; GFX12-ISEL-NEXT:    v_dual_mov_b32 v14, s7 :: v_dual_mov_b32 v15, s11
+; GFX12-ISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-GI-LABEL: test_s_signed_v8f16_v8i64:
+; GFX12-GI:       ; %bb.0:
+; GFX12-GI-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-GI-NEXT:    s_wait_expcnt 0x0
+; GFX12-GI-NEXT:    s_wait_samplecnt 0x0
+; GFX12-GI-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-GI-NEXT:    s_wait_kmcnt 0x0
+; GFX12-GI-NEXT:    s_cvt_f32_f16 s0, s0
+; GFX12-GI-NEXT:    s_cvt_f32_f16 s1, s1
+; GFX12-GI-NEXT:    s_cvt_f32_f16 s2, s2
+; GFX12-GI-NEXT:    s_cvt_f32_f16 s3, s3
+; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-GI-NEXT:    s_cvt_i32_f32 s0, s0
+; GFX12-GI-NEXT:    s_cvt_i32_f32 s1, s1
+; GFX12-GI-NEXT:    s_cvt_i32_f32 s2, s2
+; GFX12-GI-NEXT:    s_cvt_i32_f32 s3, s3
+; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-GI-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, 0
+; GFX12-GI-NEXT:    v_dual_mov_b32 v2, s0 :: v_dual_mov_b32 v3, 0
+; GFX12-GI-NEXT:    v_dual_mov_b32 v4, s1 :: v_dual_mov_b32 v5, 0
+; GFX12-GI-NEXT:    v_dual_mov_b32 v6, s1 :: v_dual_mov_b32 v7, 0
+; GFX12-GI-NEXT:    v_dual_mov_b32 v8, s2 :: v_dual_mov_b32 v9, 0
+; GFX12-GI-NEXT:    v_dual_mov_b32 v10, s2 :: v_dual_mov_b32 v11, 0
+; GFX12-GI-NEXT:    v_dual_mov_b32 v12, s3 :: v_dual_mov_b32 v13, 0
+; GFX12-GI-NEXT:    v_dual_mov_b32 v14, s3 :: v_dual_mov_b32 v15, 0
+; GFX12-GI-NEXT:    s_setpc_b64 s[30:31]
+    %x = call <8 x i64> @llvm.fptosi.sat.v8f16.v8i64(<8 x half> %f)
+    ret <8 x i64> %x
+}
+
 ;
 ; Float to signed 8-bit
 ;
@@ -3543,6 +6564,157 @@ define <4 x i8> @test_signed_v4f32_v4i8(<4 x float> %f) {
 ; GFX12-GI-NEXT:    v_med3_i32 v1, v1, v4, 0x7f
 ; GFX12-GI-NEXT:    v_med3_i32 v2, v2, v4, 0x7f
 ; GFX12-GI-NEXT:    v_med3_i32 v3, v3, v4, 0x7f
+; GFX12-GI-NEXT:    s_setpc_b64 s[30:31]
+    %x = call <4 x i8> @llvm.fptosi.sat.v4f32.v4i8(<4 x float> %f)
+    ret <4 x i8> %x
+}
+
+define <4 x i8> @test_s_signed_v4f32_v4i8(<4 x float> inreg %f) {
+; GFX7-ISEL-LABEL: test_s_signed_v4f32_v4i8:
+; GFX7-ISEL:       ; %bb.0:
+; GFX7-ISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-ISEL-NEXT:    v_cvt_i32_f32_e32 v0, s19
+; GFX7-ISEL-NEXT:    v_cvt_i32_f32_e32 v1, s18
+; GFX7-ISEL-NEXT:    s_movk_i32 s4, 0xff80
+; GFX7-ISEL-NEXT:    v_mov_b32_e32 v2, 0x7f
+; GFX7-ISEL-NEXT:    v_med3_i32 v0, v0, s4, v2
+; GFX7-ISEL-NEXT:    v_med3_i32 v1, v1, s4, v2
+; GFX7-ISEL-NEXT:    v_lshlrev_b32_e32 v0, 8, v0
+; GFX7-ISEL-NEXT:    v_and_b32_e32 v1, 0xff, v1
+; GFX7-ISEL-NEXT:    v_cvt_i32_f32_e32 v3, s17
+; GFX7-ISEL-NEXT:    v_or_b32_e32 v4, v1, v0
+; GFX7-ISEL-NEXT:    v_cvt_i32_f32_e32 v0, s16
+; GFX7-ISEL-NEXT:    v_lshlrev_b32_e32 v1, 16, v4
+; GFX7-ISEL-NEXT:    v_med3_i32 v3, v3, s4, v2
+; GFX7-ISEL-NEXT:    v_lshlrev_b32_e32 v3, 8, v3
+; GFX7-ISEL-NEXT:    v_med3_i32 v0, v0, s4, v2
+; GFX7-ISEL-NEXT:    v_and_b32_e32 v0, 0xff, v0
+; GFX7-ISEL-NEXT:    v_or_b32_e32 v0, v0, v3
+; GFX7-ISEL-NEXT:    v_and_b32_e32 v0, 0xffff, v0
+; GFX7-ISEL-NEXT:    v_or_b32_e32 v0, v0, v1
+; GFX7-ISEL-NEXT:    v_lshrrev_b32_e32 v1, 8, v0
+; GFX7-ISEL-NEXT:    v_and_b32_e32 v2, 0xffff, v4
+; GFX7-ISEL-NEXT:    v_bfe_u32 v3, v4, 8, 8
+; GFX7-ISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX7-GI-LABEL: test_s_signed_v4f32_v4i8:
+; GFX7-GI:       ; %bb.0:
+; GFX7-GI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-GI-NEXT:    v_cvt_i32_f32_e32 v0, s16
+; GFX7-GI-NEXT:    v_cvt_i32_f32_e32 v1, s17
+; GFX7-GI-NEXT:    v_cvt_i32_f32_e32 v2, s18
+; GFX7-GI-NEXT:    v_cvt_i32_f32_e32 v5, s19
+; GFX7-GI-NEXT:    v_mov_b32_e32 v3, 0x7f
+; GFX7-GI-NEXT:    v_mov_b32_e32 v4, 0xffffff80
+; GFX7-GI-NEXT:    v_med3_i32 v0, v0, v4, v3
+; GFX7-GI-NEXT:    v_med3_i32 v1, v1, v4, v3
+; GFX7-GI-NEXT:    v_med3_i32 v2, v2, v4, v3
+; GFX7-GI-NEXT:    v_med3_i32 v3, v5, v4, v3
+; GFX7-GI-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX9-LABEL: test_s_signed_v4f32_v4i8:
+; GFX9:       ; %bb.0:
+; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    v_cvt_i32_f32_e32 v0, s17
+; GFX9-NEXT:    v_cvt_i32_f32_e32 v2, s16
+; GFX9-NEXT:    s_movk_i32 s4, 0xff80
+; GFX9-NEXT:    v_mov_b32_e32 v1, 0x7f
+; GFX9-NEXT:    v_med3_i32 v0, v0, s4, v1
+; GFX9-NEXT:    v_cvt_i32_f32_e32 v4, s19
+; GFX9-NEXT:    v_lshlrev_b32_e32 v3, 8, v0
+; GFX9-NEXT:    v_med3_i32 v0, v2, s4, v1
+; GFX9-NEXT:    v_cvt_i32_f32_e32 v2, s18
+; GFX9-NEXT:    v_med3_i32 v4, v4, s4, v1
+; GFX9-NEXT:    v_lshlrev_b32_e32 v4, 8, v4
+; GFX9-NEXT:    v_or_b32_sdwa v0, v0, v3 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:BYTE_0 src1_sel:DWORD
+; GFX9-NEXT:    v_med3_i32 v1, v2, s4, v1
+; GFX9-NEXT:    v_or_b32_sdwa v2, v1, v4 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:BYTE_0 src1_sel:DWORD
+; GFX9-NEXT:    v_lshlrev_b32_e32 v1, 16, v2
+; GFX9-NEXT:    v_and_b32_e32 v3, 0xff00, v3
+; GFX9-NEXT:    v_or_b32_e32 v4, v3, v1
+; GFX9-NEXT:    v_lshrrev_b32_e32 v3, 24, v1
+; GFX9-NEXT:    v_lshrrev_b32_e32 v1, 8, v4
+; GFX9-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11-LABEL: test_s_signed_v4f32_v4i8:
+; GFX11:       ; %bb.0:
+; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-NEXT:    v_cvt_i32_f32_e32 v0, s3
+; GFX11-NEXT:    v_cvt_i32_f32_e32 v1, s2
+; GFX11-NEXT:    s_movk_i32 s2, 0xff80
+; GFX11-NEXT:    v_cvt_i32_f32_e32 v2, s1
+; GFX11-NEXT:    v_cvt_i32_f32_e32 v3, s0
+; GFX11-NEXT:    v_med3_i32 v0, v0, s2, 0x7f
+; GFX11-NEXT:    v_med3_i32 v1, v1, s2, 0x7f
+; GFX11-NEXT:    v_med3_i32 v2, v2, s2, 0x7f
+; GFX11-NEXT:    v_lshlrev_b32_e32 v0, 8, v0
+; GFX11-NEXT:    v_and_b32_e32 v1, 0xff, v1
+; GFX11-NEXT:    v_lshlrev_b32_e32 v4, 8, v2
+; GFX11-NEXT:    v_or_b32_e32 v2, v1, v0
+; GFX11-NEXT:    v_med3_i32 v0, v3, s2, 0x7f
+; GFX11-NEXT:    v_and_b32_e32 v1, 0xff00, v4
+; GFX11-NEXT:    v_lshlrev_b32_e32 v3, 16, v2
+; GFX11-NEXT:    v_and_b32_e32 v0, 0xff, v0
+; GFX11-NEXT:    v_or_b32_e32 v1, v1, v3
+; GFX11-NEXT:    v_or_b32_e32 v0, v0, v4
+; GFX11-NEXT:    v_lshrrev_b32_e32 v3, 24, v3
+; GFX11-NEXT:    v_lshrrev_b32_e32 v1, 8, v1
+; GFX11-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-ISEL-LABEL: test_s_signed_v4f32_v4i8:
+; GFX12-ISEL:       ; %bb.0:
+; GFX12-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX12-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX12-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX12-ISEL-NEXT:    v_mov_b32_e32 v0, 0x7f
+; GFX12-ISEL-NEXT:    s_cvt_i32_f32 s3, s3
+; GFX12-ISEL-NEXT:    s_cvt_i32_f32 s2, s2
+; GFX12-ISEL-NEXT:    s_cvt_i32_f32 s1, s1
+; GFX12-ISEL-NEXT:    s_cvt_i32_f32 s0, s0
+; GFX12-ISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-ISEL-NEXT:    v_med3_i32 v1, 0xffffff80, s3, v0
+; GFX12-ISEL-NEXT:    v_lshlrev_b32_e32 v1, 8, v1
+; GFX12-ISEL-NEXT:    v_med3_i32 v2, 0xffffff80, s2, v0
+; GFX12-ISEL-NEXT:    v_med3_i32 v3, 0xffffff80, s1, v0
+; GFX12-ISEL-NEXT:    v_med3_i32 v0, 0xffffff80, s0, v0
+; GFX12-ISEL-NEXT:    v_and_b32_e32 v2, 0xff, v2
+; GFX12-ISEL-NEXT:    v_lshlrev_b32_e32 v3, 8, v3
+; GFX12-ISEL-NEXT:    v_and_b32_e32 v0, 0xff, v0
+; GFX12-ISEL-NEXT:    v_or_b32_e32 v2, v2, v1
+; GFX12-ISEL-NEXT:    v_and_b32_e32 v1, 0xff00, v3
+; GFX12-ISEL-NEXT:    v_or_b32_e32 v0, v0, v3
+; GFX12-ISEL-NEXT:    v_lshlrev_b32_e32 v4, 16, v2
+; GFX12-ISEL-NEXT:    v_or_b32_e32 v1, v1, v4
+; GFX12-ISEL-NEXT:    v_lshrrev_b32_e32 v3, 24, v4
+; GFX12-ISEL-NEXT:    v_lshrrev_b32_e32 v1, 8, v1
+; GFX12-ISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-GI-LABEL: test_s_signed_v4f32_v4i8:
+; GFX12-GI:       ; %bb.0:
+; GFX12-GI-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-GI-NEXT:    s_wait_expcnt 0x0
+; GFX12-GI-NEXT:    s_wait_samplecnt 0x0
+; GFX12-GI-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-GI-NEXT:    s_wait_kmcnt 0x0
+; GFX12-GI-NEXT:    s_cvt_i32_f32 s0, s0
+; GFX12-GI-NEXT:    s_cvt_i32_f32 s1, s1
+; GFX12-GI-NEXT:    s_cvt_i32_f32 s2, s2
+; GFX12-GI-NEXT:    s_cvt_i32_f32 s3, s3
+; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-GI-NEXT:    s_min_i32 s0, s0, 0x7f
+; GFX12-GI-NEXT:    s_min_i32 s1, s1, 0x7f
+; GFX12-GI-NEXT:    s_min_i32 s2, s2, 0x7f
+; GFX12-GI-NEXT:    s_min_i32 s3, s3, 0x7f
+; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-GI-NEXT:    s_max_i32 s0, s0, 0xffffff80
+; GFX12-GI-NEXT:    s_max_i32 s1, s1, 0xffffff80
+; GFX12-GI-NEXT:    s_max_i32 s2, s2, 0xffffff80
+; GFX12-GI-NEXT:    s_max_i32 s3, s3, 0xffffff80
+; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-GI-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
+; GFX12-GI-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s3
 ; GFX12-GI-NEXT:    s_setpc_b64 s[30:31]
     %x = call <4 x i8> @llvm.fptosi.sat.v4f32.v4i8(<4 x float> %f)
     ret <4 x i8> %x

--- a/llvm/test/CodeGen/AMDGPU/fptoui-sat-scalar.ll
+++ b/llvm/test/CodeGen/AMDGPU/fptoui-sat-scalar.ll
@@ -282,6 +282,291 @@ define i64 @test_unsigned_i64_f32(float %f) nounwind {
     ret i64 %x
 }
 
+define i1 @test_s_ununsigned_i1_f32(float inreg %f) nounwind {
+; GFX7-LABEL: test_s_ununsigned_i1_f32:
+; GFX7:       ; %bb.0:
+; GFX7-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-NEXT:    v_cvt_u32_f32_e32 v0, s16
+; GFX7-NEXT:    v_min_u32_e32 v0, 1, v0
+; GFX7-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX9-LABEL: test_s_ununsigned_i1_f32:
+; GFX9:       ; %bb.0:
+; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    v_cvt_u32_f32_e32 v0, s16
+; GFX9-NEXT:    v_min_u32_e32 v0, 1, v0
+; GFX9-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11-LABEL: test_s_ununsigned_i1_f32:
+; GFX11:       ; %bb.0:
+; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-NEXT:    v_cvt_u32_f32_e32 v0, s0
+; GFX11-NEXT:    v_min_u32_e32 v0, 1, v0
+; GFX11-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-LABEL: test_s_ununsigned_i1_f32:
+; GFX12:       ; %bb.0:
+; GFX12-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-NEXT:    s_wait_expcnt 0x0
+; GFX12-NEXT:    s_wait_samplecnt 0x0
+; GFX12-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-NEXT:    s_wait_kmcnt 0x0
+; GFX12-NEXT:    s_cvt_u32_f32 s0, s0
+; GFX12-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-NEXT:    s_min_u32 s0, s0, 1
+; GFX12-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-NEXT:    v_mov_b32_e32 v0, s0
+; GFX12-NEXT:    s_setpc_b64 s[30:31]
+    %x = call i1 @llvm.fptoui.sat.i1.f32(float %f)
+    ret i1 %x
+}
+
+define i8 @test_s_unsigned_i8_f32(float inreg %f) nounwind {
+; GFX7-LABEL: test_s_unsigned_i8_f32:
+; GFX7:       ; %bb.0:
+; GFX7-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-NEXT:    v_cvt_u32_f32_e32 v0, s16
+; GFX7-NEXT:    v_min_u32_e32 v0, 0xff, v0
+; GFX7-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX9-LABEL: test_s_unsigned_i8_f32:
+; GFX9:       ; %bb.0:
+; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    v_cvt_u32_f32_e32 v0, s16
+; GFX9-NEXT:    v_min_u32_e32 v0, 0xff, v0
+; GFX9-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11-LABEL: test_s_unsigned_i8_f32:
+; GFX11:       ; %bb.0:
+; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-NEXT:    v_cvt_u32_f32_e32 v0, s0
+; GFX11-NEXT:    v_min_u32_e32 v0, 0xff, v0
+; GFX11-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-LABEL: test_s_unsigned_i8_f32:
+; GFX12:       ; %bb.0:
+; GFX12-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-NEXT:    s_wait_expcnt 0x0
+; GFX12-NEXT:    s_wait_samplecnt 0x0
+; GFX12-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-NEXT:    s_wait_kmcnt 0x0
+; GFX12-NEXT:    s_cvt_u32_f32 s0, s0
+; GFX12-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-NEXT:    s_min_u32 s0, s0, 0xff
+; GFX12-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-NEXT:    v_mov_b32_e32 v0, s0
+; GFX12-NEXT:    s_setpc_b64 s[30:31]
+    %x = call i8 @llvm.fptoui.sat.i8.f32(float %f)
+    ret i8 %x
+}
+
+define i16 @test_s_unsigned_i16_f32(float inreg %f) nounwind {
+; GFX7-LABEL: test_s_unsigned_i16_f32:
+; GFX7:       ; %bb.0:
+; GFX7-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-NEXT:    v_cvt_u32_f32_e32 v0, s16
+; GFX7-NEXT:    v_min_u32_e32 v0, 0xffff, v0
+; GFX7-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX9-LABEL: test_s_unsigned_i16_f32:
+; GFX9:       ; %bb.0:
+; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    v_cvt_u32_f32_e32 v0, s16
+; GFX9-NEXT:    v_min_u32_e32 v0, 0xffff, v0
+; GFX9-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11-LABEL: test_s_unsigned_i16_f32:
+; GFX11:       ; %bb.0:
+; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-NEXT:    v_cvt_u32_f32_e32 v0, s0
+; GFX11-NEXT:    v_min_u32_e32 v0, 0xffff, v0
+; GFX11-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-LABEL: test_s_unsigned_i16_f32:
+; GFX12:       ; %bb.0:
+; GFX12-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-NEXT:    s_wait_expcnt 0x0
+; GFX12-NEXT:    s_wait_samplecnt 0x0
+; GFX12-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-NEXT:    s_wait_kmcnt 0x0
+; GFX12-NEXT:    s_cvt_u32_f32 s0, s0
+; GFX12-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-NEXT:    s_min_u32 s0, s0, 0xffff
+; GFX12-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-NEXT:    v_mov_b32_e32 v0, s0
+; GFX12-NEXT:    s_setpc_b64 s[30:31]
+    %x = call i16 @llvm.fptoui.sat.i16.f32(float %f)
+    ret i16 %x
+}
+
+define i32 @test_s_unsigned_i32_f32(float inreg %f) nounwind {
+; GFX7-LABEL: test_s_unsigned_i32_f32:
+; GFX7:       ; %bb.0:
+; GFX7-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-NEXT:    v_cvt_u32_f32_e32 v0, s16
+; GFX7-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX9-LABEL: test_s_unsigned_i32_f32:
+; GFX9:       ; %bb.0:
+; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    v_cvt_u32_f32_e32 v0, s16
+; GFX9-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11-LABEL: test_s_unsigned_i32_f32:
+; GFX11:       ; %bb.0:
+; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-NEXT:    v_cvt_u32_f32_e32 v0, s0
+; GFX11-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-LABEL: test_s_unsigned_i32_f32:
+; GFX12:       ; %bb.0:
+; GFX12-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-NEXT:    s_wait_expcnt 0x0
+; GFX12-NEXT:    s_wait_samplecnt 0x0
+; GFX12-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-NEXT:    s_wait_kmcnt 0x0
+; GFX12-NEXT:    s_cvt_u32_f32 s0, s0
+; GFX12-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-NEXT:    v_mov_b32_e32 v0, s0
+; GFX12-NEXT:    s_setpc_b64 s[30:31]
+    %x = call i32 @llvm.fptoui.sat.i32.f32(float %f)
+    ret i32 %x
+}
+
+define i64 @test_s_unsigned_i64_f32(float inreg %f) nounwind {
+; GFX7-ISEL-LABEL: test_s_unsigned_i64_f32:
+; GFX7-ISEL:       ; %bb.0:
+; GFX7-ISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-ISEL-NEXT:    v_trunc_f32_e32 v0, s16
+; GFX7-ISEL-NEXT:    v_mul_f32_e32 v1, 0x2f800000, v0
+; GFX7-ISEL-NEXT:    v_floor_f32_e32 v1, v1
+; GFX7-ISEL-NEXT:    s_mov_b32 s4, 0xcf800000
+; GFX7-ISEL-NEXT:    v_cvt_u32_f32_e32 v2, v1
+; GFX7-ISEL-NEXT:    v_fma_f32 v0, v1, s4, v0
+; GFX7-ISEL-NEXT:    v_cvt_u32_f32_e32 v0, v0
+; GFX7-ISEL-NEXT:    v_cmp_nge_f32_e64 s[4:5], s16, 0
+; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v1, v2, 0, s[4:5]
+; GFX7-ISEL-NEXT:    v_mov_b32_e32 v2, 0x5f7fffff
+; GFX7-ISEL-NEXT:    v_cmp_gt_f32_e32 vcc, s16, v2
+; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v0, v0, 0, s[4:5]
+; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v1, v1, -1, vcc
+; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v0, v0, -1, vcc
+; GFX7-ISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX7-GI-LABEL: test_s_unsigned_i64_f32:
+; GFX7-GI:       ; %bb.0:
+; GFX7-GI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-GI-NEXT:    v_trunc_f32_e32 v0, s16
+; GFX7-GI-NEXT:    v_mul_f32_e32 v1, 0x2f800000, v0
+; GFX7-GI-NEXT:    v_floor_f32_e32 v1, v1
+; GFX7-GI-NEXT:    v_mov_b32_e32 v2, 0xcf800000
+; GFX7-GI-NEXT:    v_fma_f32 v0, v1, v2, v0
+; GFX7-GI-NEXT:    v_cvt_u32_f32_e32 v0, v0
+; GFX7-GI-NEXT:    v_cvt_u32_f32_e32 v1, v1
+; GFX7-GI-NEXT:    v_cmp_nge_f32_e64 s[4:5], s16, 0
+; GFX7-GI-NEXT:    v_mov_b32_e32 v2, 0x5f7fffff
+; GFX7-GI-NEXT:    v_cndmask_b32_e64 v0, v0, 0, s[4:5]
+; GFX7-GI-NEXT:    v_cndmask_b32_e64 v1, v1, 0, s[4:5]
+; GFX7-GI-NEXT:    v_cmp_gt_f32_e32 vcc, s16, v2
+; GFX7-GI-NEXT:    v_cndmask_b32_e64 v0, v0, -1, vcc
+; GFX7-GI-NEXT:    v_cndmask_b32_e64 v1, v1, -1, vcc
+; GFX7-GI-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX9-LABEL: test_s_unsigned_i64_f32:
+; GFX9:       ; %bb.0:
+; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    v_trunc_f32_e32 v0, s16
+; GFX9-NEXT:    v_mul_f32_e32 v1, 0x2f800000, v0
+; GFX9-NEXT:    v_floor_f32_e32 v1, v1
+; GFX9-NEXT:    s_mov_b32 s4, 0xcf800000
+; GFX9-NEXT:    v_cvt_u32_f32_e32 v2, v1
+; GFX9-NEXT:    v_fma_f32 v0, v1, s4, v0
+; GFX9-NEXT:    v_cvt_u32_f32_e32 v0, v0
+; GFX9-NEXT:    v_cmp_nge_f32_e64 s[4:5], s16, 0
+; GFX9-NEXT:    v_cndmask_b32_e64 v1, v2, 0, s[4:5]
+; GFX9-NEXT:    v_mov_b32_e32 v2, 0x5f7fffff
+; GFX9-NEXT:    v_cmp_gt_f32_e32 vcc, s16, v2
+; GFX9-NEXT:    v_cndmask_b32_e64 v0, v0, 0, s[4:5]
+; GFX9-NEXT:    v_cndmask_b32_e64 v1, v1, -1, vcc
+; GFX9-NEXT:    v_cndmask_b32_e64 v0, v0, -1, vcc
+; GFX9-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11-LABEL: test_s_unsigned_i64_f32:
+; GFX11:       ; %bb.0:
+; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-NEXT:    v_trunc_f32_e32 v0, s0
+; GFX11-NEXT:    v_cmp_nge_f32_e64 s1, s0, 0
+; GFX11-NEXT:    v_cmp_lt_f32_e64 s0, 0x5f7fffff, s0
+; GFX11-NEXT:    v_mul_f32_e32 v1, 0x2f800000, v0
+; GFX11-NEXT:    v_floor_f32_e32 v1, v1
+; GFX11-NEXT:    v_fmamk_f32 v0, v1, 0xcf800000, v0
+; GFX11-NEXT:    v_cvt_u32_f32_e32 v1, v1
+; GFX11-NEXT:    v_cvt_u32_f32_e32 v0, v0
+; GFX11-NEXT:    v_cndmask_b32_e64 v1, v1, 0, s1
+; GFX11-NEXT:    v_cndmask_b32_e64 v0, v0, 0, s1
+; GFX11-NEXT:    v_cndmask_b32_e64 v1, v1, -1, s0
+; GFX11-NEXT:    v_cndmask_b32_e64 v0, v0, -1, s0
+; GFX11-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-ISEL-LABEL: test_s_unsigned_i64_f32:
+; GFX12-ISEL:       ; %bb.0:
+; GFX12-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX12-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX12-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX12-ISEL-NEXT:    s_trunc_f32 s1, s0
+; GFX12-ISEL-NEXT:    s_cmp_nge_f32 s0, 0
+; GFX12-ISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-ISEL-NEXT:    s_mul_f32 s2, s1, 0x2f800000
+; GFX12-ISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-ISEL-NEXT:    s_floor_f32 s2, s2
+; GFX12-ISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-ISEL-NEXT:    s_fmac_f32 s1, s2, 0xcf800000
+; GFX12-ISEL-NEXT:    s_cvt_u32_f32 s2, s2
+; GFX12-ISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-ISEL-NEXT:    s_cvt_u32_f32 s1, s1
+; GFX12-ISEL-NEXT:    s_cselect_b32 s2, 0, s2
+; GFX12-ISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-ISEL-NEXT:    s_cselect_b32 s1, 0, s1
+; GFX12-ISEL-NEXT:    s_cmp_gt_f32 s0, 0x5f7fffff
+; GFX12-ISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-ISEL-NEXT:    s_cselect_b32 s0, -1, s1
+; GFX12-ISEL-NEXT:    s_cselect_b32 s1, -1, s2
+; GFX12-ISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-ISEL-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
+; GFX12-ISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-GI-LABEL: test_s_unsigned_i64_f32:
+; GFX12-GI:       ; %bb.0:
+; GFX12-GI-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-GI-NEXT:    s_wait_expcnt 0x0
+; GFX12-GI-NEXT:    s_wait_samplecnt 0x0
+; GFX12-GI-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-GI-NEXT:    s_wait_kmcnt 0x0
+; GFX12-GI-NEXT:    s_trunc_f32 s1, s0
+; GFX12-GI-NEXT:    s_cmp_nge_f32 s0, 0
+; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-GI-NEXT:    s_mul_f32 s2, s1, 0x2f800000
+; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-GI-NEXT:    s_floor_f32 s2, s2
+; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-GI-NEXT:    s_fmac_f32 s1, s2, 0xcf800000
+; GFX12-GI-NEXT:    s_cvt_u32_f32 s3, s2
+; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-GI-NEXT:    s_cvt_u32_f32 s2, s1
+; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-GI-NEXT:    s_cselect_b64 s[2:3], 0, s[2:3]
+; GFX12-GI-NEXT:    s_cmp_gt_f32 s0, 0x5f7fffff
+; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-GI-NEXT:    s_cselect_b64 s[0:1], -1, s[2:3]
+; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-GI-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
+; GFX12-GI-NEXT:    s_setpc_b64 s[30:31]
+    %x = call i64 @llvm.fptoui.sat.i64.f32(float %f)
+    ret i64 %x
+}
+
 ;
 ; 64-bit float to unsigned integer
 ;
@@ -568,6 +853,286 @@ define i64 @test_unsigned_i64_f64(double %f) nounwind {
 ; GFX12-GI-NEXT:    s_wait_alu depctr_va_sdst(0)
 ; GFX12-GI-NEXT:    v_cndmask_b32_e64 v0, v5, -1, s0
 ; GFX12-GI-NEXT:    v_cndmask_b32_e64 v1, v1, -1, s0
+; GFX12-GI-NEXT:    s_setpc_b64 s[30:31]
+    %x = call i64 @llvm.fptoui.sat.i64.f64(double %f)
+    ret i64 %x
+}
+
+define i1 @test_s_unsigned_i1_f64(double inreg %f) nounwind {
+; GFX7-LABEL: test_s_unsigned_i1_f64:
+; GFX7:       ; %bb.0:
+; GFX7-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-NEXT:    v_cvt_u32_f64_e32 v0, s[16:17]
+; GFX7-NEXT:    v_min_u32_e32 v0, 1, v0
+; GFX7-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX9-LABEL: test_s_unsigned_i1_f64:
+; GFX9:       ; %bb.0:
+; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    v_cvt_u32_f64_e32 v0, s[16:17]
+; GFX9-NEXT:    v_min_u32_e32 v0, 1, v0
+; GFX9-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11-LABEL: test_s_unsigned_i1_f64:
+; GFX11:       ; %bb.0:
+; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-NEXT:    v_cvt_u32_f64_e32 v0, s[0:1]
+; GFX11-NEXT:    v_min_u32_e32 v0, 1, v0
+; GFX11-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-LABEL: test_s_unsigned_i1_f64:
+; GFX12:       ; %bb.0:
+; GFX12-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-NEXT:    s_wait_expcnt 0x0
+; GFX12-NEXT:    s_wait_samplecnt 0x0
+; GFX12-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-NEXT:    s_wait_kmcnt 0x0
+; GFX12-NEXT:    v_cvt_u32_f64_e32 v0, s[0:1]
+; GFX12-NEXT:    v_min_u32_e32 v0, 1, v0
+; GFX12-NEXT:    s_setpc_b64 s[30:31]
+    %x = call i1 @llvm.fptoui.sat.i1.f64(double %f)
+    ret i1 %x
+}
+
+define i8 @test_s_unsigned_i8_f64(double inreg %f) nounwind {
+; GFX7-LABEL: test_s_unsigned_i8_f64:
+; GFX7:       ; %bb.0:
+; GFX7-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-NEXT:    v_cvt_u32_f64_e32 v0, s[16:17]
+; GFX7-NEXT:    v_min_u32_e32 v0, 0xff, v0
+; GFX7-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX9-LABEL: test_s_unsigned_i8_f64:
+; GFX9:       ; %bb.0:
+; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    v_cvt_u32_f64_e32 v0, s[16:17]
+; GFX9-NEXT:    v_min_u32_e32 v0, 0xff, v0
+; GFX9-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11-LABEL: test_s_unsigned_i8_f64:
+; GFX11:       ; %bb.0:
+; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-NEXT:    v_cvt_u32_f64_e32 v0, s[0:1]
+; GFX11-NEXT:    v_min_u32_e32 v0, 0xff, v0
+; GFX11-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-LABEL: test_s_unsigned_i8_f64:
+; GFX12:       ; %bb.0:
+; GFX12-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-NEXT:    s_wait_expcnt 0x0
+; GFX12-NEXT:    s_wait_samplecnt 0x0
+; GFX12-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-NEXT:    s_wait_kmcnt 0x0
+; GFX12-NEXT:    v_cvt_u32_f64_e32 v0, s[0:1]
+; GFX12-NEXT:    v_min_u32_e32 v0, 0xff, v0
+; GFX12-NEXT:    s_setpc_b64 s[30:31]
+    %x = call i8 @llvm.fptoui.sat.i8.f64(double %f)
+    ret i8 %x
+}
+
+define i16 @test_s_unsigned_i16_f64(double inreg %f) nounwind {
+; GFX7-LABEL: test_s_unsigned_i16_f64:
+; GFX7:       ; %bb.0:
+; GFX7-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-NEXT:    v_cvt_u32_f64_e32 v0, s[16:17]
+; GFX7-NEXT:    v_min_u32_e32 v0, 0xffff, v0
+; GFX7-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX9-LABEL: test_s_unsigned_i16_f64:
+; GFX9:       ; %bb.0:
+; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    v_cvt_u32_f64_e32 v0, s[16:17]
+; GFX9-NEXT:    v_min_u32_e32 v0, 0xffff, v0
+; GFX9-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11-LABEL: test_s_unsigned_i16_f64:
+; GFX11:       ; %bb.0:
+; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-NEXT:    v_cvt_u32_f64_e32 v0, s[0:1]
+; GFX11-NEXT:    v_min_u32_e32 v0, 0xffff, v0
+; GFX11-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-LABEL: test_s_unsigned_i16_f64:
+; GFX12:       ; %bb.0:
+; GFX12-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-NEXT:    s_wait_expcnt 0x0
+; GFX12-NEXT:    s_wait_samplecnt 0x0
+; GFX12-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-NEXT:    s_wait_kmcnt 0x0
+; GFX12-NEXT:    v_cvt_u32_f64_e32 v0, s[0:1]
+; GFX12-NEXT:    v_min_u32_e32 v0, 0xffff, v0
+; GFX12-NEXT:    s_setpc_b64 s[30:31]
+    %x = call i16 @llvm.fptoui.sat.i16.f64(double %f)
+    ret i16 %x
+}
+
+define i32 @test_s_unsigned_i32_f64(double inreg %f) nounwind {
+; GFX7-LABEL: test_s_unsigned_i32_f64:
+; GFX7:       ; %bb.0:
+; GFX7-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-NEXT:    v_cvt_u32_f64_e32 v0, s[16:17]
+; GFX7-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX9-LABEL: test_s_unsigned_i32_f64:
+; GFX9:       ; %bb.0:
+; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    v_cvt_u32_f64_e32 v0, s[16:17]
+; GFX9-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11-LABEL: test_s_unsigned_i32_f64:
+; GFX11:       ; %bb.0:
+; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-NEXT:    v_cvt_u32_f64_e32 v0, s[0:1]
+; GFX11-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-LABEL: test_s_unsigned_i32_f64:
+; GFX12:       ; %bb.0:
+; GFX12-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-NEXT:    s_wait_expcnt 0x0
+; GFX12-NEXT:    s_wait_samplecnt 0x0
+; GFX12-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-NEXT:    s_wait_kmcnt 0x0
+; GFX12-NEXT:    v_cvt_u32_f64_e32 v0, s[0:1]
+; GFX12-NEXT:    s_setpc_b64 s[30:31]
+    %x = call i32 @llvm.fptoui.sat.i32.f64(double %f)
+    ret i32 %x
+}
+
+define i64 @test_s_unsigned_i64_f64(double inreg %f) nounwind {
+; GFX7-ISEL-LABEL: test_s_unsigned_i64_f64:
+; GFX7-ISEL:       ; %bb.0:
+; GFX7-ISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-ISEL-NEXT:    v_trunc_f64_e32 v[0:1], s[16:17]
+; GFX7-ISEL-NEXT:    s_movk_i32 s4, 0xffe0
+; GFX7-ISEL-NEXT:    v_ldexp_f64 v[2:3], v[0:1], s4
+; GFX7-ISEL-NEXT:    s_mov_b32 s4, 0
+; GFX7-ISEL-NEXT:    s_mov_b32 s5, 0xc1f00000
+; GFX7-ISEL-NEXT:    v_floor_f64_e32 v[2:3], v[2:3]
+; GFX7-ISEL-NEXT:    v_fma_f64 v[0:1], v[2:3], s[4:5], v[0:1]
+; GFX7-ISEL-NEXT:    v_cvt_u32_f64_e32 v4, v[2:3]
+; GFX7-ISEL-NEXT:    v_mov_b32_e32 v2, -1
+; GFX7-ISEL-NEXT:    v_mov_b32_e32 v3, 0x43efffff
+; GFX7-ISEL-NEXT:    v_cmp_nge_f64_e64 s[4:5], s[16:17], 0
+; GFX7-ISEL-NEXT:    v_cmp_gt_f64_e32 vcc, s[16:17], v[2:3]
+; GFX7-ISEL-NEXT:    v_cvt_u32_f64_e32 v0, v[0:1]
+; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v4, v4, 0, s[4:5]
+; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v0, v0, 0, s[4:5]
+; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v1, v4, -1, vcc
+; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v0, v0, -1, vcc
+; GFX7-ISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX7-GI-LABEL: test_s_unsigned_i64_f64:
+; GFX7-GI:       ; %bb.0:
+; GFX7-GI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-GI-NEXT:    v_trunc_f64_e32 v[0:1], s[16:17]
+; GFX7-GI-NEXT:    v_mov_b32_e32 v2, 0
+; GFX7-GI-NEXT:    v_mov_b32_e32 v3, 0x3df00000
+; GFX7-GI-NEXT:    v_mov_b32_e32 v4, 0
+; GFX7-GI-NEXT:    v_mov_b32_e32 v5, 0xc1f00000
+; GFX7-GI-NEXT:    v_cmp_nge_f64_e64 s[4:5], s[16:17], 0
+; GFX7-GI-NEXT:    v_mul_f64 v[2:3], v[0:1], v[2:3]
+; GFX7-GI-NEXT:    v_floor_f64_e32 v[2:3], v[2:3]
+; GFX7-GI-NEXT:    v_fma_f64 v[0:1], v[2:3], v[4:5], v[0:1]
+; GFX7-GI-NEXT:    v_cvt_u32_f64_e32 v4, v[0:1]
+; GFX7-GI-NEXT:    v_mov_b32_e32 v0, -1
+; GFX7-GI-NEXT:    v_mov_b32_e32 v1, 0x43efffff
+; GFX7-GI-NEXT:    v_cmp_gt_f64_e32 vcc, s[16:17], v[0:1]
+; GFX7-GI-NEXT:    v_cvt_u32_f64_e32 v1, v[2:3]
+; GFX7-GI-NEXT:    v_cndmask_b32_e64 v4, v4, 0, s[4:5]
+; GFX7-GI-NEXT:    v_cndmask_b32_e64 v1, v1, 0, s[4:5]
+; GFX7-GI-NEXT:    v_cndmask_b32_e64 v0, v4, -1, vcc
+; GFX7-GI-NEXT:    v_cndmask_b32_e64 v1, v1, -1, vcc
+; GFX7-GI-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX9-LABEL: test_s_unsigned_i64_f64:
+; GFX9:       ; %bb.0:
+; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    v_trunc_f64_e32 v[0:1], s[16:17]
+; GFX9-NEXT:    s_movk_i32 s4, 0xffe0
+; GFX9-NEXT:    v_ldexp_f64 v[2:3], v[0:1], s4
+; GFX9-NEXT:    s_mov_b32 s4, 0
+; GFX9-NEXT:    s_mov_b32 s5, 0xc1f00000
+; GFX9-NEXT:    v_floor_f64_e32 v[2:3], v[2:3]
+; GFX9-NEXT:    v_fma_f64 v[0:1], v[2:3], s[4:5], v[0:1]
+; GFX9-NEXT:    v_cvt_u32_f64_e32 v4, v[2:3]
+; GFX9-NEXT:    v_mov_b32_e32 v2, -1
+; GFX9-NEXT:    v_mov_b32_e32 v3, 0x43efffff
+; GFX9-NEXT:    v_cmp_nge_f64_e64 s[4:5], s[16:17], 0
+; GFX9-NEXT:    v_cmp_gt_f64_e32 vcc, s[16:17], v[2:3]
+; GFX9-NEXT:    v_cvt_u32_f64_e32 v0, v[0:1]
+; GFX9-NEXT:    v_cndmask_b32_e64 v4, v4, 0, s[4:5]
+; GFX9-NEXT:    v_cndmask_b32_e64 v0, v0, 0, s[4:5]
+; GFX9-NEXT:    v_cndmask_b32_e64 v1, v4, -1, vcc
+; GFX9-NEXT:    v_cndmask_b32_e64 v0, v0, -1, vcc
+; GFX9-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11-LABEL: test_s_unsigned_i64_f64:
+; GFX11:       ; %bb.0:
+; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-NEXT:    v_trunc_f64_e32 v[0:1], s[0:1]
+; GFX11-NEXT:    v_cmp_nge_f64_e64 s4, s[0:1], 0
+; GFX11-NEXT:    s_mov_b32 s2, -1
+; GFX11-NEXT:    s_mov_b32 s3, 0x43efffff
+; GFX11-NEXT:    v_cmp_gt_f64_e64 s0, s[0:1], s[2:3]
+; GFX11-NEXT:    v_ldexp_f64 v[2:3], v[0:1], 0xffffffe0
+; GFX11-NEXT:    v_floor_f64_e32 v[2:3], v[2:3]
+; GFX11-NEXT:    v_fma_f64 v[0:1], 0xc1f00000, v[2:3], v[0:1]
+; GFX11-NEXT:    v_cvt_u32_f64_e32 v2, v[2:3]
+; GFX11-NEXT:    v_cvt_u32_f64_e32 v0, v[0:1]
+; GFX11-NEXT:    v_cndmask_b32_e64 v1, v2, 0, s4
+; GFX11-NEXT:    v_cndmask_b32_e64 v1, v1, -1, s0
+; GFX11-NEXT:    v_cndmask_b32_e64 v0, v0, 0, s4
+; GFX11-NEXT:    v_cndmask_b32_e64 v0, v0, -1, s0
+; GFX11-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-ISEL-LABEL: test_s_unsigned_i64_f64:
+; GFX12-ISEL:       ; %bb.0:
+; GFX12-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX12-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX12-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX12-ISEL-NEXT:    v_trunc_f64_e32 v[0:1], s[0:1]
+; GFX12-ISEL-NEXT:    v_cmp_nge_f64_e64 s4, s[0:1], 0
+; GFX12-ISEL-NEXT:    s_mov_b32 s2, -1
+; GFX12-ISEL-NEXT:    s_mov_b32 s3, 0x43efffff
+; GFX12-ISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-ISEL-NEXT:    v_cmp_gt_f64_e64 s0, s[0:1], s[2:3]
+; GFX12-ISEL-NEXT:    v_ldexp_f64 v[2:3], v[0:1], 0xffffffe0
+; GFX12-ISEL-NEXT:    v_floor_f64_e32 v[2:3], v[2:3]
+; GFX12-ISEL-NEXT:    v_fma_f64 v[0:1], 0xc1f00000, v[2:3], v[0:1]
+; GFX12-ISEL-NEXT:    v_cvt_u32_f64_e32 v2, v[2:3]
+; GFX12-ISEL-NEXT:    v_cvt_u32_f64_e32 v0, v[0:1]
+; GFX12-ISEL-NEXT:    s_wait_alu depctr_va_sdst(0)
+; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v1, v2, 0, s4
+; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v1, v1, -1, s0
+; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v0, v0, 0, s4
+; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v0, v0, -1, s0
+; GFX12-ISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-GI-LABEL: test_s_unsigned_i64_f64:
+; GFX12-GI:       ; %bb.0:
+; GFX12-GI-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-GI-NEXT:    s_wait_expcnt 0x0
+; GFX12-GI-NEXT:    s_wait_samplecnt 0x0
+; GFX12-GI-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-GI-NEXT:    s_wait_kmcnt 0x0
+; GFX12-GI-NEXT:    v_trunc_f64_e32 v[0:1], s[0:1]
+; GFX12-GI-NEXT:    v_cmp_nge_f64_e64 s2, s[0:1], 0
+; GFX12-GI-NEXT:    v_mul_f64_e32 v[2:3], 0x3df00000, v[0:1]
+; GFX12-GI-NEXT:    v_floor_f64_e32 v[2:3], v[2:3]
+; GFX12-GI-NEXT:    v_fma_f64 v[0:1], 0xc1f00000, v[2:3], v[0:1]
+; GFX12-GI-NEXT:    v_cvt_u32_f64_e32 v2, v[2:3]
+; GFX12-GI-NEXT:    v_cvt_u32_f64_e32 v4, v[0:1]
+; GFX12-GI-NEXT:    v_mov_b32_e32 v0, -1
+; GFX12-GI-NEXT:    v_mov_b32_e32 v1, 0x43efffff
+; GFX12-GI-NEXT:    v_cmp_gt_f64_e32 vcc_lo, s[0:1], v[0:1]
+; GFX12-GI-NEXT:    s_wait_alu depctr_va_sdst(0)
+; GFX12-GI-NEXT:    v_cndmask_b32_e64 v1, v2, 0, s2
+; GFX12-GI-NEXT:    v_cndmask_b32_e64 v3, v4, 0, s2
+; GFX12-GI-NEXT:    s_wait_alu depctr_va_vcc(0)
+; GFX12-GI-NEXT:    v_cndmask_b32_e64 v0, v3, -1, vcc_lo
+; GFX12-GI-NEXT:    v_cndmask_b32_e64 v1, v1, -1, vcc_lo
 ; GFX12-GI-NEXT:    s_setpc_b64 s[30:31]
     %x = call i64 @llvm.fptoui.sat.i64.f64(double %f)
     ret i64 %x
@@ -910,6 +1475,300 @@ define i64 @test_unsigned_i64_f16(half %f) nounwind {
 ; GFX12-GI-NEXT:    v_mov_b32_e32 v1, 0
 ; GFX12-GI-NEXT:    v_cvt_u32_f32_e32 v0, v0
 ; GFX12-GI-NEXT:    s_setpc_b64 s[30:31]
+    %x = call i64 @llvm.fptoui.sat.i64.f16(half %f)
+    ret i64 %x
+}
+
+define i1 @test_s_unsigned_i1_f16(half inreg %f) nounwind {
+; GFX7-LABEL: test_s_unsigned_i1_f16:
+; GFX7:       ; %bb.0:
+; GFX7-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-NEXT:    v_cvt_f32_f16_e32 v0, s16
+; GFX7-NEXT:    v_cvt_u32_f32_e32 v0, v0
+; GFX7-NEXT:    v_min_u32_e32 v0, 1, v0
+; GFX7-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX9-LABEL: test_s_unsigned_i1_f16:
+; GFX9:       ; %bb.0:
+; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    v_cvt_u16_f16_e32 v0, s16
+; GFX9-NEXT:    v_mov_b32_e32 v1, 1
+; GFX9-NEXT:    v_min_u32_sdwa v0, v0, v1 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
+; GFX9-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11-FAKE16-LABEL: test_s_unsigned_i1_f16:
+; GFX11-FAKE16:       ; %bb.0:
+; GFX11-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-FAKE16-NEXT:    v_cvt_u16_f16_e32 v0, s0
+; GFX11-FAKE16-NEXT:    v_and_b32_e32 v0, 0xffff, v0
+; GFX11-FAKE16-NEXT:    v_min_u32_e32 v0, 1, v0
+; GFX11-FAKE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11-TRUE16-LABEL: test_s_unsigned_i1_f16:
+; GFX11-TRUE16:       ; %bb.0:
+; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-TRUE16-NEXT:    v_cvt_u16_f16_e32 v0.l, s0
+; GFX11-TRUE16-NEXT:    v_and_b32_e32 v0, 0xffff, v0
+; GFX11-TRUE16-NEXT:    v_min_u32_e32 v0, 1, v0
+; GFX11-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-FAKE16-LABEL: test_s_unsigned_i1_f16:
+; GFX12-FAKE16:       ; %bb.0:
+; GFX12-FAKE16-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-FAKE16-NEXT:    s_wait_expcnt 0x0
+; GFX12-FAKE16-NEXT:    s_wait_samplecnt 0x0
+; GFX12-FAKE16-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-FAKE16-NEXT:    s_wait_kmcnt 0x0
+; GFX12-FAKE16-NEXT:    v_cvt_u16_f16_e32 v0, s0
+; GFX12-FAKE16-NEXT:    v_and_b32_e32 v0, 0xffff, v0
+; GFX12-FAKE16-NEXT:    v_min_u32_e32 v0, 1, v0
+; GFX12-FAKE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-TRUE16-LABEL: test_s_unsigned_i1_f16:
+; GFX12-TRUE16:       ; %bb.0:
+; GFX12-TRUE16-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-TRUE16-NEXT:    s_wait_expcnt 0x0
+; GFX12-TRUE16-NEXT:    s_wait_samplecnt 0x0
+; GFX12-TRUE16-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-TRUE16-NEXT:    s_wait_kmcnt 0x0
+; GFX12-TRUE16-NEXT:    v_cvt_u16_f16_e32 v0.l, s0
+; GFX12-TRUE16-NEXT:    v_and_b32_e32 v0, 0xffff, v0
+; GFX12-TRUE16-NEXT:    v_min_u32_e32 v0, 1, v0
+; GFX12-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-GI-LABEL: test_s_unsigned_i1_f16:
+; GFX12-GI:       ; %bb.0:
+; GFX12-GI-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-GI-NEXT:    s_wait_expcnt 0x0
+; GFX12-GI-NEXT:    s_wait_samplecnt 0x0
+; GFX12-GI-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-GI-NEXT:    s_wait_kmcnt 0x0
+; GFX12-GI-NEXT:    s_cvt_f32_f16 s0, s0
+; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-GI-NEXT:    s_cvt_u32_f32 s0, s0
+; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-GI-NEXT:    s_min_u32 s0, s0, 1
+; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-GI-NEXT:    v_mov_b32_e32 v0, s0
+; GFX12-GI-NEXT:    s_setpc_b64 s[30:31]
+    %x = call i1 @llvm.fptoui.sat.i1.f16(half %f)
+    ret i1 %x
+}
+
+define i8 @test_s_unsigned_i8_f16(half inreg %f) nounwind {
+; GFX7-LABEL: test_s_unsigned_i8_f16:
+; GFX7:       ; %bb.0:
+; GFX7-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-NEXT:    v_cvt_f32_f16_e32 v0, s16
+; GFX7-NEXT:    v_cvt_u32_f32_e32 v0, v0
+; GFX7-NEXT:    v_min_u32_e32 v0, 0xff, v0
+; GFX7-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX9-LABEL: test_s_unsigned_i8_f16:
+; GFX9:       ; %bb.0:
+; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    v_cvt_u16_f16_e32 v0, s16
+; GFX9-NEXT:    s_movk_i32 s4, 0xff
+; GFX9-NEXT:    v_min_u32_sdwa v0, v0, s4 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
+; GFX9-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11-FAKE16-LABEL: test_s_unsigned_i8_f16:
+; GFX11-FAKE16:       ; %bb.0:
+; GFX11-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-FAKE16-NEXT:    v_cvt_u16_f16_e32 v0, s0
+; GFX11-FAKE16-NEXT:    v_and_b32_e32 v0, 0xffff, v0
+; GFX11-FAKE16-NEXT:    v_min_u32_e32 v0, 0xff, v0
+; GFX11-FAKE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11-TRUE16-LABEL: test_s_unsigned_i8_f16:
+; GFX11-TRUE16:       ; %bb.0:
+; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-TRUE16-NEXT:    v_cvt_u16_f16_e32 v0.l, s0
+; GFX11-TRUE16-NEXT:    v_and_b32_e32 v0, 0xffff, v0
+; GFX11-TRUE16-NEXT:    v_min_u32_e32 v0, 0xff, v0
+; GFX11-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-FAKE16-LABEL: test_s_unsigned_i8_f16:
+; GFX12-FAKE16:       ; %bb.0:
+; GFX12-FAKE16-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-FAKE16-NEXT:    s_wait_expcnt 0x0
+; GFX12-FAKE16-NEXT:    s_wait_samplecnt 0x0
+; GFX12-FAKE16-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-FAKE16-NEXT:    s_wait_kmcnt 0x0
+; GFX12-FAKE16-NEXT:    v_cvt_u16_f16_e32 v0, s0
+; GFX12-FAKE16-NEXT:    v_and_b32_e32 v0, 0xffff, v0
+; GFX12-FAKE16-NEXT:    v_min_u32_e32 v0, 0xff, v0
+; GFX12-FAKE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-TRUE16-LABEL: test_s_unsigned_i8_f16:
+; GFX12-TRUE16:       ; %bb.0:
+; GFX12-TRUE16-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-TRUE16-NEXT:    s_wait_expcnt 0x0
+; GFX12-TRUE16-NEXT:    s_wait_samplecnt 0x0
+; GFX12-TRUE16-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-TRUE16-NEXT:    s_wait_kmcnt 0x0
+; GFX12-TRUE16-NEXT:    v_cvt_u16_f16_e32 v0.l, s0
+; GFX12-TRUE16-NEXT:    v_and_b32_e32 v0, 0xffff, v0
+; GFX12-TRUE16-NEXT:    v_min_u32_e32 v0, 0xff, v0
+; GFX12-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-GI-LABEL: test_s_unsigned_i8_f16:
+; GFX12-GI:       ; %bb.0:
+; GFX12-GI-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-GI-NEXT:    s_wait_expcnt 0x0
+; GFX12-GI-NEXT:    s_wait_samplecnt 0x0
+; GFX12-GI-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-GI-NEXT:    s_wait_kmcnt 0x0
+; GFX12-GI-NEXT:    s_cvt_f32_f16 s0, s0
+; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-GI-NEXT:    s_cvt_u32_f32 s0, s0
+; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-GI-NEXT:    s_min_u32 s0, s0, 0xff
+; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-GI-NEXT:    v_mov_b32_e32 v0, s0
+; GFX12-GI-NEXT:    s_setpc_b64 s[30:31]
+    %x = call i8 @llvm.fptoui.sat.i8.f16(half %f)
+    ret i8 %x
+}
+
+define i16 @test_s_unsigned_i16_f16(half inreg %f) nounwind {
+; GFX7-LABEL: test_s_unsigned_i16_f16:
+; GFX7:       ; %bb.0:
+; GFX7-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-NEXT:    v_cvt_f32_f16_e32 v0, s16
+; GFX7-NEXT:    v_cvt_u32_f32_e32 v0, v0
+; GFX7-NEXT:    v_min_u32_e32 v0, 0xffff, v0
+; GFX7-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX9-LABEL: test_s_unsigned_i16_f16:
+; GFX9:       ; %bb.0:
+; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    v_cvt_u16_f16_e32 v0, s16
+; GFX9-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11-FAKE16-LABEL: test_s_unsigned_i16_f16:
+; GFX11-FAKE16:       ; %bb.0:
+; GFX11-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-FAKE16-NEXT:    v_cvt_u16_f16_e32 v0, s0
+; GFX11-FAKE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11-TRUE16-LABEL: test_s_unsigned_i16_f16:
+; GFX11-TRUE16:       ; %bb.0:
+; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-TRUE16-NEXT:    v_cvt_u16_f16_e32 v0.l, s0
+; GFX11-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-FAKE16-LABEL: test_s_unsigned_i16_f16:
+; GFX12-FAKE16:       ; %bb.0:
+; GFX12-FAKE16-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-FAKE16-NEXT:    s_wait_expcnt 0x0
+; GFX12-FAKE16-NEXT:    s_wait_samplecnt 0x0
+; GFX12-FAKE16-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-FAKE16-NEXT:    s_wait_kmcnt 0x0
+; GFX12-FAKE16-NEXT:    v_cvt_u16_f16_e32 v0, s0
+; GFX12-FAKE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-TRUE16-LABEL: test_s_unsigned_i16_f16:
+; GFX12-TRUE16:       ; %bb.0:
+; GFX12-TRUE16-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-TRUE16-NEXT:    s_wait_expcnt 0x0
+; GFX12-TRUE16-NEXT:    s_wait_samplecnt 0x0
+; GFX12-TRUE16-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-TRUE16-NEXT:    s_wait_kmcnt 0x0
+; GFX12-TRUE16-NEXT:    v_cvt_u16_f16_e32 v0.l, s0
+; GFX12-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-GI-LABEL: test_s_unsigned_i16_f16:
+; GFX12-GI:       ; %bb.0:
+; GFX12-GI-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-GI-NEXT:    s_wait_expcnt 0x0
+; GFX12-GI-NEXT:    s_wait_samplecnt 0x0
+; GFX12-GI-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-GI-NEXT:    s_wait_kmcnt 0x0
+; GFX12-GI-NEXT:    v_cvt_u16_f16_e32 v0.l, s0
+; GFX12-GI-NEXT:    s_setpc_b64 s[30:31]
+    %x = call i16 @llvm.fptoui.sat.i16.f16(half %f)
+    ret i16 %x
+}
+
+define i32 @test_s_unsigned_i32_f16(half inreg %f) nounwind {
+; GFX7-LABEL: test_s_unsigned_i32_f16:
+; GFX7:       ; %bb.0:
+; GFX7-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-NEXT:    v_cvt_f32_f16_e32 v0, s16
+; GFX7-NEXT:    v_cvt_u32_f32_e32 v0, v0
+; GFX7-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX9-LABEL: test_s_unsigned_i32_f16:
+; GFX9:       ; %bb.0:
+; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    v_cvt_f32_f16_e32 v0, s16
+; GFX9-NEXT:    v_cvt_u32_f32_e32 v0, v0
+; GFX9-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11-LABEL: test_s_unsigned_i32_f16:
+; GFX11:       ; %bb.0:
+; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-NEXT:    v_cvt_f32_f16_e32 v0, s0
+; GFX11-NEXT:    v_cvt_u32_f32_e32 v0, v0
+; GFX11-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-LABEL: test_s_unsigned_i32_f16:
+; GFX12:       ; %bb.0:
+; GFX12-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-NEXT:    s_wait_expcnt 0x0
+; GFX12-NEXT:    s_wait_samplecnt 0x0
+; GFX12-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-NEXT:    s_wait_kmcnt 0x0
+; GFX12-NEXT:    s_cvt_f32_f16 s0, s0
+; GFX12-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-NEXT:    s_cvt_u32_f32 s0, s0
+; GFX12-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-NEXT:    v_mov_b32_e32 v0, s0
+; GFX12-NEXT:    s_setpc_b64 s[30:31]
+    %x = call i32 @llvm.fptoui.sat.i32.f16(half %f)
+    ret i32 %x
+}
+
+define i64 @test_s_unsigned_i64_f16(half inreg %f) nounwind {
+; GFX7-LABEL: test_s_unsigned_i64_f16:
+; GFX7:       ; %bb.0:
+; GFX7-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-NEXT:    v_cvt_f32_f16_e32 v0, s16
+; GFX7-NEXT:    v_mov_b32_e32 v1, 0
+; GFX7-NEXT:    v_cvt_u32_f32_e32 v0, v0
+; GFX7-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX9-LABEL: test_s_unsigned_i64_f16:
+; GFX9:       ; %bb.0:
+; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    v_cvt_f32_f16_e32 v0, s16
+; GFX9-NEXT:    v_mov_b32_e32 v1, 0
+; GFX9-NEXT:    v_cvt_u32_f32_e32 v0, v0
+; GFX9-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11-LABEL: test_s_unsigned_i64_f16:
+; GFX11:       ; %bb.0:
+; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-NEXT:    v_cvt_f32_f16_e32 v0, s0
+; GFX11-NEXT:    v_mov_b32_e32 v1, 0
+; GFX11-NEXT:    v_cvt_u32_f32_e32 v0, v0
+; GFX11-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-LABEL: test_s_unsigned_i64_f16:
+; GFX12:       ; %bb.0:
+; GFX12-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-NEXT:    s_wait_expcnt 0x0
+; GFX12-NEXT:    s_wait_samplecnt 0x0
+; GFX12-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-NEXT:    s_wait_kmcnt 0x0
+; GFX12-NEXT:    s_cvt_f32_f16 s0, s0
+; GFX12-NEXT:    v_mov_b32_e32 v1, 0
+; GFX12-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-NEXT:    s_cvt_u32_f32 s0, s0
+; GFX12-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-NEXT:    v_mov_b32_e32 v0, s0
+; GFX12-NEXT:    s_setpc_b64 s[30:31]
     %x = call i64 @llvm.fptoui.sat.i64.f16(half %f)
     ret i64 %x
 }

--- a/llvm/test/CodeGen/AMDGPU/fptoui-sat-vector.ll
+++ b/llvm/test/CodeGen/AMDGPU/fptoui-sat-vector.ll
@@ -389,6 +389,402 @@ define <8 x i32> @test_unsigned_v8f32_v8i32(<8 x float> %f) {
     ret <8 x i32> %x
 }
 
+define <1 x i32> @test_s_unsigned_v1f32_v1i32(<1 x float> inreg %f) {
+; GFX7-LABEL: test_s_unsigned_v1f32_v1i32:
+; GFX7:       ; %bb.0:
+; GFX7-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-NEXT:    v_cvt_u32_f32_e32 v0, s16
+; GFX7-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX9-LABEL: test_s_unsigned_v1f32_v1i32:
+; GFX9:       ; %bb.0:
+; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    v_cvt_u32_f32_e32 v0, s16
+; GFX9-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11-LABEL: test_s_unsigned_v1f32_v1i32:
+; GFX11:       ; %bb.0:
+; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-NEXT:    v_cvt_u32_f32_e32 v0, s0
+; GFX11-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-LABEL: test_s_unsigned_v1f32_v1i32:
+; GFX12:       ; %bb.0:
+; GFX12-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-NEXT:    s_wait_expcnt 0x0
+; GFX12-NEXT:    s_wait_samplecnt 0x0
+; GFX12-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-NEXT:    s_wait_kmcnt 0x0
+; GFX12-NEXT:    s_cvt_u32_f32 s0, s0
+; GFX12-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-NEXT:    v_mov_b32_e32 v0, s0
+; GFX12-NEXT:    s_setpc_b64 s[30:31]
+    %x = call <1 x i32> @llvm.fptoui.sat.v1f32.v1i32(<1 x float> %f)
+    ret <1 x i32> %x
+}
+
+define <2 x i32> @test_s_unsigned_v2f32_v2i32(<2 x float> inreg %f) {
+; GFX7-LABEL: test_s_unsigned_v2f32_v2i32:
+; GFX7:       ; %bb.0:
+; GFX7-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-NEXT:    v_cvt_u32_f32_e32 v0, s16
+; GFX7-NEXT:    v_cvt_u32_f32_e32 v1, s17
+; GFX7-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX9-LABEL: test_s_unsigned_v2f32_v2i32:
+; GFX9:       ; %bb.0:
+; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    v_cvt_u32_f32_e32 v0, s16
+; GFX9-NEXT:    v_cvt_u32_f32_e32 v1, s17
+; GFX9-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11-LABEL: test_s_unsigned_v2f32_v2i32:
+; GFX11:       ; %bb.0:
+; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-NEXT:    v_cvt_u32_f32_e32 v0, s0
+; GFX11-NEXT:    v_cvt_u32_f32_e32 v1, s1
+; GFX11-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-LABEL: test_s_unsigned_v2f32_v2i32:
+; GFX12:       ; %bb.0:
+; GFX12-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-NEXT:    s_wait_expcnt 0x0
+; GFX12-NEXT:    s_wait_samplecnt 0x0
+; GFX12-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-NEXT:    s_wait_kmcnt 0x0
+; GFX12-NEXT:    s_cvt_u32_f32 s0, s0
+; GFX12-NEXT:    s_cvt_u32_f32 s1, s1
+; GFX12-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
+; GFX12-NEXT:    s_setpc_b64 s[30:31]
+    %x = call <2 x i32> @llvm.fptoui.sat.v2f32.v2i32(<2 x float> %f)
+    ret <2 x i32> %x
+}
+
+define <3 x i32> @test_s_unsigned_v3f32_v3i32(<3 x float> inreg %f) {
+; GFX7-LABEL: test_s_unsigned_v3f32_v3i32:
+; GFX7:       ; %bb.0:
+; GFX7-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-NEXT:    v_cvt_u32_f32_e32 v0, s16
+; GFX7-NEXT:    v_cvt_u32_f32_e32 v1, s17
+; GFX7-NEXT:    v_cvt_u32_f32_e32 v2, s18
+; GFX7-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX9-LABEL: test_s_unsigned_v3f32_v3i32:
+; GFX9:       ; %bb.0:
+; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    v_cvt_u32_f32_e32 v0, s16
+; GFX9-NEXT:    v_cvt_u32_f32_e32 v1, s17
+; GFX9-NEXT:    v_cvt_u32_f32_e32 v2, s18
+; GFX9-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11-LABEL: test_s_unsigned_v3f32_v3i32:
+; GFX11:       ; %bb.0:
+; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-NEXT:    v_cvt_u32_f32_e32 v0, s0
+; GFX11-NEXT:    v_cvt_u32_f32_e32 v1, s1
+; GFX11-NEXT:    v_cvt_u32_f32_e32 v2, s2
+; GFX11-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-LABEL: test_s_unsigned_v3f32_v3i32:
+; GFX12:       ; %bb.0:
+; GFX12-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-NEXT:    s_wait_expcnt 0x0
+; GFX12-NEXT:    s_wait_samplecnt 0x0
+; GFX12-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-NEXT:    s_wait_kmcnt 0x0
+; GFX12-NEXT:    s_cvt_u32_f32 s0, s0
+; GFX12-NEXT:    s_cvt_u32_f32 s1, s1
+; GFX12-NEXT:    s_cvt_u32_f32 s2, s2
+; GFX12-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
+; GFX12-NEXT:    v_mov_b32_e32 v2, s2
+; GFX12-NEXT:    s_setpc_b64 s[30:31]
+    %x = call <3 x i32> @llvm.fptoui.sat.v3f32.v3i32(<3 x float> %f)
+    ret <3 x i32> %x
+}
+
+define <4 x i32> @test_s_unsigned_v4f32_v4i32(<4 x float> inreg %f) {
+; GFX7-LABEL: test_s_unsigned_v4f32_v4i32:
+; GFX7:       ; %bb.0:
+; GFX7-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-NEXT:    v_cvt_u32_f32_e32 v0, s16
+; GFX7-NEXT:    v_cvt_u32_f32_e32 v1, s17
+; GFX7-NEXT:    v_cvt_u32_f32_e32 v2, s18
+; GFX7-NEXT:    v_cvt_u32_f32_e32 v3, s19
+; GFX7-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX9-LABEL: test_s_unsigned_v4f32_v4i32:
+; GFX9:       ; %bb.0:
+; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    v_cvt_u32_f32_e32 v0, s16
+; GFX9-NEXT:    v_cvt_u32_f32_e32 v1, s17
+; GFX9-NEXT:    v_cvt_u32_f32_e32 v2, s18
+; GFX9-NEXT:    v_cvt_u32_f32_e32 v3, s19
+; GFX9-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11-LABEL: test_s_unsigned_v4f32_v4i32:
+; GFX11:       ; %bb.0:
+; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-NEXT:    v_cvt_u32_f32_e32 v0, s0
+; GFX11-NEXT:    v_cvt_u32_f32_e32 v1, s1
+; GFX11-NEXT:    v_cvt_u32_f32_e32 v2, s2
+; GFX11-NEXT:    v_cvt_u32_f32_e32 v3, s3
+; GFX11-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-LABEL: test_s_unsigned_v4f32_v4i32:
+; GFX12:       ; %bb.0:
+; GFX12-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-NEXT:    s_wait_expcnt 0x0
+; GFX12-NEXT:    s_wait_samplecnt 0x0
+; GFX12-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-NEXT:    s_wait_kmcnt 0x0
+; GFX12-NEXT:    s_cvt_u32_f32 s0, s0
+; GFX12-NEXT:    s_cvt_u32_f32 s1, s1
+; GFX12-NEXT:    s_cvt_u32_f32 s2, s2
+; GFX12-NEXT:    s_cvt_u32_f32 s3, s3
+; GFX12-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
+; GFX12-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s3
+; GFX12-NEXT:    s_setpc_b64 s[30:31]
+    %x = call <4 x i32> @llvm.fptoui.sat.v4f32.v4i32(<4 x float> %f)
+    ret <4 x i32> %x
+}
+
+define <5 x i32> @test_s_unsigned_v5f32_v5i32(<5 x float> inreg %f) {
+; GFX7-LABEL: test_s_unsigned_v5f32_v5i32:
+; GFX7:       ; %bb.0:
+; GFX7-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-NEXT:    v_cvt_u32_f32_e32 v0, s16
+; GFX7-NEXT:    v_cvt_u32_f32_e32 v1, s17
+; GFX7-NEXT:    v_cvt_u32_f32_e32 v2, s18
+; GFX7-NEXT:    v_cvt_u32_f32_e32 v3, s19
+; GFX7-NEXT:    v_cvt_u32_f32_e32 v4, s20
+; GFX7-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX9-LABEL: test_s_unsigned_v5f32_v5i32:
+; GFX9:       ; %bb.0:
+; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    v_cvt_u32_f32_e32 v0, s16
+; GFX9-NEXT:    v_cvt_u32_f32_e32 v1, s17
+; GFX9-NEXT:    v_cvt_u32_f32_e32 v2, s18
+; GFX9-NEXT:    v_cvt_u32_f32_e32 v3, s19
+; GFX9-NEXT:    v_cvt_u32_f32_e32 v4, s20
+; GFX9-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11-LABEL: test_s_unsigned_v5f32_v5i32:
+; GFX11:       ; %bb.0:
+; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-NEXT:    v_cvt_u32_f32_e32 v0, s0
+; GFX11-NEXT:    v_cvt_u32_f32_e32 v1, s1
+; GFX11-NEXT:    v_cvt_u32_f32_e32 v2, s2
+; GFX11-NEXT:    v_cvt_u32_f32_e32 v3, s3
+; GFX11-NEXT:    v_cvt_u32_f32_e32 v4, s16
+; GFX11-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-LABEL: test_s_unsigned_v5f32_v5i32:
+; GFX12:       ; %bb.0:
+; GFX12-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-NEXT:    s_wait_expcnt 0x0
+; GFX12-NEXT:    s_wait_samplecnt 0x0
+; GFX12-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-NEXT:    s_wait_kmcnt 0x0
+; GFX12-NEXT:    s_cvt_u32_f32 s0, s0
+; GFX12-NEXT:    s_cvt_u32_f32 s1, s1
+; GFX12-NEXT:    s_cvt_u32_f32 s2, s2
+; GFX12-NEXT:    s_cvt_u32_f32 s3, s3
+; GFX12-NEXT:    s_cvt_u32_f32 s4, s16
+; GFX12-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
+; GFX12-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s3
+; GFX12-NEXT:    v_mov_b32_e32 v4, s4
+; GFX12-NEXT:    s_setpc_b64 s[30:31]
+    %x = call <5 x i32> @llvm.fptoui.sat.v5f32.v5i32(<5 x float> %f)
+    ret <5 x i32> %x
+}
+
+define <6 x i32> @test_s_unsigned_v6f32_v6i32(<6 x float> inreg %f) {
+; GFX7-LABEL: test_s_unsigned_v6f32_v6i32:
+; GFX7:       ; %bb.0:
+; GFX7-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-NEXT:    v_cvt_u32_f32_e32 v0, s16
+; GFX7-NEXT:    v_cvt_u32_f32_e32 v1, s17
+; GFX7-NEXT:    v_cvt_u32_f32_e32 v2, s18
+; GFX7-NEXT:    v_cvt_u32_f32_e32 v3, s19
+; GFX7-NEXT:    v_cvt_u32_f32_e32 v4, s20
+; GFX7-NEXT:    v_cvt_u32_f32_e32 v5, s21
+; GFX7-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX9-LABEL: test_s_unsigned_v6f32_v6i32:
+; GFX9:       ; %bb.0:
+; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    v_cvt_u32_f32_e32 v0, s16
+; GFX9-NEXT:    v_cvt_u32_f32_e32 v1, s17
+; GFX9-NEXT:    v_cvt_u32_f32_e32 v2, s18
+; GFX9-NEXT:    v_cvt_u32_f32_e32 v3, s19
+; GFX9-NEXT:    v_cvt_u32_f32_e32 v4, s20
+; GFX9-NEXT:    v_cvt_u32_f32_e32 v5, s21
+; GFX9-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11-LABEL: test_s_unsigned_v6f32_v6i32:
+; GFX11:       ; %bb.0:
+; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-NEXT:    v_cvt_u32_f32_e32 v0, s0
+; GFX11-NEXT:    v_cvt_u32_f32_e32 v1, s1
+; GFX11-NEXT:    v_cvt_u32_f32_e32 v2, s2
+; GFX11-NEXT:    v_cvt_u32_f32_e32 v3, s3
+; GFX11-NEXT:    v_cvt_u32_f32_e32 v4, s16
+; GFX11-NEXT:    v_cvt_u32_f32_e32 v5, s17
+; GFX11-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-LABEL: test_s_unsigned_v6f32_v6i32:
+; GFX12:       ; %bb.0:
+; GFX12-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-NEXT:    s_wait_expcnt 0x0
+; GFX12-NEXT:    s_wait_samplecnt 0x0
+; GFX12-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-NEXT:    s_wait_kmcnt 0x0
+; GFX12-NEXT:    s_cvt_u32_f32 s0, s0
+; GFX12-NEXT:    s_cvt_u32_f32 s1, s1
+; GFX12-NEXT:    s_cvt_u32_f32 s2, s2
+; GFX12-NEXT:    s_cvt_u32_f32 s3, s3
+; GFX12-NEXT:    s_cvt_u32_f32 s4, s16
+; GFX12-NEXT:    s_cvt_u32_f32 s5, s17
+; GFX12-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
+; GFX12-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s3
+; GFX12-NEXT:    v_dual_mov_b32 v4, s4 :: v_dual_mov_b32 v5, s5
+; GFX12-NEXT:    s_setpc_b64 s[30:31]
+    %x = call <6 x i32> @llvm.fptoui.sat.v6f32.v6i32(<6 x float> %f)
+    ret <6 x i32> %x
+}
+
+define <7 x i32> @test_s_unsigned_v7f32_v7i32(<7 x float> inreg %f) {
+; GFX7-LABEL: test_s_unsigned_v7f32_v7i32:
+; GFX7:       ; %bb.0:
+; GFX7-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-NEXT:    v_cvt_u32_f32_e32 v0, s16
+; GFX7-NEXT:    v_cvt_u32_f32_e32 v1, s17
+; GFX7-NEXT:    v_cvt_u32_f32_e32 v2, s18
+; GFX7-NEXT:    v_cvt_u32_f32_e32 v3, s19
+; GFX7-NEXT:    v_cvt_u32_f32_e32 v4, s20
+; GFX7-NEXT:    v_cvt_u32_f32_e32 v5, s21
+; GFX7-NEXT:    v_cvt_u32_f32_e32 v6, s22
+; GFX7-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX9-LABEL: test_s_unsigned_v7f32_v7i32:
+; GFX9:       ; %bb.0:
+; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    v_cvt_u32_f32_e32 v0, s16
+; GFX9-NEXT:    v_cvt_u32_f32_e32 v1, s17
+; GFX9-NEXT:    v_cvt_u32_f32_e32 v2, s18
+; GFX9-NEXT:    v_cvt_u32_f32_e32 v3, s19
+; GFX9-NEXT:    v_cvt_u32_f32_e32 v4, s20
+; GFX9-NEXT:    v_cvt_u32_f32_e32 v5, s21
+; GFX9-NEXT:    v_cvt_u32_f32_e32 v6, s22
+; GFX9-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11-LABEL: test_s_unsigned_v7f32_v7i32:
+; GFX11:       ; %bb.0:
+; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-NEXT:    v_cvt_u32_f32_e32 v0, s0
+; GFX11-NEXT:    v_cvt_u32_f32_e32 v1, s1
+; GFX11-NEXT:    v_cvt_u32_f32_e32 v2, s2
+; GFX11-NEXT:    v_cvt_u32_f32_e32 v3, s3
+; GFX11-NEXT:    v_cvt_u32_f32_e32 v4, s16
+; GFX11-NEXT:    v_cvt_u32_f32_e32 v5, s17
+; GFX11-NEXT:    v_cvt_u32_f32_e32 v6, s18
+; GFX11-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-LABEL: test_s_unsigned_v7f32_v7i32:
+; GFX12:       ; %bb.0:
+; GFX12-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-NEXT:    s_wait_expcnt 0x0
+; GFX12-NEXT:    s_wait_samplecnt 0x0
+; GFX12-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-NEXT:    s_wait_kmcnt 0x0
+; GFX12-NEXT:    s_cvt_u32_f32 s0, s0
+; GFX12-NEXT:    s_cvt_u32_f32 s1, s1
+; GFX12-NEXT:    s_cvt_u32_f32 s2, s2
+; GFX12-NEXT:    s_cvt_u32_f32 s3, s3
+; GFX12-NEXT:    s_cvt_u32_f32 s4, s16
+; GFX12-NEXT:    s_cvt_u32_f32 s5, s17
+; GFX12-NEXT:    s_cvt_u32_f32 s6, s18
+; GFX12-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
+; GFX12-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s3
+; GFX12-NEXT:    v_dual_mov_b32 v4, s4 :: v_dual_mov_b32 v5, s5
+; GFX12-NEXT:    v_mov_b32_e32 v6, s6
+; GFX12-NEXT:    s_setpc_b64 s[30:31]
+    %x = call <7 x i32> @llvm.fptoui.sat.v7f32.v7i32(<7 x float> %f)
+    ret <7 x i32> %x
+}
+
+define <8 x i32> @test_s_unsigned_v8f32_v8i32(<8 x float> inreg %f) {
+; GFX7-LABEL: test_s_unsigned_v8f32_v8i32:
+; GFX7:       ; %bb.0:
+; GFX7-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-NEXT:    v_cvt_u32_f32_e32 v0, s16
+; GFX7-NEXT:    v_cvt_u32_f32_e32 v1, s17
+; GFX7-NEXT:    v_cvt_u32_f32_e32 v2, s18
+; GFX7-NEXT:    v_cvt_u32_f32_e32 v3, s19
+; GFX7-NEXT:    v_cvt_u32_f32_e32 v4, s20
+; GFX7-NEXT:    v_cvt_u32_f32_e32 v5, s21
+; GFX7-NEXT:    v_cvt_u32_f32_e32 v6, s22
+; GFX7-NEXT:    v_cvt_u32_f32_e32 v7, s23
+; GFX7-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX9-LABEL: test_s_unsigned_v8f32_v8i32:
+; GFX9:       ; %bb.0:
+; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    v_cvt_u32_f32_e32 v0, s16
+; GFX9-NEXT:    v_cvt_u32_f32_e32 v1, s17
+; GFX9-NEXT:    v_cvt_u32_f32_e32 v2, s18
+; GFX9-NEXT:    v_cvt_u32_f32_e32 v3, s19
+; GFX9-NEXT:    v_cvt_u32_f32_e32 v4, s20
+; GFX9-NEXT:    v_cvt_u32_f32_e32 v5, s21
+; GFX9-NEXT:    v_cvt_u32_f32_e32 v6, s22
+; GFX9-NEXT:    v_cvt_u32_f32_e32 v7, s23
+; GFX9-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11-LABEL: test_s_unsigned_v8f32_v8i32:
+; GFX11:       ; %bb.0:
+; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-NEXT:    v_cvt_u32_f32_e32 v0, s0
+; GFX11-NEXT:    v_cvt_u32_f32_e32 v1, s1
+; GFX11-NEXT:    v_cvt_u32_f32_e32 v2, s2
+; GFX11-NEXT:    v_cvt_u32_f32_e32 v3, s3
+; GFX11-NEXT:    v_cvt_u32_f32_e32 v4, s16
+; GFX11-NEXT:    v_cvt_u32_f32_e32 v5, s17
+; GFX11-NEXT:    v_cvt_u32_f32_e32 v6, s18
+; GFX11-NEXT:    v_cvt_u32_f32_e32 v7, s19
+; GFX11-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-LABEL: test_s_unsigned_v8f32_v8i32:
+; GFX12:       ; %bb.0:
+; GFX12-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-NEXT:    s_wait_expcnt 0x0
+; GFX12-NEXT:    s_wait_samplecnt 0x0
+; GFX12-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-NEXT:    s_wait_kmcnt 0x0
+; GFX12-NEXT:    s_cvt_u32_f32 s0, s0
+; GFX12-NEXT:    s_cvt_u32_f32 s1, s1
+; GFX12-NEXT:    s_cvt_u32_f32 s2, s2
+; GFX12-NEXT:    s_cvt_u32_f32 s3, s3
+; GFX12-NEXT:    s_cvt_u32_f32 s4, s16
+; GFX12-NEXT:    s_cvt_u32_f32 s5, s17
+; GFX12-NEXT:    s_cvt_u32_f32 s6, s18
+; GFX12-NEXT:    s_cvt_u32_f32 s7, s19
+; GFX12-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
+; GFX12-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s3
+; GFX12-NEXT:    v_dual_mov_b32 v4, s4 :: v_dual_mov_b32 v5, s5
+; GFX12-NEXT:    v_dual_mov_b32 v6, s6 :: v_dual_mov_b32 v7, s7
+; GFX12-NEXT:    s_setpc_b64 s[30:31]
+    %x = call <8 x i32> @llvm.fptoui.sat.v8f32.v8i32(<8 x float> %f)
+    ret <8 x i32> %x
+}
+
 ;
 ; Double to unsigned 32-bit -- Vector size variation
 ;
@@ -647,6 +1043,258 @@ define <6 x i32> @test_unsigned_v6f64_v6i32(<6 x double> %f) {
 ; GFX12-NEXT:    v_cvt_u32_f64_e32 v3, v[6:7]
 ; GFX12-NEXT:    v_cvt_u32_f64_e32 v4, v[8:9]
 ; GFX12-NEXT:    v_cvt_u32_f64_e32 v5, v[10:11]
+; GFX12-NEXT:    s_setpc_b64 s[30:31]
+    %x = call <6 x i32> @llvm.fptoui.sat.v6f64.v6i32(<6 x double> %f)
+    ret <6 x i32> %x
+}
+
+define <1 x i32> @test_s_unsigned_v1f64_v1i32(<1 x double> inreg %f) {
+; GFX7-LABEL: test_s_unsigned_v1f64_v1i32:
+; GFX7:       ; %bb.0:
+; GFX7-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-NEXT:    v_cvt_u32_f64_e32 v0, s[16:17]
+; GFX7-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX9-LABEL: test_s_unsigned_v1f64_v1i32:
+; GFX9:       ; %bb.0:
+; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    v_cvt_u32_f64_e32 v0, s[16:17]
+; GFX9-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11-LABEL: test_s_unsigned_v1f64_v1i32:
+; GFX11:       ; %bb.0:
+; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-NEXT:    v_cvt_u32_f64_e32 v0, s[0:1]
+; GFX11-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-LABEL: test_s_unsigned_v1f64_v1i32:
+; GFX12:       ; %bb.0:
+; GFX12-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-NEXT:    s_wait_expcnt 0x0
+; GFX12-NEXT:    s_wait_samplecnt 0x0
+; GFX12-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-NEXT:    s_wait_kmcnt 0x0
+; GFX12-NEXT:    v_cvt_u32_f64_e32 v0, s[0:1]
+; GFX12-NEXT:    s_setpc_b64 s[30:31]
+    %x = call <1 x i32> @llvm.fptoui.sat.v1f64.v1i32(<1 x double> %f)
+    ret <1 x i32> %x
+}
+
+define <2 x i32> @test_s_unsigned_v2f64_v2i32(<2 x double> inreg %f) {
+; GFX7-LABEL: test_s_unsigned_v2f64_v2i32:
+; GFX7:       ; %bb.0:
+; GFX7-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-NEXT:    v_cvt_u32_f64_e32 v0, s[16:17]
+; GFX7-NEXT:    v_cvt_u32_f64_e32 v1, s[18:19]
+; GFX7-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX9-LABEL: test_s_unsigned_v2f64_v2i32:
+; GFX9:       ; %bb.0:
+; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    v_cvt_u32_f64_e32 v0, s[16:17]
+; GFX9-NEXT:    v_cvt_u32_f64_e32 v1, s[18:19]
+; GFX9-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11-LABEL: test_s_unsigned_v2f64_v2i32:
+; GFX11:       ; %bb.0:
+; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-NEXT:    v_cvt_u32_f64_e32 v0, s[0:1]
+; GFX11-NEXT:    v_cvt_u32_f64_e32 v1, s[2:3]
+; GFX11-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-LABEL: test_s_unsigned_v2f64_v2i32:
+; GFX12:       ; %bb.0:
+; GFX12-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-NEXT:    s_wait_expcnt 0x0
+; GFX12-NEXT:    s_wait_samplecnt 0x0
+; GFX12-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-NEXT:    s_wait_kmcnt 0x0
+; GFX12-NEXT:    v_cvt_u32_f64_e32 v0, s[0:1]
+; GFX12-NEXT:    v_cvt_u32_f64_e32 v1, s[2:3]
+; GFX12-NEXT:    s_setpc_b64 s[30:31]
+    %x = call <2 x i32> @llvm.fptoui.sat.v2f64.v2i32(<2 x double> %f)
+    ret <2 x i32> %x
+}
+
+define <3 x i32> @test_s_unsigned_v3f64_v3i32(<3 x double> inreg %f) {
+; GFX7-LABEL: test_s_unsigned_v3f64_v3i32:
+; GFX7:       ; %bb.0:
+; GFX7-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-NEXT:    v_cvt_u32_f64_e32 v0, s[16:17]
+; GFX7-NEXT:    v_cvt_u32_f64_e32 v1, s[18:19]
+; GFX7-NEXT:    v_cvt_u32_f64_e32 v2, s[20:21]
+; GFX7-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX9-LABEL: test_s_unsigned_v3f64_v3i32:
+; GFX9:       ; %bb.0:
+; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    v_cvt_u32_f64_e32 v0, s[16:17]
+; GFX9-NEXT:    v_cvt_u32_f64_e32 v1, s[18:19]
+; GFX9-NEXT:    v_cvt_u32_f64_e32 v2, s[20:21]
+; GFX9-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11-LABEL: test_s_unsigned_v3f64_v3i32:
+; GFX11:       ; %bb.0:
+; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-NEXT:    v_cvt_u32_f64_e32 v0, s[0:1]
+; GFX11-NEXT:    v_cvt_u32_f64_e32 v1, s[2:3]
+; GFX11-NEXT:    v_cvt_u32_f64_e32 v2, s[16:17]
+; GFX11-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-LABEL: test_s_unsigned_v3f64_v3i32:
+; GFX12:       ; %bb.0:
+; GFX12-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-NEXT:    s_wait_expcnt 0x0
+; GFX12-NEXT:    s_wait_samplecnt 0x0
+; GFX12-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-NEXT:    s_wait_kmcnt 0x0
+; GFX12-NEXT:    v_cvt_u32_f64_e32 v0, s[0:1]
+; GFX12-NEXT:    v_cvt_u32_f64_e32 v1, s[2:3]
+; GFX12-NEXT:    v_cvt_u32_f64_e32 v2, s[16:17]
+; GFX12-NEXT:    s_setpc_b64 s[30:31]
+    %x = call <3 x i32> @llvm.fptoui.sat.v3f64.v3i32(<3 x double> %f)
+    ret <3 x i32> %x
+}
+
+define <4 x i32> @test_s_unsigned_v4f64_v4i32(<4 x double> inreg %f) {
+; GFX7-LABEL: test_s_unsigned_v4f64_v4i32:
+; GFX7:       ; %bb.0:
+; GFX7-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-NEXT:    v_cvt_u32_f64_e32 v0, s[16:17]
+; GFX7-NEXT:    v_cvt_u32_f64_e32 v1, s[18:19]
+; GFX7-NEXT:    v_cvt_u32_f64_e32 v2, s[20:21]
+; GFX7-NEXT:    v_cvt_u32_f64_e32 v3, s[22:23]
+; GFX7-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX9-LABEL: test_s_unsigned_v4f64_v4i32:
+; GFX9:       ; %bb.0:
+; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    v_cvt_u32_f64_e32 v0, s[16:17]
+; GFX9-NEXT:    v_cvt_u32_f64_e32 v1, s[18:19]
+; GFX9-NEXT:    v_cvt_u32_f64_e32 v2, s[20:21]
+; GFX9-NEXT:    v_cvt_u32_f64_e32 v3, s[22:23]
+; GFX9-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11-LABEL: test_s_unsigned_v4f64_v4i32:
+; GFX11:       ; %bb.0:
+; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-NEXT:    v_cvt_u32_f64_e32 v0, s[0:1]
+; GFX11-NEXT:    v_cvt_u32_f64_e32 v1, s[2:3]
+; GFX11-NEXT:    v_cvt_u32_f64_e32 v2, s[16:17]
+; GFX11-NEXT:    v_cvt_u32_f64_e32 v3, s[18:19]
+; GFX11-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-LABEL: test_s_unsigned_v4f64_v4i32:
+; GFX12:       ; %bb.0:
+; GFX12-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-NEXT:    s_wait_expcnt 0x0
+; GFX12-NEXT:    s_wait_samplecnt 0x0
+; GFX12-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-NEXT:    s_wait_kmcnt 0x0
+; GFX12-NEXT:    v_cvt_u32_f64_e32 v0, s[0:1]
+; GFX12-NEXT:    v_cvt_u32_f64_e32 v1, s[2:3]
+; GFX12-NEXT:    v_cvt_u32_f64_e32 v2, s[16:17]
+; GFX12-NEXT:    v_cvt_u32_f64_e32 v3, s[18:19]
+; GFX12-NEXT:    s_setpc_b64 s[30:31]
+    %x = call <4 x i32> @llvm.fptoui.sat.v4f64.v4i32(<4 x double> %f)
+    ret <4 x i32> %x
+}
+
+define <5 x i32> @test_s_unsigned_v5f64_v5i32(<5 x double> inreg %f) {
+; GFX7-LABEL: test_s_unsigned_v5f64_v5i32:
+; GFX7:       ; %bb.0:
+; GFX7-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-NEXT:    v_cvt_u32_f64_e32 v0, s[16:17]
+; GFX7-NEXT:    v_cvt_u32_f64_e32 v1, s[18:19]
+; GFX7-NEXT:    v_cvt_u32_f64_e32 v2, s[20:21]
+; GFX7-NEXT:    v_cvt_u32_f64_e32 v3, s[22:23]
+; GFX7-NEXT:    v_cvt_u32_f64_e32 v4, s[24:25]
+; GFX7-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX9-LABEL: test_s_unsigned_v5f64_v5i32:
+; GFX9:       ; %bb.0:
+; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    v_cvt_u32_f64_e32 v0, s[16:17]
+; GFX9-NEXT:    v_cvt_u32_f64_e32 v1, s[18:19]
+; GFX9-NEXT:    v_cvt_u32_f64_e32 v2, s[20:21]
+; GFX9-NEXT:    v_cvt_u32_f64_e32 v3, s[22:23]
+; GFX9-NEXT:    v_cvt_u32_f64_e32 v4, s[24:25]
+; GFX9-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11-LABEL: test_s_unsigned_v5f64_v5i32:
+; GFX11:       ; %bb.0:
+; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-NEXT:    v_cvt_u32_f64_e32 v0, s[0:1]
+; GFX11-NEXT:    v_cvt_u32_f64_e32 v1, s[2:3]
+; GFX11-NEXT:    v_cvt_u32_f64_e32 v2, s[16:17]
+; GFX11-NEXT:    v_cvt_u32_f64_e32 v3, s[18:19]
+; GFX11-NEXT:    v_cvt_u32_f64_e32 v4, s[20:21]
+; GFX11-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-LABEL: test_s_unsigned_v5f64_v5i32:
+; GFX12:       ; %bb.0:
+; GFX12-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-NEXT:    s_wait_expcnt 0x0
+; GFX12-NEXT:    s_wait_samplecnt 0x0
+; GFX12-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-NEXT:    s_wait_kmcnt 0x0
+; GFX12-NEXT:    v_cvt_u32_f64_e32 v0, s[0:1]
+; GFX12-NEXT:    v_cvt_u32_f64_e32 v1, s[2:3]
+; GFX12-NEXT:    v_cvt_u32_f64_e32 v2, s[16:17]
+; GFX12-NEXT:    v_cvt_u32_f64_e32 v3, s[18:19]
+; GFX12-NEXT:    v_cvt_u32_f64_e32 v4, s[20:21]
+; GFX12-NEXT:    s_setpc_b64 s[30:31]
+    %x = call <5 x i32> @llvm.fptoui.sat.v5f64.v5i32(<5 x double> %f)
+    ret <5 x i32> %x
+}
+
+define <6 x i32> @test_s_unsigned_v6f64_v6i32(<6 x double> inreg %f) {
+; GFX7-LABEL: test_s_unsigned_v6f64_v6i32:
+; GFX7:       ; %bb.0:
+; GFX7-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-NEXT:    v_cvt_u32_f64_e32 v0, s[16:17]
+; GFX7-NEXT:    v_cvt_u32_f64_e32 v1, s[18:19]
+; GFX7-NEXT:    v_cvt_u32_f64_e32 v2, s[20:21]
+; GFX7-NEXT:    v_cvt_u32_f64_e32 v3, s[22:23]
+; GFX7-NEXT:    v_cvt_u32_f64_e32 v4, s[24:25]
+; GFX7-NEXT:    v_cvt_u32_f64_e32 v5, s[26:27]
+; GFX7-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX9-LABEL: test_s_unsigned_v6f64_v6i32:
+; GFX9:       ; %bb.0:
+; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    v_cvt_u32_f64_e32 v0, s[16:17]
+; GFX9-NEXT:    v_cvt_u32_f64_e32 v1, s[18:19]
+; GFX9-NEXT:    v_cvt_u32_f64_e32 v2, s[20:21]
+; GFX9-NEXT:    v_cvt_u32_f64_e32 v3, s[22:23]
+; GFX9-NEXT:    v_cvt_u32_f64_e32 v4, s[24:25]
+; GFX9-NEXT:    v_cvt_u32_f64_e32 v5, s[26:27]
+; GFX9-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11-LABEL: test_s_unsigned_v6f64_v6i32:
+; GFX11:       ; %bb.0:
+; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-NEXT:    v_cvt_u32_f64_e32 v0, s[0:1]
+; GFX11-NEXT:    v_cvt_u32_f64_e32 v1, s[2:3]
+; GFX11-NEXT:    v_cvt_u32_f64_e32 v2, s[16:17]
+; GFX11-NEXT:    v_cvt_u32_f64_e32 v3, s[18:19]
+; GFX11-NEXT:    v_cvt_u32_f64_e32 v4, s[20:21]
+; GFX11-NEXT:    v_cvt_u32_f64_e32 v5, s[22:23]
+; GFX11-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-LABEL: test_s_unsigned_v6f64_v6i32:
+; GFX12:       ; %bb.0:
+; GFX12-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-NEXT:    s_wait_expcnt 0x0
+; GFX12-NEXT:    s_wait_samplecnt 0x0
+; GFX12-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-NEXT:    s_wait_kmcnt 0x0
+; GFX12-NEXT:    v_cvt_u32_f64_e32 v0, s[0:1]
+; GFX12-NEXT:    v_cvt_u32_f64_e32 v1, s[2:3]
+; GFX12-NEXT:    v_cvt_u32_f64_e32 v2, s[16:17]
+; GFX12-NEXT:    v_cvt_u32_f64_e32 v3, s[18:19]
+; GFX12-NEXT:    v_cvt_u32_f64_e32 v4, s[20:21]
+; GFX12-NEXT:    v_cvt_u32_f64_e32 v5, s[22:23]
 ; GFX12-NEXT:    s_setpc_b64 s[30:31]
     %x = call <6 x i32> @llvm.fptoui.sat.v6f64.v6i32(<6 x double> %f)
     ret <6 x i32> %x
@@ -1137,6 +1785,430 @@ define <2 x i64> @test_unsigned_v2f64_v2i64(<2 x double> %f) {
 ; GFX12-GI-NEXT:    v_cndmask_b32_e64 v2, v1, -1, s2
 ; GFX12-GI-NEXT:    v_cndmask_b32_e64 v1, v3, -1, s1
 ; GFX12-GI-NEXT:    v_cndmask_b32_e64 v3, v4, -1, s2
+; GFX12-GI-NEXT:    s_setpc_b64 s[30:31]
+    %x = call <2 x i64> @llvm.fptoui.sat.v2f64.v2i64(<2 x double> %f)
+    ret <2 x i64> %x
+}
+
+define <2 x i1> @test_s_unsigned_v2f64_v2i1(<2 x double> inreg %f) {
+; GFX7-LABEL: test_s_unsigned_v2f64_v2i1:
+; GFX7:       ; %bb.0:
+; GFX7-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-NEXT:    v_cvt_u32_f64_e32 v0, s[16:17]
+; GFX7-NEXT:    v_cvt_u32_f64_e32 v1, s[18:19]
+; GFX7-NEXT:    v_min_u32_e32 v0, 1, v0
+; GFX7-NEXT:    v_min_u32_e32 v1, 1, v1
+; GFX7-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX9-LABEL: test_s_unsigned_v2f64_v2i1:
+; GFX9:       ; %bb.0:
+; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    v_cvt_u32_f64_e32 v0, s[18:19]
+; GFX9-NEXT:    v_cvt_u32_f64_e32 v2, s[16:17]
+; GFX9-NEXT:    v_min_u32_e32 v1, 1, v0
+; GFX9-NEXT:    v_min_u32_e32 v0, 1, v2
+; GFX9-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11-LABEL: test_s_unsigned_v2f64_v2i1:
+; GFX11:       ; %bb.0:
+; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-NEXT:    v_cvt_u32_f64_e32 v0, s[0:1]
+; GFX11-NEXT:    v_cvt_u32_f64_e32 v1, s[2:3]
+; GFX11-NEXT:    v_min_u32_e32 v0, 1, v0
+; GFX11-NEXT:    v_min_u32_e32 v1, 1, v1
+; GFX11-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-LABEL: test_s_unsigned_v2f64_v2i1:
+; GFX12:       ; %bb.0:
+; GFX12-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-NEXT:    s_wait_expcnt 0x0
+; GFX12-NEXT:    s_wait_samplecnt 0x0
+; GFX12-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-NEXT:    s_wait_kmcnt 0x0
+; GFX12-NEXT:    v_cvt_u32_f64_e32 v0, s[0:1]
+; GFX12-NEXT:    v_cvt_u32_f64_e32 v1, s[2:3]
+; GFX12-NEXT:    v_min_u32_e32 v0, 1, v0
+; GFX12-NEXT:    v_min_u32_e32 v1, 1, v1
+; GFX12-NEXT:    s_setpc_b64 s[30:31]
+    %x = call <2 x i1> @llvm.fptoui.sat.v2f64.v2i1(<2 x double> %f)
+    ret <2 x i1> %x
+}
+
+define <2 x i8> @test_s_unsigned_v2f64_v2i8(<2 x double> inreg %f) {
+; GFX7-ISEL-LABEL: test_s_unsigned_v2f64_v2i8:
+; GFX7-ISEL:       ; %bb.0:
+; GFX7-ISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-ISEL-NEXT:    v_cvt_u32_f64_e32 v1, s[18:19]
+; GFX7-ISEL-NEXT:    v_cvt_u32_f64_e32 v0, s[16:17]
+; GFX7-ISEL-NEXT:    v_min_u32_e32 v1, 0xff, v1
+; GFX7-ISEL-NEXT:    v_min_u32_e32 v0, 0xff, v0
+; GFX7-ISEL-NEXT:    v_lshlrev_b32_e32 v2, 8, v1
+; GFX7-ISEL-NEXT:    v_or_b32_e32 v0, v0, v2
+; GFX7-ISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX7-GI-LABEL: test_s_unsigned_v2f64_v2i8:
+; GFX7-GI:       ; %bb.0:
+; GFX7-GI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-GI-NEXT:    v_cvt_u32_f64_e32 v0, s[16:17]
+; GFX7-GI-NEXT:    v_cvt_u32_f64_e32 v1, s[18:19]
+; GFX7-GI-NEXT:    v_min_u32_e32 v0, 0xff, v0
+; GFX7-GI-NEXT:    v_min_u32_e32 v1, 0xff, v1
+; GFX7-GI-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX9-LABEL: test_s_unsigned_v2f64_v2i8:
+; GFX9:       ; %bb.0:
+; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    v_cvt_u32_f64_e32 v1, s[18:19]
+; GFX9-NEXT:    v_cvt_u32_f64_e32 v0, s[16:17]
+; GFX9-NEXT:    v_min_u32_e32 v1, 0xff, v1
+; GFX9-NEXT:    v_min_u32_e32 v0, 0xff, v0
+; GFX9-NEXT:    v_lshlrev_b32_e32 v2, 8, v1
+; GFX9-NEXT:    v_or_b32_e32 v0, v0, v2
+; GFX9-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11-LABEL: test_s_unsigned_v2f64_v2i8:
+; GFX11:       ; %bb.0:
+; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-NEXT:    v_cvt_u32_f64_e32 v0, s[2:3]
+; GFX11-NEXT:    v_cvt_u32_f64_e32 v2, s[0:1]
+; GFX11-NEXT:    v_min_u32_e32 v1, 0xff, v0
+; GFX11-NEXT:    v_min_u32_e32 v0, 0xff, v2
+; GFX11-NEXT:    v_lshlrev_b32_e32 v2, 8, v1
+; GFX11-NEXT:    v_or_b32_e32 v0, v0, v2
+; GFX11-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-ISEL-LABEL: test_s_unsigned_v2f64_v2i8:
+; GFX12-ISEL:       ; %bb.0:
+; GFX12-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX12-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX12-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX12-ISEL-NEXT:    v_cvt_u32_f64_e32 v0, s[2:3]
+; GFX12-ISEL-NEXT:    v_cvt_u32_f64_e32 v2, s[0:1]
+; GFX12-ISEL-NEXT:    v_min_u32_e32 v1, 0xff, v0
+; GFX12-ISEL-NEXT:    v_min_u32_e32 v0, 0xff, v2
+; GFX12-ISEL-NEXT:    v_lshlrev_b32_e32 v2, 8, v1
+; GFX12-ISEL-NEXT:    v_or_b32_e32 v0, v0, v2
+; GFX12-ISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-GI-LABEL: test_s_unsigned_v2f64_v2i8:
+; GFX12-GI:       ; %bb.0:
+; GFX12-GI-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-GI-NEXT:    s_wait_expcnt 0x0
+; GFX12-GI-NEXT:    s_wait_samplecnt 0x0
+; GFX12-GI-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-GI-NEXT:    s_wait_kmcnt 0x0
+; GFX12-GI-NEXT:    v_cvt_u32_f64_e32 v0, s[0:1]
+; GFX12-GI-NEXT:    v_cvt_u32_f64_e32 v1, s[2:3]
+; GFX12-GI-NEXT:    v_min_u32_e32 v0, 0xff, v0
+; GFX12-GI-NEXT:    v_min_u32_e32 v1, 0xff, v1
+; GFX12-GI-NEXT:    s_setpc_b64 s[30:31]
+    %x = call <2 x i8> @llvm.fptoui.sat.v2f64.v2i8(<2 x double> %f)
+    ret <2 x i8> %x
+}
+
+define <2 x i16> @test_s_unsigned_v2f64_v2i16(<2 x double> inreg %f) {
+; GFX7-LABEL: test_s_unsigned_v2f64_v2i16:
+; GFX7:       ; %bb.0:
+; GFX7-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-NEXT:    v_cvt_u32_f64_e32 v1, s[18:19]
+; GFX7-NEXT:    v_cvt_u32_f64_e32 v0, s[16:17]
+; GFX7-NEXT:    v_min_u32_e32 v1, 0xffff, v1
+; GFX7-NEXT:    v_min_u32_e32 v0, 0xffff, v0
+; GFX7-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; GFX7-NEXT:    v_or_b32_e32 v0, v0, v1
+; GFX7-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX9-LABEL: test_s_unsigned_v2f64_v2i16:
+; GFX9:       ; %bb.0:
+; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    v_cvt_u32_f64_e32 v1, s[16:17]
+; GFX9-NEXT:    v_cvt_u32_f64_e32 v0, s[18:19]
+; GFX9-NEXT:    v_min_u32_e32 v1, 0xffff, v1
+; GFX9-NEXT:    v_min_u32_e32 v0, 0xffff, v0
+; GFX9-NEXT:    v_and_b32_e32 v1, 0xffff, v1
+; GFX9-NEXT:    v_lshl_or_b32 v0, v0, 16, v1
+; GFX9-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11-FAKE16-LABEL: test_s_unsigned_v2f64_v2i16:
+; GFX11-FAKE16:       ; %bb.0:
+; GFX11-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-FAKE16-NEXT:    v_cvt_u32_f64_e32 v0, s[0:1]
+; GFX11-FAKE16-NEXT:    v_cvt_u32_f64_e32 v1, s[2:3]
+; GFX11-FAKE16-NEXT:    v_min_u32_e32 v0, 0xffff, v0
+; GFX11-FAKE16-NEXT:    v_min_u32_e32 v1, 0xffff, v1
+; GFX11-FAKE16-NEXT:    v_and_b32_e32 v0, 0xffff, v0
+; GFX11-FAKE16-NEXT:    v_lshl_or_b32 v0, v1, 16, v0
+; GFX11-FAKE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11-TRUE16-LABEL: test_s_unsigned_v2f64_v2i16:
+; GFX11-TRUE16:       ; %bb.0:
+; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-TRUE16-NEXT:    v_cvt_u32_f64_e32 v0, s[2:3]
+; GFX11-TRUE16-NEXT:    v_cvt_u32_f64_e32 v1, s[0:1]
+; GFX11-TRUE16-NEXT:    v_min_u32_e32 v2, 0xffff, v0
+; GFX11-TRUE16-NEXT:    v_min_u32_e32 v0, 0xffff, v1
+; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v0.h, v2.l
+; GFX11-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-FAKE16-LABEL: test_s_unsigned_v2f64_v2i16:
+; GFX12-FAKE16:       ; %bb.0:
+; GFX12-FAKE16-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-FAKE16-NEXT:    s_wait_expcnt 0x0
+; GFX12-FAKE16-NEXT:    s_wait_samplecnt 0x0
+; GFX12-FAKE16-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-FAKE16-NEXT:    s_wait_kmcnt 0x0
+; GFX12-FAKE16-NEXT:    v_cvt_u32_f64_e32 v0, s[0:1]
+; GFX12-FAKE16-NEXT:    v_cvt_u32_f64_e32 v1, s[2:3]
+; GFX12-FAKE16-NEXT:    v_min_u32_e32 v0, 0xffff, v0
+; GFX12-FAKE16-NEXT:    v_min_u32_e32 v1, 0xffff, v1
+; GFX12-FAKE16-NEXT:    v_and_b32_e32 v0, 0xffff, v0
+; GFX12-FAKE16-NEXT:    v_lshl_or_b32 v0, v1, 16, v0
+; GFX12-FAKE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-TRUE16-LABEL: test_s_unsigned_v2f64_v2i16:
+; GFX12-TRUE16:       ; %bb.0:
+; GFX12-TRUE16-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-TRUE16-NEXT:    s_wait_expcnt 0x0
+; GFX12-TRUE16-NEXT:    s_wait_samplecnt 0x0
+; GFX12-TRUE16-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-TRUE16-NEXT:    s_wait_kmcnt 0x0
+; GFX12-TRUE16-NEXT:    v_cvt_u32_f64_e32 v0, s[2:3]
+; GFX12-TRUE16-NEXT:    v_cvt_u32_f64_e32 v1, s[0:1]
+; GFX12-TRUE16-NEXT:    v_min_u32_e32 v2, 0xffff, v0
+; GFX12-TRUE16-NEXT:    v_min_u32_e32 v0, 0xffff, v1
+; GFX12-TRUE16-NEXT:    v_mov_b16_e32 v0.h, v2.l
+; GFX12-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-GI-LABEL: test_s_unsigned_v2f64_v2i16:
+; GFX12-GI:       ; %bb.0:
+; GFX12-GI-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-GI-NEXT:    s_wait_expcnt 0x0
+; GFX12-GI-NEXT:    s_wait_samplecnt 0x0
+; GFX12-GI-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-GI-NEXT:    s_wait_kmcnt 0x0
+; GFX12-GI-NEXT:    v_cvt_u32_f64_e32 v0, s[2:3]
+; GFX12-GI-NEXT:    v_cvt_u32_f64_e32 v1, s[0:1]
+; GFX12-GI-NEXT:    v_min_u32_e32 v2, 0xffff, v0
+; GFX12-GI-NEXT:    v_min_u32_e32 v0, 0xffff, v1
+; GFX12-GI-NEXT:    v_mov_b16_e32 v0.h, v2.l
+; GFX12-GI-NEXT:    s_setpc_b64 s[30:31]
+    %x = call <2 x i16> @llvm.fptoui.sat.v2f64.v2i16(<2 x double> %f)
+    ret <2 x i16> %x
+}
+
+define <2 x i64> @test_s_unsigned_v2f64_v2i64(<2 x double> inreg %f) {
+; GFX7-ISEL-LABEL: test_s_unsigned_v2f64_v2i64:
+; GFX7-ISEL:       ; %bb.0:
+; GFX7-ISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-ISEL-NEXT:    v_trunc_f64_e32 v[0:1], s[16:17]
+; GFX7-ISEL-NEXT:    v_trunc_f64_e32 v[2:3], s[18:19]
+; GFX7-ISEL-NEXT:    s_movk_i32 s4, 0xffe0
+; GFX7-ISEL-NEXT:    s_mov_b32 s6, 0
+; GFX7-ISEL-NEXT:    s_mov_b32 s7, 0xc1f00000
+; GFX7-ISEL-NEXT:    v_cmp_nge_f64_e64 s[8:9], s[18:19], 0
+; GFX7-ISEL-NEXT:    v_ldexp_f64 v[4:5], v[0:1], s4
+; GFX7-ISEL-NEXT:    v_ldexp_f64 v[6:7], v[2:3], s4
+; GFX7-ISEL-NEXT:    s_mov_b32 s4, -1
+; GFX7-ISEL-NEXT:    s_mov_b32 s5, 0x43efffff
+; GFX7-ISEL-NEXT:    v_mov_b32_e32 v9, s5
+; GFX7-ISEL-NEXT:    v_mov_b32_e32 v8, s4
+; GFX7-ISEL-NEXT:    v_cmp_gt_f64_e32 vcc, s[16:17], v[8:9]
+; GFX7-ISEL-NEXT:    v_cmp_gt_f64_e64 s[4:5], s[18:19], v[8:9]
+; GFX7-ISEL-NEXT:    v_floor_f64_e32 v[4:5], v[4:5]
+; GFX7-ISEL-NEXT:    v_floor_f64_e32 v[6:7], v[6:7]
+; GFX7-ISEL-NEXT:    v_fma_f64 v[0:1], v[4:5], s[6:7], v[0:1]
+; GFX7-ISEL-NEXT:    v_fma_f64 v[2:3], v[6:7], s[6:7], v[2:3]
+; GFX7-ISEL-NEXT:    v_cmp_nge_f64_e64 s[6:7], s[16:17], 0
+; GFX7-ISEL-NEXT:    v_cvt_u32_f64_e32 v10, v[4:5]
+; GFX7-ISEL-NEXT:    v_cvt_u32_f64_e32 v11, v[6:7]
+; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v5, v11, 0, s[8:9]
+; GFX7-ISEL-NEXT:    v_cvt_u32_f64_e32 v0, v[0:1]
+; GFX7-ISEL-NEXT:    v_cvt_u32_f64_e32 v2, v[2:3]
+; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v4, v10, 0, s[6:7]
+; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v1, v4, -1, vcc
+; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v0, v0, 0, s[6:7]
+; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v2, v2, 0, s[8:9]
+; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v3, v5, -1, s[4:5]
+; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v0, v0, -1, vcc
+; GFX7-ISEL-NEXT:    v_cndmask_b32_e64 v2, v2, -1, s[4:5]
+; GFX7-ISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX7-GI-LABEL: test_s_unsigned_v2f64_v2i64:
+; GFX7-GI:       ; %bb.0:
+; GFX7-GI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-GI-NEXT:    v_trunc_f64_e32 v[0:1], s[16:17]
+; GFX7-GI-NEXT:    v_trunc_f64_e32 v[2:3], s[18:19]
+; GFX7-GI-NEXT:    v_mov_b32_e32 v4, 0
+; GFX7-GI-NEXT:    v_mov_b32_e32 v5, 0x3df00000
+; GFX7-GI-NEXT:    v_mov_b32_e32 v8, 0
+; GFX7-GI-NEXT:    v_mov_b32_e32 v9, 0xc1f00000
+; GFX7-GI-NEXT:    v_cmp_nge_f64_e64 s[6:7], s[16:17], 0
+; GFX7-GI-NEXT:    v_cmp_nge_f64_e64 s[8:9], s[18:19], 0
+; GFX7-GI-NEXT:    v_mul_f64 v[6:7], v[0:1], v[4:5]
+; GFX7-GI-NEXT:    v_mul_f64 v[4:5], v[2:3], v[4:5]
+; GFX7-GI-NEXT:    v_floor_f64_e32 v[6:7], v[6:7]
+; GFX7-GI-NEXT:    v_floor_f64_e32 v[4:5], v[4:5]
+; GFX7-GI-NEXT:    v_fma_f64 v[0:1], v[6:7], v[8:9], v[0:1]
+; GFX7-GI-NEXT:    v_fma_f64 v[2:3], v[4:5], v[8:9], v[2:3]
+; GFX7-GI-NEXT:    v_cvt_u32_f64_e32 v4, v[4:5]
+; GFX7-GI-NEXT:    v_cvt_u32_f64_e32 v8, v[0:1]
+; GFX7-GI-NEXT:    v_mov_b32_e32 v0, -1
+; GFX7-GI-NEXT:    v_mov_b32_e32 v1, 0x43efffff
+; GFX7-GI-NEXT:    v_cmp_gt_f64_e32 vcc, s[16:17], v[0:1]
+; GFX7-GI-NEXT:    v_cmp_gt_f64_e64 s[4:5], s[18:19], v[0:1]
+; GFX7-GI-NEXT:    v_cvt_u32_f64_e32 v2, v[2:3]
+; GFX7-GI-NEXT:    v_cvt_u32_f64_e32 v1, v[6:7]
+; GFX7-GI-NEXT:    v_cndmask_b32_e64 v3, v8, 0, s[6:7]
+; GFX7-GI-NEXT:    v_cndmask_b32_e64 v2, v2, 0, s[8:9]
+; GFX7-GI-NEXT:    v_cndmask_b32_e64 v1, v1, 0, s[6:7]
+; GFX7-GI-NEXT:    v_cndmask_b32_e64 v0, v3, -1, vcc
+; GFX7-GI-NEXT:    v_cndmask_b32_e64 v3, v4, 0, s[8:9]
+; GFX7-GI-NEXT:    v_cndmask_b32_e64 v2, v2, -1, s[4:5]
+; GFX7-GI-NEXT:    v_cndmask_b32_e64 v1, v1, -1, vcc
+; GFX7-GI-NEXT:    v_cndmask_b32_e64 v3, v3, -1, s[4:5]
+; GFX7-GI-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX9-LABEL: test_s_unsigned_v2f64_v2i64:
+; GFX9:       ; %bb.0:
+; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    v_trunc_f64_e32 v[0:1], s[16:17]
+; GFX9-NEXT:    v_trunc_f64_e32 v[2:3], s[18:19]
+; GFX9-NEXT:    s_movk_i32 s4, 0xffe0
+; GFX9-NEXT:    s_mov_b32 s6, 0
+; GFX9-NEXT:    s_mov_b32 s7, 0xc1f00000
+; GFX9-NEXT:    v_cmp_nge_f64_e64 s[8:9], s[18:19], 0
+; GFX9-NEXT:    v_ldexp_f64 v[4:5], v[0:1], s4
+; GFX9-NEXT:    v_ldexp_f64 v[6:7], v[2:3], s4
+; GFX9-NEXT:    s_mov_b32 s4, -1
+; GFX9-NEXT:    s_mov_b32 s5, 0x43efffff
+; GFX9-NEXT:    v_mov_b32_e32 v9, s5
+; GFX9-NEXT:    v_mov_b32_e32 v8, s4
+; GFX9-NEXT:    v_cmp_gt_f64_e32 vcc, s[16:17], v[8:9]
+; GFX9-NEXT:    v_cmp_gt_f64_e64 s[4:5], s[18:19], v[8:9]
+; GFX9-NEXT:    v_floor_f64_e32 v[4:5], v[4:5]
+; GFX9-NEXT:    v_floor_f64_e32 v[6:7], v[6:7]
+; GFX9-NEXT:    v_fma_f64 v[0:1], v[4:5], s[6:7], v[0:1]
+; GFX9-NEXT:    v_fma_f64 v[2:3], v[6:7], s[6:7], v[2:3]
+; GFX9-NEXT:    v_cmp_nge_f64_e64 s[6:7], s[16:17], 0
+; GFX9-NEXT:    v_cvt_u32_f64_e32 v10, v[4:5]
+; GFX9-NEXT:    v_cvt_u32_f64_e32 v11, v[6:7]
+; GFX9-NEXT:    v_cndmask_b32_e64 v5, v11, 0, s[8:9]
+; GFX9-NEXT:    v_cvt_u32_f64_e32 v0, v[0:1]
+; GFX9-NEXT:    v_cvt_u32_f64_e32 v2, v[2:3]
+; GFX9-NEXT:    v_cndmask_b32_e64 v4, v10, 0, s[6:7]
+; GFX9-NEXT:    v_cndmask_b32_e64 v1, v4, -1, vcc
+; GFX9-NEXT:    v_cndmask_b32_e64 v0, v0, 0, s[6:7]
+; GFX9-NEXT:    v_cndmask_b32_e64 v2, v2, 0, s[8:9]
+; GFX9-NEXT:    v_cndmask_b32_e64 v3, v5, -1, s[4:5]
+; GFX9-NEXT:    v_cndmask_b32_e64 v0, v0, -1, vcc
+; GFX9-NEXT:    v_cndmask_b32_e64 v2, v2, -1, s[4:5]
+; GFX9-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11-LABEL: test_s_unsigned_v2f64_v2i64:
+; GFX11:       ; %bb.0:
+; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-NEXT:    v_trunc_f64_e32 v[0:1], s[0:1]
+; GFX11-NEXT:    v_trunc_f64_e32 v[2:3], s[2:3]
+; GFX11-NEXT:    v_cmp_nge_f64_e64 s6, s[0:1], 0
+; GFX11-NEXT:    v_cmp_nge_f64_e64 s7, s[2:3], 0
+; GFX11-NEXT:    s_mov_b32 s4, -1
+; GFX11-NEXT:    s_mov_b32 s5, 0x43efffff
+; GFX11-NEXT:    v_cmp_gt_f64_e64 s0, s[0:1], s[4:5]
+; GFX11-NEXT:    v_cmp_gt_f64_e64 s1, s[2:3], s[4:5]
+; GFX11-NEXT:    v_ldexp_f64 v[4:5], v[0:1], 0xffffffe0
+; GFX11-NEXT:    v_ldexp_f64 v[6:7], v[2:3], 0xffffffe0
+; GFX11-NEXT:    v_floor_f64_e32 v[4:5], v[4:5]
+; GFX11-NEXT:    v_floor_f64_e32 v[6:7], v[6:7]
+; GFX11-NEXT:    v_fma_f64 v[0:1], 0xc1f00000, v[4:5], v[0:1]
+; GFX11-NEXT:    v_fma_f64 v[2:3], 0xc1f00000, v[6:7], v[2:3]
+; GFX11-NEXT:    v_cvt_u32_f64_e32 v4, v[4:5]
+; GFX11-NEXT:    v_cvt_u32_f64_e32 v5, v[6:7]
+; GFX11-NEXT:    v_cvt_u32_f64_e32 v0, v[0:1]
+; GFX11-NEXT:    v_cvt_u32_f64_e32 v1, v[2:3]
+; GFX11-NEXT:    v_cndmask_b32_e64 v2, v4, 0, s6
+; GFX11-NEXT:    v_cndmask_b32_e64 v3, v5, 0, s7
+; GFX11-NEXT:    v_cndmask_b32_e64 v3, v3, -1, s1
+; GFX11-NEXT:    v_cndmask_b32_e64 v0, v0, 0, s6
+; GFX11-NEXT:    v_cndmask_b32_e64 v4, v1, 0, s7
+; GFX11-NEXT:    v_cndmask_b32_e64 v1, v2, -1, s0
+; GFX11-NEXT:    v_cndmask_b32_e64 v0, v0, -1, s0
+; GFX11-NEXT:    v_cndmask_b32_e64 v2, v4, -1, s1
+; GFX11-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-ISEL-LABEL: test_s_unsigned_v2f64_v2i64:
+; GFX12-ISEL:       ; %bb.0:
+; GFX12-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX12-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX12-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX12-ISEL-NEXT:    v_trunc_f64_e32 v[0:1], s[0:1]
+; GFX12-ISEL-NEXT:    v_trunc_f64_e32 v[2:3], s[2:3]
+; GFX12-ISEL-NEXT:    v_cmp_nge_f64_e64 s6, s[0:1], 0
+; GFX12-ISEL-NEXT:    v_cmp_nge_f64_e64 s7, s[2:3], 0
+; GFX12-ISEL-NEXT:    s_mov_b32 s4, -1
+; GFX12-ISEL-NEXT:    s_mov_b32 s5, 0x43efffff
+; GFX12-ISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-ISEL-NEXT:    v_cmp_gt_f64_e64 s0, s[0:1], s[4:5]
+; GFX12-ISEL-NEXT:    v_cmp_gt_f64_e64 s1, s[2:3], s[4:5]
+; GFX12-ISEL-NEXT:    v_ldexp_f64 v[4:5], v[0:1], 0xffffffe0
+; GFX12-ISEL-NEXT:    v_ldexp_f64 v[6:7], v[2:3], 0xffffffe0
+; GFX12-ISEL-NEXT:    v_floor_f64_e32 v[4:5], v[4:5]
+; GFX12-ISEL-NEXT:    v_floor_f64_e32 v[6:7], v[6:7]
+; GFX12-ISEL-NEXT:    v_fma_f64 v[0:1], 0xc1f00000, v[4:5], v[0:1]
+; GFX12-ISEL-NEXT:    v_fma_f64 v[2:3], 0xc1f00000, v[6:7], v[2:3]
+; GFX12-ISEL-NEXT:    v_cvt_u32_f64_e32 v4, v[4:5]
+; GFX12-ISEL-NEXT:    v_cvt_u32_f64_e32 v5, v[6:7]
+; GFX12-ISEL-NEXT:    v_cvt_u32_f64_e32 v0, v[0:1]
+; GFX12-ISEL-NEXT:    v_cvt_u32_f64_e32 v1, v[2:3]
+; GFX12-ISEL-NEXT:    s_wait_alu depctr_va_sdst(0)
+; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v2, v4, 0, s6
+; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v3, v5, 0, s7
+; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v3, v3, -1, s1
+; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v0, v0, 0, s6
+; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v4, v1, 0, s7
+; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v1, v2, -1, s0
+; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v0, v0, -1, s0
+; GFX12-ISEL-NEXT:    v_cndmask_b32_e64 v2, v4, -1, s1
+; GFX12-ISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-GI-LABEL: test_s_unsigned_v2f64_v2i64:
+; GFX12-GI:       ; %bb.0:
+; GFX12-GI-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-GI-NEXT:    s_wait_expcnt 0x0
+; GFX12-GI-NEXT:    s_wait_samplecnt 0x0
+; GFX12-GI-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-GI-NEXT:    s_wait_kmcnt 0x0
+; GFX12-GI-NEXT:    v_trunc_f64_e32 v[0:1], s[0:1]
+; GFX12-GI-NEXT:    v_trunc_f64_e32 v[2:3], s[2:3]
+; GFX12-GI-NEXT:    v_cmp_nge_f64_e64 s4, s[0:1], 0
+; GFX12-GI-NEXT:    v_cmp_nge_f64_e64 s5, s[2:3], 0
+; GFX12-GI-NEXT:    v_mul_f64_e32 v[4:5], 0x3df00000, v[0:1]
+; GFX12-GI-NEXT:    v_mul_f64_e32 v[6:7], 0x3df00000, v[2:3]
+; GFX12-GI-NEXT:    v_floor_f64_e32 v[4:5], v[4:5]
+; GFX12-GI-NEXT:    v_floor_f64_e32 v[6:7], v[6:7]
+; GFX12-GI-NEXT:    v_fma_f64 v[0:1], 0xc1f00000, v[4:5], v[0:1]
+; GFX12-GI-NEXT:    v_fma_f64 v[2:3], 0xc1f00000, v[6:7], v[2:3]
+; GFX12-GI-NEXT:    v_cvt_u32_f64_e32 v8, v[0:1]
+; GFX12-GI-NEXT:    v_mov_b32_e32 v0, -1
+; GFX12-GI-NEXT:    v_cvt_u32_f64_e32 v2, v[2:3]
+; GFX12-GI-NEXT:    v_mov_b32_e32 v1, 0x43efffff
+; GFX12-GI-NEXT:    v_cvt_u32_f64_e32 v3, v[4:5]
+; GFX12-GI-NEXT:    v_cvt_u32_f64_e32 v4, v[6:7]
+; GFX12-GI-NEXT:    v_cmp_gt_f64_e32 vcc_lo, s[0:1], v[0:1]
+; GFX12-GI-NEXT:    v_cmp_gt_f64_e64 s0, s[2:3], v[0:1]
+; GFX12-GI-NEXT:    s_wait_alu depctr_va_sdst(0)
+; GFX12-GI-NEXT:    v_cndmask_b32_e64 v5, v8, 0, s4
+; GFX12-GI-NEXT:    v_cndmask_b32_e64 v2, v2, 0, s5
+; GFX12-GI-NEXT:    v_cndmask_b32_e64 v1, v3, 0, s4
+; GFX12-GI-NEXT:    v_cndmask_b32_e64 v3, v4, 0, s5
+; GFX12-GI-NEXT:    s_wait_alu depctr_va_vcc(0)
+; GFX12-GI-NEXT:    v_cndmask_b32_e64 v0, v5, -1, vcc_lo
+; GFX12-GI-NEXT:    v_cndmask_b32_e64 v2, v2, -1, s0
+; GFX12-GI-NEXT:    v_cndmask_b32_e64 v1, v1, -1, vcc_lo
+; GFX12-GI-NEXT:    v_cndmask_b32_e64 v3, v3, -1, s0
 ; GFX12-GI-NEXT:    s_setpc_b64 s[30:31]
     %x = call <2 x i64> @llvm.fptoui.sat.v2f64.v2i64(<2 x double> %f)
     ret <2 x i64> %x
@@ -1894,6 +2966,649 @@ define <4 x i64> @test_unsigned_v4f16_v4i64(<4 x half> %f) {
 ; GFX12-GI-NEXT:    v_mov_b32_e32 v1, 0
 ; GFX12-GI-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX12-GI-NEXT:    v_mov_b32_e32 v7, 0
+; GFX12-GI-NEXT:    s_setpc_b64 s[30:31]
+    %x = call <4 x i64> @llvm.fptoui.sat.v4f16.v4i64(<4 x half> %f)
+    ret <4 x i64> %x
+}
+
+define <4 x i1> @test_s_unsigned_v4f16_v4i1(<4 x half> inreg %f) {
+; GFX7-ISEL-LABEL: test_s_unsigned_v4f16_v4i1:
+; GFX7-ISEL:       ; %bb.0:
+; GFX7-ISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-ISEL-NEXT:    s_lshr_b32 s4, s17, 16
+; GFX7-ISEL-NEXT:    s_lshr_b32 s5, s16, 16
+; GFX7-ISEL-NEXT:    v_cvt_f32_f16_e32 v0, s16
+; GFX7-ISEL-NEXT:    v_cvt_f32_f16_e32 v1, s17
+; GFX7-ISEL-NEXT:    v_cvt_f32_f16_e32 v2, s5
+; GFX7-ISEL-NEXT:    v_cvt_f32_f16_e32 v3, s4
+; GFX7-ISEL-NEXT:    v_cvt_u32_f32_e32 v0, v0
+; GFX7-ISEL-NEXT:    v_cvt_u32_f32_e32 v1, v1
+; GFX7-ISEL-NEXT:    v_cvt_u32_f32_e32 v4, v2
+; GFX7-ISEL-NEXT:    v_cvt_u32_f32_e32 v3, v3
+; GFX7-ISEL-NEXT:    v_min_u32_e32 v0, 1, v0
+; GFX7-ISEL-NEXT:    v_min_u32_e32 v2, 1, v1
+; GFX7-ISEL-NEXT:    v_min_u32_e32 v1, 1, v4
+; GFX7-ISEL-NEXT:    v_min_u32_e32 v3, 1, v3
+; GFX7-ISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX7-GI-LABEL: test_s_unsigned_v4f16_v4i1:
+; GFX7-GI:       ; %bb.0:
+; GFX7-GI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-GI-NEXT:    s_lshr_b32 s4, s16, 16
+; GFX7-GI-NEXT:    s_lshr_b32 s5, s17, 16
+; GFX7-GI-NEXT:    v_cvt_f32_f16_e32 v0, s16
+; GFX7-GI-NEXT:    v_cvt_f32_f16_e32 v1, s4
+; GFX7-GI-NEXT:    v_cvt_f32_f16_e32 v2, s17
+; GFX7-GI-NEXT:    v_cvt_f32_f16_e32 v3, s5
+; GFX7-GI-NEXT:    v_cvt_u32_f32_e32 v0, v0
+; GFX7-GI-NEXT:    v_cvt_u32_f32_e32 v1, v1
+; GFX7-GI-NEXT:    v_cvt_u32_f32_e32 v2, v2
+; GFX7-GI-NEXT:    v_cvt_u32_f32_e32 v3, v3
+; GFX7-GI-NEXT:    v_min_u32_e32 v0, 1, v0
+; GFX7-GI-NEXT:    v_min_u32_e32 v1, 1, v1
+; GFX7-GI-NEXT:    v_min_u32_e32 v2, 1, v2
+; GFX7-GI-NEXT:    v_min_u32_e32 v3, 1, v3
+; GFX7-GI-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX9-LABEL: test_s_unsigned_v4f16_v4i1:
+; GFX9:       ; %bb.0:
+; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    s_lshr_b32 s4, s17, 16
+; GFX9-NEXT:    v_cvt_u16_f16_e32 v0, s4
+; GFX9-NEXT:    v_mov_b32_e32 v4, 1
+; GFX9-NEXT:    s_lshr_b32 s4, s16, 16
+; GFX9-NEXT:    v_min_u32_sdwa v3, v0, v4 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
+; GFX9-NEXT:    v_cvt_u16_f16_e32 v0, s4
+; GFX9-NEXT:    v_min_u32_sdwa v1, v0, v4 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
+; GFX9-NEXT:    v_cvt_u16_f16_e32 v0, s17
+; GFX9-NEXT:    v_min_u32_sdwa v2, v0, v4 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
+; GFX9-NEXT:    v_cvt_u16_f16_e32 v0, s16
+; GFX9-NEXT:    v_min_u32_sdwa v0, v0, v4 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
+; GFX9-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11-FAKE16-LABEL: test_s_unsigned_v4f16_v4i1:
+; GFX11-FAKE16:       ; %bb.0:
+; GFX11-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-FAKE16-NEXT:    s_lshr_b32 s2, s1, 16
+; GFX11-FAKE16-NEXT:    s_lshr_b32 s3, s0, 16
+; GFX11-FAKE16-NEXT:    v_cvt_u16_f16_e32 v0, s0
+; GFX11-FAKE16-NEXT:    v_cvt_u16_f16_e32 v1, s1
+; GFX11-FAKE16-NEXT:    v_cvt_u16_f16_e32 v2, s3
+; GFX11-FAKE16-NEXT:    v_cvt_u16_f16_e32 v3, s2
+; GFX11-FAKE16-NEXT:    v_and_b32_e32 v0, 0xffff, v0
+; GFX11-FAKE16-NEXT:    v_and_b32_e32 v1, 0xffff, v1
+; GFX11-FAKE16-NEXT:    v_and_b32_e32 v4, 0xffff, v2
+; GFX11-FAKE16-NEXT:    v_and_b32_e32 v3, 0xffff, v3
+; GFX11-FAKE16-NEXT:    v_min_u32_e32 v0, 1, v0
+; GFX11-FAKE16-NEXT:    v_min_u32_e32 v2, 1, v1
+; GFX11-FAKE16-NEXT:    v_min_u32_e32 v1, 1, v4
+; GFX11-FAKE16-NEXT:    v_min_u32_e32 v3, 1, v3
+; GFX11-FAKE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11-TRUE16-LABEL: test_s_unsigned_v4f16_v4i1:
+; GFX11-TRUE16:       ; %bb.0:
+; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-TRUE16-NEXT:    s_lshr_b32 s2, s1, 16
+; GFX11-TRUE16-NEXT:    s_lshr_b32 s3, s0, 16
+; GFX11-TRUE16-NEXT:    v_cvt_u16_f16_e32 v0.l, s0
+; GFX11-TRUE16-NEXT:    v_cvt_u16_f16_e32 v1.l, s1
+; GFX11-TRUE16-NEXT:    v_cvt_u16_f16_e32 v2.l, s3
+; GFX11-TRUE16-NEXT:    v_cvt_u16_f16_e32 v3.l, s2
+; GFX11-TRUE16-NEXT:    v_and_b32_e32 v0, 0xffff, v0
+; GFX11-TRUE16-NEXT:    v_and_b32_e32 v1, 0xffff, v1
+; GFX11-TRUE16-NEXT:    v_and_b32_e32 v4, 0xffff, v2
+; GFX11-TRUE16-NEXT:    v_and_b32_e32 v3, 0xffff, v3
+; GFX11-TRUE16-NEXT:    v_min_u32_e32 v0, 1, v0
+; GFX11-TRUE16-NEXT:    v_min_u32_e32 v2, 1, v1
+; GFX11-TRUE16-NEXT:    v_min_u32_e32 v1, 1, v4
+; GFX11-TRUE16-NEXT:    v_min_u32_e32 v3, 1, v3
+; GFX11-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-FAKE16-LABEL: test_s_unsigned_v4f16_v4i1:
+; GFX12-FAKE16:       ; %bb.0:
+; GFX12-FAKE16-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-FAKE16-NEXT:    s_wait_expcnt 0x0
+; GFX12-FAKE16-NEXT:    s_wait_samplecnt 0x0
+; GFX12-FAKE16-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-FAKE16-NEXT:    s_wait_kmcnt 0x0
+; GFX12-FAKE16-NEXT:    s_lshr_b32 s2, s1, 16
+; GFX12-FAKE16-NEXT:    s_lshr_b32 s3, s0, 16
+; GFX12-FAKE16-NEXT:    v_cvt_u16_f16_e32 v0, s0
+; GFX12-FAKE16-NEXT:    v_cvt_u16_f16_e32 v1, s1
+; GFX12-FAKE16-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-FAKE16-NEXT:    v_cvt_u16_f16_e32 v2, s3
+; GFX12-FAKE16-NEXT:    v_cvt_u16_f16_e32 v3, s2
+; GFX12-FAKE16-NEXT:    v_and_b32_e32 v0, 0xffff, v0
+; GFX12-FAKE16-NEXT:    v_and_b32_e32 v1, 0xffff, v1
+; GFX12-FAKE16-NEXT:    v_and_b32_e32 v4, 0xffff, v2
+; GFX12-FAKE16-NEXT:    v_and_b32_e32 v3, 0xffff, v3
+; GFX12-FAKE16-NEXT:    v_min_u32_e32 v0, 1, v0
+; GFX12-FAKE16-NEXT:    v_min_u32_e32 v2, 1, v1
+; GFX12-FAKE16-NEXT:    v_min_u32_e32 v1, 1, v4
+; GFX12-FAKE16-NEXT:    v_min_u32_e32 v3, 1, v3
+; GFX12-FAKE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-TRUE16-LABEL: test_s_unsigned_v4f16_v4i1:
+; GFX12-TRUE16:       ; %bb.0:
+; GFX12-TRUE16-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-TRUE16-NEXT:    s_wait_expcnt 0x0
+; GFX12-TRUE16-NEXT:    s_wait_samplecnt 0x0
+; GFX12-TRUE16-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-TRUE16-NEXT:    s_wait_kmcnt 0x0
+; GFX12-TRUE16-NEXT:    s_lshr_b32 s2, s1, 16
+; GFX12-TRUE16-NEXT:    s_lshr_b32 s3, s0, 16
+; GFX12-TRUE16-NEXT:    v_cvt_u16_f16_e32 v0.l, s0
+; GFX12-TRUE16-NEXT:    v_cvt_u16_f16_e32 v1.l, s1
+; GFX12-TRUE16-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-TRUE16-NEXT:    v_cvt_u16_f16_e32 v2.l, s3
+; GFX12-TRUE16-NEXT:    v_cvt_u16_f16_e32 v3.l, s2
+; GFX12-TRUE16-NEXT:    v_and_b32_e32 v0, 0xffff, v0
+; GFX12-TRUE16-NEXT:    v_and_b32_e32 v1, 0xffff, v1
+; GFX12-TRUE16-NEXT:    v_and_b32_e32 v4, 0xffff, v2
+; GFX12-TRUE16-NEXT:    v_and_b32_e32 v3, 0xffff, v3
+; GFX12-TRUE16-NEXT:    v_min_u32_e32 v0, 1, v0
+; GFX12-TRUE16-NEXT:    v_min_u32_e32 v2, 1, v1
+; GFX12-TRUE16-NEXT:    v_min_u32_e32 v1, 1, v4
+; GFX12-TRUE16-NEXT:    v_min_u32_e32 v3, 1, v3
+; GFX12-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-GI-LABEL: test_s_unsigned_v4f16_v4i1:
+; GFX12-GI:       ; %bb.0:
+; GFX12-GI-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-GI-NEXT:    s_wait_expcnt 0x0
+; GFX12-GI-NEXT:    s_wait_samplecnt 0x0
+; GFX12-GI-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-GI-NEXT:    s_wait_kmcnt 0x0
+; GFX12-GI-NEXT:    s_cvt_f32_f16 s0, s0
+; GFX12-GI-NEXT:    s_cvt_f32_f16 s1, s1
+; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-GI-NEXT:    s_cvt_u32_f32 s0, s0
+; GFX12-GI-NEXT:    s_cvt_u32_f32 s1, s1
+; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-GI-NEXT:    s_min_u32 s0, s0, 1
+; GFX12-GI-NEXT:    s_min_u32 s1, s1, 1
+; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-GI-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s0
+; GFX12-GI-NEXT:    v_dual_mov_b32 v2, s1 :: v_dual_mov_b32 v3, s1
+; GFX12-GI-NEXT:    s_setpc_b64 s[30:31]
+    %x = call <4 x i1> @llvm.fptoui.sat.v4f16.v4i1(<4 x half> %f)
+    ret <4 x i1> %x
+}
+
+define <4 x i8> @test_s_unsigned_v4f16_v4i8(<4 x half> inreg %f) {
+; GFX7-ISEL-LABEL: test_s_unsigned_v4f16_v4i8:
+; GFX7-ISEL:       ; %bb.0:
+; GFX7-ISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-ISEL-NEXT:    s_lshr_b32 s4, s16, 16
+; GFX7-ISEL-NEXT:    v_cvt_f32_f16_e32 v1, s4
+; GFX7-ISEL-NEXT:    v_cvt_f32_f16_e32 v0, s16
+; GFX7-ISEL-NEXT:    s_lshr_b32 s4, s17, 16
+; GFX7-ISEL-NEXT:    v_cvt_f32_f16_e32 v2, s17
+; GFX7-ISEL-NEXT:    v_cvt_f32_f16_e32 v3, s4
+; GFX7-ISEL-NEXT:    v_cvt_u32_f32_e32 v1, v1
+; GFX7-ISEL-NEXT:    v_cvt_u32_f32_e32 v0, v0
+; GFX7-ISEL-NEXT:    v_cvt_u32_f32_e32 v2, v2
+; GFX7-ISEL-NEXT:    v_cvt_u32_f32_e32 v3, v3
+; GFX7-ISEL-NEXT:    v_min_u32_e32 v1, 0xff, v1
+; GFX7-ISEL-NEXT:    v_min_u32_e32 v0, 0xff, v0
+; GFX7-ISEL-NEXT:    v_lshlrev_b32_e32 v1, 8, v1
+; GFX7-ISEL-NEXT:    v_or_b32_e32 v0, v0, v1
+; GFX7-ISEL-NEXT:    v_min_u32_e32 v1, 0xff, v2
+; GFX7-ISEL-NEXT:    v_min_u32_e32 v2, 0xff, v3
+; GFX7-ISEL-NEXT:    v_lshlrev_b32_e32 v2, 8, v2
+; GFX7-ISEL-NEXT:    v_or_b32_e32 v2, v1, v2
+; GFX7-ISEL-NEXT:    v_lshlrev_b32_e32 v1, 16, v2
+; GFX7-ISEL-NEXT:    v_or_b32_e32 v0, v0, v1
+; GFX7-ISEL-NEXT:    v_lshrrev_b32_e32 v1, 8, v0
+; GFX7-ISEL-NEXT:    v_bfe_u32 v3, v2, 8, 8
+; GFX7-ISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX7-GI-LABEL: test_s_unsigned_v4f16_v4i8:
+; GFX7-GI:       ; %bb.0:
+; GFX7-GI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-GI-NEXT:    s_lshr_b32 s4, s16, 16
+; GFX7-GI-NEXT:    s_lshr_b32 s5, s17, 16
+; GFX7-GI-NEXT:    v_cvt_f32_f16_e32 v0, s16
+; GFX7-GI-NEXT:    v_cvt_f32_f16_e32 v1, s4
+; GFX7-GI-NEXT:    v_cvt_f32_f16_e32 v2, s17
+; GFX7-GI-NEXT:    v_cvt_f32_f16_e32 v3, s5
+; GFX7-GI-NEXT:    v_cvt_u32_f32_e32 v0, v0
+; GFX7-GI-NEXT:    v_cvt_u32_f32_e32 v1, v1
+; GFX7-GI-NEXT:    v_cvt_u32_f32_e32 v2, v2
+; GFX7-GI-NEXT:    v_cvt_u32_f32_e32 v3, v3
+; GFX7-GI-NEXT:    v_min_u32_e32 v0, 0xff, v0
+; GFX7-GI-NEXT:    v_min_u32_e32 v1, 0xff, v1
+; GFX7-GI-NEXT:    v_min_u32_e32 v2, 0xff, v2
+; GFX7-GI-NEXT:    v_min_u32_e32 v3, 0xff, v3
+; GFX7-GI-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX9-LABEL: test_s_unsigned_v4f16_v4i8:
+; GFX9:       ; %bb.0:
+; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    s_lshr_b32 s5, s16, 16
+; GFX9-NEXT:    v_cvt_u16_f16_e32 v1, s5
+; GFX9-NEXT:    s_lshr_b32 s5, s17, 16
+; GFX9-NEXT:    s_movk_i32 s4, 0xff
+; GFX9-NEXT:    v_cvt_u16_f16_e32 v3, s5
+; GFX9-NEXT:    v_cvt_u16_f16_e32 v2, s17
+; GFX9-NEXT:    v_min_u32_sdwa v3, v3, s4 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
+; GFX9-NEXT:    v_min_u32_sdwa v2, v2, s4 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
+; GFX9-NEXT:    v_lshlrev_b32_e32 v3, 8, v3
+; GFX9-NEXT:    v_cvt_u16_f16_e32 v0, s16
+; GFX9-NEXT:    v_min_u32_sdwa v1, v1, s4 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
+; GFX9-NEXT:    v_or_b32_e32 v2, v2, v3
+; GFX9-NEXT:    v_min_u32_sdwa v0, v0, s4 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
+; GFX9-NEXT:    v_lshlrev_b32_e32 v1, 8, v1
+; GFX9-NEXT:    v_lshlrev_b32_e32 v3, 16, v2
+; GFX9-NEXT:    v_or_b32_e32 v0, v0, v1
+; GFX9-NEXT:    v_or_b32_e32 v1, v1, v3
+; GFX9-NEXT:    v_lshrrev_b32_e32 v3, 24, v3
+; GFX9-NEXT:    v_lshrrev_b32_e32 v1, 8, v1
+; GFX9-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11-FAKE16-LABEL: test_s_unsigned_v4f16_v4i8:
+; GFX11-FAKE16:       ; %bb.0:
+; GFX11-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-FAKE16-NEXT:    s_lshr_b32 s2, s1, 16
+; GFX11-FAKE16-NEXT:    v_cvt_u16_f16_e32 v1, s1
+; GFX11-FAKE16-NEXT:    v_cvt_u16_f16_e32 v0, s2
+; GFX11-FAKE16-NEXT:    s_lshr_b32 s1, s0, 16
+; GFX11-FAKE16-NEXT:    v_cvt_u16_f16_e32 v3, s0
+; GFX11-FAKE16-NEXT:    v_cvt_u16_f16_e32 v2, s1
+; GFX11-FAKE16-NEXT:    v_and_b32_e32 v1, 0xffff, v1
+; GFX11-FAKE16-NEXT:    v_and_b32_e32 v0, 0xffff, v0
+; GFX11-FAKE16-NEXT:    v_and_b32_e32 v2, 0xffff, v2
+; GFX11-FAKE16-NEXT:    v_min_u32_e32 v1, 0xff, v1
+; GFX11-FAKE16-NEXT:    v_min_u32_e32 v0, 0xff, v0
+; GFX11-FAKE16-NEXT:    v_min_u32_e32 v4, 0xff, v2
+; GFX11-FAKE16-NEXT:    v_lshlrev_b32_e32 v0, 8, v0
+; GFX11-FAKE16-NEXT:    v_or_b32_e32 v2, v1, v0
+; GFX11-FAKE16-NEXT:    v_and_b32_e32 v0, 0xffff, v3
+; GFX11-FAKE16-NEXT:    v_lshlrev_b32_e32 v1, 8, v4
+; GFX11-FAKE16-NEXT:    v_lshlrev_b32_e32 v3, 16, v2
+; GFX11-FAKE16-NEXT:    v_min_u32_e32 v0, 0xff, v0
+; GFX11-FAKE16-NEXT:    v_or_b32_e32 v4, v1, v3
+; GFX11-FAKE16-NEXT:    v_or_b32_e32 v0, v0, v1
+; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v3, 24, v3
+; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v1, 8, v4
+; GFX11-FAKE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11-TRUE16-LABEL: test_s_unsigned_v4f16_v4i8:
+; GFX11-TRUE16:       ; %bb.0:
+; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-TRUE16-NEXT:    s_lshr_b32 s2, s1, 16
+; GFX11-TRUE16-NEXT:    v_cvt_u16_f16_e32 v1.l, s1
+; GFX11-TRUE16-NEXT:    v_cvt_u16_f16_e32 v0.l, s2
+; GFX11-TRUE16-NEXT:    s_lshr_b32 s1, s0, 16
+; GFX11-TRUE16-NEXT:    v_cvt_u16_f16_e32 v3.l, s0
+; GFX11-TRUE16-NEXT:    v_cvt_u16_f16_e32 v2.l, s1
+; GFX11-TRUE16-NEXT:    v_and_b32_e32 v1, 0xffff, v1
+; GFX11-TRUE16-NEXT:    v_and_b32_e32 v0, 0xffff, v0
+; GFX11-TRUE16-NEXT:    v_and_b32_e32 v2, 0xffff, v2
+; GFX11-TRUE16-NEXT:    v_min_u32_e32 v1, 0xff, v1
+; GFX11-TRUE16-NEXT:    v_min_u32_e32 v0, 0xff, v0
+; GFX11-TRUE16-NEXT:    v_min_u32_e32 v4, 0xff, v2
+; GFX11-TRUE16-NEXT:    v_lshlrev_b32_e32 v0, 8, v0
+; GFX11-TRUE16-NEXT:    v_or_b32_e32 v2, v1, v0
+; GFX11-TRUE16-NEXT:    v_and_b32_e32 v0, 0xffff, v3
+; GFX11-TRUE16-NEXT:    v_lshlrev_b32_e32 v1, 8, v4
+; GFX11-TRUE16-NEXT:    v_lshlrev_b32_e32 v3, 16, v2
+; GFX11-TRUE16-NEXT:    v_min_u32_e32 v0, 0xff, v0
+; GFX11-TRUE16-NEXT:    v_or_b32_e32 v4, v1, v3
+; GFX11-TRUE16-NEXT:    v_or_b32_e32 v0, v0, v1
+; GFX11-TRUE16-NEXT:    v_lshrrev_b32_e32 v3, 24, v3
+; GFX11-TRUE16-NEXT:    v_lshrrev_b32_e32 v1, 8, v4
+; GFX11-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-FAKE16-LABEL: test_s_unsigned_v4f16_v4i8:
+; GFX12-FAKE16:       ; %bb.0:
+; GFX12-FAKE16-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-FAKE16-NEXT:    s_wait_expcnt 0x0
+; GFX12-FAKE16-NEXT:    s_wait_samplecnt 0x0
+; GFX12-FAKE16-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-FAKE16-NEXT:    s_wait_kmcnt 0x0
+; GFX12-FAKE16-NEXT:    s_lshr_b32 s2, s1, 16
+; GFX12-FAKE16-NEXT:    v_cvt_u16_f16_e32 v1, s1
+; GFX12-FAKE16-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-FAKE16-NEXT:    v_cvt_u16_f16_e32 v0, s2
+; GFX12-FAKE16-NEXT:    s_lshr_b32 s1, s0, 16
+; GFX12-FAKE16-NEXT:    v_cvt_u16_f16_e32 v3, s0
+; GFX12-FAKE16-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-FAKE16-NEXT:    v_cvt_u16_f16_e32 v2, s1
+; GFX12-FAKE16-NEXT:    v_and_b32_e32 v1, 0xffff, v1
+; GFX12-FAKE16-NEXT:    v_and_b32_e32 v0, 0xffff, v0
+; GFX12-FAKE16-NEXT:    v_and_b32_e32 v2, 0xffff, v2
+; GFX12-FAKE16-NEXT:    v_min_u32_e32 v1, 0xff, v1
+; GFX12-FAKE16-NEXT:    v_min_u32_e32 v0, 0xff, v0
+; GFX12-FAKE16-NEXT:    v_min_u32_e32 v4, 0xff, v2
+; GFX12-FAKE16-NEXT:    v_lshlrev_b32_e32 v0, 8, v0
+; GFX12-FAKE16-NEXT:    v_or_b32_e32 v2, v1, v0
+; GFX12-FAKE16-NEXT:    v_and_b32_e32 v0, 0xffff, v3
+; GFX12-FAKE16-NEXT:    v_lshlrev_b32_e32 v1, 8, v4
+; GFX12-FAKE16-NEXT:    v_lshlrev_b32_e32 v3, 16, v2
+; GFX12-FAKE16-NEXT:    v_min_u32_e32 v0, 0xff, v0
+; GFX12-FAKE16-NEXT:    v_or_b32_e32 v4, v1, v3
+; GFX12-FAKE16-NEXT:    v_or_b32_e32 v0, v0, v1
+; GFX12-FAKE16-NEXT:    v_lshrrev_b32_e32 v3, 24, v3
+; GFX12-FAKE16-NEXT:    v_lshrrev_b32_e32 v1, 8, v4
+; GFX12-FAKE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-TRUE16-LABEL: test_s_unsigned_v4f16_v4i8:
+; GFX12-TRUE16:       ; %bb.0:
+; GFX12-TRUE16-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-TRUE16-NEXT:    s_wait_expcnt 0x0
+; GFX12-TRUE16-NEXT:    s_wait_samplecnt 0x0
+; GFX12-TRUE16-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-TRUE16-NEXT:    s_wait_kmcnt 0x0
+; GFX12-TRUE16-NEXT:    s_lshr_b32 s2, s1, 16
+; GFX12-TRUE16-NEXT:    v_cvt_u16_f16_e32 v1.l, s1
+; GFX12-TRUE16-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-TRUE16-NEXT:    v_cvt_u16_f16_e32 v0.l, s2
+; GFX12-TRUE16-NEXT:    s_lshr_b32 s1, s0, 16
+; GFX12-TRUE16-NEXT:    v_cvt_u16_f16_e32 v3.l, s0
+; GFX12-TRUE16-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-TRUE16-NEXT:    v_cvt_u16_f16_e32 v2.l, s1
+; GFX12-TRUE16-NEXT:    v_and_b32_e32 v1, 0xffff, v1
+; GFX12-TRUE16-NEXT:    v_and_b32_e32 v0, 0xffff, v0
+; GFX12-TRUE16-NEXT:    v_and_b32_e32 v2, 0xffff, v2
+; GFX12-TRUE16-NEXT:    v_min_u32_e32 v1, 0xff, v1
+; GFX12-TRUE16-NEXT:    v_min_u32_e32 v0, 0xff, v0
+; GFX12-TRUE16-NEXT:    v_min_u32_e32 v4, 0xff, v2
+; GFX12-TRUE16-NEXT:    v_lshlrev_b32_e32 v0, 8, v0
+; GFX12-TRUE16-NEXT:    v_or_b32_e32 v2, v1, v0
+; GFX12-TRUE16-NEXT:    v_and_b32_e32 v0, 0xffff, v3
+; GFX12-TRUE16-NEXT:    v_lshlrev_b32_e32 v1, 8, v4
+; GFX12-TRUE16-NEXT:    v_lshlrev_b32_e32 v3, 16, v2
+; GFX12-TRUE16-NEXT:    v_min_u32_e32 v0, 0xff, v0
+; GFX12-TRUE16-NEXT:    v_or_b32_e32 v4, v1, v3
+; GFX12-TRUE16-NEXT:    v_or_b32_e32 v0, v0, v1
+; GFX12-TRUE16-NEXT:    v_lshrrev_b32_e32 v3, 24, v3
+; GFX12-TRUE16-NEXT:    v_lshrrev_b32_e32 v1, 8, v4
+; GFX12-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-GI-LABEL: test_s_unsigned_v4f16_v4i8:
+; GFX12-GI:       ; %bb.0:
+; GFX12-GI-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-GI-NEXT:    s_wait_expcnt 0x0
+; GFX12-GI-NEXT:    s_wait_samplecnt 0x0
+; GFX12-GI-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-GI-NEXT:    s_wait_kmcnt 0x0
+; GFX12-GI-NEXT:    s_cvt_f32_f16 s0, s0
+; GFX12-GI-NEXT:    s_cvt_f32_f16 s1, s1
+; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-GI-NEXT:    s_cvt_u32_f32 s0, s0
+; GFX12-GI-NEXT:    s_cvt_u32_f32 s1, s1
+; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-GI-NEXT:    s_min_u32 s0, s0, 0xff
+; GFX12-GI-NEXT:    s_min_u32 s1, s1, 0xff
+; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-GI-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s0
+; GFX12-GI-NEXT:    v_dual_mov_b32 v2, s1 :: v_dual_mov_b32 v3, s1
+; GFX12-GI-NEXT:    s_setpc_b64 s[30:31]
+    %x = call <4 x i8> @llvm.fptoui.sat.v4f16.v4i8(<4 x half> %f)
+    ret <4 x i8> %x
+}
+
+define <4 x i16> @test_s_unsigned_v4f16_v4i16(<4 x half> inreg %f) {
+; GFX7-ISEL-LABEL: test_s_unsigned_v4f16_v4i16:
+; GFX7-ISEL:       ; %bb.0:
+; GFX7-ISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-ISEL-NEXT:    v_cvt_f32_f16_e32 v0, s17
+; GFX7-ISEL-NEXT:    s_lshr_b32 s4, s16, 16
+; GFX7-ISEL-NEXT:    s_lshr_b32 s5, s17, 16
+; GFX7-ISEL-NEXT:    v_cvt_f32_f16_e32 v1, s5
+; GFX7-ISEL-NEXT:    v_cvt_u32_f32_e32 v0, v0
+; GFX7-ISEL-NEXT:    v_cvt_f32_f16_e32 v2, s16
+; GFX7-ISEL-NEXT:    v_cvt_f32_f16_e32 v3, s4
+; GFX7-ISEL-NEXT:    v_cvt_u32_f32_e32 v1, v1
+; GFX7-ISEL-NEXT:    v_min_u32_e32 v4, 0xffff, v0
+; GFX7-ISEL-NEXT:    v_cvt_u32_f32_e32 v0, v2
+; GFX7-ISEL-NEXT:    v_cvt_u32_f32_e32 v2, v3
+; GFX7-ISEL-NEXT:    v_min_u32_e32 v1, 0xffff, v1
+; GFX7-ISEL-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; GFX7-ISEL-NEXT:    v_min_u32_e32 v0, 0xffff, v0
+; GFX7-ISEL-NEXT:    v_min_u32_e32 v2, 0xffff, v2
+; GFX7-ISEL-NEXT:    v_lshlrev_b32_e32 v2, 16, v2
+; GFX7-ISEL-NEXT:    v_or_b32_e32 v0, v0, v2
+; GFX7-ISEL-NEXT:    v_or_b32_e32 v1, v4, v1
+; GFX7-ISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX7-GI-LABEL: test_s_unsigned_v4f16_v4i16:
+; GFX7-GI:       ; %bb.0:
+; GFX7-GI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-GI-NEXT:    s_lshr_b32 s4, s16, 16
+; GFX7-GI-NEXT:    s_lshr_b32 s5, s17, 16
+; GFX7-GI-NEXT:    v_cvt_f32_f16_e32 v1, s4
+; GFX7-GI-NEXT:    v_cvt_f32_f16_e32 v0, s16
+; GFX7-GI-NEXT:    v_cvt_f32_f16_e32 v3, s5
+; GFX7-GI-NEXT:    v_cvt_f32_f16_e32 v2, s17
+; GFX7-GI-NEXT:    v_cvt_u32_f32_e32 v1, v1
+; GFX7-GI-NEXT:    v_cvt_u32_f32_e32 v0, v0
+; GFX7-GI-NEXT:    v_cvt_u32_f32_e32 v3, v3
+; GFX7-GI-NEXT:    v_cvt_u32_f32_e32 v2, v2
+; GFX7-GI-NEXT:    v_min_u32_e32 v1, 0xffff, v1
+; GFX7-GI-NEXT:    v_min_u32_e32 v0, 0xffff, v0
+; GFX7-GI-NEXT:    v_min_u32_e32 v3, 0xffff, v3
+; GFX7-GI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; GFX7-GI-NEXT:    v_min_u32_e32 v2, 0xffff, v2
+; GFX7-GI-NEXT:    v_or_b32_e32 v0, v0, v1
+; GFX7-GI-NEXT:    v_lshlrev_b32_e32 v1, 16, v3
+; GFX7-GI-NEXT:    v_or_b32_e32 v1, v2, v1
+; GFX7-GI-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX9-LABEL: test_s_unsigned_v4f16_v4i16:
+; GFX9:       ; %bb.0:
+; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    s_lshr_b32 s4, s17, 16
+; GFX9-NEXT:    v_cvt_u16_f16_e32 v1, s4
+; GFX9-NEXT:    s_lshr_b32 s4, s16, 16
+; GFX9-NEXT:    v_cvt_u16_f16_e32 v2, s17
+; GFX9-NEXT:    v_cvt_u16_f16_e32 v3, s16
+; GFX9-NEXT:    v_cvt_u16_f16_e32 v0, s4
+; GFX9-NEXT:    v_and_b32_e32 v3, 0xffff, v3
+; GFX9-NEXT:    v_and_b32_e32 v2, 0xffff, v2
+; GFX9-NEXT:    v_lshl_or_b32 v0, v0, 16, v3
+; GFX9-NEXT:    v_lshl_or_b32 v1, v1, 16, v2
+; GFX9-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11-FAKE16-LABEL: test_s_unsigned_v4f16_v4i16:
+; GFX11-FAKE16:       ; %bb.0:
+; GFX11-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-FAKE16-NEXT:    v_cvt_u16_f16_e32 v0, s0
+; GFX11-FAKE16-NEXT:    v_cvt_u16_f16_e32 v1, s1
+; GFX11-FAKE16-NEXT:    s_lshr_b32 s2, s1, 16
+; GFX11-FAKE16-NEXT:    s_lshr_b32 s0, s0, 16
+; GFX11-FAKE16-NEXT:    v_cvt_u16_f16_e32 v2, s2
+; GFX11-FAKE16-NEXT:    v_cvt_u16_f16_e32 v3, s0
+; GFX11-FAKE16-NEXT:    v_and_b32_e32 v0, 0xffff, v0
+; GFX11-FAKE16-NEXT:    v_and_b32_e32 v1, 0xffff, v1
+; GFX11-FAKE16-NEXT:    v_lshl_or_b32 v0, v3, 16, v0
+; GFX11-FAKE16-NEXT:    v_lshl_or_b32 v1, v2, 16, v1
+; GFX11-FAKE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11-TRUE16-LABEL: test_s_unsigned_v4f16_v4i16:
+; GFX11-TRUE16:       ; %bb.0:
+; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-TRUE16-NEXT:    s_lshr_b32 s2, s0, 16
+; GFX11-TRUE16-NEXT:    s_lshr_b32 s3, s1, 16
+; GFX11-TRUE16-NEXT:    v_cvt_u16_f16_e32 v0.h, s2
+; GFX11-TRUE16-NEXT:    v_cvt_u16_f16_e32 v1.l, s1
+; GFX11-TRUE16-NEXT:    v_cvt_u16_f16_e32 v0.l, s0
+; GFX11-TRUE16-NEXT:    v_cvt_u16_f16_e32 v1.h, s3
+; GFX11-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-FAKE16-LABEL: test_s_unsigned_v4f16_v4i16:
+; GFX12-FAKE16:       ; %bb.0:
+; GFX12-FAKE16-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-FAKE16-NEXT:    s_wait_expcnt 0x0
+; GFX12-FAKE16-NEXT:    s_wait_samplecnt 0x0
+; GFX12-FAKE16-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-FAKE16-NEXT:    s_wait_kmcnt 0x0
+; GFX12-FAKE16-NEXT:    v_cvt_u16_f16_e32 v0, s0
+; GFX12-FAKE16-NEXT:    v_cvt_u16_f16_e32 v1, s1
+; GFX12-FAKE16-NEXT:    s_lshr_b32 s2, s1, 16
+; GFX12-FAKE16-NEXT:    s_lshr_b32 s0, s0, 16
+; GFX12-FAKE16-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-FAKE16-NEXT:    v_cvt_u16_f16_e32 v2, s2
+; GFX12-FAKE16-NEXT:    v_cvt_u16_f16_e32 v3, s0
+; GFX12-FAKE16-NEXT:    v_and_b32_e32 v0, 0xffff, v0
+; GFX12-FAKE16-NEXT:    v_and_b32_e32 v1, 0xffff, v1
+; GFX12-FAKE16-NEXT:    v_lshl_or_b32 v0, v3, 16, v0
+; GFX12-FAKE16-NEXT:    v_lshl_or_b32 v1, v2, 16, v1
+; GFX12-FAKE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-TRUE16-LABEL: test_s_unsigned_v4f16_v4i16:
+; GFX12-TRUE16:       ; %bb.0:
+; GFX12-TRUE16-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-TRUE16-NEXT:    s_wait_expcnt 0x0
+; GFX12-TRUE16-NEXT:    s_wait_samplecnt 0x0
+; GFX12-TRUE16-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-TRUE16-NEXT:    s_wait_kmcnt 0x0
+; GFX12-TRUE16-NEXT:    s_lshr_b32 s2, s0, 16
+; GFX12-TRUE16-NEXT:    s_lshr_b32 s3, s1, 16
+; GFX12-TRUE16-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-TRUE16-NEXT:    v_cvt_u16_f16_e32 v0.h, s2
+; GFX12-TRUE16-NEXT:    v_cvt_u16_f16_e32 v1.l, s1
+; GFX12-TRUE16-NEXT:    v_cvt_u16_f16_e32 v0.l, s0
+; GFX12-TRUE16-NEXT:    v_cvt_u16_f16_e32 v1.h, s3
+; GFX12-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-GI-LABEL: test_s_unsigned_v4f16_v4i16:
+; GFX12-GI:       ; %bb.0:
+; GFX12-GI-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-GI-NEXT:    s_wait_expcnt 0x0
+; GFX12-GI-NEXT:    s_wait_samplecnt 0x0
+; GFX12-GI-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-GI-NEXT:    s_wait_kmcnt 0x0
+; GFX12-GI-NEXT:    v_cvt_u16_f16_e32 v0.l, s0
+; GFX12-GI-NEXT:    v_cvt_u16_f16_e32 v1.l, s1
+; GFX12-GI-NEXT:    v_mov_b16_e32 v0.h, v0.l
+; GFX12-GI-NEXT:    v_mov_b16_e32 v1.h, v1.l
+; GFX12-GI-NEXT:    s_setpc_b64 s[30:31]
+    %x = call <4 x i16> @llvm.fptoui.sat.v4f16.v4i16(<4 x half> %f)
+    ret <4 x i16> %x
+}
+
+define <4 x i64> @test_s_unsigned_v4f16_v4i64(<4 x half> inreg %f) {
+; GFX7-ISEL-LABEL: test_s_unsigned_v4f16_v4i64:
+; GFX7-ISEL:       ; %bb.0:
+; GFX7-ISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-ISEL-NEXT:    s_lshr_b32 s4, s17, 16
+; GFX7-ISEL-NEXT:    s_lshr_b32 s5, s16, 16
+; GFX7-ISEL-NEXT:    v_cvt_f32_f16_e32 v0, s16
+; GFX7-ISEL-NEXT:    v_cvt_f32_f16_e32 v1, s17
+; GFX7-ISEL-NEXT:    v_cvt_f32_f16_e32 v2, s5
+; GFX7-ISEL-NEXT:    v_cvt_f32_f16_e32 v3, s4
+; GFX7-ISEL-NEXT:    v_cvt_u32_f32_e32 v0, v0
+; GFX7-ISEL-NEXT:    v_cvt_u32_f32_e32 v4, v1
+; GFX7-ISEL-NEXT:    v_cvt_u32_f32_e32 v2, v2
+; GFX7-ISEL-NEXT:    v_cvt_u32_f32_e32 v6, v3
+; GFX7-ISEL-NEXT:    v_mov_b32_e32 v1, 0
+; GFX7-ISEL-NEXT:    v_mov_b32_e32 v3, 0
+; GFX7-ISEL-NEXT:    v_mov_b32_e32 v5, 0
+; GFX7-ISEL-NEXT:    v_mov_b32_e32 v7, 0
+; GFX7-ISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX7-GI-LABEL: test_s_unsigned_v4f16_v4i64:
+; GFX7-GI:       ; %bb.0:
+; GFX7-GI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-GI-NEXT:    s_lshr_b32 s4, s16, 16
+; GFX7-GI-NEXT:    s_lshr_b32 s5, s17, 16
+; GFX7-GI-NEXT:    v_cvt_f32_f16_e32 v0, s16
+; GFX7-GI-NEXT:    v_cvt_f32_f16_e32 v1, s4
+; GFX7-GI-NEXT:    v_cvt_f32_f16_e32 v3, s17
+; GFX7-GI-NEXT:    v_cvt_f32_f16_e32 v5, s5
+; GFX7-GI-NEXT:    v_cvt_u32_f32_e32 v0, v0
+; GFX7-GI-NEXT:    v_cvt_u32_f32_e32 v2, v1
+; GFX7-GI-NEXT:    v_cvt_u32_f32_e32 v4, v3
+; GFX7-GI-NEXT:    v_cvt_u32_f32_e32 v6, v5
+; GFX7-GI-NEXT:    v_mov_b32_e32 v1, 0
+; GFX7-GI-NEXT:    v_mov_b32_e32 v3, 0
+; GFX7-GI-NEXT:    v_mov_b32_e32 v5, 0
+; GFX7-GI-NEXT:    v_mov_b32_e32 v7, 0
+; GFX7-GI-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX9-LABEL: test_s_unsigned_v4f16_v4i64:
+; GFX9:       ; %bb.0:
+; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    s_lshr_b32 s4, s16, 16
+; GFX9-NEXT:    v_cvt_f32_f16_e32 v2, s4
+; GFX9-NEXT:    s_lshr_b32 s4, s17, 16
+; GFX9-NEXT:    v_cvt_f32_f16_e32 v0, s16
+; GFX9-NEXT:    v_cvt_f32_f16_e32 v1, s17
+; GFX9-NEXT:    v_cvt_f32_f16_e32 v3, s4
+; GFX9-NEXT:    v_cvt_u32_f32_e32 v2, v2
+; GFX9-NEXT:    v_cvt_u32_f32_e32 v0, v0
+; GFX9-NEXT:    v_cvt_u32_f32_e32 v4, v1
+; GFX9-NEXT:    v_cvt_u32_f32_e32 v6, v3
+; GFX9-NEXT:    v_mov_b32_e32 v1, 0
+; GFX9-NEXT:    v_mov_b32_e32 v3, 0
+; GFX9-NEXT:    v_mov_b32_e32 v5, 0
+; GFX9-NEXT:    v_mov_b32_e32 v7, 0
+; GFX9-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11-LABEL: test_s_unsigned_v4f16_v4i64:
+; GFX11:       ; %bb.0:
+; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-NEXT:    s_lshr_b32 s2, s0, 16
+; GFX11-NEXT:    v_cvt_f32_f16_e32 v0, s0
+; GFX11-NEXT:    s_lshr_b32 s0, s1, 16
+; GFX11-NEXT:    v_cvt_f32_f16_e32 v1, s2
+; GFX11-NEXT:    v_cvt_f32_f16_e32 v3, s1
+; GFX11-NEXT:    v_cvt_f32_f16_e32 v5, s0
+; GFX11-NEXT:    v_cvt_u32_f32_e32 v0, v0
+; GFX11-NEXT:    v_mov_b32_e32 v7, 0
+; GFX11-NEXT:    v_cvt_u32_f32_e32 v2, v1
+; GFX11-NEXT:    v_cvt_u32_f32_e32 v4, v3
+; GFX11-NEXT:    v_cvt_u32_f32_e32 v6, v5
+; GFX11-NEXT:    v_mov_b32_e32 v1, 0
+; GFX11-NEXT:    v_mov_b32_e32 v3, 0
+; GFX11-NEXT:    v_mov_b32_e32 v5, 0
+; GFX11-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-ISEL-LABEL: test_s_unsigned_v4f16_v4i64:
+; GFX12-ISEL:       ; %bb.0:
+; GFX12-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX12-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX12-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX12-ISEL-NEXT:    s_cvt_f32_f16 s2, s0
+; GFX12-ISEL-NEXT:    s_cvt_hi_f32_f16 s0, s0
+; GFX12-ISEL-NEXT:    s_cvt_hi_f32_f16 s3, s1
+; GFX12-ISEL-NEXT:    s_cvt_f32_f16 s1, s1
+; GFX12-ISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-ISEL-NEXT:    s_cvt_u32_f32 s2, s2
+; GFX12-ISEL-NEXT:    s_cvt_u32_f32 s0, s0
+; GFX12-ISEL-NEXT:    s_cvt_u32_f32 s3, s3
+; GFX12-ISEL-NEXT:    s_cvt_u32_f32 s1, s1
+; GFX12-ISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-ISEL-NEXT:    v_dual_mov_b32 v0, s2 :: v_dual_mov_b32 v1, 0
+; GFX12-ISEL-NEXT:    v_dual_mov_b32 v2, s0 :: v_dual_mov_b32 v3, 0
+; GFX12-ISEL-NEXT:    v_dual_mov_b32 v4, s1 :: v_dual_mov_b32 v5, 0
+; GFX12-ISEL-NEXT:    v_dual_mov_b32 v6, s3 :: v_dual_mov_b32 v7, 0
+; GFX12-ISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-GI-LABEL: test_s_unsigned_v4f16_v4i64:
+; GFX12-GI:       ; %bb.0:
+; GFX12-GI-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-GI-NEXT:    s_wait_expcnt 0x0
+; GFX12-GI-NEXT:    s_wait_samplecnt 0x0
+; GFX12-GI-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-GI-NEXT:    s_wait_kmcnt 0x0
+; GFX12-GI-NEXT:    s_cvt_f32_f16 s0, s0
+; GFX12-GI-NEXT:    s_cvt_f32_f16 s1, s1
+; GFX12-GI-NEXT:    v_mov_b32_e32 v5, 0
+; GFX12-GI-NEXT:    v_mov_b32_e32 v7, 0
+; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-GI-NEXT:    s_cvt_u32_f32 s0, s0
+; GFX12-GI-NEXT:    s_cvt_u32_f32 s1, s1
+; GFX12-GI-NEXT:    v_mov_b32_e32 v1, 0
+; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-GI-NEXT:    v_dual_mov_b32 v3, 0 :: v_dual_mov_b32 v2, s0
+; GFX12-GI-NEXT:    v_mov_b32_e32 v0, s0
+; GFX12-GI-NEXT:    v_mov_b32_e32 v4, s1
+; GFX12-GI-NEXT:    v_mov_b32_e32 v6, s1
 ; GFX12-GI-NEXT:    s_setpc_b64 s[30:31]
     %x = call <4 x i64> @llvm.fptoui.sat.v4f16.v4i64(<4 x half> %f)
     ret <4 x i64> %x
@@ -3151,6 +4866,1075 @@ define <8 x i64> @test_unsigned_v8f16_v8i64(<8 x half> %f) {
     ret <8 x i64> %x
 }
 
+define <8 x i1> @test_s_unsigned_v8f16_v8i1(<8 x half> inreg %f) {
+; GFX7-ISEL-LABEL: test_s_unsigned_v8f16_v8i1:
+; GFX7-ISEL:       ; %bb.0:
+; GFX7-ISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-ISEL-NEXT:    v_cvt_f32_f16_e32 v1, s17
+; GFX7-ISEL-NEXT:    v_cvt_f32_f16_e32 v3, s19
+; GFX7-ISEL-NEXT:    v_cvt_f32_f16_e32 v2, s18
+; GFX7-ISEL-NEXT:    s_lshr_b32 s4, s19, 16
+; GFX7-ISEL-NEXT:    v_cvt_u32_f32_e32 v1, v1
+; GFX7-ISEL-NEXT:    v_cvt_u32_f32_e32 v3, v3
+; GFX7-ISEL-NEXT:    s_lshr_b32 s5, s18, 16
+; GFX7-ISEL-NEXT:    s_lshr_b32 s6, s17, 16
+; GFX7-ISEL-NEXT:    s_lshr_b32 s7, s16, 16
+; GFX7-ISEL-NEXT:    v_cvt_f32_f16_e32 v0, s16
+; GFX7-ISEL-NEXT:    v_cvt_u32_f32_e32 v4, v2
+; GFX7-ISEL-NEXT:    v_min_u32_e32 v2, 1, v1
+; GFX7-ISEL-NEXT:    v_min_u32_e32 v6, 1, v3
+; GFX7-ISEL-NEXT:    v_cvt_f32_f16_e32 v1, s7
+; GFX7-ISEL-NEXT:    v_cvt_f32_f16_e32 v3, s6
+; GFX7-ISEL-NEXT:    v_cvt_f32_f16_e32 v5, s5
+; GFX7-ISEL-NEXT:    v_cvt_f32_f16_e32 v7, s4
+; GFX7-ISEL-NEXT:    v_cvt_u32_f32_e32 v0, v0
+; GFX7-ISEL-NEXT:    v_cvt_u32_f32_e32 v1, v1
+; GFX7-ISEL-NEXT:    v_cvt_u32_f32_e32 v3, v3
+; GFX7-ISEL-NEXT:    v_cvt_u32_f32_e32 v5, v5
+; GFX7-ISEL-NEXT:    v_cvt_u32_f32_e32 v7, v7
+; GFX7-ISEL-NEXT:    v_min_u32_e32 v0, 1, v0
+; GFX7-ISEL-NEXT:    v_min_u32_e32 v4, 1, v4
+; GFX7-ISEL-NEXT:    v_min_u32_e32 v1, 1, v1
+; GFX7-ISEL-NEXT:    v_min_u32_e32 v3, 1, v3
+; GFX7-ISEL-NEXT:    v_min_u32_e32 v5, 1, v5
+; GFX7-ISEL-NEXT:    v_min_u32_e32 v7, 1, v7
+; GFX7-ISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX7-GI-LABEL: test_s_unsigned_v8f16_v8i1:
+; GFX7-GI:       ; %bb.0:
+; GFX7-GI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-GI-NEXT:    s_lshr_b32 s4, s16, 16
+; GFX7-GI-NEXT:    s_lshr_b32 s5, s17, 16
+; GFX7-GI-NEXT:    s_lshr_b32 s6, s18, 16
+; GFX7-GI-NEXT:    s_lshr_b32 s7, s19, 16
+; GFX7-GI-NEXT:    v_cvt_f32_f16_e32 v0, s16
+; GFX7-GI-NEXT:    v_cvt_f32_f16_e32 v1, s4
+; GFX7-GI-NEXT:    v_cvt_f32_f16_e32 v2, s17
+; GFX7-GI-NEXT:    v_cvt_f32_f16_e32 v3, s5
+; GFX7-GI-NEXT:    v_cvt_f32_f16_e32 v4, s18
+; GFX7-GI-NEXT:    v_cvt_f32_f16_e32 v5, s6
+; GFX7-GI-NEXT:    v_cvt_f32_f16_e32 v6, s19
+; GFX7-GI-NEXT:    v_cvt_f32_f16_e32 v7, s7
+; GFX7-GI-NEXT:    v_cvt_u32_f32_e32 v0, v0
+; GFX7-GI-NEXT:    v_cvt_u32_f32_e32 v1, v1
+; GFX7-GI-NEXT:    v_cvt_u32_f32_e32 v2, v2
+; GFX7-GI-NEXT:    v_cvt_u32_f32_e32 v3, v3
+; GFX7-GI-NEXT:    v_cvt_u32_f32_e32 v4, v4
+; GFX7-GI-NEXT:    v_cvt_u32_f32_e32 v5, v5
+; GFX7-GI-NEXT:    v_cvt_u32_f32_e32 v6, v6
+; GFX7-GI-NEXT:    v_cvt_u32_f32_e32 v7, v7
+; GFX7-GI-NEXT:    v_min_u32_e32 v0, 1, v0
+; GFX7-GI-NEXT:    v_min_u32_e32 v1, 1, v1
+; GFX7-GI-NEXT:    v_min_u32_e32 v2, 1, v2
+; GFX7-GI-NEXT:    v_min_u32_e32 v3, 1, v3
+; GFX7-GI-NEXT:    v_min_u32_e32 v4, 1, v4
+; GFX7-GI-NEXT:    v_min_u32_e32 v5, 1, v5
+; GFX7-GI-NEXT:    v_min_u32_e32 v6, 1, v6
+; GFX7-GI-NEXT:    v_min_u32_e32 v7, 1, v7
+; GFX7-GI-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX9-LABEL: test_s_unsigned_v8f16_v8i1:
+; GFX9:       ; %bb.0:
+; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    s_lshr_b32 s4, s19, 16
+; GFX9-NEXT:    v_cvt_u16_f16_e32 v0, s4
+; GFX9-NEXT:    v_mov_b32_e32 v8, 1
+; GFX9-NEXT:    s_lshr_b32 s4, s18, 16
+; GFX9-NEXT:    v_min_u32_sdwa v7, v0, v8 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
+; GFX9-NEXT:    v_cvt_u16_f16_e32 v0, s4
+; GFX9-NEXT:    s_lshr_b32 s4, s17, 16
+; GFX9-NEXT:    v_min_u32_sdwa v5, v0, v8 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
+; GFX9-NEXT:    v_cvt_u16_f16_e32 v0, s4
+; GFX9-NEXT:    s_lshr_b32 s4, s16, 16
+; GFX9-NEXT:    v_min_u32_sdwa v3, v0, v8 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
+; GFX9-NEXT:    v_cvt_u16_f16_e32 v0, s4
+; GFX9-NEXT:    v_min_u32_sdwa v1, v0, v8 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
+; GFX9-NEXT:    v_cvt_u16_f16_e32 v0, s19
+; GFX9-NEXT:    v_min_u32_sdwa v6, v0, v8 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
+; GFX9-NEXT:    v_cvt_u16_f16_e32 v0, s18
+; GFX9-NEXT:    v_min_u32_sdwa v4, v0, v8 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
+; GFX9-NEXT:    v_cvt_u16_f16_e32 v0, s17
+; GFX9-NEXT:    v_min_u32_sdwa v2, v0, v8 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
+; GFX9-NEXT:    v_cvt_u16_f16_e32 v0, s16
+; GFX9-NEXT:    v_min_u32_sdwa v0, v0, v8 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
+; GFX9-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11-FAKE16-LABEL: test_s_unsigned_v8f16_v8i1:
+; GFX11-FAKE16:       ; %bb.0:
+; GFX11-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-FAKE16-NEXT:    s_lshr_b32 s4, s3, 16
+; GFX11-FAKE16-NEXT:    s_lshr_b32 s5, s1, 16
+; GFX11-FAKE16-NEXT:    v_cvt_u16_f16_e32 v0, s4
+; GFX11-FAKE16-NEXT:    s_lshr_b32 s4, s2, 16
+; GFX11-FAKE16-NEXT:    v_cvt_u16_f16_e32 v2, s5
+; GFX11-FAKE16-NEXT:    v_cvt_u16_f16_e32 v1, s4
+; GFX11-FAKE16-NEXT:    s_lshr_b32 s4, s0, 16
+; GFX11-FAKE16-NEXT:    v_and_b32_e32 v0, 0xffff, v0
+; GFX11-FAKE16-NEXT:    v_cvt_u16_f16_e32 v4, s3
+; GFX11-FAKE16-NEXT:    v_and_b32_e32 v2, 0xffff, v2
+; GFX11-FAKE16-NEXT:    v_and_b32_e32 v1, 0xffff, v1
+; GFX11-FAKE16-NEXT:    v_cvt_u16_f16_e32 v6, s2
+; GFX11-FAKE16-NEXT:    v_min_u32_e32 v7, 1, v0
+; GFX11-FAKE16-NEXT:    v_cvt_u16_f16_e32 v0, s0
+; GFX11-FAKE16-NEXT:    v_min_u32_e32 v3, 1, v2
+; GFX11-FAKE16-NEXT:    v_min_u32_e32 v5, 1, v1
+; GFX11-FAKE16-NEXT:    v_cvt_u16_f16_e32 v1, s4
+; GFX11-FAKE16-NEXT:    v_cvt_u16_f16_e32 v2, s1
+; GFX11-FAKE16-NEXT:    v_and_b32_e32 v0, 0xffff, v0
+; GFX11-FAKE16-NEXT:    v_and_b32_e32 v4, 0xffff, v4
+; GFX11-FAKE16-NEXT:    v_and_b32_e32 v8, 0xffff, v6
+; GFX11-FAKE16-NEXT:    v_and_b32_e32 v1, 0xffff, v1
+; GFX11-FAKE16-NEXT:    v_and_b32_e32 v2, 0xffff, v2
+; GFX11-FAKE16-NEXT:    v_min_u32_e32 v0, 1, v0
+; GFX11-FAKE16-NEXT:    v_min_u32_e32 v6, 1, v4
+; GFX11-FAKE16-NEXT:    v_min_u32_e32 v4, 1, v8
+; GFX11-FAKE16-NEXT:    v_min_u32_e32 v1, 1, v1
+; GFX11-FAKE16-NEXT:    v_min_u32_e32 v2, 1, v2
+; GFX11-FAKE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11-TRUE16-LABEL: test_s_unsigned_v8f16_v8i1:
+; GFX11-TRUE16:       ; %bb.0:
+; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-TRUE16-NEXT:    s_lshr_b32 s4, s3, 16
+; GFX11-TRUE16-NEXT:    s_lshr_b32 s5, s1, 16
+; GFX11-TRUE16-NEXT:    v_cvt_u16_f16_e32 v0.l, s4
+; GFX11-TRUE16-NEXT:    s_lshr_b32 s4, s2, 16
+; GFX11-TRUE16-NEXT:    v_cvt_u16_f16_e32 v2.l, s5
+; GFX11-TRUE16-NEXT:    v_cvt_u16_f16_e32 v1.l, s4
+; GFX11-TRUE16-NEXT:    s_lshr_b32 s4, s0, 16
+; GFX11-TRUE16-NEXT:    v_and_b32_e32 v0, 0xffff, v0
+; GFX11-TRUE16-NEXT:    v_cvt_u16_f16_e32 v4.l, s3
+; GFX11-TRUE16-NEXT:    v_and_b32_e32 v2, 0xffff, v2
+; GFX11-TRUE16-NEXT:    v_and_b32_e32 v1, 0xffff, v1
+; GFX11-TRUE16-NEXT:    v_cvt_u16_f16_e32 v6.l, s2
+; GFX11-TRUE16-NEXT:    v_min_u32_e32 v7, 1, v0
+; GFX11-TRUE16-NEXT:    v_cvt_u16_f16_e32 v0.l, s0
+; GFX11-TRUE16-NEXT:    v_min_u32_e32 v3, 1, v2
+; GFX11-TRUE16-NEXT:    v_min_u32_e32 v5, 1, v1
+; GFX11-TRUE16-NEXT:    v_cvt_u16_f16_e32 v1.l, s4
+; GFX11-TRUE16-NEXT:    v_cvt_u16_f16_e32 v2.l, s1
+; GFX11-TRUE16-NEXT:    v_and_b32_e32 v0, 0xffff, v0
+; GFX11-TRUE16-NEXT:    v_and_b32_e32 v4, 0xffff, v4
+; GFX11-TRUE16-NEXT:    v_and_b32_e32 v8, 0xffff, v6
+; GFX11-TRUE16-NEXT:    v_and_b32_e32 v1, 0xffff, v1
+; GFX11-TRUE16-NEXT:    v_and_b32_e32 v2, 0xffff, v2
+; GFX11-TRUE16-NEXT:    v_min_u32_e32 v0, 1, v0
+; GFX11-TRUE16-NEXT:    v_min_u32_e32 v6, 1, v4
+; GFX11-TRUE16-NEXT:    v_min_u32_e32 v4, 1, v8
+; GFX11-TRUE16-NEXT:    v_min_u32_e32 v1, 1, v1
+; GFX11-TRUE16-NEXT:    v_min_u32_e32 v2, 1, v2
+; GFX11-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-FAKE16-LABEL: test_s_unsigned_v8f16_v8i1:
+; GFX12-FAKE16:       ; %bb.0:
+; GFX12-FAKE16-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-FAKE16-NEXT:    s_wait_expcnt 0x0
+; GFX12-FAKE16-NEXT:    s_wait_samplecnt 0x0
+; GFX12-FAKE16-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-FAKE16-NEXT:    s_wait_kmcnt 0x0
+; GFX12-FAKE16-NEXT:    s_lshr_b32 s4, s3, 16
+; GFX12-FAKE16-NEXT:    s_lshr_b32 s5, s1, 16
+; GFX12-FAKE16-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-FAKE16-NEXT:    v_cvt_u16_f16_e32 v0, s4
+; GFX12-FAKE16-NEXT:    s_lshr_b32 s4, s2, 16
+; GFX12-FAKE16-NEXT:    v_cvt_u16_f16_e32 v2, s5
+; GFX12-FAKE16-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-FAKE16-NEXT:    v_cvt_u16_f16_e32 v1, s4
+; GFX12-FAKE16-NEXT:    s_lshr_b32 s4, s0, 16
+; GFX12-FAKE16-NEXT:    v_and_b32_e32 v0, 0xffff, v0
+; GFX12-FAKE16-NEXT:    v_cvt_u16_f16_e32 v4, s3
+; GFX12-FAKE16-NEXT:    v_and_b32_e32 v2, 0xffff, v2
+; GFX12-FAKE16-NEXT:    v_and_b32_e32 v1, 0xffff, v1
+; GFX12-FAKE16-NEXT:    v_cvt_u16_f16_e32 v6, s2
+; GFX12-FAKE16-NEXT:    v_min_u32_e32 v7, 1, v0
+; GFX12-FAKE16-NEXT:    v_cvt_u16_f16_e32 v0, s0
+; GFX12-FAKE16-NEXT:    v_min_u32_e32 v3, 1, v2
+; GFX12-FAKE16-NEXT:    v_min_u32_e32 v5, 1, v1
+; GFX12-FAKE16-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-FAKE16-NEXT:    v_cvt_u16_f16_e32 v1, s4
+; GFX12-FAKE16-NEXT:    v_cvt_u16_f16_e32 v2, s1
+; GFX12-FAKE16-NEXT:    v_and_b32_e32 v0, 0xffff, v0
+; GFX12-FAKE16-NEXT:    v_and_b32_e32 v4, 0xffff, v4
+; GFX12-FAKE16-NEXT:    v_and_b32_e32 v8, 0xffff, v6
+; GFX12-FAKE16-NEXT:    v_and_b32_e32 v1, 0xffff, v1
+; GFX12-FAKE16-NEXT:    v_and_b32_e32 v2, 0xffff, v2
+; GFX12-FAKE16-NEXT:    v_min_u32_e32 v0, 1, v0
+; GFX12-FAKE16-NEXT:    v_min_u32_e32 v6, 1, v4
+; GFX12-FAKE16-NEXT:    v_min_u32_e32 v4, 1, v8
+; GFX12-FAKE16-NEXT:    v_min_u32_e32 v1, 1, v1
+; GFX12-FAKE16-NEXT:    v_min_u32_e32 v2, 1, v2
+; GFX12-FAKE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-TRUE16-LABEL: test_s_unsigned_v8f16_v8i1:
+; GFX12-TRUE16:       ; %bb.0:
+; GFX12-TRUE16-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-TRUE16-NEXT:    s_wait_expcnt 0x0
+; GFX12-TRUE16-NEXT:    s_wait_samplecnt 0x0
+; GFX12-TRUE16-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-TRUE16-NEXT:    s_wait_kmcnt 0x0
+; GFX12-TRUE16-NEXT:    s_lshr_b32 s4, s3, 16
+; GFX12-TRUE16-NEXT:    s_lshr_b32 s5, s1, 16
+; GFX12-TRUE16-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-TRUE16-NEXT:    v_cvt_u16_f16_e32 v0.l, s4
+; GFX12-TRUE16-NEXT:    s_lshr_b32 s4, s2, 16
+; GFX12-TRUE16-NEXT:    v_cvt_u16_f16_e32 v2.l, s5
+; GFX12-TRUE16-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-TRUE16-NEXT:    v_cvt_u16_f16_e32 v1.l, s4
+; GFX12-TRUE16-NEXT:    s_lshr_b32 s4, s0, 16
+; GFX12-TRUE16-NEXT:    v_and_b32_e32 v0, 0xffff, v0
+; GFX12-TRUE16-NEXT:    v_cvt_u16_f16_e32 v4.l, s3
+; GFX12-TRUE16-NEXT:    v_and_b32_e32 v2, 0xffff, v2
+; GFX12-TRUE16-NEXT:    v_and_b32_e32 v1, 0xffff, v1
+; GFX12-TRUE16-NEXT:    v_cvt_u16_f16_e32 v6.l, s2
+; GFX12-TRUE16-NEXT:    v_min_u32_e32 v7, 1, v0
+; GFX12-TRUE16-NEXT:    v_cvt_u16_f16_e32 v0.l, s0
+; GFX12-TRUE16-NEXT:    v_min_u32_e32 v3, 1, v2
+; GFX12-TRUE16-NEXT:    v_min_u32_e32 v5, 1, v1
+; GFX12-TRUE16-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-TRUE16-NEXT:    v_cvt_u16_f16_e32 v1.l, s4
+; GFX12-TRUE16-NEXT:    v_cvt_u16_f16_e32 v2.l, s1
+; GFX12-TRUE16-NEXT:    v_and_b32_e32 v0, 0xffff, v0
+; GFX12-TRUE16-NEXT:    v_and_b32_e32 v4, 0xffff, v4
+; GFX12-TRUE16-NEXT:    v_and_b32_e32 v8, 0xffff, v6
+; GFX12-TRUE16-NEXT:    v_and_b32_e32 v1, 0xffff, v1
+; GFX12-TRUE16-NEXT:    v_and_b32_e32 v2, 0xffff, v2
+; GFX12-TRUE16-NEXT:    v_min_u32_e32 v0, 1, v0
+; GFX12-TRUE16-NEXT:    v_min_u32_e32 v6, 1, v4
+; GFX12-TRUE16-NEXT:    v_min_u32_e32 v4, 1, v8
+; GFX12-TRUE16-NEXT:    v_min_u32_e32 v1, 1, v1
+; GFX12-TRUE16-NEXT:    v_min_u32_e32 v2, 1, v2
+; GFX12-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-GI-LABEL: test_s_unsigned_v8f16_v8i1:
+; GFX12-GI:       ; %bb.0:
+; GFX12-GI-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-GI-NEXT:    s_wait_expcnt 0x0
+; GFX12-GI-NEXT:    s_wait_samplecnt 0x0
+; GFX12-GI-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-GI-NEXT:    s_wait_kmcnt 0x0
+; GFX12-GI-NEXT:    s_cvt_f32_f16 s0, s0
+; GFX12-GI-NEXT:    s_cvt_f32_f16 s1, s1
+; GFX12-GI-NEXT:    s_cvt_f32_f16 s2, s2
+; GFX12-GI-NEXT:    s_cvt_f32_f16 s3, s3
+; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-GI-NEXT:    s_cvt_u32_f32 s0, s0
+; GFX12-GI-NEXT:    s_cvt_u32_f32 s1, s1
+; GFX12-GI-NEXT:    s_cvt_u32_f32 s2, s2
+; GFX12-GI-NEXT:    s_cvt_u32_f32 s3, s3
+; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-GI-NEXT:    s_min_u32 s0, s0, 1
+; GFX12-GI-NEXT:    s_min_u32 s1, s1, 1
+; GFX12-GI-NEXT:    s_min_u32 s2, s2, 1
+; GFX12-GI-NEXT:    s_min_u32 s3, s3, 1
+; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-GI-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s0
+; GFX12-GI-NEXT:    v_dual_mov_b32 v2, s1 :: v_dual_mov_b32 v3, s1
+; GFX12-GI-NEXT:    v_dual_mov_b32 v4, s2 :: v_dual_mov_b32 v5, s2
+; GFX12-GI-NEXT:    v_dual_mov_b32 v6, s3 :: v_dual_mov_b32 v7, s3
+; GFX12-GI-NEXT:    s_setpc_b64 s[30:31]
+    %x = call <8 x i1> @llvm.fptoui.sat.v8f16.v8i1(<8 x half> %f)
+    ret <8 x i1> %x
+}
+
+define <8 x i8> @test_s_unsigned_v8f16_v8i8(<8 x half> inreg %f) {
+; GFX7-ISEL-LABEL: test_s_unsigned_v8f16_v8i8:
+; GFX7-ISEL:       ; %bb.0:
+; GFX7-ISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-ISEL-NEXT:    s_lshr_b32 s5, s19, 16
+; GFX7-ISEL-NEXT:    v_cvt_f32_f16_e32 v0, s19
+; GFX7-ISEL-NEXT:    v_cvt_f32_f16_e32 v1, s5
+; GFX7-ISEL-NEXT:    s_lshr_b32 s6, s18, 16
+; GFX7-ISEL-NEXT:    v_cvt_f32_f16_e32 v3, s6
+; GFX7-ISEL-NEXT:    v_cvt_f32_f16_e32 v2, s18
+; GFX7-ISEL-NEXT:    v_cvt_u32_f32_e32 v0, v0
+; GFX7-ISEL-NEXT:    v_cvt_u32_f32_e32 v1, v1
+; GFX7-ISEL-NEXT:    v_cvt_u32_f32_e32 v3, v3
+; GFX7-ISEL-NEXT:    v_cvt_u32_f32_e32 v2, v2
+; GFX7-ISEL-NEXT:    s_lshr_b32 s5, s17, 16
+; GFX7-ISEL-NEXT:    v_min_u32_e32 v0, 0xff, v0
+; GFX7-ISEL-NEXT:    v_min_u32_e32 v7, 0xff, v1
+; GFX7-ISEL-NEXT:    v_cvt_f32_f16_e32 v4, s5
+; GFX7-ISEL-NEXT:    v_lshlrev_b32_e32 v0, 16, v0
+; GFX7-ISEL-NEXT:    v_lshlrev_b32_e32 v1, 24, v7
+; GFX7-ISEL-NEXT:    v_min_u32_e32 v3, 0xff, v3
+; GFX7-ISEL-NEXT:    v_or_b32_e32 v0, v1, v0
+; GFX7-ISEL-NEXT:    v_cvt_f32_f16_e32 v1, s17
+; GFX7-ISEL-NEXT:    v_min_u32_e32 v2, 0xff, v2
+; GFX7-ISEL-NEXT:    v_lshlrev_b32_e32 v3, 8, v3
+; GFX7-ISEL-NEXT:    s_lshr_b32 s4, s16, 16
+; GFX7-ISEL-NEXT:    v_or_b32_e32 v2, v2, v3
+; GFX7-ISEL-NEXT:    v_or_b32_e32 v9, v2, v0
+; GFX7-ISEL-NEXT:    v_cvt_u32_f32_e32 v2, v4
+; GFX7-ISEL-NEXT:    v_cvt_f32_f16_e32 v3, s16
+; GFX7-ISEL-NEXT:    v_cvt_f32_f16_e32 v4, s4
+; GFX7-ISEL-NEXT:    v_cvt_u32_f32_e32 v1, v1
+; GFX7-ISEL-NEXT:    v_min_u32_e32 v2, 0xff, v2
+; GFX7-ISEL-NEXT:    v_cvt_u32_f32_e32 v3, v3
+; GFX7-ISEL-NEXT:    v_cvt_u32_f32_e32 v4, v4
+; GFX7-ISEL-NEXT:    v_min_u32_e32 v1, 0xff, v1
+; GFX7-ISEL-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; GFX7-ISEL-NEXT:    v_lshlrev_b32_e32 v2, 24, v2
+; GFX7-ISEL-NEXT:    v_or_b32_e32 v1, v2, v1
+; GFX7-ISEL-NEXT:    v_min_u32_e32 v2, 0xff, v3
+; GFX7-ISEL-NEXT:    v_min_u32_e32 v3, 0xff, v4
+; GFX7-ISEL-NEXT:    v_lshlrev_b32_e32 v3, 8, v3
+; GFX7-ISEL-NEXT:    v_or_b32_e32 v2, v2, v3
+; GFX7-ISEL-NEXT:    v_or_b32_e32 v8, v2, v1
+; GFX7-ISEL-NEXT:    v_lshr_b64 v[1:2], v[8:9], 8
+; GFX7-ISEL-NEXT:    v_lshr_b64 v[2:3], v[8:9], 16
+; GFX7-ISEL-NEXT:    v_lshr_b64 v[3:4], v[8:9], 24
+; GFX7-ISEL-NEXT:    v_lshrrev_b32_e32 v5, 8, v9
+; GFX7-ISEL-NEXT:    v_lshrrev_b32_e32 v6, 16, v0
+; GFX7-ISEL-NEXT:    v_mov_b32_e32 v0, v8
+; GFX7-ISEL-NEXT:    v_mov_b32_e32 v4, v9
+; GFX7-ISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX7-GI-LABEL: test_s_unsigned_v8f16_v8i8:
+; GFX7-GI:       ; %bb.0:
+; GFX7-GI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-GI-NEXT:    s_lshr_b32 s4, s16, 16
+; GFX7-GI-NEXT:    s_lshr_b32 s5, s17, 16
+; GFX7-GI-NEXT:    s_lshr_b32 s6, s18, 16
+; GFX7-GI-NEXT:    s_lshr_b32 s7, s19, 16
+; GFX7-GI-NEXT:    v_cvt_f32_f16_e32 v0, s16
+; GFX7-GI-NEXT:    v_cvt_f32_f16_e32 v1, s4
+; GFX7-GI-NEXT:    v_cvt_f32_f16_e32 v2, s17
+; GFX7-GI-NEXT:    v_cvt_f32_f16_e32 v3, s5
+; GFX7-GI-NEXT:    v_cvt_f32_f16_e32 v4, s18
+; GFX7-GI-NEXT:    v_cvt_f32_f16_e32 v5, s6
+; GFX7-GI-NEXT:    v_cvt_f32_f16_e32 v6, s19
+; GFX7-GI-NEXT:    v_cvt_f32_f16_e32 v7, s7
+; GFX7-GI-NEXT:    v_cvt_u32_f32_e32 v0, v0
+; GFX7-GI-NEXT:    v_cvt_u32_f32_e32 v1, v1
+; GFX7-GI-NEXT:    v_cvt_u32_f32_e32 v2, v2
+; GFX7-GI-NEXT:    v_cvt_u32_f32_e32 v3, v3
+; GFX7-GI-NEXT:    v_cvt_u32_f32_e32 v4, v4
+; GFX7-GI-NEXT:    v_cvt_u32_f32_e32 v5, v5
+; GFX7-GI-NEXT:    v_cvt_u32_f32_e32 v6, v6
+; GFX7-GI-NEXT:    v_cvt_u32_f32_e32 v7, v7
+; GFX7-GI-NEXT:    v_min_u32_e32 v0, 0xff, v0
+; GFX7-GI-NEXT:    v_min_u32_e32 v1, 0xff, v1
+; GFX7-GI-NEXT:    v_min_u32_e32 v2, 0xff, v2
+; GFX7-GI-NEXT:    v_min_u32_e32 v3, 0xff, v3
+; GFX7-GI-NEXT:    v_min_u32_e32 v4, 0xff, v4
+; GFX7-GI-NEXT:    v_min_u32_e32 v5, 0xff, v5
+; GFX7-GI-NEXT:    v_min_u32_e32 v6, 0xff, v6
+; GFX7-GI-NEXT:    v_min_u32_e32 v7, 0xff, v7
+; GFX7-GI-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX9-LABEL: test_s_unsigned_v8f16_v8i8:
+; GFX9:       ; %bb.0:
+; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    s_lshr_b32 s5, s18, 16
+; GFX9-NEXT:    s_movk_i32 s4, 0xff
+; GFX9-NEXT:    v_cvt_u16_f16_e32 v1, s5
+; GFX9-NEXT:    v_cvt_u16_f16_e32 v0, s18
+; GFX9-NEXT:    v_min_u32_sdwa v1, v1, s4 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
+; GFX9-NEXT:    v_min_u32_sdwa v0, v0, s4 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
+; GFX9-NEXT:    v_lshlrev_b32_e32 v1, 8, v1
+; GFX9-NEXT:    s_lshr_b32 s5, s19, 16
+; GFX9-NEXT:    v_or_b32_e32 v8, v0, v1
+; GFX9-NEXT:    v_cvt_u16_f16_e32 v1, s5
+; GFX9-NEXT:    v_cvt_u16_f16_e32 v0, s19
+; GFX9-NEXT:    v_min_u32_sdwa v1, v1, s4 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
+; GFX9-NEXT:    s_lshr_b32 s5, s17, 16
+; GFX9-NEXT:    v_min_u32_sdwa v0, v0, s4 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
+; GFX9-NEXT:    v_lshlrev_b32_e32 v1, 8, v1
+; GFX9-NEXT:    v_cvt_u16_f16_e32 v2, s5
+; GFX9-NEXT:    v_or_b32_e32 v6, v0, v1
+; GFX9-NEXT:    v_cvt_u16_f16_e32 v0, s17
+; GFX9-NEXT:    v_min_u32_sdwa v2, v2, s4 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
+; GFX9-NEXT:    s_lshr_b32 s5, s16, 16
+; GFX9-NEXT:    v_min_u32_sdwa v0, v0, s4 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
+; GFX9-NEXT:    v_lshlrev_b32_e32 v2, 8, v2
+; GFX9-NEXT:    v_cvt_u16_f16_e32 v7, s5
+; GFX9-NEXT:    v_lshlrev_b32_e32 v1, 16, v6
+; GFX9-NEXT:    v_or_b32_e32 v2, v0, v2
+; GFX9-NEXT:    v_min_u32_sdwa v7, v7, s4 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
+; GFX9-NEXT:    v_or_b32_sdwa v4, v8, v1 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
+; GFX9-NEXT:    v_lshlrev_b32_e32 v3, 16, v2
+; GFX9-NEXT:    v_cvt_u16_f16_e32 v0, s16
+; GFX9-NEXT:    v_lshlrev_b32_e32 v7, 8, v7
+; GFX9-NEXT:    v_lshrrev_b32_e32 v5, 8, v4
+; GFX9-NEXT:    v_min_u32_sdwa v0, v0, s4 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
+; GFX9-NEXT:    v_or_b32_e32 v9, v7, v3
+; GFX9-NEXT:    v_lshrrev_b64 v[3:4], 24, v[3:4]
+; GFX9-NEXT:    v_or_b32_e32 v0, v0, v7
+; GFX9-NEXT:    v_lshrrev_b32_e32 v7, 24, v1
+; GFX9-NEXT:    v_lshrrev_b32_e32 v1, 8, v9
+; GFX9-NEXT:    v_mov_b32_e32 v4, v8
+; GFX9-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11-FAKE16-LABEL: test_s_unsigned_v8f16_v8i8:
+; GFX11-FAKE16:       ; %bb.0:
+; GFX11-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-FAKE16-NEXT:    s_lshr_b32 s4, s2, 16
+; GFX11-FAKE16-NEXT:    v_cvt_u16_f16_e32 v2, s3
+; GFX11-FAKE16-NEXT:    s_lshr_b32 s3, s3, 16
+; GFX11-FAKE16-NEXT:    v_cvt_u16_f16_e32 v1, s2
+; GFX11-FAKE16-NEXT:    s_lshr_b32 s2, s1, 16
+; GFX11-FAKE16-NEXT:    v_cvt_u16_f16_e32 v0, s4
+; GFX11-FAKE16-NEXT:    v_cvt_u16_f16_e32 v4, s3
+; GFX11-FAKE16-NEXT:    v_cvt_u16_f16_e32 v3, s2
+; GFX11-FAKE16-NEXT:    v_cvt_u16_f16_e32 v5, s1
+; GFX11-FAKE16-NEXT:    s_lshr_b32 s1, s0, 16
+; GFX11-FAKE16-NEXT:    v_and_b32_e32 v0, 0xffff, v0
+; GFX11-FAKE16-NEXT:    v_and_b32_e32 v4, 0xffff, v4
+; GFX11-FAKE16-NEXT:    v_and_b32_e32 v3, 0xffff, v3
+; GFX11-FAKE16-NEXT:    v_and_b32_e32 v1, 0xffff, v1
+; GFX11-FAKE16-NEXT:    v_and_b32_e32 v2, 0xffff, v2
+; GFX11-FAKE16-NEXT:    v_min_u32_e32 v0, 0xff, v0
+; GFX11-FAKE16-NEXT:    v_cvt_u16_f16_e32 v6, s1
+; GFX11-FAKE16-NEXT:    v_min_u32_e32 v4, 0xff, v4
+; GFX11-FAKE16-NEXT:    v_and_b32_e32 v5, 0xffff, v5
+; GFX11-FAKE16-NEXT:    v_min_u32_e32 v3, 0xff, v3
+; GFX11-FAKE16-NEXT:    v_min_u32_e32 v1, 0xff, v1
+; GFX11-FAKE16-NEXT:    v_lshlrev_b32_e32 v0, 8, v0
+; GFX11-FAKE16-NEXT:    v_min_u32_e32 v7, 0xff, v2
+; GFX11-FAKE16-NEXT:    v_and_b32_e32 v6, 0xffff, v6
+; GFX11-FAKE16-NEXT:    v_lshlrev_b32_e32 v4, 8, v4
+; GFX11-FAKE16-NEXT:    v_min_u32_e32 v5, 0xff, v5
+; GFX11-FAKE16-NEXT:    v_lshlrev_b32_e32 v3, 8, v3
+; GFX11-FAKE16-NEXT:    v_or_b32_e32 v8, v1, v0
+; GFX11-FAKE16-NEXT:    v_min_u32_e32 v1, 0xff, v6
+; GFX11-FAKE16-NEXT:    v_or_b32_e32 v6, v7, v4
+; GFX11-FAKE16-NEXT:    v_cvt_u16_f16_e32 v0, s0
+; GFX11-FAKE16-NEXT:    v_or_b32_e32 v2, v5, v3
+; GFX11-FAKE16-NEXT:    v_and_b32_e32 v3, 0xffff, v8
+; GFX11-FAKE16-NEXT:    v_lshlrev_b32_e32 v1, 8, v1
+; GFX11-FAKE16-NEXT:    v_lshlrev_b32_e32 v7, 16, v6
+; GFX11-FAKE16-NEXT:    v_and_b32_e32 v0, 0xffff, v0
+; GFX11-FAKE16-NEXT:    v_lshlrev_b32_e32 v4, 16, v2
+; GFX11-FAKE16-NEXT:    v_or_b32_e32 v5, v3, v7
+; GFX11-FAKE16-NEXT:    v_min_u32_e32 v0, 0xff, v0
+; GFX11-FAKE16-NEXT:    v_or_b32_e32 v9, v1, v4
+; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v7, 24, v7
+; GFX11-FAKE16-NEXT:    v_lshrrev_b64 v[3:4], 24, v[4:5]
+; GFX11-FAKE16-NEXT:    v_or_b32_e32 v0, v0, v1
+; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v1, 8, v9
+; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v5, 8, v5
+; GFX11-FAKE16-NEXT:    v_mov_b32_e32 v4, v8
+; GFX11-FAKE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11-TRUE16-LABEL: test_s_unsigned_v8f16_v8i8:
+; GFX11-TRUE16:       ; %bb.0:
+; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-TRUE16-NEXT:    s_lshr_b32 s4, s2, 16
+; GFX11-TRUE16-NEXT:    v_cvt_u16_f16_e32 v2.l, s3
+; GFX11-TRUE16-NEXT:    s_lshr_b32 s3, s3, 16
+; GFX11-TRUE16-NEXT:    v_cvt_u16_f16_e32 v1.l, s2
+; GFX11-TRUE16-NEXT:    s_lshr_b32 s2, s1, 16
+; GFX11-TRUE16-NEXT:    v_cvt_u16_f16_e32 v0.l, s4
+; GFX11-TRUE16-NEXT:    v_cvt_u16_f16_e32 v4.l, s3
+; GFX11-TRUE16-NEXT:    v_cvt_u16_f16_e32 v3.l, s2
+; GFX11-TRUE16-NEXT:    v_cvt_u16_f16_e32 v5.l, s1
+; GFX11-TRUE16-NEXT:    s_lshr_b32 s1, s0, 16
+; GFX11-TRUE16-NEXT:    v_and_b32_e32 v0, 0xffff, v0
+; GFX11-TRUE16-NEXT:    v_and_b32_e32 v4, 0xffff, v4
+; GFX11-TRUE16-NEXT:    v_and_b32_e32 v3, 0xffff, v3
+; GFX11-TRUE16-NEXT:    v_and_b32_e32 v1, 0xffff, v1
+; GFX11-TRUE16-NEXT:    v_and_b32_e32 v2, 0xffff, v2
+; GFX11-TRUE16-NEXT:    v_min_u32_e32 v0, 0xff, v0
+; GFX11-TRUE16-NEXT:    v_cvt_u16_f16_e32 v6.l, s1
+; GFX11-TRUE16-NEXT:    v_min_u32_e32 v4, 0xff, v4
+; GFX11-TRUE16-NEXT:    v_and_b32_e32 v5, 0xffff, v5
+; GFX11-TRUE16-NEXT:    v_min_u32_e32 v3, 0xff, v3
+; GFX11-TRUE16-NEXT:    v_min_u32_e32 v1, 0xff, v1
+; GFX11-TRUE16-NEXT:    v_lshlrev_b32_e32 v0, 8, v0
+; GFX11-TRUE16-NEXT:    v_min_u32_e32 v7, 0xff, v2
+; GFX11-TRUE16-NEXT:    v_and_b32_e32 v6, 0xffff, v6
+; GFX11-TRUE16-NEXT:    v_lshlrev_b32_e32 v4, 8, v4
+; GFX11-TRUE16-NEXT:    v_min_u32_e32 v5, 0xff, v5
+; GFX11-TRUE16-NEXT:    v_lshlrev_b32_e32 v3, 8, v3
+; GFX11-TRUE16-NEXT:    v_or_b32_e32 v8, v1, v0
+; GFX11-TRUE16-NEXT:    v_min_u32_e32 v1, 0xff, v6
+; GFX11-TRUE16-NEXT:    v_or_b32_e32 v6, v7, v4
+; GFX11-TRUE16-NEXT:    v_cvt_u16_f16_e32 v0.l, s0
+; GFX11-TRUE16-NEXT:    v_or_b32_e32 v2, v5, v3
+; GFX11-TRUE16-NEXT:    v_and_b32_e32 v3, 0xffff, v8
+; GFX11-TRUE16-NEXT:    v_lshlrev_b32_e32 v1, 8, v1
+; GFX11-TRUE16-NEXT:    v_lshlrev_b32_e32 v7, 16, v6
+; GFX11-TRUE16-NEXT:    v_and_b32_e32 v0, 0xffff, v0
+; GFX11-TRUE16-NEXT:    v_lshlrev_b32_e32 v4, 16, v2
+; GFX11-TRUE16-NEXT:    v_or_b32_e32 v5, v3, v7
+; GFX11-TRUE16-NEXT:    v_min_u32_e32 v0, 0xff, v0
+; GFX11-TRUE16-NEXT:    v_or_b32_e32 v9, v1, v4
+; GFX11-TRUE16-NEXT:    v_lshrrev_b32_e32 v7, 24, v7
+; GFX11-TRUE16-NEXT:    v_lshrrev_b64 v[3:4], 24, v[4:5]
+; GFX11-TRUE16-NEXT:    v_or_b32_e32 v0, v0, v1
+; GFX11-TRUE16-NEXT:    v_lshrrev_b32_e32 v1, 8, v9
+; GFX11-TRUE16-NEXT:    v_lshrrev_b32_e32 v5, 8, v5
+; GFX11-TRUE16-NEXT:    v_mov_b32_e32 v4, v8
+; GFX11-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-FAKE16-LABEL: test_s_unsigned_v8f16_v8i8:
+; GFX12-FAKE16:       ; %bb.0:
+; GFX12-FAKE16-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-FAKE16-NEXT:    s_wait_expcnt 0x0
+; GFX12-FAKE16-NEXT:    s_wait_samplecnt 0x0
+; GFX12-FAKE16-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-FAKE16-NEXT:    s_wait_kmcnt 0x0
+; GFX12-FAKE16-NEXT:    s_lshr_b32 s4, s2, 16
+; GFX12-FAKE16-NEXT:    v_cvt_u16_f16_e32 v2, s3
+; GFX12-FAKE16-NEXT:    s_lshr_b32 s3, s3, 16
+; GFX12-FAKE16-NEXT:    v_cvt_u16_f16_e32 v1, s2
+; GFX12-FAKE16-NEXT:    s_lshr_b32 s2, s1, 16
+; GFX12-FAKE16-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-FAKE16-NEXT:    v_cvt_u16_f16_e32 v0, s4
+; GFX12-FAKE16-NEXT:    v_cvt_u16_f16_e32 v4, s3
+; GFX12-FAKE16-NEXT:    v_cvt_u16_f16_e32 v3, s2
+; GFX12-FAKE16-NEXT:    v_cvt_u16_f16_e32 v5, s1
+; GFX12-FAKE16-NEXT:    s_lshr_b32 s1, s0, 16
+; GFX12-FAKE16-NEXT:    v_and_b32_e32 v0, 0xffff, v0
+; GFX12-FAKE16-NEXT:    v_and_b32_e32 v4, 0xffff, v4
+; GFX12-FAKE16-NEXT:    v_and_b32_e32 v3, 0xffff, v3
+; GFX12-FAKE16-NEXT:    v_and_b32_e32 v1, 0xffff, v1
+; GFX12-FAKE16-NEXT:    v_and_b32_e32 v2, 0xffff, v2
+; GFX12-FAKE16-NEXT:    v_min_u32_e32 v0, 0xff, v0
+; GFX12-FAKE16-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-FAKE16-NEXT:    v_cvt_u16_f16_e32 v6, s1
+; GFX12-FAKE16-NEXT:    v_min_u32_e32 v4, 0xff, v4
+; GFX12-FAKE16-NEXT:    v_and_b32_e32 v5, 0xffff, v5
+; GFX12-FAKE16-NEXT:    v_min_u32_e32 v3, 0xff, v3
+; GFX12-FAKE16-NEXT:    v_min_u32_e32 v1, 0xff, v1
+; GFX12-FAKE16-NEXT:    v_lshlrev_b32_e32 v0, 8, v0
+; GFX12-FAKE16-NEXT:    v_min_u32_e32 v7, 0xff, v2
+; GFX12-FAKE16-NEXT:    v_and_b32_e32 v6, 0xffff, v6
+; GFX12-FAKE16-NEXT:    v_lshlrev_b32_e32 v4, 8, v4
+; GFX12-FAKE16-NEXT:    v_min_u32_e32 v5, 0xff, v5
+; GFX12-FAKE16-NEXT:    v_lshlrev_b32_e32 v3, 8, v3
+; GFX12-FAKE16-NEXT:    v_or_b32_e32 v8, v1, v0
+; GFX12-FAKE16-NEXT:    v_min_u32_e32 v1, 0xff, v6
+; GFX12-FAKE16-NEXT:    v_or_b32_e32 v6, v7, v4
+; GFX12-FAKE16-NEXT:    v_cvt_u16_f16_e32 v0, s0
+; GFX12-FAKE16-NEXT:    v_or_b32_e32 v2, v5, v3
+; GFX12-FAKE16-NEXT:    v_and_b32_e32 v3, 0xffff, v8
+; GFX12-FAKE16-NEXT:    v_lshlrev_b32_e32 v1, 8, v1
+; GFX12-FAKE16-NEXT:    v_lshlrev_b32_e32 v7, 16, v6
+; GFX12-FAKE16-NEXT:    v_and_b32_e32 v0, 0xffff, v0
+; GFX12-FAKE16-NEXT:    v_lshlrev_b32_e32 v4, 16, v2
+; GFX12-FAKE16-NEXT:    v_or_b32_e32 v5, v3, v7
+; GFX12-FAKE16-NEXT:    v_min_u32_e32 v0, 0xff, v0
+; GFX12-FAKE16-NEXT:    v_or_b32_e32 v9, v1, v4
+; GFX12-FAKE16-NEXT:    v_lshrrev_b32_e32 v7, 24, v7
+; GFX12-FAKE16-NEXT:    v_lshrrev_b64 v[3:4], 24, v[4:5]
+; GFX12-FAKE16-NEXT:    v_or_b32_e32 v0, v0, v1
+; GFX12-FAKE16-NEXT:    v_lshrrev_b32_e32 v1, 8, v9
+; GFX12-FAKE16-NEXT:    v_lshrrev_b32_e32 v5, 8, v5
+; GFX12-FAKE16-NEXT:    v_mov_b32_e32 v4, v8
+; GFX12-FAKE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-TRUE16-LABEL: test_s_unsigned_v8f16_v8i8:
+; GFX12-TRUE16:       ; %bb.0:
+; GFX12-TRUE16-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-TRUE16-NEXT:    s_wait_expcnt 0x0
+; GFX12-TRUE16-NEXT:    s_wait_samplecnt 0x0
+; GFX12-TRUE16-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-TRUE16-NEXT:    s_wait_kmcnt 0x0
+; GFX12-TRUE16-NEXT:    s_lshr_b32 s4, s2, 16
+; GFX12-TRUE16-NEXT:    v_cvt_u16_f16_e32 v2.l, s3
+; GFX12-TRUE16-NEXT:    s_lshr_b32 s3, s3, 16
+; GFX12-TRUE16-NEXT:    v_cvt_u16_f16_e32 v1.l, s2
+; GFX12-TRUE16-NEXT:    s_lshr_b32 s2, s1, 16
+; GFX12-TRUE16-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-TRUE16-NEXT:    v_cvt_u16_f16_e32 v0.l, s4
+; GFX12-TRUE16-NEXT:    v_cvt_u16_f16_e32 v4.l, s3
+; GFX12-TRUE16-NEXT:    v_cvt_u16_f16_e32 v3.l, s2
+; GFX12-TRUE16-NEXT:    v_cvt_u16_f16_e32 v5.l, s1
+; GFX12-TRUE16-NEXT:    s_lshr_b32 s1, s0, 16
+; GFX12-TRUE16-NEXT:    v_and_b32_e32 v0, 0xffff, v0
+; GFX12-TRUE16-NEXT:    v_and_b32_e32 v4, 0xffff, v4
+; GFX12-TRUE16-NEXT:    v_and_b32_e32 v3, 0xffff, v3
+; GFX12-TRUE16-NEXT:    v_and_b32_e32 v1, 0xffff, v1
+; GFX12-TRUE16-NEXT:    v_and_b32_e32 v2, 0xffff, v2
+; GFX12-TRUE16-NEXT:    v_min_u32_e32 v0, 0xff, v0
+; GFX12-TRUE16-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-TRUE16-NEXT:    v_cvt_u16_f16_e32 v6.l, s1
+; GFX12-TRUE16-NEXT:    v_min_u32_e32 v4, 0xff, v4
+; GFX12-TRUE16-NEXT:    v_and_b32_e32 v5, 0xffff, v5
+; GFX12-TRUE16-NEXT:    v_min_u32_e32 v3, 0xff, v3
+; GFX12-TRUE16-NEXT:    v_min_u32_e32 v1, 0xff, v1
+; GFX12-TRUE16-NEXT:    v_lshlrev_b32_e32 v0, 8, v0
+; GFX12-TRUE16-NEXT:    v_min_u32_e32 v7, 0xff, v2
+; GFX12-TRUE16-NEXT:    v_and_b32_e32 v6, 0xffff, v6
+; GFX12-TRUE16-NEXT:    v_lshlrev_b32_e32 v4, 8, v4
+; GFX12-TRUE16-NEXT:    v_min_u32_e32 v5, 0xff, v5
+; GFX12-TRUE16-NEXT:    v_lshlrev_b32_e32 v3, 8, v3
+; GFX12-TRUE16-NEXT:    v_or_b32_e32 v8, v1, v0
+; GFX12-TRUE16-NEXT:    v_min_u32_e32 v1, 0xff, v6
+; GFX12-TRUE16-NEXT:    v_or_b32_e32 v6, v7, v4
+; GFX12-TRUE16-NEXT:    v_cvt_u16_f16_e32 v0.l, s0
+; GFX12-TRUE16-NEXT:    v_or_b32_e32 v2, v5, v3
+; GFX12-TRUE16-NEXT:    v_and_b32_e32 v3, 0xffff, v8
+; GFX12-TRUE16-NEXT:    v_lshlrev_b32_e32 v1, 8, v1
+; GFX12-TRUE16-NEXT:    v_lshlrev_b32_e32 v7, 16, v6
+; GFX12-TRUE16-NEXT:    v_and_b32_e32 v0, 0xffff, v0
+; GFX12-TRUE16-NEXT:    v_lshlrev_b32_e32 v4, 16, v2
+; GFX12-TRUE16-NEXT:    v_or_b32_e32 v5, v3, v7
+; GFX12-TRUE16-NEXT:    v_min_u32_e32 v0, 0xff, v0
+; GFX12-TRUE16-NEXT:    v_or_b32_e32 v9, v1, v4
+; GFX12-TRUE16-NEXT:    v_lshrrev_b32_e32 v7, 24, v7
+; GFX12-TRUE16-NEXT:    v_lshrrev_b64 v[3:4], 24, v[4:5]
+; GFX12-TRUE16-NEXT:    v_or_b32_e32 v0, v0, v1
+; GFX12-TRUE16-NEXT:    v_lshrrev_b32_e32 v1, 8, v9
+; GFX12-TRUE16-NEXT:    v_lshrrev_b32_e32 v5, 8, v5
+; GFX12-TRUE16-NEXT:    v_mov_b32_e32 v4, v8
+; GFX12-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-GI-LABEL: test_s_unsigned_v8f16_v8i8:
+; GFX12-GI:       ; %bb.0:
+; GFX12-GI-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-GI-NEXT:    s_wait_expcnt 0x0
+; GFX12-GI-NEXT:    s_wait_samplecnt 0x0
+; GFX12-GI-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-GI-NEXT:    s_wait_kmcnt 0x0
+; GFX12-GI-NEXT:    s_cvt_f32_f16 s0, s0
+; GFX12-GI-NEXT:    s_cvt_f32_f16 s1, s1
+; GFX12-GI-NEXT:    s_cvt_f32_f16 s2, s2
+; GFX12-GI-NEXT:    s_cvt_f32_f16 s3, s3
+; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-GI-NEXT:    s_cvt_u32_f32 s0, s0
+; GFX12-GI-NEXT:    s_cvt_u32_f32 s1, s1
+; GFX12-GI-NEXT:    s_cvt_u32_f32 s2, s2
+; GFX12-GI-NEXT:    s_cvt_u32_f32 s3, s3
+; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-GI-NEXT:    s_min_u32 s0, s0, 0xff
+; GFX12-GI-NEXT:    s_min_u32 s1, s1, 0xff
+; GFX12-GI-NEXT:    s_min_u32 s2, s2, 0xff
+; GFX12-GI-NEXT:    s_min_u32 s3, s3, 0xff
+; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-GI-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s0
+; GFX12-GI-NEXT:    v_dual_mov_b32 v2, s1 :: v_dual_mov_b32 v3, s1
+; GFX12-GI-NEXT:    v_dual_mov_b32 v4, s2 :: v_dual_mov_b32 v5, s2
+; GFX12-GI-NEXT:    v_dual_mov_b32 v6, s3 :: v_dual_mov_b32 v7, s3
+; GFX12-GI-NEXT:    s_setpc_b64 s[30:31]
+    %x = call <8 x i8> @llvm.fptoui.sat.v8f16.v8i8(<8 x half> %f)
+    ret <8 x i8> %x
+}
+
+define <8 x i16> @test_s_unsigned_v8f16_v8i16(<8 x half> inreg %f) {
+; GFX7-ISEL-LABEL: test_s_unsigned_v8f16_v8i16:
+; GFX7-ISEL:       ; %bb.0:
+; GFX7-ISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-ISEL-NEXT:    s_lshr_b32 s5, s19, 16
+; GFX7-ISEL-NEXT:    v_cvt_f32_f16_e32 v0, s19
+; GFX7-ISEL-NEXT:    v_cvt_f32_f16_e32 v1, s5
+; GFX7-ISEL-NEXT:    s_lshr_b32 s6, s18, 16
+; GFX7-ISEL-NEXT:    v_cvt_f32_f16_e32 v2, s18
+; GFX7-ISEL-NEXT:    v_cvt_u32_f32_e32 v0, v0
+; GFX7-ISEL-NEXT:    v_cvt_u32_f32_e32 v1, v1
+; GFX7-ISEL-NEXT:    v_cvt_f32_f16_e32 v3, s6
+; GFX7-ISEL-NEXT:    s_lshr_b32 s4, s16, 16
+; GFX7-ISEL-NEXT:    v_min_u32_e32 v4, 0xffff, v0
+; GFX7-ISEL-NEXT:    v_min_u32_e32 v0, 0xffff, v1
+; GFX7-ISEL-NEXT:    v_cvt_u32_f32_e32 v1, v2
+; GFX7-ISEL-NEXT:    v_cvt_u32_f32_e32 v2, v3
+; GFX7-ISEL-NEXT:    v_lshlrev_b32_e32 v3, 16, v0
+; GFX7-ISEL-NEXT:    v_cvt_f32_f16_e32 v0, s17
+; GFX7-ISEL-NEXT:    s_lshr_b32 s5, s17, 16
+; GFX7-ISEL-NEXT:    v_min_u32_e32 v5, 0xffff, v1
+; GFX7-ISEL-NEXT:    v_cvt_f32_f16_e32 v1, s5
+; GFX7-ISEL-NEXT:    v_cvt_u32_f32_e32 v0, v0
+; GFX7-ISEL-NEXT:    v_cvt_f32_f16_e32 v6, s16
+; GFX7-ISEL-NEXT:    v_cvt_f32_f16_e32 v7, s4
+; GFX7-ISEL-NEXT:    v_cvt_u32_f32_e32 v1, v1
+; GFX7-ISEL-NEXT:    v_min_u32_e32 v8, 0xffff, v0
+; GFX7-ISEL-NEXT:    v_cvt_u32_f32_e32 v0, v6
+; GFX7-ISEL-NEXT:    v_cvt_u32_f32_e32 v6, v7
+; GFX7-ISEL-NEXT:    v_min_u32_e32 v2, 0xffff, v2
+; GFX7-ISEL-NEXT:    v_min_u32_e32 v1, 0xffff, v1
+; GFX7-ISEL-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; GFX7-ISEL-NEXT:    v_min_u32_e32 v6, 0xffff, v6
+; GFX7-ISEL-NEXT:    v_min_u32_e32 v0, 0xffff, v0
+; GFX7-ISEL-NEXT:    v_lshlrev_b32_e32 v6, 16, v6
+; GFX7-ISEL-NEXT:    v_lshlrev_b32_e32 v2, 16, v2
+; GFX7-ISEL-NEXT:    v_or_b32_e32 v0, v0, v6
+; GFX7-ISEL-NEXT:    v_or_b32_e32 v1, v8, v1
+; GFX7-ISEL-NEXT:    v_or_b32_e32 v2, v5, v2
+; GFX7-ISEL-NEXT:    v_or_b32_e32 v3, v4, v3
+; GFX7-ISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX7-GI-LABEL: test_s_unsigned_v8f16_v8i16:
+; GFX7-GI:       ; %bb.0:
+; GFX7-GI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-GI-NEXT:    s_lshr_b32 s4, s16, 16
+; GFX7-GI-NEXT:    s_lshr_b32 s5, s17, 16
+; GFX7-GI-NEXT:    v_cvt_f32_f16_e32 v1, s4
+; GFX7-GI-NEXT:    s_lshr_b32 s6, s18, 16
+; GFX7-GI-NEXT:    s_lshr_b32 s7, s19, 16
+; GFX7-GI-NEXT:    v_cvt_f32_f16_e32 v0, s16
+; GFX7-GI-NEXT:    v_cvt_f32_f16_e32 v3, s5
+; GFX7-GI-NEXT:    v_cvt_f32_f16_e32 v2, s17
+; GFX7-GI-NEXT:    v_cvt_f32_f16_e32 v5, s6
+; GFX7-GI-NEXT:    v_cvt_f32_f16_e32 v7, s7
+; GFX7-GI-NEXT:    v_cvt_f32_f16_e32 v4, s18
+; GFX7-GI-NEXT:    v_cvt_f32_f16_e32 v6, s19
+; GFX7-GI-NEXT:    v_cvt_u32_f32_e32 v1, v1
+; GFX7-GI-NEXT:    v_cvt_u32_f32_e32 v0, v0
+; GFX7-GI-NEXT:    v_cvt_u32_f32_e32 v3, v3
+; GFX7-GI-NEXT:    v_cvt_u32_f32_e32 v2, v2
+; GFX7-GI-NEXT:    v_cvt_u32_f32_e32 v5, v5
+; GFX7-GI-NEXT:    v_cvt_u32_f32_e32 v7, v7
+; GFX7-GI-NEXT:    v_cvt_u32_f32_e32 v4, v4
+; GFX7-GI-NEXT:    v_cvt_u32_f32_e32 v6, v6
+; GFX7-GI-NEXT:    v_min_u32_e32 v1, 0xffff, v1
+; GFX7-GI-NEXT:    v_min_u32_e32 v0, 0xffff, v0
+; GFX7-GI-NEXT:    v_min_u32_e32 v3, 0xffff, v3
+; GFX7-GI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; GFX7-GI-NEXT:    v_min_u32_e32 v2, 0xffff, v2
+; GFX7-GI-NEXT:    v_min_u32_e32 v5, 0xffff, v5
+; GFX7-GI-NEXT:    v_min_u32_e32 v7, 0xffff, v7
+; GFX7-GI-NEXT:    v_or_b32_e32 v0, v0, v1
+; GFX7-GI-NEXT:    v_lshlrev_b32_e32 v1, 16, v3
+; GFX7-GI-NEXT:    v_min_u32_e32 v4, 0xffff, v4
+; GFX7-GI-NEXT:    v_min_u32_e32 v6, 0xffff, v6
+; GFX7-GI-NEXT:    v_or_b32_e32 v1, v2, v1
+; GFX7-GI-NEXT:    v_lshlrev_b32_e32 v2, 16, v5
+; GFX7-GI-NEXT:    v_lshlrev_b32_e32 v3, 16, v7
+; GFX7-GI-NEXT:    v_or_b32_e32 v2, v4, v2
+; GFX7-GI-NEXT:    v_or_b32_e32 v3, v6, v3
+; GFX7-GI-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX9-LABEL: test_s_unsigned_v8f16_v8i16:
+; GFX9:       ; %bb.0:
+; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    s_lshr_b32 s4, s19, 16
+; GFX9-NEXT:    v_cvt_u16_f16_e32 v3, s4
+; GFX9-NEXT:    s_lshr_b32 s4, s18, 16
+; GFX9-NEXT:    v_cvt_u16_f16_e32 v2, s4
+; GFX9-NEXT:    s_lshr_b32 s4, s17, 16
+; GFX9-NEXT:    v_cvt_u16_f16_e32 v1, s4
+; GFX9-NEXT:    s_lshr_b32 s4, s16, 16
+; GFX9-NEXT:    v_cvt_u16_f16_e32 v4, s19
+; GFX9-NEXT:    v_cvt_u16_f16_e32 v5, s18
+; GFX9-NEXT:    v_cvt_u16_f16_e32 v6, s17
+; GFX9-NEXT:    v_cvt_u16_f16_e32 v7, s16
+; GFX9-NEXT:    v_cvt_u16_f16_e32 v0, s4
+; GFX9-NEXT:    v_and_b32_e32 v7, 0xffff, v7
+; GFX9-NEXT:    v_and_b32_e32 v6, 0xffff, v6
+; GFX9-NEXT:    v_and_b32_e32 v5, 0xffff, v5
+; GFX9-NEXT:    v_and_b32_e32 v4, 0xffff, v4
+; GFX9-NEXT:    v_lshl_or_b32 v0, v0, 16, v7
+; GFX9-NEXT:    v_lshl_or_b32 v1, v1, 16, v6
+; GFX9-NEXT:    v_lshl_or_b32 v2, v2, 16, v5
+; GFX9-NEXT:    v_lshl_or_b32 v3, v3, 16, v4
+; GFX9-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11-FAKE16-LABEL: test_s_unsigned_v8f16_v8i16:
+; GFX11-FAKE16:       ; %bb.0:
+; GFX11-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-FAKE16-NEXT:    s_lshr_b32 s4, s3, 16
+; GFX11-FAKE16-NEXT:    v_cvt_u16_f16_e32 v0, s0
+; GFX11-FAKE16-NEXT:    v_cvt_u16_f16_e32 v4, s1
+; GFX11-FAKE16-NEXT:    v_cvt_u16_f16_e32 v5, s2
+; GFX11-FAKE16-NEXT:    v_cvt_u16_f16_e32 v6, s3
+; GFX11-FAKE16-NEXT:    v_cvt_u16_f16_e32 v3, s4
+; GFX11-FAKE16-NEXT:    s_lshr_b32 s4, s2, 16
+; GFX11-FAKE16-NEXT:    s_lshr_b32 s5, s1, 16
+; GFX11-FAKE16-NEXT:    v_cvt_u16_f16_e32 v2, s4
+; GFX11-FAKE16-NEXT:    s_lshr_b32 s4, s0, 16
+; GFX11-FAKE16-NEXT:    v_cvt_u16_f16_e32 v1, s5
+; GFX11-FAKE16-NEXT:    v_cvt_u16_f16_e32 v7, s4
+; GFX11-FAKE16-NEXT:    v_and_b32_e32 v0, 0xffff, v0
+; GFX11-FAKE16-NEXT:    v_and_b32_e32 v4, 0xffff, v4
+; GFX11-FAKE16-NEXT:    v_and_b32_e32 v5, 0xffff, v5
+; GFX11-FAKE16-NEXT:    v_and_b32_e32 v6, 0xffff, v6
+; GFX11-FAKE16-NEXT:    v_lshl_or_b32 v0, v7, 16, v0
+; GFX11-FAKE16-NEXT:    v_lshl_or_b32 v1, v1, 16, v4
+; GFX11-FAKE16-NEXT:    v_lshl_or_b32 v2, v2, 16, v5
+; GFX11-FAKE16-NEXT:    v_lshl_or_b32 v3, v3, 16, v6
+; GFX11-FAKE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11-TRUE16-LABEL: test_s_unsigned_v8f16_v8i16:
+; GFX11-TRUE16:       ; %bb.0:
+; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-TRUE16-NEXT:    s_lshr_b32 s4, s3, 16
+; GFX11-TRUE16-NEXT:    s_lshr_b32 s5, s2, 16
+; GFX11-TRUE16-NEXT:    v_cvt_u16_f16_e32 v3.h, s4
+; GFX11-TRUE16-NEXT:    v_cvt_u16_f16_e32 v2.h, s5
+; GFX11-TRUE16-NEXT:    s_lshr_b32 s4, s1, 16
+; GFX11-TRUE16-NEXT:    s_lshr_b32 s5, s0, 16
+; GFX11-TRUE16-NEXT:    v_cvt_u16_f16_e32 v1.h, s4
+; GFX11-TRUE16-NEXT:    v_cvt_u16_f16_e32 v0.h, s5
+; GFX11-TRUE16-NEXT:    v_cvt_u16_f16_e32 v0.l, s0
+; GFX11-TRUE16-NEXT:    v_cvt_u16_f16_e32 v1.l, s1
+; GFX11-TRUE16-NEXT:    v_cvt_u16_f16_e32 v2.l, s2
+; GFX11-TRUE16-NEXT:    v_cvt_u16_f16_e32 v3.l, s3
+; GFX11-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-FAKE16-LABEL: test_s_unsigned_v8f16_v8i16:
+; GFX12-FAKE16:       ; %bb.0:
+; GFX12-FAKE16-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-FAKE16-NEXT:    s_wait_expcnt 0x0
+; GFX12-FAKE16-NEXT:    s_wait_samplecnt 0x0
+; GFX12-FAKE16-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-FAKE16-NEXT:    s_wait_kmcnt 0x0
+; GFX12-FAKE16-NEXT:    s_lshr_b32 s4, s3, 16
+; GFX12-FAKE16-NEXT:    v_cvt_u16_f16_e32 v0, s0
+; GFX12-FAKE16-NEXT:    v_cvt_u16_f16_e32 v4, s1
+; GFX12-FAKE16-NEXT:    v_cvt_u16_f16_e32 v5, s2
+; GFX12-FAKE16-NEXT:    v_cvt_u16_f16_e32 v6, s3
+; GFX12-FAKE16-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-FAKE16-NEXT:    v_cvt_u16_f16_e32 v3, s4
+; GFX12-FAKE16-NEXT:    s_lshr_b32 s4, s2, 16
+; GFX12-FAKE16-NEXT:    s_lshr_b32 s5, s1, 16
+; GFX12-FAKE16-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-FAKE16-NEXT:    v_cvt_u16_f16_e32 v2, s4
+; GFX12-FAKE16-NEXT:    s_lshr_b32 s4, s0, 16
+; GFX12-FAKE16-NEXT:    v_cvt_u16_f16_e32 v1, s5
+; GFX12-FAKE16-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-FAKE16-NEXT:    v_cvt_u16_f16_e32 v7, s4
+; GFX12-FAKE16-NEXT:    v_and_b32_e32 v0, 0xffff, v0
+; GFX12-FAKE16-NEXT:    v_and_b32_e32 v4, 0xffff, v4
+; GFX12-FAKE16-NEXT:    v_and_b32_e32 v5, 0xffff, v5
+; GFX12-FAKE16-NEXT:    v_and_b32_e32 v6, 0xffff, v6
+; GFX12-FAKE16-NEXT:    v_lshl_or_b32 v0, v7, 16, v0
+; GFX12-FAKE16-NEXT:    v_lshl_or_b32 v1, v1, 16, v4
+; GFX12-FAKE16-NEXT:    v_lshl_or_b32 v2, v2, 16, v5
+; GFX12-FAKE16-NEXT:    v_lshl_or_b32 v3, v3, 16, v6
+; GFX12-FAKE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-TRUE16-LABEL: test_s_unsigned_v8f16_v8i16:
+; GFX12-TRUE16:       ; %bb.0:
+; GFX12-TRUE16-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-TRUE16-NEXT:    s_wait_expcnt 0x0
+; GFX12-TRUE16-NEXT:    s_wait_samplecnt 0x0
+; GFX12-TRUE16-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-TRUE16-NEXT:    s_wait_kmcnt 0x0
+; GFX12-TRUE16-NEXT:    s_lshr_b32 s4, s3, 16
+; GFX12-TRUE16-NEXT:    s_lshr_b32 s5, s2, 16
+; GFX12-TRUE16-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-TRUE16-NEXT:    v_cvt_u16_f16_e32 v3.h, s4
+; GFX12-TRUE16-NEXT:    v_cvt_u16_f16_e32 v2.h, s5
+; GFX12-TRUE16-NEXT:    s_lshr_b32 s4, s1, 16
+; GFX12-TRUE16-NEXT:    s_lshr_b32 s5, s0, 16
+; GFX12-TRUE16-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-TRUE16-NEXT:    v_cvt_u16_f16_e32 v1.h, s4
+; GFX12-TRUE16-NEXT:    v_cvt_u16_f16_e32 v0.h, s5
+; GFX12-TRUE16-NEXT:    v_cvt_u16_f16_e32 v0.l, s0
+; GFX12-TRUE16-NEXT:    v_cvt_u16_f16_e32 v1.l, s1
+; GFX12-TRUE16-NEXT:    v_cvt_u16_f16_e32 v2.l, s2
+; GFX12-TRUE16-NEXT:    v_cvt_u16_f16_e32 v3.l, s3
+; GFX12-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-GI-LABEL: test_s_unsigned_v8f16_v8i16:
+; GFX12-GI:       ; %bb.0:
+; GFX12-GI-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-GI-NEXT:    s_wait_expcnt 0x0
+; GFX12-GI-NEXT:    s_wait_samplecnt 0x0
+; GFX12-GI-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-GI-NEXT:    s_wait_kmcnt 0x0
+; GFX12-GI-NEXT:    v_cvt_u16_f16_e32 v0.l, s0
+; GFX12-GI-NEXT:    v_cvt_u16_f16_e32 v1.l, s1
+; GFX12-GI-NEXT:    v_cvt_u16_f16_e32 v2.l, s2
+; GFX12-GI-NEXT:    v_cvt_u16_f16_e32 v3.l, s3
+; GFX12-GI-NEXT:    v_mov_b16_e32 v0.h, v0.l
+; GFX12-GI-NEXT:    v_mov_b16_e32 v1.h, v1.l
+; GFX12-GI-NEXT:    v_mov_b16_e32 v2.h, v2.l
+; GFX12-GI-NEXT:    v_mov_b16_e32 v3.h, v3.l
+; GFX12-GI-NEXT:    s_setpc_b64 s[30:31]
+    %x = call <8 x i16> @llvm.fptoui.sat.v8f16.v8i16(<8 x half> %f)
+    ret <8 x i16> %x
+}
+
+define <8 x i64> @test_s_unsigned_v8f16_v8i64(<8 x half> inreg %f) {
+; GFX7-ISEL-LABEL: test_s_unsigned_v8f16_v8i64:
+; GFX7-ISEL:       ; %bb.0:
+; GFX7-ISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-ISEL-NEXT:    v_cvt_f32_f16_e32 v1, s17
+; GFX7-ISEL-NEXT:    v_cvt_f32_f16_e32 v3, s19
+; GFX7-ISEL-NEXT:    s_lshr_b32 s4, s19, 16
+; GFX7-ISEL-NEXT:    s_lshr_b32 s5, s18, 16
+; GFX7-ISEL-NEXT:    s_lshr_b32 s6, s17, 16
+; GFX7-ISEL-NEXT:    s_lshr_b32 s7, s16, 16
+; GFX7-ISEL-NEXT:    v_cvt_f32_f16_e32 v0, s16
+; GFX7-ISEL-NEXT:    v_cvt_f32_f16_e32 v2, s18
+; GFX7-ISEL-NEXT:    v_cvt_u32_f32_e32 v4, v1
+; GFX7-ISEL-NEXT:    v_cvt_u32_f32_e32 v12, v3
+; GFX7-ISEL-NEXT:    v_cvt_f32_f16_e32 v1, s7
+; GFX7-ISEL-NEXT:    v_cvt_f32_f16_e32 v3, s6
+; GFX7-ISEL-NEXT:    v_cvt_f32_f16_e32 v5, s5
+; GFX7-ISEL-NEXT:    v_cvt_f32_f16_e32 v7, s4
+; GFX7-ISEL-NEXT:    v_cvt_u32_f32_e32 v0, v0
+; GFX7-ISEL-NEXT:    v_cvt_u32_f32_e32 v8, v2
+; GFX7-ISEL-NEXT:    v_cvt_u32_f32_e32 v2, v1
+; GFX7-ISEL-NEXT:    v_cvt_u32_f32_e32 v6, v3
+; GFX7-ISEL-NEXT:    v_cvt_u32_f32_e32 v10, v5
+; GFX7-ISEL-NEXT:    v_cvt_u32_f32_e32 v14, v7
+; GFX7-ISEL-NEXT:    v_mov_b32_e32 v1, 0
+; GFX7-ISEL-NEXT:    v_mov_b32_e32 v3, 0
+; GFX7-ISEL-NEXT:    v_mov_b32_e32 v5, 0
+; GFX7-ISEL-NEXT:    v_mov_b32_e32 v7, 0
+; GFX7-ISEL-NEXT:    v_mov_b32_e32 v9, 0
+; GFX7-ISEL-NEXT:    v_mov_b32_e32 v11, 0
+; GFX7-ISEL-NEXT:    v_mov_b32_e32 v13, 0
+; GFX7-ISEL-NEXT:    v_mov_b32_e32 v15, 0
+; GFX7-ISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX7-GI-LABEL: test_s_unsigned_v8f16_v8i64:
+; GFX7-GI:       ; %bb.0:
+; GFX7-GI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-GI-NEXT:    s_lshr_b32 s4, s16, 16
+; GFX7-GI-NEXT:    s_lshr_b32 s5, s17, 16
+; GFX7-GI-NEXT:    v_cvt_f32_f16_e32 v1, s4
+; GFX7-GI-NEXT:    v_cvt_f32_f16_e32 v3, s17
+; GFX7-GI-NEXT:    v_cvt_f32_f16_e32 v5, s5
+; GFX7-GI-NEXT:    s_lshr_b32 s6, s18, 16
+; GFX7-GI-NEXT:    s_lshr_b32 s7, s19, 16
+; GFX7-GI-NEXT:    v_cvt_f32_f16_e32 v0, s16
+; GFX7-GI-NEXT:    v_cvt_u32_f32_e32 v2, v1
+; GFX7-GI-NEXT:    v_cvt_u32_f32_e32 v4, v3
+; GFX7-GI-NEXT:    v_cvt_u32_f32_e32 v6, v5
+; GFX7-GI-NEXT:    v_cvt_f32_f16_e32 v1, s18
+; GFX7-GI-NEXT:    v_cvt_f32_f16_e32 v3, s6
+; GFX7-GI-NEXT:    v_cvt_f32_f16_e32 v5, s19
+; GFX7-GI-NEXT:    v_cvt_f32_f16_e32 v7, s7
+; GFX7-GI-NEXT:    v_cvt_u32_f32_e32 v0, v0
+; GFX7-GI-NEXT:    v_cvt_u32_f32_e32 v8, v1
+; GFX7-GI-NEXT:    v_cvt_u32_f32_e32 v10, v3
+; GFX7-GI-NEXT:    v_cvt_u32_f32_e32 v12, v5
+; GFX7-GI-NEXT:    v_cvt_u32_f32_e32 v14, v7
+; GFX7-GI-NEXT:    v_mov_b32_e32 v1, 0
+; GFX7-GI-NEXT:    v_mov_b32_e32 v3, 0
+; GFX7-GI-NEXT:    v_mov_b32_e32 v5, 0
+; GFX7-GI-NEXT:    v_mov_b32_e32 v7, 0
+; GFX7-GI-NEXT:    v_mov_b32_e32 v9, 0
+; GFX7-GI-NEXT:    v_mov_b32_e32 v11, 0
+; GFX7-GI-NEXT:    v_mov_b32_e32 v13, 0
+; GFX7-GI-NEXT:    v_mov_b32_e32 v15, 0
+; GFX7-GI-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX9-LABEL: test_s_unsigned_v8f16_v8i64:
+; GFX9:       ; %bb.0:
+; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    v_cvt_f32_f16_e32 v1, s17
+; GFX9-NEXT:    v_cvt_f32_f16_e32 v3, s19
+; GFX9-NEXT:    s_lshr_b32 s4, s16, 16
+; GFX9-NEXT:    v_cvt_f32_f16_e32 v0, s16
+; GFX9-NEXT:    v_cvt_u32_f32_e32 v4, v1
+; GFX9-NEXT:    v_cvt_f32_f16_e32 v1, s4
+; GFX9-NEXT:    s_lshr_b32 s4, s17, 16
+; GFX9-NEXT:    v_cvt_u32_f32_e32 v12, v3
+; GFX9-NEXT:    v_cvt_f32_f16_e32 v3, s4
+; GFX9-NEXT:    s_lshr_b32 s4, s18, 16
+; GFX9-NEXT:    v_cvt_f32_f16_e32 v5, s4
+; GFX9-NEXT:    s_lshr_b32 s4, s19, 16
+; GFX9-NEXT:    v_cvt_f32_f16_e32 v2, s18
+; GFX9-NEXT:    v_cvt_f32_f16_e32 v7, s4
+; GFX9-NEXT:    v_cvt_u32_f32_e32 v0, v0
+; GFX9-NEXT:    v_cvt_u32_f32_e32 v6, v3
+; GFX9-NEXT:    v_cvt_u32_f32_e32 v8, v2
+; GFX9-NEXT:    v_cvt_u32_f32_e32 v2, v1
+; GFX9-NEXT:    v_cvt_u32_f32_e32 v10, v5
+; GFX9-NEXT:    v_cvt_u32_f32_e32 v14, v7
+; GFX9-NEXT:    v_mov_b32_e32 v1, 0
+; GFX9-NEXT:    v_mov_b32_e32 v3, 0
+; GFX9-NEXT:    v_mov_b32_e32 v5, 0
+; GFX9-NEXT:    v_mov_b32_e32 v7, 0
+; GFX9-NEXT:    v_mov_b32_e32 v9, 0
+; GFX9-NEXT:    v_mov_b32_e32 v11, 0
+; GFX9-NEXT:    v_mov_b32_e32 v13, 0
+; GFX9-NEXT:    v_mov_b32_e32 v15, 0
+; GFX9-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11-LABEL: test_s_unsigned_v8f16_v8i64:
+; GFX11:       ; %bb.0:
+; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-NEXT:    v_cvt_f32_f16_e32 v2, s2
+; GFX11-NEXT:    v_cvt_f32_f16_e32 v1, s1
+; GFX11-NEXT:    v_cvt_f32_f16_e32 v0, s0
+; GFX11-NEXT:    s_lshr_b32 s0, s0, 16
+; GFX11-NEXT:    s_lshr_b32 s1, s1, 16
+; GFX11-NEXT:    v_cvt_u32_f32_e32 v8, v2
+; GFX11-NEXT:    v_cvt_f32_f16_e32 v2, s0
+; GFX11-NEXT:    v_cvt_f32_f16_e32 v3, s1
+; GFX11-NEXT:    s_lshr_b32 s0, s2, 16
+; GFX11-NEXT:    s_lshr_b32 s1, s3, 16
+; GFX11-NEXT:    v_cvt_u32_f32_e32 v4, v1
+; GFX11-NEXT:    v_cvt_f32_f16_e32 v1, s3
+; GFX11-NEXT:    v_cvt_f32_f16_e32 v5, s0
+; GFX11-NEXT:    v_cvt_f32_f16_e32 v7, s1
+; GFX11-NEXT:    v_cvt_u32_f32_e32 v0, v0
+; GFX11-NEXT:    v_cvt_u32_f32_e32 v2, v2
+; GFX11-NEXT:    v_cvt_u32_f32_e32 v12, v1
+; GFX11-NEXT:    v_cvt_u32_f32_e32 v6, v3
+; GFX11-NEXT:    v_cvt_u32_f32_e32 v10, v5
+; GFX11-NEXT:    v_cvt_u32_f32_e32 v14, v7
+; GFX11-NEXT:    v_mov_b32_e32 v1, 0
+; GFX11-NEXT:    v_mov_b32_e32 v3, 0
+; GFX11-NEXT:    v_mov_b32_e32 v5, 0
+; GFX11-NEXT:    v_mov_b32_e32 v7, 0
+; GFX11-NEXT:    v_mov_b32_e32 v9, 0
+; GFX11-NEXT:    v_mov_b32_e32 v11, 0
+; GFX11-NEXT:    v_mov_b32_e32 v13, 0
+; GFX11-NEXT:    v_mov_b32_e32 v15, 0
+; GFX11-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-ISEL-LABEL: test_s_unsigned_v8f16_v8i64:
+; GFX12-ISEL:       ; %bb.0:
+; GFX12-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX12-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX12-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX12-ISEL-NEXT:    s_cvt_hi_f32_f16 s4, s0
+; GFX12-ISEL-NEXT:    s_cvt_hi_f32_f16 s5, s1
+; GFX12-ISEL-NEXT:    s_cvt_hi_f32_f16 s6, s2
+; GFX12-ISEL-NEXT:    s_cvt_hi_f32_f16 s7, s3
+; GFX12-ISEL-NEXT:    s_cvt_f32_f16 s0, s0
+; GFX12-ISEL-NEXT:    s_cvt_f32_f16 s1, s1
+; GFX12-ISEL-NEXT:    s_cvt_f32_f16 s2, s2
+; GFX12-ISEL-NEXT:    s_cvt_f32_f16 s3, s3
+; GFX12-ISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-ISEL-NEXT:    s_cvt_u32_f32 s4, s4
+; GFX12-ISEL-NEXT:    s_cvt_u32_f32 s5, s5
+; GFX12-ISEL-NEXT:    s_cvt_u32_f32 s6, s6
+; GFX12-ISEL-NEXT:    s_cvt_u32_f32 s7, s7
+; GFX12-ISEL-NEXT:    s_cvt_u32_f32 s0, s0
+; GFX12-ISEL-NEXT:    s_cvt_u32_f32 s1, s1
+; GFX12-ISEL-NEXT:    s_cvt_u32_f32 s2, s2
+; GFX12-ISEL-NEXT:    s_cvt_u32_f32 s3, s3
+; GFX12-ISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-ISEL-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, 0
+; GFX12-ISEL-NEXT:    v_dual_mov_b32 v2, s4 :: v_dual_mov_b32 v3, 0
+; GFX12-ISEL-NEXT:    v_dual_mov_b32 v4, s1 :: v_dual_mov_b32 v5, 0
+; GFX12-ISEL-NEXT:    v_dual_mov_b32 v6, s5 :: v_dual_mov_b32 v7, 0
+; GFX12-ISEL-NEXT:    v_dual_mov_b32 v8, s2 :: v_dual_mov_b32 v9, 0
+; GFX12-ISEL-NEXT:    v_dual_mov_b32 v10, s6 :: v_dual_mov_b32 v11, 0
+; GFX12-ISEL-NEXT:    v_dual_mov_b32 v12, s3 :: v_dual_mov_b32 v13, 0
+; GFX12-ISEL-NEXT:    v_dual_mov_b32 v14, s7 :: v_dual_mov_b32 v15, 0
+; GFX12-ISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-GI-LABEL: test_s_unsigned_v8f16_v8i64:
+; GFX12-GI:       ; %bb.0:
+; GFX12-GI-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-GI-NEXT:    s_wait_expcnt 0x0
+; GFX12-GI-NEXT:    s_wait_samplecnt 0x0
+; GFX12-GI-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-GI-NEXT:    s_wait_kmcnt 0x0
+; GFX12-GI-NEXT:    s_cvt_f32_f16 s0, s0
+; GFX12-GI-NEXT:    s_cvt_f32_f16 s1, s1
+; GFX12-GI-NEXT:    s_cvt_f32_f16 s2, s2
+; GFX12-GI-NEXT:    s_cvt_f32_f16 s3, s3
+; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-GI-NEXT:    s_cvt_u32_f32 s0, s0
+; GFX12-GI-NEXT:    s_cvt_u32_f32 s1, s1
+; GFX12-GI-NEXT:    s_cvt_u32_f32 s2, s2
+; GFX12-GI-NEXT:    s_cvt_u32_f32 s3, s3
+; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-GI-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, 0
+; GFX12-GI-NEXT:    v_dual_mov_b32 v2, s0 :: v_dual_mov_b32 v3, 0
+; GFX12-GI-NEXT:    v_dual_mov_b32 v4, s1 :: v_dual_mov_b32 v5, 0
+; GFX12-GI-NEXT:    v_dual_mov_b32 v6, s1 :: v_dual_mov_b32 v7, 0
+; GFX12-GI-NEXT:    v_dual_mov_b32 v8, s2 :: v_dual_mov_b32 v9, 0
+; GFX12-GI-NEXT:    v_dual_mov_b32 v10, s2 :: v_dual_mov_b32 v11, 0
+; GFX12-GI-NEXT:    v_dual_mov_b32 v12, s3 :: v_dual_mov_b32 v13, 0
+; GFX12-GI-NEXT:    v_dual_mov_b32 v14, s3 :: v_dual_mov_b32 v15, 0
+; GFX12-GI-NEXT:    s_setpc_b64 s[30:31]
+    %x = call <8 x i64> @llvm.fptoui.sat.v8f16.v8i64(<8 x half> %f)
+    ret <8 x i64> %x
+}
+
 ;
 ; Float to unsigned 8-bit
 ;
@@ -3321,6 +6105,141 @@ define <4 x i8> @test_unsigned_v4f32_v4i8(<4 x float> %f) {
 ; GFX12-GI-NEXT:    v_min_u32_e32 v1, 0xff, v1
 ; GFX12-GI-NEXT:    v_min_u32_e32 v2, 0xff, v2
 ; GFX12-GI-NEXT:    v_min_u32_e32 v3, 0xff, v3
+; GFX12-GI-NEXT:    s_setpc_b64 s[30:31]
+    %x = call <4 x i8> @llvm.fptoui.sat.v4f32.v4i8(<4 x float> %f)
+    ret <4 x i8> %x
+}
+
+define <4 x i8> @test_s_unsigned_v4f32_v4i8(<4 x float> inreg %f) {
+; GFX7-ISEL-LABEL: test_s_unsigned_v4f32_v4i8:
+; GFX7-ISEL:       ; %bb.0:
+; GFX7-ISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-ISEL-NEXT:    v_cvt_u32_f32_e32 v1, s17
+; GFX7-ISEL-NEXT:    v_cvt_u32_f32_e32 v0, s16
+; GFX7-ISEL-NEXT:    v_cvt_u32_f32_e32 v2, s18
+; GFX7-ISEL-NEXT:    v_cvt_u32_f32_e32 v3, s19
+; GFX7-ISEL-NEXT:    v_min_u32_e32 v1, 0xff, v1
+; GFX7-ISEL-NEXT:    v_min_u32_e32 v0, 0xff, v0
+; GFX7-ISEL-NEXT:    v_lshlrev_b32_e32 v1, 8, v1
+; GFX7-ISEL-NEXT:    v_or_b32_e32 v0, v0, v1
+; GFX7-ISEL-NEXT:    v_min_u32_e32 v1, 0xff, v2
+; GFX7-ISEL-NEXT:    v_min_u32_e32 v2, 0xff, v3
+; GFX7-ISEL-NEXT:    v_lshlrev_b32_e32 v2, 8, v2
+; GFX7-ISEL-NEXT:    v_or_b32_e32 v2, v1, v2
+; GFX7-ISEL-NEXT:    v_lshlrev_b32_e32 v1, 16, v2
+; GFX7-ISEL-NEXT:    v_or_b32_e32 v0, v0, v1
+; GFX7-ISEL-NEXT:    v_lshrrev_b32_e32 v1, 8, v0
+; GFX7-ISEL-NEXT:    v_bfe_u32 v3, v2, 8, 8
+; GFX7-ISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX7-GI-LABEL: test_s_unsigned_v4f32_v4i8:
+; GFX7-GI:       ; %bb.0:
+; GFX7-GI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-GI-NEXT:    v_cvt_u32_f32_e32 v0, s16
+; GFX7-GI-NEXT:    v_cvt_u32_f32_e32 v1, s17
+; GFX7-GI-NEXT:    v_cvt_u32_f32_e32 v2, s18
+; GFX7-GI-NEXT:    v_cvt_u32_f32_e32 v3, s19
+; GFX7-GI-NEXT:    v_min_u32_e32 v0, 0xff, v0
+; GFX7-GI-NEXT:    v_min_u32_e32 v1, 0xff, v1
+; GFX7-GI-NEXT:    v_min_u32_e32 v2, 0xff, v2
+; GFX7-GI-NEXT:    v_min_u32_e32 v3, 0xff, v3
+; GFX7-GI-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX9-LABEL: test_s_unsigned_v4f32_v4i8:
+; GFX9:       ; %bb.0:
+; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    v_cvt_u32_f32_e32 v3, s19
+; GFX9-NEXT:    v_cvt_u32_f32_e32 v2, s18
+; GFX9-NEXT:    v_cvt_u32_f32_e32 v1, s17
+; GFX9-NEXT:    v_cvt_u32_f32_e32 v0, s16
+; GFX9-NEXT:    v_min_u32_e32 v3, 0xff, v3
+; GFX9-NEXT:    v_min_u32_e32 v2, 0xff, v2
+; GFX9-NEXT:    v_lshlrev_b32_e32 v3, 8, v3
+; GFX9-NEXT:    v_min_u32_e32 v1, 0xff, v1
+; GFX9-NEXT:    v_or_b32_e32 v2, v2, v3
+; GFX9-NEXT:    v_min_u32_e32 v0, 0xff, v0
+; GFX9-NEXT:    v_lshlrev_b32_e32 v1, 8, v1
+; GFX9-NEXT:    v_lshlrev_b32_e32 v3, 16, v2
+; GFX9-NEXT:    v_or_b32_e32 v0, v0, v1
+; GFX9-NEXT:    v_or_b32_e32 v1, v1, v3
+; GFX9-NEXT:    v_lshrrev_b32_e32 v3, 24, v3
+; GFX9-NEXT:    v_lshrrev_b32_e32 v1, 8, v1
+; GFX9-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11-LABEL: test_s_unsigned_v4f32_v4i8:
+; GFX11:       ; %bb.0:
+; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-NEXT:    v_cvt_u32_f32_e32 v0, s3
+; GFX11-NEXT:    v_cvt_u32_f32_e32 v1, s2
+; GFX11-NEXT:    v_cvt_u32_f32_e32 v2, s1
+; GFX11-NEXT:    v_min_u32_e32 v0, 0xff, v0
+; GFX11-NEXT:    v_min_u32_e32 v1, 0xff, v1
+; GFX11-NEXT:    v_min_u32_e32 v3, 0xff, v2
+; GFX11-NEXT:    v_lshlrev_b32_e32 v0, 8, v0
+; GFX11-NEXT:    v_or_b32_e32 v2, v1, v0
+; GFX11-NEXT:    v_cvt_u32_f32_e32 v0, s0
+; GFX11-NEXT:    v_lshlrev_b32_e32 v1, 8, v3
+; GFX11-NEXT:    v_lshlrev_b32_e32 v3, 16, v2
+; GFX11-NEXT:    v_min_u32_e32 v0, 0xff, v0
+; GFX11-NEXT:    v_or_b32_e32 v4, v1, v3
+; GFX11-NEXT:    v_or_b32_e32 v0, v0, v1
+; GFX11-NEXT:    v_lshrrev_b32_e32 v3, 24, v3
+; GFX11-NEXT:    v_lshrrev_b32_e32 v1, 8, v4
+; GFX11-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-ISEL-LABEL: test_s_unsigned_v4f32_v4i8:
+; GFX12-ISEL:       ; %bb.0:
+; GFX12-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX12-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX12-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX12-ISEL-NEXT:    s_cvt_u32_f32 s3, s3
+; GFX12-ISEL-NEXT:    s_cvt_u32_f32 s2, s2
+; GFX12-ISEL-NEXT:    s_cvt_u32_f32 s1, s1
+; GFX12-ISEL-NEXT:    s_cvt_u32_f32 s0, s0
+; GFX12-ISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-ISEL-NEXT:    s_min_u32 s3, s3, 0xff
+; GFX12-ISEL-NEXT:    s_min_u32 s2, s2, 0xff
+; GFX12-ISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-ISEL-NEXT:    s_lshl_b32 s3, s3, 8
+; GFX12-ISEL-NEXT:    s_min_u32 s1, s1, 0xff
+; GFX12-ISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-ISEL-NEXT:    s_or_b32 s2, s2, s3
+; GFX12-ISEL-NEXT:    s_min_u32 s0, s0, 0xff
+; GFX12-ISEL-NEXT:    s_lshl_b32 s1, s1, 8
+; GFX12-ISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-ISEL-NEXT:    s_lshl_b32 s3, s2, 16
+; GFX12-ISEL-NEXT:    s_or_b32 s0, s0, s1
+; GFX12-ISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-ISEL-NEXT:    s_or_b32 s1, s1, s3
+; GFX12-ISEL-NEXT:    s_lshr_b32 s3, s3, 24
+; GFX12-ISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-ISEL-NEXT:    s_lshr_b32 s1, s1, 8
+; GFX12-ISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-ISEL-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
+; GFX12-ISEL-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s3
+; GFX12-ISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-GI-LABEL: test_s_unsigned_v4f32_v4i8:
+; GFX12-GI:       ; %bb.0:
+; GFX12-GI-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-GI-NEXT:    s_wait_expcnt 0x0
+; GFX12-GI-NEXT:    s_wait_samplecnt 0x0
+; GFX12-GI-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-GI-NEXT:    s_wait_kmcnt 0x0
+; GFX12-GI-NEXT:    s_cvt_u32_f32 s0, s0
+; GFX12-GI-NEXT:    s_cvt_u32_f32 s1, s1
+; GFX12-GI-NEXT:    s_cvt_u32_f32 s2, s2
+; GFX12-GI-NEXT:    s_cvt_u32_f32 s3, s3
+; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-GI-NEXT:    s_min_u32 s0, s0, 0xff
+; GFX12-GI-NEXT:    s_min_u32 s1, s1, 0xff
+; GFX12-GI-NEXT:    s_min_u32 s2, s2, 0xff
+; GFX12-GI-NEXT:    s_min_u32 s3, s3, 0xff
+; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-GI-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
+; GFX12-GI-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s3
 ; GFX12-GI-NEXT:    s_setpc_b64 s[30:31]
     %x = call <4 x i8> @llvm.fptoui.sat.v4f32.v4i8(<4 x float> %f)
     ret <4 x i8> %x


### PR DESCRIPTION
We attempt to select `s_cvt_i32/u32_f32` where possible, with some considerations:

  * For `f64` default to `v_` instructions as there is no support for `f64` in SALU.
  * For `f16` to `i16` select `v_cvt_i16/u16_f16` which is consistent with non-saturating conversions behavior. However we could emit `s_cvt_f32_f16` followed by `s_cvt_i32/u32_f32` to keep the computation in SALU, as SALU does not have `s_cvt_i16_f16`. Happy to look into it if beneficial.
  * When it comes to clamping, ISel turns min and max sequence into `v_med3` with `v0` destination, whereas globalisel keeps min and max as `s_min` and `s_max` and then moves the result into `v0`, as lit tests expect the return value to be in `v0` in both cases. This is unrelated to this change but I thought it is worth highlighting.