### PR TITLE
[Sparc] Report correct size for GETPCX pseudo

### DIFF
--- a/llvm/lib/Target/Sparc/SparcInstrInfo.cpp
+++ b/llvm/lib/Target/Sparc/SparcInstrInfo.cpp
@@ -665,6 +665,22 @@ unsigned SparcInstrInfo::getInstSizeInBytes(const MachineInstr &MI) const {
     return getInlineAsmLength(AsmStr, *MF->getTarget().getMCAsmInfo());
   }
 
+  if (MI.getOpcode() == SP::GETPCX) {
+    const TargetMachine &TM = MI.getParent()->getParent()->getTarget();
+    if (TM.isPositionIndependent())
+      return 16;
+    switch (TM.getCodeModel()) {
+    default:
+      llvm_unreachable("Unsupported absolute code model");
+    case CodeModel::Small:
+      return 8;
+    case CodeModel::Medium:
+      return 16;
+    case CodeModel::Large:
+      return 24;
+    }
+  }
+
   // If the instruction has a delay slot, be conservative and also include
   // it for sizing purposes. This is done so that the BranchRelaxation pass
   // will not mistakenly mark out-of-range branches as in-range.


### PR DESCRIPTION
This currently reports size 4, but the actual size is larger.

See https://github.com/llvm/llvm-project/blob/b32b31e6a7d003a96d8110c3debd891ba6977d25/llvm/lib/Target/Sparc/SparcAsmPrinter.cpp#L178 for the lowering.

Found by https://github.com/llvm/llvm-project/pull/187703.