### PR TITLE
[mlir][nfc] Fix gcc compiler error on destructor in PassRegistry.cpp

### DIFF
--- a/mlir/lib/Pass/PassRegistry.cpp
+++ b/mlir/lib/Pass/PassRegistry.cpp
@@ -419,40 +419,38 @@ size_t detail::PassOptions::getOptionWidth() const {
 // OpPassManager: OptionValue
 //===----------------------------------------------------------------------===//
 
-llvm::cl::OptionValue<OpPassManager>::OptionValue() = default;
-llvm::cl::OptionValue<OpPassManager>::OptionValue(
-    const mlir::OpPassManager &value) {
+namespace llvm::cl {
+
+OptionValue<OpPassManager>::OptionValue() = default;
+OptionValue<OpPassManager>::OptionValue(const mlir::OpPassManager &value) {
   setValue(value);
 }
-llvm::cl::OptionValue<OpPassManager>::OptionValue(
-    const llvm::cl::OptionValue<mlir::OpPassManager> &rhs) {
+OptionValue<OpPassManager>::OptionValue(
+    const OptionValue<mlir::OpPassManager> &rhs) {
   if (rhs.hasValue())
     setValue(rhs.getValue());
 }
-llvm::cl::OptionValue<OpPassManager> &
-llvm::cl::OptionValue<OpPassManager>::operator=(
-    const mlir::OpPassManager &rhs) {
+OptionValue<OpPassManager> &
+OptionValue<OpPassManager>::operator=(const mlir::OpPassManager &rhs) {
   setValue(rhs);
   return *this;
 }
 
-llvm::cl::OptionValue<OpPassManager>::~OptionValue<OpPassManager>() = default;
+OptionValue<OpPassManager>::~OptionValue() = default;
 
-void llvm::cl::OptionValue<OpPassManager>::setValue(
-    const OpPassManager &newValue) {
+void OptionValue<OpPassManager>::setValue(const OpPassManager &newValue) {
   if (hasValue())
     *value = newValue;
   else
     value = std::make_unique<mlir::OpPassManager>(newValue);
 }
-void llvm::cl::OptionValue<OpPassManager>::setValue(StringRef pipelineStr) {
+void OptionValue<OpPassManager>::setValue(StringRef pipelineStr) {
   FailureOr<OpPassManager> pipeline = parsePassPipeline(pipelineStr);
   assert(succeeded(pipeline) && "invalid pass pipeline");
   setValue(*pipeline);
 }
 
-bool llvm::cl::OptionValue<OpPassManager>::compare(
-    const mlir::OpPassManager &rhs) const {
+bool OptionValue<OpPassManager>::compare(const mlir::OpPassManager &rhs) const {
   std::string lhsStr, rhsStr;
   {
     raw_string_ostream lhsStream(lhsStr);
@@ -466,17 +464,17 @@ bool llvm::cl::OptionValue<OpPassManager>::compare(
   return lhsStr == rhsStr;
 }
 
-void llvm::cl::OptionValue<OpPassManager>::anchor() {}
+void OptionValue<OpPassManager>::anchor() {}
+
+} // namespace llvm::cl
 
 //===----------------------------------------------------------------------===//
 // OpPassManager: Parser
 //===----------------------------------------------------------------------===//
 
-namespace llvm {
-namespace cl {
+namespace llvm::cl {
 template class basic_parser<OpPassManager>;
-} // namespace cl
-} // namespace llvm
+} // namespace llvm::cl
 
 bool llvm::cl::parser<OpPassManager>::parse(Option &, StringRef, StringRef arg,
                                             ParsedPassManager &value) {


### PR DESCRIPTION
Remove template arguments from out-of-line destructor definition, as C++20 does not allow template-ids on destructors.