### PR TITLE
Fix assertion failure in PreISelIntrinsicLowering.cpp's lowerObjCCall

### DIFF
--- a/llvm/lib/IR/IntrinsicInst.cpp
+++ b/llvm/lib/IR/IntrinsicInst.cpp
@@ -50,6 +50,7 @@ bool IntrinsicInst::mayLowerToFunctionCall(Intrinsic::ID IID) {
   case Intrinsic::objc_retainAutorelease:
   case Intrinsic::objc_retainAutoreleaseReturnValue:
   case Intrinsic::objc_retainAutoreleasedReturnValue:
+  case Intrinsic::objc_claimAutoreleasedReturnValue:
   case Intrinsic::objc_retainBlock:
   case Intrinsic::objc_storeStrong:
   case Intrinsic::objc_storeWeak:

--- a/llvm/test/Transforms/PreISelIntrinsicLowering/X86/objc-arc.ll
+++ b/llvm/test/Transforms/PreISelIntrinsicLowering/X86/objc-arc.ll
@@ -236,6 +236,16 @@ define void @test_objc_unsafeClaimAutoreleasedReturnValue_bundle() {
   ret void
 }
 
+define ptr @test_objc_claimAutoreleasedReturnValue(ptr %arg0) {
+; CHECK-LABEL: test_objc_claimAutoreleasedReturnValue
+; CHECK-NEXT: entry
+; CHECK-NEXT: %0 = call ptr @objc_claimAutoreleasedReturnValue(ptr %arg0)
+; CHECK-NEXT: ret ptr %0
+entry:
+  %0 = call ptr @llvm.objc.claimAutoreleasedReturnValue(ptr %arg0)
+  ret ptr %0
+}
+
 define ptr @test_objc_retainedObject(ptr %arg0) {
 ; CHECK-LABEL: test_objc_retainedObject
 ; CHECK-NEXT: entry
@@ -315,6 +325,7 @@ declare ptr @llvm.objc.retainBlock(ptr)
 declare void @llvm.objc.storeStrong(ptr, ptr)
 declare ptr @llvm.objc.storeWeak(ptr, ptr)
 declare ptr @llvm.objc.unsafeClaimAutoreleasedReturnValue(ptr)
+declare ptr @llvm.objc.claimAutoreleasedReturnValue(ptr)
 declare ptr @llvm.objc.retainedObject(ptr)
 declare ptr @llvm.objc.unretainedObject(ptr)
 declare ptr @llvm.objc.unretainedPointer(ptr)
@@ -343,6 +354,7 @@ attributes #0 = { nounwind }
 ; CHECK: declare void @objc_storeStrong(ptr, ptr)
 ; CHECK: declare ptr @objc_storeWeak(ptr, ptr)
 ; CHECK: declare ptr @objc_unsafeClaimAutoreleasedReturnValue(ptr)
+; CHECK: declare ptr @objc_claimAutoreleasedReturnValue(ptr)
 ; CHECK: declare ptr @objc_retainedObject(ptr)
 ; CHECK: declare ptr @objc_unretainedObject(ptr)
 ; CHECK: declare ptr @objc_unretainedPointer(ptr)

--- a/llvm/unittests/SandboxIR/IntrinsicInstTest.cpp
+++ b/llvm/unittests/SandboxIR/IntrinsicInstTest.cpp
@@ -52,6 +52,11 @@ define void @foo(i8 %v1, i1 %cond) {
   call i8 @llvm.smax.i8(i8 %v1, i8 %v1)
   ret void
 }
+
+TEST_F(IntrinsicInstTest, MayLowerToFunctionCallObjCClaimARV) {
+  EXPECT_TRUE(llvm::IntrinsicInst::mayLowerToFunctionCall(
+      llvm::Intrinsic::objc_claimAutoreleasedReturnValue));
+}
 )IR");
 
   llvm::Function *LLVMF = &*M->getFunction("foo");


### PR DESCRIPTION
We should add claimAutoreleasedReturnValue to the list of intrinsics.