### PR TITLE
[lldb][test] Don't build PlatformLocateSafePathTest in non-asserts builds

### DIFF
--- a/lldb/unittests/Platform/PlatformTest.cpp
+++ b/lldb/unittests/Platform/PlatformTest.cpp
@@ -168,6 +168,8 @@ TEST_F(PlatformTest, CreateUnknown) {
   ASSERT_EQ(list.GetOrCreate("dummy"), nullptr);
 }
 
+// TestingProperties are only available in non-asserts builds.
+#ifndef NDEBUG
 struct PlatformLocateSafePathTest : public PlatformTest {
 protected:
   void SetUp() override {
@@ -667,3 +669,4 @@ TEST_F(PlatformLocateSafePathTest,
   EXPECT_EQ(file_specs.GetSize(), 1u);
   EXPECT_TRUE(ss.GetString().empty());
 }
+#endif // NDEBUG


### PR DESCRIPTION
From a CI failure:
```
FAILED: [code=1] tools/lldb/unittests/Platform/CMakeFiles/LLDBPlatformTests.dir/PlatformTest.cpp.obj
C:\Users\tcwg\scoop\shims\ccache.exe C:\Users\tcwg\scoop\apps\llvm-arm64\current\bin\clang-cl.exe  /nologo -TP -DLLVM_BUILD_STATIC -DUNICODE -D_CRT_NONSTDC_NO_DEPRECATE -D_CRT_NONSTDC_NO_WARNINGS -D_CRT_SECURE_NO_DEPRECATE -D_CRT_SECURE_NO_WARNINGS -D_ENABLE_EXTENDED_ALIGNED_STORAGE -D_HAS_EXCEPTIONS=0 -D_SCL_SECURE_NO_DEPRECATE -D_SCL_SECURE_NO_WARNINGS -D_UNICODE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -IC:\Users\tcwg\llvm-worker\lldb-aarch64-windows\build\tools\lldb\unittests\Platform -IC:\Users\tcwg\llvm-worker\lldb-aarch64-windows\llvm-project\lldb\unittests\Platform -IC:\Users\tcwg\llvm-worker\lldb-aarch64-windows\llvm-project\lldb\include -IC:\Users\tcwg\llvm-worker\lldb-aarch64-windows\build\tools\lldb\include -IC:\Users\tcwg\llvm-worker\lldb-aarch64-windows\build\include -IC:\Users\tcwg\llvm-worker\lldb-aarch64-windows\llvm-project\llvm\include -IC:\Users\tcwg\llvm-worker\lldb-aarch64-windows\llvm-project\llvm\..\clang\include -IC:\Users\tcwg\ll
 vm-worker\lldb-aarch64-windows\build\tools\lldb\..\clang\include -IC:\Users\tcwg\llvm-worker\lldb-aarch64-windows\llvm-project\lldb\source -IC:\Users\tcwg\llvm-worker\lldb-aarch64-windows\llvm-project\lldb\unittests -IC:\Users\tcwg\llvm-worker\lldb-aarch64-windows\llvm-project\third-party\unittest\googletest\include -IC:\Users\tcwg\llvm-worker\lldb-aarch64-windows\llvm-project\third-party\unittest\googlemock\include /DWIN32 /D_WINDOWS   /Zc:inline /Zc:__cplusplus /Oi /Brepro /bigobj /permissive- -Werror=unguarded-availability-new /W4  -Wextra -Wno-unused-parameter -Wwrite-strings -Wcast-qual -Wmissing-field-initializers -Wimplicit-fallthrough -Wcovered-switch-default -Wno-noexcept-type -Wnon-virtual-dtor -Wdelete-non-virtual-dtor -Wsuggest-override -Wstring-conversion -Wno-pass-failed -Wmisleading-indentation -Wctad-maybe-unsupported /Gw -Wno-vla-extension /O2 /Ob2 /DNDEBUG -std:c++17 -MD   -wd4018 -wd4068 -wd4150 -wd4201 -wd4251 -wd4521 -wd4530 -wd4589 -Wno-suggest-override -Wno-gn
 u-zero-variadic-macro-arguments /EHs-c- /GR- /showIncludes /Fotools\lldb\unittests\Platform\CMakeFiles\LLDBPlatformTests.dir\PlatformTest.cpp.obj /Fdtools\lldb\unittests\Platform\CMakeFiles\LLDBPlatformTests.dir\ -c -- C:\Users\tcwg\llvm-worker\lldb-aarch64-windows\llvm-project\lldb\unittests\Platform\PlatformTest.cpp
C:\Users\tcwg\llvm-worker\lldb-aarch64-windows\llvm-project\lldb\unittests\Platform\PlatformTest.cpp(197,5): error: use of undeclared identifier 'TestingProperties'
  197 |     TestingProperties::GetGlobalTestingProperties().SetSafeAutoLoadPaths({});
      |     ^
C:\Users\tcwg\llvm-worker\lldb-aarch64-windows\llvm-project\lldb\unittests\Platform\PlatformTest.cpp(238,3): error: use of undeclared identifier 'TestingProperties'
  238 |   TestingProperties::GetGlobalTestingProperties().AppendSafeAutoLoadPaths(
      |   ^
C:\Users\tcwg\llvm-worker\lldb-aarch64-windows\llvm-project\lldb\unittests\Platform\PlatformTest.cpp(265,3): error: use of undeclared identifier 'TestingProperties'
  265 |   TestingProperties::GetGlobalTestingProperties().AppendSafeAutoLoadPaths(
      |   ^
C:\Users\tcwg\llvm-worker\lldb-aarch64-windows\llvm-project\lldb\unittests\Platform\PlatformTest.cpp(295,3): error: use of undeclared identifier 'TestingProperties'
  295 |   TestingProperties::GetGlobalTestingProperties().AppendSafeAutoLoadPaths(
      |   ^
C:\Users\tcwg\llvm-worker\lldb-aarch64-windows\llvm-project\lldb\unittests\Platform\PlatformTest.cpp(364,3): error: use of undeclared identifier 'TestingProperties'
  364 |   TestingProperties::GetGlobalTestingProperties().AppendSafeAutoLoadPaths(
      |   ^
C:\Users\tcwg\llvm-worker\lldb-aarch64-windows\llvm-project\lldb\unittests\Platform\PlatformTest.cpp(367,3): error: use of undeclared identifier 'TestingProperties'
  367 |   TestingProperties::GetGlobalTestingProperties().AppendSafeAutoLoadPaths(
      |   ^
C:\Users\tcwg\llvm-worker\lldb-aarch64-windows\llvm-project\lldb\unittests\Platform\PlatformTest.cpp(370,3): error: use of undeclared identifier 'TestingProperties'
  370 |   TestingProperties::GetGlobalTestingProperties().AppendSafeAutoLoadPaths(
      |   ^
C:\Users\tcwg\llvm-worker\lldb-aarch64-windows\llvm-project\lldb\unittests\Platform\PlatformTest.cpp(388,3): error: use of undeclared identifier 'TestingProperties'
  388 |   TestingProperties::GetGlobalTestingProperties().AppendSafeAutoLoadPaths(
      |   ^
C:\Users\tcwg\llvm-worker\lldb-aarch64-windows\llvm-project\lldb\unittests\Platform\PlatformTest.cpp(413,3): error: use of undeclared identifier 'TestingProperties'
  413 |   TestingProperties::GetGlobalTestingProperties().AppendSafeAutoLoadPaths(
      |   ^
C:\Users\tcwg\llvm-worker\lldb-aarch64-windows\llvm-project\lldb\unittests\Platform\PlatformTest.cpp(449,3): error: use of undeclared identifier 'TestingProperties'
  449 |   TestingProperties::GetGlobalTestingProperties().AppendSafeAutoLoadPaths(
      |   ^
C:\Users\tcwg\llvm-worker\lldb-aarch64-windows\llvm-project\lldb\unittests\Platform\PlatformTest.cpp(487,3): error: use of undeclared identifier 'TestingProperties'
  487 |   TestingProperties::GetGlobalTestingProperties().AppendSafeAutoLoadPaths(
      |   ^
C:\Users\tcwg\llvm-worker\lldb-aarch64-windows\llvm-project\lldb\unittests\Platform\PlatformTest.cpp(516,3): error: use of undeclared identifier 'TestingProperties'
  516 |   TestingProperties::GetGlobalTestingProperties().AppendSafeAutoLoadPaths(
      |   ^
C:\Users\tcwg\llvm-worker\lldb-aarch64-windows\llvm-project\lldb\unittests\Platform\PlatformTest.cpp(550,3): error: use of undeclared identifier 'TestingProperties'
```