### PR TITLE
[SCCP] Relax 2-insts range check to one-icmp check

### DIFF
--- a/llvm/lib/Transforms/Utils/SCCPSolver.cpp
+++ b/llvm/lib/Transforms/Utils/SCCPSolver.cpp
@@ -146,15 +146,18 @@ static ConstantRange simplifyCmpRange(const ConstantRange &CmpCR,
       /*sge*/ CmpHi.isMinSignedValue())
     return *ActCmpCR;
 
-  // If KnownCR is both nuw and nsw, we cannot relax CmpCR at all.
-  if (KnownCR.isWrappedSet() && KnownCR.isSignWrappedSet())
-    return CmpCR;
-
   const APInt Zero = APInt::getZero(BW);
   const APInt SignMin = APInt::getSignedMinValue(BW);
 
   if (CmpLo == KnownCR.getLower()) {
     // Tie to lower:
+
+    // Try ne
+    //    L------------R   : KnownCR
+    //    L-----------R    : ActiveCmpCR
+    // ---------------RL-- : RelaxedCmpCR
+    if (CmpHi + 1 == KnownCR.getUpper())
+      return ConstantRange::getNonEmpty(KnownCR.getUpper(), CmpHi);
 
     // Try ult
     // 0
@@ -174,6 +177,14 @@ static ConstantRange simplifyCmpRange(const ConstantRange &CmpCR,
 
   } else if (CmpHi == KnownCR.getUpper()) {
     // Tie to upper:
+
+    // Try ne
+    //
+    //    L--------R       : KnownCR
+    //     L-------R       : ActiveCmpCR
+    // ---RL-------------- : RelaxedCmpCR
+    if (KnownCR.getLower() + 1 == CmpLo)
+      return ConstantRange::getNonEmpty(CmpLo, KnownCR.getLower());
 
     // Try uge
     // 0

--- a/llvm/lib/Transforms/Utils/SCCPSolver.cpp
+++ b/llvm/lib/Transforms/Utils/SCCPSolver.cpp
@@ -134,13 +134,29 @@ static ConstantRange simplifyCmpRange(const ConstantRange &CmpCR,
   std::optional<ConstantRange> ActCmpCR = CmpCR.exactIntersectWith(KnownCR);
   if (!ActCmpCR)
     return CmpCR;
+  // Proof of ActCmpCR cannot be ne:
+  // 1. ActCmpCR = ne ∧ ActCmpCR ⊆ KnownCR -> KnownCR = ActCmpCR/fullset
+  // 2. KnownCR = fullset contradicts KnownCR != fullset
+  // 3. KnownCR = ActCmpCR = KnownCR ∩ CmpCR -> KnownCR ⊆ CmpCR
+  // 4. KnownCR ⊆ CmpCR contradicts KnownCR ⊈ CmpCR
+  assert(/*ne*/ !ActCmpCR->inverse().isSingleElement() && "Unexpected ne");
+
+  // We prefer eq rather than ne.
+  if (/*eq*/ ActCmpCR->isSingleElement())
+    return *ActCmpCR;
+
+  // We prefer ne rather than lt/ge.
+  //    L--------R       : KnownCR       or    L------------R   : KnownCR
+  //     L-------R       : ActiveCmpCR         L-----------R    : ActiveCmpCR
+  // ---RL-------------- : RelaxedCmpCR     ---------------RL-- : RelaxedCmpCR
+  if (const ConstantRange FalseCR = KnownCR.intersectWith(ActCmpCR->inverse());
+      FalseCR.isSingleElement())
+    return FalseCR.inverse();
 
   const APInt &CmpLo = ActCmpCR->getLower(), &CmpHi = ActCmpCR->getUpper();
 
   // If the intersection happens to be the ONE-icmp check, just return it.
-  if (/*eq*/ ActCmpCR->isSingleElement() ||
-      /*ne*/ ActCmpCR->inverse().isSingleElement() ||
-      /*ult*/ CmpLo.isZero() ||
+  if (/*ult*/ CmpLo.isZero() ||
       /*slt*/ CmpLo.isMinSignedValue() ||
       /*uge*/ CmpHi.isZero() ||
       /*sge*/ CmpHi.isMinSignedValue())
@@ -152,14 +168,7 @@ static ConstantRange simplifyCmpRange(const ConstantRange &CmpCR,
   if (CmpLo == KnownCR.getLower()) {
     // Tie to lower:
 
-    // Try ne
-    //    L------------R   : KnownCR
-    //    L-----------R    : ActiveCmpCR
-    // ---------------RL-- : RelaxedCmpCR
-    if (CmpHi + 1 == KnownCR.getUpper())
-      return ConstantRange::getNonEmpty(KnownCR.getUpper(), CmpHi);
-
-    // Try ult
+    // Try ult.
     // 0
     // |  L------------R   : KnownCR
     // |  L---R            : ActiveCmpCR
@@ -167,7 +176,7 @@ static ConstantRange simplifyCmpRange(const ConstantRange &CmpCR,
     if (!KnownCR.isWrappedSet())
       return ConstantRange::getNonEmpty(Zero, CmpHi);
 
-    // Try slt
+    // Try slt.
     //       smin                                 smin
     // -----R  |  L------- : KnownCR        ----R   |  L------- : KnownCR
     //         |  L--R     : ActiveCmpCR    --R     |  L------- : ActiveCmpCR
@@ -178,15 +187,7 @@ static ConstantRange simplifyCmpRange(const ConstantRange &CmpCR,
   } else if (CmpHi == KnownCR.getUpper()) {
     // Tie to upper:
 
-    // Try ne
-    //
-    //    L--------R       : KnownCR
-    //     L-------R       : ActiveCmpCR
-    // ---RL-------------- : RelaxedCmpCR
-    if (KnownCR.getLower() + 1 == CmpLo)
-      return ConstantRange::getNonEmpty(CmpLo, KnownCR.getLower());
-
-    // Try uge
+    // Try uge.
     // 0
     // |  L--------R       : KnownCR
     // |       L---R       : ActiveCmpCR
@@ -194,7 +195,7 @@ static ConstantRange simplifyCmpRange(const ConstantRange &CmpCR,
     if (!KnownCR.isWrappedSet())
       return ConstantRange::getNonEmpty(CmpLo, Zero);
 
-    // Try sge
+    // Try sge.
     //       smin                                 smin
     // -----R  |  L------- : KnownCR        -----R  |  L------- : KnownCR
     //   L--R  |           : ActiveCmpCR    -----R  |      L--- : ActiveCmpCR

--- a/llvm/lib/Transforms/Utils/SCCPSolver.cpp
+++ b/llvm/lib/Transforms/Utils/SCCPSolver.cpp
@@ -126,10 +126,6 @@ static ConstantRange simplifyCmpRange(const ConstantRange &CmpCR,
   assert((!KnownCR.isFullSet() && !KnownCR.isEmptySet()) &&
          "Unexpected KnownCR");
 
-  // If KnownCR is both nuw and nsw, we cannot relax CmpCR at all.
-  if (KnownCR.isWrappedSet() && KnownCR.isSignWrappedSet())
-    return CmpCR;
-
   const unsigned BW = CmpCR.getBitWidth();
   // All reachable value satisfy CmpCR --> always true.
   if (CmpCR.contains(KnownCR))
@@ -149,6 +145,10 @@ static ConstantRange simplifyCmpRange(const ConstantRange &CmpCR,
       /*uge*/ CmpHi.isZero() ||
       /*sge*/ CmpHi.isMinSignedValue())
     return *ActCmpCR;
+
+  // If KnownCR is both nuw and nsw, we cannot relax CmpCR at all.
+  if (KnownCR.isWrappedSet() && KnownCR.isSignWrappedSet())
+    return CmpCR;
 
   const APInt Zero = APInt::getZero(BW);
   const APInt SignMin = APInt::getSignedMinValue(BW);

--- a/llvm/lib/Transforms/Utils/SCCPSolver.cpp
+++ b/llvm/lib/Transforms/Utils/SCCPSolver.cpp
@@ -120,8 +120,11 @@ static ConstantRange getRange(Value *Op, SCCPSolver &Solver,
 /// If no such range preserves the active semantics under KnownCR, keep CmpCR.
 static ConstantRange simplifyCmpRange(const ConstantRange &CmpCR,
                                       const ConstantRange &KnownCR) {
-  assert((!CmpCR.isFullSet() && !CmpCR.isEmptySet()) && "Unexpected CmpCR");
   assert(!KnownCR.isEmptySet() && "Unexpected KnownCR");
+
+  // Empty and full ranges already lower to a single icmp.
+  if (CmpCR.isEmptySet() || CmpCR.isFullSet())
+    return CmpCR;
 
   // If KnownCR is full, bail out early.
   if (KnownCR.isFullSet())

--- a/llvm/lib/Transforms/Utils/SCCPSolver.cpp
+++ b/llvm/lib/Transforms/Utils/SCCPSolver.cpp
@@ -13,7 +13,6 @@
 //===----------------------------------------------------------------------===//
 
 #include "llvm/Transforms/Utils/SCCPSolver.h"
-#include "llvm/ADT/APInt.h"
 #include "llvm/ADT/SetVector.h"
 #include "llvm/Analysis/ConstantFolding.h"
 #include "llvm/Analysis/InstructionSimplify.h"
@@ -417,10 +416,8 @@ static Value *simplifyInstruction(SCCPSolver &Solver,
 
       ICmpInst::Predicate Pred;
       APInt RHS;
-      // If NewCmpCR is just the same as CR, no simplification happens.
-      if (NewCmpCR != *CR) {
-        bool Match [[maybe_unused]] = NewCmpCR.getEquivalentICmp(Pred, RHS);
-        assert(Match && "Incorrect simplifyCmpRange");
+      // NewCmpCR might be CmpCR, i.e., no simplification happens.
+      if (NewCmpCR.getEquivalentICmp(Pred, RHS)) {
         IRBuilder<NoFolder> Builder(&Inst);
         Value *NewICmp =
             Builder.CreateICmp(Pred, X, ConstantInt::get(X->getType(), RHS));

--- a/llvm/lib/Transforms/Utils/SCCPSolver.cpp
+++ b/llvm/lib/Transforms/Utils/SCCPSolver.cpp
@@ -13,6 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "llvm/Transforms/Utils/SCCPSolver.h"
+#include "llvm/ADT/APInt.h"
 #include "llvm/ADT/SetVector.h"
 #include "llvm/Analysis/ConstantFolding.h"
 #include "llvm/Analysis/InstructionSimplify.h"
@@ -103,6 +104,96 @@ static ConstantRange getRange(Value *Op, SCCPSolver &Solver,
   }
   return Solver.getLatticeValueFor(Op).asConstantRange(Op->getType(),
                                                        /*UndefAllowed=*/false);
+}
+
+/// SCCP already proves x \in KnownCR, so only ActiveCmpCR = CmpCR ∩ KnownCR
+/// matters. Try to replace CmpCR with a simpler equivalent range NewCmpCR
+/// such that NewCmpCR ∩ KnownCR == ActiveCmpCR.
+///
+/// Prefer ranges that lower to a single canonical compare without an add:
+///   - [L, L+1)      --> X  eq L
+///   - [R+1, R)      --> X  ne R
+///   - [0, R)        --> X ult R
+///   - [L, 0)        --> X uge L
+///   - [SignMin, R)  --> X slt R
+///   - [L, SignMin)  --> X sge L
+///
+/// If no such range preserves the active semantics under KnownCR, keep CmpCR.
+static ConstantRange simplifyCmpRange(const ConstantRange &CmpCR,
+                                      const ConstantRange &KnownCR) {
+  assert(!KnownCR.inverse().contains(CmpCR) &&
+         "CmpCR ∩ KnowCR should not be ∅");
+  assert((!CmpCR.isFullSet() && !CmpCR.isEmptySet()) && "Unexpected CmpCR");
+  assert((!KnownCR.isFullSet() && !KnownCR.isEmptySet()) &&
+         "Unexpected KnownCR");
+
+  // If KnownCR is both nuw and nsw, we cannot relax CmpCR at all.
+  if (KnownCR.isWrappedSet() && KnownCR.isSignWrappedSet())
+    return CmpCR;
+
+  const unsigned BW = CmpCR.getBitWidth();
+  // All reachable value satisfy CmpCR --> always true.
+  if (CmpCR.contains(KnownCR))
+    return ConstantRange::getFull(BW);
+
+  std::optional<ConstantRange> ActCmpCR = CmpCR.exactIntersectWith(KnownCR);
+  if (!ActCmpCR)
+    return CmpCR;
+
+  const APInt &CmpLo = ActCmpCR->getLower(), &CmpHi = ActCmpCR->getUpper();
+
+  // If the intersection happens to be the ONE-icmp check, just return it.
+  if (/*eq*/ ActCmpCR->isSingleElement() ||
+      /*ne*/ ActCmpCR->inverse().isSingleElement() ||
+      /*ult*/ CmpLo.isZero() ||
+      /*slt*/ CmpLo.isMinSignedValue() ||
+      /*uge*/ CmpHi.isZero() ||
+      /*sge*/ CmpHi.isMinSignedValue())
+    return *ActCmpCR;
+
+  const APInt Zero = APInt::getZero(BW);
+  const APInt SignMin = APInt::getSignedMinValue(BW);
+
+  if (CmpLo == KnownCR.getLower()) {
+    // Tie to lower:
+
+    // Try ult
+    // 0
+    // |  L------------R   : KnownCR
+    // |  L---R            : ActiveCmpCR
+    // L------R            : RelaxedCmpCR
+    if (!KnownCR.isWrappedSet())
+      return ConstantRange::getNonEmpty(Zero, CmpHi);
+
+    // Try slt
+    //       smin                                 smin
+    // -----R  |  L------- : KnownCR        ----R   |  L------- : KnownCR
+    //         |  L--R     : ActiveCmpCR    --R     |  L------- : ActiveCmpCR
+    //         L-----R     : RelaxedCmpCR   --R     L---------- : RelaxedCmpCR
+    if (!KnownCR.isSignWrappedSet())
+      return ConstantRange::getNonEmpty(SignMin, CmpHi);
+
+  } else if (CmpHi == KnownCR.getUpper()) {
+    // Tie to upper:
+
+    // Try uge
+    // 0
+    // |  L--------R       : KnownCR
+    // |       L---R       : ActiveCmpCR
+    // R       L---------- : RelaxedCmpCR
+    if (!KnownCR.isWrappedSet())
+      return ConstantRange::getNonEmpty(CmpLo, Zero);
+
+    // Try sge
+    //       smin                                 smin
+    // -----R  |  L------- : KnownCR        -----R  |  L------- : KnownCR
+    //   L--R  |           : ActiveCmpCR    -----R  |      L--- : ActiveCmpCR
+    //   L-----R           : RelaxedCmpCR   --------R      L--- : RelaxedCmpCR
+    if (!KnownCR.isSignWrappedSet())
+      return ConstantRange::getNonEmpty(CmpLo, SignMin);
+  }
+
+  return CmpCR;
 }
 
 /// Try to use \p Inst's value range from \p Solver to infer the NUW flag.
@@ -318,29 +409,24 @@ static Value *simplifyInstruction(SCCPSolver &Solver,
       // Early exit if we know nothing about X.
       if (LRange.isFullSet())
         return nullptr;
-      auto ConvertCRToICmp =
-          [&](const std::optional<ConstantRange> &NewCR) -> Value * {
-        ICmpInst::Predicate Pred;
-        APInt RHS;
-        // Check if we can represent NewCR as an icmp predicate.
-        if (NewCR && NewCR->getEquivalentICmp(Pred, RHS)) {
-          IRBuilder<NoFolder> Builder(&Inst);
-          Value *NewICmp =
-              Builder.CreateICmp(Pred, X, ConstantInt::get(X->getType(), RHS));
-          InsertedValues.insert(NewICmp);
-          return NewICmp;
-        }
-        return nullptr;
-      };
       // We are allowed to refine the comparison to either true or false for out
-      // of range inputs.
-      // Here we refine the comparison to false, and check if we can narrow the
-      // range check to a simpler test.
-      if (auto *V = ConvertCRToICmp(CR->exactIntersectWith(LRange)))
-        return V;
-      // Here we refine the comparison to true, i.e. we relax the range check.
-      if (auto *V = ConvertCRToICmp(CR->exactUnionWith(LRange.inverse())))
-        return V;
+      // of range inputs. Based on this, try to simplify CmpCR as a single
+      // ult/uge/slt/sge/eq/ne.
+      // E.g., CmpCR = [3, 10), LRange = [5, 0) --> NewCmpCR = [0, 10) -> ult
+      ConstantRange NewCmpCR = simplifyCmpRange(*CR, LRange);
+
+      ICmpInst::Predicate Pred;
+      APInt RHS;
+      // If NewCmpCR is just the same as CR, no simplification happens.
+      if (NewCmpCR != *CR) {
+        bool Match [[maybe_unused]] = NewCmpCR.getEquivalentICmp(Pred, RHS);
+        assert(Match && "Incorrect simplifyCmpRange");
+        IRBuilder<NoFolder> Builder(&Inst);
+        Value *NewICmp =
+            Builder.CreateICmp(Pred, X, ConstantInt::get(X->getType(), RHS));
+        InsertedValues.insert(NewICmp);
+        return NewICmp;
+      }
     }
   }
 

--- a/llvm/lib/Transforms/Utils/SCCPSolver.cpp
+++ b/llvm/lib/Transforms/Utils/SCCPSolver.cpp
@@ -120,16 +120,20 @@ static ConstantRange getRange(Value *Op, SCCPSolver &Solver,
 /// If no such range preserves the active semantics under KnownCR, keep CmpCR.
 static ConstantRange simplifyCmpRange(const ConstantRange &CmpCR,
                                       const ConstantRange &KnownCR) {
-  assert(!KnownCR.inverse().contains(CmpCR) &&
-         "CmpCR ∩ KnowCR should not be ∅");
   assert((!CmpCR.isFullSet() && !CmpCR.isEmptySet()) && "Unexpected CmpCR");
-  assert((!KnownCR.isFullSet() && !KnownCR.isEmptySet()) &&
-         "Unexpected KnownCR");
+  assert(!KnownCR.isEmptySet() && "Unexpected KnownCR");
+
+  // If KnownCR is full, bail out early.
+  if (KnownCR.isFullSet())
+    return CmpCR;
 
   const unsigned BW = CmpCR.getBitWidth();
-  // All reachable value satisfy CmpCR --> always true.
+  // All reachable values satisfy CmpCR --> always true.
   if (CmpCR.contains(KnownCR))
     return ConstantRange::getFull(BW);
+  // All values in CmpCR are unreachable --> always false.
+  if (KnownCR.inverse().contains(CmpCR))
+    return ConstantRange::getEmpty(BW);
 
   std::optional<ConstantRange> ActCmpCR = CmpCR.exactIntersectWith(KnownCR);
   if (!ActCmpCR)

--- a/llvm/test/Transforms/SCCP/relax-range-checks.ll
+++ b/llvm/test/Transforms/SCCP/relax-range-checks.ll
@@ -117,7 +117,7 @@ define i1 @range_check_to_icmp_ult(i8 range(i8 2, 10) %x) {
 ; CHECK-LABEL: define i1 @range_check_to_icmp_ult(
 ; CHECK-SAME: i8 range(i8 2, 10) [[X:%.*]]) {
 ; CHECK-NEXT:    [[OFF:%.*]] = add nsw i8 [[X]], -2
-; CHECK-NEXT:    [[CMP:%.*]] = icmp ult i8 [[OFF]], 4
+; CHECK-NEXT:    [[CMP:%.*]] = icmp ult i8 [[X]], 6
 ; CHECK-NEXT:    ret i1 [[CMP]]
 ;
   %off = add i8 %x, -2
@@ -129,7 +129,7 @@ define i1 @range_check_to_icmp_uge(i8 range(i8 2, 6) %x) {
 ; CHECK-LABEL: define i1 @range_check_to_icmp_uge(
 ; CHECK-SAME: i8 range(i8 2, 6) [[X:%.*]]) {
 ; CHECK-NEXT:    [[OFF:%.*]] = add nsw i8 [[X]], -4
-; CHECK-NEXT:    [[CMP:%.*]] = icmp ult i8 [[OFF]], 2
+; CHECK-NEXT:    [[CMP:%.*]] = icmp uge i8 [[X]], 4
 ; CHECK-NEXT:    ret i1 [[CMP]]
 ;
   %off = add nsw i8 %x, -4
@@ -141,7 +141,7 @@ define i1 @range_check_to_icmp_slt(i8 range(i8 -56, 20) %x) {
 ; CHECK-LABEL: define i1 @range_check_to_icmp_slt(
 ; CHECK-SAME: i8 range(i8 -56, 20) [[X:%.*]]) {
 ; CHECK-NEXT:    [[OFF:%.*]] = add nsw i8 [[X]], 56
-; CHECK-NEXT:    [[CMP:%.*]] = icmp ult i8 [[OFF]], 50
+; CHECK-NEXT:    [[CMP:%.*]] = icmp slt i8 [[X]], -6
 ; CHECK-NEXT:    ret i1 [[CMP]]
 ;
   %off = add nsw i8 %x, 56
@@ -153,7 +153,7 @@ define i1 @range_check_to_icmp_sge(i8 range(i8 -56, 20) %x) {
 ; CHECK-LABEL: define i1 @range_check_to_icmp_sge(
 ; CHECK-SAME: i8 range(i8 -56, 20) [[X:%.*]]) {
 ; CHECK-NEXT:    [[OFF:%.*]] = add nsw i8 [[X]], 16
-; CHECK-NEXT:    [[CMP:%.*]] = icmp ult i8 [[OFF]], 36
+; CHECK-NEXT:    [[CMP:%.*]] = icmp sge i8 [[X]], -16
 ; CHECK-NEXT:    ret i1 [[CMP]]
 ;
   %off = add nsw i8 %x, 16

--- a/llvm/test/Transforms/SCCP/relax-range-checks.ll
+++ b/llvm/test/Transforms/SCCP/relax-range-checks.ll
@@ -161,6 +161,30 @@ define i1 @range_check_to_icmp_sge(i8 range(i8 -56, 20) %x) {
   ret i1 %cmp
 }
 
+define i1 @range_check_to_icmp_empty(i8 range(i8 2, 10) %x) {
+; CHECK-LABEL: define i1 @range_check_to_icmp_empty(
+; CHECK-SAME: i8 range(i8 2, 10) [[X:%.*]]) {
+; CHECK-NEXT:    [[OFF:%.*]] = add nuw nsw i8 [[X]], -2
+; CHECK-NEXT:    [[CMP:%.*]] = icmp ult i8 [[X]], 0
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %off = add nuw i8 %x, -2
+  %cmp = icmp ult i8 %off, 0
+  ret i1 %cmp
+}
+
+define i1 @range_check_to_icmp_full(i8 range(i8 2, 10) %x) {
+; CHECK-LABEL: define i1 @range_check_to_icmp_full(
+; CHECK-SAME: i8 range(i8 2, 10) [[X:%.*]]) {
+; CHECK-NEXT:    [[OFF:%.*]] = add nuw nsw i8 [[X]], -2
+; CHECK-NEXT:    [[CMP:%.*]] = icmp uge i8 [[X]], 0
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %off = add nuw i8 %x, -2
+  %cmp = icmp uge i8 %off, 0
+  ret i1 %cmp
+}
+
 ; Cover the early exit when ActiveCmpCR is already a one-icmp check.
 
 define i1 @range_check_intersection_to_icmp_eq(i32 range(i32 0, 4) %x) {

--- a/llvm/test/Transforms/SCCP/relax-range-checks.ll
+++ b/llvm/test/Transforms/SCCP/relax-range-checks.ll
@@ -113,4 +113,127 @@ define i1 @range_check_to_icmp_eq2(i32 range(i32 -1, 2) %x) {
   ret i1 %cmp
 }
 
+define i1 @range_check_to_icmp_ult(i8 range(i8 2, 10) %x) {
+; CHECK-LABEL: define i1 @range_check_to_icmp_ult(
+; CHECK-SAME: i8 range(i8 2, 10) [[X:%.*]]) {
+; CHECK-NEXT:    [[OFF:%.*]] = add nsw i8 [[X]], -2
+; CHECK-NEXT:    [[CMP:%.*]] = icmp ult i8 [[OFF]], 4
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %off = add i8 %x, -2
+  %cmp = icmp ult i8 %off, 4
+  ret i1 %cmp
+}
+
+define i1 @range_check_to_icmp_uge(i8 range(i8 2, 6) %x) {
+; CHECK-LABEL: define i1 @range_check_to_icmp_uge(
+; CHECK-SAME: i8 range(i8 2, 6) [[X:%.*]]) {
+; CHECK-NEXT:    [[OFF:%.*]] = add nsw i8 [[X]], -4
+; CHECK-NEXT:    [[CMP:%.*]] = icmp ult i8 [[OFF]], 2
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %off = add nsw i8 %x, -4
+  %cmp = icmp ult i8 %off, 2
+  ret i1 %cmp
+}
+
+define i1 @range_check_to_icmp_slt(i8 range(i8 -56, 20) %x) {
+; CHECK-LABEL: define i1 @range_check_to_icmp_slt(
+; CHECK-SAME: i8 range(i8 -56, 20) [[X:%.*]]) {
+; CHECK-NEXT:    [[OFF:%.*]] = add nsw i8 [[X]], 56
+; CHECK-NEXT:    [[CMP:%.*]] = icmp ult i8 [[OFF]], 50
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %off = add nsw i8 %x, 56
+  %cmp = icmp ult i8 %off, 50
+  ret i1 %cmp
+}
+
+define i1 @range_check_to_icmp_sge(i8 range(i8 -56, 20) %x) {
+; CHECK-LABEL: define i1 @range_check_to_icmp_sge(
+; CHECK-SAME: i8 range(i8 -56, 20) [[X:%.*]]) {
+; CHECK-NEXT:    [[OFF:%.*]] = add nsw i8 [[X]], 16
+; CHECK-NEXT:    [[CMP:%.*]] = icmp ult i8 [[OFF]], 36
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %off = add nsw i8 %x, 16
+  %cmp = icmp ult i8 %off, 36
+  ret i1 %cmp
+}
+
+; Cover the early exit when ActiveCmpCR is already a one-icmp check.
+
+define i1 @range_check_intersection_to_icmp_eq(i32 range(i32 0, 4) %x) {
+; CHECK-LABEL: define i1 @range_check_intersection_to_icmp_eq(
+; CHECK-SAME: i32 range(i32 0, 4) [[X:%.*]]) {
+; CHECK-NEXT:    [[OFF:%.*]] = add nsw i32 [[X]], -3
+; CHECK-NEXT:    [[CMP:%.*]] = icmp eq i32 [[X]], 3
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %off = add nsw i32 %x, -3
+  %cmp = icmp ult i32 %off, 2
+  ret i1 %cmp
+}
+
+define i1 @range_check_intersection_to_icmp_ult(i8 range(i8 0, 10) %x) {
+; CHECK-LABEL: define i1 @range_check_intersection_to_icmp_ult(
+; CHECK-SAME: i8 range(i8 0, 10) [[X:%.*]]) {
+; CHECK-NEXT:    [[OFF:%.*]] = add nuw nsw i8 [[X]], 2
+; CHECK-NEXT:    [[CMP:%.*]] = icmp ult i8 [[X]], 4
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %off = add i8 %x, 2
+  %cmp = icmp ult i8 %off, 6
+  ret i1 %cmp
+}
+
+define i1 @range_check_intersection_to_icmp_slt(i8 range(i8 -128, -100) %x) {
+; CHECK-LABEL: define i1 @range_check_intersection_to_icmp_slt(
+; CHECK-SAME: i8 range(i8 -128, -100) [[X:%.*]]) {
+; CHECK-NEXT:    [[OFF:%.*]] = add i8 [[X]], -120
+; CHECK-NEXT:    [[CMP:%.*]] = icmp slt i8 [[X]], -118
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %off = add i8 %x, -120
+  %cmp = icmp ult i8 %off, 18
+  ret i1 %cmp
+}
+
+define i1 @range_check_intersection_to_icmp_uge(i8 range(i8 -6, 0) %x) {
+; CHECK-LABEL: define i1 @range_check_intersection_to_icmp_uge(
+; CHECK-SAME: i8 range(i8 -6, 0) [[X:%.*]]) {
+; CHECK-NEXT:    [[OFF:%.*]] = add nsw i8 [[X]], 2
+; CHECK-NEXT:    [[CMP:%.*]] = icmp uge i8 [[X]], -2
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %off = add i8 %x, 2
+  %cmp = icmp ult i8 %off, 6
+  ret i1 %cmp
+}
+
+define i1 @range_check_intersection_to_icmp_sge(i8 range(i8 120, -128) %x) {
+; CHECK-LABEL: define i1 @range_check_intersection_to_icmp_sge(
+; CHECK-SAME: i8 range(i8 120, -128) [[X:%.*]]) {
+; CHECK-NEXT:    [[OFF:%.*]] = add nsw i8 [[X]], -122
+; CHECK-NEXT:    [[CMP:%.*]] = icmp sge i8 [[X]], 122
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %off = add i8 %x, -122
+  %cmp = icmp ult i8 %off, 14
+  ret i1 %cmp
+}
+
+; Negative test: CmpCR relaxation cannot perform when x's range is nuw and nsw.
+define i1 @range_check_nsw_nuw(i8 range(i8 -20, -56) %x) {
+; CHECK-LABEL: define i1 @range_check_nsw_nuw(
+; CHECK-SAME: i8 range(i8 -20, -56) [[X:%.*]]) {
+; CHECK-NEXT:    [[OFF:%.*]] = add i8 [[X]], 20
+; CHECK-NEXT:    [[CMP:%.*]] = icmp ult i8 [[OFF]], 14
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %off = add i8 %x, 20
+  %cmp = icmp ult i8 %off, 14
+  ret i1 %cmp
+}
+
 declare void @use(i8)


### PR DESCRIPTION
For any 2 instructions range check of `x`, we can utilize the information of `x`'s range to try emitting just ONE icmp instruction, e.g.:

```diff
; x ∈ [2,10), CmpCR ∈ [2, 6) --> CmpCR' = [0, 6)
define i1 @range_check_to_icmp_ult(i8 range(i8 2, 10) %x) {
-  %off = add i8 %x, -2
-  %cmp = icmp ult i8 %off, 4
+  %cmp = icmp ult i8 %off, 6
   ret i1 %cmp
}
```

Let $P(X, R)$ represent the range check of $x \in R$ under the known range of $x \in X$, we can change the comparison range $R$ to $R'$ if $R' \cap X = R \cap X$:

$$
P(X, R) = x \in X \land x \in R = x \in X \cap R \\
           = x \in X \cap R' = P(X, R')
$$

Therefore, after ensuring $R' \cap X = R \cap X$, we can try to set $R'$ as one of the 6 special ONE-icmp check ranges:
```
[L, L+1)      --> X  eq L
[R+1, R)      --> X  ne R
[0, R)        --> X ult R
[L, 0)        --> X uge L
[SignMin, R)  --> X slt R
[L, SignMin)  --> X sge L
```
---

Previously, #158495 and #162008 worked on this, but in a very limited scope (only tried $R' = R \cap X$ and $R' = R \cup  \text{inverse}(X)$ ).

This PR generalizes them by landing the suggestion https://github.com/llvm/llvm-project/pull/162008#pullrequestreview-3302539397 of @nikic, i.e., supports the mix of true and false for the out-of-range part.

Alive2: https://alive2.llvm.org/ce/z/Ntzpox
IR diff: https://github.com/dtcxzyw/llvm-opt-benchmark-nightly/pull/74
Compile-time impact: https://github.com/dtcxzyw/llvm-opt-benchmark-nightly/pull/76
