### PR TITLE
libclc: Update atanpi

### DIFF
--- a/libclc/clc/include/clc/math/clc_atan_helpers_decl.inc
+++ b/libclc/clc/include/clc/math/clc_atan_helpers_decl.inc
@@ -8,3 +8,6 @@
 
 _CLC_DECL _CLC_OVERLOAD _CLC_CONST __CLC_GENTYPE
 __clc_atan_reduced(__CLC_GENTYPE v);
+
+_CLC_DECL _CLC_OVERLOAD _CLC_CONST __CLC_GENTYPE
+__clc_atanpi_reduced(__CLC_GENTYPE v);

--- a/libclc/clc/lib/generic/math/clc_atan_helpers.inc
+++ b/libclc/clc/lib/generic/math/clc_atan_helpers.inc
@@ -20,6 +20,17 @@ __clc_atan_reduced(__CLC_FLOATN v) {
   return z;
 }
 
+_CLC_DEF _CLC_OVERLOAD _CLC_CONST __CLC_FLOATN
+__clc_atanpi_reduced(__CLC_FLOATN v) {
+  __CLC_GENTYPE t = v * v;
+  __CLC_GENTYPE z = __clc_mad(t, __clc_mad(t, __clc_mad(t, __clc_mad(t,
+            __clc_mad(t, __clc_mad(t, __clc_mad(t, __clc_mad(t,
+                0x1.ccf836p-11f, -0x1.4761e4p-8f), 0x1.b6662ep-7f), -0x1.8423b4p-6f),
+                0x1.149cb4p-5f), -0x1.721cccp-5f), 0x1.04a466p-4f), -0x1.b2981cp-4f),
+                0x1.45f306p-2f);
+  return v * z;
+}
+
 #elif __CLC_FPSIZE == 64
 
 _CLC_DEF _CLC_OVERLOAD _CLC_CONST __CLC_DOUBLEN
@@ -39,6 +50,23 @@ __clc_atan_reduced(__CLC_DOUBLEN v) {
   return z;
 }
 
+_CLC_DEF _CLC_OVERLOAD _CLC_CONST __CLC_DOUBLEN
+__clc_atanpi_reduced(__CLC_DOUBLEN v) {
+  __CLC_DOUBLEN t = v * v;
+  __CLC_DOUBLEN z = __clc_mad(t, __clc_mad(t, __clc_mad(t, __clc_mad(t,
+             __clc_mad(t, __clc_mad(t, __clc_mad(t, __clc_mad(t,
+             __clc_mad(t, __clc_mad(t, __clc_mad(t, __clc_mad(t,
+             __clc_mad(t, __clc_mad(t, __clc_mad(t, __clc_mad(t,
+             __clc_mad(t, __clc_mad(t, __clc_mad(t, __clc_mad(t,
+                 0x1.39e58b43320d2p-18, -0x1.be9e52f5df14fp-15), 0x1.2d7a6cad8e9dbp-12), -0x1.024ebcc10f8a6p-10),
+                 0x1.3df92946a87d8p-9), -0x1.2f04271b6cd94p-8), 0x1.d91b9a6908690p-8), -0x1.3e1c18f5ea692p-7),
+                 0x1.8253e53662be6p-7), -0x1.ba3db7e462112p-7), 0x1.ed7188505388cp-7), -0x1.121f707a5851bp-6),
+                 0x1.32b737d7f904ap-6), -0x1.5bac13378ea68p-6), 0x1.912af944c4411p-6), -0x1.da1babd44fccfp-6),
+                 0x1.21bb945aacd29p-5), -0x1.7483758f7040fp-5), 0x1.04c26be3b5934p-4), -0x1.b2995e7b7b74dp-4),
+                 0x1.45f306dc9c883p-2);
+  return v * z;
+}
+
 #elif __CLC_FPSIZE == 16
 
 _CLC_DEF _CLC_OVERLOAD _CLC_CONST __CLC_HALFN
@@ -48,6 +76,18 @@ __clc_atan_reduced(__CLC_HALFN v) {
       t, __clc_mad(t, __clc_mad(t, 0x1.938p-6h, -0x1.7f4p-4h), 0x1.7dcp-3h),
       -0x1.54p-2h);
   return __clc_mad(t, v * z, v);
+}
+
+_CLC_DEF _CLC_OVERLOAD _CLC_CONST __CLC_HALFN
+__clc_atanpi_reduced(__CLC_HALFN v) {
+  const __CLC_HALFN ch = 0x1.45cp-2h;
+  const __CLC_HALFN cl = 0x1.85cp-13h;
+  __CLC_HALFN t = v * v;
+  __CLC_HALFN y = __clc_mad(t, __clc_mad(t, __clc_mad(t, 0x1.f04p-8h, -0x1.dfp-6h), 0x1.e3p-5h), -0x1.b08p-4h);
+  __CLC_HALFN ph = v * ch;
+  __CLC_HALFN pl = __clc_mad(v, ch, -ph);
+  __CLC_HALFN r = __clc_mad(v, __clc_mad(t, y, cl), pl) + ph;
+  return r;
 }
 
 #endif

--- a/libclc/clc/lib/generic/math/clc_atanpi.cl
+++ b/libclc/clc/lib/generic/math/clc_atanpi.cl
@@ -6,14 +6,11 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "clc/clc_convert.h"
-#include "clc/float/definitions.h"
-#include "clc/internal/clc.h"
+#include "clc/math/clc_atan_helpers.h"
+#include "clc/math/clc_atanpi.h"
+#include "clc/math/clc_copysign.h"
 #include "clc/math/clc_fabs.h"
-#include "clc/math/clc_fma.h"
-#include "clc/math/clc_mad.h"
-#include "clc/math/math.h"
-#include "clc/relational/clc_isnan.h"
+#include "clc/math/clc_recip_fast.h"
 
 #define __CLC_BODY "clc_atanpi.inc"
 #include "clc/math/gentype.inc"

--- a/libclc/clc/lib/generic/math/clc_atanpi.inc
+++ b/libclc/clc/lib/generic/math/clc_atanpi.inc
@@ -8,16 +8,16 @@
 
 #if __CLC_FPSIZE == 32
 
-_CLC_OVERLOAD _CLC_DEF __CLC_GENTYPE __clc_atanpi(__CLC_GENTYPE x) {
-  __CLC_GENTYPE v = __clc_fabs(x);
+_CLC_OVERLOAD _CLC_DEF __CLC_FLOATN __clc_atanpi(__CLC_FLOATN x) {
+  __CLC_FLOATN v = __clc_fabs(x);
   __CLC_INTN g = v > 1.0f;
 
-  __CLC_GENTYPE vi = __clc_recip_fast(v);
+  __CLC_FLOATN vi = __clc_recip_fast(v);
   v = g ? vi : v;
 
-  __CLC_GENTYPE a = __clc_atanpi_reduced(v);
+  __CLC_FLOATN a = __clc_atanpi_reduced(v);
 
-  __CLC_GENTYPE y = 0.5f - a;
+  __CLC_FLOATN y = 0.5f - a;
   a = g ? y : a;
 
   return __clc_copysign(a, x);
@@ -25,14 +25,14 @@ _CLC_OVERLOAD _CLC_DEF __CLC_GENTYPE __clc_atanpi(__CLC_GENTYPE x) {
 
 #elif __CLC_FPSIZE == 64
 
-_CLC_OVERLOAD _CLC_DEF __CLC_GENTYPE __clc_atanpi(__CLC_GENTYPE x) {
-  __CLC_GENTYPE v = __clc_fabs(x);
+_CLC_OVERLOAD _CLC_DEF __CLC_DOUBLEN __clc_atanpi(__CLC_DOUBLEN x) {
+  __CLC_DOUBLEN v = __clc_fabs(x);
   __CLC_LONGN g = v > 1.0;
 
   v = g ? (1.0 / v) : v;
 
-  __CLC_GENTYPE a = __clc_atanpi_reduced(v);
-  __CLC_GENTYPE y = 0.5 - a;
+  __CLC_DOUBLEN a = __clc_atanpi_reduced(v);
+  __CLC_DOUBLEN y = 0.5 - a;
   a = g ? y : a;
 
   return __clc_copysign(a, x);
@@ -40,16 +40,16 @@ _CLC_OVERLOAD _CLC_DEF __CLC_GENTYPE __clc_atanpi(__CLC_GENTYPE x) {
 
 #elif __CLC_FPSIZE == 16
 
-_CLC_OVERLOAD _CLC_DEF __CLC_GENTYPE __clc_atanpi(__CLC_GENTYPE x) {
-  __CLC_GENTYPE v = __clc_fabs(x);
+_CLC_OVERLOAD _CLC_DEF __CLC_HALFN __clc_atanpi(__CLC_HALFN x) {
+  __CLC_HALFN v = __clc_fabs(x);
   __CLC_SHORTN g = v > 1.0h;
 
-  __CLC_GENTYPE vi = __clc_recip_fast(v);
+  __CLC_HALFN vi = __clc_recip_fast(v);
   v = g ? vi : v;
 
-  __CLC_GENTYPE a = __clc_atanpi_reduced(v);
+  __CLC_HALFN a = __clc_atanpi_reduced(v);
 
-  __CLC_GENTYPE y = 0.5h - a;
+  __CLC_HALFN y = 0.5h - a;
   a = g ? y : a;
 
   return __clc_copysign(a, x);

--- a/libclc/clc/lib/generic/math/clc_atanpi.inc
+++ b/libclc/clc/lib/generic/math/clc_atanpi.inc
@@ -9,164 +9,50 @@
 #if __CLC_FPSIZE == 32
 
 _CLC_OVERLOAD _CLC_DEF __CLC_GENTYPE __clc_atanpi(__CLC_GENTYPE x) {
-  const __CLC_GENTYPE pi = __CLC_FP_LIT(3.1415926535897932);
+  __CLC_GENTYPE v = __clc_fabs(x);
+  __CLC_INTN g = v > 1.0f;
 
-  __CLC_UINTN ux = __CLC_AS_UINTN(x);
-  __CLC_UINTN aux = ux & EXSIGNBIT_SP32;
-  __CLC_UINTN sx = ux ^ aux;
+  __CLC_GENTYPE vi = __clc_recip_fast(v);
+  v = g ? vi : v;
 
-  __CLC_GENTYPE xbypi = MATH_DIVIDE(x, pi);
-  __CLC_GENTYPE shalf =
-      __CLC_AS_GENTYPE(sx | __CLC_AS_UINTN(__CLC_FP_LIT(0.5)));
+  __CLC_GENTYPE a = __clc_atanpi_reduced(v);
 
-  __CLC_GENTYPE v = __CLC_AS_GENTYPE(aux);
+  __CLC_GENTYPE y = 0.5f - a;
+  a = g ? y : a;
 
-  // Return for NaN
-  __CLC_GENTYPE ret = x;
-
-  // 2^26 <= |x| <= Inf => atan(x) is close to piby2
-  ret = aux <= PINFBITPATT_SP32 ? shalf : ret;
-
-  // Reduce arguments 2^-19 <= |x| < 2^26
-
-  // 39/16 <= x < 2^26
-  x = -MATH_RECIP(v);
-  __CLC_GENTYPE c = 1.57079632679489655800f; // atan(infinity)
-
-  // 19/16 <= x < 39/16
-  __CLC_INTN l = aux < 0x401c0000;
-  __CLC_GENTYPE xx = MATH_DIVIDE(v - 1.5f, __clc_mad(v, 1.5f, 1.0f));
-  x = l ? xx : x;
-  c = l ? 9.82793723247329054082e-01f : c; // atan(1.5)
-
-  // 11/16 <= x < 19/16
-  l = aux < 0x3f980000U;
-  xx = MATH_DIVIDE(v - 1.0f, 1.0f + v);
-  x = l ? xx : x;
-  c = l ? 7.85398163397448278999e-01f : c; // atan(1)
-
-  // 7/16 <= x < 11/16
-  l = aux < 0x3f300000;
-  xx = MATH_DIVIDE(__clc_mad(v, 2.0f, -1.0f), 2.0f + v);
-  x = l ? xx : x;
-  c = l ? 4.63647609000806093515e-01f : c; // atan(0.5)
-
-  // 2^-19 <= x < 7/16
-  l = aux < 0x3ee00000;
-  x = l ? v : x;
-  c = l ? 0.0f : c;
-
-  // Core approximation: Remez(2,2) on [-7/16,7/16]
-
-  __CLC_GENTYPE s = x * x;
-  __CLC_GENTYPE a = __clc_mad(s,
-                              __clc_mad(s, 0.470677934286149214138357545549e-2f,
-                                        0.192324546402108583211697690500f),
-                              0.296528598819239217902158651186f);
-
-  __CLC_GENTYPE b = __clc_mad(s,
-                              __clc_mad(s, 0.299309699959659728404442796915f,
-                                        0.111072499995399550138837673349e1f),
-                              0.889585796862432286486651434570f);
-
-  __CLC_GENTYPE q = x * s * MATH_DIVIDE(a, b);
-
-  __CLC_GENTYPE z = c - (q - x);
-  z = MATH_DIVIDE(z, pi);
-  __CLC_GENTYPE zs = __CLC_AS_GENTYPE(sx | __CLC_AS_UINTN(z));
-
-  ret = aux < 0x4c800000 ? zs : ret;
-
-  // |x| < 2^-19
-  ret = aux < 0x36000000 ? xbypi : ret;
-  return ret;
+  return __clc_copysign(a, x);
 }
 
 #elif __CLC_FPSIZE == 64
 
 _CLC_OVERLOAD _CLC_DEF __CLC_GENTYPE __clc_atanpi(__CLC_GENTYPE x) {
-  const __CLC_GENTYPE pi = __CLC_FP_LIT(0x1.921fb54442d18p+1);
-
   __CLC_GENTYPE v = __clc_fabs(x);
+  __CLC_LONGN g = v > 1.0;
 
-  // 2^56 > v > 39/16
-  __CLC_GENTYPE a = -1.0;
-  __CLC_GENTYPE b = v;
-  // (chi + clo) = arctan(infinity)
-  __CLC_GENTYPE chi = 1.57079632679489655800e+00;
-  __CLC_GENTYPE clo = 6.12323399573676480327e-17;
+  v = g ? (1.0 / v) : v;
 
-  __CLC_GENTYPE ta = v - 1.5;
-  __CLC_GENTYPE tb = 1.0 + 1.5 * v;
-  __CLC_LONGN l = v <= 0x1.38p+1; // 39/16 > v > 19/16
-  a = l ? ta : a;
-  b = l ? tb : b;
-  // (chi + clo) = arctan(1.5)
-  chi = l ? 9.82793723247329054082e-01 : chi;
-  clo = l ? 1.39033110312309953701e-17 : clo;
+  __CLC_GENTYPE a = __clc_atanpi_reduced(v);
+  __CLC_GENTYPE y = 0.5 - a;
+  a = g ? y : a;
 
-  ta = v - 1.0;
-  tb = 1.0 + v;
-  l = v <= 0x1.3p+0; // 19/16 > v > 11/16
-  a = l ? ta : a;
-  b = l ? tb : b;
-  // (chi + clo) = arctan(1.)
-  chi = l ? 7.85398163397448278999e-01 : chi;
-  clo = l ? 3.06161699786838240164e-17 : clo;
-
-  ta = 2.0 * v - 1.0;
-  tb = 2.0 + v;
-  l = v <= 0x1.6p-1; // 11/16 > v > 7/16
-  a = l ? ta : a;
-  b = l ? tb : b;
-  // (chi + clo) = arctan(0.5)
-  chi = l ? 4.63647609000806093515e-01 : chi;
-  clo = l ? 2.26987774529616809294e-17 : clo;
-
-  l = v <= 0x1.cp-2; // v < 7/16
-  a = l ? v : a;
-  b = l ? 1.0 : b;
-  ;
-  chi = l ? 0.0 : chi;
-  clo = l ? 0.0 : clo;
-
-  // Core approximation: Remez(4,4) on [-7/16,7/16]
-  __CLC_GENTYPE r = a / b;
-  __CLC_GENTYPE s = r * r;
-  __CLC_GENTYPE qn =
-      __clc_fma(s,
-                __clc_fma(s,
-                          __clc_fma(s,
-                                    __clc_fma(s, 0.142316903342317766e-3,
-                                              0.304455919504853031e-1),
-                                    0.220638780716667420e0),
-                          0.447677206805497472e0),
-                0.268297920532545909e0);
-
-  __CLC_GENTYPE qd =
-      __clc_fma(s,
-                __clc_fma(s,
-                          __clc_fma(s,
-                                    __clc_fma(s, 0.389525873944742195e-1,
-                                              0.424602594203847109e0),
-                                    0.141254259931958921e1),
-                          0.182596787737507063e1),
-                0.804893761597637733e0);
-
-  __CLC_GENTYPE q = r * s * qn / qd;
-  r = (chi - ((q - clo) - r)) / pi;
-  __CLC_GENTYPE vp = v / pi;
-
-  __CLC_GENTYPE z = __clc_isnan(x) ? x : 0.5;
-  z = v <= 0x1.0p+56 ? r : z;
-  z = v < 0x1.0p-26 ? vp : z;
-  return x == v ? z : -z;
+  return __clc_copysign(a, x);
 }
 
 #elif __CLC_FPSIZE == 16
 
 _CLC_OVERLOAD _CLC_DEF __CLC_GENTYPE __clc_atanpi(__CLC_GENTYPE x) {
-  return __CLC_CONVERT_GENTYPE(__clc_atanpi(__CLC_CONVERT_FLOATN(x)));
+  __CLC_GENTYPE v = __clc_fabs(x);
+  __CLC_SHORTN g = v > 1.0h;
+
+  __CLC_GENTYPE vi = __clc_recip_fast(v);
+  v = g ? vi : v;
+
+  __CLC_GENTYPE a = __clc_atanpi_reduced(v);
+
+  __CLC_GENTYPE y = 0.5h - a;
+  a = g ? y : a;
+
+  return __clc_copysign(a, x);
 }
 
 #endif


### PR DESCRIPTION
This was originally ported from rocm device libs in
03dc366e79cd01afe0bbfad2a7ede3087d6c9356. Merge in more
recent changes.