### PR TITLE
pass target triple to `check_assembler_flag`

### DIFF
--- a/compiler-rt/cmake/Modules/CheckAssemblerFlag.cmake
+++ b/compiler-rt/cmake/Modules/CheckAssemblerFlag.cmake
@@ -26,6 +26,7 @@ function(check_assembler_flag outvar flag)
     try_compile(${outvar}
       ${CMAKE_BINARY_DIR}
       SOURCES ${asm_source_file}
+      CMAKE_FLAGS -DCMAKE_ASM_COMPILER_TARGET=${CMAKE_C_COMPILER_TARGET}
       COMPILE_DEFINITIONS ${flag})
 
     if(NOT CMAKE_REQUIRED_QUIET)


### PR DESCRIPTION
Target specific flags (Notably `-mimplict=always` for ARM) are not recognized by the clang assembler unless the target is specified. This PR passes the value of `CMAKE_C_COMPILER_TARGET` to the assembler so that target specific flags are recognized.

## Previous behaviour

When configuring builtins for an ARMv7 target:

```
-- Builtin supported architectures: armv7
-- Checking for assembler flag -mimplicit-it=always
-- Checking for assembler flag -mimplicit-it=always - Not accepted
-- Checking for assembler flag -Wa,-mimplicit-it=always
-- Checking for assembler flag -Wa,-mimplicit-it=always - Not accepted
CMake Warning at CMakeLists.txt:462 (message):
  Don't know how to set the -mimplicit-it=always flag in this assembler; not
  including Arm optimized implementations
```

## New behaviour

```
-- Builtin supported architectures: armv7
-- Checking for assembler flag -mimplicit-it=always
-- Checking for assembler flag -mimplicit-it=always - Accepted
```

## Steps to reproduce:

```
$ cmake -S compiler-rt/lib/builtins -B build \
  -DCMAKE_C_COMPILER=clang \
  -DCMAKE_C_COMPILER_TARGET=armv7-unknown-linux-gnueabihf  \
  -DCOMPILER_RT_DEFAULT_TARGET_ONLY=ON
```