### PR TITLE
[DA] Fix signed overflow bugs in weak-crossing SIV test

### DIFF
--- a/llvm/lib/Analysis/DependenceAnalysis.cpp
+++ b/llvm/lib/Analysis/DependenceAnalysis.cpp
@@ -1439,11 +1439,7 @@ bool DependenceInfo::weakCrossingSIVtest(const SCEV *Coeff,
   }
   LLVM_DEBUG(dbgs() << "\t    Distance = " << Distance << "\n");
 
-  // if 2*Coeff doesn't divide Delta, then the equal direction isn't possible
-  APInt Two = APInt(Distance.getBitWidth(), 2, true);
-  Remainder = Distance.srem(Two);
-  LLVM_DEBUG(dbgs() << "\t    Remainder = " << Remainder << "\n");
-  if (Remainder != 0) {
+  if (Distance[0]) {
     // Equal direction isn't possible
     Result.DV[Level].Direction &= ~Dependence::DVEntry::EQ;
     ++WeakCrossingSIVsuccesses;
@@ -1455,7 +1451,9 @@ bool DependenceInfo::weakCrossingSIVtest(const SCEV *Coeff,
           collectUpperBound(CurSrcLoop, Delta->getType())) {
     LLVM_DEBUG(dbgs() << "\t    UpperBound = " << *UpperBound << "\n");
     ConstantRange UBRange = SE->getSignedRange(UpperBound);
-    ConstantRange MLRange = UBRange.smul_fast(*SafeCoeff).smul_fast(Two);
+    ConstantRange MLRange =
+        UBRange.smul_fast(*SafeCoeff)
+            .smul_fast(APInt(Distance.getBitWidth(), 2, true));
     ConstantRange DeltaRange(*SafeDelta);
     LLVM_DEBUG(dbgs() << "\t    UBRange = " << UBRange << "\n");
     LLVM_DEBUG(dbgs() << "\t    MLRange = " << MLRange << "\n");

--- a/llvm/lib/Analysis/DependenceAnalysis.cpp
+++ b/llvm/lib/Analysis/DependenceAnalysis.cpp
@@ -1382,7 +1382,10 @@ bool DependenceInfo::weakCrossingSIVtest(const SCEV *Coeff,
   ++WeakCrossingSIVapplications;
   assert(0 < Level && Level <= CommonLevels && "Level out of range");
   Level--;
-  const SCEV *Delta = SE->getMinusSCEV(DstConst, SrcConst);
+  const SCEV *Delta = minusSCEVNoSignedOverflow(DstConst, SrcConst, *SE);
+  if (!Delta)
+    return false;
+
   LLVM_DEBUG(dbgs() << "\t    Delta = " << *Delta << "\n");
   if (Delta->isZero()) {
     Result.DV[Level].Direction &= ~Dependence::DVEntry::LT;
@@ -1396,67 +1399,37 @@ bool DependenceInfo::weakCrossingSIVtest(const SCEV *Coeff,
     return false;
   }
   const SCEVConstant *ConstCoeff = dyn_cast<SCEVConstant>(Coeff);
-  if (!ConstCoeff)
-    return false;
-
-  if (SE->isKnownNegative(ConstCoeff)) {
-    ConstCoeff = dyn_cast<SCEVConstant>(SE->getNegativeSCEV(ConstCoeff));
-    assert(ConstCoeff &&
-           "dynamic cast of negative of ConstCoeff should yield constant");
-    Delta = SE->getNegativeSCEV(Delta);
-  }
-  assert(SE->isKnownPositive(ConstCoeff) && "ConstCoeff should be positive");
-
   const SCEVConstant *ConstDelta = dyn_cast<SCEVConstant>(Delta);
-  if (!ConstDelta)
+  if (!ConstCoeff || !ConstDelta)
     return false;
+
+  OverflowSafeSignedAPInt SafeCoeff(ConstCoeff->getAPInt());
+  OverflowSafeSignedAPInt SafeDelta(ConstDelta->getAPInt());
+
+  if (!SafeCoeff || !SafeDelta)
+    return false;
+
+  if (SafeCoeff->isNegative()) {
+    SafeCoeff = -SafeCoeff;
+    SafeDelta = -SafeDelta;
+  }
+
+  assert(SafeCoeff->isStrictlyPositive() && "SafeCoeff should be positive");
 
   // We're certain that ConstCoeff > 0; therefore,
   // if Delta < 0, then no dependence.
-  LLVM_DEBUG(dbgs() << "\t    Delta = " << *Delta << "\n");
-  LLVM_DEBUG(dbgs() << "\t    ConstCoeff = " << *ConstCoeff << "\n");
-  if (SE->isKnownNegative(Delta)) {
+  LLVM_DEBUG(dbgs() << "\t    SafeDelta = " << *SafeDelta << "\n");
+  LLVM_DEBUG(dbgs() << "\t    SafeCoeff = " << *SafeCoeff << "\n");
+  if (SafeDelta->isNegative()) {
     // No dependence, Delta < 0
     ++WeakCrossingSIVindependence;
     ++WeakCrossingSIVsuccesses;
     return true;
   }
 
-  // We're certain that Delta > 0 and ConstCoeff > 0.
-  // Check Delta/(2*ConstCoeff) against upper loop bound
-  if (const SCEV *UpperBound =
-          collectUpperBound(CurSrcLoop, Delta->getType())) {
-    LLVM_DEBUG(dbgs() << "\t    UpperBound = " << *UpperBound << "\n");
-    const SCEV *ConstantTwo = SE->getConstant(UpperBound->getType(), 2);
-    const SCEV *ML =
-        SE->getMulExpr(SE->getMulExpr(ConstCoeff, UpperBound), ConstantTwo);
-    LLVM_DEBUG(dbgs() << "\t    ML = " << *ML << "\n");
-    if (SE->isKnownPredicate(CmpInst::ICMP_SGT, Delta, ML)) {
-      // Delta too big, no dependence
-      ++WeakCrossingSIVindependence;
-      ++WeakCrossingSIVsuccesses;
-      return true;
-    }
-    if (SE->isKnownPredicate(CmpInst::ICMP_EQ, Delta, ML)) {
-      // i = i' = UB
-      Result.DV[Level].Direction &= ~Dependence::DVEntry::LT;
-      Result.DV[Level].Direction &= ~Dependence::DVEntry::GT;
-      ++WeakCrossingSIVsuccesses;
-      if (!Result.DV[Level].Direction) {
-        ++WeakCrossingSIVindependence;
-        return true;
-      }
-      Result.DV[Level].Distance = SE->getZero(Delta->getType());
-      return false;
-    }
-  }
-
   // check that Coeff divides Delta
-  APInt APDelta = ConstDelta->getAPInt();
-  APInt APCoeff = ConstCoeff->getAPInt();
-  APInt Distance = APDelta; // these need to be initialzed
-  APInt Remainder = APDelta;
-  APInt::sdivrem(APDelta, APCoeff, Distance, Remainder);
+  APInt Distance, Remainder;
+  APInt::sdivrem(*SafeDelta, *SafeCoeff, Distance, Remainder);
   LLVM_DEBUG(dbgs() << "\t    Remainder = " << Remainder << "\n");
   if (Remainder != 0) {
     // Coeff doesn't divide Delta, no dependence
@@ -1474,6 +1447,39 @@ bool DependenceInfo::weakCrossingSIVtest(const SCEV *Coeff,
     // Equal direction isn't possible
     Result.DV[Level].Direction &= ~Dependence::DVEntry::EQ;
     ++WeakCrossingSIVsuccesses;
+  }
+
+  // We're certain that Delta > 0 and ConstCoeff > 0.
+  // Check Delta/(2*ConstCoeff) against upper loop bound
+  if (const SCEV *UpperBound =
+          collectUpperBound(CurSrcLoop, Delta->getType())) {
+    LLVM_DEBUG(dbgs() << "\t    UpperBound = " << *UpperBound << "\n");
+    ConstantRange UBRange = SE->getSignedRange(UpperBound);
+    ConstantRange MLRange = UBRange.smul_fast(*SafeCoeff).smul_fast(Two);
+    ConstantRange DeltaRange(*SafeDelta);
+    LLVM_DEBUG(dbgs() << "\t    UBRange = " << UBRange << "\n");
+    LLVM_DEBUG(dbgs() << "\t    MLRange = " << MLRange << "\n");
+    LLVM_DEBUG(dbgs() << "\t    DeltaRange = " << DeltaRange << "\n");
+
+    if (DeltaRange.intersectWith(MLRange).isEmptySet() &&
+        DeltaRange.getSignedMin().sgt(MLRange.getSignedMax())) {
+      ++WeakCrossingSIVindependence;
+      ++WeakCrossingSIVsuccesses;
+      return true;
+    }
+
+    if (DeltaRange.getSignedMin().eq(MLRange.getSignedMax())) {
+      // i = i' = UB
+      Result.DV[Level].Direction &= ~Dependence::DVEntry::LT;
+      Result.DV[Level].Direction &= ~Dependence::DVEntry::GT;
+      ++WeakCrossingSIVsuccesses;
+      if (!Result.DV[Level].Direction) {
+        ++WeakCrossingSIVindependence;
+        return true;
+      }
+      Result.DV[Level].Distance = SE->getZero(Delta->getType());
+      return false;
+    }
   }
   return false;
 }

--- a/llvm/test/Analysis/DependenceAnalysis/WeakCrossingSIV.ll
+++ b/llvm/test/Analysis/DependenceAnalysis/WeakCrossingSIV.ll
@@ -68,7 +68,7 @@ define void @weakcrossing1(ptr %A, ptr %B, i64 %n) nounwind uwtable ssp {
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: store i32 %conv, ptr %arrayidx, align 4
 ; CHECK-NEXT:    da analyze - output [*]!
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: %0 = load i32, ptr %arrayidx2, align 4
-; CHECK-NEXT:    da analyze - flow [<>]!
+; CHECK-NEXT:    da analyze - flow [*|<]!
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: store i32 %0, ptr %B.addr.02, align 4
 ; CHECK-NEXT:    da analyze - confused!
 ; CHECK-NEXT:  Src: %0 = load i32, ptr %arrayidx2, align 4 --> Dst: %0 = load i32, ptr %arrayidx2, align 4

--- a/llvm/test/Analysis/DependenceAnalysis/weak-crossing-siv-delta-signed-min.ll
+++ b/llvm/test/Analysis/DependenceAnalysis/weak-crossing-siv-delta-signed-min.ll
@@ -12,14 +12,14 @@
 ;   }
 ; }
 ;
-; FIXME: There is a dependency between the two stores in all directions.
+; There is a dependency between the two stores in all directions.
 ;
 define void @weak_crossing_siv_delta_signed_min(ptr %A) {
 ; CHECK-ALL-LABEL: 'weak_crossing_siv_delta_signed_min'
 ; CHECK-ALL-NEXT:  Src: store i8 0, ptr %gep.0, align 1 --> Dst: store i8 0, ptr %gep.0, align 1
 ; CHECK-ALL-NEXT:    da analyze - none!
 ; CHECK-ALL-NEXT:  Src: store i8 0, ptr %gep.0, align 1 --> Dst: store i8 1, ptr %gep.1, align 1
-; CHECK-ALL-NEXT:    da analyze - none!
+; CHECK-ALL-NEXT:    da analyze - output [*|<]!
 ; CHECK-ALL-NEXT:  Src: store i8 1, ptr %gep.1, align 1 --> Dst: store i8 1, ptr %gep.1, align 1
 ; CHECK-ALL-NEXT:    da analyze - none!
 ;
@@ -27,7 +27,7 @@ define void @weak_crossing_siv_delta_signed_min(ptr %A) {
 ; CHECK-WEAK-CROSSING-SIV-NEXT:  Src: store i8 0, ptr %gep.0, align 1 --> Dst: store i8 0, ptr %gep.0, align 1
 ; CHECK-WEAK-CROSSING-SIV-NEXT:    da analyze - output [*]!
 ; CHECK-WEAK-CROSSING-SIV-NEXT:  Src: store i8 0, ptr %gep.0, align 1 --> Dst: store i8 1, ptr %gep.1, align 1
-; CHECK-WEAK-CROSSING-SIV-NEXT:    da analyze - none!
+; CHECK-WEAK-CROSSING-SIV-NEXT:    da analyze - output [*|<]!
 ; CHECK-WEAK-CROSSING-SIV-NEXT:  Src: store i8 1, ptr %gep.1, align 1 --> Dst: store i8 1, ptr %gep.1, align 1
 ; CHECK-WEAK-CROSSING-SIV-NEXT:    da analyze - output [*]!
 ;

--- a/llvm/test/Analysis/DependenceAnalysis/weak-crossing-siv-large-btc.ll
+++ b/llvm/test/Analysis/DependenceAnalysis/weak-crossing-siv-large-btc.ll
@@ -13,7 +13,7 @@
 ;     A[i1] = 0;
 ; }
 ;
-; FIXME: Both `A[i0] = 0` and `A[i1] = 0` must be executed, so there is a
+; Both `A[i0] = 0` and `A[i1] = 0` must be executed, so there is a
 ; dependency between them.
 ;
 define void @weak_crossing_siv_large_btc(ptr %A) {
@@ -21,7 +21,7 @@ define void @weak_crossing_siv_large_btc(ptr %A) {
 ; CHECK-ALL-NEXT:  Src: store i8 0, ptr %gep.0, align 1 --> Dst: store i8 0, ptr %gep.0, align 1
 ; CHECK-ALL-NEXT:    da analyze - none!
 ; CHECK-ALL-NEXT:  Src: store i8 0, ptr %gep.0, align 1 --> Dst: store i8 0, ptr %gep.1, align 1
-; CHECK-ALL-NEXT:    da analyze - none!
+; CHECK-ALL-NEXT:    da analyze - output [*|<]!
 ; CHECK-ALL-NEXT:  Src: store i8 0, ptr %gep.1, align 1 --> Dst: store i8 0, ptr %gep.1, align 1
 ; CHECK-ALL-NEXT:    da analyze - none!
 ;
@@ -29,7 +29,7 @@ define void @weak_crossing_siv_large_btc(ptr %A) {
 ; CHECK-WEAK-CROSSING-SIV-NEXT:  Src: store i8 0, ptr %gep.0, align 1 --> Dst: store i8 0, ptr %gep.0, align 1
 ; CHECK-WEAK-CROSSING-SIV-NEXT:    da analyze - output [*]!
 ; CHECK-WEAK-CROSSING-SIV-NEXT:  Src: store i8 0, ptr %gep.0, align 1 --> Dst: store i8 0, ptr %gep.1, align 1
-; CHECK-WEAK-CROSSING-SIV-NEXT:    da analyze - none!
+; CHECK-WEAK-CROSSING-SIV-NEXT:    da analyze - output [*|<]!
 ; CHECK-WEAK-CROSSING-SIV-NEXT:  Src: store i8 0, ptr %gep.1, align 1 --> Dst: store i8 0, ptr %gep.1, align 1
 ; CHECK-WEAK-CROSSING-SIV-NEXT:    da analyze - output [*]!
 ;

--- a/llvm/test/Analysis/DependenceAnalysis/weak-crossing-siv-overflow.ll
+++ b/llvm/test/Analysis/DependenceAnalysis/weak-crossing-siv-overflow.ll
@@ -11,8 +11,9 @@
 ;     A[3*i - 2] = 1;
 ; }
 ;
-; FIXME: DependenceAnalysis currently detects no dependency between
-; `A[-3*i + INT64_MAX]` and `A[3*i - 2]`, but it does exist. For example,
+; 
+; There is a dependency between `A[-3*i + INT64_MAX]` and `A[3*i - 2]`,
+; for example,
 ;
 ;  memory access       | i == 1           | i == max_i
 ; ---------------------|------------------|------------------
@@ -27,7 +28,7 @@ define void @weakcorssing_delta_ovfl(ptr %A) {
 ; CHECK-ALL-NEXT:  Src: store i8 0, ptr %idx.0, align 1 --> Dst: store i8 0, ptr %idx.0, align 1
 ; CHECK-ALL-NEXT:    da analyze - none!
 ; CHECK-ALL-NEXT:  Src: store i8 0, ptr %idx.0, align 1 --> Dst: store i8 1, ptr %idx.1, align 1
-; CHECK-ALL-NEXT:    da analyze - none!
+; CHECK-ALL-NEXT:    da analyze - output [*|<]!
 ; CHECK-ALL-NEXT:  Src: store i8 1, ptr %idx.1, align 1 --> Dst: store i8 1, ptr %idx.1, align 1
 ; CHECK-ALL-NEXT:    da analyze - none!
 ;
@@ -35,7 +36,7 @@ define void @weakcorssing_delta_ovfl(ptr %A) {
 ; CHECK-WEAK-CROSSING-SIV-NEXT:  Src: store i8 0, ptr %idx.0, align 1 --> Dst: store i8 0, ptr %idx.0, align 1
 ; CHECK-WEAK-CROSSING-SIV-NEXT:    da analyze - output [*]!
 ; CHECK-WEAK-CROSSING-SIV-NEXT:  Src: store i8 0, ptr %idx.0, align 1 --> Dst: store i8 1, ptr %idx.1, align 1
-; CHECK-WEAK-CROSSING-SIV-NEXT:    da analyze - none!
+; CHECK-WEAK-CROSSING-SIV-NEXT:    da analyze - output [*|<]!
 ; CHECK-WEAK-CROSSING-SIV-NEXT:  Src: store i8 1, ptr %idx.1, align 1 --> Dst: store i8 1, ptr %idx.1, align 1
 ; CHECK-WEAK-CROSSING-SIV-NEXT:    da analyze - output [*]!
 ;
@@ -73,8 +74,8 @@ exit:
 ;   A[3*i + 1] = 1;
 ; }
 ;
-; FIXME: DependenceAnalysis currently detects no dependency between
-; `A[-3*i + INT64_MAX]` and `A[3*i - 2]`, but it does exist. For example,
+; There is a dependency between `A[-3*i + INT64_MAX]` and `A[3*i + 1]`,
+; for example,
 ;
 ;  memory access       | i == 0 | i == 1           | i == max_i - 1 | i == max_i
 ; ---------------------|--------|------------------|----------------|------------------
@@ -89,7 +90,7 @@ define void @weakcorssing_prod_ovfl(ptr %A) {
 ; CHECK-ALL-NEXT:  Src: store i8 0, ptr %idx.0, align 1 --> Dst: store i8 0, ptr %idx.0, align 1
 ; CHECK-ALL-NEXT:    da analyze - none!
 ; CHECK-ALL-NEXT:  Src: store i8 0, ptr %idx.0, align 1 --> Dst: store i8 1, ptr %idx.1, align 1
-; CHECK-ALL-NEXT:    da analyze - none!
+; CHECK-ALL-NEXT:    da analyze - output [*|<]!
 ; CHECK-ALL-NEXT:  Src: store i8 1, ptr %idx.1, align 1 --> Dst: store i8 1, ptr %idx.1, align 1
 ; CHECK-ALL-NEXT:    da analyze - none!
 ;
@@ -97,7 +98,7 @@ define void @weakcorssing_prod_ovfl(ptr %A) {
 ; CHECK-WEAK-CROSSING-SIV-NEXT:  Src: store i8 0, ptr %idx.0, align 1 --> Dst: store i8 0, ptr %idx.0, align 1
 ; CHECK-WEAK-CROSSING-SIV-NEXT:    da analyze - output [*]!
 ; CHECK-WEAK-CROSSING-SIV-NEXT:  Src: store i8 0, ptr %idx.0, align 1 --> Dst: store i8 1, ptr %idx.1, align 1
-; CHECK-WEAK-CROSSING-SIV-NEXT:    da analyze - none!
+; CHECK-WEAK-CROSSING-SIV-NEXT:    da analyze - output [*|<]!
 ; CHECK-WEAK-CROSSING-SIV-NEXT:  Src: store i8 1, ptr %idx.1, align 1 --> Dst: store i8 1, ptr %idx.1, align 1
 ; CHECK-WEAK-CROSSING-SIV-NEXT:    da analyze - output [*]!
 ;


### PR DESCRIPTION
This patch fixs signed overflowing during distance and loop bound calculations `DependenceInfo::weakCrossingSIVtest`.

Key changes:
1. Replaced `SE->getMinusSCEV` with `minusSCEVNoSignedOverflow`.
2. Adopted `OverflowSafeSignedAPInt` for `ConstCoeff` and `ConstDelta` to guarantee safe negation and manipulation.
3. Reordered the logic to check if `Coeff` exactly divides `Delta` (and `2*Coeff`) prior to checking loop bounds.

This patch fixes the overflow in Weak Crossing SIV test, but test case `weakcrossing1` in WeakCrossingSIV.ll falled back from `[<>]` to `[*|<]`