### PR TITLE
[ADT] Add predicate based match support to StringSwitch

### DIFF
--- a/llvm/include/llvm/ADT/StringSwitch.h
+++ b/llvm/include/llvm/ADT/StringSwitch.h
@@ -123,6 +123,14 @@ public:
     return *this;
   }
 
+  // A StringSwitch case that is selected if the specified predicate
+  // returns true for the subject string.
+  StringSwitch &Predicate(function_ref<bool(StringRef)> Pred, T Value) {
+    if (!Result && Pred(Str))
+      Result = std::move(Value);
+    return *this;
+  }
+
   [[nodiscard]] R Default(T Value) {
     if (Result)
       return std::move(*Result);

--- a/llvm/unittests/ADT/StringSwitchTest.cpp
+++ b/llvm/unittests/ADT/StringSwitchTest.cpp
@@ -257,6 +257,20 @@ TEST(StringSwitchTest, StringSwitchMultipleMatches) {
   EXPECT_EQ(1, Translate("b"));
 }
 
+TEST(StringPredicateTest, Predicate) {
+  auto MatchFn = [](StringRef Str) { return Str == "abc" || Str == "def"; };
+  auto PredicateMatch = [&](StringRef S) {
+    return llvm::StringSwitch<int>(S)
+        .Case("abc", 0)
+        .Predicate(MatchFn, 1)
+        .Case("def", 2)
+        .Default(3);
+  };
+  EXPECT_EQ(0, PredicateMatch("abc"));
+  EXPECT_EQ(1, PredicateMatch("def"));
+  EXPECT_EQ(3, PredicateMatch("ghi"));
+}
+
 TEST(StringSwitchTest, DefaultUnreachable) {
   auto Translate = [](StringRef S) {
     return llvm::StringSwitch<int>(S)


### PR DESCRIPTION
This introduces `Predicate` and `IfNotPredicate` case selection to StringSwitch to allow use cases like

```
StringSwitch<...>(..)
  .Case("foo", FooTok)
  .Predicate(isAlpha, IdentifierTok)
...
```

This is mostly useful for improving conciseness and clarity when processing generated strings, diagnostics, and similar.