### PR TITLE
[clang] Fix const FixIt placement after comparison operator member definition

### DIFF
--- a/clang/lib/Sema/SemaDeclCXX.cpp
+++ b/clang/lib/Sema/SemaDeclCXX.cpp
@@ -9039,7 +9039,7 @@ bool Sema::CheckExplicitlyDefaultedComparison(Scope *S, FunctionDecl *FD,
       } else {
         Loc = MD->getLocation();
         if (FunctionTypeLoc Loc = MD->getFunctionTypeLoc())
-          InsertLoc = Loc.getRParenLoc();
+          InsertLoc = getLocForEndOfToken(Loc.getRParenLoc());
       }
       // Don't diagnose an implicit 'operator=='; we will have diagnosed the
       // corresponding defaulted 'operator<=>' already.

--- a/clang/test/FixIt/fixit-defaulted-comparison.cpp
+++ b/clang/test/FixIt/fixit-defaulted-comparison.cpp
@@ -1,0 +1,12 @@
+// RUN: cp %s %t
+// RUN: not %clang_cc1 -std=c++23 -x c++ -fixit %t
+// RUN: %clang_cc1 -std=c++23 -x c++ %t
+// RUN: not %clang_cc1 -std=c++23 -x c++ -fsyntax-only -fdiagnostics-parseable-fixits %s 2>&1 | FileCheck %s
+
+#include <compare>
+
+struct Box {
+  std::partial_ordering operator<=>(const Box& other) = default;
+  // expected-error@-1 {{defaulted member three-way comparison operator must be const-qualified}}
+  // CHECK: fix-it:{{.*}}:{7:54-7:54}:" const"
+};

--- a/clang/test/FixIt/fixit-defaulted-comparison.cpp
+++ b/clang/test/FixIt/fixit-defaulted-comparison.cpp
@@ -1,12 +1,18 @@
+// RUN: %clang_cc1 -verify -std=c++23 %s
 // RUN: cp %s %t
 // RUN: not %clang_cc1 -std=c++23 -x c++ -fixit %t
 // RUN: %clang_cc1 -std=c++23 -x c++ %t
 // RUN: not %clang_cc1 -std=c++23 -x c++ -fsyntax-only -fdiagnostics-parseable-fixits %s 2>&1 | FileCheck %s
 
-#include <compare>
+namespace std {
+struct partial_ordering {};
+} // namespace std
 
 struct Box {
-  std::partial_ordering operator<=>(const Box& other) = default;
-  // expected-error@-1 {{defaulted member three-way comparison operator must be const-qualified}}
-  // CHECK: fix-it:{{.*}}:{7:54-7:54}:" const"
+  std::partial_ordering operator<=>(const Box& other) = default; // #ssdecl
+  bool operator==(const Box& other) = default; // #eqdecl
+  // expected-error@#ssdecl {{defaulted member three-way comparison operator must be const-qualified}}
+  // expected-error@#eqdecl {{defaulted member equality comparison operator must be const-qualified}}
+  // CHECK: fix-it:{{.*}}:{12:54-12:54}:" const"
+  // CHECK: fix-it:{{.*}}:{13:36-13:36}:" const"
 };


### PR DESCRIPTION
This PR updates `InsertLoc` to use the token after the closing parenthesis when placing the `const` FixIt for comparison operators.

It also adds a test covering this case for both the spaceship operator and a regular comparison operator.

Closes #187887