### PR TITLE
[SupportHTTP] Remove a redundant pragma

### DIFF
--- a/llvm/lib/Support/HTTP/HTTPClient.cpp
+++ b/llvm/lib/Support/HTTP/HTTPClient.cpp
@@ -146,7 +146,6 @@ unsigned HTTPClient::responseCode() {
 #ifdef _WIN32
 #include <windows.h>
 #include <winhttp.h>
-#pragma comment(lib, "winhttp.lib")
 
 namespace {
 


### PR DESCRIPTION
We explicitly link against the winhttp library by declaring it in CMake, in llvm/lib/Support/HTTP/CMakeLists.txt. We therefore don't need to specify linking against it through a pragma (which embeds a directive in the object file).

This fixes warnings when building in mingw mode, where this kind of pragma isn't supported:

    llvm-project/llvm/lib/Support/HTTP/HTTPClient.cpp:149:9: warning: unknown pragma ignored [-Wunknown-pragmas]
      149 | #pragma comment(lib, "winhttp.lib")
          |         ^