### PR TITLE
[libc] Wrong header guard comment for atanpif16

### DIFF
--- a/libc/src/math/atanpif16.h
+++ b/libc/src/math/atanpif16.h
@@ -18,4 +18,4 @@ float16 atanpif16(float16 x);
 
 } // namespace LIBC_NAMESPACE_DECL
 
-#endif // LLVM_LIBC_SRC_MATH_ASINF16_H
+#endif // LLVM_LIBC_SRC_MATH_ATANPIF16_H


### PR DESCRIPTION
This PR intends to fix a small nit caused in [1c1135b](https://github.com/llvm/llvm-project/pull/150400/commits/1c1135b3fccf59537243fc365e83a568f77273ae)
```
#endif // LLVM_LIBC_SRC_MATH_ASINIF16_H
```
to 
```
#endif // LLVM_LIBC_SRC_MATH_ATANPIF16_H
```
