### PR TITLE
[MLIR] [Mem2Reg] [NFC] Update pass documentation

### DIFF
--- a/mlir/include/mlir/Transforms/Passes.td
+++ b/mlir/include/mlir/Transforms/Passes.td
@@ -373,17 +373,14 @@ def Mem2Reg : Pass<"mem2reg"> {
   let description = [{
     This pass removes loads out of and stores into a memory slot, and turns
     them into direct uses of SSA values. This is done generically using the
-    `PromotableAllocationOpInterface`, `PromotableOpInterface` and
-    `PromotableMemOpInterface` interfaces.
+    `PromotableAllocationOpInterface`, `PromotableOpInterface`,
+    `PromotableMemOpInterface` and `PromotableRegionOpInterface` interfaces.
 
     This pass will attempt to compute which definitions of the content of
     the memory slot reach operations that use the memory slot pointer. It
     will rewire or remove operations that use the slot pointer so they no
     longer use it. If any of this is not possible, the IR will be left
     without mutation.
-
-    This pass only supports unstructured control-flow. Promotion of operations
-    within subregions will not happen.
   }];
 
   let options = [


### PR DESCRIPTION
In #185036, we added region control flow support but forgot to update the pass declaration documentation. This NFC addresses this.