### PR TITLE
[lld-macho][LTO] Emit `__llvm_addrsig` for `--icf=safe_thunks`

### DIFF
--- a/lld/MachO/LTO.cpp
+++ b/lld/MachO/LTO.cpp
@@ -39,7 +39,8 @@ static std::string getThinLTOOutputFile(StringRef modulePath) {
 static lto::Config createConfig() {
   lto::Config c;
   c.Options = initTargetOptionsFromCodeGenFlags();
-  c.Options.EmitAddrsig = config->icfLevel == ICFLevel::safe;
+  c.Options.EmitAddrsig = config->icfLevel == ICFLevel::safe ||
+                          config->icfLevel == ICFLevel::safe_thunks;
   for (StringRef C : config->mllvmOpts)
     c.MllvmArgs.emplace_back(C.str());
   for (StringRef pluginFn : config->passPlugins)

--- a/lld/test/MachO/icf-safe-thunks.ll
+++ b/lld/test/MachO/icf-safe-thunks.ll
@@ -8,6 +8,13 @@
 ; RUN: llvm-objdump %t/a.dylib -d --macho | FileCheck %s --check-prefixes=CHECK-ARM64
 ; RUN: cat %t/a.map | FileCheck %s --check-prefixes=CHECK-ARM64-MAP
 
+;; Test LTO path: llvm-as assembles IR to bitcode, then lld links with LTO
+;; (which should emit __llvm_addrsig for safe_thunks, enabling body-folding).
+; RUN: llvm-as %t/a.ll -o %t/a.bc
+; RUN: %lld -arch arm64 -lSystem --icf=safe_thunks -dylib -o %t/a-lto.dylib -map %t/a-lto.map %t/a.bc
+; RUN: llvm-objdump %t/a-lto.dylib -d --macho | FileCheck %s --check-prefixes=CHECK-LTO
+; RUN: cat %t/a-lto.map | FileCheck %s --check-prefixes=CHECK-LTO-MAP
+
 ; CHECK-ARM64:        (__TEXT,__text) section
 ; CHECK-ARM64-NEXT:   _func_unique_1:
 ; CHECK-ARM64-NEXT:        mov {{.*}}, #0x1
@@ -44,6 +51,58 @@
 ; CHECK-ARM64-NEXT:   _func_3identical_v3:
 ; CHECK-ARM64-NEXT:        b  _func_3identical_v1
 
+
+; CHECK-LTO:        (__TEXT,__text) section
+; CHECK-LTO-NEXT:   _func_unique_1:
+; CHECK-LTO-NEXT:        mov {{.*}}, #0x1
+;
+; CHECK-LTO:        _func_unique_2_canmerge:
+; CHECK-LTO-NEXT:   _func_2identical_v1:
+; CHECK-LTO-NEXT:        mov {{.*}}, #0x2
+;
+; CHECK-LTO:        _func_3identical_v1:
+; CHECK-LTO-NEXT:        mov {{.*}}, #0x3
+;
+; CHECK-LTO:        _func_3identical_v1_canmerge:
+; CHECK-LTO-NEXT:   _func_3identical_v2_canmerge:
+; CHECK-LTO-NEXT:   _func_3identical_v3_canmerge:
+; CHECK-LTO-NEXT:        mov {{.*}}, #0x21
+;
+; CHECK-LTO:        _func_call_thunked_1_nomerge:
+; CHECK-LTO-NEXT:        stp	x29
+;
+; CHECK-LTO:        _func_call_thunked_2_nomerge:
+; CHECK-LTO-NEXT:   _func_call_thunked_2_merge:
+; CHECK-LTO-NEXT:        stp	x29
+;
+; CHECK-LTO:        _call_all_funcs:
+; CHECK-LTO-NEXT:        stp  x29
+;
+; CHECK-LTO:        _take_func_addr:
+; CHECK-LTO-NEXT:        adr
+;
+; CHECK-LTO:        _func_2identical_v2:
+; CHECK-LTO-NEXT:        b  _func_2identical_v1
+; CHECK-LTO-NEXT:   _func_3identical_v2:
+; CHECK-LTO-NEXT:        b  _func_3identical_v1
+; CHECK-LTO-NEXT:   _func_3identical_v3:
+; CHECK-LTO-NEXT:        b  _func_3identical_v1
+
+; CHECK-LTO-MAP:      0x00000010 [  2] _func_unique_1
+; CHECK-LTO-MAP-NEXT: 0x00000010 [  2] _func_2identical_v1
+; CHECK-LTO-MAP-NEXT: 0x00000000 [  2] _func_unique_2_canmerge
+; CHECK-LTO-MAP-NEXT: 0x00000010 [  2] _func_3identical_v1
+; CHECK-LTO-MAP-NEXT: 0x00000010 [  2] _func_3identical_v1_canmerge
+; CHECK-LTO-MAP-NEXT: 0x00000000 [  2] _func_3identical_v2_canmerge
+; CHECK-LTO-MAP-NEXT: 0x00000000 [  2] _func_3identical_v3_canmerge
+; CHECK-LTO-MAP-NEXT: 0x00000020 [  2] _func_call_thunked_1_nomerge
+; CHECK-LTO-MAP-NEXT: 0x00000020 [  2] _func_call_thunked_2_nomerge
+; CHECK-LTO-MAP-NEXT: 0x00000000 [  2] _func_call_thunked_2_merge
+; CHECK-LTO-MAP-NEXT: 0x00000034 [  2] _call_all_funcs
+; CHECK-LTO-MAP-NEXT: 0x00000050 [  2] _take_func_addr
+; CHECK-LTO-MAP-NEXT: 0x00000004 [  2] _func_2identical_v2
+; CHECK-LTO-MAP-NEXT: 0x00000004 [  2] _func_3identical_v2
+; CHECK-LTO-MAP-NEXT: 0x00000004 [  2] _func_3identical_v3
 
 ; CHECK-ARM64-MAP:      0x00000010 [  2] _func_unique_1
 ; CHECK-ARM64-MAP-NEXT: 0x00000010 [  2] _func_2identical_v1


### PR DESCRIPTION
LTO was emitting `__llvm_addrsig` metadata when `--icf=safe` was specified, but not for `--icf=safe_thunks`. After the recent PR https://github.com/llvm/llvm-project/pull/188400 that makes safe ICF conservative without `__llvm_addrsig` (marking all symbols as address-significant when the section is absent), this omission caused safe_thunks to silently degrade for all LTO-compiled objects: every symbol became `keepUnique`, preventing body folding entirely.

Fix this by also enabling `EmitAddrsig` when `icfLevel` is `safe_thunks`. This allows the LTO backend to emit precise address-significance metadata, so that only truly address-significant functions get thunk treatment while non-address-significant identical functions can still be body-folded.

Add a regression test that verifies LTO + `--icf=safe_thunks` correctly body-folds non-address-significant identical functions, which would fail without this fix due to missing addrsig metadata.