### PR TITLE
[clang][Sema] Fix assertion on invalid template template parameter during typo correction

### DIFF
--- a/clang/include/clang/Sema/TypoCorrection.h
+++ b/clang/include/clang/Sema/TypoCorrection.h
@@ -350,6 +350,34 @@ protected:
   NestedNameSpecifier TypoNNS;
 };
 
+/// Callback class to reject typo corrections that look like template parameters
+/// when doing a qualified lookup. A template parameter (type or template) is
+/// local to the current template scope and cannot be validly qualified by any
+/// external scope (e.g. 'std::T' where T is a template parameter).
+class QualifiedLookupValidatorCCC : public CorrectionCandidateCallback {
+public:
+  explicit QualifiedLookupValidatorCCC(bool HasQualifier)
+      : HasQualifier(HasQualifier) {}
+
+  bool ValidateCandidate(const TypoCorrection &Candidate) override {
+    if (HasQualifier) {
+      if (const NamedDecl *ND = Candidate.getCorrectionDecl()) {
+        // A template parameter can never be a member of any qualifier scope.
+        if (isa<TemplateTypeParmDecl>(ND) || isa<TemplateTemplateParmDecl>(ND))
+          return false;
+      }
+    }
+    return CorrectionCandidateCallback::ValidateCandidate(Candidate);
+  }
+
+  std::unique_ptr<CorrectionCandidateCallback> clone() override {
+    return std::make_unique<QualifiedLookupValidatorCCC>(*this);
+  }
+
+private:
+  bool HasQualifier;
+};
+
 class DefaultFilterCCC final : public CorrectionCandidateCallback {
 public:
   explicit DefaultFilterCCC(const IdentifierInfo *Typo = nullptr,

--- a/clang/lib/Sema/SemaCXXScopeSpec.cpp
+++ b/clang/lib/Sema/SemaCXXScopeSpec.cpp
@@ -19,6 +19,7 @@
 #include "clang/Sema/DeclSpec.h"
 #include "clang/Sema/Lookup.h"
 #include "clang/Sema/Template.h"
+#include "clang/Sema/TypoCorrection.h"
 #include "llvm/ADT/STLExtras.h"
 using namespace clang;
 
@@ -379,17 +380,16 @@ namespace {
 // Callback to only accept typo corrections that can be a valid C++ member
 // initializer: either a non-static field member or a base class.
 class NestedNameSpecifierValidatorCCC final
-    : public CorrectionCandidateCallback {
+    : public QualifiedLookupValidatorCCC {
 public:
   explicit NestedNameSpecifierValidatorCCC(Sema &SRef, bool HasQualifier)
-      : SRef(SRef), HasQualifier(HasQualifier) {}
+      : QualifiedLookupValidatorCCC(HasQualifier), SRef(SRef) {}
 
   bool ValidateCandidate(const TypoCorrection &candidate) override {
+    if (!QualifiedLookupValidatorCCC::ValidateCandidate(candidate))
+      return false;
     const NamedDecl *ND = candidate.getCorrectionDecl();
     if (!SRef.isAcceptableNestedNameSpecifier(ND))
-      return false;
-    // A template type parameter cannot have a nested name specifier.
-    if (HasQualifier && isa<TemplateTypeParmDecl>(ND))
       return false;
     return true;
   }
@@ -399,10 +399,8 @@ public:
   }
 
  private:
-  Sema &SRef;
-  bool HasQualifier;
+   Sema &SRef;
 };
-
 }
 
 [[nodiscard]] static bool ExtendNestedNameSpecifier(Sema &S, CXXScopeSpec &SS,

--- a/clang/lib/Sema/SemaTemplate.cpp
+++ b/clang/lib/Sema/SemaTemplate.cpp
@@ -519,28 +519,7 @@ bool Sema::LookupTemplateName(LookupResult &Found, Scope *S, CXXScopeSpec &SS,
     // to correct any typos.
     DeclarationName Name = Found.getLookupName();
     Found.clear();
-    // Simple filter callback that, for keywords, only accepts the C++ *_cast
-    struct TemplateQualifierFilter final : CorrectionCandidateCallback {
-      const CXXScopeSpec &SS;
-      TemplateQualifierFilter(const CXXScopeSpec &SS) : SS(SS) {}
-      bool ValidateCandidate(const TypoCorrection &Candidate) override {
-        if (SS.isNotEmpty()) { // Qualified lookup
-          if (NamedDecl *ND = Candidate.getFoundDecl()) {
-            // A template template parameter is a name in the current template
-            // parameter list and cannot be validly qualified by any scope.
-            // Therefore, we should never suggest it as a typo correction for a
-            // qualified name.
-            if (isa<TemplateTemplateParmDecl>(ND))
-              return false;
-          }
-        }
-        return CorrectionCandidateCallback::ValidateCandidate(Candidate);
-      }
-      std::unique_ptr<CorrectionCandidateCallback> clone() override {
-        return std::make_unique<TemplateQualifierFilter>(*this);
-      }
-    };
-    TemplateQualifierFilter FilterCCC{SS};
+    QualifiedLookupValidatorCCC FilterCCC(!SS.isEmpty());
     FilterCCC.WantTypeSpecifiers = false;
     FilterCCC.WantExpressionKeywords = false;
     FilterCCC.WantRemainingKeywords = false;

--- a/clang/lib/Sema/SemaTemplate.cpp
+++ b/clang/lib/Sema/SemaTemplate.cpp
@@ -520,7 +520,27 @@ bool Sema::LookupTemplateName(LookupResult &Found, Scope *S, CXXScopeSpec &SS,
     DeclarationName Name = Found.getLookupName();
     Found.clear();
     // Simple filter callback that, for keywords, only accepts the C++ *_cast
-    DefaultFilterCCC FilterCCC{};
+    struct TemplateQualifierFilter final : CorrectionCandidateCallback {
+      const CXXScopeSpec &SS;
+      TemplateQualifierFilter(const CXXScopeSpec &SS) : SS(SS) {}
+      bool ValidateCandidate(const TypoCorrection &Candidate) override {
+        if (SS.isNotEmpty()) { // Qualified lookup
+          if (NamedDecl *ND = Candidate.getFoundDecl()) {
+            // A template template parameter is a name in the current template
+            // parameter list and cannot be validly qualified by any scope.
+            // Therefore, we should never suggest it as a typo correction for a
+            // qualified name.
+            if (isa<TemplateTemplateParmDecl>(ND))
+              return false;
+          }
+        }
+        return CorrectionCandidateCallback::ValidateCandidate(Candidate);
+      }
+      std::unique_ptr<CorrectionCandidateCallback> clone() override {
+        return std::make_unique<TemplateQualifierFilter>(*this);
+      }
+    };
+    TemplateQualifierFilter FilterCCC{SS};
     FilterCCC.WantTypeSpecifiers = false;
     FilterCCC.WantExpressionKeywords = false;
     FilterCCC.WantRemainingKeywords = false;

--- a/clang/test/SemaTemplate/gh183983.cpp
+++ b/clang/test/SemaTemplate/gh183983.cpp
@@ -1,0 +1,10 @@
+// RUN: %clang_cc1 -fsyntax-only -verify %s
+
+// expected-error@10 {{template template parameter requires 'class' or 'typename' after the parameter list}}
+// expected-error@10 {{template template parameter must have its own template parameters}}
+// expected-error@10 {{no template named 'a' in the global namespace}}
+// expected-note@10 {{to match this '<'}}
+// expected-error@10 {{expected expression}}
+// expected-error@10 {{expected '>'}}
+// expected-error@10 {{expected unqualified-id}}
+template <template <> a>::a <


### PR DESCRIPTION
In the crash example, when performing typo correction for a qualified name lookup (`::a`),  clang suggests a template template parameter from an outer scope. 

However, template template parameters can not be qualified by  any scope. Attempting to combine the qualifier with the suggested template  template parameter resulted in an assertion failure in `ASTContext::getQualifiedTemplateName`:

This patch is to update the typo correction filter to reject `TemplateTemplateParmDecl` candidates when a qualifier is present . This prevents the invalid suggestion from being generated and avoids the assertion violation.

Fixes #183983 
