### PR TITLE
[opt] Add -mtune option

### DIFF
--- a/llvm/docs/CommandGuide/opt.rst
+++ b/llvm/docs/CommandGuide/opt.rst
@@ -53,6 +53,17 @@ OPTIONS
  `invoking opt <../NewPassManager.html#invoking-opt>`_ for more details on the
  pass pipeline syntax.
 
+.. option:: -mtune=<cpuname>
+
+ Specify a specific chip microarchitecture in the current architecture
+ to tune code for. By default this is inferred from the target triple and
+ autodetected to the current architecture. For a list of available tuning
+ CPUs, use:
+
+ .. code-block:: none
+
+   llvm-as < /dev/null | opt -march=xyz -mtune=help
+
 .. option:: -strip-debug
 
  This option causes opt to strip debug information from the module before

--- a/llvm/docs/ReleaseNotes.md
+++ b/llvm/docs/ReleaseNotes.md
@@ -242,6 +242,7 @@ Changes to the LLVM tools
 * `FileCheck` option `-check-prefix` now accepts a comma-separated list of
   prefixes, making it an alias of the existing `-check-prefixes` option.
 * Add `-mtune` option to `llc`.
+* Add `-mtune` option to `opt`.
 
 Changes to LLDB
 ---------------

--- a/llvm/test/tools/opt/mtune.ll
+++ b/llvm/test/tools/opt/mtune.ll
@@ -1,0 +1,75 @@
+; REQUIRES: aarch64-registered-target
+; REQUIRES: default_triple
+
+;; There shouldn't be a default -mtune.
+; RUN: opt < %s -passes=loop-vectorize -S -mtriple=aarch64 | FileCheck %s --check-prefixes=CHECK-NOTUNE
+
+; RUN: opt < %s -passes=loop-vectorize -S -mtriple=aarch64 -mtune=generic | FileCheck %s --check-prefixes=CHECK-TUNE-GENERIC
+; RUN: opt < %s -passes=loop-vectorize -S -mtriple=aarch64 -mtune=apple-m5 | FileCheck %s --check-prefixes=CHECK-TUNE-APPLE-M5
+
+;; Check interaction between mcpu and mtune.
+; RUN: opt < %s -passes=loop-vectorize -S -mtriple=aarch64 -mcpu=apple-m5 | FileCheck %s --check-prefixes=CHECK-TUNE-APPLE-M5
+; RUN: opt < %s -passes=loop-vectorize -S -mtriple=aarch64 -mcpu=apple-m5 -mtune=generic | FileCheck %s --check-prefixes=CHECK-TUNE-GENERIC
+
+;; Test -mtune=help
+; RUN: opt -mtriple=aarch64 -mtune=help 2>&1 | FileCheck %s --check-prefixes=CHECK-TUNE-HELP,CHECK-TUNE-HELP-NO-OPTIMIZE
+; RUN: opt -mtriple=aarch64 -mtune=help -o %t.s 2>&1 | FileCheck %s --check-prefixes=CHECK-TUNE-HELP,CHECK-TUNE-HELP-NO-OPTIMIZE
+; RUN: opt < %s -mtriple=aarch64 -mtune=help 2>&1 | FileCheck %s --check-prefixes=CHECK-TUNE-HELP,CHECK-TUNE-HELP-NO-OPTIMIZE
+; RUN: opt < %s -mtriple=aarch64 -mtune=help -o %t.s 2>&1 | FileCheck %s --check-prefixes=CHECK-TUNE-HELP,CHECK-TUNE-HELP-NO-OPTIMIZE
+
+;; Using default triple for -mtune=help
+; RUN: opt -mtune=help 2>&1 | FileCheck %s --check-prefixes=CHECK-TUNE-HELP,CHECK-TUNE-HELP-NO-OPTIMIZE
+; RUN: opt < %s -mtune=help 2>&1 | FileCheck %s --check-prefixes=CHECK-TUNE-HELP,CHECK-TUNE-HELP-NO-OPTIMIZE
+
+; CHECK-TUNE-HELP: Available CPUs for this target:
+; CHECK-TUNE-HELP: Available features for this target:
+
+;; To check we dont optimize the file
+; CHECK-TUNE-HELP-NO-OPTIMIZE-NOT: loop:
+
+;; A test case that depends on `FeatureMaxInterleaveFactor4` tuning feature, to enable -mtune verification
+;; through codegen effects. Taken from: llvm/test/Transforms/LoopVectorize/max-interleave-factor-debug.ll
+define void @loop(ptr noalias %src, ptr noalias %dst, i64 %n) {
+; CHECK-NOTUNE-LABEL: define void @loop(
+; CHECK-NOTUNE:       [[VECTOR_BODY:.*]]:
+; CHECK-NOTUNE:         [[WIDE_LOAD:%.*]] = load <4 x i32>, ptr
+; CHECK-NOTUNE-NEXT:    [[WIDE_LOAD1:%.*]] = load <4 x i32>, ptr
+; CHECK-NOTUNE:         store <4 x i32> [[WIDE_LOAD]], ptr
+; CHECK-NOTUNE-NEXT:    store <4 x i32> [[WIDE_LOAD1]], ptr
+; CHECK-NOTUNE-NEXT:    [[INDEX_NEXT:%.*]] = add nuw i64 [[INDEX:%.*]], 8
+;
+; CHECK-TUNE-GENERIC-LABEL: define void @loop(
+; CHECK-TUNE-GENERIC:       [[VECTOR_BODY:.*]]:
+; CHECK-TUNE-GENERIC:         [[WIDE_LOAD:%.*]] = load <4 x i32>, ptr
+; CHECK-TUNE-GENERIC-NEXT:    [[WIDE_LOAD1:%.*]] = load <4 x i32>, ptr
+; CHECK-TUNE-GENERIC:         store <4 x i32> [[WIDE_LOAD]], ptr
+; CHECK-TUNE-GENERIC-NEXT:    store <4 x i32> [[WIDE_LOAD1]], ptr
+; CHECK-TUNE-GENERIC-NEXT:    [[INDEX_NEXT:%.*]] = add nuw i64 [[INDEX:%.*]], 8
+;
+; CHECK-TUNE-APPLE-M5-LABEL: define void @loop(
+; CHECK-TUNE-APPLE-M5:       [[VECTOR_BODY:.*]]:
+; CHECK-TUNE-APPLE-M5:         [[WIDE_LOAD:%.*]] = load <4 x i32>, ptr
+; CHECK-TUNE-APPLE-M5-NEXT:    [[WIDE_LOAD2:%.*]] = load <4 x i32>, ptr
+; CHECK-TUNE-APPLE-M5-NEXT:    [[WIDE_LOAD3:%.*]] = load <4 x i32>, ptr
+; CHECK-TUNE-APPLE-M5-NEXT:    [[WIDE_LOAD4:%.*]] = load <4 x i32>, ptr
+; CHECK-TUNE-APPLE-M5:         store <4 x i32> [[WIDE_LOAD]], ptr
+; CHECK-TUNE-APPLE-M5-NEXT:    store <4 x i32> [[WIDE_LOAD2]], ptr
+; CHECK-TUNE-APPLE-M5-NEXT:    store <4 x i32> [[WIDE_LOAD3]], ptr
+; CHECK-TUNE-APPLE-M5-NEXT:    store <4 x i32> [[WIDE_LOAD4]], ptr
+; CHECK-TUNE-APPLE-M5-NEXT:    [[INDEX_NEXT:%.*]] = add nuw i64 [[INDEX:%.*]], 16
+entry:
+  br label %loop
+
+loop:
+  %iv = phi i64 [ 0, %entry ], [ %iv.next, %loop ]
+  %p = getelementptr i32, ptr %src, i64 %iv
+  %v = load i32, ptr %p, align 4
+  %q = getelementptr i32, ptr %dst, i64 %iv
+  store i32 %v, ptr %q, align 4
+  %iv.next = add nuw nsw i64 %iv, 1
+  %cond = icmp ne i64 %iv.next, %n
+  br i1 %cond, label %loop, label %exit
+
+exit:
+  ret void
+}

--- a/llvm/tools/opt/optdriver.cpp
+++ b/llvm/tools/opt/optdriver.cpp
@@ -66,6 +66,7 @@ using namespace llvm;
 using namespace opt_tool;
 
 static codegen::RegisterCodeGenFlags CFG;
+static codegen::RegisterMTuneFlag MTF;
 static codegen::RegisterSaveStatsFlag SSF;
 
 // The OptimizationList is automatically populated with registered Passes by the
@@ -489,8 +490,10 @@ optMain(int argc, char **argv,
 
   // If user just wants to list available options, skip module loading.
   auto MAttrs = codegen::getMAttrs();
+  std::string CPUStr = codegen::getCPUStr();
+  std::string TuneCPUStr = codegen::getTuneCPUStr();
   bool SkipModule =
-      codegen::getCPUStr() == "help" || is_contained(MAttrs, "help");
+      CPUStr == "help" || TuneCPUStr == "help" || is_contained(MAttrs, "help");
   if (SkipModule) {
     Triple TheTriple;
     if (!TargetTriple.empty())
@@ -498,15 +501,25 @@ optMain(int argc, char **argv,
     else
       TheTriple = Triple(sys::getDefaultTargetTriple());
 
-    // Create the target machine just to print the help info. Use unique_ptr
-    // to avoid a memory leak.
-    Expected<std::unique_ptr<TargetMachine>> ExpectedTM =
-        codegen::createTargetMachineForTriple(TheTriple.str(),
-                                              GetCodeGenOptLevel());
-    if (Error E = ExpectedTM.takeError()) {
-      errs() << argv[0] << ": " << toString(std::move(E)) << "\n";
+    std::string Error;
+    const Target *TheTarget =
+        TargetRegistry::lookupTarget(codegen::getMArch(), TheTriple, Error);
+    if (!TheTarget) {
+      errs() << argv[0] << ": " << Error << "\n";
       return 1;
     }
+
+    // Pass "help" as CPU for -mtune=help
+    std::string SkipModuleCPU = (TuneCPUStr == "help" ? "help" : CPUStr);
+    TargetOptions Options =
+        codegen::InitTargetOptionsFromCodeGenFlags(TheTriple);
+    // Create the target machine just to print the help info. Use unique_ptr
+    // to avoid a memory leak.
+    std::unique_ptr<TargetMachine> TM(TheTarget->createTargetMachine(
+        TheTriple, SkipModuleCPU, codegen::getFeaturesStr(), Options,
+        codegen::getExplicitRelocModel(), codegen::getExplicitCodeModel(),
+        GetCodeGenOptLevel()));
+    assert(TM && "Could not allocate target machine!");
 
     // If we don't have a module then just exit now. We do this down
     // here since the CPU/Feature help is underneath the target machine
@@ -653,10 +666,15 @@ optMain(int argc, char **argv,
   }
 
   Triple ModuleTriple(M->getTargetTriple());
-  std::string CPUStr, FeaturesStr;
+  // Avoid setting target function attributes if no arch is found, by resetting
+  // them first
+  CPUStr.clear();
+  TuneCPUStr.clear();
+  std::string FeaturesStr;
   std::unique_ptr<TargetMachine> TM;
   if (ModuleTriple.getArch()) {
     CPUStr = codegen::getCPUStr();
+    TuneCPUStr = codegen::getTuneCPUStr();
     FeaturesStr = codegen::getFeaturesStr();
     Expected<std::unique_ptr<TargetMachine>> ExpectedTM =
         codegen::createTargetMachineForTriple(ModuleTriple.str(),
@@ -681,9 +699,9 @@ optMain(int argc, char **argv,
         codegen::InitTargetOptionsFromCodeGenFlags(ModuleTriple);
   }
 
-  // Override function attributes based on CPUStr, FeaturesStr, and command line
-  // flags.
-  codegen::setFunctionAttributes(*M, CPUStr, FeaturesStr);
+  // Override function attributes based on CPUStr, TuneCPUStr, FeaturesStr, and
+  // command line flags.
+  codegen::setFunctionAttributes(*M, CPUStr, FeaturesStr, TuneCPUStr);
 
   // If the output is set to be emitted to standard out, and standard out is a
   // console, print out a warning message and refuse to do it.  We don't

--- a/llvm/tools/opt/optdriver.cpp
+++ b/llvm/tools/opt/optdriver.cpp
@@ -519,7 +519,10 @@ optMain(int argc, char **argv,
         TheTriple, SkipModuleCPU, codegen::getFeaturesStr(), Options,
         codegen::getExplicitRelocModel(), codegen::getExplicitCodeModel(),
         GetCodeGenOptLevel()));
-    assert(TM && "Could not allocate target machine!");
+    if (!TM) {
+      errs() << argv[0] << ": could not allocate target machine\n";
+      return 1;
+    }
 
     // If we don't have a module then just exit now. We do this down
     // here since the CPU/Feature help is underneath the target machine


### PR DESCRIPTION
This patch adds a Clang-compatible -mtune option to opt, following up the addition to llc: https://github.com/llvm/llvm-project/pull/186998, to enable decoupled ISA and microarchitecture targeting. Example use case is `MaxInterleaveFactor` for the loop vectorizer.
    
The implementation registers the new codegen flag for opt, which consumes it and sets tune-cpu attributes for functions to be consumed by the backend.