### PR TITLE
[lldb] Introduce Module::IsSystem

### DIFF
--- a/lldb/include/lldb/Symbol/ObjectFile.h
+++ b/lldb/include/lldb/Symbol/ObjectFile.h
@@ -22,6 +22,7 @@
 #include "lldb/Utility/StructuredData.h"
 #include "lldb/Utility/UUID.h"
 #include "lldb/lldb-private.h"
+#include "llvm/ADT/StringRef.h"
 #include "llvm/Support/Threading.h"
 #include "llvm/Support/VersionTuple.h"
 #include <optional>
@@ -261,6 +262,13 @@ public:
   /// \return
   ///     \b true if it is, \b false otherwise.
   virtual bool IsExecutable() const = 0;
+
+  /// Tells whether this object file is a system binary - one provided by the
+  /// OS rather than by the user installed files.
+  ///
+  /// \return
+  ///     \b true if this is a system binary, \b false otherwise.
+  virtual bool IsSystem() const { return false; }
 
   /// Returns the offset into a file at which this object resides.
   ///
@@ -755,6 +763,21 @@ public:
   std::string GetObjectName() const;
 
 protected:
+  /// Returns true if the object file's path is under a known OS system
+  /// directory. For use by IsSystem() implementations on platforms that lack a
+  /// "system binary" flag (ex. ELF, XCOFF).
+  bool IsUnixSystemPath() const {
+    std::string path_str = m_file.GetPath();
+    llvm::StringRef path = path_str;
+    // Linux / glibc multiarch, FreeBSD, AIX
+    if (path.starts_with("/lib") || path.starts_with("/usr/lib"))
+      return true;
+    // Android system partition
+    if (path.starts_with("/system/"))
+      return true;
+    return false;
+  }
+
   typedef NonNullSharedPtr<lldb_private::DataExtractor> DataExtractorNSP;
 
   // Member variables.

--- a/lldb/source/Plugins/ObjectFile/ELF/ObjectFileELF.h
+++ b/lldb/source/Plugins/ObjectFile/ELF/ObjectFileELF.h
@@ -108,6 +108,8 @@ public:
 
   bool IsExecutable() const override;
 
+  bool IsSystem() const override { return IsUnixSystemPath(); }
+
   uint32_t GetAddressByteSize() const override;
 
   lldb_private::AddressClass GetAddressClass(lldb::addr_t file_addr) override;

--- a/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.h
+++ b/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.h
@@ -102,6 +102,8 @@ public:
 
   bool IsStripped() override;
 
+  bool IsSystem() const override { return IsSharedCacheBinary(); }
+
   void CreateSections(lldb_private::SectionList &unified_section_list) override;
 
   void Dump(lldb_private::Stream *s) override;

--- a/lldb/source/Plugins/ObjectFile/PECOFF/ObjectFilePECOFF.h
+++ b/lldb/source/Plugins/ObjectFile/PECOFF/ObjectFilePECOFF.h
@@ -14,6 +14,7 @@
 
 #include "lldb/Symbol/ObjectFile.h"
 #include "lldb/Symbol/SaveCoreOptions.h"
+#include "llvm/ADT/StringExtras.h"
 #include "llvm/Object/COFF.h"
 
 class ObjectFilePECOFF : public lldb_private::ObjectFile {
@@ -108,6 +109,23 @@ public:
   lldb::ByteOrder GetByteOrder() const override;
 
   bool IsExecutable() const override;
+
+  bool IsSystem() const override {
+    std::string path_str = m_file.GetPath();
+    if (path_str.empty())
+      return false;
+    std::replace(path_str.begin(), path_str.end(), '\\', '/');
+    llvm::StringRef path = path_str;
+
+    // Skip past drive letter.
+    if (!llvm::isAlpha(path[0]))
+      return false;
+    path = path.substr(1);
+
+    return path.starts_with_insensitive(":/windows/system32/") ||
+           path.starts_with_insensitive(":/windows/syswow64/") ||
+           path.starts_with_insensitive(":/windows/winsxs/");
+  }
 
   uint32_t GetAddressByteSize() const override;
 

--- a/lldb/source/Plugins/ObjectFile/XCOFF/ObjectFileXCOFF.h
+++ b/lldb/source/Plugins/ObjectFile/XCOFF/ObjectFileXCOFF.h
@@ -67,6 +67,8 @@ public:
 
   bool IsExecutable() const override;
 
+  bool IsSystem() const override { return IsUnixSystemPath(); }
+
   uint32_t GetAddressByteSize() const override;
 
   lldb_private::AddressClass GetAddressClass(lldb::addr_t file_addr) override;

--- a/lldb/unittests/ObjectFile/MachO/TestObjectFileMachO.cpp
+++ b/lldb/unittests/ObjectFile/MachO/TestObjectFileMachO.cpp
@@ -48,6 +48,7 @@ TEST_F(ObjectFileMachOTest, ModuleFromSharedCacheInfo) {
   ModuleSpec spec(FileSpec(), UUID(), image_info.GetExtractor());
   lldb::ModuleSP module = std::make_shared<Module>(spec);
   ObjectFile *OF = module->GetObjectFile();
+  ASSERT_TRUE(OF->IsSystem());
   ASSERT_TRUE(llvm::isa<ObjectFileMachO>(OF));
   EXPECT_TRUE(
       OF->GetArchitecture().IsCompatibleMatch(HostInfo::GetArchitecture()));
@@ -96,6 +97,7 @@ TEST_F(ObjectFileMachOTest, IndirectSymbolsInTheSharedCache) {
   lldb::ModuleSP module = std::make_shared<Module>(spec);
 
   ObjectFile *OF = module->GetObjectFile();
+  ASSERT_TRUE(OF->IsSystem());
   ASSERT_TRUE(llvm::isa<ObjectFileMachO>(OF));
   EXPECT_TRUE(
       OF->GetArchitecture().IsCompatibleMatch(HostInfo::GetArchitecture()));


### PR DESCRIPTION
This `IsSystem` predicate can be used to help determine some level of trust of the binary.

This function will be consulted when loading bytecode data formatters embedded in binaries. Formatters from system binaries are always trusted, while formatters from user binaries will be subject to the `load-formatters-from-user-binaries` setting.

Assisted-by: claude