### PR TITLE
[lldb][test] Don't treat 'xcrun clang' as a path for finding clang++

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/builders/builder.py
+++ b/lldb/packages/Python/lldbsuite/test/builders/builder.py
@@ -151,8 +151,13 @@ class Builder:
             "gcc": "g++",
             "cc": "c++",
             "clang": "clang++",
+            "xcrun clang": "xcrun clang++",
         }
-        cxx_type = cxx_types.get(cc_type, cc_type)
+        # Determine the C++ compiler based on the given compiler path/command.
+        cxx_type = cxx_types.get(compiler)
+        if cxx_type is None:
+            # If that did not work, then use the inferred cc_type.
+            cxx_type = cxx_types.get(cc_type, cxx_type)
 
         cc_dir = cc_path.parent
 


### PR DESCRIPTION
[lldb][test] Don't treat 'xcrun clang' as a path for finding clang++
TestPrintObjectArray.py uses `xcrun clang` as the test compiler.
This is because the test source requires some Objective-C features
that are only available in downstream clang:

```
self.build(dictionary=[...], compiler="xcrun clang")
```

However, this currently just results in us running `clang++`
instead of `xcrun clang++` to compile test sources. If the downstream
`clang++` in PATH is not Apple's downstream version, this then causes
the tests to fail with compilation errors:

```
clang++: error: unknown argument: '-fno-constant-nsnumber-literals'
clang++: error: unknown argument: '-fno-constant-nsarray-literals'
clang++: error: unknown argument: '-fno-constant-nsdictionary-literals'
```

We end up in this situation as we treat this command as a path when
trying to assemble the `clang++` command. This patch just adds a
special case for `xcrun` and we now first try the compiler (verbatim)
before falling back to the inferred compiler type.