### PR TITLE
[IR] Make succ_iterator compliant with C++20

### DIFF
--- a/llvm/include/llvm/IR/Instruction.h
+++ b/llvm/include/llvm/IR/Instruction.h
@@ -78,6 +78,7 @@ public:
       : iterator_adaptor_base<succ_iterator, op_iterator,
                               std::random_access_iterator_tag, BasicBlock *,
                               ptrdiff_t, BasicBlock *, BasicBlock *> {
+    succ_iterator() = default;
     explicit succ_iterator(op_iterator I) : iterator_adaptor_base(I) {}
 
     BasicBlock *operator*() const { return cast<BasicBlock>(*I); }
@@ -92,6 +93,7 @@ public:
                               std::random_access_iterator_tag,
                               const BasicBlock *, ptrdiff_t, const BasicBlock *,
                               const BasicBlock *> {
+    const_succ_iterator() = default;
     explicit const_succ_iterator(const_op_iterator I)
         : iterator_adaptor_base(I) {}
 


### PR DESCRIPTION
GCC 15.2 enforces the `DefaultConstructible` requirement for
`std::reverse_iterator<llvm::succ_iterator>` causing LLVM to fail to
build with C++20 (see
https://discourse.llvm.org/t/suspicious-usages-of-std-reverse-iterator-and-associated-llvm-build-failures-with-gcc-15-2-1/89426,
issue #182417).

```
$ cmake -G Ninja -S llvm -B llvm/build \
    -DCMAKE_INSTALL_PREFIX=$(mktemp -d) \
    -DCMAKE_BUILD_TYPE=Release \
    -DCMAKE_C_COMPILER=gcc \
    -DCMAKE_CXX_COMPILER=g++ \
    -DLLVM_ENABLE_PROJECTS="clang;" \
    -DLLVM_ENABLE_ASSERTIONS=ON \
    -DLLVM_USE_LINKER=lld \
    -DCMAKE_CXX_STANDARD=20 \
    -DLLVM_OPTIMIZED_TABLEGEN=ON \
    -DLLVM_PARALLEL_LINK_JOBS=4

$ ninja -C llvm/build bin/llvm-lib

...
/usr/include/c++/15/bits/stl_iterator.h:182:7: error: no matching function for call to ‘llvm::Instruction::succ_iterator::succ_iterator()’
  182 |       _GLIBCXX_NOEXCEPT_IF(noexcept(_Iterator()))
...
```

Adding a default constructor fixes this error.

Fixes #182417.
