### PR TITLE
[mlir][XeGPU] Validate single-block requirement in MoveFuncBodyToWarpOp

### DIFF
--- a/mlir/lib/Dialect/XeGPU/Transforms/XeGPUSubgroupDistribute.cpp
+++ b/mlir/lib/Dialect/XeGPU/Transforms/XeGPUSubgroupDistribute.cpp
@@ -153,8 +153,8 @@ struct MoveFuncBodyToWarpOp : public OpRewritePattern<gpu::GPUFuncOp> {
           gpuFuncOp, "Subgroup distribution requires target attribute attached "
                      "to set the warp size");
     if (!gpuFuncOp.getBody().hasOneBlock())
-        return rewriter.notifyMatchFailure(
-            gpuFuncOp, "expected gpu.func to have a single block");
+      return rewriter.notifyMatchFailure(
+          gpuFuncOp, "expected gpu.func to have a single block");
 
     // If the function only contains a single void return, skip.
     if (llvm::all_of(gpuFuncOp.getBody().getOps(), [](Operation &op) {

--- a/mlir/lib/Dialect/XeGPU/Transforms/XeGPUSubgroupDistribute.cpp
+++ b/mlir/lib/Dialect/XeGPU/Transforms/XeGPUSubgroupDistribute.cpp
@@ -152,6 +152,10 @@ struct MoveFuncBodyToWarpOp : public OpRewritePattern<gpu::GPUFuncOp> {
       return rewriter.notifyMatchFailure(
           gpuFuncOp, "Subgroup distribution requires target attribute attached "
                      "to set the warp size");
+    if (!gpuFuncOp.getBody().hasOneBlock())
+        return rewriter.notifyMatchFailure(
+            gpuFuncOp, "expected gpu.func to have a single block");
+
     // If the function only contains a single void return, skip.
     if (llvm::all_of(gpuFuncOp.getBody().getOps(), [](Operation &op) {
           return isa<gpu::ReturnOp>(op) && !op.getNumOperands();

--- a/mlir/test/Dialect/XeGPU/move-gpu-func-to-warp-op.mlir
+++ b/mlir/test/Dialect/XeGPU/move-gpu-func-to-warp-op.mlir
@@ -70,3 +70,26 @@ gpu.module @test {
 // Regression test for MoveFuncBodyToWarpOp on malformed generic gpu.func.
 // CHECK-LABEL: gpu.func @missing_return_terminator
 // CHECK-NEXT:    "test.unknown"() : () -> ()
+
+// -----
+
+gpu.module @test {
+  gpu.func @multiple_blocks(%cond: i1) {
+    cf.cond_br %cond, ^bb1, ^bb2
+  ^bb1:  // pred: ^bb0
+    "test.unknown"() : () -> ()
+    cf.br ^bb2
+  ^bb2:  // 2 preds: ^bb0, ^bb1
+    gpu.return
+  }
+}
+
+// CHECK-LABEL:  gpu.func @multiple_blocks(
+// CHECK-SAME:                             %[[VAL_0:.*]]: i1) {
+// CHECK:          cf.cond_br %[[VAL_0]], ^bb1, ^bb2
+// CHECK:        ^bb1:
+// CHECK:          "test.unknown"() : () -> ()
+// CHECK:          cf.br ^bb2
+// CHECK:        ^bb2:
+// CHECK:          gpu.return
+// CHECK:        }

--- a/mlir/test/Dialect/XeGPU/move-gpu-func-to-warp-op.mlir
+++ b/mlir/test/Dialect/XeGPU/move-gpu-func-to-warp-op.mlir
@@ -84,12 +84,11 @@ gpu.module @test {
   }
 }
 
-// CHECK-LABEL:  gpu.func @multiple_blocks(
-// CHECK-SAME:                             %[[VAL_0:.*]]: i1) {
-// CHECK:          cf.cond_br %[[VAL_0]], ^bb1, ^bb2
-// CHECK:        ^bb1:
-// CHECK:          "test.unknown"() : () -> ()
-// CHECK:          cf.br ^bb2
-// CHECK:        ^bb2:
-// CHECK:          gpu.return
-// CHECK:        }
+// CHECK-LABEL: gpu.func @multiple_blocks
+// CHECK-SAME:  %[[COND:.*]]: i1
+// CHECK-NEXT:  cf.cond_br %[[COND]], ^bb1, ^bb2
+// CHECK:       ^bb1:
+// CHECK-NEXT:    "test.unknown"() : () -> ()
+// CHECK-NEXT:    cf.br ^bb2
+// CHECK:       ^bb2:
+// CHECK-NEXT:    gpu.return


### PR DESCRIPTION
Add validation to ensure GPU function body has a single block before applying the MoveFuncBodyToWarpOp transformation in XeGPU subgroup distribution. This check prevents incorrect handling of multi-block GPU functions. Fixes #185366.