### PR TITLE
[TargetLowering] In expandDIVREMByConstant, combine shift by trailing zeros with chunk shifts.

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/TargetLowering.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/TargetLowering.cpp
@@ -8276,7 +8276,8 @@ bool TargetLowering::expandDIVREMByConstant(SDNode *N,
   } else {
     // Otherwise split into multple chunks and add them together. We chose
     // BestChunkWidth so that the sum will not overflow.
-    APInt Mask = APInt::getLowBitsSet(HBitWidth, BestChunkWidth);
+    SDValue Mask = DAG.getConstant(
+        APInt::getLowBitsSet(HBitWidth, BestChunkWidth), dl, HiLoVT);
 
     for (unsigned I = 0; I < BitWidth - TrailingZeros; I += BestChunkWidth) {
       // If there were trailing zeros in the divisor, increase the shift amount.
@@ -8292,8 +8293,7 @@ bool TargetLowering::expandDIVREMByConstant(SDNode *N,
         Chunk = GetFSHR(LL, LH, Shift);
       // If we're on the last chunk, we don't need an AND.
       if (I + BestChunkWidth < BitWidth - TrailingZeros)
-        Chunk = DAG.getNode(ISD::AND, dl, HiLoVT, Chunk,
-                            DAG.getConstant(Mask, dl, HiLoVT));
+        Chunk = DAG.getNode(ISD::AND, dl, HiLoVT, Chunk, Mask);
       if (!Sum)
         Sum = Chunk;
       else

--- a/llvm/lib/CodeGen/SelectionDAG/TargetLowering.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/TargetLowering.cpp
@@ -8282,15 +8282,14 @@ bool TargetLowering::expandDIVREMByConstant(SDNode *N,
       // If there were trailing zeros in the divisor, increase the shift amount.
       unsigned Shift = I + TrailingZeros;
       SDValue Chunk;
-      if (Shift == 0) {
+      if (Shift == 0)
         Chunk = LL;
-      } else if (Shift >= HBitWidth) {
+      else if (Shift >= HBitWidth)
         Chunk = DAG.getNode(
             ISD::SRL, dl, HiLoVT, LH,
             DAG.getShiftAmountConstant(Shift - HBitWidth, HiLoVT, dl));
-      } else {
+      else
         Chunk = GetFSHR(LL, LH, Shift);
-      }
       // If we're on the last chunk, we don't need an AND.
       if (I + BestChunkWidth < BitWidth - TrailingZeros)
         Chunk = DAG.getNode(ISD::AND, dl, HiLoVT, Chunk,

--- a/llvm/lib/CodeGen/SelectionDAG/TargetLowering.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/TargetLowering.cpp
@@ -8218,6 +8218,7 @@ bool TargetLowering::expandDIVREMByConstant(SDNode *N,
   bool HasFSHR = isOperationLegal(ISD::FSHR, HiLoVT);
 
   auto GetFSHR = [&](SDValue Lo, SDValue Hi, unsigned ShiftAmt) {
+    assert(ShiftAmt > 0 && ShiftAmt < HBitWidth);
     if (HasFSHR)
       return DAG.getNode(ISD::FSHR, dl, HiLoVT, Hi, Lo,
                          DAG.getShiftAmountConstant(ShiftAmt, HiLoVT, dl));
@@ -8233,23 +8234,24 @@ bool TargetLowering::expandDIVREMByConstant(SDNode *N,
   // Shift the input by the number of TrailingZeros in the divisor. The
   // shifted out bits will be added to the remainder later.
   SDValue PartialRem;
-  if (TrailingZeros) {
+  if (TrailingZeros && Opcode != ISD::UDIV) {
     // Save the shifted off bits if we need the remainder.
-    if (Opcode != ISD::UDIV) {
-      APInt Mask = APInt::getLowBitsSet(HBitWidth, TrailingZeros);
-      PartialRem = DAG.getNode(ISD::AND, dl, HiLoVT, LL,
-                               DAG.getConstant(Mask, dl, HiLoVT));
-    }
-
-    LL = GetFSHR(LL, LH, TrailingZeros);
-    LH = DAG.getNode(ISD::SRL, dl, HiLoVT, LH,
-                     DAG.getShiftAmountConstant(TrailingZeros, HiLoVT, dl));
+    APInt Mask = APInt::getLowBitsSet(HBitWidth, TrailingZeros);
+    PartialRem = DAG.getNode(ISD::AND, dl, HiLoVT, LL,
+                             DAG.getConstant(Mask, dl, HiLoVT));
   }
 
   SDValue Sum;
   // If BestChunkWidth is HBitWidth add low and high half. If there is a carry
   // out, add that to the final sum.
   if (BestChunkWidth == HBitWidth) {
+    // Shift LH:LL right if there were trailing zeros in the divisor.
+    if (TrailingZeros) {
+      LL = GetFSHR(LL, LH, TrailingZeros);
+      LH = DAG.getNode(ISD::SRL, dl, HiLoVT, LH,
+                       DAG.getShiftAmountConstant(TrailingZeros, HiLoVT, dl));
+    }
+
     // Use uaddo_carry if we can, otherwise use a compare to detect overflow.
     EVT SetCCType =
         getSetCCResultType(DAG.getDataLayout(), *DAG.getContext(), HiLoVT);
@@ -8274,23 +8276,25 @@ bool TargetLowering::expandDIVREMByConstant(SDNode *N,
   } else {
     // Otherwise split into multple chunks and add them together. We chose
     // BestChunkWidth so that the sum will not overflow.
-    SDValue Mask = DAG.getConstant(
-        APInt::getLowBitsSet(HBitWidth, BestChunkWidth), dl, HiLoVT);
+    APInt Mask = APInt::getLowBitsSet(HBitWidth, BestChunkWidth);
 
     for (unsigned I = 0; I < BitWidth - TrailingZeros; I += BestChunkWidth) {
+      // If there were trailing zeros in the divisor, increase the shift amount.
+      unsigned Shift = I + TrailingZeros;
       SDValue Chunk;
-      if (I == 0)
+      if (Shift == 0) {
         Chunk = LL;
-      else if (I >= HBitWidth)
-        Chunk =
-            DAG.getNode(ISD::SRL, dl, HiLoVT, LH,
-                        DAG.getShiftAmountConstant(I - HBitWidth, HiLoVT, dl));
-      else
-        Chunk = GetFSHR(LL, LH, I);
-
+      } else if (Shift >= HBitWidth) {
+        Chunk = DAG.getNode(
+            ISD::SRL, dl, HiLoVT, LH,
+            DAG.getShiftAmountConstant(Shift - HBitWidth, HiLoVT, dl));
+      } else {
+        Chunk = GetFSHR(LL, LH, Shift);
+      }
       // If we're on the last chunk, we don't need an AND.
       if (I + BestChunkWidth < BitWidth - TrailingZeros)
-        Chunk = DAG.getNode(ISD::AND, dl, HiLoVT, Chunk, Mask);
+        Chunk = DAG.getNode(ISD::AND, dl, HiLoVT, Chunk,
+                            DAG.getConstant(Mask, dl, HiLoVT));
       if (!Sum)
         Sum = Chunk;
       else
@@ -8305,6 +8309,13 @@ bool TargetLowering::expandDIVREMByConstant(SDNode *N,
   SDValue RemH = DAG.getConstant(0, dl, HiLoVT);
 
   if (Opcode != ISD::UREM) {
+    // If we didn't shift LH/LR earlier, do it now.
+    if (BestChunkWidth != HBitWidth && TrailingZeros) {
+      LL = GetFSHR(LL, LH, TrailingZeros);
+      LH = DAG.getNode(ISD::SRL, dl, HiLoVT, LH,
+                       DAG.getShiftAmountConstant(TrailingZeros, HiLoVT, dl));
+    }
+
     // Subtract the remainder from the shifted dividend.
     SDValue Dividend = DAG.getNode(ISD::BUILD_PAIR, dl, VT, LL, LH);
     SDValue Rem = DAG.getNode(ISD::BUILD_PAIR, dl, VT, RemL, RemH);
@@ -8327,12 +8338,13 @@ bool TargetLowering::expandDIVREMByConstant(SDNode *N,
 
   if (Opcode != ISD::UDIV) {
     // If we shifted the input, shift the remainder left and add the bits we
-    // shifted off the input. This add does not overflow.
+    // shifted off the input.
     if (TrailingZeros) {
       RemL = DAG.getNode(ISD::SHL, dl, HiLoVT, RemL,
                          DAG.getShiftAmountConstant(TrailingZeros, HiLoVT, dl));
 
-      RemL = DAG.getNode(ISD::ADD, dl, HiLoVT, RemL, PartialRem);
+      RemL = DAG.getNode(ISD::OR, dl, HiLoVT, RemL, PartialRem,
+                         SDNodeFlags::Disjoint);
     }
     Result.push_back(RemL);
     Result.push_back(RemH);

--- a/llvm/test/CodeGen/AArch64/rem-by-const.ll
+++ b/llvm/test/CodeGen/AArch64/rem-by-const.ll
@@ -586,13 +586,11 @@ entry:
 define i128 @ui128_100(i128 %a, i128 %b) {
 ; CHECK-SD-LABEL: ui128_100:
 ; CHECK-SD:       // %bb.0: // %entry
-; CHECK-SD-NEXT:    extr x8, x1, x0, #2
-; CHECK-SD-NEXT:    lsr x9, x1, #2
+; CHECK-SD-NEXT:    extr x8, x1, x0, #62
+; CHECK-SD-NEXT:    ubfx x9, x0, #2, #60
 ; CHECK-SD-NEXT:    mov w10, #25 // =0x19
-; CHECK-SD-NEXT:    extr x9, x9, x8, #60
 ; CHECK-SD-NEXT:    and x8, x8, #0xfffffffffffffff
-; CHECK-SD-NEXT:    and x9, x9, #0xfffffffffffffff
-; CHECK-SD-NEXT:    add x8, x8, x9
+; CHECK-SD-NEXT:    add x8, x9, x8
 ; CHECK-SD-NEXT:    mov x9, #62915 // =0xf5c3
 ; CHECK-SD-NEXT:    movk x9, #23592, lsl #16
 ; CHECK-SD-NEXT:    add x8, x8, x1, lsr #58
@@ -3242,35 +3240,31 @@ entry:
 define <2 x i128> @uv2i128_100(<2 x i128> %d, <2 x i128> %e) {
 ; CHECK-SD-LABEL: uv2i128_100:
 ; CHECK-SD:       // %bb.0: // %entry
-; CHECK-SD-NEXT:    lsr x8, x1, #2
-; CHECK-SD-NEXT:    extr x9, x1, x0, #2
-; CHECK-SD-NEXT:    extr x10, x3, x2, #2
-; CHECK-SD-NEXT:    lsr x11, x3, #2
-; CHECK-SD-NEXT:    mov w12, #25 // =0x19
-; CHECK-SD-NEXT:    extr x8, x8, x9, #60
-; CHECK-SD-NEXT:    and x9, x9, #0xfffffffffffffff
-; CHECK-SD-NEXT:    extr x11, x11, x10, #60
-; CHECK-SD-NEXT:    and x8, x8, #0xfffffffffffffff
-; CHECK-SD-NEXT:    add x8, x9, x8
-; CHECK-SD-NEXT:    and x9, x10, #0xfffffffffffffff
-; CHECK-SD-NEXT:    and x10, x11, #0xfffffffffffffff
+; CHECK-SD-NEXT:    extr x9, x1, x0, #62
+; CHECK-SD-NEXT:    ubfx x10, x0, #2, #60
+; CHECK-SD-NEXT:    extr x8, x3, x2, #62
 ; CHECK-SD-NEXT:    mov x11, #62915 // =0xf5c3
-; CHECK-SD-NEXT:    add x9, x9, x10
-; CHECK-SD-NEXT:    add x8, x8, x1, lsr #58
+; CHECK-SD-NEXT:    mov w12, #25 // =0x19
+; CHECK-SD-NEXT:    and x9, x9, #0xfffffffffffffff
+; CHECK-SD-NEXT:    and x8, x8, #0xfffffffffffffff
 ; CHECK-SD-NEXT:    movk x11, #23592, lsl #16
-; CHECK-SD-NEXT:    add x9, x9, x3, lsr #58
-; CHECK-SD-NEXT:    mov x1, xzr
+; CHECK-SD-NEXT:    add x9, x10, x9
+; CHECK-SD-NEXT:    ubfx x10, x2, #2, #60
 ; CHECK-SD-NEXT:    movk x11, #49807, lsl #32
-; CHECK-SD-NEXT:    mov x3, xzr
+; CHECK-SD-NEXT:    add x9, x9, x1, lsr #58
 ; CHECK-SD-NEXT:    movk x11, #10485, lsl #48
-; CHECK-SD-NEXT:    umulh x10, x8, x11
-; CHECK-SD-NEXT:    umulh x11, x9, x11
+; CHECK-SD-NEXT:    mov x1, xzr
+; CHECK-SD-NEXT:    add x8, x10, x8
+; CHECK-SD-NEXT:    add x8, x8, x3, lsr #58
+; CHECK-SD-NEXT:    umulh x10, x9, x11
+; CHECK-SD-NEXT:    mov x3, xzr
+; CHECK-SD-NEXT:    umulh x11, x8, x11
 ; CHECK-SD-NEXT:    lsr x10, x10, #2
 ; CHECK-SD-NEXT:    lsr x11, x11, #2
-; CHECK-SD-NEXT:    msub x8, x10, x12, x8
-; CHECK-SD-NEXT:    msub x9, x11, x12, x9
-; CHECK-SD-NEXT:    bfi x0, x8, #2, #62
-; CHECK-SD-NEXT:    bfi x2, x9, #2, #62
+; CHECK-SD-NEXT:    msub x9, x10, x12, x9
+; CHECK-SD-NEXT:    msub x8, x11, x12, x8
+; CHECK-SD-NEXT:    bfi x0, x9, #2, #62
+; CHECK-SD-NEXT:    bfi x2, x8, #2, #62
 ; CHECK-SD-NEXT:    ret
 ;
 ; CHECK-GI-LABEL: uv2i128_100:

--- a/llvm/test/CodeGen/RISCV/urem-lkk.ll
+++ b/llvm/test/CodeGen/RISCV/urem-lkk.ll
@@ -229,24 +229,21 @@ define i64 @dont_fold_urem_i64(i64 %x) nounwind {
 ;
 ; RV32IM-LABEL: dont_fold_urem_i64:
 ; RV32IM:       # %bb.0:
-; RV32IM-NEXT:    slli a2, a1, 31
-; RV32IM-NEXT:    srli a3, a0, 1
-; RV32IM-NEXT:    lui a4, 512
-; RV32IM-NEXT:    srli a5, a1, 1
-; RV32IM-NEXT:    srli a1, a1, 11
+; RV32IM-NEXT:    slli a2, a1, 10
+; RV32IM-NEXT:    srli a3, a0, 22
 ; RV32IM-NEXT:    or a2, a3, a2
-; RV32IM-NEXT:    slli a5, a5, 11
-; RV32IM-NEXT:    srli a3, a2, 21
-; RV32IM-NEXT:    or a3, a3, a5
-; RV32IM-NEXT:    lui a5, 21400
-; RV32IM-NEXT:    addi a4, a4, -1
-; RV32IM-NEXT:    and a2, a2, a4
-; RV32IM-NEXT:    add a1, a2, a1
+; RV32IM-NEXT:    lui a3, 512
+; RV32IM-NEXT:    addi a3, a3, -1
+; RV32IM-NEXT:    and a2, a2, a3
+; RV32IM-NEXT:    slli a3, a0, 10
+; RV32IM-NEXT:    srli a1, a1, 11
+; RV32IM-NEXT:    srli a3, a3, 11
+; RV32IM-NEXT:    add a1, a3, a1
+; RV32IM-NEXT:    lui a3, 21400
+; RV32IM-NEXT:    add a1, a1, a2
 ; RV32IM-NEXT:    li a2, 49
-; RV32IM-NEXT:    addi a5, a5, -2006
-; RV32IM-NEXT:    and a3, a3, a4
-; RV32IM-NEXT:    add a1, a1, a3
-; RV32IM-NEXT:    mulhu a3, a1, a5
+; RV32IM-NEXT:    addi a3, a3, -2006
+; RV32IM-NEXT:    mulhu a3, a1, a3
 ; RV32IM-NEXT:    mul a2, a3, a2
 ; RV32IM-NEXT:    sub a1, a1, a2
 ; RV32IM-NEXT:    slli a1, a1, 1

--- a/llvm/test/CodeGen/X86/divmod128.ll
+++ b/llvm/test/CodeGen/X86/divmod128.ll
@@ -1034,69 +1034,67 @@ entry:
 define i128 @udiv_i128_100(i128 %x) nounwind {
 ; X86-64-LABEL: udiv_i128_100:
 ; X86-64:       # %bb.0: # %entry
+; X86-64-NEXT:    movq %rdi, %rax
+; X86-64-NEXT:    shrdq $62, %rsi, %rax
+; X86-64-NEXT:    movabsq $1152921504606846975, %rdx # imm = 0xFFFFFFFFFFFFFFF
+; X86-64-NEXT:    andq %rdx, %rax
 ; X86-64-NEXT:    shrdq $2, %rsi, %rdi
-; X86-64-NEXT:    movabsq $1152921504606846975, %rax # imm = 0xFFFFFFFFFFFFFFF
-; X86-64-NEXT:    movq %rdi, %rdx
-; X86-64-NEXT:    andq %rax, %rdx
+; X86-64-NEXT:    andq %rdi, %rdx
+; X86-64-NEXT:    addq %rax, %rdx
 ; X86-64-NEXT:    movq %rsi, %rcx
-; X86-64-NEXT:    shrq $2, %rcx
-; X86-64-NEXT:    movq %rdi, %r8
-; X86-64-NEXT:    shrdq $60, %rcx, %r8
-; X86-64-NEXT:    andq %rax, %r8
-; X86-64-NEXT:    shrq $58, %rsi
-; X86-64-NEXT:    addq %rdx, %rsi
-; X86-64-NEXT:    addq %r8, %rsi
+; X86-64-NEXT:    shrq $58, %rcx
+; X86-64-NEXT:    addq %rdx, %rcx
 ; X86-64-NEXT:    movabsq $2951479051793528259, %rdx # imm = 0x28F5C28F5C28F5C3
-; X86-64-NEXT:    movq %rsi, %rax
+; X86-64-NEXT:    movq %rcx, %rax
 ; X86-64-NEXT:    mulq %rdx
 ; X86-64-NEXT:    shrq $2, %rdx
 ; X86-64-NEXT:    leaq (%rdx,%rdx,4), %rax
 ; X86-64-NEXT:    leaq (%rax,%rax,4), %rax
-; X86-64-NEXT:    subq %rax, %rsi
-; X86-64-NEXT:    subq %rsi, %rdi
-; X86-64-NEXT:    sbbq $0, %rcx
-; X86-64-NEXT:    movabsq $2951479051793528258, %rsi # imm = 0x28F5C28F5C28F5C2
-; X86-64-NEXT:    imulq %rdi, %rsi
+; X86-64-NEXT:    subq %rax, %rcx
+; X86-64-NEXT:    shrq $2, %rsi
+; X86-64-NEXT:    subq %rcx, %rdi
+; X86-64-NEXT:    sbbq $0, %rsi
+; X86-64-NEXT:    movabsq $2951479051793528258, %rcx # imm = 0x28F5C28F5C28F5C2
+; X86-64-NEXT:    imulq %rdi, %rcx
 ; X86-64-NEXT:    movabsq $-8116567392432202711, %r8 # imm = 0x8F5C28F5C28F5C29
 ; X86-64-NEXT:    movq %rdi, %rax
 ; X86-64-NEXT:    mulq %r8
-; X86-64-NEXT:    addq %rsi, %rdx
-; X86-64-NEXT:    imulq %r8, %rcx
 ; X86-64-NEXT:    addq %rcx, %rdx
+; X86-64-NEXT:    imulq %rsi, %r8
+; X86-64-NEXT:    addq %r8, %rdx
 ; X86-64-NEXT:    retq
 ;
 ; WIN64-LABEL: udiv_i128_100:
 ; WIN64:       # %bb.0: # %entry
 ; WIN64-NEXT:    movq %rdx, %r8
-; WIN64-NEXT:    shrdq $2, %rdx, %rcx
-; WIN64-NEXT:    movabsq $1152921504606846975, %rax # imm = 0xFFFFFFFFFFFFFFF
-; WIN64-NEXT:    movq %rcx, %rdx
-; WIN64-NEXT:    andq %rax, %rdx
+; WIN64-NEXT:    movq %rcx, %rax
+; WIN64-NEXT:    shrdq $62, %rdx, %rax
+; WIN64-NEXT:    movabsq $1152921504606846975, %rdx # imm = 0xFFFFFFFFFFFFFFF
+; WIN64-NEXT:    andq %rdx, %rax
+; WIN64-NEXT:    shrdq $2, %r8, %rcx
+; WIN64-NEXT:    andq %rcx, %rdx
+; WIN64-NEXT:    addq %rax, %rdx
 ; WIN64-NEXT:    movq %r8, %r9
-; WIN64-NEXT:    shrq $2, %r9
-; WIN64-NEXT:    movq %rcx, %r10
-; WIN64-NEXT:    shrdq $60, %r9, %r10
-; WIN64-NEXT:    andq %rax, %r10
-; WIN64-NEXT:    shrq $58, %r8
-; WIN64-NEXT:    addq %rdx, %r8
-; WIN64-NEXT:    addq %r10, %r8
+; WIN64-NEXT:    shrq $58, %r9
+; WIN64-NEXT:    addq %rdx, %r9
 ; WIN64-NEXT:    movabsq $2951479051793528259, %rdx # imm = 0x28F5C28F5C28F5C3
-; WIN64-NEXT:    movq %r8, %rax
+; WIN64-NEXT:    movq %r9, %rax
 ; WIN64-NEXT:    mulq %rdx
 ; WIN64-NEXT:    shrq $2, %rdx
 ; WIN64-NEXT:    leaq (%rdx,%rdx,4), %rax
 ; WIN64-NEXT:    leaq (%rax,%rax,4), %rax
-; WIN64-NEXT:    subq %rax, %r8
-; WIN64-NEXT:    subq %r8, %rcx
-; WIN64-NEXT:    sbbq $0, %r9
-; WIN64-NEXT:    movabsq $2951479051793528258, %r8 # imm = 0x28F5C28F5C28F5C2
-; WIN64-NEXT:    imulq %rcx, %r8
+; WIN64-NEXT:    subq %rax, %r9
+; WIN64-NEXT:    shrq $2, %r8
+; WIN64-NEXT:    subq %r9, %rcx
+; WIN64-NEXT:    sbbq $0, %r8
+; WIN64-NEXT:    movabsq $2951479051793528258, %r9 # imm = 0x28F5C28F5C28F5C2
+; WIN64-NEXT:    imulq %rcx, %r9
 ; WIN64-NEXT:    movabsq $-8116567392432202711, %r10 # imm = 0x8F5C28F5C28F5C29
 ; WIN64-NEXT:    movq %rcx, %rax
 ; WIN64-NEXT:    mulq %r10
-; WIN64-NEXT:    addq %r8, %rdx
-; WIN64-NEXT:    imulq %r10, %r9
 ; WIN64-NEXT:    addq %r9, %rdx
+; WIN64-NEXT:    imulq %r10, %r8
+; WIN64-NEXT:    addq %r8, %rdx
 ; WIN64-NEXT:    retq
 entry:
   %rem = udiv i128 %x, 100

--- a/llvm/test/CodeGen/X86/i128-udiv.ll
+++ b/llvm/test/CodeGen/X86/i128-udiv.ll
@@ -1584,34 +1584,33 @@ define i128 @div_by_22(i128 %x) nounwind {
 ;
 ; X64-LABEL: div_by_22:
 ; X64:       # %bb.0: # %entry
+; X64-NEXT:    movq %rdi, %rax
+; X64-NEXT:    shrdq $61, %rsi, %rax
+; X64-NEXT:    movabsq $1152921504606846975, %rdx # imm = 0xFFFFFFFFFFFFFFF
+; X64-NEXT:    andq %rdx, %rax
 ; X64-NEXT:    shrdq $1, %rsi, %rdi
-; X64-NEXT:    movabsq $1152921504606846975, %rax # imm = 0xFFFFFFFFFFFFFFF
-; X64-NEXT:    movq %rdi, %rdx
-; X64-NEXT:    andq %rax, %rdx
+; X64-NEXT:    andq %rdi, %rdx
+; X64-NEXT:    addq %rax, %rdx
 ; X64-NEXT:    movq %rsi, %rcx
-; X64-NEXT:    shrq %rcx
-; X64-NEXT:    movq %rdi, %r8
-; X64-NEXT:    shrdq $60, %rcx, %r8
-; X64-NEXT:    andq %rax, %r8
-; X64-NEXT:    shrq $57, %rsi
-; X64-NEXT:    addq %rdx, %rsi
-; X64-NEXT:    addq %r8, %rsi
+; X64-NEXT:    shrq $57, %rcx
+; X64-NEXT:    addq %rdx, %rcx
 ; X64-NEXT:    movabsq $3353953467947191203, %r8 # imm = 0x2E8BA2E8BA2E8BA3
-; X64-NEXT:    movq %rsi, %rax
+; X64-NEXT:    movq %rcx, %rax
 ; X64-NEXT:    mulq %r8
 ; X64-NEXT:    shrq %rdx
 ; X64-NEXT:    leaq (%rdx,%rdx,4), %rax
 ; X64-NEXT:    leaq (%rdx,%rax,2), %rax
-; X64-NEXT:    subq %rax, %rsi
-; X64-NEXT:    subq %rsi, %rdi
-; X64-NEXT:    sbbq $0, %rcx
-; X64-NEXT:    movabsq $-6707906935894382406, %rsi # imm = 0xA2E8BA2E8BA2E8BA
-; X64-NEXT:    imulq %rdi, %rsi
+; X64-NEXT:    subq %rax, %rcx
+; X64-NEXT:    shrq %rsi
+; X64-NEXT:    subq %rcx, %rdi
+; X64-NEXT:    sbbq $0, %rsi
+; X64-NEXT:    movabsq $-6707906935894382406, %rcx # imm = 0xA2E8BA2E8BA2E8BA
+; X64-NEXT:    imulq %rdi, %rcx
 ; X64-NEXT:    movq %rdi, %rax
 ; X64-NEXT:    mulq %r8
-; X64-NEXT:    addq %rsi, %rdx
-; X64-NEXT:    imulq %r8, %rcx
 ; X64-NEXT:    addq %rcx, %rdx
+; X64-NEXT:    imulq %rsi, %r8
+; X64-NEXT:    addq %r8, %rdx
 ; X64-NEXT:    retq
 entry:
   %div = udiv i128 %x, 22
@@ -1911,35 +1910,34 @@ define i128 @div_by_56(i128 %x) nounwind {
 ;
 ; X64-LABEL: div_by_56:
 ; X64:       # %bb.0:
+; X64-NEXT:    movq %rdi, %rax
+; X64-NEXT:    shrdq $63, %rsi, %rax
+; X64-NEXT:    movabsq $1152921504606846975, %rdx # imm = 0xFFFFFFFFFFFFFFF
+; X64-NEXT:    andq %rdx, %rax
 ; X64-NEXT:    shrdq $3, %rsi, %rdi
-; X64-NEXT:    movabsq $1152921504606846975, %rax # imm = 0xFFFFFFFFFFFFFFF
-; X64-NEXT:    movq %rdi, %rdx
-; X64-NEXT:    andq %rax, %rdx
+; X64-NEXT:    andq %rdi, %rdx
+; X64-NEXT:    addq %rax, %rdx
 ; X64-NEXT:    movq %rsi, %rcx
-; X64-NEXT:    shrq $3, %rcx
-; X64-NEXT:    movq %rdi, %r8
-; X64-NEXT:    shrdq $60, %rcx, %r8
-; X64-NEXT:    andq %rax, %r8
-; X64-NEXT:    shrq $59, %rsi
-; X64-NEXT:    addq %rdx, %rsi
-; X64-NEXT:    addq %r8, %rsi
+; X64-NEXT:    shrq $59, %rcx
+; X64-NEXT:    addq %rdx, %rcx
 ; X64-NEXT:    movabsq $5270498306774157605, %rdx # imm = 0x4924924924924925
-; X64-NEXT:    movq %rsi, %rax
+; X64-NEXT:    movq %rcx, %rax
 ; X64-NEXT:    mulq %rdx
 ; X64-NEXT:    shrq %rdx
 ; X64-NEXT:    leaq (,%rdx,8), %rax
 ; X64-NEXT:    subq %rax, %rdx
-; X64-NEXT:    addq %rsi, %rdx
+; X64-NEXT:    addq %rcx, %rdx
+; X64-NEXT:    shrq $3, %rsi
 ; X64-NEXT:    subq %rdx, %rdi
-; X64-NEXT:    sbbq $0, %rcx
-; X64-NEXT:    movabsq $-5270498306774157605, %rsi # imm = 0xB6DB6DB6DB6DB6DB
-; X64-NEXT:    imulq %rdi, %rsi
+; X64-NEXT:    sbbq $0, %rsi
+; X64-NEXT:    movabsq $-5270498306774157605, %rcx # imm = 0xB6DB6DB6DB6DB6DB
+; X64-NEXT:    imulq %rdi, %rcx
 ; X64-NEXT:    movabsq $7905747460161236407, %r8 # imm = 0x6DB6DB6DB6DB6DB7
 ; X64-NEXT:    movq %rdi, %rax
 ; X64-NEXT:    mulq %r8
-; X64-NEXT:    addq %rsi, %rdx
-; X64-NEXT:    imulq %r8, %rcx
 ; X64-NEXT:    addq %rcx, %rdx
+; X64-NEXT:    imulq %rsi, %r8
+; X64-NEXT:    addq %r8, %rdx
 ; X64-NEXT:    retq
   %div = udiv i128 %x, 56 ; 8 * 7
   ret i128 %div
@@ -2592,15 +2590,14 @@ define i128 @rem_by_14(i128 %x) nounwind {
 ; X64-LABEL: rem_by_14:
 ; X64:       # %bb.0:
 ; X64-NEXT:    movq %rdi, %rax
-; X64-NEXT:    shrdq $1, %rsi, %rax
+; X64-NEXT:    shrdq $61, %rsi, %rax
 ; X64-NEXT:    movabsq $1152921504606846975, %rcx # imm = 0xFFFFFFFFFFFFFFF
-; X64-NEXT:    movq %rsi, %rdx
-; X64-NEXT:    shrq %rdx
-; X64-NEXT:    shldq $4, %rax, %rdx
 ; X64-NEXT:    andq %rcx, %rax
+; X64-NEXT:    movq %rdi, %rdx
+; X64-NEXT:    shrq %rdx
 ; X64-NEXT:    andq %rcx, %rdx
+; X64-NEXT:    addq %rax, %rdx
 ; X64-NEXT:    shrq $57, %rsi
-; X64-NEXT:    addq %rax, %rsi
 ; X64-NEXT:    addq %rdx, %rsi
 ; X64-NEXT:    movabsq $5270498306774157605, %rcx # imm = 0x4924924924924925
 ; X64-NEXT:    movq %rsi, %rax

--- a/llvm/test/CodeGen/X86/vector-idiv-udiv-128.ll
+++ b/llvm/test/CodeGen/X86/vector-idiv-udiv-128.ll
@@ -1090,67 +1090,67 @@ define <2 x i128> @v2i128_div_by_14(<2 x i128> %x) nounwind {
 ; SSE-NEXT:    pushq %r15
 ; SSE-NEXT:    pushq %r14
 ; SSE-NEXT:    pushq %rbx
-; SSE-NEXT:    movq %rdx, %r9
-; SSE-NEXT:    shrdq $1, %rdx, %rsi
-; SSE-NEXT:    movabsq $1152921504606846975, %r11 # imm = 0xFFFFFFFFFFFFFFF
+; SSE-NEXT:    movq %rcx, %r9
+; SSE-NEXT:    movq %rdx, %rcx
 ; SSE-NEXT:    movq %rsi, %rax
+; SSE-NEXT:    shrdq $61, %rdx, %rax
+; SSE-NEXT:    movabsq $1152921504606846975, %r11 # imm = 0xFFFFFFFFFFFFFFF
 ; SSE-NEXT:    andq %r11, %rax
-; SSE-NEXT:    movq %rdx, %r10
-; SSE-NEXT:    shrq %r10
+; SSE-NEXT:    shrdq $1, %rdx, %rsi
 ; SSE-NEXT:    movq %rsi, %rdx
-; SSE-NEXT:    shrdq $60, %r10, %rdx
 ; SSE-NEXT:    andq %r11, %rdx
-; SSE-NEXT:    shrq $57, %r9
-; SSE-NEXT:    addq %rax, %r9
-; SSE-NEXT:    addq %rdx, %r9
-; SSE-NEXT:    movabsq $5270498306774157605, %r14 # imm = 0x4924924924924925
+; SSE-NEXT:    addq %rax, %rdx
+; SSE-NEXT:    movq %rcx, %r10
+; SSE-NEXT:    shrq $57, %r10
+; SSE-NEXT:    addq %rdx, %r10
+; SSE-NEXT:    movabsq $5270498306774157605, %r15 # imm = 0x4924924924924925
+; SSE-NEXT:    movq %r10, %rax
+; SSE-NEXT:    mulq %r15
+; SSE-NEXT:    shrq %rdx
+; SSE-NEXT:    leaq (,%rdx,8), %rax
+; SSE-NEXT:    subq %rax, %rdx
+; SSE-NEXT:    addq %r10, %rdx
+; SSE-NEXT:    shrq %rcx
+; SSE-NEXT:    subq %rdx, %rsi
+; SSE-NEXT:    sbbq $0, %rcx
+; SSE-NEXT:    movabsq $-5270498306774157605, %rbx # imm = 0xB6DB6DB6DB6DB6DB
+; SSE-NEXT:    movq %rsi, %r10
+; SSE-NEXT:    imulq %rbx, %r10
+; SSE-NEXT:    movabsq $7905747460161236407, %r14 # imm = 0x6DB6DB6DB6DB6DB7
+; SSE-NEXT:    movq %rsi, %rax
+; SSE-NEXT:    mulq %r14
+; SSE-NEXT:    movq %rax, %rsi
+; SSE-NEXT:    addq %r10, %rdx
+; SSE-NEXT:    imulq %r14, %rcx
+; SSE-NEXT:    addq %rdx, %rcx
+; SSE-NEXT:    movq %r9, %rax
+; SSE-NEXT:    shrdq $61, %r8, %rax
+; SSE-NEXT:    andq %r11, %rax
+; SSE-NEXT:    shrdq $1, %r8, %r9
+; SSE-NEXT:    andq %r9, %r11
+; SSE-NEXT:    addq %rax, %r11
+; SSE-NEXT:    movq %r8, %r10
+; SSE-NEXT:    shrq $57, %r10
+; SSE-NEXT:    addq %r11, %r10
+; SSE-NEXT:    movq %r10, %rax
+; SSE-NEXT:    mulq %r15
+; SSE-NEXT:    shrq %rdx
+; SSE-NEXT:    leaq (,%rdx,8), %rax
+; SSE-NEXT:    subq %rax, %rdx
+; SSE-NEXT:    addq %r10, %rdx
+; SSE-NEXT:    shrq %r8
+; SSE-NEXT:    subq %rdx, %r9
+; SSE-NEXT:    sbbq $0, %r8
+; SSE-NEXT:    imulq %r9, %rbx
 ; SSE-NEXT:    movq %r9, %rax
 ; SSE-NEXT:    mulq %r14
-; SSE-NEXT:    shrq %rdx
-; SSE-NEXT:    leaq (,%rdx,8), %rax
-; SSE-NEXT:    subq %rax, %rdx
-; SSE-NEXT:    addq %r9, %rdx
-; SSE-NEXT:    subq %rdx, %rsi
-; SSE-NEXT:    sbbq $0, %r10
-; SSE-NEXT:    movabsq $-5270498306774157605, %r9 # imm = 0xB6DB6DB6DB6DB6DB
-; SSE-NEXT:    movq %rsi, %r15
-; SSE-NEXT:    imulq %r9, %r15
-; SSE-NEXT:    movabsq $7905747460161236407, %rbx # imm = 0x6DB6DB6DB6DB6DB7
-; SSE-NEXT:    movq %rsi, %rax
-; SSE-NEXT:    mulq %rbx
-; SSE-NEXT:    movq %rax, %rsi
-; SSE-NEXT:    addq %r15, %rdx
-; SSE-NEXT:    imulq %rbx, %r10
-; SSE-NEXT:    addq %rdx, %r10
-; SSE-NEXT:    shrdq $1, %r8, %rcx
-; SSE-NEXT:    movq %rcx, %rax
-; SSE-NEXT:    andq %r11, %rax
-; SSE-NEXT:    movq %r8, %r15
-; SSE-NEXT:    shrq %r15
-; SSE-NEXT:    movq %rcx, %rdx
-; SSE-NEXT:    shrdq $60, %r15, %rdx
-; SSE-NEXT:    andq %r11, %rdx
-; SSE-NEXT:    shrq $57, %r8
-; SSE-NEXT:    addq %rax, %r8
+; SSE-NEXT:    addq %rbx, %rdx
+; SSE-NEXT:    imulq %r14, %r8
 ; SSE-NEXT:    addq %rdx, %r8
-; SSE-NEXT:    movq %r8, %rax
-; SSE-NEXT:    mulq %r14
-; SSE-NEXT:    shrq %rdx
-; SSE-NEXT:    leaq (,%rdx,8), %rax
-; SSE-NEXT:    subq %rax, %rdx
-; SSE-NEXT:    addq %r8, %rdx
-; SSE-NEXT:    subq %rdx, %rcx
-; SSE-NEXT:    sbbq $0, %r15
-; SSE-NEXT:    imulq %rcx, %r9
-; SSE-NEXT:    movq %rcx, %rax
-; SSE-NEXT:    mulq %rbx
-; SSE-NEXT:    addq %r9, %rdx
-; SSE-NEXT:    imulq %rbx, %r15
-; SSE-NEXT:    addq %rdx, %r15
 ; SSE-NEXT:    movq %rax, 16(%rdi)
 ; SSE-NEXT:    movq %rsi, (%rdi)
-; SSE-NEXT:    movq %r15, 24(%rdi)
-; SSE-NEXT:    movq %r10, 8(%rdi)
+; SSE-NEXT:    movq %r8, 24(%rdi)
+; SSE-NEXT:    movq %rcx, 8(%rdi)
 ; SSE-NEXT:    movq %rdi, %rax
 ; SSE-NEXT:    popq %rbx
 ; SSE-NEXT:    popq %r14
@@ -1162,67 +1162,67 @@ define <2 x i128> @v2i128_div_by_14(<2 x i128> %x) nounwind {
 ; AVX-NEXT:    pushq %r15
 ; AVX-NEXT:    pushq %r14
 ; AVX-NEXT:    pushq %rbx
-; AVX-NEXT:    movq %rdx, %r9
-; AVX-NEXT:    shrdq $1, %rdx, %rsi
-; AVX-NEXT:    movabsq $1152921504606846975, %r11 # imm = 0xFFFFFFFFFFFFFFF
+; AVX-NEXT:    movq %rcx, %r9
+; AVX-NEXT:    movq %rdx, %rcx
 ; AVX-NEXT:    movq %rsi, %rax
+; AVX-NEXT:    shrdq $61, %rdx, %rax
+; AVX-NEXT:    movabsq $1152921504606846975, %r11 # imm = 0xFFFFFFFFFFFFFFF
 ; AVX-NEXT:    andq %r11, %rax
-; AVX-NEXT:    movq %rdx, %r10
-; AVX-NEXT:    shrq %r10
+; AVX-NEXT:    shrdq $1, %rdx, %rsi
 ; AVX-NEXT:    movq %rsi, %rdx
-; AVX-NEXT:    shrdq $60, %r10, %rdx
 ; AVX-NEXT:    andq %r11, %rdx
-; AVX-NEXT:    shrq $57, %r9
-; AVX-NEXT:    addq %rax, %r9
-; AVX-NEXT:    addq %rdx, %r9
-; AVX-NEXT:    movabsq $5270498306774157605, %r14 # imm = 0x4924924924924925
+; AVX-NEXT:    addq %rax, %rdx
+; AVX-NEXT:    movq %rcx, %r10
+; AVX-NEXT:    shrq $57, %r10
+; AVX-NEXT:    addq %rdx, %r10
+; AVX-NEXT:    movabsq $5270498306774157605, %r15 # imm = 0x4924924924924925
+; AVX-NEXT:    movq %r10, %rax
+; AVX-NEXT:    mulq %r15
+; AVX-NEXT:    shrq %rdx
+; AVX-NEXT:    leaq (,%rdx,8), %rax
+; AVX-NEXT:    subq %rax, %rdx
+; AVX-NEXT:    addq %r10, %rdx
+; AVX-NEXT:    shrq %rcx
+; AVX-NEXT:    subq %rdx, %rsi
+; AVX-NEXT:    sbbq $0, %rcx
+; AVX-NEXT:    movabsq $-5270498306774157605, %rbx # imm = 0xB6DB6DB6DB6DB6DB
+; AVX-NEXT:    movq %rsi, %r10
+; AVX-NEXT:    imulq %rbx, %r10
+; AVX-NEXT:    movabsq $7905747460161236407, %r14 # imm = 0x6DB6DB6DB6DB6DB7
+; AVX-NEXT:    movq %rsi, %rax
+; AVX-NEXT:    mulq %r14
+; AVX-NEXT:    movq %rax, %rsi
+; AVX-NEXT:    addq %r10, %rdx
+; AVX-NEXT:    imulq %r14, %rcx
+; AVX-NEXT:    addq %rdx, %rcx
+; AVX-NEXT:    movq %r9, %rax
+; AVX-NEXT:    shrdq $61, %r8, %rax
+; AVX-NEXT:    andq %r11, %rax
+; AVX-NEXT:    shrdq $1, %r8, %r9
+; AVX-NEXT:    andq %r9, %r11
+; AVX-NEXT:    addq %rax, %r11
+; AVX-NEXT:    movq %r8, %r10
+; AVX-NEXT:    shrq $57, %r10
+; AVX-NEXT:    addq %r11, %r10
+; AVX-NEXT:    movq %r10, %rax
+; AVX-NEXT:    mulq %r15
+; AVX-NEXT:    shrq %rdx
+; AVX-NEXT:    leaq (,%rdx,8), %rax
+; AVX-NEXT:    subq %rax, %rdx
+; AVX-NEXT:    addq %r10, %rdx
+; AVX-NEXT:    shrq %r8
+; AVX-NEXT:    subq %rdx, %r9
+; AVX-NEXT:    sbbq $0, %r8
+; AVX-NEXT:    imulq %r9, %rbx
 ; AVX-NEXT:    movq %r9, %rax
 ; AVX-NEXT:    mulq %r14
-; AVX-NEXT:    shrq %rdx
-; AVX-NEXT:    leaq (,%rdx,8), %rax
-; AVX-NEXT:    subq %rax, %rdx
-; AVX-NEXT:    addq %r9, %rdx
-; AVX-NEXT:    subq %rdx, %rsi
-; AVX-NEXT:    sbbq $0, %r10
-; AVX-NEXT:    movabsq $-5270498306774157605, %r9 # imm = 0xB6DB6DB6DB6DB6DB
-; AVX-NEXT:    movq %rsi, %r15
-; AVX-NEXT:    imulq %r9, %r15
-; AVX-NEXT:    movabsq $7905747460161236407, %rbx # imm = 0x6DB6DB6DB6DB6DB7
-; AVX-NEXT:    movq %rsi, %rax
-; AVX-NEXT:    mulq %rbx
-; AVX-NEXT:    movq %rax, %rsi
-; AVX-NEXT:    addq %r15, %rdx
-; AVX-NEXT:    imulq %rbx, %r10
-; AVX-NEXT:    addq %rdx, %r10
-; AVX-NEXT:    shrdq $1, %r8, %rcx
-; AVX-NEXT:    movq %rcx, %rax
-; AVX-NEXT:    andq %r11, %rax
-; AVX-NEXT:    movq %r8, %r15
-; AVX-NEXT:    shrq %r15
-; AVX-NEXT:    movq %rcx, %rdx
-; AVX-NEXT:    shrdq $60, %r15, %rdx
-; AVX-NEXT:    andq %r11, %rdx
-; AVX-NEXT:    shrq $57, %r8
-; AVX-NEXT:    addq %rax, %r8
+; AVX-NEXT:    addq %rbx, %rdx
+; AVX-NEXT:    imulq %r14, %r8
 ; AVX-NEXT:    addq %rdx, %r8
-; AVX-NEXT:    movq %r8, %rax
-; AVX-NEXT:    mulq %r14
-; AVX-NEXT:    shrq %rdx
-; AVX-NEXT:    leaq (,%rdx,8), %rax
-; AVX-NEXT:    subq %rax, %rdx
-; AVX-NEXT:    addq %r8, %rdx
-; AVX-NEXT:    subq %rdx, %rcx
-; AVX-NEXT:    sbbq $0, %r15
-; AVX-NEXT:    imulq %rcx, %r9
-; AVX-NEXT:    movq %rcx, %rax
-; AVX-NEXT:    mulq %rbx
-; AVX-NEXT:    addq %r9, %rdx
-; AVX-NEXT:    imulq %rbx, %r15
-; AVX-NEXT:    addq %rdx, %r15
 ; AVX-NEXT:    movq %rax, 16(%rdi)
 ; AVX-NEXT:    movq %rsi, (%rdi)
-; AVX-NEXT:    movq %r15, 24(%rdi)
-; AVX-NEXT:    movq %r10, 8(%rdi)
+; AVX-NEXT:    movq %r8, 24(%rdi)
+; AVX-NEXT:    movq %rcx, 8(%rdi)
 ; AVX-NEXT:    movq %rdi, %rax
 ; AVX-NEXT:    popq %rbx
 ; AVX-NEXT:    popq %r14
@@ -1321,14 +1321,14 @@ define <2 x i128> @v2i128_rem_by_14(<2 x i128> %x) nounwind {
 ; SSE:       # %bb.0: # %entry
 ; SSE-NEXT:    movq %rdx, %r9
 ; SSE-NEXT:    movq %rsi, %rax
-; SSE-NEXT:    shrdq $1, %rdx, %rax
+; SSE-NEXT:    shrdq $61, %rdx, %rax
 ; SSE-NEXT:    movabsq $1152921504606846975, %r10 # imm = 0xFFFFFFFFFFFFFFF
-; SSE-NEXT:    shrq %rdx
-; SSE-NEXT:    shldq $4, %rax, %rdx
 ; SSE-NEXT:    andq %r10, %rax
+; SSE-NEXT:    movq %rsi, %rdx
+; SSE-NEXT:    shrq %rdx
 ; SSE-NEXT:    andq %r10, %rdx
+; SSE-NEXT:    addq %rax, %rdx
 ; SSE-NEXT:    shrq $57, %r9
-; SSE-NEXT:    addq %rax, %r9
 ; SSE-NEXT:    addq %rdx, %r9
 ; SSE-NEXT:    movabsq $5270498306774157605, %r11 # imm = 0x4924924924924925
 ; SSE-NEXT:    movq %r9, %rax
@@ -1340,14 +1340,13 @@ define <2 x i128> @v2i128_rem_by_14(<2 x i128> %x) nounwind {
 ; SSE-NEXT:    andl $1, %esi
 ; SSE-NEXT:    leaq (%rsi,%r9,2), %rsi
 ; SSE-NEXT:    movq %rcx, %rax
-; SSE-NEXT:    shrdq $1, %r8, %rax
-; SSE-NEXT:    movq %r8, %rdx
-; SSE-NEXT:    shrq %rdx
-; SSE-NEXT:    shldq $4, %rax, %rdx
+; SSE-NEXT:    shrdq $61, %r8, %rax
 ; SSE-NEXT:    andq %r10, %rax
+; SSE-NEXT:    movq %rcx, %rdx
+; SSE-NEXT:    shrq %rdx
 ; SSE-NEXT:    andq %r10, %rdx
+; SSE-NEXT:    addq %rax, %rdx
 ; SSE-NEXT:    shrq $57, %r8
-; SSE-NEXT:    addq %rax, %r8
 ; SSE-NEXT:    addq %rdx, %r8
 ; SSE-NEXT:    movq %r8, %rax
 ; SSE-NEXT:    mulq %r11
@@ -1368,14 +1367,14 @@ define <2 x i128> @v2i128_rem_by_14(<2 x i128> %x) nounwind {
 ; AVX:       # %bb.0: # %entry
 ; AVX-NEXT:    movq %rdx, %r9
 ; AVX-NEXT:    movq %rsi, %rax
-; AVX-NEXT:    shrdq $1, %rdx, %rax
+; AVX-NEXT:    shrdq $61, %rdx, %rax
 ; AVX-NEXT:    movabsq $1152921504606846975, %r10 # imm = 0xFFFFFFFFFFFFFFF
-; AVX-NEXT:    shrq %rdx
-; AVX-NEXT:    shldq $4, %rax, %rdx
 ; AVX-NEXT:    andq %r10, %rax
+; AVX-NEXT:    movq %rsi, %rdx
+; AVX-NEXT:    shrq %rdx
 ; AVX-NEXT:    andq %r10, %rdx
+; AVX-NEXT:    addq %rax, %rdx
 ; AVX-NEXT:    shrq $57, %r9
-; AVX-NEXT:    addq %rax, %r9
 ; AVX-NEXT:    addq %rdx, %r9
 ; AVX-NEXT:    movabsq $5270498306774157605, %r11 # imm = 0x4924924924924925
 ; AVX-NEXT:    movq %r9, %rax
@@ -1387,14 +1386,13 @@ define <2 x i128> @v2i128_rem_by_14(<2 x i128> %x) nounwind {
 ; AVX-NEXT:    andl $1, %esi
 ; AVX-NEXT:    leaq (%rsi,%r9,2), %rsi
 ; AVX-NEXT:    movq %rcx, %rax
-; AVX-NEXT:    shrdq $1, %r8, %rax
-; AVX-NEXT:    movq %r8, %rdx
-; AVX-NEXT:    shrq %rdx
-; AVX-NEXT:    shldq $4, %rax, %rdx
+; AVX-NEXT:    shrdq $61, %r8, %rax
 ; AVX-NEXT:    andq %r10, %rax
+; AVX-NEXT:    movq %rcx, %rdx
+; AVX-NEXT:    shrq %rdx
 ; AVX-NEXT:    andq %r10, %rdx
+; AVX-NEXT:    addq %rax, %rdx
 ; AVX-NEXT:    shrq $57, %r8
-; AVX-NEXT:    addq %rax, %r8
 ; AVX-NEXT:    addq %rdx, %r8
 ; AVX-NEXT:    movq %r8, %rax
 ; AVX-NEXT:    mulq %r11


### PR DESCRIPTION
This reduces the number of generated instructions in some cases.

While I was there, I changed an Add to a Disjoint OR since DAGCombine was going to do it anyway.