### PR TITLE
[Clang] Honour [[maybe_unused]] on private fields

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -309,6 +309,10 @@ Improvements to Clang's diagnostics
   (``-fimplicit-module-maps``). This does not affect module maps specified
   explicitly via ``-fmodule-map-file=``.
 
+- Honour ``[[maybe_unused]]`` attribute on private fields.
+  ``-Wunused-private-field`` no longer emits a warning for annotated private
+  fields.
+
 Improvements to Clang's time-trace
 ----------------------------------
 

--- a/clang/lib/Sema/Sema.cpp
+++ b/clang/lib/Sema/Sema.cpp
@@ -1611,7 +1611,7 @@ void Sema::ActOnEndOfTranslationUnit() {
     RecordCompleteMap MNCComplete;
     for (const NamedDecl *D : UnusedPrivateFields) {
       const CXXRecordDecl *RD = dyn_cast<CXXRecordDecl>(D->getDeclContext());
-      if (RD && !RD->isUnion() &&
+      if (RD && !RD->isUnion() && !D->hasAttr<UnusedAttr>() &&
           IsRecordFullyDefined(RD, RecordsComplete, MNCComplete)) {
         Diag(D->getLocation(), diag::warn_unused_private_field)
               << D->getDeclName();

--- a/clang/test/SemaCXX/warn-maybe-unused-private-field.cpp
+++ b/clang/test/SemaCXX/warn-maybe-unused-private-field.cpp
@@ -1,0 +1,11 @@
+// RUN: %clang_cc1 -fsyntax-only -Wunused-private-field -verify -std=c++17 %s
+// RUN: %clang_cc1 -fsyntax-only -Wunused-private-field -verify -std=c++20 %s
+// RUN: %clang_cc1 -fsyntax-only -Wunused-private-field -verify -std=c++23 %s
+
+class MyClass {
+	// Marking an unused field with [[maybe_unused]] shouldn't result in a
+	// warning
+	[[maybe_unused]]
+	unsigned field1;
+	signed field2; // expected-warning{{private field 'field2' is not used}}
+};


### PR DESCRIPTION
Before this commit, [[maybe_unused]] on private fields was ignored. In conjunction with `-Wunused-private-field`, false warnings were emitted by clang. This commit fixes this by checking if an unused private field is annotated with [[maybe_unused]].