### PR TITLE
[llvm][DebugInfo] Make to be formatted test value 64-bit

### DIFF
--- a/llvm/unittests/Support/FormatVariadicTest.cpp
+++ b/llvm/unittests/Support/FormatVariadicTest.cpp
@@ -412,8 +412,8 @@ TEST(FormatAndFormatvTest, EquivalentHexFormatting) {
             formatv("0x{0:x-}", fmt_align(N, AlignStyle::Right, HexDigits, '0'))
                 .str());
 
-  EXPECT_EQ("0x000000fe", printToString(format("0x%8.8" PRIx64, 254)));
-  EXPECT_EQ("0x000000fe", formatv("{0:x+8}", 254).str());
+  EXPECT_EQ("0x000000fe", printToString(format("0x%8.8" PRIx64, 0xfeULL)));
+  EXPECT_EQ("0x000000fe", formatv("{0:x+8}", 0xfeULL).str());
 }
 
 TEST(FormatAndFormatvTest, NonNegativePlusInteger) {


### PR DESCRIPTION
This is a fix up for #186800 which failed on clang-armv8-quick builder with this message:

```
../llvm/llvm/unittests/Support/FormatVariadicTest.cpp:415: Failure
Expected equality of these values:
  "0x000000fe"
  printToString(format("0x%8.8" "ll" "x", 254))
    Which is: "0xffd448e000000000"
../llvm/llvm/unittests/Support/FormatVariadicTest.cpp:415
Expected equality of these values:
  "0x000000fe"
  printToString(format("0x%8.8" "ll" "x", 254))
    Which is: "0xffd448e000000000"
```