### PR TITLE
[ORC] EPCGenericJITLinkMemoryManager from SimpleNativeMemoryMap syms.

### DIFF
--- a/llvm/include/llvm/ExecutionEngine/Orc/EPCGenericJITLinkMemoryManager.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/EPCGenericJITLinkMemoryManager.h
@@ -46,6 +46,10 @@ public:
     StringRef ReleaseName;
   };
 
+  /// Default symbol names for the ORC runtime's SimpleNativeMemoryMap SPS
+  /// interface.
+  static const SymbolNames orc_rt_SimpleNativeMemoryMapSPSSymbols;
+
   /// Create an EPCGenericJITLinkMemoryManager instance from a given set of
   /// function addrs.
   EPCGenericJITLinkMemoryManager(ExecutorProcessControl &EPC, SymbolAddrs SAs)
@@ -54,7 +58,15 @@ public:
   /// Create an EPCGenericJITLinkMemoryManager using the given implementation
   /// symbol names. These will be looked up in the given JITDylib.
   static Expected<std::unique_ptr<EPCGenericJITLinkMemoryManager>>
-  Create(JITDylib &JD, SymbolNames SNs);
+  Create(JITDylib &JD,
+         SymbolNames SNs = orc_rt_SimpleNativeMemoryMapSPSSymbols);
+
+  /// Create an EPCGenericJITLinkMemoryManager using the given implementation
+  /// symbol names. These will be looked up in the given ExecutionSession's
+  /// Bootstrap JITDylib.
+  static Expected<std::unique_ptr<EPCGenericJITLinkMemoryManager>>
+  Create(ExecutionSession &ES,
+         SymbolNames SNs = orc_rt_SimpleNativeMemoryMapSPSSymbols);
 
   void allocate(const jitlink::JITLinkDylib *JD, jitlink::LinkGraph &G,
                 OnAllocatedFunction OnAllocated) override;

--- a/llvm/lib/ExecutionEngine/Orc/EPCGenericJITLinkMemoryManager.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/EPCGenericJITLinkMemoryManager.cpp
@@ -19,6 +19,15 @@ using namespace llvm::jitlink;
 namespace llvm {
 namespace orc {
 
+const EPCGenericJITLinkMemoryManager::SymbolNames
+    EPCGenericJITLinkMemoryManager::orc_rt_SimpleNativeMemoryMapSPSSymbols = {
+        "orc_rt_SimpleNativeMemoryMap_Instance",
+        "orc_rt_SimpleNativeMemoryMap_reserve_sps_wrapper",
+        "orc_rt_SimpleNativeMemoryMap_initialize_sps_wrapper",
+        "orc_rt_SimpleNativeMemoryMap_deinitializeMultiple_sps_wrapper",
+        "orc_rt_SimpleNativeMemoryMap_releaseMultiple_sps_wrapper",
+};
+
 class EPCGenericJITLinkMemoryManager::InFlightAlloc
     : public jitlink::JITLinkMemoryManager::InFlightAlloc {
 public:
@@ -114,6 +123,11 @@ EPCGenericJITLinkMemoryManager::Create(JITDylib &JD, SymbolNames SNs) {
     return Err;
   return std::make_unique<EPCGenericJITLinkMemoryManager>(
       ES.getExecutorProcessControl(), SAs);
+}
+
+Expected<std::unique_ptr<EPCGenericJITLinkMemoryManager>>
+EPCGenericJITLinkMemoryManager::Create(ExecutionSession &ES, SymbolNames SNs) {
+  return Create(ES.getBootstrapJITDylib(), std::move(SNs));
 }
 
 void EPCGenericJITLinkMemoryManager::allocate(const JITLinkDylib *JD,

--- a/llvm/unittests/ExecutionEngine/Orc/EPCGenericJITLinkMemoryManagerTest.cpp
+++ b/llvm/unittests/ExecutionEngine/Orc/EPCGenericJITLinkMemoryManagerTest.cpp
@@ -202,4 +202,40 @@ TEST(EPCGenericJITLinkMemoryManagerTest, CreateFailsOnMissingSymbol) {
   cantFail(ES.endSession());
 }
 
+TEST(EPCGenericJITLinkMemoryManagerTest, CreateFromExecutionSession) {
+  // Verify that Create(ExecutionSession&) looks up symbols in the bootstrap
+  // JITDylib using the default SimpleNativeMemoryMap symbol names.
+  class EPCWithBootstrapSymbols : public UnsupportedExecutorProcessControl {
+  public:
+    EPCWithBootstrapSymbols(std::shared_ptr<SymbolStringPool> SSP,
+                            StringMap<ExecutorAddr> BS)
+        : UnsupportedExecutorProcessControl(std::move(SSP)) {
+      this->BootstrapSymbols = std::move(BS);
+    }
+  };
+
+  auto &SNs =
+      EPCGenericJITLinkMemoryManager::orc_rt_SimpleNativeMemoryMapSPSSymbols;
+
+  ExecutorAddr AllocatorAddr(1), ReserveAddr(2), InitAddr(3), DeinitAddr(4),
+      ReleaseAddr(5);
+
+  StringMap<ExecutorAddr> BootstrapSyms;
+  BootstrapSyms[SNs.AllocatorName] = AllocatorAddr;
+  BootstrapSyms[SNs.ReserveName] = ReserveAddr;
+  BootstrapSyms[SNs.InitializeName] = InitAddr;
+  BootstrapSyms[SNs.DeinitializeName] = DeinitAddr;
+  BootstrapSyms[SNs.ReleaseName] = ReleaseAddr;
+
+  auto SSP = std::make_shared<SymbolStringPool>();
+  auto EPC =
+      std::make_unique<EPCWithBootstrapSymbols>(SSP, std::move(BootstrapSyms));
+  ExecutionSession ES(std::move(EPC));
+
+  auto Result = EPCGenericJITLinkMemoryManager::Create(ES, SNs);
+  EXPECT_THAT_EXPECTED(Result, Succeeded());
+
+  cantFail(ES.endSession());
+}
+
 } // namespace


### PR DESCRIPTION
Adds a new EPCGenericJITLinkMemoryManager convenience constructor that constructs an instance by looking up the given symbol names in the bootstrap JITDylib of the given ExecutionSession.

The symbol names default to the SimpleNativeMemoryMap SPS-interface symbol names provided by the new ORC runtime.