### PR TITLE
[InstCombine] Fold X * ldexp(1.0, Y) -> ldexp(X, Y).

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineMulDivRem.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineMulDivRem.cpp
@@ -1091,9 +1091,10 @@ Instruction *InstCombinerImpl::visitFMul(BinaryOperator &I) {
   }
 
   // X * ldexp(1.0, Y) -> ldexp(X, Y)
-  if (I.hasAllowContract() &&
-      match(&I, m_c_FMul(m_Value(X), m_OneUse(m_Intrinsic<Intrinsic::ldexp>(
-                                         m_FPOne(), m_Value(Y))))))
+  if (match(&I, m_AllowContract(m_c_FMul(
+                    m_Value(X),
+                    m_AllowContract(m_OneUse(m_Intrinsic<Intrinsic::ldexp>(
+                        m_FPOne(), m_Value(Y))))))))
     return replaceInstUsesWith(
         I, Builder.CreateIntrinsic(Intrinsic::ldexp,
                                    {X->getType(), Y->getType()}, {X, Y}, &I));

--- a/llvm/lib/Transforms/InstCombine/InstCombineMulDivRem.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineMulDivRem.cpp
@@ -1090,6 +1090,14 @@ Instruction *InstCombinerImpl::visitFMul(BinaryOperator &I) {
     return replaceInstUsesWith(I, Sin);
   }
 
+  // X * ldexp(1.0, Y) -> ldexp(X, Y)
+  if (I.hasAllowContract() &&
+      match(&I, m_c_FMul(m_Value(X), m_OneUse(m_Intrinsic<Intrinsic::ldexp>(
+                                         m_FPOne(), m_Value(Y))))))
+    return replaceInstUsesWith(
+        I, Builder.CreateIntrinsic(Intrinsic::ldexp,
+                                   {X->getType(), Y->getType()}, {X, Y}, &I));
+
   if (SimplifyDemandedInstructionFPClass(I))
     return &I;
 

--- a/llvm/lib/Transforms/InstCombine/InstCombineMulDivRem.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineMulDivRem.cpp
@@ -1091,9 +1091,9 @@ Instruction *InstCombinerImpl::visitFMul(BinaryOperator &I) {
   }
 
   // X * ldexp(1.0, Y) -> ldexp(X, Y)
-  if (match(&I, m_AllowContract(m_c_FMul(
+  if (match(&I, m_AllowReassoc(m_c_FMul(
                     m_Value(X),
-                    m_AllowContract(m_OneUse(m_Intrinsic<Intrinsic::ldexp>(
+                    m_AllowReassoc(m_OneUse(m_Intrinsic<Intrinsic::ldexp>(
                         m_FPOne(), m_Value(Y))))))))
     return replaceInstUsesWith(
         I, Builder.CreateIntrinsic(Intrinsic::ldexp,

--- a/llvm/test/Transforms/InstCombine/fmul.ll
+++ b/llvm/test/Transforms/InstCombine/fmul.ll
@@ -1415,7 +1415,7 @@ define float @fmul_ldexp(float %x, i32 %exp) {
 ; CHECK-NEXT:    [[MUL:%.*]] = call contract float @llvm.ldexp.f32.i32(float [[X:%.*]], i32 [[EXP:%.*]])
 ; CHECK-NEXT:    ret float [[MUL]]
 ;
-  %ldexp = call float @llvm.ldexp(float 1.0, i32 %exp)
+  %ldexp = call contract float @llvm.ldexp(float 1.0, i32 %exp)
   %mul = fmul contract float %x, %ldexp
   ret float %mul
 }
@@ -1425,7 +1425,7 @@ define float @fmul_ldexp_comm(float %x, i32 %exp) {
 ; CHECK-NEXT:    [[MUL:%.*]] = call contract float @llvm.ldexp.f32.i32(float [[X:%.*]], i32 [[EXP:%.*]])
 ; CHECK-NEXT:    ret float [[MUL]]
 ;
-  %ldexp = call float @llvm.ldexp(float 1.0, i32 %exp)
+  %ldexp = call contract float @llvm.ldexp(float 1.0, i32 %exp)
   %mul = fmul contract float %ldexp, %x
   ret float %mul
 }
@@ -1435,7 +1435,7 @@ define double @fmul_ldexp_f64(double %x, i32 %exp) {
 ; CHECK-NEXT:    [[MUL:%.*]] = call contract double @llvm.ldexp.f64.i32(double [[X:%.*]], i32 [[EXP:%.*]])
 ; CHECK-NEXT:    ret double [[MUL]]
 ;
-  %ldexp = call double @llvm.ldexp(double 1.0, i32 %exp)
+  %ldexp = call contract double @llvm.ldexp(double 1.0, i32 %exp)
   %mul = fmul contract double %x, %ldexp
   ret double %mul
 }
@@ -1445,30 +1445,41 @@ define <2 x float> @fmul_ldexp_v2f32(<2 x float> %x, <2 x i32> %exp) {
 ; CHECK-NEXT:    [[MUL:%.*]] = call contract <2 x float> @llvm.ldexp.v2f32.v2i32(<2 x float> [[X:%.*]], <2 x i32> [[EXP:%.*]])
 ; CHECK-NEXT:    ret <2 x float> [[MUL]]
 ;
-  %ldexp = call <2 x float> @llvm.ldexp(<2 x float> splat (float 1.0), <2 x i32> %exp)
-  %mul = fmul contract <2 x float> %ldexp, %x
+  %ldexp = call contract <2 x float> @llvm.ldexp(<2 x float> splat (float 1.0), <2 x i32> %exp)
+  %mul = fmul contract <2 x float> %x, %ldexp
   ret <2 x float> %mul
 }
 
-define float @fmul_ldexp_nocontract(float %x, i32 %exp) {
-; CHECK-LABEL: @fmul_ldexp_nocontract(
-; CHECK-NEXT:    [[LDEXP:%.*]] = call nnan float @llvm.ldexp.f32.i32(float 1.000000e+00, i32 [[EXP:%.*]])
+define float @fmul_ldexp_nocontract_fmul(float %x, i32 %exp) {
+; CHECK-LABEL: @fmul_ldexp_nocontract_fmul(
+; CHECK-NEXT:    [[LDEXP:%.*]] = call nnan contract float @llvm.ldexp.f32.i32(float 1.000000e+00, i32 [[EXP:%.*]])
 ; CHECK-NEXT:    [[MUL:%.*]] = fmul float [[X:%.*]], [[LDEXP]]
 ; CHECK-NEXT:    ret float [[MUL]]
 ;
-  %ldexp = call float @llvm.ldexp(float 1.0, i32 %exp)
+  %ldexp = call contract float @llvm.ldexp(float 1.0, i32 %exp)
   %mul = fmul float %x, %ldexp
+  ret float %mul
+}
+
+define float @fmul_ldexp_nocontract_ldexp(float %x, i32 %exp) {
+; CHECK-LABEL: @fmul_ldexp_nocontract_ldexp(
+; CHECK-NEXT:    [[LDEXP:%.*]] = call nnan float @llvm.ldexp.f32.i32(float 1.000000e+00, i32 [[EXP:%.*]])
+; CHECK-NEXT:    [[MUL:%.*]] = fmul contract float [[X:%.*]], [[LDEXP]]
+; CHECK-NEXT:    ret float [[MUL]]
+;
+  %ldexp = call float @llvm.ldexp(float 1.0, i32 %exp)
+  %mul = fmul contract float %x, %ldexp
   ret float %mul
 }
 
 define float @fmul_ldexp_multiuse_ldexp(float %x, i32 %exp) {
 ; CHECK-LABEL: @fmul_ldexp_multiuse_ldexp(
-; CHECK-NEXT:    [[LDEXP:%.*]] = call float @llvm.ldexp.f32.i32(float 1.000000e+00, i32 [[EXP:%.*]])
+; CHECK-NEXT:    [[LDEXP:%.*]] = call contract float @llvm.ldexp.f32.i32(float 1.000000e+00, i32 [[EXP:%.*]])
 ; CHECK-NEXT:    [[MUL:%.*]] = fmul contract float [[X:%.*]], [[LDEXP]]
 ; CHECK-NEXT:    tail call void @use_f32(float [[LDEXP]])
 ; CHECK-NEXT:    ret float [[MUL]]
 ;
-  %ldexp = call float @llvm.ldexp(float 1.0, i32 %exp)
+  %ldexp = call contract float @llvm.ldexp(float 1.0, i32 %exp)
   %mul = fmul contract float %x, %ldexp
   tail call void @use_f32(float %ldexp)
   ret float %mul
@@ -1480,7 +1491,7 @@ define float @fmul_ldexp_multiuse_x(float %x, i32 %exp) {
 ; CHECK-NEXT:    tail call void @use_f32(float [[X]])
 ; CHECK-NEXT:    ret float [[MUL]]
 ;
-  %ldexp = call float @llvm.ldexp(float 1.0, i32 %exp)
+  %ldexp = call contract float @llvm.ldexp(float 1.0, i32 %exp)
   %mul = fmul contract float %x, %ldexp
   tail call void @use_f32(float %x)
   ret float %mul
@@ -1488,13 +1499,21 @@ define float @fmul_ldexp_multiuse_x(float %x, i32 %exp) {
 
 define float @fmul_ldexp_not_fpone(float %x, i32 %exp) {
 ; CHECK-LABEL: @fmul_ldexp_not_fpone(
-; CHECK-NEXT:    [[LDEXP:%.*]] = call nnan float @llvm.ldexp.f32.i32(float 2.000000e+00, i32 [[EXP:%.*]])
+; CHECK-NEXT:    [[LDEXP:%.*]] = call nnan contract float @llvm.ldexp.f32.i32(float 2.000000e+00, i32 [[EXP:%.*]])
 ; CHECK-NEXT:    [[MUL:%.*]] = fmul contract float [[X:%.*]], [[LDEXP]]
-; CHECK-NEXT:    tail call void @use_f32(float [[X]])
 ; CHECK-NEXT:    ret float [[MUL]]
 ;
-  %ldexp = call float @llvm.ldexp(float 2.0, i32 %exp)
+  %ldexp = call contract float @llvm.ldexp(float 2.0, i32 %exp)
   %mul = fmul contract float %x, %ldexp
-  tail call void @use_f32(float %x)
+  ret float %mul
+}
+
+define float @fmul_ldexp_preserve_fmul_flags(float %x, i32 %exp) {
+; CHECK-LABEL: @fmul_ldexp_preserve_fmul_flags(
+; CHECK-NEXT:    [[MUL:%.*]] = call ninf arcp contract float @llvm.ldexp.f32.i32(float [[X:%.*]], i32 [[EXP:%.*]])
+; CHECK-NEXT:    ret float [[MUL]]
+;
+  %ldexp = call nnan contract float @llvm.ldexp(float 1.0, i32 %exp)
+  %mul = fmul ninf arcp contract float %x, %ldexp
   ret float %mul
 }

--- a/llvm/test/Transforms/InstCombine/fmul.ll
+++ b/llvm/test/Transforms/InstCombine/fmul.ll
@@ -1408,3 +1408,98 @@ entry:
   %ret = fmul <3 x float> %a, <float -0.0, float 0.0, float poison>
   ret <3 x float> %ret
 }
+
+; fmul X, ldexp(1.0, Y) -> ldexp X, Y
+define float @fmul_ldexp(float %x, i32 %exp) {
+; CHECK-LABEL: @fmul_ldexp(
+; CHECK-NEXT:    [[LDEXP:%.*]] = call nnan float @llvm.ldexp.f32.i32(float 1.000000e+00, i32 [[EXP:%.*]])
+; CHECK-NEXT:    [[MUL:%.*]] = fmul contract float [[X:%.*]], [[LDEXP]]
+; CHECK-NEXT:    ret float [[MUL]]
+;
+  %ldexp = call float @llvm.ldexp(float 1.0, i32 %exp)
+  %mul = fmul contract float %x, %ldexp
+  ret float %mul
+}
+
+define float @fmul_ldexp_comm(float %x, i32 %exp) {
+; CHECK-LABEL: @fmul_ldexp_comm(
+; CHECK-NEXT:    [[LDEXP:%.*]] = call nnan float @llvm.ldexp.f32.i32(float 1.000000e+00, i32 [[EXP:%.*]])
+; CHECK-NEXT:    [[MUL:%.*]] = fmul contract float [[LDEXP]], [[X:%.*]]
+; CHECK-NEXT:    ret float [[MUL]]
+;
+  %ldexp = call float @llvm.ldexp(float 1.0, i32 %exp)
+  %mul = fmul contract float %ldexp, %x
+  ret float %mul
+}
+
+define double @fmul_ldexp_f64(double %x, i32 %exp) {
+; CHECK-LABEL: @fmul_ldexp_f64(
+; CHECK-NEXT:    [[LDEXP:%.*]] = call nnan double @llvm.ldexp.f64.i32(double 1.000000e+00, i32 [[EXP:%.*]])
+; CHECK-NEXT:    [[MUL:%.*]] = fmul contract double [[X:%.*]], [[LDEXP]]
+; CHECK-NEXT:    ret double [[MUL]]
+;
+  %ldexp = call double @llvm.ldexp(double 1.0, i32 %exp)
+  %mul = fmul contract double %x, %ldexp
+  ret double %mul
+}
+
+define <2 x float> @fmul_ldexp_v2f32(<2 x float> %x, <2 x i32> %exp) {
+; CHECK-LABEL: @fmul_ldexp_v2f32(
+; CHECK-NEXT:    [[LDEXP:%.*]] = call nnan <2 x float> @llvm.ldexp.v2f32.v2i32(<2 x float> splat (float 1.000000e+00), <2 x i32> [[EXP:%.*]])
+; CHECK-NEXT:    [[MUL:%.*]] = fmul contract <2 x float> [[LDEXP]], [[X:%.*]]
+; CHECK-NEXT:    ret <2 x float> [[MUL]]
+;
+  %ldexp = call <2 x float> @llvm.ldexp(<2 x float> splat (float 1.0), <2 x i32> %exp)
+  %mul = fmul contract <2 x float> %ldexp, %x
+  ret <2 x float> %mul
+}
+
+define float @fmul_ldexp_nocontract(float %x, i32 %exp) {
+; CHECK-LABEL: @fmul_ldexp_nocontract(
+; CHECK-NEXT:    [[LDEXP:%.*]] = call nnan float @llvm.ldexp.f32.i32(float 1.000000e+00, i32 [[EXP:%.*]])
+; CHECK-NEXT:    [[MUL:%.*]] = fmul float [[X:%.*]], [[LDEXP]]
+; CHECK-NEXT:    ret float [[MUL]]
+;
+  %ldexp = call float @llvm.ldexp(float 1.0, i32 %exp)
+  %mul = fmul float %x, %ldexp
+  ret float %mul
+}
+
+define float @fmul_ldexp_multiuse_ldexp(float %x, i32 %exp) {
+; CHECK-LABEL: @fmul_ldexp_multiuse_ldexp(
+; CHECK-NEXT:    [[LDEXP:%.*]] = call float @llvm.ldexp.f32.i32(float 1.000000e+00, i32 [[EXP:%.*]])
+; CHECK-NEXT:    [[MUL:%.*]] = fmul contract float [[X:%.*]], [[LDEXP]]
+; CHECK-NEXT:    tail call void @use_f32(float [[LDEXP]])
+; CHECK-NEXT:    ret float [[MUL]]
+;
+  %ldexp = call float @llvm.ldexp(float 1.0, i32 %exp)
+  %mul = fmul contract float %x, %ldexp
+  tail call void @use_f32(float %ldexp)
+  ret float %mul
+}
+
+define float @fmul_ldexp_multiuse_x(float %x, i32 %exp) {
+; CHECK-LABEL: @fmul_ldexp_multiuse_x(
+; CHECK-NEXT:    [[LDEXP:%.*]] = call nnan float @llvm.ldexp.f32.i32(float 1.000000e+00, i32 [[EXP:%.*]])
+; CHECK-NEXT:    [[MUL:%.*]] = fmul contract float [[X:%.*]], [[LDEXP]]
+; CHECK-NEXT:    tail call void @use_f32(float [[X]])
+; CHECK-NEXT:    ret float [[MUL]]
+;
+  %ldexp = call float @llvm.ldexp(float 1.0, i32 %exp)
+  %mul = fmul contract float %x, %ldexp
+  tail call void @use_f32(float %x)
+  ret float %mul
+}
+
+define float @fmul_ldexp_not_fpone(float %x, i32 %exp) {
+; CHECK-LABEL: @fmul_ldexp_not_fpone(
+; CHECK-NEXT:    [[LDEXP:%.*]] = call nnan float @llvm.ldexp.f32.i32(float 2.000000e+00, i32 [[EXP:%.*]])
+; CHECK-NEXT:    [[MUL:%.*]] = fmul contract float [[X:%.*]], [[LDEXP]]
+; CHECK-NEXT:    tail call void @use_f32(float [[X]])
+; CHECK-NEXT:    ret float [[MUL]]
+;
+  %ldexp = call float @llvm.ldexp(float 2.0, i32 %exp)
+  %mul = fmul contract float %x, %ldexp
+  tail call void @use_f32(float %x)
+  ret float %mul
+}

--- a/llvm/test/Transforms/InstCombine/fmul.ll
+++ b/llvm/test/Transforms/InstCombine/fmul.ll
@@ -1412,8 +1412,7 @@ entry:
 ; fmul X, ldexp(1.0, Y) -> ldexp X, Y
 define float @fmul_ldexp(float %x, i32 %exp) {
 ; CHECK-LABEL: @fmul_ldexp(
-; CHECK-NEXT:    [[LDEXP:%.*]] = call nnan float @llvm.ldexp.f32.i32(float 1.000000e+00, i32 [[EXP:%.*]])
-; CHECK-NEXT:    [[MUL:%.*]] = fmul contract float [[X:%.*]], [[LDEXP]]
+; CHECK-NEXT:    [[MUL:%.*]] = call contract float @llvm.ldexp.f32.i32(float [[X:%.*]], i32 [[EXP:%.*]])
 ; CHECK-NEXT:    ret float [[MUL]]
 ;
   %ldexp = call float @llvm.ldexp(float 1.0, i32 %exp)
@@ -1423,8 +1422,7 @@ define float @fmul_ldexp(float %x, i32 %exp) {
 
 define float @fmul_ldexp_comm(float %x, i32 %exp) {
 ; CHECK-LABEL: @fmul_ldexp_comm(
-; CHECK-NEXT:    [[LDEXP:%.*]] = call nnan float @llvm.ldexp.f32.i32(float 1.000000e+00, i32 [[EXP:%.*]])
-; CHECK-NEXT:    [[MUL:%.*]] = fmul contract float [[LDEXP]], [[X:%.*]]
+; CHECK-NEXT:    [[MUL:%.*]] = call contract float @llvm.ldexp.f32.i32(float [[X:%.*]], i32 [[EXP:%.*]])
 ; CHECK-NEXT:    ret float [[MUL]]
 ;
   %ldexp = call float @llvm.ldexp(float 1.0, i32 %exp)
@@ -1434,8 +1432,7 @@ define float @fmul_ldexp_comm(float %x, i32 %exp) {
 
 define double @fmul_ldexp_f64(double %x, i32 %exp) {
 ; CHECK-LABEL: @fmul_ldexp_f64(
-; CHECK-NEXT:    [[LDEXP:%.*]] = call nnan double @llvm.ldexp.f64.i32(double 1.000000e+00, i32 [[EXP:%.*]])
-; CHECK-NEXT:    [[MUL:%.*]] = fmul contract double [[X:%.*]], [[LDEXP]]
+; CHECK-NEXT:    [[MUL:%.*]] = call contract double @llvm.ldexp.f64.i32(double [[X:%.*]], i32 [[EXP:%.*]])
 ; CHECK-NEXT:    ret double [[MUL]]
 ;
   %ldexp = call double @llvm.ldexp(double 1.0, i32 %exp)
@@ -1445,8 +1442,7 @@ define double @fmul_ldexp_f64(double %x, i32 %exp) {
 
 define <2 x float> @fmul_ldexp_v2f32(<2 x float> %x, <2 x i32> %exp) {
 ; CHECK-LABEL: @fmul_ldexp_v2f32(
-; CHECK-NEXT:    [[LDEXP:%.*]] = call nnan <2 x float> @llvm.ldexp.v2f32.v2i32(<2 x float> splat (float 1.000000e+00), <2 x i32> [[EXP:%.*]])
-; CHECK-NEXT:    [[MUL:%.*]] = fmul contract <2 x float> [[LDEXP]], [[X:%.*]]
+; CHECK-NEXT:    [[MUL:%.*]] = call contract <2 x float> @llvm.ldexp.v2f32.v2i32(<2 x float> [[X:%.*]], <2 x i32> [[EXP:%.*]])
 ; CHECK-NEXT:    ret <2 x float> [[MUL]]
 ;
   %ldexp = call <2 x float> @llvm.ldexp(<2 x float> splat (float 1.0), <2 x i32> %exp)
@@ -1480,8 +1476,7 @@ define float @fmul_ldexp_multiuse_ldexp(float %x, i32 %exp) {
 
 define float @fmul_ldexp_multiuse_x(float %x, i32 %exp) {
 ; CHECK-LABEL: @fmul_ldexp_multiuse_x(
-; CHECK-NEXT:    [[LDEXP:%.*]] = call nnan float @llvm.ldexp.f32.i32(float 1.000000e+00, i32 [[EXP:%.*]])
-; CHECK-NEXT:    [[MUL:%.*]] = fmul contract float [[X:%.*]], [[LDEXP]]
+; CHECK-NEXT:    [[MUL:%.*]] = call contract float @llvm.ldexp.f32.i32(float [[X:%.*]], i32 [[EXP:%.*]])
 ; CHECK-NEXT:    tail call void @use_f32(float [[X]])
 ; CHECK-NEXT:    ret float [[MUL]]
 ;

--- a/llvm/test/Transforms/InstCombine/fmul.ll
+++ b/llvm/test/Transforms/InstCombine/fmul.ll
@@ -1412,108 +1412,108 @@ entry:
 ; fmul X, ldexp(1.0, Y) -> ldexp X, Y
 define float @fmul_ldexp(float %x, i32 %exp) {
 ; CHECK-LABEL: @fmul_ldexp(
-; CHECK-NEXT:    [[MUL:%.*]] = call contract float @llvm.ldexp.f32.i32(float [[X:%.*]], i32 [[EXP:%.*]])
+; CHECK-NEXT:    [[MUL:%.*]] = call reassoc float @llvm.ldexp.f32.i32(float [[X:%.*]], i32 [[EXP:%.*]])
 ; CHECK-NEXT:    ret float [[MUL]]
 ;
-  %ldexp = call contract float @llvm.ldexp(float 1.0, i32 %exp)
-  %mul = fmul contract float %x, %ldexp
+  %ldexp = call reassoc float @llvm.ldexp(float 1.0, i32 %exp)
+  %mul = fmul reassoc float %x, %ldexp
   ret float %mul
 }
 
 define float @fmul_ldexp_comm(float %x, i32 %exp) {
 ; CHECK-LABEL: @fmul_ldexp_comm(
-; CHECK-NEXT:    [[MUL:%.*]] = call contract float @llvm.ldexp.f32.i32(float [[X:%.*]], i32 [[EXP:%.*]])
+; CHECK-NEXT:    [[MUL:%.*]] = call reassoc float @llvm.ldexp.f32.i32(float [[X:%.*]], i32 [[EXP:%.*]])
 ; CHECK-NEXT:    ret float [[MUL]]
 ;
-  %ldexp = call contract float @llvm.ldexp(float 1.0, i32 %exp)
-  %mul = fmul contract float %ldexp, %x
+  %ldexp = call reassoc float @llvm.ldexp(float 1.0, i32 %exp)
+  %mul = fmul reassoc float %ldexp, %x
   ret float %mul
 }
 
 define double @fmul_ldexp_f64(double %x, i32 %exp) {
 ; CHECK-LABEL: @fmul_ldexp_f64(
-; CHECK-NEXT:    [[MUL:%.*]] = call contract double @llvm.ldexp.f64.i32(double [[X:%.*]], i32 [[EXP:%.*]])
+; CHECK-NEXT:    [[MUL:%.*]] = call reassoc double @llvm.ldexp.f64.i32(double [[X:%.*]], i32 [[EXP:%.*]])
 ; CHECK-NEXT:    ret double [[MUL]]
 ;
-  %ldexp = call contract double @llvm.ldexp(double 1.0, i32 %exp)
-  %mul = fmul contract double %x, %ldexp
+  %ldexp = call reassoc double @llvm.ldexp(double 1.0, i32 %exp)
+  %mul = fmul reassoc double %x, %ldexp
   ret double %mul
 }
 
 define <2 x float> @fmul_ldexp_v2f32(<2 x float> %x, <2 x i32> %exp) {
 ; CHECK-LABEL: @fmul_ldexp_v2f32(
-; CHECK-NEXT:    [[MUL:%.*]] = call contract <2 x float> @llvm.ldexp.v2f32.v2i32(<2 x float> [[X:%.*]], <2 x i32> [[EXP:%.*]])
+; CHECK-NEXT:    [[MUL:%.*]] = call reassoc <2 x float> @llvm.ldexp.v2f32.v2i32(<2 x float> [[X:%.*]], <2 x i32> [[EXP:%.*]])
 ; CHECK-NEXT:    ret <2 x float> [[MUL]]
 ;
-  %ldexp = call contract <2 x float> @llvm.ldexp(<2 x float> splat (float 1.0), <2 x i32> %exp)
-  %mul = fmul contract <2 x float> %x, %ldexp
+  %ldexp = call reassoc <2 x float> @llvm.ldexp(<2 x float> splat (float 1.0), <2 x i32> %exp)
+  %mul = fmul reassoc <2 x float> %x, %ldexp
   ret <2 x float> %mul
 }
 
-define float @fmul_ldexp_nocontract_fmul(float %x, i32 %exp) {
-; CHECK-LABEL: @fmul_ldexp_nocontract_fmul(
-; CHECK-NEXT:    [[LDEXP:%.*]] = call nnan contract float @llvm.ldexp.f32.i32(float 1.000000e+00, i32 [[EXP:%.*]])
+define float @fmul_ldexp_noreassoc_fmul(float %x, i32 %exp) {
+; CHECK-LABEL: @fmul_ldexp_noreassoc_fmul(
+; CHECK-NEXT:    [[LDEXP:%.*]] = call reassoc nnan float @llvm.ldexp.f32.i32(float 1.000000e+00, i32 [[EXP:%.*]])
 ; CHECK-NEXT:    [[MUL:%.*]] = fmul float [[X:%.*]], [[LDEXP]]
 ; CHECK-NEXT:    ret float [[MUL]]
 ;
-  %ldexp = call contract float @llvm.ldexp(float 1.0, i32 %exp)
+  %ldexp = call reassoc float @llvm.ldexp(float 1.0, i32 %exp)
   %mul = fmul float %x, %ldexp
   ret float %mul
 }
 
-define float @fmul_ldexp_nocontract_ldexp(float %x, i32 %exp) {
-; CHECK-LABEL: @fmul_ldexp_nocontract_ldexp(
+define float @fmul_ldexp_noreassoc_ldexp(float %x, i32 %exp) {
+; CHECK-LABEL: @fmul_ldexp_noreassoc_ldexp(
 ; CHECK-NEXT:    [[LDEXP:%.*]] = call nnan float @llvm.ldexp.f32.i32(float 1.000000e+00, i32 [[EXP:%.*]])
-; CHECK-NEXT:    [[MUL:%.*]] = fmul contract float [[X:%.*]], [[LDEXP]]
+; CHECK-NEXT:    [[MUL:%.*]] = fmul reassoc float [[X:%.*]], [[LDEXP]]
 ; CHECK-NEXT:    ret float [[MUL]]
 ;
   %ldexp = call float @llvm.ldexp(float 1.0, i32 %exp)
-  %mul = fmul contract float %x, %ldexp
+  %mul = fmul reassoc float %x, %ldexp
   ret float %mul
 }
 
 define float @fmul_ldexp_multiuse_ldexp(float %x, i32 %exp) {
 ; CHECK-LABEL: @fmul_ldexp_multiuse_ldexp(
-; CHECK-NEXT:    [[LDEXP:%.*]] = call contract float @llvm.ldexp.f32.i32(float 1.000000e+00, i32 [[EXP:%.*]])
-; CHECK-NEXT:    [[MUL:%.*]] = fmul contract float [[X:%.*]], [[LDEXP]]
+; CHECK-NEXT:    [[LDEXP:%.*]] = call reassoc float @llvm.ldexp.f32.i32(float 1.000000e+00, i32 [[EXP:%.*]])
+; CHECK-NEXT:    [[MUL:%.*]] = fmul reassoc float [[X:%.*]], [[LDEXP]]
 ; CHECK-NEXT:    tail call void @use_f32(float [[LDEXP]])
 ; CHECK-NEXT:    ret float [[MUL]]
 ;
-  %ldexp = call contract float @llvm.ldexp(float 1.0, i32 %exp)
-  %mul = fmul contract float %x, %ldexp
+  %ldexp = call reassoc float @llvm.ldexp(float 1.0, i32 %exp)
+  %mul = fmul reassoc float %x, %ldexp
   tail call void @use_f32(float %ldexp)
   ret float %mul
 }
 
 define float @fmul_ldexp_multiuse_x(float %x, i32 %exp) {
 ; CHECK-LABEL: @fmul_ldexp_multiuse_x(
-; CHECK-NEXT:    [[MUL:%.*]] = call contract float @llvm.ldexp.f32.i32(float [[X:%.*]], i32 [[EXP:%.*]])
+; CHECK-NEXT:    [[MUL:%.*]] = call reassoc float @llvm.ldexp.f32.i32(float [[X:%.*]], i32 [[EXP:%.*]])
 ; CHECK-NEXT:    tail call void @use_f32(float [[X]])
 ; CHECK-NEXT:    ret float [[MUL]]
 ;
-  %ldexp = call contract float @llvm.ldexp(float 1.0, i32 %exp)
-  %mul = fmul contract float %x, %ldexp
+  %ldexp = call reassoc float @llvm.ldexp(float 1.0, i32 %exp)
+  %mul = fmul reassoc float %x, %ldexp
   tail call void @use_f32(float %x)
   ret float %mul
 }
 
 define float @fmul_ldexp_not_fpone(float %x, i32 %exp) {
 ; CHECK-LABEL: @fmul_ldexp_not_fpone(
-; CHECK-NEXT:    [[LDEXP:%.*]] = call nnan contract float @llvm.ldexp.f32.i32(float 2.000000e+00, i32 [[EXP:%.*]])
-; CHECK-NEXT:    [[MUL:%.*]] = fmul contract float [[X:%.*]], [[LDEXP]]
+; CHECK-NEXT:    [[LDEXP:%.*]] = call reassoc nnan float @llvm.ldexp.f32.i32(float 2.000000e+00, i32 [[EXP:%.*]])
+; CHECK-NEXT:    [[MUL:%.*]] = fmul reassoc float [[X:%.*]], [[LDEXP]]
 ; CHECK-NEXT:    ret float [[MUL]]
 ;
-  %ldexp = call contract float @llvm.ldexp(float 2.0, i32 %exp)
-  %mul = fmul contract float %x, %ldexp
+  %ldexp = call reassoc float @llvm.ldexp(float 2.0, i32 %exp)
+  %mul = fmul reassoc float %x, %ldexp
   ret float %mul
 }
 
 define float @fmul_ldexp_preserve_fmul_flags(float %x, i32 %exp) {
 ; CHECK-LABEL: @fmul_ldexp_preserve_fmul_flags(
-; CHECK-NEXT:    [[MUL:%.*]] = call ninf arcp contract float @llvm.ldexp.f32.i32(float [[X:%.*]], i32 [[EXP:%.*]])
+; CHECK-NEXT:    [[MUL:%.*]] = call reassoc ninf arcp float @llvm.ldexp.f32.i32(float [[X:%.*]], i32 [[EXP:%.*]])
 ; CHECK-NEXT:    ret float [[MUL]]
 ;
-  %ldexp = call nnan contract float @llvm.ldexp(float 1.0, i32 %exp)
-  %mul = fmul ninf arcp contract float %x, %ldexp
+  %ldexp = call nnan reassoc float @llvm.ldexp(float 1.0, i32 %exp)
+  %mul = fmul ninf arcp reassoc float %x, %ldexp
   ret float %mul
 }


### PR DESCRIPTION
This would avoid the FMUL in sequences such as [these](https://godbolt.org/z/xhqfe5sb1).