### PR TITLE
[clang] Adjust -pedantic-errors -WX/-Wno-error=X interaction (#184756)

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -572,6 +572,12 @@ Bug Fixes in This Version
   by diagnosing invalid comma-separated argument lists. (#GH166325)
 - Clang now treats enumeration constants of fixed-underlying enums as the enumerated type. (#GH172118)
 - Fixed a failed assertion in the preprocessor when ``__has_embed`` parameters are missing parentheses. (#GH175088)
+- Fixed the interaction between ``-pedantic-errors`` and ``-Wno-error=X``.
+  Previously, ``-Wno-error=X`` failed to downgrade ``-pedantic-errors``
+  diagnostics to warnings (e.g., ``-pedantic-errors -Wno-error=long-long``
+  still emitted an error for ``long long`` in C89 mode). Now ``-Wno-error=X``
+  correctly downgrades the diagnostic to a warning, matching GCC's behavior.
+  (#GH184250)
 
 Bug Fixes to Compiler Builtins
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/lib/Basic/DiagnosticIDs.cpp
+++ b/clang/lib/Basic/DiagnosticIDs.cpp
@@ -501,8 +501,13 @@ DiagnosticIDs::getDiagnosticSeverity(unsigned DiagID, SourceLocation Loc,
 
   // For extension diagnostics that haven't been explicitly mapped, check if we
   // should upgrade the diagnostic.
-  if (IsExtensionDiag && !Mapping.isUser())
-    Result = std::max(Result, State->ExtBehavior);
+  if (IsExtensionDiag && !Mapping.isUser()) {
+    if (Mapping.hasNoWarningAsError())
+      Result = std::max(Result,
+                        std::min(State->ExtBehavior, diag::Severity::Warning));
+    else
+      Result = std::max(Result, State->ExtBehavior);
+  }
 
   // At this point, ignored errors can no longer be upgraded.
   if (Result == diag::Severity::Ignored)

--- a/clang/test/Misc/diag-mapping.c
+++ b/clang/test/Misc/diag-mapping.c
@@ -18,11 +18,16 @@
 // This should emit an error with -pedantic-errors.
 // RUN: not %clang_cc1 %s -pedantic-errors 2>&1 | grep "error:"
 
+// RUN: %clang_cc1 %s -pedantic -Wno-error=extra-tokens 2>&1 | grep "warning:"
+
 // This should emit a warning, because -Wfoo overrides -pedantic*.
 // RUN: %clang_cc1 %s -pedantic-errors -Wextra-tokens 2>&1 | grep "warning:"
 
 // This should emit nothing, because -Wno-extra-tokens overrides -pedantic*
 // RUN: %clang_cc1 %s -pedantic-errors -Wno-extra-tokens 2>&1 | not grep diagnostic
+
+// -Wno-error=extra-tokens should downgrade -pedantic-errors to warning.
+// RUN: %clang_cc1 %s -pedantic-errors -Wno-error=extra-tokens 2>&1 | grep "warning:"
 
 #ifdef foo
 #endif bad // extension!


### PR DESCRIPTION
While -Wno-long-long suppresses -pedantic-errors diagnostics in both GCC and Clang, GCC -Wno-error=long-long emits warnings while Clang still emits errors.

```
% echo 'long long x = 0;' | gcc -std=c89 -pedantic-errors -Wno-error=long-long -x c -fsyntax-only -
<stdin>:1:6: warning: ISO C90 does not support 'long long' [-Wlong-long]
% echo 'long long x = 0;' | clang -std=c89 -pedantic-errors -Wno-error=long-long -x c -fsyntax-only -
<stdin>:1:1: error: 'long long' is an extension when C99 mode is not enabled [-Werror,-Wlong-long]
    1 | long long x = 0;
      | ^
1 error generated.
```

The order of -pedantic-errors and -Wno-error=long-long does not matter.

Two fixes to how extension diagnostics interact with -pedantic-errors in getDiagnosticSeverity():

1. -Wno-error=X now downgrades -pedantic-errors diagnostics to warnings. setDiagnosticGroupWarningAsError() sets HasNoWarningAsError but not IsUser, so the ExtBehavior upgrade would re-promote to error. When HasNoWarningAsError is set, cap the ExtBehavior upgrade at Warning.

2. -Wfoo no longer prevents -pedantic-errors from upgrading to error. Previously, -Wfoo set IsUser which blocked the ExtBehavior upgrade entirely. Now only -Wno-foo (IsUser + Ignored) blocks the upgrade, matching GCC behavior.

```
% echo 'long long x = 0;' | myclang -std=c89 -pedantic-errors -Wno-error=long-long -x c -fsyntax-only -
<stdin>:1:1: warning: 'long long' is an extension when C99 mode is not enabled [-Wlong-long]
    1 | long long x = 0;
      | ^
1 warning generated.
```

Fixes https://github.com/llvm/llvm-project/issues/184250