### PR TITLE
[MLIR] [Python] A few minor fixes to type annotations

### DIFF
--- a/mlir/include/mlir/Bindings/Python/IRAttributes.h
+++ b/mlir/include/mlir/Bindings/Python/IRAttributes.h
@@ -342,7 +342,7 @@ public:
   static void bindDerived(ClassTy &c);
 
 private:
-  static nanobind::object toPyInt(PyIntegerAttribute &self);
+  static nanobind::int_ toPyInt(PyIntegerAttribute &self);
 };
 
 /// Bool Attribute subclass - BoolAttr.

--- a/mlir/include/mlir/Bindings/Python/IRCore.h
+++ b/mlir/include/mlir/Bindings/Python/IRCore.h
@@ -739,7 +739,7 @@ public:
 
   nanobind::object getOperationObject() { return operationObject; }
 
-  static nanobind::object
+  static nanobind::typed<nanobind::object, PyOperation>
   buildGeneric(std::string_view name, std::tuple<int, bool> opRegionSpec,
                nanobind::object operandSegmentSpecObj,
                nanobind::object resultSegmentSpecObj,

--- a/mlir/lib/Bindings/Python/IRAttributes.cpp
+++ b/mlir/lib/Bindings/Python/IRAttributes.cpp
@@ -426,7 +426,7 @@ void PyIntegerAttribute::bindDerived(ClassTy &c) {
   });
 }
 
-nb::object PyIntegerAttribute::toPyInt(PyIntegerAttribute &self) {
+nb::int_ PyIntegerAttribute::toPyInt(PyIntegerAttribute &self) {
   MlirType type = mlirAttributeGetType(self);
   unsigned bitWidth = mlirIntegerAttrGetValueBitWidth(self);
 
@@ -463,7 +463,7 @@ nb::object PyIntegerAttribute::toPyInt(PyIntegerAttribute &self) {
     }
   }
 
-  return result;
+  return nb::cast<nb::int_>(result);
 }
 
 void PyBoolAttribute::bindDerived(ClassTy &c) {

--- a/mlir/lib/Bindings/Python/IRCore.cpp
+++ b/mlir/lib/Bindings/Python/IRCore.cpp
@@ -1591,7 +1591,7 @@ static MlirValue getOpResultOrValue(nb::handle operand) {
   throw nb::value_error("is not a Value");
 }
 
-nb::object PyOpView::buildGeneric(
+nb::typed<nb::object, PyOperation> PyOpView::buildGeneric(
     std::string_view name, std::tuple<int, bool> opRegionSpec,
     nb::object operandSegmentSpecObj, nb::object resultSegmentSpecObj,
     std::optional<nb::list> resultTypeList, nb::list operandList,
@@ -4844,12 +4844,12 @@ void populateIRCore(nb::module_ &m) {
           "Returns the string form of value as an operand (i.e., the ValueID).")
       .def_prop_ro(
           "type",
-          [](PyValue &self) -> nb::typed<nb::object, PyType> {
+          [](PyValue &self) {
             return PyType(self.getParentOperation()->getContext(),
                           mlirValueGetType(self.get()))
                 .maybeDownCast();
           },
-          "Returns the type of the value.")
+          "Returns the type of the value.", nb::sig("def type(self) -> _T"))
       .def(
           "set_type",
           [](PyValue &self, const PyType &type) {


### PR DESCRIPTION
* ir.IntegerAttr.value is now an int
* ir.Value.type correctly returns a value of type _T
* ir.OpView.build_generic returns ir.Operation, which matches the implementation.