### PR TITLE
[clang] On Windows, silence warning when building with MSVC

### DIFF
--- a/clang/lib/AST/TemplateBase.cpp
+++ b/clang/lib/AST/TemplateBase.cpp
@@ -750,8 +750,8 @@ clang::TemplateArgumentLocInfo::TemplateArgumentLocInfo(
 clang::TemplateArgumentLocInfo::TemplateArgumentLocInfo(
     ASTContext &Ctx, SourceLocation TrivialLoc) {
   if constexpr (EmbedLocInPointer)
-    Pointer = reinterpret_cast<LocOrPointer>((TrivialLoc.getRawEncoding() + 1u)
-                                             << LowBitsRequired);
+    Pointer = reinterpret_cast<LocOrPointer>(static_cast<uintptr_t>(
+        (TrivialLoc.getRawEncoding() + 1u) << LowBitsRequired));
   else
     Pointer = new (Ctx) SourceLocation(TrivialLoc);
 }


### PR DESCRIPTION
This fixes:
```
[2124/7029] Building CXX object tools\clang\lib\AST\CMakeFiles\obj.clangAST.dir\TemplateBase.cpp.obj
C:\git\llvm-project\clang\lib\AST\TemplateBase.cpp(753): warning C4312: 'reinterpret_cast': conversion from 'clang::SourceLocation::UIntTy' to 'clang::TemplateArgumentLocInfo::LocOrPointer' of greater size
```