### PR TITLE
Add missing CLANG_ABI annotations to enable building clang and llvm shared libraries on Windows

### DIFF
--- a/clang/include/clang/AST/ASTContext.h
+++ b/clang/include/clang/AST/ASTContext.h
@@ -44,6 +44,7 @@
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/StringSet.h"
 #include "llvm/ADT/TinyPtrVector.h"
+#include "clang/Support/Compiler.h"
 #include "llvm/Support/TypeSize.h"
 #include <optional>
 
@@ -1389,19 +1390,19 @@ public:
   /// are stored here.
   llvm::DenseMap<const CXXMethodDecl *, CXXCastPath> LambdaCastPaths;
 
-  ASTContext(LangOptions &LOpts, SourceManager &SM, IdentifierTable &idents,
+  CLANG_ABI ASTContext(LangOptions &LOpts, SourceManager &SM, IdentifierTable &idents,
              SelectorTable &sels, Builtin::Context &builtins,
              TranslationUnitKind TUKind);
   ASTContext(const ASTContext &) = delete;
   ASTContext &operator=(const ASTContext &) = delete;
-  ~ASTContext();
+  CLANG_ABI ~ASTContext();
 
   /// Attach an external AST source to the AST context.
   ///
   /// The external AST source provides the ability to load parts of
   /// the abstract syntax tree as needed from some external storage,
   /// e.g., a precompiled header.
-  void setExternalSource(IntrusiveRefCntPtr<ExternalASTSource> Source);
+  CLANG_ABI void setExternalSource(IntrusiveRefCntPtr<ExternalASTSource> Source);
 
   /// Retrieve a pointer to the external AST source associated
   /// with this AST context, if any.
@@ -3672,7 +3673,7 @@ public:
   /// It is normally invoked after ASTContext construction.
   ///
   /// \param Target The target
-  void InitBuiltinTypes(const TargetInfo &Target,
+  CLANG_ABI void InitBuiltinTypes(const TargetInfo &Target,
                         const TargetInfo *AuxTarget = nullptr);
 
 private:

--- a/clang/include/clang/AST/ASTContext.h
+++ b/clang/include/clang/AST/ASTContext.h
@@ -30,6 +30,7 @@
 #include "clang/Basic/LLVM.h"
 #include "clang/Basic/PartialDiagnostic.h"
 #include "clang/Basic/SourceLocation.h"
+#include "clang/Support/Compiler.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/DenseMapInfo.h"
 #include "llvm/ADT/DenseSet.h"
@@ -44,7 +45,6 @@
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/StringSet.h"
 #include "llvm/ADT/TinyPtrVector.h"
-#include "clang/Support/Compiler.h"
 #include "llvm/Support/TypeSize.h"
 #include <optional>
 
@@ -1390,9 +1390,9 @@ public:
   /// are stored here.
   llvm::DenseMap<const CXXMethodDecl *, CXXCastPath> LambdaCastPaths;
 
-  CLANG_ABI ASTContext(LangOptions &LOpts, SourceManager &SM, IdentifierTable &idents,
-             SelectorTable &sels, Builtin::Context &builtins,
-             TranslationUnitKind TUKind);
+  CLANG_ABI ASTContext(LangOptions &LOpts, SourceManager &SM,
+                       IdentifierTable &idents, SelectorTable &sels,
+                       Builtin::Context &builtins, TranslationUnitKind TUKind);
   ASTContext(const ASTContext &) = delete;
   ASTContext &operator=(const ASTContext &) = delete;
   CLANG_ABI ~ASTContext();
@@ -1402,7 +1402,8 @@ public:
   /// The external AST source provides the ability to load parts of
   /// the abstract syntax tree as needed from some external storage,
   /// e.g., a precompiled header.
-  CLANG_ABI void setExternalSource(IntrusiveRefCntPtr<ExternalASTSource> Source);
+  CLANG_ABI void
+  setExternalSource(IntrusiveRefCntPtr<ExternalASTSource> Source);
 
   /// Retrieve a pointer to the external AST source associated
   /// with this AST context, if any.
@@ -3674,7 +3675,7 @@ public:
   ///
   /// \param Target The target
   CLANG_ABI void InitBuiltinTypes(const TargetInfo &Target,
-                        const TargetInfo *AuxTarget = nullptr);
+                                  const TargetInfo *AuxTarget = nullptr);
 
 private:
   void InitBuiltinType(CanQualType &R, BuiltinType::Kind K);

--- a/clang/include/clang/AST/ExternalASTMerger.h
+++ b/clang/include/clang/AST/ExternalASTMerger.h
@@ -16,6 +16,7 @@
 #include "clang/AST/ASTImporter.h"
 #include "clang/AST/ASTImporterSharedState.h"
 #include "clang/AST/ExternalASTSource.h"
+#include "clang/Support/Compiler.h"
 #include "llvm/Support/raw_ostream.h"
 
 namespace clang {
@@ -112,7 +113,7 @@ private:
   std::shared_ptr<ASTImporterSharedState> SharedState;
 
 public:
-  ExternalASTMerger(const ImporterTarget &Target,
+  CLANG_ABI ExternalASTMerger(const ImporterTarget &Target,
                     ArrayRef<ImporterSource> Sources);
 
   /// Asks all connected ASTImporters if any of them imported the given
@@ -137,7 +138,7 @@ public:
   ///
   /// The caller is responsible for ensuring that this doesn't leave
   /// DeclContexts that can't be completed.
-  void RemoveSources(ArrayRef<ImporterSource> Sources);
+  CLANG_ABI void RemoveSources(ArrayRef<ImporterSource> Sources);
 
   /// Implementation of the ExternalASTSource API.
   bool FindExternalVisibleDeclsByName(const DeclContext *DC,

--- a/clang/include/clang/AST/ExternalASTMerger.h
+++ b/clang/include/clang/AST/ExternalASTMerger.h
@@ -114,7 +114,7 @@ private:
 
 public:
   CLANG_ABI ExternalASTMerger(const ImporterTarget &Target,
-                    ArrayRef<ImporterSource> Sources);
+                              ArrayRef<ImporterSource> Sources);
 
   /// Asks all connected ASTImporters if any of them imported the given
   /// declaration. If any ASTImporter did import the given declaration,

--- a/clang/include/clang/Basic/Builtins.h
+++ b/clang/include/clang/Basic/Builtins.h
@@ -19,6 +19,7 @@
 #include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/StringTable.h"
+#include "clang/Support/Compiler.h"
 #include "llvm/TargetParser/Triple.h"
 #include <cstring>
 
@@ -242,7 +243,7 @@ class Context {
   unsigned NumAuxTargetBuiltins = 0;
 
 public:
-  Context();
+  CLANG_ABI Context();
 
   /// Perform target-specific initialization
   /// \param AuxTarget Target info to incorporate builtins from. May be nullptr.

--- a/clang/include/clang/Basic/Builtins.h
+++ b/clang/include/clang/Basic/Builtins.h
@@ -15,11 +15,11 @@
 #ifndef LLVM_CLANG_BASIC_BUILTINS_H
 #define LLVM_CLANG_BASIC_BUILTINS_H
 
+#include "clang/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/StringTable.h"
-#include "clang/Support/Compiler.h"
 #include "llvm/TargetParser/Triple.h"
 #include <cstring>
 

--- a/clang/include/clang/Basic/Diagnostic.h
+++ b/clang/include/clang/Basic/Diagnostic.h
@@ -19,6 +19,7 @@
 #include "clang/Basic/SourceLocation.h"
 #include "clang/Basic/Specifiers.h"
 #include "clang/Basic/UnsignedOrNone.h"
+#include "clang/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/FunctionExtras.h"
@@ -27,7 +28,6 @@
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/iterator_range.h"
-#include "clang/Support/Compiler.h"
 #include <cassert>
 #include <cstdint>
 #include <limits>
@@ -1792,7 +1792,7 @@ public:
   /// The default implementation just keeps track of the total number of
   /// warnings and errors.
   CLANG_ABI virtual void HandleDiagnostic(DiagnosticsEngine::Level DiagLevel,
-                                const Diagnostic &Info);
+                                          const Diagnostic &Info);
 };
 
 /// A diagnostic client that ignores all diagnostics.

--- a/clang/include/clang/Basic/Diagnostic.h
+++ b/clang/include/clang/Basic/Diagnostic.h
@@ -27,7 +27,7 @@
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/iterator_range.h"
-#include "llvm/Support/Compiler.h"
+#include "clang/Support/Compiler.h"
 #include <cassert>
 #include <cstdint>
 #include <limits>
@@ -588,7 +588,7 @@ public:
                              bool ShouldOwnClient = true);
   DiagnosticsEngine(const DiagnosticsEngine &) = delete;
   DiagnosticsEngine &operator=(const DiagnosticsEngine &) = delete;
-  ~DiagnosticsEngine();
+  CLANG_ABI ~DiagnosticsEngine();
 
   friend void DiagnosticsTestHelper(DiagnosticsEngine &);
   LLVM_DUMP_METHOD void dump() const;
@@ -1682,7 +1682,7 @@ public:
   /// formal arguments into the %0 slots.
   ///
   /// The result is appended onto the \p OutStr array.
-  void FormatDiagnostic(SmallVectorImpl<char> &OutStr) const;
+  CLANG_ABI void FormatDiagnostic(SmallVectorImpl<char> &OutStr) const;
 
   /// Format the given format-string into the output buffer using the
   /// arguments stored in this diagnostic.
@@ -1752,7 +1752,7 @@ protected:
 
 public:
   DiagnosticConsumer() = default;
-  virtual ~DiagnosticConsumer();
+  CLANG_ABI virtual ~DiagnosticConsumer();
 
   unsigned getNumErrors() const { return NumErrors; }
   unsigned getNumWarnings() const { return NumWarnings; }
@@ -1784,14 +1784,14 @@ public:
   /// reported by DiagnosticsEngine.
   ///
   /// The default implementation returns true.
-  virtual bool IncludeInDiagnosticCounts() const;
+  CLANG_ABI virtual bool IncludeInDiagnosticCounts() const;
 
   /// Handle this diagnostic, reporting it to the user or
   /// capturing it to a log as needed.
   ///
   /// The default implementation just keeps track of the total number of
   /// warnings and errors.
-  virtual void HandleDiagnostic(DiagnosticsEngine::Level DiagLevel,
+  CLANG_ABI virtual void HandleDiagnostic(DiagnosticsEngine::Level DiagLevel,
                                 const Diagnostic &Info);
 };
 
@@ -1819,7 +1819,7 @@ public:
                         const Diagnostic &Info) override;
   void clear() override;
 
-  bool IncludeInDiagnosticCounts() const override;
+  CLANG_ABI bool IncludeInDiagnosticCounts() const override;
 };
 
 // Struct used for sending info about how a type should be printed.

--- a/clang/include/clang/Basic/FileManager.h
+++ b/clang/include/clang/Basic/FileManager.h
@@ -18,6 +18,7 @@
 #include "clang/Basic/FileEntry.h"
 #include "clang/Basic/FileSystemOptions.h"
 #include "clang/Basic/LLVM.h"
+#include "clang/Support/Compiler.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/IntrusiveRefCntPtr.h"
 #include "llvm/ADT/PointerUnion.h"
@@ -25,7 +26,6 @@
 #include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/Allocator.h"
-#include "clang/Support/Compiler.h"
 #include "llvm/Support/ErrorOr.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/VirtualFileSystem.h"
@@ -193,9 +193,9 @@ public:
   /// \param CacheFailure If true and the file does not exist, we'll cache
   /// the failure to find this file.
   CLANG_ABI llvm::Expected<FileEntryRef> getFileRef(StringRef Filename,
-                                          bool OpenFile = false,
-                                          bool CacheFailure = true,
-                                          bool IsText = true);
+                                                    bool OpenFile = false,
+                                                    bool CacheFailure = true,
+                                                    bool IsText = true);
 
   /// Get the FileEntryRef for stdin, returning an error if stdin cannot be
   /// read.

--- a/clang/include/clang/Basic/FileManager.h
+++ b/clang/include/clang/Basic/FileManager.h
@@ -25,6 +25,7 @@
 #include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/Allocator.h"
+#include "clang/Support/Compiler.h"
 #include "llvm/Support/ErrorOr.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/VirtualFileSystem.h"
@@ -191,7 +192,7 @@ public:
   ///
   /// \param CacheFailure If true and the file does not exist, we'll cache
   /// the failure to find this file.
-  llvm::Expected<FileEntryRef> getFileRef(StringRef Filename,
+  CLANG_ABI llvm::Expected<FileEntryRef> getFileRef(StringRef Filename,
                                           bool OpenFile = false,
                                           bool CacheFailure = true,
                                           bool IsText = true);

--- a/clang/include/clang/Basic/IdentifierTable.h
+++ b/clang/include/clang/Basic/IdentifierTable.h
@@ -20,6 +20,7 @@
 #include "clang/Basic/LLVM.h"
 #include "clang/Basic/SourceLocation.h"
 #include "clang/Basic/TokenKinds.h"
+#include "clang/Support/Compiler.h"
 #include "llvm/ADT/DenseMapInfo.h"
 #include "llvm/ADT/FoldingSet.h"
 #include "llvm/ADT/PointerIntPair.h"
@@ -28,7 +29,6 @@
 #include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/Allocator.h"
-#include "clang/Support/Compiler.h"
 #include "llvm/Support/PointerLikeTypeTraits.h"
 #include "llvm/Support/type_traits.h"
 #include <cassert>

--- a/clang/include/clang/Basic/IdentifierTable.h
+++ b/clang/include/clang/Basic/IdentifierTable.h
@@ -28,6 +28,7 @@
 #include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/Allocator.h"
+#include "clang/Support/Compiler.h"
 #include "llvm/Support/PointerLikeTypeTraits.h"
 #include "llvm/Support/type_traits.h"
 #include <cassert>
@@ -1202,10 +1203,10 @@ class SelectorTable {
   void *Impl;
 
 public:
-  SelectorTable();
+  CLANG_ABI SelectorTable();
   SelectorTable(const SelectorTable &) = delete;
   SelectorTable &operator=(const SelectorTable &) = delete;
-  ~SelectorTable();
+  CLANG_ABI ~SelectorTable();
 
   /// Can create any sort of selector.
   ///

--- a/clang/include/clang/Basic/LangOptions.h
+++ b/clang/include/clang/Basic/LangOptions.h
@@ -26,6 +26,7 @@
 #include "llvm/ADT/StringRef.h"
 #include "llvm/BinaryFormat/DXContainer.h"
 #include "llvm/Support/AllocToken.h"
+#include "clang/Support/Compiler.h"
 #include "llvm/TargetParser/Triple.h"
 #include <optional>
 #include <string>
@@ -613,7 +614,7 @@ public:
   /// The allocation token mode.
   std::optional<llvm::AllocTokenMode> AllocTokenMode;
 
-  LangOptions();
+  CLANG_ABI LangOptions();
 
   /// Set language defaults for the given input language and
   /// language standard in the given LangOptions object.

--- a/clang/include/clang/Basic/LangOptions.h
+++ b/clang/include/clang/Basic/LangOptions.h
@@ -22,11 +22,11 @@
 #include "clang/Basic/Sanitizers.h"
 #include "clang/Basic/TargetCXXABI.h"
 #include "clang/Basic/Visibility.h"
+#include "clang/Support/Compiler.h"
 #include "llvm/ADT/FloatingPointMode.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/BinaryFormat/DXContainer.h"
 #include "llvm/Support/AllocToken.h"
-#include "clang/Support/Compiler.h"
 #include "llvm/TargetParser/Triple.h"
 #include <optional>
 #include <string>

--- a/clang/include/clang/Basic/SourceLocation.h
+++ b/clang/include/clang/Basic/SourceLocation.h
@@ -16,6 +16,7 @@
 
 #include "clang/Basic/FileEntry.h"
 #include "clang/Basic/LLVM.h"
+#include "clang/Support/Compiler.h"
 #include "llvm/ADT/StringRef.h"
 #include <cassert>
 #include <cstdint>
@@ -187,7 +188,7 @@ public:
   }
 
   unsigned getHashValue() const;
-  void print(raw_ostream &OS, const SourceManager &SM) const;
+  CLANG_ABI void print(raw_ostream &OS, const SourceManager &SM) const;
   std::string printToString(const SourceManager &SM) const;
   void dump(const SourceManager &SM) const;
 };

--- a/clang/include/clang/Basic/SourceManager.h
+++ b/clang/include/clang/Basic/SourceManager.h
@@ -48,7 +48,7 @@
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/Allocator.h"
-#include "llvm/Support/Compiler.h"
+#include "clang/Support/Compiler.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include <cassert>
 #include <cstddef>
@@ -217,7 +217,7 @@ public:
   ///
   /// \param Loc If specified, is the location that invalid file diagnostics
   ///   will be emitted at.
-  std::optional<llvm::MemoryBufferRef>
+  CLANG_ABI std::optional<llvm::MemoryBufferRef>
   getBufferOrNone(DiagnosticsEngine &Diag, FileManager &FM,
                   SourceLocation Loc = SourceLocation()) const;
 
@@ -916,7 +916,7 @@ public:
 
   /// Create a new FileID that represents the specified file
   /// being \#included from the specified IncludePosition.
-  FileID createFileID(FileEntryRef SourceFile, SourceLocation IncludePos,
+  CLANG_ABI FileID createFileID(FileEntryRef SourceFile, SourceLocation IncludePos,
                       SrcMgr::CharacteristicKind FileCharacter,
                       int LoadedID = 0,
                       SourceLocation::UIntTy LoadedOffset = 0);
@@ -1398,7 +1398,7 @@ public:
   /// in the appropriate spelling MemoryBuffer.
   ///
   /// \param Invalid If non-NULL, will be set \c true if an error occurs.
-  const char *getCharacterData(SourceLocation SL,
+  CLANG_ABI const char *getCharacterData(SourceLocation SL,
                                bool *Invalid = nullptr) const;
 
   /// Return the column # for the specified file position.
@@ -1409,7 +1409,7 @@ public:
   /// before calling this method.
   unsigned getColumnNumber(FileID FID, unsigned FilePos,
                            bool *Invalid = nullptr) const;
-  unsigned getColumnNumber(SourceLocation Loc, bool *Invalid = nullptr) const;
+  CLANG_ABI unsigned getColumnNumber(SourceLocation Loc, bool *Invalid = nullptr) const;
   unsigned getSpellingColumnNumber(SourceLocation Loc,
                                    bool *Invalid = nullptr) const {
     return getColumnNumber(getSpellingLoc(Loc), Invalid);
@@ -1847,11 +1847,11 @@ private:
   friend class ASTReader;
   friend class ASTWriter;
 
-  llvm::MemoryBufferRef getFakeBufferForRecovery() const;
+  CLANG_ABI llvm::MemoryBufferRef getFakeBufferForRecovery() const;
   SrcMgr::ContentCache &getFakeContentCacheForRecovery() const;
 
   const SrcMgr::SLocEntry &loadSLocEntry(unsigned Index, bool *Invalid) const;
-  SrcMgr::SLocEntry &loadSLocEntry(unsigned Index, bool *Invalid);
+  CLANG_ABI SrcMgr::SLocEntry &loadSLocEntry(unsigned Index, bool *Invalid);
 
   const SrcMgr::SLocEntry *getSLocEntryOrNull(FileID FID) const {
     return const_cast<SourceManager *>(this)->getSLocEntryOrNull(FID);
@@ -1966,12 +1966,12 @@ private:
   SrcMgr::ContentCache &
   createMemBufferContentCache(std::unique_ptr<llvm::MemoryBuffer> Buf);
 
-  FileID getFileIDSlow(SourceLocation::UIntTy SLocOffset) const;
+  CLANG_ABI FileID getFileIDSlow(SourceLocation::UIntTy SLocOffset) const;
   FileID getFileIDLocal(SourceLocation::UIntTy SLocOffset) const;
   FileID getFileIDLoaded(SourceLocation::UIntTy SLocOffset) const;
 
   SourceLocation getExpansionLocSlowCase(SourceLocation Loc) const;
-  SourceLocation getSpellingLocSlowCase(SourceLocation Loc) const;
+  CLANG_ABI SourceLocation getSpellingLocSlowCase(SourceLocation Loc) const;
   SourceLocation getFileLocSlowCase(SourceLocation Loc) const;
 
   void computeMacroArgsCache(MacroArgsMap &MacroArgsCache, FileID FID) const;

--- a/clang/include/clang/Basic/SourceManager.h
+++ b/clang/include/clang/Basic/SourceManager.h
@@ -38,6 +38,7 @@
 #include "clang/Basic/FileEntry.h"
 #include "clang/Basic/FileManager.h"
 #include "clang/Basic/SourceLocation.h"
+#include "clang/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/BitVector.h"
 #include "llvm/ADT/DenseMap.h"
@@ -48,7 +49,6 @@
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/Allocator.h"
-#include "clang/Support/Compiler.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include <cassert>
 #include <cstddef>
@@ -916,10 +916,11 @@ public:
 
   /// Create a new FileID that represents the specified file
   /// being \#included from the specified IncludePosition.
-  CLANG_ABI FileID createFileID(FileEntryRef SourceFile, SourceLocation IncludePos,
-                      SrcMgr::CharacteristicKind FileCharacter,
-                      int LoadedID = 0,
-                      SourceLocation::UIntTy LoadedOffset = 0);
+  CLANG_ABI FileID createFileID(FileEntryRef SourceFile,
+                                SourceLocation IncludePos,
+                                SrcMgr::CharacteristicKind FileCharacter,
+                                int LoadedID = 0,
+                                SourceLocation::UIntTy LoadedOffset = 0);
 
   /// Create a new FileID that represents the specified memory buffer.
   ///
@@ -1399,7 +1400,7 @@ public:
   ///
   /// \param Invalid If non-NULL, will be set \c true if an error occurs.
   CLANG_ABI const char *getCharacterData(SourceLocation SL,
-                               bool *Invalid = nullptr) const;
+                                         bool *Invalid = nullptr) const;
 
   /// Return the column # for the specified file position.
   ///
@@ -1409,7 +1410,8 @@ public:
   /// before calling this method.
   unsigned getColumnNumber(FileID FID, unsigned FilePos,
                            bool *Invalid = nullptr) const;
-  CLANG_ABI unsigned getColumnNumber(SourceLocation Loc, bool *Invalid = nullptr) const;
+  CLANG_ABI unsigned getColumnNumber(SourceLocation Loc,
+                                     bool *Invalid = nullptr) const;
   unsigned getSpellingColumnNumber(SourceLocation Loc,
                                    bool *Invalid = nullptr) const {
     return getColumnNumber(getSpellingLoc(Loc), Invalid);

--- a/clang/include/clang/Basic/TargetInfo.h
+++ b/clang/include/clang/Basic/TargetInfo.h
@@ -24,6 +24,7 @@
 #include "clang/Basic/Specifiers.h"
 #include "clang/Basic/TargetCXXABI.h"
 #include "clang/Basic/TargetOptions.h"
+#include "clang/Support/Compiler.h"
 #include "llvm/ADT/APFloat.h"
 #include "llvm/ADT/APInt.h"
 #include "llvm/ADT/APSInt.h"
@@ -36,7 +37,6 @@
 #include "llvm/ADT/StringTable.h"
 #include "llvm/Frontend/OpenMP/OMPGridValues.h"
 #include "llvm/IR/DerivedTypes.h"
-#include "clang/Support/Compiler.h"
 #include "llvm/Support/DataTypes.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/VersionTuple.h"
@@ -320,7 +320,7 @@ public:
   /// modify the options to canonicalize the target feature information to match
   /// what the backend expects. These must outlive the returned TargetInfo.
   CLANG_ABI static TargetInfo *CreateTargetInfo(DiagnosticsEngine &Diags,
-                                      TargetOptions &Opts);
+                                                TargetOptions &Opts);
 
   virtual ~TargetInfo();
 

--- a/clang/include/clang/Basic/TargetInfo.h
+++ b/clang/include/clang/Basic/TargetInfo.h
@@ -36,6 +36,7 @@
 #include "llvm/ADT/StringTable.h"
 #include "llvm/Frontend/OpenMP/OMPGridValues.h"
 #include "llvm/IR/DerivedTypes.h"
+#include "clang/Support/Compiler.h"
 #include "llvm/Support/DataTypes.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/VersionTuple.h"
@@ -318,7 +319,7 @@ public:
   /// \param Opts - The options to use to initialize the target. The target may
   /// modify the options to canonicalize the target feature information to match
   /// what the backend expects. These must outlive the returned TargetInfo.
-  static TargetInfo *CreateTargetInfo(DiagnosticsEngine &Diags,
+  CLANG_ABI static TargetInfo *CreateTargetInfo(DiagnosticsEngine &Diags,
                                       TargetOptions &Opts);
 
   virtual ~TargetInfo();

--- a/clang/include/clang/CodeGen/ModuleBuilder.h
+++ b/clang/include/clang/CodeGen/ModuleBuilder.h
@@ -15,8 +15,8 @@
 
 #include "clang/AST/ASTConsumer.h"
 #include "clang/Basic/LLVM.h"
-#include "llvm/ADT/StringRef.h"
 #include "clang/Support/Compiler.h"
+#include "llvm/ADT/StringRef.h"
 
 namespace llvm {
   class Constant;

--- a/clang/include/clang/CodeGen/ModuleBuilder.h
+++ b/clang/include/clang/CodeGen/ModuleBuilder.h
@@ -16,6 +16,7 @@
 #include "clang/AST/ASTConsumer.h"
 #include "clang/Basic/LLVM.h"
 #include "llvm/ADT/StringRef.h"
+#include "clang/Support/Compiler.h"
 
 namespace llvm {
   class Constant;
@@ -74,7 +75,7 @@ public:
   /// will be deleted.
   ///
   /// It will also return null if the module is released.
-  llvm::Module *GetModule();
+  CLANG_ABI llvm::Module *GetModule();
 
   /// Release ownership of the module to the caller.
   ///
@@ -113,7 +114,7 @@ public:
 /// CreateLLVMCodeGen - Create a CodeGenerator instance.
 ///
 /// Remember to call Initialize() if you plan to use this directly.
-std::unique_ptr<CodeGenerator>
+CLANG_ABI std::unique_ptr<CodeGenerator>
 CreateLLVMCodeGen(const CompilerInstance &CI, llvm::StringRef ModuleName,
                   llvm::LLVMContext &C,
                   CoverageSourceInfo *CoverageInfo = nullptr);

--- a/clang/include/clang/Driver/Types.h
+++ b/clang/include/clang/Driver/Types.h
@@ -10,9 +10,9 @@
 #define LLVM_CLANG_DRIVER_TYPES_H
 
 #include "clang/Driver/Phases.h"
+#include "clang/Support/Compiler.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Option/ArgList.h"
-#include "clang/Support/Compiler.h"
 
 namespace llvm {
 class StringRef;

--- a/clang/include/clang/Driver/Types.h
+++ b/clang/include/clang/Driver/Types.h
@@ -12,6 +12,7 @@
 #include "clang/Driver/Phases.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Option/ArgList.h"
+#include "clang/Support/Compiler.h"
 
 namespace llvm {
 class StringRef;
@@ -78,7 +79,7 @@ namespace types {
   bool isDerivedFromC(ID Id);
 
   /// isCXX - Is this a "C++" input (C++ and Obj-C++ sources and headers).
-  bool isCXX(ID Id);
+  CLANG_ABI bool isCXX(ID Id);
 
   /// Is this LLVM IR.
   bool isLLVMIR(ID Id);
@@ -90,7 +91,7 @@ namespace types {
   bool isHIP(ID Id);
 
   /// isObjC - Is this an "ObjC" input (Obj-C and Obj-C++ sources and headers).
-  bool isObjC(ID Id);
+  CLANG_ABI bool isObjC(ID Id);
 
   /// isOpenCL - Is this an "OpenCL" input.
   bool isOpenCL(ID Id);
@@ -109,7 +110,7 @@ namespace types {
 
   /// lookupTypeForTypSpecifier - Lookup the type to use for a user
   /// specified type name.
-  ID lookupTypeForTypeSpecifier(const char *Name);
+  CLANG_ABI ID lookupTypeForTypeSpecifier(const char *Name);
 
   /// getCompilationPhases - Get the list of compilation phases ('Phases') to be
   /// done for type 'Id' up until including LastPhase.

--- a/clang/include/clang/Frontend/ASTConsumers.h
+++ b/clang/include/clang/Frontend/ASTConsumers.h
@@ -15,6 +15,7 @@
 
 #include "clang/AST/ASTDumperUtils.h"
 #include "clang/Basic/LLVM.h"
+#include "clang/Support/Compiler.h"
 #include <memory>
 
 namespace clang {
@@ -30,7 +31,7 @@ std::unique_ptr<ASTConsumer> CreateASTPrinter(std::unique_ptr<raw_ostream> OS,
 
 // AST dumper: dumps the raw AST in human-readable form to the given output
 // stream, or stdout if OS is nullptr.
-std::unique_ptr<ASTConsumer>
+CLANG_ABI std::unique_ptr<ASTConsumer>
 CreateASTDumper(std::unique_ptr<raw_ostream> OS, StringRef FilterString,
                 bool DumpDecls, bool Deserialize, bool DumpLookups,
                 bool DumpDeclTypes, ASTDumpOutputFormat Format);

--- a/clang/include/clang/Frontend/ASTUnit.h
+++ b/clang/include/clang/Frontend/ASTUnit.h
@@ -39,6 +39,7 @@
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/iterator_range.h"
 #include "llvm/Bitstream/BitstreamWriter.h"
+#include "clang/Support/Compiler.h"
 #include <cassert>
 #include <cstddef>
 #include <cstdint>
@@ -425,7 +426,7 @@ public:
 
   ASTUnit(const ASTUnit &) = delete;
   ASTUnit &operator=(const ASTUnit &) = delete;
-  ~ASTUnit();
+  CLANG_ABI ~ASTUnit();
 
   bool isMainFileAST() const { return MainFileIsAST; }
 

--- a/clang/include/clang/Frontend/ASTUnit.h
+++ b/clang/include/clang/Frontend/ASTUnit.h
@@ -30,6 +30,7 @@
 #include "clang/Sema/CodeCompleteConsumer.h"
 #include "clang/Serialization/ASTBitCodes.h"
 #include "clang/Serialization/ASTWriter.h"
+#include "clang/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/IntrusiveRefCntPtr.h"
@@ -39,7 +40,6 @@
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/iterator_range.h"
 #include "llvm/Bitstream/BitstreamWriter.h"
-#include "clang/Support/Compiler.h"
 #include <cassert>
 #include <cstddef>
 #include <cstdint>

--- a/clang/include/clang/Frontend/CompilerInstance.h
+++ b/clang/include/clang/Frontend/CompilerInstance.h
@@ -25,6 +25,7 @@
 #include "llvm/ADT/IntrusiveRefCntPtr.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/BuryPointer.h"
+#include "clang/Support/Compiler.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/VirtualFileSystem.h"
 #include "llvm/Support/VirtualOutputBackend.h"
@@ -209,7 +210,7 @@ class CompilerInstance : public ModuleLoader {
   CompilerInstance(const CompilerInstance &) = delete;
   void operator=(const CompilerInstance &) = delete;
 public:
-  explicit CompilerInstance(
+  CLANG_ABI explicit CompilerInstance(
       std::shared_ptr<CompilerInvocation> Invocation =
           std::make_shared<CompilerInvocation>(),
       std::shared_ptr<PCHContainerOperations> PCHContainerOps =
@@ -407,7 +408,7 @@ public:
   }
 
   /// Replace the current Target.
-  void setTarget(TargetInfo *Value);
+  CLANG_ABI void setTarget(TargetInfo *Value);
 
   /// @}
   /// @name AuxTarget Info
@@ -436,7 +437,7 @@ public:
   ///           configuring the file system emits diagnostics. Note that the
   ///           DiagnosticsEngine using the consumer won't obey the
   ///           --warning-suppression-mappings= flag.
-  void createVirtualFileSystem(IntrusiveRefCntPtr<llvm::vfs::FileSystem>
+  CLANG_ABI void createVirtualFileSystem(IntrusiveRefCntPtr<llvm::vfs::FileSystem>
                                    BaseFS = llvm::vfs::getRealFileSystem(),
                                DiagnosticConsumer *DC = nullptr);
 
@@ -560,7 +561,7 @@ public:
   }
 
   /// setASTContext - Replace the current AST context.
-  void setASTContext(llvm::IntrusiveRefCntPtr<ASTContext> Value);
+  CLANG_ABI void setASTContext(llvm::IntrusiveRefCntPtr<ASTContext> Value);
 
   /// Replace the current Sema; the compiler instance takes ownership
   /// of S.
@@ -702,7 +703,7 @@ public:
   ///
   /// \param ShouldOwnClient If Client is non-NULL, specifies whether
   /// the diagnostic object should take ownership of the client.
-  void createDiagnostics(DiagnosticConsumer *Client = nullptr,
+  CLANG_ABI void createDiagnostics(DiagnosticConsumer *Client = nullptr,
                          bool ShouldOwnClient = true);
 
   /// Create a DiagnosticsEngine object.
@@ -726,21 +727,21 @@ public:
   /// used by some diagnostics printers (for logging purposes only).
   ///
   /// \return The new object on success, or null on failure.
-  static IntrusiveRefCntPtr<DiagnosticsEngine>
+  CLANG_ABI static IntrusiveRefCntPtr<DiagnosticsEngine>
   createDiagnostics(llvm::vfs::FileSystem &VFS, DiagnosticOptions &Opts,
                     DiagnosticConsumer *Client = nullptr,
                     bool ShouldOwnClient = true,
                     const CodeGenOptions *CodeGenOpts = nullptr);
 
   /// Create the file manager and replace any existing one with it.
-  void createFileManager();
+  CLANG_ABI void createFileManager();
 
   /// Create the source manager and replace any existing one with it.
-  void createSourceManager();
+  CLANG_ABI void createSourceManager();
 
   /// Create the preprocessor, using the invocation, file, and source managers,
   /// and replace any existing one with it.
-  void createPreprocessor(TranslationUnitKind TUKind);
+  CLANG_ABI void createPreprocessor(TranslationUnitKind TUKind);
 
   void setDependencyDirectivesGetter(
       std::unique_ptr<DependencyDirectivesGetter> Getter) {

--- a/clang/include/clang/Frontend/CompilerInstance.h
+++ b/clang/include/clang/Frontend/CompilerInstance.h
@@ -20,12 +20,12 @@
 #include "clang/Lex/HeaderSearch.h"
 #include "clang/Lex/HeaderSearchOptions.h"
 #include "clang/Lex/ModuleLoader.h"
+#include "clang/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/IntrusiveRefCntPtr.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/BuryPointer.h"
-#include "clang/Support/Compiler.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/VirtualFileSystem.h"
 #include "llvm/Support/VirtualOutputBackend.h"
@@ -437,9 +437,10 @@ public:
   ///           configuring the file system emits diagnostics. Note that the
   ///           DiagnosticsEngine using the consumer won't obey the
   ///           --warning-suppression-mappings= flag.
-  CLANG_ABI void createVirtualFileSystem(IntrusiveRefCntPtr<llvm::vfs::FileSystem>
-                                   BaseFS = llvm::vfs::getRealFileSystem(),
-                               DiagnosticConsumer *DC = nullptr);
+  CLANG_ABI void
+  createVirtualFileSystem(IntrusiveRefCntPtr<llvm::vfs::FileSystem> BaseFS =
+                              llvm::vfs::getRealFileSystem(),
+                          DiagnosticConsumer *DC = nullptr);
 
   /// Use the given file system.
   void setVirtualFileSystem(IntrusiveRefCntPtr<llvm::vfs::FileSystem> FS) {
@@ -704,7 +705,7 @@ public:
   /// \param ShouldOwnClient If Client is non-NULL, specifies whether
   /// the diagnostic object should take ownership of the client.
   CLANG_ABI void createDiagnostics(DiagnosticConsumer *Client = nullptr,
-                         bool ShouldOwnClient = true);
+                                   bool ShouldOwnClient = true);
 
   /// Create a DiagnosticsEngine object.
   ///

--- a/clang/include/clang/Frontend/CompilerInvocation.h
+++ b/clang/include/clang/Frontend/CompilerInvocation.h
@@ -21,9 +21,9 @@
 #include "clang/Frontend/MigratorOptions.h"
 #include "clang/Frontend/PreprocessorOutputOptions.h"
 #include "clang/StaticAnalyzer/Core/AnalyzerOptions.h"
-#include "llvm/ADT/IntrusiveRefCntPtr.h"
-#include "llvm/ADT/ArrayRef.h"
 #include "clang/Support/Compiler.h"
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/IntrusiveRefCntPtr.h"
 #include <memory>
 #include <string>
 
@@ -296,9 +296,9 @@ public:
   /// \param [in] CommandLineArgs - Array of argument strings, this must not
   /// contain "-cc1".
   CLANG_ABI static bool CreateFromArgs(CompilerInvocation &Res,
-                             ArrayRef<const char *> CommandLineArgs,
-                             DiagnosticsEngine &Diags,
-                             const char *Argv0 = nullptr);
+                                       ArrayRef<const char *> CommandLineArgs,
+                                       DiagnosticsEngine &Diags,
+                                       const char *Argv0 = nullptr);
 
   /// Populate \p Opts with the default set of pointer authentication-related
   /// options given \p LangOpts and \p Triple.

--- a/clang/include/clang/Frontend/CompilerInvocation.h
+++ b/clang/include/clang/Frontend/CompilerInvocation.h
@@ -23,6 +23,7 @@
 #include "clang/StaticAnalyzer/Core/AnalyzerOptions.h"
 #include "llvm/ADT/IntrusiveRefCntPtr.h"
 #include "llvm/ADT/ArrayRef.h"
+#include "clang/Support/Compiler.h"
 #include <memory>
 #include <string>
 
@@ -120,7 +121,7 @@ protected:
   /// prevent creation of the reference-counted option objects.
   struct EmptyConstructor {};
 
-  CompilerInvocationBase();
+  CLANG_ABI CompilerInvocationBase();
   CompilerInvocationBase(EmptyConstructor) {}
   CompilerInvocationBase(const CompilerInvocationBase &X) = delete;
   CompilerInvocationBase(CompilerInvocationBase &&X) = default;
@@ -294,7 +295,7 @@ public:
   /// \param [out] Res - The resulting invocation.
   /// \param [in] CommandLineArgs - Array of argument strings, this must not
   /// contain "-cc1".
-  static bool CreateFromArgs(CompilerInvocation &Res,
+  CLANG_ABI static bool CreateFromArgs(CompilerInvocation &Res,
                              ArrayRef<const char *> CommandLineArgs,
                              DiagnosticsEngine &Diags,
                              const char *Argv0 = nullptr);

--- a/clang/include/clang/Frontend/MultiplexConsumer.h
+++ b/clang/include/clang/Frontend/MultiplexConsumer.h
@@ -17,6 +17,7 @@
 #include "clang/Basic/LLVM.h"
 #include "clang/Sema/SemaConsumer.h"
 #include "clang/Serialization/ASTDeserializationListener.h"
+#include "clang/Support/Compiler.h"
 #include <memory>
 #include <vector>
 
@@ -52,12 +53,12 @@ private:
 class MultiplexConsumer : public SemaConsumer {
 public:
   // Takes ownership of the pointers in C.
-  MultiplexConsumer(std::vector<std::unique_ptr<ASTConsumer>> C);
-  MultiplexConsumer(std::unique_ptr<ASTConsumer> C);
-  ~MultiplexConsumer() override;
+  CLANG_ABI MultiplexConsumer(std::vector<std::unique_ptr<ASTConsumer>> C);
+  CLANG_ABI MultiplexConsumer(std::unique_ptr<ASTConsumer> C);
+  CLANG_ABI ~MultiplexConsumer() override;
 
   // ASTConsumer
-  void Initialize(ASTContext &Context) override;
+  CLANG_ABI void Initialize(ASTContext &Context) override;
   void HandleCXXStaticMemberVarInstantiation(VarDecl *VD) override;
   bool HandleTopLevelDecl(DeclGroupRef D) override;
   void HandleInlineFunctionDefinition(FunctionDecl *D) override;

--- a/clang/include/clang/Frontend/TextDiagnosticBuffer.h
+++ b/clang/include/clang/Frontend/TextDiagnosticBuffer.h
@@ -57,7 +57,7 @@ public:
   AllDiagList::const_iterator all_end() const { return All.end(); }
 
   CLANG_ABI void HandleDiagnostic(DiagnosticsEngine::Level DiagLevel,
-                        const Diagnostic &Info) override;
+                                  const Diagnostic &Info) override;
 
   /// FlushDiagnostics - Flush the buffered diagnostics to an given
   /// diagnostic engine.

--- a/clang/include/clang/Frontend/TextDiagnosticBuffer.h
+++ b/clang/include/clang/Frontend/TextDiagnosticBuffer.h
@@ -15,6 +15,7 @@
 
 #include "clang/Basic/Diagnostic.h"
 #include "clang/Basic/SourceLocation.h"
+#include "clang/Support/Compiler.h"
 #include <cstddef>
 #include <string>
 #include <utility>
@@ -55,7 +56,7 @@ public:
   AllDiagList::const_iterator all_begin() const { return All.begin(); }
   AllDiagList::const_iterator all_end() const { return All.end(); }
 
-  void HandleDiagnostic(DiagnosticsEngine::Level DiagLevel,
+  CLANG_ABI void HandleDiagnostic(DiagnosticsEngine::Level DiagLevel,
                         const Diagnostic &Info) override;
 
   /// FlushDiagnostics - Flush the buffered diagnostics to an given

--- a/clang/include/clang/Frontend/TextDiagnosticPrinter.h
+++ b/clang/include/clang/Frontend/TextDiagnosticPrinter.h
@@ -16,8 +16,8 @@
 
 #include "clang/Basic/Diagnostic.h"
 #include "clang/Basic/LLVM.h"
-#include "llvm/ADT/IntrusiveRefCntPtr.h"
 #include "clang/Support/Compiler.h"
+#include "llvm/ADT/IntrusiveRefCntPtr.h"
 #include <memory>
 
 namespace clang {
@@ -51,7 +51,7 @@ public:
   void BeginSourceFile(const LangOptions &LO, const Preprocessor *PP) override;
   void EndSourceFile() override;
   CLANG_ABI void HandleDiagnostic(DiagnosticsEngine::Level Level,
-                        const Diagnostic &Info) override;
+                                  const Diagnostic &Info) override;
 };
 
 } // end namespace clang

--- a/clang/include/clang/Frontend/TextDiagnosticPrinter.h
+++ b/clang/include/clang/Frontend/TextDiagnosticPrinter.h
@@ -17,6 +17,7 @@
 #include "clang/Basic/Diagnostic.h"
 #include "clang/Basic/LLVM.h"
 #include "llvm/ADT/IntrusiveRefCntPtr.h"
+#include "clang/Support/Compiler.h"
 #include <memory>
 
 namespace clang {
@@ -49,7 +50,7 @@ public:
 
   void BeginSourceFile(const LangOptions &LO, const Preprocessor *PP) override;
   void EndSourceFile() override;
-  void HandleDiagnostic(DiagnosticsEngine::Level Level,
+  CLANG_ABI void HandleDiagnostic(DiagnosticsEngine::Level Level,
                         const Diagnostic &Info) override;
 };
 

--- a/clang/include/clang/Lex/Lexer.h
+++ b/clang/include/clang/Lex/Lexer.h
@@ -19,9 +19,9 @@
 #include "clang/Lex/DependencyDirectivesScanner.h"
 #include "clang/Lex/PreprocessorLexer.h"
 #include "clang/Lex/Token.h"
+#include "clang/Support/Compiler.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
-#include "clang/Support/Compiler.h"
 #include <cassert>
 #include <cstdint>
 #include <optional>
@@ -496,9 +496,9 @@ public:
 
   /// Returns a string for the source that the range encompasses.
   CLANG_ABI static StringRef getSourceText(CharSourceRange Range,
-                                 const SourceManager &SM,
-                                 const LangOptions &LangOpts,
-                                 bool *Invalid = nullptr);
+                                           const SourceManager &SM,
+                                           const LangOptions &LangOpts,
+                                           bool *Invalid = nullptr);
 
   /// Retrieve the name of the immediate macro expansion.
   ///

--- a/clang/include/clang/Lex/Lexer.h
+++ b/clang/include/clang/Lex/Lexer.h
@@ -21,6 +21,7 @@
 #include "clang/Lex/Token.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
+#include "clang/Support/Compiler.h"
 #include <cassert>
 #include <cstdint>
 #include <optional>
@@ -494,7 +495,7 @@ public:
                                            const LangOptions &LangOpts);
 
   /// Returns a string for the source that the range encompasses.
-  static StringRef getSourceText(CharSourceRange Range,
+  CLANG_ABI static StringRef getSourceText(CharSourceRange Range,
                                  const SourceManager &SM,
                                  const LangOptions &LangOpts,
                                  bool *Invalid = nullptr);

--- a/clang/include/clang/Parse/ParseAST.h
+++ b/clang/include/clang/Parse/ParseAST.h
@@ -36,11 +36,11 @@ namespace clang {
   /// \param SkipFunctionBodies Whether to skip parsing of function bodies.
   /// This option can be used, for example, to speed up searches for
   /// declarations/definitions when indexing.
-  CLANG_ABI void ParseAST(Preprocessor &pp, ASTConsumer *C,
-                ASTContext &Ctx, bool PrintStats = false,
-                TranslationUnitKind TUKind = TU_Complete,
-                CodeCompleteConsumer *CompletionConsumer = nullptr,
-                bool SkipFunctionBodies = false);
+  CLANG_ABI void ParseAST(Preprocessor &pp, ASTConsumer *C, ASTContext &Ctx,
+                          bool PrintStats = false,
+                          TranslationUnitKind TUKind = TU_Complete,
+                          CodeCompleteConsumer *CompletionConsumer = nullptr,
+                          bool SkipFunctionBodies = false);
 
   /// Parse the main file known to the preprocessor, producing an
   /// abstract syntax tree.

--- a/clang/include/clang/Parse/ParseAST.h
+++ b/clang/include/clang/Parse/ParseAST.h
@@ -14,6 +14,7 @@
 #define LLVM_CLANG_PARSE_PARSEAST_H
 
 #include "clang/Basic/LangOptions.h"
+#include "clang/Support/Compiler.h"
 
 namespace clang {
   class Preprocessor;
@@ -35,7 +36,7 @@ namespace clang {
   /// \param SkipFunctionBodies Whether to skip parsing of function bodies.
   /// This option can be used, for example, to speed up searches for
   /// declarations/definitions when indexing.
-  void ParseAST(Preprocessor &pp, ASTConsumer *C,
+  CLANG_ABI void ParseAST(Preprocessor &pp, ASTConsumer *C,
                 ASTContext &Ctx, bool PrintStats = false,
                 TranslationUnitKind TUKind = TU_Complete,
                 CodeCompleteConsumer *CompletionConsumer = nullptr,

--- a/clang/include/clang/Rewrite/Core/Rewriter.h
+++ b/clang/include/clang/Rewrite/Core/Rewriter.h
@@ -16,9 +16,9 @@
 
 #include "clang/Basic/LLVM.h"
 #include "clang/Basic/SourceLocation.h"
+#include "clang/Support/Compiler.h"
 #include "llvm/ADT/RewriteBuffer.h"
 #include "llvm/ADT/StringRef.h"
-#include "clang/Support/Compiler.h"
 #include <map>
 #include <string>
 

--- a/clang/include/clang/Rewrite/Core/Rewriter.h
+++ b/clang/include/clang/Rewrite/Core/Rewriter.h
@@ -18,6 +18,7 @@
 #include "clang/Basic/SourceLocation.h"
 #include "llvm/ADT/RewriteBuffer.h"
 #include "llvm/ADT/StringRef.h"
+#include "clang/Support/Compiler.h"
 #include <map>
 #include <string>
 
@@ -192,7 +193,7 @@ public:
   /// buffer, and allows you to write on it directly.  This is useful if you
   /// want efficient low-level access to apis for scribbling on one specific
   /// FileID's buffer.
-  llvm::RewriteBuffer &getEditBuffer(FileID FID);
+  CLANG_ABI llvm::RewriteBuffer &getEditBuffer(FileID FID);
 
   /// getRewriteBufferFor - Return the rewrite buffer for the specified FileID.
   /// If no modification has been made to it, return null.
@@ -213,7 +214,7 @@ public:
   /// Returns true if any files were not saved successfully.
   /// Outputs diagnostics via the source manager's diagnostic engine
   /// in case of an error.
-  bool overwriteChangedFiles();
+  CLANG_ABI bool overwriteChangedFiles();
 
 private:
   unsigned getLocationOffsetAndFileID(SourceLocation Loc, FileID &FID) const;

--- a/clang/include/clang/Serialization/PCHContainerOperations.h
+++ b/clang/include/clang/Serialization/PCHContainerOperations.h
@@ -10,9 +10,9 @@
 #define LLVM_CLANG_SERIALIZATION_PCHCONTAINEROPERATIONS_H
 
 #include "clang/Basic/Module.h"
+#include "clang/Support/Compiler.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringMap.h"
-#include "clang/Support/Compiler.h"
 #include "llvm/Support/MemoryBufferRef.h"
 #include <memory>
 

--- a/clang/include/clang/Serialization/PCHContainerOperations.h
+++ b/clang/include/clang/Serialization/PCHContainerOperations.h
@@ -12,6 +12,7 @@
 #include "clang/Basic/Module.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringMap.h"
+#include "clang/Support/Compiler.h"
 #include "llvm/Support/MemoryBufferRef.h"
 #include <memory>
 
@@ -92,7 +93,7 @@ class PCHContainerOperations {
 public:
   /// Automatically registers a RawPCHContainerWriter and
   /// RawPCHContainerReader.
-  PCHContainerOperations();
+  CLANG_ABI PCHContainerOperations();
   void registerWriter(std::unique_ptr<PCHContainerWriter> Writer) {
     Writers[Writer->getFormat()] = std::move(Writer);
   }

--- a/clang/include/clang/Tooling/ASTDiff/ASTDiff.h
+++ b/clang/include/clang/Tooling/ASTDiff/ASTDiff.h
@@ -19,8 +19,8 @@
 #ifndef LLVM_CLANG_TOOLING_ASTDIFF_ASTDIFF_H
 #define LLVM_CLANG_TOOLING_ASTDIFF_ASTDIFF_H
 
-#include "clang/Tooling/ASTDiff/ASTDiffInternal.h"
 #include "clang/Support/Compiler.h"
+#include "clang/Tooling/ASTDiff/ASTDiffInternal.h"
 #include <optional>
 
 namespace clang {
@@ -76,7 +76,8 @@ public:
   CLANG_ABI int findPositionInParent(NodeId Id) const;
 
   // Returns the starting and ending offset of the node in its source file.
-  CLANG_ABI std::pair<unsigned, unsigned> getSourceRangeOffsets(const Node &N) const;
+  CLANG_ABI std::pair<unsigned, unsigned>
+  getSourceRangeOffsets(const Node &N) const;
 
   /// Serialize the node attributes to a string representation. This should
   /// uniquely distinguish nodes of the same kind. Note that this function just
@@ -110,7 +111,8 @@ struct ComparisonOptions {
 
 class ASTDiff {
 public:
-  CLANG_ABI ASTDiff(SyntaxTree &Src, SyntaxTree &Dst, const ComparisonOptions &Options);
+  CLANG_ABI ASTDiff(SyntaxTree &Src, SyntaxTree &Dst,
+                    const ComparisonOptions &Options);
   CLANG_ABI ~ASTDiff();
 
   // Returns the ID of the node that is mapped to the given node in SourceTree.

--- a/clang/include/clang/Tooling/ASTDiff/ASTDiff.h
+++ b/clang/include/clang/Tooling/ASTDiff/ASTDiff.h
@@ -20,6 +20,7 @@
 #define LLVM_CLANG_TOOLING_ASTDIFF_ASTDIFF_H
 
 #include "clang/Tooling/ASTDiff/ASTDiffInternal.h"
+#include "clang/Support/Compiler.h"
 #include <optional>
 
 namespace clang {
@@ -43,10 +44,10 @@ struct Node {
   ChangeKind Change = None;
 
   ASTNodeKind getType() const;
-  StringRef getTypeLabel() const;
+  CLANG_ABI StringRef getTypeLabel() const;
   bool isLeaf() const { return Children.empty(); }
-  std::optional<StringRef> getIdentifier() const;
-  std::optional<std::string> getQualifiedIdentifier() const;
+  CLANG_ABI std::optional<StringRef> getIdentifier() const;
+  CLANG_ABI std::optional<std::string> getQualifiedIdentifier() const;
 };
 
 /// SyntaxTree objects represent subtrees of the AST.
@@ -54,34 +55,34 @@ struct Node {
 class SyntaxTree {
 public:
   /// Constructs a tree from a translation unit.
-  SyntaxTree(ASTContext &AST);
+  CLANG_ABI SyntaxTree(ASTContext &AST);
   /// Constructs a tree from any AST node.
   template <class T>
   SyntaxTree(T *Node, ASTContext &AST)
       : TreeImpl(std::make_unique<Impl>(this, Node, AST)) {}
   SyntaxTree(SyntaxTree &&Other) = default;
-  ~SyntaxTree();
+  CLANG_ABI ~SyntaxTree();
 
-  const ASTContext &getASTContext() const;
+  CLANG_ABI const ASTContext &getASTContext() const;
   StringRef getFilename() const;
 
   int getSize() const;
-  NodeId getRootId() const;
+  CLANG_ABI NodeId getRootId() const;
   using PreorderIterator = NodeId;
-  PreorderIterator begin() const;
-  PreorderIterator end() const;
+  CLANG_ABI PreorderIterator begin() const;
+  CLANG_ABI PreorderIterator end() const;
 
-  const Node &getNode(NodeId Id) const;
-  int findPositionInParent(NodeId Id) const;
+  CLANG_ABI const Node &getNode(NodeId Id) const;
+  CLANG_ABI int findPositionInParent(NodeId Id) const;
 
   // Returns the starting and ending offset of the node in its source file.
-  std::pair<unsigned, unsigned> getSourceRangeOffsets(const Node &N) const;
+  CLANG_ABI std::pair<unsigned, unsigned> getSourceRangeOffsets(const Node &N) const;
 
   /// Serialize the node attributes to a string representation. This should
   /// uniquely distinguish nodes of the same kind. Note that this function just
   /// returns a representation of the node value, not considering descendants.
-  std::string getNodeValue(NodeId Id) const;
-  std::string getNodeValue(const Node &Node) const;
+  CLANG_ABI std::string getNodeValue(NodeId Id) const;
+  CLANG_ABI std::string getNodeValue(const Node &Node) const;
 
   class Impl;
   std::unique_ptr<Impl> TreeImpl;
@@ -109,11 +110,11 @@ struct ComparisonOptions {
 
 class ASTDiff {
 public:
-  ASTDiff(SyntaxTree &Src, SyntaxTree &Dst, const ComparisonOptions &Options);
-  ~ASTDiff();
+  CLANG_ABI ASTDiff(SyntaxTree &Src, SyntaxTree &Dst, const ComparisonOptions &Options);
+  CLANG_ABI ~ASTDiff();
 
   // Returns the ID of the node that is mapped to the given node in SourceTree.
-  NodeId getMapped(const SyntaxTree &SourceTree, NodeId Id) const;
+  CLANG_ABI NodeId getMapped(const SyntaxTree &SourceTree, NodeId Id) const;
 
   class Impl;
 

--- a/clang/include/clang/Tooling/ArgumentsAdjusters.h
+++ b/clang/include/clang/Tooling/ArgumentsAdjusters.h
@@ -17,8 +17,8 @@
 #define LLVM_CLANG_TOOLING_ARGUMENTSADJUSTERS_H
 
 #include "clang/Basic/LLVM.h"
-#include "llvm/ADT/StringRef.h"
 #include "clang/Support/Compiler.h"
+#include "llvm/ADT/StringRef.h"
 #include <functional>
 #include <string>
 #include <vector>
@@ -52,8 +52,8 @@ enum class ArgumentInsertPosition { BEGIN, END };
 
 /// Gets an argument adjuster which inserts \p Extra arguments in the
 /// specified position.
-CLANG_ABI ArgumentsAdjuster getInsertArgumentAdjuster(const CommandLineArguments &Extra,
-                                            ArgumentInsertPosition Pos);
+CLANG_ABI ArgumentsAdjuster getInsertArgumentAdjuster(
+    const CommandLineArguments &Extra, ArgumentInsertPosition Pos);
 
 /// Gets an argument adjuster which inserts an \p Extra argument in the
 /// specified position.

--- a/clang/include/clang/Tooling/ArgumentsAdjusters.h
+++ b/clang/include/clang/Tooling/ArgumentsAdjusters.h
@@ -18,6 +18,7 @@
 
 #include "clang/Basic/LLVM.h"
 #include "llvm/ADT/StringRef.h"
+#include "clang/Support/Compiler.h"
 #include <functional>
 #include <string>
 #include <vector>
@@ -51,12 +52,12 @@ enum class ArgumentInsertPosition { BEGIN, END };
 
 /// Gets an argument adjuster which inserts \p Extra arguments in the
 /// specified position.
-ArgumentsAdjuster getInsertArgumentAdjuster(const CommandLineArguments &Extra,
+CLANG_ABI ArgumentsAdjuster getInsertArgumentAdjuster(const CommandLineArguments &Extra,
                                             ArgumentInsertPosition Pos);
 
 /// Gets an argument adjuster which inserts an \p Extra argument in the
 /// specified position.
-ArgumentsAdjuster getInsertArgumentAdjuster(
+CLANG_ABI ArgumentsAdjuster getInsertArgumentAdjuster(
     const char *Extra,
     ArgumentInsertPosition Pos = ArgumentInsertPosition::END);
 

--- a/clang/include/clang/Tooling/CommonOptionsParser.h
+++ b/clang/include/clang/Tooling/CommonOptionsParser.h
@@ -29,6 +29,7 @@
 #include "clang/Tooling/ArgumentsAdjusters.h"
 #include "clang/Tooling/CompilationDatabase.h"
 #include "llvm/Support/CommandLine.h"
+#include "clang/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 
 namespace clang {
@@ -126,14 +127,14 @@ public:
       std::unique_ptr<CompilationDatabase> Compilations)
       : Compilations(std::move(Compilations)) {}
 
-  void appendArgumentsAdjuster(ArgumentsAdjuster Adjuster);
+  CLANG_ABI void appendArgumentsAdjuster(ArgumentsAdjuster Adjuster);
 
-  std::vector<CompileCommand>
+  CLANG_ABI std::vector<CompileCommand>
   getCompileCommands(StringRef FilePath) const override;
 
-  std::vector<std::string> getAllFiles() const override;
+  CLANG_ABI std::vector<std::string> getAllFiles() const override;
 
-  std::vector<CompileCommand> getAllCompileCommands() const override;
+  CLANG_ABI std::vector<CompileCommand> getAllCompileCommands() const override;
 
 private:
   std::unique_ptr<CompilationDatabase> Compilations;

--- a/clang/include/clang/Tooling/CommonOptionsParser.h
+++ b/clang/include/clang/Tooling/CommonOptionsParser.h
@@ -26,10 +26,10 @@
 #ifndef LLVM_CLANG_TOOLING_COMMONOPTIONSPARSER_H
 #define LLVM_CLANG_TOOLING_COMMONOPTIONSPARSER_H
 
+#include "clang/Support/Compiler.h"
 #include "clang/Tooling/ArgumentsAdjusters.h"
 #include "clang/Tooling/CompilationDatabase.h"
 #include "llvm/Support/CommandLine.h"
-#include "clang/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 
 namespace clang {

--- a/clang/include/clang/Tooling/CompilationDatabase.h
+++ b/clang/include/clang/Tooling/CompilationDatabase.h
@@ -28,10 +28,10 @@
 #define LLVM_CLANG_TOOLING_COMPILATIONDATABASE_H
 
 #include "clang/Basic/LLVM.h"
+#include "clang/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/Twine.h"
-#include "clang/Support/Compiler.h"
 #include "llvm/Support/VirtualFileSystem.h"
 #include <memory>
 #include <string>
@@ -127,8 +127,8 @@ public:
   /// $ clang++ -o production a.cc b.cc -DPRODUCTION
   /// A compilation database representing the project would return both command
   /// lines for a.cc and b.cc and only the first command line for t.cc.
-  CLANG_ABI virtual std::vector<CompileCommand> getCompileCommands(
-      StringRef FilePath) const = 0;
+  CLANG_ABI virtual std::vector<CompileCommand>
+  getCompileCommands(StringRef FilePath) const = 0;
 
   /// Returns the list of all files available in the compilation database.
   ///
@@ -152,7 +152,7 @@ public:
 ///
 /// Useful when we want a tool to behave more like a compiler invocation.
 /// This compilation database is not enumerable: getAllFiles() returns {}.
-   class FixedCompilationDatabase : public CompilationDatabase {
+class FixedCompilationDatabase : public CompilationDatabase {
 public:
   /// Creates a FixedCompilationDatabase from the arguments after "--".
   ///
@@ -198,7 +198,7 @@ public:
   /// Constructs a compilation data base from a specified directory
   /// and command line.
   CLANG_ABI FixedCompilationDatabase(const Twine &Directory,
-                           ArrayRef<std::string> CommandLine);
+                                     ArrayRef<std::string> CommandLine);
 
   /// Returns the given compile command.
   ///
@@ -206,7 +206,7 @@ public:
   /// and command line specified at construction with "clang-tool" as argv[0]
   /// and 'FilePath' as positional argument.
   std::vector<CompileCommand>
-  CLANG_ABI getCompileCommands(StringRef FilePath) const override;
+      CLANG_ABI getCompileCommands(StringRef FilePath) const override;
 
 private:
   /// This is built up to contain a single entry vector to be returned from

--- a/clang/include/clang/Tooling/CompilationDatabase.h
+++ b/clang/include/clang/Tooling/CompilationDatabase.h
@@ -31,6 +31,7 @@
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/Twine.h"
+#include "clang/Support/Compiler.h"
 #include "llvm/Support/VirtualFileSystem.h"
 #include <memory>
 #include <string>
@@ -86,7 +87,7 @@ struct CompileCommand {
 /// in a project.
 class CompilationDatabase {
 public:
-  virtual ~CompilationDatabase();
+  CLANG_ABI virtual ~CompilationDatabase();
 
   /// Loads a compilation database from a build directory.
   ///
@@ -107,7 +108,7 @@ public:
   ///
   /// Looks for a compilation database in all parent paths of file 'SourceFile'
   /// by calling loadFromDirectory.
-  static std::unique_ptr<CompilationDatabase>
+  CLANG_ABI static std::unique_ptr<CompilationDatabase>
   autoDetectFromSource(StringRef SourceFile, std::string &ErrorMessage);
 
   /// Tries to detect a compilation database location and load it.
@@ -126,7 +127,7 @@ public:
   /// $ clang++ -o production a.cc b.cc -DPRODUCTION
   /// A compilation database representing the project would return both command
   /// lines for a.cc and b.cc and only the first command line for t.cc.
-  virtual std::vector<CompileCommand> getCompileCommands(
+  CLANG_ABI virtual std::vector<CompileCommand> getCompileCommands(
       StringRef FilePath) const = 0;
 
   /// Returns the list of all files available in the compilation database.
@@ -144,14 +145,14 @@ public:
   ///
   /// By default, this is implemented in terms of getAllFiles() and
   /// getCompileCommands(). Subclasses may override this for efficiency.
-  virtual std::vector<CompileCommand> getAllCompileCommands() const;
+  CLANG_ABI virtual std::vector<CompileCommand> getAllCompileCommands() const;
 };
 
 /// A compilation database that returns a single compile command line.
 ///
 /// Useful when we want a tool to behave more like a compiler invocation.
 /// This compilation database is not enumerable: getAllFiles() returns {}.
-class FixedCompilationDatabase : public CompilationDatabase {
+   class FixedCompilationDatabase : public CompilationDatabase {
 public:
   /// Creates a FixedCompilationDatabase from the arguments after "--".
   ///
@@ -180,7 +181,7 @@ public:
   /// \param Argv Points to the command line arguments.
   /// \param ErrorMsg Contains error text if the function returns null pointer.
   /// \param Directory The base directory used in the FixedCompilationDatabase.
-  static std::unique_ptr<FixedCompilationDatabase>
+  CLANG_ABI static std::unique_ptr<FixedCompilationDatabase>
   loadFromCommandLine(int &Argc, const char *const *Argv, std::string &ErrorMsg,
                       const Twine &Directory = ".");
 
@@ -196,7 +197,7 @@ public:
 
   /// Constructs a compilation data base from a specified directory
   /// and command line.
-  FixedCompilationDatabase(const Twine &Directory,
+  CLANG_ABI FixedCompilationDatabase(const Twine &Directory,
                            ArrayRef<std::string> CommandLine);
 
   /// Returns the given compile command.
@@ -205,7 +206,7 @@ public:
   /// and command line specified at construction with "clang-tool" as argv[0]
   /// and 'FilePath' as positional argument.
   std::vector<CompileCommand>
-  getCompileCommands(StringRef FilePath) const override;
+  CLANG_ABI getCompileCommands(StringRef FilePath) const override;
 
 private:
   /// This is built up to contain a single entry vector to be returned from

--- a/clang/include/clang/Tooling/Core/Replacement.h
+++ b/clang/include/clang/Tooling/Core/Replacement.h
@@ -21,7 +21,7 @@
 #include "clang/Basic/LangOptions.h"
 #include "clang/Basic/SourceLocation.h"
 #include "llvm/ADT/StringRef.h"
-#include "llvm/Support/Compiler.h"
+#include "clang/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/raw_ostream.h"
 #include <map>
@@ -270,7 +270,7 @@ public:
   // Returns the new offset in the code after replacements being applied.
   // Note that if there is an insertion at Offset in the current replacements,
   // \p Offset will be shifted to Offset + Length in inserted text.
-  unsigned getShiftedCodePosition(unsigned Position) const;
+  CLANG_ABI unsigned getShiftedCodePosition(unsigned Position) const;
 
   unsigned size() const { return Replaces.size(); }
 
@@ -328,7 +328,7 @@ bool applyAllReplacements(const Replacements &Replaces, Rewriter &Rewrite);
 /// replacements applied; otherwise, an llvm::Error carrying llvm::StringError
 /// is returned (the Error message can be converted to string using
 /// `llvm::toString()` and 'std::error_code` in the `Error` should be ignored).
-llvm::Expected<std::string> applyAllReplacements(StringRef Code,
+CLANG_ABI llvm::Expected<std::string> applyAllReplacements(StringRef Code,
                                                  const Replacements &Replaces);
 
 /// Collection of Replacements generated from a single translation unit.

--- a/clang/include/clang/Tooling/Core/Replacement.h
+++ b/clang/include/clang/Tooling/Core/Replacement.h
@@ -20,8 +20,8 @@
 
 #include "clang/Basic/LangOptions.h"
 #include "clang/Basic/SourceLocation.h"
-#include "llvm/ADT/StringRef.h"
 #include "clang/Support/Compiler.h"
+#include "llvm/ADT/StringRef.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/raw_ostream.h"
 #include <map>
@@ -328,8 +328,8 @@ bool applyAllReplacements(const Replacements &Replaces, Rewriter &Rewrite);
 /// replacements applied; otherwise, an llvm::Error carrying llvm::StringError
 /// is returned (the Error message can be converted to string using
 /// `llvm::toString()` and 'std::error_code` in the `Error` should be ignored).
-CLANG_ABI llvm::Expected<std::string> applyAllReplacements(StringRef Code,
-                                                 const Replacements &Replaces);
+CLANG_ABI llvm::Expected<std::string>
+applyAllReplacements(StringRef Code, const Replacements &Replaces);
 
 /// Collection of Replacements generated from a single translation unit.
 struct TranslationUnitReplacements {

--- a/clang/include/clang/Tooling/Tooling.h
+++ b/clang/include/clang/Tooling/Tooling.h
@@ -35,6 +35,7 @@
 #include "clang/Frontend/ASTUnit.h"
 #include "clang/Frontend/FrontendAction.h"
 #include "clang/Frontend/PCHContainerOperations.h"
+#include "clang/Support/Compiler.h"
 #include "clang/Tooling/ArgumentsAdjusters.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/IntrusiveRefCntPtr.h"
@@ -43,7 +44,6 @@
 #include "llvm/ADT/StringSet.h"
 #include "llvm/ADT/Twine.h"
 #include "llvm/Option/Option.h"
-#include "clang/Support/Compiler.h"
 #include "llvm/Support/VirtualFileSystem.h"
 #include <memory>
 #include <string>
@@ -332,12 +332,12 @@ public:
   /// \param Files The file manager to use for underlying file operations when
   /// running the tool.
   CLANG_ABI ClangTool(const CompilationDatabase &Compilations,
-            ArrayRef<std::string> SourcePaths,
-            std::shared_ptr<PCHContainerOperations> PCHContainerOps =
-                std::make_shared<PCHContainerOperations>(),
-            IntrusiveRefCntPtr<llvm::vfs::FileSystem> BaseFS =
-                llvm::vfs::getRealFileSystem(),
-            IntrusiveRefCntPtr<FileManager> Files = nullptr);
+                      ArrayRef<std::string> SourcePaths,
+                      std::shared_ptr<PCHContainerOperations> PCHContainerOps =
+                          std::make_shared<PCHContainerOperations>(),
+                      IntrusiveRefCntPtr<llvm::vfs::FileSystem> BaseFS =
+                          llvm::vfs::getRealFileSystem(),
+                      IntrusiveRefCntPtr<FileManager> Files = nullptr);
 
   CLANG_ABI ~ClangTool();
 

--- a/clang/include/clang/Tooling/Tooling.h
+++ b/clang/include/clang/Tooling/Tooling.h
@@ -43,6 +43,7 @@
 #include "llvm/ADT/StringSet.h"
 #include "llvm/ADT/Twine.h"
 #include "llvm/Option/Option.h"
+#include "clang/Support/Compiler.h"
 #include "llvm/Support/VirtualFileSystem.h"
 #include <memory>
 #include <string>
@@ -330,7 +331,7 @@ public:
   /// tool.
   /// \param Files The file manager to use for underlying file operations when
   /// running the tool.
-  ClangTool(const CompilationDatabase &Compilations,
+  CLANG_ABI ClangTool(const CompilationDatabase &Compilations,
             ArrayRef<std::string> SourcePaths,
             std::shared_ptr<PCHContainerOperations> PCHContainerOps =
                 std::make_shared<PCHContainerOperations>(),
@@ -338,7 +339,7 @@ public:
                 llvm::vfs::getRealFileSystem(),
             IntrusiveRefCntPtr<FileManager> Files = nullptr);
 
-  ~ClangTool();
+  CLANG_ABI ~ClangTool();
 
   /// Set a \c DiagnosticConsumer to use during parsing.
   void setDiagnosticConsumer(DiagnosticConsumer *DiagConsumer) {
@@ -355,7 +356,7 @@ public:
   ///
   /// \param Adjuster An argument adjuster, which will be run on the output of
   ///        previous argument adjusters.
-  void appendArgumentsAdjuster(ArgumentsAdjuster Adjuster);
+  CLANG_ABI void appendArgumentsAdjuster(ArgumentsAdjuster Adjuster);
 
   /// Clear the command line arguments adjuster chain.
   void clearArgumentsAdjusters();
@@ -370,7 +371,7 @@ public:
 
   /// Create an AST for each file specified in the command line and
   /// append them to ASTs.
-  int buildASTs(std::vector<std::unique_ptr<ASTUnit>> &ASTs);
+  CLANG_ABI int buildASTs(std::vector<std::unique_ptr<ASTUnit>> &ASTs);
 
   /// Sets whether an error message should be printed out if an action fails. By
   /// default, if an action fails, a message is printed out to stderr.

--- a/llvm/include/llvm/TargetParser/Triple.h
+++ b/llvm/include/llvm/TargetParser/Triple.h
@@ -1240,7 +1240,7 @@ public:
   }
 
   /// Returns the default wchar_t size (in bytes) for this target triple.
-  unsigned getDefaultWCharSize() const;
+  LLVM_ABI unsigned getDefaultWCharSize() const;
 
   /// Tests if the environment supports dllimport/export annotations.
   bool hasDLLImportExport() const { return isOSWindows() || isPS(); }


### PR DESCRIPTION
This PR is part of work towards issue https://github.com/llvm/llvm-project/issues/109483 . It adds the missing CLANG_ABI annotations and a missing LLVM_ABI annotation to enable building clang and llvm as shared libraries on Windows. This external ci run run very recently (last 2 hours) did a full build without any errors (see https://github.com/mcbarton/ci-workflows/actions/runs/23400429345/job/68589171575#step:6:4095)

The build configuration is as follows. 

```
  cmake -S ./llvm/ -B build -G Ninja                `
        -DCMAKE_ASM_MASM_FLAGS="-m64"     `
        -DLLVM_ENABLE_PROJECTS="clang"              `
        -DLLVM_ENABLE_PLUGINS=On                    `
        -DLLVM_TARGETS_TO_BUILD="host"              `
        -DCMAKE_BUILD_TYPE=RelWithDebInfo           `
        -DCMAKE_CXX_COMPILER=clang-cl               `
        -DCMAKE_C_COMPILER=clang-cl                 `
        -DCMAKE_ASM_MASM_COMPILER=llvm-ml           `
        -DLLVM_BUILD_LLVM_DYLIB_VIS=On              `
        -DLLVM_LINK_LLVM_DYLIB=On                   `
        -DCLANG_ENABLE_STATIC_ANALYZER=OFF                  `
        -DLLVM_INCLUDE_BENCHMARKS=OFF                    `
        -DLLVM_INCLUDE_EXAMPLES=OFF                      `
        -DLLVM_INCLUDE_TESTS=OFF                         `
        -DLLVM_BUILD_TOOLS=OFF                           `
        -DCLANG_BUILD_TOOLS=OFF                          `
        -DCMAKE_DISABLE_PRECOMPILE_HEADERS=ON            `
        -DCLANG_LINK_CLANG_DYLIB=On                                 
cmake --build build --config RelWithDebInfo --parallel 4
```

I know this PR hits quite a few header files, all at once. I didn't know how to break it up.

cc @nikic @Steelskin @vgvassilev @compnerd 