### PR TITLE
[Linker] Resolve duplicate defs when Src is a lazy bitcode stub

### DIFF
--- a/llvm/lib/Linker/LinkModules.cpp
+++ b/llvm/lib/Linker/LinkModules.cpp
@@ -14,6 +14,7 @@
 #include "llvm-c/Linker.h"
 #include "llvm/ADT/SetVector.h"
 #include "llvm/IR/Comdat.h"
+#include "llvm/IR/Function.h"
 #include "llvm/IR/GlobalValue.h"
 #include "llvm/IR/LLVMContext.h"
 #include "llvm/IR/Module.h"
@@ -255,6 +256,14 @@ bool ModuleLinker::shouldLinkFromSource(bool &LinkFromSrc,
 
   bool SrcIsDeclaration = Src.isDeclarationForLinker();
   bool DestIsDeclaration = Dest.isDeclarationForLinker();
+
+  // Materializable functions with empty bodies are lazy-loaded placeholders from
+  // bitcode. When the source module is loaded without materializing functions (e.g. with
+  // -save-temps), these appear as definitions with empty body.
+  // Prefer the destination's definition(composite module) for the function.
+  if (const Function *F = dyn_cast<Function>(&Src))
+    if (F->isMaterializable() && F->empty())
+      SrcIsDeclaration = true;
 
   if (SrcIsDeclaration) {
     // If Src is external or if both Src & Dest are external..  Just link the

--- a/llvm/test/Linker/Inputs/materializable-dup-def-dst.ll
+++ b/llvm/test/Linker/Inputs/materializable-dup-def-dst.ll
@@ -1,0 +1,11 @@
+define i32 @mat_dup_test_1() {
+entry:
+  ret i32 42
+}
+
+define void @mat_dup_test_2(i32 %a, i32 %b) {
+entry:
+  %sum = add nsw i32 %a, %b
+  %prod = mul nsw i32 %sum, 3
+  ret void
+}

--- a/llvm/test/Linker/Inputs/materializable-dup-def-src.ll
+++ b/llvm/test/Linker/Inputs/materializable-dup-def-src.ll
@@ -1,0 +1,11 @@
+; Materializable
+define i32 @mat_dup_test_1() noreturn {
+entry:
+  unreachable
+}
+
+; Materializable
+define void @mat_dup_test_2(i32 %a, i32 %b) noreturn {
+entry:
+  unreachable
+}

--- a/llvm/test/Linker/materializable-dup-def.ll
+++ b/llvm/test/Linker/materializable-dup-def.ll
@@ -1,0 +1,25 @@
+; Test that linking a lazy-loaded bitcode module whose definitions are still
+; materializable (empty body) against an already-linked definition does not
+; report "multiply defined" — see shouldLinkFromSource in LinkModules.cpp.
+;
+
+; RUN: llvm-as %p/Inputs/materializable-dup-def-dst.ll -o %t.dst.bc
+; RUN: llvm-as %p/Inputs/materializable-dup-def-src.ll -o %t.src.bc
+; RUN: llvm-link %t.dst.bc %t.src.bc -o %t.linked.bc
+; RUN: llvm-dis %t.linked.bc -o - | FileCheck %s
+
+; CHECK: define i32 @mat_dup_test_1() {
+; CHECK-NEXT: entry:
+; CHECK-NEXT:   ret i32 42
+; CHECK-NEXT: }
+
+; CHECK: define void @mat_dup_test_2(i32 %a, i32 %b) {
+; CHECK-NEXT: entry:
+; CHECK-NEXT:   %sum = add nsw i32 %a, %b
+; CHECK-NEXT:   %prod = mul nsw i32 %sum, 3
+; CHECK-NEXT:   ret void
+; CHECK-NEXT: }
+
+; With eager loading both sides have full definitions; the linker correctly errors.
+; RUN: not llvm-link -disable-lazy-loading %t.dst.bc %t.src.bc -o %t.eager.bc 2>&1 | FileCheck --check-prefix=EAGER %s
+; EAGER: error: Linking globals named 'mat_dup_test_1': symbol multiply defined!


### PR DESCRIPTION
When the source module is loaded lazily, functions may still be materializable with no basic blocks until their bodies are read from bitcode. Those placeholders are not real competing definitions; treat them like declarations so we keep the destination (composite) definition and avoid "symbol multiply defined" for the same name.

This can occur when linking bitcode (e.g. device libs) where the composite already holds a full definition and the incoming module still has deferred bodies.