### PR TITLE
[llvm-profgen] Fix break to continue in PrologEpilogTracker loops

### DIFF
--- a/llvm/tools/llvm-profgen/ProfiledBinary.h
+++ b/llvm/tools/llvm-profgen/ProfiledBinary.h
@@ -129,7 +129,7 @@ struct PrologEpilogTracker {
       PrologEpilogSet.insert(I.first);
       InstructionPointer IP(Binary, I.first);
       if (!IP.advance())
-        break;
+        continue;
       PrologEpilogSet.insert(IP.Address);
     }
   }
@@ -140,7 +140,7 @@ struct PrologEpilogTracker {
       PrologEpilogSet.insert(Addr);
       InstructionPointer IP(Binary, Addr);
       if (!IP.backward())
-        break;
+        continue;
       PrologEpilogSet.insert(IP.Address);
     }
   }


### PR DESCRIPTION
In inferPrologAddresses and inferEpilogAddresses, using `break` incorrectly stops processing all remaining entries when a single IP.advance() or IP.backward() fails. Change to `continue` so that only the failing entry is skipped.