### PR TITLE
[SPIR-V] Don't lower builtin variadic functions

### DIFF
--- a/llvm/lib/Transforms/IPO/ExpandVariadics.cpp
+++ b/llvm/lib/Transforms/IPO/ExpandVariadics.cpp
@@ -130,7 +130,7 @@ public:
   bool vaCopyIsMemcpy() { return true; }
 
   // Per-target overrides of special symbols.
-  virtual bool ignoreFunction(Function *F) { return false; }
+  virtual bool ignoreFunction(const Function *F) { return false; }
 
   // Any additional address spaces used in va intrinsics that should be
   // expanded.
@@ -994,7 +994,7 @@ struct SPIRV final : public VariadicABIInfo {
   }
 
   // The SPIR-V backend has special handling for builtins.
-  bool ignoreFunction(Function *F) override {
+  bool ignoreFunction(const Function *F) override {
     if (!F->isDeclaration())
       return false;
 

--- a/llvm/lib/Transforms/IPO/ExpandVariadics.cpp
+++ b/llvm/lib/Transforms/IPO/ExpandVariadics.cpp
@@ -129,6 +129,9 @@ public:
   bool vaEndIsNop() { return true; }
   bool vaCopyIsMemcpy() { return true; }
 
+  // Per-target overrides of special symbols.
+  virtual bool ignoreFunction(Function *F) { return false; }
+
   // Any additional address spaces used in va intrinsics that should be
   // expanded.
   virtual SmallVector<unsigned> getTargetSpecificVaIntrinAddrSpaces() const {
@@ -240,6 +243,9 @@ public:
   bool expansionApplicableToFunction(Module &M, Function *F) {
     if (F->isIntrinsic() || !F->isVarArg() ||
         F->hasFnAttribute(Attribute::Naked))
+      return false;
+
+    if (ABI->ignoreFunction(F))
       return false;
 
     if (!isValidCallingConv(F))
@@ -627,6 +633,9 @@ bool ExpandVariadics::expandCall(Module &M, IRBuilder<> &Builder, CallBase *CB,
   bool Changed = false;
   const DataLayout &DL = M.getDataLayout();
 
+  if (ABI->ignoreFunction(CB->getCalledFunction()))
+    return Changed;
+
   if (!expansionApplicableToFunctionCall(CB)) {
     if (rewriteABI())
       report_fatal_error("Cannot lower callbase instruction");
@@ -982,6 +991,29 @@ struct SPIRV final : public VariadicABIInfo {
     // promoting types to their appropriate size and alignment.
     Align A = DL.getABITypeAlign(Parameter);
     return {A, false};
+  }
+
+  // The SPIR-V backend has special handling for builtins.
+  bool ignoreFunction(Function *F) override {
+    if (!F->isDeclaration())
+      return false;
+
+    StringRef Name = F->getName();
+
+    // Skip any SPIR-V builtins.
+    if (Name.contains("__spirv_"))
+      return true;
+
+    // Skip the builtin printf function.
+    if (Name.contains("printf")) {
+      std::string Demangled = llvm::demangle(Name.str());
+      // Demangled name will be "printf(...)" for the builtin, "printf" for
+      // unmangled extern "C", or "namespace::printf(...)" for namespaced.
+      if (StringRef(Demangled).starts_with("printf(") || Demangled == "printf")
+        return true;
+    }
+
+    return false;
   }
 
   // We will likely see va intrinsics in the generic addrspace (4).

--- a/llvm/lib/Transforms/IPO/ExpandVariadics.cpp
+++ b/llvm/lib/Transforms/IPO/ExpandVariadics.cpp
@@ -998,20 +998,13 @@ struct SPIRV final : public VariadicABIInfo {
     if (!F->isDeclaration())
       return false;
 
-    StringRef Name = F->getName();
+    std::string Demangled = llvm::demangle(F->getName());
+    StringRef DemangledName(Demangled);
 
     // Skip any SPIR-V builtins.
-    if (Name.contains("__spirv_"))
+    if (DemangledName.starts_with("__spirv_") ||
+        DemangledName.starts_with("printf("))
       return true;
-
-    // Skip the builtin printf function.
-    if (Name.contains("printf")) {
-      std::string Demangled = llvm::demangle(Name.str());
-      // Demangled name will be "printf(...)" for the builtin, "printf" for
-      // unmangled extern "C", or "namespace::printf(...)" for namespaced.
-      if (StringRef(Demangled).starts_with("printf(") || Demangled == "printf")
-        return true;
-    }
 
     return false;
   }

--- a/llvm/test/CodeGen/SPIRV/function/variadics-lowering-builtin-substr-in-name.ll
+++ b/llvm/test/CodeGen/SPIRV/function/variadics-lowering-builtin-substr-in-name.ll
@@ -1,0 +1,22 @@
+; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv64 < %s 2>&1 | FileCheck %s
+
+; Variadics lowering will introduce a buffer that will be accessed through GEP.
+; We don't lower SPIR-V builtins or printf, but make sure these functions aren't
+; identified as such and are lowered.
+
+; CHECK-COUNT-6: OpInBoundsPtrAccessChain
+
+@.str = private unnamed_addr constant [4 x i8] c"hey\00", align 1
+
+define dso_local noundef i32 @main() {
+  call void (ptr, ...) @_Z16my__spirv_printfPKcz(ptr noundef @.str, i32 noundef 5, i32 noundef 6)
+  call void (ptr, ...) @_Z16your__spirv_funcPKcz(ptr noundef @.str, i32 noundef 6, i32 noundef 7)
+  call void (ptr, ...) @_Z22their_cool_printf_funcPKcz(ptr noundef @.str, i32 noundef 8, i32 noundef 9)
+  ret i32 0
+}
+
+declare void @_Z16my__spirv_printfPKcz(ptr noundef, ...)
+
+declare void @_Z16your__spirv_funcPKcz(ptr noundef, ...)
+
+declare void @_Z22their_cool_printf_funcPKcz(ptr noundef, ...)

--- a/llvm/test/CodeGen/SPIRV/printf.ll
+++ b/llvm/test/CodeGen/SPIRV/printf.ll
@@ -6,35 +6,33 @@
 
 ; CHECK: %[[#ExtImport:]] = OpExtInstImport "OpenCL.std"
 ; CHECK: %[[#Char:]] = OpTypeInt 8 0
-; CHECK: %[[#ConstCharPtr:]] = OpTypePointer UniformConstant %[[#Char]]
-; CHECK: %[[#VarargStruct:]] = OpTypeStruct %[[#Char]]
-; CHECK: %[[#VarargStructPtr:]] = OpTypePointer Function %[[#VarargStruct]]
-; CHECK: %[[#CharPtr:]] = OpTypePointer Function %[[#Char]]
-; CHECK: %[[#IntConst:]] = OpConstant %[[#Char]] 97
+; CHECK: %[[#CharPtr:]] = OpTypePointer UniformConstant %[[#Char]]
 ; CHECK: %[[#GV:]] = OpVariable %[[#]] UniformConstant %[[#]]
 ; CHECK: OpFunction
-; CHECK: %[[#Arg:]] = OpFunctionParameter
-; CHECK: %[[#VarargBuffer1:]] = OpVariable %[[#VarargStructPtr]] Function
-; CHECK: %[[#VarargBuffer2:]] = OpVariable %[[#VarargStructPtr]] Function
-; CHECK: %[[#CastedBuffer1:]] = OpBitcast %[[#CharPtr]] %[[#VarargBuffer1]]
-; CHECK: %[[#GEP1:]] = OpInBoundsPtrAccessChain %[[#CharPtr]] %[[#VarargBuffer1]]
-; CHECK: OpStore %[[#GEP1]] %[[#IntConst]] Aligned 1
-; CHECK: %[[#CastedGV:]] = OpBitcast %[[#ConstCharPtr]] %[[#GV]]
-; CHECK: OpExtInst %[[#]] %[[#ExtImport]] printf %[[#CastedGV]] %[[#CastedBuffer1:]]
-; CHECK: %[[#CastedBuffer2:]] = OpBitcast %[[#CharPtr]] %[[#VarargBuffer2]]
-; CHECK: %[[#GEP2:]] = OpInBoundsPtrAccessChain %[[#CharPtr]] %[[#VarargBuffer2]]
-; CHECK: OpStore %[[#GEP2]] %[[#IntConst]] Aligned 1
-; CHECK: OpExtInst %[[#]] %[[#ExtImport]] printf %[[#Arg]] %[[#CastedBuffer2:]]
+; CHECK: %[[#Arg1:]] = OpFunctionParameter
+; CHECK: %[[#Arg2:]] = OpFunctionParameter
+; CHECK: %[[#CastedGV:]] = OpBitcast %[[#CharPtr]] %[[#GV]]
+; CHECK-NEXT: OpExtInst %[[#]] %[[#ExtImport]] printf %[[#CastedGV]] %[[#ArgConst:]]
+; CHECK-NEXT: OpExtInst %[[#]] %[[#ExtImport]] printf %[[#CastedGV]] %[[#ArgConst]]
+; CHECK-NEXT: OpExtInst %[[#]] %[[#ExtImport]] printf %[[#Arg1]] %[[#ArgConst]]
+; CHECK-NEXT: OpExtInst %[[#]] %[[#ExtImport]] printf %[[#Arg1]] %[[#ArgConst]]
+; CHECK-NEXT: %[[#CastedArg2:]] = OpBitcast %[[#CharPtr]] %[[#Arg2]]
+; CHECK-NEXT: OpExtInst %[[#]] %[[#ExtImport]] printf %[[#CastedArg2]] %[[#ArgConst]]
+; CHECK-NEXT: OpExtInst %[[#]] %[[#ExtImport]] printf %[[#CastedArg2]] %[[#ArgConst]]
 ; CHECK: OpFunctionEnd
 
 %struct = type { [6 x i8] }
 
 @FmtStr = internal addrspace(2) constant [6 x i8] c"c=%c\0A\00", align 1
 
-define spir_kernel void @foo(ptr addrspace(2) %_arg_fmt) {
+define spir_kernel void @foo(ptr addrspace(2) %_arg_fmt1, ptr addrspace(2) byval(%struct) %_arg_fmt2) {
 entry:
   %r1 = tail call spir_func i32 (ptr addrspace(2), ...) @_Z6printfPU3AS2Kcz(ptr addrspace(2) @FmtStr, i8 signext 97)
-  %r2 = tail call spir_func i32 (ptr addrspace(2), ...) @_Z18__spirv_ocl_printfPU3AS2Kcz(ptr addrspace(2) %_arg_fmt, i8 signext 97)
+  %r2 = tail call spir_func i32 (ptr addrspace(2), ...) @_Z18__spirv_ocl_printfPU3AS2Kcz(ptr addrspace(2) @FmtStr, i8 signext 97)
+  %r3 = tail call spir_func i32 (ptr addrspace(2), ...) @_Z6printfPU3AS2Kcz(ptr addrspace(2) %_arg_fmt1, i8 signext 97)
+  %r4 = tail call spir_func i32 (ptr addrspace(2), ...) @_Z18__spirv_ocl_printfPU3AS2Kcz(ptr addrspace(2) %_arg_fmt1, i8 signext 97)
+  %r5 = tail call spir_func i32 (ptr addrspace(2), ...) @_Z6printfPU3AS2Kcz(ptr addrspace(2) %_arg_fmt2, i8 signext 97)
+  %r6 = tail call spir_func i32 (ptr addrspace(2), ...) @_Z18__spirv_ocl_printfPU3AS2Kcz(ptr addrspace(2) %_arg_fmt2, i8 signext 97)
   ret void
 }
 


### PR DESCRIPTION
In https://github.com/llvm/llvm-project/pull/178980 I tried to remove the special handling for `printf`, but the fix was wrong, the pass expects that `printf` abides by the variadic ABI (single buffer passed in, args extracted by caller), which isn't how it works.

However the root issue is with any builtin, they are just replaced directly with instructions, and the only place that could generate code to honor the variadic ABI would bei in the SPIR-V backend, and it would be pretty complicated for pretty much no benefit.

It's much simpler to teach the pass to skip certain functions, as we did before, but this time skip all SPIR-V builtin.