### PR TITLE
[lldb][trace] Ensure ProcessTrace plugin can be re-registered

### DIFF
--- a/lldb/source/Target/ProcessTrace.cpp
+++ b/lldb/source/Target/ProcessTrace.cpp
@@ -108,10 +108,8 @@ void ProcessTrace::Clear() { m_thread_list.Clear(); }
 void ProcessTrace::Initialize() {
   static llvm::once_flag g_once_flag;
 
-  llvm::call_once(g_once_flag, []() {
-    PluginManager::RegisterPlugin(GetPluginNameStatic(),
-                                  GetPluginDescriptionStatic(), CreateInstance);
-  });
+  PluginManager::RegisterPlugin(GetPluginNameStatic(),
+                                GetPluginDescriptionStatic(), CreateInstance);
 }
 
 ArchSpec ProcessTrace::GetArchitecture() {

--- a/lldb/source/Target/ProcessTrace.cpp
+++ b/lldb/source/Target/ProcessTrace.cpp
@@ -106,8 +106,6 @@ size_t ProcessTrace::ReadMemory(addr_t addr, void *buf, size_t size,
 void ProcessTrace::Clear() { m_thread_list.Clear(); }
 
 void ProcessTrace::Initialize() {
-  static llvm::once_flag g_once_flag;
-
   PluginManager::RegisterPlugin(GetPluginNameStatic(),
                                 GetPluginDescriptionStatic(), CreateInstance);
 }


### PR DESCRIPTION
Initialize makes sure that it calls RegisterPlugin only once, but Terminate always calls UnregisterPlugin. This is a problem for tests that call Initialize/Terminate before and after each test case: the second case will fail because the trace plugin won't be loaded.

This fixes a test failure introduced by #187768, which adds a test case that passes on its own but fails when run after the previous test case.