### PR TITLE
[clang] Fix crash on invalid out-of-line enum definition with template parameters

### DIFF
--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -17966,7 +17966,8 @@ Sema::ActOnTag(Scope *S, unsigned TagSpec, TagUseKind TUK, SourceLocation KWLoc,
   bool IsFixed = !UnderlyingType.isUnset() || ScopedEnum;
 
   if (Kind == TagTypeKind::Enum) {
-    if (UnderlyingType.isInvalid() || (!UnderlyingType.get() && ScopedEnum)) {
+    if (UnderlyingType.isInvalid() || (!UnderlyingType.get() && ScopedEnum) ||
+        Invalid) {
       // No underlying type explicitly specified, or we failed to parse the
       // type, default to int.
       EnumUnderlying = Context.IntTy.getTypePtr();

--- a/clang/test/SemaTemplate/GH187909.cpp
+++ b/clang/test/SemaTemplate/GH187909.cpp
@@ -1,0 +1,10 @@
+// RUN: %clang_cc1 -fsyntax-only -verify %s
+
+template<typename T> struct A {
+  enum E : T;
+  E v = E{};
+};
+
+template<typename T> enum A<int>::E : T { e1 }; // expected-error {{template parameter list matching the non-templated nested type 'A<int>' should be empty ('template<>')}}
+
+A<int> a;


### PR DESCRIPTION
clang crashes when an invalid out-of-line enum definition is provided with template parameters. In these cases, clang produces a dependent type within a non-dependent context, violating internal invariants.

The fix is to fallback the underlying type of the enum to `int` during error recovery in `Sema::ActOnTag` when `Invalid` is true, making it safe for downstream processing while still preserving the invalid declaration in the AST.


Fixes #187909

