### PR TITLE
[LoongArch] Report correct instruction size for PATCHABLE_*

### DIFF
--- a/llvm/lib/Target/LoongArch/LoongArchInstrInfo.cpp
+++ b/llvm/lib/Target/LoongArch/LoongArchInstrInfo.cpp
@@ -263,6 +263,23 @@ unsigned LoongArchInstrInfo::getInstSizeInBytes(const MachineInstr &MI) const {
     if (NumBytes == 0)
       NumBytes = 4;
     break;
+  case TargetOpcode::PATCHABLE_FUNCTION_ENTER: {
+    const MachineFunction *MF = MI.getParent()->getParent();
+    const Function &F = MF->getFunction();
+    if (F.hasFnAttribute("patchable-function-entry")) {
+      unsigned Num;
+      if (F.getFnAttribute("patchable-function-entry")
+              .getValueAsString()
+              .getAsInteger(10, Num))
+        return 0;
+      return Num * 4;
+    }
+    [[fallthrough]];
+  }
+  case TargetOpcode::PATCHABLE_FUNCTION_EXIT:
+  case TargetOpcode::PATCHABLE_TAIL_CALL:
+    // Size of xray sled (branch + 11 nops).
+    return 12 * 4;
   }
   return NumBytes;
 }


### PR DESCRIPTION
This is either the number of nops provided by patchable-function-entry or the size of the xray sled.

See https://github.com/llvm/llvm-project/blob/7d39664a6ae8daaf186b65578492244d96a50bf2/llvm/lib/Target/LoongArch/LoongArchAsmPrinter.cpp#L214 for the corresponding lowering code.

This came up while working on https://github.com/llvm/llvm-project/pull/187703.