### PR TITLE
[llc] Fix -mcpu=help for default target triple

### DIFF
--- a/llvm/test/tools/llc/mattr-mcpu-help.ll
+++ b/llvm/test/tools/llc/mattr-mcpu-help.ll
@@ -1,4 +1,5 @@
 ; REQUIRES: aarch64-registered-target
+; REQUIRES: default_triple
 
 ;; Test -mattr=help
 ; RUN: llc -mtriple=aarch64 -mattr=help 2>&1 | FileCheck %s --check-prefixes=CHECK,CHECK-NO-COMPILE
@@ -9,9 +10,9 @@
 ;; -mattr=help doesn't have to be first
 ; RUN: llc -mtriple=aarch64 -mattr=+zcm-fpr64 -mattr=help 2>&1 | FileCheck %s --check-prefixes=CHECK,CHECK-NO-COMPILE
 
-;; Missing target triple for -mattr=help
-; RUN: not llc -mattr=help 2>&1 | FileCheck %s --check-prefixes=CHECK-MISSING-TRIPLE
-; RUN: not llc < %s -mattr=help 2>&1 | FileCheck %s --check-prefixes=CHECK-MISSING-TRIPLE
+;; Using default target triple for -mattr=help
+; RUN: llc -mattr=help 2>&1 | FileCheck %s --check-prefixes=CHECK,CHECK-NO-COMPILE
+; RUN: llc < %s -mattr=help 2>&1 | FileCheck %s --check-prefixes=CHECK,CHECK-NO-COMPILE
 
 ;; Test -mcpu=help
 ; RUN: llc -mtriple=aarch64 -mcpu=help 2>&1 | FileCheck %s --check-prefixes=CHECK,CHECK-NO-COMPILE
@@ -19,14 +20,12 @@
 ; RUN: llc < %s -mtriple=aarch64 -mcpu=help 2>&1 | FileCheck %s --check-prefixes=CHECK,CHECK-NO-COMPILE
 ; RUN: llc < %s -mtriple=aarch64 -mcpu=help -o %t.s 2>&1 | FileCheck %s --check-prefixes=CHECK,CHECK-NO-COMPILE
 
-;; Missing target triple for -mcpu=help
-; RUN: not llc -mcpu=help 2>&1 | FileCheck %s --check-prefixes=CHECK-MISSING-TRIPLE
-; RUN: not llc < %s -mcpu=help 2>&1 | FileCheck %s --check-prefixes=CHECK-MISSING-TRIPLE
+;; Using default target triple for -mcpu=help
+; RUN: llc -mcpu=help 2>&1 | FileCheck %s --check-prefixes=CHECK,CHECK-NO-COMPILE
+; RUN: llc < %s -mcpu=help 2>&1 | FileCheck %s --check-prefixes=CHECK,CHECK-NO-COMPILE
 
 ; CHECK: Available CPUs for this target:
 ; CHECK: Available features for this target:
-
-; CHECK-MISSING-TRIPLE: error: unable to get target for 'unknown', see --version and --triple.
 
 ;; To check we dont compile the file
 ; CHECK-NO-COMPILE-NOT: foo

--- a/llvm/test/tools/llc/mtune.ll
+++ b/llvm/test/tools/llc/mtune.ll
@@ -16,17 +16,15 @@
 ; RUN: llc < %s -mtriple=aarch64 -mtune=help 2>&1 | FileCheck %s --check-prefixes=CHECK-TUNE-HELP,CHECK-TUNE-HELP-NO-COMPILE
 ; RUN: llc < %s -mtriple=aarch64 -mtune=help -o %t.s 2>&1 | FileCheck %s --check-prefixes=CHECK-TUNE-HELP,CHECK-TUNE-HELP-NO-COMPILE
 
-;; Missing target triple for -mtune=help
-; RUN: not llc -mtune=help 2>&1 | FileCheck %s --check-prefixes=CHECK-TUNE-HELP-MISSING-TRIPLE
-; RUN: not llc < %s -mtune=help 2>&1 | FileCheck %s --check-prefixes=CHECK-TUNE-HELP-MISSING-TRIPLE
+;; Using default target triple for -mtune=help
+; RUN: llc -mtune=help 2>&1 | FileCheck %s --check-prefixes=CHECK-TUNE-HELP,CHECK-TUNE-HELP-NO-COMPILE
+; RUN: llc < %s -mtune=help 2>&1 | FileCheck %s --check-prefixes=CHECK-TUNE-HELP,CHECK-TUNE-HELP-NO-COMPILE
 
 ; CHECK-TUNE-HELP: Available CPUs for this target:
 ; CHECK-TUNE-HELP: Available features for this target:
 
 ;; To check we dont compile the file
 ; CHECK-TUNE-HELP-NO-COMPILE-NOT: zero_cycle_regmove_FPR32:
-
-; CHECK-TUNE-HELP-MISSING-TRIPLE: error: unable to get target for 'unknown', see --version and --triple.
 
 ;; A test case that depends on `FeatureZCRegMoveFPR128` tuning feature, to enable -mtune verification
 ;; through codegen effects. Taken from: llvm/test/CodeGen/AArch64/arm64-zero-cycle-regmove-fpr.ll

--- a/llvm/tools/llc/llc.cpp
+++ b/llvm/tools/llc/llc.cpp
@@ -596,9 +596,10 @@ static int compileModule(char **argv, SmallVectorImpl<PassPlugin> &PluginList,
   bool SkipModule =
       CPUStr == "help" || TuneCPUStr == "help" || is_contained(MAttrs, "help");
   if (SkipModule) {
-    TheTriple = Triple(Triple::normalize(TargetTriple));
-    if (TheTriple.getTriple().empty())
-      TheTriple.setTriple(sys::getDefaultTargetTriple());
+    if (!TargetTriple.empty())
+      TheTriple = Triple(Triple::normalize(TargetTriple));
+    else
+      TheTriple = Triple(sys::getDefaultTargetTriple());
 
     // Get the target specific parser.
     std::string Error;


### PR DESCRIPTION
Previously, a command like `llc -mcpu=help` would fail on invalid target triple, due to wrongly passing empty target to `Triple::normalize` resulting in `unknown`.