### PR TITLE
[offload] Define flang-rt as an available test feature

### DIFF
--- a/offload/test/lit.cfg
+++ b/offload/test/lit.cfg
@@ -71,6 +71,14 @@ def evaluate_bool_env(env):
             return True
     return False
 
+def remove_suffix_if_present(name):
+    if name.endswith('-LTO'):
+        return name[:-4]
+    elif name.endswith('-JIT-LTO'):
+        return name[:-8]
+    else:
+        return name
+
 # name: The name of this test suite.
 config.name = 'libomptarget :: ' + config.libomptarget_current_target
 
@@ -133,19 +141,21 @@ if config.libomptarget_has_libc:
   config.available_features.add('libc')
 
 profdata_path = os.path.join(config.bin_llvm_tools_dir, "llvm-profdata")
-target = config.libomptarget_current_target
-for suffix in ['-JIT-LTO', '-LTO']:
-  if target.endswith(suffix):
-    target = target[:-len(suffix)]
-    break
+target = remove_suffix_if_present(config.libomptarget_current_target)
 has_profile_rt = True
+has_flang_rt = True
 if target.startswith('amdgcn') or target.startswith('nvptx'):
   has_profile_rt = bool(glob.glob(os.path.join(
       config.llvm_lib_directory, 'clang', '*', 'lib', target,
       'libclang_rt.profile.a')))
+  has_flang_rt = bool(glob.glob(os.path.join(
+      config.llvm_lib_directory, 'clang', '*', 'lib', target,
+      'libflang_rt.runtime.a')))
 if has_profile_rt:
   config.available_features.add('pgo')
   config.substitutions.append(("%profdata", profdata_path))
+if has_flang_rt:
+  config.available_features.add('flang-rt')
 
 # Determine whether the test system supports unified memory.
 # For CUDA, this is the case with compute capability 70 (Volta) or higher.
@@ -225,14 +235,6 @@ if config.libomptarget_current_target.startswith('spirv64-intel'):
     config.available_features.add('intelgpu')
 if config.libomptarget_current_target in host_targets:
     config.available_features.add('host')
-
-def remove_suffix_if_present(name):
-    if name.endswith('-LTO'):
-        return name[:-4]
-    elif name.endswith('-JIT-LTO'):
-        return name[:-8]
-    else:
-        return name
 
 def add_libraries(source):
     if "gpu" not in config.available_features:


### PR DESCRIPTION
Can now be used as `REQUIRES: flang-rt`, for example.