### PR TITLE
[CodeView] Expose fallible type accessors in TpiStream

### DIFF
--- a/llvm/include/llvm/DebugInfo/CodeView/LazyRandomTypeCollection.h
+++ b/llvm/include/llvm/DebugInfo/CodeView/LazyRandomTypeCollection.h
@@ -72,6 +72,7 @@ public:
   std::optional<CVType> tryGetType(TypeIndex Index);
   llvm::Expected<CVType> getTypeOrError(TypeIndex Index);
   CVType getType(TypeIndex Index) override;
+
   StringRef getTypeName(TypeIndex Index) override;
   bool contains(TypeIndex Index) override;
   uint32_t size() override;

--- a/llvm/include/llvm/DebugInfo/PDB/Native/TpiStream.h
+++ b/llvm/include/llvm/DebugInfo/PDB/Native/TpiStream.h
@@ -67,7 +67,18 @@ public:
   LLVM_ABI std::vector<codeview::TypeIndex>
   findRecordsByName(StringRef Name) const;
 
+  /// Get a type by its index. \p Index must be a valid type index.
   LLVM_ABI codeview::CVType getType(codeview::TypeIndex Index);
+
+  /// The same as getType() except that the return value is defined
+  /// (empty/invalid) if \p Index doesn't exist. Use codeview::CVType::valid()
+  /// to check the return value.
+  LLVM_ABI codeview::CVType getTypeOrEmpty(codeview::TypeIndex Index);
+
+  LLVM_ABI std::optional<codeview::CVType>
+  tryGetType(codeview::TypeIndex Index);
+
+  LLVM_ABI Expected<codeview::CVType> getTypeOrError(codeview::TypeIndex Index);
 
   LLVM_ABI BinarySubstreamRef getTypeRecordsSubstream() const;
 

--- a/llvm/include/llvm/DebugInfo/PDB/Native/TpiStream.h
+++ b/llvm/include/llvm/DebugInfo/PDB/Native/TpiStream.h
@@ -68,6 +68,7 @@ public:
   findRecordsByName(StringRef Name) const;
 
   /// Get a type by its index. \p Index must be a valid type index.
+  /// Otherwise, this method asserts in Debug mode.
   LLVM_ABI codeview::CVType getType(codeview::TypeIndex Index);
 
   /// The same as getType() except that the return value is defined
@@ -75,9 +76,11 @@ public:
   /// to check the return value.
   LLVM_ABI codeview::CVType getTypeOrEmpty(codeview::TypeIndex Index);
 
+  /// Get the type at \p Index if it exists or \c std::nullopt otherwise.
   LLVM_ABI std::optional<codeview::CVType>
   tryGetType(codeview::TypeIndex Index);
 
+  /// Get the type at \p Index if it exists or an error about the failure.
   LLVM_ABI Expected<codeview::CVType> getTypeOrError(codeview::TypeIndex Index);
 
   LLVM_ABI BinarySubstreamRef getTypeRecordsSubstream() const;

--- a/llvm/lib/DebugInfo/CodeView/LazyRandomTypeCollection.cpp
+++ b/llvm/lib/DebugInfo/CodeView/LazyRandomTypeCollection.cpp
@@ -87,7 +87,11 @@ CVType LazyRandomTypeCollection::getType(TypeIndex Index) {
   assert(!Index.isSimple());
 
   auto EC = ensureTypeExists(Index);
-  error(std::move(EC));
+  if (EC) {
+    assert(false && "Invalid type index (use tryGetType or getTypeOrError)");
+    llvm::consumeError(std::move(EC));
+    return {};
+  }
   assert(contains(Index));
 
   return Records[Index.toArrayIndex()].Type;
@@ -98,9 +102,8 @@ LazyRandomTypeCollection::getTypeOrError(TypeIndex Index) {
   if (Index.isSimple())
     return llvm::createStringError("Type index too low (%d)", Index.getIndex());
 
-  if (auto EC = ensureTypeExists(Index)) {
+  if (auto EC = ensureTypeExists(Index))
     return EC;
-  }
 
   if (!contains(Index))
     return llvm::createStringError("Type index too high (%d)",

--- a/llvm/lib/DebugInfo/PDB/Native/TpiStream.cpp
+++ b/llvm/lib/DebugInfo/PDB/Native/TpiStream.cpp
@@ -222,6 +222,20 @@ codeview::CVType TpiStream::getType(codeview::TypeIndex Index) {
   return Types->getType(Index);
 }
 
+codeview::CVType TpiStream::getTypeOrEmpty(codeview::TypeIndex Index) {
+  return Types->tryGetType(Index).value_or({});
+}
+
+std::optional<codeview::CVType>
+TpiStream::tryGetType(codeview::TypeIndex Index) {
+  return Types->tryGetType(Index);
+}
+
+Expected<codeview::CVType>
+TpiStream::getTypeOrError(codeview::TypeIndex Index) {
+  return Types->getTypeOrError(Index);
+}
+
 BinarySubstreamRef TpiStream::getTypeRecordsSubstream() const {
   return TypeRecordsSubstream;
 }

--- a/llvm/lib/DebugInfo/PDB/Native/TpiStream.cpp
+++ b/llvm/lib/DebugInfo/PDB/Native/TpiStream.cpp
@@ -223,7 +223,7 @@ codeview::CVType TpiStream::getType(codeview::TypeIndex Index) {
 }
 
 codeview::CVType TpiStream::getTypeOrEmpty(codeview::TypeIndex Index) {
-  return Types->tryGetType(Index).value_or({});
+  return Types->tryGetType(Index).value_or<CVType>({});
 }
 
 std::optional<codeview::CVType>

--- a/llvm/unittests/DebugInfo/PDB/CMakeLists.txt
+++ b/llvm/unittests/DebugInfo/PDB/CMakeLists.txt
@@ -12,6 +12,7 @@ add_llvm_unittest_with_input_files(DebugInfoPDBTests
   PDBApiTest.cpp
   PDBVariantTest.cpp
   PublicsStreamTest.cpp
+  TpiStreamTest.cpp
   )
 
 target_link_libraries(DebugInfoPDBTests PRIVATE LLVMTestingSupport)

--- a/llvm/unittests/DebugInfo/PDB/TpiStreamTest.cpp
+++ b/llvm/unittests/DebugInfo/PDB/TpiStreamTest.cpp
@@ -1,0 +1,142 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/DebugInfo/PDB/Native/TpiStream.h"
+#include "llvm/DebugInfo/PDB/Native/NativeSession.h"
+#include "llvm/DebugInfo/PDB/Native/PDBFile.h"
+#include "llvm/DebugInfo/PDB/PDB.h"
+#include "llvm/Support/Path.h"
+
+#include "llvm/Testing/Support/Error.h"
+
+#include "gtest/gtest.h"
+
+using namespace llvm;
+using namespace llvm::pdb;
+using namespace llvm::codeview;
+
+extern const char *TestMainArgv0;
+
+// FIXME: This should use ObjectYAML to create a PDB from YAML.
+static std::string getPdbPath() {
+  SmallString<128> InputsDir = unittest::getInputFileDirectory(TestMainArgv0);
+  llvm::sys::path::append(InputsDir, "SimpleTest.pdb");
+  return std::string(InputsDir);
+}
+
+// Types:
+//  0x1000 | LF_ARGLIST [size = 8]
+//  0x1001 | LF_PROCEDURE [size = 16]
+static Expected<std::unique_ptr<PDBFile>>
+openSimplePdb(BumpPtrAllocator &Allocator) {
+  std::string PdbPath = getPdbPath();
+  ErrorOr<std::unique_ptr<MemoryBuffer>> ErrorOrBuffer =
+      MemoryBuffer::getFile(PdbPath, /*IsText=*/false,
+                            /*RequiresNullTerminator=*/false);
+  EXPECT_TRUE(ErrorOrBuffer);
+  std::unique_ptr<llvm::MemoryBuffer> Buffer = std::move(*ErrorOrBuffer);
+
+  auto Stream = std::make_unique<MemoryBufferByteStream>(
+      std::move(Buffer), llvm::endianness::little);
+
+  auto File = std::make_unique<PDBFile>(PdbPath, std::move(Stream), Allocator);
+  if (Error Err = File->parseFileHeaders())
+    return Err;
+  if (Error Err = File->parseStreamData())
+    return Err;
+  return File;
+}
+
+TEST(TpiStreamTest, getType) {
+  BumpPtrAllocator Allocator;
+  Expected<std::unique_ptr<PDBFile>> FileOrErr = openSimplePdb(Allocator);
+  ASSERT_TRUE(!!FileOrErr);
+  std::unique_ptr<PDBFile> File = std::move(*FileOrErr);
+
+  Expected<TpiStream &> Tpi = File->getPDBTpiStream();
+  ASSERT_TRUE(!!Tpi) << Tpi.takeError();
+
+  ASSERT_EQ(Tpi->getType(TypeIndex(0x1000)).kind(), LF_ARGLIST);
+  ASSERT_EQ(Tpi->getType(TypeIndex(0x1001)).kind(), LF_PROCEDURE);
+}
+
+TEST(TpiStreamTest, getTypeOrEmpty) {
+  BumpPtrAllocator Allocator;
+  Expected<std::unique_ptr<PDBFile>> FileOrErr = openSimplePdb(Allocator);
+  ASSERT_TRUE(!!FileOrErr);
+  std::unique_ptr<PDBFile> File = std::move(*FileOrErr);
+
+  Expected<TpiStream &> Tpi = File->getPDBTpiStream();
+  ASSERT_TRUE(!!Tpi);
+
+  ASSERT_FALSE(Tpi->getTypeOrEmpty(TypeIndex(0)).valid());
+  ASSERT_FALSE(Tpi->getTypeOrEmpty(TypeIndex(0xFFF)).valid());
+  ASSERT_FALSE(Tpi->getTypeOrEmpty(TypeIndex(0x1002)).valid());
+  ASSERT_FALSE(Tpi->getTypeOrEmpty(TypeIndex(0x1003)).valid());
+  ASSERT_FALSE(Tpi->getTypeOrEmpty(TypeIndex(0x1234567)).valid());
+
+  ASSERT_EQ(Tpi->getTypeOrEmpty(TypeIndex(0x1000)).kind(), LF_ARGLIST);
+  ASSERT_EQ(Tpi->getTypeOrEmpty(TypeIndex(0x1001)).kind(), LF_PROCEDURE);
+}
+
+TEST(TpiStreamTest, tryGetType) {
+  BumpPtrAllocator Allocator;
+  Expected<std::unique_ptr<PDBFile>> FileOrErr = openSimplePdb(Allocator);
+  ASSERT_TRUE(!!FileOrErr);
+  std::unique_ptr<PDBFile> File = std::move(*FileOrErr);
+
+  Expected<TpiStream &> Tpi = File->getPDBTpiStream();
+  ASSERT_TRUE(!!Tpi);
+
+  ASSERT_FALSE(Tpi->tryGetType(TypeIndex(0)).has_value());
+  ASSERT_FALSE(Tpi->tryGetType(TypeIndex(0xFFF)).has_value());
+  ASSERT_FALSE(Tpi->tryGetType(TypeIndex(0x1002)).has_value());
+  ASSERT_FALSE(Tpi->tryGetType(TypeIndex(0x1003)).has_value());
+  ASSERT_FALSE(Tpi->tryGetType(TypeIndex(0x1234567)).has_value());
+
+  std::optional<CVType> T0 = Tpi->tryGetType(TypeIndex(0x1000));
+  std::optional<CVType> T1 = Tpi->tryGetType(TypeIndex(0x1001));
+  ASSERT_TRUE(T0.has_value());
+  ASSERT_EQ(T0->kind(), LF_ARGLIST);
+  ASSERT_TRUE(T1.has_value());
+  ASSERT_EQ(T1->kind(), LF_PROCEDURE);
+}
+
+TEST(TpiStreamTest, getTypeOrErr) {
+  BumpPtrAllocator Allocator;
+  Expected<std::unique_ptr<PDBFile>> FileOrErr = openSimplePdb(Allocator);
+  ASSERT_TRUE(!!FileOrErr);
+  std::unique_ptr<PDBFile> File = std::move(*FileOrErr);
+
+  Expected<TpiStream &> Tpi = File->getPDBTpiStream();
+  ASSERT_TRUE(!!Tpi);
+
+  Expected<CVType> E0 = Tpi->getTypeOrError(TypeIndex(0));
+  ASSERT_FALSE(E0);
+  ASSERT_EQ(toString(E0.takeError()), "Type index too low (0)");
+  Expected<CVType> E1 = Tpi->getTypeOrError(TypeIndex(0xFFF));
+  ASSERT_FALSE(E1);
+  ASSERT_EQ(toString(E1.takeError()), "Type index too low (4095)");
+  Expected<CVType> E2 = Tpi->getTypeOrError(TypeIndex(0x1002));
+  ASSERT_FALSE(E2);
+  ASSERT_EQ(toString(E2.takeError()), "Type index too high (4098)");
+  Expected<CVType> E3 = Tpi->getTypeOrError(TypeIndex(0x1003));
+  ASSERT_FALSE(E3);
+  ASSERT_EQ(toString(E3.takeError()), "Invalid type index");
+  Expected<CVType> E4 = Tpi->getTypeOrError(TypeIndex(0x123456));
+  ASSERT_FALSE(E4);
+  ASSERT_EQ(toString(E4.takeError()), "Invalid type index");
+
+  Expected<CVType> T0 = Tpi->getTypeOrError(TypeIndex(0x1000));
+  ASSERT_TRUE(!!T0);
+  ASSERT_EQ(T0->kind(), LF_ARGLIST);
+
+  Expected<CVType> T1 = Tpi->getTypeOrError(TypeIndex(0x1001));
+  ASSERT_TRUE(!!T1);
+  ASSERT_EQ(T1->kind(), LF_PROCEDURE);
+}


### PR DESCRIPTION
`LazyRandomTypeCollection` already has fallible functions for `getType(TypeIndex)` this exposes them in `TpiStream` and does a mini cleanup in `LazyRandomTypeCollection`'s `GetType`.

Context: #186948 saw a crash in LLDB where we call `GetType` without checking the type index before calling the method. In `GetType` we called `error(std::move(EC))`, which ignores the error in release mode. The cause was the type index `0x80000169` in an `S_LOCAL`.

We now do a soft fail in release mode - we already check the error, so we might as well return an empty value.

Aside: The type index there feels really unusual, the type indices in other records around the `S_LOCAL` were in a similar range. Almost looks like some integer over-/underflow.