### PR TITLE
[win][x64] Unwind v2: When making headroom leave space for the header

### DIFF
--- a/llvm/lib/MC/MCWin64EH.cpp
+++ b/llvm/lib/MC/MCWin64EH.cpp
@@ -335,7 +335,8 @@ static void EmitUnwindInfo(MCStreamer &streamer, WinEH::FrameInfo *info) {
   // Emit the epilog instructions.
   if (EnableUnwindV2) {
     // Ensure the fixups and appended content apply to the same fragment.
-    OS->ensureHeadroom(info->EpilogMap.size() * 2);
+    // size byte + flags byte + 2 per epilog (for the distance).
+    OS->ensureHeadroom(2 + info->EpilogMap.size() * 2);
 
     bool IsLast = true;
     for (const auto &Epilog : llvm::reverse(info->EpilogMap)) {


### PR DESCRIPTION
When the `ensureHeadroom` call was added during unwind v2 info emission, it didn't take into account that there is a header of 2-bytes before all the fixups, so not enough space was actually reserved.