### PR TITLE
[lldb] Fix null pointer dereference in FormatEntity array expansion

### DIFF
--- a/lldb/source/Core/FormatEntity.cpp
+++ b/lldb/source/Core/FormatEntity.cpp
@@ -1047,12 +1047,13 @@ bool FormatEntity::Formatter::DumpValue(Stream &s,
                   "[Debugger::FormatPrompt] ERROR in getting child item at "
                   "index %" PRId64,
                   index);
-      } else {
-        LLDB_LOGF(
-            log,
-            "[Debugger::FormatPrompt] special_directions for child item: %s",
-            special_directions.data() ? special_directions.data() : "");
+        success = false;
+        continue;
       }
+
+      LLDB_LOGF(
+          log, "[Debugger::FormatPrompt] special_directions for child item: %s",
+          special_directions.data() ? special_directions.data() : "");
 
       if (special_directions.empty()) {
         success &= item->DumpPrintableRepresentation(s, val_obj_display,


### PR DESCRIPTION
 When ExpandIndexedExpression returns null, the code logged the error but
  fell through to dereference the null item pointer. Add an early continue
  to skip the null item and mark the operation as failed.'