### PR TITLE
[MLIR] Fix a problem with parseOptionalAttribute

### DIFF
--- a/mlir/include/mlir/IR/OpImplementation.h
+++ b/mlir/include/mlir/IR/OpImplementation.h
@@ -1156,17 +1156,32 @@ public:
   virtual OptionalParseResult parseOptionalAttribute(SymbolRefAttr &result,
                                                      Type type = {}) = 0;
 
+  /// Parse an optional attribute that must begin with a '#' hash identifier
+  /// (i.e. `#dialect.mnemonic<...>`). Returns std::nullopt if the next token
+  /// is not a hash identifier, without consuming any tokens.
+  virtual OptionalParseResult parseOptionalHashAttribute(Attribute &result,
+                                                         Type type = {}) = 0;
+
   /// Parse an optional attribute of a specific typed result. This overload
   /// handles concrete attribute types (e.g. FloatAttr) that are not covered by
   /// a dedicated virtual overload. It parses any attribute and then validates
   /// that the result is of the expected type, emitting an error if not.
+  ///
+  /// For attribute types that define a custom `parse` method (i.e. AttrDef
+  /// types with assemblyFormat), parsing is restricted to `#`-prefixed
+  /// attribute syntax to avoid greedily consuming tokens (like `@symbol`)
+  /// that are intended for later format elements.
   template <
       typename AttrType,
       typename = std::enable_if_t<!llvm::is_one_of<
           AttrType, Attribute, ArrayAttr, StringAttr, SymbolRefAttr>::value>>
   OptionalParseResult parseOptionalAttribute(AttrType &result, Type type = {}) {
     Attribute attr;
-    OptionalParseResult parseResult = parseOptionalAttribute(attr, type);
+    OptionalParseResult parseResult;
+    if constexpr (detect_has_parse_method<AttrType>::value)
+      parseResult = parseOptionalHashAttribute(attr, type);
+    else
+      parseResult = parseOptionalAttribute(attr, type);
     if (!parseResult.has_value() || failed(*parseResult))
       return parseResult;
     result = dyn_cast<AttrType>(attr);

--- a/mlir/lib/AsmParser/AsmParserImpl.h
+++ b/mlir/lib/AsmParser/AsmParserImpl.h
@@ -458,6 +458,13 @@ public:
                                              Type type) override {
     return parser.parseOptionalAttribute(result, type);
   }
+  OptionalParseResult parseOptionalHashAttribute(Attribute &result,
+                                                 Type type) override {
+    if (parser.getToken().isNot(Token::hash_identifier))
+      return std::nullopt;
+    result = parser.parseAttribute(type);
+    return success(static_cast<bool>(result));
+  }
   OptionalParseResult parseOptionalAttribute(ArrayAttr &result,
                                              Type type) override {
     return parser.parseOptionalAttribute(result, type);

--- a/mlir/test/lib/Dialect/Test/TestOpsSyntax.td
+++ b/mlir/test/lib/Dialect/Test/TestOpsSyntax.td
@@ -477,6 +477,16 @@ def FormatOptionalPropDict : TEST_Op<"format_optional_prop_dict"> {
   let assemblyFormat = "prop-dict attr-dict";
 }
 
+// Test that an optional AttrDef attribute (with a custom parse method) does not
+// greedily consume tokens meant for a later symbol name in the format.
+def FormatOptionalAttrDefBeforeSymbol
+    : TEST_Op<"format_opt_attrdef_before_symbol", [Symbol]> {
+  let arguments = (ins
+    OptionalAttr<CompoundAttrNested>:$opt_compound,
+    SymbolNameAttr:$sym_name);
+  let assemblyFormat = "(qualified($opt_compound)^)? $sym_name attr-dict";
+}
+
 def FormatCompoundAttr : TEST_Op<"format_compound_attr"> {
   let arguments = (ins CompoundAttrA:$compound);
   let assemblyFormat = "$compound attr-dict-with-keyword";

--- a/mlir/test/mlir-tblgen/op-format.mlir
+++ b/mlir/test/mlir-tblgen/op-format.mlir
@@ -307,6 +307,19 @@ test.format_optional_prop_dict <{b = 2 : i32}>
 test.format_optional_prop_dict <{a = ["foo"], b = 2 : i32}>
 
 //===----------------------------------------------------------------------===//
+// Optional AttrDef attribute before symbol name
+//===----------------------------------------------------------------------===//
+
+// Verify that an optional AttrDef attribute does not greedily consume the @
+// token when the attribute is absent.
+// CHECK: test.format_opt_attrdef_before_symbol @opt_attrdef_sym1
+test.format_opt_attrdef_before_symbol @opt_attrdef_sym1
+
+// Verify round-trip when the optional AttrDef attribute is present (full form).
+// CHECK: test.format_opt_attrdef_before_symbol #test.cmpnd_nested<nested = <1, !test.smpla, [5, 6]>> @opt_attrdef_sym2
+test.format_opt_attrdef_before_symbol #test.cmpnd_nested<nested = <1, !test.smpla, [5, 6]>> @opt_attrdef_sym2
+
+//===----------------------------------------------------------------------===//
 // Format a custom attribute
 //===----------------------------------------------------------------------===//
 


### PR DESCRIPTION
The recent changes to introduce a non-virtual template overload of `parseOptionalAttribute` triggered a regression in CIR where we had a default-valued attribute using a dialect-specific enum followed by a required attribute that also used a dialect-specific enum. The `parseOptionalAttribute` change caused our test for the required attribute being missing to fail with the wrong message. Debugging indicated that `parseOptionalAttribute` was consuming an unrelated token in the operation (in this case `@`), causing an incorrect diagnosis of the problem.

This change updates the new `parseOptionalAttribute` implementation to specifically look for attributes in the `#dialect.mnemnoc<>` form before falling back on the default handling.

This fixes a regression in `clang/test/CIR/IR/invalid-linkage.cir`

Assisted by: Cursor / claude-4.6-opus-high