### PR TITLE
[LV][NFC] Remove more function attributes from tests

### DIFF
--- a/llvm/test/Transforms/LoopVectorize/12-12-11-if-conv.ll
+++ b/llvm/test/Transforms/LoopVectorize/12-12-11-if-conv.ll
@@ -6,7 +6,7 @@ target datalayout = "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f3
 ;CHECK: icmp eq <4 x i32>
 ;CHECK: select <4 x i1>
 ;CHECK: ret void
-define void @foo(i32 %x, i32 %t, ptr nocapture %A) nounwind uwtable ssp {
+define void @foo(i32 %x, i32 %t, ptr nocapture %A) {
 entry:
   %cmp10 = icmp sgt i32 %x, 0
   br i1 %cmp10, label %for.body, label %for.end

--- a/llvm/test/Transforms/LoopVectorize/2012-10-20-infloop.ll
+++ b/llvm/test/Transforms/LoopVectorize/2012-10-20-infloop.ll
@@ -27,7 +27,7 @@ for.end:                                          ; preds = %for.body
 }
 
 ;PR14701
-define void @start_model_rare(i1 %arg) nounwind uwtable ssp {
+define void @start_model_rare(i1 %arg) {
 entry:
   br i1 false, label %return, label %if.end
 

--- a/llvm/test/Transforms/LoopVectorize/2012-10-22-isconsec.ll
+++ b/llvm/test/Transforms/LoopVectorize/2012-10-22-isconsec.ll
@@ -8,7 +8,7 @@ module asm "\09.ident\09\22GCC: (GNU) 4.6.3 LLVM: 3.2svn\22"
 
 @b = common global [32000 x float] zeroinitializer, align 16
 
-define i32 @set1ds(i32 %_n, ptr nocapture %arr, float %value, i32 %stride) nounwind uwtable {
+define i32 @set1ds(i32 %_n, ptr nocapture %arr, float %value, i32 %stride) {
 entry:
   %0 = icmp sgt i32 %_n, 0
   br i1 %0, label %"3.lr.ph", label %"5"
@@ -31,7 +31,7 @@ entry:
   ret i32 0
 }
 
-define i32 @init(ptr nocapture %name) unnamed_addr nounwind uwtable {
+define i32 @init(ptr nocapture %name) unnamed_addr {
 entry:
   br label %"3"
 

--- a/llvm/test/Transforms/LoopVectorize/2012-10-22-isconsec.ll
+++ b/llvm/test/Transforms/LoopVectorize/2012-10-22-isconsec.ll
@@ -31,7 +31,7 @@ entry:
   ret i32 0
 }
 
-define i32 @init(ptr nocapture %name) unnamed_addr {
+define i32 @init(ptr nocapture %name) {
 entry:
   br label %"3"
 

--- a/llvm/test/Transforms/LoopVectorize/AArch64/outer_loop_test1_no_explicit_vect_width.ll
+++ b/llvm/test/Transforms/LoopVectorize/AArch64/outer_loop_test1_no_explicit_vect_width.ll
@@ -23,7 +23,7 @@
 @arrX = external global [8 x i64], align 16
 @arrY = external global [8 x [8 x i64]], align 16
 
-; Function Attrs: norecurse nounwind uwtable
+; Function Attrs: norecurse
 define void @foo_i32(i32 %n) {
 ; CHECK-LABEL: define void @foo_i32(
 ; CHECK-SAME: i32 [[N:%.*]]) {

--- a/llvm/test/Transforms/LoopVectorize/AArch64/outer_loop_test1_no_explicit_vect_width.ll
+++ b/llvm/test/Transforms/LoopVectorize/AArch64/outer_loop_test1_no_explicit_vect_width.ll
@@ -23,7 +23,6 @@
 @arrX = external global [8 x i64], align 16
 @arrY = external global [8 x [8 x i64]], align 16
 
-; Function Attrs: norecurse
 define void @foo_i32(i32 %n) {
 ; CHECK-LABEL: define void @foo_i32(
 ; CHECK-SAME: i32 [[N:%.*]]) {

--- a/llvm/test/Transforms/LoopVectorize/ARM/arm-unroll.ll
+++ b/llvm/test/Transforms/LoopVectorize/ARM/arm-unroll.ll
@@ -13,7 +13,7 @@ target triple = "thumbv7-apple-ios3.0.0"
 ;SWIFT: load <4 x i32>
 ;SWIFT: load <4 x i32>
 ;SWIFT: ret
-define i32 @foo(ptr nocapture %A, i32 %n) nounwind readonly ssp {
+define i32 @foo(ptr nocapture %A, i32 %n) nounwind readonly {
   %1 = icmp sgt i32 %n, 0
   br i1 %1, label %.lr.ph, label %._crit_edge
 

--- a/llvm/test/Transforms/LoopVectorize/ARM/arm-unroll.ll
+++ b/llvm/test/Transforms/LoopVectorize/ARM/arm-unroll.ll
@@ -13,7 +13,7 @@ target triple = "thumbv7-apple-ios3.0.0"
 ;SWIFT: load <4 x i32>
 ;SWIFT: load <4 x i32>
 ;SWIFT: ret
-define i32 @foo(ptr nocapture %A, i32 %n) nounwind readonly {
+define i32 @foo(ptr nocapture %A, i32 %n) {
   %1 = icmp sgt i32 %n, 0
   br i1 %1, label %.lr.ph, label %._crit_edge
 

--- a/llvm/test/Transforms/LoopVectorize/ARM/gcc-examples.ll
+++ b/llvm/test/Transforms/LoopVectorize/ARM/gcc-examples.ll
@@ -13,7 +13,7 @@ target triple = "thumbv7-apple-ios3.0.0"
 ;CHECK: add nsw <4 x i32>
 ;CHECK: store <4 x i32>
 ;CHECK: ret void
-define void @example1() nounwind uwtable ssp {
+define void @example1() {
   br label %1
 
 ; <label>:1                                       ; preds = %1, %0
@@ -39,7 +39,7 @@ define void @example1() nounwind uwtable ssp {
 ;CHECK: sext <4 x i16>
 ;CHECK: store <4 x i32>
 ;CHECK: ret void
-define void @example10b(ptr noalias nocapture %sa, ptr noalias nocapture %sb, ptr noalias nocapture %sc, ptr noalias nocapture %ia, ptr noalias nocapture %ib, ptr noalias nocapture %ic) nounwind uwtable ssp {
+define void @example10b(ptr noalias nocapture %sa, ptr noalias nocapture %sb, ptr noalias nocapture %sc, ptr noalias nocapture %ia, ptr noalias nocapture %ib, ptr noalias nocapture %ic) {
   br label %1
 
 ; <label>:1                                       ; preds = %1, %0

--- a/llvm/test/Transforms/LoopVectorize/ARM/width-detect.ll
+++ b/llvm/test/Transforms/LoopVectorize/ARM/width-detect.ll
@@ -29,7 +29,7 @@ define float @foo_F32(ptr nocapture %A, i32 %n) readonly {
 ;CHECK:foo_I8
 ;CHECK: xor <16 x i8>
 ;CHECK:ret
-define signext i8 @foo_I8(ptr nocapture %A, i32 %n) readonly {
+define i8 @foo_I8(ptr nocapture %A, i32 %n) readonly {
   %1 = icmp sgt i32 %n, 0
   br i1 %1, label %.lr.ph, label %._crit_edge
 

--- a/llvm/test/Transforms/LoopVectorize/ARM/width-detect.ll
+++ b/llvm/test/Transforms/LoopVectorize/ARM/width-detect.ll
@@ -6,7 +6,7 @@ target triple = "thumbv7-apple-ios3.0.0"
 ;CHECK:foo_F32
 ;CHECK: <4 x float>
 ;CHECK:ret
-define float @foo_F32(ptr nocapture %A, i32 %n) nounwind uwtable readonly ssp {
+define float @foo_F32(ptr nocapture %A, i32 %n) readonly {
   %1 = icmp sgt i32 %n, 0
   br i1 %1, label %.lr.ph, label %._crit_edge
 
@@ -29,7 +29,7 @@ define float @foo_F32(ptr nocapture %A, i32 %n) nounwind uwtable readonly ssp {
 ;CHECK:foo_I8
 ;CHECK: xor <16 x i8>
 ;CHECK:ret
-define signext i8 @foo_I8(ptr nocapture %A, i32 %n) nounwind uwtable readonly ssp {
+define signext i8 @foo_I8(ptr nocapture %A, i32 %n) readonly {
   %1 = icmp sgt i32 %n, 0
   br i1 %1, label %.lr.ph, label %._crit_edge
 

--- a/llvm/test/Transforms/LoopVectorize/PowerPC/reg-usage.ll
+++ b/llvm/test/Transforms/LoopVectorize/PowerPC/reg-usage.ll
@@ -168,7 +168,7 @@ for.end:
 }
 
 
-define void @double_(ptr nocapture %A, i32 %n) nounwind uwtable ssp {
+define void @double_(ptr nocapture %A, i32 %n) {
 ;CHECK-LABEL: double_
 ;CHECK-PWR8: LV(REG): VF = 2
 ;CHECK-PWR8: LV(REG): Found max usage: 2 item

--- a/llvm/test/Transforms/LoopVectorize/VPlan/vplan-dot-printing.ll
+++ b/llvm/test/Transforms/LoopVectorize/VPlan/vplan-dot-printing.ll
@@ -4,7 +4,7 @@ target datalayout = "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f3
 
 ; Verify that -vplan-print-in-dot-format option works.
 
-define void @print_call_and_memory(i64 %n, ptr noalias %y, ptr noalias %x) nounwind uwtable {
+define void @print_call_and_memory(i64 %n, ptr noalias %y, ptr noalias %x) {
 ; CHECK:      digraph VPlan {
 ; CHECK-NEXT:  graph [labelloc=t, fontsize=30; label="Vectorization Plan\nInitial VPlan for VF=\{4\},UF\>=1\nLive-in vp\<[[VF:%.+]]\> = VF\nLive-in vp\<[[VFxUF:%.+]]\> = VF * UF\nLive-in vp\<[[VEC_TC:%.+]]\> = vector-trip-count\nLive-in ir\<%n\> = original trip-count\n"]
 ; CHECK-NEXT:  node [shape=rect, fontname=Courier, fontsize=30]

--- a/llvm/test/Transforms/LoopVectorize/VPlan/vplan-printing.ll
+++ b/llvm/test/Transforms/LoopVectorize/VPlan/vplan-printing.ll
@@ -6,7 +6,7 @@ target datalayout = "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f3
 
 ; Tests for printing VPlans.
 
-define void @print_call_and_memory(i64 %n, ptr noalias %y, ptr noalias %x) nounwind uwtable {
+define void @print_call_and_memory(i64 %n, ptr noalias %y, ptr noalias %x) {
 ; CHECK-LABEL: VPlan for loop in 'print_call_and_memory'
 ; CHECK:  VPlan 'Initial VPlan for VF={4},UF>=1' {
 ; CHECK-NEXT:  Live-in vp<[[VP0:%[0-9]+]]> = VF
@@ -53,7 +53,7 @@ define void @print_call_and_memory(i64 %n, ptr noalias %y, ptr noalias %x) nounw
 ; CHECK-NEXT:    IR   %iv = phi i64 [ %iv.next, %for.body ], [ 0, %for.body.preheader ] (extra operand: vp<%bc.resume.val> from scalar.ph)
 ; CHECK-NEXT:    IR   %arrayidx = getelementptr inbounds float, ptr %y, i64 %iv
 ; CHECK-NEXT:    IR   %lv = load float, ptr %arrayidx, align 4
-; CHECK-NEXT:    IR   %call = tail call float @llvm.sqrt.f32(float %lv) #3
+; CHECK-NEXT:    IR   %call = tail call float @llvm.sqrt.f32(float %lv)
 ; CHECK-NEXT:    IR   %arrayidx2 = getelementptr inbounds float, ptr %x, i64 %iv
 ; CHECK-NEXT:    IR   store float %call, ptr %arrayidx2, align 4
 ; CHECK-NEXT:    IR   %iv.next = add i64 %iv, 1
@@ -80,7 +80,7 @@ for.end:                                          ; preds = %for.body, %entry
   ret void
 }
 
-define void @print_widen_gep_and_select(i64 %n, ptr noalias %y, ptr noalias %x, ptr %z) nounwind uwtable {
+define void @print_widen_gep_and_select(i64 %n, ptr noalias %y, ptr noalias %x, ptr %z) {
 ; CHECK-LABEL: VPlan for loop in 'print_widen_gep_and_select'
 ; CHECK:  VPlan 'Initial VPlan for VF={4},UF>=1' {
 ; CHECK-NEXT:  Live-in vp<[[VP0:%[0-9]+]]> = VF

--- a/llvm/test/Transforms/LoopVectorize/VPlan/vplan-stress-test-no-explict-vf.ll
+++ b/llvm/test/Transforms/LoopVectorize/VPlan/vplan-stress-test-no-explict-vf.ll
@@ -9,7 +9,7 @@
 @arr2 = external global [8 x i32], align 16
 @arr = external global [8 x [8 x i32]], align 16
 
-; Function Attrs: norecurse nounwind uwtable
+; Function Attrs: norecurse
 define void @foo(i32 %n) {
 entry:
   br label %for.body

--- a/llvm/test/Transforms/LoopVectorize/VPlan/vplan-stress-test-no-explict-vf.ll
+++ b/llvm/test/Transforms/LoopVectorize/VPlan/vplan-stress-test-no-explict-vf.ll
@@ -9,7 +9,6 @@
 @arr2 = external global [8 x i32], align 16
 @arr = external global [8 x [8 x i32]], align 16
 
-; Function Attrs: norecurse
 define void @foo(i32 %n) {
 entry:
   br label %for.body

--- a/llvm/test/Transforms/LoopVectorize/X86/CostModel/strided-load-i16.ll
+++ b/llvm/test/Transforms/LoopVectorize/X86/CostModel/strided-load-i16.ll
@@ -7,7 +7,6 @@ target triple = "x86_64-unknown-linux-gnu"
 @A = global [10240 x i16] zeroinitializer, align 16
 @B = global [10240 x i16] zeroinitializer, align 16
 
-; Function Attrs:
 define void @load_i16_stride2() {
 ;CHECK-LABEL: load_i16_stride2
 ;CHECK: Found an estimated cost of 1 for VF 1 For instruction:   %1 = load

--- a/llvm/test/Transforms/LoopVectorize/X86/CostModel/strided-load-i16.ll
+++ b/llvm/test/Transforms/LoopVectorize/X86/CostModel/strided-load-i16.ll
@@ -7,7 +7,7 @@ target triple = "x86_64-unknown-linux-gnu"
 @A = global [10240 x i16] zeroinitializer, align 16
 @B = global [10240 x i16] zeroinitializer, align 16
 
-; Function Attrs: nounwind uwtable
+; Function Attrs:
 define void @load_i16_stride2() {
 ;CHECK-LABEL: load_i16_stride2
 ;CHECK: Found an estimated cost of 1 for VF 1 For instruction:   %1 = load

--- a/llvm/test/Transforms/LoopVectorize/X86/CostModel/strided-load-i32.ll
+++ b/llvm/test/Transforms/LoopVectorize/X86/CostModel/strided-load-i32.ll
@@ -7,7 +7,6 @@ target triple = "x86_64-unknown-linux-gnu"
 @A = global [10240 x i32] zeroinitializer, align 16
 @B = global [10240 x i32] zeroinitializer, align 16
 
-; Function Attrs:
 define void @load_int_stride2() {
 ;CHECK-LABEL: load_int_stride2
 ;CHECK: Found an estimated cost of 1 for VF 1 For instruction:   %1 = load

--- a/llvm/test/Transforms/LoopVectorize/X86/CostModel/strided-load-i32.ll
+++ b/llvm/test/Transforms/LoopVectorize/X86/CostModel/strided-load-i32.ll
@@ -7,7 +7,7 @@ target triple = "x86_64-unknown-linux-gnu"
 @A = global [10240 x i32] zeroinitializer, align 16
 @B = global [10240 x i32] zeroinitializer, align 16
 
-; Function Attrs: nounwind uwtable
+; Function Attrs:
 define void @load_int_stride2() {
 ;CHECK-LABEL: load_int_stride2
 ;CHECK: Found an estimated cost of 1 for VF 1 For instruction:   %1 = load

--- a/llvm/test/Transforms/LoopVectorize/X86/CostModel/strided-load-i64.ll
+++ b/llvm/test/Transforms/LoopVectorize/X86/CostModel/strided-load-i64.ll
@@ -7,7 +7,7 @@ target triple = "x86_64-unknown-linux-gnu"
 @A = global [10240 x i64] zeroinitializer, align 16
 @B = global [10240 x i64] zeroinitializer, align 16
 
-; Function Attrs: nounwind uwtable
+; Function Attrs:
 define void @load_i64_stride2() {
 ;CHECK-LABEL: load_i64_stride2
 ;CHECK: Found an estimated cost of 1 for VF 1 For instruction:   %1 = load

--- a/llvm/test/Transforms/LoopVectorize/X86/CostModel/strided-load-i64.ll
+++ b/llvm/test/Transforms/LoopVectorize/X86/CostModel/strided-load-i64.ll
@@ -7,7 +7,6 @@ target triple = "x86_64-unknown-linux-gnu"
 @A = global [10240 x i64] zeroinitializer, align 16
 @B = global [10240 x i64] zeroinitializer, align 16
 
-; Function Attrs:
 define void @load_i64_stride2() {
 ;CHECK-LABEL: load_i64_stride2
 ;CHECK: Found an estimated cost of 1 for VF 1 For instruction:   %1 = load

--- a/llvm/test/Transforms/LoopVectorize/X86/CostModel/strided-load-i8.ll
+++ b/llvm/test/Transforms/LoopVectorize/X86/CostModel/strided-load-i8.ll
@@ -7,7 +7,6 @@ target triple = "x86_64-unknown-linux-gnu"
 @A = global [10240 x i8] zeroinitializer, align 16
 @B = global [10240 x i8] zeroinitializer, align 16
 
-; Function Attrs:
 define void @load_i8_stride2() {
 ;CHECK-LABEL: load_i8_stride2
 ;CHECK: Found an estimated cost of 1 for VF 1 For instruction:   %1 = load

--- a/llvm/test/Transforms/LoopVectorize/X86/CostModel/strided-load-i8.ll
+++ b/llvm/test/Transforms/LoopVectorize/X86/CostModel/strided-load-i8.ll
@@ -7,7 +7,7 @@ target triple = "x86_64-unknown-linux-gnu"
 @A = global [10240 x i8] zeroinitializer, align 16
 @B = global [10240 x i8] zeroinitializer, align 16
 
-; Function Attrs: nounwind uwtable
+; Function Attrs:
 define void @load_i8_stride2() {
 ;CHECK-LABEL: load_i8_stride2
 ;CHECK: Found an estimated cost of 1 for VF 1 For instruction:   %1 = load

--- a/llvm/test/Transforms/LoopVectorize/X86/avx1.ll
+++ b/llvm/test/Transforms/LoopVectorize/X86/avx1.ll
@@ -7,7 +7,7 @@ target triple = "x86_64-apple-macosx10.8.0"
 ; CHECK-LABEL: @read_mod_write_single_ptr(
 ; CHECK: load <8 x float>
 ; CHECK: ret void
-define void @read_mod_write_single_ptr(ptr nocapture %a, i32 %n) nounwind uwtable ssp {
+define void @read_mod_write_single_ptr(ptr nocapture %a, i32 %n) {
   %1 = icmp sgt i32 %n, 0
   br i1 %1, label %.lr.ph, label %._crit_edge
 
@@ -31,7 +31,7 @@ define void @read_mod_write_single_ptr(ptr nocapture %a, i32 %n) nounwind uwtabl
 ; SLOWMEM32: load <2 x i64>
 ; FASTMEM32: load <4 x i64>
 ; CHECK: ret void
-define void @read_mod_i64(ptr nocapture %a, i32 %n) nounwind uwtable ssp {
+define void @read_mod_i64(ptr nocapture %a, i32 %n) {
   %1 = icmp sgt i32 %n, 0
   br i1 %1, label %.lr.ph, label %._crit_edge
 

--- a/llvm/test/Transforms/LoopVectorize/X86/conversion-cost.ll
+++ b/llvm/test/Transforms/LoopVectorize/X86/conversion-cost.ll
@@ -4,7 +4,7 @@
 target datalayout = "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f32:32:32-f64:64:64-v64:64:64-v128:128:128-a0:0:64-s0:64:64-f80:128:128-n8:16:32:64-S128"
 target triple = "x86_64-apple-macosx10.8.0"
 
-define void @conversion_cost1(i32 %n, ptr nocapture %A, ptr nocapture %B) nounwind uwtable ssp {
+define void @conversion_cost1(i32 %n, ptr nocapture %A, ptr nocapture %B) {
 ; CHECK-LABEL: @conversion_cost1(
 ; CHECK-NEXT:    [[TMP1:%.*]] = icmp sgt i32 [[N:%.*]], 3
 ; CHECK-NEXT:    br i1 [[TMP1]], label [[ITER_CHECK:%.*]], label [[DOT_CRIT_EDGE:%.*]]
@@ -95,7 +95,7 @@ define void @conversion_cost1(i32 %n, ptr nocapture %A, ptr nocapture %B) nounwi
   ret void
 }
 
-define void @conversion_cost2(i32 %n, ptr nocapture %A, ptr nocapture %B) nounwind uwtable ssp {
+define void @conversion_cost2(i32 %n, ptr nocapture %A, ptr nocapture %B) {
 ; CHECK-LABEL: @conversion_cost2(
 ; CHECK-NEXT:    [[TMP1:%.*]] = icmp sgt i32 [[N:%.*]], 9
 ; CHECK-NEXT:    br i1 [[TMP1]], label [[DOTLR_PH_PREHEADER:%.*]], label [[DOT_CRIT_EDGE:%.*]]

--- a/llvm/test/Transforms/LoopVectorize/X86/cost-model.ll
+++ b/llvm/test/Transforms/LoopVectorize/X86/cost-model.ll
@@ -10,7 +10,7 @@ target triple = "x86_64-apple-macosx10.8.0"
 @a = common global [2048 x i32] zeroinitializer, align 16
 
 ; The program below gathers and scatters data. We better not vectorize it.
-define void @cost_model_1() nounwind uwtable noinline ssp {
+define void @cost_model_1() noinline {
 ; CHECK-LABEL: define void @cost_model_1(
 ; CHECK-SAME: ) #[[ATTR0:[0-9]+]] {
 ; CHECK-NEXT:  [[ENTRY:.*]]:

--- a/llvm/test/Transforms/LoopVectorize/X86/drop-poison-generating-flags.ll
+++ b/llvm/test/Transforms/LoopVectorize/X86/drop-poison-generating-flags.ll
@@ -833,7 +833,7 @@ exit:
   ret void
 }
 
-attributes #0 = { noinline nounwind uwtable "target-features"="+avx512bw,+avx512cd,+avx512dq,+avx512f,+avx512vl" }
+attributes #0 = { noinline "target-features"="+avx512bw,+avx512cd,+avx512dq,+avx512f,+avx512vl" }
 attributes #1 = { "target-features"="+avx" }
 
 !0 = !{}

--- a/llvm/test/Transforms/LoopVectorize/X86/gather_scatter.ll
+++ b/llvm/test/Transforms/LoopVectorize/X86/gather_scatter.ll
@@ -20,7 +20,7 @@ target triple = "x86_64-pc_linux"
 ;  }
 ;}
 
-; Function Attrs: nounwind uwtable
+; Function Attrs:
 define void @foo1(ptr noalias %in, ptr noalias %out, ptr noalias %trigger, ptr noalias %index) {
 ; AVX512-LABEL: @foo1(
 ; AVX512-NEXT:  entry:

--- a/llvm/test/Transforms/LoopVectorize/X86/gather_scatter.ll
+++ b/llvm/test/Transforms/LoopVectorize/X86/gather_scatter.ll
@@ -20,7 +20,6 @@ target triple = "x86_64-pc_linux"
 ;  }
 ;}
 
-; Function Attrs:
 define void @foo1(ptr noalias %in, ptr noalias %out, ptr noalias %trigger, ptr noalias %index) {
 ; AVX512-LABEL: @foo1(
 ; AVX512-NEXT:  entry:

--- a/llvm/test/Transforms/LoopVectorize/X86/gcc-examples.ll
+++ b/llvm/test/Transforms/LoopVectorize/X86/gcc-examples.ll
@@ -23,7 +23,7 @@ target triple = "x86_64-apple-macosx10.8.0"
 ;UNROLL: store <4 x i32>
 ;UNROLL: store <4 x i32>
 ;UNROLL: ret void
-define void @example1() nounwind uwtable ssp {
+define void @example1() {
   br label %1
 
 ; <label>:1                                       ; preds = %1, %0
@@ -56,7 +56,7 @@ define void @example1() nounwind uwtable ssp {
 ;UNROLL: store <4 x i32>
 ;UNROLL: store <4 x i32>
 ;UNROLL: ret void
-define void @example10b(ptr noalias nocapture %sa, ptr noalias nocapture %sb, ptr noalias nocapture %sc, ptr noalias nocapture %ia, ptr noalias nocapture %ib, ptr noalias nocapture %ic) nounwind uwtable ssp {
+define void @example10b(ptr noalias nocapture %sa, ptr noalias nocapture %sb, ptr noalias nocapture %sc, ptr noalias nocapture %ia, ptr noalias nocapture %ib, ptr noalias nocapture %ic) {
   br label %1
 
 ; <label>:1                                       ; preds = %1, %0

--- a/llvm/test/Transforms/LoopVectorize/X86/illegal-parallel-loop-uniform-write.ll
+++ b/llvm/test/Transforms/LoopVectorize/X86/illegal-parallel-loop-uniform-write.ll
@@ -18,7 +18,7 @@ target triple = "x86_64-unknown-linux-gnu"
 ;   }
 ; }
 
-; Function Attrs: nounwind uwtable
+; Function Attrs:
 define void @foo(ptr nocapture %a, ptr nocapture %b, i32 %k, i32 %m) #0 {
 ; CHECK-LABEL: @foo(
 ; CHECK-NEXT:  entry:
@@ -214,7 +214,7 @@ for.end15:                                        ; preds = %for.end.us, %entry
   ret void
 }
 
-attributes #0 = { nounwind uwtable "less-precise-fpmad"="false" "frame-pointer"="none" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "use-soft-float"="false" }
+attributes #0 = { "less-precise-fpmad"="false" "frame-pointer"="none" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "use-soft-float"="false" }
 
 !3 = !{!4, !5}
 !4 = !{!4}

--- a/llvm/test/Transforms/LoopVectorize/X86/illegal-parallel-loop-uniform-write.ll
+++ b/llvm/test/Transforms/LoopVectorize/X86/illegal-parallel-loop-uniform-write.ll
@@ -18,7 +18,6 @@ target triple = "x86_64-unknown-linux-gnu"
 ;   }
 ; }
 
-; Function Attrs:
 define void @foo(ptr nocapture %a, ptr nocapture %b, i32 %k, i32 %m) #0 {
 ; CHECK-LABEL: @foo(
 ; CHECK-NEXT:  entry:

--- a/llvm/test/Transforms/LoopVectorize/X86/int128_no_gather.ll
+++ b/llvm/test/Transforms/LoopVectorize/X86/int128_no_gather.ll
@@ -12,7 +12,7 @@ target triple = "x86_64-unknown-linux-gnu"
 @.str.1 = private unnamed_addr constant [44 x i8] c" FAIL.....Y3 1/1 (BUBBLE SORT), X(25) = %d\0A\00", align 1
 @str = private unnamed_addr constant [45 x i8] c" PASS.....Y3 1/1 (BUBBLE SORT), X(25) = 5085\00"
 
-; Function Attrs: noinline nounwind uwtable
+; Function Attrs: noinline
 declare i32 @y3inner() #0
 
 define i32 @main() #0 {
@@ -71,6 +71,6 @@ declare i32 @printf(ptr, ...) #1
 ; Function Attrs: nounwind
 declare i32 @puts(ptr nocapture readonly) #2
 
-attributes #0 = { noinline nounwind uwtable "disable-tail-calls"="false" "less-precise-fpmad"="false" "frame-pointer"="all" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "stack-protector-buffer-size"="8" "target-cpu"="skylake-avx512" "target-features"="+adx,+aes,+avx,+avx2,+avx512bw,+avx512cd,+avx512dq,+avx512f,+avx512vl,+bmi,+bmi2,+clflushopt,+clwb,+cx16,+f16c,+fma,+fsgsbase,+fxsr,+lzcnt,+mmx,+movbe,+mpx,+pclmul,+pku,+popcnt,+rdrnd,+rdseed,+rtm,+sgx,+sse,+sse2,+sse3,+sse4.1,+sse4.2,+ssse3,+x87,+xsave,+xsavec,+xsaveopt,+xsaves" "use-soft-float"="false" }
+attributes #0 = { noinline "disable-tail-calls"="false" "less-precise-fpmad"="false" "frame-pointer"="all" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "stack-protector-buffer-size"="8" "target-cpu"="skylake-avx512" "target-features"="+adx,+aes,+avx,+avx2,+avx512bw,+avx512cd,+avx512dq,+avx512f,+avx512vl,+bmi,+bmi2,+clflushopt,+clwb,+cx16,+f16c,+fma,+fsgsbase,+fxsr,+lzcnt,+mmx,+movbe,+mpx,+pclmul,+pku,+popcnt,+rdrnd,+rdseed,+rtm,+sgx,+sse,+sse2,+sse3,+sse4.1,+sse4.2,+ssse3,+x87,+xsave,+xsavec,+xsaveopt,+xsaves" "use-soft-float"="false" }
 attributes #1 = { nounwind "disable-tail-calls"="false" "less-precise-fpmad"="false" "frame-pointer"="all" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "stack-protector-buffer-size"="8" "target-cpu"="skylake-avx512" "target-features"="+adx,+aes,+avx,+avx2,+avx512bw,+avx512cd,+avx512dq,+avx512f,+avx512vl,+bmi,+bmi2,+clflushopt,+clwb,+cx16,+f16c,+fma,+fsgsbase,+fxsr,+lzcnt,+mmx,+movbe,+mpx,+pclmul,+pku,+popcnt,+rdrnd,+rdseed,+rtm,+sgx,+sse,+sse2,+sse3,+sse4.1,+sse4.2,+ssse3,+x87,+xsave,+xsavec,+xsaveopt,+xsaves" "use-soft-float"="false" }
 attributes #2 = { nounwind }

--- a/llvm/test/Transforms/LoopVectorize/X86/interleave_short_tc.ll
+++ b/llvm/test/Transforms/LoopVectorize/X86/interleave_short_tc.ll
@@ -17,7 +17,7 @@ target triple = "x86_64-unknown-linux-gnu"
 @a = global [5 x i32] zeroinitializer, align 16
 @b = global [5 x i32] zeroinitializer, align 16
 
-; Function Attrs: nofree norecurse nounwind uwtable
+; Function Attrs: nofree norecurse
 define void @_Z3fooi(i32 %M) {
 ; CHECK-LABEL: @_Z3fooi(
 ; CHECK:       [[VECTOR_BODY:vector\.body]]:

--- a/llvm/test/Transforms/LoopVectorize/X86/interleave_short_tc.ll
+++ b/llvm/test/Transforms/LoopVectorize/X86/interleave_short_tc.ll
@@ -17,7 +17,6 @@ target triple = "x86_64-unknown-linux-gnu"
 @a = global [5 x i32] zeroinitializer, align 16
 @b = global [5 x i32] zeroinitializer, align 16
 
-; Function Attrs: nofree norecurse
 define void @_Z3fooi(i32 %M) {
 ; CHECK-LABEL: @_Z3fooi(
 ; CHECK:       [[VECTOR_BODY:vector\.body]]:

--- a/llvm/test/Transforms/LoopVectorize/X86/min-trip-count-switch.ll
+++ b/llvm/test/Transforms/LoopVectorize/X86/min-trip-count-switch.ll
@@ -4,7 +4,7 @@ target datalayout = "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f3
 target triple = "x86_64-unknown-linux-gnu"
 
 ; CHECK: <4 x float>
-define void @trivial_loop(ptr nocapture %a) nounwind uwtable optsize {
+define void @trivial_loop(ptr nocapture %a) optsize {
 entry:
   br label %for.body
 

--- a/llvm/test/Transforms/LoopVectorize/X86/outer_loop_test1_no_explicit_vect_width.ll
+++ b/llvm/test/Transforms/LoopVectorize/X86/outer_loop_test1_no_explicit_vect_width.ll
@@ -22,7 +22,7 @@
 @arr2 = external global [8 x i32], align 16
 @arr = external global [8 x [8 x i32]], align 16
 
-; Function Attrs: norecurse nounwind uwtable
+; Function Attrs: norecurse
 define void @foo(i32 %n) {
 ; CHECK-LABEL: define void @foo(
 ; CHECK-SAME: i32 [[N:%.*]]) {

--- a/llvm/test/Transforms/LoopVectorize/X86/outer_loop_test1_no_explicit_vect_width.ll
+++ b/llvm/test/Transforms/LoopVectorize/X86/outer_loop_test1_no_explicit_vect_width.ll
@@ -22,7 +22,6 @@
 @arr2 = external global [8 x i32], align 16
 @arr = external global [8 x [8 x i32]], align 16
 
-; Function Attrs: norecurse
 define void @foo(i32 %n) {
 ; CHECK-LABEL: define void @foo(
 ; CHECK-SAME: i32 [[N:%.*]]) {

--- a/llvm/test/Transforms/LoopVectorize/X86/parallel-loops-after-reg2mem.ll
+++ b/llvm/test/Transforms/LoopVectorize/X86/parallel-loops-after-reg2mem.ll
@@ -8,7 +8,7 @@ target triple = "x86_64-unknown-linux-gnu"
 ; now non-vectorizable.
 
 ;CHECK-NOT: <4 x i32>
-define void @parallel_loop(ptr nocapture %a, ptr nocapture %b) nounwind uwtable {
+define void @parallel_loop(ptr nocapture %a, ptr nocapture %b) {
 entry:
   %indvars.iv.next.reg2mem = alloca i64
   %indvars.iv.reg2mem = alloca i64

--- a/llvm/test/Transforms/LoopVectorize/X86/parallel-loops.ll
+++ b/llvm/test/Transforms/LoopVectorize/X86/parallel-loops.ll
@@ -13,7 +13,7 @@ target triple = "x86_64-unknown-linux-gnu"
 ;    }
 ;}
 
-define void @loop(ptr nocapture %a, ptr nocapture %b) nounwind uwtable {
+define void @loop(ptr nocapture %a, ptr nocapture %b) {
 ; CHECK-LABEL: @loop(
 ; CHECK-NEXT:  entry:
 ; CHECK-NEXT:    br label [[FOR_BODY:%.*]]
@@ -63,7 +63,7 @@ for.end:                                          ; preds = %for.body
 ; The same loop with parallel loop metadata added to the loop branch
 ; and the memory instructions.
 
-define void @parallel_loop(ptr nocapture %a, ptr nocapture %b) nounwind uwtable {
+define void @parallel_loop(ptr nocapture %a, ptr nocapture %b) {
 ; CHECK-LABEL: @parallel_loop(
 ; CHECK-NEXT:  entry:
 ; CHECK-NEXT:    br label [[VECTOR_PH:%.*]]
@@ -142,7 +142,7 @@ for.end:                                          ; preds = %for.body
 ; accesses refer to a different loop's identifier.
 
 
-define void @mixed_metadata(ptr nocapture %a, ptr nocapture %b) nounwind uwtable {
+define void @mixed_metadata(ptr nocapture %a, ptr nocapture %b) {
 ; CHECK-LABEL: @mixed_metadata(
 ; CHECK-NEXT:  entry:
 ; CHECK-NEXT:    br label [[FOR_BODY:%.*]]

--- a/llvm/test/Transforms/LoopVectorize/X86/tail_folding_and_assume_safety.ll
+++ b/llvm/test/Transforms/LoopVectorize/X86/tail_folding_and_assume_safety.ll
@@ -20,7 +20,7 @@ target triple = "x86_64-pc-linux-gnu"
 ;CHECK: call <8 x i32> @llvm.masked.load
 ;CHECK: call void @llvm.masked.store
 
-; Function Attrs: nofree norecurse nounwind uwtable
+; Function Attrs: nofree norecurse
 define void @fold_tail(ptr noalias nocapture %p, ptr noalias nocapture readonly %q1, ptr noalias nocapture readonly %q2,
 i32 %guard) #0 {
 entry:
@@ -66,7 +66,7 @@ for.inc:
 ;CHECK:  call <8 x i32> @llvm.masked.load
 ;CHECK:  call void @llvm.masked.store
 
-; Function Attrs: norecurse nounwind uwtable
+; Function Attrs: norecurse
 define void @assume_safety(ptr nocapture, ptr nocapture readonly, ptr nocapture readonly, i32) #0 {
   %5 = sext i32 %3 to i64
   br label %7
@@ -112,7 +112,7 @@ define void @assume_safety(ptr nocapture, ptr nocapture readonly, ptr nocapture 
 ;CHECK: call <8 x i32> @llvm.masked.load
 ;CHECK: call void @llvm.masked.store
 
-; Function Attrs: nofree norecurse nounwind uwtable
+; Function Attrs: nofree norecurse
 define void @fold_tail_and_assume_safety(ptr noalias nocapture %p, ptr noalias nocapture readonly %q1, ptr noalias nocapture readonly %q2,
 i32 %guard) #0 {
 entry:
@@ -143,7 +143,7 @@ for.inc:
   br i1 %exitcond, label %for.cond.cleanup, label %for.body, !llvm.loop !11
 }
 
-attributes #0 = { norecurse nounwind uwtable "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "frame-pointer"="none" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="8" "target-features"="+fxsr,+mmx,+sse,+sse2,+x87" "use-soft-float"="false" }
+attributes #0 = { norecurse "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "frame-pointer"="none" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="8" "target-features"="+fxsr,+mmx,+sse,+sse2,+x87" "use-soft-float"="false" }
 
 !llvm.module.flags = !{!0}
 !llvm.ident = !{!1}

--- a/llvm/test/Transforms/LoopVectorize/X86/tail_folding_and_assume_safety.ll
+++ b/llvm/test/Transforms/LoopVectorize/X86/tail_folding_and_assume_safety.ll
@@ -20,7 +20,6 @@ target triple = "x86_64-pc-linux-gnu"
 ;CHECK: call <8 x i32> @llvm.masked.load
 ;CHECK: call void @llvm.masked.store
 
-; Function Attrs: nofree norecurse
 define void @fold_tail(ptr noalias nocapture %p, ptr noalias nocapture readonly %q1, ptr noalias nocapture readonly %q2,
 i32 %guard) #0 {
 entry:
@@ -66,7 +65,6 @@ for.inc:
 ;CHECK:  call <8 x i32> @llvm.masked.load
 ;CHECK:  call void @llvm.masked.store
 
-; Function Attrs: norecurse
 define void @assume_safety(ptr nocapture, ptr nocapture readonly, ptr nocapture readonly, i32) #0 {
   %5 = sext i32 %3 to i64
   br label %7
@@ -112,7 +110,6 @@ define void @assume_safety(ptr nocapture, ptr nocapture readonly, ptr nocapture 
 ;CHECK: call <8 x i32> @llvm.masked.load
 ;CHECK: call void @llvm.masked.store
 
-; Function Attrs: nofree norecurse
 define void @fold_tail_and_assume_safety(ptr noalias nocapture %p, ptr noalias nocapture readonly %q1, ptr noalias nocapture readonly %q2,
 i32 %guard) #0 {
 entry:
@@ -143,7 +140,7 @@ for.inc:
   br i1 %exitcond, label %for.cond.cleanup, label %for.body, !llvm.loop !11
 }
 
-attributes #0 = { norecurse "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "frame-pointer"="none" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="8" "target-features"="+fxsr,+mmx,+sse,+sse2,+x87" "use-soft-float"="false" }
+attributes #0 = { "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "frame-pointer"="none" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="8" "target-features"="+fxsr,+mmx,+sse,+sse2,+x87" "use-soft-float"="false" }
 
 !llvm.module.flags = !{!0}
 !llvm.ident = !{!1}

--- a/llvm/test/Transforms/LoopVectorize/X86/unroll-pm.ll
+++ b/llvm/test/Transforms/LoopVectorize/X86/unroll-pm.ll
@@ -11,7 +11,7 @@ target triple = "x86_64-apple-macosx10.8.0"
 ;CHECK-NOUNRL: store <4 x i32>
 ;CHECK-NOUNRL-NOT: store <4 x i32>
 ;CHECK-NOUNRL: ret
-define void @bar(ptr nocapture %A, i32 %n) nounwind uwtable ssp {
+define void @bar(ptr nocapture %A, i32 %n) {
   %1 = icmp sgt i32 %n, 0
   br i1 %1, label %.lr.ph, label %._crit_edge
 

--- a/llvm/test/Transforms/LoopVectorize/X86/unroll-small-loops.ll
+++ b/llvm/test/Transforms/LoopVectorize/X86/unroll-small-loops.ll
@@ -22,7 +22,7 @@ target triple = "x86_64-apple-macosx10.8.0"
 ; CHECK-SCALAR: store i32
 ; CHECK-SCALAR-NOT: store i32
 ; CHECK-SCALAR: ret
-define void @foo_trip_count_8(ptr nocapture %A) nounwind uwtable ssp {
+define void @foo_trip_count_8(ptr nocapture %A) {
 entry:
   br label %for.body
 
@@ -64,7 +64,7 @@ for.end:                                       ; preds = %for.body
 ; CHECK-SCALAR: store i32
 ; CHECK-SCALAR-NOT: store i32
 ; CHECK-SCALAR: ret
-define void @foo_trip_count_16(ptr nocapture %A) nounwind uwtable ssp {
+define void @foo_trip_count_16(ptr nocapture %A) {
 entry:
   br label %for.body
 
@@ -106,7 +106,7 @@ for.end:                                       ; preds = %for.body
 ; CHECK-SCALAR: store i32
 ; CHECK-SCALAR-NOT: store i32
 ; CHECK-SCALAR: ret
-define void @foo_trip_count_17(ptr nocapture %A) nounwind uwtable ssp {
+define void @foo_trip_count_17(ptr nocapture %A) {
 entry:
   br label %for.body
 
@@ -144,7 +144,7 @@ for.end:                                       ; preds = %for.body
 ; CHECK-SCALAR: store i32
 ; CHECK-SCALAR-NOT: store i32
 ; CHECK-SCALAR: ret
-define void @foo_trip_count_24(ptr nocapture %A) nounwind uwtable ssp {
+define void @foo_trip_count_24(ptr nocapture %A) {
 entry:
   br label %for.body
 
@@ -182,7 +182,7 @@ for.end:                                       ; preds = %for.body
 ; CHECK-SCALAR: store i32
 ; CHECK-SCALAR-NOT: store i32
 ; CHECK-SCALAR: ret
-define void @foo_trip_count_25(ptr nocapture %A) nounwind uwtable ssp {
+define void @foo_trip_count_25(ptr nocapture %A) {
 entry:
   br label %for.body
 
@@ -224,7 +224,7 @@ for.end:                                       ; preds = %for.body
 ; CHECK-SCALAR: store i32
 ; CHECK-SCALAR-NOT: store i32
 ; CHECK-SCALAR: ret
-define void @foo_trip_count_33(ptr nocapture %A) nounwind uwtable ssp {
+define void @foo_trip_count_33(ptr nocapture %A) {
 entry:
   br label %for.body
 
@@ -267,7 +267,7 @@ for.end:                                       ; preds = %for.body
 ; CHECK-SCALAR: store i32
 ; CHECK-SCALAR-NOT: store i32
 ; CHECK-SCALAR: ret
-define void @foo_trip_count_101(ptr nocapture %A) nounwind uwtable ssp {
+define void @foo_trip_count_101(ptr nocapture %A) {
 entry:
   br label %for.body
 
@@ -300,7 +300,7 @@ for.end:                                       ; preds = %for.body
 ; CHECK-SCALAR: store i32
 ; CHECK-SCALAR-NOT: store i32
 ; CHECK-SCALAR: ret
-define void @bar(ptr nocapture %A, i32 %n) nounwind uwtable ssp {
+define void @bar(ptr nocapture %A, i32 %n) {
   %1 = icmp sgt i32 %n, 0
   br i1 %1, label %.lr.ph, label %._crit_edge
 

--- a/llvm/test/Transforms/LoopVectorize/X86/unroll_selection.ll
+++ b/llvm/test/Transforms/LoopVectorize/X86/unroll_selection.ll
@@ -10,7 +10,7 @@ target triple = "x86_64-apple-macosx10.8.0"
 ;CHECK: store <4 x double>
 ;CHECK-NOT: store <4 x double>
 ;CHECK: ret
-define void @reg_pressure(ptr nocapture %A, i32 %n) nounwind uwtable ssp {
+define void @reg_pressure(ptr nocapture %A, i32 %n) {
   %1 = sext i32 %n to i64
   br label %2
 
@@ -52,7 +52,7 @@ define void @reg_pressure(ptr nocapture %A, i32 %n) nounwind uwtable ssp {
 ;CHECK: xor
 ;CHECK: xor
 ;CHECK: ret
-define void @small_loop(ptr nocapture %A, i64 %n) nounwind uwtable ssp {
+define void @small_loop(ptr nocapture %A, i64 %n) {
   %1 = icmp eq i64 %n, 0
   br i1 %1, label %._crit_edge, label %.lr.ph
 

--- a/llvm/test/Transforms/LoopVectorize/X86/veclib-calls.ll
+++ b/llvm/test/Transforms/LoopVectorize/X86/veclib-calls.ll
@@ -7,7 +7,7 @@ target triple = "x86_64-unknown-linux-gnu"
 ;CHECK: vsqrtf{{.*}}<4 x float>
 ;CHECK: ret void
 declare float @sqrtf(float) nounwind readnone
-define void @sqrt_f32(i32 %n, ptr noalias %y, ptr noalias %x) nounwind uwtable {
+define void @sqrt_f32(i32 %n, ptr noalias %y, ptr noalias %x) {
 entry:
   %cmp6 = icmp sgt i32 %n, 0
   br i1 %cmp6, label %for.body, label %for.end
@@ -32,7 +32,7 @@ for.end:                                          ; preds = %for.body, %entry
 ;CHECK: vexpf{{.*}}<4 x float>
 ;CHECK: ret void
 declare float @expf(float) nounwind readnone
-define void @exp_f32(i32 %n, ptr noalias %y, ptr noalias %x) nounwind uwtable {
+define void @exp_f32(i32 %n, ptr noalias %y, ptr noalias %x) {
 entry:
   %cmp6 = icmp sgt i32 %n, 0
   br i1 %cmp6, label %for.body, label %for.end
@@ -57,7 +57,7 @@ for.end:                                          ; preds = %for.body, %entry
 ;CHECK: vlogf{{.*}}<4 x float>
 ;CHECK: ret void
 declare float @logf(float) nounwind readnone
-define void @log_f32(i32 %n, ptr noalias %y, ptr noalias %x) nounwind uwtable {
+define void @log_f32(i32 %n, ptr noalias %y, ptr noalias %x) {
 entry:
   %cmp6 = icmp sgt i32 %n, 0
   br i1 %cmp6, label %for.body, label %for.end
@@ -83,7 +83,7 @@ for.end:                                          ; preds = %for.body, %entry
 ;CHECK: fabs{{.*}}<4 x float>
 ;CHECK: ret void
 declare float @fabsf(float) nounwind readnone
-define void @fabs_f32(i32 %n, ptr noalias %y, ptr noalias %x) nounwind uwtable {
+define void @fabs_f32(i32 %n, ptr noalias %y, ptr noalias %x) {
 entry:
   %cmp6 = icmp sgt i32 %n, 0
   br i1 %cmp6, label %for.body, label %for.end
@@ -109,7 +109,7 @@ for.end:                                          ; preds = %for.body, %entry
 ;CHECK: vexpf{{.*}}<4 x float>
 ;CHECK: ret void
 declare float @llvm.exp.f32(float) nounwind readnone
-define void @exp_f32_intrin(i32 %n, ptr noalias %y, ptr noalias %x) nounwind uwtable {
+define void @exp_f32_intrin(i32 %n, ptr noalias %y, ptr noalias %x) {
 entry:
   %cmp6 = icmp sgt i32 %n, 0
   br i1 %cmp6, label %for.body, label %for.end
@@ -135,7 +135,7 @@ for.end:                                          ; preds = %for.body, %entry
 ;CHECK-NOT: foo{{.*}}<4 x float>
 ;CHECK: ret void
 declare float @foo(float) nounwind readnone
-define void @foo_f32(i32 %n, ptr noalias %y, ptr noalias %x) nounwind uwtable {
+define void @foo_f32(i32 %n, ptr noalias %y, ptr noalias %x) {
 entry:
   %cmp6 = icmp sgt i32 %n, 0
   br i1 %cmp6, label %for.body, label %for.end
@@ -160,7 +160,7 @@ for.end:                                          ; preds = %for.body, %entry
 ;CHECK-LABEL: @sqrt_f32_nobuiltin(
 ;CHECK-NOT: vsqrtf{{.*}}<4 x float>
 ;CHECK: ret void
-define void @sqrt_f32_nobuiltin(i32 %n, ptr noalias %y, ptr noalias %x) nounwind uwtable {
+define void @sqrt_f32_nobuiltin(i32 %n, ptr noalias %y, ptr noalias %x) {
 entry:
   %cmp6 = icmp sgt i32 %n, 0
   br i1 %cmp6, label %for.body, label %for.end
@@ -185,7 +185,7 @@ for.end:                                          ; preds = %for.body, %entry
 ;CHECK: vceilf{{.*}}<4 x float>
 ;CHECK: ret void
 declare float @ceilf(float) nounwind readnone
-define void @ceil_f32(i32 %n, ptr noalias %y, ptr noalias %x) nounwind uwtable {
+define void @ceil_f32(i32 %n, ptr noalias %y, ptr noalias %x) {
 entry:
   %cmp6 = icmp sgt i32 %n, 0
   br i1 %cmp6, label %for.body, label %for.end
@@ -210,7 +210,7 @@ for.end:                                          ; preds = %for.body, %entry
 ;CHECK: vfloorf{{.*}}<4 x float>
 ;CHECK: ret void
 declare float @floorf(float) nounwind readnone
-define void @floor_f32(i32 %n, ptr noalias %y, ptr noalias %x) nounwind uwtable {
+define void @floor_f32(i32 %n, ptr noalias %y, ptr noalias %x) {
 entry:
   %cmp6 = icmp sgt i32 %n, 0
   br i1 %cmp6, label %for.body, label %for.end
@@ -235,7 +235,7 @@ for.end:                                          ; preds = %for.body, %entry
 ;CHECK: vexpm1f{{.*}}<4 x float>
 ;CHECK: ret void
 declare float @expm1f(float) nounwind readnone
-define void @expm1_f32(i32 %n, ptr noalias %y, ptr noalias %x) nounwind uwtable {
+define void @expm1_f32(i32 %n, ptr noalias %y, ptr noalias %x) {
 entry:
   %cmp6 = icmp sgt i32 %n, 0
   br i1 %cmp6, label %for.body, label %for.end
@@ -260,7 +260,7 @@ for.end:                                          ; preds = %for.body, %entry
 ;CHECK: vlog1pf{{.*}}<4 x float>
 ;CHECK: ret void
 declare float @log1pf(float) nounwind readnone
-define void @log1p_f32(i32 %n, ptr noalias %y, ptr noalias %x) nounwind uwtable {
+define void @log1p_f32(i32 %n, ptr noalias %y, ptr noalias %x) {
 entry:
   %cmp6 = icmp sgt i32 %n, 0
   br i1 %cmp6, label %for.body, label %for.end
@@ -285,7 +285,7 @@ for.end:                                          ; preds = %for.body, %entry
 ;CHECK: vlog10f{{.*}}<4 x float>
 ;CHECK: ret void
 declare float @log10f(float) nounwind readnone
-define void @log10_f32(i32 %n, ptr noalias %y, ptr noalias %x) nounwind uwtable {
+define void @log10_f32(i32 %n, ptr noalias %y, ptr noalias %x) {
 entry:
   %cmp6 = icmp sgt i32 %n, 0
   br i1 %cmp6, label %for.body, label %for.end
@@ -310,7 +310,7 @@ for.end:                                          ; preds = %for.body, %entry
 ;CHECK: vlogbf{{.*}}<4 x float>
 ;CHECK: ret void
 declare float @logbf(float) nounwind readnone
-define void @logb_f32(i32 %n, ptr noalias %y, ptr noalias %x) nounwind uwtable {
+define void @logb_f32(i32 %n, ptr noalias %y, ptr noalias %x) {
 entry:
   %cmp6 = icmp sgt i32 %n, 0
   br i1 %cmp6, label %for.body, label %for.end
@@ -335,7 +335,7 @@ for.end:                                          ; preds = %for.body, %entry
 ;CHECK: vsinf{{.*}}<4 x float>
 ;CHECK: ret void
 declare float @sinf(float) nounwind readnone
-define void @sin_f32(i32 %n, ptr noalias %y, ptr noalias %x) nounwind uwtable {
+define void @sin_f32(i32 %n, ptr noalias %y, ptr noalias %x) {
 entry:
   %cmp6 = icmp sgt i32 %n, 0
   br i1 %cmp6, label %for.body, label %for.end
@@ -360,7 +360,7 @@ for.end:                                          ; preds = %for.body, %entry
 ;CHECK: vcosf{{.*}}<4 x float>
 ;CHECK: ret void
 declare float @cosf(float) nounwind readnone
-define void @cos_f32(i32 %n, ptr noalias %y, ptr noalias %x) nounwind uwtable {
+define void @cos_f32(i32 %n, ptr noalias %y, ptr noalias %x) {
 entry:
   %cmp6 = icmp sgt i32 %n, 0
   br i1 %cmp6, label %for.body, label %for.end
@@ -385,7 +385,7 @@ for.end:                                          ; preds = %for.body, %entry
 ;CHECK: vtanf{{.*}}<4 x float>
 ;CHECK: ret void
 declare float @tanf(float) nounwind readnone
-define void @tan_f32(i32 %n, ptr noalias %y, ptr noalias %x) nounwind uwtable {
+define void @tan_f32(i32 %n, ptr noalias %y, ptr noalias %x) {
 entry:
   %cmp6 = icmp sgt i32 %n, 0
   br i1 %cmp6, label %for.body, label %for.end
@@ -410,7 +410,7 @@ for.end:                                          ; preds = %for.body, %entry
 ;CHECK: vtanf{{.*}}<4 x float>
 ;CHECK: ret void
 declare float @llvm.tan.f32(float) nounwind readnone
-define void @tan_f32_intrinsic(i32 %n, ptr noalias %y, ptr noalias %x) nounwind uwtable {
+define void @tan_f32_intrinsic(i32 %n, ptr noalias %y, ptr noalias %x) {
 entry:
   %cmp6 = icmp sgt i32 %n, 0
   br i1 %cmp6, label %for.body, label %for.end
@@ -435,7 +435,7 @@ for.end:                                          ; preds = %for.body, %entry
 ;CHECK: vasinf{{.*}}<4 x float>
 ;CHECK: ret void
 declare float @asinf(float) nounwind readnone
-define void @asin_f32(i32 %n, ptr noalias %y, ptr noalias %x) nounwind uwtable {
+define void @asin_f32(i32 %n, ptr noalias %y, ptr noalias %x) {
 entry:
   %cmp6 = icmp sgt i32 %n, 0
   br i1 %cmp6, label %for.body, label %for.end
@@ -460,7 +460,7 @@ for.end:                                          ; preds = %for.body, %entry
 ;CHECK: vasinf{{.*}}<4 x float>
 ;CHECK: ret void
 declare float @llvm.asin.f32(float) nounwind readnone
-define void @asin_f32_intrinsic(i32 %n, ptr noalias %y, ptr noalias %x) nounwind uwtable {
+define void @asin_f32_intrinsic(i32 %n, ptr noalias %y, ptr noalias %x) {
 entry:
   %cmp6 = icmp sgt i32 %n, 0
   br i1 %cmp6, label %for.body, label %for.end
@@ -485,7 +485,7 @@ for.end:                                          ; preds = %for.body, %entry
 ;CHECK: vacosf{{.*}}<4 x float>
 ;CHECK: ret void
 declare float @acosf(float) nounwind readnone
-define void @acos_f32(i32 %n, ptr noalias %y, ptr noalias %x) nounwind uwtable {
+define void @acos_f32(i32 %n, ptr noalias %y, ptr noalias %x) {
 entry:
   %cmp6 = icmp sgt i32 %n, 0
   br i1 %cmp6, label %for.body, label %for.end
@@ -510,7 +510,7 @@ for.end:                                          ; preds = %for.body, %entry
 ;CHECK: vacosf{{.*}}<4 x float>
 ;CHECK: ret void
 declare float @llvm.acos.f32(float) nounwind readnone
-define void @acos_f32_intrinsic(i32 %n, ptr noalias %y, ptr noalias %x) nounwind uwtable {
+define void @acos_f32_intrinsic(i32 %n, ptr noalias %y, ptr noalias %x) {
 entry:
   %cmp6 = icmp sgt i32 %n, 0
   br i1 %cmp6, label %for.body, label %for.end
@@ -535,7 +535,7 @@ for.end:                                          ; preds = %for.body, %entry
 ;CHECK: vatanf{{.*}}<4 x float>
 ;CHECK: ret void
 declare float @atanf(float) nounwind readnone
-define void @atan_f32(i32 %n, ptr noalias %y, ptr noalias %x) nounwind uwtable {
+define void @atan_f32(i32 %n, ptr noalias %y, ptr noalias %x) {
 entry:
   %cmp6 = icmp sgt i32 %n, 0
   br i1 %cmp6, label %for.body, label %for.end
@@ -560,7 +560,7 @@ for.end:                                          ; preds = %for.body, %entry
 ;CHECK: vatanf{{.*}}<4 x float>
 ;CHECK: ret void
 declare float @llvm.atan.f32(float) nounwind readnone
-define void @atan_f32_intrinsic(i32 %n, ptr noalias %y, ptr noalias %x) nounwind uwtable {
+define void @atan_f32_intrinsic(i32 %n, ptr noalias %y, ptr noalias %x) {
 entry:
   %cmp6 = icmp sgt i32 %n, 0
   br i1 %cmp6, label %for.body, label %for.end
@@ -585,7 +585,7 @@ for.end:                                          ; preds = %for.body, %entry
 ;CHECK: vsinhf{{.*}}<4 x float>
 ;CHECK: ret void
 declare float @sinhf(float) nounwind readnone
-define void @sinh_f32(i32 %n, ptr noalias %y, ptr noalias %x) nounwind uwtable {
+define void @sinh_f32(i32 %n, ptr noalias %y, ptr noalias %x) {
 entry:
   %cmp6 = icmp sgt i32 %n, 0
   br i1 %cmp6, label %for.body, label %for.end
@@ -610,7 +610,7 @@ for.end:                                          ; preds = %for.body, %entry
 ;CHECK: vsinhf{{.*}}<4 x float>
 ;CHECK: ret void
 declare float @llvm.sinh.f32(float) nounwind readnone
-define void @sinh_f32_intrinsic(i32 %n, ptr noalias %y, ptr noalias %x) nounwind uwtable {
+define void @sinh_f32_intrinsic(i32 %n, ptr noalias %y, ptr noalias %x) {
 entry:
   %cmp6 = icmp sgt i32 %n, 0
   br i1 %cmp6, label %for.body, label %for.end
@@ -635,7 +635,7 @@ for.end:                                          ; preds = %for.body, %entry
 ;CHECK: vcoshf{{.*}}<4 x float>
 ;CHECK: ret void
 declare float @coshf(float) nounwind readnone
-define void @cosh_f32(i32 %n, ptr noalias %y, ptr noalias %x) nounwind uwtable {
+define void @cosh_f32(i32 %n, ptr noalias %y, ptr noalias %x) {
 entry:
   %cmp6 = icmp sgt i32 %n, 0
   br i1 %cmp6, label %for.body, label %for.end
@@ -660,7 +660,7 @@ for.end:                                          ; preds = %for.body, %entry
 ;CHECK: vcoshf{{.*}}<4 x float>
 ;CHECK: ret void
 declare float @llvm.cosh.f32(float) nounwind readnone
-define void @cosh_f32_intrinsic(i32 %n, ptr noalias %y, ptr noalias %x) nounwind uwtable {
+define void @cosh_f32_intrinsic(i32 %n, ptr noalias %y, ptr noalias %x) {
 entry:
   %cmp6 = icmp sgt i32 %n, 0
   br i1 %cmp6, label %for.body, label %for.end
@@ -685,7 +685,7 @@ for.end:                                          ; preds = %for.body, %entry
 ;CHECK: vtanhf{{.*}}<4 x float>
 ;CHECK: ret void
 declare float @tanhf(float) nounwind readnone
-define void @tanh_f32(i32 %n, ptr noalias %y, ptr noalias %x) nounwind uwtable {
+define void @tanh_f32(i32 %n, ptr noalias %y, ptr noalias %x) {
 entry:
   %cmp6 = icmp sgt i32 %n, 0
   br i1 %cmp6, label %for.body, label %for.end
@@ -710,7 +710,7 @@ for.end:                                          ; preds = %for.body, %entry
 ;CHECK: vtanhf{{.*}}<4 x float>
 ;CHECK: ret void
 declare float @llvm.tanh.f32(float) nounwind readnone
-define void @tanh_f32_intrinsic(i32 %n, ptr noalias %y, ptr noalias %x) nounwind uwtable {
+define void @tanh_f32_intrinsic(i32 %n, ptr noalias %y, ptr noalias %x) {
 entry:
   %cmp6 = icmp sgt i32 %n, 0
   br i1 %cmp6, label %for.body, label %for.end
@@ -735,7 +735,7 @@ for.end:                                          ; preds = %for.body, %entry
 ;CHECK: vasinhf{{.*}}<4 x float>
 ;CHECK: ret void
 declare float @asinhf(float) nounwind readnone
-define void @asinh_f32(i32 %n, ptr noalias %y, ptr noalias %x) nounwind uwtable {
+define void @asinh_f32(i32 %n, ptr noalias %y, ptr noalias %x) {
 entry:
   %cmp6 = icmp sgt i32 %n, 0
   br i1 %cmp6, label %for.body, label %for.end
@@ -760,7 +760,7 @@ for.end:                                          ; preds = %for.body, %entry
 ;CHECK: vacoshf{{.*}}<4 x float>
 ;CHECK: ret void
 declare float @acoshf(float) nounwind readnone
-define void @acosh_f32(i32 %n, ptr noalias %y, ptr noalias %x) nounwind uwtable {
+define void @acosh_f32(i32 %n, ptr noalias %y, ptr noalias %x) {
 entry:
   %cmp6 = icmp sgt i32 %n, 0
   br i1 %cmp6, label %for.body, label %for.end
@@ -785,7 +785,7 @@ for.end:                                          ; preds = %for.body, %entry
 ;CHECK: vatanhf{{.*}}<4 x float>
 ;CHECK: ret void
 declare float @atanhf(float) nounwind readnone
-define void @atanh_f32(i32 %n, ptr noalias %y, ptr noalias %x) nounwind uwtable {
+define void @atanh_f32(i32 %n, ptr noalias %y, ptr noalias %x) {
 entry:
   %cmp6 = icmp sgt i32 %n, 0
   br i1 %cmp6, label %for.body, label %for.end

--- a/llvm/test/Transforms/LoopVectorize/X86/vectorization-remarks-missed.ll
+++ b/llvm/test/Transforms/LoopVectorize/X86/vectorization-remarks-missed.ll
@@ -253,7 +253,7 @@ exit:
 ; CHECK-NOT: x i32>
 ; CHECK: ret
 
-; Function Attrs: nounwind uwtable
+; Function Attrs:
 define i32 @test_multiple_failures(ptr nocapture readonly %A) #0 !dbg !46 {
 entry:
   br label %loop, !dbg !38

--- a/llvm/test/Transforms/LoopVectorize/X86/vectorization-remarks-missed.ll
+++ b/llvm/test/Transforms/LoopVectorize/X86/vectorization-remarks-missed.ll
@@ -253,7 +253,6 @@ exit:
 ; CHECK-NOT: x i32>
 ; CHECK: ret
 
-; Function Attrs:
 define i32 @test_multiple_failures(ptr nocapture readonly %A) #0 !dbg !46 {
 entry:
   br label %loop, !dbg !38

--- a/llvm/test/Transforms/LoopVectorize/X86/vectorization-remarks-profitable.ll
+++ b/llvm/test/Transforms/LoopVectorize/X86/vectorization-remarks-profitable.ll
@@ -22,7 +22,7 @@
 target datalayout = "e-m:o-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-apple-macosx10.10.0"
 
-; Function Attrs: nounwind uwtable
+; Function Attrs:
 define void @do_not_interleave(ptr noalias nocapture readonly %in, ptr noalias nocapture %out, i32 %size) #0 !dbg !4 {
 entry:
   %cmp.4 = icmp eq i32 %size, 0, !dbg !10
@@ -50,7 +50,7 @@ for.end:                                          ; preds = %for.end.loopexit, %
   ret void, !dbg !19
 }
 
-; Function Attrs: nounwind uwtable
+; Function Attrs:
 define void @interleave_not_profitable(ptr noalias nocapture readonly %in, ptr noalias nocapture %out, i32 %size) #0 !dbg !6 {
 entry:
   %cmp.4 = icmp eq i32 %size, 0, !dbg !20
@@ -72,7 +72,7 @@ for.end:                                          ; preds = %for.body, %entry
   ret void, !dbg !27
 }
 
-attributes #0 = { nounwind uwtable "disable-tail-calls"="false" "less-precise-fpmad"="false" "frame-pointer"="all" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+mmx,+sse,+sse2" "use-soft-float"="false" }
+attributes #0 = { "disable-tail-calls"="false" "less-precise-fpmad"="false" "frame-pointer"="all" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+mmx,+sse,+sse2" "use-soft-float"="false" }
 
 !llvm.dbg.cu = !{!0}
 !llvm.module.flags = !{!7, !8}

--- a/llvm/test/Transforms/LoopVectorize/X86/vectorization-remarks-profitable.ll
+++ b/llvm/test/Transforms/LoopVectorize/X86/vectorization-remarks-profitable.ll
@@ -22,7 +22,6 @@
 target datalayout = "e-m:o-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-apple-macosx10.10.0"
 
-; Function Attrs:
 define void @do_not_interleave(ptr noalias nocapture readonly %in, ptr noalias nocapture %out, i32 %size) #0 !dbg !4 {
 entry:
   %cmp.4 = icmp eq i32 %size, 0, !dbg !10
@@ -50,7 +49,6 @@ for.end:                                          ; preds = %for.end.loopexit, %
   ret void, !dbg !19
 }
 
-; Function Attrs:
 define void @interleave_not_profitable(ptr noalias nocapture readonly %in, ptr noalias nocapture %out, i32 %size) #0 !dbg !6 {
 entry:
   %cmp.4 = icmp eq i32 %size, 0, !dbg !20

--- a/llvm/test/Transforms/LoopVectorize/X86/x86-interleaved-store-accesses-with-gaps.ll
+++ b/llvm/test/Transforms/LoopVectorize/X86/x86-interleaved-store-accesses-with-gaps.ll
@@ -17,7 +17,7 @@ target triple = "x86_64-unknown-linux-gnu"
 ;     }
 ; (relates to the testcase in PR50566)
 
-; Function Attrs: nofree norecurse nosync nounwind uwtable
+; Function Attrs: nofree norecurse nosync
 define void @test1(ptr noalias nocapture %points, ptr noalias nocapture readonly %x, ptr noalias nocapture readonly %y) {
 ; DISABLED_MASKED_STRIDED-LABEL: @test1(
 ; DISABLED_MASKED_STRIDED-NEXT:  entry:
@@ -121,7 +121,7 @@ for.end:
 ;       points[i*4 + 1] = y[i];
 ;     }
 
-; Function Attrs: nofree norecurse nosync nounwind uwtable
+; Function Attrs: nofree norecurse nosync
 define void @test2(ptr noalias nocapture %points, i32 %numPoints, ptr noalias nocapture readonly %x, ptr noalias nocapture readonly %y) {
 ; DISABLED_MASKED_STRIDED-LABEL: @test2(
 ; DISABLED_MASKED_STRIDED-NEXT:  entry:
@@ -299,7 +299,7 @@ for.end:
 ;       if (x[i] > 0)
 ;         points[i*3] = x[i];
 ;     }
-; Function Attrs: nofree norecurse nosync nounwind uwtable
+; Function Attrs: nofree norecurse nosync
 define void @test(ptr noalias nocapture %points, ptr noalias nocapture readonly %x, ptr noalias nocapture readnone %y) {
 ; DISABLED_MASKED_STRIDED-LABEL: @test(
 ; DISABLED_MASKED_STRIDED-NEXT:  entry:

--- a/llvm/test/Transforms/LoopVectorize/X86/x86-interleaved-store-accesses-with-gaps.ll
+++ b/llvm/test/Transforms/LoopVectorize/X86/x86-interleaved-store-accesses-with-gaps.ll
@@ -17,7 +17,6 @@ target triple = "x86_64-unknown-linux-gnu"
 ;     }
 ; (relates to the testcase in PR50566)
 
-; Function Attrs: nofree norecurse nosync
 define void @test1(ptr noalias nocapture %points, ptr noalias nocapture readonly %x, ptr noalias nocapture readonly %y) {
 ; DISABLED_MASKED_STRIDED-LABEL: @test1(
 ; DISABLED_MASKED_STRIDED-NEXT:  entry:
@@ -121,7 +120,6 @@ for.end:
 ;       points[i*4 + 1] = y[i];
 ;     }
 
-; Function Attrs: nofree norecurse nosync
 define void @test2(ptr noalias nocapture %points, i32 %numPoints, ptr noalias nocapture readonly %x, ptr noalias nocapture readonly %y) {
 ; DISABLED_MASKED_STRIDED-LABEL: @test2(
 ; DISABLED_MASKED_STRIDED-NEXT:  entry:
@@ -299,7 +297,6 @@ for.end:
 ;       if (x[i] > 0)
 ;         points[i*3] = x[i];
 ;     }
-; Function Attrs: nofree norecurse nosync
 define void @test(ptr noalias nocapture %points, ptr noalias nocapture readonly %x, ptr noalias nocapture readnone %y) {
 ; DISABLED_MASKED_STRIDED-LABEL: @test(
 ; DISABLED_MASKED_STRIDED-NEXT:  entry:

--- a/llvm/test/Transforms/LoopVectorize/align.ll
+++ b/llvm/test/Transforms/LoopVectorize/align.ll
@@ -9,7 +9,7 @@ target datalayout = "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f3
 ;CHECK: load <4 x i32>, ptr {{.*}} align  4
 ;CHECK: store <4 x i32> {{.*}} align  4
 
-define void @align(ptr %a, ptr %b, ptr %c) nounwind uwtable ssp {
+define void @align(ptr %a, ptr %b, ptr %c) {
   br label %1
 
 ; <label>:1                                       ; preds = %1, %0

--- a/llvm/test/Transforms/LoopVectorize/bzip_reverse_loops.ll
+++ b/llvm/test/Transforms/LoopVectorize/bzip_reverse_loops.ll
@@ -8,7 +8,7 @@ target datalayout = "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f3
 ;CHECK: select <4 x i1>
 ;CHECK: store <4 x i16>
 ;CHECK: ret
-define void @fc(ptr nocapture %p, i32 %n, i32 %size) nounwind uwtable ssp {
+define void @fc(ptr nocapture %p, i32 %n, i32 %size) {
 entry:
   br label %do.body
 
@@ -44,7 +44,7 @@ do.end:                                           ; preds = %cond.end
 ;CHECK: select <4 x i1>
 ;CHECK: store <4 x i32>
 ;CHECK: ret
-define void @example1(ptr nocapture %a, i32 %n, i32 %wsize) nounwind uwtable ssp {
+define void @example1(ptr nocapture %a, i32 %n, i32 %wsize) {
 entry:
   br label %do.body
 

--- a/llvm/test/Transforms/LoopVectorize/calloc.ll
+++ b/llvm/test/Transforms/LoopVectorize/calloc.ll
@@ -6,7 +6,7 @@ target datalayout = "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f3
 ;CHECK: zext <4 x i8>
 ;CHECK: ret
 
-define noalias ptr @hexit(ptr nocapture %bytes, i64 %length) nounwind uwtable ssp {
+define noalias ptr @hexit(ptr nocapture %bytes, i64 %length) {
 entry:
   %shl = shl i64 %length, 1
   %add28 = or i64 %shl, 1

--- a/llvm/test/Transforms/LoopVectorize/cpp-new-array.ll
+++ b/llvm/test/Transforms/LoopVectorize/cpp-new-array.ll
@@ -7,7 +7,7 @@ target datalayout = "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f3
 ;CHECK: load <4 x float>
 ;CHECK: fadd <4 x float>
 ;CHECK: ret i32
-define i32 @cpp_new_arrays() uwtable ssp {
+define i32 @cpp_new_arrays() uwtable {
 entry:
   %call = call noalias ptr @_Znwm(i64 4)
   store float 1.000000e+03, ptr %call, align 4

--- a/llvm/test/Transforms/LoopVectorize/float-reduction.ll
+++ b/llvm/test/Transforms/LoopVectorize/float-reduction.ll
@@ -4,7 +4,7 @@ target datalayout = "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f3
 ;CHECK-LABEL: @foo(
 ;CHECK: fadd fast <4 x float>
 ;CHECK: ret
-define float @foo(ptr nocapture %A, ptr nocapture %n) nounwind uwtable readonly ssp {
+define float @foo(ptr nocapture %A, ptr nocapture %n) readonly {
 entry:
   br label %for.body
 
@@ -26,7 +26,7 @@ for.end:                                          ; preds = %for.body
 ;CHECK-LABEL: @foosub(
 ;CHECK: fsub fast <4 x float>
 ;CHECK: ret
-define float @foosub(ptr nocapture %A, ptr nocapture %n) nounwind uwtable readonly ssp {
+define float @foosub(ptr nocapture %A, ptr nocapture %n) readonly {
 entry:
   br label %for.body
 
@@ -48,7 +48,7 @@ for.end:                                          ; preds = %for.body
 ;CHECK-LABEL: @foodiv(
 ;CHECK: fdiv fast <4 x float>
 ;CHECK: ret
-define float @foodiv(ptr nocapture %A, ptr nocapture %n) nounwind uwtable readonly ssp {
+define float @foodiv(ptr nocapture %A, ptr nocapture %n) readonly {
 entry:
   br label %for.body
 
@@ -70,7 +70,7 @@ for.end:                                          ; preds = %for.body
 ;CHECK-LABEL: @foonodiv(
 ;CHECK-NOT: fdiv fast <4 x float>
 ;CHECK: ret
-define float @foonodiv(ptr nocapture %A, ptr nocapture %n) nounwind uwtable readonly ssp {
+define float @foonodiv(ptr nocapture %A, ptr nocapture %n) readonly {
 entry:
   br label %for.body
 

--- a/llvm/test/Transforms/LoopVectorize/gcc-examples.ll
+++ b/llvm/test/Transforms/LoopVectorize/gcc-examples.ll
@@ -38,7 +38,7 @@ target datalayout = "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f3
 ;UNROLL: store <4 x i32>
 ;UNROLL: store <4 x i32>
 ;UNROLL: ret void
-define void @example1() nounwind uwtable ssp {
+define void @example1() {
   br label %1
 
 ; <label>:1                                       ; preds = %1, %0
@@ -68,7 +68,7 @@ define void @example1() nounwind uwtable ssp {
 ;UNROLL: store <4 x i32>
 ;UNROLL: store <4 x i32>
 ;UNROLL: ret void
-define void @example2(i32 %n, i32 %x) nounwind uwtable ssp {
+define void @example2(i32 %n, i32 %x) {
   %1 = icmp sgt i32 %n, 0
   br i1 %1, label %.lr.ph5, label %.preheader
 
@@ -118,7 +118,7 @@ define void @example2(i32 %n, i32 %x) nounwind uwtable ssp {
 ;UNROLL: <4 x i32>
 ;UNROLL: <4 x i32>
 ;UNROLL: ret void
-define void @example3(i32 %n, ptr noalias nocapture %p, ptr noalias nocapture %q) nounwind uwtable ssp {
+define void @example3(i32 %n, ptr noalias nocapture %p, ptr noalias nocapture %q) {
   %1 = icmp eq i32 %n, 0
   br i1 %1, label %._crit_edge, label %.lr.ph
 
@@ -147,7 +147,7 @@ define void @example3(i32 %n, ptr noalias nocapture %p, ptr noalias nocapture %q
 ;UNROLL: load <4 x i32>
 ;UNROLL: load <4 x i32>
 ;UNROLL: ret void
-define void @example4(i32 %n, ptr noalias nocapture %p, ptr noalias nocapture %q) nounwind uwtable ssp {
+define void @example4(i32 %n, ptr noalias nocapture %p, ptr noalias nocapture %q) {
   %1 = add nsw i32 %n, -1
   %2 = icmp eq i32 %n, 0
   br i1 %2, label %.preheader4, label %.lr.ph10
@@ -213,7 +213,7 @@ define void @example4(i32 %n, ptr noalias nocapture %p, ptr noalias nocapture %q
 ;UNROLL: store <4 x i32>
 ;UNROLL: store <4 x i32>
 ;UNROLL: ret void
-define void @example8(i32 %x) nounwind uwtable ssp {
+define void @example8(i32 %x) {
   br label %.preheader
 
 .preheader:                                       ; preds = %3, %0
@@ -242,7 +242,7 @@ define void @example8(i32 %x) nounwind uwtable ssp {
 ;CHECK-LABEL: @example9(
 ;CHECK: phi <4 x i32>
 ;CHECK: ret i32
-define i32 @example9() nounwind uwtable readonly ssp {
+define i32 @example9() readonly {
   br label %1
 
 ; <label>:1                                       ; preds = %1, %0
@@ -270,7 +270,7 @@ define i32 @example9() nounwind uwtable readonly ssp {
 ;CHECK: add <4 x i16>
 ;CHECK: store <4 x i16>
 ;CHECK: ret void
-define void @example10a(ptr noalias nocapture %sa, ptr noalias nocapture %sb, ptr noalias nocapture %sc, ptr noalias nocapture %ia, ptr noalias nocapture %ib, ptr noalias nocapture %ic) nounwind uwtable ssp {
+define void @example10a(ptr noalias nocapture %sa, ptr noalias nocapture %sb, ptr noalias nocapture %sc, ptr noalias nocapture %ia, ptr noalias nocapture %ib, ptr noalias nocapture %ic) {
   br label %1
 
 ; <label>:1                                       ; preds = %1, %0
@@ -303,7 +303,7 @@ define void @example10a(ptr noalias nocapture %sa, ptr noalias nocapture %sb, pt
 ;CHECK: sext <4 x i16>
 ;CHECK: store <4 x i32>
 ;CHECK: ret void
-define void @example10b(ptr noalias nocapture %sa, ptr noalias nocapture %sb, ptr noalias nocapture %sc, ptr noalias nocapture %ia, ptr noalias nocapture %ib, ptr noalias nocapture %ic) nounwind uwtable ssp {
+define void @example10b(ptr noalias nocapture %sa, ptr noalias nocapture %sb, ptr noalias nocapture %sc, ptr noalias nocapture %ia, ptr noalias nocapture %ib, ptr noalias nocapture %ic) {
   br label %1
 
 ; <label>:1                                       ; preds = %1, %0
@@ -332,7 +332,7 @@ define void @example10b(ptr noalias nocapture %sa, ptr noalias nocapture %sb, pt
 ;CHECK: insertelement
 ;CHECK: insertelement
 ;CHECK: ret void
-define void @example11() nounwind uwtable ssp {
+define void @example11() {
   br label %1
 
 ; <label>:1                                       ; preds = %1, %0
@@ -391,7 +391,7 @@ define void @example12() {
 ;CHECK-LABEL: @example13(
 ;CHECK: <4 x i32>
 ;CHECK: ret void
-define void @example13(ptr nocapture %A, ptr nocapture %B, ptr nocapture %out) nounwind uwtable ssp {
+define void @example13(ptr nocapture %A, ptr nocapture %B, ptr nocapture %out) {
   br label %.preheader
 
 .preheader:                                       ; preds = %14, %0
@@ -432,7 +432,7 @@ define void @example13(ptr nocapture %A, ptr nocapture %B, ptr nocapture %out) n
 ;CHECK-LABEL: @example14(
 ;CHECK: <4 x i32>
 ;CHECK: ret void
-define void @example14(ptr nocapture %in, ptr nocapture %coeff, ptr nocapture %out) nounwind uwtable ssp {
+define void @example14(ptr nocapture %in, ptr nocapture %coeff, ptr nocapture %out) {
 .preheader3:
   br label %.preheader
 
@@ -578,7 +578,7 @@ define void @example14(ptr nocapture %in, ptr nocapture %coeff, ptr nocapture %o
 ;CHECK: load <4 x i32>
 ;CHECK: shufflevector {{.*}} <i32 3, i32 2, i32 1, i32 0>
 ;CHECK: ret i32
-define i32 @example21(ptr nocapture %b, i32 %n) nounwind uwtable readonly ssp {
+define i32 @example21(ptr nocapture %b, i32 %n) readonly {
   %1 = icmp sgt i32 %n, 0
   br i1 %1, label %.lr.ph, label %._crit_edge
 
@@ -605,7 +605,7 @@ define i32 @example21(ptr nocapture %b, i32 %n) nounwind uwtable readonly ssp {
 ;CHECK-LABEL: @example23(
 ;CHECK: <4 x i32>
 ;CHECK: ret void
-define void @example23(ptr nocapture %src, ptr nocapture %dst) nounwind uwtable ssp {
+define void @example23(ptr nocapture %src, ptr nocapture %dst) {
   br label %1
 
 ; <label>:1                                       ; preds = %1, %0
@@ -629,7 +629,7 @@ define void @example23(ptr nocapture %src, ptr nocapture %dst) nounwind uwtable 
 ;CHECK-LABEL: @example24(
 ;CHECK: shufflevector <4 x i16>
 ;CHECK: ret void
-define void @example24(i16 signext %x, i16 signext %y) nounwind uwtable ssp {
+define void @example24(i16 signext %x, i16 signext %y) {
   br label %1
 
 ; <label>:1                                       ; preds = %1, %0
@@ -656,7 +656,7 @@ define void @example24(i16 signext %x, i16 signext %y) nounwind uwtable ssp {
 ;CHECK: and <4 x i1>
 ;CHECK: zext <4 x i1>
 ;CHECK: ret void
-define void @example25() nounwind uwtable ssp {
+define void @example25() {
   br label %1
 
 ; <label>:1                                       ; preds = %1, %0

--- a/llvm/test/Transforms/LoopVectorize/i8-induction.ll
+++ b/llvm/test/Transforms/LoopVectorize/i8-induction.ll
@@ -6,7 +6,7 @@ target datalayout = "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f3
 @a = common global i8 0, align 1
 @b = common global i8 0, align 1
 
-define void @f() nounwind uwtable ssp {
+define void @f() {
 ; Check that the induction phis and adds have debug location.
 ;
 ; DEBUGLOC-LABEL: vector.body:

--- a/llvm/test/Transforms/LoopVectorize/if-conv-crash.ll
+++ b/llvm/test/Transforms/LoopVectorize/if-conv-crash.ll
@@ -2,7 +2,7 @@
 
 target datalayout = "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f32:32:32-f64:64:64-v64:64:64-v128:128:128-a0:0:64-s0:64:64-f80:128:128-n8:16:32:64-S128"
 
-define fastcc void @DD_dump() nounwind uwtable ssp {
+define fastcc void @DD_dump() {
 entry:
   br i1 true, label %lor.lhs.false, label %if.end25
 

--- a/llvm/test/Transforms/LoopVectorize/if-conversion-reduction.ll
+++ b/llvm/test/Transforms/LoopVectorize/if-conversion-reduction.ll
@@ -5,7 +5,7 @@ target datalayout = "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f3
 ;CHECK-LABEL: @reduction_func(
 ;CHECK-NOT: load <4 x i32>
 ;CHECK: ret i32
-define i32 @reduction_func(ptr nocapture %A, i32 %n) nounwind uwtable readonly ssp {
+define i32 @reduction_func(ptr nocapture %A, i32 %n) readonly {
 entry:
   %cmp10 = icmp sgt i32 %n, 0
   br i1 %cmp10, label %for.body, label %for.end

--- a/llvm/test/Transforms/LoopVectorize/if-conversion.ll
+++ b/llvm/test/Transforms/LoopVectorize/if-conversion.ll
@@ -17,9 +17,9 @@ target datalayout = "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f3
 ;  }
 ;}
 
-define void @function0(ptr nocapture %a, ptr nocapture %b, i32 %start, i32 %end) nounwind uwtable ssp {
+define void @function0(ptr nocapture %a, ptr nocapture %b, i32 %start, i32 %end) {
 ; CHECK-LABEL: define void @function0(
-; CHECK-SAME: ptr captures(none) [[A:%.*]], ptr captures(none) [[B:%.*]], i32 [[START:%.*]], i32 [[END:%.*]]) #[[ATTR0:[0-9]+]] {
+; CHECK-SAME: ptr captures(none) [[A:%.*]], ptr captures(none) [[B:%.*]], i32 [[START:%.*]], i32 [[END:%.*]]) {
 ; CHECK-NEXT:  [[ENTRY:.*:]]
 ; CHECK-NEXT:    [[CMP16:%.*]] = icmp slt i32 [[START]], [[END]]
 ; CHECK-NEXT:    br i1 [[CMP16]], label %[[FOR_BODY_LR_PH:.*]], label %[[FOR_END:.*]]
@@ -141,9 +141,9 @@ for.end:
 ;   return sum;
 ; }
 
-define i32 @reduction_func(ptr nocapture %A, i32 %n) nounwind uwtable readonly ssp {
+define i32 @reduction_func(ptr nocapture %A, i32 %n) readonly {
 ; CHECK-LABEL: define i32 @reduction_func(
-; CHECK-SAME: ptr captures(none) [[A:%.*]], i32 [[N:%.*]]) #[[ATTR1:[0-9]+]] {
+; CHECK-SAME: ptr captures(none) [[A:%.*]], i32 [[N:%.*]]) #[[ATTR0:[0-9]+]] {
 ; CHECK-NEXT:  [[ENTRY:.*]]:
 ; CHECK-NEXT:    [[CMP10:%.*]] = icmp sgt i32 [[N]], 0
 ; CHECK-NEXT:    br i1 [[CMP10]], label %[[FOR_BODY_PREHEADER:.*]], label %[[FOR_END:.*]]

--- a/llvm/test/Transforms/LoopVectorize/increment.ll
+++ b/llvm/test/Transforms/LoopVectorize/increment.ll
@@ -13,7 +13,7 @@ target datalayout = "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f3
 ;CHECK: add nsw <4 x i32>
 ;CHECK: store <4 x i32>
 ;CHECK: ret void
-define void @inc(i32 %n) nounwind uwtable noinline ssp {
+define void @inc(i32 %n) noinline {
   %1 = icmp sgt i32 %n, 0
   br i1 %1, label %.lr.ph, label %._crit_edge
 
@@ -41,7 +41,7 @@ define void @inc(i32 %n) nounwind uwtable noinline ssp {
 ;CHECK-LABEL: @histogram(
 ;CHECK-NOT: <4 x i32>
 ;CHECK: ret i32
-define i32 @histogram(ptr nocapture noalias %A, ptr nocapture noalias %B, i32 %n) nounwind uwtable ssp {
+define i32 @histogram(ptr nocapture noalias %A, ptr nocapture noalias %B, i32 %n) {
 entry:
   %cmp6 = icmp sgt i32 %n, 0
   br i1 %cmp6, label %for.body, label %for.end

--- a/llvm/test/Transforms/LoopVectorize/loop-legality-checks-remarks.ll
+++ b/llvm/test/Transforms/LoopVectorize/loop-legality-checks-remarks.ll
@@ -4,7 +4,7 @@
 ; Make sure LV legal bails out when the loop doesn't have a legal pre-header.
 ; CHECK-LABEL: 'not_exist_preheader'
 ; CHECK: LV: Not vectorizing: Loop doesn't have a legal pre-header.
-define void @not_exist_preheader(ptr %dst, ptr %arg) nounwind uwtable {
+define void @not_exist_preheader(ptr %dst, ptr %arg) {
 entry:
   indirectbr ptr %arg, [label %exit.0, label %loop]
 

--- a/llvm/test/Transforms/LoopVectorize/memdep.ll
+++ b/llvm/test/Transforms/LoopVectorize/memdep.ll
@@ -249,7 +249,6 @@ for.end:
 
 @a = common global [64 x i32] zeroinitializer, align 16
 
-; Function Attrs: norecurse
 define void @pr34283() {
 entry:
   br label %for.body

--- a/llvm/test/Transforms/LoopVectorize/memdep.ll
+++ b/llvm/test/Transforms/LoopVectorize/memdep.ll
@@ -249,7 +249,7 @@ for.end:
 
 @a = common global [64 x i32] zeroinitializer, align 16
 
-; Function Attrs: norecurse nounwind uwtable
+; Function Attrs: norecurse
 define void @pr34283() {
 entry:
   br label %for.body

--- a/llvm/test/Transforms/LoopVectorize/metadata-unroll.ll
+++ b/llvm/test/Transforms/LoopVectorize/metadata-unroll.ll
@@ -16,7 +16,7 @@ target datalayout = "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f3
 ;CHECK: store <4 x i32>
 ;CHECK: store <4 x i32>
 ;CHECK: ret void
-define void @inc(i32 %n) nounwind uwtable noinline ssp {
+define void @inc(i32 %n) noinline {
   %1 = icmp sgt i32 %n, 0
   br i1 %1, label %.lr.ph, label %._crit_edge
 

--- a/llvm/test/Transforms/LoopVectorize/metadata-width.ll
+++ b/llvm/test/Transforms/LoopVectorize/metadata-width.ll
@@ -89,7 +89,7 @@ for.end:                                          ; preds = %for.body, %entry
   ret void
 }
 
-attributes #0 = { nounwind uwtable "less-precise-fpmad"="false" "frame-pointer"="none" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "use-soft-float"="false" }
+attributes #0 = { "less-precise-fpmad"="false" "frame-pointer"="none" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "use-soft-float"="false" }
 
 !0 = !{!0, !1, !5}
 !1 = !{!"llvm.loop.vectorize.width", i32 8}

--- a/llvm/test/Transforms/LoopVectorize/multiple-address-spaces.ll
+++ b/llvm/test/Transforms/LoopVectorize/multiple-address-spaces.ll
@@ -56,4 +56,4 @@ for.end:                                          ; preds = %for.body
   ret i32 0
 }
 
-attributes #0 = { nounwind uwtable "less-precise-fpmad"="false" "frame-pointer"="none" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "use-soft-float"="false" }
+attributes #0 = { "less-precise-fpmad"="false" "frame-pointer"="none" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "use-soft-float"="false" }

--- a/llvm/test/Transforms/LoopVectorize/no_int_induction.ll
+++ b/llvm/test/Transforms/LoopVectorize/no_int_induction.ll
@@ -12,7 +12,7 @@ target datalayout = "e-p:64:64:64-p1:16:16:16-i1:8:8-i8:8:8-i16:16:16-i32:32:32-
 ;CHECK: load <4 x i32>
 ;CHECK: add <4 x i32>
 ;CHECK: ret i32
-define i32 @sum_array(ptr %A, i32 %n) nounwind uwtable readonly noinline ssp {
+define i32 @sum_array(ptr %A, i32 %n) readonly noinline {
   %1 = sext i32 %n to i64
   %2 = getelementptr inbounds i32, ptr %A, i64 %1
   %3 = icmp eq i32 %n, 0
@@ -39,7 +39,7 @@ _ZSt10accumulateIPiiET0_T_S2_S1_.exit:            ; preds = %.lr.ph.i, %0
 ;CHECK: load <4 x i32>
 ;CHECK: add <4 x i32>
 ;CHECK: ret i32
-define i32 @sum_array_as1(ptr addrspace(1) %A, i32 %n) nounwind uwtable readonly noinline ssp {
+define i32 @sum_array_as1(ptr addrspace(1) %A, i32 %n) readonly noinline {
   %1 = sext i32 %n to i64
   %2 = getelementptr inbounds i32, ptr addrspace(1) %A, i64 %1
   %3 = icmp eq i32 %n, 0

--- a/llvm/test/Transforms/LoopVectorize/no_outside_user.ll
+++ b/llvm/test/Transforms/LoopVectorize/no_outside_user.ll
@@ -327,7 +327,7 @@ f1.exit.loopexit:
 ; non hdr phi that depends on reduction and is used outside the loop.
 ; reduction phis are only allowed to have bump or reduction operations as the inside user, so we should
 ; not vectorize this.
-define i32 @reduction_sum(i32 %n, ptr noalias nocapture %A, ptr noalias nocapture %B) nounwind uwtable readonly noinline ssp {
+define i32 @reduction_sum(i32 %n, ptr noalias nocapture %A, ptr noalias nocapture %B) readonly noinline {
 ; CHECK-LABEL: define i32 @reduction_sum(
 ; CHECK-SAME: i32 [[N:%.*]], ptr noalias captures(none) [[A:%.*]], ptr noalias captures(none) [[B:%.*]]) #[[ATTR0:[0-9]+]] {
 ; CHECK-NEXT:  [[ENTRY:.*]]:
@@ -447,7 +447,7 @@ f1.exit.loopexit:
 
 ; non-reduction phi 'tmp17' used outside loop has cyclic dependence with %x.05 phi
 ; cannot vectorize.
-define i32 @not_valid_reduction(i32 %n, ptr noalias nocapture %A) nounwind uwtable readonly {
+define i32 @not_valid_reduction(i32 %n, ptr noalias nocapture %A) readonly {
 ; CHECK-LABEL: define i32 @not_valid_reduction(
 ; CHECK-SAME: i32 [[N:%.*]], ptr noalias captures(none) [[A:%.*]]) #[[ATTR1:[0-9]+]] {
 ; CHECK-NEXT:  [[ENTRY:.*]]:
@@ -585,7 +585,7 @@ f1.exit.loopexit:
   ret i8 %.lcssa
 }
 
-define i32 @no_vectorize_reduction_with_outside_use(i32 %n, ptr nocapture %A, ptr nocapture %B) nounwind uwtable readonly {
+define i32 @no_vectorize_reduction_with_outside_use(i32 %n, ptr nocapture %A, ptr nocapture %B) readonly {
 ; CHECK-LABEL: define i32 @no_vectorize_reduction_with_outside_use(
 ; CHECK-SAME: i32 [[N:%.*]], ptr captures(none) [[A:%.*]], ptr captures(none) [[B:%.*]]) #[[ATTR1]] {
 ; CHECK-NEXT:  [[ENTRY:.*]]:

--- a/llvm/test/Transforms/LoopVectorize/non-const-n.ll
+++ b/llvm/test/Transforms/LoopVectorize/non-const-n.ll
@@ -7,9 +7,9 @@ target datalayout = "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f3
 @c = common global [2048 x i32] zeroinitializer, align 16
 @a = common global [2048 x i32] zeroinitializer, align 16
 
-define void @example1(i32 %n) nounwind uwtable ssp {
+define void @example1(i32 %n) {
 ; CHECK-LABEL: define void @example1(
-; CHECK-SAME: i32 [[N:%.*]]) #[[ATTR0:[0-9]+]] {
+; CHECK-SAME: i32 [[N:%.*]]) {
 ; CHECK-NEXT:  entry:
 ; CHECK-NEXT:    [[N4:%.*]] = shl i32 [[N]], 2
 ; CHECK-NEXT:    [[TMP0:%.*]] = add i32 [[N4]], -4

--- a/llvm/test/Transforms/LoopVectorize/outer_loop_test1.ll
+++ b/llvm/test/Transforms/LoopVectorize/outer_loop_test1.ll
@@ -20,7 +20,7 @@
 @arr2 = external global [8 x i32], align 16
 @arr = external global [8 x [8 x i32]], align 16
 
-; Function Attrs: norecurse nounwind uwtable
+; Function Attrs: norecurse
 define void @foo(i32 %n) {
 ; CHECK-LABEL: define void @foo(
 ; CHECK-SAME: i32 [[N:%.*]]) {

--- a/llvm/test/Transforms/LoopVectorize/outer_loop_test1.ll
+++ b/llvm/test/Transforms/LoopVectorize/outer_loop_test1.ll
@@ -20,7 +20,6 @@
 @arr2 = external global [8 x i32], align 16
 @arr = external global [8 x [8 x i32]], align 16
 
-; Function Attrs: norecurse
 define void @foo(i32 %n) {
 ; CHECK-LABEL: define void @foo(
 ; CHECK-SAME: i32 [[N:%.*]]) {

--- a/llvm/test/Transforms/LoopVectorize/outer_loop_test2.ll
+++ b/llvm/test/Transforms/LoopVectorize/outer_loop_test2.ll
@@ -56,7 +56,7 @@
 @A = common global [1024 x i32] zeroinitializer, align 16
 @B = common global [1024 x i32] zeroinitializer, align 16
 
-; Function Attrs: norecurse nounwind uwtable
+; Function Attrs: norecurse
 define void @foo(i32 %iCount, i32 %c, i32 %jCount) {
 entry:
   %cmp22 = icmp sgt i32 %iCount, 0

--- a/llvm/test/Transforms/LoopVectorize/outer_loop_test2.ll
+++ b/llvm/test/Transforms/LoopVectorize/outer_loop_test2.ll
@@ -56,7 +56,6 @@
 @A = common global [1024 x i32] zeroinitializer, align 16
 @B = common global [1024 x i32] zeroinitializer, align 16
 
-; Function Attrs: norecurse
 define void @foo(i32 %iCount, i32 %c, i32 %jCount) {
 entry:
   %cmp22 = icmp sgt i32 %iCount, 0

--- a/llvm/test/Transforms/LoopVectorize/pr30654-phiscev-sext-trunc.ll
+++ b/llvm/test/Transforms/LoopVectorize/pr30654-phiscev-sext-trunc.ll
@@ -31,7 +31,7 @@ target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 
 @a = common global [250 x i32] zeroinitializer, align 16
 
-; Function Attrs: norecurse nounwind uwtable
+; Function Attrs: norecurse
 define void @doit1(i32 %n, i32 %step) {
 ; CHECK-LABEL: @doit1(
 ; CHECK-NEXT:  entry:
@@ -152,7 +152,7 @@ for.end:
 ;
 
 
-; Function Attrs: norecurse nounwind uwtable
+; Function Attrs: norecurse
 define void @doit2(i32 %n, i32 %step)  {
 ; CHECK-LABEL: @doit2(
 ; CHECK-NEXT:  entry:
@@ -270,7 +270,7 @@ for.end:
 ;
 
 
-; Function Attrs: norecurse nounwind uwtable
+; Function Attrs: norecurse
 define void @doit3(i32 %n, i32 %step) {
 ; CHECK-LABEL: @doit3(
 ; CHECK-NEXT:  entry:
@@ -346,7 +346,7 @@ for.end:
 ; }
 
 
-; Function Attrs: norecurse nounwind uwtable
+; Function Attrs: norecurse
 define void @doit4(i32 %n, i8 signext %cstep) {
 ; CHECK-LABEL: @doit4(
 ; CHECK-NEXT:  entry:

--- a/llvm/test/Transforms/LoopVectorize/pr30654-phiscev-sext-trunc.ll
+++ b/llvm/test/Transforms/LoopVectorize/pr30654-phiscev-sext-trunc.ll
@@ -31,7 +31,6 @@ target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 
 @a = common global [250 x i32] zeroinitializer, align 16
 
-; Function Attrs: norecurse
 define void @doit1(i32 %n, i32 %step) {
 ; CHECK-LABEL: @doit1(
 ; CHECK-NEXT:  entry:
@@ -152,7 +151,6 @@ for.end:
 ;
 
 
-; Function Attrs: norecurse
 define void @doit2(i32 %n, i32 %step)  {
 ; CHECK-LABEL: @doit2(
 ; CHECK-NEXT:  entry:
@@ -270,7 +268,6 @@ for.end:
 ;
 
 
-; Function Attrs: norecurse
 define void @doit3(i32 %n, i32 %step) {
 ; CHECK-LABEL: @doit3(
 ; CHECK-NEXT:  entry:
@@ -346,7 +343,6 @@ for.end:
 ; }
 
 
-; Function Attrs: norecurse
 define void @doit4(i32 %n, i8 signext %cstep) {
 ; CHECK-LABEL: @doit4(
 ; CHECK-NEXT:  entry:

--- a/llvm/test/Transforms/LoopVectorize/pr32859.ll
+++ b/llvm/test/Transforms/LoopVectorize/pr32859.ll
@@ -9,8 +9,7 @@
 ; CHECK-LABEL: for.cond.preheader:
 ; CHECK: %e.0.ph = phi i32 [ 0, %if.end.2.i ], [ 0, %middle.block ]
 
-; Function Attrs:
-define void @main(i32 %n, i32 %v) #0 {
+define void @main(i32 %n, i32 %v) {
 entry:
   br label %for.cond1.preheader.i
 

--- a/llvm/test/Transforms/LoopVectorize/pr32859.ll
+++ b/llvm/test/Transforms/LoopVectorize/pr32859.ll
@@ -9,7 +9,7 @@
 ; CHECK-LABEL: for.cond.preheader:
 ; CHECK: %e.0.ph = phi i32 [ 0, %if.end.2.i ], [ 0, %middle.block ]
 
-; Function Attrs: nounwind uwtable
+; Function Attrs:
 define void @main(i32 %n, i32 %v) #0 {
 entry:
   br label %for.cond1.preheader.i

--- a/llvm/test/Transforms/LoopVectorize/pseudoprobe.ll
+++ b/llvm/test/Transforms/LoopVectorize/pseudoprobe.ll
@@ -2,8 +2,7 @@
 
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 
-; Function Attrs:
-define i32 @test1(ptr nocapture %a, ptr nocapture readonly %b) #0 {
+define i32 @test1(ptr nocapture %a, ptr nocapture readonly %b) {
 entry:
   call void @llvm.pseudoprobe(i64 3666282617048535130, i64 1, i32 0, i64 -1)
   br label %for.body
@@ -36,8 +35,7 @@ for.end:                                          ; preds = %for.body
 
 
 
-; Function Attrs: nocallback nofree nosync nounwind willreturn memory(inaccessiblemem: readwrite)
-declare void @llvm.pseudoprobe(i64, i64, i32, i64) #1
+declare void @llvm.pseudoprobe(i64, i64, i32, i64)
 
 !llvm.pseudo_probe_desc = !{!0}
 

--- a/llvm/test/Transforms/LoopVectorize/pseudoprobe.ll
+++ b/llvm/test/Transforms/LoopVectorize/pseudoprobe.ll
@@ -2,7 +2,7 @@
 
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 
-; Function Attrs: nounwind uwtable
+; Function Attrs:
 define i32 @test1(ptr nocapture %a, ptr nocapture readonly %b) #0 {
 entry:
   call void @llvm.pseudoprobe(i64 3666282617048535130, i64 1, i32 0, i64 -1)
@@ -38,9 +38,6 @@ for.end:                                          ; preds = %for.body
 
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(inaccessiblemem: readwrite)
 declare void @llvm.pseudoprobe(i64, i64, i32, i64) #1
-
-attributes #0 = { nounwind uwtable }
-attributes #1 = { nocallback nofree nosync nounwind willreturn memory(inaccessiblemem: readwrite) }
 
 !llvm.pseudo_probe_desc = !{!0}
 

--- a/llvm/test/Transforms/LoopVectorize/ptr_loops.ll
+++ b/llvm/test/Transforms/LoopVectorize/ptr_loops.ll
@@ -10,7 +10,7 @@ target datalayout = "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f3
 ;CHECK: shufflevector <4 x i32>
 ;CHECK: store <4 x i32>
 ;CHECK: ret
-define i32 @_Z5test1v() nounwind uwtable ssp {
+define i32 @_Z5test1v() {
   br label %1
 
 ; <label>:1                                       ; preds = %0, %1
@@ -33,7 +33,7 @@ define i32 @_Z5test1v() nounwind uwtable ssp {
 ;CHECK: shufflevector <4 x i32>
 ;CHECK: store <4 x i32>
 ;CHECK: ret
-define i32 @_Z5test2v() nounwind uwtable ssp {
+define i32 @_Z5test2v() {
   br label %1
 
 ; <label>:1                                       ; preds = %0, %1
@@ -55,7 +55,7 @@ define i32 @_Z5test2v() nounwind uwtable ssp {
 ;CHECK: shufflevector <4 x i32>
 ;CHECK: store <4 x i32>
 ;CHECK: ret
-define i32 @_Z5test3v() nounwind uwtable ssp {
+define i32 @_Z5test3v() {
   br label %1
 
 ; <label>:1                                       ; preds = %0, %1

--- a/llvm/test/Transforms/LoopVectorize/read-only.ll
+++ b/llvm/test/Transforms/LoopVectorize/read-only.ll
@@ -5,7 +5,7 @@ target datalayout = "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f3
 ;CHECK-LABEL: @read_only_func(
 ;CHECK: load <4 x i32>
 ;CHECK: ret i32
-define i32 @read_only_func(ptr nocapture %A, ptr nocapture %B, i32 %n) nounwind uwtable readonly ssp {
+define i32 @read_only_func(ptr nocapture %A, ptr nocapture %B, i32 %n) readonly {
   %1 = icmp sgt i32 %n, 0
   br i1 %1, label %.lr.ph, label %._crit_edge
 
@@ -35,7 +35,7 @@ define i32 @read_only_func(ptr nocapture %A, ptr nocapture %B, i32 %n) nounwind 
 ;CHECK-LABEL: @read_only_func_volatile(
 ;CHECK-NOT: load <4 x i32>
 ;CHECK: ret i32
-define i32 @read_only_func_volatile(ptr nocapture %A, ptr nocapture %B, i32 %n) nounwind uwtable readonly ssp {
+define i32 @read_only_func_volatile(ptr nocapture %A, ptr nocapture %B, i32 %n) readonly {
   %1 = icmp sgt i32 %n, 0
   br i1 %1, label %.lr.ph, label %._crit_edge
 

--- a/llvm/test/Transforms/LoopVectorize/runtime-check-address-space.ll
+++ b/llvm/test/Transforms/LoopVectorize/runtime-check-address-space.ll
@@ -218,4 +218,4 @@ for.end:                                          ; preds = %for.body, %entry
   ret void
 }
 
-attributes #0 = { nounwind uwtable "less-precise-fpmad"="false" "frame-pointer"="all" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "stack-protector-buffer-size"="8" "use-soft-float"="false" }
+attributes #0 = { "less-precise-fpmad"="false" "frame-pointer"="all" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "stack-protector-buffer-size"="8" "use-soft-float"="false" }

--- a/llvm/test/Transforms/LoopVectorize/runtime-check-readonly-address-space.ll
+++ b/llvm/test/Transforms/LoopVectorize/runtime-check-readonly-address-space.ll
@@ -129,4 +129,4 @@ for.end:                                          ; preds = %for.body
   ret void
 }
 
-attributes #0 = { nounwind uwtable "less-precise-fpmad"="false" "frame-pointer"="all" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "stack-protector-buffer-size"="8" "use-soft-float"="false" }
+attributes #0 = { "less-precise-fpmad"="false" "frame-pointer"="all" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "stack-protector-buffer-size"="8" "use-soft-float"="false" }

--- a/llvm/test/Transforms/LoopVectorize/runtime-check.ll
+++ b/llvm/test/Transforms/LoopVectorize/runtime-check.ll
@@ -10,7 +10,7 @@ target datalayout = "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f3
 ;     a[i] = b[i] * 3;
 ; }
 
-define void @foo(ptr nocapture %a, ptr nocapture %b, i32 %n) nounwind uwtable ssp {
+define void @foo(ptr nocapture %a, ptr nocapture %b, i32 %n) {
 ; CHECK-LABEL: @foo(
 ; CHECK-NEXT:  entry:
 ; CHECK-NEXT:    [[B2:%.*]] = ptrtoaddr ptr [[B:%.*]] to i64, !dbg [[DBG4:![0-9]+]]

--- a/llvm/test/Transforms/LoopVectorize/same-base-access.ll
+++ b/llvm/test/Transforms/LoopVectorize/same-base-access.ll
@@ -13,7 +13,7 @@ target datalayout = "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f3
 ; CHECK-LABEL: @kernel11(
 ; CHECK-NOT: <4 x double>
 ; CHECK: ret
-define i32 @kernel11(ptr %x, ptr %y, i32 %n) nounwind uwtable ssp {
+define i32 @kernel11(ptr %x, ptr %y, i32 %n) {
   %1 = alloca ptr, align 8
   %2 = alloca ptr, align 8
   %3 = alloca i32, align 4
@@ -77,7 +77,7 @@ define i32 @kernel11(ptr %x, ptr %y, i32 %n) nounwind uwtable ssp {
 ; CHECK-LABEL: @func2(
 ; CHECK: <4 x i32>
 ; CHECK: ret
-define i32 @func2(ptr nocapture %a) nounwind uwtable ssp {
+define i32 @func2(ptr nocapture %a) {
   br label %1
 
 ; <label>:1                                       ; preds = %7, %0

--- a/llvm/test/Transforms/LoopVectorize/scalar-select.ll
+++ b/llvm/test/Transforms/LoopVectorize/scalar-select.ll
@@ -12,7 +12,7 @@ target datalayout = "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f3
 ;CHECK: select i1 %cond, <4 x i32>
 ;CHECK: store <4 x i32>
 ;CHECK: ret void
-define void @example1(i1 %cond) nounwind uwtable ssp {
+define void @example1(i1 %cond) {
   br label %1
 
 ; <label>:1                                       ; preds = %1, %0

--- a/llvm/test/Transforms/LoopVectorize/simple-unroll.ll
+++ b/llvm/test/Transforms/LoopVectorize/simple-unroll.ll
@@ -16,7 +16,7 @@ target datalayout = "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f3
 ;CHECK: store <4 x i32>
 ;CHECK: store <4 x i32>
 ;CHECK: ret void
-define void @inc(i32 %n) nounwind uwtable noinline ssp {
+define void @inc(i32 %n) noinline {
   %1 = icmp sgt i32 %n, 0
   br i1 %1, label %.lr.ph, label %._crit_edge
 

--- a/llvm/test/Transforms/LoopVectorize/small-loop.ll
+++ b/llvm/test/Transforms/LoopVectorize/small-loop.ll
@@ -9,7 +9,7 @@ target datalayout = "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f3
 ;CHECK-LABEL: @example1(
 ;CHECK: load <4 x i32>
 ;CHECK: ret void
-define void @example1() nounwind uwtable ssp {
+define void @example1() {
   br label %1
 
 ; <label>:1                                       ; preds = %1, %0
@@ -33,7 +33,7 @@ define void @example1() nounwind uwtable ssp {
 ;CHECK-LABEL: @bound1(
 ;CHECK-NOT: load <4 x i32>
 ;CHECK: ret void
-define void @bound1(i32 %k) nounwind uwtable ssp {
+define void @bound1(i32 %k) {
   br label %1
 
 ; <label>:1                                       ; preds = %1, %0

--- a/llvm/test/Transforms/LoopVectorize/start-non-zero.ll
+++ b/llvm/test/Transforms/LoopVectorize/start-non-zero.ll
@@ -5,7 +5,7 @@ target datalayout = "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f3
 ;CHECK-LABEL: @start_at_nonzero(
 ;CHECK: mul nuw <4 x i32>
 ;CHECK: ret i32
-define i32 @start_at_nonzero(ptr nocapture %a, i32 %start, i32 %end) nounwind uwtable ssp {
+define i32 @start_at_nonzero(ptr nocapture %a, i32 %start, i32 %end) {
 entry:
   %cmp3 = icmp slt i32 %start, %end
   br i1 %cmp3, label %for.body.lr.ph, label %for.end

--- a/llvm/test/Transforms/LoopVectorize/struct_access.ll
+++ b/llvm/test/Transforms/LoopVectorize/struct_access.ll
@@ -23,7 +23,7 @@ target datalayout = "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f3
 ;CHECK-LABEL: @foo(
 ;CHECK-NOT: load <4 x i32>
 ;CHECK: ret
-define i32 @foo(ptr nocapture %A, i32 %n) nounwind uwtable readonly ssp {
+define i32 @foo(ptr nocapture %A, i32 %n) readonly {
 entry:
   %cmp4 = icmp sgt i32 %n, 0
   br i1 %cmp4, label %for.body, label %for.end
@@ -65,7 +65,7 @@ for.end:                                          ; preds = %for.body, %entry
 ;CHECK-LABEL: @bar(
 ;CHECK: load <4 x i32>
 ;CHECK: ret
-define i32 @bar(ptr nocapture %A, i32 %n) nounwind uwtable readonly ssp {
+define i32 @bar(ptr nocapture %A, i32 %n) readonly {
 entry:
   %cmp4 = icmp sgt i32 %n, 0
   br i1 %cmp4, label %for.body, label %for.end

--- a/llvm/test/Transforms/LoopVectorize/unroll-novec-memcheck-metadata.ll
+++ b/llvm/test/Transforms/LoopVectorize/unroll-novec-memcheck-metadata.ll
@@ -13,8 +13,7 @@ target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 ; CHECK-DAG: ![[MD2]] = distinct !{![[MD2]], ![[MD3:[0-9]+]]}
 ; CHECK-DAG: ![[MD3]] = distinct !{![[MD3]], !"LVerDomain"}
 
-; Function Attrs: norecurse
-define void @test(ptr nocapture readonly %a, ptr nocapture %b) #0 {
+define void @test(ptr nocapture readonly %a, ptr nocapture %b) {
 entry:
   br label %for.body
 
@@ -33,5 +32,3 @@ for.body:                                         ; preds = %for.body, %entry
 for.end:                                          ; preds = %for.body
   ret void
 }
-
-attributes #0 = { norecurse }

--- a/llvm/test/Transforms/LoopVectorize/unroll-novec-memcheck-metadata.ll
+++ b/llvm/test/Transforms/LoopVectorize/unroll-novec-memcheck-metadata.ll
@@ -13,7 +13,7 @@ target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 ; CHECK-DAG: ![[MD2]] = distinct !{![[MD2]], ![[MD3:[0-9]+]]}
 ; CHECK-DAG: ![[MD3]] = distinct !{![[MD3]], !"LVerDomain"}
 
-; Function Attrs: norecurse nounwind uwtable
+; Function Attrs: norecurse
 define void @test(ptr nocapture readonly %a, ptr nocapture %b) #0 {
 entry:
   br label %for.body
@@ -34,4 +34,4 @@ for.end:                                          ; preds = %for.body
   ret void
 }
 
-attributes #0 = { norecurse nounwind uwtable }
+attributes #0 = { norecurse }

--- a/llvm/test/Transforms/LoopVectorize/unroll_novec.ll
+++ b/llvm/test/Transforms/LoopVectorize/unroll_novec.ll
@@ -26,7 +26,7 @@ target datalayout = "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f3
 ;CHECK-NOT: store i32
 ;CHECK: add nuw i64 %{{.*}}, 4
 ;CHECK: ret void
-define void @inc(i32 %n) noinline {
+define void @inc(i32 %n) {
   %1 = icmp sgt i32 %n, 0
   br i1 %1, label %.lr.ph, label %._crit_edge
 

--- a/llvm/test/Transforms/LoopVectorize/unroll_novec.ll
+++ b/llvm/test/Transforms/LoopVectorize/unroll_novec.ll
@@ -26,7 +26,7 @@ target datalayout = "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f3
 ;CHECK-NOT: store i32
 ;CHECK: add nuw i64 %{{.*}}, 4
 ;CHECK: ret void
-define void @inc(i32 %n) nounwind uwtable noinline ssp {
+define void @inc(i32 %n) noinline {
   %1 = icmp sgt i32 %n, 0
   br i1 %1, label %.lr.ph, label %._crit_edge
 

--- a/llvm/test/Transforms/LoopVectorize/write-only.ll
+++ b/llvm/test/Transforms/LoopVectorize/write-only.ll
@@ -5,7 +5,7 @@ target datalayout = "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f3
 ;CHECK-LABEL: @read_mod_write_single_ptr(
 ;CHECK: load <4 x float>
 ;CHECK: ret void
-define void @read_mod_write_single_ptr(ptr nocapture %a, i32 %n) nounwind uwtable ssp {
+define void @read_mod_write_single_ptr(ptr nocapture %a, i32 %n) {
   %1 = icmp sgt i32 %n, 0
   br i1 %1, label %.lr.ph, label %._crit_edge
 
@@ -28,7 +28,7 @@ define void @read_mod_write_single_ptr(ptr nocapture %a, i32 %n) nounwind uwtabl
 ; CHECK-LABEL: @read_mod_write_single_ptr_volatile_store(
 ; CHECK-NOT: store <4 x float>
 ; CHECK: ret void
-define void @read_mod_write_single_ptr_volatile_store(ptr nocapture %a, i32 %n) nounwind uwtable ssp {
+define void @read_mod_write_single_ptr_volatile_store(ptr nocapture %a, i32 %n) {
   %1 = icmp sgt i32 %n, 0
   br i1 %1, label %.lr.ph, label %._crit_edge
 


### PR DESCRIPTION
Following on from PR #188091 I've also removed the following function attributes from tests:

 nounwind uwtable ssp

as they didn't make any difference to the tests.