### PR TITLE
AMDGPU: incrementally reanalyze stale PromoteAlloca state

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUPromoteAlloca.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUPromoteAlloca.cpp
@@ -90,11 +90,11 @@ static cl::opt<unsigned>
 // VarIndex is A, VarMul is stride, VarShift is shift and ConstIndex is B. All
 // parts are optional.
 struct GEPToVectorIndex {
-  Value *VarIndex = nullptr;         // defaults to 0
+  WeakTrackingVH VarIndex;           // defaults to 0
   ConstantInt *VarMul = nullptr;     // defaults to 1
   ConstantInt *VarShift = nullptr;   // defaults to 0
   ConstantInt *ConstIndex = nullptr; // defaults to 0
-  Value *Full = nullptr;
+  WeakTrackingVH Full;
 };
 
 struct MemTransferInfo {
@@ -102,23 +102,29 @@ struct MemTransferInfo {
   ConstantInt *DestIndex = nullptr;
 };
 
+struct TrackedUse {
+  WeakVH User;
+  unsigned OperandNo = 0;
+};
+
 // Analysis for planning the different strategies of alloca promotion.
 struct AllocaAnalysis {
   AllocaInst *Alloca = nullptr;
   DenseSet<Value *> Pointers;
-  SmallVector<Use *> Uses;
+  SmallVector<TrackedUse> Uses;
+  SmallVector<WeakVH> Dependencies;
   unsigned Score = 0;
   bool HaveSelectOrPHI = false;
   struct {
     FixedVectorType *Ty = nullptr;
-    SmallVector<Instruction *> Worklist;
-    SmallVector<Instruction *> UsersToRemove;
+    SmallVector<WeakVH> Worklist;
+    SmallVector<WeakVH> UsersToRemove;
     MapVector<GetElementPtrInst *, GEPToVectorIndex> GEPVectorIdx;
     MapVector<MemTransferInst *, MemTransferInfo> TransferInfo;
   } Vector;
   struct {
     bool Enable = false;
-    SmallVector<User *> Worklist;
+    SmallVector<WeakVH> Worklist;
   } LDS;
 
   explicit AllocaAnalysis(AllocaInst *Alloca) : Alloca(Alloca) {}
@@ -168,6 +174,8 @@ private:
   finishDeferredAllocaToLDSPromotion(SetVector<IntrinsicInst *> &DeferredIntrs);
 
   void scoreAlloca(AllocaAnalysis &AA) const;
+  bool shouldReanalyzeAlloca(const AllocaAnalysis &AA) const;
+  bool rebuildAllocaAnalysis(AllocaAnalysis &AA, bool PromoteToLDS) const;
 
   void setFunctionLimits(const Function &F);
 
@@ -298,7 +306,7 @@ bool AMDGPUPromoteAllocaImpl::collectAllocaUses(AllocaAnalysis &AA) const {
           return RejectUser(Inst, "pointer escapes via store");
         }
       }
-      AA.Uses.push_back(&U);
+      AA.Uses.push_back({Inst, U.getOperandNo()});
 
       if (isa<GetElementPtrInst>(U.getUser())) {
         WorkList.push_back(Inst);
@@ -337,8 +345,10 @@ void AMDGPUPromoteAllocaImpl::scoreAlloca(AllocaAnalysis &AA) const {
   LLVM_DEBUG(dbgs() << "Scoring: " << *AA.Alloca << "\n");
   unsigned Score = 0;
   // Increment score by one for each user + a bonus for users within loops.
-  for (auto *U : AA.Uses) {
-    Instruction *Inst = cast<Instruction>(U->getUser());
+  for (const TrackedUse &U : AA.Uses) {
+    Instruction *Inst = dyn_cast_or_null<Instruction>((Value *)U.User);
+    if (!Inst)
+      continue;
     if (isa<GetElementPtrInst>(Inst) || isa<SelectInst>(Inst) ||
         isa<PHINode>(Inst))
       continue;
@@ -366,6 +376,103 @@ void AMDGPUPromoteAllocaImpl::setFunctionLimits(const Function &F) {
       PromoteAllocaToVectorVGPRRatio);
   if (PromoteAllocaToVectorVGPRRatio.getNumOccurrences())
     VGPRBudgetRatio = PromoteAllocaToVectorVGPRRatio;
+}
+
+static bool hasLiveHandle(const SmallVectorImpl<WeakVH> &Handles) {
+  return any_of(Handles, [](const WeakVH &Handle) { return (Value *)Handle; });
+}
+
+static bool containsHandle(const SmallVectorImpl<WeakVH> &Handles, Value *V) {
+  return any_of(Handles,
+                [V](const WeakVH &Handle) { return (Value *)Handle == V; });
+}
+
+static SmallVector<Instruction *> getLiveInstructions(
+    const SmallVectorImpl<WeakVH> &Handles) {
+  SmallVector<Instruction *> Result;
+  Result.reserve(Handles.size());
+  for (const WeakVH &Handle : Handles)
+    if (auto *Inst = dyn_cast_or_null<Instruction>((Value *)Handle))
+      Result.push_back(Inst);
+  return Result;
+}
+
+static SmallVector<Value *>
+getLiveValues(const SmallVectorImpl<WeakVH> &Handles) {
+  SmallVector<Value *> Result;
+  Result.reserve(Handles.size());
+  for (const WeakVH &Handle : Handles)
+    if (Value *V = Handle)
+      Result.push_back(V);
+  return Result;
+}
+
+static SmallVector<Instruction *>
+getLiveUseUsers(const SmallVectorImpl<TrackedUse> &Uses) {
+  SmallVector<Instruction *> Result;
+  Result.reserve(Uses.size());
+  for (const TrackedUse &Use : Uses)
+    if (auto *Inst = dyn_cast_or_null<Instruction>((Value *)Use.User))
+      Result.push_back(Inst);
+  return Result;
+}
+
+static void trackDependency(AllocaAnalysis &AA, Value *V) {
+  if (!V || isa<Constant>(V) || AA.Pointers.contains(V) ||
+      containsHandle(AA.Dependencies, V))
+    return;
+  AA.Dependencies.push_back(V);
+}
+
+bool AMDGPUPromoteAllocaImpl::shouldReanalyzeAlloca(
+    const AllocaAnalysis &AA) const {
+  if (!AA.Alloca || !AA.Alloca->getParent() || AA.Alloca->use_empty())
+    return false;
+
+  if (getLiveUseUsers(AA.Uses).size() != AA.Uses.size())
+    return true;
+
+  if (getLiveValues(AA.Dependencies).size() != AA.Dependencies.size())
+    return true;
+
+  if (AA.Vector.Ty) {
+    if (getLiveInstructions(AA.Vector.Worklist).size() !=
+        AA.Vector.Worklist.size())
+      return true;
+    if (getLiveInstructions(AA.Vector.UsersToRemove).size() !=
+        AA.Vector.UsersToRemove.size())
+      return true;
+  }
+
+  if (AA.LDS.Enable &&
+      getLiveValues(AA.LDS.Worklist).size() != AA.LDS.Worklist.size())
+    return true;
+
+  return false;
+}
+
+bool AMDGPUPromoteAllocaImpl::rebuildAllocaAnalysis(AllocaAnalysis &AA,
+                                                    bool PromoteToLDS) const {
+  AllocaInst *AI = AA.Alloca;
+  if (!AI || !AI->getParent() || AI->use_empty())
+    return false;
+
+  LLVM_DEBUG(dbgs() << "Re-analyzing alloca after earlier rewrite: " << *AI
+                    << '\n');
+
+  AllocaAnalysis Updated{AI};
+  if (!collectAllocaUses(Updated))
+    return false;
+
+  analyzePromoteToVector(Updated);
+  if (PromoteToLDS)
+    analyzePromoteToLDS(Updated);
+  if (!Updated.Vector.Ty && !Updated.LDS.Enable)
+    return false;
+
+  scoreAlloca(Updated);
+  AA = std::move(Updated);
+  return true;
 }
 
 bool AMDGPUPromoteAllocaImpl::run(Function &F, bool PromoteToLDS) {
@@ -420,7 +527,24 @@ bool AMDGPUPromoteAllocaImpl::run(Function &F, bool PromoteToLDS) {
 
   bool Changed = false;
   SetVector<IntrinsicInst *> DeferredIntrs;
-  for (AllocaAnalysis &AA : Allocas) {
+  for (auto It : enumerate(Allocas)) {
+    AllocaAnalysis &AA = It.value();
+    if (AA.Alloca->use_empty()) {
+      LLVM_DEBUG(dbgs() << "Skipping dead alloca: " << *AA.Alloca << "\n");
+      continue;
+    }
+
+    if (shouldReanalyzeAlloca(AA)) {
+      if (!rebuildAllocaAnalysis(AA, PromoteToLDS))
+        continue;
+    }
+
+    if (AA.Vector.Ty && !hasLiveHandle(AA.Vector.Worklist)) {
+      LLVM_DEBUG(dbgs() << "Skipping stale vector state with no live worklist: "
+                        << *AA.Alloca << "\n");
+      AA.Vector.Ty = nullptr;
+    }
+
     if (AA.Vector.Ty) {
       std::optional<TypeSize> Size = AA.Alloca->getAllocationSize(*DL);
       assert(Size); // Expected to succeed on non-array alloca.
@@ -483,35 +607,34 @@ static Value *calculateVectorIndex(Value *Ptr, AllocaAnalysis &AA) {
   auto I = AA.Vector.GEPVectorIdx.find(GEP);
   assert(I != AA.Vector.GEPVectorIdx.end() && "Must have entry for GEP!");
 
-  if (!I->second.Full) {
-    Value *Result = nullptr;
-    B.SetInsertPoint(GEP);
+  if (Value *Cached = I->second.Full)
+    return Cached;
 
-    if (I->second.VarIndex) {
-      Result = I->second.VarIndex;
-      Result = B.CreateSExtOrTrunc(Result, B.getInt32Ty());
+  Value *Result = nullptr;
+  B.SetInsertPoint(GEP);
 
-      if (I->second.VarMul)
-        Result = B.CreateMul(Result, I->second.VarMul);
+  if (Value *VarIndex = I->second.VarIndex) {
+    Result = B.CreateSExtOrTrunc(VarIndex, B.getInt32Ty());
 
-      if (I->second.VarShift)
-        Result = B.CreateAShr(Result, I->second.VarShift, "", /*isExact*/ true);
-    }
+    if (I->second.VarMul)
+      Result = B.CreateMul(Result, I->second.VarMul);
 
-    if (I->second.ConstIndex) {
-      if (Result)
-        Result = B.CreateAdd(Result, I->second.ConstIndex);
-      else
-        Result = I->second.ConstIndex;
-    }
-
-    if (!Result)
-      Result = B.getInt32(0);
-
-    I->second.Full = Result;
+    if (I->second.VarShift)
+      Result = B.CreateAShr(Result, I->second.VarShift, "", /*isExact*/ true);
   }
 
-  return I->second.Full;
+  if (I->second.ConstIndex) {
+    if (Result)
+      Result = B.CreateAdd(Result, I->second.ConstIndex);
+    else
+      Result = I->second.ConstIndex;
+  }
+
+  if (!Result)
+    Result = B.getInt32(0);
+
+  I->second.Full = Result;
+  return Result;
 }
 
 static std::optional<GEPToVectorIndex>
@@ -983,12 +1106,12 @@ void AMDGPUPromoteAllocaImpl::analyzePromoteToVector(AllocaAnalysis &AA) const {
   Type *VecEltTy = AA.Vector.Ty->getElementType();
   unsigned ElementSize = DL->getTypeSizeInBits(VecEltTy) / 8;
   assert(ElementSize > 0);
-  for (auto *U : AA.Uses) {
-    Instruction *Inst = cast<Instruction>(U->getUser());
+  for (const TrackedUse &U : AA.Uses) {
+    Instruction *Inst = cast<Instruction>((Value *)U.User);
 
     if (Value *Ptr = getLoadStorePointerOperand(Inst)) {
       assert(!isa<StoreInst>(Inst) ||
-             U->getOperandNo() == StoreInst::getPointerOperandIndex());
+             U.OperandNo == StoreInst::getPointerOperandIndex());
 
       Type *AccessTy = getLoadStoreType(Inst);
       if (AccessTy->isAggregateType())
@@ -1025,6 +1148,8 @@ void AMDGPUPromoteAllocaImpl::analyzePromoteToVector(AllocaAnalysis &AA) const {
       if (!Index)
         return RejectUser(Inst, "cannot compute vector index for GEP");
 
+      if (Index->VarIndex)
+        trackDependency(AA, Index->VarIndex);
       AA.Vector.GEPVectorIdx[GEP] = std::move(Index.value());
       AA.Vector.UsersToRemove.push_back(Inst);
       continue;
@@ -1060,7 +1185,7 @@ void AMDGPUPromoteAllocaImpl::analyzePromoteToVector(AllocaAnalysis &AA) const {
 
       MemTransferInfo *TI =
           &AA.Vector.TransferInfo.try_emplace(TransferInst).first->second;
-      unsigned OpNum = U->getOperandNo();
+      unsigned OpNum = U.OperandNo;
       if (OpNum == 0) {
         Value *Dest = TransferInst->getDest();
         ConstantInt *Index = getConstIndexIntoAlloca(Dest);
@@ -1117,6 +1242,13 @@ void AMDGPUPromoteAllocaImpl::promoteAllocaToVector(AllocaAnalysis &AA) {
   LLVM_DEBUG(dbgs() << "Promoting to vectors: " << *AA.Alloca << '\n');
   LLVM_DEBUG(dbgs() << "  type conversion: " << *AA.Alloca->getAllocatedType()
                     << " -> " << *AA.Vector.Ty << '\n');
+  SmallVector<Instruction *> Worklist = getLiveInstructions(AA.Vector.Worklist);
+  if (Worklist.empty()) {
+    LLVM_DEBUG(dbgs() << "  No live vector users remain\n");
+    return;
+  }
+  SmallVector<Instruction *> UsersToRemove =
+      getLiveInstructions(AA.Vector.UsersToRemove);
   const unsigned VecStoreSize = DL->getTypeStoreSize(AA.Vector.Ty);
 
   Type *VecEltTy = AA.Vector.Ty->getElementType();
@@ -1141,7 +1273,7 @@ void AMDGPUPromoteAllocaImpl::promoteAllocaToVector(AllocaAnalysis &AA) {
   // Insert a placeholder whenever we need the vector value at the top of a
   // basic block.
   SmallVector<Instruction *> Placeholders;
-  forEachWorkListItem(AA.Vector.Worklist, [&](Instruction *I) {
+  forEachWorkListItem(Worklist, [&](Instruction *I) {
     BasicBlock *BB = I->getParent();
     auto GetCurVal = [&]() -> Value * {
       if (Value *CurVal = Updater.FindValueForBlock(BB))
@@ -1182,13 +1314,13 @@ void AMDGPUPromoteAllocaImpl::promoteAllocaToVector(AllocaAnalysis &AA) {
   }
 
   // Delete all instructions.
-  for (Instruction *I : AA.Vector.Worklist) {
+  for (Instruction *I : Worklist) {
     assert(I->use_empty());
     I->eraseFromParent();
   }
 
   // Delete all the users that are known to be removeable.
-  for (Instruction *I : reverse(AA.Vector.UsersToRemove)) {
+  for (Instruction *I : reverse(UsersToRemove)) {
     I->dropDroppableUses();
     assert(I->use_empty());
     I->eraseFromParent();
@@ -1393,19 +1525,21 @@ void AMDGPUPromoteAllocaImpl::analyzePromoteToLDS(AllocaAnalysis &AA) const {
     return;
   }
 
-  for (Use *Use : AA.Uses) {
-    auto *User = Use->getUser();
+  for (const TrackedUse &Use : AA.Uses) {
+    auto *TrackedUser = dyn_cast_or_null<llvm::User>((Value *)Use.User);
+    if (!TrackedUser)
+      return;
 
-    if (CallInst *CI = dyn_cast<CallInst>(User)) {
+    if (CallInst *CI = dyn_cast<CallInst>(TrackedUser)) {
       if (!isCallPromotable(CI))
         return;
 
-      if (find(AA.LDS.Worklist, User) == AA.LDS.Worklist.end())
-        AA.LDS.Worklist.push_back(User);
+      if (!containsHandle(AA.LDS.Worklist, TrackedUser))
+        AA.LDS.Worklist.push_back(TrackedUser);
       continue;
     }
 
-    Instruction *UseInst = cast<Instruction>(User);
+    Instruction *UseInst = cast<Instruction>(TrackedUser);
     if (UseInst->getOpcode() == Instruction::PtrToInt)
       return;
 
@@ -1436,11 +1570,13 @@ void AMDGPUPromoteAllocaImpl::analyzePromoteToLDS(AllocaAnalysis &AA) const {
     // Only promote a select if we know that the other select operand
     // is from another pointer that will also be promoted.
     if (ICmpInst *ICmp = dyn_cast<ICmpInst>(UseInst)) {
-      if (!binaryOpIsDerivedFromSameAlloca(AA.Alloca, Use->get(), ICmp, 0, 1))
+      if (!binaryOpIsDerivedFromSameAlloca(AA.Alloca,
+                                           ICmp->getOperand(Use.OperandNo), ICmp,
+                                           0, 1))
         return;
 
       // May need to rewrite constant operands.
-      if (find(AA.LDS.Worklist, User) == AA.LDS.Worklist.end())
+      if (!containsHandle(AA.LDS.Worklist, TrackedUser))
         AA.LDS.Worklist.push_back(ICmp);
       continue;
     }
@@ -1450,7 +1586,7 @@ void AMDGPUPromoteAllocaImpl::analyzePromoteToLDS(AllocaAnalysis &AA) const {
       // the alloca.
       if (!GEP->isInBounds())
         return;
-    } else if (!isa<ExtractElementInst, SelectInst, PHINode>(User)) {
+    } else if (!isa<ExtractElementInst, SelectInst, PHINode>(TrackedUser)) {
       // Do not promote vector/aggregate type instructions. It is hard to track
       // their users.
 
@@ -1461,8 +1597,8 @@ void AMDGPUPromoteAllocaImpl::analyzePromoteToLDS(AllocaAnalysis &AA) const {
       return;
     }
 
-    if (find(AA.LDS.Worklist, User) == AA.LDS.Worklist.end())
-      AA.LDS.Worklist.push_back(User);
+    if (!containsHandle(AA.LDS.Worklist, TrackedUser))
+      AA.LDS.Worklist.push_back(TrackedUser);
   }
 
   AA.LDS.Enable = true;
@@ -1601,6 +1737,11 @@ bool AMDGPUPromoteAllocaImpl::tryPromoteAllocaToLDS(
     SetVector<IntrinsicInst *> &DeferredIntrs) {
   LLVM_DEBUG(dbgs() << "Trying to promote to LDS: " << *AA.Alloca << '\n');
 
+  if (AA.Alloca->use_empty()) {
+    LLVM_DEBUG(dbgs() << "  Alloca already dead, skipping LDS promotion\n");
+    return false;
+  }
+
   // Not likely to have sufficient local memory for promotion.
   if (!SufficientLDS)
     return false;
@@ -1670,7 +1811,8 @@ bool AMDGPUPromoteAllocaImpl::tryPromoteAllocaToLDS(
 
   PointerType *NewPtrTy = PointerType::get(Context, AMDGPUAS::LOCAL_ADDRESS);
 
-  for (Value *V : AA.LDS.Worklist) {
+  SmallVector<Value *> LDSWorklist = getLiveValues(AA.LDS.Worklist);
+  for (Value *V : LDSWorklist) {
     CallInst *Call = dyn_cast<CallInst>(V);
     if (!Call) {
       if (ICmpInst *CI = dyn_cast<ICmpInst>(V)) {
@@ -1783,22 +1925,13 @@ void AMDGPUPromoteAllocaImpl::finishDeferredAllocaToLDSPromotion(
     SetVector<IntrinsicInst *> &DeferredIntrs) {
 
   for (IntrinsicInst *Intr : DeferredIntrs) {
-    IRBuilder<> Builder(Intr);
-    Builder.SetInsertPoint(Intr);
     Intrinsic::ID ID = Intr->getIntrinsicID();
     assert(ID == Intrinsic::memcpy || ID == Intrinsic::memmove);
 
     MemTransferInst *MI = cast<MemTransferInst>(Intr);
-    auto *B = Builder.CreateMemTransferInst(
-        ID, MI->getRawDest(), MI->getDestAlign(), MI->getRawSource(),
-        MI->getSourceAlign(), MI->getLength(), MI->isVolatile());
-
-    for (unsigned I = 0; I != 2; ++I) {
-      if (uint64_t Bytes = Intr->getParamDereferenceableBytes(I)) {
-        B->addDereferenceableParamAttr(I, Bytes);
-      }
-    }
-
-    Intr->eraseFromParent();
+    Type *ArgTys[3] = {MI->getRawDest()->getType(), MI->getRawSource()->getType(),
+                       MI->getLength()->getType()};
+    MI->setCalledFunction(
+        Intrinsic::getOrInsertDeclaration(MI->getModule(), ID, ArgTys));
   }
 }

--- a/llvm/test/CodeGen/AMDGPU/promote-alloca-cross-alloca-indices-crash.ll
+++ b/llvm/test/CodeGen/AMDGPU/promote-alloca-cross-alloca-indices-crash.ll
@@ -1,81 +1,44 @@
-; NOTE: Pattern-only regression test for a cross-alloca indices crash.
-; Distilled from promote-alloca-crash-ce6eff-min.ll.
 ; RUN: opt -mtriple=amdgcn--amdpal -disable-output -verify-each -passes=amdgpu-promote-alloca -amdgpu-promote-alloca-to-vector-limit=512 < %s
+;
+; Regression test for stale cross-alloca index analysis.
+; The first loop builds entries in alloca %a using indices loaded from
+; alloca %b. The second loop then indexes %b using values loaded back from %a.
+; PromoteAlloca must not reuse invalid per-alloca index state across those
+; two allocas.
+;
+; This is a pattern-only test: the pass only needs to finish without
+; crashing while walking and rewriting the mixed %a/%b access graph.
 
 define internal amdgpu_cs void @cross_alloca_indices_crash() {
 entry:
-  %a = alloca [16 x i32], align 4, addrspace(5)
-  %b = alloca [16 x i32], align 4, addrspace(5)
-  br label %64
+  %a = alloca [4 x i32], align 4, addrspace(5)
+  %b = alloca [4 x i32], align 4, addrspace(5)
+  br label %map
 
-64:                                                ; preds = %entry, %64
-  %m = phi i32 [ 0, %entry ], [ %m.next, %64 ]
-  %b.ptr2 = getelementptr inbounds [16 x i32], ptr addrspace(5) %b, i32 0, i32 %m
-  %b.val = load i32, ptr addrspace(5) %b.ptr2, align 4
-  %idx = and i32 %b.val, 15
-  %a.ptr1 = getelementptr inbounds [16 x i32], ptr addrspace(5) %a, i32 0, i32 %idx
+  ; Build %a entries using indices loaded from %b.
+map:                                               ; preds = %entry, %map
+  %m = phi i32 [ 0, %entry ], [ %m.next, %map ]
+  %b.ptr1 = getelementptr inbounds [4 x i32], ptr addrspace(5) %b, i32 0, i32 %m
+  %b.val = load i32, ptr addrspace(5) %b.ptr1, align 4
+  %idx = and i32 %b.val, 3
+  %a.ptr1 = getelementptr inbounds [4 x i32], ptr addrspace(5) %a, i32 0, i32 %idx
   store i32 %m, ptr addrspace(5) %a.ptr1, align 4
   %m.next = add nuw nsw i32 %m, 1
-  %map.done = icmp eq i32 %m.next, 15
-  br i1 %map.done, label %.loopexit4, label %64
+  %map.done = icmp eq i32 %m.next, 4
+  br i1 %map.done, label %consume, label %map
 
-.loopexit4:                                       ; preds = %64
-  br label %79
-
-79:                                                ; preds = %.loopexit4, %.critedge
-  %in = phi i32 [ 15, %.loopexit4 ], [ %in.next, %.critedge ]
-  %in.next = add nsw i32 %in, -1
-  %b.ptr3 = getelementptr inbounds [16 x i32], ptr addrspace(5) %b, i32 0, i32 %in.next
-  %b.val2 = load i32, ptr addrspace(5) %b.ptr3, align 4
-  %start = and i32 %b.val2, 15
-  %start.plus2 = add i32 %start, 2
-  %has.candidates = icmp ult i32 %start.plus2, 16
-  br i1 %has.candidates, label %.lr.ph, label %.critedge
-
-.lr.ph:                                           ; preds = %79, %104
-  %cand = phi i32 [ %start.plus2, %79 ], [ %cand.next, %104 ]
-  %best.idx = phi i32 [ %start, %79 ], [ %cand, %104 ]
-  %a.ptr2 = getelementptr inbounds [16 x i32], ptr addrspace(5) %a, i32 0, i32 %cand
-  %a.val = load i32, ptr addrspace(5) %a.ptr2, align 4
-  %is.free = icmp eq i32 %a.val, -1
-  br i1 %is.free, label %109, label %.critedge
-
-104:                                               ; preds = %109
-  %cand.next = add i32 %cand, 2
-  %cont.search = icmp ult i32 %cand.next, 16
-  br i1 %cont.search, label %.lr.ph, label %.critedge
-
-109:                                               ; preds = %.lr.ph
-  %a.old.ptr = getelementptr inbounds [16 x i32], ptr addrspace(5) %a, i32 0, i32 %best.idx
-  store i32 -1, ptr addrspace(5) %a.old.ptr, align 4
-  store i32 %in.next, ptr addrspace(5) %a.ptr2, align 4
-  br label %104
-
-.critedge:                                        ; preds = %.lr.ph, %104, %79
-  %more = icmp sgt i32 %in, 1
-  br i1 %more, label %79, label %.loopexit2
-
-.loopexit2:                                       ; preds = %.critedge, %.loopexit4
-  br label %116
-
-116:                                               ; preds = %.loopexit2, %128
-  %p = phi i32 [ 0, %.loopexit2 ], [ %p.next, %128 ]
-  %a.ptr3 = getelementptr inbounds [16 x i32], ptr addrspace(5) %a, i32 0, i32 %p
-  %a.elem = load i32, ptr addrspace(5) %a.ptr3, align 4
-  %skip = icmp eq i32 %a.elem, -1
-  br i1 %skip, label %128, label %121
-
-121:                                               ; preds = %116
-  %b.ptr4 = getelementptr inbounds [16 x i32], ptr addrspace(5) %b, i32 0, i32 %a.elem
-  %b.elem = load i32, ptr addrspace(5) %b.ptr4, align 4
-  store i32 %b.elem, ptr addrspace(5) %b.ptr4, align 4
-  br label %128
-
-128:                                               ; preds = %121, %116
+  ; Revisit %b through indices loaded back from %a.
+consume:                                           ; preds = %map, %consume
+  %p = phi i32 [ 0, %map ], [ %p.next, %consume ]
+  %a.ptr2 = getelementptr inbounds [4 x i32], ptr addrspace(5) %a, i32 0, i32 %p
+  %a.elem = load i32, ptr addrspace(5) %a.ptr2, align 4
+  %b.ptr2 = getelementptr inbounds [4 x i32], ptr addrspace(5) %b, i32 0, i32 %a.elem
+  %b.elem = load i32, ptr addrspace(5) %b.ptr2, align 4
+  store i32 %b.elem, ptr addrspace(5) %b.ptr2, align 4
   %p.next = add nuw nsw i32 %p, 1
-  %final.done = icmp eq i32 %p.next, 16
-  br i1 %final.done, label %.loopexit, label %116
+  %consume.done = icmp eq i32 %p.next, 4
+  br i1 %consume.done, label %exit, label %consume
 
-.loopexit:                                        ; preds = %128
+exit:                                              ; preds = %consume
   ret void
 }

--- a/llvm/test/CodeGen/AMDGPU/promote-alloca-cross-alloca-indices-crash.ll
+++ b/llvm/test/CodeGen/AMDGPU/promote-alloca-cross-alloca-indices-crash.ll
@@ -1,0 +1,81 @@
+; NOTE: Pattern-only regression test for a cross-alloca indices crash.
+; Distilled from promote-alloca-crash-ce6eff-min.ll.
+; RUN: opt -mtriple=amdgcn--amdpal -disable-output -verify-each -passes=amdgpu-promote-alloca -amdgpu-promote-alloca-to-vector-limit=512 < %s
+
+define internal amdgpu_cs void @cross_alloca_indices_crash() {
+entry:
+  %a = alloca [16 x i32], align 4, addrspace(5)
+  %b = alloca [16 x i32], align 4, addrspace(5)
+  br label %64
+
+64:                                                ; preds = %entry, %64
+  %m = phi i32 [ 0, %entry ], [ %m.next, %64 ]
+  %b.ptr2 = getelementptr inbounds [16 x i32], ptr addrspace(5) %b, i32 0, i32 %m
+  %b.val = load i32, ptr addrspace(5) %b.ptr2, align 4
+  %idx = and i32 %b.val, 15
+  %a.ptr1 = getelementptr inbounds [16 x i32], ptr addrspace(5) %a, i32 0, i32 %idx
+  store i32 %m, ptr addrspace(5) %a.ptr1, align 4
+  %m.next = add nuw nsw i32 %m, 1
+  %map.done = icmp eq i32 %m.next, 15
+  br i1 %map.done, label %.loopexit4, label %64
+
+.loopexit4:                                       ; preds = %64
+  br label %79
+
+79:                                                ; preds = %.loopexit4, %.critedge
+  %in = phi i32 [ 15, %.loopexit4 ], [ %in.next, %.critedge ]
+  %in.next = add nsw i32 %in, -1
+  %b.ptr3 = getelementptr inbounds [16 x i32], ptr addrspace(5) %b, i32 0, i32 %in.next
+  %b.val2 = load i32, ptr addrspace(5) %b.ptr3, align 4
+  %start = and i32 %b.val2, 15
+  %start.plus2 = add i32 %start, 2
+  %has.candidates = icmp ult i32 %start.plus2, 16
+  br i1 %has.candidates, label %.lr.ph, label %.critedge
+
+.lr.ph:                                           ; preds = %79, %104
+  %cand = phi i32 [ %start.plus2, %79 ], [ %cand.next, %104 ]
+  %best.idx = phi i32 [ %start, %79 ], [ %cand, %104 ]
+  %a.ptr2 = getelementptr inbounds [16 x i32], ptr addrspace(5) %a, i32 0, i32 %cand
+  %a.val = load i32, ptr addrspace(5) %a.ptr2, align 4
+  %is.free = icmp eq i32 %a.val, -1
+  br i1 %is.free, label %109, label %.critedge
+
+104:                                               ; preds = %109
+  %cand.next = add i32 %cand, 2
+  %cont.search = icmp ult i32 %cand.next, 16
+  br i1 %cont.search, label %.lr.ph, label %.critedge
+
+109:                                               ; preds = %.lr.ph
+  %a.old.ptr = getelementptr inbounds [16 x i32], ptr addrspace(5) %a, i32 0, i32 %best.idx
+  store i32 -1, ptr addrspace(5) %a.old.ptr, align 4
+  store i32 %in.next, ptr addrspace(5) %a.ptr2, align 4
+  br label %104
+
+.critedge:                                        ; preds = %.lr.ph, %104, %79
+  %more = icmp sgt i32 %in, 1
+  br i1 %more, label %79, label %.loopexit2
+
+.loopexit2:                                       ; preds = %.critedge, %.loopexit4
+  br label %116
+
+116:                                               ; preds = %.loopexit2, %128
+  %p = phi i32 [ 0, %.loopexit2 ], [ %p.next, %128 ]
+  %a.ptr3 = getelementptr inbounds [16 x i32], ptr addrspace(5) %a, i32 0, i32 %p
+  %a.elem = load i32, ptr addrspace(5) %a.ptr3, align 4
+  %skip = icmp eq i32 %a.elem, -1
+  br i1 %skip, label %128, label %121
+
+121:                                               ; preds = %116
+  %b.ptr4 = getelementptr inbounds [16 x i32], ptr addrspace(5) %b, i32 0, i32 %a.elem
+  %b.elem = load i32, ptr addrspace(5) %b.ptr4, align 4
+  store i32 %b.elem, ptr addrspace(5) %b.ptr4, align 4
+  br label %128
+
+128:                                               ; preds = %121, %116
+  %p.next = add nuw nsw i32 %p, 1
+  %final.done = icmp eq i32 %p.next, 16
+  br i1 %final.done, label %.loopexit, label %116
+
+.loopexit:                                        ; preds = %128
+  ret void
+}

--- a/llvm/test/CodeGen/AMDGPU/promote-alloca-dirty-reanalyze-vector-after-memcpy-index.ll
+++ b/llvm/test/CodeGen/AMDGPU/promote-alloca-dirty-reanalyze-vector-after-memcpy-index.ll
@@ -1,0 +1,53 @@
+; RUN: opt -S -verify-each -mtriple=amdgcn-amd-amdhsa -mcpu=gfx900 -passes=amdgpu-promote-alloca < %s | FileCheck %s
+; RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx900 -mattr=+promote-alloca -filetype=null < %s
+;
+; Earlier vector promotion can collapse a later alloca's memcpy index from a
+; dynamic load to a constant. Re-analyzing the dirty later alloca lets it stay
+; on the vector path instead of falling back to LDS.
+
+declare void @llvm.memcpy.p5.p5.i64(ptr addrspace(5) nocapture,
+                                    ptr addrspace(5) nocapture, i64,
+                                    i1 immarg)
+
+define amdgpu_kernel void @dirty_reanalyze_vector_after_memcpy_index(
+    ptr addrspace(1) %out) #0 {
+; CHECK-LABEL: @dirty_reanalyze_vector_after_memcpy_index(
+; CHECK-NOT: alloca [4 x i32]
+; CHECK-NOT: @dirty_reanalyze_vector_after_memcpy_index.c
+; CHECK-DAG: %b = freeze <4 x i32> poison
+; CHECK-DAG: %c = freeze <4 x i32> poison
+; CHECK: ret void
+entry:
+  %b = alloca [4 x i32], align 4, addrspace(5)
+  %c = alloca [4 x i32], align 4, addrspace(5)
+
+  ; Make %b score highly enough that it is promoted first, and let its final
+  ; value collapse to the constant 1 after vector promotion.
+  %b0 = getelementptr inbounds [4 x i32], ptr addrspace(5) %b, i32 0, i32 0
+  store i32 1, ptr addrspace(5) %b0, align 4
+  %bval0 = load i32, ptr addrspace(5) %b0, align 4
+  %b1 = getelementptr inbounds [4 x i32], ptr addrspace(5) %b, i32 0, i32 1
+  store i32 %bval0, ptr addrspace(5) %b1, align 4
+  %bval1 = load i32, ptr addrspace(5) %b1, align 4
+  %b2 = getelementptr inbounds [4 x i32], ptr addrspace(5) %b, i32 0, i32 2
+  store i32 %bval1, ptr addrspace(5) %b2, align 4
+  %bval = load i32, ptr addrspace(5) %b2, align 4
+
+  ; %c is only LDS-promotable during the initial analysis because its memcpy
+  ; source index is dynamic. After %b is promoted, %bval becomes a constant and
+  ; re-analyzing %c should keep it on the vector path too.
+  %c0 = getelementptr inbounds [4 x i32], ptr addrspace(5) %c, i32 0, i32 0
+  store i32 11, ptr addrspace(5) %c0, align 4
+  %c1 = getelementptr inbounds [4 x i32], ptr addrspace(5) %c, i32 0, i32 1
+  store i32 22, ptr addrspace(5) %c1, align 4
+  %cdst = getelementptr inbounds [4 x i32], ptr addrspace(5) %c, i32 0, i32 2
+  %csrc = getelementptr inbounds [4 x i32], ptr addrspace(5) %c, i32 0, i32 %bval
+  call void @llvm.memcpy.p5.p5.i64(ptr addrspace(5) align 4 %cdst,
+                                   ptr addrspace(5) align 4 %csrc, i64 8,
+                                   i1 false)
+  %cout = load i32, ptr addrspace(5) %cdst, align 4
+  store i32 %cout, ptr addrspace(1) %out, align 4
+  ret void
+}
+
+attributes #0 = { "amdgpu-promote-alloca-to-vector-max-regs"="1024" }

--- a/llvm/test/CodeGen/AMDGPU/promote-alloca-dynamic-index-stale-state.ll
+++ b/llvm/test/CodeGen/AMDGPU/promote-alloca-dynamic-index-stale-state.ll
@@ -1,0 +1,65 @@
+; RUN: opt -S -mtriple=amdgcn-amd-amdhsa -passes=amdgpu-promote-alloca -amdgpu-promote-alloca-to-vector-limit=512 %s | FileCheck %s
+
+; Regression test for stale state with a dynamic promoted index.
+; Earlier alloca promotion can rewrite the value used as a later alloca's
+; dynamic vector index. If the later alloca reuses stale cached analysis state
+; and falls back to index 0, this becomes obvious wrong code: the transformed IR
+; would read and write b[0] instead of b[idx].
+
+define amdgpu_kernel void @dynamic_index_stale_state(ptr addrspace(1) %out, i32 %sel) #0 {
+; CHECK-LABEL: define amdgpu_kernel void @dynamic_index_stale_state(
+; CHECK-SAME: ptr addrspace(1) [[OUT:%.*]], i32 [[SEL:%.*]]) #[[ATTRS:[0-9]+]] {
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    %b = freeze <4 x i32> poison
+; CHECK-NEXT:    %a = freeze <4 x i32> poison
+; CHECK-NEXT:    [[IDX:%.*]] = and i32 [[SEL]], 3
+; CHECK:         [[B0:%.*]] = insertelement <4 x i32> {{.*}}, i32 11, i32 0
+; CHECK-NEXT:    [[B1:%.*]] = insertelement <4 x i32> [[B0]], i32 22, i32 1
+; CHECK-NEXT:    [[B2:%.*]] = insertelement <4 x i32> [[B1]], i32 33, i32 2
+; CHECK-NEXT:    [[B3:%.*]] = insertelement <4 x i32> [[B2]], i32 44, i32 3
+; CHECK:         [[OLD:%.*]] = extractelement <4 x i32> [[B3]], i32 [[IDX]]
+; CHECK-NEXT:    [[NEW:%.*]] = add i32 [[OLD]], 100
+; CHECK-NEXT:    [[B4:%.*]] = insertelement <4 x i32> [[B3]], i32 [[NEW]], i32 [[IDX]]
+; CHECK-NEXT:    store i32 [[NEW]], ptr addrspace(1) [[OUT]], align 4
+; CHECK-NEXT:    ret void
+entry:
+  %a = alloca [4 x i32], align 4, addrspace(5)
+  %b = alloca [4 x i32], align 4, addrspace(5)
+
+  ; Keep the dynamic index in range but still data-dependent.
+  %idx = and i32 %sel, 3
+
+  ; Give %a enough users that it stays first in the sorted promotion worklist.
+  %a.ptr0 = getelementptr inbounds [4 x i32], ptr addrspace(5) %a, i32 0, i32 0
+  store i32 %idx, ptr addrspace(5) %a.ptr0, align 4
+  %a.idx0 = load i32, ptr addrspace(5) %a.ptr0, align 4
+  %a.ptr1 = getelementptr inbounds [4 x i32], ptr addrspace(5) %a, i32 0, i32 1
+  store i32 %a.idx0, ptr addrspace(5) %a.ptr1, align 4
+  %a.idx1 = load i32, ptr addrspace(5) %a.ptr1, align 4
+  %a.ptr2 = getelementptr inbounds [4 x i32], ptr addrspace(5) %a, i32 0, i32 2
+  store i32 %a.idx1, ptr addrspace(5) %a.ptr2, align 4
+  %a.idx2 = load i32, ptr addrspace(5) %a.ptr2, align 4
+
+  ; Initialize %b with distinct values so collapsing the dynamic index to 0 is
+  ; clearly visible in the promoted IR.
+  %b.ptr0 = getelementptr inbounds [4 x i32], ptr addrspace(5) %b, i32 0, i32 0
+  store i32 11, ptr addrspace(5) %b.ptr0, align 4
+  %b.ptr1 = getelementptr inbounds [4 x i32], ptr addrspace(5) %b, i32 0, i32 1
+  store i32 22, ptr addrspace(5) %b.ptr1, align 4
+  %b.ptr2 = getelementptr inbounds [4 x i32], ptr addrspace(5) %b, i32 0, i32 2
+  store i32 33, ptr addrspace(5) %b.ptr2, align 4
+  %b.ptr3 = getelementptr inbounds [4 x i32], ptr addrspace(5) %b, i32 0, i32 3
+  store i32 44, ptr addrspace(5) %b.ptr3, align 4
+
+  ; %b's cached vector index is based on the load chain from %a. After %a is
+  ; promoted, the replacement value must still be used here rather than
+  ; incorrectly falling back to element 0.
+  %b.ptr.dynamic = getelementptr inbounds [4 x i32], ptr addrspace(5) %b, i32 0, i32 %a.idx2
+  %old = load i32, ptr addrspace(5) %b.ptr.dynamic, align 4
+  %new = add i32 %old, 100
+  store i32 %new, ptr addrspace(5) %b.ptr.dynamic, align 4
+  store i32 %new, ptr addrspace(1) %out, align 4
+  ret void
+}
+
+attributes #0 = { "amdgpu-promote-alloca-to-vector-max-regs"="1024" }

--- a/llvm/test/CodeGen/AMDGPU/promote-alloca-mixed-promotion-shared-transfer.ll
+++ b/llvm/test/CodeGen/AMDGPU/promote-alloca-mixed-promotion-shared-transfer.ll
@@ -1,0 +1,42 @@
+; RUN: opt -S -verify-each -mtriple=amdgcn-amd-amdhsa -mcpu=gfx900 -passes=amdgpu-promote-alloca < %s | FileCheck %s
+; RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx900 -mattr=+promote-alloca -filetype=null < %s
+;
+; Regression test for stale analysis across mixed promotion modes.
+; One alloca is promoted to vector, while two other allocas participate in a
+; cross-object memcpy (LDS path). After a successful promotion, remaining
+; allocas must be re-analyzed before further rewrites.
+
+declare void @llvm.memcpy.p5.p5.i64(ptr addrspace(5) nocapture, ptr addrspace(5) nocapture, i64, i1 immarg)
+
+define amdgpu_kernel void @mixed_promotion_shared_transfer(i32 %idx, ptr addrspace(1) %out) {
+; CHECK-LABEL: @mixed_promotion_shared_transfer(
+; CHECK-NOT: alloca [4 x i32]
+; CHECK-DAG: @mixed_promotion_shared_transfer.a
+; CHECK-DAG: @mixed_promotion_shared_transfer.b
+; CHECK: %vec = freeze <4 x i32> poison
+; CHECK: call void @llvm.memcpy.p3.p3.i64
+entry:
+  %vec = alloca [4 x i32], align 16, addrspace(5)
+  %a = alloca [4 x i32], align 16, addrspace(5)
+  %b = alloca [4 x i32], align 16, addrspace(5)
+
+  ; Vector-friendly alloca.
+  %vec.0 = getelementptr inbounds [4 x i32], ptr addrspace(5) %vec, i32 0, i32 0
+  %vec.1 = getelementptr inbounds [4 x i32], ptr addrspace(5) %vec, i32 0, i32 1
+  store i32 11, ptr addrspace(5) %vec.0, align 4
+  store i32 22, ptr addrspace(5) %vec.1, align 4
+  %vec.val = load i32, ptr addrspace(5) %vec.1, align 4
+
+  ; Cross-object transfer between allocas a and b.
+  %a.base = getelementptr inbounds [4 x i32], ptr addrspace(5) %a, i32 0, i32 0
+  store i32 7, ptr addrspace(5) %a.base, align 4
+  %b.base = getelementptr inbounds [4 x i32], ptr addrspace(5) %b, i32 0, i32 0
+  call void @llvm.memcpy.p5.p5.i64(ptr addrspace(5) align 4 %b.base, ptr addrspace(5) align 4 %a.base, i64 16, i1 false)
+
+  %b.row = getelementptr inbounds [4 x i32], ptr addrspace(5) %b, i32 0, i32 %idx
+  %b.val = load i32, ptr addrspace(5) %b.row, align 4
+
+  %sum = add i32 %vec.val, %b.val
+  store i32 %sum, ptr addrspace(1) %out, align 4
+  ret void
+}

--- a/llvm/test/CodeGen/AMDGPU/promote-alloca-multi-alloca-stale-state.ll
+++ b/llvm/test/CodeGen/AMDGPU/promote-alloca-multi-alloca-stale-state.ll
@@ -1,0 +1,52 @@
+; RUN: opt -S -verify-each -mtriple=amdgcn-amd-amdhsa -mcpu=gfx900 -passes=amdgpu-promote-alloca < %s | FileCheck %s
+; RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx900 -mattr=+promote-alloca -filetype=null < %s
+;
+; Regression test for stale state across multiple profitable allocas.
+; This is intended to exercise single-pass analyze + sequential rewrite paths
+; with many cached uses/worklists alive at once.
+
+declare void @llvm.memcpy.p5.p5.i64(ptr addrspace(5) nocapture, ptr addrspace(5) nocapture, i64, i1 immarg)
+declare void @llvm.memmove.p5.p5.i64(ptr addrspace(5) nocapture, ptr addrspace(5) nocapture, i64, i1 immarg)
+declare i32 @llvm.objectsize.i32.p5(ptr addrspace(5), i1, i1, i1)
+
+define amdgpu_kernel void @multi_alloca_stale_state(i32 %idx, ptr addrspace(1) %out) {
+; CHECK-LABEL: @multi_alloca_stale_state(
+; CHECK-NOT: alloca [4 x i32]
+; CHECK-DAG: @multi_alloca_stale_state.a
+; CHECK-DAG: @multi_alloca_stale_state.b
+; CHECK: %c = freeze <4 x i32> poison
+; CHECK: call void @llvm.memmove.p3.p3.i64
+; CHECK: call void @llvm.memcpy.p3.p3.i64
+entry:
+  %a = alloca [4 x i32], align 16, addrspace(5)
+  %b = alloca [4 x i32], align 16, addrspace(5)
+  %c = alloca [4 x i32], align 16, addrspace(5)
+
+  ; Alloca a: memmove within the same object.
+  %a.src = getelementptr inbounds [4 x i32], ptr addrspace(5) %a, i32 0, i32 %idx
+  %a.dst = getelementptr inbounds [4 x i32], ptr addrspace(5) %a, i32 0, i32 1
+  call void @llvm.memmove.p5.p5.i64(ptr addrspace(5) align 4 %a.dst, ptr addrspace(5) align 4 %a.src, i64 8, i1 false)
+  %a.val = load i32, ptr addrspace(5) %a.dst, align 4
+
+  ; Alloca b: GEP-of-GEP plus memcpy within the same object.
+  %b.row = getelementptr inbounds [4 x i32], ptr addrspace(5) %b, i32 0, i32 %idx
+  store i32 7, ptr addrspace(5) %b.row, align 4
+  %b.byte = getelementptr inbounds i8, ptr addrspace(5) %b.row, i32 0
+  %b.base = getelementptr inbounds [4 x i32], ptr addrspace(5) %b, i32 0, i32 0
+  call void @llvm.memcpy.p5.p5.i64(ptr addrspace(5) align 4 %b.base, ptr addrspace(5) align 4 %b.byte, i64 8, i1 false)
+  %b.idx1 = getelementptr inbounds [4 x i32], ptr addrspace(5) %b, i32 0, i32 1
+  %b.val = load i32, ptr addrspace(5) %b.idx1, align 4
+
+  ; Alloca c: objectsize plus scalar access.
+  %c.sz = call i32 @llvm.objectsize.i32.p5(ptr addrspace(5) %c, i1 false, i1 false, i1 false)
+  %c.ptr = getelementptr inbounds [4 x i32], ptr addrspace(5) %c, i32 0, i32 0
+  %c.old = load i32, ptr addrspace(5) %c.ptr, align 4
+  %c.new = add i32 %c.old, %c.sz
+  store i32 %c.new, ptr addrspace(5) %c.ptr, align 4
+  %c.val = load i32, ptr addrspace(5) %c.ptr, align 4
+
+  %t0 = add i32 %a.val, %b.val
+  %sum = add i32 %t0, %c.val
+  store i32 %sum, ptr addrspace(1) %out, align 4
+  ret void
+}

--- a/llvm/test/CodeGen/AMDGPU/promote-alloca-shared-assume-stale-analysis.ll
+++ b/llvm/test/CodeGen/AMDGPU/promote-alloca-shared-assume-stale-analysis.ll
@@ -1,0 +1,63 @@
+; RUN: opt -S -mtriple=amdgcn-amd-amdhsa -passes=amdgpu-promote-alloca -amdgpu-promote-alloca-to-vector-limit=512 %s | FileCheck %s
+
+declare void @llvm.assume(i1)
+
+; Check that there is no use-after-free when promoting one alloca
+; touches instructions that also relate to another alloca.
+
+; Two allocas sharing an icmp+assume chain.
+
+define amdgpu_kernel void @shared_assume_stale_analysis_two_allocas(ptr addrspace(1) %out) {
+; CHECK-LABEL: @shared_assume_stale_analysis_two_allocas(
+; CHECK-NOT: alloca
+; CHECK: call void @llvm.assume(i1 true)
+; CHECK: ret void
+entry:
+  %a = alloca [4 x i32], align 4, addrspace(5)
+  %b = alloca [4 x i32], align 4, addrspace(5)
+
+  %a0 = getelementptr inbounds i32, ptr addrspace(5) %a, i32 0
+  %b0 = getelementptr inbounds i32, ptr addrspace(5) %b, i32 0
+  %cmp = icmp ne ptr addrspace(5) %a0, %b0
+  call void @llvm.assume(i1 %cmp)
+
+  store i32 1, ptr addrspace(5) %a0, align 4
+  %av = load i32, ptr addrspace(5) %a0, align 4
+  store i32 2, ptr addrspace(5) %b0, align 4
+  %bv = load i32, ptr addrspace(5) %b0, align 4
+  %sum = add i32 %av, %bv
+  store i32 %sum, ptr addrspace(1) %out, align 4
+  ret void
+}
+
+; Three allocas where the middle alloca participates in two icmp+assume chains.
+; Promoting it first erases both chains.
+
+define amdgpu_kernel void @shared_assume_stale_analysis_three_allocas(ptr addrspace(1) %out) {
+; CHECK-LABEL: @shared_assume_stale_analysis_three_allocas(
+; CHECK-NOT: alloca
+; CHECK: ret void
+entry:
+  %a = alloca [4 x i32], align 4, addrspace(5)
+  %b = alloca [4 x i32], align 4, addrspace(5)
+  %c = alloca [4 x i32], align 4, addrspace(5)
+
+  %a0 = getelementptr inbounds i32, ptr addrspace(5) %a, i32 0
+  %b0 = getelementptr inbounds i32, ptr addrspace(5) %b, i32 0
+  %c0 = getelementptr inbounds i32, ptr addrspace(5) %c, i32 0
+  %cmp.ab = icmp ne ptr addrspace(5) %a0, %b0
+  call void @llvm.assume(i1 %cmp.ab)
+  %cmp.bc = icmp ne ptr addrspace(5) %b0, %c0
+  call void @llvm.assume(i1 %cmp.bc)
+
+  store i32 1, ptr addrspace(5) %a0, align 4
+  %av = load i32, ptr addrspace(5) %a0, align 4
+  store i32 2, ptr addrspace(5) %b0, align 4
+  %bv = load i32, ptr addrspace(5) %b0, align 4
+  store i32 3, ptr addrspace(5) %c0, align 4
+  %cv = load i32, ptr addrspace(5) %c0, align 4
+  %sum0 = add i32 %av, %bv
+  %sum1 = add i32 %sum0, %cv
+  store i32 %sum1, ptr addrspace(1) %out, align 4
+  ret void
+}

--- a/llvm/test/CodeGen/AMDGPU/promote-alloca-shared-assume-stale-state.ll
+++ b/llvm/test/CodeGen/AMDGPU/promote-alloca-shared-assume-stale-state.ll
@@ -1,0 +1,33 @@
+; RUN: opt -S -mtriple=amdgcn-amd-amdhsa -passes=amdgpu-promote-alloca -amdgpu-promote-alloca-to-vector-limit=512 %s | FileCheck %s
+
+declare void @llvm.assume(i1)
+
+; Regression test for stale state after shared-assume rewriting.
+; Earlier promotions can erase users shared with later allocas. Re-analysis
+; must use current IR and skip stale promotion state.
+
+define amdgpu_kernel void @skip_dead_alloca_after_shared_assume(ptr addrspace(1) %out) #0 {
+; CHECK-LABEL: @skip_dead_alloca_after_shared_assume(
+; CHECK: alloca [4 x i32], align 4, addrspace(5)
+; CHECK: freeze <4 x i32> poison
+; CHECK-NOT: freeze <4 x i32> poison
+; CHECK: call void @llvm.assume(i1 true)
+; CHECK: store i32 7, ptr addrspace(1) %out, align 4
+; CHECK: ret void
+entry:
+  %a = alloca [4 x i32], align 4, addrspace(5)
+  %b = alloca [4 x i32], align 4, addrspace(5)
+
+  ; This compare is shared by %a and %b.
+  %cmp = icmp ne ptr addrspace(5) %a, %b
+  call void @llvm.assume(i1 %cmp)
+
+  ; Make %a high-score so it is promoted first.
+  %a0 = getelementptr inbounds i32, ptr addrspace(5) %a, i32 0
+  store i32 7, ptr addrspace(5) %a0, align 4
+  %av = load i32, ptr addrspace(5) %a0, align 4
+  store i32 %av, ptr addrspace(1) %out, align 4
+  ret void
+}
+
+attributes #0 = { "amdgpu-promote-alloca-to-vector-max-regs"="1024" }

--- a/llvm/test/CodeGen/AMDGPU/promote-alloca-two-alloca-memintrinsics.ll
+++ b/llvm/test/CodeGen/AMDGPU/promote-alloca-two-alloca-memintrinsics.ll
@@ -1,0 +1,39 @@
+; RUN: opt -S -verify-each -mtriple=amdgcn-amd-amdhsa -mcpu=gfx900 -passes=amdgpu-promote-alloca < %s | FileCheck %s
+; RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx900 -mattr=+promote-alloca -filetype=null < %s
+;
+; Regression test for stale analysis with two allocas using memintrinsics.
+; Multiple profitable allocas are analyzed up-front, then rewritten. The pass
+; must not invalidate analysis snapshots for later allocas while rewriting
+; earlier ones.
+
+declare void @llvm.memcpy.p5.p5.i64(ptr addrspace(5) nocapture, ptr addrspace(5) nocapture, i64, i1 immarg)
+declare void @llvm.memmove.p5.p5.i64(ptr addrspace(5) nocapture, ptr addrspace(5) nocapture, i64, i1 immarg)
+
+define amdgpu_kernel void @two_alloca_memintrinsics(i32 %idx, ptr addrspace(1) %out) {
+; CHECK-LABEL: @two_alloca_memintrinsics(
+; CHECK-NOT: alloca [4 x i32]
+; CHECK: @two_alloca_memintrinsics.a
+; CHECK: @two_alloca_memintrinsics.b
+; CHECK: call void @llvm.memmove.p3.p3.i64
+; CHECK: call void @llvm.memcpy.p3.p3.i64
+entry:
+  %a = alloca [4 x i32], align 16, addrspace(5)
+  %b = alloca [4 x i32], align 16, addrspace(5)
+
+  %a.src = getelementptr inbounds [4 x i32], ptr addrspace(5) %a, i32 0, i32 %idx
+  %a.dst = getelementptr inbounds [4 x i32], ptr addrspace(5) %a, i32 0, i32 1
+  call void @llvm.memmove.p5.p5.i64(ptr addrspace(5) align 4 %a.dst, ptr addrspace(5) align 4 %a.src, i64 8, i1 false)
+  %a.val = load i32, ptr addrspace(5) %a.dst, align 4
+
+  %b.row = getelementptr inbounds [4 x i32], ptr addrspace(5) %b, i32 0, i32 %idx
+  store i32 7, ptr addrspace(5) %b.row, align 4
+  %b.byte = getelementptr inbounds i8, ptr addrspace(5) %b.row, i32 0
+  %b.base = getelementptr inbounds [4 x i32], ptr addrspace(5) %b, i32 0, i32 0
+  call void @llvm.memcpy.p5.p5.i64(ptr addrspace(5) align 4 %b.base, ptr addrspace(5) align 4 %b.byte, i64 8, i1 false)
+  %b.idx1 = getelementptr inbounds [4 x i32], ptr addrspace(5) %b, i32 0, i32 1
+  %b.val = load i32, ptr addrspace(5) %b.idx1, align 4
+
+  %sum = add i32 %a.val, %b.val
+  store i32 %sum, ptr addrspace(1) %out, align 4
+  ret void
+}


### PR DESCRIPTION
Recompute invalidated per-alloca analysis state when promotion decisions become stale, and add regressions for dirty reanalysis and cross-alloca indexing cases.