### PR TITLE
[Codegen] Assert instead err on `createTargetMachineForTriple`

### DIFF
--- a/llvm/lib/CodeGen/CommandFlags.cpp
+++ b/llvm/lib/CodeGen/CommandFlags.cpp
@@ -803,10 +803,7 @@ codegen::createTargetMachineForTriple(StringRef TargetTriple,
       codegen::InitTargetOptionsFromCodeGenFlags(TheTriple),
       codegen::getExplicitRelocModel(), codegen::getExplicitCodeModel(),
       OptLevel);
-  if (!Target)
-    return createStringError(inconvertibleErrorCode(),
-                             Twine("could not allocate target machine for ") +
-                                 TargetTriple);
+  assert(Target && "Could not allocate target machine!");
   return std::unique_ptr<TargetMachine>(Target);
 }
 


### PR DESCRIPTION
In `codegen::createTargetMachineForTriple` after `lookupTarget` - a failure to create a target machine is really an assert. Similarly to how `llc.cpp` handles this case.