### PR TITLE
[X86][NewPM] Mark X86AsmPrinter isRequired

### DIFF
--- a/llvm/lib/Target/X86/X86AsmPrinter.h
+++ b/llvm/lib/Target/X86/X86AsmPrinter.h
@@ -224,6 +224,7 @@ public:
 
   PreservedAnalyses run(MachineFunction &MF,
                         MachineFunctionAnalysisManager &MFAM);
+  // AsmPrinter needs to run regardless of optimization level.
   static bool isRequired() { return true; }
 
 private:

--- a/llvm/lib/Target/X86/X86AsmPrinter.h
+++ b/llvm/lib/Target/X86/X86AsmPrinter.h
@@ -224,6 +224,7 @@ public:
 
   PreservedAnalyses run(MachineFunction &MF,
                         MachineFunctionAnalysisManager &MFAM);
+  static bool isRequired() { return true; }
 
 private:
   TargetMachine &TM;

--- a/llvm/test/CodeGen/X86/npm-asmprint.ll
+++ b/llvm/test/CodeGen/X86/npm-asmprint.ll
@@ -7,3 +7,12 @@ define void @test() {
 ; CHECK-NEXT:    retq
   ret void
 }
+
+define void @test2() #0 {
+; CHECK-LABEL: test2:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    retq
+  ret void
+}
+
+attributes #0 = { optnone noinline }


### PR DESCRIPTION
Otherwise the pass does not run when a function has the optnone attribute, which means we get no assembly out for functions marked optnone.