### PR TITLE
[libc] Fix unused variable warning in utimes.cpp (#188347)

### DIFF
--- a/libc/src/sys/time/linux/utimes.cpp
+++ b/libc/src/sys/time/linux/utimes.cpp
@@ -22,11 +22,9 @@ namespace LIBC_NAMESPACE_DECL {
 
 LLVM_LIBC_FUNCTION(int, utimes,
                    (const char *path, const struct timeval times[2])) {
-  int ret;
-
 #ifdef SYS_utimes
   // No need to define a timespec struct, use the syscall directly.
-  ret = LIBC_NAMESPACE::syscall_impl<int>(SYS_utimes, path, times);
+  int ret = LIBC_NAMESPACE::syscall_impl<int>(SYS_utimes, path, times);
 
   if (ret < 0) {
     libc_errno = -ret;


### PR DESCRIPTION
Moved the declaration of 'ret' inside the SYS_utimes block to prevent an unused variable warning on the libc-riscv32-qemu-yocto-fullbuild-dbg builder, which doesn't define SYS_utimes.