### PR TITLE
[libclang/python] Fix Type.get_offset annotation

### DIFF
--- a/clang/bindings/python/clang/cindex.py
+++ b/clang/bindings/python/clang/cindex.py
@@ -2919,7 +2919,7 @@ class Type(Structure):
         """
         return conf.lib.clang_Type_getSizeOf(self)  # type: ignore [no-any-return]
 
-    def get_offset(self, fieldname: str) -> int:
+    def get_offset(self, fieldname: TUnion[str, bytes]) -> int:
         """
         Retrieve the offset of a field in the record.
         """


### PR DESCRIPTION
As discussed in https://github.com/llvm/llvm-project/pull/180876#discussion_r2934372753, `Type.get_offset` can process `bytes` arguments as well. For consistency with other functions taking `str` arguments, its type annotation is adapted to reflect this.