### PR TITLE
[lldb] [windows] Fix warning about unused static functions

### DIFF
--- a/lldb/source/Host/windows/PythonPathSetup/PythonPathSetup.cpp
+++ b/lldb/source/Host/windows/PythonPathSetup/PythonPathSetup.cpp
@@ -19,6 +19,7 @@
 
 using namespace llvm;
 
+#ifdef LLDB_PYTHON_DLL_RELATIVE_PATH
 static std::string GetModulePath(HMODULE module) {
   std::vector<WCHAR> buffer(MAX_PATH);
   while (buffer.size() <= PATHCCH_MAX_CCH) {
@@ -40,7 +41,6 @@ static std::string GetModulePath(HMODULE module) {
 /// Returns the full path to the lldb.exe executable.
 static std::string GetPathToExecutable() { return GetModulePath(NULL); }
 
-#ifdef LLDB_PYTHON_DLL_RELATIVE_PATH
 bool AddPythonDLLToSearchPath() {
   std::string path_str = GetPathToExecutable();
   if (path_str.empty())


### PR DESCRIPTION
This fixes warnings about unused static functions, if building without LLDB_PYTHON_DLL_RELATIVE_PATH defined.

These two static functions are only used by the non-static function AddPythonDLLToSearchPath below; include them in the ifdef enclosing it.