### PR TITLE
[llvm-libgcc] armv7 builtin arch should be armhf

### DIFF
--- a/llvm-libgcc/CMakeLists.txt
+++ b/llvm-libgcc/CMakeLists.txt
@@ -109,6 +109,13 @@ add_custom_target(gcc_s.ver
 add_dependencies(unwind_shared gcc_s.ver)
 
 construct_compiler_rt_default_triple()
+# See compiler-rt/CMakeLists.txt
+if ("${COMPILER_RT_DEFAULT_TARGET_TRIPLE}" MATCHES ".*hf$")
+  if (${COMPILER_RT_DEFAULT_TARGET_ARCH} MATCHES "^arm")
+    set(COMPILER_RT_DEFAULT_TARGET_ARCH "armhf")
+    CHECK_SYMBOL_EXISTS (__thumb__ "" COMPILER_RT_ARM_THUMB)
+  endif()
+endif()
 
 target_link_options(unwind_shared PUBLIC
   -Wl,--version-script,${CMAKE_CURRENT_BINARY_DIR}/gcc_s.ver


### PR DESCRIPTION
llvm-libgcc project configuration for armv7 target fails as the architecture (armv7) does not match the builtin target (armhf).

This PR duplicates the logic from `compiler-rt/CMakeLists.txt` to set `COMPILER_RT_DEFAULT_TARGET_ARCH` to `armhf` after the `construct_compiler_rt_default_triple()` call if appropriate.

## Current Behaviour

```
-- Builtin supported architectures: armhf
...
-- cmake c compiler target: armv7-rdk-linux-gnueabihf
...
CMake Error at llvm-project/llvm-libgcc/CMakeLists.txt:157 (install):
  install TARGETS given target "clang_rt.builtins-armv7" which does not
  exist.
```

## Steps to reproduce

```
export SYSROOT=<some arm sysroot>
cmake -S llvm -B build \
 -DCMAKE_C_COMPILER=clang \
 -DCMAKE_CXX_COMPILER=clang++ \
 -DCLANG_DEFAULT_RTLIB=compiler-rt \
 -DLLVM_ENABLE_PROJECTS=clang \
 -DLLVM_ENABLE_RUNTIMES=llvm-libgcc \
 -DLLVM_TARGETS_TO_BUILD="Native;ARM" \
 -DLLVM_ENABLE_LLD=ON \
 -DLLVM_RUNTIME_TARGETS=armv7-unknown-linux-gnueabihf \
 -DLLVM_BUILTIN_TARGETS=armv7-unknown-linux-gnueabihf \
 -DRUNTIMES_armv7-unknown-linux-gnueabihf_LLVM_LIBGCC_EXPLICIT_OPT_IN=ON \
 -DRUNTIMES_armv7-unknown-linux-gnueabihf_CMAKE_SYSROOT=${SYSROOT} \
 -DBUILTINS_armv7-unknown-linux-gnueabihf_CMAKE_SYSROOT=${SYSROOT}
cmake --build build
```