### PR TITLE
[ASan] Make __SANITIZER_DISABLE_CONTAINER_OVERFLOW__ bypass definitions return values

### DIFF
--- a/compiler-rt/include/sanitizer/common_interface_defs.h
+++ b/compiler-rt/include/sanitizer/common_interface_defs.h
@@ -273,7 +273,9 @@ void SANITIZER_CDECL __sanitizer_copy_contiguous_container_annotations(
 __attribute__((__internal_linkage__)) inline int
     SANITIZER_CDECL __sanitizer_verify_contiguous_container(const void *beg,
                                                             const void *mid,
-                                                            const void *end) {}
+                                                            const void *end) {
+  return 1;
+}
 #else
 int SANITIZER_CDECL __sanitizer_verify_contiguous_container(const void *beg,
                                                             const void *mid,
@@ -306,7 +308,9 @@ __attribute__((__internal_linkage__)) inline int SANITIZER_CDECL
 __sanitizer_verify_double_ended_contiguous_container(const void *storage_beg,
                                                      const void *container_beg,
                                                      const void *container_end,
-                                                     const void *storage_end) {}
+                                                     const void *storage_end) {
+  return 1;
+}
 #else
 int SANITIZER_CDECL __sanitizer_verify_double_ended_contiguous_container(
     const void *storage_beg, const void *container_beg,
@@ -327,7 +331,9 @@ int SANITIZER_CDECL __sanitizer_verify_double_ended_contiguous_container(
 __attribute__((__internal_linkage__)) inline const void *SANITIZER_CDECL
 __sanitizer_contiguous_container_find_bad_address(const void *beg,
                                                   const void *mid,
-                                                  const void *end) {}
+                                                  const void *end) {
+  return NULL;
+}
 #else
 const void *SANITIZER_CDECL __sanitizer_contiguous_container_find_bad_address(
     const void *beg, const void *mid, const void *end);
@@ -347,7 +353,9 @@ const void *SANITIZER_CDECL __sanitizer_contiguous_container_find_bad_address(
 __attribute__((__internal_linkage__)) inline const void *SANITIZER_CDECL
 __sanitizer_double_ended_contiguous_container_find_bad_address(
     const void *storage_beg, const void *container_beg,
-    const void *container_end, const void *storage_end) {}
+    const void *container_end, const void *storage_end) {
+  return NULL;
+}
 #else
 const void *SANITIZER_CDECL
 __sanitizer_double_ended_contiguous_container_find_bad_address(


### PR DESCRIPTION
Currently all of these functions are empty bodies; this means that when including this header and compiling with __SANITIZER_DISABLE_CONTAINER_OVERFLOW__ defined, warnings are emitted about the missing return values for those functions that do return values.

This patch returns success values for all those check functions with non-void return types. Note: these were originally added in https://github.com/llvm/llvm-project/pull/163468.