### PR TITLE
[flang][cuda] Fix const mismatch in CUFRegisterManagedVariable for __cudaRegisterManagedVar

### DIFF
--- a/flang-rt/lib/cuda/registration.cpp
+++ b/flang-rt/lib/cuda/registration.cpp
@@ -46,7 +46,7 @@ void RTDEF(CUFRegisterVariable)(
 }
 
 void RTDEF(CUFRegisterManagedVariable)(
-    void **module, void **varSym, const char *varName, int64_t size) {
+    void **module, void **varSym, char *varName, int64_t size) {
   __cudaRegisterManagedVar(module, varSym, varName, varName, 0, size, 0, 0);
 }
 

--- a/flang/include/flang/Runtime/CUDA/registration.h
+++ b/flang/include/flang/Runtime/CUDA/registration.h
@@ -30,7 +30,7 @@ void RTDECL(CUFRegisterVariable)(
 
 /// Register a managed variable.
 void RTDECL(CUFRegisterManagedVariable)(
-    void **module, void **varSym, const char *varName, int64_t size);
+    void **module, void **varSym, char *varName, int64_t size);
 
 } // extern "C"
 


### PR DESCRIPTION
Change varName parameter from `const char *` to `char *` in CUFRegisterManagedVariable to match the CUDA runtime API signature of __cudaRegisterManagedVar, which declares deviceAddress as `char *`.