### PR TITLE
[flang][cuda] Do not check for implicit transfer on managed symbols

### DIFF
--- a/flang/include/flang/Evaluate/tools.h
+++ b/flang/include/flang/Evaluate/tools.h
@@ -1297,6 +1297,7 @@ bool CheckForCoindexedObject(parser::ContextualMessages &,
     const std::string &argName);
 
 bool IsCUDADeviceSymbol(const Symbol &sym);
+bool IsCUDADeviceOnlySymbol(const Symbol &sym);
 
 inline bool IsCUDAManagedOrUnifiedSymbol(const Symbol &sym) {
   if (const auto *details =
@@ -1358,6 +1359,8 @@ inline bool IsCUDADataTransfer(const A &lhs, const B &rhs) {
   // - Only managed or unifed symbols are involved on RHS and LHS.
   // - LHS is managed or unified and the RHS is host only.
   if ((lhsNbManagedSymbols >= 1 && rhsNbManagedSymbols == rhsNbSymbols) ||
+      (lhsNbManagedSymbols == 0 && rhsNbManagedSymbols >= 1 &&
+          rhsNbManagedSymbols == rhsNbSymbols) ||
       (lhsNbManagedSymbols >= 1 && rhsNbSymbols == 0)) {
     return false;
   }

--- a/flang/lib/Evaluate/tools.cpp
+++ b/flang/lib/Evaluate/tools.cpp
@@ -1143,7 +1143,7 @@ bool HasCUDAImplicitTransfer(const Expr<SomeType> &expr) {
       bool isComponent{sym.owner().IsDerivedType()};
       bool skipComponent{false};
       if (!skipNext) {
-        if (IsCUDADeviceSymbol(sym)) {
+        if (IsCUDADeviceOnlySymbol(sym)) {
           deviceSymbols.insert(sym);
         } else if (isComponent) {
           skipComponent = true; // Component is not device. Look on the base.
@@ -1168,6 +1168,16 @@ bool IsCUDADeviceSymbol(const Symbol &sym) {
   } else if (const auto *details =
                  sym.GetUltimate().detailsIf<semantics::AssocEntityDetails>()) {
     return GetNbOfCUDADeviceSymbols(details->expr()) > 0;
+  }
+  return false;
+}
+
+bool IsCUDADeviceOnlySymbol(const Symbol &sym) {
+  if (const auto *details =
+          sym.GetUltimate().detailsIf<semantics::ObjectEntityDetails>()) {
+    return details->cudaDataAttr() &&
+        (*details->cudaDataAttr() == common::CUDADataAttr::Device ||
+            *details->cudaDataAttr() == common::CUDADataAttr::Constant);
   }
   return false;
 }

--- a/flang/lib/Semantics/check-cuda.cpp
+++ b/flang/lib/Semantics/check-cuda.cpp
@@ -759,10 +759,11 @@ void CUDAChecker::Enter(const parser::AssignmentStmt &x) {
 
   int nbLhs{evaluate::GetNbOfCUDADeviceSymbols(assign->lhs)};
   int nbRhs{evaluate::GetNbOfCUDADeviceSymbols(assign->rhs)};
+  int nbRhsManaged{evaluate::GetNbOfCUDAManagedOrUnifiedSymbols(assign->rhs)};
 
   // device to host transfer with more than one device object on the rhs is not
   // legal.
-  if (nbLhs == 0 && nbRhs > 1) {
+  if (nbLhs == 0 && nbRhs > 1 && nbRhsManaged != nbRhs) {
     context_.Say(lhsLoc,
         "More than one reference to a CUDA object on the right hand side of the assignment"_err_en_US);
   }

--- a/flang/test/Lower/CUDA/cuda-data-transfer-implicit.cuf
+++ b/flang/test/Lower/CUDA/cuda-data-transfer-implicit.cuf
@@ -1,0 +1,17 @@
+! RUN: bbc -emit-hlfir -fopenacc -fcuda -gpu=managed %s -o - | FileCheck %s
+
+subroutine test()
+  real, allocatable :: a(:), b(:)
+  real :: c(10)
+
+  allocate(a(10))
+  allocate(b(10))
+  do i = 1, 10
+  c(i) = a(i) + b(i) ! no implicit data transfer generated
+  end do
+  deallocate(a)
+  deallocate(b)
+end subroutine test
+
+! CHECK-NOT: cuf.data_transfer
+! CHECK: hlfir.assign

--- a/flang/test/Lower/CUDA/cuda-data-transfer.cuf
+++ b/flang/test/Lower/CUDA/cuda-data-transfer.cuf
@@ -626,9 +626,7 @@ subroutine sub33(m, n)
 end subroutine
 
 ! CHECK-LABEL: func.func @_QPsub33
-! CHECK: cuf.data_transfer 
-! CHECK-COUNT-2: hlfir.elemental
-! CHECK: hlfir.assign
+! CHECK-NOT: cuf.data_transfer 
 
 subroutine sub34(n)
   integer :: n

--- a/flang/test/Lower/CUDA/cuda-managed.cuf
+++ b/flang/test/Lower/CUDA/cuda-managed.cuf
@@ -17,7 +17,4 @@ subroutine testr2(N1,N2)
 end subroutine
 
 ! CHECK-LABEL: func.func @_QPtestr2
-! CHECK:  %[[MANAGED:.*]]:2 = hlfir.declare %22(%23) {data_attr = #cuf.cuda<managed>, uniq_name = "_QFtestr2Eai4"} : (!fir.ref<!fir.array<?x?xf32>>, !fir.shape<2>) -> (!fir.box<!fir.array<?x?xf32>>, !fir.ref<!fir.array<?x?xf32>>)
-! CHECK: %[[TMP:.*]] = fir.allocmem !fir.array<?x?xf32>, %16, %21 {bindc_name = ".tmp", uniq_name = ""}
-! CHECK: %[[TMP_DECL:.*]]:2 = hlfir.declare %[[TMP]](%{{.*}}) {uniq_name = ".tmp"} : (!fir.heap<!fir.array<?x?xf32>>, !fir.shape<2>) -> (!fir.box<!fir.array<?x?xf32>>, !fir.heap<!fir.array<?x?xf32>>)
-! CHECK: cuf.data_transfer %[[MANAGED]]#1 to %[[TMP_DECL]]#0 {transfer_kind = #cuf.cuda_transfer<device_host>} : !fir.ref<!fir.array<?x?xf32>>, !fir.box<!fir.array<?x?xf32>>
+! CHECK-NOT: cuf.data_transfer


### PR DESCRIPTION
Avoid to trigger a semantic error when only managed symbols are on the right hand side. 