### PR TITLE
[clang][Parser] Fix an assertion during decltype error recovery with missing ;

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -449,6 +449,7 @@ Miscellaneous Clang Crashes Fixed
 - Fixed a crash when evaluating ``__is_bitwise_cloneable`` on invalid record types. (#GH183707)
 - Fixed an assertion failure when casting a function pointer with a target with a non-default program address space. (#GH186210)
 - Fixed a crash when ``decltype(__builtin_FUNCTION())`` is used as a template type argument. (#GH167433)
+- Fixed an assertion failure when parsing an invalid ``decltype`` specifier with missing parentheses or extra semicolons. (#GH188014)
 
 OpenACC Specific Changes
 ------------------------

--- a/clang/lib/Parse/ParseDeclCXX.cpp
+++ b/clang/lib/Parse/ParseDeclCXX.cpp
@@ -1082,7 +1082,6 @@ SourceLocation Parser::ParseDecltypeSpecifier(DeclSpec &DS) {
             PP.RevertCachedTokens(2);
             ConsumeToken(); // the semi.
             EndLoc = ConsumeAnyToken();
-            assert(Tok.is(tok::semi));
           } else {
             EndLoc = Tok.getLocation();
           }

--- a/clang/test/Parser/decltype-gh188014.cpp
+++ b/clang/test/Parser/decltype-gh188014.cpp
@@ -1,0 +1,4 @@
+// RUN: %clang_cc1 -fsyntax-only -verify -std=c++11 %s
+
+// GH188014
+& decltype ( ( union { // expected-error {{expected ';' after union}} expected-error {{expected '}'}} expected-error {{expected ')'}} expected-error {{expected expression}} expected-error {{expected unqualified-id}} expected-note {{to match this '('}} expected-note {{to match this '{'}}


### PR DESCRIPTION
Fix an assertion failure in `ParseDecltypeSpecifier` when parsing malformed expressions e.g. `decltype(union { ... )`.

When a class/union definition is missing a semicolon, clang's error recovery may synthetically set the current token to `tok::semi` without actually inserting it into the preprocessor's backtrack cache, see https://github.com/llvm/llvm-project/blob/9096c9cda3df4d09c9c6e4efa1a07a232a9ac8f8/clang/lib/Parse/ParseDeclCXX.cpp#L1920-L1927

If `ParseDecltypeSpecifier` later encounters this synthetic semicolon during its own error recovery, its attempts to revert the cache and re-lex the tokens will lead to reading  unexpected tokens from the historical stream, failing the strict 
`Tok.is(tok::semi)` assertion.

This patch removes this assertion, acknowledging that during invalid parses and error recovery, the preprocessor's cache state may not strictly align with the parser's simulated state.


Fixes: #188014