### PR TITLE
[clang-tidy][NFC] Remove hack in readability-implicit-bool-conversion testcases

### DIFF
--- a/clang-tools-extra/test/clang-tidy/checkers/Inputs/Headers/std/cstddef
+++ b/clang-tools-extra/test/clang-tidy/checkers/Inputs/Headers/std/cstddef
@@ -15,7 +15,9 @@ namespace std {
   using ::ptrdiff_t;
   using ::size_t;
 
+#if __cplusplus >= 201103L
   using nullptr_t = decltype(nullptr);
+#endif
 }
 
 #endif // _CSTDDEF_

--- a/clang-tools-extra/test/clang-tidy/checkers/Inputs/Headers/std/stddef.h
+++ b/clang-tools-extra/test/clang-tidy/checkers/Inputs/Headers/std/stddef.h
@@ -9,6 +9,8 @@
 #ifndef _STDDEF_H_
 #define _STDDEF_H_
 
+#define NULL 0L
+
 typedef __PTRDIFF_TYPE__ ptrdiff_t;
 typedef __SIZE_TYPE__ size_t;
 

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/implicit-bool-conversion-cxx98.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/implicit-bool-conversion-cxx98.cpp
@@ -1,9 +1,6 @@
 // RUN: %check_clang_tidy -std=c++98 %s readability-implicit-bool-conversion %t
 
-// We need NULL macro, but some buildbots don't like including <cstddef> header
-// This is a portable way of getting it to work
-#undef NULL
-#define NULL 0L
+#include <cstddef>
 
 template<typename T>
 void functionTaking(T);

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/implicit-bool-conversion.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/implicit-bool-conversion.cpp
@@ -1,13 +1,10 @@
-// RUN: %check_clang_tidy %s readability-implicit-bool-conversion %t
-// RUN: %check_clang_tidy -check-suffix=UPPER-CASE %s readability-implicit-bool-conversion %t -- \
+// RUN: %check_clang_tidy %s readability-implicit-bool-conversion %t -- --system-headers
+// RUN: %check_clang_tidy -check-suffix=UPPER-CASE %s readability-implicit-bool-conversion %t -- --system-headers \
 // RUN:     -config='{CheckOptions: { \
 // RUN:         readability-implicit-bool-conversion.UseUpperCaseLiteralSuffix: true \
 // RUN:     }}'
 
-// We need NULL macro, but some buildbots don't like including <cstddef> header
-// This is a portable way of getting it to work
-#undef NULL
-#define NULL 0L
+#include <cstddef>
 
 template<typename T>
 void functionTaking(T);
@@ -548,7 +545,7 @@ namespace PR71848 {
   }
 }
 
-namespace PR161318 {  
+namespace PR161318 {
   int AddParenOutsideOfCompoundAssignOp() {
     int val = -1;
     while(val >>= 7) {


### PR DESCRIPTION
Another attempt after #184850