### PR TITLE
[AMDGPU] Add v2i32 and/or patterns for VOP3 AND_OR and OR3 operations

### DIFF
--- a/llvm/lib/Target/AMDGPU/VOP3Instructions.td
+++ b/llvm/lib/Target/AMDGPU/VOP3Instructions.td
@@ -955,6 +955,26 @@ def : ThreeOp_i32_Pats<and, or, V_AND_OR_B32_e64>;
 def : ThreeOp_i32_Pats<or, or, V_OR3_B32_e64>;
 def : ThreeOp_i32_Pats<xor, add, V_XAD_U32_e64>;
 
+class ThreeOp_v2i32_Pats <SDPatternOperator op1, SDPatternOperator op2, Instruction inst> : GCNPat <
+  // This matches (op2 (op1 v2i32:$src0, v2i32:$src1), v2i32:$src2) with conditions.
+  (ThreeOpFrag<op1, op2> v2i32:$src0, v2i32:$src1, v2i32:$src2),
+  (REG_SEQUENCE VReg_64,
+    (inst
+      (i32 (EXTRACT_SUBREG $src0, sub0)),
+      (i32 (EXTRACT_SUBREG $src1, sub0)),
+      (i32 (EXTRACT_SUBREG $src2, sub0))
+    ), sub0,
+    (inst
+      (i32 (EXTRACT_SUBREG $src0, sub1)),
+      (i32 (EXTRACT_SUBREG $src1, sub1)),
+      (i32 (EXTRACT_SUBREG $src2, sub1))
+    ), sub1
+  )
+>;
+
+def : ThreeOp_v2i32_Pats<and, or, V_AND_OR_B32_e64>;
+def : ThreeOp_v2i32_Pats<or, or, V_OR3_B32_e64>;
+
 let SubtargetPredicate = HasMadU32Inst, AddedComplexity = 10 in
   def : ThreeOp_i32_Pats<mul, add, V_MAD_U32_e64>;
 

--- a/llvm/test/CodeGen/AMDGPU/and_or.ll
+++ b/llvm/test/CodeGen/AMDGPU/and_or.ll
@@ -143,304 +143,276 @@ define amdgpu_ps float @and_or_vgpr_inline_const_x2(i32 %a) {
   ret float %bc
 }
 
-define amdgpu_ps <2 x i32> @v_and_or_v2i32(<2 x i32> %a, <2 x i32> %b, <2 x i32> %c) {
+define <2 x i32> @v_and_or_v2i32(<2 x i32> %a, <2 x i32> %b, <2 x i32> %c) {
 ; VI-LABEL: v_and_or_v2i32:
 ; VI:       ; %bb.0:
+; VI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; VI-NEXT:    v_and_b32_e32 v1, v1, v3
 ; VI-NEXT:    v_and_b32_e32 v0, v0, v2
 ; VI-NEXT:    v_or_b32_e32 v1, v1, v5
 ; VI-NEXT:    v_or_b32_e32 v0, v0, v4
-; VI-NEXT:    v_readfirstlane_b32 s0, v0
-; VI-NEXT:    v_readfirstlane_b32 s1, v1
-; VI-NEXT:    ; return to shader part epilog
+; VI-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX9-LABEL: v_and_or_v2i32:
 ; GFX9:       ; %bb.0:
+; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX9-NEXT:    v_and_or_b32 v1, v1, v3, v5
 ; GFX9-NEXT:    v_and_or_b32 v0, v0, v2, v4
-; GFX9-NEXT:    v_readfirstlane_b32 s0, v0
-; GFX9-NEXT:    v_readfirstlane_b32 s1, v1
-; GFX9-NEXT:    ; return to shader part epilog
+; GFX9-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-LABEL: v_and_or_v2i32:
 ; GFX10:       ; %bb.0:
+; GFX10-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX10-NEXT:    v_and_or_b32 v0, v0, v2, v4
 ; GFX10-NEXT:    v_and_or_b32 v1, v1, v3, v5
-; GFX10-NEXT:    v_readfirstlane_b32 s0, v0
-; GFX10-NEXT:    v_readfirstlane_b32 s1, v1
-; GFX10-NEXT:    ; return to shader part epilog
+; GFX10-NEXT:    s_setpc_b64 s[30:31]
   %x = and <2 x i32> %a, %b
   %result = or <2 x i32> %x, %c
   ret <2 x i32> %result
 }
 
 ; ThreeOp instruction variant not used due to Constant Bus Limitations
-define amdgpu_ps <2 x i32> @v_and_or_v2i32_b(<2 x i32> inreg %a, <2 x i32> %b, <2 x i32> inreg %c) {
+define <2 x i32> @v_and_or_v2i32_b(<2 x i32> inreg %a, <2 x i32> %b, <2 x i32> inreg %c) {
 ; VI-LABEL: v_and_or_v2i32_b:
 ; VI:       ; %bb.0:
-; VI-NEXT:    v_and_b32_e32 v1, s3, v1
-; VI-NEXT:    v_and_b32_e32 v0, s2, v0
-; VI-NEXT:    v_or_b32_e32 v1, s5, v1
-; VI-NEXT:    v_or_b32_e32 v0, s4, v0
-; VI-NEXT:    v_readfirstlane_b32 s0, v0
-; VI-NEXT:    v_readfirstlane_b32 s1, v1
-; VI-NEXT:    ; return to shader part epilog
+; VI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; VI-NEXT:    v_and_b32_e32 v1, s17, v1
+; VI-NEXT:    v_and_b32_e32 v0, s16, v0
+; VI-NEXT:    v_or_b32_e32 v1, s19, v1
+; VI-NEXT:    v_or_b32_e32 v0, s18, v0
+; VI-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX9-LABEL: v_and_or_v2i32_b:
 ; GFX9:       ; %bb.0:
-; GFX9-NEXT:    v_and_b32_e32 v1, s3, v1
-; GFX9-NEXT:    v_and_b32_e32 v0, s2, v0
-; GFX9-NEXT:    v_or_b32_e32 v1, s5, v1
-; GFX9-NEXT:    v_or_b32_e32 v0, s4, v0
-; GFX9-NEXT:    v_readfirstlane_b32 s0, v0
-; GFX9-NEXT:    v_readfirstlane_b32 s1, v1
-; GFX9-NEXT:    ; return to shader part epilog
+; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    v_and_b32_e32 v1, s17, v1
+; GFX9-NEXT:    v_and_b32_e32 v0, s16, v0
+; GFX9-NEXT:    v_or_b32_e32 v1, s19, v1
+; GFX9-NEXT:    v_or_b32_e32 v0, s18, v0
+; GFX9-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-LABEL: v_and_or_v2i32_b:
 ; GFX10:       ; %bb.0:
-; GFX10-NEXT:    v_and_or_b32 v0, s2, v0, s4
-; GFX10-NEXT:    v_and_or_b32 v1, s3, v1, s5
-; GFX10-NEXT:    v_readfirstlane_b32 s0, v0
-; GFX10-NEXT:    v_readfirstlane_b32 s1, v1
-; GFX10-NEXT:    ; return to shader part epilog
+; GFX10-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX10-DAG:     v_and_or_b32 v0, s{{[0-9]+}}, v0, s{{[0-9]+}}
+; GFX10-DAG:     v_and_or_b32 v1, s{{[0-9]+}}, v1, s{{[0-9]+}}
+; GFX10-NEXT:    s_setpc_b64 s[30:31]
   %x = and <2 x i32> %a, %b
   %result = or <2 x i32> %x, %c
   ret <2 x i32> %result
 }
 
-define amdgpu_ps <2 x i32> @v_and_or_v2i32_ab(<2 x i32> %a, <2 x i32> %b, <2 x i32> inreg %c) {
+define <2 x i32> @v_and_or_v2i32_ab(<2 x i32> %a, <2 x i32> %b, <2 x i32> inreg %c) {
 ; VI-LABEL: v_and_or_v2i32_ab:
 ; VI:       ; %bb.0:
+; VI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; VI-NEXT:    v_and_b32_e32 v1, v1, v3
 ; VI-NEXT:    v_and_b32_e32 v0, v0, v2
-; VI-NEXT:    v_or_b32_e32 v1, s3, v1
-; VI-NEXT:    v_or_b32_e32 v0, s2, v0
-; VI-NEXT:    v_readfirstlane_b32 s0, v0
-; VI-NEXT:    v_readfirstlane_b32 s1, v1
-; VI-NEXT:    ; return to shader part epilog
+; VI-NEXT:    v_or_b32_e32 v1, s17, v1
+; VI-NEXT:    v_or_b32_e32 v0, s16, v0
+; VI-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX9-LABEL: v_and_or_v2i32_ab:
 ; GFX9:       ; %bb.0:
-; GFX9-NEXT:    v_and_or_b32 v1, v1, v3, s3
-; GFX9-NEXT:    v_and_or_b32 v0, v0, v2, s2
-; GFX9-NEXT:    v_readfirstlane_b32 s0, v0
-; GFX9-NEXT:    v_readfirstlane_b32 s1, v1
-; GFX9-NEXT:    ; return to shader part epilog
+; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    v_and_or_b32 v1, v1, v3, s17
+; GFX9-NEXT:    v_and_or_b32 v0, v0, v2, s16
+; GFX9-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-LABEL: v_and_or_v2i32_ab:
 ; GFX10:       ; %bb.0:
-; GFX10-NEXT:    v_and_or_b32 v0, v0, v2, s2
-; GFX10-NEXT:    v_and_or_b32 v1, v1, v3, s3
-; GFX10-NEXT:    v_readfirstlane_b32 s0, v0
-; GFX10-NEXT:    v_readfirstlane_b32 s1, v1
-; GFX10-NEXT:    ; return to shader part epilog
+; GFX10-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX10-DAG:     v_and_or_b32 v1, v1, v3, {{s[0-9]+}}
+; GFX10-DAG:     v_and_or_b32 v0, v0, v2, {{s[0-9]+}}
+; GFX10-NEXT:    s_setpc_b64 s[30:31]
   %x = and <2 x i32> %a, %b
   %result = or <2 x i32> %x, %c
   ret <2 x i32> %result
 }
 
-define amdgpu_ps <2 x i32> @v_and_or_v2i32_const(<2 x i32> %a, <2 x i32> %b) {
+define <2 x i32> @v_and_or_v2i32_const(<2 x i32> %a, <2 x i32> %b) {
 ; VI-LABEL: v_and_or_v2i32_const:
 ; VI:       ; %bb.0:
+; VI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; VI-NEXT:    v_and_b32_e32 v1, 16, v1
 ; VI-NEXT:    v_and_b32_e32 v0, 4, v0
 ; VI-NEXT:    v_or_b32_e32 v1, v1, v3
 ; VI-NEXT:    v_or_b32_e32 v0, v0, v2
-; VI-NEXT:    v_readfirstlane_b32 s0, v0
-; VI-NEXT:    v_readfirstlane_b32 s1, v1
-; VI-NEXT:    ; return to shader part epilog
+; VI-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX9-LABEL: v_and_or_v2i32_const:
 ; GFX9:       ; %bb.0:
+; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX9-NEXT:    v_and_or_b32 v1, v1, 16, v3
 ; GFX9-NEXT:    v_and_or_b32 v0, v0, 4, v2
-; GFX9-NEXT:    v_readfirstlane_b32 s0, v0
-; GFX9-NEXT:    v_readfirstlane_b32 s1, v1
-; GFX9-NEXT:    ; return to shader part epilog
+; GFX9-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-LABEL: v_and_or_v2i32_const:
 ; GFX10:       ; %bb.0:
+; GFX10-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX10-NEXT:    v_and_or_b32 v0, v0, 4, v2
 ; GFX10-NEXT:    v_and_or_b32 v1, v1, 16, v3
-; GFX10-NEXT:    v_readfirstlane_b32 s0, v0
-; GFX10-NEXT:    v_readfirstlane_b32 s1, v1
-; GFX10-NEXT:    ; return to shader part epilog
+; GFX10-NEXT:    s_setpc_b64 s[30:31]
   %x = and <2 x i32> %a, <i32 4, i32 16>
   %result = or <2 x i32> %x, %b
   ret <2 x i32> %result
 }
 
-define amdgpu_ps <2 x i32> @v_and_or_v2i32_inline_const(<2 x i32> %a, <2 x i32> %b) {
+define <2 x i32> @v_and_or_v2i32_inline_const(<2 x i32> %a, <2 x i32> %b) {
 ; VI-LABEL: v_and_or_v2i32_inline_const:
 ; VI:       ; %bb.0:
+; VI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; VI-NEXT:    v_and_b32_e32 v1, 0x809, v1
 ; VI-NEXT:    v_and_b32_e32 v0, 0x808, v0
 ; VI-NEXT:    v_or_b32_e32 v1, v1, v3
 ; VI-NEXT:    v_or_b32_e32 v0, v0, v2
-; VI-NEXT:    v_readfirstlane_b32 s0, v0
-; VI-NEXT:    v_readfirstlane_b32 s1, v1
-; VI-NEXT:    ; return to shader part epilog
+; VI-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX9-LABEL: v_and_or_v2i32_inline_const:
 ; GFX9:       ; %bb.0:
-; GFX9-NEXT:    s_movk_i32 s0, 0x809
-; GFX9-NEXT:    v_and_or_b32 v1, v1, s0, v3
-; GFX9-NEXT:    s_movk_i32 s0, 0x808
-; GFX9-NEXT:    v_and_or_b32 v0, v0, s0, v2
-; GFX9-NEXT:    v_readfirstlane_b32 s0, v0
-; GFX9-NEXT:    v_readfirstlane_b32 s1, v1
-; GFX9-NEXT:    ; return to shader part epilog
+; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    s_movk_i32 s4, 0x809
+; GFX9-NEXT:    v_and_or_b32 v1, v1, s4, v3
+; GFX9-NEXT:    s_movk_i32 s4, 0x808
+; GFX9-NEXT:    v_and_or_b32 v0, v0, s4, v2
+; GFX9-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-LABEL: v_and_or_v2i32_inline_const:
 ; GFX10:       ; %bb.0:
+; GFX10-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX10-NEXT:    v_and_or_b32 v0, 0x808, v0, v2
 ; GFX10-NEXT:    v_and_or_b32 v1, 0x809, v1, v3
-; GFX10-NEXT:    v_readfirstlane_b32 s0, v0
-; GFX10-NEXT:    v_readfirstlane_b32 s1, v1
-; GFX10-NEXT:    ; return to shader part epilog
+; GFX10-NEXT:    s_setpc_b64 s[30:31]
   %x = and <2 x i32> %a, <i32 2056, i32 2057>
   %result = or <2 x i32> %x, %b
   ret <2 x i32> %result
 }
 
-define amdgpu_ps <2 x i32> @v_and_or_v2i32_inline_const_x2(<2 x i32> %a) {
+define <2 x i32> @v_and_or_v2i32_inline_const_x2(<2 x i32> %a) {
 ; VI-LABEL: v_and_or_v2i32_inline_const_x2:
 ; VI:       ; %bb.0:
+; VI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; VI-NEXT:    v_and_b32_e32 v1, 0x809, v1
 ; VI-NEXT:    v_and_b32_e32 v0, 0x808, v0
 ; VI-NEXT:    v_or_b32_e32 v1, 16, v1
 ; VI-NEXT:    v_or_b32_e32 v0, 4, v0
-; VI-NEXT:    v_readfirstlane_b32 s0, v0
-; VI-NEXT:    v_readfirstlane_b32 s1, v1
-; VI-NEXT:    ; return to shader part epilog
+; VI-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX9-LABEL: v_and_or_v2i32_inline_const_x2:
 ; GFX9:       ; %bb.0:
+; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX9-NEXT:    v_and_b32_e32 v1, 0x809, v1
 ; GFX9-NEXT:    v_and_b32_e32 v0, 0x808, v0
 ; GFX9-NEXT:    v_or_b32_e32 v1, 16, v1
 ; GFX9-NEXT:    v_or_b32_e32 v0, 4, v0
-; GFX9-NEXT:    v_readfirstlane_b32 s0, v0
-; GFX9-NEXT:    v_readfirstlane_b32 s1, v1
-; GFX9-NEXT:    ; return to shader part epilog
+; GFX9-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-LABEL: v_and_or_v2i32_inline_const_x2:
 ; GFX10:       ; %bb.0:
+; GFX10-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX10-NEXT:    v_and_or_b32 v0, 0x808, v0, 4
 ; GFX10-NEXT:    v_and_or_b32 v1, 0x809, v1, 16
-; GFX10-NEXT:    v_readfirstlane_b32 s0, v0
-; GFX10-NEXT:    v_readfirstlane_b32 s1, v1
-; GFX10-NEXT:    ; return to shader part epilog
+; GFX10-NEXT:    s_setpc_b64 s[30:31]
   %x = and <2 x i32> %a, <i32 2056, i32 2057>
   %result = or <2 x i32> %x, <i32 4, i32 16>
   ret <2 x i32> %result
 }
 
-define amdgpu_ps <2 x i32> @v_and_or_v2i32_inline_const_x3(<2 x i32> %a) {
+define <2 x i32> @v_and_or_v2i32_inline_const_x3(<2 x i32> %a) {
 ; VI-LABEL: v_and_or_v2i32_inline_const_x3:
 ; VI:       ; %bb.0:
+; VI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; VI-NEXT:    v_and_b32_e32 v1, 0x809, v1
 ; VI-NEXT:    v_and_b32_e32 v0, 0x808, v0
 ; VI-NEXT:    v_or_b32_e32 v1, 16, v1
 ; VI-NEXT:    v_or_b32_e32 v0, 0x81, v0
-; VI-NEXT:    v_readfirstlane_b32 s0, v0
-; VI-NEXT:    v_readfirstlane_b32 s1, v1
-; VI-NEXT:    ; return to shader part epilog
+; VI-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX9-LABEL: v_and_or_v2i32_inline_const_x3:
 ; GFX9:       ; %bb.0:
+; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX9-NEXT:    v_and_b32_e32 v1, 0x809, v1
 ; GFX9-NEXT:    v_and_b32_e32 v0, 0x808, v0
 ; GFX9-NEXT:    v_or_b32_e32 v1, 16, v1
 ; GFX9-NEXT:    v_or_b32_e32 v0, 0x81, v0
-; GFX9-NEXT:    v_readfirstlane_b32 s0, v0
-; GFX9-NEXT:    v_readfirstlane_b32 s1, v1
-; GFX9-NEXT:    ; return to shader part epilog
+; GFX9-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-LABEL: v_and_or_v2i32_inline_const_x3:
 ; GFX10:       ; %bb.0:
-; GFX10-NEXT:    s_movk_i32 s0, 0x808
-; GFX10-NEXT:    v_and_or_b32 v1, 0x809, v1, 16
-; GFX10-NEXT:    v_and_or_b32 v0, v0, s0, 0x81
-; GFX10-NEXT:    v_readfirstlane_b32 s1, v1
-; GFX10-NEXT:    v_readfirstlane_b32 s0, v0
-; GFX10-NEXT:    ; return to shader part epilog
+; GFX10-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX10-NEXT:    s_movk_i32 [[SR:s[0-9]+]], 0x808
+; GFX10-DAG:     v_and_or_b32 v0, v0, [[SR]], 0x81
+; GFX10-DAG:     v_and_or_b32 v1, 0x809, v1, 16
   %x = and <2 x i32> %a, <i32 2056, i32 2057>
   %result = or <2 x i32> %x, <i32 129, i32 16>
   ret <2 x i32> %result
 }
 
-define amdgpu_ps <2 x i32> @v_and_or_v2i32_inline_const_x4(<2 x i32> %a) {
+define <2 x i32> @v_and_or_v2i32_inline_const_x4(<2 x i32> %a) {
 ; VI-LABEL: v_and_or_v2i32_inline_const_x4:
 ; VI:       ; %bb.0:
+; VI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; VI-NEXT:    v_and_b32_e32 v1, 0x809, v1
 ; VI-NEXT:    v_and_b32_e32 v0, 0x808, v0
 ; VI-NEXT:    v_or_b32_e32 v1, 0x101, v1
 ; VI-NEXT:    v_or_b32_e32 v0, 0x81, v0
-; VI-NEXT:    v_readfirstlane_b32 s0, v0
-; VI-NEXT:    v_readfirstlane_b32 s1, v1
-; VI-NEXT:    ; return to shader part epilog
+; VI-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX9-LABEL: v_and_or_v2i32_inline_const_x4:
 ; GFX9:       ; %bb.0:
+; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX9-NEXT:    v_and_b32_e32 v1, 0x809, v1
 ; GFX9-NEXT:    v_and_b32_e32 v0, 0x808, v0
 ; GFX9-NEXT:    v_or_b32_e32 v1, 0x101, v1
 ; GFX9-NEXT:    v_or_b32_e32 v0, 0x81, v0
-; GFX9-NEXT:    v_readfirstlane_b32 s0, v0
-; GFX9-NEXT:    v_readfirstlane_b32 s1, v1
-; GFX9-NEXT:    ; return to shader part epilog
+; GFX9-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-LABEL: v_and_or_v2i32_inline_const_x4:
 ; GFX10:       ; %bb.0:
-; GFX10-NEXT:    s_movk_i32 s0, 0x808
-; GFX10-NEXT:    s_movk_i32 s1, 0x809
-; GFX10-NEXT:    v_and_or_b32 v0, v0, s0, 0x81
-; GFX10-NEXT:    v_and_or_b32 v1, v1, s1, 0x101
-; GFX10-NEXT:    v_readfirstlane_b32 s0, v0
-; GFX10-NEXT:    v_readfirstlane_b32 s1, v1
-; GFX10-NEXT:    ; return to shader part epilog
+; GFX10-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX10-DAG:     s_movk_i32 [[SR0:s[0-9]+]], 0x808
+; GFX10-DAG:     s_movk_i32 [[SR1:s[0-9]+]], 0x809
+; GFX10-CHECK-NOT: {{.}}
+; GFX10-DAG:     v_and_or_b32 v0, v0, [[SR0]], 0x81
+; GFX10-DAG:     v_and_or_b32 v1, v1, [[SR1]], 0x101
   %x = and <2 x i32> %a, <i32 2056, i32 2057>
   %result = or <2 x i32> %x, <i32 129, i32 257>
   ret <2 x i32> %result
 }
 
-define amdgpu_ps <2 x i32> @v_and_or_v2i32_multi_use(<2 x i32> %a, <2 x i32> %b, <2 x i32> %c) {
+define <2 x i32> @v_and_or_v2i32_multi_use(<2 x i32> %a, <2 x i32> %b, <2 x i32> %c) {
 ; VI-LABEL: v_and_or_v2i32_multi_use:
 ; VI:       ; %bb.0:
+; VI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; VI-NEXT:    v_and_b32_e32 v1, v1, v3
 ; VI-NEXT:    v_and_b32_e32 v0, v0, v2
 ; VI-NEXT:    v_or_b32_e32 v2, v1, v5
 ; VI-NEXT:    v_or_b32_e32 v3, v0, v4
-; VI-NEXT:    v_add_u32_e32 v1, vcc, v1, v2
 ; VI-NEXT:    v_add_u32_e32 v0, vcc, v0, v3
-; VI-NEXT:    v_readfirstlane_b32 s0, v0
-; VI-NEXT:    v_readfirstlane_b32 s1, v1
-; VI-NEXT:    ; return to shader part epilog
+; VI-NEXT:    v_add_u32_e32 v1, vcc, v1, v2
+; VI-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX9-LABEL: v_and_or_v2i32_multi_use:
 ; GFX9:       ; %bb.0:
+; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX9-NEXT:    v_and_b32_e32 v1, v1, v3
 ; GFX9-NEXT:    v_and_b32_e32 v0, v0, v2
 ; GFX9-NEXT:    v_or_b32_e32 v2, v1, v5
 ; GFX9-NEXT:    v_or_b32_e32 v3, v0, v4
-; GFX9-NEXT:    v_add_u32_e32 v1, v1, v2
 ; GFX9-NEXT:    v_add_u32_e32 v0, v0, v3
-; GFX9-NEXT:    v_readfirstlane_b32 s0, v0
-; GFX9-NEXT:    v_readfirstlane_b32 s1, v1
-; GFX9-NEXT:    ; return to shader part epilog
+; GFX9-NEXT:    v_add_u32_e32 v1, v1, v2
+; GFX9-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-LABEL: v_and_or_v2i32_multi_use:
 ; GFX10:       ; %bb.0:
+; GFX10-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX10-NEXT:    v_and_b32_e32 v0, v0, v2
 ; GFX10-NEXT:    v_and_b32_e32 v1, v1, v3
 ; GFX10-NEXT:    v_or_b32_e32 v2, v0, v4
 ; GFX10-NEXT:    v_or_b32_e32 v3, v1, v5
 ; GFX10-NEXT:    v_add_nc_u32_e32 v0, v0, v2
 ; GFX10-NEXT:    v_add_nc_u32_e32 v1, v1, v3
-; GFX10-NEXT:    v_readfirstlane_b32 s0, v0
-; GFX10-NEXT:    v_readfirstlane_b32 s1, v1
-; GFX10-NEXT:    ; return to shader part epilog
+; GFX10-NEXT:    s_setpc_b64 s[30:31]
   %x = and <2 x i32> %a, %b
   %y = or <2 x i32> %x, %c
   %result = add <2 x i32> %x, %y

--- a/llvm/test/CodeGen/AMDGPU/and_or.ll
+++ b/llvm/test/CodeGen/AMDGPU/and_or.ll
@@ -216,6 +216,26 @@ define <2 x i32> @and_or_v2i32_ab(<2 x i32> %a, <2 x i32> %b, <2 x i32> inreg %c
   ret <2 x i32> %result
 }
 
+define <2 x i32> @and_or_v2i32_abc(<2 x i32> inreg %a, <2 x i32> inreg %b, <2 x i32> inreg %c) {
+; VI-LABEL: and_or_v2i32_abc:
+; VI:         s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; VI-NEXT:    s_and_b64 s[4:5], s[16:17], s[18:19]
+; VI-NEXT:    s_or_b64 s[4:5], s[4:5], s[20:21]
+;
+; GFX9-LABEL: and_or_v2i32_abc:
+; GFX9:         s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    s_and_b64 s[4:5], s[16:17], s[18:19]
+; GFX9-NEXT:    s_or_b64 s[4:5], s[4:5], s[20:21]
+;
+; GFX10-LABEL: and_or_v2i32_abc:
+; GFX10:         s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX10-NEXT:    s_and_b64 [[SV0:s\[[0-9]+:[0-9]+\]]], [[SV1:s\[[0-9]+:[0-9]+\]]], [[SV2:s\[[0-9]+:[0-9]+\]]]
+; GFX10-NEXT:    s_or_b64 [[SV0]], [[SV0]], [[SV3:s\[[0-9]+:[0-9]+\]]]
+  %x = and <2 x i32> %a, %b
+  %result = or <2 x i32> %x, %c
+  ret <2 x i32> %result
+}
+
 define <2 x i32> @and_or_v2i32_const(<2 x i32> %a, <2 x i32> %b) {
 ; VI-LABEL: and_or_v2i32_const:
 ; VI:        s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)

--- a/llvm/test/CodeGen/AMDGPU/and_or.ll
+++ b/llvm/test/CodeGen/AMDGPU/and_or.ll
@@ -143,76 +143,307 @@ define amdgpu_ps float @and_or_vgpr_inline_const_x2(i32 %a) {
   ret float %bc
 }
 
-define <2 x i32> @and_or_v2i32(<2 x i32> %a, <2 x i32> %b, <2 x i32> %c) {
-; VI-LABEL: and_or_v2i32:
-; VI:        s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; VI-DAG:    v_and_b32_e32 v0, v0, v2
-; VI-DAG:    v_and_b32_e32 v1, v1, v3
-; VI-CHECK-NOT: {{.}}
-; VI-DAG:    v_or_b32_e32 v0, v0, v4
-; VI-DAG:    v_or_b32_e32 v1, v1, v5
+define amdgpu_ps <2 x i32> @v_and_or_v2i32(<2 x i32> %a, <2 x i32> %b, <2 x i32> %c) {
+; VI-LABEL: v_and_or_v2i32:
+; VI:       ; %bb.0:
+; VI-NEXT:    v_and_b32_e32 v1, v1, v3
+; VI-NEXT:    v_and_b32_e32 v0, v0, v2
+; VI-NEXT:    v_or_b32_e32 v1, v1, v5
+; VI-NEXT:    v_or_b32_e32 v0, v0, v4
+; VI-NEXT:    v_readfirstlane_b32 s0, v0
+; VI-NEXT:    v_readfirstlane_b32 s1, v1
+; VI-NEXT:    ; return to shader part epilog
 ;
-; GFX9-LABEL: and_or_v2i32:
-; GFX9:         s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX9-DAG:     v_and_or_b32 v0, v0, v2, v4
-; GFX9-DAG:     v_and_or_b32 v1, v1, v3, v5
+; GFX9-LABEL: v_and_or_v2i32:
+; GFX9:       ; %bb.0:
+; GFX9-NEXT:    v_and_or_b32 v1, v1, v3, v5
+; GFX9-NEXT:    v_and_or_b32 v0, v0, v2, v4
+; GFX9-NEXT:    v_readfirstlane_b32 s0, v0
+; GFX9-NEXT:    v_readfirstlane_b32 s1, v1
+; GFX9-NEXT:    ; return to shader part epilog
 ;
-; GFX10-LABEL: and_or_v2i32:
-; GFX10:         s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX10-DAG:     v_and_or_b32 v0, v0, v2, v4
-; GFX10-DAG:     v_and_or_b32 v1, v1, v3, v5
+; GFX10-LABEL: v_and_or_v2i32:
+; GFX10:       ; %bb.0:
+; GFX10-NEXT:    v_and_or_b32 v0, v0, v2, v4
+; GFX10-NEXT:    v_and_or_b32 v1, v1, v3, v5
+; GFX10-NEXT:    v_readfirstlane_b32 s0, v0
+; GFX10-NEXT:    v_readfirstlane_b32 s1, v1
+; GFX10-NEXT:    ; return to shader part epilog
   %x = and <2 x i32> %a, %b
   %result = or <2 x i32> %x, %c
   ret <2 x i32> %result
 }
 
 ; ThreeOp instruction variant not used due to Constant Bus Limitations
-define <2 x i32> @and_or_v2i32_b(<2 x i32> inreg %a, <2 x i32> %b, <2 x i32> inreg %c) {
-; VI-LABEL: and_or_v2i32_b:
-; VI:        s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; VI-DAG:    v_and_b32_e32 v0, s16, v0
-; VI-DAG:    v_and_b32_e32 v1, s17, v1
-; VI-CHECK-NOT: {{.}}
-; VI-DAG:    v_or_b32_e32 v0, s18, v0
-; VI-DAG:    v_or_b32_e32 v1, s19, v1
+define amdgpu_ps <2 x i32> @v_and_or_v2i32_b(<2 x i32> inreg %a, <2 x i32> %b, <2 x i32> inreg %c) {
+; VI-LABEL: v_and_or_v2i32_b:
+; VI:       ; %bb.0:
+; VI-NEXT:    v_and_b32_e32 v1, s3, v1
+; VI-NEXT:    v_and_b32_e32 v0, s2, v0
+; VI-NEXT:    v_or_b32_e32 v1, s5, v1
+; VI-NEXT:    v_or_b32_e32 v0, s4, v0
+; VI-NEXT:    v_readfirstlane_b32 s0, v0
+; VI-NEXT:    v_readfirstlane_b32 s1, v1
+; VI-NEXT:    ; return to shader part epilog
 ;
-; GFX9-LABEL: and_or_v2i32_b:
-; GFX9:        s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX9-DAG:    v_and_b32_e32 v0, s16, v0
-; GFX9-DAG:    v_and_b32_e32 v1, s17, v1
-; GFX9-CHECK-NOT: {{.}}
-; GFX9-DAG:    v_or_b32_e32 v0, s18, v0
-; GFX9-DAG:    v_or_b32_e32 v1, s19, v1
+; GFX9-LABEL: v_and_or_v2i32_b:
+; GFX9:       ; %bb.0:
+; GFX9-NEXT:    v_and_b32_e32 v1, s3, v1
+; GFX9-NEXT:    v_and_b32_e32 v0, s2, v0
+; GFX9-NEXT:    v_or_b32_e32 v1, s5, v1
+; GFX9-NEXT:    v_or_b32_e32 v0, s4, v0
+; GFX9-NEXT:    v_readfirstlane_b32 s0, v0
+; GFX9-NEXT:    v_readfirstlane_b32 s1, v1
+; GFX9-NEXT:    ; return to shader part epilog
 ;
-; GFX10-LABEL: and_or_v2i32_b:
-; GFX10:         s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX10-DAG:     v_and_or_b32 v0, s{{[0-9]+}}, v0, s{{[0-9]+}}
-; GFX10-DAG:     v_and_or_b32 v1, s{{[0-9]+}}, v1, s{{[0-9]+}}
+; GFX10-LABEL: v_and_or_v2i32_b:
+; GFX10:       ; %bb.0:
+; GFX10-NEXT:    v_and_or_b32 v0, s2, v0, s4
+; GFX10-NEXT:    v_and_or_b32 v1, s3, v1, s5
+; GFX10-NEXT:    v_readfirstlane_b32 s0, v0
+; GFX10-NEXT:    v_readfirstlane_b32 s1, v1
+; GFX10-NEXT:    ; return to shader part epilog
   %x = and <2 x i32> %a, %b
   %result = or <2 x i32> %x, %c
   ret <2 x i32> %result
 }
 
-define <2 x i32> @and_or_v2i32_ab(<2 x i32> %a, <2 x i32> %b, <2 x i32> inreg %c) {
-; VI-LABEL: and_or_v2i32_ab:
-; VI:        s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; VI-DAG:    v_and_b32_e32 v0, v0, v2
-; VI-DAG:    v_and_b32_e32 v1, v1, v3
-; VI-CHECK-NOT: {{.}}
-; VI-DAG:    v_or_b32_e32 v0, s16, v0
-; VI-DAG:    v_or_b32_e32 v1, s17, v1
+define amdgpu_ps <2 x i32> @v_and_or_v2i32_ab(<2 x i32> %a, <2 x i32> %b, <2 x i32> inreg %c) {
+; VI-LABEL: v_and_or_v2i32_ab:
+; VI:       ; %bb.0:
+; VI-NEXT:    v_and_b32_e32 v1, v1, v3
+; VI-NEXT:    v_and_b32_e32 v0, v0, v2
+; VI-NEXT:    v_or_b32_e32 v1, s3, v1
+; VI-NEXT:    v_or_b32_e32 v0, s2, v0
+; VI-NEXT:    v_readfirstlane_b32 s0, v0
+; VI-NEXT:    v_readfirstlane_b32 s1, v1
+; VI-NEXT:    ; return to shader part epilog
 ;
-; GFX9-LABEL: and_or_v2i32_ab:
-; GFX9:         s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX9-DAG:     v_and_or_b32 v0, v0, v2, s16
-; GFX9-DAG:     v_and_or_b32 v1, v1, v3, s17
+; GFX9-LABEL: v_and_or_v2i32_ab:
+; GFX9:       ; %bb.0:
+; GFX9-NEXT:    v_and_or_b32 v1, v1, v3, s3
+; GFX9-NEXT:    v_and_or_b32 v0, v0, v2, s2
+; GFX9-NEXT:    v_readfirstlane_b32 s0, v0
+; GFX9-NEXT:    v_readfirstlane_b32 s1, v1
+; GFX9-NEXT:    ; return to shader part epilog
 ;
-; GFX10-LABEL: and_or_v2i32_ab:
-; GFX10:         s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX10-DAG:     v_and_or_b32 v0, v0, v2, s{{[0-9]+}}
-; GFX10-DAG:     v_and_or_b32 v1, v1, v3, s{{[0-9]+}}
+; GFX10-LABEL: v_and_or_v2i32_ab:
+; GFX10:       ; %bb.0:
+; GFX10-NEXT:    v_and_or_b32 v0, v0, v2, s2
+; GFX10-NEXT:    v_and_or_b32 v1, v1, v3, s3
+; GFX10-NEXT:    v_readfirstlane_b32 s0, v0
+; GFX10-NEXT:    v_readfirstlane_b32 s1, v1
+; GFX10-NEXT:    ; return to shader part epilog
   %x = and <2 x i32> %a, %b
   %result = or <2 x i32> %x, %c
+  ret <2 x i32> %result
+}
+
+define amdgpu_ps <2 x i32> @v_and_or_v2i32_const(<2 x i32> %a, <2 x i32> %b) {
+; VI-LABEL: v_and_or_v2i32_const:
+; VI:       ; %bb.0:
+; VI-NEXT:    v_and_b32_e32 v1, 16, v1
+; VI-NEXT:    v_and_b32_e32 v0, 4, v0
+; VI-NEXT:    v_or_b32_e32 v1, v1, v3
+; VI-NEXT:    v_or_b32_e32 v0, v0, v2
+; VI-NEXT:    v_readfirstlane_b32 s0, v0
+; VI-NEXT:    v_readfirstlane_b32 s1, v1
+; VI-NEXT:    ; return to shader part epilog
+;
+; GFX9-LABEL: v_and_or_v2i32_const:
+; GFX9:       ; %bb.0:
+; GFX9-NEXT:    v_and_or_b32 v1, v1, 16, v3
+; GFX9-NEXT:    v_and_or_b32 v0, v0, 4, v2
+; GFX9-NEXT:    v_readfirstlane_b32 s0, v0
+; GFX9-NEXT:    v_readfirstlane_b32 s1, v1
+; GFX9-NEXT:    ; return to shader part epilog
+;
+; GFX10-LABEL: v_and_or_v2i32_const:
+; GFX10:       ; %bb.0:
+; GFX10-NEXT:    v_and_or_b32 v0, v0, 4, v2
+; GFX10-NEXT:    v_and_or_b32 v1, v1, 16, v3
+; GFX10-NEXT:    v_readfirstlane_b32 s0, v0
+; GFX10-NEXT:    v_readfirstlane_b32 s1, v1
+; GFX10-NEXT:    ; return to shader part epilog
+  %x = and <2 x i32> %a, <i32 4, i32 16>
+  %result = or <2 x i32> %x, %b
+  ret <2 x i32> %result
+}
+
+define amdgpu_ps <2 x i32> @v_and_or_v2i32_inline_const(<2 x i32> %a, <2 x i32> %b) {
+; VI-LABEL: v_and_or_v2i32_inline_const:
+; VI:       ; %bb.0:
+; VI-NEXT:    v_and_b32_e32 v1, 0x809, v1
+; VI-NEXT:    v_and_b32_e32 v0, 0x808, v0
+; VI-NEXT:    v_or_b32_e32 v1, v1, v3
+; VI-NEXT:    v_or_b32_e32 v0, v0, v2
+; VI-NEXT:    v_readfirstlane_b32 s0, v0
+; VI-NEXT:    v_readfirstlane_b32 s1, v1
+; VI-NEXT:    ; return to shader part epilog
+;
+; GFX9-LABEL: v_and_or_v2i32_inline_const:
+; GFX9:       ; %bb.0:
+; GFX9-NEXT:    s_movk_i32 s0, 0x809
+; GFX9-NEXT:    v_and_or_b32 v1, v1, s0, v3
+; GFX9-NEXT:    s_movk_i32 s0, 0x808
+; GFX9-NEXT:    v_and_or_b32 v0, v0, s0, v2
+; GFX9-NEXT:    v_readfirstlane_b32 s0, v0
+; GFX9-NEXT:    v_readfirstlane_b32 s1, v1
+; GFX9-NEXT:    ; return to shader part epilog
+;
+; GFX10-LABEL: v_and_or_v2i32_inline_const:
+; GFX10:       ; %bb.0:
+; GFX10-NEXT:    v_and_or_b32 v0, 0x808, v0, v2
+; GFX10-NEXT:    v_and_or_b32 v1, 0x809, v1, v3
+; GFX10-NEXT:    v_readfirstlane_b32 s0, v0
+; GFX10-NEXT:    v_readfirstlane_b32 s1, v1
+; GFX10-NEXT:    ; return to shader part epilog
+  %x = and <2 x i32> %a, <i32 2056, i32 2057>
+  %result = or <2 x i32> %x, %b
+  ret <2 x i32> %result
+}
+
+define amdgpu_ps <2 x i32> @v_and_or_v2i32_inline_const_x2(<2 x i32> %a) {
+; VI-LABEL: v_and_or_v2i32_inline_const_x2:
+; VI:       ; %bb.0:
+; VI-NEXT:    v_and_b32_e32 v1, 0x809, v1
+; VI-NEXT:    v_and_b32_e32 v0, 0x808, v0
+; VI-NEXT:    v_or_b32_e32 v1, 16, v1
+; VI-NEXT:    v_or_b32_e32 v0, 4, v0
+; VI-NEXT:    v_readfirstlane_b32 s0, v0
+; VI-NEXT:    v_readfirstlane_b32 s1, v1
+; VI-NEXT:    ; return to shader part epilog
+;
+; GFX9-LABEL: v_and_or_v2i32_inline_const_x2:
+; GFX9:       ; %bb.0:
+; GFX9-NEXT:    v_and_b32_e32 v1, 0x809, v1
+; GFX9-NEXT:    v_and_b32_e32 v0, 0x808, v0
+; GFX9-NEXT:    v_or_b32_e32 v1, 16, v1
+; GFX9-NEXT:    v_or_b32_e32 v0, 4, v0
+; GFX9-NEXT:    v_readfirstlane_b32 s0, v0
+; GFX9-NEXT:    v_readfirstlane_b32 s1, v1
+; GFX9-NEXT:    ; return to shader part epilog
+;
+; GFX10-LABEL: v_and_or_v2i32_inline_const_x2:
+; GFX10:       ; %bb.0:
+; GFX10-NEXT:    v_and_or_b32 v0, 0x808, v0, 4
+; GFX10-NEXT:    v_and_or_b32 v1, 0x809, v1, 16
+; GFX10-NEXT:    v_readfirstlane_b32 s0, v0
+; GFX10-NEXT:    v_readfirstlane_b32 s1, v1
+; GFX10-NEXT:    ; return to shader part epilog
+  %x = and <2 x i32> %a, <i32 2056, i32 2057>
+  %result = or <2 x i32> %x, <i32 4, i32 16>
+  ret <2 x i32> %result
+}
+
+define amdgpu_ps <2 x i32> @v_and_or_v2i32_inline_const_x3(<2 x i32> %a) {
+; VI-LABEL: v_and_or_v2i32_inline_const_x3:
+; VI:       ; %bb.0:
+; VI-NEXT:    v_and_b32_e32 v1, 0x809, v1
+; VI-NEXT:    v_and_b32_e32 v0, 0x808, v0
+; VI-NEXT:    v_or_b32_e32 v1, 16, v1
+; VI-NEXT:    v_or_b32_e32 v0, 0x81, v0
+; VI-NEXT:    v_readfirstlane_b32 s0, v0
+; VI-NEXT:    v_readfirstlane_b32 s1, v1
+; VI-NEXT:    ; return to shader part epilog
+;
+; GFX9-LABEL: v_and_or_v2i32_inline_const_x3:
+; GFX9:       ; %bb.0:
+; GFX9-NEXT:    v_and_b32_e32 v1, 0x809, v1
+; GFX9-NEXT:    v_and_b32_e32 v0, 0x808, v0
+; GFX9-NEXT:    v_or_b32_e32 v1, 16, v1
+; GFX9-NEXT:    v_or_b32_e32 v0, 0x81, v0
+; GFX9-NEXT:    v_readfirstlane_b32 s0, v0
+; GFX9-NEXT:    v_readfirstlane_b32 s1, v1
+; GFX9-NEXT:    ; return to shader part epilog
+;
+; GFX10-LABEL: v_and_or_v2i32_inline_const_x3:
+; GFX10:       ; %bb.0:
+; GFX10-NEXT:    s_movk_i32 s0, 0x808
+; GFX10-NEXT:    v_and_or_b32 v1, 0x809, v1, 16
+; GFX10-NEXT:    v_and_or_b32 v0, v0, s0, 0x81
+; GFX10-NEXT:    v_readfirstlane_b32 s1, v1
+; GFX10-NEXT:    v_readfirstlane_b32 s0, v0
+; GFX10-NEXT:    ; return to shader part epilog
+  %x = and <2 x i32> %a, <i32 2056, i32 2057>
+  %result = or <2 x i32> %x, <i32 129, i32 16>
+  ret <2 x i32> %result
+}
+
+define amdgpu_ps <2 x i32> @v_and_or_v2i32_inline_const_x4(<2 x i32> %a) {
+; VI-LABEL: v_and_or_v2i32_inline_const_x4:
+; VI:       ; %bb.0:
+; VI-NEXT:    v_and_b32_e32 v1, 0x809, v1
+; VI-NEXT:    v_and_b32_e32 v0, 0x808, v0
+; VI-NEXT:    v_or_b32_e32 v1, 0x101, v1
+; VI-NEXT:    v_or_b32_e32 v0, 0x81, v0
+; VI-NEXT:    v_readfirstlane_b32 s0, v0
+; VI-NEXT:    v_readfirstlane_b32 s1, v1
+; VI-NEXT:    ; return to shader part epilog
+;
+; GFX9-LABEL: v_and_or_v2i32_inline_const_x4:
+; GFX9:       ; %bb.0:
+; GFX9-NEXT:    v_and_b32_e32 v1, 0x809, v1
+; GFX9-NEXT:    v_and_b32_e32 v0, 0x808, v0
+; GFX9-NEXT:    v_or_b32_e32 v1, 0x101, v1
+; GFX9-NEXT:    v_or_b32_e32 v0, 0x81, v0
+; GFX9-NEXT:    v_readfirstlane_b32 s0, v0
+; GFX9-NEXT:    v_readfirstlane_b32 s1, v1
+; GFX9-NEXT:    ; return to shader part epilog
+;
+; GFX10-LABEL: v_and_or_v2i32_inline_const_x4:
+; GFX10:       ; %bb.0:
+; GFX10-NEXT:    s_movk_i32 s0, 0x808
+; GFX10-NEXT:    s_movk_i32 s1, 0x809
+; GFX10-NEXT:    v_and_or_b32 v0, v0, s0, 0x81
+; GFX10-NEXT:    v_and_or_b32 v1, v1, s1, 0x101
+; GFX10-NEXT:    v_readfirstlane_b32 s0, v0
+; GFX10-NEXT:    v_readfirstlane_b32 s1, v1
+; GFX10-NEXT:    ; return to shader part epilog
+  %x = and <2 x i32> %a, <i32 2056, i32 2057>
+  %result = or <2 x i32> %x, <i32 129, i32 257>
+  ret <2 x i32> %result
+}
+
+define amdgpu_ps <2 x i32> @v_and_or_v2i32_multi_use(<2 x i32> %a, <2 x i32> %b, <2 x i32> %c) {
+; VI-LABEL: v_and_or_v2i32_multi_use:
+; VI:       ; %bb.0:
+; VI-NEXT:    v_and_b32_e32 v1, v1, v3
+; VI-NEXT:    v_and_b32_e32 v0, v0, v2
+; VI-NEXT:    v_or_b32_e32 v2, v1, v5
+; VI-NEXT:    v_or_b32_e32 v3, v0, v4
+; VI-NEXT:    v_add_u32_e32 v1, vcc, v1, v2
+; VI-NEXT:    v_add_u32_e32 v0, vcc, v0, v3
+; VI-NEXT:    v_readfirstlane_b32 s0, v0
+; VI-NEXT:    v_readfirstlane_b32 s1, v1
+; VI-NEXT:    ; return to shader part epilog
+;
+; GFX9-LABEL: v_and_or_v2i32_multi_use:
+; GFX9:       ; %bb.0:
+; GFX9-NEXT:    v_and_b32_e32 v1, v1, v3
+; GFX9-NEXT:    v_and_b32_e32 v0, v0, v2
+; GFX9-NEXT:    v_or_b32_e32 v2, v1, v5
+; GFX9-NEXT:    v_or_b32_e32 v3, v0, v4
+; GFX9-NEXT:    v_add_u32_e32 v1, v1, v2
+; GFX9-NEXT:    v_add_u32_e32 v0, v0, v3
+; GFX9-NEXT:    v_readfirstlane_b32 s0, v0
+; GFX9-NEXT:    v_readfirstlane_b32 s1, v1
+; GFX9-NEXT:    ; return to shader part epilog
+;
+; GFX10-LABEL: v_and_or_v2i32_multi_use:
+; GFX10:       ; %bb.0:
+; GFX10-NEXT:    v_and_b32_e32 v0, v0, v2
+; GFX10-NEXT:    v_and_b32_e32 v1, v1, v3
+; GFX10-NEXT:    v_or_b32_e32 v2, v0, v4
+; GFX10-NEXT:    v_or_b32_e32 v3, v1, v5
+; GFX10-NEXT:    v_add_nc_u32_e32 v0, v0, v2
+; GFX10-NEXT:    v_add_nc_u32_e32 v1, v1, v3
+; GFX10-NEXT:    v_readfirstlane_b32 s0, v0
+; GFX10-NEXT:    v_readfirstlane_b32 s1, v1
+; GFX10-NEXT:    ; return to shader part epilog
+  %x = and <2 x i32> %a, %b
+  %y = or <2 x i32> %x, %c
+  %result = add <2 x i32> %x, %y
   ret <2 x i32> %result
 }
 
@@ -221,177 +452,20 @@ define amdgpu_ps <2 x i32> @s_and_or_v2i32(<2 x i32> inreg %a, <2 x i32> inreg %
 ; VI:       ; %bb.0:
 ; VI-NEXT:    s_and_b64 s[0:1], s[2:3], s[4:5]
 ; VI-NEXT:    s_or_b64 s[0:1], s[0:1], s[6:7]
+; VI-NEXT:    ; return to shader part epilog
 ;
 ; GFX9-LABEL: s_and_or_v2i32:
 ; GFX9:       ; %bb.0:
 ; GFX9-NEXT:    s_and_b64 s[0:1], s[2:3], s[4:5]
 ; GFX9-NEXT:    s_or_b64 s[0:1], s[0:1], s[6:7]
+; GFX9-NEXT:    ; return to shader part epilog
 ;
 ; GFX10-LABEL: s_and_or_v2i32:
 ; GFX10:       ; %bb.0:
 ; GFX10-NEXT:    s_and_b64 s[0:1], s[2:3], s[4:5]
 ; GFX10-NEXT:    s_or_b64 s[0:1], s[0:1], s[6:7]
+; GFX10-NEXT:    ; return to shader part epilog
   %x = and <2 x i32> %a, %b
   %result = or <2 x i32> %x, %c
-  ret <2 x i32> %result
-}
-
-define <2 x i32> @and_or_v2i32_const(<2 x i32> %a, <2 x i32> %b) {
-; VI-LABEL: and_or_v2i32_const:
-; VI:        s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; VI-DAG:    v_and_b32_e32 v0, 4, v0
-; VI-DAG:    v_and_b32_e32 v1, 16, v1
-; VI-CHECK-NOT: {{.}}
-; VI-DAG:    v_or_b32_e32 v0, v0, v2
-; VI-DAG:    v_or_b32_e32 v1, v1, v3
-;
-; GFX9-LABEL: and_or_v2i32_const:
-; GFX9:        s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX9-DAG:    v_and_or_b32 v0, v0, 4, v2
-; GFX9-DAG:    v_and_or_b32 v1, v1, 16, v3
-;
-; GFX10-LABEL: and_or_v2i32_const:
-; GFX10:         s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX10-DAG:     v_and_or_b32 v0, v0, 4, v2
-; GFX10-DAG:     v_and_or_b32 v1, v1, 16, v3
-  %x = and <2 x i32> %a, <i32 4, i32 16>
-  %result = or <2 x i32> %x, %b
-  ret <2 x i32> %result
-}
-
-define <2 x i32> @and_or_v2i32_inline_const(<2 x i32> %a, <2 x i32> %b) {
-; VI-LABEL: and_or_v2i32_inline_const:
-; VI:        s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; VI-DAG:    v_and_b32_e32 v0, 0x808, v0
-; VI-DAG:    v_and_b32_e32 v1, 0x809, v1
-; VI-CHECK-NOT: {{.}}
-; VI-DAG:    v_or_b32_e32 v0, v0, v2
-; VI-DAG:    v_or_b32_e32 v1, v1, v3
-;
-; GFX9-LABEL: and_or_v2i32_inline_const:
-; GFX9:         s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX9-NEXT:    s_movk_i32 s4, 0x809
-; GFX9-NEXT:    v_and_or_b32 v1, v1, s4, v3
-; GFX9-NEXT:    s_movk_i32 s4, 0x808
-; GFX9-NEXT:    v_and_or_b32 v0, v0, s4, v2
-;
-; GFX10-LABEL: and_or_v2i32_inline_const:
-; GFX10:         s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX10-DAG:     v_and_or_b32 v0, 0x808, v0, v2
-; GFX10-DAG:     v_and_or_b32 v1, 0x809, v1, v3
-  %x = and <2 x i32> %a, <i32 2056, i32 2057>
-  %result = or <2 x i32> %x, %b
-  ret <2 x i32> %result
-}
-
-define <2 x i32> @and_or_v2i32_inline_const_x2(<2 x i32> %a) {
-; VI-LABEL: and_or_v2i32_inline_const_x2:
-; VI:        s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; VI-DAG:    v_and_b32_e32 v0, 0x808, v0
-; VI-DAG:    v_and_b32_e32 v1, 0x809, v1
-; VI-CHECK-NOT: {{.}}
-; VI-DAG:    v_or_b32_e32 v0, 4, v0
-; VI-DAG:    v_or_b32_e32 v1, 16, v1
-;
-; GFX9-LABEL: and_or_v2i32_inline_const_x2:
-; GFX9:        s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX9-DAG:    v_and_b32_e32 v0, 0x808, v0
-; GFX9-DAG:    v_and_b32_e32 v1, 0x809, v1
-; GFX9-CHECK-NOT: {{.}}
-; GFX9-DAG:    v_or_b32_e32 v0, 4, v0
-; GFX9-DAG:    v_or_b32_e32 v1, 16, v1
-;
-; GFX10-LABEL: and_or_v2i32_inline_const_x2:
-; GFX10:         s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX10-DAG:     v_and_or_b32 v0, 0x808, v0, 4
-; GFX10-DAG:     v_and_or_b32 v1, 0x809, v1, 16
-  %x = and <2 x i32> %a, <i32 2056, i32 2057>
-  %result = or <2 x i32> %x, <i32 4, i32 16>
-  ret <2 x i32> %result
-}
-
-define <2 x i32> @and_or_v2i32_inline_const_x3(<2 x i32> %a) {
-; VI-LABEL: and_or_v2i32_inline_const_x3:
-; VI:        s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; VI-DAG:    v_and_b32_e32 v0, 0x808, v0
-; VI-DAG:    v_and_b32_e32 v1, 0x809, v1
-; VI-CHECK-NOT: {{.}}
-; VI-DAG:    v_or_b32_e32 v0, 0x81, v0
-; VI-DAG:    v_or_b32_e32 v1, 16, v1
-;
-; GFX9-LABEL: and_or_v2i32_inline_const_x3:
-; GFX9:        s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX9-DAG:    v_and_b32_e32 v0, 0x808, v0
-; GFX9-DAG:    v_and_b32_e32 v1, 0x809, v1
-; GFX9-CHECK-NOT: {{.}}
-; GFX9-DAG:    v_or_b32_e32 v0, 0x81, v0
-; GFX9-DAG:    v_or_b32_e32 v1, 16, v1
-;
-; GFX10-LABEL: and_or_v2i32_inline_const_x3:
-; GFX10:         s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX10-NEXT:    s_movk_i32 [[SR:s[0-9]+]], 0x808
-; GFX10-DAG:     v_and_or_b32 v0, v0, [[SR]], 0x81
-; GFX10-DAG:     v_and_or_b32 v1, 0x809, v1, 16
-  %x = and <2 x i32> %a, <i32 2056, i32 2057>
-  %result = or <2 x i32> %x, <i32 129, i32 16>
-  ret <2 x i32> %result
-}
-
-define <2 x i32> @and_or_v2i32_inline_const_x4(<2 x i32> %a) {
-; VI-LABEL: and_or_v2i32_inline_const_x4:
-; VI:        s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; VI-DAG:    v_and_b32_e32 v0, 0x808, v0
-; VI-DAG:    v_and_b32_e32 v1, 0x809, v1
-; VI-CHECK-NOT: {{.}}
-; VI-DAG:    v_or_b32_e32 v0, 0x81, v0
-; VI-DAG:    v_or_b32_e32 v1, 0x101, v1
-;
-; GFX9-LABEL: and_or_v2i32_inline_const_x4:
-; GFX9:        s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX9-DAG:    v_and_b32_e32 v0, 0x808, v0
-; GFX9-DAG:    v_and_b32_e32 v1, 0x809, v1
-; GFX9-CHECK-NOT: {{.}}
-; GFX9-DAG:    v_or_b32_e32 v0, 0x81, v0
-; GFX9-DAG:    v_or_b32_e32 v1, 0x101, v1
-;
-; GFX10-LABEL: and_or_v2i32_inline_const_x4:
-; GFX10:         s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX10-DAG:     s_movk_i32 [[SR0:s[0-9]+]], 0x808
-; GFX10-DAG:     s_movk_i32 [[SR1:s[0-9]+]], 0x809
-; GFX10-CHECK-NOT: {{.}}
-; GFX10-DAG:     v_and_or_b32 v0, v0, [[SR0]], 0x81
-; GFX10-DAG:     v_and_or_b32 v1, v1, [[SR1]], 0x101
-  %x = and <2 x i32> %a, <i32 2056, i32 2057>
-  %result = or <2 x i32> %x, <i32 129, i32 257>
-  ret <2 x i32> %result
-}
-
-define <2 x i32> @and_or_v2i32_multi_use(<2 x i32> %a, <2 x i32> %b, <2 x i32> %c) {
-; VI-LABEL: and_or_v2i32_multi_use:
-; VI:        s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; VI-DAG:    v_and_b32_e32 v0, v0, v2
-; VI-DAG:    v_and_b32_e32 v1, v1, v3
-; VI-CHECK-NOT: {{.}}
-; VI-DAG:    v_or_b32_e32 v3, v0, v4
-; VI-DAG:    v_or_b32_e32 v2, v1, v5
-;
-; GFX9-LABEL: and_or_v2i32_multi_use:
-; GFX9:        s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX9-DAG:    v_and_b32_e32 v0, v0, v2
-; GFX9-DAG:    v_and_b32_e32 v1, v1, v3
-; GFX9-CHECK-NOT: {{.}}
-; GFX9-DAG:    v_or_b32_e32 v{{[0-9]+}}, v0, v4
-; GFX9-DAG:    v_or_b32_e32 v{{[0-9]+}}, v1, v5
-;
-; GFX10-LABEL: and_or_v2i32_multi_use:
-; GFX10:        s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX10-DAG:    v_and_b32_e32 v0, v0, v2
-; GFX10-DAG:    v_and_b32_e32 v1, v1, v3
-; GFX10-CHECK-NOT: {{.}}
-; GFX10-DAG:    v_or_b32_e32 v{{[0-9]+}}, v0, v4
-; GFX10-DAG:    v_or_b32_e32 v{{[0-9]+}}, v1, v5
-  %x = and <2 x i32> %a, %b
-  %y = or <2 x i32> %x, %c
-  %result = add <2 x i32> %x, %y
   ret <2 x i32> %result
 }

--- a/llvm/test/CodeGen/AMDGPU/and_or.ll
+++ b/llvm/test/CodeGen/AMDGPU/and_or.ll
@@ -216,18 +216,18 @@ define <2 x i32> @and_or_v2i32_ab(<2 x i32> %a, <2 x i32> %b, <2 x i32> inreg %c
   ret <2 x i32> %result
 }
 
-define <2 x i32> @and_or_v2i32_abc(<2 x i32> inreg %a, <2 x i32> inreg %b, <2 x i32> inreg %c) {
-; VI-LABEL: and_or_v2i32_abc:
+define <2 x i32> @and_or_v2i32_scalar(<2 x i32> inreg %a, <2 x i32> inreg %b, <2 x i32> inreg %c) {
+; VI-LABEL: and_or_v2i32_scalar:
 ; VI:         s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; VI-NEXT:    s_and_b64 s[4:5], s[16:17], s[18:19]
 ; VI-NEXT:    s_or_b64 s[4:5], s[4:5], s[20:21]
 ;
-; GFX9-LABEL: and_or_v2i32_abc:
+; GFX9-LABEL: and_or_v2i32_scalar:
 ; GFX9:         s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX9-NEXT:    s_and_b64 s[4:5], s[16:17], s[18:19]
 ; GFX9-NEXT:    s_or_b64 s[4:5], s[4:5], s[20:21]
 ;
-; GFX10-LABEL: and_or_v2i32_abc:
+; GFX10-LABEL: and_or_v2i32_scalar:
 ; GFX10:         s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX10-NEXT:    s_and_b64 [[SV0:s\[[0-9]+:[0-9]+\]]], [[SV1:s\[[0-9]+:[0-9]+\]]], [[SV2:s\[[0-9]+:[0-9]+\]]]
 ; GFX10-NEXT:    s_or_b64 [[SV0]], [[SV0]], [[SV3:s\[[0-9]+:[0-9]+\]]]

--- a/llvm/test/CodeGen/AMDGPU/and_or.ll
+++ b/llvm/test/CodeGen/AMDGPU/and_or.ll
@@ -145,7 +145,7 @@ define amdgpu_ps float @and_or_vgpr_inline_const_x2(i32 %a) {
 
 define <2 x i32> @and_or_v2i32(<2 x i32> %a, <2 x i32> %b, <2 x i32> %c) {
 ; VI-LABEL: and_or_v2i32:
-; VI:         s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; VI:        s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; VI-DAG:    v_and_b32_e32 v0, v0, v2
 ; VI-DAG:    v_and_b32_e32 v1, v1, v3
 ; VI-CHECK-NOT: {{.}}
@@ -163,5 +163,215 @@ define <2 x i32> @and_or_v2i32(<2 x i32> %a, <2 x i32> %b, <2 x i32> %c) {
 ; GFX10-DAG:     v_and_or_b32 v1, v1, v3, v5
   %x = and <2 x i32> %a, %b
   %result = or <2 x i32> %x, %c
+  ret <2 x i32> %result
+}
+
+; ThreeOp instruction variant not used due to Constant Bus Limitations
+define <2 x i32> @and_or_v2i32_b(<2 x i32> inreg %a, <2 x i32> %b, <2 x i32> inreg %c) {
+; VI-LABEL: and_or_v2i32_b:
+; VI:        s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; VI-DAG:    v_and_b32_e32 v0, s16, v0
+; VI-DAG:    v_and_b32_e32 v1, s17, v1
+; VI-CHECK-NOT: {{.}}
+; VI-DAG:    v_or_b32_e32 v0, s18, v0
+; VI-DAG:    v_or_b32_e32 v1, s19, v1
+;
+; GFX9-LABEL: and_or_v2i32_b:
+; GFX9:        s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-DAG:    v_and_b32_e32 v0, s16, v0
+; GFX9-DAG:    v_and_b32_e32 v1, s17, v1
+; GFX9-CHECK-NOT: {{.}}
+; GFX9-DAG:    v_or_b32_e32 v0, s18, v0
+; GFX9-DAG:    v_or_b32_e32 v1, s19, v1
+;
+; GFX10-LABEL: and_or_v2i32_b:
+; GFX10:         s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX10-DAG:     v_and_or_b32 v0, s{{[0-9]+}}, v0, s{{[0-9]+}}
+; GFX10-DAG:     v_and_or_b32 v1, s{{[0-9]+}}, v1, s{{[0-9]+}}
+  %x = and <2 x i32> %a, %b
+  %result = or <2 x i32> %x, %c
+  ret <2 x i32> %result
+}
+
+define <2 x i32> @and_or_v2i32_ab(<2 x i32> %a, <2 x i32> %b, <2 x i32> inreg %c) {
+; VI-LABEL: and_or_v2i32_ab:
+; VI:        s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; VI-DAG:    v_and_b32_e32 v0, v0, v2
+; VI-DAG:    v_and_b32_e32 v1, v1, v3
+; VI-CHECK-NOT: {{.}}
+; VI-DAG:    v_or_b32_e32 v0, s16, v0
+; VI-DAG:    v_or_b32_e32 v1, s17, v1
+;
+; GFX9-LABEL: and_or_v2i32_ab:
+; GFX9:         s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-DAG:     v_and_or_b32 v0, v0, v2, s16
+; GFX9-DAG:     v_and_or_b32 v1, v1, v3, s17
+;
+; GFX10-LABEL: and_or_v2i32_ab:
+; GFX10:         s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX10-DAG:     v_and_or_b32 v0, v0, v2, s{{[0-9]+}}
+; GFX10-DAG:     v_and_or_b32 v1, v1, v3, s{{[0-9]+}}
+  %x = and <2 x i32> %a, %b
+  %result = or <2 x i32> %x, %c
+  ret <2 x i32> %result
+}
+
+define <2 x i32> @and_or_v2i32_const(<2 x i32> %a, <2 x i32> %b) {
+; VI-LABEL: and_or_v2i32_const:
+; VI:        s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; VI-DAG:    v_and_b32_e32 v0, 4, v0
+; VI-DAG:    v_and_b32_e32 v1, 16, v1
+; VI-CHECK-NOT: {{.}}
+; VI-DAG:    v_or_b32_e32 v0, v0, v2
+; VI-DAG:    v_or_b32_e32 v1, v1, v3
+;
+; GFX9-LABEL: and_or_v2i32_const:
+; GFX9:        s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-DAG:    v_and_or_b32 v0, v0, 4, v2
+; GFX9-DAG:    v_and_or_b32 v1, v1, 16, v3
+;
+; GFX10-LABEL: and_or_v2i32_const:
+; GFX10:         s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX10-DAG:     v_and_or_b32 v0, v0, 4, v2
+; GFX10-DAG:     v_and_or_b32 v1, v1, 16, v3
+  %x = and <2 x i32> %a, <i32 4, i32 16>
+  %result = or <2 x i32> %x, %b
+  ret <2 x i32> %result
+}
+
+define <2 x i32> @and_or_v2i32_inline_const(<2 x i32> %a, <2 x i32> %b) {
+; VI-LABEL: and_or_v2i32_inline_const:
+; VI:        s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; VI-DAG:    v_and_b32_e32 v0, 0x808, v0
+; VI-DAG:    v_and_b32_e32 v1, 0x809, v1
+; VI-CHECK-NOT: {{.}}
+; VI-DAG:    v_or_b32_e32 v0, v0, v2
+; VI-DAG:    v_or_b32_e32 v1, v1, v3
+;
+; GFX9-LABEL: and_or_v2i32_inline_const:
+; GFX9:         s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    s_movk_i32 s4, 0x809
+; GFX9-NEXT:    v_and_or_b32 v1, v1, s4, v3
+; GFX9-NEXT:    s_movk_i32 s4, 0x808
+; GFX9-NEXT:    v_and_or_b32 v0, v0, s4, v2
+;
+; GFX10-LABEL: and_or_v2i32_inline_const:
+; GFX10:         s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX10-DAG:     v_and_or_b32 v0, 0x808, v0, v2
+; GFX10-DAG:     v_and_or_b32 v1, 0x809, v1, v3
+  %x = and <2 x i32> %a, <i32 2056, i32 2057>
+  %result = or <2 x i32> %x, %b
+  ret <2 x i32> %result
+}
+
+define <2 x i32> @and_or_v2i32_inline_const_x2(<2 x i32> %a) {
+; VI-LABEL: and_or_v2i32_inline_const_x2:
+; VI:        s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; VI-DAG:    v_and_b32_e32 v0, 0x808, v0
+; VI-DAG:    v_and_b32_e32 v1, 0x809, v1
+; VI-CHECK-NOT: {{.}}
+; VI-DAG:    v_or_b32_e32 v0, 4, v0
+; VI-DAG:    v_or_b32_e32 v1, 16, v1
+;
+; GFX9-LABEL: and_or_v2i32_inline_const_x2:
+; GFX9:        s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-DAG:    v_and_b32_e32 v0, 0x808, v0
+; GFX9-DAG:    v_and_b32_e32 v1, 0x809, v1
+; GFX9-CHECK-NOT: {{.}}
+; GFX9-DAG:    v_or_b32_e32 v0, 4, v0
+; GFX9-DAG:    v_or_b32_e32 v1, 16, v1
+;
+; GFX10-LABEL: and_or_v2i32_inline_const_x2:
+; GFX10:         s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX10-DAG:     v_and_or_b32 v0, 0x808, v0, 4
+; GFX10-DAG:     v_and_or_b32 v1, 0x809, v1, 16
+  %x = and <2 x i32> %a, <i32 2056, i32 2057>
+  %result = or <2 x i32> %x, <i32 4, i32 16>
+  ret <2 x i32> %result
+}
+
+define <2 x i32> @and_or_v2i32_inline_const_x3(<2 x i32> %a) {
+; VI-LABEL: and_or_v2i32_inline_const_x3:
+; VI:        s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; VI-DAG:    v_and_b32_e32 v0, 0x808, v0
+; VI-DAG:    v_and_b32_e32 v1, 0x809, v1
+; VI-CHECK-NOT: {{.}}
+; VI-DAG:    v_or_b32_e32 v0, 0x81, v0
+; VI-DAG:    v_or_b32_e32 v1, 16, v1
+;
+; GFX9-LABEL: and_or_v2i32_inline_const_x3:
+; GFX9:        s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-DAG:    v_and_b32_e32 v0, 0x808, v0
+; GFX9-DAG:    v_and_b32_e32 v1, 0x809, v1
+; GFX9-CHECK-NOT: {{.}}
+; GFX9-DAG:    v_or_b32_e32 v0, 0x81, v0
+; GFX9-DAG:    v_or_b32_e32 v1, 16, v1
+;
+; GFX10-LABEL: and_or_v2i32_inline_const_x3:
+; GFX10:         s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX10-NEXT:    s_movk_i32 [[SR:s[0-9]+]], 0x808
+; GFX10-DAG:     v_and_or_b32 v0, v0, [[SR]], 0x81
+; GFX10-DAG:     v_and_or_b32 v1, 0x809, v1, 16
+  %x = and <2 x i32> %a, <i32 2056, i32 2057>
+  %result = or <2 x i32> %x, <i32 129, i32 16>
+  ret <2 x i32> %result
+}
+
+define <2 x i32> @and_or_v2i32_inline_const_x4(<2 x i32> %a) {
+; VI-LABEL: and_or_v2i32_inline_const_x4:
+; VI:        s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; VI-DAG:    v_and_b32_e32 v0, 0x808, v0
+; VI-DAG:    v_and_b32_e32 v1, 0x809, v1
+; VI-CHECK-NOT: {{.}}
+; VI-DAG:    v_or_b32_e32 v0, 0x81, v0
+; VI-DAG:    v_or_b32_e32 v1, 0x101, v1
+;
+; GFX9-LABEL: and_or_v2i32_inline_const_x4:
+; GFX9:        s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-DAG:    v_and_b32_e32 v0, 0x808, v0
+; GFX9-DAG:    v_and_b32_e32 v1, 0x809, v1
+; GFX9-CHECK-NOT: {{.}}
+; GFX9-DAG:    v_or_b32_e32 v0, 0x81, v0
+; GFX9-DAG:    v_or_b32_e32 v1, 0x101, v1
+;
+; GFX10-LABEL: and_or_v2i32_inline_const_x4:
+; GFX10:         s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX10-DAG:     s_movk_i32 [[SR0:s[0-9]+]], 0x808
+; GFX10-DAG:     s_movk_i32 [[SR1:s[0-9]+]], 0x809
+; GFX10-CHECK-NOT: {{.}}
+; GFX10-DAG:     v_and_or_b32 v0, v0, [[SR0]], 0x81
+; GFX10-DAG:     v_and_or_b32 v1, v1, [[SR1]], 0x101
+  %x = and <2 x i32> %a, <i32 2056, i32 2057>
+  %result = or <2 x i32> %x, <i32 129, i32 257>
+  ret <2 x i32> %result
+}
+
+define <2 x i32> @and_or_v2i32_multi_use(<2 x i32> %a, <2 x i32> %b, <2 x i32> %c) {
+; VI-LABEL: and_or_v2i32_multi_use:
+; VI:        s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; VI-DAG:    v_and_b32_e32 v0, v0, v2
+; VI-DAG:    v_and_b32_e32 v1, v1, v3
+; VI-CHECK-NOT: {{.}}
+; VI-DAG:    v_or_b32_e32 v3, v0, v4
+; VI-DAG:    v_or_b32_e32 v2, v1, v5
+;
+; GFX9-LABEL: and_or_v2i32_multi_use:
+; GFX9:        s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-DAG:    v_and_b32_e32 v0, v0, v2
+; GFX9-DAG:    v_and_b32_e32 v1, v1, v3
+; GFX9-CHECK-NOT: {{.}}
+; GFX9-DAG:    v_or_b32_e32 v{{[0-9]+}}, v0, v4
+; GFX9-DAG:    v_or_b32_e32 v{{[0-9]+}}, v1, v5
+;
+; GFX10-LABEL: and_or_v2i32_multi_use:
+; GFX10:        s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX10-DAG:    v_and_b32_e32 v0, v0, v2
+; GFX10-DAG:    v_and_b32_e32 v1, v1, v3
+; GFX10-CHECK-NOT: {{.}}
+; GFX10-DAG:    v_or_b32_e32 v{{[0-9]+}}, v0, v4
+; GFX10-DAG:    v_or_b32_e32 v{{[0-9]+}}, v1, v5
+  %x = and <2 x i32> %a, %b
+  %y = or <2 x i32> %x, %c
+  %result = add <2 x i32> %x, %y
   ret <2 x i32> %result
 }

--- a/llvm/test/CodeGen/AMDGPU/and_or.ll
+++ b/llvm/test/CodeGen/AMDGPU/and_or.ll
@@ -142,3 +142,26 @@ define amdgpu_ps float @and_or_vgpr_inline_const_x2(i32 %a) {
   %bc = bitcast i32 %result to float
   ret float %bc
 }
+
+define <2 x i32> @and_or_v2i32(<2 x i32> %a, <2 x i32> %b, <2 x i32> %c) {
+; VI-LABEL: and_or_v2i32:
+; VI:         s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; VI-DAG:    v_and_b32_e32 v0, v0, v2
+; VI-DAG:    v_and_b32_e32 v1, v1, v3
+; VI-CHECK-NOT: {{.}}
+; VI-DAG:    v_or_b32_e32 v0, v0, v4
+; VI-DAG:    v_or_b32_e32 v1, v1, v5
+;
+; GFX9-LABEL: and_or_v2i32:
+; GFX9:         s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-DAG:     v_and_or_b32 v0, v0, v2, v4
+; GFX9-DAG:     v_and_or_b32 v1, v1, v3, v5
+;
+; GFX10-LABEL: and_or_v2i32:
+; GFX10:         s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX10-DAG:     v_and_or_b32 v0, v0, v2, v4
+; GFX10-DAG:     v_and_or_b32 v1, v1, v3, v5
+  %x = and <2 x i32> %a, %b
+  %result = or <2 x i32> %x, %c
+  ret <2 x i32> %result
+}

--- a/llvm/test/CodeGen/AMDGPU/and_or.ll
+++ b/llvm/test/CodeGen/AMDGPU/and_or.ll
@@ -216,21 +216,21 @@ define <2 x i32> @and_or_v2i32_ab(<2 x i32> %a, <2 x i32> %b, <2 x i32> inreg %c
   ret <2 x i32> %result
 }
 
-define <2 x i32> @and_or_v2i32_scalar(<2 x i32> inreg %a, <2 x i32> inreg %b, <2 x i32> inreg %c) {
-; VI-LABEL: and_or_v2i32_scalar:
-; VI:         s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; VI-NEXT:    s_and_b64 s[4:5], s[16:17], s[18:19]
-; VI-NEXT:    s_or_b64 s[4:5], s[4:5], s[20:21]
+define amdgpu_ps <2 x i32> @s_and_or_v2i32(<2 x i32> inreg %a, <2 x i32> inreg %b, <2 x i32> inreg %c) {
+; VI-LABEL: s_and_or_v2i32:
+; VI:       ; %bb.0:
+; VI-NEXT:    s_and_b64 s[0:1], s[2:3], s[4:5]
+; VI-NEXT:    s_or_b64 s[0:1], s[0:1], s[6:7]
 ;
-; GFX9-LABEL: and_or_v2i32_scalar:
-; GFX9:         s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX9-NEXT:    s_and_b64 s[4:5], s[16:17], s[18:19]
-; GFX9-NEXT:    s_or_b64 s[4:5], s[4:5], s[20:21]
+; GFX9-LABEL: s_and_or_v2i32:
+; GFX9:       ; %bb.0:
+; GFX9-NEXT:    s_and_b64 s[0:1], s[2:3], s[4:5]
+; GFX9-NEXT:    s_or_b64 s[0:1], s[0:1], s[6:7]
 ;
-; GFX10-LABEL: and_or_v2i32_scalar:
-; GFX10:         s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX10-NEXT:    s_and_b64 [[SV0:s\[[0-9]+:[0-9]+\]]], [[SV1:s\[[0-9]+:[0-9]+\]]], [[SV2:s\[[0-9]+:[0-9]+\]]]
-; GFX10-NEXT:    s_or_b64 [[SV0]], [[SV0]], [[SV3:s\[[0-9]+:[0-9]+\]]]
+; GFX10-LABEL: s_and_or_v2i32:
+; GFX10:       ; %bb.0:
+; GFX10-NEXT:    s_and_b64 s[0:1], s[2:3], s[4:5]
+; GFX10-NEXT:    s_or_b64 s[0:1], s[0:1], s[6:7]
   %x = and <2 x i32> %a, %b
   %result = or <2 x i32> %x, %c
   ret <2 x i32> %result

--- a/llvm/test/CodeGen/AMDGPU/or3.ll
+++ b/llvm/test/CodeGen/AMDGPU/or3.ll
@@ -126,6 +126,7 @@ define <2 x i32> @or3_v2i32(<2 x i32> %a, <2 x i32> %b, <2 x i32> %c) {
 ; VI:         s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; VI-DAG:    v_or_b32_e32 v0, v0, v2
 ; VI-DAG:    v_or_b32_e32 v1, v1, v3
+; VI-CHECK-NOT: {{.}}
 ; VI-DAG:    v_or_b32_e32 v0, v0, v4
 ; VI-DAG:    v_or_b32_e32 v1, v1, v5
 ;
@@ -188,6 +189,26 @@ define <2 x i32> @or3_v2i32_ab(<2 x i32> %a, <2 x i32> %b, <2 x i32> inreg %c) {
 ; GFX10:         s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX10-DAG:     v_or3_b32 v0, v0, v2, s{{[0-9]+}}
 ; GFX10-DAG:     v_or3_b32 v1, v1, v3, s{{[0-9]+}}
+  %x = or <2 x i32> %a, %b
+  %result = or <2 x i32> %x, %c
+  ret <2 x i32> %result
+}
+
+define <2 x i32> @or3_v2i32_abc(<2 x i32> inreg %a, <2 x i32> inreg %b, <2 x i32> inreg %c) {
+; VI-LABEL: or3_v2i32_abc:
+; VI:         s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; VI-NEXT:    s_or_b64 s[4:5], s[16:17], s[18:19]
+; VI-NEXT:    s_or_b64 s[4:5], s[4:5], s[20:21]
+;
+; GFX9-LABEL: or3_v2i32_abc:
+; GFX9:         s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    s_or_b64 s[4:5], s[16:17], s[18:19]
+; GFX9-NEXT:    s_or_b64 s[4:5], s[4:5], s[20:21]
+;
+; GFX10-LABEL: or3_v2i32_abc:
+; GFX10:         s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX10-NEXT:    s_or_b64 [[SV0:s\[[0-9]+:[0-9]+\]]], [[SV1:s\[[0-9]+:[0-9]+\]]], [[SV2:s\[[0-9]+:[0-9]+\]]]
+; GFX10-NEXT:    s_or_b64 [[SV0]], [[SV0]], [[SV3:s\[[0-9]+:[0-9]+\]]]
   %x = or <2 x i32> %a, %b
   %result = or <2 x i32> %x, %c
   ret <2 x i32> %result

--- a/llvm/test/CodeGen/AMDGPU/or3.ll
+++ b/llvm/test/CodeGen/AMDGPU/or3.ll
@@ -121,76 +121,205 @@ define amdgpu_ps float @or3_vgpr_const(i32 %a, i32 %b) {
   ret float %bc
 }
 
-define <2 x i32> @or3_v2i32(<2 x i32> %a, <2 x i32> %b, <2 x i32> %c) {
-; VI-LABEL: or3_v2i32:
-; VI:         s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; VI-DAG:    v_or_b32_e32 v0, v0, v2
-; VI-DAG:    v_or_b32_e32 v1, v1, v3
-; VI-CHECK-NOT: {{.}}
-; VI-DAG:    v_or_b32_e32 v0, v0, v4
-; VI-DAG:    v_or_b32_e32 v1, v1, v5
+define amdgpu_ps <2 x i32> @v_or3_v2i32(<2 x i32> %a, <2 x i32> %b, <2 x i32> %c) {
+; VI-LABEL: v_or3_v2i32:
+; VI:       ; %bb.0:
+; VI-NEXT:    v_or_b32_e32 v1, v1, v3
+; VI-NEXT:    v_or_b32_e32 v0, v0, v2
+; VI-NEXT:    v_or_b32_e32 v1, v1, v5
+; VI-NEXT:    v_or_b32_e32 v0, v0, v4
+; VI-NEXT:    v_readfirstlane_b32 s0, v0
+; VI-NEXT:    v_readfirstlane_b32 s1, v1
+; VI-NEXT:    ; return to shader part epilog
 ;
-; GFX9-LABEL: or3_v2i32:
-; GFX9:         s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX9-DAG:     v_or3_b32 v0, v0, v2, v4
-; GFX9-DAG:     v_or3_b32 v1, v1, v3, v5
+; GFX9-LABEL: v_or3_v2i32:
+; GFX9:       ; %bb.0:
+; GFX9-NEXT:    v_or3_b32 v1, v1, v3, v5
+; GFX9-NEXT:    v_or3_b32 v0, v0, v2, v4
+; GFX9-NEXT:    v_readfirstlane_b32 s0, v0
+; GFX9-NEXT:    v_readfirstlane_b32 s1, v1
+; GFX9-NEXT:    ; return to shader part epilog
 ;
-; GFX10-LABEL: or3_v2i32:
-; GFX10:         s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX10-DAG:     v_or3_b32 v0, v0, v2, v4
-; GFX10-DAG:     v_or3_b32 v1, v1, v3, v5
+; GFX10-LABEL: v_or3_v2i32:
+; GFX10:       ; %bb.0:
+; GFX10-NEXT:    v_or3_b32 v0, v0, v2, v4
+; GFX10-NEXT:    v_or3_b32 v1, v1, v3, v5
+; GFX10-NEXT:    v_readfirstlane_b32 s0, v0
+; GFX10-NEXT:    v_readfirstlane_b32 s1, v1
+; GFX10-NEXT:    ; return to shader part epilog
   %x = or <2 x i32> %a, %b
   %result = or <2 x i32> %x, %c
   ret <2 x i32> %result
 }
 
 ; ThreeOp instruction variant not used due to Constant Bus Limitations
-define <2 x i32> @or3_v2i32_b(<2 x i32> inreg %a, <2 x i32> %b, <2 x i32> inreg %c) {
-; VI-LABEL: or3_v2i32_b:
-; VI:        s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; VI-DAG:    v_or_b32_e32 v0, s16, v0
-; VI-DAG:    v_or_b32_e32 v1, s17, v1
-; VI-CHECK-NOT: {{.}}
-; VI-DAG:    v_or_b32_e32 v0, s18, v0
-; VI-DAG:    v_or_b32_e32 v1, s19, v1
+define amdgpu_ps <2 x i32> @v_or3_v2i32_b(<2 x i32> inreg %a, <2 x i32> %b, <2 x i32> inreg %c) {
+; VI-LABEL: v_or3_v2i32_b:
+; VI:       ; %bb.0:
+; VI-NEXT:    v_or_b32_e32 v1, s3, v1
+; VI-NEXT:    v_or_b32_e32 v0, s2, v0
+; VI-NEXT:    v_or_b32_e32 v1, s5, v1
+; VI-NEXT:    v_or_b32_e32 v0, s4, v0
+; VI-NEXT:    v_readfirstlane_b32 s0, v0
+; VI-NEXT:    v_readfirstlane_b32 s1, v1
+; VI-NEXT:    ; return to shader part epilog
 ;
-; GFX9-LABEL: or3_v2i32_b:
-; GFX9:        s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX9-DAG:    v_or_b32_e32 v0, s16, v0
-; GFX9-DAG:    v_or_b32_e32 v1, s17, v1
-; GFX9-CHECK-NOT: {{.}}
-; GFX9-DAG:    v_or_b32_e32 v0, s18, v0
-; GFX9-DAG:    v_or_b32_e32 v1, s19, v1
+; GFX9-LABEL: v_or3_v2i32_b:
+; GFX9:       ; %bb.0:
+; GFX9-NEXT:    v_or_b32_e32 v1, s3, v1
+; GFX9-NEXT:    v_or_b32_e32 v0, s2, v0
+; GFX9-NEXT:    v_or_b32_e32 v1, s5, v1
+; GFX9-NEXT:    v_or_b32_e32 v0, s4, v0
+; GFX9-NEXT:    v_readfirstlane_b32 s0, v0
+; GFX9-NEXT:    v_readfirstlane_b32 s1, v1
+; GFX9-NEXT:    ; return to shader part epilog
 ;
-; GFX10-LABEL: or3_v2i32_b:
-; GFX10:         s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX10-DAG:     v_or3_b32 v0, s{{[0-9]+}}, v0, s{{[0-9]+}}
-; GFX10-DAG:     v_or3_b32 v1, s{{[0-9]+}}, v1, s{{[0-9]+}}
+; GFX10-LABEL: v_or3_v2i32_b:
+; GFX10:       ; %bb.0:
+; GFX10-NEXT:    v_or3_b32 v0, s2, v0, s4
+; GFX10-NEXT:    v_or3_b32 v1, s3, v1, s5
+; GFX10-NEXT:    v_readfirstlane_b32 s0, v0
+; GFX10-NEXT:    v_readfirstlane_b32 s1, v1
+; GFX10-NEXT:    ; return to shader part epilog
   %x = or <2 x i32> %a, %b
   %result = or <2 x i32> %x, %c
   ret <2 x i32> %result
 }
 
-define <2 x i32> @or3_v2i32_ab(<2 x i32> %a, <2 x i32> %b, <2 x i32> inreg %c) {
-; VI-LABEL: or3_v2i32_ab:
-; VI:        s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; VI-DAG:    v_or_b32_e32 v0, v0, v2
-; VI-DAG:    v_or_b32_e32 v1, v1, v3
-; VI-CHECK-NOT: {{.}}
-; VI-DAG:    v_or_b32_e32 v0, s16, v0
-; VI-DAG:    v_or_b32_e32 v1, s17, v1
+define amdgpu_ps <2 x i32> @v_or3_v2i32_ab(<2 x i32> %a, <2 x i32> %b, <2 x i32> inreg %c) {
+; VI-LABEL: v_or3_v2i32_ab:
+; VI:       ; %bb.0:
+; VI-NEXT:    v_or_b32_e32 v1, v1, v3
+; VI-NEXT:    v_or_b32_e32 v0, v0, v2
+; VI-NEXT:    v_or_b32_e32 v1, s3, v1
+; VI-NEXT:    v_or_b32_e32 v0, s2, v0
+; VI-NEXT:    v_readfirstlane_b32 s0, v0
+; VI-NEXT:    v_readfirstlane_b32 s1, v1
+; VI-NEXT:    ; return to shader part epilog
 ;
-; GFX9-LABEL: or3_v2i32_ab:
-; GFX9:         s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX9-DAG:     v_or3_b32 v0, v0, v2, s16
-; GFX9-DAG:     v_or3_b32 v1, v1, v3, s17
+; GFX9-LABEL: v_or3_v2i32_ab:
+; GFX9:       ; %bb.0:
+; GFX9-NEXT:    v_or3_b32 v1, v1, v3, s3
+; GFX9-NEXT:    v_or3_b32 v0, v0, v2, s2
+; GFX9-NEXT:    v_readfirstlane_b32 s0, v0
+; GFX9-NEXT:    v_readfirstlane_b32 s1, v1
+; GFX9-NEXT:    ; return to shader part epilog
 ;
-; GFX10-LABEL: or3_v2i32_ab:
-; GFX10:         s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX10-DAG:     v_or3_b32 v0, v0, v2, s{{[0-9]+}}
-; GFX10-DAG:     v_or3_b32 v1, v1, v3, s{{[0-9]+}}
+; GFX10-LABEL: v_or3_v2i32_ab:
+; GFX10:       ; %bb.0:
+; GFX10-NEXT:    v_or3_b32 v0, v0, v2, s2
+; GFX10-NEXT:    v_or3_b32 v1, v1, v3, s3
+; GFX10-NEXT:    v_readfirstlane_b32 s0, v0
+; GFX10-NEXT:    v_readfirstlane_b32 s1, v1
+; GFX10-NEXT:    ; return to shader part epilog
   %x = or <2 x i32> %a, %b
   %result = or <2 x i32> %x, %c
+  ret <2 x i32> %result
+}
+
+define amdgpu_ps <2 x i32> @v_or3_v2i32_const(<2 x i32> %a, <2 x i32> %b) {
+; VI-LABEL: v_or3_v2i32_const:
+; VI:       ; %bb.0:
+; VI-NEXT:    v_or_b32_e32 v1, v1, v3
+; VI-NEXT:    v_or_b32_e32 v0, v0, v2
+; VI-NEXT:    v_or_b32_e32 v1, 16, v1
+; VI-NEXT:    v_or_b32_e32 v0, 4, v0
+; VI-NEXT:    v_readfirstlane_b32 s0, v0
+; VI-NEXT:    v_readfirstlane_b32 s1, v1
+; VI-NEXT:    ; return to shader part epilog
+;
+; GFX9-LABEL: v_or3_v2i32_const:
+; GFX9:       ; %bb.0:
+; GFX9-NEXT:    v_or3_b32 v1, v1, v3, 16
+; GFX9-NEXT:    v_or3_b32 v0, v0, v2, 4
+; GFX9-NEXT:    v_readfirstlane_b32 s0, v0
+; GFX9-NEXT:    v_readfirstlane_b32 s1, v1
+; GFX9-NEXT:    ; return to shader part epilog
+;
+; GFX10-LABEL: v_or3_v2i32_const:
+; GFX10:       ; %bb.0:
+; GFX10-NEXT:    v_or3_b32 v0, v0, v2, 4
+; GFX10-NEXT:    v_or3_b32 v1, v1, v3, 16
+; GFX10-NEXT:    v_readfirstlane_b32 s0, v0
+; GFX10-NEXT:    v_readfirstlane_b32 s1, v1
+; GFX10-NEXT:    ; return to shader part epilog
+  %x = or <2 x i32> %a, <i32 4, i32 16>
+  %result = or <2 x i32> %x, %b
+  ret <2 x i32> %result
+}
+
+define amdgpu_ps <2 x i32> @v_or3_v2i32_inline_const(<2 x i32> %a, <2 x i32> %b) {
+; VI-LABEL: v_or3_v2i32_inline_const:
+; VI:       ; %bb.0:
+; VI-NEXT:    v_or_b32_e32 v1, v1, v3
+; VI-NEXT:    v_or_b32_e32 v0, v0, v2
+; VI-NEXT:    v_or_b32_e32 v1, 0x809, v1
+; VI-NEXT:    v_or_b32_e32 v0, 0x808, v0
+; VI-NEXT:    v_readfirstlane_b32 s0, v0
+; VI-NEXT:    v_readfirstlane_b32 s1, v1
+; VI-NEXT:    ; return to shader part epilog
+;
+; GFX9-LABEL: v_or3_v2i32_inline_const:
+; GFX9:       ; %bb.0:
+; GFX9-NEXT:    s_movk_i32 s0, 0x809
+; GFX9-NEXT:    v_or3_b32 v1, v1, v3, s0
+; GFX9-NEXT:    s_movk_i32 s0, 0x808
+; GFX9-NEXT:    v_or3_b32 v0, v0, v2, s0
+; GFX9-NEXT:    v_readfirstlane_b32 s0, v0
+; GFX9-NEXT:    v_readfirstlane_b32 s1, v1
+; GFX9-NEXT:    ; return to shader part epilog
+;
+; GFX10-LABEL: v_or3_v2i32_inline_const:
+; GFX10:       ; %bb.0:
+; GFX10-NEXT:    v_or3_b32 v0, v0, v2, 0x808
+; GFX10-NEXT:    v_or3_b32 v1, v1, v3, 0x809
+; GFX10-NEXT:    v_readfirstlane_b32 s0, v0
+; GFX10-NEXT:    v_readfirstlane_b32 s1, v1
+; GFX10-NEXT:    ; return to shader part epilog
+  %x = or <2 x i32> %a, <i32 2056, i32 2057>
+  %result = or <2 x i32> %x, %b
+  ret <2 x i32> %result
+}
+
+define amdgpu_ps <2 x i32> @v_or3_v2i32_multi_use(<2 x i32> %a, <2 x i32> %b, <2 x i32> %c) {
+; VI-LABEL: v_or3_v2i32_multi_use:
+; VI:       ; %bb.0:
+; VI-NEXT:    v_or_b32_e32 v1, v1, v3
+; VI-NEXT:    v_or_b32_e32 v0, v0, v2
+; VI-NEXT:    v_or_b32_e32 v2, v1, v5
+; VI-NEXT:    v_or_b32_e32 v3, v0, v4
+; VI-NEXT:    v_add_u32_e32 v1, vcc, v1, v2
+; VI-NEXT:    v_add_u32_e32 v0, vcc, v0, v3
+; VI-NEXT:    v_readfirstlane_b32 s0, v0
+; VI-NEXT:    v_readfirstlane_b32 s1, v1
+; VI-NEXT:    ; return to shader part epilog
+;
+; GFX9-LABEL: v_or3_v2i32_multi_use:
+; GFX9:       ; %bb.0:
+; GFX9-NEXT:    v_or_b32_e32 v1, v1, v3
+; GFX9-NEXT:    v_or_b32_e32 v0, v0, v2
+; GFX9-NEXT:    v_or_b32_e32 v2, v1, v5
+; GFX9-NEXT:    v_or_b32_e32 v3, v0, v4
+; GFX9-NEXT:    v_add_u32_e32 v1, v1, v2
+; GFX9-NEXT:    v_add_u32_e32 v0, v0, v3
+; GFX9-NEXT:    v_readfirstlane_b32 s0, v0
+; GFX9-NEXT:    v_readfirstlane_b32 s1, v1
+; GFX9-NEXT:    ; return to shader part epilog
+;
+; GFX10-LABEL: v_or3_v2i32_multi_use:
+; GFX10:       ; %bb.0:
+; GFX10-NEXT:    v_or_b32_e32 v0, v0, v2
+; GFX10-NEXT:    v_or_b32_e32 v1, v1, v3
+; GFX10-NEXT:    v_or_b32_e32 v2, v0, v4
+; GFX10-NEXT:    v_or_b32_e32 v3, v1, v5
+; GFX10-NEXT:    v_add_nc_u32_e32 v0, v0, v2
+; GFX10-NEXT:    v_add_nc_u32_e32 v1, v1, v3
+; GFX10-NEXT:    v_readfirstlane_b32 s0, v0
+; GFX10-NEXT:    v_readfirstlane_b32 s1, v1
+; GFX10-NEXT:    ; return to shader part epilog
+  %x = or <2 x i32> %a, %b
+  %y = or <2 x i32> %x, %c
+  %result = add <2 x i32> %x, %y
   ret <2 x i32> %result
 }
 
@@ -199,95 +328,20 @@ define amdgpu_ps <2 x i32> @s_or3_v2i32(<2 x i32> inreg %a, <2 x i32> inreg %b, 
 ; VI:       ; %bb.0:
 ; VI-NEXT:    s_or_b64 s[0:1], s[2:3], s[4:5]
 ; VI-NEXT:    s_or_b64 s[0:1], s[0:1], s[6:7]
+; VI-NEXT:    ; return to shader part epilog
 ;
 ; GFX9-LABEL: s_or3_v2i32:
 ; GFX9:       ; %bb.0:
 ; GFX9-NEXT:    s_or_b64 s[0:1], s[2:3], s[4:5]
 ; GFX9-NEXT:    s_or_b64 s[0:1], s[0:1], s[6:7]
+; GFX9-NEXT:    ; return to shader part epilog
 ;
 ; GFX10-LABEL: s_or3_v2i32:
 ; GFX10:       ; %bb.0:
 ; GFX10-NEXT:    s_or_b64 s[0:1], s[2:3], s[4:5]
 ; GFX10-NEXT:    s_or_b64 s[0:1], s[0:1], s[6:7]
+; GFX10-NEXT:    ; return to shader part epilog
   %x = or <2 x i32> %a, %b
   %result = or <2 x i32> %x, %c
-  ret <2 x i32> %result
-}
-
-define <2 x i32> @or3_v2i32_const(<2 x i32> %a, <2 x i32> %b) {
-; VI-LABEL: or3_v2i32_const:
-; VI:        s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; VI-DAG:    v_or_b32_e32 v0, 4, v0
-; VI-DAG:    v_or_b32_e32 v1, 16, v1
-; VI-CHECK-NOT: {{.}}
-; VI-DAG:    v_or_b32_e32 v0, v0, v2
-; VI-DAG:    v_or_b32_e32 v1, v1, v3
-;
-; GFX9-LABEL: or3_v2i32_const:
-; GFX9:        s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX9-DAG:    v_or3_b32 v0, v0, v2, 4
-; GFX9-DAG:    v_or3_b32 v1, v1, v3, 16
-;
-; GFX10-LABEL: or3_v2i32_const:
-; GFX10:         s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX10-DAG:     v_or3_b32 v0, v0, v2, 4
-; GFX10-DAG:     v_or3_b32 v1, v1, v3, 16
-  %x = or <2 x i32> %a, <i32 4, i32 16>
-  %result = or <2 x i32> %x, %b
-  ret <2 x i32> %result
-}
-
-define <2 x i32> @or3_v2i32_inline_const(<2 x i32> %a, <2 x i32> %b) {
-; VI-LABEL: or3_v2i32_inline_const:
-; VI:        s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; VI-DAG:    v_or_b32_e32 v0, 0x808, v0
-; VI-DAG:    v_or_b32_e32 v1, 0x809, v1
-; VI-CHECK-NOT: {{.}}
-; VI-DAG:    v_or_b32_e32 v0, v0, v2
-; VI-DAG:    v_or_b32_e32 v1, v1, v3
-;
-; GFX9-LABEL: or3_v2i32_inline_const:
-; GFX9:         s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX9-NEXT:    s_movk_i32 s4, 0x809
-; GFX9-NEXT:    v_or3_b32 v1, v1, v3, s4
-; GFX9-NEXT:    s_movk_i32 s4, 0x808
-; GFX9-NEXT:    v_or3_b32 v0, v0, v2, s4
-;
-; GFX10-LABEL: or3_v2i32_inline_const:
-; GFX10:         s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX10-DAG:     v_or3_b32 v0, v0, v2, 0x808
-; GFX10-DAG:     v_or3_b32 v1, v1, v3, 0x809
-  %x = or <2 x i32> %a, <i32 2056, i32 2057>
-  %result = or <2 x i32> %x, %b
-  ret <2 x i32> %result
-}
-
-define <2 x i32> @or3_v2i32_multi_use(<2 x i32> %a, <2 x i32> %b, <2 x i32> %c) {
-; VI-LABEL: or3_v2i32_multi_use:
-; VI:        s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; VI-DAG:    v_or_b32_e32 v0, v0, v2
-; VI-DAG:    v_or_b32_e32 v1, v1, v3
-; VI-CHECK-NOT: {{.}}
-; VI-DAG:    v_or_b32_e32 v3, v0, v4
-; VI-DAG:    v_or_b32_e32 v2, v1, v5
-;
-; GFX9-LABEL: or3_v2i32_multi_use:
-; GFX9:        s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX9-DAG:    v_or_b32_e32 v0, v0, v2
-; GFX9-DAG:    v_or_b32_e32 v1, v1, v3
-; GFX9-CHECK-NOT: {{.}}
-; GFX9-DAG:    v_or_b32_e32 v{{[0-9]+}}, v0, v4
-; GFX9-DAG:    v_or_b32_e32 v{{[0-9]+}}, v1, v5
-;
-; GFX10-LABEL: or3_v2i32_multi_use:
-; GFX10:        s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX10-DAG:    v_or_b32_e32 v0, v0, v2
-; GFX10-DAG:    v_or_b32_e32 v1, v1, v3
-; GFX10-CHECK-NOT: {{.}}
-; GFX10-DAG:    v_or_b32_e32 v{{[0-9]+}}, v0, v4
-; GFX10-DAG:    v_or_b32_e32 v{{[0-9]+}}, v1, v5
-  %x = or <2 x i32> %a, %b
-  %y = or <2 x i32> %x, %c
-  %result = add <2 x i32> %x, %y
   ret <2 x i32> %result
 }

--- a/llvm/test/CodeGen/AMDGPU/or3.ll
+++ b/llvm/test/CodeGen/AMDGPU/or3.ll
@@ -120,3 +120,25 @@ define amdgpu_ps float @or3_vgpr_const(i32 %a, i32 %b) {
   %bc = bitcast i32 %result to float
   ret float %bc
 }
+
+define <2 x i32> @or3_v2i32(<2 x i32> %a, <2 x i32> %b, <2 x i32> %c) {
+; VI-LABEL: or3_v2i32:
+; VI:         s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; VI-DAG:    v_or_b32_e32 v0, v0, v2
+; VI-DAG:    v_or_b32_e32 v1, v1, v3
+; VI-DAG:    v_or_b32_e32 v0, v0, v4
+; VI-DAG:    v_or_b32_e32 v1, v1, v5
+;
+; GFX9-LABEL: or3_v2i32:
+; GFX9:         s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-DAG:     v_or3_b32 v0, v0, v2, v4
+; GFX9-DAG:     v_or3_b32 v1, v1, v3, v5
+;
+; GFX10-LABEL: or3_v2i32:
+; GFX10:         s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX10-DAG:     v_or3_b32 v0, v0, v2, v4
+; GFX10-DAG:     v_or3_b32 v1, v1, v3, v5
+  %x = or <2 x i32> %a, %b
+  %result = or <2 x i32> %x, %c
+  ret <2 x i32> %result
+}

--- a/llvm/test/CodeGen/AMDGPU/or3.ll
+++ b/llvm/test/CodeGen/AMDGPU/or3.ll
@@ -194,21 +194,21 @@ define <2 x i32> @or3_v2i32_ab(<2 x i32> %a, <2 x i32> %b, <2 x i32> inreg %c) {
   ret <2 x i32> %result
 }
 
-define <2 x i32> @or3_v2i32_scalar(<2 x i32> inreg %a, <2 x i32> inreg %b, <2 x i32> inreg %c) {
-; VI-LABEL: or3_v2i32_scalar:
-; VI:         s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; VI-NEXT:    s_or_b64 s[4:5], s[16:17], s[18:19]
-; VI-NEXT:    s_or_b64 s[4:5], s[4:5], s[20:21]
+define amdgpu_ps <2 x i32> @s_or3_v2i32(<2 x i32> inreg %a, <2 x i32> inreg %b, <2 x i32> inreg %c) {
+; VI-LABEL: s_or3_v2i32:
+; VI:       ; %bb.0:
+; VI-NEXT:    s_or_b64 s[0:1], s[2:3], s[4:5]
+; VI-NEXT:    s_or_b64 s[0:1], s[0:1], s[6:7]
 ;
-; GFX9-LABEL: or3_v2i32_scalar:
-; GFX9:         s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX9-NEXT:    s_or_b64 s[4:5], s[16:17], s[18:19]
-; GFX9-NEXT:    s_or_b64 s[4:5], s[4:5], s[20:21]
+; GFX9-LABEL: s_or3_v2i32:
+; GFX9:       ; %bb.0:
+; GFX9-NEXT:    s_or_b64 s[0:1], s[2:3], s[4:5]
+; GFX9-NEXT:    s_or_b64 s[0:1], s[0:1], s[6:7]
 ;
-; GFX10-LABEL: or3_v2i32_scalar:
-; GFX10:         s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX10-NEXT:    s_or_b64 [[SV0:s\[[0-9]+:[0-9]+\]]], [[SV1:s\[[0-9]+:[0-9]+\]]], [[SV2:s\[[0-9]+:[0-9]+\]]]
-; GFX10-NEXT:    s_or_b64 [[SV0]], [[SV0]], [[SV3:s\[[0-9]+:[0-9]+\]]]
+; GFX10-LABEL: s_or3_v2i32:
+; GFX10:       ; %bb.0:
+; GFX10-NEXT:    s_or_b64 s[0:1], s[2:3], s[4:5]
+; GFX10-NEXT:    s_or_b64 s[0:1], s[0:1], s[6:7]
   %x = or <2 x i32> %a, %b
   %result = or <2 x i32> %x, %c
   ret <2 x i32> %result

--- a/llvm/test/CodeGen/AMDGPU/or3.ll
+++ b/llvm/test/CodeGen/AMDGPU/or3.ll
@@ -121,202 +121,182 @@ define amdgpu_ps float @or3_vgpr_const(i32 %a, i32 %b) {
   ret float %bc
 }
 
-define amdgpu_ps <2 x i32> @v_or3_v2i32(<2 x i32> %a, <2 x i32> %b, <2 x i32> %c) {
+define <2 x i32> @v_or3_v2i32(<2 x i32> %a, <2 x i32> %b, <2 x i32> %c) {
 ; VI-LABEL: v_or3_v2i32:
 ; VI:       ; %bb.0:
+; VI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; VI-NEXT:    v_or_b32_e32 v1, v1, v3
 ; VI-NEXT:    v_or_b32_e32 v0, v0, v2
 ; VI-NEXT:    v_or_b32_e32 v1, v1, v5
 ; VI-NEXT:    v_or_b32_e32 v0, v0, v4
-; VI-NEXT:    v_readfirstlane_b32 s0, v0
-; VI-NEXT:    v_readfirstlane_b32 s1, v1
-; VI-NEXT:    ; return to shader part epilog
+; VI-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX9-LABEL: v_or3_v2i32:
 ; GFX9:       ; %bb.0:
+; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX9-NEXT:    v_or3_b32 v1, v1, v3, v5
 ; GFX9-NEXT:    v_or3_b32 v0, v0, v2, v4
-; GFX9-NEXT:    v_readfirstlane_b32 s0, v0
-; GFX9-NEXT:    v_readfirstlane_b32 s1, v1
-; GFX9-NEXT:    ; return to shader part epilog
+; GFX9-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-LABEL: v_or3_v2i32:
 ; GFX10:       ; %bb.0:
+; GFX10-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX10-NEXT:    v_or3_b32 v0, v0, v2, v4
 ; GFX10-NEXT:    v_or3_b32 v1, v1, v3, v5
-; GFX10-NEXT:    v_readfirstlane_b32 s0, v0
-; GFX10-NEXT:    v_readfirstlane_b32 s1, v1
-; GFX10-NEXT:    ; return to shader part epilog
+; GFX10-NEXT:    s_setpc_b64 s[30:31]
   %x = or <2 x i32> %a, %b
   %result = or <2 x i32> %x, %c
   ret <2 x i32> %result
 }
 
 ; ThreeOp instruction variant not used due to Constant Bus Limitations
-define amdgpu_ps <2 x i32> @v_or3_v2i32_b(<2 x i32> inreg %a, <2 x i32> %b, <2 x i32> inreg %c) {
+define <2 x i32> @v_or3_v2i32_b(<2 x i32> inreg %a, <2 x i32> %b, <2 x i32> inreg %c) {
 ; VI-LABEL: v_or3_v2i32_b:
 ; VI:       ; %bb.0:
-; VI-NEXT:    v_or_b32_e32 v1, s3, v1
-; VI-NEXT:    v_or_b32_e32 v0, s2, v0
-; VI-NEXT:    v_or_b32_e32 v1, s5, v1
-; VI-NEXT:    v_or_b32_e32 v0, s4, v0
-; VI-NEXT:    v_readfirstlane_b32 s0, v0
-; VI-NEXT:    v_readfirstlane_b32 s1, v1
-; VI-NEXT:    ; return to shader part epilog
+; VI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; VI-NEXT:    v_or_b32_e32 v1, s17, v1
+; VI-NEXT:    v_or_b32_e32 v0, s16, v0
+; VI-NEXT:    v_or_b32_e32 v1, s19, v1
+; VI-NEXT:    v_or_b32_e32 v0, s18, v0
+; VI-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX9-LABEL: v_or3_v2i32_b:
 ; GFX9:       ; %bb.0:
-; GFX9-NEXT:    v_or_b32_e32 v1, s3, v1
-; GFX9-NEXT:    v_or_b32_e32 v0, s2, v0
-; GFX9-NEXT:    v_or_b32_e32 v1, s5, v1
-; GFX9-NEXT:    v_or_b32_e32 v0, s4, v0
-; GFX9-NEXT:    v_readfirstlane_b32 s0, v0
-; GFX9-NEXT:    v_readfirstlane_b32 s1, v1
-; GFX9-NEXT:    ; return to shader part epilog
+; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    v_or_b32_e32 v1, s17, v1
+; GFX9-NEXT:    v_or_b32_e32 v0, s16, v0
+; GFX9-NEXT:    v_or_b32_e32 v1, s19, v1
+; GFX9-NEXT:    v_or_b32_e32 v0, s18, v0
+; GFX9-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-LABEL: v_or3_v2i32_b:
 ; GFX10:       ; %bb.0:
-; GFX10-NEXT:    v_or3_b32 v0, s2, v0, s4
-; GFX10-NEXT:    v_or3_b32 v1, s3, v1, s5
-; GFX10-NEXT:    v_readfirstlane_b32 s0, v0
-; GFX10-NEXT:    v_readfirstlane_b32 s1, v1
-; GFX10-NEXT:    ; return to shader part epilog
+; GFX10-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX10-DAG:     v_or3_b32 v0, s{{[0-9]+}}, v0, s{{[0-9]+}}
+; GFX10-DAG:     v_or3_b32 v1, s{{[0-9]+}}, v1, s{{[0-9]+}}
   %x = or <2 x i32> %a, %b
   %result = or <2 x i32> %x, %c
   ret <2 x i32> %result
 }
 
-define amdgpu_ps <2 x i32> @v_or3_v2i32_ab(<2 x i32> %a, <2 x i32> %b, <2 x i32> inreg %c) {
+define <2 x i32> @v_or3_v2i32_ab(<2 x i32> %a, <2 x i32> %b, <2 x i32> inreg %c) {
 ; VI-LABEL: v_or3_v2i32_ab:
 ; VI:       ; %bb.0:
+; VI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; VI-NEXT:    v_or_b32_e32 v1, v1, v3
 ; VI-NEXT:    v_or_b32_e32 v0, v0, v2
-; VI-NEXT:    v_or_b32_e32 v1, s3, v1
-; VI-NEXT:    v_or_b32_e32 v0, s2, v0
-; VI-NEXT:    v_readfirstlane_b32 s0, v0
-; VI-NEXT:    v_readfirstlane_b32 s1, v1
-; VI-NEXT:    ; return to shader part epilog
+; VI-NEXT:    v_or_b32_e32 v1, s17, v1
+; VI-NEXT:    v_or_b32_e32 v0, s16, v0
+; VI-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX9-LABEL: v_or3_v2i32_ab:
 ; GFX9:       ; %bb.0:
-; GFX9-NEXT:    v_or3_b32 v1, v1, v3, s3
-; GFX9-NEXT:    v_or3_b32 v0, v0, v2, s2
-; GFX9-NEXT:    v_readfirstlane_b32 s0, v0
-; GFX9-NEXT:    v_readfirstlane_b32 s1, v1
-; GFX9-NEXT:    ; return to shader part epilog
+; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    v_or3_b32 v1, v1, v3, s17
+; GFX9-NEXT:    v_or3_b32 v0, v0, v2, s16
+; GFX9-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-LABEL: v_or3_v2i32_ab:
 ; GFX10:       ; %bb.0:
-; GFX10-NEXT:    v_or3_b32 v0, v0, v2, s2
-; GFX10-NEXT:    v_or3_b32 v1, v1, v3, s3
-; GFX10-NEXT:    v_readfirstlane_b32 s0, v0
-; GFX10-NEXT:    v_readfirstlane_b32 s1, v1
-; GFX10-NEXT:    ; return to shader part epilog
+; GFX10-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX10-DAG:     v_or3_b32 v0, v0, v2, s{{[0-9]+}}
+; GFX10-DAG:     v_or3_b32 v1, v1, v3, s{{[0-9]+}}
   %x = or <2 x i32> %a, %b
   %result = or <2 x i32> %x, %c
   ret <2 x i32> %result
 }
 
-define amdgpu_ps <2 x i32> @v_or3_v2i32_const(<2 x i32> %a, <2 x i32> %b) {
+define <2 x i32> @v_or3_v2i32_const(<2 x i32> %a, <2 x i32> %b) {
 ; VI-LABEL: v_or3_v2i32_const:
 ; VI:       ; %bb.0:
+; VI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; VI-NEXT:    v_or_b32_e32 v1, v1, v3
 ; VI-NEXT:    v_or_b32_e32 v0, v0, v2
 ; VI-NEXT:    v_or_b32_e32 v1, 16, v1
 ; VI-NEXT:    v_or_b32_e32 v0, 4, v0
-; VI-NEXT:    v_readfirstlane_b32 s0, v0
-; VI-NEXT:    v_readfirstlane_b32 s1, v1
-; VI-NEXT:    ; return to shader part epilog
+; VI-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX9-LABEL: v_or3_v2i32_const:
 ; GFX9:       ; %bb.0:
+; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX9-NEXT:    v_or3_b32 v1, v1, v3, 16
 ; GFX9-NEXT:    v_or3_b32 v0, v0, v2, 4
-; GFX9-NEXT:    v_readfirstlane_b32 s0, v0
-; GFX9-NEXT:    v_readfirstlane_b32 s1, v1
-; GFX9-NEXT:    ; return to shader part epilog
+; GFX9-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-LABEL: v_or3_v2i32_const:
 ; GFX10:       ; %bb.0:
+; GFX10-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX10-NEXT:    v_or3_b32 v0, v0, v2, 4
 ; GFX10-NEXT:    v_or3_b32 v1, v1, v3, 16
-; GFX10-NEXT:    v_readfirstlane_b32 s0, v0
-; GFX10-NEXT:    v_readfirstlane_b32 s1, v1
-; GFX10-NEXT:    ; return to shader part epilog
+; GFX10-NEXT:    s_setpc_b64 s[30:31]
   %x = or <2 x i32> %a, <i32 4, i32 16>
   %result = or <2 x i32> %x, %b
   ret <2 x i32> %result
 }
 
-define amdgpu_ps <2 x i32> @v_or3_v2i32_inline_const(<2 x i32> %a, <2 x i32> %b) {
+define <2 x i32> @v_or3_v2i32_inline_const(<2 x i32> %a, <2 x i32> %b) {
 ; VI-LABEL: v_or3_v2i32_inline_const:
 ; VI:       ; %bb.0:
+; VI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; VI-NEXT:    v_or_b32_e32 v1, v1, v3
 ; VI-NEXT:    v_or_b32_e32 v0, v0, v2
 ; VI-NEXT:    v_or_b32_e32 v1, 0x809, v1
 ; VI-NEXT:    v_or_b32_e32 v0, 0x808, v0
-; VI-NEXT:    v_readfirstlane_b32 s0, v0
-; VI-NEXT:    v_readfirstlane_b32 s1, v1
-; VI-NEXT:    ; return to shader part epilog
+; VI-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX9-LABEL: v_or3_v2i32_inline_const:
 ; GFX9:       ; %bb.0:
-; GFX9-NEXT:    s_movk_i32 s0, 0x809
-; GFX9-NEXT:    v_or3_b32 v1, v1, v3, s0
-; GFX9-NEXT:    s_movk_i32 s0, 0x808
-; GFX9-NEXT:    v_or3_b32 v0, v0, v2, s0
-; GFX9-NEXT:    v_readfirstlane_b32 s0, v0
-; GFX9-NEXT:    v_readfirstlane_b32 s1, v1
-; GFX9-NEXT:    ; return to shader part epilog
+; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    s_movk_i32 s4, 0x809
+; GFX9-NEXT:    v_or3_b32 v1, v1, v3, s4
+; GFX9-NEXT:    s_movk_i32 s4, 0x808
+; GFX9-NEXT:    v_or3_b32 v0, v0, v2, s4
+; GFX9-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-LABEL: v_or3_v2i32_inline_const:
 ; GFX10:       ; %bb.0:
+; GFX10-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX10-NEXT:    v_or3_b32 v0, v0, v2, 0x808
 ; GFX10-NEXT:    v_or3_b32 v1, v1, v3, 0x809
-; GFX10-NEXT:    v_readfirstlane_b32 s0, v0
-; GFX10-NEXT:    v_readfirstlane_b32 s1, v1
-; GFX10-NEXT:    ; return to shader part epilog
+; GFX10-NEXT:    s_setpc_b64 s[30:31]
   %x = or <2 x i32> %a, <i32 2056, i32 2057>
   %result = or <2 x i32> %x, %b
   ret <2 x i32> %result
 }
 
-define amdgpu_ps <2 x i32> @v_or3_v2i32_multi_use(<2 x i32> %a, <2 x i32> %b, <2 x i32> %c) {
+define <2 x i32> @v_or3_v2i32_multi_use(<2 x i32> %a, <2 x i32> %b, <2 x i32> %c) {
 ; VI-LABEL: v_or3_v2i32_multi_use:
 ; VI:       ; %bb.0:
+; VI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; VI-NEXT:    v_or_b32_e32 v1, v1, v3
 ; VI-NEXT:    v_or_b32_e32 v0, v0, v2
 ; VI-NEXT:    v_or_b32_e32 v2, v1, v5
 ; VI-NEXT:    v_or_b32_e32 v3, v0, v4
-; VI-NEXT:    v_add_u32_e32 v1, vcc, v1, v2
 ; VI-NEXT:    v_add_u32_e32 v0, vcc, v0, v3
-; VI-NEXT:    v_readfirstlane_b32 s0, v0
-; VI-NEXT:    v_readfirstlane_b32 s1, v1
-; VI-NEXT:    ; return to shader part epilog
+; VI-NEXT:    v_add_u32_e32 v1, vcc, v1, v2
+; VI-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX9-LABEL: v_or3_v2i32_multi_use:
 ; GFX9:       ; %bb.0:
+; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX9-NEXT:    v_or_b32_e32 v1, v1, v3
 ; GFX9-NEXT:    v_or_b32_e32 v0, v0, v2
 ; GFX9-NEXT:    v_or_b32_e32 v2, v1, v5
 ; GFX9-NEXT:    v_or_b32_e32 v3, v0, v4
-; GFX9-NEXT:    v_add_u32_e32 v1, v1, v2
 ; GFX9-NEXT:    v_add_u32_e32 v0, v0, v3
-; GFX9-NEXT:    v_readfirstlane_b32 s0, v0
-; GFX9-NEXT:    v_readfirstlane_b32 s1, v1
-; GFX9-NEXT:    ; return to shader part epilog
+; GFX9-NEXT:    v_add_u32_e32 v1, v1, v2
+; GFX9-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-LABEL: v_or3_v2i32_multi_use:
 ; GFX10:       ; %bb.0:
+; GFX10-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX10-NEXT:    v_or_b32_e32 v0, v0, v2
 ; GFX10-NEXT:    v_or_b32_e32 v1, v1, v3
 ; GFX10-NEXT:    v_or_b32_e32 v2, v0, v4
 ; GFX10-NEXT:    v_or_b32_e32 v3, v1, v5
 ; GFX10-NEXT:    v_add_nc_u32_e32 v0, v0, v2
 ; GFX10-NEXT:    v_add_nc_u32_e32 v1, v1, v3
-; GFX10-NEXT:    v_readfirstlane_b32 s0, v0
-; GFX10-NEXT:    v_readfirstlane_b32 s1, v1
-; GFX10-NEXT:    ; return to shader part epilog
+; GFX10-NEXT:    s_setpc_b64 s[30:31]
   %x = or <2 x i32> %a, %b
   %y = or <2 x i32> %x, %c
   %result = add <2 x i32> %x, %y

--- a/llvm/test/CodeGen/AMDGPU/or3.ll
+++ b/llvm/test/CodeGen/AMDGPU/or3.ll
@@ -142,3 +142,131 @@ define <2 x i32> @or3_v2i32(<2 x i32> %a, <2 x i32> %b, <2 x i32> %c) {
   %result = or <2 x i32> %x, %c
   ret <2 x i32> %result
 }
+
+; ThreeOp instruction variant not used due to Constant Bus Limitations
+define <2 x i32> @or3_v2i32_b(<2 x i32> inreg %a, <2 x i32> %b, <2 x i32> inreg %c) {
+; VI-LABEL: or3_v2i32_b:
+; VI:        s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; VI-DAG:    v_or_b32_e32 v0, s16, v0
+; VI-DAG:    v_or_b32_e32 v1, s17, v1
+; VI-CHECK-NOT: {{.}}
+; VI-DAG:    v_or_b32_e32 v0, s18, v0
+; VI-DAG:    v_or_b32_e32 v1, s19, v1
+;
+; GFX9-LABEL: or3_v2i32_b:
+; GFX9:        s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-DAG:    v_or_b32_e32 v0, s16, v0
+; GFX9-DAG:    v_or_b32_e32 v1, s17, v1
+; GFX9-CHECK-NOT: {{.}}
+; GFX9-DAG:    v_or_b32_e32 v0, s18, v0
+; GFX9-DAG:    v_or_b32_e32 v1, s19, v1
+;
+; GFX10-LABEL: or3_v2i32_b:
+; GFX10:         s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX10-DAG:     v_or3_b32 v0, s{{[0-9]+}}, v0, s{{[0-9]+}}
+; GFX10-DAG:     v_or3_b32 v1, s{{[0-9]+}}, v1, s{{[0-9]+}}
+  %x = or <2 x i32> %a, %b
+  %result = or <2 x i32> %x, %c
+  ret <2 x i32> %result
+}
+
+define <2 x i32> @or3_v2i32_ab(<2 x i32> %a, <2 x i32> %b, <2 x i32> inreg %c) {
+; VI-LABEL: or3_v2i32_ab:
+; VI:        s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; VI-DAG:    v_or_b32_e32 v0, v0, v2
+; VI-DAG:    v_or_b32_e32 v1, v1, v3
+; VI-CHECK-NOT: {{.}}
+; VI-DAG:    v_or_b32_e32 v0, s16, v0
+; VI-DAG:    v_or_b32_e32 v1, s17, v1
+;
+; GFX9-LABEL: or3_v2i32_ab:
+; GFX9:         s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-DAG:     v_or3_b32 v0, v0, v2, s16
+; GFX9-DAG:     v_or3_b32 v1, v1, v3, s17
+;
+; GFX10-LABEL: or3_v2i32_ab:
+; GFX10:         s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX10-DAG:     v_or3_b32 v0, v0, v2, s{{[0-9]+}}
+; GFX10-DAG:     v_or3_b32 v1, v1, v3, s{{[0-9]+}}
+  %x = or <2 x i32> %a, %b
+  %result = or <2 x i32> %x, %c
+  ret <2 x i32> %result
+}
+
+define <2 x i32> @or3_v2i32_const(<2 x i32> %a, <2 x i32> %b) {
+; VI-LABEL: or3_v2i32_const:
+; VI:        s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; VI-DAG:    v_or_b32_e32 v0, 4, v0
+; VI-DAG:    v_or_b32_e32 v1, 16, v1
+; VI-CHECK-NOT: {{.}}
+; VI-DAG:    v_or_b32_e32 v0, v0, v2
+; VI-DAG:    v_or_b32_e32 v1, v1, v3
+;
+; GFX9-LABEL: or3_v2i32_const:
+; GFX9:        s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-DAG:    v_or3_b32 v0, v0, v2, 4
+; GFX9-DAG:    v_or3_b32 v1, v1, v3, 16
+;
+; GFX10-LABEL: or3_v2i32_const:
+; GFX10:         s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX10-DAG:     v_or3_b32 v0, v0, v2, 4
+; GFX10-DAG:     v_or3_b32 v1, v1, v3, 16
+  %x = or <2 x i32> %a, <i32 4, i32 16>
+  %result = or <2 x i32> %x, %b
+  ret <2 x i32> %result
+}
+
+define <2 x i32> @or3_v2i32_inline_const(<2 x i32> %a, <2 x i32> %b) {
+; VI-LABEL: or3_v2i32_inline_const:
+; VI:        s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; VI-DAG:    v_or_b32_e32 v0, 0x808, v0
+; VI-DAG:    v_or_b32_e32 v1, 0x809, v1
+; VI-CHECK-NOT: {{.}}
+; VI-DAG:    v_or_b32_e32 v0, v0, v2
+; VI-DAG:    v_or_b32_e32 v1, v1, v3
+;
+; GFX9-LABEL: or3_v2i32_inline_const:
+; GFX9:         s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    s_movk_i32 s4, 0x809
+; GFX9-NEXT:    v_or3_b32 v1, v1, v3, s4
+; GFX9-NEXT:    s_movk_i32 s4, 0x808
+; GFX9-NEXT:    v_or3_b32 v0, v0, v2, s4
+;
+; GFX10-LABEL: or3_v2i32_inline_const:
+; GFX10:         s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX10-DAG:     v_or3_b32 v0, v0, v2, 0x808
+; GFX10-DAG:     v_or3_b32 v1, v1, v3, 0x809
+  %x = or <2 x i32> %a, <i32 2056, i32 2057>
+  %result = or <2 x i32> %x, %b
+  ret <2 x i32> %result
+}
+
+define <2 x i32> @or3_v2i32_multi_use(<2 x i32> %a, <2 x i32> %b, <2 x i32> %c) {
+; VI-LABEL: or3_v2i32_multi_use:
+; VI:        s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; VI-DAG:    v_or_b32_e32 v0, v0, v2
+; VI-DAG:    v_or_b32_e32 v1, v1, v3
+; VI-CHECK-NOT: {{.}}
+; VI-DAG:    v_or_b32_e32 v3, v0, v4
+; VI-DAG:    v_or_b32_e32 v2, v1, v5
+;
+; GFX9-LABEL: or3_v2i32_multi_use:
+; GFX9:        s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-DAG:    v_or_b32_e32 v0, v0, v2
+; GFX9-DAG:    v_or_b32_e32 v1, v1, v3
+; GFX9-CHECK-NOT: {{.}}
+; GFX9-DAG:    v_or_b32_e32 v{{[0-9]+}}, v0, v4
+; GFX9-DAG:    v_or_b32_e32 v{{[0-9]+}}, v1, v5
+;
+; GFX10-LABEL: or3_v2i32_multi_use:
+; GFX10:        s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX10-DAG:    v_or_b32_e32 v0, v0, v2
+; GFX10-DAG:    v_or_b32_e32 v1, v1, v3
+; GFX10-CHECK-NOT: {{.}}
+; GFX10-DAG:    v_or_b32_e32 v{{[0-9]+}}, v0, v4
+; GFX10-DAG:    v_or_b32_e32 v{{[0-9]+}}, v1, v5
+  %x = or <2 x i32> %a, %b
+  %y = or <2 x i32> %x, %c
+  %result = add <2 x i32> %x, %y
+  ret <2 x i32> %result
+}

--- a/llvm/test/CodeGen/AMDGPU/or3.ll
+++ b/llvm/test/CodeGen/AMDGPU/or3.ll
@@ -194,18 +194,18 @@ define <2 x i32> @or3_v2i32_ab(<2 x i32> %a, <2 x i32> %b, <2 x i32> inreg %c) {
   ret <2 x i32> %result
 }
 
-define <2 x i32> @or3_v2i32_abc(<2 x i32> inreg %a, <2 x i32> inreg %b, <2 x i32> inreg %c) {
-; VI-LABEL: or3_v2i32_abc:
+define <2 x i32> @or3_v2i32_scalar(<2 x i32> inreg %a, <2 x i32> inreg %b, <2 x i32> inreg %c) {
+; VI-LABEL: or3_v2i32_scalar:
 ; VI:         s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; VI-NEXT:    s_or_b64 s[4:5], s[16:17], s[18:19]
 ; VI-NEXT:    s_or_b64 s[4:5], s[4:5], s[20:21]
 ;
-; GFX9-LABEL: or3_v2i32_abc:
+; GFX9-LABEL: or3_v2i32_scalar:
 ; GFX9:         s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX9-NEXT:    s_or_b64 s[4:5], s[16:17], s[18:19]
 ; GFX9-NEXT:    s_or_b64 s[4:5], s[4:5], s[20:21]
 ;
-; GFX10-LABEL: or3_v2i32_abc:
+; GFX10-LABEL: or3_v2i32_scalar:
 ; GFX10:         s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX10-NEXT:    s_or_b64 [[SV0:s\[[0-9]+:[0-9]+\]]], [[SV1:s\[[0-9]+:[0-9]+\]]], [[SV2:s\[[0-9]+:[0-9]+\]]]
 ; GFX10-NEXT:    s_or_b64 [[SV0]], [[SV0]], [[SV3:s\[[0-9]+:[0-9]+\]]]


### PR DESCRIPTION
Add ThreeOp_v2i32_Pats pattern class to support v2i32 vector operations for AND_OR_B32 and OR3_B32 instructions. The new patterns check the v2i32 and-or or or-or instruction sequence, extract individual 32-bit elements from v2i32 operands, and applies the and_or or or3 vop3 operations.

