### PR TITLE
 [InstCombine] fold ctlz(zext(x), zero_is_poison) -> zext(ctlz(x, zero_is_poison)) + (DestWidth - SrcWidth)

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineCalls.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCalls.cpp
@@ -596,6 +596,20 @@ static Instruction *foldCttzCtlz(IntrinsicInst &II, InstCombinerImpl &IC) {
       auto *Bw = ConstantInt::get(Ty, APInt(BitWidth, BitWidth));
       return IC.replaceInstUsesWith(II, IC.Builder.CreateSub(Bw, Cttz));
     }
+
+    // ctlz(zext(x), is_zero_poison) -> zext(ctlz(x, is_zero_poison)) +
+    // (DestWidth - SrcWidth). Zero-extension prepends (DestWidth - SrcWidth)
+    // zero bits, so the number of leading zeros of the wide value equals the
+    // leading zeros of the narrow value plus the number of extended bits.
+    // The ZeroIsPoison flag is passed through unchanged.
+    if (match(Op0, m_OneUse(m_ZExt(m_Value(X))))) {
+      auto *Ctlz = IC.Builder.CreateBinaryIntrinsic(Intrinsic::ctlz, X, Op1);
+      auto *ZextCtlz = IC.Builder.CreateZExt(Ctlz, II.getType());
+      unsigned SrcWidth = X->getType()->getScalarSizeInBits();
+      unsigned DstWidth = II.getType()->getScalarSizeInBits();
+      auto *Offset = ConstantInt::get(II.getType(), DstWidth - SrcWidth);
+      return IC.replaceInstUsesWith(II, IC.Builder.CreateAdd(ZextCtlz, Offset));
+    }
   }
 
   // cttz(Pow2) -> Log2(Pow2)

--- a/llvm/test/Transforms/InstCombine/ctlz-cttz.ll
+++ b/llvm/test/Transforms/InstCombine/ctlz-cttz.ll
@@ -143,3 +143,46 @@ define <2 x i8> @ctlz_to_sub_bw_cttz_vec_splat(<2 x i8> %a0) {
   %clz = tail call <2 x i8>@llvm.ctlz.v2i8(<2 x i8> %and, i1 false)
   ret <2 x i8> %clz
 }
+
+; ctlz(zext(x), true) -> zext(ctlz(x, true)) + (DestWidth - SrcWidth)
+define i128 @ctlz_zext_i32_to_i128(i32 %x) {
+; CHECK-LABEL: define i128 @ctlz_zext_i32_to_i128(
+; CHECK-SAME: i32 [[X:%.*]]) {
+; CHECK-NEXT:    [[Z:%.*]] = zext i32 [[X]] to i128
+; CHECK-NEXT:    [[RES:%.*]] = call range(i128 96, 129) i128 @llvm.ctlz.i128(i128 [[Z]], i1 true)
+; CHECK-NEXT:    ret i128 [[RES]]
+;
+  %z = zext i32 %x to i128
+  %clz = call i128 @llvm.ctlz.i128(i128 %z, i1 true)
+  ret i128 %clz
+}
+
+; Negative: ZeroIsPoison=false should not fold
+define i128 @ctlz_zext_i32_to_i128_no_poison(i32 %x) {
+; CHECK-LABEL: define i128 @ctlz_zext_i32_to_i128_no_poison(
+; CHECK-SAME: i32 [[X:%.*]]) {
+; CHECK-NEXT:    [[Z:%.*]] = zext i32 [[X]] to i128
+; CHECK-NEXT:    [[CLZ:%.*]] = call range(i128 96, 129) i128 @llvm.ctlz.i128(i128 [[Z]], i1 false)
+; CHECK-NEXT:    ret i128 [[CLZ]]
+;
+  %z = zext i32 %x to i128
+  %clz = call i128 @llvm.ctlz.i128(i128 %z, i1 false)
+  ret i128 %clz
+}
+
+; Negative: zext has two uses so we do not narrow the ctlz.
+define i128 @ctlz_zext_i32_to_i128_multiuse(i32 %x) {
+; CHECK-LABEL: define i128 @ctlz_zext_i32_to_i128_multiuse(
+; CHECK-SAME: i32 [[X:%.*]]) {
+; CHECK-NEXT:    [[Z:%.*]] = zext i32 [[X]] to i128
+; CHECK-NEXT:    [[CLZ:%.*]] = call range(i128 96, 129) i128 @llvm.ctlz.i128(i128 [[Z]], i1 true)
+; CHECK-NEXT:    [[ADD:%.*]] = add nuw nsw i128 [[CLZ]], [[Z]]
+; CHECK-NEXT:    ret i128 [[ADD]]
+;
+  %z = zext i32 %x to i128
+  %clz = call i128 @llvm.ctlz.i128(i128 %z, i1 true)
+  %add = add i128 %clz, %z
+  ret i128 %add
+}
+
+declare i128 @llvm.ctlz.i128(i128, i1)

--- a/llvm/test/Transforms/InstCombine/ctlz-cttz.ll
+++ b/llvm/test/Transforms/InstCombine/ctlz-cttz.ll
@@ -144,12 +144,13 @@ define <2 x i8> @ctlz_to_sub_bw_cttz_vec_splat(<2 x i8> %a0) {
   ret <2 x i8> %clz
 }
 
-; ctlz(zext(x), true) -> zext(ctlz(x, true)) + (DestWidth - SrcWidth)
+; ctlz(zext(x), is_zero_poison) -> zext(ctlz(x, is_zero_poison)) + (DestWidth - SrcWidth)
 define i128 @ctlz_zext_i32_to_i128(i32 %x) {
 ; CHECK-LABEL: define i128 @ctlz_zext_i32_to_i128(
 ; CHECK-SAME: i32 [[X:%.*]]) {
-; CHECK-NEXT:    [[Z:%.*]] = zext i32 [[X]] to i128
-; CHECK-NEXT:    [[RES:%.*]] = call range(i128 96, 129) i128 @llvm.ctlz.i128(i128 [[Z]], i1 true)
+; CHECK-NEXT:    [[TMP1:%.*]] = call range(i32 0, 33) i32 @llvm.ctlz.i32(i32 [[X]], i1 true)
+; CHECK-NEXT:    [[TMP2:%.*]] = or disjoint i32 [[TMP1]], 96
+; CHECK-NEXT:    [[RES:%.*]] = zext nneg i32 [[TMP2]] to i128
 ; CHECK-NEXT:    ret i128 [[RES]]
 ;
   %z = zext i32 %x to i128
@@ -157,12 +158,13 @@ define i128 @ctlz_zext_i32_to_i128(i32 %x) {
   ret i128 %clz
 }
 
-; Negative: ZeroIsPoison=false should not fold
+; ZeroIsPoison=false folds the same way; the flag is passed through.
 define i128 @ctlz_zext_i32_to_i128_no_poison(i32 %x) {
 ; CHECK-LABEL: define i128 @ctlz_zext_i32_to_i128_no_poison(
 ; CHECK-SAME: i32 [[X:%.*]]) {
-; CHECK-NEXT:    [[Z:%.*]] = zext i32 [[X]] to i128
-; CHECK-NEXT:    [[CLZ:%.*]] = call range(i128 96, 129) i128 @llvm.ctlz.i128(i128 [[Z]], i1 false)
+; CHECK-NEXT:    [[TMP1:%.*]] = call range(i32 0, 33) i32 @llvm.ctlz.i32(i32 [[X]], i1 false)
+; CHECK-NEXT:    [[NARROW:%.*]] = add nuw nsw i32 [[TMP1]], 96
+; CHECK-NEXT:    [[CLZ:%.*]] = zext nneg i32 [[NARROW]] to i128
 ; CHECK-NEXT:    ret i128 [[CLZ]]
 ;
   %z = zext i32 %x to i128
@@ -184,5 +186,3 @@ define i128 @ctlz_zext_i32_to_i128_multiuse(i32 %x) {
   %add = add i128 %clz, %z
   ret i128 %add
 }
-
-declare i128 @llvm.ctlz.i128(i128, i1)

--- a/llvm/test/Transforms/InstCombine/zext-ctlz-trunc-to-ctlz-add.ll
+++ b/llvm/test/Transforms/InstCombine/zext-ctlz-trunc-to-ctlz-add.ll
@@ -55,9 +55,9 @@ define <vscale x 2 x i16> @trunc_ctlz_zext_nxv2i16_nxv2i64(<vscale x 2 x i16> %x
 
 define <2 x i17> @trunc_ctlz_zext_v2i17_v2i32_multiple_uses(<2 x i17> %x) {
 ; CHECK-LABEL: @trunc_ctlz_zext_v2i17_v2i32_multiple_uses(
-; CHECK-NEXT:    [[Z:%.*]] = zext <2 x i17> [[X:%.*]] to <2 x i32>
-; CHECK-NEXT:    [[P:%.*]] = call range(i32 15, 33) <2 x i32> @llvm.ctlz.v2i32(<2 x i32> [[Z]], i1 false)
-; CHECK-NEXT:    [[ZZ:%.*]] = trunc nuw nsw <2 x i32> [[P]] to <2 x i17>
+; CHECK-NEXT:    [[TMP1:%.*]] = call range(i17 0, 18) <2 x i17> @llvm.ctlz.v2i17(<2 x i17> [[X:%.*]], i1 false)
+; CHECK-NEXT:    [[ZZ:%.*]] = add nuw nsw <2 x i17> [[TMP1]], splat (i17 15)
+; CHECK-NEXT:    [[P:%.*]] = zext nneg <2 x i17> [[ZZ]] to <2 x i32>
 ; CHECK-NEXT:    call void @use(<2 x i32> [[P]])
 ; CHECK-NEXT:    ret <2 x i17> [[ZZ]]
 ;
@@ -89,9 +89,9 @@ define <vscale x 2 x i16> @trunc_ctlz_zext_nxv2i16_nxv2i63_multiple_uses(<vscale
 
 define i16 @trunc_ctlz_zext_i10_i32(i10 %x) {
 ; CHECK-LABEL: @trunc_ctlz_zext_i10_i32(
-; CHECK-NEXT:    [[Z:%.*]] = zext i10 [[X:%.*]] to i32
-; CHECK-NEXT:    [[P:%.*]] = call range(i32 22, 33) i32 @llvm.ctlz.i32(i32 [[Z]], i1 false)
-; CHECK-NEXT:    [[ZZ:%.*]] = trunc nuw nsw i32 [[P]] to i16
+; CHECK-NEXT:    [[TMP1:%.*]] = call range(i10 0, 11) i10 @llvm.ctlz.i10(i10 [[X:%.*]], i1 false)
+; CHECK-NEXT:    [[NARROW:%.*]] = add nuw nsw i10 [[TMP1]], 22
+; CHECK-NEXT:    [[ZZ:%.*]] = zext nneg i10 [[NARROW]] to i16
 ; CHECK-NEXT:    ret i16 [[ZZ]]
 ;
   %z = zext i10 %x to i32
@@ -107,9 +107,8 @@ define i16 @trunc_ctlz_zext_i10_i32(i10 %x) {
 
 define i3 @trunc_ctlz_zext_i3_i34(i3 %x) {
 ; CHECK-LABEL: @trunc_ctlz_zext_i3_i34(
-; CHECK-NEXT:    [[Z:%.*]] = zext i3 [[X:%.*]] to i34
-; CHECK-NEXT:    [[P:%.*]] = call range(i34 31, 35) i34 @llvm.ctlz.i34(i34 [[Z]], i1 false)
-; CHECK-NEXT:    [[T:%.*]] = trunc i34 [[P]] to i3
+; CHECK-NEXT:    [[TMP1:%.*]] = call range(i3 0, -4) i3 @llvm.ctlz.i3(i3 [[X:%.*]], i1 false)
+; CHECK-NEXT:    [[T:%.*]] = add nsw i3 [[TMP1]], -1
 ; CHECK-NEXT:    ret i3 [[T]]
 ;
   %z = zext i3 %x to i34


### PR DESCRIPTION
Relates: https://github.com/llvm/llvm-project/issues/187838

`zext` prepends `DestWidth - SrcWidth` known-zero bits, so the leading zero count of the wide value is always the leading zero count of the narrow value plus the number of extended bits. InstCombine can therefore narrow the `ctlz` to the source type and add the constant offset. The `is_zero_poison` flag is passed through unchanged since zero-ness of the input is invariant under zero-extension.

The fold makes sure the `zext` is one use. If the extended value is used elsewhere, narrowing is not profitable, because it turns zext + ctlz.i128 (any wider type) into zext + ctlz.i32 (any narrower type) + add + zext, so this is gated to one use zexts.

This IR:
```llvm
%zext = zext i32 %x to i128
%r    = call i128 @llvm.ctlz.i128(i128 %zext, i1 true)
```

Turns to this:
```llvm
%ctlz = call i32 @llvm.ctlz.i32(i32 %x, i1 true)
%add  = or disjoint i32 %ctlz, 96        ; 128 - 32 = 96
%r    = zext nneg i32 %add to i128
```

The motivating case is Rust's `leading_zeros()` on narrow integer types, which zero-extends to i128 before calling `llvm.ctlz.i128`. Since i128 `ctlz` has no native hardware instruction and backends lower it to a branch + two 64-bit `ctlz` ops, narrowing to the source type gives a single native instruction.