### PR TITLE
[CIR][CIRGen] Support for section atttribute on cir.global

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -2842,7 +2842,9 @@ def CIR_GlobalOp : CIR_Op<"global", [
                        UnitAttr:$dso_local,
                        OptionalAttr<CIR_StaticLocalGuardAttr>:$static_local_guard,
                        OptionalAttr<I64Attr>:$alignment,
-                       OptionalAttr<ASTVarDeclInterface>:$ast);
+                       OptionalAttr<ASTVarDeclInterface>:$ast,
+                       OptionalAttr<StrAttr>:$section
+                       );
 
   let regions = (region MaxSizedRegion<1>:$ctorRegion,
                         MaxSizedRegion<1>:$dtorRegion);
@@ -2900,6 +2902,10 @@ def CIR_GlobalOp : CIR_Op<"global", [
 
     void setupRegionInitializedLLVMGlobalOp(
         cir::GlobalOp op, mlir::ConversionPatternRewriter &rewriter) const;
+
+    llvm::SmallVector<mlir::NamedAttribute> lowerGlobalAttributes(
+        cir::GlobalOp op,
+        mlir::ConversionPatternRewriter &rewriter) const;
 
     mutable mlir::LLVM::ComdatOp comdatOp = nullptr;
     mlir::SymbolRefAttr getComdatAttr(cir::GlobalOp &op,

--- a/clang/include/clang/CIR/Interfaces/CIROpInterfaces.td
+++ b/clang/include/clang/CIR/Interfaces/CIROpInterfaces.td
@@ -155,6 +155,22 @@ let cppNamespace = "::cir" in {
       /*defaultImplementation=*/[{
         return cir::isWeakForLinker($_op.getLinkage());
       }]
+      >,
+      InterfaceMethod<"",
+      "void", "setSection", (ins "mlir::StringAttr":$val), [{}],
+      /*defaultImplementation=*/[{
+        if (val)
+          $_op->setAttr("section", val);
+        else
+          $_op->removeAttr("section");
+      }]
+      >,
+      InterfaceMethod<"",
+      "mlir::StringAttr", "getSectionAttr", (ins), [{}],
+      /*defaultImplementation=*/[{
+        return mlir::dyn_cast_if_present<mlir::StringAttr>(
+            $_op->getAttr("section"));
+      }]
       >
     ];
     let extraClassDeclaration = [{

--- a/clang/include/clang/CIR/MissingFeatures.h
+++ b/clang/include/clang/CIR/MissingFeatures.h
@@ -31,7 +31,6 @@ struct MissingFeatures {
   static bool opGlobalThreadLocal() { return false; }
   static bool opGlobalWeakRef() { return false; }
   static bool opGlobalUnnamedAddr() { return false; }
-  static bool opGlobalSection() { return false; }
   static bool opGlobalVisibility() { return false; }
   static bool opGlobalDLLImportExport() { return false; }
   static bool opGlobalPartition() { return false; }

--- a/clang/include/clang/CIR/MissingFeatures.h
+++ b/clang/include/clang/CIR/MissingFeatures.h
@@ -85,7 +85,6 @@ struct MissingFeatures {
   static bool opFuncOptNoneAttr() { return false; }
   static bool opFuncParameterAttributes() { return false; }
   static bool opFuncReadOnly() { return false; }
-  static bool opFuncSection() { return false; }
   static bool opFuncUnwindTablesAttr() { return false; }
   static bool opFuncWillReturn() { return false; }
   static bool opFuncNoReturn() { return false; }

--- a/clang/include/clang/CIR/MissingFeatures.h
+++ b/clang/include/clang/CIR/MissingFeatures.h
@@ -35,6 +35,7 @@ struct MissingFeatures {
   static bool opGlobalDLLImportExport() { return false; }
   static bool opGlobalPartition() { return false; }
   static bool opGlobalUsedOrCompilerUsed() { return false; }
+  static bool opGlobalPragmaClangSection() { return false; }
   static bool opGlobalAnnotations() { return false; }
   static bool opGlobalCtorPriority() { return false; }
   static bool setDSOLocal() { return false; }

--- a/clang/lib/CIR/CodeGen/CIRGenModule.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.cpp
@@ -674,7 +674,6 @@ void CIRGenModule::setNonAliasAttributes(GlobalDecl gd, mlir::Operation *op) {
 
   assert(!cir::MissingFeatures::opGlobalUsedOrCompilerUsed());
   assert(!cir::MissingFeatures::opFuncCPUAndFeaturesAttributes());
-  assert(!cir::MissingFeatures::opFuncSection());
 
   getTargetCIRGenInfo().setTargetAttributes(gd.getDecl(), op, *this);
 }

--- a/clang/lib/CIR/CodeGen/CIRGenModule.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.cpp
@@ -664,8 +664,15 @@ void CIRGenModule::setCommonAttributes(GlobalDecl gd, mlir::Operation *gv) {
 void CIRGenModule::setNonAliasAttributes(GlobalDecl gd, mlir::Operation *op) {
   setCommonAttributes(gd, op);
 
+  const Decl *d = gd.getDecl();
+  if (d) {
+    if (auto globalOp = mlir::dyn_cast<cir::GlobalOp>(op)) {
+      if (const auto *sa = d->getAttr<SectionAttr>())
+        globalOp.setSectionAttr(builder.getStringAttr(sa->getName()));
+    }
+  }
+
   assert(!cir::MissingFeatures::opGlobalUsedOrCompilerUsed());
-  assert(!cir::MissingFeatures::opGlobalSection());
   assert(!cir::MissingFeatures::opFuncCPUAndFeaturesAttributes());
   assert(!cir::MissingFeatures::opFuncSection());
 
@@ -991,7 +998,11 @@ CIRGenModule::getOrCreateCIRGlobal(StringRef mangledName, mlir::Type ty,
       errorNYI(d->getSourceRange(),
                "getOrCreateCIRGlobal: MS static data member inline definition");
 
-    assert(!cir::MissingFeatures::opGlobalSection());
+    // Emit section information for extern variables.
+    if (d->hasExternalStorage()) {
+      if (const SectionAttr *sa = d->getAttr<SectionAttr>())
+        gv.setSectionAttr(builder.getStringAttr(sa->getName()));
+    }
     gv.setGlobalVisibilityAttr(getGlobalVisibilityAttrFromDecl(d));
 
     // Handle XCore specific ABI requirements.
@@ -1243,7 +1254,13 @@ void CIRGenModule::emitGlobalVarDefinition(const clang::VarDecl *vd,
                   vd->getType().isConstantStorage(astContext,
                                                   /*ExcludeCtor=*/true,
                                                   /*ExcludeDtor=*/true)));
-  assert(!cir::MissingFeatures::opGlobalSection());
+  // If it is in a read-only section, mark it 'constant'.
+  if (const SectionAttr *sa = vd->getAttr<SectionAttr>()) {
+    gv.setSectionAttr(getBuilder().getStringAttr(sa->getName()));
+    const ASTContext::SectionInfo &si = astContext.SectionInfos[sa->getName()];
+    if ((si.SectionFlags & ASTContext::PSF_Write) == 0)
+      gv.setConstant(true);
+  }
 
   // Set CIR linkage and DLL storage class.
   gv.setLinkage(linkage);

--- a/clang/lib/CIR/CodeGen/CIRGenModule.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.cpp
@@ -666,9 +666,9 @@ void CIRGenModule::setNonAliasAttributes(GlobalDecl gd, mlir::Operation *op) {
 
   const Decl *d = gd.getDecl();
   if (d) {
-    if (auto globalOp = mlir::dyn_cast<cir::GlobalOp>(op)) {
+    if (auto gvi = mlir::dyn_cast<cir::CIRGlobalValueInterface>(op)) {
       if (const auto *sa = d->getAttr<SectionAttr>())
-        globalOp.setSectionAttr(builder.getStringAttr(sa->getName()));
+        gvi.setSection(builder.getStringAttr(sa->getName()));
     }
   }
 
@@ -1256,7 +1256,6 @@ void CIRGenModule::emitGlobalVarDefinition(const clang::VarDecl *vd,
                                                   /*ExcludeDtor=*/true)));
   // If it is in a read-only section, mark it 'constant'.
   if (const SectionAttr *sa = vd->getAttr<SectionAttr>()) {
-    gv.setSectionAttr(getBuilder().getStringAttr(sa->getName()));
     const ASTContext::SectionInfo &si = astContext.SectionInfos[sa->getName()];
     if ((si.SectionFlags & ASTContext::PSF_Write) == 0)
       gv.setConstant(true);

--- a/clang/lib/CIR/CodeGen/CIRGenModule.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.cpp
@@ -672,6 +672,7 @@ void CIRGenModule::setNonAliasAttributes(GlobalDecl gd, mlir::Operation *op) {
     }
   }
 
+  assert(!cir::MissingFeatures::opGlobalPragmaClangSection());
   assert(!cir::MissingFeatures::opGlobalUsedOrCompilerUsed());
   assert(!cir::MissingFeatures::opFuncCPUAndFeaturesAttributes());
 

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -2566,6 +2566,26 @@ mlir::LogicalResult CIRToLLVMGetGlobalOpLowering::matchAndRewrite(
   return mlir::success();
 }
 
+llvm::SmallVector<mlir::NamedAttribute>
+CIRToLLVMGlobalOpLowering::lowerGlobalAttributes(
+    cir::GlobalOp op, mlir::ConversionPatternRewriter &rewriter) const {
+  SmallVector<mlir::NamedAttribute> attributes;
+
+  if (auto sectionAttr = op.getSectionAttr())
+    attributes.push_back(rewriter.getNamedAttr("section", sectionAttr));
+
+  mlir::LLVM::VisibilityAttr visibility = mlir::LLVM::VisibilityAttr::get(
+      getContext(), lowerCIRVisibilityToLLVMVisibility(
+                        op.getGlobalVisibilityAttr().getValue()));
+  attributes.push_back(rewriter.getNamedAttr("visibility_", visibility));
+
+  if (op->getAttr(CUDAExternallyInitializedAttr::getMnemonic()))
+    attributes.push_back(rewriter.getNamedAttr("externally_initialized",
+                                               rewriter.getUnitAttr()));
+
+  return attributes;
+}
+
 /// Replace CIR global with a region initialized LLVM global and update
 /// insertion point to the end of the initializer block.
 void CIRToLLVMGlobalOpLowering::setupRegionInitializedLLVMGlobalOp(
@@ -2589,7 +2609,9 @@ void CIRToLLVMGlobalOpLowering::setupRegionInitializedLLVMGlobalOp(
   const StringRef symbol = op.getSymName();
   mlir::SymbolRefAttr comdatAttr = getComdatAttr(op, rewriter);
 
-  SmallVector<mlir::NamedAttribute> attributes;
+  SmallVector<mlir::NamedAttribute> attributes =
+      lowerGlobalAttributes(op, rewriter);
+
   mlir::LLVM::GlobalOp newGlobalOp =
       rewriter.replaceOpWithNewOp<mlir::LLVM::GlobalOp>(
           op, llvmType, isConst, linkage, symbol, nullptr, alignment, addrSpace,
@@ -2650,14 +2672,8 @@ mlir::LogicalResult CIRToLLVMGlobalOpLowering::matchAndRewrite(
   const uint64_t alignment = op.getAlignment().value_or(0);
   const mlir::LLVM::Linkage linkage = convertLinkage(op.getLinkage());
   const StringRef symbol = op.getSymName();
-  SmallVector<mlir::NamedAttribute> attributes;
-
-  // Mark externally_initialized for __device__ and __constant__
-  if (auto extInit =
-          op->getAttr(CUDAExternallyInitializedAttr::getMnemonic())) {
-    attributes.push_back(rewriter.getNamedAttr("externally_initialized",
-                                               rewriter.getUnitAttr()));
-  }
+  SmallVector<mlir::NamedAttribute> attributes =
+      lowerGlobalAttributes(op, rewriter);
 
   if (init.has_value()) {
     if (mlir::isa<cir::FPAttr, cir::IntAttr, cir::BoolAttr>(init.value())) {
@@ -2688,13 +2704,10 @@ mlir::LogicalResult CIRToLLVMGlobalOpLowering::matchAndRewrite(
     }
   }
 
-  mlir::LLVM::Visibility visibility =
-      lowerCIRVisibilityToLLVMVisibility(op.getGlobalVisibility());
   mlir::SymbolRefAttr comdatAttr = getComdatAttr(op, rewriter);
-  auto newOp = rewriter.replaceOpWithNewOp<mlir::LLVM::GlobalOp>(
+  rewriter.replaceOpWithNewOp<mlir::LLVM::GlobalOp>(
       op, llvmType, isConst, linkage, symbol, init.value_or(mlir::Attribute()),
       alignment, addrSpace, isDsoLocal, isThreadLocal, comdatAttr, attributes);
-  newOp.setVisibility_(visibility);
 
   return mlir::success();
 }

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -2571,7 +2571,7 @@ CIRToLLVMGlobalOpLowering::lowerGlobalAttributes(
     cir::GlobalOp op, mlir::ConversionPatternRewriter &rewriter) const {
   SmallVector<mlir::NamedAttribute> attributes;
 
-  if (auto sectionAttr = op.getSectionAttr())
+  if (mlir::StringAttr sectionAttr = op.getSectionAttr())
     attributes.push_back(rewriter.getNamedAttr("section", sectionAttr));
 
   mlir::LLVM::VisibilityAttr visibility = mlir::LLVM::VisibilityAttr::get(

--- a/clang/test/CIR/CodeGen/global-section.c
+++ b/clang/test/CIR/CodeGen/global-section.c
@@ -1,0 +1,14 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o - | FileCheck %s --check-prefix=CIR
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o - | FileCheck %s --check-prefix=LLVM
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -emit-llvm %s -o - | FileCheck %s --check-prefix=LLVM
+
+extern int __attribute__((section(".shared"))) ext;
+int getExt(void) {
+  return ext;
+}
+// CIR: cir.global "private" external @ext : !s32i {{{.*}}section = ".shared"}
+// LLVM: @ext = external global i32, section ".shared"
+
+int __attribute__((section(".shared"))) glob = 42;
+// CIR: cir.global external @glob = #cir.int<42> : !s32i {{{.*}}section = ".shared"}
+// LLVM: @glob = global i32 42, section ".shared"

--- a/clang/test/CIR/CodeGen/global-section.c
+++ b/clang/test/CIR/CodeGen/global-section.c
@@ -12,3 +12,7 @@ int getExt(void) {
 int __attribute__((section(".shared"))) glob = 42;
 // CIR: cir.global external @glob = #cir.int<42> : !s32i {{{.*}}section = ".shared"}
 // LLVM: @glob = global i32 42, section ".shared"
+
+__attribute__((section(".custom_fn"))) void func_in_section(void) {}
+// CIR: cir.func {{.*}}@func_in_section() {{.*}}section = ".custom_fn"
+// LLVM: define {{.*}}@func_in_section(){{.*}}section ".custom_fn"


### PR DESCRIPTION
Upstreaming clangIR PR: https://github.com/llvm/clangir/pull/422

This PR implement support for `__attribute__((section("name")))` on global variables in ClangIR, matching OGCG behavior.
