### PR TITLE
[ARM] Fix incorrect post increment from Or

### DIFF
--- a/llvm/lib/Target/ARM/ARMISelLowering.cpp
+++ b/llvm/lib/Target/ARM/ARMISelLowering.cpp
@@ -16193,25 +16193,27 @@ static SDValue CombineBaseUpdate(SDNode *N,
   if (findPointerConstIncrement(Addr.getNode(), &Base, &CInc)) {
     unsigned Offset =
         getPointerConstIncrement(Addr->getOpcode(), Base, CInc, DCI.DAG);
-    for (SDUse &Use : Base->uses()) {
+    if (Offset) {
+      for (SDUse &Use : Base->uses()) {
 
-      SDNode *User = Use.getUser();
-      if (Use.getResNo() != Base.getResNo() || User == Addr.getNode() ||
-          User->getNumOperands() != 2)
-        continue;
+        SDNode *User = Use.getUser();
+        if (Use.getResNo() != Base.getResNo() || User == Addr.getNode() ||
+            User->getNumOperands() != 2)
+          continue;
 
-      SDValue UserInc = User->getOperand(Use.getOperandNo() == 0 ? 1 : 0);
-      unsigned UserOffset =
-          getPointerConstIncrement(User->getOpcode(), Base, UserInc, DCI.DAG);
+        SDValue UserInc = User->getOperand(Use.getOperandNo() == 0 ? 1 : 0);
+        unsigned UserOffset =
+            getPointerConstIncrement(User->getOpcode(), Base, UserInc, DCI.DAG);
 
-      if (!UserOffset || UserOffset <= Offset)
-        continue;
+        if (!UserOffset || UserOffset <= Offset)
+          continue;
 
-      unsigned NewConstInc = UserOffset - Offset;
-      SDValue NewInc = DCI.DAG.getConstant(NewConstInc, SDLoc(N), MVT::i32);
-      BaseUpdates.push_back({User, NewInc, NewConstInc});
-      if (BaseUpdates.size() >= MaxBaseUpdates)
-        break;
+        unsigned NewConstInc = UserOffset - Offset;
+        SDValue NewInc = DCI.DAG.getConstant(NewConstInc, SDLoc(N), MVT::i32);
+        BaseUpdates.push_back({User, NewInc, NewConstInc});
+        if (BaseUpdates.size() >= MaxBaseUpdates)
+          break;
+      }
     }
   }
 

--- a/llvm/test/CodeGen/ARM/vld2.ll
+++ b/llvm/test/CodeGen/ARM/vld2.ll
@@ -194,13 +194,12 @@ define <4 x float> @vld2Qf(ptr %A) nounwind {
   ret <4 x float> %tmp4
 }
 
-; FIXME: Do not update with an invalid increment
 define ptr @test_or_update(ptr %p, ptr %q) {
 ; CHECK-LABEL: test_or_update:
 ; CHECK:       @ %bb.0:
-; CHECK-NEXT:    orr r0, r0, #3
-; CHECK-NEXT:    mov r2, #2
-; CHECK-NEXT:    vld2.32 {d16, d17}, [r0], r2
+; CHECK-NEXT:    orr r2, r0, #3
+; CHECK-NEXT:    add r0, r0, #2
+; CHECK-NEXT:    vld2.32 {d16, d17}, [r2]
 ; CHECK-NEXT:    vstr d16, [r1]
 ; CHECK-NEXT:    mov pc, lr
   %p1 = ptrtoint ptr %p to i32


### PR DESCRIPTION
If a Or is detected by findPointerConstIncrement but not by getPointerConstIncrement it could use an invalid increment for the offset. Protect against cases where getPointerConstIncrement cannot return a valid offset.

Fixes #185677