### PR TITLE
libclc: Update atan

### DIFF
--- a/libclc/clc/include/clc/math/clc_atan_helpers.h
+++ b/libclc/clc/include/clc/math/clc_atan_helpers.h
@@ -6,15 +6,12 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "clc/clc_convert.h"
-#include "clc/float/definitions.h"
-#include "clc/internal/clc.h"
-#include "clc/math/clc_atan_helpers.h"
-#include "clc/math/clc_copysign.h"
-#include "clc/math/clc_fabs.h"
-#include "clc/math/clc_fma.h"
-#include "clc/math/clc_mad.h"
-#include "clc/math/clc_recip_fast.h"
+#ifndef __CLC_MATH_CLC_ATAN_HELPERS_H__
+#define __CLC_MATH_CLC_ATAN_HELPERS_H__
 
-#define __CLC_BODY "clc_atan.inc"
+#include "clc/internal/clc.h"
+
+#define __CLC_BODY "clc/math/clc_atan_helpers_decl.inc"
 #include "clc/math/gentype.inc"
+
+#endif // __CLC_MATH_CLC_ATAN_HELPERS_H__

--- a/libclc/clc/include/clc/math/clc_atan_helpers_decl.inc
+++ b/libclc/clc/include/clc/math/clc_atan_helpers_decl.inc
@@ -6,15 +6,5 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "clc/clc_convert.h"
-#include "clc/float/definitions.h"
-#include "clc/internal/clc.h"
-#include "clc/math/clc_atan_helpers.h"
-#include "clc/math/clc_copysign.h"
-#include "clc/math/clc_fabs.h"
-#include "clc/math/clc_fma.h"
-#include "clc/math/clc_mad.h"
-#include "clc/math/clc_recip_fast.h"
-
-#define __CLC_BODY "clc_atan.inc"
-#include "clc/math/gentype.inc"
+_CLC_DECL _CLC_OVERLOAD _CLC_CONST __CLC_GENTYPE
+__clc_atan_reduced(__CLC_GENTYPE v);

--- a/libclc/clc/lib/generic/CMakeLists.txt
+++ b/libclc/clc/lib/generic/CMakeLists.txt
@@ -62,6 +62,7 @@ libclc_configure_source_list(CLC_GENERIC_SOURCES
   math/clc_asinh.cl
   math/clc_asinpi.cl
   math/clc_atan.cl
+  math/clc_atan_helpers.cl
   math/clc_atan2.cl
   math/clc_atan2pi.cl
   math/clc_atanh.cl

--- a/libclc/clc/lib/generic/math/clc_asin.cl
+++ b/libclc/clc/lib/generic/math/clc_asin.cl
@@ -9,10 +9,13 @@
 #include "clc/clc_convert.h"
 #include "clc/float/definitions.h"
 #include "clc/internal/clc.h"
+#include "clc/math/clc_copysign.h"
+#include "clc/math/clc_ep.h"
 #include "clc/math/clc_fabs.h"
 #include "clc/math/clc_fma.h"
 #include "clc/math/clc_mad.h"
 #include "clc/math/clc_sqrt.h"
+#include "clc/math/clc_sqrt_fast.h"
 #include "clc/math/math.h"
 
 #define __CLC_BODY "clc_asin.inc"

--- a/libclc/clc/lib/generic/math/clc_asin.inc
+++ b/libclc/clc/lib/generic/math/clc_asin.inc
@@ -26,129 +26,137 @@
 
 #if __CLC_FPSIZE == 32
 
-_CLC_OVERLOAD _CLC_DEF __CLC_GENTYPE __clc_asin(__CLC_GENTYPE x) {
-  // 0x33a22168
-  const __CLC_GENTYPE piby2_tail = __CLC_FP_LIT(7.5497894159e-08);
-  // 0x3f490fda
-  const __CLC_GENTYPE hpiby2_head = __CLC_FP_LIT(7.8539812565e-01);
-  // 0x3fc90fdb
-  const __CLC_GENTYPE piby2 = __CLC_FP_LIT(1.5707963705e+00);
+_CLC_DEF _CLC_OVERLOAD _CLC_CONST __CLC_GENTYPE __clc_asin(__CLC_GENTYPE x) {
+  // Computes arcsin(x).
+  // The argument is first reduced by noting that arcsin(x)
+  // is invalid for abs(x) > 1 and arcsin(-x) = -arcsin(x).
+  // For denormal and small arguments arcsin(x) = x to machine
+  // accuracy. Remaining argument ranges are handled as follows.
+  // For abs(x) <= 0.5 use
+  // arcsin(x) = x + x^3*R(x^2)
+  // where R(x^2) is a polynomial minimax approximation to
+  // (arcsin(x) - x)/x^3.
+  // For abs(x) > 0.5 exploit the identity:
+  // arcsin(x) = pi/2 - 2*arcsin(sqrt(1-x)/2)
+  // together with the above polynomial approximation, and
+  // reconstruct the terms carefully.
 
-  __CLC_UINTN ux = __CLC_AS_UINTN(x);
-  __CLC_UINTN aux = ux & EXSIGNBIT_SP32;
-  __CLC_UINTN xs = ux ^ aux;
-  __CLC_GENTYPE spiby2 = __CLC_AS_GENTYPE(xs | __CLC_AS_UINTN(piby2));
-  __CLC_INTN xexp = __CLC_AS_INTN(aux >> EXPSHIFTBITS_SP32) - EXPBIAS_SP32;
-  __CLC_GENTYPE y = __CLC_AS_GENTYPE(aux);
+  __CLC_GENTYPE ax = __clc_fabs(x);
+  __CLC_GENTYPE tx = __clc_mad(ax, -0.5f, 0.5f);
+  __CLC_GENTYPE x2 = x * x;
+  __CLC_GENTYPE r = ax >= 0.5f ? tx : x2;
 
-  // abs(x) >= 0.5
-  __CLC_INTN transform = xexp >= -1;
-
-  __CLC_GENTYPE y2 = y * y;
-  __CLC_GENTYPE rt = __CLC_FP_LIT(0.5) * (__CLC_FP_LIT(1.0) - y);
-  __CLC_GENTYPE r = transform ? rt : y2;
-
-  // Use a rational approximation for [0.0, 0.5]
-  __CLC_GENTYPE a =
-      __clc_mad(r,
+  __CLC_GENTYPE u = r * __clc_mad(r, __clc_mad(r, __clc_mad(r, __clc_mad(r,
                 __clc_mad(r,
-                          __clc_mad(r, -0.00396137437848476485201154797087F,
-                                    -0.0133819288943925804214011424456F),
-                          -0.0565298683201845211985026327361F),
-                0.184161606965100694821398249421F);
+                    0x1.38434ep-5f, 0x1.bf8bb4p-7f), 0x1.069878p-5f), 0x1.6c8362p-5f),
+                    0x1.33379p-4f), 0x1.555558p-3f);
 
-  __CLC_GENTYPE b = __clc_mad(r, -0.836411276854206731913362287293F,
-                              1.10496961524520294485512696706F);
-  __CLC_GENTYPE u = r * MATH_DIVIDE(a, b);
+  __CLC_GENTYPE s = __clc_sqrt_fast(r);
+  __CLC_GENTYPE ret =
+      __clc_mad(0x1.ddcb02p-1f, 0x1.aee9d6p+0f, -2.0f * __clc_mad(s, u, s));
 
-  __CLC_GENTYPE s = __clc_sqrt(r);
-  __CLC_GENTYPE s1 = __CLC_AS_GENTYPE(__CLC_AS_UINTN(s) & 0xffff0000);
-  __CLC_GENTYPE c = MATH_DIVIDE(__clc_mad(-s1, s1, r), s + s1);
-  __CLC_GENTYPE p = __clc_mad(2.0f * s, u, -__clc_mad(c, -2.0f, piby2_tail));
-  __CLC_GENTYPE q = __clc_mad(s1, -2.0f, hpiby2_head);
-  __CLC_GENTYPE vt = hpiby2_head - (p - q);
-  __CLC_GENTYPE v = __clc_mad(y, u, y);
-  v = transform ? vt : v;
+  __CLC_GENTYPE xux = __clc_mad(ax, u, ax);
+  ret = ax < 0.5f ? xux : ret;
 
-  __CLC_GENTYPE ret = __CLC_AS_GENTYPE(xs | __CLC_AS_UINTN(v));
-  ret = aux > 0x3f800000U ? __CLC_GENTYPE_NAN : ret;
-  ret = aux == 0x3f800000U ? spiby2 : ret;
-  ret = xexp < -14 ? x : ret;
-
-  return ret;
+  return __clc_copysign(ret, x);
 }
 
 #elif __CLC_FPSIZE == 64
 
-_CLC_OVERLOAD _CLC_DEF __CLC_GENTYPE __clc_asin(__CLC_GENTYPE x) {
-  // 0x3c91a62633145c07
-  const __CLC_GENTYPE piby2_tail = __CLC_FP_LIT(6.1232339957367660e-17);
-  // 0x3fe921fb54442d18
-  const __CLC_GENTYPE hpiby2_head = 7.8539816339744831e-01;
-  // 0x3ff921fb54442d18
-  const __CLC_GENTYPE piby2 = 1.5707963267948965e+00;
+static _CLC_OVERLOAD _CLC_CONST __CLC_GENTYPE __clc_asin_identity_reduction(__CLC_GENTYPE x, __CLC_GENTYPE r,
+                                                                            __CLC_GENTYPE u, __CLC_GENTYPE v) {
+  __CLC_GENTYPE y = __clc_fabs(x);
+  __CLC_EP_PAIR s = __clc_ep_sqrt(r);
+  __CLC_EP_PAIR ve = __clc_ep_fast_sub(
+    __clc_ep_make_pair(__CLC_FP_LIT(0x1.921fb54442d18p-1), __CLC_FP_LIT(0x1.1a62633145c07p-55)),
+    __clc_ep_fast_add(s, __clc_ep_mul(s, u)));
+  v = ve.hi + ve.hi;
+  return y == 1.0 ? 0x1.921fb54442d18p+0 : v;
+}
+
+_CLC_DEF _CLC_OVERLOAD _CLC_CONST __CLC_GENTYPE __clc_asin(__CLC_GENTYPE x) {
+  // Computes arcsin(x).
+  // The argument is first reduced by noting that arcsin(x)
+  // is invalid for abs(x) > 1 and arcsin(-x) = -arcsin(x).
+  // For denormal and small arguments arcsin(x) = x to machine
+  // accuracy. Remaining argument ranges are handled as follows.
+  // For abs(x) <= 0.5 use
+  // arcsin(x) = x + x^3*R(x^2)
+  // where R(x^2) is a rational minimax approximation to
+  // (arcsin(x) - x)/x^3.
+  // For abs(x) > 0.5 exploit the identity:
+  // arcsin(x) = pi/2 - 2*arcsin(sqrt(1-x)/2)
+  // together with the above rational approximation, and
+  // reconstruct the terms carefully.
 
   __CLC_GENTYPE y = __clc_fabs(x);
-  __CLC_LONGN xneg = x < __CLC_FP_LIT(0.0);
-  __CLC_INTN xexp = __CLC_CONVERT_INTN(
-      (__CLC_AS_ULONGN(y) >> EXPSHIFTBITS_DP64) - EXPBIAS_DP64);
+  __CLC_S_GENTYPE transform = y >= 0.5;
 
-  // abs(x) >= 0.5
-  __CLC_LONGN transform = __CLC_CONVERT_LONGN(xexp >= -1);
-
-  __CLC_GENTYPE rt = __CLC_FP_LIT(0.5) * (__CLC_FP_LIT(1.0) - y);
+  __CLC_GENTYPE rt = __clc_mad(y, -0.5, 0.5);
   __CLC_GENTYPE y2 = y * y;
   __CLC_GENTYPE r = transform ? rt : y2;
 
-  // Use a rational approximation for [0.0, 0.5]
+  __CLC_GENTYPE u = r * __clc_mad(r, __clc_mad(r, __clc_mad(r, __clc_mad(r,
+                 __clc_mad(r, __clc_mad(r, __clc_mad(r, __clc_mad(r,
+                 __clc_mad(r, __clc_mad(r, __clc_mad(r,
+                     0x1.059859fea6a70p-5, -0x1.0a5a378a05eafp-6), 0x1.4052137024d6ap-6), 0x1.ab3a098a70509p-8),
+                     0x1.8ed60a300c8d2p-7), 0x1.c6fa84b77012bp-7), 0x1.1c6c111dccb70p-6), 0x1.6e89f0a0adacfp-6),
+                     0x1.f1c72c668963fp-6), 0x1.6db6db41ce4bdp-5), 0x1.333333336fd5bp-4), 0x1.5555555555380p-3);
 
-  __CLC_GENTYPE un = __clc_fma(
-      r,
-      __clc_fma(
-          r,
-          __clc_fma(r,
-                    __clc_fma(r,
-                              __clc_fma(r, 0.0000482901920344786991880522822991,
-                                        0.00109242697235074662306043804220),
-                              -0.0549989809235685841612020091328),
-                    0.275558175256937652532686256258),
-          -0.445017216867635649900123110649),
-      0.227485835556935010735943483075);
+  __CLC_GENTYPE v = __clc_mad(y, u, y);
 
-  __CLC_GENTYPE ud = __clc_fma(
-      r,
-      __clc_fma(r,
-                __clc_fma(r,
-                          __clc_fma(r, 0.105869422087204370341222318533,
-                                    -0.943639137032492685763471240072),
-                          2.76568859157270989520376345954),
-                -3.28431505720958658909889444194),
-      1.36491501334161032038194214209);
+#ifdef __CLC_SCALAR
+  if (transform) {
+    v = __clc_asin_identity_reduction(x, r, u, v);
+  }
+#else
+  __CLC_GENTYPE identity = __clc_asin_identity_reduction(x, r, u, v);
+  v = transform ? identity : v;
+#endif
 
-  __CLC_GENTYPE u = r * MATH_DIVIDE(un, ud);
-
-  // Reconstruct asin carefully in transformed region
-  __CLC_GENTYPE s = __clc_sqrt(r);
-  __CLC_GENTYPE sh =
-      __CLC_AS_GENTYPE(__CLC_AS_ULONGN(s) & 0xffffffff00000000UL);
-  __CLC_GENTYPE c = MATH_DIVIDE(__clc_fma(-sh, sh, r), s + sh);
-  __CLC_GENTYPE p = __clc_fma(2.0 * s, u, -__clc_fma(-2.0, c, piby2_tail));
-  __CLC_GENTYPE q = __clc_fma(-2.0, sh, hpiby2_head);
-  __CLC_GENTYPE vt = hpiby2_head - (p - q);
-  __CLC_GENTYPE v = __clc_fma(y, u, y);
-  v = transform ? vt : v;
-
-  v = __CLC_CONVERT_LONGN(xexp < -28) ? y : v;
-  v = __CLC_CONVERT_LONGN(xexp >= 0) ? __CLC_GENTYPE_NAN : v;
-  v = y == 1.0 ? piby2 : v;
-
-  return xneg ? -v : v;
+  return __clc_copysign(v, x);
 }
 
 #elif __CLC_FPSIZE == 16
 
-_CLC_OVERLOAD _CLC_DEF __CLC_GENTYPE __clc_asin(__CLC_GENTYPE x) {
-  return __CLC_CONVERT_GENTYPE(__clc_asin(__CLC_CONVERT_FLOATN(x)));
+static _CLC_OVERLOAD _CLC_CONST __CLC_GENTYPE
+__clc_asin_small_case(__CLC_GENTYPE x) {
+  __CLC_HALFN ax = __clc_fabs(x);
+  __CLC_HALFN s = x * x;
+  __CLC_HALFN p = s * __clc_mad(s, 0x1.828p-4h, 0x1.52p-3h);
+  return __clc_mad(ax, p, ax);
+}
+
+static _CLC_OVERLOAD _CLC_CONST __CLC_GENTYPE
+__clc_asin_large_case(__CLC_GENTYPE x) {
+  __CLC_HALFN ax = __clc_fabs(x);
+  __CLC_FLOATN s = __clc_mad(__CLC_CONVERT_FLOATN(ax), (__CLC_FLOATN)-0.5f,
+                             (__CLC_FLOATN)0.5f);
+  __CLC_FLOATN t = __clc_sqrt_fast(s);
+  __CLC_FLOATN p = __clc_mad(t, __clc_mad(s, -0x1.82675ap-2f, -0x1.ff9f6p+0f),
+                             0x1.921fb6p+0f);
+  return __CLC_CONVERT_HALFN(p);
+}
+
+_CLC_DEF _CLC_OVERLOAD _CLC_CONST __CLC_GENTYPE __clc_asin(__CLC_GENTYPE x) {
+  // Computes arcsin(x).
+  // The argument is first reduced by noting that arcsin(x)
+  // is invalid for abs(x) > 1 and arcsin(-x) = -arcsin(x).
+  // For denormal and small arguments arcsin(x) = x to machine
+  // accuracy. Remaining argument ranges are handled as follows.
+  // For abs(x) <= 0.5 use
+  // arcsin(x) = x + x^3*R(x^2)
+  // where R(x^2) is a polynomial minimax approximation to
+  // (arcsin(x) - x)/x^3.
+  // For abs(x) > 0.5 exploit the identity:
+  // arcsin(x) = pi/2 - 2*arcsin(sqrt(1-x)/2)
+  // together with the above polynomial approximation, and
+  // reconstruct the terms carefully.
+
+  __CLC_HALFN ax = __clc_fabs(x);
+  __CLC_HALFN r =
+      ax <= 0.5h ? __clc_asin_small_case(x) : __clc_asin_large_case(x);
+  return __clc_copysign(r, x);
 }
 
 #endif

--- a/libclc/clc/lib/generic/math/clc_atan.inc
+++ b/libclc/clc/lib/generic/math/clc_atan.inc
@@ -8,161 +8,51 @@
 
 #if __CLC_FPSIZE == 32
 
-_CLC_OVERLOAD _CLC_DEF __CLC_GENTYPE __clc_atan(__CLC_GENTYPE x) {
-  const __CLC_GENTYPE piby2 = 1.5707963267948966f; // 0x3ff921fb54442d18
+_CLC_DEF _CLC_OVERLOAD _CLC_CONST __CLC_FLOATN __clc_atan(__CLC_FLOATN x) {
+  __CLC_FLOATN v = __clc_fabs(x);
+  __CLC_INTN g = v > 1.0f;
 
-  __CLC_UINTN ux = __CLC_AS_UINTN(x);
-  __CLC_UINTN aux = ux & EXSIGNBIT_SP32;
-  __CLC_UINTN sx = ux ^ aux;
+  __CLC_FLOATN vi = __clc_recip_fast(v);
+  v = g ? vi : v;
 
-  __CLC_GENTYPE spiby2 = __CLC_AS_GENTYPE(sx | __CLC_AS_UINTN(piby2));
+  __CLC_FLOATN a = __clc_atan_reduced(v);
 
-  __CLC_GENTYPE v = __CLC_AS_GENTYPE(aux);
+  __CLC_FLOATN y = __clc_mad(0x1.ddcb02p-1f, 0x1.aee9d6p+0f, -a);
+  a = g ? y : a;
 
-  // Return for NaN
-  __CLC_GENTYPE ret = x;
-
-  // 2^26 <= |x| <= Inf => atan(x) is close to piby2
-  ret = aux <= PINFBITPATT_SP32 ? spiby2 : ret;
-
-  // Reduce arguments 2^-19 <= |x| < 2^26
-
-  // 39/16 <= x < 2^26
-  x = -MATH_RECIP(v);
-  __CLC_GENTYPE c = 1.57079632679489655800f; // atan(infinity)
-
-  // 19/16 <= x < 39/16
-  __CLC_INTN l = aux < 0x401c0000;
-  __CLC_GENTYPE xx = MATH_DIVIDE(v - 1.5f, __clc_mad(v, 1.5f, 1.0f));
-  x = l ? xx : x;
-  c = l ? 9.82793723247329054082e-01f : c; // atan(1.5)
-
-  // 11/16 <= x < 19/16
-  l = aux < 0x3f980000U;
-  xx = MATH_DIVIDE(v - 1.0f, 1.0f + v);
-  x = l ? xx : x;
-  c = l ? 7.85398163397448278999e-01f : c; // atan(1)
-
-  // 7/16 <= x < 11/16
-  l = aux < 0x3f300000;
-  xx = MATH_DIVIDE(__clc_mad(v, 2.0f, -1.0f), 2.0f + v);
-  x = l ? xx : x;
-  c = l ? 4.63647609000806093515e-01f : c; // atan(0.5)
-
-  // 2^-19 <= x < 7/16
-  l = aux < 0x3ee00000;
-  x = l ? v : x;
-  c = l ? 0.0f : c;
-
-  // Core approximation: Remez(2,2) on [-7/16,7/16]
-
-  __CLC_GENTYPE s = x * x;
-  __CLC_GENTYPE a = __clc_mad(s,
-                              __clc_mad(s, 0.470677934286149214138357545549e-2f,
-                                        0.192324546402108583211697690500f),
-                              0.296528598819239217902158651186f);
-
-  __CLC_GENTYPE b = __clc_mad(s,
-                              __clc_mad(s, 0.299309699959659728404442796915f,
-                                        0.111072499995399550138837673349e1f),
-                              0.889585796862432286486651434570f);
-
-  __CLC_GENTYPE q = x * s * MATH_DIVIDE(a, b);
-
-  __CLC_GENTYPE z = c - (q - x);
-  __CLC_GENTYPE zs = __CLC_AS_GENTYPE(sx | __CLC_AS_UINTN(z));
-
-  ret = aux < 0x4c800000 ? zs : ret;
-
-  // |x| < 2^-19
-  ret = aux < 0x36000000 ? __CLC_AS_GENTYPE(ux) : ret;
-  return ret;
+  return __clc_copysign(a, x);
 }
 
 #elif __CLC_FPSIZE == 64
 
-_CLC_OVERLOAD _CLC_DEF __CLC_GENTYPE __clc_atan(__CLC_GENTYPE x) {
-  const __CLC_GENTYPE piby2 = 1.5707963267948966e+00; // 0x3ff921fb54442d18
+_CLC_DEF _CLC_OVERLOAD _CLC_CONST __CLC_DOUBLEN __clc_atan(__CLC_DOUBLEN x) {
+  __CLC_DOUBLEN v = __clc_fabs(x);
+  __CLC_LONGN g = v > 1.0;
 
-  __CLC_GENTYPE v = __clc_fabs(x);
+  v = g ? (1.0 / v) : v;
 
-  // 2^56 > v > 39/16
-  __CLC_GENTYPE a = -1.0;
-  __CLC_GENTYPE b = v;
-  // (chi + clo) = arctan(infinity)
-  __CLC_GENTYPE chi = 1.57079632679489655800e+00;
-  __CLC_GENTYPE clo = 6.12323399573676480327e-17;
+  __CLC_DOUBLEN a = __clc_atan_reduced(v);
+  __CLC_DOUBLEN y = __clc_fma(0x1.dd9ad336a0500p-1, 0x1.af154eeb562d6p+0, -a);
+  a = g ? y : a;
 
-  __CLC_GENTYPE ta = v - 1.5;
-  __CLC_GENTYPE tb = 1.0 + 1.5 * v;
-  __CLC_LONGN l = v <= 0x1.38p+1; // 39/16 > v > 19/16
-  a = l ? ta : a;
-  b = l ? tb : b;
-  // (chi + clo) = arctan(1.5)
-  chi = l ? 9.82793723247329054082e-01 : chi;
-  clo = l ? 1.39033110312309953701e-17 : clo;
-
-  ta = v - 1.0;
-  tb = 1.0 + v;
-  l = v <= 0x1.3p+0; // 19/16 > v > 11/16
-  a = l ? ta : a;
-  b = l ? tb : b;
-  // (chi + clo) = arctan(1.)
-  chi = l ? 7.85398163397448278999e-01 : chi;
-  clo = l ? 3.06161699786838240164e-17 : clo;
-
-  ta = 2.0 * v - 1.0;
-  tb = 2.0 + v;
-  l = v <= 0x1.6p-1; // 11/16 > v > 7/16
-  a = l ? ta : a;
-  b = l ? tb : b;
-  // (chi + clo) = arctan(0.5)
-  chi = l ? 4.63647609000806093515e-01 : chi;
-  clo = l ? 2.26987774529616809294e-17 : clo;
-
-  l = v <= 0x1.cp-2; // v < 7/16
-  a = l ? v : a;
-  b = l ? 1.0 : b;
-  ;
-  chi = l ? 0.0 : chi;
-  clo = l ? 0.0 : clo;
-
-  // Core approximation: Remez(4,4) on [-7/16,7/16]
-  __CLC_GENTYPE r = a / b;
-  __CLC_GENTYPE s = r * r;
-  __CLC_GENTYPE qn =
-      __clc_fma(s,
-                __clc_fma(s,
-                          __clc_fma(s,
-                                    __clc_fma(s, 0.142316903342317766e-3,
-                                              0.304455919504853031e-1),
-                                    0.220638780716667420e0),
-                          0.447677206805497472e0),
-                0.268297920532545909e0);
-
-  __CLC_GENTYPE qd =
-      __clc_fma(s,
-                __clc_fma(s,
-                          __clc_fma(s,
-                                    __clc_fma(s, 0.389525873944742195e-1,
-                                              0.424602594203847109e0),
-                                    0.141254259931958921e1),
-                          0.182596787737507063e1),
-                0.804893761597637733e0);
-
-  __CLC_GENTYPE q = r * s * qn / qd;
-  r = chi - ((q - clo) - r);
-
-  __CLC_GENTYPE z = __clc_isnan(x) ? x : piby2;
-  z = v <= 0x1.0p+56 ? r : z;
-  z = v < 0x1.0p-26 ? v : z;
-  return x == v ? z : -z;
+  return __clc_copysign(a, x);
 }
 
 #elif __CLC_FPSIZE == 16
 
-_CLC_OVERLOAD _CLC_DEF __CLC_GENTYPE __clc_atan(__CLC_GENTYPE x) {
-  return __CLC_CONVERT_GENTYPE(__clc_atan(__CLC_CONVERT_FLOATN(x)));
+_CLC_DEF _CLC_OVERLOAD _CLC_CONST __CLC_HALFN __clc_atan(__CLC_HALFN x) {
+  __CLC_HALFN v = __clc_fabs(x);
+  __CLC_SHORTN g = v > 1.0h;
+
+  __CLC_HALFN vi = __clc_recip_fast(v);
+  v = g ? vi : v;
+
+  __CLC_HALFN a = __clc_atan_reduced(v);
+
+  __CLC_HALFN y = __clc_mad(0x1.ea8p-1h, 0x1.a3cp+0h, -a);
+  a = g ? y : a;
+
+  return __clc_copysign(a, x);
 }
 
 #endif

--- a/libclc/clc/lib/generic/math/clc_atan_helpers.cl
+++ b/libclc/clc/lib/generic/math/clc_atan_helpers.cl
@@ -6,15 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "clc/clc_convert.h"
-#include "clc/float/definitions.h"
-#include "clc/internal/clc.h"
 #include "clc/math/clc_atan_helpers.h"
-#include "clc/math/clc_copysign.h"
-#include "clc/math/clc_fabs.h"
-#include "clc/math/clc_fma.h"
 #include "clc/math/clc_mad.h"
-#include "clc/math/clc_recip_fast.h"
 
-#define __CLC_BODY "clc_atan.inc"
+#define __CLC_BODY "clc_atan_helpers.inc"
+
 #include "clc/math/gentype.inc"

--- a/libclc/clc/lib/generic/math/clc_atan_helpers.inc
+++ b/libclc/clc/lib/generic/math/clc_atan_helpers.inc
@@ -1,0 +1,53 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#if __CLC_FPSIZE == 32
+
+_CLC_DEF _CLC_OVERLOAD _CLC_CONST __CLC_FLOATN
+__clc_atan_reduced(__CLC_FLOATN v) {
+  __CLC_FLOATN t = v * v;
+  __CLC_FLOATN z = __clc_mad(t, __clc_mad(t, __clc_mad(t, __clc_mad(t,
+            __clc_mad(t, __clc_mad(t, __clc_mad(t,
+                0x1.5a54bp-9f, -0x1.f4b218p-7f), 0x1.53f67ep-5f), -0x1.2fa9aep-4f),
+                0x1.b26364p-4f), -0x1.22c1ccp-3f), 0x1.99717ep-3f), -0x1.5554c4p-2f);
+
+  z = __clc_mad(v, t * z, v);
+  return z;
+}
+
+#elif __CLC_FPSIZE == 64
+
+_CLC_DEF _CLC_OVERLOAD _CLC_CONST __CLC_DOUBLEN
+__clc_atan_reduced(__CLC_DOUBLEN v) {
+  __CLC_DOUBLEN t = v * v;
+  __CLC_DOUBLEN z = __clc_mad(t, __clc_mad(t, __clc_mad(t, __clc_mad(t,
+             __clc_mad(t, __clc_mad(t, __clc_mad(t, __clc_mad(t,
+             __clc_mad(t, __clc_mad(t, __clc_mad(t, __clc_mad(t,
+             __clc_mad(t, __clc_mad(t, __clc_mad(t, __clc_mad(t,
+             __clc_mad(t, __clc_mad(t, __clc_mad(t,
+                 0x1.ba404b5e68a13p-17, -0x1.3e260bd3237f4p-13), 0x1.b2bb069efb384p-11), -0x1.7952daf56de9bp-9),
+                 0x1.d6d43a595c56fp-8), -0x1.c6ea4a57d9582p-7), 0x1.67e295f08b19fp-6), -0x1.e9ae6fc27006ap-6),
+                 0x1.2c15b5711927ap-5), -0x1.59976e82d3ff0p-5), 0x1.82d5d6ef28734p-5), -0x1.ae5ce6a214619p-5),
+                 0x1.e1bb48427b883p-5), -0x1.110e48b207f05p-4), 0x1.3b13657b87036p-4), -0x1.745d119378e4fp-4),
+                 0x1.c71c717e1913cp-4), -0x1.2492492376b7dp-3), 0x1.99999999952ccp-3), -0x1.5555555555523p-2);
+  z = __clc_mad(v, t*z, v);
+  return z;
+}
+
+#elif __CLC_FPSIZE == 16
+
+_CLC_DEF _CLC_OVERLOAD _CLC_CONST __CLC_HALFN
+__clc_atan_reduced(__CLC_HALFN v) {
+  __CLC_HALFN t = v * v;
+  __CLC_HALFN z = __clc_mad(
+      t, __clc_mad(t, __clc_mad(t, 0x1.938p-6h, -0x1.7f4p-4h), 0x1.7dcp-3h),
+      -0x1.54p-2h);
+  return __clc_mad(t, v * z, v);
+}
+
+#endif


### PR DESCRIPTION
This was originally ported from rocm device libs in
47882923c7b48c00d6c0ea9960b5457e957093c4. Merge in more
recent changes.