### PR TITLE
[clang][test] Add missing FileCheck pipe in ast-crash-doc-function-template.cpp

### DIFF
--- a/clang/test/AST/ast-crash-doc-function-template.cpp
+++ b/clang/test/AST/ast-crash-doc-function-template.cpp
@@ -1,7 +1,7 @@
 // RUN: rm -rf %t
 // RUN: split-file %s %t
 
-// RUN: %clang_cc1 -x c++ -Wdocumentation -ast-dump-all %t/t.cpp
+// RUN: %clang_cc1 -x c++ -Wdocumentation -ast-dump-all %t/t.cpp | FileCheck %s
 
 //--- t.h
 /// MyClass in the header file


### PR DESCRIPTION
The test had a CHECK directive that was never executed because the RUN line did not pipe output to FileCheck.