### PR TITLE
[Hexagon] Add clang builtins for icinva and isync cache instructions

### DIFF
--- a/clang/include/clang/Basic/BuiltinsHexagon.td
+++ b/clang/include/clang/Basic/BuiltinsHexagon.td
@@ -996,6 +996,8 @@ def Y2_dccleaninva : HexagonBuiltin<"void(void *)">;
 def Y2_dcfetch : HexagonBuiltin<"void(void *)">;
 def Y2_dcinva : HexagonBuiltin<"void(void *)">;
 def Y2_dczeroa : HexagonBuiltin<"void(void *)">;
+def Y2_icinva : HexagonBuiltin<"void(void *)">;
+def Y2_isync : HexagonBuiltin<"void()">;
 def Y4_l2fetch : HexagonBuiltin<"void(void *, int)">;
 def Y5_l2fetch : HexagonBuiltin<"void(void *, long long int)">;
 

--- a/clang/lib/Headers/hexagon_protos.h
+++ b/clang/lib/Headers/hexagon_protos.h
@@ -7799,6 +7799,24 @@
 #define Q6_dczeroa_A __builtin_HEXAGON_Y2_dczeroa
 
 /* ==========================================================================
+   Assembly Syntax:       icinva(Rs32)
+   C Intrinsic Prototype: void Q6_icinva_A(Address Rs)
+   Instruction Type:      J
+   Execution Slots:       SLOT2
+   ========================================================================== */
+
+#define Q6_icinva_A __builtin_HEXAGON_Y2_icinva
+
+/* ==========================================================================
+   Assembly Syntax:       isync
+   C Intrinsic Prototype: void Q6_isync()
+   Instruction Type:      J
+   Execution Slots:       SLOT2
+   ========================================================================== */
+
+#define Q6_isync __builtin_HEXAGON_Y2_isync
+
+/* ==========================================================================
    Assembly Syntax:       l2fetch(Rs32,Rt32)
    C Intrinsic Prototype: void Q6_l2fetch_AR(Address Rs, Word32 Rt)
    Instruction Type:      ST

--- a/clang/test/CodeGen/builtins-hexagon.c
+++ b/clang/test/CodeGen/builtins-hexagon.c
@@ -1726,6 +1726,10 @@ void test() {
   __builtin_HEXAGON_Y2_dcinva(0);
   // CHECK: @llvm.hexagon.Y2.dczeroa
   __builtin_HEXAGON_Y2_dczeroa(0);
+  // CHECK: @llvm.hexagon.Y2.icinva
+  __builtin_HEXAGON_Y2_icinva(0);
+  // CHECK: @llvm.hexagon.Y2.isync
+  __builtin_HEXAGON_Y2_isync();
   // CHECK: @llvm.hexagon.Y4.l2fetch
   __builtin_HEXAGON_Y4_l2fetch(0, 0);
   // CHECK: @llvm.hexagon.Y5.l2fetch


### PR DESCRIPTION
Add __builtin_HEXAGON_Y2_icinva (instruction cache invalidate) and __builtin_HEXAGON_Y2_isync (instruction sync barrier) builtins, along with Q6_icinva_A and Q6_isync convenience macros in hexagon_protos.h.