### PR TITLE
Create `hlsl` directory before generating headers into it

### DIFF
--- a/clang/lib/Headers/CMakeLists.txt
+++ b/clang/lib/Headers/CMakeLists.txt
@@ -505,6 +505,7 @@ if(RISCV IN_LIST LLVM_TARGETS_TO_BUILD)
 endif()
 
 # Generate HLSL intrinsic overloads
+file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/hlsl")
 clang_generate_header(-gen-hlsl-alias-intrinsics HLSLIntrinsics.td
                       hlsl/hlsl_alias_intrinsics_gen.inc)
 clang_generate_header(-gen-hlsl-inline-intrinsics HLSLIntrinsics.td


### PR DESCRIPTION
This PR should fix an issue reported by https://github.com/llvm/llvm-project/pull/187440#issuecomment-4129823619 and https://github.com/llvm/llvm-project/pull/187610#issuecomment-4129976404 where using `clang_generate_header` to generate a header into a directory that did not exist caused an error.