### PR TITLE
[PowerPC] Change assert to error

### DIFF
--- a/llvm/lib/Target/PowerPC/PPCTargetMachine.cpp
+++ b/llvm/lib/Target/PowerPC/PPCTargetMachine.cpp
@@ -39,6 +39,7 @@
 #include "llvm/Support/CodeGen.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Compiler.h"
+#include "llvm/Support/Error.h"
 #include "llvm/Target/TargetLoweringObjectFile.h"
 #include "llvm/Target/TargetOptions.h"
 #include "llvm/TargetParser/Triple.h"
@@ -253,7 +254,9 @@ getEffectivePPCCodeModel(const Triple &TT, std::optional<CodeModel::Model> CM,
     return CodeModel::Small;
   }
 
-  assert(TT.isOSBinFormatELF() && "All remaining PPC OSes are ELF based.");
+  if (!TT.isOSBinFormatELF())
+    reportFatalUsageError(
+        "The only supported target OS's are AIX and ELF-based OS's");
 
   if (TT.isArch32Bit())
     return CodeModel::Small;

--- a/llvm/test/CodeGen/PowerPC/pr172812.ll
+++ b/llvm/test/CodeGen/PowerPC/pr172812.ll
@@ -1,0 +1,9 @@
+; RUN: not opt %s 2>&1 | FileCheck %s
+
+; CHECK: LLVM ERROR: The only supported target OS's are AIX and ELF-based OS's
+target triple = "powerpc-apple-darwin7.2"
+
+define void @_Z4testv() {
+entry:
+  ret void
+}


### PR DESCRIPTION
Support for Darwin was removed from PowerPC a number of years ago. However, if IR (presumably produced by a tool other than clang) has a Darwin triple, the
compiler fails with an assert. This is not ideal and a proper error is preferred.

Fixes: https://github.com/llvm/llvm-project/issues/172812