### PR TITLE
[CIR] Disable CIR pipeline for LLVM IR inputs

### DIFF
--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -3291,6 +3291,12 @@ static bool ParseFrontendArgs(FrontendOptions &Opts, ArgList &Args,
 
   Opts.DashX = DashX;
 
+  // CIR is a source-level frontend pipeline. When the input is already LLVM IR
+  // (e.g. during the backend phase of OpenMP offloading), the standard LLVM
+  // backend should be used instead.
+  if (Opts.UseClangIRPipeline && DashX.getLanguage() == Language::LLVM_IR)
+    Opts.UseClangIRPipeline = false;
+
   return Diags.getNumErrors() == NumErrorsBefore;
 }
 

--- a/clang/test/CIR/Driver/clangir.c
+++ b/clang/test/CIR/Driver/clangir.c
@@ -1,3 +1,5 @@
+// Tests related to -fclangir option.
+
 // Verify that -fclangir is always forwarded to -cc1 by the driver, and
 // that the frontend ignores it when the input is LLVM IR.
 

--- a/clang/test/Driver/clangir-no-llvmir.c
+++ b/clang/test/Driver/clangir-no-llvmir.c
@@ -1,0 +1,16 @@
+// Verify that -fclangir is always forwarded to -cc1 by the driver, and
+// that the frontend ignores it when the input is LLVM IR.
+
+// -fclangir should be passed to -cc1 for source inputs.
+// RUN: %clang -### -fclangir -S %s 2>&1 | FileCheck %s --check-prefix=SOURCE
+// SOURCE: "-cc1"
+// SOURCE-SAME: "-fclangir"
+// SOURCE-SAME: "-x" "c"
+
+// -fclangir should also be passed to -cc1 for LLVM IR inputs (the frontend
+// will ignore it and use the standard LLVM backend).
+// RUN: %clang -### -fclangir -S -x ir /dev/null 2>&1 | FileCheck %s --check-prefix=LLVMIR
+// LLVMIR: "-cc1"
+// LLVMIR-SAME: "-fclangir"
+
+void foo() {}


### PR DESCRIPTION
When -fclangir is passed and the input is LLVM IR (e.g. during the
backend phase of OpenMP offloading), the CIR frontend pipeline is not
applicable.


Co-authored-by: Claude Opus 4.6 <noreply@anthropic.com>
