### PR TITLE
[X86] canonicalizeShuffleWithOp - add handling for SHUFFLE(PSADBW(X,Y),PSADBW(Z,W)) -> PSADBW(SHUFFLE(X,Z),SHUFFLE(Y,W))

### DIFF
--- a/llvm/lib/Target/X86/X86ISelLowering.cpp
+++ b/llvm/lib/Target/X86/X86ISelLowering.cpp
@@ -42651,7 +42651,8 @@ static SDValue canonicalizeShuffleWithOp(SDValue N, SelectionDAG &DAG,
       SDValue N0 = peekThroughOneUseBitcasts(N.getOperand(0));
       SDValue N1 = peekThroughOneUseBitcasts(N.getOperand(1));
       unsigned SrcOpcode = N0.getOpcode();
-      if (TLI.isBinOp(SrcOpcode) && N1.getOpcode() == SrcOpcode &&
+      if ((SrcOpcode == X86ISD::PSADBW || TLI.isBinOp(SrcOpcode)) &&
+          N1.getOpcode() == SrcOpcode &&
           N0.getValueType() == N1.getValueType() &&
           IsSafeToMoveShuffle(N0, SrcOpcode) &&
           IsSafeToMoveShuffle(N1, SrcOpcode)) {
@@ -42677,11 +42678,12 @@ static SDValue canonicalizeShuffleWithOp(SDValue N, SelectionDAG &DAG,
             LHS = DAG.getNode(Opc, DL, ShuffleVT, Op00, Op10);
             RHS = DAG.getNode(Opc, DL, ShuffleVT, Op01, Op11);
           }
-          EVT OpVT = N0.getValueType();
+          EVT OpSrcVT = N0.getOperand(0).getValueType();
+          EVT OpDstVT = N0.getValueType();
           return DAG.getBitcast(ShuffleVT,
-                                DAG.getNode(SrcOpcode, DL, OpVT,
-                                            DAG.getBitcast(OpVT, LHS),
-                                            DAG.getBitcast(OpVT, RHS)));
+                                DAG.getNode(SrcOpcode, DL, OpDstVT,
+                                            DAG.getBitcast(OpSrcVT, LHS),
+                                            DAG.getBitcast(OpSrcVT, RHS)));
         }
       }
       if (isUnaryOp(SrcOpcode) && N1.getOpcode() == SrcOpcode &&

--- a/llvm/test/CodeGen/X86/bitcnt-big-integer.ll
+++ b/llvm/test/CodeGen/X86/bitcnt-big-integer.ll
@@ -836,12 +836,11 @@ define <2 x i64> @load_ctpop_v2i256_v2i64(ptr %p0) nounwind {
 ; AVX512POPCNT-NEXT:    vmovdqa 32(%rdi), %ymm1
 ; AVX512POPCNT-NEXT:    vpopcntq %zmm1, %zmm1
 ; AVX512POPCNT-NEXT:    vpmovqb %zmm1, %xmm1
-; AVX512POPCNT-NEXT:    vpxor %xmm2, %xmm2, %xmm2
-; AVX512POPCNT-NEXT:    vpsadbw %xmm2, %xmm1, %xmm1
 ; AVX512POPCNT-NEXT:    vpopcntq %zmm0, %zmm0
 ; AVX512POPCNT-NEXT:    vpmovqb %zmm0, %xmm0
-; AVX512POPCNT-NEXT:    vpsadbw %xmm2, %xmm0, %xmm0
 ; AVX512POPCNT-NEXT:    vpunpcklqdq {{.*#+}} xmm0 = xmm0[0],xmm1[0]
+; AVX512POPCNT-NEXT:    vpxor %xmm1, %xmm1, %xmm1
+; AVX512POPCNT-NEXT:    vpsadbw %xmm1, %xmm0, %xmm0
 ; AVX512POPCNT-NEXT:    retq
 ;
 ; AVX512VL-LABEL: load_ctpop_v2i256_v2i64:
@@ -872,12 +871,11 @@ define <2 x i64> @load_ctpop_v2i256_v2i64(ptr %p0) nounwind {
 ; AVX512VLPOPCNT:       # %bb.0:
 ; AVX512VLPOPCNT-NEXT:    vpopcntq 32(%rdi), %ymm0
 ; AVX512VLPOPCNT-NEXT:    vpmovqb %ymm0, %xmm0
+; AVX512VLPOPCNT-NEXT:    vpopcntq (%rdi), %ymm1
+; AVX512VLPOPCNT-NEXT:    vpmovqb %ymm1, %xmm1
+; AVX512VLPOPCNT-NEXT:    vpunpcklqdq {{.*#+}} xmm0 = xmm1[0],xmm0[0]
 ; AVX512VLPOPCNT-NEXT:    vpxor %xmm1, %xmm1, %xmm1
 ; AVX512VLPOPCNT-NEXT:    vpsadbw %xmm1, %xmm0, %xmm0
-; AVX512VLPOPCNT-NEXT:    vpopcntq (%rdi), %ymm2
-; AVX512VLPOPCNT-NEXT:    vpmovqb %ymm2, %xmm2
-; AVX512VLPOPCNT-NEXT:    vpsadbw %xmm1, %xmm2, %xmm1
-; AVX512VLPOPCNT-NEXT:    vpunpcklqdq {{.*#+}} xmm0 = xmm1[0],xmm0[0]
 ; AVX512VLPOPCNT-NEXT:    vzeroupper
 ; AVX512VLPOPCNT-NEXT:    retq
   %a0 = load <2 x i256>, ptr %p0


### PR DESCRIPTION
PSADBW takes vXi8 inputs and gives a vXi64 result so we need to tweak the bitcasts (shuffle types checks will already ensure that the result type isn't affected).

Minor improvement to #187447