### PR TITLE
[Workflows] Add Zizmor check

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,29 @@
+name: Zizmor GitHub Actions Analysis
+
+on:
+  push:
+    branches: ["main"]
+    paths: [".github/**"]
+  pull_request:
+    paths: [".github/**"]
+
+permissions:
+  contents: read
+
+jobs:
+  zizmor:
+    if: github.repository_owner == 'llvm'
+    name: Run zizmor
+    runs-on: ubuntu-24.04
+    permissions:
+      security-events: write # Required for upload-sarif (used by zizmor-action) to upload SARIF files.
+      contents: read
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@71321a20a9ded102f6e9ce5718a2fcec2c4f70d8 # v0.5.2


### PR DESCRIPTION
The recent Trivy breach[^1] made me consider re-opening #117787.

Trivy was breached using an impostor commit[^2], which Zizmor can flag.

It's also much more widely used since my last PR.[^3]

The new workflow was taken from the example workflow in their
documentation.[^4]

[^1]: https://github.com/aquasecurity/trivy/discussions/10425
[^2]: https://docs.zizmor.sh/audits/#impostor-commit
[^3]: https://docs.zizmor.sh/trophy-case/
[^4]: https://docs.zizmor.sh/integrations/#via-zizmorcorezizmor-action
