### PR TITLE
[NFC][llvm-symbolizer]Replace makeStringError helper with createStringError

### DIFF
--- a/llvm/tools/llvm-symbolizer/llvm-symbolizer.cpp
+++ b/llvm/tools/llvm-symbolizer/llvm-symbolizer.cpp
@@ -153,10 +153,6 @@ static StringRef getSpaceDelimitedWord(StringRef &Source) {
   return Result;
 }
 
-static Error makeStringError(StringRef Msg) {
-  return make_error<StringError>(Msg, inconvertibleErrorCode());
-}
-
 static Error parseCommand(StringRef BinaryName, bool IsAddr2Line,
                           StringRef InputString, Command &Cmd,
                           std::string &ModuleName, object::BuildID &BuildID,
@@ -180,13 +176,13 @@ static Error parseCommand(StringRef BinaryName, bool IsAddr2Line,
     InputString = InputString.ltrim();
     if (InputString.consume_front("FILE:")) {
       if (HasFilePrefix || HasBuildIDPrefix)
-        return makeStringError("duplicate input file specification prefix");
+        return createStringError("duplicate input file specification prefix");
       HasFilePrefix = true;
       continue;
     }
     if (InputString.consume_front("BUILDID:")) {
       if (HasBuildIDPrefix || HasFilePrefix)
-        return makeStringError("duplicate input file specification prefix");
+        return createStringError("duplicate input file specification prefix");
       HasBuildIDPrefix = true;
       continue;
     }
@@ -199,21 +195,21 @@ static Error parseCommand(StringRef BinaryName, bool IsAddr2Line,
     InputString = InputString.ltrim();
     if (InputString.empty()) {
       if (HasFilePrefix)
-        return makeStringError("must be followed by an input file");
+        return createStringError("must be followed by an input file");
       else
-        return makeStringError("must be followed by a hash");
+        return createStringError("must be followed by a hash");
     }
 
     if (!BinaryName.empty() || !BuildID.empty())
-      return makeStringError("input file has already been specified");
+      return createStringError("input file has already been specified");
 
     StringRef Name = getSpaceDelimitedWord(InputString);
     if (Name.empty())
-      return makeStringError("unbalanced quotes in input file name");
+      return createStringError("unbalanced quotes in input file name");
     if (HasBuildIDPrefix) {
       BuildID = parseBuildID(Name);
       if (BuildID.empty())
-        return makeStringError("wrong format of build-id");
+        return createStringError("wrong format of build-id");
     } else {
       ModuleName = Name;
     }
@@ -222,14 +218,14 @@ static Error parseCommand(StringRef BinaryName, bool IsAddr2Line,
     // two items, assume that the first item is a file name.
     ModuleName = getSpaceDelimitedWord(InputString);
     if (ModuleName.empty())
-      return makeStringError("no input filename has been specified");
+      return createStringError("no input filename has been specified");
   }
 
   // Parse address specification, which can be an offset in module or a
   // symbol with optional offset.
   InputString = InputString.trim();
   if (InputString.empty())
-    return makeStringError("no module offset has been specified");
+    return createStringError("no module offset has been specified");
 
   // If input string contains a space, ignore everything after it. This behavior
   // is consistent with GNU addr2line.
@@ -255,7 +251,7 @@ static Error parseCommand(StringRef BinaryName, bool IsAddr2Line,
   // If address specification starts with a digit, but is not a number, consider
   // it as invalid.
   if (StartsWithDigit || AddrSpec.empty())
-    return makeStringError("expected a number as module offset");
+    return createStringError("expected a number as module offset");
 
   // Otherwise it is a symbol name, potentially with an offset.
   Symbol = AddrSpec;


### PR DESCRIPTION
The local `makeStringError` helper in `llvm-symbolizer.cpp` is equivalent to `createStringError` from `llvm/Support/Error.h`. Remove it and use `createStringError` directly at all call sites.
