### PR TITLE
libclc: Fix missing overloads for atomic_fetch_add/sub

### DIFF
--- a/libclc/opencl/lib/generic/atomic/atomic_fetch_add.cl
+++ b/libclc/opencl/lib/generic/atomic/atomic_fetch_add.cl
@@ -18,19 +18,14 @@
 #define __CLC_BODY "atomic_def.inc"
 #include "clc/math/gentype.inc"
 
-#if defined(__opencl_c_atomic_order_seq_cst) &&                                \
-    defined(__opencl_c_atomic_scope_device)
+#ifdef __opencl_c_atomic_scope_device
+
+#ifdef __opencl_c_atomic_order_seq_cst
 
 _CLC_OVERLOAD _CLC_DEF uintptr_t
 atomic_fetch_add(volatile __local atomic_uintptr_t *p, ptrdiff_t v) {
   return __scoped_atomic_fetch_add((volatile __local uintptr_t *)p, v,
                                    __ATOMIC_SEQ_CST, __MEMORY_SCOPE_DEVICE);
-}
-
-_CLC_OVERLOAD _CLC_DEF uintptr_t atomic_fetch_add(
-    volatile __local atomic_uintptr_t *p, ptrdiff_t v, memory_order order) {
-  return __scoped_atomic_fetch_add((volatile __local uintptr_t *)p, v, order,
-                                   __MEMORY_SCOPE_DEVICE);
 }
 
 _CLC_OVERLOAD _CLC_DEF uintptr_t
@@ -39,20 +34,42 @@ atomic_fetch_add(volatile __global atomic_uintptr_t *p, ptrdiff_t v) {
                                    __ATOMIC_SEQ_CST, __MEMORY_SCOPE_DEVICE);
 }
 
+#if _CLC_GENERIC_AS_SUPPORTED
+_CLC_OVERLOAD _CLC_DEF uintptr_t atomic_fetch_add(volatile atomic_uintptr_t *p,
+                                                  ptrdiff_t v) {
+  return __scoped_atomic_fetch_add((volatile uintptr_t *)p, v, __ATOMIC_SEQ_CST,
+                                   __MEMORY_SCOPE_DEVICE);
+}
+#endif // _CLC_GENERIC_AS_SUPPORTED
+#endif // __opencl_c_atomic_order_seq_cst
+
+_CLC_OVERLOAD _CLC_DEF uintptr_t atomic_fetch_add(
+    volatile __local atomic_uintptr_t *p, ptrdiff_t v, memory_order order) {
+  return __scoped_atomic_fetch_add((volatile __local uintptr_t *)p, v, order,
+                                   __MEMORY_SCOPE_DEVICE);
+}
+
+_CLC_OVERLOAD _CLC_DEF uintptr_t
+atomic_fetch_add(volatile __local atomic_uintptr_t *p, ptrdiff_t v,
+                 memory_order order, memory_scope scope) {
+  return __scoped_atomic_fetch_add((volatile __local uintptr_t *)p, v, order,
+                                   __opencl_get_clang_memory_scope(scope));
+}
+
 _CLC_OVERLOAD _CLC_DEF uintptr_t atomic_fetch_add(
     volatile __global atomic_uintptr_t *p, ptrdiff_t v, memory_order order) {
   return __scoped_atomic_fetch_add((volatile __global uintptr_t *)p, v, order,
                                    __MEMORY_SCOPE_DEVICE);
 }
 
-#if _CLC_GENERIC_AS_SUPPORTED
-
-_CLC_OVERLOAD _CLC_DEF uintptr_t atomic_fetch_add(volatile atomic_uintptr_t *p,
-                                                  ptrdiff_t v) {
-  return __scoped_atomic_fetch_add((volatile uintptr_t *)p, v, __ATOMIC_SEQ_CST,
-                                   __MEMORY_SCOPE_DEVICE);
+_CLC_OVERLOAD _CLC_DEF uintptr_t
+atomic_fetch_add(volatile __global atomic_uintptr_t *p, ptrdiff_t v,
+                 memory_order order, memory_scope scope) {
+  return __scoped_atomic_fetch_add((volatile __global uintptr_t *)p, v, order,
+                                   __opencl_get_clang_memory_scope(scope));
 }
 
+#if _CLC_GENERIC_AS_SUPPORTED
 _CLC_OVERLOAD _CLC_DEF uintptr_t atomic_fetch_add(volatile atomic_uintptr_t *p,
                                                   ptrdiff_t v,
                                                   memory_order order) {
@@ -60,7 +77,13 @@ _CLC_OVERLOAD _CLC_DEF uintptr_t atomic_fetch_add(volatile atomic_uintptr_t *p,
                                    __MEMORY_SCOPE_DEVICE);
 }
 
-#endif // _CLC_GENERIC_AS_SUPPORTED
+_CLC_OVERLOAD _CLC_DEF uintptr_t atomic_fetch_add(volatile atomic_uintptr_t *p,
+                                                  ptrdiff_t v,
+                                                  memory_order order,
+                                                  memory_scope scope) {
+  return __scoped_atomic_fetch_add((volatile uintptr_t *)p, v, order,
+                                   __opencl_get_clang_memory_scope(scope));
+}
 
-#endif // defined(__opencl_c_atomic_order_seq_cst) &&
-       // defined(__opencl_c_atomic_scope_device)
+#endif // _CLC_GENERIC_AS_SUPPORTED
+#endif // __opencl_c_atomic_scope_device

--- a/libclc/opencl/lib/generic/atomic/atomic_fetch_add.cl
+++ b/libclc/opencl/lib/generic/atomic/atomic_fetch_add.cl
@@ -18,9 +18,15 @@
 #define __CLC_BODY "atomic_def.inc"
 #include "clc/math/gentype.inc"
 
-#ifdef __opencl_c_atomic_scope_device
+// If the device address space is 64-bits, the data types atomic_intptr_t,
+// atomic_uintptr_t, atomic_size_t and atomic_ptrdiff_t are supported if the
+// cl_khr_int64_base_atomics and cl_khr_int64_extended_atomics extensions are
+// supported and have been enabled.
+#if __SIZEOF_POINTER__ < 8 || (defined(cl_khr_int64_base_atomics) &&           \
+                               defined(cl_khr_int64_extended_atomics))
 
-#ifdef __opencl_c_atomic_order_seq_cst
+#if defined(__opencl_c_atomic_scope_device) &&                                 \
+    defined(__opencl_c_atomic_order_seq_cst)
 
 _CLC_DEF _CLC_OVERLOAD uintptr_t
 atomic_fetch_add(volatile __local atomic_uintptr_t *p, ptrdiff_t v) {
@@ -41,7 +47,10 @@ _CLC_DEF _CLC_OVERLOAD uintptr_t atomic_fetch_add(volatile atomic_uintptr_t *p,
                                    __MEMORY_SCOPE_DEVICE);
 }
 #endif // _CLC_GENERIC_AS_SUPPORTED
-#endif // __opencl_c_atomic_order_seq_cst
+#endif // defined(__opencl_c_atomic_scope_device) &&
+       // defined(__opencl_c_atomic_order_seq_cst)
+
+#ifdef __opencl_c_atomic_scope_device
 
 _CLC_DEF _CLC_OVERLOAD uintptr_t atomic_fetch_add(
     volatile __local atomic_uintptr_t *p, ptrdiff_t v, memory_order order) {
@@ -49,17 +58,27 @@ _CLC_DEF _CLC_OVERLOAD uintptr_t atomic_fetch_add(
                                    __MEMORY_SCOPE_DEVICE);
 }
 
+_CLC_DEF _CLC_OVERLOAD uintptr_t atomic_fetch_add(
+    volatile __global atomic_uintptr_t *p, ptrdiff_t v, memory_order order) {
+  return __scoped_atomic_fetch_add((volatile __global uintptr_t *)p, v, order,
+                                   __MEMORY_SCOPE_DEVICE);
+}
+
+#if _CLC_GENERIC_AS_SUPPORTED
+_CLC_DEF _CLC_OVERLOAD uintptr_t atomic_fetch_add(volatile atomic_uintptr_t *p,
+                                                  ptrdiff_t v,
+                                                  memory_order order) {
+  return __scoped_atomic_fetch_add((volatile uintptr_t *)p, v, order,
+                                   __MEMORY_SCOPE_DEVICE);
+}
+#endif // _CLC_GENERIC_AS_SUPPORTED
+#endif // __opencl_c_atomic_scope_device
+
 _CLC_DEF _CLC_OVERLOAD uintptr_t
 atomic_fetch_add(volatile __local atomic_uintptr_t *p, ptrdiff_t v,
                  memory_order order, memory_scope scope) {
   return __scoped_atomic_fetch_add((volatile __local uintptr_t *)p, v, order,
                                    __opencl_get_clang_memory_scope(scope));
-}
-
-_CLC_DEF _CLC_OVERLOAD uintptr_t atomic_fetch_add(
-    volatile __global atomic_uintptr_t *p, ptrdiff_t v, memory_order order) {
-  return __scoped_atomic_fetch_add((volatile __global uintptr_t *)p, v, order,
-                                   __MEMORY_SCOPE_DEVICE);
 }
 
 _CLC_DEF _CLC_OVERLOAD uintptr_t
@@ -70,12 +89,6 @@ atomic_fetch_add(volatile __global atomic_uintptr_t *p, ptrdiff_t v,
 }
 
 #if _CLC_GENERIC_AS_SUPPORTED
-_CLC_DEF _CLC_OVERLOAD uintptr_t atomic_fetch_add(volatile atomic_uintptr_t *p,
-                                                  ptrdiff_t v,
-                                                  memory_order order) {
-  return __scoped_atomic_fetch_add((volatile uintptr_t *)p, v, order,
-                                   __MEMORY_SCOPE_DEVICE);
-}
 
 _CLC_DEF _CLC_OVERLOAD uintptr_t atomic_fetch_add(volatile atomic_uintptr_t *p,
                                                   ptrdiff_t v,
@@ -86,4 +99,6 @@ _CLC_DEF _CLC_OVERLOAD uintptr_t atomic_fetch_add(volatile atomic_uintptr_t *p,
 }
 
 #endif // _CLC_GENERIC_AS_SUPPORTED
-#endif // __opencl_c_atomic_scope_device
+
+#endif // __SIZEOF_POINTER__ < 8 || (defined(cl_khr_int64_base_atomics) &&
+       // defined(cl_khr_int64_extended_atomics))

--- a/libclc/opencl/lib/generic/atomic/atomic_fetch_add.cl
+++ b/libclc/opencl/lib/generic/atomic/atomic_fetch_add.cl
@@ -27,10 +27,22 @@ atomic_fetch_add(volatile __local atomic_uintptr_t *p, ptrdiff_t v) {
                                    __ATOMIC_SEQ_CST, __MEMORY_SCOPE_DEVICE);
 }
 
+_CLC_OVERLOAD _CLC_DEF uintptr_t atomic_fetch_add(
+    volatile __local atomic_uintptr_t *p, ptrdiff_t v, memory_order order) {
+  return __scoped_atomic_fetch_add((volatile __local uintptr_t *)p, v, order,
+                                   __MEMORY_SCOPE_DEVICE);
+}
+
 _CLC_OVERLOAD _CLC_DEF uintptr_t
 atomic_fetch_add(volatile __global atomic_uintptr_t *p, ptrdiff_t v) {
   return __scoped_atomic_fetch_add((volatile __global uintptr_t *)p, v,
                                    __ATOMIC_SEQ_CST, __MEMORY_SCOPE_DEVICE);
+}
+
+_CLC_OVERLOAD _CLC_DEF uintptr_t atomic_fetch_add(
+    volatile __global atomic_uintptr_t *p, ptrdiff_t v, memory_order order) {
+  return __scoped_atomic_fetch_add((volatile __global uintptr_t *)p, v, order,
+                                   __MEMORY_SCOPE_DEVICE);
 }
 
 #if _CLC_GENERIC_AS_SUPPORTED
@@ -38,6 +50,13 @@ atomic_fetch_add(volatile __global atomic_uintptr_t *p, ptrdiff_t v) {
 _CLC_OVERLOAD _CLC_DEF uintptr_t atomic_fetch_add(volatile atomic_uintptr_t *p,
                                                   ptrdiff_t v) {
   return __scoped_atomic_fetch_add((volatile uintptr_t *)p, v, __ATOMIC_SEQ_CST,
+                                   __MEMORY_SCOPE_DEVICE);
+}
+
+_CLC_OVERLOAD _CLC_DEF uintptr_t atomic_fetch_add(volatile atomic_uintptr_t *p,
+                                                  ptrdiff_t v,
+                                                  memory_order order) {
+  return __scoped_atomic_fetch_add((volatile uintptr_t *)p, v, order,
                                    __MEMORY_SCOPE_DEVICE);
 }
 

--- a/libclc/opencl/lib/generic/atomic/atomic_fetch_add.cl
+++ b/libclc/opencl/lib/generic/atomic/atomic_fetch_add.cl
@@ -22,20 +22,20 @@
 
 #ifdef __opencl_c_atomic_order_seq_cst
 
-_CLC_OVERLOAD _CLC_DEF uintptr_t
+_CLC_DEF _CLC_OVERLOAD uintptr_t
 atomic_fetch_add(volatile __local atomic_uintptr_t *p, ptrdiff_t v) {
   return __scoped_atomic_fetch_add((volatile __local uintptr_t *)p, v,
                                    __ATOMIC_SEQ_CST, __MEMORY_SCOPE_DEVICE);
 }
 
-_CLC_OVERLOAD _CLC_DEF uintptr_t
+_CLC_DEF _CLC_OVERLOAD uintptr_t
 atomic_fetch_add(volatile __global atomic_uintptr_t *p, ptrdiff_t v) {
   return __scoped_atomic_fetch_add((volatile __global uintptr_t *)p, v,
                                    __ATOMIC_SEQ_CST, __MEMORY_SCOPE_DEVICE);
 }
 
 #if _CLC_GENERIC_AS_SUPPORTED
-_CLC_OVERLOAD _CLC_DEF uintptr_t atomic_fetch_add(volatile atomic_uintptr_t *p,
+_CLC_DEF _CLC_OVERLOAD uintptr_t atomic_fetch_add(volatile atomic_uintptr_t *p,
                                                   ptrdiff_t v) {
   return __scoped_atomic_fetch_add((volatile uintptr_t *)p, v, __ATOMIC_SEQ_CST,
                                    __MEMORY_SCOPE_DEVICE);
@@ -43,26 +43,26 @@ _CLC_OVERLOAD _CLC_DEF uintptr_t atomic_fetch_add(volatile atomic_uintptr_t *p,
 #endif // _CLC_GENERIC_AS_SUPPORTED
 #endif // __opencl_c_atomic_order_seq_cst
 
-_CLC_OVERLOAD _CLC_DEF uintptr_t atomic_fetch_add(
+_CLC_DEF _CLC_OVERLOAD uintptr_t atomic_fetch_add(
     volatile __local atomic_uintptr_t *p, ptrdiff_t v, memory_order order) {
   return __scoped_atomic_fetch_add((volatile __local uintptr_t *)p, v, order,
                                    __MEMORY_SCOPE_DEVICE);
 }
 
-_CLC_OVERLOAD _CLC_DEF uintptr_t
+_CLC_DEF _CLC_OVERLOAD uintptr_t
 atomic_fetch_add(volatile __local atomic_uintptr_t *p, ptrdiff_t v,
                  memory_order order, memory_scope scope) {
   return __scoped_atomic_fetch_add((volatile __local uintptr_t *)p, v, order,
                                    __opencl_get_clang_memory_scope(scope));
 }
 
-_CLC_OVERLOAD _CLC_DEF uintptr_t atomic_fetch_add(
+_CLC_DEF _CLC_OVERLOAD uintptr_t atomic_fetch_add(
     volatile __global atomic_uintptr_t *p, ptrdiff_t v, memory_order order) {
   return __scoped_atomic_fetch_add((volatile __global uintptr_t *)p, v, order,
                                    __MEMORY_SCOPE_DEVICE);
 }
 
-_CLC_OVERLOAD _CLC_DEF uintptr_t
+_CLC_DEF _CLC_OVERLOAD uintptr_t
 atomic_fetch_add(volatile __global atomic_uintptr_t *p, ptrdiff_t v,
                  memory_order order, memory_scope scope) {
   return __scoped_atomic_fetch_add((volatile __global uintptr_t *)p, v, order,
@@ -70,14 +70,14 @@ atomic_fetch_add(volatile __global atomic_uintptr_t *p, ptrdiff_t v,
 }
 
 #if _CLC_GENERIC_AS_SUPPORTED
-_CLC_OVERLOAD _CLC_DEF uintptr_t atomic_fetch_add(volatile atomic_uintptr_t *p,
+_CLC_DEF _CLC_OVERLOAD uintptr_t atomic_fetch_add(volatile atomic_uintptr_t *p,
                                                   ptrdiff_t v,
                                                   memory_order order) {
   return __scoped_atomic_fetch_add((volatile uintptr_t *)p, v, order,
                                    __MEMORY_SCOPE_DEVICE);
 }
 
-_CLC_OVERLOAD _CLC_DEF uintptr_t atomic_fetch_add(volatile atomic_uintptr_t *p,
+_CLC_DEF _CLC_OVERLOAD uintptr_t atomic_fetch_add(volatile atomic_uintptr_t *p,
                                                   ptrdiff_t v,
                                                   memory_order order,
                                                   memory_scope scope) {

--- a/libclc/opencl/lib/generic/atomic/atomic_fetch_sub.cl
+++ b/libclc/opencl/lib/generic/atomic/atomic_fetch_sub.cl
@@ -18,19 +18,14 @@
 #define __CLC_BODY "atomic_def.inc"
 #include "clc/math/gentype.inc"
 
-#if defined(__opencl_c_atomic_order_seq_cst) &&                                \
-    defined(__opencl_c_atomic_scope_device)
+#ifdef __opencl_c_atomic_scope_device
+
+#ifdef __opencl_c_atomic_order_seq_cst
 
 _CLC_OVERLOAD _CLC_DEF uintptr_t
 atomic_fetch_sub(volatile __local atomic_uintptr_t *p, ptrdiff_t v) {
   return __scoped_atomic_fetch_sub((volatile __local uintptr_t *)p, v,
                                    __ATOMIC_SEQ_CST, __MEMORY_SCOPE_DEVICE);
-}
-
-_CLC_OVERLOAD _CLC_DEF uintptr_t atomic_fetch_sub(
-    volatile __local atomic_uintptr_t *p, ptrdiff_t v, memory_order order) {
-  return __scoped_atomic_fetch_sub((volatile __local uintptr_t *)p, v, order,
-                                   __MEMORY_SCOPE_DEVICE);
 }
 
 _CLC_OVERLOAD _CLC_DEF uintptr_t
@@ -39,20 +34,42 @@ atomic_fetch_sub(volatile __global atomic_uintptr_t *p, ptrdiff_t v) {
                                    __ATOMIC_SEQ_CST, __MEMORY_SCOPE_DEVICE);
 }
 
+#if _CLC_GENERIC_AS_SUPPORTED
+_CLC_OVERLOAD _CLC_DEF uintptr_t atomic_fetch_sub(volatile atomic_uintptr_t *p,
+                                                  ptrdiff_t v) {
+  return __scoped_atomic_fetch_sub((volatile uintptr_t *)p, v, __ATOMIC_SEQ_CST,
+                                   __MEMORY_SCOPE_DEVICE);
+}
+#endif // _CLC_GENERIC_AS_SUPPORTED
+#endif // __opencl_c_atomic_order_seq_cst
+
+_CLC_OVERLOAD _CLC_DEF uintptr_t atomic_fetch_sub(
+    volatile __local atomic_uintptr_t *p, ptrdiff_t v, memory_order order) {
+  return __scoped_atomic_fetch_sub((volatile __local uintptr_t *)p, v, order,
+                                   __MEMORY_SCOPE_DEVICE);
+}
+
+_CLC_OVERLOAD _CLC_DEF uintptr_t
+atomic_fetch_sub(volatile __local atomic_uintptr_t *p, ptrdiff_t v,
+                 memory_order order, memory_scope scope) {
+  return __scoped_atomic_fetch_sub((volatile __local uintptr_t *)p, v, order,
+                                   __opencl_get_clang_memory_scope(scope));
+}
+
 _CLC_OVERLOAD _CLC_DEF uintptr_t atomic_fetch_sub(
     volatile __global atomic_uintptr_t *p, ptrdiff_t v, memory_order order) {
   return __scoped_atomic_fetch_sub((volatile __global uintptr_t *)p, v, order,
                                    __MEMORY_SCOPE_DEVICE);
 }
 
-#if _CLC_GENERIC_AS_SUPPORTED
-
-_CLC_OVERLOAD _CLC_DEF uintptr_t atomic_fetch_sub(volatile atomic_uintptr_t *p,
-                                                  ptrdiff_t v) {
-  return __scoped_atomic_fetch_sub((volatile uintptr_t *)p, v, __ATOMIC_SEQ_CST,
-                                   __MEMORY_SCOPE_DEVICE);
+_CLC_OVERLOAD _CLC_DEF uintptr_t
+atomic_fetch_sub(volatile __global atomic_uintptr_t *p, ptrdiff_t v,
+                 memory_order order, memory_scope scope) {
+  return __scoped_atomic_fetch_sub((volatile __global uintptr_t *)p, v, order,
+                                   __opencl_get_clang_memory_scope(scope));
 }
 
+#if _CLC_GENERIC_AS_SUPPORTED
 _CLC_OVERLOAD _CLC_DEF uintptr_t atomic_fetch_sub(volatile atomic_uintptr_t *p,
                                                   ptrdiff_t v,
                                                   memory_order order) {
@@ -60,7 +77,13 @@ _CLC_OVERLOAD _CLC_DEF uintptr_t atomic_fetch_sub(volatile atomic_uintptr_t *p,
                                    __MEMORY_SCOPE_DEVICE);
 }
 
-#endif // _CLC_GENERIC_AS_SUPPORTED
+_CLC_OVERLOAD _CLC_DEF uintptr_t atomic_fetch_sub(volatile atomic_uintptr_t *p,
+                                                  ptrdiff_t v,
+                                                  memory_order order,
+                                                  memory_scope scope) {
+  return __scoped_atomic_fetch_sub((volatile uintptr_t *)p, v, order,
+                                   __opencl_get_clang_memory_scope(scope));
+}
 
-#endif // defined(__opencl_c_atomic_order_seq_cst) &&
-       // defined(__opencl_c_atomic_scope_device)
+#endif // _CLC_GENERIC_AS_SUPPORTED
+#endif // __opencl_c_atomic_scope_device

--- a/libclc/opencl/lib/generic/atomic/atomic_fetch_sub.cl
+++ b/libclc/opencl/lib/generic/atomic/atomic_fetch_sub.cl
@@ -18,9 +18,15 @@
 #define __CLC_BODY "atomic_def.inc"
 #include "clc/math/gentype.inc"
 
-#ifdef __opencl_c_atomic_scope_device
+// If the device subress space is 64-bits, the data types atomic_intptr_t,
+// atomic_uintptr_t, atomic_size_t and atomic_ptrdiff_t are supported if the
+// cl_khr_int64_base_atomics and cl_khr_int64_extended_atomics extensions are
+// supported and have been enabled.
+#if __SIZEOF_POINTER__ < 8 || (defined(cl_khr_int64_base_atomics) &&           \
+                               defined(cl_khr_int64_extended_atomics))
 
-#ifdef __opencl_c_atomic_order_seq_cst
+#if defined(__opencl_c_atomic_scope_device) &&                                 \
+    defined(__opencl_c_atomic_order_seq_cst)
 
 _CLC_DEF _CLC_OVERLOAD uintptr_t
 atomic_fetch_sub(volatile __local atomic_uintptr_t *p, ptrdiff_t v) {
@@ -41,7 +47,10 @@ _CLC_DEF _CLC_OVERLOAD uintptr_t atomic_fetch_sub(volatile atomic_uintptr_t *p,
                                    __MEMORY_SCOPE_DEVICE);
 }
 #endif // _CLC_GENERIC_AS_SUPPORTED
-#endif // __opencl_c_atomic_order_seq_cst
+#endif // defined(__opencl_c_atomic_scope_device) &&
+       // defined(__opencl_c_atomic_order_seq_cst)
+
+#ifdef __opencl_c_atomic_scope_device
 
 _CLC_DEF _CLC_OVERLOAD uintptr_t atomic_fetch_sub(
     volatile __local atomic_uintptr_t *p, ptrdiff_t v, memory_order order) {
@@ -49,17 +58,27 @@ _CLC_DEF _CLC_OVERLOAD uintptr_t atomic_fetch_sub(
                                    __MEMORY_SCOPE_DEVICE);
 }
 
+_CLC_DEF _CLC_OVERLOAD uintptr_t atomic_fetch_sub(
+    volatile __global atomic_uintptr_t *p, ptrdiff_t v, memory_order order) {
+  return __scoped_atomic_fetch_sub((volatile __global uintptr_t *)p, v, order,
+                                   __MEMORY_SCOPE_DEVICE);
+}
+
+#if _CLC_GENERIC_AS_SUPPORTED
+_CLC_DEF _CLC_OVERLOAD uintptr_t atomic_fetch_sub(volatile atomic_uintptr_t *p,
+                                                  ptrdiff_t v,
+                                                  memory_order order) {
+  return __scoped_atomic_fetch_sub((volatile uintptr_t *)p, v, order,
+                                   __MEMORY_SCOPE_DEVICE);
+}
+#endif // _CLC_GENERIC_AS_SUPPORTED
+#endif // __opencl_c_atomic_scope_device
+
 _CLC_DEF _CLC_OVERLOAD uintptr_t
 atomic_fetch_sub(volatile __local atomic_uintptr_t *p, ptrdiff_t v,
                  memory_order order, memory_scope scope) {
   return __scoped_atomic_fetch_sub((volatile __local uintptr_t *)p, v, order,
                                    __opencl_get_clang_memory_scope(scope));
-}
-
-_CLC_DEF _CLC_OVERLOAD uintptr_t atomic_fetch_sub(
-    volatile __global atomic_uintptr_t *p, ptrdiff_t v, memory_order order) {
-  return __scoped_atomic_fetch_sub((volatile __global uintptr_t *)p, v, order,
-                                   __MEMORY_SCOPE_DEVICE);
 }
 
 _CLC_DEF _CLC_OVERLOAD uintptr_t
@@ -70,12 +89,6 @@ atomic_fetch_sub(volatile __global atomic_uintptr_t *p, ptrdiff_t v,
 }
 
 #if _CLC_GENERIC_AS_SUPPORTED
-_CLC_DEF _CLC_OVERLOAD uintptr_t atomic_fetch_sub(volatile atomic_uintptr_t *p,
-                                                  ptrdiff_t v,
-                                                  memory_order order) {
-  return __scoped_atomic_fetch_sub((volatile uintptr_t *)p, v, order,
-                                   __MEMORY_SCOPE_DEVICE);
-}
 
 _CLC_DEF _CLC_OVERLOAD uintptr_t atomic_fetch_sub(volatile atomic_uintptr_t *p,
                                                   ptrdiff_t v,
@@ -86,4 +99,6 @@ _CLC_DEF _CLC_OVERLOAD uintptr_t atomic_fetch_sub(volatile atomic_uintptr_t *p,
 }
 
 #endif // _CLC_GENERIC_AS_SUPPORTED
-#endif // __opencl_c_atomic_scope_device
+
+#endif // __SIZEOF_POINTER__ < 8 || (defined(cl_khr_int64_base_atomics) &&
+       // defined(cl_khr_int64_extended_atomics))

--- a/libclc/opencl/lib/generic/atomic/atomic_fetch_sub.cl
+++ b/libclc/opencl/lib/generic/atomic/atomic_fetch_sub.cl
@@ -22,20 +22,20 @@
 
 #ifdef __opencl_c_atomic_order_seq_cst
 
-_CLC_OVERLOAD _CLC_DEF uintptr_t
+_CLC_DEF _CLC_OVERLOAD uintptr_t
 atomic_fetch_sub(volatile __local atomic_uintptr_t *p, ptrdiff_t v) {
   return __scoped_atomic_fetch_sub((volatile __local uintptr_t *)p, v,
                                    __ATOMIC_SEQ_CST, __MEMORY_SCOPE_DEVICE);
 }
 
-_CLC_OVERLOAD _CLC_DEF uintptr_t
+_CLC_DEF _CLC_OVERLOAD uintptr_t
 atomic_fetch_sub(volatile __global atomic_uintptr_t *p, ptrdiff_t v) {
   return __scoped_atomic_fetch_sub((volatile __global uintptr_t *)p, v,
                                    __ATOMIC_SEQ_CST, __MEMORY_SCOPE_DEVICE);
 }
 
 #if _CLC_GENERIC_AS_SUPPORTED
-_CLC_OVERLOAD _CLC_DEF uintptr_t atomic_fetch_sub(volatile atomic_uintptr_t *p,
+_CLC_DEF _CLC_OVERLOAD uintptr_t atomic_fetch_sub(volatile atomic_uintptr_t *p,
                                                   ptrdiff_t v) {
   return __scoped_atomic_fetch_sub((volatile uintptr_t *)p, v, __ATOMIC_SEQ_CST,
                                    __MEMORY_SCOPE_DEVICE);
@@ -43,26 +43,26 @@ _CLC_OVERLOAD _CLC_DEF uintptr_t atomic_fetch_sub(volatile atomic_uintptr_t *p,
 #endif // _CLC_GENERIC_AS_SUPPORTED
 #endif // __opencl_c_atomic_order_seq_cst
 
-_CLC_OVERLOAD _CLC_DEF uintptr_t atomic_fetch_sub(
+_CLC_DEF _CLC_OVERLOAD uintptr_t atomic_fetch_sub(
     volatile __local atomic_uintptr_t *p, ptrdiff_t v, memory_order order) {
   return __scoped_atomic_fetch_sub((volatile __local uintptr_t *)p, v, order,
                                    __MEMORY_SCOPE_DEVICE);
 }
 
-_CLC_OVERLOAD _CLC_DEF uintptr_t
+_CLC_DEF _CLC_OVERLOAD uintptr_t
 atomic_fetch_sub(volatile __local atomic_uintptr_t *p, ptrdiff_t v,
                  memory_order order, memory_scope scope) {
   return __scoped_atomic_fetch_sub((volatile __local uintptr_t *)p, v, order,
                                    __opencl_get_clang_memory_scope(scope));
 }
 
-_CLC_OVERLOAD _CLC_DEF uintptr_t atomic_fetch_sub(
+_CLC_DEF _CLC_OVERLOAD uintptr_t atomic_fetch_sub(
     volatile __global atomic_uintptr_t *p, ptrdiff_t v, memory_order order) {
   return __scoped_atomic_fetch_sub((volatile __global uintptr_t *)p, v, order,
                                    __MEMORY_SCOPE_DEVICE);
 }
 
-_CLC_OVERLOAD _CLC_DEF uintptr_t
+_CLC_DEF _CLC_OVERLOAD uintptr_t
 atomic_fetch_sub(volatile __global atomic_uintptr_t *p, ptrdiff_t v,
                  memory_order order, memory_scope scope) {
   return __scoped_atomic_fetch_sub((volatile __global uintptr_t *)p, v, order,
@@ -70,14 +70,14 @@ atomic_fetch_sub(volatile __global atomic_uintptr_t *p, ptrdiff_t v,
 }
 
 #if _CLC_GENERIC_AS_SUPPORTED
-_CLC_OVERLOAD _CLC_DEF uintptr_t atomic_fetch_sub(volatile atomic_uintptr_t *p,
+_CLC_DEF _CLC_OVERLOAD uintptr_t atomic_fetch_sub(volatile atomic_uintptr_t *p,
                                                   ptrdiff_t v,
                                                   memory_order order) {
   return __scoped_atomic_fetch_sub((volatile uintptr_t *)p, v, order,
                                    __MEMORY_SCOPE_DEVICE);
 }
 
-_CLC_OVERLOAD _CLC_DEF uintptr_t atomic_fetch_sub(volatile atomic_uintptr_t *p,
+_CLC_DEF _CLC_OVERLOAD uintptr_t atomic_fetch_sub(volatile atomic_uintptr_t *p,
                                                   ptrdiff_t v,
                                                   memory_order order,
                                                   memory_scope scope) {

--- a/libclc/opencl/lib/generic/atomic/atomic_fetch_sub.cl
+++ b/libclc/opencl/lib/generic/atomic/atomic_fetch_sub.cl
@@ -27,10 +27,22 @@ atomic_fetch_sub(volatile __local atomic_uintptr_t *p, ptrdiff_t v) {
                                    __ATOMIC_SEQ_CST, __MEMORY_SCOPE_DEVICE);
 }
 
+_CLC_OVERLOAD _CLC_DEF uintptr_t atomic_fetch_sub(
+    volatile __local atomic_uintptr_t *p, ptrdiff_t v, memory_order order) {
+  return __scoped_atomic_fetch_sub((volatile __local uintptr_t *)p, v, order,
+                                   __MEMORY_SCOPE_DEVICE);
+}
+
 _CLC_OVERLOAD _CLC_DEF uintptr_t
 atomic_fetch_sub(volatile __global atomic_uintptr_t *p, ptrdiff_t v) {
   return __scoped_atomic_fetch_sub((volatile __global uintptr_t *)p, v,
                                    __ATOMIC_SEQ_CST, __MEMORY_SCOPE_DEVICE);
+}
+
+_CLC_OVERLOAD _CLC_DEF uintptr_t atomic_fetch_sub(
+    volatile __global atomic_uintptr_t *p, ptrdiff_t v, memory_order order) {
+  return __scoped_atomic_fetch_sub((volatile __global uintptr_t *)p, v, order,
+                                   __MEMORY_SCOPE_DEVICE);
 }
 
 #if _CLC_GENERIC_AS_SUPPORTED
@@ -38,6 +50,13 @@ atomic_fetch_sub(volatile __global atomic_uintptr_t *p, ptrdiff_t v) {
 _CLC_OVERLOAD _CLC_DEF uintptr_t atomic_fetch_sub(volatile atomic_uintptr_t *p,
                                                   ptrdiff_t v) {
   return __scoped_atomic_fetch_sub((volatile uintptr_t *)p, v, __ATOMIC_SEQ_CST,
+                                   __MEMORY_SCOPE_DEVICE);
+}
+
+_CLC_OVERLOAD _CLC_DEF uintptr_t atomic_fetch_sub(volatile atomic_uintptr_t *p,
+                                                  ptrdiff_t v,
+                                                  memory_order order) {
+  return __scoped_atomic_fetch_sub((volatile uintptr_t *)p, v, order,
                                    __MEMORY_SCOPE_DEVICE);
 }
 


### PR DESCRIPTION
Follow up to #185263, which missed the overloads which take a memory
order.