### PR TITLE
[Offload][OpenMP][libdevice] Make check to enter state machine architecture dependent

### DIFF
--- a/openmp/device/include/Configuration.h
+++ b/openmp/device/include/Configuration.h
@@ -62,45 +62,6 @@ bool mayUseThreadStates();
 /// parallelism, or if it was explicitly disabled by the user.
 bool mayUseNestedParallelism();
 
-/// Returns true if the current thread should enter the generic state machine.
-/// On some architectures, some threads should not enter the state machine to
-/// avoid warp-level barrier forwarding issues during initialization.
-/// On other architectures, all threads must enter the state machine to satisfy
-/// the requirements of workgroup synchronization.
-static inline bool shouldEnterStateMachine(bool IsSPMD);
-
-} // namespace config
-} // namespace ompx
-
-#include "Mapping.h"
-
-namespace ompx {
-namespace config {
-
-static inline bool shouldEnterStateMachine(bool IsSPMD) {
-#if defined(__NVPTX__) || defined(__AMDGPU__)
-  // This check is important for NVIDIA Pascal (but not Volta) and AMD
-  // GPU. In those cases, a single thread can apparently satisfy a barrier on
-  // behalf of all threads in the same warp. Thus, it would not be safe for
-  // other threads in the main thread's warp to reach the first
-  // synchronize::threads call in genericStateMachine before the main thread
-  // reaches its corresponding synchronize::threads call: that would permit all
-  // active worker threads to proceed before the main thread has actually set
-  // state::ParallelRegionFn, and then they would immediately quit without
-  // doing any work.  mapping::getMaxTeamThreads() does not include any of the
-  // main thread's warp, so none of its threads can ever be active worker
-  // threads.
-  return mapping::getThreadIdInBlock() < mapping::getMaxTeamThreads(IsSPMD);
-#else
-  // On other architectures (e.g., Intel GPUs) all threads must enter the state
-  // machine to satisfy the requirements of workgroup of synchronize::threads
-  // call in genericStateMachine. Otherwise, the workers will wait on the
-  // call to synchronize::threads forever and never proceed.
-  (void)IsSPMD;
-  return true;
-#endif
-}
-
 } // namespace config
 } // namespace ompx
 

--- a/openmp/device/include/Configuration.h
+++ b/openmp/device/include/Configuration.h
@@ -62,6 +62,45 @@ bool mayUseThreadStates();
 /// parallelism, or if it was explicitly disabled by the user.
 bool mayUseNestedParallelism();
 
+/// Returns true if the current thread should enter the generic state machine.
+/// On some architectures, some threads should not enter the state machine to
+/// avoid warp-level barrier forwarding issues during initialization.
+/// On other architectures, all threads must enter the state machine to satisfy
+/// the requirements of workgroup synchronization.
+static inline bool shouldEnterStateMachine(bool IsSPMD);
+
+} // namespace config
+} // namespace ompx
+
+#include "Mapping.h"
+
+namespace ompx {
+namespace config {
+
+static inline bool shouldEnterStateMachine(bool IsSPMD) {
+#if defined(__NVPTX__) || defined(__AMDGPU__)
+  // This check is important for NVIDIA Pascal (but not Volta) and AMD
+  // GPU. In those cases, a single thread can apparently satisfy a barrier on
+  // behalf of all threads in the same warp. Thus, it would not be safe for
+  // other threads in the main thread's warp to reach the first
+  // synchronize::threads call in genericStateMachine before the main thread
+  // reaches its corresponding synchronize::threads call: that would permit all
+  // active worker threads to proceed before the main thread has actually set
+  // state::ParallelRegionFn, and then they would immediately quit without
+  // doing any work.  mapping::getMaxTeamThreads() does not include any of the
+  // main thread's warp, so none of its threads can ever be active worker
+  // threads.
+  return mapping::getThreadIdInBlock() < mapping::getMaxTeamThreads(IsSPMD);
+#else
+  // On other architectures (e.g., Intel GPUs) all threads must enter the state
+  // machine to satisfy the requirements of workgroup of synchronize::threads
+  // call in genericStateMachine. Otherwise, the workers will wait on the
+  // call to synchronize::threads forever and never proceed.
+  (void)IsSPMD;
+  return true;
+#endif
+}
+
 } // namespace config
 } // namespace ompx
 

--- a/openmp/device/src/Kernel.cpp
+++ b/openmp/device/src/Kernel.cpp
@@ -44,6 +44,31 @@ initializeRuntime(bool IsSPMD, KernelEnvironmentTy &KernelEnvironment,
   workshare::init(IsSPMD);
 }
 
+/// Returns true if the current thread should enter the generic state machine.
+static bool shouldEnterStateMachine(bool IsSPMD) {
+#if defined(__NVPTX__) || defined(__AMDGPU__)
+  // This check is important for NVIDIA Pascal (but not Volta) and AMD
+  // GPU. In those cases, a single thread can apparently satisfy a barrier on
+  // behalf of all threads in the same warp. Thus, it would not be safe for
+  // other threads in the main thread's warp to reach the first
+  // synchronize::threads call in genericStateMachine before the main thread
+  // reaches its corresponding synchronize::threads call: that would permit all
+  // active worker threads to proceed before the main thread has actually set
+  // state::ParallelRegionFn, and then they would immediately quit without
+  // doing any work.  mapping::getMaxTeamThreads() does not include any of the
+  // main thread's warp, so none of its threads can ever be active worker
+  // threads.
+  return mapping::getThreadIdInBlock() < mapping::getMaxTeamThreads(IsSPMD);
+#else
+  // On other architectures (e.g., Intel GPUs) all threads must enter the state
+  // machine to satisfy the requirements of workgroup of synchronize::threads
+  // call in genericStateMachine. Otherwise, the workers will wait on the
+  // call to synchronize::threads forever and never proceed.
+  (void)IsSPMD;
+  return true;
+#endif
+}
+
 /// Simple generic state machine for worker threads.
 static void genericStateMachine(IdentTy *Ident) {
   uint32_t TId = mapping::getThreadIdInBlock();
@@ -111,7 +136,7 @@ int32_t __kmpc_target_init(KernelEnvironmentTy &KernelEnvironment,
   // be an active worker thread. The shouldEnterStateMachine check is
   // architecture-specific and handles platforms where warp-level barrier
   // forwarding could cause races during state machine initialization.
-  if (UseGenericStateMachine && config::shouldEnterStateMachine(IsSPMD))
+  if (UseGenericStateMachine && shouldEnterStateMachine(IsSPMD))
     genericStateMachine(KernelEnvironment.Ident);
 
   return mapping::getThreadIdInBlock();

--- a/openmp/device/src/Kernel.cpp
+++ b/openmp/device/src/Kernel.cpp
@@ -108,21 +108,10 @@ int32_t __kmpc_target_init(KernelEnvironmentTy &KernelEnvironment,
     return -1;
 
   // Enter the generic state machine if enabled and if this thread can possibly
-  // be an active worker thread.
-  //
-  // The latter check is important for NVIDIA Pascal (but not Volta) and AMD
-  // GPU.  In those cases, a single thread can apparently satisfy a barrier on
-  // behalf of all threads in the same warp.  Thus, it would not be safe for
-  // other threads in the main thread's warp to reach the first
-  // synchronize::threads call in genericStateMachine before the main thread
-  // reaches its corresponding synchronize::threads call: that would permit all
-  // active worker threads to proceed before the main thread has actually set
-  // state::ParallelRegionFn, and then they would immediately quit without
-  // doing any work.  mapping::getMaxTeamThreads() does not include any of the
-  // main thread's warp, so none of its threads can ever be active worker
-  // threads.
-  if (UseGenericStateMachine &&
-      mapping::getThreadIdInBlock() < mapping::getMaxTeamThreads(IsSPMD))
+  // be an active worker thread. The shouldEnterStateMachine check is
+  // architecture-specific and handles platforms where warp-level barrier
+  // forwarding could cause races during state machine initialization.
+  if (UseGenericStateMachine && config::shouldEnterStateMachine(IsSPMD))
     genericStateMachine(KernelEnvironment.Ident);
 
   return mapping::getThreadIdInBlock();


### PR DESCRIPTION
The genericStateMachine call uses synchronize::thread wich is expected to be implemented using a workgroup level barrier. 
Currently as in some other architectures where if threads in the same warp as the main thread reach the barrier may cause a race condition there's a condition that makes some threads not enter the state machine.
But in Intel GPUs all threads must reach the barrier for it to be completed, otherwise the threads in the state machine never make progress.

This PR moves the condition into an architecture-dependent config so it can work correctly for both kinds of hardware.
