### PR TITLE
[lldb] Clear up GetModuleSpecifications return value confusion

### DIFF
--- a/lldb/include/lldb/Expression/ObjectFileJIT.h
+++ b/lldb/include/lldb/Expression/ObjectFileJIT.h
@@ -58,12 +58,11 @@ public:
       const lldb::ModuleSP &module_sp, lldb::WritableDataBufferSP data_sp,
       const lldb::ProcessSP &process_sp, lldb::addr_t header_addr);
 
-  static size_t GetModuleSpecifications(const lldb_private::FileSpec &file,
-                                        lldb::DataExtractorSP &extractor_sp,
-                                        lldb::offset_t data_offset,
-                                        lldb::offset_t file_offset,
-                                        lldb::offset_t length,
-                                        lldb_private::ModuleSpecList &specs);
+  static ModuleSpecList
+  GetModuleSpecifications(const lldb_private::FileSpec &file,
+                          lldb::DataExtractorSP &extractor_sp,
+                          lldb::offset_t data_offset,
+                          lldb::offset_t file_offset, lldb::offset_t length);
 
   // LLVM RTTI support
   static char ID;

--- a/lldb/include/lldb/lldb-private-interfaces.h
+++ b/lldb/include/lldb/lldb-private-interfaces.h
@@ -46,10 +46,10 @@ typedef ObjectContainer *(*ObjectContainerCreateInstance)(
 typedef ObjectContainer *(*ObjectContainerCreateMemoryInstance)(
     const lldb::ModuleSP &module_sp, lldb::WritableDataBufferSP data_sp,
     const lldb::ProcessSP &process_sp, lldb::addr_t offset);
-typedef size_t (*ObjectFileGetModuleSpecifications)(
+typedef ModuleSpecList (*ObjectFileGetModuleSpecifications)(
     const FileSpec &file, lldb::DataExtractorSP &extractor_sp,
     lldb::offset_t data_offset, lldb::offset_t file_offset,
-    lldb::offset_t length, ModuleSpecList &module_specs);
+    lldb::offset_t length);
 typedef ObjectFile *(*ObjectFileCreateInstance)(
     const lldb::ModuleSP &module_sp, lldb::DataExtractorSP extractor_sp,
     lldb::offset_t data_offset, const FileSpec *file,

--- a/lldb/source/Expression/ObjectFileJIT.cpp
+++ b/lldb/source/Expression/ObjectFileJIT.cpp
@@ -60,12 +60,12 @@ ObjectFile *ObjectFileJIT::CreateMemoryInstance(const lldb::ModuleSP &module_sp,
   return nullptr;
 }
 
-size_t ObjectFileJIT::GetModuleSpecifications(
+ModuleSpecList ObjectFileJIT::GetModuleSpecifications(
     const lldb_private::FileSpec &file, lldb::DataExtractorSP &extractor_sp,
     lldb::offset_t data_offset, lldb::offset_t file_offset,
-    lldb::offset_t length, lldb_private::ModuleSpecList &specs) {
+    lldb::offset_t length) {
   // JIT'ed object file can't be read from a file on disk
-  return 0;
+  return {};
 }
 
 ObjectFileJIT::ObjectFileJIT(const lldb::ModuleSP &module_sp,

--- a/lldb/source/Plugins/ObjectContainer/BSD-Archive/ObjectContainerBSDArchive.cpp
+++ b/lldb/source/Plugins/ObjectContainer/BSD-Archive/ObjectContainerBSDArchive.cpp
@@ -434,13 +434,13 @@ ObjectFileSP ObjectContainerBSDArchive::GetObjectFile(const FileSpec *file) {
   return ObjectFileSP();
 }
 
-size_t ObjectContainerBSDArchive::GetModuleSpecifications(
+ModuleSpecList ObjectContainerBSDArchive::GetModuleSpecifications(
     const FileSpec &file, lldb::DataExtractorSP &extractor_sp,
     lldb::offset_t data_offset, lldb::offset_t file_offset,
-    lldb::offset_t file_size, ModuleSpecList &specs) {
+    lldb::offset_t file_size) {
 
   if (!file || !extractor_sp)
-    return 0;
+    return {};
 
   DataExtractorSP data_extractor_sp =
       extractor_sp->GetSubsetExtractorSP(data_offset);
@@ -449,9 +449,8 @@ size_t ObjectContainerBSDArchive::GetModuleSpecifications(
   // contents for the archive and cache it
   ArchiveType archive_type = MagicBytesMatch(*data_extractor_sp);
   if (archive_type == ArchiveType::Invalid)
-    return 0;
+    return {};
 
-  const size_t initial_count = specs.GetSize();
   llvm::sys::TimePoint<> file_mod_time =
       FileSystem::Instance().GetModificationTime(file);
   ArchiveSP archive_sp(
@@ -469,6 +468,7 @@ size_t ObjectContainerBSDArchive::GetModuleSpecifications(
     }
   }
 
+  ModuleSpecList specs;
   if (archive_sp) {
     const size_t num_objects = archive_sp->GetNumObjects();
     for (size_t idx = 0; idx < num_objects; ++idx) {
@@ -512,11 +512,10 @@ size_t ObjectContainerBSDArchive::GetModuleSpecifications(
     }
   }
   const size_t end_count = specs.GetSize();
-  size_t num_specs_added = end_count - initial_count;
-  if (set_archive_arch && num_specs_added > 0) {
+  if (set_archive_arch && specs.GetSize() > 0) {
     // The archive was created but we didn't have an architecture so we need to
     // set it
-    for (size_t i = initial_count; i < end_count; ++i) {
+    for (size_t i = 0; i < end_count; ++i) {
       ModuleSpec module_spec;
       if (specs.GetModuleSpecAtIndex(i, module_spec)) {
         if (module_spec.GetArchitecture().IsValid()) {
@@ -526,5 +525,5 @@ size_t ObjectContainerBSDArchive::GetModuleSpecifications(
       }
     }
   }
-  return num_specs_added;
+  return specs;
 }

--- a/lldb/source/Plugins/ObjectContainer/BSD-Archive/ObjectContainerBSDArchive.h
+++ b/lldb/source/Plugins/ObjectContainer/BSD-Archive/ObjectContainerBSDArchive.h
@@ -9,6 +9,7 @@
 #ifndef LLDB_SOURCE_PLUGINS_OBJECTCONTAINER_BSD_ARCHIVE_OBJECTCONTAINERBSDARCHIVE_H
 #define LLDB_SOURCE_PLUGINS_OBJECTCONTAINER_BSD_ARCHIVE_OBJECTCONTAINERBSDARCHIVE_H
 
+#include "lldb/Core/ModuleSpec.h"
 #include "lldb/Core/UniqueCStringMap.h"
 #include "lldb/Symbol/ObjectContainer.h"
 #include "lldb/Utility/ArchSpec.h"
@@ -54,12 +55,11 @@ public:
                  lldb::offset_t data_offset, const lldb_private::FileSpec *file,
                  lldb::offset_t offset, lldb::offset_t length);
 
-  static size_t GetModuleSpecifications(const lldb_private::FileSpec &file,
-                                        lldb::DataExtractorSP &extractor_sp,
-                                        lldb::offset_t data_offset,
-                                        lldb::offset_t file_offset,
-                                        lldb::offset_t length,
-                                        lldb_private::ModuleSpecList &specs);
+  static lldb_private::ModuleSpecList
+  GetModuleSpecifications(const lldb_private::FileSpec &file,
+                          lldb::DataExtractorSP &extractor_sp,
+                          lldb::offset_t data_offset,
+                          lldb::offset_t file_offset, lldb::offset_t length);
 
   static ArchiveType
   MagicBytesMatch(const lldb_private::DataExtractor &extractor);

--- a/lldb/source/Plugins/ObjectContainer/Big-Archive/ObjectContainerBigArchive.cpp
+++ b/lldb/source/Plugins/ObjectContainer/Big-Archive/ObjectContainerBigArchive.cpp
@@ -43,11 +43,11 @@ ObjectContainer *ObjectContainerBigArchive::CreateInstance(
   return nullptr;
 }
 
-size_t ObjectContainerBigArchive::GetModuleSpecifications(
+ModuleSpecList ObjectContainerBigArchive::GetModuleSpecifications(
     const lldb_private::FileSpec &file, lldb::DataExtractorSP &extractor_sp,
     lldb::offset_t data_offset, lldb::offset_t file_offset,
-    lldb::offset_t file_size, lldb_private::ModuleSpecList &specs) {
-  return 0;
+    lldb::offset_t file_size) {
+  return {};
 }
 
 ObjectContainerBigArchive::ObjectContainerBigArchive(

--- a/lldb/source/Plugins/ObjectContainer/Big-Archive/ObjectContainerBigArchive.h
+++ b/lldb/source/Plugins/ObjectContainer/Big-Archive/ObjectContainerBigArchive.h
@@ -44,12 +44,11 @@ public:
                  lldb::offset_t data_offset, const lldb_private::FileSpec *file,
                  lldb::offset_t offset, lldb::offset_t length);
 
-  static size_t GetModuleSpecifications(const lldb_private::FileSpec &file,
-                                        lldb::DataExtractorSP &extractor_sp,
-                                        lldb::offset_t data_offset,
-                                        lldb::offset_t file_offset,
-                                        lldb::offset_t length,
-                                        lldb_private::ModuleSpecList &specs);
+  static lldb_private::ModuleSpecList
+  GetModuleSpecifications(const lldb_private::FileSpec &file,
+                          lldb::DataExtractorSP &extractor_sp,
+                          lldb::offset_t data_offset,
+                          lldb::offset_t file_offset, lldb::offset_t length);
 
   // Member Functions
   bool ParseHeader() override;

--- a/lldb/source/Plugins/ObjectContainer/Mach-O-Fileset/ObjectContainerMachOFileset.cpp
+++ b/lldb/source/Plugins/ObjectContainer/Mach-O-Fileset/ObjectContainerMachOFileset.cpp
@@ -219,18 +219,18 @@ bool ObjectContainerMachOFileset::ParseHeader() {
   return ParseFileset(*m_extractor_sp, *header, m_entries, m_memory_addr);
 }
 
-size_t ObjectContainerMachOFileset::GetModuleSpecifications(
+ModuleSpecList ObjectContainerMachOFileset::GetModuleSpecifications(
     const lldb_private::FileSpec &file, lldb::DataExtractorSP &extractor_sp,
     lldb::offset_t data_offset, lldb::offset_t file_offset,
-    lldb::offset_t file_size, lldb_private::ModuleSpecList &specs) {
-  const size_t initial_count = specs.GetSize();
+    lldb::offset_t file_size) {
   if (!extractor_sp)
-    return initial_count;
+    return {};
 
   DataExtractorSP data_extractor_sp =
       extractor_sp->GetSubsetExtractorSP(data_offset);
   if (!data_extractor_sp)
-    return initial_count;
+    return {};
+  ModuleSpecList specs;
   if (MagicBytesMatch(*data_extractor_sp)) {
     std::vector<Entry> entries;
     if (ParseHeader(*data_extractor_sp, file, file_offset, entries)) {
@@ -244,7 +244,7 @@ size_t ObjectContainerMachOFileset::GetModuleSpecifications(
       }
     }
   }
-  return specs.GetSize() - initial_count;
+  return specs;
 }
 
 bool ObjectContainerMachOFileset::MagicBytesMatch(DataBufferSP data_sp,

--- a/lldb/source/Plugins/ObjectContainer/Mach-O-Fileset/ObjectContainerMachOFileset.h
+++ b/lldb/source/Plugins/ObjectContainer/Mach-O-Fileset/ObjectContainerMachOFileset.h
@@ -48,12 +48,11 @@ public:
       const lldb::ModuleSP &module_sp, lldb::WritableDataBufferSP data_sp,
       const lldb::ProcessSP &process_sp, lldb::addr_t header_addr);
 
-  static size_t GetModuleSpecifications(const lldb_private::FileSpec &file,
-                                        lldb::DataExtractorSP &extractor_sp,
-                                        lldb::offset_t data_offset,
-                                        lldb::offset_t file_offset,
-                                        lldb::offset_t length,
-                                        lldb_private::ModuleSpecList &specs);
+  static ModuleSpecList
+  GetModuleSpecifications(const lldb_private::FileSpec &file,
+                          lldb::DataExtractorSP &extractor_sp,
+                          lldb::offset_t data_offset,
+                          lldb::offset_t file_offset, lldb::offset_t length);
 
   static bool MagicBytesMatch(const lldb_private::DataExtractor &data);
   static bool MagicBytesMatch(lldb::DataBufferSP data_sp,

--- a/lldb/source/Plugins/ObjectContainer/Universal-Mach-O/ObjectContainerUniversalMachO.cpp
+++ b/lldb/source/Plugins/ObjectContainer/Universal-Mach-O/ObjectContainerUniversalMachO.cpp
@@ -188,14 +188,14 @@ ObjectContainerUniversalMachO::GetObjectFile(const FileSpec *file) {
   return ObjectFileSP();
 }
 
-size_t ObjectContainerUniversalMachO::GetModuleSpecifications(
+ModuleSpecList ObjectContainerUniversalMachO::GetModuleSpecifications(
     const lldb_private::FileSpec &file, lldb::DataExtractorSP &extractor_sp,
     lldb::offset_t data_offset, lldb::offset_t file_offset,
-    lldb::offset_t file_size, lldb_private::ModuleSpecList &specs) {
-  const size_t initial_count = specs.GetSize();
+    lldb::offset_t file_size) {
   if (!extractor_sp)
-    return initial_count;
+    return {};
 
+  ModuleSpecList specs;
   DataExtractorSP data_extractor_sp =
       extractor_sp->GetSubsetExtractorSP(data_offset);
   if (ObjectContainerUniversalMachO::MagicBytesMatch(*data_extractor_sp)) {
@@ -212,5 +212,5 @@ size_t ObjectContainerUniversalMachO::GetModuleSpecifications(
       }
     }
   }
-  return specs.GetSize() - initial_count;
+  return specs;
 }

--- a/lldb/source/Plugins/ObjectContainer/Universal-Mach-O/ObjectContainerUniversalMachO.h
+++ b/lldb/source/Plugins/ObjectContainer/Universal-Mach-O/ObjectContainerUniversalMachO.h
@@ -39,12 +39,11 @@ public:
                  lldb::offset_t data_offset, const lldb_private::FileSpec *file,
                  lldb::offset_t offset, lldb::offset_t length);
 
-  static size_t GetModuleSpecifications(const lldb_private::FileSpec &file,
-                                        lldb::DataExtractorSP &extractor_sp,
-                                        lldb::offset_t data_offset,
-                                        lldb::offset_t file_offset,
-                                        lldb::offset_t length,
-                                        lldb_private::ModuleSpecList &specs);
+  static lldb_private::ModuleSpecList
+  GetModuleSpecifications(const lldb_private::FileSpec &file,
+                          lldb::DataExtractorSP &extractor_sp,
+                          lldb::offset_t data_offset,
+                          lldb::offset_t file_offset, lldb::offset_t length);
 
   static bool MagicBytesMatch(const lldb_private::DataExtractor &data);
 

--- a/lldb/source/Plugins/ObjectFile/Breakpad/ObjectFileBreakpad.cpp
+++ b/lldb/source/Plugins/ObjectFile/Breakpad/ObjectFileBreakpad.cpp
@@ -101,11 +101,11 @@ ObjectFile *ObjectFileBreakpad::CreateMemoryInstance(
   return nullptr;
 }
 
-size_t ObjectFileBreakpad::GetModuleSpecifications(
+ModuleSpecList ObjectFileBreakpad::GetModuleSpecifications(
     const FileSpec &file, DataExtractorSP &extractor_sp, offset_t data_offset,
-    offset_t file_offset, offset_t length, ModuleSpecList &specs) {
+    offset_t file_offset, offset_t length) {
   if (!extractor_sp || !extractor_sp->HasData())
-    return 0;
+    return {};
   // If this is opearting on a VirtualDataExtractor, it can have
   // gaps between valid bytes in the DataBuffer. We extract an
   // ArrayRef of the raw bytes, and can segfault.
@@ -114,11 +114,12 @@ size_t ObjectFileBreakpad::GetModuleSpecifications(
   auto text = toStringRef(contiguous_extractor_sp->GetData());
   std::optional<Header> header = Header::parse(text);
   if (!header)
-    return 0;
+    return {};
   ModuleSpec spec(file, std::move(header->arch));
   spec.GetUUID() = std::move(header->uuid);
+  ModuleSpecList specs;
   specs.Append(spec);
-  return 1;
+  return specs;
 }
 
 ObjectFileBreakpad::ObjectFileBreakpad(const ModuleSP &module_sp,

--- a/lldb/source/Plugins/ObjectFile/Breakpad/ObjectFileBreakpad.h
+++ b/lldb/source/Plugins/ObjectFile/Breakpad/ObjectFileBreakpad.h
@@ -38,12 +38,11 @@ public:
                                           const lldb::ProcessSP &process_sp,
                                           lldb::addr_t header_addr);
 
-  static size_t GetModuleSpecifications(const FileSpec &file,
-                                        lldb::DataExtractorSP &extractor_sp,
-                                        lldb::offset_t data_offset,
-                                        lldb::offset_t file_offset,
-                                        lldb::offset_t length,
-                                        ModuleSpecList &specs);
+  static ModuleSpecList
+  GetModuleSpecifications(const FileSpec &file,
+                          lldb::DataExtractorSP &extractor_sp,
+                          lldb::offset_t data_offset,
+                          lldb::offset_t file_offset, lldb::offset_t length);
 
   // PluginInterface protocol
   llvm::StringRef GetPluginName() override { return GetPluginNameStatic(); }

--- a/lldb/source/Plugins/ObjectFile/COFF/ObjectFileCOFF.cpp
+++ b/lldb/source/Plugins/ObjectFile/COFF/ObjectFileCOFF.cpp
@@ -113,11 +113,11 @@ lldb_private::ObjectFile *ObjectFileCOFF::CreateMemoryInstance(
   return nullptr;
 }
 
-size_t ObjectFileCOFF::GetModuleSpecifications(
+ModuleSpecList ObjectFileCOFF::GetModuleSpecifications(
     const FileSpec &file, DataExtractorSP &extractor_sp, offset_t data_offset,
-    offset_t file_offset, offset_t length, ModuleSpecList &specs) {
+    offset_t file_offset, offset_t length) {
   if (!extractor_sp || !extractor_sp->HasData())
-    return 0;
+    return {};
 
   // If this is opearting on a VirtualDataExtractor, it can have
   // gaps between valid bytes in the DataBuffer. We extract an
@@ -125,9 +125,9 @@ size_t ObjectFileCOFF::GetModuleSpecifications(
   DataExtractorSP contiguous_extractor_sp =
       extractor_sp->GetContiguousDataExtractorSP();
   if (!contiguous_extractor_sp)
-    return 0;
+    return {};
   if (!IsCOFFObjectFile(contiguous_extractor_sp->GetData()))
-    return 0;
+    return {};
 
   MemoryBufferRef buffer{toStringRef(contiguous_extractor_sp->GetData()),
                          file.GetFilename().GetStringRef()};
@@ -137,27 +137,28 @@ size_t ObjectFileCOFF::GetModuleSpecifications(
     LLDB_LOG_ERROR(log, binary.takeError(),
                    "Failed to create binary for file ({1}): {0}",
                    file.GetFilename());
-    return 0;
+    return {};
   }
 
   std::unique_ptr<COFFObjectFile> object =
       unique_dyn_cast<COFFObjectFile>(std::move(*binary));
+  ModuleSpecList specs;
   switch (static_cast<COFF::MachineTypes>(object->getMachine())) {
-  case COFF::IMAGE_FILE_MACHINE_I386:
     specs.Append(ModuleSpec(file, ArchSpec("i686-unknown-windows-msvc")));
-    return 1;
+    return specs;
   case COFF::IMAGE_FILE_MACHINE_AMD64:
     specs.Append(ModuleSpec(file, ArchSpec("x86_64-unknown-windows-msvc")));
-    return 1;
+    return specs;
   case COFF::IMAGE_FILE_MACHINE_ARMNT:
     specs.Append(ModuleSpec(file, ArchSpec("armv7-unknown-windows-msvc")));
-    return 1;
+    return specs;
   case COFF::IMAGE_FILE_MACHINE_ARM64:
     specs.Append(ModuleSpec(file, ArchSpec("aarch64-unknown-windows-msvc")));
-    return 1;
+    return specs;
   default:
-    return 0;
+    break;
   }
+  return {};
 }
 
 void ObjectFileCOFF::Dump(Stream *stream) {

--- a/lldb/source/Plugins/ObjectFile/COFF/ObjectFileCOFF.h
+++ b/lldb/source/Plugins/ObjectFile/COFF/ObjectFileCOFF.h
@@ -54,12 +54,11 @@ public:
                        lldb::WritableDataBufferSP data_sp,
                        const lldb::ProcessSP &process_sp, lldb::addr_t header);
 
-  static size_t GetModuleSpecifications(const lldb_private::FileSpec &file,
-                                        lldb::DataExtractorSP &extractor_sp,
-                                        lldb::offset_t data_offset,
-                                        lldb::offset_t file_offset,
-                                        lldb::offset_t length,
-                                        lldb_private::ModuleSpecList &specs);
+  static lldb_private::ModuleSpecList
+  GetModuleSpecifications(const lldb_private::FileSpec &file,
+                          lldb::DataExtractorSP &extractor_sp,
+                          lldb::offset_t data_offset,
+                          lldb::offset_t file_offset, lldb::offset_t length);
 
   // LLVM RTTI support
   static char ID;

--- a/lldb/source/Plugins/ObjectFile/ELF/ObjectFileELF.cpp
+++ b/lldb/source/Plugins/ObjectFile/ELF/ObjectFileELF.cpp
@@ -591,16 +591,14 @@ static bool GetOsFromOSABI(unsigned char osabi_byte,
   return ostype != llvm::Triple::OSType::UnknownOS;
 }
 
-size_t ObjectFileELF::GetModuleSpecifications(
+ModuleSpecList ObjectFileELF::GetModuleSpecifications(
     const lldb_private::FileSpec &file, lldb::DataExtractorSP &extractor_sp,
     lldb::offset_t data_offset, lldb::offset_t file_offset,
-    lldb::offset_t length, lldb_private::ModuleSpecList &specs) {
+    lldb::offset_t length) {
   Log *log = GetLog(LLDBLog::Modules);
 
-  const size_t initial_count = specs.GetSize();
-
   if (!extractor_sp || !extractor_sp->HasData())
-    return 0;
+    return {};
   if (ObjectFileELF::MagicBytesMatch(extractor_sp->GetSharedDataBuffer(), 0,
                                      extractor_sp->GetByteSize())) {
     DataExtractor data;
@@ -723,12 +721,14 @@ size_t ObjectFileELF::GetModuleSpecifications(
           }
         }
 
+        ModuleSpecList specs;
         specs.Append(spec);
+        return specs;
       }
     }
   }
 
-  return specs.GetSize() - initial_count;
+  return {};
 }
 
 // ObjectFile protocol

--- a/lldb/source/Plugins/ObjectFile/ELF/ObjectFileELF.h
+++ b/lldb/source/Plugins/ObjectFile/ELF/ObjectFileELF.h
@@ -78,12 +78,11 @@ public:
       const lldb::ModuleSP &module_sp, lldb::WritableDataBufferSP data_sp,
       const lldb::ProcessSP &process_sp, lldb::addr_t header_addr);
 
-  static size_t GetModuleSpecifications(const lldb_private::FileSpec &file,
-                                        lldb::DataExtractorSP &extractor_sp,
-                                        lldb::offset_t data_offset,
-                                        lldb::offset_t file_offset,
-                                        lldb::offset_t length,
-                                        lldb_private::ModuleSpecList &specs);
+  static lldb_private::ModuleSpecList
+  GetModuleSpecifications(const lldb_private::FileSpec &file,
+                          lldb::DataExtractorSP &extractor_sp,
+                          lldb::offset_t data_offset,
+                          lldb::offset_t file_offset, lldb::offset_t length);
 
   static bool MagicBytesMatch(lldb::DataBufferSP data_sp, lldb::addr_t offset,
                               lldb::addr_t length);

--- a/lldb/source/Plugins/ObjectFile/JSON/ObjectFileJSON.cpp
+++ b/lldb/source/Plugins/ObjectFile/JSON/ObjectFileJSON.cpp
@@ -108,19 +108,19 @@ ObjectFile *ObjectFileJSON::CreateMemoryInstance(const ModuleSP &module_sp,
   return nullptr;
 }
 
-size_t ObjectFileJSON::GetModuleSpecifications(
+ModuleSpecList ObjectFileJSON::GetModuleSpecifications(
     const FileSpec &file, DataExtractorSP &extractor_sp, offset_t data_offset,
-    offset_t file_offset, offset_t length, ModuleSpecList &specs) {
+    offset_t file_offset, offset_t length) {
   if (!extractor_sp ||
       !MagicBytesMatch(extractor_sp->GetSubsetExtractorSP(data_offset)))
-    return 0;
+    return {};
 
   // Update the data to contain the entire file if it doesn't already.
   if (extractor_sp->GetByteSize() < length) {
     if (DataBufferSP file_data_sp = MapFileData(file, length, file_offset))
       extractor_sp->SetData(file_data_sp);
     if (!extractor_sp->HasData())
-      return 0;
+      return {};
     data_offset = 0;
   }
 
@@ -132,7 +132,7 @@ size_t ObjectFileJSON::GetModuleSpecifications(
   if (!json) {
     LLDB_LOG_ERROR(log, json.takeError(),
                    "failed to parse JSON object file: {0}");
-    return 0;
+    return {};
   }
 
   json::Path::Root root;
@@ -140,7 +140,7 @@ size_t ObjectFileJSON::GetModuleSpecifications(
   if (!fromJSON(*json, header, root)) {
     LLDB_LOG_ERROR(log, root.getError(),
                    "failed to parse JSON object file header: {0}");
-    return 0;
+    return {};
   }
 
   ArchSpec arch(header.triple);
@@ -149,8 +149,9 @@ size_t ObjectFileJSON::GetModuleSpecifications(
 
   ModuleSpec spec(file, std::move(arch));
   spec.GetUUID() = std::move(uuid);
+  ModuleSpecList specs;
   specs.Append(spec);
-  return 1;
+  return specs;
 }
 
 ObjectFileJSON::ObjectFileJSON(const ModuleSP &module_sp,

--- a/lldb/source/Plugins/ObjectFile/JSON/ObjectFileJSON.h
+++ b/lldb/source/Plugins/ObjectFile/JSON/ObjectFileJSON.h
@@ -38,12 +38,11 @@ public:
                                           const lldb::ProcessSP &process_sp,
                                           lldb::addr_t header_addr);
 
-  static size_t GetModuleSpecifications(const FileSpec &file,
-                                        lldb::DataExtractorSP &extractor_sp,
-                                        lldb::offset_t data_offset,
-                                        lldb::offset_t file_offset,
-                                        lldb::offset_t length,
-                                        ModuleSpecList &specs);
+  static ModuleSpecList
+  GetModuleSpecifications(const FileSpec &file,
+                          lldb::DataExtractorSP &extractor_sp,
+                          lldb::offset_t data_offset,
+                          lldb::offset_t file_offset, lldb::offset_t length);
 
   llvm::StringRef GetPluginName() override { return GetPluginNameStatic(); }
 

--- a/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.cpp
+++ b/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.cpp
@@ -827,14 +827,14 @@ ObjectFile *ObjectFileMachO::CreateMemoryInstance(
   return nullptr;
 }
 
-size_t ObjectFileMachO::GetModuleSpecifications(
+ModuleSpecList ObjectFileMachO::GetModuleSpecifications(
     const lldb_private::FileSpec &file, lldb::DataExtractorSP &extractor_sp,
     lldb::offset_t data_offset, lldb::offset_t file_offset,
-    lldb::offset_t length, lldb_private::ModuleSpecList &specs) {
-  const size_t initial_count = specs.GetSize();
+    lldb::offset_t length) {
   if (!extractor_sp || !extractor_sp->HasData())
-    return initial_count;
+    return {};
 
+  ModuleSpecList specs;
   if (ObjectFileMachO::MagicBytesMatch(extractor_sp, 0,
                                        extractor_sp->GetByteSize())) {
     llvm::MachO::mach_header header;
@@ -857,7 +857,7 @@ size_t ObjectFileMachO::GetModuleSpecifications(
       }
     }
   }
-  return specs.GetSize() - initial_count;
+  return specs;
 }
 
 ConstString ObjectFileMachO::GetSegmentNameTEXT() {

--- a/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.h
+++ b/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.h
@@ -57,12 +57,11 @@ public:
       const lldb::ModuleSP &module_sp, lldb::WritableDataBufferSP data_sp,
       const lldb::ProcessSP &process_sp, lldb::addr_t header_addr);
 
-  static size_t GetModuleSpecifications(const lldb_private::FileSpec &file,
-                                        lldb::DataExtractorSP &extractor_sp,
-                                        lldb::offset_t data_offset,
-                                        lldb::offset_t file_offset,
-                                        lldb::offset_t length,
-                                        lldb_private::ModuleSpecList &specs);
+  static lldb_private::ModuleSpecList
+  GetModuleSpecifications(const lldb_private::FileSpec &file,
+                          lldb::DataExtractorSP &extractor_sp,
+                          lldb::offset_t data_offset,
+                          lldb::offset_t file_offset, lldb::offset_t length);
 
   static bool SaveCore(const lldb::ProcessSP &process_sp,
                        lldb_private::SaveCoreOptions &options,

--- a/lldb/source/Plugins/ObjectFile/Minidump/ObjectFileMinidump.cpp
+++ b/lldb/source/Plugins/ObjectFile/Minidump/ObjectFileMinidump.cpp
@@ -47,12 +47,11 @@ ObjectFile *ObjectFileMinidump::CreateMemoryInstance(
   return nullptr;
 }
 
-size_t ObjectFileMinidump::GetModuleSpecifications(
+ModuleSpecList ObjectFileMinidump::GetModuleSpecifications(
     const lldb_private::FileSpec &file, lldb::DataExtractorSP &extractor_sp,
     lldb::offset_t data_offset, lldb::offset_t file_offset,
-    lldb::offset_t length, lldb_private::ModuleSpecList &specs) {
-  specs.Clear();
-  return 0;
+    lldb::offset_t length) {
+  return {};
 }
 
 struct DumpFailRemoveHolder {

--- a/lldb/source/Plugins/ObjectFile/Minidump/ObjectFileMinidump.h
+++ b/lldb/source/Plugins/ObjectFile/Minidump/ObjectFileMinidump.h
@@ -48,12 +48,11 @@ public:
       const lldb::ModuleSP &module_sp, lldb::WritableDataBufferSP data_sp,
       const lldb::ProcessSP &process_sp, lldb::addr_t header_addr);
 
-  static size_t GetModuleSpecifications(const lldb_private::FileSpec &file,
-                                        lldb::DataExtractorSP &extractor_sp,
-                                        lldb::offset_t data_offset,
-                                        lldb::offset_t file_offset,
-                                        lldb::offset_t length,
-                                        lldb_private::ModuleSpecList &specs);
+  static lldb_private::ModuleSpecList
+  GetModuleSpecifications(const lldb_private::FileSpec &file,
+                          lldb::DataExtractorSP &extractor_sp,
+                          lldb::offset_t data_offset,
+                          lldb::offset_t file_offset, lldb::offset_t length);
 
   // Saves dump in Minidump file format
   static bool SaveCore(const lldb::ProcessSP &process_sp,

--- a/lldb/source/Plugins/ObjectFile/PDB/ObjectFilePDB.cpp
+++ b/lldb/source/Plugins/ObjectFile/PDB/ObjectFilePDB.cpp
@@ -111,30 +111,30 @@ ObjectFile *ObjectFilePDB::CreateMemoryInstance(const ModuleSP &module_sp,
   return nullptr;
 }
 
-size_t ObjectFilePDB::GetModuleSpecifications(
+ModuleSpecList ObjectFilePDB::GetModuleSpecifications(
     const FileSpec &file, DataExtractorSP &extractor_sp, offset_t data_offset,
-    offset_t file_offset, offset_t length, ModuleSpecList &specs) {
-  const size_t initial_count = specs.GetSize();
+    offset_t file_offset, offset_t length) {
   ModuleSpec module_spec(file);
   llvm::BumpPtrAllocator allocator;
   std::unique_ptr<PDBFile> pdb_file = loadPDBFile(file.GetPath(), allocator);
   if (!pdb_file)
-    return initial_count;
+    return {};
 
   auto info_stream = pdb_file->getPDBInfoStream();
   if (!info_stream) {
     llvm::consumeError(info_stream.takeError());
-    return initial_count;
+    return {};
   }
   auto dbi_stream = pdb_file->getPDBDbiStream();
   if (!dbi_stream) {
     llvm::consumeError(dbi_stream.takeError());
-    return initial_count;
+    return {};
   }
 
   lldb_private::UUID &uuid = module_spec.GetUUID();
   uuid = GetPDBUUID(*info_stream, *dbi_stream);
 
+  ModuleSpecList specs;
   ArchSpec &module_arch = module_spec.GetArchitecture();
   switch (dbi_stream->getMachineType()) {
   case PDB_Machine::Amd64:
@@ -157,7 +157,7 @@ size_t ObjectFilePDB::GetModuleSpecifications(
     break;
   }
 
-  return specs.GetSize() - initial_count;
+  return specs;
 }
 
 ObjectFilePDB::ObjectFilePDB(const ModuleSP &module_sp,

--- a/lldb/source/Plugins/ObjectFile/PDB/ObjectFilePDB.h
+++ b/lldb/source/Plugins/ObjectFile/PDB/ObjectFilePDB.h
@@ -42,12 +42,11 @@ public:
                                           const lldb::ProcessSP &process_sp,
                                           lldb::addr_t header_addr);
 
-  static size_t GetModuleSpecifications(const FileSpec &file,
-                                        lldb::DataExtractorSP &extractor_sp,
-                                        lldb::offset_t data_offset,
-                                        lldb::offset_t file_offset,
-                                        lldb::offset_t length,
-                                        ModuleSpecList &specs);
+  static ModuleSpecList
+  GetModuleSpecifications(const FileSpec &file,
+                          lldb::DataExtractorSP &extractor_sp,
+                          lldb::offset_t data_offset,
+                          lldb::offset_t file_offset, lldb::offset_t length);
 
   // PluginInterface protocol
   llvm::StringRef GetPluginName() override { return GetPluginNameStatic(); }

--- a/lldb/source/Plugins/ObjectFile/PECOFF/ObjectFilePECOFF.cpp
+++ b/lldb/source/Plugins/ObjectFile/PECOFF/ObjectFilePECOFF.cpp
@@ -254,14 +254,13 @@ ObjectFile *ObjectFilePECOFF::CreateMemoryInstance(
   return nullptr;
 }
 
-size_t ObjectFilePECOFF::GetModuleSpecifications(
+ModuleSpecList ObjectFilePECOFF::GetModuleSpecifications(
     const lldb_private::FileSpec &file, lldb::DataExtractorSP &extractor_sp,
     lldb::offset_t data_offset, lldb::offset_t file_offset,
-    lldb::offset_t length, lldb_private::ModuleSpecList &specs) {
-  const size_t initial_count = specs.GetSize();
+    lldb::offset_t length) {
   if (!extractor_sp || !extractor_sp->HasData() ||
       !ObjectFilePECOFF::MagicBytesMatch(extractor_sp))
-    return initial_count;
+    return {};
 
   Log *log = GetLog(LLDBLog::Object);
 
@@ -275,12 +274,12 @@ size_t ObjectFilePECOFF::GetModuleSpecifications(
   if (!binary) {
     LLDB_LOG_ERROR(log, binary.takeError(),
                    "Failed to create binary for file ({1}): {0}", file);
-    return initial_count;
+    return {};
   }
 
   auto *COFFObj = llvm::dyn_cast<llvm::object::COFFObjectFile>(binary->get());
   if (!COFFObj)
-    return initial_count;
+    return {};
 
   ModuleSpec module_spec(file);
   ArchSpec &spec = module_spec.GetArchitecture();
@@ -334,6 +333,7 @@ size_t ObjectFilePECOFF::GetModuleSpecifications(
   if (env == llvm::Triple::UnknownEnvironment)
     env = default_env;
 
+  ModuleSpecList specs;
   switch (COFFObj->getMachine()) {
   case MachineAmd64:
     spec.SetTriple("x86_64-pc-windows");
@@ -360,7 +360,7 @@ size_t ObjectFilePECOFF::GetModuleSpecifications(
     break;
   }
 
-  return specs.GetSize() - initial_count;
+  return specs;
 }
 
 bool ObjectFilePECOFF::SaveCore(const lldb::ProcessSP &process_sp,

--- a/lldb/source/Plugins/ObjectFile/PECOFF/ObjectFilePECOFF.h
+++ b/lldb/source/Plugins/ObjectFile/PECOFF/ObjectFilePECOFF.h
@@ -78,12 +78,11 @@ public:
       const lldb::ModuleSP &module_sp, lldb::WritableDataBufferSP data_sp,
       const lldb::ProcessSP &process_sp, lldb::addr_t header_addr);
 
-  static size_t GetModuleSpecifications(const lldb_private::FileSpec &file,
-                                        lldb::DataExtractorSP &extractor_sp,
-                                        lldb::offset_t data_offset,
-                                        lldb::offset_t file_offset,
-                                        lldb::offset_t length,
-                                        lldb_private::ModuleSpecList &specs);
+  static lldb_private::ModuleSpecList
+  GetModuleSpecifications(const lldb_private::FileSpec &file,
+                          lldb::DataExtractorSP &extractor_sp,
+                          lldb::offset_t data_offset,
+                          lldb::offset_t file_offset, lldb::offset_t length);
 
   static bool SaveCore(const lldb::ProcessSP &process_sp,
                        lldb_private::SaveCoreOptions &options,

--- a/lldb/source/Plugins/ObjectFile/XCOFF/ObjectFileXCOFF.cpp
+++ b/lldb/source/Plugins/ObjectFile/XCOFF/ObjectFileXCOFF.cpp
@@ -126,15 +126,14 @@ ObjectFile *ObjectFileXCOFF::CreateMemoryInstance(
   return nullptr;
 }
 
-size_t ObjectFileXCOFF::GetModuleSpecifications(
+ModuleSpecList ObjectFileXCOFF::GetModuleSpecifications(
     const lldb_private::FileSpec &file, lldb::DataExtractorSP &extractor_sp,
     lldb::offset_t data_offset, lldb::offset_t file_offset,
-    lldb::offset_t length, lldb_private::ModuleSpecList &specs) {
-  const size_t initial_count = specs.GetSize();
-
+    lldb::offset_t length) {
   if (!extractor_sp || !extractor_sp->HasData())
-    return 0;
+    return {};
 
+  ModuleSpecList specs;
   if (ObjectFileXCOFF::MagicBytesMatch(extractor_sp, 0,
                                        extractor_sp->GetByteSize())) {
     ArchSpec arch_spec =
@@ -145,7 +144,7 @@ size_t ObjectFileXCOFF::GetModuleSpecifications(
                                            llvm::Triple::AIX);
     specs.Append(spec);
   }
-  return specs.GetSize() - initial_count;
+  return specs;
 }
 
 static uint32_t XCOFFHeaderSizeFromMagic(uint32_t magic) {

--- a/lldb/source/Plugins/ObjectFile/XCOFF/ObjectFileXCOFF.h
+++ b/lldb/source/Plugins/ObjectFile/XCOFF/ObjectFileXCOFF.h
@@ -47,12 +47,11 @@ public:
       const lldb::ModuleSP &module_sp, lldb::WritableDataBufferSP data_sp,
       const lldb::ProcessSP &process_sp, lldb::addr_t header_addr);
 
-  static size_t GetModuleSpecifications(const lldb_private::FileSpec &file,
-                                        lldb::DataExtractorSP &extractor_sp,
-                                        lldb::offset_t data_offset,
-                                        lldb::offset_t file_offset,
-                                        lldb::offset_t length,
-                                        lldb_private::ModuleSpecList &specs);
+  static lldb_private::ModuleSpecList
+  GetModuleSpecifications(const lldb_private::FileSpec &file,
+                          lldb::DataExtractorSP &extractor_sp,
+                          lldb::offset_t data_offset,
+                          lldb::offset_t file_offset, lldb::offset_t length);
 
   static bool MagicBytesMatch(lldb::DataExtractorSP &extractor_sp,
                               lldb::addr_t offset, lldb::addr_t length);

--- a/lldb/source/Plugins/ObjectFile/wasm/ObjectFileWasm.cpp
+++ b/lldb/source/Plugins/ObjectFile/wasm/ObjectFileWasm.cpp
@@ -273,16 +273,15 @@ bool ObjectFileWasm::DecodeSections() {
   return true;
 }
 
-size_t ObjectFileWasm::GetModuleSpecifications(
+ModuleSpecList ObjectFileWasm::GetModuleSpecifications(
     const FileSpec &file, DataExtractorSP &extractor_sp, offset_t data_offset,
-    offset_t file_offset, offset_t length, ModuleSpecList &specs) {
-  if (!ValidateModuleHeader(extractor_sp->GetData())) {
-    return 0;
-  }
+    offset_t file_offset, offset_t length) {
+  if (!ValidateModuleHeader(extractor_sp->GetData()))
+    return {};
 
-  ModuleSpec spec(file, ArchSpec("wasm32-unknown-unknown-wasm"));
-  specs.Append(spec);
-  return 1;
+  ModuleSpecList specs;
+  specs.Append(ModuleSpec(file, ArchSpec("wasm32-unknown-unknown-wasm")));
+  return specs;
 }
 
 ObjectFileWasm::ObjectFileWasm(const ModuleSP &module_sp,

--- a/lldb/source/Plugins/ObjectFile/wasm/ObjectFileWasm.h
+++ b/lldb/source/Plugins/ObjectFile/wasm/ObjectFileWasm.h
@@ -42,12 +42,11 @@ public:
                                           const lldb::ProcessSP &process_sp,
                                           lldb::addr_t header_addr);
 
-  static size_t GetModuleSpecifications(const FileSpec &file,
-                                        lldb::DataExtractorSP &extractor_sp,
-                                        lldb::offset_t data_offset,
-                                        lldb::offset_t file_offset,
-                                        lldb::offset_t length,
-                                        ModuleSpecList &specs);
+  static ModuleSpecList
+  GetModuleSpecifications(const FileSpec &file,
+                          lldb::DataExtractorSP &extractor_sp,
+                          lldb::offset_t data_offset,
+                          lldb::offset_t file_offset, lldb::offset_t length);
 
   /// PluginInterface protocol.
   /// \{

--- a/lldb/source/Symbol/ObjectFile.cpp
+++ b/lldb/source/Symbol/ObjectFile.cpp
@@ -227,19 +227,24 @@ size_t ObjectFile::GetModuleSpecifications(
     const lldb_private::FileSpec &file, lldb::DataExtractorSP &extractor_sp,
     lldb::offset_t data_offset, lldb::offset_t file_offset,
     lldb::offset_t file_size, lldb_private::ModuleSpecList &specs) {
-  const size_t initial_count = specs.GetSize();
   // Try the ObjectFile plug-ins
   for (auto &cbs : PluginManager::GetObjectFileCallbacks()) {
-    if (cbs.get_module_specifications(file, extractor_sp, data_offset,
-                                      file_offset, file_size, specs) > 0)
-      return specs.GetSize() - initial_count;
+    ModuleSpecList cb_specs = cbs.get_module_specifications(
+        file, extractor_sp, data_offset, file_offset, file_size);
+    if (cb_specs.GetSize() > 0) {
+      specs.Append(cb_specs);
+      return cb_specs.GetSize();
+    }
   }
 
   // Try the ObjectContainer plug-ins
   for (auto &cbs : PluginManager::GetObjectContainerCallbacks()) {
-    if (cbs.get_module_specifications(file, extractor_sp, data_offset,
-                                      file_offset, file_size, specs) > 0)
-      return specs.GetSize() - initial_count;
+    ModuleSpecList cb_specs = cbs.get_module_specifications(
+        file, extractor_sp, data_offset, file_offset, file_size);
+    if (cb_specs.GetSize() > 0) {
+      specs.Append(cb_specs);
+      return cb_specs.GetSize();
+    }
   }
   return 0;
 }


### PR DESCRIPTION
Some plugins were returning the number of specifications they have added, while others were returning the total final number. Particularly devious plugins (Minidump) were clearing the specification list altogether. This resulted in nondeterministic failures (depending on plugin ininitialization order) in TestSBModule.

This PR defines the problem away by having each plugin only return the specifications it is responsible for. If the caller wants to merge them, it is free to do so. This *might* be slighly less efficient, but this is hardly hot code.

I'm not touching the ObjectFile::GetModuleSpecifications function (the caller of all these functions) as the PR is big enough, although the same approach might be warranted there as well.

Fixes https://github.com/llvm/llvm-project/issues/178625.