### PR TITLE
[MLIR][Python] Support `has_trait` for operations

### DIFF
--- a/mlir/include/mlir-c/ExtensibleDialect.h
+++ b/mlir/include/mlir-c/ExtensibleDialect.h
@@ -50,9 +50,17 @@ mlirDynamicOpTraitAttach(MlirDynamicOpTrait dynamicOpTrait,
 MLIR_CAPI_EXPORTED MlirDynamicOpTrait
 mlirDynamicOpTraitIsTerminatorCreate(void);
 
+/// Get the type ID of the dynamic op trait that indicates the operation is a
+/// terminator.
+MLIR_CAPI_EXPORTED MlirTypeID mlirDynamicOpTraitIsTerminatorGetTypeID(void);
+
 /// Get the dynamic op trait that indicates regions have no terminator.
 MLIR_CAPI_EXPORTED MlirDynamicOpTrait
 mlirDynamicOpTraitNoTerminatorCreate(void);
+
+/// Get the type ID of the dynamic op trait that indicates regions have no
+/// terminator.
+MLIR_CAPI_EXPORTED MlirTypeID mlirDynamicOpTraitNoTerminatorGetTypeID(void);
 
 /// Destroy the dynamic op trait.
 MLIR_CAPI_EXPORTED void

--- a/mlir/include/mlir-c/IR.h
+++ b/mlir/include/mlir-c/IR.h
@@ -631,6 +631,10 @@ MLIR_CAPI_EXPORTED size_t mlirOperationHashValue(MlirOperation op);
 /// Gets the context this operation is associated with
 MLIR_CAPI_EXPORTED MlirContext mlirOperationGetContext(MlirOperation op);
 
+/// Checks if the operation has a trait identified by the given type id.
+MLIR_CAPI_EXPORTED bool mlirOperationHasTrait(MlirOperation op,
+                                              MlirTypeID traitTypeID);
+
 /// Gets the location of the operation.
 MLIR_CAPI_EXPORTED MlirLocation mlirOperationGetLocation(MlirOperation op);
 

--- a/mlir/include/mlir-c/IR.h
+++ b/mlir/include/mlir-c/IR.h
@@ -631,9 +631,10 @@ MLIR_CAPI_EXPORTED size_t mlirOperationHashValue(MlirOperation op);
 /// Gets the context this operation is associated with
 MLIR_CAPI_EXPORTED MlirContext mlirOperationGetContext(MlirOperation op);
 
-/// Checks if the operation has a trait identified by the given type id.
-MLIR_CAPI_EXPORTED bool mlirOperationHasTrait(MlirOperation op,
-                                              MlirTypeID traitTypeID);
+/// Checks if the operation name has a trait identified by the given type id.
+MLIR_CAPI_EXPORTED bool mlirOperationNameHasTrait(MlirStringRef opName,
+                                                  MlirTypeID traitTypeID,
+                                                  MlirContext context);
 
 /// Gets the location of the operation.
 MLIR_CAPI_EXPORTED MlirLocation mlirOperationGetLocation(MlirOperation op);

--- a/mlir/include/mlir/Bindings/Python/IRCore.h
+++ b/mlir/include/mlir/Bindings/Python/IRCore.h
@@ -1861,6 +1861,8 @@ public:
                      const nanobind::object &target, PyMlirContext &context);
 
   static void bind(nanobind::module_ &m);
+
+  static inline const char *typeIDAttr = "_trait_typeid";
 };
 
 namespace PyDynamicOpTraits {

--- a/mlir/include/mlir/IR/ExtensibleDialect.h
+++ b/mlir/include/mlir/IR/ExtensibleDialect.h
@@ -401,7 +401,8 @@ private:
 template <template <typename T> class Trait>
 class DynamicOpTraitImpl : public DynamicOpTrait {
 public:
-  TypeID getTypeID() const override { return TypeID::get<Trait>(); }
+  static TypeID getStaticTypeID() { return TypeID::get<Trait>(); }
+  TypeID getTypeID() const override { return getStaticTypeID(); }
 };
 
 namespace DynamicOpTraits {

--- a/mlir/lib/Bindings/Python/IRCore.cpp
+++ b/mlir/lib/Bindings/Python/IRCore.cpp
@@ -3965,12 +3965,18 @@ void populateIRCore(nb::module_ &m) {
                callback: A callable that takes an Operation and returns a WalkResult.
                walk_order: The order of traversal (PRE_ORDER or POST_ORDER).
                op_class: If provided, only operations of this type are passed to the callback.)")
-      .def("has_trait", [](PyOperationBase &self, nb::type_object &traitCls) {
-        PyTypeID traitTypeID =
-            nb::cast<PyTypeID>(traitCls.attr(PyDynamicOpTrait::typeIDAttr));
-        return mlirOperationHasTrait(self.getOperation().get(),
-                                     traitTypeID.get());
-      });
+      .def(
+          "has_trait",
+          [](PyOperationBase &self, nb::type_object &traitCls) {
+            PyTypeID traitTypeID =
+                nb::cast<PyTypeID>(traitCls.attr(PyDynamicOpTrait::typeIDAttr));
+            MlirIdentifier opName =
+                mlirOperationGetName(self.getOperation().get());
+            return mlirOperationNameHasTrait(
+                mlirIdentifierStr(opName), traitTypeID.get(),
+                self.getOperation().getContext()->get());
+          },
+          "trait_cls"_a, "Checks if the operation has a given trait.");
 
   nb::class_<PyOperation, PyOperationBase>(m, "Operation")
       .def_static(
@@ -4172,6 +4178,18 @@ void populateIRCore(nb::module_ &m) {
       "cls"_a, "source"_a, nb::kw_only(), "source_name"_a = "",
       "context"_a = nb::none(),
       "Parses a specific, generated OpView based on class level attributes.");
+  opViewClass.attr("has_trait") = classmethod(
+      [](nb::object &self, nb::type_object &traitCls,
+         DefaultingPyMlirContext &context) {
+        PyTypeID traitTypeID =
+            nb::cast<PyTypeID>(traitCls.attr(PyDynamicOpTrait::typeIDAttr));
+        std::string opName = nb::cast<std::string>(self.attr("OPERATION_NAME"));
+        return mlirOperationNameHasTrait(
+            mlirStringRefCreate(opName.data(), opName.size()),
+            traitTypeID.get(), context->get());
+      },
+      "cls"_a, "trait_cls"_a, "context"_a = nb::none(),
+      "Checks if the operation has a given trait.");
 
   PyOpAdaptor::bind(m);
 

--- a/mlir/lib/Bindings/Python/IRCore.cpp
+++ b/mlir/lib/Bindings/Python/IRCore.cpp
@@ -2608,7 +2608,6 @@ bool PyDynamicOpTrait::attach(const nb::object &opName,
 
   // To ensure that the same dynamic trait gets the same TypeID despite how many
   // times `attach` is called, we store it as an attribute on the target class.
-  constexpr const char *typeIDAttr = "_TYPE_ID";
   if (!nb::hasattr(target, typeIDAttr)) {
     nb::setattr(target, typeIDAttr,
                 nb::cast(PyTypeID(PyGlobals::get().allocateTypeID())));
@@ -2642,6 +2641,7 @@ bool PyDynamicOpTraits::IsTerminator::attach(const nb::object &opName,
 void PyDynamicOpTraits::IsTerminator::bind(nb::module_ &m) {
   nb::class_<PyDynamicOpTraits::IsTerminator, PyDynamicOpTrait> cls(
       m, "IsTerminatorTrait");
+  cls.attr(typeIDAttr) = PyTypeID(mlirDynamicOpTraitIsTerminatorGetTypeID());
   cls.attr("attach") = classmethod(
       [](const nb::object &cls, const nb::object &opName,
          DefaultingPyMlirContext context) {
@@ -2660,6 +2660,7 @@ bool PyDynamicOpTraits::NoTerminator::attach(const nb::object &opName,
 void PyDynamicOpTraits::NoTerminator::bind(nb::module_ &m) {
   nb::class_<PyDynamicOpTraits::NoTerminator, PyDynamicOpTrait> cls(
       m, "NoTerminatorTrait");
+  cls.attr(typeIDAttr) = PyTypeID(mlirDynamicOpTraitNoTerminatorGetTypeID());
   cls.attr("attach") = classmethod(
       [](const nb::object &cls, const nb::object &opName,
          DefaultingPyMlirContext context) {
@@ -3963,7 +3964,13 @@ void populateIRCore(nb::module_ &m) {
              Args:
                callback: A callable that takes an Operation and returns a WalkResult.
                walk_order: The order of traversal (PRE_ORDER or POST_ORDER).
-               op_class: If provided, only operations of this type are passed to the callback.)");
+               op_class: If provided, only operations of this type are passed to the callback.)")
+      .def("has_trait", [](PyOperationBase &self, nb::type_object &traitCls) {
+        PyTypeID traitTypeID =
+            nb::cast<PyTypeID>(traitCls.attr(PyDynamicOpTrait::typeIDAttr));
+        return mlirOperationHasTrait(self.getOperation().get(),
+                                     traitTypeID.get());
+      });
 
   nb::class_<PyOperation, PyOperationBase>(m, "Operation")
       .def_static(

--- a/mlir/lib/CAPI/IR/ExtensibleDialect.cpp
+++ b/mlir/lib/CAPI/IR/ExtensibleDialect.cpp
@@ -42,8 +42,16 @@ MlirDynamicOpTrait mlirDynamicOpTraitIsTerminatorCreate() {
   return wrap(new DynamicOpTraits::IsTerminator());
 }
 
+MlirTypeID mlirDynamicOpTraitIsTerminatorGetTypeID() {
+  return wrap(DynamicOpTraits::IsTerminator::getStaticTypeID());
+}
+
 MlirDynamicOpTrait mlirDynamicOpTraitNoTerminatorCreate() {
   return wrap(new DynamicOpTraits::NoTerminator());
+}
+
+MlirTypeID mlirDynamicOpTraitNoTerminatorGetTypeID() {
+  return wrap(DynamicOpTraits::NoTerminator::getStaticTypeID());
 }
 
 void mlirDynamicOpTraitDestroy(MlirDynamicOpTrait dynamicOpTrait) {

--- a/mlir/lib/CAPI/IR/IR.cpp
+++ b/mlir/lib/CAPI/IR/IR.cpp
@@ -651,8 +651,10 @@ MlirContext mlirOperationGetContext(MlirOperation op) {
   return wrap(unwrap(op)->getContext());
 }
 
-bool mlirOperationNameHasTrait(MlirStringRef opName, MlirTypeID traitTypeID, MlirContext context) {
-  return OperationName(unwrap(opName), unwrap(context)).hasTrait(unwrap(traitTypeID));
+bool mlirOperationNameHasTrait(MlirStringRef opName, MlirTypeID traitTypeID,
+                               MlirContext context) {
+  return OperationName(unwrap(opName), unwrap(context))
+      .hasTrait(unwrap(traitTypeID));
 }
 
 MlirLocation mlirOperationGetLocation(MlirOperation op) {

--- a/mlir/lib/CAPI/IR/IR.cpp
+++ b/mlir/lib/CAPI/IR/IR.cpp
@@ -651,6 +651,10 @@ MlirContext mlirOperationGetContext(MlirOperation op) {
   return wrap(unwrap(op)->getContext());
 }
 
+bool mlirOperationHasTrait(MlirOperation op, MlirTypeID traitTypeID) {
+  return unwrap(op)->getName().hasTrait(unwrap(traitTypeID));
+}
+
 MlirLocation mlirOperationGetLocation(MlirOperation op) {
   return wrap(unwrap(op)->getLoc());
 }

--- a/mlir/lib/CAPI/IR/IR.cpp
+++ b/mlir/lib/CAPI/IR/IR.cpp
@@ -651,8 +651,8 @@ MlirContext mlirOperationGetContext(MlirOperation op) {
   return wrap(unwrap(op)->getContext());
 }
 
-bool mlirOperationHasTrait(MlirOperation op, MlirTypeID traitTypeID) {
-  return unwrap(op)->getName().hasTrait(unwrap(traitTypeID));
+bool mlirOperationNameHasTrait(MlirStringRef opName, MlirTypeID traitTypeID, MlirContext context) {
+  return OperationName(unwrap(opName), unwrap(context)).hasTrait(unwrap(traitTypeID));
 }
 
 MlirLocation mlirOperationGetLocation(MlirOperation op) {

--- a/mlir/test/python/dialects/builtin.py
+++ b/mlir/test/python/dialects/builtin.py
@@ -259,6 +259,10 @@ def testBuiltinTraits():
         module = builtin.ModuleOp()
 
         # CHECK: True
-        print(module.has_trait(NoTerminatorTrait))
+        print(module.operation.has_trait(NoTerminatorTrait))
         # CHECK: False
-        print(module.has_trait(IsTerminatorTrait))
+        print(module.operation.has_trait(IsTerminatorTrait))
+        # CHECK: True
+        print(builtin.ModuleOp.has_trait(NoTerminatorTrait))
+        # CHECK: False
+        print(builtin.ModuleOp.has_trait(IsTerminatorTrait))

--- a/mlir/test/python/dialects/builtin.py
+++ b/mlir/test/python/dialects/builtin.py
@@ -250,3 +250,15 @@ def testDenseElementsAttr():
         idx_type = IndexType.get()
         print(DenseElementsAttr.get(idx_values, type=VectorType.get([4], idx_type)))
         # CHECK{LITERAL}: dense<[0, 1, 2, 3]> : vector<4xindex>
+
+
+# CHECK-LABEL: TEST: testBuiltinTraits
+@run
+def testBuiltinTraits():
+    with Context() as ctx, Location.unknown() as loc:
+        module = builtin.ModuleOp()
+
+        # CHECK: True
+        print(module.has_trait(NoTerminatorTrait))
+        # CHECK: False
+        print(module.has_trait(IsTerminatorTrait))

--- a/mlir/test/python/dialects/ext.py
+++ b/mlir/test/python/dialects/ext.py
@@ -480,11 +480,17 @@ def testExtDialectWithRegion():
         # CHECK: True
         print(yield_.has_trait(ParentIsIfTrait))
         # CHECK: False
-        print(nt.has_trait(IsTerminatorTrait))
+        print(nt.operation.has_trait(IsTerminatorTrait))
         # CHECK: True
-        print(nt.has_trait(NoTerminatorTrait))
+        print(nt.operation.has_trait(NoTerminatorTrait))
         # CHECK: False
-        print(nt.has_trait(ParentIsIfTrait))
+        print(nt.operation.has_trait(ParentIsIfTrait))
+        # CHECK: False
+        print(NoTermOp.has_trait(IsTerminatorTrait))
+        # CHECK: True
+        print(NoTermOp.has_trait(NoTerminatorTrait))
+        # CHECK: False
+        print(NoTermOp.has_trait(ParentIsIfTrait))
 
         # CHECK: %c2_i32 = arith.constant 2 : i32
         print(if_.then.blocks[0])

--- a/mlir/test/python/dialects/ext.py
+++ b/mlir/test/python/dialects/ext.py
@@ -444,7 +444,7 @@ def testExtDialectWithRegion():
 
             with InsertionPoint(if_.then.blocks[0]):
                 v = arith.constant(i32, 2)
-                YieldOp(v)
+                yield_ = YieldOp(v)
 
             with InsertionPoint(if_.else_.blocks[0]):
                 v = arith.constant(i32, 3)
@@ -472,6 +472,19 @@ def testExtDialectWithRegion():
         # CHECK:     }) : () -> ()
         # CHECK: }
         print(module)
+
+        # CHECK: True
+        print(yield_.has_trait(IsTerminatorTrait))
+        # CHECK: False
+        print(yield_.has_trait(NoTerminatorTrait))
+        # CHECK: True
+        print(yield_.has_trait(ParentIsIfTrait))
+        # CHECK: False
+        print(nt.has_trait(IsTerminatorTrait))
+        # CHECK: True
+        print(nt.has_trait(NoTerminatorTrait))
+        # CHECK: False
+        print(nt.has_trait(ParentIsIfTrait))
 
         # CHECK: %c2_i32 = arith.constant 2 : i32
         print(if_.then.blocks[0])

--- a/mlir/test/python/dialects/func.py
+++ b/mlir/test/python/dialects/func.py
@@ -141,6 +141,10 @@ def testFunctionTraits():
     ret = func.ReturnOp([])
 
     # CHECK: False
-    print(ret.has_trait(NoTerminatorTrait))
+    print(ret.operation.has_trait(NoTerminatorTrait))
     # CHECK: True
-    print(ret.has_trait(IsTerminatorTrait))
+    print(ret.operation.has_trait(IsTerminatorTrait))
+    # CHECK: False
+    print(func.ReturnOp.has_trait(NoTerminatorTrait))
+    # CHECK: True
+    print(func.ReturnOp.has_trait(IsTerminatorTrait))

--- a/mlir/test/python/dialects/func.py
+++ b/mlir/test/python/dialects/func.py
@@ -133,3 +133,14 @@ def testFunctionArgAttrs():
 
 # CHECK: func private @foo(f32 {test.foo = "bar"})
 # CHECK: func private @foo2(f32, f32  {test.baz = "qux"})
+
+
+# CHECK-LABEL: TEST: testFunctionTraits
+@constructAndPrintInModule
+def testFunctionTraits():
+    ret = func.ReturnOp([])
+
+    # CHECK: False
+    print(ret.has_trait(NoTerminatorTrait))
+    # CHECK: True
+    print(ret.has_trait(IsTerminatorTrait))


### PR DESCRIPTION
This PR adds a `has_trait(trait_cls)` API to `_OperationBase`, that can be used for:
- C++-defined operations and C++-defined traits (e.g. `func_return_op.has_trait(IsTerminatorTrait)`)
- Python-defined operations and C++-defined traits (e.g. `my_python_op.has_trait(IsTerminatorTrait)`)
- Python-defined operations and Python-defined traits (e.g. `my_python_op.has_trait(MyPythonTrait)`)