### PR TITLE
[WinEH] Diagnose SEH object unwinding in skipped __except bodies

### DIFF
--- a/clang/lib/CodeGen/CGDecl.cpp
+++ b/clang/lib/CodeGen/CGDecl.cpp
@@ -2229,8 +2229,6 @@ void CodeGenFunction::EmitAutoVarCleanups(const AutoVarEmission &emission) {
   // Check the type for a cleanup.
   if (QualType::DestructionKind dtorKind = D.needsDestruction(getContext())) {
     // Check if we're in a SEH block with /EH, prevent it
-    // TODO: /EHs* differs from /EHa, the former may not be executed to this
-    // point.
     if (getLangOpts().CXXExceptions && currentFunctionUsesSEHTry())
       getContext().getDiagnostics().Report(D.getLocation(),
                                            diag::err_seh_object_unwinding);

--- a/clang/lib/CodeGen/CGException.cpp
+++ b/clang/lib/CodeGen/CGException.cpp
@@ -2246,6 +2246,17 @@ void CodeGenFunction::ExitSEHTryStmt(const SEHTryStmt &S) {
   // TODO: Model unwind edges from instructions, either with iload / istore or
   // a try body function.
   if (!CatchScope.hasEHBranches()) {
+    // Even though we skip emitting the __except body, diagnose variables
+    // with non-trivial destructors that would normally be caught by
+    // EmitAutoVarCleanups.
+    if (getLangOpts().CXXExceptions && currentFunctionUsesSEHTry())
+      for (const Stmt *S : Except->getBlock()->body())
+        if (const auto *DS = dyn_cast<DeclStmt>(S))
+          for (const Decl *D : DS->decls())
+            if (const auto *VD = dyn_cast<VarDecl>(D))
+              if (VD->needsDestruction(getContext()))
+                getContext().getDiagnostics().Report(
+                    VD->getLocation(), diag::err_seh_object_unwinding);
     CatchScope.clearHandlerBlocks();
     EHStack.popCatch();
     SEHCodeSlotStack.pop_back();

--- a/clang/test/CodeGenCXX/exceptions-seh.cpp
+++ b/clang/test/CodeGenCXX/exceptions-seh.cpp
@@ -5,13 +5,17 @@
 // RUN:         -o - -mconstructor-aliases -O1 -disable-llvm-passes | \
 // RUN:         FileCheck %s --check-prefix=CHECK --check-prefix=NOCXX
 // RUN: %clang_cc1 -triple x86_64-windows -fasync-exceptions -fcxx-exceptions -fexceptions \
-// RUN:         -fms-extensions -x c++ -emit-llvm-only -verify %s -DERR1
+// RUN:         -fms-extensions -x c++ -emit-llvm-only -verify %s -DERR_ASYNC1
 // RUN: %clang_cc1 -triple x86_64-windows -fasync-exceptions -fcxx-exceptions -fexceptions \
-// RUN:         -fms-extensions -x c++ -emit-llvm-only -verify %s -DERR2
+// RUN:         -fms-extensions -x c++ -emit-llvm-only -verify %s -DERR_ASYNC2
 // RUN: %clang_cc1 -triple x86_64-windows -fasync-exceptions -fcxx-exceptions -fexceptions \
-// RUN:         -fms-extensions -x c++ -emit-llvm-only -verify %s -DERR3
+// RUN:         -fms-extensions -x c++ -emit-llvm-only -verify %s -DERR_ASYNC3
 // RUN: %clang_cc1 -triple x86_64-windows -fcxx-exceptions -fexceptions \
-// RUN:         -fms-extensions -x c++ -emit-llvm-only -verify %s -DERR4
+// RUN:         -fms-extensions -x c++ -emit-llvm-only -verify %s -DERR_SYNC1
+// RUN: %clang_cc1 -triple x86_64-windows -fcxx-exceptions -fexceptions \
+// RUN:         -fms-extensions -x c++ -emit-llvm-only -verify %s -DERR_SYNC2
+// RUN: %clang_cc1 -triple x86_64-windows -fcxx-exceptions -fexceptions \
+// RUN:         -fms-extensions -x c++ -emit-llvm-only -verify %s -DERR_SYNC3
 // RUN: %clang_cc1 -triple x86_64-windows \
 // RUN:         -fms-extensions -x c++ -emit-llvm-only -verify %s -DNOERR
 
@@ -186,31 +190,45 @@ void use_inline() {
 
 void seh_in_noexcept() noexcept { __try {} __finally {} }
 
-#if defined(ERR1)
+#if defined(ERR_ASYNC1)
 void seh_unwinding() {
   __try {
     HasCleanup x; // expected-error{{'__try' is not permitted in functions that require object unwinding}}
   } __except (1) {
   }
 }
-#elif defined(ERR2)
+#elif defined(ERR_ASYNC2)
 void seh_unwinding() {
   __try {
   } __except (1) {
     HasCleanup x; // expected-error{{'__try' is not permitted in functions that require object unwinding}}
   }
 }
-#elif defined(ERR3)
+#elif defined(ERR_ASYNC3)
 void seh_unwinding() {
   HasCleanup x; // expected-error{{'__try' is not permitted in functions that require object unwinding}}
   __try {
   } __except (1) {
   }
 }
-#elif defined(ERR4)
+#elif defined(ERR_SYNC1)
 void seh_unwinding() {
   __try {
     HasCleanup x; // expected-error{{'__try' is not permitted in functions that require object unwinding}}
+  } __except (1) {
+  }
+}
+#elif defined(ERR_SYNC2)
+void seh_unwinding() {
+  __try {
+  } __except (1) {
+    HasCleanup x; // expected-error{{'__try' is not permitted in functions that require object unwinding}}
+  }
+}
+#elif defined(ERR_SYNC3)
+void seh_unwinding() {
+  HasCleanup x; // expected-error{{'__try' is not permitted in functions that require object unwinding}}
+  __try {
   } __except (1) {
   }
 }

--- a/clang/test/CodeGenCXX/exceptions-seh.cpp
+++ b/clang/test/CodeGenCXX/exceptions-seh.cpp
@@ -190,42 +190,21 @@ void use_inline() {
 
 void seh_in_noexcept() noexcept { __try {} __finally {} }
 
-#if defined(ERR_ASYNC1)
+#if defined(ERR_ASYNC1) || defined(ERR_SYNC1)
 void seh_unwinding() {
   __try {
     HasCleanup x; // expected-error{{'__try' is not permitted in functions that require object unwinding}}
   } __except (1) {
   }
 }
-#elif defined(ERR_ASYNC2)
+#elif defined(ERR_ASYNC2) || defined(ERR_SYNC2)
 void seh_unwinding() {
   __try {
   } __except (1) {
     HasCleanup x; // expected-error{{'__try' is not permitted in functions that require object unwinding}}
   }
 }
-#elif defined(ERR_ASYNC3)
-void seh_unwinding() {
-  HasCleanup x; // expected-error{{'__try' is not permitted in functions that require object unwinding}}
-  __try {
-  } __except (1) {
-  }
-}
-#elif defined(ERR_SYNC1)
-void seh_unwinding() {
-  __try {
-    HasCleanup x; // expected-error{{'__try' is not permitted in functions that require object unwinding}}
-  } __except (1) {
-  }
-}
-#elif defined(ERR_SYNC2)
-void seh_unwinding() {
-  __try {
-  } __except (1) {
-    HasCleanup x; // expected-error{{'__try' is not permitted in functions that require object unwinding}}
-  }
-}
-#elif defined(ERR_SYNC3)
+#elif defined(ERR_ASYNC3) || defined(ERR_SYNC3)
 void seh_unwinding() {
   HasCleanup x; // expected-error{{'__try' is not permitted in functions that require object unwinding}}
   __try {


### PR DESCRIPTION
This PR fixes a previously discovered [issue](#180959) where destructors in the `except` block could not be diagnosed under enabled exceptions.

For example, The following code could not be diagnosed before this patch when only `CXXExceptions` were enabled:
```
void seh_unwinding() {
  __try {
  } __except (1) {
    HasCleanup x; // expected-error{{'__try' is not permitted in functions that require object unwinding}}
  }
}
```
In the above case, even if `EHBranches` does not exist, it still diagnoses whether object unwinding