### PR TITLE
[AMDGPU] Align GlobalISel with SelectionDAG for f16 to i1/i8 saturated conversions

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPULegalizerInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPULegalizerInfo.cpp
@@ -1208,9 +1208,12 @@ AMDGPULegalizerInfo::AMDGPULegalizerInfo(const GCNSubtarget &ST_,
   // clang-format off
   auto &FPToISat = getActionDefinitionsBuilder({G_FPTOSI_SAT, G_FPTOUI_SAT})
     .legalFor({{S32, S32}, {S32, S64}})
+    .legalFor(ST.has16BitInsts(),{{S16, S16}})
     .narrowScalarFor({{S64, S16}}, changeTo(0, S32));
+
+  // If available, widen i1 and i8 to i16, intead of i32 so v_cvt_i16/u16_f16 can be used.
   if (ST.has16BitInsts())
-    FPToISat.legalFor({{S16, S16}});
+    FPToISat.widenScalarFor({{S1, S16}, {S8, S16}}, changeTo(0, S16));
 
   FPToISat.minScalar(1, S32);
   FPToISat.minScalar(0, S32)

--- a/llvm/lib/Target/AMDGPU/AMDGPULegalizerInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPULegalizerInfo.cpp
@@ -1211,9 +1211,9 @@ AMDGPULegalizerInfo::AMDGPULegalizerInfo(const GCNSubtarget &ST_,
     .legalFor(ST.has16BitInsts(),{{S16, S16}})
     .narrowScalarFor({{S64, S16}}, changeTo(0, S32));
 
-  // If available, widen i1 and i8 to i16, intead of i32 so v_cvt_i16/u16_f16 can be used.
+  // If available, widen width <16 to i16, intead of i32 so v_cvt_i16/u16_f16 can be used.
   if (ST.has16BitInsts())
-    FPToISat.widenScalarFor({{S1, S16}, {S8, S16}}, changeTo(0, S16));
+    FPToISat.minScalarIf(typeIs(1, S16), 0, S16);
 
   FPToISat.minScalar(1, S32);
   FPToISat.minScalar(0, S32)

--- a/llvm/test/CodeGen/AMDGPU/fptosi-sat-scalar.ll
+++ b/llvm/test/CodeGen/AMDGPU/fptosi-sat-scalar.ll
@@ -1669,9 +1669,8 @@ define i1 @test_signed_i1_f16(half %f) nounwind {
 ; GFX12-GI-NEXT:    s_wait_samplecnt 0x0
 ; GFX12-GI-NEXT:    s_wait_bvhcnt 0x0
 ; GFX12-GI-NEXT:    s_wait_kmcnt 0x0
-; GFX12-GI-NEXT:    v_cvt_f32_f16_e32 v0, v0.l
-; GFX12-GI-NEXT:    v_cvt_i32_f32_e32 v0, v0
-; GFX12-GI-NEXT:    v_med3_i32 v0, v0, -1, 0
+; GFX12-GI-NEXT:    v_cvt_i16_f16_e32 v0.l, v0.l
+; GFX12-GI-NEXT:    v_med3_i16 v0.l, v0.l, -1, 0
 ; GFX12-GI-NEXT:    s_setpc_b64 s[30:31]
     %x = call i1 @llvm.fptosi.sat.i1.f16(half %f)
     ret i1 %x
@@ -1755,10 +1754,9 @@ define i8 @test_signed_i8_f16(half %f) nounwind {
 ; GFX12-GI-NEXT:    s_wait_samplecnt 0x0
 ; GFX12-GI-NEXT:    s_wait_bvhcnt 0x0
 ; GFX12-GI-NEXT:    s_wait_kmcnt 0x0
-; GFX12-GI-NEXT:    v_cvt_f32_f16_e32 v0, v0.l
-; GFX12-GI-NEXT:    v_mov_b32_e32 v1, 0xffffff80
-; GFX12-GI-NEXT:    v_cvt_i32_f32_e32 v0, v0
-; GFX12-GI-NEXT:    v_med3_i32 v0, v0, v1, 0x7f
+; GFX12-GI-NEXT:    v_cvt_i16_f16_e32 v0.l, v0.l
+; GFX12-GI-NEXT:    v_mov_b16_e32 v0.h, 0xff80
+; GFX12-GI-NEXT:    v_med3_i16 v0.l, v0.l, v0.h, 0x7f
 ; GFX12-GI-NEXT:    s_setpc_b64 s[30:31]
     %x = call i8 @llvm.fptosi.sat.i8.f16(half %f)
     ret i8 %x
@@ -2045,15 +2043,8 @@ define i1 @test_s_signed_i1_f16(half inreg %f) nounwind {
 ; GFX12-GI-NEXT:    s_wait_samplecnt 0x0
 ; GFX12-GI-NEXT:    s_wait_bvhcnt 0x0
 ; GFX12-GI-NEXT:    s_wait_kmcnt 0x0
-; GFX12-GI-NEXT:    s_cvt_f32_f16 s0, s0
-; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX12-GI-NEXT:    s_cvt_i32_f32 s0, s0
-; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX12-GI-NEXT:    s_min_i32 s0, s0, 0
-; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX12-GI-NEXT:    s_max_i32 s0, s0, -1
-; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX12-GI-NEXT:    v_mov_b32_e32 v0, s0
+; GFX12-GI-NEXT:    v_cvt_i16_f16_e32 v0.l, s0
+; GFX12-GI-NEXT:    v_med3_i16 v0.l, v0.l, -1, 0
 ; GFX12-GI-NEXT:    s_setpc_b64 s[30:31]
     %x = call i1 @llvm.fptosi.sat.i1.f16(half %f)
     ret i1 %x
@@ -2143,15 +2134,9 @@ define i8 @test_s_signed_i8_f16(half inreg %f) nounwind {
 ; GFX12-GI-NEXT:    s_wait_samplecnt 0x0
 ; GFX12-GI-NEXT:    s_wait_bvhcnt 0x0
 ; GFX12-GI-NEXT:    s_wait_kmcnt 0x0
-; GFX12-GI-NEXT:    s_cvt_f32_f16 s0, s0
-; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX12-GI-NEXT:    s_cvt_i32_f32 s0, s0
-; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX12-GI-NEXT:    s_min_i32 s0, s0, 0x7f
-; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX12-GI-NEXT:    s_max_i32 s0, s0, 0xffffff80
-; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX12-GI-NEXT:    v_mov_b32_e32 v0, s0
+; GFX12-GI-NEXT:    v_cvt_i16_f16_e32 v0.l, s0
+; GFX12-GI-NEXT:    v_mov_b16_e32 v0.h, 0xff80
+; GFX12-GI-NEXT:    v_med3_i16 v0.l, v0.l, v0.h, 0x7f
 ; GFX12-GI-NEXT:    s_setpc_b64 s[30:31]
     %x = call i8 @llvm.fptosi.sat.i8.f16(half %f)
     ret i8 %x

--- a/llvm/test/CodeGen/AMDGPU/fptosi-sat-vector.ll
+++ b/llvm/test/CodeGen/AMDGPU/fptosi-sat-vector.ll
@@ -2537,18 +2537,14 @@ define <4 x i1> @test_signed_v4f16_v4i1(<4 x half> %f) {
 ; GFX12-GI-NEXT:    s_wait_samplecnt 0x0
 ; GFX12-GI-NEXT:    s_wait_bvhcnt 0x0
 ; GFX12-GI-NEXT:    s_wait_kmcnt 0x0
-; GFX12-GI-NEXT:    v_cvt_f32_f16_e32 v2, v0.l
-; GFX12-GI-NEXT:    v_cvt_f32_f16_e32 v0, v0.h
-; GFX12-GI-NEXT:    v_cvt_f32_f16_e32 v3, v1.l
-; GFX12-GI-NEXT:    v_cvt_f32_f16_e32 v1, v1.h
-; GFX12-GI-NEXT:    v_cvt_i32_f32_e32 v2, v2
-; GFX12-GI-NEXT:    v_cvt_i32_f32_e32 v4, v0
-; GFX12-GI-NEXT:    v_cvt_i32_f32_e32 v3, v3
-; GFX12-GI-NEXT:    v_cvt_i32_f32_e32 v5, v1
-; GFX12-GI-NEXT:    v_med3_i32 v0, v2, -1, 0
-; GFX12-GI-NEXT:    v_med3_i32 v1, v4, -1, 0
-; GFX12-GI-NEXT:    v_med3_i32 v2, v3, -1, 0
-; GFX12-GI-NEXT:    v_med3_i32 v3, v5, -1, 0
+; GFX12-GI-NEXT:    v_cvt_i16_f16_e32 v0.l, v0.l
+; GFX12-GI-NEXT:    v_cvt_i16_f16_e32 v0.h, v0.h
+; GFX12-GI-NEXT:    v_cvt_i16_f16_e32 v2.l, v1.l
+; GFX12-GI-NEXT:    v_cvt_i16_f16_e32 v1.h, v1.h
+; GFX12-GI-NEXT:    v_med3_i16 v0.l, v0.l, -1, 0
+; GFX12-GI-NEXT:    v_med3_i16 v1.l, v0.h, -1, 0
+; GFX12-GI-NEXT:    v_med3_i16 v2.l, v2.l, -1, 0
+; GFX12-GI-NEXT:    v_med3_i16 v3.l, v1.h, -1, 0
 ; GFX12-GI-NEXT:    s_setpc_b64 s[30:31]
     %x = call <4 x i1> @llvm.fptosi.sat.v4f16.v4i1(<4 x half> %f)
     ret <4 x i1> %x
@@ -2752,19 +2748,15 @@ define <4 x i8> @test_signed_v4f16_v4i8(<4 x half> %f) {
 ; GFX12-GI-NEXT:    s_wait_samplecnt 0x0
 ; GFX12-GI-NEXT:    s_wait_bvhcnt 0x0
 ; GFX12-GI-NEXT:    s_wait_kmcnt 0x0
-; GFX12-GI-NEXT:    v_cvt_f32_f16_e32 v2, v0.l
-; GFX12-GI-NEXT:    v_cvt_f32_f16_e32 v0, v0.h
-; GFX12-GI-NEXT:    v_cvt_f32_f16_e32 v3, v1.l
-; GFX12-GI-NEXT:    v_cvt_f32_f16_e32 v1, v1.h
-; GFX12-GI-NEXT:    v_mov_b32_e32 v4, 0xffffff80
-; GFX12-GI-NEXT:    v_cvt_i32_f32_e32 v2, v2
-; GFX12-GI-NEXT:    v_cvt_i32_f32_e32 v5, v0
-; GFX12-GI-NEXT:    v_cvt_i32_f32_e32 v3, v3
-; GFX12-GI-NEXT:    v_cvt_i32_f32_e32 v6, v1
-; GFX12-GI-NEXT:    v_med3_i32 v0, v2, v4, 0x7f
-; GFX12-GI-NEXT:    v_med3_i32 v1, v5, v4, 0x7f
-; GFX12-GI-NEXT:    v_med3_i32 v2, v3, v4, 0x7f
-; GFX12-GI-NEXT:    v_med3_i32 v3, v6, v4, 0x7f
+; GFX12-GI-NEXT:    v_mov_b16_e32 v2.h, 0xff80
+; GFX12-GI-NEXT:    v_cvt_i16_f16_e32 v0.l, v0.l
+; GFX12-GI-NEXT:    v_cvt_i16_f16_e32 v0.h, v0.h
+; GFX12-GI-NEXT:    v_cvt_i16_f16_e32 v2.l, v1.l
+; GFX12-GI-NEXT:    v_cvt_i16_f16_e32 v1.h, v1.h
+; GFX12-GI-NEXT:    v_med3_i16 v0.l, v0.l, v2.h, 0x7f
+; GFX12-GI-NEXT:    v_med3_i16 v1.l, v0.h, v2.h, 0x7f
+; GFX12-GI-NEXT:    v_med3_i16 v2.l, v2.l, v2.h, 0x7f
+; GFX12-GI-NEXT:    v_med3_i16 v3.l, v1.h, v2.h, 0x7f
 ; GFX12-GI-NEXT:    s_setpc_b64 s[30:31]
     %x = call <4 x i8> @llvm.fptosi.sat.v4f16.v4i8(<4 x half> %f)
     ret <4 x i8> %x
@@ -3346,28 +3338,17 @@ define <4 x i1> @test_s_signed_v4f16_v4i1(<4 x half> inreg %f) {
 ; GFX12-GI-NEXT:    s_wait_samplecnt 0x0
 ; GFX12-GI-NEXT:    s_wait_bvhcnt 0x0
 ; GFX12-GI-NEXT:    s_wait_kmcnt 0x0
-; GFX12-GI-NEXT:    s_cvt_f32_f16 s2, s0
-; GFX12-GI-NEXT:    s_cvt_hi_f32_f16 s0, s0
-; GFX12-GI-NEXT:    s_cvt_f32_f16 s3, s1
-; GFX12-GI-NEXT:    s_cvt_hi_f32_f16 s1, s1
+; GFX12-GI-NEXT:    s_lshr_b32 s2, s0, 16
+; GFX12-GI-NEXT:    s_lshr_b32 s3, s1, 16
+; GFX12-GI-NEXT:    v_cvt_i16_f16_e32 v0.l, s0
+; GFX12-GI-NEXT:    v_cvt_i16_f16_e32 v0.h, s1
 ; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX12-GI-NEXT:    s_cvt_i32_f32 s2, s2
-; GFX12-GI-NEXT:    s_cvt_i32_f32 s0, s0
-; GFX12-GI-NEXT:    s_cvt_i32_f32 s3, s3
-; GFX12-GI-NEXT:    s_cvt_i32_f32 s1, s1
-; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX12-GI-NEXT:    s_min_i32 s2, s2, 0
-; GFX12-GI-NEXT:    s_min_i32 s0, s0, 0
-; GFX12-GI-NEXT:    s_min_i32 s3, s3, 0
-; GFX12-GI-NEXT:    s_min_i32 s1, s1, 0
-; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX12-GI-NEXT:    s_max_i32 s2, s2, -1
-; GFX12-GI-NEXT:    s_max_i32 s0, s0, -1
-; GFX12-GI-NEXT:    s_max_i32 s3, s3, -1
-; GFX12-GI-NEXT:    s_max_i32 s1, s1, -1
-; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX12-GI-NEXT:    v_dual_mov_b32 v0, s2 :: v_dual_mov_b32 v1, s0
-; GFX12-GI-NEXT:    v_dual_mov_b32 v2, s3 :: v_dual_mov_b32 v3, s1
+; GFX12-GI-NEXT:    v_cvt_i16_f16_e32 v1.l, s2
+; GFX12-GI-NEXT:    v_cvt_i16_f16_e32 v1.h, s3
+; GFX12-GI-NEXT:    v_med3_i16 v0.l, v0.l, -1, 0
+; GFX12-GI-NEXT:    v_med3_i16 v2.l, v0.h, -1, 0
+; GFX12-GI-NEXT:    v_med3_i16 v1.l, v1.l, -1, 0
+; GFX12-GI-NEXT:    v_med3_i16 v3.l, v1.h, -1, 0
 ; GFX12-GI-NEXT:    s_setpc_b64 s[30:31]
     %x = call <4 x i1> @llvm.fptosi.sat.v4f16.v4i1(<4 x half> %f)
     ret <4 x i1> %x
@@ -3603,28 +3584,18 @@ define <4 x i8> @test_s_signed_v4f16_v4i8(<4 x half> inreg %f) {
 ; GFX12-GI-NEXT:    s_wait_samplecnt 0x0
 ; GFX12-GI-NEXT:    s_wait_bvhcnt 0x0
 ; GFX12-GI-NEXT:    s_wait_kmcnt 0x0
-; GFX12-GI-NEXT:    s_cvt_f32_f16 s2, s0
-; GFX12-GI-NEXT:    s_cvt_hi_f32_f16 s0, s0
-; GFX12-GI-NEXT:    s_cvt_f32_f16 s3, s1
-; GFX12-GI-NEXT:    s_cvt_hi_f32_f16 s1, s1
+; GFX12-GI-NEXT:    s_lshr_b32 s2, s0, 16
+; GFX12-GI-NEXT:    s_lshr_b32 s3, s1, 16
+; GFX12-GI-NEXT:    v_cvt_i16_f16_e32 v0.l, s0
+; GFX12-GI-NEXT:    v_mov_b16_e32 v0.h, 0xff80
 ; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX12-GI-NEXT:    s_cvt_i32_f32 s2, s2
-; GFX12-GI-NEXT:    s_cvt_i32_f32 s0, s0
-; GFX12-GI-NEXT:    s_cvt_i32_f32 s3, s3
-; GFX12-GI-NEXT:    s_cvt_i32_f32 s1, s1
-; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX12-GI-NEXT:    s_min_i32 s2, s2, 0x7f
-; GFX12-GI-NEXT:    s_min_i32 s0, s0, 0x7f
-; GFX12-GI-NEXT:    s_min_i32 s3, s3, 0x7f
-; GFX12-GI-NEXT:    s_min_i32 s1, s1, 0x7f
-; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX12-GI-NEXT:    s_max_i32 s2, s2, 0xffffff80
-; GFX12-GI-NEXT:    s_max_i32 s0, s0, 0xffffff80
-; GFX12-GI-NEXT:    s_max_i32 s3, s3, 0xffffff80
-; GFX12-GI-NEXT:    s_max_i32 s1, s1, 0xffffff80
-; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX12-GI-NEXT:    v_dual_mov_b32 v0, s2 :: v_dual_mov_b32 v1, s0
-; GFX12-GI-NEXT:    v_dual_mov_b32 v2, s3 :: v_dual_mov_b32 v3, s1
+; GFX12-GI-NEXT:    v_cvt_i16_f16_e32 v1.l, s2
+; GFX12-GI-NEXT:    v_cvt_i16_f16_e32 v1.h, s1
+; GFX12-GI-NEXT:    v_cvt_i16_f16_e32 v2.h, s3
+; GFX12-GI-NEXT:    v_med3_i16 v0.l, v0.l, v0.h, 0x7f
+; GFX12-GI-NEXT:    v_med3_i16 v1.l, v1.l, v0.h, 0x7f
+; GFX12-GI-NEXT:    v_med3_i16 v2.l, v1.h, v0.h, 0x7f
+; GFX12-GI-NEXT:    v_med3_i16 v3.l, v2.h, v0.h, 0x7f
 ; GFX12-GI-NEXT:    s_setpc_b64 s[30:31]
     %x = call <4 x i8> @llvm.fptosi.sat.v4f16.v4i8(<4 x half> %f)
     ret <4 x i8> %x
@@ -4126,30 +4097,23 @@ define <8 x i1> @test_signed_v8f16_v8i1(<8 x half> %f) {
 ; GFX12-GI-NEXT:    s_wait_samplecnt 0x0
 ; GFX12-GI-NEXT:    s_wait_bvhcnt 0x0
 ; GFX12-GI-NEXT:    s_wait_kmcnt 0x0
-; GFX12-GI-NEXT:    v_cvt_f32_f16_e32 v4, v0.l
-; GFX12-GI-NEXT:    v_cvt_f32_f16_e32 v0, v0.h
-; GFX12-GI-NEXT:    v_cvt_f32_f16_e32 v5, v1.l
-; GFX12-GI-NEXT:    v_cvt_f32_f16_e32 v6, v1.h
-; GFX12-GI-NEXT:    v_cvt_f32_f16_e32 v7, v2.l
-; GFX12-GI-NEXT:    v_cvt_i32_f32_e32 v1, v4
-; GFX12-GI-NEXT:    v_cvt_i32_f32_e32 v4, v0
-; GFX12-GI-NEXT:    v_cvt_i32_f32_e32 v5, v5
-; GFX12-GI-NEXT:    v_cvt_f32_f16_e32 v8, v2.h
-; GFX12-GI-NEXT:    v_med3_i32 v0, v1, -1, 0
-; GFX12-GI-NEXT:    v_med3_i32 v1, v4, -1, 0
-; GFX12-GI-NEXT:    v_cvt_f32_f16_e32 v4, v3.l
-; GFX12-GI-NEXT:    v_cvt_f32_f16_e32 v3, v3.h
-; GFX12-GI-NEXT:    v_med3_i32 v2, v5, -1, 0
-; GFX12-GI-NEXT:    v_cvt_i32_f32_e32 v5, v6
-; GFX12-GI-NEXT:    v_cvt_i32_f32_e32 v6, v7
-; GFX12-GI-NEXT:    v_cvt_i32_f32_e32 v7, v8
-; GFX12-GI-NEXT:    v_cvt_i32_f32_e32 v8, v4
-; GFX12-GI-NEXT:    v_cvt_i32_f32_e32 v9, v3
-; GFX12-GI-NEXT:    v_med3_i32 v3, v5, -1, 0
-; GFX12-GI-NEXT:    v_med3_i32 v4, v6, -1, 0
-; GFX12-GI-NEXT:    v_med3_i32 v5, v7, -1, 0
-; GFX12-GI-NEXT:    v_med3_i32 v6, v8, -1, 0
-; GFX12-GI-NEXT:    v_med3_i32 v7, v9, -1, 0
+; GFX12-GI-NEXT:    v_cvt_i16_f16_e32 v0.h, v0.h
+; GFX12-GI-NEXT:    v_cvt_i16_f16_e32 v4.l, v1.l
+; GFX12-GI-NEXT:    v_cvt_i16_f16_e32 v0.l, v0.l
+; GFX12-GI-NEXT:    v_cvt_i16_f16_e32 v1.h, v1.h
+; GFX12-GI-NEXT:    v_cvt_i16_f16_e32 v3.h, v3.h
+; GFX12-GI-NEXT:    v_med3_i16 v1.l, v0.h, -1, 0
+; GFX12-GI-NEXT:    v_med3_i16 v8.l, v4.l, -1, 0
+; GFX12-GI-NEXT:    v_cvt_i16_f16_e32 v0.h, v2.l
+; GFX12-GI-NEXT:    v_cvt_i16_f16_e32 v2.l, v2.h
+; GFX12-GI-NEXT:    v_cvt_i16_f16_e32 v2.h, v3.l
+; GFX12-GI-NEXT:    v_med3_i16 v0.l, v0.l, -1, 0
+; GFX12-GI-NEXT:    v_med3_i16 v3.l, v1.h, -1, 0
+; GFX12-GI-NEXT:    v_med3_i16 v4.l, v0.h, -1, 0
+; GFX12-GI-NEXT:    v_med3_i16 v5.l, v2.l, -1, 0
+; GFX12-GI-NEXT:    v_med3_i16 v6.l, v2.h, -1, 0
+; GFX12-GI-NEXT:    v_med3_i16 v7.l, v3.h, -1, 0
+; GFX12-GI-NEXT:    v_mov_b32_e32 v2, v8
 ; GFX12-GI-NEXT:    s_setpc_b64 s[30:31]
     %x = call <8 x i1> @llvm.fptosi.sat.v8f16.v8i1(<8 x half> %f)
     ret <8 x i1> %x
@@ -4496,32 +4460,24 @@ define <8 x i8> @test_signed_v8f16_v8i8(<8 x half> %f) {
 ; GFX12-GI-NEXT:    s_wait_samplecnt 0x0
 ; GFX12-GI-NEXT:    s_wait_bvhcnt 0x0
 ; GFX12-GI-NEXT:    s_wait_kmcnt 0x0
-; GFX12-GI-NEXT:    v_cvt_f32_f16_e32 v4, v0.l
-; GFX12-GI-NEXT:    v_cvt_f32_f16_e32 v0, v0.h
-; GFX12-GI-NEXT:    v_cvt_f32_f16_e32 v5, v1.l
-; GFX12-GI-NEXT:    v_mov_b32_e32 v7, 0xffffff80
-; GFX12-GI-NEXT:    v_cvt_f32_f16_e32 v9, v1.h
-; GFX12-GI-NEXT:    v_cvt_i32_f32_e32 v4, v4
-; GFX12-GI-NEXT:    v_cvt_i32_f32_e32 v6, v0
-; GFX12-GI-NEXT:    v_cvt_i32_f32_e32 v5, v5
-; GFX12-GI-NEXT:    v_cvt_f32_f16_e32 v10, v2.l
-; GFX12-GI-NEXT:    v_cvt_f32_f16_e32 v2, v2.h
-; GFX12-GI-NEXT:    v_med3_i32 v0, v4, v7, 0x7f
-; GFX12-GI-NEXT:    v_cvt_f32_f16_e32 v4, v3.l
-; GFX12-GI-NEXT:    v_cvt_f32_f16_e32 v3, v3.h
-; GFX12-GI-NEXT:    v_med3_i32 v1, v6, v7, 0x7f
-; GFX12-GI-NEXT:    v_med3_i32 v8, v5, v7, 0x7f
-; GFX12-GI-NEXT:    v_cvt_i32_f32_e32 v5, v9
-; GFX12-GI-NEXT:    v_cvt_i32_f32_e32 v6, v10
-; GFX12-GI-NEXT:    v_cvt_i32_f32_e32 v2, v2
-; GFX12-GI-NEXT:    v_cvt_i32_f32_e32 v9, v4
-; GFX12-GI-NEXT:    v_cvt_i32_f32_e32 v10, v3
-; GFX12-GI-NEXT:    v_med3_i32 v3, v5, v7, 0x7f
-; GFX12-GI-NEXT:    v_med3_i32 v5, v2, v7, 0x7f
+; GFX12-GI-NEXT:    v_mov_b16_e32 v4.h, 0xff80
+; GFX12-GI-NEXT:    v_cvt_i16_f16_e32 v0.h, v0.h
+; GFX12-GI-NEXT:    v_cvt_i16_f16_e32 v4.l, v1.l
+; GFX12-GI-NEXT:    v_cvt_i16_f16_e32 v0.l, v0.l
+; GFX12-GI-NEXT:    v_cvt_i16_f16_e32 v3.h, v3.h
+; GFX12-GI-NEXT:    v_med3_i16 v1.l, v0.h, v4.h, 0x7f
+; GFX12-GI-NEXT:    v_med3_i16 v8.l, v4.l, v4.h, 0x7f
+; GFX12-GI-NEXT:    v_cvt_i16_f16_e32 v0.h, v1.h
+; GFX12-GI-NEXT:    v_cvt_i16_f16_e32 v1.h, v2.l
+; GFX12-GI-NEXT:    v_cvt_i16_f16_e32 v2.l, v2.h
+; GFX12-GI-NEXT:    v_cvt_i16_f16_e32 v2.h, v3.l
+; GFX12-GI-NEXT:    v_med3_i16 v0.l, v0.l, v4.h, 0x7f
+; GFX12-GI-NEXT:    v_med3_i16 v3.l, v0.h, v4.h, 0x7f
+; GFX12-GI-NEXT:    v_med3_i16 v4.l, v1.h, v4.h, 0x7f
+; GFX12-GI-NEXT:    v_med3_i16 v5.l, v2.l, v4.h, 0x7f
+; GFX12-GI-NEXT:    v_med3_i16 v6.l, v2.h, v4.h, 0x7f
+; GFX12-GI-NEXT:    v_med3_i16 v7.l, v3.h, v4.h, 0x7f
 ; GFX12-GI-NEXT:    v_mov_b32_e32 v2, v8
-; GFX12-GI-NEXT:    v_med3_i32 v4, v6, v7, 0x7f
-; GFX12-GI-NEXT:    v_med3_i32 v6, v9, v7, 0x7f
-; GFX12-GI-NEXT:    v_med3_i32 v7, v10, v7, 0x7f
 ; GFX12-GI-NEXT:    s_setpc_b64 s[30:31]
     %x = call <8 x i8> @llvm.fptosi.sat.v8f16.v8i8(<8 x half> %f)
     ret <8 x i8> %x
@@ -5481,46 +5437,28 @@ define <8 x i1> @test_s_signed_v8f16_v8i1(<8 x half> inreg %f) {
 ; GFX12-GI-NEXT:    s_wait_samplecnt 0x0
 ; GFX12-GI-NEXT:    s_wait_bvhcnt 0x0
 ; GFX12-GI-NEXT:    s_wait_kmcnt 0x0
-; GFX12-GI-NEXT:    s_cvt_f32_f16 s4, s0
-; GFX12-GI-NEXT:    s_cvt_hi_f32_f16 s0, s0
-; GFX12-GI-NEXT:    s_cvt_f32_f16 s5, s1
-; GFX12-GI-NEXT:    s_cvt_hi_f32_f16 s1, s1
-; GFX12-GI-NEXT:    s_cvt_f32_f16 s6, s2
-; GFX12-GI-NEXT:    s_cvt_hi_f32_f16 s2, s2
-; GFX12-GI-NEXT:    s_cvt_f32_f16 s7, s3
-; GFX12-GI-NEXT:    s_cvt_hi_f32_f16 s3, s3
+; GFX12-GI-NEXT:    s_lshr_b32 s4, s0, 16
+; GFX12-GI-NEXT:    v_cvt_i16_f16_e32 v1.h, s1
 ; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX12-GI-NEXT:    s_cvt_i32_f32 s4, s4
-; GFX12-GI-NEXT:    s_cvt_i32_f32 s0, s0
-; GFX12-GI-NEXT:    s_cvt_i32_f32 s5, s5
-; GFX12-GI-NEXT:    s_cvt_i32_f32 s1, s1
-; GFX12-GI-NEXT:    s_cvt_i32_f32 s6, s6
-; GFX12-GI-NEXT:    s_cvt_i32_f32 s2, s2
-; GFX12-GI-NEXT:    s_cvt_i32_f32 s7, s7
-; GFX12-GI-NEXT:    s_cvt_i32_f32 s3, s3
+; GFX12-GI-NEXT:    v_cvt_i16_f16_e32 v0.h, s4
+; GFX12-GI-NEXT:    s_lshr_b32 s5, s1, 16
+; GFX12-GI-NEXT:    v_cvt_i16_f16_e32 v0.l, s0
+; GFX12-GI-NEXT:    s_lshr_b32 s0, s2, 16
+; GFX12-GI-NEXT:    s_lshr_b32 s1, s3, 16
+; GFX12-GI-NEXT:    v_med3_i16 v1.l, v0.h, -1, 0
+; GFX12-GI-NEXT:    v_med3_i16 v2.l, v1.h, -1, 0
 ; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX12-GI-NEXT:    s_min_i32 s4, s4, 0
-; GFX12-GI-NEXT:    s_min_i32 s0, s0, 0
-; GFX12-GI-NEXT:    s_min_i32 s5, s5, 0
-; GFX12-GI-NEXT:    s_min_i32 s1, s1, 0
-; GFX12-GI-NEXT:    s_min_i32 s6, s6, 0
-; GFX12-GI-NEXT:    s_min_i32 s2, s2, 0
-; GFX12-GI-NEXT:    s_min_i32 s7, s7, 0
-; GFX12-GI-NEXT:    s_min_i32 s3, s3, 0
-; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX12-GI-NEXT:    s_max_i32 s4, s4, -1
-; GFX12-GI-NEXT:    s_max_i32 s0, s0, -1
-; GFX12-GI-NEXT:    s_max_i32 s5, s5, -1
-; GFX12-GI-NEXT:    s_max_i32 s1, s1, -1
-; GFX12-GI-NEXT:    s_max_i32 s6, s6, -1
-; GFX12-GI-NEXT:    s_max_i32 s2, s2, -1
-; GFX12-GI-NEXT:    s_max_i32 s7, s7, -1
-; GFX12-GI-NEXT:    s_max_i32 s3, s3, -1
-; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX12-GI-NEXT:    v_dual_mov_b32 v0, s4 :: v_dual_mov_b32 v1, s0
-; GFX12-GI-NEXT:    v_dual_mov_b32 v2, s5 :: v_dual_mov_b32 v3, s1
-; GFX12-GI-NEXT:    v_dual_mov_b32 v4, s6 :: v_dual_mov_b32 v5, s2
-; GFX12-GI-NEXT:    v_dual_mov_b32 v6, s7 :: v_dual_mov_b32 v7, s3
+; GFX12-GI-NEXT:    v_cvt_i16_f16_e32 v0.h, s5
+; GFX12-GI-NEXT:    v_cvt_i16_f16_e32 v1.h, s2
+; GFX12-GI-NEXT:    v_cvt_i16_f16_e32 v2.h, s0
+; GFX12-GI-NEXT:    v_cvt_i16_f16_e32 v3.h, s3
+; GFX12-GI-NEXT:    v_cvt_i16_f16_e32 v4.h, s1
+; GFX12-GI-NEXT:    v_med3_i16 v0.l, v0.l, -1, 0
+; GFX12-GI-NEXT:    v_med3_i16 v3.l, v0.h, -1, 0
+; GFX12-GI-NEXT:    v_med3_i16 v4.l, v1.h, -1, 0
+; GFX12-GI-NEXT:    v_med3_i16 v5.l, v2.h, -1, 0
+; GFX12-GI-NEXT:    v_med3_i16 v6.l, v3.h, -1, 0
+; GFX12-GI-NEXT:    v_med3_i16 v7.l, v4.h, -1, 0
 ; GFX12-GI-NEXT:    s_setpc_b64 s[30:31]
     %x = call <8 x i1> @llvm.fptosi.sat.v8f16.v8i1(<8 x half> %f)
     ret <8 x i1> %x
@@ -5925,46 +5863,28 @@ define <8 x i8> @test_s_signed_v8f16_v8i8(<8 x half> inreg %f) {
 ; GFX12-GI-NEXT:    s_wait_samplecnt 0x0
 ; GFX12-GI-NEXT:    s_wait_bvhcnt 0x0
 ; GFX12-GI-NEXT:    s_wait_kmcnt 0x0
-; GFX12-GI-NEXT:    s_cvt_f32_f16 s4, s0
-; GFX12-GI-NEXT:    s_cvt_hi_f32_f16 s0, s0
-; GFX12-GI-NEXT:    s_cvt_f32_f16 s5, s1
-; GFX12-GI-NEXT:    s_cvt_hi_f32_f16 s1, s1
-; GFX12-GI-NEXT:    s_cvt_f32_f16 s6, s2
-; GFX12-GI-NEXT:    s_cvt_hi_f32_f16 s2, s2
-; GFX12-GI-NEXT:    s_cvt_f32_f16 s7, s3
-; GFX12-GI-NEXT:    s_cvt_hi_f32_f16 s3, s3
+; GFX12-GI-NEXT:    v_mov_b16_e32 v0.h, 0xff80
+; GFX12-GI-NEXT:    v_cvt_i16_f16_e32 v1.h, s1
+; GFX12-GI-NEXT:    s_lshr_b32 s4, s0, 16
+; GFX12-GI-NEXT:    s_lshr_b32 s5, s1, 16
+; GFX12-GI-NEXT:    v_cvt_i16_f16_e32 v0.l, s0
+; GFX12-GI-NEXT:    s_lshr_b32 s0, s2, 16
+; GFX12-GI-NEXT:    s_lshr_b32 s1, s3, 16
 ; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX12-GI-NEXT:    s_cvt_i32_f32 s4, s4
-; GFX12-GI-NEXT:    s_cvt_i32_f32 s0, s0
-; GFX12-GI-NEXT:    s_cvt_i32_f32 s5, s5
-; GFX12-GI-NEXT:    s_cvt_i32_f32 s1, s1
-; GFX12-GI-NEXT:    s_cvt_i32_f32 s6, s6
-; GFX12-GI-NEXT:    s_cvt_i32_f32 s2, s2
-; GFX12-GI-NEXT:    s_cvt_i32_f32 s7, s7
-; GFX12-GI-NEXT:    s_cvt_i32_f32 s3, s3
-; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX12-GI-NEXT:    s_min_i32 s4, s4, 0x7f
-; GFX12-GI-NEXT:    s_min_i32 s0, s0, 0x7f
-; GFX12-GI-NEXT:    s_min_i32 s5, s5, 0x7f
-; GFX12-GI-NEXT:    s_min_i32 s1, s1, 0x7f
-; GFX12-GI-NEXT:    s_min_i32 s6, s6, 0x7f
-; GFX12-GI-NEXT:    s_min_i32 s2, s2, 0x7f
-; GFX12-GI-NEXT:    s_min_i32 s7, s7, 0x7f
-; GFX12-GI-NEXT:    s_min_i32 s3, s3, 0x7f
-; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX12-GI-NEXT:    s_max_i32 s4, s4, 0xffffff80
-; GFX12-GI-NEXT:    s_max_i32 s0, s0, 0xffffff80
-; GFX12-GI-NEXT:    s_max_i32 s5, s5, 0xffffff80
-; GFX12-GI-NEXT:    s_max_i32 s1, s1, 0xffffff80
-; GFX12-GI-NEXT:    s_max_i32 s6, s6, 0xffffff80
-; GFX12-GI-NEXT:    s_max_i32 s2, s2, 0xffffff80
-; GFX12-GI-NEXT:    s_max_i32 s7, s7, 0xffffff80
-; GFX12-GI-NEXT:    s_max_i32 s3, s3, 0xffffff80
-; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX12-GI-NEXT:    v_dual_mov_b32 v0, s4 :: v_dual_mov_b32 v1, s0
-; GFX12-GI-NEXT:    v_dual_mov_b32 v2, s5 :: v_dual_mov_b32 v3, s1
-; GFX12-GI-NEXT:    v_dual_mov_b32 v4, s6 :: v_dual_mov_b32 v5, s2
-; GFX12-GI-NEXT:    v_dual_mov_b32 v6, s7 :: v_dual_mov_b32 v7, s3
+; GFX12-GI-NEXT:    v_cvt_i16_f16_e32 v1.l, s4
+; GFX12-GI-NEXT:    v_med3_i16 v2.l, v1.h, v0.h, 0x7f
+; GFX12-GI-NEXT:    v_cvt_i16_f16_e32 v1.h, s5
+; GFX12-GI-NEXT:    v_cvt_i16_f16_e32 v2.h, s2
+; GFX12-GI-NEXT:    v_cvt_i16_f16_e32 v3.h, s0
+; GFX12-GI-NEXT:    v_cvt_i16_f16_e32 v4.h, s3
+; GFX12-GI-NEXT:    v_cvt_i16_f16_e32 v5.h, s1
+; GFX12-GI-NEXT:    v_med3_i16 v0.l, v0.l, v0.h, 0x7f
+; GFX12-GI-NEXT:    v_med3_i16 v1.l, v1.l, v0.h, 0x7f
+; GFX12-GI-NEXT:    v_med3_i16 v3.l, v1.h, v0.h, 0x7f
+; GFX12-GI-NEXT:    v_med3_i16 v4.l, v2.h, v0.h, 0x7f
+; GFX12-GI-NEXT:    v_med3_i16 v5.l, v3.h, v0.h, 0x7f
+; GFX12-GI-NEXT:    v_med3_i16 v6.l, v4.h, v0.h, 0x7f
+; GFX12-GI-NEXT:    v_med3_i16 v7.l, v5.h, v0.h, 0x7f
 ; GFX12-GI-NEXT:    s_setpc_b64 s[30:31]
     %x = call <8 x i8> @llvm.fptosi.sat.v8f16.v8i8(<8 x half> %f)
     ret <8 x i8> %x

--- a/llvm/test/CodeGen/AMDGPU/fptoui-sat-scalar.ll
+++ b/llvm/test/CodeGen/AMDGPU/fptoui-sat-scalar.ll
@@ -1205,9 +1205,8 @@ define i1 @test_unsigned_i1_f16(half %f) nounwind {
 ; GFX12-GI-NEXT:    s_wait_samplecnt 0x0
 ; GFX12-GI-NEXT:    s_wait_bvhcnt 0x0
 ; GFX12-GI-NEXT:    s_wait_kmcnt 0x0
-; GFX12-GI-NEXT:    v_cvt_f32_f16_e32 v0, v0.l
-; GFX12-GI-NEXT:    v_cvt_u32_f32_e32 v0, v0
-; GFX12-GI-NEXT:    v_min_u32_e32 v0, 1, v0
+; GFX12-GI-NEXT:    v_cvt_u16_f16_e32 v0.l, v0.l
+; GFX12-GI-NEXT:    v_min_u16 v0.l, v0.l, 1
 ; GFX12-GI-NEXT:    s_setpc_b64 s[30:31]
     %x = call i1 @llvm.fptoui.sat.i1.f16(half %f)
     ret i1 %x
@@ -1272,9 +1271,8 @@ define i8 @test_unsigned_i8_f16(half %f) nounwind {
 ; GFX12-GI-NEXT:    s_wait_samplecnt 0x0
 ; GFX12-GI-NEXT:    s_wait_bvhcnt 0x0
 ; GFX12-GI-NEXT:    s_wait_kmcnt 0x0
-; GFX12-GI-NEXT:    v_cvt_f32_f16_e32 v0, v0.l
-; GFX12-GI-NEXT:    v_cvt_u32_f32_e32 v0, v0
-; GFX12-GI-NEXT:    v_min_u32_e32 v0, 0xff, v0
+; GFX12-GI-NEXT:    v_cvt_u16_f16_e32 v0.l, v0.l
+; GFX12-GI-NEXT:    v_min_u16 v0.l, 0xff, v0.l
 ; GFX12-GI-NEXT:    s_setpc_b64 s[30:31]
     %x = call i8 @llvm.fptoui.sat.i8.f16(half %f)
     ret i8 %x
@@ -1541,13 +1539,8 @@ define i1 @test_s_unsigned_i1_f16(half inreg %f) nounwind {
 ; GFX12-GI-NEXT:    s_wait_samplecnt 0x0
 ; GFX12-GI-NEXT:    s_wait_bvhcnt 0x0
 ; GFX12-GI-NEXT:    s_wait_kmcnt 0x0
-; GFX12-GI-NEXT:    s_cvt_f32_f16 s0, s0
-; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX12-GI-NEXT:    s_cvt_u32_f32 s0, s0
-; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX12-GI-NEXT:    s_min_u32 s0, s0, 1
-; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX12-GI-NEXT:    v_mov_b32_e32 v0, s0
+; GFX12-GI-NEXT:    v_cvt_u16_f16_e32 v0.l, s0
+; GFX12-GI-NEXT:    v_min_u16 v0.l, v0.l, 1
 ; GFX12-GI-NEXT:    s_setpc_b64 s[30:31]
     %x = call i1 @llvm.fptoui.sat.i1.f16(half %f)
     ret i1 %x
@@ -1617,13 +1610,8 @@ define i8 @test_s_unsigned_i8_f16(half inreg %f) nounwind {
 ; GFX12-GI-NEXT:    s_wait_samplecnt 0x0
 ; GFX12-GI-NEXT:    s_wait_bvhcnt 0x0
 ; GFX12-GI-NEXT:    s_wait_kmcnt 0x0
-; GFX12-GI-NEXT:    s_cvt_f32_f16 s0, s0
-; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX12-GI-NEXT:    s_cvt_u32_f32 s0, s0
-; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX12-GI-NEXT:    s_min_u32 s0, s0, 0xff
-; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX12-GI-NEXT:    v_mov_b32_e32 v0, s0
+; GFX12-GI-NEXT:    v_cvt_u16_f16_e32 v0.l, s0
+; GFX12-GI-NEXT:    v_min_u16 v0.l, 0xff, v0.l
 ; GFX12-GI-NEXT:    s_setpc_b64 s[30:31]
     %x = call i8 @llvm.fptoui.sat.i8.f16(half %f)
     ret i8 %x

--- a/llvm/test/CodeGen/AMDGPU/fptoui-sat-vector.ll
+++ b/llvm/test/CodeGen/AMDGPU/fptoui-sat-vector.ll
@@ -2346,18 +2346,14 @@ define <4 x i1> @test_unsigned_v4f16_v4i1(<4 x half> %f) {
 ; GFX12-GI-NEXT:    s_wait_samplecnt 0x0
 ; GFX12-GI-NEXT:    s_wait_bvhcnt 0x0
 ; GFX12-GI-NEXT:    s_wait_kmcnt 0x0
-; GFX12-GI-NEXT:    v_cvt_f32_f16_e32 v2, v0.l
-; GFX12-GI-NEXT:    v_cvt_f32_f16_e32 v0, v0.h
-; GFX12-GI-NEXT:    v_cvt_f32_f16_e32 v3, v1.l
-; GFX12-GI-NEXT:    v_cvt_f32_f16_e32 v1, v1.h
-; GFX12-GI-NEXT:    v_cvt_u32_f32_e32 v2, v2
-; GFX12-GI-NEXT:    v_cvt_u32_f32_e32 v4, v0
-; GFX12-GI-NEXT:    v_cvt_u32_f32_e32 v3, v3
-; GFX12-GI-NEXT:    v_cvt_u32_f32_e32 v5, v1
-; GFX12-GI-NEXT:    v_min_u32_e32 v0, 1, v2
-; GFX12-GI-NEXT:    v_min_u32_e32 v1, 1, v4
-; GFX12-GI-NEXT:    v_min_u32_e32 v2, 1, v3
-; GFX12-GI-NEXT:    v_min_u32_e32 v3, 1, v5
+; GFX12-GI-NEXT:    v_cvt_u16_f16_e32 v0.l, v0.l
+; GFX12-GI-NEXT:    v_cvt_u16_f16_e32 v0.h, v0.h
+; GFX12-GI-NEXT:    v_cvt_u16_f16_e32 v2.l, v1.l
+; GFX12-GI-NEXT:    v_cvt_u16_f16_e32 v1.h, v1.h
+; GFX12-GI-NEXT:    v_min_u16 v0.l, v0.l, 1
+; GFX12-GI-NEXT:    v_min_u16 v1.l, v0.h, 1
+; GFX12-GI-NEXT:    v_min_u16 v2.l, v2.l, 1
+; GFX12-GI-NEXT:    v_min_u16 v3.l, v1.h, 1
 ; GFX12-GI-NEXT:    s_setpc_b64 s[30:31]
     %x = call <4 x i1> @llvm.fptoui.sat.v4f16.v4i1(<4 x half> %f)
     ret <4 x i1> %x
@@ -2537,18 +2533,14 @@ define <4 x i8> @test_unsigned_v4f16_v4i8(<4 x half> %f) {
 ; GFX12-GI-NEXT:    s_wait_samplecnt 0x0
 ; GFX12-GI-NEXT:    s_wait_bvhcnt 0x0
 ; GFX12-GI-NEXT:    s_wait_kmcnt 0x0
-; GFX12-GI-NEXT:    v_cvt_f32_f16_e32 v2, v0.l
-; GFX12-GI-NEXT:    v_cvt_f32_f16_e32 v0, v0.h
-; GFX12-GI-NEXT:    v_cvt_f32_f16_e32 v3, v1.l
-; GFX12-GI-NEXT:    v_cvt_f32_f16_e32 v1, v1.h
-; GFX12-GI-NEXT:    v_cvt_u32_f32_e32 v2, v2
-; GFX12-GI-NEXT:    v_cvt_u32_f32_e32 v4, v0
-; GFX12-GI-NEXT:    v_cvt_u32_f32_e32 v3, v3
-; GFX12-GI-NEXT:    v_cvt_u32_f32_e32 v5, v1
-; GFX12-GI-NEXT:    v_min_u32_e32 v0, 0xff, v2
-; GFX12-GI-NEXT:    v_min_u32_e32 v1, 0xff, v4
-; GFX12-GI-NEXT:    v_min_u32_e32 v2, 0xff, v3
-; GFX12-GI-NEXT:    v_min_u32_e32 v3, 0xff, v5
+; GFX12-GI-NEXT:    v_cvt_u16_f16_e32 v0.l, v0.l
+; GFX12-GI-NEXT:    v_cvt_u16_f16_e32 v0.h, v0.h
+; GFX12-GI-NEXT:    v_cvt_u16_f16_e32 v2.l, v1.l
+; GFX12-GI-NEXT:    v_cvt_u16_f16_e32 v1.h, v1.h
+; GFX12-GI-NEXT:    v_min_u16 v0.l, 0xff, v0.l
+; GFX12-GI-NEXT:    v_min_u16 v1.l, 0xff, v0.h
+; GFX12-GI-NEXT:    v_min_u16 v2.l, 0xff, v2.l
+; GFX12-GI-NEXT:    v_min_u16 v3.l, 0xff, v1.h
 ; GFX12-GI-NEXT:    s_setpc_b64 s[30:31]
     %x = call <4 x i8> @llvm.fptoui.sat.v4f16.v4i8(<4 x half> %f)
     ret <4 x i8> %x
@@ -3117,23 +3109,17 @@ define <4 x i1> @test_s_unsigned_v4f16_v4i1(<4 x half> inreg %f) {
 ; GFX12-GI-NEXT:    s_wait_samplecnt 0x0
 ; GFX12-GI-NEXT:    s_wait_bvhcnt 0x0
 ; GFX12-GI-NEXT:    s_wait_kmcnt 0x0
-; GFX12-GI-NEXT:    s_cvt_f32_f16 s2, s0
-; GFX12-GI-NEXT:    s_cvt_hi_f32_f16 s0, s0
-; GFX12-GI-NEXT:    s_cvt_f32_f16 s3, s1
-; GFX12-GI-NEXT:    s_cvt_hi_f32_f16 s1, s1
+; GFX12-GI-NEXT:    s_lshr_b32 s2, s0, 16
+; GFX12-GI-NEXT:    s_lshr_b32 s3, s1, 16
+; GFX12-GI-NEXT:    v_cvt_u16_f16_e32 v0.l, s0
+; GFX12-GI-NEXT:    v_cvt_u16_f16_e32 v0.h, s1
 ; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX12-GI-NEXT:    s_cvt_u32_f32 s2, s2
-; GFX12-GI-NEXT:    s_cvt_u32_f32 s0, s0
-; GFX12-GI-NEXT:    s_cvt_u32_f32 s3, s3
-; GFX12-GI-NEXT:    s_cvt_u32_f32 s1, s1
-; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX12-GI-NEXT:    s_min_u32 s2, s2, 1
-; GFX12-GI-NEXT:    s_min_u32 s0, s0, 1
-; GFX12-GI-NEXT:    s_min_u32 s3, s3, 1
-; GFX12-GI-NEXT:    s_min_u32 s1, s1, 1
-; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX12-GI-NEXT:    v_dual_mov_b32 v0, s2 :: v_dual_mov_b32 v1, s0
-; GFX12-GI-NEXT:    v_dual_mov_b32 v2, s3 :: v_dual_mov_b32 v3, s1
+; GFX12-GI-NEXT:    v_cvt_u16_f16_e32 v1.l, s2
+; GFX12-GI-NEXT:    v_cvt_u16_f16_e32 v1.h, s3
+; GFX12-GI-NEXT:    v_min_u16 v0.l, v0.l, 1
+; GFX12-GI-NEXT:    v_min_u16 v2.l, v0.h, 1
+; GFX12-GI-NEXT:    v_min_u16 v1.l, v1.l, 1
+; GFX12-GI-NEXT:    v_min_u16 v3.l, v1.h, 1
 ; GFX12-GI-NEXT:    s_setpc_b64 s[30:31]
     %x = call <4 x i1> @llvm.fptoui.sat.v4f16.v4i1(<4 x half> %f)
     ret <4 x i1> %x
@@ -3337,23 +3323,17 @@ define <4 x i8> @test_s_unsigned_v4f16_v4i8(<4 x half> inreg %f) {
 ; GFX12-GI-NEXT:    s_wait_samplecnt 0x0
 ; GFX12-GI-NEXT:    s_wait_bvhcnt 0x0
 ; GFX12-GI-NEXT:    s_wait_kmcnt 0x0
-; GFX12-GI-NEXT:    s_cvt_f32_f16 s2, s0
-; GFX12-GI-NEXT:    s_cvt_hi_f32_f16 s0, s0
-; GFX12-GI-NEXT:    s_cvt_f32_f16 s3, s1
-; GFX12-GI-NEXT:    s_cvt_hi_f32_f16 s1, s1
+; GFX12-GI-NEXT:    s_lshr_b32 s2, s0, 16
+; GFX12-GI-NEXT:    s_lshr_b32 s3, s1, 16
+; GFX12-GI-NEXT:    v_cvt_u16_f16_e32 v0.l, s0
+; GFX12-GI-NEXT:    v_cvt_u16_f16_e32 v0.h, s1
 ; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX12-GI-NEXT:    s_cvt_u32_f32 s2, s2
-; GFX12-GI-NEXT:    s_cvt_u32_f32 s0, s0
-; GFX12-GI-NEXT:    s_cvt_u32_f32 s3, s3
-; GFX12-GI-NEXT:    s_cvt_u32_f32 s1, s1
-; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX12-GI-NEXT:    s_min_u32 s2, s2, 0xff
-; GFX12-GI-NEXT:    s_min_u32 s0, s0, 0xff
-; GFX12-GI-NEXT:    s_min_u32 s3, s3, 0xff
-; GFX12-GI-NEXT:    s_min_u32 s1, s1, 0xff
-; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX12-GI-NEXT:    v_dual_mov_b32 v0, s2 :: v_dual_mov_b32 v1, s0
-; GFX12-GI-NEXT:    v_dual_mov_b32 v2, s3 :: v_dual_mov_b32 v3, s1
+; GFX12-GI-NEXT:    v_cvt_u16_f16_e32 v1.l, s2
+; GFX12-GI-NEXT:    v_cvt_u16_f16_e32 v1.h, s3
+; GFX12-GI-NEXT:    v_min_u16 v0.l, 0xff, v0.l
+; GFX12-GI-NEXT:    v_min_u16 v2.l, 0xff, v0.h
+; GFX12-GI-NEXT:    v_min_u16 v1.l, 0xff, v1.l
+; GFX12-GI-NEXT:    v_min_u16 v3.l, 0xff, v1.h
 ; GFX12-GI-NEXT:    s_setpc_b64 s[30:31]
     %x = call <4 x i8> @llvm.fptoui.sat.v4f16.v4i8(<4 x half> %f)
     ret <4 x i8> %x
@@ -3840,30 +3820,23 @@ define <8 x i1> @test_unsigned_v8f16_v8i1(<8 x half> %f) {
 ; GFX12-GI-NEXT:    s_wait_samplecnt 0x0
 ; GFX12-GI-NEXT:    s_wait_bvhcnt 0x0
 ; GFX12-GI-NEXT:    s_wait_kmcnt 0x0
-; GFX12-GI-NEXT:    v_cvt_f32_f16_e32 v4, v0.l
-; GFX12-GI-NEXT:    v_cvt_f32_f16_e32 v0, v0.h
-; GFX12-GI-NEXT:    v_cvt_f32_f16_e32 v5, v1.l
-; GFX12-GI-NEXT:    v_cvt_f32_f16_e32 v6, v1.h
-; GFX12-GI-NEXT:    v_cvt_f32_f16_e32 v7, v2.l
-; GFX12-GI-NEXT:    v_cvt_u32_f32_e32 v1, v4
-; GFX12-GI-NEXT:    v_cvt_u32_f32_e32 v4, v0
-; GFX12-GI-NEXT:    v_cvt_u32_f32_e32 v5, v5
-; GFX12-GI-NEXT:    v_cvt_f32_f16_e32 v8, v2.h
-; GFX12-GI-NEXT:    v_min_u32_e32 v0, 1, v1
-; GFX12-GI-NEXT:    v_min_u32_e32 v1, 1, v4
-; GFX12-GI-NEXT:    v_cvt_f32_f16_e32 v4, v3.l
-; GFX12-GI-NEXT:    v_cvt_f32_f16_e32 v3, v3.h
-; GFX12-GI-NEXT:    v_min_u32_e32 v2, 1, v5
-; GFX12-GI-NEXT:    v_cvt_u32_f32_e32 v5, v6
-; GFX12-GI-NEXT:    v_cvt_u32_f32_e32 v6, v7
-; GFX12-GI-NEXT:    v_cvt_u32_f32_e32 v7, v8
-; GFX12-GI-NEXT:    v_cvt_u32_f32_e32 v8, v4
-; GFX12-GI-NEXT:    v_cvt_u32_f32_e32 v9, v3
-; GFX12-GI-NEXT:    v_min_u32_e32 v3, 1, v5
-; GFX12-GI-NEXT:    v_min_u32_e32 v4, 1, v6
-; GFX12-GI-NEXT:    v_min_u32_e32 v5, 1, v7
-; GFX12-GI-NEXT:    v_min_u32_e32 v6, 1, v8
-; GFX12-GI-NEXT:    v_min_u32_e32 v7, 1, v9
+; GFX12-GI-NEXT:    v_cvt_u16_f16_e32 v0.h, v0.h
+; GFX12-GI-NEXT:    v_cvt_u16_f16_e32 v4.l, v1.l
+; GFX12-GI-NEXT:    v_cvt_u16_f16_e32 v0.l, v0.l
+; GFX12-GI-NEXT:    v_cvt_u16_f16_e32 v1.h, v1.h
+; GFX12-GI-NEXT:    v_cvt_u16_f16_e32 v3.h, v3.h
+; GFX12-GI-NEXT:    v_min_u16 v1.l, v0.h, 1
+; GFX12-GI-NEXT:    v_min_u16 v8.l, v4.l, 1
+; GFX12-GI-NEXT:    v_cvt_u16_f16_e32 v0.h, v2.l
+; GFX12-GI-NEXT:    v_cvt_u16_f16_e32 v2.l, v2.h
+; GFX12-GI-NEXT:    v_cvt_u16_f16_e32 v2.h, v3.l
+; GFX12-GI-NEXT:    v_min_u16 v0.l, v0.l, 1
+; GFX12-GI-NEXT:    v_min_u16 v3.l, v1.h, 1
+; GFX12-GI-NEXT:    v_min_u16 v4.l, v0.h, 1
+; GFX12-GI-NEXT:    v_min_u16 v5.l, v2.l, 1
+; GFX12-GI-NEXT:    v_min_u16 v6.l, v2.h, 1
+; GFX12-GI-NEXT:    v_min_u16 v7.l, v3.h, 1
+; GFX12-GI-NEXT:    v_mov_b32_e32 v2, v8
 ; GFX12-GI-NEXT:    s_setpc_b64 s[30:31]
     %x = call <8 x i1> @llvm.fptoui.sat.v8f16.v8i1(<8 x half> %f)
     ret <8 x i1> %x
@@ -4173,30 +4146,23 @@ define <8 x i8> @test_unsigned_v8f16_v8i8(<8 x half> %f) {
 ; GFX12-GI-NEXT:    s_wait_samplecnt 0x0
 ; GFX12-GI-NEXT:    s_wait_bvhcnt 0x0
 ; GFX12-GI-NEXT:    s_wait_kmcnt 0x0
-; GFX12-GI-NEXT:    v_cvt_f32_f16_e32 v4, v0.l
-; GFX12-GI-NEXT:    v_cvt_f32_f16_e32 v0, v0.h
-; GFX12-GI-NEXT:    v_cvt_f32_f16_e32 v5, v1.l
-; GFX12-GI-NEXT:    v_cvt_f32_f16_e32 v6, v1.h
-; GFX12-GI-NEXT:    v_cvt_f32_f16_e32 v7, v2.l
-; GFX12-GI-NEXT:    v_cvt_u32_f32_e32 v1, v4
-; GFX12-GI-NEXT:    v_cvt_u32_f32_e32 v4, v0
-; GFX12-GI-NEXT:    v_cvt_u32_f32_e32 v5, v5
-; GFX12-GI-NEXT:    v_cvt_f32_f16_e32 v8, v2.h
-; GFX12-GI-NEXT:    v_min_u32_e32 v0, 0xff, v1
-; GFX12-GI-NEXT:    v_min_u32_e32 v1, 0xff, v4
-; GFX12-GI-NEXT:    v_cvt_f32_f16_e32 v4, v3.l
-; GFX12-GI-NEXT:    v_cvt_f32_f16_e32 v3, v3.h
-; GFX12-GI-NEXT:    v_min_u32_e32 v2, 0xff, v5
-; GFX12-GI-NEXT:    v_cvt_u32_f32_e32 v5, v6
-; GFX12-GI-NEXT:    v_cvt_u32_f32_e32 v6, v7
-; GFX12-GI-NEXT:    v_cvt_u32_f32_e32 v7, v8
-; GFX12-GI-NEXT:    v_cvt_u32_f32_e32 v8, v4
-; GFX12-GI-NEXT:    v_cvt_u32_f32_e32 v9, v3
-; GFX12-GI-NEXT:    v_min_u32_e32 v3, 0xff, v5
-; GFX12-GI-NEXT:    v_min_u32_e32 v4, 0xff, v6
-; GFX12-GI-NEXT:    v_min_u32_e32 v5, 0xff, v7
-; GFX12-GI-NEXT:    v_min_u32_e32 v6, 0xff, v8
-; GFX12-GI-NEXT:    v_min_u32_e32 v7, 0xff, v9
+; GFX12-GI-NEXT:    v_cvt_u16_f16_e32 v0.h, v0.h
+; GFX12-GI-NEXT:    v_cvt_u16_f16_e32 v4.l, v1.l
+; GFX12-GI-NEXT:    v_cvt_u16_f16_e32 v0.l, v0.l
+; GFX12-GI-NEXT:    v_cvt_u16_f16_e32 v1.h, v1.h
+; GFX12-GI-NEXT:    v_cvt_u16_f16_e32 v3.h, v3.h
+; GFX12-GI-NEXT:    v_min_u16 v1.l, 0xff, v0.h
+; GFX12-GI-NEXT:    v_min_u16 v8.l, 0xff, v4.l
+; GFX12-GI-NEXT:    v_cvt_u16_f16_e32 v0.h, v2.l
+; GFX12-GI-NEXT:    v_cvt_u16_f16_e32 v2.l, v2.h
+; GFX12-GI-NEXT:    v_cvt_u16_f16_e32 v2.h, v3.l
+; GFX12-GI-NEXT:    v_min_u16 v0.l, 0xff, v0.l
+; GFX12-GI-NEXT:    v_min_u16 v3.l, 0xff, v1.h
+; GFX12-GI-NEXT:    v_min_u16 v4.l, 0xff, v0.h
+; GFX12-GI-NEXT:    v_min_u16 v5.l, 0xff, v2.l
+; GFX12-GI-NEXT:    v_min_u16 v6.l, 0xff, v2.h
+; GFX12-GI-NEXT:    v_min_u16 v7.l, 0xff, v3.h
+; GFX12-GI-NEXT:    v_mov_b32_e32 v2, v8
 ; GFX12-GI-NEXT:    s_setpc_b64 s[30:31]
     %x = call <8 x i8> @llvm.fptoui.sat.v8f16.v8i8(<8 x half> %f)
     ret <8 x i8> %x
@@ -5126,37 +5092,28 @@ define <8 x i1> @test_s_unsigned_v8f16_v8i1(<8 x half> inreg %f) {
 ; GFX12-GI-NEXT:    s_wait_samplecnt 0x0
 ; GFX12-GI-NEXT:    s_wait_bvhcnt 0x0
 ; GFX12-GI-NEXT:    s_wait_kmcnt 0x0
-; GFX12-GI-NEXT:    s_cvt_f32_f16 s4, s0
-; GFX12-GI-NEXT:    s_cvt_hi_f32_f16 s0, s0
-; GFX12-GI-NEXT:    s_cvt_f32_f16 s5, s1
-; GFX12-GI-NEXT:    s_cvt_hi_f32_f16 s1, s1
-; GFX12-GI-NEXT:    s_cvt_f32_f16 s6, s2
-; GFX12-GI-NEXT:    s_cvt_hi_f32_f16 s2, s2
-; GFX12-GI-NEXT:    s_cvt_f32_f16 s7, s3
-; GFX12-GI-NEXT:    s_cvt_hi_f32_f16 s3, s3
+; GFX12-GI-NEXT:    s_lshr_b32 s4, s0, 16
+; GFX12-GI-NEXT:    v_cvt_u16_f16_e32 v1.h, s1
 ; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX12-GI-NEXT:    s_cvt_u32_f32 s4, s4
-; GFX12-GI-NEXT:    s_cvt_u32_f32 s0, s0
-; GFX12-GI-NEXT:    s_cvt_u32_f32 s5, s5
-; GFX12-GI-NEXT:    s_cvt_u32_f32 s1, s1
-; GFX12-GI-NEXT:    s_cvt_u32_f32 s6, s6
-; GFX12-GI-NEXT:    s_cvt_u32_f32 s2, s2
-; GFX12-GI-NEXT:    s_cvt_u32_f32 s7, s7
-; GFX12-GI-NEXT:    s_cvt_u32_f32 s3, s3
+; GFX12-GI-NEXT:    v_cvt_u16_f16_e32 v0.h, s4
+; GFX12-GI-NEXT:    s_lshr_b32 s5, s1, 16
+; GFX12-GI-NEXT:    v_cvt_u16_f16_e32 v0.l, s0
+; GFX12-GI-NEXT:    s_lshr_b32 s0, s2, 16
+; GFX12-GI-NEXT:    s_lshr_b32 s1, s3, 16
+; GFX12-GI-NEXT:    v_min_u16 v1.l, v0.h, 1
+; GFX12-GI-NEXT:    v_min_u16 v2.l, v1.h, 1
 ; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX12-GI-NEXT:    s_min_u32 s4, s4, 1
-; GFX12-GI-NEXT:    s_min_u32 s0, s0, 1
-; GFX12-GI-NEXT:    s_min_u32 s5, s5, 1
-; GFX12-GI-NEXT:    s_min_u32 s1, s1, 1
-; GFX12-GI-NEXT:    s_min_u32 s6, s6, 1
-; GFX12-GI-NEXT:    s_min_u32 s2, s2, 1
-; GFX12-GI-NEXT:    s_min_u32 s7, s7, 1
-; GFX12-GI-NEXT:    s_min_u32 s3, s3, 1
-; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX12-GI-NEXT:    v_dual_mov_b32 v0, s4 :: v_dual_mov_b32 v1, s0
-; GFX12-GI-NEXT:    v_dual_mov_b32 v2, s5 :: v_dual_mov_b32 v3, s1
-; GFX12-GI-NEXT:    v_dual_mov_b32 v4, s6 :: v_dual_mov_b32 v5, s2
-; GFX12-GI-NEXT:    v_dual_mov_b32 v6, s7 :: v_dual_mov_b32 v7, s3
+; GFX12-GI-NEXT:    v_cvt_u16_f16_e32 v0.h, s5
+; GFX12-GI-NEXT:    v_cvt_u16_f16_e32 v1.h, s2
+; GFX12-GI-NEXT:    v_cvt_u16_f16_e32 v2.h, s0
+; GFX12-GI-NEXT:    v_cvt_u16_f16_e32 v3.h, s3
+; GFX12-GI-NEXT:    v_cvt_u16_f16_e32 v4.h, s1
+; GFX12-GI-NEXT:    v_min_u16 v0.l, v0.l, 1
+; GFX12-GI-NEXT:    v_min_u16 v3.l, v0.h, 1
+; GFX12-GI-NEXT:    v_min_u16 v4.l, v1.h, 1
+; GFX12-GI-NEXT:    v_min_u16 v5.l, v2.h, 1
+; GFX12-GI-NEXT:    v_min_u16 v6.l, v3.h, 1
+; GFX12-GI-NEXT:    v_min_u16 v7.l, v4.h, 1
 ; GFX12-GI-NEXT:    s_setpc_b64 s[30:31]
     %x = call <8 x i1> @llvm.fptoui.sat.v8f16.v8i1(<8 x half> %f)
     ret <8 x i1> %x
@@ -5514,37 +5471,28 @@ define <8 x i8> @test_s_unsigned_v8f16_v8i8(<8 x half> inreg %f) {
 ; GFX12-GI-NEXT:    s_wait_samplecnt 0x0
 ; GFX12-GI-NEXT:    s_wait_bvhcnt 0x0
 ; GFX12-GI-NEXT:    s_wait_kmcnt 0x0
-; GFX12-GI-NEXT:    s_cvt_f32_f16 s4, s0
-; GFX12-GI-NEXT:    s_cvt_hi_f32_f16 s0, s0
-; GFX12-GI-NEXT:    s_cvt_f32_f16 s5, s1
-; GFX12-GI-NEXT:    s_cvt_hi_f32_f16 s1, s1
-; GFX12-GI-NEXT:    s_cvt_f32_f16 s6, s2
-; GFX12-GI-NEXT:    s_cvt_hi_f32_f16 s2, s2
-; GFX12-GI-NEXT:    s_cvt_f32_f16 s7, s3
-; GFX12-GI-NEXT:    s_cvt_hi_f32_f16 s3, s3
+; GFX12-GI-NEXT:    s_lshr_b32 s4, s0, 16
+; GFX12-GI-NEXT:    v_cvt_u16_f16_e32 v1.h, s1
 ; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX12-GI-NEXT:    s_cvt_u32_f32 s4, s4
-; GFX12-GI-NEXT:    s_cvt_u32_f32 s0, s0
-; GFX12-GI-NEXT:    s_cvt_u32_f32 s5, s5
-; GFX12-GI-NEXT:    s_cvt_u32_f32 s1, s1
-; GFX12-GI-NEXT:    s_cvt_u32_f32 s6, s6
-; GFX12-GI-NEXT:    s_cvt_u32_f32 s2, s2
-; GFX12-GI-NEXT:    s_cvt_u32_f32 s7, s7
-; GFX12-GI-NEXT:    s_cvt_u32_f32 s3, s3
+; GFX12-GI-NEXT:    v_cvt_u16_f16_e32 v0.h, s4
+; GFX12-GI-NEXT:    s_lshr_b32 s5, s1, 16
+; GFX12-GI-NEXT:    v_cvt_u16_f16_e32 v0.l, s0
+; GFX12-GI-NEXT:    s_lshr_b32 s0, s2, 16
+; GFX12-GI-NEXT:    s_lshr_b32 s1, s3, 16
+; GFX12-GI-NEXT:    v_min_u16 v1.l, 0xff, v0.h
+; GFX12-GI-NEXT:    v_min_u16 v2.l, 0xff, v1.h
 ; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX12-GI-NEXT:    s_min_u32 s4, s4, 0xff
-; GFX12-GI-NEXT:    s_min_u32 s0, s0, 0xff
-; GFX12-GI-NEXT:    s_min_u32 s5, s5, 0xff
-; GFX12-GI-NEXT:    s_min_u32 s1, s1, 0xff
-; GFX12-GI-NEXT:    s_min_u32 s6, s6, 0xff
-; GFX12-GI-NEXT:    s_min_u32 s2, s2, 0xff
-; GFX12-GI-NEXT:    s_min_u32 s7, s7, 0xff
-; GFX12-GI-NEXT:    s_min_u32 s3, s3, 0xff
-; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX12-GI-NEXT:    v_dual_mov_b32 v0, s4 :: v_dual_mov_b32 v1, s0
-; GFX12-GI-NEXT:    v_dual_mov_b32 v2, s5 :: v_dual_mov_b32 v3, s1
-; GFX12-GI-NEXT:    v_dual_mov_b32 v4, s6 :: v_dual_mov_b32 v5, s2
-; GFX12-GI-NEXT:    v_dual_mov_b32 v6, s7 :: v_dual_mov_b32 v7, s3
+; GFX12-GI-NEXT:    v_cvt_u16_f16_e32 v0.h, s5
+; GFX12-GI-NEXT:    v_cvt_u16_f16_e32 v1.h, s2
+; GFX12-GI-NEXT:    v_cvt_u16_f16_e32 v2.h, s0
+; GFX12-GI-NEXT:    v_cvt_u16_f16_e32 v3.h, s3
+; GFX12-GI-NEXT:    v_cvt_u16_f16_e32 v4.h, s1
+; GFX12-GI-NEXT:    v_min_u16 v0.l, 0xff, v0.l
+; GFX12-GI-NEXT:    v_min_u16 v3.l, 0xff, v0.h
+; GFX12-GI-NEXT:    v_min_u16 v4.l, 0xff, v1.h
+; GFX12-GI-NEXT:    v_min_u16 v5.l, 0xff, v2.h
+; GFX12-GI-NEXT:    v_min_u16 v6.l, 0xff, v3.h
+; GFX12-GI-NEXT:    v_min_u16 v7.l, 0xff, v4.h
 ; GFX12-GI-NEXT:    s_setpc_b64 s[30:31]
     %x = call <8 x i8> @llvm.fptoui.sat.v8f16.v8i8(<8 x half> %f)
     ret <8 x i8> %x


### PR DESCRIPTION
GlobaISel now also saturates `i1` and `i8` to `f16` conversion at `i16` where available. As a side effect, this also causes the two uniform test cases: `f16_i1` and `f16_i8` to use VALU instructions, instead of SALU instructions. This is potentially sub-optimal but it makes it consistent with ISel and has been already highlighted as future work in #187711.