### PR TITLE
[RISCV] Fix the pipe used by `fmv.x.<fp>/<fp>.x` in SiFive7 sched model

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVSchedSiFive7.td
+++ b/llvm/lib/Target/RISCV/RISCVSchedSiFive7.td
@@ -523,12 +523,12 @@ multiclass SiFive7WriteResBase<int VLEN,
   def : WriteRes<WriteFCmp16, [PipeB]>;
   def : WriteRes<WriteFCmp32, [PipeB]>;
   def : WriteRes<WriteFCmp64, [PipeB]>;
-  def : WriteRes<WriteFMovI16ToF16, [PipeB]>;
-  def : WriteRes<WriteFMovF16ToI16, [PipeB]>;
-  def : WriteRes<WriteFMovI32ToF32, [PipeB]>;
-  def : WriteRes<WriteFMovF32ToI32, [PipeB]>;
-  def : WriteRes<WriteFMovI64ToF64, [PipeB]>;
-  def : WriteRes<WriteFMovF64ToI64, [PipeB]>;
+  def : WriteRes<WriteFMovI16ToF16, [PipeA]>;
+  def : WriteRes<WriteFMovF16ToI16, [PipeA]>;
+  def : WriteRes<WriteFMovI32ToF32, [PipeA]>;
+  def : WriteRes<WriteFMovF32ToI32, [PipeA]>;
+  def : WriteRes<WriteFMovI64ToF64, [PipeA]>;
+  def : WriteRes<WriteFMovF64ToI64, [PipeA]>;
   }
 
   // 6. Configuration-Setting Instructions

--- a/llvm/test/tools/llvm-mca/RISCV/SiFiveX100/floating-point.test
+++ b/llvm/test/tools/llvm-mca/RISCV/SiFiveX100/floating-point.test
@@ -58,8 +58,8 @@
 # CHECK-NEXT:  1      3     1.00                         3     VLEN128X100SiFive7PipeAB,VLEN128X100SiFive7PipeB FCVT_LU_S            fcvt.lu.s	a1, ft1
 # CHECK-NEXT:  1      3     1.00                         3     VLEN128X100SiFive7PipeAB,VLEN128X100SiFive7PipeB FCVT_S_L             fcvt.s.l	ft2, a2
 # CHECK-NEXT:  1      3     1.00                         3     VLEN128X100SiFive7PipeAB,VLEN128X100SiFive7PipeB FCVT_S_LU            fcvt.s.lu	ft3, a3
-# CHECK-NEXT:  1      3     1.00                         3     VLEN128X100SiFive7PipeAB,VLEN128X100SiFive7PipeB FMV_X_W              fmv.x.w	a2, fs7
-# CHECK-NEXT:  1      3     1.00                         3     VLEN128X100SiFive7PipeAB,VLEN128X100SiFive7PipeB FMV_W_X              fmv.w.x	ft1, a6
+# CHECK-NEXT:  1      3     1.00                         3     VLEN128X100SiFive7PipeA,VLEN128X100SiFive7PipeAB FMV_X_W              fmv.x.w	a2, fs7
+# CHECK-NEXT:  1      3     1.00                         3     VLEN128X100SiFive7PipeA,VLEN128X100SiFive7PipeAB FMV_W_X              fmv.w.x	ft1, a6
 # CHECK-NEXT:  1      3     1.00                         3     VLEN128X100SiFive7PipeAB,VLEN128X100SiFive7PipeB FSGNJ_S              fsgnj.s	fs1, fa0, fa1
 # CHECK-NEXT:  1      3     1.00                         3     VLEN128X100SiFive7PipeAB,VLEN128X100SiFive7PipeB FSGNJN_S             fsgnjn.s	fa1, fa3, fa4
 # CHECK-NEXT:  1      3     1.00                         3     VLEN128X100SiFive7PipeAB,VLEN128X100SiFive7PipeB FCVT_WU_D            fcvt.wu.d	a4, ft11
@@ -72,8 +72,8 @@
 # CHECK-NEXT:  1      3     1.00                         3     VLEN128X100SiFive7PipeAB,VLEN128X100SiFive7PipeB FCVT_LU_D            fcvt.lu.d	a1, ft1
 # CHECK-NEXT:  1      3     1.00                         3     VLEN128X100SiFive7PipeAB,VLEN128X100SiFive7PipeB FCVT_D_L             fcvt.d.l	ft3, a3
 # CHECK-NEXT:  1      3     1.00                         3     VLEN128X100SiFive7PipeAB,VLEN128X100SiFive7PipeB FCVT_D_LU            fcvt.d.lu	ft4, a4
-# CHECK-NEXT:  1      3     1.00                         3     VLEN128X100SiFive7PipeAB,VLEN128X100SiFive7PipeB FMV_X_D              fmv.x.d	a2, ft2
-# CHECK-NEXT:  1      3     1.00                         3     VLEN128X100SiFive7PipeAB,VLEN128X100SiFive7PipeB FMV_D_X              fmv.d.x	ft5, a5
+# CHECK-NEXT:  1      3     1.00                         3     VLEN128X100SiFive7PipeA,VLEN128X100SiFive7PipeAB FMV_X_D              fmv.x.d	a2, ft2
+# CHECK-NEXT:  1      3     1.00                         3     VLEN128X100SiFive7PipeA,VLEN128X100SiFive7PipeAB FMV_D_X              fmv.d.x	ft5, a5
 # CHECK-NEXT:  1      3     1.00                         3     VLEN128X100SiFive7PipeAB,VLEN128X100SiFive7PipeB FSGNJ_D              fsgnj.d	fs1, fa0, fa1
 # CHECK-NEXT:  1      3     1.00                         3     VLEN128X100SiFive7PipeAB,VLEN128X100SiFive7PipeB FSGNJN_D             fsgnjn.d	fa1, fa3, fa4
 # CHECK-NEXT:  1      3     1.00                         3     VLEN128X100SiFive7PipeAB,VLEN128X100SiFive7PipeB FEQ_S                feq.s	a1, fs8, fs9
@@ -97,7 +97,7 @@
 
 # CHECK:      Resource pressure per iteration:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]
-# CHECK-NEXT: 162.00  -     4.00   56.00   -      -      -      -
+# CHECK-NEXT: 162.00  -     8.00   52.00   -      -      -      -
 
 # CHECK:      Resource pressure by instruction:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]    Instructions:
@@ -135,8 +135,8 @@
 # CHECK-NEXT:  -      -      -     1.00    -      -      -      -     fcvt.lu.s	a1, ft1
 # CHECK-NEXT:  -      -      -     1.00    -      -      -      -     fcvt.s.l	ft2, a2
 # CHECK-NEXT:  -      -      -     1.00    -      -      -      -     fcvt.s.lu	ft3, a3
-# CHECK-NEXT:  -      -      -     1.00    -      -      -      -     fmv.x.w	a2, fs7
-# CHECK-NEXT:  -      -      -     1.00    -      -      -      -     fmv.w.x	ft1, a6
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     fmv.x.w	a2, fs7
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     fmv.w.x	ft1, a6
 # CHECK-NEXT:  -      -      -     1.00    -      -      -      -     fsgnj.s	fs1, fa0, fa1
 # CHECK-NEXT:  -      -      -     1.00    -      -      -      -     fsgnjn.s	fa1, fa3, fa4
 # CHECK-NEXT:  -      -      -     1.00    -      -      -      -     fcvt.wu.d	a4, ft11
@@ -149,8 +149,8 @@
 # CHECK-NEXT:  -      -      -     1.00    -      -      -      -     fcvt.lu.d	a1, ft1
 # CHECK-NEXT:  -      -      -     1.00    -      -      -      -     fcvt.d.l	ft3, a3
 # CHECK-NEXT:  -      -      -     1.00    -      -      -      -     fcvt.d.lu	ft4, a4
-# CHECK-NEXT:  -      -      -     1.00    -      -      -      -     fmv.x.d	a2, ft2
-# CHECK-NEXT:  -      -      -     1.00    -      -      -      -     fmv.d.x	ft5, a5
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     fmv.x.d	a2, ft2
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     fmv.d.x	ft5, a5
 # CHECK-NEXT:  -      -      -     1.00    -      -      -      -     fsgnj.d	fs1, fa0, fa1
 # CHECK-NEXT:  -      -      -     1.00    -      -      -      -     fsgnjn.d	fa1, fa3, fa4
 # CHECK-NEXT:  -      -      -     1.00    -      -      -      -     feq.s	a1, fs8, fs9

--- a/llvm/test/tools/llvm-mca/RISCV/SiFiveX100/zfhmin.test
+++ b/llvm/test/tools/llvm-mca/RISCV/SiFiveX100/zfhmin.test
@@ -26,8 +26,8 @@
 # CHECK:      [1]    [2]    [3]    [4]    [5]    [6]    [7]    [8]                                        [9]                        Instructions:
 # CHECK-NEXT:  1      3     1.00    *                    3     VLEN128X100SiFive7PipeA,VLEN128X100SiFive7PipeAB FLH                  flh	ft0, 0(a0)
 # CHECK-NEXT:  1      1     1.00           *             1     VLEN128X100SiFive7PipeA,VLEN128X100SiFive7PipeAB FSH                  fsh	ft0, 0(a0)
-# CHECK-NEXT:  1      3     1.00                         3     VLEN128X100SiFive7PipeAB,VLEN128X100SiFive7PipeB FMV_X_H              fmv.x.h	a2, fs7
-# CHECK-NEXT:  1      3     1.00                         3     VLEN128X100SiFive7PipeAB,VLEN128X100SiFive7PipeB FMV_H_X              fmv.h.x	ft1, a6
+# CHECK-NEXT:  1      3     1.00                         3     VLEN128X100SiFive7PipeA,VLEN128X100SiFive7PipeAB FMV_X_H              fmv.x.h	a2, fs7
+# CHECK-NEXT:  1      3     1.00                         3     VLEN128X100SiFive7PipeA,VLEN128X100SiFive7PipeAB FMV_H_X              fmv.h.x	ft1, a6
 # CHECK-NEXT:  1      3     1.00                         3     VLEN128X100SiFive7PipeAB,VLEN128X100SiFive7PipeB FCVT_S_H             fcvt.s.h	fa0, ft0
 # CHECK-NEXT:  1      3     1.00                         3     VLEN128X100SiFive7PipeAB,VLEN128X100SiFive7PipeB FCVT_S_H             fcvt.s.h	fa0, ft0, rup
 # CHECK-NEXT:  1      3     1.00                         3     VLEN128X100SiFive7PipeAB,VLEN128X100SiFive7PipeB FCVT_H_S             fcvt.h.s	ft2, fa2
@@ -47,14 +47,14 @@
 
 # CHECK:      Resource pressure per iteration:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]
-# CHECK-NEXT:  -      -     2.00   8.00    -      -      -      -
+# CHECK-NEXT:  -      -     4.00   6.00    -      -      -      -
 
 # CHECK:      Resource pressure by instruction:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]    Instructions:
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     flh	ft0, 0(a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     fsh	ft0, 0(a0)
-# CHECK-NEXT:  -      -      -     1.00    -      -      -      -     fmv.x.h	a2, fs7
-# CHECK-NEXT:  -      -      -     1.00    -      -      -      -     fmv.h.x	ft1, a6
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     fmv.x.h	a2, fs7
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     fmv.h.x	ft1, a6
 # CHECK-NEXT:  -      -      -     1.00    -      -      -      -     fcvt.s.h	fa0, ft0
 # CHECK-NEXT:  -      -      -     1.00    -      -      -      -     fcvt.s.h	fa0, ft0, rup
 # CHECK-NEXT:  -      -      -     1.00    -      -      -      -     fcvt.h.s	ft2, fa2


### PR DESCRIPTION
These FP <-> Integer conversion instructions should use PipeA instead.