### PR TITLE
[flang-rt] Fix test isolation, fixture usage, and other issues in Stop.cpp tests

### DIFF
--- a/flang-rt/unittests/Runtime/Stop.cpp
+++ b/flang-rt/unittests/Runtime/Stop.cpp
@@ -122,9 +122,8 @@ TEST_F(TestProgramEnd, CrashTest) {
   static const std::string fileName{"file name"};
   // CrashHandlerFixture installs a custom crash handler that formats messages
   // as: "Test <name> crashed in file <file>(<line>): <message>"
-  static const std::string fullMessage{
-      "Test CrashTest crashed in file " + fileName + "\\(343\\): " +
-      crashMessage};
+  static const std::string fullMessage{"Test CrashTest crashed in file " +
+      fileName + "\\(343\\): " + crashMessage};
   EXPECT_DEATH(
       RTNAME(ReportFatalUserError)(crashMessage.c_str(), fileName.c_str(), 343),
       fullMessage.c_str());

--- a/flang-rt/unittests/Runtime/Stop.cpp
+++ b/flang-rt/unittests/Runtime/Stop.cpp
@@ -14,26 +14,31 @@
 #include "CrashHandlerFixture.h"
 #include "flang-rt/runtime/environment.h"
 #include <cstdlib>
+#include <cstring>
 #include <gtest/gtest.h>
 
 using namespace Fortran::runtime;
 
 struct TestProgramEnd : CrashHandlerFixture {};
 
-TEST(TestProgramEnd, StopTest) {
+TEST_F(TestProgramEnd, StopTest) {
   EXPECT_EXIT(RTNAME(StopStatement)(), testing::ExitedWithCode(EXIT_SUCCESS),
       "Fortran STOP");
 }
 
-TEST(TestProgramEnd, StopTestNoStopMessage) {
-  putenv(const_cast<char *>("NO_STOP_MESSAGE=1"));
-  Fortran::runtime::executionEnvironment.Configure(
-      0, nullptr, nullptr, nullptr);
+TEST_F(TestProgramEnd, StopTestNoStopMessage) {
   EXPECT_EXIT(
-      RTNAME(StopStatement)(), testing::ExitedWithCode(EXIT_SUCCESS), "");
+      {
+        static char noStopMessage[] = "NO_STOP_MESSAGE=1";
+        putenv(noStopMessage);
+        Fortran::runtime::executionEnvironment.Configure(
+            0, nullptr, nullptr, nullptr);
+        RTNAME(StopStatement)();
+      },
+      testing::ExitedWithCode(EXIT_SUCCESS), "");
 }
 
-TEST(TestProgramEnd, StopMessageTest) {
+TEST_F(TestProgramEnd, StopMessageTest) {
   static const char *message{"bye bye"};
   EXPECT_EXIT(RTNAME(StopStatementText)(message, std::strlen(message),
                   /*isErrorStop=*/false, /*quiet=*/false),
@@ -52,48 +57,74 @@ TEST(TestProgramEnd, StopMessageTest) {
       testing::ExitedWithCode(EXIT_FAILURE), "");
 }
 
-TEST(TestProgramEnd, NoStopMessageTest) {
-  putenv(const_cast<char *>("NO_STOP_MESSAGE=1"));
-  Fortran::runtime::executionEnvironment.Configure(
-      0, nullptr, nullptr, nullptr);
+TEST_F(TestProgramEnd, NoStopMessageTest) {
   static const char *message{"bye bye"};
-  EXPECT_EXIT(RTNAME(StopStatementText)(message, std::strlen(message),
-                  /*isErrorStop=*/false, /*quiet=*/false),
+  EXPECT_EXIT(
+      {
+        static char noStopMessage[] = "NO_STOP_MESSAGE=1";
+        putenv(noStopMessage);
+        Fortran::runtime::executionEnvironment.Configure(
+            0, nullptr, nullptr, nullptr);
+        RTNAME(StopStatementText)(message, std::strlen(message),
+            /*isErrorStop=*/false, /*quiet=*/false);
+      },
       testing::ExitedWithCode(EXIT_SUCCESS), "bye bye");
 
-  EXPECT_EXIT(RTNAME(StopStatementText)(message, std::strlen(message),
-                  /*isErrorStop=*/false, /*quiet=*/true),
+  EXPECT_EXIT(
+      {
+        static char noStopMessage[] = "NO_STOP_MESSAGE=1";
+        putenv(noStopMessage);
+        Fortran::runtime::executionEnvironment.Configure(
+            0, nullptr, nullptr, nullptr);
+        RTNAME(StopStatementText)(message, std::strlen(message),
+            /*isErrorStop=*/false, /*quiet=*/true);
+      },
       testing::ExitedWithCode(EXIT_SUCCESS), "");
 
-  EXPECT_EXIT(RTNAME(StopStatementText)(message, std::strlen(message),
-                  /*isErrorStop=*/true, /*quiet=*/false),
+  EXPECT_EXIT(
+      {
+        static char noStopMessage[] = "NO_STOP_MESSAGE=1";
+        putenv(noStopMessage);
+        Fortran::runtime::executionEnvironment.Configure(
+            0, nullptr, nullptr, nullptr);
+        RTNAME(StopStatementText)(message, std::strlen(message),
+            /*isErrorStop=*/true, /*quiet=*/false);
+      },
       testing::ExitedWithCode(EXIT_FAILURE), "Fortran ERROR STOP: bye bye");
 
-  EXPECT_EXIT(RTNAME(StopStatementText)(message, std::strlen(message),
-                  /*isErrorStop=*/true, /*quiet=*/true),
+  EXPECT_EXIT(
+      {
+        static char noStopMessage[] = "NO_STOP_MESSAGE=1";
+        putenv(noStopMessage);
+        Fortran::runtime::executionEnvironment.Configure(
+            0, nullptr, nullptr, nullptr);
+        RTNAME(StopStatementText)(message, std::strlen(message),
+            /*isErrorStop=*/true, /*quiet=*/true);
+      },
       testing::ExitedWithCode(EXIT_FAILURE), "");
 }
 
-TEST(TestProgramEnd, FailImageTest) {
+TEST_F(TestProgramEnd, FailImageTest) {
   EXPECT_EXIT(
       RTNAME(FailImageStatement)(), testing::ExitedWithCode(EXIT_FAILURE), "");
 }
 
-TEST(TestProgramEnd, ExitTest) {
+TEST_F(TestProgramEnd, ExitTest) {
   EXPECT_EXIT(RTNAME(Exit)(), testing::ExitedWithCode(EXIT_SUCCESS), "");
   EXPECT_EXIT(
       RTNAME(Exit)(EXIT_FAILURE), testing::ExitedWithCode(EXIT_FAILURE), "");
 }
 
-TEST(TestProgramEnd, AbortTest) { EXPECT_DEATH(RTNAME(Abort)(), ""); }
+TEST_F(TestProgramEnd, AbortTest) { EXPECT_DEATH(RTNAME(Abort)(), ""); }
 
-TEST(TestProgramEnd, CrashTest) {
+TEST_F(TestProgramEnd, CrashTest) {
   static const std::string crashMessage{"bad user code"};
   static const std::string fileName{"file name"};
-  static const std::string headMessage{"fatal Fortran runtime error\\("};
-  static const std::string tailMessage{":343\\): "};
+  // CrashHandlerFixture installs a custom crash handler that formats messages
+  // as: "Test <name> crashed in file <file>(<line>): <message>"
   static const std::string fullMessage{
-      headMessage + fileName + tailMessage + crashMessage};
+      "Test CrashTest crashed in file " + fileName + "\\(343\\): " +
+      crashMessage};
   EXPECT_DEATH(
       RTNAME(ReportFatalUserError)(crashMessage.c_str(), fileName.c_str(), 343),
       fullMessage.c_str());


### PR DESCRIPTION
- Use TEST_F instead of TEST so CrashHandlerFixture::SetUp() is actually called, registering the custom crash handler for death tests.
- Move putenv/executionEnvironment.Configure calls inside EXPECT_EXIT blocks so they run in the forked child process, preventing the NO_STOP_MESSAGE environment variable and configured global state from leaking into subsequent tests.
- Replace const_cast<char *>("NO_STOP_MESSAGE=1") with a mutable static char array, to avoid casting away constness of a string literal.
- Update CrashTest's expected pattern to match the output format of the custom crash handler installed by CrashHandlerFixture, which was previously never invoked due to the TEST vs TEST_F bug. (Note: there was a buildbot failure related to this: https://lab.llvm.org/buildbot/#/builders/130/builds/18413 )

Assisted-by: AI