### PR TITLE
[clang] Improve the diagnostic for unexpected token after module name

### DIFF
--- a/clang/include/clang/Basic/DiagnosticLexKinds.td
+++ b/clang/include/clang/Basic/DiagnosticLexKinds.td
@@ -1007,8 +1007,9 @@ def err_pp_module_name_is_macro : Error<
 def err_pp_module_expected_ident : Error<
   "expected %select{identifier after '.' in |}0module name">;
 def err_pp_unexpected_tok_after_module_name : Error<
-  "unexpected preprocessing token '%0' after module name, "
-  "only ';' and '[' (start of attribute specifier sequence) are allowed">;
+  "unexpected preprocessing token '%0' after module name; "
+  "%select{only ';' and '[' (start of attribute specifier sequence) "
+  "are allowed|expansion of %2 is not part of module name}1">;
 def warn_pp_extra_tokens_at_module_directive_eol
     : Warning<"extra tokens after semicolon in '%0' directive">,
       InGroup<ExtraTokens>;

--- a/clang/lib/Lex/PPDirectives.cpp
+++ b/clang/lib/Lex/PPDirectives.cpp
@@ -4417,9 +4417,20 @@ void Preprocessor::HandleCXXModuleDirective(Token ModuleTok) {
 
   // Only ';' and '[' are allowed after module name.
   // We also check 'private' because the previous is not a module name.
-  if (!NextPPTok->isOneOf(tok::semi, tok::eod, tok::l_square, tok::kw_private))
-    Diag(*NextPPTok, diag::err_pp_unexpected_tok_after_module_name)
-        << getSpelling(*NextPPTok);
+  if (!NextPPTok->isOneOf(tok::semi, tok::eod, tok::l_square,
+                          tok::kw_private)) {
+    SourceLocation Loc = NextPPTok->getLocation();
+    auto DB = Diag(*NextPPTok, diag::err_pp_unexpected_tok_after_module_name)
+              << getSpelling(*NextPPTok) << Loc.isMacroID();
+
+    if (Loc.isMacroID()) {
+      StringRef MacroName = Lexer::getImmediateMacroNameForDiagnostics(
+          Loc, getSourceManager(), getLangOpts());
+      IdentifierInfo *II = getIdentifierInfo(MacroName);
+      assert(II && "Macro should be defined");
+      DB << II;
+    }
+  }
 
   if (!DirToks.back().isOneOf(tok::semi, tok::eod)) {
     // Consume the pp-import-suffix and expand any macros in it now. We'll add

--- a/clang/test/CXX/drs/cwg2947.cpp
+++ b/clang/test/CXX/drs/cwg2947.cpp
@@ -35,9 +35,9 @@
 // cwg2947: 23 tentatively ready 2026-03-06
 
 //--- cwg2947_example1.cpp
-// #define DOT_BAR .bar
+// -D'DOT_BAR=.bar'
 export module foo DOT_BAR; // error: expansion of DOT_BAR; does not begin with ; or [
-// expected-error@-1 {{unexpected preprocessing token '.' after module name, only ';' and '[' (start of attribute specifier sequence) are allowed}}
+// expected-error@-1 {{unexpected preprocessing token '.' after module name; expansion of 'DOT_BAR' is not part of module name}}
 
 //--- cwg2947_example2.cpp
 export module M MOD_ATTR;        // OK
@@ -46,7 +46,7 @@ export module M MOD_ATTR;        // OK
 //--- cwg2947_example3.cpp
 export module a
   .b;                         // error: preprocessing token after pp-module-name is not ; or [
-// expected-error@-1 {{unexpected preprocessing token '.' after module name, only ';' and '[' (start of attribute specifier sequence) are allowed}}
+// expected-error@-1 {{unexpected preprocessing token '.' after module name; only ';' and '[' (start of attribute specifier sequence) are allowed}}
 
 //--- cwg2947_example4.cpp
 export module M [[


### PR DESCRIPTION
 Improve the diagnostic for unexpected token after module name:
 
Consider the following code:
```cpp
// -D'DOT_BAR=.bar'
export module foo DOT_BAR;
```

Before:

```
error: unexpected preprocessing token '.' after module name, only ';' and '[' (start of attribute specifier sequence) are allowed
```

After:

```
error: unexpected preprocessing token '.' after module name; expansion of 'DOT_BAR' is not part of module name
```