### PR TITLE
[InstSimplify][InstCombine] Handle nsz in fabs(fneg x) (llvm#151303)

### DIFF
--- a/llvm/lib/Analysis/InstructionSimplify.cpp
+++ b/llvm/lib/Analysis/InstructionSimplify.cpp
@@ -6538,6 +6538,12 @@ static Value *simplifyUnaryIntrinsic(Function *F, Value *Op0,
   switch (IID) {
   case Intrinsic::fabs: {
     KnownFPClass KnownClass = computeKnownFPClass(Op0, fcAllFlags, Q);
+
+    // If Op0 has the flag nsz, do not simplify
+    if (Instruction *I = dyn_cast<Instruction>(Op0))
+      if (I->hasNoSignedZeros())
+        break;
+
     if (KnownClass.SignBit == false)
       return Op0;
 

--- a/llvm/lib/Transforms/InstCombine/InstCombineCalls.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCalls.cpp
@@ -3115,6 +3115,14 @@ Instruction *InstCombinerImpl::visitCallInst(CallInst &CI) {
     Value *Cond, *TVal, *FVal;
     Value *Arg = II->getArgOperand(0);
     Value *X;
+
+    // If instruction is fneg and has nsz flag, remove it
+    if (Instruction *I = dyn_cast<Instruction>(Arg))
+      if (I->hasNoSignedZeros() && I->getOpcode() == Instruction::FNeg) {
+        I->setHasNoSignedZeros(false);
+        return &CI;
+      }
+
     // fabs (-X) --> fabs (X)
     if (match(Arg, m_FNeg(m_Value(X)))) {
         CallInst *Fabs = Builder.CreateUnaryIntrinsic(Intrinsic::fabs, X, II);

--- a/llvm/test/Transforms/InstCombine/fabs.ll
+++ b/llvm/test/Transforms/InstCombine/fabs.ll
@@ -1826,3 +1826,19 @@ define i1 @test_fabs_used_is_fpclass_pzero(float %x) {
   %is_fpclass = call i1 @llvm.is.fpclass.f32(float %sel, i32 64)
   ret i1 %is_fpclass
 }
+
+define float @fabs_fneg_nsz_assume_neg(float %a) {
+; CHECK-LABEL: @fabs_fneg_nsz_assume_neg(
+; CHECK-NEXT:    [[I32:%.*]] = bitcast float [[A:%.*]] to i32
+; CHECK-NEXT:    [[CMP:%.*]] = icmp slt i32 [[I32]], 0
+; CHECK-NEXT:    call void @llvm.assume(i1 [[CMP]])
+; CHECK-NEXT:    [[B:%.*]] = fneg float [[A]]
+; CHECK-NEXT:    ret float [[B]]
+;
+  %i32 = bitcast float %a to i32
+  %cmp = icmp slt i32 %i32, 0
+  call void @llvm.assume(i1 %cmp)
+  %b = fneg nsz float %a
+  %c = call float @llvm.fabs.f32(float %b)
+  ret float %c
+}

--- a/llvm/test/Transforms/InstCombine/fast-math.ll
+++ b/llvm/test/Transforms/InstCombine/fast-math.ll
@@ -742,7 +742,8 @@ define double @sqrt_intrinsic_not_so_fast(double %x, double %y) {
 define double @sqrt_intrinsic_arg_4th(double noundef %x) {
 ; CHECK-LABEL: @sqrt_intrinsic_arg_4th(
 ; CHECK-NEXT:    [[MUL:%.*]] = fmul fast double [[X:%.*]], [[X]]
-; CHECK-NEXT:    ret double [[MUL]]
+; CHECK-NEXT:    [[FABS:%.*]] = call fast double @llvm.fabs.f64(double [[MUL]])
+; CHECK-NEXT:    ret double [[FABS]]
 ;
   %mul = fmul fast double %x, %x
   %mul2 = fmul fast double %mul, %mul

--- a/llvm/test/Transforms/InstSimplify/floating-point-arithmetic-strictfp.ll
+++ b/llvm/test/Transforms/InstSimplify/floating-point-arithmetic-strictfp.ll
@@ -252,10 +252,11 @@ define float @fabs_sqrt_nsz(float %a) #0 {
 define float @fabs_sqrt_nnan_nsz(float %a) #0 {
 ; CHECK-LABEL: @fabs_sqrt_nnan_nsz(
 ; CHECK-NEXT:    [[SQRT:%.*]] = call nnan nsz float @llvm.experimental.constrained.sqrt.f32(float [[A:%.*]], metadata !"round.tonearest", metadata !"fpexcept.ignore")
-; CHECK-NEXT:    ret float [[SQRT]]
+; CHECK-NEXT:    [[FABS:%.*]] = call float @llvm.fabs.f32(float [[SQRT]])
+; CHECK-NEXT:    ret float [[FABS]]
 ;
   %sqrt = call nnan nsz float @llvm.experimental.constrained.sqrt.f32(float %a, metadata !"round.tonearest", metadata !"fpexcept.ignore")
-  %fabs = call float @llvm.fabs.f32(float %sqrt) #0
+  %fabs = call float @llvm.fabs.f32(float %sqrt)
   ret float %fabs
 }
 

--- a/llvm/test/Transforms/InstSimplify/floating-point-arithmetic.ll
+++ b/llvm/test/Transforms/InstSimplify/floating-point-arithmetic.ll
@@ -640,11 +640,12 @@ define float @fabs_sqrt_nsz(float %a) {
   ret float %fabs
 }
 
-; The fabs can be eliminated because we're nsz and nnan.
+; The fabs cannot be eliminated because sqrt nsz may return -0.0.
 define float @fabs_sqrt_nnan_nsz(float %a) {
 ; CHECK-LABEL: @fabs_sqrt_nnan_nsz(
 ; CHECK-NEXT:    [[SQRT:%.*]] = call nnan nsz float @llvm.sqrt.f32(float [[A:%.*]])
-; CHECK-NEXT:    ret float [[SQRT]]
+; CHECK-NEXT:    [[FABS:%.*]] = call float @llvm.fabs.f32(float [[SQRT]])
+; CHECK-NEXT:    ret float [[FABS]]
 ;
   %sqrt = call nnan nsz float @llvm.sqrt.f32(float %a)
   %fabs = call float @llvm.fabs.f32(float %sqrt)


### PR DESCRIPTION
When InstCombine encounters fabs(fneg nsz x), it eliminates the fabs instruction under the assumption that the result is always positive. However, this transformation is incorrect, as it allows -0.0 to appear in the output, which Alive2 identifies as an invalid optimization (https://alive2.llvm.org/ce/z/FmBrma).

In InstSimplify, within simplifyUnaryIntrinsic for the Intrinsic::fabs case, skip simplification when Op0 carries the nsz (no-signed-zero) flag. Because nsz allows the sign bit to be unspecified, the sign cannot be reliably determined.

In InstCombine, within InstCombinerImpl::visitCallInst for the Intrinsic::fabs case, when Arg is an fneg instruction that carries nsz, strip the flag and requeue the instruction rather than simplifying immediately.

The affected tests previously permitted -0.0 to flow through after simplification, which is wrong. Fabs must always produce a non-negative result.

Alive2 proof: https://alive2.llvm.org/ce/z/zrszzo

Fixes #151303