### PR TITLE
[compiler-rt] Implement __clear_cache for Hexagon

### DIFF
--- a/compiler-rt/lib/builtins/clear_cache.c
+++ b/compiler-rt/lib/builtins/clear_cache.c
@@ -218,10 +218,10 @@ void __clear_cache(void *start, void *end) {
 
   // Invalidate instruction cache so it re-fetches from memory.
   for (uintptr_t addr = start_line; addr < end_addr; addr += line_size)
-    __builtin_HEXAGON_Y2_icinva((void *)addr);
+    __asm__ volatile("icinva(%[a])" : : [a] "r"((void *)addr));
 
   // Instruction sync barrier ensures subsequent fetches see the new code.
-  __builtin_HEXAGON_Y2_isync();
+  __asm__ volatile("isync");
 #else
 #if __APPLE__
   // On Darwin, sys_icache_invalidate() provides this functionality

--- a/compiler-rt/lib/builtins/clear_cache.c
+++ b/compiler-rt/lib/builtins/clear_cache.c
@@ -204,6 +204,24 @@ void __clear_cache(void *start, void *end) {
   sysarch(RISCV_SYNC_ICACHE, &arg);
 #elif defined(__ve__)
   __asm__ volatile("fencec 2");
+#elif defined(__hexagon__)
+  // Hexagon has separate instruction and data caches.
+  const size_t line_size = __GCC_DESTRUCTIVE_SIZE;
+  const uintptr_t mask = ~(line_size - 1);
+  const uintptr_t start_line = (uintptr_t)start & mask;
+  const uintptr_t end_addr = (uintptr_t)end;
+
+  // Clean and invalidate data cache to push new code to memory and
+  // invalidate stale lines in the L2 cache.
+  for (uintptr_t addr = start_line; addr < end_addr; addr += line_size)
+    __builtin_HEXAGON_Y2_dccleaninva((void *)addr);
+
+  // Invalidate instruction cache so it re-fetches from memory.
+  for (uintptr_t addr = start_line; addr < end_addr; addr += line_size)
+    __builtin_HEXAGON_Y2_icinva((void *)addr);
+
+  // Instruction sync barrier ensures subsequent fetches see the new code.
+  __builtin_HEXAGON_Y2_isync();
 #else
 #if __APPLE__
   // On Darwin, sys_icache_invalidate() provides this functionality


### PR DESCRIPTION
Add Hexagon support to compiler-rt's __clear_cache implementation. The sequence follows the Hexagon PRM (§ 5.10.3-5.10.4):

* dccleaninva per cache line
* icinva per cache line
* isync