### PR TITLE
[scudo][PoC] Introduce libc_pal.h for PAL-backed libc calls

### DIFF
--- a/compiler-rt/lib/scudo/standalone/CMakeLists.txt
+++ b/compiler-rt/lib/scudo/standalone/CMakeLists.txt
@@ -72,6 +72,7 @@ set(SCUDO_HEADERS
   flags.h
   fuchsia.h
   internal_defs.h
+  libc_pal.h
   linux.h
   list.h
   memtag.h

--- a/compiler-rt/lib/scudo/standalone/flags_parser.cpp
+++ b/compiler-rt/lib/scudo/standalone/flags_parser.cpp
@@ -8,12 +8,10 @@
 
 #include "flags_parser.h"
 #include "common.h"
+#include "libc_pal.h"
 #include "report.h"
 
-#include <errno.h>
 #include <limits.h>
-#include <stdlib.h>
-#include <string.h>
 
 namespace scudo {
 
@@ -144,9 +142,9 @@ bool FlagParser::runHandler(const char *Name, const char *Value,
       break;
     case FlagType::FT_int:
       char *ValueEnd;
-      errno = 0;
-      long V = strtol(Value, &ValueEnd, 10);
-      if (errno != 0 ||                 // strtol failed (over or underflow)
+      LibcPAL::seterrno(0);
+      long V = LibcPAL::strtol(Value, &ValueEnd, 10);
+      if (LibcPAL::geterrno() != 0 ||   // strtol failed (over or underflow)
           V > INT_MAX || V < INT_MIN || // overflows integer
           // contains unexpected characters
           (*ValueEnd != '"' && *ValueEnd != '\'' &&

--- a/compiler-rt/lib/scudo/standalone/libc_pal.h
+++ b/compiler-rt/lib/scudo/standalone/libc_pal.h
@@ -1,0 +1,141 @@
+//===-- libc_pal.h ----------------------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SCUDO_LIBC_PAL_H_
+#define SCUDO_LIBC_PAL_H_
+
+#include "internal_defs.h"
+#include "platform.h"
+
+#include <errno.h>
+#include <pthread.h>
+#include <stdlib.h>
+#include <string.h>
+
+#if SCUDO_LINUX || SCUDO_TRUSTY
+#include <sys/auxv.h>
+#endif
+
+#if SCUDO_LINUX
+#include <fcntl.h>
+#include <linux/futex.h>
+#include <sched.h>
+#include <sys/mman.h>
+#include <sys/prctl.h>
+#include <sys/syscall.h>
+#include <time.h>
+#include <unistd.h>
+#endif
+
+namespace scudo {
+
+struct LibcPAL {
+  using PThreadKeyT = pthread_key_t;
+
+  static int geterrno() { return errno; }
+  static void seterrno(int ErrorNum) { errno = ErrorNum; }
+
+  static long strtol(const char *Str, char **EndPtr, int Base) {
+    return ::strtol(Str, EndPtr, Base);
+  }
+
+#if SCUDO_LINUX || SCUDO_TRUSTY
+  static unsigned long getauxval(unsigned long Type) {
+    return ::getauxval(Type);
+  }
+#endif
+
+  static char *strerror(int ErrorNum) { return ::strerror(ErrorNum); }
+  static size_t strlen(const char *Str) { return ::strlen(Str); }
+
+  static void *memcpy(void *Dst, const void *Src, size_t Count) {
+    return ::memcpy(Dst, Src, Count);
+  }
+
+  static void *memset(void *Dst, int Value, size_t Count) {
+    return ::memset(Dst, Value, Count);
+  }
+
+  static int pthread_key_create(PThreadKeyT *Key, void (*Dtor)(void *)) {
+    return ::pthread_key_create(Key, Dtor);
+  }
+
+  static int pthread_key_delete(PThreadKeyT Key) {
+    return ::pthread_key_delete(Key);
+  }
+
+  static void *pthread_getspecific(PThreadKeyT Key) {
+    return ::pthread_getspecific(Key);
+  }
+
+  static int pthread_setspecific(PThreadKeyT Key, const void *Value) {
+    return ::pthread_setspecific(Key, Value);
+  }
+
+#if SCUDO_LINUX
+  static constexpr uptr kMmapFailed = static_cast<uptr>(-1);
+
+  static void abort() { ::abort(); }
+
+  static void *mmap(void *Addr, uptr Size, int Prot, int Flags, int FD,
+                    off_t Offset) {
+    return ::mmap(Addr, Size, Prot, Flags, FD, Offset);
+  }
+
+  static int munmap(void *Addr, uptr Size) { return ::munmap(Addr, Size); }
+
+  static int mprotect(void *Addr, uptr Size, int Prot) {
+    return ::mprotect(Addr, Size, Prot);
+  }
+
+  static int madvise(void *Addr, uptr Size, int Advice) {
+    return ::madvise(Addr, Size, Advice);
+  }
+
+  static char *getenv(const char *Name) { return ::getenv(Name); }
+
+  template <typename... Args> static long syscall(long Number, Args... args) {
+    return ::syscall(Number, args...);
+  }
+
+  static int clock_gettime(clockid_t ClockID, timespec *TS) {
+    return ::clock_gettime(ClockID, TS);
+  }
+
+  static int sched_getaffinity(pid_t PID, size_t CpuSetSize, cpu_set_t *Mask) {
+    return ::sched_getaffinity(PID, CpuSetSize, Mask);
+  }
+
+  static int cpuCount(const cpu_set_t *Mask) { return CPU_COUNT(Mask); }
+  static pid_t gettid() { return ::gettid(); }
+  static int open(const char *Path, int Flags) { return ::open(Path, Flags); }
+
+  static ssize_t read(int FD, void *Buffer, size_t Count) {
+    return ::read(FD, Buffer, Count);
+  }
+
+  static int close(int FD) { return ::close(FD); }
+
+  static ssize_t write(int FD, const void *Buffer, size_t Count) {
+    return ::write(FD, Buffer, Count);
+  }
+
+  static int mincore(void *Addr, uptr Size, unsigned char *Vec) {
+    return ::mincore(Addr, Size, Vec);
+  }
+
+  static int prctl(int Option, int Arg2, void *Arg3, uptr Arg4,
+                   const char *Arg5) {
+    return ::prctl(Option, Arg2, Arg3, Arg4, Arg5);
+  }
+#endif
+};
+
+} // namespace scudo
+
+#endif // SCUDO_LIBC_PAL_H_

--- a/compiler-rt/lib/scudo/standalone/linux.cpp
+++ b/compiler-rt/lib/scudo/standalone/linux.cpp
@@ -12,24 +12,11 @@
 
 #include "common.h"
 #include "internal_defs.h"
+#include "libc_pal.h"
 #include "linux.h"
 #include "mutex.h"
 #include "report_linux.h"
 #include "string_utils.h"
-
-#include <errno.h>
-#include <fcntl.h>
-#include <linux/futex.h>
-#include <sched.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <sys/mman.h>
-#include <sys/stat.h>
-#include <sys/syscall.h>
-#include <sys/time.h>
-#include <time.h>
-#include <unistd.h>
 
 #if SCUDO_ANDROID
 #include <sys/prctl.h>
@@ -42,10 +29,13 @@ namespace scudo {
 
 #if !defined(SCUDO_PAGE_SIZE)
 // This function is only used when page size is not hard-coded.
-uptr getPageSize() { return static_cast<uptr>(sysconf(_SC_PAGESIZE)); }
+uptr getPageSize() { return LibcPAL::getauxval(AT_PAGESZ); }
 #endif
 
-void NORETURN die() { abort(); }
+void NORETURN die() {
+  LibcPAL::abort();
+  __builtin_unreachable();
+}
 
 // TODO: Will be deprecated. Use the interfaces in MemMapLinux instead.
 void *map(void *Addr, uptr Size, UNUSED const char *Name, uptr Flags,
@@ -67,15 +57,16 @@ void *map(void *Addr, uptr Size, UNUSED const char *Name, uptr Flags,
 #endif
   if (Addr)
     MmapFlags |= MAP_FIXED;
-  void *P = mmap(Addr, Size, MmapProt, MmapFlags, -1, 0);
-  if (P == MAP_FAILED) {
-    if (!(Flags & MAP_ALLOWNOMEM) || errno != ENOMEM)
-      reportMapError(errno == ENOMEM ? Size : 0);
+  void *P = LibcPAL::mmap(Addr, Size, MmapProt, MmapFlags, -1, 0);
+  if (reinterpret_cast<uptr>(P) == LibcPAL::kMmapFailed) {
+    if (!(Flags & MAP_ALLOWNOMEM) || LibcPAL::geterrno() != ENOMEM)
+      reportMapError(LibcPAL::geterrno() == ENOMEM ? Size : 0);
     return nullptr;
   }
 #if SCUDO_ANDROID
   if (Name)
-    prctl(ANDROID_PR_SET_VMA, ANDROID_PR_SET_VMA_ANON_NAME, P, Size, Name);
+    LibcPAL::prctl(ANDROID_PR_SET_VMA, ANDROID_PR_SET_VMA_ANON_NAME, P, Size,
+                   Name);
 #endif
   return P;
 }
@@ -83,7 +74,7 @@ void *map(void *Addr, uptr Size, UNUSED const char *Name, uptr Flags,
 // TODO: Will be deprecated. Use the interfaces in MemMapLinux instead.
 void unmap(void *Addr, uptr Size, UNUSED uptr Flags,
            UNUSED MapPlatformData *Data) {
-  if (munmap(Addr, Size) != 0)
+  if (LibcPAL::munmap(Addr, Size) != 0)
     reportUnmapError(reinterpret_cast<uptr>(Addr), Size);
 }
 
@@ -91,7 +82,7 @@ void unmap(void *Addr, uptr Size, UNUSED uptr Flags,
 void setMemoryPermission(uptr Addr, uptr Size, uptr Flags,
                          UNUSED MapPlatformData *Data) {
   int Prot = (Flags & MAP_NOACCESS) ? PROT_NONE : (PROT_READ | PROT_WRITE);
-  if (mprotect(reinterpret_cast<void *>(Addr), Size, Prot) != 0)
+  if (LibcPAL::mprotect(reinterpret_cast<void *>(Addr), Size, Prot) != 0)
     reportProtectError(Addr, Size, Prot);
 }
 
@@ -100,12 +91,13 @@ void releasePagesToOS(uptr BaseAddress, uptr Offset, uptr Size,
                       UNUSED MapPlatformData *Data) {
   void *Addr = reinterpret_cast<void *>(BaseAddress + Offset);
 
-  while (madvise(Addr, Size, MADV_DONTNEED) == -1 && errno == EAGAIN) {
+  while (LibcPAL::madvise(Addr, Size, MADV_DONTNEED) == -1 &&
+         LibcPAL::geterrno() == EAGAIN) {
   }
 }
 
 // Calling getenv should be fine (c)(tm) at any time.
-const char *getEnv(const char *Name) { return getenv(Name); }
+const char *getEnv(const char *Name) { return LibcPAL::getenv(Name); }
 
 namespace {
 enum State : u32 { Unlocked = 0, Locked = 1, Sleeping = 2 };
@@ -125,8 +117,8 @@ void HybridMutex::lockSlow() {
   if (V != Sleeping)
     V = atomic_exchange(&M, Sleeping, memory_order_acquire);
   while (V != Unlocked) {
-    syscall(SYS_futex, reinterpret_cast<uptr>(&M), FUTEX_WAIT_PRIVATE, Sleeping,
-            nullptr, nullptr, 0);
+    LibcPAL::syscall(SYS_futex, reinterpret_cast<uptr>(&M), FUTEX_WAIT_PRIVATE,
+                     Sleeping, nullptr, nullptr, 0);
     V = atomic_exchange(&M, Sleeping, memory_order_acquire);
   }
 }
@@ -134,8 +126,8 @@ void HybridMutex::lockSlow() {
 void HybridMutex::unlock() {
   if (atomic_fetch_sub(&M, 1U, memory_order_release) != Locked) {
     atomic_store(&M, Unlocked, memory_order_release);
-    syscall(SYS_futex, reinterpret_cast<uptr>(&M), FUTEX_WAKE_PRIVATE, 1,
-            nullptr, nullptr, 0);
+    LibcPAL::syscall(SYS_futex, reinterpret_cast<uptr>(&M), FUTEX_WAKE_PRIVATE,
+                     1, nullptr, nullptr, 0);
   }
 }
 
@@ -145,7 +137,7 @@ void HybridMutex::assertHeldImpl() {
 
 u64 getMonotonicTime() {
   timespec TS;
-  clock_gettime(CLOCK_MONOTONIC, &TS);
+  LibcPAL::clock_gettime(CLOCK_MONOTONIC, &TS);
   return static_cast<u64>(TS.tv_sec) * (1000ULL * 1000 * 1000) +
          static_cast<u64>(TS.tv_nsec);
 }
@@ -153,7 +145,7 @@ u64 getMonotonicTime() {
 u64 getMonotonicTimeFast() {
 #if defined(CLOCK_MONOTONIC_COARSE)
   timespec TS;
-  clock_gettime(CLOCK_MONOTONIC_COARSE, &TS);
+  LibcPAL::clock_gettime(CLOCK_MONOTONIC_COARSE, &TS);
   return static_cast<u64>(TS.tv_sec) * (1000ULL * 1000 * 1000) +
          static_cast<u64>(TS.tv_nsec);
 #else
@@ -165,16 +157,16 @@ u32 getNumberOfCPUs() {
   cpu_set_t CPUs;
   // sched_getaffinity can fail for a variety of legitimate reasons (lack of
   // CAP_SYS_NICE, syscall filtering, etc), in which case we shall return 0.
-  if (sched_getaffinity(0, sizeof(cpu_set_t), &CPUs) != 0)
+  if (LibcPAL::sched_getaffinity(0, sizeof(cpu_set_t), &CPUs) != 0)
     return 0;
-  return static_cast<u32>(CPU_COUNT(&CPUs));
+  return static_cast<u32>(LibcPAL::cpuCount(&CPUs));
 }
 
 u32 getThreadID() {
 #if SCUDO_ANDROID
-  return static_cast<u32>(gettid());
+  return static_cast<u32>(LibcPAL::gettid());
 #else
-  return static_cast<u32>(syscall(SYS_gettid));
+  return static_cast<u32>(LibcPAL::syscall(SYS_gettid));
 #endif
 }
 
@@ -188,24 +180,24 @@ bool getRandom(void *Buffer, uptr Length, UNUSED bool Blocking) {
 #define GRND_NONBLOCK 1
 #endif
   // Up to 256 bytes, getrandom will not be interrupted.
-  ReadBytes =
-      syscall(SYS_getrandom, Buffer, Length, Blocking ? 0 : GRND_NONBLOCK);
+  ReadBytes = LibcPAL::syscall(SYS_getrandom, Buffer, Length,
+                               Blocking ? 0 : GRND_NONBLOCK);
   if (ReadBytes == static_cast<ssize_t>(Length))
     return true;
   // If this system call is not implemented in the kernel, then we will try
   // and use /dev/urandom. Otherwise, if the syscall fails, return false
   // assuming that trying to read /dev/urandom will cause a delay waiting for
   // the random data to be usable.
-  if (errno != ENOSYS)
+  if (LibcPAL::geterrno() != ENOSYS)
     return false;
 #endif // defined(SYS_getrandom)
   // Up to 256 bytes, a read off /dev/urandom will not be interrupted.
   // Blocking is moot here, O_NONBLOCK has no effect when opening /dev/urandom.
-  const int FileDesc = open("/dev/urandom", O_RDONLY);
+  const int FileDesc = LibcPAL::open("/dev/urandom", O_RDONLY);
   if (FileDesc == -1)
     return false;
-  ReadBytes = read(FileDesc, Buffer, Length);
-  close(FileDesc);
+  ReadBytes = LibcPAL::read(FileDesc, Buffer, Length);
+  LibcPAL::close(FileDesc);
   return (ReadBytes == static_cast<ssize_t>(Length));
 }
 
@@ -218,11 +210,11 @@ void outputRaw(const char *Buffer) {
     constexpr s32 AndroidLogInfo = 4;
     constexpr uptr MaxLength = 1024U;
     char LocalBuffer[MaxLength];
-    while (strlen(Buffer) > MaxLength) {
+    while (LibcPAL::strlen(Buffer) > MaxLength) {
       uptr P;
       for (P = MaxLength - 1; P > 0; P--) {
         if (Buffer[P] == '\n') {
-          memcpy(LocalBuffer, Buffer, P);
+          LibcPAL::memcpy(LocalBuffer, Buffer, P);
           LocalBuffer[P] = '\0';
           async_safe_write_log(AndroidLogInfo, "scudo", LocalBuffer);
           Buffer = &Buffer[P + 1];
@@ -235,7 +227,7 @@ void outputRaw(const char *Buffer) {
     }
     async_safe_write_log(AndroidLogInfo, "scudo", Buffer);
   } else {
-    (void)write(2, Buffer, strlen(Buffer));
+    (void)LibcPAL::write(2, Buffer, LibcPAL::strlen(Buffer));
   }
 }
 

--- a/compiler-rt/lib/scudo/standalone/mem_map_linux.cpp
+++ b/compiler-rt/lib/scudo/standalone/mem_map_linux.cpp
@@ -14,24 +14,11 @@
 
 #include "common.h"
 #include "internal_defs.h"
+#include "libc_pal.h"
 #include "linux.h"
 #include "mutex.h"
 #include "report_linux.h"
 #include "string_utils.h"
-
-#include <errno.h>
-#include <fcntl.h>
-#include <linux/futex.h>
-#include <sched.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <sys/mman.h>
-#include <sys/stat.h>
-#include <sys/syscall.h>
-#include <sys/time.h>
-#include <time.h>
-#include <unistd.h>
 
 #if SCUDO_ANDROID
 // TODO(chiahungduan): Review if we still need the followings macros.
@@ -61,16 +48,17 @@ static void *mmapWrapper(uptr Addr, uptr Size, const char *Name, uptr Flags) {
 #endif
   if (Addr)
     MmapFlags |= MAP_FIXED;
-  void *P =
-      mmap(reinterpret_cast<void *>(Addr), Size, MmapProt, MmapFlags, -1, 0);
-  if (P == MAP_FAILED) {
-    if (!(Flags & MAP_ALLOWNOMEM) || errno != ENOMEM)
-      reportMapError(errno == ENOMEM ? Size : 0);
+  void *P = LibcPAL::mmap(reinterpret_cast<void *>(Addr), Size, MmapProt,
+                          MmapFlags, -1, 0);
+  if (reinterpret_cast<uptr>(P) == LibcPAL::kMmapFailed) {
+    if (!(Flags & MAP_ALLOWNOMEM) || LibcPAL::geterrno() != ENOMEM)
+      reportMapError(LibcPAL::geterrno() == ENOMEM ? Size : 0);
     return nullptr;
   }
 #if SCUDO_ANDROID
   if (Name)
-    prctl(ANDROID_PR_SET_VMA, ANDROID_PR_SET_VMA_ANON_NAME, P, Size, Name);
+    LibcPAL::prctl(ANDROID_PR_SET_VMA, ANDROID_PR_SET_VMA_ANON_NAME, P, Size,
+                   Name);
 #else
   (void)Name;
 #endif
@@ -101,7 +89,7 @@ void MemMapLinux::unmapImpl(uptr Addr, uptr Size) {
     MapCapacity -= Size;
   }
 
-  if (munmap(reinterpret_cast<void *>(Addr), Size) != 0)
+  if (LibcPAL::munmap(reinterpret_cast<void *>(Addr), Size) != 0)
     reportUnmapError(Addr, Size);
 }
 
@@ -115,7 +103,7 @@ bool MemMapLinux::remapImpl(uptr Addr, uptr Size, const char *Name,
 
 void MemMapLinux::setMemoryPermissionImpl(uptr Addr, uptr Size, uptr Flags) {
   int Prot = (Flags & MAP_NOACCESS) ? PROT_NONE : (PROT_READ | PROT_WRITE);
-  if (mprotect(reinterpret_cast<void *>(Addr), Size, Prot) != 0)
+  if (LibcPAL::mprotect(reinterpret_cast<void *>(Addr), Size, Prot) != 0)
     reportProtectError(Addr, Size, Prot);
 }
 
@@ -123,11 +111,12 @@ void MemMapLinux::releaseAndZeroPagesToOSImpl(uptr From, uptr Size) {
   void *Addr = reinterpret_cast<void *>(From);
 
   int rc;
-  while ((rc = madvise(Addr, Size, MADV_DONTNEED)) == -1 && errno == EAGAIN) {
+  while ((rc = LibcPAL::madvise(Addr, Size, MADV_DONTNEED)) == -1 &&
+         LibcPAL::geterrno() == EAGAIN) {
   }
   if (rc == -1) {
     // If we can't madvies the memory, then we still need to zero it.
-    memset(Addr, 0, Size);
+    LibcPAL::memset(Addr, 0, Size);
   }
 }
 
@@ -146,10 +135,11 @@ s64 MemMapLinux::getResidentPagesImpl(uptr From, uptr Size) {
     if ((Length >> PageSizeLog) > sizeof(PageData)) {
       Length = sizeof(PageData) << PageSizeLog;
     }
-    if (mincore(reinterpret_cast<void *>(CurrentAddress), Length, PageData) ==
-        -1) {
+    if (LibcPAL::mincore(reinterpret_cast<void *>(CurrentAddress), Length,
+                         PageData) == -1) {
       ScopedString Str;
-      Str.append("mincore failed: %s\n", strerror(errno));
+      Str.append("mincore failed: %s\n",
+                 LibcPAL::strerror(LibcPAL::geterrno()));
       Str.output();
       return -1;
     }
@@ -176,7 +166,7 @@ bool ReservedMemoryLinux::createImpl(uptr Addr, uptr Size, const char *Name,
 }
 
 void ReservedMemoryLinux::releaseImpl() {
-  if (munmap(reinterpret_cast<void *>(getBase()), getCapacity()) != 0)
+  if (LibcPAL::munmap(reinterpret_cast<void *>(getBase()), getCapacity()) != 0)
     reportUnmapError(getBase(), getCapacity());
 }
 

--- a/compiler-rt/lib/scudo/standalone/memtag.h
+++ b/compiler-rt/lib/scudo/standalone/memtag.h
@@ -12,8 +12,7 @@
 #include "internal_defs.h"
 
 #if SCUDO_CAN_USE_MTE
-#include <sys/auxv.h>
-#include <sys/prctl.h>
+#include "libc_pal.h"
 #endif
 
 namespace scudo {
@@ -66,7 +65,7 @@ inline bool systemSupportsMemoryTagging() {
 #ifndef HWCAP2_MTE
 #define HWCAP2_MTE (1 << 18)
 #endif
-  return getauxval(AT_HWCAP2) & HWCAP2_MTE;
+  return LibcPAL::getauxval(AT_HWCAP2) & HWCAP2_MTE;
 }
 
 inline bool systemDetectsMemoryTagFaultsTestOnly() {
@@ -94,16 +93,17 @@ inline bool systemDetectsMemoryTagFaultsTestOnly() {
 #ifndef PR_MTE_TCF_MASK
 #define PR_MTE_TCF_MASK (3UL << PR_MTE_TCF_SHIFT)
 #endif
-  int res = prctl(PR_GET_TAGGED_ADDR_CTRL, 0, 0, 0, 0);
+  int res = LibcPAL::prctl(PR_GET_TAGGED_ADDR_CTRL, 0, 0, 0, 0);
   if (res == -1)
     return false;
   return (static_cast<unsigned long>(res) & PR_MTE_TCF_MASK) != PR_MTE_TCF_NONE;
 }
 
 inline void enableSystemMemoryTaggingTestOnly() {
-  prctl(PR_SET_TAGGED_ADDR_CTRL,
-        PR_TAGGED_ADDR_ENABLE | PR_MTE_TCF_SYNC | (0xfffe << PR_MTE_TAG_SHIFT),
-        0, 0, 0);
+  LibcPAL::prctl(PR_SET_TAGGED_ADDR_CTRL,
+                 PR_TAGGED_ADDR_ENABLE | PR_MTE_TCF_SYNC |
+                     (0xfffe << PR_MTE_TAG_SHIFT),
+                 0, 0, 0);
 }
 
 #else // !SCUDO_CAN_USE_MTE

--- a/compiler-rt/lib/scudo/standalone/mutex.h
+++ b/compiler-rt/lib/scudo/standalone/mutex.h
@@ -13,8 +13,6 @@
 #include "common.h"
 #include "thread_annotations.h"
 
-#include <string.h>
-
 #if SCUDO_FUCHSIA
 #include <lib/sync/mutex.h> // for sync_mutex_t
 #endif
@@ -27,10 +25,10 @@ public:
   NOINLINE void lock() ACQUIRE() {
     if (LIKELY(tryLock()))
       return;
-      // The compiler may try to fully unroll the loop, ending up in a
-      // NumberOfTries*NumberOfYields block of pauses mixed with tryLocks. This
-      // is large, ugly and unneeded, a compact loop is better for our purpose
-      // here. Use a pragma to tell the compiler not to unroll the loop.
+    // The compiler may try to fully unroll the loop, ending up in a
+    // NumberOfTries*NumberOfYields block of pauses mixed with tryLocks. This
+    // is large, ugly and unneeded, a compact loop is better for our purpose
+    // here. Use a pragma to tell the compiler not to unroll the loop.
 #ifdef __clang__
 #pragma nounroll
 #endif

--- a/compiler-rt/lib/scudo/standalone/report_linux.cpp
+++ b/compiler-rt/lib/scudo/standalone/report_linux.cpp
@@ -12,13 +12,10 @@
 
 #include "common.h"
 #include "internal_defs.h"
+#include "libc_pal.h"
 #include "report.h"
 #include "report_linux.h"
 #include "string_utils.h"
-
-#include <errno.h>
-#include <stdlib.h>
-#include <string.h>
 
 namespace scudo {
 
@@ -26,7 +23,7 @@ namespace scudo {
 void NORETURN reportMapError(uptr SizeIfOOM) {
   ScopedString Error;
   Error.append("Scudo ERROR: internal map failure (error desc=%s)",
-               strerror(errno));
+               LibcPAL::strerror(LibcPAL::geterrno()));
   if (SizeIfOOM)
     Error.append(" requesting %zuKB", SizeIfOOM >> 10);
   Error.append("\n");
@@ -37,7 +34,7 @@ void NORETURN reportUnmapError(uptr Addr, uptr Size) {
   ScopedString Error;
   Error.append("Scudo ERROR: internal unmap failure (error desc=%s) Addr 0x%zx "
                "Size %zu\n",
-               strerror(errno), Addr, Size);
+               LibcPAL::strerror(LibcPAL::geterrno()), Addr, Size);
   reportRawError(Error.data());
 }
 
@@ -46,7 +43,7 @@ void NORETURN reportProtectError(uptr Addr, uptr Size, int Prot) {
   Error.append(
       "Scudo ERROR: internal protect failure (error desc=%s) Addr 0x%zx "
       "Size %zu Prot %x\n",
-      strerror(errno), Addr, Size, Prot);
+      LibcPAL::strerror(LibcPAL::geterrno()), Addr, Size, Prot);
   reportRawError(Error.data());
 }
 

--- a/compiler-rt/lib/scudo/standalone/tsd.h
+++ b/compiler-rt/lib/scudo/standalone/tsd.h
@@ -11,11 +11,11 @@
 
 #include "atomic_helpers.h"
 #include "common.h"
+#include "libc_pal.h"
 #include "mutex.h"
 #include "thread_annotations.h"
 
 #include <limits.h> // for PTHREAD_DESTRUCTOR_ITERATIONS
-#include <pthread.h>
 
 // With some build setups, this might still not be defined.
 #ifndef PTHREAD_DESTRUCTOR_ITERATIONS

--- a/compiler-rt/lib/scudo/standalone/tsd_exclusive.h
+++ b/compiler-rt/lib/scudo/standalone/tsd_exclusive.h
@@ -59,7 +59,8 @@ template <class Allocator> struct TSDRegistryExT {
     if (UNLIKELY(atomic_load_relaxed(&Initialized) != 0))
       return;
     Instance->init();
-    CHECK_EQ(pthread_key_create(&PThreadKey, teardownThread<Allocator>), 0);
+    CHECK_EQ(
+        LibcPAL::pthread_key_create(&PThreadKey, teardownThread<Allocator>), 0);
     FallbackTSD.init(Instance);
     atomic_store_relaxed(&Initialized, 1);
   }
@@ -72,13 +73,15 @@ template <class Allocator> struct TSDRegistryExT {
 
   void unmapTestOnly(Allocator *Instance) EXCLUDES(Mutex) {
     DCHECK(Instance);
-    if (reinterpret_cast<Allocator *>(pthread_getspecific(PThreadKey))) {
-      DCHECK_EQ(reinterpret_cast<Allocator *>(pthread_getspecific(PThreadKey)),
+    if (reinterpret_cast<Allocator *>(
+            LibcPAL::pthread_getspecific(PThreadKey))) {
+      DCHECK_EQ(reinterpret_cast<Allocator *>(
+                    LibcPAL::pthread_getspecific(PThreadKey)),
                 Instance);
       ThreadTSD.commitBack(Instance);
       ThreadTSD = {};
     }
-    CHECK_EQ(pthread_key_delete(PThreadKey), 0);
+    CHECK_EQ(LibcPAL::pthread_key_delete(PThreadKey), 0);
     PThreadKey = {};
     FallbackTSD.commitBack(Instance);
     FallbackTSD = {};
@@ -153,14 +156,15 @@ private:
     initOnceMaybe(Instance);
     if (UNLIKELY(MinimalInit))
       return;
-    CHECK_EQ(
-        pthread_setspecific(PThreadKey, reinterpret_cast<void *>(Instance)), 0);
+    CHECK_EQ(LibcPAL::pthread_setspecific(PThreadKey,
+                                          reinterpret_cast<void *>(Instance)),
+             0);
     ThreadTSD.init(Instance);
     State.InitState = ThreadState::Initialized;
     Instance->callPostInitCallback();
   }
 
-  pthread_key_t PThreadKey = {};
+  typename LibcPAL::PThreadKeyT PThreadKey = {};
   atomic_u8 Initialized = {};
   atomic_u8 Disabled = {};
   TSD<Allocator> FallbackTSD;
@@ -188,8 +192,8 @@ void teardownThread(void *Ptr) NO_THREAD_SAFETY_ANALYSIS {
   if (TSDRegistryT::ThreadTSD.DestructorIterations > 1) {
     TSDRegistryT::ThreadTSD.DestructorIterations--;
     // If pthread_setspecific fails, we will go ahead with the teardown.
-    if (LIKELY(pthread_setspecific(Instance->getTSDRegistry()->PThreadKey,
-                                   Ptr) == 0))
+    if (LIKELY(LibcPAL::pthread_setspecific(
+                   Instance->getTSDRegistry()->PThreadKey, Ptr) == 0))
       return;
   }
   TSDRegistryT::ThreadTSD.commitBack(Instance);

--- a/compiler-rt/lib/scudo/standalone/wrappers_c.inc
+++ b/compiler-rt/lib/scudo/standalone/wrappers_c.inc
@@ -52,7 +52,7 @@ INTERFACE WEAK void *SCUDO_PREFIX(calloc)(size_t nmemb, size_t size) {
   scudo::uptr Product;
   if (UNLIKELY(scudo::checkForCallocOverflow(size, nmemb, &Product))) {
     if (SCUDO_ALLOCATOR.canReturnNull()) {
-      errno = ENOMEM;
+      scudo::LibcPAL::seterrno(ENOMEM);
       return nullptr;
     }
     scudo::reportCallocOverflow(nmemb, size);
@@ -145,7 +145,7 @@ INTERFACE WEAK void *SCUDO_PREFIX(memalign)(size_t alignment, size_t size) {
   } else {
     if (UNLIKELY(!scudo::isPowerOfTwo(alignment))) {
       if (SCUDO_ALLOCATOR.canReturnNull()) {
-        errno = EINVAL;
+        scudo::LibcPAL::seterrno(EINVAL);
         return nullptr;
       }
       scudo::reportAlignmentNotPowerOfTwo(alignment);
@@ -178,7 +178,7 @@ INTERFACE WEAK void *SCUDO_PREFIX(pvalloc)(size_t size) {
   const scudo::uptr PageSize = scudo::getPageSizeCached();
   if (UNLIKELY(scudo::checkForPvallocOverflow(size, PageSize))) {
     if (SCUDO_ALLOCATOR.canReturnNull()) {
-      errno = ENOMEM;
+      scudo::LibcPAL::seterrno(ENOMEM);
       return nullptr;
     }
     scudo::reportPvallocOverflow(size);
@@ -234,7 +234,7 @@ INTERFACE WEAK void *SCUDO_PREFIX(reallocarray)(void *ptr, size_t nmemb,
   scudo::uptr Product;
   if (UNLIKELY(scudo::checkForCallocOverflow(size, nmemb, &Product))) {
     if (SCUDO_ALLOCATOR.canReturnNull()) {
-      errno = ENOMEM;
+      scudo::LibcPAL::seterrno(ENOMEM);
       return nullptr;
     }
     scudo::reportReallocarrayOverflow(nmemb, size);
@@ -329,7 +329,7 @@ INTERFACE WEAK void *SCUDO_PREFIX(aligned_alloc)(size_t alignment,
                                                  size_t size) {
   if (UNLIKELY(scudo::checkAlignedAllocAlignmentAndSize(alignment, size))) {
     if (SCUDO_ALLOCATOR.canReturnNull()) {
-      errno = EINVAL;
+      scudo::LibcPAL::seterrno(EINVAL);
       return nullptr;
     }
     scudo::reportInvalidAlignedAllocAlignment(alignment, size);

--- a/compiler-rt/lib/scudo/standalone/wrappers_c_checks.h
+++ b/compiler-rt/lib/scudo/standalone/wrappers_c_checks.h
@@ -10,8 +10,7 @@
 #define SCUDO_CHECKS_H_
 
 #include "common.h"
-
-#include <errno.h>
+#include "libc_pal.h"
 
 #ifndef __has_builtin
 #define __has_builtin(X) 0
@@ -22,7 +21,7 @@ namespace scudo {
 // A common errno setting logic shared by almost all Scudo C wrappers.
 inline void *setErrnoOnNull(void *Ptr) {
   if (UNLIKELY(!Ptr))
-    errno = ENOMEM;
+    LibcPAL::seterrno(ENOMEM);
   return Ptr;
 }
 


### PR DESCRIPTION
This patch series attempt to provide llvm-libc with an internal scudo allocator.
RFC at https://discourse.llvm.org/t/rfc-llvm-libc-internal-scudo-allocator-and-allocation-model/90258/2.

Split out of #187595 as the first scudo-only patch in the series.

This change introduces compiler-rt/lib/scudo/standalone/libc_pal.h and switches the existing scudo standalone Linux/POSIX call sites over to the PAL wrappers. It intentionally does not include the llvm-libc integration path yet; this patch is only the standalone scudo refactoring needed to route those calls through the PAL layer. Android/Fuchsia support is not yet considered.

Tested with:
- ninja  ScudoUnitTests
- ninja check-scudo_standalone
