### PR TITLE
[lldb] Mark lldbtest.build() parameters as keyword-only

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/lldbtest.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbtest.py
@@ -1523,6 +1523,7 @@ class Base(unittest.TestCase):
 
     def build(
         self,
+        *,
         debug_info=None,
         architecture=None,
         compiler=None,


### PR DESCRIPTION
This reinforces what is already true in the codebase: all uses of `build()` use keyword arguments.

With this change, it will be an error to call `build` using positional arguments:

```
TypeError: build() takes 1 positional argument but 2 were given
```
