### PR TITLE
[CIR][NFC] Fix llvm.returnaddress call in tests

### DIFF
--- a/clang/test/CIR/CodeGen/ms-intrinsics.c
+++ b/clang/test/CIR/CodeGen/ms-intrinsics.c
@@ -32,10 +32,10 @@ void *test_ReturnAddress(void) {
   // CIR: {{%.*}} = cir.return_address([[ARG]])
 
   // LLVM-LABEL: test_ReturnAddress
-  // LLVM: {{%.*}} = call ptr @llvm.returnaddress(i32 0)
+  // LLVM: {{%.*}} = call ptr @llvm.returnaddress.p0(i32 0)
 
   // OGCG-LABEL: test_ReturnAddress
-  // OGCG: {{%.*}} = call ptr @llvm.returnaddress(i32 0)
+  // OGCG: {{%.*}} = call ptr @llvm.returnaddress.p0(i32 0)
 }
 
 #if defined(__i386__) || defined(__x86_64__) || defined (__aarch64__)

--- a/clang/test/CIR/CodeGenBuiltins/builtins.cpp
+++ b/clang/test/CIR/CodeGenBuiltins/builtins.cpp
@@ -21,10 +21,10 @@ extern "C" void *test_return_address(void) {
   // CIR: {{%.*}} = cir.return_address([[ARG]])
 
   // LLVM-LABEL: @test_return_address
-  // LLVM: {{%.*}} = call ptr @llvm.returnaddress(i32 1)
+  // LLVM: {{%.*}} = call ptr @llvm.returnaddress.p0(i32 1)
 
   // OGCG-LABEL: @test_return_address
-  // OGCG: {{%.*}} = call ptr @llvm.returnaddress(i32 1)
+  // OGCG: {{%.*}} = call ptr @llvm.returnaddress.p0(i32 1)
 }
 
 extern "C" void *test_frame_address(void) {


### PR DESCRIPTION
Fix llvm.returnaddress call in tests after changes from #188464