### PR TITLE
[Clang][Sema] Prevent implicit casting Complex type to Vector

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -358,6 +358,8 @@ Improvements to Clang's diagnostics
 - Improved ``-Wgnu-zero-variadic-macro-arguments`` to suggest using
   ``__VA_OPT__`` if the current language version supports it(#GH188624)
 
+- Clang now emits an error when implicitly casting a complex type to a built-in vector type. (#GH186805)
+
 Improvements to Clang's time-trace
 ----------------------------------
 

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -4501,6 +4501,8 @@ def warn_impcast_float_result_precision : Warning<
 def warn_impcast_double_promotion : Warning<
   "implicit conversion increases floating-point precision: %0 to %1">,
   InGroup<DoublePromotion>, DefaultIgnore;
+def err_impcast_incompatible_type : Error<
+  "implicit conversion from %0 to incompatible type %1">;
 def warn_impcast_integer_sign : Warning<
   "implicit conversion changes signedness: %0 to %1">,
   InGroup<SignConversion>, DefaultIgnore;

--- a/clang/lib/Sema/SemaChecking.cpp
+++ b/clang/lib/Sema/SemaChecking.cpp
@@ -13003,6 +13003,27 @@ void Sema::CheckImplicitConversion(Expr *E, QualType T, SourceLocation CC,
   else if (auto *DictionaryLiteral = dyn_cast<ObjCDictionaryLiteral>(E))
     ObjC().checkDictionaryLiteral(QualType(Target, 0), DictionaryLiteral);
 
+  // Strip complex types.
+  if (isa<ComplexType>(Source)) {
+    if (!isa<ComplexType>(Target)) {
+      if (SourceMgr.isInSystemMacro(CC) || Target->isBooleanType())
+        return;
+
+      if (!getLangOpts().CPlusPlus && Target->isVectorType()) {
+        return DiagnoseImpCast(*this, E, T, CC,
+                               diag::err_impcast_incompatible_type);
+      }
+
+      return DiagnoseImpCast(*this, E, T, CC,
+                             getLangOpts().CPlusPlus
+                                 ? diag::err_impcast_complex_scalar
+                                 : diag::warn_impcast_complex_scalar);
+    }
+
+    Source = cast<ComplexType>(Source)->getElementType().getTypePtr();
+    Target = cast<ComplexType>(Target)->getElementType().getTypePtr();
+  }
+
   // Strip vector types.
   if (isa<VectorType>(Source)) {
     if (Target->isSveVLSBuiltinType() &&
@@ -13064,27 +13085,6 @@ void Sema::CheckImplicitConversion(Expr *E, QualType T, SourceLocation CC,
   }
   if (const auto *MatTy = dyn_cast<ConstantMatrixType>(Target))
     Target = MatTy->getElementType().getTypePtr();
-
-  // Strip complex types.
-  if (isa<ComplexType>(Source)) {
-    if (!isa<ComplexType>(Target)) {
-      if (SourceMgr.isInSystemMacro(CC) || Target->isBooleanType())
-        return;
-
-      if (!getLangOpts().CPlusPlus && T->isVectorType()) {
-        return DiagnoseImpCast(*this, E, T, CC,
-                               diag::err_impcast_incompatible_type);
-      }
-
-      return DiagnoseImpCast(*this, E, T, CC,
-                             getLangOpts().CPlusPlus
-                                 ? diag::err_impcast_complex_scalar
-                                 : diag::warn_impcast_complex_scalar);
-    }
-
-    Source = cast<ComplexType>(Source)->getElementType().getTypePtr();
-    Target = cast<ComplexType>(Target)->getElementType().getTypePtr();
-  }
 
   const BuiltinType *SourceBT = dyn_cast<BuiltinType>(Source);
   const BuiltinType *TargetBT = dyn_cast<BuiltinType>(Target);

--- a/clang/lib/Sema/SemaChecking.cpp
+++ b/clang/lib/Sema/SemaChecking.cpp
@@ -13071,9 +13071,12 @@ void Sema::CheckImplicitConversion(Expr *E, QualType T, SourceLocation CC,
       if (SourceMgr.isInSystemMacro(CC) || Target->isBooleanType())
         return;
 
+      const Type *OriginalTargetTy = Context.getCanonicalType(T).getTypePtr();
       return DiagnoseImpCast(*this, E, T, CC,
                              getLangOpts().CPlusPlus
                                  ? diag::err_impcast_complex_scalar
+                             : OriginalTargetTy->isVectorType()
+                                 ? diag::err_impcast_incompatible_type
                                  : diag::warn_impcast_complex_scalar);
     }
 

--- a/clang/lib/Sema/SemaChecking.cpp
+++ b/clang/lib/Sema/SemaChecking.cpp
@@ -13071,12 +13071,14 @@ void Sema::CheckImplicitConversion(Expr *E, QualType T, SourceLocation CC,
       if (SourceMgr.isInSystemMacro(CC) || Target->isBooleanType())
         return;
 
-      const Type *OriginalTargetTy = Context.getCanonicalType(T).getTypePtr();
+      if (!getLangOpts().CPlusPlus && T->isVectorType()) {
+        return DiagnoseImpCast(*this, E, T, CC,
+                               diag::err_impcast_incompatible_type);
+      }
+
       return DiagnoseImpCast(*this, E, T, CC,
                              getLangOpts().CPlusPlus
                                  ? diag::err_impcast_complex_scalar
-                             : OriginalTargetTy->isVectorType()
-                                 ? diag::err_impcast_incompatible_type
                                  : diag::warn_impcast_complex_scalar);
     }
 

--- a/clang/test/Sema/implicit-cast-complex-to-vector.c
+++ b/clang/test/Sema/implicit-cast-complex-to-vector.c
@@ -1,0 +1,11 @@
+// RUN: %clang_cc1 -fsyntax-only -verify %s
+
+typedef char __attribute__((__vector_size__(64))) V;
+
+void implicit_cast_complex_to_vector() {
+  _Complex double x;
+  V y;
+  // expected-error@+1 {{implicit conversion from '_Complex double' to incompatible type 'V' (vector of 64 'char' values)}}
+  V z = x + y;
+}
+

--- a/clang/test/Sema/implicit-cast-complex-to-vector.c
+++ b/clang/test/Sema/implicit-cast-complex-to-vector.c
@@ -1,11 +1,13 @@
-// RUN: %clang_cc1 -fsyntax-only -verify %s
+// RUN: %clang_cc1 -fsyntax-only -verify=c %s
+// RUN: %clang_cc1 -x c++ -fsyntax-only -verify=cxx %s
 
 typedef char __attribute__((__vector_size__(64))) V;
 
 void implicit_cast_complex_to_vector() {
   _Complex double x;
   V y;
-  // expected-error@+1 {{implicit conversion from '_Complex double' to incompatible type 'V' (vector of 64 'char' values)}}
+  // c-error@+2 {{implicit conversion from '_Complex double' to incompatible type 'V' (vector of 64 'char' values)}}
+  // cxx-error@+1 {{implicit conversion from '_Complex double' to 'V' (vector of 64 'char' values) is not permitted in C++}}
   V z = x + y;
 }
 


### PR DESCRIPTION
Emitting an error message in case of implicit casting of a complex type to a built-in vector type in C

Fixes: #186805