### PR TITLE
libclc: Use nextup and nextdown in place of nextafter

### DIFF
--- a/libclc/clc/lib/generic/conversion/clc_convert_float.inc
+++ b/libclc/clc/lib/generic/conversion/clc_convert_float.inc
@@ -118,8 +118,8 @@ _CLC_OVERLOAD _CLC_DEF __CLC_GENTYPE __CLC_XCONCAT(__CLC_FUNCTION,
 #else
   __CLC_GENTYPE_SRC y = __CLC_XCONCAT(__clc_convert_, __CLC_GENTYPE_SRC)(r);
 #endif
-  __CLC_GENTYPE sel = __clc_select(r, __clc_nextafter(r, __CLC_GENTYPE_INF),
-                                   __CLC_CONVERT_S_GENTYPE(y < x));
+  __CLC_GENTYPE sel =
+      __clc_select(r, __clc_nextup(r), __CLC_CONVERT_S_GENTYPE(y < x));
 #if defined(__CLC_I2F) && (__CLC_FPSIZE == 16) && (__CLC_GENSIZE_SRC >= 16)
   half dst_min = -0x1.ffcp+15h;
   sel = __clc_max(sel, (__CLC_GENTYPE)dst_min);
@@ -140,8 +140,7 @@ _CLC_OVERLOAD _CLC_DEF __CLC_GENTYPE __CLC_XCONCAT(__CLC_FUNCTION,
 #if defined(__CLC_I2F) && (__CLC_GENSIZE_SRC >= __CLC_FPSIZE)
   c = c || __CLC_CONVERT_S_GENTYPE((__CLC_GENTYPE_SRC)__CLC_SRC_MAX == x);
 #endif
-  __CLC_GENTYPE sel =
-      __clc_select(r, __clc_nextafter(r, -__CLC_GENTYPE_INF), c);
+  __CLC_GENTYPE sel = __clc_select(r, __clc_nextdown(r), c);
 #if defined(__CLC_I2F) && (__CLC_FPSIZE == 16) && (__CLC_GENSIZE_SRC >= 16)
 #if defined(__CLC_GEN_S) && (__CLC_GENSIZE_SRC == 16)
   // short is 16 bits signed, so the maximum value rounded to negative infinity

--- a/libclc/clc/lib/generic/conversion/clc_convert_float.inc
+++ b/libclc/clc/lib/generic/conversion/clc_convert_float.inc
@@ -93,8 +93,7 @@ _CLC_OVERLOAD _CLC_DEF __CLC_GENTYPE __CLC_XCONCAT(__CLC_FUNCTION,
 #if defined(__CLC_I2F) && (__CLC_GENSIZE_SRC >= __CLC_FPSIZE)
   c = c || __CLC_CONVERT_S_GENTYPE((__CLC_GENTYPE_SRC)__CLC_SRC_MAX == x);
 #endif
-  __CLC_GENTYPE sel = __clc_select(
-      r, __clc_nextafter(r, __clc_sign(r) * -__CLC_GENTYPE_INF), c);
+  __CLC_GENTYPE sel = __clc_select(r, __clc_nextafter(r, __CLC_FP_LIT(0.0)), c);
 #if defined(__CLC_I2F) && (__CLC_FPSIZE == 16) && (__CLC_GENSIZE_SRC >= 16)
 #if defined(__CLC_GEN_S) && (__CLC_GENSIZE_SRC == 16)
   // short is 16 bits signed, so the maximum value rounded to zero is

--- a/libclc/clc/lib/generic/conversion/clc_convert_float2float.cl
+++ b/libclc/clc/lib/generic/conversion/clc_convert_float2float.cl
@@ -11,6 +11,8 @@
 #include "clc/float/definitions.h"
 #include "clc/math/clc_fabs.h"
 #include "clc/math/clc_nextafter.h"
+#include "clc/math/clc_nextdown.h"
+#include "clc/math/clc_nextup.h"
 #include "clc/relational/clc_select.h"
 #include "clc/shared/clc_clamp.h"
 

--- a/libclc/clc/lib/generic/conversion/clc_convert_int2float.cl
+++ b/libclc/clc/lib/generic/conversion/clc_convert_int2float.cl
@@ -12,6 +12,8 @@
 #include "clc/integer/clc_abs.h"
 #include "clc/integer/definitions.h"
 #include "clc/math/clc_nextafter.h"
+#include "clc/math/clc_nextdown.h"
+#include "clc/math/clc_nextup.h"
 #include "clc/relational/clc_select.h"
 #include "clc/shared/clc_clamp.h"
 #include "clc/shared/clc_max.h"


### PR DESCRIPTION
Unfortunately it seems the optimizer isn't able to clean this
up, so this is a code quality improvement.