### PR TITLE
[flang][cuda] Add CUFRegisterManagedVariable runtime entry for __cudaRegisterManagedVar

### DIFF
--- a/flang-rt/lib/cuda/registration.cpp
+++ b/flang-rt/lib/cuda/registration.cpp
@@ -24,6 +24,9 @@ extern void __cudaRegisterFunction(void **fatCubinHandle, const char *hostFun,
 extern void __cudaRegisterVar(void **fatCubinHandle, char *hostVar,
     const char *deviceAddress, const char *deviceName, int ext, size_t size,
     int constant, int global);
+extern void __cudaRegisterManagedVar(void **fatCubinHandle,
+    void **hostVarPtrAddress, char *deviceAddress, const char *deviceName,
+    int ext, size_t size, int constant, int global);
 
 void *RTDECL(CUFRegisterModule)(void *data) {
   void **fatHandle{__cudaRegisterFatBinary(data)};
@@ -40,6 +43,11 @@ void RTDEF(CUFRegisterFunction)(
 void RTDEF(CUFRegisterVariable)(
     void **module, char *varSym, const char *varName, int64_t size) {
   __cudaRegisterVar(module, varSym, varName, varName, 0, size, 0, 0);
+}
+
+void RTDEF(CUFRegisterManagedVariable)(
+    void **module, void **varSym, const char *varName, int64_t size) {
+  __cudaRegisterManagedVar(module, varSym, varName, varName, 0, size, 0, 0);
 }
 
 } // extern "C"

--- a/flang/include/flang/Runtime/CUDA/registration.h
+++ b/flang/include/flang/Runtime/CUDA/registration.h
@@ -28,6 +28,10 @@ void RTDECL(CUFRegisterFunction)(
 void RTDECL(CUFRegisterVariable)(
     void **module, char *varSym, const char *varName, int64_t size);
 
+/// Register a managed variable.
+void RTDECL(CUFRegisterManagedVariable)(
+    void **module, void **varSym, const char *varName, int64_t size);
+
 } // extern "C"
 
 } // namespace Fortran::runtime::cuda


### PR DESCRIPTION
Add CUFRegisterManagedVariable runtime wrapper in flang-rt that calls __cudaRegisterManagedVar. 
This is preparation for supporting non-allocatable managed variables.
No functional change -- nothing calls this yet.