### PR TITLE
[clang] Fix DirectoryWatcher test to check for platform headers

### DIFF
--- a/clang/unittests/DirectoryWatcher/CMakeLists.txt
+++ b/clang/unittests/DirectoryWatcher/CMakeLists.txt
@@ -1,4 +1,15 @@
-if(APPLE OR CMAKE_SYSTEM_NAME MATCHES "Linux" OR CMAKE_SYSTEM_NAME STREQUAL Windows)
+include(CheckIncludeFiles)
+
+if(APPLE)
+  check_include_files("CoreServices/CoreServices.h" HAVE_CORESERVICES)
+endif()
+if(CMAKE_SYSTEM_NAME MATCHES "Linux")
+  check_include_files("sys/inotify.h" HAVE_INOTIFY)
+endif()
+
+if((APPLE AND HAVE_CORESERVICES) OR
+   (CMAKE_SYSTEM_NAME MATCHES "Linux" AND HAVE_INOTIFY) OR
+   CMAKE_SYSTEM_NAME MATCHES "Windows")
 
   add_clang_unittest(DirectoryWatcherTests
     DirectoryWatcherTest.cpp


### PR DESCRIPTION
The unit test was guarded only by platform checks (Apple/Linux/Windows) but the library itself additionally requires CoreServices.h on macOS and sys/inotify.h on Linux. Without these header checks, the test could be built against a non-functional DirectoryWatcher backend.

Align the test's build conditions with the library's header availability checks in clang/lib/DirectoryWatcher/CMakeLists.txt.