### PR TITLE
[GlobalISel] Add `widenScalarFor()` function

### DIFF
--- a/llvm/include/llvm/CodeGen/GlobalISel/LegalizerInfo.h
+++ b/llvm/include/llvm/CodeGen/GlobalISel/LegalizerInfo.h
@@ -840,6 +840,14 @@ public:
     markAllIdxsAsCovered();
     return actionIf(LegalizeAction::WidenScalar, Predicate, Mutation);
   }
+  /// Widen the scalar, specified in mutation, when type indexes 0 and 1 is any
+  /// type pair in the given list.
+  LegalizeRuleSet &
+  widenScalarFor(std::initializer_list<std::pair<LLT, LLT>> Types,
+                 LegalizeMutation Mutation) {
+    return actionFor(LegalizeAction::WidenScalar, Types, Mutation);
+  }
+
   /// Narrow the scalar to the one selected by the mutation if the predicate is
   /// true.
   LegalizeRuleSet &narrowScalarIf(LegalityPredicate Predicate,


### PR DESCRIPTION
The function is mentioned in `Legalizer.rst` but has been missing. This also fixes the asymetry between `narrowScalarXXX()` that has both `narrowScalarFor()` and `narrowScalarIf()`, and `widenScalarXXX()` that only had `widenScalarIf()`.