### PR TITLE
[Clang] Use stable_sort in VerifyDiagnosticsConsumer.

### DIFF
--- a/clang/lib/Frontend/VerifyDiagnosticConsumer.cpp
+++ b/clang/lib/Frontend/VerifyDiagnosticConsumer.cpp
@@ -1178,7 +1178,7 @@ static unsigned CheckResultsAreInOrder(DiagnosticsEngine &Diags,
     std::vector<const Directive *> Ordered(Unordered.size());
     std::transform(Unordered.cbegin(), Unordered.cend(), Ordered.begin(),
                    [](const std::unique_ptr<Directive> &D) { return &*D; });
-    std::sort(Ordered.begin(), Ordered.end(), directiveComparator);
+    std::stable_sort(Ordered.begin(), Ordered.end(), directiveComparator);
     return Ordered;
   };
   std::vector<const Directive *> OrderedErrors = sortDirectives(ED.Errors);


### PR DESCRIPTION
The new code introduced for `-verify-directives` in PR #179835 enforces that the order of diagnostics matches the order of the directives.  However, before checking this, it sorts the directives by SourceLocation. Perhaps non-obviously, all directives which appear inside a single comment are given the same SourceLocation, pointing to the beginning of the comment. While these are added in order they appear in the comment, the non-stable std::sort may non-detministically misorder them. Switching to stable_sort ensures the correct order is verified.

This was observed as a random test failure on the checks in clang/test/CXX/drs/cwg25xx.cpp lines 250 and 264, in some builds of Clang. Note that those lines end in backslashes, and thus, despite appearances, the directives on the following lines are also within the same single comment.