### PR TITLE
[DAGCombiner][GlobalISel] Extend allMulUsesCanBeContracted with FNEG pattern

### DIFF
--- a/llvm/lib/CodeGen/GlobalISel/CombinerHelper.cpp
+++ b/llvm/lib/CodeGen/GlobalISel/CombinerHelper.cpp
@@ -6329,8 +6329,9 @@ static bool hasMoreUses(const MachineInstr &MI0, const MachineInstr &MI1,
 /// would duplicate the multiply without reducing the total number of
 /// operations.
 ///
-/// Currently checks for the following pattern:
+/// Currently checks for the following patterns:
 ///   - fmul --> fadd/fsub: Direct contraction
+///   - fmul --> fneg --> fsub: Contraction through fneg
 bool CombinerHelper::allMulUsesCanBeContracted(const MachineInstr &MI) const {
   Register MulReg = MI.getOperand(0).getReg();
 
@@ -6340,6 +6341,17 @@ bool CombinerHelper::allMulUsesCanBeContracted(const MachineInstr &MI) const {
     // Direct FADD/FSUB uses - contractable.
     if (Opcode == TargetOpcode::G_FADD || Opcode == TargetOpcode::G_FSUB)
       continue;
+
+    // G_FNEG use - contractable if all users of the fneg are G_FSUB.
+    if (Opcode == TargetOpcode::G_FNEG) {
+      Register FNegReg = UseMI.getOperand(0).getReg();
+      for (const MachineInstr &FNegUser : MRI.use_nodbg_instructions(FNegReg)) {
+        unsigned FNegUserOp = FNegUser.getOpcode();
+        if (FNegUserOp != TargetOpcode::G_FSUB)
+          return false;
+      }
+      continue;
+    }
 
     // Any other use type is not currently recognized as contractable.
     return false;
@@ -6757,9 +6769,10 @@ bool CombinerHelper::matchCombineFSubFNegFMulToFMadOrFMA(
   MachineInstr *FMulMI;
   // fold (fsub (fneg (fmul x, y)), z) -> (fma (fneg x), y, (fneg z))
   if (mi_match(LHSReg, MRI, m_GFNeg(m_MInstr(FMulMI))) &&
-      (Aggressive || (MRI.hasOneNonDBGUse(LHSReg) &&
-                      MRI.hasOneNonDBGUse(FMulMI->getOperand(0).getReg()))) &&
-      isContractableFMul(*FMulMI, AllowFusionGlobally)) {
+      isContractableFMul(*FMulMI, AllowFusionGlobally) &&
+      ((MRI.hasOneNonDBGUse(LHSReg) &&
+        MRI.hasOneNonDBGUse(FMulMI->getOperand(0).getReg())) ||
+       (Aggressive && allMulUsesCanBeContracted(*FMulMI)))) {
     MatchInfo = [=, &MI](MachineIRBuilder &B) {
       Register NegX =
           B.buildFNeg(DstTy, FMulMI->getOperand(1).getReg()).getReg(0);
@@ -6771,10 +6784,15 @@ bool CombinerHelper::matchCombineFSubFNegFMulToFMadOrFMA(
   }
 
   // fold (fsub x, (fneg (fmul, y, z))) -> (fma y, z, x)
+  // Note: In the standard combiner ordering, redundant_neg_operands
+  // canonicalizes fsub(x, fneg(y)) -> fadd(x, y) before fma_combines runs,
+  // so this fold may not fire in practice. It is kept as defensive code
+  // against combiner reordering.
   if (mi_match(RHSReg, MRI, m_GFNeg(m_MInstr(FMulMI))) &&
-      (Aggressive || (MRI.hasOneNonDBGUse(RHSReg) &&
-                      MRI.hasOneNonDBGUse(FMulMI->getOperand(0).getReg()))) &&
-      isContractableFMul(*FMulMI, AllowFusionGlobally)) {
+      isContractableFMul(*FMulMI, AllowFusionGlobally) &&
+      ((MRI.hasOneNonDBGUse(RHSReg) &&
+        MRI.hasOneNonDBGUse(FMulMI->getOperand(0).getReg())) ||
+       (Aggressive && allMulUsesCanBeContracted(*FMulMI)))) {
     MatchInfo = [=, &MI](MachineIRBuilder &B) {
       B.buildInstr(PreferredFusedOpcode, {MI.getOperand(0).getReg()},
                    {FMulMI->getOperand(1).getReg(),

--- a/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
@@ -17828,8 +17828,9 @@ static bool isFMulAdd(const MatchContextClass &Matcher, SDValue N) {
 /// would duplicate the multiply without reducing the total number of
 /// operations.
 ///
-/// Currently checks for the following pattern:
+/// Currently checks for the following patterns:
 ///   - fmul --> fadd/fsub: Direct contraction
+///   - fmul --> fneg --> fsub: Contraction through fneg
 static bool allMulUsesCanBeContracted(SDValue Mul) {
   for (const auto *User : Mul->users()) {
     unsigned Opcode = User->getOpcode();
@@ -17837,6 +17838,16 @@ static bool allMulUsesCanBeContracted(SDValue Mul) {
     // Direct FADD/FSUB - contractable.
     if (Opcode == ISD::FADD || Opcode == ISD::FSUB)
       continue;
+
+    // FNEG use - contractable if all users of the fneg are FSUB.
+    if (Opcode == ISD::FNEG) {
+      for (const auto *FNegUser : User->users()) {
+        unsigned FNegUserOp = FNegUser->getOpcode();
+        if (FNegUserOp != ISD::FSUB)
+          return false;
+      }
+      continue;
+    }
 
     // Any other use type is not currently recognized as contractable.
     return false;
@@ -18173,8 +18184,13 @@ SDValue DAGCombiner::visitFSUBForFMACombine(SDNode *N) {
   }
 
   // fold (fsub (fneg (fmul, x, y)), z) -> (fma (fneg x), y, (fneg z))
+  // Note: SDAG does not need the symmetric fold (fsub x, (fneg (fmul y, z)))
+  // because visitFSUB canonicalizes fsub(A, fneg(B)) -> fadd(A, B) before
+  // calling visitFSUBForFMACombine, so that pattern is handled by
+  // visitFADDForFMACombine instead.
   if (matcher.match(N0, ISD::FNEG) && isContractableFMUL(N0.getOperand(0)) &&
-      (Aggressive || (N0->hasOneUse() && N0.getOperand(0).hasOneUse()))) {
+      ((N0->hasOneUse() && N0.getOperand(0).hasOneUse()) ||
+       (Aggressive && allMulUsesCanBeContracted(N0.getOperand(0))))) {
     SDValue N00 = N0.getOperand(0).getOperand(0);
     SDValue N01 = N0.getOperand(0).getOperand(1);
     return matcher.getNode(PreferredFusedOpcode, SL, VT,

--- a/llvm/test/CodeGen/AMDGPU/fma-multiple-uses-contraction.ll
+++ b/llvm/test/CodeGen/AMDGPU/fma-multiple-uses-contraction.ll
@@ -714,15 +714,9 @@ define { float, float, float } @mul_three_contractable_uses(float %a, float %b, 
   ret { float, float, float } %ret2
 }
 
-
 ; ==========================================================================
 ; FNEG patterns
 ; Tests for allMulUsesCanBeContracted recognizing fneg as a transparent user.
-;
-; NOTE: The allMulUsesCanBeContracted guard does not yet recognize fneg as
-; transparent. That support is added by the next patch in the series. Until
-; then, the CHECK lines below reflect current (potentially over-conservative)
-; codegen and may not match the "Expected:" comments on individual tests.
 ; ==========================================================================
 
 ; Test case: fmul -> fneg -> fsub (single use chain).
@@ -731,55 +725,55 @@ define { float, float, float } @mul_three_contractable_uses(float %a, float %b, 
 ; Should contract -- single-use chain, fneg folds into fma.
 ; Expected: single fma/mad, no v_mul.
 define float @mul_fneg_fsub_single_use(float %a, float %b, float %c) {
-; P0-GFX9-SDAG-F32FLUSH-LABEL: mul_fneg_fsub_single_use:
-; P0-GFX9-SDAG-F32FLUSH:       ; %bb.0:
-; P0-GFX9-SDAG-F32FLUSH-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; P0-GFX9-SDAG-F32FLUSH-NEXT:    v_mad_f32 v0, v0, -v1, -v2
-; P0-GFX9-SDAG-F32FLUSH-NEXT:    s_setpc_b64 s[30:31]
+; GFX9-SDAG-F32FLUSH-LABEL: mul_fneg_fsub_single_use:
+; GFX9-SDAG-F32FLUSH:       ; %bb.0:
+; GFX9-SDAG-F32FLUSH-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-SDAG-F32FLUSH-NEXT:    v_mad_f32 v0, v0, -v1, -v2
+; GFX9-SDAG-F32FLUSH-NEXT:    s_setpc_b64 s[30:31]
 ;
-; P0-GFX9-GISEL-F32FLUSH-LABEL: mul_fneg_fsub_single_use:
-; P0-GFX9-GISEL-F32FLUSH:       ; %bb.0:
-; P0-GFX9-GISEL-F32FLUSH-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; P0-GFX9-GISEL-F32FLUSH-NEXT:    v_mad_f32 v0, v0, -v1, -v2
-; P0-GFX9-GISEL-F32FLUSH-NEXT:    s_setpc_b64 s[30:31]
+; GFX9-GISEL-F32FLUSH-LABEL: mul_fneg_fsub_single_use:
+; GFX9-GISEL-F32FLUSH:       ; %bb.0:
+; GFX9-GISEL-F32FLUSH-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-GISEL-F32FLUSH-NEXT:    v_mad_f32 v0, v0, -v1, -v2
+; GFX9-GISEL-F32FLUSH-NEXT:    s_setpc_b64 s[30:31]
 ;
-; P0-GFX9_4-SDAG-LABEL: mul_fneg_fsub_single_use:
-; P0-GFX9_4-SDAG:       ; %bb.0:
-; P0-GFX9_4-SDAG-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; P0-GFX9_4-SDAG-NEXT:    v_fma_f32 v0, -v0, v1, -v2
-; P0-GFX9_4-SDAG-NEXT:    s_setpc_b64 s[30:31]
+; GFX9_4-SDAG-LABEL: mul_fneg_fsub_single_use:
+; GFX9_4-SDAG:       ; %bb.0:
+; GFX9_4-SDAG-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9_4-SDAG-NEXT:    v_fma_f32 v0, -v0, v1, -v2
+; GFX9_4-SDAG-NEXT:    s_setpc_b64 s[30:31]
 ;
-; P0-GFX9_4-GISEL-LABEL: mul_fneg_fsub_single_use:
-; P0-GFX9_4-GISEL:       ; %bb.0:
-; P0-GFX9_4-GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; P0-GFX9_4-GISEL-NEXT:    v_fma_f32 v0, v0, -v1, -v2
-; P0-GFX9_4-GISEL-NEXT:    s_setpc_b64 s[30:31]
+; GFX9_4-GISEL-LABEL: mul_fneg_fsub_single_use:
+; GFX9_4-GISEL:       ; %bb.0:
+; GFX9_4-GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9_4-GISEL-NEXT:    v_fma_f32 v0, v0, -v1, -v2
+; GFX9_4-GISEL-NEXT:    s_setpc_b64 s[30:31]
 ;
-; P0-GFX12_5-SDAG-LABEL: mul_fneg_fsub_single_use:
-; P0-GFX12_5-SDAG:       ; %bb.0:
-; P0-GFX12_5-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
-; P0-GFX12_5-SDAG-NEXT:    s_wait_kmcnt 0x0
-; P0-GFX12_5-SDAG-NEXT:    v_fma_f32 v0, -v0, v1, -v2
-; P0-GFX12_5-SDAG-NEXT:    s_set_pc_i64 s[30:31]
+; GFX12_5-SDAG-LABEL: mul_fneg_fsub_single_use:
+; GFX12_5-SDAG:       ; %bb.0:
+; GFX12_5-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12_5-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX12_5-SDAG-NEXT:    v_fma_f32 v0, -v0, v1, -v2
+; GFX12_5-SDAG-NEXT:    s_set_pc_i64 s[30:31]
 ;
-; P0-GFX12_5-GISEL-LABEL: mul_fneg_fsub_single_use:
-; P0-GFX12_5-GISEL:       ; %bb.0:
-; P0-GFX12_5-GISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
-; P0-GFX12_5-GISEL-NEXT:    s_wait_kmcnt 0x0
-; P0-GFX12_5-GISEL-NEXT:    v_fma_f32 v0, v0, -v1, -v2
-; P0-GFX12_5-GISEL-NEXT:    s_set_pc_i64 s[30:31]
+; GFX12_5-GISEL-LABEL: mul_fneg_fsub_single_use:
+; GFX12_5-GISEL:       ; %bb.0:
+; GFX12_5-GISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12_5-GISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX12_5-GISEL-NEXT:    v_fma_f32 v0, v0, -v1, -v2
+; GFX12_5-GISEL-NEXT:    s_set_pc_i64 s[30:31]
 ;
-; P0-GFX9-SDAG-F32DENORM-LABEL: mul_fneg_fsub_single_use:
-; P0-GFX9-SDAG-F32DENORM:       ; %bb.0:
-; P0-GFX9-SDAG-F32DENORM-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; P0-GFX9-SDAG-F32DENORM-NEXT:    v_fma_f32 v0, -v0, v1, -v2
-; P0-GFX9-SDAG-F32DENORM-NEXT:    s_setpc_b64 s[30:31]
+; GFX9-SDAG-F32DENORM-LABEL: mul_fneg_fsub_single_use:
+; GFX9-SDAG-F32DENORM:       ; %bb.0:
+; GFX9-SDAG-F32DENORM-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-SDAG-F32DENORM-NEXT:    v_fma_f32 v0, -v0, v1, -v2
+; GFX9-SDAG-F32DENORM-NEXT:    s_setpc_b64 s[30:31]
 ;
-; P0-GFX9-GISEL-F32DENORM-LABEL: mul_fneg_fsub_single_use:
-; P0-GFX9-GISEL-F32DENORM:       ; %bb.0:
-; P0-GFX9-GISEL-F32DENORM-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; P0-GFX9-GISEL-F32DENORM-NEXT:    v_fma_f32 v0, v0, -v1, -v2
-; P0-GFX9-GISEL-F32DENORM-NEXT:    s_setpc_b64 s[30:31]
+; GFX9-GISEL-F32DENORM-LABEL: mul_fneg_fsub_single_use:
+; GFX9-GISEL-F32DENORM:       ; %bb.0:
+; GFX9-GISEL-F32DENORM-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-GISEL-F32DENORM-NEXT:    v_fma_f32 v0, v0, -v1, -v2
+; GFX9-GISEL-F32DENORM-NEXT:    s_setpc_b64 s[30:31]
   %mul = fmul contract float %a, %b
   %neg = fneg contract float %mul
   %sub = fsub contract float %neg, %c       ; contractable
@@ -792,71 +786,71 @@ define float @mul_fneg_fsub_single_use(float %a, float %b, float %c) {
 ; Should contract -- all fneg uses are contractable fsubs.
 ; Expected: two fma/mad instructions, no v_mul.
 define { float, float } @mul_fneg_multiple_fsub_uses(float %a, float %b, float %c, float %d) {
-; P0-GFX9-SDAG-F32FLUSH-LABEL: mul_fneg_multiple_fsub_uses:
-; P0-GFX9-SDAG-F32FLUSH:       ; %bb.0:
-; P0-GFX9-SDAG-F32FLUSH-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; P0-GFX9-SDAG-F32FLUSH-NEXT:    v_mad_f32 v2, v0, -v1, -v2
-; P0-GFX9-SDAG-F32FLUSH-NEXT:    v_mad_f32 v1, v0, -v1, -v3
-; P0-GFX9-SDAG-F32FLUSH-NEXT:    v_mov_b32_e32 v0, v2
-; P0-GFX9-SDAG-F32FLUSH-NEXT:    s_setpc_b64 s[30:31]
+; GFX9-SDAG-F32FLUSH-LABEL: mul_fneg_multiple_fsub_uses:
+; GFX9-SDAG-F32FLUSH:       ; %bb.0:
+; GFX9-SDAG-F32FLUSH-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-SDAG-F32FLUSH-NEXT:    v_mad_f32 v2, v0, -v1, -v2
+; GFX9-SDAG-F32FLUSH-NEXT:    v_mad_f32 v1, v0, -v1, -v3
+; GFX9-SDAG-F32FLUSH-NEXT:    v_mov_b32_e32 v0, v2
+; GFX9-SDAG-F32FLUSH-NEXT:    s_setpc_b64 s[30:31]
 ;
-; P0-GFX9-GISEL-F32FLUSH-LABEL: mul_fneg_multiple_fsub_uses:
-; P0-GFX9-GISEL-F32FLUSH:       ; %bb.0:
-; P0-GFX9-GISEL-F32FLUSH-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; P0-GFX9-GISEL-F32FLUSH-NEXT:    v_mad_f32 v2, v0, -v1, -v2
-; P0-GFX9-GISEL-F32FLUSH-NEXT:    v_mad_f32 v1, v0, -v1, -v3
-; P0-GFX9-GISEL-F32FLUSH-NEXT:    v_mov_b32_e32 v0, v2
-; P0-GFX9-GISEL-F32FLUSH-NEXT:    s_setpc_b64 s[30:31]
+; GFX9-GISEL-F32FLUSH-LABEL: mul_fneg_multiple_fsub_uses:
+; GFX9-GISEL-F32FLUSH:       ; %bb.0:
+; GFX9-GISEL-F32FLUSH-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-GISEL-F32FLUSH-NEXT:    v_mad_f32 v2, v0, -v1, -v2
+; GFX9-GISEL-F32FLUSH-NEXT:    v_mad_f32 v1, v0, -v1, -v3
+; GFX9-GISEL-F32FLUSH-NEXT:    v_mov_b32_e32 v0, v2
+; GFX9-GISEL-F32FLUSH-NEXT:    s_setpc_b64 s[30:31]
 ;
-; P0-GFX9_4-SDAG-LABEL: mul_fneg_multiple_fsub_uses:
-; P0-GFX9_4-SDAG:       ; %bb.0:
-; P0-GFX9_4-SDAG-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; P0-GFX9_4-SDAG-NEXT:    v_fma_f32 v2, -v0, v1, -v2
-; P0-GFX9_4-SDAG-NEXT:    v_fma_f32 v1, -v0, v1, -v3
-; P0-GFX9_4-SDAG-NEXT:    v_mov_b32_e32 v0, v2
-; P0-GFX9_4-SDAG-NEXT:    s_setpc_b64 s[30:31]
+; GFX9_4-SDAG-LABEL: mul_fneg_multiple_fsub_uses:
+; GFX9_4-SDAG:       ; %bb.0:
+; GFX9_4-SDAG-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9_4-SDAG-NEXT:    v_fma_f32 v2, -v0, v1, -v2
+; GFX9_4-SDAG-NEXT:    v_fma_f32 v1, -v0, v1, -v3
+; GFX9_4-SDAG-NEXT:    v_mov_b32_e32 v0, v2
+; GFX9_4-SDAG-NEXT:    s_setpc_b64 s[30:31]
 ;
-; P0-GFX9_4-GISEL-LABEL: mul_fneg_multiple_fsub_uses:
-; P0-GFX9_4-GISEL:       ; %bb.0:
-; P0-GFX9_4-GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; P0-GFX9_4-GISEL-NEXT:    v_fma_f32 v2, v0, -v1, -v2
-; P0-GFX9_4-GISEL-NEXT:    v_fma_f32 v1, v0, -v1, -v3
-; P0-GFX9_4-GISEL-NEXT:    v_mov_b32_e32 v0, v2
-; P0-GFX9_4-GISEL-NEXT:    s_setpc_b64 s[30:31]
+; GFX9_4-GISEL-LABEL: mul_fneg_multiple_fsub_uses:
+; GFX9_4-GISEL:       ; %bb.0:
+; GFX9_4-GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9_4-GISEL-NEXT:    v_fma_f32 v2, v0, -v1, -v2
+; GFX9_4-GISEL-NEXT:    v_fma_f32 v1, v0, -v1, -v3
+; GFX9_4-GISEL-NEXT:    v_mov_b32_e32 v0, v2
+; GFX9_4-GISEL-NEXT:    s_setpc_b64 s[30:31]
 ;
-; P0-GFX12_5-SDAG-LABEL: mul_fneg_multiple_fsub_uses:
-; P0-GFX12_5-SDAG:       ; %bb.0:
-; P0-GFX12_5-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
-; P0-GFX12_5-SDAG-NEXT:    s_wait_kmcnt 0x0
-; P0-GFX12_5-SDAG-NEXT:    v_dual_fma_f32 v2, -v0, v1, -v2 :: v_dual_fma_f32 v1, -v0, v1, -v3
-; P0-GFX12_5-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; P0-GFX12_5-SDAG-NEXT:    v_mov_b32_e32 v0, v2
-; P0-GFX12_5-SDAG-NEXT:    s_set_pc_i64 s[30:31]
+; GFX12_5-SDAG-LABEL: mul_fneg_multiple_fsub_uses:
+; GFX12_5-SDAG:       ; %bb.0:
+; GFX12_5-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12_5-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX12_5-SDAG-NEXT:    v_dual_fma_f32 v2, -v0, v1, -v2 :: v_dual_fma_f32 v1, -v0, v1, -v3
+; GFX12_5-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX12_5-SDAG-NEXT:    v_mov_b32_e32 v0, v2
+; GFX12_5-SDAG-NEXT:    s_set_pc_i64 s[30:31]
 ;
-; P0-GFX12_5-GISEL-LABEL: mul_fneg_multiple_fsub_uses:
-; P0-GFX12_5-GISEL:       ; %bb.0:
-; P0-GFX12_5-GISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
-; P0-GFX12_5-GISEL-NEXT:    s_wait_kmcnt 0x0
-; P0-GFX12_5-GISEL-NEXT:    v_dual_fma_f32 v2, v0, -v1, -v2 :: v_dual_fma_f32 v1, v0, -v1, -v3
-; P0-GFX12_5-GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; P0-GFX12_5-GISEL-NEXT:    v_mov_b32_e32 v0, v2
-; P0-GFX12_5-GISEL-NEXT:    s_set_pc_i64 s[30:31]
+; GFX12_5-GISEL-LABEL: mul_fneg_multiple_fsub_uses:
+; GFX12_5-GISEL:       ; %bb.0:
+; GFX12_5-GISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12_5-GISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX12_5-GISEL-NEXT:    v_dual_fma_f32 v2, v0, -v1, -v2 :: v_dual_fma_f32 v1, v0, -v1, -v3
+; GFX12_5-GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX12_5-GISEL-NEXT:    v_mov_b32_e32 v0, v2
+; GFX12_5-GISEL-NEXT:    s_set_pc_i64 s[30:31]
 ;
-; P0-GFX9-SDAG-F32DENORM-LABEL: mul_fneg_multiple_fsub_uses:
-; P0-GFX9-SDAG-F32DENORM:       ; %bb.0:
-; P0-GFX9-SDAG-F32DENORM-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; P0-GFX9-SDAG-F32DENORM-NEXT:    v_fma_f32 v2, -v0, v1, -v2
-; P0-GFX9-SDAG-F32DENORM-NEXT:    v_fma_f32 v1, -v0, v1, -v3
-; P0-GFX9-SDAG-F32DENORM-NEXT:    v_mov_b32_e32 v0, v2
-; P0-GFX9-SDAG-F32DENORM-NEXT:    s_setpc_b64 s[30:31]
+; GFX9-SDAG-F32DENORM-LABEL: mul_fneg_multiple_fsub_uses:
+; GFX9-SDAG-F32DENORM:       ; %bb.0:
+; GFX9-SDAG-F32DENORM-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-SDAG-F32DENORM-NEXT:    v_fma_f32 v2, -v0, v1, -v2
+; GFX9-SDAG-F32DENORM-NEXT:    v_fma_f32 v1, -v0, v1, -v3
+; GFX9-SDAG-F32DENORM-NEXT:    v_mov_b32_e32 v0, v2
+; GFX9-SDAG-F32DENORM-NEXT:    s_setpc_b64 s[30:31]
 ;
-; P0-GFX9-GISEL-F32DENORM-LABEL: mul_fneg_multiple_fsub_uses:
-; P0-GFX9-GISEL-F32DENORM:       ; %bb.0:
-; P0-GFX9-GISEL-F32DENORM-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; P0-GFX9-GISEL-F32DENORM-NEXT:    v_fma_f32 v2, v0, -v1, -v2
-; P0-GFX9-GISEL-F32DENORM-NEXT:    v_fma_f32 v1, v0, -v1, -v3
-; P0-GFX9-GISEL-F32DENORM-NEXT:    v_mov_b32_e32 v0, v2
-; P0-GFX9-GISEL-F32DENORM-NEXT:    s_setpc_b64 s[30:31]
+; GFX9-GISEL-F32DENORM-LABEL: mul_fneg_multiple_fsub_uses:
+; GFX9-GISEL-F32DENORM:       ; %bb.0:
+; GFX9-GISEL-F32DENORM-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-GISEL-F32DENORM-NEXT:    v_fma_f32 v2, v0, -v1, -v2
+; GFX9-GISEL-F32DENORM-NEXT:    v_fma_f32 v1, v0, -v1, -v3
+; GFX9-GISEL-F32DENORM-NEXT:    v_mov_b32_e32 v0, v2
+; GFX9-GISEL-F32DENORM-NEXT:    s_setpc_b64 s[30:31]
   %mul = fmul contract float %a, %b
   %neg = fneg contract float %mul
   %sub1 = fsub contract float %neg, %c      ; contractable
@@ -872,71 +866,71 @@ define { float, float } @mul_fneg_multiple_fsub_uses(float %a, float %b, float %
 ; Should contract -- both fneg uses (fsub, fadd) are contractable.
 ; Expected: two fma/mad instructions, no v_mul.
 define { float, float } @mul_fneg_mixed_uses(float %a, float %b, float %c, float %d) {
-; P0-GFX9-SDAG-F32FLUSH-LABEL: mul_fneg_mixed_uses:
-; P0-GFX9-SDAG-F32FLUSH:       ; %bb.0:
-; P0-GFX9-SDAG-F32FLUSH-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; P0-GFX9-SDAG-F32FLUSH-NEXT:    v_mad_f32 v2, -v0, v1, -v2
-; P0-GFX9-SDAG-F32FLUSH-NEXT:    v_mad_f32 v1, -v0, v1, v3
-; P0-GFX9-SDAG-F32FLUSH-NEXT:    v_mov_b32_e32 v0, v2
-; P0-GFX9-SDAG-F32FLUSH-NEXT:    s_setpc_b64 s[30:31]
+; GFX9-SDAG-F32FLUSH-LABEL: mul_fneg_mixed_uses:
+; GFX9-SDAG-F32FLUSH:       ; %bb.0:
+; GFX9-SDAG-F32FLUSH-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-SDAG-F32FLUSH-NEXT:    v_mad_f32 v2, -v0, v1, -v2
+; GFX9-SDAG-F32FLUSH-NEXT:    v_mad_f32 v1, -v0, v1, v3
+; GFX9-SDAG-F32FLUSH-NEXT:    v_mov_b32_e32 v0, v2
+; GFX9-SDAG-F32FLUSH-NEXT:    s_setpc_b64 s[30:31]
 ;
-; P0-GFX9-GISEL-F32FLUSH-LABEL: mul_fneg_mixed_uses:
-; P0-GFX9-GISEL-F32FLUSH:       ; %bb.0:
-; P0-GFX9-GISEL-F32FLUSH-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; P0-GFX9-GISEL-F32FLUSH-NEXT:    v_mad_f32 v2, v0, -v1, -v2
-; P0-GFX9-GISEL-F32FLUSH-NEXT:    v_mad_f32 v1, v0, -v1, v3
-; P0-GFX9-GISEL-F32FLUSH-NEXT:    v_mov_b32_e32 v0, v2
-; P0-GFX9-GISEL-F32FLUSH-NEXT:    s_setpc_b64 s[30:31]
+; GFX9-GISEL-F32FLUSH-LABEL: mul_fneg_mixed_uses:
+; GFX9-GISEL-F32FLUSH:       ; %bb.0:
+; GFX9-GISEL-F32FLUSH-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-GISEL-F32FLUSH-NEXT:    v_mad_f32 v2, v0, -v1, -v2
+; GFX9-GISEL-F32FLUSH-NEXT:    v_mad_f32 v1, v0, -v1, v3
+; GFX9-GISEL-F32FLUSH-NEXT:    v_mov_b32_e32 v0, v2
+; GFX9-GISEL-F32FLUSH-NEXT:    s_setpc_b64 s[30:31]
 ;
-; P0-GFX9_4-SDAG-LABEL: mul_fneg_mixed_uses:
-; P0-GFX9_4-SDAG:       ; %bb.0:
-; P0-GFX9_4-SDAG-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; P0-GFX9_4-SDAG-NEXT:    v_fma_f32 v2, -v0, v1, -v2
-; P0-GFX9_4-SDAG-NEXT:    v_fma_f32 v1, -v0, v1, v3
-; P0-GFX9_4-SDAG-NEXT:    v_mov_b32_e32 v0, v2
-; P0-GFX9_4-SDAG-NEXT:    s_setpc_b64 s[30:31]
+; GFX9_4-SDAG-LABEL: mul_fneg_mixed_uses:
+; GFX9_4-SDAG:       ; %bb.0:
+; GFX9_4-SDAG-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9_4-SDAG-NEXT:    v_fma_f32 v2, -v0, v1, -v2
+; GFX9_4-SDAG-NEXT:    v_fma_f32 v1, -v0, v1, v3
+; GFX9_4-SDAG-NEXT:    v_mov_b32_e32 v0, v2
+; GFX9_4-SDAG-NEXT:    s_setpc_b64 s[30:31]
 ;
-; P0-GFX9_4-GISEL-LABEL: mul_fneg_mixed_uses:
-; P0-GFX9_4-GISEL:       ; %bb.0:
-; P0-GFX9_4-GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; P0-GFX9_4-GISEL-NEXT:    v_fma_f32 v2, v0, -v1, -v2
-; P0-GFX9_4-GISEL-NEXT:    v_fma_f32 v1, v0, -v1, v3
-; P0-GFX9_4-GISEL-NEXT:    v_mov_b32_e32 v0, v2
-; P0-GFX9_4-GISEL-NEXT:    s_setpc_b64 s[30:31]
+; GFX9_4-GISEL-LABEL: mul_fneg_mixed_uses:
+; GFX9_4-GISEL:       ; %bb.0:
+; GFX9_4-GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9_4-GISEL-NEXT:    v_fma_f32 v2, v0, -v1, -v2
+; GFX9_4-GISEL-NEXT:    v_fma_f32 v1, v0, -v1, v3
+; GFX9_4-GISEL-NEXT:    v_mov_b32_e32 v0, v2
+; GFX9_4-GISEL-NEXT:    s_setpc_b64 s[30:31]
 ;
-; P0-GFX12_5-SDAG-LABEL: mul_fneg_mixed_uses:
-; P0-GFX12_5-SDAG:       ; %bb.0:
-; P0-GFX12_5-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
-; P0-GFX12_5-SDAG-NEXT:    s_wait_kmcnt 0x0
-; P0-GFX12_5-SDAG-NEXT:    v_dual_fma_f32 v2, -v0, v1, -v2 :: v_dual_fma_f32 v1, -v0, v1, v3
-; P0-GFX12_5-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; P0-GFX12_5-SDAG-NEXT:    v_mov_b32_e32 v0, v2
-; P0-GFX12_5-SDAG-NEXT:    s_set_pc_i64 s[30:31]
+; GFX12_5-SDAG-LABEL: mul_fneg_mixed_uses:
+; GFX12_5-SDAG:       ; %bb.0:
+; GFX12_5-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12_5-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX12_5-SDAG-NEXT:    v_dual_fma_f32 v2, -v0, v1, -v2 :: v_dual_fma_f32 v1, -v0, v1, v3
+; GFX12_5-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX12_5-SDAG-NEXT:    v_mov_b32_e32 v0, v2
+; GFX12_5-SDAG-NEXT:    s_set_pc_i64 s[30:31]
 ;
-; P0-GFX12_5-GISEL-LABEL: mul_fneg_mixed_uses:
-; P0-GFX12_5-GISEL:       ; %bb.0:
-; P0-GFX12_5-GISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
-; P0-GFX12_5-GISEL-NEXT:    s_wait_kmcnt 0x0
-; P0-GFX12_5-GISEL-NEXT:    v_dual_fma_f32 v2, v0, -v1, -v2 :: v_dual_fma_f32 v1, v0, -v1, v3
-; P0-GFX12_5-GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; P0-GFX12_5-GISEL-NEXT:    v_mov_b32_e32 v0, v2
-; P0-GFX12_5-GISEL-NEXT:    s_set_pc_i64 s[30:31]
+; GFX12_5-GISEL-LABEL: mul_fneg_mixed_uses:
+; GFX12_5-GISEL:       ; %bb.0:
+; GFX12_5-GISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12_5-GISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX12_5-GISEL-NEXT:    v_dual_fma_f32 v2, v0, -v1, -v2 :: v_dual_fma_f32 v1, v0, -v1, v3
+; GFX12_5-GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX12_5-GISEL-NEXT:    v_mov_b32_e32 v0, v2
+; GFX12_5-GISEL-NEXT:    s_set_pc_i64 s[30:31]
 ;
-; P0-GFX9-SDAG-F32DENORM-LABEL: mul_fneg_mixed_uses:
-; P0-GFX9-SDAG-F32DENORM:       ; %bb.0:
-; P0-GFX9-SDAG-F32DENORM-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; P0-GFX9-SDAG-F32DENORM-NEXT:    v_fma_f32 v2, -v0, v1, -v2
-; P0-GFX9-SDAG-F32DENORM-NEXT:    v_fma_f32 v1, -v0, v1, v3
-; P0-GFX9-SDAG-F32DENORM-NEXT:    v_mov_b32_e32 v0, v2
-; P0-GFX9-SDAG-F32DENORM-NEXT:    s_setpc_b64 s[30:31]
+; GFX9-SDAG-F32DENORM-LABEL: mul_fneg_mixed_uses:
+; GFX9-SDAG-F32DENORM:       ; %bb.0:
+; GFX9-SDAG-F32DENORM-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-SDAG-F32DENORM-NEXT:    v_fma_f32 v2, -v0, v1, -v2
+; GFX9-SDAG-F32DENORM-NEXT:    v_fma_f32 v1, -v0, v1, v3
+; GFX9-SDAG-F32DENORM-NEXT:    v_mov_b32_e32 v0, v2
+; GFX9-SDAG-F32DENORM-NEXT:    s_setpc_b64 s[30:31]
 ;
-; P0-GFX9-GISEL-F32DENORM-LABEL: mul_fneg_mixed_uses:
-; P0-GFX9-GISEL-F32DENORM:       ; %bb.0:
-; P0-GFX9-GISEL-F32DENORM-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; P0-GFX9-GISEL-F32DENORM-NEXT:    v_fma_f32 v2, v0, -v1, -v2
-; P0-GFX9-GISEL-F32DENORM-NEXT:    v_fma_f32 v1, v0, -v1, v3
-; P0-GFX9-GISEL-F32DENORM-NEXT:    v_mov_b32_e32 v0, v2
-; P0-GFX9-GISEL-F32DENORM-NEXT:    s_setpc_b64 s[30:31]
+; GFX9-GISEL-F32DENORM-LABEL: mul_fneg_mixed_uses:
+; GFX9-GISEL-F32DENORM:       ; %bb.0:
+; GFX9-GISEL-F32DENORM-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-GISEL-F32DENORM-NEXT:    v_fma_f32 v2, v0, -v1, -v2
+; GFX9-GISEL-F32DENORM-NEXT:    v_fma_f32 v1, v0, -v1, v3
+; GFX9-GISEL-F32DENORM-NEXT:    v_mov_b32_e32 v0, v2
+; GFX9-GISEL-F32DENORM-NEXT:    s_setpc_b64 s[30:31]
   %mul = fmul contract float %a, %b
   %neg = fneg contract float %mul
   %sub = fsub contract float %neg, %c       ; contractable
@@ -952,71 +946,55 @@ define { float, float } @mul_fneg_mixed_uses(float %a, float %b, float %c, float
 ; Should NOT contract -- one fneg user (fmul) is not contractable.
 ; Expected: v_mul + v_mul, no fma contraction.
 define { float, float } @mul_fneg_mixed_uses_2(float %a, float %b, float %c, float %d) {
-; P0-GFX9-SDAG-F32FLUSH-LABEL: mul_fneg_mixed_uses_2:
-; P0-GFX9-SDAG-F32FLUSH:       ; %bb.0:
-; P0-GFX9-SDAG-F32FLUSH-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; P0-GFX9-SDAG-F32FLUSH-NEXT:    v_mul_f32_e64 v4, v0, -v1
-; P0-GFX9-SDAG-F32FLUSH-NEXT:    v_mad_f32 v0, v0, -v1, -v2
-; P0-GFX9-SDAG-F32FLUSH-NEXT:    v_mul_f32_e32 v1, v4, v3
-; P0-GFX9-SDAG-F32FLUSH-NEXT:    s_setpc_b64 s[30:31]
+; GFX9-SDAG-LABEL: mul_fneg_mixed_uses_2:
+; GFX9-SDAG:       ; %bb.0:
+; GFX9-SDAG-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-SDAG-NEXT:    v_mul_f32_e64 v1, v0, -v1
+; GFX9-SDAG-NEXT:    v_sub_f32_e32 v0, v1, v2
+; GFX9-SDAG-NEXT:    v_mul_f32_e32 v1, v1, v3
+; GFX9-SDAG-NEXT:    s_setpc_b64 s[30:31]
 ;
-; P0-GFX9-GISEL-F32FLUSH-LABEL: mul_fneg_mixed_uses_2:
-; P0-GFX9-GISEL-F32FLUSH:       ; %bb.0:
-; P0-GFX9-GISEL-F32FLUSH-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; P0-GFX9-GISEL-F32FLUSH-NEXT:    v_mul_f32_e64 v4, v0, -v1
-; P0-GFX9-GISEL-F32FLUSH-NEXT:    v_mad_f32 v0, v0, -v1, -v2
-; P0-GFX9-GISEL-F32FLUSH-NEXT:    v_mul_f32_e32 v1, v4, v3
-; P0-GFX9-GISEL-F32FLUSH-NEXT:    s_setpc_b64 s[30:31]
+; GFX9-GISEL-LABEL: mul_fneg_mixed_uses_2:
+; GFX9-GISEL:       ; %bb.0:
+; GFX9-GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-GISEL-NEXT:    v_mul_f32_e64 v1, v0, -v1
+; GFX9-GISEL-NEXT:    v_sub_f32_e32 v0, v1, v2
+; GFX9-GISEL-NEXT:    v_mul_f32_e32 v1, v1, v3
+; GFX9-GISEL-NEXT:    s_setpc_b64 s[30:31]
 ;
-; P0-GFX9_4-SDAG-LABEL: mul_fneg_mixed_uses_2:
-; P0-GFX9_4-SDAG:       ; %bb.0:
-; P0-GFX9_4-SDAG-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; P0-GFX9_4-SDAG-NEXT:    v_mul_f32_e64 v4, v0, -v1
-; P0-GFX9_4-SDAG-NEXT:    v_fma_f32 v0, -v0, v1, -v2
-; P0-GFX9_4-SDAG-NEXT:    v_mul_f32_e32 v1, v4, v3
-; P0-GFX9_4-SDAG-NEXT:    s_setpc_b64 s[30:31]
+; GFX9_4-SDAG-LABEL: mul_fneg_mixed_uses_2:
+; GFX9_4-SDAG:       ; %bb.0:
+; GFX9_4-SDAG-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9_4-SDAG-NEXT:    v_mul_f32_e64 v1, v0, -v1
+; GFX9_4-SDAG-NEXT:    v_sub_f32_e32 v0, v1, v2
+; GFX9_4-SDAG-NEXT:    v_mul_f32_e32 v1, v1, v3
+; GFX9_4-SDAG-NEXT:    s_setpc_b64 s[30:31]
 ;
-; P0-GFX9_4-GISEL-LABEL: mul_fneg_mixed_uses_2:
-; P0-GFX9_4-GISEL:       ; %bb.0:
-; P0-GFX9_4-GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; P0-GFX9_4-GISEL-NEXT:    v_mul_f32_e64 v4, v0, -v1
-; P0-GFX9_4-GISEL-NEXT:    v_fma_f32 v0, v0, -v1, -v2
-; P0-GFX9_4-GISEL-NEXT:    v_mul_f32_e32 v1, v4, v3
-; P0-GFX9_4-GISEL-NEXT:    s_setpc_b64 s[30:31]
+; GFX9_4-GISEL-LABEL: mul_fneg_mixed_uses_2:
+; GFX9_4-GISEL:       ; %bb.0:
+; GFX9_4-GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9_4-GISEL-NEXT:    v_mul_f32_e64 v1, v0, -v1
+; GFX9_4-GISEL-NEXT:    v_sub_f32_e32 v0, v1, v2
+; GFX9_4-GISEL-NEXT:    v_mul_f32_e32 v1, v1, v3
+; GFX9_4-GISEL-NEXT:    s_setpc_b64 s[30:31]
 ;
-; P0-GFX12_5-SDAG-LABEL: mul_fneg_mixed_uses_2:
-; P0-GFX12_5-SDAG:       ; %bb.0:
-; P0-GFX12_5-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
-; P0-GFX12_5-SDAG-NEXT:    s_wait_kmcnt 0x0
-; P0-GFX12_5-SDAG-NEXT:    v_dual_mul_f32 v4, v0, -v1 :: v_dual_fma_f32 v0, -v0, v1, -v2
-; P0-GFX12_5-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; P0-GFX12_5-SDAG-NEXT:    v_mul_f32_e32 v1, v4, v3
-; P0-GFX12_5-SDAG-NEXT:    s_set_pc_i64 s[30:31]
+; GFX12_5-SDAG-LABEL: mul_fneg_mixed_uses_2:
+; GFX12_5-SDAG:       ; %bb.0:
+; GFX12_5-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12_5-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX12_5-SDAG-NEXT:    v_mul_f32_e64 v1, v0, -v1
+; GFX12_5-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX12_5-SDAG-NEXT:    v_dual_sub_f32 v0, v1, v2 :: v_dual_mul_f32 v1, v1, v3
+; GFX12_5-SDAG-NEXT:    s_set_pc_i64 s[30:31]
 ;
-; P0-GFX12_5-GISEL-LABEL: mul_fneg_mixed_uses_2:
-; P0-GFX12_5-GISEL:       ; %bb.0:
-; P0-GFX12_5-GISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
-; P0-GFX12_5-GISEL-NEXT:    s_wait_kmcnt 0x0
-; P0-GFX12_5-GISEL-NEXT:    v_dual_mul_f32 v4, v0, -v1 :: v_dual_fma_f32 v0, v0, -v1, -v2
-; P0-GFX12_5-GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; P0-GFX12_5-GISEL-NEXT:    v_mul_f32_e32 v1, v4, v3
-; P0-GFX12_5-GISEL-NEXT:    s_set_pc_i64 s[30:31]
-;
-; P0-GFX9-SDAG-F32DENORM-LABEL: mul_fneg_mixed_uses_2:
-; P0-GFX9-SDAG-F32DENORM:       ; %bb.0:
-; P0-GFX9-SDAG-F32DENORM-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; P0-GFX9-SDAG-F32DENORM-NEXT:    v_mul_f32_e64 v4, v0, -v1
-; P0-GFX9-SDAG-F32DENORM-NEXT:    v_fma_f32 v0, -v0, v1, -v2
-; P0-GFX9-SDAG-F32DENORM-NEXT:    v_mul_f32_e32 v1, v4, v3
-; P0-GFX9-SDAG-F32DENORM-NEXT:    s_setpc_b64 s[30:31]
-;
-; P0-GFX9-GISEL-F32DENORM-LABEL: mul_fneg_mixed_uses_2:
-; P0-GFX9-GISEL-F32DENORM:       ; %bb.0:
-; P0-GFX9-GISEL-F32DENORM-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; P0-GFX9-GISEL-F32DENORM-NEXT:    v_mul_f32_e64 v4, v0, -v1
-; P0-GFX9-GISEL-F32DENORM-NEXT:    v_fma_f32 v0, v0, -v1, -v2
-; P0-GFX9-GISEL-F32DENORM-NEXT:    v_mul_f32_e32 v1, v4, v3
-; P0-GFX9-GISEL-F32DENORM-NEXT:    s_setpc_b64 s[30:31]
+; GFX12_5-GISEL-LABEL: mul_fneg_mixed_uses_2:
+; GFX12_5-GISEL:       ; %bb.0:
+; GFX12_5-GISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12_5-GISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX12_5-GISEL-NEXT:    v_mul_f32_e64 v1, v0, -v1
+; GFX12_5-GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX12_5-GISEL-NEXT:    v_dual_sub_f32 v0, v1, v2 :: v_dual_mul_f32 v1, v1, v3
+; GFX12_5-GISEL-NEXT:    s_set_pc_i64 s[30:31]
   %mul = fmul contract float %a, %b
   %neg = fneg contract float %mul
   %sub = fsub contract float %neg, %c       ; contractable
@@ -1032,71 +1010,55 @@ define { float, float } @mul_fneg_mixed_uses_2(float %a, float %b, float %c, flo
 ; Should NOT contract -- one path (fneg -> fmul) is not contractable.
 ; Expected: v_mul shared by both paths, no fma contraction.
 define { float, float } @mul_fneg_nonfsub_noncontractable(float %a, float %b, float %c, float %d) {
-; P0-GFX9-SDAG-F32FLUSH-LABEL: mul_fneg_nonfsub_noncontractable:
-; P0-GFX9-SDAG-F32FLUSH:       ; %bb.0:
-; P0-GFX9-SDAG-F32FLUSH-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; P0-GFX9-SDAG-F32FLUSH-NEXT:    v_mul_f32_e32 v4, v0, v1
-; P0-GFX9-SDAG-F32FLUSH-NEXT:    v_mad_f32 v0, v0, v1, v2
-; P0-GFX9-SDAG-F32FLUSH-NEXT:    v_mul_f32_e64 v1, -v4, v3
-; P0-GFX9-SDAG-F32FLUSH-NEXT:    s_setpc_b64 s[30:31]
+; GFX9-SDAG-LABEL: mul_fneg_nonfsub_noncontractable:
+; GFX9-SDAG:       ; %bb.0:
+; GFX9-SDAG-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-SDAG-NEXT:    v_mul_f32_e32 v1, v0, v1
+; GFX9-SDAG-NEXT:    v_add_f32_e32 v0, v1, v2
+; GFX9-SDAG-NEXT:    v_mul_f32_e64 v1, -v1, v3
+; GFX9-SDAG-NEXT:    s_setpc_b64 s[30:31]
 ;
-; P0-GFX9-GISEL-F32FLUSH-LABEL: mul_fneg_nonfsub_noncontractable:
-; P0-GFX9-GISEL-F32FLUSH:       ; %bb.0:
-; P0-GFX9-GISEL-F32FLUSH-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; P0-GFX9-GISEL-F32FLUSH-NEXT:    v_mul_f32_e64 v4, v0, -v1
-; P0-GFX9-GISEL-F32FLUSH-NEXT:    v_mad_f32 v0, v0, v1, v2
-; P0-GFX9-GISEL-F32FLUSH-NEXT:    v_mul_f32_e32 v1, v4, v3
-; P0-GFX9-GISEL-F32FLUSH-NEXT:    s_setpc_b64 s[30:31]
+; GFX9-GISEL-LABEL: mul_fneg_nonfsub_noncontractable:
+; GFX9-GISEL:       ; %bb.0:
+; GFX9-GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-GISEL-NEXT:    v_mul_f32_e32 v1, v0, v1
+; GFX9-GISEL-NEXT:    v_add_f32_e32 v0, v1, v2
+; GFX9-GISEL-NEXT:    v_mul_f32_e64 v1, -v1, v3
+; GFX9-GISEL-NEXT:    s_setpc_b64 s[30:31]
 ;
-; P0-GFX9_4-SDAG-LABEL: mul_fneg_nonfsub_noncontractable:
-; P0-GFX9_4-SDAG:       ; %bb.0:
-; P0-GFX9_4-SDAG-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; P0-GFX9_4-SDAG-NEXT:    v_mul_f32_e64 v4, v0, -v1
-; P0-GFX9_4-SDAG-NEXT:    v_fma_f32 v0, v0, v1, v2
-; P0-GFX9_4-SDAG-NEXT:    v_mul_f32_e32 v1, v4, v3
-; P0-GFX9_4-SDAG-NEXT:    s_setpc_b64 s[30:31]
+; GFX9_4-SDAG-LABEL: mul_fneg_nonfsub_noncontractable:
+; GFX9_4-SDAG:       ; %bb.0:
+; GFX9_4-SDAG-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9_4-SDAG-NEXT:    v_mul_f32_e32 v1, v0, v1
+; GFX9_4-SDAG-NEXT:    v_add_f32_e32 v0, v1, v2
+; GFX9_4-SDAG-NEXT:    v_mul_f32_e64 v1, -v1, v3
+; GFX9_4-SDAG-NEXT:    s_setpc_b64 s[30:31]
 ;
-; P0-GFX9_4-GISEL-LABEL: mul_fneg_nonfsub_noncontractable:
-; P0-GFX9_4-GISEL:       ; %bb.0:
-; P0-GFX9_4-GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; P0-GFX9_4-GISEL-NEXT:    v_mul_f32_e64 v4, v0, -v1
-; P0-GFX9_4-GISEL-NEXT:    v_fma_f32 v0, v0, v1, v2
-; P0-GFX9_4-GISEL-NEXT:    v_mul_f32_e32 v1, v4, v3
-; P0-GFX9_4-GISEL-NEXT:    s_setpc_b64 s[30:31]
+; GFX9_4-GISEL-LABEL: mul_fneg_nonfsub_noncontractable:
+; GFX9_4-GISEL:       ; %bb.0:
+; GFX9_4-GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9_4-GISEL-NEXT:    v_mul_f32_e32 v1, v0, v1
+; GFX9_4-GISEL-NEXT:    v_add_f32_e32 v0, v1, v2
+; GFX9_4-GISEL-NEXT:    v_mul_f32_e64 v1, -v1, v3
+; GFX9_4-GISEL-NEXT:    s_setpc_b64 s[30:31]
 ;
-; P0-GFX12_5-SDAG-LABEL: mul_fneg_nonfsub_noncontractable:
-; P0-GFX12_5-SDAG:       ; %bb.0:
-; P0-GFX12_5-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
-; P0-GFX12_5-SDAG-NEXT:    s_wait_kmcnt 0x0
-; P0-GFX12_5-SDAG-NEXT:    v_dual_mul_f32 v4, v0, -v1 :: v_dual_fma_f32 v0, v0, v1, v2
-; P0-GFX12_5-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; P0-GFX12_5-SDAG-NEXT:    v_mul_f32_e32 v1, v4, v3
-; P0-GFX12_5-SDAG-NEXT:    s_set_pc_i64 s[30:31]
+; GFX12_5-SDAG-LABEL: mul_fneg_nonfsub_noncontractable:
+; GFX12_5-SDAG:       ; %bb.0:
+; GFX12_5-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12_5-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX12_5-SDAG-NEXT:    v_mul_f32_e32 v1, v0, v1
+; GFX12_5-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX12_5-SDAG-NEXT:    v_dual_add_f32 v0, v1, v2 :: v_dual_mul_f32 v1, -v1, v3
+; GFX12_5-SDAG-NEXT:    s_set_pc_i64 s[30:31]
 ;
-; P0-GFX12_5-GISEL-LABEL: mul_fneg_nonfsub_noncontractable:
-; P0-GFX12_5-GISEL:       ; %bb.0:
-; P0-GFX12_5-GISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
-; P0-GFX12_5-GISEL-NEXT:    s_wait_kmcnt 0x0
-; P0-GFX12_5-GISEL-NEXT:    v_dual_mul_f32 v4, v0, -v1 :: v_dual_fma_f32 v0, v0, v1, v2
-; P0-GFX12_5-GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; P0-GFX12_5-GISEL-NEXT:    v_mul_f32_e32 v1, v4, v3
-; P0-GFX12_5-GISEL-NEXT:    s_set_pc_i64 s[30:31]
-;
-; P0-GFX9-SDAG-F32DENORM-LABEL: mul_fneg_nonfsub_noncontractable:
-; P0-GFX9-SDAG-F32DENORM:       ; %bb.0:
-; P0-GFX9-SDAG-F32DENORM-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; P0-GFX9-SDAG-F32DENORM-NEXT:    v_mul_f32_e64 v4, v0, -v1
-; P0-GFX9-SDAG-F32DENORM-NEXT:    v_fma_f32 v0, v0, v1, v2
-; P0-GFX9-SDAG-F32DENORM-NEXT:    v_mul_f32_e32 v1, v4, v3
-; P0-GFX9-SDAG-F32DENORM-NEXT:    s_setpc_b64 s[30:31]
-;
-; P0-GFX9-GISEL-F32DENORM-LABEL: mul_fneg_nonfsub_noncontractable:
-; P0-GFX9-GISEL-F32DENORM:       ; %bb.0:
-; P0-GFX9-GISEL-F32DENORM-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; P0-GFX9-GISEL-F32DENORM-NEXT:    v_mul_f32_e64 v4, v0, -v1
-; P0-GFX9-GISEL-F32DENORM-NEXT:    v_fma_f32 v0, v0, v1, v2
-; P0-GFX9-GISEL-F32DENORM-NEXT:    v_mul_f32_e32 v1, v4, v3
-; P0-GFX9-GISEL-F32DENORM-NEXT:    s_setpc_b64 s[30:31]
+; GFX12_5-GISEL-LABEL: mul_fneg_nonfsub_noncontractable:
+; GFX12_5-GISEL:       ; %bb.0:
+; GFX12_5-GISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12_5-GISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX12_5-GISEL-NEXT:    v_mul_f32_e32 v1, v0, v1
+; GFX12_5-GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX12_5-GISEL-NEXT:    v_dual_add_f32 v0, v1, v2 :: v_dual_mul_f32 v1, -v1, v3
+; GFX12_5-GISEL-NEXT:    s_set_pc_i64 s[30:31]
   %mul = fmul contract float %a, %b
   %neg = fneg float %mul
   %add = fadd contract float %mul, %c       ; contractable
@@ -1112,71 +1074,71 @@ define { float, float } @mul_fneg_nonfsub_noncontractable(float %a, float %b, fl
 ; Should contract -- all paths are contractable.
 ; Expected: two fma/mad instructions, no v_mul.
 define { float, float } @mul_direct_and_fneg_contractable_uses(float %a, float %b, float %c, float %d) {
-; P0-GFX9-SDAG-F32FLUSH-LABEL: mul_direct_and_fneg_contractable_uses:
-; P0-GFX9-SDAG-F32FLUSH:       ; %bb.0:
-; P0-GFX9-SDAG-F32FLUSH-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; P0-GFX9-SDAG-F32FLUSH-NEXT:    v_mad_f32 v2, v0, v1, v2
-; P0-GFX9-SDAG-F32FLUSH-NEXT:    v_mad_f32 v1, -v0, v1, -v3
-; P0-GFX9-SDAG-F32FLUSH-NEXT:    v_mov_b32_e32 v0, v2
-; P0-GFX9-SDAG-F32FLUSH-NEXT:    s_setpc_b64 s[30:31]
+; GFX9-SDAG-F32FLUSH-LABEL: mul_direct_and_fneg_contractable_uses:
+; GFX9-SDAG-F32FLUSH:       ; %bb.0:
+; GFX9-SDAG-F32FLUSH-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-SDAG-F32FLUSH-NEXT:    v_mad_f32 v2, v0, v1, v2
+; GFX9-SDAG-F32FLUSH-NEXT:    v_mad_f32 v1, -v0, v1, -v3
+; GFX9-SDAG-F32FLUSH-NEXT:    v_mov_b32_e32 v0, v2
+; GFX9-SDAG-F32FLUSH-NEXT:    s_setpc_b64 s[30:31]
 ;
-; P0-GFX9-GISEL-F32FLUSH-LABEL: mul_direct_and_fneg_contractable_uses:
-; P0-GFX9-GISEL-F32FLUSH:       ; %bb.0:
-; P0-GFX9-GISEL-F32FLUSH-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; P0-GFX9-GISEL-F32FLUSH-NEXT:    v_mad_f32 v2, v0, v1, v2
-; P0-GFX9-GISEL-F32FLUSH-NEXT:    v_mad_f32 v1, v0, -v1, -v3
-; P0-GFX9-GISEL-F32FLUSH-NEXT:    v_mov_b32_e32 v0, v2
-; P0-GFX9-GISEL-F32FLUSH-NEXT:    s_setpc_b64 s[30:31]
+; GFX9-GISEL-F32FLUSH-LABEL: mul_direct_and_fneg_contractable_uses:
+; GFX9-GISEL-F32FLUSH:       ; %bb.0:
+; GFX9-GISEL-F32FLUSH-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-GISEL-F32FLUSH-NEXT:    v_mad_f32 v2, v0, v1, v2
+; GFX9-GISEL-F32FLUSH-NEXT:    v_mad_f32 v1, v0, -v1, -v3
+; GFX9-GISEL-F32FLUSH-NEXT:    v_mov_b32_e32 v0, v2
+; GFX9-GISEL-F32FLUSH-NEXT:    s_setpc_b64 s[30:31]
 ;
-; P0-GFX9_4-SDAG-LABEL: mul_direct_and_fneg_contractable_uses:
-; P0-GFX9_4-SDAG:       ; %bb.0:
-; P0-GFX9_4-SDAG-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; P0-GFX9_4-SDAG-NEXT:    v_fma_f32 v2, v0, v1, v2
-; P0-GFX9_4-SDAG-NEXT:    v_fma_f32 v1, -v0, v1, -v3
-; P0-GFX9_4-SDAG-NEXT:    v_mov_b32_e32 v0, v2
-; P0-GFX9_4-SDAG-NEXT:    s_setpc_b64 s[30:31]
+; GFX9_4-SDAG-LABEL: mul_direct_and_fneg_contractable_uses:
+; GFX9_4-SDAG:       ; %bb.0:
+; GFX9_4-SDAG-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9_4-SDAG-NEXT:    v_fma_f32 v2, v0, v1, v2
+; GFX9_4-SDAG-NEXT:    v_fma_f32 v1, -v0, v1, -v3
+; GFX9_4-SDAG-NEXT:    v_mov_b32_e32 v0, v2
+; GFX9_4-SDAG-NEXT:    s_setpc_b64 s[30:31]
 ;
-; P0-GFX9_4-GISEL-LABEL: mul_direct_and_fneg_contractable_uses:
-; P0-GFX9_4-GISEL:       ; %bb.0:
-; P0-GFX9_4-GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; P0-GFX9_4-GISEL-NEXT:    v_fma_f32 v2, v0, v1, v2
-; P0-GFX9_4-GISEL-NEXT:    v_fma_f32 v1, v0, -v1, -v3
-; P0-GFX9_4-GISEL-NEXT:    v_mov_b32_e32 v0, v2
-; P0-GFX9_4-GISEL-NEXT:    s_setpc_b64 s[30:31]
+; GFX9_4-GISEL-LABEL: mul_direct_and_fneg_contractable_uses:
+; GFX9_4-GISEL:       ; %bb.0:
+; GFX9_4-GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9_4-GISEL-NEXT:    v_fma_f32 v2, v0, v1, v2
+; GFX9_4-GISEL-NEXT:    v_fma_f32 v1, v0, -v1, -v3
+; GFX9_4-GISEL-NEXT:    v_mov_b32_e32 v0, v2
+; GFX9_4-GISEL-NEXT:    s_setpc_b64 s[30:31]
 ;
-; P0-GFX12_5-SDAG-LABEL: mul_direct_and_fneg_contractable_uses:
-; P0-GFX12_5-SDAG:       ; %bb.0:
-; P0-GFX12_5-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
-; P0-GFX12_5-SDAG-NEXT:    s_wait_kmcnt 0x0
-; P0-GFX12_5-SDAG-NEXT:    v_dual_fma_f32 v2, v0, v1, v2 :: v_dual_fma_f32 v1, -v0, v1, -v3
-; P0-GFX12_5-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; P0-GFX12_5-SDAG-NEXT:    v_mov_b32_e32 v0, v2
-; P0-GFX12_5-SDAG-NEXT:    s_set_pc_i64 s[30:31]
+; GFX12_5-SDAG-LABEL: mul_direct_and_fneg_contractable_uses:
+; GFX12_5-SDAG:       ; %bb.0:
+; GFX12_5-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12_5-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX12_5-SDAG-NEXT:    v_dual_fma_f32 v2, v0, v1, v2 :: v_dual_fma_f32 v1, -v0, v1, -v3
+; GFX12_5-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX12_5-SDAG-NEXT:    v_mov_b32_e32 v0, v2
+; GFX12_5-SDAG-NEXT:    s_set_pc_i64 s[30:31]
 ;
-; P0-GFX12_5-GISEL-LABEL: mul_direct_and_fneg_contractable_uses:
-; P0-GFX12_5-GISEL:       ; %bb.0:
-; P0-GFX12_5-GISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
-; P0-GFX12_5-GISEL-NEXT:    s_wait_kmcnt 0x0
-; P0-GFX12_5-GISEL-NEXT:    v_dual_fma_f32 v2, v0, v1, v2 :: v_dual_fma_f32 v1, v0, -v1, -v3
-; P0-GFX12_5-GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; P0-GFX12_5-GISEL-NEXT:    v_mov_b32_e32 v0, v2
-; P0-GFX12_5-GISEL-NEXT:    s_set_pc_i64 s[30:31]
+; GFX12_5-GISEL-LABEL: mul_direct_and_fneg_contractable_uses:
+; GFX12_5-GISEL:       ; %bb.0:
+; GFX12_5-GISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12_5-GISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX12_5-GISEL-NEXT:    v_dual_fma_f32 v2, v0, v1, v2 :: v_dual_fma_f32 v1, v0, -v1, -v3
+; GFX12_5-GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX12_5-GISEL-NEXT:    v_mov_b32_e32 v0, v2
+; GFX12_5-GISEL-NEXT:    s_set_pc_i64 s[30:31]
 ;
-; P0-GFX9-SDAG-F32DENORM-LABEL: mul_direct_and_fneg_contractable_uses:
-; P0-GFX9-SDAG-F32DENORM:       ; %bb.0:
-; P0-GFX9-SDAG-F32DENORM-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; P0-GFX9-SDAG-F32DENORM-NEXT:    v_fma_f32 v2, v0, v1, v2
-; P0-GFX9-SDAG-F32DENORM-NEXT:    v_fma_f32 v1, -v0, v1, -v3
-; P0-GFX9-SDAG-F32DENORM-NEXT:    v_mov_b32_e32 v0, v2
-; P0-GFX9-SDAG-F32DENORM-NEXT:    s_setpc_b64 s[30:31]
+; GFX9-SDAG-F32DENORM-LABEL: mul_direct_and_fneg_contractable_uses:
+; GFX9-SDAG-F32DENORM:       ; %bb.0:
+; GFX9-SDAG-F32DENORM-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-SDAG-F32DENORM-NEXT:    v_fma_f32 v2, v0, v1, v2
+; GFX9-SDAG-F32DENORM-NEXT:    v_fma_f32 v1, -v0, v1, -v3
+; GFX9-SDAG-F32DENORM-NEXT:    v_mov_b32_e32 v0, v2
+; GFX9-SDAG-F32DENORM-NEXT:    s_setpc_b64 s[30:31]
 ;
-; P0-GFX9-GISEL-F32DENORM-LABEL: mul_direct_and_fneg_contractable_uses:
-; P0-GFX9-GISEL-F32DENORM:       ; %bb.0:
-; P0-GFX9-GISEL-F32DENORM-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; P0-GFX9-GISEL-F32DENORM-NEXT:    v_fma_f32 v2, v0, v1, v2
-; P0-GFX9-GISEL-F32DENORM-NEXT:    v_fma_f32 v1, v0, -v1, -v3
-; P0-GFX9-GISEL-F32DENORM-NEXT:    v_mov_b32_e32 v0, v2
-; P0-GFX9-GISEL-F32DENORM-NEXT:    s_setpc_b64 s[30:31]
+; GFX9-GISEL-F32DENORM-LABEL: mul_direct_and_fneg_contractable_uses:
+; GFX9-GISEL-F32DENORM:       ; %bb.0:
+; GFX9-GISEL-F32DENORM-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-GISEL-F32DENORM-NEXT:    v_fma_f32 v2, v0, v1, v2
+; GFX9-GISEL-F32DENORM-NEXT:    v_fma_f32 v1, v0, -v1, -v3
+; GFX9-GISEL-F32DENORM-NEXT:    v_mov_b32_e32 v0, v2
+; GFX9-GISEL-F32DENORM-NEXT:    s_setpc_b64 s[30:31]
   %mul = fmul contract float %a, %b
   %add = fadd contract float %mul, %c       ; contractable
   %neg = fneg contract float %mul
@@ -1192,71 +1154,71 @@ define { float, float } @mul_direct_and_fneg_contractable_uses(float %a, float %
 ; Should contract -- all paths are contractable.
 ; Expected: two fma/mad instructions, no v_mul.
 define { float, float } @mul_fsub_and_fneg_fsub_contractable(float %a, float %b, float %c, float %d) {
-; P0-GFX9-SDAG-F32FLUSH-LABEL: mul_fsub_and_fneg_fsub_contractable:
-; P0-GFX9-SDAG-F32FLUSH:       ; %bb.0:
-; P0-GFX9-SDAG-F32FLUSH-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; P0-GFX9-SDAG-F32FLUSH-NEXT:    v_mad_f32 v2, v0, v1, -v2
-; P0-GFX9-SDAG-F32FLUSH-NEXT:    v_mad_f32 v1, -v0, v1, -v3
-; P0-GFX9-SDAG-F32FLUSH-NEXT:    v_mov_b32_e32 v0, v2
-; P0-GFX9-SDAG-F32FLUSH-NEXT:    s_setpc_b64 s[30:31]
+; GFX9-SDAG-F32FLUSH-LABEL: mul_fsub_and_fneg_fsub_contractable:
+; GFX9-SDAG-F32FLUSH:       ; %bb.0:
+; GFX9-SDAG-F32FLUSH-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-SDAG-F32FLUSH-NEXT:    v_mad_f32 v2, v0, v1, -v2
+; GFX9-SDAG-F32FLUSH-NEXT:    v_mad_f32 v1, -v0, v1, -v3
+; GFX9-SDAG-F32FLUSH-NEXT:    v_mov_b32_e32 v0, v2
+; GFX9-SDAG-F32FLUSH-NEXT:    s_setpc_b64 s[30:31]
 ;
-; P0-GFX9-GISEL-F32FLUSH-LABEL: mul_fsub_and_fneg_fsub_contractable:
-; P0-GFX9-GISEL-F32FLUSH:       ; %bb.0:
-; P0-GFX9-GISEL-F32FLUSH-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; P0-GFX9-GISEL-F32FLUSH-NEXT:    v_mad_f32 v2, v0, v1, -v2
-; P0-GFX9-GISEL-F32FLUSH-NEXT:    v_mad_f32 v1, v0, -v1, -v3
-; P0-GFX9-GISEL-F32FLUSH-NEXT:    v_mov_b32_e32 v0, v2
-; P0-GFX9-GISEL-F32FLUSH-NEXT:    s_setpc_b64 s[30:31]
+; GFX9-GISEL-F32FLUSH-LABEL: mul_fsub_and_fneg_fsub_contractable:
+; GFX9-GISEL-F32FLUSH:       ; %bb.0:
+; GFX9-GISEL-F32FLUSH-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-GISEL-F32FLUSH-NEXT:    v_mad_f32 v2, v0, v1, -v2
+; GFX9-GISEL-F32FLUSH-NEXT:    v_mad_f32 v1, v0, -v1, -v3
+; GFX9-GISEL-F32FLUSH-NEXT:    v_mov_b32_e32 v0, v2
+; GFX9-GISEL-F32FLUSH-NEXT:    s_setpc_b64 s[30:31]
 ;
-; P0-GFX9_4-SDAG-LABEL: mul_fsub_and_fneg_fsub_contractable:
-; P0-GFX9_4-SDAG:       ; %bb.0:
-; P0-GFX9_4-SDAG-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; P0-GFX9_4-SDAG-NEXT:    v_fma_f32 v2, v0, v1, -v2
-; P0-GFX9_4-SDAG-NEXT:    v_fma_f32 v1, -v0, v1, -v3
-; P0-GFX9_4-SDAG-NEXT:    v_mov_b32_e32 v0, v2
-; P0-GFX9_4-SDAG-NEXT:    s_setpc_b64 s[30:31]
+; GFX9_4-SDAG-LABEL: mul_fsub_and_fneg_fsub_contractable:
+; GFX9_4-SDAG:       ; %bb.0:
+; GFX9_4-SDAG-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9_4-SDAG-NEXT:    v_fma_f32 v2, v0, v1, -v2
+; GFX9_4-SDAG-NEXT:    v_fma_f32 v1, -v0, v1, -v3
+; GFX9_4-SDAG-NEXT:    v_mov_b32_e32 v0, v2
+; GFX9_4-SDAG-NEXT:    s_setpc_b64 s[30:31]
 ;
-; P0-GFX9_4-GISEL-LABEL: mul_fsub_and_fneg_fsub_contractable:
-; P0-GFX9_4-GISEL:       ; %bb.0:
-; P0-GFX9_4-GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; P0-GFX9_4-GISEL-NEXT:    v_fma_f32 v2, v0, v1, -v2
-; P0-GFX9_4-GISEL-NEXT:    v_fma_f32 v1, v0, -v1, -v3
-; P0-GFX9_4-GISEL-NEXT:    v_mov_b32_e32 v0, v2
-; P0-GFX9_4-GISEL-NEXT:    s_setpc_b64 s[30:31]
+; GFX9_4-GISEL-LABEL: mul_fsub_and_fneg_fsub_contractable:
+; GFX9_4-GISEL:       ; %bb.0:
+; GFX9_4-GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9_4-GISEL-NEXT:    v_fma_f32 v2, v0, v1, -v2
+; GFX9_4-GISEL-NEXT:    v_fma_f32 v1, v0, -v1, -v3
+; GFX9_4-GISEL-NEXT:    v_mov_b32_e32 v0, v2
+; GFX9_4-GISEL-NEXT:    s_setpc_b64 s[30:31]
 ;
-; P0-GFX12_5-SDAG-LABEL: mul_fsub_and_fneg_fsub_contractable:
-; P0-GFX12_5-SDAG:       ; %bb.0:
-; P0-GFX12_5-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
-; P0-GFX12_5-SDAG-NEXT:    s_wait_kmcnt 0x0
-; P0-GFX12_5-SDAG-NEXT:    v_dual_fma_f32 v2, v0, v1, -v2 :: v_dual_fma_f32 v1, -v0, v1, -v3
-; P0-GFX12_5-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; P0-GFX12_5-SDAG-NEXT:    v_mov_b32_e32 v0, v2
-; P0-GFX12_5-SDAG-NEXT:    s_set_pc_i64 s[30:31]
+; GFX12_5-SDAG-LABEL: mul_fsub_and_fneg_fsub_contractable:
+; GFX12_5-SDAG:       ; %bb.0:
+; GFX12_5-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12_5-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX12_5-SDAG-NEXT:    v_dual_fma_f32 v2, v0, v1, -v2 :: v_dual_fma_f32 v1, -v0, v1, -v3
+; GFX12_5-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX12_5-SDAG-NEXT:    v_mov_b32_e32 v0, v2
+; GFX12_5-SDAG-NEXT:    s_set_pc_i64 s[30:31]
 ;
-; P0-GFX12_5-GISEL-LABEL: mul_fsub_and_fneg_fsub_contractable:
-; P0-GFX12_5-GISEL:       ; %bb.0:
-; P0-GFX12_5-GISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
-; P0-GFX12_5-GISEL-NEXT:    s_wait_kmcnt 0x0
-; P0-GFX12_5-GISEL-NEXT:    v_dual_fma_f32 v2, v0, v1, -v2 :: v_dual_fma_f32 v1, v0, -v1, -v3
-; P0-GFX12_5-GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; P0-GFX12_5-GISEL-NEXT:    v_mov_b32_e32 v0, v2
-; P0-GFX12_5-GISEL-NEXT:    s_set_pc_i64 s[30:31]
+; GFX12_5-GISEL-LABEL: mul_fsub_and_fneg_fsub_contractable:
+; GFX12_5-GISEL:       ; %bb.0:
+; GFX12_5-GISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12_5-GISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX12_5-GISEL-NEXT:    v_dual_fma_f32 v2, v0, v1, -v2 :: v_dual_fma_f32 v1, v0, -v1, -v3
+; GFX12_5-GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX12_5-GISEL-NEXT:    v_mov_b32_e32 v0, v2
+; GFX12_5-GISEL-NEXT:    s_set_pc_i64 s[30:31]
 ;
-; P0-GFX9-SDAG-F32DENORM-LABEL: mul_fsub_and_fneg_fsub_contractable:
-; P0-GFX9-SDAG-F32DENORM:       ; %bb.0:
-; P0-GFX9-SDAG-F32DENORM-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; P0-GFX9-SDAG-F32DENORM-NEXT:    v_fma_f32 v2, v0, v1, -v2
-; P0-GFX9-SDAG-F32DENORM-NEXT:    v_fma_f32 v1, -v0, v1, -v3
-; P0-GFX9-SDAG-F32DENORM-NEXT:    v_mov_b32_e32 v0, v2
-; P0-GFX9-SDAG-F32DENORM-NEXT:    s_setpc_b64 s[30:31]
+; GFX9-SDAG-F32DENORM-LABEL: mul_fsub_and_fneg_fsub_contractable:
+; GFX9-SDAG-F32DENORM:       ; %bb.0:
+; GFX9-SDAG-F32DENORM-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-SDAG-F32DENORM-NEXT:    v_fma_f32 v2, v0, v1, -v2
+; GFX9-SDAG-F32DENORM-NEXT:    v_fma_f32 v1, -v0, v1, -v3
+; GFX9-SDAG-F32DENORM-NEXT:    v_mov_b32_e32 v0, v2
+; GFX9-SDAG-F32DENORM-NEXT:    s_setpc_b64 s[30:31]
 ;
-; P0-GFX9-GISEL-F32DENORM-LABEL: mul_fsub_and_fneg_fsub_contractable:
-; P0-GFX9-GISEL-F32DENORM:       ; %bb.0:
-; P0-GFX9-GISEL-F32DENORM-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; P0-GFX9-GISEL-F32DENORM-NEXT:    v_fma_f32 v2, v0, v1, -v2
-; P0-GFX9-GISEL-F32DENORM-NEXT:    v_fma_f32 v1, v0, -v1, -v3
-; P0-GFX9-GISEL-F32DENORM-NEXT:    v_mov_b32_e32 v0, v2
-; P0-GFX9-GISEL-F32DENORM-NEXT:    s_setpc_b64 s[30:31]
+; GFX9-GISEL-F32DENORM-LABEL: mul_fsub_and_fneg_fsub_contractable:
+; GFX9-GISEL-F32DENORM:       ; %bb.0:
+; GFX9-GISEL-F32DENORM-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-GISEL-F32DENORM-NEXT:    v_fma_f32 v2, v0, v1, -v2
+; GFX9-GISEL-F32DENORM-NEXT:    v_fma_f32 v1, v0, -v1, -v3
+; GFX9-GISEL-F32DENORM-NEXT:    v_mov_b32_e32 v0, v2
+; GFX9-GISEL-F32DENORM-NEXT:    s_setpc_b64 s[30:31]
   %mul = fmul contract float %a, %b
   %sub1 = fsub contract float %mul, %c      ; contractable
   %neg = fneg contract float %mul

--- a/llvm/test/CodeGen/AMDGPU/mad-combine.ll
+++ b/llvm/test/CodeGen/AMDGPU/mad-combine.ll
@@ -960,12 +960,11 @@ define amdgpu_kernel void @combine_to_mad_fsub_2_f32_2uses_mul(ptr addrspace(1) 
 ; SI-STD-NEXT:    buffer_load_dword v5, v[0:1], s[4:7], 0 addr64 offset:12 glc
 ; SI-STD-NEXT:    s_waitcnt vmcnt(0)
 ; SI-STD-NEXT:    s_mov_b64 s[2:3], s[6:7]
-; SI-STD-NEXT:    v_mul_f32_e32 v6, v2, v3
-; SI-STD-NEXT:    v_mad_f32 v2, -v2, v3, -v4
-; SI-STD-NEXT:    v_sub_f32_e32 v3, v6, v5
-; SI-STD-NEXT:    buffer_store_dword v2, v[0:1], s[0:3], 0 addr64
+; SI-STD-NEXT:    v_mad_f32 v4, -v2, v3, -v4
+; SI-STD-NEXT:    v_mad_f32 v2, v2, v3, -v5
+; SI-STD-NEXT:    buffer_store_dword v4, v[0:1], s[0:3], 0 addr64
 ; SI-STD-NEXT:    s_waitcnt vmcnt(0)
-; SI-STD-NEXT:    buffer_store_dword v3, v[0:1], s[0:3], 0 addr64 offset:4
+; SI-STD-NEXT:    buffer_store_dword v2, v[0:1], s[0:3], 0 addr64 offset:4
 ; SI-STD-NEXT:    s_waitcnt vmcnt(0)
 ; SI-STD-NEXT:    s_endpgm
 ;


### PR DESCRIPTION
Supersedes #169735 (PR 3/5). Split into a stack of 5 PRs per reviewer request.

This patch extends `allMulUsesCanBeContracted()` to recognize `fmul -> fneg -> fsub` chains as contractable uses in both DAGCombiner.cpp and CombinerHelper.cpp.

Additionally, the patch makes the following test changes:

1. Modify the checks for and enable the tests in fma-multiple-uses-contraction.ll that are specific to FNEG. All other tests are blocked for now.
2. Reverted mad-combine.ll back to its original state before the stack.

_This PR was split from the original #169735 with the assistance of [Claude Code](https://claude.ai/code)._