### PR TITLE
[X86] Fix widening for strict_fmin/fmax

### DIFF
--- a/llvm/lib/Target/X86/X86ISelLowering.cpp
+++ b/llvm/lib/Target/X86/X86ISelLowering.cpp
@@ -34931,11 +34931,13 @@ void X86TargetLowering::ReplaceNodeResults(SDNode *N,
     EVT VT = N->getValueType(0);
     assert(VT == MVT::v2f32 && "Unexpected type (!= v2f32) on FMIN/FMAX.");
     bool IsStrict = Opc == X86ISD::STRICT_FMIN || Opc == X86ISD::STRICT_FMAX;
-    SDValue UNDEF = DAG.getUNDEF(VT);
+    // For strict FP use a value that can not signal.
+    SDValue Filler =
+        IsStrict ? DAG.getConstantFP(0.0, dl, VT) : DAG.getUNDEF(VT);
     SDValue LHS = DAG.getNode(ISD::CONCAT_VECTORS, dl, MVT::v4f32,
-                              N->getOperand(IsStrict ? 1 : 0), UNDEF);
+                              N->getOperand(IsStrict ? 1 : 0), Filler);
     SDValue RHS = DAG.getNode(ISD::CONCAT_VECTORS, dl, MVT::v4f32,
-                              N->getOperand(IsStrict ? 2 : 1), UNDEF);
+                              N->getOperand(IsStrict ? 2 : 1), Filler);
     SDValue Res;
     if (IsStrict)
       Res = DAG.getNode(Opc, dl, {MVT::v4f32, MVT::Other},

--- a/llvm/test/CodeGen/X86/vec-strict-cmp-128.ll
+++ b/llvm/test/CodeGen/X86/vec-strict-cmp-128.ll
@@ -6090,41 +6090,57 @@ define <2 x double> @test_v4f64_ogt2_s(<2 x double> %a, <2 x double> %b) #0 {
 define <2 x float> @test_v2f32_ogt2_s(<2 x float> %a, <2 x float> %b) #0 {
 ; SSE-32-LABEL: test_v2f32_ogt2_s:
 ; SSE-32:       # %bb.0:
+; SSE-32-NEXT:    movq {{.*#+}} xmm1 = xmm1[0],zero
+; SSE-32-NEXT:    movq {{.*#+}} xmm0 = xmm0[0],zero
 ; SSE-32-NEXT:    maxps %xmm1, %xmm0
 ; SSE-32-NEXT:    retl
 ;
 ; SSE-64-LABEL: test_v2f32_ogt2_s:
 ; SSE-64:       # %bb.0:
+; SSE-64-NEXT:    movq {{.*#+}} xmm1 = xmm1[0],zero
+; SSE-64-NEXT:    movq {{.*#+}} xmm0 = xmm0[0],zero
 ; SSE-64-NEXT:    maxps %xmm1, %xmm0
 ; SSE-64-NEXT:    retq
 ;
 ; AVX-32-LABEL: test_v2f32_ogt2_s:
 ; AVX-32:       # %bb.0:
+; AVX-32-NEXT:    vmovq {{.*#+}} xmm1 = xmm1[0],zero
+; AVX-32-NEXT:    vmovq {{.*#+}} xmm0 = xmm0[0],zero
 ; AVX-32-NEXT:    vmaxps %xmm1, %xmm0, %xmm0
 ; AVX-32-NEXT:    retl
 ;
 ; AVX-64-LABEL: test_v2f32_ogt2_s:
 ; AVX-64:       # %bb.0:
+; AVX-64-NEXT:    vmovq {{.*#+}} xmm1 = xmm1[0],zero
+; AVX-64-NEXT:    vmovq {{.*#+}} xmm0 = xmm0[0],zero
 ; AVX-64-NEXT:    vmaxps %xmm1, %xmm0, %xmm0
 ; AVX-64-NEXT:    retq
 ;
 ; AVX512-32-LABEL: test_v2f32_ogt2_s:
 ; AVX512-32:       # %bb.0:
+; AVX512-32-NEXT:    vmovq {{.*#+}} xmm1 = xmm1[0],zero
+; AVX512-32-NEXT:    vmovq {{.*#+}} xmm0 = xmm0[0],zero
 ; AVX512-32-NEXT:    vmaxps %xmm1, %xmm0, %xmm0
 ; AVX512-32-NEXT:    retl
 ;
 ; AVX512-64-LABEL: test_v2f32_ogt2_s:
 ; AVX512-64:       # %bb.0:
+; AVX512-64-NEXT:    vmovq {{.*#+}} xmm1 = xmm1[0],zero
+; AVX512-64-NEXT:    vmovq {{.*#+}} xmm0 = xmm0[0],zero
 ; AVX512-64-NEXT:    vmaxps %xmm1, %xmm0, %xmm0
 ; AVX512-64-NEXT:    retq
 ;
 ; AVX512F-32-LABEL: test_v2f32_ogt2_s:
 ; AVX512F-32:       # %bb.0:
+; AVX512F-32-NEXT:    vmovq {{.*#+}} xmm1 = xmm1[0],zero
+; AVX512F-32-NEXT:    vmovq {{.*#+}} xmm0 = xmm0[0],zero
 ; AVX512F-32-NEXT:    vmaxps %xmm1, %xmm0, %xmm0
 ; AVX512F-32-NEXT:    retl
 ;
 ; AVX512F-64-LABEL: test_v2f32_ogt2_s:
 ; AVX512F-64:       # %bb.0:
+; AVX512F-64-NEXT:    vmovq {{.*#+}} xmm1 = xmm1[0],zero
+; AVX512F-64-NEXT:    vmovq {{.*#+}} xmm0 = xmm0[0],zero
 ; AVX512F-64-NEXT:    vmaxps %xmm1, %xmm0, %xmm0
 ; AVX512F-64-NEXT:    retq
   %cond = call <2 x i1> @llvm.experimental.constrained.fcmps.v2f32(
@@ -6137,43 +6153,57 @@ define <2 x float> @test_v2f32_ogt2_s(<2 x float> %a, <2 x float> %b) #0 {
 define <2 x float> @test_v2f32_ule2_s(<2 x float> %a, <2 x float> %b) #0 {
 ; SSE-32-LABEL: test_v2f32_ule2_s:
 ; SSE-32:       # %bb.0:
-; SSE-32-NEXT:    minps %xmm0, %xmm1
-; SSE-32-NEXT:    movaps %xmm1, %xmm0
+; SSE-32-NEXT:    movq {{.*#+}} xmm2 = xmm0[0],zero
+; SSE-32-NEXT:    movq {{.*#+}} xmm0 = xmm1[0],zero
+; SSE-32-NEXT:    minps %xmm2, %xmm0
 ; SSE-32-NEXT:    retl
 ;
 ; SSE-64-LABEL: test_v2f32_ule2_s:
 ; SSE-64:       # %bb.0:
-; SSE-64-NEXT:    minps %xmm0, %xmm1
-; SSE-64-NEXT:    movaps %xmm1, %xmm0
+; SSE-64-NEXT:    movq {{.*#+}} xmm2 = xmm0[0],zero
+; SSE-64-NEXT:    movq {{.*#+}} xmm0 = xmm1[0],zero
+; SSE-64-NEXT:    minps %xmm2, %xmm0
 ; SSE-64-NEXT:    retq
 ;
 ; AVX-32-LABEL: test_v2f32_ule2_s:
 ; AVX-32:       # %bb.0:
+; AVX-32-NEXT:    vmovq {{.*#+}} xmm0 = xmm0[0],zero
+; AVX-32-NEXT:    vmovq {{.*#+}} xmm1 = xmm1[0],zero
 ; AVX-32-NEXT:    vminps %xmm0, %xmm1, %xmm0
 ; AVX-32-NEXT:    retl
 ;
 ; AVX-64-LABEL: test_v2f32_ule2_s:
 ; AVX-64:       # %bb.0:
+; AVX-64-NEXT:    vmovq {{.*#+}} xmm0 = xmm0[0],zero
+; AVX-64-NEXT:    vmovq {{.*#+}} xmm1 = xmm1[0],zero
 ; AVX-64-NEXT:    vminps %xmm0, %xmm1, %xmm0
 ; AVX-64-NEXT:    retq
 ;
 ; AVX512-32-LABEL: test_v2f32_ule2_s:
 ; AVX512-32:       # %bb.0:
+; AVX512-32-NEXT:    vmovq {{.*#+}} xmm0 = xmm0[0],zero
+; AVX512-32-NEXT:    vmovq {{.*#+}} xmm1 = xmm1[0],zero
 ; AVX512-32-NEXT:    vminps %xmm0, %xmm1, %xmm0
 ; AVX512-32-NEXT:    retl
 ;
 ; AVX512-64-LABEL: test_v2f32_ule2_s:
 ; AVX512-64:       # %bb.0:
+; AVX512-64-NEXT:    vmovq {{.*#+}} xmm0 = xmm0[0],zero
+; AVX512-64-NEXT:    vmovq {{.*#+}} xmm1 = xmm1[0],zero
 ; AVX512-64-NEXT:    vminps %xmm0, %xmm1, %xmm0
 ; AVX512-64-NEXT:    retq
 ;
 ; AVX512F-32-LABEL: test_v2f32_ule2_s:
 ; AVX512F-32:       # %bb.0:
+; AVX512F-32-NEXT:    vmovq {{.*#+}} xmm0 = xmm0[0],zero
+; AVX512F-32-NEXT:    vmovq {{.*#+}} xmm1 = xmm1[0],zero
 ; AVX512F-32-NEXT:    vminps %xmm0, %xmm1, %xmm0
 ; AVX512F-32-NEXT:    retl
 ;
 ; AVX512F-64-LABEL: test_v2f32_ule2_s:
 ; AVX512F-64:       # %bb.0:
+; AVX512F-64-NEXT:    vmovq {{.*#+}} xmm0 = xmm0[0],zero
+; AVX512F-64-NEXT:    vmovq {{.*#+}} xmm1 = xmm1[0],zero
 ; AVX512F-64-NEXT:    vminps %xmm0, %xmm1, %xmm0
 ; AVX512F-64-NEXT:    retq
   %cond = call <2 x i1> @llvm.experimental.constrained.fcmps.v2f32(


### PR DESCRIPTION
I believe that widening these with undef is not correct, because the undef values might be picked as sNaN and then trap.