### PR TITLE
[Support] [Windows] Silence warnings about anonymous unions

### DIFF
--- a/llvm/lib/Support/Windows/Path.inc
+++ b/llvm/lib/Support/Windows/Path.inc
@@ -1710,6 +1710,10 @@ std::error_code real_path(const Twine &path, SmallVectorImpl<char> &dest,
   return std::error_code();
 }
 
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wnested-anon-types"
+#endif
 // This struct is normally only available in the Windows Driver Kit (WDK)
 // headers, not in the standard Windows SDK.
 struct LLVM_REPARSE_DATA_BUFFER {
@@ -1737,6 +1741,9 @@ struct LLVM_REPARSE_DATA_BUFFER {
     } GenericReparseBuffer;
   };
 };
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
 
 std::error_code readlink(const Twine &path, SmallVectorImpl<char> &dest) {
   dest.clear();


### PR DESCRIPTION
When building in mingw mode with Clang, we currently get the following warnings:

    llvm-project/llvm/lib/Support/Windows/Path.inc:1720:5: warning: anonymous types declared in an anonymous union are an extension [-Wnested-anon-types]
     1720 |     struct {
          |     ^
    llvm-project/llvm/lib/Support/Windows/Path.inc:1728:5: warning: anonymous types declared in an anonymous union are an extension [-Wnested-anon-types]
     1728 |     struct {
          |     ^

Since these declarations mirror parts of the Microsoft SDKs, we don't want to deviate from it needlessly; instead add a pragma to silence this diagnostic for this specific area.