### PR TITLE
[mlir][spirv] Add last 4 data layout ops in TOSA Ext Inst Set

### DIFF
--- a/mlir/include/mlir/Dialect/SPIRV/IR/SPIRVTosaOps.td
+++ b/mlir/include/mlir/Dialect/SPIRV/IR/SPIRVTosaOps.td
@@ -2271,4 +2271,195 @@ def SPIRV_TosaReshapeOp : SPIRV_TosaOpWithResult<"Reshape", 56, [Pure,
 }
 
 
+def SPIRV_TosaReverseOp : SPIRV_TosaOpWithResult<"Reverse", 57, [Pure,
+  AllTypesMatch<["input1", "output"]>,
+  AxisValueLessThanRankOf<"input1">]> {
+  let summary = "Reverse operator.";
+
+  let description = [{
+    Returns a tensor with the same type/values as the input, with the data
+    reversed along the given axis. No data conversion happens during a reverse
+    operation.
+
+    References:
+      * https://github.khronos.org/SPIRV-Registry/extended/TOSA.001000.1.html#_reverse
+      * https://www.mlplatform.org/tosa/tosa_spec_1_0_1.html#_reverse
+
+    #### Example:
+    ```mlir
+    %1 = spirv.Tosa.Reverse axis = 2, %arg0 : !spirv.arm.tensor<20x5x28x31xi32> -> !spirv.arm.tensor<20x5x28x31xi32>
+    %1 = spirv.Tosa.Reverse axis = 1, %arg0 : !spirv.arm.tensor<21x34x47xf32> -> !spirv.arm.tensor<21x34x47xf32>
+    ```
+  }];
+
+  let arguments = (ins
+    SPIRV_TensorArmAxisAttr: $axis,
+    SPIRV_TosaAny_TensorArm: $input1
+  );
+
+  let results = (outs
+    SPIRV_TosaAny_TensorArm: $output
+  );
+
+  let assemblyFormat = [{
+    `axis` `=` $axis `,`
+    $input1
+    attr-dict `:` type(operands) `->` type(results)
+  }];
+
+  let extraClassDeclaration = extraBaseClassDeclaration#[{
+    ::mlir::spirv::TensorArmType getInput1Type() {
+      return cast<::mlir::spirv::TensorArmType>(getInput1().getType());
+    }
+  }];
+}
+
+
+def SPIRV_TosaSliceOp : SPIRV_TosaOpWithResult<"Slice", 58, [Pure,
+  AllElementTypesMatch<["input1", "output"]>,
+  ShapeConstraintFromInputRank<"input1", "start">,
+  ShapeConstraintFromInputRank<"input1", "size">]> {
+  let summary = "Slice operator.";
+
+  let description = [{
+    Extracts a slice of input1, beginning at the start coordinates,
+    and extending for size elements in each direction.
+    No data conversion happens during a slice operation.
+
+    References:
+      * https://github.khronos.org/SPIRV-Registry/extended/TOSA.001000.1.html#_slice
+      * https://www.mlplatform.org/tosa/tosa_spec_1_0_1.html#_slice
+
+    #### Example:
+    ```mlir
+    %2 = spirv.Tosa.Slice %arg0, %start, %size : !spirv.arm.tensor<32x19x41xi8>, !spirv.arm.tensor<3xi32>, !spirv.arm.tensor<3xi32> -> !spirv.arm.tensor<21x5x2xi8>
+    %2 = spirv.Tosa.Slice %arg0, %start, %size : !spirv.arm.tensor<30x45x29xf32>, !spirv.arm.tensor<3xi32>, !spirv.arm.tensor<3xi32> -> !spirv.arm.tensor<5x12x11xf32>
+    ```
+  }];
+
+  let arguments = (ins
+    SPIRV_TosaAny_TensorArm: $input1,
+    SPIRV_Int32_1DTensorArmOfLength1To6: $start,
+    SPIRV_Int32_1DTensorArmOfLength1To6: $size
+  );
+
+  let results = (outs
+    SPIRV_TosaAny_TensorArm: $output
+  );
+
+  let assemblyFormat = [{
+    $input1 `,`
+    $start `,`
+    $size
+    attr-dict `:` type(operands) `->` type(results)
+  }];
+
+  let extraClassDeclaration = extraBaseClassDeclaration#[{
+    ::mlir::spirv::TensorArmType getInput1Type() {
+      return cast<::mlir::spirv::TensorArmType>(getInput1().getType());
+    }
+    ::mlir::spirv::TensorArmType getStartType() {
+      return cast<::mlir::spirv::TensorArmType>(getStart().getType());
+    }
+    ::mlir::spirv::TensorArmType getSizeType() {
+      return cast<::mlir::spirv::TensorArmType>(getSize().getType());
+    }
+  }];
+}
+
+
+def SPIRV_TosaTileOp : SPIRV_TosaOpWithResult<"Tile", 59, [Pure,
+  AllElementTypesMatch<["input1", "output"]>,
+  AllRanksMatch<["input1", "output"]>,
+  ShapeConstraintFromInputRank<"input1", "multiples">]> {
+  let summary = "Tile operator.";
+
+  let description = [{
+    Replicates input1 multiples times along each dimension.
+
+    References:
+      * https://github.khronos.org/SPIRV-Registry/extended/TOSA.001000.1.html#_tile
+      * https://www.mlplatform.org/tosa/tosa_spec_1_0_1.html#_tile
+
+    #### Example:
+    ```mlir
+    %1 = spirv.Tosa.Tile %arg0, %multiples : !spirv.arm.tensor<10x28x21xi16>, !spirv.arm.tensor<3xi32> -> !spirv.arm.tensor<10x28x63xi16>
+    %1 = spirv.Tosa.Tile %arg0, %multiples : !spirv.arm.tensor<31x19x5xf16>, !spirv.arm.tensor<3xi32> -> !spirv.arm.tensor<62x57x10xf16>
+    ```
+
+    For %multiples = [1, 1, 3], the first two dimesions will be tiled just once, whilst the third will be tiled 3 times.
+  }];
+
+  let arguments = (ins
+    SPIRV_TosaAny_TensorArm: $input1,
+    SPIRV_Int32_1DTensorArmOfLength1To6: $multiples
+  );
+
+  let results = (outs
+    SPIRV_TosaAny_TensorArm: $output
+  );
+
+  let assemblyFormat = [{
+    $input1 `,`
+    $multiples
+    attr-dict `:` type(operands) `->` type(results)
+  }];
+
+  let extraClassDeclaration = extraBaseClassDeclaration#[{
+    ::mlir::spirv::TensorArmType getInput1Type() {
+      return cast<::mlir::spirv::TensorArmType>(getInput1().getType());
+    }
+    ::mlir::spirv::TensorArmType getMultiplesType() {
+      return cast<::mlir::spirv::TensorArmType>(getMultiples().getType());
+    }
+  }];
+}
+
+
+def SPIRV_TosaTransposeOp : SPIRV_TosaOpWithResult<"Transpose", 60, [Pure,
+  AllElementTypesMatch<["input1", "output"]>,
+  AllRanksMatch<["input1", "output"]>,
+  AllElementCountsMatch<["input1", "output"]>,
+  ShapeConstraintFromInputRank<"input1", "perms">]> {
+  let summary = "Transpose operator.";
+
+  let description = [{
+    Permutes the dimensions of the input tensor input1 based on the perms
+    argument. Each value in the perms list must be a valid dimension of the
+    input tensor and may not be repeated.
+
+    References:
+      * https://github.khronos.org/SPIRV-Registry/extended/TOSA.001000.1.html#_transpose
+      * https://www.mlplatform.org/tosa/tosa_spec_1_0_1.html#_transpose
+
+    #### Example:
+    ```mlir
+    %1 = spirv.Tosa.Transpose perms = [2, 0, 1, 3], %arg0 : !spirv.arm.tensor<14x28x1x61xi16> -> !spirv.arm.tensor<1x14x28x61xi16>
+    %1 = spirv.Tosa.Transpose perms = [2, 0, 1], %arg0 : !spirv.arm.tensor<42x22x49xi1> -> !spirv.arm.tensor<49x42x22xi1>
+    ```
+  }];
+
+  let arguments = (ins
+    SPIRV_Int32_1DTensorArmOfLength1To6Attr: $perms,
+    SPIRV_TosaAny_TensorArm: $input1
+  );
+
+  let results = (outs
+    SPIRV_TosaAny_TensorArm: $output
+  );
+
+  let assemblyFormat = [{
+    `perms` `=` custom<SPIRV_I32_1DArmTensor>($perms) `,`
+    $input1
+    attr-dict `:` type(operands) `->` type(results)
+  }];
+
+  let extraClassDeclaration = extraBaseClassDeclaration#[{
+    ::mlir::spirv::TensorArmType getInput1Type() {
+      return cast<::mlir::spirv::TensorArmType>(getInput1().getType());
+    }
+  }];
+}
+
+
 #endif // MLIR_DIALECT_SPIRV_IR_TOSA_OPS

--- a/mlir/include/mlir/Dialect/SPIRV/IR/SPIRVTosaTypes.td
+++ b/mlir/include/mlir/Dialect/SPIRV/IR/SPIRVTosaTypes.td
@@ -78,6 +78,15 @@ def SPIRV_Int32_1DTensorArmOfLength4Attr : ConfinedAttr<RankedI32ElementsAttr<[4
 def SPIRV_Int32_1DTensorArmOfLength5Attr : ConfinedAttr<RankedI32ElementsAttr<[5]>, [SPIRV_DenseElementAttrsWithTensorArmType]>;
 def SPIRV_Int32_1DTensorArmOfLength6Attr : ConfinedAttr<RankedI32ElementsAttr<[6]>, [SPIRV_DenseElementAttrsWithTensorArmType]>;
 
+class Is1DTensorArmAttrOfLength<list<int> allowedLengths> :
+  AttrConstraint<And<[CPred<[{::llvm::cast<::mlir::spirv::TensorArmType>(::llvm::cast<::mlir::DenseElementsAttr>($_self).getType()).getShape().size() == 1 }]>,
+    Or<!foreach(allowedlength, allowedLengths,
+      CPred<[{::llvm::cast<::mlir::spirv::TensorArmType>(::llvm::cast<::mlir::DenseElementsAttr>($_self).getType()).getShape()[0] == }]
+              # allowedlength>)>]>>;
+
+def SPIRV_Int32_1DTensorArmOfLength1To6Attr : ConfinedAttr<
+  I32ElementsAttr, [SPIRV_DenseElementAttrsWithTensorArmType, Is1DTensorArmAttrOfLength<[1, 2, 3, 4, 5, 6]>]>;
+
 def SPIRV_Int8_1DTensorArmOfLength1 : SPIRV_1DTensorArmOfLengthAndType<[1], [SPIRV_Int8]>;
 def SPIRV_TosaNumerical_1DTensorArmOfLength1 : SPIRV_1DTensorArmOfLengthAndType<[1], [SPIRV_TosaNumerical]>;
 def SPIRV_TosaAny_1DTensorArmOfLength1 : SPIRV_1DTensorArmOfLengthAndType<[1], [SPIRV_TosaAny]>;

--- a/mlir/test/Dialect/SPIRV/IR/tosa-ops-verification.mlir
+++ b/mlir/test/Dialect/SPIRV/IR/tosa-ops-verification.mlir
@@ -1756,3 +1756,100 @@ spirv.ARM.Graph @reshape_shape_element_count_not_output_rank(%arg0: !spirv.arm.t
   %0 = spirv.Tosa.Reshape %arg0, %arg1 : !spirv.arm.tensor<2x3x4xi8>, !spirv.arm.tensor<4xi32> -> !spirv.arm.tensor<6x4xi8>
   spirv.ARM.GraphOutputs %0 : !spirv.arm.tensor<6x4xi8>
 }
+
+//===----------------------------------------------------------------------===//
+// spirv.TOSA.Reverse
+//===----------------------------------------------------------------------===//
+
+spirv.ARM.Graph @reverse_input_output_types_not_matching(%arg0: !spirv.arm.tensor<2x3x4xi8>) -> (!spirv.arm.tensor<2x3x4xi16>) {
+  // expected-error @+1 {{op failed to verify that all of {input1, output} have same type}}
+  %0 = spirv.Tosa.Reverse axis = 1, %arg0 : !spirv.arm.tensor<2x3x4xi8> -> !spirv.arm.tensor<2x3x4xi16>
+  spirv.ARM.GraphOutputs %0 : !spirv.arm.tensor<2x3x4xi16>
+}
+
+spirv.ARM.Graph @reverse_axis_value_not_in_input_rank_range(%arg0: !spirv.arm.tensor<2x3x4xi8>) -> (!spirv.arm.tensor<2x3x4xi8>) {
+  // expected-error @+1 {{op failed to verify that axis attribute value should be lower than rank(input1)}}
+  %0 = spirv.Tosa.Reverse axis = 3, %arg0 : !spirv.arm.tensor<2x3x4xi8> -> !spirv.arm.tensor<2x3x4xi8>
+  spirv.ARM.GraphOutputs %0 : !spirv.arm.tensor<2x3x4xi8>
+}
+
+//===----------------------------------------------------------------------===//
+// spirv.TOSA.Slice
+//===----------------------------------------------------------------------===//
+
+spirv.ARM.Graph @slice_input_output_element_types_not_matching(%arg0: !spirv.arm.tensor<4x5x6xi8>) -> (!spirv.arm.tensor<2x3x4xi16>) {
+  %start = spirv.Constant dense<[0, 1, 2]> : !spirv.arm.tensor<3xi32>
+  %size = spirv.Constant dense<[2, 3, 4]> : !spirv.arm.tensor<3xi32>
+  // expected-error @+1 {{op failed to verify that all of {input1, output} have same element type}}
+  %0 = spirv.Tosa.Slice %arg0, %start, %size : !spirv.arm.tensor<4x5x6xi8>, !spirv.arm.tensor<3xi32>, !spirv.arm.tensor<3xi32> -> !spirv.arm.tensor<2x3x4xi16>
+  spirv.ARM.GraphOutputs %0 : !spirv.arm.tensor<2x3x4xi16>
+}
+
+spirv.ARM.Graph @slice_start_element_count_not_input_rank(%arg0: !spirv.arm.tensor<4x5x6xi8>) -> (!spirv.arm.tensor<2x3x4xi8>) {
+  %start = spirv.Constant dense<[0, 1]> : !spirv.arm.tensor<2xi32>
+  %size = spirv.Constant dense<[2, 3, 4]> : !spirv.arm.tensor<3xi32>
+  // expected-error @+1 {{op failed to verify that the number of elements of start must be rank(input1)}}
+  %0 = spirv.Tosa.Slice %arg0, %start, %size : !spirv.arm.tensor<4x5x6xi8>, !spirv.arm.tensor<2xi32>, !spirv.arm.tensor<3xi32> -> !spirv.arm.tensor<2x3x4xi8>
+  spirv.ARM.GraphOutputs %0 : !spirv.arm.tensor<2x3x4xi8>
+}
+
+spirv.ARM.Graph @slice_size_element_count_not_input_rank(%arg0: !spirv.arm.tensor<4x5x6xi8>) -> (!spirv.arm.tensor<2x3x4xi8>) {
+  %start = spirv.Constant dense<[0, 1, 2]> : !spirv.arm.tensor<3xi32>
+  %size = spirv.Constant dense<[2, 3]> : !spirv.arm.tensor<2xi32>
+  // expected-error @+1 {{op failed to verify that the number of elements of size must be rank(input1)}}
+  %0 = spirv.Tosa.Slice %arg0, %start, %size : !spirv.arm.tensor<4x5x6xi8>, !spirv.arm.tensor<3xi32>, !spirv.arm.tensor<2xi32> -> !spirv.arm.tensor<2x3x4xi8>
+  spirv.ARM.GraphOutputs %0 : !spirv.arm.tensor<2x3x4xi8>
+}
+
+//===----------------------------------------------------------------------===//
+// spirv.TOSA.Tile
+//===----------------------------------------------------------------------===//
+
+spirv.ARM.Graph @tile_input_output_element_types_not_matching(%arg0: !spirv.arm.tensor<2x3x4xi8>) -> (!spirv.arm.tensor<4x3x8xi16>) {
+  %multiples = spirv.Constant dense<[2, 1, 2]> : !spirv.arm.tensor<3xi32>
+  // expected-error @+1 {{op failed to verify that all of {input1, output} have same element type}}
+  %0 = spirv.Tosa.Tile %arg0, %multiples : !spirv.arm.tensor<2x3x4xi8>, !spirv.arm.tensor<3xi32> -> !spirv.arm.tensor<4x3x8xi16>
+  spirv.ARM.GraphOutputs %0 : !spirv.arm.tensor<4x3x8xi16>
+}
+
+spirv.ARM.Graph @tile_input_output_ranks_not_matching(%arg0: !spirv.arm.tensor<2x3x4xi8>) -> (!spirv.arm.tensor<2x12xi8>) {
+  %multiples = spirv.Constant dense<[1, 1, 1]> : !spirv.arm.tensor<3xi32>
+  // expected-error @+1 {{op failed to verify that all of {input1, output} have same rank}}
+  %0 = spirv.Tosa.Tile %arg0, %multiples : !spirv.arm.tensor<2x3x4xi8>, !spirv.arm.tensor<3xi32> -> !spirv.arm.tensor<2x12xi8>
+  spirv.ARM.GraphOutputs %0 : !spirv.arm.tensor<2x12xi8>
+}
+
+spirv.ARM.Graph @tile_multiples_element_count_not_input_rank(%arg0: !spirv.arm.tensor<2x3x4xi8>) -> (!spirv.arm.tensor<4x3x8xi8>) {
+  %multiples = spirv.Constant dense<[2, 1]> : !spirv.arm.tensor<2xi32>
+  // expected-error @+1 {{op failed to verify that the number of elements of multiples must be rank(input1)}}
+  %0 = spirv.Tosa.Tile %arg0, %multiples : !spirv.arm.tensor<2x3x4xi8>, !spirv.arm.tensor<2xi32> -> !spirv.arm.tensor<4x3x8xi8>
+  spirv.ARM.GraphOutputs %0 : !spirv.arm.tensor<4x3x8xi8>
+}
+
+//===----------------------------------------------------------------------===//
+// spirv.TOSA.Transpose
+//===----------------------------------------------------------------------===//
+
+spirv.ARM.Graph @transpose_input_output_element_types_not_matching(%arg0: !spirv.arm.tensor<2x3x4xi8>) -> (!spirv.arm.tensor<4x2x3xi16>) {
+  // expected-error @+1 {{op failed to verify that all of {input1, output} have same element type}}
+  %0 = spirv.Tosa.Transpose perms = [2, 0, 1], %arg0 : !spirv.arm.tensor<2x3x4xi8> -> !spirv.arm.tensor<4x2x3xi16>
+  spirv.ARM.GraphOutputs %0 : !spirv.arm.tensor<4x2x3xi16>
+}
+
+spirv.ARM.Graph @transpose_input_output_ranks_not_matching(%arg0: !spirv.arm.tensor<2x3x4xi8>) -> (!spirv.arm.tensor<24xi8>) {
+  // expected-error @+1 {{op failed to verify that all of {input1, output} have same rank}}
+  %0 = spirv.Tosa.Transpose perms = [2, 0, 1], %arg0 : !spirv.arm.tensor<2x3x4xi8> -> !spirv.arm.tensor<24xi8>
+  spirv.ARM.GraphOutputs %0 : !spirv.arm.tensor<24xi8>
+}
+
+spirv.ARM.Graph @transpose_input_output_element_counts_not_matching(%arg0: !spirv.arm.tensor<2x3x4xi8>) -> (!spirv.arm.tensor<3x3x3xi8>) {
+  // expected-error @+1 {{op failed to verify that all of {input1, output} have same element count}}
+  %0 = spirv.Tosa.Transpose perms = [2, 0, 1], %arg0 : !spirv.arm.tensor<2x3x4xi8> -> !spirv.arm.tensor<3x3x3xi8>
+  spirv.ARM.GraphOutputs %0 : !spirv.arm.tensor<3x3x3xi8>
+}
+
+spirv.ARM.Graph @transpose_perms_element_count_not_input_rank(%arg0: !spirv.arm.tensor<2x3x4xi8>) -> (!spirv.arm.tensor<4x2x3xi8>) {
+  // expected-error @+1 {{op failed to verify that the number of elements of perms must be rank(input1)}}
+  %0 = spirv.Tosa.Transpose perms = [1, 0], %arg0 : !spirv.arm.tensor<2x3x4xi8> -> !spirv.arm.tensor<4x2x3xi8>
+  spirv.ARM.GraphOutputs %0 : !spirv.arm.tensor<4x2x3xi8>
+}

--- a/mlir/test/Dialect/SPIRV/IR/tosa-ops.mlir
+++ b/mlir/test/Dialect/SPIRV/IR/tosa-ops.mlir
@@ -957,3 +957,97 @@ spirv.ARM.Graph @reshape_fp(%arg0: !spirv.arm.tensor<1x2x7x2xf32>) -> (!spirv.ar
   // CHECK: spirv.ARM.GraphOutputs {{%.*}} : !spirv.arm.tensor<2x1x14xf32>
   spirv.ARM.GraphOutputs %1 : !spirv.arm.tensor<2x1x14xf32>
 }
+
+//===----------------------------------------------------------------------===//
+// spirv.TOSA.Reverse - PRO-INT
+//===----------------------------------------------------------------------===//
+
+spirv.ARM.Graph @reverse_int(%arg0: !spirv.arm.tensor<20x5x28x31xi32>) -> (!spirv.arm.tensor<20x5x28x31xi32>) {
+  // CHECK: {{%.*}} = spirv.Tosa.Reverse axis = 2, %arg0 : !spirv.arm.tensor<20x5x28x31xi32> -> !spirv.arm.tensor<20x5x28x31xi32>
+  %1 = spirv.Tosa.Reverse axis = 2, %arg0 : !spirv.arm.tensor<20x5x28x31xi32> -> !spirv.arm.tensor<20x5x28x31xi32>
+  // CHECK: spirv.ARM.GraphOutputs {{%.*}} : !spirv.arm.tensor<20x5x28x31xi32>
+  spirv.ARM.GraphOutputs %1 : !spirv.arm.tensor<20x5x28x31xi32>
+}
+
+//===----------------------------------------------------------------------===//
+// spirv.TOSA.Reverse - PRO-FP
+//===----------------------------------------------------------------------===//
+
+spirv.ARM.Graph @reverse_fp(%arg0: !spirv.arm.tensor<21x34x47xf32>) -> (!spirv.arm.tensor<21x34x47xf32>) {
+  // CHECK: {{%.*}} = spirv.Tosa.Reverse axis = 1, %arg0 : !spirv.arm.tensor<21x34x47xf32> -> !spirv.arm.tensor<21x34x47xf32>
+  %1 = spirv.Tosa.Reverse axis = 1, %arg0 : !spirv.arm.tensor<21x34x47xf32> -> !spirv.arm.tensor<21x34x47xf32>
+  // CHECK: spirv.ARM.GraphOutputs {{%.*}} : !spirv.arm.tensor<21x34x47xf32>
+  spirv.ARM.GraphOutputs %1 : !spirv.arm.tensor<21x34x47xf32>
+}
+
+//===----------------------------------------------------------------------===//
+// spirv.TOSA.Slice - PRO-INT
+//===----------------------------------------------------------------------===//
+
+spirv.ARM.Graph @slice_int(%arg0: !spirv.arm.tensor<32x19x41xi8>) -> (!spirv.arm.tensor<21x5x2xi8>) {
+  %0 = spirv.Constant dense<[8, 11, 39]> : !spirv.arm.tensor<3xi32>
+  %1 = spirv.Constant dense<[21, 5, 2]> : !spirv.arm.tensor<3xi32>
+  // CHECK: {{%.*}} = spirv.Tosa.Slice %arg0, {{%.*}}, {{%.*}} : !spirv.arm.tensor<32x19x41xi8>, !spirv.arm.tensor<3xi32>, !spirv.arm.tensor<3xi32> -> !spirv.arm.tensor<21x5x2xi8>
+  %2 = spirv.Tosa.Slice %arg0, %0, %1 : !spirv.arm.tensor<32x19x41xi8>, !spirv.arm.tensor<3xi32>, !spirv.arm.tensor<3xi32> -> !spirv.arm.tensor<21x5x2xi8>
+  // CHECK: spirv.ARM.GraphOutputs {{%.*}} : !spirv.arm.tensor<21x5x2xi8>
+  spirv.ARM.GraphOutputs %2 : !spirv.arm.tensor<21x5x2xi8>
+}
+
+//===----------------------------------------------------------------------===//
+// spirv.TOSA.Slice - PRO-FP
+//===----------------------------------------------------------------------===//
+
+spirv.ARM.Graph @slice_fp(%arg0: !spirv.arm.tensor<30x45x29xf32>) -> (!spirv.arm.tensor<5x12x11xf32>) {
+  %0 = spirv.Constant dense<[21, 20, 10]> : !spirv.arm.tensor<3xi32>
+  %1 = spirv.Constant dense<[5, 12, 11]> : !spirv.arm.tensor<3xi32>
+  // CHECK: {{%.*}} = spirv.Tosa.Slice %arg0, {{%.*}}, {{%.*}} : !spirv.arm.tensor<30x45x29xf32>, !spirv.arm.tensor<3xi32>, !spirv.arm.tensor<3xi32> -> !spirv.arm.tensor<5x12x11xf32>
+  %2 = spirv.Tosa.Slice %arg0, %0, %1 : !spirv.arm.tensor<30x45x29xf32>, !spirv.arm.tensor<3xi32>, !spirv.arm.tensor<3xi32> -> !spirv.arm.tensor<5x12x11xf32>
+  // CHECK: spirv.ARM.GraphOutputs {{%.*}} : !spirv.arm.tensor<5x12x11xf32>
+  spirv.ARM.GraphOutputs %2 : !spirv.arm.tensor<5x12x11xf32>
+}
+
+//===----------------------------------------------------------------------===//
+// spirv.TOSA.Tile - PRO-INT
+//===----------------------------------------------------------------------===//
+
+spirv.ARM.Graph @tile_int(%arg0: !spirv.arm.tensor<10x28x21xi16>) -> (!spirv.arm.tensor<10x28x63xi16>) {
+  %0 = spirv.Constant dense<[1, 1, 3]> : !spirv.arm.tensor<3xi32>
+  // CHECK: {{%.*}} = spirv.Tosa.Tile %arg0, {{%.*}} : !spirv.arm.tensor<10x28x21xi16>, !spirv.arm.tensor<3xi32> -> !spirv.arm.tensor<10x28x63xi16>
+  %1 = spirv.Tosa.Tile %arg0, %0 : !spirv.arm.tensor<10x28x21xi16>, !spirv.arm.tensor<3xi32> -> !spirv.arm.tensor<10x28x63xi16>
+  // CHECK: spirv.ARM.GraphOutputs {{%.*}} : !spirv.arm.tensor<10x28x63xi16>
+  spirv.ARM.GraphOutputs %1 : !spirv.arm.tensor<10x28x63xi16>
+}
+
+//===----------------------------------------------------------------------===//
+// spirv.TOSA.Tile - PRO-FP
+//===----------------------------------------------------------------------===//
+
+spirv.ARM.Graph @tile_fp(%arg0: !spirv.arm.tensor<31x19x5xf16>) -> (!spirv.arm.tensor<62x57x10xf16>) {
+  %0 = spirv.Constant dense<[2, 3, 2]> : !spirv.arm.tensor<3xi32>
+  // CHECK: {{%.*}} = spirv.Tosa.Tile %arg0, {{%.*}} : !spirv.arm.tensor<31x19x5xf16>, !spirv.arm.tensor<3xi32> -> !spirv.arm.tensor<62x57x10xf16>
+  %1 = spirv.Tosa.Tile %arg0, %0 : !spirv.arm.tensor<31x19x5xf16>, !spirv.arm.tensor<3xi32> -> !spirv.arm.tensor<62x57x10xf16>
+  // CHECK: spirv.ARM.GraphOutputs {{%.*}} : !spirv.arm.tensor<62x57x10xf16>
+  spirv.ARM.GraphOutputs %1 : !spirv.arm.tensor<62x57x10xf16>
+}
+
+//===----------------------------------------------------------------------===//
+// spirv.TOSA.Transpose - PRO-INT
+//===----------------------------------------------------------------------===//
+
+spirv.ARM.Graph @transpose_int(%arg0: !spirv.arm.tensor<14x28x1x61xi16>) -> (!spirv.arm.tensor<1x14x28x61xi16>) {
+  // CHECK: {{%.*}} = spirv.Tosa.Transpose perms = [2, 0, 1, 3], %arg0 : !spirv.arm.tensor<14x28x1x61xi16> -> !spirv.arm.tensor<1x14x28x61xi16>
+  %1 = spirv.Tosa.Transpose perms = [2, 0, 1, 3], %arg0 : !spirv.arm.tensor<14x28x1x61xi16> -> !spirv.arm.tensor<1x14x28x61xi16>
+  // CHECK: spirv.ARM.GraphOutputs {{%.*}} : !spirv.arm.tensor<1x14x28x61xi16>
+  spirv.ARM.GraphOutputs %1 : !spirv.arm.tensor<1x14x28x61xi16>
+}
+
+//===----------------------------------------------------------------------===//
+// spirv.TOSA.Transpose - PRO-FP
+//===----------------------------------------------------------------------===//
+
+spirv.ARM.Graph @transpose_fp(%arg0: !spirv.arm.tensor<42x22x49xi1>) -> (!spirv.arm.tensor<49x42x22xi1>) {
+  // CHECK: {{%.*}} = spirv.Tosa.Transpose perms = [2, 0, 1], %arg0 : !spirv.arm.tensor<42x22x49xi1> -> !spirv.arm.tensor<49x42x22xi1>
+  %1 = spirv.Tosa.Transpose perms = [2, 0, 1], %arg0 : !spirv.arm.tensor<42x22x49xi1> -> !spirv.arm.tensor<49x42x22xi1>
+  // CHECK: spirv.ARM.GraphOutputs {{%.*}} : !spirv.arm.tensor<49x42x22xi1>
+  spirv.ARM.GraphOutputs %1 : !spirv.arm.tensor<49x42x22xi1>
+}

--- a/mlir/test/Target/SPIRV/tosa-ops.mlir
+++ b/mlir/test/Target/SPIRV/tosa-ops.mlir
@@ -1680,3 +1680,161 @@ spirv.module Logical Vulkan requires #spirv.vce<v1.3, [VulkanMemoryModel, Shader
     spirv.ARM.GraphOutputs %1 : !spirv.arm.tensor<2x1x14xf32>
   }
 }
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// spirv.TOSA.Reverse - PRO-INT
+//===----------------------------------------------------------------------===//
+
+// CHECK: spirv.module Logical Vulkan requires #spirv.vce<v1.3, [VulkanMemoryModel, Shader, Int8, Int16, Int64, Float16, TensorsARM, GraphARM], [SPV_ARM_tensors, SPV_ARM_graph, SPV_KHR_vulkan_memory_model]>
+spirv.module Logical Vulkan requires #spirv.vce<v1.3, [VulkanMemoryModel, Shader, Int8, Int16, Int64, Float16, TensorsARM, GraphARM], [SPV_ARM_tensors, SPV_ARM_graph, SPV_KHR_vulkan_memory_model]> {
+  spirv.GlobalVariable @reverse_int_arg_0 bind(0, 0) : !spirv.ptr<!spirv.arm.tensor<20x5x28x31xi32>, UniformConstant>
+  spirv.GlobalVariable @reverse_int_res_0 bind(1, 0) : !spirv.ptr<!spirv.arm.tensor<20x5x28x31xi32>, UniformConstant>
+  spirv.ARM.GraphEntryPoint @reverse_int, @reverse_int_arg_0, @reverse_int_res_0
+  spirv.ARM.Graph @reverse_int(%arg0: !spirv.arm.tensor<20x5x28x31xi32>) -> (!spirv.arm.tensor<20x5x28x31xi32>) {
+    // CHECK: {{%.*}} = spirv.Tosa.Reverse axis = 2, %arg0 : !spirv.arm.tensor<20x5x28x31xi32> -> !spirv.arm.tensor<20x5x28x31xi32>
+    %1 = spirv.Tosa.Reverse axis = 2, %arg0 : !spirv.arm.tensor<20x5x28x31xi32> -> !spirv.arm.tensor<20x5x28x31xi32>
+    // CHECK: spirv.ARM.GraphOutputs {{%.*}} : !spirv.arm.tensor<20x5x28x31xi32>
+    spirv.ARM.GraphOutputs %1 : !spirv.arm.tensor<20x5x28x31xi32>
+  }
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// spirv.TOSA.Reverse - PRO-FP
+//===----------------------------------------------------------------------===//
+
+// CHECK: spirv.module Logical Vulkan requires #spirv.vce<v1.3, [VulkanMemoryModel, Shader, Int8, Int16, Int64, Float16, TensorsARM, GraphARM], [SPV_ARM_tensors, SPV_ARM_graph, SPV_KHR_vulkan_memory_model]>
+spirv.module Logical Vulkan requires #spirv.vce<v1.3, [VulkanMemoryModel, Shader, Int8, Int16, Int64, Float16, TensorsARM, GraphARM], [SPV_ARM_tensors, SPV_ARM_graph, SPV_KHR_vulkan_memory_model]> {
+  spirv.GlobalVariable @reverse_fp_arg_0 bind(0, 0) : !spirv.ptr<!spirv.arm.tensor<21x34x47xf32>, UniformConstant>
+  spirv.GlobalVariable @reverse_fp_res_0 bind(1, 0) : !spirv.ptr<!spirv.arm.tensor<21x34x47xf32>, UniformConstant>
+  spirv.ARM.GraphEntryPoint @reverse_fp, @reverse_fp_arg_0, @reverse_fp_res_0
+  spirv.ARM.Graph @reverse_fp(%arg0: !spirv.arm.tensor<21x34x47xf32>) -> (!spirv.arm.tensor<21x34x47xf32>) {
+    // CHECK: {{%.*}} = spirv.Tosa.Reverse axis = 1, %arg0 : !spirv.arm.tensor<21x34x47xf32> -> !spirv.arm.tensor<21x34x47xf32>
+    %1 = spirv.Tosa.Reverse axis = 1, %arg0 : !spirv.arm.tensor<21x34x47xf32> -> !spirv.arm.tensor<21x34x47xf32>
+    // CHECK: spirv.ARM.GraphOutputs {{%.*}} : !spirv.arm.tensor<21x34x47xf32>
+    spirv.ARM.GraphOutputs %1 : !spirv.arm.tensor<21x34x47xf32>
+  }
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// spirv.TOSA.Slice - PRO-INT
+//===----------------------------------------------------------------------===//
+
+// CHECK: spirv.module Logical Vulkan requires #spirv.vce<v1.3, [VulkanMemoryModel, Shader, Int8, Int16, Int64, Float16, TensorsARM, GraphARM], [SPV_ARM_tensors, SPV_ARM_graph, SPV_KHR_vulkan_memory_model]>
+spirv.module Logical Vulkan requires #spirv.vce<v1.3, [VulkanMemoryModel, Shader, Int8, Int16, Int64, Float16, TensorsARM, GraphARM], [SPV_ARM_tensors, SPV_ARM_graph, SPV_KHR_vulkan_memory_model]> {
+  spirv.GlobalVariable @slice_int_arg_0 bind(0, 0) : !spirv.ptr<!spirv.arm.tensor<32x19x41xi8>, UniformConstant>
+  spirv.GlobalVariable @slice_int_res_0 bind(1, 0) : !spirv.ptr<!spirv.arm.tensor<21x5x2xi8>, UniformConstant>
+  spirv.ARM.GraphEntryPoint @slice_int, @slice_int_arg_0, @slice_int_res_0
+  spirv.ARM.Graph @slice_int(%arg0: !spirv.arm.tensor<32x19x41xi8>) -> (!spirv.arm.tensor<21x5x2xi8>) {
+    %0 = spirv.Constant dense<[8, 11, 39]> : !spirv.arm.tensor<3xi32>
+    %1 = spirv.Constant dense<[21, 5, 2]> : !spirv.arm.tensor<3xi32>
+    // CHECK: {{%.*}} = spirv.Tosa.Slice %arg0, {{%.*}}, {{%.*}} : !spirv.arm.tensor<32x19x41xi8>, !spirv.arm.tensor<3xi32>, !spirv.arm.tensor<3xi32> -> !spirv.arm.tensor<21x5x2xi8>
+    %2 = spirv.Tosa.Slice %arg0, %0, %1 : !spirv.arm.tensor<32x19x41xi8>, !spirv.arm.tensor<3xi32>, !spirv.arm.tensor<3xi32> -> !spirv.arm.tensor<21x5x2xi8>
+    // CHECK: spirv.ARM.GraphOutputs {{%.*}} : !spirv.arm.tensor<21x5x2xi8>
+    spirv.ARM.GraphOutputs %2 : !spirv.arm.tensor<21x5x2xi8>
+  }
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// spirv.TOSA.Slice - PRO-FP
+//===----------------------------------------------------------------------===//
+
+// CHECK: spirv.module Logical Vulkan requires #spirv.vce<v1.3, [VulkanMemoryModel, Shader, Int8, Int16, Int64, Float16, TensorsARM, GraphARM], [SPV_ARM_tensors, SPV_ARM_graph, SPV_KHR_vulkan_memory_model]>
+spirv.module Logical Vulkan requires #spirv.vce<v1.3, [VulkanMemoryModel, Shader, Int8, Int16, Int64, Float16, TensorsARM, GraphARM], [SPV_ARM_tensors, SPV_ARM_graph, SPV_KHR_vulkan_memory_model]> {
+  spirv.GlobalVariable @slice_fp_arg_0 bind(0, 0) : !spirv.ptr<!spirv.arm.tensor<30x45x29xf32>, UniformConstant>
+  spirv.GlobalVariable @slice_fp_res_0 bind(1, 0) : !spirv.ptr<!spirv.arm.tensor<5x12x11xf32>, UniformConstant>
+  spirv.ARM.GraphEntryPoint @slice_fp, @slice_fp_arg_0, @slice_fp_res_0
+  spirv.ARM.Graph @slice_fp(%arg0: !spirv.arm.tensor<30x45x29xf32>) -> (!spirv.arm.tensor<5x12x11xf32>) {
+    %0 = spirv.Constant dense<[21, 20, 10]> : !spirv.arm.tensor<3xi32>
+    %1 = spirv.Constant dense<[5, 12, 11]> : !spirv.arm.tensor<3xi32>
+    // CHECK: {{%.*}} = spirv.Tosa.Slice %arg0, {{%.*}}, {{%.*}} : !spirv.arm.tensor<30x45x29xf32>, !spirv.arm.tensor<3xi32>, !spirv.arm.tensor<3xi32> -> !spirv.arm.tensor<5x12x11xf32>
+    %2 = spirv.Tosa.Slice %arg0, %0, %1 : !spirv.arm.tensor<30x45x29xf32>, !spirv.arm.tensor<3xi32>, !spirv.arm.tensor<3xi32> -> !spirv.arm.tensor<5x12x11xf32>
+    // CHECK: spirv.ARM.GraphOutputs {{%.*}} : !spirv.arm.tensor<5x12x11xf32>
+    spirv.ARM.GraphOutputs %2 : !spirv.arm.tensor<5x12x11xf32>
+  }
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// spirv.TOSA.Tile - PRO-INT
+//===----------------------------------------------------------------------===//
+
+// CHECK: spirv.module Logical Vulkan requires #spirv.vce<v1.3, [VulkanMemoryModel, Shader, Int8, Int16, Int64, Float16, TensorsARM, GraphARM], [SPV_ARM_tensors, SPV_ARM_graph, SPV_KHR_vulkan_memory_model]>
+spirv.module Logical Vulkan requires #spirv.vce<v1.3, [VulkanMemoryModel, Shader, Int8, Int16, Int64, Float16, TensorsARM, GraphARM], [SPV_ARM_tensors, SPV_ARM_graph, SPV_KHR_vulkan_memory_model]> {
+  spirv.GlobalVariable @tile_int_arg_0 bind(0, 0) : !spirv.ptr<!spirv.arm.tensor<10x28x21xi16>, UniformConstant>
+  spirv.GlobalVariable @tile_int_res_0 bind(1, 0) : !spirv.ptr<!spirv.arm.tensor<10x28x63xi16>, UniformConstant>
+  spirv.ARM.GraphEntryPoint @tile_int, @tile_int_arg_0, @tile_int_res_0
+  spirv.ARM.Graph @tile_int(%arg0: !spirv.arm.tensor<10x28x21xi16>) -> (!spirv.arm.tensor<10x28x63xi16>) {
+    %0 = spirv.Constant dense<[1, 1, 3]> : !spirv.arm.tensor<3xi32>
+    // CHECK: {{%.*}} = spirv.Tosa.Tile %arg0, {{%.*}} : !spirv.arm.tensor<10x28x21xi16>, !spirv.arm.tensor<3xi32> -> !spirv.arm.tensor<10x28x63xi16>
+    %1 = spirv.Tosa.Tile %arg0, %0 : !spirv.arm.tensor<10x28x21xi16>, !spirv.arm.tensor<3xi32> -> !spirv.arm.tensor<10x28x63xi16>
+    // CHECK: spirv.ARM.GraphOutputs {{%.*}} : !spirv.arm.tensor<10x28x63xi16>
+    spirv.ARM.GraphOutputs %1 : !spirv.arm.tensor<10x28x63xi16>
+  }
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// spirv.TOSA.Tile - PRO-FP
+//===----------------------------------------------------------------------===//
+
+// CHECK: spirv.module Logical Vulkan requires #spirv.vce<v1.3, [VulkanMemoryModel, Shader, Int8, Int16, Int64, Float16, TensorsARM, GraphARM], [SPV_ARM_tensors, SPV_ARM_graph, SPV_KHR_vulkan_memory_model]>
+spirv.module Logical Vulkan requires #spirv.vce<v1.3, [VulkanMemoryModel, Shader, Int8, Int16, Int64, Float16, TensorsARM, GraphARM], [SPV_ARM_tensors, SPV_ARM_graph, SPV_KHR_vulkan_memory_model]> {
+  spirv.GlobalVariable @tile_fp_arg_0 bind(0, 0) : !spirv.ptr<!spirv.arm.tensor<31x19x5xf16>, UniformConstant>
+  spirv.GlobalVariable @tile_fp_res_0 bind(1, 0) : !spirv.ptr<!spirv.arm.tensor<62x57x10xf16>, UniformConstant>
+  spirv.ARM.GraphEntryPoint @tile_fp, @tile_fp_arg_0, @tile_fp_res_0
+  spirv.ARM.Graph @tile_fp(%arg0: !spirv.arm.tensor<31x19x5xf16>) -> (!spirv.arm.tensor<62x57x10xf16>) {
+    %0 = spirv.Constant dense<[2, 3, 2]> : !spirv.arm.tensor<3xi32>
+    // CHECK: {{%.*}} = spirv.Tosa.Tile %arg0, {{%.*}} : !spirv.arm.tensor<31x19x5xf16>, !spirv.arm.tensor<3xi32> -> !spirv.arm.tensor<62x57x10xf16>
+    %1 = spirv.Tosa.Tile %arg0, %0 : !spirv.arm.tensor<31x19x5xf16>, !spirv.arm.tensor<3xi32> -> !spirv.arm.tensor<62x57x10xf16>
+    // CHECK: spirv.ARM.GraphOutputs {{%.*}} : !spirv.arm.tensor<62x57x10xf16>
+    spirv.ARM.GraphOutputs %1 : !spirv.arm.tensor<62x57x10xf16>
+  }
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// spirv.TOSA.Transpose - PRO-INT
+//===----------------------------------------------------------------------===//
+
+// CHECK: spirv.module Logical Vulkan requires #spirv.vce<v1.3, [VulkanMemoryModel, Shader, Int8, Int16, Int64, Float16, TensorsARM, GraphARM], [SPV_ARM_tensors, SPV_ARM_graph, SPV_KHR_vulkan_memory_model]>
+spirv.module Logical Vulkan requires #spirv.vce<v1.3, [VulkanMemoryModel, Shader, Int8, Int16, Int64, Float16, TensorsARM, GraphARM], [SPV_ARM_tensors, SPV_ARM_graph, SPV_KHR_vulkan_memory_model]> {
+  spirv.GlobalVariable @transpose_int_arg_0 bind(0, 0) : !spirv.ptr<!spirv.arm.tensor<14x28x1x61xi16>, UniformConstant>
+  spirv.GlobalVariable @transpose_int_res_0 bind(1, 0) : !spirv.ptr<!spirv.arm.tensor<1x14x28x61xi16>, UniformConstant>
+  spirv.ARM.GraphEntryPoint @transpose_int, @transpose_int_arg_0, @transpose_int_res_0
+  spirv.ARM.Graph @transpose_int(%arg0: !spirv.arm.tensor<14x28x1x61xi16>) -> (!spirv.arm.tensor<1x14x28x61xi16>) {
+    // CHECK: {{%.*}} = spirv.Tosa.Transpose perms = [2, 0, 1, 3], %arg0 : !spirv.arm.tensor<14x28x1x61xi16> -> !spirv.arm.tensor<1x14x28x61xi16>
+    %1 = spirv.Tosa.Transpose perms = [2, 0, 1, 3], %arg0 : !spirv.arm.tensor<14x28x1x61xi16> -> !spirv.arm.tensor<1x14x28x61xi16>
+    // CHECK: spirv.ARM.GraphOutputs {{%.*}} : !spirv.arm.tensor<1x14x28x61xi16>
+    spirv.ARM.GraphOutputs %1 : !spirv.arm.tensor<1x14x28x61xi16>
+  }
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// spirv.TOSA.Transpose - PRO-FP
+//===----------------------------------------------------------------------===//
+
+// CHECK: spirv.module Logical Vulkan requires #spirv.vce<v1.3, [VulkanMemoryModel, Shader, Int8, Int16, Int64, Float16, TensorsARM, GraphARM], [SPV_ARM_tensors, SPV_ARM_graph, SPV_KHR_vulkan_memory_model]>
+spirv.module Logical Vulkan requires #spirv.vce<v1.3, [VulkanMemoryModel, Shader, Int8, Int16, Int64, Float16, TensorsARM, GraphARM], [SPV_ARM_tensors, SPV_ARM_graph, SPV_KHR_vulkan_memory_model]> {
+  spirv.GlobalVariable @transpose_fp_arg_0 bind(0, 0) : !spirv.ptr<!spirv.arm.tensor<42x22x49xi1>, UniformConstant>
+  spirv.GlobalVariable @transpose_fp_res_0 bind(1, 0) : !spirv.ptr<!spirv.arm.tensor<49x42x22xi1>, UniformConstant>
+  spirv.ARM.GraphEntryPoint @transpose_fp, @transpose_fp_arg_0, @transpose_fp_res_0
+  spirv.ARM.Graph @transpose_fp(%arg0: !spirv.arm.tensor<42x22x49xi1>) -> (!spirv.arm.tensor<49x42x22xi1>) {
+    // CHECK: {{%.*}} = spirv.Tosa.Transpose perms = [2, 0, 1], %arg0 : !spirv.arm.tensor<42x22x49xi1> -> !spirv.arm.tensor<49x42x22xi1>
+    %1 = spirv.Tosa.Transpose perms = [2, 0, 1], %arg0 : !spirv.arm.tensor<42x22x49xi1> -> !spirv.arm.tensor<49x42x22xi1>
+    // CHECK: spirv.ARM.GraphOutputs {{%.*}} : !spirv.arm.tensor<49x42x22xi1>
+    spirv.ARM.GraphOutputs %1 : !spirv.arm.tensor<49x42x22xi1>
+  }
+}


### PR DESCRIPTION
This patch introduces the following reduction operators:

spirv.Tosa.Reverse
spirv.Tosa.Slice
spirv.Tosa.Tile
spirv.Tosa.Transpose

Also dialect and serialization round-trip tests have been added.