### PR TITLE
Make sure optional components are excluded

### DIFF
--- a/llvm/cmake/modules/CrossCompile.cmake
+++ b/llvm/cmake/modules/CrossCompile.cmake
@@ -106,6 +106,8 @@ function(llvm_create_cross_target project_name target_name toolchain buildtype)
         -DLLVM_TEMPORARILY_ALLOW_OLD_TOOLCHAIN="${LLVM_TEMPORARILY_ALLOW_OLD_TOOLCHAIN}"
         -DLLVM_INCLUDE_BENCHMARKS=OFF
         -DLLVM_INCLUDE_TESTS=OFF
+        -DLLVM_INCLUDE_DOCS=OFF
+        -DLLVM_INCLUDE_EXAMPLES=OFF
         -DLLVM_TABLEGEN_FLAGS="${llvm_tablegen_flags}"
         ${python_executable_flag}
         ${build_type_flags} ${linker_flag} ${external_clang_dir} ${libc_flags}


### PR DESCRIPTION
Extends a fix from https://github.com/llvm/llvm-project/commit/b1e92f8def98c5e34fdb3b4c18ac16d65fb613a2 to examples and docs, both of which may be missing but are unconditionally included if missing

This fixes an issue where the Chapel team vendors LLVM (and subsequently deletes directories like docs and examples for smaller file sizes), but if those directories are missing the build will fail