### PR TITLE
[CodeGen] Discard oracle functions during ISel translation

### DIFF
--- a/llvm/lib/CodeGen/GlobalISel/IRTranslator.cpp
+++ b/llvm/lib/CodeGen/GlobalISel/IRTranslator.cpp
@@ -4151,6 +4151,14 @@ static bool checkForMustTailInVarArgFn(bool IsVarArg, const BasicBlock &BB) {
 bool IRTranslator::runOnMachineFunction(MachineFunction &CurMF) {
   MF = &CurMF;
   const Function &F = MF->getFunction();
+
+  // Skip oracle functions by changing their linkage to
+  // available_externally to not generate any code.
+  if (F.hasFnAttribute("oracle-function")) {
+    MF->getFunction().setLinkage(GlobalValue::AvailableExternallyLinkage);
+    return false;
+  }
+
   ORE = std::make_unique<OptimizationRemarkEmitter>(&F);
   CLI = MF->getSubtarget().getCallLowering();
 

--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAGISel.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAGISel.cpp
@@ -375,6 +375,14 @@ bool SelectionDAGISelLegacy::runOnMachineFunction(MachineFunction &MF) {
   if (MF.getProperties().hasSelected())
     return false;
 
+  // Skip oracle functions by changing their linkage to
+  // available_externally to not generate any code.
+  Function &F = MF.getFunction();
+  if (F.hasFnAttribute("oracle-function")) {
+    F.setLinkage(GlobalValue::AvailableExternallyLinkage);
+    return false;
+  }
+
   // Do some sanity-checking on the command-line options.
   if (EnableFastISelAbort && !Selector->TM.Options.EnableFastISel)
     reportFatalUsageError("-fast-isel-abort > 0 requires -fast-isel");

--- a/llvm/test/CodeGen/AArch64/remove-oracle-functions.ll
+++ b/llvm/test/CodeGen/AArch64/remove-oracle-functions.ll
@@ -1,0 +1,57 @@
+; RUN: llc -mtriple=arm64-apple-macosx < %s | FileCheck %s
+; RUN: llc -mtriple=arm64-apple-macosx -global-isel < %s | FileCheck %s
+
+; Oracle functions with no uses should be removed entirely.
+; CHECK-NOT: oracle_unused1
+; CHECK-NOT: oracle_unused2
+
+; A normal function should not be affected regardless of uses.
+; CHECK-LABEL: normal_unused:
+; CHECK:       ret
+
+define void @oracle_unused1(ptr %p, i64 %n) #0 {
+entry:
+  br label %loop
+
+loop:
+  %i = phi i64 [ 0, %entry ], [ %i.next, %loop ]
+  %gep = getelementptr inbounds i32, ptr %p, i64 %i
+  %val = load i32, ptr %gep, align 4
+  %add = add nsw i32 %val, 42
+  store i32 %add, ptr %gep, align 4
+  %i.next = add nuw nsw i64 %i, 1
+  %cmp = icmp ult i64 %i.next, %n
+  br i1 %cmp, label %loop, label %exit
+
+exit:
+  ret void
+}
+
+define i64 @oracle_unused2(ptr %p, i64 %n) #0 {
+entry:
+  %cmp0 = icmp eq i64 %n, 0
+  br i1 %cmp0, label %exit, label %loop
+
+loop:
+  %i = phi i64 [ 0, %entry ], [ %i.next, %loop.latch ]
+  %sum = phi i64 [ 0, %entry ], [ %sum.next, %loop.latch ]
+  %gep = getelementptr inbounds i64, ptr %p, i64 %i
+  %val = load i64, ptr %gep, align 8
+  %sum.next = add i64 %sum, %val
+  br label %loop.latch
+
+loop.latch:
+  %i.next = add nuw nsw i64 %i, 1
+  %cmp = icmp ult i64 %i.next, %n
+  br i1 %cmp, label %loop, label %exit
+
+exit:
+  %result = phi i64 [ 0, %entry ], [ %sum.next, %loop.latch ]
+  ret i64 %result
+}
+
+define void @normal_unused() {
+  ret void
+}
+
+attributes #0 = { "oracle-function" }

--- a/llvm/test/CodeGen/X86/remove-oracle-functions.ll
+++ b/llvm/test/CodeGen/X86/remove-oracle-functions.ll
@@ -1,0 +1,54 @@
+; RUN: llc -mtriple=x86_64-unknown-linux < %s | FileCheck %s
+
+; CHECK-NOT: oracle_unused1
+; CHECK-NOT: oracle_unused2
+
+; CHECK-LABEL: normal_unused:
+; CHECK:       retq
+
+define void @oracle_unused1(ptr %p, i64 %n) #0 {
+entry:
+  br label %loop
+
+loop:
+  %i = phi i64 [ 0, %entry ], [ %i.next, %loop ]
+  %gep = getelementptr inbounds i32, ptr %p, i64 %i
+  %val = load i32, ptr %gep, align 4
+  %add = add nsw i32 %val, 42
+  store i32 %add, ptr %gep, align 4
+  %i.next = add nuw nsw i64 %i, 1
+  %cmp = icmp ult i64 %i.next, %n
+  br i1 %cmp, label %loop, label %exit
+
+exit:
+  ret void
+}
+
+define i64 @oracle_unused2(ptr %p, i64 %n) #0 {
+entry:
+  %cmp0 = icmp eq i64 %n, 0
+  br i1 %cmp0, label %exit, label %loop
+
+loop:
+  %i = phi i64 [ 0, %entry ], [ %i.next, %loop.latch ]
+  %sum = phi i64 [ 0, %entry ], [ %sum.next, %loop.latch ]
+  %gep = getelementptr inbounds i64, ptr %p, i64 %i
+  %val = load i64, ptr %gep, align 8
+  %sum.next = add i64 %sum, %val
+  br label %loop.latch
+
+loop.latch:
+  %i.next = add nuw nsw i64 %i, 1
+  %cmp = icmp ult i64 %i.next, %n
+  br i1 %cmp, label %loop, label %exit
+
+exit:
+  %result = phi i64 [ 0, %entry ], [ %sum.next, %loop.latch ]
+  ret i64 %result
+}
+
+define void @normal_unused() {
+  ret void
+}
+
+attributes #0 = { "oracle-function" }


### PR DESCRIPTION
Update both IRTranslator.cpp and SelectionDAGISel.cpp to set the linkage for oracle functions to available_externally, so no code is generated for them and no functions are emitted.