### PR TITLE
[clang] fix error: cannot compile this l-value expression yet (#187755)

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -687,6 +687,7 @@ Miscellaneous Clang Crashes Fixed
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 - Fixed a crash when attempting to jump over initialization of a variable with variably modified type. (#GH175540)
+- Fixed a crash when ``decltype(__builtin_FUNCTION())`` is used as a template type argument. (#GH167433)
 
 OpenACC Specific Changes
 ------------------------

--- a/clang/lib/AST/Expr.cpp
+++ b/clang/lib/AST/Expr.cpp
@@ -2254,7 +2254,7 @@ SourceLocExpr::SourceLocExpr(const ASTContext &Ctx, SourceLocIdentKind Kind,
   SourceLocExprBits.Kind = llvm::to_underlying(Kind);
   // In dependent contexts, function names may change.
   setDependence(MayBeDependent(Kind) && ParentContext->isDependentContext()
-                    ? ExprDependence::Value
+                    ? ExprDependence::ValueInstantiation
                     : ExprDependence::None);
 }
 

--- a/clang/test/CodeGenCXX/builtin_FUNCTION.cpp
+++ b/clang/test/CodeGenCXX/builtin_FUNCTION.cpp
@@ -39,3 +39,20 @@ void do_default_arg_test() {
 }
 
 } // namespace test_func
+
+namespace test_decltype_template {
+
+template <typename> void template_func() {}
+
+// CHECK: define linkonce_odr {{(dso_local )?}}void @_ZN22test_decltype_template21use_decltype_templateIiEEvv(
+// CHECK: call void @_ZN22test_decltype_template13template_funcIPKcEEvv()
+template <typename> void use_decltype_template() {
+  template_func<decltype(__builtin_FUNCTION())>();
+}
+
+// CHECK: define linkonce_odr {{(dso_local )?}}void @_ZN22test_decltype_template13template_funcIPKcEEvv()
+void do_decltype_template_test() {
+  use_decltype_template<int>();
+}
+
+} // namespace test_decltype_template

--- a/clang/test/SemaCXX/source_location.cpp
+++ b/clang/test/SemaCXX/source_location.cpp
@@ -1081,3 +1081,13 @@ static_assert(X{}.
 static_assert(X{}.
                 foo() == 10001);
 }
+
+#ifdef MS
+namespace GH178324 {
+  struct a {
+    using e = int;
+  };
+  void current(const char * = __builtin_FUNCSIG());
+  template <class> void c() { decltype(a(current()))::e; }
+} // namespace GH178324
+#endif


### PR DESCRIPTION
Backporting crash fix when ``decltype(__builtin_FUNCTION())`` is used as a template type argument

Cherry-pick of 335a2d0e7e5a7e83723b9a32a0eed8aa373e8f62 from #187755

Pinging @mizvekov as instructed. Thanks