### PR TITLE
[NFC][AArch64] ConditionOptimizer: replace hardcoded CC switch with TII hook

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64ConditionOptimizer.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ConditionOptimizer.cpp
@@ -65,6 +65,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "AArch64.h"
+#include "AArch64Subtarget.h"
 #include "MCTargetDesc/AArch64AddressingModes.h"
 #include "Utils/AArch64BaseInfo.h"
 #include "llvm/ADT/ArrayRef.h"
@@ -116,7 +117,7 @@ class AArch64ConditionOptimizerImpl {
     unsigned getOpc() const { return CmpMI->getOpcode(); }
   };
 
-  const TargetInstrInfo *TII;
+  const AArch64InstrInfo *TII;
   const TargetRegisterInfo *TRI;
   MachineDominatorTree *DomTree;
   const MachineRegisterInfo *MRI;
@@ -384,20 +385,10 @@ void AArch64ConditionOptimizerImpl::updateCmpInstr(MachineInstr *CmpMI,
 // Modifies the condition code of a conditional instruction.
 void AArch64ConditionOptimizerImpl::updateCondInstr(MachineInstr *CondMI,
                                                     AArch64CC::CondCode NewCC) {
-  // Get the correct operand index for the conditional instruction
-  unsigned CondOpIdx;
-  switch (CondMI->getOpcode()) {
-  case AArch64::Bcc:
-    CondOpIdx = 0;
-    break;
-  case AArch64::CSINCWr:
-  case AArch64::CSINCXr:
-    CondOpIdx = 3;
-    break;
-  default:
-    llvm_unreachable("Unsupported conditional instruction");
-  }
-  CondMI->getOperand(CondOpIdx).setImm(NewCC);
+  int CCOpIdx =
+      AArch64InstrInfo::findCondCodeUseOperandIdxForBranchOrSelect(*CondMI);
+  assert(CCOpIdx >= 0 && "Unsupported conditional instruction");
+  CondMI->getOperand(CCOpIdx).setImm(NewCC);
   ++NumConditionsAdjusted;
 }
 
@@ -715,7 +706,7 @@ bool AArch64ConditionOptimizerImpl::run(MachineFunction &MF,
   LLVM_DEBUG(dbgs() << "********** AArch64 Conditional Compares **********\n"
                     << "********** Function: " << MF.getName() << '\n');
 
-  TII = MF.getSubtarget().getInstrInfo();
+  TII = static_cast<const AArch64InstrInfo *>(MF.getSubtarget().getInstrInfo());
   TRI = MF.getSubtarget().getRegisterInfo();
   DomTree = &MDT;
   MRI = &MF.getRegInfo();

--- a/llvm/lib/Target/AArch64/AArch64InstrInfo.cpp
+++ b/llvm/lib/Target/AArch64/AArch64InstrInfo.cpp
@@ -2072,8 +2072,8 @@ static bool areCFlagsAliveInSuccessors(const MachineBasicBlock *MBB) {
 
 /// \returns The condition code operand index for \p Instr if it is a branch
 /// or select and -1 otherwise.
-static int
-findCondCodeUseOperandIdxForBranchOrSelect(const MachineInstr &Instr) {
+int AArch64InstrInfo::findCondCodeUseOperandIdxForBranchOrSelect(
+    const MachineInstr &Instr) {
   switch (Instr.getOpcode()) {
   default:
     return -1;
@@ -2105,7 +2105,8 @@ findCondCodeUseOperandIdxForBranchOrSelect(const MachineInstr &Instr) {
 /// Returns AArch64CC::Invalid if either the instruction does not use condition
 /// codes or we don't optimize CmpInstr in the presence of such instructions.
 static AArch64CC::CondCode findCondCodeUsedByInstr(const MachineInstr &Instr) {
-  int CCIdx = findCondCodeUseOperandIdxForBranchOrSelect(Instr);
+  int CCIdx =
+      AArch64InstrInfo::findCondCodeUseOperandIdxForBranchOrSelect(Instr);
   return CCIdx >= 0 ? static_cast<AArch64CC::CondCode>(
                           Instr.getOperand(CCIdx).getImm())
                     : AArch64CC::Invalid;

--- a/llvm/lib/Target/AArch64/AArch64InstrInfo.h
+++ b/llvm/lib/Target/AArch64/AArch64InstrInfo.h
@@ -571,6 +571,9 @@ public:
                                                Register TargetReg,
                                                bool FrameSetup) const;
 
+  static int
+  findCondCodeUseOperandIdxForBranchOrSelect(const MachineInstr &Instr);
+
 #define GET_INSTRINFO_HELPER_DECLS
 #include "AArch64GenInstrInfo.inc"
 


### PR DESCRIPTION
Elevate findCondCodeUseOperandIdxForBranchOrSelect to a class member on AArch64InstrInfo and use it in updateCondInstr to replace the hardcoded switch on condition code operand indices.