### PR TITLE
libclc: Unify fast FMA controls

### DIFF
--- a/libclc/clc/include/clc/math/gentype.inc
+++ b/libclc/clc/include/clc/math/gentype.inc
@@ -84,6 +84,7 @@
 #define __CLC_U_GENTYPE __CLC_XCONCAT(uint, __CLC_VECSIZE)
 
 #define __CLC_GENTYPE_DENORMS_ARE_ZERO __clc_denormals_are_zero_fp32()
+#define __CLC_GENTYPE_FAST_FMA __CLC_FAST_FMA_F32
 
 #define __CLC_BIT_INT int
 #define __CLC_SCALAR
@@ -124,6 +125,7 @@
 #undef __CLC_GENTYPE_MIN
 #undef __CLC_GENTYPE_TRUE_MIN
 #undef __CLC_GENTYPE_DENORMS_ARE_ZERO
+#undef __CLC_GENTYPE_FAST_FMA
 #undef __CLC_FP_LIT
 #undef __CLC_FPSIZE
 #undef __CLC_SCALAR_GENTYPE
@@ -141,6 +143,7 @@
 #define __CLC_GENTYPE_MIN (__CLC_GENTYPE) DBL_MIN
 #define __CLC_GENTYPE_TRUE_MIN (__CLC_GENTYPE) DBL_TRUE_MIN
 #define __CLC_GENTYPE_DENORMS_ARE_ZERO __clc_denormals_are_zero_fp64()
+#define __CLC_GENTYPE_FAST_FMA __CLC_FAST_FMA_F64
 
 #define __CLC_S_GENTYPE __CLC_XCONCAT(long, __CLC_VECSIZE)
 #define __CLC_U_GENTYPE __CLC_XCONCAT(ulong, __CLC_VECSIZE)
@@ -184,6 +187,7 @@
 #undef __CLC_GENTYPE_MIN
 #undef __CLC_GENTYPE_TRUE_MIN
 #undef __CLC_GENTYPE_DENORMS_ARE_ZERO
+#undef __CLC_GENTYPE_FAST_FMA
 #undef __CLC_FP_LIT
 #undef __CLC_FPSIZE
 #undef __CLC_SCALAR_GENTYPE
@@ -201,6 +205,7 @@
 #define __CLC_GENTYPE_MIN (__CLC_GENTYPE) HALF_MIN
 #define __CLC_GENTYPE_TRUE_MIN (__CLC_GENTYPE) HALF_TRUE_MIN
 #define __CLC_GENTYPE_DENORMS_ARE_ZERO __clc_denormals_are_zero_fp16()
+#define __CLC_GENTYPE_FAST_FMA __CLC_FAST_FMA_F16
 
 #define __CLC_S_GENTYPE __CLC_XCONCAT(short, __CLC_VECSIZE)
 #define __CLC_U_GENTYPE __CLC_XCONCAT(ushort, __CLC_VECSIZE)
@@ -244,6 +249,7 @@
 #undef __CLC_GENTYPE_MIN
 #undef __CLC_GENTYPE_TRUE_MIN
 #undef __CLC_GENTYPE_DENORMS_ARE_ZERO
+#undef __CLC_GENTYPE_FAST_FMA
 #undef __CLC_FP_LIT
 #undef __CLC_FPSIZE
 #undef __CLC_SCALAR_GENTYPE

--- a/libclc/clc/include/clc/math/math.h
+++ b/libclc/clc/include/clc/math/math.h
@@ -24,10 +24,25 @@
 #define PNOR 0x100
 #define PINF 0x200
 
-#define __CLC_HAVE_HW_FMA32() (1)
+#ifdef FP_FAST_FMA_HALF
+#define __CLC_FAST_FMA_F16 1
+#else
+#define __CLC_FAST_FMA_F16 0
+#endif
+
+#ifdef FP_FAST_FMAF
+#define __CLC_FAST_FMA_F32 1
+#else
+#define __CLC_FAST_FMA_F32 0
+#endif
+
+#ifdef FP_FAST_FMA
+#define __CLC_FAST_FMA_F64 1
+#else
+#define __CLC_FAST_FMA_F64 0
+#endif
 
 #define HAVE_BITALIGN() (0)
-#define HAVE_FAST_FMA32() (0)
 
 #define MATH_DIVIDE(X, Y) ((X) / (Y))
 #define MATH_RECIP(X) (1.0f / (X))

--- a/libclc/clc/lib/generic/math/clc_ep.cl
+++ b/libclc/clc/lib/generic/math/clc_ep.cl
@@ -17,6 +17,7 @@
 #include "clc/math/clc_recip_fast.h"
 #include "clc/math/clc_rint.h"
 #include "clc/math/clc_sqrt_fast.h"
+#include "clc/math/math.h"
 #include "clc/relational/clc_isinf.h"
 #include "clc/relational/clc_signbit.h"
 

--- a/libclc/clc/lib/generic/math/clc_ep.inc
+++ b/libclc/clc/lib/generic/math/clc_ep.inc
@@ -6,23 +6,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if __CLC_FPSIZE == 16
-#define __CLC_EP_USE_FMA true
-#elif __CLC_FPSIZE == 32
-#if defined(FP_FAST_FMAF)
-#define __CLC_EP_USE_FMA true
-#else
-#define __CLC_EP_USE_FMA false
-#endif
-
-#elif __CLC_FPSIZE == 64
-#if defined(FP_FAST_FMA)
-#define __CLC_EP_USE_FMA true
-#else
-#define __CLC_EP_USE_FMA false
-#endif
-#endif
-
 #pragma OPENCL FP_CONTRACT OFF
 
 #if __CLC_FPSIZE == 16
@@ -132,7 +115,7 @@ _CLC_DEF _CLC_OVERLOAD _CLC_CONST __CLC_EP_PAIR __clc_ep_sub(__CLC_GENTYPE a,
 _CLC_DEF _CLC_OVERLOAD _CLC_CONST __CLC_EP_PAIR __clc_ep_mul(__CLC_GENTYPE a,
                                                              __CLC_GENTYPE b) {
   __CLC_GENTYPE p = a * b;
-  if (__CLC_EP_USE_FMA) {
+  if (__CLC_GENTYPE_FAST_FMA) {
     return __clc_ep_make_pair(p, __clc_fma(a, b, -p));
   }
 
@@ -145,7 +128,7 @@ _CLC_DEF _CLC_OVERLOAD _CLC_CONST __CLC_EP_PAIR __clc_ep_mul(__CLC_GENTYPE a,
 
 _CLC_DEF _CLC_OVERLOAD _CLC_CONST __CLC_EP_PAIR __clc_ep_sqr(__CLC_GENTYPE a) {
   __CLC_GENTYPE p = a * a;
-  if (__CLC_EP_USE_FMA)
+  if (__CLC_GENTYPE_FAST_FMA)
     return __clc_ep_make_pair(p, __clc_fma(a, a, -p));
 
   __CLC_GENTYPE ah = ep_high_fp_bits(a);
@@ -252,7 +235,7 @@ _CLC_DEF _CLC_OVERLOAD _CLC_CONST __CLC_EP_PAIR __clc_ep_ldexp(__CLC_EP_PAIR a,
 _CLC_DEF _CLC_OVERLOAD _CLC_CONST __CLC_EP_PAIR __clc_ep_mul(__CLC_EP_PAIR a,
                                                              __CLC_GENTYPE b) {
   __CLC_EP_PAIR p = __clc_ep_mul(a.hi, b);
-  if (__CLC_EP_USE_FMA) {
+  if (__CLC_GENTYPE_FAST_FMA) {
     p.lo = __clc_fma(a.lo, b, p.lo);
   } else {
     p.lo += a.lo * b;
@@ -263,7 +246,7 @@ _CLC_DEF _CLC_OVERLOAD _CLC_CONST __CLC_EP_PAIR __clc_ep_mul(__CLC_EP_PAIR a,
 _CLC_DEF _CLC_OVERLOAD _CLC_CONST __CLC_EP_PAIR
 __clc_ep_mul_overflow(__CLC_EP_PAIR a, __CLC_GENTYPE b) {
   __CLC_EP_PAIR p = __clc_ep_mul(a.hi, b);
-  if (__CLC_EP_USE_FMA) {
+  if (__CLC_GENTYPE_FAST_FMA) {
     p.lo = __clc_fma(a.lo, b, p.lo);
   } else {
     p.lo += a.lo * b;
@@ -274,7 +257,7 @@ __clc_ep_mul_overflow(__CLC_EP_PAIR a, __CLC_GENTYPE b) {
 _CLC_DEF _CLC_OVERLOAD _CLC_CONST __CLC_EP_PAIR __clc_ep_mul(__CLC_GENTYPE a,
                                                              __CLC_EP_PAIR b) {
   __CLC_EP_PAIR p = __clc_ep_mul(a, b.hi);
-  if (__CLC_EP_USE_FMA) {
+  if (__CLC_GENTYPE_FAST_FMA) {
     p.lo = __clc_fma(a, b.lo, p.lo);
   } else {
     p.lo += a * b.lo;
@@ -285,7 +268,7 @@ _CLC_DEF _CLC_OVERLOAD _CLC_CONST __CLC_EP_PAIR __clc_ep_mul(__CLC_GENTYPE a,
 _CLC_DEF _CLC_OVERLOAD _CLC_CONST __CLC_EP_PAIR
 __clc_ep_mul_overflow(__CLC_GENTYPE a, __CLC_EP_PAIR b) {
   __CLC_EP_PAIR p = __clc_ep_mul(a, b.hi);
-  if (__CLC_EP_USE_FMA) {
+  if (__CLC_GENTYPE_FAST_FMA) {
     p.lo = __clc_fma(a, b.lo, p.lo);
   } else {
     p.lo += a * b.lo;
@@ -296,7 +279,7 @@ __clc_ep_mul_overflow(__CLC_GENTYPE a, __CLC_EP_PAIR b) {
 _CLC_DEF _CLC_OVERLOAD _CLC_CONST __CLC_EP_PAIR __clc_ep_mul(__CLC_EP_PAIR a,
                                                              __CLC_EP_PAIR b) {
   __CLC_EP_PAIR p = __clc_ep_mul(a.hi, b.hi);
-  if (__CLC_EP_USE_FMA) {
+  if (__CLC_GENTYPE_FAST_FMA) {
     p.lo = __clc_fma(a.lo, b.hi, __clc_fma(a.hi, b.lo, p.lo));
   } else {
     p.lo += a.hi * b.lo + a.lo * b.hi;
@@ -307,7 +290,7 @@ _CLC_DEF _CLC_OVERLOAD _CLC_CONST __CLC_EP_PAIR __clc_ep_mul(__CLC_EP_PAIR a,
 _CLC_DEF _CLC_OVERLOAD _CLC_CONST __CLC_EP_PAIR
 __clc_ep_mul_overflow(__CLC_EP_PAIR a, __CLC_EP_PAIR b) {
   __CLC_EP_PAIR p = __clc_ep_mul(a.hi, b.hi);
-  if (__CLC_EP_USE_FMA) {
+  if (__CLC_GENTYPE_FAST_FMA) {
     p.lo += __clc_fma(a.hi, b.lo, a.lo * b.hi);
   } else {
     p.lo += a.hi * b.lo + a.lo * b.hi;
@@ -406,7 +389,7 @@ __clc_ep_recip(__CLC_EP_PAIR b) {
 
 _CLC_DEF _CLC_OVERLOAD _CLC_CONST __CLC_EP_PAIR __clc_ep_sqr(__CLC_EP_PAIR a) {
   __CLC_EP_PAIR p = __clc_ep_sqr(a.hi);
-  if (__CLC_EP_USE_FMA) {
+  if (__CLC_GENTYPE_FAST_FMA) {
     p.lo = __clc_fma(a.hi, __CLC_FP_LIT(2.0) * a.lo, p.lo);
   } else {
     p.lo = p.lo + __CLC_FP_LIT(2.0) * a.lo * a.hi;
@@ -646,5 +629,3 @@ _CLC_DEF _CLC_OVERLOAD _CLC_CONST __CLC_DOUBLEN __clc_ep_ln_hi(__CLC_EP_PAIR a,
 }
 
 #endif
-
-#undef __CLC_EP_USE_FMA

--- a/libclc/clc/lib/generic/math/clc_sincos_helpers.inc
+++ b/libclc/clc/lib/generic/math/clc_sincos_helpers.inc
@@ -128,7 +128,7 @@ _CLC_DEF _CLC_OVERLOAD void __clc_fullMulS(private __CLC_FLOATN *hi,
                                            private __CLC_FLOATN *lo,
                                            __CLC_FLOATN a, __CLC_FLOATN b,
                                            __CLC_FLOATN bh, __CLC_FLOATN bt) {
-  if (__CLC_HAVE_HW_FMA32()) {
+  if (__CLC_FAST_FMA_F32) {
     __CLC_FLOATN ph = a * b;
     *hi = ph;
     *lo = __clc_fma(a, b, -ph);
@@ -305,7 +305,7 @@ __clc_argReductionLargeS(private __CLC_FLOATN *r, __CLC_FLOATN x) {
 
   __CLC_FLOATN rh, rt;
 
-  if (__CLC_HAVE_HW_FMA32()) {
+  if (__CLC_FAST_FMA_F32) {
     rh = q1 * pio2h;
     rt = __clc_fma(q0, pio2h, __clc_fma(q1, pio2t, __clc_fma(q1, pio2h, -rh)));
   } else {


### PR DESCRIPTION
This was defined in multiple places with different names. Consolidate
on one, with a gentype wrapper for it. Also set the value based on the
standard FP_FAST_FMA* macros.