### PR TITLE
[clang-tidy] Do not provide diagnostics for cert-dcl58-cpp on implicit declarations

### DIFF
--- a/clang-tools-extra/clang-tidy/bugprone/StdNamespaceModificationCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/StdNamespaceModificationCheck.cpp
@@ -117,6 +117,10 @@ void clang::tidy::bugprone::StdNamespaceModificationCheck::check(
   if (!D || !NS)
     return;
 
+  // Skip compiler-generated implicit declarations (e.g. std::align_val_t).
+  if (D->isImplicit())
+    return;
+
   diag(D->getLocation(),
        "modification of %0 namespace can result in undefined behavior")
       << NS;

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -226,7 +226,8 @@ Changes in existing checks
 - Improved :doc:`bugprone-std-namespace-modification
   <clang-tidy/checks/bugprone/std-namespace-modification>` check by fixing
   false positives when extending the standard library with a specialization of
-  user-defined type.
+  user-defined type and by removing detection of the compiler generated ``std``
+  namespace extensions. 
 
 - Improved :doc:`bugprone-string-constructor
   <clang-tidy/checks/bugprone/string-constructor>` check to detect suspicious

--- a/clang-tools-extra/test/clang-tidy/checkers/bugprone/std-namespace-modification-implicit.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/bugprone/std-namespace-modification-implicit.cpp
@@ -1,0 +1,21 @@
+// RUN: %check_clang_tidy -std=c++17-or-later %s bugprone-std-namespace-modification %t \
+// RUN:   -- -system-headers
+
+// Compiler-generated implicit declarations in namespace std (e.g.
+// std::align_val_t) should not trigger a warning or crash clang-tidy.
+// A new expression forces Clang to implicitly declare std::align_val_t
+// inside namespace std when alignment is enabled. This test verifies
+// the checker handles this situation correctly in case of -system-headers
+// switch present. Situation without -system-headers is handled in
+// std-namespace-modification.cpp test file.
+
+namespace std {}
+
+// Trigger implicit std::align_val_t declaration.
+void *implicit_decl_test = new int;
+
+namespace std {
+// CHECK-MESSAGES: :[[@LINE+2]]:5: warning: modification of 'std' namespace
+// CHECK-MESSAGES: :[[@LINE-2]]:11: note: 'std' namespace opened here
+int x;
+}

--- a/clang/test/AST/ast-dump-implicit-align-val.cpp
+++ b/clang/test/AST/ast-dump-implicit-align-val.cpp
@@ -1,0 +1,18 @@
+// This test checks that the implicit std::align_val_t is created with no source
+// location and marked implicit when a new-expression triggers its synthesis.
+
+// align_val_t is implicitly created in C++17+ (aligned allocation on by default).
+// RUN: %clang_cc1 -std=c++17 -ast-dump %s | FileCheck %s
+// RUN: %clang_cc1 -std=c++20 -ast-dump %s | FileCheck %s
+// RUN: %clang_cc1 -std=c++23 -ast-dump %s | FileCheck %s
+
+// In older standards, -faligned-allocation must be explicit.
+// RUN: %clang_cc1 -std=c++03 -faligned-allocation -ast-dump %s | FileCheck %s
+// RUN: %clang_cc1 -std=c++11 -faligned-allocation -ast-dump %s | FileCheck %s
+// RUN: %clang_cc1 -std=c++14 -faligned-allocation -ast-dump %s | FileCheck %s
+
+namespace std {}
+void *p = new int;
+
+// CHECK: NamespaceDecl {{.*}} std
+// CHECK: EnumDecl {{.*}} <<invalid sloc>> <invalid sloc> implicit class align_val_t


### PR DESCRIPTION
Do not provide diagnostics for cert-dcl58-cpp for compiler generated intrinsic as it will be a false positive.

In provided tests compiler generates align_val_t which ends up inside std namespace, resulting in std::align_val_t symbol. This symbol is compiler generated, having no location, causing compiler crash. Also there is no point to notify user about violations which user has no control of.

Resolution: Diagnostics suppressed.