### PR TITLE
[lldb][Process/FreeBSDKernelCore] Fix thread ordering

### DIFF
--- a/lldb/source/Plugins/Process/FreeBSD-Kernel-Core/ProcessFreeBSDKernelCore.cpp
+++ b/lldb/source/Plugins/Process/FreeBSD-Kernel-Core/ProcessFreeBSDKernelCore.cpp
@@ -255,7 +255,7 @@ bool ProcessFreeBSDKernelCore::DoUpdateThreadList(ThreadList &old_thread_list,
     if (lldb::addr_t allproc_addr = FindSymbol("allproc");
         allproc_addr != LLDB_INVALID_ADDRESS) {
       for (lldb::addr_t proc = ReadPointerFromMemory(allproc_addr, error);
-           proc != 0 && proc != LLDB_INVALID_ADDRESS && error.Success();
+           error.Success() && proc != 0 && proc != LLDB_INVALID_ADDRESS;
            proc = ReadPointerFromMemory(proc + offset_p_list, error)) {
         int32_t pid =
             ReadSignedIntegerFromMemory(proc + offset_p_pid, 4, -1, error);
@@ -263,10 +263,9 @@ bool ProcessFreeBSDKernelCore::DoUpdateThreadList(ThreadList &old_thread_list,
           return false;
         process_addrs.emplace_back(proc, pid);
       }
-    }
-
-    if (error.Fail())
+    } else {
       return false;
+    }
 
     std::sort(process_addrs.begin(), process_addrs.end(),
               [](const std::pair<lldb::addr_t, int32_t> &a,

--- a/lldb/source/Plugins/Process/FreeBSD-Kernel-Core/ProcessFreeBSDKernelCore.cpp
+++ b/lldb/source/Plugins/Process/FreeBSD-Kernel-Core/ProcessFreeBSDKernelCore.cpp
@@ -247,10 +247,8 @@ bool ProcessFreeBSDKernelCore::DoUpdateThreadList(ThreadList &old_thread_list,
     // https://cgit.freebsd.org/src/tree/sys/sys/param.h
     constexpr size_t fbsd_maxcomlen = 19;
 
-    // Iterate through a linked list of all processes. New processes are added
-    // to the head of this list. Which means that earlier PIDs are actually at
-    // the end of the list, so we have to walk it backwards. First collect all
-    // the processes in the list order.
+    // Iterate through a linked list of all processes then order incrementally
+    // by pid.
     std::vector<lldb::addr_t> process_addrs;
     if (lldb::addr_t allproc_addr = FindSymbol("allproc");
         allproc_addr != LLDB_INVALID_ADDRESS) {
@@ -259,12 +257,17 @@ bool ProcessFreeBSDKernelCore::DoUpdateThreadList(ThreadList &old_thread_list,
            proc = ReadPointerFromMemory(proc + offset_p_list, error))
         process_addrs.push_back(proc);
     }
+    std::sort(process_addrs.begin(), process_addrs.end(),
+              [&](lldb::addr_t a, lldb::addr_t b) {
+                Status err;
+                int32_t pid_a =
+                    ReadSignedIntegerFromMemory(a + offset_p_pid, 4, -1, err);
+                int32_t pid_b =
+                    ReadSignedIntegerFromMemory(b + offset_p_pid, 4, -1, err);
+                return pid_a < pid_b;
+              });
 
-    // Processes are in the linked list in descending PID order, so we must walk
-    // them in reverse to get ascending PID order.
-    for (auto proc_it = process_addrs.rbegin(); proc_it != process_addrs.rend();
-         ++proc_it) {
-      lldb::addr_t proc = *proc_it;
+    for (lldb::addr_t proc : process_addrs) {
       int32_t pid =
           ReadSignedIntegerFromMemory(proc + offset_p_pid, 4, -1, error);
       // process' command-line string

--- a/lldb/source/Plugins/Process/FreeBSD-Kernel-Core/ProcessFreeBSDKernelCore.cpp
+++ b/lldb/source/Plugins/Process/FreeBSD-Kernel-Core/ProcessFreeBSDKernelCore.cpp
@@ -266,6 +266,9 @@ bool ProcessFreeBSDKernelCore::DoUpdateThreadList(ThreadList &old_thread_list,
       process_addrs.emplace_back(proc, pid);
     }
 
+    if (error.Fail())
+      return false;
+
     std::sort(process_addrs.begin(), process_addrs.end(),
               [](const auto &a, const auto &b) { return a.second < b.second; });
 

--- a/lldb/source/Plugins/Process/FreeBSD-Kernel-Core/ProcessFreeBSDKernelCore.cpp
+++ b/lldb/source/Plugins/Process/FreeBSD-Kernel-Core/ProcessFreeBSDKernelCore.cpp
@@ -248,28 +248,33 @@ bool ProcessFreeBSDKernelCore::DoUpdateThreadList(ThreadList &old_thread_list,
     constexpr size_t fbsd_maxcomlen = 19;
 
     // Iterate through a linked list of all processes then order incrementally
-    // by pid.
-    std::vector<lldb::addr_t> process_addrs;
+    // by pid. Though new processes are added to the head of this list, process
+    // ids may be reused as well. So we cannot rely on it being in a particular
+    // order.
+    std::vector<std::pair<lldb::addr_t, int32_t>> process_addrs;
     if (lldb::addr_t allproc_addr = FindSymbol("allproc");
         allproc_addr != LLDB_INVALID_ADDRESS) {
       for (lldb::addr_t proc = ReadPointerFromMemory(allproc_addr, error);
            proc != 0 && proc != LLDB_INVALID_ADDRESS && error.Success();
-           proc = ReadPointerFromMemory(proc + offset_p_list, error))
-        process_addrs.push_back(proc);
+           proc = ReadPointerFromMemory(proc + offset_p_list, error)) {
+        int32_t pid =
+            ReadSignedIntegerFromMemory(proc + offset_p_pid, 4, -1, error);
+        if (error.Fail())
+          return false;
+        process_addrs.emplace_back(proc, pid);
+      }
     }
+
+    if (error.Fail())
+      return false;
+
     std::sort(process_addrs.begin(), process_addrs.end(),
-              [&](lldb::addr_t a, lldb::addr_t b) {
-                Status err;
-                int32_t pid_a =
-                    ReadSignedIntegerFromMemory(a + offset_p_pid, 4, -1, err);
-                int32_t pid_b =
-                    ReadSignedIntegerFromMemory(b + offset_p_pid, 4, -1, err);
-                return pid_a < pid_b;
+              [](const std::pair<lldb::addr_t, int32_t> &a,
+                 const std::pair<lldb::addr_t, int32_t> &b) {
+                return a.second < b.second;
               });
 
-    for (lldb::addr_t proc : process_addrs) {
-      int32_t pid =
-          ReadSignedIntegerFromMemory(proc + offset_p_pid, 4, -1, error);
+    for (auto [proc, pid] : process_addrs) {
       // process' command-line string
       char comm[fbsd_maxcomlen + 1];
       ReadCStringFromMemory(proc + offset_p_comm, comm, sizeof(comm), error);

--- a/lldb/source/Plugins/Process/FreeBSD-Kernel-Core/ProcessFreeBSDKernelCore.cpp
+++ b/lldb/source/Plugins/Process/FreeBSD-Kernel-Core/ProcessFreeBSDKernelCore.cpp
@@ -251,27 +251,23 @@ bool ProcessFreeBSDKernelCore::DoUpdateThreadList(ThreadList &old_thread_list,
     // by pid. Though new processes are added to the head of this list, process
     // ids may be reused as well. So we cannot rely on it being in a particular
     // order.
-    std::vector<std::pair<lldb::addr_t, int32_t>> process_addrs;
-    if (lldb::addr_t allproc_addr = FindSymbol("allproc");
-        allproc_addr != LLDB_INVALID_ADDRESS) {
-      for (lldb::addr_t proc = ReadPointerFromMemory(allproc_addr, error);
-           error.Success() && proc != 0 && proc != LLDB_INVALID_ADDRESS;
-           proc = ReadPointerFromMemory(proc + offset_p_list, error)) {
-        int32_t pid =
-            ReadSignedIntegerFromMemory(proc + offset_p_pid, 4, -1, error);
-        if (error.Fail())
-          return false;
-        process_addrs.emplace_back(proc, pid);
-      }
-    } else {
+    const lldb::addr_t allproc_addr = FindSymbol("allproc");
+    if (allproc_addr == LLDB_INVALID_ADDRESS)
       return false;
+
+    std::vector<std::pair<lldb::addr_t, int32_t>> process_addrs;
+    for (lldb::addr_t proc = ReadPointerFromMemory(allproc_addr, error);
+         error.Success() && proc != 0 && proc != LLDB_INVALID_ADDRESS;
+         proc = ReadPointerFromMemory(proc + offset_p_list, error)) {
+      int32_t pid =
+          ReadSignedIntegerFromMemory(proc + offset_p_pid, 4, -1, error);
+      if (error.Fail())
+        return false;
+      process_addrs.emplace_back(proc, pid);
     }
 
     std::sort(process_addrs.begin(), process_addrs.end(),
-              [](const std::pair<lldb::addr_t, int32_t> &a,
-                 const std::pair<lldb::addr_t, int32_t> &b) {
-                return a.second < b.second;
-              });
+              [](const auto &a, const auto &b) { return a.second < b.second; });
 
     for (auto [proc, pid] : process_addrs) {
       // process' command-line string


### PR DESCRIPTION
In #178306, I made an incorrect assumption that traversing `allproc` in reverse direction would give incremental pid order based on the fact that new processes are added at the head of allproc. However, this assumption is false under certain circumstance such as reusing pid number, thus failing to sort threads correctly. Without using any assumption, explicitly sort threads based on pid retrieved from memory.

Fixes: 5349c664fabd49f88c87e31bb3774f40bf938691 (#178306)