### PR TITLE
[clang] fix error: cannot compile this l-value expression yet

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -402,7 +402,7 @@ Miscellaneous Clang Crashes Fixed
 - Fixed a crash when subscripting a vector type with large unsigned integer values. (#GH180563)
 - Fixed a crash when evaluating ``__is_bitwise_cloneable`` on invalid record types. (#GH183707)
 - Fixed an assertion failure when casting a function pointer with a target with a non-default program address space. (#GH186210)
-- Fixed a crash when ``__builtin_FUNCTION()`` is passed to ``decltype()`` when used as a template type argument. (#GH167433)
+- Fixed a crash when ``decltype(__builtin_FUNCTION())`` is used as a template type argument. (#GH167433)
 
 OpenACC Specific Changes
 ------------------------

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -402,6 +402,7 @@ Miscellaneous Clang Crashes Fixed
 - Fixed a crash when subscripting a vector type with large unsigned integer values. (#GH180563)
 - Fixed a crash when evaluating ``__is_bitwise_cloneable`` on invalid record types. (#GH183707)
 - Fixed an assertion failure when casting a function pointer with a target with a non-default program address space. (#GH186210)
+- Fixed a crash when ``__builtin_FUNCTION()`` is passed to ``decltype()`` when used as a template type argument. (#GH167433)
 
 OpenACC Specific Changes
 ------------------------

--- a/clang/lib/AST/Expr.cpp
+++ b/clang/lib/AST/Expr.cpp
@@ -2255,7 +2255,7 @@ SourceLocExpr::SourceLocExpr(const ASTContext &Ctx, SourceLocIdentKind Kind,
   SourceLocExprBits.Kind = llvm::to_underlying(Kind);
   // In dependent contexts, function names may change.
   setDependence(MayBeDependent(Kind) && ParentContext->isDependentContext()
-                    ? ExprDependence::Value
+                    ? ExprDependence::ValueInstantiation
                     : ExprDependence::None);
 }
 

--- a/clang/test/CodeGenCXX/builtin_FUNCTION.cpp
+++ b/clang/test/CodeGenCXX/builtin_FUNCTION.cpp
@@ -39,3 +39,20 @@ void do_default_arg_test() {
 }
 
 } // namespace test_func
+
+namespace test_decltype_template {
+
+template <typename> void template_func() {}
+
+// CHECK: define linkonce_odr {{(dso_local )?}}void @_ZN22test_decltype_template21use_decltype_templateIiEEvv(
+// CHECK: call void @_ZN22test_decltype_template13template_funcIPKcEEvv()
+template <typename> void use_decltype_template() {
+  template_func<decltype(__builtin_FUNCTION())>();
+}
+
+// CHECK: define linkonce_odr {{(dso_local )?}}void @_ZN22test_decltype_template13template_funcIPKcEEvv()
+void do_decltype_template_test() {
+  use_decltype_template<int>();
+}
+
+} // namespace test_decltype_template


### PR DESCRIPTION
My understanding is that ExprDependence::ValueInstantiation is required so the type can be resolved immediately when passed into decltype to be used as a template type argument in another template, but I will admit I have limited understanding of this code.

From looking at the file history this looks related to a previous fix in https://github.com/llvm/llvm-project/pull/78436 by @cor3ntin 

Resolves https://github.com/llvm/llvm-project/issues/167433

This is my first llvm contribution so let me know if there is anything else I'm missing. Thanks.

The test I added shows the crash with a prior version of clang, if there is a better file to place this in let me know but since it was related to the builtins not being resolved at compile time it seemed like a good enough file to add it to. Here is what the crash was with clang 22:

```clang/test/CodeGenCXX/builtin_FUNCTION.cpp:50:3: error: cannot compile this l-value expression yet
   50 |   template_func<decltype(__builtin_FUNCTION())>();
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
PLEASE submit a bug report to https://github.com/llvm/llvm-project/issues/ and include the crash backtrace, preprocessed source, and associated run script.
Stack dump:
0.	Program arguments: E:\\devel\\AutoSDK\\HostWin64\\Win64\\LLVM\\22.1.1\\bin\\clang.exe -cc1 -std=c++2a -fblocks clang/test/CodeGenCXX/builtin_FUNCTION.cpp -triple x86_64-unknown-linux-gnu -emit-llvm -o nul
1.	<eof> parser at end of file
2.	Per-file LLVM IR generation
3.	clang/test/CodeGenCXX/builtin_FUNCTION.cpp:49:26: Generating code for declaration 'test_decltype_template::use_decltype_template'
Exception Code: 0xC0000005
 #0 0x00007ff785719fab (E:\devel\AutoSDK\HostWin64\Win64\LLVM\22.1.1\bin\clang.exe+0x1929fab)
 #1 0x00007ff784068f33 (E:\devel\AutoSDK\HostWin64\Win64\LLVM\22.1.1\bin\clang.exe+0x278f33)
 #2 0x00007ff78571903e (E:\devel\AutoSDK\HostWin64\Win64\LLVM\22.1.1\bin\clang.exe+0x192903e)
 #3 0x00007ff7857008bc (E:\devel\AutoSDK\HostWin64\Win64\LLVM\22.1.1\bin\clang.exe+0x19108bc)
 #4 0x00007ff7856fa4c9 (E:\devel\AutoSDK\HostWin64\Win64\LLVM\22.1.1\bin\clang.exe+0x190a4c9)
 #5 0x00007ff7856f7a91 (E:\devel\AutoSDK\HostWin64\Win64\LLVM\22.1.1\bin\clang.exe+0x1907a91)
 #6 0x00007ff78508c4b9 (E:\devel\AutoSDK\HostWin64\Win64\LLVM\22.1.1\bin\clang.exe+0x129c4b9)
 #7 0x00007ff78508b90e (E:\devel\AutoSDK\HostWin64\Win64\LLVM\22.1.1\bin\clang.exe+0x129b90e)
 #8 0x00007ff78508b5ff (E:\devel\AutoSDK\HostWin64\Win64\LLVM\22.1.1\bin\clang.exe+0x129b5ff)
 #9 0x00007ff785089cc2 (E:\devel\AutoSDK\HostWin64\Win64\LLVM\22.1.1\bin\clang.exe+0x1299cc2)
#10 0x00007ff78508656d (E:\devel\AutoSDK\HostWin64\Win64\LLVM\22.1.1\bin\clang.exe+0x129656d)
#11 0x00007ff7850858b5 (E:\devel\AutoSDK\HostWin64\Win64\LLVM\22.1.1\bin\clang.exe+0x12958b5)
#12 0x00007ff785085194 (E:\devel\AutoSDK\HostWin64\Win64\LLVM\22.1.1\bin\clang.exe+0x1295194)
#13 0x00007ff7846bc17e (E:\devel\AutoSDK\HostWin64\Win64\LLVM\22.1.1\bin\clang.exe+0x8cc17e)
#14 0x00007ff7846bc0cd (E:\devel\AutoSDK\HostWin64\Win64\LLVM\22.1.1\bin\clang.exe+0x8cc0cd)
#15 0x00007ff78517937d (E:\devel\AutoSDK\HostWin64\Win64\LLVM\22.1.1\bin\clang.exe+0x138937d)
#16 0x00007ff78527ed90 (E:\devel\AutoSDK\HostWin64\Win64\LLVM\22.1.1\bin\clang.exe+0x148ed90)
#17 0x00007ff784427ee3 (E:\devel\AutoSDK\HostWin64\Win64\LLVM\22.1.1\bin\clang.exe+0x637ee3)
#18 0x00007ff784427b1d (E:\devel\AutoSDK\HostWin64\Win64\LLVM\22.1.1\bin\clang.exe+0x637b1d)
#19 0x00007ff784425d19 (E:\devel\AutoSDK\HostWin64\Win64\LLVM\22.1.1\bin\clang.exe+0x635d19)
#20 0x00007ff784421bff (E:\devel\AutoSDK\HostWin64\Win64\LLVM\22.1.1\bin\clang.exe+0x631bff)
#21 0x00007ff784420575 (E:\devel\AutoSDK\HostWin64\Win64\LLVM\22.1.1\bin\clang.exe+0x630575)
#22 0x00007ff783f2868d (E:\devel\AutoSDK\HostWin64\Win64\LLVM\22.1.1\bin\clang.exe+0x13868d)
#23 0x00007ff783f24a43 (E:\devel\AutoSDK\HostWin64\Win64\LLVM\22.1.1\bin\clang.exe+0x134a43)
#24 0x00007ff785e4c03c (E:\devel\AutoSDK\HostWin64\Win64\LLVM\22.1.1\bin\clang.exe+0x205c03c)
#25 0x00007ff99edbe8d7 (C:\WINDOWS\System32\KERNEL32.DLL+0x2e8d7)
#26 0x00007ff99fb2c48c (C:\WINDOWS\SYSTEM32\ntdll.dll+0x8c48c)
```

