### PR TITLE
Add spirv-val compilation step when targeting SPIR-V

### DIFF
--- a/clang/include/clang/Basic/DiagnosticDriverKinds.td
+++ b/clang/include/clang/Basic/DiagnosticDriverKinds.td
@@ -873,6 +873,9 @@ def err_drv_hlsl_bad_shader_unsupported : Error<
 def warn_drv_dxc_missing_dxv : Warning<
   "dxv not found; resulting DXIL will not be validated or signed for use in "
   "release environment">, InGroup<DXILValidation>;
+def warn_drv_dxc_missing_spirv_val : Warning<
+  "spirv-val not found; resulting SPIR-V will not be validated">,
+  InGroup<SPIRVValidation>;
 
 def err_drv_invalid_range_dxil_validator_version : Error<
   "invalid validator version : %0; validator version must be less than or "

--- a/clang/include/clang/Basic/DiagnosticGroups.td
+++ b/clang/include/clang/Basic/DiagnosticGroups.td
@@ -1875,6 +1875,9 @@ def HLSLExplicitBinding : DiagGroup<"hlsl-explicit-binding">;
 // Warnings for DXIL validation
 def DXILValidation : DiagGroup<"dxil-validation">;
 
+// Warnings for SPIRV validation
+def SPIRVValidation : DiagGroup<"spirv-validation">;
+
 // Warning for HLSL API availability
 def HLSLAvailability : DiagGroup<"hlsl-availability">;
 

--- a/clang/include/clang/Options/Options.td
+++ b/clang/include/clang/Options/Options.td
@@ -9976,6 +9976,8 @@ def dxc_hlsl_version : Option<["/", "-"], "HV", KIND_JOINED_OR_SEPARATE>,
                      Values<"2016, 2017, 2018, 2021, 202x, 202y">;
 def dxc_validator_path_EQ : Joined<["--"], "dxv-path=">, Group<dxc_Group>,
   HelpText<"DXIL validator installation path">;
+def spirv_validator_path_EQ : Joined<["--"], "spirv-val-path=">, Group<dxc_Group>,
+  HelpText<"SPIRV validator installation path">;
 def dxc_disable_validation : DXCFlag<"Vd">,
   HelpText<"Disable validation">;
 def dxc_gis : DXCFlag<"Gis">,

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -4704,9 +4704,10 @@ void Driver::BuildActions(Compilation &C, DerivedArgList &Args,
         I.second->claim();
     }
   }
-
-  if (C.getDefaultToolChain().getTriple().isDXIL() ||
-      C.getDefaultToolChain().getTriple().isSPIRV()) {
+  
+  llvm::Triple TargetTriple(C.getDriver().getTargetTriple());
+  if (TargetTriple.getOS() == llvm::Triple::Vulkan ||
+      TargetTriple.getOS() == llvm::Triple::ShaderModel) {
     const auto &TC =
         static_cast<const toolchains::HLSLToolChain &>(C.getDefaultToolChain());
 

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -4704,7 +4704,7 @@ void Driver::BuildActions(Compilation &C, DerivedArgList &Args,
         I.second->claim();
     }
   }
-  
+
   llvm::Triple TargetTriple(C.getDriver().getTargetTriple());
   if (TargetTriple.getOS() == llvm::Triple::Vulkan ||
       TargetTriple.getOS() == llvm::Triple::ShaderModel) {

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -4739,6 +4739,18 @@ void Driver::BuildActions(Compilation &C, DerivedArgList &Args,
     }
   }
 
+  if (C.getDefaultToolChain().getTriple().isSPIRV()) {
+    const auto &TC =
+        static_cast<const toolchains::HLSLToolChain &>(C.getDefaultToolChain());
+
+    // Call spirv-val for SPIR-V when -Vd not in Args.
+    if (TC.requiresValidation(Args)) {
+      Action *LastAction = Actions.back();
+      Actions.push_back(
+          C.MakeAction<BinaryAnalyzeJobAction>(LastAction, types::TY_Object));
+    }
+  }
+
   // Claim ignored clang-cl options.
   Args.ClaimAllArgs(options::OPT_cl_ignored_Group);
 }
@@ -5381,11 +5393,9 @@ void Driver::BuildJobs(Compilation &C) const {
     unsigned NumOutputs = 0;
     unsigned NumIfsOutputs = 0;
     for (const Action *A : C.getActions()) {
-      // The actions below do not increase the number of outputs, when operating
-      // on DX containers.
-      if (A->getType() == types::TY_DX_CONTAINER &&
-          (A->getKind() == clang::driver::Action::BinaryAnalyzeJobClass ||
-           A->getKind() == clang::driver::Action::BinaryTranslatorJobClass))
+      // The actions below do not increase the number of outputs.
+      if (A->getKind() == clang::driver::Action::BinaryAnalyzeJobClass ||
+          A->getKind() == clang::driver::Action::BinaryTranslatorJobClass)
         continue;
 
       if (A->getType() != types::TY_Nothing &&
@@ -6434,10 +6444,22 @@ const char *Driver::GetNamedOutputPath(Compilation &C, const JobAction &JA,
       const char *Suffix = types::getTypeTempSuffix(JA.getType(), true);
       return CreateTempFile(C, Split.first, Suffix, false);
     }
-    // We don't have SPIRV-val integrated (yet), so for now we can assume this
-    // is the final output.
+
     assert(C.getDefaultToolChain().getTriple().isSPIRV());
-    return C.addResultFile(C.getArgs().MakeArgString(FoValue.str()), &JA);
+    const auto &TC =
+        static_cast<const toolchains::HLSLToolChain &>(C.getDefaultToolChain());
+
+    // If this is the last job in the compilation for this input, and Fo is
+    // non-empty, we can return the Fo file (the final output)
+    if (TC.isLastJob(C.getArgs(), JA.getKind()) && !FoValue.empty())
+      return C.addResultFile(C.getArgs().MakeArgString(FoValue.str()), &JA);
+
+    // Otherwise, create a temporary file for validation (like DXIL creates
+    // temp files).
+    StringRef Name = llvm::sys::path::filename(BaseInput);
+    std::pair<StringRef, StringRef> Split = Name.split('.');
+    const char *Suffix = types::getTypeTempSuffix(JA.getType(), true);
+    return CreateTempFile(C, Split.first, Suffix, false);
   }
 
   // Is this the assembly listing for /FA?

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -4705,7 +4705,8 @@ void Driver::BuildActions(Compilation &C, DerivedArgList &Args,
     }
   }
 
-  if (C.getDefaultToolChain().getTriple().isDXIL()) {
+  if (C.getDefaultToolChain().getTriple().isDXIL() ||
+      C.getDefaultToolChain().getTriple().isSPIRV()) {
     const auto &TC =
         static_cast<const toolchains::HLSLToolChain &>(C.getDefaultToolChain());
 
@@ -4719,11 +4720,16 @@ void Driver::BuildActions(Compilation &C, DerivedArgList &Args,
             C.MakeAction<ObjcopyJobAction>(LastAction, types::TY_Object));
     }
 
-    // Call validator for dxil when -Vd not in Args.
-    if (TC.requiresValidation(Args)) {
+    // Call validator when -Vd not in Args.
+    auto ValInfo = TC.getValidationInfo(Args);
+    if (ValInfo.NeedsValidation) {
       Action *LastAction = Actions.back();
-      Actions.push_back(C.MakeAction<BinaryAnalyzeJobAction>(
-          LastAction, types::TY_DX_CONTAINER));
+      if (LastAction->getType() == types::TY_Object) {
+        types::ID OutType =
+            ValInfo.ProducesOutput ? types::TY_DX_CONTAINER : types::TY_Object;
+        Actions.push_back(
+            C.MakeAction<BinaryAnalyzeJobAction>(LastAction, OutType));
+      }
     }
 
     // Call metal-shaderconverter when targeting metal.
@@ -4736,19 +4742,6 @@ void Driver::BuildActions(Compilation &C, DerivedArgList &Args,
           LastAction->getType() == types::TY_Object)
         Actions.push_back(C.MakeAction<BinaryTranslatorJobAction>(
             LastAction, types::TY_DX_CONTAINER));
-    }
-  }
-
-  if (C.getDefaultToolChain().getTriple().isSPIRV()) {
-    const auto &TC =
-        static_cast<const toolchains::HLSLToolChain &>(C.getDefaultToolChain());
-
-    // Call spirv-val for SPIR-V when -Vd not in Args.
-    if (TC.requiresValidation(Args)) {
-      Action *LastAction = Actions.back();
-      if (LastAction->getType() == types::TY_Object)
-        Actions.push_back(
-            C.MakeAction<BinaryAnalyzeJobAction>(LastAction, types::TY_Object));
     }
   }
 
@@ -6430,33 +6423,16 @@ const char *Driver::GetNamedOutputPath(Compilation &C, const JobAction &JA,
        C.getArgs().hasArg(options::OPT_dxc_Fo)) ||
       JA.getType() == types::TY_DX_CONTAINER) {
     StringRef FoValue = C.getArgs().getLastArgValue(options::OPT_dxc_Fo);
-    // If we are targeting DXIL and not validating/translating/objcopying, we
-    // should set the final result file. Otherwise we should emit to a
-    // temporary.
-    if (C.getDefaultToolChain().getTriple().isDXIL()) {
-      const auto &TC = static_cast<const toolchains::HLSLToolChain &>(
-          C.getDefaultToolChain());
-      // Fo can be empty here if the validator is running for a compiler flow
-      // that is using Fc or just printing disassembly.
-      if (TC.isLastJob(C.getArgs(), JA.getKind()) && !FoValue.empty())
-        return C.addResultFile(C.getArgs().MakeArgString(FoValue.str()), &JA);
-      StringRef Name = llvm::sys::path::filename(BaseInput);
-      std::pair<StringRef, StringRef> Split = Name.split('.');
-      const char *Suffix = types::getTypeTempSuffix(JA.getType(), true);
-      return CreateTempFile(C, Split.first, Suffix, false);
-    }
-
-    assert(C.getDefaultToolChain().getTriple().isSPIRV());
+    assert((C.getDefaultToolChain().getTriple().isDXIL() ||
+            C.getDefaultToolChain().getTriple().isSPIRV()) &&
+           "expected DXIL or SPIR-V triple for HLSL output path");
     const auto &TC =
         static_cast<const toolchains::HLSLToolChain &>(C.getDefaultToolChain());
-
-    // If this is the last job in the compilation for this input, and Fo is
-    // non-empty, we can return the Fo file (the final output)
-    if (TC.isLastJob(C.getArgs(), JA.getKind()) && !FoValue.empty())
+    // Fo can be empty here if the validator is running for a compiler flow
+    // that is using Fc or just printing disassembly.
+    if (TC.isLastOutputProducingJob(C.getArgs(), JA.getKind()) &&
+        !FoValue.empty())
       return C.addResultFile(C.getArgs().MakeArgString(FoValue.str()), &JA);
-
-    // Otherwise, create a temporary file for validation (like DXIL creates
-    // temp files).
     StringRef Name = llvm::sys::path::filename(BaseInput);
     std::pair<StringRef, StringRef> Split = Name.split('.');
     const char *Suffix = types::getTypeTempSuffix(JA.getType(), true);

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -4746,8 +4746,9 @@ void Driver::BuildActions(Compilation &C, DerivedArgList &Args,
     // Call spirv-val for SPIR-V when -Vd not in Args.
     if (TC.requiresValidation(Args)) {
       Action *LastAction = Actions.back();
-      Actions.push_back(
-          C.MakeAction<BinaryAnalyzeJobAction>(LastAction, types::TY_Object));
+      if (LastAction->getType() == types::TY_Object)
+        Actions.push_back(
+            C.MakeAction<BinaryAnalyzeJobAction>(LastAction, types::TY_Object));
     }
   }
 

--- a/clang/lib/Driver/ToolChains/HLSL.cpp
+++ b/clang/lib/Driver/ToolChains/HLSL.cpp
@@ -325,6 +325,13 @@ void tools::hlsl::SPIRV_Validator::ConstructJob(
   ArgStringList CmdArgs;
   assert(Inputs.size() == 1 && "Unable to handle multiple inputs.");
   const InputInfo &Input = Inputs[0];
+
+  const llvm::Triple &T = getToolChain().getTriple();
+  CmdArgs.push_back("--target-env");
+  CmdArgs.push_back(Args.MakeArgString(T.getOSName()));
+
+  CmdArgs.push_back("--scalar-block-layout");
+
   CmdArgs.push_back(Input.getFilename());
 
   const char *Exec = Args.MakeArgString(SPIRVValPath);
@@ -608,7 +615,7 @@ bool HLSLToolChain::requiresValidation(DerivedArgList &Args,
   if (DisableValidation || !HasFo)
     return false;
 
-  if (getArch() != llvm::Triple::spirv) {
+  if (getArch() == llvm::Triple::dxil) {
     std::string DxvPath = GetProgramPath("dxv");
     if (DxvPath != "dxv")
       return true;

--- a/clang/lib/Driver/ToolChains/HLSL.cpp
+++ b/clang/lib/Driver/ToolChains/HLSL.cpp
@@ -315,6 +315,23 @@ void tools::hlsl::Validator::ConstructJob(Compilation &C, const JobAction &JA,
                                          Exec, CmdArgs, Inputs, Input));
 }
 
+void tools::hlsl::SPIRV_Validator::ConstructJob(
+    Compilation &C, const JobAction &JA, const InputInfo &Output,
+    const InputInfoList &Inputs, const ArgList &Args,
+    const char *LinkingOutput) const {
+  std::string SPIRVValPath = getToolChain().GetProgramPath("spirv-val");
+  assert(SPIRVValPath != "spirv-val" && "cannot find spirv-val");
+
+  ArgStringList CmdArgs;
+  assert(Inputs.size() == 1 && "Unable to handle multiple inputs.");
+  const InputInfo &Input = Inputs[0];
+  CmdArgs.push_back(Input.getFilename());
+
+  const char *Exec = Args.MakeArgString(SPIRVValPath);
+  C.addCommand(std::make_unique<Command>(JA, *this, ResponseFileSupport::None(),
+                                         Exec, CmdArgs, Inputs, Input));
+}
+
 void tools::hlsl::MetalConverter::ConstructJob(
     Compilation &C, const JobAction &JA, const InputInfo &Output,
     const InputInfoList &Inputs, const ArgList &Args,
@@ -384,12 +401,20 @@ HLSLToolChain::HLSLToolChain(const Driver &D, const llvm::Triple &Triple,
   if (Args.hasArg(options::OPT_dxc_validator_path_EQ))
     getProgramPaths().push_back(
         Args.getLastArgValue(options::OPT_dxc_validator_path_EQ).str());
+  if (Args.hasArg(options::OPT_spirv_validator_path_EQ))
+    getProgramPaths().push_back(
+        Args.getLastArgValue(options::OPT_spirv_validator_path_EQ).str());
 }
 
 Tool *clang::driver::toolchains::HLSLToolChain::getTool(
     Action::ActionClass AC) const {
   switch (AC) {
   case Action::BinaryAnalyzeJobClass:
+    if (getTriple().isSPIRV()) {
+      if (!SPIRVValidator)
+        SPIRVValidator.reset(new tools::hlsl::SPIRV_Validator(*this));
+      return SPIRVValidator.get();
+    }
     if (!Validator)
       Validator.reset(new tools::hlsl::Validator(*this));
     return Validator.get();
@@ -574,18 +599,31 @@ HLSLToolChain::TranslateArgs(const DerivedArgList &Args, StringRef BoundArch,
   return DAL;
 }
 
-bool HLSLToolChain::requiresValidation(DerivedArgList &Args) const {
-  if (!Args.hasArg(options::OPT_dxc_Fo))
+bool HLSLToolChain::requiresValidation(DerivedArgList &Args,
+                                       bool Diagnose) const {
+  bool HasFo = Args.hasArg(options::OPT_dxc_Fo);
+  bool DisableValidation =
+      Args.getLastArg(options::OPT_dxc_disable_validation) != nullptr;
+
+  if (DisableValidation || !HasFo)
     return false;
 
-  if (Args.getLastArg(options::OPT_dxc_disable_validation))
-    return false;
+  if (getArch() != llvm::Triple::spirv) {
+    std::string DxvPath = GetProgramPath("dxv");
+    if (DxvPath != "dxv")
+      return true;
 
-  std::string DxvPath = GetProgramPath("dxv");
-  if (DxvPath != "dxv")
+    if (Diagnose)
+      getDriver().Diag(diag::warn_drv_dxc_missing_dxv);
+    return false;
+  }
+
+  std::string SpirvValPath = GetProgramPath("spirv-val");
+  if (SpirvValPath != "spirv-val")
     return true;
 
-  getDriver().Diag(diag::warn_drv_dxc_missing_dxv);
+  if (Diagnose)
+    getDriver().Diag(diag::warn_drv_dxc_missing_spirv_val);
   return false;
 }
 
@@ -604,8 +642,14 @@ bool HLSLToolChain::isLastJob(DerivedArgList &Args,
   // Note: we check in the reverse order of execution
   if (requiresBinaryTranslation(Args))
     return AC == Action::Action::BinaryTranslatorJobClass;
-  if (requiresValidation(Args))
+  // For SPIR-V, spirv-val is a pure validator that doesn't produce output
+  // files, so the compile step is the output-producing step. For DXIL, dxv
+  // validates and signs, producing the final output.
+  if (requiresValidation(Args, /*Diagnose=*/false)) {
+    if (getTriple().isSPIRV())
+      return AC != Action::Action::BinaryAnalyzeJobClass;
     return AC == Action::Action::BinaryAnalyzeJobClass;
+  }
   if (requiresObjcopy(Args))
     return AC == Action::Action::ObjcopyJobClass;
 

--- a/clang/lib/Driver/ToolChains/HLSL.cpp
+++ b/clang/lib/Driver/ToolChains/HLSL.cpp
@@ -305,30 +305,29 @@ void tools::hlsl::Validator::ConstructJob(Compilation &C, const JobAction &JA,
   const InputInfo &Input = Inputs[0];
 
   const llvm::Triple &T = getToolChain().getTriple();
+  std::string ExecPath;
   if (T.isSPIRV()) {
-    std::string SPIRVValPath = getToolChain().GetProgramPath("spirv-val");
-    assert(SPIRVValPath != "spirv-val" && "cannot find spirv-val");
+    ExecPath = getToolChain().GetProgramPath("spirv-val");
+    assert(ExecPath != "spirv-val" && "cannot find spirv-val");
 
     CmdArgs.push_back("--target-env");
     CmdArgs.push_back(Args.MakeArgString(T.getOSName()));
     CmdArgs.push_back("--scalar-block-layout");
     CmdArgs.push_back(Input.getFilename());
-
-    const char *Exec = Args.MakeArgString(SPIRVValPath);
-    C.addCommand(std::make_unique<Command>(
-        JA, *this, ResponseFileSupport::None(), Exec, CmdArgs, Inputs, Input));
-  } else {
-    std::string DxvPath = getToolChain().GetProgramPath("dxv");
-    assert(DxvPath != "dxv" && "cannot find dxv");
+  } else if (T.isDXIL()) {
+    ExecPath = getToolChain().GetProgramPath("dxv");
+    assert(ExecPath != "dxv" && "cannot find dxv");
 
     CmdArgs.push_back(Input.getFilename());
     CmdArgs.push_back("-o");
     CmdArgs.push_back(Output.getFilename());
-
-    const char *Exec = Args.MakeArgString(DxvPath);
-    C.addCommand(std::make_unique<Command>(
-        JA, *this, ResponseFileSupport::None(), Exec, CmdArgs, Inputs, Input));
+  } else {
+    llvm_unreachable("unexpected triple for HLSL validation");
   }
+
+  const char *Exec = Args.MakeArgString(ExecPath);
+  C.addCommand(std::make_unique<Command>(JA, *this, ResponseFileSupport::None(),
+                                         Exec, CmdArgs, Inputs, Input));
 }
 
 void tools::hlsl::MetalConverter::ConstructJob(
@@ -593,35 +592,43 @@ HLSLToolChain::TranslateArgs(const DerivedArgList &Args, StringRef BoundArch,
   return DAL;
 }
 
-bool HLSLToolChain::requiresValidation(DerivedArgList &Args,
-                                       bool Diagnose) const {
+HLSLToolChain::ValidationInfo
+HLSLToolChain::getValidationInfo(DerivedArgList &Args, bool Diagnose) const {
+  ValidationInfo Info;
+
   bool HasFo = Args.hasArg(options::OPT_dxc_Fo);
   bool DisableValidation =
       Args.getLastArg(options::OPT_dxc_disable_validation) != nullptr;
 
   if (DisableValidation || !HasFo)
-    return false;
+    return Info;
 
-  if (getArch() == llvm::Triple::dxil) {
+  if (getTriple().isDXIL()) {
     std::string DxvPath = GetProgramPath("dxv");
-    if (DxvPath != "dxv")
-      return true;
+    if (DxvPath != "dxv") {
+      Info.NeedsValidation = true;
+      Info.ProducesOutput = true;
+      return Info;
+    }
 
     if (Diagnose)
       getDriver().Diag(diag::warn_drv_dxc_missing_dxv);
-    return false;
+    return Info;
   }
 
   if (getTriple().isSPIRV()) {
     std::string SpirvValPath = GetProgramPath("spirv-val");
-    if (SpirvValPath != "spirv-val")
-      return true;
+    if (SpirvValPath != "spirv-val") {
+      Info.NeedsValidation = true;
+      Info.ProducesOutput = false;
+      return Info;
+    }
 
     if (Diagnose)
       getDriver().Diag(diag::warn_drv_dxc_missing_spirv_val);
   }
 
-  return false;
+  return Info;
 }
 
 bool HLSLToolChain::requiresBinaryTranslation(DerivedArgList &Args) const {
@@ -634,18 +641,16 @@ bool HLSLToolChain::requiresObjcopy(DerivedArgList &Args) const {
           Args.hasArg(options::OPT_dxc_Frs) || isRootSignatureTarget(Args));
 }
 
-bool HLSLToolChain::isLastJob(DerivedArgList &Args,
-                              Action::ActionClass AC) const {
+bool HLSLToolChain::isLastOutputProducingJob(DerivedArgList &Args,
+                                             Action::ActionClass AC) const {
   // Note: we check in the reverse order of execution
   if (requiresBinaryTranslation(Args))
     return AC == Action::Action::BinaryTranslatorJobClass;
-  // For SPIR-V, spirv-val is a pure validator that doesn't produce output
-  // files, so the compile step is the last output-producing job. For DXIL,
-  // dxv validates and signs, producing the final output.
-  if (requiresValidation(Args, /*Diagnose=*/false)) {
-    if (getTriple().isSPIRV())
-      return AC == Action::Action::AssembleJobClass;
-    return AC == Action::Action::BinaryAnalyzeJobClass;
+  auto ValInfo = getValidationInfo(Args, /*Diagnose=*/false);
+  if (ValInfo.NeedsValidation) {
+    if (ValInfo.ProducesOutput)
+      return AC == Action::Action::BinaryAnalyzeJobClass;
+    return AC == Action::Action::AssembleJobClass;
   }
   if (requiresObjcopy(Args))
     return AC == Action::Action::ObjcopyJobClass;

--- a/clang/lib/Driver/ToolChains/HLSL.cpp
+++ b/clang/lib/Driver/ToolChains/HLSL.cpp
@@ -300,43 +300,35 @@ void tools::hlsl::Validator::ConstructJob(Compilation &C, const JobAction &JA,
                                           const InputInfoList &Inputs,
                                           const ArgList &Args,
                                           const char *LinkingOutput) const {
-  std::string DxvPath = getToolChain().GetProgramPath("dxv");
-  assert(DxvPath != "dxv" && "cannot find dxv");
-
-  ArgStringList CmdArgs;
-  assert(Inputs.size() == 1 && "Unable to handle multiple inputs.");
-  const InputInfo &Input = Inputs[0];
-  CmdArgs.push_back(Input.getFilename());
-  CmdArgs.push_back("-o");
-  CmdArgs.push_back(Output.getFilename());
-
-  const char *Exec = Args.MakeArgString(DxvPath);
-  C.addCommand(std::make_unique<Command>(JA, *this, ResponseFileSupport::None(),
-                                         Exec, CmdArgs, Inputs, Input));
-}
-
-void tools::hlsl::SPIRV_Validator::ConstructJob(
-    Compilation &C, const JobAction &JA, const InputInfo &Output,
-    const InputInfoList &Inputs, const ArgList &Args,
-    const char *LinkingOutput) const {
-  std::string SPIRVValPath = getToolChain().GetProgramPath("spirv-val");
-  assert(SPIRVValPath != "spirv-val" && "cannot find spirv-val");
-
   ArgStringList CmdArgs;
   assert(Inputs.size() == 1 && "Unable to handle multiple inputs.");
   const InputInfo &Input = Inputs[0];
 
   const llvm::Triple &T = getToolChain().getTriple();
-  CmdArgs.push_back("--target-env");
-  CmdArgs.push_back(Args.MakeArgString(T.getOSName()));
+  if (T.isSPIRV()) {
+    std::string SPIRVValPath = getToolChain().GetProgramPath("spirv-val");
+    assert(SPIRVValPath != "spirv-val" && "cannot find spirv-val");
 
-  CmdArgs.push_back("--scalar-block-layout");
+    CmdArgs.push_back("--target-env");
+    CmdArgs.push_back(Args.MakeArgString(T.getOSName()));
+    CmdArgs.push_back("--scalar-block-layout");
+    CmdArgs.push_back(Input.getFilename());
 
-  CmdArgs.push_back(Input.getFilename());
+    const char *Exec = Args.MakeArgString(SPIRVValPath);
+    C.addCommand(std::make_unique<Command>(
+        JA, *this, ResponseFileSupport::None(), Exec, CmdArgs, Inputs, Input));
+  } else {
+    std::string DxvPath = getToolChain().GetProgramPath("dxv");
+    assert(DxvPath != "dxv" && "cannot find dxv");
 
-  const char *Exec = Args.MakeArgString(SPIRVValPath);
-  C.addCommand(std::make_unique<Command>(JA, *this, ResponseFileSupport::None(),
-                                         Exec, CmdArgs, Inputs, Input));
+    CmdArgs.push_back(Input.getFilename());
+    CmdArgs.push_back("-o");
+    CmdArgs.push_back(Output.getFilename());
+
+    const char *Exec = Args.MakeArgString(DxvPath);
+    C.addCommand(std::make_unique<Command>(
+        JA, *this, ResponseFileSupport::None(), Exec, CmdArgs, Inputs, Input));
+  }
 }
 
 void tools::hlsl::MetalConverter::ConstructJob(
@@ -417,11 +409,6 @@ Tool *clang::driver::toolchains::HLSLToolChain::getTool(
     Action::ActionClass AC) const {
   switch (AC) {
   case Action::BinaryAnalyzeJobClass:
-    if (getTriple().isSPIRV()) {
-      if (!SPIRVValidator)
-        SPIRVValidator.reset(new tools::hlsl::SPIRV_Validator(*this));
-      return SPIRVValidator.get();
-    }
     if (!Validator)
       Validator.reset(new tools::hlsl::Validator(*this));
     return Validator.get();
@@ -625,12 +612,15 @@ bool HLSLToolChain::requiresValidation(DerivedArgList &Args,
     return false;
   }
 
-  std::string SpirvValPath = GetProgramPath("spirv-val");
-  if (SpirvValPath != "spirv-val")
-    return true;
+  if (getTriple().isSPIRV()) {
+    std::string SpirvValPath = GetProgramPath("spirv-val");
+    if (SpirvValPath != "spirv-val")
+      return true;
 
-  if (Diagnose)
-    getDriver().Diag(diag::warn_drv_dxc_missing_spirv_val);
+    if (Diagnose)
+      getDriver().Diag(diag::warn_drv_dxc_missing_spirv_val);
+  }
+
   return false;
 }
 
@@ -650,11 +640,11 @@ bool HLSLToolChain::isLastJob(DerivedArgList &Args,
   if (requiresBinaryTranslation(Args))
     return AC == Action::Action::BinaryTranslatorJobClass;
   // For SPIR-V, spirv-val is a pure validator that doesn't produce output
-  // files, so the compile step is the output-producing step. For DXIL, dxv
-  // validates and signs, producing the final output.
+  // files, so the compile step is the last output-producing job. For DXIL,
+  // dxv validates and signs, producing the final output.
   if (requiresValidation(Args, /*Diagnose=*/false)) {
     if (getTriple().isSPIRV())
-      return AC != Action::Action::BinaryAnalyzeJobClass;
+      return AC == Action::Action::AssembleJobClass;
     return AC == Action::Action::BinaryAnalyzeJobClass;
   }
   if (requiresObjcopy(Args))

--- a/clang/lib/Driver/ToolChains/HLSL.h
+++ b/clang/lib/Driver/ToolChains/HLSL.h
@@ -79,8 +79,17 @@ public:
   TranslateArgs(const llvm::opt::DerivedArgList &Args, StringRef BoundArch,
                 Action::OffloadKind DeviceOffloadKind) const override;
   static std::optional<std::string> parseTargetProfile(StringRef TargetProfile);
-  bool requiresValidation(llvm::opt::DerivedArgList &Args,
-                          bool Diagnose = true) const;
+
+  struct ValidationInfo {
+    bool NeedsValidation = false;
+    bool ProducesOutput = false;
+  };
+
+  /// Returns information about whether validation is required and whether the
+  /// validator produces output. When Diagnose is true, emits a warning if the
+  /// required validator executable cannot be found.
+  ValidationInfo getValidationInfo(llvm::opt::DerivedArgList &Args,
+                                   bool Diagnose = true) const;
   bool requiresBinaryTranslation(llvm::opt::DerivedArgList &Args) const;
   bool requiresObjcopy(llvm::opt::DerivedArgList &Args) const;
 
@@ -92,7 +101,8 @@ public:
   /// step but doesn't produce output, so the compile step is the last
   /// output-producing job. For DXIL, dxv validates and signs, producing the
   /// final output.
-  bool isLastJob(llvm::opt::DerivedArgList &Args, Action::ActionClass AC) const;
+  bool isLastOutputProducingJob(llvm::opt::DerivedArgList &Args,
+                                Action::ActionClass AC) const;
 
   // Set default DWARF version to 4 for DXIL uses version 4.
   unsigned GetDefaultDwarfVersion() const override { return 4; }

--- a/clang/lib/Driver/ToolChains/HLSL.h
+++ b/clang/lib/Driver/ToolChains/HLSL.h
@@ -30,6 +30,19 @@ public:
                     const char *LinkingOutput) const override;
 };
 
+class LLVM_LIBRARY_VISIBILITY SPIRV_Validator : public Tool {
+public:
+  SPIRV_Validator(const ToolChain &TC)
+      : Tool("hlsl::SPIRV_Validator", "spirv-val", TC) {}
+
+  bool hasIntegratedCPP() const override { return false; }
+
+  void ConstructJob(Compilation &C, const JobAction &JA,
+                    const InputInfo &Output, const InputInfoList &Inputs,
+                    const llvm::opt::ArgList &TCArgs,
+                    const char *LinkingOutput) const override;
+};
+
 class LLVM_LIBRARY_VISIBILITY MetalConverter : public Tool {
 public:
   MetalConverter(const ToolChain &TC)
@@ -77,7 +90,8 @@ public:
   TranslateArgs(const llvm::opt::DerivedArgList &Args, StringRef BoundArch,
                 Action::OffloadKind DeviceOffloadKind) const override;
   static std::optional<std::string> parseTargetProfile(StringRef TargetProfile);
-  bool requiresValidation(llvm::opt::DerivedArgList &Args) const;
+  bool requiresValidation(llvm::opt::DerivedArgList &Args,
+                          bool Diagnose = true) const;
   bool requiresBinaryTranslation(llvm::opt::DerivedArgList &Args) const;
   bool requiresObjcopy(llvm::opt::DerivedArgList &Args) const;
 
@@ -95,6 +109,7 @@ public:
 
 private:
   mutable std::unique_ptr<tools::hlsl::Validator> Validator;
+  mutable std::unique_ptr<tools::hlsl::SPIRV_Validator> SPIRVValidator;
   mutable std::unique_ptr<tools::hlsl::MetalConverter> MetalConverter;
   mutable std::unique_ptr<tools::hlsl::LLVMObjcopy> LLVMObjcopy;
 };

--- a/clang/lib/Driver/ToolChains/HLSL.h
+++ b/clang/lib/Driver/ToolChains/HLSL.h
@@ -20,20 +20,9 @@ namespace tools {
 namespace hlsl {
 class LLVM_LIBRARY_VISIBILITY Validator : public Tool {
 public:
-  Validator(const ToolChain &TC) : Tool("hlsl::Validator", "dxv", TC) {}
-
-  bool hasIntegratedCPP() const override { return false; }
-
-  void ConstructJob(Compilation &C, const JobAction &JA,
-                    const InputInfo &Output, const InputInfoList &Inputs,
-                    const llvm::opt::ArgList &TCArgs,
-                    const char *LinkingOutput) const override;
-};
-
-class LLVM_LIBRARY_VISIBILITY SPIRV_Validator : public Tool {
-public:
-  SPIRV_Validator(const ToolChain &TC)
-      : Tool("hlsl::SPIRV_Validator", "spirv-val", TC) {}
+  Validator(const ToolChain &TC)
+      : Tool("hlsl::Validator", TC.getTriple().isSPIRV() ? "spirv-val" : "dxv",
+             TC) {}
 
   bool hasIntegratedCPP() const override { return false; }
 
@@ -95,11 +84,14 @@ public:
   bool requiresBinaryTranslation(llvm::opt::DerivedArgList &Args) const;
   bool requiresObjcopy(llvm::opt::DerivedArgList &Args) const;
 
-  /// If we are targeting DXIL then the last job should output the DXContainer
-  /// to the specified output file with /Fo. Otherwise, we will emit to a
-  /// temporary file for the next job to use.
+  /// Determines whether the given action class is the last job that produces
+  /// an output file. This is used to decide whether to write to the -Fo
+  /// output path or to a temporary file.
   ///
-  /// Returns true if we should output to the final result file.
+  /// For example, spirv-val is a pure validator that runs after the compile
+  /// step but doesn't produce output, so the compile step is the last
+  /// output-producing job. For DXIL, dxv validates and signs, producing the
+  /// final output.
   bool isLastJob(llvm::opt::DerivedArgList &Args, Action::ActionClass AC) const;
 
   // Set default DWARF version to 4 for DXIL uses version 4.
@@ -109,7 +101,6 @@ public:
 
 private:
   mutable std::unique_ptr<tools::hlsl::Validator> Validator;
-  mutable std::unique_ptr<tools::hlsl::SPIRV_Validator> SPIRVValidator;
   mutable std::unique_ptr<tools::hlsl::MetalConverter> MetalConverter;
   mutable std::unique_ptr<tools::hlsl::LLVMObjcopy> LLVMObjcopy;
 };

--- a/clang/test/Driver/dxc_spirv-val_missing.hlsl
+++ b/clang/test/Driver/dxc_spirv-val_missing.hlsl
@@ -1,0 +1,15 @@
+// UNSUPPORTED: spirv-val
+//
+// Verify that a warning is emitted exactly once when spirv-val is not found.
+// This test is unsupported when spirv-val is in the build directory because
+// GetProgramPath finds it via the application directory search, bypassing PATH.
+
+// RUN: env PATH="" %clang_dxc -spirv -I test -Tlib_6_3 -Fo %t.spv -### %s 2>&1 | FileCheck %s
+
+// CHECK: spirv-val not found; resulting SPIR-V will not be validated
+// CHECK-NOT: spirv-val not found; resulting SPIR-V will not be validated
+
+// Also verify -Vd suppresses the warning.
+// RUN: %clang_dxc -spirv -I test -Vd -Tlib_6_3 -### %s 2>&1 | FileCheck %s --check-prefix=VD
+// VD: "-cc1"{{.*}}"-triple" "spirv1.6-unknown-vulkan1.3-library"
+// VD-NOT: spirv-val not found; resulting SPIR-V will not be validated

--- a/clang/test/Driver/dxc_spirv-val_path.hlsl
+++ b/clang/test/Driver/dxc_spirv-val_path.hlsl
@@ -2,15 +2,18 @@
 // RUN: env PATH="" %clang_dxc -spirv -I test -Tlib_6_3 -Fo %t.dir/a.spv  -### %s 2>&1 | FileCheck %s
 
 // Make sure report warning, and only once.
-// CHECK:spirv-val not found
-// CHECK-NOT:spirv-val not found
+// CHECK:spirv-val not found; resulting SPIR-V will not be validated
+// CHECK-NOT:spirv-val not found; resulting SPIR-V will not be validated
 
 // RUN: echo "spirv-val" > %t.dir/spirv-val && chmod 754 %t.dir/spirv-val && %clang_dxc -spirv --spirv-val-path=%t.dir %s -Tlib_6_3 -Fo %t.dir/a.spv -### 2>&1 | FileCheck %s --check-prefix=SPIRV_VAL_PATH
-// SPIRV_VAL_PATH:spirv-val{{(.exe)?}}" "{{.*}}.spv"
+// SPIRV_VAL_PATH:spirv-val{{(.exe)?}}" "--target-env" "vulkan1.3" "--scalar-block-layout" "{{.*}}.spv"
+
+// RUN: echo "spirv-val" > %t.dir/spirv-val && chmod 754 %t.dir/spirv-val && %clang_dxc -spirv --spirv-val-path=%t.dir %s -Tlib_6_3 -fspv-target-env=vulkan1.2 -Fo %t.dir/a.spv -### 2>&1 | FileCheck %s --check-prefix=SPIRV_VAL_VK12
+// SPIRV_VAL_VK12:spirv-val{{(.exe)?}}" "--target-env" "vulkan1.2" "--scalar-block-layout" "{{.*}}.spv"
 
 // RUN: %clang_dxc -spirv -I test -Vd -Tlib_6_3  -### %s 2>&1 | FileCheck %s --check-prefix=VD
 // VD:"-cc1"{{.*}}"-triple" "spirv1.6-unknown-vulkan1.3-library"
-// VD-NOT:spirv-val not found
+// VD-NOT:spirv-val not found; resulting SPIR-V will not be validated
 
 // RUN: %clang_dxc -spirv -Tlib_6_3 -ccc-print-bindings --spirv-val-path=%t.dir -Fo %t.spv  %s 2>&1 | FileCheck %s --check-prefix=BINDINGS
 // BINDINGS: "spirv1.6-unknown-vulkan1.3-library" - "clang", inputs: ["[[INPUT:.+]]"], output: "[[spv:.+]].spv"

--- a/clang/test/Driver/dxc_spirv-val_path.hlsl
+++ b/clang/test/Driver/dxc_spirv-val_path.hlsl
@@ -1,0 +1,26 @@
+// RUN: mkdir -p %t.dir
+// RUN: env PATH="" %clang_dxc -spirv -I test -Tlib_6_3 -Fo %t.dir/a.spv  -### %s 2>&1 | FileCheck %s
+
+// Make sure report warning, and only once.
+// CHECK:spirv-val not found
+// CHECK-NOT:spirv-val not found
+
+// RUN: echo "spirv-val" > %t.dir/spirv-val && chmod 754 %t.dir/spirv-val && %clang_dxc -spirv --spirv-val-path=%t.dir %s -Tlib_6_3 -Fo %t.dir/a.spv -### 2>&1 | FileCheck %s --check-prefix=SPIRV_VAL_PATH
+// SPIRV_VAL_PATH:spirv-val{{(.exe)?}}" "{{.*}}.spv"
+
+// RUN: %clang_dxc -spirv -I test -Vd -Tlib_6_3  -### %s 2>&1 | FileCheck %s --check-prefix=VD
+// VD:"-cc1"{{.*}}"-triple" "spirv1.6-unknown-vulkan1.3-library"
+// VD-NOT:spirv-val not found
+
+// RUN: %clang_dxc -spirv -Tlib_6_3 -ccc-print-bindings --spirv-val-path=%t.dir -Fo %t.spv  %s 2>&1 | FileCheck %s --check-prefix=BINDINGS
+// BINDINGS: "spirv1.6-unknown-vulkan1.3-library" - "clang", inputs: ["[[INPUT:.+]]"], output: "[[spv:.+]].spv"
+// BINDINGS-NEXT: "spirv1.6-unknown-vulkan1.3-library" - "hlsl::SPIRV_Validator", inputs: ["[[spv]].spv"], output: "{{.+}}.obj"
+
+// RUN: %clang_dxc -spirv -Tlib_6_3 -ccc-print-phases --spirv-val-path=%t.dir -Fo %t.spv  %s 2>&1 | FileCheck %s --check-prefix=PHASES
+
+// PHASES: 0: input, "[[INPUT:.+]]", hlsl
+// PHASES-NEXT: 1: preprocessor, {0}, c++-cpp-output
+// PHASES-NEXT: 2: compiler, {1}, ir
+// PHASES-NEXT: 3: backend, {2}, assembler
+// PHASES-NEXT: 4: assembler, {3}, object
+// PHASES-NEXT: 5: binary-analyzer, {4}, object

--- a/clang/test/Driver/dxc_spirv-val_path.hlsl
+++ b/clang/test/Driver/dxc_spirv-val_path.hlsl
@@ -17,7 +17,7 @@
 
 // RUN: %clang_dxc -spirv -Tlib_6_3 -ccc-print-bindings --spirv-val-path=%t.dir -Fo %t.spv  %s 2>&1 | FileCheck %s --check-prefix=BINDINGS
 // BINDINGS: "spirv1.6-unknown-vulkan1.3-library" - "clang", inputs: ["[[INPUT:.+]]"], output: "[[spv:.+]].spv"
-// BINDINGS-NEXT: "spirv1.6-unknown-vulkan1.3-library" - "hlsl::SPIRV_Validator", inputs: ["[[spv]].spv"], output: "{{.+}}.obj"
+// BINDINGS-NEXT: "spirv1.6-unknown-vulkan1.3-library" - "hlsl::Validator", inputs: ["[[spv]].spv"], output: "{{.+}}.obj"
 
 // RUN: %clang_dxc -spirv -Tlib_6_3 -ccc-print-phases --spirv-val-path=%t.dir -Fo %t.spv  %s 2>&1 | FileCheck %s --check-prefix=PHASES
 

--- a/clang/test/Driver/dxc_spirv-val_path.hlsl
+++ b/clang/test/Driver/dxc_spirv-val_path.hlsl
@@ -1,19 +1,10 @@
 // RUN: mkdir -p %t.dir
-// RUN: env PATH="" %clang_dxc -spirv -I test -Tlib_6_3 -Fo %t.dir/a.spv  -### %s 2>&1 | FileCheck %s
-
-// Make sure report warning, and only once.
-// CHECK:spirv-val not found; resulting SPIR-V will not be validated
-// CHECK-NOT:spirv-val not found; resulting SPIR-V will not be validated
 
 // RUN: echo "spirv-val" > %t.dir/spirv-val && chmod 754 %t.dir/spirv-val && %clang_dxc -spirv --spirv-val-path=%t.dir %s -Tlib_6_3 -Fo %t.dir/a.spv -### 2>&1 | FileCheck %s --check-prefix=SPIRV_VAL_PATH
 // SPIRV_VAL_PATH:spirv-val{{(.exe)?}}" "--target-env" "vulkan1.3" "--scalar-block-layout" "{{.*}}.spv"
 
 // RUN: echo "spirv-val" > %t.dir/spirv-val && chmod 754 %t.dir/spirv-val && %clang_dxc -spirv --spirv-val-path=%t.dir %s -Tlib_6_3 -fspv-target-env=vulkan1.2 -Fo %t.dir/a.spv -### 2>&1 | FileCheck %s --check-prefix=SPIRV_VAL_VK12
 // SPIRV_VAL_VK12:spirv-val{{(.exe)?}}" "--target-env" "vulkan1.2" "--scalar-block-layout" "{{.*}}.spv"
-
-// RUN: %clang_dxc -spirv -I test -Vd -Tlib_6_3  -### %s 2>&1 | FileCheck %s --check-prefix=VD
-// VD:"-cc1"{{.*}}"-triple" "spirv1.6-unknown-vulkan1.3-library"
-// VD-NOT:spirv-val not found; resulting SPIR-V will not be validated
 
 // RUN: %clang_dxc -spirv -Tlib_6_3 -ccc-print-bindings --spirv-val-path=%t.dir -Fo %t.spv  %s 2>&1 | FileCheck %s --check-prefix=BINDINGS
 // BINDINGS: "spirv1.6-unknown-vulkan1.3-library" - "clang", inputs: ["[[INPUT:.+]]"], output: "[[spv:.+]].spv"

--- a/clang/test/lit.cfg.py
+++ b/clang/test/lit.cfg.py
@@ -268,6 +268,10 @@ if config.clang_staticanalyzer:
 if config.clang_enable_cir:
     config.available_features.add("cir-support")
 
+# SPIRV-Tools validator availability (e.g. built with -DLLVM_INCLUDE_SPIRV_TOOLS_TESTS)
+if lit.util.which("spirv-val", config.llvm_tools_dir):
+    config.available_features.add("spirv-val")
+
 llvm_config.add_tool_substitutions(tools, tool_dirs)
 
 config.substitutions.append(


### PR DESCRIPTION
Clang-dxc.exe currently uses dxv by default after compiling HLSL that targets DXIL, assuming dxv can be found. However, there is no counterpart for SPIR-V. This PR changes clang-dxc.exe so that the DXC driver inserts a step to run spirv-val when SPIR-V is the target. It also accounts for whether or not the -Fo option is passed. In all cases, spirv-val will be run, as long as the target is SPIR-V and the spirv-val executable can be found on the PATH.

This PR also adds a new option --spirv-val-path, a counterpart to --dxv-path, for specifying an explicit path to spirv-val.

Key differences from dxv: Unlike dxv, which validates and signs DXIL containers and produces an output file, spirv-val is a pure validator — it checks the SPIR-V binary and exits with a status code without producing output. Because of this, the compile step writes directly to -Fo and spirv-val validates the file in-place.

Additional fixes:

 - Fixes a duplicate "validator not found" warning that was emitted twice per invocation — once from BuildActions and once from isLastJob (via GetNamedOutputPath). This was a pre-existing bug introduced by #130436 (https://github.com/llvm/llvm-project/pull/130436). Fixed by 
adding a Diagnose parameter to requiresValidation so only one call site emits the diagnostic.
 - Fixes an "unused argument" warning for -Vd when targeting SPIR-V, caused by early returns in requiresValidation before the argument was claimed.
 - Adds a new SPIRVValidation diagnostic group and warn_drv_dxc_missing_spirv_val diagnostic for the missing spirv-val warning.

Fixes https://github.com/llvm/llvm-project/issues/142669

Assisted by: Claude Opus 4.6