### PR TITLE
[libunwind] Fix building on OpenBSD / FreeBSD aarch64

### DIFF
--- a/libunwind/CMakeLists.txt
+++ b/libunwind/CMakeLists.txt
@@ -336,6 +336,16 @@ if (RUNTIMES_EXECUTE_ONLY_CODE)
   add_compile_definitions(_LIBUNWIND_EXECUTE_ONLY_CODE)
 endif()
 
+check_symbol_exists(getauxval "sys/auxv.h" HAVE_GETAUXVAL)
+if (HAVE_GETAUXVAL)
+  add_definitions(-D_LIBUNWIND_HAVE_GETAUXVAL)
+endif()
+
+check_symbol_exists(elf_aux_info "sys/auxv.h" HAVE_ELF_AUX_INFO)
+if (HAVE_ELF_AUX_INFO)
+  add_definitions(-D_LIBUNWIND_HAVE_ELF_AUX_INFO)
+endif()
+
 add_custom_target(unwind-test-depends
   COMMENT "Build dependencies required to run the libunwind test suite.")
 

--- a/libunwind/src/Registers.hpp
+++ b/libunwind/src/Registers.hpp
@@ -20,9 +20,8 @@
 #include "libunwind_ext.h"
 #include "shadow_stack_unwind.h"
 
-#if __has_include(<sys/auxv.h>)
+#if defined(_LIBUNWIND_HAVE_GETAUXVAL) || defined(_LIBUNWIND_HAVE_ELF_AUX_INFO)
 #include <sys/auxv.h>
-#define HAVE_SYS_AUXV_H
 #endif
 
 namespace libunwind {
@@ -1941,15 +1940,25 @@ private:
       _LIBUNWIND_ABORT("SME ZA disable failed");
   }
 
+#if defined(_LIBUNWIND_HAVE_GETAUXVAL)
   static bool checkHasSME() {
-#if defined(HAVE_SYS_AUXV_H)
     constexpr int hwcap2_sme = (1 << 23);
     unsigned long hwcap2 = getauxval(AT_HWCAP2);
     return (hwcap2 & hwcap2_sme) != 0;
-#endif
+  }
+#elif defined(_LIBUNWIND_HAVE_ELF_AUX_INFO)
+  static bool checkHasSME() {
+    constexpr int hwcap2_sme = (1 << 23);
+    unsigned long hwcap2 = 0;
+    elf_aux_info(AT_HWCAP2, &hwcap2, sizeof(hwcap2));
+    return (hwcap2 & hwcap2_sme) != 0;
+  }
+#else
+  static bool checkHasSME() {
     // TODO: Support other platforms.
     return false;
   }
+#endif
 
   struct GPRs {
     uint64_t __x[29] = {};        // x0-x28


### PR DESCRIPTION
Just checking for the header presence of sys/auxv.h breaks the
build on OpenBSD / FreeBSD. Make use of elf_aux_info().