### PR TITLE
[clang][ModulesDriver] Fix build failure with Xcode 14

### DIFF
--- a/clang/lib/Driver/ModulesDriver.cpp
+++ b/clang/lib/Driver/ModulesDriver.cpp
@@ -1412,8 +1412,7 @@ pruneUnusedStdlibModuleJobs(CompilationGraph &Graph,
         llvm::map_range(llvm::depth_first(cast<CGNode>(PrunableJobNodeRoot)),
                         llvm::CastTo<JobNode>);
     auto ReachableNonImageNodes = llvm::make_filter_range(
-        ReachableJobNodes, std::not_fn(llvm::IsaPred<ImageJobNode>));
-
+        ReachableJobNodes, [](auto *N) { return !llvm::isa<ImageJobNode>(N); });
     PrunableJobNodes.insert_range(ReachableNonImageNodes);
   }
 


### PR DESCRIPTION
As pointed out by https://github.com/llvm/llvm-project/pull/152770#issuecomment-4096179622, 81e8a1e causes build errors with older versions of Xcode (Xcode 14 and older) when using `std::not_fn()` with `llvm::make_filter_range()`.

This implements the same fix as in d1d9413.