### PR TITLE
[JITLink][AArch64] GOT and PLT optimization for AArch64

### DIFF
--- a/llvm/include/llvm/ExecutionEngine/JITLink/aarch64.h
+++ b/llvm/include/llvm/ExecutionEngine/JITLink/aarch64.h
@@ -138,6 +138,10 @@ enum EdgeKind_aarch64 : Edge::Kind {
   ///     out-of-range error will be returned.
   Branch26PCRel,
 
+  /// Branch26PCRel, but relaxable if the GOT entry target is in range of the
+  /// fixup.
+  Branch26PCRelRelaxable,
+
   /// A 14-bit PC-relative test and branch.
   ///
   /// Represents a PC-relative test and branch to a target within +/-32Kb. The
@@ -247,6 +251,9 @@ enum EdgeKind_aarch64 : Edge::Kind {
   ///     out-of-range error will be returned.
   Page21,
 
+  /// Page21, but relaxable if the GOT entry target is in range of the fixup.
+  Page21Relaxable,
+
   /// The 12-bit (potentially shifted) offset of the target within its page.
   ///
   /// Typically used to fix up LDR immediates.
@@ -263,6 +270,10 @@ enum EdgeKind_aarch64 : Edge::Kind {
   ///   - The result of the fixup expression must fit into a uint12 otherwise an
   ///     out-of-range error will be returned.
   PageOffset12,
+
+  /// PageOffset12, but relaxable if the GOT entry target is in range of the
+  /// fixup.
+  PageOffset12Relaxable,
 
   /// The 15-bit offset of the GOT entry from the GOT table.
   ///
@@ -533,7 +544,8 @@ inline Error applyFixup(LinkGraph &G, Block &B, const Edge &E,
       *(little64_t *)FixupPtr = Value;
     break;
   }
-  case Branch26PCRel: {
+  case Branch26PCRel:
+  case Branch26PCRelRelaxable: {
     assert((FixupAddress.getValue() & 0x3) == 0 &&
            "Branch-inst is not 32-bit aligned");
 
@@ -632,7 +644,8 @@ inline Error applyFixup(LinkGraph &G, Block &B, const Edge &E,
     *(ulittle32_t *)FixupPtr = FixedInstr;
     break;
   }
-  case Page21: {
+  case Page21:
+  case Page21Relaxable: {
     uint64_t TargetPage =
         (E.getTarget().getAddress().getValue() + E.getAddend()) &
         ~static_cast<uint64_t>(4096 - 1);
@@ -652,7 +665,8 @@ inline Error applyFixup(LinkGraph &G, Block &B, const Edge &E,
     *(ulittle32_t *)FixupPtr = FixedInstr;
     break;
   }
-  case PageOffset12: {
+  case PageOffset12:
+  case PageOffset12Relaxable: {
     uint64_t TargetOffset =
         (E.getTarget().getAddress() + E.getAddend()).getValue() & 0xfff;
 
@@ -800,12 +814,12 @@ public:
     switch (E.getKind()) {
     case aarch64::RequestGOTAndTransformToPage21:
     case aarch64::RequestTLVPAndTransformToPage21: {
-      KindToSet = aarch64::Page21;
+      KindToSet = aarch64::Page21Relaxable;
       break;
     }
     case aarch64::RequestGOTAndTransformToPageOffset12:
     case aarch64::RequestTLVPAndTransformToPageOffset12: {
-      KindToSet = aarch64::PageOffset12;
+      KindToSet = aarch64::PageOffset12Relaxable;
       uint32_t RawInstr = *(const support::ulittle32_t *)FixupPtr;
       (void)RawInstr;
       assert(E.getAddend() == 0 &&
@@ -876,6 +890,7 @@ public:
                << B->getFixupAddress(E) << " (" << B->getAddress() << " + "
                << formatv("{0:x}", E.getOffset()) << ")\n";
       });
+      E.setKind(aarch64::Branch26PCRelRelaxable);
       E.setTarget(getEntryForTarget(G, E.getTarget()));
       return true;
     }
@@ -923,6 +938,15 @@ LLVM_ABI Error createEmptyPointerSigningFunction(LinkGraph &G);
 /// containing an anonymous function that will sign all pointers in the graph.
 /// An allocation action will be added to run this function during finalization.
 LLVM_ABI Error lowerPointer64AuthEdgesToSigningFunction(LinkGraph &G);
+
+/// Optimize GOT and stub relocations when the target edge address is in range.
+/// 1. bl instructions with an Branch26PCRelRelaxable edge to a PLT thunk become
+/// direct jumps to the target, if in range.
+/// 2. adrp/ldr pairs, of the form described in the "Large GOT indirection"
+/// optimization from the "ELF for the Arm 64-bit Architecture" document
+/// (section "Relocation optimization"), may be optimized to either a nop/adr or
+/// a adrp/add if the address in the GOT entry is in range.
+LLVM_ABI Error optimizeGOTAndStubAccesses(LinkGraph &G);
 
 } // namespace aarch64
 } // namespace jitlink

--- a/llvm/lib/ExecutionEngine/JITLink/ELF_aarch64.cpp
+++ b/llvm/lib/ExecutionEngine/JITLink/ELF_aarch64.cpp
@@ -722,6 +722,9 @@ void link_ELF_aarch64(std::unique_ptr<LinkGraph> G,
 
     // Add an in-place GOT/TLS/Stubs build pass.
     Config.PostPrunePasses.push_back(buildTables_ELF_aarch64);
+
+    // Add GOT/Stubs optimizer pass.
+    Config.PreFixupPasses.push_back(aarch64::optimizeGOTAndStubAccesses);
   }
 
   if (auto Err = Ctx->modifyPassConfig(*G, Config))

--- a/llvm/lib/ExecutionEngine/JITLink/MachO_arm64.cpp
+++ b/llvm/lib/ExecutionEngine/JITLink/MachO_arm64.cpp
@@ -713,6 +713,9 @@ void link_MachO_arm64(std::unique_ptr<LinkGraph> G,
     Config.PreFixupPasses.push_back([CompactUnwindMgr](LinkGraph &G) {
       return CompactUnwindMgr->writeUnwindInfo(G);
     });
+
+    // Add GOT/Stubs optimizer pass.
+    Config.PreFixupPasses.push_back(aarch64::optimizeGOTAndStubAccesses);
   }
 
   if (auto Err = Ctx->modifyPassConfig(*G, Config))

--- a/llvm/lib/ExecutionEngine/JITLink/aarch64.cpp
+++ b/llvm/lib/ExecutionEngine/JITLink/aarch64.cpp
@@ -449,18 +449,18 @@ Error optimizeGOTAndStubAccesses(LinkGraph &G) {
 
       // GOT indirection optimization:
       //   ADRP x0, :got: symbol            Page21Relaxable
-      //   LDR  x1, [x0 :got_lo12: symbol]  PageOffset12Relaxable
+      //   LDR  x0, [x0 :got_lo12: symbol]  PageOffset12Relaxable
       //     to
       //   ADRP x0, symbol                  Page21
-      //   ADD  x1, x0, :lo12: symbol       PageOffset12
+      //   ADD  x0, x0, :lo12: symbol       PageOffset12
       //     or, when the displacement is small
       //   NOP
-      //   ADR  x1, symbol                  ADRLiteral21
+      //   ADR  x0, symbol                  ADRLiteral21
       if (E2 && E.getKind() == aarch64::Page21Relaxable &&
           E2->getKind() == aarch64::PageOffset12Relaxable &&
           (Instr >> 24 & 0b10011111) == 0b10010000 && // ADRP
           Instr2 >> 22 == 0b1111100101 &&             // LDR (unsigned offset)
-          Rd1 == Rn2 && // ldr source must match adrp dest.
+          Rd1 == Rn2 && Rd1 == Rt2 && // ldr source, dest must match adrp dest.
           &E.getTarget() == &E2->getTarget() && E.getAddend() == 0 &&
           E.getTarget().isDefined() && E2->getAddend() == 0) {
 

--- a/llvm/lib/ExecutionEngine/JITLink/aarch64.cpp
+++ b/llvm/lib/ExecutionEngine/JITLink/aarch64.cpp
@@ -13,12 +13,15 @@
 #include "llvm/ExecutionEngine/JITLink/aarch64.h"
 
 #include "llvm/Support/BinaryStreamWriter.h"
+#include "llvm/Support/Endian.h"
 
 #define DEBUG_TYPE "jitlink"
 
 namespace llvm {
 namespace jitlink {
 namespace aarch64 {
+
+namespace endian = support::endian;
 
 const char NullPointerContent[8] = {0x00, 0x00, 0x00, 0x00,
                                     0x00, 0x00, 0x00, 0x00};
@@ -52,6 +55,8 @@ const char *getEdgeKindName(Edge::Kind R) {
     return "NegDelta32";
   case Branch26PCRel:
     return "Branch26PCRel";
+  case Branch26PCRelRelaxable:
+    return "Branch26PCRelRelaxable";
   case MoveWide16:
     return "MoveWide16";
   case LDRLiteral19:
@@ -64,8 +69,12 @@ const char *getEdgeKindName(Edge::Kind R) {
     return "ADRLiteral21";
   case Page21:
     return "Page21";
+  case Page21Relaxable:
+    return "Page21Relaxable";
   case PageOffset12:
     return "PageOffset12";
+  case PageOffset12Relaxable:
+    return "PageOffset12Relaxable";
   case GotPageOffset15:
     return "GotPageOffset15";
   case RequestGOTAndTransformToPage21:
@@ -400,6 +409,151 @@ Error lowerPointer64AuthEdgesToSigningFunction(LinkGraph &G) {
       {cantFail(WrapperFunctionCall::Create<SPSArgList<>>(
            SigningFunctionSym.getAddress())),
        {}});
+
+  return Error::success();
+}
+
+Error optimizeGOTAndStubAccesses(LinkGraph &G) {
+  LLVM_DEBUG(dbgs() << "Optimizing GOT entries and stubs:\n");
+  auto Endian = G.getEndianness();
+
+  for (auto *B : G.blocks()) {
+    SmallVector<Edge *> Edges;
+    for (auto &E : B->edges())
+      Edges.push_back(&E);
+    llvm::sort(Edges, [](Edge *E1, Edge *E2) {
+      return E1->getOffset() < E2->getOffset();
+    });
+
+    for (auto *EI = Edges.begin(); EI != Edges.end(); ++EI) {
+      Edge &E = **EI;
+      auto *FixupData = reinterpret_cast<uint8_t *>(
+                            const_cast<char *>(B->getContent().data())) +
+                        E.getOffset();
+
+      // E2, if non-null, is the sole relocation that applies to the instruction
+      // after E.
+      auto *EI2 = EI + 1;
+      Edge *E2 = EI2 != Edges.end() &&
+                         (*EI2)->getOffset() == E.getOffset() + 4 &&
+                         (EI2 + 1 == Edges.end() ||
+                          (*(EI2 + 1))->getOffset() > E.getOffset() + 4)
+                     ? *EI2
+                     : nullptr;
+      uint32_t Instr = endian::read<uint32_t>(FixupData, Endian);
+      uint32_t Instr2 = E2 ? endian::read<uint32_t>(FixupData + 4, Endian) : 0;
+
+      auto Rd1 = Instr & 0x1f;
+      auto Rt2 = Instr2 & 0x1f;
+      auto Rn2 = Instr2 >> 5 & 0x1f;
+
+      // GOT indirection optimization:
+      //   ADRP x0, :got: symbol            Page21Relaxable
+      //   LDR  x1, [x0 :got_lo12: symbol]  PageOffset12Relaxable
+      //     to
+      //   ADRP x0, symbol                  Page21
+      //   ADD  x1, x0, :lo12: symbol       PageOffset12
+      //     or, when the displacement is small
+      //   NOP
+      //   ADR  x1, symbol                  ADRLiteral21
+      if (E2 && E.getKind() == aarch64::Page21Relaxable &&
+          E2->getKind() == aarch64::PageOffset12Relaxable &&
+          (Instr >> 24 & 0b10011111) == 0b10010000 && // ADRP
+          Instr2 >> 22 == 0b1111100101 &&             // LDR (unsigned offset)
+          Rd1 == Rn2 && // ldr source must match adrp dest.
+          &E.getTarget() == &E2->getTarget() && E.getAddend() == 0 &&
+          E.getTarget().isDefined() && E2->getAddend() == 0) {
+
+        auto &GOTBlock = E.getTarget().getBlock();
+        assert(GOTBlock.getSize() == G.getPointerSize() &&
+               "GOT block should be pointer sized");
+        assert(GOTBlock.edges_size() == 1 &&
+               "GOT block should only have one outgoing edge");
+        auto &GOTTarget = GOTBlock.edges().begin()->getTarget();
+        orc::ExecutorAddr TargetAddr = GOTTarget.getAddress();
+        orc::ExecutorAddr EdgeAddr = B->getFixupAddress(E);
+
+        int64_t DispADRP = TargetAddr - EdgeAddr;
+        int64_t DispADR = TargetAddr - EdgeAddr + 4;
+        if (isInt<33>(DispADRP)) {
+          LLVM_DEBUG({
+            const char *Replacement =
+                isInt<21>(DispADR) ? "nop/adr" : "adrp/add";
+            dbgs() << "  Replacing GOT load with " << Replacement << ":\n    ";
+            printEdge(dbgs(), *B, E, getEdgeKindName(E.getKind()));
+            dbgs() << "\n    ";
+            printEdge(dbgs(), *B, *E2, getEdgeKindName(E2->getKind()));
+            dbgs() << "\n";
+          });
+
+          E.setTarget(GOTTarget);
+          E2->setTarget(GOTTarget);
+
+          if (isInt<21>(DispADR)) {
+            E.setKind(Edge::Invalid);
+            E2->setKind(aarch64::ADRLiteral21);
+            // Assemble NOP
+            endian::write<uint32_t>(FixupData, 0xd503201f, Endian);
+            // Assemble ADR  x1, symbol
+            endian::write<uint32_t>(FixupData + 4, 0b00010000 << 24 | Rt2,
+                                    Endian);
+          } else {
+            E.setKind(aarch64::Page21);
+            E2->setKind(aarch64::PageOffset12);
+            // Assemble ADD  x1, x0, :lo12: symbol
+            endian::write<uint32_t>(
+                FixupData + 4, 0b1001000100 << 22 | Rn2 << 5 | Rt2, Endian);
+          }
+        }
+
+        continue;
+      }
+
+      if (E.getKind() == aarch64::Branch26PCRelRelaxable) {
+        auto &StubBlock = E.getTarget().getBlock();
+        assert(StubBlock.getSize() == sizeof(PointerJumpStubContent) &&
+               "Stub block should be stub sized");
+        assert(StubBlock.edges_size() >= 1 &&
+               "Stub block should have an outgoing edge");
+
+        auto &StubTarget = StubBlock.edges().begin()->getTarget();
+        Symbol *CallTarget;
+        if (StubTarget.isDefined()) {
+          auto &GOTBlock = StubTarget.getBlock();
+          assert(GOTBlock.getSize() == G.getPointerSize() &&
+                 "GOT block should be pointer sized");
+          assert(GOTBlock.edges_size() == 1 &&
+                 "GOT block should only have one outgoing edge");
+          CallTarget = &GOTBlock.edges().begin()->getTarget();
+        } else {
+          // If the stub target is undefined, we previously optimized it to
+          // point directly to the call target.
+          CallTarget = &StubTarget;
+        }
+
+        orc::ExecutorAddr EdgeAddr = B->getFixupAddress(E);
+        orc::ExecutorAddr TargetAddr = CallTarget->getAddress();
+
+        int64_t Displacement = TargetAddr - EdgeAddr;
+        if (isInt<28>(Displacement) && (Displacement & 0x3) == 0) {
+          LLVM_DEBUG({
+            dbgs() << "  Replaced stub branch with direct branch:\n    ";
+            printEdge(dbgs(), *B, E, getEdgeKindName(E.getKind()));
+            dbgs() << "\n";
+          });
+          E.setKind(aarch64::Branch26PCRel);
+          E.setTarget(*CallTarget);
+        }
+      }
+    }
+
+    for (auto IE = B->edges().begin(); IE != B->edges().end();) {
+      if (IE->getKind() == Edge::Invalid)
+        IE = B->removeEdge(IE);
+      else
+        ++IE;
+    }
+  }
 
   return Error::success();
 }

--- a/llvm/test/ExecutionEngine/JITLink/AArch64/ELF_got_plt_optimizations.s
+++ b/llvm/test/ExecutionEngine/JITLink/AArch64/ELF_got_plt_optimizations.s
@@ -1,0 +1,74 @@
+# RUN: rm -rf %t && mkdir -p %t
+# RUN: llvm-mc -triple=aarch64-linux-gnu -filetype=obj -o %t/elf_opt.o %s
+# RUN: llvm-jitlink -noexec \
+# RUN:     -slab-allocate 64Kb -slab-page-size 16384 -slab-address 0xfff00000 \
+# RUN:     -abs var0=0xfff80008 -abs var1=0xfe00000c -abs var2=0xf00000014 \
+# RUN:     -abs func0=0xffff0000 \
+# RUN:     -check=%s %t/elf_opt.o
+
+# We should branch directly to func0, without the PLT.
+#
+# jitlink-check: decode_operand(main, 0) = (func0 - main)[27:2]
+        .globl main
+        .p2align        2
+main:
+        bl      func0
+        ret
+        .size main, .-main
+
+# Loading var0's address (21 bit range) is optimized to:
+#   nop
+#   adr x0, var0
+#
+# NOP
+# jitlink-check: *{4}load_var0 = 0xd503201f
+# ADR x0, ?
+# jitlink-check: (*{4}(load_var0 + 4)) & 0x9f00001f = 0x10000000
+# jitlink-check: decode_operand(load_var0 + 4, 1) = var0 - (load_var0+4)
+        .globl  load_var0
+        .p2align        2
+load_var0:
+        adrp    x1, :got: var0
+        ldr     x0, [x1, :got_lo12: var0]
+        ldr     x0, [x0]
+        ret
+        .size load_var0, .-load_var0
+
+# Loading var1's address (33 bit range) is optimized to:
+#   adrp x1, var1
+#   add  x0, x1, :lo12:var0
+#
+# ADRP x1, ?
+# jitlink-check: (*{4}load_var1) & 0x9f00001f = 0x90000001
+# jitlink-check: decode_operand(load_var1, 1) = var1[64:12]-load_var1[64:12]
+# ADD  x0, x1, ?
+# jitlink-check: (*{4}(load_var1+4)) & 0xffc003ff = 0x91000020
+# jitlink-check: decode_operand(load_var1+4, 2) = var1[11:0]
+
+        .globl  load_var1
+        .p2align        2
+load_var1:
+        adrp    x1, :got: var1
+        ldr     x0, [x1, :got_lo12: var1]
+        ldr     x0, [x0]
+        ret
+        .size load_var1, .-load_var1
+
+# Loading var2's address (>33 bit range) is not optimized.
+#
+# ADRP x1, ?
+# jitlink-check: (*{4}load_var2) & 0x9f00001f = 0x90000001
+# jitlink-check: decode_operand(load_var2, 1) = \
+# jitlink-check:    got_addr(elf_opt.o, var2)[64:12]-load_var2[64:12]
+# LDR  x0, x1, ?
+# jitlink-check: (*{4}(load_var2+4)) & 0xffc003ff = 0xf9400020
+# jitlink-check: decode_operand(load_var2+4, 2) = \
+# jitlink-check:    got_addr(elf_opt.o, var2)[11:0] >> 3
+        .globl  load_var2
+        .p2align        2
+load_var2:
+        adrp    x1, :got: var2
+        ldr     x0, [x1, :got_lo12: var2]
+        ldr     x0, [x0]
+        ret
+        .size load_var2, .-load_var2

--- a/llvm/test/ExecutionEngine/JITLink/AArch64/ELF_got_plt_optimizations.s
+++ b/llvm/test/ExecutionEngine/JITLink/AArch64/ELF_got_plt_optimizations.s
@@ -22,35 +22,35 @@ main:
 #
 # NOP
 # jitlink-check: *{4}load_var0 = 0xd503201f
-# ADR x0, ?
-# jitlink-check: (*{4}(load_var0 + 4)) & 0x9f00001f = 0x10000000
+# ADR x1, ?
+# jitlink-check: (*{4}(load_var0 + 4)) & 0x9f00001f = 0x10000001
 # jitlink-check: decode_operand(load_var0 + 4, 1) = var0 - (load_var0+4)
         .globl  load_var0
         .p2align        2
 load_var0:
         adrp    x1, :got: var0
-        ldr     x0, [x1, :got_lo12: var0]
-        ldr     x0, [x0]
+        ldr     x1, [x1, :got_lo12: var0]
+        ldr     x0, [x1]
         ret
         .size load_var0, .-load_var0
 
 # Loading var1's address (33 bit range) is optimized to:
 #   adrp x1, var1
-#   add  x0, x1, :lo12:var0
+#   add  x1, x1, :lo12:var0
 #
 # ADRP x1, ?
 # jitlink-check: (*{4}load_var1) & 0x9f00001f = 0x90000001
 # jitlink-check: decode_operand(load_var1, 1) = var1[64:12]-load_var1[64:12]
-# ADD  x0, x1, ?
-# jitlink-check: (*{4}(load_var1+4)) & 0xffc003ff = 0x91000020
+# ADD  x1, x1, ?
+# jitlink-check: (*{4}(load_var1+4)) & 0xffc003ff = 0x91000021
 # jitlink-check: decode_operand(load_var1+4, 2) = var1[11:0]
 
         .globl  load_var1
         .p2align        2
 load_var1:
         adrp    x1, :got: var1
-        ldr     x0, [x1, :got_lo12: var1]
-        ldr     x0, [x0]
+        ldr     x1, [x1, :got_lo12: var1]
+        ldr     x0, [x1]
         ret
         .size load_var1, .-load_var1
 
@@ -60,15 +60,15 @@ load_var1:
 # jitlink-check: (*{4}load_var2) & 0x9f00001f = 0x90000001
 # jitlink-check: decode_operand(load_var2, 1) = \
 # jitlink-check:    got_addr(elf_opt.o, var2)[64:12]-load_var2[64:12]
-# LDR  x0, x1, ?
-# jitlink-check: (*{4}(load_var2+4)) & 0xffc003ff = 0xf9400020
+# LDR  x1, x1, ?
+# jitlink-check: (*{4}(load_var2+4)) & 0xffc003ff = 0xf9400021
 # jitlink-check: decode_operand(load_var2+4, 2) = \
 # jitlink-check:    got_addr(elf_opt.o, var2)[11:0] >> 3
         .globl  load_var2
         .p2align        2
 load_var2:
         adrp    x1, :got: var2
-        ldr     x0, [x1, :got_lo12: var2]
-        ldr     x0, [x0]
+        ldr     x1, [x1, :got_lo12: var2]
+        ldr     x0, [x1]
         ret
         .size load_var2, .-load_var2

--- a/llvm/test/ExecutionEngine/JITLink/AArch64/ELF_relocations.s
+++ b/llvm/test/ExecutionEngine/JITLink/AArch64/ELF_relocations.s
@@ -2,9 +2,10 @@
 # RUN: llvm-mc -triple=aarch64-unknown-linux-gnu -x86-relax-relocations=false \
 # RUN:   -position-independent -filetype=obj -o %t/elf_reloc.o %s
 # RUN: llvm-jitlink -noexec \
-# RUN:              -abs external_data=0xdeadbeef \
-# RUN:              -abs external_func=0xcafef00d \
-# RUN:              -check %s %t/elf_reloc.o
+# RUN:    -slab-allocate 100Kb -slab-address 0xffff000000 -slab-page-size 16384 \
+# RUN:    -abs external_data=0xdeadbeef \
+# RUN:    -abs external_func=0xcafef00d \
+# RUN:    -check %s %t/elf_reloc.o
 
         .text
 

--- a/llvm/test/ExecutionEngine/JITLink/AArch64/MachO_got_stub_optimizations.s
+++ b/llvm/test/ExecutionEngine/JITLink/AArch64/MachO_got_stub_optimizations.s
@@ -19,38 +19,38 @@ _main:
 
 # Loading var0's address (21 bit range) is optimized to:
 #   nop
-#   adr x0, _var0
+#   adr x1, _var0
 #
 # NOP
 # jitlink-check: *{4}_load_var0 = 0xd503201f
-# ADR x0, ?
-# jitlink-check: (*{4}(_load_var0 + 4)) & 0x9f00001f = 0x10000000
+# ADR x1, ?
+# jitlink-check: (*{4}(_load_var0 + 4)) & 0x9f00001f = 0x10000001
 # jitlink-check: decode_operand(_load_var0 + 4, 1) = _var0 - (_load_var0+4)
         .globl  _load_var0
         .p2align        2
 _load_var0:
         adrp    x1, _var0@GOTPAGE
-        ldr     x0, [x1, _var0@GOTPAGEOFF]
-        ldr     x0, [x0]
+        ldr     x1, [x1, _var0@GOTPAGEOFF]
+        ldr     x0, [x1]
         ret
 
 # Loading var1's address (33 bit range) is optimized to:
 #   adrp x1, _var1
-#   add  x0, x1, _var1@PAGEOFF
+#   add  x1, x1, _var1@PAGEOFF
 #
 # ADRP x1, ?
 # jitlink-check: (*{4}_load_var1) & 0x9f00001f = 0x90000001
 # jitlink-check: decode_operand(_load_var1, 1) = _var1[32:12] - _load_var1[32:12]
-# ADD  x0, x1, ?
-# jitlink-check: (*{4}(_load_var1+4)) & 0xffc003ff = 0x91000020
+# ADD  x1, x1, ?
+# jitlink-check: (*{4}(_load_var1+4)) & 0xffc003ff = 0x91000021
 # jitlink-check: decode_operand(_load_var1+4, 2) = _var1[11:0]
 
         .globl  _load_var1
         .p2align        2
 _load_var1:
         adrp    x1, _var1@GOTPAGE
-        ldr     x0, [x1, _var1@GOTPAGEOFF]
-        ldr     x0, [x0]
+        ldr     x1, [x1, _var1@GOTPAGEOFF]
+        ldr     x0, [x1]
         ret
 
 # Loading var2's address (>33 bit range) is not optimized.
@@ -59,16 +59,16 @@ _load_var1:
 # jitlink-check: (*{4}_load_var2) & 0x9f00001f = 0x90000001
 # jitlink-check: decode_operand(_load_var2, 1) = \
 # jitlink-check:    (got_addr(macho_opt.o, _var2)[32:12] - _load_var2[32:12])
-# LDR  x0, x1, ?
-# jitlink-check: (*{4}(_load_var2+4)) & 0xffc003ff = 0xf9400020
+# LDR  x1, x1, ?
+# jitlink-check: (*{4}(_load_var2+4)) & 0xffc003ff = 0xf9400021
 # jitlink-check: decode_operand(_load_var2+4, 2) = \
 # jitlink-check:    got_addr(macho_opt.o, _var2)[11:3]
         .globl  _load_var2
         .p2align        2
 _load_var2:
         adrp    x1, _var2@GOTPAGE
-        ldr     x0, [x1, _var2@GOTPAGEOFF]
-        ldr     x0, [x0]
+        ldr     x1, [x1, _var2@GOTPAGEOFF]
+        ldr     x0, [x1]
         ret
 
         .subsections_via_symbols

--- a/llvm/test/ExecutionEngine/JITLink/AArch64/MachO_got_stub_optimizations.s
+++ b/llvm/test/ExecutionEngine/JITLink/AArch64/MachO_got_stub_optimizations.s
@@ -1,0 +1,74 @@
+# RUN: rm -rf %t && mkdir -p %t
+# RUN: llvm-mc -triple=arm64-apple-darwin19 -filetype=obj -o %t/macho_opt.o %s
+# RUN: llvm-jitlink -noexec \
+# RUN:     -slab-allocate 64Kb -slab-page-size 16384 -slab-address 0xfff00000 \
+# RUN:     -abs _var0=0xfff80008 -abs _var1=0xfe00000c -abs _var2=0xf00000014 \
+# RUN:     -abs _func0=0xffff0000 \
+# RUN:     -check=%s %t/macho_opt.o
+
+        .section        __TEXT,__text,regular,pure_instructions
+
+# We should branch directly to func0, without the stub.
+#
+# jitlink-check: decode_operand(_main, 0) = (_func0 - _main)[27:2]
+        .globl _main
+        .p2align        2
+_main:
+        bl      _func0
+        ret
+
+# Loading var0's address (21 bit range) is optimized to:
+#   nop
+#   adr x0, _var0
+#
+# NOP
+# jitlink-check: *{4}_load_var0 = 0xd503201f
+# ADR x0, ?
+# jitlink-check: (*{4}(_load_var0 + 4)) & 0x9f00001f = 0x10000000
+# jitlink-check: decode_operand(_load_var0 + 4, 1) = _var0 - (_load_var0+4)
+        .globl  _load_var0
+        .p2align        2
+_load_var0:
+        adrp    x1, _var0@GOTPAGE
+        ldr     x0, [x1, _var0@GOTPAGEOFF]
+        ldr     x0, [x0]
+        ret
+
+# Loading var1's address (33 bit range) is optimized to:
+#   adrp x1, _var1
+#   add  x0, x1, _var1@PAGEOFF
+#
+# ADRP x1, ?
+# jitlink-check: (*{4}_load_var1) & 0x9f00001f = 0x90000001
+# jitlink-check: decode_operand(_load_var1, 1) = _var1[32:12] - _load_var1[32:12]
+# ADD  x0, x1, ?
+# jitlink-check: (*{4}(_load_var1+4)) & 0xffc003ff = 0x91000020
+# jitlink-check: decode_operand(_load_var1+4, 2) = _var1[11:0]
+
+        .globl  _load_var1
+        .p2align        2
+_load_var1:
+        adrp    x1, _var1@GOTPAGE
+        ldr     x0, [x1, _var1@GOTPAGEOFF]
+        ldr     x0, [x0]
+        ret
+
+# Loading var2's address (>33 bit range) is not optimized.
+#
+# ADRP x1, ?
+# jitlink-check: (*{4}_load_var2) & 0x9f00001f = 0x90000001
+# jitlink-check: decode_operand(_load_var2, 1) = \
+# jitlink-check:    (got_addr(macho_opt.o, _var2)[32:12] - _load_var2[32:12])
+# LDR  x0, x1, ?
+# jitlink-check: (*{4}(_load_var2+4)) & 0xffc003ff = 0xf9400020
+# jitlink-check: decode_operand(_load_var2+4, 2) = \
+# jitlink-check:    got_addr(macho_opt.o, _var2)[11:3]
+        .globl  _load_var2
+        .p2align        2
+_load_var2:
+        adrp    x1, _var2@GOTPAGE
+        ldr     x0, [x1, _var2@GOTPAGEOFF]
+        ldr     x0, [x0]
+        ret
+
+        .subsections_via_symbols

--- a/llvm/test/ExecutionEngine/JITLink/AArch64/MachO_relocations.s
+++ b/llvm/test/ExecutionEngine/JITLink/AArch64/MachO_relocations.s
@@ -1,6 +1,10 @@
 # RUN: rm -rf %t && mkdir -p %t
 # RUN: llvm-mc -triple=arm64-apple-darwin19 -filetype=obj -o %t/macho_reloc.o %s
-# RUN: llvm-jitlink -noexec -abs external_data=0xdeadbeef -abs external_func=0xcafef00d -check=%s %t/macho_reloc.o
+# RUN: llvm-jitlink -noexec \
+# RUN:    -slab-allocate 100Kb -slab-address 0xffff000000 -slab-page-size 16384 \
+# RUN:    -abs external_data=0xdeadbeef \
+# RUN:    -abs external_func=0xcafef00d \
+# RUN:    -check=%s %t/macho_reloc.o
 
         .section        __TEXT,__text,regular,pure_instructions
 


### PR DESCRIPTION
This change adds two optimizations to JITLink, described in the "ELF for the Arm 64-bit Architecture (AArch64)" ABI document[1].  They are similar to the optimizations we do for x86-64.

The first replaces the target of `bl` instructions that have been rewritten to point to a PLT thunk when the target is in range (26 bits).

The second replaces pairs of `adrp`/`ldr` instructions that load from a GOT address with a pair of instructions that directly compute the address, depending on how close the target is:

```
  ADRP x1, :got: symbol            Page21Relaxable
  LDR  x1, [x1 :got_lo12: symbol]  PageOffset12Relaxable
    becomes, when symbol is within range (33 bits)
  ADRP x1, symbol                  Page21
  ADD  x1, x1, :lo12: symbol       PageOffset12
    or, when the symbol is even closer (21 bits)
  NOP
  ADR  x1, symbol                  ADRLiteral21
```

The MachO and ELF relocation tests on AArch64 have been tweaked so the GOT/PLT relocations don't trigger the optimization.

[1] https://github.com/ARM-software/abi-aa/blob/main/aaelf64/aaelf64.rst#relocation-optimization