### PR TITLE
[LLDB] Use shared_ptr for m_current_private_state_thread

### DIFF
--- a/lldb/include/lldb/Target/Process.h
+++ b/lldb/include/lldb/Target/Process.h
@@ -3186,15 +3186,11 @@ protected:
   /// private state thread that we spin up when we need to run an expression on
   /// the private state thread.
   struct PrivateStateThread {
-    PrivateStateThread(
-        Process &process, lldb::StateType public_state,
-        lldb::StateType private_state,
-        bool is_secondary_thread, // FIXME: Can I get rid of this?
-        llvm::StringRef thread_name)
+    PrivateStateThread(Process &process, lldb::StateType public_state,
+                       lldb::StateType private_state,
+                       llvm::StringRef thread_name)
         : m_process(process), m_public_state(public_state),
-          m_private_state(private_state),
-          m_is_secondary_thread(is_secondary_thread),
-          m_thread_name(thread_name) {}
+          m_private_state(private_state), m_thread_name(thread_name) {}
     // This returns false if we couldn't start up the thread.  If that happens,
     // you won't be doing any debugging today.
     bool StartupThread();
@@ -3281,11 +3277,6 @@ protected:
     ProcessRunLock m_public_run_lock;
     ProcessRunLock m_private_run_lock;
     bool m_is_running = false;
-    /// If we need to run an expression modally in the private state thread, we
-    /// have to spin up a secondary private state thread to manage the events
-    /// that drive that interaction.  This will be true if this is a modal
-    /// private state thread.
-    bool m_is_secondary_thread;
     ///< This will be the thread name given to the Private State HostThread when
     ///< it gets spun up.
     std::string m_thread_name;
@@ -3508,10 +3499,15 @@ protected:
   void SetPrivateState(lldb::StateType state);
 
   // Starts the private state thread and assigns it to
-  // m_current_private_state_thread_sp.  Clients who are making a secondary
-  // thread for now have to manage backing that up by hand.
-  bool StartPrivateStateThread(lldb::StateType state, bool run_lock_is_running,
-                               bool is_secondary_thread = false);
+  // m_current_private_state_thread_sp.  If backup_ptr is non-null, this is
+  // a "secondary" thread, and the current thread will be backed up into
+  // backup_ptr before being replaced by the new thread. Pass a non-null
+  // backup_ptr in the case where you have to temporarily spin up a secondary
+  // state thread to handle events from a hand-called function on the primary
+  // private state thread.
+  bool StartPrivateStateThread(
+      lldb::StateType state, bool run_lock_is_running,
+      std::shared_ptr<PrivateStateThread> *backup_ptr = nullptr);
 
   void StopPrivateStateThread();
 
@@ -3520,10 +3516,8 @@ protected:
   void ResumePrivateStateThread();
 
 private:
-  // The starts up the private state thread that will watch for events from the
-  // debugee. Pass true for is_secondary_thread in the case where you have to
-  // temporarily spin up a secondary state thread to handle events from a hand-
-  // called function on the primary private state thread.
+  // Starts up the private state thread that will watch for events from the
+  // debugee.
 
   lldb::thread_result_t RunPrivateStateThread();
 

--- a/lldb/include/lldb/Target/Process.h
+++ b/lldb/include/lldb/Target/Process.h
@@ -3052,11 +3052,12 @@ protected:
   };
 
   bool PrivateStateThreadIsRunning() const {
-    if (!m_current_private_state_thread ||
-        !m_current_private_state_thread->IsRunning())
+    if (!m_current_private_state_thread_sp ||
+        !m_current_private_state_thread_sp->IsRunning())
       return false;
 
-    lldb::StateType state = m_current_private_state_thread->GetPrivateState();
+    lldb::StateType state =
+        m_current_private_state_thread_sp->GetPrivateState();
     return state != lldb::eStateInvalid && state != lldb::eStateDetached &&
            state != lldb::eStateExited;
   }
@@ -3291,56 +3292,56 @@ protected:
   };
 
   bool SetPrivateRunLockToStopped() {
-    assert(m_current_private_state_thread);
-    if (m_current_private_state_thread)
-      return m_current_private_state_thread->SetPrivateRunLockToStopped();
+    assert(m_current_private_state_thread_sp);
+    if (m_current_private_state_thread_sp)
+      return m_current_private_state_thread_sp->SetPrivateRunLockToStopped();
     return false;
   }
   bool SetPrivateRunLockToRunning() {
-    assert(m_current_private_state_thread);
-    if (m_current_private_state_thread)
-      return m_current_private_state_thread->SetPrivateRunLockToStopped();
+    assert(m_current_private_state_thread_sp);
+    if (m_current_private_state_thread_sp)
+      return m_current_private_state_thread_sp->SetPrivateRunLockToStopped();
     return false;
   }
   bool SetPublicRunLockToStopped() {
-    assert(m_current_private_state_thread);
-    if (m_current_private_state_thread)
-      return m_current_private_state_thread->SetPublicRunLockToStopped();
+    assert(m_current_private_state_thread_sp);
+    if (m_current_private_state_thread_sp)
+      return m_current_private_state_thread_sp->SetPublicRunLockToStopped();
     return false;
   }
   bool SetPublicRunLockToRunning() {
-    assert(m_current_private_state_thread);
-    if (m_current_private_state_thread)
-      return m_current_private_state_thread->SetPublicRunLockToRunning();
+    assert(m_current_private_state_thread_sp);
+    if (m_current_private_state_thread_sp)
+      return m_current_private_state_thread_sp->SetPublicRunLockToRunning();
     return false;
   }
 
   std::recursive_mutex &GetPrivateStateMutex() {
-    assert(m_current_private_state_thread);
-    return m_current_private_state_thread->GetPrivateStateMutex();
+    assert(m_current_private_state_thread_sp);
+    return m_current_private_state_thread_sp->GetPrivateStateMutex();
   }
 
   lldb::StateType GetPublicState() const {
-    if (!m_current_private_state_thread)
+    if (!m_current_private_state_thread_sp)
       return lldb::eStateUnloaded;
-    return m_current_private_state_thread->GetPublicState();
+    return m_current_private_state_thread_sp->GetPublicState();
   }
 
   lldb::StateType GetPrivateState() const {
-    if (!m_current_private_state_thread)
+    if (!m_current_private_state_thread_sp)
       return lldb::eStateUnloaded;
-    return m_current_private_state_thread->GetPrivateState();
+    return m_current_private_state_thread_sp->GetPrivateState();
   }
 
   lldb::StateType GetPrivateStateNoLock() const {
-    if (!m_current_private_state_thread)
+    if (!m_current_private_state_thread_sp)
       return lldb::eStateUnloaded;
-    return m_current_private_state_thread->GetPrivateStateNoLock();
+    return m_current_private_state_thread_sp->GetPrivateStateNoLock();
   }
 
   void SetPrivateStateNoLock(lldb::StateType new_state) {
-    assert(m_current_private_state_thread);
-    m_current_private_state_thread->SetPrivateStateNoLock(new_state);
+    assert(m_current_private_state_thread_sp);
+    m_current_private_state_thread_sp->SetPrivateStateNoLock(new_state);
   }
 
   // Member variables
@@ -3360,7 +3361,7 @@ protected:
   /// state thread until you call StartupThread.  This needs to be a pointer
   /// so I can transparently swap it out for the modal one, but there will
   /// always be a private state thread in this slot.
-  std::shared_ptr<PrivateStateThread> m_current_private_state_thread;
+  std::shared_ptr<PrivateStateThread> m_current_private_state_thread_sp;
 
   ProcessModID m_mod_id; ///< Tracks the state of the process over stops and
                          ///other alterations.
@@ -3507,8 +3508,8 @@ protected:
   void SetPrivateState(lldb::StateType state);
 
   // Starts the private state thread and assigns it to
-  // m_current_private_state_thread.  Clients who are making a secondary thread
-  // for now have to manage backing that up by hand.
+  // m_current_private_state_thread_sp.  Clients who are making a secondary
+  // thread for now have to manage backing that up by hand.
   bool StartPrivateStateThread(lldb::StateType state, bool run_lock_is_running,
                                bool is_secondary_thread = false);
 

--- a/lldb/include/lldb/Target/Process.h
+++ b/lldb/include/lldb/Target/Process.h
@@ -3355,11 +3355,11 @@ protected:
                                                    // private state thread.
   lldb::ListenerSP m_private_state_listener_sp; // This is the listener for the
                                                 // private state thread.
-  ///< This is filled on construction with the "main" private state which will
-  ///< be exposed to clients of this process.  It won't have a running private
-  ///< state thread until you call StartupThread.  This needs to be a pointer
-  ///< so I can transparently swap it out for the modal one, but there will
-  ///< always be a private state thread in this slot.
+  /// This is filled on construction with the "main" private state which will
+  /// be exposed to clients of this process.  It won't have a running private
+  /// state thread until you call StartupThread.  This needs to be a pointer
+  /// so I can transparently swap it out for the modal one, but there will
+  /// always be a private state thread in this slot.
   std::shared_ptr<PrivateStateThread> m_current_private_state_thread;
 
   ProcessModID m_mod_id; ///< Tracks the state of the process over stops and

--- a/lldb/include/lldb/Target/Process.h
+++ b/lldb/include/lldb/Target/Process.h
@@ -3360,7 +3360,7 @@ protected:
   ///< state thread until you call StartupThread.  This needs to be a pointer
   ///< so I can transparently swap it out for the modal one, but there will
   ///< always be a private state thread in this slot.
-  PrivateStateThread *m_current_private_state_thread;
+  std::shared_ptr<PrivateStateThread> m_current_private_state_thread;
 
   ProcessModID m_mod_id; ///< Tracks the state of the process over stops and
                          ///other alterations.

--- a/lldb/source/Target/Process.cpp
+++ b/lldb/source/Target/Process.cpp
@@ -440,7 +440,7 @@ Process::Process(lldb::TargetSP target_sp, ListenerSP listener_sp,
           nullptr, "lldb.process.internal_state_control_broadcaster"),
       m_private_state_listener_sp(
           Listener::MakeListener("lldb.process.internal_state_listener")),
-      m_current_private_state_thread(new PrivateStateThread(
+      m_current_private_state_thread(std::make_shared<PrivateStateThread>(
           *this, eStateUnloaded, eStateUnloaded, false, "rename-this-thread")),
       m_mod_id(), m_process_unique_id(0), m_thread_index_id(0),
       m_thread_id_to_index_id_map(), m_exit_status(-1),

--- a/lldb/source/Target/Process.cpp
+++ b/lldb/source/Target/Process.cpp
@@ -441,7 +441,7 @@ Process::Process(lldb::TargetSP target_sp, ListenerSP listener_sp,
       m_private_state_listener_sp(
           Listener::MakeListener("lldb.process.internal_state_listener")),
       m_current_private_state_thread_sp(std::make_shared<PrivateStateThread>(
-          *this, eStateUnloaded, eStateUnloaded, false, "rename-this-thread")),
+          *this, eStateUnloaded, eStateUnloaded, "rename-this-thread")),
       m_mod_id(), m_process_unique_id(0), m_thread_index_id(0),
       m_thread_id_to_index_id_map(), m_exit_status(-1),
       m_thread_list_real(*this), m_thread_list(*this), m_thread_plans(*this),
@@ -3897,9 +3897,9 @@ bool Process::PrivateStateThread::IsOnThread(const HostThread &thread) const {
   return m_private_state_thread.EqualsThread(thread);
 }
 
-bool Process::StartPrivateStateThread(lldb::StateType state,
-                                      bool run_lock_is_running,
-                                      bool is_secondary_thread) {
+bool Process::StartPrivateStateThread(
+    lldb::StateType state, bool run_lock_is_running,
+    std::shared_ptr<PrivateStateThread> *backup_ptr) {
   Log *log = GetLog(LLDBLog::Events);
 
   bool already_running = PrivateStateThreadIsRunning();
@@ -3907,7 +3907,7 @@ bool Process::StartPrivateStateThread(lldb::StateType state,
             already_running ? " already running"
                             : " starting private state thread");
 
-  if (!is_secondary_thread && already_running)
+  if (backup_ptr == nullptr && already_running)
     return true;
 
   // Create a thread that watches our internal state and controls which events
@@ -3931,12 +3931,12 @@ bool Process::StartPrivateStateThread(lldb::StateType state,
                "<lldb.process.internal-state(pid=%" PRIu64 ")>", GetID());
   }
 
-  if (is_secondary_thread) {
+  if (backup_ptr) {
     // StartupThread expects the m_current_private_state_thread_sp to be in
     // place already, so do that first:
-    m_current_private_state_thread_sp.reset(
-        new PrivateStateThread(*this, GetPublicState(), GetPrivateState(),
-                               is_secondary_thread, thread_name));
+    *backup_ptr = m_current_private_state_thread_sp;
+    m_current_private_state_thread_sp.reset(new PrivateStateThread(
+        *this, GetPublicState(), GetPrivateState(), thread_name));
   } else
     m_current_private_state_thread_sp->SetThreadName(thread_name);
 
@@ -5216,8 +5216,6 @@ Process::RunThreadPlan(ExecutionContext &exe_ctx,
     LLDB_LOGF(log, "Running thread plan on private state thread, spinning up "
                    "another state thread to handle the events.");
 
-    backup_private_state_thread = m_current_private_state_thread_sp;
-
     // One other bit of business: we want to run just this thread plan and
     // anything it pushes, and then stop, returning control here. But in the
     // normal course of things, the plan above us on the stack would be given a
@@ -5234,7 +5232,7 @@ Process::RunThreadPlan(ExecutionContext &exe_ctx,
 
     // Now spin up the private state thread:
     StartPrivateStateThread(lldb::eStateStopped, /* RunLock is stopped*/ false,
-                            /*secondary_thread=*/true);
+                            &backup_private_state_thread);
     if (!m_current_private_state_thread_sp) {
       // If we can't spin up a thread here we can't run this expression.  But
       // presumably the old private state thread is still good, so just put it

--- a/lldb/source/Target/Process.cpp
+++ b/lldb/source/Target/Process.cpp
@@ -522,8 +522,6 @@ Process::~Process() {
   // explicitly clear the thread list here to ensure that the mutex is not
   // destroyed before the thread list.
   m_thread_list.Clear();
-  delete m_current_private_state_thread;
-  m_current_private_state_thread = nullptr;
 }
 
 ProcessProperties &Process::GetGlobalProperties() {
@@ -3934,12 +3932,11 @@ bool Process::StartPrivateStateThread(lldb::StateType state,
   }
 
   if (is_secondary_thread) {
-    PrivateStateThread *new_private_state_thread =
-        new PrivateStateThread(*this, GetPublicState(), GetPrivateState(),
-                               is_secondary_thread, thread_name);
     // StartupThread expects the m_current_private_state_thread to be in place
     // already, so do that first:
-    m_current_private_state_thread = new_private_state_thread;
+    m_current_private_state_thread.reset(
+        new PrivateStateThread(*this, GetPublicState(), GetPrivateState(),
+                               is_secondary_thread, thread_name));
   } else
     m_current_private_state_thread->SetThreadName(thread_name);
 
@@ -5205,7 +5202,7 @@ Process::RunThreadPlan(ExecutionContext &exe_ctx,
     selected_tid = LLDB_INVALID_THREAD_ID;
   }
 
-  PrivateStateThread *backup_private_state_thread = nullptr;
+  std::shared_ptr<PrivateStateThread> backup_private_state_thread;
   lldb::StateType old_state = eStateInvalid;
   lldb::ThreadPlanSP stopper_base_plan_sp;
 

--- a/lldb/source/Target/Process.cpp
+++ b/lldb/source/Target/Process.cpp
@@ -440,7 +440,7 @@ Process::Process(lldb::TargetSP target_sp, ListenerSP listener_sp,
           nullptr, "lldb.process.internal_state_control_broadcaster"),
       m_private_state_listener_sp(
           Listener::MakeListener("lldb.process.internal_state_listener")),
-      m_current_private_state_thread(std::make_shared<PrivateStateThread>(
+      m_current_private_state_thread_sp(std::make_shared<PrivateStateThread>(
           *this, eStateUnloaded, eStateUnloaded, false, "rename-this-thread")),
       m_mod_id(), m_process_unique_id(0), m_thread_index_id(0),
       m_thread_id_to_index_id_map(), m_exit_status(-1),
@@ -1074,7 +1074,7 @@ bool Process::SetExitStatus(int status, llvm::StringRef exit_string) {
 }
 
 bool Process::IsAlive() {
-  if (!m_current_private_state_thread)
+  if (!m_current_private_state_thread_sp)
     return false;
 
   switch (GetPrivateState()) {
@@ -1250,7 +1250,7 @@ uint32_t Process::AssignIndexIDToThread(uint64_t thread_id) {
 }
 
 StateType Process::GetState() {
-  if (!m_current_private_state_thread)
+  if (!m_current_private_state_thread_sp)
     return eStateUnloaded;
 
   if (CurrentThreadPosesAsPrivateStateThread())
@@ -1275,7 +1275,7 @@ void Process::SetPublicState(StateType new_state, bool restarted) {
   LLDB_LOGF(log, "(plugin = %s, state = %s, restarted = %i)",
            GetPluginName().data(), StateAsCString(new_state), restarted);
   const StateType old_state = GetPublicState();
-  m_current_private_state_thread->SetPublicState(new_state);
+  m_current_private_state_thread_sp->SetPublicState(new_state);
 
   // On the transition from Run to Stopped, we unlock the writer end of the run
   // lock.  The lock gets locked in Resume, which is the public API to tell the
@@ -1379,7 +1379,7 @@ void Process::SetPrivateState(StateType new_state) {
   if (m_destructing)
     return;
 
-  if (!m_current_private_state_thread)
+  if (!m_current_private_state_thread_sp)
     return;
 
   Log *log(GetLog(LLDBLog::State | LLDBLog::Process | LLDBLog::Unwind));
@@ -2698,7 +2698,7 @@ Status Process::Launch(ProcessLaunchInfo &launch_info) {
     ResumePrivateStateThread();
   } else {
     StartPrivateStateThread(state_after_launch, false);
-    if (!m_current_private_state_thread) {
+    if (!m_current_private_state_thread_sp) {
       // We are not going to get any further here. The only way this could fail
       // is if we can't start a host thread, so we're pretty much toast at that
       // point.
@@ -2859,7 +2859,7 @@ Status Process::LoadCore() {
     else {
       StartPrivateStateThread(lldb::eStateStopped,
                               /*RunLock is stopped*/ false);
-      if (!m_current_private_state_thread) {
+      if (!m_current_private_state_thread_sp) {
         // We are not going to get any further here. The only way this
         // could fail is if we can't start a host thread, so we're pretty much
         //  toast at that point.
@@ -3071,7 +3071,7 @@ Status Process::Attach(ProcessAttachInfo &attach_info) {
             SetNextEventAction(new Process::AttachCompletionHandler(
                 this, attach_info.GetResumeCount()));
             StartPrivateStateThread(lldb::eStateAttaching, true);
-            if (!m_current_private_state_thread) {
+            if (!m_current_private_state_thread_sp) {
               // We are not going to get any further here.  The only way
               // this could fail is if we can't start a host thread, and we're
               // pretty much toast at that point.
@@ -3134,7 +3134,7 @@ Status Process::Attach(ProcessAttachInfo &attach_info) {
             this, attach_info.GetResumeCount()));
 
         StartPrivateStateThread(lldb::eStateAttaching, true);
-        if (!m_current_private_state_thread) {
+        if (!m_current_private_state_thread_sp) {
           // We are not going to get any further here.  The only way this
           // could fail is if we can't start a host thread, so we're pretty much
           // toast at thatpoint.
@@ -3321,7 +3321,7 @@ Status Process::ConnectRemote(llvm::StringRef remote_url) {
     else {
       StartPrivateStateThread(lldb::eStateStopped,
                               /*RunLock is stopped */ false);
-      if (!m_current_private_state_thread) {
+      if (!m_current_private_state_thread_sp) {
         // We are not going to get any further here.  The only way this
         // could fail is if we can't start a host thread, so we're pretty much
         // toast at that point.
@@ -3932,13 +3932,13 @@ bool Process::StartPrivateStateThread(lldb::StateType state,
   }
 
   if (is_secondary_thread) {
-    // StartupThread expects the m_current_private_state_thread to be in place
-    // already, so do that first:
-    m_current_private_state_thread.reset(
+    // StartupThread expects the m_current_private_state_thread_sp to be in
+    // place already, so do that first:
+    m_current_private_state_thread_sp.reset(
         new PrivateStateThread(*this, GetPublicState(), GetPrivateState(),
                                is_secondary_thread, thread_name));
   } else
-    m_current_private_state_thread->SetThreadName(thread_name);
+    m_current_private_state_thread_sp->SetThreadName(thread_name);
 
   SetPublicState(state, /*restarted=*/false);
   if (run_lock_is_running)
@@ -3946,7 +3946,7 @@ bool Process::StartPrivateStateThread(lldb::StateType state,
   else
     SetPublicRunLockToStopped();
 
-  return m_current_private_state_thread->StartupThread();
+  return m_current_private_state_thread_sp->StartupThread();
 }
 
 void Process::PausePrivateStateThread() {
@@ -3958,10 +3958,10 @@ void Process::ResumePrivateStateThread() {
 }
 
 void Process::StopPrivateStateThread() {
-  if (!m_current_private_state_thread)
+  if (!m_current_private_state_thread_sp)
     return;
 
-  if (m_current_private_state_thread->IsJoinable())
+  if (m_current_private_state_thread_sp->IsJoinable())
     ControlPrivateStateThread(eBroadcastInternalStateControlStop);
   else {
     Log *log = GetLog(LLDBLog::Process);
@@ -3981,7 +3981,7 @@ void Process::ControlPrivateStateThread(uint32_t signal) {
   LLDB_LOGF(log, "Process::%s (signal = %d)", __FUNCTION__, signal);
 
   // Signal the private state thread
-  if (m_current_private_state_thread->IsJoinable()) {
+  if (m_current_private_state_thread_sp->IsJoinable()) {
     // Broadcast the event.
     // It is important to do this outside of the if below, because it's
     // possible that the thread state is invalid but that the thread is waiting
@@ -4010,7 +4010,7 @@ void Process::ControlPrivateStateThread(uint32_t signal) {
     }
 
     if (signal == eBroadcastInternalStateControlStop)
-      m_current_private_state_thread->JoinAndReset();
+      m_current_private_state_thread_sp->JoinAndReset();
 
   } else {
     LLDB_LOGF(
@@ -5207,7 +5207,7 @@ Process::RunThreadPlan(ExecutionContext &exe_ctx,
   lldb::ThreadPlanSP stopper_base_plan_sp;
 
   Log *log(GetLog(LLDBLog::Step | LLDBLog::Process));
-  if (m_current_private_state_thread->IsOnThread(Host::GetCurrentThread())) {
+  if (m_current_private_state_thread_sp->IsOnThread(Host::GetCurrentThread())) {
     // Yikes, we are running on the private state thread!  So we can't wait for
     // public events on this thread, since we are the thread that is generating
     // public events. The simplest thing to do is to spin up a temporary thread
@@ -5216,7 +5216,7 @@ Process::RunThreadPlan(ExecutionContext &exe_ctx,
     LLDB_LOGF(log, "Running thread plan on private state thread, spinning up "
                    "another state thread to handle the events.");
 
-    backup_private_state_thread = m_current_private_state_thread;
+    backup_private_state_thread = m_current_private_state_thread_sp;
 
     // One other bit of business: we want to run just this thread plan and
     // anything it pushes, and then stop, returning control here. But in the
@@ -5230,12 +5230,12 @@ Process::RunThreadPlan(ExecutionContext &exe_ctx,
     // Have to make sure our public state is stopped, since otherwise the
     // reporting logic below doesn't work correctly.
     old_state = GetPublicState();
-    m_current_private_state_thread->SetPublicStateNoLock(eStateStopped);
+    m_current_private_state_thread_sp->SetPublicStateNoLock(eStateStopped);
 
     // Now spin up the private state thread:
     StartPrivateStateThread(lldb::eStateStopped, /* RunLock is stopped*/ false,
                             /*secondary_thread=*/true);
-    if (!m_current_private_state_thread) {
+    if (!m_current_private_state_thread_sp) {
       // If we can't spin up a thread here we can't run this expression.  But
       // presumably the old private state thread is still good, so just put it
       // back and return an error.
@@ -5243,7 +5243,7 @@ Process::RunThreadPlan(ExecutionContext &exe_ctx,
           lldb::eSeverityError,
           "could not spin up a thread to handle events for an expression"
           " run on the private state thread.");
-      m_current_private_state_thread = backup_private_state_thread;
+      m_current_private_state_thread_sp = backup_private_state_thread;
       return eExpressionSetupError;
     }
   }
@@ -5689,12 +5689,12 @@ Process::RunThreadPlan(ExecutionContext &exe_ctx,
         backup_private_state_thread->IsJoinable()) {
       StopPrivateStateThread();
       Status error;
-      m_current_private_state_thread = backup_private_state_thread;
+      m_current_private_state_thread_sp = backup_private_state_thread;
       if (stopper_base_plan_sp) {
         thread->DiscardThreadPlansUpToPlan(stopper_base_plan_sp);
       }
       if (old_state != eStateInvalid)
-        m_current_private_state_thread->SetPublicStateNoLock(old_state);
+        m_current_private_state_thread_sp->SetPublicStateNoLock(old_state);
     }
 
     // If our thread went away on us, we need to get out of here without
@@ -5997,23 +5997,25 @@ void Process::ClearPreResumeAction(PreResumeActionCallback callback, void *baton
 }
 
 ProcessRunLock &Process::GetRunLock() {
-  return m_current_private_state_thread->GetRunLock();
+  return m_current_private_state_thread_sp->GetRunLock();
 }
 
 bool Process::CurrentThreadIsPrivateStateThread()
 {
-  if (!m_current_private_state_thread)
+  if (!m_current_private_state_thread_sp)
     return true;
-  return m_current_private_state_thread->IsOnThread(Host::GetCurrentThread());
+  return m_current_private_state_thread_sp->IsOnThread(
+      Host::GetCurrentThread());
 }
 
 bool Process::CurrentThreadPosesAsPrivateStateThread() {
   // If we haven't started up the private state thread yet, then whatever thread
   // is fetching this event should be temporarily the private state thread.
-  if (!m_current_private_state_thread ||
-      !m_current_private_state_thread->IsRunning())
+  if (!m_current_private_state_thread_sp ||
+      !m_current_private_state_thread_sp->IsRunning())
     return true;
-  return m_current_private_state_thread->IsOnThread(Host::GetCurrentThread());
+  return m_current_private_state_thread_sp->IsOnThread(
+      Host::GetCurrentThread());
 }
 
 void Process::Flush() {

--- a/lldb/source/Target/ProcessTrace.cpp
+++ b/lldb/source/Target/ProcessTrace.cpp
@@ -66,7 +66,7 @@ void ProcessTrace::DidAttach(ArchSpec &process_arch) {
 
   SetCanJIT(false);
   StartPrivateStateThread(lldb::eStateStopped, false);
-  if (!m_current_private_state_thread) {
+  if (!m_current_private_state_thread_sp) {
     LLDB_LOG(GetLog(LLDBLog::Process), "ProcessTrace: failed to start private "
                                        "state thread.");
     return;


### PR DESCRIPTION
Avoids manual memory management.

Uses `shared_ptr` instead of `unique_ptr` because we store references to the current thread in a backup variable.

Simplifies the private thread `is_secondary` semantics by providing a backup storage for the current thread instead of a boolean value with a contract to manage the backup separately.