### PR TITLE
[CIR][NFC] Mark invalid-linkage.cir as XFAIL

### DIFF
--- a/clang/test/CIR/IR/invalid-linkage.cir
+++ b/clang/test/CIR/IR/invalid-linkage.cir
@@ -1,8 +1,11 @@
 // Test that cir.global requires a valid linkage attribute
 // RUN: cir-opt %s -verify-diagnostics
 
+// XFAIL: *
+
 !u32i = !cir.int<u, 32>
 module {
+  // expected-error@+1 {{this is here to prevent the test from being reported as an unexpected pass if the problem is fixed outside of CIR}}
   // expected-error@+1 {{expected string or keyword containing one of the following enum values for attribute 'linkage' [external, available_externally, linkonce, linkonce_odr, weak, weak_odr, appending, internal, cir_private, extern_weak, common]}}
   cir.global @a = #cir.const_array<[0 : !u8i, -23 : !u8i, 33 : !u8i] : !cir.array<!u32i x 3>>
 }


### PR DESCRIPTION
The invalid-linkage.cir test is currently failing as a result of a recent change to the MLIR attribute parser. I am temporarily marking this test as XFAIL while that problem is being worked on to unblock CIR development. I added a check that will force the test to fail even after the problem is fixed so that we don't start getting unexpected passes when the fix is merged. (CIR testing isn't run during CI for MLIR changes.) I will reenable the test after the problem has been fixed.