### PR TITLE
[DA] Optimize parity check in weakCrossingSIVtest (NFC)

### DIFF
--- a/llvm/lib/Analysis/DependenceAnalysis.cpp
+++ b/llvm/lib/Analysis/DependenceAnalysis.cpp
@@ -1473,10 +1473,7 @@ bool DependenceInfo::weakCrossingSIVtest(const SCEV *Coeff,
   LLVM_DEBUG(dbgs() << "\t    Distance = " << Distance << "\n");
 
   // if 2*Coeff doesn't divide Delta, then the equal direction isn't possible
-  APInt Two = APInt(Distance.getBitWidth(), 2, true);
-  Remainder = Distance.srem(Two);
-  LLVM_DEBUG(dbgs() << "\t    Remainder = " << Remainder << "\n");
-  if (Remainder != 0) {
+  if (Distance[0]) {
     // Equal direction isn't possible
     Result.DV[Level].Direction &= ~Dependence::DVEntry::EQ;
     ++WeakCrossingSIVsuccesses;


### PR DESCRIPTION
This patch simplifies the logic used to determine if the `Distance`
is divisible by 2. Previously, this was done by allocating an APInt
and performing a signed remainder (`srem`) operation.

Since `Distance` is an APInt, we can more efficiently check if it
is odd by directly inspecting the least significant bit (`Distance[0]`).
This avoids an expensive division operation and APInt allocation
while making the code more concise.

