### PR TITLE
[NVPTX] Fix assumption of sm versioning

### DIFF
--- a/llvm/test/CodeGen/NVPTX/i1-int-to-fp.ll
+++ b/llvm/test/CodeGen/NVPTX/i1-int-to-fp.ll
@@ -1,5 +1,5 @@
 ; RUN: llc < %s -mtriple=nvptx64 -mcpu=sm_90 -mattr=+ptx78 | FileCheck %s
-; RUN: %if ptxas %{ llc < %s -mtriple=nvptx64 -mcpu=sm_90 -mattr=+ptx78 | %ptxas-verify %}
+; RUN: %if ptxas-sm_90 && ptxas-isa-7.8 %{ llc < %s -mtriple=nvptx64 -mcpu=sm_90 -mattr=+ptx78 | %ptxas-verify -arch=sm_90 %}
 
 ; CHECK-LABEL: foo
 ; CHECK: setp.ne.b16 %[[P:p[0-9]+]], %{{.*}}, 0;


### PR DESCRIPTION
The test case in #188118 assumes sm-90 is always available, leading to a crash
```
 # | ptxas fatal   : SM version specified by .target is higher than default SM version assumed
```

This PR updates the test case to follow the check specified in `llvm/test/CodeGen/NVPTX/cp-async-bulk-tensor-reduce.ll`,
namely `%if ptxas-sm_90 && ptxas-isa-7.8`