### PR TITLE
[Hexagon] Make usesQF helpers robust

### DIFF
--- a/llvm/lib/Target/Hexagon/HexagonInstrInfo.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonInstrInfo.cpp
@@ -4909,9 +4909,10 @@ bool HexagonInstrInfo::usesQF32Operand(MachineInstr *MI, unsigned Index) const {
     return Info.Input1 == HexagonII::RegType::QF32 ||
            Info.Input2 == HexagonII::RegType::QF32 ||
            Info.Input3 == HexagonII::RegType::QF32;
-  default:
-    llvm_unreachable("Incorrect input machine operand index encountered!");
+  default: // No instruction with more than 3 operands uses QF32.
+    return false;
   }
+  return false;
 }
 
 bool HexagonInstrInfo::usesQF16Operand(MachineInstr *MI, unsigned Index) const {
@@ -4927,9 +4928,10 @@ bool HexagonInstrInfo::usesQF16Operand(MachineInstr *MI, unsigned Index) const {
     return Info.Input1 == HexagonII::RegType::QF16 ||
            Info.Input2 == HexagonII::RegType::QF16 ||
            Info.Input3 == HexagonII::RegType::QF16;
-  default:
-    llvm_unreachable("Incorrect input machine operand index encountered!");
+  default: // No instruction with more than 3 operands uses QF16.
+    return false;
   }
+  return false;
 }
 
 bool HexagonInstrInfo::usesQFOperand(MachineInstr *MI, unsigned Index) const {

--- a/llvm/test/CodeGen/Hexagon/qf-helpers-out-of-range.ll
+++ b/llvm/test/CodeGen/Hexagon/qf-helpers-out-of-range.ll
@@ -1,0 +1,12 @@
+; RUN: llc -O2 -march=hexagon -mcpu=hexagonv79 -o - %s | FileCheck %s
+
+; Crash regression: ensures Hexagon QF helpers (usesQF*Operand) does
+; not crash during codegen.
+
+; CHECK-LABEL: qf_helpers_qf32
+define <32 x float> @qf_helpers_qf32(<32 x float> %a, <32 x float> %b) {
+entry:
+  %mul = fmul <32 x float> %a, %b
+  %add = fadd <32 x float> %mul, %a
+  ret <32 x float> %add
+}


### PR DESCRIPTION
Relax usesQF*Operand to return false for indices greater than the first three inputs instead of asserting.
