### PR TITLE
[ORC] Move DylibManager impl out of SimpleRemoteEPC.

### DIFF
--- a/llvm/include/llvm/ExecutionEngine/Orc/EPCGenericDylibManager.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/EPCGenericDylibManager.h
@@ -28,7 +28,7 @@ namespace orc {
 
 class SymbolLookupSet;
 
-class EPCGenericDylibManager {
+class EPCGenericDylibManager : public DylibManager {
 public:
   /// Function addresses for memory access.
   struct SymbolAddrs {
@@ -80,6 +80,17 @@ public:
   LLVM_ABI void lookupAsync(tpctypes::DylibHandle H,
                             const RemoteSymbolLookupSet &Lookup,
                             SymbolLookupCompleteFn Complete);
+
+  /// Load the dynamic library at the given path and return a handle to it.
+  /// If DylibPath is null this function will return the global handle for
+  /// the target process.
+  LLVM_ABI Expected<tpctypes::DylibHandle>
+  loadDylib(const char *DylibPath) override;
+
+  /// Search for symbols in the target process.
+  LLVM_ABI void
+  lookupSymbolsAsync(ArrayRef<DylibManager::LookupRequest> Request,
+                     DylibManager::SymbolLookupCompleteFn Complete) override;
 
 private:
   ExecutorProcessControl &EPC;

--- a/llvm/include/llvm/ExecutionEngine/Orc/SimpleRemoteEPC.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/SimpleRemoteEPC.h
@@ -30,8 +30,7 @@ namespace llvm {
 namespace orc {
 
 class LLVM_ABI SimpleRemoteEPC : public ExecutorProcessControl,
-                                 public SimpleRemoteEPCTransportClient,
-                                 private DylibManager {
+                                 public SimpleRemoteEPCTransportClient {
 public:
   /// A setup object containing callbacks to construct a memory manager and
   /// memory access object. Both are optional. If not specified,
@@ -93,9 +92,7 @@ public:
 private:
   SimpleRemoteEPC(std::shared_ptr<SymbolStringPool> SSP,
                   std::unique_ptr<TaskDispatcher> D)
-      : ExecutorProcessControl(std::move(SSP), std::move(D)) {
-    this->DylibMgr = this;
-  }
+      : ExecutorProcessControl(std::move(SSP), std::move(D)) {}
 
   static Expected<std::unique_ptr<jitlink::JITLinkMemoryManager>>
   createDefaultMemoryManager(SimpleRemoteEPC &SREPC);
@@ -117,11 +114,6 @@ private:
 
   uint64_t getNextSeqNo() { return NextSeqNo++; }
   void releaseSeqNo(uint64_t SeqNo) {}
-
-  Expected<tpctypes::DylibHandle> loadDylib(const char *DylibPath) override;
-
-  void lookupSymbolsAsync(ArrayRef<LookupRequest> Request,
-                          SymbolLookupCompleteFn F) override;
 
   using PendingCallWrapperResultsMap =
     DenseMap<uint64_t, IncomingWFRHandler>;

--- a/llvm/lib/ExecutionEngine/Orc/EPCGenericDylibManager.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/EPCGenericDylibManager.cpp
@@ -119,5 +119,43 @@ void EPCGenericDylibManager::lookupAsync(tpctypes::DylibHandle H,
       H, Lookup);
 }
 
+Expected<tpctypes::DylibHandle>
+EPCGenericDylibManager::loadDylib(const char *DylibPath) {
+  return open(DylibPath, 0);
+}
+
+/// Async helper to chain together calls to lookupAsync to fulfill all
+/// the requests.
+/// FIXME: The dylib manager should support multiple LookupRequests natively.
+static void
+lookupSymbolsAsyncHelper(EPCGenericDylibManager &DylibMgr,
+                         ArrayRef<DylibManager::LookupRequest> Request,
+                         std::vector<tpctypes::LookupResult> Result,
+                         DylibManager::SymbolLookupCompleteFn Complete) {
+  if (Request.empty())
+    return Complete(std::move(Result));
+
+  auto &Element = Request.front();
+  DylibMgr.lookupAsync(Element.Handle, Element.Symbols,
+                       [&DylibMgr, Request, Complete = std::move(Complete),
+                        Result = std::move(Result)](auto R) mutable {
+                         if (!R)
+                           return Complete(R.takeError());
+                         Result.push_back({});
+                         Result.back().reserve(R->size());
+                         llvm::append_range(Result.back(), *R);
+
+                         lookupSymbolsAsyncHelper(
+                             DylibMgr, Request.drop_front(), std::move(Result),
+                             std::move(Complete));
+                       });
+}
+
+void EPCGenericDylibManager::lookupSymbolsAsync(
+    ArrayRef<DylibManager::LookupRequest> Request,
+    DylibManager::SymbolLookupCompleteFn Complete) {
+  lookupSymbolsAsyncHelper(*this, Request, {}, std::move(Complete));
+}
+
 } // end namespace orc
 } // end namespace llvm

--- a/llvm/lib/ExecutionEngine/Orc/SimpleRemoteEPC.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/SimpleRemoteEPC.cpp
@@ -23,43 +23,6 @@ SimpleRemoteEPC::~SimpleRemoteEPC() {
 #endif // NDEBUG
 }
 
-Expected<tpctypes::DylibHandle>
-SimpleRemoteEPC::loadDylib(const char *DylibPath) {
-  return EPCDylibMgr->open(DylibPath, 0);
-}
-
-/// Async helper to chain together calls to DylibMgr::lookupAsync to fulfill all
-/// all the requests.
-/// FIXME: The dylib manager should support multiple LookupRequests natively.
-static void
-lookupSymbolsAsyncHelper(EPCGenericDylibManager &DylibMgr,
-                         ArrayRef<DylibManager::LookupRequest> Request,
-                         std::vector<tpctypes::LookupResult> Result,
-                         DylibManager::SymbolLookupCompleteFn Complete) {
-  if (Request.empty())
-    return Complete(std::move(Result));
-
-  auto &Element = Request.front();
-  DylibMgr.lookupAsync(Element.Handle, Element.Symbols,
-                       [&DylibMgr, Request, Complete = std::move(Complete),
-                        Result = std::move(Result)](auto R) mutable {
-                         if (!R)
-                           return Complete(R.takeError());
-                         Result.push_back({});
-                         Result.back().reserve(R->size());
-                         llvm::append_range(Result.back(), *R);
-
-                         lookupSymbolsAsyncHelper(
-                             DylibMgr, Request.drop_front(), std::move(Result),
-                             std::move(Complete));
-                       });
-}
-
-void SimpleRemoteEPC::lookupSymbolsAsync(ArrayRef<LookupRequest> Request,
-                                         SymbolLookupCompleteFn Complete) {
-  lookupSymbolsAsyncHelper(*EPCDylibMgr, Request, {}, std::move(Complete));
-}
-
 Expected<int32_t> SimpleRemoteEPC::runAsMain(ExecutorAddr MainFnAddr,
                                              ArrayRef<std::string> Args) {
   int64_t Result = 0;
@@ -374,6 +337,8 @@ Error SimpleRemoteEPC::setup(Setup S) {
     EPCDylibMgr = std::make_unique<EPCGenericDylibManager>(std::move(*DM));
   else
     return DM.takeError();
+
+  this->DylibMgr = EPCDylibMgr.get();
 
   // Set a default CreateMemoryManager if none is specified.
   if (!S.CreateMemoryManager)


### PR DESCRIPTION
This updates EPCGenericDylibManager to implement the DylibManager interface, and drops the DylibManager implementation from SimpleRemoteEPC. Since SimpleRemoteEPC already owned an EPCGenericDylibManager it can simply provide that as its DylibManager implementation. This change should not affect the behavior of SimpleRemoteEPC from the perspective of API clients.