### PR TITLE
[OFFLOAD][L0] Improve cleanup on errors

### DIFF
--- a/offload/plugins-nextgen/level_zero/src/L0Context.cpp
+++ b/offload/plugins-nextgen/level_zero/src/L0Context.cpp
@@ -16,16 +16,28 @@
 namespace llvm::omp::target::plugin {
 
 Error L0ContextTy::init() {
+  auto cleanupOnError = [&]() {
+    if (zeContext) {
+      zeContextDestroy(zeContext);
+      zeContext = nullptr;
+    }
+  };
   CALL_ZE_RET_ERROR(zeDriverGetApiVersion, zeDriver, &APIVersion);
   ODBG(OLDT_Init) << "Driver API version is "
                   << llvm::format(PRIx32, APIVersion);
 
   ze_context_desc_t Desc{ZE_STRUCTURE_TYPE_CONTEXT_DESC, nullptr, 0};
   CALL_ZE_RET_ERROR(zeContextCreate, zeDriver, &Desc, &zeContext);
-  if (auto Err = EventPool.init(zeContext, 0))
+  if (auto Err = EventPool.init(zeContext, 0)) {
+    cleanupOnError();
     return Err;
-  if (auto Err = HostMemAllocator.initHostPool(*this, Plugin.getOptions()))
+  }
+  if (auto Err = HostMemAllocator.initHostPool(*this, Plugin.getOptions())) {
+    if (auto DeinitErr = EventPool.deinit())
+      Err = joinErrors(std::move(Err), std::move(DeinitErr));
+    cleanupOnError();
     return Err;
+  }
   return Plugin::success();
 }
 

--- a/offload/plugins-nextgen/level_zero/src/L0Plugin.cpp
+++ b/offload/plugins-nextgen/level_zero/src/L0Plugin.cpp
@@ -61,8 +61,11 @@ Expected<int32_t> LevelZeroPluginTy::findDevices() {
     // We have a driver that supports at least one device.
     ContextList.emplace_back(*this, Driver, DriverId);
     auto &DrvInfo = ContextList.back();
-    if (auto Err = DrvInfo.init())
+    if (auto Err = DrvInfo.init()) {
+      // Remove the partially initialized context from the list
+      ContextList.pop_back();
       return std::move(Err);
+    }
     llvm::SmallVector<ze_device_handle_t> FoundDevices(DeviceCount);
     CALL_ZE_RET_ERROR(zeDeviceGet, Driver, &DeviceCount, FoundDevices.data());
 

--- a/offload/plugins-nextgen/level_zero/src/L0Program.cpp
+++ b/offload/plugins-nextgen/level_zero/src/L0Program.cpp
@@ -83,8 +83,19 @@ Error L0ProgramBuilderTy::addModule(size_t Size, const uint8_t *Image,
   ModuleDesc.pInputModule = Image;
   ModuleDesc.pBuildFlags = BuildOptions.c_str();
   ModuleDesc.pConstants = &SpecConstants;
-  CALL_ZE_RET_ERROR(zeModuleCreate, l0Device.getZeContext(),
-                    l0Device.getZeDevice(), &ModuleDesc, &Module, &BuildLog);
+  Error CreateErrors = Error::success();
+  auto handleError = [&](Error Err) {
+    if (BuildLog)
+      zeModuleBuildLogDestroy(BuildLog);
+    CreateErrors = joinErrors(std::move(CreateErrors), std::move(Err));
+  };
+  CALL_ZE_HANDLE_ERROR(handleError, zeModuleCreate, l0Device.getZeContext(),
+                       l0Device.getZeDevice(), &ModuleDesc, &Module, &BuildLog);
+  if (CreateErrors)
+    return CreateErrors;
+
+  if (BuildLog)
+    zeModuleBuildLogDestroy(BuildLog);
 
   // Check if module link is required. We do not need this check for
   // library module.


### PR DESCRIPTION
Additional cleanup improvements on error conditions (in addition to those in #187597):

  * Fixed incomplete cleanup in L0Context::init()
  * Fixed build log leak in addModule()
  * Fixed context inconsistent state in findDevices()

Disclaimer: The base of this PR was generated by Claude and adjusted by me afterwards.