### PR TITLE
[NewPM] Adds a port for AArch64PointerAuth

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64.h
+++ b/llvm/lib/Target/AArch64/AArch64.h
@@ -84,7 +84,7 @@ void initializeAArch64A53Fix835769LegacyPass(PassRegistry &);
 void initializeAArch64A57FPLoadBalancingPass(PassRegistry&);
 void initializeAArch64AdvSIMDScalarLegacyPass(PassRegistry &);
 void initializeAArch64AsmPrinterPass(PassRegistry &);
-void initializeAArch64PointerAuthPass(PassRegistry&);
+void initializeAArch64PointerAuthLegacyPass(PassRegistry &);
 void initializeAArch64BranchTargetsLegacyPass(PassRegistry &);
 void initializeAArch64CFIFixupPass(PassRegistry&);
 void initializeAArch64CollectLOHLegacyPass(PassRegistry &);
@@ -184,6 +184,12 @@ public:
 
 class AArch64ConditionOptimizerPass
     : public PassInfoMixin<AArch64ConditionOptimizerPass> {
+public:
+  PreservedAnalyses run(MachineFunction &MF,
+                        MachineFunctionAnalysisManager &MFAM);
+};
+
+class AArch64PointerAuthPass : public PassInfoMixin<AArch64PointerAuthPass> {
 public:
   PreservedAnalyses run(MachineFunction &MF,
                         MachineFunctionAnalysisManager &MFAM);

--- a/llvm/lib/Target/AArch64/AArch64PassRegistry.def
+++ b/llvm/lib/Target/AArch64/AArch64PassRegistry.def
@@ -35,5 +35,6 @@ MACHINE_FUNCTION_PASS("aarch64-fix-cortex-a53-835769", AArch64A53Fix835769Pass()
 MACHINE_FUNCTION_PASS("aarch64-jump-tables", AArch64CompressJumpTablesPass())
 MACHINE_FUNCTION_PASS("aarch64-ldst-opt", AArch64LoadStoreOptPass())
 MACHINE_FUNCTION_PASS("aarch64-mi-peephole-opt", AArch64MIPeepholeOptPass())
+MACHINE_FUNCTION_PASS("aarch64-ptrauth", AArch64PointerAuthPass())
 MACHINE_FUNCTION_PASS("aarch64-simd-scalar", AArch64AdvSIMDScalarPass())
 #undef MACHINE_FUNCTION_PASS

--- a/llvm/lib/Target/AArch64/AArch64PointerAuth.cpp
+++ b/llvm/lib/Target/AArch64/AArch64PointerAuth.cpp
@@ -24,15 +24,9 @@ using namespace llvm::AArch64PAuth;
 
 namespace {
 
-class AArch64PointerAuth : public MachineFunctionPass {
+class AArch64PointerAuthImpl {
 public:
-  static char ID;
-
-  AArch64PointerAuth() : MachineFunctionPass(ID) {}
-
-  bool runOnMachineFunction(MachineFunction &MF) override;
-
-  StringRef getPassName() const override { return AARCH64_POINTER_AUTH_NAME; }
+  bool run(MachineFunction &MF);
 
 private:
   const AArch64Subtarget *Subtarget = nullptr;
@@ -44,16 +38,27 @@ private:
                       MachineBasicBlock::iterator MBBI) const;
 };
 
+class AArch64PointerAuthLegacy : public MachineFunctionPass {
+public:
+  static char ID;
+
+  AArch64PointerAuthLegacy() : MachineFunctionPass(ID) {}
+
+  bool runOnMachineFunction(MachineFunction &MF) override;
+
+  StringRef getPassName() const override { return AARCH64_POINTER_AUTH_NAME; }
+};
+
 } // end anonymous namespace
 
-INITIALIZE_PASS(AArch64PointerAuth, "aarch64-ptrauth",
+INITIALIZE_PASS(AArch64PointerAuthLegacy, "aarch64-ptrauth",
                 AARCH64_POINTER_AUTH_NAME, false, false)
 
 FunctionPass *llvm::createAArch64PointerAuthPass() {
-  return new AArch64PointerAuth();
+  return new AArch64PointerAuthLegacy();
 }
 
-char AArch64PointerAuth::ID = 0;
+char AArch64PointerAuthLegacy::ID = 0;
 
 static void emitPACSymOffsetIntoX16(const TargetInstrInfo &TII,
                                     MachineBasicBlock &MBB,
@@ -80,8 +85,8 @@ static void emitPACCFI(MachineBasicBlock &MBB, MachineBasicBlock::iterator MBBI,
                                  : CFIBuilder.buildNegateRAState();
 }
 
-void AArch64PointerAuth::signLR(MachineFunction &MF,
-                                MachineBasicBlock::iterator MBBI) const {
+void AArch64PointerAuthImpl::signLR(MachineFunction &MF,
+                                    MachineBasicBlock::iterator MBBI) const {
   auto &MFnI = *MF.getInfo<AArch64FunctionInfo>();
   bool UseBKey = MFnI.shouldSignWithBKey();
   bool EmitCFI = MFnI.needsDwarfUnwindInfo(MF);
@@ -134,7 +139,7 @@ void AArch64PointerAuth::signLR(MachineFunction &MF,
   }
 }
 
-void AArch64PointerAuth::authenticateLR(
+void AArch64PointerAuthImpl::authenticateLR(
     MachineFunction &MF, MachineBasicBlock::iterator MBBI) const {
   const AArch64FunctionInfo *MFnI = MF.getInfo<AArch64FunctionInfo>();
   bool UseBKey = MFnI->shouldSignWithBKey();
@@ -223,7 +228,7 @@ unsigned llvm::AArch64PAuth::getCheckerSizeInBytes(AuthCheckMethod Method) {
   llvm_unreachable("Unknown AuthCheckMethod enum");
 }
 
-bool AArch64PointerAuth::runOnMachineFunction(MachineFunction &MF) {
+bool AArch64PointerAuthImpl::run(MachineFunction &MF) {
   Subtarget = &MF.getSubtarget<AArch64Subtarget>();
   TII = Subtarget->getInstrInfo();
 
@@ -260,4 +265,19 @@ bool AArch64PointerAuth::runOnMachineFunction(MachineFunction &MF) {
   }
 
   return Modified;
+}
+
+bool AArch64PointerAuthLegacy::runOnMachineFunction(MachineFunction &MF) {
+  return AArch64PointerAuthImpl().run(MF);
+}
+
+PreservedAnalyses
+AArch64PointerAuthPass::run(MachineFunction &MF,
+                            MachineFunctionAnalysisManager &MFAM) {
+  const bool Changed = AArch64PointerAuthImpl().run(MF);
+  if (!Changed)
+    return PreservedAnalyses::all();
+  PreservedAnalyses PA = getMachineFunctionPassPreservedAnalyses();
+  PA.preserveSet<CFGAnalyses>();
+  return PA;
 }

--- a/llvm/lib/Target/AArch64/AArch64TargetMachine.cpp
+++ b/llvm/lib/Target/AArch64/AArch64TargetMachine.cpp
@@ -259,7 +259,7 @@ LLVMInitializeAArch64Target() {
   initializeAArch64SIMDInstrOptPass(PR);
   initializeAArch64O0PreLegalizerCombinerPass(PR);
   initializeAArch64PreLegalizerCombinerPass(PR);
-  initializeAArch64PointerAuthPass(PR);
+  initializeAArch64PointerAuthLegacyPass(PR);
   initializeAArch64PostCoalescerPass(PR);
   initializeAArch64PostLegalizerCombinerPass(PR);
   initializeAArch64PostLegalizerLoweringPass(PR);


### PR DESCRIPTION
Adds a standard NewPM port for AArch64PointerAuth.

No test updates since all `.mir` files referencing this pass run combinations of passes, not all of which are ported.