### PR TITLE
[mlir][docs] Add page for third-party tutorials

### DIFF
--- a/mlir/docs/Tutorials/ExternalTutorials.md
+++ b/mlir/docs/Tutorials/ExternalTutorials.md
@@ -1,0 +1,31 @@
+# External tutorials
+
+## Upstream tutorial
+
+- [LLVM - Lighthouse](https://github.com/llvm/lighthouse): "In essence, this
+  project should guide you through using MLIR for your own projects, showing the
+  way, but not forcing you to follow a particular path. Essentially, the role of
+  a lighthouse."
+
+## Third-party tutorials
+
+The following lists tutorials and blogs that people have created independently.
+
+**Disclaimer**: These tutorials and blogs are maintained by third parties and
+may therefore be out of sync with the upstream implementation. Please do not
+report bugs upstream (e.g., on Discourse).
+
+- MLIR for beginners —
+  [Blog](https://www.jeremykun.com/2023/08/10/mlir-getting-started/) /
+  [Repository](https://github.com/j2kun/mlir-tutorial): A general introduction
+  to MLIR. Resembles the Toy tutorial.
+
+- [mlir-tutor](https://github.com/Groverkss/mlir-tutor): Exercises for learning
+  MLIR.
+
+- [MLIR introduction by Stephen Diehl](https://www.stephendiehl.com/tags/mlir/):
+  Focuses on explaining dialects and passes.
+
+- [End-to-End MLIR pipeline](https://github.com/DavidGinten/ML-compiler-exercise):
+  Demonstrates how deep learning models can be lowered from an ML framework to
+  executable binaries.


### PR DESCRIPTION
This PR adds a new page to the MLIR documentation that links to the upstream Lighthouse project as well as additional third-party tutorials. The goal is to make it easier for newcomers to discover MLIR learning resources beyond the Toy tutorial.

The underlying discussion/RFC can be found [here](https://discourse.llvm.org/t/rfc-tutorial-a-beginner-friendly-end-to-end-mlir-compiler-pipeline/89788).