### PR TITLE
[clang-tidy] Add missing #include insertion in macros for modernize-use-std-print

### DIFF
--- a/clang-tools-extra/clang-tidy/modernize/UseStdPrintCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/UseStdPrintCheck.cpp
@@ -158,7 +158,8 @@ void UseStdPrintCheck::check(const MatchFinder::MatchResult &Result) {
 
   if (MaybeHeaderToInclude)
     Diag << IncludeInserter.createIncludeInsertion(
-        Result.Context->getSourceManager().getFileID(PrintfCall->getBeginLoc()),
+        Result.SourceManager->getFileID(
+            Result.SourceManager->getExpansionLoc(PrintfCall->getBeginLoc())),
         *MaybeHeaderToInclude);
 }
 

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -313,6 +313,11 @@ Changes in existing checks
   <clang-tidy/checks/modernize/use-std-format>` check by fixing a crash
   when an argument is part of a macro expansion.
 
+- Improved :doc:`modernize-use-std-print
+  <clang-tidy/checks/modernize/use-std-print>` check by adding missing
+  ``#include`` insertion when the format function call appears as an
+  argument to a macro.
+
 - Improved :doc:`modernize-use-trailing-return-type
   <clang-tidy/checks/modernize/use-trailing-return-type>` check by fixing
   spurious ``missing '(' after '__has_feature'`` errors caused by builtin

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/use-std-print-macro.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/use-std-print-macro.cpp
@@ -1,0 +1,13 @@
+// RUN: %check_clang_tidy -std=c++23-or-later %s modernize-use-std-print %t -- \
+// RUN:   -- -fexceptions
+
+#include <cstdio>
+// CHECK-FIXES: #include <print>
+
+#define WRAP_MSG(msg) msg
+
+void macro_argument_include(int n) {
+  WRAP_MSG(printf("value %d", n));
+  // CHECK-MESSAGES: [[@LINE-1]]:12: warning: use 'std::print' instead of 'printf' [modernize-use-std-print]
+  // CHECK-FIXES: WRAP_MSG(std::print("value {}", n));
+}

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/use-std-print-macro.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/use-std-print-macro.cpp
@@ -1,5 +1,4 @@
-// RUN: %check_clang_tidy -std=c++23-or-later %s modernize-use-std-print %t -- \
-// RUN:   -- -fexceptions
+// RUN: %check_clang_tidy -std=c++23-or-later %s modernize-use-std-print %t
 
 #include <cstdio>
 // CHECK-FIXES: #include <print>


### PR DESCRIPTION
Follow-up of: #188247