### PR TITLE
[llvm] Refactor llc to use OptTable

### DIFF
--- a/llvm/tools/llc/CMakeLists.txt
+++ b/llvm/tools/llc/CMakeLists.txt
@@ -13,6 +13,7 @@ set(LLVM_LINK_COMPONENTS
   IRReader
   MC
   MIRParser
+  Option
   Passes
   Plugins
   Remarks
@@ -25,11 +26,16 @@ set(LLVM_LINK_COMPONENTS
   Vectorize
   )
 
+set(LLVM_TARGET_DEFINITIONS Opts.td)
+tablegen(LLVM Opts.inc -gen-opt-parser-defs)
+add_public_tablegen_target(LlcOptsTableGen)
+
 add_llvm_tool(llc
   llc.cpp
   NewPMDriver.cpp
 
   DEPENDS
+  LlcOptsTableGen
   intrinsics_gen
   SUPPORT_PLUGINS
   )

--- a/llvm/tools/llc/Opts.td
+++ b/llvm/tools/llc/Opts.td
@@ -143,3 +143,4 @@ defm tail_predication : Eq<"tail-predication", "Tail predication mode">;
 defm aarch64_cb_offset_bits : Eq<"aarch64-cb-offset-bits", "AArch64 CB offset bits">;
 defm aarch64_enable_atomic_cfg_tidy : Eq<"aarch64-enable-atomic-cfg-tidy", "AArch64 enable atomic CFG tidy">;
 defm aarch64_min_jump_table_entries : Eq<"aarch64-min-jump-table-entries", "AArch64 min jump table entries">;
+

--- a/llvm/tools/llc/Opts.td
+++ b/llvm/tools/llc/Opts.td
@@ -1,0 +1,145 @@
+include "llvm/Option/OptParser.td"
+
+def LlcLocalOption : OptionFlag;
+
+class F<string letter, string help> : Flag<["-"], letter>, HelpText<help>;
+class FF<string name, string help> : Flag<["--", "-"], name>, HelpText<help>;
+
+multiclass Eq<string name, string help> {
+  def NAME #_EQ : Joined<["--", "-"], name #"=">, HelpText<help>;
+  def NAME : Separate<["--", "-"], name>, Alias<!cast<Joined>(NAME #_EQ)>;
+}
+
+let Flags = [LlcLocalOption] in {
+
+def help : FF<"help", "Display available options (-help-hidden for more)">;
+def version : FF<"version", "Display the version">;
+
+def O_flag : Joined<["-"], "O">, HelpText<"Optimization level. [-O0, -O1, -O2, or -O3] (default = '-O2')">, MetaVarName<"<n>">;
+
+defm o : Eq<"o", "Output filename">, MetaVarName<"<filename>">;
+defm x : Eq<"x", "Input language ('ir' or 'mir')">, MetaVarName<"<language>">;
+defm mtriple : Eq<"mtriple", "Override target triple for module">, MetaVarName<"<target triple>">;
+def M : JoinedOrSeparate<["-", "--"], "M">, HelpText<"InstPrinter options">, MetaVarName<"<options>">;
+
+defm split_dwarf_output : Eq<"split-dwarf-output", ".dwo output filename">, MetaVarName<"<filename>">;
+defm split_dwarf_file : Eq<"split-dwarf-file", "Specify the name of the .dwo file to encode in the DWARF output">, MetaVarName<"<filename>">;
+
+defm time_compilations : Eq<"time-compilations", "Repeat compilation N times for timing">, MetaVarName<"<N>">;
+def time_trace : FF<"time-trace", "Record time trace">;
+defm time_trace_granularity : Eq<"time-trace-granularity", "Minimum time granularity (in microseconds) traced by time profiler">, MetaVarName<"<microseconds>">;
+defm time_trace_file : Eq<"time-trace-file", "Specify time trace file destination">, MetaVarName<"<filename>">;
+
+defm binutils_version : Eq<"binutils-version", "Produced object files can use all ELF features supported by this binutils version and newer.">, MetaVarName<"<version>">;
+def preserve_as_comments : FF<"preserve-as-comments", "Preserve Comments in outputted assembly">;
+
+def disable_verify : FF<"disable-verify", "Do not verify input module">;
+def verify_each : FF<"verify-each", "Verify after each transform">;
+def disable_simplify_libcalls : FF<"disable-simplify-libcalls", "Disable simplify-libcalls">;
+def show_mc_encoding : FF<"show-mc-encoding", "Show encoding in .s output">;
+defm output_asm_variant : Eq<"output-asm-variant", "Syntax variant to use for output printing">, MetaVarName<"<variant>">;
+def dwarf_directory : FF<"dwarf-directory", "Use .file directives with an explicit directory">;
+def dwarf_directory_EQ : JoinedOrSeparate<["-", "--"], "dwarf-directory=">, HelpText<"Use .file directives with an explicit directory">;
+def asm_verbose : FF<"asm-verbose", "Add comments to directives.">;
+def asm_verbose_EQ : Joined<["--", "-"], "asm-verbose=">, HelpText<"Add comments to directives.">;
+def compile_twice : FF<"compile-twice", "Run everything twice, re-using the same pass manager and verify the result is the same.">;
+def discard_value_names : FF<"discard-value-names", "Discard names from Value (other than GlobalValue).">;
+def print_mir2vec_vocab : FF<"print-mir2vec-vocab", "Print MIR2Vec vocabulary contents">;
+def print_mir2vec : FF<"print-mir2vec", "Print MIR2Vec embeddings for functions">;
+
+def I : JoinedOrSeparate<["-"], "I">, HelpText<"include search path">, MetaVarName<"<dir>">;
+def pass_remarks_with_hotness : FF<"pass-remarks-with-hotness", "With PGO, include profile count in optimization remarks">;
+def pass_remarks_with_hotness_EQ : Joined<["--", "-"], "pass-remarks-with-hotness=">, HelpText<"With PGO, include profile count in optimization remarks">;
+defm pass_remarks_hotness_threshold : Eq<"pass-remarks-hotness-threshold", "Minimum profile count required for an optimization remark to be output.">, MetaVarName<"<N or 'auto'>">;
+defm pass_remarks_output : Eq<"pass-remarks-output", "Output filename for pass remarks">, MetaVarName<"<filename>">;
+defm pass_remarks_filter : Eq<"pass-remarks-filter", "Only record optimization remarks from passes whose names match the given regular expression">, MetaVarName<"<regex>">;
+defm pass_remarks_format : Eq<"pass-remarks-format", "The format used for serializing remarks (default: YAML)">, MetaVarName<"<format>">;
+
+def load_pass_plugin_EQ : Joined<["--", "-"], "load-pass-plugin=">, HelpText<"Load plugin library">, MetaVarName<"<plugin>">;
+def load_pass_plugin : Separate<["--", "-"], "load-pass-plugin">, Alias<load_pass_plugin_EQ>;
+
+def enable_new_pm : FF<"enable-new-pm", "Enable the new pass manager">;
+def enable_new_pm_EQ : Joined<["--", "-"], "enable-new-pm=">, HelpText<"Enable the new pass manager">;
+defm passes : Eq<"passes", "A textual description of the pass pipeline.">, MetaVarName<"<pipeline>">;
+def p : Separate<["--", "-"], "p">, Alias<passes_EQ>;
+def p_EQ : Joined<["--", "-"], "p=">, Alias<passes_EQ>;
+
+defm run_pass : Eq<"run-pass", "Run compiler only for specified passes (comma separated list)">, MetaVarName<"<pass-name>">;
+defm pgo_kind : Eq<"pgo-kind", "The kind of profile guided optimization">, MetaVarName<"<kind>">;
+
+} // end let Flags = [LlcLocalOption]
+
+
+//
+// NOTE: Each Opt declared below is forwarded to the backend. These are not explicitly used in llc.
+//
+def tail_merge_threshold : JoinedOrSeparate<["-", "--"], "tail-merge-threshold">, HelpText<"Threshold for tail merging">;
+def pre_RA_sched : JoinedOrSeparate<["-", "--"], "pre-RA-sched">, HelpText<"Pre-RA Scheduler">;
+def march : JoinedOrSeparate<["-", "--"], "march">, HelpText<"Architecture to generate code for">;
+def mcpu : JoinedOrSeparate<["-", "--"], "mcpu">, HelpText<"Target a specific cpu type">;
+def mattr : JoinedOrSeparate<["-", "--"], "mattr">, HelpText<"Target specific attributes">;
+def relocation_model : JoinedOrSeparate<["-", "--"], "relocation-model">, HelpText<"Choose relocation model">;
+def thread_model : JoinedOrSeparate<["-", "--"], "thread-model">, HelpText<"Choose threading model">;
+def code_model : JoinedOrSeparate<["-", "--"], "code-model">, HelpText<"Choose code model">;
+def large_data_threshold : JoinedOrSeparate<["-", "--"], "large-data-threshold">, HelpText<"Choose large data threshold">;
+def exception_model : JoinedOrSeparate<["-", "--"], "exception-model">, HelpText<"Choose exception model">;
+def frame_pointer : JoinedOrSeparate<["-", "--"], "frame-pointer">, HelpText<"Specify frame pointer elimination optimization">;
+def denormal_fp_math : JoinedOrSeparate<["-", "--"], "denormal-fp-math">, HelpText<"Select denormal numbers mode">;
+def denormal_fp_math_f32 : JoinedOrSeparate<["-", "--"], "denormal-fp-math-f32">, HelpText<"Select denormal numbers mode for float">;
+def float_abi : JoinedOrSeparate<["-", "--"], "float-abi">, HelpText<"Choose float ABI type">;
+def fp_contract : JoinedOrSeparate<["-", "--"], "fp-contract">, HelpText<"Enable aggressive formation of fused FP ops">;
+def swift_async_fp : JoinedOrSeparate<["-", "--"], "swift-async-fp">, HelpText<"Swift async frame pointer mode">;
+def trap_func : JoinedOrSeparate<["-", "--"], "trap-func">, HelpText<"Emit a call to trap function">;
+def basic_block_sections : JoinedOrSeparate<["-", "--"], "basic-block-sections">, HelpText<"Emit basic blocks into separate sections">;
+def tls_size : JoinedOrSeparate<["-", "--"], "tls-size">, HelpText<"Bit size of immediate TLS offsets">;
+def meabi : JoinedOrSeparate<["-", "--"], "meabi">, HelpText<"Set EABI type">;
+def debugger_tune : JoinedOrSeparate<["-", "--"], "debugger-tune">, HelpText<"Tune debug info for a particular debugger">;
+def vector_library : JoinedOrSeparate<["-", "--"], "vector-library">, HelpText<"Vector functions library">;
+def align_loops : JoinedOrSeparate<["-", "--"], "align-loops">, HelpText<"Default alignment for loops">;
+def save_stats : FF<"save-stats", "Save LLVM statistics to a file">;
+def save_stats_EQ : Joined<["-", "--"], "save-stats=">, HelpText<"Save LLVM statistics to a file">;
+def filetype : JoinedOrSeparate<["-", "--"], "filetype">, HelpText<"Choose a file type">;
+defm pass_remarks_missed : Eq<"pass-remarks-missed", "Enable missed optimization remarks from passes matching regex">, MetaVarName<"<regex>">;
+defm pass_remarks_analysis : Eq<"pass-remarks-analysis", "Enable optimization remarks analysis from passes matching regex">, MetaVarName<"<regex>">;
+defm pass_remarks : Eq<"pass-remarks", "Enable optimization remarks from passes matching regex">, MetaVarName<"<regex>">;
+defm target_abi : Eq<"target-abi", "The name of the target ABI to use">, MetaVarName<"<name>">;
+
+defm dwarf_version : Eq<"dwarf-version", "Dwarf version to use">, MetaVarName<"<version>">;
+defm filter_print_funcs : Eq<"filter-print-funcs", "Only print IR for functions matching this">, MetaVarName<"<name>">;
+defm print_after : Eq<"print-after", "Only print IR after these passes">, MetaVarName<"<pass-name>">;
+defm print_before : Eq<"print-before", "Only print IR before these passes">, MetaVarName<"<pass-name>">;
+
+// Forwarding-only options for separated fallback support.
+def stop_before : JoinedOrSeparate<["-", "--"], "stop-before">, HelpText<"Stop before pass">;
+def stop_after : JoinedOrSeparate<["-", "--"], "stop-after">, HelpText<"Stop after pass">;
+def start_before : JoinedOrSeparate<["-", "--"], "start-before">, HelpText<"Start before pass">;
+def start_after : JoinedOrSeparate<["-", "--"], "start-after">, HelpText<"Start after pass">;
+def x86_asm_syntax : JoinedOrSeparate<["-", "--"], "x86-asm-syntax">, HelpText<"X86 assembly syntax mode">;
+def info_output_file : JoinedOrSeparate<["-", "--"], "info-output-file">, HelpText<"File to append -stats and -timer output to">;
+def gotol_abs_low_bound : JoinedOrSeparate<["-", "--"], "gotol-abs-low-bound">, HelpText<"BPF: Least number of PC-relative jump distance for GOTOL">;
+
+// Backend-specific and global options for forwarding.
+defm regalloc : Eq<"regalloc", "Register allocator to use">, MetaVarName<"<name>">;
+defm debug_only : Eq<"debug-only", "Enable a specific type of debug output">, MetaVarName<"<type>">;
+defm debug_pass : Eq<"debug-pass", "Print the name of each pass when it is executed">, MetaVarName<"<type>">;
+def systemz_subreg_liveness : FF<"systemz-subreg-liveness", "Enable SystemZ subregister liveness tracking">;
+def stress_sched : FF<"stress-sched", "Stress list scheduler">;
+def terminal_rule : FF<"terminal-rule", "Apply the terminal rule during coalescing">;
+def fast_isel : FF<"fast-isel", "Enable fast instruction selection">;
+defm fast_isel_abort : Eq<"fast-isel-abort", "Enable/disable target-specific 'abort on fast-isel failure' mode">, MetaVarName<"<n>">;
+defm global_isel_abort : Eq<"global-isel-abort", "Enable/disable target-specific 'abort on global-isel failure' mode">, MetaVarName<"<n>">;
+def fast_isel_report_on_fallback : FF<"fast-isel-report-on-fallback", "Report when fast-isel falls back to SelectionDAG">;
+
+// Boolean and value taking options that take no values causing fallthrough.
+def verify_machineinstrs : FF<"verify-machineinstrs", "Verify machine instructions after each pass">;
+def global_isel : FF<"global-isel", "Enable GlobalISel">;
+def debugify_and_strip_all_safe : FF<"debugify-and-strip-all-safe", "Enable debugify and strip all safe">;
+def debugify_and_strip_all_safe_EQ : Joined<["--", "-"], "debugify-and-strip-all-safe=">, HelpText<"Enable debugify and strip all safe">;
+def simplify_mir : FF<"simplify-mir", "Simplify MIR output">;
+def enable_arm_maskedldst : FF<"enable-arm-maskedldst", "Enable ARM masked load/store">;
+def enable_arm_maskedgatscat : FF<"enable-arm-maskedgatscat", "Enable ARM masked gather/scatter">;
+def force_dwarf_frame_section : FF<"force-dwarf-frame-section", "Force DWARF frame section">;
+defm tail_predication : Eq<"tail-predication", "Tail predication mode">;
+defm aarch64_cb_offset_bits : Eq<"aarch64-cb-offset-bits", "AArch64 CB offset bits">;
+defm aarch64_enable_atomic_cfg_tidy : Eq<"aarch64-enable-atomic-cfg-tidy", "AArch64 enable atomic CFG tidy">;
+defm aarch64_min_jump_table_entries : Eq<"aarch64-min-jump-table-entries", "AArch64 min jump table entries">;

--- a/llvm/tools/llc/llc.cpp
+++ b/llvm/tools/llc/llc.cpp
@@ -42,6 +42,7 @@
 #include "llvm/Pass.h"
 #include "llvm/Plugins/PassPlugin.h"
 #include "llvm/Remarks/HotnessThresholdParser.h"
+#include "llvm/Support/Allocator.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/FileSystem.h"
@@ -51,6 +52,7 @@
 #include "llvm/Support/Path.h"
 #include "llvm/Support/PluginLoader.h"
 #include "llvm/Support/SourceMgr.h"
+#include "llvm/Support/StringSaver.h"
 #include "llvm/Support/TargetSelect.h"
 #include "llvm/Support/TimeProfiler.h"
 #include "llvm/Support/ToolOutputFile.h"
@@ -62,7 +64,6 @@
 #include "llvm/TargetParser/Triple.h"
 #include "llvm/Transforms/Utils/Cloning.h"
 #include <cassert>
-#include <list>
 #include <memory>
 #include <optional>
 using namespace llvm;
@@ -275,10 +276,8 @@ static void RecordLlcOpts(opt::InputArgList &Args,
     exit(0);
   }
 
-  for (const auto *A : Args) {
-    if (A->getOption().getID() == OPT_INPUT)
-      InputFilename = A->getValue();
-  }
+  if (const opt::Arg *A = Args.getLastArg(OPT_INPUT))
+    InputFilename = A->getValue();
 
   InstPrinterOptions = Args.getAllArgValues(OPT_M);
   if (const opt::Arg *A = Args.getLastArg(OPT_x_EQ, OPT_x))
@@ -475,14 +474,13 @@ int main(int argc, char **argv) {
   // string pointers to the original argv from main, but there's no easy way to
   // do this. Here, we instead reconstruct the arguments as strings and convert
   // them to `const char*`.
-  std::vector<const char *> NewArgv;
+  SmallVector<const char *, 8> NewArgv;
   NewArgv.push_back(argv[0]);
 
   // This is used as storage for arguments that need to be rendered and
-  // eventually passed into NewArgv. A std::list is used because it guarantees
-  // that additions to RenderedArgs can be made without invalidating any
-  // pointers to existing elements. These pointers are what we store in NewArgv.
-  std::list<std::string> RenderedArgs;
+  // eventually passed into NewArgv.
+  BumpPtrAllocator Alloc;
+  StringSaver RenderedArgs(Alloc);
 
   // Forward all options that are NOT locally consumed and NOT unknown/input.
   for (const auto *A : Args) {
@@ -503,17 +501,19 @@ int main(int argc, char **argv) {
     // to cl::ParseCommandLineOptions.
     opt::ArgStringList TempList;
     A->render(Args, TempList);
+    std::string prev;
     for (auto *ArgStr : TempList) {
       StringRef S(ArgStr);
       if (S.starts_with("=")) {
         // If the argument starts with "=", it means it's a joined argument,
         // and we should append it to the last rendered argument.
-        RenderedArgs.back().append(S.str());
-        NewArgv.back() = RenderedArgs.back().c_str();
+        assert(!prev.empty());
+        prev.append(S.str());
+        NewArgv.back() = RenderedArgs.save(prev).data();
       } else if (!S.empty()) {
         // Otherwise, it's a new argument, and we should add it to the list.
-        RenderedArgs.push_back(S.str());
-        NewArgv.push_back(RenderedArgs.back().c_str());
+        prev = S.str();
+        NewArgv.push_back(RenderedArgs.save(prev).data());
       }
     }
   }

--- a/llvm/tools/llc/llc.cpp
+++ b/llvm/tools/llc/llc.cpp
@@ -62,6 +62,7 @@
 #include "llvm/TargetParser/Triple.h"
 #include "llvm/Transforms/Utils/Cloning.h"
 #include <cassert>
+#include <list>
 #include <memory>
 #include <optional>
 using namespace llvm;
@@ -70,206 +71,102 @@ static codegen::RegisterCodeGenFlags CGF;
 static codegen::RegisterMTuneFlag MTF;
 static codegen::RegisterSaveStatsFlag SSF;
 
+#include "Opts.inc"
+#include "llvm/Option/ArgList.h"
+#include "llvm/Option/OptTable.h"
+#include "llvm/Option/Option.h"
+
+using namespace llvm;
+using namespace llvm::opt;
+
+namespace {
+
+enum ID {
+  OPT_INVALID = 0, // This is not an option ID.
+#define OPTION(...) LLVM_MAKE_OPT_ID(__VA_ARGS__),
+#include "Opts.inc"
+#undef OPTION
+};
+
+#define OPTTABLE_STR_TABLE_CODE
+#include "Opts.inc"
+#undef OPTTABLE_STR_TABLE_CODE
+
+#define OPTTABLE_PREFIXES_TABLE_CODE
+#include "Opts.inc"
+#undef OPTTABLE_PREFIXES_TABLE_CODE
+
+enum OptionFlags {
+  LlcLocalOption = (1 << 0),
+};
+
+static constexpr OptTable::Info InfoTable[] = {
+#define OPTION(...) LLVM_CONSTRUCT_OPT_INFO(__VA_ARGS__),
+#include "Opts.inc"
+#undef OPTION
+};
+
+class LlcOptTable : public GenericOptTable {
+public:
+  LlcOptTable()
+      : GenericOptTable(OptionStrTable, OptionPrefixesTable, InfoTable) {}
+};
+
+} // end anonymous namespace
+
 // General options for llc.  Other pass-specific options are specified
 // within the corresponding llc passes, and target-specific options
 // and back-end code generation options are specified with the target machine.
 //
-static cl::opt<std::string>
-    InputFilename(cl::Positional, cl::desc("<input bitcode>"), cl::init("-"));
-
-static cl::list<std::string>
-    InstPrinterOptions("M", cl::desc("InstPrinter options"));
-
-static cl::opt<std::string>
-    InputLanguage("x", cl::desc("Input language ('ir' or 'mir')"));
-
-static cl::opt<std::string> OutputFilename("o", cl::desc("Output filename"),
-                                           cl::value_desc("filename"));
-
-static cl::opt<std::string>
-    SplitDwarfOutputFile("split-dwarf-output", cl::desc(".dwo output filename"),
-                         cl::value_desc("filename"));
-
-static cl::opt<unsigned>
-    TimeCompilations("time-compilations", cl::Hidden, cl::init(1u),
-                     cl::value_desc("N"),
-                     cl::desc("Repeat compilation N times for timing"));
-
-static cl::opt<bool> TimeTrace("time-trace", cl::desc("Record time trace"));
-
-static cl::opt<unsigned> TimeTraceGranularity(
-    "time-trace-granularity",
-    cl::desc(
-        "Minimum time granularity (in microseconds) traced by time profiler"),
-    cl::init(500), cl::Hidden);
-
-static cl::opt<std::string>
-    TimeTraceFile("time-trace-file",
-                  cl::desc("Specify time trace file destination"),
-                  cl::value_desc("filename"));
-
-static cl::opt<std::string>
-    BinutilsVersion("binutils-version", cl::Hidden,
-                    cl::desc("Produced object files can use all ELF features "
-                             "supported by this binutils version and newer."
-                             "If -no-integrated-as is specified, the generated "
-                             "assembly will consider GNU as support."
-                             "'none' means that all ELF features can be used, "
-                             "regardless of binutils support"));
-
-static cl::opt<bool>
-    PreserveComments("preserve-as-comments", cl::Hidden,
-                     cl::desc("Preserve Comments in outputted assembly"),
-                     cl::init(true));
-
-// Determine optimization level.
-static cl::opt<char>
-    OptLevel("O",
-             cl::desc("Optimization level. [-O0, -O1, -O2, or -O3] "
-                      "(default = '-O2')"),
-             cl::Prefix, cl::init('2'));
-
-static cl::opt<std::string>
-    TargetTriple("mtriple", cl::desc("Override target triple for module"));
-
-static cl::opt<std::string> SplitDwarfFile(
-    "split-dwarf-file",
-    cl::desc(
-        "Specify the name of the .dwo file to encode in the DWARF output"));
-
-static cl::opt<bool> NoVerify("disable-verify", cl::Hidden,
-                              cl::desc("Do not verify input module"));
-
-static cl::opt<bool> VerifyEach("verify-each",
-                                cl::desc("Verify after each transform"));
-
-static cl::opt<bool>
-    DisableSimplifyLibCalls("disable-simplify-libcalls",
-                            cl::desc("Disable simplify-libcalls"));
-
-static cl::opt<bool> ShowMCEncoding("show-mc-encoding", cl::Hidden,
-                                    cl::desc("Show encoding in .s output"));
-
-static cl::opt<unsigned>
-    OutputAsmVariant("output-asm-variant",
-                     cl::desc("Syntax variant to use for output printing"));
-
-static cl::opt<bool>
-    DwarfDirectory("dwarf-directory", cl::Hidden,
-                   cl::desc("Use .file directives with an explicit directory"),
-                   cl::init(true));
-
-static cl::opt<bool> AsmVerbose("asm-verbose",
-                                cl::desc("Add comments to directives."),
-                                cl::init(true));
-
-static cl::opt<bool>
-    CompileTwice("compile-twice", cl::Hidden,
-                 cl::desc("Run everything twice, re-using the same pass "
-                          "manager and verify the result is the same."),
-                 cl::init(false));
-
-static cl::opt<bool> DiscardValueNames(
-    "discard-value-names",
-    cl::desc("Discard names from Value (other than GlobalValue)."),
-    cl::init(false), cl::Hidden);
-
-static cl::opt<bool>
-    PrintMIR2VecVocab("print-mir2vec-vocab", cl::Hidden,
-                      cl::desc("Print MIR2Vec vocabulary contents"),
-                      cl::init(false));
-
-static cl::opt<bool>
-    PrintMIR2Vec("print-mir2vec", cl::Hidden,
-                 cl::desc("Print MIR2Vec embeddings for functions"),
-                 cl::init(false));
-
-static cl::list<std::string> IncludeDirs("I", cl::desc("include search path"));
-
-static cl::opt<bool> RemarksWithHotness(
-    "pass-remarks-with-hotness",
-    cl::desc("With PGO, include profile count in optimization remarks"),
-    cl::Hidden);
-
-static cl::opt<std::optional<uint64_t>, false, remarks::HotnessThresholdParser>
-    RemarksHotnessThreshold(
-        "pass-remarks-hotness-threshold",
-        cl::desc("Minimum profile count required for "
-                 "an optimization remark to be output. "
-                 "Use 'auto' to apply the threshold from profile summary."),
-        cl::value_desc("N or 'auto'"), cl::init(0), cl::Hidden);
-
-static cl::opt<std::string>
-    RemarksFilename("pass-remarks-output",
-                    cl::desc("Output filename for pass remarks"),
-                    cl::value_desc("filename"));
-
-static cl::opt<std::string>
-    RemarksPasses("pass-remarks-filter",
-                  cl::desc("Only record optimization remarks from passes whose "
-                           "names match the given regular expression"),
-                  cl::value_desc("regex"));
-
-static cl::opt<std::string> RemarksFormat(
-    "pass-remarks-format",
-    cl::desc("The format used for serializing remarks (default: YAML)"),
-    cl::value_desc("format"), cl::init("yaml"));
-
-static cl::list<std::string> PassPlugins("load-pass-plugin",
-                                         cl::desc("Load plugin library"));
-
-static cl::opt<bool> EnableNewPassManager(
-    "enable-new-pm", cl::desc("Enable the new pass manager"), cl::init(false));
-
-// This flag specifies a textual description of the optimization pass pipeline
-// to run over the module. This flag switches opt to use the new pass manager
-// infrastructure, completely disabling all of the flags specific to the old
-// pass management.
-static cl::opt<std::string> PassPipeline(
-    "passes",
-    cl::desc(
-        "A textual description of the pass pipeline. To have analysis passes "
-        "available before a certain pass, add 'require<foo-analysis>'."));
-static cl::alias PassPipeline2("p", cl::aliasopt(PassPipeline),
-                               cl::desc("Alias for -passes"));
+// TODO: These are static because the prior implementation using cl::opt
+// defined these as static globals. It's probably neater to instead have these
+// in some Config struct that gets passed around, but that can be done after
+// the migration to using OptTable.
+static std::string InputFilename = "-";
+static std::vector<std::string> InstPrinterOptions;
+static std::string InputLanguage = "";
+static std::string OutputFilename = "";
+static std::string SplitDwarfOutputFile = "";
+static unsigned TimeCompilations = 1u;
+static bool TimeTrace = false;
+static unsigned TimeTraceGranularity = 500;
+static std::string TimeTraceFile = "";
+static std::string BinutilsVersion = "";
+static bool PreserveComments = true;
+static char OptLevel = '2';
+static std::string TargetTriple = "";
+static std::string SplitDwarfFile = "";
+static bool NoVerify = false;
+static bool VerifyEach = false;
+static bool DisableSimplifyLibCalls = false;
+static bool ShowMCEncoding = false;
+static std::optional<unsigned> OutputAsmVariant;
+static std::optional<bool> DwarfDirectory;
+static bool AsmVerbose = true;
+static bool CompileTwice = false;
+static bool DiscardValueNames = false;
+static bool PrintMIR2VecVocab = false;
+static bool PrintMIR2Vec = false;
+static std::vector<std::string> IncludeDirs;
+static bool RemarksWithHotness = false;
+static uint64_t RemarksHotnessThreshold = 0;
+static std::string RemarksFilename = "";
+static std::string RemarksPasses = "";
+static std::string RemarksFormat = "yaml";
+static bool EnableNewPassManager = false;
+static std::string PassPipeline = "";
 
 static std::vector<std::string> &getRunPassNames() {
   static std::vector<std::string> RunPassNames;
   return RunPassNames;
 }
 
-namespace {
-struct RunPassOption {
-  void operator=(const std::string &Val) const {
-    if (Val.empty())
-      return;
-    SmallVector<StringRef, 8> PassNames;
-    StringRef(Val).split(PassNames, ',', -1, false);
-    for (auto PassName : PassNames)
-      getRunPassNames().push_back(std::string(PassName));
-  }
-};
-} // namespace
-
-static RunPassOption RunPassOpt;
-
-static cl::opt<RunPassOption, true, cl::parser<std::string>> RunPass(
-    "run-pass",
-    cl::desc("Run compiler only for specified passes (comma separated list)"),
-    cl::value_desc("pass-name"), cl::location(RunPassOpt));
-
 // PGO command line options
 enum PGOKind {
   NoPGO,
   SampleUse,
 };
-
-static cl::opt<PGOKind>
-    PGOKindFlag("pgo-kind", cl::init(NoPGO), cl::Hidden,
-                cl::desc("The kind of profile guided optimization"),
-                cl::values(clEnumValN(NoPGO, "nopgo", "Do not use PGO."),
-                           clEnumValN(SampleUse, "pgo-sample-use-pipeline",
-                                      "Use sampled profile to guide PGO.")));
+static PGOKind PGOKindFlag = NoPGO;
 
 // Function to set PGO options on TargetMachine based on command line flags.
 static void setPGOOptions(TargetMachine &TM) {
@@ -366,6 +263,158 @@ static std::unique_ptr<ToolOutputFile> GetOutputStream(Triple::OSType OS) {
   return FDOut;
 }
 
+static void RecordLlcOpts(opt::InputArgList &Args,
+                          SmallVector<PassPlugin, 1> &PluginList) {
+  if (Args.hasArg(OPT_version)) {
+    // Register the Target and CPU printer for --version.
+    cl::AddExtraVersionPrinter(sys::printDefaultTargetAndDetectedCPU);
+    // Register the target printer for --version.
+    cl::AddExtraVersionPrinter(
+        TargetRegistry::printRegisteredTargetsForVersion);
+    cl::PrintVersionMessage();
+    exit(0);
+  }
+
+  for (const auto *A : Args) {
+    if (A->getOption().getID() == OPT_INPUT)
+      InputFilename = A->getValue();
+  }
+
+  InstPrinterOptions = Args.getAllArgValues(OPT_M);
+  if (const opt::Arg *A = Args.getLastArg(OPT_x_EQ, OPT_x))
+    InputLanguage = A->getValue();
+  if (const opt::Arg *A = Args.getLastArg(OPT_o_EQ, OPT_o))
+    OutputFilename = A->getValue();
+  if (const opt::Arg *A =
+          Args.getLastArg(OPT_split_dwarf_output_EQ, OPT_split_dwarf_output))
+    SplitDwarfOutputFile = A->getValue();
+
+  if (const opt::Arg *A =
+          Args.getLastArg(OPT_time_compilations_EQ, OPT_time_compilations))
+    StringRef(A->getValue()).getAsInteger(10, TimeCompilations);
+  TimeTrace = Args.hasArg(OPT_time_trace);
+  if (const opt::Arg *A = Args.getLastArg(OPT_time_trace_granularity_EQ,
+                                          OPT_time_trace_granularity))
+    StringRef(A->getValue()).getAsInteger(10, TimeTraceGranularity);
+  if (const opt::Arg *A =
+          Args.getLastArg(OPT_time_trace_file_EQ, OPT_time_trace_file))
+    TimeTraceFile = A->getValue();
+
+  if (const opt::Arg *A =
+          Args.getLastArg(OPT_binutils_version_EQ, OPT_binutils_version))
+    BinutilsVersion = A->getValue();
+
+  if (const opt::Arg *A = Args.getLastArg(OPT_O_flag)) {
+    StringRef Val = A->getValue();
+    if (Val.starts_with("="))
+      Val = Val.drop_front();
+    if (!Val.empty())
+      OptLevel = Val[0];
+  }
+
+  if (const opt::Arg *A = Args.getLastArg(OPT_mtriple_EQ, OPT_mtriple))
+    TargetTriple = A->getValue();
+  if (const opt::Arg *A =
+          Args.getLastArg(OPT_split_dwarf_file_EQ, OPT_split_dwarf_file))
+    SplitDwarfFile = A->getValue();
+
+  NoVerify = Args.hasArg(OPT_disable_verify);
+  VerifyEach = Args.hasArg(OPT_verify_each);
+  DisableSimplifyLibCalls = Args.hasArg(OPT_disable_simplify_libcalls);
+  ShowMCEncoding = Args.hasArg(OPT_show_mc_encoding);
+
+  if (const opt::Arg *A =
+          Args.getLastArg(OPT_output_asm_variant_EQ, OPT_output_asm_variant)) {
+    unsigned variant;
+    StringRef(A->getValue()).getAsInteger(10, variant);
+    OutputAsmVariant = variant;
+  }
+
+  auto GetLastBooleanArg = [&Args](unsigned OptID,
+                                   unsigned OptIDEQ) -> std::optional<bool> {
+    if (const opt::Arg *A = Args.getLastArg(OptIDEQ)) {
+      return StringRef(A->getValue()) == "1" ||
+             StringRef(A->getValue()) == "true";
+    } else if (Args.hasArg(OptID))
+      return true;
+    return {};
+  };
+
+  if (auto Val = GetLastBooleanArg(OPT_dwarf_directory, OPT_dwarf_directory_EQ))
+    DwarfDirectory = *Val;
+
+  if (auto Val = GetLastBooleanArg(OPT_asm_verbose, OPT_asm_verbose_EQ))
+    AsmVerbose = *Val;
+
+  if (const Arg *A = Args.getLastArg(OPT_preserve_as_comments))
+    PreserveComments = A->getValue();
+
+  CompileTwice = Args.hasArg(OPT_compile_twice);
+  DiscardValueNames = Args.hasArg(OPT_discard_value_names);
+  PrintMIR2VecVocab = Args.hasArg(OPT_print_mir2vec_vocab);
+  PrintMIR2Vec = Args.hasArg(OPT_print_mir2vec);
+
+  IncludeDirs = Args.getAllArgValues(OPT_I);
+  for (std::string &Dir : IncludeDirs) {
+    // Some of the values may include a '=' prefix, remove it.
+    if (Dir.front() == '=')
+      Dir = Dir.substr(1);
+  }
+
+  if (auto Val = GetLastBooleanArg(OPT_pass_remarks_with_hotness,
+                                   OPT_pass_remarks_with_hotness_EQ))
+    RemarksWithHotness = *Val;
+
+  if (const opt::Arg *A = Args.getLastArg(OPT_pass_remarks_hotness_threshold_EQ,
+                                          OPT_pass_remarks_hotness_threshold)) {
+    if (StringRef(A->getValue()) != "auto") {
+      uint64_t Val;
+      StringRef(A->getValue()).getAsInteger(10, Val);
+      RemarksHotnessThreshold = Val;
+    }
+  }
+  if (const opt::Arg *A =
+          Args.getLastArg(OPT_pass_remarks_output_EQ, OPT_pass_remarks_output))
+    RemarksFilename = A->getValue();
+  if (const opt::Arg *A =
+          Args.getLastArg(OPT_pass_remarks_filter_EQ, OPT_pass_remarks_filter))
+    RemarksPasses = A->getValue();
+  if (const opt::Arg *A =
+          Args.getLastArg(OPT_pass_remarks_format_EQ, OPT_pass_remarks_format))
+    RemarksFormat = A->getValue();
+
+  for (const std::string &PluginPath :
+       Args.getAllArgValues(OPT_load_pass_plugin_EQ)) {
+    auto Plugin = PassPlugin::Load(PluginPath);
+    if (!Plugin)
+      reportFatalUsageError(Plugin.takeError());
+    PluginList.emplace_back(Plugin.get());
+  }
+
+  if (auto Val = GetLastBooleanArg(OPT_enable_new_pm, OPT_enable_new_pm_EQ))
+    EnableNewPassManager = *Val;
+
+  if (const opt::Arg *A = Args.getLastArg(OPT_passes_EQ, OPT_passes))
+    PassPipeline = A->getValue();
+
+  for (const auto *A : Args) {
+    if (A->getOption().matches(OPT_run_pass) ||
+        A->getOption().matches(OPT_run_pass_EQ)) {
+      SmallVector<StringRef, 8> PassNames;
+      StringRef(A->getValue()).split(PassNames, ',', -1, false);
+      for (auto PassName : PassNames)
+        getRunPassNames().push_back(std::string(PassName));
+    }
+  }
+
+  if (const opt::Arg *A = Args.getLastArg(OPT_pgo_kind_EQ, OPT_pgo_kind)) {
+    if (StringRef(A->getValue()) == "pgo-sample-use-pipeline")
+      PGOKindFlag = SampleUse;
+    else
+      PGOKindFlag = NoPGO;
+  }
+}
+
 // main - Entry point for the llc compiler.
 //
 int main(int argc, char **argv) {
@@ -399,19 +448,79 @@ int main(int argc, char **argv) {
   initializeScavengerTestPass(*Registry);
 
   SmallVector<PassPlugin, 1> PluginList;
-  PassPlugins.setCallback([&](const std::string &PluginPath) {
-    auto Plugin = PassPlugin::Load(PluginPath);
-    if (!Plugin)
-      reportFatalUsageError(Plugin.takeError());
-    PluginList.emplace_back(Plugin.get());
-  });
 
-  // Register the Target and CPU printer for --version.
-  cl::AddExtraVersionPrinter(sys::printDefaultTargetAndDetectedCPU);
-  // Register the target printer for --version.
-  cl::AddExtraVersionPrinter(TargetRegistry::printRegisteredTargetsForVersion);
+  LlcOptTable Tbl;
+  unsigned MissingArgIndex, MissingArgCount;
+  ArrayRef<const char *> ArgsArr = ArrayRef(argv + 1, argc - 1);
+  opt::InputArgList Args =
+      Tbl.ParseArgs(ArgsArr, MissingArgIndex, MissingArgCount);
 
-  cl::ParseCommandLineOptions(argc, argv, "llvm system compiler\n");
+  if (MissingArgCount) {
+    reportError("missing argument to option: " +
+                Twine(Args.getArgString(MissingArgIndex)));
+  }
+
+  if (Args.hasArg(OPT_help)) {
+    Tbl.printHelp(outs(), "llc [options] <input bitcode>",
+                  "llvm system compiler");
+    return 0;
+  }
+
+  RecordLlcOpts(Args, PluginList);
+
+  // Arguments not consumed by llc directly must be passed
+  // to the backend via cl::ParseCommandLineOptions. Unfortunately, this
+  // function only accepts a raw argc + argv. Ideally, we'd just construct a
+  // `const char*` vector that we could pass to this function consisting of
+  // string pointers to the original argv from main, but there's no easy way to
+  // do this. Here, we instead reconstruct the arguments as strings and convert
+  // them to `const char*`.
+  std::vector<const char *> NewArgv;
+  NewArgv.push_back(argv[0]);
+
+  // This is used as storage for arguments that need to be rendered and
+  // eventually passed into NewArgv. A std::list is used because it guarantees
+  // that additions to RenderedArgs can be made without invalidating any
+  // pointers to existing elements. These pointers are what we store in NewArgv.
+  std::list<std::string> RenderedArgs;
+
+  // Forward all options that are NOT locally consumed and NOT unknown/input.
+  for (const auto *A : Args) {
+    unsigned ID = A->getOption().getID();
+    if (ID == OPT_INPUT)
+      continue;
+
+    if (ID == OPT_UNKNOWN) {
+      NewArgv.push_back(A->getSpelling().data());
+      continue;
+    }
+
+    if (A->getOption().hasFlag(LlcLocalOption))
+      continue;
+
+    // Here we render the argument into a list of strings. Rendered arguments
+    // expand the original argument into a list of strings that can be passed
+    // to cl::ParseCommandLineOptions.
+    opt::ArgStringList TempList;
+    A->render(Args, TempList);
+    for (auto *ArgStr : TempList) {
+      StringRef S(ArgStr);
+      if (S.starts_with("=")) {
+        // If the argument starts with "=", it means it's a joined argument,
+        // and we should append it to the last rendered argument.
+        RenderedArgs.back().append(S.str());
+        NewArgv.back() = RenderedArgs.back().c_str();
+      } else if (!S.empty()) {
+        // Otherwise, it's a new argument, and we should add it to the list.
+        RenderedArgs.push_back(S.str());
+        NewArgv.push_back(RenderedArgs.back().c_str());
+      }
+    }
+  }
+
+  // Now pass the filtered arguments to the backend.
+  cl::ParseCommandLineOptions(NewArgv.size(), NewArgv.data(),
+                              "llvm system compiler\n");
 
   if (!PassPipeline.empty() && !getRunPassNames().empty()) {
     errs() << "The `llc -run-pass=...` syntax for the new pass manager is "
@@ -523,7 +632,7 @@ static int compileModule(char **argv, SmallVectorImpl<PassPlugin> &PluginList,
   // Parse 'none' or '$major.$minor'. Disallow -binutils-version=0 because we
   // use that to indicate the MC default.
   if (!BinutilsVersion.empty() && BinutilsVersion != "none") {
-    StringRef V = BinutilsVersion.getValue();
+    StringRef V = BinutilsVersion;
     unsigned Num;
     if (V.consumeInteger(10, Num) || Num == 0 ||
         !(V.empty() ||
@@ -566,15 +675,16 @@ static int compileModule(char **argv, SmallVectorImpl<PassPlugin> &PluginList,
     Options.MCOptions.ShowMCEncoding = ShowMCEncoding;
     Options.MCOptions.AsmVerbose = AsmVerbose;
     Options.MCOptions.PreserveAsmComments = PreserveComments;
-    if (OutputAsmVariant.getNumOccurrences())
-      Options.MCOptions.OutputAsmVariant = OutputAsmVariant;
+    if (OutputAsmVariant.has_value())
+      Options.MCOptions.OutputAsmVariant = *OutputAsmVariant;
     Options.MCOptions.IASSearchPaths = IncludeDirs;
+
     Options.MCOptions.InstPrinterOptions = InstPrinterOptions;
     Options.MCOptions.SplitDwarfFile = SplitDwarfFile;
-    if (DwarfDirectory.getPosition()) {
+    if (DwarfDirectory.has_value()) {
       Options.MCOptions.MCUseDwarfDirectory =
-          DwarfDirectory ? MCTargetOptions::EnableDwarfDirectory
-                         : MCTargetOptions::DisableDwarfDirectory;
+          *DwarfDirectory ? MCTargetOptions::EnableDwarfDirectory
+                          : MCTargetOptions::DisableDwarfDirectory;
     } else {
       // -dwarf-directory is not set explicitly. Some assemblers
       // (e.g. GNU as or ptxas) do not support `.file directory'


### PR DESCRIPTION
We would like to include llc as part of the greater multicall binary, but merging in tools that use cl::opt also merges in globals and static initializers specific to that tool, some of which might have duplicate flag names. OptTable mitigates this by allowing these arguments to be parsed into local variables and avoiding excess globals and potential flag-naming collisions.

Note this PR still technically retains globals for the actual flag values after parsing, but that can be refactored in a followup PR that changes the global states used here to passing some `Config` struct for arguments like what other llvm tools do. This PR focuses solely on the OptTable migration.

Also note that flags unique to CodeGen are still parsed using the normal `cl::ParseCommandLineOptions`. Until those flags get migrated (which affects all other llvm tools), the flags unique to llc need to be explicitly filtered before passing an adjusted argv to `cl::ParseCommandLineOptions` for the backend.

The bulk of this PR was generated by gemini but thoroughly reviewed and edited by me to the best of my ability.