### PR TITLE
[FIRToMemRef] copy ACC Variable Name attribute

### DIFF
--- a/flang/lib/Optimizer/Transforms/FIRToMemRef.cpp
+++ b/flang/lib/Optimizer/Transforms/FIRToMemRef.cpp
@@ -330,6 +330,7 @@ void FIRToMemRef::rewriteAlloca(fir::AllocaOp firAlloca,
   copyAttribute(firAlloca, alloca, firAlloca.getBindcNameAttrName());
   copyAttribute(firAlloca, alloca, firAlloca.getUniqNameAttrName());
   copyAttribute(firAlloca, alloca, cuf::getDataAttrName());
+  copyAttribute(firAlloca, alloca, acc::getVarNameAttrName());
 
   auto convert = fir::ConvertOp::create(rewriter, loc, type, alloca);
 

--- a/flang/test/Transforms/FIRToMemRef/alloca.mlir
+++ b/flang/test/Transforms/FIRToMemRef/alloca.mlir
@@ -71,6 +71,7 @@ func.func @alloca_nonconvertible() {
   return
 }
 
+// compiler generated alloca will not perserve declare
 // CHECK-LABEL: func.func @peep_declare
 // CHECK:       [[ALLOCA:%.+]] = memref.alloca() : memref<i32>
 // CHECK-NOT:   fircg.ext_declare
@@ -83,14 +84,33 @@ func.func @peep_declare() {
   return
 }
 
-
 // check that attributes are copied when they exist
-// CHECK-LABEL: func.func @no_peep_declare
-// CHECK:       memref.alloca() {acc.var_name = #acc.var_name<"z">, bindc_name = "x", uniq_name = "y"} : memref<i32>
-// CHECK-NOT:   memref.store %c1_i32, %alloca[] : memref<i32>
-func.func @no_peep_declare() {
+// CHECK-LABEL: func.func @perserve_declare
+// CHECK:       [[ALLOCA:%.*]] = memref.alloca() {bindc_name = "x", uniq_name = "y"} : memref<i32>
+// CHECK-NOT:   memref.store %c1_i32, [[ALLOCA]][] : memref<i32>
+func.func @perserve_declare() {
   %c1_i32 = arith.constant 1 : i32
-  %0 = fir.alloca i32 {acc.var_name = #acc.var_name<"z">, bindc_name = "x", uniq_name = "y"}
+  %0 = fir.alloca i32 {bindc_name = "x", uniq_name = "y"}
+  %1 = fir.declare %0 {uniq_name = "some_name"} : (!fir.ref<i32>) -> !fir.ref<i32>
+  fir.store %c1_i32 to %1 : !fir.ref<i32>
+  return
+}
+
+// CHECK-LABEL: func.func @copy_cuf_data_attr
+// CHECK:       memref.alloca() {cuf.data_attr = #cuf.cuda<device>} : memref<i32>
+func.func @copy_cuf_data_attr() {
+  %c1_i32 = arith.constant 1 : i32
+  %0 = fir.alloca i32 {cuf.data_attr = #cuf.cuda<device>}
+  %1 = fir.declare %0 {uniq_name = "some_name"} : (!fir.ref<i32>) -> !fir.ref<i32>
+  fir.store %c1_i32 to %1 : !fir.ref<i32>
+  return
+}
+
+// CHECK-LABEL: func.func @copy_acc_var_name_attr
+// CHECK:       memref.alloca() {acc.var_name = #acc.var_name<"x">} : memref<i32>
+func.func @copy_acc_var_name_attr() {
+  %c1_i32 = arith.constant 1 : i32
+  %0 = fir.alloca i32 {acc.var_name = #acc.var_name<"x">}
   %1 = fir.declare %0 {uniq_name = "some_name"} : (!fir.ref<i32>) -> !fir.ref<i32>
   fir.store %c1_i32 to %1 : !fir.ref<i32>
   return

--- a/flang/test/Transforms/FIRToMemRef/alloca.mlir
+++ b/flang/test/Transforms/FIRToMemRef/alloca.mlir
@@ -86,11 +86,11 @@ func.func @peep_declare() {
 
 // check that attributes are copied when they exist
 // CHECK-LABEL: func.func @no_peep_declare
-// CHECK:       memref.alloca() {bindc_name = "x", uniq_name = "y"} : memref<i32>
+// CHECK:       memref.alloca() {acc.var_name = #acc.var_name<"z">, bindc_name = "x", uniq_name = "y"} : memref<i32>
 // CHECK-NOT:   memref.store %c1_i32, %alloca[] : memref<i32>
 func.func @no_peep_declare() {
   %c1_i32 = arith.constant 1 : i32
-  %0 = fir.alloca i32 {bindc_name = "x", uniq_name = "y"}
+  %0 = fir.alloca i32 {acc.var_name = #acc.var_name<"z">, bindc_name = "x", uniq_name = "y"}
   %1 = fir.declare %0 {uniq_name = "some_name"} : (!fir.ref<i32>) -> !fir.ref<i32>
   fir.store %c1_i32 to %1 : !fir.ref<i32>
   return

--- a/flang/test/Transforms/FIRToMemRef/alloca.mlir
+++ b/flang/test/Transforms/FIRToMemRef/alloca.mlir
@@ -71,10 +71,10 @@ func.func @alloca_nonconvertible() {
   return
 }
 
-// compiler generated alloca will not perserve declare
+// compiler generated alloca will not preserve declare
 // CHECK-LABEL: func.func @peep_declare
 // CHECK:       [[ALLOCA:%.+]] = memref.alloca() : memref<i32>
-// CHECK-NOT:   fircg.ext_declare
+// CHECK-NOT:   fir.declare
 // CHECK:       memref.store %c1_i32, [[ALLOCA]][] : memref<i32>
 func.func @peep_declare() {
   %c1_i32 = arith.constant 1 : i32
@@ -85,10 +85,10 @@ func.func @peep_declare() {
 }
 
 // check that attributes are copied when they exist
-// CHECK-LABEL: func.func @perserve_declare
+// CHECK-LABEL: func.func @preserve_declare
 // CHECK:       [[ALLOCA:%.*]] = memref.alloca() {bindc_name = "x", uniq_name = "y"} : memref<i32>
 // CHECK-NOT:   memref.store %c1_i32, [[ALLOCA]][] : memref<i32>
-func.func @perserve_declare() {
+func.func @preserve_declare() {
   %c1_i32 = arith.constant 1 : i32
   %0 = fir.alloca i32 {bindc_name = "x", uniq_name = "y"}
   %1 = fir.declare %0 {uniq_name = "some_name"} : (!fir.ref<i32>) -> !fir.ref<i32>


### PR DESCRIPTION
When converting from fir.alloca to memref.alloca, also copy the acc variable name attribute if it exists