### PR TITLE
[lldb] fix data race in ProcessGDBRemote module spec cache

### DIFF
--- a/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
@@ -4461,12 +4461,17 @@ bool ProcessGDBRemote::GetModuleSpec(const FileSpec &module_file_spec,
 
   const ModuleCacheKey key(module_file_spec.GetPath(),
                            arch.GetTriple().getTriple());
-  auto cached = m_cached_module_specs.find(key);
-  if (cached != m_cached_module_specs.end()) {
-    module_spec = cached->second;
-    return bool(module_spec);
+  {
+    std::lock_guard<std::mutex> guard(m_cached_module_specs_mutex);
+    auto cached = m_cached_module_specs.find(key);
+    if (cached != m_cached_module_specs.end()) {
+      module_spec = cached->second;
+      return bool(module_spec);
+    }
   }
 
+  // GetModuleInfo issues a GDB remote packet, which can be slow. Do this
+  // outside the lock so other threads can still read cached entries.
   if (!m_gdb_comm.GetModuleInfo(module_file_spec, arch, module_spec)) {
     LLDB_LOGF(log, "ProcessGDBRemote::%s - failed to get module info for %s:%s",
               __FUNCTION__, module_file_spec.GetPath().c_str(),
@@ -4482,14 +4487,19 @@ bool ProcessGDBRemote::GetModuleSpec(const FileSpec &module_file_spec,
               arch.GetTriple().getTriple().c_str(), stream.GetData());
   }
 
-  m_cached_module_specs[key] = module_spec;
+  {
+    std::lock_guard<std::mutex> guard(m_cached_module_specs_mutex);
+    m_cached_module_specs[key] = module_spec;
+  }
   return true;
 }
 
 void ProcessGDBRemote::PrefetchModuleSpecs(
     llvm::ArrayRef<FileSpec> module_file_specs, const llvm::Triple &triple) {
+  // GetModulesInfo issues a GDB remote packet — do it outside the lock.
   auto module_specs = m_gdb_comm.GetModulesInfo(module_file_specs, triple);
   if (module_specs) {
+    std::lock_guard<std::mutex> guard(m_cached_module_specs_mutex);
     for (const FileSpec &spec : module_file_specs)
       m_cached_module_specs[ModuleCacheKey(spec.GetPath(),
                                            triple.getTriple())] = ModuleSpec();

--- a/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.h
+++ b/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.h
@@ -489,8 +489,11 @@ private:
     }
   };
 
+  // Guarded by m_cached_module_specs_mutex. Accessed from multiple threads
+  // during parallel module loading (DynamicLoaderPOSIXDYLD::RefreshModules).
   llvm::DenseMap<ModuleCacheKey, ModuleSpec, ModuleCacheInfo>
       m_cached_module_specs;
+  std::mutex m_cached_module_specs_mutex;
 
   ProcessGDBRemote(const ProcessGDBRemote &) = delete;
   const ProcessGDBRemote &operator=(const ProcessGDBRemote &) = delete;


### PR DESCRIPTION
## [lldb] Fix data race in ProcessGDBRemote module spec cache

### Summary

Fix a data race in `ProcessGDBRemote::m_cached_module_specs` that causes segfaults during parallel module loading on Android/Linux.

`m_cached_module_specs` is an `llvm::DenseMap` accessed without synchronization from multiple threads. During parallel module loading (`DynamicLoaderPOSIXDYLD::RefreshModules`), multiple threads call `ProcessGDBRemote::GetModuleSpec()` concurrently, performing `find()` + `operator[]` on the map. Concurrent inserts can trigger DenseMap rehashing, which reallocates the bucket array while other threads are mid-lookup — use-after-free.

### Fix

Add `std::mutex m_cached_module_specs_mutex` and protect all `m_cached_module_specs` accesses with `std::lock_guard` in `GetModuleSpec()` and `PrefetchModuleSpecs()`. The GDB remote packet calls (`GetModuleInfo`/`GetModulesInfo`) remain outside the lock to avoid serializing slow network I/O.

### Reproducing the bug

The following test reproduces the original unprotected access pattern (same DenseMap types as production, 8 threads, 200 modules, no mutex):

```cpp
// Unprotected lookup-or-insert — the original buggy pattern.
void GetModuleSpecUnsafe(ModuleCacheMap &cache, const std::string &path,
                         const std::string &triple) {
  const ModuleCacheKey key(path, triple);
  if (cache.find(key) != cache.end())
    return;
  ModuleSpec spec;
  spec.GetFileSpec().SetFile(path, FileSpec::Style::posix);
  cache[key] = spec;
}

TEST(GDBRemoteModuleCacheTest, UnprotectedConcurrentAccessCrashes) {
  for (int iteration = 0; iteration < 50; ++iteration) {
    ModuleCacheMap cache;
    const std::string triple = "aarch64-unknown-linux-android";
    const int kNumModules = 200;
    const int kNumThreads = 8;
    std::vector<std::thread> threads;
    for (int t = 0; t < kNumThreads; ++t) {
      threads.emplace_back([&cache, &triple, t]() {
        for (int i = t; i < kNumModules; i += kNumThreads) {
          std::string path = "/system/lib64/lib" + std::to_string(i) + ".so";
          GetModuleSpecUnsafe(cache, path, triple);
        }
      });
    }
    for (auto &t : threads)
      t.join();
  }
}
```

Crashes immediately on the first iteration:

```
[ RUN      ] GDBRemoteModuleCacheTest.UnprotectedConcurrentAccessCrashes
DenseMap.h:1230: Assertion `(!RHS.getEpochAddress() || RHS.isHandleInSync()) && "handle not in sync!"' failed.
DenseMap.h:448: Assertion `!FoundVal && "Key already in new map?"' failed.
Aborted (core dumped)
```

Two separate assertions fire — `"handle not in sync"` (iterator invalidated mid-lookup by another thread's rehash) and `"Key already in new map"` (duplicate keys from concurrent inserts during rehash). In release builds without assertions, this silently corrupts memory leading to segfaults.

### Test plan

The reproducer above can be added to `GDBRemoteModuleCacheTest.cpp` to confirm the crash without the fix. With the mutex in place, the same concurrent workload completes without issue.

```
ninja -C build -j72 ProcessGdbRemoteTests
./build/tools/lldb/unittests/Process/gdb-remote/ProcessGdbRemoteTests
```

All 41 existing ProcessGdbRemote tests pass. No regressions.
