### PR TITLE
[MLIR][AMDGPU] Added l2-prefetch op to AMDGPU

### DIFF
--- a/mlir/include/mlir/Dialect/AMDGPU/IR/AMDGPUAttrs.td
+++ b/mlir/include/mlir/Dialect/AMDGPU/IR/AMDGPUAttrs.td
@@ -50,4 +50,7 @@ def AMDGPU_MFMAPermBAttr : EnumAttr<AMDGPU_Dialect, AMDGPU_MFMAPermB,
 def AMDGPU_TemporalHintAttr : EnumAttr<AMDGPU_Dialect, AMDGPU_TemporalHint,
   "temporal_hint">;
 
+def AMDGPU_CacheScopeAttr : EnumAttr<AMDGPU_Dialect, AMDGPU_CacheScope,
+  "cache_scope">;
+
 #endif // MLIR_DIALECT_AMDGPU_IR_AMDGPUATTRS_TD

--- a/mlir/include/mlir/Dialect/AMDGPU/IR/AMDGPUAttrs.td
+++ b/mlir/include/mlir/Dialect/AMDGPU/IR/AMDGPUAttrs.td
@@ -47,4 +47,7 @@ def AMDGPU_SchedBarrierOpOptAttr : EnumAttr<AMDGPU_Dialect, AMDGPU_SchedBarrierO
 def AMDGPU_MFMAPermBAttr : EnumAttr<AMDGPU_Dialect, AMDGPU_MFMAPermB,
   "mfma_perm_b">;
 
+def AMDGPU_TemporalHintAttr : EnumAttr<AMDGPU_Dialect, AMDGPU_TemporalHint,
+  "temporal_hint">;
+
 #endif // MLIR_DIALECT_AMDGPU_IR_AMDGPUATTRS_TD

--- a/mlir/include/mlir/Dialect/AMDGPU/IR/AMDGPUEnums.td
+++ b/mlir/include/mlir/Dialect/AMDGPU/IR/AMDGPUEnums.td
@@ -88,7 +88,7 @@ def AMDGPU_TemporalHint : I32Enum<"TemporalHint",
     "LU - last-use; "
     "NT_RT - non-temporal for near cache(s) and regular for far caches; "
     "RT_NT - regular for near cache(s) and non-temporal for far caches; "
-    "NT_HT - non-temporal for near cache(s) and high-priority temporal for far caches; ",
+    "NT_HT - non-temporal for near cache(s) and high-priority temporal for far caches",
     [
       I32EnumAttrCase<"RT",    0>,
       I32EnumAttrCase<"NT",    1>,
@@ -97,6 +97,21 @@ def AMDGPU_TemporalHint : I32Enum<"TemporalHint",
       I32EnumAttrCase<"NT_RT", 4>,
       I32EnumAttrCase<"RT_NT", 5>,
       I32EnumAttrCase<"NT_HT", 6>
+    ]> {
+  let cppNamespace = "::mlir::amdgpu";
+}
+
+def AMDGPU_CacheScope : I32Enum<"Scope",
+    "AMDGPU-specific cache scopes. "
+    "WGP - workgroup processor (CUs); "
+    "SE - shader engine (GL2); "
+    "DEV - device; "
+    "SYS - system",
+    [
+      I32EnumAttrCase<"WGP",    0>,
+      I32EnumAttrCase<"SE",     1>,
+      I32EnumAttrCase<"DEV",    2>,
+      I32EnumAttrCase<"SYS",    3>
     ]> {
   let cppNamespace = "::mlir::amdgpu";
 }

--- a/mlir/include/mlir/Dialect/AMDGPU/IR/AMDGPUEnums.td
+++ b/mlir/include/mlir/Dialect/AMDGPU/IR/AMDGPUEnums.td
@@ -90,13 +90,13 @@ def AMDGPU_TemporalHint : I32Enum<"TemporalHint",
     "RT_NT - regular for near cache(s) and non-temporal for far caches; "
     "NT_HT - non-temporal for near cache(s) and high-priority temporal for far caches",
     [
-      I32EnumAttrCase<"RT",    0>,
-      I32EnumAttrCase<"NT",    1>,
-      I32EnumAttrCase<"HT",    2>,
-      I32EnumAttrCase<"LU",    3>,
-      I32EnumAttrCase<"NT_RT", 4>,
-      I32EnumAttrCase<"RT_NT", 5>,
-      I32EnumAttrCase<"NT_HT", 6>
+      I32EnumCase<"RT",    0>,
+      I32EnumCase<"NT",    1>,
+      I32EnumCase<"HT",    2>,
+      I32EnumCase<"LU",    3>,
+      I32EnumCase<"NT_RT", 4>,
+      I32EnumCase<"RT_NT", 5>,
+      I32EnumCase<"NT_HT", 6>
     ]> {
   let cppNamespace = "::mlir::amdgpu";
 }
@@ -108,10 +108,10 @@ def AMDGPU_CacheScope : I32Enum<"Scope",
     "DEV - device; "
     "SYS - system",
     [
-      I32EnumAttrCase<"WGP",    0>,
-      I32EnumAttrCase<"SE",     1>,
-      I32EnumAttrCase<"DEV",    2>,
-      I32EnumAttrCase<"SYS",    3>
+      I32EnumCase<"WGP",    0>,
+      I32EnumCase<"SE",     1>,
+      I32EnumCase<"DEV",    2>,
+      I32EnumCase<"SYS",    3>
     ]> {
   let cppNamespace = "::mlir::amdgpu";
 }

--- a/mlir/include/mlir/Dialect/AMDGPU/IR/AMDGPUEnums.td
+++ b/mlir/include/mlir/Dialect/AMDGPU/IR/AMDGPUEnums.td
@@ -80,4 +80,25 @@ def AMDGPU_MFMAPermB : I32Enum<"MFMAPermB",
   let cppNamespace = "::mlir::amdgpu";
 }
 
+def AMDGPU_TemporalHint : I32Enum<"TemporalHint",
+    "AMDGPU-specific prefetch temporal hints. "
+    "RT - regular temporal for both near and far caches; "
+    "NT - non-temporal for both near and far caches; "
+    "HT - high-priority temporal for both near and far caches; "
+    "LU - last-use; "
+    "NT_RT - non-temporal for near cache(s) and regular for far caches; "
+    "RT_NT - regular for near cache(s) and non-temporal for far caches; "
+    "NT_HT - non-temporal for near cache(s) and high-priority temporal for far caches; ",
+    [
+      I32EnumAttrCase<"RT",    0>,
+      I32EnumAttrCase<"NT",    1>,
+      I32EnumAttrCase<"HT",    2>,
+      I32EnumAttrCase<"LU",    3>,
+      I32EnumAttrCase<"NT_RT", 4>,
+      I32EnumAttrCase<"RT_NT", 5>,
+      I32EnumAttrCase<"NT_HT", 6>
+    ]> {
+  let cppNamespace = "::mlir::amdgpu";
+}
+
 #endif // MLIR_DIALECT_AMDGPU_IR_AMDGPUENUMS_TD

--- a/mlir/include/mlir/Dialect/AMDGPU/IR/AMDGPUOps.td
+++ b/mlir/include/mlir/Dialect/AMDGPU/IR/AMDGPUOps.td
@@ -1957,6 +1957,7 @@ def AMDGPU_GlobalPrefetchOp :
     Arguments<(ins AnyMemRef:$src,
                Variadic<I64>:$indices,
                AMDGPU_TemporalHintAttr:$temporalHint,
+               AMDGPU_CacheScopeAttr:$cacheScope,
                UnitAttr:$speculative)>,
     Results<(outs)> {
 
@@ -1966,18 +1967,19 @@ def AMDGPU_GlobalPrefetchOp :
     the source `memref` and an offset provided by the indices of the element
     containing the cache line. This provides temporal hints (e.g., regular
     or high-priority). Note that out-of-bounds access is allowed in
-    speculative mode. The provided memref must be in the global address space (`#gpu.address_space<global>` or 1).
+    speculative mode. The provided memref must be in the global address space
+    (`#gpu.address_space<global>` or 1).
 
     This operation was introduced in gfx1250.
 
     Example:
     ```mlir
-    amdgpu.global_prefetch %src[%i, %j] RT speculative : memref<64x64xf16, 1>
+    amdgpu.global_prefetch %src[%i, %j] RT SE speculative : memref<64x64xf16, #gpu.address_space<global>>
     ```
   }];
 
   let assemblyFormat = [{
-    $src `[` $indices `]` $temporalHint (`speculative` $speculative^)? attr-dict `:` qualified(type($src))
+    $src `[` $indices `]` $temporalHint $cacheScope (`speculative` $speculative^)? attr-dict `:` qualified(type($src))
   }];
 
   let hasVerifier = 1;

--- a/mlir/include/mlir/Dialect/AMDGPU/IR/AMDGPUOps.td
+++ b/mlir/include/mlir/Dialect/AMDGPU/IR/AMDGPUOps.td
@@ -1952,4 +1952,35 @@ def AMDGPU_DsBarrierStatePhaseParity :
   }];
 }
 
+def AMDGPU_GlobalPrefetchOp :
+    AMDGPU_Op<"global_prefetch", [MemoryEffects<[MemWrite, MemRead]>]>,
+    Arguments<(ins AnyMemRef:$src,
+               Variadic<I64>:$indices,
+               AMDGPU_TemporalHintAttr:$temporalHint,
+               UnitAttr:$speculative)>,
+    Results<(outs)> {
+
+  let summary = "Prefetch data to caches.";
+  let description = [{
+    Prefetches a cache line to high-level caches using the aligned address of
+    the source `memref` and an offset provided by the indices of the element
+    containing the cache line. This provides temporal hints (e.g., regular
+    or high-priority). Note that out-of-bounds access is allowed in
+    speculative mode. Ensure the source `memref` is in address space `1`.
+
+    This operation was introduced in gfx1250.
+
+    Example:
+    ```mlir
+    amdgpu.global_prefetch %src[%i, %j] RT speculative : memref<64x64xf16, 1>
+    ```
+  }];
+
+  let assemblyFormat = [{
+    $src `[` $indices `]` $temporalHint (`speculative` $speculative^)? attr-dict `:` qualified(type($src))
+  }];
+
+  let hasVerifier = 1;
+}
+
 #endif // MLIR_DIALECT_AMDGPU_IR_AMDGPUOPS_TD

--- a/mlir/include/mlir/Dialect/AMDGPU/IR/AMDGPUOps.td
+++ b/mlir/include/mlir/Dialect/AMDGPU/IR/AMDGPUOps.td
@@ -1966,7 +1966,7 @@ def AMDGPU_GlobalPrefetchOp :
     the source `memref` and an offset provided by the indices of the element
     containing the cache line. This provides temporal hints (e.g., regular
     or high-priority). Note that out-of-bounds access is allowed in
-    speculative mode. Ensure the source `memref` is in address space `1`.
+    speculative mode. The provided memref must be in the global address space (`#gpu.address_space<global>` or 1).
 
     This operation was introduced in gfx1250.
 

--- a/mlir/lib/Conversion/AMDGPUToROCDL/AMDGPUToROCDL.cpp
+++ b/mlir/lib/Conversion/AMDGPUToROCDL/AMDGPUToROCDL.cpp
@@ -3950,6 +3950,56 @@ struct AMDGPUTensorLoadStoreOpLowering
   }
 };
 
+struct GlobalPrefetchOpLowering
+    : public ConvertOpToLLVMPattern<GlobalPrefetchOp> {
+  GlobalPrefetchOpLowering(const LLVMTypeConverter &converter, Chipset chipset)
+      : ConvertOpToLLVMPattern<GlobalPrefetchOp>(converter), chipset(chipset) {}
+
+  LogicalResult
+  matchAndRewrite(GlobalPrefetchOp op, GlobalPrefetchOpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    if (chipset < kGfx1250)
+      return op->emitOpError("is only supported on gfx1250+");
+
+    const TemporalHint hint = op.getTemporalHint();
+    const bool isSpeculative = op.getSpeculative();
+
+    int32_t llvmScopeValue = static_cast<int32_t>(hint);
+    if ((hint == TemporalHint::RT) || (hint == TemporalHint::HT))
+      llvmScopeValue = isSpeculative ? llvmScopeValue : llvmScopeValue | 1;
+
+    IntegerAttr scopeAttr = rewriter.getI32IntegerAttr(llvmScopeValue);
+
+    ValueRange indices = adaptor.getIndices();
+    Value memRef = adaptor.getSrc();
+    MemRefDescriptor descriptor(memRef);
+    Location loc = op->getLoc();
+    Value offset =
+        LLVM::ConstantOp::create(rewriter, loc, rewriter.getI64Type(), 0);
+    for (size_t i = 0; i < indices.size(); ++i) {
+      Value stride = descriptor.stride(rewriter, loc, i);
+      Value mulOp = LLVM::MulOp::create(rewriter, loc, rewriter.getI64Type(),
+                                        stride, indices[i]);
+      offset = LLVM::AddOp::create(rewriter, loc, rewriter.getI64Type(), offset,
+                                   mulOp);
+    }
+
+    Value basePtr = descriptor.alignedPtr(rewriter, loc);
+    Type elemTy = op.getSrc().getType().getElementType();
+    Type llvmElemTy = getTypeConverter()->convertType(elemTy);
+    Value prefetchPtr = LLVM::GEPOp::create(rewriter, loc, basePtr.getType(),
+                                            llvmElemTy, basePtr, offset);
+    Operation *newOp = ROCDL::GlobalPrefetchOp::create(
+        rewriter, loc, prefetchPtr, scopeAttr, {}, {}, {});
+
+    rewriter.replaceOp(op, newOp);
+    return success();
+  }
+
+private:
+  Chipset chipset;
+};
+
 struct ConvertAMDGPUToROCDLPass
     : public impl::ConvertAMDGPUToROCDLPassBase<ConvertAMDGPUToROCDLPass> {
   using Base::Base;
@@ -4086,8 +4136,8 @@ void mlir::populateAMDGPUToROCDLConversionPatterns(LLVMTypeConverter &converter,
            AMDGPUTensorLoadStoreOpLowering<TensorStoreFromLDSOp,
                                            ROCDL::TensorStoreFromLDSOp>,
            DsBarrierInitOpLowering, DsBarrierPollStateOpLowering,
-           DsAsyncBarrierArriveOpLowering, DsBarrierArriveOpLowering>(converter,
-                                                                      chipset);
+           DsAsyncBarrierArriveOpLowering, DsBarrierArriveOpLowering,
+           GlobalPrefetchOpLowering>(converter, chipset);
   patterns.add<AMDGPUSwizzleBitModeLowering, DsBarrierStatePhaseOpLowering,
                DsBarrierStatePendingCountOpLowering,
                DsBarrierStateInitCountOpLowering,

--- a/mlir/lib/Conversion/AMDGPUToROCDL/AMDGPUToROCDL.cpp
+++ b/mlir/lib/Conversion/AMDGPUToROCDL/AMDGPUToROCDL.cpp
@@ -3965,7 +3965,12 @@ struct GlobalPrefetchOpLowering
     const bool isSpeculative = op.getSpeculative();
 
     int32_t llvmScopeValue = static_cast<int32_t>(hint);
-    if (hint == TemporalHint::RT || hint == TemporalHint::HT)
+
+    // Note that only RT and HT can operate in both speculative and
+    // non-speculative modes. The other variants (NT_RT, RT_NT, NT_HT, etc.)
+    // operate only in the speculative mode and, therefore, do not require
+    // toggling the least significant bit for mode changes
+    if (llvm::is_contained({TemporalHint::RT, TemporalHint::HT}, hint))
       llvmScopeValue = isSpeculative ? llvmScopeValue : llvmScopeValue | 1;
 
     IntegerAttr scopeAttr = rewriter.getI32IntegerAttr(llvmScopeValue);
@@ -3973,10 +3978,14 @@ struct GlobalPrefetchOpLowering
     ValueRange indices = adaptor.getIndices();
     Value memRef = adaptor.getSrc();
     MemRefDescriptor descriptor(memRef);
+    MemRefType memRefType = op.getSrc().getType();
     Location loc = op->getLoc();
-    auto inboundsFlags = isSpeculative ? LLVM::GEPNoWrapFlags::none : LLVM::GEPNoWrapFlags::inbounds | LLVM::GEPNoWrapFlags::nuw;
-    Value prefetchPtr = getStridedElementPtr(rewriter, loc, adaptor.getSrc(), adaptor.getIndices(), inboundsFlags);
-                                            llvmElemTy, basePtr, offset);
+    auto inboundsFlags = isSpeculative ? LLVM::GEPNoWrapFlags::none
+                                       : LLVM::GEPNoWrapFlags::inbounds |
+                                             LLVM::GEPNoWrapFlags::nuw;
+    Value prefetchPtr = getStridedElementPtr(
+        rewriter, loc, memRefType, descriptor, indices, inboundsFlags);
+
     Operation *newOp = ROCDL::GlobalPrefetchOp::create(
         rewriter, loc, prefetchPtr, scopeAttr, {}, {}, {});
 

--- a/mlir/lib/Conversion/AMDGPUToROCDL/AMDGPUToROCDL.cpp
+++ b/mlir/lib/Conversion/AMDGPUToROCDL/AMDGPUToROCDL.cpp
@@ -3990,10 +3990,9 @@ struct GlobalPrefetchOpLowering
     Value prefetchPtr = getStridedElementPtr(
         rewriter, loc, memRefType, descriptor, indices, inboundsFlags);
 
-    Operation *newOp = ROCDL::GlobalPrefetchOp::create(
-        rewriter, loc, prefetchPtr, immArgAttr, {}, {}, {});
-
-    rewriter.replaceOp(op, newOp);
+    rewriter.replaceOpWithNewOp<ROCDL::GlobalPrefetchOp>(
+        op, prefetchPtr, immArgAttr, mlir::ArrayAttr{}, mlir::ArrayAttr{},
+        mlir::ArrayAttr{});
     return success();
   }
 

--- a/mlir/lib/Conversion/AMDGPUToROCDL/AMDGPUToROCDL.cpp
+++ b/mlir/lib/Conversion/AMDGPUToROCDL/AMDGPUToROCDL.cpp
@@ -3965,7 +3965,7 @@ struct GlobalPrefetchOpLowering
     const bool isSpeculative = op.getSpeculative();
 
     int32_t llvmScopeValue = static_cast<int32_t>(hint);
-    if ((hint == TemporalHint::RT) || (hint == TemporalHint::HT))
+    if (hint == TemporalHint::RT || hint == TemporalHint::HT)
       llvmScopeValue = isSpeculative ? llvmScopeValue : llvmScopeValue | 1;
 
     IntegerAttr scopeAttr = rewriter.getI32IntegerAttr(llvmScopeValue);
@@ -3976,10 +3976,10 @@ struct GlobalPrefetchOpLowering
     Location loc = op->getLoc();
     Value offset =
         LLVM::ConstantOp::create(rewriter, loc, rewriter.getI64Type(), 0);
-    for (size_t i = 0; i < indices.size(); ++i) {
+    for (auto [i, index] : llvm::enumerate(indices)) {
       Value stride = descriptor.stride(rewriter, loc, i);
       Value mulOp = LLVM::MulOp::create(rewriter, loc, rewriter.getI64Type(),
-                                        stride, indices[i]);
+                                        stride, index);
       offset = LLVM::AddOp::create(rewriter, loc, rewriter.getI64Type(), offset,
                                    mulOp);
     }

--- a/mlir/lib/Conversion/AMDGPUToROCDL/AMDGPUToROCDL.cpp
+++ b/mlir/lib/Conversion/AMDGPUToROCDL/AMDGPUToROCDL.cpp
@@ -3964,16 +3964,20 @@ struct GlobalPrefetchOpLowering
     const TemporalHint hint = op.getTemporalHint();
     const bool isSpeculative = op.getSpeculative();
 
-    int32_t llvmScopeValue = static_cast<int32_t>(hint);
+    int32_t immArgValue = static_cast<int32_t>(hint);
 
     // Note that only RT and HT can operate in both speculative and
     // non-speculative modes. The other variants (NT_RT, RT_NT, NT_HT, etc.)
     // operate only in the speculative mode and, therefore, do not require
     // toggling the least significant bit for mode changes
+    // Temporal hint is encoded in lower bits - i.e. [2:0]
     if (llvm::is_contained({TemporalHint::RT, TemporalHint::HT}, hint))
-      llvmScopeValue = isSpeculative ? llvmScopeValue : llvmScopeValue | 1;
+      immArgValue = isSpeculative ? immArgValue : immArgValue | 1;
 
-    IntegerAttr scopeAttr = rewriter.getI32IntegerAttr(llvmScopeValue);
+    // Prefetch scope level is encoded in upper bits - i.e., [4:3]
+    immArgValue = static_cast<int32_t>(op.getCacheScope()) << 3 | immArgValue;
+
+    IntegerAttr immArgAttr = rewriter.getI32IntegerAttr(immArgValue);
 
     ValueRange indices = adaptor.getIndices();
     Value memRef = adaptor.getSrc();
@@ -3987,7 +3991,7 @@ struct GlobalPrefetchOpLowering
         rewriter, loc, memRefType, descriptor, indices, inboundsFlags);
 
     Operation *newOp = ROCDL::GlobalPrefetchOp::create(
-        rewriter, loc, prefetchPtr, scopeAttr, {}, {}, {});
+        rewriter, loc, prefetchPtr, immArgAttr, {}, {}, {});
 
     rewriter.replaceOp(op, newOp);
     return success();

--- a/mlir/lib/Conversion/AMDGPUToROCDL/AMDGPUToROCDL.cpp
+++ b/mlir/lib/Conversion/AMDGPUToROCDL/AMDGPUToROCDL.cpp
@@ -3974,20 +3974,8 @@ struct GlobalPrefetchOpLowering
     Value memRef = adaptor.getSrc();
     MemRefDescriptor descriptor(memRef);
     Location loc = op->getLoc();
-    Value offset =
-        LLVM::ConstantOp::create(rewriter, loc, rewriter.getI64Type(), 0);
-    for (auto [i, index] : llvm::enumerate(indices)) {
-      Value stride = descriptor.stride(rewriter, loc, i);
-      Value mulOp = LLVM::MulOp::create(rewriter, loc, rewriter.getI64Type(),
-                                        stride, index);
-      offset = LLVM::AddOp::create(rewriter, loc, rewriter.getI64Type(), offset,
-                                   mulOp);
-    }
-
-    Value basePtr = descriptor.alignedPtr(rewriter, loc);
-    Type elemTy = op.getSrc().getType().getElementType();
-    Type llvmElemTy = getTypeConverter()->convertType(elemTy);
-    Value prefetchPtr = LLVM::GEPOp::create(rewriter, loc, basePtr.getType(),
+    auto inboundsFlags = isSpeculative ? LLVM::GEPNoWrapFlags::none : LLVM::GEPNoWrapFlags::inbounds | LLVM::GEPNoWrapFlags::nuw;
+    Value prefetchPtr = getStridedElementPtr(rewriter, loc, adaptor.getSrc(), adaptor.getIndices(), inboundsFlags);
                                             llvmElemTy, basePtr, offset);
     Operation *newOp = ROCDL::GlobalPrefetchOp::create(
         rewriter, loc, prefetchPtr, scopeAttr, {}, {}, {});

--- a/mlir/lib/Dialect/AMDGPU/IR/AMDGPUOps.cpp
+++ b/mlir/lib/Dialect/AMDGPU/IR/AMDGPUOps.cpp
@@ -1323,8 +1323,15 @@ LogicalResult GlobalPrefetchOp::verify() {
 
   const TemporalHint temporalHint = getTemporalHint();
   const bool isSpeculative = getSpeculative();
-  if (temporalHint == TemporalHint::NT)
-    return this->emitOpError("does not support NT mode");
+
+  // Note that temporal hints are shared between load, store,
+  // prefetch, etc. instructions. However, some instructions
+  // operate only with a subset of hints according to the ISA
+  // documentation. In case of global prefetch, non-temporal (NT)
+  // and last-use (LU) hints are not used. The extra bits of encoding
+  // are used to encode speculative or non-speculative instruction behavior
+  if (llvm::is_contained({TemporalHint::NT, TemporalHint::LU}, temporalHint))
+    return this->emitOpError("does not support NT and LU modes");
 
   if (llvm::is_contained(
           {TemporalHint::NT_RT, TemporalHint::RT_NT, TemporalHint::NT_HT},

--- a/mlir/lib/Dialect/AMDGPU/IR/AMDGPUOps.cpp
+++ b/mlir/lib/Dialect/AMDGPU/IR/AMDGPUOps.cpp
@@ -1302,5 +1302,35 @@ LogicalResult DsBarrierArriveOp::verify() {
   return verifyDsBarrierOpCommon(*this);
 }
 
+//===----------------------------------------------------------------------===//
+// GlobalPrefetchOp
+//===----------------------------------------------------------------------===//
+
+LogicalResult GlobalPrefetchOp::verify() {
+  auto src = cast<MemRefType>(getSrc().getType());
+
+  const unsigned memorySpace = src.getMemorySpaceAsInt();
+  if (memorySpace != 1)
+    return this->emitOpError("the source must reside in address space `1`");
+
+  ArrayRef<int64_t> srcShape = src.getShape();
+  const size_t numIndices = getIndices().size();
+  if (srcShape.size() != numIndices)
+    return this->emitOpError(
+        "the number of indices must match the source shape size");
+
+  const TemporalHint temporalHint = getTemporalHint();
+  const bool isSpeculative = getSpeculative();
+  if (temporalHint == TemporalHint::NT)
+    return this->emitOpError("does not support NT mode");
+  if ((temporalHint == TemporalHint::NT_RT) ||
+      (temporalHint == TemporalHint::RT_NT) ||
+      (temporalHint == TemporalHint::NT_HT)) {
+    if (!isSpeculative)
+      return this->emitOpError("operates only in the speculative mode");
+  }
+  return success();
+}
+
 #define GET_OP_CLASSES
 #include "mlir/Dialect/AMDGPU/IR/AMDGPU.cpp.inc"

--- a/mlir/lib/Dialect/AMDGPU/IR/AMDGPUOps.cpp
+++ b/mlir/lib/Dialect/AMDGPU/IR/AMDGPUOps.cpp
@@ -1309,7 +1309,10 @@ LogicalResult DsBarrierArriveOp::verify() {
 LogicalResult GlobalPrefetchOp::verify() {
   auto src = cast<MemRefType>(getSrc().getType());
 
-  if (!hasGlobalMemorySpace(src.getMemorySpace()))
+  Attribute memSpace = src.getMemorySpace();
+  if (!memSpace)
+    return this->emitOpError("the source must have address space attribute");
+  if (!hasGlobalMemorySpace(memSpace))
     return this->emitOpError("the source must reside in global address space");
 
   ArrayRef<int64_t> srcShape = src.getShape();

--- a/mlir/lib/Dialect/AMDGPU/IR/AMDGPUOps.cpp
+++ b/mlir/lib/Dialect/AMDGPU/IR/AMDGPUOps.cpp
@@ -1323,11 +1323,12 @@ LogicalResult GlobalPrefetchOp::verify() {
   const bool isSpeculative = getSpeculative();
   if (temporalHint == TemporalHint::NT)
     return this->emitOpError("does not support NT mode");
-  if ((temporalHint == TemporalHint::NT_RT) ||
-      (temporalHint == TemporalHint::RT_NT) ||
-      (temporalHint == TemporalHint::NT_HT)) {
-    if (!isSpeculative)
-      return this->emitOpError("operates only in the speculative mode");
+
+  if (llvm::is_contained(
+          {TemporalHint::NT_RT, TemporalHint::RT_NT, TemporalHint::NT_HT},
+          temporalHint) &&
+      !isSpeculative) {
+    return this->emitOpError("operates only in the speculative mode");
   }
   return success();
 }

--- a/mlir/lib/Dialect/AMDGPU/IR/AMDGPUOps.cpp
+++ b/mlir/lib/Dialect/AMDGPU/IR/AMDGPUOps.cpp
@@ -1309,12 +1309,8 @@ LogicalResult DsBarrierArriveOp::verify() {
 LogicalResult GlobalPrefetchOp::verify() {
   auto src = cast<MemRefType>(getSrc().getType());
 
-  if (auto spaceAttr = dyn_cast<gpu::AddressSpaceAttr>(src.getMemorySpace())) {
-    if (spaceAttr.getValue() != gpu::AddressSpace::Global)
-      return this->emitOpError(
-          "the source must reside in global address space");
-  } else
-    return this->emitOpError("requires gpu address space attrubute");
+  if (!hasGlobalMemorySpace(src.getMemorySpace()))
+    return this->emitOpError("the source must reside in global address space");
 
   ArrayRef<int64_t> srcShape = src.getShape();
   const size_t numIndices = getIndices().size();

--- a/mlir/lib/Dialect/AMDGPU/IR/AMDGPUOps.cpp
+++ b/mlir/lib/Dialect/AMDGPU/IR/AMDGPUOps.cpp
@@ -1309,9 +1309,12 @@ LogicalResult DsBarrierArriveOp::verify() {
 LogicalResult GlobalPrefetchOp::verify() {
   auto src = cast<MemRefType>(getSrc().getType());
 
-  const unsigned memorySpace = src.getMemorySpaceAsInt();
-  if (memorySpace != 1)
-    return this->emitOpError("the source must reside in address space `1`");
+  if (auto spaceAttr = dyn_cast<gpu::AddressSpaceAttr>(src.getMemorySpace())) {
+    if (spaceAttr.getValue() != gpu::AddressSpace::Global)
+      return this->emitOpError(
+          "the source must reside in global address space");
+  } else
+    return this->emitOpError("requires gpu address space attrubute");
 
   ArrayRef<int64_t> srcShape = src.getShape();
   const size_t numIndices = getIndices().size();

--- a/mlir/test/Conversion/AMDGPUToROCDL/global-prefetch.mlir
+++ b/mlir/test/Conversion/AMDGPUToROCDL/global-prefetch.mlir
@@ -4,7 +4,7 @@
 func.func @glb_prefetch0(%src : memref<64x64xf16, #gpu.address_space<global>>, %i : i64, %j : i64) {
   // CHECK: %[[PTR:.*]] = llvm.getelementptr %{{.*}}[%{{.*}}] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f16
   // CHECK: rocdl.global.prefetch %{{.*}}, scope 0 : !llvm.ptr<1>
-  amdgpu.global_prefetch %src[%i, %j] RT speculative : memref<64x64xf16, #gpu.address_space<global>>
+  amdgpu.global_prefetch %src[%i, %j] RT WGP speculative : memref<64x64xf16, #gpu.address_space<global>>
   func.return
 }
 
@@ -12,6 +12,14 @@ func.func @glb_prefetch0(%src : memref<64x64xf16, #gpu.address_space<global>>, %
 func.func @glb_prefetch1(%src : memref<64x64xf16, #gpu.address_space<global>>, %i : i64, %j : i64) {
   // CHECK: %[[PTR:.*]] = llvm.getelementptr inbounds|nuw %{{.*}}[%{{.*}}] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f16
   // CHECK: rocdl.global.prefetch %[[PTR]], scope 3 : !llvm.ptr<1>
-  amdgpu.global_prefetch %src[%i, %j] HT : memref<64x64xf16, #gpu.address_space<global>>
+  amdgpu.global_prefetch %src[%i, %j] HT WGP : memref<64x64xf16, #gpu.address_space<global>>
+  func.return
+}
+
+// CHECK-LABEL: @glb_prefetch2
+func.func @glb_prefetch2(%src : memref<64x64xf16, #gpu.address_space<global>>, %i : i64, %j : i64) {
+  // CHECK: %[[PTR:.*]] = llvm.getelementptr %{{.*}}[%{{.*}}] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f16
+  // CHECK: rocdl.global.prefetch %[[PTR]], scope 10 : !llvm.ptr<1>
+  amdgpu.global_prefetch %src[%i, %j] HT SE speculative : memref<64x64xf16, #gpu.address_space<global>>
   func.return
 }

--- a/mlir/test/Conversion/AMDGPUToROCDL/global-prefetch.mlir
+++ b/mlir/test/Conversion/AMDGPUToROCDL/global-prefetch.mlir
@@ -2,6 +2,7 @@
 
 // CHECK-LABEL: @glb_prefetch0
 func.func @glb_prefetch0(%src : memref<64x64xf16, #gpu.address_space<global>>, %i : i64, %j : i64) {
+  // CHECK: %[[PTR:.*]] = llvm.getelementptr %{{.*}}[%{{.*}}] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f16
   // CHECK: rocdl.global.prefetch %{{.*}}, scope 0 : !llvm.ptr<1>
   amdgpu.global_prefetch %src[%i, %j] RT speculative : memref<64x64xf16, #gpu.address_space<global>>
   func.return
@@ -9,7 +10,8 @@ func.func @glb_prefetch0(%src : memref<64x64xf16, #gpu.address_space<global>>, %
 
 // CHECK-LABEL: @glb_prefetch1
 func.func @glb_prefetch1(%src : memref<64x64xf16, #gpu.address_space<global>>, %i : i64, %j : i64) {
-  // CHECK: rocdl.global.prefetch %{{.*}}, scope 3 : !llvm.ptr<1>
+  // CHECK: %[[PTR:.*]] = llvm.getelementptr inbounds|nuw %{{.*}}[%{{.*}}] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f16
+  // CHECK: rocdl.global.prefetch %[[PTR]], scope 3 : !llvm.ptr<1>
   amdgpu.global_prefetch %src[%i, %j] HT : memref<64x64xf16, #gpu.address_space<global>>
   func.return
 }

--- a/mlir/test/Conversion/AMDGPUToROCDL/global-prefetch.mlir
+++ b/mlir/test/Conversion/AMDGPUToROCDL/global-prefetch.mlir
@@ -1,15 +1,15 @@
 // RUN: mlir-opt %s --convert-amdgpu-to-rocdl=chipset=gfx1250 --split-input-file --verify-diagnostics | FileCheck %s
 
 // CHECK-LABEL: @glb_prefetch0
-func.func @glb_prefetch0(%src : memref<64x64xf16, 1>, %i : i64, %j : i64) {
+func.func @glb_prefetch0(%src : memref<64x64xf16, #gpu.address_space<global>>, %i : i64, %j : i64) {
   // CHECK: rocdl.global.prefetch %{{.*}}, scope 0 : !llvm.ptr<1>
-  amdgpu.global_prefetch %src[%i, %j] RT speculative : memref<64x64xf16, 1>
+  amdgpu.global_prefetch %src[%i, %j] RT speculative : memref<64x64xf16, #gpu.address_space<global>>
   func.return
 }
 
 // CHECK-LABEL: @glb_prefetch1
-func.func @glb_prefetch1(%src : memref<64x64xf16, 1>, %i : i64, %j : i64) {
+func.func @glb_prefetch1(%src : memref<64x64xf16, #gpu.address_space<global>>, %i : i64, %j : i64) {
   // CHECK: rocdl.global.prefetch %{{.*}}, scope 3 : !llvm.ptr<1>
-  amdgpu.global_prefetch %src[%i, %j] HT : memref<64x64xf16, 1>
+  amdgpu.global_prefetch %src[%i, %j] HT : memref<64x64xf16, #gpu.address_space<global>>
   func.return
 }

--- a/mlir/test/Conversion/AMDGPUToROCDL/global-prefetch.mlir
+++ b/mlir/test/Conversion/AMDGPUToROCDL/global-prefetch.mlir
@@ -1,0 +1,15 @@
+// RUN: mlir-opt %s --convert-amdgpu-to-rocdl=chipset=gfx1250 --split-input-file --verify-diagnostics | FileCheck %s
+
+// CHECK-LABEL: @glb_prefetch0
+func.func @glb_prefetch0(%src : memref<64x64xf16, 1>, %i : i64, %j : i64) {
+  // CHECK: rocdl.global.prefetch %{{.*}}, scope 0 : !llvm.ptr<1>
+  amdgpu.global_prefetch %src[%i, %j] RT speculative : memref<64x64xf16, 1>
+  func.return
+}
+
+// CHECK-LABEL: @glb_prefetch1
+func.func @glb_prefetch1(%src : memref<64x64xf16, 1>, %i : i64, %j : i64) {
+  // CHECK: rocdl.global.prefetch %{{.*}}, scope 3 : !llvm.ptr<1>
+  amdgpu.global_prefetch %src[%i, %j] HT : memref<64x64xf16, 1>
+  func.return
+}

--- a/mlir/test/Dialect/AMDGPU/invalid.mlir
+++ b/mlir/test/Dialect/AMDGPU/invalid.mlir
@@ -693,8 +693,17 @@ func.func @global_prefetch_wrong_num_indices(%src: memref<64x64xf16, #gpu.addres
 
 // GlobalPrefetchOp: NT temporal hint is not supported
 func.func @global_prefetch_nt_mode(%src: memref<64x64xf16, #gpu.address_space<global>>, %i: i64, %j: i64) {
-  // expected-error@+1 {{'amdgpu.global_prefetch' op does not support NT mode}}
+  // expected-error@+1 {{'amdgpu.global_prefetch' op does not support NT and LU modes}}
   amdgpu.global_prefetch %src[%i, %j] NT SYS : memref<64x64xf16, #gpu.address_space<global>>
+  func.return
+}
+
+// -----
+
+// GlobalPrefetchOp: LU temporal hint is not supported
+func.func @global_prefetch_lu_mode(%src: memref<64x64xf16, #gpu.address_space<global>>, %i: i64, %j: i64) {
+  // expected-error@+1 {{'amdgpu.global_prefetch' op does not support NT and LU modes}}
+  amdgpu.global_prefetch %src[%i, %j] LU DEV : memref<64x64xf16, #gpu.address_space<global>>
   func.return
 }
 

--- a/mlir/test/Dialect/AMDGPU/invalid.mlir
+++ b/mlir/test/Dialect/AMDGPU/invalid.mlir
@@ -666,7 +666,7 @@ func.func @sparse_wmma_i4_requires_equal_length_wave64(%a: vector<8xi4>, %b: vec
 // GlobalPrefetchOp: source must have address space attribute
 func.func @global_prefetch_no_address_space(%src: memref<64x64xf16>, %i: i64, %j: i64) {
   // expected-error@+1 {{'amdgpu.global_prefetch' op the source must have address space attribute}}
-  amdgpu.global_prefetch %src[%i, %j] RT : memref<64x64xf16>
+  amdgpu.global_prefetch %src[%i, %j] RT WGP : memref<64x64xf16>
   func.return
 }
 
@@ -676,7 +676,7 @@ func.func @global_prefetch_no_address_space(%src: memref<64x64xf16>, %i: i64, %j
 // GlobalPrefetchOp: source must reside in global address space
 func.func @global_prefetch_wrong_address_space(%src: memref<64x64xf16, #gpu.address_space<workgroup>>, %i: i64, %j: i64) {
   // expected-error@+1 {{'amdgpu.global_prefetch' op the source must reside in global address space}}
-  amdgpu.global_prefetch %src[%i, %j] RT : memref<64x64xf16, #gpu.address_space<workgroup>>
+  amdgpu.global_prefetch %src[%i, %j] RT SE : memref<64x64xf16, #gpu.address_space<workgroup>>
   func.return
 }
 
@@ -685,7 +685,7 @@ func.func @global_prefetch_wrong_address_space(%src: memref<64x64xf16, #gpu.addr
 // GlobalPrefetchOp: number of indices must match source shape rank
 func.func @global_prefetch_wrong_num_indices(%src: memref<64x64xf16, #gpu.address_space<global>>, %i: i64) {
   // expected-error@+1 {{'amdgpu.global_prefetch' op the number of indices must match the source shape size}}
-  amdgpu.global_prefetch %src[%i] RT : memref<64x64xf16, #gpu.address_space<global>>
+  amdgpu.global_prefetch %src[%i] RT DEV : memref<64x64xf16, #gpu.address_space<global>>
   func.return
 }
 
@@ -694,7 +694,7 @@ func.func @global_prefetch_wrong_num_indices(%src: memref<64x64xf16, #gpu.addres
 // GlobalPrefetchOp: NT temporal hint is not supported
 func.func @global_prefetch_nt_mode(%src: memref<64x64xf16, #gpu.address_space<global>>, %i: i64, %j: i64) {
   // expected-error@+1 {{'amdgpu.global_prefetch' op does not support NT mode}}
-  amdgpu.global_prefetch %src[%i, %j] NT : memref<64x64xf16, #gpu.address_space<global>>
+  amdgpu.global_prefetch %src[%i, %j] NT SYS : memref<64x64xf16, #gpu.address_space<global>>
   func.return
 }
 
@@ -703,7 +703,7 @@ func.func @global_prefetch_nt_mode(%src: memref<64x64xf16, #gpu.address_space<gl
 // GlobalPrefetchOp: NT_RT requires speculative mode
 func.func @global_prefetch_nt_rt_not_speculative(%src: memref<64x64xf16, #gpu.address_space<global>>, %i: i64, %j: i64) {
   // expected-error@+1 {{'amdgpu.global_prefetch' op operates only in the speculative mode}}
-  amdgpu.global_prefetch %src[%i, %j] NT_RT : memref<64x64xf16, #gpu.address_space<global>>
+  amdgpu.global_prefetch %src[%i, %j] NT_RT WGP : memref<64x64xf16, #gpu.address_space<global>>
   func.return
 }
 
@@ -712,7 +712,7 @@ func.func @global_prefetch_nt_rt_not_speculative(%src: memref<64x64xf16, #gpu.ad
 // GlobalPrefetchOp: RT_NT requires speculative mode
 func.func @global_prefetch_rt_nt_not_speculative(%src: memref<64x64xf16, #gpu.address_space<global>>, %i: i64, %j: i64) {
   // expected-error@+1 {{'amdgpu.global_prefetch' op operates only in the speculative mode}}
-  amdgpu.global_prefetch %src[%i, %j] RT_NT : memref<64x64xf16, #gpu.address_space<global>>
+  amdgpu.global_prefetch %src[%i, %j] RT_NT SE : memref<64x64xf16, #gpu.address_space<global>>
   func.return
 }
 
@@ -721,6 +721,6 @@ func.func @global_prefetch_rt_nt_not_speculative(%src: memref<64x64xf16, #gpu.ad
 // GlobalPrefetchOp: NT_HT requires speculative mode
 func.func @global_prefetch_nt_ht_not_speculative(%src: memref<64x64xf16, #gpu.address_space<global>>, %i: i64, %j: i64) {
   // expected-error@+1 {{'amdgpu.global_prefetch' op operates only in the speculative mode}}
-  amdgpu.global_prefetch %src[%i, %j] NT_HT : memref<64x64xf16, #gpu.address_space<global>>
+  amdgpu.global_prefetch %src[%i, %j] NT_HT DEV : memref<64x64xf16, #gpu.address_space<global>>
   func.return
 }

--- a/mlir/test/Dialect/AMDGPU/invalid.mlir
+++ b/mlir/test/Dialect/AMDGPU/invalid.mlir
@@ -660,3 +660,57 @@ func.func @sparse_wmma_i4_requires_equal_length_wave64(%a: vector<8xi4>, %b: vec
   %d = amdgpu.sparse_wmma 16x16x32 %a * %b + %c sparse(%idx : vector<4xi8>) {wave64} : vector<8xi4>, vector<16xi4>, vector<4xi32>
   func.return %d : vector<4xi32>
 }
+
+// -----
+
+// GlobalPrefetchOp: source must reside in address space 1
+func.func @global_prefetch_wrong_address_space(%src: memref<64x64xf16>, %i: i64, %j: i64) {
+  // expected-error@+1 {{'amdgpu.global_prefetch' op the source must reside in address space `1`}}
+  amdgpu.global_prefetch %src[%i, %j] RT : memref<64x64xf16>
+  func.return
+}
+
+// -----
+
+// GlobalPrefetchOp: number of indices must match source shape rank
+func.func @global_prefetch_wrong_num_indices(%src: memref<64x64xf16, 1>, %i: i64) {
+  // expected-error@+1 {{'amdgpu.global_prefetch' op the number of indices must match the source shape size}}
+  amdgpu.global_prefetch %src[%i] RT : memref<64x64xf16, 1>
+  func.return
+}
+
+// -----
+
+// GlobalPrefetchOp: NT temporal hint is not supported
+func.func @global_prefetch_nt_mode(%src: memref<64x64xf16, 1>, %i: i64, %j: i64) {
+  // expected-error@+1 {{'amdgpu.global_prefetch' op does not support NT mode}}
+  amdgpu.global_prefetch %src[%i, %j] NT : memref<64x64xf16, 1>
+  func.return
+}
+
+// -----
+
+// GlobalPrefetchOp: NT_RT requires speculative mode
+func.func @global_prefetch_nt_rt_not_speculative(%src: memref<64x64xf16, 1>, %i: i64, %j: i64) {
+  // expected-error@+1 {{'amdgpu.global_prefetch' op operates only in the speculative mode}}
+  amdgpu.global_prefetch %src[%i, %j] NT_RT : memref<64x64xf16, 1>
+  func.return
+}
+
+// -----
+
+// GlobalPrefetchOp: RT_NT requires speculative mode
+func.func @global_prefetch_rt_nt_not_speculative(%src: memref<64x64xf16, 1>, %i: i64, %j: i64) {
+  // expected-error@+1 {{'amdgpu.global_prefetch' op operates only in the speculative mode}}
+  amdgpu.global_prefetch %src[%i, %j] RT_NT : memref<64x64xf16, 1>
+  func.return
+}
+
+// -----
+
+// GlobalPrefetchOp: NT_HT requires speculative mode
+func.func @global_prefetch_nt_ht_not_speculative(%src: memref<64x64xf16, 1>, %i: i64, %j: i64) {
+  // expected-error@+1 {{'amdgpu.global_prefetch' op operates only in the speculative mode}}
+  amdgpu.global_prefetch %src[%i, %j] NT_HT : memref<64x64xf16, 1>
+  func.return
+}

--- a/mlir/test/Dialect/AMDGPU/invalid.mlir
+++ b/mlir/test/Dialect/AMDGPU/invalid.mlir
@@ -663,54 +663,64 @@ func.func @sparse_wmma_i4_requires_equal_length_wave64(%a: vector<8xi4>, %b: vec
 
 // -----
 
-// GlobalPrefetchOp: source must reside in address space 1
-func.func @global_prefetch_wrong_address_space(%src: memref<64x64xf16>, %i: i64, %j: i64) {
-  // expected-error@+1 {{'amdgpu.global_prefetch' op the source must reside in address space `1`}}
+// GlobalPrefetchOp: source must have address space attribute
+func.func @global_prefetch_no_address_space(%src: memref<64x64xf16>, %i: i64, %j: i64) {
+  // expected-error@+1 {{'amdgpu.global_prefetch' op the source must have address space attribute}}
   amdgpu.global_prefetch %src[%i, %j] RT : memref<64x64xf16>
+  func.return
+}
+
+
+// -----
+
+// GlobalPrefetchOp: source must reside in global address space
+func.func @global_prefetch_wrong_address_space(%src: memref<64x64xf16, #gpu.address_space<workgroup>>, %i: i64, %j: i64) {
+  // expected-error@+1 {{'amdgpu.global_prefetch' op the source must reside in global address space}}
+  amdgpu.global_prefetch %src[%i, %j] RT : memref<64x64xf16, #gpu.address_space<workgroup>>
   func.return
 }
 
 // -----
 
 // GlobalPrefetchOp: number of indices must match source shape rank
-func.func @global_prefetch_wrong_num_indices(%src: memref<64x64xf16, 1>, %i: i64) {
+func.func @global_prefetch_wrong_num_indices(%src: memref<64x64xf16, #gpu.address_space<global>>, %i: i64) {
   // expected-error@+1 {{'amdgpu.global_prefetch' op the number of indices must match the source shape size}}
-  amdgpu.global_prefetch %src[%i] RT : memref<64x64xf16, 1>
+  amdgpu.global_prefetch %src[%i] RT : memref<64x64xf16, #gpu.address_space<global>>
   func.return
 }
 
 // -----
 
 // GlobalPrefetchOp: NT temporal hint is not supported
-func.func @global_prefetch_nt_mode(%src: memref<64x64xf16, 1>, %i: i64, %j: i64) {
+func.func @global_prefetch_nt_mode(%src: memref<64x64xf16, #gpu.address_space<global>>, %i: i64, %j: i64) {
   // expected-error@+1 {{'amdgpu.global_prefetch' op does not support NT mode}}
-  amdgpu.global_prefetch %src[%i, %j] NT : memref<64x64xf16, 1>
+  amdgpu.global_prefetch %src[%i, %j] NT : memref<64x64xf16, #gpu.address_space<global>>
   func.return
 }
 
 // -----
 
 // GlobalPrefetchOp: NT_RT requires speculative mode
-func.func @global_prefetch_nt_rt_not_speculative(%src: memref<64x64xf16, 1>, %i: i64, %j: i64) {
+func.func @global_prefetch_nt_rt_not_speculative(%src: memref<64x64xf16, #gpu.address_space<global>>, %i: i64, %j: i64) {
   // expected-error@+1 {{'amdgpu.global_prefetch' op operates only in the speculative mode}}
-  amdgpu.global_prefetch %src[%i, %j] NT_RT : memref<64x64xf16, 1>
+  amdgpu.global_prefetch %src[%i, %j] NT_RT : memref<64x64xf16, #gpu.address_space<global>>
   func.return
 }
 
 // -----
 
 // GlobalPrefetchOp: RT_NT requires speculative mode
-func.func @global_prefetch_rt_nt_not_speculative(%src: memref<64x64xf16, 1>, %i: i64, %j: i64) {
+func.func @global_prefetch_rt_nt_not_speculative(%src: memref<64x64xf16, #gpu.address_space<global>>, %i: i64, %j: i64) {
   // expected-error@+1 {{'amdgpu.global_prefetch' op operates only in the speculative mode}}
-  amdgpu.global_prefetch %src[%i, %j] RT_NT : memref<64x64xf16, 1>
+  amdgpu.global_prefetch %src[%i, %j] RT_NT : memref<64x64xf16, #gpu.address_space<global>>
   func.return
 }
 
 // -----
 
 // GlobalPrefetchOp: NT_HT requires speculative mode
-func.func @global_prefetch_nt_ht_not_speculative(%src: memref<64x64xf16, 1>, %i: i64, %j: i64) {
+func.func @global_prefetch_nt_ht_not_speculative(%src: memref<64x64xf16, #gpu.address_space<global>>, %i: i64, %j: i64) {
   // expected-error@+1 {{'amdgpu.global_prefetch' op operates only in the speculative mode}}
-  amdgpu.global_prefetch %src[%i, %j] NT_HT : memref<64x64xf16, 1>
+  amdgpu.global_prefetch %src[%i, %j] NT_HT : memref<64x64xf16, #gpu.address_space<global>>
   func.return
 }


### PR DESCRIPTION
This PR adds `global_prefetch` op to  prefetch a cache line to high-level caches using the aligned address of the source `memref` and an offset provided by the indices of the element containing the cache line. This provides temporal hints (e.g., regular or high-priority). Note that out-of-bounds access is allowed in speculative mode. Ensure the source `memref` is in address space `1`.