### PR TITLE
[llvm] Update terminal list with ANSI colors

### DIFF
--- a/llvm/lib/Support/Unix/Process.inc
+++ b/llvm/lib/Support/Unix/Process.inc
@@ -348,8 +348,11 @@ static bool terminalHasColors() {
   // ANSI color escape codes.
   if (const char *TermStr = std::getenv("TERM")) {
     return StringSwitch<bool>(TermStr)
+        .Case("alacritty", true)
         .Case("ansi", true)
         .Case("cygwin", true)
+        .Case("ghostty", true)
+        .Case("kitty", true)
         .Case("linux", true)
         .StartsWith("screen", true)
         .StartsWith("xterm", true)


### PR DESCRIPTION
ncurses hasn't adopted terminal entries for some terminal emulators like Alacritty, Ghostty, and kitty in `xterm-*`  format. To fix mismatch between remote terminfo-db and terminal emulator that is accessing (e.g. SSH), users explicitly set `$TERM` to `ghostty` or similar on the remote side to make colors work. However, since `$TERM` has changed to non `xterm-*` format in this case, llvm's `xterm-*` filter fails to catch the terminal. Thus add entries for most widely used terminal emulators (Alacritty, Ghostty, kitty) in terminfo-db version so llvm's filter can catch it.