### PR TITLE
[mlir][spirv][gpu] Add lowering for gpu.subgroup_broadcast

### DIFF
--- a/mlir/lib/Conversion/GPUToSPIRV/GPUToSPIRV.cpp
+++ b/mlir/lib/Conversion/GPUToSPIRV/GPUToSPIRV.cpp
@@ -130,6 +130,18 @@ public:
                   ConversionPatternRewriter &rewriter) const override;
 };
 
+/// Pattern to convert a gpu.subgroup_broadcast op into a
+/// spirv.GroupNonUniformBroadcast op.
+class GPUSubgroupBroadcastConversion final
+    : public OpConversionPattern<gpu::SubgroupBroadcastOp> {
+public:
+  using Base::Base;
+
+  LogicalResult
+  matchAndRewrite(gpu::SubgroupBroadcastOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override;
+};
+
 class GPUPrintfConversion final : public OpConversionPattern<gpu::PrintfOp> {
 public:
   using Base::Base;
@@ -543,6 +555,32 @@ LogicalResult GPURotateConversion::matchAndRewrite(
 }
 
 //===----------------------------------------------------------------------===//
+// Subgroup broadcast
+//===----------------------------------------------------------------------===//
+
+LogicalResult GPUSubgroupBroadcastConversion::matchAndRewrite(
+    gpu::SubgroupBroadcastOp op, OpAdaptor adaptor,
+    ConversionPatternRewriter &rewriter) const {
+  Location loc = op.getLoc();
+  auto scope = rewriter.getAttr<spirv::ScopeAttr>(spirv::Scope::Subgroup);
+  Value result;
+
+  switch (op.getBroadcastType()) {
+  case gpu::BroadcastType::specific_lane:
+    result = spirv::GroupNonUniformBroadcastOp::create(
+        rewriter, loc, scope, adaptor.getSrc(), adaptor.getLane());
+    break;
+  case gpu::BroadcastType::first_active_lane:
+    result = spirv::GroupNonUniformBroadcastFirstOp::create(
+        rewriter, loc, scope, adaptor.getSrc());
+    break;
+  }
+
+  rewriter.replaceOp(op, result);
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
 // Group ops
 //===----------------------------------------------------------------------===//
 
@@ -832,6 +870,7 @@ void mlir::populateGPUToSPIRVPatterns(const SPIRVTypeConverter &typeConverter,
   patterns.add<
       GPUBarrierConversion, GPUFuncOpConversion, GPUModuleConversion,
       GPUReturnOpConversion, GPUShuffleConversion, GPURotateConversion,
+      GPUSubgroupBroadcastConversion,
       LaunchConfigConversion<gpu::BlockIdOp, spirv::BuiltIn::WorkgroupId>,
       LaunchConfigConversion<gpu::GridDimOp, spirv::BuiltIn::NumWorkgroups>,
       LaunchConfigConversion<gpu::BlockDimOp, spirv::BuiltIn::WorkgroupSize>,

--- a/mlir/lib/Conversion/GPUToSPIRV/GPUToSPIRV.cpp
+++ b/mlir/lib/Conversion/GPUToSPIRV/GPUToSPIRV.cpp
@@ -574,6 +574,8 @@ LogicalResult GPUSubgroupBroadcastConversion::matchAndRewrite(
     result = spirv::GroupNonUniformBroadcastFirstOp::create(
         rewriter, loc, scope, adaptor.getSrc());
     break;
+  default:
+    llvm_unreachable("unsupported gpu.subgroup_broadcast type");
   }
 
   rewriter.replaceOp(op, result);

--- a/mlir/lib/Conversion/GPUToSPIRV/GPUToSPIRV.cpp
+++ b/mlir/lib/Conversion/GPUToSPIRV/GPUToSPIRV.cpp
@@ -20,6 +20,7 @@
 #include "mlir/Dialect/SPIRV/Transforms/SPIRVConversion.h"
 #include "mlir/IR/Matchers.h"
 #include "mlir/Transforms/DialectConversion.h"
+#include "llvm/Support/ErrorHandling.h"
 #include <optional>
 
 using namespace mlir;

--- a/mlir/lib/Conversion/GPUToSPIRV/GPUToSPIRV.cpp
+++ b/mlir/lib/Conversion/GPUToSPIRV/GPUToSPIRV.cpp
@@ -20,7 +20,6 @@
 #include "mlir/Dialect/SPIRV/Transforms/SPIRVConversion.h"
 #include "mlir/IR/Matchers.h"
 #include "mlir/Transforms/DialectConversion.h"
-#include "llvm/Support/ErrorHandling.h"
 #include <optional>
 
 using namespace mlir;
@@ -575,8 +574,6 @@ LogicalResult GPUSubgroupBroadcastConversion::matchAndRewrite(
     result = spirv::GroupNonUniformBroadcastFirstOp::create(
         rewriter, loc, scope, adaptor.getSrc());
     break;
-  default:
-    llvm_unreachable("unsupported gpu.subgroup_broadcast type");
   }
 
   rewriter.replaceOp(op, result);

--- a/mlir/test/Conversion/GPUToSPIRV/broadcast.mlir
+++ b/mlir/test/Conversion/GPUToSPIRV/broadcast.mlir
@@ -1,4 +1,4 @@
-// RUN: mlir-opt -split-input-file -convert-gpu-to-spirv -verify-diagnostics %s -o - | FileCheck %s
+// RUN: mlir-opt --split-input-file --convert-gpu-to-spirv %s -o - | FileCheck %s
 
 // -----
 

--- a/mlir/test/Conversion/GPUToSPIRV/broadcast.mlir
+++ b/mlir/test/Conversion/GPUToSPIRV/broadcast.mlir
@@ -1,0 +1,47 @@
+// RUN: mlir-opt -split-input-file -convert-gpu-to-spirv -verify-diagnostics %s -o - | FileCheck %s
+
+// -----
+
+module attributes {
+  gpu.container_module,
+  spirv.target_env = #spirv.target_env<#spirv.vce<v1.3, [Shader, GroupNonUniformBallot], []>, #spirv.resource_limits<>>
+} {
+
+gpu.module @kernels {
+  // CHECK-LABEL: spirv.func @broadcast_specific_lane()
+  gpu.func @broadcast_specific_lane() kernel
+    attributes {spirv.entry_point_abi = #spirv.entry_point_abi<workgroup_size = [16, 1, 1]>} {
+    %lane = arith.constant 0 : i32
+    %val = arith.constant 42.0 : f32
+
+    // CHECK: %[[LANE:.+]] = spirv.Constant 0 : i32
+    // CHECK: %[[VAL:.+]] = spirv.Constant 4.200000e+01 : f32
+    // CHECK: %{{.+}} = spirv.GroupNonUniformBroadcast <Subgroup> %[[VAL]], %[[LANE]] : f32, i32
+    %result = gpu.subgroup_broadcast %val, specific_lane %lane : f32
+    gpu.return
+  }
+}
+
+}
+
+// -----
+
+module attributes {
+  gpu.container_module,
+  spirv.target_env = #spirv.target_env<#spirv.vce<v1.3, [Shader, GroupNonUniformBallot], []>, #spirv.resource_limits<>>
+} {
+
+gpu.module @kernels {
+  // CHECK-LABEL: spirv.func @broadcast_first_active_lane()
+  gpu.func @broadcast_first_active_lane() kernel
+    attributes {spirv.entry_point_abi = #spirv.entry_point_abi<workgroup_size = [16, 1, 1]>} {
+    %val = arith.constant 42.0 : f32
+
+    // CHECK: %[[VAL:.+]] = spirv.Constant 4.200000e+01 : f32
+    // CHECK: %{{.+}} = spirv.GroupNonUniformBroadcastFirst <Subgroup> %[[VAL]] : f32
+    %result = gpu.subgroup_broadcast %val, first_active_lane : f32
+    gpu.return
+  }
+}
+
+}


### PR DESCRIPTION
Fixes #157940

Add lowering for `gpu.subgroup_broadcast` and `gpu.subgroup_broadcast_first` to `spirv.GroupNonUniformBroadcast` and `spirv.GroupNonUniformBroadcastFirst`.