### PR TITLE
[ObjCARC] Optimize MayAutorelease by skipping over pools

### DIFF
--- a/llvm/lib/Transforms/ObjCARC/ObjCARCOpts.cpp
+++ b/llvm/lib/Transforms/ObjCARC/ObjCARCOpts.cpp
@@ -2502,17 +2502,32 @@ bool MayAutorelease(const CallBase &CB, unsigned Depth = 0) {
     if (!Callee->hasExactDefinition())
       return true;
     for (const BasicBlock &BB : *Callee) {
+      // Track nested autorelease pools in a single pass. Autoreleases inside a
+      // pool are drained before the pool ends; only effects at function scope
+      // (empty stack) or in a pool not closed in this block matter.
+      SmallVector<bool, 4> PoolStack;
       for (const Instruction &I : BB) {
-        // TODO: Ignore all instructions between autorelease pools
         ARCInstKind InstKind = GetBasicARCInstKind(&I);
         switch (InstKind) {
+        case ARCInstKind::AutoreleasepoolPush:
+          PoolStack.push_back(false);
+          break;
+
+        case ARCInstKind::AutoreleasepoolPop:
+          if (!PoolStack.empty())
+            PoolStack.pop_back();
+          break;
+
         case ARCInstKind::Autorelease:
         case ARCInstKind::AutoreleaseRV:
         case ARCInstKind::FusedRetainAutorelease:
         case ARCInstKind::FusedRetainAutoreleaseRV:
         case ARCInstKind::LoadWeak:
           // These may produce autoreleases
-          return true;
+          if (PoolStack.empty())
+            return true;
+          PoolStack.back() = true;
+          break;
 
         case ARCInstKind::Retain:
         case ARCInstKind::RetainRV:
@@ -2527,16 +2542,17 @@ bool MayAutorelease(const CallBase &CB, unsigned Depth = 0) {
         case ARCInstKind::CopyWeak:
         case ARCInstKind::DestroyWeak:
         case ARCInstKind::StoreStrong:
-        case ARCInstKind::AutoreleasepoolPush:
-        case ARCInstKind::AutoreleasepoolPop:
           // These ObjC runtime functions don't produce autoreleases
           break;
 
         case ARCInstKind::CallOrUser:
         case ARCInstKind::Call:
-          // For non-ObjC function calls, recursively analyze
-          if (MayAutorelease(cast<CallBase>(I), Depth + 1))
-            return true;
+          // For non-ObjC function calls, recursively analyze.
+          if (MayAutorelease(cast<CallBase>(I), Depth + 1)) {
+            if (PoolStack.empty())
+              return true;
+            PoolStack.back() = true;
+          }
           break;
 
         case ARCInstKind::IntrinsicUser:
@@ -2546,6 +2562,8 @@ bool MayAutorelease(const CallBase &CB, unsigned Depth = 0) {
           break;
         }
       }
+      if (!PoolStack.empty() && llvm::is_contained(PoolStack, true))
+        return true;
     }
     return false;
   }

--- a/llvm/test/Transforms/ObjCARC/test_autorelease_pool.ll
+++ b/llvm/test/Transforms/ObjCARC/test_autorelease_pool.ll
@@ -314,6 +314,37 @@ define ptr @function_that_might_autorelease() {
   ret ptr %autoreleased
 }
 
+; Cross-function: callee has its own inner pool containing an autorelease.
+; The caller's pool should be optimizable since the callee's autorelease
+; is contained within the callee's own pool.
+define void @test_cross_function_inner_pool_caller() {
+; CHECK-LABEL: define void @test_cross_function_inner_pool_caller() {
+; CHECK-NEXT:    [[POOL:%.*]] = call ptr @llvm.objc.autoreleasePoolPush() #[[ATTR0]]
+; CHECK-NEXT:    call void @test_cross_function_inner_pool_callee()
+; CHECK-NEXT:    call void @llvm.objc.autoreleasePoolPop(ptr [[POOL]]) #[[ATTR0]]
+; CHECK-NEXT:    ret void
+;
+  %pool = call ptr @llvm.objc.autoreleasePoolPush()
+  call void @test_cross_function_inner_pool_callee()
+  call void @llvm.objc.autoreleasePoolPop(ptr %pool)
+  ret void
+}
+
+define void @test_cross_function_inner_pool_callee() {
+; CHECK-LABEL: define void @test_cross_function_inner_pool_callee() {
+; CHECK-NEXT:    [[INNER_POOL:%.*]] = call ptr @llvm.objc.autoreleasePoolPush() #[[ATTR0]]
+; CHECK-NEXT:    [[OBJ:%.*]] = call ptr @create_object()
+; CHECK-NEXT:    call void @llvm.objc.release(ptr [[OBJ]]) #[[ATTR0]], !clang.imprecise_release [[META0]]
+; CHECK-NEXT:    call void @llvm.objc.autoreleasePoolPop(ptr [[INNER_POOL]]) #[[ATTR0]]
+; CHECK-NEXT:    ret void
+;
+  %inner_pool = call ptr @llvm.objc.autoreleasePoolPush()
+  %obj = call ptr @create_object()
+  %ar = call ptr @llvm.objc.autorelease(ptr %obj)
+  call void @llvm.objc.autoreleasePoolPop(ptr %inner_pool)
+  ret void
+}
+
 ;.
 ; CHECK: [[META0]] = !{}
 ;.

--- a/llvm/test/Transforms/ObjCARC/test_autorelease_pool.ll
+++ b/llvm/test/Transforms/ObjCARC/test_autorelease_pool.ll
@@ -319,9 +319,7 @@ define ptr @function_that_might_autorelease() {
 ; is contained within the callee's own pool.
 define void @test_cross_function_inner_pool_caller() {
 ; CHECK-LABEL: define void @test_cross_function_inner_pool_caller() {
-; CHECK-NEXT:    [[POOL:%.*]] = call ptr @llvm.objc.autoreleasePoolPush() #[[ATTR0]]
 ; CHECK-NEXT:    call void @test_cross_function_inner_pool_callee()
-; CHECK-NEXT:    call void @llvm.objc.autoreleasePoolPop(ptr [[POOL]]) #[[ATTR0]]
 ; CHECK-NEXT:    ret void
 ;
   %pool = call ptr @llvm.objc.autoreleasePoolPush()


### PR DESCRIPTION
This enables the ARC optimizer to remove autoreleasePoolPush/Pop pairs that were previously retained. By skipping over nested autorelease pools, MayAutorelease now correctly recognizes that autoreleases contained within an inner pool do not escape, allowing the removal of outer pool boundaries.