### PR TITLE
[MLIR][DataFlow] Fix two crashes in DeadCodeAnalysis on empty/no-terminator regions

### DIFF
--- a/mlir/lib/Analysis/DataFlow/DeadCodeAnalysis.cpp
+++ b/mlir/lib/Analysis/DataFlow/DeadCodeAnalysis.cpp
@@ -249,6 +249,7 @@ void DeadCodeAnalysis::initializeSymbolCallables(Operation *top) {
 static bool isRegionOrCallableReturn(Operation *op) {
   return op->getBlock() != nullptr && !op->getNumSuccessors() &&
          isa<RegionBranchOpInterface, CallableOpInterface>(op->getParentOp()) &&
+         op->getBlock()->mightHaveTerminator() &&
          op->getBlock()->getTerminator() == op;
 }
 
@@ -521,6 +522,9 @@ void DeadCodeAnalysis::visitRegionBranchEdges(
     const SmallVector<RegionSuccessor> &successors) {
   for (const RegionSuccessor &successor : successors) {
     // The successor can be either an entry block or the parent operation.
+    // Skip empty regions — they have no entry block to mark executable.
+    if (!successor.isParent() && successor.getSuccessor()->empty())
+      continue;
     ProgramPoint *point =
         successor.isParent()
             ? getProgramPointAfter(regionBranchOp)

--- a/mlir/test/Transforms/sccp.mlir
+++ b/mlir/test/Transforms/sccp.mlir
@@ -255,3 +255,34 @@ func.func @no_crash_with_different_source_type() {
   %1 = vector.broadcast %0 : i64 to vector<128xi64>
   llvm.return
 }
+
+// -----
+
+// Regression test for https://github.com/llvm/llvm-project/issues/187972
+// DeadCodeAnalysis::visitRegionBranchEdges must not dereference the front()
+// of an empty region (acc.serial with no blocks).
+
+// CHECK-LABEL: no_crash_acc_serial_empty_region
+func.func @no_crash_acc_serial_empty_region() {
+  // CHECK: acc.serial
+  acc.serial {
+  }
+  return
+}
+
+// -----
+
+// Regression test for https://github.com/llvm/llvm-project/issues/188408
+// isRegionOrCallableReturn must guard getTerminator() with mightHaveTerminator()
+// to avoid asserting on blocks in nested acc regions without terminators.
+
+// CHECK-LABEL: no_crash_acc_kernel_environment
+func.func @no_crash_acc_kernel_environment(%data: memref<8xi32>) {
+  // CHECK: acc.kernel_environment
+  acc.kernel_environment {
+    acc.compute_region {
+      acc.yield
+    } {origin = "acc.parallel"}
+  }
+  return
+}


### PR DESCRIPTION
Two related assertion failures in DeadCodeAnalysis when processing OpenACC operations:

1. visitRegionBranchEdges (issue #187972): When a RegionSuccessor refers to an empty region (no blocks), calling getSuccessor()->front() dereferences a sentinel ilist iterator, crashing with "\!NodePtr->isKnownSentinel()". Fix: skip successors whose region is empty.

2. isRegionOrCallableReturn (issue #188408): When iterating over ops in a nested acc region whose blocks do not have a required terminator, Block::getTerminator() is called without first checking mightHaveTerminator(), triggering "Assertion `mightHaveTerminator()' failed". Fix: guard the getTerminator() call with mightHaveTerminator().

Fixes #187972, #188408

Assisted-by: Claude Code