### PR TITLE
[AMDGPU] DPP insns cannot use SGPR for src1 on gfx11

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPU.td
+++ b/llvm/lib/Target/AMDGPU/AMDGPU.td
@@ -2652,6 +2652,12 @@ def NeedsAlignedVGPRs : Predicate<"Subtarget->needsAlignedVGPRs()">,
 def NotNeedsAlignedVGPRs : Predicate<"!Subtarget->needsAlignedVGPRs()">,
                       AssemblerPredicate<(all_of (not FeatureRequiresAlignedVGPRs))>;
 
+def HasDPPSrc1SGPR : Predicate<"Subtarget->hasDPPSrc1SGPR()">,
+                      AssemblerPredicate<(all_of FeatureDPPSrc1SGPR)>;
+
+def NotHasDPPSrc1SGPR : Predicate<"!Subtarget->hasDPPSrc1SGPR()">,
+                      AssemblerPredicate<(all_of (not FeatureDPPSrc1SGPR))>;
+
 def isWave32 : Predicate<"Subtarget->isWave32()">,
   AssemblerPredicate <(any_of FeatureWavefrontSize32,
                               FeatureAssemblerPermissiveWavesize)>;
@@ -2669,15 +2675,20 @@ def isWave64Strict : Predicate<"Subtarget->isWave64()">,
 //===----------------------------------------------------------------------===//
 
 defvar DefaultMode_Wave64 = DefaultMode;
-defvar DefaultMode_Wave32 = HwMode<[isWave32, NotNeedsAlignedVGPRs]>;
+
+defvar DefaultMode_Wave32_HasDPPSrc1SGPR = HwMode<[isWave32, NotNeedsAlignedVGPRs, HasDPPSrc1SGPR]>;
+defvar DefaultMode_Wave32_NotHasDPPSrc1SGPR = HwMode<[isWave32, NotNeedsAlignedVGPRs, NotHasDPPSrc1SGPR]>;
 
 // gfx90a-gfx950. Has AGPRs, and also the align2 VGPR/AGPR requirement. Implied
 // wave64.
-def AVAlign2LoadStoreMode : HwMode<[HasMAIInsts, NeedsAlignedVGPRs]>;
+def AVAlign2LoadStoreMode_HasDPPSrc1SGPR    : HwMode<[HasMAIInsts, NeedsAlignedVGPRs, HasDPPSrc1SGPR]>;
+def AVAlign2LoadStoreMode_NotHasDPPSrc1SGPR : HwMode<[HasMAIInsts, NeedsAlignedVGPRs, NotHasDPPSrc1SGPR]>;
 
 // gfx1250, has alignment requirement but no AGPRs.
-def AlignedVGPRNoAGPRMode_Wave32 : HwMode<[NotHasMAIInsts, NeedsAlignedVGPRs, isWave32Strict]>;
-def AlignedVGPRNoAGPRMode_Wave64 : HwMode<[NotHasMAIInsts, NeedsAlignedVGPRs, isWave64Strict]>;
+def AlignedVGPRNoAGPRMode_Wave32_HasDPPSrc1SGPR    : HwMode<[NotHasMAIInsts, NeedsAlignedVGPRs, isWave32Strict, HasDPPSrc1SGPR]>;
+def AlignedVGPRNoAGPRMode_Wave32_NotHasDPPSrc1SGPR : HwMode<[NotHasMAIInsts, NeedsAlignedVGPRs, isWave32Strict, NotHasDPPSrc1SGPR]>;
+def AlignedVGPRNoAGPRMode_Wave64_HasDPPSrc1SGPR    : HwMode<[NotHasMAIInsts, NeedsAlignedVGPRs, isWave64Strict, HasDPPSrc1SGPR]>;
+def AlignedVGPRNoAGPRMode_Wave64_NotHasDPPSrc1SGPR : HwMode<[NotHasMAIInsts, NeedsAlignedVGPRs, isWave64Strict, NotHasDPPSrc1SGPR]>;
 
 // FIXME: This should be able to only define a separate hwmode that
 // only depends on wavesize for just ValueTypes. These use different
@@ -2685,10 +2696,14 @@ def AlignedVGPRNoAGPRMode_Wave64 : HwMode<[NotHasMAIInsts, NeedsAlignedVGPRs, is
 // for RegClassByHwMode, tablegen crashes for some reason
 def WaveSizeVT : ValueTypeByHwMode<[
   DefaultMode_Wave64,
-  AVAlign2LoadStoreMode,
-  AlignedVGPRNoAGPRMode_Wave64,
-  DefaultMode_Wave32,
-  AlignedVGPRNoAGPRMode_Wave32], [i64, i64, i64, i32, i32]>;
+  AVAlign2LoadStoreMode_HasDPPSrc1SGPR,
+  AVAlign2LoadStoreMode_NotHasDPPSrc1SGPR,
+  AlignedVGPRNoAGPRMode_Wave64_HasDPPSrc1SGPR,
+  AlignedVGPRNoAGPRMode_Wave64_NotHasDPPSrc1SGPR,
+  DefaultMode_Wave32_HasDPPSrc1SGPR,
+  DefaultMode_Wave32_NotHasDPPSrc1SGPR,
+  AlignedVGPRNoAGPRMode_Wave32_HasDPPSrc1SGPR,
+  AlignedVGPRNoAGPRMode_Wave32_NotHasDPPSrc1SGPR], [i64, i64, i64, i64, i64, i32, i32, i32, i32]>;
 
 
 // Include AMDGPU TD files

--- a/llvm/lib/Target/AMDGPU/AsmParser/AMDGPUAsmParser.cpp
+++ b/llvm/lib/Target/AMDGPU/AsmParser/AMDGPUAsmParser.cpp
@@ -526,6 +526,38 @@ public:
            isLiteralImm(MVT::i32) || isExpr();
   }
 
+  bool isVHSrc_b16() const {
+    return isRegOrInlineNoMods(AMDGPU::VS_32RegClassID, MVT::i32);
+  }
+
+  bool isVHSrc_bf16() const {
+    return isRegOrInlineNoMods(AMDGPU::VS_32RegClassID, MVT::i32);
+  }
+
+  bool isVHSrc_f16() const {
+    return isRegOrInlineNoMods(AMDGPU::VS_32RegClassID, MVT::i32);
+  }
+
+  bool isVHSrc_b32() const {
+    return isRegOrInlineNoMods(AMDGPU::VS_32RegClassID, MVT::i32);
+  }
+
+  bool isVHSrc_f32() const {
+    return isRegOrInlineNoMods(AMDGPU::VS_32RegClassID, MVT::i32);
+  }
+
+  bool isVHSrc_v2b16() const {
+    return isRegOrInlineNoMods(AMDGPU::VS_32RegClassID, MVT::i32);
+  }
+
+  bool isVHSrc_v2bf16() const {
+    return isRegOrInlineNoMods(AMDGPU::VS_32RegClassID, MVT::i32);
+  }
+
+  bool isVHSrc_v2f16() const {
+    return isRegOrInlineNoMods(AMDGPU::VS_32RegClassID, MVT::i32);
+  }
+
   bool isVCSrc_b32() const {
     return isRegOrInlineNoMods(AMDGPU::VS_32RegClassID, MVT::i32);
   }

--- a/llvm/lib/Target/AMDGPU/GCNDPPCombine.cpp
+++ b/llvm/lib/Target/AMDGPU/GCNDPPCombine.cpp
@@ -308,9 +308,6 @@ MachineInstr *GCNDPPCombine::createDPPInst(MachineInstr &OrigMI,
     if (Src1) {
       assert(AMDGPU::hasNamedOperand(DPPOp, AMDGPU::OpName::src1) &&
              "dpp version of instruction missing src1");
-      // If subtarget does not support SGPRs for src1 operand then the
-      // requirements are the same as for src0. We check src0 instead because
-      // pseudos are shared between subtargets and allow SGPR for src1 on all.
       if (!ST->hasDPPSrc1SGPR()) {
         assert(TII->getOpSize(*DPPInst, Src0Idx) ==
                    TII->getOpSize(*DPPInst, NumOperands) &&
@@ -437,6 +434,16 @@ MachineInstr *GCNDPPCombine::createDPPInst(MachineInstr &OrigMI,
     DPPInst.getInstr()->eraseFromParent();
     return nullptr;
   }
+
+  if (!ST->hasDPPSrc1SGPR()) {
+    auto *Src1 =
+        TII->getNamedOperand(*DPPInst.getInstr(), AMDGPU::OpName::src1);
+    assert((!Src1 || !Src1->isReg() ||
+            !ST->getRegisterInfo()->isSGPRClass(
+                MRI->getRegClass(Src1->getReg()))) &&
+           "Src1 in a DPP instruction must not be a SGPR for this target");
+  }
+
   LLVM_DEBUG(dbgs() << "  combined:  " << *DPPInst.getInstr());
   return DPPInst.getInstr();
 }

--- a/llvm/lib/Target/AMDGPU/SIInstrInfo.td
+++ b/llvm/lib/Target/AMDGPU/SIInstrInfo.td
@@ -2016,6 +2016,27 @@ class getVOP3DPPSrcForVT<ValueType VT, bit IsFake16 = 1> {
         1               : VCSrc_b32);
 }
 
+// Like getVOP3DPPSrcForVT but use VHSrc* to conditionally
+// allow SGPR based on HwMode.
+
+class getVOP3DPPSrc1ForVT<ValueType VT, bit IsFake16 = 1> {
+
+  assert !ne(VT, i1), "DPP SRC1 cannot be 1-bit";
+
+  RegisterOperand ret =
+  !cond(!eq(VT, i16)    : !if (IsFake16, VHSrc_b16, VCSrcT_b16),
+        !eq(VT, i64)    : VCSrc_b64,
+        !eq(VT, f16)    : !if (IsFake16, VHSrc_f16, VCSrcT_f16),
+        !eq(VT, bf16)   : !if (IsFake16, VHSrc_bf16, VCSrcT_bf16),
+        !eq(VT, v2i16)  : VHSrc_v2b16,
+        !eq(VT, v2f16)  : VHSrc_v2f16,
+        !eq(VT, v2bf16) : VHSrc_v2bf16,
+        !eq(VT, f32)    : VHSrc_f32,
+        !eq(VT, f64)    : VCSrc_f64,
+        !eq(VT, v2i32)  : VCSrc_v2b32,
+        1               : VHSrc_b32);
+}
+
 // Float or packed int
 class isModifierType<ValueType SrcVT> {
   bit ret = !or(!eq(SrcVT, f16),
@@ -2757,7 +2778,7 @@ class VOPProfile <list<ValueType> _ArgVT, bit _EnableClamp = 0> {
   field RegisterOperand Src1DPP = getVregSrcForVT<Src1VT>.ret;
   field RegisterOperand Src2DPP = getVregSrcForVT<Src2VT>.ret;
   field RegisterOperand Src0VOP3DPP = getVGPRSrcForVT<Src0VT>.ret;
-  field RegisterOperand Src1VOP3DPP = getVOP3DPPSrcForVT<Src1VT>.ret;
+  field RegisterOperand Src1VOP3DPP = getVOP3DPPSrc1ForVT<Src1VT>.ret;
   field RegisterOperand Src2VOP3DPP = getVOP3DPPSrcForVT<Src2VT>.ret;
   field RegisterOperand Src0SDWA = getSDWASrcForVT<Src0VT>.ret;
   field RegisterOperand Src1SDWA = getSDWASrcForVT<Src0VT>.ret;
@@ -2973,7 +2994,7 @@ class VOPProfile_True16<VOPProfile P> : VOPProfile<P.ArgVT> {
   let Src1ModDPP = getSrcModDPP_t16<Src1VT, 0 /*IsFake16*/>.ret;
   let Src2ModDPP = getSrcModDPP_t16<Src2VT, 0 /*IsFake16*/>.ret;
   let Src0VOP3DPP = !if (!eq(Src0VT.Size, 16), VGPROp_16, VGPROp_32);
-  let Src1VOP3DPP = getVOP3DPPSrcForVT<Src1VT, 0 /*IsFake16*/>.ret;
+  let Src1VOP3DPP = getVOP3DPPSrc1ForVT<Src1VT, 0 /*IsFake16*/>.ret;
   let Src2VOP3DPP = getVOP3DPPSrcForVT<Src2VT, 0 /*IsFake16*/>.ret;
   let Src0ModVOP3DPP = getSrc0ModVOP3DPP<Src0VT, DstVT, 0/*IsFake16*/>.ret;
   let Src1ModVOP3DPP = getSrcModVOP3VC<Src1VT, 0 /*IsFake16*/>.ret;
@@ -3003,7 +3024,7 @@ class VOPProfile_Fake16<VOPProfile P> : VOPProfile<P.ArgVT> {
   let Src0Mod = getSrc0Mod<Src0VT, DstVT, 1/*IsTrue16*/, 1/*IsFake16*/>.ret;
   let Src1Mod = getSrcMod<Src1VT, 1 /*IsTrue16*/, 1/*IsFake16*/>.ret;
   let Src2Mod = getSrcMod<Src2VT, 1 /*IsTrue16*/, 1/*IsFake16*/>.ret;
-  let Src1VOP3DPP = getVOP3DPPSrcForVT<Src1VT, 1 /*IsFake16*/>.ret;
+  let Src1VOP3DPP = getVOP3DPPSrc1ForVT<Src1VT, 1 /*IsFake16*/>.ret;
   let Src2VOP3DPP = getVOP3DPPSrcForVT<Src2VT, 1 /*IsFake16*/>.ret;
   let Src0ModVOP3DPP = getSrc0ModVOP3DPP<Src0VT, DstVT, 1/*IsFake16*/>.ret;
   let Src1ModVOP3DPP = getSrcModVOP3VC<Src1VT, 1 /*IsFake16*/>.ret;

--- a/llvm/lib/Target/AMDGPU/SIRegisterInfo.td
+++ b/llvm/lib/Target/AMDGPU/SIRegisterInfo.td
@@ -1194,27 +1194,43 @@ defm AV_1024 : AVRegClass<32, VReg_1024.RegTypes, (add VGPR_1024), (add AGPR_102
 def SReg_1_XEXEC : SIRegisterClassLike<0, false, false, true>,
   RegClassByHwMode<
     [DefaultMode_Wave64,
-     AlignedVGPRNoAGPRMode_Wave64,
-     AVAlign2LoadStoreMode,
-     DefaultMode_Wave32,
-     AlignedVGPRNoAGPRMode_Wave32],
+     AlignedVGPRNoAGPRMode_Wave64_HasDPPSrc1SGPR,
+     AlignedVGPRNoAGPRMode_Wave64_NotHasDPPSrc1SGPR,
+     AVAlign2LoadStoreMode_HasDPPSrc1SGPR,
+     AVAlign2LoadStoreMode_NotHasDPPSrc1SGPR,
+     DefaultMode_Wave32_HasDPPSrc1SGPR,
+     DefaultMode_Wave32_NotHasDPPSrc1SGPR,
+     AlignedVGPRNoAGPRMode_Wave32_HasDPPSrc1SGPR,
+     AlignedVGPRNoAGPRMode_Wave32_NotHasDPPSrc1SGPR],
     [SReg_64_XEXEC,
      SReg_64_XEXEC,
      SReg_64_XEXEC,
+     SReg_64_XEXEC,
+     SReg_64_XEXEC,
      SReg_32_XM0_XEXEC, // FIXME: Why do the wave32 cases exclude m0?
+     SReg_32_XM0_XEXEC, // FIXME: Why do the wave32 cases exclude m0?
+     SReg_32_XM0_XEXEC,
      SReg_32_XM0_XEXEC]
 >;
 
 def SReg_1 : SIRegisterClassLike<0, false, false, true>,
   RegClassByHwMode<
     [DefaultMode_Wave64,
-     AlignedVGPRNoAGPRMode_Wave64,
-     AVAlign2LoadStoreMode,
-     DefaultMode_Wave32,
-     AlignedVGPRNoAGPRMode_Wave32],
+     AlignedVGPRNoAGPRMode_Wave64_HasDPPSrc1SGPR,
+     AlignedVGPRNoAGPRMode_Wave64_NotHasDPPSrc1SGPR,
+     AVAlign2LoadStoreMode_HasDPPSrc1SGPR,
+     AVAlign2LoadStoreMode_NotHasDPPSrc1SGPR,
+     DefaultMode_Wave32_HasDPPSrc1SGPR,
+     DefaultMode_Wave32_NotHasDPPSrc1SGPR,
+     AlignedVGPRNoAGPRMode_Wave32_HasDPPSrc1SGPR,
+     AlignedVGPRNoAGPRMode_Wave32_NotHasDPPSrc1SGPR],
     [SReg_64,
      SReg_64,
      SReg_64,
+     SReg_64,
+     SReg_64,
+     SReg_32,
+     SReg_32,
      SReg_32,
      SReg_32]
 >;
@@ -1232,13 +1248,21 @@ def SReg_1 : SIRegisterClassLike<0, false, false, true>,
 
 def AV_LdSt_32_Target : RegClassByHwMode<
     [DefaultMode_Wave64,
-     DefaultMode_Wave32,
-     AVAlign2LoadStoreMode,
-     AlignedVGPRNoAGPRMode_Wave64,
-     AlignedVGPRNoAGPRMode_Wave32],
+     DefaultMode_Wave32_HasDPPSrc1SGPR,
+     DefaultMode_Wave32_NotHasDPPSrc1SGPR,
+     AVAlign2LoadStoreMode_HasDPPSrc1SGPR,
+     AVAlign2LoadStoreMode_NotHasDPPSrc1SGPR,
+     AlignedVGPRNoAGPRMode_Wave64_HasDPPSrc1SGPR,
+     AlignedVGPRNoAGPRMode_Wave64_NotHasDPPSrc1SGPR,
+     AlignedVGPRNoAGPRMode_Wave32_HasDPPSrc1SGPR,
+     AlignedVGPRNoAGPRMode_Wave32_NotHasDPPSrc1SGPR],
     [VGPR_32,
      VGPR_32,
+     VGPR_32,
      AV_32,
+     AV_32,
+     VGPR_32,
+     VGPR_32,
      VGPR_32,
      VGPR_32]>,
     SIRegisterClassLike<32, true, true> {
@@ -1249,12 +1273,20 @@ foreach RegSize = [ 64, 96, 128, 160, 192, 224, 256, 288, 320, 352, 384, 512, 10
   def VReg_#RegSize#_AlignTarget : SIRegisterClassLike<RegSize, true>,
     RegClassByHwMode<
       [DefaultMode_Wave64,
-       DefaultMode_Wave32,
-       AVAlign2LoadStoreMode,
-       AlignedVGPRNoAGPRMode_Wave64,
-       AlignedVGPRNoAGPRMode_Wave32],
+       DefaultMode_Wave32_HasDPPSrc1SGPR,
+       DefaultMode_Wave32_NotHasDPPSrc1SGPR,
+       AVAlign2LoadStoreMode_HasDPPSrc1SGPR,
+       AVAlign2LoadStoreMode_NotHasDPPSrc1SGPR,
+       AlignedVGPRNoAGPRMode_Wave64_HasDPPSrc1SGPR,
+       AlignedVGPRNoAGPRMode_Wave64_NotHasDPPSrc1SGPR,
+       AlignedVGPRNoAGPRMode_Wave32_HasDPPSrc1SGPR,
+       AlignedVGPRNoAGPRMode_Wave32_NotHasDPPSrc1SGPR],
       [!cast<RegisterClass>("VReg_"#RegSize),
        !cast<RegisterClass>("VReg_"#RegSize),
+       !cast<RegisterClass>("VReg_"#RegSize),
+       !cast<RegisterClass>("VReg_"#RegSize#_Align2),
+       !cast<RegisterClass>("VReg_"#RegSize#_Align2),
+       !cast<RegisterClass>("VReg_"#RegSize#_Align2),
        !cast<RegisterClass>("VReg_"#RegSize#_Align2),
        !cast<RegisterClass>("VReg_"#RegSize#_Align2),
        !cast<RegisterClass>("VReg_"#RegSize#_Align2)]> {
@@ -1263,25 +1295,33 @@ foreach RegSize = [ 64, 96, 128, 160, 192, 224, 256, 288, 320, 352, 384, 512, 10
 
   def AReg_#RegSize#_AlignTarget : SIRegisterClassLike<RegSize, false, true>,
     RegClassByHwMode<
-      [DefaultMode_Wave64, /*unused combination*/ AVAlign2LoadStoreMode, /*Unused combination*/ /*Unused combination*/],
+      [DefaultMode_Wave64,
+       /*unused combination*/ AVAlign2LoadStoreMode_HasDPPSrc1SGPR,
+       AVAlign2LoadStoreMode_NotHasDPPSrc1SGPR],
       [!cast<RegisterClass>("AReg_"#RegSize),
-       /*unused combination*/
-       !cast<RegisterClass>("AReg_"#RegSize#_Align2)
-       /*Unused combination*/
-       /*Unused combination*/]> {
+       /*unused combination*/ !cast<RegisterClass>("AReg_"#RegSize#_Align2),
+       /*unused combination*/ !cast<RegisterClass>("AReg_"#RegSize#_Align2)]> {
      let DecoderMethod = "DecodeAReg_"#RegSize#"RegisterClass";
    }
 
   def AV_#RegSize#_AlignTarget : SIRegisterClassLike<RegSize, true, true>,
     RegClassByHwMode<
-      [DefaultMode_Wave32,
+      [DefaultMode_Wave32_HasDPPSrc1SGPR,
+       DefaultMode_Wave32_NotHasDPPSrc1SGPR,
        DefaultMode_Wave64,
-       AVAlign2LoadStoreMode,
-       AlignedVGPRNoAGPRMode_Wave64,
-       AlignedVGPRNoAGPRMode_Wave32],
+       AVAlign2LoadStoreMode_HasDPPSrc1SGPR,
+       AVAlign2LoadStoreMode_NotHasDPPSrc1SGPR,
+       AlignedVGPRNoAGPRMode_Wave64_HasDPPSrc1SGPR,
+       AlignedVGPRNoAGPRMode_Wave64_NotHasDPPSrc1SGPR,
+       AlignedVGPRNoAGPRMode_Wave32_HasDPPSrc1SGPR,
+       AlignedVGPRNoAGPRMode_Wave32_NotHasDPPSrc1SGPR],
       [!cast<RegisterClass>("AV_"#RegSize),
        !cast<RegisterClass>("AV_"#RegSize),
+       !cast<RegisterClass>("AV_"#RegSize),
        !cast<RegisterClass>("AV_"#RegSize#_Align2),
+       !cast<RegisterClass>("AV_"#RegSize#_Align2),
+       !cast<RegisterClass>("VReg_"#RegSize#_Align2),
+       !cast<RegisterClass>("VReg_"#RegSize#_Align2),
        !cast<RegisterClass>("VReg_"#RegSize#_Align2),
        !cast<RegisterClass>("VReg_"#RegSize#_Align2)]> {
      let DecoderMethod = "DecodeAV_"#RegSize#"RegisterClass";
@@ -1289,10 +1329,22 @@ foreach RegSize = [ 64, 96, 128, 160, 192, 224, 256, 288, 320, 352, 384, 512, 10
 
   def AV_LdSt_#RegSize#_AlignTarget : SIRegisterClassLike<RegSize, true, true>,
     RegClassByHwMode<
-      [DefaultMode_Wave64, DefaultMode_Wave32, AVAlign2LoadStoreMode, AlignedVGPRNoAGPRMode_Wave64, AlignedVGPRNoAGPRMode_Wave32],
+      [DefaultMode_Wave64,
+       DefaultMode_Wave32_HasDPPSrc1SGPR,
+       DefaultMode_Wave32_NotHasDPPSrc1SGPR,
+       AVAlign2LoadStoreMode_HasDPPSrc1SGPR,
+       AVAlign2LoadStoreMode_NotHasDPPSrc1SGPR,
+       AlignedVGPRNoAGPRMode_Wave64_HasDPPSrc1SGPR,
+       AlignedVGPRNoAGPRMode_Wave64_NotHasDPPSrc1SGPR,
+       AlignedVGPRNoAGPRMode_Wave32_HasDPPSrc1SGPR,
+       AlignedVGPRNoAGPRMode_Wave32_NotHasDPPSrc1SGPR],
       [!cast<RegisterClass>("VReg_"#RegSize),
        !cast<RegisterClass>("VReg_"#RegSize),
+       !cast<RegisterClass>("VReg_"#RegSize),
        !cast<RegisterClass>("AV_"#RegSize#_Align2),
+       !cast<RegisterClass>("AV_"#RegSize#_Align2),
+       !cast<RegisterClass>("VReg_"#RegSize#_Align2),
+       !cast<RegisterClass>("VReg_"#RegSize#_Align2),
        !cast<RegisterClass>("VReg_"#RegSize#_Align2),
        !cast<RegisterClass>("VReg_"#RegSize#_Align2)]> {
     let DecoderMethod = "decodeAVLdSt";
@@ -1300,10 +1352,22 @@ foreach RegSize = [ 64, 96, 128, 160, 192, 224, 256, 288, 320, 352, 384, 512, 10
 
   def AV_LdSt_#RegSize#_Align2 : SIRegisterClassLike<RegSize, true, true>,
     RegClassByHwMode<
-      [DefaultMode_Wave64, DefaultMode_Wave32, AVAlign2LoadStoreMode, AlignedVGPRNoAGPRMode_Wave64, AlignedVGPRNoAGPRMode_Wave32],
+      [DefaultMode_Wave64,
+       DefaultMode_Wave32_HasDPPSrc1SGPR,
+       DefaultMode_Wave32_NotHasDPPSrc1SGPR,
+       AVAlign2LoadStoreMode_HasDPPSrc1SGPR,
+       AVAlign2LoadStoreMode_NotHasDPPSrc1SGPR,
+       AlignedVGPRNoAGPRMode_Wave64_HasDPPSrc1SGPR,
+       AlignedVGPRNoAGPRMode_Wave64_NotHasDPPSrc1SGPR,
+       AlignedVGPRNoAGPRMode_Wave32_HasDPPSrc1SGPR,
+       AlignedVGPRNoAGPRMode_Wave32_NotHasDPPSrc1SGPR],
       [!cast<RegisterClass>("VReg_"#RegSize#_Align2),
        !cast<RegisterClass>("VReg_"#RegSize#_Align2),
+       !cast<RegisterClass>("VReg_"#RegSize#_Align2),
        !cast<RegisterClass>("AV_"#RegSize#_Align2),
+       !cast<RegisterClass>("AV_"#RegSize#_Align2),
+       !cast<RegisterClass>("VReg_"#RegSize#_Align2),
+       !cast<RegisterClass>("VReg_"#RegSize#_Align2),
        !cast<RegisterClass>("VReg_"#RegSize#_Align2),
        !cast<RegisterClass>("VReg_"#RegSize#_Align2)]> {
     let DecoderMethod = "decodeAVLdSt";
@@ -1311,10 +1375,22 @@ foreach RegSize = [ 64, 96, 128, 160, 192, 224, 256, 288, 320, 352, 384, 512, 10
 
   def AV_LdSt_#RegSize#_Align1 : SIRegisterClassLike<RegSize, true, true>,
     RegClassByHwMode<
-        [DefaultMode_Wave64, DefaultMode_Wave32, AVAlign2LoadStoreMode, AlignedVGPRNoAGPRMode_Wave64, AlignedVGPRNoAGPRMode_Wave32],
+        [DefaultMode_Wave64,
+         DefaultMode_Wave32_HasDPPSrc1SGPR,
+         DefaultMode_Wave32_NotHasDPPSrc1SGPR,
+         AVAlign2LoadStoreMode_HasDPPSrc1SGPR,
+         AVAlign2LoadStoreMode_NotHasDPPSrc1SGPR,
+         AlignedVGPRNoAGPRMode_Wave64_HasDPPSrc1SGPR,
+         AlignedVGPRNoAGPRMode_Wave64_NotHasDPPSrc1SGPR,
+         AlignedVGPRNoAGPRMode_Wave32_HasDPPSrc1SGPR,
+         AlignedVGPRNoAGPRMode_Wave32_NotHasDPPSrc1SGPR],
         [!cast<RegisterClass>("VReg_"#RegSize),
          !cast<RegisterClass>("VReg_"#RegSize),
+         !cast<RegisterClass>("VReg_"#RegSize),
          !cast<RegisterClass>("AV_"#RegSize),
+         !cast<RegisterClass>("AV_"#RegSize),
+         !cast<RegisterClass>("VReg_"#RegSize),
+         !cast<RegisterClass>("VReg_"#RegSize),
          !cast<RegisterClass>("VReg_"#RegSize),
          !cast<RegisterClass>("VReg_"#RegSize)]> {
     let DecoderMethod = "decodeAVLdSt";
@@ -1323,19 +1399,73 @@ foreach RegSize = [ 64, 96, 128, 160, 192, 224, 256, 288, 320, 352, 384, 512, 10
 
 def VS_64_AlignTarget : SIRegisterClassLike<64, true, false, true>,
   RegClassByHwMode<
-      [DefaultMode_Wave64, DefaultMode_Wave32, AVAlign2LoadStoreMode, AlignedVGPRNoAGPRMode_Wave64, AlignedVGPRNoAGPRMode_Wave32],
-      [VS_64,              VS_64,              VS_64_Align2,          VS_64_Align2,                 VS_64_Align2]> {
+      [DefaultMode_Wave64,
+       DefaultMode_Wave32_HasDPPSrc1SGPR,
+       DefaultMode_Wave32_NotHasDPPSrc1SGPR,
+       AVAlign2LoadStoreMode_HasDPPSrc1SGPR,
+       AVAlign2LoadStoreMode_NotHasDPPSrc1SGPR,
+       AlignedVGPRNoAGPRMode_Wave64_HasDPPSrc1SGPR,
+       AlignedVGPRNoAGPRMode_Wave64_NotHasDPPSrc1SGPR,
+       AlignedVGPRNoAGPRMode_Wave32_HasDPPSrc1SGPR,
+       AlignedVGPRNoAGPRMode_Wave32_NotHasDPPSrc1SGPR],
+      [VS_64,
+       VS_64,
+       VS_64,
+       VS_64_Align2,
+       VS_64_Align2,
+       VS_64_Align2,
+       VS_64_Align2,
+       VS_64_Align2,
+       VS_64_Align2]> {
   let DecoderMethod = "decodeSrcRegOrImm9";
 }
 
+def VS_OR_V_Target : SIRegisterClassLike<32, true, false, true>,
+  RegClassByHwMode<
+    [DefaultMode_Wave64,
+     AlignedVGPRNoAGPRMode_Wave64_HasDPPSrc1SGPR,
+     AlignedVGPRNoAGPRMode_Wave64_NotHasDPPSrc1SGPR,
+     AVAlign2LoadStoreMode_HasDPPSrc1SGPR,
+     AVAlign2LoadStoreMode_NotHasDPPSrc1SGPR,
+     DefaultMode_Wave32_HasDPPSrc1SGPR,
+     DefaultMode_Wave32_NotHasDPPSrc1SGPR,
+     AlignedVGPRNoAGPRMode_Wave32_HasDPPSrc1SGPR,
+     AlignedVGPRNoAGPRMode_Wave32_NotHasDPPSrc1SGPR],
+    [VS_32,
+     VS_32,
+     VGPR_32,
+     VS_32,
+     VGPR_32,
+     VS_32,
+     VGPR_32,
+     VS_32,
+     VGPR_32]> {
+  let DecoderMethod = "decodeSrcRegOrImm9";
+}
 
 // Special case for DS_GWS instructions. The register input is really
 // 32-bit, but it needs to be even aligned on targets with a VGPR
 // alignment requirement.
 def AV_LdSt_32_Align2 : SIRegisterClassLike</*Bitwidth=*/32, /*VGPR=*/true, /*AGPR=*/true>,
                         RegClassByHwMode<
-  [DefaultMode_Wave64, DefaultMode_Wave32, AVAlign2LoadStoreMode, AlignedVGPRNoAGPRMode_Wave64, AlignedVGPRNoAGPRMode_Wave32],
-  [VGPR_32,            VGPR_32,            AV_64_Align2,          VReg_64_Align2,               VReg_64_Align2]> {
+  [DefaultMode_Wave64,
+   DefaultMode_Wave32_HasDPPSrc1SGPR,
+   DefaultMode_Wave32_NotHasDPPSrc1SGPR,
+   AVAlign2LoadStoreMode_HasDPPSrc1SGPR,
+   AVAlign2LoadStoreMode_NotHasDPPSrc1SGPR,
+   AlignedVGPRNoAGPRMode_Wave64_HasDPPSrc1SGPR,
+   AlignedVGPRNoAGPRMode_Wave64_NotHasDPPSrc1SGPR,
+   AlignedVGPRNoAGPRMode_Wave32_HasDPPSrc1SGPR,
+   AlignedVGPRNoAGPRMode_Wave32_NotHasDPPSrc1SGPR],
+  [VGPR_32,
+   VGPR_32,
+   VGPR_32,
+   AV_64_Align2,
+   AV_64_Align2,
+   VReg_64_Align2,
+   VReg_64_Align2,
+   VReg_64_Align2,
+   VReg_64_Align2]> {
   let DecoderMethod = "decodeAVLdSt<32>";
 }
 
@@ -1430,6 +1560,19 @@ def VSrc_v2f32 : SrcRegOrImm9 <VS_64_AlignTarget, "OPERAND_REG_IMM_V2FP32">;
 def VSrc_NoInline_v2f16  : SrcRegOrImm9 <VS_32, "OPERAND_REG_IMM_NOINLINE_V2FP16">;
 
 def VSrc_v2f16_splat : SrcRegOrImm9 <VS_32, "OPERAND_REG_IMM_V2FP16_SPLAT">;
+
+//===----------------------------------------------------------------------===//
+//  VHSrc_* Operands with an SGPR (dependent on HwMode), VGPR or an inline constant
+//===----------------------------------------------------------------------===//
+
+def VHSrc_b16         : SrcRegOrImm9 <VS_OR_V_Target, "OPERAND_REG_INLINE_C_INT16">;
+def VHSrc_bf16        : SrcRegOrImm9 <VS_OR_V_Target, "OPERAND_REG_INLINE_C_BF16">;
+def VHSrc_f16         : SrcRegOrImm9 <VS_OR_V_Target, "OPERAND_REG_INLINE_C_FP16">;
+def VHSrc_b32         : SrcRegOrImm9 <VS_OR_V_Target, "OPERAND_REG_INLINE_C_INT32">;
+def VHSrc_f32         : SrcRegOrImm9 <VS_OR_V_Target, "OPERAND_REG_INLINE_C_FP32">;
+def VHSrc_v2b16       : SrcRegOrImm9 <VS_OR_V_Target, "OPERAND_REG_INLINE_C_V2INT16">;
+def VHSrc_v2bf16      : SrcRegOrImm9 <VS_OR_V_Target, "OPERAND_REG_INLINE_C_V2BF16">;
+def VHSrc_v2f16       : SrcRegOrImm9 <VS_OR_V_Target, "OPERAND_REG_INLINE_C_V2FP16">;
 
 //===----------------------------------------------------------------------===//
 //  VRegSrc_* Operands with a VGPR

--- a/llvm/test/CodeGen/AMDGPU/dpp_combine_gfx11.mir
+++ b/llvm/test/CodeGen/AMDGPU/dpp_combine_gfx11.mir
@@ -1,6 +1,6 @@
-# RUN: llc -mtriple=amdgcn -mcpu=gfx1100 -mattr=-real-true16 -run-pass=gcn-dpp-combine -verify-machineinstrs -o - %s | FileCheck %s -check-prefixes=GCN
-# RUN: llc -mtriple=amdgcn -mcpu=gfx1150 -mattr=-real-true16 -run-pass=gcn-dpp-combine -verify-machineinstrs -o - %s | FileCheck %s -check-prefixes=GCN
-# RUN: llc -mtriple=amdgcn -mcpu=gfx1200 -mattr=-real-true16 -run-pass=gcn-dpp-combine -verify-machineinstrs -o - %s | FileCheck %s -check-prefixes=GCN
+# RUN: llc -mtriple=amdgcn -mcpu=gfx1100 -mattr=-real-true16 -run-pass=gcn-dpp-combine -verify-machineinstrs -o - %s | FileCheck %s -check-prefixes=GCN,GFX1100
+# RUN: llc -mtriple=amdgcn -mcpu=gfx1150 -mattr=-real-true16 -run-pass=gcn-dpp-combine -verify-machineinstrs -o - %s | FileCheck %s -check-prefixes=GCN,GFX1150
+# RUN: llc -mtriple=amdgcn -mcpu=gfx1200 -mattr=-real-true16 -run-pass=gcn-dpp-combine -verify-machineinstrs -o - %s | FileCheck %s -check-prefixes=GCN,GFX1150
 
 ---
 
@@ -38,8 +38,10 @@ body:             |
 
 # GCN-LABEL: name: vop3_sgpr_src1
 # GCN: %6:vgpr_32 = V_MED3_F32_e64_dpp %4, 0, %0, 0, %1, 0, %2, 0, 0, 1, 15, 15, 1, implicit $mode, implicit $exec
-# GCN: %8:vgpr_32 = V_MED3_F32_e64_dpp %4, 0, %0, 0, %2, 0, %1, 0, 0, 1, 15, 15, 1, implicit $mode, implicit $exec
-# GCN: %10:vgpr_32 = V_MED3_F32_e64_dpp %4, 0, %0, 0, %2, 0, %3, 0, 0, 1, 15, 15, 1, implicit $mode, implicit $exec
+# GFX1100: %8:vgpr_32 = V_MED3_F32_e64 0, %7, 0, %2, 0, %1, 0, 0, implicit $mode, implicit $exec
+# GFX1150: %8:vgpr_32 = V_MED3_F32_e64_dpp %4, 0, %0, 0, %2, 0, %1, 0, 0, 1, 15, 15, 1, implicit $mode, implicit $exec
+# GFX1100: %10:vgpr_32 = V_MED3_F32_e64 0, %9, 0, %2, 0, %3, 0, 0, implicit $mode, implicit $exec
+# GFX1150: %10:vgpr_32 = V_MED3_F32_e64_dpp %4, 0, %0, 0, %2, 0, %3, 0, 0, 1, 15, 15, 1, implicit $mode, implicit $exec
 # GCN: %12:vgpr_32 = V_MED3_F32_e64_dpp %4, 0, %0, 0, 42, 0, %2, 0, 0, 1, 15, 15, 1, implicit $mode, implicit $exec
 # GCN: %14:vgpr_32 = V_MED3_F32_e64 0, %13, 0, 4242, 0, %2, 0, 0, implicit $mode, implicit $exec
 name: vop3_sgpr_src1


### PR DESCRIPTION
Do not allow SGPRs to be used as src1 for DPP insns on targets that do not allow it.  #67461 allowed SGPRs for all dpp opcodes, but it used an isOperandLegal check to validate if a SGPR is legal.  This was incorrect because isOperandLegal is not valid on an incomplete instruction and removed in #155595.  This PR guards against using SGPRs as src1 for targets that disallow it by using RegClassByHwMode.