### PR TITLE
[ARM] Consider register pressure when vectorizing with MVE

### DIFF
--- a/llvm/lib/Target/ARM/ARMTargetTransformInfo.cpp
+++ b/llvm/lib/Target/ARM/ARMTargetTransformInfo.cpp
@@ -2852,6 +2852,13 @@ InstructionCost ARMTTIImpl::getScalingFactorCost(Type *Ty, GlobalValue *BaseGV,
   return InstructionCost::getInvalid();
 }
 
+bool ARMTTIImpl::shouldConsiderVectorizationRegPressure() const {
+  // MVE only has 8 vector registers, so we should consider register pressure to
+  // avoid vectorizing when the cost of spills exceeds the gains from
+  // vectorization.
+  return ST->hasMVEIntegerOps();
+}
+
 bool ARMTTIImpl::hasArmWideBranch(bool Thumb) const {
   if (Thumb) {
     // B.W is available in any Thumb2-supporting target, and also in every

--- a/llvm/lib/Target/ARM/ARMTargetTransformInfo.h
+++ b/llvm/lib/Target/ARM/ARMTargetTransformInfo.h
@@ -446,6 +446,8 @@ public:
     return true;
   }
 
+  bool shouldConsiderVectorizationRegPressure() const override;
+
   bool hasArmWideBranch(bool Thumb) const override;
 
   bool isProfitableToSinkOperands(Instruction *I,

--- a/llvm/test/Transforms/LoopVectorize/ARM/mve-reg-pressure-spills.ll
+++ b/llvm/test/Transforms/LoopVectorize/ARM/mve-reg-pressure-spills.ll
@@ -1,6 +1,7 @@
 ; REQUIRES: asserts
 ; RUN: opt -mcpu=cortex-m55 -passes=loop-vectorize -disable-output -debug-only=loop-vectorize,vplan -vplan-verify-each -vectorizer-consider-reg-pressure=false %s 2>&1 | FileCheck %s --check-prefixes=CHECK,CHECK-NOPRESSURE
 ; RUN: opt -mcpu=cortex-m55 -passes=loop-vectorize -disable-output -debug-only=loop-vectorize,vplan -vplan-verify-each -vectorizer-consider-reg-pressure=true %s 2>&1 | FileCheck %s --check-prefixes=CHECK,CHECK-PRESSURE
+; RUN: opt -mcpu=cortex-m55 -passes=loop-vectorize -disable-output -debug-only=loop-vectorize,vplan -vplan-verify-each %s 2>&1 | FileCheck %s --check-prefixes=CHECK,CHECK-PRESSURE
 
 target datalayout = "e-m:e-p:32:32-Fi8-i64:64-v128:64:128-a:0:32-n32-S64"
 target triple = "thumbv8.1m.main-unknown-none-eabihf"


### PR DESCRIPTION
MVE only has 8 vector registers, so it's not too hard for the vectorizer to end up using more than that resulting in enough spilling that it's worse than not vectorizing. Enable shouldConsiderVectorizationRegPressure for targets with MVE so the vectorizer doesn't vectorize in those cases.