### PR TITLE
[clang] Silence warning in `WhitespaceManager` when building with MSVC

### DIFF
--- a/clang/lib/Format/WhitespaceManager.cpp
+++ b/clang/lib/Format/WhitespaceManager.cpp
@@ -14,6 +14,7 @@
 #include "WhitespaceManager.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/ErrorHandling.h"
 #include <algorithm>
 #include <limits>
 #include <optional>
@@ -636,6 +637,8 @@ static unsigned AlignTokens(const FormatStyle &Style, F &&Matches,
       case AlignStrategy::Macro:
       case AlignStrategy::Normal:
         return {true, false};
+      default:
+        llvm_unreachable("Unhandled AlignStrategy");
       }
     }();
 

--- a/clang/lib/Format/WhitespaceManager.cpp
+++ b/clang/lib/Format/WhitespaceManager.cpp
@@ -14,7 +14,6 @@
 #include "WhitespaceManager.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallVector.h"
-#include "llvm/Support/ErrorHandling.h"
 #include <algorithm>
 #include <limits>
 #include <optional>
@@ -634,11 +633,8 @@ static unsigned AlignTokens(const FormatStyle &Style, F &&Matches,
           Tok = Tok->getNextNonComment();
         return {Tok && Tok->isOneOf(tok::kw_case, tok::kw_default), false};
       }
-      case AlignStrategy::Macro:
-      case AlignStrategy::Normal:
+      default: // AlignStrategy::Macro and AlignStrategy::Normal:
         return {true, false};
-      default:
-        llvm_unreachable("Unhandled AlignStrategy");
       }
     }();
 


### PR DESCRIPTION
This fixes:
```
[4544/7029] Building CXX object tools\clang\lib\Format\CMakeFiles\obj.clangFormat.dir\WhitespaceManager.cpp.obj
C:\git\llvm-project\clang\lib\Format\WhitespaceManager.cpp(640) : warning C4715: '`clang::format::AlignTokens<`clang::format::WhitespaceManager::alignConsecutiveColons'::`2'::<lambda_1> &,0>'::`4'::<lambda_2>::operator()': not all control paths return a value
C:\git\llvm-project\clang\lib\Format\WhitespaceManager.cpp(640) : warning C4715: '`clang::format::AlignTokens<`clang::format::WhitespaceManager::alignConsecutiveShortCaseStatements'::`2'::<lambda_1> &,3>'::`4'::<lambda_2>::operator()': not all control paths return a value
C:\git\llvm-project\clang\lib\Format\WhitespaceManager.cpp(640) : warning C4715: '`clang::format::AlignTokens<`clang::format::WhitespaceManager::alignConsecutiveDeclarations'::`2'::<lambda_1> &,0>'::`4'::<lambda_2>::operator()': not all control paths return a value
C:\git\llvm-project\clang\lib\Format\WhitespaceManager.cpp(640) : warning C4715: '`clang::format::AlignTokens<`clang::format::WhitespaceManager::alignConsecutiveAssignments'::`2'::<lambda_1> &,0>'::`4'::<lambda_2>::operator()': not all control paths return a value
C:\git\llvm-project\clang\lib\Format\WhitespaceManager.cpp(640) : warning C4715: '`clang::format::AlignTokens<`clang::format::WhitespaceManager::alignConsecutiveMacros'::`2'::<lambda_1> &,1>'::`4'::<lambda_2>::operator()': not all control paths return a value
C:\git\llvm-project\clang\lib\Format\WhitespaceManager.cpp(640) : warning C4715: '`clang::format::AlignTokens<`clang::format::WhitespaceManager::alignChainedConditionals'::`7'::<lambda_3> &,0>'::`4'::<lambda_2>::operator()': not all control paths return a value
C:\git\llvm-project\clang\lib\Format\WhitespaceManager.cpp(640) : warning C4715: '`clang::format::AlignTokens<`clang::format::WhitespaceManager::alignConsecutiveColons'::`2'::<lambda_1>,0>'::`4'::<lambda_2>::operator()': not all control paths return a value
C:\git\llvm-project\clang\lib\Format\WhitespaceManager.cpp(640) : warning C4715: '`clang::format::AlignTokens<`clang::format::WhitespaceManager::alignConsecutiveAssignments'::`2'::<lambda_1>,0>'::`4'::<lambda_2>::operator()': not all control paths return a value
C:\git\llvm-project\clang\lib\Format\WhitespaceManager.cpp(640) : warning C4715: '`clang::format::AlignTokens<`clang::format::WhitespaceManager::alignChainedConditionals'::`5'::<lambda_1> &,0>'::`4'::<lambda_2>::operator()': not all control paths return a value
C:\git\llvm-project\clang\lib\Format\WhitespaceManager.cpp(640) : warning C4715: '`clang::format::AlignTokens<`clang::format::WhitespaceManager::alignConsecutiveDeclarations'::`2'::<lambda_1>,0>'::`4'::<lambda_2>::operator()': not all control paths return a value
C:\git\llvm-project\clang\lib\Format\WhitespaceManager.cpp(640) : warning C4715: '`clang::format::AlignTokens<`clang::format::WhitespaceManager::alignChainedConditionals'::`5'::<lambda_1>,0>'::`4'::<lambda_2>::operator()': not all control paths return a value
C:\git\llvm-project\clang\lib\Format\WhitespaceManager.cpp(640) : warning C4715: '`clang::format::AlignTokens<`clang::format::WhitespaceManager::alignConsecutiveShortCaseStatements'::`2'::<lambda_1> &,2>'::`4'::<lambda_2>::operator()': not all control paths return a value
C:\git\llvm-project\clang\lib\Format\WhitespaceManager.cpp(640) : warning C4715: '`clang::format::AlignTokens<`clang::format::WhitespaceManager::alignChainedConditionals'::`7'::<lambda_3>,0>'::`4'::<lambda_2>::operator()': not all control paths return a value
```