### PR TITLE
[SystemZ][z/OS] Make emitIncrement() a member function of SystemZFrameLowering.

### DIFF
--- a/llvm/lib/Target/SystemZ/SystemZFrameLowering.cpp
+++ b/llvm/lib/Target/SystemZ/SystemZFrameLowering.cpp
@@ -162,6 +162,33 @@ bool SystemZFrameLowering::hasReservedCallFrame(
   return true;
 }
 
+void SystemZFrameLowering::emitIncrement(
+    MachineBasicBlock &MBB, MachineBasicBlock::iterator &MBBI,
+    const DebugLoc &DL, Register Reg, int64_t NumBytes,
+    const TargetInstrInfo *TII) const {
+  while (NumBytes) {
+    unsigned Opcode;
+    int64_t ThisVal = NumBytes;
+    if (isInt<16>(NumBytes))
+      Opcode = SystemZ::AGHI;
+    else {
+      Opcode = SystemZ::AGFI;
+      // Make sure we maintain stack alignment.
+      int64_t MinVal = -uint64_t(1) << 31;
+      int64_t MaxVal = (int64_t(1) << 31) - getStackAlignment();
+      if (ThisVal < MinVal)
+        ThisVal = MinVal;
+      else if (ThisVal > MaxVal)
+        ThisVal = MaxVal;
+    }
+    MachineInstr *MI = BuildMI(MBB, MBBI, DL, TII->get(Opcode), Reg)
+      .addReg(Reg).addImm(ThisVal);
+    // The CC implicit def is dead.
+    MI->getOperand(3).setIsDead();
+    NumBytes -= ThisVal;
+  }
+}
+
 bool SystemZELFFrameLowering::assignCalleeSavedSpillSlots(
     MachineFunction &MF, const TargetRegisterInfo *TRI,
     std::vector<CalleeSavedInfo> &CSI) const {
@@ -472,34 +499,6 @@ void SystemZELFFrameLowering::processFunctionBeforeFrameFinalized(
       ZFI->getRestoreGPRRegs().LowGPR != SystemZ::R6D)
     for (auto &MO : MRI->use_nodbg_operands(SystemZ::R6D))
       MO.setIsKill(false);
-}
-
-// Emit instructions before MBBI (in MBB) to add NumBytes to Reg.
-static void emitIncrement(MachineBasicBlock &MBB,
-                          MachineBasicBlock::iterator &MBBI, const DebugLoc &DL,
-                          Register Reg, int64_t NumBytes,
-                          const TargetInstrInfo *TII) {
-  while (NumBytes) {
-    unsigned Opcode;
-    int64_t ThisVal = NumBytes;
-    if (isInt<16>(NumBytes))
-      Opcode = SystemZ::AGHI;
-    else {
-      Opcode = SystemZ::AGFI;
-      // Make sure we maintain 8-byte stack alignment.
-      int64_t MinVal = -uint64_t(1) << 31;
-      int64_t MaxVal = (int64_t(1) << 31) - 8;
-      if (ThisVal < MinVal)
-        ThisVal = MinVal;
-      else if (ThisVal > MaxVal)
-        ThisVal = MaxVal;
-    }
-    MachineInstr *MI = BuildMI(MBB, MBBI, DL, TII->get(Opcode), Reg)
-      .addReg(Reg).addImm(ThisVal);
-    // The CC implicit def is dead.
-    MI->getOperand(3).setIsDead();
-    NumBytes -= ThisVal;
-  }
 }
 
 // Add CFI for the new CFA offset.

--- a/llvm/lib/Target/SystemZ/SystemZFrameLowering.cpp
+++ b/llvm/lib/Target/SystemZ/SystemZFrameLowering.cpp
@@ -162,10 +162,11 @@ bool SystemZFrameLowering::hasReservedCallFrame(
   return true;
 }
 
-void SystemZFrameLowering::emitIncrement(
-    MachineBasicBlock &MBB, MachineBasicBlock::iterator &MBBI,
-    const DebugLoc &DL, Register Reg, int64_t NumBytes,
-    const TargetInstrInfo *TII) const {
+void SystemZFrameLowering::emitIncrement(MachineBasicBlock &MBB,
+                                         MachineBasicBlock::iterator &MBBI,
+                                         const DebugLoc &DL, Register Reg,
+                                         int64_t NumBytes,
+                                         const TargetInstrInfo *TII) const {
   while (NumBytes) {
     unsigned Opcode;
     int64_t ThisVal = NumBytes;
@@ -182,7 +183,8 @@ void SystemZFrameLowering::emitIncrement(
         ThisVal = MaxVal;
     }
     MachineInstr *MI = BuildMI(MBB, MBBI, DL, TII->get(Opcode), Reg)
-      .addReg(Reg).addImm(ThisVal);
+                           .addReg(Reg)
+                           .addImm(ThisVal);
     // The CC implicit def is dead.
     MI->getOperand(3).setIsDead();
     NumBytes -= ThisVal;

--- a/llvm/lib/Target/SystemZ/SystemZFrameLowering.h
+++ b/llvm/lib/Target/SystemZ/SystemZFrameLowering.h
@@ -54,6 +54,11 @@ public:
   // Return the size of a pointer (in bytes).
   unsigned getPointerSize() const { return PointerSize; }
 
+  // Emit instructions before MBBI (in MBB) to add NumBytes to Reg.
+  void emitIncrement(MachineBasicBlock &MBB, MachineBasicBlock::iterator &MBBI,
+                     const DebugLoc &DL, Register Reg, int64_t NumBytes,
+                     const TargetInstrInfo *TII) const;
+
 private:
   unsigned PointerSize;
 };

--- a/llvm/test/CodeGen/SystemZ/zos-prologue-epilog.ll
+++ b/llvm/test/CodeGen/SystemZ/zos-prologue-epilog.ll
@@ -400,6 +400,18 @@ define void @large_stack2(i64 %n1, i64 %n2, i64 %n3) {
   ret void
 }
 
+; Verify stack alignment is 32
+; CHECK-LABEL: large_stack3
+; CHECK: agfi 4,-2147483648
+; CHECK-NEXT: aghi 4,-224
+; CHECK: agfi 4,2147483616
+; CHECK-NEXT: aghi 4,256
+define void @large_stack3() {
+  %arr = alloca [268435457 x i64], align 8
+  call i64 (ptr) @fun1(ptr %arr)
+  ret void
+}
+
 ; CHECK-LABEL: L#EPM_leaf_func0_0 DS 0H
 ; CHECK: * DSA Size 0x0
 ; CHECK: * Entry Flags


### PR DESCRIPTION
Function `emitIncrement()` uses 8 for stack alignment, but the stack alignment for 64-bit XPLINK is 32 on z/OS.
This PR changes it to a member function of SystemZFrameLowering to get the correct stack alignment by `getStackAlignment()`. It also adds a test to verify it.