### PR TITLE
[clang][AST] Preserve qualifiers in getFullyQualifiedType for AutoType

### DIFF
--- a/clang/lib/AST/QualTypeNames.cpp
+++ b/clang/lib/AST/QualTypeNames.cpp
@@ -370,9 +370,15 @@ NestedNameSpecifier createNestedNameSpecifier(const ASTContext &Ctx,
 QualType getFullyQualifiedType(QualType QT, const ASTContext &Ctx,
                                bool WithGlobalNsPrefix) {
   // Use the underlying deduced type for AutoType
-  if (const auto *AT = dyn_cast<AutoType>(QT.getTypePtr()))
-    if (AT->isDeduced())
+  if (const auto *AT = dyn_cast<AutoType>(QT.getTypePtr())) {
+    if (AT->isDeduced()) {
+      // Get the qualifiers.
+      Qualifiers Quals = QT.getQualifiers();
       QT = AT->getDeducedType();
+      // Add back the qualifiers.
+      QT = Ctx.getQualifiedType(QT, Quals);
+    }
+  }
 
   // In case of myType* we need to strip the pointer first, fully
   // qualify and attach the pointer once again.

--- a/clang/test/Interpreter/pretty-print.cpp
+++ b/clang/test/Interpreter/pretty-print.cpp
@@ -69,6 +69,10 @@ namespace Outer { template<class T> struct Bar {}; }
 auto y = Outer::Bar<int>(); y
 // CHECK-NEXT: (Outer::Bar<int> &) @0x{{[0-9a-f]+}}
 
+// Check that const is preserved
+const auto z = Outer::Foo(); z
+// CHECK-NEXT: (const Outer::Foo &) @0x{{[0-9a-f]+}}
+
 // int i = 12;
 // int &iref = i;
 // iref


### PR DESCRIPTION
A previous change (86c4e96) did not preserve qualifiers attached to the AutoType QualType when the type was deduced.

For an AutoType after `getDeducedType()`, qualifiers from the original QualType were dropped. Preserve and reapply them to the deduced type.