### PR TITLE
[CIR][AArch64] Lower vfma lane builtins

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenBuiltinAArch64.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuiltinAArch64.cpp
@@ -139,11 +139,10 @@ static cir::VectorType getNeonType(CIRGenFunction *cgf, NeonTypeFlags typeFlags,
       cgf->getCIRGenModule().errorNYI(loc, std::string("NEON type: BFloat16"));
     [[fallthrough]];
   case NeonTypeFlags::Float16:
-    if (hasLegalHalfType)
+    if (!hasLegalHalfType)
       cgf->getCIRGenModule().errorNYI(loc, std::string("NEON type: Float16"));
-    else
-      cgf->getCIRGenModule().errorNYI(loc, std::string("NEON type: Float16"));
-    [[fallthrough]];
+    return cir::VectorType::get(cgf->getCIRGenModule().fP16Ty,
+                                v1Ty ? 1 : (4 << isQuad));
   case NeonTypeFlags::Int32:
     return cir::VectorType::get(typeFlags.isUnsigned() ? cgf->uInt32Ty
                                                        : cgf->sInt32Ty,
@@ -628,11 +627,6 @@ static bool hasExtraNeonArgument(unsigned builtinID) {
   case ARM::BI__builtin_arm_vcvtr_d:
     mask = 1;
   }
-  switch (builtinID) {
-  default:
-    break;
-  }
-
   return mask != 0;
 }
 
@@ -2186,6 +2180,23 @@ CIRGenFunction::emitAArch64BuiltinExpr(unsigned builtinID, const CallExpr *expr,
     return mlir::Value{};
   }
 
+  switch (builtinID) {
+  case NEON::BI__builtin_neon_vfmah_lane_f16:
+  case NEON::BI__builtin_neon_vfmas_lane_f32:
+  case NEON::BI__builtin_neon_vfmah_laneq_f16:
+  case NEON::BI__builtin_neon_vfmas_laneq_f32:
+  case NEON::BI__builtin_neon_vfmad_lane_f64:
+  case NEON::BI__builtin_neon_vfmad_laneq_f64: {
+    mlir::Value lane = cir::VecExtractOp::create(builder, loc, ops[2], ops[3]);
+    mlir::Type scalarTy = convertType(expr->getType());
+    llvm::SmallVector<mlir::Value> fmaOps = {ops[1], lane, ops[0]};
+    return emitCallMaybeConstrainedBuiltin(builder, loc, "fma", scalarTy,
+                                           fmaOps);
+  }
+  default:
+    break;
+  }
+
   cir::VectorType ty = getNeonType(this, type, loc);
   if (!ty)
     return nullptr;
@@ -2200,13 +2211,36 @@ CIRGenFunction::emitAArch64BuiltinExpr(unsigned builtinID, const CallExpr *expr,
   case NEON::BI__builtin_neon_vfma_lane_v:
   case NEON::BI__builtin_neon_vfmaq_lane_v:
   case NEON::BI__builtin_neon_vfma_laneq_v:
-  case NEON::BI__builtin_neon_vfmaq_laneq_v:
-  case NEON::BI__builtin_neon_vfmah_lane_f16:
-  case NEON::BI__builtin_neon_vfmas_lane_f32:
-  case NEON::BI__builtin_neon_vfmah_laneq_f16:
-  case NEON::BI__builtin_neon_vfmas_laneq_f32:
-  case NEON::BI__builtin_neon_vfmad_lane_f64:
-  case NEON::BI__builtin_neon_vfmad_laneq_f64:
+  case NEON::BI__builtin_neon_vfmaq_laneq_v: {
+    mlir::Value addend = ops[0];
+    mlir::Value multiplicand = ops[1];
+    mlir::Value laneSource = ops[2];
+    auto vecTy = mlir::cast<cir::VectorType>(ty);
+    auto elemTy = vecTy.getElementType();
+    auto numElts = vecTy.getSize();
+
+    if (addend.getType() != ty)
+      addend = builder.createBitcast(loc, addend, ty);
+    if (multiplicand.getType() != ty)
+      multiplicand = builder.createBitcast(loc, multiplicand, ty);
+
+    cir::VectorType sourceTy = ty;
+    if (builtinID == NEON::BI__builtin_neon_vfmaq_lane_v)
+      sourceTy = cir::VectorType::get(elemTy, numElts / 2);
+    else if (builtinID == NEON::BI__builtin_neon_vfma_laneq_v)
+      sourceTy = cir::VectorType::get(elemTy, numElts * 2);
+
+    if (laneSource.getType() != sourceTy)
+      laneSource = builder.createBitcast(loc, laneSource, sourceTy);
+
+    int64_t lane =
+        expr->getArg(3)->EvaluateKnownConstInt(getContext()).getSExtValue();
+    llvm::SmallVector<int64_t> mask(numElts, lane);
+    mlir::Value splat = builder.createVecShuffle(loc, laneSource, mask);
+
+    llvm::SmallVector<mlir::Value> fmaOps = {multiplicand, splat, addend};
+    return emitCallMaybeConstrainedBuiltin(builder, loc, "fma", ty, fmaOps);
+  }
   case NEON::BI__builtin_neon_vmull_v:
   case NEON::BI__builtin_neon_vmax_v:
   case NEON::BI__builtin_neon_vmaxq_v:

--- a/clang/lib/CIR/CodeGen/CIRGenBuiltinAArch64.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuiltinAArch64.cpp
@@ -139,9 +139,10 @@ static cir::VectorType getNeonType(CIRGenFunction *cgf, NeonTypeFlags typeFlags,
       cgf->getCIRGenModule().errorNYI(loc, std::string("NEON type: BFloat16"));
     [[fallthrough]];
   case NeonTypeFlags::Float16:
-    return cir::VectorType::get(hasLegalHalfType ? cgf->getCIRGenModule().fP16Ty
-                                                 : cgf->uInt16Ty,
-                                v1Ty ? 1 : (4 << isQuad));
+    if (hasLegalHalfType)
+      return cir::VectorType::get(cgf->getCIRGenModule().fP16Ty,
+                                  v1Ty ? 1 : (4 << isQuad));
+    return cir::VectorType::get(cgf->uInt16Ty, v1Ty ? 1 : (4 << isQuad));
   case NeonTypeFlags::Int32:
     return cir::VectorType::get(typeFlags.isUnsigned() ? cgf->uInt32Ty
                                                        : cgf->sInt32Ty,
@@ -358,8 +359,6 @@ static mlir::Value emitCommonNeonBuiltinExpr(
   case NEON::BI__builtin_neon_vld4q_lane_v:
   case NEON::BI__builtin_neon_vmovl_v:
   case NEON::BI__builtin_neon_vmovn_v:
-  case NEON::BI__builtin_neon_vbsl_v:
-  case NEON::BI__builtin_neon_vbslq_v:
   case NEON::BI__builtin_neon_vmull_v:
   case NEON::BI__builtin_neon_vpadal_v:
   case NEON::BI__builtin_neon_vpadalq_v:
@@ -478,77 +477,6 @@ emitCallMaybeConstrainedBuiltin(CIRGenBuilderTy &builder, mlir::Location loc,
   assert(!cir::MissingFeatures::emitConstrainedFPCall());
 
   return builder.emitIntrinsicCallOp(loc, intrName, retTy, ops);
-}
-
-static mlir::Value emitVectorFmaLaneSource(CIRGenBuilderTy &builder,
-                                           mlir::Location loc,
-                                           const CallExpr *expr,
-                                           ASTContext &ctx,
-                                           mlir::Value laneSource,
-                                           cir::VectorType ty,
-                                           cir::VectorType sourceTy) {
-  if (laneSource.getType() != sourceTy)
-    laneSource = builder.createBitcast(loc, laneSource, sourceTy);
-
-  auto vecTy = mlir::cast<cir::VectorType>(ty);
-  int64_t lane = expr->getArg(3)->EvaluateKnownConstInt(ctx).getSExtValue();
-  llvm::SmallVector<int64_t> mask(vecTy.getSize(), lane);
-  return builder.createVecShuffle(loc, laneSource, mask);
-}
-
-static mlir::Value emitVectorFmaBuiltin(CIRGenFunction &cgf,
-                                        mlir::Location loc,
-                                        llvm::SmallVectorImpl<mlir::Value> &ops,
-                                        const CallExpr *expr) {
-  cir::VectorType ty = mlir::cast<cir::VectorType>(cgf.convertType(expr->getType()));
-  if (ops[0].getType() != ty)
-    ops[0] = cgf.getBuilder().createBitcast(loc, ops[0], ty);
-  if (ops[1].getType() != ty)
-    ops[1] = cgf.getBuilder().createBitcast(loc, ops[1], ty);
-  if (ops[2].getType() != ty)
-    ops[2] = cgf.getBuilder().createBitcast(loc, ops[2], ty);
-  std::rotate(ops.begin(), ops.begin() + 1, ops.end());
-  return emitCallMaybeConstrainedBuiltin(cgf.getBuilder(), loc, "fma", ty, ops);
-}
-
-static mlir::Value emitVectorFmaLaneBuiltin(CIRGenFunction &cgf,
-                                            unsigned builtinID,
-                                            NeonTypeFlags type,
-                                            mlir::Location loc,
-                                            const CallExpr *expr,
-                                            llvm::SmallVectorImpl<mlir::Value> &ops) {
-  cir::VectorType ty = getNeonType(&cgf, type, loc);
-  if (!ty)
-    return nullptr;
-
-  auto vecTy = mlir::cast<cir::VectorType>(ty);
-  cir::VectorType sourceTy = ty;
-  unsigned vectorFmaBuiltin = NEON::BI__builtin_neon_vfma_v;
-
-  switch (builtinID) {
-  case NEON::BI__builtin_neon_vfmaq_lane_v:
-    sourceTy = cir::VectorType::get(vecTy.getElementType(), vecTy.getSize() / 2);
-    vectorFmaBuiltin = NEON::BI__builtin_neon_vfmaq_v;
-    break;
-  case NEON::BI__builtin_neon_vfma_laneq_v:
-    sourceTy = cir::VectorType::get(vecTy.getElementType(), vecTy.getSize() * 2);
-    break;
-  case NEON::BI__builtin_neon_vfmaq_laneq_v:
-    vectorFmaBuiltin = NEON::BI__builtin_neon_vfmaq_v;
-    break;
-  case NEON::BI__builtin_neon_vfma_lane_v:
-    break;
-  default:
-    llvm_unreachable("unexpected vfma lane builtin");
-  }
-
-  llvm::SmallVector<mlir::Value> fmaOps(ops.begin(), ops.end() - 1);
-  fmaOps[2] = emitVectorFmaLaneSource(cgf.getBuilder(), loc, expr,
-                                      cgf.getContext(), ops[2], ty, sourceTy);
-  const ARMVectorIntrinsicInfo *info = findARMVectorIntrinsicInMap(
-      AArch64SIMDIntrinsicMap, vectorFmaBuiltin,
-      aarch64SIMDIntrinsicsProvenSorted);
-  return emitCommonNeonBuiltinExpr(cgf, *info, fmaOps, expr);
 }
 
 bool CIRGenFunction::getAArch64SVEProcessedOperands(
@@ -805,8 +733,17 @@ static mlir::Value emitCommonNeonSISDBuiltinExpr(
                         {cgf.convertType(expr->getArg(0)->getType())}, ops,
                         llvmIntrName, cgf.convertType(expr->getType()), loc);
   case NEON::BI__builtin_neon_vfma_v:
-  case NEON::BI__builtin_neon_vfmaq_v:
-    return emitVectorFmaBuiltin(cgf, loc, ops, expr);
+  case NEON::BI__builtin_neon_vfmaq_v: {
+    auto ty = mlir::cast<cir::VectorType>(cgf.convertType(expr->getType()));
+    for (auto &op : ops)
+      if (op.getType() != ty)
+        op = cgf.getBuilder().createBitcast(loc, op, ty);
+
+    llvm::SmallVector<mlir::Value> fmaOps(ops.begin(), ops.end());
+    std::rotate(fmaOps.begin(), fmaOps.begin() + 1, fmaOps.end());
+    return emitNeonCall(cgf.cgm, cgf.getBuilder(), {ty, ty, ty}, fmaOps,
+                        "fma", ty, loc);
+  }
   }
 
   return nullptr;
@@ -2260,27 +2197,95 @@ CIRGenFunction::emitAArch64BuiltinExpr(unsigned builtinID, const CallExpr *expr,
     return mlir::Value{};
   }
 
+  cir::VectorType ty = getNeonType(this, type, loc);
+  if (!ty)
+    return nullptr;
+
   llvm::StringRef intrName;
 
   switch (builtinID) {
   default:
     return std::nullopt;
+  case NEON::BI__builtin_neon_vbsl_v:
+  case NEON::BI__builtin_neon_vbslq_v:
   case NEON::BI__builtin_neon_vfma_lane_v:
-  case NEON::BI__builtin_neon_vfmaq_lane_v:
-  case NEON::BI__builtin_neon_vfma_laneq_v:
-  case NEON::BI__builtin_neon_vfmaq_laneq_v:
-    return emitVectorFmaLaneBuiltin(*this, builtinID, type, loc, expr, ops);
+  case NEON::BI__builtin_neon_vfmaq_lane_v: {
+    auto vecTy = mlir::cast<cir::VectorType>(ty);
+    ops[0] = builder.createBitcast(loc, ops[0], ty);
+    ops[1] = builder.createBitcast(loc, ops[1], ty);
+    cir::VectorType sourceTy = cir::VectorType::get(
+        vecTy.getElementType(), builtinID == NEON::BI__builtin_neon_vfmaq_lane_v
+                                    ? vecTy.getSize() / 2
+                                    : vecTy.getSize());
+    ops[2] = builder.createBitcast(loc, ops[2], sourceTy);
+
+    int64_t lane =
+        expr->getArg(3)->EvaluateKnownConstInt(getContext()).getSExtValue();
+    llvm::SmallVector<int64_t> mask(vecTy.getSize(), lane);
+    ops[2] = builder.createVecShuffle(loc, ops[2], mask);
+    llvm::SmallVector<mlir::Value> fmaOps = {ops[1], ops[2], ops[0]};
+    return emitNeonCall(cgm, builder, {ty, ty, ty}, fmaOps, "fma", ty, loc);
+  }
+  case NEON::BI__builtin_neon_vfma_laneq_v: {
+    auto vecTy = mlir::cast<cir::VectorType>(ty);
+    if (vecTy.getElementType() == cgm.doubleTy) {
+      mlir::Type scalarTy = vecTy.getElementType();
+      mlir::Value acc = builder.createBitcast(loc, ops[0], scalarTy);
+      mlir::Value lhs = builder.createBitcast(loc, ops[1], scalarTy);
+      cir::VectorType sourceTy = cir::VectorType::get(scalarTy, 2);
+      mlir::Value rhsVec = builder.createBitcast(loc, ops[2], sourceTy);
+      mlir::Value rhs = cir::VecExtractOp::create(builder, loc, rhsVec, ops[3]);
+      llvm::SmallVector<mlir::Value> fmaOps = {lhs, rhs, acc};
+      mlir::Value scalarRes = emitNeonCall(cgm, builder,
+                                           {scalarTy, scalarTy, scalarTy},
+                                           fmaOps, "fma", scalarTy, loc);
+      return builder.createBitcast(loc, scalarRes, ty);
+    }
+    cir::VectorType sourceTy =
+        cir::VectorType::get(vecTy.getElementType(), vecTy.getSize() * 2);
+    ops[0] = builder.createBitcast(loc, ops[0], ty);
+    ops[1] = builder.createBitcast(loc, ops[1], ty);
+    ops[2] = builder.createBitcast(loc, ops[2], sourceTy);
+
+    int64_t lane =
+        expr->getArg(3)->EvaluateKnownConstInt(getContext()).getSExtValue();
+    llvm::SmallVector<int64_t> mask(vecTy.getSize(), lane);
+    ops[2] = builder.createVecShuffle(loc, ops[2], mask);
+    llvm::SmallVector<mlir::Value> fmaOps = {ops[1], ops[2], ops[0]};
+    return emitNeonCall(cgm, builder, {ty, ty, ty}, fmaOps, "fma", ty, loc);
+  }
+  case NEON::BI__builtin_neon_vfmaq_laneq_v: {
+    auto vecTy = mlir::cast<cir::VectorType>(ty);
+    ops[0] = builder.createBitcast(loc, ops[0], ty);
+    ops[1] = builder.createBitcast(loc, ops[1], ty);
+    ops[2] = builder.createBitcast(loc, ops[2], ty);
+
+    int64_t lane =
+        expr->getArg(3)->EvaluateKnownConstInt(getContext()).getSExtValue();
+    llvm::SmallVector<int64_t> mask(vecTy.getSize(), lane);
+    ops[2] = builder.createVecShuffle(loc, ops[2], mask);
+    llvm::SmallVector<mlir::Value> fmaOps = {ops[1], ops[2], ops[0]};
+    return emitNeonCall(cgm, builder, {ty, ty, ty}, fmaOps, "fma", ty, loc);
+  }
   case NEON::BI__builtin_neon_vfmah_lane_f16:
   case NEON::BI__builtin_neon_vfmas_lane_f32:
   case NEON::BI__builtin_neon_vfmah_laneq_f16:
   case NEON::BI__builtin_neon_vfmas_laneq_f32:
   case NEON::BI__builtin_neon_vfmad_lane_f64:
   case NEON::BI__builtin_neon_vfmad_laneq_f64: {
-    mlir::Value lane = cir::VecExtractOp::create(builder, loc, ops[2], ops[3]);
     mlir::Type scalarTy = convertType(expr->getType());
-    llvm::SmallVector<mlir::Value> fmaOps = {ops[1], lane, ops[0]};
-    return emitCallMaybeConstrainedBuiltin(builder, loc, "fma", scalarTy,
-                                           fmaOps);
+    mlir::Value acc = ops[0];
+    mlir::Value lhs = ops[1];
+    mlir::Value lane = cir::VecExtractOp::create(builder, loc, ops[2], ops[3]);
+    if (acc.getType() != scalarTy)
+      acc = builder.createBitcast(loc, acc, scalarTy);
+    if (lhs.getType() != scalarTy)
+      lhs = builder.createBitcast(loc, lhs, scalarTy);
+    if (lane.getType() != scalarTy)
+      lane = builder.createBitcast(loc, lane, scalarTy);
+    llvm::SmallVector<mlir::Value> fmaOps = {lhs, lane, acc};
+    return emitNeonCall(cgm, builder, {scalarTy, scalarTy, scalarTy}, fmaOps,
+                        "fma", scalarTy, loc);
   }
   case NEON::BI__builtin_neon_vmull_v:
   case NEON::BI__builtin_neon_vmax_v:
@@ -2294,15 +2299,11 @@ CIRGenFunction::emitAArch64BuiltinExpr(unsigned builtinID, const CallExpr *expr,
                      getContext().BuiltinInfo.getName(builtinID));
     return mlir::Value{};
   case NEON::BI__builtin_neon_vabd_v:
-  case NEON::BI__builtin_neon_vabdq_v: {
-    cir::VectorType ty = getNeonType(this, type, loc);
-    if (!ty)
-      return nullptr;
+  case NEON::BI__builtin_neon_vabdq_v:
     intrName = usgn ? "aarch64.neon.uabd" : "aarch64.neon.sabd";
     if (cir::isFPOrVectorOfFPType(ty))
       intrName = "aarch64.neon.fabd";
     return emitNeonCall(cgm, builder, {ty, ty}, ops, intrName, ty, loc);
-  }
   case NEON::BI__builtin_neon_vpadal_v:
   case NEON::BI__builtin_neon_vpadalq_v:
   case NEON::BI__builtin_neon_vpmin_v:

--- a/clang/lib/CIR/CodeGen/CIRGenBuiltinAArch64.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuiltinAArch64.cpp
@@ -140,9 +140,10 @@ static cir::VectorType getNeonType(CIRGenFunction *cgf, NeonTypeFlags typeFlags,
     [[fallthrough]];
   case NeonTypeFlags::Float16:
     if (hasLegalHalfType)
-      return cir::VectorType::get(cgf->getCIRGenModule().fP16Ty,
-                                  v1Ty ? 1 : (4 << isQuad));
-    return cir::VectorType::get(cgf->uInt16Ty, v1Ty ? 1 : (4 << isQuad));
+      cgf->getCIRGenModule().errorNYI(loc, std::string("NEON type: Float16"));
+    else
+      cgf->getCIRGenModule().errorNYI(loc, std::string("NEON type: Float16"));
+    [[fallthrough]];
   case NeonTypeFlags::Int32:
     return cir::VectorType::get(typeFlags.isUnsigned() ? cgf->uInt32Ty
                                                        : cgf->sInt32Ty,
@@ -2268,11 +2269,21 @@ CIRGenFunction::emitAArch64BuiltinExpr(unsigned builtinID, const CallExpr *expr,
     return emitNeonCall(cgm, builder, {ty, ty, ty}, fmaOps, "fma", ty, loc);
   }
   case NEON::BI__builtin_neon_vfmah_lane_f16:
+    cgm.errorNYI(expr->getSourceRange(),
+                 std::string("unimplemented AArch64 builtin call: ") +
+                     getContext().BuiltinInfo.getName(builtinID));
+    return mlir::Value{};
   case NEON::BI__builtin_neon_vfmas_lane_f32:
   case NEON::BI__builtin_neon_vfmah_laneq_f16:
   case NEON::BI__builtin_neon_vfmas_laneq_f32:
   case NEON::BI__builtin_neon_vfmad_lane_f64:
   case NEON::BI__builtin_neon_vfmad_laneq_f64: {
+    if (builtinID == NEON::BI__builtin_neon_vfmah_laneq_f16) {
+      cgm.errorNYI(expr->getSourceRange(),
+                   std::string("unimplemented AArch64 builtin call: ") +
+                       getContext().BuiltinInfo.getName(builtinID));
+      return mlir::Value{};
+    }
     mlir::Type scalarTy = convertType(expr->getType());
     mlir::Value acc = ops[0];
     mlir::Value lhs = ops[1];

--- a/clang/lib/CIR/CodeGen/CIRGenBuiltinAArch64.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuiltinAArch64.cpp
@@ -139,7 +139,8 @@ static cir::VectorType getNeonType(CIRGenFunction *cgf, NeonTypeFlags typeFlags,
       cgf->getCIRGenModule().errorNYI(loc, std::string("NEON type: BFloat16"));
     [[fallthrough]];
   case NeonTypeFlags::Float16:
-    return cir::VectorType::get(cgf->getCIRGenModule().fP16Ty,
+    return cir::VectorType::get(hasLegalHalfType ? cgf->getCIRGenModule().fP16Ty
+                                                 : cgf->uInt16Ty,
                                 v1Ty ? 1 : (4 << isQuad));
   case NeonTypeFlags::Int32:
     return cir::VectorType::get(typeFlags.isUnsigned() ? cgf->uInt32Ty
@@ -357,6 +358,8 @@ static mlir::Value emitCommonNeonBuiltinExpr(
   case NEON::BI__builtin_neon_vld4q_lane_v:
   case NEON::BI__builtin_neon_vmovl_v:
   case NEON::BI__builtin_neon_vmovn_v:
+  case NEON::BI__builtin_neon_vbsl_v:
+  case NEON::BI__builtin_neon_vbslq_v:
   case NEON::BI__builtin_neon_vmull_v:
   case NEON::BI__builtin_neon_vpadal_v:
   case NEON::BI__builtin_neon_vpadalq_v:
@@ -475,6 +478,77 @@ emitCallMaybeConstrainedBuiltin(CIRGenBuilderTy &builder, mlir::Location loc,
   assert(!cir::MissingFeatures::emitConstrainedFPCall());
 
   return builder.emitIntrinsicCallOp(loc, intrName, retTy, ops);
+}
+
+static mlir::Value emitVectorFmaLaneSource(CIRGenBuilderTy &builder,
+                                           mlir::Location loc,
+                                           const CallExpr *expr,
+                                           ASTContext &ctx,
+                                           mlir::Value laneSource,
+                                           cir::VectorType ty,
+                                           cir::VectorType sourceTy) {
+  if (laneSource.getType() != sourceTy)
+    laneSource = builder.createBitcast(loc, laneSource, sourceTy);
+
+  auto vecTy = mlir::cast<cir::VectorType>(ty);
+  int64_t lane = expr->getArg(3)->EvaluateKnownConstInt(ctx).getSExtValue();
+  llvm::SmallVector<int64_t> mask(vecTy.getSize(), lane);
+  return builder.createVecShuffle(loc, laneSource, mask);
+}
+
+static mlir::Value emitVectorFmaBuiltin(CIRGenFunction &cgf,
+                                        mlir::Location loc,
+                                        llvm::SmallVectorImpl<mlir::Value> &ops,
+                                        const CallExpr *expr) {
+  cir::VectorType ty = mlir::cast<cir::VectorType>(cgf.convertType(expr->getType()));
+  if (ops[0].getType() != ty)
+    ops[0] = cgf.getBuilder().createBitcast(loc, ops[0], ty);
+  if (ops[1].getType() != ty)
+    ops[1] = cgf.getBuilder().createBitcast(loc, ops[1], ty);
+  if (ops[2].getType() != ty)
+    ops[2] = cgf.getBuilder().createBitcast(loc, ops[2], ty);
+  std::rotate(ops.begin(), ops.begin() + 1, ops.end());
+  return emitCallMaybeConstrainedBuiltin(cgf.getBuilder(), loc, "fma", ty, ops);
+}
+
+static mlir::Value emitVectorFmaLaneBuiltin(CIRGenFunction &cgf,
+                                            unsigned builtinID,
+                                            NeonTypeFlags type,
+                                            mlir::Location loc,
+                                            const CallExpr *expr,
+                                            llvm::SmallVectorImpl<mlir::Value> &ops) {
+  cir::VectorType ty = getNeonType(&cgf, type, loc);
+  if (!ty)
+    return nullptr;
+
+  auto vecTy = mlir::cast<cir::VectorType>(ty);
+  cir::VectorType sourceTy = ty;
+  unsigned vectorFmaBuiltin = NEON::BI__builtin_neon_vfma_v;
+
+  switch (builtinID) {
+  case NEON::BI__builtin_neon_vfmaq_lane_v:
+    sourceTy = cir::VectorType::get(vecTy.getElementType(), vecTy.getSize() / 2);
+    vectorFmaBuiltin = NEON::BI__builtin_neon_vfmaq_v;
+    break;
+  case NEON::BI__builtin_neon_vfma_laneq_v:
+    sourceTy = cir::VectorType::get(vecTy.getElementType(), vecTy.getSize() * 2);
+    break;
+  case NEON::BI__builtin_neon_vfmaq_laneq_v:
+    vectorFmaBuiltin = NEON::BI__builtin_neon_vfmaq_v;
+    break;
+  case NEON::BI__builtin_neon_vfma_lane_v:
+    break;
+  default:
+    llvm_unreachable("unexpected vfma lane builtin");
+  }
+
+  llvm::SmallVector<mlir::Value> fmaOps(ops.begin(), ops.end() - 1);
+  fmaOps[2] = emitVectorFmaLaneSource(cgf.getBuilder(), loc, expr,
+                                      cgf.getContext(), ops[2], ty, sourceTy);
+  const ARMVectorIntrinsicInfo *info = findARMVectorIntrinsicInMap(
+      AArch64SIMDIntrinsicMap, vectorFmaBuiltin,
+      aarch64SIMDIntrinsicsProvenSorted);
+  return emitCommonNeonBuiltinExpr(cgf, *info, fmaOps, expr);
 }
 
 bool CIRGenFunction::getAArch64SVEProcessedOperands(
@@ -730,6 +804,9 @@ static mlir::Value emitCommonNeonSISDBuiltinExpr(
     return emitNeonCall(cgf.cgm, cgf.getBuilder(),
                         {cgf.convertType(expr->getArg(0)->getType())}, ops,
                         llvmIntrName, cgf.convertType(expr->getType()), loc);
+  case NEON::BI__builtin_neon_vfma_v:
+  case NEON::BI__builtin_neon_vfmaq_v:
+    return emitVectorFmaBuiltin(cgf, loc, ops, expr);
   }
 
   return nullptr;
@@ -2188,45 +2265,11 @@ CIRGenFunction::emitAArch64BuiltinExpr(unsigned builtinID, const CallExpr *expr,
   switch (builtinID) {
   default:
     return std::nullopt;
-  case NEON::BI__builtin_neon_vbsl_v:
-  case NEON::BI__builtin_neon_vbslq_v:
   case NEON::BI__builtin_neon_vfma_lane_v:
   case NEON::BI__builtin_neon_vfmaq_lane_v:
   case NEON::BI__builtin_neon_vfma_laneq_v:
-  case NEON::BI__builtin_neon_vfmaq_laneq_v: {
-    // Keep the NEON vector type local to each vector-only builtin block.
-    cir::VectorType ty = getNeonType(this, type, loc);
-    if (!ty)
-      return nullptr;
-    mlir::Value addend = ops[0];
-    mlir::Value multiplicand = ops[1];
-    mlir::Value laneSource = ops[2];
-    auto vecTy = mlir::cast<cir::VectorType>(ty);
-    auto elemTy = vecTy.getElementType();
-    auto numElts = vecTy.getSize();
-
-    if (addend.getType() != ty)
-      addend = builder.createBitcast(loc, addend, ty);
-    if (multiplicand.getType() != ty)
-      multiplicand = builder.createBitcast(loc, multiplicand, ty);
-
-    cir::VectorType sourceTy = ty;
-    if (builtinID == NEON::BI__builtin_neon_vfmaq_lane_v)
-      sourceTy = cir::VectorType::get(elemTy, numElts / 2);
-    else if (builtinID == NEON::BI__builtin_neon_vfma_laneq_v)
-      sourceTy = cir::VectorType::get(elemTy, numElts * 2);
-
-    if (laneSource.getType() != sourceTy)
-      laneSource = builder.createBitcast(loc, laneSource, sourceTy);
-
-    int64_t lane =
-        expr->getArg(3)->EvaluateKnownConstInt(getContext()).getSExtValue();
-    llvm::SmallVector<int64_t> mask(numElts, lane);
-    mlir::Value splat = builder.createVecShuffle(loc, laneSource, mask);
-
-    llvm::SmallVector<mlir::Value> fmaOps = {multiplicand, splat, addend};
-    return emitCallMaybeConstrainedBuiltin(builder, loc, "fma", ty, fmaOps);
-  }
+  case NEON::BI__builtin_neon_vfmaq_laneq_v:
+    return emitVectorFmaLaneBuiltin(*this, builtinID, type, loc, expr, ops);
   case NEON::BI__builtin_neon_vfmah_lane_f16:
   case NEON::BI__builtin_neon_vfmas_lane_f32:
   case NEON::BI__builtin_neon_vfmah_laneq_f16:

--- a/clang/lib/CIR/CodeGen/CIRGenBuiltinAArch64.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuiltinAArch64.cpp
@@ -139,8 +139,6 @@ static cir::VectorType getNeonType(CIRGenFunction *cgf, NeonTypeFlags typeFlags,
       cgf->getCIRGenModule().errorNYI(loc, std::string("NEON type: BFloat16"));
     [[fallthrough]];
   case NeonTypeFlags::Float16:
-    if (!hasLegalHalfType)
-      cgf->getCIRGenModule().errorNYI(loc, std::string("NEON type: Float16"));
     return cir::VectorType::get(cgf->getCIRGenModule().fP16Ty,
                                 v1Ty ? 1 : (4 << isQuad));
   case NeonTypeFlags::Int32:
@@ -627,6 +625,11 @@ static bool hasExtraNeonArgument(unsigned builtinID) {
   case ARM::BI__builtin_arm_vcvtr_d:
     mask = 1;
   }
+  switch (builtinID) {
+  default:
+    break;
+  }
+
   return mask != 0;
 }
 
@@ -2180,27 +2183,6 @@ CIRGenFunction::emitAArch64BuiltinExpr(unsigned builtinID, const CallExpr *expr,
     return mlir::Value{};
   }
 
-  switch (builtinID) {
-  case NEON::BI__builtin_neon_vfmah_lane_f16:
-  case NEON::BI__builtin_neon_vfmas_lane_f32:
-  case NEON::BI__builtin_neon_vfmah_laneq_f16:
-  case NEON::BI__builtin_neon_vfmas_laneq_f32:
-  case NEON::BI__builtin_neon_vfmad_lane_f64:
-  case NEON::BI__builtin_neon_vfmad_laneq_f64: {
-    mlir::Value lane = cir::VecExtractOp::create(builder, loc, ops[2], ops[3]);
-    mlir::Type scalarTy = convertType(expr->getType());
-    llvm::SmallVector<mlir::Value> fmaOps = {ops[1], lane, ops[0]};
-    return emitCallMaybeConstrainedBuiltin(builder, loc, "fma", scalarTy,
-                                           fmaOps);
-  }
-  default:
-    break;
-  }
-
-  cir::VectorType ty = getNeonType(this, type, loc);
-  if (!ty)
-    return nullptr;
-
   llvm::StringRef intrName;
 
   switch (builtinID) {
@@ -2212,6 +2194,10 @@ CIRGenFunction::emitAArch64BuiltinExpr(unsigned builtinID, const CallExpr *expr,
   case NEON::BI__builtin_neon_vfmaq_lane_v:
   case NEON::BI__builtin_neon_vfma_laneq_v:
   case NEON::BI__builtin_neon_vfmaq_laneq_v: {
+    // Keep the NEON vector type local to each vector-only builtin block.
+    cir::VectorType ty = getNeonType(this, type, loc);
+    if (!ty)
+      return nullptr;
     mlir::Value addend = ops[0];
     mlir::Value multiplicand = ops[1];
     mlir::Value laneSource = ops[2];
@@ -2241,6 +2227,18 @@ CIRGenFunction::emitAArch64BuiltinExpr(unsigned builtinID, const CallExpr *expr,
     llvm::SmallVector<mlir::Value> fmaOps = {multiplicand, splat, addend};
     return emitCallMaybeConstrainedBuiltin(builder, loc, "fma", ty, fmaOps);
   }
+  case NEON::BI__builtin_neon_vfmah_lane_f16:
+  case NEON::BI__builtin_neon_vfmas_lane_f32:
+  case NEON::BI__builtin_neon_vfmah_laneq_f16:
+  case NEON::BI__builtin_neon_vfmas_laneq_f32:
+  case NEON::BI__builtin_neon_vfmad_lane_f64:
+  case NEON::BI__builtin_neon_vfmad_laneq_f64: {
+    mlir::Value lane = cir::VecExtractOp::create(builder, loc, ops[2], ops[3]);
+    mlir::Type scalarTy = convertType(expr->getType());
+    llvm::SmallVector<mlir::Value> fmaOps = {ops[1], lane, ops[0]};
+    return emitCallMaybeConstrainedBuiltin(builder, loc, "fma", scalarTy,
+                                           fmaOps);
+  }
   case NEON::BI__builtin_neon_vmull_v:
   case NEON::BI__builtin_neon_vmax_v:
   case NEON::BI__builtin_neon_vmaxq_v:
@@ -2253,11 +2251,15 @@ CIRGenFunction::emitAArch64BuiltinExpr(unsigned builtinID, const CallExpr *expr,
                      getContext().BuiltinInfo.getName(builtinID));
     return mlir::Value{};
   case NEON::BI__builtin_neon_vabd_v:
-  case NEON::BI__builtin_neon_vabdq_v:
+  case NEON::BI__builtin_neon_vabdq_v: {
+    cir::VectorType ty = getNeonType(this, type, loc);
+    if (!ty)
+      return nullptr;
     intrName = usgn ? "aarch64.neon.uabd" : "aarch64.neon.sabd";
     if (cir::isFPOrVectorOfFPType(ty))
       intrName = "aarch64.neon.fabd";
     return emitNeonCall(cgm, builder, {ty, ty}, ops, intrName, ty, loc);
+  }
   case NEON::BI__builtin_neon_vpadal_v:
   case NEON::BI__builtin_neon_vpadalq_v:
   case NEON::BI__builtin_neon_vpmin_v:

--- a/clang/test/CodeGen/AArch64/neon-2velem.c
+++ b/clang/test/CodeGen/AArch64/neon-2velem.c
@@ -404,83 +404,6 @@ uint32x2_t test_vmul_laneq_u32(uint32x2_t a, uint32x4_t v) {
 uint32x4_t test_vmulq_laneq_u32(uint32x4_t a, uint32x4_t v) {
   return vmulq_laneq_u32(a, v, 3);
 }
-
-// CHECK-LABEL: @test_vfma_lane_f32(
-// CHECK-NEXT:  entry:
-// CHECK-NEXT:    [[TMP0:%.*]] = bitcast <2 x float> [[A:%.*]] to <2 x i32>
-// CHECK-NEXT:    [[TMP1:%.*]] = bitcast <2 x float> [[B:%.*]] to <2 x i32>
-// CHECK-NEXT:    [[TMP2:%.*]] = bitcast <2 x float> [[V:%.*]] to <2 x i32>
-// CHECK-NEXT:    [[TMP3:%.*]] = bitcast <2 x i32> [[TMP0]] to <8 x i8>
-// CHECK-NEXT:    [[TMP4:%.*]] = bitcast <2 x i32> [[TMP1]] to <8 x i8>
-// CHECK-NEXT:    [[TMP5:%.*]] = bitcast <2 x i32> [[TMP2]] to <8 x i8>
-// CHECK-NEXT:    [[TMP6:%.*]] = bitcast <8 x i8> [[TMP5]] to <2 x float>
-// CHECK-NEXT:    [[LANE:%.*]] = shufflevector <2 x float> [[TMP6]], <2 x float> [[TMP6]], <2 x i32> <i32 1, i32 1>
-// CHECK-NEXT:    [[FMLA:%.*]] = bitcast <8 x i8> [[TMP4]] to <2 x float>
-// CHECK-NEXT:    [[FMLA1:%.*]] = bitcast <8 x i8> [[TMP3]] to <2 x float>
-// CHECK-NEXT:    [[FMLA2:%.*]] = call <2 x float> @llvm.fma.v2f32(<2 x float> [[FMLA]], <2 x float> [[LANE]], <2 x float> [[FMLA1]])
-// CHECK-NEXT:    ret <2 x float> [[FMLA2]]
-//
-float32x2_t test_vfma_lane_f32(float32x2_t a, float32x2_t b, float32x2_t v) {
-  return vfma_lane_f32(a, b, v, 1);
-}
-
-// CHECK-LABEL: @test_vfmaq_lane_f32(
-// CHECK-NEXT:  entry:
-// CHECK-NEXT:    [[TMP0:%.*]] = bitcast <4 x float> [[A:%.*]] to <4 x i32>
-// CHECK-NEXT:    [[TMP1:%.*]] = bitcast <4 x float> [[B:%.*]] to <4 x i32>
-// CHECK-NEXT:    [[TMP2:%.*]] = bitcast <2 x float> [[V:%.*]] to <2 x i32>
-// CHECK-NEXT:    [[TMP3:%.*]] = bitcast <4 x i32> [[TMP0]] to <16 x i8>
-// CHECK-NEXT:    [[TMP4:%.*]] = bitcast <4 x i32> [[TMP1]] to <16 x i8>
-// CHECK-NEXT:    [[TMP5:%.*]] = bitcast <2 x i32> [[TMP2]] to <8 x i8>
-// CHECK-NEXT:    [[TMP6:%.*]] = bitcast <8 x i8> [[TMP5]] to <2 x float>
-// CHECK-NEXT:    [[LANE:%.*]] = shufflevector <2 x float> [[TMP6]], <2 x float> [[TMP6]], <4 x i32> <i32 1, i32 1, i32 1, i32 1>
-// CHECK-NEXT:    [[FMLA:%.*]] = bitcast <16 x i8> [[TMP4]] to <4 x float>
-// CHECK-NEXT:    [[FMLA1:%.*]] = bitcast <16 x i8> [[TMP3]] to <4 x float>
-// CHECK-NEXT:    [[FMLA2:%.*]] = call <4 x float> @llvm.fma.v4f32(<4 x float> [[FMLA]], <4 x float> [[LANE]], <4 x float> [[FMLA1]])
-// CHECK-NEXT:    ret <4 x float> [[FMLA2]]
-//
-float32x4_t test_vfmaq_lane_f32(float32x4_t a, float32x4_t b, float32x2_t v) {
-  return vfmaq_lane_f32(a, b, v, 1);
-}
-
-// CHECK-LABEL: @test_vfma_laneq_f32(
-// CHECK-NEXT:  entry:
-// CHECK-NEXT:    [[TMP0:%.*]] = bitcast <2 x float> [[A:%.*]] to <2 x i32>
-// CHECK-NEXT:    [[TMP1:%.*]] = bitcast <2 x float> [[B:%.*]] to <2 x i32>
-// CHECK-NEXT:    [[TMP2:%.*]] = bitcast <4 x float> [[V:%.*]] to <4 x i32>
-// CHECK-NEXT:    [[TMP3:%.*]] = bitcast <2 x i32> [[TMP0]] to <8 x i8>
-// CHECK-NEXT:    [[TMP4:%.*]] = bitcast <2 x i32> [[TMP1]] to <8 x i8>
-// CHECK-NEXT:    [[TMP5:%.*]] = bitcast <4 x i32> [[TMP2]] to <16 x i8>
-// CHECK-NEXT:    [[TMP6:%.*]] = bitcast <8 x i8> [[TMP3]] to <2 x float>
-// CHECK-NEXT:    [[TMP7:%.*]] = bitcast <8 x i8> [[TMP4]] to <2 x float>
-// CHECK-NEXT:    [[TMP8:%.*]] = bitcast <16 x i8> [[TMP5]] to <4 x float>
-// CHECK-NEXT:    [[LANE:%.*]] = shufflevector <4 x float> [[TMP8]], <4 x float> [[TMP8]], <2 x i32> <i32 3, i32 3>
-// CHECK-NEXT:    [[TMP9:%.*]] = call <2 x float> @llvm.fma.v2f32(<2 x float> [[LANE]], <2 x float> [[TMP7]], <2 x float> [[TMP6]])
-// CHECK-NEXT:    ret <2 x float> [[TMP9]]
-//
-float32x2_t test_vfma_laneq_f32(float32x2_t a, float32x2_t b, float32x4_t v) {
-  return vfma_laneq_f32(a, b, v, 3);
-}
-
-// CHECK-LABEL: @test_vfmaq_laneq_f32(
-// CHECK-NEXT:  entry:
-// CHECK-NEXT:    [[TMP0:%.*]] = bitcast <4 x float> [[A:%.*]] to <4 x i32>
-// CHECK-NEXT:    [[TMP1:%.*]] = bitcast <4 x float> [[B:%.*]] to <4 x i32>
-// CHECK-NEXT:    [[TMP2:%.*]] = bitcast <4 x float> [[V:%.*]] to <4 x i32>
-// CHECK-NEXT:    [[TMP3:%.*]] = bitcast <4 x i32> [[TMP0]] to <16 x i8>
-// CHECK-NEXT:    [[TMP4:%.*]] = bitcast <4 x i32> [[TMP1]] to <16 x i8>
-// CHECK-NEXT:    [[TMP5:%.*]] = bitcast <4 x i32> [[TMP2]] to <16 x i8>
-// CHECK-NEXT:    [[TMP6:%.*]] = bitcast <16 x i8> [[TMP3]] to <4 x float>
-// CHECK-NEXT:    [[TMP7:%.*]] = bitcast <16 x i8> [[TMP4]] to <4 x float>
-// CHECK-NEXT:    [[TMP8:%.*]] = bitcast <16 x i8> [[TMP5]] to <4 x float>
-// CHECK-NEXT:    [[LANE:%.*]] = shufflevector <4 x float> [[TMP8]], <4 x float> [[TMP8]], <4 x i32> <i32 3, i32 3, i32 3, i32 3>
-// CHECK-NEXT:    [[TMP9:%.*]] = call <4 x float> @llvm.fma.v4f32(<4 x float> [[LANE]], <4 x float> [[TMP7]], <4 x float> [[TMP6]])
-// CHECK-NEXT:    ret <4 x float> [[TMP9]]
-//
-float32x4_t test_vfmaq_laneq_f32(float32x4_t a, float32x4_t b, float32x4_t v) {
-  return vfmaq_laneq_f32(a, b, v, 3);
-}
-
 // CHECK-LABEL: @test_vfms_lane_f32(
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[TMP0:%.*]] = bitcast <2 x float> [[A:%.*]] to <2 x i32>
@@ -560,46 +483,6 @@ float32x2_t test_vfms_laneq_f32(float32x2_t a, float32x2_t b, float32x4_t v) {
 float32x4_t test_vfmsq_laneq_f32(float32x4_t a, float32x4_t b, float32x4_t v) {
   return vfmsq_laneq_f32(a, b, v, 3);
 }
-
-// CHECK-LABEL: @test_vfmaq_lane_f64(
-// CHECK-NEXT:  entry:
-// CHECK-NEXT:    [[TMP0:%.*]] = bitcast <2 x double> [[A:%.*]] to <2 x i64>
-// CHECK-NEXT:    [[TMP1:%.*]] = bitcast <2 x double> [[B:%.*]] to <2 x i64>
-// CHECK-NEXT:    [[TMP2:%.*]] = bitcast <1 x double> [[V:%.*]] to i64
-// CHECK-NEXT:    [[__S2_SROA_0_0_VEC_INSERT:%.*]] = insertelement <1 x i64> undef, i64 [[TMP2]], i32 0
-// CHECK-NEXT:    [[TMP3:%.*]] = bitcast <2 x i64> [[TMP0]] to <16 x i8>
-// CHECK-NEXT:    [[TMP4:%.*]] = bitcast <2 x i64> [[TMP1]] to <16 x i8>
-// CHECK-NEXT:    [[TMP5:%.*]] = bitcast <1 x i64> [[__S2_SROA_0_0_VEC_INSERT]] to <8 x i8>
-// CHECK-NEXT:    [[TMP6:%.*]] = bitcast <8 x i8> [[TMP5]] to <1 x double>
-// CHECK-NEXT:    [[LANE:%.*]] = shufflevector <1 x double> [[TMP6]], <1 x double> [[TMP6]], <2 x i32> zeroinitializer
-// CHECK-NEXT:    [[FMLA:%.*]] = bitcast <16 x i8> [[TMP4]] to <2 x double>
-// CHECK-NEXT:    [[FMLA1:%.*]] = bitcast <16 x i8> [[TMP3]] to <2 x double>
-// CHECK-NEXT:    [[FMLA2:%.*]] = call <2 x double> @llvm.fma.v2f64(<2 x double> [[FMLA]], <2 x double> [[LANE]], <2 x double> [[FMLA1]])
-// CHECK-NEXT:    ret <2 x double> [[FMLA2]]
-//
-float64x2_t test_vfmaq_lane_f64(float64x2_t a, float64x2_t b, float64x1_t v) {
-  return vfmaq_lane_f64(a, b, v, 0);
-}
-
-// CHECK-LABEL: @test_vfmaq_laneq_f64(
-// CHECK-NEXT:  entry:
-// CHECK-NEXT:    [[TMP0:%.*]] = bitcast <2 x double> [[A:%.*]] to <2 x i64>
-// CHECK-NEXT:    [[TMP1:%.*]] = bitcast <2 x double> [[B:%.*]] to <2 x i64>
-// CHECK-NEXT:    [[TMP2:%.*]] = bitcast <2 x double> [[V:%.*]] to <2 x i64>
-// CHECK-NEXT:    [[TMP3:%.*]] = bitcast <2 x i64> [[TMP0]] to <16 x i8>
-// CHECK-NEXT:    [[TMP4:%.*]] = bitcast <2 x i64> [[TMP1]] to <16 x i8>
-// CHECK-NEXT:    [[TMP5:%.*]] = bitcast <2 x i64> [[TMP2]] to <16 x i8>
-// CHECK-NEXT:    [[TMP6:%.*]] = bitcast <16 x i8> [[TMP3]] to <2 x double>
-// CHECK-NEXT:    [[TMP7:%.*]] = bitcast <16 x i8> [[TMP4]] to <2 x double>
-// CHECK-NEXT:    [[TMP8:%.*]] = bitcast <16 x i8> [[TMP5]] to <2 x double>
-// CHECK-NEXT:    [[LANE:%.*]] = shufflevector <2 x double> [[TMP8]], <2 x double> [[TMP8]], <2 x i32> <i32 1, i32 1>
-// CHECK-NEXT:    [[TMP9:%.*]] = call <2 x double> @llvm.fma.v2f64(<2 x double> [[LANE]], <2 x double> [[TMP7]], <2 x double> [[TMP6]])
-// CHECK-NEXT:    ret <2 x double> [[TMP9]]
-//
-float64x2_t test_vfmaq_laneq_f64(float64x2_t a, float64x2_t b, float64x2_t v) {
-  return vfmaq_laneq_f64(a, b, v, 1);
-}
-
 // CHECK-LABEL: @test_vfmsq_lane_f64(
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[TMP0:%.*]] = bitcast <2 x double> [[A:%.*]] to <2 x i64>
@@ -640,17 +523,6 @@ float64x2_t test_vfmsq_lane_f64(float64x2_t a, float64x2_t b, float64x1_t v) {
 float64x2_t test_vfmsq_laneq_f64(float64x2_t a, float64x2_t b, float64x2_t v) {
   return vfmsq_laneq_f64(a, b, v, 1);
 }
-
-// CHECK-LABEL: @test_vfmas_laneq_f32(
-// CHECK-NEXT:  entry:
-// CHECK-NEXT:    [[EXTRACT:%.*]] = extractelement <4 x float> [[V:%.*]], i32 3
-// CHECK-NEXT:    [[TMP0:%.*]] = call float @llvm.fma.f32(float [[B:%.*]], float [[EXTRACT]], float [[A:%.*]])
-// CHECK-NEXT:    ret float [[TMP0]]
-//
-float32_t test_vfmas_laneq_f32(float32_t a, float32_t b, float32x4_t v) {
-  return vfmas_laneq_f32(a, b, v, 3);
-}
-
 // CHECK-LABEL: @test_vfmsd_lane_f64(
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[FNEG:%.*]] = fneg double [[B:%.*]]
@@ -2547,83 +2419,6 @@ uint32x2_t test_vmul_laneq_u32_0(uint32x2_t a, uint32x4_t v) {
 uint32x4_t test_vmulq_laneq_u32_0(uint32x4_t a, uint32x4_t v) {
   return vmulq_laneq_u32(a, v, 0);
 }
-
-// CHECK-LABEL: @test_vfma_lane_f32_0(
-// CHECK-NEXT:  entry:
-// CHECK-NEXT:    [[TMP0:%.*]] = bitcast <2 x float> [[A:%.*]] to <2 x i32>
-// CHECK-NEXT:    [[TMP1:%.*]] = bitcast <2 x float> [[B:%.*]] to <2 x i32>
-// CHECK-NEXT:    [[TMP2:%.*]] = bitcast <2 x float> [[V:%.*]] to <2 x i32>
-// CHECK-NEXT:    [[TMP3:%.*]] = bitcast <2 x i32> [[TMP0]] to <8 x i8>
-// CHECK-NEXT:    [[TMP4:%.*]] = bitcast <2 x i32> [[TMP1]] to <8 x i8>
-// CHECK-NEXT:    [[TMP5:%.*]] = bitcast <2 x i32> [[TMP2]] to <8 x i8>
-// CHECK-NEXT:    [[TMP6:%.*]] = bitcast <8 x i8> [[TMP5]] to <2 x float>
-// CHECK-NEXT:    [[LANE:%.*]] = shufflevector <2 x float> [[TMP6]], <2 x float> [[TMP6]], <2 x i32> zeroinitializer
-// CHECK-NEXT:    [[FMLA:%.*]] = bitcast <8 x i8> [[TMP4]] to <2 x float>
-// CHECK-NEXT:    [[FMLA1:%.*]] = bitcast <8 x i8> [[TMP3]] to <2 x float>
-// CHECK-NEXT:    [[FMLA2:%.*]] = call <2 x float> @llvm.fma.v2f32(<2 x float> [[FMLA]], <2 x float> [[LANE]], <2 x float> [[FMLA1]])
-// CHECK-NEXT:    ret <2 x float> [[FMLA2]]
-//
-float32x2_t test_vfma_lane_f32_0(float32x2_t a, float32x2_t b, float32x2_t v) {
-  return vfma_lane_f32(a, b, v, 0);
-}
-
-// CHECK-LABEL: @test_vfmaq_lane_f32_0(
-// CHECK-NEXT:  entry:
-// CHECK-NEXT:    [[TMP0:%.*]] = bitcast <4 x float> [[A:%.*]] to <4 x i32>
-// CHECK-NEXT:    [[TMP1:%.*]] = bitcast <4 x float> [[B:%.*]] to <4 x i32>
-// CHECK-NEXT:    [[TMP2:%.*]] = bitcast <2 x float> [[V:%.*]] to <2 x i32>
-// CHECK-NEXT:    [[TMP3:%.*]] = bitcast <4 x i32> [[TMP0]] to <16 x i8>
-// CHECK-NEXT:    [[TMP4:%.*]] = bitcast <4 x i32> [[TMP1]] to <16 x i8>
-// CHECK-NEXT:    [[TMP5:%.*]] = bitcast <2 x i32> [[TMP2]] to <8 x i8>
-// CHECK-NEXT:    [[TMP6:%.*]] = bitcast <8 x i8> [[TMP5]] to <2 x float>
-// CHECK-NEXT:    [[LANE:%.*]] = shufflevector <2 x float> [[TMP6]], <2 x float> [[TMP6]], <4 x i32> zeroinitializer
-// CHECK-NEXT:    [[FMLA:%.*]] = bitcast <16 x i8> [[TMP4]] to <4 x float>
-// CHECK-NEXT:    [[FMLA1:%.*]] = bitcast <16 x i8> [[TMP3]] to <4 x float>
-// CHECK-NEXT:    [[FMLA2:%.*]] = call <4 x float> @llvm.fma.v4f32(<4 x float> [[FMLA]], <4 x float> [[LANE]], <4 x float> [[FMLA1]])
-// CHECK-NEXT:    ret <4 x float> [[FMLA2]]
-//
-float32x4_t test_vfmaq_lane_f32_0(float32x4_t a, float32x4_t b, float32x2_t v) {
-  return vfmaq_lane_f32(a, b, v, 0);
-}
-
-// CHECK-LABEL: @test_vfma_laneq_f32_0(
-// CHECK-NEXT:  entry:
-// CHECK-NEXT:    [[TMP0:%.*]] = bitcast <2 x float> [[A:%.*]] to <2 x i32>
-// CHECK-NEXT:    [[TMP1:%.*]] = bitcast <2 x float> [[B:%.*]] to <2 x i32>
-// CHECK-NEXT:    [[TMP2:%.*]] = bitcast <4 x float> [[V:%.*]] to <4 x i32>
-// CHECK-NEXT:    [[TMP3:%.*]] = bitcast <2 x i32> [[TMP0]] to <8 x i8>
-// CHECK-NEXT:    [[TMP4:%.*]] = bitcast <2 x i32> [[TMP1]] to <8 x i8>
-// CHECK-NEXT:    [[TMP5:%.*]] = bitcast <4 x i32> [[TMP2]] to <16 x i8>
-// CHECK-NEXT:    [[TMP6:%.*]] = bitcast <8 x i8> [[TMP3]] to <2 x float>
-// CHECK-NEXT:    [[TMP7:%.*]] = bitcast <8 x i8> [[TMP4]] to <2 x float>
-// CHECK-NEXT:    [[TMP8:%.*]] = bitcast <16 x i8> [[TMP5]] to <4 x float>
-// CHECK-NEXT:    [[LANE:%.*]] = shufflevector <4 x float> [[TMP8]], <4 x float> [[TMP8]], <2 x i32> zeroinitializer
-// CHECK-NEXT:    [[TMP9:%.*]] = call <2 x float> @llvm.fma.v2f32(<2 x float> [[LANE]], <2 x float> [[TMP7]], <2 x float> [[TMP6]])
-// CHECK-NEXT:    ret <2 x float> [[TMP9]]
-//
-float32x2_t test_vfma_laneq_f32_0(float32x2_t a, float32x2_t b, float32x4_t v) {
-  return vfma_laneq_f32(a, b, v, 0);
-}
-
-// CHECK-LABEL: @test_vfmaq_laneq_f32_0(
-// CHECK-NEXT:  entry:
-// CHECK-NEXT:    [[TMP0:%.*]] = bitcast <4 x float> [[A:%.*]] to <4 x i32>
-// CHECK-NEXT:    [[TMP1:%.*]] = bitcast <4 x float> [[B:%.*]] to <4 x i32>
-// CHECK-NEXT:    [[TMP2:%.*]] = bitcast <4 x float> [[V:%.*]] to <4 x i32>
-// CHECK-NEXT:    [[TMP3:%.*]] = bitcast <4 x i32> [[TMP0]] to <16 x i8>
-// CHECK-NEXT:    [[TMP4:%.*]] = bitcast <4 x i32> [[TMP1]] to <16 x i8>
-// CHECK-NEXT:    [[TMP5:%.*]] = bitcast <4 x i32> [[TMP2]] to <16 x i8>
-// CHECK-NEXT:    [[TMP6:%.*]] = bitcast <16 x i8> [[TMP3]] to <4 x float>
-// CHECK-NEXT:    [[TMP7:%.*]] = bitcast <16 x i8> [[TMP4]] to <4 x float>
-// CHECK-NEXT:    [[TMP8:%.*]] = bitcast <16 x i8> [[TMP5]] to <4 x float>
-// CHECK-NEXT:    [[LANE:%.*]] = shufflevector <4 x float> [[TMP8]], <4 x float> [[TMP8]], <4 x i32> zeroinitializer
-// CHECK-NEXT:    [[TMP9:%.*]] = call <4 x float> @llvm.fma.v4f32(<4 x float> [[LANE]], <4 x float> [[TMP7]], <4 x float> [[TMP6]])
-// CHECK-NEXT:    ret <4 x float> [[TMP9]]
-//
-float32x4_t test_vfmaq_laneq_f32_0(float32x4_t a, float32x4_t b, float32x4_t v) {
-  return vfmaq_laneq_f32(a, b, v, 0);
-}
-
 // CHECK-LABEL: @test_vfms_lane_f32_0(
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[TMP0:%.*]] = bitcast <2 x float> [[A:%.*]] to <2 x i32>
@@ -2703,26 +2498,6 @@ float32x2_t test_vfms_laneq_f32_0(float32x2_t a, float32x2_t b, float32x4_t v) {
 float32x4_t test_vfmsq_laneq_f32_0(float32x4_t a, float32x4_t b, float32x4_t v) {
   return vfmsq_laneq_f32(a, b, v, 0);
 }
-
-// CHECK-LABEL: @test_vfmaq_laneq_f64_0(
-// CHECK-NEXT:  entry:
-// CHECK-NEXT:    [[TMP0:%.*]] = bitcast <2 x double> [[A:%.*]] to <2 x i64>
-// CHECK-NEXT:    [[TMP1:%.*]] = bitcast <2 x double> [[B:%.*]] to <2 x i64>
-// CHECK-NEXT:    [[TMP2:%.*]] = bitcast <2 x double> [[V:%.*]] to <2 x i64>
-// CHECK-NEXT:    [[TMP3:%.*]] = bitcast <2 x i64> [[TMP0]] to <16 x i8>
-// CHECK-NEXT:    [[TMP4:%.*]] = bitcast <2 x i64> [[TMP1]] to <16 x i8>
-// CHECK-NEXT:    [[TMP5:%.*]] = bitcast <2 x i64> [[TMP2]] to <16 x i8>
-// CHECK-NEXT:    [[TMP6:%.*]] = bitcast <16 x i8> [[TMP3]] to <2 x double>
-// CHECK-NEXT:    [[TMP7:%.*]] = bitcast <16 x i8> [[TMP4]] to <2 x double>
-// CHECK-NEXT:    [[TMP8:%.*]] = bitcast <16 x i8> [[TMP5]] to <2 x double>
-// CHECK-NEXT:    [[LANE:%.*]] = shufflevector <2 x double> [[TMP8]], <2 x double> [[TMP8]], <2 x i32> zeroinitializer
-// CHECK-NEXT:    [[TMP9:%.*]] = call <2 x double> @llvm.fma.v2f64(<2 x double> [[LANE]], <2 x double> [[TMP7]], <2 x double> [[TMP6]])
-// CHECK-NEXT:    ret <2 x double> [[TMP9]]
-//
-float64x2_t test_vfmaq_laneq_f64_0(float64x2_t a, float64x2_t b, float64x2_t v) {
-  return vfmaq_laneq_f64(a, b, v, 0);
-}
-
 // CHECK-LABEL: @test_vfmsq_laneq_f64_0(
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[TMP0:%.*]] = bitcast <2 x double> [[A:%.*]] to <2 x i64>

--- a/clang/test/CodeGen/AArch64/neon-scalar-x-indexed-elem.c
+++ b/clang/test/CodeGen/AArch64/neon-scalar-x-indexed-elem.c
@@ -146,41 +146,6 @@ float64x1_t test_vmulx_laneq_f64_0(float64x1_t a, float64x2_t b) {
 float64x1_t test_vmulx_laneq_f64_1(float64x1_t a, float64x2_t b) {
   return vmulx_laneq_f64(a, b, 1);
 }
-
-
-// CHECK-LABEL: define dso_local float @test_vfmas_lane_f32(
-// CHECK-SAME: float noundef [[A:%.*]], float noundef [[B:%.*]], <2 x float> noundef [[C:%.*]]) #[[ATTR0]] {
-// CHECK-NEXT:  [[ENTRY:.*:]]
-// CHECK-NEXT:    [[EXTRACT:%.*]] = extractelement <2 x float> [[C]], i32 1
-// CHECK-NEXT:    [[TMP0:%.*]] = call float @llvm.fma.f32(float [[B]], float [[EXTRACT]], float [[A]])
-// CHECK-NEXT:    ret float [[TMP0]]
-//
-float32_t test_vfmas_lane_f32(float32_t a, float32_t b, float32x2_t c) {
-  return vfmas_lane_f32(a, b, c, 1);
-}
-
-// CHECK-LABEL: define dso_local double @test_vfmad_lane_f64(
-// CHECK-SAME: double noundef [[A:%.*]], double noundef [[B:%.*]], <1 x double> noundef [[C:%.*]]) #[[ATTR0]] {
-// CHECK-NEXT:  [[ENTRY:.*:]]
-// CHECK-NEXT:    [[EXTRACT:%.*]] = extractelement <1 x double> [[C]], i32 0
-// CHECK-NEXT:    [[TMP0:%.*]] = call double @llvm.fma.f64(double [[B]], double [[EXTRACT]], double [[A]])
-// CHECK-NEXT:    ret double [[TMP0]]
-//
-float64_t test_vfmad_lane_f64(float64_t a, float64_t b, float64x1_t c) {
-  return vfmad_lane_f64(a, b, c, 0);
-}
-
-// CHECK-LABEL: define dso_local double @test_vfmad_laneq_f64(
-// CHECK-SAME: double noundef [[A:%.*]], double noundef [[B:%.*]], <2 x double> noundef [[C:%.*]]) #[[ATTR0]] {
-// CHECK-NEXT:  [[ENTRY:.*:]]
-// CHECK-NEXT:    [[EXTRACT:%.*]] = extractelement <2 x double> [[C]], i32 1
-// CHECK-NEXT:    [[TMP0:%.*]] = call double @llvm.fma.f64(double [[B]], double [[EXTRACT]], double [[A]])
-// CHECK-NEXT:    ret double [[TMP0]]
-//
-float64_t test_vfmad_laneq_f64(float64_t a, float64_t b, float64x2_t c) {
-  return vfmad_laneq_f64(a, b, c, 1);
-}
-
 // CHECK-LABEL: define dso_local float @test_vfmss_lane_f32(
 // CHECK-SAME: float noundef [[A:%.*]], float noundef [[B:%.*]], <2 x float> noundef [[C:%.*]]) #[[ATTR0]] {
 // CHECK-NEXT:  [[ENTRY:.*:]]
@@ -192,30 +157,6 @@ float64_t test_vfmad_laneq_f64(float64_t a, float64_t b, float64x2_t c) {
 float32_t test_vfmss_lane_f32(float32_t a, float32_t b, float32x2_t c) {
   return vfmss_lane_f32(a, b, c, 1);
 }
-
-// CHECK-LABEL: define dso_local <1 x double> @test_vfma_lane_f64(
-// CHECK-SAME: <1 x double> noundef [[A:%.*]], <1 x double> noundef [[B:%.*]], <1 x double> noundef [[V:%.*]]) #[[ATTR0]] {
-// CHECK-NEXT:  [[ENTRY:.*:]]
-// CHECK-NEXT:    [[TMP0:%.*]] = bitcast <1 x double> [[A]] to i64
-// CHECK-NEXT:    [[__S0_SROA_0_0_VEC_INSERT:%.*]] = insertelement <1 x i64> undef, i64 [[TMP0]], i32 0
-// CHECK-NEXT:    [[TMP1:%.*]] = bitcast <1 x double> [[B]] to i64
-// CHECK-NEXT:    [[__S1_SROA_0_0_VEC_INSERT:%.*]] = insertelement <1 x i64> undef, i64 [[TMP1]], i32 0
-// CHECK-NEXT:    [[TMP2:%.*]] = bitcast <1 x double> [[V]] to i64
-// CHECK-NEXT:    [[__S2_SROA_0_0_VEC_INSERT:%.*]] = insertelement <1 x i64> undef, i64 [[TMP2]], i32 0
-// CHECK-NEXT:    [[TMP3:%.*]] = bitcast <1 x i64> [[__S0_SROA_0_0_VEC_INSERT]] to <8 x i8>
-// CHECK-NEXT:    [[TMP4:%.*]] = bitcast <1 x i64> [[__S1_SROA_0_0_VEC_INSERT]] to <8 x i8>
-// CHECK-NEXT:    [[TMP5:%.*]] = bitcast <1 x i64> [[__S2_SROA_0_0_VEC_INSERT]] to <8 x i8>
-// CHECK-NEXT:    [[TMP6:%.*]] = bitcast <8 x i8> [[TMP5]] to <1 x double>
-// CHECK-NEXT:    [[LANE:%.*]] = shufflevector <1 x double> [[TMP6]], <1 x double> [[TMP6]], <1 x i32> zeroinitializer
-// CHECK-NEXT:    [[FMLA:%.*]] = bitcast <8 x i8> [[TMP4]] to <1 x double>
-// CHECK-NEXT:    [[FMLA1:%.*]] = bitcast <8 x i8> [[TMP3]] to <1 x double>
-// CHECK-NEXT:    [[FMLA2:%.*]] = call <1 x double> @llvm.fma.v1f64(<1 x double> [[FMLA]], <1 x double> [[LANE]], <1 x double> [[FMLA1]])
-// CHECK-NEXT:    ret <1 x double> [[FMLA2]]
-//
-float64x1_t test_vfma_lane_f64(float64x1_t a, float64x1_t b, float64x1_t v) {
-  return vfma_lane_f64(a, b, v, 0);
-}
-
 // CHECK-LABEL: define dso_local <1 x double> @test_vfms_lane_f64(
 // CHECK-SAME: <1 x double> noundef [[A:%.*]], <1 x double> noundef [[B:%.*]], <1 x double> noundef [[V:%.*]]) #[[ATTR0]] {
 // CHECK-NEXT:  [[ENTRY:.*:]]
@@ -239,30 +180,6 @@ float64x1_t test_vfma_lane_f64(float64x1_t a, float64x1_t b, float64x1_t v) {
 float64x1_t test_vfms_lane_f64(float64x1_t a, float64x1_t b, float64x1_t v) {
   return vfms_lane_f64(a, b, v, 0);
 }
-
-// CHECK-LABEL: define dso_local <1 x double> @test_vfma_laneq_f64(
-// CHECK-SAME: <1 x double> noundef [[A:%.*]], <1 x double> noundef [[B:%.*]], <2 x double> noundef [[V:%.*]]) #[[ATTR0]] {
-// CHECK-NEXT:  [[ENTRY:.*:]]
-// CHECK-NEXT:    [[TMP0:%.*]] = bitcast <1 x double> [[A]] to i64
-// CHECK-NEXT:    [[__S0_SROA_0_0_VEC_INSERT:%.*]] = insertelement <1 x i64> undef, i64 [[TMP0]], i32 0
-// CHECK-NEXT:    [[TMP1:%.*]] = bitcast <1 x double> [[B]] to i64
-// CHECK-NEXT:    [[__S1_SROA_0_0_VEC_INSERT:%.*]] = insertelement <1 x i64> undef, i64 [[TMP1]], i32 0
-// CHECK-NEXT:    [[TMP2:%.*]] = bitcast <2 x double> [[V]] to <2 x i64>
-// CHECK-NEXT:    [[TMP3:%.*]] = bitcast <1 x i64> [[__S0_SROA_0_0_VEC_INSERT]] to <8 x i8>
-// CHECK-NEXT:    [[TMP4:%.*]] = bitcast <1 x i64> [[__S1_SROA_0_0_VEC_INSERT]] to <8 x i8>
-// CHECK-NEXT:    [[TMP5:%.*]] = bitcast <2 x i64> [[TMP2]] to <16 x i8>
-// CHECK-NEXT:    [[TMP6:%.*]] = bitcast <8 x i8> [[TMP3]] to double
-// CHECK-NEXT:    [[TMP7:%.*]] = bitcast <8 x i8> [[TMP4]] to double
-// CHECK-NEXT:    [[TMP8:%.*]] = bitcast <16 x i8> [[TMP5]] to <2 x double>
-// CHECK-NEXT:    [[EXTRACT:%.*]] = extractelement <2 x double> [[TMP8]], i32 0
-// CHECK-NEXT:    [[TMP9:%.*]] = call double @llvm.fma.f64(double [[TMP7]], double [[EXTRACT]], double [[TMP6]])
-// CHECK-NEXT:    [[TMP10:%.*]] = bitcast double [[TMP9]] to <1 x double>
-// CHECK-NEXT:    ret <1 x double> [[TMP10]]
-//
-float64x1_t test_vfma_laneq_f64(float64x1_t a, float64x1_t b, float64x2_t v) {
-  return vfma_laneq_f64(a, b, v, 0);
-}
-
 // CHECK-LABEL: define dso_local <1 x double> @test_vfms_laneq_f64(
 // CHECK-SAME: <1 x double> noundef [[A:%.*]], <1 x double> noundef [[B:%.*]], <2 x double> noundef [[V:%.*]]) #[[ATTR0]] {
 // CHECK-NEXT:  [[ENTRY:.*:]]

--- a/clang/test/CodeGen/AArch64/neon/vfma-lane.c
+++ b/clang/test/CodeGen/AArch64/neon/vfma-lane.c
@@ -1,0 +1,126 @@
+// REQUIRES: aarch64-registered-target
+
+// RUN:                   %clang_cc1 -triple arm64-none-linux-gnu -target-feature +neon -target-feature +fullfp16 -disable-O0-optnone -flax-vector-conversions=none           -emit-llvm -o - %s | opt -S -passes=mem2reg,sroa | FileCheck %s --check-prefixes=LLVM
+// RUN: %if cir-enabled %{%clang_cc1 -triple arm64-none-linux-gnu -target-feature +neon -target-feature +fullfp16 -disable-O0-optnone -flax-vector-conversions=none -fclangir -emit-llvm -o - %s | opt -S -passes=mem2reg,sroa | FileCheck %s --check-prefixes=LLVM %}
+// RUN: %if cir-enabled %{%clang_cc1 -triple arm64-none-linux-gnu -target-feature +neon -target-feature +fullfp16 -disable-O0-optnone -flax-vector-conversions=none -fclangir -emit-cir  -o - %s |                               FileCheck %s --check-prefixes=CIR %}
+
+#include <arm_neon.h>
+
+// LLVM-LABEL: @test_vfma_lane_f16(
+// LLVM: shufflevector <4 x half>
+// LLVM: call <4 x half> @llvm.fma.v4f16(
+// CIR-LABEL: @test_vfma_lane_f16(
+// CIR: cir.vec.shuffle
+// CIR: cir.call_llvm_intrinsic "fma"
+float16x4_t test_vfma_lane_f16(float16x4_t a, float16x4_t b, float16x4_t c) {
+  return vfma_lane_f16(a, b, c, 3);
+}
+
+// LLVM-LABEL: @test_vfmaq_lane_f16(
+// LLVM: shufflevector <4 x half>
+// LLVM: call <8 x half> @llvm.fma.v8f16(
+// CIR-LABEL: @test_vfmaq_lane_f16(
+// CIR: cir.vec.shuffle
+// CIR: cir.call_llvm_intrinsic "fma"
+float16x8_t test_vfmaq_lane_f16(float16x8_t a, float16x8_t b, float16x4_t c) {
+  return vfmaq_lane_f16(a, b, c, 3);
+}
+
+// LLVM-LABEL: @test_vfma_laneq_f16(
+// LLVM: shufflevector <8 x half>
+// LLVM: call <4 x half> @llvm.fma.v4f16(
+// CIR-LABEL: @test_vfma_laneq_f16(
+// CIR: cir.vec.shuffle
+// CIR: cir.call_llvm_intrinsic "fma"
+float16x4_t test_vfma_laneq_f16(float16x4_t a, float16x4_t b, float16x8_t c) {
+  return vfma_laneq_f16(a, b, c, 7);
+}
+
+// LLVM-LABEL: @test_vfmaq_laneq_f16(
+// LLVM: shufflevector <8 x half>
+// LLVM: call <8 x half> @llvm.fma.v8f16(
+// CIR-LABEL: @test_vfmaq_laneq_f16(
+// CIR: cir.vec.shuffle
+// CIR: cir.call_llvm_intrinsic "fma"
+float16x8_t test_vfmaq_laneq_f16(float16x8_t a, float16x8_t b, float16x8_t c) {
+  return vfmaq_laneq_f16(a, b, c, 7);
+}
+
+// LLVM-LABEL: @test_vfma_lane_f32(
+// LLVM: shufflevector <2 x float>
+// LLVM: call <2 x float> @llvm.fma.v2f32(
+// CIR-LABEL: @test_vfma_lane_f32(
+// CIR: cir.vec.shuffle
+// CIR: cir.call_llvm_intrinsic "fma"
+float32x2_t test_vfma_lane_f32(float32x2_t a, float32x2_t b, float32x2_t v) {
+  return vfma_lane_f32(a, b, v, 1);
+}
+
+// LLVM-LABEL: @test_vfmaq_lane_f32(
+// LLVM: shufflevector <2 x float>
+// LLVM: call <4 x float> @llvm.fma.v4f32(
+// CIR-LABEL: @test_vfmaq_lane_f32(
+// CIR: cir.vec.shuffle
+// CIR: cir.call_llvm_intrinsic "fma"
+float32x4_t test_vfmaq_lane_f32(float32x4_t a, float32x4_t b, float32x2_t v) {
+  return vfmaq_lane_f32(a, b, v, 1);
+}
+
+// LLVM-LABEL: @test_vfma_laneq_f32(
+// LLVM: shufflevector <4 x float>
+// LLVM: call <2 x float> @llvm.fma.v2f32(
+// CIR-LABEL: @test_vfma_laneq_f32(
+// CIR: cir.vec.shuffle
+// CIR: cir.call_llvm_intrinsic "fma"
+float32x2_t test_vfma_laneq_f32(float32x2_t a, float32x2_t b, float32x4_t v) {
+  return vfma_laneq_f32(a, b, v, 3);
+}
+
+// LLVM-LABEL: @test_vfmaq_laneq_f32(
+// LLVM: shufflevector <4 x float>
+// LLVM: call <4 x float> @llvm.fma.v4f32(
+// CIR-LABEL: @test_vfmaq_laneq_f32(
+// CIR: cir.vec.shuffle
+// CIR: cir.call_llvm_intrinsic "fma"
+float32x4_t test_vfmaq_laneq_f32(float32x4_t a, float32x4_t b, float32x4_t v) {
+  return vfmaq_laneq_f32(a, b, v, 3);
+}
+
+// LLVM-LABEL: @test_vfma_lane_f64(
+// LLVM: shufflevector <1 x double>
+// LLVM: call <1 x double> @llvm.fma.v1f64(
+// CIR-LABEL: @test_vfma_lane_f64(
+// CIR: cir.vec.shuffle
+// CIR: cir.call_llvm_intrinsic "fma"
+float64x1_t test_vfma_lane_f64(float64x1_t a, float64x1_t b, float64x1_t v) {
+  return vfma_lane_f64(a, b, v, 0);
+}
+
+// LLVM-LABEL: @test_vfmaq_lane_f64(
+// LLVM: shufflevector <1 x double>
+// LLVM: call <2 x double> @llvm.fma.v2f64(
+// CIR-LABEL: @test_vfmaq_lane_f64(
+// CIR: cir.vec.shuffle
+// CIR: cir.call_llvm_intrinsic "fma"
+float64x2_t test_vfmaq_lane_f64(float64x2_t a, float64x2_t b, float64x1_t v) {
+  return vfmaq_lane_f64(a, b, v, 0);
+}
+
+// LLVM-LABEL: @test_vfma_laneq_f64(
+// LLVM: @llvm.fma
+// CIR-LABEL: @test_vfma_laneq_f64(
+// CIR: cir.vec.shuffle
+// CIR: cir.call_llvm_intrinsic "fma"
+float64x1_t test_vfma_laneq_f64(float64x1_t a, float64x1_t b, float64x2_t v) {
+  return vfma_laneq_f64(a, b, v, 0);
+}
+
+// LLVM-LABEL: @test_vfmaq_laneq_f64(
+// LLVM: shufflevector <2 x double>
+// LLVM: call <2 x double> @llvm.fma.v2f64(
+// CIR-LABEL: @test_vfmaq_laneq_f64(
+// CIR: cir.vec.shuffle
+// CIR: cir.call_llvm_intrinsic "fma"
+float64x2_t test_vfmaq_laneq_f64(float64x2_t a, float64x2_t b, float64x2_t v) {
+  return vfmaq_laneq_f64(a, b, v, 1);
+}

--- a/clang/test/CodeGen/AArch64/neon/vfma-lane.c
+++ b/clang/test/CodeGen/AArch64/neon/vfma-lane.c
@@ -1,214 +1,332 @@
 // REQUIRES: aarch64-registered-target
 
-// RUN:                   %clang_cc1 -triple arm64-none-linux-gnu -target-feature +neon -target-feature +fullfp16 -disable-O0-optnone -flax-vector-conversions=none           -emit-llvm -o - %s | opt -S -passes=mem2reg,sroa | FileCheck %s --check-prefixes=LLVM,PLAINLLVM
-// RUN: %if cir-enabled %{%clang_cc1 -triple arm64-none-linux-gnu -target-feature +neon -target-feature +fullfp16 -disable-O0-optnone -flax-vector-conversions=none -fclangir -emit-llvm -o - %s | opt -S -passes=mem2reg,sroa | FileCheck %s --check-prefixes=LLVM,CIRLLVM %}
-// RUN: %if cir-enabled %{%clang_cc1 -triple arm64-none-linux-gnu -target-feature +neon -target-feature +fullfp16 -disable-O0-optnone -flax-vector-conversions=none -fclangir -emit-cir  -o - %s |                               FileCheck %s --check-prefixes=CIR %}
+// RUN: %clang_cc1 -triple arm64-none-linux-gnu -target-feature +neon -target-feature +fullfp16 -disable-O0-optnone -flax-vector-conversions=none -emit-llvm -o - %s | opt -S -passes=mem2reg,sroa | FileCheck %s --check-prefixes=LLVM
+// RUN: %if cir-enabled %{%clang_cc1 -triple arm64-none-linux-gnu -target-feature +neon -target-feature +fullfp16 -disable-O0-optnone -flax-vector-conversions=none -fclangir -emit-llvm -o - %s | opt -S -passes=mem2reg,sroa | FileCheck %s --check-prefixes=CIRLLVM %}
+// RUN: %if cir-enabled %{%clang_cc1 -triple arm64-none-linux-gnu -target-feature +neon -target-feature +fullfp16 -disable-O0-optnone -flax-vector-conversions=none -fclangir -emit-cir -o - %s | FileCheck %s --check-prefixes=CIR %}
 
 #include <arm_neon.h>
 
 // LLVM-LABEL: define {{[^@]+}}@test_vfma_lane_f16
-// LLVM-SAME: (<4 x half> noundef [[A:%.*]], <4 x half> noundef [[B:%.*]], <4 x half> noundef [[C:%.*]]) #[[ATTR0:[0-9]+]] {
 // CIR-LABEL: @test_vfma_lane_f16(
 float16x4_t test_vfma_lane_f16(float16x4_t a, float16x4_t b, float16x4_t c) {
-  // CIR: cir.vec.shuffle
-  // CIR: cir.call_llvm_intrinsic "fma"
+// CIR: cir.vec.shuffle
+// CIR: cir.call_llvm_intrinsic "fma"
 
-  // LLVM: [[TMP0:%.*]] = bitcast <4 x half> [[A]] to <4 x i16>
-  // LLVM: [[TMP1:%.*]] = bitcast <4 x half> [[B]] to <4 x i16>
-  // LLVM: [[TMP2:%.*]] = bitcast <4 x half> [[C]] to <4 x i16>
-  // LLVM: [[TMP5:%.*]] = bitcast <4 x i16> [[TMP2]] to <8 x i8>
-  // LLVM: [[TMP6:%.*]] = bitcast <8 x i8> [[TMP5]] to <4 x half>
-  // LLVM: shufflevector <4 x half> [[TMP6]], <4 x half> {{[^,]+}}, <4 x i32> <i32 3, i32 3, i32 3, i32 3>
-  // LLVM: call <4 x half> @llvm.fma.v4f16(
+// CIRLLVM:      shufflevector <4 x half> {{.*}} <i32 3, i32 3, i32 3, i32 3>
+// CIRLLVM-NEXT: {{.*}}call <4 x half> @llvm.fma.v4f16({{.*}}
+
+// LLVM-SAME: (<4 x half> {{.*}} [[A:%.*]], <4 x half> {{.*}} [[B:%.*]], <4 x half> {{.*}} [[C:%.*]]) {{.*}} {
+// LLVM-NEXT:  entry:
+// LLVM-NEXT:    [[TMP0:%.*]] = bitcast <4 x half> [[A]] to <4 x i16>
+// LLVM-NEXT:    [[TMP1:%.*]] = bitcast <4 x half> [[B]] to <4 x i16>
+// LLVM-NEXT:    [[TMP2:%.*]] = bitcast <4 x half> [[C]] to <4 x i16>
+// LLVM-NEXT:    [[TMP3:%.*]] = bitcast <4 x i16> [[TMP0]] to <8 x i8>
+// LLVM-NEXT:    [[TMP4:%.*]] = bitcast <4 x i16> [[TMP1]] to <8 x i8>
+// LLVM-NEXT:    [[TMP5:%.*]] = bitcast <4 x i16> [[TMP2]] to <8 x i8>
+// LLVM-NEXT:    [[TMP6:%.*]] = bitcast <8 x i8> [[TMP5]] to <4 x half>
+// LLVM-NEXT:    [[LANE:%.*]] = shufflevector <4 x half> [[TMP6]], <4 x half> [[TMP6]], <4 x i32> <i32 3, i32 3, i32 3, i32 3>
+// LLVM-NEXT:    [[FMLA:%.*]] = bitcast <8 x i8> [[TMP4]] to <4 x half>
+// LLVM-NEXT:    [[FMLA1:%.*]] = bitcast <8 x i8> [[TMP3]] to <4 x half>
+// LLVM-NEXT:    [[FMLA2:%.*]] = call <4 x half> @llvm.fma.v4f16(<4 x half> [[FMLA]], <4 x half> [[LANE]], <4 x half> [[FMLA1]])
+// LLVM-NEXT:    ret <4 x half> [[FMLA2]]
   return vfma_lane_f16(a, b, c, 3);
 }
 
 // LLVM-LABEL: define {{[^@]+}}@test_vfmaq_lane_f16
-// LLVM-SAME: (<8 x half> noundef [[A:%.*]], <8 x half> noundef [[B:%.*]], <4 x half> noundef [[C:%.*]]) #[[ATTR0]] {
 // CIR-LABEL: @test_vfmaq_lane_f16(
 float16x8_t test_vfmaq_lane_f16(float16x8_t a, float16x8_t b, float16x4_t c) {
-  // CIR: cir.vec.shuffle
-  // CIR: cir.call_llvm_intrinsic "fma"
+// CIR: cir.vec.shuffle
+// CIR: cir.call_llvm_intrinsic "fma"
 
-  // LLVM: [[TMP0:%.*]] = bitcast <8 x half> [[A]] to <8 x i16>
-  // LLVM: [[TMP1:%.*]] = bitcast <8 x half> [[B]] to <8 x i16>
-  // LLVM: [[TMP2:%.*]] = bitcast <4 x half> [[C]] to <4 x i16>
-  // LLVM: [[TMP5:%.*]] = bitcast <4 x i16> [[TMP2]] to <8 x i8>
-  // LLVM: [[TMP6:%.*]] = bitcast <8 x i8> [[TMP5]] to <4 x half>
-  // LLVM: shufflevector <4 x half> [[TMP6]], <4 x half> {{[^,]+}}, <8 x i32> <i32 3, i32 3, i32 3, i32 3, i32 3, i32 3, i32 3, i32 3>
-  // LLVM: call <8 x half> @llvm.fma.v8f16(
+// CIRLLVM:      shufflevector <4 x half> {{.*}} <i32 3, i32 3, i32 3, i32 3, i32 3, i32 3, i32 3, i32 3>
+// CIRLLVM-NEXT: {{.*}}call <8 x half> @llvm.fma.v8f16({{.*}}
+
+// LLVM-SAME: (<8 x half> {{.*}} [[A:%.*]], <8 x half> {{.*}} [[B:%.*]], <4 x half> {{.*}} [[C:%.*]]) {{.*}} {
+// LLVM-NEXT:  entry:
+// LLVM-NEXT:    [[TMP0:%.*]] = bitcast <8 x half> [[A]] to <8 x i16>
+// LLVM-NEXT:    [[TMP1:%.*]] = bitcast <8 x half> [[B]] to <8 x i16>
+// LLVM-NEXT:    [[TMP2:%.*]] = bitcast <4 x half> [[C]] to <4 x i16>
+// LLVM-NEXT:    [[TMP3:%.*]] = bitcast <8 x i16> [[TMP0]] to <16 x i8>
+// LLVM-NEXT:    [[TMP4:%.*]] = bitcast <8 x i16> [[TMP1]] to <16 x i8>
+// LLVM-NEXT:    [[TMP5:%.*]] = bitcast <4 x i16> [[TMP2]] to <8 x i8>
+// LLVM-NEXT:    [[TMP6:%.*]] = bitcast <8 x i8> [[TMP5]] to <4 x half>
+// LLVM-NEXT:    [[LANE:%.*]] = shufflevector <4 x half> [[TMP6]], <4 x half> [[TMP6]], <8 x i32> <i32 3, i32 3, i32 3, i32 3, i32 3, i32 3, i32 3, i32 3>
+// LLVM-NEXT:    [[FMLA:%.*]] = bitcast <16 x i8> [[TMP4]] to <8 x half>
+// LLVM-NEXT:    [[FMLA1:%.*]] = bitcast <16 x i8> [[TMP3]] to <8 x half>
+// LLVM-NEXT:    [[FMLA2:%.*]] = call <8 x half> @llvm.fma.v8f16(<8 x half> [[FMLA]], <8 x half> [[LANE]], <8 x half> [[FMLA1]])
+// LLVM-NEXT:    ret <8 x half> [[FMLA2]]
   return vfmaq_lane_f16(a, b, c, 3);
 }
 
 // LLVM-LABEL: define {{[^@]+}}@test_vfma_laneq_f16
-// LLVM-SAME: (<4 x half> noundef [[A:%.*]], <4 x half> noundef [[B:%.*]], <8 x half> noundef [[C:%.*]]) #[[ATTR0]] {
 // CIR-LABEL: @test_vfma_laneq_f16(
 float16x4_t test_vfma_laneq_f16(float16x4_t a, float16x4_t b, float16x8_t c) {
-  // CIR: cir.vec.shuffle
-  // CIR: cir.call_llvm_intrinsic "fma"
+// CIR: cir.vec.shuffle
+// CIR: cir.call_llvm_intrinsic "fma"
 
-  // LLVM: [[TMP0:%.*]] = bitcast <4 x half> [[A]] to <4 x i16>
-  // LLVM: [[TMP1:%.*]] = bitcast <4 x half> [[B]] to <4 x i16>
-  // LLVM: [[TMP2:%.*]] = bitcast <8 x half> [[C]] to <8 x i16>
-  // LLVM: [[TMP5:%.*]] = bitcast <8 x i16> [[TMP2]] to <16 x i8>
-  // LLVM: [[TMP8:%.*]] = bitcast <16 x i8> [[TMP5]] to <8 x half>
-  // LLVM: shufflevector <8 x half> [[TMP8]], <8 x half> {{[^,]+}}, <4 x i32> <i32 7, i32 7, i32 7, i32 7>
-  // LLVM: call <4 x half> @llvm.fma.v4f16(
+// CIRLLVM:      shufflevector <8 x half> {{.*}} <i32 7, i32 7, i32 7, i32 7>
+// CIRLLVM-NEXT: {{.*}}call <4 x half> @llvm.fma.v4f16({{.*}}
+
+// LLVM-SAME: (<4 x half> {{.*}} [[A:%.*]], <4 x half> {{.*}} [[B:%.*]], <8 x half> {{.*}} [[C:%.*]]) {{.*}} {
+// LLVM-NEXT:  entry:
+// LLVM-NEXT:    [[TMP0:%.*]] = bitcast <4 x half> [[A]] to <4 x i16>
+// LLVM-NEXT:    [[TMP1:%.*]] = bitcast <4 x half> [[B]] to <4 x i16>
+// LLVM-NEXT:    [[TMP2:%.*]] = bitcast <8 x half> [[C]] to <8 x i16>
+// LLVM-NEXT:    [[TMP3:%.*]] = bitcast <4 x i16> [[TMP0]] to <8 x i8>
+// LLVM-NEXT:    [[TMP4:%.*]] = bitcast <4 x i16> [[TMP1]] to <8 x i8>
+// LLVM-NEXT:    [[TMP5:%.*]] = bitcast <8 x i16> [[TMP2]] to <16 x i8>
+// LLVM-NEXT:    [[TMP6:%.*]] = bitcast <8 x i8> [[TMP3]] to <4 x half>
+// LLVM-NEXT:    [[TMP7:%.*]] = bitcast <8 x i8> [[TMP4]] to <4 x half>
+// LLVM-NEXT:    [[TMP8:%.*]] = bitcast <16 x i8> [[TMP5]] to <8 x half>
+// LLVM-NEXT:    [[LANE:%.*]] = shufflevector <8 x half> [[TMP8]], <8 x half> [[TMP8]], <4 x i32> <i32 7, i32 7, i32 7, i32 7>
+// LLVM-NEXT:    [[TMP9:%.*]] = call <4 x half> @llvm.fma.v4f16(<4 x half> [[LANE]], <4 x half> [[TMP7]], <4 x half> [[TMP6]])
+// LLVM-NEXT:    ret <4 x half> [[TMP9]]
   return vfma_laneq_f16(a, b, c, 7);
 }
 
 // LLVM-LABEL: define {{[^@]+}}@test_vfmaq_laneq_f16
-// LLVM-SAME: (<8 x half> noundef [[A:%.*]], <8 x half> noundef [[B:%.*]], <8 x half> noundef [[C:%.*]]) #[[ATTR0]] {
 // CIR-LABEL: @test_vfmaq_laneq_f16(
 float16x8_t test_vfmaq_laneq_f16(float16x8_t a, float16x8_t b, float16x8_t c) {
-  // CIR: cir.vec.shuffle
-  // CIR: cir.call_llvm_intrinsic "fma"
+// CIR: cir.vec.shuffle
+// CIR: cir.call_llvm_intrinsic "fma"
 
-  // LLVM: [[TMP0:%.*]] = bitcast <8 x half> [[A]] to <8 x i16>
-  // LLVM: [[TMP1:%.*]] = bitcast <8 x half> [[B]] to <8 x i16>
-  // LLVM: [[TMP2:%.*]] = bitcast <8 x half> [[C]] to <8 x i16>
-  // LLVM: [[TMP5:%.*]] = bitcast <8 x i16> [[TMP2]] to <16 x i8>
-  // LLVM: [[TMP8:%.*]] = bitcast <16 x i8> [[TMP5]] to <8 x half>
-  // LLVM: shufflevector <8 x half> [[TMP8]], <8 x half> {{[^,]+}}, <8 x i32> <i32 7, i32 7, i32 7, i32 7, i32 7, i32 7, i32 7, i32 7>
-  // LLVM: call <8 x half> @llvm.fma.v8f16(
+// CIRLLVM:      shufflevector <8 x half> {{.*}} <i32 7, i32 7, i32 7, i32 7, i32 7, i32 7, i32 7, i32 7>
+// CIRLLVM-NEXT: {{.*}}call <8 x half> @llvm.fma.v8f16({{.*}}
+
+// LLVM-SAME: (<8 x half> {{.*}} [[A:%.*]], <8 x half> {{.*}} [[B:%.*]], <8 x half> {{.*}} [[C:%.*]]) {{.*}} {
+// LLVM-NEXT:  entry:
+// LLVM-NEXT:    [[TMP0:%.*]] = bitcast <8 x half> [[A]] to <8 x i16>
+// LLVM-NEXT:    [[TMP1:%.*]] = bitcast <8 x half> [[B]] to <8 x i16>
+// LLVM-NEXT:    [[TMP2:%.*]] = bitcast <8 x half> [[C]] to <8 x i16>
+// LLVM-NEXT:    [[TMP3:%.*]] = bitcast <8 x i16> [[TMP0]] to <16 x i8>
+// LLVM-NEXT:    [[TMP4:%.*]] = bitcast <8 x i16> [[TMP1]] to <16 x i8>
+// LLVM-NEXT:    [[TMP5:%.*]] = bitcast <8 x i16> [[TMP2]] to <16 x i8>
+// LLVM-NEXT:    [[TMP6:%.*]] = bitcast <16 x i8> [[TMP3]] to <8 x half>
+// LLVM-NEXT:    [[TMP7:%.*]] = bitcast <16 x i8> [[TMP4]] to <8 x half>
+// LLVM-NEXT:    [[TMP8:%.*]] = bitcast <16 x i8> [[TMP5]] to <8 x half>
+// LLVM-NEXT:    [[LANE:%.*]] = shufflevector <8 x half> [[TMP8]], <8 x half> [[TMP8]], <8 x i32> <i32 7, i32 7, i32 7, i32 7, i32 7, i32 7, i32 7, i32 7>
+// LLVM-NEXT:    [[TMP9:%.*]] = call <8 x half> @llvm.fma.v8f16(<8 x half> [[LANE]], <8 x half> [[TMP7]], <8 x half> [[TMP6]])
+// LLVM-NEXT:    ret <8 x half> [[TMP9]]
   return vfmaq_laneq_f16(a, b, c, 7);
 }
 
-// LLVM-LABEL: define {{[^@]+}}@test_vfma_lane_f32(
-// LLVM-SAME: <2 x float> noundef [[A:%.*]], <2 x float> noundef [[B:%.*]], <2 x float> noundef [[V:%.*]]) #[[ATTR0]] {
+// LLVM-LABEL: @test_vfma_lane_f32(
+// CIRLLVM-LABEL: @test_vfma_lane_f32(
 // CIR-LABEL: @test_vfma_lane_f32(
 float32x2_t test_vfma_lane_f32(float32x2_t a, float32x2_t b, float32x2_t v) {
-  // CIR: cir.vec.shuffle
-  // CIR: cir.call_llvm_intrinsic "fma"
+// CIR: cir.vec.shuffle
+// CIR: cir.call_llvm_intrinsic "fma"
 
-  // LLVM: [[TMP0:%.*]] = bitcast <2 x float> [[A]] to <2 x i32>
-  // LLVM: [[TMP1:%.*]] = bitcast <2 x float> [[B]] to <2 x i32>
-  // LLVM: [[TMP2:%.*]] = bitcast <2 x float> [[V]] to <2 x i32>
-  // LLVM: [[TMP5:%.*]] = bitcast <2 x i32> [[TMP2]] to <8 x i8>
-  // LLVM: [[TMP6:%.*]] = bitcast <8 x i8> [[TMP5]] to <2 x float>
-  // LLVM: shufflevector <2 x float> [[TMP6]], <2 x float> {{[^,]+}}, <2 x i32> <i32 1, i32 1>
-  // LLVM: call <2 x float> @llvm.fma.v2f32(
+// CIRLLVM:      shufflevector <2 x float> {{.*}} <i32 1, i32 1>
+// CIRLLVM-NEXT: {{.*}}call <2 x float> @llvm.fma.v2f32({{.*}}
+
+// LLVM-SAME: <2 x float> {{.*}} [[A:%.*]], <2 x float> {{.*}} [[B:%.*]], <2 x float> {{.*}} [[V:%.*]]) {{.*}} {
+// LLVM-NEXT:  entry:
+// LLVM-NEXT:    [[TMP0:%.*]] = bitcast <2 x float> [[A]] to <2 x i32>
+// LLVM-NEXT:    [[TMP1:%.*]] = bitcast <2 x float> [[B]] to <2 x i32>
+// LLVM-NEXT:    [[TMP2:%.*]] = bitcast <2 x float> [[V]] to <2 x i32>
+// LLVM-NEXT:    [[TMP3:%.*]] = bitcast <2 x i32> [[TMP0]] to <8 x i8>
+// LLVM-NEXT:    [[TMP4:%.*]] = bitcast <2 x i32> [[TMP1]] to <8 x i8>
+// LLVM-NEXT:    [[TMP5:%.*]] = bitcast <2 x i32> [[TMP2]] to <8 x i8>
+// LLVM-NEXT:    [[TMP6:%.*]] = bitcast <8 x i8> [[TMP5]] to <2 x float>
+// LLVM-NEXT:    [[LANE:%.*]] = shufflevector <2 x float> [[TMP6]], <2 x float> [[TMP6]], <2 x i32> <i32 1, i32 1>
+// LLVM-NEXT:    [[FMLA:%.*]] = bitcast <8 x i8> [[TMP4]] to <2 x float>
+// LLVM-NEXT:    [[FMLA1:%.*]] = bitcast <8 x i8> [[TMP3]] to <2 x float>
+// LLVM-NEXT:    [[FMLA2:%.*]] = call <2 x float> @llvm.fma.v2f32(<2 x float> [[FMLA]], <2 x float> [[LANE]], <2 x float> [[FMLA1]])
+// LLVM-NEXT:    ret <2 x float> [[FMLA2]]
   return vfma_lane_f32(a, b, v, 1);
 }
 
-// LLVM-LABEL: define {{[^@]+}}@test_vfmaq_lane_f32(
-// LLVM-SAME: <4 x float> noundef [[A:%.*]], <4 x float> noundef [[B:%.*]], <2 x float> noundef [[V:%.*]]) #[[ATTR0]] {
+// LLVM-LABEL: @test_vfmaq_lane_f32(
+// CIRLLVM-LABEL: @test_vfmaq_lane_f32(
 // CIR-LABEL: @test_vfmaq_lane_f32(
 float32x4_t test_vfmaq_lane_f32(float32x4_t a, float32x4_t b, float32x2_t v) {
-  // CIR: cir.vec.shuffle
-  // CIR: cir.call_llvm_intrinsic "fma"
+// CIR: cir.vec.shuffle
+// CIR: cir.call_llvm_intrinsic "fma"
 
-  // LLVM: [[TMP0:%.*]] = bitcast <4 x float> [[A]] to <4 x i32>
-  // LLVM: [[TMP1:%.*]] = bitcast <4 x float> [[B]] to <4 x i32>
-  // LLVM: [[TMP2:%.*]] = bitcast <2 x float> [[V]] to <2 x i32>
-  // LLVM: [[TMP5:%.*]] = bitcast <2 x i32> [[TMP2]] to <8 x i8>
-  // LLVM: [[TMP6:%.*]] = bitcast <8 x i8> [[TMP5]] to <2 x float>
-  // LLVM: shufflevector <2 x float> [[TMP6]], <2 x float> {{[^,]+}}, <4 x i32> <i32 1, i32 1, i32 1, i32 1>
-  // LLVM: call <4 x float> @llvm.fma.v4f32(
+// CIRLLVM:      shufflevector <2 x float> {{.*}} <i32 1, i32 1, i32 1, i32 1>
+// CIRLLVM-NEXT: {{.*}}call <4 x float> @llvm.fma.v4f32({{.*}}
+
+// LLVM-SAME: <4 x float> {{.*}} [[A:%.*]], <4 x float> {{.*}} [[B:%.*]], <2 x float> {{.*}} [[V:%.*]]) {{.*}} {
+// LLVM-NEXT:  entry:
+// LLVM-NEXT:    [[TMP0:%.*]] = bitcast <4 x float> [[A]] to <4 x i32>
+// LLVM-NEXT:    [[TMP1:%.*]] = bitcast <4 x float> [[B]] to <4 x i32>
+// LLVM-NEXT:    [[TMP2:%.*]] = bitcast <2 x float> [[V]] to <2 x i32>
+// LLVM-NEXT:    [[TMP3:%.*]] = bitcast <4 x i32> [[TMP0]] to <16 x i8>
+// LLVM-NEXT:    [[TMP4:%.*]] = bitcast <4 x i32> [[TMP1]] to <16 x i8>
+// LLVM-NEXT:    [[TMP5:%.*]] = bitcast <2 x i32> [[TMP2]] to <8 x i8>
+// LLVM-NEXT:    [[TMP6:%.*]] = bitcast <8 x i8> [[TMP5]] to <2 x float>
+// LLVM-NEXT:    [[LANE:%.*]] = shufflevector <2 x float> [[TMP6]], <2 x float> [[TMP6]], <4 x i32> <i32 1, i32 1, i32 1, i32 1>
+// LLVM-NEXT:    [[FMLA:%.*]] = bitcast <16 x i8> [[TMP4]] to <4 x float>
+// LLVM-NEXT:    [[FMLA1:%.*]] = bitcast <16 x i8> [[TMP3]] to <4 x float>
+// LLVM-NEXT:    [[FMLA2:%.*]] = call <4 x float> @llvm.fma.v4f32(<4 x float> [[FMLA]], <4 x float> [[LANE]], <4 x float> [[FMLA1]])
+// LLVM-NEXT:    ret <4 x float> [[FMLA2]]
   return vfmaq_lane_f32(a, b, v, 1);
 }
 
-// LLVM-LABEL: define {{[^@]+}}@test_vfma_laneq_f32(
-// LLVM-SAME: <2 x float> noundef [[A:%.*]], <2 x float> noundef [[B:%.*]], <4 x float> noundef [[V:%.*]]) #[[ATTR0]] {
+// LLVM-LABEL: @test_vfma_laneq_f32(
+// CIRLLVM-LABEL: @test_vfma_laneq_f32(
 // CIR-LABEL: @test_vfma_laneq_f32(
 float32x2_t test_vfma_laneq_f32(float32x2_t a, float32x2_t b, float32x4_t v) {
-  // CIR: cir.vec.shuffle
-  // CIR: cir.call_llvm_intrinsic "fma"
+// CIR: cir.vec.shuffle
+// CIR: cir.call_llvm_intrinsic "fma"
 
-  // LLVM: [[TMP0:%.*]] = bitcast <2 x float> [[A]] to <2 x i32>
-  // LLVM: [[TMP1:%.*]] = bitcast <2 x float> [[B]] to <2 x i32>
-  // LLVM: [[TMP2:%.*]] = bitcast <4 x float> [[V]] to <4 x i32>
-  // LLVM: [[TMP5:%.*]] = bitcast <4 x i32> [[TMP2]] to <16 x i8>
-  // LLVM: [[TMP8:%.*]] = bitcast <16 x i8> [[TMP5]] to <4 x float>
-  // LLVM: shufflevector <4 x float> [[TMP8]], <4 x float> {{[^,]+}}, <2 x i32> <i32 3, i32 3>
-  // LLVM: call <2 x float> @llvm.fma.v2f32(
+// CIRLLVM:      shufflevector <4 x float> {{.*}} <i32 3, i32 3>
+// CIRLLVM-NEXT: {{.*}}call <2 x float> @llvm.fma.v2f32({{.*}}
+
+// LLVM-SAME: <2 x float> {{.*}} [[A:%.*]], <2 x float> {{.*}} [[B:%.*]], <4 x float> {{.*}} [[V:%.*]]) {{.*}} {
+// LLVM-NEXT:  entry:
+// LLVM-NEXT:    [[TMP0:%.*]] = bitcast <2 x float> [[A]] to <2 x i32>
+// LLVM-NEXT:    [[TMP1:%.*]] = bitcast <2 x float> [[B]] to <2 x i32>
+// LLVM-NEXT:    [[TMP2:%.*]] = bitcast <4 x float> [[V]] to <4 x i32>
+// LLVM-NEXT:    [[TMP3:%.*]] = bitcast <2 x i32> [[TMP0]] to <8 x i8>
+// LLVM-NEXT:    [[TMP4:%.*]] = bitcast <2 x i32> [[TMP1]] to <8 x i8>
+// LLVM-NEXT:    [[TMP5:%.*]] = bitcast <4 x i32> [[TMP2]] to <16 x i8>
+// LLVM-NEXT:    [[TMP6:%.*]] = bitcast <8 x i8> [[TMP3]] to <2 x float>
+// LLVM-NEXT:    [[TMP7:%.*]] = bitcast <8 x i8> [[TMP4]] to <2 x float>
+// LLVM-NEXT:    [[TMP8:%.*]] = bitcast <16 x i8> [[TMP5]] to <4 x float>
+// LLVM-NEXT:    [[LANE:%.*]] = shufflevector <4 x float> [[TMP8]], <4 x float> [[TMP8]], <2 x i32> <i32 3, i32 3>
+// LLVM-NEXT:    [[TMP9:%.*]] = call <2 x float> @llvm.fma.v2f32(<2 x float> [[LANE]], <2 x float> [[TMP7]], <2 x float> [[TMP6]])
+// LLVM-NEXT:    ret <2 x float> [[TMP9]]
   return vfma_laneq_f32(a, b, v, 3);
 }
 
-// LLVM-LABEL: define {{[^@]+}}@test_vfmaq_laneq_f32(
-// LLVM-SAME: <4 x float> noundef [[A:%.*]], <4 x float> noundef [[B:%.*]], <4 x float> noundef [[V:%.*]]) #[[ATTR0]] {
+// LLVM-LABEL: @test_vfmaq_laneq_f32(
+// CIRLLVM-LABEL: @test_vfmaq_laneq_f32(
 // CIR-LABEL: @test_vfmaq_laneq_f32(
 float32x4_t test_vfmaq_laneq_f32(float32x4_t a, float32x4_t b, float32x4_t v) {
-  // CIR: cir.vec.shuffle
-  // CIR: cir.call_llvm_intrinsic "fma"
+// CIR: cir.vec.shuffle
+// CIR: cir.call_llvm_intrinsic "fma"
 
-  // LLVM: [[TMP0:%.*]] = bitcast <4 x float> [[A]] to <4 x i32>
-  // LLVM: [[TMP1:%.*]] = bitcast <4 x float> [[B]] to <4 x i32>
-  // LLVM: [[TMP2:%.*]] = bitcast <4 x float> [[V]] to <4 x i32>
-  // LLVM: [[TMP5:%.*]] = bitcast <4 x i32> [[TMP2]] to <16 x i8>
-  // LLVM: [[TMP8:%.*]] = bitcast <16 x i8> [[TMP5]] to <4 x float>
-  // LLVM: shufflevector <4 x float> [[TMP8]], <4 x float> {{[^,]+}}, <4 x i32> <i32 3, i32 3, i32 3, i32 3>
-  // LLVM: call <4 x float> @llvm.fma.v4f32(
+// CIRLLVM:      shufflevector <4 x float> {{.*}} <i32 3, i32 3, i32 3, i32 3>
+// CIRLLVM-NEXT: {{.*}}call <4 x float> @llvm.fma.v4f32({{.*}}
+
+// LLVM-SAME: <4 x float> {{.*}} [[A:%.*]], <4 x float> {{.*}} [[B:%.*]], <4 x float> {{.*}} [[V:%.*]]) {{.*}} {
+// LLVM-NEXT:  entry:
+// LLVM-NEXT:    [[TMP0:%.*]] = bitcast <4 x float> [[A]] to <4 x i32>
+// LLVM-NEXT:    [[TMP1:%.*]] = bitcast <4 x float> [[B]] to <4 x i32>
+// LLVM-NEXT:    [[TMP2:%.*]] = bitcast <4 x float> [[V]] to <4 x i32>
+// LLVM-NEXT:    [[TMP3:%.*]] = bitcast <4 x i32> [[TMP0]] to <16 x i8>
+// LLVM-NEXT:    [[TMP4:%.*]] = bitcast <4 x i32> [[TMP1]] to <16 x i8>
+// LLVM-NEXT:    [[TMP5:%.*]] = bitcast <4 x i32> [[TMP2]] to <16 x i8>
+// LLVM-NEXT:    [[TMP6:%.*]] = bitcast <16 x i8> [[TMP3]] to <4 x float>
+// LLVM-NEXT:    [[TMP7:%.*]] = bitcast <16 x i8> [[TMP4]] to <4 x float>
+// LLVM-NEXT:    [[TMP8:%.*]] = bitcast <16 x i8> [[TMP5]] to <4 x float>
+// LLVM-NEXT:    [[LANE:%.*]] = shufflevector <4 x float> [[TMP8]], <4 x float> [[TMP8]], <4 x i32> <i32 3, i32 3, i32 3, i32 3>
+// LLVM-NEXT:    [[TMP9:%.*]] = call <4 x float> @llvm.fma.v4f32(<4 x float> [[LANE]], <4 x float> [[TMP7]], <4 x float> [[TMP6]])
+// LLVM-NEXT:    ret <4 x float> [[TMP9]]
   return vfmaq_laneq_f32(a, b, v, 3);
 }
 
-// LLVM-LABEL: define {{[^@]+}}@test_vfma_lane_f64(
-// LLVM-SAME: <1 x double> noundef [[A:%.*]], <1 x double> noundef [[B:%.*]], <1 x double> noundef [[V:%.*]]) #[[ATTR0]] {
+// LLVM-LABEL: define dso_local <1 x double> @test_vfma_lane_f64(
 // CIR-LABEL: @test_vfma_lane_f64(
 float64x1_t test_vfma_lane_f64(float64x1_t a, float64x1_t b, float64x1_t v) {
-  // CIR: cir.vec.shuffle
-  // CIR: cir.call_llvm_intrinsic "fma"
+// CIR: cir.vec.shuffle
+// CIR: cir.call_llvm_intrinsic "fma"
 
-  // LLVM: [[TMP0:%.*]] = bitcast <1 x double> [[A]] to i64
-  // LLVM: [[TMP1:%.*]] = bitcast <1 x double> [[B]] to i64
-  // LLVM: [[TMP2:%.*]] = bitcast <1 x double> [[V]] to i64
-  // LLVM: [[INS:%.*]] = insertelement <1 x i64> undef, i64 [[TMP2]], i32 0
-  // LLVM: shufflevector <1 x double> {{[^,]+}}, <1 x double> {{[^,]+}}, <1 x i32> zeroinitializer
-  // LLVM: call <1 x double> @llvm.fma.v1f64(
+// CIRLLVM:      shufflevector <1 x double> {{.*}} zeroinitializer
+// CIRLLVM-NEXT: {{.*}}call <1 x double> @llvm.fma.v1f64({{.*}}
+
+// LLVM-SAME: <1 x double> {{.*}} [[A:%.*]], <1 x double> {{.*}} [[B:%.*]], <1 x double> {{.*}} [[V:%.*]]) {{.*}} {
+// LLVM-NEXT:  [[ENTRY:.*:]]
+// LLVM-NEXT:    [[TMP0:%.*]] = bitcast <1 x double> [[A]] to i64
+// LLVM-NEXT:    [[__S0_SROA_0_0_VEC_INSERT:%.*]] = insertelement <1 x i64> undef, i64 [[TMP0]], i32 0
+// LLVM-NEXT:    [[TMP1:%.*]] = bitcast <1 x double> [[B]] to i64
+// LLVM-NEXT:    [[__S1_SROA_0_0_VEC_INSERT:%.*]] = insertelement <1 x i64> undef, i64 [[TMP1]], i32 0
+// LLVM-NEXT:    [[TMP2:%.*]] = bitcast <1 x double> [[V]] to i64
+// LLVM-NEXT:    [[__S2_SROA_0_0_VEC_INSERT:%.*]] = insertelement <1 x i64> undef, i64 [[TMP2]], i32 0
+// LLVM-NEXT:    [[TMP3:%.*]] = bitcast <1 x i64> [[__S0_SROA_0_0_VEC_INSERT]] to <8 x i8>
+// LLVM-NEXT:    [[TMP4:%.*]] = bitcast <1 x i64> [[__S1_SROA_0_0_VEC_INSERT]] to <8 x i8>
+// LLVM-NEXT:    [[TMP5:%.*]] = bitcast <1 x i64> [[__S2_SROA_0_0_VEC_INSERT]] to <8 x i8>
+// LLVM-NEXT:    [[TMP6:%.*]] = bitcast <8 x i8> [[TMP5]] to <1 x double>
+// LLVM-NEXT:    [[LANE:%.*]] = shufflevector <1 x double> [[TMP6]], <1 x double> [[TMP6]], <1 x i32> zeroinitializer
+// LLVM-NEXT:    [[FMLA:%.*]] = bitcast <8 x i8> [[TMP4]] to <1 x double>
+// LLVM-NEXT:    [[FMLA1:%.*]] = bitcast <8 x i8> [[TMP3]] to <1 x double>
+// LLVM-NEXT:    [[FMLA2:%.*]] = call <1 x double> @llvm.fma.v1f64(<1 x double> [[FMLA]], <1 x double> [[LANE]], <1 x double> [[FMLA1]])
+// LLVM-NEXT:    ret <1 x double> [[FMLA2]]
   return vfma_lane_f64(a, b, v, 0);
 }
 
-// LLVM-LABEL: define {{[^@]+}}@test_vfmaq_lane_f64(
-// LLVM-SAME: <2 x double> noundef [[A:%.*]], <2 x double> noundef [[B:%.*]], <1 x double> noundef [[V:%.*]]) #[[ATTR0]] {
+// LLVM-LABEL: @test_vfmaq_lane_f64(
+// CIRLLVM-LABEL: @test_vfmaq_lane_f64(
 // CIR-LABEL: @test_vfmaq_lane_f64(
 float64x2_t test_vfmaq_lane_f64(float64x2_t a, float64x2_t b, float64x1_t v) {
-  // CIR: cir.vec.shuffle
-  // CIR: cir.call_llvm_intrinsic "fma"
+// CIR: cir.vec.shuffle
+// CIR: cir.call_llvm_intrinsic "fma"
 
-  // LLVM: [[TMP0:%.*]] = bitcast <2 x double> [[A]] to <2 x i64>
-  // LLVM: [[TMP1:%.*]] = bitcast <2 x double> [[B]] to <2 x i64>
-  // LLVM: [[TMP2:%.*]] = bitcast <1 x double> [[V]] to i64
-  // LLVM: [[INS:%.*]] = insertelement <1 x i64> undef, i64 [[TMP2]], i32 0
-  // LLVM: shufflevector <1 x double> {{[^,]+}}, <1 x double> {{[^,]+}}, <2 x i32> zeroinitializer
-  // LLVM: call <2 x double> @llvm.fma.v2f64(
+// CIRLLVM:      shufflevector <1 x double> {{.*}} <2 x i32> zeroinitializer
+// CIRLLVM-NEXT: {{.*}}call <2 x double> @llvm.fma.v2f64({{.*}}
+
+// LLVM-SAME: <2 x double> {{.*}} [[A:%.*]], <2 x double> {{.*}} [[B:%.*]], <1 x double> {{.*}} [[V:%.*]]) {{.*}} {
+// LLVM-NEXT:  entry:
+// LLVM-NEXT:    [[TMP0:%.*]] = bitcast <2 x double> [[A]] to <2 x i64>
+// LLVM-NEXT:    [[TMP1:%.*]] = bitcast <2 x double> [[B]] to <2 x i64>
+// LLVM-NEXT:    [[TMP2:%.*]] = bitcast <1 x double> [[V]] to i64
+// LLVM-NEXT:    [[__S2_SROA_0_0_VEC_INSERT:%.*]] = insertelement <1 x i64> undef, i64 [[TMP2]], i32 0
+// LLVM-NEXT:    [[TMP3:%.*]] = bitcast <2 x i64> [[TMP0]] to <16 x i8>
+// LLVM-NEXT:    [[TMP4:%.*]] = bitcast <2 x i64> [[TMP1]] to <16 x i8>
+// LLVM-NEXT:    [[TMP5:%.*]] = bitcast <1 x i64> [[__S2_SROA_0_0_VEC_INSERT]] to <8 x i8>
+// LLVM-NEXT:    [[TMP6:%.*]] = bitcast <8 x i8> [[TMP5]] to <1 x double>
+// LLVM-NEXT:    [[LANE:%.*]] = shufflevector <1 x double> [[TMP6]], <1 x double> [[TMP6]], <2 x i32> zeroinitializer
+// LLVM-NEXT:    [[FMLA:%.*]] = bitcast <16 x i8> [[TMP4]] to <2 x double>
+// LLVM-NEXT:    [[FMLA1:%.*]] = bitcast <16 x i8> [[TMP3]] to <2 x double>
+// LLVM-NEXT:    [[FMLA2:%.*]] = call <2 x double> @llvm.fma.v2f64(<2 x double> [[FMLA]], <2 x double> [[LANE]], <2 x double> [[FMLA1]])
+// LLVM-NEXT:    ret <2 x double> [[FMLA2]]
   return vfmaq_lane_f64(a, b, v, 0);
 }
 
-// PLAINLLVM-LABEL: define {{[^@]+}}@test_vfma_laneq_f64(
-// PLAINLLVM-SAME: <1 x double> noundef [[A:%.*]], <1 x double> noundef [[B:%.*]], <2 x double> noundef [[V:%.*]]) #[[ATTR0]] {
-// CIRLLVM-LABEL: define {{[^@]+}}@test_vfma_laneq_f64(
-// CIRLLVM-SAME: <1 x double> noundef [[A:%.*]], <1 x double> noundef [[B:%.*]], <2 x double> noundef [[V:%.*]]) #[[ATTR0]] {
+// LLVM-LABEL: define dso_local <1 x double> @test_vfma_laneq_f64(
 // CIR-LABEL: @test_vfma_laneq_f64(
 float64x1_t test_vfma_laneq_f64(float64x1_t a, float64x1_t b, float64x2_t v) {
-  // CIR: cir.vec.shuffle
-  // CIR: cir.call_llvm_intrinsic "fma"
+// CIR: cir.vec.extract
+// CIR: cir.call_llvm_intrinsic "fma"
 
-  // PLAINLLVM: [[TMP0:%.*]] = bitcast <1 x double> [[A]] to i64
-  // PLAINLLVM: [[TMP1:%.*]] = bitcast <1 x double> [[B]] to i64
-  // PLAINLLVM: [[TMP2:%.*]] = bitcast <2 x double> [[V]] to <2 x i64>
-  // PLAINLLVM: extractelement <2 x double>{{.*}}, i32 1
-  // PLAINLLVM: call double @llvm.fma.f64(
-  // CIRLLVM: [[TMP0:%.*]] = bitcast <1 x double> [[A]] to i64
-  // CIRLLVM: [[TMP1:%.*]] = bitcast <1 x double> [[B]] to i64
-  // CIRLLVM: [[TMP2:%.*]] = bitcast <2 x double> [[V]] to <2 x i64>
-  // CIRLLVM: shufflevector <2 x double> {{[^,]+}}, <2 x double> {{[^,]+}}, <1 x i32> <i32 1>
-  // CIRLLVM: call <1 x double> @llvm.fma.v1f64(
+// CIRLLVM:      extractelement <2 x double> {{.*}}, i32 1
+// CIRLLVM-NEXT: {{.*}}call double @llvm.fma.f64({{.*}}
+
+// LLVM-SAME: <1 x double> {{.*}} [[A:%.*]], <1 x double> {{.*}} [[B:%.*]], <2 x double> {{.*}} [[V:%.*]]) {{.*}} {
+// LLVM-NEXT:  [[ENTRY:.*:]]
+// LLVM-NEXT:    [[TMP0:%.*]] = bitcast <1 x double> [[A]] to i64
+// LLVM-NEXT:    [[__S0_SROA_0_0_VEC_INSERT:%.*]] = insertelement <1 x i64> undef, i64 [[TMP0]], i32 0
+// LLVM-NEXT:    [[TMP1:%.*]] = bitcast <1 x double> [[B]] to i64
+// LLVM-NEXT:    [[__S1_SROA_0_0_VEC_INSERT:%.*]] = insertelement <1 x i64> undef, i64 [[TMP1]], i32 0
+// LLVM-NEXT:    [[TMP2:%.*]] = bitcast <2 x double> [[V]] to <2 x i64>
+// LLVM-NEXT:    [[TMP3:%.*]] = bitcast <1 x i64> [[__S0_SROA_0_0_VEC_INSERT]] to <8 x i8>
+// LLVM-NEXT:    [[TMP4:%.*]] = bitcast <1 x i64> [[__S1_SROA_0_0_VEC_INSERT]] to <8 x i8>
+// LLVM-NEXT:    [[TMP5:%.*]] = bitcast <2 x i64> [[TMP2]] to <16 x i8>
+// LLVM-NEXT:    [[TMP6:%.*]] = bitcast <8 x i8> [[TMP3]] to double
+// LLVM-NEXT:    [[TMP7:%.*]] = bitcast <8 x i8> [[TMP4]] to double
+// LLVM-NEXT:    [[TMP8:%.*]] = bitcast <16 x i8> [[TMP5]] to <2 x double>
+// LLVM-NEXT:    [[EXTRACT:%.*]] = extractelement <2 x double> [[TMP8]], i32 1
+// LLVM-NEXT:    [[TMP9:%.*]] = call double @llvm.fma.f64(double [[TMP7]], double [[EXTRACT]], double [[TMP6]])
+// LLVM-NEXT:    [[TMP10:%.*]] = bitcast double [[TMP9]] to <1 x double>
+// LLVM-NEXT:    ret <1 x double> [[TMP10]]
   return vfma_laneq_f64(a, b, v, 1);
 }
 
-// LLVM-LABEL: define {{[^@]+}}@test_vfmaq_laneq_f64(
-// LLVM-SAME: <2 x double> noundef [[A:%.*]], <2 x double> noundef [[B:%.*]], <2 x double> noundef [[V:%.*]]) #[[ATTR0]] {
+// LLVM-LABEL: @test_vfmaq_laneq_f64(
+// CIRLLVM-LABEL: @test_vfmaq_laneq_f64(
 // CIR-LABEL: @test_vfmaq_laneq_f64(
 float64x2_t test_vfmaq_laneq_f64(float64x2_t a, float64x2_t b, float64x2_t v) {
-  // CIR: cir.vec.shuffle
-  // CIR: cir.call_llvm_intrinsic "fma"
+// CIR: cir.vec.shuffle
+// CIR: cir.call_llvm_intrinsic "fma"
 
-  // LLVM: [[TMP0:%.*]] = bitcast <2 x double> [[A]] to <2 x i64>
-  // LLVM: [[TMP1:%.*]] = bitcast <2 x double> [[B]] to <2 x i64>
-  // LLVM: [[TMP2:%.*]] = bitcast <2 x double> [[V]] to <2 x i64>
-  // LLVM: [[TMP5:%.*]] = bitcast <2 x i64> [[TMP2]] to <16 x i8>
-  // LLVM: [[TMP8:%.*]] = bitcast <16 x i8> [[TMP5]] to <2 x double>
-  // LLVM: shufflevector <2 x double> [[TMP8]], <2 x double> {{[^,]+}}, <2 x i32> <i32 1, i32 1>
-  // LLVM: call <2 x double> @llvm.fma.v2f64(
+// CIRLLVM:      shufflevector <2 x double> {{.*}} <i32 1, i32 1>
+// CIRLLVM-NEXT: {{.*}}call <2 x double> @llvm.fma.v2f64({{.*}}
+
+// LLVM-SAME: <2 x double> {{.*}} [[A:%.*]], <2 x double> {{.*}} [[B:%.*]], <2 x double> {{.*}} [[V:%.*]]) {{.*}} {
+// LLVM-NEXT:  entry:
+// LLVM-NEXT:    [[TMP0:%.*]] = bitcast <2 x double> [[A]] to <2 x i64>
+// LLVM-NEXT:    [[TMP1:%.*]] = bitcast <2 x double> [[B]] to <2 x i64>
+// LLVM-NEXT:    [[TMP2:%.*]] = bitcast <2 x double> [[V]] to <2 x i64>
+// LLVM-NEXT:    [[TMP3:%.*]] = bitcast <2 x i64> [[TMP0]] to <16 x i8>
+// LLVM-NEXT:    [[TMP4:%.*]] = bitcast <2 x i64> [[TMP1]] to <16 x i8>
+// LLVM-NEXT:    [[TMP5:%.*]] = bitcast <2 x i64> [[TMP2]] to <16 x i8>
+// LLVM-NEXT:    [[TMP6:%.*]] = bitcast <16 x i8> [[TMP3]] to <2 x double>
+// LLVM-NEXT:    [[TMP7:%.*]] = bitcast <16 x i8> [[TMP4]] to <2 x double>
+// LLVM-NEXT:    [[TMP8:%.*]] = bitcast <16 x i8> [[TMP5]] to <2 x double>
+// LLVM-NEXT:    [[LANE:%.*]] = shufflevector <2 x double> [[TMP8]], <2 x double> [[TMP8]], <2 x i32> <i32 1, i32 1>
+// LLVM-NEXT:    [[TMP9:%.*]] = call <2 x double> @llvm.fma.v2f64(<2 x double> [[LANE]], <2 x double> [[TMP7]], <2 x double> [[TMP6]])
+// LLVM-NEXT:    ret <2 x double> [[TMP9]]
   return vfmaq_laneq_f64(a, b, v, 1);
 }

--- a/clang/test/CodeGen/AArch64/neon/vfma-lane.c
+++ b/clang/test/CodeGen/AArch64/neon/vfma-lane.c
@@ -1,115 +1,31 @@
 // REQUIRES: aarch64-registered-target
 
-// RUN: %clang_cc1 -triple arm64-none-linux-gnu -target-feature +neon -target-feature +fullfp16 -disable-O0-optnone -flax-vector-conversions=none -emit-llvm -o - %s | opt -S -passes=mem2reg,sroa | FileCheck %s --check-prefixes=LLVM
-// RUN: %if cir-enabled %{%clang_cc1 -triple arm64-none-linux-gnu -target-feature +neon -target-feature +fullfp16 -disable-O0-optnone -flax-vector-conversions=none -fclangir -emit-llvm -o - %s | opt -S -passes=mem2reg,sroa | FileCheck %s --check-prefixes=CIRLLVM %}
-// RUN: %if cir-enabled %{%clang_cc1 -triple arm64-none-linux-gnu -target-feature +neon -target-feature +fullfp16 -disable-O0-optnone -flax-vector-conversions=none -fclangir -emit-cir -o - %s | FileCheck %s --check-prefixes=CIR %}
+// RUN:                   %clang_cc1 -triple arm64-none-linux-gnu -target-feature +neon -disable-O0-optnone -flax-vector-conversions=none           -emit-llvm -o - %s | opt -S -passes=mem2reg,sroa | FileCheck %s --check-prefixes=LLVM
+// RUN: %if cir-enabled %{%clang_cc1 -triple arm64-none-linux-gnu -target-feature +neon -disable-O0-optnone -flax-vector-conversions=none -fclangir -emit-llvm -o - %s | opt -S -passes=mem2reg,sroa | FileCheck %s --check-prefixes=CIRLLVM %}
+// RUN: %if cir-enabled %{%clang_cc1 -triple arm64-none-linux-gnu -target-feature +neon -disable-O0-optnone -flax-vector-conversions=none -fclangir -emit-cir  -o - %s |                               FileCheck %s --check-prefixes=CIR %}
+
+//=============================================================================
+// NOTES
+//
+// This file contains tests that were originally located in:
+//  * clang/test/CodeGen/AArch64/neon-2velem.c
+//  * clang/test/CodeGen/AArch64/neon-scalar-x-indexed-elem.c
+// The main difference is the use of RUN lines that enable ClangIR lowering;
+// therefore only the non-f16 forms currently supported by ClangIR are tested
+// here.
+// Once ClangIR support is complete, this file is intended to replace the
+// original test coverage in those legacy files.
+//
+// ACLE section headings based on v2025Q2 of the ACLE specification:
+//  * https://arm-software.github.io/acle/neon_intrinsics/advsimd.html#fused-multiply-accumulate
+//
+//=============================================================================
 
 #include <arm_neon.h>
 
-// LLVM-LABEL: define {{[^@]+}}@test_vfma_lane_f16
-// CIR-LABEL: @test_vfma_lane_f16(
-float16x4_t test_vfma_lane_f16(float16x4_t a, float16x4_t b, float16x4_t c) {
-// CIR: cir.vec.shuffle
-// CIR: cir.call_llvm_intrinsic "fma"
-
-// CIRLLVM:      shufflevector <4 x half> {{.*}} <i32 3, i32 3, i32 3, i32 3>
-// CIRLLVM-NEXT: {{.*}}call <4 x half> @llvm.fma.v4f16({{.*}}
-
-// LLVM-SAME: (<4 x half> {{.*}} [[A:%.*]], <4 x half> {{.*}} [[B:%.*]], <4 x half> {{.*}} [[C:%.*]]) {{.*}} {
-// LLVM-NEXT:  entry:
-// LLVM-NEXT:    [[TMP0:%.*]] = bitcast <4 x half> [[A]] to <4 x i16>
-// LLVM-NEXT:    [[TMP1:%.*]] = bitcast <4 x half> [[B]] to <4 x i16>
-// LLVM-NEXT:    [[TMP2:%.*]] = bitcast <4 x half> [[C]] to <4 x i16>
-// LLVM-NEXT:    [[TMP3:%.*]] = bitcast <4 x i16> [[TMP0]] to <8 x i8>
-// LLVM-NEXT:    [[TMP4:%.*]] = bitcast <4 x i16> [[TMP1]] to <8 x i8>
-// LLVM-NEXT:    [[TMP5:%.*]] = bitcast <4 x i16> [[TMP2]] to <8 x i8>
-// LLVM-NEXT:    [[TMP6:%.*]] = bitcast <8 x i8> [[TMP5]] to <4 x half>
-// LLVM-NEXT:    [[LANE:%.*]] = shufflevector <4 x half> [[TMP6]], <4 x half> [[TMP6]], <4 x i32> <i32 3, i32 3, i32 3, i32 3>
-// LLVM-NEXT:    [[FMLA:%.*]] = bitcast <8 x i8> [[TMP4]] to <4 x half>
-// LLVM-NEXT:    [[FMLA1:%.*]] = bitcast <8 x i8> [[TMP3]] to <4 x half>
-// LLVM-NEXT:    [[FMLA2:%.*]] = call <4 x half> @llvm.fma.v4f16(<4 x half> [[FMLA]], <4 x half> [[LANE]], <4 x half> [[FMLA1]])
-// LLVM-NEXT:    ret <4 x half> [[FMLA2]]
-  return vfma_lane_f16(a, b, c, 3);
-}
-
-// LLVM-LABEL: define {{[^@]+}}@test_vfmaq_lane_f16
-// CIR-LABEL: @test_vfmaq_lane_f16(
-float16x8_t test_vfmaq_lane_f16(float16x8_t a, float16x8_t b, float16x4_t c) {
-// CIR: cir.vec.shuffle
-// CIR: cir.call_llvm_intrinsic "fma"
-
-// CIRLLVM:      shufflevector <4 x half> {{.*}} <i32 3, i32 3, i32 3, i32 3, i32 3, i32 3, i32 3, i32 3>
-// CIRLLVM-NEXT: {{.*}}call <8 x half> @llvm.fma.v8f16({{.*}}
-
-// LLVM-SAME: (<8 x half> {{.*}} [[A:%.*]], <8 x half> {{.*}} [[B:%.*]], <4 x half> {{.*}} [[C:%.*]]) {{.*}} {
-// LLVM-NEXT:  entry:
-// LLVM-NEXT:    [[TMP0:%.*]] = bitcast <8 x half> [[A]] to <8 x i16>
-// LLVM-NEXT:    [[TMP1:%.*]] = bitcast <8 x half> [[B]] to <8 x i16>
-// LLVM-NEXT:    [[TMP2:%.*]] = bitcast <4 x half> [[C]] to <4 x i16>
-// LLVM-NEXT:    [[TMP3:%.*]] = bitcast <8 x i16> [[TMP0]] to <16 x i8>
-// LLVM-NEXT:    [[TMP4:%.*]] = bitcast <8 x i16> [[TMP1]] to <16 x i8>
-// LLVM-NEXT:    [[TMP5:%.*]] = bitcast <4 x i16> [[TMP2]] to <8 x i8>
-// LLVM-NEXT:    [[TMP6:%.*]] = bitcast <8 x i8> [[TMP5]] to <4 x half>
-// LLVM-NEXT:    [[LANE:%.*]] = shufflevector <4 x half> [[TMP6]], <4 x half> [[TMP6]], <8 x i32> <i32 3, i32 3, i32 3, i32 3, i32 3, i32 3, i32 3, i32 3>
-// LLVM-NEXT:    [[FMLA:%.*]] = bitcast <16 x i8> [[TMP4]] to <8 x half>
-// LLVM-NEXT:    [[FMLA1:%.*]] = bitcast <16 x i8> [[TMP3]] to <8 x half>
-// LLVM-NEXT:    [[FMLA2:%.*]] = call <8 x half> @llvm.fma.v8f16(<8 x half> [[FMLA]], <8 x half> [[LANE]], <8 x half> [[FMLA1]])
-// LLVM-NEXT:    ret <8 x half> [[FMLA2]]
-  return vfmaq_lane_f16(a, b, c, 3);
-}
-
-// LLVM-LABEL: define {{[^@]+}}@test_vfma_laneq_f16
-// CIR-LABEL: @test_vfma_laneq_f16(
-float16x4_t test_vfma_laneq_f16(float16x4_t a, float16x4_t b, float16x8_t c) {
-// CIR: cir.vec.shuffle
-// CIR: cir.call_llvm_intrinsic "fma"
-
-// CIRLLVM:      shufflevector <8 x half> {{.*}} <i32 7, i32 7, i32 7, i32 7>
-// CIRLLVM-NEXT: {{.*}}call <4 x half> @llvm.fma.v4f16({{.*}}
-
-// LLVM-SAME: (<4 x half> {{.*}} [[A:%.*]], <4 x half> {{.*}} [[B:%.*]], <8 x half> {{.*}} [[C:%.*]]) {{.*}} {
-// LLVM-NEXT:  entry:
-// LLVM-NEXT:    [[TMP0:%.*]] = bitcast <4 x half> [[A]] to <4 x i16>
-// LLVM-NEXT:    [[TMP1:%.*]] = bitcast <4 x half> [[B]] to <4 x i16>
-// LLVM-NEXT:    [[TMP2:%.*]] = bitcast <8 x half> [[C]] to <8 x i16>
-// LLVM-NEXT:    [[TMP3:%.*]] = bitcast <4 x i16> [[TMP0]] to <8 x i8>
-// LLVM-NEXT:    [[TMP4:%.*]] = bitcast <4 x i16> [[TMP1]] to <8 x i8>
-// LLVM-NEXT:    [[TMP5:%.*]] = bitcast <8 x i16> [[TMP2]] to <16 x i8>
-// LLVM-NEXT:    [[TMP6:%.*]] = bitcast <8 x i8> [[TMP3]] to <4 x half>
-// LLVM-NEXT:    [[TMP7:%.*]] = bitcast <8 x i8> [[TMP4]] to <4 x half>
-// LLVM-NEXT:    [[TMP8:%.*]] = bitcast <16 x i8> [[TMP5]] to <8 x half>
-// LLVM-NEXT:    [[LANE:%.*]] = shufflevector <8 x half> [[TMP8]], <8 x half> [[TMP8]], <4 x i32> <i32 7, i32 7, i32 7, i32 7>
-// LLVM-NEXT:    [[TMP9:%.*]] = call <4 x half> @llvm.fma.v4f16(<4 x half> [[LANE]], <4 x half> [[TMP7]], <4 x half> [[TMP6]])
-// LLVM-NEXT:    ret <4 x half> [[TMP9]]
-  return vfma_laneq_f16(a, b, c, 7);
-}
-
-// LLVM-LABEL: define {{[^@]+}}@test_vfmaq_laneq_f16
-// CIR-LABEL: @test_vfmaq_laneq_f16(
-float16x8_t test_vfmaq_laneq_f16(float16x8_t a, float16x8_t b, float16x8_t c) {
-// CIR: cir.vec.shuffle
-// CIR: cir.call_llvm_intrinsic "fma"
-
-// CIRLLVM:      shufflevector <8 x half> {{.*}} <i32 7, i32 7, i32 7, i32 7, i32 7, i32 7, i32 7, i32 7>
-// CIRLLVM-NEXT: {{.*}}call <8 x half> @llvm.fma.v8f16({{.*}}
-
-// LLVM-SAME: (<8 x half> {{.*}} [[A:%.*]], <8 x half> {{.*}} [[B:%.*]], <8 x half> {{.*}} [[C:%.*]]) {{.*}} {
-// LLVM-NEXT:  entry:
-// LLVM-NEXT:    [[TMP0:%.*]] = bitcast <8 x half> [[A]] to <8 x i16>
-// LLVM-NEXT:    [[TMP1:%.*]] = bitcast <8 x half> [[B]] to <8 x i16>
-// LLVM-NEXT:    [[TMP2:%.*]] = bitcast <8 x half> [[C]] to <8 x i16>
-// LLVM-NEXT:    [[TMP3:%.*]] = bitcast <8 x i16> [[TMP0]] to <16 x i8>
-// LLVM-NEXT:    [[TMP4:%.*]] = bitcast <8 x i16> [[TMP1]] to <16 x i8>
-// LLVM-NEXT:    [[TMP5:%.*]] = bitcast <8 x i16> [[TMP2]] to <16 x i8>
-// LLVM-NEXT:    [[TMP6:%.*]] = bitcast <16 x i8> [[TMP3]] to <8 x half>
-// LLVM-NEXT:    [[TMP7:%.*]] = bitcast <16 x i8> [[TMP4]] to <8 x half>
-// LLVM-NEXT:    [[TMP8:%.*]] = bitcast <16 x i8> [[TMP5]] to <8 x half>
-// LLVM-NEXT:    [[LANE:%.*]] = shufflevector <8 x half> [[TMP8]], <8 x half> [[TMP8]], <8 x i32> <i32 7, i32 7, i32 7, i32 7, i32 7, i32 7, i32 7, i32 7>
-// LLVM-NEXT:    [[TMP9:%.*]] = call <8 x half> @llvm.fma.v8f16(<8 x half> [[LANE]], <8 x half> [[TMP7]], <8 x half> [[TMP6]])
-// LLVM-NEXT:    ret <8 x half> [[TMP9]]
-  return vfmaq_laneq_f16(a, b, c, 7);
-}
-
+//===------------------------------------------------------===//
+// Fused multiply-accumulate lane/laneq, vector forms
+//===------------------------------------------------------===//
 // LLVM-LABEL: @test_vfma_lane_f32(
 // CIRLLVM-LABEL: @test_vfma_lane_f32(
 // CIR-LABEL: @test_vfma_lane_f32(
@@ -218,7 +134,8 @@ float32x4_t test_vfmaq_laneq_f32(float32x4_t a, float32x4_t b, float32x4_t v) {
   return vfmaq_laneq_f32(a, b, v, 3);
 }
 
-// LLVM-LABEL: define dso_local <1 x double> @test_vfma_lane_f64(
+// LLVM-LABEL: @test_vfma_lane_f64(
+// CIRLLVM-LABEL: @test_vfma_lane_f64(
 // CIR-LABEL: @test_vfma_lane_f64(
 float64x1_t test_vfma_lane_f64(float64x1_t a, float64x1_t b, float64x1_t v) {
 // CIR: cir.vec.shuffle
@@ -275,7 +192,8 @@ float64x2_t test_vfmaq_lane_f64(float64x2_t a, float64x2_t b, float64x1_t v) {
   return vfmaq_lane_f64(a, b, v, 0);
 }
 
-// LLVM-LABEL: define dso_local <1 x double> @test_vfma_laneq_f64(
+// LLVM-LABEL: @test_vfma_laneq_f64(
+// CIRLLVM-LABEL: @test_vfma_laneq_f64(
 // CIR-LABEL: @test_vfma_laneq_f64(
 float64x1_t test_vfma_laneq_f64(float64x1_t a, float64x1_t b, float64x2_t v) {
 // CIR: cir.vec.extract

--- a/clang/test/CodeGen/AArch64/neon/vfma-lane.c
+++ b/clang/test/CodeGen/AArch64/neon/vfma-lane.c
@@ -30,15 +30,14 @@
 // CIRLLVM-LABEL: @test_vfma_lane_f32(
 // CIR-LABEL: @test_vfma_lane_f32(
 float32x2_t test_vfma_lane_f32(float32x2_t a, float32x2_t b, float32x2_t v) {
-// CIR: cir.vec.shuffle
-// CIR: cir.call_llvm_intrinsic "fma"
+// CIR:      [[LANE:%.*]] = cir.vec.shuffle(%{{.*}}, %{{.*}} : !cir.vector<2 x !cir.float>) [#cir.int<1> : !s32i, #cir.int<1> : !s32i] : !cir.vector<2 x !cir.float>
+// CIR-NEXT: [[RES:%.*]] = cir.call_llvm_intrinsic "fma" %{{.*}}, [[LANE]], %{{.*}} : (!cir.vector<2 x !cir.float>, !cir.vector<2 x !cir.float>, !cir.vector<2 x !cir.float>) -> !cir.vector<2 x !cir.float>
 
 // CIRLLVM:      shufflevector <2 x float> {{.*}} <i32 1, i32 1>
 // CIRLLVM-NEXT: {{.*}}call <2 x float> @llvm.fma.v2f32({{.*}}
 
 // LLVM-SAME: <2 x float> {{.*}} [[A:%.*]], <2 x float> {{.*}} [[B:%.*]], <2 x float> {{.*}} [[V:%.*]]) {{.*}} {
-// LLVM-NEXT:  entry:
-// LLVM-NEXT:    [[TMP0:%.*]] = bitcast <2 x float> [[A]] to <2 x i32>
+// LLVM:         [[TMP0:%.*]] = bitcast <2 x float> [[A]] to <2 x i32>
 // LLVM-NEXT:    [[TMP1:%.*]] = bitcast <2 x float> [[B]] to <2 x i32>
 // LLVM-NEXT:    [[TMP2:%.*]] = bitcast <2 x float> [[V]] to <2 x i32>
 // LLVM-NEXT:    [[TMP3:%.*]] = bitcast <2 x i32> [[TMP0]] to <8 x i8>
@@ -57,15 +56,14 @@ float32x2_t test_vfma_lane_f32(float32x2_t a, float32x2_t b, float32x2_t v) {
 // CIRLLVM-LABEL: @test_vfmaq_lane_f32(
 // CIR-LABEL: @test_vfmaq_lane_f32(
 float32x4_t test_vfmaq_lane_f32(float32x4_t a, float32x4_t b, float32x2_t v) {
-// CIR: cir.vec.shuffle
-// CIR: cir.call_llvm_intrinsic "fma"
+// CIR:      [[LANE:%.*]] = cir.vec.shuffle(%{{.*}}, %{{.*}} : !cir.vector<2 x !cir.float>) [#cir.int<1> : !s32i, #cir.int<1> : !s32i, #cir.int<1> : !s32i, #cir.int<1> : !s32i] : !cir.vector<4 x !cir.float>
+// CIR-NEXT: [[RES:%.*]] = cir.call_llvm_intrinsic "fma" %{{.*}}, [[LANE]], %{{.*}} : (!cir.vector<4 x !cir.float>, !cir.vector<4 x !cir.float>, !cir.vector<4 x !cir.float>) -> !cir.vector<4 x !cir.float>
 
 // CIRLLVM:      shufflevector <2 x float> {{.*}} <i32 1, i32 1, i32 1, i32 1>
 // CIRLLVM-NEXT: {{.*}}call <4 x float> @llvm.fma.v4f32({{.*}}
 
 // LLVM-SAME: <4 x float> {{.*}} [[A:%.*]], <4 x float> {{.*}} [[B:%.*]], <2 x float> {{.*}} [[V:%.*]]) {{.*}} {
-// LLVM-NEXT:  entry:
-// LLVM-NEXT:    [[TMP0:%.*]] = bitcast <4 x float> [[A]] to <4 x i32>
+// LLVM:         [[TMP0:%.*]] = bitcast <4 x float> [[A]] to <4 x i32>
 // LLVM-NEXT:    [[TMP1:%.*]] = bitcast <4 x float> [[B]] to <4 x i32>
 // LLVM-NEXT:    [[TMP2:%.*]] = bitcast <2 x float> [[V]] to <2 x i32>
 // LLVM-NEXT:    [[TMP3:%.*]] = bitcast <4 x i32> [[TMP0]] to <16 x i8>
@@ -84,15 +82,14 @@ float32x4_t test_vfmaq_lane_f32(float32x4_t a, float32x4_t b, float32x2_t v) {
 // CIRLLVM-LABEL: @test_vfma_laneq_f32(
 // CIR-LABEL: @test_vfma_laneq_f32(
 float32x2_t test_vfma_laneq_f32(float32x2_t a, float32x2_t b, float32x4_t v) {
-// CIR: cir.vec.shuffle
-// CIR: cir.call_llvm_intrinsic "fma"
+// CIR:      [[LANE:%.*]] = cir.vec.shuffle(%{{.*}}, %{{.*}} : !cir.vector<4 x !cir.float>) [#cir.int<3> : !s32i, #cir.int<3> : !s32i] : !cir.vector<2 x !cir.float>
+// CIR-NEXT: [[RES:%.*]] = cir.call_llvm_intrinsic "fma" %{{.*}}, [[LANE]], %{{.*}} : (!cir.vector<2 x !cir.float>, !cir.vector<2 x !cir.float>, !cir.vector<2 x !cir.float>) -> !cir.vector<2 x !cir.float>
 
 // CIRLLVM:      shufflevector <4 x float> {{.*}} <i32 3, i32 3>
 // CIRLLVM-NEXT: {{.*}}call <2 x float> @llvm.fma.v2f32({{.*}}
 
 // LLVM-SAME: <2 x float> {{.*}} [[A:%.*]], <2 x float> {{.*}} [[B:%.*]], <4 x float> {{.*}} [[V:%.*]]) {{.*}} {
-// LLVM-NEXT:  entry:
-// LLVM-NEXT:    [[TMP0:%.*]] = bitcast <2 x float> [[A]] to <2 x i32>
+// LLVM:         [[TMP0:%.*]] = bitcast <2 x float> [[A]] to <2 x i32>
 // LLVM-NEXT:    [[TMP1:%.*]] = bitcast <2 x float> [[B]] to <2 x i32>
 // LLVM-NEXT:    [[TMP2:%.*]] = bitcast <4 x float> [[V]] to <4 x i32>
 // LLVM-NEXT:    [[TMP3:%.*]] = bitcast <2 x i32> [[TMP0]] to <8 x i8>
@@ -111,15 +108,14 @@ float32x2_t test_vfma_laneq_f32(float32x2_t a, float32x2_t b, float32x4_t v) {
 // CIRLLVM-LABEL: @test_vfmaq_laneq_f32(
 // CIR-LABEL: @test_vfmaq_laneq_f32(
 float32x4_t test_vfmaq_laneq_f32(float32x4_t a, float32x4_t b, float32x4_t v) {
-// CIR: cir.vec.shuffle
-// CIR: cir.call_llvm_intrinsic "fma"
+// CIR:      [[LANE:%.*]] = cir.vec.shuffle(%{{.*}}, %{{.*}} : !cir.vector<4 x !cir.float>) [#cir.int<3> : !s32i, #cir.int<3> : !s32i, #cir.int<3> : !s32i, #cir.int<3> : !s32i] : !cir.vector<4 x !cir.float>
+// CIR-NEXT: [[RES:%.*]] = cir.call_llvm_intrinsic "fma" %{{.*}}, [[LANE]], %{{.*}} : (!cir.vector<4 x !cir.float>, !cir.vector<4 x !cir.float>, !cir.vector<4 x !cir.float>) -> !cir.vector<4 x !cir.float>
 
 // CIRLLVM:      shufflevector <4 x float> {{.*}} <i32 3, i32 3, i32 3, i32 3>
 // CIRLLVM-NEXT: {{.*}}call <4 x float> @llvm.fma.v4f32({{.*}}
 
 // LLVM-SAME: <4 x float> {{.*}} [[A:%.*]], <4 x float> {{.*}} [[B:%.*]], <4 x float> {{.*}} [[V:%.*]]) {{.*}} {
-// LLVM-NEXT:  entry:
-// LLVM-NEXT:    [[TMP0:%.*]] = bitcast <4 x float> [[A]] to <4 x i32>
+// LLVM:         [[TMP0:%.*]] = bitcast <4 x float> [[A]] to <4 x i32>
 // LLVM-NEXT:    [[TMP1:%.*]] = bitcast <4 x float> [[B]] to <4 x i32>
 // LLVM-NEXT:    [[TMP2:%.*]] = bitcast <4 x float> [[V]] to <4 x i32>
 // LLVM-NEXT:    [[TMP3:%.*]] = bitcast <4 x i32> [[TMP0]] to <16 x i8>
@@ -138,15 +134,14 @@ float32x4_t test_vfmaq_laneq_f32(float32x4_t a, float32x4_t b, float32x4_t v) {
 // CIRLLVM-LABEL: @test_vfma_lane_f64(
 // CIR-LABEL: @test_vfma_lane_f64(
 float64x1_t test_vfma_lane_f64(float64x1_t a, float64x1_t b, float64x1_t v) {
-// CIR: cir.vec.shuffle
-// CIR: cir.call_llvm_intrinsic "fma"
+// CIR:      [[LANE:%.*]] = cir.vec.shuffle(%{{.*}}, %{{.*}} : !cir.vector<1 x !cir.double>) [#cir.int<0> : !s32i] : !cir.vector<1 x !cir.double>
+// CIR-NEXT: [[RES:%.*]] = cir.call_llvm_intrinsic "fma" %{{.*}}, [[LANE]], %{{.*}} : (!cir.vector<1 x !cir.double>, !cir.vector<1 x !cir.double>, !cir.vector<1 x !cir.double>) -> !cir.vector<1 x !cir.double>
 
 // CIRLLVM:      shufflevector <1 x double> {{.*}} zeroinitializer
 // CIRLLVM-NEXT: {{.*}}call <1 x double> @llvm.fma.v1f64({{.*}}
 
 // LLVM-SAME: <1 x double> {{.*}} [[A:%.*]], <1 x double> {{.*}} [[B:%.*]], <1 x double> {{.*}} [[V:%.*]]) {{.*}} {
-// LLVM-NEXT:  [[ENTRY:.*:]]
-// LLVM-NEXT:    [[TMP0:%.*]] = bitcast <1 x double> [[A]] to i64
+// LLVM:         [[TMP0:%.*]] = bitcast <1 x double> [[A]] to i64
 // LLVM-NEXT:    [[__S0_SROA_0_0_VEC_INSERT:%.*]] = insertelement <1 x i64> undef, i64 [[TMP0]], i32 0
 // LLVM-NEXT:    [[TMP1:%.*]] = bitcast <1 x double> [[B]] to i64
 // LLVM-NEXT:    [[__S1_SROA_0_0_VEC_INSERT:%.*]] = insertelement <1 x i64> undef, i64 [[TMP1]], i32 0
@@ -168,15 +163,14 @@ float64x1_t test_vfma_lane_f64(float64x1_t a, float64x1_t b, float64x1_t v) {
 // CIRLLVM-LABEL: @test_vfmaq_lane_f64(
 // CIR-LABEL: @test_vfmaq_lane_f64(
 float64x2_t test_vfmaq_lane_f64(float64x2_t a, float64x2_t b, float64x1_t v) {
-// CIR: cir.vec.shuffle
-// CIR: cir.call_llvm_intrinsic "fma"
+// CIR:      [[LANE:%.*]] = cir.vec.shuffle(%{{.*}}, %{{.*}} : !cir.vector<1 x !cir.double>) [#cir.int<0> : !s32i, #cir.int<0> : !s32i] : !cir.vector<2 x !cir.double>
+// CIR-NEXT: [[RES:%.*]] = cir.call_llvm_intrinsic "fma" %{{.*}}, [[LANE]], %{{.*}} : (!cir.vector<2 x !cir.double>, !cir.vector<2 x !cir.double>, !cir.vector<2 x !cir.double>) -> !cir.vector<2 x !cir.double>
 
 // CIRLLVM:      shufflevector <1 x double> {{.*}} <2 x i32> zeroinitializer
 // CIRLLVM-NEXT: {{.*}}call <2 x double> @llvm.fma.v2f64({{.*}}
 
 // LLVM-SAME: <2 x double> {{.*}} [[A:%.*]], <2 x double> {{.*}} [[B:%.*]], <1 x double> {{.*}} [[V:%.*]]) {{.*}} {
-// LLVM-NEXT:  entry:
-// LLVM-NEXT:    [[TMP0:%.*]] = bitcast <2 x double> [[A]] to <2 x i64>
+// LLVM:         [[TMP0:%.*]] = bitcast <2 x double> [[A]] to <2 x i64>
 // LLVM-NEXT:    [[TMP1:%.*]] = bitcast <2 x double> [[B]] to <2 x i64>
 // LLVM-NEXT:    [[TMP2:%.*]] = bitcast <1 x double> [[V]] to i64
 // LLVM-NEXT:    [[__S2_SROA_0_0_VEC_INSERT:%.*]] = insertelement <1 x i64> undef, i64 [[TMP2]], i32 0
@@ -196,15 +190,14 @@ float64x2_t test_vfmaq_lane_f64(float64x2_t a, float64x2_t b, float64x1_t v) {
 // CIRLLVM-LABEL: @test_vfma_laneq_f64(
 // CIR-LABEL: @test_vfma_laneq_f64(
 float64x1_t test_vfma_laneq_f64(float64x1_t a, float64x1_t b, float64x2_t v) {
-// CIR: cir.vec.extract
-// CIR: cir.call_llvm_intrinsic "fma"
+// CIR:      [[EXTRACT:%.*]] = cir.vec.extract %{{.*}}[%{{.*}} : !s32i] : !cir.vector<2 x !cir.double>
+// CIR-NEXT: [[RES:%.*]] = cir.call_llvm_intrinsic "fma" %{{.*}}, [[EXTRACT]], %{{.*}} : (!cir.double, !cir.double, !cir.double) -> !cir.double
 
 // CIRLLVM:      extractelement <2 x double> {{.*}}, i32 1
 // CIRLLVM-NEXT: {{.*}}call double @llvm.fma.f64({{.*}}
 
 // LLVM-SAME: <1 x double> {{.*}} [[A:%.*]], <1 x double> {{.*}} [[B:%.*]], <2 x double> {{.*}} [[V:%.*]]) {{.*}} {
-// LLVM-NEXT:  [[ENTRY:.*:]]
-// LLVM-NEXT:    [[TMP0:%.*]] = bitcast <1 x double> [[A]] to i64
+// LLVM:         [[TMP0:%.*]] = bitcast <1 x double> [[A]] to i64
 // LLVM-NEXT:    [[__S0_SROA_0_0_VEC_INSERT:%.*]] = insertelement <1 x i64> undef, i64 [[TMP0]], i32 0
 // LLVM-NEXT:    [[TMP1:%.*]] = bitcast <1 x double> [[B]] to i64
 // LLVM-NEXT:    [[__S1_SROA_0_0_VEC_INSERT:%.*]] = insertelement <1 x i64> undef, i64 [[TMP1]], i32 0
@@ -226,15 +219,14 @@ float64x1_t test_vfma_laneq_f64(float64x1_t a, float64x1_t b, float64x2_t v) {
 // CIRLLVM-LABEL: @test_vfmaq_laneq_f64(
 // CIR-LABEL: @test_vfmaq_laneq_f64(
 float64x2_t test_vfmaq_laneq_f64(float64x2_t a, float64x2_t b, float64x2_t v) {
-// CIR: cir.vec.shuffle
-// CIR: cir.call_llvm_intrinsic "fma"
+// CIR:      [[LANE:%.*]] = cir.vec.shuffle(%{{.*}}, %{{.*}} : !cir.vector<2 x !cir.double>) [#cir.int<1> : !s32i, #cir.int<1> : !s32i] : !cir.vector<2 x !cir.double>
+// CIR-NEXT: [[RES:%.*]] = cir.call_llvm_intrinsic "fma" %{{.*}}, [[LANE]], %{{.*}} : (!cir.vector<2 x !cir.double>, !cir.vector<2 x !cir.double>, !cir.vector<2 x !cir.double>) -> !cir.vector<2 x !cir.double>
 
 // CIRLLVM:      shufflevector <2 x double> {{.*}} <i32 1, i32 1>
 // CIRLLVM-NEXT: {{.*}}call <2 x double> @llvm.fma.v2f64({{.*}}
 
 // LLVM-SAME: <2 x double> {{.*}} [[A:%.*]], <2 x double> {{.*}} [[B:%.*]], <2 x double> {{.*}} [[V:%.*]]) {{.*}} {
-// LLVM-NEXT:  entry:
-// LLVM-NEXT:    [[TMP0:%.*]] = bitcast <2 x double> [[A]] to <2 x i64>
+// LLVM:         [[TMP0:%.*]] = bitcast <2 x double> [[A]] to <2 x i64>
 // LLVM-NEXT:    [[TMP1:%.*]] = bitcast <2 x double> [[B]] to <2 x i64>
 // LLVM-NEXT:    [[TMP2:%.*]] = bitcast <2 x double> [[V]] to <2 x i64>
 // LLVM-NEXT:    [[TMP3:%.*]] = bitcast <2 x i64> [[TMP0]] to <16 x i8>

--- a/clang/test/CodeGen/AArch64/neon/vfma-lane.c
+++ b/clang/test/CodeGen/AArch64/neon/vfma-lane.c
@@ -31,10 +31,10 @@
 // CIR-LABEL: @test_vfma_lane_f32(
 float32x2_t test_vfma_lane_f32(float32x2_t a, float32x2_t b, float32x2_t v) {
 // CIR:      [[LANE:%.*]] = cir.vec.shuffle(%{{.*}}, %{{.*}} : !cir.vector<2 x !cir.float>) [#cir.int<1> : !s32i, #cir.int<1> : !s32i] : !cir.vector<2 x !cir.float>
-// CIR-NEXT: [[RES:%.*]] = cir.call_llvm_intrinsic "fma" %{{.*}}, [[LANE]], %{{.*}} : (!cir.vector<2 x !cir.float>, !cir.vector<2 x !cir.float>, !cir.vector<2 x !cir.float>) -> !cir.vector<2 x !cir.float>
+// CIR-NEXT: {{%.*}} = cir.call_llvm_intrinsic "fma" %{{.*}}, [[LANE]], %{{.*}} : (!cir.vector<2 x !cir.float>, !cir.vector<2 x !cir.float>, !cir.vector<2 x !cir.float>) -> !cir.vector<2 x !cir.float>
 
-// CIRLLVM:      shufflevector <2 x float> {{.*}} <i32 1, i32 1>
-// CIRLLVM-NEXT: {{.*}}call <2 x float> @llvm.fma.v2f32({{.*}}
+// CIRLLVM:      [[LANE:%.*]] = shufflevector <2 x float> {{.*}} <i32 1, i32 1>
+// CIRLLVM-NEXT: {{%.*}} = call <2 x float> @llvm.fma.v2f32(<2 x float> {{.*}}, <2 x float> [[LANE]], <2 x float> {{.*}})
 
 // LLVM-SAME: <2 x float> {{.*}} [[A:%.*]], <2 x float> {{.*}} [[B:%.*]], <2 x float> {{.*}} [[V:%.*]]) {{.*}} {
 // LLVM:         [[TMP0:%.*]] = bitcast <2 x float> [[A]] to <2 x i32>
@@ -57,10 +57,10 @@ float32x2_t test_vfma_lane_f32(float32x2_t a, float32x2_t b, float32x2_t v) {
 // CIR-LABEL: @test_vfmaq_lane_f32(
 float32x4_t test_vfmaq_lane_f32(float32x4_t a, float32x4_t b, float32x2_t v) {
 // CIR:      [[LANE:%.*]] = cir.vec.shuffle(%{{.*}}, %{{.*}} : !cir.vector<2 x !cir.float>) [#cir.int<1> : !s32i, #cir.int<1> : !s32i, #cir.int<1> : !s32i, #cir.int<1> : !s32i] : !cir.vector<4 x !cir.float>
-// CIR-NEXT: [[RES:%.*]] = cir.call_llvm_intrinsic "fma" %{{.*}}, [[LANE]], %{{.*}} : (!cir.vector<4 x !cir.float>, !cir.vector<4 x !cir.float>, !cir.vector<4 x !cir.float>) -> !cir.vector<4 x !cir.float>
+// CIR-NEXT: {{%.*}} = cir.call_llvm_intrinsic "fma" %{{.*}}, [[LANE]], %{{.*}} : (!cir.vector<4 x !cir.float>, !cir.vector<4 x !cir.float>, !cir.vector<4 x !cir.float>) -> !cir.vector<4 x !cir.float>
 
-// CIRLLVM:      shufflevector <2 x float> {{.*}} <i32 1, i32 1, i32 1, i32 1>
-// CIRLLVM-NEXT: {{.*}}call <4 x float> @llvm.fma.v4f32({{.*}}
+// CIRLLVM:      [[LANE:%.*]] = shufflevector <2 x float> {{.*}} <i32 1, i32 1, i32 1, i32 1>
+// CIRLLVM-NEXT: {{%.*}} = call <4 x float> @llvm.fma.v4f32(<4 x float> {{.*}}, <4 x float> [[LANE]], <4 x float> {{.*}})
 
 // LLVM-SAME: <4 x float> {{.*}} [[A:%.*]], <4 x float> {{.*}} [[B:%.*]], <2 x float> {{.*}} [[V:%.*]]) {{.*}} {
 // LLVM:         [[TMP0:%.*]] = bitcast <4 x float> [[A]] to <4 x i32>
@@ -83,10 +83,10 @@ float32x4_t test_vfmaq_lane_f32(float32x4_t a, float32x4_t b, float32x2_t v) {
 // CIR-LABEL: @test_vfma_laneq_f32(
 float32x2_t test_vfma_laneq_f32(float32x2_t a, float32x2_t b, float32x4_t v) {
 // CIR:      [[LANE:%.*]] = cir.vec.shuffle(%{{.*}}, %{{.*}} : !cir.vector<4 x !cir.float>) [#cir.int<3> : !s32i, #cir.int<3> : !s32i] : !cir.vector<2 x !cir.float>
-// CIR-NEXT: [[RES:%.*]] = cir.call_llvm_intrinsic "fma" %{{.*}}, [[LANE]], %{{.*}} : (!cir.vector<2 x !cir.float>, !cir.vector<2 x !cir.float>, !cir.vector<2 x !cir.float>) -> !cir.vector<2 x !cir.float>
+// CIR-NEXT: {{%.*}} = cir.call_llvm_intrinsic "fma" %{{.*}}, [[LANE]], %{{.*}} : (!cir.vector<2 x !cir.float>, !cir.vector<2 x !cir.float>, !cir.vector<2 x !cir.float>) -> !cir.vector<2 x !cir.float>
 
-// CIRLLVM:      shufflevector <4 x float> {{.*}} <i32 3, i32 3>
-// CIRLLVM-NEXT: {{.*}}call <2 x float> @llvm.fma.v2f32({{.*}}
+// CIRLLVM:      [[LANE:%.*]] = shufflevector <4 x float> {{.*}} <i32 3, i32 3>
+// CIRLLVM-NEXT: {{%.*}} = call <2 x float> @llvm.fma.v2f32(<2 x float> {{.*}}, <2 x float> [[LANE]], <2 x float> {{.*}})
 
 // LLVM-SAME: <2 x float> {{.*}} [[A:%.*]], <2 x float> {{.*}} [[B:%.*]], <4 x float> {{.*}} [[V:%.*]]) {{.*}} {
 // LLVM:         [[TMP0:%.*]] = bitcast <2 x float> [[A]] to <2 x i32>
@@ -109,10 +109,10 @@ float32x2_t test_vfma_laneq_f32(float32x2_t a, float32x2_t b, float32x4_t v) {
 // CIR-LABEL: @test_vfmaq_laneq_f32(
 float32x4_t test_vfmaq_laneq_f32(float32x4_t a, float32x4_t b, float32x4_t v) {
 // CIR:      [[LANE:%.*]] = cir.vec.shuffle(%{{.*}}, %{{.*}} : !cir.vector<4 x !cir.float>) [#cir.int<3> : !s32i, #cir.int<3> : !s32i, #cir.int<3> : !s32i, #cir.int<3> : !s32i] : !cir.vector<4 x !cir.float>
-// CIR-NEXT: [[RES:%.*]] = cir.call_llvm_intrinsic "fma" %{{.*}}, [[LANE]], %{{.*}} : (!cir.vector<4 x !cir.float>, !cir.vector<4 x !cir.float>, !cir.vector<4 x !cir.float>) -> !cir.vector<4 x !cir.float>
+// CIR-NEXT: {{%.*}} = cir.call_llvm_intrinsic "fma" %{{.*}}, [[LANE]], %{{.*}} : (!cir.vector<4 x !cir.float>, !cir.vector<4 x !cir.float>, !cir.vector<4 x !cir.float>) -> !cir.vector<4 x !cir.float>
 
-// CIRLLVM:      shufflevector <4 x float> {{.*}} <i32 3, i32 3, i32 3, i32 3>
-// CIRLLVM-NEXT: {{.*}}call <4 x float> @llvm.fma.v4f32({{.*}}
+// CIRLLVM:      [[LANE:%.*]] = shufflevector <4 x float> {{.*}} <i32 3, i32 3, i32 3, i32 3>
+// CIRLLVM-NEXT: {{%.*}} = call <4 x float> @llvm.fma.v4f32(<4 x float> {{.*}}, <4 x float> [[LANE]], <4 x float> {{.*}})
 
 // LLVM-SAME: <4 x float> {{.*}} [[A:%.*]], <4 x float> {{.*}} [[B:%.*]], <4 x float> {{.*}} [[V:%.*]]) {{.*}} {
 // LLVM:         [[TMP0:%.*]] = bitcast <4 x float> [[A]] to <4 x i32>
@@ -135,10 +135,10 @@ float32x4_t test_vfmaq_laneq_f32(float32x4_t a, float32x4_t b, float32x4_t v) {
 // CIR-LABEL: @test_vfma_lane_f64(
 float64x1_t test_vfma_lane_f64(float64x1_t a, float64x1_t b, float64x1_t v) {
 // CIR:      [[LANE:%.*]] = cir.vec.shuffle(%{{.*}}, %{{.*}} : !cir.vector<1 x !cir.double>) [#cir.int<0> : !s32i] : !cir.vector<1 x !cir.double>
-// CIR-NEXT: [[RES:%.*]] = cir.call_llvm_intrinsic "fma" %{{.*}}, [[LANE]], %{{.*}} : (!cir.vector<1 x !cir.double>, !cir.vector<1 x !cir.double>, !cir.vector<1 x !cir.double>) -> !cir.vector<1 x !cir.double>
+// CIR-NEXT: {{%.*}} = cir.call_llvm_intrinsic "fma" %{{.*}}, [[LANE]], %{{.*}} : (!cir.vector<1 x !cir.double>, !cir.vector<1 x !cir.double>, !cir.vector<1 x !cir.double>) -> !cir.vector<1 x !cir.double>
 
-// CIRLLVM:      shufflevector <1 x double> {{.*}} zeroinitializer
-// CIRLLVM-NEXT: {{.*}}call <1 x double> @llvm.fma.v1f64({{.*}}
+// CIRLLVM:      [[LANE:%.*]] = shufflevector <1 x double> {{.*}} zeroinitializer
+// CIRLLVM-NEXT: {{%.*}} = call <1 x double> @llvm.fma.v1f64(<1 x double> {{.*}}, <1 x double> [[LANE]], <1 x double> {{.*}})
 
 // LLVM-SAME: <1 x double> {{.*}} [[A:%.*]], <1 x double> {{.*}} [[B:%.*]], <1 x double> {{.*}} [[V:%.*]]) {{.*}} {
 // LLVM:         [[TMP0:%.*]] = bitcast <1 x double> [[A]] to i64
@@ -164,10 +164,10 @@ float64x1_t test_vfma_lane_f64(float64x1_t a, float64x1_t b, float64x1_t v) {
 // CIR-LABEL: @test_vfmaq_lane_f64(
 float64x2_t test_vfmaq_lane_f64(float64x2_t a, float64x2_t b, float64x1_t v) {
 // CIR:      [[LANE:%.*]] = cir.vec.shuffle(%{{.*}}, %{{.*}} : !cir.vector<1 x !cir.double>) [#cir.int<0> : !s32i, #cir.int<0> : !s32i] : !cir.vector<2 x !cir.double>
-// CIR-NEXT: [[RES:%.*]] = cir.call_llvm_intrinsic "fma" %{{.*}}, [[LANE]], %{{.*}} : (!cir.vector<2 x !cir.double>, !cir.vector<2 x !cir.double>, !cir.vector<2 x !cir.double>) -> !cir.vector<2 x !cir.double>
+// CIR-NEXT: {{%.*}} = cir.call_llvm_intrinsic "fma" %{{.*}}, [[LANE]], %{{.*}} : (!cir.vector<2 x !cir.double>, !cir.vector<2 x !cir.double>, !cir.vector<2 x !cir.double>) -> !cir.vector<2 x !cir.double>
 
-// CIRLLVM:      shufflevector <1 x double> {{.*}} <2 x i32> zeroinitializer
-// CIRLLVM-NEXT: {{.*}}call <2 x double> @llvm.fma.v2f64({{.*}}
+// CIRLLVM:      [[LANE:%.*]] = shufflevector <1 x double> {{.*}} <2 x i32> zeroinitializer
+// CIRLLVM-NEXT: {{%.*}} = call <2 x double> @llvm.fma.v2f64(<2 x double> {{.*}}, <2 x double> [[LANE]], <2 x double> {{.*}})
 
 // LLVM-SAME: <2 x double> {{.*}} [[A:%.*]], <2 x double> {{.*}} [[B:%.*]], <1 x double> {{.*}} [[V:%.*]]) {{.*}} {
 // LLVM:         [[TMP0:%.*]] = bitcast <2 x double> [[A]] to <2 x i64>
@@ -191,10 +191,10 @@ float64x2_t test_vfmaq_lane_f64(float64x2_t a, float64x2_t b, float64x1_t v) {
 // CIR-LABEL: @test_vfma_laneq_f64(
 float64x1_t test_vfma_laneq_f64(float64x1_t a, float64x1_t b, float64x2_t v) {
 // CIR:      [[EXTRACT:%.*]] = cir.vec.extract %{{.*}}[%{{.*}} : !s32i] : !cir.vector<2 x !cir.double>
-// CIR-NEXT: [[RES:%.*]] = cir.call_llvm_intrinsic "fma" %{{.*}}, [[EXTRACT]], %{{.*}} : (!cir.double, !cir.double, !cir.double) -> !cir.double
+// CIR-NEXT: {{%.*}} = cir.call_llvm_intrinsic "fma" %{{.*}}, [[EXTRACT]], %{{.*}} : (!cir.double, !cir.double, !cir.double) -> !cir.double
 
-// CIRLLVM:      extractelement <2 x double> {{.*}}, i32 1
-// CIRLLVM-NEXT: {{.*}}call double @llvm.fma.f64({{.*}}
+// CIRLLVM:      [[EXTRACT:%.*]] = extractelement <2 x double> {{.*}}, i32 1
+// CIRLLVM-NEXT: {{%.*}} = call double @llvm.fma.f64(double {{.*}}, double [[EXTRACT]], double {{.*}})
 
 // LLVM-SAME: <1 x double> {{.*}} [[A:%.*]], <1 x double> {{.*}} [[B:%.*]], <2 x double> {{.*}} [[V:%.*]]) {{.*}} {
 // LLVM:         [[TMP0:%.*]] = bitcast <1 x double> [[A]] to i64
@@ -220,10 +220,10 @@ float64x1_t test_vfma_laneq_f64(float64x1_t a, float64x1_t b, float64x2_t v) {
 // CIR-LABEL: @test_vfmaq_laneq_f64(
 float64x2_t test_vfmaq_laneq_f64(float64x2_t a, float64x2_t b, float64x2_t v) {
 // CIR:      [[LANE:%.*]] = cir.vec.shuffle(%{{.*}}, %{{.*}} : !cir.vector<2 x !cir.double>) [#cir.int<1> : !s32i, #cir.int<1> : !s32i] : !cir.vector<2 x !cir.double>
-// CIR-NEXT: [[RES:%.*]] = cir.call_llvm_intrinsic "fma" %{{.*}}, [[LANE]], %{{.*}} : (!cir.vector<2 x !cir.double>, !cir.vector<2 x !cir.double>, !cir.vector<2 x !cir.double>) -> !cir.vector<2 x !cir.double>
+// CIR-NEXT: {{%.*}} = cir.call_llvm_intrinsic "fma" %{{.*}}, [[LANE]], %{{.*}} : (!cir.vector<2 x !cir.double>, !cir.vector<2 x !cir.double>, !cir.vector<2 x !cir.double>) -> !cir.vector<2 x !cir.double>
 
-// CIRLLVM:      shufflevector <2 x double> {{.*}} <i32 1, i32 1>
-// CIRLLVM-NEXT: {{.*}}call <2 x double> @llvm.fma.v2f64({{.*}}
+// CIRLLVM:      [[LANE:%.*]] = shufflevector <2 x double> {{.*}} <i32 1, i32 1>
+// CIRLLVM-NEXT: {{%.*}} = call <2 x double> @llvm.fma.v2f64(<2 x double> {{.*}}, <2 x double> [[LANE]], <2 x double> {{.*}})
 
 // LLVM-SAME: <2 x double> {{.*}} [[A:%.*]], <2 x double> {{.*}} [[B:%.*]], <2 x double> {{.*}} [[V:%.*]]) {{.*}} {
 // LLVM:         [[TMP0:%.*]] = bitcast <2 x double> [[A]] to <2 x i64>

--- a/clang/test/CodeGen/AArch64/neon/vfma-lane.c
+++ b/clang/test/CodeGen/AArch64/neon/vfma-lane.c
@@ -1,126 +1,214 @@
 // REQUIRES: aarch64-registered-target
 
-// RUN:                   %clang_cc1 -triple arm64-none-linux-gnu -target-feature +neon -target-feature +fullfp16 -disable-O0-optnone -flax-vector-conversions=none           -emit-llvm -o - %s | opt -S -passes=mem2reg,sroa | FileCheck %s --check-prefixes=LLVM
-// RUN: %if cir-enabled %{%clang_cc1 -triple arm64-none-linux-gnu -target-feature +neon -target-feature +fullfp16 -disable-O0-optnone -flax-vector-conversions=none -fclangir -emit-llvm -o - %s | opt -S -passes=mem2reg,sroa | FileCheck %s --check-prefixes=LLVM %}
+// RUN:                   %clang_cc1 -triple arm64-none-linux-gnu -target-feature +neon -target-feature +fullfp16 -disable-O0-optnone -flax-vector-conversions=none           -emit-llvm -o - %s | opt -S -passes=mem2reg,sroa | FileCheck %s --check-prefixes=LLVM,PLAINLLVM
+// RUN: %if cir-enabled %{%clang_cc1 -triple arm64-none-linux-gnu -target-feature +neon -target-feature +fullfp16 -disable-O0-optnone -flax-vector-conversions=none -fclangir -emit-llvm -o - %s | opt -S -passes=mem2reg,sroa | FileCheck %s --check-prefixes=LLVM,CIRLLVM %}
 // RUN: %if cir-enabled %{%clang_cc1 -triple arm64-none-linux-gnu -target-feature +neon -target-feature +fullfp16 -disable-O0-optnone -flax-vector-conversions=none -fclangir -emit-cir  -o - %s |                               FileCheck %s --check-prefixes=CIR %}
 
 #include <arm_neon.h>
 
-// LLVM-LABEL: @test_vfma_lane_f16(
-// LLVM: shufflevector <4 x half>
-// LLVM: call <4 x half> @llvm.fma.v4f16(
+// LLVM-LABEL: define {{[^@]+}}@test_vfma_lane_f16
+// LLVM-SAME: (<4 x half> noundef [[A:%.*]], <4 x half> noundef [[B:%.*]], <4 x half> noundef [[C:%.*]]) #[[ATTR0:[0-9]+]] {
 // CIR-LABEL: @test_vfma_lane_f16(
-// CIR: cir.vec.shuffle
-// CIR: cir.call_llvm_intrinsic "fma"
 float16x4_t test_vfma_lane_f16(float16x4_t a, float16x4_t b, float16x4_t c) {
+  // CIR: cir.vec.shuffle
+  // CIR: cir.call_llvm_intrinsic "fma"
+
+  // LLVM: [[TMP0:%.*]] = bitcast <4 x half> [[A]] to <4 x i16>
+  // LLVM: [[TMP1:%.*]] = bitcast <4 x half> [[B]] to <4 x i16>
+  // LLVM: [[TMP2:%.*]] = bitcast <4 x half> [[C]] to <4 x i16>
+  // LLVM: [[TMP5:%.*]] = bitcast <4 x i16> [[TMP2]] to <8 x i8>
+  // LLVM: [[TMP6:%.*]] = bitcast <8 x i8> [[TMP5]] to <4 x half>
+  // LLVM: shufflevector <4 x half> [[TMP6]], <4 x half> {{[^,]+}}, <4 x i32> <i32 3, i32 3, i32 3, i32 3>
+  // LLVM: call <4 x half> @llvm.fma.v4f16(
   return vfma_lane_f16(a, b, c, 3);
 }
 
-// LLVM-LABEL: @test_vfmaq_lane_f16(
-// LLVM: shufflevector <4 x half>
-// LLVM: call <8 x half> @llvm.fma.v8f16(
+// LLVM-LABEL: define {{[^@]+}}@test_vfmaq_lane_f16
+// LLVM-SAME: (<8 x half> noundef [[A:%.*]], <8 x half> noundef [[B:%.*]], <4 x half> noundef [[C:%.*]]) #[[ATTR0]] {
 // CIR-LABEL: @test_vfmaq_lane_f16(
-// CIR: cir.vec.shuffle
-// CIR: cir.call_llvm_intrinsic "fma"
 float16x8_t test_vfmaq_lane_f16(float16x8_t a, float16x8_t b, float16x4_t c) {
+  // CIR: cir.vec.shuffle
+  // CIR: cir.call_llvm_intrinsic "fma"
+
+  // LLVM: [[TMP0:%.*]] = bitcast <8 x half> [[A]] to <8 x i16>
+  // LLVM: [[TMP1:%.*]] = bitcast <8 x half> [[B]] to <8 x i16>
+  // LLVM: [[TMP2:%.*]] = bitcast <4 x half> [[C]] to <4 x i16>
+  // LLVM: [[TMP5:%.*]] = bitcast <4 x i16> [[TMP2]] to <8 x i8>
+  // LLVM: [[TMP6:%.*]] = bitcast <8 x i8> [[TMP5]] to <4 x half>
+  // LLVM: shufflevector <4 x half> [[TMP6]], <4 x half> {{[^,]+}}, <8 x i32> <i32 3, i32 3, i32 3, i32 3, i32 3, i32 3, i32 3, i32 3>
+  // LLVM: call <8 x half> @llvm.fma.v8f16(
   return vfmaq_lane_f16(a, b, c, 3);
 }
 
-// LLVM-LABEL: @test_vfma_laneq_f16(
-// LLVM: shufflevector <8 x half>
-// LLVM: call <4 x half> @llvm.fma.v4f16(
+// LLVM-LABEL: define {{[^@]+}}@test_vfma_laneq_f16
+// LLVM-SAME: (<4 x half> noundef [[A:%.*]], <4 x half> noundef [[B:%.*]], <8 x half> noundef [[C:%.*]]) #[[ATTR0]] {
 // CIR-LABEL: @test_vfma_laneq_f16(
-// CIR: cir.vec.shuffle
-// CIR: cir.call_llvm_intrinsic "fma"
 float16x4_t test_vfma_laneq_f16(float16x4_t a, float16x4_t b, float16x8_t c) {
+  // CIR: cir.vec.shuffle
+  // CIR: cir.call_llvm_intrinsic "fma"
+
+  // LLVM: [[TMP0:%.*]] = bitcast <4 x half> [[A]] to <4 x i16>
+  // LLVM: [[TMP1:%.*]] = bitcast <4 x half> [[B]] to <4 x i16>
+  // LLVM: [[TMP2:%.*]] = bitcast <8 x half> [[C]] to <8 x i16>
+  // LLVM: [[TMP5:%.*]] = bitcast <8 x i16> [[TMP2]] to <16 x i8>
+  // LLVM: [[TMP8:%.*]] = bitcast <16 x i8> [[TMP5]] to <8 x half>
+  // LLVM: shufflevector <8 x half> [[TMP8]], <8 x half> {{[^,]+}}, <4 x i32> <i32 7, i32 7, i32 7, i32 7>
+  // LLVM: call <4 x half> @llvm.fma.v4f16(
   return vfma_laneq_f16(a, b, c, 7);
 }
 
-// LLVM-LABEL: @test_vfmaq_laneq_f16(
-// LLVM: shufflevector <8 x half>
-// LLVM: call <8 x half> @llvm.fma.v8f16(
+// LLVM-LABEL: define {{[^@]+}}@test_vfmaq_laneq_f16
+// LLVM-SAME: (<8 x half> noundef [[A:%.*]], <8 x half> noundef [[B:%.*]], <8 x half> noundef [[C:%.*]]) #[[ATTR0]] {
 // CIR-LABEL: @test_vfmaq_laneq_f16(
-// CIR: cir.vec.shuffle
-// CIR: cir.call_llvm_intrinsic "fma"
 float16x8_t test_vfmaq_laneq_f16(float16x8_t a, float16x8_t b, float16x8_t c) {
+  // CIR: cir.vec.shuffle
+  // CIR: cir.call_llvm_intrinsic "fma"
+
+  // LLVM: [[TMP0:%.*]] = bitcast <8 x half> [[A]] to <8 x i16>
+  // LLVM: [[TMP1:%.*]] = bitcast <8 x half> [[B]] to <8 x i16>
+  // LLVM: [[TMP2:%.*]] = bitcast <8 x half> [[C]] to <8 x i16>
+  // LLVM: [[TMP5:%.*]] = bitcast <8 x i16> [[TMP2]] to <16 x i8>
+  // LLVM: [[TMP8:%.*]] = bitcast <16 x i8> [[TMP5]] to <8 x half>
+  // LLVM: shufflevector <8 x half> [[TMP8]], <8 x half> {{[^,]+}}, <8 x i32> <i32 7, i32 7, i32 7, i32 7, i32 7, i32 7, i32 7, i32 7>
+  // LLVM: call <8 x half> @llvm.fma.v8f16(
   return vfmaq_laneq_f16(a, b, c, 7);
 }
 
-// LLVM-LABEL: @test_vfma_lane_f32(
-// LLVM: shufflevector <2 x float>
-// LLVM: call <2 x float> @llvm.fma.v2f32(
+// LLVM-LABEL: define {{[^@]+}}@test_vfma_lane_f32(
+// LLVM-SAME: <2 x float> noundef [[A:%.*]], <2 x float> noundef [[B:%.*]], <2 x float> noundef [[V:%.*]]) #[[ATTR0]] {
 // CIR-LABEL: @test_vfma_lane_f32(
-// CIR: cir.vec.shuffle
-// CIR: cir.call_llvm_intrinsic "fma"
 float32x2_t test_vfma_lane_f32(float32x2_t a, float32x2_t b, float32x2_t v) {
+  // CIR: cir.vec.shuffle
+  // CIR: cir.call_llvm_intrinsic "fma"
+
+  // LLVM: [[TMP0:%.*]] = bitcast <2 x float> [[A]] to <2 x i32>
+  // LLVM: [[TMP1:%.*]] = bitcast <2 x float> [[B]] to <2 x i32>
+  // LLVM: [[TMP2:%.*]] = bitcast <2 x float> [[V]] to <2 x i32>
+  // LLVM: [[TMP5:%.*]] = bitcast <2 x i32> [[TMP2]] to <8 x i8>
+  // LLVM: [[TMP6:%.*]] = bitcast <8 x i8> [[TMP5]] to <2 x float>
+  // LLVM: shufflevector <2 x float> [[TMP6]], <2 x float> {{[^,]+}}, <2 x i32> <i32 1, i32 1>
+  // LLVM: call <2 x float> @llvm.fma.v2f32(
   return vfma_lane_f32(a, b, v, 1);
 }
 
-// LLVM-LABEL: @test_vfmaq_lane_f32(
-// LLVM: shufflevector <2 x float>
-// LLVM: call <4 x float> @llvm.fma.v4f32(
+// LLVM-LABEL: define {{[^@]+}}@test_vfmaq_lane_f32(
+// LLVM-SAME: <4 x float> noundef [[A:%.*]], <4 x float> noundef [[B:%.*]], <2 x float> noundef [[V:%.*]]) #[[ATTR0]] {
 // CIR-LABEL: @test_vfmaq_lane_f32(
-// CIR: cir.vec.shuffle
-// CIR: cir.call_llvm_intrinsic "fma"
 float32x4_t test_vfmaq_lane_f32(float32x4_t a, float32x4_t b, float32x2_t v) {
+  // CIR: cir.vec.shuffle
+  // CIR: cir.call_llvm_intrinsic "fma"
+
+  // LLVM: [[TMP0:%.*]] = bitcast <4 x float> [[A]] to <4 x i32>
+  // LLVM: [[TMP1:%.*]] = bitcast <4 x float> [[B]] to <4 x i32>
+  // LLVM: [[TMP2:%.*]] = bitcast <2 x float> [[V]] to <2 x i32>
+  // LLVM: [[TMP5:%.*]] = bitcast <2 x i32> [[TMP2]] to <8 x i8>
+  // LLVM: [[TMP6:%.*]] = bitcast <8 x i8> [[TMP5]] to <2 x float>
+  // LLVM: shufflevector <2 x float> [[TMP6]], <2 x float> {{[^,]+}}, <4 x i32> <i32 1, i32 1, i32 1, i32 1>
+  // LLVM: call <4 x float> @llvm.fma.v4f32(
   return vfmaq_lane_f32(a, b, v, 1);
 }
 
-// LLVM-LABEL: @test_vfma_laneq_f32(
-// LLVM: shufflevector <4 x float>
-// LLVM: call <2 x float> @llvm.fma.v2f32(
+// LLVM-LABEL: define {{[^@]+}}@test_vfma_laneq_f32(
+// LLVM-SAME: <2 x float> noundef [[A:%.*]], <2 x float> noundef [[B:%.*]], <4 x float> noundef [[V:%.*]]) #[[ATTR0]] {
 // CIR-LABEL: @test_vfma_laneq_f32(
-// CIR: cir.vec.shuffle
-// CIR: cir.call_llvm_intrinsic "fma"
 float32x2_t test_vfma_laneq_f32(float32x2_t a, float32x2_t b, float32x4_t v) {
+  // CIR: cir.vec.shuffle
+  // CIR: cir.call_llvm_intrinsic "fma"
+
+  // LLVM: [[TMP0:%.*]] = bitcast <2 x float> [[A]] to <2 x i32>
+  // LLVM: [[TMP1:%.*]] = bitcast <2 x float> [[B]] to <2 x i32>
+  // LLVM: [[TMP2:%.*]] = bitcast <4 x float> [[V]] to <4 x i32>
+  // LLVM: [[TMP5:%.*]] = bitcast <4 x i32> [[TMP2]] to <16 x i8>
+  // LLVM: [[TMP8:%.*]] = bitcast <16 x i8> [[TMP5]] to <4 x float>
+  // LLVM: shufflevector <4 x float> [[TMP8]], <4 x float> {{[^,]+}}, <2 x i32> <i32 3, i32 3>
+  // LLVM: call <2 x float> @llvm.fma.v2f32(
   return vfma_laneq_f32(a, b, v, 3);
 }
 
-// LLVM-LABEL: @test_vfmaq_laneq_f32(
-// LLVM: shufflevector <4 x float>
-// LLVM: call <4 x float> @llvm.fma.v4f32(
+// LLVM-LABEL: define {{[^@]+}}@test_vfmaq_laneq_f32(
+// LLVM-SAME: <4 x float> noundef [[A:%.*]], <4 x float> noundef [[B:%.*]], <4 x float> noundef [[V:%.*]]) #[[ATTR0]] {
 // CIR-LABEL: @test_vfmaq_laneq_f32(
-// CIR: cir.vec.shuffle
-// CIR: cir.call_llvm_intrinsic "fma"
 float32x4_t test_vfmaq_laneq_f32(float32x4_t a, float32x4_t b, float32x4_t v) {
+  // CIR: cir.vec.shuffle
+  // CIR: cir.call_llvm_intrinsic "fma"
+
+  // LLVM: [[TMP0:%.*]] = bitcast <4 x float> [[A]] to <4 x i32>
+  // LLVM: [[TMP1:%.*]] = bitcast <4 x float> [[B]] to <4 x i32>
+  // LLVM: [[TMP2:%.*]] = bitcast <4 x float> [[V]] to <4 x i32>
+  // LLVM: [[TMP5:%.*]] = bitcast <4 x i32> [[TMP2]] to <16 x i8>
+  // LLVM: [[TMP8:%.*]] = bitcast <16 x i8> [[TMP5]] to <4 x float>
+  // LLVM: shufflevector <4 x float> [[TMP8]], <4 x float> {{[^,]+}}, <4 x i32> <i32 3, i32 3, i32 3, i32 3>
+  // LLVM: call <4 x float> @llvm.fma.v4f32(
   return vfmaq_laneq_f32(a, b, v, 3);
 }
 
-// LLVM-LABEL: @test_vfma_lane_f64(
-// LLVM: shufflevector <1 x double>
-// LLVM: call <1 x double> @llvm.fma.v1f64(
+// LLVM-LABEL: define {{[^@]+}}@test_vfma_lane_f64(
+// LLVM-SAME: <1 x double> noundef [[A:%.*]], <1 x double> noundef [[B:%.*]], <1 x double> noundef [[V:%.*]]) #[[ATTR0]] {
 // CIR-LABEL: @test_vfma_lane_f64(
-// CIR: cir.vec.shuffle
-// CIR: cir.call_llvm_intrinsic "fma"
 float64x1_t test_vfma_lane_f64(float64x1_t a, float64x1_t b, float64x1_t v) {
+  // CIR: cir.vec.shuffle
+  // CIR: cir.call_llvm_intrinsic "fma"
+
+  // LLVM: [[TMP0:%.*]] = bitcast <1 x double> [[A]] to i64
+  // LLVM: [[TMP1:%.*]] = bitcast <1 x double> [[B]] to i64
+  // LLVM: [[TMP2:%.*]] = bitcast <1 x double> [[V]] to i64
+  // LLVM: [[INS:%.*]] = insertelement <1 x i64> undef, i64 [[TMP2]], i32 0
+  // LLVM: shufflevector <1 x double> {{[^,]+}}, <1 x double> {{[^,]+}}, <1 x i32> zeroinitializer
+  // LLVM: call <1 x double> @llvm.fma.v1f64(
   return vfma_lane_f64(a, b, v, 0);
 }
 
-// LLVM-LABEL: @test_vfmaq_lane_f64(
-// LLVM: shufflevector <1 x double>
-// LLVM: call <2 x double> @llvm.fma.v2f64(
+// LLVM-LABEL: define {{[^@]+}}@test_vfmaq_lane_f64(
+// LLVM-SAME: <2 x double> noundef [[A:%.*]], <2 x double> noundef [[B:%.*]], <1 x double> noundef [[V:%.*]]) #[[ATTR0]] {
 // CIR-LABEL: @test_vfmaq_lane_f64(
-// CIR: cir.vec.shuffle
-// CIR: cir.call_llvm_intrinsic "fma"
 float64x2_t test_vfmaq_lane_f64(float64x2_t a, float64x2_t b, float64x1_t v) {
+  // CIR: cir.vec.shuffle
+  // CIR: cir.call_llvm_intrinsic "fma"
+
+  // LLVM: [[TMP0:%.*]] = bitcast <2 x double> [[A]] to <2 x i64>
+  // LLVM: [[TMP1:%.*]] = bitcast <2 x double> [[B]] to <2 x i64>
+  // LLVM: [[TMP2:%.*]] = bitcast <1 x double> [[V]] to i64
+  // LLVM: [[INS:%.*]] = insertelement <1 x i64> undef, i64 [[TMP2]], i32 0
+  // LLVM: shufflevector <1 x double> {{[^,]+}}, <1 x double> {{[^,]+}}, <2 x i32> zeroinitializer
+  // LLVM: call <2 x double> @llvm.fma.v2f64(
   return vfmaq_lane_f64(a, b, v, 0);
 }
 
-// LLVM-LABEL: @test_vfma_laneq_f64(
-// LLVM: @llvm.fma
+// PLAINLLVM-LABEL: define {{[^@]+}}@test_vfma_laneq_f64(
+// PLAINLLVM-SAME: <1 x double> noundef [[A:%.*]], <1 x double> noundef [[B:%.*]], <2 x double> noundef [[V:%.*]]) #[[ATTR0]] {
+// CIRLLVM-LABEL: define {{[^@]+}}@test_vfma_laneq_f64(
+// CIRLLVM-SAME: <1 x double> noundef [[A:%.*]], <1 x double> noundef [[B:%.*]], <2 x double> noundef [[V:%.*]]) #[[ATTR0]] {
 // CIR-LABEL: @test_vfma_laneq_f64(
-// CIR: cir.vec.shuffle
-// CIR: cir.call_llvm_intrinsic "fma"
 float64x1_t test_vfma_laneq_f64(float64x1_t a, float64x1_t b, float64x2_t v) {
-  return vfma_laneq_f64(a, b, v, 0);
+  // CIR: cir.vec.shuffle
+  // CIR: cir.call_llvm_intrinsic "fma"
+
+  // PLAINLLVM: [[TMP0:%.*]] = bitcast <1 x double> [[A]] to i64
+  // PLAINLLVM: [[TMP1:%.*]] = bitcast <1 x double> [[B]] to i64
+  // PLAINLLVM: [[TMP2:%.*]] = bitcast <2 x double> [[V]] to <2 x i64>
+  // PLAINLLVM: extractelement <2 x double>{{.*}}, i32 1
+  // PLAINLLVM: call double @llvm.fma.f64(
+  // CIRLLVM: [[TMP0:%.*]] = bitcast <1 x double> [[A]] to i64
+  // CIRLLVM: [[TMP1:%.*]] = bitcast <1 x double> [[B]] to i64
+  // CIRLLVM: [[TMP2:%.*]] = bitcast <2 x double> [[V]] to <2 x i64>
+  // CIRLLVM: shufflevector <2 x double> {{[^,]+}}, <2 x double> {{[^,]+}}, <1 x i32> <i32 1>
+  // CIRLLVM: call <1 x double> @llvm.fma.v1f64(
+  return vfma_laneq_f64(a, b, v, 1);
 }
 
-// LLVM-LABEL: @test_vfmaq_laneq_f64(
-// LLVM: shufflevector <2 x double>
-// LLVM: call <2 x double> @llvm.fma.v2f64(
+// LLVM-LABEL: define {{[^@]+}}@test_vfmaq_laneq_f64(
+// LLVM-SAME: <2 x double> noundef [[A:%.*]], <2 x double> noundef [[B:%.*]], <2 x double> noundef [[V:%.*]]) #[[ATTR0]] {
 // CIR-LABEL: @test_vfmaq_laneq_f64(
-// CIR: cir.vec.shuffle
-// CIR: cir.call_llvm_intrinsic "fma"
 float64x2_t test_vfmaq_laneq_f64(float64x2_t a, float64x2_t b, float64x2_t v) {
+  // CIR: cir.vec.shuffle
+  // CIR: cir.call_llvm_intrinsic "fma"
+
+  // LLVM: [[TMP0:%.*]] = bitcast <2 x double> [[A]] to <2 x i64>
+  // LLVM: [[TMP1:%.*]] = bitcast <2 x double> [[B]] to <2 x i64>
+  // LLVM: [[TMP2:%.*]] = bitcast <2 x double> [[V]] to <2 x i64>
+  // LLVM: [[TMP5:%.*]] = bitcast <2 x i64> [[TMP2]] to <16 x i8>
+  // LLVM: [[TMP8:%.*]] = bitcast <16 x i8> [[TMP5]] to <2 x double>
+  // LLVM: shufflevector <2 x double> [[TMP8]], <2 x double> {{[^,]+}}, <2 x i32> <i32 1, i32 1>
+  // LLVM: call <2 x double> @llvm.fma.v2f64(
   return vfmaq_laneq_f64(a, b, v, 1);
 }

--- a/clang/test/CodeGen/AArch64/neon/vfma-scalar-lane.c
+++ b/clang/test/CodeGen/AArch64/neon/vfma-scalar-lane.c
@@ -1,0 +1,67 @@
+// REQUIRES: aarch64-registered-target
+
+// RUN:                   %clang_cc1 -triple arm64-none-linux-gnu -target-feature +neon -target-feature +fullfp16 -disable-O0-optnone -flax-vector-conversions=none           -emit-llvm -o - %s | opt -S -passes=mem2reg,sroa | FileCheck %s --check-prefixes=LLVM
+// RUN: %if cir-enabled %{%clang_cc1 -triple arm64-none-linux-gnu -target-feature +neon -target-feature +fullfp16 -disable-O0-optnone -flax-vector-conversions=none -fclangir -emit-llvm -o - %s | opt -S -passes=mem2reg,sroa | FileCheck %s --check-prefixes=LLVM %}
+// RUN: %if cir-enabled %{%clang_cc1 -triple arm64-none-linux-gnu -target-feature +neon -target-feature +fullfp16 -disable-O0-optnone -flax-vector-conversions=none -fclangir -emit-cir  -o - %s |                               FileCheck %s --check-prefixes=CIR %}
+
+#include <arm_neon.h>
+
+// LLVM-LABEL: @test_vfmah_lane_f16(
+// LLVM: extractelement <4 x half>
+// LLVM: call half @llvm.fma.f16(
+// CIR-LABEL: @test_vfmah_lane_f16(
+// CIR: cir.vec.extract
+// CIR: cir.call_llvm_intrinsic "fma"
+float16_t test_vfmah_lane_f16(float16_t a, float16_t b, float16x4_t c) {
+  return vfmah_lane_f16(a, b, c, 3);
+}
+
+// LLVM-LABEL: @test_vfmah_laneq_f16(
+// LLVM: extractelement <8 x half>
+// LLVM: call half @llvm.fma.f16(
+// CIR-LABEL: @test_vfmah_laneq_f16(
+// CIR: cir.vec.extract
+// CIR: cir.call_llvm_intrinsic "fma"
+float16_t test_vfmah_laneq_f16(float16_t a, float16_t b, float16x8_t c) {
+  return vfmah_laneq_f16(a, b, c, 7);
+}
+
+// LLVM-LABEL: @test_vfmas_lane_f32(
+// LLVM: extractelement <2 x float>
+// LLVM: call float @llvm.fma.f32(
+// CIR-LABEL: @test_vfmas_lane_f32(
+// CIR: cir.vec.extract
+// CIR: cir.call_llvm_intrinsic "fma"
+float32_t test_vfmas_lane_f32(float32_t a, float32_t b, float32x2_t c) {
+  return vfmas_lane_f32(a, b, c, 1);
+}
+
+// LLVM-LABEL: @test_vfmas_laneq_f32(
+// LLVM: extractelement <4 x float>
+// LLVM: call float @llvm.fma.f32(
+// CIR-LABEL: @test_vfmas_laneq_f32(
+// CIR: cir.vec.extract
+// CIR: cir.call_llvm_intrinsic "fma"
+float32_t test_vfmas_laneq_f32(float32_t a, float32_t b, float32x4_t c) {
+  return vfmas_laneq_f32(a, b, c, 3);
+}
+
+// LLVM-LABEL: @test_vfmad_lane_f64(
+// LLVM: extractelement <1 x double>
+// LLVM: call double @llvm.fma.f64(
+// CIR-LABEL: @test_vfmad_lane_f64(
+// CIR: cir.vec.extract
+// CIR: cir.call_llvm_intrinsic "fma"
+float64_t test_vfmad_lane_f64(float64_t a, float64_t b, float64x1_t c) {
+  return vfmad_lane_f64(a, b, c, 0);
+}
+
+// LLVM-LABEL: @test_vfmad_laneq_f64(
+// LLVM: extractelement <2 x double>
+// LLVM: call double @llvm.fma.f64(
+// CIR-LABEL: @test_vfmad_laneq_f64(
+// CIR: cir.vec.extract
+// CIR: cir.call_llvm_intrinsic "fma"
+float64_t test_vfmad_laneq_f64(float64_t a, float64_t b, float64x2_t c) {
+  return vfmad_laneq_f64(a, b, c, 1);
+}

--- a/clang/test/CodeGen/AArch64/neon/vfma-scalar-lane.c
+++ b/clang/test/CodeGen/AArch64/neon/vfma-scalar-lane.c
@@ -1,85 +1,103 @@
 // REQUIRES: aarch64-registered-target
 
-// RUN:                   %clang_cc1 -triple arm64-none-linux-gnu -target-feature +neon -target-feature +fullfp16 -disable-O0-optnone -flax-vector-conversions=none           -emit-llvm -o - %s | opt -S -passes=mem2reg,sroa | FileCheck %s --check-prefixes=LLVM
-// RUN: %if cir-enabled %{%clang_cc1 -triple arm64-none-linux-gnu -target-feature +neon -target-feature +fullfp16 -disable-O0-optnone -flax-vector-conversions=none -fclangir -emit-llvm -o - %s | opt -S -passes=mem2reg,sroa | FileCheck %s --check-prefixes=LLVM %}
-// RUN: %if cir-enabled %{%clang_cc1 -triple arm64-none-linux-gnu -target-feature +neon -target-feature +fullfp16 -disable-O0-optnone -flax-vector-conversions=none -fclangir -emit-cir  -o - %s |                               FileCheck %s --check-prefixes=CIR %}
+// RUN: %clang_cc1 -triple arm64-none-linux-gnu -target-feature +neon -target-feature +fullfp16 -disable-O0-optnone -flax-vector-conversions=none -emit-llvm -o - %s | opt -S -passes=mem2reg,sroa | FileCheck %s --check-prefixes=LLVM
+// RUN: %if cir-enabled %{%clang_cc1 -triple arm64-none-linux-gnu -target-feature +neon -target-feature +fullfp16 -disable-O0-optnone -flax-vector-conversions=none -DCIR_SCALAR_F32_F64_ONLY -fclangir -emit-llvm -o - %s | opt -S -passes=mem2reg,sroa | FileCheck %s --check-prefixes=CIRLLVM %}
+// RUN: %if cir-enabled %{%clang_cc1 -triple arm64-none-linux-gnu -target-feature +neon -target-feature +fullfp16 -disable-O0-optnone -flax-vector-conversions=none -DCIR_SCALAR_F32_F64_ONLY -fclangir -emit-cir -o - %s | FileCheck %s --check-prefixes=CIR %}
 
 #include <arm_neon.h>
 
+#ifndef CIR_SCALAR_F32_F64_ONLY
 // LLVM-LABEL: define {{[^@]+}}@test_vfmah_lane_f16
-// LLVM-SAME: (half noundef [[A:%.*]], half noundef [[B:%.*]], <4 x half> noundef [[C:%.*]]) #[[ATTR0:[0-9]+]] {
-// CIR-LABEL: @test_vfmah_lane_f16(
 float16_t test_vfmah_lane_f16(float16_t a, float16_t b, float16x4_t c) {
-  // CIR: cir.vec.extract
-  // CIR: cir.call_llvm_intrinsic "fma"
 
-  // LLVM: [[EXTRACT:%.*]] = extractelement <4 x half> [[C]], i32 3
-  // LLVM: [[TMP0:%.*]] = call half @llvm.fma.f16(half [[B]], half [[EXTRACT]], half [[A]])
-  // LLVM: ret half [[TMP0]]
+// LLVM-SAME: (half {{.*}} [[A:%.*]], half {{.*}} [[B:%.*]], <4 x half> {{.*}} [[C:%.*]]) {{.*}} {
+// LLVM-NEXT:  [[ENTRY:.*:]]
+// LLVM-NEXT:    [[EXTRACT:%.*]] = extractelement <4 x half> [[C]], i32 3
+// LLVM-NEXT:    [[TMP0:%.*]] = call half @llvm.fma.f16(half [[B]], half [[EXTRACT]], half [[A]])
+// LLVM-NEXT:    ret half [[TMP0]]
   return vfmah_lane_f16(a, b, c, 3);
 }
 
 // LLVM-LABEL: define {{[^@]+}}@test_vfmah_laneq_f16
-// LLVM-SAME: (half noundef [[A:%.*]], half noundef [[B:%.*]], <8 x half> noundef [[C:%.*]]) #[[ATTR0]] {
-// CIR-LABEL: @test_vfmah_laneq_f16(
 float16_t test_vfmah_laneq_f16(float16_t a, float16_t b, float16x8_t c) {
-  // CIR: cir.vec.extract
-  // CIR: cir.call_llvm_intrinsic "fma"
 
-  // LLVM: [[EXTRACT:%.*]] = extractelement <8 x half> [[C]], i32 7
-  // LLVM: [[TMP0:%.*]] = call half @llvm.fma.f16(half [[B]], half [[EXTRACT]], half [[A]])
-  // LLVM: ret half [[TMP0]]
+// LLVM-SAME: (half {{.*}} [[A:%.*]], half {{.*}} [[B:%.*]], <8 x half> {{.*}} [[C:%.*]]) {{.*}} {
+// LLVM-NEXT:  [[ENTRY:.*:]]
+// LLVM-NEXT:    [[EXTRACT:%.*]] = extractelement <8 x half> [[C]], i32 7
+// LLVM-NEXT:    [[TMP0:%.*]] = call half @llvm.fma.f16(half [[B]], half [[EXTRACT]], half [[A]])
+// LLVM-NEXT:    ret half [[TMP0]]
   return vfmah_laneq_f16(a, b, c, 7);
 }
+#endif
 
 // LLVM-LABEL: define dso_local float @test_vfmas_lane_f32(
-// LLVM-SAME: float noundef [[A:%.*]], float noundef [[B:%.*]], <2 x float> noundef [[C:%.*]]) #[[ATTR0]] {
+// CIRLLVM-LABEL: define dso_local float @test_vfmas_lane_f32(
 // CIR-LABEL: @test_vfmas_lane_f32(
 float32_t test_vfmas_lane_f32(float32_t a, float32_t b, float32x2_t c) {
-  // CIR: cir.vec.extract
-  // CIR: cir.call_llvm_intrinsic "fma"
+// CIR: cir.vec.extract
+// CIR: cir.call_llvm_intrinsic "fma"
 
-  // LLVM: [[EXTRACT:%.*]] = extractelement <2 x float> [[C]], i32 1
-  // LLVM: [[TMP0:%.*]] = call float @llvm.fma.f32(float [[B]], float [[EXTRACT]], float [[A]])
-  // LLVM: ret float [[TMP0]]
+// CIRLLVM:      [[EXTRACT:%.*]] = extractelement <2 x float> {{.*}}, i32 1
+// CIRLLVM-NEXT: [[RES:%.*]] = call float @llvm.fma.f32(float {{.*}}, float [[EXTRACT]], float {{.*}})
+
+// LLVM-SAME: float {{.*}} [[A:%.*]], float {{.*}} [[B:%.*]], <2 x float> {{.*}} [[C:%.*]]) {{.*}} {
+// LLVM-NEXT:  [[ENTRY:.*:]]
+// LLVM-NEXT:    [[EXTRACT:%.*]] = extractelement <2 x float> [[C]], i32 1
+// LLVM-NEXT:    [[TMP0:%.*]] = call float @llvm.fma.f32(float [[B]], float [[EXTRACT]], float [[A]])
+// LLVM-NEXT:    ret float [[TMP0]]
   return vfmas_lane_f32(a, b, c, 1);
 }
 
 // LLVM-LABEL: define dso_local float @test_vfmas_laneq_f32(
-// LLVM-SAME: float noundef [[A:%.*]], float noundef [[B:%.*]], <4 x float> noundef [[C:%.*]]) #[[ATTR0]] {
+// CIRLLVM-LABEL: define dso_local float @test_vfmas_laneq_f32(
 // CIR-LABEL: @test_vfmas_laneq_f32(
 float32_t test_vfmas_laneq_f32(float32_t a, float32_t b, float32x4_t c) {
-  // CIR: cir.vec.extract
-  // CIR: cir.call_llvm_intrinsic "fma"
+// CIR: cir.vec.extract
+// CIR: cir.call_llvm_intrinsic "fma"
 
-  // LLVM: [[EXTRACT:%.*]] = extractelement <4 x float> [[C]], i32 3
-  // LLVM: [[TMP0:%.*]] = call float @llvm.fma.f32(float [[B]], float [[EXTRACT]], float [[A]])
-  // LLVM: ret float [[TMP0]]
+// CIRLLVM:      [[EXTRACT:%.*]] = extractelement <4 x float> {{.*}}, i32 3
+// CIRLLVM-NEXT: [[RES:%.*]] = call float @llvm.fma.f32(float {{.*}}, float [[EXTRACT]], float {{.*}})
+
+// LLVM-SAME: float {{.*}} [[A:%.*]], float {{.*}} [[B:%.*]], <4 x float> {{.*}} [[C:%.*]]) {{.*}} {
+// LLVM-NEXT:  [[ENTRY:.*:]]
+// LLVM-NEXT:    [[EXTRACT:%.*]] = extractelement <4 x float> [[C]], i32 3
+// LLVM-NEXT:    [[TMP0:%.*]] = call float @llvm.fma.f32(float [[B]], float [[EXTRACT]], float [[A]])
+// LLVM-NEXT:    ret float [[TMP0]]
   return vfmas_laneq_f32(a, b, c, 3);
 }
 
 // LLVM-LABEL: define dso_local double @test_vfmad_lane_f64(
-// LLVM-SAME: double noundef [[A:%.*]], double noundef [[B:%.*]], <1 x double> noundef [[C:%.*]]) #[[ATTR0]] {
+// CIRLLVM-LABEL: define dso_local double @test_vfmad_lane_f64(
 // CIR-LABEL: @test_vfmad_lane_f64(
 float64_t test_vfmad_lane_f64(float64_t a, float64_t b, float64x1_t c) {
-  // CIR: cir.vec.extract
-  // CIR: cir.call_llvm_intrinsic "fma"
+// CIR: cir.vec.extract
+// CIR: cir.call_llvm_intrinsic "fma"
 
-  // LLVM: [[EXTRACT:%.*]] = extractelement <1 x double> [[C]], i32 0
-  // LLVM: [[TMP0:%.*]] = call double @llvm.fma.f64(double [[B]], double [[EXTRACT]], double [[A]])
-  // LLVM: ret double [[TMP0]]
+// CIRLLVM:      [[EXTRACT:%.*]] = extractelement <1 x double> {{.*}}, i32 0
+// CIRLLVM-NEXT: [[RES:%.*]] = call double @llvm.fma.f64(double {{.*}}, double [[EXTRACT]], double {{.*}})
+
+// LLVM-SAME: double {{.*}} [[A:%.*]], double {{.*}} [[B:%.*]], <1 x double> {{.*}} [[C:%.*]]) {{.*}} {
+// LLVM-NEXT:  [[ENTRY:.*:]]
+// LLVM-NEXT:    [[EXTRACT:%.*]] = extractelement <1 x double> [[C]], i32 0
+// LLVM-NEXT:    [[TMP0:%.*]] = call double @llvm.fma.f64(double [[B]], double [[EXTRACT]], double [[A]])
+// LLVM-NEXT:    ret double [[TMP0]]
   return vfmad_lane_f64(a, b, c, 0);
 }
 
 // LLVM-LABEL: define dso_local double @test_vfmad_laneq_f64(
-// LLVM-SAME: double noundef [[A:%.*]], double noundef [[B:%.*]], <2 x double> noundef [[C:%.*]]) #[[ATTR0]] {
+// CIRLLVM-LABEL: define dso_local double @test_vfmad_laneq_f64(
 // CIR-LABEL: @test_vfmad_laneq_f64(
 float64_t test_vfmad_laneq_f64(float64_t a, float64_t b, float64x2_t c) {
-  // CIR: cir.vec.extract
-  // CIR: cir.call_llvm_intrinsic "fma"
+// CIR: cir.vec.extract
+// CIR: cir.call_llvm_intrinsic "fma"
 
-  // LLVM: [[EXTRACT:%.*]] = extractelement <2 x double> [[C]], i32 1
-  // LLVM: [[TMP0:%.*]] = call double @llvm.fma.f64(double [[B]], double [[EXTRACT]], double [[A]])
-  // LLVM: ret double [[TMP0]]
+// CIRLLVM:      [[EXTRACT:%.*]] = extractelement <2 x double> {{.*}}, i32 1
+// CIRLLVM-NEXT: [[RES:%.*]] = call double @llvm.fma.f64(double {{.*}}, double [[EXTRACT]], double {{.*}})
+
+// LLVM-SAME: double {{.*}} [[A:%.*]], double {{.*}} [[B:%.*]], <2 x double> {{.*}} [[C:%.*]]) {{.*}} {
+// LLVM-NEXT:  [[ENTRY:.*:]]
+// LLVM-NEXT:    [[EXTRACT:%.*]] = extractelement <2 x double> [[C]], i32 1
+// LLVM-NEXT:    [[TMP0:%.*]] = call double @llvm.fma.f64(double [[B]], double [[EXTRACT]], double [[A]])
+// LLVM-NEXT:    ret double [[TMP0]]
   return vfmad_laneq_f64(a, b, c, 1);
 }

--- a/clang/test/CodeGen/AArch64/neon/vfma-scalar-lane.c
+++ b/clang/test/CodeGen/AArch64/neon/vfma-scalar-lane.c
@@ -30,15 +30,14 @@
 // CIRLLVM-LABEL: @test_vfmas_lane_f32(
 // CIR-LABEL: @test_vfmas_lane_f32(
 float32_t test_vfmas_lane_f32(float32_t a, float32_t b, float32x2_t c) {
-// CIR: cir.vec.extract
-// CIR: cir.call_llvm_intrinsic "fma"
+// CIR:      [[EXTRACT:%.*]] = cir.vec.extract %{{.*}}[%{{.*}} : !s32i] : !cir.vector<2 x !cir.float>
+// CIR-NEXT: [[RES:%.*]] = cir.call_llvm_intrinsic "fma" %{{.*}}, [[EXTRACT]], %{{.*}} : (!cir.float, !cir.float, !cir.float) -> !cir.float
 
 // CIRLLVM:      [[EXTRACT:%.*]] = extractelement <2 x float> {{.*}}, i32 1
 // CIRLLVM-NEXT: [[RES:%.*]] = call float @llvm.fma.f32(float {{.*}}, float [[EXTRACT]], float {{.*}})
 
 // LLVM-SAME: float {{.*}} [[A:%.*]], float {{.*}} [[B:%.*]], <2 x float> {{.*}} [[C:%.*]]) {{.*}} {
-// LLVM-NEXT:  [[ENTRY:.*:]]
-// LLVM-NEXT:    [[EXTRACT:%.*]] = extractelement <2 x float> [[C]], i32 1
+// LLVM:         [[EXTRACT:%.*]] = extractelement <2 x float> [[C]], i32 1
 // LLVM-NEXT:    [[TMP0:%.*]] = call float @llvm.fma.f32(float [[B]], float [[EXTRACT]], float [[A]])
 // LLVM-NEXT:    ret float [[TMP0]]
   return vfmas_lane_f32(a, b, c, 1);
@@ -48,15 +47,14 @@ float32_t test_vfmas_lane_f32(float32_t a, float32_t b, float32x2_t c) {
 // CIRLLVM-LABEL: @test_vfmas_laneq_f32(
 // CIR-LABEL: @test_vfmas_laneq_f32(
 float32_t test_vfmas_laneq_f32(float32_t a, float32_t b, float32x4_t c) {
-// CIR: cir.vec.extract
-// CIR: cir.call_llvm_intrinsic "fma"
+// CIR:      [[EXTRACT:%.*]] = cir.vec.extract %{{.*}}[%{{.*}} : !s32i] : !cir.vector<4 x !cir.float>
+// CIR-NEXT: [[RES:%.*]] = cir.call_llvm_intrinsic "fma" %{{.*}}, [[EXTRACT]], %{{.*}} : (!cir.float, !cir.float, !cir.float) -> !cir.float
 
 // CIRLLVM:      [[EXTRACT:%.*]] = extractelement <4 x float> {{.*}}, i32 3
 // CIRLLVM-NEXT: [[RES:%.*]] = call float @llvm.fma.f32(float {{.*}}, float [[EXTRACT]], float {{.*}})
 
 // LLVM-SAME: float {{.*}} [[A:%.*]], float {{.*}} [[B:%.*]], <4 x float> {{.*}} [[C:%.*]]) {{.*}} {
-// LLVM-NEXT:  [[ENTRY:.*:]]
-// LLVM-NEXT:    [[EXTRACT:%.*]] = extractelement <4 x float> [[C]], i32 3
+// LLVM:         [[EXTRACT:%.*]] = extractelement <4 x float> [[C]], i32 3
 // LLVM-NEXT:    [[TMP0:%.*]] = call float @llvm.fma.f32(float [[B]], float [[EXTRACT]], float [[A]])
 // LLVM-NEXT:    ret float [[TMP0]]
   return vfmas_laneq_f32(a, b, c, 3);
@@ -66,15 +64,14 @@ float32_t test_vfmas_laneq_f32(float32_t a, float32_t b, float32x4_t c) {
 // CIRLLVM-LABEL: @test_vfmad_lane_f64(
 // CIR-LABEL: @test_vfmad_lane_f64(
 float64_t test_vfmad_lane_f64(float64_t a, float64_t b, float64x1_t c) {
-// CIR: cir.vec.extract
-// CIR: cir.call_llvm_intrinsic "fma"
+// CIR:      [[EXTRACT:%.*]] = cir.vec.extract %{{.*}}[%{{.*}} : !s32i] : !cir.vector<1 x !cir.double>
+// CIR-NEXT: [[RES:%.*]] = cir.call_llvm_intrinsic "fma" %{{.*}}, [[EXTRACT]], %{{.*}} : (!cir.double, !cir.double, !cir.double) -> !cir.double
 
 // CIRLLVM:      [[EXTRACT:%.*]] = extractelement <1 x double> {{.*}}, i32 0
 // CIRLLVM-NEXT: [[RES:%.*]] = call double @llvm.fma.f64(double {{.*}}, double [[EXTRACT]], double {{.*}})
 
 // LLVM-SAME: double {{.*}} [[A:%.*]], double {{.*}} [[B:%.*]], <1 x double> {{.*}} [[C:%.*]]) {{.*}} {
-// LLVM-NEXT:  [[ENTRY:.*:]]
-// LLVM-NEXT:    [[EXTRACT:%.*]] = extractelement <1 x double> [[C]], i32 0
+// LLVM:         [[EXTRACT:%.*]] = extractelement <1 x double> [[C]], i32 0
 // LLVM-NEXT:    [[TMP0:%.*]] = call double @llvm.fma.f64(double [[B]], double [[EXTRACT]], double [[A]])
 // LLVM-NEXT:    ret double [[TMP0]]
   return vfmad_lane_f64(a, b, c, 0);
@@ -84,15 +81,14 @@ float64_t test_vfmad_lane_f64(float64_t a, float64_t b, float64x1_t c) {
 // CIRLLVM-LABEL: @test_vfmad_laneq_f64(
 // CIR-LABEL: @test_vfmad_laneq_f64(
 float64_t test_vfmad_laneq_f64(float64_t a, float64_t b, float64x2_t c) {
-// CIR: cir.vec.extract
-// CIR: cir.call_llvm_intrinsic "fma"
+// CIR:      [[EXTRACT:%.*]] = cir.vec.extract %{{.*}}[%{{.*}} : !s32i] : !cir.vector<2 x !cir.double>
+// CIR-NEXT: [[RES:%.*]] = cir.call_llvm_intrinsic "fma" %{{.*}}, [[EXTRACT]], %{{.*}} : (!cir.double, !cir.double, !cir.double) -> !cir.double
 
 // CIRLLVM:      [[EXTRACT:%.*]] = extractelement <2 x double> {{.*}}, i32 1
 // CIRLLVM-NEXT: [[RES:%.*]] = call double @llvm.fma.f64(double {{.*}}, double [[EXTRACT]], double {{.*}})
 
 // LLVM-SAME: double {{.*}} [[A:%.*]], double {{.*}} [[B:%.*]], <2 x double> {{.*}} [[C:%.*]]) {{.*}} {
-// LLVM-NEXT:  [[ENTRY:.*:]]
-// LLVM-NEXT:    [[EXTRACT:%.*]] = extractelement <2 x double> [[C]], i32 1
+// LLVM:         [[EXTRACT:%.*]] = extractelement <2 x double> [[C]], i32 1
 // LLVM-NEXT:    [[TMP0:%.*]] = call double @llvm.fma.f64(double [[B]], double [[EXTRACT]], double [[A]])
 // LLVM-NEXT:    ret double [[TMP0]]
   return vfmad_laneq_f64(a, b, c, 1);

--- a/clang/test/CodeGen/AArch64/neon/vfma-scalar-lane.c
+++ b/clang/test/CodeGen/AArch64/neon/vfma-scalar-lane.c
@@ -31,10 +31,10 @@
 // CIR-LABEL: @test_vfmas_lane_f32(
 float32_t test_vfmas_lane_f32(float32_t a, float32_t b, float32x2_t c) {
 // CIR:      [[EXTRACT:%.*]] = cir.vec.extract %{{.*}}[%{{.*}} : !s32i] : !cir.vector<2 x !cir.float>
-// CIR-NEXT: [[RES:%.*]] = cir.call_llvm_intrinsic "fma" %{{.*}}, [[EXTRACT]], %{{.*}} : (!cir.float, !cir.float, !cir.float) -> !cir.float
+// CIR-NEXT: {{%.*}} = cir.call_llvm_intrinsic "fma" %{{.*}}, [[EXTRACT]], %{{.*}} : (!cir.float, !cir.float, !cir.float) -> !cir.float
 
 // CIRLLVM:      [[EXTRACT:%.*]] = extractelement <2 x float> {{.*}}, i32 1
-// CIRLLVM-NEXT: [[RES:%.*]] = call float @llvm.fma.f32(float {{.*}}, float [[EXTRACT]], float {{.*}})
+// CIRLLVM-NEXT: {{%.*}} = call float @llvm.fma.f32(float {{.*}}, float [[EXTRACT]], float {{.*}})
 
 // LLVM-SAME: float {{.*}} [[A:%.*]], float {{.*}} [[B:%.*]], <2 x float> {{.*}} [[C:%.*]]) {{.*}} {
 // LLVM:         [[EXTRACT:%.*]] = extractelement <2 x float> [[C]], i32 1
@@ -48,10 +48,10 @@ float32_t test_vfmas_lane_f32(float32_t a, float32_t b, float32x2_t c) {
 // CIR-LABEL: @test_vfmas_laneq_f32(
 float32_t test_vfmas_laneq_f32(float32_t a, float32_t b, float32x4_t c) {
 // CIR:      [[EXTRACT:%.*]] = cir.vec.extract %{{.*}}[%{{.*}} : !s32i] : !cir.vector<4 x !cir.float>
-// CIR-NEXT: [[RES:%.*]] = cir.call_llvm_intrinsic "fma" %{{.*}}, [[EXTRACT]], %{{.*}} : (!cir.float, !cir.float, !cir.float) -> !cir.float
+// CIR-NEXT: {{%.*}} = cir.call_llvm_intrinsic "fma" %{{.*}}, [[EXTRACT]], %{{.*}} : (!cir.float, !cir.float, !cir.float) -> !cir.float
 
 // CIRLLVM:      [[EXTRACT:%.*]] = extractelement <4 x float> {{.*}}, i32 3
-// CIRLLVM-NEXT: [[RES:%.*]] = call float @llvm.fma.f32(float {{.*}}, float [[EXTRACT]], float {{.*}})
+// CIRLLVM-NEXT: {{%.*}} = call float @llvm.fma.f32(float {{.*}}, float [[EXTRACT]], float {{.*}})
 
 // LLVM-SAME: float {{.*}} [[A:%.*]], float {{.*}} [[B:%.*]], <4 x float> {{.*}} [[C:%.*]]) {{.*}} {
 // LLVM:         [[EXTRACT:%.*]] = extractelement <4 x float> [[C]], i32 3
@@ -65,10 +65,10 @@ float32_t test_vfmas_laneq_f32(float32_t a, float32_t b, float32x4_t c) {
 // CIR-LABEL: @test_vfmad_lane_f64(
 float64_t test_vfmad_lane_f64(float64_t a, float64_t b, float64x1_t c) {
 // CIR:      [[EXTRACT:%.*]] = cir.vec.extract %{{.*}}[%{{.*}} : !s32i] : !cir.vector<1 x !cir.double>
-// CIR-NEXT: [[RES:%.*]] = cir.call_llvm_intrinsic "fma" %{{.*}}, [[EXTRACT]], %{{.*}} : (!cir.double, !cir.double, !cir.double) -> !cir.double
+// CIR-NEXT: {{%.*}} = cir.call_llvm_intrinsic "fma" %{{.*}}, [[EXTRACT]], %{{.*}} : (!cir.double, !cir.double, !cir.double) -> !cir.double
 
 // CIRLLVM:      [[EXTRACT:%.*]] = extractelement <1 x double> {{.*}}, i32 0
-// CIRLLVM-NEXT: [[RES:%.*]] = call double @llvm.fma.f64(double {{.*}}, double [[EXTRACT]], double {{.*}})
+// CIRLLVM-NEXT: {{%.*}} = call double @llvm.fma.f64(double {{.*}}, double [[EXTRACT]], double {{.*}})
 
 // LLVM-SAME: double {{.*}} [[A:%.*]], double {{.*}} [[B:%.*]], <1 x double> {{.*}} [[C:%.*]]) {{.*}} {
 // LLVM:         [[EXTRACT:%.*]] = extractelement <1 x double> [[C]], i32 0
@@ -82,10 +82,10 @@ float64_t test_vfmad_lane_f64(float64_t a, float64_t b, float64x1_t c) {
 // CIR-LABEL: @test_vfmad_laneq_f64(
 float64_t test_vfmad_laneq_f64(float64_t a, float64_t b, float64x2_t c) {
 // CIR:      [[EXTRACT:%.*]] = cir.vec.extract %{{.*}}[%{{.*}} : !s32i] : !cir.vector<2 x !cir.double>
-// CIR-NEXT: [[RES:%.*]] = cir.call_llvm_intrinsic "fma" %{{.*}}, [[EXTRACT]], %{{.*}} : (!cir.double, !cir.double, !cir.double) -> !cir.double
+// CIR-NEXT: {{%.*}} = cir.call_llvm_intrinsic "fma" %{{.*}}, [[EXTRACT]], %{{.*}} : (!cir.double, !cir.double, !cir.double) -> !cir.double
 
 // CIRLLVM:      [[EXTRACT:%.*]] = extractelement <2 x double> {{.*}}, i32 1
-// CIRLLVM-NEXT: [[RES:%.*]] = call double @llvm.fma.f64(double {{.*}}, double [[EXTRACT]], double {{.*}})
+// CIRLLVM-NEXT: {{%.*}} = call double @llvm.fma.f64(double {{.*}}, double [[EXTRACT]], double {{.*}})
 
 // LLVM-SAME: double {{.*}} [[A:%.*]], double {{.*}} [[B:%.*]], <2 x double> {{.*}} [[C:%.*]]) {{.*}} {
 // LLVM:         [[EXTRACT:%.*]] = extractelement <2 x double> [[C]], i32 1

--- a/clang/test/CodeGen/AArch64/neon/vfma-scalar-lane.c
+++ b/clang/test/CodeGen/AArch64/neon/vfma-scalar-lane.c
@@ -1,37 +1,33 @@
 // REQUIRES: aarch64-registered-target
 
-// RUN: %clang_cc1 -triple arm64-none-linux-gnu -target-feature +neon -target-feature +fullfp16 -disable-O0-optnone -flax-vector-conversions=none -emit-llvm -o - %s | opt -S -passes=mem2reg,sroa | FileCheck %s --check-prefixes=LLVM
-// RUN: %if cir-enabled %{%clang_cc1 -triple arm64-none-linux-gnu -target-feature +neon -target-feature +fullfp16 -disable-O0-optnone -flax-vector-conversions=none -DCIR_SCALAR_F32_F64_ONLY -fclangir -emit-llvm -o - %s | opt -S -passes=mem2reg,sroa | FileCheck %s --check-prefixes=CIRLLVM %}
-// RUN: %if cir-enabled %{%clang_cc1 -triple arm64-none-linux-gnu -target-feature +neon -target-feature +fullfp16 -disable-O0-optnone -flax-vector-conversions=none -DCIR_SCALAR_F32_F64_ONLY -fclangir -emit-cir -o - %s | FileCheck %s --check-prefixes=CIR %}
+// RUN:                   %clang_cc1 -triple arm64-none-linux-gnu -target-feature +neon -disable-O0-optnone -flax-vector-conversions=none           -emit-llvm -o - %s | opt -S -passes=mem2reg,sroa | FileCheck %s --check-prefixes=LLVM
+// RUN: %if cir-enabled %{%clang_cc1 -triple arm64-none-linux-gnu -target-feature +neon -disable-O0-optnone -flax-vector-conversions=none -fclangir -emit-llvm -o - %s | opt -S -passes=mem2reg,sroa | FileCheck %s --check-prefixes=CIRLLVM %}
+// RUN: %if cir-enabled %{%clang_cc1 -triple arm64-none-linux-gnu -target-feature +neon -disable-O0-optnone -flax-vector-conversions=none -fclangir -emit-cir  -o - %s |                               FileCheck %s --check-prefixes=CIR %}
+
+//=============================================================================
+// NOTES
+//
+// This file contains tests that were originally located in:
+//  * clang/test/CodeGen/AArch64/neon-2velem.c
+//  * clang/test/CodeGen/AArch64/neon-scalar-x-indexed-elem.c
+// The main difference is the use of RUN lines that enable ClangIR lowering;
+// therefore only the non-f16 forms currently supported by ClangIR are tested
+// here.
+// Once ClangIR support is complete, this file is intended to replace the
+// original test coverage in those legacy files.
+//
+// ACLE section headings based on v2025Q2 of the ACLE specification:
+//  * https://arm-software.github.io/acle/neon_intrinsics/advsimd.html#fused-multiply-accumulate
+//
+//=============================================================================
 
 #include <arm_neon.h>
 
-#ifndef CIR_SCALAR_F32_F64_ONLY
-// LLVM-LABEL: define {{[^@]+}}@test_vfmah_lane_f16
-float16_t test_vfmah_lane_f16(float16_t a, float16_t b, float16x4_t c) {
-
-// LLVM-SAME: (half {{.*}} [[A:%.*]], half {{.*}} [[B:%.*]], <4 x half> {{.*}} [[C:%.*]]) {{.*}} {
-// LLVM-NEXT:  [[ENTRY:.*:]]
-// LLVM-NEXT:    [[EXTRACT:%.*]] = extractelement <4 x half> [[C]], i32 3
-// LLVM-NEXT:    [[TMP0:%.*]] = call half @llvm.fma.f16(half [[B]], half [[EXTRACT]], half [[A]])
-// LLVM-NEXT:    ret half [[TMP0]]
-  return vfmah_lane_f16(a, b, c, 3);
-}
-
-// LLVM-LABEL: define {{[^@]+}}@test_vfmah_laneq_f16
-float16_t test_vfmah_laneq_f16(float16_t a, float16_t b, float16x8_t c) {
-
-// LLVM-SAME: (half {{.*}} [[A:%.*]], half {{.*}} [[B:%.*]], <8 x half> {{.*}} [[C:%.*]]) {{.*}} {
-// LLVM-NEXT:  [[ENTRY:.*:]]
-// LLVM-NEXT:    [[EXTRACT:%.*]] = extractelement <8 x half> [[C]], i32 7
-// LLVM-NEXT:    [[TMP0:%.*]] = call half @llvm.fma.f16(half [[B]], half [[EXTRACT]], half [[A]])
-// LLVM-NEXT:    ret half [[TMP0]]
-  return vfmah_laneq_f16(a, b, c, 7);
-}
-#endif
-
-// LLVM-LABEL: define dso_local float @test_vfmas_lane_f32(
-// CIRLLVM-LABEL: define dso_local float @test_vfmas_lane_f32(
+//===------------------------------------------------------===//
+// Fused multiply-accumulate lane/laneq, scalar forms
+//===------------------------------------------------------===//
+// LLVM-LABEL: @test_vfmas_lane_f32(
+// CIRLLVM-LABEL: @test_vfmas_lane_f32(
 // CIR-LABEL: @test_vfmas_lane_f32(
 float32_t test_vfmas_lane_f32(float32_t a, float32_t b, float32x2_t c) {
 // CIR: cir.vec.extract
@@ -48,8 +44,8 @@ float32_t test_vfmas_lane_f32(float32_t a, float32_t b, float32x2_t c) {
   return vfmas_lane_f32(a, b, c, 1);
 }
 
-// LLVM-LABEL: define dso_local float @test_vfmas_laneq_f32(
-// CIRLLVM-LABEL: define dso_local float @test_vfmas_laneq_f32(
+// LLVM-LABEL: @test_vfmas_laneq_f32(
+// CIRLLVM-LABEL: @test_vfmas_laneq_f32(
 // CIR-LABEL: @test_vfmas_laneq_f32(
 float32_t test_vfmas_laneq_f32(float32_t a, float32_t b, float32x4_t c) {
 // CIR: cir.vec.extract
@@ -66,8 +62,8 @@ float32_t test_vfmas_laneq_f32(float32_t a, float32_t b, float32x4_t c) {
   return vfmas_laneq_f32(a, b, c, 3);
 }
 
-// LLVM-LABEL: define dso_local double @test_vfmad_lane_f64(
-// CIRLLVM-LABEL: define dso_local double @test_vfmad_lane_f64(
+// LLVM-LABEL: @test_vfmad_lane_f64(
+// CIRLLVM-LABEL: @test_vfmad_lane_f64(
 // CIR-LABEL: @test_vfmad_lane_f64(
 float64_t test_vfmad_lane_f64(float64_t a, float64_t b, float64x1_t c) {
 // CIR: cir.vec.extract
@@ -84,8 +80,8 @@ float64_t test_vfmad_lane_f64(float64_t a, float64_t b, float64x1_t c) {
   return vfmad_lane_f64(a, b, c, 0);
 }
 
-// LLVM-LABEL: define dso_local double @test_vfmad_laneq_f64(
-// CIRLLVM-LABEL: define dso_local double @test_vfmad_laneq_f64(
+// LLVM-LABEL: @test_vfmad_laneq_f64(
+// CIRLLVM-LABEL: @test_vfmad_laneq_f64(
 // CIR-LABEL: @test_vfmad_laneq_f64(
 float64_t test_vfmad_laneq_f64(float64_t a, float64_t b, float64x2_t c) {
 // CIR: cir.vec.extract

--- a/clang/test/CodeGen/AArch64/neon/vfma-scalar-lane.c
+++ b/clang/test/CodeGen/AArch64/neon/vfma-scalar-lane.c
@@ -6,62 +6,80 @@
 
 #include <arm_neon.h>
 
-// LLVM-LABEL: @test_vfmah_lane_f16(
-// LLVM: extractelement <4 x half>
-// LLVM: call half @llvm.fma.f16(
+// LLVM-LABEL: define {{[^@]+}}@test_vfmah_lane_f16
+// LLVM-SAME: (half noundef [[A:%.*]], half noundef [[B:%.*]], <4 x half> noundef [[C:%.*]]) #[[ATTR0:[0-9]+]] {
 // CIR-LABEL: @test_vfmah_lane_f16(
-// CIR: cir.vec.extract
-// CIR: cir.call_llvm_intrinsic "fma"
 float16_t test_vfmah_lane_f16(float16_t a, float16_t b, float16x4_t c) {
+  // CIR: cir.vec.extract
+  // CIR: cir.call_llvm_intrinsic "fma"
+
+  // LLVM: [[EXTRACT:%.*]] = extractelement <4 x half> [[C]], i32 3
+  // LLVM: [[TMP0:%.*]] = call half @llvm.fma.f16(half [[B]], half [[EXTRACT]], half [[A]])
+  // LLVM: ret half [[TMP0]]
   return vfmah_lane_f16(a, b, c, 3);
 }
 
-// LLVM-LABEL: @test_vfmah_laneq_f16(
-// LLVM: extractelement <8 x half>
-// LLVM: call half @llvm.fma.f16(
+// LLVM-LABEL: define {{[^@]+}}@test_vfmah_laneq_f16
+// LLVM-SAME: (half noundef [[A:%.*]], half noundef [[B:%.*]], <8 x half> noundef [[C:%.*]]) #[[ATTR0]] {
 // CIR-LABEL: @test_vfmah_laneq_f16(
-// CIR: cir.vec.extract
-// CIR: cir.call_llvm_intrinsic "fma"
 float16_t test_vfmah_laneq_f16(float16_t a, float16_t b, float16x8_t c) {
+  // CIR: cir.vec.extract
+  // CIR: cir.call_llvm_intrinsic "fma"
+
+  // LLVM: [[EXTRACT:%.*]] = extractelement <8 x half> [[C]], i32 7
+  // LLVM: [[TMP0:%.*]] = call half @llvm.fma.f16(half [[B]], half [[EXTRACT]], half [[A]])
+  // LLVM: ret half [[TMP0]]
   return vfmah_laneq_f16(a, b, c, 7);
 }
 
-// LLVM-LABEL: @test_vfmas_lane_f32(
-// LLVM: extractelement <2 x float>
-// LLVM: call float @llvm.fma.f32(
+// LLVM-LABEL: define dso_local float @test_vfmas_lane_f32(
+// LLVM-SAME: float noundef [[A:%.*]], float noundef [[B:%.*]], <2 x float> noundef [[C:%.*]]) #[[ATTR0]] {
 // CIR-LABEL: @test_vfmas_lane_f32(
-// CIR: cir.vec.extract
-// CIR: cir.call_llvm_intrinsic "fma"
 float32_t test_vfmas_lane_f32(float32_t a, float32_t b, float32x2_t c) {
+  // CIR: cir.vec.extract
+  // CIR: cir.call_llvm_intrinsic "fma"
+
+  // LLVM: [[EXTRACT:%.*]] = extractelement <2 x float> [[C]], i32 1
+  // LLVM: [[TMP0:%.*]] = call float @llvm.fma.f32(float [[B]], float [[EXTRACT]], float [[A]])
+  // LLVM: ret float [[TMP0]]
   return vfmas_lane_f32(a, b, c, 1);
 }
 
-// LLVM-LABEL: @test_vfmas_laneq_f32(
-// LLVM: extractelement <4 x float>
-// LLVM: call float @llvm.fma.f32(
+// LLVM-LABEL: define dso_local float @test_vfmas_laneq_f32(
+// LLVM-SAME: float noundef [[A:%.*]], float noundef [[B:%.*]], <4 x float> noundef [[C:%.*]]) #[[ATTR0]] {
 // CIR-LABEL: @test_vfmas_laneq_f32(
-// CIR: cir.vec.extract
-// CIR: cir.call_llvm_intrinsic "fma"
 float32_t test_vfmas_laneq_f32(float32_t a, float32_t b, float32x4_t c) {
+  // CIR: cir.vec.extract
+  // CIR: cir.call_llvm_intrinsic "fma"
+
+  // LLVM: [[EXTRACT:%.*]] = extractelement <4 x float> [[C]], i32 3
+  // LLVM: [[TMP0:%.*]] = call float @llvm.fma.f32(float [[B]], float [[EXTRACT]], float [[A]])
+  // LLVM: ret float [[TMP0]]
   return vfmas_laneq_f32(a, b, c, 3);
 }
 
-// LLVM-LABEL: @test_vfmad_lane_f64(
-// LLVM: extractelement <1 x double>
-// LLVM: call double @llvm.fma.f64(
+// LLVM-LABEL: define dso_local double @test_vfmad_lane_f64(
+// LLVM-SAME: double noundef [[A:%.*]], double noundef [[B:%.*]], <1 x double> noundef [[C:%.*]]) #[[ATTR0]] {
 // CIR-LABEL: @test_vfmad_lane_f64(
-// CIR: cir.vec.extract
-// CIR: cir.call_llvm_intrinsic "fma"
 float64_t test_vfmad_lane_f64(float64_t a, float64_t b, float64x1_t c) {
+  // CIR: cir.vec.extract
+  // CIR: cir.call_llvm_intrinsic "fma"
+
+  // LLVM: [[EXTRACT:%.*]] = extractelement <1 x double> [[C]], i32 0
+  // LLVM: [[TMP0:%.*]] = call double @llvm.fma.f64(double [[B]], double [[EXTRACT]], double [[A]])
+  // LLVM: ret double [[TMP0]]
   return vfmad_lane_f64(a, b, c, 0);
 }
 
-// LLVM-LABEL: @test_vfmad_laneq_f64(
-// LLVM: extractelement <2 x double>
-// LLVM: call double @llvm.fma.f64(
+// LLVM-LABEL: define dso_local double @test_vfmad_laneq_f64(
+// LLVM-SAME: double noundef [[A:%.*]], double noundef [[B:%.*]], <2 x double> noundef [[C:%.*]]) #[[ATTR0]] {
 // CIR-LABEL: @test_vfmad_laneq_f64(
-// CIR: cir.vec.extract
-// CIR: cir.call_llvm_intrinsic "fma"
 float64_t test_vfmad_laneq_f64(float64_t a, float64_t b, float64x2_t c) {
+  // CIR: cir.vec.extract
+  // CIR: cir.call_llvm_intrinsic "fma"
+
+  // LLVM: [[EXTRACT:%.*]] = extractelement <2 x double> [[C]], i32 1
+  // LLVM: [[TMP0:%.*]] = call double @llvm.fma.f64(double [[B]], double [[EXTRACT]], double [[A]])
+  // LLVM: ret double [[TMP0]]
   return vfmad_laneq_f64(a, b, c, 1);
 }

--- a/clang/test/CodeGen/AArch64/v8.2a-neon-intrinsics.c
+++ b/clang/test/CodeGen/AArch64/v8.2a-neon-intrinsics.c
@@ -1679,87 +1679,6 @@ float16x4_t test_vfms_f16(float16x4_t a, float16x4_t b, float16x4_t c) {
 float16x8_t test_vfmsq_f16(float16x8_t a, float16x8_t b, float16x8_t c) {
   return vfmsq_f16(a, b, c);
 }
-
-// CHECK-LABEL: define {{[^@]+}}@test_vfma_lane_f16
-// CHECK-SAME: (<4 x half> noundef [[A:%.*]], <4 x half> noundef [[B:%.*]], <4 x half> noundef [[C:%.*]]) #[[ATTR0]] {
-// CHECK-NEXT:  entry:
-// CHECK-NEXT:    [[TMP0:%.*]] = bitcast <4 x half> [[A]] to <4 x i16>
-// CHECK-NEXT:    [[TMP1:%.*]] = bitcast <4 x half> [[B]] to <4 x i16>
-// CHECK-NEXT:    [[TMP2:%.*]] = bitcast <4 x half> [[C]] to <4 x i16>
-// CHECK-NEXT:    [[TMP3:%.*]] = bitcast <4 x i16> [[TMP0]] to <8 x i8>
-// CHECK-NEXT:    [[TMP4:%.*]] = bitcast <4 x i16> [[TMP1]] to <8 x i8>
-// CHECK-NEXT:    [[TMP5:%.*]] = bitcast <4 x i16> [[TMP2]] to <8 x i8>
-// CHECK-NEXT:    [[TMP6:%.*]] = bitcast <8 x i8> [[TMP5]] to <4 x half>
-// CHECK-NEXT:    [[LANE:%.*]] = shufflevector <4 x half> [[TMP6]], <4 x half> [[TMP6]], <4 x i32> <i32 3, i32 3, i32 3, i32 3>
-// CHECK-NEXT:    [[FMLA:%.*]] = bitcast <8 x i8> [[TMP4]] to <4 x half>
-// CHECK-NEXT:    [[FMLA1:%.*]] = bitcast <8 x i8> [[TMP3]] to <4 x half>
-// CHECK-NEXT:    [[FMLA2:%.*]] = call <4 x half> @llvm.fma.v4f16(<4 x half> [[FMLA]], <4 x half> [[LANE]], <4 x half> [[FMLA1]])
-// CHECK-NEXT:    ret <4 x half> [[FMLA2]]
-//
-float16x4_t test_vfma_lane_f16(float16x4_t a, float16x4_t b, float16x4_t c) {
-  return vfma_lane_f16(a, b, c, 3);
-}
-
-// CHECK-LABEL: define {{[^@]+}}@test_vfmaq_lane_f16
-// CHECK-SAME: (<8 x half> noundef [[A:%.*]], <8 x half> noundef [[B:%.*]], <4 x half> noundef [[C:%.*]]) #[[ATTR0]] {
-// CHECK-NEXT:  entry:
-// CHECK-NEXT:    [[TMP0:%.*]] = bitcast <8 x half> [[A]] to <8 x i16>
-// CHECK-NEXT:    [[TMP1:%.*]] = bitcast <8 x half> [[B]] to <8 x i16>
-// CHECK-NEXT:    [[TMP2:%.*]] = bitcast <4 x half> [[C]] to <4 x i16>
-// CHECK-NEXT:    [[TMP3:%.*]] = bitcast <8 x i16> [[TMP0]] to <16 x i8>
-// CHECK-NEXT:    [[TMP4:%.*]] = bitcast <8 x i16> [[TMP1]] to <16 x i8>
-// CHECK-NEXT:    [[TMP5:%.*]] = bitcast <4 x i16> [[TMP2]] to <8 x i8>
-// CHECK-NEXT:    [[TMP6:%.*]] = bitcast <8 x i8> [[TMP5]] to <4 x half>
-// CHECK-NEXT:    [[LANE:%.*]] = shufflevector <4 x half> [[TMP6]], <4 x half> [[TMP6]], <8 x i32> <i32 3, i32 3, i32 3, i32 3, i32 3, i32 3, i32 3, i32 3>
-// CHECK-NEXT:    [[FMLA:%.*]] = bitcast <16 x i8> [[TMP4]] to <8 x half>
-// CHECK-NEXT:    [[FMLA1:%.*]] = bitcast <16 x i8> [[TMP3]] to <8 x half>
-// CHECK-NEXT:    [[FMLA2:%.*]] = call <8 x half> @llvm.fma.v8f16(<8 x half> [[FMLA]], <8 x half> [[LANE]], <8 x half> [[FMLA1]])
-// CHECK-NEXT:    ret <8 x half> [[FMLA2]]
-//
-float16x8_t test_vfmaq_lane_f16(float16x8_t a, float16x8_t b, float16x4_t c) {
-  return vfmaq_lane_f16(a, b, c, 3);
-}
-
-// CHECK-LABEL: define {{[^@]+}}@test_vfma_laneq_f16
-// CHECK-SAME: (<4 x half> noundef [[A:%.*]], <4 x half> noundef [[B:%.*]], <8 x half> noundef [[C:%.*]]) #[[ATTR0]] {
-// CHECK-NEXT:  entry:
-// CHECK-NEXT:    [[TMP0:%.*]] = bitcast <4 x half> [[A]] to <4 x i16>
-// CHECK-NEXT:    [[TMP1:%.*]] = bitcast <4 x half> [[B]] to <4 x i16>
-// CHECK-NEXT:    [[TMP2:%.*]] = bitcast <8 x half> [[C]] to <8 x i16>
-// CHECK-NEXT:    [[TMP3:%.*]] = bitcast <4 x i16> [[TMP0]] to <8 x i8>
-// CHECK-NEXT:    [[TMP4:%.*]] = bitcast <4 x i16> [[TMP1]] to <8 x i8>
-// CHECK-NEXT:    [[TMP5:%.*]] = bitcast <8 x i16> [[TMP2]] to <16 x i8>
-// CHECK-NEXT:    [[TMP6:%.*]] = bitcast <8 x i8> [[TMP3]] to <4 x half>
-// CHECK-NEXT:    [[TMP7:%.*]] = bitcast <8 x i8> [[TMP4]] to <4 x half>
-// CHECK-NEXT:    [[TMP8:%.*]] = bitcast <16 x i8> [[TMP5]] to <8 x half>
-// CHECK-NEXT:    [[LANE:%.*]] = shufflevector <8 x half> [[TMP8]], <8 x half> [[TMP8]], <4 x i32> <i32 7, i32 7, i32 7, i32 7>
-// CHECK-NEXT:    [[TMP9:%.*]] = call <4 x half> @llvm.fma.v4f16(<4 x half> [[LANE]], <4 x half> [[TMP7]], <4 x half> [[TMP6]])
-// CHECK-NEXT:    ret <4 x half> [[TMP9]]
-//
-float16x4_t test_vfma_laneq_f16(float16x4_t a, float16x4_t b, float16x8_t c) {
-  return vfma_laneq_f16(a, b, c, 7);
-}
-
-// CHECK-LABEL: define {{[^@]+}}@test_vfmaq_laneq_f16
-// CHECK-SAME: (<8 x half> noundef [[A:%.*]], <8 x half> noundef [[B:%.*]], <8 x half> noundef [[C:%.*]]) #[[ATTR0]] {
-// CHECK-NEXT:  entry:
-// CHECK-NEXT:    [[TMP0:%.*]] = bitcast <8 x half> [[A]] to <8 x i16>
-// CHECK-NEXT:    [[TMP1:%.*]] = bitcast <8 x half> [[B]] to <8 x i16>
-// CHECK-NEXT:    [[TMP2:%.*]] = bitcast <8 x half> [[C]] to <8 x i16>
-// CHECK-NEXT:    [[TMP3:%.*]] = bitcast <8 x i16> [[TMP0]] to <16 x i8>
-// CHECK-NEXT:    [[TMP4:%.*]] = bitcast <8 x i16> [[TMP1]] to <16 x i8>
-// CHECK-NEXT:    [[TMP5:%.*]] = bitcast <8 x i16> [[TMP2]] to <16 x i8>
-// CHECK-NEXT:    [[TMP6:%.*]] = bitcast <16 x i8> [[TMP3]] to <8 x half>
-// CHECK-NEXT:    [[TMP7:%.*]] = bitcast <16 x i8> [[TMP4]] to <8 x half>
-// CHECK-NEXT:    [[TMP8:%.*]] = bitcast <16 x i8> [[TMP5]] to <8 x half>
-// CHECK-NEXT:    [[LANE:%.*]] = shufflevector <8 x half> [[TMP8]], <8 x half> [[TMP8]], <8 x i32> <i32 7, i32 7, i32 7, i32 7, i32 7, i32 7, i32 7, i32 7>
-// CHECK-NEXT:    [[TMP9:%.*]] = call <8 x half> @llvm.fma.v8f16(<8 x half> [[LANE]], <8 x half> [[TMP7]], <8 x half> [[TMP6]])
-// CHECK-NEXT:    ret <8 x half> [[TMP9]]
-//
-float16x8_t test_vfmaq_laneq_f16(float16x8_t a, float16x8_t b, float16x8_t c) {
-  return vfmaq_laneq_f16(a, b, c, 7);
-}
-
 // CHECK-LABEL: define {{[^@]+}}@test_vfma_n_f16
 // CHECK-SAME: (<4 x half> noundef [[A:%.*]], <4 x half> noundef [[B:%.*]], half noundef [[C:%.*]]) #[[ATTR0]] {
 // CHECK-NEXT:  entry:
@@ -1809,29 +1728,6 @@ float16x4_t test_vfma_n_f16(float16x4_t a, float16x4_t b, float16_t c) {
 float16x8_t test_vfmaq_n_f16(float16x8_t a, float16x8_t b, float16_t c) {
   return vfmaq_n_f16(a, b, c);
 }
-
-// CHECK-LABEL: define {{[^@]+}}@test_vfmah_lane_f16
-// CHECK-SAME: (half noundef [[A:%.*]], half noundef [[B:%.*]], <4 x half> noundef [[C:%.*]]) #[[ATTR0]] {
-// CHECK-NEXT:  entry:
-// CHECK-NEXT:    [[EXTRACT:%.*]] = extractelement <4 x half> [[C]], i32 3
-// CHECK-NEXT:    [[TMP0:%.*]] = call half @llvm.fma.f16(half [[B]], half [[EXTRACT]], half [[A]])
-// CHECK-NEXT:    ret half [[TMP0]]
-//
-float16_t test_vfmah_lane_f16(float16_t a, float16_t b, float16x4_t c) {
-  return vfmah_lane_f16(a, b, c, 3);
-}
-
-// CHECK-LABEL: define {{[^@]+}}@test_vfmah_laneq_f16
-// CHECK-SAME: (half noundef [[A:%.*]], half noundef [[B:%.*]], <8 x half> noundef [[C:%.*]]) #[[ATTR0]] {
-// CHECK-NEXT:  entry:
-// CHECK-NEXT:    [[EXTRACT:%.*]] = extractelement <8 x half> [[C]], i32 7
-// CHECK-NEXT:    [[TMP0:%.*]] = call half @llvm.fma.f16(half [[B]], half [[EXTRACT]], half [[A]])
-// CHECK-NEXT:    ret half [[TMP0]]
-//
-float16_t test_vfmah_laneq_f16(float16_t a, float16_t b, float16x8_t c) {
-  return vfmah_laneq_f16(a, b, c, 7);
-}
-
 // CHECK-LABEL: define {{[^@]+}}@test_vfms_lane_f16
 // CHECK-SAME: (<4 x half> noundef [[A:%.*]], <4 x half> noundef [[B:%.*]], <4 x half> noundef [[C:%.*]]) #[[ATTR0]] {
 // CHECK-NEXT:  entry:

--- a/clang/test/CodeGen/AArch64/v8.2a-neon-intrinsics.c
+++ b/clang/test/CodeGen/AArch64/v8.2a-neon-intrinsics.c
@@ -1679,6 +1679,87 @@ float16x4_t test_vfms_f16(float16x4_t a, float16x4_t b, float16x4_t c) {
 float16x8_t test_vfmsq_f16(float16x8_t a, float16x8_t b, float16x8_t c) {
   return vfmsq_f16(a, b, c);
 }
+
+// CHECK-LABEL: define {{[^@]+}}@test_vfma_lane_f16
+// CHECK-SAME: (<4 x half> noundef [[A:%.*]], <4 x half> noundef [[B:%.*]], <4 x half> noundef [[C:%.*]]) #[[ATTR0]] {
+// CHECK-NEXT:  entry:
+// CHECK-NEXT:    [[TMP0:%.*]] = bitcast <4 x half> [[A]] to <4 x i16>
+// CHECK-NEXT:    [[TMP1:%.*]] = bitcast <4 x half> [[B]] to <4 x i16>
+// CHECK-NEXT:    [[TMP2:%.*]] = bitcast <4 x half> [[C]] to <4 x i16>
+// CHECK-NEXT:    [[TMP3:%.*]] = bitcast <4 x i16> [[TMP0]] to <8 x i8>
+// CHECK-NEXT:    [[TMP4:%.*]] = bitcast <4 x i16> [[TMP1]] to <8 x i8>
+// CHECK-NEXT:    [[TMP5:%.*]] = bitcast <4 x i16> [[TMP2]] to <8 x i8>
+// CHECK-NEXT:    [[TMP6:%.*]] = bitcast <8 x i8> [[TMP5]] to <4 x half>
+// CHECK-NEXT:    [[LANE:%.*]] = shufflevector <4 x half> [[TMP6]], <4 x half> [[TMP6]], <4 x i32> <i32 3, i32 3, i32 3, i32 3>
+// CHECK-NEXT:    [[FMLA:%.*]] = bitcast <8 x i8> [[TMP4]] to <4 x half>
+// CHECK-NEXT:    [[FMLA1:%.*]] = bitcast <8 x i8> [[TMP3]] to <4 x half>
+// CHECK-NEXT:    [[FMLA2:%.*]] = call <4 x half> @llvm.fma.v4f16(<4 x half> [[FMLA]], <4 x half> [[LANE]], <4 x half> [[FMLA1]])
+// CHECK-NEXT:    ret <4 x half> [[FMLA2]]
+//
+float16x4_t test_vfma_lane_f16(float16x4_t a, float16x4_t b, float16x4_t c) {
+  return vfma_lane_f16(a, b, c, 3);
+}
+
+// CHECK-LABEL: define {{[^@]+}}@test_vfmaq_lane_f16
+// CHECK-SAME: (<8 x half> noundef [[A:%.*]], <8 x half> noundef [[B:%.*]], <4 x half> noundef [[C:%.*]]) #[[ATTR0]] {
+// CHECK-NEXT:  entry:
+// CHECK-NEXT:    [[TMP0:%.*]] = bitcast <8 x half> [[A]] to <8 x i16>
+// CHECK-NEXT:    [[TMP1:%.*]] = bitcast <8 x half> [[B]] to <8 x i16>
+// CHECK-NEXT:    [[TMP2:%.*]] = bitcast <4 x half> [[C]] to <4 x i16>
+// CHECK-NEXT:    [[TMP3:%.*]] = bitcast <8 x i16> [[TMP0]] to <16 x i8>
+// CHECK-NEXT:    [[TMP4:%.*]] = bitcast <8 x i16> [[TMP1]] to <16 x i8>
+// CHECK-NEXT:    [[TMP5:%.*]] = bitcast <4 x i16> [[TMP2]] to <8 x i8>
+// CHECK-NEXT:    [[TMP6:%.*]] = bitcast <8 x i8> [[TMP5]] to <4 x half>
+// CHECK-NEXT:    [[LANE:%.*]] = shufflevector <4 x half> [[TMP6]], <4 x half> [[TMP6]], <8 x i32> <i32 3, i32 3, i32 3, i32 3, i32 3, i32 3, i32 3, i32 3>
+// CHECK-NEXT:    [[FMLA:%.*]] = bitcast <16 x i8> [[TMP4]] to <8 x half>
+// CHECK-NEXT:    [[FMLA1:%.*]] = bitcast <16 x i8> [[TMP3]] to <8 x half>
+// CHECK-NEXT:    [[FMLA2:%.*]] = call <8 x half> @llvm.fma.v8f16(<8 x half> [[FMLA]], <8 x half> [[LANE]], <8 x half> [[FMLA1]])
+// CHECK-NEXT:    ret <8 x half> [[FMLA2]]
+//
+float16x8_t test_vfmaq_lane_f16(float16x8_t a, float16x8_t b, float16x4_t c) {
+  return vfmaq_lane_f16(a, b, c, 3);
+}
+
+// CHECK-LABEL: define {{[^@]+}}@test_vfma_laneq_f16
+// CHECK-SAME: (<4 x half> noundef [[A:%.*]], <4 x half> noundef [[B:%.*]], <8 x half> noundef [[C:%.*]]) #[[ATTR0]] {
+// CHECK-NEXT:  entry:
+// CHECK-NEXT:    [[TMP0:%.*]] = bitcast <4 x half> [[A]] to <4 x i16>
+// CHECK-NEXT:    [[TMP1:%.*]] = bitcast <4 x half> [[B]] to <4 x i16>
+// CHECK-NEXT:    [[TMP2:%.*]] = bitcast <8 x half> [[C]] to <8 x i16>
+// CHECK-NEXT:    [[TMP3:%.*]] = bitcast <4 x i16> [[TMP0]] to <8 x i8>
+// CHECK-NEXT:    [[TMP4:%.*]] = bitcast <4 x i16> [[TMP1]] to <8 x i8>
+// CHECK-NEXT:    [[TMP5:%.*]] = bitcast <8 x i16> [[TMP2]] to <16 x i8>
+// CHECK-NEXT:    [[TMP6:%.*]] = bitcast <8 x i8> [[TMP3]] to <4 x half>
+// CHECK-NEXT:    [[TMP7:%.*]] = bitcast <8 x i8> [[TMP4]] to <4 x half>
+// CHECK-NEXT:    [[TMP8:%.*]] = bitcast <16 x i8> [[TMP5]] to <8 x half>
+// CHECK-NEXT:    [[LANE:%.*]] = shufflevector <8 x half> [[TMP8]], <8 x half> [[TMP8]], <4 x i32> <i32 7, i32 7, i32 7, i32 7>
+// CHECK-NEXT:    [[TMP9:%.*]] = call <4 x half> @llvm.fma.v4f16(<4 x half> [[LANE]], <4 x half> [[TMP7]], <4 x half> [[TMP6]])
+// CHECK-NEXT:    ret <4 x half> [[TMP9]]
+//
+float16x4_t test_vfma_laneq_f16(float16x4_t a, float16x4_t b, float16x8_t c) {
+  return vfma_laneq_f16(a, b, c, 7);
+}
+
+// CHECK-LABEL: define {{[^@]+}}@test_vfmaq_laneq_f16
+// CHECK-SAME: (<8 x half> noundef [[A:%.*]], <8 x half> noundef [[B:%.*]], <8 x half> noundef [[C:%.*]]) #[[ATTR0]] {
+// CHECK-NEXT:  entry:
+// CHECK-NEXT:    [[TMP0:%.*]] = bitcast <8 x half> [[A]] to <8 x i16>
+// CHECK-NEXT:    [[TMP1:%.*]] = bitcast <8 x half> [[B]] to <8 x i16>
+// CHECK-NEXT:    [[TMP2:%.*]] = bitcast <8 x half> [[C]] to <8 x i16>
+// CHECK-NEXT:    [[TMP3:%.*]] = bitcast <8 x i16> [[TMP0]] to <16 x i8>
+// CHECK-NEXT:    [[TMP4:%.*]] = bitcast <8 x i16> [[TMP1]] to <16 x i8>
+// CHECK-NEXT:    [[TMP5:%.*]] = bitcast <8 x i16> [[TMP2]] to <16 x i8>
+// CHECK-NEXT:    [[TMP6:%.*]] = bitcast <16 x i8> [[TMP3]] to <8 x half>
+// CHECK-NEXT:    [[TMP7:%.*]] = bitcast <16 x i8> [[TMP4]] to <8 x half>
+// CHECK-NEXT:    [[TMP8:%.*]] = bitcast <16 x i8> [[TMP5]] to <8 x half>
+// CHECK-NEXT:    [[LANE:%.*]] = shufflevector <8 x half> [[TMP8]], <8 x half> [[TMP8]], <8 x i32> <i32 7, i32 7, i32 7, i32 7, i32 7, i32 7, i32 7, i32 7>
+// CHECK-NEXT:    [[TMP9:%.*]] = call <8 x half> @llvm.fma.v8f16(<8 x half> [[LANE]], <8 x half> [[TMP7]], <8 x half> [[TMP6]])
+// CHECK-NEXT:    ret <8 x half> [[TMP9]]
+//
+float16x8_t test_vfmaq_laneq_f16(float16x8_t a, float16x8_t b, float16x8_t c) {
+  return vfmaq_laneq_f16(a, b, c, 7);
+}
+
 // CHECK-LABEL: define {{[^@]+}}@test_vfma_n_f16
 // CHECK-SAME: (<4 x half> noundef [[A:%.*]], <4 x half> noundef [[B:%.*]], half noundef [[C:%.*]]) #[[ATTR0]] {
 // CHECK-NEXT:  entry:
@@ -1728,6 +1809,29 @@ float16x4_t test_vfma_n_f16(float16x4_t a, float16x4_t b, float16_t c) {
 float16x8_t test_vfmaq_n_f16(float16x8_t a, float16x8_t b, float16_t c) {
   return vfmaq_n_f16(a, b, c);
 }
+
+// CHECK-LABEL: define {{[^@]+}}@test_vfmah_lane_f16
+// CHECK-SAME: (half noundef [[A:%.*]], half noundef [[B:%.*]], <4 x half> noundef [[C:%.*]]) #[[ATTR0]] {
+// CHECK-NEXT:  entry:
+// CHECK-NEXT:    [[EXTRACT:%.*]] = extractelement <4 x half> [[C]], i32 3
+// CHECK-NEXT:    [[TMP0:%.*]] = call half @llvm.fma.f16(half [[B]], half [[EXTRACT]], half [[A]])
+// CHECK-NEXT:    ret half [[TMP0]]
+//
+float16_t test_vfmah_lane_f16(float16_t a, float16_t b, float16x4_t c) {
+  return vfmah_lane_f16(a, b, c, 3);
+}
+
+// CHECK-LABEL: define {{[^@]+}}@test_vfmah_laneq_f16
+// CHECK-SAME: (half noundef [[A:%.*]], half noundef [[B:%.*]], <8 x half> noundef [[C:%.*]]) #[[ATTR0]] {
+// CHECK-NEXT:  entry:
+// CHECK-NEXT:    [[EXTRACT:%.*]] = extractelement <8 x half> [[C]], i32 7
+// CHECK-NEXT:    [[TMP0:%.*]] = call half @llvm.fma.f16(half [[B]], half [[EXTRACT]], half [[A]])
+// CHECK-NEXT:    ret half [[TMP0]]
+//
+float16_t test_vfmah_laneq_f16(float16_t a, float16_t b, float16x8_t c) {
+  return vfmah_laneq_f16(a, b, c, 7);
+}
+
 // CHECK-LABEL: define {{[^@]+}}@test_vfms_lane_f16
 // CHECK-SAME: (<4 x half> noundef [[A:%.*]], <4 x half> noundef [[B:%.*]], <4 x half> noundef [[C:%.*]]) #[[ATTR0]] {
 // CHECK-NEXT:  entry:


### PR DESCRIPTION
This PR implements the AArch64 NEON ClangIR lowering for the vfma lane/laneq builtins and adds CIR-enabled regression tests.

Covered scope:
  - vector lane/laneq forms
  - scalar lane/laneq forms
  - includes the vfmaq_laneq_v family called out in #185382

Validation:
  - clean build from scratch
  - post-build sanity check
  - focused llvm-lit validation for the touched AArch64 NEON tests

Part of #185382 