### PR TITLE
docs: add gitcgr code graph badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/llvm/llvm-project/badge)](https://securityscorecards.dev/viewer/?uri=github.com/llvm/llvm-project)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/8273/badge)](https://www.bestpractices.dev/projects/8273)
 [![libc++](https://github.com/llvm/llvm-project/actions/workflows/libcxx-build-and-test.yaml/badge.svg?branch=main&event=schedule)](https://github.com/llvm/llvm-project/actions/workflows/libcxx-build-and-test.yaml?query=event%3Aschedule)
+[![gitcgr](https://gitcgr.com/badge/llvm/llvm-project.svg)](https://gitcgr.com/llvm/llvm-project)
 
 Welcome to the LLVM project!
 


### PR DESCRIPTION
Adds a [gitcgr](https://gitcgr.com) badge to the README showing code graph statistics for this repository.

**Badge preview:**

[![gitcgr](https://gitcgr.com/badge/llvm/llvm-project.svg)](https://gitcgr.com/llvm/llvm-project)

---

[gitcgr.com](https://gitcgr.com) visualizes any GitHub repo as an interactive code graph — just change `hub` to `cgr` in the URL.

Generated automatically by [gitcgr](https://gitcgr.com).