### PR TITLE
[Clang] Fix crash when type-name is combined with class specifier in template argument

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -382,6 +382,7 @@ Bug Fixes to AST Handling
 - Fixed a bug where explicit nullability property attributes were not stored in AST nodes in Objective-C. (#GH179703)
 - Fixed a crash when parsing Doxygen ``@param`` commands attached to invalid declarations or non-function entities. (#GH182737)
 - Fixed a assertion when __block is used on global variables in C mode. (#GH183974)
+- Fixed a crash when a type-name is incorrectly combined with a class specifier within a template default argument. (#GH187664)
 
 Miscellaneous Bug Fixes
 ^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/lib/Parse/ParseDecl.cpp
+++ b/clang/lib/Parse/ParseDecl.cpp
@@ -4456,6 +4456,18 @@ void Parser::ParseDeclarationSpecifiers(
     case tok::kw___interface:
     case tok::kw_union: {
       tok::TokenKind Kind = Tok.getKind();
+
+      // If already has a TST, skip it.
+      if (DS.getTypeSpecType() != DeclSpec::TST_unspecified) {
+        Diag(Tok, diag::err_invalid_decl_spec_combination)
+            << DeclSpec::getSpecifierName(DS.getTypeSpecType(),
+                                          Actions.getPrintingPolicy());
+
+        ConsumeToken();
+        DS.SetTypeSpecError();
+        continue;
+      }
+
       ConsumeToken();
 
       // These are attributes following class specifiers.

--- a/clang/test/SemaTemplate/gh187664.cpp
+++ b/clang/test/SemaTemplate/gh187664.cpp
@@ -1,0 +1,14 @@
+// RUN: %clang_cc1 -fblocks -fsyntax-only -verify %s
+
+class A {
+public:
+    class B {};
+};
+
+using X = A::B;
+
+class C {
+    template <typename T = X class A::B> void f();
+    // expected-error@-1 {{cannot combine with previous 'type-name' declaration specifier}}
+    // expected-error@-2 {{expected ',' or '>' in template-parameter-list}}
+};


### PR DESCRIPTION
Added extra checks to ParseDeclarationSpecifiers to prevent multiple type specifiers from being assigned to the same DeclSpec.
close #187664 