### PR TITLE
[flang][openacc] Handle fir.undefined with OutlineRematerializationOpInterface in OffloadLiveInValueCanonicalization

### DIFF
--- a/flang/lib/Optimizer/OpenACC/Support/RegisterOpenACCExtensions.cpp
+++ b/flang/lib/Optimizer/OpenACC/Support/RegisterOpenACCExtensions.cpp
@@ -81,6 +81,10 @@ void registerOpenACCExtensions(mlir::DialectRegistry &registry) {
         OutlineRematerializationModel<fir::FieldIndexOp>>(*ctx);
     fir::ConvertOp::attachInterface<
         OutlineRematerializationModel<fir::ConvertOp>>(*ctx);
+    fir::UndefOp::attachInterface<
+        OutlineRematerializationModel<fir::UndefOp>>(*ctx);
+    fir::SliceOp::attachInterface<
+        OutlineRematerializationModel<fir::SliceOp>>(*ctx);
   });
 
   // Register HLFIR operation interfaces

--- a/flang/test/Fir/OpenACC/offload-livein-value-canonicalization.fir
+++ b/flang/test/Fir/OpenACC/offload-livein-value-canonicalization.fir
@@ -371,3 +371,55 @@ func.func @test_convert_chain_and_direct(%arg0: !fir.boxchar<1>, %arg1: !fir.ref
 // CHECK:   %[[CVT_INT:.*]] = fir.convert %arg1
 // CHECK:   fir.call @use_ref(%[[DECL]])
 // CHECK:   fir.call @use_i64(%[[CVT_INT]])
+
+// -----
+
+// Test fir.undefined sinking into offload region.
+// fir.undefined is used in fir.slice to mark collapsed dimensions.
+// After gpu-kernel-outlining, function arguments lose their defining op,
+// so SliceOp::getOutputRank() can no longer identify collapsed dims.
+// The pass must sink fir.undefined to preserve this information.
+
+func.func @test_undef_slice_sink(%arg0: !fir.box<!fir.array<?x?xf32>>) {
+  %c1 = arith.constant 1 : index
+  %c10 = arith.constant 10 : index
+  %undef = fir.undefined index
+  %slice = fir.slice %c1, %c10, %c1, %c1, %undef, %undef : (index, index, index, index, index, index) -> !fir.slice<2>
+  acc.serial {
+    %rebox = fir.rebox %arg0 [%slice] : (!fir.box<!fir.array<?x?xf32>>, !fir.slice<2>) -> !fir.box<!fir.array<?xf32>>
+    acc.yield
+  }
+  return
+}
+
+// CHECK-LABEL: @test_undef_slice_sink
+// CHECK: acc.serial {
+// CHECK:   %[[UNDEF:.*]] = fir.undefined index
+// CHECK:   %[[SLICE:.*]] = fir.slice {{.*}}, %[[UNDEF]], %[[UNDEF]]
+// CHECK:   fir.rebox %arg0 [%[[SLICE]]]
+
+// -----
+
+// Test fir.undefined rematerialization (used both inside and outside region).
+
+func.func @test_undef_slice_rematerialize(%arg0: !fir.box<!fir.array<?x?xf32>>) {
+  %c1 = arith.constant 1 : index
+  %c10 = arith.constant 10 : index
+  %undef = fir.undefined index
+  %slice = fir.slice %c1, %c10, %c1, %c1, %undef, %undef : (index, index, index, index, index, index) -> !fir.slice<2>
+  %rebox_outer = fir.rebox %arg0 [%slice] : (!fir.box<!fir.array<?x?xf32>>, !fir.slice<2>) -> !fir.box<!fir.array<?xf32>>
+  acc.serial {
+    %rebox_inner = fir.rebox %arg0 [%slice] : (!fir.box<!fir.array<?x?xf32>>, !fir.slice<2>) -> !fir.box<!fir.array<?xf32>>
+    acc.yield
+  }
+  return
+}
+
+// CHECK-LABEL: @test_undef_slice_rematerialize
+// CHECK: %[[UNDEF_OUTER:.*]] = fir.undefined index
+// CHECK: %[[SLICE_OUTER:.*]] = fir.slice {{.*}}, %[[UNDEF_OUTER]], %[[UNDEF_OUTER]]
+// CHECK: fir.rebox %arg0 [%[[SLICE_OUTER]]]
+// CHECK: acc.serial {
+// CHECK:   %[[UNDEF_INNER:.*]] = fir.undefined index
+// CHECK:   %[[SLICE_INNER:.*]] = fir.slice {{.*}}, %[[UNDEF_INNER]], %[[UNDEF_INNER]]
+// CHECK:   fir.rebox %arg0 [%[[SLICE_INNER]]]

--- a/mlir/lib/Dialect/OpenACC/Transforms/ACCSpecializeForDevice.cpp
+++ b/mlir/lib/Dialect/OpenACC/Transforms/ACCSpecializeForDevice.cpp
@@ -95,6 +95,11 @@ public:
     } else {
       // For non-specialized functions, apply patterns only to ACC operations
       // inside compute constructs (not to the compute constructs themselves).
+      // Use ExistingOps strictness so the greedy driver does not expand the
+      // worklist to parent ops, which would accidentally unwrap the compute
+      // construct (e.g. after inlining acc routines with their own data
+      // regions).
+      config.setStrictness(GreedyRewriteStrictness::ExistingOps);
       SmallVector<Operation *> opsToTransform;
       func.walk([&](Operation *op) {
         if (isa<ACC_COMPUTE_CONSTRUCT_OPS>(op)) {

--- a/mlir/test/Dialect/OpenACC/acc-specialize-for-device.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-specialize-for-device.mlir
@@ -80,6 +80,34 @@ func.func @copyin_outside_parallel(%arg0 : memref<i32>) {
 }
 
 //===----------------------------------------------------------------------===//
+// Nested data constructs inside compute construct (non-specialized function).
+// After inlining an acc routine that has its own data region into a parallel
+// loop body, the inlined acc.data/acc.copyin end up inside acc.parallel.
+// The outer acc.parallel must NOT be unwrapped even though the inner data
+// ops are stripped. Regression test for greedy driver worklist expansion.
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: func.func @nested_data_inside_parallel
+// CHECK:       acc.copyin
+// CHECK:       acc.parallel
+// CHECK-NOT:   acc.data
+// CHECK-NOT:   acc.copyin
+// CHECK:       acc.yield
+func.func @nested_data_inside_parallel(%arg0 : memref<i32>, %arg1 : memref<i32>) {
+  %c0 = arith.constant 0 : i32
+  %0 = acc.copyin varPtr(%arg0 : memref<i32>) -> memref<i32>
+  acc.parallel dataOperands(%0 : memref<i32>) {
+    %1 = acc.copyin varPtr(%arg1 : memref<i32>) -> memref<i32>
+    acc.data dataOperands(%1 : memref<i32>) {
+      memref.store %c0, %arg1[] : memref<i32>
+      acc.terminator
+    }
+    acc.yield
+  }
+  return
+}
+
+//===----------------------------------------------------------------------===//
 // Data exit ops in specialized routines
 //===----------------------------------------------------------------------===//
 


### PR DESCRIPTION
Example:
```fortran
!$ACC KERNELS PRESENT(CG, W1)
  CG(1:W1%WDES1%NPL, NN) = W1%CPTWFP(1:W1%WDES1%NPL)
  CPROJ(:, NN) = W1%CPROJ(1:SIZE(CPROJ,1))
!$ACC END KERNELS
```

When compiling OpenACC kernels containing array section assignments of rank-2 arrays with a scalar index in one dimension (e.g. `CG(1:NPL, NN)`), the Fortran lowering creates a `fir.slice` where collapsed (scalar) dimensions use `fir.undefined index` as the stop/step values. `SliceOp::getOutputRank()` relies on `getDefiningOp()` returning `fir::UndefOp` to identify these collapsed dimensions and compute the correct output rank.

When `fir.undefined` values defined outside an offload region are used inside it, `gpu-kernel-outlining` turns them into function arguments. Since function arguments have no defining op (`getDefiningOp()` returns `nullptr`), `getOutputRank()` no longer recognizes the collapsed dimensions, computing rank 2 instead of rank 1. This causes the `fir.rebox` verifier to fail with:

```
'fir.rebox' op result type rank and rank after applying slice operand must match
```

Fix: Register `OutlineRematerializationOpInterface` for `fir::UndefOp` (and `fir::SliceOp`) in `RegisterOpenACCExtensions.cpp`. This causes `OffloadLiveInValueCanonicalization` to clone these operations inside the offload region before outlining, preserving the `fir::UndefOp` identity so that `getOutputRank()` correctly identifies collapsed dimensions.