### PR TITLE
[lldb][Process/FreeBSDKernelCore] Remove interactive mode check

### DIFF
--- a/lldb/source/Plugins/Process/FreeBSD-Kernel-Core/ProcessFreeBSDKernelCore.cpp
+++ b/lldb/source/Plugins/Process/FreeBSD-Kernel-Core/ProcessFreeBSDKernelCore.cpp
@@ -394,9 +394,6 @@ void ProcessFreeBSDKernelCore::PrintUnreadMessage() {
   Target &target = GetTarget();
   Debugger &debugger = target.GetDebugger();
 
-  if (!debugger.GetCommandInterpreter().IsInteractive())
-    return;
-
   Status error;
 
   // Find msgbufp symbol (pointer to message buffer)


### PR DESCRIPTION
`debugger.GetCommandInterpreter().IsInteractive()` doesn't necessarily mean that the debugger is running without `-b` or `--batch` flag. This caused an issue where the message isn't printed in any case. Remove the check so the message is always printed for now.

Fixes: 9d9c7fc00bdddd72e78b19e9fbb6af9d07c2218b (#178027)