### PR TITLE
[libclang/python] Renaming `get_version` into `get_clang_version` 

### DIFF
--- a/clang/bindings/python/clang/cindex.py
+++ b/clang/bindings/python/clang/cindex.py
@@ -4650,7 +4650,7 @@ class Config:
 
         return library
 
-    def get_version(self):
+    def get_clang_version(self) -> str:
         """
         Returns the libclang version string used by the bindings
         """

--- a/clang/bindings/python/tests/cindex/test_version.py
+++ b/clang/bindings/python/tests/cindex/test_version.py
@@ -6,6 +6,6 @@ from clang.cindex import Config
 class TestClangVersion(unittest.TestCase):
     def test_get_version_format(self):
         conf = Config()
-        version = conf.get_version()
+        version = conf.get_clang_version()
 
         self.assertRegex(version, r"^clang version \d+\.\d+\.\d+")

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -563,8 +563,8 @@ Python Binding Changes
   ``CodeCompletionResults.results`` should be changed to directly use
   ``CodeCompletionResults``: it nows supports ``__len__`` and ``__getitem__``,
   so it can be used the same as ``CodeCompletionResults.results``.
-- Added a new helper method ``get_version`` to the class ``Config`` to read the
-  version string of the libclang in use.
+- Added a new helper method ``get_clang_version`` to the class ``Config`` to
+  read the version string of the libclang in use.
 
 OpenMP Support
 --------------


### PR DESCRIPTION
Rename `get_version` to `get_clang_version` to match the `libclang.so` name[1], and be clear we doesn't return some `cindex.py` internal versioning but the `libclang.so` one. 

[1]  This match was some current API are doing for example `conf.lib.clang_getArraySize` is mapped to `get_array_size`.

--- 

We now have an inconsistency between `get_cindex_library` who return a path to `libclang.so`, and `get_clang_version` (and not `get_cindex_version`) who return the version of this lib. 

- One possibility will be to rename `get_cindex_library` to `get_clang_library`, but this is quite a big breaking change
- Another will be to rename `get_clang_version` to `get_cindex_version` but this obscure the link between `cindex_version` and the libclang.so call `getClangversion`. 

So personally, I can leave with this inconsistency. 