### PR TITLE
[Mips] Correctly report sizes for PATCHABLE_*

### DIFF
--- a/llvm/lib/Target/Mips/MipsInstrInfo.cpp
+++ b/llvm/lib/Target/Mips/MipsInstrInfo.cpp
@@ -718,10 +718,13 @@ unsigned MipsInstrInfo::getInstSizeInBytes(const MachineInstr &MI) const {
   case TargetOpcode::PATCHABLE_FUNCTION_EXIT:
   case TargetOpcode::PATCHABLE_TAIL_CALL:
     // Size of xray sled
-    if (Subtarget.isGP64bit())
+    if (Subtarget.isGP64bit()) {
+      // beq + 15 nops
       return 16 * 4;
-    else
+    } else {
+      // beq + 11 nops + addiu
       return 13 * 4;
+    }
   case Mips::CONSTPOOL_ENTRY:
     // If this machine instr is a constant pool entry, its size is recorded as
     // operand #2.

--- a/llvm/lib/Target/Mips/MipsInstrInfo.cpp
+++ b/llvm/lib/Target/Mips/MipsInstrInfo.cpp
@@ -714,6 +714,14 @@ unsigned MipsInstrInfo::getInstSizeInBytes(const MachineInstr &MI) const {
     const char *AsmStr = MI.getOperand(0).getSymbolName();
     return getInlineAsmLength(AsmStr, *MF->getTarget().getMCAsmInfo());
   }
+  case TargetOpcode::PATCHABLE_FUNCTION_ENTER:
+  case TargetOpcode::PATCHABLE_FUNCTION_EXIT:
+  case TargetOpcode::PATCHABLE_TAIL_CALL:
+    // Size of xray sled
+    if (Subtarget.isGP64bit())
+      return 16 * 4;
+    else
+      return 13 * 4;
   case Mips::CONSTPOOL_ENTRY:
     // If this machine instr is a constant pool entry, its size is recorded as
     // operand #2.


### PR DESCRIPTION
Report the size of the xray sled.

See https://github.com/llvm/llvm-project/blob/7d39664a6ae8daaf186b65578492244d96a50bf2/llvm/lib/Target/Mips/MipsAsmPrinter.cpp#L1123 for the corresponding lowering.

This came up while working on https://github.com/llvm/llvm-project/pull/187703.