### PR TITLE
[PAC][compiler-rt] Use `__ptrauth` qualifier instead of builtins

### DIFF
--- a/clang/lib/Headers/ptrauth.h
+++ b/clang/lib/Headers/ptrauth.h
@@ -349,6 +349,14 @@ typedef __UINTPTR_TYPE__ ptrauth_generic_signature_t;
   __ptrauth(ptrauth_key_objc_class_ro_pointer, 1,                              \
             __ptrauth_objc_class_ro_discriminator)
 
+#if __has_feature(ptrauth_init_fini_address_discrimination)
+#define __ptrauth_init_fini_pointer                                            \
+  __ptrauth(ptrauth_key_init_fini_pointer, 1, __ptrauth_init_fini_discriminator)
+#else
+#define __ptrauth_init_fini_pointer                                            \
+  __ptrauth(ptrauth_key_init_fini_pointer, 0, __ptrauth_init_fini_discriminator)
+#endif
+
 #else
 
 #define ptrauth_strip(__value, __key)                                          \

--- a/compiler-rt/lib/builtins/crtbegin.c
+++ b/compiler-rt/lib/builtins/crtbegin.c
@@ -55,17 +55,9 @@ static void __attribute__((used)) __do_init(void) {
 
 #ifdef CRT_HAS_INITFINI_ARRAY
 # if __has_feature(ptrauth_init_fini)
-// TODO: use __ptrauth-qualified pointers when they are supported on clang side
-#  if __has_feature(ptrauth_init_fini_address_discrimination)
-__attribute__((section(".init_array"), used)) static void *__init =
-    ptrauth_sign_constant(&__do_init, ptrauth_key_init_fini_pointer,
-                          ptrauth_blend_discriminator(
-                              &__init, __ptrauth_init_fini_discriminator));
-#  else
-__attribute__((section(".init_array"), used)) static void *__init =
-    ptrauth_sign_constant(&__do_init, ptrauth_key_init_fini_pointer,
-                          __ptrauth_init_fini_discriminator);
-#  endif
+__attribute__((section(".init_array"),
+               used)) static void *__ptrauth_init_fini_pointer __init =
+    __do_init;
 # elif __has_feature(ptrauth_calls)
 #  ifdef __aarch64__
 // If ptrauth_init_fini feature is not present, compiler emits raw unsigned
@@ -137,17 +129,9 @@ static void __attribute__((used)) __do_fini(void) {
 
 #ifdef CRT_HAS_INITFINI_ARRAY
 # if __has_feature(ptrauth_init_fini)
-// TODO: use __ptrauth-qualified pointers when they are supported on clang side
-#  if __has_feature(ptrauth_init_fini_address_discrimination)
-__attribute__((section(".fini_array"), used)) static void *__fini =
-    ptrauth_sign_constant(&__do_fini, ptrauth_key_init_fini_pointer,
-                          ptrauth_blend_discriminator(
-                              &__fini, __ptrauth_init_fini_discriminator));
-#  else
-__attribute__((section(".fini_array"), used)) static void *__fini =
-    ptrauth_sign_constant(&__do_fini, ptrauth_key_init_fini_pointer,
-                          __ptrauth_init_fini_discriminator);
-#  endif
+__attribute__((section(".fini_array"),
+               used)) static void *__ptrauth_init_fini_pointer __fini =
+    __do_fini;
 # elif __has_feature(ptrauth_calls)
 #  ifdef __aarch64__
 // If ptrauth_init_fini feature is not present, compiler emits raw unsigned


### PR DESCRIPTION
Since #100830 has landed, we no longer need to rely on builtins