### PR TITLE
[clang][bytecode] Disable tail calls on MSVC and PPC

### DIFF
--- a/clang/lib/AST/ByteCode/Interp.cpp
+++ b/clang/lib/AST/ByteCode/Interp.cpp
@@ -37,7 +37,9 @@ using namespace clang::interp;
 #endif
 
 // On MSVC, musttail does not guarantee tail calls in debug mode.
-#if (defined(_MSC_VER) && defined(_DEBUG)) || !defined(MUSTTAIL)
+// We disable it on MSVC generally since it doesn't seem to be able
+// to handle the way we use tailcalls.
+#if defined(_MSC_VER) || !defined(MUSTTAIL)
 #define MUSTTAIL
 #define USE_TAILCALLS 0
 #else

--- a/clang/lib/AST/ByteCode/Interp.cpp
+++ b/clang/lib/AST/ByteCode/Interp.cpp
@@ -39,7 +39,8 @@ using namespace clang::interp;
 // On MSVC, musttail does not guarantee tail calls in debug mode.
 // We disable it on MSVC generally since it doesn't seem to be able
 // to handle the way we use tailcalls.
-#if defined(_MSC_VER) || !defined(MUSTTAIL)
+// PPC can't tail-call external calls, which is a problem for InterpNext.
+#if defined(_MSC_VER) || defined(_ARCH_PPC) || !defined(MUSTTAIL)
 #define MUSTTAIL
 #define USE_TAILCALLS 0
 #else


### PR DESCRIPTION
Since I now have to wait for CI to do a revert, might as well to the actual change first.