### PR TITLE
[llvm] Silence llvm-debuginfod-find/headers-winhttp.test on Windows bots temporarily

### DIFF
--- a/llvm/test/tools/llvm-debuginfod-find/headers-winhttp.test
+++ b/llvm/test/tools/llvm-debuginfod-find/headers-winhttp.test
@@ -1,4 +1,4 @@
-REQUIRES: system-windows, http-server
+REQUIRES: system-windows, http-server, disabled-temp
 
 RUN: not llvm-debuginfod-find --debuginfo 0 2>&1 | FileCheck %s --check-prefix CHECK-STDOUT
 CHECK-STDOUT: Build ID 00 could not be found


### PR DESCRIPTION
Windows bots are still failing after a3db68a97b2c321ef0af73f39a3725490c131468 and d7dbba55bff52f342f4d2c7b0bd04dd8e28a274b. This test is new, let's take it off while we investigate.