### PR TITLE
[NVPTX] Canonicalize NVVM attribute strings and refactor property queries (NFC)

### DIFF
--- a/clang/lib/CodeGen/Targets/NVPTX.cpp
+++ b/clang/lib/CodeGen/Targets/NVPTX.cpp
@@ -13,6 +13,7 @@
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/IR/CallingConv.h"
 #include "llvm/IR/IntrinsicsNVPTX.h"
+#include "llvm/Support/NVVMAttributes.h"
 
 using namespace clang;
 using namespace clang::CodeGen;
@@ -272,9 +273,9 @@ void NVPTXTargetCodeGenInfo::setTargetAttributes(
 
         for (auto IV : llvm::enumerate(FD->parameters()))
           if (IV.value()->hasAttr<CUDAGridConstantAttr>())
-            F->addParamAttr(
-                IV.index(),
-                llvm::Attribute::get(F->getContext(), "nvvm.grid_constant"));
+            F->addParamAttr(IV.index(),
+                            llvm::Attribute::get(F->getContext(),
+                                                 llvm::NVVMAttr::GridConstant));
       }
       if (CUDALaunchBoundsAttr *Attr = FD->getAttr<CUDALaunchBoundsAttr>())
         M.handleCUDALaunchBoundsAttr(F, Attr);
@@ -358,7 +359,8 @@ void CodeGenModule::handleCUDALaunchBoundsAttr(llvm::Function *F,
     if (MaxThreadsVal)
       *MaxThreadsVal = MaxThreads.getExtValue();
     if (F)
-      F->addFnAttr("nvvm.maxntid", llvm::utostr(MaxThreads.getExtValue()));
+      F->addFnAttr(llvm::NVVMAttr::MaxNTID,
+                   llvm::utostr(MaxThreads.getExtValue()));
   }
 
   // min and max blocks is an optional argument for CUDALaunchBoundsAttr. If it
@@ -371,7 +373,8 @@ void CodeGenModule::handleCUDALaunchBoundsAttr(llvm::Function *F,
       if (MinBlocksVal)
         *MinBlocksVal = MinBlocks.getExtValue();
       if (F)
-        F->addFnAttr("nvvm.minctasm", llvm::utostr(MinBlocks.getExtValue()));
+        F->addFnAttr(llvm::NVVMAttr::MinCTASm,
+                     llvm::utostr(MinBlocks.getExtValue()));
     }
   }
   if (Attr->getMaxBlocks()) {
@@ -381,7 +384,7 @@ void CodeGenModule::handleCUDALaunchBoundsAttr(llvm::Function *F,
       if (MaxClusterRankVal)
         *MaxClusterRankVal = MaxBlocks.getExtValue();
       if (F)
-        F->addFnAttr("nvvm.maxclusterrank",
+        F->addFnAttr(llvm::NVVMAttr::MaxClusterRank,
                      llvm::utostr(MaxBlocks.getExtValue()));
     }
   }

--- a/llvm/include/llvm/Support/NVVMAttributes.h
+++ b/llvm/include/llvm/Support/NVVMAttributes.h
@@ -1,0 +1,33 @@
+//===--- NVVMAttributes.h - NVVM IR attribute names -------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Canonical string constants for NVVM function and parameter attributes.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_SUPPORT_NVVMATTRIBUTES_H
+#define LLVM_SUPPORT_NVVMATTRIBUTES_H
+
+#include "llvm/ADT/StringRef.h"
+
+namespace llvm {
+namespace NVVMAttr {
+
+constexpr StringLiteral MaxNTID("nvvm.maxntid");
+constexpr StringLiteral ReqNTID("nvvm.reqntid");
+constexpr StringLiteral ClusterDim("nvvm.cluster_dim");
+constexpr StringLiteral MaxClusterRank("nvvm.maxclusterrank");
+constexpr StringLiteral MinCTASm("nvvm.minctasm");
+constexpr StringLiteral MaxNReg("nvvm.maxnreg");
+constexpr StringLiteral BlocksAreClusters("nvvm.blocksareclusters");
+constexpr StringLiteral GridConstant("nvvm.grid_constant");
+
+} // namespace NVVMAttr
+} // namespace llvm
+
+#endif // LLVM_SUPPORT_NVVMATTRIBUTES_H

--- a/llvm/lib/Frontend/OpenMP/OMPIRBuilder.cpp
+++ b/llvm/lib/Frontend/OpenMP/OMPIRBuilder.cpp
@@ -53,6 +53,7 @@
 #include "llvm/Support/Error.h"
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/FileSystem.h"
+#include "llvm/Support/NVVMAttributes.h"
 #include "llvm/Support/VirtualFileSystem.h"
 #include "llvm/Target/TargetMachine.h"
 #include "llvm/Target/TargetOptions.h"
@@ -7945,8 +7946,8 @@ OpenMPIRBuilder::readThreadBoundsForKernel(const Triple &T, Function &Kernel) {
     return {LB, UB};
   }
 
-  if (Kernel.hasFnAttribute("nvvm.maxntid")) {
-    int32_t UB = Kernel.getFnAttributeAsParsedInteger("nvvm.maxntid");
+  if (Kernel.hasFnAttribute(NVVMAttr::MaxNTID)) {
+    int32_t UB = Kernel.getFnAttributeAsParsedInteger(NVVMAttr::MaxNTID);
     return {0, ThreadLimit ? std::min(ThreadLimit, UB) : UB};
   }
   return {0, ThreadLimit};
@@ -7963,7 +7964,7 @@ void OpenMPIRBuilder::writeThreadBoundsForKernel(const Triple &T,
     return;
   }
 
-  updateNVPTXAttr(Kernel, "nvvm.maxntid", UB, true);
+  updateNVPTXAttr(Kernel, NVVMAttr::MaxNTID, UB, true);
 }
 
 std::pair<int32_t, int32_t>
@@ -7976,7 +7977,7 @@ void OpenMPIRBuilder::writeTeamsForKernel(const Triple &T, Function &Kernel,
                                           int32_t LB, int32_t UB) {
   if (T.isNVPTX())
     if (UB > 0)
-      Kernel.addFnAttr("nvvm.maxclusterrank", llvm::utostr(UB));
+      Kernel.addFnAttr(NVVMAttr::MaxClusterRank, llvm::utostr(UB));
   if (T.isAMDGPU())
     Kernel.addFnAttr("amdgpu-max-num-workgroups", llvm::utostr(LB) + ",1,1");
 

--- a/llvm/lib/IR/AutoUpgrade.cpp
+++ b/llvm/lib/IR/AutoUpgrade.cpp
@@ -48,6 +48,7 @@
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/NVPTXAddrSpace.h"
+#include "llvm/Support/NVVMAttributes.h"
 #include "llvm/Support/Regex.h"
 #include "llvm/Support/TimeProfiler.h"
 #include "llvm/TargetParser/Triple.h"
@@ -5875,33 +5876,33 @@ bool static upgradeSingleNVVMAnnotation(GlobalValue *GV, StringRef K,
   }
   if (K == "maxclusterrank" || K == "cluster_max_blocks") {
     const auto CV = mdconst::extract<ConstantInt>(V)->getZExtValue();
-    cast<Function>(GV)->addFnAttr("nvvm.maxclusterrank", llvm::utostr(CV));
+    cast<Function>(GV)->addFnAttr(NVVMAttr::MaxClusterRank, llvm::utostr(CV));
     return true;
   }
   if (K == "minctasm") {
     const auto CV = mdconst::extract<ConstantInt>(V)->getZExtValue();
-    cast<Function>(GV)->addFnAttr("nvvm.minctasm", llvm::utostr(CV));
+    cast<Function>(GV)->addFnAttr(NVVMAttr::MinCTASm, llvm::utostr(CV));
     return true;
   }
   if (K == "maxnreg") {
     const auto CV = mdconst::extract<ConstantInt>(V)->getZExtValue();
-    cast<Function>(GV)->addFnAttr("nvvm.maxnreg", llvm::utostr(CV));
+    cast<Function>(GV)->addFnAttr(NVVMAttr::MaxNReg, llvm::utostr(CV));
     return true;
   }
   if (K.consume_front("maxntid") && isXYZ(K)) {
-    upgradeNVVMFnVectorAttr("nvvm.maxntid", K[0], GV, V);
+    upgradeNVVMFnVectorAttr(NVVMAttr::MaxNTID, K[0], GV, V);
     return true;
   }
   if (K.consume_front("reqntid") && isXYZ(K)) {
-    upgradeNVVMFnVectorAttr("nvvm.reqntid", K[0], GV, V);
+    upgradeNVVMFnVectorAttr(NVVMAttr::ReqNTID, K[0], GV, V);
     return true;
   }
   if (K.consume_front("cluster_dim_") && isXYZ(K)) {
-    upgradeNVVMFnVectorAttr("nvvm.cluster_dim", K[0], GV, V);
+    upgradeNVVMFnVectorAttr(NVVMAttr::ClusterDim, K[0], GV, V);
     return true;
   }
   if (K == "grid_constant") {
-    const auto Attr = Attribute::get(GV->getContext(), "nvvm.grid_constant");
+    const auto Attr = Attribute::get(GV->getContext(), NVVMAttr::GridConstant);
     for (const auto &Op : cast<MDNode>(V)->operands()) {
       // For some reason, the index is 1-based in the metadata. Good thing we're
       // able to auto-upgrade it!

--- a/llvm/lib/Target/NVPTX/NVPTXAsmPrinter.cpp
+++ b/llvm/lib/Target/NVPTX/NVPTXAsmPrinter.cpp
@@ -887,12 +887,14 @@ void NVPTXAsmPrinter::printModuleLevelGV(const GlobalVariable *GVar,
     O << ".weak ";
   }
 
-  if (isTexture(*GVar)) {
+  const PTXOpaqueType OpaqueType = getPTXOpaqueType(*GVar);
+
+  if (OpaqueType == PTXOpaqueType::Texture) {
     O << ".global .texref " << getTextureName(*GVar) << ";\n";
     return;
   }
 
-  if (isSurface(*GVar)) {
+  if (OpaqueType == PTXOpaqueType::Surface) {
     O << ".global .surfref " << getSurfaceName(*GVar) << ";\n";
     return;
   }
@@ -906,7 +908,7 @@ void NVPTXAsmPrinter::printModuleLevelGV(const GlobalVariable *GVar,
     return;
   }
 
-  if (isSampler(*GVar)) {
+  if (OpaqueType == PTXOpaqueType::Sampler) {
     O << ".global .samplerref " << getSamplerName(*GVar);
 
     const Constant *Initializer = nullptr;
@@ -1355,22 +1357,26 @@ void NVPTXAsmPrinter::emitFunctionParamList(const Function *F, raw_ostream &O) {
 
     // Handle image/sampler parameters
     if (IsKernelFunc) {
-      const bool IsSampler = isSampler(Arg);
-      const bool IsTexture = !IsSampler && isImageReadOnly(Arg);
-      const bool IsSurface = !IsSampler && !IsTexture &&
-                             (isImageReadWrite(Arg) || isImageWriteOnly(Arg));
-      if (IsSampler || IsTexture || IsSurface) {
+      const PTXOpaqueType ArgOpaqueType = getPTXOpaqueType(Arg);
+      if (ArgOpaqueType != PTXOpaqueType::None) {
         const bool EmitImgPtr = !MFI || !MFI->checkImageHandleSymbol(ParamSym);
         O << "\t.param ";
         if (EmitImgPtr)
           O << ".u64 .ptr ";
 
-        if (IsSampler)
+        switch (ArgOpaqueType) {
+        case PTXOpaqueType::Sampler:
           O << ".samplerref ";
-        else if (IsTexture)
+          break;
+        case PTXOpaqueType::Texture:
           O << ".texref ";
-        else // IsSurface
+          break;
+        case PTXOpaqueType::Surface:
           O << ".surfref ";
+          break;
+        case PTXOpaqueType::None:
+          llvm_unreachable("handled above");
+        }
         O << ParamSym;
         continue;
       }

--- a/llvm/lib/Target/NVPTX/NVPTXCtorDtorLowering.cpp
+++ b/llvm/lib/Target/NVPTX/NVPTXCtorDtorLowering.cpp
@@ -24,6 +24,7 @@
 #include "llvm/Pass.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/MD5.h"
+#include "llvm/Support/NVVMAttributes.h"
 #include "llvm/Transforms/Utils/ModuleUtils.h"
 
 using namespace llvm;
@@ -51,8 +52,8 @@ static std::string getHash(StringRef Str) {
 }
 
 static void addKernelAttrs(Function *F) {
-  F->addFnAttr("nvvm.maxclusterrank", "1");
-  F->addFnAttr("nvvm.maxntid", "1");
+  F->addFnAttr(NVVMAttr::MaxClusterRank, "1");
+  F->addFnAttr(NVVMAttr::MaxNTID, "1");
   F->setCallingConv(CallingConv::PTX_Kernel);
 }
 

--- a/llvm/lib/Target/NVPTX/NVPTXGenericToNVVM.cpp
+++ b/llvm/lib/Target/NVPTX/NVPTXGenericToNVVM.cpp
@@ -57,7 +57,7 @@ bool GenericToNVVM::runOnModule(Module &M) {
 
   for (GlobalVariable &GV : llvm::make_early_inc_range(M.globals())) {
     if (GV.getType()->getAddressSpace() == llvm::ADDRESS_SPACE_GENERIC &&
-        !llvm::isTexture(GV) && !llvm::isSurface(GV) && !llvm::isSampler(GV) &&
+        llvm::getPTXOpaqueType(GV) == llvm::PTXOpaqueType::None &&
         !GV.getName().starts_with("llvm.")) {
       GlobalVariable *NewGV = new GlobalVariable(
           M, GV.getValueType(), GV.isConstant(), GV.getLinkage(),

--- a/llvm/lib/Target/NVPTX/NVPTXImageOptimizer.cpp
+++ b/llvm/lib/Target/NVPTX/NVPTXImageOptimizer.cpp
@@ -38,9 +38,7 @@ public:
   StringRef getPassName() const override { return "NVPTX Image Optimizer"; }
 
 private:
-  bool replaceIsTypePSampler(Instruction &I);
-  bool replaceIsTypePSurface(Instruction &I);
-  bool replaceIsTypePTexture(Instruction &I);
+  bool replaceIsTypeP(Instruction &I, PTXOpaqueType Expected);
   Value *cleanupValue(Value *V);
   void replaceWith(Instruction *From, ConstantInt *To);
 };
@@ -68,13 +66,13 @@ bool NVPTXImageOptimizer::runOnFunction(Function &F) {
           switch (CalledF->getIntrinsicID()) {
           default: break;
           case Intrinsic::nvvm_istypep_sampler:
-            Changed |= replaceIsTypePSampler(Instr);
+            Changed |= replaceIsTypeP(Instr, PTXOpaqueType::Sampler);
             break;
           case Intrinsic::nvvm_istypep_surface:
-            Changed |= replaceIsTypePSurface(Instr);
+            Changed |= replaceIsTypeP(Instr, PTXOpaqueType::Surface);
             break;
           case Intrinsic::nvvm_istypep_texture:
-            Changed |= replaceIsTypePTexture(Instr);
+            Changed |= replaceIsTypeP(Instr, PTXOpaqueType::Texture);
             break;
           }
         }
@@ -89,58 +87,13 @@ bool NVPTXImageOptimizer::runOnFunction(Function &F) {
   return Changed;
 }
 
-bool NVPTXImageOptimizer::replaceIsTypePSampler(Instruction &I) {
-  Value *TexHandle = cleanupValue(I.getOperand(0));
-  if (isSampler(*TexHandle)) {
-    // This is an OpenCL sampler, so it must be a samplerref
-    replaceWith(&I, ConstantInt::getTrue(I.getContext()));
-    return true;
-  } else if (isImage(*TexHandle)) {
-    // This is an OpenCL image, so it cannot be a samplerref
-    replaceWith(&I, ConstantInt::getFalse(I.getContext()));
-    return true;
-  } else {
-    // The image type is unknown, so we cannot eliminate the intrinsic
+bool NVPTXImageOptimizer::replaceIsTypeP(Instruction &I,
+                                         PTXOpaqueType Expected) {
+  PTXOpaqueType OT = getPTXOpaqueType(*cleanupValue(I.getOperand(0)));
+  if (OT == PTXOpaqueType::None)
     return false;
-  }
-}
-
-bool NVPTXImageOptimizer::replaceIsTypePSurface(Instruction &I) {
-  Value *TexHandle = cleanupValue(I.getOperand(0));
-  if (isImageReadWrite(*TexHandle) ||
-      isImageWriteOnly(*TexHandle)) {
-    // This is an OpenCL read-only/read-write image, so it must be a surfref
-    replaceWith(&I, ConstantInt::getTrue(I.getContext()));
-    return true;
-  } else if (isImageReadOnly(*TexHandle) ||
-             isSampler(*TexHandle)) {
-    // This is an OpenCL read-only/ imageor sampler, so it cannot be
-    // a surfref
-    replaceWith(&I, ConstantInt::getFalse(I.getContext()));
-    return true;
-  } else {
-    // The image type is unknown, so we cannot eliminate the intrinsic
-    return false;
-  }
-}
-
-bool NVPTXImageOptimizer::replaceIsTypePTexture(Instruction &I) {
-  Value *TexHandle = cleanupValue(I.getOperand(0));
-  if (isImageReadOnly(*TexHandle)) {
-    // This is an OpenCL read-only image, so it must be a texref
-    replaceWith(&I, ConstantInt::getTrue(I.getContext()));
-    return true;
-  } else if (isImageWriteOnly(*TexHandle) ||
-             isImageReadWrite(*TexHandle) ||
-             isSampler(*TexHandle)) {
-    // This is an OpenCL read-write/write-only image or a sampler, so it
-    // cannot be a texref
-    replaceWith(&I, ConstantInt::getFalse(I.getContext()));
-    return true;
-  } else {
-    // The image type is unknown, so we cannot eliminate the intrinsic
-    return false;
-  }
+  replaceWith(&I, ConstantInt::getBool(I.getContext(), OT == Expected));
+  return true;
 }
 
 void NVPTXImageOptimizer::replaceWith(Instruction *From, ConstantInt *To) {

--- a/llvm/lib/Target/NVPTX/NVPTXLowerArgs.cpp
+++ b/llvm/lib/Target/NVPTX/NVPTXLowerArgs.cpp
@@ -155,6 +155,7 @@
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/NVPTXAddrSpace.h"
+#include "llvm/Support/NVVMAttributes.h"
 #include <queue>
 
 #define DEBUG_TYPE "nvptx-lower-args"
@@ -375,7 +376,7 @@ static CallInst *createNVVMInternalAddrspaceWrap(IRBuilder<> &IRB,
     ArgInParam->addRetAttr(
         Attribute::getWithAlignment(ArgInParam->getContext(), *ParamAlign));
 
-  Arg.addAttr(Attribute::get(Arg.getContext(), "nvvm.grid_constant"));
+  Arg.addAttr(Attribute::get(Arg.getContext(), NVVMAttr::GridConstant));
   Arg.addAttr(Attribute::ReadOnly);
 
   return ArgInParam;

--- a/llvm/lib/Target/NVPTX/NVVMProperties.cpp
+++ b/llvm/lib/Target/NVPTX/NVVMProperties.cpp
@@ -18,11 +18,13 @@
 #include "llvm/IR/Constants.h"
 #include "llvm/IR/Function.h"
 #include "llvm/IR/GlobalValue.h"
+#include "llvm/IR/GlobalVariable.h"
 #include "llvm/IR/Instructions.h"
 #include "llvm/IR/Metadata.h"
 #include "llvm/IR/Module.h"
 #include "llvm/Support/ModRef.h"
 #include "llvm/Support/Mutex.h"
+#include "llvm/Support/NVVMAttributes.h"
 #include <functional>
 #include <map>
 #include <mutex>
@@ -46,6 +48,18 @@ AnnotationCache &getAnnotationCache() {
   return AC;
 }
 } // namespace
+
+// TODO: Replace these legacy nvvm.annotations metadata names with proper
+// function/parameter attributes (like the NVVMAttr:: constants).
+namespace NVVMMetadata {
+constexpr StringLiteral Texture("texture");
+constexpr StringLiteral Surface("surface");
+constexpr StringLiteral Sampler("sampler");
+constexpr StringLiteral ReadOnlyImage("rdoimage");
+constexpr StringLiteral WriteOnlyImage("wroimage");
+constexpr StringLiteral ReadWriteImage("rdwrimage");
+constexpr StringLiteral Managed("managed");
+} // namespace NVVMMetadata
 
 void clearAnnotationCache(const Module *Mod) {
   auto &AC = getAnnotationCache();
@@ -102,7 +116,7 @@ static void cacheAnnotationFromMD(const Module *M, const GlobalValue *GV) {
 }
 
 static std::optional<unsigned> findOneNVVMAnnotation(const GlobalValue *GV,
-                                                     const std::string &Prop) {
+                                                     StringRef Prop) {
   auto &AC = getAnnotationCache();
   std::lock_guard<sys::Mutex> Guard(AC.Lock);
   const Module *M = GV->getParent();
@@ -113,14 +127,13 @@ static std::optional<unsigned> findOneNVVMAnnotation(const GlobalValue *GV,
     cacheAnnotationFromMD(M, GV);
 
   auto &KVP = AC.Cache[M][GV];
-  auto It = KVP.find(Prop);
+  auto It = KVP.find(Prop.str());
   if (It == KVP.end())
     return std::nullopt;
   return It->second[0];
 }
 
-static bool findAllNVVMAnnotation(const GlobalValue *GV,
-                                  const std::string &Prop,
+static bool findAllNVVMAnnotation(const GlobalValue *GV, StringRef Prop,
                                   std::vector<unsigned> &RetVal) {
   auto &AC = getAnnotationCache();
   std::lock_guard<sys::Mutex> Guard(AC.Lock);
@@ -132,14 +145,14 @@ static bool findAllNVVMAnnotation(const GlobalValue *GV,
     cacheAnnotationFromMD(M, GV);
 
   auto &KVP = AC.Cache[M][GV];
-  auto It = KVP.find(Prop);
+  auto It = KVP.find(Prop.str());
   if (It == KVP.end())
     return false;
   RetVal = It->second;
   return true;
 }
 
-static bool globalHasNVVMAnnotation(const Value &V, const std::string &Prop) {
+static bool globalHasNVVMAnnotation(const Value &V, StringRef Prop) {
   if (const auto *GV = dyn_cast<GlobalValue>(&V))
     if (const auto Annot = findOneNVVMAnnotation(GV, Prop)) {
       assert((*Annot == 1) && "Unexpected annotation on a symbol");
@@ -149,8 +162,7 @@ static bool globalHasNVVMAnnotation(const Value &V, const std::string &Prop) {
   return false;
 }
 
-static bool argHasNVVMAnnotation(const Value &Val,
-                                 const std::string &Annotation) {
+static bool argHasNVVMAnnotation(const Value &Val, StringRef Annotation) {
   if (const auto *Arg = dyn_cast<Argument>(&Val)) {
     std::vector<unsigned> Annot;
     if (findAllNVVMAnnotation(Arg->getParent(), Annotation, Annot) &&
@@ -197,44 +209,49 @@ static std::optional<uint64_t> getVectorProduct(ArrayRef<unsigned> V) {
                          std::multiplies<uint64_t>{});
 }
 
-bool isTexture(const Value &V) { return globalHasNVVMAnnotation(V, "texture"); }
-
-bool isSurface(const Value &V) { return globalHasNVVMAnnotation(V, "surface"); }
-
-bool isSampler(const Value &V) {
-  const char *AnnotationName = "sampler";
-  return globalHasNVVMAnnotation(V, AnnotationName) ||
-         argHasNVVMAnnotation(V, AnnotationName);
+PTXOpaqueType getPTXOpaqueType(const GlobalVariable &GV) {
+  if (findOneNVVMAnnotation(&GV, NVVMMetadata::Texture))
+    return PTXOpaqueType::Texture;
+  if (findOneNVVMAnnotation(&GV, NVVMMetadata::Surface))
+    return PTXOpaqueType::Surface;
+  if (findOneNVVMAnnotation(&GV, NVVMMetadata::Sampler))
+    return PTXOpaqueType::Sampler;
+  return PTXOpaqueType::None;
 }
 
-bool isImageReadOnly(const Value &V) {
-  return argHasNVVMAnnotation(V, "rdoimage");
+PTXOpaqueType getPTXOpaqueType(const Argument &Arg) {
+  if (argHasNVVMAnnotation(Arg, NVVMMetadata::Sampler))
+    return PTXOpaqueType::Sampler;
+  if (argHasNVVMAnnotation(Arg, NVVMMetadata::ReadOnlyImage))
+    return PTXOpaqueType::Texture;
+  if (argHasNVVMAnnotation(Arg, NVVMMetadata::WriteOnlyImage) ||
+      argHasNVVMAnnotation(Arg, NVVMMetadata::ReadWriteImage))
+    return PTXOpaqueType::Surface;
+  return PTXOpaqueType::None;
 }
 
-bool isImageWriteOnly(const Value &V) {
-  return argHasNVVMAnnotation(V, "wroimage");
+PTXOpaqueType getPTXOpaqueType(const Value &V) {
+  if (const auto *GV = dyn_cast<GlobalVariable>(&V))
+    return getPTXOpaqueType(*GV);
+  if (const auto *Arg = dyn_cast<Argument>(&V))
+    return getPTXOpaqueType(*Arg);
+  return PTXOpaqueType::None;
 }
 
-bool isImageReadWrite(const Value &V) {
-  return argHasNVVMAnnotation(V, "rdwrimage");
+bool isManaged(const Value &V) {
+  return globalHasNVVMAnnotation(V, NVVMMetadata::Managed);
 }
-
-bool isImage(const Value &V) {
-  return isImageReadOnly(V) || isImageWriteOnly(V) || isImageReadWrite(V);
-}
-
-bool isManaged(const Value &V) { return globalHasNVVMAnnotation(V, "managed"); }
 
 SmallVector<unsigned, 3> getMaxNTID(const Function &F) {
-  return getFnAttrParsedVector(F, "nvvm.maxntid");
+  return getFnAttrParsedVector(F, NVVMAttr::MaxNTID);
 }
 
 SmallVector<unsigned, 3> getReqNTID(const Function &F) {
-  return getFnAttrParsedVector(F, "nvvm.reqntid");
+  return getFnAttrParsedVector(F, NVVMAttr::ReqNTID);
 }
 
 SmallVector<unsigned, 3> getClusterDim(const Function &F) {
-  return getFnAttrParsedVector(F, "nvvm.cluster_dim");
+  return getFnAttrParsedVector(F, NVVMAttr::ClusterDim);
 }
 
 std::optional<uint64_t> getOverallMaxNTID(const Function &F) {
@@ -262,19 +279,19 @@ std::optional<uint64_t> getOverallClusterRank(const Function &F) {
 }
 
 std::optional<unsigned> getMaxClusterRank(const Function &F) {
-  return getFnAttrParsedInt(F, "nvvm.maxclusterrank");
+  return getFnAttrParsedInt(F, NVVMAttr::MaxClusterRank);
 }
 
 std::optional<unsigned> getMinCTASm(const Function &F) {
-  return getFnAttrParsedInt(F, "nvvm.minctasm");
+  return getFnAttrParsedInt(F, NVVMAttr::MinCTASm);
 }
 
 std::optional<unsigned> getMaxNReg(const Function &F) {
-  return getFnAttrParsedInt(F, "nvvm.maxnreg");
+  return getFnAttrParsedInt(F, NVVMAttr::MaxNReg);
 }
 
 bool hasBlocksAreClusters(const Function &F) {
-  return F.hasFnAttribute("nvvm.blocksareclusters");
+  return F.hasFnAttribute(NVVMAttr::BlocksAreClusters);
 }
 
 bool isParamGridConstant(const Argument &Arg) {
@@ -297,7 +314,7 @@ bool isParamGridConstant(const Argument &Arg) {
   }
 
   // "grid_constant" counts argument indices starting from 1
-  return Arg.hasAttribute("nvvm.grid_constant");
+  return Arg.hasAttribute(NVVMAttr::GridConstant);
 }
 
 MaybeAlign getAlign(const CallInst &I, unsigned Index) {

--- a/llvm/lib/Target/NVPTX/NVVMProperties.h
+++ b/llvm/lib/Target/NVPTX/NVVMProperties.h
@@ -25,6 +25,7 @@ namespace llvm {
 
 class Argument;
 class CallInst;
+class GlobalVariable;
 class Module;
 class Value;
 
@@ -34,13 +35,12 @@ inline bool isKernelFunction(const Function &F) {
   return F.getCallingConv() == CallingConv::PTX_Kernel;
 }
 
-bool isTexture(const Value &);
-bool isSurface(const Value &);
-bool isSampler(const Value &);
-bool isImage(const Value &);
-bool isImageReadOnly(const Value &);
-bool isImageWriteOnly(const Value &);
-bool isImageReadWrite(const Value &);
+enum class PTXOpaqueType { None, Texture, Surface, Sampler };
+
+PTXOpaqueType getPTXOpaqueType(const GlobalVariable &);
+PTXOpaqueType getPTXOpaqueType(const Argument &);
+PTXOpaqueType getPTXOpaqueType(const Value &);
+
 bool isManaged(const Value &);
 
 SmallVector<unsigned, 3> getMaxNTID(const Function &);

--- a/mlir/lib/Target/LLVMIR/Dialect/NVVM/NVVMToLLVMIRTranslation.cpp
+++ b/mlir/lib/Target/LLVMIR/Dialect/NVVM/NVVMToLLVMIRTranslation.cpp
@@ -21,6 +21,7 @@
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/IntrinsicsNVPTX.h"
 #include "llvm/Support/FormatVariadic.h"
+#include "llvm/Support/NVVMAttributes.h"
 
 using namespace mlir;
 using namespace mlir::LLVM;
@@ -714,7 +715,7 @@ public:
       const std::string attr = llvm::formatv(
           "{0:$[,]}", llvm::make_range(values.asArrayRef().begin(),
                                        values.asArrayRef().end()));
-      llvmFunc->addFnAttr("nvvm.maxntid", attr);
+      llvmFunc->addFnAttr(llvm::NVVMAttr::MaxNTID, attr);
     } else if (attribute.getName() == NVVM::NVVMDialect::getReqntidAttrName()) {
       if (!isa<DenseI32ArrayAttr>(attribute.getValue()))
         return failure();
@@ -722,7 +723,7 @@ public:
       const std::string attr = llvm::formatv(
           "{0:$[,]}", llvm::make_range(values.asArrayRef().begin(),
                                        values.asArrayRef().end()));
-      llvmFunc->addFnAttr("nvvm.reqntid", attr);
+      llvmFunc->addFnAttr(llvm::NVVMAttr::ReqNTID, attr);
     } else if (attribute.getName() ==
                NVVM::NVVMDialect::getClusterDimAttrName()) {
       if (!isa<DenseI32ArrayAttr>(attribute.getValue()))
@@ -731,24 +732,27 @@ public:
       const std::string attr = llvm::formatv(
           "{0:$[,]}", llvm::make_range(values.asArrayRef().begin(),
                                        values.asArrayRef().end()));
-      llvmFunc->addFnAttr("nvvm.cluster_dim", attr);
+      llvmFunc->addFnAttr(llvm::NVVMAttr::ClusterDim, attr);
     } else if (attribute.getName() ==
                NVVM::NVVMDialect::getClusterMaxBlocksAttrName()) {
       auto value = dyn_cast<IntegerAttr>(attribute.getValue());
-      llvmFunc->addFnAttr("nvvm.maxclusterrank", llvm::utostr(value.getInt()));
+      llvmFunc->addFnAttr(llvm::NVVMAttr::MaxClusterRank,
+                          llvm::utostr(value.getInt()));
     } else if (attribute.getName() ==
                NVVM::NVVMDialect::getMinctasmAttrName()) {
       auto value = dyn_cast<IntegerAttr>(attribute.getValue());
-      llvmFunc->addFnAttr("nvvm.minctasm", llvm::utostr(value.getInt()));
+      llvmFunc->addFnAttr(llvm::NVVMAttr::MinCTASm,
+                          llvm::utostr(value.getInt()));
     } else if (attribute.getName() == NVVM::NVVMDialect::getMaxnregAttrName()) {
       auto value = dyn_cast<IntegerAttr>(attribute.getValue());
-      llvmFunc->addFnAttr("nvvm.maxnreg", llvm::utostr(value.getInt()));
+      llvmFunc->addFnAttr(llvm::NVVMAttr::MaxNReg,
+                          llvm::utostr(value.getInt()));
     } else if (attribute.getName() ==
                NVVM::NVVMDialect::getKernelFuncAttrName()) {
       llvmFunc->setCallingConv(llvm::CallingConv::PTX_Kernel);
     } else if (attribute.getName() ==
                NVVM::NVVMDialect::getBlocksAreClustersAttrName()) {
-      llvmFunc->addFnAttr("nvvm.blocksareclusters");
+      llvmFunc->addFnAttr(llvm::NVVMAttr::BlocksAreClusters);
     }
 
     return success();
@@ -764,7 +768,8 @@ public:
 
     if (attribute.getName() == NVVM::NVVMDialect::getGridConstantAttrName()) {
       llvmFunc->addParamAttr(
-          argIdx, llvm::Attribute::get(llvmContext, "nvvm.grid_constant"));
+          argIdx,
+          llvm::Attribute::get(llvmContext, llvm::NVVMAttr::GridConstant));
     }
     return success();
   }


### PR DESCRIPTION
Introduce `NVVMAttributes.h` with `constexpr StringLiteral` constants for all NVVM function and parameter attributes (`nvvm.maxntid`, `nvvm.reqntid`, etc.) and use them consistently across the NVPTX backend, AutoUpgrade, OMPIRBuilder, Clang codegen, and the MLIR NVVM translation.

Also refactor the texture/surface/sampler query functions in `NVVMProperties`. Replace the collection of boolean helpers (`isTexture`, `isSurface`, `isSampler`, `isImage`, `isImageReadOnly`, `isImageWriteOnly`, `isImageReadWrite`) with a single `PTXOpaqueType` enum and `getPTXOpaqueType` overloads for `GlobalVariable`, `Argument`, and `Value`. Simplify `NVPTXImageOptimizer` and `NVPTXAsmPrinter` to use the new enum.