### PR TITLE
[MLIR] Fix crash in alias printer when encountering null operands

### DIFF
--- a/mlir/lib/IR/AsmPrinter.cpp
+++ b/mlir/lib/IR/AsmPrinter.cpp
@@ -752,9 +752,12 @@ private:
                     /*printBlockTerminators=*/true);
     }
 
-    // Visit all the types used in the operation.
-    for (Type type : op->getOperandTypes())
-      printType(type);
+    // Visit all the types used in the operation. Null operands/types can
+    // occur when operating on invalid IR (e.g., with
+    // --mlir-very-unsafe-disable-verifier-on-parsing), so guard against them.
+    for (Value operand : op->getOperands())
+      if (operand && operand.getType())
+        printType(operand.getType());
     for (Type type : op->getResultTypes())
       printType(type);
 
@@ -820,7 +823,10 @@ private:
   }
 
   /// Consider the given type to be printed for an alias.
-  void printType(Type type) override { initializer.visit(type); }
+  void printType(Type type) override {
+    if (type)
+      initializer.visit(type);
+  }
 
   /// Consider the given attribute to be printed for an alias.
   void printAttribute(Attribute attr) override { initializer.visit(attr); }
@@ -970,6 +976,8 @@ private:
     }
   }
   void printAndVisitNestedAliasesImpl(Type type) {
+    if (!type)
+      return;
     if (!isa<BuiltinDialect>(type.getDialect()))
       return type.getDialect().printType(type, *this);
 

--- a/mlir/test/IR/print-unsafe-null-operand.mlir
+++ b/mlir/test/IR/print-unsafe-null-operand.mlir
@@ -1,0 +1,15 @@
+// RUN: mlir-opt %s --mlir-very-unsafe-disable-verifier-on-parsing 2>&1 | FileCheck %s
+//
+// Regression test for https://github.com/llvm/llvm-project/issues/182747
+// Verify that printing does not crash when an operation has a null operand
+// due to an unresolvable forward reference created with
+// --mlir-very-unsafe-disable-verifier-on-parsing.
+
+// CHECK: "scf.if"(<<NULL VALUE>>)
+// CHECK: <<NULL TYPE>>
+func.func @t() {
+  scf.if %c {
+    %c = arith.constant true
+  }
+  return
+}


### PR DESCRIPTION
When the IR contains operations with null operand values, the DummyAliasOperationPrinter used during alias collection crashed when iterating over operand types via op->getOperandTypes(), because ValueTypeIterator::mapElement calls value.getType() on each operand, which dereferences null for a null Value.

Fix the crash by:
1. Iterating over operand values directly in printGenericOp, skipping any null operands.
2. Adding a null-type guard in printType so that null types are silently skipped.
3. Adding a null-type guard at the top of printAndVisitNestedAliasesImpl to avoid crashing when visiting sub-elements of a null type.

The test requires using --mlir-very-unsafe-disable-verifier-on-parsing to construct the invalid IR.

Fixes #182747

Assisted-by: Claude Code