### PR TITLE
[Clang] Use stable_sort for UnqualUsingDirectiveSet for determinism in ambiguity notes

### DIFF
--- a/clang/lib/Sema/SemaLookup.cpp
+++ b/clang/lib/Sema/SemaLookup.cpp
@@ -193,7 +193,7 @@ namespace {
       list.push_back(UnqualUsingEntry(UD->getNominatedNamespace(), Common));
     }
 
-    void done() { llvm::sort(list, UnqualUsingEntry::Comparator()); }
+    void done() { llvm::stable_sort(list, UnqualUsingEntry::Comparator()); }
 
     typedef ListTy::const_iterator const_iterator;
 


### PR DESCRIPTION
In SemaLookup.cpp, `UnqualUsingDirectiveSet::done()` uses `llvm::sort` with a comparator that only checks the ancestor relationships. So, if there are multiple "neighbor" namespaces, they are considered equal, and thus `llvm::sort` may return the using directives in a non-deterministic order.

This was observed as a test failure on clang/test/CXX/drs/cwg0xx.cpp at line 220 after PR #187219 started verifying the diagnostics ordering. The two "candidate found by name lookup" notes were emitted in the opposite order from the test's expectations -- in some builds of Clang, but not others.

Switching to `llvm::stable_sort` ensures that using-directives are always traversed in a deterministic order, and thus the notes emitted deterministically.