### PR TITLE
[lldb] [windows] Fix warnings in ConnectionConPTYWindows

### DIFF
--- a/lldb/source/Host/windows/ConnectionConPTYWindows.cpp
+++ b/lldb/source/Host/windows/ConnectionConPTYWindows.cpp
@@ -44,7 +44,7 @@ static bool StripConPTYInitSequences(void *dst, size_t dst_len, size_t &len) {
 }
 
 ConnectionConPTY::ConnectionConPTY(std::shared_ptr<PseudoConsole> pty)
-    : m_pty(pty), ConnectionGenericFile(pty->GetSTDOUTHandle(), false) {};
+    : ConnectionGenericFile(pty->GetSTDOUTHandle(), false), m_pty(pty) {}
 
 ConnectionConPTY::~ConnectionConPTY() {}
 


### PR DESCRIPTION
This fixes the following warnings, when building in mingw mode:

    llvm-project/lldb/source/Host/windows/ConnectionConPTYWindows.cpp:47:7: warning: field 'm_pty' will be initialized after base 'ConnectionGenericFile' [-Wreorder-ctor]
       47 |     : m_pty(pty), ConnectionGenericFile(pty->GetSTDOUTHandle(), false) {};
          |       ^~~~~~~~~~  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          |       ConnectionGenericFile(pty->GetSTDOUTHandle(), false) m_pty(pty)
    llvm-project/lldb/source/Host/windows/ConnectionConPTYWindows.cpp:47:74: warning: extra ';' outside of a function is incompatible with C++98 [-Wc++98-compat-extra-semi]
       47 |     : m_pty(pty), ConnectionGenericFile(pty->GetSTDOUTHandle(), false) {};
          |                                                                          ^