### PR TITLE
[lldb] Fix wrong arguments in MergeSections address mismatch warning

### DIFF
--- a/lldb/source/Plugins/ObjectFile/ELF/ObjectFileELF.cpp
+++ b/lldb/source/Plugins/ObjectFile/ELF/ObjectFileELF.cpp
@@ -152,7 +152,7 @@ lldb::SectionSP MergeSections(lldb::SectionSP lhs, lldb::SectionSP rhs) {
         "actual: {3:x}",
         lhs->GetTypeAsCString(),
         rhs_module_parent->GetFileSpec().GetPathAsConstString().GetCString(),
-        lhs->GetByteSize(), rhs->GetByteSize());
+        lhs->GetFileAddress(), rhs->GetFileAddress());
 
   // We want to take the greater of two sections. If LHS and RHS are both
   // SHT_NOBITS, we should default to LHS. If RHS has a bigger section,


### PR DESCRIPTION
The warning message intended to print the mismatched file addresses, but was passing GetByteSize() instead of GetFileAddress() for both the expected and actual values.