### PR TITLE
[ScalarEvolution] Analyze PHI nodes more aggressively in getRangeRef.

### DIFF
--- a/llvm/lib/Analysis/ScalarEvolution.cpp
+++ b/llvm/lib/Analysis/ScalarEvolution.cpp
@@ -6668,6 +6668,138 @@ getRangeForUnknownRecurrence(const SCEVUnknown *U) {
   return FullSet;
 }
 
+static bool RangeRefPHIAllowedRecurrence(LoopInfo &LI, DominatorTree &DT,
+                                         AssumptionCache &AC, PHINode *PHI) {
+  // Check for a loop PHI where the incoming value from the backedge is
+  // a recurrence in the same loop which doesn't depend on this PHI node.
+  //
+  // Restrict to two incoming values for now for simplicity.  More incoming
+  // values would require a more complex analysis of which values come from
+  // outside the loop, and which come from different backedges inside the loop.
+  if (PHI->getNumIncomingValues() != 2)
+    return false;
+
+  // The PHI must be in a loop header.
+  const Loop *L = LI.getLoopFor(PHI->getParent());
+  if (!L || L->getHeader() != PHI->getParent())
+    return false;
+
+  // Get the loop-variant operand.  (The loop-invariant operand is irrelevant:
+  // it must dominate the PHI, so it's safe according to getRangeRef rules.)
+  Value *BackedgeVal;
+  BasicBlock *Backedge;
+  if (!DT.properlyDominates(PHI->getIncomingBlock(0), PHI->getParent())) {
+    Backedge = PHI->getIncomingBlock(0);
+    BackedgeVal = PHI->getIncomingValue(0);
+  } else {
+    Backedge = PHI->getIncomingBlock(1);
+    BackedgeVal = PHI->getIncomingValue(1);
+  }
+
+  auto IsSimpleRecurrencePHI = [&](PHINode *SubPHI) {
+    if (SubPHI == PHI)
+      return false;
+    Value *Recurrence = SubPHI->getIncomingValueForBlock(Backedge);
+
+    // Look for a single binary operation, where one operand is the sub-PHI,
+    // and the other is loop-invariant.
+    //
+    // We could generalize this to allow more general recurrences, as long as
+    // they don't depend on the original PHI.
+    auto BO = MatchBinaryOp(Recurrence, PHI->getDataLayout(), AC, DT,
+                            dyn_cast<Instruction>(Recurrence));
+    if (!BO)
+      return false;
+    return (BO->LHS == SubPHI && L->isLoopInvariant(BO->RHS)) ||
+           (BO->RHS == SubPHI && L->isLoopInvariant(BO->LHS));
+  };
+
+  assert(isa<Instruction>(BackedgeVal) &&
+         "Non-instructions should be handled by dominance check");
+  int WorkLimit = 20;
+  SmallVector<Instruction *> Worklist;
+  SmallPtrSet<Instruction *, 20> Visited;
+  Worklist.push_back(cast<Instruction>(BackedgeVal));
+  Visited.insert(cast<Instruction>(BackedgeVal));
+  do {
+    Instruction *I = Worklist.pop_back_val();
+    if (auto *SubPHI = dyn_cast<PHINode>(I)) {
+      // PHI nodes outside the loop header are complicated to analyze.
+      // (For example, if they match createNodeFromSelectLikePHI, we need
+      // to analyze the condition.)  Don't try for now.
+      if (SubPHI->getParent() != PHI->getParent())
+        return false;
+
+      // Check that the PHI node in the loop header is a simple recurrence.
+      //
+      // (We could potentially loosen this to recursively allow a PHI
+      // which is itself RangeRefPHIAllowedRecurrence.)
+      if (!IsSimpleRecurrencePHI(SubPHI))
+        return false;
+    } else if (DT.dominates(PHI, I)) {
+      // We have a value inside the loop; add its operands to the worklist.
+      for (Value *Operand : I->operands()) {
+        if (auto *OperandI = dyn_cast<Instruction>(Operand)) {
+          if (Visited.insert(OperandI).second)
+            Worklist.push_back(OperandI);
+        }
+      }
+    } else {
+      // Otherwise we have an instruction that dominates the loop or is
+      // unreachable; ignore it.
+      assert(DT.dominates(I->getParent(), PHI->getParent()) ||
+             !DT.isReachableFromEntry(I->getParent()));
+    }
+    if (!--WorkLimit)
+      return false;
+  } while (!Worklist.empty());
+  return true;
+}
+
+// Analyze a PHI node, and see if it's a "select recurrence", where all
+// possible input values come from outside the loop, and one is chosen
+// based on PHIs inside the loop.
+static std::optional<SmallVector<Value *>>
+getSelectRecurrencePHI(LoopInfo &LI, DominatorTree &DT, AssumptionCache &AC,
+                       PHINode *PHI) {
+  if (PHI->getNumIncomingValues() != 2)
+    return std::nullopt;
+
+  // The PHI must be in a loop header.
+  const Loop *L = LI.getLoopFor(PHI->getParent());
+  if (!L || L->getHeader() != PHI->getParent())
+    return std::nullopt;
+
+  SmallVector<Value *> Result;
+  // Get the loop-variant operand.  (The loop-invariant operand is irrelevant:
+  // it must dominate the PHI, so it's safe according to getRangeRef rules.)
+  Value *BackedgeVal;
+  if (!DT.properlyDominates(PHI->getIncomingBlock(0), PHI->getParent())) {
+    BackedgeVal = PHI->getIncomingValue(0);
+    Result.push_back(PHI->getIncomingValue(1));
+  } else {
+    BackedgeVal = PHI->getIncomingValue(1);
+    Result.push_back(PHI->getIncomingValue(0));
+  }
+
+  // Check for a PHI that is in the loop, but not in the loop header.
+  PHINode *BackedgePHI = dyn_cast<PHINode>(BackedgeVal);
+  if (!BackedgePHI || BackedgePHI->getParent() == PHI->getParent() ||
+      DT.dominates(BackedgePHI, PHI))
+    return std::nullopt;
+
+  // Check that all the operands of the PHI are either the recurrence itself,
+  // or values from outside the loop.
+  for (Value *Operand : BackedgePHI->operands()) {
+    if (DT.dominates(Operand, PHI))
+      Result.push_back(Operand);
+    else if (Operand != PHI)
+      return std::nullopt;
+  }
+
+  return Result;
+}
+
 // The goal of this function is to check if recursively visiting the operands
 // of this PHI might lead to an infinite loop. If we do see such a loop,
 // there's no good way to break it, so we avoid analyzing such cases.
@@ -6680,16 +6812,27 @@ getRangeForUnknownRecurrence(const SCEVUnknown *U) {
 // FIXME: The way this is implemented is overly conservative; this checks
 // for a few obviously safe patterns, but anything that doesn't lead to
 // recursion is fine.
-static bool RangeRefPHIAllowedOperands(DominatorTree &DT, PHINode *PHI) {
+static std::optional<SmallVector<Value *>>
+RangeRefPHIOperandsToAnalyze(LoopInfo &LI, DominatorTree &DT,
+                             AssumptionCache &AC, PHINode *PHI) {
   Value *Cond = nullptr, *LHS = nullptr, *RHS = nullptr;
-  if (getOperandsForSelectLikePHI(DT, PHI, Cond, LHS, RHS))
-    return true;
+  if (getOperandsForSelectLikePHI(DT, PHI, Cond, LHS, RHS)) {
+    // We don't care about the condition to compute the range; just return
+    // the possible values.
+    return SmallVector<Value *>{LHS, RHS};
+  }
 
   if (all_of(PHI->operands(),
              [&](Value *Operand) { return DT.dominates(Operand, PHI); }))
-    return true;
+    return SmallVector<Value *>{PHI->operands()};
 
-  return false;
+  if (RangeRefPHIAllowedRecurrence(LI, DT, AC, PHI))
+    return SmallVector<Value *>{PHI->operands()};
+
+  if (auto Operands = getSelectRecurrencePHI(LI, DT, AC, PHI))
+    return Operands;
+
+  return std::nullopt;
 }
 
 const ConstantRange &
@@ -6749,9 +6892,11 @@ ScalarEvolution::getRangeRefIter(const SCEV *S,
     }
     // `SCEVUnknown`'s require special treatment.
     if (PHINode *P = dyn_cast<PHINode>(UnknownS->getValue())) {
-      if (!RangeRefPHIAllowedOperands(DT, P))
+      std::optional<SmallVector<Value *>> Operands =
+          RangeRefPHIOperandsToAnalyze(LI, DT, AC, P);
+      if (!Operands)
         continue;
-      for (auto &Op : reverse(P->operands()))
+      for (auto &Op : reverse(*Operands))
         AddToWorklist(getSCEV(Op));
     }
   }
@@ -7086,11 +7231,12 @@ const ConstantRange &ScalarEvolution::getRangeRef(
       if (auto *AR = dyn_cast<SCEVAddRecExpr>(getSCEV(V)))
         return getRangeRef(AR, SignHint, Depth + 1);
 
-      // Make sure that we do not run over cycled Phis.
-      if (RangeRefPHIAllowedOperands(DT, Phi)) {
+      if (auto Operands = RangeRefPHIOperandsToAnalyze(LI, DT, AC, Phi)) {
+        // The PHI node matches a pattern where we know we won't cause
+        // a cycle; analyze the extracted operands.
         ConstantRange RangeFromOps(BitWidth, /*isFullSet=*/false);
 
-        for (const auto &Op : Phi->operands()) {
+        for (const auto &Op : *Operands) {
           auto OpRange = getRangeRef(getSCEV(Op), SignHint, Depth + 1);
           RangeFromOps = RangeFromOps.unionWith(OpRange);
           // No point to continue if we already have a full set.
@@ -7821,9 +7967,9 @@ ScalarEvolution::getOperandsToCreate(Value *V, SmallVectorImpl<Value *> &Ops) {
     //
     // In addition to getNodeForPHI, also construct nodes which might be needed
     // by getRangeRef.
-    if (RangeRefPHIAllowedOperands(DT, cast<PHINode>(U))) {
-      for (Value *V : cast<PHINode>(U)->operands())
-        Ops.push_back(V);
+    if (auto PHIOperands =
+            RangeRefPHIOperandsToAnalyze(LI, DT, AC, cast<PHINode>(U))) {
+      Ops.append(*PHIOperands);
       return nullptr;
     }
     return nullptr;

--- a/llvm/test/Analysis/ScalarEvolution/pr123550.ll
+++ b/llvm/test/Analysis/ScalarEvolution/pr123550.ll
@@ -6,7 +6,7 @@ define i32 @test() {
 ; CHECK-LABEL: 'test'
 ; CHECK-NEXT:  Classifying expressions for: @test
 ; CHECK-NEXT:    %phi = phi i32 [ -173, %bb ], [ %sub, %loop ]
-; CHECK-NEXT:    --> %phi U: [-256,256) S: [-256,256) Exits: -173 LoopDispositions: { %loop: Variant }
+; CHECK-NEXT:    --> %phi U: [-173,1) S: [-173,1) Exits: -173 LoopDispositions: { %loop: Variant }
 ; CHECK-NEXT:    %iv2 = phi i32 [ 1, %bb ], [ %iv2.inc, %loop ]
 ; CHECK-NEXT:    --> {1,+,1}<nuw><nsw><%loop> U: [1,2) S: [1,2) Exits: 1 LoopDispositions: { %loop: Computable }
 ; CHECK-NEXT:    %srem = srem i32 729259140, %phi

--- a/llvm/test/Analysis/ScalarEvolution/ranges.ll
+++ b/llvm/test/Analysis/ScalarEvolution/ranges.ll
@@ -509,4 +509,111 @@ leave:
   ret void
 }
 
+define void @select_recurrence(i16 %n) {
+; %t is not a multiple of 7 because we cannot make the assumption through truncation
+; CHECK-LABEL: 'select_recurrence'
+; CHECK-NEXT:  Classifying expressions for: @select_recurrence
+; CHECK-NEXT:    %max = phi i16 [ %n, %entry ], [ 1, %if ]
+; CHECK-NEXT:    --> (1 smax %n) U: [1,-32768) S: [1,-32768)
+; CHECK-NEXT:    %rec = phi i16 [ %max, %preheader ], [ %new, %latch ]
+; CHECK-NEXT:    --> %rec U: [1,-32768) S: [1,-32768) Exits: <<Unknown>> LoopDispositions: { %loop: Variant }
+; CHECK-NEXT:    %new = phi i16 [ %rec, %loop ], [ 5, %if2 ]
+; CHECK-NEXT:    --> %new U: [1,-32768) S: [1,-32768) Exits: <<Unknown>> LoopDispositions: { %loop: Variant }
+; CHECK-NEXT:  Determining loop execution counts for: @select_recurrence
+; CHECK-NEXT:  Loop %loop: <multiple exits> Unpredictable backedge-taken count.
+; CHECK-NEXT:  Loop %loop: Unpredictable constant max backedge-taken count.
+; CHECK-NEXT:  Loop %loop: Unpredictable symbolic max backedge-taken count.
+;
+entry:
+  %c1 = icmp slt i16 %n, 1
+  br i1 %c1, label %if, label %preheader
 
+if:
+  br label %preheader
+
+preheader:
+  %max = phi i16 [%n, %entry], [1, %if]
+  br label %loop
+
+loop:
+  %rec = phi i16 [ %max, %preheader ], [ %new, %latch]
+  %c = icmp eq i16 %rec, 22
+  br i1 %c, label %if2, label %latch
+
+if2:
+  br label %latch
+
+latch:
+  %new = phi i16 [ %rec, %loop], [5, %if2]
+  br label %loop
+}
+
+; Based on llvm-test-suite/SingleSource/Regression/C/gcc-c-torture/execute/pr68249.c
+define void @select_recurrence_2(i16 %n) {
+; %t is not a multiple of 7 because we cannot make the assumption through truncation
+; CHECK-LABEL: 'select_recurrence_2'
+; CHECK-NEXT:  Classifying expressions for: @select_recurrence_2
+; CHECK-NEXT:    %max = phi i16 [ %n, %entry ], [ 1, %if ]
+; CHECK-NEXT:    --> (1 smax %n) U: [1,-32768) S: [1,-32768)
+; CHECK-NEXT:    %rec = phi i16 [ %max, %preheader ], [ %new, %latch ]
+; CHECK-NEXT:    --> %rec U: [1,-32768) S: [1,-32768) Exits: <<Unknown>> LoopDispositions: { %loop: Variant }
+; CHECK-NEXT:    %new = phi i16 [ %rec, %loop ], [ 1, %if2 ]
+; CHECK-NEXT:    --> %rec U: [1,-32768) S: [1,-32768) Exits: <<Unknown>> LoopDispositions: { %loop: Variant }
+; CHECK-NEXT:  Determining loop execution counts for: @select_recurrence_2
+; CHECK-NEXT:  Loop %loop: <multiple exits> Unpredictable backedge-taken count.
+; CHECK-NEXT:  Loop %loop: Unpredictable constant max backedge-taken count.
+; CHECK-NEXT:  Loop %loop: Unpredictable symbolic max backedge-taken count.
+;
+entry:
+  %c1 = icmp slt i16 %n, 1
+  br i1 %c1, label %if, label %preheader
+
+if:
+  br label %preheader
+
+preheader:
+  %max = phi i16 [%n, %entry], [1, %if]
+  br label %loop
+
+loop:
+  %rec = phi i16 [ %max, %preheader ], [ %new, %latch]
+  %c = icmp slt i16 %rec, 1
+  br i1 %c, label %if2, label %latch
+
+if2:
+  br label %latch
+
+latch:
+  %new = phi i16 [ %rec, %loop], [1, %if2]
+  br label %loop
+}
+
+; Based on TSVC s291
+define void @loop_phi_based_on_addrec() {
+; CHECK-LABEL: 'loop_phi_based_on_addrec'
+; CHECK-NEXT:  Classifying expressions for: @loop_phi_based_on_addrec
+; CHECK-NEXT:    %addrec = phi i64 [ 0, %entry ], [ %inc, %loop ]
+; CHECK-NEXT:    --> {0,+,1}<nuw><nsw><%loop> U: [0,32000) S: [0,32000) Exits: 31999 LoopDispositions: { %loop: Computable }
+; CHECK-NEXT:    %derived = phi i64 [ 31999, %entry ], [ %addrec, %loop ]
+; CHECK-NEXT:    --> %derived U: [0,32000) S: [0,32000) Exits: <<Unknown>> LoopDispositions: { %loop: Variant }
+; CHECK-NEXT:    %inc = add nuw nsw i64 %addrec, 1
+; CHECK-NEXT:    --> {1,+,1}<nuw><nsw><%loop> U: [1,32001) S: [1,32001) Exits: 32000 LoopDispositions: { %loop: Computable }
+; CHECK-NEXT:  Determining loop execution counts for: @loop_phi_based_on_addrec
+; CHECK-NEXT:  Loop %loop: backedge-taken count is i64 31999
+; CHECK-NEXT:  Loop %loop: constant max backedge-taken count is i64 31999
+; CHECK-NEXT:  Loop %loop: symbolic max backedge-taken count is i64 31999
+; CHECK-NEXT:  Loop %loop: Trip multiple is 32000
+;
+entry:
+  br label %loop
+
+loop:
+  %addrec = phi i64 [ 0, %entry ], [ %inc, %loop ]
+  %derived = phi i64 [ 31999, %entry ], [ %addrec, %loop ]
+  %inc = add nuw nsw i64 %addrec, 1
+  %c = icmp eq i64 %inc, 32000
+  br i1 %c, label %exit, label %loop
+
+exit:
+  ret void
+}

--- a/polly/test/ScopInfo/NonAffine/non_affine_loop_used_later.ll
+++ b/polly/test/ScopInfo/NonAffine/non_affine_loop_used_later.ll
@@ -67,7 +67,7 @@
 ; CHECK-NEXT:         ReadAccess :=    [Reduction Type: NONE] [Scalar: 1]
 ; CHECK-NEXT:             [N] -> { Stmt_bb18[i0] -> MemRef_j_2__phi[] };
 ; CHECK-NEXT:         ReadAccess :=    [Reduction Type: NONE] [Scalar: 0]
-; CHECK-NEXT:             [N] -> { Stmt_bb18[i0] -> MemRef_A[o0] };
+; CHECK-NEXT:             [N] -> { Stmt_bb18[i0] -> MemRef_A[o0] : 0 <= o0 <= 2147483647 };
 ; CHECK-NEXT:         MustWriteAccess :=    [Reduction Type: NONE] [Scalar: 0]
 ; CHECK-NEXT:             [N] -> { Stmt_bb18[i0] -> MemRef_A[i0] };
 ; CHECK-NEXT:     Stmt_bb23


### PR DESCRIPTION
7bc3bb0196 restricted the nodes getRangeRef would analyze in order to avoid unbounded recursion. This made the analysis less precise in some cases which show up in practice. Add additional checks to recover those cases.

(This is unfortunately a bit complicated, but I'm not sure there's any good way to simplify it.)

The code avoids using `L->contains()` in a few places to work around bug #187902.