### PR TITLE
[llvm][ADT] Refactor PointerUnion to use PunnedPointer. NFC.

### DIFF
--- a/llvm/include/llvm/ADT/PointerUnion.h
+++ b/llvm/include/llvm/ADT/PointerUnion.h
@@ -28,63 +28,56 @@
 namespace llvm {
 
 namespace pointer_union_detail {
-  /// Determine the number of bits required to store integers with values < n.
-  /// This is ceil(log2(n)).
-  constexpr int bitsRequired(unsigned n) {
-    return n == 0 ? 0 : llvm::bit_width_constexpr(n - 1);
-  }
 
-  template <typename... Ts> constexpr int lowBitsAvailable() {
-    return std::min<int>({PointerLikeTypeTraits<Ts>::NumLowBitsAvailable...});
-  }
-
-  /// Provide PointerLikeTypeTraits for void* that is used by PointerUnion
-  /// for the template arguments.
-  template <typename ...PTs> class PointerUnionUIntTraits {
-  public:
-    static inline void *getAsVoidPointer(void *P) { return P; }
-    static inline void *getFromVoidPointer(void *P) { return P; }
-    static constexpr int NumLowBitsAvailable = lowBitsAvailable<PTs...>();
-  };
-
-  template <typename Derived, typename ValTy, int I, typename ...Types>
-  class PointerUnionMembers;
-
-  template <typename Derived, typename ValTy, int I>
-  class PointerUnionMembers<Derived, ValTy, I> {
-  protected:
-    ValTy Val;
-    PointerUnionMembers() = default;
-    PointerUnionMembers(ValTy Val) : Val(Val) {}
-
-    friend struct PointerLikeTypeTraits<Derived>;
-  };
-
-  template <typename Derived, typename ValTy, int I, typename Type,
-            typename ...Types>
-  class PointerUnionMembers<Derived, ValTy, I, Type, Types...>
-      : public PointerUnionMembers<Derived, ValTy, I + 1, Types...> {
-    using Base = PointerUnionMembers<Derived, ValTy, I + 1, Types...>;
-  public:
-    using Base::Base;
-    PointerUnionMembers() = default;
-    PointerUnionMembers(Type V)
-        : Base(ValTy(const_cast<void *>(
-                         PointerLikeTypeTraits<Type>::getAsVoidPointer(V)),
-                     I)) {}
-
-    using Base::operator=;
-    Derived &operator=(Type V) {
-      this->Val = ValTy(
-          const_cast<void *>(PointerLikeTypeTraits<Type>::getAsVoidPointer(V)),
-          I);
-      return static_cast<Derived &>(*this);
-    };
-  };
+/// Determine the number of bits required to store values in [0, NumValues).
+/// This is ceil(log2(NumValues)).
+constexpr int bitsRequired(unsigned NumValues) {
+  return NumValues == 0 ? 0 : llvm::bit_width_constexpr(NumValues - 1);
 }
 
+template <typename... Ts> constexpr int lowBitsAvailable() {
+  return std::min(
+      {static_cast<int>(PointerLikeTypeTraits<Ts>::NumLowBitsAvailable)...});
+}
+
+/// CRTP base that generates non-template constructors and assignment operators
+/// for each type in the union. Non-template constructors allow implicit
+/// conversions (derived-to-base, non-const-to-const).
+template <typename Derived, int Idx, typename... Types>
+class PointerUnionMembers;
+
+template <typename Derived, int Idx> class PointerUnionMembers<Derived, Idx> {
+protected:
+  detail::PunnedPointer<void *> Val;
+  PointerUnionMembers() : Val(uintptr_t(0)) {}
+
+  template <typename To, typename From, typename Enable>
+  friend struct ::llvm::CastInfo;
+  template <typename> friend struct ::llvm::PointerLikeTypeTraits;
+};
+
+template <typename Derived, int Idx, typename Type, typename... Types>
+class PointerUnionMembers<Derived, Idx, Type, Types...>
+    : public PointerUnionMembers<Derived, Idx + 1, Types...> {
+  using Base = PointerUnionMembers<Derived, Idx + 1, Types...>;
+
+public:
+  using Base::Base;
+  PointerUnionMembers() = default;
+
+  PointerUnionMembers(Type V) { this->Val = Derived::encode(V); }
+
+  using Base::operator=;
+  Derived &operator=(Type V) {
+    this->Val = Derived::encode(V);
+    return static_cast<Derived &>(*this);
+  }
+};
+
+} // end namespace pointer_union_detail
+
 /// A discriminated union of two or more pointer types, with the discriminator
-/// in the low bit of the pointer.
+/// in the low bits of the pointer.
 ///
 /// This implementation is extremely efficient in space due to leveraging the
 /// low bits of the pointer, while exposing a natural and type-safe API.
@@ -102,38 +95,65 @@ namespace pointer_union_detail {
 ///    PointerUnion<int*, int*> Q; // compile time failure.
 template <typename... PTs>
 class PointerUnion
-    : public pointer_union_detail::PointerUnionMembers<
-          PointerUnion<PTs...>,
-          PointerIntPair<
-              void *, pointer_union_detail::bitsRequired(sizeof...(PTs)), int,
-              pointer_union_detail::PointerUnionUIntTraits<PTs...>>,
-          0, PTs...> {
+    : public pointer_union_detail::PointerUnionMembers<PointerUnion<PTs...>, 0,
+                                                       PTs...> {
   static_assert(TypesAreDistinct<PTs...>::value,
                 "PointerUnion alternative types cannot be repeated");
-  // The first type is special because we want to directly cast a pointer to a
-  // default-initialized union to a pointer to the first type. But we don't
-  // want PointerUnion to be a 'template <typename First, typename ...Rest>'
-  // because it's much more convenient to have a name for the whole pack. So
-  // split off the first type here.
-  using First = TypeAtIndex<0, PTs...>;
-  using Base = typename PointerUnion::PointerUnionMembers;
 
-  // Give the CastInfo specialization below access to protected members.
-  //
-  // This makes all of CastInfo a friend, which is more than strictly
-  // necessary. It's a workaround for C++'s inability to friend a
-  // partial template specialization.
+  using Base = typename PointerUnion::PointerUnionMembers;
+  using First = TypeAtIndex<0, PTs...>;
+
+  template <typename, int, typename...>
+  friend class pointer_union_detail::PointerUnionMembers;
   template <typename To, typename From, typename Enable> friend struct CastInfo;
+  template <typename> friend struct PointerLikeTypeTraits;
+
+  // These are constexpr functions rather than static constexpr data members
+  // so that alignof() on potentially incomplete types is not evaluated at
+  // class-definition time.
+  static constexpr int numLowBitsAvailable() {
+    return pointer_union_detail::lowBitsAvailable<PTs...>();
+  }
+
+  static constexpr int tagBits() {
+    return pointer_union_detail::bitsRequired(sizeof...(PTs));
+  }
+
+  /// The tag is shifted to the high end of the available low bits so that
+  /// the lowest bits remain free for nesting in PointerIntPair or SmallPtrSet.
+  static constexpr int tagShift() { return numLowBitsAvailable() - tagBits(); }
+
+  static constexpr uintptr_t tagMask() {
+    return (uintptr_t(1) << tagBits()) - 1;
+  }
+
+  template <typename T> static uintptr_t encode(T V) {
+    constexpr int Shift = tagShift();
+    constexpr auto Tag = uintptr_t(FirstIndexOfType<T, PTs...>::value);
+    uintptr_t PtrInt = reinterpret_cast<uintptr_t>(
+        PointerLikeTypeTraits<T>::getAsVoidPointer(V));
+    assert((PtrInt & (tagMask() << Shift)) == 0 &&
+           "Pointer low bits collide with tag");
+    return PtrInt | (Tag << Shift);
+  }
 
 public:
   PointerUnion() = default;
-
   PointerUnion(std::nullptr_t) : PointerUnion() {}
   using Base::Base;
+  using Base::operator=;
+
+  /// Assignment from nullptr clears the union, resetting to the first type.
+  const PointerUnion &operator=(std::nullptr_t) {
+    this->Val = uintptr_t(0);
+    return *this;
+  }
 
   /// Test if the pointer held in the union is null, regardless of
   /// which type it is.
-  bool isNull() const { return !this->Val.getPointer(); }
+  bool isNull() const {
+    return (static_cast<uintptr_t>(this->Val.asInt()) >> numLowBitsAvailable()) == 0;
+  }
 
   explicit operator bool() const { return !isNull(); }
 
@@ -141,18 +161,14 @@ public:
   //        isa<T>, cast<T> and the llvm::dyn_cast<T>
 
   /// Test if the Union currently holds the type matching T.
-  template <typename T>
-  [[deprecated("Use isa instead")]]
-  inline bool is() const {
+  template <typename T> [[deprecated("Use isa instead")]] bool is() const {
     return isa<T>(*this);
   }
 
   /// Returns the value of the specified pointer type.
   ///
   /// If the specified pointer type is incorrect, assert.
-  template <typename T>
-  [[deprecated("Use cast instead")]]
-  inline T get() const {
+  template <typename T> [[deprecated("Use cast instead")]] T get() const {
     assert(isa<T>(*this) && "Invalid accessor called");
     return cast<T>(*this);
   }
@@ -172,61 +188,62 @@ public:
   /// If the union is set to the first pointer type get an address pointing to
   /// it.
   First *getAddrOfPtr1() {
+    static_assert(FirstIndexOfType<First, PTs...>::value == 0,
+                  "First type must have tag value 0 for getAddrOfPtr1");
     assert(isa<First>(*this) && "Val is not the first pointer");
+    // tag == 0 for first type, so asInt() is the raw pointer value.
     assert(
         PointerLikeTypeTraits<First>::getAsVoidPointer(cast<First>(*this)) ==
-            this->Val.getPointer() &&
+            reinterpret_cast<void *>(this->Val.asInt()) &&
         "Can't get the address because PointerLikeTypeTraits changes the ptr");
     return const_cast<First *>(
-        reinterpret_cast<const First *>(this->Val.getAddrOfPointer()));
+        reinterpret_cast<const First *>(this->Val.getPointerAddress()));
   }
 
-  /// Assignment from nullptr which just clears the union.
-  const PointerUnion &operator=(std::nullptr_t) {
-    this->Val.initWithPointer(nullptr);
-    return *this;
+  void *getOpaqueValue() const {
+    return reinterpret_cast<void *>(this->Val.asInt());
   }
 
-  /// Assignment from elements of the union.
-  using Base::operator=;
-
-  void *getOpaqueValue() const { return this->Val.getOpaqueValue(); }
   static inline PointerUnion getFromOpaqueValue(void *VP) {
     PointerUnion V;
-    V.Val = decltype(V.Val)::getFromOpaqueValue(VP);
+    V.Val = reinterpret_cast<intptr_t>(VP);
     return V;
+  }
+
+  friend bool operator==(PointerUnion lhs, PointerUnion rhs) {
+    return lhs.getOpaqueValue() == rhs.getOpaqueValue();
+  }
+
+  friend bool operator!=(PointerUnion lhs, PointerUnion rhs) {
+    return lhs.getOpaqueValue() != rhs.getOpaqueValue();
+  }
+
+  friend bool operator<(PointerUnion lhs, PointerUnion rhs) {
+    return lhs.getOpaqueValue() < rhs.getOpaqueValue();
   }
 };
 
-template <typename ...PTs>
-bool operator==(PointerUnion<PTs...> lhs, PointerUnion<PTs...> rhs) {
-  return lhs.getOpaqueValue() == rhs.getOpaqueValue();
-}
-
-template <typename ...PTs>
-bool operator!=(PointerUnion<PTs...> lhs, PointerUnion<PTs...> rhs) {
-  return lhs.getOpaqueValue() != rhs.getOpaqueValue();
-}
-
-template <typename ...PTs>
-bool operator<(PointerUnion<PTs...> lhs, PointerUnion<PTs...> rhs) {
-  return lhs.getOpaqueValue() < rhs.getOpaqueValue();
-}
-
-// Specialization of CastInfo for PointerUnion
+// Specialization of CastInfo for PointerUnion.
 template <typename To, typename... PTs>
 struct CastInfo<To, PointerUnion<PTs...>>
     : public DefaultDoCastIfPossible<To, PointerUnion<PTs...>,
                                      CastInfo<To, PointerUnion<PTs...>>> {
   using From = PointerUnion<PTs...>;
 
-  static inline bool isPossible(From &f) {
-    return f.Val.getInt() == FirstIndexOfType<To, PTs...>::value;
+  static inline bool isPossible(From &F) {
+    constexpr int Shift = From::tagShift();
+    constexpr auto Tag = uintptr_t(FirstIndexOfType<To, PTs...>::value);
+    auto V = reinterpret_cast<uintptr_t>(F.getOpaqueValue());
+    return ((V >> Shift) & From::tagMask()) == Tag;
   }
 
-  static To doCast(From &f) {
-    assert(isPossible(f) && "cast to an incompatible type!");
-    return PointerLikeTypeTraits<To>::getFromVoidPointer(f.Val.getPointer());
+  static To doCast(From &F) {
+    assert(isPossible(F) && "cast to an incompatible type!");
+    constexpr uintptr_t PtrMask =
+        ~((uintptr_t(1) << PointerLikeTypeTraits<To>::NumLowBitsAvailable) - 1);
+    void *Ptr = reinterpret_cast<void *>(
+        reinterpret_cast<uintptr_t>(F.getOpaqueValue()) & PtrMask);
+    return PointerLikeTypeTraits<To>::getFromVoidPointer(Ptr);
   }
 
   static inline To castFailed() { return To(); }
@@ -238,26 +255,27 @@ struct CastInfo<To, const PointerUnion<PTs...>>
                                           CastInfo<To, PointerUnion<PTs...>>> {
 };
 
-// Teach SmallPtrSet that PointerUnion is "basically a pointer", that has
-// # low bits available = min(PT1bits,PT2bits)-1.
-template <typename ...PTs>
-struct PointerLikeTypeTraits<PointerUnion<PTs...>> {
-  static inline void *getAsVoidPointer(const PointerUnion<PTs...> &P) {
+// Teach SmallPtrSet that PointerUnion is "basically a pointer".
+// Spare low bits below the tag are available for nesting.
+// This specialization is only instantiated when used (lazy), so
+// PointerLikeTypeTraits<PTs> / alignof() are not evaluated for
+// incomplete types.
+template <typename... PTs> struct PointerLikeTypeTraits<PointerUnion<PTs...>> {
+  using Union = PointerUnion<PTs...>;
+
+  static inline void *getAsVoidPointer(const Union &P) {
     return P.getOpaqueValue();
   }
 
-  static inline PointerUnion<PTs...> getFromVoidPointer(void *P) {
-    return PointerUnion<PTs...>::getFromOpaqueValue(P);
+  static inline Union getFromVoidPointer(void *P) {
+    return Union::getFromOpaqueValue(P);
   }
 
-  // The number of bits available are the min of the pointer types minus the
-  // bits needed for the discriminator.
-  static constexpr int NumLowBitsAvailable = PointerLikeTypeTraits<decltype(
-      PointerUnion<PTs...>::Val)>::NumLowBitsAvailable;
+  static constexpr int NumLowBitsAvailable = Union::tagShift();
 };
 
 // Teach DenseMap how to use PointerUnions as keys.
-template <typename ...PTs> struct DenseMapInfo<PointerUnion<PTs...>> {
+template <typename... PTs> struct DenseMapInfo<PointerUnion<PTs...>> {
   using Union = PointerUnion<PTs...>;
   using FirstInfo = DenseMapInfo<TypeAtIndex<0, PTs...>>;
 
@@ -268,8 +286,8 @@ template <typename ...PTs> struct DenseMapInfo<PointerUnion<PTs...>> {
   }
 
   static unsigned getHashValue(const Union &UnionVal) {
-    intptr_t key = (intptr_t)UnionVal.getOpaqueValue();
-    return DenseMapInfo<intptr_t>::getHashValue(key);
+    auto Key = reinterpret_cast<uintptr_t>(UnionVal.getOpaqueValue());
+    return DenseMapInfo<uintptr_t>::getHashValue(Key);
   }
 
   static bool isEqual(const Union &LHS, const Union &RHS) {

--- a/llvm/include/llvm/ADT/PointerUnion.h
+++ b/llvm/include/llvm/ADT/PointerUnion.h
@@ -111,7 +111,7 @@ class PointerUnion
   // These are constexpr functions rather than static constexpr data members
   // so that alignof() on potentially incomplete types is not evaluated at
   // class-definition time.
-  static constexpr int numLowBitsAvailable() {
+  static constexpr int minLowBitsAvailable() {
     return pointer_union_detail::lowBitsAvailable<PTs...>();
   }
 
@@ -121,7 +121,7 @@ class PointerUnion
 
   /// The tag is shifted to the high end of the available low bits so that
   /// the lowest bits remain free for nesting in PointerIntPair or SmallPtrSet.
-  static constexpr int tagShift() { return numLowBitsAvailable() - tagBits(); }
+  static constexpr int tagShift() { return minLowBitsAvailable() - tagBits(); }
 
   static constexpr uintptr_t tagMask() {
     return (uintptr_t(1) << tagBits()) - 1;
@@ -153,7 +153,7 @@ public:
   /// which type it is.
   bool isNull() const {
     return (static_cast<uintptr_t>(this->Val.asInt()) >>
-            numLowBitsAvailable()) == 0;
+            minLowBitsAvailable()) == 0;
   }
 
   explicit operator bool() const { return !isNull(); }
@@ -272,6 +272,8 @@ template <typename... PTs> struct PointerLikeTypeTraits<PointerUnion<PTs...>> {
     return Union::getFromOpaqueValue(P);
   }
 
+  // The number of bits available are the min of the pointer types minus the
+  // bits needed for the discriminator.
   static constexpr int NumLowBitsAvailable = Union::tagShift();
 };
 

--- a/llvm/include/llvm/ADT/PointerUnion.h
+++ b/llvm/include/llvm/ADT/PointerUnion.h
@@ -152,7 +152,8 @@ public:
   /// Test if the pointer held in the union is null, regardless of
   /// which type it is.
   bool isNull() const {
-    return (static_cast<uintptr_t>(this->Val.asInt()) >> numLowBitsAvailable()) == 0;
+    return (static_cast<uintptr_t>(this->Val.asInt()) >>
+            numLowBitsAvailable()) == 0;
   }
 
   explicit operator bool() const { return !isNull(); }


### PR DESCRIPTION
Replace `PointerIntPair`-based storage with raw `PunnedPointer<void*>` and explicit tag encoding. The bit layout stay identical. Use constexpr functions (`minBits`, `tagBits`, `tagShift`) whose bodies are only instantiated when called, for incomplete-type compatibility

The goal is to prepare `PointerUnion` for future extension to support variable-length encoding and allow for more variants than with simple tags, which will require direct bit manipulation not possible with `PointerIntPair`.

I benchmarked this with https://github.com/llvm/llvm-project/pull/187874 and the performance is identical on my system.