### PR TITLE
[PatternMatch][NFC] Add `m_IToFP` and `m_FPToI`

### DIFF
--- a/llvm/include/llvm/IR/PatternMatch.h
+++ b/llvm/include/llvm/IR/PatternMatch.h
@@ -2418,6 +2418,13 @@ inline CastInst_match<OpTy, SIToFPInst> m_SIToFP(const OpTy &Op) {
 }
 
 template <typename OpTy>
+inline match_combine_or<CastInst_match<OpTy, UIToFPInst>,
+                        CastInst_match<OpTy, SIToFPInst>>
+m_IToFP(const OpTy &Op) {
+  return m_CombineOr(m_UIToFP(Op), m_SIToFP(Op));
+}
+
+template <typename OpTy>
 inline CastInst_match<OpTy, FPToUIInst> m_FPToUI(const OpTy &Op) {
   return CastInst_match<OpTy, FPToUIInst>(Op);
 }
@@ -2425,6 +2432,13 @@ inline CastInst_match<OpTy, FPToUIInst> m_FPToUI(const OpTy &Op) {
 template <typename OpTy>
 inline CastInst_match<OpTy, FPToSIInst> m_FPToSI(const OpTy &Op) {
   return CastInst_match<OpTy, FPToSIInst>(Op);
+}
+
+template <typename OpTy>
+inline match_combine_or<CastInst_match<OpTy, FPToUIInst>,
+                        CastInst_match<OpTy, FPToSIInst>>
+m_FPToI(const OpTy &Op) {
+  return m_CombineOr(m_FPToUI(Op), m_FPToSI(Op));
 }
 
 template <typename OpTy>

--- a/llvm/lib/Analysis/InstructionSimplify.cpp
+++ b/llvm/lib/Analysis/InstructionSimplify.cpp
@@ -6530,7 +6530,7 @@ static Value *simplifyUnaryIntrinsic(Function *F, Value *Op0,
     // round (ceil x) -> ceil x
     auto *II = dyn_cast<IntrinsicInst>(Op0);
     if ((II && removesFPFraction(II->getIntrinsicID())) ||
-        match(Op0, m_SIToFP(m_Value())) || match(Op0, m_UIToFP(m_Value())))
+        match(Op0, m_IToFP(m_Value())))
       return Op0;
   }
 

--- a/llvm/lib/Transforms/InstCombine/InstCombineCasts.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCasts.cpp
@@ -2029,7 +2029,7 @@ static bool isKnownExactCastIntToFP(CastInst &I, InstCombinerImpl &IC) {
   // Cast from FP to integer and back to FP is independent of the intermediate
   // integer width because of poison on overflow.
   Value *F;
-  if (match(Src, m_FPToSI(m_Value(F))) || match(Src, m_FPToUI(m_Value(F)))) {
+  if (match(Src, m_FPToI(m_Value(F)))) {
     // If this is uitofp (fptosi F), the source needs an extra bit to avoid
     // potential rounding of negative FP input values.
     int SrcNumSigBits = F->getType()->getFPMantissaWidth();

--- a/llvm/lib/Transforms/InstCombine/InstructionCombining.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstructionCombining.cpp
@@ -1695,13 +1695,11 @@ Instruction *InstCombinerImpl::foldFBinOpOfIntCasts(BinaryOperator &BO) {
   // Check for:
   //    1) (binop ({s|u}itofp x), ({s|u}itofp y))
   //    2) (binop ({s|u}itofp x), FpC)
-  if (!match(BO.getOperand(0), m_SIToFP(m_Value(IntOps[0]))) &&
-      !match(BO.getOperand(0), m_UIToFP(m_Value(IntOps[0]))))
+  if (!match(BO.getOperand(0), m_IToFP(m_Value(IntOps[0]))))
     return nullptr;
 
   if (!match(BO.getOperand(1), m_Constant(Op1FpC)) &&
-      !match(BO.getOperand(1), m_SIToFP(m_Value(IntOps[1]))) &&
-      !match(BO.getOperand(1), m_UIToFP(m_Value(IntOps[1]))))
+      !match(BO.getOperand(1), m_IToFP(m_Value(IntOps[1]))))
     return nullptr;
 
   // Cache KnownBits a bit to potentially save some analysis.

--- a/llvm/unittests/IR/PatternMatch.cpp
+++ b/llvm/unittests/IR/PatternMatch.cpp
@@ -635,6 +635,25 @@ TEST_F(PatternMatchTest, ZExtSExtSelf) {
   EXPECT_TRUE(m_ZExtOrSExtOrSelf(m_One()).match(One64S));
 }
 
+TEST_F(PatternMatchTest, IntFPConversions) {
+  LLVMContext &Ctx = IRB.getContext();
+
+  Value *One32 = IRB.getInt32(1);
+  Value *OneDouble = ConstantFP::get(IRB.getDoubleTy(), APFloat(1.0));
+  Value *OneDoubleU = IRB.CreateUIToFP(One32, Type::getDoubleTy(Ctx));
+  Value *OneDoubleS = IRB.CreateSIToFP(One32, Type::getDoubleTy(Ctx));
+  Value *One32U = IRB.CreateFPToUI(OneDouble, Type::getInt32Ty(Ctx));
+  Value *One32S = IRB.CreateFPToSI(OneDouble, Type::getInt32Ty(Ctx));
+
+  EXPECT_FALSE(m_IToFP(m_One()).match(One32));
+  EXPECT_TRUE(m_IToFP(m_One()).match(OneDoubleU));
+  EXPECT_TRUE(m_IToFP(m_One()).match(OneDoubleS));
+
+  EXPECT_FALSE(m_FPToI(m_FPOne()).match(OneDouble));
+  EXPECT_TRUE(m_FPToI(m_FPOne()).match(One32U));
+  EXPECT_TRUE(m_FPToI(m_FPOne()).match(One32S));
+}
+
 TEST_F(PatternMatchTest, BooleanMap) {
   Value *Alloca = IRB.CreateAlloca(IRB.getInt1Ty());
   Value *SelectCond = IRB.CreateLoad(IRB.getInt1Ty(), Alloca);


### PR DESCRIPTION
Added two patterns for IR pattern matching, `m_IToFP` and `m_FPToI` which are basically shortcuts of `m_CombinedOr(..., ...)`

> if there isn't already one, PatternMatch should have an m_ItoFP which covers both

_Originally posted by @arsenm in https://github.com/llvm/llvm-project/pull/185826#discussion_r2967473936_

/cc @arsenm 