### PR TITLE
[llvm] Run headers-winhttp.test only if the Python side of it works

### DIFF
--- a/llvm/test/tools/llvm-debuginfod-find/headers-curl.test
+++ b/llvm/test/tools/llvm-debuginfod-find/headers-curl.test
@@ -1,4 +1,4 @@
-REQUIRES: curl
+REQUIRES: curl, http-server
 
 RUN: rm -rf %t
 RUN: mkdir -p %t/debuginfod-cache

--- a/llvm/test/tools/llvm-debuginfod-find/headers-winhttp.test
+++ b/llvm/test/tools/llvm-debuginfod-find/headers-winhttp.test
@@ -1,4 +1,4 @@
-REQUIRES: system-windows
+REQUIRES: system-windows, http-server
 
 RUN: rm -rf %t
 RUN: mkdir -p %t/debuginfod-cache

--- a/llvm/test/tools/llvm-debuginfod-find/headers-winhttp.test
+++ b/llvm/test/tools/llvm-debuginfod-find/headers-winhttp.test
@@ -1,5 +1,8 @@
 REQUIRES: system-windows, http-server
 
+RUN: llvm-debuginfod-find --debuginfo 0 | FileCheck --check-prefix CHECK-STDOUT
+CHECK-STDOUT: Build ID 00 could not be found
+
 RUN: rm -rf %t
 RUN: mkdir -p %t/debuginfod-cache
 RUN: %python %S/Inputs/capture_req.py llvm-debuginfod-find --debuginfo 0 \

--- a/llvm/test/tools/llvm-debuginfod-find/headers-winhttp.test
+++ b/llvm/test/tools/llvm-debuginfod-find/headers-winhttp.test
@@ -1,6 +1,6 @@
 REQUIRES: system-windows, http-server
 
-RUN: llvm-debuginfod-find --debuginfo 0 | FileCheck --check-prefix CHECK-STDOUT
+RUN: not llvm-debuginfod-find --debuginfo 0 2>&1 | FileCheck %s --check-prefix CHECK-STDOUT
 CHECK-STDOUT: Build ID 00 could not be found
 
 RUN: rm -rf %t

--- a/llvm/test/tools/llvm-debuginfod-find/lit.local.cfg.py
+++ b/llvm/test/tools/llvm-debuginfod-find/lit.local.cfg.py
@@ -1,0 +1,41 @@
+import http.server
+import threading
+import urllib.request
+import time
+import sys
+
+captured_req = False
+
+class TrivialHandler(http.server.BaseHTTPRequestHandler):
+    def do_GET(self):
+        self.send_response(200)
+        self.end_headers()
+    def log_request(self, *args, **kwargs):
+        if len(self.requestline) > 0:
+            if len(self.headers) > 0:
+                global captured_req
+                captured_req = True
+
+# Start server on random free port, query it and check response
+def can_capture_req_to_http_server():
+    if sys.platform != "win32":
+        return True
+    try:
+        httpd = http.server.HTTPServer(("127.0.0.1", 0), TrivialHandler)
+        port = httpd.server_address[1]
+        thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+        thread.start()
+        time.sleep(0.2)
+        url = f"http://127.0.0.1:{port}/"
+        with urllib.request.urlopen(url) as response:
+            if response.status == 200:
+              return captured_req
+    except Exception as e:
+        print("Failed to start and query HTTP server: ", repr(e))
+        return False
+    finally:
+        httpd.shutdown()
+        thread.join()
+
+if can_capture_req_to_http_server():
+    config.available_features.add("http-server")

--- a/llvm/test/tools/llvm-debuginfod-find/lit.local.cfg.py
+++ b/llvm/test/tools/llvm-debuginfod-find/lit.local.cfg.py
@@ -4,7 +4,9 @@ import urllib.request
 import time
 import sys
 
+
 captured_req = False
+
 
 class TrivialHandler(http.server.BaseHTTPRequestHandler):
     def do_GET(self):
@@ -15,6 +17,7 @@ class TrivialHandler(http.server.BaseHTTPRequestHandler):
             if len(self.headers) > 0:
                 global captured_req
                 captured_req = True
+
 
 # Start server on random free port, query it and check response
 def can_capture_req_to_http_server():
@@ -29,13 +32,14 @@ def can_capture_req_to_http_server():
         url = f"http://127.0.0.1:{port}/"
         with urllib.request.urlopen(url) as response:
             if response.status == 200:
-              return captured_req
+                return captured_req
     except Exception as e:
         print("Failed to start and query HTTP server: ", repr(e))
         return False
     finally:
         httpd.shutdown()
         thread.join()
+
 
 if can_capture_req_to_http_server():
     config.available_features.add("http-server")

--- a/llvm/test/tools/llvm-debuginfod-find/lit.local.cfg.py
+++ b/llvm/test/tools/llvm-debuginfod-find/lit.local.cfg.py
@@ -12,6 +12,7 @@ class TrivialHandler(http.server.BaseHTTPRequestHandler):
     def do_GET(self):
         self.send_response(200)
         self.end_headers()
+
     def log_request(self, *args, **kwargs):
         if len(self.requestline) > 0:
             if len(self.headers) > 0:


### PR DESCRIPTION
a3db68a97b2c321ef0af73f39a3725490c131468 seemed t be the obvious fix for the winhttp issue from 39d6bb21804d21abe2fa0ec019919d72104827ac in llvm-debuginfod-find, but there are still bots failing. This patch disables the test on all bots that cannot spawn an HTTP server in Python and record request headers. Ideally it turns all affected bots back to green and gives us time to investigate.