### PR TITLE
[TargetLowering] Avoid unnecessary nodes in the chunk loop in expandDIVREMByConstant

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/TargetLowering.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/TargetLowering.cpp
@@ -8298,9 +8298,9 @@ bool TargetLowering::expandDIVREMByConstant(SDNode *N,
                         DAG.getShiftAmountConstant(HBitWidth - I, HiLoVT, dl)));
       }
 
-      // For the last chunk, we might not need a mask if it's smaller than
-      // BestChunkWidth, but applying it is always safe.
-      Chunk = DAG.getNode(ISD::AND, dl, HiLoVT, Chunk, Mask);
+      // If we're on the last chunk, we don't need an AND.
+      if (I < BitWidth - BestChunkWidth)
+        Chunk = DAG.getNode(ISD::AND, dl, HiLoVT, Chunk, Mask);
       if (!Sum)
         Sum = Chunk;
       else

--- a/llvm/lib/CodeGen/SelectionDAG/TargetLowering.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/TargetLowering.cpp
@@ -8278,7 +8278,7 @@ bool TargetLowering::expandDIVREMByConstant(SDNode *N,
     SDValue Mask = DAG.getConstant(
         APInt::getLowBitsSet(HBitWidth, BestChunkWidth), dl, HiLoVT);
 
-    for (unsigned I = 0; I < BitWidth; I += BestChunkWidth) {
+    for (unsigned I = 0; I < BitWidth - TrailingZeros; I += BestChunkWidth) {
       SDValue Chunk;
       if (I == 0) {
         Chunk = LL;
@@ -8299,7 +8299,7 @@ bool TargetLowering::expandDIVREMByConstant(SDNode *N,
       }
 
       // If we're on the last chunk, we don't need an AND.
-      if (I + BestChunkWidth < BitWidth)
+      if (I + BestChunkWidth < BitWidth - TrailingZeros)
         Chunk = DAG.getNode(ISD::AND, dl, HiLoVT, Chunk, Mask);
       if (!Sum)
         Sum = Chunk;

--- a/llvm/lib/CodeGen/SelectionDAG/TargetLowering.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/TargetLowering.cpp
@@ -8299,7 +8299,7 @@ bool TargetLowering::expandDIVREMByConstant(SDNode *N,
       }
 
       // If we're on the last chunk, we don't need an AND.
-      if (I < BitWidth - BestChunkWidth)
+      if (I + BestChunkWidth < BitWidth)
         Chunk = DAG.getNode(ISD::AND, dl, HiLoVT, Chunk, Mask);
       if (!Sum)
         Sum = Chunk;


### PR DESCRIPTION
We don't need an AND on the last iteration. If we shifted the dividend due to trailing zeros in the divisor, we don't need a chunk that only contains shifted in zeros.