### PR TITLE
[libc++] Use internal std::__is_sufficiently_aligned for atomic ref constructors and as helper for the public std::is_sufficiently_aligned

### DIFF
--- a/libcxx/include/__atomic/atomic_ref.h
+++ b/libcxx/include/__atomic/atomic_ref.h
@@ -30,9 +30,9 @@
 #include <__cstddef/byte.h>
 #include <__cstddef/ptrdiff_t.h>
 #include <__memory/addressof.h>
+#include <__memory/is_sufficiently_aligned.h>
 #include <__type_traits/has_unique_object_representation.h>
 #include <__type_traits/is_trivially_copyable.h>
-#include <cstdint>
 #include <cstring>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
@@ -254,7 +254,7 @@ struct atomic_ref : public __atomic_ref_base<_Tp> {
 
   _LIBCPP_HIDE_FROM_ABI explicit atomic_ref(_Tp& __obj) : __base(__obj) {
     _LIBCPP_ASSERT_ARGUMENT_WITHIN_DOMAIN(
-        reinterpret_cast<uintptr_t>(std::addressof(__obj)) % __base::required_alignment == 0,
+        std::__is_sufficiently_aligned<__base::required_alignment>(std::addressof(__obj)),
         "atomic_ref ctor: referenced object must be aligned to required_alignment");
   }
 
@@ -274,7 +274,7 @@ struct atomic_ref<_Tp> : public __atomic_ref_base<_Tp> {
 
   _LIBCPP_HIDE_FROM_ABI explicit atomic_ref(_Tp& __obj) : __base(__obj) {
     _LIBCPP_ASSERT_ARGUMENT_WITHIN_DOMAIN(
-        reinterpret_cast<uintptr_t>(std::addressof(__obj)) % __base::required_alignment == 0,
+        std::__is_sufficiently_aligned<__base::required_alignment>(std::addressof(__obj)),
         "atomic_ref ctor: referenced object must be aligned to required_alignment");
   }
 
@@ -320,7 +320,7 @@ struct atomic_ref<_Tp> : public __atomic_ref_base<_Tp> {
 
   _LIBCPP_HIDE_FROM_ABI explicit atomic_ref(_Tp& __obj) : __base(__obj) {
     _LIBCPP_ASSERT_ARGUMENT_WITHIN_DOMAIN(
-        reinterpret_cast<uintptr_t>(std::addressof(__obj)) % __base::required_alignment == 0,
+        std::__is_sufficiently_aligned<__base::required_alignment>(std::addressof(__obj)),
         "atomic_ref ctor: referenced object must be aligned to required_alignment");
   }
 

--- a/libcxx/include/__memory/is_sufficiently_aligned.h
+++ b/libcxx/include/__memory/is_sufficiently_aligned.h
@@ -20,11 +20,16 @@
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 
+template <size_t _Alignment, class _Tp>
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI bool __is_sufficiently_aligned(_Tp* __ptr) {
+  return reinterpret_cast<uintptr_t>(__ptr) % _Alignment == 0;
+}
+
 #if _LIBCPP_STD_VER >= 26
 
 template <size_t _Alignment, class _Tp>
 [[nodiscard]] _LIBCPP_HIDE_FROM_ABI bool is_sufficiently_aligned(_Tp* __ptr) {
-  return reinterpret_cast<uintptr_t>(__ptr) % _Alignment == 0;
+  return std::__is_sufficiently_aligned<_Alignment>(__ptr);
 }
 
 #endif // _LIBCPP_STD_VER >= 26


### PR DESCRIPTION
This PR resolves https://github.com/llvm/llvm-project/issues/179803

It introduces a `std::__is_sufficiently_aligned` helper function that can be used for the `atomic_ref` C++20 constructors while the public C++26 `std::is_sufficiently_aligned` delegates to the new helper function.  

Assisted-by: Claude Code