### PR TITLE
[scudo] Use portable TEST_SKIP macro

### DIFF
--- a/compiler-rt/lib/scudo/standalone/tests/combined_test.cpp
+++ b/compiler-rt/lib/scudo/standalone/tests/combined_test.cpp
@@ -1829,7 +1829,7 @@ TEST(ScudoCombinedDeathTest, AlignMismatch) {
   // Pointer is guaranteed to not be aligned to 2 * page size.
   void *AlignedPtr = getMinAlignedPointer<AllocatorT>(Allocator.get());
   if (AlignedPtr == nullptr) {
-    GTEST_SKIP() << "Cannot allocate aligned pointer for test.";
+    TEST_SKIP("Cannot allocate aligned pointer for test.");
   }
 
   scudo::uptr Alignment = 2 * scudo::getPageSizeCached();

--- a/compiler-rt/lib/scudo/standalone/tests/common_test.cpp
+++ b/compiler-rt/lib/scudo/standalone/tests/common_test.cpp
@@ -23,7 +23,7 @@ namespace scudo {
 
 TEST(ScudoCommonTest, VerifyGetResidentPages) {
   if (!SCUDO_LINUX)
-    GTEST_SKIP() << "Only valid on linux systems.";
+    TEST_SKIP("Only valid on linux systems.");
 
   constexpr uptr NumPages = 512;
   const uptr SizeBytes = NumPages * getPageSizeCached();
@@ -67,7 +67,7 @@ TEST(ScudoCommonTest, VerifyGetResidentPages) {
 
 TEST(ScudoCommonTest, VerifyReleasePagesToOS) {
   if (!SCUDO_LINUX)
-    GTEST_SKIP() << "Only valid on linux systems.";
+    TEST_SKIP("Only valid on linux systems.");
 
   constexpr uptr NumPages = 1000;
   const uptr SizeBytes = NumPages * getPageSizeCached();


### PR DESCRIPTION
Which expands to ZXTEST_SKIP on Fuchsia.