### PR TITLE
[SelectionDAG] Add known bit for `ISD::FABS`

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAG.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAG.cpp
@@ -4135,6 +4135,11 @@ KnownBits SelectionDAG::computeKnownBits(SDValue Op, const APInt &DemandedElts,
 
     break;
   }
+  case ISD::FABS:
+    // fabs clears the sign bit
+    Known = computeKnownBits(Op.getOperand(0), DemandedElts, Depth + 1);
+    Known.makeNonNegative();
+    break;
   case ISD::FGETSIGN:
     // All bits are zero except the low bit.
     Known.Zero.setBitsFrom(1);

--- a/llvm/test/CodeGen/AMDGPU/llvm.exp.ll
+++ b/llvm/test/CodeGen/AMDGPU/llvm.exp.ll
@@ -2681,7 +2681,7 @@ define float @v_exp_fabs_f32(float %in) {
 ; VI-SDAG:       ; %bb.0:
 ; VI-SDAG-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; VI-SDAG-NEXT:    v_and_b32_e32 v1, 0x7fffffff, v0
-; VI-SDAG-NEXT:    v_and_b32_e32 v1, 0xfffff000, v1
+; VI-SDAG-NEXT:    v_and_b32_e32 v1, 0x7ffff000, v1
 ; VI-SDAG-NEXT:    v_sub_f32_e64 v4, |v0|, v1
 ; VI-SDAG-NEXT:    v_mul_f32_e32 v2, 0x3fb8a000, v1
 ; VI-SDAG-NEXT:    v_mul_f32_e32 v5, 0x39a3b295, v4

--- a/llvm/test/CodeGen/AMDGPU/llvm.exp10.ll
+++ b/llvm/test/CodeGen/AMDGPU/llvm.exp10.ll
@@ -2683,7 +2683,7 @@ define float @v_exp10_fabs_f32(float %in) {
 ; VI-SDAG:       ; %bb.0:
 ; VI-SDAG-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; VI-SDAG-NEXT:    v_and_b32_e32 v1, 0x7fffffff, v0
-; VI-SDAG-NEXT:    v_and_b32_e32 v1, 0xfffff000, v1
+; VI-SDAG-NEXT:    v_and_b32_e32 v1, 0x7ffff000, v1
 ; VI-SDAG-NEXT:    v_sub_f32_e64 v4, |v0|, v1
 ; VI-SDAG-NEXT:    v_mul_f32_e32 v2, 0x40549000, v1
 ; VI-SDAG-NEXT:    v_mul_f32_e32 v5, 0x3a2784bc, v4


### PR DESCRIPTION
Absolute value always clears the sign bit, so make that knowh to selectionDAG's `computeKnownBits`.