### PR TITLE
[clang-tidy] Add missing #include insertion in macros for modernize-use-std-format

### DIFF
--- a/clang-tools-extra/clang-tidy/modernize/UseStdFormatCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/UseStdFormatCheck.cpp
@@ -99,8 +99,8 @@ void UseStdFormatCheck::check(const MatchFinder::MatchResult &Result) {
 
   if (MaybeHeaderToInclude)
     Diag << IncludeInserter.createIncludeInsertion(
-        Result.Context->getSourceManager().getFileID(
-            StrFormatCall->getBeginLoc()),
+        Result.SourceManager->getFileID(Result.SourceManager->getExpansionLoc(
+            StrFormatCall->getBeginLoc())),
         *MaybeHeaderToInclude);
 }
 

--- a/clang-tools-extra/clang-tidy/modernize/UseStdPrintCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/UseStdPrintCheck.cpp
@@ -158,7 +158,8 @@ void UseStdPrintCheck::check(const MatchFinder::MatchResult &Result) {
 
   if (MaybeHeaderToInclude)
     Diag << IncludeInserter.createIncludeInsertion(
-        Result.Context->getSourceManager().getFileID(PrintfCall->getBeginLoc()),
+        Result.SourceManager->getFileID(
+            Result.SourceManager->getExpansionLoc(PrintfCall->getBeginLoc())),
         *MaybeHeaderToInclude);
 }
 

--- a/clang-tools-extra/clang-tidy/modernize/UseStdPrintCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/UseStdPrintCheck.cpp
@@ -158,8 +158,7 @@ void UseStdPrintCheck::check(const MatchFinder::MatchResult &Result) {
 
   if (MaybeHeaderToInclude)
     Diag << IncludeInserter.createIncludeInsertion(
-        Result.SourceManager->getFileID(
-            Result.SourceManager->getExpansionLoc(PrintfCall->getBeginLoc())),
+        Result.Context->getSourceManager().getFileID(PrintfCall->getBeginLoc()),
         *MaybeHeaderToInclude);
 }
 

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -310,8 +310,12 @@ Changes in existing checks
   special member function.
 
 - Improved :doc:`modernize-use-std-format
-  <clang-tidy/checks/modernize/use-std-format>` check by fixing a crash
-  when an argument is part of a macro expansion.
+  <clang-tidy/checks/modernize/use-std-format>` check:
+
+  - Fixed a crash when an argument is part of a macro expansion.
+
+  - Added missing ``#include`` insertion when the format function call
+    appears as an argument to a macro.
 
 - Improved :doc:`modernize-use-trailing-return-type
   <clang-tidy/checks/modernize/use-trailing-return-type>` check by fixing

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/use-std-format-macro.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/use-std-format-macro.cpp
@@ -1,0 +1,21 @@
+// RUN: %check_clang_tidy -std=c++20-or-later %s modernize-use-std-format %t -- \
+// RUN:   -config="{CheckOptions: { \
+// RUN:              modernize-use-std-format.StrFormatLikeFunctions: 'String::Printf', \
+// RUN:              modernize-use-std-format.ReplacementFormatFunction: 'fmt::format', \
+// RUN:              modernize-use-std-format.FormatHeader: '<fmt/format.h>' \
+// RUN:            }}"
+
+#include <string>
+// CHECK-FIXES: #include <fmt/format.h>
+
+namespace String {
+extern std::string Printf(const char *format, ...);
+} // namespace String
+
+#define WRAP_MSG(msg) msg
+
+std::string macro_argument_include(int n) {
+  return WRAP_MSG(String::Printf("value %d", n));
+  // CHECK-MESSAGES: [[@LINE-1]]:19: warning: use 'fmt::format' instead of 'Printf' [modernize-use-std-format]
+  // CHECK-FIXES: return WRAP_MSG(fmt::format("value {}", n));
+}

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/use-std-format-macro.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/use-std-format-macro.cpp
@@ -9,7 +9,7 @@
 // CHECK-FIXES: #include <fmt/format.h>
 
 namespace String {
-extern std::string Printf(const char *format, ...);
+std::string Printf(const char *format, ...);
 } // namespace String
 
 #define WRAP_MSG(msg) msg


### PR DESCRIPTION
Added missing ``#include`` insertion when the format function call appears as an argument to a macro.

Part of #175183