### PR TITLE
[MLIR][Python][Docs] Fix example of Python-defined dialects

### DIFF
--- a/mlir/docs/Bindings/Python.md
+++ b/mlir/docs/Bindings/Python.md
@@ -1307,12 +1307,12 @@ class MyInt(Dialect, name="myint"):
 
 class ConstantOp(MyInt.Operation, name="constant"):
     value: IntegerAttr
-    cst: Result[IntegerType[32]]
+    cst: Result[IntegerType[32]] = result(infer_type=True)
 
 class AddOp(MyInt.Operation, name="add"):
     lhs: Operand[IntegerType[32]]
     rhs: Operand[IntegerType[32]]
-    res: Result[IntegerType[32]]
+    res: Result[IntegerType[32]] = result(infer_type=True)
 
 # The code below requires an available MLIR context and location.
 


### PR DESCRIPTION
Some breaking changes are introduced in #186574 for Python-defined dialects. So we need to fix the example in the docs.