### PR TITLE
[clang][AST] Fix assertion in getFullyQualifiedType for DecltypeType

### DIFF
--- a/clang/lib/AST/QualTypeNames.cpp
+++ b/clang/lib/AST/QualTypeNames.cpp
@@ -450,6 +450,17 @@ QualType getFullyQualifiedType(QualType QT, const ASTContext &Ctx,
     QT = Ctx.getQualifiedType(QT, Quals);
   }
 
+  // Try to get to the underlying type for DecltypeType
+  while (const auto *DT = dyn_cast<DecltypeType>(QT.getTypePtr())) {
+    // Get the qualifiers.
+    Qualifiers Quals = QT.getQualifiers();
+    QualType Underlying = DT->getUnderlyingType();
+    if (Underlying.isNull() || Underlying->isDependentType())
+      break;
+    // Add back the qualifiers.
+    QT = Ctx.getQualifiedType(Underlying, Quals);
+  }
+
   if (const auto *TST =
           dyn_cast<const TemplateSpecializationType>(QT.getTypePtr())) {
 

--- a/clang/test/Interpreter/pretty-print.cpp
+++ b/clang/test/Interpreter/pretty-print.cpp
@@ -73,6 +73,18 @@ auto y = Outer::Bar<int>(); y
 const auto z = Outer::Foo(); z
 // CHECK-NEXT: (const Outer::Foo &) @0x{{[0-9a-f]+}}
 
+// Check printing of DecltypeTypes (this used to assert)
+namespace N { struct D {}; }
+decltype(N::D()) decl1; decl1
+// CHECK-NEXT: (N::D &) @0x{{[0-9a-f]+}}
+
+// double-nested DecltypeType
+decltype(decl1) decl2; decl2
+// CHECK-NEXT: (N::D &) @0x{{[0-9a-f]+}}
+
+const decltype(N::D()) decl3; decl3
+// CHECK-NEXT: (const N::D &) @0x{{[0-9a-f]+}}
+
 // int i = 12;
 // int &iref = i;
 // iref


### PR DESCRIPTION
This is similar to 86c4e96, asserts "Unhandled type node" when the input QualType is a DecltypeType.

This was exposed by clang-repl's value printer:
```
clang-repl> namespace N { struct D {}; }
clang-repl> decltype(N::D()) x; x // asserts
```