### PR TITLE
[WebAssembly][NFC] use getOneBitSet instead init + shifting for APint

### DIFF
--- a/llvm/lib/Target/WebAssembly/WebAssemblyISelLowering.cpp
+++ b/llvm/lib/Target/WebAssembly/WebAssemblyISelLowering.cpp
@@ -3787,7 +3787,7 @@ static SDValue performShiftCombine(SDNode *N,
     if (ShiftAmt.uge(MaxValidShift))
       return SDValue();
 
-    APInt MulAmt = APInt::getOneBitSet(BitWidth, ShiftAmt);
+    APInt MulAmt = APInt::getOneBitSet(BitWidth, ShiftAmt.getZExtValue());
     MulConsts.push_back(DAG.getConstant(MulAmt, DL, FromVT.getScalarType(),
                                         /*isTarget=*/false, /*isOpaque=*/true));
   }

--- a/llvm/lib/Target/WebAssembly/WebAssemblyISelLowering.cpp
+++ b/llvm/lib/Target/WebAssembly/WebAssemblyISelLowering.cpp
@@ -3787,7 +3787,7 @@ static SDValue performShiftCombine(SDNode *N,
     if (ShiftAmt.uge(MaxValidShift))
       return SDValue();
 
-    APInt MulAmt = APInt(BitWidth, 1).shl(ShiftAmt);
+    APInt MulAmt = APInt::getOneBitSet(BitWidth, ShiftAmt);
     MulConsts.push_back(DAG.getConstant(MulAmt, DL, FromVT.getScalarType(),
                                         /*isTarget=*/false, /*isOpaque=*/true));
   }


### PR DESCRIPTION
This is valid due to `ShiftAmt < BitWidth` which is ensured by early `ShiftAmt.uge(MaxValidShift)` testing.