### PR TITLE
[AArch64] Combine cases with the same code in `expandMOVImm` (NFC)

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64ExpandPseudoInsts.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ExpandPseudoInsts.cpp
@@ -171,6 +171,8 @@ bool AArch64ExpandPseudoImpl::expandMOVImm(MachineBasicBlock &MBB,
 
     case AArch64::ORRWri:
     case AArch64::ORRXri:
+    case AArch64::ANDXri:
+    case AArch64::EORXri:
       if (I->Op1 == 0) {
         MIBS.push_back(BuildMI(MBB, MBBI, MI.getDebugLoc(), TII->get(I->Opcode))
                            .add(MI.getOperand(0))
@@ -203,25 +205,6 @@ bool AArch64ExpandPseudoImpl::expandMOVImm(MachineBasicBlock &MBB,
               .addReg(DstReg)
               .addImm(I->Op2));
     } break;
-    case AArch64::ANDXri:
-    case AArch64::EORXri:
-      if (I->Op1 == 0) {
-        MIBS.push_back(BuildMI(MBB, MBBI, MI.getDebugLoc(), TII->get(I->Opcode))
-                           .add(MI.getOperand(0))
-                           .addReg(BitSize == 32 ? AArch64::WZR : AArch64::XZR)
-                           .addImm(I->Op2));
-      } else {
-        Register DstReg = MI.getOperand(0).getReg();
-        bool DstIsDead = MI.getOperand(0).isDead();
-        MIBS.push_back(
-            BuildMI(MBB, MBBI, MI.getDebugLoc(), TII->get(I->Opcode))
-                .addReg(DstReg, RegState::Define |
-                                    getDeadRegState(DstIsDead && LastItem) |
-                                    RenamableState)
-                .addReg(DstReg)
-                .addImm(I->Op2));
-      }
-      break;
     case AArch64::MOVNWi:
     case AArch64::MOVNXi:
     case AArch64::MOVZWi:


### PR DESCRIPTION
Combine cases for `ORRWri`, `ORRXri`, `ANDXri` and `EORXri` in `AArch64ExpandPseudoImpl::expandMOVImm`, because these cases are handled with exactly the same code.