### PR TITLE
[compiler-rt] COMPILER_RT_DEFAULT_TARGET_ONLY should explicitly pass the triple to test 

### DIFF
--- a/compiler-rt/cmake/base-config-ix.cmake
+++ b/compiler-rt/cmake/base-config-ix.cmake
@@ -229,6 +229,7 @@ macro(test_targets)
   elseif(NOT APPLE) # Supported archs for Apple platforms are generated later
     if(COMPILER_RT_DEFAULT_TARGET_ONLY)
       add_default_target_arch(${COMPILER_RT_DEFAULT_TARGET_ARCH})
+      set(TARGET_${COMPILER_RT_DEFAULT_TARGET_ARCH}_CFLAGS -target ${COMPILER_RT_DEFAULT_TARGET_TRIPLE})
     elseif("${COMPILER_RT_DEFAULT_TARGET_ARCH}" MATCHES "i[2-6]86|x86|amd64")
       if(NOT MSVC)
         test_target_arch(x86_64 "" "-m64")


### PR DESCRIPTION
COMPILER_RT_DEFAULT_TARGET_ONLY normally requires CMAKE_C_COMPILER_TARGET, which ensures that CMake *builds* with the specified target triple (e.g. by CMake automatically appending the -target flag)

However, when running tests no target triple is currently passed. This can cause issues (#176913) when the default architecture assumed by `clang` (i.e. the host architecture) does not match the architecture being tested -- for example i386 on x86_64. To solve this, we add -target to the cflags used for the tests as well.

Closes #176913

rdar://172833755