### PR TITLE
[libc++] Use __ugly__ spellings of vendor attributes in verbose_abort.cpp

### DIFF
--- a/libcxx/src/verbose_abort.cpp
+++ b/libcxx/src/verbose_abort.cpp
@@ -23,7 +23,7 @@ extern "C" void android_set_abort_message(const char* msg);
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 
-[[gnu::weak]] void __libcpp_verbose_abort(char const* format, ...) noexcept {
+[[__gnu__::__weak__]] void __libcpp_verbose_abort(char const* format, ...) noexcept {
   // Write message to stderr. We do this before formatting into a
   // buffer so that we still get some information out if that fails.
   {


### PR DESCRIPTION
Non-standard attributes should use the _Ugly spelling as per the coding guidelines.