### PR TITLE
[clang] Move the diagnostic of unexpected token after module name from phase 4 to phase 7

### DIFF
--- a/clang/docs/ReleaseNotes.md
+++ b/clang/docs/ReleaseNotes.md
@@ -358,6 +358,9 @@ features cannot lower the translation-unit ABI level;
   template was instantiated after the global module fragment was closed,
   producing a spurious "no matching function" error with no candidate notes.
   (#GH210822)
+
+- Fixed a crash when module directive export module foo not following a 
+  semicolon and there are no rest pp-tokens in current module file. (#GH187771)
   
 - Fixed a crash when a lambda parameter pack was given a default argument that
   is a pack expansion referencing an enclosing function's parameter pack (e.g.

--- a/clang/include/clang/Basic/DiagnosticLexKinds.td
+++ b/clang/include/clang/Basic/DiagnosticLexKinds.td
@@ -1039,9 +1039,6 @@ def err_pp_module_name_is_macro : Error<
   "%select{module|partition}0 name component %1 cannot be a object-like macro">;
 def err_pp_module_expected_ident : Error<
   "expected %select{identifier after '.' in |}0module name">;
-def err_pp_unexpected_tok_after_module_name : Error<
-  "unexpected preprocessing token '%0' after module name, "
-  "only ';' and '[' (start of attribute specifier sequence) are allowed">;
 def warn_pp_extra_tokens_at_module_directive_eol
     : Warning<"extra tokens after semicolon in '%0' directive">,
       InGroup<ExtraTokens>;

--- a/clang/include/clang/Basic/DiagnosticParseKinds.td
+++ b/clang/include/clang/Basic/DiagnosticParseKinds.td
@@ -1815,6 +1815,9 @@ def ext_bit_int : Extension<
 } // end of Parse Issue category.
 
 let CategoryName = "Modules Issue" in {
+def err_unexpected_tok_after_module_name : Error<
+  "unexpected '%0' after module name, only ';' and '[' (start of attribute "
+  "specifier sequence) are allowed">;
 def err_unexpected_module_or_import_decl : Error<
   "%select{module|import}0 declaration can only appear at the top level">;
 def err_attribute_not_module_attr : Error<

--- a/clang/lib/Lex/PPDirectives.cpp
+++ b/clang/lib/Lex/PPDirectives.cpp
@@ -4420,22 +4420,6 @@ void Preprocessor::HandleCXXModuleDirective(Token ModuleTok) {
     break;
   }
 
-  // Consume the pp-import-suffix and expand any macros in it now, if we're not
-  // at the semicolon already.
-  std::optional<Token> NextPPTok =
-      DirToks.back().is(tok::eod) ? peekNextPPToken() : DirToks.back();
-
-  // Only ';' and '[' are allowed after module name.
-  // We also check 'private' because the previous is not a module name.
-  if (NextPPTok) {
-    if (NextPPTok->is(tok::raw_identifier))
-      LookUpIdentifierInfo(*NextPPTok);
-    if (!NextPPTok->isOneOf(tok::semi, tok::eod, tok::l_square,
-                            tok::kw_private))
-      Diag(*NextPPTok, diag::err_pp_unexpected_tok_after_module_name)
-          << getSpelling(*NextPPTok);
-  }
-
   if (!DirToks.back().isOneOf(tok::semi, tok::eod)) {
     // Consume the pp-import-suffix and expand any macros in it now. We'll add
     // it back into the token stream later.

--- a/clang/lib/Parse/Parser.cpp
+++ b/clang/lib/Parse/Parser.cpp
@@ -2383,9 +2383,11 @@ Parser::ParseModuleDecl(Sema::ModuleImportState &ImportState) {
   }
 
   // This should already diagnosed in phase 4, just skip unil semicolon.
-  if (!Tok.isOneOf(tok::semi, tok::l_square))
+  if (!Tok.isOneOf(tok::semi, tok::l_square)) {
+    Diag(Tok, diag::err_unexpected_tok_after_module_name)
+        << PP.getSpelling(Tok);
     SkipUntil(tok::semi, SkipUntilFlags::StopBeforeMatch);
-
+  }
   // We don't support any module attributes yet; just parse them and diagnose.
   ParsedAttributes Attrs(AttrFactory);
   MaybeParseCXX11Attributes(Attrs);

--- a/clang/lib/Parse/Parser.cpp
+++ b/clang/lib/Parse/Parser.cpp
@@ -2382,12 +2382,12 @@ Parser::ParseModuleDecl(Sema::ModuleImportState &ImportState) {
       return nullptr;
   }
 
-  // This should already diagnosed in phase 4, just skip unil semicolon.
-  if (!Tok.isOneOf(tok::semi, tok::l_square)) {
+  if (Tok.isNoneOf(tok::semi, tok::l_square, tok::eof)) {
     Diag(Tok, diag::err_unexpected_tok_after_module_name)
         << PP.getSpelling(Tok);
     SkipUntil(tok::semi, SkipUntilFlags::StopBeforeMatch);
   }
+
   // We don't support any module attributes yet; just parse them and diagnose.
   ParsedAttributes Attrs(AttrFactory);
   MaybeParseCXX11Attributes(Attrs);

--- a/clang/test/CXX/basic/basic.link/p3.cpp
+++ b/clang/test/CXX/basic/basic.link/p3.cpp
@@ -14,7 +14,7 @@ constexpr int n = 123;
 
 export module m; // #1
 module y = {}; // expected-error {{multiple module declarations}}
-// expected-error@-1 {{unexpected preprocessing token '=' after module name, only ';' and '[' (start of attribute specifier sequence) are allowed}}
+// expected-error@-1 {{unexpected '=' after module name, only ';' and '[' (start of attribute specifier sequence) are allowed}}
 // expected-note@#1 {{previous module declaration}}
 
 ::import x = {};

--- a/clang/test/CXX/drs/cwg2947.cpp
+++ b/clang/test/CXX/drs/cwg2947.cpp
@@ -37,7 +37,7 @@
 //--- cwg2947_example1.cpp
 // #define DOT_BAR .bar
 export module foo DOT_BAR; // error: expansion of DOT_BAR; does not begin with ; or [
-// expected-error@-1 {{unexpected preprocessing token '.' after module name, only ';' and '[' (start of attribute specifier sequence) are allowed}}
+// expected-error@-1 {{unexpected '.' after module name, only ';' and '[' (start of attribute specifier sequence) are allowed}}
 
 //--- cwg2947_example2.cpp
 export module M MOD_ATTR;        // OK
@@ -46,7 +46,7 @@ export module M MOD_ATTR;        // OK
 //--- cwg2947_example3.cpp
 export module a
   .b;                         // error: preprocessing token after pp-module-name is not ; or [
-// expected-error@-1 {{unexpected preprocessing token '.' after module name, only ';' and '[' (start of attribute specifier sequence) are allowed}}
+// expected-error@-1 {{unexpected '.' after module name, only ';' and '[' (start of attribute specifier sequence) are allowed}}
 
 //--- cwg2947_example4.cpp
 export module M [[

--- a/clang/test/CXX/module/basic/basic.link/module-declaration.cpp
+++ b/clang/test/CXX/module/basic/basic.link/module-declaration.cpp
@@ -47,7 +47,7 @@ export module x;
 
 //--- invalid_module_name.cppm
 export module z elderberry;
-// expected-error@-1 {{unexpected preprocessing token 'elderberry' after module name, only ';' and '[' (start of attribute specifier sequence) are allowed}}
+// expected-error@-1 {{unexpected 'elderberry' after module name, only ';' and '[' (start of attribute specifier sequence) are allowed}}
 
 //--- empty_attribute.cppm
 // expected-no-diagnostics

--- a/clang/test/CXX/module/cpp.pre/p1.cpp
+++ b/clang/test/CXX/module/cpp.pre/p1.cpp
@@ -153,7 +153,7 @@ export module m:n;
 
 //--- unexpected_character_in_pp_module_suffix.cpp
 export module m();
-// expected-error@-1 {{unexpected preprocessing token '(' after module name, only ';' and '[' (start of attribute specifier sequence) are allowed}}
+// expected-error@-1 {{unexpected '(' after module name, only ';' and '[' (start of attribute specifier sequence) are allowed}}
 
 //--- semi_in_same_line.cpp
 export module m // OK
@@ -189,13 +189,13 @@ module x;
 //--- func_like_macro.cpp
 // #define m(x) x
 export module m
-     (foo); // expected-error {{unexpected preprocessing token '(' after module name, only ';' and '[' (start of attribute specifier sequence) are allowed}}
+     (foo); // expected-error {{unexpected '(' after module name, only ';' and '[' (start of attribute specifier sequence) are allowed}}
 
 //--- lparen.cpp
 // #define m(x) x
 // #define LPAREN (
 export module m
-    LPAREN foo); // expected-error {{unexpected preprocessing token 'LPAREN' after module name, only ';' and '[' (start of attribute specifier sequence) are allowed}}
+    LPAREN foo); // expected-error {{unexpected '(' after module name, only ';' and '[' (start of attribute specifier sequence) are allowed}}
 
 //--- control_line.cpp
 #if 0 // #1

--- a/clang/test/Preprocessor/modules.cpp
+++ b/clang/test/Preprocessor/modules.cpp
@@ -1,0 +1,7 @@
+// RUN: %clang_cc1 -std=c++20 -E -verify %s | FileCheck %s
+
+// We will emit error in phase 7, so no diagnostics in -E mode.
+// expected-no-diagnostics
+
+// CHECK: export __preprocessed_module M
+export module M


### PR DESCRIPTION
The PR https://github.com/llvm/llvm-project/pull/107168 implement [CWG2947](https://cplusplus.github.io/CWG/issues/2947.html). And clang checks next pp-token after module name in phase 4.

This PR move the check to phase 7, there are three main motivations:
1. We already convert the module name pp-tokens sequence into a annot_module_name token, so for the following case, macro expansion will be disabled.
2. In the original implementation, we need to look ahead a token even if we already hit an `eod` token, but in phase7, we don't need to look ahead a token.
3. The original implementation checked and emit a diagnosis in phase 4, and then skipped these unexpected tokens in phase 7. Now we've merged them into one step and are able to get a diagnosis approximate as before.

```cpp
// #define m(x) x
export module m
     (foo);                 // Before: unexpected preprocessing token '(' after module name .....
                              // After: unexpected '(' after module name ....
```

But in the following will be breaking current behavior:

```cpp
// #define m(x) x
// #define LPAREN (
export module m
    LPAREN foo);     // Before: unexpected preprocessing token 'LPAREN' after module name .....
                              // After: unexpected '(' after module name ....
``` 
