### PR TITLE
[mlir][CAPI] Fix unused-but-set-variable warning in smt.c (NFC)

### DIFF
--- a/mlir/test/CAPI/smt.c
+++ b/mlir/test/CAPI/smt.c
@@ -44,6 +44,7 @@ void testExportSMTLIB(MlirContext ctx) {
   result = mlirTranslateModuleToSMTLIB(module, dumpCallback, NULL, false, false,
                                        false);
   assert(mlirLogicalResultIsSuccess(result));
+  (void)result;
 
   // CHECK-NOT: (reset)
   mlirModuleDestroy(module);


### PR DESCRIPTION
llvm-project/mlir/test/CAPI/smt.c:37:21: warning: variable 'result' set but not used [-Wunused-but-set-variable]
   37 |   MlirLogicalResult result = mlirTranslateModuleToSMTLIB(
      |                     ^
1 warning generated.