### PR TITLE
[SDAG] Follow target boolean semantics in `PromoteIntOp_VECTOR_FIND_LAST_ACTIVE`

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/LegalizeIntegerTypes.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/LegalizeIntegerTypes.cpp
@@ -2995,9 +2995,17 @@ SDValue DAGTypeLegalizer::PromoteIntOp_VECTOR_HISTOGRAM(SDNode *N,
 
 SDValue DAGTypeLegalizer::PromoteIntOp_VECTOR_FIND_LAST_ACTIVE(SDNode *N,
                                                                unsigned OpNo) {
-  SmallVector<SDValue, 1> NewOps(N->ops());
-  NewOps[OpNo] = GetPromotedInteger(N->getOperand(OpNo));
-  return SDValue(DAG.UpdateNodeOperands(N, NewOps), 0);
+  assert(OpNo == 0 && "Unexpected operand for promotion");
+  SDValue Op = N->getOperand(0);
+
+  SDValue NewOp;
+  if (TLI.getBooleanContents(Op.getValueType()) ==
+      TargetLowering::ZeroOrNegativeOneBooleanContent)
+    NewOp = SExtPromotedInteger(Op);
+  else
+    NewOp = ZExtPromotedInteger(Op);
+
+  return SDValue(DAG.UpdateNodeOperands(N, NewOp), 0);
 }
 
 SDValue DAGTypeLegalizer::PromoteIntOp_GET_ACTIVE_LANE_MASK(SDNode *N) {

--- a/llvm/test/CodeGen/AArch64/vector-extract-last-active.ll
+++ b/llvm/test/CodeGen/AArch64/vector-extract-last-active.ll
@@ -500,19 +500,21 @@ define i32 @extract_last_active_v3i32(<3 x i32> %a, <3 x i1> %c) {
 ; NEON-FIXED-NEXT:    movi v1.2d, #0000000000000000
 ; NEON-FIXED-NEXT:    adrp x8, .LCPI18_0
 ; NEON-FIXED-NEXT:    mov x11, sp
-; NEON-FIXED-NEXT:    ldr d2, [x8, :lo12:.LCPI18_0]
+; NEON-FIXED-NEXT:    ldr d3, [x8, :lo12:.LCPI18_0]
 ; NEON-FIXED-NEXT:    str q0, [sp]
 ; NEON-FIXED-NEXT:    mov v1.h[0], w0
 ; NEON-FIXED-NEXT:    mov v1.h[1], w1
 ; NEON-FIXED-NEXT:    mov v1.h[2], w2
-; NEON-FIXED-NEXT:    and v2.8b, v1.8b, v2.8b
+; NEON-FIXED-NEXT:    shl v2.4h, v1.4h, #15
 ; NEON-FIXED-NEXT:    fmov x8, d1
-; NEON-FIXED-NEXT:    umaxv h2, v2.4h
+; NEON-FIXED-NEXT:    cmlt v2.4h, v2.4h, #0
 ; NEON-FIXED-NEXT:    lsr x9, x8, #32
 ; NEON-FIXED-NEXT:    orr w9, w8, w9
+; NEON-FIXED-NEXT:    and v2.8b, v2.8b, v3.8b
 ; NEON-FIXED-NEXT:    orr w8, w9, w8, lsr #16
-; NEON-FIXED-NEXT:    fmov w10, s2
 ; NEON-FIXED-NEXT:    tst w8, #0x1
+; NEON-FIXED-NEXT:    umaxv h2, v2.4h
+; NEON-FIXED-NEXT:    fmov w10, s2
 ; NEON-FIXED-NEXT:    bfi x11, x10, #2, #2
 ; NEON-FIXED-NEXT:    ldr w9, [x11]
 ; NEON-FIXED-NEXT:    csinv w0, w9, wzr, ne
@@ -524,20 +526,22 @@ define i32 @extract_last_active_v3i32(<3 x i32> %a, <3 x i1> %c) {
 ; SVE-FIXED-NEXT:    sub sp, sp, #16
 ; SVE-FIXED-NEXT:    .cfi_def_cfa_offset 16
 ; SVE-FIXED-NEXT:    movi v1.2d, #0000000000000000
-; SVE-FIXED-NEXT:    index z2.h, #0, #1
+; SVE-FIXED-NEXT:    index z3.h, #0, #1
 ; SVE-FIXED-NEXT:    mov x11, sp
 ; SVE-FIXED-NEXT:    str q0, [sp]
 ; SVE-FIXED-NEXT:    mov v1.h[0], w0
 ; SVE-FIXED-NEXT:    mov v1.h[1], w1
 ; SVE-FIXED-NEXT:    mov v1.h[2], w2
-; SVE-FIXED-NEXT:    and v2.8b, v1.8b, v2.8b
+; SVE-FIXED-NEXT:    shl v2.4h, v1.4h, #15
 ; SVE-FIXED-NEXT:    fmov x8, d1
-; SVE-FIXED-NEXT:    umaxv h2, v2.4h
+; SVE-FIXED-NEXT:    cmlt v2.4h, v2.4h, #0
 ; SVE-FIXED-NEXT:    lsr x9, x8, #32
 ; SVE-FIXED-NEXT:    orr w9, w8, w9
+; SVE-FIXED-NEXT:    and v2.8b, v2.8b, v3.8b
 ; SVE-FIXED-NEXT:    orr w8, w9, w8, lsr #16
-; SVE-FIXED-NEXT:    fmov w10, s2
 ; SVE-FIXED-NEXT:    tst w8, #0x1
+; SVE-FIXED-NEXT:    umaxv h2, v2.4h
+; SVE-FIXED-NEXT:    fmov w10, s2
 ; SVE-FIXED-NEXT:    bfi x11, x10, #2, #2
 ; SVE-FIXED-NEXT:    ldr w9, [x11]
 ; SVE-FIXED-NEXT:    csinv w0, w9, wzr, ne

--- a/llvm/test/CodeGen/X86/vector-extract-last-active.ll
+++ b/llvm/test/CodeGen/X86/vector-extract-last-active.ll
@@ -15,6 +15,8 @@ define i32 @extract_last_active_v4i32(<4 x i32> %a, <4 x i1> %c) {
 ; CHECK-NEXT:    movd %xmm1, %edx
 ; CHECK-NEXT:    pshufd {{.*#+}} xmm2 = xmm1[1,1,1,1]
 ; CHECK-NEXT:    movd %xmm2, %esi
+; CHECK-NEXT:    pslld $31, %xmm1
+; CHECK-NEXT:    psrad $31, %xmm1
 ; CHECK-NEXT:    movaps %xmm0, -{{[0-9]+}}(%rsp)
 ; CHECK-NEXT:    pand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm1
 ; CHECK-NEXT:    pshufd {{.*#+}} xmm0 = xmm1[2,3,2,3]
@@ -43,6 +45,8 @@ define i32 @extract_last_active_v4i32(<4 x i32> %a, <4 x i1> %c) {
 define i32 @extract_last_active_v4i32_no_default(<4 x i32> %a, <4 x i1> %c) {
 ; CHECK-LABEL: extract_last_active_v4i32_no_default:
 ; CHECK:       # %bb.0:
+; CHECK-NEXT:    pslld $31, %xmm1
+; CHECK-NEXT:    psrad $31, %xmm1
 ; CHECK-NEXT:    movaps %xmm0, -{{[0-9]+}}(%rsp)
 ; CHECK-NEXT:    pand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm1
 ; CHECK-NEXT:    pshufd {{.*#+}} xmm0 = xmm1[2,3,2,3]
@@ -66,15 +70,19 @@ define i32 @extract_last_active_v2i32(<2 x i32> %a, <2 x i1> %c) {
 ; CHECK-LABEL: extract_last_active_v2i32:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    pshufd {{.*#+}} xmm2 = xmm1[2,3,2,3]
+; CHECK-NEXT:    movq %xmm1, %rax
+; CHECK-NEXT:    psllq $63, %xmm1
 ; CHECK-NEXT:    movq %xmm2, %rcx
-; CHECK-NEXT:    movq %xmm1, %rdx
 ; CHECK-NEXT:    movaps %xmm0, -{{[0-9]+}}(%rsp)
-; CHECK-NEXT:    orl %ecx, %edx
-; CHECK-NEXT:    andb $1, %dl
+; CHECK-NEXT:    orl %eax, %ecx
+; CHECK-NEXT:    andb $1, %cl
 ; CHECK-NEXT:    xorl %eax, %eax
-; CHECK-NEXT:    cmpb $1, %dl
+; CHECK-NEXT:    cmpb $1, %cl
 ; CHECK-NEXT:    sbbl %eax, %eax
-; CHECK-NEXT:    andl $1, %ecx
+; CHECK-NEXT:    pshufd {{.*#+}} xmm0 = xmm1[3,3,3,3]
+; CHECK-NEXT:    psrld $31, %xmm0
+; CHECK-NEXT:    movq %xmm0, %rcx
+; CHECK-NEXT:    movl %ecx, %ecx
 ; CHECK-NEXT:    orl -24(%rsp,%rcx,4), %eax
 ; CHECK-NEXT:    retq
   %res = call i32 @llvm.experimental.vector.extract.last.active.v2i32(<2 x i32> %a, <2 x i1> %c, i32 -1)
@@ -86,18 +94,23 @@ define i32 @extract_last_active_v2i32(<2 x i32> %a, <2 x i1> %c) {
 define i32 @extract_last_active_v3i32(<3 x i32> %a, <3 x i1> %c) {
 ; CHECK-LABEL: extract_last_active_v3i32:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    movd %edx, %xmm1
-; CHECK-NEXT:    movd %esi, %xmm2
-; CHECK-NEXT:    pshufd {{.*#+}} xmm2 = xmm2[0,0,1,1]
-; CHECK-NEXT:    punpcklqdq {{.*#+}} xmm2 = xmm2[0],xmm1[0]
 ; CHECK-NEXT:    movaps %xmm0, -{{[0-9]+}}(%rsp)
-; CHECK-NEXT:    pand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm2
-; CHECK-NEXT:    pshufd {{.*#+}} xmm0 = xmm2[2,3,2,3]
+; CHECK-NEXT:    movd %edx, %xmm0
+; CHECK-NEXT:    movd %esi, %xmm1
+; CHECK-NEXT:    shufps {{.*#+}} xmm1 = xmm1[1,0],xmm0[0,1]
+; CHECK-NEXT:    pslld $31, %xmm1
+; CHECK-NEXT:    psrad $31, %xmm1
+; CHECK-NEXT:    pand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm1
+; CHECK-NEXT:    pshufd {{.*#+}} xmm0 = xmm1[2,3,2,3]
 ; CHECK-NEXT:    movd %xmm0, %ecx
-; CHECK-NEXT:    pshufd {{.*#+}} xmm0 = xmm2[1,1,1,1]
+; CHECK-NEXT:    pshufd {{.*#+}} xmm0 = xmm1[1,1,1,1]
 ; CHECK-NEXT:    movd %xmm0, %eax
 ; CHECK-NEXT:    cmpl %ecx, %eax
 ; CHECK-NEXT:    cmoval %eax, %ecx
+; CHECK-NEXT:    pshufd {{.*#+}} xmm0 = xmm1[3,3,3,3]
+; CHECK-NEXT:    movd %xmm0, %eax
+; CHECK-NEXT:    cmpl %eax, %ecx
+; CHECK-NEXT:    cmovbel %eax, %ecx
 ; CHECK-NEXT:    orl %esi, %edi
 ; CHECK-NEXT:    orl %edx, %edi
 ; CHECK-NEXT:    andb $1, %dil
@@ -118,48 +131,50 @@ define i32 @extract_last_active_v8i32(<8 x i32> %a, <8 x i1> %c) {
 ; CHECK-NEXT:    .cfi_def_cfa_offset 16
 ; CHECK-NEXT:    .cfi_offset %rbx, -16
 ; CHECK-NEXT:    pextrw $7, %xmm2, %eax
-; CHECK-NEXT:    pextrw $6, %xmm2, %esi
+; CHECK-NEXT:    pextrw $6, %xmm2, %edx
 ; CHECK-NEXT:    pextrw $5, %xmm2, %r8d
 ; CHECK-NEXT:    pextrw $4, %xmm2, %ecx
 ; CHECK-NEXT:    pextrw $3, %xmm2, %r9d
 ; CHECK-NEXT:    pextrw $2, %xmm2, %edi
 ; CHECK-NEXT:    pextrw $1, %xmm2, %r11d
 ; CHECK-NEXT:    movd %xmm2, %r10d
+; CHECK-NEXT:    psllw $15, %xmm2
+; CHECK-NEXT:    psraw $15, %xmm2
 ; CHECK-NEXT:    movaps %xmm1, -{{[0-9]+}}(%rsp)
 ; CHECK-NEXT:    movaps %xmm0, -{{[0-9]+}}(%rsp)
 ; CHECK-NEXT:    pand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm2
-; CHECK-NEXT:    pextrw $2, %xmm2, %edx
+; CHECK-NEXT:    pextrw $2, %xmm2, %esi
 ; CHECK-NEXT:    pextrw $1, %xmm2, %ebx
-; CHECK-NEXT:    cmpw %dx, %bx
-; CHECK-NEXT:    cmoval %ebx, %edx
+; CHECK-NEXT:    cmpw %si, %bx
+; CHECK-NEXT:    cmoval %ebx, %esi
 ; CHECK-NEXT:    pextrw $3, %xmm2, %ebx
-; CHECK-NEXT:    cmpw %bx, %dx
-; CHECK-NEXT:    cmovbel %ebx, %edx
+; CHECK-NEXT:    cmpw %bx, %si
+; CHECK-NEXT:    cmovbel %ebx, %esi
 ; CHECK-NEXT:    pextrw $4, %xmm2, %ebx
-; CHECK-NEXT:    cmpw %bx, %dx
-; CHECK-NEXT:    cmovbel %ebx, %edx
+; CHECK-NEXT:    cmpw %bx, %si
+; CHECK-NEXT:    cmovbel %ebx, %esi
 ; CHECK-NEXT:    pextrw $5, %xmm2, %ebx
-; CHECK-NEXT:    cmpw %bx, %dx
-; CHECK-NEXT:    cmovbel %ebx, %edx
+; CHECK-NEXT:    cmpw %bx, %si
+; CHECK-NEXT:    cmovbel %ebx, %esi
 ; CHECK-NEXT:    pextrw $6, %xmm2, %ebx
-; CHECK-NEXT:    cmpw %bx, %dx
-; CHECK-NEXT:    cmovbel %ebx, %edx
+; CHECK-NEXT:    cmpw %bx, %si
+; CHECK-NEXT:    cmovbel %ebx, %esi
 ; CHECK-NEXT:    pextrw $7, %xmm2, %ebx
-; CHECK-NEXT:    cmpw %bx, %dx
-; CHECK-NEXT:    cmovbel %ebx, %edx
-; CHECK-NEXT:    andl $7, %edx
+; CHECK-NEXT:    cmpw %bx, %si
+; CHECK-NEXT:    cmovbel %ebx, %esi
+; CHECK-NEXT:    andl $7, %esi
 ; CHECK-NEXT:    orl %r11d, %r10d
 ; CHECK-NEXT:    orl %r9d, %edi
 ; CHECK-NEXT:    orl %r10d, %edi
 ; CHECK-NEXT:    orl %r8d, %ecx
-; CHECK-NEXT:    orl %esi, %ecx
+; CHECK-NEXT:    orl %edx, %ecx
 ; CHECK-NEXT:    orl %edi, %ecx
 ; CHECK-NEXT:    orl %eax, %ecx
 ; CHECK-NEXT:    andb $1, %cl
 ; CHECK-NEXT:    xorl %eax, %eax
 ; CHECK-NEXT:    cmpb $1, %cl
 ; CHECK-NEXT:    sbbl %eax, %eax
-; CHECK-NEXT:    orl -32(%rsp,%rdx,4), %eax
+; CHECK-NEXT:    orl -32(%rsp,%rsi,4), %eax
 ; CHECK-NEXT:    popq %rbx
 ; CHECK-NEXT:    .cfi_def_cfa_offset 8
 ; CHECK-NEXT:    retq
@@ -171,10 +186,13 @@ define i32 @extract_last_active_v8i32(<8 x i32> %a, <8 x i1> %c) {
 define i32 @extract_last_active_v16i32(<16 x i32> %a, <16 x i1> %c) {
 ; CHECK-LABEL: extract_last_active_v16i32:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    movaps %xmm4, -{{[0-9]+}}(%rsp)
+; CHECK-NEXT:    movdqa %xmm4, -{{[0-9]+}}(%rsp)
+; CHECK-NEXT:    psllw $7, %xmm4
+; CHECK-NEXT:    pxor %xmm5, %xmm5
+; CHECK-NEXT:    pcmpgtb %xmm4, %xmm5
 ; CHECK-NEXT:    movzbl -{{[0-9]+}}(%rsp), %ecx
-; CHECK-NEXT:    andps {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm4
-; CHECK-NEXT:    movaps %xmm4, -{{[0-9]+}}(%rsp)
+; CHECK-NEXT:    pand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm5
+; CHECK-NEXT:    movdqa %xmm5, -{{[0-9]+}}(%rsp)
 ; CHECK-NEXT:    movaps %xmm3, -{{[0-9]+}}(%rsp)
 ; CHECK-NEXT:    movaps %xmm2, -{{[0-9]+}}(%rsp)
 ; CHECK-NEXT:    movaps %xmm1, -{{[0-9]+}}(%rsp)
@@ -253,20 +271,18 @@ define i32 @extract_last_active_v16i32(<16 x i32> %a, <16 x i1> %c) {
 define i32 @extract_last_active_v4i32_penryn(<4 x i32> %a, <4 x i1> %c) "target-cpu"="penryn" {
 ; CHECK-LABEL: extract_last_active_v4i32_penryn:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    movaps %xmm0, %xmm2
-; CHECK-NEXT:    xorps %xmm3, %xmm3
-; CHECK-NEXT:    movaps %xmm1, %xmm0
-; CHECK-NEXT:    blendvps %xmm0, {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm3
-; CHECK-NEXT:    extractps $2, %xmm3, %eax
-; CHECK-NEXT:    extractps $1, %xmm3, %ecx
+; CHECK-NEXT:    pslld $31, %xmm1
+; CHECK-NEXT:    psrad $31, %xmm1
+; CHECK-NEXT:    pand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm1
+; CHECK-NEXT:    pextrd $2, %xmm1, %eax
+; CHECK-NEXT:    pextrd $1, %xmm1, %ecx
 ; CHECK-NEXT:    cmpl %eax, %ecx
 ; CHECK-NEXT:    cmoval %ecx, %eax
-; CHECK-NEXT:    extractps $3, %xmm3, %ecx
+; CHECK-NEXT:    pextrd $3, %xmm1, %ecx
 ; CHECK-NEXT:    cmpl %ecx, %eax
 ; CHECK-NEXT:    cmovbel %ecx, %eax
-; CHECK-NEXT:    movaps %xmm2, -{{[0-9]+}}(%rsp)
-; CHECK-NEXT:    shll $2, %eax
-; CHECK-NEXT:    movl -24(%rsp,%rax), %eax
+; CHECK-NEXT:    movaps %xmm0, -{{[0-9]+}}(%rsp)
+; CHECK-NEXT:    movl -24(%rsp,%rax,4), %eax
 ; CHECK-NEXT:    retq
   %res = call i32 @llvm.experimental.vector.extract.last.active.v4i32(<4 x i32> %a, <4 x i1> %c, i32 poison)
   ret i32 %res


### PR DESCRIPTION
Before handling `VECTOR_FIND_LAST_ACTIVE` mask expansion, ensure vector mask's elements get extended accordingly, after the vector mask type is promoted to its legal one.

Directly favoured `getBooleanContents` over `GetPromotedInteger` w/ `PromoteTargetBoolean`, as should make the code clearer.

Fixes: https://github.com/llvm/llvm-project/issues/187875.