### PR TITLE
[RISCV] Fix ssub_sat cost model to use signed VSSUB instead of VSSUBU

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVTargetTransformInfo.cpp
+++ b/llvm/lib/Target/RISCV/RISCVTargetTransformInfo.cpp
@@ -1476,7 +1476,7 @@ RISCVTTIImpl::getIntrinsicInstrCost(const IntrinsicCostAttributes &ICA,
         Op = RISCV::VSADD_VV;
         break;
       case Intrinsic::ssub_sat:
-        Op = RISCV::VSSUBU_VV;
+        Op = RISCV::VSSUB_VV;
         break;
       case Intrinsic::uadd_sat:
         Op = RISCV::VSADDU_VV;


### PR DESCRIPTION
Intrinsic::ssub_sat was incorrectly mapped to RISCV::VSSUBU_VV (unsigned saturating subtract) instead of RISCV::VSSUB_VV (signed saturating subtract), causing wrong cost estimates.