### PR TITLE
[lldb] Disallow SHARED_BUILD_TESTCASE for non-default self.build()

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/lldbtest.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbtest.py
@@ -1530,10 +1530,10 @@ class Base(unittest.TestCase):
         dictionary=None,
         make_targets=None,
     ):
+        """Platform specific way to build binaries."""
         if debug_info or architecture or compiler or dictionary or make_targets:
             self.assertFalse(self.SHARED_BUILD_TESTCASE)
 
-        """Platform specific way to build binaries."""
         if not architecture and configuration.arch:
             architecture = configuration.arch
 

--- a/lldb/packages/Python/lldbsuite/test/lldbtest.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbtest.py
@@ -1530,6 +1530,9 @@ class Base(unittest.TestCase):
         dictionary=None,
         make_targets=None,
     ):
+        if debug_info or architecture or compiler or dictionary or make_targets:
+            self.assertFalse(self.SHARED_BUILD_TESTCASE)
+
         """Platform specific way to build binaries."""
         if not architecture and configuration.arch:
             architecture = configuration.arch

--- a/lldb/packages/Python/lldbsuite/test/lldbtest.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbtest.py
@@ -1532,7 +1532,7 @@ class Base(unittest.TestCase):
     ):
         """Platform specific way to build binaries."""
         if debug_info or architecture or compiler or dictionary or make_targets:
-            self.assertFalse(self.SHARED_BUILD_TESTCASE)
+            self.assertFalse(self.SHARED_BUILD_TESTCASE, "shared build test cases reuse the same compilation artifacts for all test functions")
 
         if not architecture and configuration.arch:
             architecture = configuration.arch

--- a/lldb/packages/Python/lldbsuite/test/lldbtest.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbtest.py
@@ -1532,7 +1532,10 @@ class Base(unittest.TestCase):
     ):
         """Platform specific way to build binaries."""
         if debug_info or architecture or compiler or dictionary or make_targets:
-            self.assertFalse(self.SHARED_BUILD_TESTCASE, "shared build test cases reuse the same compilation artifacts for all test functions")
+            self.assertFalse(
+                self.SHARED_BUILD_TESTCASE,
+                "shared build tests reuse the same compilation artifacts for all test functions",
+            )
 
         if not architecture and configuration.arch:
             architecture = configuration.arch

--- a/lldb/test/API/api/check_public_api_headers/TestPublicAPIHeaders.py
+++ b/lldb/test/API/api/check_public_api_headers/TestPublicAPIHeaders.py
@@ -12,6 +12,7 @@ from lldbsuite.test import lldbutil
 @skipIfRemote
 @skipUnlessDarwin
 class SBDirCheckerCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
     NO_DEBUG_INFO_TESTCASE = True
 
     def setUp(self):

--- a/lldb/test/API/api/command-return-object/TestSBCommandReturnObject.py
+++ b/lldb/test/API/api/command-return-object/TestSBCommandReturnObject.py
@@ -8,6 +8,7 @@ from lldbsuite.test import lldbutil
 
 
 class TestSBCommandReturnObject(TestBase):
+    SHARED_BUILD_TESTCASE = False
     NO_DEBUG_INFO_TESTCASE = True
 
     @skipIfNoSBHeaders

--- a/lldb/test/API/api/multiple-debuggers/TestMultipleDebuggers.py
+++ b/lldb/test/API/api/multiple-debuggers/TestMultipleDebuggers.py
@@ -10,6 +10,7 @@ from lldbsuite.test import lldbutil
 
 
 class TestMultipleSimultaneousDebuggers(TestBase):
+    SHARED_BUILD_TESTCASE = False
     NO_DEBUG_INFO_TESTCASE = True
 
     # Times out on heavily loaded Linux buildbots, don't want to get into tweaking

--- a/lldb/test/API/api/multiple-targets/TestMultipleTargets.py
+++ b/lldb/test/API/api/multiple-targets/TestMultipleTargets.py
@@ -9,6 +9,7 @@ from lldbsuite.test import lldbutil
 
 
 class TestMultipleTargets(TestBase):
+    SHARED_BUILD_TESTCASE = False
     NO_DEBUG_INFO_TESTCASE = True
 
     @skipIf(oslist=["linux"], archs=["arm$", "aarch64"])

--- a/lldb/test/API/api/multithreaded/TestMultithreaded.py
+++ b/lldb/test/API/api/multithreaded/TestMultithreaded.py
@@ -10,6 +10,7 @@ from lldbsuite.test import lldbutil
 
 @skipIfNoSBHeaders
 class SBBreakpointCallbackCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
     NO_DEBUG_INFO_TESTCASE = True
 
     def setUp(self):

--- a/lldb/test/API/arm/thumb-function-addr/TestThumbFunctionAddr.py
+++ b/lldb/test/API/arm/thumb-function-addr/TestThumbFunctionAddr.py
@@ -10,6 +10,8 @@ from lldbsuite.test import lldbutil
 
 
 class TestThumbFunctionAddr(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def do_thumb_function_test(self, language):
         self.build(dictionary={"CFLAGS_EXTRAS": f"-x {language} -mthumb"})
 

--- a/lldb/test/API/commands/add-dsym/uuid/TestAddDsymCommand.py
+++ b/lldb/test/API/commands/add-dsym/uuid/TestAddDsymCommand.py
@@ -11,6 +11,8 @@ from lldbsuite.test import lldbutil
 
 @skipUnlessDarwin
 class AddDsymCommandCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def setUp(self):
         TestBase.setUp(self)
         self.template = "main.cpp.template"

--- a/lldb/test/API/commands/expression/char/TestExprsChar.py
+++ b/lldb/test/API/commands/expression/char/TestExprsChar.py
@@ -5,6 +5,8 @@ from lldbsuite.test import lldbutil
 
 
 class ExprCharTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def do_test(self, dictionary=None):
         """These basic expression commands should work as expected."""
         self.build(dictionary=dictionary)

--- a/lldb/test/API/commands/expression/weak_symbols/TestWeakSymbols.py
+++ b/lldb/test/API/commands/expression/weak_symbols/TestWeakSymbols.py
@@ -12,6 +12,7 @@ from lldbsuite.test.lldbtest import *
 
 
 class TestWeakSymbolsInExpressions(TestBase):
+    SHARED_BUILD_TESTCASE = False
     NO_DEBUG_INFO_TESTCASE = True
 
     @skipUnlessDarwin

--- a/lldb/test/API/commands/process/attach/TestProcessAttach.py
+++ b/lldb/test/API/commands/process/attach/TestProcessAttach.py
@@ -14,6 +14,7 @@ exe_name = "ProcessAttach"  # Must match Makefile
 
 
 class ProcessAttachTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
     NO_DEBUG_INFO_TESTCASE = True
 
     def setUp(self):

--- a/lldb/test/API/commands/register/register/aarch64_sve_registers/rw_access_dynamic_resize/TestSVEThreadedDynamic.py
+++ b/lldb/test/API/commands/register/register/aarch64_sve_registers/rw_access_dynamic_resize/TestSVEThreadedDynamic.py
@@ -21,6 +21,8 @@ class Mode(Enum):
 
 
 class RegisterCommandsTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def get_supported_vg(self):
         # Changing VL trashes the register state, so we need to run the program
         # just to test this. Then run it again for the test.

--- a/lldb/test/API/commands/register/register/aarch64_sve_registers/rw_access_static_config/TestSVERegisters.py
+++ b/lldb/test/API/commands/register/register/aarch64_sve_registers/rw_access_static_config/TestSVERegisters.py
@@ -15,6 +15,8 @@ class Mode(Enum):
 
 
 class RegisterCommandsTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def check_sve_register_size(self, set, name, expected):
         reg_value = set.GetChildMemberWithName(name)
         self.assertTrue(

--- a/lldb/test/API/commands/register/register/aarch64_sve_simd_registers/TestSVESIMDRegisters.py
+++ b/lldb/test/API/commands/register/register/aarch64_sve_simd_registers/TestSVESIMDRegisters.py
@@ -27,6 +27,8 @@ class Mode(Enum):
 
 
 class SVESIMDRegistersTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def get_build_flags(self, mode):
         cflags = "-march=armv8-a+sve"
         if mode == Mode.SSVE:

--- a/lldb/test/API/commands/target/basic/TestTargetCommand.py
+++ b/lldb/test/API/commands/target/basic/TestTargetCommand.py
@@ -13,6 +13,8 @@ from lldbsuite.test import lldbutil
 
 
 class targetCommandTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def setUp(self):
         # Call super's setUp().
         TestBase.setUp(self)

--- a/lldb/test/API/commands/target/dump-separate-debug-info/oso/TestDumpOso.py
+++ b/lldb/test/API/commands/target/dump-separate-debug-info/oso/TestDumpOso.py
@@ -10,6 +10,7 @@ from lldbsuite.test.decorators import *
 
 
 class TestDumpOso(lldbtest.TestBase):
+    SHARED_BUILD_TESTCASE = False
     NO_DEBUG_INFO_TESTCASE = True
 
     def get_osos_from_json_output(self):

--- a/lldb/test/API/commands/watchpoints/hello_watchlocation/TestWatchLocation.py
+++ b/lldb/test/API/commands/watchpoints/hello_watchlocation/TestWatchLocation.py
@@ -11,6 +11,7 @@ from lldbsuite.test import lldbutil
 
 
 class HelloWatchLocationTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
     NO_DEBUG_INFO_TESTCASE = True
 
     def setUp(self):

--- a/lldb/test/API/commands/watchpoints/hello_watchpoint/TestMyFirstWatchpoint.py
+++ b/lldb/test/API/commands/watchpoints/hello_watchpoint/TestMyFirstWatchpoint.py
@@ -10,6 +10,7 @@ from lldbsuite.test import lldbutil
 
 
 class HelloWatchpointTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
     NO_DEBUG_INFO_TESTCASE = True
 
     def setUp(self):

--- a/lldb/test/API/commands/watchpoints/multi_watchpoint_slots/TestWatchpointMultipleSlots.py
+++ b/lldb/test/API/commands/watchpoints/multi_watchpoint_slots/TestWatchpointMultipleSlots.py
@@ -12,6 +12,7 @@ from lldbsuite.test import lldbutil
 
 
 class WatchpointSlotsTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
     NO_DEBUG_INFO_TESTCASE = True
 
     def setUp(self):

--- a/lldb/test/API/commands/watchpoints/variable_out_of_scope/TestWatchedVarHitWhenInScope.py
+++ b/lldb/test/API/commands/watchpoints/variable_out_of_scope/TestWatchedVarHitWhenInScope.py
@@ -10,6 +10,7 @@ from lldbsuite.test.decorators import *
 
 
 class WatchedVariableHitWhenInScopeTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
     NO_DEBUG_INFO_TESTCASE = True
 
     # This test depends on not tracking watchpoint expression hits if we have

--- a/lldb/test/API/commands/watchpoints/watchpoint_commands/TestWatchpointCommands.py
+++ b/lldb/test/API/commands/watchpoints/watchpoint_commands/TestWatchpointCommands.py
@@ -10,6 +10,7 @@ from lldbsuite.test import lldbutil
 
 
 class WatchpointCommandsTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
     NO_DEBUG_INFO_TESTCASE = True
 
     def setUp(self):

--- a/lldb/test/API/commands/watchpoints/watchpoint_commands/command/TestWatchpointCommandLLDB.py
+++ b/lldb/test/API/commands/watchpoints/watchpoint_commands/command/TestWatchpointCommandLLDB.py
@@ -10,6 +10,7 @@ from lldbsuite.test import lldbutil
 
 
 class WatchpointLLDBCommandTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
     NO_DEBUG_INFO_TESTCASE = True
 
     def setUp(self):

--- a/lldb/test/API/commands/watchpoints/watchpoint_commands/command/TestWatchpointCommandPython.py
+++ b/lldb/test/API/commands/watchpoints/watchpoint_commands/command/TestWatchpointCommandPython.py
@@ -11,6 +11,7 @@ from lldbsuite.test import lldbutil
 
 
 class WatchpointPythonCommandTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
     NO_DEBUG_INFO_TESTCASE = True
 
     def setUp(self):

--- a/lldb/test/API/commands/watchpoints/watchpoint_commands/condition/TestWatchpointConditionCmd.py
+++ b/lldb/test/API/commands/watchpoints/watchpoint_commands/condition/TestWatchpointConditionCmd.py
@@ -10,6 +10,7 @@ from lldbsuite.test import lldbutil
 
 
 class WatchpointConditionCmdTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
     NO_DEBUG_INFO_TESTCASE = True
 
     def setUp(self):

--- a/lldb/test/API/commands/watchpoints/watchpoint_on_vectors/TestValueOfVectorVariable.py
+++ b/lldb/test/API/commands/watchpoints/watchpoint_on_vectors/TestValueOfVectorVariable.py
@@ -10,6 +10,7 @@ from lldbsuite.test import lldbutil
 
 
 class TestValueOfVectorVariableTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
     NO_DEBUG_INFO_TESTCASE = True
 
     def test_value_of_vector_variable_using_watchpoint_set(self):

--- a/lldb/test/API/commands/watchpoints/watchpoint_size/TestWatchpointSizes.py
+++ b/lldb/test/API/commands/watchpoints/watchpoint_size/TestWatchpointSizes.py
@@ -13,6 +13,7 @@ from lldbsuite.test import lldbutil
 
 
 class WatchpointSizeTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
     NO_DEBUG_INFO_TESTCASE = True
 
     def setUp(self):

--- a/lldb/test/API/functionalities/archives/TestBSDArchives.py
+++ b/lldb/test/API/functionalities/archives/TestBSDArchives.py
@@ -10,6 +10,7 @@ import time
 
 
 class BSDArchivesTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
     # If your test case doesn't stress debug info, then
     # set this to true.  That way it won't be run once for
     # each debug info format.

--- a/lldb/test/API/functionalities/asan/TestMemoryHistory.py
+++ b/lldb/test/API/functionalities/asan/TestMemoryHistory.py
@@ -11,6 +11,8 @@ from lldbsuite.test_event.build_exception import BuildError
 
 
 class MemoryHistoryTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     @skipIfFreeBSD  # llvm.org/pr21136 runtimes not yet available by default
     @expectedFailureNetBSD
     @skipUnlessAddressSanitizer

--- a/lldb/test/API/functionalities/asan/TestReportData.py
+++ b/lldb/test/API/functionalities/asan/TestReportData.py
@@ -11,6 +11,8 @@ from lldbsuite.test_event.build_exception import BuildError
 
 
 class AsanTestReportDataCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     @skipIfFreeBSD  # llvm.org/pr21136 runtimes not yet available by default
     @expectedFailureNetBSD
     @skipUnlessAddressSanitizer

--- a/lldb/test/API/functionalities/breakpoint/breakpoint_locations/after_rebuild/TestLocationsAfterRebuild.py
+++ b/lldb/test/API/functionalities/breakpoint/breakpoint_locations/after_rebuild/TestLocationsAfterRebuild.py
@@ -12,6 +12,7 @@ import os
 
 
 class TestLocationsAfterRebuild(TestBase):
+    SHARED_BUILD_TESTCASE = False
     # If your test case doesn't stress debug info, then
     # set this to true.  That way it won't be run once for
     # each debug info format.

--- a/lldb/test/API/functionalities/breakpoint/cpp/TestCPPBreakpointLocations.py
+++ b/lldb/test/API/functionalities/breakpoint/cpp/TestCPPBreakpointLocations.py
@@ -9,6 +9,8 @@ from lldbsuite.test import lldbutil
 
 
 class TestCPPBreakpointLocations(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     @expectedFailureAll(oslist=["windows"], bugnumber="llvm.org/pr24764")
     def test(self):
         self.do_test(dict())

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-objc/ObjCDataFormatterTestCase.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-objc/ObjCDataFormatterTestCase.py
@@ -11,6 +11,8 @@ from lldbsuite.test import lldbutil
 
 
 class ObjCDataFormatterTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def appkit_tester_impl(self, commands, use_constant_classes):
         if use_constant_classes:
             self.build()

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-objc/TestDataFormatterObjCNSBundle.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-objc/TestDataFormatterObjCNSBundle.py
@@ -13,6 +13,8 @@ from ObjCDataFormatterTestCase import ObjCDataFormatterTestCase
 
 
 class ObjCDataFormatterNSBundle(ObjCDataFormatterTestCase):
+    SHARED_BUILD_TESTCASE = False
+
     def test_nsbundle_with_run_command(self):
         """Test formatters for NSBundle."""
         self.appkit_tester_impl(self.nsbundle_data_formatter_commands, True)

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-objc/TestDataFormatterObjCNSContainer.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-objc/TestDataFormatterObjCNSContainer.py
@@ -13,6 +13,8 @@ from ObjCDataFormatterTestCase import ObjCDataFormatterTestCase
 
 
 class ObjCDataFormatterNSContainer(ObjCDataFormatterTestCase):
+    SHARED_BUILD_TESTCASE = False
+
     def test_nscontainers_with_run_command(self):
         """Test formatters for  NS container classes."""
         self.appkit_tester_impl(self.nscontainers_data_formatter_commands, False)

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-objc/TestDataFormatterObjCNSData.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-objc/TestDataFormatterObjCNSData.py
@@ -13,6 +13,8 @@ from ObjCDataFormatterTestCase import ObjCDataFormatterTestCase
 
 
 class ObjCDataFormatterNSData(ObjCDataFormatterTestCase):
+    SHARED_BUILD_TESTCASE = False
+
     def test_nsdata_with_run_command(self):
         """Test formatters for  NSData."""
         self.appkit_tester_impl(self.nsdata_data_formatter_commands, True)

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-objc/TestDataFormatterObjCNSDate.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-objc/TestDataFormatterObjCNSDate.py
@@ -15,6 +15,8 @@ import datetime
 
 
 class ObjCDataFormatterNSDate(ObjCDataFormatterTestCase):
+    SHARED_BUILD_TESTCASE = False
+
     def test_nsdate_with_run_command(self):
         """Test formatters for  NSDate."""
         self.appkit_tester_impl(self.nsdate_data_formatter_commands, False)

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-objc/TestDataFormatterObjCNSError.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-objc/TestDataFormatterObjCNSError.py
@@ -13,6 +13,8 @@ from ObjCDataFormatterTestCase import ObjCDataFormatterTestCase
 
 
 class ObjCDataFormatterNSError(ObjCDataFormatterTestCase):
+    SHARED_BUILD_TESTCASE = False
+
     def test_nserror_with_run_command(self):
         """Test formatters for NSError."""
         self.appkit_tester_impl(self.nserror_data_formatter_commands, True)

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-objc/TestDataFormatterObjCNSNumber.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-objc/TestDataFormatterObjCNSNumber.py
@@ -12,6 +12,8 @@ from ObjCDataFormatterTestCase import ObjCDataFormatterTestCase
 
 
 class ObjCDataFormatterNSNumber(ObjCDataFormatterTestCase):
+    SHARED_BUILD_TESTCASE = False
+
     @skipUnlessDarwin
     def test_nsnumber_with_run_command(self):
         """Test formatters for  NS container classes."""

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-objc/TestDataFormatterObjCNSURL.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-objc/TestDataFormatterObjCNSURL.py
@@ -13,6 +13,8 @@ from ObjCDataFormatterTestCase import ObjCDataFormatterTestCase
 
 
 class ObjCDataFormatterNSURL(ObjCDataFormatterTestCase):
+    SHARED_BUILD_TESTCASE = False
+
     def test_nsurl_with_run_command(self):
         """Test formatters for NSURL."""
         self.appkit_tester_impl(self.nsurl_data_formatter_commands, True)

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-objc/TestDataFormatterObjNSException.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-objc/TestDataFormatterObjNSException.py
@@ -13,6 +13,8 @@ from ObjCDataFormatterTestCase import ObjCDataFormatterTestCase
 
 
 class ObjCDataFormatterNSException(ObjCDataFormatterTestCase):
+    SHARED_BUILD_TESTCASE = False
+
     def test_nsexception_with_run_command(self):
         """Test formatters for NSException."""
         self.appkit_tester_impl(self.nsexception_data_formatter_commands, True)

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/atomic/TestDataFormatterStdAtomic.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/atomic/TestDataFormatterStdAtomic.py
@@ -10,6 +10,7 @@ from lldbsuite.test import lldbutil
 
 
 class StdAtomicTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
     TEST_WITH_PDB_DEBUG_INFO = True
 
     def get_variable(self, name):

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/bitset/TestDataFormatterGenericBitset.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/bitset/TestDataFormatterGenericBitset.py
@@ -13,6 +13,8 @@ POINTER = "POINTER"
 
 
 class GenericBitsetDataFormatterTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def setUp(self):
         TestBase.setUp(self)
         primes = [1] * 1000

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/chrono/TestDataFormatterStdChrono.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/chrono/TestDataFormatterStdChrono.py
@@ -9,6 +9,8 @@ from lldbsuite.test import lldbutil
 
 
 class StdChronoDataFormatterTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def do_test(self):
         """Test that that file and class static variables display correctly."""
         isNotWindowsHost = lldbplatformutil.getHostPlatform() != "windows"

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/coroutine_handle/TestCoroutineHandle.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/coroutine_handle/TestCoroutineHandle.py
@@ -9,6 +9,8 @@ from lldbsuite.test import lldbutil
 
 
 class TestCoroutineHandle(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def do_test(self):
         """Test std::coroutine_handle is displayed correctly."""
         is_clang = self.expectedCompiler(["clang"])

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/deque/TestDataFormatterGenericDeque.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/deque/TestDataFormatterGenericDeque.py
@@ -5,6 +5,7 @@ from lldbsuite.test import lldbutil
 
 
 class GenericDequeDataFormatterTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
     TEST_WITH_PDB_DEBUG_INFO = True
 
     def findVariable(self, name):

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/forward_list/TestDataFormatterGenericForwardList.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/forward_list/TestDataFormatterGenericForwardList.py
@@ -9,6 +9,7 @@ from lldbsuite.test import lldbutil
 
 
 class TestDataFormatterGenericForwardList(TestBase):
+    SHARED_BUILD_TESTCASE = False
     TEST_WITH_PDB_DEBUG_INFO = True
 
     def setUp(self):

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/function/TestDataFormatterStdFunction.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/function/TestDataFormatterStdFunction.py
@@ -9,6 +9,8 @@ from lldbsuite.test import lldbutil
 
 
 class StdFunctionTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     # Run frame var for a variable twice. Verify we do not hit the cache
     # the first time but do the second time.
     def run_frame_var_check_cache_use(

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/initializer_list/TestDataFormatterStdInitializerList.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/initializer_list/TestDataFormatterStdInitializerList.py
@@ -10,6 +10,8 @@ from lldbsuite.test import lldbutil
 
 
 class InitializerListTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def do_test(self):
         self.runCmd("file " + self.getBuildArtifact("a.out"), CURRENT_EXECUTABLE_SET)
 

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/iterator/TestDataFormatterStdIterator.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/iterator/TestDataFormatterStdIterator.py
@@ -9,6 +9,8 @@ from lldbsuite.test import lldbutil
 
 
 class StdIteratorDataFormatterTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def setUp(self):
         # Call super's setUp().
         TestBase.setUp(self)

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/list/TestDataFormatterGenericList.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/list/TestDataFormatterGenericList.py
@@ -10,6 +10,7 @@ from lldbsuite.test import lldbutil
 
 
 class GenericListDataFormatterTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
     TEST_WITH_PDB_DEBUG_INFO = True
 
     def setUp(self):

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/list/loop/TestDataFormatterGenericListLoop.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/list/loop/TestDataFormatterGenericListLoop.py
@@ -11,6 +11,7 @@ from lldbsuite.test import lldbutil
 
 
 class GenericListDataFormatterTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
     TEST_WITH_PDB_DEBUG_INFO = True
     NO_DEBUG_INFO_TESTCASE = True
 

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/multimap/TestDataFormatterGenericMultiMap.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/multimap/TestDataFormatterGenericMultiMap.py
@@ -11,6 +11,7 @@ from lldbsuite.test import lldbutil
 
 
 class GenericMultiMapDataFormatterTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
     TEST_WITH_PDB_DEBUG_INFO = True
 
     def setUp(self):

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/multiset/TestDataFormatterGenericMultiSet.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/multiset/TestDataFormatterGenericMultiSet.py
@@ -10,6 +10,7 @@ from lldbsuite.test import lldbutil
 
 
 class GenericMultiSetDataFormatterTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
     TEST_WITH_PDB_DEBUG_INFO = True
 
     def setUp(self):

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/ordering/TestDataFormatterStdOrdering.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/ordering/TestDataFormatterStdOrdering.py
@@ -9,6 +9,7 @@ from lldbsuite.test import lldbutil
 
 
 class StdOrderingTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
     TEST_WITH_PDB_DEBUG_INFO = True
 
     def do_test(self):

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/queue/TestDataFormatterStdQueue.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/queue/TestDataFormatterStdQueue.py
@@ -9,6 +9,8 @@ from lldbsuite.test import lldbutil
 
 
 class TestDataFormatterStdQueue(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def setUp(self):
         TestBase.setUp(self)
         self.namespace = "std"

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/ranges/ref_view/TestDataFormatterStdRangesRefView.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/ranges/ref_view/TestDataFormatterStdRangesRefView.py
@@ -9,6 +9,8 @@ from lldbsuite.test import lldbutil
 
 
 class StdRangesRefViewDataFormatterTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def check_string_vec_children(self):
         return [
             ValueCheck(name="[0]", summary='"First"'),

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/set/TestDataFormatterGenericSet.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/set/TestDataFormatterGenericSet.py
@@ -10,6 +10,7 @@ from lldbsuite.test import lldbutil
 
 
 class GenericSetDataFormatterTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
     TEST_WITH_PDB_DEBUG_INFO = True
 
     def setUp(self):

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/tuple/TestDataFormatterStdTuple.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/tuple/TestDataFormatterStdTuple.py
@@ -9,6 +9,7 @@ from lldbsuite.test import lldbutil
 
 
 class TestDataFormatterStdTuple(TestBase):
+    SHARED_BUILD_TESTCASE = False
     TEST_WITH_PDB_DEBUG_INFO = True
 
     def setUp(self):

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/unordered_map-iterator/TestDataFormatterStdUnorderedMap.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/unordered_map-iterator/TestDataFormatterStdUnorderedMap.py
@@ -9,6 +9,8 @@ from lldbsuite.test import lldbutil
 
 
 class StdUnorderedMapDataFormatterTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def check_ptr_or_ref(self, var_name: str):
         var = self.frame().FindVariable(var_name)
         self.assertTrue(var)

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/valarray/TestDataFormatterStdValarray.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/valarray/TestDataFormatterStdValarray.py
@@ -9,6 +9,8 @@ from lldbsuite.test import lldbutil
 
 
 class StdValarrayDataFormatterTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def do_test(self):
         (self.target, process, thread, bkpt) = lldbutil.run_to_source_breakpoint(
             self, "break here", lldb.SBFileSpec("main.cpp", False)

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/vbool/TestDataFormatterStdVBool.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/vbool/TestDataFormatterStdVBool.py
@@ -9,6 +9,7 @@ from lldbsuite.test import lldbutil
 
 
 class StdVBoolDataFormatterTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
     TEST_WITH_PDB_DEBUG_INFO = True
 
     def setUp(self):

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx-simulators/optional/TestDataFormatterLibcxxOptionalSimulator.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx-simulators/optional/TestDataFormatterLibcxxOptionalSimulator.py
@@ -11,6 +11,7 @@ import functools
 
 
 class LibcxxOptionalDataFormatterSimulatorTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
     NO_DEBUG_INFO_TESTCASE = True
 
     def _run_test(self, defines):

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx-simulators/string/TestDataFormatterLibcxxStringSimulator.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx-simulators/string/TestDataFormatterLibcxxStringSimulator.py
@@ -11,6 +11,7 @@ import functools
 
 
 class LibcxxStringDataFormatterSimulatorTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
     NO_DEBUG_INFO_TESTCASE = True
 
     def _run_test(self, defines):

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx-simulators/unique_ptr/TestDataFormatterLibcxxUniquePtrSimulator.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx-simulators/unique_ptr/TestDataFormatterLibcxxUniquePtrSimulator.py
@@ -11,6 +11,7 @@ import functools
 
 
 class LibcxxUniquePtrDataFormatterSimulatorTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
     NO_DEBUG_INFO_TESTCASE = True
 
     def _run_test(self, defines):

--- a/lldb/test/API/functionalities/data-formatter/nsdictionarysynth/TestNSDictionarySynthetic.py
+++ b/lldb/test/API/functionalities/data-formatter/nsdictionarysynth/TestNSDictionarySynthetic.py
@@ -9,6 +9,8 @@ from lldbsuite.test import lldbutil
 
 
 class NSDictionarySyntheticTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def setUp(self):
         # Call super's setUp().
         TestBase.setUp(self)

--- a/lldb/test/API/functionalities/data-formatter/nssetsynth/TestNSSetSynthetic.py
+++ b/lldb/test/API/functionalities/data-formatter/nssetsynth/TestNSSetSynthetic.py
@@ -10,6 +10,8 @@ from lldbsuite.test import lldbutil
 
 
 class NSSetSyntheticTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def setUp(self):
         # Call super's setUp().
         TestBase.setUp(self)

--- a/lldb/test/API/functionalities/data-formatter/poarray/TestPrintObjectArray.py
+++ b/lldb/test/API/functionalities/data-formatter/poarray/TestPrintObjectArray.py
@@ -10,6 +10,8 @@ from lldbsuite.test import lldbutil
 
 
 class PrintObjectArrayTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     @skipUnlessDarwin
     def test_print_array(self):
         """Test that expr -O -Z works"""

--- a/lldb/test/API/functionalities/gdb_remote_client/TestPlatformKill.py
+++ b/lldb/test/API/functionalities/gdb_remote_client/TestPlatformKill.py
@@ -7,6 +7,8 @@ from lldbsuite.test.lldbgdbclient import GDBRemoteTestBase
 
 
 class TestPlatformKill(GDBRemoteTestBase):
+    SHARED_BUILD_TESTCASE = False
+
     @skipIfRemote
     def test_kill_different_platform(self):
         """Test connecting to a remote linux platform"""

--- a/lldb/test/API/functionalities/plugins/command_plugin/TestPluginCommands.py
+++ b/lldb/test/API/functionalities/plugins/command_plugin/TestPluginCommands.py
@@ -9,6 +9,8 @@ from lldbsuite.test import lldbutil
 
 
 class PluginCommandTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def setUp(self):
         TestBase.setUp(self)
 

--- a/lldb/test/API/functionalities/plugins/python_os_plugin/os_plugin_in_dsym/TestOSIndSYM.py
+++ b/lldb/test/API/functionalities/plugins/python_os_plugin/os_plugin_in_dsym/TestOSIndSYM.py
@@ -16,6 +16,7 @@ import shutil
 
 
 class TestOSPluginIndSYM(TestBase):
+    SHARED_BUILD_TESTCASE = False
     NO_DEBUG_INFO_TESTCASE = True
 
     # The port used by debugserver.

--- a/lldb/test/API/functionalities/thread/step_until/TestStepUntil.py
+++ b/lldb/test/API/functionalities/thread/step_until/TestStepUntil.py
@@ -7,6 +7,8 @@ from lldbsuite.test_event.build_exception import BuildError
 
 
 class StepUntilTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def setUp(self):
         # Call super's setUp().
         TestBase.setUp(self)

--- a/lldb/test/API/iohandler/sigint/TestProcessIOHandlerInterrupt.py
+++ b/lldb/test/API/iohandler/sigint/TestProcessIOHandlerInterrupt.py
@@ -11,6 +11,8 @@ from lldbsuite.test.lldbpexpect import PExpectTest
 
 
 class TestCase(PExpectTest):
+    SHARED_BUILD_TESTCASE = False
+
     @skipIf(macos_version=["<", "14.0"], asan=True)
     @skipIf(compiler="clang", compiler_version=["<", "11.0"])
     @skipIf(oslist=["linux"], archs=["arm$", "aarch64"])

--- a/lldb/test/API/lang/BoundsSafety/soft_trap/TestBoundsSafetyInstrumentationPlugin.py
+++ b/lldb/test/API/lang/BoundsSafety/soft_trap/TestBoundsSafetyInstrumentationPlugin.py
@@ -13,6 +13,8 @@ SOFT_TRAP_FUNC_WITH_STR = "__bounds_safety_soft_trap_s"
 
 
 class BoundsSafetyTestSoftTrapPlugin(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def _check_stop_reason_impl(
         self,
         expected_soft_trap_func: str,

--- a/lldb/test/API/lang/c/forward/TestForwardDeclaration.py
+++ b/lldb/test/API/lang/c/forward/TestForwardDeclaration.py
@@ -8,6 +8,8 @@ import lldbsuite.test.lldbutil as lldbutil
 
 
 class ForwardDeclarationTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def do_test(self, dictionary=None):
         """Display *bar_ptr when stopped on a function with forward declaration of struct bar."""
         self.build(dictionary=dictionary)

--- a/lldb/test/API/lang/cpp/dynamic-value/TestCppValueCast.py
+++ b/lldb/test/API/lang/cpp/dynamic-value/TestCppValueCast.py
@@ -9,6 +9,8 @@ from lldbsuite.test import lldbutil
 
 
 class CppValueCastTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     @skipIf(bugnumber="llvm.org/PR36714")
     @add_test_categories(["pyapi"])
     def test_value_cast_with_virtual_inheritance(self):

--- a/lldb/test/API/lang/cpp/forward/TestCPPForwardDeclaration.py
+++ b/lldb/test/API/lang/cpp/forward/TestCPPForwardDeclaration.py
@@ -7,6 +7,8 @@ import lldbsuite.test.lldbutil as lldbutil
 
 
 class ForwardDeclarationTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def do_test(self, dictionary=None):
         """Display *bar_ptr when stopped on a function with forward declaration of struct bar."""
         self.build(dictionary=dictionary)

--- a/lldb/test/API/lang/cpp/limit-debug-info/TestWithLimitDebugInfo.py
+++ b/lldb/test/API/lang/cpp/limit-debug-info/TestWithLimitDebugInfo.py
@@ -5,6 +5,8 @@ from lldbsuite.test import lldbutil
 
 
 class TestWithLimitDebugInfo(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def _run_test(self, build_dict):
         self.build(dictionary=build_dict)
 

--- a/lldb/test/API/lang/cpp/nested-template/TestNestedTemplate.py
+++ b/lldb/test/API/lang/cpp/nested-template/TestNestedTemplate.py
@@ -9,6 +9,8 @@ from lldbsuite.test.lldbtest import *
 
 
 class NestedTemplateTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def do_test(self, debug_flags):
         self.build(dictionary=debug_flags)
         self.dbg.CreateTarget(self.getBuildArtifact("a.out"))

--- a/lldb/test/API/lang/cpp/unique-types2/TestUniqueTypes2.py
+++ b/lldb/test/API/lang/cpp/unique-types2/TestUniqueTypes2.py
@@ -9,6 +9,8 @@ from lldbsuite.test.lldbtest import *
 
 
 class UniqueTypesTestCase2(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def do_test(self, debug_flags):
         """Test that we only display the requested Foo instantiation, not all Foo instantiations."""
         self.build(dictionary=debug_flags)

--- a/lldb/test/API/lang/cpp/unique-types4/TestUniqueTypes4.py
+++ b/lldb/test/API/lang/cpp/unique-types4/TestUniqueTypes4.py
@@ -9,6 +9,8 @@ from lldbsuite.test.lldbtest import *
 
 
 class UniqueTypesTestCase4(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def do_test(self, debug_flags):
         """Test that we display the correct template instantiation."""
         self.build(dictionary=debug_flags)

--- a/lldb/test/API/lang/objc/direct-dispatch-step/TestObjCDirectDispatchStepping.py
+++ b/lldb/test/API/lang/objc/direct-dispatch-step/TestObjCDirectDispatchStepping.py
@@ -7,6 +7,7 @@ from lldbsuite.test import lldbutil
 
 
 class TestObjCDirectDispatchStepping(TestBase):
+    SHARED_BUILD_TESTCASE = False
     NO_DEBUG_INFO_TESTCASE = True
 
     def setUp(self):

--- a/lldb/test/API/lang/objc/forward-decl/TestForwardDecl.py
+++ b/lldb/test/API/lang/objc/forward-decl/TestForwardDecl.py
@@ -8,6 +8,8 @@ from lldbsuite.test import lldbutil
 
 
 class ForwardDeclTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def setUp(self):
         # Call super's setUp().
         TestBase.setUp(self)

--- a/lldb/test/API/lang/objc/foundation/TestConstStrings.py
+++ b/lldb/test/API/lang/objc/foundation/TestConstStrings.py
@@ -11,6 +11,7 @@ from lldbsuite.test import lldbutil
 
 
 class ConstStringTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
     d = {"OBJC_SOURCES": "const-strings.m"}
 
     def setUp(self):

--- a/lldb/test/API/lang/objc/foundation/TestObjectDescriptionAPI.py
+++ b/lldb/test/API/lang/objc/foundation/TestObjectDescriptionAPI.py
@@ -9,6 +9,8 @@ from lldbsuite.test import lldbutil
 
 
 class ObjectDescriptionAPITestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def setUp(self):
         # Call super's setUp().
         TestBase.setUp(self)

--- a/lldb/test/API/lang/objc/modules-update/TestClangModulesUpdate.py
+++ b/lldb/test/API/lang/objc/modules-update/TestClangModulesUpdate.py
@@ -8,6 +8,8 @@ from lldbsuite.test import lldbutil
 
 
 class TestClangModuleUpdate(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     @add_test_categories(["gmodules"])
     @skipIfDarwin  # rdar://76540904
     def test_expr(self):

--- a/lldb/test/API/lang/objc/objc-dyn-sbtype/TestObjCDynamicSBType.py
+++ b/lldb/test/API/lang/objc/objc-dyn-sbtype/TestObjCDynamicSBType.py
@@ -10,6 +10,8 @@ from lldbsuite.test import lldbutil
 
 
 class ObjCDynamicSBTypeTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def setUp(self):
         # Call super's setUp().
         TestBase.setUp(self)

--- a/lldb/test/API/lang/objc/orderedset/TestOrderedSet.py
+++ b/lldb/test/API/lang/objc/orderedset/TestOrderedSet.py
@@ -5,6 +5,8 @@ from lldbsuite.test import lldbutil
 
 
 class TestOrderedSet(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def test_ordered_set(self):
         self.build()
         self.run_tests()

--- a/lldb/test/API/lang/objc/print-obj/TestPrintObj.py
+++ b/lldb/test/API/lang/objc/print-obj/TestPrintObj.py
@@ -9,6 +9,8 @@ from lldbsuite.test import lldbutil
 
 
 class PrintObjTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def setUp(self):
         # Call super's setUp().
         TestBase.setUp(self)

--- a/lldb/test/API/lang/objc/radar-9691614/TestObjCMethodReturningBOOL.py
+++ b/lldb/test/API/lang/objc/radar-9691614/TestObjCMethodReturningBOOL.py
@@ -10,6 +10,8 @@ from lldbsuite.test import lldbutil
 
 
 class MethodReturningBOOLTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def setUp(self):
         # Call super's setUp().
         TestBase.setUp(self)

--- a/lldb/test/API/lang/objc/rdar-10967107/TestRdar10967107.py
+++ b/lldb/test/API/lang/objc/rdar-10967107/TestRdar10967107.py
@@ -10,6 +10,8 @@ from lldbsuite.test import lldbutil
 
 
 class Rdar10967107TestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def setUp(self):
         # Call super's setUp().
         TestBase.setUp(self)

--- a/lldb/test/API/lang/objc/rdar-12408181/TestRdar12408181.py
+++ b/lldb/test/API/lang/objc/rdar-12408181/TestRdar12408181.py
@@ -15,6 +15,8 @@ from lldbsuite.test import lldbutil
 # Note: Simply applying the @skipIf decorator here confuses the test harness
 # and gives a spurious failure.
 class Rdar12408181TestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def setUp(self):
         # Call super's setUp().
         TestBase.setUp(self)

--- a/lldb/test/API/lang/objc/single-entry-dictionary/TestObjCSingleEntryDictionary.py
+++ b/lldb/test/API/lang/objc/single-entry-dictionary/TestObjCSingleEntryDictionary.py
@@ -8,6 +8,8 @@ from lldbsuite.test import lldbutil
 
 
 class ObjCSingleEntryDictionaryTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def setUp(self):
         # Call super's setUp().
         TestBase.setUp(self)

--- a/lldb/test/API/linux/linker-symbols/TestLinkerSymbols.py
+++ b/lldb/test/API/linux/linker-symbols/TestLinkerSymbols.py
@@ -13,6 +13,7 @@ class TestLinkerSymbols(TestBase):
     # set this to true.  That way it won't be run once for
     # each debug info format.
     NO_DEBUG_INFO_TESTCASE = True
+    SHARED_BUILD_TESTCASE = False
 
     @skipUnlessPlatform(["linux"])
     def test_linker_symbols(self):

--- a/lldb/test/API/linux/loongarch64/simd_registers/TestLoongArch64LinuxSIMDRegisters.py
+++ b/lldb/test/API/linux/loongarch64/simd_registers/TestLoongArch64LinuxSIMDRegisters.py
@@ -15,6 +15,7 @@ class Mode(Enum):
 
 
 class LoongArch64LinuxRegisters(TestBase):
+    SHARED_BUILD_TESTCASE = False
     NO_DEBUG_INFO_TESTCASE = True
 
     def get_build_flags(self, mode):

--- a/lldb/test/API/macosx/ctf/TestCTF.py
+++ b/lldb/test/API/macosx/ctf/TestCTF.py
@@ -6,6 +6,7 @@ import os
 
 
 class TestCTF(TestBase):
+    SHARED_BUILD_TESTCASE = False
     NO_DEBUG_INFO_TESTCASE = True
 
     def no_ctf_convert(self):

--- a/lldb/test/API/macosx/dsym_modules/TestdSYMModuleInit.py
+++ b/lldb/test/API/macosx/dsym_modules/TestdSYMModuleInit.py
@@ -13,6 +13,8 @@ from lldbsuite.test.decorators import *
 
 @skipUnlessDarwin
 class TestdSYMModuleInit(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     @no_debug_info_test
     def test_add_module(self):
         """This loads a file into a target and ensures that the python module was

--- a/lldb/test/API/macosx/function-starts/TestFunctionStarts.py
+++ b/lldb/test/API/macosx/function-starts/TestFunctionStarts.py
@@ -12,6 +12,7 @@ exe_name = "StripMe"  # Must match Makefile
 
 
 class FunctionStartsTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
     NO_DEBUG_INFO_TESTCASE = True
 
     @skipIfRemote

--- a/lldb/test/API/macosx/mte/TestDarwinMTE.py
+++ b/lldb/test/API/macosx/mte/TestDarwinMTE.py
@@ -12,6 +12,7 @@ exe_name = "uaf"  # Must match Makefile
 
 
 class TestDarwinMTE(TestBase):
+    SHARED_BUILD_TESTCASE = False
     NO_DEBUG_INFO_TESTCASE = True
 
     @skipUnlessFeature(cpu_feature.AArch64.MTE)

--- a/lldb/test/API/macosx/nslog/TestDarwinNSLogOutput.py
+++ b/lldb/test/API/macosx/nslog/TestDarwinNSLogOutput.py
@@ -18,6 +18,7 @@ from lldbsuite.test import lldbtest_config
 
 
 class DarwinNSLogOutputTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
     NO_DEBUG_INFO_TESTCASE = True
 
     def setUp(self):

--- a/lldb/test/API/macosx/universal64/TestUniversal64.py
+++ b/lldb/test/API/macosx/universal64/TestUniversal64.py
@@ -4,6 +4,7 @@ from lldbsuite.test import lldbutil
 
 
 class Universal64TestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
     NO_DEBUG_INFO_TESTCASE = True
 
     def do_test(self):

--- a/lldb/test/API/python_api/class_members/TestSBTypeClassMembers.py
+++ b/lldb/test/API/python_api/class_members/TestSBTypeClassMembers.py
@@ -10,6 +10,8 @@ from lldbsuite.test import lldbutil
 
 
 class SBTypeMemberFunctionsTest(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def setUp(self):
         # Call super's setUp().
         TestBase.setUp(self)

--- a/lldb/test/API/python_api/formatters/TestFormattersSBAPI.py
+++ b/lldb/test/API/python_api/formatters/TestFormattersSBAPI.py
@@ -7,6 +7,7 @@ from lldbsuite.test import lldbutil
 
 
 class SBFormattersAPITestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
     NO_DEBUG_INFO_TESTCASE = True
 
     def setUp(self):

--- a/lldb/test/API/python_api/global_module_cache/TestGlobalModuleCache.py
+++ b/lldb/test/API/python_api/global_module_cache/TestGlobalModuleCache.py
@@ -14,6 +14,7 @@ import time
 
 
 class GlobalModuleCacheTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
     # NO_DEBUG_INFO_TESTCASE = True
 
     def check_counter_var(self, thread, value):

--- a/lldb/test/API/python_api/hello_world/TestHelloWorld.py
+++ b/lldb/test/API/python_api/hello_world/TestHelloWorld.py
@@ -10,6 +10,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 
 class HelloWorldTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
     NO_DEBUG_INFO_TESTCASE = True
 
     def setUp(self):

--- a/lldb/test/API/python_api/module_section/TestModuleAndSection.py
+++ b/lldb/test/API/python_api/module_section/TestModuleAndSection.py
@@ -10,6 +10,8 @@ from lldbsuite.test.lldbutil import symbol_type_to_str
 
 
 class ModuleAndSectionAPIsTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def test_module_and_section(self):
         """Test module and section APIs."""
         self.build()

--- a/lldb/test/API/python_api/target/TestTargetAPI.py
+++ b/lldb/test/API/python_api/target/TestTargetAPI.py
@@ -10,6 +10,8 @@ from lldbsuite.test import lldbutil
 
 
 class TargetAPITestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def setUp(self):
         # Call super's setUp().
         TestBase.setUp(self)

--- a/lldb/test/API/python_api/thread/TestThreadAPI.py
+++ b/lldb/test/API/python_api/thread/TestThreadAPI.py
@@ -10,6 +10,8 @@ from lldbsuite.test.lldbutil import get_stopped_thread, get_caller_symbol
 
 
 class ThreadAPITestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def test_get_process(self):
         """Test Python SBThread.GetProcess() API."""
         self.build()

--- a/lldb/test/API/python_api/value/TestValueAPI.py
+++ b/lldb/test/API/python_api/value/TestValueAPI.py
@@ -9,6 +9,8 @@ from lldbsuite.test.lldbtest import *
 
 
 class ValueAPITestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def setUp(self):
         # Call super's setUp().
         TestBase.setUp(self)

--- a/lldb/test/API/python_api/value/change_values/TestChangeValueAPI.py
+++ b/lldb/test/API/python_api/value/change_values/TestChangeValueAPI.py
@@ -9,6 +9,8 @@ from lldbsuite.test import lldbutil
 
 
 class ChangeValueAPITestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def setUp(self):
         # Call super's setUp().
         TestBase.setUp(self)

--- a/lldb/test/API/python_api/value/linked_list/TestValueAPILinkedList.py
+++ b/lldb/test/API/python_api/value/linked_list/TestValueAPILinkedList.py
@@ -10,6 +10,7 @@ from lldbsuite.test import lldbutil
 
 
 class ValueAsLinkedListTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
     NO_DEBUG_INFO_TESTCASE = True
 
     def setUp(self):

--- a/lldb/test/API/python_api/value_var_update/TestValueVarUpdate.py
+++ b/lldb/test/API/python_api/value_var_update/TestValueVarUpdate.py
@@ -8,6 +8,8 @@ from lldbsuite.test import lldbutil
 
 
 class ValueVarUpdateTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def test_with_process_launch_api(self):
         """Test SBValue::GetValueDidChange"""
         # Get the full path to our executable to be attached/debugged.

--- a/lldb/test/API/python_api/watchpoint/condition/TestWatchpointConditionAPI.py
+++ b/lldb/test/API/python_api/watchpoint/condition/TestWatchpointConditionAPI.py
@@ -9,6 +9,7 @@ from lldbsuite.test import lldbutil
 
 
 class WatchpointConditionAPITestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
     NO_DEBUG_INFO_TESTCASE = True
 
     def setUp(self):

--- a/lldb/test/API/riscv/break-undecoded/TestBreakpointIllegal.py
+++ b/lldb/test/API/riscv/break-undecoded/TestBreakpointIllegal.py
@@ -9,6 +9,8 @@ from lldbsuite.test import lldbutil
 
 
 class TestBreakpointIllegal(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     @skipIf(archs=no_match(["rv64gc"]))
     def test_4(self):
         self.build()

--- a/lldb/test/API/riscv/step/TestSoftwareStep.py
+++ b/lldb/test/API/riscv/step/TestSoftwareStep.py
@@ -10,6 +10,8 @@ from lldbsuite.test import lldbutil
 
 
 class TestSoftwareStep(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def do_sequence_test(self, filename, bkpt_name):
         source_file = filename + ".c"
         exe_file = filename + ".x"

--- a/lldb/test/API/tools/lldb-dap/attach-commands/TestDAP_attachCommands.py
+++ b/lldb/test/API/tools/lldb-dap/attach-commands/TestDAP_attachCommands.py
@@ -10,6 +10,8 @@ import time
 
 
 class TestDAP_attachCommands(lldbdap_testcase.DAPTestCaseBase):
+    SHARED_BUILD_TESTCASE = False
+
     @skipIfNetBSD  # Hangs on NetBSD as well
     def test_commands(self):
         """

--- a/lldb/test/API/tools/lldb-dap/attach/TestDAP_attach.py
+++ b/lldb/test/API/tools/lldb-dap/attach/TestDAP_attach.py
@@ -15,6 +15,8 @@ import time
 # process scheduling can cause a massive (minutes) delay during this test.
 @skipIf(oslist=["linux"], archs=["arm$"])
 class TestDAP_attach(lldbdap_testcase.DAPTestCaseBase):
+    SHARED_BUILD_TESTCASE = False
+
     def spawn(self, program, args=None):
         return self.spawnSubprocess(
             executable=program,

--- a/lldb/test/API/tools/lldb-dap/commands/TestDAP_commands.py
+++ b/lldb/test/API/tools/lldb-dap/commands/TestDAP_commands.py
@@ -7,6 +7,8 @@ from lldbsuite.test.decorators import *
 
 
 class TestDAP_commands(lldbdap_testcase.DAPTestCaseBase):
+    SHARED_BUILD_TESTCASE = False
+
     def test_command_directive_quiet_on_success(self):
         program = self.getBuildArtifact("a.out")
         command_quiet = (

--- a/lldb/test/API/tools/lldb-server/TestLldbGdbServer.py
+++ b/lldb/test/API/tools/lldb-server/TestLldbGdbServer.py
@@ -29,6 +29,8 @@ from lldbsuite.test import lldbutil, lldbplatformutil
 class LldbGdbServerTestCase(
     gdbremote_testcase.GdbRemoteTestCaseBase, DwarfOpcodeParser
 ):
+    SHARED_BUILD_TESTCASE = False
+
     def test_thread_suffix_supported(self):
         server = self.connect_to_debug_monitor()
         self.assertIsNotNone(server)

--- a/lldb/test/API/tools/lldb-server/attach-wait/TestGdbRemoteAttachWait.py
+++ b/lldb/test/API/tools/lldb-server/attach-wait/TestGdbRemoteAttachWait.py
@@ -10,6 +10,8 @@ from lldbsuite.test import lldbutil
 
 @skipIfMTE  # MTE security transition shims restrict socket operations.
 class TestGdbRemoteAttachWait(gdbremote_testcase.GdbRemoteTestCaseBase):
+    SHARED_BUILD_TESTCASE = False
+
     def _set_up_inferior(self):
         self._exe_to_attach = "%s_%d" % (self.testMethodName, os.getpid())
         self.build(dictionary={"EXE": self._exe_to_attach, "CXX_SOURCES": "main.cpp"})

--- a/lldb/test/API/types/HideTestFailures.py
+++ b/lldb/test/API/types/HideTestFailures.py
@@ -13,6 +13,8 @@ from lldbsuite.test.lldbtest import *
 
 
 class DebugIntegerTypesFailures(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def setUp(self):
         # Call super's setUp().
         TestBase.setUp(self)

--- a/lldb/test/API/types/TestRecursiveTypes.py
+++ b/lldb/test/API/types/TestRecursiveTypes.py
@@ -2,13 +2,14 @@
 Test that recursive types are handled correctly.
 """
 
-
 import lldb
 import lldbsuite.test.lldbutil as lldbutil
 from lldbsuite.test.lldbtest import *
 
 
 class RecursiveTypesTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def setUp(self):
         # Call super's setUp().
         TestBase.setUp(self)


### PR DESCRIPTION
Change `self.build(...)` to assert if called with arguments of any kind, for tests which have `SHARED_BUILD_TESTCASE` enabled (the default).

This also changes all tests that began asserting with this change, tests which call `self.build(...)` with arguments.