### PR TITLE
[lldb] Fix discarded return value of UpdateImageLoadAddress for commpage modules

### DIFF
--- a/lldb/source/Plugins/DynamicLoader/MacOSX-DYLD/DynamicLoaderDarwin.cpp
+++ b/lldb/source/Plugins/DynamicLoader/MacOSX-DYLD/DynamicLoaderDarwin.cpp
@@ -769,9 +769,8 @@ bool DynamicLoaderDarwin::AddModulesUsingPreloadedModules(
                   // The __LINKEDIT will need to be mapped so we can figure out
                   // where the symbol table bits are...
                   commpage_image_module_sp = *module_sp_or_err;
-                  bool changed = false;
-                  UpdateImageLoadAddress(commpage_image_module_sp.get(),
-                                         image_info);
+                  bool changed = UpdateImageLoadAddress(
+                      commpage_image_module_sp.get(), image_info);
                   target.GetImages().Append(commpage_image_module_sp);
                   if (changed) {
                     image_info.load_stop_id = m_process->GetStopID();


### PR DESCRIPTION


The return value of UpdateImageLoadAddress() was not captured in the commpage module loading path within AddModulesUsingPreloadedModules(). This meant `changed` was always false, so the commpage module was never added to loaded_module_list and ModulesDidLoad was never called for it.

Capture the return value so that when load addresses actually change, the commpage module is properly registered and downstream notifications fire.
