### PR TITLE
[Driver] Add LTO support for NetBSD

### DIFF
--- a/clang/lib/Driver/ToolChains/NetBSD.cpp
+++ b/clang/lib/Driver/ToolChains/NetBSD.cpp
@@ -274,6 +274,10 @@ void netbsd::Linker::ConstructJob(Compilation &C, const JobAction &JA,
                             options::OPT_s, options::OPT_t});
   ToolChain.AddFilePathLibArgs(Args, CmdArgs);
 
+  if (D.isUsingLTO())
+    addLTOOptions(ToolChain, Args, CmdArgs, Output, Inputs,
+                  D.getLTOMode() == LTOK_Thin);
+
   bool NeedsSanitizerDeps = addSanitizerRuntimes(ToolChain, Args, CmdArgs);
   bool NeedsXRayDeps = addXRayRuntime(ToolChain, Args, CmdArgs);
   AddLinkerInputs(ToolChain, Inputs, Args, CmdArgs, JA);
@@ -436,6 +440,8 @@ Tool *NetBSD::buildAssembler() const {
 }
 
 Tool *NetBSD::buildLinker() const { return new tools::netbsd::Linker(*this); }
+
+bool NetBSD::HasNativeLLVMSupport() const { return true; }
 
 ToolChain::CXXStdlibType NetBSD::GetDefaultCXXStdlibType() const {
   switch (getArch()) {

--- a/clang/lib/Driver/ToolChains/NetBSD.h
+++ b/clang/lib/Driver/ToolChains/NetBSD.h
@@ -52,6 +52,7 @@ class LLVM_LIBRARY_VISIBILITY NetBSD : public Generic_ELF {
 public:
   NetBSD(const Driver &D, const llvm::Triple &Triple,
          const llvm::opt::ArgList &Args);
+  bool HasNativeLLVMSupport() const override;
 
   bool IsMathErrnoDefault() const override { return false; }
   bool IsObjCNonFragileABIDefault() const override { return true; }

--- a/clang/test/Driver/netbsd.c
+++ b/clang/test/Driver/netbsd.c
@@ -338,3 +338,8 @@
 // RUN: %clang --target=riscv64-unknown-netbsd -mno-relax -### %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=RISCV-FLAGS %s
 // RISCV-FLAGS: "-X" "--no-relax"
+
+// Check passing LTO flags to the linker
+// RUN: %clang --target=amd64-unknown-netbsd -flto -### %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHECK-LTO-FLAGS %s
+// CHECK-LTO-FLAGS: "-plugin-opt=mcpu=x86-64"

--- a/clang/test/Driver/save-stats.c
+++ b/clang/test/Driver/save-stats.c
@@ -24,6 +24,8 @@
 // RUN: %clang --target=x86_64-unknown-linux -save-stats -flto -o obj/dir/save-stats.exe -Wl,-plugin-opt=-dummy %s -### 2>&1 | FileCheck %s -check-prefix=CHECK-LTO
 // RUN: %clang --target=x86_64-unknown-freebsd -save-stats -flto -o obj/dir/save-stats.exe %s -### 2>&1 | FileCheck %s -check-prefix=CHECK-LTO
 // RUN: %clang --target=x86_64-unknown-freebsd -save-stats -flto -o obj/dir/save-stats.exe -Wl,-plugin-opt=-dummy %s -### 2>&1 | FileCheck %s -check-prefix=CHECK-LTO
+// RUN: %clang --target=x86_64-unknown-netbsd -save-stats -flto -o obj/dir/save-stats.exe %s -### 2>&1 | FileCheck %s -check-prefix=CHECK-LTO
+// RUN: %clang --target=x86_64-unknown-netbsd -save-stats -flto -o obj/dir/save-stats.exe -Wl,-plugin-opt=-dummy %s -### 2>&1 | FileCheck %s -check-prefix=CHECK-LTO
 // RUN: %clang --target=x86_64-unknown-openbsd -save-stats -flto -o obj/dir/save-stats.exe %s -### 2>&1 | FileCheck %s -check-prefix=CHECK-LTO
 // RUN: %clang --target=x86_64-unknown-openbsd -save-stats -flto -o obj/dir/save-stats.exe -Wl,-plugin-opt=-dummy %s -### 2>&1 | FileCheck %s -check-prefix=CHECK-LTO
 // RUN: %clang --target=x86_64-unknown-fuchsia -save-stats -flto -o obj/dir/save-stats.exe %s -### 2>&1 | FileCheck %s -check-prefix=CHECK-LTO


### PR DESCRIPTION
Basically copy-and-paste from FreeBSD/OpenBSD.

Note: as system /usr/bin/ld is not threaded, LLVMgold.so fails if it attempts to create threads. i couldn't find a way to suppress the use of threads. -fuse-ld=lld works.