### PR TITLE
[clangd] Add ArcsinX as a maintainer

### DIFF
--- a/clang-tools-extra/Maintainers.rst
+++ b/clang-tools-extra/Maintainers.rst
@@ -57,6 +57,9 @@ clangd
 | Nathan Ridge
 | zeratul976@hotmail.com (email), HighCommander4 (GitHub), HighCommander4 (Discourse), nridge (Discord)
 
+| Aleksandr Platonov
+| arcsinx45@gmail.com (email), ArcsinX (GitHub), ArcsinX (Discourse)
+
 
 Inactive Maintainers
 ====================


### PR DESCRIPTION
To address clangd maintance problem, I'm nominating myself as a clangd maintainer.
I'm currently actively reviewing PRs. I also participated in clangd-related discourse discussions, subscribed to clangd issues and PRs. For a while I plan to spend some time for PRs review in clangd.