### PR TITLE
[clang-tidy][NFC] Use mock header instead of #define NULL in tests

### DIFF
--- a/clang-tools-extra/test/clang-tidy/checkers/android/cloexec-accept.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/android/cloexec-accept.cpp
@@ -2,7 +2,7 @@
 
 struct sockaddr {};
 typedef int socklen_t;
-#define NULL 0
+#include <cstddef>
 
 extern "C" int accept(int sockfd, struct sockaddr *addr, socklen_t *addrlen);
 

--- a/clang-tools-extra/test/clang-tidy/checkers/android/cloexec-accept.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/android/cloexec-accept.cpp
@@ -1,8 +1,9 @@
 // RUN: %check_clang_tidy %s android-cloexec-accept %t
 
+#include <cstddef>
+
 struct sockaddr {};
 typedef int socklen_t;
-#include <cstddef>
 
 extern "C" int accept(int sockfd, struct sockaddr *addr, socklen_t *addrlen);
 

--- a/clang-tools-extra/test/clang-tidy/checkers/android/cloexec-accept4.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/android/cloexec-accept4.cpp
@@ -1,5 +1,7 @@
 // RUN: %check_clang_tidy %s android-cloexec-accept4 %t
 
+#include <cstddef>
+
 typedef int socklen_t;
 struct sockaddr {};
 
@@ -13,7 +15,6 @@ struct sockaddr {};
       _rc = (exp);              \
     } while (_rc == -1);        \
   })
-#include <cstddef>
 
 extern "C" int accept4(int sockfd, struct sockaddr *addr, socklen_t *addrlen, int flags);
 

--- a/clang-tools-extra/test/clang-tidy/checkers/android/cloexec-accept4.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/android/cloexec-accept4.cpp
@@ -13,7 +13,7 @@ struct sockaddr {};
       _rc = (exp);              \
     } while (_rc == -1);        \
   })
-#define NULL 0
+#include <cstddef>
 
 extern "C" int accept4(int sockfd, struct sockaddr *addr, socklen_t *addrlen, int flags);
 

--- a/clang-tools-extra/test/clang-tidy/checkers/android/cloexec-memfd-create.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/android/cloexec-memfd-create.cpp
@@ -1,5 +1,7 @@
 // RUN: %check_clang_tidy %s android-cloexec-memfd-create %t
 
+#include <cstddef>
+
 #define MFD_ALLOW_SEALING 1
 #define __O_CLOEXEC 3
 #define MFD_CLOEXEC __O_CLOEXEC
@@ -10,7 +12,6 @@
       _rc = (exp);              \
     } while (_rc == -1);        \
   })
-#include <cstddef>
 
 extern "C" int memfd_create(const char *name, unsigned int flags);
 

--- a/clang-tools-extra/test/clang-tidy/checkers/android/cloexec-memfd-create.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/android/cloexec-memfd-create.cpp
@@ -10,7 +10,7 @@
       _rc = (exp);              \
     } while (_rc == -1);        \
   })
-#define NULL 0
+#include <cstddef>
 
 extern "C" int memfd_create(const char *name, unsigned int flags);
 

--- a/clang-tools-extra/test/clang-tidy/checkers/android/cloexec-pipe2.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/android/cloexec-pipe2.cpp
@@ -10,7 +10,6 @@
       _rc = (exp);              \
     } while (_rc == -1);        \
   })
-#include <cstddef>
 
 extern "C" int pipe2(int pipefd[2], int flags);
 

--- a/clang-tools-extra/test/clang-tidy/checkers/android/cloexec-pipe2.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/android/cloexec-pipe2.cpp
@@ -10,7 +10,7 @@
       _rc = (exp);              \
     } while (_rc == -1);        \
   })
-#define NULL 0
+#include <cstddef>
 
 extern "C" int pipe2(int pipefd[2], int flags);
 

--- a/clang-tools-extra/test/clang-tidy/checkers/bugprone/posix-return.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/bugprone/posix-return.cpp
@@ -1,6 +1,7 @@
 // RUN: %check_clang_tidy %s bugprone-posix-return %t
 
 #include <cstddef>
+
 #define ZERO 0
 #define NEGATIVE_ONE -1
 

--- a/clang-tools-extra/test/clang-tidy/checkers/bugprone/posix-return.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/bugprone/posix-return.cpp
@@ -1,6 +1,6 @@
 // RUN: %check_clang_tidy %s bugprone-posix-return %t
 
-#define NULL nullptr
+#include <cstddef>
 #define ZERO 0
 #define NEGATIVE_ONE -1
 

--- a/clang-tools-extra/test/clang-tidy/checkers/bugprone/spuriously-wake-up-functions.c
+++ b/clang-tools-extra/test/clang-tidy/checkers/bugprone/spuriously-wake-up-functions.c
@@ -1,4 +1,5 @@
 // RUN: %check_clang_tidy %s bugprone-spuriously-wake-up-functions %t -- --
+
 #include <stddef.h>
 
 struct Node1 {

--- a/clang-tools-extra/test/clang-tidy/checkers/bugprone/spuriously-wake-up-functions.c
+++ b/clang-tools-extra/test/clang-tidy/checkers/bugprone/spuriously-wake-up-functions.c
@@ -1,5 +1,5 @@
 // RUN: %check_clang_tidy %s bugprone-spuriously-wake-up-functions %t -- --
-#define NULL 0
+#include <stddef.h>
 
 struct Node1 {
   void *Node1;

--- a/clang-tools-extra/test/clang-tidy/checkers/bugprone/spuriously-wake-up-functions.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/bugprone/spuriously-wake-up-functions.cpp
@@ -1,5 +1,5 @@
 // RUN: %check_clang_tidy %s bugprone-spuriously-wake-up-functions %t -- --
-#define NULL 0
+#include <cstddef>
 
 namespace std {
 using intmax_t = int;

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/redundant-void-arg.c
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/redundant-void-arg.c
@@ -3,7 +3,7 @@
 // RUN: clang-tidy %s -checks=-*,modernize-redundant-void-arg -- -std=c17 -Wno-strict-prototypes | count 0
 // RUN: %check_clang_tidy -std=c23-or-later -check-suffixes=C23 %s modernize-redundant-void-arg %t
 
-#define NULL 0
+#include <stddef.h>
 
 extern int i;
 

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/redundant-void-arg.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/redundant-void-arg.cpp
@@ -1,6 +1,6 @@
 // RUN: %check_clang_tidy %s modernize-redundant-void-arg %t
 
-#define NULL 0
+#include <cstddef>
 
 int foo();
 

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/use-nullptr-basic.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/use-nullptr-basic.cpp
@@ -1,7 +1,7 @@
 // RUN: %check_clang_tidy %s modernize-use-nullptr %t -- -- -fno-delayed-template-parsing
 
 const unsigned int g_null = 0;
-#define NULL 0
+#include <cstddef>
 
 void test_assignment() {
   int *p1 = 0;

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/use-nullptr-c23.c
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/use-nullptr-c23.c
@@ -1,6 +1,6 @@
 // RUN: %check_clang_tidy -std=c23-or-later %s modernize-use-nullptr %t
 
-#define NULL 0
+#include <stddef.h>
 
 void test_assignment() {
   int *p1 = 0;

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/use-nullptr.c
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/use-nullptr.c
@@ -3,7 +3,7 @@
 // Note: this test expects no diagnostics, but FileCheck cannot handle that,
 // hence the use of | count 0.
 
-#define NULL 0
+#include <stddef.h>
 void f(void) {
   char *str = NULL; // ok
   (void)str;

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/use-nullptr.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/use-nullptr.cpp
@@ -1,7 +1,7 @@
 // RUN: %check_clang_tidy %s modernize-use-nullptr %t -- \
 // RUN:   -config="{CheckOptions: {modernize-use-nullptr.NullMacros: 'MY_NULL,NULL'}}"
 
-#define NULL 0
+#include <cstddef>
 
 namespace std {
 

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/delete-null-pointer.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/delete-null-pointer.cpp
@@ -1,6 +1,6 @@
 // RUN: %check_clang_tidy %s readability-delete-null-pointer %t -- -- -fno-delayed-template-parsing
 
-#define NULL 0
+#include <cstddef>
 
 template <typename T>
 struct Templ {

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/implicit-bool-conversion.c
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/implicit-bool-conversion.c
@@ -4,8 +4,7 @@
 // RUN:         readability-implicit-bool-conversion.UseUpperCaseLiteralSuffix: true \
 // RUN:     }}'
 
-#undef NULL
-#define NULL 0L
+#include <stddef.h>
 
 void functionTakingBool(bool);
 void functionTakingInt(int);

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/implicit-bool-conversion.c
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/implicit-bool-conversion.c
@@ -1,5 +1,5 @@
-// RUN: %check_clang_tidy -std=c23-or-later %s readability-implicit-bool-conversion %t
-// RUN: %check_clang_tidy -std=c23-or-later -check-suffix=UPPER-CASE %s readability-implicit-bool-conversion %t -- \
+// RUN: %check_clang_tidy -std=c23-or-later %s readability-implicit-bool-conversion %t --system-headers
+// RUN: %check_clang_tidy -std=c23-or-later -check-suffix=UPPER-CASE %s readability-implicit-bool-conversion %t -- --system-headers \
 // RUN:     -config='{CheckOptions: { \
 // RUN:         readability-implicit-bool-conversion.UseUpperCaseLiteralSuffix: true \
 // RUN:     }}'

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/isolate-declaration.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/isolate-declaration.cpp
@@ -190,7 +190,7 @@ void forbidden_transformations() {
     ;
 }
 
-#define NULL 0
+#include <cstddef>
 #define MY_NICE_TYPE int **
 #define VAR_NAME(name) name##__LINE__
 #define A_BUNCH_OF_VARIABLES int m1 = 42, m2 = 43, m3 = 44;

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/isolate-declaration.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/isolate-declaration.cpp
@@ -1,5 +1,7 @@
 // RUN: %check_clang_tidy %s readability-isolate-declaration %t -- -- -fexceptions
 
+#include <cstddef>
+
 void f() {
   int i;
 }
@@ -190,7 +192,6 @@ void forbidden_transformations() {
     ;
 }
 
-#include <cstddef>
 #define MY_NICE_TYPE int **
 #define VAR_NAME(name) name##__LINE__
 #define A_BUNCH_OF_VARIABLES int m1 = 42, m2 = 43, m3 = 44;

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/redundant-smartptr-get-msvc.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/redundant-smartptr-get-msvc.cpp
@@ -1,6 +1,6 @@
 // RUN: %check_clang_tidy %s readability-redundant-smartptr-get %t
 
-#define NULL __null
+#include <cstddef>
 
 namespace std {
 

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/redundant-smartptr-get.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/redundant-smartptr-get.cpp
@@ -2,7 +2,7 @@
 #include <vector>
 #include <memory>
 
-#define NULL __null
+#include <cstddef>
 
 struct Bar {
   void Do();


### PR DESCRIPTION
Since stddef.h in the mock headers of clang-tidy tests now provides `#define NULL 0L`, we can migrate manual `#define NULL` in these tests to standard `#include`s.
