### PR TITLE
[InstallAPI] [Tests] Avoid checking compiler output for 'error'

### DIFF
--- a/clang/test/InstallAPI/extra-exclude-headers.test
+++ b/clang/test/InstallAPI/extra-exclude-headers.test
@@ -45,7 +45,7 @@
 ; WARNINGS: warning: no declaration was found for exported symbol '(ObjC Class) SimpleInternalSPI' in dynamic library
 ; WARNINGS: warning: no declaration was found for exported symbol '(ObjC Class) SimpleInternalAPI' in dynamic library
 
-; PEDANTIC-NOT: error
+; PEDANTIC-NOT: error:
 ; PEDANTIC: warning: cannot find protocol definition for 'ForwardProcotol'
 
 ; NOPUBLIC: error: no such public header file:

--- a/clang/test/InstallAPI/hiddens.test
+++ b/clang/test/InstallAPI/hiddens.test
@@ -11,7 +11,7 @@
 // RUN: --verify-against=%t/System/Library/Frameworks/Hidden.framework/Hidden \
 // RUN: --verify-mode=Pedantic -o %t/output.tbd 2>&1 | FileCheck %s 
 
-// CHECK-NOT: error
+// CHECK-NOT: error:
 // CHECK:  warning: use of __private_extern__ 
 
 // RUN: llvm-readtapi --compare %t/output.tbd %t/expected.tbd 


### PR DESCRIPTION
We have two tests that use FileCheck for diagnostics and which try to check that the output contains no compiler errors by checking for the string 'error'. The issue with this approach is that this also causes those tests to fail if the *path* contains the word 'error', which can happen e.g. if the branch name contains the word 'error'.

Instead, we now check for `error:` since that string is much less likely to appear in a path.