### PR TITLE
[LLVM] Fix Fortran `omp_lib.mod` generation when cross-compiling

### DIFF
--- a/flang/tools/f18/CMakeLists.txt
+++ b/flang/tools/f18/CMakeLists.txt
@@ -50,6 +50,20 @@ endif()
 # these module files will be contributed from the CMakeLists in flang/tools/f18.
 set(module_objects "")
 
+# Check both top-level and per-target runtimes lists, since openmp may only
+# be enabled for specific triples via RUNTIMES_<target>_LLVM_ENABLE_RUNTIMES.
+set(openmp_in_runtimes FALSE)
+if ("openmp" IN_LIST LLVM_ENABLE_RUNTIMES)
+  set(openmp_in_runtimes TRUE)
+else()
+  foreach(_target ${LLVM_RUNTIME_TARGETS})
+    if ("openmp" IN_LIST RUNTIMES_${_target}_LLVM_ENABLE_RUNTIMES)
+      set(openmp_in_runtimes TRUE)
+      break()
+    endif()
+  endforeach()
+endif()
+
 # Create module files directly from the top-level module source directory.
 # If CMAKE_CROSSCOMPILING, then the newly built flang executable was
 # cross compiled, and thus can't be executed on the build system and thus
@@ -137,7 +151,7 @@ if (NOT CMAKE_CROSSCOMPILING)
   # Special case for omp_lib.mod, because its source comes from openmp/runtime/src/include.
   # It also produces two module files: omp_lib.mod and omp_lib_kinds.mod.  Compile these
   # files only if OpenMP support has been configured.
-  if ("openmp" IN_LIST LLVM_ENABLE_RUNTIMES)
+  if (openmp_in_runtimes)
     message(STATUS "OpenMP runtime support enabled via LLVM_ENABLE_RUNTIMES, assuming omp_lib.mod is built there")
   else()
     message(WARNING "Not building omp_lib.mod, no OpenMP runtime in either LLVM_ENABLE_PROJECTS or LLVM_ENABLE_RUNTIMES")
@@ -153,7 +167,7 @@ set_target_properties(module_files PROPERTIES FOLDER "Flang/Resources")
 
 # TODO Move this to a more suitable location
 # Copy the generated omp_lib.h header file, if OpenMP support has been configured.
-if ("openmp" IN_LIST LLVM_ENABLE_RUNTIMES)
+if (openmp_in_runtimes)
   message(STATUS "OpenMP runtime support enabled via LLVM_ENABLE_RUNTIMES, assuming omp_lib.h is built there")
 else()
   message(STATUS "Not copying omp_lib.h, no OpenMP runtime in either LLVM_ENABLE_PROJECTS or LLVM_ENABLE_RUNTIMES")

--- a/llvm/runtimes/CMakeLists.txt
+++ b/llvm/runtimes/CMakeLists.txt
@@ -552,8 +552,14 @@ if(build_runtimes)
     list(APPEND extra_cmake_args "-DCMAKE_PROGRAM_PATH=${CMAKE_PROGRAM_PATH}")
   endif()
 
-  # TODO: We need to consider passing it as '-DRUNTIMES_x86_64_LLVM_ENABLE_RUNTIMES'.
-  if("libclc" IN_LIST LLVM_ENABLE_RUNTIMES)
+  # Top level list of all enabled runtimes across all runtime targets.
+  set(_all_runtimes ${LLVM_ENABLE_RUNTIMES})
+  foreach(_target ${LLVM_RUNTIME_TARGETS})
+    list(APPEND _all_runtimes ${RUNTIMES_${_target}_LLVM_ENABLE_RUNTIMES})
+  endforeach()
+  list(REMOVE_DUPLICATES _all_runtimes)
+
+  if("libclc" IN_LIST _all_runtimes)
     foreach(dep clang llvm-link opt llvm-ar llvm-ranlib)
       if(TARGET ${dep})
         list(APPEND extra_deps ${dep})
@@ -561,7 +567,7 @@ if(build_runtimes)
     endforeach()
   endif()
   # Tools needed by build_symbolizer.sh.
-  if("compiler-rt" IN_LIST LLVM_ENABLE_RUNTIMES AND COMPILER_RT_ENABLE_INTERNAL_SYMBOLIZER)
+  if("compiler-rt" IN_LIST _all_runtimes AND COMPILER_RT_ENABLE_INTERNAL_SYMBOLIZER)
     foreach(dep clang llvm-tblgen opt llvm-ar llvm-link)
       if(TARGET ${dep})
         list(APPEND extra_deps ${dep})
@@ -569,14 +575,17 @@ if(build_runtimes)
     endforeach()
   endif()
   # Allow openmp to see the Fortran compiler
-  if ("openmp" IN_LIST LLVM_ENABLE_RUNTIMES AND "flang" IN_LIST LLVM_ENABLE_PROJECTS)
+  if ("openmp" IN_LIST _all_runtimes AND "flang" IN_LIST LLVM_ENABLE_PROJECTS)
     list(APPEND extra_args ENABLE_FORTRAN)
   endif()
-  if("openmp" IN_LIST LLVM_ENABLE_RUNTIMES OR "offload" IN_LIST LLVM_ENABLE_RUNTIMES)
+  if("openmp" IN_LIST _all_runtimes OR "offload" IN_LIST _all_runtimes)
     if (${LLVM_TOOL_FLANG_BUILD})
       message(STATUS "Configuring build of omp_lib.mod and omp_lib_kinds.mod via flang")
       set(LIBOMP_FORTRAN_MODULES_COMPILER "${CMAKE_BINARY_DIR}/bin/flang")
       set(LIBOMP_MODULES_INSTALL_PATH "${CMAKE_INSTALL_INCLUDEDIR}/flang")
+      list(APPEND extra_cmake_args
+        "-DLIBOMP_FORTRAN_MODULES_COMPILER=${LIBOMP_FORTRAN_MODULES_COMPILER}"
+        "-DLIBOMP_MODULES_INSTALL_PATH=${LIBOMP_MODULES_INSTALL_PATH}")
       # TODO: This is a workaround until flang becomes a first-class project
       # in llvm/CMakeList.txt.  Until then, this line ensures that flang is
       # built before "openmp" is built as a runtime project.  Besides "flang"
@@ -602,7 +611,7 @@ if(build_runtimes)
   if(LLVM_LIBC_FULL_BUILD)
     list(APPEND extra_cmake_args "-DLLVM_LIBC_FULL_BUILD=ON")
   endif()
-  if("flang-rt" IN_LIST LLVM_ENABLE_RUNTIMES)
+  if("flang-rt" IN_LIST _all_runtimes)
     list(APPEND extra_args ENABLE_FORTRAN)
   endif ()
 


### PR DESCRIPTION
Summary:
Currently, the runtimes interface only checks the top-level "default"
runtimes target. This causes Flang to not generate the OpenMP module
files required if it is build anywhere outside of the default runtime.
This PR changes the logic in the runtime CMake to look through *all*
enabled runtimes across all architectures and for the Flang CMake to
check all enabled runtimes for 'openmp' similarly to how we check for
GPU libc.
