### PR TITLE
[clang] Tests for CWG1670 and CWG1878: `auto` in conversion functions

### DIFF
--- a/clang/test/CXX/drs/cwg16xx.cpp
+++ b/clang/test/CXX/drs/cwg16xx.cpp
@@ -328,6 +328,15 @@ namespace cwg1658 { // cwg1658: 5
   // assignment case is superseded by cwg2180
 } // namespace cwg1658
 
+namespace cwg1670 { // cwg1670: no
+#if __cpusplus >= 201103L
+struct S {
+  operator auto() { return 0; }
+  // FIXME-error@-1 {{'auto' not allowed in declaration of conversion function}}
+};
+#endif
+} // namespace cwg1670
+
 namespace cwg1672 { // cwg1672: 7
   struct Empty {};
   struct A : Empty {};

--- a/clang/test/CXX/drs/cwg18xx.cpp
+++ b/clang/test/CXX/drs/cwg18xx.cpp
@@ -1,5 +1,5 @@
 // RUN: %clang_cc1 -std=c++98 -triple x86_64-unknown-unknown %s -fexceptions -fcxx-exceptions -pedantic-errors -verify-directives -verify=expected,cxx98-14,cxx98
-// RUN: %clang_cc1 -std=c++11 -triple x86_64-unknown-unknown %s -fexceptions -fcxx-exceptions -pedantic-errors -verify-directives -verify=expected,cxx11-20,cxx98-14,cxx11-17,since-cxx11
+// RUN: %clang_cc1 -std=c++11 -triple x86_64-unknown-unknown %s -fexceptions -fcxx-exceptions -pedantic-errors -verify-directives -verify=expected,cxx11-20,cxx98-14,cxx11-17,since-cxx11,cxx11
 // RUN: %clang_cc1 -std=c++14 -triple x86_64-unknown-unknown %s -fexceptions -fcxx-exceptions -pedantic-errors -verify-directives -verify=expected,cxx11-20,since-cxx14,cxx98-14,cxx11-17,since-cxx11,since-cxx14
 // RUN: %clang_cc1 -std=c++17 -triple x86_64-unknown-unknown %s -fexceptions -fcxx-exceptions -pedantic-errors -verify-directives -verify=expected,cxx11-20,since-cxx14,since-cxx17,cxx11-17,since-cxx11,since-cxx14,cxx17
 // RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-unknown %s -fexceptions -fcxx-exceptions -pedantic-errors -verify-directives -verify=expected,cxx11-20,since-cxx14,since-cxx17,since-cxx20,since-cxx11,since-cxx14
@@ -466,6 +466,17 @@ T A<T>::i() { (void)c.private_int; }
 template<int U>
 int A<int>::i() { (void)c.private_int; }
 } // namespace cwg1862
+
+namespace cwg1870 { // cwg1870: 2.7
+#if __cplusplus >= 201103L
+struct S {
+  // FIXME: why C++11 has its own diagnostic message?
+  template<class T> operator auto() { return 42; }
+  // cxx11-error@-1 {{'auto' not allowed in conversion function type}}
+  // since-cxx14-error@-2 {{'auto' not allowed in declaration of conversion function template}}
+};
+#endif
+} // namespace cwg1870
 
 namespace cwg1872 { // cwg1872: 9
 #if __cplusplus >= 201103L

--- a/clang/www/cxx_dr_status.html
+++ b/clang/www/cxx_dr_status.html
@@ -11475,7 +11475,7 @@
     <td>[<a href="https://wg21.link/dcl.spec.auto">dcl.spec.auto</a>]</td>
     <td>DR</td>
     <td><TT>auto</TT> as <I>conversion-type-id</I></td>
-    <td class="unknown" align="center">Unknown</td>
+    <td class="none" align="center">No</td>
   </tr>
   <tr id="1671">
     <td><a href="https://cplusplus.github.io/CWG/issues/1671.html">1671</a></td>
@@ -12875,7 +12875,7 @@
     <td>[<a href="https://wg21.link/basic.def">basic.def</a>]</td>
     <td>CD4</td>
     <td>Contradictory wording about definitions vs explicit specialization/instantiation</td>
-    <td class="unknown" align="center">Unknown</td>
+    <td class="full" align="center">Clang 2.7</td>
   </tr>
   <tr id="1871">
     <td><a href="https://cplusplus.github.io/CWG/issues/1871.html">1871</a></td>


### PR DESCRIPTION
This PR adds tests for [CWG1670](https://cplusplus.github.io/CWG/issues/1670.html) "`auto` as _conversion-type-id_" and [CWG1878](https://cplusplus.github.io/CWG/issues/1878.html) "`operator auto` template". The long and short of it is that placeholder type specifier (`auto`) cannot be used to declare conversion function or conversion function template. We've always diagnosed template case but not non-template case.