### PR TITLE
[DA] Hoist division check for early exit in weakCrossingSIVtest

### DIFF
--- a/llvm/lib/Analysis/DependenceAnalysis.cpp
+++ b/llvm/lib/Analysis/DependenceAnalysis.cpp
@@ -1428,6 +1428,27 @@ bool DependenceInfo::weakCrossingSIVtest(const SCEV *Coeff,
     return true;
   }
 
+  // check that Coeff divides Delta
+  APInt APDelta = ConstDelta->getAPInt();
+  APInt APCoeff = ConstCoeff->getAPInt();
+  APInt Distance = APDelta; // these need to be initialzed
+  APInt Remainder = APDelta;
+  APInt::sdivrem(APDelta, APCoeff, Distance, Remainder);
+  LLVM_DEBUG(dbgs() << "\t    Remainder = " << Remainder << "\n");
+  if (Remainder != 0) {
+    // Coeff doesn't divide Delta, no dependence
+    ++WeakCrossingSIVindependence;
+    ++WeakCrossingSIVsuccesses;
+    return true;
+  }
+  LLVM_DEBUG(dbgs() << "\t    Distance = " << Distance << "\n");
+  // if 2*Coeff doesn't divide Delta, then the equal direction isn't possible
+  if (Distance[0]) {
+    // Equal direction isn't possible
+    Result.DV[Level].Direction &= ~Dependence::DVEntry::EQ;
+    ++WeakCrossingSIVsuccesses;
+  }
+
   // We're certain that Delta > 0 and ConstCoeff > 0.
   // Check Delta/(2*ConstCoeff) against upper loop bound
   if (const SCEV *UpperBound =
@@ -1457,27 +1478,6 @@ bool DependenceInfo::weakCrossingSIVtest(const SCEV *Coeff,
     }
   }
 
-  // check that Coeff divides Delta
-  APInt APDelta = ConstDelta->getAPInt();
-  APInt APCoeff = ConstCoeff->getAPInt();
-  APInt Distance = APDelta; // these need to be initialzed
-  APInt Remainder = APDelta;
-  APInt::sdivrem(APDelta, APCoeff, Distance, Remainder);
-  LLVM_DEBUG(dbgs() << "\t    Remainder = " << Remainder << "\n");
-  if (Remainder != 0) {
-    // Coeff doesn't divide Delta, no dependence
-    ++WeakCrossingSIVindependence;
-    ++WeakCrossingSIVsuccesses;
-    return true;
-  }
-  LLVM_DEBUG(dbgs() << "\t    Distance = " << Distance << "\n");
-
-  // if 2*Coeff doesn't divide Delta, then the equal direction isn't possible
-  if (Distance[0]) {
-    // Equal direction isn't possible
-    Result.DV[Level].Direction &= ~Dependence::DVEntry::EQ;
-    ++WeakCrossingSIVsuccesses;
-  }
   return false;
 }
 


### PR DESCRIPTION
This patch moves the check that `Coeff` divides `Delta` earlier in the
function to enable an early exit. Potentially improve performance.

