### PR TITLE
[clang] On Windows, silence warning in `CFGBackEdgesTest` with MSVC

### DIFF
--- a/clang/unittests/Analysis/CFGBackEdgesTest.cpp
+++ b/clang/unittests/Analysis/CFGBackEdgesTest.cpp
@@ -167,7 +167,7 @@ TEST(CFGBackEdgesTest, WhileWithContinueLoop) {
   ASSERT_THAT(Cfg, NotNull());
 
   auto BackEdges = findCFGBackEdges(*Cfg);
-  EXPECT_THAT(BackEdges, SizeIs(testing::Gt(0)));
+  EXPECT_THAT(BackEdges, SizeIs(testing::Gt(0u)));
   for (const auto &[From, To] : BackEdges)
     EXPECT_THAT(From->getLoopTarget(), NotNull());
 }


### PR DESCRIPTION
This fixes:
```
[5804/7029] Building CXX object tools\clang\unittests\CMakeFiles\AllClangUnitTests.dir\Analysis\CFGBackEdgesTest.cpp.obj
C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.44.35207\include\xutility(721): warning C4018: '>': signed/unsigned mismatch
...
C:\git\llvm-project\clang\unittests\Analysis\CFGBackEdgesTest.cpp(170): note: see the first reference to 'testing::internal::PredicateFormatterFromMatcher<testing::internal::SizeIsMatcher<testing::internal::GtMatcher<int>>>::operator ()' in 'clang::analysis::`anonymous-namespace'::CFGBackEdgesTest_WhileWithContinueLoop_Test::TestBody'
```