### PR TITLE
[AMDGPU][SIInsertWaitcnts] Fix counterOutOfOrder() check for LOAD_CNT

### DIFF
--- a/llvm/lib/Target/AMDGPU/SIInsertWaitcnts.cpp
+++ b/llvm/lib/Target/AMDGPU/SIInsertWaitcnts.cpp
@@ -1676,13 +1676,15 @@ bool WaitcntBrackets::counterOutOfOrder(InstCounterType T) const {
   // so having GLOBAL_INV_ACCESS mixed with other LOAD_CNT events doesn't cause
   // out-of-order completion.
   if (T == LOAD_CNT) {
-    unsigned Events = hasPendingEvent(T);
+    WaitEventSet Events;
+    if (hasPendingEvent(T))
+      Events.insert(VMEM_ACCESS);
     // Remove GLOBAL_INV_ACCESS from the event mask before checking for mixed
     // events
-    Events &= ~(1 << GLOBAL_INV_ACCESS);
+    Events.remove(GLOBAL_INV_ACCESS);
     // Return true only if there are still multiple event types after removing
     // GLOBAL_INV
-    return Events & (Events - 1);
+    return Events.twoOrMore();
   }
 
   return hasMixedPendingEvents(T);

--- a/llvm/lib/Target/AMDGPU/SIInsertWaitcnts.cpp
+++ b/llvm/lib/Target/AMDGPU/SIInsertWaitcnts.cpp
@@ -1676,9 +1676,7 @@ bool WaitcntBrackets::counterOutOfOrder(InstCounterType T) const {
   // so having GLOBAL_INV_ACCESS mixed with other LOAD_CNT events doesn't cause
   // out-of-order completion.
   if (T == LOAD_CNT) {
-    WaitEventSet Events;
-    if (hasPendingEvent(T))
-      Events.insert(VMEM_ACCESS);
+    WaitEventSet Events = PendingEvents & Context->getWaitEvents(T);
     // Remove GLOBAL_INV_ACCESS from the event mask before checking for mixed
     // events
     Events.remove(GLOBAL_INV_ACCESS);


### PR DESCRIPTION
This is a follow-up to @piotrAMD's comment in #178511 .  
`hasPendingEvent()` used to return an unsigned mask but this changed in #178511 when this function started to return bool. This changed the functionality of `counterOutOfOrder()` which was still using an unsigned mask that was erroneously being assigned a boolean instead of the expected mask.