### PR TITLE
[AMDGPU] Handle high element extraction with G_UNMERGE_VALUES

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUInstructionSelector.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUInstructionSelector.cpp
@@ -2837,6 +2837,18 @@ static Register stripBitCast(Register Reg, MachineRegisterInfo &MRI) {
 
 static bool isExtractHiElt(MachineRegisterInfo &MRI, Register In,
                            Register &Out) {
+  // When unmerging a register that is composed of 2 x 16-bit values allow to
+  // use an extract hi instruction for the upper 16 bits. We only need to check
+  // the size of `In` as all defs are guaranteed to be the same type for
+  // GUnmerge.
+  if (auto *Unmerge = dyn_cast<GUnmerge>(MRI.getVRegDef(In))) {
+    if (Unmerge->getNumDefs() == 2 && Unmerge->getOperand(1).getReg() == In &&
+        MRI.getType(In).getSizeInBits() == 16) {
+      Out = Unmerge->getSourceReg();
+      return true;
+    }
+  }
+
   Register Trunc;
   if (!mi_match(In, MRI, m_GTrunc(m_Reg(Trunc))))
     return false;

--- a/llvm/test/CodeGen/AMDGPU/fptosi-sat-vector.ll
+++ b/llvm/test/CodeGen/AMDGPU/fptosi-sat-vector.ll
@@ -3346,31 +3346,28 @@ define <4 x i1> @test_s_signed_v4f16_v4i1(<4 x half> inreg %f) {
 ; GFX12-GI-NEXT:    s_wait_samplecnt 0x0
 ; GFX12-GI-NEXT:    s_wait_bvhcnt 0x0
 ; GFX12-GI-NEXT:    s_wait_kmcnt 0x0
-; GFX12-GI-NEXT:    s_lshr_b32 s2, s0, 16
-; GFX12-GI-NEXT:    s_lshr_b32 s3, s1, 16
-; GFX12-GI-NEXT:    s_cvt_f32_f16 s0, s0
-; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX12-GI-NEXT:    s_cvt_f32_f16 s2, s2
-; GFX12-GI-NEXT:    s_cvt_f32_f16 s1, s1
-; GFX12-GI-NEXT:    s_cvt_f32_f16 s3, s3
-; GFX12-GI-NEXT:    s_cvt_i32_f32 s0, s0
+; GFX12-GI-NEXT:    s_cvt_f32_f16 s2, s0
+; GFX12-GI-NEXT:    s_cvt_hi_f32_f16 s0, s0
+; GFX12-GI-NEXT:    s_cvt_f32_f16 s3, s1
+; GFX12-GI-NEXT:    s_cvt_hi_f32_f16 s1, s1
 ; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
 ; GFX12-GI-NEXT:    s_cvt_i32_f32 s2, s2
-; GFX12-GI-NEXT:    s_cvt_i32_f32 s1, s1
+; GFX12-GI-NEXT:    s_cvt_i32_f32 s0, s0
 ; GFX12-GI-NEXT:    s_cvt_i32_f32 s3, s3
-; GFX12-GI-NEXT:    s_min_i32 s0, s0, 0
+; GFX12-GI-NEXT:    s_cvt_i32_f32 s1, s1
 ; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
 ; GFX12-GI-NEXT:    s_min_i32 s2, s2, 0
-; GFX12-GI-NEXT:    s_min_i32 s1, s1, 0
+; GFX12-GI-NEXT:    s_min_i32 s0, s0, 0
 ; GFX12-GI-NEXT:    s_min_i32 s3, s3, 0
-; GFX12-GI-NEXT:    s_max_i32 s0, s0, -1
+; GFX12-GI-NEXT:    s_min_i32 s1, s1, 0
 ; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
 ; GFX12-GI-NEXT:    s_max_i32 s2, s2, -1
-; GFX12-GI-NEXT:    s_max_i32 s1, s1, -1
+; GFX12-GI-NEXT:    s_max_i32 s0, s0, -1
 ; GFX12-GI-NEXT:    s_max_i32 s3, s3, -1
+; GFX12-GI-NEXT:    s_max_i32 s1, s1, -1
 ; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX12-GI-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s2
-; GFX12-GI-NEXT:    v_dual_mov_b32 v2, s1 :: v_dual_mov_b32 v3, s3
+; GFX12-GI-NEXT:    v_dual_mov_b32 v0, s2 :: v_dual_mov_b32 v1, s0
+; GFX12-GI-NEXT:    v_dual_mov_b32 v2, s3 :: v_dual_mov_b32 v3, s1
 ; GFX12-GI-NEXT:    s_setpc_b64 s[30:31]
     %x = call <4 x i1> @llvm.fptosi.sat.v4f16.v4i1(<4 x half> %f)
     ret <4 x i1> %x
@@ -3606,31 +3603,28 @@ define <4 x i8> @test_s_signed_v4f16_v4i8(<4 x half> inreg %f) {
 ; GFX12-GI-NEXT:    s_wait_samplecnt 0x0
 ; GFX12-GI-NEXT:    s_wait_bvhcnt 0x0
 ; GFX12-GI-NEXT:    s_wait_kmcnt 0x0
-; GFX12-GI-NEXT:    s_lshr_b32 s2, s0, 16
-; GFX12-GI-NEXT:    s_lshr_b32 s3, s1, 16
-; GFX12-GI-NEXT:    s_cvt_f32_f16 s0, s0
-; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX12-GI-NEXT:    s_cvt_f32_f16 s2, s2
-; GFX12-GI-NEXT:    s_cvt_f32_f16 s1, s1
-; GFX12-GI-NEXT:    s_cvt_f32_f16 s3, s3
-; GFX12-GI-NEXT:    s_cvt_i32_f32 s0, s0
+; GFX12-GI-NEXT:    s_cvt_f32_f16 s2, s0
+; GFX12-GI-NEXT:    s_cvt_hi_f32_f16 s0, s0
+; GFX12-GI-NEXT:    s_cvt_f32_f16 s3, s1
+; GFX12-GI-NEXT:    s_cvt_hi_f32_f16 s1, s1
 ; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
 ; GFX12-GI-NEXT:    s_cvt_i32_f32 s2, s2
-; GFX12-GI-NEXT:    s_cvt_i32_f32 s1, s1
+; GFX12-GI-NEXT:    s_cvt_i32_f32 s0, s0
 ; GFX12-GI-NEXT:    s_cvt_i32_f32 s3, s3
-; GFX12-GI-NEXT:    s_min_i32 s0, s0, 0x7f
+; GFX12-GI-NEXT:    s_cvt_i32_f32 s1, s1
 ; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
 ; GFX12-GI-NEXT:    s_min_i32 s2, s2, 0x7f
-; GFX12-GI-NEXT:    s_min_i32 s1, s1, 0x7f
+; GFX12-GI-NEXT:    s_min_i32 s0, s0, 0x7f
 ; GFX12-GI-NEXT:    s_min_i32 s3, s3, 0x7f
-; GFX12-GI-NEXT:    s_max_i32 s0, s0, 0xffffff80
+; GFX12-GI-NEXT:    s_min_i32 s1, s1, 0x7f
 ; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
 ; GFX12-GI-NEXT:    s_max_i32 s2, s2, 0xffffff80
-; GFX12-GI-NEXT:    s_max_i32 s1, s1, 0xffffff80
+; GFX12-GI-NEXT:    s_max_i32 s0, s0, 0xffffff80
 ; GFX12-GI-NEXT:    s_max_i32 s3, s3, 0xffffff80
+; GFX12-GI-NEXT:    s_max_i32 s1, s1, 0xffffff80
 ; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX12-GI-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s2
-; GFX12-GI-NEXT:    v_dual_mov_b32 v2, s1 :: v_dual_mov_b32 v3, s3
+; GFX12-GI-NEXT:    v_dual_mov_b32 v0, s2 :: v_dual_mov_b32 v1, s0
+; GFX12-GI-NEXT:    v_dual_mov_b32 v2, s3 :: v_dual_mov_b32 v3, s1
 ; GFX12-GI-NEXT:    s_setpc_b64 s[30:31]
     %x = call <4 x i8> @llvm.fptosi.sat.v4f16.v4i8(<4 x half> %f)
     ret <4 x i8> %x
@@ -3901,23 +3895,20 @@ define <4 x i64> @test_s_signed_v4f16_v4i64(<4 x half> inreg %f) {
 ; GFX12-GI-NEXT:    s_wait_samplecnt 0x0
 ; GFX12-GI-NEXT:    s_wait_bvhcnt 0x0
 ; GFX12-GI-NEXT:    s_wait_kmcnt 0x0
-; GFX12-GI-NEXT:    s_lshr_b32 s2, s0, 16
-; GFX12-GI-NEXT:    s_lshr_b32 s3, s1, 16
-; GFX12-GI-NEXT:    s_cvt_f32_f16 s0, s0
-; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX12-GI-NEXT:    s_cvt_f32_f16 s2, s2
-; GFX12-GI-NEXT:    s_cvt_f32_f16 s1, s1
-; GFX12-GI-NEXT:    s_cvt_f32_f16 s3, s3
-; GFX12-GI-NEXT:    s_cvt_i32_f32 s0, s0
+; GFX12-GI-NEXT:    s_cvt_f32_f16 s2, s0
+; GFX12-GI-NEXT:    s_cvt_hi_f32_f16 s0, s0
+; GFX12-GI-NEXT:    s_cvt_f32_f16 s3, s1
+; GFX12-GI-NEXT:    s_cvt_hi_f32_f16 s1, s1
 ; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
 ; GFX12-GI-NEXT:    s_cvt_i32_f32 s2, s2
-; GFX12-GI-NEXT:    s_cvt_i32_f32 s1, s1
+; GFX12-GI-NEXT:    s_cvt_i32_f32 s0, s0
 ; GFX12-GI-NEXT:    s_cvt_i32_f32 s3, s3
-; GFX12-GI-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, 0
+; GFX12-GI-NEXT:    s_cvt_i32_f32 s1, s1
 ; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX12-GI-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, 0
-; GFX12-GI-NEXT:    v_dual_mov_b32 v4, s1 :: v_dual_mov_b32 v5, 0
-; GFX12-GI-NEXT:    v_dual_mov_b32 v6, s3 :: v_dual_mov_b32 v7, 0
+; GFX12-GI-NEXT:    v_dual_mov_b32 v0, s2 :: v_dual_mov_b32 v1, 0
+; GFX12-GI-NEXT:    v_dual_mov_b32 v2, s0 :: v_dual_mov_b32 v3, 0
+; GFX12-GI-NEXT:    v_dual_mov_b32 v4, s3 :: v_dual_mov_b32 v5, 0
+; GFX12-GI-NEXT:    v_dual_mov_b32 v6, s1 :: v_dual_mov_b32 v7, 0
 ; GFX12-GI-NEXT:    s_setpc_b64 s[30:31]
     %x = call <4 x i64> @llvm.fptosi.sat.v4f16.v4i64(<4 x half> %f)
     ret <4 x i64> %x
@@ -5490,51 +5481,46 @@ define <8 x i1> @test_s_signed_v8f16_v8i1(<8 x half> inreg %f) {
 ; GFX12-GI-NEXT:    s_wait_samplecnt 0x0
 ; GFX12-GI-NEXT:    s_wait_bvhcnt 0x0
 ; GFX12-GI-NEXT:    s_wait_kmcnt 0x0
-; GFX12-GI-NEXT:    s_lshr_b32 s4, s0, 16
-; GFX12-GI-NEXT:    s_lshr_b32 s5, s1, 16
-; GFX12-GI-NEXT:    s_lshr_b32 s6, s2, 16
-; GFX12-GI-NEXT:    s_lshr_b32 s7, s3, 16
-; GFX12-GI-NEXT:    s_cvt_f32_f16 s0, s0
-; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX12-GI-NEXT:    s_cvt_f32_f16 s4, s4
-; GFX12-GI-NEXT:    s_cvt_f32_f16 s1, s1
-; GFX12-GI-NEXT:    s_cvt_f32_f16 s5, s5
-; GFX12-GI-NEXT:    s_cvt_f32_f16 s2, s2
-; GFX12-GI-NEXT:    s_cvt_f32_f16 s6, s6
-; GFX12-GI-NEXT:    s_cvt_f32_f16 s3, s3
-; GFX12-GI-NEXT:    s_cvt_f32_f16 s7, s7
-; GFX12-GI-NEXT:    s_cvt_i32_f32 s0, s0
+; GFX12-GI-NEXT:    s_cvt_f32_f16 s4, s0
+; GFX12-GI-NEXT:    s_cvt_hi_f32_f16 s0, s0
+; GFX12-GI-NEXT:    s_cvt_f32_f16 s5, s1
+; GFX12-GI-NEXT:    s_cvt_hi_f32_f16 s1, s1
+; GFX12-GI-NEXT:    s_cvt_f32_f16 s6, s2
+; GFX12-GI-NEXT:    s_cvt_hi_f32_f16 s2, s2
+; GFX12-GI-NEXT:    s_cvt_f32_f16 s7, s3
+; GFX12-GI-NEXT:    s_cvt_hi_f32_f16 s3, s3
 ; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
 ; GFX12-GI-NEXT:    s_cvt_i32_f32 s4, s4
-; GFX12-GI-NEXT:    s_cvt_i32_f32 s1, s1
+; GFX12-GI-NEXT:    s_cvt_i32_f32 s0, s0
 ; GFX12-GI-NEXT:    s_cvt_i32_f32 s5, s5
-; GFX12-GI-NEXT:    s_cvt_i32_f32 s2, s2
+; GFX12-GI-NEXT:    s_cvt_i32_f32 s1, s1
 ; GFX12-GI-NEXT:    s_cvt_i32_f32 s6, s6
-; GFX12-GI-NEXT:    s_cvt_i32_f32 s3, s3
+; GFX12-GI-NEXT:    s_cvt_i32_f32 s2, s2
 ; GFX12-GI-NEXT:    s_cvt_i32_f32 s7, s7
-; GFX12-GI-NEXT:    s_min_i32 s0, s0, 0
+; GFX12-GI-NEXT:    s_cvt_i32_f32 s3, s3
 ; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
 ; GFX12-GI-NEXT:    s_min_i32 s4, s4, 0
-; GFX12-GI-NEXT:    s_min_i32 s1, s1, 0
+; GFX12-GI-NEXT:    s_min_i32 s0, s0, 0
 ; GFX12-GI-NEXT:    s_min_i32 s5, s5, 0
-; GFX12-GI-NEXT:    s_min_i32 s2, s2, 0
+; GFX12-GI-NEXT:    s_min_i32 s1, s1, 0
 ; GFX12-GI-NEXT:    s_min_i32 s6, s6, 0
-; GFX12-GI-NEXT:    s_min_i32 s3, s3, 0
+; GFX12-GI-NEXT:    s_min_i32 s2, s2, 0
 ; GFX12-GI-NEXT:    s_min_i32 s7, s7, 0
-; GFX12-GI-NEXT:    s_max_i32 s0, s0, -1
+; GFX12-GI-NEXT:    s_min_i32 s3, s3, 0
 ; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
 ; GFX12-GI-NEXT:    s_max_i32 s4, s4, -1
-; GFX12-GI-NEXT:    s_max_i32 s1, s1, -1
+; GFX12-GI-NEXT:    s_max_i32 s0, s0, -1
 ; GFX12-GI-NEXT:    s_max_i32 s5, s5, -1
-; GFX12-GI-NEXT:    s_max_i32 s2, s2, -1
+; GFX12-GI-NEXT:    s_max_i32 s1, s1, -1
 ; GFX12-GI-NEXT:    s_max_i32 s6, s6, -1
-; GFX12-GI-NEXT:    s_max_i32 s3, s3, -1
+; GFX12-GI-NEXT:    s_max_i32 s2, s2, -1
 ; GFX12-GI-NEXT:    s_max_i32 s7, s7, -1
+; GFX12-GI-NEXT:    s_max_i32 s3, s3, -1
 ; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX12-GI-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s4
-; GFX12-GI-NEXT:    v_dual_mov_b32 v2, s1 :: v_dual_mov_b32 v3, s5
-; GFX12-GI-NEXT:    v_dual_mov_b32 v4, s2 :: v_dual_mov_b32 v5, s6
-; GFX12-GI-NEXT:    v_dual_mov_b32 v6, s3 :: v_dual_mov_b32 v7, s7
+; GFX12-GI-NEXT:    v_dual_mov_b32 v0, s4 :: v_dual_mov_b32 v1, s0
+; GFX12-GI-NEXT:    v_dual_mov_b32 v2, s5 :: v_dual_mov_b32 v3, s1
+; GFX12-GI-NEXT:    v_dual_mov_b32 v4, s6 :: v_dual_mov_b32 v5, s2
+; GFX12-GI-NEXT:    v_dual_mov_b32 v6, s7 :: v_dual_mov_b32 v7, s3
 ; GFX12-GI-NEXT:    s_setpc_b64 s[30:31]
     %x = call <8 x i1> @llvm.fptosi.sat.v8f16.v8i1(<8 x half> %f)
     ret <8 x i1> %x
@@ -5939,51 +5925,46 @@ define <8 x i8> @test_s_signed_v8f16_v8i8(<8 x half> inreg %f) {
 ; GFX12-GI-NEXT:    s_wait_samplecnt 0x0
 ; GFX12-GI-NEXT:    s_wait_bvhcnt 0x0
 ; GFX12-GI-NEXT:    s_wait_kmcnt 0x0
-; GFX12-GI-NEXT:    s_lshr_b32 s4, s0, 16
-; GFX12-GI-NEXT:    s_lshr_b32 s5, s1, 16
-; GFX12-GI-NEXT:    s_lshr_b32 s6, s2, 16
-; GFX12-GI-NEXT:    s_lshr_b32 s7, s3, 16
-; GFX12-GI-NEXT:    s_cvt_f32_f16 s0, s0
-; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX12-GI-NEXT:    s_cvt_f32_f16 s4, s4
-; GFX12-GI-NEXT:    s_cvt_f32_f16 s1, s1
-; GFX12-GI-NEXT:    s_cvt_f32_f16 s5, s5
-; GFX12-GI-NEXT:    s_cvt_f32_f16 s2, s2
-; GFX12-GI-NEXT:    s_cvt_f32_f16 s6, s6
-; GFX12-GI-NEXT:    s_cvt_f32_f16 s3, s3
-; GFX12-GI-NEXT:    s_cvt_f32_f16 s7, s7
-; GFX12-GI-NEXT:    s_cvt_i32_f32 s0, s0
+; GFX12-GI-NEXT:    s_cvt_f32_f16 s4, s0
+; GFX12-GI-NEXT:    s_cvt_hi_f32_f16 s0, s0
+; GFX12-GI-NEXT:    s_cvt_f32_f16 s5, s1
+; GFX12-GI-NEXT:    s_cvt_hi_f32_f16 s1, s1
+; GFX12-GI-NEXT:    s_cvt_f32_f16 s6, s2
+; GFX12-GI-NEXT:    s_cvt_hi_f32_f16 s2, s2
+; GFX12-GI-NEXT:    s_cvt_f32_f16 s7, s3
+; GFX12-GI-NEXT:    s_cvt_hi_f32_f16 s3, s3
 ; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
 ; GFX12-GI-NEXT:    s_cvt_i32_f32 s4, s4
-; GFX12-GI-NEXT:    s_cvt_i32_f32 s1, s1
+; GFX12-GI-NEXT:    s_cvt_i32_f32 s0, s0
 ; GFX12-GI-NEXT:    s_cvt_i32_f32 s5, s5
-; GFX12-GI-NEXT:    s_cvt_i32_f32 s2, s2
+; GFX12-GI-NEXT:    s_cvt_i32_f32 s1, s1
 ; GFX12-GI-NEXT:    s_cvt_i32_f32 s6, s6
-; GFX12-GI-NEXT:    s_cvt_i32_f32 s3, s3
+; GFX12-GI-NEXT:    s_cvt_i32_f32 s2, s2
 ; GFX12-GI-NEXT:    s_cvt_i32_f32 s7, s7
-; GFX12-GI-NEXT:    s_min_i32 s0, s0, 0x7f
+; GFX12-GI-NEXT:    s_cvt_i32_f32 s3, s3
 ; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
 ; GFX12-GI-NEXT:    s_min_i32 s4, s4, 0x7f
-; GFX12-GI-NEXT:    s_min_i32 s1, s1, 0x7f
+; GFX12-GI-NEXT:    s_min_i32 s0, s0, 0x7f
 ; GFX12-GI-NEXT:    s_min_i32 s5, s5, 0x7f
-; GFX12-GI-NEXT:    s_min_i32 s2, s2, 0x7f
+; GFX12-GI-NEXT:    s_min_i32 s1, s1, 0x7f
 ; GFX12-GI-NEXT:    s_min_i32 s6, s6, 0x7f
-; GFX12-GI-NEXT:    s_min_i32 s3, s3, 0x7f
+; GFX12-GI-NEXT:    s_min_i32 s2, s2, 0x7f
 ; GFX12-GI-NEXT:    s_min_i32 s7, s7, 0x7f
-; GFX12-GI-NEXT:    s_max_i32 s0, s0, 0xffffff80
+; GFX12-GI-NEXT:    s_min_i32 s3, s3, 0x7f
 ; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
 ; GFX12-GI-NEXT:    s_max_i32 s4, s4, 0xffffff80
-; GFX12-GI-NEXT:    s_max_i32 s1, s1, 0xffffff80
+; GFX12-GI-NEXT:    s_max_i32 s0, s0, 0xffffff80
 ; GFX12-GI-NEXT:    s_max_i32 s5, s5, 0xffffff80
-; GFX12-GI-NEXT:    s_max_i32 s2, s2, 0xffffff80
+; GFX12-GI-NEXT:    s_max_i32 s1, s1, 0xffffff80
 ; GFX12-GI-NEXT:    s_max_i32 s6, s6, 0xffffff80
-; GFX12-GI-NEXT:    s_max_i32 s3, s3, 0xffffff80
+; GFX12-GI-NEXT:    s_max_i32 s2, s2, 0xffffff80
 ; GFX12-GI-NEXT:    s_max_i32 s7, s7, 0xffffff80
+; GFX12-GI-NEXT:    s_max_i32 s3, s3, 0xffffff80
 ; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX12-GI-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s4
-; GFX12-GI-NEXT:    v_dual_mov_b32 v2, s1 :: v_dual_mov_b32 v3, s5
-; GFX12-GI-NEXT:    v_dual_mov_b32 v4, s2 :: v_dual_mov_b32 v5, s6
-; GFX12-GI-NEXT:    v_dual_mov_b32 v6, s3 :: v_dual_mov_b32 v7, s7
+; GFX12-GI-NEXT:    v_dual_mov_b32 v0, s4 :: v_dual_mov_b32 v1, s0
+; GFX12-GI-NEXT:    v_dual_mov_b32 v2, s5 :: v_dual_mov_b32 v3, s1
+; GFX12-GI-NEXT:    v_dual_mov_b32 v4, s6 :: v_dual_mov_b32 v5, s2
+; GFX12-GI-NEXT:    v_dual_mov_b32 v6, s7 :: v_dual_mov_b32 v7, s3
 ; GFX12-GI-NEXT:    s_setpc_b64 s[30:31]
     %x = call <8 x i8> @llvm.fptosi.sat.v8f16.v8i8(<8 x half> %f)
     ret <8 x i8> %x
@@ -6419,37 +6400,32 @@ define <8 x i64> @test_s_signed_v8f16_v8i64(<8 x half> inreg %f) {
 ; GFX12-GI-NEXT:    s_wait_samplecnt 0x0
 ; GFX12-GI-NEXT:    s_wait_bvhcnt 0x0
 ; GFX12-GI-NEXT:    s_wait_kmcnt 0x0
-; GFX12-GI-NEXT:    s_lshr_b32 s4, s0, 16
-; GFX12-GI-NEXT:    s_lshr_b32 s5, s1, 16
-; GFX12-GI-NEXT:    s_lshr_b32 s6, s2, 16
-; GFX12-GI-NEXT:    s_lshr_b32 s7, s3, 16
-; GFX12-GI-NEXT:    s_cvt_f32_f16 s0, s0
-; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX12-GI-NEXT:    s_cvt_f32_f16 s4, s4
-; GFX12-GI-NEXT:    s_cvt_f32_f16 s1, s1
-; GFX12-GI-NEXT:    s_cvt_f32_f16 s5, s5
-; GFX12-GI-NEXT:    s_cvt_f32_f16 s2, s2
-; GFX12-GI-NEXT:    s_cvt_f32_f16 s6, s6
-; GFX12-GI-NEXT:    s_cvt_f32_f16 s3, s3
-; GFX12-GI-NEXT:    s_cvt_f32_f16 s7, s7
-; GFX12-GI-NEXT:    s_cvt_i32_f32 s0, s0
+; GFX12-GI-NEXT:    s_cvt_f32_f16 s4, s0
+; GFX12-GI-NEXT:    s_cvt_hi_f32_f16 s0, s0
+; GFX12-GI-NEXT:    s_cvt_f32_f16 s5, s1
+; GFX12-GI-NEXT:    s_cvt_hi_f32_f16 s1, s1
+; GFX12-GI-NEXT:    s_cvt_f32_f16 s6, s2
+; GFX12-GI-NEXT:    s_cvt_hi_f32_f16 s2, s2
+; GFX12-GI-NEXT:    s_cvt_f32_f16 s7, s3
+; GFX12-GI-NEXT:    s_cvt_hi_f32_f16 s3, s3
 ; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
 ; GFX12-GI-NEXT:    s_cvt_i32_f32 s4, s4
-; GFX12-GI-NEXT:    s_cvt_i32_f32 s1, s1
+; GFX12-GI-NEXT:    s_cvt_i32_f32 s0, s0
 ; GFX12-GI-NEXT:    s_cvt_i32_f32 s5, s5
-; GFX12-GI-NEXT:    s_cvt_i32_f32 s2, s2
+; GFX12-GI-NEXT:    s_cvt_i32_f32 s1, s1
 ; GFX12-GI-NEXT:    s_cvt_i32_f32 s6, s6
-; GFX12-GI-NEXT:    s_cvt_i32_f32 s3, s3
+; GFX12-GI-NEXT:    s_cvt_i32_f32 s2, s2
 ; GFX12-GI-NEXT:    s_cvt_i32_f32 s7, s7
-; GFX12-GI-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, 0
+; GFX12-GI-NEXT:    s_cvt_i32_f32 s3, s3
 ; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX12-GI-NEXT:    v_dual_mov_b32 v2, s4 :: v_dual_mov_b32 v3, 0
-; GFX12-GI-NEXT:    v_dual_mov_b32 v4, s1 :: v_dual_mov_b32 v5, 0
-; GFX12-GI-NEXT:    v_dual_mov_b32 v6, s5 :: v_dual_mov_b32 v7, 0
-; GFX12-GI-NEXT:    v_dual_mov_b32 v8, s2 :: v_dual_mov_b32 v9, 0
-; GFX12-GI-NEXT:    v_dual_mov_b32 v10, s6 :: v_dual_mov_b32 v11, 0
-; GFX12-GI-NEXT:    v_dual_mov_b32 v12, s3 :: v_dual_mov_b32 v13, 0
-; GFX12-GI-NEXT:    v_dual_mov_b32 v14, s7 :: v_dual_mov_b32 v15, 0
+; GFX12-GI-NEXT:    v_dual_mov_b32 v0, s4 :: v_dual_mov_b32 v1, 0
+; GFX12-GI-NEXT:    v_dual_mov_b32 v2, s0 :: v_dual_mov_b32 v3, 0
+; GFX12-GI-NEXT:    v_dual_mov_b32 v4, s5 :: v_dual_mov_b32 v5, 0
+; GFX12-GI-NEXT:    v_dual_mov_b32 v6, s1 :: v_dual_mov_b32 v7, 0
+; GFX12-GI-NEXT:    v_dual_mov_b32 v8, s6 :: v_dual_mov_b32 v9, 0
+; GFX12-GI-NEXT:    v_dual_mov_b32 v10, s2 :: v_dual_mov_b32 v11, 0
+; GFX12-GI-NEXT:    v_dual_mov_b32 v12, s7 :: v_dual_mov_b32 v13, 0
+; GFX12-GI-NEXT:    v_dual_mov_b32 v14, s3 :: v_dual_mov_b32 v15, 0
 ; GFX12-GI-NEXT:    s_setpc_b64 s[30:31]
     %x = call <8 x i64> @llvm.fptosi.sat.v8f16.v8i64(<8 x half> %f)
     ret <8 x i64> %x

--- a/llvm/test/CodeGen/AMDGPU/fptoui-sat-vector.ll
+++ b/llvm/test/CodeGen/AMDGPU/fptoui-sat-vector.ll
@@ -3117,26 +3117,23 @@ define <4 x i1> @test_s_unsigned_v4f16_v4i1(<4 x half> inreg %f) {
 ; GFX12-GI-NEXT:    s_wait_samplecnt 0x0
 ; GFX12-GI-NEXT:    s_wait_bvhcnt 0x0
 ; GFX12-GI-NEXT:    s_wait_kmcnt 0x0
-; GFX12-GI-NEXT:    s_lshr_b32 s2, s0, 16
-; GFX12-GI-NEXT:    s_lshr_b32 s3, s1, 16
-; GFX12-GI-NEXT:    s_cvt_f32_f16 s0, s0
-; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX12-GI-NEXT:    s_cvt_f32_f16 s2, s2
-; GFX12-GI-NEXT:    s_cvt_f32_f16 s1, s1
-; GFX12-GI-NEXT:    s_cvt_f32_f16 s3, s3
-; GFX12-GI-NEXT:    s_cvt_u32_f32 s0, s0
+; GFX12-GI-NEXT:    s_cvt_f32_f16 s2, s0
+; GFX12-GI-NEXT:    s_cvt_hi_f32_f16 s0, s0
+; GFX12-GI-NEXT:    s_cvt_f32_f16 s3, s1
+; GFX12-GI-NEXT:    s_cvt_hi_f32_f16 s1, s1
 ; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
 ; GFX12-GI-NEXT:    s_cvt_u32_f32 s2, s2
-; GFX12-GI-NEXT:    s_cvt_u32_f32 s1, s1
+; GFX12-GI-NEXT:    s_cvt_u32_f32 s0, s0
 ; GFX12-GI-NEXT:    s_cvt_u32_f32 s3, s3
-; GFX12-GI-NEXT:    s_min_u32 s0, s0, 1
+; GFX12-GI-NEXT:    s_cvt_u32_f32 s1, s1
 ; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
 ; GFX12-GI-NEXT:    s_min_u32 s2, s2, 1
-; GFX12-GI-NEXT:    s_min_u32 s1, s1, 1
+; GFX12-GI-NEXT:    s_min_u32 s0, s0, 1
 ; GFX12-GI-NEXT:    s_min_u32 s3, s3, 1
+; GFX12-GI-NEXT:    s_min_u32 s1, s1, 1
 ; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX12-GI-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s2
-; GFX12-GI-NEXT:    v_dual_mov_b32 v2, s1 :: v_dual_mov_b32 v3, s3
+; GFX12-GI-NEXT:    v_dual_mov_b32 v0, s2 :: v_dual_mov_b32 v1, s0
+; GFX12-GI-NEXT:    v_dual_mov_b32 v2, s3 :: v_dual_mov_b32 v3, s1
 ; GFX12-GI-NEXT:    s_setpc_b64 s[30:31]
     %x = call <4 x i1> @llvm.fptoui.sat.v4f16.v4i1(<4 x half> %f)
     ret <4 x i1> %x
@@ -3340,26 +3337,23 @@ define <4 x i8> @test_s_unsigned_v4f16_v4i8(<4 x half> inreg %f) {
 ; GFX12-GI-NEXT:    s_wait_samplecnt 0x0
 ; GFX12-GI-NEXT:    s_wait_bvhcnt 0x0
 ; GFX12-GI-NEXT:    s_wait_kmcnt 0x0
-; GFX12-GI-NEXT:    s_lshr_b32 s2, s0, 16
-; GFX12-GI-NEXT:    s_lshr_b32 s3, s1, 16
-; GFX12-GI-NEXT:    s_cvt_f32_f16 s0, s0
-; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX12-GI-NEXT:    s_cvt_f32_f16 s2, s2
-; GFX12-GI-NEXT:    s_cvt_f32_f16 s1, s1
-; GFX12-GI-NEXT:    s_cvt_f32_f16 s3, s3
-; GFX12-GI-NEXT:    s_cvt_u32_f32 s0, s0
+; GFX12-GI-NEXT:    s_cvt_f32_f16 s2, s0
+; GFX12-GI-NEXT:    s_cvt_hi_f32_f16 s0, s0
+; GFX12-GI-NEXT:    s_cvt_f32_f16 s3, s1
+; GFX12-GI-NEXT:    s_cvt_hi_f32_f16 s1, s1
 ; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
 ; GFX12-GI-NEXT:    s_cvt_u32_f32 s2, s2
-; GFX12-GI-NEXT:    s_cvt_u32_f32 s1, s1
+; GFX12-GI-NEXT:    s_cvt_u32_f32 s0, s0
 ; GFX12-GI-NEXT:    s_cvt_u32_f32 s3, s3
-; GFX12-GI-NEXT:    s_min_u32 s0, s0, 0xff
+; GFX12-GI-NEXT:    s_cvt_u32_f32 s1, s1
 ; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
 ; GFX12-GI-NEXT:    s_min_u32 s2, s2, 0xff
-; GFX12-GI-NEXT:    s_min_u32 s1, s1, 0xff
+; GFX12-GI-NEXT:    s_min_u32 s0, s0, 0xff
 ; GFX12-GI-NEXT:    s_min_u32 s3, s3, 0xff
+; GFX12-GI-NEXT:    s_min_u32 s1, s1, 0xff
 ; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX12-GI-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s2
-; GFX12-GI-NEXT:    v_dual_mov_b32 v2, s1 :: v_dual_mov_b32 v3, s3
+; GFX12-GI-NEXT:    v_dual_mov_b32 v0, s2 :: v_dual_mov_b32 v1, s0
+; GFX12-GI-NEXT:    v_dual_mov_b32 v2, s3 :: v_dual_mov_b32 v3, s1
 ; GFX12-GI-NEXT:    s_setpc_b64 s[30:31]
     %x = call <4 x i8> @llvm.fptoui.sat.v4f16.v4i8(<4 x half> %f)
     ret <4 x i8> %x
@@ -3615,23 +3609,20 @@ define <4 x i64> @test_s_unsigned_v4f16_v4i64(<4 x half> inreg %f) {
 ; GFX12-GI-NEXT:    s_wait_samplecnt 0x0
 ; GFX12-GI-NEXT:    s_wait_bvhcnt 0x0
 ; GFX12-GI-NEXT:    s_wait_kmcnt 0x0
-; GFX12-GI-NEXT:    s_lshr_b32 s2, s0, 16
-; GFX12-GI-NEXT:    s_lshr_b32 s3, s1, 16
-; GFX12-GI-NEXT:    s_cvt_f32_f16 s0, s0
-; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX12-GI-NEXT:    s_cvt_f32_f16 s2, s2
-; GFX12-GI-NEXT:    s_cvt_f32_f16 s1, s1
-; GFX12-GI-NEXT:    s_cvt_f32_f16 s3, s3
-; GFX12-GI-NEXT:    s_cvt_u32_f32 s0, s0
+; GFX12-GI-NEXT:    s_cvt_f32_f16 s2, s0
+; GFX12-GI-NEXT:    s_cvt_hi_f32_f16 s0, s0
+; GFX12-GI-NEXT:    s_cvt_f32_f16 s3, s1
+; GFX12-GI-NEXT:    s_cvt_hi_f32_f16 s1, s1
 ; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
 ; GFX12-GI-NEXT:    s_cvt_u32_f32 s2, s2
-; GFX12-GI-NEXT:    s_cvt_u32_f32 s1, s1
+; GFX12-GI-NEXT:    s_cvt_u32_f32 s0, s0
 ; GFX12-GI-NEXT:    s_cvt_u32_f32 s3, s3
-; GFX12-GI-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, 0
+; GFX12-GI-NEXT:    s_cvt_u32_f32 s1, s1
 ; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX12-GI-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, 0
-; GFX12-GI-NEXT:    v_dual_mov_b32 v4, s1 :: v_dual_mov_b32 v5, 0
-; GFX12-GI-NEXT:    v_dual_mov_b32 v6, s3 :: v_dual_mov_b32 v7, 0
+; GFX12-GI-NEXT:    v_dual_mov_b32 v0, s2 :: v_dual_mov_b32 v1, 0
+; GFX12-GI-NEXT:    v_dual_mov_b32 v2, s0 :: v_dual_mov_b32 v3, 0
+; GFX12-GI-NEXT:    v_dual_mov_b32 v4, s3 :: v_dual_mov_b32 v5, 0
+; GFX12-GI-NEXT:    v_dual_mov_b32 v6, s1 :: v_dual_mov_b32 v7, 0
 ; GFX12-GI-NEXT:    s_setpc_b64 s[30:31]
     %x = call <4 x i64> @llvm.fptoui.sat.v4f16.v4i64(<4 x half> %f)
     ret <4 x i64> %x
@@ -5135,42 +5126,37 @@ define <8 x i1> @test_s_unsigned_v8f16_v8i1(<8 x half> inreg %f) {
 ; GFX12-GI-NEXT:    s_wait_samplecnt 0x0
 ; GFX12-GI-NEXT:    s_wait_bvhcnt 0x0
 ; GFX12-GI-NEXT:    s_wait_kmcnt 0x0
-; GFX12-GI-NEXT:    s_lshr_b32 s4, s0, 16
-; GFX12-GI-NEXT:    s_lshr_b32 s5, s1, 16
-; GFX12-GI-NEXT:    s_lshr_b32 s6, s2, 16
-; GFX12-GI-NEXT:    s_lshr_b32 s7, s3, 16
-; GFX12-GI-NEXT:    s_cvt_f32_f16 s0, s0
-; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX12-GI-NEXT:    s_cvt_f32_f16 s4, s4
-; GFX12-GI-NEXT:    s_cvt_f32_f16 s1, s1
-; GFX12-GI-NEXT:    s_cvt_f32_f16 s5, s5
-; GFX12-GI-NEXT:    s_cvt_f32_f16 s2, s2
-; GFX12-GI-NEXT:    s_cvt_f32_f16 s6, s6
-; GFX12-GI-NEXT:    s_cvt_f32_f16 s3, s3
-; GFX12-GI-NEXT:    s_cvt_f32_f16 s7, s7
-; GFX12-GI-NEXT:    s_cvt_u32_f32 s0, s0
+; GFX12-GI-NEXT:    s_cvt_f32_f16 s4, s0
+; GFX12-GI-NEXT:    s_cvt_hi_f32_f16 s0, s0
+; GFX12-GI-NEXT:    s_cvt_f32_f16 s5, s1
+; GFX12-GI-NEXT:    s_cvt_hi_f32_f16 s1, s1
+; GFX12-GI-NEXT:    s_cvt_f32_f16 s6, s2
+; GFX12-GI-NEXT:    s_cvt_hi_f32_f16 s2, s2
+; GFX12-GI-NEXT:    s_cvt_f32_f16 s7, s3
+; GFX12-GI-NEXT:    s_cvt_hi_f32_f16 s3, s3
 ; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
 ; GFX12-GI-NEXT:    s_cvt_u32_f32 s4, s4
-; GFX12-GI-NEXT:    s_cvt_u32_f32 s1, s1
+; GFX12-GI-NEXT:    s_cvt_u32_f32 s0, s0
 ; GFX12-GI-NEXT:    s_cvt_u32_f32 s5, s5
-; GFX12-GI-NEXT:    s_cvt_u32_f32 s2, s2
+; GFX12-GI-NEXT:    s_cvt_u32_f32 s1, s1
 ; GFX12-GI-NEXT:    s_cvt_u32_f32 s6, s6
-; GFX12-GI-NEXT:    s_cvt_u32_f32 s3, s3
+; GFX12-GI-NEXT:    s_cvt_u32_f32 s2, s2
 ; GFX12-GI-NEXT:    s_cvt_u32_f32 s7, s7
-; GFX12-GI-NEXT:    s_min_u32 s0, s0, 1
+; GFX12-GI-NEXT:    s_cvt_u32_f32 s3, s3
 ; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
 ; GFX12-GI-NEXT:    s_min_u32 s4, s4, 1
-; GFX12-GI-NEXT:    s_min_u32 s1, s1, 1
+; GFX12-GI-NEXT:    s_min_u32 s0, s0, 1
 ; GFX12-GI-NEXT:    s_min_u32 s5, s5, 1
-; GFX12-GI-NEXT:    s_min_u32 s2, s2, 1
+; GFX12-GI-NEXT:    s_min_u32 s1, s1, 1
 ; GFX12-GI-NEXT:    s_min_u32 s6, s6, 1
-; GFX12-GI-NEXT:    s_min_u32 s3, s3, 1
+; GFX12-GI-NEXT:    s_min_u32 s2, s2, 1
 ; GFX12-GI-NEXT:    s_min_u32 s7, s7, 1
+; GFX12-GI-NEXT:    s_min_u32 s3, s3, 1
 ; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX12-GI-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s4
-; GFX12-GI-NEXT:    v_dual_mov_b32 v2, s1 :: v_dual_mov_b32 v3, s5
-; GFX12-GI-NEXT:    v_dual_mov_b32 v4, s2 :: v_dual_mov_b32 v5, s6
-; GFX12-GI-NEXT:    v_dual_mov_b32 v6, s3 :: v_dual_mov_b32 v7, s7
+; GFX12-GI-NEXT:    v_dual_mov_b32 v0, s4 :: v_dual_mov_b32 v1, s0
+; GFX12-GI-NEXT:    v_dual_mov_b32 v2, s5 :: v_dual_mov_b32 v3, s1
+; GFX12-GI-NEXT:    v_dual_mov_b32 v4, s6 :: v_dual_mov_b32 v5, s2
+; GFX12-GI-NEXT:    v_dual_mov_b32 v6, s7 :: v_dual_mov_b32 v7, s3
 ; GFX12-GI-NEXT:    s_setpc_b64 s[30:31]
     %x = call <8 x i1> @llvm.fptoui.sat.v8f16.v8i1(<8 x half> %f)
     ret <8 x i1> %x
@@ -5528,42 +5514,37 @@ define <8 x i8> @test_s_unsigned_v8f16_v8i8(<8 x half> inreg %f) {
 ; GFX12-GI-NEXT:    s_wait_samplecnt 0x0
 ; GFX12-GI-NEXT:    s_wait_bvhcnt 0x0
 ; GFX12-GI-NEXT:    s_wait_kmcnt 0x0
-; GFX12-GI-NEXT:    s_lshr_b32 s4, s0, 16
-; GFX12-GI-NEXT:    s_lshr_b32 s5, s1, 16
-; GFX12-GI-NEXT:    s_lshr_b32 s6, s2, 16
-; GFX12-GI-NEXT:    s_lshr_b32 s7, s3, 16
-; GFX12-GI-NEXT:    s_cvt_f32_f16 s0, s0
-; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX12-GI-NEXT:    s_cvt_f32_f16 s4, s4
-; GFX12-GI-NEXT:    s_cvt_f32_f16 s1, s1
-; GFX12-GI-NEXT:    s_cvt_f32_f16 s5, s5
-; GFX12-GI-NEXT:    s_cvt_f32_f16 s2, s2
-; GFX12-GI-NEXT:    s_cvt_f32_f16 s6, s6
-; GFX12-GI-NEXT:    s_cvt_f32_f16 s3, s3
-; GFX12-GI-NEXT:    s_cvt_f32_f16 s7, s7
-; GFX12-GI-NEXT:    s_cvt_u32_f32 s0, s0
+; GFX12-GI-NEXT:    s_cvt_f32_f16 s4, s0
+; GFX12-GI-NEXT:    s_cvt_hi_f32_f16 s0, s0
+; GFX12-GI-NEXT:    s_cvt_f32_f16 s5, s1
+; GFX12-GI-NEXT:    s_cvt_hi_f32_f16 s1, s1
+; GFX12-GI-NEXT:    s_cvt_f32_f16 s6, s2
+; GFX12-GI-NEXT:    s_cvt_hi_f32_f16 s2, s2
+; GFX12-GI-NEXT:    s_cvt_f32_f16 s7, s3
+; GFX12-GI-NEXT:    s_cvt_hi_f32_f16 s3, s3
 ; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
 ; GFX12-GI-NEXT:    s_cvt_u32_f32 s4, s4
-; GFX12-GI-NEXT:    s_cvt_u32_f32 s1, s1
+; GFX12-GI-NEXT:    s_cvt_u32_f32 s0, s0
 ; GFX12-GI-NEXT:    s_cvt_u32_f32 s5, s5
-; GFX12-GI-NEXT:    s_cvt_u32_f32 s2, s2
+; GFX12-GI-NEXT:    s_cvt_u32_f32 s1, s1
 ; GFX12-GI-NEXT:    s_cvt_u32_f32 s6, s6
-; GFX12-GI-NEXT:    s_cvt_u32_f32 s3, s3
+; GFX12-GI-NEXT:    s_cvt_u32_f32 s2, s2
 ; GFX12-GI-NEXT:    s_cvt_u32_f32 s7, s7
-; GFX12-GI-NEXT:    s_min_u32 s0, s0, 0xff
+; GFX12-GI-NEXT:    s_cvt_u32_f32 s3, s3
 ; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
 ; GFX12-GI-NEXT:    s_min_u32 s4, s4, 0xff
-; GFX12-GI-NEXT:    s_min_u32 s1, s1, 0xff
+; GFX12-GI-NEXT:    s_min_u32 s0, s0, 0xff
 ; GFX12-GI-NEXT:    s_min_u32 s5, s5, 0xff
-; GFX12-GI-NEXT:    s_min_u32 s2, s2, 0xff
+; GFX12-GI-NEXT:    s_min_u32 s1, s1, 0xff
 ; GFX12-GI-NEXT:    s_min_u32 s6, s6, 0xff
-; GFX12-GI-NEXT:    s_min_u32 s3, s3, 0xff
+; GFX12-GI-NEXT:    s_min_u32 s2, s2, 0xff
 ; GFX12-GI-NEXT:    s_min_u32 s7, s7, 0xff
+; GFX12-GI-NEXT:    s_min_u32 s3, s3, 0xff
 ; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX12-GI-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s4
-; GFX12-GI-NEXT:    v_dual_mov_b32 v2, s1 :: v_dual_mov_b32 v3, s5
-; GFX12-GI-NEXT:    v_dual_mov_b32 v4, s2 :: v_dual_mov_b32 v5, s6
-; GFX12-GI-NEXT:    v_dual_mov_b32 v6, s3 :: v_dual_mov_b32 v7, s7
+; GFX12-GI-NEXT:    v_dual_mov_b32 v0, s4 :: v_dual_mov_b32 v1, s0
+; GFX12-GI-NEXT:    v_dual_mov_b32 v2, s5 :: v_dual_mov_b32 v3, s1
+; GFX12-GI-NEXT:    v_dual_mov_b32 v4, s6 :: v_dual_mov_b32 v5, s2
+; GFX12-GI-NEXT:    v_dual_mov_b32 v6, s7 :: v_dual_mov_b32 v7, s3
 ; GFX12-GI-NEXT:    s_setpc_b64 s[30:31]
     %x = call <8 x i8> @llvm.fptoui.sat.v8f16.v8i8(<8 x half> %f)
     ret <8 x i8> %x
@@ -5974,37 +5955,32 @@ define <8 x i64> @test_s_unsigned_v8f16_v8i64(<8 x half> inreg %f) {
 ; GFX12-GI-NEXT:    s_wait_samplecnt 0x0
 ; GFX12-GI-NEXT:    s_wait_bvhcnt 0x0
 ; GFX12-GI-NEXT:    s_wait_kmcnt 0x0
-; GFX12-GI-NEXT:    s_lshr_b32 s4, s0, 16
-; GFX12-GI-NEXT:    s_lshr_b32 s5, s1, 16
-; GFX12-GI-NEXT:    s_lshr_b32 s6, s2, 16
-; GFX12-GI-NEXT:    s_lshr_b32 s7, s3, 16
-; GFX12-GI-NEXT:    s_cvt_f32_f16 s0, s0
-; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX12-GI-NEXT:    s_cvt_f32_f16 s4, s4
-; GFX12-GI-NEXT:    s_cvt_f32_f16 s1, s1
-; GFX12-GI-NEXT:    s_cvt_f32_f16 s5, s5
-; GFX12-GI-NEXT:    s_cvt_f32_f16 s2, s2
-; GFX12-GI-NEXT:    s_cvt_f32_f16 s6, s6
-; GFX12-GI-NEXT:    s_cvt_f32_f16 s3, s3
-; GFX12-GI-NEXT:    s_cvt_f32_f16 s7, s7
-; GFX12-GI-NEXT:    s_cvt_u32_f32 s0, s0
+; GFX12-GI-NEXT:    s_cvt_f32_f16 s4, s0
+; GFX12-GI-NEXT:    s_cvt_hi_f32_f16 s0, s0
+; GFX12-GI-NEXT:    s_cvt_f32_f16 s5, s1
+; GFX12-GI-NEXT:    s_cvt_hi_f32_f16 s1, s1
+; GFX12-GI-NEXT:    s_cvt_f32_f16 s6, s2
+; GFX12-GI-NEXT:    s_cvt_hi_f32_f16 s2, s2
+; GFX12-GI-NEXT:    s_cvt_f32_f16 s7, s3
+; GFX12-GI-NEXT:    s_cvt_hi_f32_f16 s3, s3
 ; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
 ; GFX12-GI-NEXT:    s_cvt_u32_f32 s4, s4
-; GFX12-GI-NEXT:    s_cvt_u32_f32 s1, s1
+; GFX12-GI-NEXT:    s_cvt_u32_f32 s0, s0
 ; GFX12-GI-NEXT:    s_cvt_u32_f32 s5, s5
-; GFX12-GI-NEXT:    s_cvt_u32_f32 s2, s2
+; GFX12-GI-NEXT:    s_cvt_u32_f32 s1, s1
 ; GFX12-GI-NEXT:    s_cvt_u32_f32 s6, s6
-; GFX12-GI-NEXT:    s_cvt_u32_f32 s3, s3
+; GFX12-GI-NEXT:    s_cvt_u32_f32 s2, s2
 ; GFX12-GI-NEXT:    s_cvt_u32_f32 s7, s7
-; GFX12-GI-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, 0
+; GFX12-GI-NEXT:    s_cvt_u32_f32 s3, s3
 ; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX12-GI-NEXT:    v_dual_mov_b32 v2, s4 :: v_dual_mov_b32 v3, 0
-; GFX12-GI-NEXT:    v_dual_mov_b32 v4, s1 :: v_dual_mov_b32 v5, 0
-; GFX12-GI-NEXT:    v_dual_mov_b32 v6, s5 :: v_dual_mov_b32 v7, 0
-; GFX12-GI-NEXT:    v_dual_mov_b32 v8, s2 :: v_dual_mov_b32 v9, 0
-; GFX12-GI-NEXT:    v_dual_mov_b32 v10, s6 :: v_dual_mov_b32 v11, 0
-; GFX12-GI-NEXT:    v_dual_mov_b32 v12, s3 :: v_dual_mov_b32 v13, 0
-; GFX12-GI-NEXT:    v_dual_mov_b32 v14, s7 :: v_dual_mov_b32 v15, 0
+; GFX12-GI-NEXT:    v_dual_mov_b32 v0, s4 :: v_dual_mov_b32 v1, 0
+; GFX12-GI-NEXT:    v_dual_mov_b32 v2, s0 :: v_dual_mov_b32 v3, 0
+; GFX12-GI-NEXT:    v_dual_mov_b32 v4, s5 :: v_dual_mov_b32 v5, 0
+; GFX12-GI-NEXT:    v_dual_mov_b32 v6, s1 :: v_dual_mov_b32 v7, 0
+; GFX12-GI-NEXT:    v_dual_mov_b32 v8, s6 :: v_dual_mov_b32 v9, 0
+; GFX12-GI-NEXT:    v_dual_mov_b32 v10, s2 :: v_dual_mov_b32 v11, 0
+; GFX12-GI-NEXT:    v_dual_mov_b32 v12, s7 :: v_dual_mov_b32 v13, 0
+; GFX12-GI-NEXT:    v_dual_mov_b32 v14, s3 :: v_dual_mov_b32 v15, 0
 ; GFX12-GI-NEXT:    s_setpc_b64 s[30:31]
     %x = call <8 x i64> @llvm.fptoui.sat.v8f16.v8i64(<8 x half> %f)
     ret <8 x i64> %x


### PR DESCRIPTION
This allows to detect when G_UNMERGE_VALUES extracts a hi16 element and select `s_cvt_hi_f32_f16` removing need for a shift.

---

(old description for context, will be removed form the final commit message)

Without the change the redundant copy elimination at the end of instruction selection treats copies, generated from `G_UNMERGE_VALYES`, from higher and lower bits as the same instruction, resulting in extraction of higher 16 bits being ignored.

Code before instruction selection:

```
bb.1 (%ir-block.0):
  liveins: $sgpr0, $sgpr1
  %9:sgpr(<2 x s16>) = COPY $sgpr0
  %24:sgpr(s16), %25:sgpr(s16) = G_UNMERGE_VALUES %9:sgpr(<2 x s16>)
  %42:sgpr(s32) = G_FPEXT %24:sgpr(s16)
  %39:sgpr(s32) = G_FPEXT %25:sgpr(s16)
  ...
```

Code after instruction selection but before redundant copies are removed:

```
bb.1 (%ir-block.0):
  liveins: $sgpr0, $sgpr1
  %9:sreg_32(<2 x s16>) = COPY $sgpr0
  %24:sreg_32(s16) = COPY %9.lo16:sreg_32(<2 x s16>)
  %25:sreg_32(s16) = COPY %9.hi16:sreg_32(<2 x s16>)
  %42:sreg_32(s32) = nofpexcept S_CVT_F32_F16 %24:sreg_32(s16), implicit $mode
  %39:sreg_32(s32) = nofpexcept S_CVT_F32_F16 %25:sreg_32(s16), implicit $mode
  ...
```

Final code after instruction selection (note: the first convert should read lower bits and the second one higher, but they both reference `%9`):

```
bb.1 (%ir-block.0):
  liveins: $sgpr0, $sgpr1
  %9:sreg_32 = COPY $sgpr0
  %42:sreg_32 = nofpexcept S_CVT_F32_F16 %9:sreg_32, implicit $mode
  %39:sreg_32 = nofpexcept S_CVT_F32_F16 %9:sreg_32, implicit $mode
  ...
```

With the fix `S_CVT_HI` is being used:

```
bb.1 (%ir-block.0):
  liveins: $sgpr0, $sgpr1
  %9:sreg_32 = COPY $sgpr0
  %42:sreg_32 = nofpexcept S_CVT_F32_F16 %9:sreg_32, implicit $mode
  %39:sreg_32 = S_CVT_HI_F32_F16 %9:sreg_32, implicit $mode
```

This addresses a bug found in #188019.