### PR TITLE
[clang] Don't cutoff parsing when load C++ named module failed

### DIFF
--- a/clang-tools-extra/clangd/test/non-existent.test
+++ b/clang-tools-extra/clangd/test/non-existent.test
@@ -1,0 +1,82 @@
+#
+## reproduce a crash in module processing - seems having a non-existent module imported
+## as the last statement in a file causes clangd to crash
+## modified from modules.test
+#
+# Windows have different escaping modes.
+# FIXME: We should add one for windows.
+# UNSUPPORTED: system-windows
+#
+# RUN: rm -fr %t
+# RUN: mkdir -p %t
+# RUN: split-file %s %t
+#
+# RUN: sed -e "s|DIR|%/t|g" %t/compile_commands.json.tmpl > %t/compile_commands.json.tmp
+# RUN: sed -e "s|CLANG_CC|%clang|g" %t/compile_commands.json.tmp > %t/compile_commands.json
+# RUN: sed -e "s|DIR|%/t|g" %t/definition.jsonrpc.tmpl > %t/definition.jsonrpc
+#
+# RUN: clangd -experimental-modules-support -lit-test < %t/definition.jsonrpc
+
+#--- A.cppm
+module;
+export module A;
+
+#--- Use.cpp
+module;
+export module Use;
+import A;
+import NonExistent;
+
+#--- compile_commands.json.tmpl
+[
+    {
+      "directory": "DIR",
+      "command": "CLANG_CC -fprebuilt-module-path=DIR -std=c++20 -o DIR/main.cpp.o  DIR/Use.cpp  -fmodule-file=A=DIR/A.pcm",
+      "file": "DIR/Use.cpp",
+      "output": "DIR/main.cpp.o"
+    },
+    {
+      "directory": "DIR",
+      "command": "CLANG_CC -fprebuilt-module-path=DIR --std=c++20 DIR/A.cppm --precompile -o DIR/A.pcm",
+      "file": "DIR/A.cppm",
+      "output": "DIR/A.pcm"
+    }
+]
+
+#--- definition.jsonrpc.tmpl
+{
+  "jsonrpc": "2.0",
+  "id": 0,
+  "method": "initialize",
+  "params": {
+    "processId": 123,
+    "rootPath": "clangd",
+    "capabilities": {
+      "textDocument": {
+        "completion": {
+          "completionItem": {
+            "snippetSupport": true
+          }
+        }
+      }
+    },
+    "trace": "off"
+  }
+}
+---
+{
+  "jsonrpc": "2.0",
+  "method": "textDocument/didOpen",
+  "params": {
+    "textDocument": {
+      "uri": "file://DIR/Use.cpp",
+      "languageId": "cpp",
+      "version": 1,
+      "text": "module;\nexport module Use;\nimport A;\nimport NonExistent;\n"
+    }
+  }
+}
+---
+{"jsonrpc":"2.0","id":2,"method":"shutdown"}
+---
+{"jsonrpc":"2.0","method":"exit"}

--- a/clang/lib/Parse/Parser.cpp
+++ b/clang/lib/Parse/Parser.cpp
@@ -2451,7 +2451,13 @@ Decl *Parser::ParseModuleImport(SourceLocation AtLoc,
                           /*DiagnoseEmptyAttrs=*/false,
                           /*WarnOnUnknownAttrs=*/true);
 
-  if (PP.hadModuleLoaderFatalFailure()) {
+  // Clang modules can inject token streams while loading, so a fatal loader
+  // failure must stop parsing. C++20 named module imports are ordinary
+  // declarations, and a prior failed import should not hide later diagnostics.
+  bool IsCXX20NamedModuleImport =
+      getLangOpts().CPlusPlusModules && !IsObjCAtImport && !Path.empty();
+
+  if (PP.hadModuleLoaderFatalFailure() && !IsCXX20NamedModuleImport) {
     // With a fatal failure in the module loader, we abort parsing.
     cutOffParsing();
     return nullptr;

--- a/clang/test/Modules/cxx20-fatal-module-loader-error.cpp
+++ b/clang/test/Modules/cxx20-fatal-module-loader-error.cpp
@@ -1,0 +1,12 @@
+// RUN: rm -rf %t
+// RUN: mkdir %t
+// RUN: touch %t/A.pcm
+// RUN: not %clang_cc1 -std=c++20 -fmodule-file=A=%t/A.pcm -ast-dump %s 2>&1 | FileCheck %s
+
+// CHECK: fatal error: file '{{.*}}A.pcm' is not a valid module file
+// CHECK: VarDecl {{.*}} n 'int'
+
+import A;
+import NonExistent;
+
+int n;


### PR DESCRIPTION
Since https://github.com/llvm/llvm-project/pull/173130, clang convert module name pp-token sequence into a annot_module_name token for C++20 module/import directive. This PR follows the changes and correct the module name handling in clangd.

This PR avoid parsing cutoff when hit an C++ named module loading.

Fixes https://github.com/llvm/llvm-project/issues/181358.