### PR TITLE
[PowerPC] Fix instruction size for XRay PATCHABLE_FUNCTION_ENTER

### DIFF
--- a/llvm/lib/Target/PowerPC/PPCInstrInfo.cpp
+++ b/llvm/lib/Target/PowerPC/PPCInstrInfo.cpp
@@ -3027,7 +3027,20 @@ unsigned PPCInstrInfo::getInstSizeInBytes(const MachineInstr &MI) const {
     (void)F.getFnAttribute("patchable-function-entry")
         .getValueAsString()
         .getAsInteger(10, Num);
-    return Num * 4;
+    if (Num)
+      return Num * 4;
+    // When XRay is used on PPC64LE, seven instructions are emitted:
+    // B, NOP, STD, MFLR8, BL8_NOP (bl+nop), MTLR8 = 7 instructions.
+    // The AsmPrinter verifies that the instruction size reported by InstrInfo
+    // matches the actual emitted size. However, under XRay and when the
+    // `patchable-function-entry` function attribute is not present, we
+    // run into the situation where the expected number of bytes are 0,
+    // when the actual number of bytes are 28 (7 instructions * 4 bytes).
+    // Specifically check for the XRay path and return the appropriate
+    // number of bytes accordingly.
+    if (Subtarget.isXRaySupported())
+      return 7 * 4;  // 28 bytes
+    return 0;
   }
   default:
     return get(Opcode).getSize();

--- a/llvm/test/CodeGen/PowerPC/ppc64le-xray-check-patchable-function.ll
+++ b/llvm/test/CodeGen/PowerPC/ppc64le-xray-check-patchable-function.ll
@@ -1,0 +1,18 @@
+; RUN: llc -mtriple=powerpc64le-unknown-linux-gnu -mcpu=pwr8 -filetype=obj \
+; RUN:   %s -o %t.o 2>&1 | FileCheck %s --check-prefix=NOERR --allow-empty
+
+; This test ensures that XRay patchable-entry size mismatches no longer occur
+; when emitting an object file.
+
+; NOERR-NOT: In function: MyFunction
+; NOERR-NOT: Size mismatch for: PATCHABLE_FUNCTION_ENTER
+
+target datalayout = "e-m:e-Fn32-i64:64-i128:128-n32:64-S128-v256:256:256-v512:512:512"
+target triple = "powerpc64le-unknown-linux-gnu"
+
+define i16 @MyFunction() #0 {
+entry:
+  ret i16 0
+}
+
+attributes #0 = { "function-instrument"="xray-always" }


### PR DESCRIPTION
This patch fixes a crash when compiling with XRay instrumentation on PPC64LE. 2bd0d770af5b added support
for `-fpatchable-function-entry` but full accommodation for XRay is appears to be missing in `getInstSizeInBytes()` within `PPCInstrInfo.cpp`.

When XRay instrumentation is enabled, the assembly printer will emit seven instructions for `PATCHABLE_FUNCTION_ENTER`, which is 28 bytes (7 instructions * 4 bytes).
However, `getInstSizeInBytes()` was returning 0 bytes previously when the `patchable-function-entry attribute` was not present, which causes an instruction size verification mismatch (introduced in 85ab2a9706b6).

This attempts to resolve the XRay buildbot failures in https://lab.llvm.org/buildbot/#/builders/95/builds/20440.