### PR TITLE
[GlobalISel][Test] Fix `IRTranslatorBF16Test` crash

### DIFF
--- a/llvm/unittests/CodeGen/GlobalISel/IRTranslatorBF16Test.cpp
+++ b/llvm/unittests/CodeGen/GlobalISel/IRTranslatorBF16Test.cpp
@@ -87,6 +87,8 @@ TEST_F(AArch64IRTranslatorTest, IRTranslateBfloat16) {
   )");
 
   auto TM = createTargetMachine();
+  if (!TM)
+    GTEST_SKIP();
   M->setDataLayout(TM->createDataLayout());
 
   TM->setGlobalISel(true);


### PR DESCRIPTION
Skip the test when the AArch64 target is unavailable.