### PR TITLE
clang: Define FP_FAST_FMA_HALF macro for AMDGPU

### DIFF
--- a/clang/lib/Basic/Targets/AMDGPU.cpp
+++ b/clang/lib/Basic/Targets/AMDGPU.cpp
@@ -239,6 +239,8 @@ AMDGPUTargetInfo::AMDGPUTargetInfo(const llvm::Triple &Triple,
     BFloat16Format = &llvm::APFloat::BFloat();
   }
 
+  // TODO: This is not really true for targets without half support, but also
+  // should just be assumed true for the dummy target.
   HasFastHalfType = true;
   HasFloat16 = true;
   WavefrontSize = (GPUFeatures & llvm::AMDGPU::FEATURE_WAVE32) ? 32 : 64;
@@ -301,6 +303,8 @@ void AMDGPUTargetInfo::getTargetDefines(const LangOptions &Opts,
     Builder.defineMacro("__HAS_FP64__");
   if (hasFastFMA())
     Builder.defineMacro("FP_FAST_FMA");
+  if (HasFastHalfType)
+    Builder.defineMacro("FP_FAST_FMA_HALF");
 
   Builder.defineMacro("__AMDGCN_CUMODE__", Twine(CUMode));
 

--- a/clang/test/Driver/amdgpu-macros.cl
+++ b/clang/test/Driver/amdgpu-macros.cl
@@ -145,6 +145,7 @@
 // RUN: %clang -E -dM -target amdgcn -mcpu=gfx12-5-generic %s 2>&1 | FileCheck --check-prefixes=ARCH-GCN,FAST_FMAF %s -DWAVEFRONT_SIZE=32 -DCPU=gfx12_5_generic -DFAMILY=GFX12
 
 // ARCH-GCN-DAG: #define FP_FAST_FMA 1
+// ARCH-GCN-DAG: #define FP_FAST_FMA_HALF 1
 
 // FAST_FMAF-DAG: #define FP_FAST_FMAF 1
 // SLOW_FMAF-NOT: #define FP_FAST_FMAF 1

--- a/clang/test/Preprocessor/predefined-arch-macros.c
+++ b/clang/test/Preprocessor/predefined-arch-macros.c
@@ -4619,6 +4619,7 @@
 // RUN:   | FileCheck -match-full-lines %s -check-prefixes=CHECK_AMDGCN,CHECK_AMDGCN_NONE
 // CHECK_AMDGCN: #define FP_FAST_FMA 1
 // CHECK_AMDGCN_900: #define FP_FAST_FMAF 1
+// CHECK_AMDGCN: #define FP_FAST_FMA_HALF 1
 // CHECK_AMDGCN_NONE-NOT: FP_FAST_FMAF
 // CHECK_AMDGCN: #define __AMDGCN__ 1
 // CHECK_AMDGCN: #define __HAS_FMAF__ 1


### PR DESCRIPTION
OpenCL specifies this should be defined if cl_khr_fp16 is
implemented and half fma is fast compared to a separate mul
and add. This is trivially true for all targets with native
half support. It's not true for targets without half support
which need to legalize by promotion to double. We already lie
about this though, for the convenience of the dummy default
target.