### PR TITLE
[libclc][NFC] Simplify __CLC_GENTYPE/__CLC_U_GENTYPE/__CLC_S_GENTYPE define in gentype.inc

### DIFF
--- a/libclc/clc/include/clc/integer/gentype.inc
+++ b/libclc/clc/include/clc/integer/gentype.inc
@@ -9,6 +9,10 @@
 #include "clc/clcfunc.h"
 #include "clc/utils.h"
 
+#define __CLC_GENTYPE __CLC_XCONCAT(__CLC_SCALAR_GENTYPE, __CLC_VECSIZE)
+#define __CLC_U_GENTYPE __CLC_XCONCAT(__CLC_U_SCALAR_GENTYPE, __CLC_VECSIZE)
+#define __CLC_S_GENTYPE __CLC_XCONCAT(__CLC_S_SCALAR_GENTYPE, __CLC_VECSIZE)
+
 #define __CLC_AS_GENTYPE __CLC_XCONCAT(__clc_as_, __CLC_GENTYPE)
 #define __CLC_CONVERT_GENTYPE __CLC_XCONCAT(__clc_convert_, __CLC_GENTYPE)
 
@@ -22,11 +26,10 @@
 // to keep this file manageable.
 #define __CLC_GENSIZE 8
 #define __CLC_SCALAR_GENTYPE char
+#define __CLC_U_SCALAR_GENTYPE uchar
+#define __CLC_S_SCALAR_GENTYPE char
 #define __CLC_GEN_S
 
-#define __CLC_GENTYPE char
-#define __CLC_U_GENTYPE uchar
-#define __CLC_S_GENTYPE char
 #define __CLC_SCALAR
 #define __CLC_VECSIZE
 #define __CLC_VECSIZE_OR_1 1
@@ -34,71 +37,39 @@
 #undef __CLC_VECSIZE_OR_1
 #undef __CLC_VECSIZE
 #undef __CLC_SCALAR
-#undef __CLC_GENTYPE
-#undef __CLC_U_GENTYPE
-#undef __CLC_S_GENTYPE
 
 #define __CLC_VECSIZE_OR_1 __CLC_VECSIZE
 
-#define __CLC_GENTYPE char2
-#define __CLC_U_GENTYPE uchar2
-#define __CLC_S_GENTYPE char2
 #define __CLC_VECSIZE 2
 #include __CLC_BODY
 #undef __CLC_VECSIZE
-#undef __CLC_GENTYPE
-#undef __CLC_U_GENTYPE
-#undef __CLC_S_GENTYPE
 
-#define __CLC_GENTYPE char3
-#define __CLC_U_GENTYPE uchar3
-#define __CLC_S_GENTYPE char3
 #define __CLC_VECSIZE 3
 #include __CLC_BODY
 #undef __CLC_VECSIZE
-#undef __CLC_GENTYPE
-#undef __CLC_U_GENTYPE
-#undef __CLC_S_GENTYPE
 
-#define __CLC_GENTYPE char4
-#define __CLC_U_GENTYPE uchar4
-#define __CLC_S_GENTYPE char4
 #define __CLC_VECSIZE 4
 #include __CLC_BODY
 #undef __CLC_VECSIZE
-#undef __CLC_GENTYPE
-#undef __CLC_U_GENTYPE
-#undef __CLC_S_GENTYPE
 
-#define __CLC_GENTYPE char8
-#define __CLC_U_GENTYPE uchar8
-#define __CLC_S_GENTYPE char8
 #define __CLC_VECSIZE 8
 #include __CLC_BODY
 #undef __CLC_VECSIZE
-#undef __CLC_GENTYPE
-#undef __CLC_U_GENTYPE
-#undef __CLC_S_GENTYPE
 
-#define __CLC_GENTYPE char16
-#define __CLC_U_GENTYPE uchar16
-#define __CLC_S_GENTYPE char16
 #define __CLC_VECSIZE 16
 #include __CLC_BODY
 #undef __CLC_VECSIZE
-#undef __CLC_GENTYPE
-#undef __CLC_U_GENTYPE
-#undef __CLC_S_GENTYPE
 #undef __CLC_VECSIZE_OR_1
 
 #undef __CLC_SCALAR_GENTYPE
+#undef __CLC_U_SCALAR_GENTYPE
+#undef __CLC_S_SCALAR_GENTYPE
 #define __CLC_SCALAR_GENTYPE uchar
+#define __CLC_U_SCALAR_GENTYPE uchar
+#define __CLC_S_SCALAR_GENTYPE char
 #undef __CLC_GEN_S
 #define __CLC_GEN_U
 
-#define __CLC_GENTYPE uchar
-#define __CLC_U_GENTYPE uchar
-#define __CLC_S_GENTYPE char
 #define __CLC_SCALAR
 #define __CLC_VECSIZE
 #define __CLC_VECSIZE_OR_1 1
@@ -106,73 +77,41 @@
 #undef __CLC_VECSIZE_OR_1
 #undef __CLC_VECSIZE
 #undef __CLC_SCALAR
-#undef __CLC_GENTYPE
-#undef __CLC_U_GENTYPE
-#undef __CLC_S_GENTYPE
 
 #define __CLC_VECSIZE_OR_1 __CLC_VECSIZE
 
-#define __CLC_GENTYPE uchar2
-#define __CLC_U_GENTYPE uchar2
-#define __CLC_S_GENTYPE char2
 #define __CLC_VECSIZE 2
 #include __CLC_BODY
 #undef __CLC_VECSIZE
-#undef __CLC_GENTYPE
-#undef __CLC_U_GENTYPE
-#undef __CLC_S_GENTYPE
 
-#define __CLC_GENTYPE uchar3
-#define __CLC_U_GENTYPE uchar3
-#define __CLC_S_GENTYPE char3
 #define __CLC_VECSIZE 3
 #include __CLC_BODY
 #undef __CLC_VECSIZE
-#undef __CLC_GENTYPE
-#undef __CLC_U_GENTYPE
-#undef __CLC_S_GENTYPE
 
-#define __CLC_GENTYPE uchar4
-#define __CLC_U_GENTYPE uchar4
-#define __CLC_S_GENTYPE char4
 #define __CLC_VECSIZE 4
 #include __CLC_BODY
 #undef __CLC_VECSIZE
-#undef __CLC_GENTYPE
-#undef __CLC_U_GENTYPE
-#undef __CLC_S_GENTYPE
 
-#define __CLC_GENTYPE uchar8
-#define __CLC_U_GENTYPE uchar8
-#define __CLC_S_GENTYPE char8
 #define __CLC_VECSIZE 8
 #include __CLC_BODY
 #undef __CLC_VECSIZE
-#undef __CLC_GENTYPE
-#undef __CLC_U_GENTYPE
-#undef __CLC_S_GENTYPE
 
-#define __CLC_GENTYPE uchar16
-#define __CLC_U_GENTYPE uchar16
-#define __CLC_S_GENTYPE char16
 #define __CLC_VECSIZE 16
 #include __CLC_BODY
 #undef __CLC_VECSIZE
-#undef __CLC_GENTYPE
-#undef __CLC_U_GENTYPE
-#undef __CLC_S_GENTYPE
 #undef __CLC_VECSIZE_OR_1
 
 #undef __CLC_GENSIZE
 #define __CLC_GENSIZE 16
 #undef __CLC_SCALAR_GENTYPE
+#undef __CLC_U_SCALAR_GENTYPE
+#undef __CLC_S_SCALAR_GENTYPE
 #define __CLC_SCALAR_GENTYPE short
+#define __CLC_U_SCALAR_GENTYPE ushort
+#define __CLC_S_SCALAR_GENTYPE short
 #undef __CLC_GEN_U
 #define __CLC_GEN_S
 
-#define __CLC_GENTYPE short
-#define __CLC_U_GENTYPE ushort
-#define __CLC_S_GENTYPE short
 #define __CLC_SCALAR
 #define __CLC_VECSIZE
 #define __CLC_VECSIZE_OR_1 1
@@ -180,71 +119,39 @@
 #undef __CLC_VECSIZE_OR_1
 #undef __CLC_VECSIZE
 #undef __CLC_SCALAR
-#undef __CLC_GENTYPE
-#undef __CLC_U_GENTYPE
-#undef __CLC_S_GENTYPE
 
 #define __CLC_VECSIZE_OR_1 __CLC_VECSIZE
 
-#define __CLC_GENTYPE short2
-#define __CLC_U_GENTYPE ushort2
-#define __CLC_S_GENTYPE short2
 #define __CLC_VECSIZE 2
 #include __CLC_BODY
 #undef __CLC_VECSIZE
-#undef __CLC_GENTYPE
-#undef __CLC_U_GENTYPE
-#undef __CLC_S_GENTYPE
 
-#define __CLC_GENTYPE short3
-#define __CLC_U_GENTYPE ushort3
-#define __CLC_S_GENTYPE short3
 #define __CLC_VECSIZE 3
 #include __CLC_BODY
 #undef __CLC_VECSIZE
-#undef __CLC_GENTYPE
-#undef __CLC_U_GENTYPE
-#undef __CLC_S_GENTYPE
 
-#define __CLC_GENTYPE short4
-#define __CLC_U_GENTYPE ushort4
-#define __CLC_S_GENTYPE short4
 #define __CLC_VECSIZE 4
 #include __CLC_BODY
 #undef __CLC_VECSIZE
-#undef __CLC_GENTYPE
-#undef __CLC_U_GENTYPE
-#undef __CLC_S_GENTYPE
 
-#define __CLC_GENTYPE short8
-#define __CLC_U_GENTYPE ushort8
-#define __CLC_S_GENTYPE short8
 #define __CLC_VECSIZE 8
 #include __CLC_BODY
 #undef __CLC_VECSIZE
-#undef __CLC_GENTYPE
-#undef __CLC_U_GENTYPE
-#undef __CLC_S_GENTYPE
 
-#define __CLC_GENTYPE short16
-#define __CLC_U_GENTYPE ushort16
-#define __CLC_S_GENTYPE short16
 #define __CLC_VECSIZE 16
 #include __CLC_BODY
 #undef __CLC_VECSIZE
-#undef __CLC_GENTYPE
-#undef __CLC_U_GENTYPE
-#undef __CLC_S_GENTYPE
 #undef __CLC_VECSIZE_OR_1
 
 #undef __CLC_SCALAR_GENTYPE
+#undef __CLC_U_SCALAR_GENTYPE
+#undef __CLC_S_SCALAR_GENTYPE
 #define __CLC_SCALAR_GENTYPE ushort
+#define __CLC_U_SCALAR_GENTYPE ushort
+#define __CLC_S_SCALAR_GENTYPE short
 #undef __CLC_GEN_S
 #define __CLC_GEN_U
 
-#define __CLC_GENTYPE ushort
-#define __CLC_U_GENTYPE ushort
-#define __CLC_S_GENTYPE short
 #define __CLC_SCALAR
 #define __CLC_VECSIZE
 #define __CLC_VECSIZE_OR_1 1
@@ -252,73 +159,41 @@
 #undef __CLC_VECSIZE_OR_1
 #undef __CLC_VECSIZE
 #undef __CLC_SCALAR
-#undef __CLC_GENTYPE
-#undef __CLC_U_GENTYPE
-#undef __CLC_S_GENTYPE
 
 #define __CLC_VECSIZE_OR_1 __CLC_VECSIZE
 
-#define __CLC_GENTYPE ushort2
-#define __CLC_U_GENTYPE ushort2
-#define __CLC_S_GENTYPE short2
 #define __CLC_VECSIZE 2
 #include __CLC_BODY
 #undef __CLC_VECSIZE
-#undef __CLC_GENTYPE
-#undef __CLC_U_GENTYPE
-#undef __CLC_S_GENTYPE
 
-#define __CLC_GENTYPE ushort3
-#define __CLC_U_GENTYPE ushort3
-#define __CLC_S_GENTYPE short3
 #define __CLC_VECSIZE 3
 #include __CLC_BODY
 #undef __CLC_VECSIZE
-#undef __CLC_GENTYPE
-#undef __CLC_U_GENTYPE
-#undef __CLC_S_GENTYPE
 
-#define __CLC_GENTYPE ushort4
-#define __CLC_U_GENTYPE ushort4
-#define __CLC_S_GENTYPE short4
 #define __CLC_VECSIZE 4
 #include __CLC_BODY
 #undef __CLC_VECSIZE
-#undef __CLC_GENTYPE
-#undef __CLC_U_GENTYPE
-#undef __CLC_S_GENTYPE
 
-#define __CLC_GENTYPE ushort8
-#define __CLC_U_GENTYPE ushort8
-#define __CLC_S_GENTYPE short8
 #define __CLC_VECSIZE 8
 #include __CLC_BODY
 #undef __CLC_VECSIZE
-#undef __CLC_GENTYPE
-#undef __CLC_U_GENTYPE
-#undef __CLC_S_GENTYPE
 
-#define __CLC_GENTYPE ushort16
-#define __CLC_U_GENTYPE ushort16
-#define __CLC_S_GENTYPE short16
 #define __CLC_VECSIZE 16
 #include __CLC_BODY
 #undef __CLC_VECSIZE
-#undef __CLC_GENTYPE
-#undef __CLC_U_GENTYPE
-#undef __CLC_S_GENTYPE
 #undef __CLC_VECSIZE_OR_1
 
 #undef __CLC_GENSIZE
 #define __CLC_GENSIZE 32
 #undef __CLC_SCALAR_GENTYPE
+#undef __CLC_U_SCALAR_GENTYPE
+#undef __CLC_S_SCALAR_GENTYPE
 #define __CLC_SCALAR_GENTYPE int
+#define __CLC_U_SCALAR_GENTYPE uint
+#define __CLC_S_SCALAR_GENTYPE int
 #undef __CLC_GEN_U
 #define __CLC_GEN_S
 
-#define __CLC_GENTYPE int
-#define __CLC_U_GENTYPE uint
-#define __CLC_S_GENTYPE int
 #define __CLC_SCALAR
 #define __CLC_VECSIZE
 #define __CLC_VECSIZE_OR_1 1
@@ -326,71 +201,39 @@
 #undef __CLC_VECSIZE_OR_1
 #undef __CLC_VECSIZE
 #undef __CLC_SCALAR
-#undef __CLC_GENTYPE
-#undef __CLC_U_GENTYPE
-#undef __CLC_S_GENTYPE
 
 #define __CLC_VECSIZE_OR_1 __CLC_VECSIZE
 
-#define __CLC_GENTYPE int2
-#define __CLC_U_GENTYPE uint2
-#define __CLC_S_GENTYPE int2
 #define __CLC_VECSIZE 2
 #include __CLC_BODY
 #undef __CLC_VECSIZE
-#undef __CLC_GENTYPE
-#undef __CLC_U_GENTYPE
-#undef __CLC_S_GENTYPE
 
-#define __CLC_GENTYPE int3
-#define __CLC_U_GENTYPE uint3
-#define __CLC_S_GENTYPE int3
 #define __CLC_VECSIZE 3
 #include __CLC_BODY
 #undef __CLC_VECSIZE
-#undef __CLC_GENTYPE
-#undef __CLC_U_GENTYPE
-#undef __CLC_S_GENTYPE
 
-#define __CLC_GENTYPE int4
-#define __CLC_U_GENTYPE uint4
-#define __CLC_S_GENTYPE int4
 #define __CLC_VECSIZE 4
 #include __CLC_BODY
 #undef __CLC_VECSIZE
-#undef __CLC_GENTYPE
-#undef __CLC_U_GENTYPE
-#undef __CLC_S_GENTYPE
 
-#define __CLC_GENTYPE int8
-#define __CLC_U_GENTYPE uint8
-#define __CLC_S_GENTYPE int8
 #define __CLC_VECSIZE 8
 #include __CLC_BODY
 #undef __CLC_VECSIZE
-#undef __CLC_GENTYPE
-#undef __CLC_U_GENTYPE
-#undef __CLC_S_GENTYPE
 
-#define __CLC_GENTYPE int16
-#define __CLC_U_GENTYPE uint16
-#define __CLC_S_GENTYPE int16
 #define __CLC_VECSIZE 16
 #include __CLC_BODY
 #undef __CLC_VECSIZE
-#undef __CLC_GENTYPE
-#undef __CLC_U_GENTYPE
-#undef __CLC_S_GENTYPE
 #undef __CLC_VECSIZE_OR_1
 
 #undef __CLC_SCALAR_GENTYPE
+#undef __CLC_U_SCALAR_GENTYPE
+#undef __CLC_S_SCALAR_GENTYPE
 #define __CLC_SCALAR_GENTYPE uint
+#define __CLC_U_SCALAR_GENTYPE uint
+#define __CLC_S_SCALAR_GENTYPE int
 #undef __CLC_GEN_S
 #define __CLC_GEN_U
 
-#define __CLC_GENTYPE uint
-#define __CLC_U_GENTYPE uint
-#define __CLC_S_GENTYPE int
 #define __CLC_SCALAR
 #define __CLC_VECSIZE
 #define __CLC_VECSIZE_OR_1 1
@@ -398,73 +241,41 @@
 #undef __CLC_VECSIZE_OR_1
 #undef __CLC_VECSIZE
 #undef __CLC_SCALAR
-#undef __CLC_GENTYPE
-#undef __CLC_U_GENTYPE
-#undef __CLC_S_GENTYPE
 
 #define __CLC_VECSIZE_OR_1 __CLC_VECSIZE
 
-#define __CLC_GENTYPE uint2
-#define __CLC_U_GENTYPE uint2
-#define __CLC_S_GENTYPE int2
 #define __CLC_VECSIZE 2
 #include __CLC_BODY
 #undef __CLC_VECSIZE
-#undef __CLC_GENTYPE
-#undef __CLC_U_GENTYPE
-#undef __CLC_S_GENTYPE
 
-#define __CLC_GENTYPE uint3
-#define __CLC_U_GENTYPE uint3
-#define __CLC_S_GENTYPE int3
 #define __CLC_VECSIZE 3
 #include __CLC_BODY
 #undef __CLC_VECSIZE
-#undef __CLC_GENTYPE
-#undef __CLC_U_GENTYPE
-#undef __CLC_S_GENTYPE
 
-#define __CLC_GENTYPE uint4
-#define __CLC_U_GENTYPE uint4
-#define __CLC_S_GENTYPE int4
 #define __CLC_VECSIZE 4
 #include __CLC_BODY
 #undef __CLC_VECSIZE
-#undef __CLC_GENTYPE
-#undef __CLC_U_GENTYPE
-#undef __CLC_S_GENTYPE
 
-#define __CLC_GENTYPE uint8
-#define __CLC_U_GENTYPE uint8
-#define __CLC_S_GENTYPE int8
 #define __CLC_VECSIZE 8
 #include __CLC_BODY
 #undef __CLC_VECSIZE
-#undef __CLC_GENTYPE
-#undef __CLC_U_GENTYPE
-#undef __CLC_S_GENTYPE
 
-#define __CLC_GENTYPE uint16
-#define __CLC_U_GENTYPE uint16
-#define __CLC_S_GENTYPE int16
 #define __CLC_VECSIZE 16
 #include __CLC_BODY
 #undef __CLC_VECSIZE
-#undef __CLC_GENTYPE
-#undef __CLC_U_GENTYPE
-#undef __CLC_S_GENTYPE
 #undef __CLC_VECSIZE_OR_1
 
 #undef __CLC_GENSIZE
 #define __CLC_GENSIZE 64
 #undef __CLC_SCALAR_GENTYPE
+#undef __CLC_U_SCALAR_GENTYPE
+#undef __CLC_S_SCALAR_GENTYPE
 #define __CLC_SCALAR_GENTYPE long
+#define __CLC_U_SCALAR_GENTYPE ulong
+#define __CLC_S_SCALAR_GENTYPE long
 #undef __CLC_GEN_U
 #define __CLC_GEN_S
 
-#define __CLC_GENTYPE long
-#define __CLC_U_GENTYPE ulong
-#define __CLC_S_GENTYPE long
 #define __CLC_SCALAR
 #define __CLC_VECSIZE
 #define __CLC_VECSIZE_OR_1 1
@@ -472,71 +283,39 @@
 #undef __CLC_VECSIZE_OR_1
 #undef __CLC_VECSIZE
 #undef __CLC_SCALAR
-#undef __CLC_GENTYPE
-#undef __CLC_U_GENTYPE
-#undef __CLC_S_GENTYPE
 
 #define __CLC_VECSIZE_OR_1 __CLC_VECSIZE
 
-#define __CLC_GENTYPE long2
-#define __CLC_U_GENTYPE ulong2
-#define __CLC_S_GENTYPE long2
 #define __CLC_VECSIZE 2
 #include __CLC_BODY
 #undef __CLC_VECSIZE
-#undef __CLC_GENTYPE
-#undef __CLC_U_GENTYPE
-#undef __CLC_S_GENTYPE
 
-#define __CLC_GENTYPE long3
-#define __CLC_U_GENTYPE ulong3
-#define __CLC_S_GENTYPE long3
 #define __CLC_VECSIZE 3
 #include __CLC_BODY
 #undef __CLC_VECSIZE
-#undef __CLC_GENTYPE
-#undef __CLC_U_GENTYPE
-#undef __CLC_S_GENTYPE
 
-#define __CLC_GENTYPE long4
-#define __CLC_U_GENTYPE ulong4
-#define __CLC_S_GENTYPE long4
 #define __CLC_VECSIZE 4
 #include __CLC_BODY
 #undef __CLC_VECSIZE
-#undef __CLC_GENTYPE
-#undef __CLC_U_GENTYPE
-#undef __CLC_S_GENTYPE
 
-#define __CLC_GENTYPE long8
-#define __CLC_U_GENTYPE ulong8
-#define __CLC_S_GENTYPE long8
 #define __CLC_VECSIZE 8
 #include __CLC_BODY
 #undef __CLC_VECSIZE
-#undef __CLC_GENTYPE
-#undef __CLC_U_GENTYPE
-#undef __CLC_S_GENTYPE
 
-#define __CLC_GENTYPE long16
-#define __CLC_U_GENTYPE ulong16
-#define __CLC_S_GENTYPE long16
 #define __CLC_VECSIZE 16
 #include __CLC_BODY
 #undef __CLC_VECSIZE
-#undef __CLC_GENTYPE
-#undef __CLC_U_GENTYPE
-#undef __CLC_S_GENTYPE
 #undef __CLC_VECSIZE_OR_1
 
 #undef __CLC_SCALAR_GENTYPE
+#undef __CLC_U_SCALAR_GENTYPE
+#undef __CLC_S_SCALAR_GENTYPE
 #define __CLC_SCALAR_GENTYPE ulong
+#define __CLC_U_SCALAR_GENTYPE ulong
+#define __CLC_S_SCALAR_GENTYPE long
 #undef __CLC_GEN_S
 #define __CLC_GEN_U
 
-#define __CLC_GENTYPE ulong
-#define __CLC_U_GENTYPE ulong
-#define __CLC_S_GENTYPE long
 #define __CLC_SCALAR
 #define __CLC_VECSIZE
 #define __CLC_VECSIZE_OR_1 1
@@ -545,67 +324,36 @@
 #undef __CLC_VECSIZE_OR_1
 #undef __CLC_VECSIZE
 #undef __CLC_SCALAR
-#undef __CLC_GENTYPE
-#undef __CLC_U_GENTYPE
-#undef __CLC_S_GENTYPE
 
 #define __CLC_VECSIZE_OR_1 __CLC_VECSIZE
 
-#define __CLC_GENTYPE ulong2
-#define __CLC_U_GENTYPE ulong2
-#define __CLC_S_GENTYPE long2
 #define __CLC_VECSIZE 2
 #include __CLC_BODY
 #undef __CLC_VECSIZE
-#undef __CLC_GENTYPE
-#undef __CLC_U_GENTYPE
-#undef __CLC_S_GENTYPE
 
-#define __CLC_GENTYPE ulong3
-#define __CLC_U_GENTYPE ulong3
-#define __CLC_S_GENTYPE long3
 #define __CLC_VECSIZE 3
 #include __CLC_BODY
 #undef __CLC_VECSIZE
-#undef __CLC_GENTYPE
-#undef __CLC_U_GENTYPE
-#undef __CLC_S_GENTYPE
 
-#define __CLC_GENTYPE ulong4
-#define __CLC_U_GENTYPE ulong4
-#define __CLC_S_GENTYPE long4
 #define __CLC_VECSIZE 4
 #include __CLC_BODY
 #undef __CLC_VECSIZE
-#undef __CLC_GENTYPE
-#undef __CLC_U_GENTYPE
-#undef __CLC_S_GENTYPE
 
-#define __CLC_GENTYPE ulong8
-#define __CLC_U_GENTYPE ulong8
-#define __CLC_S_GENTYPE long8
 #define __CLC_VECSIZE 8
 #include __CLC_BODY
 #undef __CLC_VECSIZE
-#undef __CLC_GENTYPE
-#undef __CLC_U_GENTYPE
-#undef __CLC_S_GENTYPE
 
-#define __CLC_GENTYPE ulong16
-#define __CLC_U_GENTYPE ulong16
-#define __CLC_S_GENTYPE long16
 #define __CLC_VECSIZE 16
 #include __CLC_BODY
 #undef __CLC_VECSIZE
-#undef __CLC_GENTYPE
-#undef __CLC_U_GENTYPE
-#undef __CLC_S_GENTYPE
 #undef __CLC_VECSIZE_OR_1
 
 #undef __CLC_GEN_U
 
 #undef __CLC_GENSIZE
 #undef __CLC_SCALAR_GENTYPE
+#undef __CLC_U_SCALAR_GENTYPE
+#undef __CLC_S_SCALAR_GENTYPE
 #undef __CLC_BODY
 
 #undef __CLC_CONVERT_S_GENTYPE
@@ -616,3 +364,7 @@
 
 #undef __CLC_CONVERT_GENTYPE
 #undef __CLC_AS_GENTYPE
+
+#undef __CLC_S_GENTYPE
+#undef __CLC_U_GENTYPE
+#undef __CLC_GENTYPE

--- a/libclc/clc/include/clc/math/gentype.inc
+++ b/libclc/clc/include/clc/math/gentype.inc
@@ -9,6 +9,8 @@
 #include "clc/clcfunc.h"
 #include "clc/utils.h"
 
+#define __CLC_GENTYPE __CLC_XCONCAT(__CLC_SCALAR_GENTYPE, __CLC_VECSIZE)
+
 // Define some useful macros for type conversions.
 #define __CLC_AS_GENTYPE __CLC_XCONCAT(__clc_as_, __CLC_GENTYPE)
 #define __CLC_CONVERT_GENTYPE __CLC_XCONCAT(__clc_convert_, __CLC_GENTYPE)
@@ -85,7 +87,6 @@
 
 #define __CLC_GENTYPE_DENORMS_ARE_ZERO __clc_denormals_are_zero_fp32()
 
-#define __CLC_GENTYPE float
 #define __CLC_BIT_INT int
 #define __CLC_BIT_INTN int
 #define __CLC_SCALAR
@@ -94,50 +95,39 @@
 #include __CLC_BODY
 #undef __CLC_VECSIZE_OR_1
 #undef __CLC_VECSIZE
-#undef __CLC_GENTYPE
 #undef __CLC_BIT_INTN
 #undef __CLC_SCALAR
 
 #define __CLC_VECSIZE_OR_1 __CLC_VECSIZE
 
-#define __CLC_GENTYPE float2
 #define __CLC_BIT_INTN int2
 #define __CLC_VECSIZE 2
 #include __CLC_BODY
 #undef __CLC_VECSIZE
-#undef __CLC_GENTYPE
 #undef __CLC_BIT_INTN
 
-#define __CLC_GENTYPE float3
 #define __CLC_BIT_INTN int3
 #define __CLC_VECSIZE 3
 #include __CLC_BODY
 #undef __CLC_VECSIZE
-#undef __CLC_GENTYPE
 #undef __CLC_BIT_INTN
 
-#define __CLC_GENTYPE float4
 #define __CLC_BIT_INTN int4
 #define __CLC_VECSIZE 4
 #include __CLC_BODY
 #undef __CLC_VECSIZE
-#undef __CLC_GENTYPE
 #undef __CLC_BIT_INTN
 
-#define __CLC_GENTYPE float8
 #define __CLC_BIT_INTN int8
 #define __CLC_VECSIZE 8
 #include __CLC_BODY
 #undef __CLC_VECSIZE
-#undef __CLC_GENTYPE
 #undef __CLC_BIT_INTN
 
-#define __CLC_GENTYPE float16
 #define __CLC_BIT_INTN int16
 #define __CLC_VECSIZE 16
 #include __CLC_BODY
 #undef __CLC_VECSIZE
-#undef __CLC_GENTYPE
 #undef __CLC_BIT_INT
 #undef __CLC_BIT_INTN
 
@@ -172,56 +162,44 @@
 #define __CLC_SCALAR
 #define __CLC_VECSIZE
 #define __CLC_VECSIZE_OR_1 1
-#define __CLC_GENTYPE double
 #define __CLC_BIT_INT long
 #define __CLC_BIT_INTN long
 #include __CLC_BODY
 #undef __CLC_VECSIZE_OR_1
-#undef __CLC_GENTYPE
 #undef __CLC_BIT_INTN
 #undef __CLC_VECSIZE
 #undef __CLC_SCALAR
 
 #define __CLC_VECSIZE_OR_1 __CLC_VECSIZE
 
-#define __CLC_GENTYPE double2
 #define __CLC_BIT_INTN long2
 #define __CLC_VECSIZE 2
 #include __CLC_BODY
 #undef __CLC_VECSIZE
-#undef __CLC_GENTYPE
 #undef __CLC_BIT_INTN
 
-#define __CLC_GENTYPE double3
 #define __CLC_BIT_INTN long3
 #define __CLC_VECSIZE 3
 #include __CLC_BODY
 #undef __CLC_VECSIZE
-#undef __CLC_GENTYPE
 #undef __CLC_BIT_INTN
 
-#define __CLC_GENTYPE double4
 #define __CLC_BIT_INTN long4
 #define __CLC_VECSIZE 4
 #include __CLC_BODY
 #undef __CLC_VECSIZE
-#undef __CLC_GENTYPE
 #undef __CLC_BIT_INTN
 
-#define __CLC_GENTYPE double8
 #define __CLC_BIT_INTN long8
 #define __CLC_VECSIZE 8
 #include __CLC_BODY
 #undef __CLC_VECSIZE
-#undef __CLC_GENTYPE
 #undef __CLC_BIT_INTN
 
-#define __CLC_GENTYPE double16
 #define __CLC_BIT_INTN long16
 #define __CLC_VECSIZE 16
 #include __CLC_BODY
 #undef __CLC_VECSIZE
-#undef __CLC_GENTYPE
 #undef __CLC_BIT_INT
 #undef __CLC_BIT_INTN
 
@@ -256,11 +234,9 @@
 #define __CLC_SCALAR
 #define __CLC_VECSIZE
 #define __CLC_VECSIZE_OR_1 1
-#define __CLC_GENTYPE half
 #define __CLC_BIT_INT short
 #define __CLC_BIT_INTN short
 #include __CLC_BODY
-#undef __CLC_GENTYPE
 #undef __CLC_BIT_INTN
 #undef __CLC_VECSIZE_OR_1
 #undef __CLC_VECSIZE
@@ -268,44 +244,34 @@
 
 #define __CLC_VECSIZE_OR_1 __CLC_VECSIZE
 
-#define __CLC_GENTYPE half2
 #define __CLC_BIT_INTN short2
 #define __CLC_VECSIZE 2
 #include __CLC_BODY
 #undef __CLC_VECSIZE
-#undef __CLC_GENTYPE
 #undef __CLC_BIT_INTN
 
-#define __CLC_GENTYPE half3
 #define __CLC_BIT_INTN short3
 #define __CLC_VECSIZE 3
 #include __CLC_BODY
 #undef __CLC_VECSIZE
-#undef __CLC_GENTYPE
 #undef __CLC_BIT_INTN
 
-#define __CLC_GENTYPE half4
 #define __CLC_BIT_INTN short4
 #define __CLC_VECSIZE 4
 #include __CLC_BODY
 #undef __CLC_VECSIZE
-#undef __CLC_GENTYPE
 #undef __CLC_BIT_INTN
 
-#define __CLC_GENTYPE half8
 #define __CLC_BIT_INTN short8
 #define __CLC_VECSIZE 8
 #include __CLC_BODY
 #undef __CLC_VECSIZE
-#undef __CLC_GENTYPE
 #undef __CLC_BIT_INTN
 
-#define __CLC_GENTYPE half16
 #define __CLC_BIT_INTN short16
 #define __CLC_VECSIZE 16
 #include __CLC_BODY
 #undef __CLC_VECSIZE
-#undef __CLC_GENTYPE
 #undef __CLC_BIT_INT
 #undef __CLC_BIT_INTN
 
@@ -380,3 +346,5 @@
 #undef __CLC_HALF_ONLY
 #undef __CLC_FLOAT_ONLY
 #undef __CLC_DOUBLE_ONLY
+
+#undef __CLC_GENTYPE


### PR DESCRIPTION
Reduce macro re-definition overhead.