### PR TITLE
[CIR] Add Involution trait to BitReverseOp and ByteSwapOp

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -5696,6 +5696,8 @@ def CIR_BitReverseOp : CIR_BitOpBase<"bitreverse",
     %1 = cir.bitreverse %0: !u32i
     ```
   }];
+  
+  let append traits = [Involution];
 }
 
 def CIR_ByteSwapOp : CIR_BitOpBase<"byte_swap",
@@ -5719,6 +5721,8 @@ def CIR_ByteSwapOp : CIR_BitOpBase<"byte_swap",
     %1 = cir.byte_swap %0 : !u32i
     ```
   }];
+  
+  let append traits = [Involution];
 }
 
 //===----------------------------------------------------------------------===//

--- a/clang/test/CIR/Transforms/bit.cir
+++ b/clang/test/CIR/Transforms/bit.cir
@@ -229,4 +229,24 @@ module {
   // CHECK-NEXT:    %[[P:.+]] = cir.const #cir.poison : !u32i
   // CHECK-NEXT:    cir.return %[[P]] : !u32i
   // CHECK-NEXT:  }
+
+  cir.func @involution_bitreverse(%arg0 : !u32i) -> !u32i {
+    %0 = cir.bitreverse %arg0 : !u32i
+    %1 = cir.bitreverse %0 : !u32i
+    cir.return %1 : !u32i
+  }
+  // CHECK-LABEL: @involution_bitreverse
+  // CHECK-SAME:  (%[[X:.+]]: !u32i)
+  // CHECK-NEXT:    cir.return %[[X]] : !u32i
+  // CHECK-NEXT:  }
+
+  cir.func @involution_byte_swap(%arg0 : !u32i) -> !u32i {
+    %0 = cir.byte_swap %arg0 : !u32i
+    %1 = cir.byte_swap %0 : !u32i
+    cir.return %1 : !u32i
+  }
+  // CHECK-LABEL: @involution_byte_swap
+  // CHECK-SAME:  (%[[X:.+]]: !u32i)
+  // CHECK-NEXT:    cir.return %[[X]] : !u32i
+  // CHECK-NEXT:  }
 }


### PR DESCRIPTION
bitreverse(bitreverse(x)) == x and byte_swap(byte_swap(x)) == x are mathematical involutions. 

This adds MLIR Involution trait to CIR opetation, it encodes this property and automatically folds away the outer application when an op's input is produced by the same op type.