### PR TITLE
[libc] cbrtf guard to sync with general format

### DIFF
--- a/libc/shared/math/cbrtf.h
+++ b/libc/shared/math/cbrtf.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef LIBC_SHARED_MATH_CBRTF_H
-#define LIBC_SHARED_MATH_CBRTF_H
+#ifndef LLVM_LIBC_SHARED_MATH_CBRTF_H
+#define LLVM_LIBC_SHARED_MATH_CBRTF_H
 
 #include "shared/libc_common.h"
 #include "src/__support/math/cbrtf.h"

--- a/libc/shared/math/cbrtf.h
+++ b/libc/shared/math/cbrtf.h
@@ -20,4 +20,4 @@ using math::cbrtf;
 } // namespace shared
 } // namespace LIBC_NAMESPACE_DECL
 
-#endif // LIBC_SHARED_MATH_CBRTF_H
+#endif // LLVM_LIBC_SHARED_MATH_CBRTF_H


### PR DESCRIPTION
This PR intends to make the cbrtf guard sync with the general format ( as other functions consistently use `LLVM_LIBC_SHARED_MATH_<func>_H`). 
This was found during refactoring cbrtbf16.
