### PR TITLE
[lldb][bytecode] Add setting to disable loading formatters from user (non-system) binaries

### DIFF
--- a/lldb/include/lldb/Symbol/ObjectFile.h
+++ b/lldb/include/lldb/Symbol/ObjectFile.h
@@ -22,6 +22,7 @@
 #include "lldb/Utility/StructuredData.h"
 #include "lldb/Utility/UUID.h"
 #include "lldb/lldb-private.h"
+#include "llvm/ADT/StringRef.h"
 #include "llvm/Support/Threading.h"
 #include "llvm/Support/VersionTuple.h"
 #include <optional>
@@ -261,6 +262,13 @@ public:
   /// \return
   ///     \b true if it is, \b false otherwise.
   virtual bool IsExecutable() const = 0;
+
+  /// Tells whether this object file is a system binary - one provided by the
+  /// OS rather than by the user installed files.
+  ///
+  /// \return
+  ///     \b true if this is a system binary, \b false otherwise.
+  virtual bool IsSystem() const { return false; }
 
   /// Returns the offset into a file at which this object resides.
   ///
@@ -755,6 +763,21 @@ public:
   std::string GetObjectName() const;
 
 protected:
+  /// Returns true if the object file's path is under a known OS system
+  /// directory. For use by IsSystem() implementations on platforms that lack a
+  /// "system binary" flag (ex. ELF, XCOFF).
+  bool IsUnixSystemPath() const {
+    std::string path_str = m_file.GetPath();
+    llvm::StringRef path = path_str;
+    // Linux / glibc multiarch, FreeBSD, AIX
+    if (path.starts_with("/lib") || path.starts_with("/usr/lib"))
+      return true;
+    // Android system partition
+    if (path.starts_with("/system/"))
+      return true;
+    return false;
+  }
+
   typedef NonNullSharedPtr<lldb_private::DataExtractor> DataExtractorNSP;
 
   // Member variables.

--- a/lldb/include/lldb/Target/Target.h
+++ b/lldb/include/lldb/Target/Target.h
@@ -278,6 +278,8 @@ public:
 
   bool GetDebugUtilityExpression() const;
 
+  bool GetLoadFormattersFromUserBinaries() const;
+
 private:
   std::optional<bool>
   GetExperimentalPropertyValue(size_t prop_idx,

--- a/lldb/source/Plugins/ObjectFile/ELF/ObjectFileELF.h
+++ b/lldb/source/Plugins/ObjectFile/ELF/ObjectFileELF.h
@@ -108,6 +108,8 @@ public:
 
   bool IsExecutable() const override;
 
+  bool IsSystem() const override { return IsUnixSystemPath(); }
+
   uint32_t GetAddressByteSize() const override;
 
   lldb_private::AddressClass GetAddressClass(lldb::addr_t file_addr) override;

--- a/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.h
+++ b/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.h
@@ -102,6 +102,8 @@ public:
 
   bool IsStripped() override;
 
+  bool IsSystem() const override { return IsSharedCacheBinary(); }
+
   void CreateSections(lldb_private::SectionList &unified_section_list) override;
 
   void Dump(lldb_private::Stream *s) override;

--- a/lldb/source/Plugins/ObjectFile/PECOFF/ObjectFilePECOFF.h
+++ b/lldb/source/Plugins/ObjectFile/PECOFF/ObjectFilePECOFF.h
@@ -14,6 +14,7 @@
 
 #include "lldb/Symbol/ObjectFile.h"
 #include "lldb/Symbol/SaveCoreOptions.h"
+#include "llvm/ADT/StringExtras.h"
 #include "llvm/Object/COFF.h"
 
 class ObjectFilePECOFF : public lldb_private::ObjectFile {
@@ -108,6 +109,23 @@ public:
   lldb::ByteOrder GetByteOrder() const override;
 
   bool IsExecutable() const override;
+
+  bool IsSystem() const override {
+    std::string path_str = m_file.GetPath();
+    if (path_str.empty())
+      return false;
+    std::replace(path_str.begin(), path_str.end(), '\\', '/');
+    llvm::StringRef path = path_str;
+
+    // Skip past drive letter.
+    if (!llvm::isAlpha(path[0]))
+      return false;
+    path = path.substr(1);
+
+    return path.starts_with_insensitive(":/windows/system32/") ||
+           path.starts_with_insensitive(":/windows/syswow64/") ||
+           path.starts_with_insensitive(":/windows/winsxs/");
+  }
 
   uint32_t GetAddressByteSize() const override;
 

--- a/lldb/source/Plugins/ObjectFile/XCOFF/ObjectFileXCOFF.h
+++ b/lldb/source/Plugins/ObjectFile/XCOFF/ObjectFileXCOFF.h
@@ -67,6 +67,8 @@ public:
 
   bool IsExecutable() const override;
 
+  bool IsSystem() const override { return IsUnixSystemPath(); }
+
   uint32_t GetAddressByteSize() const override;
 
   lldb_private::AddressClass GetAddressClass(lldb::addr_t file_addr) override;

--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -44,6 +44,7 @@
 #include "lldb/Interpreter/Property.h"
 #include "lldb/Symbol/Function.h"
 #include "lldb/Symbol/ObjectFile.h"
+#include "Plugins/ObjectFile/Mach-O/ObjectFileMachO.h"
 #include "lldb/Symbol/Symbol.h"
 #include "lldb/Target/ABI.h"
 #include "lldb/Target/ExecutionContext.h"
@@ -1542,6 +1543,13 @@ Module *Target::GetExecutableModulePointer() {
   return GetExecutableModule().get();
 }
 
+static bool IsSystemBinary(const ModuleSP &module_sp) {
+  if (auto *objfile = module_sp->GetObjectFile())
+    if (auto *macho = llvm::dyn_cast<ObjectFileMachO>(objfile))
+      return macho->IsSharedCacheBinary();
+  return false;
+}
+
 static void LoadScriptingResourceForModule(const ModuleSP &module_sp,
                                            Target *target) {
   Status error;
@@ -1861,7 +1869,8 @@ void Target::ModulesDidLoad(ModuleList &module_list) {
       ModuleSP module_sp(module_list.GetModuleAtIndex(idx));
       LoadScriptingResourceForModule(module_sp, this);
       LoadTypeSummariesForModule(module_sp);
-      LoadFormattersForModule(module_sp);
+      if (GetLoadFormattersFromUserBinaries() || IsSystemBinary(module_sp))
+        LoadFormattersForModule(module_sp);
     }
     m_breakpoint_list.UpdateBreakpoints(module_list, true, false);
     m_internal_breakpoint_list.UpdateBreakpoints(module_list, true, false);
@@ -5254,6 +5263,12 @@ bool TargetProperties::GetDebugUtilityExpression() const {
 void TargetProperties::SetDebugUtilityExpression(bool debug) {
   const uint32_t idx = ePropertyDebugUtilityExpression;
   SetPropertyAtIndex(idx, debug);
+}
+
+bool TargetProperties::GetLoadFormattersFromUserBinaries() const {
+  const uint32_t idx = ePropertyLoadFormattersFromUserBinaries;
+  return GetPropertyAtIndexAs<bool>(
+      idx, g_target_properties[idx].default_uint_value != 0);
 }
 
 // Target::TargetEventData

--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -1545,8 +1545,7 @@ Module *Target::GetExecutableModulePointer() {
 
 static bool IsSystemBinary(const ModuleSP &module_sp) {
   if (auto *objfile = module_sp->GetObjectFile())
-    if (auto *macho = llvm::dyn_cast<ObjectFileMachO>(objfile))
-      return macho->IsSharedCacheBinary();
+    return objfile->IsSystem();
   return false;
 }
 

--- a/lldb/source/Target/TargetProperties.td
+++ b/lldb/source/Target/TargetProperties.td
@@ -176,6 +176,9 @@ let Definition = "target", Path = "target" in {
   def UseFastStepping: Property<"use-fast-stepping", "Boolean">,
     DefaultTrue,
     Desc<"Use a fast stepping algorithm based on running from branch to branch rather than instruction single-stepping.">;
+  def LoadFormattersFromUserBinaries: Property<"load-formatters-from-user-binaries", "Boolean">,
+    DefaultTrue,
+    Desc<"Load formatter bytecode embedded in user (non-system) binaries.">;
   def LoadScriptFromSymbolFile: Property<"load-script-from-symbol-file", "Enum">,
     DefaultEnumValue<"eLoadScriptFromSymFileWarn">,
     EnumValues<"OptionEnumValues(g_load_script_from_sym_file_values)">,


### PR DESCRIPTION
For anyone working with untrusted binaries, they can disable this `target.load-formatters-from-user-binaries` setting to rest assured embedded formatters can take no action.