### PR TITLE
[Hexagon] Add LLVM intrinsics for icinva and isync instructions

### DIFF
--- a/llvm/include/llvm/IR/IntrinsicsHexagonDep.td
+++ b/llvm/include/llvm/IR/IntrinsicsHexagonDep.td
@@ -3589,6 +3589,12 @@ Hexagon__ptr_Intrinsic<"HEXAGON_Y2_dcinva", []>;
 def int_hexagon_Y2_dczeroa :
 Hexagon__ptr_Intrinsic<"HEXAGON_Y2_dczeroa", []>;
 
+def int_hexagon_Y2_icinva :
+Hexagon__ptr_Intrinsic<"HEXAGON_Y2_icinva", []>;
+
+def int_hexagon_Y2_isync :
+Hexagon_Intrinsic<"HEXAGON_Y2_isync", [], [], []>;
+
 def int_hexagon_Y4_l2fetch :
 Hexagon__ptri32_Intrinsic<"HEXAGON_Y4_l2fetch", []>;
 

--- a/llvm/lib/Target/Hexagon/HexagonDepInstrInfo.td
+++ b/llvm/lib/Target/Hexagon/HexagonDepInstrInfo.td
@@ -41328,6 +41328,7 @@ tc_0ba0d5da, TypeJ>, Enc_ecbcc8 {
 let Inst{13-0} = 0b00000000000000;
 let Inst{31-21} = 0b01010110110;
 let isSolo = 1;
+let hasSideEffects = 1;
 }
 def Y2_icinvidx : HInst<
 (outs),
@@ -41376,6 +41377,7 @@ tc_9b34f5e0, TypeJ>, Enc_e3b0c4 {
 let Inst{13-0} = 0b00000000000010;
 let Inst{31-16} = 0b0101011111000000;
 let isSolo = 1;
+let hasSideEffects = 1;
 }
 def Y2_k0lock : HInst<
 (outs),

--- a/llvm/lib/Target/Hexagon/HexagonDepInstrIntrinsics.inc
+++ b/llvm/lib/Target/Hexagon/HexagonDepInstrIntrinsics.inc
@@ -931,6 +931,8 @@
 {Hexagon::Y2_dcfetch, Intrinsic::hexagon_Y2_dcfetch},
 {Hexagon::Y2_dcinva, Intrinsic::hexagon_Y2_dcinva},
 {Hexagon::Y2_dczeroa, Intrinsic::hexagon_Y2_dczeroa},
+{Hexagon::Y2_icinva, Intrinsic::hexagon_Y2_icinva},
+{Hexagon::Y2_isync, Intrinsic::hexagon_Y2_isync},
 {Hexagon::Y4_l2fetch, Intrinsic::hexagon_Y4_l2fetch},
 {Hexagon::Y5_l2fetch, Intrinsic::hexagon_Y5_l2fetch},
 {Hexagon::Y6_dmlink, Intrinsic::hexagon_Y6_dmlink},

--- a/llvm/lib/Target/Hexagon/HexagonIntrinsics.td
+++ b/llvm/lib/Target/Hexagon/HexagonIntrinsics.td
@@ -232,6 +232,8 @@ def: T_R_pat<Y2_dccleana,    int_hexagon_Y2_dccleana>;
 def: T_R_pat<Y2_dccleaninva, int_hexagon_Y2_dccleaninva>;
 def: T_R_pat<Y2_dcinva,      int_hexagon_Y2_dcinva>;
 def: T_R_pat<Y2_dczeroa,     int_hexagon_Y2_dczeroa>;
+def: T_R_pat<Y2_icinva,      int_hexagon_Y2_icinva>;
+def: Pat<(int_hexagon_Y2_isync), (Y2_isync)>;
 
 def: T_RR_pat<Y4_l2fetch,    int_hexagon_Y4_l2fetch>;
 def: T_RP_pat<Y5_l2fetch,    int_hexagon_Y5_l2fetch>;

--- a/llvm/test/CodeGen/Hexagon/intrinsics/system_user.ll
+++ b/llvm/test/CodeGen/Hexagon/intrinsics/system_user.ll
@@ -57,11 +57,29 @@ entry:
   ret void
 }
 
+; CHECK-LABEL: ic00:
+; CHECK: icinva(r{{[0-9]+}})
+define void @ic00(ptr nocapture readonly %p) local_unnamed_addr #0 {
+entry:
+  tail call void @llvm.hexagon.Y2.icinva(ptr %p)
+  ret void
+}
+
+; CHECK-LABEL: ic01:
+; CHECK: isync
+define void @ic01() local_unnamed_addr #0 {
+entry:
+  tail call void @llvm.hexagon.Y2.isync()
+  ret void
+}
+
 declare void @llvm.hexagon.prefetch(ptr nocapture) #1
 declare void @llvm.hexagon.Y2.dccleana(ptr nocapture readonly) #2
 declare void @llvm.hexagon.Y2.dccleaninva(ptr nocapture readonly) #2
 declare void @llvm.hexagon.Y2.dcinva(ptr nocapture readonly) #2
 declare void @llvm.hexagon.Y2.dczeroa(ptr nocapture) #3
+declare void @llvm.hexagon.Y2.icinva(ptr nocapture readonly) #2
+declare void @llvm.hexagon.Y2.isync() #2
 declare void @llvm.hexagon.Y4.l2fetch(ptr nocapture readonly, i32) #2
 declare void @llvm.hexagon.Y5.l2fetch(ptr nocapture readonly, i64) #2
 


### PR DESCRIPTION
Add int_hexagon_Y2_icinva (instruction cache line invalidate) and int_hexagon_Y2_isync (instruction synchronization barrier) intrinsics with corresponding instruction selection patterns.

Also set hasSideEffects=1 on both Y2_icinva and Y2_isync instruction definitions, since these cache maintenance operations have observable side effects.