### PR TITLE
[InstCombine] Generalize `(A + 1) + ~B` fold to any constant

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineAddSub.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineAddSub.cpp
@@ -1610,10 +1610,10 @@ Instruction *InstCombinerImpl::visitAdd(BinaryOperator &I) {
     // (~B + A) + C --> A - B + (C-1)
     // (A + ~B) + C --> A - B + (C-1)
     const APInt *C;
-    if (match(&I,
-              m_c_BinOp(m_Add(m_Value(A), m_APInt(C)), m_Not(m_Value(B)))) ||
-        match(&I,
-              m_BinOp(m_c_Add(m_Not(m_Value(B)), m_Value(A)), m_APInt(C)))) {
+    if (match(&I, m_c_BinOp(m_Add(m_Value(A), m_APIntAllowPoison(C)),
+                            m_Not(m_Value(B)))) ||
+        match(&I, m_BinOp(m_c_Add(m_Not(m_Value(B)), m_Value(A)),
+                          m_APIntAllowPoison(C)))) {
       Value *Sub = Builder.CreateSub(A, B);
       return BinaryOperator::CreateAdd(Sub, ConstantInt::get(Ty, *C - 1));
     }

--- a/llvm/lib/Transforms/InstCombine/InstCombineAddSub.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineAddSub.cpp
@@ -1604,13 +1604,20 @@ Instruction *InstCombinerImpl::visitAdd(BinaryOperator &I) {
   if (Value *V = checkForNegativeOperand(I, Builder))
     return replaceInstUsesWith(I, V);
 
-  // (A + 1) + ~B --> A - B
-  // ~B + (A + 1) --> A - B
-  // (~B + A) + 1 --> A - B
-  // (A + ~B) + 1 --> A - B
-  if (match(&I, m_c_BinOp(m_Add(m_Value(A), m_One()), m_Not(m_Value(B)))) ||
-      match(&I, m_BinOp(m_c_Add(m_Not(m_Value(B)), m_Value(A)), m_One())))
-    return BinaryOperator::CreateSub(A, B);
+  {
+    // (A + C) + ~B --> A - B + (C-1)
+    // ~B + (A + C) --> A - B + (C-1)
+    // (~B + A) + C --> A - B + (C-1)
+    // (A + ~B) + C --> A - B + (C-1)
+    const APInt *C;
+    if (match(&I,
+              m_c_BinOp(m_Add(m_Value(A), m_APInt(C)), m_Not(m_Value(B)))) ||
+        match(&I,
+              m_BinOp(m_c_Add(m_Not(m_Value(B)), m_Value(A)), m_APInt(C)))) {
+      Value *Sub = Builder.CreateSub(A, B);
+      return BinaryOperator::CreateAdd(Sub, ConstantInt::get(Ty, *C - 1));
+    }
+  }
 
   // (A + RHS) + RHS --> A + (RHS << 1)
   if (match(LHS, m_OneUse(m_c_Add(m_Value(A), m_Specific(RHS)))))

--- a/llvm/lib/Transforms/InstCombine/InstCombineAddSub.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineAddSub.cpp
@@ -1609,6 +1609,10 @@ Instruction *InstCombinerImpl::visitAdd(BinaryOperator &I) {
     // ~B + (A + C) --> A - B + (C-1)
     // (~B + A) + C --> A - B + (C-1)
     // (A + ~B) + C --> A - B + (C-1)
+    // This relies on the ~B == -1-B identity.
+    // With constant C, subtraction of one is free, so we replace three ops
+    // (two adds and a bitwise-not) with two (sub and add)
+    // or even one (just sub for the C==1 special case).
     const APInt *C;
     if (match(&I, m_c_BinOp(m_Add(m_Value(A), m_APIntAllowPoison(C)),
                             m_Not(m_Value(B)))) ||

--- a/llvm/lib/Transforms/InstCombine/InstCombineAddSub.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineAddSub.cpp
@@ -1604,21 +1604,25 @@ Instruction *InstCombinerImpl::visitAdd(BinaryOperator &I) {
   if (Value *V = checkForNegativeOperand(I, Builder))
     return replaceInstUsesWith(I, V);
 
+  // (A + 1) + ~B --> A - B
+  // ~B + (A + 1) --> A - B
+  // (~B + A) + 1 --> A - B
+  // (A + ~B) + 1 --> A - B
+  // This relies on the ~B == -1-B identity.
+  if (match(&I, m_c_BinOp(m_Add(m_Value(A), m_One()), m_Not(m_Value(B)))) ||
+      match(&I, m_BinOp(m_c_Add(m_Not(m_Value(B)), m_Value(A)), m_One())))
+    return BinaryOperator::CreateSub(A, B);
+
   {
     // (A + C) + ~B --> A - B + (C-1)
     // ~B + (A + C) --> A - B + (C-1)
     // (~B + A) + C --> A - B + (C-1)
     // (A + ~B) + C --> A - B + (C-1)
-    // This relies on the ~B == -1-B identity.
     // With constant C, subtraction of one is free, so we replace three ops
-    // (two adds and a bitwise-not) with two (sub and add)
-    // or even one (just sub for the C==1 special case).
+    // (two adds and a bitwise-not) with two (sub and add).
     const APInt *C;
     if (match(&I, m_c_BinOp(m_OneUse(m_Add(m_Value(A), m_APIntAllowPoison(C))),
                             m_Not(m_Value(B)))) ||
-        (match(&I, m_c_BinOp(m_Add(m_Value(A), m_APIntAllowPoison(C)),
-                             m_OneUse(m_Not(m_Value(B))))) &&
-         *C == 1) ||
         match(&I, m_BinOp(m_OneUse(m_c_Add(m_Not(m_Value(B)), m_Value(A))),
                           m_APIntAllowPoison(C)))) {
       Value *Sub = Builder.CreateSub(A, B);

--- a/llvm/lib/Transforms/InstCombine/InstCombineAddSub.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineAddSub.cpp
@@ -1616,7 +1616,7 @@ Instruction *InstCombinerImpl::visitAdd(BinaryOperator &I) {
     const APInt *C;
     if (match(&I, m_c_BinOp(m_Add(m_Value(A), m_APIntAllowPoison(C)),
                             m_Not(m_Value(B)))) ||
-        match(&I, m_BinOp(m_c_Add(m_Not(m_Value(B)), m_Value(A)),
+        match(&I, m_BinOp(m_OneUse(m_c_Add(m_Not(m_Value(B)), m_Value(A))),
                           m_APIntAllowPoison(C)))) {
       Value *Sub = Builder.CreateSub(A, B);
       return BinaryOperator::CreateAdd(Sub, ConstantInt::get(Ty, *C - 1));

--- a/llvm/lib/Transforms/InstCombine/InstCombineAddSub.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineAddSub.cpp
@@ -1616,8 +1616,9 @@ Instruction *InstCombinerImpl::visitAdd(BinaryOperator &I) {
     const APInt *C;
     if (match(&I, m_c_BinOp(m_OneUse(m_Add(m_Value(A), m_APIntAllowPoison(C))),
                             m_Not(m_Value(B)))) ||
-        match(&I, m_c_BinOp(m_Add(m_Value(A), m_APIntAllowPoison(C)),
-                            m_OneUse(m_Not(m_Value(B))))) ||
+        (match(&I, m_c_BinOp(m_Add(m_Value(A), m_APIntAllowPoison(C)),
+                             m_OneUse(m_Not(m_Value(B))))) &&
+         *C == 1) ||
         match(&I, m_BinOp(m_OneUse(m_c_Add(m_Not(m_Value(B)), m_Value(A))),
                           m_APIntAllowPoison(C)))) {
       Value *Sub = Builder.CreateSub(A, B);

--- a/llvm/lib/Transforms/InstCombine/InstCombineAddSub.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineAddSub.cpp
@@ -1614,8 +1614,10 @@ Instruction *InstCombinerImpl::visitAdd(BinaryOperator &I) {
     // (two adds and a bitwise-not) with two (sub and add)
     // or even one (just sub for the C==1 special case).
     const APInt *C;
-    if (match(&I, m_c_BinOp(m_Add(m_Value(A), m_APIntAllowPoison(C)),
+    if (match(&I, m_c_BinOp(m_OneUse(m_Add(m_Value(A), m_APIntAllowPoison(C))),
                             m_Not(m_Value(B)))) ||
+        match(&I, m_c_BinOp(m_Add(m_Value(A), m_APIntAllowPoison(C)),
+                            m_OneUse(m_Not(m_Value(B))))) ||
         match(&I, m_BinOp(m_OneUse(m_c_Add(m_Not(m_Value(B)), m_Value(A))),
                           m_APIntAllowPoison(C)))) {
       Value *Sub = Builder.CreateSub(A, B);

--- a/llvm/test/Transforms/InstCombine/add.ll
+++ b/llvm/test/Transforms/InstCombine/add.ll
@@ -1196,9 +1196,8 @@ define i32 @add_to_sub2(i32 %A, i32 %M) {
 
 define i32 @add_not_add_m1(i32 %a, i32 %b) {
 ; CHECK-LABEL: @add_not_add_m1(
-; CHECK-NEXT:    [[NOT:%.*]] = xor i32 [[B:%.*]], -1
-; CHECK-NEXT:    [[ADD:%.*]] = add i32 [[A:%.*]], -1
-; CHECK-NEXT:    [[R:%.*]] = add i32 [[ADD]], [[NOT]]
+; CHECK-NEXT:    [[TMP1:%.*]] = sub i32 [[A:%.*]], [[B:%.*]]
+; CHECK-NEXT:    [[R:%.*]] = add i32 [[TMP1]], -2
 ; CHECK-NEXT:    ret i32 [[R]]
 ;
   %not = xor i32 %b, -1
@@ -1209,9 +1208,8 @@ define i32 @add_not_add_m1(i32 %a, i32 %b) {
 
 define <2 x i32> @add_not_add_m1_vec(<2 x i32> %a, <2 x i32> %b) {
 ; CHECK-LABEL: @add_not_add_m1_vec(
-; CHECK-NEXT:    [[NOT:%.*]] = xor <2 x i32> [[B:%.*]], splat (i32 -1)
-; CHECK-NEXT:    [[ADD:%.*]] = add <2 x i32> [[A:%.*]], splat (i32 -1)
-; CHECK-NEXT:    [[R:%.*]] = add <2 x i32> [[ADD]], [[NOT]]
+; CHECK-NEXT:    [[TMP1:%.*]] = sub <2 x i32> [[A:%.*]], [[B:%.*]]
+; CHECK-NEXT:    [[R:%.*]] = add <2 x i32> [[TMP1]], splat (i32 -2)
 ; CHECK-NEXT:    ret <2 x i32> [[R]]
 ;
   %not = xor <2 x i32> %b, <i32 -1, i32 -1>
@@ -1222,9 +1220,8 @@ define <2 x i32> @add_not_add_m1_vec(<2 x i32> %a, <2 x i32> %b) {
 
 define i32 @add_not_add_m1_commuted(i32 %a, i32 %b) {
 ; CHECK-LABEL: @add_not_add_m1_commuted(
-; CHECK-NEXT:    [[NOT:%.*]] = xor i32 [[B:%.*]], -1
-; CHECK-NEXT:    [[ADD:%.*]] = add i32 [[A:%.*]], -1
-; CHECK-NEXT:    [[R:%.*]] = add i32 [[ADD]], [[NOT]]
+; CHECK-NEXT:    [[TMP1:%.*]] = sub i32 [[A:%.*]], [[B:%.*]]
+; CHECK-NEXT:    [[R:%.*]] = add i32 [[TMP1]], -2
 ; CHECK-NEXT:    ret i32 [[R]]
 ;
   %not = xor i32 %b, -1
@@ -1235,9 +1232,8 @@ define i32 @add_not_add_m1_commuted(i32 %a, i32 %b) {
 
 define i32 @add_not_add_m1_assoc(i32 %a, i32 %b) {
 ; CHECK-LABEL: @add_not_add_m1_assoc(
-; CHECK-NEXT:    [[NOT:%.*]] = xor i32 [[B:%.*]], -1
-; CHECK-NEXT:    [[ADD:%.*]] = add i32 [[A:%.*]], [[NOT]]
-; CHECK-NEXT:    [[R:%.*]] = add i32 [[ADD]], -1
+; CHECK-NEXT:    [[TMP1:%.*]] = sub i32 [[A:%.*]], [[B:%.*]]
+; CHECK-NEXT:    [[R:%.*]] = add i32 [[TMP1]], -2
 ; CHECK-NEXT:    ret i32 [[R]]
 ;
   %not = xor i32 %b, -1

--- a/llvm/test/Transforms/InstCombine/add.ll
+++ b/llvm/test/Transforms/InstCombine/add.ll
@@ -1194,67 +1194,6 @@ define i32 @add_to_sub2(i32 %A, i32 %M) {
   ret i32 %E
 }
 
-define i32 @add_not_add_m1(i32 %a, i32 %b) {
-; CHECK-LABEL: @add_not_add_m1(
-; CHECK-NEXT:    [[TMP1:%.*]] = sub i32 [[A:%.*]], [[B:%.*]]
-; CHECK-NEXT:    [[R:%.*]] = add i32 [[TMP1]], -2
-; CHECK-NEXT:    ret i32 [[R]]
-;
-  %not = xor i32 %b, -1
-  %add = add i32 %a, -1
-  %r = add i32 %add, %not
-  ret i32 %r
-}
-
-define <2 x i32> @add_not_add_m1_vec(<2 x i32> %a, <2 x i32> %b) {
-; CHECK-LABEL: @add_not_add_m1_vec(
-; CHECK-NEXT:    [[TMP1:%.*]] = sub <2 x i32> [[A:%.*]], [[B:%.*]]
-; CHECK-NEXT:    [[R:%.*]] = add <2 x i32> [[TMP1]], splat (i32 -2)
-; CHECK-NEXT:    ret <2 x i32> [[R]]
-;
-  %not = xor <2 x i32> %b, <i32 -1, i32 -1>
-  %add = add <2 x i32> %a, <i32 -1, i32 -1>
-  %r = add <2 x i32> %add, %not
-  ret <2 x i32> %r
-}
-
-define i32 @add_not_add_m1_commuted(i32 %a, i32 %b) {
-; CHECK-LABEL: @add_not_add_m1_commuted(
-; CHECK-NEXT:    [[TMP1:%.*]] = sub i32 [[A:%.*]], [[B:%.*]]
-; CHECK-NEXT:    [[R:%.*]] = add i32 [[TMP1]], -2
-; CHECK-NEXT:    ret i32 [[R]]
-;
-  %not = xor i32 %b, -1
-  %add = add i32 %a, -1
-  %r = add i32 %not, %add
-  ret i32 %r
-}
-
-define i32 @add_not_add_m1_assoc(i32 %a, i32 %b) {
-; CHECK-LABEL: @add_not_add_m1_assoc(
-; CHECK-NEXT:    [[TMP1:%.*]] = sub i32 [[A:%.*]], [[B:%.*]]
-; CHECK-NEXT:    [[R:%.*]] = add i32 [[TMP1]], -2
-; CHECK-NEXT:    ret i32 [[R]]
-;
-  %not = xor i32 %b, -1
-  %add = add i32 %not, %a
-  %r = add i32 %add, -1
-  ret i32 %r
-}
-
-define i32 @add_not_add_intmin(i32 %a, i32 %b) {
-; CHECK-LABEL: @add_not_add_intmin(
-; CHECK-NEXT:    [[NOT:%.*]] = xor i32 [[B:%.*]], -1
-; CHECK-NEXT:    [[ADD:%.*]] = xor i32 [[A:%.*]], -2147483648
-; CHECK-NEXT:    [[R:%.*]] = add i32 [[ADD]], [[NOT]]
-; CHECK-NEXT:    ret i32 [[R]]
-;
-  %not = xor i32 %b, -1
-  %add = add i32 %a, -2147483648
-  %r = add i32 %add, %not
-  ret i32 %r
-}
-
 ; (X | C1) + C2 --> (X | C1) ^ C1 iff (C1 == -C2)
 define i32 @test44(i32 %A) {
 ; CHECK-LABEL: @test44(

--- a/llvm/test/Transforms/InstCombine/add.ll
+++ b/llvm/test/Transforms/InstCombine/add.ll
@@ -1194,6 +1194,71 @@ define i32 @add_to_sub2(i32 %A, i32 %M) {
   ret i32 %E
 }
 
+define i32 @add_not_add_m1(i32 %a, i32 %b) {
+; CHECK-LABEL: @add_not_add_m1(
+; CHECK-NEXT:    [[NOT:%.*]] = xor i32 [[B:%.*]], -1
+; CHECK-NEXT:    [[ADD:%.*]] = add i32 [[A:%.*]], -1
+; CHECK-NEXT:    [[R:%.*]] = add i32 [[ADD]], [[NOT]]
+; CHECK-NEXT:    ret i32 [[R]]
+;
+  %not = xor i32 %b, -1
+  %add = add i32 %a, -1
+  %r = add i32 %add, %not
+  ret i32 %r
+}
+
+define <2 x i32> @add_not_add_m1_vec(<2 x i32> %a, <2 x i32> %b) {
+; CHECK-LABEL: @add_not_add_m1_vec(
+; CHECK-NEXT:    [[NOT:%.*]] = xor <2 x i32> [[B:%.*]], splat (i32 -1)
+; CHECK-NEXT:    [[ADD:%.*]] = add <2 x i32> [[A:%.*]], splat (i32 -1)
+; CHECK-NEXT:    [[R:%.*]] = add <2 x i32> [[ADD]], [[NOT]]
+; CHECK-NEXT:    ret <2 x i32> [[R]]
+;
+  %not = xor <2 x i32> %b, <i32 -1, i32 -1>
+  %add = add <2 x i32> %a, <i32 -1, i32 -1>
+  %r = add <2 x i32> %add, %not
+  ret <2 x i32> %r
+}
+
+define i32 @add_not_add_m1_commuted(i32 %a, i32 %b) {
+; CHECK-LABEL: @add_not_add_m1_commuted(
+; CHECK-NEXT:    [[NOT:%.*]] = xor i32 [[B:%.*]], -1
+; CHECK-NEXT:    [[ADD:%.*]] = add i32 [[A:%.*]], -1
+; CHECK-NEXT:    [[R:%.*]] = add i32 [[ADD]], [[NOT]]
+; CHECK-NEXT:    ret i32 [[R]]
+;
+  %not = xor i32 %b, -1
+  %add = add i32 %a, -1
+  %r = add i32 %not, %add
+  ret i32 %r
+}
+
+define i32 @add_not_add_m1_assoc(i32 %a, i32 %b) {
+; CHECK-LABEL: @add_not_add_m1_assoc(
+; CHECK-NEXT:    [[NOT:%.*]] = xor i32 [[B:%.*]], -1
+; CHECK-NEXT:    [[ADD:%.*]] = add i32 [[A:%.*]], [[NOT]]
+; CHECK-NEXT:    [[R:%.*]] = add i32 [[ADD]], -1
+; CHECK-NEXT:    ret i32 [[R]]
+;
+  %not = xor i32 %b, -1
+  %add = add i32 %not, %a
+  %r = add i32 %add, -1
+  ret i32 %r
+}
+
+define i32 @add_not_add_intmin(i32 %a, i32 %b) {
+; CHECK-LABEL: @add_not_add_intmin(
+; CHECK-NEXT:    [[NOT:%.*]] = xor i32 [[B:%.*]], -1
+; CHECK-NEXT:    [[ADD:%.*]] = xor i32 [[A:%.*]], -2147483648
+; CHECK-NEXT:    [[R:%.*]] = add i32 [[ADD]], [[NOT]]
+; CHECK-NEXT:    ret i32 [[R]]
+;
+  %not = xor i32 %b, -1
+  %add = add i32 %a, -2147483648
+  %r = add i32 %add, %not
+  ret i32 %r
+}
+
 ; (X | C1) + C2 --> (X | C1) ^ C1 iff (C1 == -C2)
 define i32 @test44(i32 %A) {
 ; CHECK-LABEL: @test44(

--- a/llvm/test/Transforms/InstCombine/fold-inc-of-add-of-not-x-and-y-to-sub-x-from-y.ll
+++ b/llvm/test/Transforms/InstCombine/fold-inc-of-add-of-not-x-and-y-to-sub-x-from-y.ll
@@ -21,6 +21,18 @@ define i32 @t0(i32 %x, i32 %y) {
   ret i32 %t2
 }
 
+define i32 @t12(i32 %x, i32 %y) {
+; CHECK-LABEL: @t12(
+; CHECK-NEXT:    [[TMP1:%.*]] = sub i32 [[Y:%.*]], [[X:%.*]]
+; CHECK-NEXT:    [[T2:%.*]] = add i32 [[TMP1]], 1
+; CHECK-NEXT:    ret i32 [[T2]]
+;
+  %t0 = xor i32 %x, -1
+  %t1 = add i32 %t0, %y
+  %t2 = add i32 %t1, 2
+  ret i32 %t2
+}
+
 define i32 @add_not_add_m1(i32 %a, i32 %b) {
 ; CHECK-LABEL: @add_not_add_m1(
 ; CHECK-NEXT:    [[TMP1:%.*]] = sub i32 [[A:%.*]], [[B:%.*]]
@@ -269,17 +281,5 @@ define i32 @n11(i32 %x, i32 %y) {
   %t0 = xor i32 %x, 2147483647 ; not -1
   %t1 = add i32 %t0, %y
   %t2 = add i32 %t1, 1
-  ret i32 %t2
-}
-
-define i32 @n12(i32 %x, i32 %y) {
-; CHECK-LABEL: @n12(
-; CHECK-NEXT:    [[TMP1:%.*]] = sub i32 [[Y:%.*]], [[X:%.*]]
-; CHECK-NEXT:    [[T2:%.*]] = add i32 [[TMP1]], 1
-; CHECK-NEXT:    ret i32 [[T2]]
-;
-  %t0 = xor i32 %x, -1
-  %t1 = add i32 %t0, %y
-  %t2 = add i32 %t1, 2 ; not +1
   ret i32 %t2
 }

--- a/llvm/test/Transforms/InstCombine/fold-inc-of-add-of-not-x-and-y-to-sub-x-from-y.ll
+++ b/llvm/test/Transforms/InstCombine/fold-inc-of-add-of-not-x-and-y-to-sub-x-from-y.ll
@@ -49,7 +49,9 @@ define <4 x i32> @t2_vec_poison0(<4 x i32> %x, <4 x i32> %y) {
 
 define <4 x i32> @t3_vec_poison1(<4 x i32> %x, <4 x i32> %y) {
 ; CHECK-LABEL: @t3_vec_poison1(
-; CHECK-NEXT:    [[T2:%.*]] = sub <4 x i32> [[Y:%.*]], [[X:%.*]]
+; CHECK-NEXT:    [[T0:%.*]] = xor <4 x i32> [[X:%.*]], splat (i32 -1)
+; CHECK-NEXT:    [[T1:%.*]] = add <4 x i32> [[Y:%.*]], [[T0]]
+; CHECK-NEXT:    [[T2:%.*]] = add <4 x i32> [[T1]], <i32 1, i32 1, i32 poison, i32 1>
 ; CHECK-NEXT:    ret <4 x i32> [[T2]]
 ;
   %t0 = xor <4 x i32> %x, <i32 -1, i32 -1, i32 -1, i32 -1>
@@ -60,7 +62,9 @@ define <4 x i32> @t3_vec_poison1(<4 x i32> %x, <4 x i32> %y) {
 
 define <4 x i32> @t4_vec_poison2(<4 x i32> %x, <4 x i32> %y) {
 ; CHECK-LABEL: @t4_vec_poison2(
-; CHECK-NEXT:    [[T2:%.*]] = sub <4 x i32> [[Y:%.*]], [[X:%.*]]
+; CHECK-NEXT:    [[T0:%.*]] = xor <4 x i32> [[X:%.*]], <i32 -1, i32 -1, i32 poison, i32 -1>
+; CHECK-NEXT:    [[T1:%.*]] = add <4 x i32> [[Y:%.*]], [[T0]]
+; CHECK-NEXT:    [[T2:%.*]] = add <4 x i32> [[T1]], <i32 1, i32 1, i32 poison, i32 1>
 ; CHECK-NEXT:    ret <4 x i32> [[T2]]
 ;
   %t0 = xor <4 x i32> %x, <i32 -1, i32 -1, i32 poison, i32 -1>
@@ -201,9 +205,8 @@ define i32 @n11(i32 %x, i32 %y) {
 
 define i32 @n12(i32 %x, i32 %y) {
 ; CHECK-LABEL: @n12(
-; CHECK-NEXT:    [[T0:%.*]] = xor i32 [[X:%.*]], -1
-; CHECK-NEXT:    [[T1:%.*]] = add i32 [[Y:%.*]], [[T0]]
-; CHECK-NEXT:    [[T2:%.*]] = add i32 [[T1]], 2
+; CHECK-NEXT:    [[TMP1:%.*]] = sub i32 [[Y:%.*]], [[X:%.*]]
+; CHECK-NEXT:    [[T2:%.*]] = add i32 [[TMP1]], 1
 ; CHECK-NEXT:    ret i32 [[T2]]
 ;
   %t0 = xor i32 %x, -1

--- a/llvm/test/Transforms/InstCombine/fold-inc-of-add-of-not-x-and-y-to-sub-x-from-y.ll
+++ b/llvm/test/Transforms/InstCombine/fold-inc-of-add-of-not-x-and-y-to-sub-x-from-y.ll
@@ -49,9 +49,7 @@ define <4 x i32> @t2_vec_poison0(<4 x i32> %x, <4 x i32> %y) {
 
 define <4 x i32> @t3_vec_poison1(<4 x i32> %x, <4 x i32> %y) {
 ; CHECK-LABEL: @t3_vec_poison1(
-; CHECK-NEXT:    [[T0:%.*]] = xor <4 x i32> [[X:%.*]], splat (i32 -1)
-; CHECK-NEXT:    [[T1:%.*]] = add <4 x i32> [[Y:%.*]], [[T0]]
-; CHECK-NEXT:    [[T2:%.*]] = add <4 x i32> [[T1]], <i32 1, i32 1, i32 poison, i32 1>
+; CHECK-NEXT:    [[T2:%.*]] = sub <4 x i32> [[Y:%.*]], [[X:%.*]]
 ; CHECK-NEXT:    ret <4 x i32> [[T2]]
 ;
   %t0 = xor <4 x i32> %x, <i32 -1, i32 -1, i32 -1, i32 -1>
@@ -62,9 +60,7 @@ define <4 x i32> @t3_vec_poison1(<4 x i32> %x, <4 x i32> %y) {
 
 define <4 x i32> @t4_vec_poison2(<4 x i32> %x, <4 x i32> %y) {
 ; CHECK-LABEL: @t4_vec_poison2(
-; CHECK-NEXT:    [[T0:%.*]] = xor <4 x i32> [[X:%.*]], <i32 -1, i32 -1, i32 poison, i32 -1>
-; CHECK-NEXT:    [[T1:%.*]] = add <4 x i32> [[Y:%.*]], [[T0]]
-; CHECK-NEXT:    [[T2:%.*]] = add <4 x i32> [[T1]], <i32 1, i32 1, i32 poison, i32 1>
+; CHECK-NEXT:    [[T2:%.*]] = sub <4 x i32> [[Y:%.*]], [[X:%.*]]
 ; CHECK-NEXT:    ret <4 x i32> [[T2]]
 ;
   %t0 = xor <4 x i32> %x, <i32 -1, i32 -1, i32 poison, i32 -1>

--- a/llvm/test/Transforms/InstCombine/fold-inc-of-add-of-not-x-and-y-to-sub-x-from-y.ll
+++ b/llvm/test/Transforms/InstCombine/fold-inc-of-add-of-not-x-and-y-to-sub-x-from-y.ll
@@ -21,6 +21,31 @@ define i32 @t0(i32 %x, i32 %y) {
   ret i32 %t2
 }
 
+define i32 @add_not_add_m1(i32 %a, i32 %b) {
+; CHECK-LABEL: @add_not_add_m1(
+; CHECK-NEXT:    [[TMP1:%.*]] = sub i32 [[A:%.*]], [[B:%.*]]
+; CHECK-NEXT:    [[R:%.*]] = add i32 [[TMP1]], -2
+; CHECK-NEXT:    ret i32 [[R]]
+;
+  %not = xor i32 %b, -1
+  %add = add i32 %a, -1
+  %r = add i32 %add, %not
+  ret i32 %r
+}
+
+define i32 @add_not_add_intmin(i32 %a, i32 %b) {
+; CHECK-LABEL: @add_not_add_intmin(
+; CHECK-NEXT:    [[NOT:%.*]] = xor i32 [[B:%.*]], -1
+; CHECK-NEXT:    [[ADD:%.*]] = xor i32 [[A:%.*]], -2147483648
+; CHECK-NEXT:    [[R:%.*]] = add i32 [[ADD]], [[NOT]]
+; CHECK-NEXT:    ret i32 [[R]]
+;
+  %not = xor i32 %b, -1
+  %add = add i32 %a, -2147483648
+  %r = add i32 %add, %not
+  ret i32 %r
+}
+
 ;------------------------------------------------------------------------------;
 ; Vector tests
 ;------------------------------------------------------------------------------;
@@ -67,6 +92,18 @@ define <4 x i32> @t4_vec_poison2(<4 x i32> %x, <4 x i32> %y) {
   %t1 = add <4 x i32> %t0, %y
   %t2 = add <4 x i32> %t1, <i32 1, i32 1, i32 poison, i32 1>
   ret <4 x i32> %t2
+}
+
+define <2 x i32> @add_not_add_m1_vec(<2 x i32> %a, <2 x i32> %b) {
+; CHECK-LABEL: @add_not_add_m1_vec(
+; CHECK-NEXT:    [[TMP1:%.*]] = sub <2 x i32> [[A:%.*]], [[B:%.*]]
+; CHECK-NEXT:    [[R:%.*]] = add <2 x i32> [[TMP1]], splat (i32 -2)
+; CHECK-NEXT:    ret <2 x i32> [[R]]
+;
+  %not = xor <2 x i32> %b, splat (i32 -1)
+  %add = add <2 x i32> %a, splat (i32 -1)
+  %r = add <2 x i32> %add, %not
+  ret <2 x i32> %r
 }
 
 ;------------------------------------------------------------------------------;
@@ -180,6 +217,30 @@ define i32 @t10_commutative2(i32 %x) {
   call void @use32(i32 %t1)
   %t2 = add i32 %y, %t1 ; swapped
   ret i32 %t2
+}
+
+define i32 @add_not_add_m1_commuted(i32 %a, i32 %b) {
+; CHECK-LABEL: @add_not_add_m1_commuted(
+; CHECK-NEXT:    [[TMP1:%.*]] = sub i32 [[A:%.*]], [[B:%.*]]
+; CHECK-NEXT:    [[R:%.*]] = add i32 [[TMP1]], -2
+; CHECK-NEXT:    ret i32 [[R]]
+;
+  %not = xor i32 %b, -1
+  %add = add i32 %a, -1
+  %r = add i32 %not, %add
+  ret i32 %r
+}
+
+define i32 @add_not_add_m1_assoc(i32 %a, i32 %b) {
+; CHECK-LABEL: @add_not_add_m1_assoc(
+; CHECK-NEXT:    [[TMP1:%.*]] = sub i32 [[A:%.*]], [[B:%.*]]
+; CHECK-NEXT:    [[R:%.*]] = add i32 [[TMP1]], -2
+; CHECK-NEXT:    ret i32 [[R]]
+;
+  %not = xor i32 %b, -1
+  %add = add i32 %not, %a
+  %r = add i32 %add, -1
+  ret i32 %r
 }
 
 ;------------------------------------------------------------------------------;

--- a/llvm/test/Transforms/InstCombine/fold-inc-of-add-of-not-x-and-y-to-sub-x-from-y.ll
+++ b/llvm/test/Transforms/InstCombine/fold-inc-of-add-of-not-x-and-y-to-sub-x-from-y.ll
@@ -106,6 +106,18 @@ define <2 x i32> @add_not_add_m1_vec(<2 x i32> %a, <2 x i32> %b) {
   ret <2 x i32> %r
 }
 
+define <2 x i32> @add_not_add_m1_vec_poison(<2 x i32> %a, <2 x i32> %b) {
+; CHECK-LABEL: @add_not_add_m1_vec_poison(
+; CHECK-NEXT:    [[TMP1:%.*]] = sub <2 x i32> [[A:%.*]], [[B:%.*]]
+; CHECK-NEXT:    [[R:%.*]] = add <2 x i32> [[TMP1]], splat (i32 -2)
+; CHECK-NEXT:    ret <2 x i32> [[R]]
+;
+  %not = xor <2 x i32> %b, splat (i32 -1)
+  %add = add <2 x i32> %a, <i32 -1, i32 poison>
+  %r = add <2 x i32> %add, %not
+  ret <2 x i32> %r
+}
+
 ;------------------------------------------------------------------------------;
 ; One-use tests
 ;------------------------------------------------------------------------------;

--- a/llvm/test/Transforms/InstCombine/fold-inc-of-add-of-not-x-and-y-to-sub-x-from-y.ll
+++ b/llvm/test/Transforms/InstCombine/fold-inc-of-add-of-not-x-and-y-to-sub-x-from-y.ll
@@ -258,6 +258,70 @@ define i32 @t13_5(i32 %x, i32 %y) {
   ret i32 %t2
 }
 
+define i32 @t14(i32 %x, i32 %y) {
+; CHECK-LABEL: @t14(
+; CHECK-NEXT:    [[T1:%.*]] = xor i32 [[X:%.*]], -1
+; CHECK-NEXT:    call void @use32(i32 [[T1]])
+; CHECK-NEXT:    [[TMP1:%.*]] = sub i32 [[Y:%.*]], [[X]]
+; CHECK-NEXT:    ret i32 [[TMP1]]
+;
+  %t0 = add i32 %y, 1
+  %t1 = xor i32 %x, -1
+  call void @use32(i32 %t1)
+  %t2 = add i32 %t0, %t1
+  ret i32 %t2
+}
+
+define i32 @t14_5(i32 %x, i32 %y) {
+; CHECK-LABEL: @t14_5(
+; CHECK-NEXT:    [[T1:%.*]] = xor i32 [[X:%.*]], -1
+; CHECK-NEXT:    call void @use32(i32 [[T1]])
+; CHECK-NEXT:    [[TMP1:%.*]] = sub i32 [[Y:%.*]], [[X]]
+; CHECK-NEXT:    [[T2:%.*]] = add i32 [[TMP1]], 4
+; CHECK-NEXT:    ret i32 [[T2]]
+;
+  %t0 = add i32 %y, 5
+  %t1 = xor i32 %x, -1
+  call void @use32(i32 %t1)
+  %t2 = add i32 %t0, %t1
+  ret i32 %t2
+}
+
+define i32 @t15(i32 %x, i32 %y) {
+; CHECK-LABEL: @t15(
+; CHECK-NEXT:    [[T0:%.*]] = add i32 [[Y:%.*]], 1
+; CHECK-NEXT:    call void @use32(i32 [[T0]])
+; CHECK-NEXT:    [[T1:%.*]] = xor i32 [[X:%.*]], -1
+; CHECK-NEXT:    call void @use32(i32 [[T1]])
+; CHECK-NEXT:    [[TMP1:%.*]] = sub i32 [[Y]], [[X]]
+; CHECK-NEXT:    ret i32 [[TMP1]]
+;
+  %t0 = add i32 %y, 1
+  call void @use32(i32 %t0)
+  %t1 = xor i32 %x, -1
+  call void @use32(i32 %t1)
+  %t2 = add i32 %t0, %t1
+  ret i32 %t2
+}
+
+define i32 @t15_5(i32 %x, i32 %y) {
+; CHECK-LABEL: @t15_5(
+; CHECK-NEXT:    [[T0:%.*]] = add i32 [[Y:%.*]], 5
+; CHECK-NEXT:    call void @use32(i32 [[T0]])
+; CHECK-NEXT:    [[T1:%.*]] = xor i32 [[X:%.*]], -1
+; CHECK-NEXT:    call void @use32(i32 [[T1]])
+; CHECK-NEXT:    [[TMP1:%.*]] = sub i32 [[Y]], [[X]]
+; CHECK-NEXT:    [[T2:%.*]] = add i32 [[TMP1]], 4
+; CHECK-NEXT:    ret i32 [[T2]]
+;
+  %t0 = add i32 %y, 5
+  call void @use32(i32 %t0)
+  %t1 = xor i32 %x, -1
+  call void @use32(i32 %t1)
+  %t2 = add i32 %t0, %t1
+  ret i32 %t2
+}
+
 ;------------------------------------------------------------------------------;
 ; Commutativity
 ;------------------------------------------------------------------------------;

--- a/llvm/test/Transforms/InstCombine/fold-inc-of-add-of-not-x-and-y-to-sub-x-from-y.ll
+++ b/llvm/test/Transforms/InstCombine/fold-inc-of-add-of-not-x-and-y-to-sub-x-from-y.ll
@@ -247,8 +247,8 @@ define i32 @t13_5(i32 %x, i32 %y) {
 ; CHECK-LABEL: @t13_5(
 ; CHECK-NEXT:    [[T0:%.*]] = add i32 [[Y:%.*]], 5
 ; CHECK-NEXT:    call void @use32(i32 [[T0]])
-; CHECK-NEXT:    [[TMP1:%.*]] = sub i32 [[Y]], [[X:%.*]]
-; CHECK-NEXT:    [[T2:%.*]] = add i32 [[TMP1]], 4
+; CHECK-NEXT:    [[T1:%.*]] = xor i32 [[X:%.*]], -1
+; CHECK-NEXT:    [[T2:%.*]] = add i32 [[T0]], [[T1]]
 ; CHECK-NEXT:    ret i32 [[T2]]
 ;
   %t0 = add i32 %y, 5

--- a/llvm/test/Transforms/InstCombine/fold-inc-of-add-of-not-x-and-y-to-sub-x-from-y.ll
+++ b/llvm/test/Transforms/InstCombine/fold-inc-of-add-of-not-x-and-y-to-sub-x-from-y.ll
@@ -2,9 +2,9 @@
 ; RUN: opt -passes=instcombine -S < %s | FileCheck %s
 
 ; Given:
-;   add (add (xor %x, -1), %y), 1
+;   add (add (xor %x, -1), %y), C
 ; Transform it to:
-;   sub %y, %x
+;   add (sub %y, %x), C-1
 
 ;------------------------------------------------------------------------------;
 ; Scalar tests

--- a/llvm/test/Transforms/InstCombine/fold-inc-of-add-of-not-x-and-y-to-sub-x-from-y.ll
+++ b/llvm/test/Transforms/InstCombine/fold-inc-of-add-of-not-x-and-y-to-sub-x-from-y.ll
@@ -155,7 +155,7 @@ define i32 @t6(i32 %x, i32 %y) {
 ; CHECK-NEXT:    [[T0:%.*]] = xor i32 [[X:%.*]], -1
 ; CHECK-NEXT:    [[T1:%.*]] = add i32 [[Y:%.*]], [[T0]]
 ; CHECK-NEXT:    call void @use32(i32 [[T1]])
-; CHECK-NEXT:    [[T2:%.*]] = add i32 [[T1]], 1
+; CHECK-NEXT:    [[T2:%.*]] = sub i32 [[Y]], [[X]]
 ; CHECK-NEXT:    ret i32 [[T2]]
 ;
   %t0 = xor i32 %x, -1
@@ -171,7 +171,7 @@ define i32 @t7(i32 %x, i32 %y) {
 ; CHECK-NEXT:    call void @use32(i32 [[T0]])
 ; CHECK-NEXT:    [[T1:%.*]] = add i32 [[Y:%.*]], [[T0]]
 ; CHECK-NEXT:    call void @use32(i32 [[T1]])
-; CHECK-NEXT:    [[T2:%.*]] = add i32 [[T1]], 1
+; CHECK-NEXT:    [[T2:%.*]] = sub i32 [[Y]], [[X]]
 ; CHECK-NEXT:    ret i32 [[T2]]
 ;
   %t0 = xor i32 %x, -1
@@ -293,7 +293,7 @@ define i32 @t15(i32 %x, i32 %y) {
 ; CHECK-NEXT:    call void @use32(i32 [[T0]])
 ; CHECK-NEXT:    [[T1:%.*]] = xor i32 [[X:%.*]], -1
 ; CHECK-NEXT:    call void @use32(i32 [[T1]])
-; CHECK-NEXT:    [[TMP1:%.*]] = add i32 [[T0]], [[T1]]
+; CHECK-NEXT:    [[TMP1:%.*]] = sub i32 [[Y]], [[X]]
 ; CHECK-NEXT:    ret i32 [[TMP1]]
 ;
   %t0 = add i32 %y, 1
@@ -334,7 +334,7 @@ define i32 @t8_commutative0(i32 %x) {
 ; CHECK-NEXT:    call void @use32(i32 [[T0]])
 ; CHECK-NEXT:    [[T1:%.*]] = add i32 [[Y]], [[T0]]
 ; CHECK-NEXT:    call void @use32(i32 [[T1]])
-; CHECK-NEXT:    [[T2:%.*]] = add i32 [[T1]], 1
+; CHECK-NEXT:    [[T2:%.*]] = sub i32 [[Y]], [[X]]
 ; CHECK-NEXT:    ret i32 [[T2]]
 ;
   %y = call i32 @gen32()

--- a/llvm/test/Transforms/InstCombine/fold-inc-of-add-of-not-x-and-y-to-sub-x-from-y.ll
+++ b/llvm/test/Transforms/InstCombine/fold-inc-of-add-of-not-x-and-y-to-sub-x-from-y.ll
@@ -155,7 +155,7 @@ define i32 @t6(i32 %x, i32 %y) {
 ; CHECK-NEXT:    [[T0:%.*]] = xor i32 [[X:%.*]], -1
 ; CHECK-NEXT:    [[T1:%.*]] = add i32 [[Y:%.*]], [[T0]]
 ; CHECK-NEXT:    call void @use32(i32 [[T1]])
-; CHECK-NEXT:    [[T2:%.*]] = sub i32 [[Y]], [[X]]
+; CHECK-NEXT:    [[T2:%.*]] = add i32 [[T1]], 1
 ; CHECK-NEXT:    ret i32 [[T2]]
 ;
   %t0 = xor i32 %x, -1
@@ -171,7 +171,7 @@ define i32 @t7(i32 %x, i32 %y) {
 ; CHECK-NEXT:    call void @use32(i32 [[T0]])
 ; CHECK-NEXT:    [[T1:%.*]] = add i32 [[Y:%.*]], [[T0]]
 ; CHECK-NEXT:    call void @use32(i32 [[T1]])
-; CHECK-NEXT:    [[T2:%.*]] = sub i32 [[Y]], [[X]]
+; CHECK-NEXT:    [[T2:%.*]] = add i32 [[T1]], 1
 ; CHECK-NEXT:    ret i32 [[T2]]
 ;
   %t0 = xor i32 %x, -1
@@ -202,8 +202,7 @@ define i32 @t6_5(i32 %x, i32 %y) {
 ; CHECK-NEXT:    [[T0:%.*]] = xor i32 [[X:%.*]], -1
 ; CHECK-NEXT:    [[T1:%.*]] = add i32 [[Y:%.*]], [[T0]]
 ; CHECK-NEXT:    call void @use32(i32 [[T1]])
-; CHECK-NEXT:    [[TMP1:%.*]] = sub i32 [[Y]], [[X]]
-; CHECK-NEXT:    [[T2:%.*]] = add i32 [[TMP1]], 4
+; CHECK-NEXT:    [[T2:%.*]] = add i32 [[T1]], 5
 ; CHECK-NEXT:    ret i32 [[T2]]
 ;
   %t0 = xor i32 %x, -1
@@ -219,8 +218,7 @@ define i32 @t7_5(i32 %x, i32 %y) {
 ; CHECK-NEXT:    call void @use32(i32 [[T0]])
 ; CHECK-NEXT:    [[T1:%.*]] = add i32 [[Y:%.*]], [[T0]]
 ; CHECK-NEXT:    call void @use32(i32 [[T1]])
-; CHECK-NEXT:    [[TMP1:%.*]] = sub i32 [[Y]], [[X]]
-; CHECK-NEXT:    [[T2:%.*]] = add i32 [[TMP1]], 4
+; CHECK-NEXT:    [[T2:%.*]] = add i32 [[T1]], 5
 ; CHECK-NEXT:    ret i32 [[T2]]
 ;
   %t0 = xor i32 %x, -1
@@ -244,7 +242,7 @@ define i32 @t8_commutative0(i32 %x) {
 ; CHECK-NEXT:    call void @use32(i32 [[T0]])
 ; CHECK-NEXT:    [[T1:%.*]] = add i32 [[Y]], [[T0]]
 ; CHECK-NEXT:    call void @use32(i32 [[T1]])
-; CHECK-NEXT:    [[T2:%.*]] = sub i32 [[Y]], [[X]]
+; CHECK-NEXT:    [[T2:%.*]] = add i32 [[T1]], 1
 ; CHECK-NEXT:    ret i32 [[T2]]
 ;
   %y = call i32 @gen32()

--- a/llvm/test/Transforms/InstCombine/fold-inc-of-add-of-not-x-and-y-to-sub-x-from-y.ll
+++ b/llvm/test/Transforms/InstCombine/fold-inc-of-add-of-not-x-and-y-to-sub-x-from-y.ll
@@ -45,6 +45,7 @@ define i32 @add_not_add_m1(i32 %a, i32 %b) {
   ret i32 %r
 }
 
+; Unfortunately not matched, because add converted to xor earlier
 define i32 @add_not_add_intmin(i32 %a, i32 %b) {
 ; CHECK-LABEL: @add_not_add_intmin(
 ; CHECK-NEXT:    [[NOT:%.*]] = xor i32 [[B:%.*]], -1

--- a/llvm/test/Transforms/InstCombine/fold-inc-of-add-of-not-x-and-y-to-sub-x-from-y.ll
+++ b/llvm/test/Transforms/InstCombine/fold-inc-of-add-of-not-x-and-y-to-sub-x-from-y.ll
@@ -182,6 +182,55 @@ define i32 @t7(i32 %x, i32 %y) {
   ret i32 %t2
 }
 
+define i32 @t5_5(i32 %x, i32 %y) {
+; CHECK-LABEL: @t5_5(
+; CHECK-NEXT:    [[T0:%.*]] = xor i32 [[X:%.*]], -1
+; CHECK-NEXT:    call void @use32(i32 [[T0]])
+; CHECK-NEXT:    [[TMP1:%.*]] = sub i32 [[Y:%.*]], [[X]]
+; CHECK-NEXT:    [[T2:%.*]] = add i32 [[TMP1]], 4
+; CHECK-NEXT:    ret i32 [[T2]]
+;
+  %t0 = xor i32 %x, -1
+  call void @use32(i32 %t0)
+  %t1 = add i32 %t0, %y
+  %t2 = add i32 %t1, 5
+  ret i32 %t2
+}
+
+define i32 @t6_5(i32 %x, i32 %y) {
+; CHECK-LABEL: @t6_5(
+; CHECK-NEXT:    [[T0:%.*]] = xor i32 [[X:%.*]], -1
+; CHECK-NEXT:    [[T1:%.*]] = add i32 [[Y:%.*]], [[T0]]
+; CHECK-NEXT:    call void @use32(i32 [[T1]])
+; CHECK-NEXT:    [[TMP1:%.*]] = sub i32 [[Y]], [[X]]
+; CHECK-NEXT:    [[T2:%.*]] = add i32 [[TMP1]], 4
+; CHECK-NEXT:    ret i32 [[T2]]
+;
+  %t0 = xor i32 %x, -1
+  %t1 = add i32 %t0, %y
+  call void @use32(i32 %t1)
+  %t2 = add i32 %t1, 5
+  ret i32 %t2
+}
+
+define i32 @t7_5(i32 %x, i32 %y) {
+; CHECK-LABEL: @t7_5(
+; CHECK-NEXT:    [[T0:%.*]] = xor i32 [[X:%.*]], -1
+; CHECK-NEXT:    call void @use32(i32 [[T0]])
+; CHECK-NEXT:    [[T1:%.*]] = add i32 [[Y:%.*]], [[T0]]
+; CHECK-NEXT:    call void @use32(i32 [[T1]])
+; CHECK-NEXT:    [[TMP1:%.*]] = sub i32 [[Y]], [[X]]
+; CHECK-NEXT:    [[T2:%.*]] = add i32 [[TMP1]], 4
+; CHECK-NEXT:    ret i32 [[T2]]
+;
+  %t0 = xor i32 %x, -1
+  call void @use32(i32 %t0)
+  %t1 = add i32 %t0, %y
+  call void @use32(i32 %t1)
+  %t2 = add i32 %t1, 5
+  ret i32 %t2
+}
+
 ;------------------------------------------------------------------------------;
 ; Commutativity
 ;------------------------------------------------------------------------------;

--- a/llvm/test/Transforms/InstCombine/fold-inc-of-add-of-not-x-and-y-to-sub-x-from-y.ll
+++ b/llvm/test/Transforms/InstCombine/fold-inc-of-add-of-not-x-and-y-to-sub-x-from-y.ll
@@ -229,6 +229,35 @@ define i32 @t7_5(i32 %x, i32 %y) {
   ret i32 %t2
 }
 
+define i32 @t13(i32 %x, i32 %y) {
+; CHECK-LABEL: @t13(
+; CHECK-NEXT:    [[T0:%.*]] = add i32 [[Y:%.*]], 1
+; CHECK-NEXT:    call void @use32(i32 [[T0]])
+; CHECK-NEXT:    [[TMP1:%.*]] = sub i32 [[Y]], [[X:%.*]]
+; CHECK-NEXT:    ret i32 [[TMP1]]
+;
+  %t0 = add i32 %y, 1
+  call void @use32(i32 %t0)
+  %t1 = xor i32 %x, -1
+  %t2 = add i32 %t0, %t1
+  ret i32 %t2
+}
+
+define i32 @t13_5(i32 %x, i32 %y) {
+; CHECK-LABEL: @t13_5(
+; CHECK-NEXT:    [[T0:%.*]] = add i32 [[Y:%.*]], 5
+; CHECK-NEXT:    call void @use32(i32 [[T0]])
+; CHECK-NEXT:    [[TMP1:%.*]] = sub i32 [[Y]], [[X:%.*]]
+; CHECK-NEXT:    [[T2:%.*]] = add i32 [[TMP1]], 4
+; CHECK-NEXT:    ret i32 [[T2]]
+;
+  %t0 = add i32 %y, 5
+  call void @use32(i32 %t0)
+  %t1 = xor i32 %x, -1
+  %t2 = add i32 %t0, %t1
+  ret i32 %t2
+}
+
 ;------------------------------------------------------------------------------;
 ; Commutativity
 ;------------------------------------------------------------------------------;

--- a/llvm/test/Transforms/InstCombine/fold-inc-of-add-of-not-x-and-y-to-sub-x-from-y.ll
+++ b/llvm/test/Transforms/InstCombine/fold-inc-of-add-of-not-x-and-y-to-sub-x-from-y.ll
@@ -293,7 +293,7 @@ define i32 @t15(i32 %x, i32 %y) {
 ; CHECK-NEXT:    call void @use32(i32 [[T0]])
 ; CHECK-NEXT:    [[T1:%.*]] = xor i32 [[X:%.*]], -1
 ; CHECK-NEXT:    call void @use32(i32 [[T1]])
-; CHECK-NEXT:    [[TMP1:%.*]] = sub i32 [[Y]], [[X]]
+; CHECK-NEXT:    [[TMP1:%.*]] = add i32 [[T0]], [[T1]]
 ; CHECK-NEXT:    ret i32 [[TMP1]]
 ;
   %t0 = add i32 %y, 1
@@ -310,8 +310,7 @@ define i32 @t15_5(i32 %x, i32 %y) {
 ; CHECK-NEXT:    call void @use32(i32 [[T0]])
 ; CHECK-NEXT:    [[T1:%.*]] = xor i32 [[X:%.*]], -1
 ; CHECK-NEXT:    call void @use32(i32 [[T1]])
-; CHECK-NEXT:    [[TMP1:%.*]] = sub i32 [[Y]], [[X]]
-; CHECK-NEXT:    [[T2:%.*]] = add i32 [[TMP1]], 4
+; CHECK-NEXT:    [[T2:%.*]] = add i32 [[T0]], [[T1]]
 ; CHECK-NEXT:    ret i32 [[T2]]
 ;
   %t0 = add i32 %y, 5


### PR DESCRIPTION
Example:

    int foo(int a, int b) { return a - 1 + ~b; }

Before, on AArch64:

    mvn w8, w1
    add w8, w0, w8
    sub w0, w8, #1

After (matches gcc):

    sub w0, w0, w1
    sub w0, w0, #2

Proof: https://alive2.llvm.org/ce/z/g_bV01