### PR TITLE
[flang] Add guidelines for referencing the Fortran Standard

### DIFF
--- a/flang/docs/C++style.md
+++ b/flang/docs/C++style.md
@@ -97,6 +97,18 @@ when creating names.
 well as you do and avoid distracting her by calling out usage of new
 features in comments.
 
+### Referencing the Fortran Standard
+When referencing the Fortran Standard, always qualify the reference
+with the version. Use the format `F<version>` as a prefix. For
+sections and paragraphs, use e.g., `F2023 9.7.3.2 p7` (Fortran
+2023, section 9.7.3.2, paragraph 7). For rules and constraints,
+use e.g., `F2023 R1526` or `F2018 C919`.
+
+#### Notes
+1. If no version is mentioned, the default is assumed to be `F2018`.
+1. Existing code may use the `F'2023` style (with an apostrophe).
+   New code should omit the apostrophe for consistency.
+
 ### Layout
 Always run `clang-format` on your changes before committing code. LLVM
 has a `git-clang-format` script to facilitate running clang-format only


### PR DESCRIPTION
In response to [[RFC] Qualifying syntax rule numbers with Fortran standard version in comments](https://discourse.llvm.org/t/rfc-qualifying-syntax-rule-numbers-with-fortran-standard-version-in-comments/90167) this PR adds a section on guidelines for referencing the Fortran Standard.