### PR TITLE
[compiler-rt] Add bitmask to fix warning

### DIFF
--- a/compiler-rt/lib/scudo/standalone/chunk.h
+++ b/compiler-rt/lib/scudo/standalone/chunk.h
@@ -91,7 +91,7 @@ struct UnpackedHeader {
 
   ALWAYS_INLINE u8 getOrigin() { return OriginOrWasZeroed; }
 
-  ALWAYS_INLINE void setOrigin(u8 Origin) { OriginOrWasZeroed = Origin; }
+  ALWAYS_INLINE void setOrigin(u8 Origin) { OriginOrWasZeroed = Origin & 0x3; }
 };
 typedef atomic_u64 AtomicPackedHeader;
 static_assert(sizeof(UnpackedHeader) == sizeof(PackedHeader), "");


### PR DESCRIPTION
After #186881 was merged the gcc libc bots started complaining about the
conversion from u8 to 2 bit integer being unsafe (see:
https://lab.llvm.org/buildbot/#/builders/131/builds/42788). This PR
adds a bitmask that fixes the warning.
