### PR TITLE
[mlir][memref] Skip reinterpret_cast constant fold when invalid constified memref size

### DIFF
--- a/mlir/lib/Dialect/MemRef/IR/MemRefOps.cpp
+++ b/mlir/lib/Dialect/MemRef/IR/MemRefOps.cpp
@@ -2282,6 +2282,12 @@ public:
     SmallVector<OpFoldResult> sizes = op.getConstifiedMixedSizes();
     SmallVector<OpFoldResult> strides = op.getConstifiedMixedStrides();
 
+    for (auto sizeOfr : sizes) {
+      if (auto cst = getConstantIntValue(sizeOfr))
+        if (cst.value() < 0)
+          return rewriter.notifyMatchFailure(op, "negative size");
+    }
+
     // TODO: Using counting comparison instead of direct comparison because
     // getMixedValues (and therefore ReinterpretCastOp::getMixed...) returns
     // IntegerAttrs, while constifyIndexValues (and therefore

--- a/mlir/test/Dialect/MemRef/canonicalize.mlir
+++ b/mlir/test/Dialect/MemRef/canonicalize.mlir
@@ -1177,6 +1177,24 @@ func.func @reinterpret_constant_fold(%arg0: memref<f32>) -> memref<?x?xf32, stri
 
 // -----
 
+// ReinterpretCastOpConstantFolder must not apply when a constified size is
+// negative (invalid for memref dimensions). The successful fold inserts
+// memref.cast; ensure it does not trigger here.
+// CHECK-LABEL: func @reinterpret_constant_fold_negative_size
+//  CHECK-SAME: (%[[ARG:.*]]: memref<f32>)
+//       CHECK-NOT: memref.cast
+//       CHECK: memref.reinterpret_cast %[[ARG]]
+func.func @reinterpret_constant_fold_negative_size(%arg0: memref<f32>) -> memref<?x?xf32, strided<[?, ?], offset: ?>> {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %cn1 = arith.constant -1 : index
+  %c100 = arith.constant 100 : index
+  %reinterpret_cast = memref.reinterpret_cast %arg0 to offset: [%c0], sizes: [%cn1, %c100], strides: [%c100, %c1] : memref<f32> to memref<?x?xf32, strided<[?, ?], offset: ?>>
+  return %reinterpret_cast : memref<?x?xf32, strided<[?, ?], offset: ?>>
+}
+
+// -----
+
 // CHECK-LABEL: func @reinterpret_of_reinterpret
 //  CHECK-SAME: (%[[ARG:.*]]: memref<?xi8>, %[[SIZE1:.*]]: index, %[[SIZE2:.*]]: index)
 //       CHECK: %[[RES:.*]] = memref.reinterpret_cast %[[ARG]] to offset: [0], sizes: [%[[SIZE2]]], strides: [1]


### PR DESCRIPTION
Fixes #188407 After computing constified sizes, bail out of the pattern if any size is a known integer constant and is `< 0` (using getConstantIntValue), so we do not build invalid IR.

Assisted-by: CLion code completion