### PR TITLE
[libc][docs] Avoid docgen target collisions and restore pthread docs

### DIFF
--- a/libc/docs/CMakeLists.txt
+++ b/libc/docs/CMakeLists.txt
@@ -54,8 +54,7 @@ if (SPHINX_FOUND)
       locale
       net/if
       netinet/in
-      # TODO: https://github.com/llvm/llvm-project/issues/123821
-      # pthread
+      pthread
       setjmp
       signal
       stdbit
@@ -81,15 +80,17 @@ if (SPHINX_FOUND)
     foreach(stem IN LISTS docgen_list)
       # It is an error in cmake to have a target name that contains a "/", but
       # docgen relies on the "/" to find headers nested under directories.
-      # Replace with underscore.
+      # Replace with underscore and namespace the target to avoid collisions
+      # with other runtime targets in combined builds.
       string(REPLACE "/" "_" stem_rst ${stem})
+      set(docgen_target_name libc-docgen-${stem_rst})
 
       # docgen invocation.
-      add_custom_target(${stem_rst}
+      add_custom_target(${docgen_target_name}
         COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/../utils/docgen/docgen.py ${stem}.h >
                 ${CMAKE_CURRENT_BINARY_DIR}/headers/${stem}.rst)
       # depend on the docgen invocation.
-      add_dependencies(docs-libc-html ${stem_rst})
+      add_dependencies(docs-libc-html ${docgen_target_name})
     endforeach()
   endif()
 endif()

--- a/libc/docs/headers/index.rst
+++ b/libc/docs/headers/index.rst
@@ -44,6 +44,4 @@ Implementation Status
    unistd
    wchar
    wctype
-..
-   TODO: https://github.com/llvm/llvm-project/issues/123821
    pthread


### PR DESCRIPTION
Fixes llvm/llvm-project#123821.

Re-enabling pthread docs created a global CMake utility target named `pthread`, which collides in combined runtime builds where `pthread` is expected to be a library name. Namespace the internal libc docgen helper targets under `libc-docgen-*` and restore the generated pthread docs page. `docs-libc-html` is unchanged.