### PR TITLE
[lldb] Use `llvm::APInt` for `VariantMember` Discriminants

### DIFF
--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserClang.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserClang.cpp
@@ -13,6 +13,7 @@
 #include "DWARFDebugInfo.h"
 #include "DWARFDeclContext.h"
 #include "DWARFDefines.h"
+#include "DWARFFormValue.h"
 #include "SymbolFileDWARF.h"
 #include "SymbolFileDWARFDebugMap.h"
 #include "SymbolFileDWARFDwo.h"
@@ -2568,7 +2569,7 @@ struct VariantMember {
   explicit VariantMember(DWARFDIE &die, ModuleSP module_sp);
   bool IsDefault() const;
 
-  std::optional<uint32_t> discr_value;
+  std::optional<llvm::APInt> discr_value;
   DWARFFormValue type_ref;
   ConstString variant_name;
   uint32_t byte_offset;
@@ -2596,8 +2597,35 @@ bool VariantMember::IsDefault() const { return !discr_value; }
 
 VariantMember::VariantMember(DWARFDIE &die, lldb::ModuleSP module_sp) {
   assert(die.Tag() == llvm::dwarf::DW_TAG_variant);
-  this->discr_value =
-      die.GetAttributeValueAsOptionalUnsigned(DW_AT_discr_value);
+
+  DWARFFormValue discr_form;
+  die.GetDIE()->GetAttributeValue(die.GetCU(), DW_AT_discr_value, discr_form);
+
+  // Rust can output 128-bit discrs (e.g. NonNull<u128>) as `DW_FORM_block1`.
+  // There is a `data16`, but the DIE function treats it as a block anyway.
+  // Handling is included for it just in case rust's output changes to the
+  // `data16` version.
+  dw_form_t form = discr_form.Form();
+  if ((form == DW_FORM_block1 && discr_form.Unsigned() == 16) ||
+      form == DW_FORM_data16) {
+    const uint8_t *block_data = discr_form.BlockData();
+
+    DataExtractor extractor(block_data, 16, die.GetCU()->GetByteOrder(),
+                            die.GetCU()->GetAddressByteSize());
+    lldb::offset_t offset = 0;
+    uint64_t lo = extractor.GetU64(&offset);
+    uint64_t hi = extractor.GetU64(&offset);
+    uint64_t words[] = {lo, hi};
+    this->discr_value = llvm::APInt(128, words);
+  } else {
+    if (auto result =
+            die.GetAttributeValueAsOptionalUnsigned(DW_AT_discr_value)) {
+      this->discr_value =
+          llvm::APInt(sizeof(uint64_t) * 8, result.value(), false);
+    } else {
+      this->discr_value = std::nullopt;
+    };
+  }
 
   for (auto child_die : die.children()) {
     switch (child_die.Tag()) {
@@ -3834,9 +3862,14 @@ void DWARFASTParserClang::ParseRustVariantPart(
 
     m_ast.CompleteTagDeclarationDefinition(field_type);
 
-    auto name = has_discriminant
-                    ? llvm::formatv("$variant${0}", member.discr_value.value())
-                    : std::string("$variant$");
+    auto name = std::string("$variant$");
+    if (has_discriminant) {
+      // u128::MAX = 340282366920938463463374607431768211455 which is 39 digits
+      // long + 1 for null terminator.
+      llvm::SmallString<40> discr_str;
+      member.discr_value.value().toStringUnsigned(discr_str);
+      name.append(discr_str.c_str());
+    }
 
     auto variant_decl = m_ast.AddFieldToRecordType(
         inner_holder, llvm::StringRef(name), field_type, 0);

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserClang.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserClang.cpp
@@ -13,6 +13,7 @@
 #include "DWARFDebugInfo.h"
 #include "DWARFDeclContext.h"
 #include "DWARFDefines.h"
+#include "DWARFFormValue.h"
 #include "SymbolFileDWARF.h"
 #include "SymbolFileDWARFDebugMap.h"
 #include "SymbolFileDWARFDwo.h"
@@ -2568,7 +2569,7 @@ struct VariantMember {
   explicit VariantMember(DWARFDIE &die, ModuleSP module_sp);
   bool IsDefault() const;
 
-  std::optional<uint32_t> discr_value;
+  std::optional<llvm::APInt> discr_value;
   DWARFFormValue type_ref;
   ConstString variant_name;
   uint32_t byte_offset;
@@ -2596,8 +2597,34 @@ bool VariantMember::IsDefault() const { return !discr_value; }
 
 VariantMember::VariantMember(DWARFDIE &die, lldb::ModuleSP module_sp) {
   assert(die.Tag() == llvm::dwarf::DW_TAG_variant);
-  this->discr_value =
-      die.GetAttributeValueAsOptionalUnsigned(DW_AT_discr_value);
+
+  DWARFFormValue discr_form;
+  die.GetDIE()->GetAttributeValue(die.GetCU(), DW_AT_discr_value, discr_form);
+
+  // Rust can output 128-bit discriminants (e.g. NonNull<u128>) as
+  // `DW_FORM_block1`. There is a `data16` dwarf form, but DWARFFormValue treats
+  // it as a BlockData anyway. Handling is included for it just in case rust's
+  // output changes to the `data16` form.
+  dw_form_t form = discr_form.Form();
+  if ((form == DW_FORM_block1 && discr_form.Unsigned() == 16) ||
+      form == DW_FORM_data16) {
+    const uint8_t *block_data = discr_form.BlockData();
+
+    DataExtractor extractor(block_data, 16, die.GetCU()->GetByteOrder(),
+                            die.GetCU()->GetAddressByteSize());
+    lldb::offset_t offset = 0;
+    uint64_t lo = extractor.GetU64(&offset);
+    uint64_t hi = extractor.GetU64(&offset);
+    uint64_t words[] = {lo, hi};
+    this->discr_value = llvm::APInt(128, words);
+  } else {
+    if (auto result =
+            die.GetAttributeValueAsOptionalUnsigned(DW_AT_discr_value)) {
+      this->discr_value = llvm::APInt(sizeof(uint64_t) * 8, result.value());
+    } else {
+      this->discr_value = std::nullopt;
+    };
+  }
 
   for (auto child_die : die.children()) {
     switch (child_die.Tag()) {
@@ -3834,9 +3861,14 @@ void DWARFASTParserClang::ParseRustVariantPart(
 
     m_ast.CompleteTagDeclarationDefinition(field_type);
 
-    auto name = has_discriminant
-                    ? llvm::formatv("$variant${0}", member.discr_value.value())
-                    : std::string("$variant$");
+    auto name = std::string("$variant$");
+    if (has_discriminant) {
+      // u128::MAX = 340282366920938463463374607431768211455 which is 39 digits
+      // long + 1 for null terminator.
+      llvm::SmallString<40> discr_str;
+      member.discr_value.value().toStringUnsigned(discr_str);
+      name.append(discr_str.c_str());
+    }
 
     auto variant_decl = m_ast.AddFieldToRecordType(
         inner_holder, llvm::StringRef(name), field_type, 0);

--- a/lldb/unittests/SymbolFile/DWARF/CMakeLists.txt
+++ b/lldb/unittests/SymbolFile/DWARF/CMakeLists.txt
@@ -28,6 +28,7 @@ add_lldb_unittest(SymbolFileDWARFTests
 set(test_inputs
    test-dwarf.exe
    DW_AT_default_value-test.yaml
-   DW_AT_spec_decl_exists-test.yaml)
+   DW_AT_spec_decl_exists-test.yaml
+   DW_TAG_variant_rust-test.yaml)
 
 add_unittest_inputs(SymbolFileDWARFTests "${test_inputs}")

--- a/lldb/unittests/SymbolFile/DWARF/DWARFASTParserClangTests.cpp
+++ b/lldb/unittests/SymbolFile/DWARF/DWARFASTParserClangTests.cpp
@@ -667,14 +667,14 @@ DWARF:
   debug_str:
     - Foo
 
-  debug_line:      
+  debug_line:
     - Version:         4
       MinInstLength:   1
       MaxOpsPerInst:   1
       DefaultIsStmt:   1
       LineBase:        0
       LineRange:       0
-      Files:           
+      Files:
         - Name:            main.cpp
           DirIdx:          0
           ModTime:         0
@@ -2117,4 +2117,36 @@ DWARF:
   EXPECT_TRUE(type_sp->IsTypedef());
   EXPECT_EQ(type_sp->GetName(), "Bar<int>");
   EXPECT_EQ(type_sp->GetForwardCompilerType().GetTypeName(), "Foo::Bar<int>");
+}
+
+TEST_F(DWARFASTParserClangTests, TestRustVariantMember) {
+  // Tests that 128-bit discriminants are output to variant names correctly.
+  auto yamldata = llvm::MemoryBuffer::getFile(
+      GetInputFilePath("DW_TAG_variant_rust-test.yaml"), /*IsText=*/true);
+  ASSERT_TRUE(yamldata);
+
+  DWARFASTParserClangYAMLTester tester(yamldata->get()->getBuffer());
+
+  auto &ts_clang = tester.GetTypeSystem();
+  auto *symbol_file = ts_clang.GetSymbolFile();
+
+  TypeQuery query{ConstString("BigDiscr")};
+  TypeResults result{};
+  symbol_file->FindTypes(query, result);
+
+  auto type = result.GetFirstType();
+  auto enum_type = type.get()->GetFullCompilerType();
+  std::string f_name;
+  auto all_variants =
+      enum_type.GetFieldAtIndex(0, f_name, nullptr, nullptr, nullptr);
+  ASSERT_EQ(f_name, "$variants$");
+
+  f_name.clear();
+  all_variants.GetFieldAtIndex(0, f_name, nullptr, nullptr, nullptr);
+  ASSERT_EQ(f_name, "$variant$0");
+
+  all_variants.GetFieldAtIndex(1, f_name, nullptr, nullptr, nullptr);
+  // 0x16151413121110090807060504030201 ==
+  // 29352461300415899028694309177919734273
+  ASSERT_EQ(f_name, "$variant$29352461300415899028694309177919734273");
 }

--- a/lldb/unittests/SymbolFile/DWARF/DWARFASTParserClangTests.cpp
+++ b/lldb/unittests/SymbolFile/DWARF/DWARFASTParserClangTests.cpp
@@ -2118,3 +2118,33 @@ DWARF:
   EXPECT_EQ(type_sp->GetName(), "Bar<int>");
   EXPECT_EQ(type_sp->GetForwardCompilerType().GetTypeName(), "Foo::Bar<int>");
 }
+
+TEST_F(DWARFASTParserClangTests, TestRustVariantMember) {
+  // Tests that 128-bit discriminants are output to variant names correctly
+  auto yamldata = llvm::MemoryBuffer::getFile(
+      GetInputFilePath("DW_TAG_variant_rust-test.yaml"), /*IsText=*/true);
+  ASSERT_TRUE(yamldata);
+
+  DWARFASTParserClangYAMLTester tester(yamldata->get()->getBuffer());
+
+  auto &ts_clang = tester.GetTypeSystem();
+  auto *symbol_file = ts_clang.GetSymbolFile();
+
+  TypeQuery query{ConstString("BigDiscr")};
+  TypeResults result{};
+  symbol_file->FindTypes(query, result);
+
+  auto type = result.GetFirstType();
+  auto enum_type = type.get()->GetFullCompilerType();
+  std::string f_name;
+  auto all_variants =
+      enum_type.GetFieldAtIndex(0, f_name, nullptr, nullptr, nullptr);
+  ASSERT_EQ(f_name, "$variants$");
+
+  f_name.clear();
+  all_variants.GetFieldAtIndex(0, f_name, nullptr, nullptr, nullptr);
+  ASSERT_EQ(f_name, "$variant$0");
+
+  all_variants.GetFieldAtIndex(1, f_name, nullptr, nullptr, nullptr);
+  ASSERT_EQ(f_name, "$variant$29352461300415899028694309177919734273");
+}

--- a/lldb/unittests/SymbolFile/DWARF/Inputs/DW_TAG_variant_rust-test.yaml
+++ b/lldb/unittests/SymbolFile/DWARF/Inputs/DW_TAG_variant_rust-test.yaml
@@ -1,0 +1,871 @@
+# Below code compiled with rustc src/main.rs --target=x86_64-unknown-linux-gnu -g -C panic=abort
+#
+# #![no_std]
+# #![no_main]
+#
+# #[allow(unused)]
+# #[repr(u128)]
+# enum BigDiscr {
+#     Value(u64),
+#     None = 0x16151413121110090807060504030201,
+# }
+#
+# fn use_it(_: &BigDiscr) {}
+#
+# #[panic_handler]
+# fn panic(_info: &core::panic::PanicInfo) -> ! {
+#     loop {}
+# }
+#
+# #[unsafe(no_mangle)]
+# extern "C" fn main() {
+#     let none = BigDiscr::None;
+#     let some = BigDiscr::Value(31);
+#
+#     use_it(&none);
+#     use_it(&some);
+# }
+
+--- !ELF
+FileHeader:
+  Class:           ELFCLASS64
+  Data:            ELFDATA2LSB
+  Type:            ET_REL
+  Machine:         EM_X86_64
+  SectionHeaderStringTable: .strtab
+Sections:
+  - Name:            .text
+    Type:            SHT_PROGBITS
+    Flags:           [ SHF_ALLOC, SHF_EXECINSTR ]
+    AddressAlign:    0x4
+  - Name:            .text._RNvCshXwFllX56pT_7___rustc17rust_begin_unwind
+    Type:            SHT_PROGBITS
+    Flags:           [ SHF_ALLOC, SHF_EXECINSTR ]
+    AddressAlign:    0x10
+    Content:         48897C24F8EBFE
+  - Name:            .text._ZN4main6use_it17h7beb6f96865c87acE
+    Type:            SHT_PROGBITS
+    Flags:           [ SHF_ALLOC, SHF_EXECINSTR ]
+    AddressAlign:    0x10
+    Content:         48897C24F8C3
+  - Name:            .text.main
+    Type:            SHT_PROGBITS
+    Flags:           [ SHF_ALLOC, SHF_EXECINSTR ]
+    AddressAlign:    0x10
+    Content:         4883EC4848B80910111213141516488944240848B801020304050607084889042448C74424301F00000048C74424280000000048C7442420000000004889E7E800000000488D7C2420E8000000004883C448C3
+  - Name:            .debug_gdb_scripts
+    Type:            SHT_PROGBITS
+    Flags:           [ SHF_ALLOC, SHF_MERGE, SHF_STRINGS ]
+    AddressAlign:    0x1
+    EntSize:         0x1
+    Content:         016764625F6C6F61645F727573745F7072657474795F7072696E746572732E707900
+  - Name:            .debug_abbrev
+    Type:            SHT_PROGBITS
+    AddressAlign:    0x1
+    Content:         011101250E1305030E10171B0E110155170000023901030E0000032E011101120640186E0E030E3A0B3B0B87011900000405000218030E3A0B3B0B49130000052E011101120640186E0E030E3A0B3B0B000006050002183A0B3B0B49130000072E01110112064018030E3A0B3B0B3F190000080B011101120600000934000218030E88010F3A0B3B0B491300000A1301030E0B0B320B88010F00000B3301151300000C0D00491388010F380B341900000D1901160A00000E0D00030E491388010F380B00000F0D00030E491388010F380B320B0000101300030E0B0B320B88010F0000110F004913030E330600001219010000131901160B0000142F004913030E0000152400030E3E0B0B0B00001615014913000017050049130000181301030E0B0B88010F0000190F004913330600001A1300030E0B0B88010F00001B0101491300001C21004913220D370B00001D2400030E0B0B3E0B000000
+  - Name:            .debug_info
+    Type:            SHT_PROGBITS
+    AddressAlign:    0x1
+    Content:         5F0500000400000000000801000000001C0000000000000000000000000000000000000000000000000002000000000300000000000000000700000001570000000000000000010E0402917800000000010E3B010000000500000000000000000600000001570000000000000000010B06029178010B4E050000000700000000000000005300000001570000000001130800000000000000002D0000000902910000000000100114CB000000080000000000000000120000000902912000000000100115CB0000000000000A000000002003100BD80000000C5B05000010000D10000000000000000000000000000000000E000000001C0100001000000D10010203040506070809101112131415160E0000000031010000100000000A000000002003100F00000000320400000810030010000000002003100000115701000000000000000000000200000000020000000002000000000A000000001801080F00000000110400000800030F00000000F50400000808030F00000000470500000110030F0000000047050000011103000002000000000A000000001801080F00000000400300000800030F00000000770400000410030F00000000770400000414030F00000000FD03000001180300000002000000000A000000001001080F00000000E60200000800030F00000000040300000808030002000000000A000000001001080F0000000011020000080003000A000000001003080B1E0200000C320400000800120E000000004102000008000013000E000000006E020000080000000A000000001003080F00000000220300000800030F000000004D0400000808030F00000000EB030000011003000A000000001003080F000000007E04000002080300000010000000000001010A000000001801080F00000000AE0200000410030F0000000085040000080003000A000000000801040F00000000770400000400030F000000007E0400000204030F000000007E0400000206030000020000000002000000000A00000000080108141E040000000000000F0000000025040000080003000A0000000008010814FC010000000000000F00000000E8040000080003000A000000000801081439040000000000000F0000000040040000080003000A00000000100108141E040000000000000F000000000205000008000300000002000000000A000000000101010B720300000C1E040000010013000E000000009603000001000013010E00000000BD030000010000000A000000000101011439040000000000001485020000000000000F0000000039040000010101000A000000000101011439040000000000001485020000000000000F000000008502000001010100000002000000000A0000000000010114DB04000000000000000A0000000000010114290500000000000000000011D6010000000000000000000015000000000701111E0400000000000000000000150000000007081500000000070011390400000000000000000000115A040000000000000000000016650300001722030000176A04000000118D02000000000000000000001500000000070415000000000702180000000010080E00000000A304000008000E00000000B304000008080019AC040000000000001A00000000000111C004000000000000000000001BCD0400001CD4040000000600150000000007081D0000000008071139040000000000000000000011FC010000000000000000000011960100000000000000000000180000000010080E000000002005000008000E00000000CD040000080800191E04000000000000180000000010080E000000002005000008000E00000000CD0400000808001500000000020111CB00000000000000000000001500000000071000
+  - Name:            .comment
+    Type:            SHT_PROGBITS
+    Flags:           [ SHF_MERGE, SHF_STRINGS ]
+    AddressAlign:    0x1
+    EntSize:         0x1
+    Content:         0072757374632076657273696F6E20312E39332E30202832353462353936303720323032362D30312D31392900
+  - Name:            .note.GNU-stack
+    Type:            SHT_PROGBITS
+    AddressAlign:    0x1
+  - Name:            .eh_frame
+    Type:            SHT_X86_64_UNWIND
+    Flags:           [ SHF_ALLOC ]
+    AddressAlign:    0x8
+    Content:         1400000000000000017A5200017810011B0C070890010000100000001C00000000000000070000000000000010000000300000000000000006000000000000001400000044000000000000005300000000440E50024E0E08
+  - Name:            .debug_line
+    Type:            SHT_PROGBITS
+    AddressAlign:    0x1
+    Content:         79000000040023000000010101FB0E0D00010101010000000100000173726300006D61696E2E727300010000000009020000000000000000030D0105050A5902020001010009020000000000000000030A01051B0A580201000101000902000000000000000003120105100AD7082F050508A08305020B9F0205000101
+  - Name:            .rela.text.main
+    Type:            SHT_RELA
+    Flags:           [ SHF_INFO_LINK ]
+    Link:            .symtab
+    AddressAlign:    0x8
+    Info:            .text.main
+    Relocations:
+      - Offset:          0x40
+        Symbol:          .text._ZN4main6use_it17h7beb6f96865c87acE
+        Type:            R_X86_64_PLT32
+        Addend:          -4
+      - Offset:          0x4A
+        Symbol:          .text._ZN4main6use_it17h7beb6f96865c87acE
+        Type:            R_X86_64_PLT32
+        Addend:          -4
+  - Name:            .rela.debug_info
+    Type:            SHT_RELA
+    Flags:           [ SHF_INFO_LINK ]
+    Link:            .symtab
+    AddressAlign:    0x8
+    Info:            .debug_info
+    Relocations:
+      - Offset:          0x6
+        Symbol:          .debug_abbrev
+        Type:            R_X86_64_32
+      - Offset:          0xC
+        Symbol:          .debug_str
+        Type:            R_X86_64_32
+      - Offset:          0x12
+        Symbol:          .debug_str
+        Type:            R_X86_64_32
+        Addend:          57
+      - Offset:          0x16
+        Symbol:          .debug_line
+        Type:            R_X86_64_32
+      - Offset:          0x1A
+        Symbol:          .debug_str
+        Type:            R_X86_64_32
+        Addend:          99
+      - Offset:          0x26
+        Symbol:          .debug_ranges
+        Type:            R_X86_64_32
+      - Offset:          0x2B
+        Symbol:          .debug_str
+        Type:            R_X86_64_32
+        Addend:          147
+      - Offset:          0x30
+        Symbol:          .text._RNvCshXwFllX56pT_7___rustc17rust_begin_unwind
+        Type:            R_X86_64_64
+      - Offset:          0x3E
+        Symbol:          .debug_str
+        Type:            R_X86_64_32
+        Addend:          152
+      - Offset:          0x42
+        Symbol:          .debug_str
+        Type:            R_X86_64_32
+        Addend:          199
+      - Offset:          0x4C
+        Symbol:          .debug_str
+        Type:            R_X86_64_32
+        Addend:          248
+      - Offset:          0x58
+        Symbol:          .text._ZN4main6use_it17h7beb6f96865c87acE
+        Type:            R_X86_64_64
+      - Offset:          0x66
+        Symbol:          .debug_str
+        Type:            R_X86_64_32
+        Addend:          205
+      - Offset:          0x6A
+        Symbol:          .debug_str
+        Type:            R_X86_64_32
+        Addend:          241
+      - Offset:          0x7C
+        Symbol:          .text.main
+        Type:            R_X86_64_64
+      - Offset:          0x8A
+        Symbol:          .debug_str
+        Type:            R_X86_64_32
+        Addend:          147
+      - Offset:          0x91
+        Symbol:          .text.main
+        Type:            R_X86_64_64
+        Addend:          33
+      - Offset:          0xA1
+        Symbol:          .debug_str
+        Type:            R_X86_64_32
+        Addend:          1193
+      - Offset:          0xAD
+        Symbol:          .text.main
+        Type:            R_X86_64_64
+        Addend:          60
+      - Offset:          0xBD
+        Symbol:          .debug_str
+        Type:            R_X86_64_32
+        Addend:          1198
+      - Offset:          0xCC
+        Symbol:          .debug_str
+        Type:            R_X86_64_32
+        Addend:          1168
+      - Offset:          0xF2
+        Symbol:          .debug_str
+        Type:            R_X86_64_32
+        Addend:          1157
+      - Offset:          0x110
+        Symbol:          .debug_str
+        Type:            R_X86_64_32
+        Addend:          1163
+      - Offset:          0x11D
+        Symbol:          .debug_str
+        Type:            R_X86_64_32
+        Addend:          1157
+      - Offset:          0x125
+        Symbol:          .debug_str
+        Type:            R_X86_64_32
+        Addend:          425
+      - Offset:          0x132
+        Symbol:          .debug_str
+        Type:            R_X86_64_32
+        Addend:          1163
+      - Offset:          0x140
+        Symbol:          .debug_str
+        Type:            R_X86_64_32
+        Addend:          1116
+      - Offset:          0x149
+        Symbol:          .debug_str
+        Type:            R_X86_64_32
+        Addend:          254
+      - Offset:          0x14E
+        Symbol:          .debug_str
+        Type:            R_X86_64_32
+        Addend:          199
+      - Offset:          0x153
+        Symbol:          .debug_str
+        Type:            R_X86_64_32
+        Addend:          259
+      - Offset:          0x158
+        Symbol:          .debug_str
+        Type:            R_X86_64_32
+        Addend:          1106
+      - Offset:          0x160
+        Symbol:          .debug_str
+        Type:            R_X86_64_32
+        Addend:          270
+      - Offset:          0x16C
+        Symbol:          .debug_str
+        Type:            R_X86_64_32
+        Addend:          929
+      - Offset:          0x178
+        Symbol:          .debug_str
+        Type:            R_X86_64_32
+        Addend:          1071
+      - Offset:          0x184
+        Symbol:          .debug_str
+        Type:            R_X86_64_32
+        Addend:          1087
+      - Offset:          0x192
+        Symbol:          .debug_str
+        Type:            R_X86_64_32
+        Addend:          929
+      - Offset:          0x197
+        Symbol:          .debug_str
+        Type:            R_X86_64_32
+        Addend:          1029
+      - Offset:          0x19F
+        Symbol:          .debug_str
+        Type:            R_X86_64_32
+        Addend:          938
+      - Offset:          0x1AB
+        Symbol:          .debug_str
+        Type:            R_X86_64_32
+        Addend:          987
+      - Offset:          0x1B7
+        Symbol:          .debug_str
+        Type:            R_X86_64_32
+        Addend:          992
+      - Offset:          0x1C3
+        Symbol:          .debug_str
+        Type:            R_X86_64_32
+        Addend:          996
+      - Offset:          0x1D2
+        Symbol:          .debug_str
+        Type:            R_X86_64_32
+        Addend:          278
+      - Offset:          0x1D7
+        Symbol:          .debug_str
+        Type:            R_X86_64_32
+        Addend:          897
+      - Offset:          0x1DF
+        Symbol:          .debug_str
+        Type:            R_X86_64_32
+        Addend:          282
+      - Offset:          0x1EB
+        Symbol:          .debug_str
+        Type:            R_X86_64_32
+        Addend:          339
+      - Offset:          0x1F8
+        Symbol:          .debug_str
+        Type:            R_X86_64_32
+        Addend:          344
+      - Offset:          0x1FD
+        Symbol:          .debug_str
+        Type:            R_X86_64_32
+        Addend:          824
+      - Offset:          0x205
+        Symbol:          .debug_str
+        Type:            R_X86_64_32
+        Addend:          347
+      - Offset:          0x212
+        Symbol:          .debug_str
+        Type:            R_X86_64_32
+        Addend:          811
+      - Offset:          0x227
+        Symbol:          .debug_str
+        Type:            R_X86_64_32
+        Addend:          354
+      - Offset:          0x235
+        Symbol:          .debug_str
+        Type:            R_X86_64_32
+        Addend:          805
+      - Offset:          0x242
+        Symbol:          .debug_str
+        Type:            R_X86_64_32
+        Addend:          354
+      - Offset:          0x24A
+        Symbol:          .debug_str
+        Type:            R_X86_64_32
+        Addend:          366
+      - Offset:          0x256
+        Symbol:          .debug_str
+        Type:            R_X86_64_32
+        Addend:          397
+      - Offset:          0x262
+        Symbol:          .debug_str
+        Type:            R_X86_64_32
+        Addend:          767
+      - Offset:          0x26F
+        Symbol:          .debug_str
+        Type:            R_X86_64_32
+        Addend:          805
+      - Offset:          0x277
+        Symbol:          .debug_str
+        Type:            R_X86_64_32
+        Addend:          425
+      - Offset:          0x286
+        Symbol:          .debug_str
+        Type:            R_X86_64_32
+        Addend:          417
+      - Offset:          0x28E
+        Symbol:          .debug_str
+        Type:            R_X86_64_32
+        Addend:          614
+      - Offset:          0x296
+        Symbol:          .debug_str
+        Type:            R_X86_64_32
+        Addend:          462
+      - Offset:          0x2A2
+        Symbol:          .debug_str
+        Type:            R_X86_64_32
+        Addend:          518
+      - Offset:          0x2AF
+        Symbol:          .debug_str
+        Type:            R_X86_64_32
+        Addend:          500
+      - Offset:          0x2B7
+        Symbol:          .debug_str
+        Type:            R_X86_64_32
+        Addend:          470
+      - Offset:          0x2C3
+        Symbol:          .debug_str
+        Type:            R_X86_64_32
+        Addend:          480
+      - Offset:          0x2CF
+        Symbol:          .debug_str
+        Type:            R_X86_64_32
+        Addend:          490
+      - Offset:          0x2DD
+        Symbol:          .debug_str
+        Type:            R_X86_64_32
+        Addend:          291
+      - Offset:          0x2E2
+        Symbol:          .debug_str
+        Type:            R_X86_64_32
+        Addend:          295
+      - Offset:          0x2E7
+        Symbol:          .debug_str
+        Type:            R_X86_64_32
+        Addend:          327
+      - Offset:          0x2F3
+        Symbol:          .debug_str
+        Type:            R_X86_64_32
+        Addend:          307
+      - Offset:          0x2F8
+        Symbol:          .debug_str
+        Type:            R_X86_64_32
+        Addend:          309
+      - Offset:          0x305
+        Symbol:          .debug_str
+        Type:            R_X86_64_32
+        Addend:          864
+      - Offset:          0x311
+        Symbol:          .debug_str
+        Type:            R_X86_64_32
+        Addend:          307
+      - Offset:          0x316
+        Symbol:          .debug_str
+        Type:            R_X86_64_32
+        Addend:          309
+      - Offset:          0x323
+        Symbol:          .debug_str
+        Type:            R_X86_64_32
+        Addend:          385
+      - Offset:          0x32F
+        Symbol:          .debug_str
+        Type:            R_X86_64_32
+        Addend:          307
+      - Offset:          0x334
+        Symbol:          .debug_str
+        Type:            R_X86_64_32
+        Addend:          309
+      - Offset:          0x341
+        Symbol:          .debug_str
+        Type:            R_X86_64_32
+        Addend:          974
+      - Offset:          0x34D
+        Symbol:          .debug_str
+        Type:            R_X86_64_32
+        Addend:          307
+      - Offset:          0x352
+        Symbol:          .debug_str
+        Type:            R_X86_64_32
+        Addend:          309
+      - Offset:          0x361
+        Symbol:          .debug_str
+        Type:            R_X86_64_32
+        Addend:          407
+      - Offset:          0x366
+        Symbol:          .debug_str
+        Type:            R_X86_64_32
+        Addend:          433
+      - Offset:          0x37C
+        Symbol:          .debug_str
+        Type:            R_X86_64_32
+        Addend:          414
+      - Offset:          0x38A
+        Symbol:          .debug_str
+        Type:            R_X86_64_32
+        Addend:          429
+      - Offset:          0x397
+        Symbol:          .debug_str
+        Type:            R_X86_64_32
+        Addend:          414
+      - Offset:          0x3A3
+        Symbol:          .debug_str
+        Type:            R_X86_64_32
+        Addend:          307
+      - Offset:          0x3AC
+        Symbol:          .debug_str
+        Type:            R_X86_64_32
+        Addend:          423
+      - Offset:          0x3B1
+        Symbol:          .debug_str
+        Type:            R_X86_64_32
+        Addend:          425
+      - Offset:          0x3BE
+        Symbol:          .debug_str
+        Type:            R_X86_64_32
+        Addend:          429
+      - Offset:          0x3CA
+        Symbol:          .debug_str
+        Type:            R_X86_64_32
+        Addend:          307
+      - Offset:          0x3D3
+        Symbol:          .debug_str
+        Type:            R_X86_64_32
+        Addend:          423
+      - Offset:          0x3D8
+        Symbol:          .debug_str
+        Type:            R_X86_64_32
+        Addend:          425
+      - Offset:          0x3E7
+        Symbol:          .debug_str
+        Type:            R_X86_64_32
+        Addend:          777
+      - Offset:          0x3EC
+        Symbol:          .debug_str
+        Type:            R_X86_64_32
+        Addend:          788
+      - Offset:          0x3F8
+        Symbol:          .debug_str
+        Type:            R_X86_64_32
+        Addend:          307
+      - Offset:          0x3FE
+        Symbol:          .debug_str
+        Type:            R_X86_64_32
+        Addend:          1011
+      - Offset:          0x40A
+        Symbol:          .debug_str
+        Type:            R_X86_64_32
+        Addend:          307
+      - Offset:          0x416
+        Symbol:          .debug_str
+        Type:            R_X86_64_32
+        Addend:          907
+      - Offset:          0x41F
+        Symbol:          .debug_str
+        Type:            R_X86_64_32
+        Addend:          304
+      - Offset:          0x42A
+        Symbol:          .debug_str
+        Type:            R_X86_64_32
+        Addend:          317
+      - Offset:          0x433
+        Symbol:          .debug_str
+        Type:            R_X86_64_32
+        Addend:          350
+      - Offset:          0x43A
+        Symbol:          .debug_str
+        Type:            R_X86_64_32
+        Addend:          372
+      - Offset:          0x445
+        Symbol:          .debug_str
+        Type:            R_X86_64_32
+        Addend:          375
+      - Offset:          0x452
+        Symbol:          .debug_str
+        Type:            R_X86_64_32
+        Addend:          650
+      - Offset:          0x46F
+        Symbol:          .debug_str
+        Type:            R_X86_64_32
+        Addend:          624
+      - Offset:          0x478
+        Symbol:          .debug_str
+        Type:            R_X86_64_32
+        Addend:          476
+      - Offset:          0x47F
+        Symbol:          .debug_str
+        Type:            R_X86_64_32
+        Addend:          486
+      - Offset:          0x486
+        Symbol:          .debug_str
+        Type:            R_X86_64_32
+        Addend:          588
+      - Offset:          0x48D
+        Symbol:          .debug_str
+        Type:            R_X86_64_32
+        Addend:          309
+      - Offset:          0x498
+        Symbol:          .debug_str
+        Type:            R_X86_64_32
+        Addend:          543
+      - Offset:          0x4AD
+        Symbol:          .debug_str
+        Type:            R_X86_64_32
+        Addend:          522
+      - Offset:          0x4B8
+        Symbol:          .debug_str
+        Type:            R_X86_64_32
+        Addend:          576
+      - Offset:          0x4CE
+        Symbol:          .debug_str
+        Type:            R_X86_64_32
+        Addend:          550
+      - Offset:          0x4D5
+        Symbol:          .debug_str
+        Type:            R_X86_64_32
+        Addend:          556
+      - Offset:          0x4E0
+        Symbol:          .debug_str
+        Type:            R_X86_64_32
+        Addend:          784
+      - Offset:          0x4ED
+        Symbol:          .debug_str
+        Type:            R_X86_64_32
+        Addend:          833
+      - Offset:          0x4FA
+        Symbol:          .debug_str
+        Type:            R_X86_64_32
+        Addend:          1038
+      - Offset:          0x503
+        Symbol:          .debug_str
+        Type:            R_X86_64_32
+        Addend:          963
+      - Offset:          0x50A
+        Symbol:          .debug_str
+        Type:            R_X86_64_32
+        Addend:          947
+      - Offset:          0x515
+        Symbol:          .debug_str
+        Type:            R_X86_64_32
+        Addend:          956
+      - Offset:          0x52A
+        Symbol:          .debug_str
+        Type:            R_X86_64_32
+        Addend:          1006
+      - Offset:          0x531
+        Symbol:          .debug_str
+        Type:            R_X86_64_32
+        Addend:          947
+      - Offset:          0x53C
+        Symbol:          .debug_str
+        Type:            R_X86_64_32
+        Addend:          956
+      - Offset:          0x548
+        Symbol:          .debug_str
+        Type:            R_X86_64_32
+        Addend:          1082
+      - Offset:          0x553
+        Symbol:          .debug_str
+        Type:            R_X86_64_32
+        Addend:          1177
+      - Offset:          0x55C
+        Symbol:          .debug_str
+        Type:            R_X86_64_32
+        Addend:          1152
+  - Name:            .rela.debug_aranges
+    Type:            SHT_RELA
+    Flags:           [ SHF_INFO_LINK ]
+    Link:            .symtab
+    AddressAlign:    0x8
+    Info:            .debug_aranges
+    Relocations:
+      - Offset:          0x6
+        Symbol:          .debug_info
+        Type:            R_X86_64_32
+      - Offset:          0x10
+        Symbol:          .text._RNvCshXwFllX56pT_7___rustc17rust_begin_unwind
+        Type:            R_X86_64_64
+      - Offset:          0x20
+        Symbol:          .text._ZN4main6use_it17h7beb6f96865c87acE
+        Type:            R_X86_64_64
+      - Offset:          0x30
+        Symbol:          .text.main
+        Type:            R_X86_64_64
+  - Name:            .rela.debug_ranges
+    Type:            SHT_RELA
+    Flags:           [ SHF_INFO_LINK ]
+    Link:            .symtab
+    AddressAlign:    0x8
+    Info:            .debug_ranges
+    Relocations:
+      - Symbol:          .text._RNvCshXwFllX56pT_7___rustc17rust_begin_unwind
+        Type:            R_X86_64_64
+      - Offset:          0x8
+        Symbol:          .text._RNvCshXwFllX56pT_7___rustc17rust_begin_unwind
+        Type:            R_X86_64_64
+        Addend:          7
+      - Offset:          0x10
+        Symbol:          .text._ZN4main6use_it17h7beb6f96865c87acE
+        Type:            R_X86_64_64
+      - Offset:          0x18
+        Symbol:          .text._ZN4main6use_it17h7beb6f96865c87acE
+        Type:            R_X86_64_64
+        Addend:          6
+      - Offset:          0x20
+        Symbol:          .text.main
+        Type:            R_X86_64_64
+      - Offset:          0x28
+        Symbol:          .text.main
+        Type:            R_X86_64_64
+        Addend:          83
+  - Name:            .rela.eh_frame
+    Type:            SHT_RELA
+    Flags:           [ SHF_INFO_LINK ]
+    Link:            .symtab
+    AddressAlign:    0x8
+    Info:            .eh_frame
+    Relocations:
+      - Offset:          0x20
+        Symbol:          .text._RNvCshXwFllX56pT_7___rustc17rust_begin_unwind
+        Type:            R_X86_64_PC32
+      - Offset:          0x34
+        Symbol:          .text._ZN4main6use_it17h7beb6f96865c87acE
+        Type:            R_X86_64_PC32
+      - Offset:          0x48
+        Symbol:          .text.main
+        Type:            R_X86_64_PC32
+  - Name:            .rela.debug_line
+    Type:            SHT_RELA
+    Flags:           [ SHF_INFO_LINK ]
+    Link:            .symtab
+    AddressAlign:    0x8
+    Info:            .debug_line
+    Relocations:
+      - Offset:          0x30
+        Symbol:          .text._RNvCshXwFllX56pT_7___rustc17rust_begin_unwind
+        Type:            R_X86_64_64
+      - Offset:          0x47
+        Symbol:          .text._ZN4main6use_it17h7beb6f96865c87acE
+        Type:            R_X86_64_64
+      - Offset:          0x5E
+        Symbol:          .text.main
+        Type:            R_X86_64_64
+  - Type:            SectionHeaderTable
+    Sections:
+      - Name:            .strtab
+      - Name:            .text
+      - Name:            .text._RNvCshXwFllX56pT_7___rustc17rust_begin_unwind
+      - Name:            .text._ZN4main6use_it17h7beb6f96865c87acE
+      - Name:            .text.main
+      - Name:            .rela.text.main
+      - Name:            .debug_gdb_scripts
+      - Name:            .debug_abbrev
+      - Name:            .debug_info
+      - Name:            .rela.debug_info
+      - Name:            .debug_aranges
+      - Name:            .rela.debug_aranges
+      - Name:            .debug_ranges
+      - Name:            .rela.debug_ranges
+      - Name:            .debug_str
+      - Name:            .comment
+      - Name:            .note.GNU-stack
+      - Name:            .eh_frame
+      - Name:            .rela.eh_frame
+      - Name:            .debug_line
+      - Name:            .rela.debug_line
+      - Name:            .symtab
+Symbols:
+  - Name:            main.9b5cc465332d101d-cgu.0
+    Type:            STT_FILE
+    Index:           SHN_ABS
+  - Name:            .text._RNvCshXwFllX56pT_7___rustc17rust_begin_unwind
+    Type:            STT_SECTION
+    Section:         .text._RNvCshXwFllX56pT_7___rustc17rust_begin_unwind
+  - Name:            .text._ZN4main6use_it17h7beb6f96865c87acE
+    Type:            STT_SECTION
+    Section:         .text._ZN4main6use_it17h7beb6f96865c87acE
+  - Name:            _ZN4main6use_it17h7beb6f96865c87acE
+    Type:            STT_FUNC
+    Section:         .text._ZN4main6use_it17h7beb6f96865c87acE
+    Size:            0x6
+  - Name:            .text.main
+    Type:            STT_SECTION
+    Section:         .text.main
+  - Name:            .debug_abbrev
+    Type:            STT_SECTION
+    Section:         .debug_abbrev
+  - Name:            .debug_info
+    Type:            STT_SECTION
+    Section:         .debug_info
+  - Name:            .debug_ranges
+    Type:            STT_SECTION
+    Section:         .debug_ranges
+  - Name:            .debug_str
+    Type:            STT_SECTION
+    Section:         .debug_str
+  - Name:            .debug_line
+    Type:            STT_SECTION
+    Section:         .debug_line
+  - Name:            _RNvCshXwFllX56pT_7___rustc17rust_begin_unwind
+    Type:            STT_FUNC
+    Section:         .text._RNvCshXwFllX56pT_7___rustc17rust_begin_unwind
+    Binding:         STB_GLOBAL
+    Size:            0x7
+    Other:           [ STV_HIDDEN ]
+  - Name:            main
+    Type:            STT_FUNC
+    Section:         .text.main
+    Binding:         STB_GLOBAL
+    Size:            0x53
+  - Name:            __rustc_debug_gdb_scripts_section__
+    Type:            STT_OBJECT
+    Section:         .debug_gdb_scripts
+    Binding:         STB_WEAK
+    Size:            0x22
+DWARF:
+  debug_str:
+    - 'clang LLVM (rustc version 1.93.0 (254b59607 2026-01-19))'
+    - 'src/main.rs\@\main.9b5cc465332d101d-cgu.0'
+    - 'C:\Coding\NotMyCode\llvm_patches\llvm-project\z'
+    - main
+    - _RNvCshXwFllX56pT_7___rustc17rust_begin_unwind
+    - panic
+    - _ZN4main6use_it17h7beb6f96865c87acE
+    - use_it
+    - _info
+    - core
+    - panic_info
+    - message
+    - fmt
+    - template
+    - ptr
+    - non_null
+    - u8
+    - T
+    - pointer
+    - '*const u8'
+    - 'NonNull<u8>'
+    - args
+    - rt
+    - ty
+    - u64
+    - Placeholder
+    - value
+    - '()'
+    - '*const ()'
+    - 'NonNull<()>'
+    - formatter
+    - result
+    - Ok
+    - Error
+    - E
+    - __0
+    - Err
+    - 'Result<(), core::fmt::Error>'
+    - options
+    - flags
+    - u32
+    - width
+    - u16
+    - precision
+    - FormattingOptions
+    - buf
+    - 'dyn core::fmt::Write'
+    - vtable
+    - usize
+    - __ARRAY_SIZE_TYPE__
+    - '&[usize; 6]'
+    - '&mut dyn core::fmt::Write'
+    - Formatter
+    - '&mut core::fmt::Formatter'
+    - 'unsafe fn(core::ptr::non_null::NonNull<()>, &mut core::fmt::Formatter) -> core::result::Result<(), core::fmt::Error>'
+    - _lifetime
+    - marker
+    - '&()'
+    - 'PhantomData<&()>'
+    - Count
+    - ArgumentType
+    - Argument
+    - '*const core::fmt::rt::Argument'
+    - 'NonNull<core::fmt::rt::Argument>'
+    - Arguments
+    - '&core::fmt::Arguments'
+    - location
+    - filename
+    - data_ptr
+    - length
+    - '*const str'
+    - 'NonNull<str>'
+    - line
+    - col
+    - _filename
+    - '&str'
+    - 'PhantomData<&str>'
+    - Location
+    - '&core::panic::location::Location'
+    - can_unwind
+    - bool
+    - force_no_backtrace
+    - PanicInfo
+    - '&core::panic::panic_info::PanicInfo'
+    - u128
+    - Value
+    - None
+    - BigDiscr
+    - '&main::BigDiscr'
+    - none
+    - some
+  debug_aranges:
+    - Length:          0x4C
+      Version:         2
+      CuOffset:        0x0
+      AddressSize:     0x8
+      Descriptors:
+        - Address:         0x0
+          Length:          0x7
+        - Address:         0x0
+          Length:          0x6
+        - Address:         0x0
+          Length:          0x53
+  debug_ranges:
+    - Offset:          0x0
+      AddrSize:        0x8
+      Entries:         []
+    - Offset:          0x10
+      AddrSize:        0x8
+      Entries:         []
+    - Offset:          0x20
+      AddrSize:        0x8
+      Entries:         []
+    - Offset:          0x30
+      AddrSize:        0x8
+      Entries:         []
+...


### PR DESCRIPTION
resolves #177812 

It currently uses a `uint32_t` even though Rust can output 64- and 128-bit discriminants. This became a more obvious issue when Rust started niche-optimizing based on the capacity of strings (which are `NoHighBit` values, guaranteed to be less than `u64::MAX / 2`), rather than the `NonNull` heap pointer. With this optimization, the `None` variant of strings is 9223372036854775808, which LLDB truncates to 0. This means whenever the capacity is 0 (e.g. `Some(String::new())`, LLDB will mistakenly read it as the `None` variant. Additionally, when trying to determine the `None` variant, lldb will read the discr from memory correctly (9223372036854775808), and the visualizer scripts will compare that to the value in the variant name (`$variant$0`), see that it doesn't match, and incorrectly decides that it must not be the `None` variant.

This patch simply swaps the `uint32_t` with an `llvm::APInt`. 

Sample program:

```rust
#[repr(u128)]
enum BigDiscr {
    Value(u64),
    None = 0x16151413121110090807060504030201,
}

fn main() {
    let big_discr_none = BigDiscr::None;
    let big_disr_some = BigDiscr::Value(31);

    let some_string = Some(String::from("asdf"));
    let some_empty_string = Some(String::new());
    let none_string: Option<String> = Option::None;

    println!("Hello world!"); // break
}
```

New output without visualizers:

```txt
(sample::BigDiscr) big_discr_none = {
  $variants$ = {
    $variant$0 = {
      $discr$ = 29352461300415899028694309177919734273
      value = (__0 = 0)
    }
    $variant$29352461300415899028694309177919734273 = ($discr$ = 29352461300415899028694309177919734273, value = sample::BigDiscr::None:128 @ 0x000000710a7ff7d0)
  }
}
(sample::BigDiscr) big_disr_some = {
  $variants$ = {
    $variant$0 = {
      $discr$ = 0
      value = (__0 = 31)
    }
    $variant$29352461300415899028694309177919734273 = ($discr$ = 0, value = sample::BigDiscr::None:128 @ 0x000000710a7ff7f0)
  }
}
(core::option::Option<alloc::string::String>) some_string = {
  $variants$ = {
    $variant$9223372036854775808 = ($discr$ = 4, value = core::option::Option<alloc::string::String>::None<alloc::string::String>:64 @ 0x000000710a7ff750)
    $variant$ = {
      value = {
        __0 = {
          vec = {...}
        }
      }
    }
  }
}
(core::option::Option<alloc::string::String>) some_empty_string = {
  $variants$ = {
    $variant$9223372036854775808 = ($discr$ = 0, value = core::option::Option<alloc::string::String>::None<alloc::string::String>:64 @ 0x000000710a7ff780)
    $variant$ = {
      value = {
        __0 = {
          vec = {...}
        }
      }
    }
  }
}
(core::option::Option<alloc::string::String>) none_string = {
  $variants$ = {
    $variant$9223372036854775808 = ($discr$ = 9223372036854775808, value = core::option::Option<alloc::string::String>::None<alloc::string::String>:64 @ 0x000000710a7ff7b8)
    $variant$ = {
      value = {
        __0 = {
          vec = {...}
        }
      }
    }
  }
}
```

New output with Rust's current visualizers:

```txt
# this one is incorrect because the visualizer scripts are wrong, not because of LLDB.
# the scripts use `GetValue()`, which returns a 64 bit number. They can be modified
# on Rust's end to use `GetData()` instead. The rest work as expected
(sample::BigDiscr) big_discr_none = Value(0) {
  0 = 0
}
(sample::BigDiscr) big_disr_some = Value(31) {
  0 = 31
}
(core::option::Option<alloc::string::String>) some_string = Some("asdf") {
  0 = "asdf" {
    [0] = 'a'
    [1] = 's'
    [2] = 'd'
    [3] = 'f'
  }
}
(core::option::Option<alloc::string::String>) some_empty_string = Some("") {
  0 = ""
}
```