### PR TITLE
[MLIR] Enable multi-buffer support in loadSourceFileBuffer

### DIFF
--- a/mlir/lib/Parser/Parser.cpp
+++ b/mlir/lib/Parser/Parser.cpp
@@ -73,19 +73,17 @@ LogicalResult mlir::parseSourceFile(llvm::StringRef filename, Block *block,
 
 static LogicalResult loadSourceFileBuffer(llvm::StringRef filename,
                                           llvm::SourceMgr &sourceMgr,
-                                          MLIRContext *ctx) {
-  if (sourceMgr.getNumBuffers() != 0) {
-    // TODO: Extend to support multiple buffers.
-    return emitError(mlir::UnknownLoc::get(ctx),
-                     "only main buffer parsed at the moment");
-  }
-  auto fileOrErr = llvm::MemoryBuffer::getFileOrSTDIN(filename);
-  if (fileOrErr.getError())
-    return emitError(mlir::UnknownLoc::get(ctx),
-                     "could not open input file " + filename);
+                                          MLIRContext *ctx,
+                                          SMLoc includeLoc = SMLoc()) {
 
-  // Load the MLIR source file.
-  sourceMgr.AddNewSourceBuffer(std::move(*fileOrErr), SMLoc());
+  auto fileOrErr = llvm::MemoryBuffer::getFileOrSTDIN(filename);
+  if (std::error_code ec = fileOrErr.getError()) {
+    return emitError(mlir::UnknownLoc::get(ctx),
+                     "could not open input file '" + filename + "': " + ec.message());
+  }
+
+  sourceMgr.AddNewSourceBuffer(std::move(*fileOrErr), includeLoc);
+  
   return success();
 }
 


### PR DESCRIPTION
This PR implements multi-buffer support in the `loadSourceFileBuffer` utility, transitioning the infrastructure from a single-input constraint to a system capable of managing multiple source files within a single `llvm::SourceMgr`.

* Removed the single-buffer constraint: Deleted the check that limited `loadSourceFileBuffer` to a single active buffer.
* Implemented `SMLoc` support: Added an optional `includeLoc` parameter, enabling the `SourceMgr` to track and display *"included from"* stack traces for nested files.
* Enhanced error reporting: Refactored the error handling to include system-level error messages (`std::error_code`), providing clearer diagnostics for file I/O failures.