### PR TITLE
clang: Report subgroup ext types for AMDGPU with llvm env

### DIFF
--- a/clang/lib/Basic/Targets/AMDGPU.h
+++ b/clang/lib/Basic/Targets/AMDGPU.h
@@ -346,6 +346,10 @@ public:
         Opts["__opencl_c_device_enqueue"] = true;
         Opts["__opencl_c_pipes"] = true;
       }
+
+      if (getTriple().getEnvironment() == llvm::Triple::LLVM) {
+        Opts["cl_khr_subgroup_extended_types"] = true;
+      }
     }
   }
 

--- a/clang/test/Misc/amdgcn.languageOptsOpenCL.cl
+++ b/clang/test/Misc/amdgcn.languageOptsOpenCL.cl
@@ -14,6 +14,8 @@
 // Test none target with amdhsa triple, which implies >= gfx700
 // RUN: %clang_cc1 -x cl -cl-std=CL3.0 %s -verify -triple amdgcn-unknown-amdhsa -Wpedantic-core-features -DTEST_CORE_FEATURES -DFLAT_SUPPORT
 
+// RUN: %clang_cc1 -x cl -cl-std=CL3.0 %s -verify -triple amdgcn-unknown-amdhsa-llvm -Wpedantic-core-features -DTEST_CORE_FEATURES -DFLAT_SUPPORT -DLLVM_ENV_EXTENSIONS
+
 // Extensions in all versions
 #ifndef cl_clang_storage_class_specifiers
 #error "Missing cl_clang_storage_class_specifiers define"
@@ -217,5 +219,17 @@
     #ifdef __opencl_c_pipes
       #error "Incorrect __opencl_c_pipes define"
     #endif
+  #endif
+#endif
+
+#ifdef LLVM_ENV_EXTENSIONS
+  // Features available with llvm env
+  #ifndef cl_khr_subgroup_extended_types
+    #error "missing cl_khr_subgroup_extended_types define"
+  #endif
+#else
+  // Features not available with unknown environment.
+  #ifdef cl_khr_subgroup_extended_types
+    #error "incorrect cl_khr_subgroup_extended_types define"
   #endif
 #endif


### PR DESCRIPTION
Report cl_khr_subgroup_extended_types for AMDGPU when targeting
the llvm environment.