### PR TITLE
[flang][OpenMP] Rename GetAllDesignators to GetTopLevelDesignators, NFC

### DIFF
--- a/flang/include/flang/Semantics/openmp-utils.h
+++ b/flang/include/flang/Semantics/openmp-utils.h
@@ -105,7 +105,7 @@ std::optional<bool> GetLogicalValue(const SomeExpr &expr);
 std::optional<bool> IsContiguous(
     SemanticsContext &semaCtx, const parser::OmpObject &object);
 
-std::vector<SomeExpr> GetAllDesignators(const SomeExpr &expr);
+std::vector<SomeExpr> GetTopLevelDesignators(const SomeExpr &expr);
 const SomeExpr *HasStorageOverlap(
     const SomeExpr &base, llvm::ArrayRef<SomeExpr> exprs);
 bool IsAssignment(const parser::ActionStmt *x);

--- a/flang/lib/Semantics/check-omp-atomic.cpp
+++ b/flang/lib/Semantics/check-omp-atomic.cpp
@@ -586,7 +586,7 @@ void OmpStructureChecker::CheckAtomicVariable(
         atom.AsFortran());
   }
 
-  std::vector<SomeExpr> dsgs{GetAllDesignators(atom)};
+  std::vector<SomeExpr> dsgs{GetTopLevelDesignators(atom)};
 
   // Procedure references are valid if they return a pointer to a scalar.
   // Just return if we don't have exactly one designator - other checks will

--- a/flang/lib/Semantics/openmp-utils.cpp
+++ b/flang/lib/Semantics/openmp-utils.cpp
@@ -418,7 +418,7 @@ struct DesignatorCollector : public evaluate::Traverse<DesignatorCollector,
   }
 };
 
-std::vector<SomeExpr> GetAllDesignators(const SomeExpr &expr) {
+std::vector<SomeExpr> GetTopLevelDesignators(const SomeExpr &expr) {
   return DesignatorCollector{}(expr);
 }
 
@@ -480,7 +480,7 @@ static bool HasCommonTopLevelDesignators(
   // Compare designators directly as expressions. This will ensure
   // that x(y) and x(y+1) are not flagged as overlapping, whereas
   // the symbol vectors for both of these would be identical.
-  std::vector<SomeExpr> otherDsgs{GetAllDesignators(other)};
+  std::vector<SomeExpr> otherDsgs{GetTopLevelDesignators(other)};
 
   for (auto &s : baseDsgs) {
     if (llvm::any_of(otherDsgs, [&](auto &&t) { return s == t; })) {
@@ -493,7 +493,7 @@ static bool HasCommonTopLevelDesignators(
 const SomeExpr *HasStorageOverlap(
     const SomeExpr &base, llvm::ArrayRef<SomeExpr> exprs) {
   evaluate::SymbolVector baseSyms{evaluate::GetSymbolVector(base)};
-  std::vector<SomeExpr> baseDsgs{GetAllDesignators(base)};
+  std::vector<SomeExpr> baseDsgs{GetTopLevelDesignators(base)};
 
   for (const SomeExpr &expr : exprs) {
     if (!HasCommonDesignatorSymbols(baseSyms, expr)) {


### PR DESCRIPTION
The function collects all top-level designators. Emphasize the "top level" part for clarity.