### PR TITLE
[AIX][ifunc] fix error message creation logic (misbehaves in production builds)

### DIFF
--- a/llvm/lib/Target/PowerPC/PPCAsmPrinter.cpp
+++ b/llvm/lib/Target/PowerPC/PPCAsmPrinter.cpp
@@ -3632,12 +3632,13 @@ void PPCAIXAsmPrinter::emitGlobalIFunc(Module &M, const GlobalIFunc &GI) {
 
   // generate the code for .foo now:
   if (TOCRestoreNeededForCallToImplementation(GI)) {
-    Twine Msg = "unimplemented: TOC register save/restore needed for ifunc \"" +
-                Twine(GI.getName()) +
-                "\", because couldn't prove all candidates "
-                "are static or hidden/protected visibility definitions";
+    SmallString<128> Msg;
+    Msg.append("unimplemented: TOC register save/restore needed for ifunc \"");
+    getNameWithPrefix(Msg, &GI);
+    Msg.append("\", because couldn't prove all candidates are static or "
+               "hidden/protected visibility definitions");
     if (!IFuncWarnInsteadOfError)
-      reportFatalUsageError(Msg);
+      reportFatalUsageError(Msg.str());
     else
       dbgs() << Msg << "\n";
   }


### PR DESCRIPTION
I don't know why the old code was causing the function name to come out empty in the message, in certain builds of llvm.
It's either a misuse[1] of the Twine class, or a bug somewhere else.
So this PR rewrites the logic by building the message into a SmallString<128>. This logic is part of error handling, so optimizing it is not important.

[1] I checked the usage and couldn't find anything suspicious