### PR TITLE
[HLSL] handle hlslAttributedResourceType in init list code

### DIFF
--- a/clang/lib/Sema/SemaHLSL.cpp
+++ b/clang/lib/Sema/SemaHLSL.cpp
@@ -5544,7 +5544,6 @@ class InitListTransformer {
       return *(ArgIt++);
 
     llvm::SmallVector<Expr *> Inits;
-    Ty = Ty.getDesugaredType(Ctx);
     if (Ty->isVectorType() || Ty->isConstantArrayType() ||
         Ty->isConstantMatrixType()) {
       QualType ElTy;

--- a/clang/lib/Sema/SemaHLSL.cpp
+++ b/clang/lib/Sema/SemaHLSL.cpp
@@ -5442,7 +5442,7 @@ class InitListTransformer {
     QualType Ty = E->getType().getDesugaredType(Ctx);
 
     if (Ty->isScalarType() || (Ty->isRecordType() && !Ty->isAggregateType()) ||
-	Ty->isHLSLAttributedResourceType())
+        Ty->isHLSLAttributedResourceType())
       return castInitializer(E);
 
     if (auto *VecTy = Ty->getAs<VectorType>()) {
@@ -5540,7 +5540,7 @@ class InitListTransformer {
     Ty = Ty.getDesugaredType(Ctx);
     assert(ArgIt != ArgExprs.end() && "Something is off in iteration!");
     if (Ty->isScalarType() || (Ty->isRecordType() && !Ty->isAggregateType()) ||
-	Ty->isHLSLAttributedResourceType())
+        Ty->isHLSLAttributedResourceType())
       return *(ArgIt++);
 
     llvm::SmallVector<Expr *> Inits;

--- a/clang/lib/Sema/SemaHLSL.cpp
+++ b/clang/lib/Sema/SemaHLSL.cpp
@@ -5439,9 +5439,10 @@ class InitListTransformer {
     }
 
     // If this is a scalar type, just enqueue the expression.
-    QualType Ty = E->getType();
+    QualType Ty = E->getType().getDesugaredType(Ctx);
 
-    if (Ty->isScalarType() || (Ty->isRecordType() && !Ty->isAggregateType()))
+    if (Ty->isScalarType() || (Ty->isRecordType() && !Ty->isAggregateType()) ||
+	Ty->isHLSLAttributedResourceType())
       return castInitializer(E);
 
     if (auto *VecTy = Ty->getAs<VectorType>()) {
@@ -5536,8 +5537,10 @@ class InitListTransformer {
   }
 
   Expr *generateInitListsImpl(QualType Ty) {
+    Ty = Ty.getDesugaredType(Ctx);
     assert(ArgIt != ArgExprs.end() && "Something is off in iteration!");
-    if (Ty->isScalarType() || (Ty->isRecordType() && !Ty->isAggregateType()))
+    if (Ty->isScalarType() || (Ty->isRecordType() && !Ty->isAggregateType()) ||
+	Ty->isHLSLAttributedResourceType())
       return *(ArgIt++);
 
     llvm::SmallVector<Expr *> Inits;

--- a/clang/test/CodeGenHLSL/BasicFeatures/InitLists.hlsl
+++ b/clang/test/CodeGenHLSL/BasicFeatures/InitLists.hlsl
@@ -1126,7 +1126,25 @@ void case26(TwoInts TI) {
   float4 F = float4(TI, 1, 2);
   float3 F2 = float3(3, TI);
 }
+
+using handle_float_t = __hlsl_resource_t [[hlsl::resource_class(UAV)]] [[hlsl::contained_type(float)]];
+
+struct CustomResource {
+  handle_float_t h;
+};
+
+// CHECK-LABEL: define hidden void @_Z6case2714CustomResource
+// CHECK: [[b:%.*]] = alloca %struct.CustomResource, align 1
+// CHECK: [[h:%.*]] = getelementptr inbounds nuw %struct.CustomResource, ptr [[b]], i32 0, i32 0
+// CHECK: [[h1:%.*]] = getelementptr inbounds nuw %struct.CustomResource, ptr %a, i32 0, i32 0
+// CHECK: [[Z:%.*]] = load target("dx.TypedBuffer", float, 1, 0, 0), ptr [[h1]], align 1
+// CHECK: store target("dx.TypedBuffer", float, 1, 0, 0) %0, ptr [[h]], align 1
+// CHECK: ret void
+void case27(CustomResource a) {
+  CustomResource b = {a};
+}
 //.
 // CHECK: [[META3]] = !{}
 // CHECK: [[META4]] = !{i64 4}
 //.
+

--- a/clang/test/CodeGenHLSL/BasicFeatures/InitLists.hlsl
+++ b/clang/test/CodeGenHLSL/BasicFeatures/InitLists.hlsl
@@ -1133,13 +1133,16 @@ struct CustomResource {
   handle_float_t h;
 };
 
-// CHECK-LABEL: define hidden void @_Z6case2714CustomResource
-// CHECK: [[b:%.*]] = alloca %struct.CustomResource, align 1
-// CHECK: [[h:%.*]] = getelementptr inbounds nuw %struct.CustomResource, ptr [[b]], i32 0, i32 0
-// CHECK: [[h1:%.*]] = getelementptr inbounds nuw %struct.CustomResource, ptr %a, i32 0, i32 0
-// CHECK: [[Z:%.*]] = load target("dx.TypedBuffer", float, 1, 0, 0), ptr [[h1]], align 1
-// CHECK: store target("dx.TypedBuffer", float, 1, 0, 0) %0, ptr [[h]], align 1
-// CHECK: ret void
+// CHECK-LABEL: define hidden void @_Z6case2714CustomResource(
+// CHECK-SAME: ptr noundef byval([[STRUCT_CUSTOMRESOURCE:%.*]]) align 1 [[A:%.*]]) #[[ATTR0]] {
+// CHECK-NEXT:  [[ENTRY:.*:]]
+// CHECK-NEXT:    [[B:%.*]] = alloca [[STRUCT_CUSTOMRESOURCE]], align 1
+// CHECK-NEXT:    [[H:%.*]] = getelementptr inbounds nuw [[STRUCT_CUSTOMRESOURCE]], ptr [[B]], i32 0, i32 0
+// CHECK-NEXT:    [[H1:%.*]] = getelementptr inbounds nuw [[STRUCT_CUSTOMRESOURCE]], ptr [[A]], i32 0, i32 0
+// CHECK-NEXT:    [[TMP0:%.*]] = load target("dx.TypedBuffer", float, 1, 0, 0), ptr [[H1]], align 1
+// CHECK-NEXT:    store target("dx.TypedBuffer", float, 1, 0, 0) [[TMP0]], ptr [[H]], align 1
+// CHECK-NEXT:    ret void
+//
 void case27(CustomResource a) {
   CustomResource b = {a};
 }

--- a/clang/test/CodeGenHLSL/BasicFeatures/InitLists.hlsl
+++ b/clang/test/CodeGenHLSL/BasicFeatures/InitLists.hlsl
@@ -1147,4 +1147,3 @@ void case27(CustomResource a) {
 // CHECK: [[META3]] = !{}
 // CHECK: [[META4]] = !{i64 4}
 //.
-


### PR DESCRIPTION
Handle HLSL Attributed Resource Type in the init list code. Treat it like its a scalar value. 
Closes #187568