### PR TITLE
[ORC] Move DylibManager impl out of SelfExecutorProcessControl.

### DIFF
--- a/llvm/include/llvm/ExecutionEngine/Orc/SelfExecutorProcessControl.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/SelfExecutorProcessControl.h
@@ -22,8 +22,7 @@
 namespace llvm::orc {
 
 /// A ExecutorProcessControl implementation targeting the current process.
-class LLVM_ABI SelfExecutorProcessControl : public ExecutorProcessControl,
-                                            private DylibManager {
+class LLVM_ABI SelfExecutorProcessControl : public ExecutorProcessControl {
 public:
   SelfExecutorProcessControl(
       std::shared_ptr<SymbolStringPool> SSP, std::unique_ptr<TaskDispatcher> D,
@@ -54,21 +53,28 @@ public:
   Error disconnect() override;
 
 private:
+  class InProcessDylibManager : public DylibManager {
+  public:
+    InProcessDylibManager(char GlobalManglingPrefix);
+    Expected<tpctypes::DylibHandle> loadDylib(const char *DylibPath) override;
+    void
+    lookupSymbolsAsync(ArrayRef<LookupRequest> Request,
+                       DylibManager::SymbolLookupCompleteFn Complete) override;
+
+  private:
+    char GlobalManglingPrefix;
+  };
+
   static shared::CWrapperFunctionBuffer
   jitDispatchViaWrapperFunctionManager(void *Ctx, const void *FnTag,
                                        const char *Data, size_t Size);
-
-  Expected<tpctypes::DylibHandle> loadDylib(const char *DylibPath) override;
-
-  void lookupSymbolsAsync(ArrayRef<LookupRequest> Request,
-                          SymbolLookupCompleteFn F) override;
 
   std::unique_ptr<jitlink::JITLinkMemoryManager> OwnedMemMgr;
 #ifdef __APPLE__
   std::unique_ptr<UnwindInfoManager> UnwindInfoMgr;
 #endif // __APPLE__
-  char GlobalManglingPrefix = 0;
   InProcessMemoryAccess IPMA;
+  InProcessDylibManager IPDM;
 };
 
 } // namespace llvm::orc

--- a/llvm/lib/ExecutionEngine/Orc/SelfExecutorProcessControl.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/SelfExecutorProcessControl.cpp
@@ -24,7 +24,8 @@ SelfExecutorProcessControl::SelfExecutorProcessControl(
     Triple TargetTriple, unsigned PageSize,
     std::unique_ptr<jitlink::JITLinkMemoryManager> MemMgr)
     : ExecutorProcessControl(std::move(SSP), std::move(D)),
-      IPMA(TargetTriple.isArch64Bit()) {
+      IPMA(TargetTriple.isArch64Bit()),
+      IPDM(TargetTriple.isOSBinFormatMachO() ? '_' : '\0') {
 
   OwnedMemMgr = std::move(MemMgr);
   if (!OwnedMemMgr)
@@ -35,12 +36,9 @@ SelfExecutorProcessControl::SelfExecutorProcessControl(
   this->PageSize = PageSize;
   this->MemMgr = OwnedMemMgr.get();
   this->MemAccess = &IPMA;
-  this->DylibMgr = this;
+  this->DylibMgr = &IPDM;
   this->JDI = {ExecutorAddr::fromPtr(jitDispatchViaWrapperFunctionManager),
                ExecutorAddr::fromPtr(this)};
-
-  if (this->TargetTriple.isOSBinFormatMachO())
-    GlobalManglingPrefix = '_';
 
   addDefaultBootstrapValuesForHostProcess(BootstrapMap, BootstrapSymbols);
 
@@ -73,40 +71,6 @@ SelfExecutorProcessControl::Create(
   return std::make_unique<SelfExecutorProcessControl>(
       std::move(SSP), std::move(D), std::move(TT), *PageSize,
       std::move(MemMgr));
-}
-
-Expected<tpctypes::DylibHandle>
-SelfExecutorProcessControl::loadDylib(const char *DylibPath) {
-  std::string ErrMsg;
-  auto Dylib = sys::DynamicLibrary::getPermanentLibrary(DylibPath, &ErrMsg);
-  if (!Dylib.isValid())
-    return make_error<StringError>(std::move(ErrMsg), inconvertibleErrorCode());
-  return ExecutorAddr::fromPtr(Dylib.getOSSpecificHandle());
-}
-
-void SelfExecutorProcessControl::lookupSymbolsAsync(
-    ArrayRef<LookupRequest> Request,
-    DylibManager::SymbolLookupCompleteFn Complete) {
-  std::vector<tpctypes::LookupResult> R;
-
-  for (auto &Elem : Request) {
-    sys::DynamicLibrary Dylib(Elem.Handle.toPtr<void *>());
-    R.push_back(tpctypes::LookupResult());
-    for (auto &KV : Elem.Symbols) {
-      auto &Sym = KV.first;
-      std::string Tmp((*Sym).data() + !!GlobalManglingPrefix,
-                      (*Sym).size() - !!GlobalManglingPrefix);
-      void *Addr = Dylib.getAddressOfSymbol(Tmp.c_str());
-      if (!Addr && KV.second == SymbolLookupFlags::RequiredSymbol)
-        R.back().emplace_back();
-      else
-        // FIXME: determine accurate JITSymbolFlags.
-        R.back().emplace_back(ExecutorSymbolDef(ExecutorAddr::fromPtr(Addr),
-                                                JITSymbolFlags::Exported));
-    }
-  }
-
-  Complete(std::move(R));
 }
 
 Expected<int32_t>
@@ -165,6 +129,44 @@ SelfExecutorProcessControl::jitDispatchViaWrapperFunctionManager(
           shared::WrapperFunctionBuffer::copyFrom(Data, Size));
 
   return ResultF.get().release();
+}
+
+SelfExecutorProcessControl::InProcessDylibManager::InProcessDylibManager(
+    char GlobalManglingPrefix)
+    : GlobalManglingPrefix(GlobalManglingPrefix) {}
+
+Expected<tpctypes::DylibHandle>
+SelfExecutorProcessControl::InProcessDylibManager::loadDylib(
+    const char *DylibPath) {
+  std::string ErrMsg;
+  auto Dylib = sys::DynamicLibrary::getPermanentLibrary(DylibPath, &ErrMsg);
+  if (!Dylib.isValid())
+    return make_error<StringError>(std::move(ErrMsg), inconvertibleErrorCode());
+  return ExecutorAddr::fromPtr(Dylib.getOSSpecificHandle());
+}
+
+void SelfExecutorProcessControl::InProcessDylibManager::lookupSymbolsAsync(
+    ArrayRef<LookupRequest> Request,
+    DylibManager::SymbolLookupCompleteFn Complete) {
+  std::vector<tpctypes::LookupResult> R;
+
+  for (auto &Elem : Request) {
+    sys::DynamicLibrary Dylib(Elem.Handle.toPtr<void *>());
+    R.push_back(tpctypes::LookupResult());
+    for (auto &KV : Elem.Symbols) {
+      auto &Sym = KV.first;
+      std::string Tmp((*Sym).data() + !!GlobalManglingPrefix,
+                      (*Sym).size() - !!GlobalManglingPrefix);
+      void *Addr = Dylib.getAddressOfSymbol(Tmp.c_str());
+      if (!Addr && KV.second == SymbolLookupFlags::RequiredSymbol)
+        R.back().emplace_back();
+      else
+        // FIXME: determine accurate JITSymbolFlags.
+        R.back().emplace_back(ExecutorSymbolDef(ExecutorAddr::fromPtr(Addr),
+                                                JITSymbolFlags::Exported));
+    }
+  }
+  Complete(std::move(R));
 }
 
 } // namespace llvm::orc


### PR DESCRIPTION
SelfExecutorProcessControl no longer implements DylibManager. Instead a private inner class, InProcessDylibManager, is used to implement this interface. This change should not affect the behavior of SelfExecutorProcessControl from the perspective of API clients.

This is a step towards decoupling ExecutorProcessControl implementations from other interfaces.