### PR TITLE
[CIR][ABI][NFC] Tighten LLVM CHECK lines in codegen tests

### DIFF
--- a/clang/test/CIR/CodeGen/atomic-thread-fence.c
+++ b/clang/test/CIR/CodeGen/atomic-thread-fence.c
@@ -54,7 +54,7 @@ void modifyWithThreadFence(DataPtr d) {
   // CIR:    cir.store{{.*}} %[[VAL_42]], %[[DATA_VALUE]] : !s32i, !cir.ptr<!s32i>
   // CIR:    cir.return
 
-  // LLVM-LABEL: @modifyWithThreadFence
+  // LLVM-LABEL: @modifyWithThreadFence(ptr noundef
   // LLVM:    %[[DATA:.*]] = alloca ptr, i64 1, align 8
   // LLVM:    fence seq_cst
   // LLVM:    %[[DATA_PTR:.*]] = load ptr, ptr %[[DATA]], align 8
@@ -83,7 +83,7 @@ void modifyWithSignalFence(DataPtr d) {
   // CIR:    cir.store{{.*}} %[[VAL_42]], %[[DATA_VALUE]] : !s32i, !cir.ptr<!s32i>
   // CIR:    cir.return
 
-  // LLVM-LABEL: @modifyWithSignalFence
+  // LLVM-LABEL: @modifyWithSignalFence(ptr noundef
   // LLVM:    %[[DATA:.*]] = alloca ptr, i64 1, align 8
   // LLVM:    fence syncscope("singlethread") seq_cst
   // LLVM:    %[[DATA_PTR:.*]] = load ptr, ptr %[[DATA]], align 8
@@ -114,7 +114,7 @@ void loadWithThreadFence(DataPtr d) {
   // CIR:    %[[ATOMIC_LOAD_PTR:.*]] = cir.load{{.*}} %[[ATOMIC_TEMP]] : !cir.ptr<!cir.ptr<!void>>, !cir.ptr<!void>
   // CIR:    cir.return
 
-  // LLVM-LABEL: @loadWithThreadFence
+  // LLVM-LABEL: @loadWithThreadFence(ptr noundef
   // LLVM:    %[[DATA:.*]] = alloca ptr, i64 1, align 8
   // LLVM:    %[[DATA_TEMP:.*]] = alloca ptr, i64 1, align 8
   // LLVM:    fence seq_cst
@@ -151,7 +151,7 @@ void loadWithSignalFence(DataPtr d) {
   // CIR:    %[[LOAD_ATOMIC_TEMP:.*]] = cir.load{{.*}} %[[ATOMIC_TEMP]] : !cir.ptr<!cir.ptr<!void>>, !cir.ptr<!void>
   // CIR:    cir.return
 
-  // LLVM-LABEL: @loadWithSignalFence
+  // LLVM-LABEL: @loadWithSignalFence(ptr noundef
   // LLVM:    %[[DATA:.*]] = alloca ptr, i64 1, align 8
   // LLVM:    %[[DATA_TEMP:.*]] = alloca ptr, i64 1, align 8
   // LLVM:    fence syncscope("singlethread") seq_cst
@@ -328,7 +328,7 @@ void variable_atomic_thread_fences(int memorder) {
   // CIR:    cir.yield
   // CIR:  }
 
-  // LLVM-LABEL: variable_atomic_thread_fences
+  // LLVM-LABEL: variable_atomic_thread_fences(i32 noundef
   // LLVM:   %[[ORDER:.+]] = load i32, ptr %[[PTR:.+]], align 4
   // LLVM:   br label %[[SWITCH_BLK:.+]]
   // LLVM: [[SWITCH_BLK]]:
@@ -405,7 +405,7 @@ void variable_c11_atomic_thread_fences(int memorder) {
   // CIR:    cir.yield
   // CIR:  }
 
-  // LLVM-LABEL: variable_c11_atomic_thread_fences
+  // LLVM-LABEL: variable_c11_atomic_thread_fences(i32 noundef
   // LLVM:   %[[ORDER:.+]] = load i32, ptr %[[PTR:.+]], align 4
   // LLVM:   br label %[[SWITCH_BLK:.+]]
   // LLVM: [[SWITCH_BLK]]:
@@ -482,7 +482,7 @@ void variable_atomic_signal_fences(int memorder) {
   // CIR:    cir.yield
   // CIR:  }
 
-  // LLVM-LABEL: variable_atomic_signal_fences
+  // LLVM-LABEL: variable_atomic_signal_fences(i32 noundef
   // LLVM:   %[[ORDER:.+]] = load i32, ptr %[[PTR:.+]], align 4
   // LLVM:   br label %[[SWITCH_BLK:.+]]
   // LLVM: [[SWITCH_BLK]]:
@@ -559,7 +559,7 @@ void variable_c11_atomic_signal_fences(int memorder) {
   // CIR:    cir.yield
   // CIR:  }
 
-  // LLVM-LABEL: variable_c11_atomic_signal_fences
+  // LLVM-LABEL: variable_c11_atomic_signal_fences(i32 noundef
   // LLVM:   %[[ORDER:.+]] = load i32, ptr %[[PTR:.+]], align 4
   // LLVM:   br label %[[SWITCH_BLK:.+]]
   // LLVM: [[SWITCH_BLK]]:

--- a/clang/test/CIR/CodeGen/atomic.c
+++ b/clang/test/CIR/CodeGen/atomic.c
@@ -15,7 +15,7 @@ void f1(void) {
 // CIR-NEXT:    cir.store align(4) %[[INIT]], %[[SLOT]] : !s32i, !cir.ptr<!s32i>
 // CIR:       }
 
-// LLVM-LABEL: @f1
+// LLVM-LABEL: define{{.*}} void @f1(){{.*}}
 // LLVM:         %[[SLOT:.+]] = alloca i32, i64 1, align 4
 // LLVM-NEXT:    store i32 42, ptr %[[SLOT]], align 4
 // LLVM:       }
@@ -36,7 +36,7 @@ void f2(void) {
 // CIR-NEXT:    cir.store align(4) %[[INIT]], %[[SLOT]] : !s32i, !cir.ptr<!s32i>
 // CIR:       }
 
-// LLVM-LABEL: @f2
+// LLVM-LABEL: define{{.*}} void @f2(){{.*}}
 // LLVM:         %[[SLOT:.+]] = alloca i32, i64 1, align 4
 // LLVM-NEXT:    store i32 42, ptr %[[SLOT]], align 4
 // LLVM:       }
@@ -53,7 +53,7 @@ void f3(_Atomic(int) *p) {
 // CIR-LABEL: @f3
 // CIR: cir.store align(4) atomic(seq_cst) %{{.+}}, %{{.+}} : !s32i, !cir.ptr<!s32i>
 
-// LLVM-LABEL: @f3
+// LLVM-LABEL: define{{.*}} void @f3(ptr noundef %{{.*}}){{.*}}
 // LLVM: store atomic i32 42, ptr %{{.+}} seq_cst, align 4
 
 // OGCG-LABEL: @f3
@@ -66,7 +66,7 @@ void f4(_Atomic(float) *p) {
 // CIR-LABEL: @f4
 // CIR: cir.store align(4) atomic(seq_cst) %{{.+}}, %{{.+}} : !cir.float, !cir.ptr<!cir.float>
 
-// LLVM-LABEL: @f4
+// LLVM-LABEL: define{{.*}} void @f4(ptr noundef %{{.*}}){{.*}}
 // LLVM: store atomic float 0x40091EB860000000, ptr %{{.+}} seq_cst, align 4
 
 // OGCG-LABEL: @f4
@@ -116,7 +116,7 @@ void load_n(int *ptr) {
 // CIR:   %{{.+}} = cir.load align(4) syncscope(system) atomic(seq_cst) %{{.+}} : !cir.ptr<!s32i>, !s32i
 // CIR: }
 
-// LLVM-LABEL: @load_n
+// LLVM-LABEL: define{{.*}} void @load_n(ptr noundef %{{.*}}){{.*}}
 // LLVM:   %{{.+}} = load atomic i32, ptr %{{.+}} monotonic, align 4
 // LLVM:   %{{.+}} = load atomic i32, ptr %{{.+}} acquire, align 4
 // LLVM:   %{{.+}} = load atomic i32, ptr %{{.+}} acquire, align 4
@@ -175,7 +175,7 @@ void c11_load_aggregate() {
 // CIR: %{{.*}} = cir.load {{.*}} syncscope(system) atomic(acquire) %{{.*}} : !cir.ptr<!u64i>, !u64i
 // CIR: %{{.*}} = cir.load {{.*}} syncscope(system) atomic(seq_cst) %{{.*}} : !cir.ptr<!u64i>, !u64i
 
-// LLVM-LABEL: @c11_load_aggregate
+// LLVM-LABEL: define{{.*}} void @c11_load_aggregate(){{.*}}
 // LLVM: %{{.*}} = load atomic i64, ptr %{{.*}} monotonic, align 8
 // LLVM: %{{.*}} = load atomic i64, ptr %{{.*}} acquire, align 8
 // LLVM: %{{.*}} = load atomic i64, ptr %{{.*}} seq_cst, align 8
@@ -221,7 +221,7 @@ void store_n(int *ptr, int x) {
 // CIR:   cir.store align(4) syncscope(system) atomic(seq_cst) %{{.+}}, %{{.+}} : !s32i, !cir.ptr<!s32i>
 // CIR: }
 
-// LLVM-LABEL: @store_n
+// LLVM-LABEL: define{{.*}} void @store_n(ptr noundef %{{.*}}, i32 noundef %{{.*}}){{.*}}
 // LLVM:   store atomic i32 %{{.+}}, ptr %{{.+}} monotonic, align 4
 // LLVM:   store atomic i32 %{{.+}}, ptr %{{.+}} release, align 4
 // LLVM:   store atomic i32 %{{.+}}, ptr %{{.+}} seq_cst, align 4
@@ -245,7 +245,7 @@ void c11_store(_Atomic(int) *ptr, int x) {
 // CIR:   cir.store align(4) syncscope(system) atomic(seq_cst) %{{.+}}, %{{.+}} : !s32i, !cir.ptr<!s32i>
 // CIR: }
 
-// LLVM-LABEL: @c11_store
+// LLVM-LABEL: define{{.*}} void @c11_store(ptr noundef %{{.*}}, i32 noundef %{{.*}}){{.*}}
 // LLVM:   store atomic i32 %{{.+}}, ptr %{{.+}} monotonic, align 4
 // LLVM:   store atomic i32 %{{.+}}, ptr %{{.+}} release, align 4
 // LLVM:   store atomic i32 %{{.+}}, ptr %{{.+}} seq_cst, align 4
@@ -259,7 +259,7 @@ void c11_store(_Atomic(int) *ptr, int x) {
 
 void c11_atomic_cmpxchg_strong(_Atomic(int) *ptr, int *expected, int desired, int failure) {
   // CIR-LABEL: @c11_atomic_cmpxchg_strong
-  // LLVM-LABEL: @c11_atomic_cmpxchg_strong
+  // LLVM-LABEL: define{{.*}} void @c11_atomic_cmpxchg_strong(ptr noundef %{{.*}}, ptr noundef %{{.*}}, i32 noundef %{{.*}}){{.*}}
   // OGCG-LABEL: @c11_atomic_cmpxchg_strong
   // CIR: %[[FAILURE:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["failure", init]
 
@@ -341,7 +341,7 @@ void c11_atomic_cmpxchg_strong(_Atomic(int) *ptr, int *expected, int desired, in
 
 void c11_atomic_cmpxchg_weak(_Atomic(int) *ptr, int *expected, int desired, int failure) {
   // CIR-LABEL: @c11_atomic_cmpxchg_weak
-  // LLVM-LABEL: @c11_atomic_cmpxchg_weak
+  // LLVM-LABEL: define{{.*}} void @c11_atomic_cmpxchg_weak(ptr noundef %{{.*}}, ptr noundef %{{.*}}, i32 noundef %{{.*}}){{.*}}
   // OGCG-LABEL: @c11_atomic_cmpxchg_weak
   // CIR: %[[FAILURE:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["failure", init]
 
@@ -575,7 +575,7 @@ void atomic_cmpxchg(int *ptr, int *expected, int *desired, int failure) {
 
 void atomic_cmpxchg_n(int *ptr, int *expected, int desired, int failure) {
   // CIR-LABEL: @atomic_cmpxchg_n
-  // LLVM-LABEL: @atomic_cmpxchg_n
+  // LLVM-LABEL: define{{.*}} void @atomic_cmpxchg_n(ptr noundef %{{.*}}, ptr noundef %{{.*}}, i32 noundef %{{.*}}){{.*}}
   // OGCG-LABEL: @atomic_cmpxchg_n
   // CIR: %[[FAILURE:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["failure", init]
 
@@ -727,7 +727,7 @@ void atomic_cmpxchg_n(int *ptr, int *expected, int desired, int failure) {
 
 void c11_atomic_exchange(_Atomic(int) *ptr, int value) {
   // CIR-LABEL: @c11_atomic_exchange
-  // LLVM-LABEL: @c11_atomic_exchange
+  // LLVM-LABEL: define{{.*}} void @c11_atomic_exchange(ptr noundef %{{.*}}, i32 noundef %{{.*}}){{.*}}
   // OGCG-LABEL: @c11_atomic_exchange
 
   __c11_atomic_exchange(ptr, value, __ATOMIC_RELAXED);
@@ -793,7 +793,7 @@ void atomic_exchange(int *ptr, int *value, int *old) {
 
 void atomic_exchange_n(int *ptr, int value) {
   // CIR-LABEL: @atomic_exchange_n
-  // LLVM-LABEL: @atomic_exchange_n
+  // LLVM-LABEL: define{{.*}} void @atomic_exchange_n(ptr noundef %{{.*}}, i32 noundef %{{.*}}){{.*}}
   // OGCG-LABEL: @atomic_exchange_n
 
   __atomic_exchange_n(ptr, value, __ATOMIC_RELAXED);
@@ -846,7 +846,7 @@ void test_and_set(void *p) {
 
 void test_and_set_volatile(volatile void *p) {
   // CIR-LABEL: @test_and_set_volatile
-  // LLVM-LABEL: @test_and_set_volatile
+  // LLVM-LABEL: define{{.*}} void @test_and_set_volatile(ptr noundef %{{.*}}){{.*}}
   // OGCG-LABEL: @test_and_set_volatile
 
   __atomic_test_and_set(p, __ATOMIC_SEQ_CST);
@@ -881,7 +881,7 @@ void clear(void *p) {
 
 void clear_volatile(volatile void *p) {
   // CIR-LABEL: @clear_volatile
-  // LLVM-LABEL: @clear_volatile
+  // LLVM-LABEL: define{{.*}} void @clear_volatile(ptr noundef %{{.*}}){{.*}}
   // OGCG-LABEL: @clear_volatile
 
   __atomic_clear(p, __ATOMIC_SEQ_CST);
@@ -928,7 +928,7 @@ int atomic_add_fetch(int *ptr, int value) {
 
 int c11_atomic_fetch_add(_Atomic(int) *ptr, int value) {
   // CIR-LABEL: @c11_atomic_fetch_add
-  // LLVM-LABEL: @c11_atomic_fetch_add
+  // LLVM-LABEL: define{{.*}} i32 @c11_atomic_fetch_add(ptr noundef %{{.*}}, i32 noundef %{{.*}}){{.*}}
   // OGCG-LABEL: @c11_atomic_fetch_add
 
   return __c11_atomic_fetch_add(ptr, value, __ATOMIC_SEQ_CST);
@@ -943,7 +943,7 @@ int c11_atomic_fetch_add(_Atomic(int) *ptr, int value) {
 
 int atomic_fetch_sub(int *ptr, int value) {
   // CIR-LABEL: @atomic_fetch_sub
-  // LLVM-LABEL: @atomic_fetch_sub
+  // LLVM-LABEL: define{{.*}} i32 @atomic_fetch_sub(ptr noundef %{{.*}}, i32 noundef %{{.*}}){{.*}}
   // OGCG-LABEL: @atomic_fetch_sub
 
   return __atomic_fetch_sub(ptr, value, __ATOMIC_SEQ_CST);
@@ -958,7 +958,7 @@ int atomic_fetch_sub(int *ptr, int value) {
 
 int atomic_sub_fetch(int *ptr, int value) {
   // CIR-LABEL: @atomic_sub_fetch
-  // LLVM-LABEL: @atomic_sub_fetch
+  // LLVM-LABEL: define{{.*}} i32 @atomic_sub_fetch(ptr noundef %{{.*}}, i32 noundef %{{.*}}){{.*}}
   // OGCG-LABEL: @atomic_sub_fetch
 
   return __atomic_sub_fetch(ptr, value, __ATOMIC_SEQ_CST);
@@ -990,7 +990,7 @@ int c11_atomic_fetch_sub(_Atomic(int) *ptr, int value) {
 
 float atomic_fetch_add_fp(float *ptr, float value) {
   // CIR-LABEL: @atomic_fetch_add_fp
-  // LLVM-LABEL: @atomic_fetch_add_fp
+  // LLVM-LABEL: define{{.*}} float @atomic_fetch_add_fp(ptr noundef %{{.*}}, float noundef %{{.*}}){{.*}}
   // OGCG-LABEL: @atomic_fetch_add_fp
 
   return __atomic_fetch_add(ptr, value, __ATOMIC_SEQ_CST);
@@ -1005,7 +1005,7 @@ float atomic_fetch_add_fp(float *ptr, float value) {
 
 float atomic_add_fetch_fp(float *ptr, float value) {
   // CIR-LABEL: @atomic_add_fetch_fp
-  // LLVM-LABEL: @atomic_add_fetch_fp
+  // LLVM-LABEL: define{{.*}} float @atomic_add_fetch_fp(ptr noundef %{{.*}}, float noundef %{{.*}}){{.*}}
   // OGCG-LABEL: @atomic_add_fetch_fp
 
   return __atomic_add_fetch(ptr, value, __ATOMIC_SEQ_CST);
@@ -1022,7 +1022,7 @@ float atomic_add_fetch_fp(float *ptr, float value) {
 
 float c11_atomic_fetch_sub_fp(_Atomic(float) *ptr, float value) {
   // CIR-LABEL: @c11_atomic_fetch_sub_fp
-  // LLVM-LABEL: @c11_atomic_fetch_sub_fp
+  // LLVM-LABEL: define{{.*}} float @c11_atomic_fetch_sub_fp(ptr noundef %{{.*}}, float noundef %{{.*}}){{.*}}
   // OGCG-LABEL: @c11_atomic_fetch_sub_fp
 
   return __c11_atomic_fetch_sub(ptr, value, __ATOMIC_SEQ_CST);
@@ -1086,7 +1086,7 @@ int c11_atomic_fetch_min(_Atomic(int) *ptr, int value) {
 
 float atomic_fetch_min_fp(float *ptr, float value) {
   // CIR-LABEL: @atomic_fetch_min_fp
-  // LLVM-LABEL: @atomic_fetch_min_fp
+  // LLVM-LABEL: define{{.*}} float @atomic_fetch_min_fp(ptr noundef %{{.*}}, float noundef %{{.*}}){{.*}}
   // OGCG-LABEL: @atomic_fetch_min_fp
 
   return __atomic_fetch_min(ptr, value, __ATOMIC_SEQ_CST);
@@ -1101,7 +1101,7 @@ float atomic_fetch_min_fp(float *ptr, float value) {
 
 float atomic_min_fetch_fp(float *ptr, float value) {
   // CIR-LABEL: @atomic_min_fetch_fp
-  // LLVM-LABEL: @atomic_min_fetch_fp
+  // LLVM-LABEL: define{{.*}} float @atomic_min_fetch_fp(ptr noundef %{{.*}}, float noundef %{{.*}}){{.*}}
   // OGCG-LABEL: @atomic_min_fetch_fp
 
   return __atomic_min_fetch(ptr, value, __ATOMIC_SEQ_CST);
@@ -1118,7 +1118,7 @@ float atomic_min_fetch_fp(float *ptr, float value) {
 
 float c11_atomic_fetch_min_fp(_Atomic(float) *ptr, float value) {
   // CIR-LABEL: @c11_atomic_fetch_min_fp
-  // LLVM-LABEL: @c11_atomic_fetch_min_fp
+  // LLVM-LABEL: define{{.*}} float @c11_atomic_fetch_min_fp(ptr noundef %{{.*}}, float noundef %{{.*}}){{.*}}
   // OGCG-LABEL: @c11_atomic_fetch_min_fp
 
   return __c11_atomic_fetch_min(ptr, value, __ATOMIC_SEQ_CST);
@@ -1182,7 +1182,7 @@ int c11_atomic_fetch_max(_Atomic(int) *ptr, int value) {
 
 float atomic_fetch_max_fp(float *ptr, float value) {
   // CIR-LABEL: @atomic_fetch_max_fp
-  // LLVM-LABEL: @atomic_fetch_max_fp
+  // LLVM-LABEL: define{{.*}} float @atomic_fetch_max_fp(ptr noundef %{{.*}}, float noundef %{{.*}}){{.*}}
   // OGCG-LABEL: @atomic_fetch_max_fp
 
   return __atomic_fetch_max(ptr, value, __ATOMIC_SEQ_CST);
@@ -1197,7 +1197,7 @@ float atomic_fetch_max_fp(float *ptr, float value) {
 
 float atomic_max_fetch_fp(float *ptr, float value) {
   // CIR-LABEL: @atomic_max_fetch_fp
-  // LLVM-LABEL: @atomic_max_fetch_fp
+  // LLVM-LABEL: define{{.*}} float @atomic_max_fetch_fp(ptr noundef %{{.*}}, float noundef %{{.*}}){{.*}}
   // OGCG-LABEL: @atomic_max_fetch_fp
 
   return __atomic_max_fetch(ptr, value, __ATOMIC_SEQ_CST);
@@ -1214,7 +1214,7 @@ float atomic_max_fetch_fp(float *ptr, float value) {
 
 float c11_atomic_fetch_max_fp(_Atomic(float) *ptr, float value) {
   // CIR-LABEL: @c11_atomic_fetch_max_fp
-  // LLVM-LABEL: @c11_atomic_fetch_max_fp
+  // LLVM-LABEL: define{{.*}} float @c11_atomic_fetch_max_fp(ptr noundef %{{.*}}, float noundef %{{.*}}){{.*}}
   // OGCG-LABEL: @c11_atomic_fetch_max_fp
 
   return __c11_atomic_fetch_max(ptr, value, __ATOMIC_SEQ_CST);
@@ -1229,7 +1229,7 @@ float c11_atomic_fetch_max_fp(_Atomic(float) *ptr, float value) {
 
 int atomic_fetch_and(int *ptr, int value) {
   // CIR-LABEL: @atomic_fetch_and
-  // LLVM-LABEL: @atomic_fetch_and
+  // LLVM-LABEL: define{{.*}} i32 @atomic_fetch_and(ptr noundef %{{.*}}, i32 noundef %{{.*}}){{.*}}
   // OGCG-LABEL: @atomic_fetch_and
 
   return __atomic_fetch_and(ptr, value, __ATOMIC_SEQ_CST);
@@ -1244,7 +1244,7 @@ int atomic_fetch_and(int *ptr, int value) {
 
 int atomic_and_fetch(int *ptr, int value) {
   // CIR-LABEL: @atomic_and_fetch
-  // LLVM-LABEL: @atomic_and_fetch
+  // LLVM-LABEL: define{{.*}} i32 @atomic_and_fetch(ptr noundef %{{.*}}, i32 noundef %{{.*}}){{.*}}
   // OGCG-LABEL: @atomic_and_fetch
 
   return __atomic_and_fetch(ptr, value, __ATOMIC_SEQ_CST);
@@ -1261,7 +1261,7 @@ int atomic_and_fetch(int *ptr, int value) {
 
 int c11_atomic_fetch_and(_Atomic(int) *ptr, int value) {
   // CIR-LABEL: @c11_atomic_fetch_and
-  // LLVM-LABEL: @c11_atomic_fetch_and
+  // LLVM-LABEL: define{{.*}} i32 @c11_atomic_fetch_and(ptr noundef %{{.*}}, i32 noundef %{{.*}}){{.*}}
   // OGCG-LABEL: @c11_atomic_fetch_and
 
   return __c11_atomic_fetch_and(ptr, value, __ATOMIC_SEQ_CST);
@@ -1276,7 +1276,7 @@ int c11_atomic_fetch_and(_Atomic(int) *ptr, int value) {
 
 int atomic_fetch_or(int *ptr, int value) {
   // CIR-LABEL: @atomic_fetch_or
-  // LLVM-LABEL: @atomic_fetch_or
+  // LLVM-LABEL: define{{.*}} i32 @atomic_fetch_or(ptr noundef %{{.*}}, i32 noundef %{{.*}}){{.*}}
   // OGCG-LABEL: @atomic_fetch_or
 
   return __atomic_fetch_or(ptr, value, __ATOMIC_SEQ_CST);
@@ -1291,7 +1291,7 @@ int atomic_fetch_or(int *ptr, int value) {
 
 int atomic_or_fetch(int *ptr, int value) {
   // CIR-LABEL: @atomic_or_fetch
-  // LLVM-LABEL: @atomic_or_fetch
+  // LLVM-LABEL: define{{.*}} i32 @atomic_or_fetch(ptr noundef %{{.*}}, i32 noundef %{{.*}}){{.*}}
   // OGCG-LABEL: @atomic_or_fetch
 
   return __atomic_or_fetch(ptr, value, __ATOMIC_SEQ_CST);
@@ -1308,7 +1308,7 @@ int atomic_or_fetch(int *ptr, int value) {
 
 int c11_atomic_fetch_or(_Atomic(int) *ptr, int value) {
   // CIR-LABEL: @c11_atomic_fetch_or
-  // LLVM-LABEL: @c11_atomic_fetch_or
+  // LLVM-LABEL: define{{.*}} i32 @c11_atomic_fetch_or(ptr noundef %{{.*}}, i32 noundef %{{.*}}){{.*}}
   // OGCG-LABEL: @c11_atomic_fetch_or
 
   return __c11_atomic_fetch_or(ptr, value, __ATOMIC_SEQ_CST);
@@ -1323,7 +1323,7 @@ int c11_atomic_fetch_or(_Atomic(int) *ptr, int value) {
 
 int atomic_fetch_xor(int *ptr, int value) {
   // CIR-LABEL: @atomic_fetch_xor
-  // LLVM-LABEL: @atomic_fetch_xor
+  // LLVM-LABEL: define{{.*}} i32 @atomic_fetch_xor(ptr noundef %{{.*}}, i32 noundef %{{.*}}){{.*}}
   // OGCG-LABEL: @atomic_fetch_xor
 
   return __atomic_fetch_xor(ptr, value, __ATOMIC_SEQ_CST);
@@ -1338,7 +1338,7 @@ int atomic_fetch_xor(int *ptr, int value) {
 
 int atomic_xor_fetch(int *ptr, int value) {
   // CIR-LABEL: @atomic_xor_fetch
-  // LLVM-LABEL: @atomic_xor_fetch
+  // LLVM-LABEL: define{{.*}} i32 @atomic_xor_fetch(ptr noundef %{{.*}}, i32 noundef %{{.*}}){{.*}}
   // OGCG-LABEL: @atomic_xor_fetch
 
   return __atomic_xor_fetch(ptr, value, __ATOMIC_SEQ_CST);
@@ -1355,7 +1355,7 @@ int atomic_xor_fetch(int *ptr, int value) {
 
 int c11_atomic_fetch_xor(_Atomic(int) *ptr, int value) {
   // CIR-LABEL: @c11_atomic_fetch_xor
-  // LLVM-LABEL: @c11_atomic_fetch_xor
+  // LLVM-LABEL: define{{.*}} i32 @c11_atomic_fetch_xor(ptr noundef %{{.*}}, i32 noundef %{{.*}}){{.*}}
   // OGCG-LABEL: @c11_atomic_fetch_xor
 
   return __c11_atomic_fetch_xor(ptr, value, __ATOMIC_SEQ_CST);
@@ -1370,7 +1370,7 @@ int c11_atomic_fetch_xor(_Atomic(int) *ptr, int value) {
 
 int atomic_fetch_nand(int *ptr, int value) {
   // CIR-LABEL: @atomic_fetch_nand
-  // LLVM-LABEL: @atomic_fetch_nand
+  // LLVM-LABEL: define{{.*}} i32 @atomic_fetch_nand(ptr noundef %{{.*}}, i32 noundef %{{.*}}){{.*}}
   // OGCG-LABEL: @atomic_fetch_nand
 
   return __atomic_fetch_nand(ptr, value, __ATOMIC_SEQ_CST);
@@ -1385,7 +1385,7 @@ int atomic_fetch_nand(int *ptr, int value) {
 
 int atomic_nand_fetch(int *ptr, int value) {
   // CIR-LABEL: @atomic_nand_fetch
-  // LLVM-LABEL: @atomic_nand_fetch
+  // LLVM-LABEL: define{{.*}} i32 @atomic_nand_fetch(ptr noundef %{{.*}}, i32 noundef %{{.*}}){{.*}}
   // OGCG-LABEL: @atomic_nand_fetch
 
   return __atomic_nand_fetch(ptr, value, __ATOMIC_SEQ_CST);
@@ -1404,7 +1404,7 @@ int atomic_nand_fetch(int *ptr, int value) {
 
 int c11_atomic_fetch_nand(_Atomic(int) *ptr, int value) {
   // CIR-LABEL: @c11_atomic_fetch_nand
-  // LLVM-LABEL: @c11_atomic_fetch_nand
+  // LLVM-LABEL: define{{.*}} i32 @c11_atomic_fetch_nand(ptr noundef %{{.*}}, i32 noundef %{{.*}}){{.*}}
   // OGCG-LABEL: @c11_atomic_fetch_nand
 
   return __c11_atomic_fetch_nand(ptr, value, __ATOMIC_SEQ_CST);
@@ -1938,7 +1938,7 @@ void nand_uchar(unsigned char* a, char b) {
 }
 
 // CIR-LABEL: @test_op_and_fetch
-// LLVM-LABEL: @test_op_and_fetch
+// LLVM-LABEL: define{{.*}} void @test_op_and_fetch(){{.*}}
 void test_op_and_fetch() {
   int *ptr;
   signed char sc;
@@ -2688,7 +2688,7 @@ void test_op_and_fetch() {
 
 int atomic_load_dynamic_order(int *ptr, int order) {
   // CIR-LABEL: atomic_load_dynamic_order
-  // LLVM-LABEL: atomic_load_dynamic_order
+  // LLVM-LABEL: define{{.*}} i32 @atomic_load_dynamic_order(ptr noundef %{{.*}}, i32 noundef %{{.*}}){{.*}}
   // OGCG-LABEL: atomic_load_dynamic_order
 
   return __atomic_load_n(ptr, order);
@@ -2764,7 +2764,7 @@ int atomic_load_dynamic_order(int *ptr, int order) {
 
 void atomic_store_dynamic_order(int *ptr, int order) {
   // CIR-LABEL: atomic_store_dynamic_order
-  // LLVM-LABEL: atomic_store_dynamic_order
+  // LLVM-LABEL: define{{.*}} void @atomic_store_dynamic_order(ptr noundef %{{.*}}, i32 noundef %{{.*}}){{.*}}
   // OGCG-LABEL: atomic_store_dynamic_order
 
   __atomic_store_n(ptr, 10, order);
@@ -2833,7 +2833,7 @@ void atomic_store_dynamic_order(int *ptr, int order) {
 
 int atomic_load_and_store_dynamic_order(int *ptr, int order) {
   // CIR-LABEL: atomic_load_and_store_dynamic_order
-  // LLVM-LABEL: atomic_load_and_store_dynamic_order
+  // LLVM-LABEL: define{{.*}} i32 @atomic_load_and_store_dynamic_order(ptr noundef %{{.*}}, i32 noundef %{{.*}}){{.*}}
   // OGCG-LABEL: atomic_load_and_store_dynamic_order
 
   return __atomic_exchange_n(ptr, 20, order);

--- a/clang/test/CIR/CodeGen/basic.c
+++ b/clang/test/CIR/CodeGen/basic.c
@@ -205,7 +205,7 @@ int f7(int a, int b, int c) {
 // CIR:  %[[B_PLUS_C:.*]] = cir.add nsw %[[B]], %[[C]] : !s32i
 // CIR:  %[[RETVAL:.*]] = cir.add nsw %[[A]], %[[B_PLUS_C]] : !s32i
 
-// LLVM: define{{.*}} i32 @f7
+// LLVM: define{{.*}} i32 @f7(i32 noundef %{{[0-9]+}}, i32 noundef %{{[0-9]+}}, i32 noundef %{{[0-9]+}})
 // LLVM:   %[[A_PTR:.*]] = alloca i32, i64 1, align 4
 // LLVM:   %[[B_PTR:.*]] = alloca i32, i64 1, align 4
 // LLVM:   %[[C_PTR:.*]] = alloca i32, i64 1, align 4
@@ -239,7 +239,7 @@ int f8(int *p) {
 // CIR:    %[[P2:.*]] = cir.load deref{{.*}} %[[P_PTR]] : !cir.ptr<!cir.ptr<!s32i>>, !cir.ptr<!s32i>
 // CIR:    %[[STAR_P:.*]] = cir.load{{.*}} %[[P2]] : !cir.ptr<!s32i>, !s32i
 
-// LLVM: define{{.*}} i32 @f8
+// LLVM: define{{.*}} i32 @f8(ptr noundef %{{[0-9]+}})
 // LLVM:   %[[P_PTR:.*]] = alloca ptr, i64 1, align 8
 // LLVM:   %[[P:.*]] = load ptr, ptr %[[P_PTR]], align 8
 // LLVM:   store i32 2, ptr %[[P]], align 4

--- a/clang/test/CIR/CodeGen/bitfields.c
+++ b/clang/test/CIR/CodeGen/bitfields.c
@@ -100,7 +100,7 @@ int load_field(S* s) {
 // CIR:   [[TMP2:%.*]] = cir.get_member [[TMP1]][0] {name = "c"} : !cir.ptr<!rec_S> -> !cir.ptr<!u64i>
 // CIR:   [[TMP3:%.*]] = cir.get_bitfield align(4) (#bfi_c, [[TMP2]] : !cir.ptr<!u64i>) -> !s32i
 
-// LLVM: define dso_local i32 @load_field
+// LLVM: define dso_local i32 @load_field(ptr noundef
 // LLVM:   [[TMP0:%.*]] = alloca ptr, i64 1, align 8
 // LLVM:   [[TMP1:%.*]] = alloca i32, i64 1, align 4
 // LLVM:   [[TMP2:%.*]] = load ptr, ptr [[TMP0]], align 8
@@ -128,7 +128,7 @@ unsigned int load_field_unsigned(A* s) {
 //CIR:   [[TMP2:%.*]] = cir.get_member [[TMP1]][3] {name = "more_bits"} : !cir.ptr<!rec_A> -> !cir.ptr<!u16i>
 //CIR:   [[TMP3:%.*]] = cir.get_bitfield align(1) (#bfi_more_bits, [[TMP2]] : !cir.ptr<!u16i>) -> !u32i
 
-//LLVM: define dso_local i32 @load_field_unsigned
+//LLVM: define dso_local i32 @load_field_unsigned(ptr noundef
 //LLVM:   [[TMP0:%.*]] = alloca ptr, i64 1, align 8
 //LLVM:   [[TMP1:%.*]] = load ptr, ptr [[TMP0]], align 8
 //LLVM:   [[TMP2:%.*]] = getelementptr %struct.A, ptr [[TMP1]], i32 0, i32 3
@@ -235,7 +235,7 @@ void get_volatile(V* v) {
 // CIR:   [[TMP3:%.*]] = cir.get_member [[TMP2]][0] {name = "b"} : !cir.ptr<!rec_V> -> !cir.ptr<!u64i>
 // CIR:   [[TMP4:%.*]] = cir.set_bitfield align(4) (#bfi_b, [[TMP3]] : !cir.ptr<!u64i>, [[TMP1]] : !s32i) {is_volatile} -> !s32i
 
-// LLVM: define dso_local void @get_volatile
+// LLVM: define dso_local void @get_volatile(ptr noundef
 // LLVM:   [[TMP0:%.*]] = alloca ptr, i64 1, align 8
 // LLVM:   [[TMP1:%.*]] = load ptr, ptr [[TMP0]], align 8
 // LLVM:   [[TMP2:%.*]] = getelementptr %struct.V, ptr [[TMP1]], i32 0, i32 0
@@ -262,7 +262,7 @@ void set_volatile(V* v) {
 //CIR:   [[TMP3:%.*]] = cir.get_member [[TMP2]][0] {name = "b"} : !cir.ptr<!rec_V> -> !cir.ptr<!u64i>
 //CIR:   [[TMP4:%.*]] = cir.set_bitfield align(4) (#bfi_b, [[TMP3]] : !cir.ptr<!u64i>, [[TMP1]] : !s32i) {is_volatile} -> !s32i
 
-// LLVM: define dso_local void @set_volatile
+// LLVM: define dso_local void @set_volatile(ptr noundef
 // LLVM:   [[TMP0:%.*]] = alloca ptr, i64 1, align 8
 // LLVM:   [[TMP1:%.*]] = load ptr, ptr [[TMP0]], align 8
 // LLVM:   [[TMP2:%.*]] = getelementptr %struct.V, ptr [[TMP1]], i32 0, i32 0
@@ -291,7 +291,7 @@ void unOp(S* s) {
 // CIR:   [[TMP4:%.*]] = cir.inc nsw [[TMP3]] : !s32i
 // CIR:   cir.set_bitfield align(4) (#bfi_d, [[TMP2]] : !cir.ptr<!u64i>, [[TMP4]] : !s32i)
 
-// LLVM: define {{.*@unOp}}
+// LLVM: define {{.*}} void @unOp(ptr noundef
 // LLVM:   [[TMP0:%.*]] = getelementptr %struct.S, ptr [[LOAD0:%.*]], i32 0, i32 0
 // LLVM:   [[TMP1:%.*]] = load i64, ptr [[TMP0]], align 4
 // LLVM:   [[TMP2:%.*]] = shl i64 [[TMP1]], 13
@@ -338,7 +338,7 @@ void binOp(S* s) {
 // CIR:   [[TMP3:%.*]] = cir.or [[TMP2]], [[TMP0]] : !s32i
 // CIR:   cir.set_bitfield align(4) (#bfi_d, [[TMP1]] : !cir.ptr<!u64i>, [[TMP3]] : !s32i)
 
-// LLVM: define {{.*@binOp}}
+// LLVM: define {{.*}} void @binOp(ptr noundef
 // LLVM:   [[TMP0:%.*]] = load ptr, ptr {{.*}}, align 8
 // LLVM:   [[TMP1:%.*]] = getelementptr %struct.S, ptr [[TMP0]], i32 0, i32 0
 // LLVM:   [[TMP2:%.*]] = load i64, ptr [[TMP1]], align 4

--- a/clang/test/CIR/CodeGen/bitfields_be.c
+++ b/clang/test/CIR/CodeGen/bitfields_be.c
@@ -58,7 +58,7 @@ void load(S* s) {
 // CIR:    %[[GET0:.*]] = cir.get_member %[[VAL0]][0] {name = "a"} : !cir.ptr<!rec_S> -> !cir.ptr<!u32i>
 // CIR:    %[[SET0:.*]] = cir.set_bitfield align(4) (#bfi_a, %[[GET0]] : !cir.ptr<!u32i>, %[[CONST1]] : !s32i) -> !s32i
 
-// LLVM: define dso_local void @load{{.*}}{{.*}}
+// LLVM: define dso_local void @load(ptr noundef
 // LLVM:   %[[PTR0:.*]] = load ptr
 // LLVM:   %[[GET0:.*]] = getelementptr %struct.S, ptr %[[PTR0]], i32 0, i32 0
 // LLVM:   %[[VAL0:.*]] = load i32, ptr %[[GET0]], align 4

--- a/clang/test/CIR/CodeGen/call-via-class-member-funcptr.cpp
+++ b/clang/test/CIR/CodeGen/call-via-class-member-funcptr.cpp
@@ -27,7 +27,7 @@ void fn1() { F f1; }
 // CIR:   %[[H_VAL:.*]] = cir.load{{.*}} %[[H_PTR]] : !cir.ptr<!s32i>, !s32i
 // CIR:   %[[RET:.*]] = cir.call @_ZN1A1bEi(%[[H_VAL]]) : (!s32i {llvm.noundef}) -> (!cir.ptr<!s8i> {llvm.noundef})
 
-// LLVM: define {{.*}} ptr @_ZN1F1bEv
+// LLVM: define {{.*}} noundef ptr @_ZN1F1bEv(ptr noundef nonnull align 1 dereferenceable(1) %0)
 // LLVM:   %[[VAR_H:.*]] = load i32, ptr @h
 // LLVM:   %[[RET:.*]] = call noundef ptr @_ZN1A1bEi(i32 noundef %[[VAR_H]])
 

--- a/clang/test/CIR/CodeGen/call.cpp
+++ b/clang/test/CIR/CodeGen/call.cpp
@@ -25,7 +25,7 @@ int f4() {
 // CIR-LABEL: cir.func{{.*}} @_Z2f4v() -> (!s32i{{.*}})
 // CIR:         cir.call @_Z2f3v() : () -> (!s32i{{.*}})
 
-// LLVM-LABEL: define{{.*}} i32 @_Z2f4v(){{.*}} {
+// LLVM-LABEL: define{{.*}} noundef i32 @_Z2f4v(){{.*}} {
 // LLVM:         %{{.+}} = call{{.*}} i32 @_Z2f3v()
 
 int f5(int a, int *b, bool c);
@@ -40,7 +40,7 @@ int f6() {
 // CIR-NEXT:    %[[#c:]] = cir.const #false
 // CIR-NEXT:    %{{.+}} = cir.call @_Z2f5iPib(%[[#a]], %[[#b:]], %[[#c]]) : (!s32i {{.*}}, !cir.ptr<!s32i> {{.*}}, !cir.bool {{.*}}) -> (!s32i{{.*}})
 
-// LLVM-LABEL: define{{.*}} i32 @_Z2f6v(){{.*}} {
+// LLVM-LABEL: define{{.*}} noundef i32 @_Z2f6v(){{.*}} {
 // LLVM:         %{{.+}} = call{{.*}} i32 @_Z2f5iPib(i32 {{.*}} 2, ptr {{.*}} %{{.+}}, i1 {{.*}} false)
 
 int f7(int (*ptr)(int, int)) {
@@ -53,7 +53,7 @@ int f7(int (*ptr)(int, int)) {
 // CIR-NEXT:    %[[#b:]] = cir.const #cir.int<2> : !s32i
 // CIR-NEXT:    %{{.+}} = cir.call %[[#ptr]](%[[#a]], %[[#b]]) : (!cir.ptr<!cir.func<(!s32i, !s32i) -> !s32i>>, !s32i {{.*}}, !s32i {{.*}}) -> (!s32i{{.*}})
 
-// LLVM-LABEL: define{{.*}} i32 @_Z2f7PFiiiE
+// LLVM-LABEL: define{{.*}} noundef i32 @_Z2f7PFiiiE(ptr noundef %{{.*}}){{.*}}
 // LLVM:         %[[#ptr:]] = load ptr, ptr %{{.+}}
 // LLVM-NEXT:    %{{.+}} = call{{.*}} i32 %[[#ptr]](i32 {{.*}} 1, i32 {{.*}} 2)
 

--- a/clang/test/CIR/CodeGen/cast.cpp
+++ b/clang/test/CIR/CodeGen/cast.cpp
@@ -27,7 +27,7 @@ unsigned char cxxstaticcast_0(unsigned int x) {
 
 int cStyleCasts_0(unsigned x1, int x2, float x3, short x4, double x5) {
 // CIR: cir.func{{.*}} @_Z13cStyleCasts_0jifsd
-// LLVM: define{{.*}} i32 @_Z13cStyleCasts_0jifsd
+// LLVM: define{{.*}} noundef i32 @_Z13cStyleCasts_0jifsd(i32 noundef %{{[0-9]+}}, i32 noundef %{{[0-9]+}}, float noundef %{{[0-9]+}}, i16 noundef %{{[0-9]+}}, double noundef %{{[0-9]+}})
 
   char a = (char)x1; // truncate
   // CIR: %{{[0-9]+}} = cir.cast integral %{{[0-9]+}} : !u32i -> !s8i

--- a/clang/test/CIR/CodeGen/compound_assign.cpp
+++ b/clang/test/CIR/CodeGen/compound_assign.cpp
@@ -42,7 +42,7 @@ int compound_assign(int b) {
 // CIR:   %[[OR:.*]] = cir.or %{{.*}}, %{{.*}} : !s32i
 // CIR:   cir.store{{.*}} %[[OR]], %{{.*}} : !s32i, !cir.ptr<!s32i>
 
-// LLVM: define {{.*}}i32 @_Z15compound_assigni
+// LLVM: define {{.*}} noundef i32 @_Z15compound_assigni(i32 noundef %0)
 // LLVM:   %[[MUL:.*]] = mul nsw i32 %{{.*}}, %{{.*}}
 // LLVM:   store i32 %[[MUL]], ptr %{{.*}}
 // LLVM:   %[[DIV:.*]] = sdiv i32 %{{.*}}, %{{.*}}

--- a/clang/test/CIR/CodeGen/delete.cpp
+++ b/clang/test/CIR/CodeGen/delete.cpp
@@ -34,7 +34,7 @@ void test_sized_delete(SizedDelete *x) {
 // CIR:     }
 // CIR:   }
 
-// LLVM: define dso_local void @_Z17test_sized_deleteP11SizedDelete
+// LLVM: define dso_local void @_Z17test_sized_deleteP11SizedDelete(ptr noundef %0)
 // LLVM:   %[[X:.*]] = load ptr, ptr %{{.*}}
 // LLVM:   %[[NOT_NULL:.*]] = icmp ne ptr %[[X]], null
 // LLVM:   br i1 %[[NOT_NULL]], label %[[DELETE_NOTNULL:.*]], label %[[DELETE_END:.*]]

--- a/clang/test/CIR/CodeGen/dtors.cpp
+++ b/clang/test/CIR/CodeGen/dtors.cpp
@@ -71,7 +71,7 @@ bool test_temp_or() { return make_temp(1) || make_temp(2); }
 // CIR:   %[[RETVAL:.*]] = cir.load{{.*}} %[[RET_ADDR]]
 // CIR:   cir.return %[[RETVAL]]
 
-// LLVM: define{{.*}} i1 @_Z12test_temp_orv(){{.*}} {
+// LLVM: define{{.*}} noundef i1 @_Z12test_temp_orv(){{.*}} {
 // LLVM:   %[[REF_TMP0:.*]] = alloca %struct.B
 // LLVM:   %[[REF_TMP1:.*]] = alloca %struct.B
 // LLVM:   %[[TMP_RESULT1:.*]] = alloca i8
@@ -177,7 +177,7 @@ bool test_temp_and() { return make_temp(1) && make_temp(2); }
 // CIR:   %[[RETVAL:.*]] = cir.load{{.*}} %[[RET_ADDR]]
 // CIR:   cir.return %[[RETVAL]]
 
-// LLVM: define{{.*}} i1 @_Z13test_temp_andv(){{.*}} {
+// LLVM: define{{.*}} noundef i1 @_Z13test_temp_andv(){{.*}} {
 // LLVM:   %[[REF_TMP0:.*]] = alloca %struct.B{{.*}}
 // LLVM:   %[[REF_TMP1:.*]] = alloca %struct.B{{.*}}
 // LLVM:   %[[TMP_RESULT:.*]] = alloca i8{{.*}}
@@ -482,7 +482,7 @@ void test_base_dtor_call_virtual_base() {
 // CIR:   %[[VIRTUAL_BASE:.*]] = cir.base_class_addr %[[THIS]] : !cir.ptr<!rec_Derived> nonnull [0] -> !cir.ptr<!rec_VirtualBase>
 // CIR:   cir.call @_ZN11VirtualBaseD2Ev(%[[VIRTUAL_BASE]])
 
-// LLVM: define {{.*}} void @_ZN7DerivedD1Ev
+// LLVM: define {{.*}} void @_ZN7DerivedD1Ev(ptr noundef nonnull align 8 dereferenceable(8) %{{.*}})
 // LLVM:   call void @_ZN7DerivedD2Ev(ptr {{.*}} %{{.*}}, ptr {{.*}} @_ZTT7Derived)
 // LLVM:   call void @_ZN11VirtualBaseD2Ev(ptr {{.*}} %{{.*}})
 

--- a/clang/test/CIR/CodeGen/dynamic-cast-exact.cpp
+++ b/clang/test/CIR/CodeGen/dynamic-cast-exact.cpp
@@ -90,7 +90,7 @@ Derived &ref_cast(Base1 &ref) {
 // CIR-NEXT:   }
 // CIR-NEXT:   %{{.+}} = cir.cast bitcast %[[SRC]] : !cir.ptr<!rec_Base1> -> !cir.ptr<!rec_Derived>
 
-//      LLVM: define{{.*}} ptr @_Z8ref_castR5Base1(ptr{{.*}} %[[SRC:.*]])
+//      LLVM: define{{.*}} noundef nonnull align 8 dereferenceable(8) ptr @_Z8ref_castR5Base1(ptr noundef nonnull{{.*}} dereferenceable(8) %[[SRC:.*]])
 // LLVM-NEXT:   %[[VPTR:.*]] = load ptr, ptr %[[SRC]], align 8
 // LLVM-NEXT:   %[[OK:.*]] = icmp eq ptr %[[VPTR]], getelementptr inbounds nuw (i8, ptr @_ZTV7Derived, i64 16)
 // LLVM-NEXT:   br i1 %[[OK]], label %[[LABEL_OK:.*]], label %[[LABEL_FAIL:.*]]
@@ -182,7 +182,7 @@ Derived *ptr_cast_always_fail(Base2 *ptr) {
 // CIR-NEXT:   %[[RESULT:.*]] = cir.const #cir.ptr<null> : !cir.ptr<!rec_Derived>
 // CIR-NEXT:   cir.store %[[RESULT]], %{{.*}} : !cir.ptr<!rec_Derived>, !cir.ptr<!cir.ptr<!rec_Derived>>
 
-//      LLVM: define {{.*}} ptr @_Z20ptr_cast_always_failP5Base2
+//      LLVM: define {{.*}} noundef ptr @_Z20ptr_cast_always_failP5Base2(ptr noundef{{.*}})
 // LLVM-NEXT:   ret ptr null
 
 //      OGCG: define {{.*}} ptr @_Z20ptr_cast_always_failP5Base2
@@ -198,7 +198,7 @@ Derived &ref_cast_always_fail(Base2 &ref) {
 // CIR-NEXT:   cir.call @__cxa_bad_cast() : () -> ()
 // CIR-NEXT:   cir.unreachable
 
-//      LLVM: define {{.*}} ptr @_Z20ref_cast_always_failR5Base2
+//      LLVM: define {{.*}} noundef nonnull align 8 dereferenceable(8) ptr @_Z20ref_cast_always_failR5Base2(ptr noundef nonnull{{.*}} dereferenceable(8) %0)
 // LLVM-NEXT:   tail call void @__cxa_bad_cast()
 // LLVM-NEXT:   unreachable
 

--- a/clang/test/CIR/CodeGen/dynamic-cast.cpp
+++ b/clang/test/CIR/CodeGen/dynamic-cast.cpp
@@ -42,7 +42,7 @@ Derived *ptr_cast(Base *b) {
 // CIR-AFTER-NEXT:   }) : (!cir.bool) -> !cir.ptr<!rec_Derived>
 //      CIR-AFTER: }
 
-// LLVM: define {{.*}} @_Z8ptr_castP4Base
+// LLVM: define {{.*}} noundef ptr @_Z8ptr_castP4Base(ptr noundef %0)
 // LLVM:   %[[IS_NOT_NULL:.*]] = icmp ne ptr %[[PTR:.*]], null
 // LLVM:   br i1 %[[IS_NOT_NULL]], label %[[NOT_NULL:.*]], label %[[NULL:.*]]
 // LLVM: [[NOT_NULL]]:
@@ -88,7 +88,7 @@ Derived &ref_cast(Base &b) {
 // CIR-AFTER-NEXT:   %{{.+}} = cir.cast bitcast %[[CASTED_PTR]] : !cir.ptr<!void> -> !cir.ptr<!rec_Derived>
 //      CIR-AFTER: }
 
-// LLVM: define {{.*}} ptr @_Z8ref_castR4Base
+// LLVM: define {{.*}} noundef nonnull align 8 dereferenceable(8) ptr @_Z8ref_castR4Base(ptr noundef nonnull align 8 dereferenceable(8) %0)
 // LLVM:   %[[RESULT:.*]] = call ptr @__dynamic_cast(ptr %{{.*}}, ptr @_ZTI4Base, ptr @_ZTI7Derived, i64 0)
 // LLVM:   %[[IS_NULL:.*]] = icmp eq ptr %[[RESULT]], null
 // LLVM:   br i1 %[[IS_NULL]], label %[[BAD_CAST:.*]], label %[[DONE:.*]]
@@ -130,7 +130,7 @@ void *ptr_cast_to_complete(Base *ptr) {
 // CIR-AFTER-NEXT:   }) : (!cir.bool) -> !cir.ptr<!void>
 //      CIR-AFTER: }
 
-// LLVM: define {{.*}} @_Z20ptr_cast_to_completeP4Base
+// LLVM: define {{.*}} noundef ptr @_Z20ptr_cast_to_completeP4Base(ptr noundef %0)
 // LLVM:   %[[IS_NOT_NULL:.*]] = icmp ne ptr %[[PTR:.*]], null
 // LLVM:   br i1 %[[IS_NOT_NULL]], label %[[NOT_NULL:.*]], label %[[NULL:.*]]
 // LLVM: [[NOT_NULL]]:

--- a/clang/test/CIR/CodeGen/finegrain-bitfield-access.cpp
+++ b/clang/test/CIR/CodeGen/finegrain-bitfield-access.cpp
@@ -52,7 +52,7 @@ unsigned read8_1() {
 // CIR: [[RET:%.*]] = cir.load {{.*}} : !cir.ptr<!u32i>, !u32i
 // CIR: cir.return [[RET]] : !u32i
 
-// LLVM-LABEL: @_Z7read8_1v
+// LLVM-LABEL: define{{.*}} noundef i32 @_Z7read8_1v
 // LLVM:  [[MEMBER:%.*]] = load i8, ptr getelementptr inbounds nuw (i8, ptr {{.*}}, i64 1), align 1
 // LLVM:  [[BFCAST:%.*]] = zext i8 [[MEMBER]] to i32
 // LLVM:  store i32 [[BFCAST]], ptr {{.*}}, align 4
@@ -93,7 +93,7 @@ unsigned read8_2() {
 // CIR: [[RET:%.*]] = cir.load {{.*}} : !cir.ptr<!u32i>, !u32i
 // CIR: cir.return [[RET]] : !u32i
 
-// LLVM-LABEL: @_Z7read8_2v
+// LLVM-LABEL: define{{.*}} noundef i32 @_Z7read8_2v
 // LLVM:  [[BFLOAD:%.*]] = load i16, ptr getelementptr inbounds nuw (i8, ptr {{.*}}, i64 2), align 2
 // LLVM:  [[BFLSHR:%.*]] = lshr i16 [[BFLOAD]], 4
 // LLVM:  [[BFCLEAR:%.*]] = and i16 [[BFLSHR]], 255
@@ -144,7 +144,7 @@ unsigned read16_1() {
 // CIR: [[RET:%.*]] = cir.load {{.*}} : !cir.ptr<!u32i>, !u32i
 // CIR: cir.return [[RET]] : !u32i
 
-// LLVM-LABEL: @_Z8read16_1v
+// LLVM-LABEL: define{{.*}} noundef i32 @_Z8read16_1v
 // LLVM:  [[BFLOAD:%.*]] = load i16, ptr {{.*}}, align 8
 // LLVM:  [[BFCAST:%.*]] = zext i16 [[BFLOAD]] to i64
 // LLVM:  [[BF:%.*]] = trunc i64 [[BFCAST]] to i32
@@ -170,7 +170,7 @@ unsigned read16_2() {
 // CIR: [[RET:%.*]] = cir.load {{.*}} : !cir.ptr<!u32i>, !u32i
 // CIR: cir.return [[RET]] : !u32i
 
-// LLVM-LABEL: @_Z8read16_2v
+// LLVM-LABEL: define{{.*}} noundef i32 @_Z8read16_2v
 // LLVM:  [[BFLOAD:%.*]] = load i16, ptr getelementptr inbounds nuw (i8, ptr {{.*}}, i64 2), align 2
 // LLVM:  [[BFCAST:%.*]] = zext i16 [[BFLOAD]] to i64
 // LLVM:  [[BF:%.*]] = trunc i64 [[BFCAST]] to i32
@@ -233,7 +233,7 @@ unsigned read32_1() {
 // CIR: [[RET:%.*]] = cir.load {{.*}} : !cir.ptr<!u32i>, !u32i
 // CIR: cir.return [[RET]] : !u32i
 
-// LLVM-LABEL: @_Z8read32_1v
+// LLVM-LABEL: define{{.*}} noundef i32 @_Z8read32_1v
 // LLVM: [[BFLOAD:%.*]] = load i32, ptr getelementptr inbounds nuw (i8, ptr {{.*}}, i64 4), align 4
 // LLVM: [[BFCAST:%.*]] = zext i32 [[BFLOAD]] to i64
 // LLVM: [[BF:%.*]] = trunc i64 [[BFCAST]] to i32

--- a/clang/test/CIR/CodeGen/goto.cpp
+++ b/clang/test/CIR/CodeGen/goto.cpp
@@ -27,7 +27,7 @@ err:
 // CIR:    [[RET:%.*]] = cir.load [[RETVAL]] : !cir.ptr<!s32i>, !s32i
 // CIR:    cir.return [[RET]] : !s32i
 
-// LLVM: define dso_local noundef i32 @_Z21shouldNotGenBranchReti
+// LLVM: define dso_local noundef i32 @_Z21shouldNotGenBranchReti(i32 noundef %{{[0-9]+}})
 // LLVM:   [[COND:%.*]] = load i32, ptr {{.*}}, align 4
 // LLVM:   [[CMP:%.*]] = icmp sgt i32 [[COND]], 5
 // LLVM:   br i1 [[CMP]], label %[[IFTHEN:.*]], label %[[IFEND:.*]]
@@ -66,7 +66,7 @@ err:
 // CIR:  ^bb1:
 // CIR:    cir.label "err"
 
-// LLVM: define dso_local noundef i32 @_Z15shouldGenBranchi
+// LLVM: define dso_local noundef i32 @_Z15shouldGenBranchi(i32 noundef %{{[0-9]+}})
 // LLVM:   br i1 [[CMP:%.*]], label %[[IFTHEN:.*]], label %[[IFEND:.*]]
 // LLVM: [[IFTHEN]]:
 // LLVM:   br label %[[ERR:.*]]
@@ -104,7 +104,7 @@ end2:
 // CIR:  ^bb[[#BLK3]]:
 // CIR:    cir.label "end2"
 
-// LLVM: define dso_local void @_Z19severalLabelsInARowi
+// LLVM: define dso_local void @_Z19severalLabelsInARowi(i32 noundef %{{[0-9]+}})
 // LLVM:   br label %[[END1:.*]]
 // LLVM: [[UNRE:.*]]:                                                ; No predecessors!
 // LLVM:   br label %[[END2:.*]]
@@ -134,7 +134,7 @@ end:
 // CIR:  ^bb[[#BLK2:]]:
 // CIR:    cir.label "end"
 
-// LLVM: define dso_local void @_Z18severalGotosInARowi
+// LLVM: define dso_local void @_Z18severalGotosInARowi(i32 noundef %{{[0-9]+}})
 // LLVM:   br label %[[END:.*]]
 // LLVM: [[UNRE:.*]]:                                                ; No predecessors!
 // LLVM:   br label %[[END]]
@@ -168,7 +168,7 @@ extern "C" void multiple_non_case(int v) {
 // CIR: cir.call @action2()
 // CIR: cir.break
 
-// LLVM: define dso_local void @multiple_non_case
+// LLVM: define dso_local void @multiple_non_case(i32 noundef %{{[0-9]+}})
 // LLVM: [[SWDEFAULT:.*]]:
 // LLVM:   call void @action1()
 // LLVM:   br label %[[L2:.*]]
@@ -210,7 +210,7 @@ extern "C" void case_follow_label(int v) {
 // CIR:   cir.call @action2()
 // CIR:   cir.goto "label"
 
-// LLVM: define dso_local void @case_follow_label
+// LLVM: define dso_local void @case_follow_label(i32 noundef %{{[0-9]+}})
 // LLVM:  switch i32 {{.*}}, label %[[SWDEFAULT:.*]] [
 // LLVM:    i32 1, label %[[CASE1:.*]]
 // LLVM:    i32 2, label %[[CASE2:.*]]
@@ -271,7 +271,7 @@ extern "C" void default_follow_label(int v) {
 // CIR:   cir.call @action2()
 // CIR:   cir.goto "label"
 
-// LLVM: define dso_local void @default_follow_label
+// LLVM: define dso_local void @default_follow_label(i32 noundef %{{[0-9]+}})
 // LLVM: [[CASE1:.*]]:
 // LLVM:   br label %[[BB8:.*]]
 // LLVM: [[BB8]]:

--- a/clang/test/CIR/CodeGen/if.cpp
+++ b/clang/test/CIR/CodeGen/if.cpp
@@ -285,7 +285,7 @@ int if_init() {
 // CIR:   }
 // CIR: }
 
-// LLVM: define{{.*}} i32 @_Z7if_initv()
+// LLVM: define{{.*}} noundef i32 @_Z7if_initv()
 // LLVM: %[[X:.*]] = alloca i32, i64 1, align 4
 // LLVM: %[[RETVAL:.*]] = alloca i32, i64 1, align 4
 // LLVM: store i32 42, ptr %[[X]], align 4

--- a/clang/test/CIR/CodeGen/inline-attributes.cpp
+++ b/clang/test/CIR/CodeGen/inline-attributes.cpp
@@ -42,20 +42,20 @@ int (*regular_ptr)(int) = &regular_function;
 // CIR-LABEL: cir.func{{.*}} inline_hint {{.*}}@_Z20inline_hint_functioni(%arg0: !s32i {{.*}}) -> (!s32i{{.*}})
 
 // LLVM: ; Function Attrs:{{.*}} noinline
-// LLVM: define{{.*}} i32 @_Z17noinline_functioni
+// LLVM: define{{.*}} noundef i32 @_Z17noinline_functioni(i32 noundef
 
 // LLVM: ; Function Attrs:
 // LLVM-NOT: noinline
 // LLVM-NOT: alwaysinline
 // LLVM-NOT: inlinehint
 // LLVM-SAME: {{$}}
-// LLVM: define{{.*}} i32 @_Z16regular_functioni
+// LLVM: define{{.*}} noundef i32 @_Z16regular_functioni(i32 noundef
 
 // LLVM: ; Function Attrs:{{.*}} alwaysinline
-// LLVM: define{{.*}} i32 @_Z22always_inline_functioni
+// LLVM: define{{.*}} noundef i32 @_Z22always_inline_functioni(i32 noundef
 
 // LLVM: ; Function Attrs:{{.*}} inlinehint
-// LLVM: define{{.*}} i32 @_Z20inline_hint_functioni
+// LLVM: define{{.*}} noundef i32 @_Z20inline_hint_functioni(i32 noundef
 
 // OGCG: ; Function Attrs:{{.*}} noinline
 // OGCG: define{{.*}} i32 @_Z17noinline_functioni

--- a/clang/test/CIR/CodeGen/label.c
+++ b/clang/test/CIR/CodeGen/label.c
@@ -73,7 +73,7 @@ labelD:
 // CIR:      }
 // CIR:    cir.return
 
-// LLVM: define dso_local void @label_in_if{{.*}}
+// LLVM: define dso_local void @label_in_if(i32 noundef %{{[0-9]+}}){{.*}}
 // LLVM:   br label %3
 // LLVM: 3:
 // LLVM:   [[LOAD:%.*]] = load i32, ptr [[COND:%.*]], align 4

--- a/clang/test/CIR/CodeGen/lambda.cpp
+++ b/clang/test/CIR/CodeGen/lambda.cpp
@@ -279,7 +279,7 @@ int f() {
 // LLVM:   %[[RET:.*]] = load i32, ptr %[[I_ALLOCA]]
 // LLVM:   ret i32 %[[RET]]
 
-// LLVM: define {{.*}} i32 @_Z1fv()
+// LLVM: define {{.*}} noundef i32 @_Z1fv()
 // LLVM:   %[[TMP:.*]] = alloca %[[REC_LAM_G2]]
 // LLVM:   %[[RETVAL:.*]] = alloca i32
 // LLVM:   br label %[[SCOPE_BB:.*]]
@@ -504,7 +504,7 @@ int test_lambda_this1(){
 // CIR:   cir.call @_ZN1A3fooEv(%[[A_THIS]]){{.*}} : (!cir.ptr<!rec_A> {{.*}}) -> (!s32i {llvm.noundef})
 // CIR:   cir.call @_ZN1A3barEv(%[[A_THIS]]){{.*}} : (!cir.ptr<!rec_A> {{.*}}) -> (!s32i {llvm.noundef})
 
-// LLVM: define {{.*}} i32 @_Z17test_lambda_this1v
+// LLVM: define {{.*}} noundef i32 @_Z17test_lambda_this1v
 // LLVM:   %[[A_THIS:.*]] = alloca %struct.A
 // LLVM:   call void @_ZN1AC1Ev(ptr {{.*}} %[[A_THIS]])
 // LLVM:   call noundef i32 @_ZN1A3fooEv(ptr {{.*}} %[[A_THIS]])

--- a/clang/test/CIR/CodeGen/multi-vtable.cpp
+++ b/clang/test/CIR/CodeGen/multi-vtable.cpp
@@ -158,13 +158,13 @@ Child::Child() {}
 
 // The GEP instructions are different between LLVM and OGCG, but they calculate the same addresses.
 
-// LLVM: define{{.*}} void @_ZN5ChildC2Ev(ptr{{.*}} %[[THIS_ARG:.*]])
+// LLVM: define{{.*}} void @_ZN5ChildC2Ev(ptr noundef nonnull align 8 dereferenceable(16) %[[THIS_ARG:.*]])
 // LLVM:   %[[THIS_ADDR:.*]] = alloca ptr
 // LLVM:   store ptr %[[THIS_ARG]], ptr %[[THIS_ADDR]]
 // LLVM:   %[[THIS:.*]] = load ptr, ptr %[[THIS_ADDR]]
-// LLVM:   call void @_ZN6MotherC2Ev(ptr{{.*}} %[[THIS]])
+// LLVM:   call void @_ZN6MotherC2Ev(ptr noundef nonnull align 8 dereferenceable(8) %[[THIS]])
 // LLVM:   %[[FATHER_BASE:.*]] = getelementptr{{.*}} i8, ptr %[[THIS]], i32 8
-// LLVM:   call void @_ZN6FatherC2Ev(ptr{{.*}} %[[FATHER_BASE]])
+// LLVM:   call void @_ZN6FatherC2Ev(ptr noundef nonnull align 8 dereferenceable(8) %[[FATHER_BASE]])
 // LLVM:   store ptr getelementptr inbounds nuw (i8, ptr @_ZTV5Child, i64 16), ptr %[[THIS]]
 // LLVM:   %[[FATHER_BASE:.*]] = getelementptr{{.*}} i8, ptr %[[THIS]], i32 8
 // LLVM:   store ptr getelementptr inbounds nuw (i8, ptr @_ZTV5Child, i64 48), ptr %[[FATHER_BASE]]

--- a/clang/test/CIR/CodeGen/new.cpp
+++ b/clang/test/CIR/CodeGen/new.cpp
@@ -462,7 +462,7 @@ void t_new_var_size(size_t n) {
 // CHECK:    %[[N:.*]] = cir.load{{.*}} %[[ARG_ALLOCA:.*]]
 // CHECK:    %[[PTR:.*]] = cir.call @_Znam(%[[N]]) {allocsize = array<i32: 0>, builtin} : (!u64i {llvm.noundef})
 
-// LLVM: define{{.*}} void @_Z14t_new_var_sizem
+// LLVM: define{{.*}} void @_Z14t_new_var_sizem(i64 noundef
 // LLVM:   %[[N:.*]] = load i64, ptr %{{.+}}
 // LLVM:   %[[PTR:.*]] = call noundef ptr @_Znam(i64 {{.*}} %[[N]])
 
@@ -479,7 +479,7 @@ void t_new_var_size2(int n) {
 // CHECK:    %[[N_SIZE_T:.*]] = cir.cast integral %[[N]] : !s32i -> !u64i
 // CHECK:    %[[PTR:.*]] = cir.call @_Znam(%[[N_SIZE_T]]) {allocsize = array<i32: 0>, builtin} : (!u64i {llvm.noundef})
 
-// LLVM: define{{.*}} void @_Z15t_new_var_size2i
+// LLVM: define{{.*}} void @_Z15t_new_var_size2i(i32 noundef
 // LLVM:   %[[N:.*]] = load i32, ptr %{{.+}}
 // LLVM:   %[[N_SIZE_T:.*]] = sext i32 %[[N]] to i64
 // LLVM:   %[[PTR:.*]] = call noundef ptr @_Znam(i64 {{.*}} %[[N_SIZE_T]])
@@ -501,7 +501,7 @@ void t_new_var_size3(size_t n) {
 // CHECK:    %[[ALLOC_SIZE:.*]] = cir.select if %[[OVERFLOW]] then %[[ALL_ONES]] else %[[RESULT]] : (!cir.bool, !u64i, !u64i)
 // CHECK:    %[[PTR:.*]] = cir.call @_Znam(%[[ALLOC_SIZE]]) {allocsize = array<i32: 0>, builtin} : (!u64i {llvm.noundef})
 
-// LLVM: define{{.*}} void @_Z15t_new_var_size3m
+// LLVM: define{{.*}} void @_Z15t_new_var_size3m(i64 noundef
 // LLVM:   %[[N:.*]] = load i64, ptr %{{.+}}
 // LLVM:   %[[MUL_OVERFLOW:.*]] = call { i64, i1 } @llvm.umul.with.overflow.i64(i64 %[[N]], i64 8)
 // LLVM:   %[[ELEMENT_SIZE:.*]] = extractvalue { i64, i1 } %[[MUL_OVERFLOW]], 0
@@ -530,7 +530,7 @@ void t_new_var_size4(int n) {
 // CHECK:    %[[ALLOC_SIZE:.*]] = cir.select if %[[OVERFLOW]] then %[[ALL_ONES]] else %[[RESULT]] : (!cir.bool, !u64i, !u64i)
 // CHECK:    %[[PTR:.*]] = cir.call @_Znam(%[[ALLOC_SIZE]]) {allocsize = array<i32: 0>, builtin} : (!u64i {llvm.noundef})
 
-// LLVM: define{{.*}} void @_Z15t_new_var_size4i
+// LLVM: define{{.*}} void @_Z15t_new_var_size4i(i32 noundef
 // LLVM:   %[[N:.*]] = load i32, ptr %{{.+}}
 // LLVM:   %[[N_SIZE_T:.*]] = sext i32 %[[N]] to i64
 // LLVM:   %[[MUL_OVERFLOW:.*]] = call { i64, i1 } @llvm.umul.with.overflow.i64(i64 %[[N_SIZE_T]], i64 8)
@@ -564,7 +564,7 @@ void t_new_var_size5(int n) {
 // CHECK:    %[[ALLOC_SIZE:.*]] = cir.select if %[[OVERFLOW]] then %[[ALL_ONES]] else %[[RESULT]] : (!cir.bool, !u64i, !u64i)
 // CHECK:    %[[PTR:.*]] = cir.call @_Znam(%[[ALLOC_SIZE]]) {allocsize = array<i32: 0>, builtin} : (!u64i {llvm.noundef})
 
-// LLVM: define{{.*}} void @_Z15t_new_var_size5i
+// LLVM: define{{.*}} void @_Z15t_new_var_size5i(i32 noundef
 // LLVM:   %[[N:.*]] = load i32, ptr %{{.+}}
 // LLVM:   %[[N_SIZE_T:.*]] = sext i32 %[[N]] to i64
 // LLVM:   %[[MUL_OVERFLOW:.*]] = call { i64, i1 } @llvm.umul.with.overflow.i64(i64 %[[N_SIZE_T]], i64 48)
@@ -616,7 +616,7 @@ void t_new_var_size6(int n) {
 // CHECK:    %[[ZERO:.*]] = cir.const #cir.int<0> : !u8i
 // CHECK:    cir.libc.memset{{.*}} bytes at %[[PTR_DOUBLE_3_VOID]] to %[[ZERO]]
 
-// LLVM: define{{.*}} void @_Z15t_new_var_size6i
+// LLVM: define{{.*}} void @_Z15t_new_var_size6i(i32 noundef
 // LLVM:   %[[N:.*]] = load i32, ptr %{{.+}}
 // LLVM:   %[[N_SIZE_T:.*]] = sext i32 %[[N]] to i64
 // LLVM:   %[[LT_MIN_SIZE:.*]] = icmp ult i64 %[[N_SIZE_T]], 3
@@ -667,7 +667,7 @@ void t_new_var_size7(__int128 n) {
 // CHECK:    %[[ALLOC_SIZE:.*]] = cir.select if %[[OVERFLOW]] then %[[ALL_ONES]] else %[[RESULT]] : (!cir.bool, !u64i, !u64i)
 // CHECK:    %[[PTR:.*]] = cir.call @_Znam(%[[ALLOC_SIZE]]) {allocsize = array<i32: 0>, builtin} : (!u64i {llvm.noundef})
 
-// LLVM: define{{.*}} void @_Z15t_new_var_size7n
+// LLVM: define{{.*}} void @_Z15t_new_var_size7n(i128 noundef
 // LLVM:   %[[N:.*]] = load i128, ptr %{{.+}}
 // LLVM:   %[[N_SIZE_T:.*]] = trunc i128 %[[N]] to i64
 // LLVM:   %[[MUL_OVERFLOW:.*]] = call { i64, i1 } @llvm.umul.with.overflow.i64(i64 %[[N_SIZE_T]], i64 8)
@@ -700,7 +700,7 @@ void t_new_var_size_nontrivial(size_t n) {
 // CHECK:    %[[ALLOC_SIZE:.*]] = cir.select if %[[ANY_OVERFLOW]] then %[[ALL_ONES]] else %[[SIZE]] : (!cir.bool, !u64i, !u64i)
 // CHECK:    %[[PTR:.*]] = cir.call @_Znam(%[[ALLOC_SIZE]]) {allocsize = array<i32: 0>, builtin} : (!u64i {llvm.noundef})
 
-// LLVM: define{{.*}} void @_Z25t_new_var_size_nontrivialm
+// LLVM: define{{.*}} void @_Z25t_new_var_size_nontrivialm(i64 noundef
 // LLVM:   %[[N:.*]] = load i64, ptr %{{.+}}
 // LLVM:   %[[MUL_OVERFLOW:.*]] = call { i64, i1 } @llvm.umul.with.overflow.i64(i64 %[[N]], i64 4)
 // LLVM:   %[[MUL_SIZE:.*]] = extractvalue { i64, i1 } %[[MUL_OVERFLOW]], 0

--- a/clang/test/CIR/CodeGen/pointer-to-data-member-cast.cpp
+++ b/clang/test/CIR/CodeGen/pointer-to-data-member-cast.cpp
@@ -154,7 +154,7 @@ bool to_bool(int Foo::*x) {
 // CIR-AFTER:   %[[NULL_VAL:.*]] = cir.const #cir.int<-1> : !s64i
 // CIR-AFTER:   %[[BOOL_VAL:.*]] = cir.cmp ne %{{.*}}, %[[NULL_VAL]] : !s64i
 
-// LLVM: define {{.*}} i1 @_Z7to_boolM3Fooi
+// LLVM: define {{.*}} noundef i1 @_Z7to_boolM3Fooi(i64 %{{.*}})
 // LLVM:   %[[X:.*]] = load i64, ptr %{{.*}}
 // LLVM:   %[[IS_NULL:.*]] = icmp ne i64 %[[X]], -1
 

--- a/clang/test/CIR/CodeGen/pointer-to-data-member-cmp.cpp
+++ b/clang/test/CIR/CodeGen/pointer-to-data-member-cmp.cpp
@@ -29,7 +29,7 @@ bool eq(int Foo::*x, int Foo::*y) {
 // CIR-AFTER:   %[[#y:]] = cir.load{{.*}} %{{.*}} : !cir.ptr<!s64i>, !s64i
 // CIR-AFTER:   %{{.*}} = cir.cmp eq %[[#x]], %[[#y]] : !s64i
 
-// LLVM-LABEL: @_Z2eqM3FooiS0_
+// LLVM: define {{.*}} noundef i1 @_Z2eqM3FooiS0_(i64 %{{.*}}, i64 %{{.*}})
 //      LLVM:   %[[#x:]] = load i64, ptr %{{.+}}, align 8
 // LLVM-NEXT:   %[[#y:]] = load i64, ptr %{{.+}}, align 8
 // LLVM-NEXT:   %{{.+}} = icmp eq i64 %[[#x]], %[[#y]]
@@ -56,7 +56,7 @@ bool ne(int Foo::*x, int Foo::*y) {
 // CIR-AFTER:   %[[#y:]] = cir.load{{.*}} %{{.*}} : !cir.ptr<!s64i>, !s64i
 // CIR-AFTER:   %{{.*}} = cir.cmp ne %[[#x]], %[[#y]] : !s64i
 
-// LLVM-LABEL: @_Z2neM3FooiS0_
+// LLVM: define {{.*}} noundef i1 @_Z2neM3FooiS0_(i64 %{{.*}}, i64 %{{.*}})
 //      LLVM:   %[[#x:]] = load i64, ptr %{{.+}}, align 8
 // LLVM-NEXT:   %[[#y:]] = load i64, ptr %{{.+}}, align 8
 // LLVM-NEXT:   %{{.+}} = icmp ne i64 %[[#x]], %[[#y]]

--- a/clang/test/CIR/CodeGen/pointer-to-member-func-cast.cpp
+++ b/clang/test/CIR/CodeGen/pointer-to-member-func-cast.cpp
@@ -29,7 +29,7 @@ bool memfunc_to_bool(void (Foo::*func)(int)) {
 // CIR-AFTER:   %[[FUNC_PTR:.*]] = cir.extract_member %[[FUNC]][0] : !rec_anon_struct -> !s64i
 // CIR-AFTER:   %[[BOOL_VAL:.*]] = cir.cmp ne %[[FUNC_PTR]], %[[NULL_VAL]] : !s64i
 
-// LLVM: define {{.*}} i1 @_Z15memfunc_to_boolM3FooFviE
+// LLVM: define {{.*}} noundef i1 @_Z15memfunc_to_boolM3FooFviE({ i64, i64 } %{{.*}})
 // LLVM:   %[[FUNC:.*]] = load { i64, i64 }, ptr %{{.*}}
 // LLVM:   %[[FUNC_PTR:.*]] = extractvalue { i64, i64 } %[[FUNC]], 0
 // LLVM:   %{{.*}} = icmp ne i64 %[[FUNC_PTR]], 0

--- a/clang/test/CIR/CodeGen/pointer-to-member-func-cmp.cpp
+++ b/clang/test/CIR/CodeGen/pointer-to-member-func-cmp.cpp
@@ -36,7 +36,7 @@ bool cmp_eq(void (Foo::*lhs)(int), void (Foo::*rhs)(int)) {
 // CIR-AFTER:   %[[TMP:.*]] = cir.or %[[PTR_NULL]], %[[ADJ_CMP]] : !cir.bool
 // CIR-AFTER:   %[[RESULT:.*]] = cir.and %[[PTR_CMP]], %[[TMP]] : !cir.bool
 
-// LLVM: define {{.*}} i1 @_Z6cmp_eqM3FooFviES1_
+// LLVM: define {{.*}} noundef i1 @_Z6cmp_eqM3FooFviES1_({ i64, i64 } %{{.*}}, { i64, i64 } %{{.*}})
 // LLVM:   %[[LHS:.*]] = load { i64, i64 }, ptr %{{.+}}
 // LLVM:   %[[RHS:.*]] = load { i64, i64 }, ptr %{{.+}}
 // LLVM:   %[[LHS_PTR:.*]] = extractvalue { i64, i64 } %[[LHS]], 0
@@ -90,7 +90,7 @@ bool cmp_ne(void (Foo::*lhs)(int), void (Foo::*rhs)(int)) {
 // CIR-AFTER:   %[[TMP:.*]] = cir.and %[[PTR_NULL]], %[[ADJ_CMP]] : !cir.bool
 // CIR-AFTER:   %[[RESULT:.*]] = cir.or %[[PTR_CMP]], %[[TMP]] : !cir.bool
 
-// LLVM: define {{.*}} i1 @_Z6cmp_neM3FooFviES1_
+// LLVM: define {{.*}} noundef i1 @_Z6cmp_neM3FooFviES1_({ i64, i64 } %{{.*}}, { i64, i64 } %{{.*}})
 // LLVM:   %[[LHS:.*]] = load { i64, i64 }, ptr %{{.*}}
 // LLVM:   %[[RHS:.*]] = load { i64, i64 }, ptr %{{.*}}
 // LLVM:   %[[LHS_PTR:.*]] = extractvalue { i64, i64 } %[[LHS]], 0

--- a/clang/test/CIR/CodeGen/pointer-to-member-func.cpp
+++ b/clang/test/CIR/CodeGen/pointer-to-member-func.cpp
@@ -79,7 +79,7 @@ auto make_virtual() -> void (Foo::*)(int) {
 // CIR-AFTER:   %[[RET:.*]] = cir.load %[[RETVAL]]
 // CIR-AFTER:   cir.return %[[RET]] : !rec_anon_struct
 
-// LLVM: define {{.*}} @_Z12make_virtualv()
+// LLVM: define {{.*}} { i64, i64 } @_Z12make_virtualv()
 // LLVM:   %[[RETVAL:.*]] = alloca { i64, i64 }
 // LLVM:   call void @llvm.memcpy{{.*}}(ptr %[[RETVAL]], ptr @[[VIRT_RET]]
 // LLVM:   %[[RET:.*]] = load { i64, i64 }, ptr %[[RETVAL]]
@@ -106,7 +106,7 @@ auto make_null() -> void (Foo::*)(int) {
 // CIR-AFTER:   %[[RET:.*]] = cir.load %[[RETVAL]]
 // CIR-AFTER:   cir.return %[[RET]] : !rec_anon_struct
 
-// LLVM: define {{.*}} @_Z9make_nullv()
+// LLVM: define {{.*}} { i64, i64 } @_Z9make_nullv()
 // LLVM:   %[[RETVAL:.*]] = alloca { i64, i64 }
 // LLVM:   call void @llvm.memcpy{{.*}}(ptr %[[RETVAL]], ptr @[[NULL_RET]]
 // LLVM:   %[[RET:.*]] = load { i64, i64 }, ptr %[[RETVAL]]
@@ -151,7 +151,7 @@ void call(Foo *obj, void (Foo::*func)(int), int arg) {
 // CIR-AFTER:   %[[ARG:.*]] = cir.load{{.*}} %{{.*}} : !cir.ptr<!s32i>, !s32i
 // CIR-AFTER:   cir.call %[[CALLEE]](%[[ADJUSTED_THIS]], %[[ARG]]) : (!cir.ptr<!cir.func<(!cir.ptr<!void>, !cir.ptr<!rec_Foo>, !s32i)>>, !cir.ptr<!void> {{.*}}, !s32i {{.*}}) -> ()
 
-// LLVM: define {{.*}} @_Z4callP3FooMS_FviEi
+// LLVM: define {{.*}} void @_Z4callP3FooMS_FviEi(ptr noundef %{{.*}}, i32 noundef %{{.*}})
 // LLVM:   %[[OBJ:.*]] = load ptr, ptr %{{.*}}
 // LLVM:   %[[MEMFN_PTR:.*]] = load { i64, i64 }, ptr %{{.*}}
 // LLVM:   %[[THIS_ADJ:.*]] = extractvalue { i64, i64 } %[[MEMFN_PTR]], 1

--- a/clang/test/CIR/CodeGen/statement-exprs.c
+++ b/clang/test/CIR/CodeGen/statement-exprs.c
@@ -280,5 +280,5 @@ int test3() { return ({ struct S s = {1}; s; }).x; }
 // Expression is wrapped in an expression attribute (just ensure it does not crash).
 void test4(int x) { ({[[gsl::suppress("foo")]] x;}); }
 // CIR: cir.func {{.*}} @test4
-// LLVM: @test4
+// LLVM: define{{.*}} void @test4(i32 noundef %0)
 // OGCG: @test4

--- a/clang/test/CIR/CodeGen/struct.c
+++ b/clang/test/CIR/CodeGen/struct.c
@@ -298,7 +298,7 @@ void f5(struct NodeS* a) {
 // CIR:   %[[NEXT:.*]] = cir.get_member {{%.}}[0] {name = "next"} : !cir.ptr<!rec_NodeS> -> !cir.ptr<!cir.ptr<!rec_NodeS>>
 // CIR:   cir.store {{.*}}, %[[NEXT]]
 
-// LLVM: define{{.*}} void @f5
+// LLVM: define{{.*}} void @f5(ptr noundef %{{.*}})
 // LLVM:   %[[NEXT:.*]] = getelementptr %struct.NodeS, ptr %{{.*}}, i32 0, i32 0
 // LLVM:   store ptr null, ptr %[[NEXT]]
 
@@ -317,7 +317,7 @@ void f6(struct CycleStart *start) {
 // CIR:   %[[END:.*]] = cir.get_member %{{.*}}[0] {name = "end"} : !cir.ptr<!rec_CycleMiddle> -> !cir.ptr<!cir.ptr<!rec_CycleEnd>>
 // CIR:   %[[START2:.*]] = cir.get_member %{{.*}}[0] {name = "start"} : !cir.ptr<!rec_CycleEnd> -> !cir.ptr<!cir.ptr<!rec_CycleStart>>
 
-// LLVM: define{{.*}} void @f6
+// LLVM: define{{.*}} void @f6(ptr noundef %{{.*}})
 // LLVM:   %[[MIDDLE:.*]] = getelementptr %struct.CycleStart, ptr %{{.*}}, i32 0, i32 0
 // LLVM:   %[[END:.*]] = getelementptr %struct.CycleMiddle, ptr %{{.*}}, i32 0, i32 0
 // LLVM:   %[[START2:.*]] = getelementptr %struct.CycleEnd, ptr %{{.*}}, i32 0, i32 0

--- a/clang/test/CIR/CodeGen/struct.cpp
+++ b/clang/test/CIR/CodeGen/struct.cpp
@@ -60,7 +60,7 @@ char f2(CompleteS &s) {
 // CIR:   %[[S_ADDR2:.*]] = cir.get_member %[[S_REF]][1] {name = "b"}
 // CIR:   %[[S_B:.*]] = cir.load{{.*}} %[[S_ADDR2]]
 
-// LLVM: define{{.*}} i8 @_Z2f2R9CompleteS(ptr{{.*}} %[[ARG_S:.*]])
+// LLVM: define{{.*}} noundef i8 @_Z2f2R9CompleteS(ptr noundef nonnull align 4 dereferenceable(8) %[[ARG_S:.*]])
 // LLVM:   %[[S_ADDR:.*]] = alloca ptr
 // LLVM:   store ptr %[[ARG_S]], ptr %[[S_ADDR]]
 // LLVM:   %[[S_REF:.*]] = load ptr, ptr %[[S_ADDR]], align 8

--- a/clang/test/CIR/CodeGen/template-specialization.cpp
+++ b/clang/test/CIR/CodeGen/template-specialization.cpp
@@ -44,7 +44,7 @@ void test_double() {
 // CIR: cir.func{{.*}} @_Z11test_doublev()
 // CIR:   cir.call @_ZN1XIdE1fEv
 
-// LLVM: define{{.*}} i32 @_ZN1XIdE1fEv
+// LLVM: define{{.*}} noundef i32 @_ZN1XIdE1fEv(ptr noundef nonnull align 1 dereferenceable(1) %0)
 // LLVM:   store i32 0
 //
 // LLVM: define{{.*}} void @_Z11test_doublev()
@@ -67,7 +67,7 @@ void test_int() {
 // CIR: cir.func{{.*}} @_Z8test_intv()
 // CIR:   cir.call @_ZN1XIiE1fEv
 
-// LLVM: define{{.*}} i32 @_ZN1XIiE1fEv
+// LLVM: define{{.*}} noundef i32 @_ZN1XIiE1fEv(ptr noundef nonnull align 1 dereferenceable(1) %0)
 // LLVM:   store i32 1
 //
 // LLVM: define{{.*}} void @_Z8test_intv()
@@ -90,7 +90,7 @@ void test_short() {
 // CIR: cir.func{{.*}} @_Z10test_shortv()
 // CIR:   cir.call @_ZN1XIsE1fEv
 
-// LLVM: define{{.*}} i32 @_ZN1XIsE1fEv
+// LLVM: define{{.*}} noundef i32 @_ZN1XIsE1fEv(ptr noundef nonnull align 1 dereferenceable(1) %0)
 // LLVM: store i32 0
 //
 // LLVM: define{{.*}} void @_Z10test_shortv()

--- a/clang/test/CIR/CodeGen/temporary-materialization.cpp
+++ b/clang/test/CIR/CodeGen/temporary-materialization.cpp
@@ -19,7 +19,7 @@ int test() {
 // CIR-NEXT:   cir.store{{.*}} %[[TEMP_VALUE]], %[[TEMP_SLOT]]
 // CIR-NEXT:   cir.store{{.*}} %[[TEMP_SLOT]], %[[X]]
 
-// LLVM: define {{.*}} i32 @_Z4testv()
+// LLVM: define {{.*}} noundef i32 @_Z4testv()
 // LLVM:   %[[RETVAL:.*]] = alloca i32
 // LLVM:   %[[TEMP_SLOT:.*]] = alloca i32
 // LLVM:   %[[X:.*]] = alloca ptr
@@ -56,7 +56,7 @@ int test_scoped() {
 // CIR-NEXT:     cir.store{{.*}} %[[Y_VALUE]], %[[X]] : !s32i, !cir.ptr<!s32i>
 // CIR-NEXT:   }
 
-// LLVM: define {{.*}} i32 @_Z11test_scopedv()
+// LLVM: define {{.*}} noundef i32 @_Z11test_scopedv()
 // LLVM:   %[[TEMP_SLOT:.*]] = alloca i32
 // LLVM:   %[[Y_ADDR:.*]] = alloca ptr
 // LLVM:   %[[RETVAL:.*]] = alloca i32

--- a/clang/test/CIR/CodeGen/ternary.cpp
+++ b/clang/test/CIR/CodeGen/ternary.cpp
@@ -24,7 +24,7 @@ int x(int y) {
 // CIR: [[RETVAL_VAL:%.+]] = cir.load [[RETVAL]] : !cir.ptr<!s32i>, !s32i
 // CIR: cir.return [[RETVAL_VAL]] : !s32i
 
-// LLVM-LABEL: define{{.*}} i32 @_Z1xi(
+// LLVM-LABEL: define{{.*}} noundef i32 @_Z1xi(
 // LLVM-SAME: i32 {{.*}} %[[ARG0:.+]])
 // LLVM: %[[Y:.*]] = alloca i32
 // LLVM: %[[RETVAL:.*]] = alloca i32
@@ -82,7 +82,7 @@ int foo(int a, int b) {
 // CIR: [[RETVAL_VAL2:%.+]] = cir.load [[RETVAL]] : !cir.ptr<!s32i>, !s32i
 // CIR: cir.return [[RETVAL_VAL2]] : !s32i
 
-// LLVM-LABEL: define{{.*}} i32 @_Z3fooii(
+// LLVM-LABEL: define{{.*}} noundef i32 @_Z3fooii(
 // LLVM-SAME: i32 {{.*}} %[[ARG0:.*]], i32 {{.*}} %[[ARG1:.*]])
 // LLVM: %[[A:.*]] = alloca i32
 // LLVM: %[[B:.*]] = alloca i32
@@ -163,7 +163,7 @@ void test_cond_lvalue_assign(bool flag) {
 // CIR: }) : (!cir.bool) -> !cir.ptr<!s32i>
 // CIR: cir.store{{.*}} %{{.*}}, %[[TERNARY_PTR]] : !s32i, !cir.ptr<!s32i>
 
-// LLVM-LABEL: define{{.*}} void @_Z23test_cond_lvalue_assignb(
+// LLVM-LABEL: define{{.*}} void @_Z23test_cond_lvalue_assignb(i1 noundef %0)
 // LLVM: %[[FLAG:.*]] = alloca i8
 // LLVM: %[[A:.*]] = alloca i32
 // LLVM: %[[B:.*]] = alloca i32
@@ -213,7 +213,7 @@ int& test_cond_lvalue_ref(bool cond, int x, int y) {
 // CIR: %[[RET_VAL:.*]] = cir.load
 // CIR: cir.return %[[RET_VAL]] : !cir.ptr<!s32i>
 
-// LLVM-LABEL: define{{.*}} ptr @_Z20test_cond_lvalue_refbii(
+// LLVM-LABEL: define{{.*}} noundef nonnull align 4 dereferenceable(4) ptr @_Z20test_cond_lvalue_refbii(i1 noundef %0, i32 noundef %1, i32 noundef %2)
 // LLVM: %[[COND:.*]] = alloca i8
 // LLVM: %[[X:.*]] = alloca i32
 // LLVM: %[[Y:.*]] = alloca i32
@@ -268,7 +268,7 @@ void test_cond_lvalue_compound(bool flag) {
 // CIR: %[[NEW_VAL:.*]] = cir.add nsw %[[OLD_VAL]], %{{.*}}
 // CIR: cir.store{{.*}} %[[NEW_VAL]], %[[LVAL_PTR]]
 
-// LLVM-LABEL: define{{.*}} void @_Z25test_cond_lvalue_compoundb(
+// LLVM-LABEL: define{{.*}} void @_Z25test_cond_lvalue_compoundb(i1 noundef %0)
 // LLVM: %[[FLAG:.*]] = alloca i8
 // LLVM: %[[A:.*]] = alloca i32
 // LLVM: %[[B:.*]] = alloca i32

--- a/clang/test/CIR/CodeGen/unary.cpp
+++ b/clang/test/CIR/CodeGen/unary.cpp
@@ -14,7 +14,7 @@ unsigned up0() {
 // CHECK:   %[[A:.*]] = cir.alloca !u32i, !cir.ptr<!u32i>, ["a", init]
 // CHECK:   %[[INPUT:.*]] = cir.load{{.*}} %[[A]]
 
-// LLVM: define{{.*}} i32 @_Z3up0v()
+// LLVM: define{{.*}} noundef i32 @_Z3up0v()
 // LLVM:   %[[RV:.*]] = alloca i32, i64 1, align 4
 // LLVM:   %[[A:.*]] = alloca i32, i64 1, align 4
 // LLVM:   store i32 1, ptr %[[A]], align 4
@@ -35,7 +35,7 @@ unsigned um0() {
 // CHECK:   %[[INPUT:.*]] = cir.load{{.*}} %[[A]]
 // CHECK:   %[[OUTPUT:.*]] = cir.minus %[[INPUT]]
 
-// LLVM: define{{.*}} i32 @_Z3um0v()
+// LLVM: define{{.*}} noundef i32 @_Z3um0v()
 // LLVM:   %[[RV:.*]] = alloca i32, i64 1, align 4
 // LLVM:   %[[A:.*]] = alloca i32, i64 1, align 4
 // LLVM:   store i32 1, ptr %[[A]], align 4
@@ -58,7 +58,7 @@ unsigned un0() {
 // CHECK:   %[[INPUT:.*]] = cir.load{{.*}} %[[A]]
 // CHECK:   %[[OUTPUT:.*]] = cir.not %[[INPUT]]
 
-// LLVM: define{{.*}} i32 @_Z3un0v()
+// LLVM: define{{.*}} noundef i32 @_Z3un0v()
 // LLVM:   %[[RV:.*]] = alloca i32, i64 1, align 4
 // LLVM:   %[[A:.*]] = alloca i32, i64 1, align 4
 // LLVM:   store i32 1, ptr %[[A]], align 4
@@ -86,7 +86,7 @@ int inc0() {
 // CHECK:   cir.store{{.*}} %[[INCREMENTED]], %[[A]]
 // CHECK:   %[[A_TO_OUTPUT:.*]] = cir.load{{.*}} %[[A]]
 
-// LLVM: define{{.*}} i32 @_Z4inc0v()
+// LLVM: define{{.*}} noundef i32 @_Z4inc0v()
 // LLVM:   %[[RV:.*]] = alloca i32, i64 1, align 4
 // LLVM:   %[[A:.*]] = alloca i32, i64 1, align 4
 // LLVM:   store i32 1, ptr %[[A]], align 4
@@ -114,7 +114,7 @@ int dec0() {
 // CHECK:   cir.store{{.*}} %[[DECREMENTED]], %[[A]]
 // CHECK:   %[[A_TO_OUTPUT:.*]] = cir.load{{.*}} %[[A]]
 
-// LLVM: define{{.*}} i32 @_Z4dec0v()
+// LLVM: define{{.*}} noundef i32 @_Z4dec0v()
 // LLVM:   %[[RV:.*]] = alloca i32, i64 1, align 4
 // LLVM:   %[[A:.*]] = alloca i32, i64 1, align 4
 // LLVM:   store i32 1, ptr %[[A]], align 4
@@ -142,7 +142,7 @@ int inc1() {
 // CHECK:   cir.store{{.*}} %[[INCREMENTED]], %[[A]]
 // CHECK:   %[[A_TO_OUTPUT:.*]] = cir.load{{.*}} %[[A]]
 
-// LLVM: define{{.*}} i32 @_Z4inc1v()
+// LLVM: define{{.*}} noundef i32 @_Z4inc1v()
 // LLVM:   %[[RV:.*]] = alloca i32, i64 1, align 4
 // LLVM:   %[[A:.*]] = alloca i32, i64 1, align 4
 // LLVM:   store i32 1, ptr %[[A]], align 4
@@ -170,7 +170,7 @@ int dec1() {
 // CHECK:   cir.store{{.*}} %[[DECREMENTED]], %[[A]]
 // CHECK:   %[[A_TO_OUTPUT:.*]] = cir.load{{.*}} %[[A]]
 
-// LLVM: define{{.*}} i32 @_Z4dec1v()
+// LLVM: define{{.*}} noundef i32 @_Z4dec1v()
 // LLVM:   %[[RV:.*]] = alloca i32, i64 1, align 4
 // LLVM:   %[[A:.*]] = alloca i32, i64 1, align 4
 // LLVM:   store i32 1, ptr %[[A]], align 4
@@ -201,7 +201,7 @@ int inc2() {
 // CHECK:   cir.store{{.*}} %[[ATOB]], %[[B]]
 // CHECK:   %[[B_TO_OUTPUT:.*]] = cir.load{{.*}} %[[B]]
 
-// LLVM: define{{.*}} i32 @_Z4inc2v()
+// LLVM: define{{.*}} noundef i32 @_Z4inc2v()
 // LLVM:   %[[RV:.*]] = alloca i32, i64 1, align 4
 // LLVM:   %[[A:.*]] = alloca i32, i64 1, align 4
 // LLVM:   %[[B:.*]] = alloca i32, i64 1, align 4
@@ -231,7 +231,7 @@ float fpPlus() {
 // CHECK:   %[[A:.*]] = cir.alloca !cir.float, !cir.ptr<!cir.float>, ["a", init]
 // CHECK:   %[[INPUT:.*]] = cir.load{{.*}} %[[A]]
 
-// LLVM: define{{.*}} float @_Z6fpPlusv()
+// LLVM: define{{.*}} noundef float @_Z6fpPlusv()
 // LLVM:   %[[RV:.*]] = alloca float, i64 1, align 4
 // LLVM:   %[[A:.*]] = alloca float, i64 1, align 4
 // LLVM:   store float 1.000000e+00, ptr %[[A]], align 4
@@ -252,7 +252,7 @@ float fpMinus() {
 // CHECK:   %[[INPUT:.*]] = cir.load{{.*}} %[[A]]
 // CHECK:   %[[OUTPUT:.*]] = cir.minus %[[INPUT]]
 
-// LLVM: define{{.*}} float @_Z7fpMinusv()
+// LLVM: define{{.*}} noundef float @_Z7fpMinusv()
 // LLVM:   %[[RV:.*]] = alloca float, i64 1, align 4
 // LLVM:   %[[A:.*]] = alloca float, i64 1, align 4
 // LLVM:   store float 1.000000e+00, ptr %[[A]], align 4
@@ -277,7 +277,7 @@ float fpPreInc() {
 // CHECK:   %[[INPUT:.*]] = cir.load{{.*}} %[[A]]
 // CHECK:   %[[INCREMENTED:.*]] = cir.inc %[[INPUT]]
 
-// LLVM: define{{.*}} float @_Z8fpPreIncv()
+// LLVM: define{{.*}} noundef float @_Z8fpPreIncv()
 // LLVM:   %[[RV:.*]] = alloca float, i64 1, align 4
 // LLVM:   %[[A:.*]] = alloca float, i64 1, align 4
 // LLVM:   store float 1.000000e+00, ptr %[[A]], align 4
@@ -302,7 +302,7 @@ float fpPreDec() {
 // CHECK:   %[[INPUT:.*]] = cir.load{{.*}} %[[A]]
 // CHECK:   %[[DECREMENTED:.*]] = cir.dec %[[INPUT]]
 
-// LLVM: define{{.*}} float @_Z8fpPreDecv()
+// LLVM: define{{.*}} noundef float @_Z8fpPreDecv()
 // LLVM:   %[[RV:.*]] = alloca float, i64 1, align 4
 // LLVM:   %[[A:.*]] = alloca float, i64 1, align 4
 // LLVM:   store float 1.000000e+00, ptr %[[A]], align 4
@@ -327,7 +327,7 @@ float fpPostInc() {
 // CHECK:   %[[INPUT:.*]] = cir.load{{.*}} %[[A]]
 // CHECK:   %[[INCREMENTED:.*]] = cir.inc %[[INPUT]]
 
-// LLVM: define{{.*}} float @_Z9fpPostIncv()
+// LLVM: define{{.*}} noundef float @_Z9fpPostIncv()
 // LLVM:   %[[RV:.*]] = alloca float, i64 1, align 4
 // LLVM:   %[[A:.*]] = alloca float, i64 1, align 4
 // LLVM:   store float 1.000000e+00, ptr %[[A]], align 4
@@ -352,7 +352,7 @@ float fpPostDec() {
 // CHECK:   %[[INPUT:.*]] = cir.load{{.*}} %[[A]]
 // CHECK:   %[[DECREMENTED:.*]] = cir.dec %[[INPUT]]
 
-// LLVM: define{{.*}} float @_Z9fpPostDecv()
+// LLVM: define{{.*}} noundef float @_Z9fpPostDecv()
 // LLVM:   %[[RV:.*]] = alloca float, i64 1, align 4
 // LLVM:   %[[A:.*]] = alloca float, i64 1, align 4
 // LLVM:   store float 1.000000e+00, ptr %[[A]], align 4
@@ -383,7 +383,7 @@ float fpPostInc2() {
 // CHECK:   cir.store{{.*}} %[[ATOB]], %[[B]]
 // CHECK:   %[[B_TO_OUTPUT:.*]] = cir.load{{.*}} %[[B]]
 
-// LLVM: define{{.*}} float @_Z10fpPostInc2v()
+// LLVM: define{{.*}} noundef float @_Z10fpPostInc2v()
 // LLVM:   %[[RV:.*]] = alloca float, i64 1, align 4
 // LLVM:   %[[A:.*]] = alloca float, i64 1, align 4
 // LLVM:   %[[B:.*]] = alloca float, i64 1, align 4
@@ -431,7 +431,7 @@ _Float16 fp16UPlus(_Float16 f) {
 // CHECK:   %[[PROMOTED:.*]] = cir.cast floating %[[INPUT]] : !cir.f16 -> !cir.float
 // CHECK:   %[[UNPROMOTED:.*]] = cir.cast floating %[[PROMOTED]] : !cir.float -> !cir.f16
 
-// LLVM: define{{.*}} half @_Z9fp16UPlusDF16_({{.*}})
+// LLVM: define{{.*}} noundef half @_Z9fp16UPlusDF16_(half noundef %0)
 // LLVM:   %[[F_LOAD:.*]] = load half, ptr %{{.*}}, align 2
 // LLVM:   %[[PROMOTED:.*]] = fpext half %[[F_LOAD]] to float
 // LLVM:   %[[UNPROMOTED:.*]] = fptrunc float %[[PROMOTED]] to half
@@ -451,7 +451,7 @@ _Float16 fp16UMinus(_Float16 f) {
 // CHECK:   %[[RESULT:.*]] = cir.minus %[[PROMOTED]]
 // CHECK:   %[[UNPROMOTED:.*]] = cir.cast floating %[[RESULT]] : !cir.float -> !cir.f16
 
-// LLVM: define{{.*}} half @_Z10fp16UMinusDF16_({{.*}})
+// LLVM: define{{.*}} noundef half @_Z10fp16UMinusDF16_(half noundef %0)
 // LLVM:   %[[F_LOAD:.*]] = load half, ptr %{{.*}}, align 2
 // LLVM:   %[[PROMOTED:.*]] = fpext half %[[F_LOAD]] to float
 // LLVM:   %[[RESULT:.*]] = fneg float %[[PROMOTED]]

--- a/clang/test/CIR/CodeGen/var_arg.c
+++ b/clang/test/CIR/CodeGen/var_arg.c
@@ -33,7 +33,7 @@ int varargs(int count, ...) {
 // CIR:   %[[RETVAL:.+]] = cir.load{{.*}} %[[RET_ADDR]] : !cir.ptr<!s32i>, !s32i
 // CIR:   cir.return %[[RETVAL]] : !s32i
 
-// LLVM-LABEL: define dso_local i32 @varargs(
+// LLVM-LABEL: define dso_local i32 @varargs(i32 noundef %0, ...)
 // LLVM:   %[[COUNT_ADDR:.+]] = alloca i32{{.*}}
 // LLVM:   %[[RET_ADDR:.+]] = alloca i32{{.*}}
 // LLVM:   %[[VAAREA:.+]] = alloca [1 x %struct.__va_list_tag]{{.*}}
@@ -106,7 +106,7 @@ int stdarg_start(int count, ...) {
 // CIR:   %[[RETVAL:.+]] = cir.load{{.*}} %[[RET_ADDR]] : !cir.ptr<!s32i>, !s32i
 // CIR:   cir.return %[[RETVAL]] : !s32i
 
-// LLVM-LABEL: define dso_local i32 @stdarg_start(
+// LLVM-LABEL: define dso_local i32 @stdarg_start(i32 noundef %0, ...)
 // LLVM:   %[[COUNT_ADDR:.+]] = alloca i32{{.*}}
 // LLVM:   %[[RET_ADDR:.+]] = alloca i32{{.*}}
 // LLVM:   %[[VAAREA:.+]] = alloca [1 x %struct.__va_list_tag]{{.*}}

--- a/clang/test/CIR/CodeGen/virtual-destructor-calls.cpp
+++ b/clang/test/CIR/CodeGen/virtual-destructor-calls.cpp
@@ -41,9 +41,9 @@ B::~B() { }
 // CIR:   cir.call @_ZN6MemberD1Ev
 // CIR:   cir.call @_ZN1AD2Ev
 
-// LLVM: define{{.*}} void @_ZN1BD2Ev
-// LLVM:   call void @_ZN6MemberD1Ev
-// LLVM:   call void @_ZN1AD2Ev
+// LLVM: define{{.*}} void @_ZN1BD2Ev(ptr noundef nonnull align 8 dereferenceable(9) {{.*}})
+// LLVM:   call void @_ZN6MemberD1Ev(ptr noundef nonnull align 1 dereferenceable(1) {{.*}})
+// LLVM:   call void @_ZN1AD2Ev(ptr noundef nonnull align 8 dereferenceable(8) {{.*}})
 
 // OGCG: define{{.*}} @_ZN1BD2Ev
 // OGCG:   call void @_ZN6MemberD1Ev
@@ -62,8 +62,8 @@ B::~B() { }
 // CIR:   %[[SIZE:.*]] = cir.const #cir.int<16>
 // CIR:   cir.call @_ZdlPvm(%[[THIS_VOID]], %[[SIZE]])
 
-// LLVM: define{{.*}} void @_ZN1BD0Ev
-// LLVM:   call void @_ZN1BD1Ev(ptr {{.*}} %[[THIS:.*]])
+// LLVM: define{{.*}} void @_ZN1BD0Ev(ptr noundef nonnull align 8 dereferenceable(9) {{.*}})
+// LLVM:   call void @_ZN1BD1Ev(ptr noundef nonnull align 8 dereferenceable(9) %[[THIS:.*]])
 // LLVM:   call void @_ZdlPvm(ptr {{.*}} %[[THIS]], i64 {{.*}} 16)
 
 // OGCG: define{{.*}} @_ZN1BD0Ev
@@ -82,8 +82,8 @@ C::~C() { }
 // CIR:   %[[B:.*]] = cir.base_class_addr %[[THIS:.*]] : !cir.ptr<!rec_C> nonnull [0] -> !cir.ptr<!rec_B>
 // CIR:   cir.call @_ZN1BD2Ev(%[[B]])
 
-// LLVM: define{{.*}} void @_ZN1CD2Ev
-// LLVM:   call void @_ZN1BD2Ev
+// LLVM: define{{.*}} void @_ZN1CD2Ev(ptr noundef nonnull align 8 dereferenceable(9) {{.*}})
+// LLVM:   call void @_ZN1BD2Ev(ptr noundef nonnull align 8 dereferenceable(9) {{.*}})
 
 // OGCG: define{{.*}} @_ZN1CD2Ev
 // OGCG:   call void @_ZN1BD2Ev
@@ -102,8 +102,8 @@ C::~C() { }
 // CIR:   %[[SIZE:.*]] = cir.const #cir.int<16>
 // CIR:   cir.call @_ZdlPvm(%[[THIS_VOID]], %[[SIZE]])
 
-// LLVM: define{{.*}} void @_ZN1CD0Ev
-// LLVM:   call void @_ZN1CD1Ev(ptr {{.*}} %[[THIS:.*]])
+// LLVM: define{{.*}} void @_ZN1CD0Ev(ptr noundef nonnull align 8 dereferenceable(9) {{.*}})
+// LLVM:   call void @_ZN1CD1Ev(ptr noundef nonnull align 8 dereferenceable(9) %[[THIS:.*]])
 // LLVM:   call void @_ZdlPvm(ptr {{.*}} %[[THIS]], i64 {{.*}} 16)
 
 // OGCG: define{{.*}} @_ZN1CD0Ev
@@ -119,8 +119,8 @@ namespace PR12798 {
   // CIR: cir.func{{.*}} @_ZN7PR127981fINS_1AEEEvPT_
   // CIR:   cir.call @_ZN7PR127981AD1Ev
 
-  // LLVM: define{{.*}} @_ZN7PR127981fINS_1AEEEvPT_
-  // LLVM:   call void @_ZN7PR127981AD1Ev
+  // LLVM: define{{.*}} @_ZN7PR127981fINS_1AEEEvPT_(ptr noundef {{.*}})
+  // LLVM:   call void @_ZN7PR127981AD1Ev(ptr noundef nonnull align 8 dereferenceable(8) {{.*}})
 
   // OGCG: define{{.*}} @_ZN7PR127981fINS_1AEEEvPT_
   // OGCG:   call void @_ZN7PR127981AD1Ev


### PR DESCRIPTION
Tighten LLVM CHECK lines in 35 existing test files to verify ABI-relevant attributes (`noundef`, `nonnull`, `dereferenceable`, `align`) on function definitions and calls.

These attributes are already emitted by upstream CIR thanks to #181052 and #182910 but were not previously checked.  Making the checks more precise helps catch regressions as the ABI lowering work progresses.

160 CHECK lines updated across 35 test files.  No functional change.
