### PR TITLE
[PowerPC] Add pnop (prefixed no-op) instruction (ISA v3.1)

### DIFF
--- a/llvm/lib/Target/PowerPC/PPCInstrP10.td
+++ b/llvm/lib/Target/PowerPC/PPCInstrP10.td
@@ -2988,3 +2988,19 @@ let Predicates = [IsISA3_1, PrefixInstrs], isAsmParserOnly = 1, hasNoSchedulingI
                                  (ins s34imm64_pcrel:$SI),
                                  "pla $RT, $SI", IIC_IntSimple, []>, isPCRel;
 }
+
+// pnop - Prefixed No-Op (Power ISA v3.1, Section 3.3.1.2)
+// Prefix word 0x07000000: primary opcode 1, prefix type 3, remaining bits 0.
+// Suffix word 0x00000000. Like all prefixed instructions it must not cross a
+// 64-byte boundary.
+let Predicates = [PrefixInstrs],
+    hasNoSchedulingInfo = 1, hasSideEffects = 0,
+    mayLoad = 0, mayStore = 0 in {
+  def PNOP : PI<1, 0, (outs), (ins), "pnop", IIC_IntSimple> {
+    // Prefix: type 3, remaining prefix bits all zero.
+    let Inst{6...7} = 3;
+    let Inst{8...31} = 0;
+    // Suffix: bits 38-63 all zero (bits 32-37 already = 0 from opcode)
+    let Inst{38...63} = 0;
+  }
+}

--- a/llvm/test/MC/Disassembler/PowerPC/ppc-pnop.txt
+++ b/llvm/test/MC/Disassembler/PowerPC/ppc-pnop.txt
@@ -1,0 +1,6 @@
+# RUN: llvm-mc --disassemble %s -triple powerpc64-unknown-linux-gnu \
+# RUN:   -mcpu=pwr10 | FileCheck %s
+
+# Prefixed no-op (Power ISA v3.1). Instruction bytes are big-endian.
+# CHECK: pnop
+0x07 0x00 0x00 0x00 0x00 0x00 0x00 0x00

--- a/llvm/test/MC/PowerPC/ppc-pnop.s
+++ b/llvm/test/MC/PowerPC/ppc-pnop.s
@@ -1,0 +1,10 @@
+# RUN: llvm-mc -triple powerpc64-unknown-linux-gnu -show-encoding %s | \
+# RUN:   FileCheck %s --check-prefix=CHECK-BE
+# RUN: llvm-mc -triple powerpc64le-unknown-linux-gnu -show-encoding %s | \
+# RUN:   FileCheck %s --check-prefix=CHECK-LE
+
+# Prefixed no-op (Power ISA v3.1, Section 3.3.1.2)
+# Encoding: prefix 0x0700_0000 + suffix 0x0000_0000
+pnop
+# CHECK-BE: pnop  # encoding: [0x07,0x00,0x00,0x00,0x00,0x00,0x00,0x00]
+# CHECK-LE: pnop  # encoding: [0x00,0x00,0x00,0x07,0x00,0x00,0x00,0x00]


### PR DESCRIPTION
This PR is LLM-assisted. Most of it was written with Claude (Anthropic), per the [LLVM AI Tool Policy](https://llvm.org/docs/AIToolPolicy.html#policy). I reviewed it and I'm responsible for it.

## Summary

Add the `pnop` instruction that was missed when prefixed instructions were initially added to the PowerPC backend.

`pnop` is defined in Power ISA v3.1, Section 3.3.1.2.

Fixes #176831.

## Encoding

| Field | Bits | Value |
|-------|------|-------|
| Prefix primary opcode | 0-5 | 1 |
| Prefix type | 6-7 | 3 |
| Prefix remaining | 8-31 | all zeros |
| Suffix opcode | 32-37 | 0 |
| Suffix remaining | 38-63 | all zeros |
| Prefix word | | 0x07000000 |
| Suffix word | | 0x00000000 |

Like all prefixed instructions, `pnop` must not cross a 64-byte boundary.

## Implementation

- `PNOP` in `PPCInstrP10.td` built on the `PI` base class, matching how the other prefixed instructions are defined (`PI<1, opcode, ...>` with the type in bits 6-7)
- Guarded by the `PrefixInstrs` predicate
- No codegen pattern, so it is never selected, but it is left in the disassembler tables so `llvm-mc --disassemble` can decode it
- Assembly test: `llvm/test/MC/PowerPC/ppc-pnop.s`
- Disassembly test: `llvm/test/MC/Disassembler/PowerPC/ppc-pnop.txt`

## Context

As noted in #176831, `pnop` was skipped at first because it has no codegen use. It's still needed by people testing a PowerISA decoder against `llvm-mc`, which uses the disassembler side as well as the assembler side, so both are covered here.

Assisted-by: Claude (Anthropic)

