### PR TITLE
[lldb] use the Py_REFCNT() macro instead of directly accessing member

### DIFF
--- a/lldb/bindings/python/python-wrapper.swig
+++ b/lldb/bindings/python/python-wrapper.swig
@@ -134,7 +134,7 @@ bool lldb_private::python::SWIGBridge::LLDBSwigPythonCallTypeScript(
 #endif
       ) {
     pfunc_impl = (PyObject *)(*pyfunct_wrapper);
-    if (pfunc_impl->ob_refcnt == 1) {
+    if (Py_REFCNT(pfunc_impl) == 1) {
       Py_XDECREF(pfunc_impl);
       pfunc_impl = NULL;
     }


### PR DESCRIPTION
[PyObject members are not to be accessed directly](https://docs.python.org/3/c-api/structures.html#c.PyObject), but rather through macros, in this case `Py_REFCNT()`.

In most, ie Global Interpreter Lock-enabled, CPython cases, `Py_REFCNT()` expands to accessing `ob_refcnt` anyway. However, in a free-threaded CPython, combined with disabling the limited API (since it requires the GIL for now), the direct member does not exist, causing the build to fail. The macro expands to the correct access method in the free-threaded configuration.