### PR TITLE
[MLIR] [Mem2Reg] Quick fix for dominance info invalidation

### DIFF
--- a/mlir/lib/Transforms/Mem2Reg.cpp
+++ b/mlir/lib/Transforms/Mem2Reg.cpp
@@ -608,6 +608,13 @@ Value MemorySlotPromoter::promoteInBlock(Block *block, Value reachingDef) {
           promoteInRegion(region, reachingDef);
         }
 
+        // TODO: Currently we have to invalidate the dominance information of
+        // the regions of the operation because finalizePromotion may move their
+        // content. We might want to support moving dominance information
+        // accross regions as this can be detected.
+        for (Region &region : op->getRegions())
+          dominance.invalidate(&region);
+
         builder.setInsertionPointAfter(op);
         reachingDef = promotableRegionOp.finalizePromotion(
             slot, reachingDef, hasValueStores, reachingAtBlockEnd, builder);


### PR DESCRIPTION
We have identified a problem with DominanceInfo caching in Mem2Reg. It appears to also be subject to incorrect cache hits when regions are deleted, causing sporadic bugs that are difficult to test for.

This quick fix invalidates region that could be invalidated. This attempts to not be too eager by only invalidating regions that are exposed to a `finalizePromotion` call.

Ultimately it would be nice to have the ability to move the cached information from one region to the next, but this is currently not supported by DominanceInfo.

I was not able to produce a test for this as it is very sporadic. We would need to be testing for a case where a region is re-allocated at the same address as a previously erased region. If you know how to make this sort of behavior consistent, I would be interested. Otherwise this might require no testing.