### PR TITLE
[clang][bytecode] Disable tailcalls on aarch64

### DIFF
--- a/clang/lib/AST/ByteCode/Interp.cpp
+++ b/clang/lib/AST/ByteCode/Interp.cpp
@@ -40,7 +40,9 @@ using namespace clang::interp;
 // We disable it on MSVC generally since it doesn't seem to be able
 // to handle the way we use tailcalls.
 // PPC can't tail-call external calls, which is a problem for InterpNext.
-#if defined(_MSC_VER) || defined(_ARCH_PPC) || !defined(MUSTTAIL)
+// aarch64 seems to have problems too, at least with sanitizers enabled.
+#if defined(_MSC_VER) || defined(_ARCH_PPC) || defined(__aarch64__) ||         \
+    !defined(MUSTTAIL)
 #define MUSTTAIL
 #define USE_TAILCALLS 0
 #else


### PR DESCRIPTION
Apparently it causes problems there, too.
See https://lab.llvm.org/buildbot/#/builders/24/builds/18781