### PR TITLE
[TargetLowering] Use APInt::setAllBits() instead of assigning -1.

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/TargetLowering.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/TargetLowering.cpp
@@ -7169,7 +7169,7 @@ TargetLowering::prepareUREMEqFold(EVT SETCCVT, SDValue REMNode,
       K = -1;
       // And ensure that comparison constant is tautological,
       // it will always compare true/false.
-      Q = -1;
+      Q.setAllBits();
     }
 
     PAmts.push_back(DAG.getConstant(P, DL, SVT));
@@ -7436,11 +7436,11 @@ TargetLowering::prepareSREMEqFold(EVT SETCCVT, SDValue REMNode,
     if (D.isOne()) {
       // Set P, A and K to a bogus values so we can try to splat them.
       P = 0;
-      A = -1;
+      A.setAllBits();
       K = -1;
 
       // x ?% 1 == 0  <-->  true  <-->  x u<= -1
-      Q = -1;
+      Q.setAllBits();
     }
 
     PAmts.push_back(DAG.getConstant(P, DL, SVT));


### PR DESCRIPTION
The -1 has 'int' type. The APInt assignment operator takes uint64_t. Fortunately, due to C rules, the -1 will be converted to an all ones uint64_t. Unfortunately, if the APInt has more than 64 bits, the upper words will be zeroed. I don't think we have any testing of that today.

Use setAllBits to avoid the subtle cast and fix the bits > 64 issue.

K still has its own issue that needs to be fixed.