### PR TITLE
[clang][bytecode] Avoid a macro redefinition

### DIFF
--- a/clang/lib/AST/ByteCode/Interp.cpp
+++ b/clang/lib/AST/ByteCode/Interp.cpp
@@ -43,6 +43,7 @@ using namespace clang::interp;
 // aarch64 seems to have problems too, at least with sanitizers enabled.
 #if defined(_MSC_VER) || defined(_ARCH_PPC) || defined(__aarch64__) ||         \
     !defined(MUSTTAIL)
+#undef MUSTTAIL
 #define MUSTTAIL
 #define USE_TAILCALLS 0
 #else


### PR DESCRIPTION
Fixes:

```
/home/b/sanitizer-aarch64-linux/build/llvm-project/clang/lib/AST/ByteCode/Interp.cpp:46:9: error: 'MUSTTAIL' macro redefined [-Werror,-Wmacro-redefined]
   46 | #define MUSTTAIL
      |         ^
/home/b/sanitizer-aarch64-linux/build/llvm-project/clang/lib/AST/ByteCode/Interp.cpp:32:9: note: previous definition is here
   32 | #define MUSTTAIL [[clang::musttail]]
      |         ^
1 error generated.
```