### PR TITLE
[lldb] Fix trace load hang

### DIFF
--- a/lldb/source/Target/ProcessTrace.cpp
+++ b/lldb/source/Target/ProcessTrace.cpp
@@ -72,6 +72,10 @@ void ProcessTrace::DidAttach(ArchSpec &process_arch) {
     return;
   }
 
+  // Pretend we stopped so we can show all of the threads
+  // in the trace and explore the final state.
+  SetPrivateState(lldb::eStateStopped);
+
   EventSP event_sp;
   WaitForProcessToStop(std::nullopt, &event_sp, true, listener_sp);
 

--- a/lldb/unittests/Process/ProcessTraceTest.cpp
+++ b/lldb/unittests/Process/ProcessTraceTest.cpp
@@ -1,4 +1,4 @@
-//===-- ProcessEventDataTest.cpp ------------------------------------------===//
+//===-- ProcessTraceTest.cpp ----------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -60,4 +60,29 @@ TEST_F(ProcessTraceTest, ConstructorWithNullptrCoreFile) {
       /*can_connect*/ false);
 
   ASSERT_NE(process_sp, nullptr);
+}
+
+// Test that a trace process stops after attaching.
+TEST_F(ProcessTraceTest, DidAttach) {
+  ArchSpec arch("i386-pc-linux");
+
+  Platform::SetHostPlatform(PlatformLinux::CreateInstance(true, &arch));
+  ASSERT_NE(Platform::GetHostPlatform(), nullptr);
+
+  DebuggerSP debugger_sp = Debugger::CreateInstance();
+  ASSERT_TRUE(debugger_sp);
+
+  TargetSP target_sp = CreateTarget(debugger_sp, arch);
+  ASSERT_TRUE(target_sp);
+
+  ProcessSP process_sp = target_sp->CreateProcess(
+      /*listener*/ nullptr, "trace",
+      /*crash_file*/ nullptr,
+      /*can_connect*/ false);
+
+  ASSERT_NE(process_sp, nullptr);
+
+  process_sp->DidAttach(arch);
+
+  ASSERT_EQ(process_sp->GetState(), lldb::eStateStopped);
 }


### PR DESCRIPTION
#179799 removed the `SetPrivateState(eStateStopped)` call in `ProcessTrace::DidAttach()`. This makes the call to `WaitForProcessToStop` hang forever, causing the `trace load` command to hang.

This fix reintroduces the `SetPrivateState` call so a postmortem trace process will "stop" after being loaded, matching the logic used in `Process::LoadCore()`.