### PR TITLE
[ORC] Add EPCGenericJITLinkMemoryManager::Create named constructor.

### DIFF
--- a/llvm/include/llvm/ExecutionEngine/Orc/EPCGenericJITLinkMemoryManager.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/EPCGenericJITLinkMemoryManager.h
@@ -28,7 +28,7 @@ namespace orc {
 class LLVM_ABI EPCGenericJITLinkMemoryManager
     : public jitlink::JITLinkMemoryManager {
 public:
-  /// Function addresses for memory access.
+  /// Symbol addresses for memory management implementation.
   struct SymbolAddrs {
     ExecutorAddr Allocator;
     ExecutorAddr Reserve;
@@ -37,10 +37,24 @@ public:
     ExecutorAddr Release;
   };
 
+  /// Symbol names for memory management implementation.
+  struct SymbolNames {
+    StringRef AllocatorName;
+    StringRef ReserveName;
+    StringRef InitializeName;
+    StringRef DeinitializeName;
+    StringRef ReleaseName;
+  };
+
   /// Create an EPCGenericJITLinkMemoryManager instance from a given set of
   /// function addrs.
   EPCGenericJITLinkMemoryManager(ExecutorProcessControl &EPC, SymbolAddrs SAs)
       : EPC(EPC), SAs(SAs) {}
+
+  /// Create an EPCGenericJITLinkMemoryManager using the given implementation
+  /// symbol names. These will be looked up in the given JITDylib.
+  static Expected<std::unique_ptr<EPCGenericJITLinkMemoryManager>>
+  Create(JITDylib &JD, SymbolNames SNs);
 
   void allocate(const jitlink::JITLinkDylib *JD, jitlink::LinkGraph &G,
                 OnAllocatedFunction OnAllocated) override;

--- a/llvm/lib/ExecutionEngine/Orc/EPCGenericJITLinkMemoryManager.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/EPCGenericJITLinkMemoryManager.cpp
@@ -9,6 +9,7 @@
 #include "llvm/ExecutionEngine/Orc/EPCGenericJITLinkMemoryManager.h"
 
 #include "llvm/ExecutionEngine/JITLink/JITLink.h"
+#include "llvm/ExecutionEngine/Orc/LookupAndRecordAddrs.h"
 #include "llvm/ExecutionEngine/Orc/Shared/OrcRTBridge.h"
 
 #include <limits>
@@ -96,6 +97,24 @@ private:
   ExecutorAddr AllocAddr;
   SegInfoMap Segs;
 };
+
+Expected<std::unique_ptr<EPCGenericJITLinkMemoryManager>>
+EPCGenericJITLinkMemoryManager::Create(JITDylib &JD, SymbolNames SNs) {
+  auto &ES = JD.getExecutionSession();
+  SymbolAddrs SAs;
+  if (auto Err = lookupAndRecordAddrs(
+          ES, LookupKind::Static, makeJITDylibSearchOrder({&JD}),
+          {
+              {ES.intern(SNs.AllocatorName), &SAs.Allocator},
+              {ES.intern(SNs.ReserveName), &SAs.Reserve},
+              {ES.intern(SNs.InitializeName), &SAs.Initialize},
+              {ES.intern(SNs.DeinitializeName), &SAs.Deinitialize},
+              {ES.intern(SNs.ReleaseName), &SAs.Release},
+          }))
+    return Err;
+  return std::make_unique<EPCGenericJITLinkMemoryManager>(
+      ES.getExecutorProcessControl(), SAs);
+}
 
 void EPCGenericJITLinkMemoryManager::allocate(const JITLinkDylib *JD,
                                               LinkGraph &G,

--- a/llvm/unittests/ExecutionEngine/Orc/EPCGenericJITLinkMemoryManagerTest.cpp
+++ b/llvm/unittests/ExecutionEngine/Orc/EPCGenericJITLinkMemoryManagerTest.cpp
@@ -11,6 +11,7 @@
 #include "llvm/ExecutionEngine/Orc/EPCGenericJITLinkMemoryManager.h"
 
 #include "llvm/ADT/DenseMap.h"
+#include "llvm/ExecutionEngine/Orc/AbsoluteSymbols.h"
 #include "llvm/ExecutionEngine/Orc/SelfExecutorProcessControl.h"
 #include "llvm/ExecutionEngine/Orc/Shared/OrcRTBridge.h"
 #include "llvm/ExecutionEngine/Orc/Shared/TargetProcessControlTypes.h"
@@ -138,6 +139,63 @@ TEST(EPCGenericJITLinkMemoryManagerTest, AllocFinalizeFree) {
   EXPECT_THAT_ERROR(std::move(Err2), Succeeded());
 
   cantFail(SelfEPC->disconnect());
+}
+
+TEST(EPCGenericJITLinkMemoryManagerTest, CreateFromSymbolNames) {
+  // Verify that Create successfully looks up symbols and constructs
+  // the memory manager.
+  auto SSP = std::make_shared<SymbolStringPool>();
+  auto EPC =
+      std::make_unique<UnsupportedExecutorProcessControl>(std::move(SSP));
+  ExecutionSession ES(std::move(EPC));
+  auto &JD = ES.createBareJITDylib("JD");
+
+  ExecutorAddr AllocatorAddr(1), ReserveAddr(2), InitAddr(3), DeinitAddr(4),
+      ReleaseAddr(5);
+
+  cantFail(JD.define(absoluteSymbols({
+      {ES.intern("allocator_instance"),
+       {AllocatorAddr, JITSymbolFlags::Exported}},
+      {ES.intern("allocator_reserve"), {ReserveAddr, JITSymbolFlags::Exported}},
+      {ES.intern("allocator_init"), {InitAddr, JITSymbolFlags::Exported}},
+      {ES.intern("allocator_deinit"), {DeinitAddr, JITSymbolFlags::Exported}},
+      {ES.intern("allocator_release"), {ReleaseAddr, JITSymbolFlags::Exported}},
+  })));
+
+  auto Result = EPCGenericJITLinkMemoryManager::Create(
+      JD, {.AllocatorName = "allocator_instance",
+           .ReserveName = "allocator_reserve",
+           .InitializeName = "allocator_init",
+           .DeinitializeName = "allocator_deinit",
+           .ReleaseName = "allocator_release"});
+  EXPECT_THAT_EXPECTED(Result, Succeeded());
+
+  cantFail(ES.endSession());
+}
+
+TEST(EPCGenericJITLinkMemoryManagerTest, CreateFailsOnMissingSymbol) {
+  // Verify that Create returns an error when a symbol is missing.
+  auto SSP = std::make_shared<SymbolStringPool>();
+  auto EPC =
+      std::make_unique<UnsupportedExecutorProcessControl>(std::move(SSP));
+  ExecutionSession ES(std::move(EPC));
+  auto &JD = ES.createBareJITDylib("JD");
+
+  // Only define some of the required symbols.
+  cantFail(JD.define(absoluteSymbols({
+      {ES.intern("allocator_instance"),
+       {ExecutorAddr(1), JITSymbolFlags::Exported}},
+  })));
+
+  auto Result = EPCGenericJITLinkMemoryManager::Create(
+      JD, {.AllocatorName = "allocator_instance",
+           .ReserveName = "allocator_reserve",     // missing
+           .InitializeName = "allocator_init",     // missing
+           .DeinitializeName = "allocator_deinit", // missing
+           .ReleaseName = "allocator_release"});   // missing
+  EXPECT_THAT_EXPECTED(Result, Failed());
+
+  cantFail(ES.endSession());
 }
 
 } // namespace

--- a/llvm/unittests/ExecutionEngine/Orc/EPCGenericJITLinkMemoryManagerTest.cpp
+++ b/llvm/unittests/ExecutionEngine/Orc/EPCGenericJITLinkMemoryManagerTest.cpp
@@ -162,12 +162,14 @@ TEST(EPCGenericJITLinkMemoryManagerTest, CreateFromSymbolNames) {
       {ES.intern("allocator_release"), {ReleaseAddr, JITSymbolFlags::Exported}},
   })));
 
-  auto Result = EPCGenericJITLinkMemoryManager::Create(
-      JD, {.AllocatorName = "allocator_instance",
-           .ReserveName = "allocator_reserve",
-           .InitializeName = "allocator_init",
-           .DeinitializeName = "allocator_deinit",
-           .ReleaseName = "allocator_release"});
+  EPCGenericJITLinkMemoryManager::SymbolNames SNs;
+  SNs.AllocatorName = "allocator_instance";
+  SNs.ReserveName = "allocator_reserve";
+  SNs.InitializeName = "allocator_init";
+  SNs.DeinitializeName = "allocator_deinit";
+  SNs.ReleaseName = "allocator_release";
+
+  auto Result = EPCGenericJITLinkMemoryManager::Create(JD, SNs);
   EXPECT_THAT_EXPECTED(Result, Succeeded());
 
   cantFail(ES.endSession());
@@ -187,12 +189,14 @@ TEST(EPCGenericJITLinkMemoryManagerTest, CreateFailsOnMissingSymbol) {
        {ExecutorAddr(1), JITSymbolFlags::Exported}},
   })));
 
-  auto Result = EPCGenericJITLinkMemoryManager::Create(
-      JD, {.AllocatorName = "allocator_instance",
-           .ReserveName = "allocator_reserve",     // missing
-           .InitializeName = "allocator_init",     // missing
-           .DeinitializeName = "allocator_deinit", // missing
-           .ReleaseName = "allocator_release"});   // missing
+  EPCGenericJITLinkMemoryManager::SymbolNames SNs;
+  SNs.AllocatorName = "allocator_instance";
+  SNs.ReserveName = "allocator_reserve";     // missing
+  SNs.InitializeName = "allocator_init";     // missing
+  SNs.DeinitializeName = "allocator_deinit"; // missing
+  SNs.ReleaseName = "allocator_release";     // missing
+
+  auto Result = EPCGenericJITLinkMemoryManager::Create(JD, SNs);
   EXPECT_THAT_EXPECTED(Result, Failed());
 
   cantFail(ES.endSession());


### PR DESCRIPTION
Create takes a JITDylib and a SymbolNames struct, looks up the implementation symbol addresses in the given JITDylib, and uses them to construct an EPCGenericJITLinkMemoryManager instance. This makes it easier for ORC clients to construct the memory manager from named symbols (e.g. in a bootstrap JITDylib) rather than raw addresses.