### PR TITLE
[mlir][mem2reg] Process direct uses inside other regions.

### DIFF
--- a/mlir/lib/Transforms/Mem2Reg.cpp
+++ b/mlir/lib/Transforms/Mem2Reg.cpp
@@ -397,6 +397,7 @@ LogicalResult MemorySlotPromotionAnalyzer::computeBlockingUses(
       if (!promotable.canUsesBeRemoved(blockingUses, newBlockingUses,
                                        dataLayout))
         return failure();
+      regionsWithDirectUse.insert(user->getParentRegion());
     } else if (auto promotable = dyn_cast<PromotableMemOpInterface>(user)) {
       if (!promotable.canUsesBeRemoved(slot, blockingUses, newBlockingUses,
                                        dataLayout))

--- a/mlir/test/Dialect/LLVMIR/mem2reg.mlir
+++ b/mlir/test/Dialect/LLVMIR/mem2reg.mlir
@@ -1164,3 +1164,19 @@ llvm.func @store_out_of_bounds(%arg : i64) {
   llvm.store %arg, %1 : i64, !llvm.ptr
   llvm.return
 }
+
+// -----
+
+// Verify that a dead direct use is properly deleted by mem2reg.
+
+// CHECK-LABEL: @dead_direct_use
+llvm.func @dead_direct_use(%arg0 : i1) {
+  %0 = llvm.mlir.constant(1 : i32) : i32
+  // CHECK-NOT: llvm.alloca
+  %1 = llvm.alloca %0 x i32 : (i32) -> !llvm.ptr
+  scf.if %arg0 {
+    // CHECK-NOT: llvm.addrspacecast
+    %2 = llvm.addrspacecast %1 : !llvm.ptr to !llvm.ptr<5>
+  }
+  llvm.return
+}


### PR DESCRIPTION
We need to add the regions with the direct uses into the list
for processing, otherwise the direct uses will not be removed
and will use the slot after the promotion.

The added LIT test was triggering "after promotion, the slot pointer
should not be used anymore" assertion.
