### PR TITLE
[mlir][linalg] Improve inner tile size mismatch diagnostics in pack/unpack verifier

### DIFF
--- a/mlir/lib/Dialect/Linalg/IR/LinalgOps.cpp
+++ b/mlir/lib/Dialect/Linalg/IR/LinalgOps.cpp
@@ -5026,8 +5026,8 @@ getNewMixedTileSizes(PatternRewriter &rewriter, Type newPackedTy,
                                .getShape()
                                .take_back(mixedTiles.size()),
                            mixedTiles)) {
-    int64_t shape = std::get<0>(it);
-    if (shape == ShapedType::kDynamic) {
+    int64_t dimSize = std::get<0>(it);
+    if (dimSize == ShapedType::kDynamic) {
       newMixedTileSizes.push_back(std::get<1>(it));
       continue;
     }
@@ -5039,10 +5039,10 @@ getNewMixedTileSizes(PatternRewriter &rewriter, Type newPackedTy,
       // Already a constant
       newMixedTileSizes.push_back(tile);
     } else {
-      assert(getConstantIntValue(tile).value() == shape &&
+      assert(getConstantIntValue(tile).value() == dimSize &&
              "tile size and dim size don't match!");
       newMixedTileSizes.push_back(
-          (rewriter.getIntegerAttr(rewriter.getIndexType(), shape)));
+          (rewriter.getIntegerAttr(rewriter.getIndexType(), dimSize)));
     }
   }
 
@@ -5197,21 +5197,23 @@ static LogicalResult commonVerifierPackAndUnPackOp(OpTy packOrUnPack) {
   SmallVector<int64_t> expectedPackedShape = PackOp::inferPackedShape(
       unpackedType.getShape(), packOrUnPack.getStaticTiles(),
       packOrUnPack.getInnerDimsPos(), packOrUnPack.getOuterDimsPerm());
-  if (!llvm::all_of(
-          llvm::zip(packedType.getShape().take_back(mixedTiles.size()),
-                    mixedTiles),
-          [](std::tuple<int64_t, OpFoldResult> it) {
-            int64_t shape = std::get<0>(it);
-            if (Attribute attr =
-                    llvm::dyn_cast_if_present<Attribute>(std::get<1>(it))) {
-              IntegerAttr intAttr = dyn_cast_or_null<IntegerAttr>(attr);
-              int64_t staticTileSize = intAttr.getValue().getSExtValue();
-              return shape == staticTileSize;
-            }
-            return ShapedType::isDynamic(shape);
-          })) {
-    return op->emitError("mismatch in inner tile sizes specified and shaped of "
-                         "tiled dimension in the packed type");
+  for (auto it : llvm::enumerate(llvm::zip(
+           packedType.getShape().take_back(mixedTiles.size()), mixedTiles))) {
+    int64_t dimSize = std::get<0>(it.value());
+    if (Attribute attr =
+            llvm::dyn_cast_if_present<Attribute>(std::get<1>(it.value()))) {
+      IntegerAttr intAttr = dyn_cast_or_null<IntegerAttr>(attr);
+      int64_t staticTileSize = intAttr.getValue().getSExtValue();
+      if (dimSize != staticTileSize)
+        return op->emitError(
+                   "mismatch in inner tile sizes specified and shaped of "
+                   "tiled dimension in the packed type at index ")
+               << it.index() << ": got " << dimSize << " != " << staticTileSize;
+    } else if (!ShapedType::isDynamic(dimSize)) {
+      return op->emitError("mismatch in inner tile sizes specified at index ")
+             << it.index() << ": got static shape " << dimSize
+             << " but dynamic tile size";
+    }
   }
   if (failed(
           verifyCompatibleShape(expectedPackedShape, packedType.getShape()))) {

--- a/mlir/test/Dialect/Linalg/invalid.mlir
+++ b/mlir/test/Dialect/Linalg/invalid.mlir
@@ -1877,7 +1877,7 @@ func.func @pack_invalid(%input: tensor<256x128xf32>, %output: tensor<8x8x32x16xf
 
 func.func @pack_mismatch_inner_tile_size_and_output_shape(
   %input : tensor<?x?xf32>, %output : tensor<?x?x8x8xf32>) -> tensor<?x?x8x8xf32> {
-  // expected-error@+1 {{mismatch in inner tile sizes specified and shaped of tiled dimension in the packed type}}
+  // expected-error@+1 {{mismatch in inner tile sizes specified and shaped of tiled dimension in the packed type at index 1: got 8 != 4}}
   %0 = linalg.pack %input inner_dims_pos = [0, 1] inner_tiles = [8, 4] into %output : tensor<?x?xf32> -> tensor<?x?x8x8xf32>
   return %0 : tensor<?x?x8x8xf32>
 }
@@ -1887,7 +1887,7 @@ func.func @pack_mismatch_inner_tile_size_and_output_shape(
 func.func @pack_dynamic_inner_tile_size_and_static_output_shape(
   %input : tensor<?x?xf32>, %output : tensor<?x?x8x8xf32>) -> tensor<?x?x8x8xf32> {
   %c8 = arith.constant 8 : index
-  // expected-error@+1 {{mismatch in inner tile sizes specified and shaped of tiled dimension in the packed type}}
+  // expected-error@+1 {{mismatch in inner tile sizes specified at index 1: got static shape 8 but dynamic tile size}}
   %0 = linalg.pack %input inner_dims_pos = [0, 1] inner_tiles = [8, %c8] into %output : tensor<?x?xf32> -> tensor<?x?x8x8xf32>
   return %0 : tensor<?x?x8x8xf32>
 }
@@ -1896,7 +1896,7 @@ func.func @pack_dynamic_inner_tile_size_and_static_output_shape(
 
 func.func @pack_static_inner_tile_size_and_dynamic_output_shape(
   %input : tensor<?x?xf32>, %output : tensor<?x?x8x?xf32>) -> tensor<?x?x8x?xf32> {
-  // expected-error@+1 {{mismatch in inner tile sizes specified and shaped of tiled dimension in the packed type}}
+  // expected-error@+1 {{mismatch in inner tile sizes specified and shaped of tiled dimension in the packed type at index 1: got}}
   %0 = linalg.pack %input inner_dims_pos = [0, 1] inner_tiles = [8, 8] into %output : tensor<?x?xf32> -> tensor<?x?x8x?xf32>
   return %0 : tensor<?x?x8x?xf32>
 }
@@ -1987,7 +1987,7 @@ func.func @unpack_invalid_source_shape(%output: tensor<256x128xf32>, %input: ten
 
 func.func @unpack_mismatch_inner_tile_size_and_output_shape(
   %input : tensor<?x?x8x8xf32>, %output : tensor<?x?xf32>) -> tensor<?x?xf32> {
-  // expected-error@+1 {{mismatch in inner tile sizes specified and shaped of tiled dimension in the packed type}}
+  // expected-error@+1 {{mismatch in inner tile sizes specified and shaped of tiled dimension in the packed type at index 1: got 8 != 4}}
   %0 = linalg.unpack %input inner_dims_pos = [0, 1] inner_tiles = [8, 4] into %output : tensor<?x?x8x8xf32> -> tensor<?x?xf32>
   return %0 : tensor<?x?xf32>
 }
@@ -1997,7 +1997,7 @@ func.func @unpack_mismatch_inner_tile_size_and_output_shape(
 func.func @unpack_dynamic_inner_tile_size_and_static_output_shape(
   %input : tensor<?x?x8x4xf32>, %output : tensor<?x?xf32>) -> tensor<?x?xf32> {
   %c8 = arith.constant 8 : index
-  // expected-error@+1 {{mismatch in inner tile sizes specified and shaped of tiled dimension in the packed type}}
+  // expected-error@+1 {{mismatch in inner tile sizes specified at index 0: got static shape 8 but dynamic tile size}}
   %0 = linalg.unpack %input inner_dims_pos = [0, 1] inner_tiles = [%c8, 4] into %output : tensor<?x?x8x4xf32> -> tensor<?x?xf32>
   return %0 : tensor<?x?xf32>
 }
@@ -2006,7 +2006,7 @@ func.func @unpack_dynamic_inner_tile_size_and_static_output_shape(
 
 func.func @unpack_static_inner_tile_size_and_dynamic_output_shape(
   %input : tensor<?x?x?x4xf32>, %output : tensor<?x?xf32>) -> tensor<?x?xf32> {
-  // expected-error@+1 {{mismatch in inner tile sizes specified and shaped of tiled dimension in the packed type}}
+  // expected-error@+1 {{mismatch in inner tile sizes specified and shaped of tiled dimension in the packed type at index 0: got}}
   %0 = linalg.unpack %input inner_dims_pos = [0, 1] inner_tiles = [8, 4] into %output : tensor<?x?x?x4xf32> -> tensor<?x?xf32>
   return %0 : tensor<?x?xf32>
 }


### PR DESCRIPTION
Refactor the tile-size consistency check in `commonVerifierPackAndUnPackOp` from a bulk `all_of` into an indexed loop so that error messages include the offending dimension index and the conflicting values, making failures easier to diagnose.

Before:
  error: mismatch in inner tile sizes specified and shaped of tiled
         dimension in the packed type

After (static/static mismatch):
  error: mismatch in inner tile sizes specified and shaped of tiled
         dimension in the packed type at index 1: got 8 \!= 4

After (dynamic tile, static packed dim):
  error: mismatch in inner tile sizes specified at index 1: got static
         shape 8 but dynamic tile size

Update the six affected expected-error lines in invalid.mlir accordingly.

Assisted-by: Claude Code