### PR TITLE
[lldb][Process/FreeBSDKernelCore] Always reconstruct thread list for kvm

### DIFF
--- a/lldb/include/lldb/Target/Process.h
+++ b/lldb/include/lldb/Target/Process.h
@@ -3381,6 +3381,8 @@ protected:
                             ///see them. This is usually the same as
   ///< m_thread_list_real, but might be different if there is an OS plug-in
   ///creating memory threads
+  bool m_always_update_thread_list = false; ///< Always run UpdateThreadList()
+                                            /// in UpdateThreadListIfNeeded()
   ThreadPlanStackMap m_thread_plans; ///< This is the list of thread plans for
                                      /// threads in m_thread_list, as well as
                                      /// threads we knew existed, but haven't

--- a/lldb/source/Plugins/Process/FreeBSD-Kernel-Core/ProcessFreeBSDKernelCore.cpp
+++ b/lldb/source/Plugins/Process/FreeBSD-Kernel-Core/ProcessFreeBSDKernelCore.cpp
@@ -65,7 +65,9 @@ ProcessFreeBSDKernelCore::ProcessFreeBSDKernelCore(lldb::TargetSP target_sp,
                                                    kvm_t *kvm,
                                                    const FileSpec &core_file)
     : PostMortemProcess(target_sp, listener_sp, core_file), m_is_kvm(true),
-      m_kvm(kvm) {}
+      m_kvm(kvm) {
+  m_always_update_thread_list = true;
+}
 
 ProcessFreeBSDKernelCore::~ProcessFreeBSDKernelCore() {
   if (m_kvm)

--- a/lldb/source/Plugins/Process/FreeBSD-Kernel-Core/ProcessFreeBSDKernelCore.cpp
+++ b/lldb/source/Plugins/Process/FreeBSD-Kernel-Core/ProcessFreeBSDKernelCore.cpp
@@ -64,7 +64,8 @@ ProcessFreeBSDKernelCore::ProcessFreeBSDKernelCore(lldb::TargetSP target_sp,
                                                    ListenerSP listener_sp,
                                                    kvm_t *kvm,
                                                    const FileSpec &core_file)
-    : PostMortemProcess(target_sp, listener_sp, core_file), m_kvm(kvm) {}
+    : PostMortemProcess(target_sp, listener_sp, core_file), m_is_kvm(true),
+      m_kvm(kvm) {}
 
 ProcessFreeBSDKernelCore::~ProcessFreeBSDKernelCore() {
   if (m_kvm)
@@ -157,9 +158,10 @@ size_t ProcessFreeBSDKernelCore::DoWriteMemory(lldb::addr_t addr,
 
 bool ProcessFreeBSDKernelCore::DoUpdateThreadList(ThreadList &old_thread_list,
                                                   ThreadList &new_thread_list) {
-  if (old_thread_list.GetSize(false) == 0) {
+  if (m_is_kvm || old_thread_list.GetSize(false) == 0) {
     // Make up the thread the first time this is called so we can set our one
-    // and only core thread state up.
+    // and only core thread state up. Since target type (crash dump or live
+    // memory) isn't identifable in kvm, always reconstruct thread list for kvm.
 
     // We cannot construct a thread without a register context as that crashes
     // LLDB but we can construct a process without threads to provide minimal

--- a/lldb/source/Plugins/Process/FreeBSD-Kernel-Core/ProcessFreeBSDKernelCore.h
+++ b/lldb/source/Plugins/Process/FreeBSD-Kernel-Core/ProcessFreeBSDKernelCore.h
@@ -70,9 +70,11 @@ private:
 
   const char *GetError();
 
-  bool m_printed_unread_message = false;
+  const bool m_is_kvm;
 
   kvm_t *m_kvm;
+
+  bool m_printed_unread_message = false;
 };
 
 #endif // LLDB_SOURCE_PLUGINS_PROCESS_FREEBSDKERNEL_PROCESSFREEBSDKERNELCORE_H

--- a/lldb/source/Target/Process.cpp
+++ b/lldb/source/Target/Process.cpp
@@ -1102,7 +1102,7 @@ bool Process::UpdateThreadList(ThreadList &old_thread_list,
 
 void Process::UpdateThreadListIfNeeded() {
   const uint32_t stop_id = GetStopID();
-  if (m_thread_list.GetSize(false) == 0 ||
+  if (m_always_update_thread_list || m_thread_list.GetSize(false) == 0 ||
       stop_id != m_thread_list.GetStopID()) {
     bool clear_unused_threads = true;
     const StateType state = GetPrivateState();


### PR DESCRIPTION
Since `/dev/mem` is live memory, its thread list is updated while running LLDB. In the current model, users need to restart LLDB to get new thread list, and this is prone to error when writing to memory because LLDB's thread information and `/dev/mem` might be out of sync. This change always reconstruct thread list during `DoThreadListUpdate()` to solve this synchronization issue. However, there could still be synchronization issue when there is a change between thread list reconstruction and memory write, but currently there is no solution for this currently even for kgdb.

This is enabled for all kvm invocation regardless of type of the target (crash dump or live kernel) because kvm hides the target type information. Elf-core based implementation in future will need to update thread list only at the first time as it is guaranteed that elf-core handles static files.