### PR TITLE
[MLIR][SCFToOpenMP] Fix crash when scf.parallel uses non-LLVM-compatible reduction type

### DIFF
--- a/mlir/lib/Conversion/SCFToOpenMP/SCFToOpenMP.cpp
+++ b/mlir/lib/Conversion/SCFToOpenMP/SCFToOpenMP.cpp
@@ -412,6 +412,16 @@ struct ParallelOpLowering : public OpRewritePattern<scf::ParallelOp> {
 
   LogicalResult matchAndRewrite(scf::ParallelOp parallelOp,
                                 PatternRewriter &rewriter) const override {
+    // Bail out early if any reduction init value has a type that is not
+    // compatible with LLVM (e.g. index), since we cannot allocate a reduction
+    // variable for such types.
+    for (Value init : parallelOp.getInitVals()) {
+      if (!LLVM::isCompatibleType(init.getType()) &&
+          !isa<LLVM::PointerElementTypeInterface>(init.getType()))
+        return rewriter.notifyMatchFailure(
+            parallelOp, "reduction init type is not an LLVM-compatible type");
+    }
+
     // Declare reductions.
     // TODO: consider checking it here is already a compatible reduction
     // declaration and use it instead of redeclaring.
@@ -437,10 +447,6 @@ struct ParallelOpLowering : public OpRewritePattern<scf::ParallelOp> {
     reductionVariables.reserve(parallelOp.getNumReductions());
     auto ptrType = LLVM::LLVMPointerType::get(parallelOp.getContext());
     for (Value init : parallelOp.getInitVals()) {
-      assert((LLVM::isCompatibleType(init.getType()) ||
-              isa<LLVM::PointerElementTypeInterface>(init.getType())) &&
-             "cannot create a reduction variable if the type is not an LLVM "
-             "pointer element");
       Value storage = LLVM::AllocaOp::create(rewriter, loc, ptrType,
                                              init.getType(), one, 0);
       LLVM::StoreOp::create(rewriter, loc, init, storage);

--- a/mlir/test/Conversion/SCFToOpenMP/non-llvm-reduction-type.mlir
+++ b/mlir/test/Conversion/SCFToOpenMP/non-llvm-reduction-type.mlir
@@ -1,0 +1,28 @@
+// RUN: not mlir-opt -convert-scf-to-openmp %s 2>&1 | FileCheck %s
+
+// Regression test for https://github.com/llvm/llvm-project/issues/61342
+// Verify that -convert-scf-to-openmp does not crash when an scf.parallel
+// reduction uses a type that is not an LLVM-compatible type (e.g. index).
+// Instead of asserting, the pass must fail gracefully.
+
+// CHECK: unconverted operation found
+
+func.func @no_crash_index_reduction(%A: index, %B: index) -> (index, index) {
+  %c1 = arith.constant 1 : index
+  %c2 = arith.constant 2 : index
+  %c3 = arith.constant 3 : index
+  %c6 = arith.constant 6 : index
+  %0:2 = scf.parallel (%i0, %i1) = (%c1, %c3) to (%c2, %c6) step (%c1, %c3)
+      init (%A, %B) -> (index, index) {
+    scf.reduce(%i0, %i1 : index, index) {
+    ^bb0(%lhs0: index, %rhs0: index):
+      %r0 = arith.addi %lhs0, %rhs0 : index
+      scf.reduce.return %r0 : index
+    }, {
+    ^bb0(%lhs1: index, %rhs1: index):
+      %r1 = arith.muli %lhs1, %rhs1 : index
+      scf.reduce.return %r1 : index
+    }
+  }
+  return %0#0, %0#1 : index, index
+}


### PR DESCRIPTION
Replace the assert in ParallelOpLowering::matchAndRewrite that fires when an scf.parallel reduction init value has a type incompatible with LLVM (e.g. index) with an early notifyMatchFailure call, so the pass fails gracefully instead of crashing.

Add a regression test that verifies the pass emits an error instead of asserting.

Fixes #61342

Assisted-by: Claude Code