### PR TITLE
[NFC][analyzer] Eliminate SwitchNodeBuilder

### DIFF
--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/CoreEngine.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/CoreEngine.h
@@ -336,11 +336,6 @@ class SwitchNodeBuilder : public NodeBuilder {
 public:
   SwitchNodeBuilder(ExplodedNodeSet &DstSet, const NodeBuilderContext &Ctx)
       : NodeBuilder(DstSet, Ctx) {}
-
-  using iterator = CFGBlock::const_succ_reverse_iterator;
-
-  iterator begin() { return C.getBlock()->succ_rbegin() + 1; }
-  iterator end() { return C.getBlock()->succ_rend(); }
 };
 
 } // namespace ento

--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/CoreEngine.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/CoreEngine.h
@@ -51,7 +51,6 @@ class CoreEngine {
   friend class ExprEngine;
   friend class NodeBuilder;
   friend class NodeBuilderContext;
-  friend class SwitchNodeBuilder;
 
 public:
   using BlocksExhausted =
@@ -330,12 +329,6 @@ public:
 
   ExplodedNode *generateNode(ProgramStateRef State, bool branch,
                              ExplodedNode *Pred);
-};
-
-class SwitchNodeBuilder : public NodeBuilder {
-public:
-  SwitchNodeBuilder(ExplodedNodeSet &DstSet, const NodeBuilderContext &Ctx)
-      : NodeBuilder(DstSet, Ctx) {}
 };
 
 } // namespace ento

--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/CoreEngine.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/CoreEngine.h
@@ -341,12 +341,6 @@ public:
 
   iterator begin() { return C.getBlock()->succ_rbegin() + 1; }
   iterator end() { return C.getBlock()->succ_rend(); }
-
-  ExplodedNode *generateCaseStmtNode(const CFGBlock *Block,
-                                     ProgramStateRef State, ExplodedNode *Pred);
-
-  ExplodedNode *generateDefaultCaseNode(ProgramStateRef State,
-                                        ExplodedNode *Pred);
 };
 
 } // namespace ento

--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/ExprEngine.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/ExprEngine.h
@@ -89,7 +89,6 @@ class ProgramState;
 class ProgramStateManager;
 class RegionAndSymbolInvalidationTraits;
 class SymbolManager;
-class SwitchNodeBuilder;
 
 /// Hints for figuring out of a call should be inlined during evalCall().
 struct EvalCallOptions {

--- a/clang/lib/StaticAnalyzer/Core/CoreEngine.cpp
+++ b/clang/lib/StaticAnalyzer/Core/CoreEngine.cpp
@@ -707,26 +707,3 @@ ExplodedNode *BranchNodeBuilder::generateNode(ProgramStateRef State,
   ExplodedNode *Succ = NodeBuilder::generateNode(Loc, State, NodePred);
   return Succ;
 }
-
-ExplodedNode *SwitchNodeBuilder::generateCaseStmtNode(const CFGBlock *Block,
-                                                      ProgramStateRef St,
-                                                      ExplodedNode *Pred) {
-  BlockEdge BE(C.getBlock(), Block, Pred->getLocationContext());
-  return generateNode(BE, St, Pred);
-}
-
-ExplodedNode *SwitchNodeBuilder::generateDefaultCaseNode(ProgramStateRef St,
-                                                         ExplodedNode *Pred) {
-  // Get the block for the default case.
-  const CFGBlock *Src = C.getBlock();
-  assert(Src->succ_rbegin() != Src->succ_rend());
-  CFGBlock *DefaultBlock = *Src->succ_rbegin();
-
-  // Basic correctness check for default blocks that are unreachable and not
-  // caught by earlier stages.
-  if (!DefaultBlock)
-    return nullptr;
-
-  BlockEdge BE(Src, DefaultBlock, Pred->getLocationContext());
-  return generateNode(BE, St, Pred);
-}

--- a/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
@@ -3131,8 +3131,10 @@ void ExprEngine::processSwitch(const SwitchStmt *Switch, ExplodedNode *Pred,
         StateMatching = State;
       }
 
-      if (StateMatching)
-        Builder.generateCaseStmtNode(Block, StateMatching, Node);
+      if (StateMatching) {
+        BlockEdge BE(getCurrBlock(), Block, Node->getLocationContext());
+        Builder.generateNode(BE, StateMatching, Node);
+      }
 
       // If _not_ entering the current case is infeasible, then we are done
       // with processing the paths through the current Node.
@@ -3154,7 +3156,18 @@ void ExprEngine::processSwitch(const SwitchStmt *Switch, ExplodedNode *Pred,
         continue;
     }
 
-    Builder.generateDefaultCaseNode(State, Node);
+    // Get the block for the default case.
+    const CFGBlock *Src = getCurrBlock();
+    assert(Src->succ_rbegin() != Src->succ_rend());
+    CFGBlock *DefaultBlock = *Src->succ_rbegin();
+
+    // Basic correctness check for default blocks that are unreachable and not
+    // caught by earlier stages.
+    if (!DefaultBlock)
+      return;
+
+    BlockEdge BE(Src, DefaultBlock, Node->getLocationContext());
+    Builder.generateNode(BE, State, Node);
   }
 }
 

--- a/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
@@ -3084,7 +3084,6 @@ void ExprEngine::processSwitch(const SwitchStmt *Switch, ExplodedNode *Pred,
                                ExplodedNodeSet &Dst) {
   const Expr *Condition = Switch->getCond();
 
-  NodeBuilder Builder(Dst, *currBldrCtx);
   ExplodedNodeSet CheckersOutSet;
 
   getCheckerManager().runCheckersForBranchCondition(
@@ -3145,7 +3144,7 @@ void ExprEngine::processSwitch(const SwitchStmt *Switch, ExplodedNode *Pred,
 
       if (StateMatching) {
         BlockEdge BE(getCurrBlock(), Block, Node->getLocationContext());
-        Builder.generateNode(BE, StateMatching, Node);
+        Dst.insert(Engine.makeNode(BE, StateMatching, Node));
       }
 
       // If _not_ entering the current case is infeasible, then we are done
@@ -3179,7 +3178,7 @@ void ExprEngine::processSwitch(const SwitchStmt *Switch, ExplodedNode *Pred,
       return;
 
     BlockEdge BE(Src, DefaultBlock, Node->getLocationContext());
-    Builder.generateNode(BE, State, Node);
+    Dst.insert(Engine.makeNode(BE, State, Node));
   }
 }
 

--- a/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
@@ -3083,6 +3083,7 @@ void ExprEngine::processEndOfFunction(ExplodedNode *Pred,
 void ExprEngine::processSwitch(const SwitchStmt *Switch, ExplodedNode *Pred,
                                ExplodedNodeSet &Dst) {
   const ASTContext &ACtx = getContext();
+  const LocationContext *LCtx = Pred->getLocationContext();
   const Expr *Condition = Switch->getCond();
 
   ExplodedNodeSet CheckersOutSet;
@@ -3092,7 +3093,6 @@ void ExprEngine::processSwitch(const SwitchStmt *Switch, ExplodedNode *Pred,
 
   for (ExplodedNode *Node : CheckersOutSet) {
     ProgramStateRef State = Node->getState();
-    const LocationContext *LCtx = Node->getLocationContext();
 
     SVal CondV = State->getSVal(Condition, LCtx);
     if (CondV.isUndef()) {

--- a/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
@@ -3091,13 +3091,13 @@ void ExprEngine::processSwitch(const SwitchStmt *Switch, ExplodedNode *Pred,
 
   for (ExplodedNode *Node : CheckersOutSet) {
     ProgramStateRef State = Node->getState();
+    const LocationContext *LCtx = Node->getLocationContext();
 
-    SVal CondV = State->getSVal(Condition, Node->getLocationContext());
+    SVal CondV = State->getSVal(Condition, LCtx);
     if (CondV.isUndef()) {
       // This can only happen if core.uninitialized.Branch is disabled.
       continue;
     }
-
     std::optional<NonLoc> CondNL = CondV.getAs<NonLoc>();
 
     // The reversed iteration order was arbitrarily introduced in 2008 by
@@ -3143,7 +3143,7 @@ void ExprEngine::processSwitch(const SwitchStmt *Switch, ExplodedNode *Pred,
       }
 
       if (StateMatching) {
-        BlockEdge BE(getCurrBlock(), Block, Node->getLocationContext());
+        BlockEdge BE(getCurrBlock(), Block, LCtx);
         Dst.insert(Engine.makeNode(BE, StateMatching, Node));
       }
 
@@ -3177,7 +3177,7 @@ void ExprEngine::processSwitch(const SwitchStmt *Switch, ExplodedNode *Pred,
     if (!DefaultBlock)
       return;
 
-    BlockEdge BE(Src, DefaultBlock, Node->getLocationContext());
+    BlockEdge BE(Src, DefaultBlock, LCtx);
     Dst.insert(Engine.makeNode(BE, State, Node));
   }
 }

--- a/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
@@ -3084,7 +3084,7 @@ void ExprEngine::processSwitch(const SwitchStmt *Switch, ExplodedNode *Pred,
                                ExplodedNodeSet &Dst) {
   const Expr *Condition = Switch->getCond();
 
-  SwitchNodeBuilder Builder(Dst, *currBldrCtx);
+  NodeBuilder Builder(Dst, *currBldrCtx);
   ExplodedNodeSet CheckersOutSet;
 
   getCheckerManager().runCheckersForBranchCondition(

--- a/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
@@ -3101,7 +3101,19 @@ void ExprEngine::processSwitch(const SwitchStmt *Switch, ExplodedNode *Pred,
 
     std::optional<NonLoc> CondNL = CondV.getAs<NonLoc>();
 
-    for (const CFGBlock *Block : Builder) {
+    // The reversed iteration order was arbitrarily introduced in 2008 by
+    // commit 80ebc1d1c95704b0ff0386b3a3cbc8b3ff960654 (which added support for
+    // control flow in switch statements). I don't see any advantage of this
+    // iteration order, but changing it would change the order of insertion
+    // into the work list, which would perturb the analyzer results.
+    // FIXME: With forward iterators it would be possible to replace this
+    // convoluted code with a simple range-based for loop over
+    // CFGBlock::succs().
+    using iterator = CFGBlock::const_succ_reverse_iterator;
+    iterator LastCase = getCurrBlock()->succ_rbegin() + 1;
+    iterator BeforeFirstCase = getCurrBlock()->succ_rend();
+    for (iterator I = LastCase; I < BeforeFirstCase; I++) {
+      const CFGBlock *Block = *I;
       // Successor may be pruned out during CFG construction.
       if (!Block)
         continue;

--- a/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
@@ -3082,6 +3082,7 @@ void ExprEngine::processEndOfFunction(ExplodedNode *Pred,
 ///  nodes by processing the 'effects' of a switch statement.
 void ExprEngine::processSwitch(const SwitchStmt *Switch, ExplodedNode *Pred,
                                ExplodedNodeSet &Dst) {
+  const ASTContext &ACtx = getContext();
   const Expr *Condition = Switch->getCond();
 
   ExplodedNodeSet CheckersOutSet;
@@ -3120,14 +3121,14 @@ void ExprEngine::processSwitch(const SwitchStmt *Switch, ExplodedNode *Pred,
       const CaseStmt *Case = cast<CaseStmt>(Block->getLabel());
 
       // Evaluate the LHS of the case value.
-      llvm::APSInt V1 = Case->getLHS()->EvaluateKnownConstInt(getContext());
+      llvm::APSInt V1 = Case->getLHS()->EvaluateKnownConstInt(ACtx);
       assert(V1.getBitWidth() ==
              getContext().getIntWidth(Condition->getType()));
 
       // Get the RHS of the case, if it exists.
       llvm::APSInt V2;
       if (const Expr *E = Case->getRHS())
-        V2 = E->EvaluateKnownConstInt(getContext());
+        V2 = E->EvaluateKnownConstInt(ACtx);
       else
         V2 = V1;
 

--- a/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
@@ -3086,6 +3086,17 @@ void ExprEngine::processSwitch(const SwitchStmt *Switch, ExplodedNode *Pred,
   const LocationContext *LCtx = Pred->getLocationContext();
   const Expr *Condition = Switch->getCond();
 
+  // The block that is terminated by the switch statement.
+  const CFGBlock *SwitchBlock = getCurrBlock();
+  // The reversed iteration order is present since the beginning, when in 2008
+  // commit 80ebc1d1c95704b0ff0386b3a3cbc8b3ff960654 added support for handling
+  // switch statements. I don't see any advantage over regular forward
+  // iteration -- but switching the order would perturb the insertion order of
+  // the work list and therefore the analysis results.
+  llvm::iterator_range<CFGBlock::const_succ_reverse_iterator> CaseBlocks(
+      SwitchBlock->succ_rbegin() + 1, SwitchBlock->succ_rend());
+  const CFGBlock *DefaultBlock = *SwitchBlock->succ_rbegin();
+
   ExplodedNodeSet CheckersOutSet;
 
   getCheckerManager().runCheckersForBranchCondition(
@@ -3101,24 +3112,12 @@ void ExprEngine::processSwitch(const SwitchStmt *Switch, ExplodedNode *Pred,
     }
     std::optional<NonLoc> CondNL = CondV.getAs<NonLoc>();
 
-    // The reversed iteration order was arbitrarily introduced in 2008 by
-    // commit 80ebc1d1c95704b0ff0386b3a3cbc8b3ff960654 (which added support for
-    // control flow in switch statements). I don't see any advantage of this
-    // iteration order, but changing it would change the order of insertion
-    // into the work list, which would perturb the analyzer results.
-    // FIXME: With forward iterators it would be possible to replace this
-    // convoluted code with a simple range-based for loop over
-    // CFGBlock::succs().
-    using iterator = CFGBlock::const_succ_reverse_iterator;
-    iterator LastCase = getCurrBlock()->succ_rbegin() + 1;
-    iterator BeforeFirstCase = getCurrBlock()->succ_rend();
-    for (iterator I = LastCase; I < BeforeFirstCase; I++) {
-      const CFGBlock *Block = *I;
+    for (const CFGBlock *CaseBlock : CaseBlocks) {
       // Successor may be pruned out during CFG construction.
-      if (!Block)
+      if (!CaseBlock)
         continue;
 
-      const CaseStmt *Case = cast<CaseStmt>(Block->getLabel());
+      const CaseStmt *Case = cast<CaseStmt>(CaseBlock->getLabel());
 
       // Evaluate the LHS of the case value.
       llvm::APSInt V1 = Case->getLHS()->EvaluateKnownConstInt(ACtx);
@@ -3144,7 +3143,7 @@ void ExprEngine::processSwitch(const SwitchStmt *Switch, ExplodedNode *Pred,
       }
 
       if (StateMatching) {
-        BlockEdge BE(getCurrBlock(), Block, LCtx);
+        BlockEdge BE(SwitchBlock, CaseBlock, LCtx);
         Dst.insert(Engine.makeNode(BE, StateMatching, Node));
       }
 
@@ -3168,17 +3167,12 @@ void ExprEngine::processSwitch(const SwitchStmt *Switch, ExplodedNode *Pred,
         continue;
     }
 
-    // Get the block for the default case.
-    const CFGBlock *Src = getCurrBlock();
-    assert(Src->succ_rbegin() != Src->succ_rend());
-    CFGBlock *DefaultBlock = *Src->succ_rbegin();
-
     // Basic correctness check for default blocks that are unreachable and not
     // caught by earlier stages.
     if (!DefaultBlock)
       return;
 
-    BlockEdge BE(Src, DefaultBlock, LCtx);
+    BlockEdge BE(SwitchBlock, DefaultBlock, LCtx);
     Dst.insert(Engine.makeNode(BE, State, Node));
   }
 }

--- a/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
@@ -3157,6 +3157,10 @@ void ExprEngine::processSwitch(const SwitchStmt *Switch, ExplodedNode *Pred,
     if (!State)
       continue;
 
+    // The default block may be null if it is "optimized out" by CFG creation.
+    if (!DefaultBlock)
+      continue;
+
     // If we have switch(enum value), the default branch is not
     // feasible if all of the enum constants not covered by 'case:' statements
     // are not feasible values for the switch condition.
@@ -3168,11 +3172,6 @@ void ExprEngine::processSwitch(const SwitchStmt *Switch, ExplodedNode *Pred,
       if (Switch->isAllEnumCasesCovered())
         continue;
     }
-
-    // Basic correctness check for default blocks that are unreachable and not
-    // caught by earlier stages.
-    if (!DefaultBlock)
-      return;
 
     BlockEdge BE(SwitchBlock, DefaultBlock, LCtx);
     Dst.insert(Engine.makeNode(BE, State, Node));

--- a/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
@@ -3088,6 +3088,8 @@ void ExprEngine::processSwitch(const SwitchStmt *Switch, ExplodedNode *Pred,
 
   // The block that is terminated by the switch statement.
   const CFGBlock *SwitchBlock = getCurrBlock();
+  // Note that successors may be null if they are pruned as unreachable.
+  assert(SwitchBlock->succ_size() && "Switch must have at least one successor");
   // The reversed iteration order is present since the beginning, when in 2008
   // commit 80ebc1d1c95704b0ff0386b3a3cbc8b3ff960654 added support for handling
   // switch statements. I don't see any advantage over regular forward

--- a/clang/test/Analysis/switch-basics.c
+++ b/clang/test/Analysis/switch-basics.c
@@ -1,6 +1,6 @@
 // RUN: %clang_analyze_cc1 -verify %s -analyzer-checker=core
 
-// This file tests ExprEngine::processSwitch and the class SwitchNodeBuilder.
+// This file tests ExprEngine::processSwitch.
 
 int switch_simple(int x) {
   // Validate that switch behaves as expected in a very simple situation.

--- a/clang/test/Analysis/switch-basics.c
+++ b/clang/test/Analysis/switch-basics.c
@@ -93,6 +93,19 @@ int switch_no_compound_stmt(int x) {
   return 0;
 }
 
+int switch_empty(int x) {
+  // Validate that the engine does not crash on these "empty" switches.
+  // (These are pretty useless and the second is reported by a compiler
+  // warning, but the analyzer should still be prepared to handle them.)
+
+  switch (x) {}
+
+  switch (x); // expected-warning {{Switch statement has empty body}}
+
+  return 0;
+}
+
+
 int switch_with_case_range(int x) {
   // Validate that the GNU case range extension is properly handled.
   switch (x) {

--- a/clang/test/Analysis/switch-basics.c
+++ b/clang/test/Analysis/switch-basics.c
@@ -93,7 +93,7 @@ int switch_no_compound_stmt(int x) {
   return 0;
 }
 
-int switch_empty(int x) {
+void switch_empty(int x) {
   // Validate that the engine does not crash on these empty switches.
   // (These are pretty useless, but the analyzer should still handle them.)
 
@@ -101,10 +101,7 @@ int switch_empty(int x) {
 
   switch (x)
     ;
-
-  return 0;
 }
-
 
 int switch_with_case_range(int x) {
   // Validate that the GNU case range extension is properly handled.

--- a/clang/test/Analysis/switch-basics.c
+++ b/clang/test/Analysis/switch-basics.c
@@ -94,13 +94,13 @@ int switch_no_compound_stmt(int x) {
 }
 
 int switch_empty(int x) {
-  // Validate that the engine does not crash on these "empty" switches.
-  // (These are pretty useless and the second is reported by a compiler
-  // warning, but the analyzer should still be prepared to handle them.)
+  // Validate that the engine does not crash on these empty switches.
+  // (These are pretty useless, but the analyzer should still handle them.)
 
   switch (x) {}
 
-  switch (x); // expected-warning {{Switch statement has empty body}}
+  switch (x)
+    ;
 
   return 0;
 }


### PR DESCRIPTION
This commit removes the class `SwitchNodeBuilder` because it just obscured the logic of switch handling by hiding some parts of it in another source file.