### PR TITLE
[PowerPC] Fix some instruction sizes

### DIFF
--- a/llvm/lib/Target/PowerPC/PPCInstr64Bit.td
+++ b/llvm/lib/Target/PowerPC/PPCInstr64Bit.td
@@ -1619,6 +1619,7 @@ def ADDIdtprelL : PPCEmitTimePseudo<(outs g8rc:$rD), (ins g8rc_nox0:$reg, s16imm
                          [(set i64:$rD,
                            (PPCaddiDtprelL i64:$reg, tglobaltlsaddr:$disp))]>,
                   isPPC64;
+let Size = 8 in
 def PADDIdtprel : PPCEmitTimePseudo<(outs g8rc:$rD), (ins g8rc_nox0:$reg, s16imm64:$disp),
                           "#PADDIdtprel",
                           [(set i64:$rD,

--- a/llvm/lib/Target/PowerPC/PPCInstrInfo.cpp
+++ b/llvm/lib/Target/PowerPC/PPCInstrInfo.cpp
@@ -3027,7 +3027,17 @@ unsigned PPCInstrInfo::getInstSizeInBytes(const MachineInstr &MI) const {
     (void)F.getFnAttribute("patchable-function-entry")
         .getValueAsString()
         .getAsInteger(10, Num);
-    return Num * 4;
+    if (Num || MF->getTarget().getTargetTriple().isOSAIX() ||
+        !MF->getTarget().getTargetTriple().isLittleEndian())
+      return Num * 4;
+    // Size of xray sled.
+    return 7 * 4;
+  }
+  case TargetOpcode::PATCHABLE_RET: {
+    // Size of xray sled.
+    unsigned RetOpcode = MI.getOperand(0).getImm();
+    bool IsConditional = RetOpcode == PPC::BCCLR;
+    return (8 + IsConditional) * 4;
   }
   default:
     return get(Opcode).getSize();


### PR DESCRIPTION
This fixes:
 * PADDIdtprel: Lowers to PADDI8, which is prefixed.
 * PATCHABLE_FUNTION_ENTER/PATCHABLE_RET: Handle xray sleds.

These came up when generalizing the instruction size verification infrastructure.