### PR TITLE
[libc++][AIX] Marking the tests UNSUPPORTED as the current implementation of fopen w+bx overrides ios::noreplace

### DIFF
--- a/libcxx/test/std/input.output/file.streams/fstreams/filebuf.members/open_pointer.pass.cpp
+++ b/libcxx/test/std/input.output/file.streams/fstreams/filebuf.members/open_pointer.pass.cpp
@@ -13,7 +13,8 @@
 // In C++23 and later, this test requires support for P2467R1 in the dylib (a3f17ba3febbd546f2342ffc780ac93b694fdc8d)
 // XFAIL: (!c++03 && !c++11 && !c++14 && !c++17 && !c++20) && using-built-library-before-llvm-18
 
-// XFAIL: LIBCXX-AIX-FIXME
+// fopen() with "w+bx" mode ignores the 'x' (exclusive) flag, allowing existing files to be opened and truncated, breaking C++23 ios_base::noreplace functionality.
+// UNSUPPORTED: target={{.*}}-aix{{.*}}
 
 #include <fstream>
 #include <cassert>

--- a/libcxx/test/std/input.output/file.streams/fstreams/fstream.cons/pointer.pass.cpp
+++ b/libcxx/test/std/input.output/file.streams/fstreams/fstream.cons/pointer.pass.cpp
@@ -16,7 +16,8 @@
 // In C++23 and later, this test requires support for P2467R1 in the dylib (a3f17ba3febbd546f2342ffc780ac93b694fdc8d)
 // XFAIL: (!c++03 && !c++11 && !c++14 && !c++17 && !c++20) && using-built-library-before-llvm-18
 
-// XFAIL: LIBCXX-AIX-FIXME
+// fopen() with "w+bx" mode ignores the 'x' (exclusive) flag, allowing existing files to be opened and truncated, breaking C++23 ios_base::noreplace functionality.
+// UNSUPPORTED: target={{.*}}-aix{{.*}}
 
 #include <fstream>
 #include <cassert>

--- a/libcxx/test/std/input.output/file.streams/fstreams/fstream.members/open_pointer.pass.cpp
+++ b/libcxx/test/std/input.output/file.streams/fstreams/fstream.members/open_pointer.pass.cpp
@@ -16,7 +16,8 @@
 // In C++23 and later, this test requires support for P2467R1 in the dylib (a3f17ba3febbd546f2342ffc780ac93b694fdc8d)
 // XFAIL: (!c++03 && !c++11 && !c++14 && !c++17 && !c++20) && using-built-library-before-llvm-18
 
-// XFAIL: LIBCXX-AIX-FIXME
+// fopen() with "w+bx" mode ignores the 'x' (exclusive) flag, allowing existing files to be opened and truncated, breaking C++23 ios_base::noreplace functionality.
+// UNSUPPORTED: target={{.*}}-aix{{.*}}
 
 #include <fstream>
 #include <cassert>

--- a/libcxx/test/std/input.output/file.streams/fstreams/ofstream.cons/pointer.pass.cpp
+++ b/libcxx/test/std/input.output/file.streams/fstreams/ofstream.cons/pointer.pass.cpp
@@ -16,7 +16,8 @@
 // In C++23 and later, this test requires support for P2467R1 in the dylib (a3f17ba3febbd546f2342ffc780ac93b694fdc8d)
 // XFAIL: (!c++03 && !c++11 && !c++14 && !c++17 && !c++20) && using-built-library-before-llvm-18
 
-// XFAIL: LIBCXX-AIX-FIXME
+// fopen() with "w+bx" mode ignores the 'x' (exclusive) flag, allowing existing files to be opened and truncated, breaking C++23 ios_base::noreplace functionality.
+// UNSUPPORTED: target={{.*}}-aix{{.*}}
 
 #include <fstream>
 #include <cassert>

--- a/libcxx/test/std/input.output/file.streams/fstreams/ofstream.members/open_pointer.pass.cpp
+++ b/libcxx/test/std/input.output/file.streams/fstreams/ofstream.members/open_pointer.pass.cpp
@@ -16,7 +16,8 @@
 // In C++23 and later, this test requires support for P2467R1 in the dylib (a3f17ba3febbd546f2342ffc780ac93b694fdc8d)
 // XFAIL: (!c++03 && !c++11 && !c++14 && !c++17 && !c++20) && using-built-library-before-llvm-18
 
-// XFAIL: LIBCXX-AIX-FIXME
+// fopen() with "w+bx" mode ignores the 'x' (exclusive) flag, allowing existing files to be opened and truncated, breaking C++23 ios_base::noreplace functionality.
+// UNSUPPORTED: target={{.*}}-aix{{.*}}
 
 #include <fstream>
 #include <cassert>


### PR DESCRIPTION
Mode below fails due to `w+bx` overriding the `ios::noreplace`, which clearly states the file should not be opened if it already exists. This is being disregarded causing assertion failure.
```
std::ios_base::in | std::ios_base::out | std::ios_base::trunc | std::ios_base::noreplace |
                std::ios_base::binary,
```