### PR TITLE
[llvm-profgen] Add branch/target validation

### DIFF
--- a/llvm/tools/llvm-profgen/PerfReader.cpp
+++ b/llvm/tools/llvm-profgen/PerfReader.cpp
@@ -1383,7 +1383,7 @@ void PerfScriptReader::warnIfBranchTargetMismatch() {
       WithColor::warning()
           << format("%.2f", MismatchPct) << "% of sampled " << Kind
           << " addresses (" << Mismatched << "/" << SampleAddrs.size()
-          << ") do not match the binary, likely due to problematic raw samples or mismatch in binary.\n"
+          << ") do not match the binary, likely due to problematic raw samples or mismatch in binary.\n";
     }
   };
 

--- a/llvm/tools/llvm-profgen/PerfReader.cpp
+++ b/llvm/tools/llvm-profgen/PerfReader.cpp
@@ -1344,6 +1344,60 @@ void PerfScriptReader::warnInvalidRange() {
       "range end acrossing the unconditinal jmp.");
 }
 
+void PerfScriptReader::warnIfBranchTargetMismatch() {
+  // Collect unique branch source and target addresses from LBR samples,
+  // then check what percentage don't match known instructions in the binary.
+
+  std::unordered_set<uint64_t> SampleBranches;
+  std::unordered_set<uint64_t> SampleIndirectTargets;
+  std::unordered_set<uint64_t> SampleTargets;
+
+  for (const auto &Item : AggregatedSamples) {
+    const PerfSample *Sample = Item.first.getPtr();
+    for (const LBREntry &LBR : Sample->LBRStack) {
+      uint64_t Source = LBR.Source;
+      uint64_t Target = LBR.Target;
+      if (Source == ExternalAddr || Target == ExternalAddr)
+        continue;
+      SampleBranches.insert(Source);
+      if (Binary->addressIsIndirectBranch(Source))
+        SampleIndirectTargets.insert(Target);
+      else
+        SampleTargets.insert(Target);
+    }
+  }
+
+  auto CheckMismatch = [&](StringRef Kind,
+                           const std::unordered_set<uint64_t> &SampleAddrs,
+                           auto IsValidAddr) {
+    if (SampleAddrs.empty())
+      return;
+    uint64_t Mismatched = 0;
+    for (uint64_t Addr : SampleAddrs) {
+      if (!IsValidAddr(Addr))
+        Mismatched++;
+    }
+    double MismatchPct =
+        static_cast<double>(Mismatched) / SampleAddrs.size() * 100;
+    if (Mismatched) {
+      WithColor::warning()
+          << format("%.2f", MismatchPct) << "% of sampled " << Kind
+          << " addresses (" << Mismatched << "/" << SampleAddrs.size()
+          << ") do not match the binary, likely due to problematic raw samples or mismatch in binary.\n"
+    }
+  };
+
+  CheckMismatch("branch", SampleBranches, [&](uint64_t Addr) {
+    return Binary->addressIsTransfer(Addr);
+  });
+  CheckMismatch("target", SampleTargets, [&](uint64_t Addr) {
+    return Binary->addressIsBranchTarget(Addr) || Binary->findFuncRangeForStartAddr(Addr);
+  });
+  CheckMismatch("indirect branch target", SampleIndirectTargets, [&](uint64_t Addr) {
+    return Binary->addressIsCode(Addr);
+  });
+}
+
 void PerfScriptReader::parsePerfTraces() {
   // Parse perf traces and do aggregation.
   parseAndAggregateTrace();
@@ -1360,6 +1414,7 @@ void PerfScriptReader::parsePerfTraces() {
   // Generate unsymbolized profile.
   warnTruncatedStack();
   warnInvalidRange();
+  warnIfBranchTargetMismatch();
   generateUnsymbolizedProfile();
   AggregatedSamples.clear();
 

--- a/llvm/tools/llvm-profgen/PerfReader.cpp
+++ b/llvm/tools/llvm-profgen/PerfReader.cpp
@@ -1379,15 +1379,11 @@ void PerfScriptReader::warnIfBranchTargetMismatch() {
   }
 
   emitWarningSummary(MismatchedBranches, TotalSamples,
-                     "of branches do not match the binary, likely due to "
-                     "problematic raw samples or mismatch in binary.");
+                     "of branch samples do not match the binary.");
   emitWarningSummary(MismatchedTargets, TotalSamples,
-                     "of branch targets do not match the binary, likely due to "
-                     "problematic raw samples or mismatch in binary.");
-  emitWarningSummary(
-      MismatchedIndirectTargets, TotalSamples,
-      "of indirect branch targets do not match the binary, likely due to "
-      "problematic raw samples or mismatch in binary.");
+                     "of branch targets do not match the binary.");
+  emitWarningSummary(MismatchedIndirectTargets, TotalSamples,
+                     "of indirect branch targets do not match the binary.");
 }
 
 void PerfScriptReader::parsePerfTraces() {

--- a/llvm/tools/llvm-profgen/PerfReader.cpp
+++ b/llvm/tools/llvm-profgen/PerfReader.cpp
@@ -1348,9 +1348,10 @@ void PerfScriptReader::warnIfBranchTargetMismatch() {
   // Collect unique branch source and target addresses from LBR samples,
   // then check what percentage don't match known instructions in the binary.
 
-  std::unordered_set<uint64_t> SampleBranches;
-  std::unordered_set<uint64_t> SampleIndirectTargets;
-  std::unordered_set<uint64_t> SampleTargets;
+  uint64_t MismatchedBranches = 0;
+  uint64_t MismatchedIndirectTargets = 0;
+  uint64_t MismatchedTargets = 0;
+  uint64_t TotalSamples = 0;
 
   for (const auto &Item : AggregatedSamples) {
     const PerfSample *Sample = Item.first.getPtr();
@@ -1359,43 +1360,34 @@ void PerfScriptReader::warnIfBranchTargetMismatch() {
       uint64_t Target = LBR.Target;
       if (Source == ExternalAddr || Target == ExternalAddr)
         continue;
-      SampleBranches.insert(Source);
-      if (Binary->addressIsIndirectBranch(Source))
-        SampleIndirectTargets.insert(Target);
-      else
-        SampleTargets.insert(Target);
+      TotalSamples++;
+
+      // Validate Branch sources are Call/Branch/Indirect Branch
+      if (!Binary->addressIsTransfer(Source))
+        MismatchedBranches++;
+
+      // Validate Indirect Branch targets landed in code. This may over estimate
+      // the vaid targets only because there's no good way to determine jump
+      // table targets
+      if (Binary->addressIsIndirectBranch(Source)) {
+        if (!Binary->addressIsCode(Target))
+          MismatchedIndirectTargets++;
+      } else if (!Binary->addressIsBranchTarget(Target) &&
+                 !Binary->findFuncRangeForStartAddr(Target))
+        MismatchedTargets++;
     }
   }
 
-  auto CheckMismatch = [&](StringRef Kind,
-                           const std::unordered_set<uint64_t> &SampleAddrs,
-                           auto IsValidAddr) {
-    if (SampleAddrs.empty())
-      return;
-    uint64_t Mismatched = 0;
-    for (uint64_t Addr : SampleAddrs) {
-      if (!IsValidAddr(Addr))
-        Mismatched++;
-    }
-    double MismatchPct =
-        static_cast<double>(Mismatched) / SampleAddrs.size() * 100;
-    if (Mismatched) {
-      WithColor::warning()
-          << format("%.2f", MismatchPct) << "% of sampled " << Kind
-          << " addresses (" << Mismatched << "/" << SampleAddrs.size()
-          << ") do not match the binary, likely due to problematic raw samples or mismatch in binary.\n";
-    }
-  };
-
-  CheckMismatch("branch", SampleBranches, [&](uint64_t Addr) {
-    return Binary->addressIsTransfer(Addr);
-  });
-  CheckMismatch("target", SampleTargets, [&](uint64_t Addr) {
-    return Binary->addressIsBranchTarget(Addr) || Binary->findFuncRangeForStartAddr(Addr);
-  });
-  CheckMismatch("indirect branch target", SampleIndirectTargets, [&](uint64_t Addr) {
-    return Binary->addressIsCode(Addr);
-  });
+  emitWarningSummary(MismatchedBranches, TotalSamples,
+                     "of branches do not match the binary, likely due to "
+                     "problematic raw samples or mismatch in binary.");
+  emitWarningSummary(MismatchedTargets, TotalSamples,
+                     "of branch targets do not match the binary, likely due to "
+                     "problematic raw samples or mismatch in binary.");
+  emitWarningSummary(
+      MismatchedIndirectTargets, TotalSamples,
+      "of indirect branch targets do not match the binary, likely due to "
+      "problematic raw samples or mismatch in binary.");
 }
 
 void PerfScriptReader::parsePerfTraces() {

--- a/llvm/tools/llvm-profgen/PerfReader.h
+++ b/llvm/tools/llvm-profgen/PerfReader.h
@@ -650,6 +650,8 @@ protected:
   void warnTruncatedStack();
   // Warn if range is invalid.
   void warnInvalidRange();
+  // Warn if sampled branch/target addresses don't match the binary.
+  void warnIfBranchTargetMismatch();
   // Extract call stack from the perf trace lines
   bool extractCallstack(TraceStream &TraceIt,
                         SmallVectorImpl<uint64_t> &CallStack);

--- a/llvm/tools/llvm-profgen/ProfiledBinary.cpp
+++ b/llvm/tools/llvm-profgen/ProfiledBinary.cpp
@@ -628,6 +628,8 @@ bool ProfiledBinary::dissassembleSymbol(std::size_t SI, ArrayRef<uint8_t> Bytes,
       if (MCDesc.isCall()) {
         CallAddressSet.insert(Address);
         UncondBranchAddrSet.insert(Address);
+        // Record the instruction after call as the branch target of a ret
+        BranchTargetAddressSet.insert(Address + Size);
       } else if (MCDesc.isReturn()) {
         RetAddressSet.insert(Address);
         UncondBranchAddrSet.insert(Address);
@@ -635,6 +637,17 @@ bool ProfiledBinary::dissassembleSymbol(std::size_t SI, ArrayRef<uint8_t> Bytes,
         if (MCDesc.isUnconditionalBranch())
           UncondBranchAddrSet.insert(Address);
         BranchAddressSet.insert(Address);
+      }
+
+      if (MCDesc.isIndirectBranch()) {
+        IndirectBranchAddressSet.insert(Address);
+      }
+
+      // Record branch target addresses for branches and calls.
+      if (MCDesc.isCall() || MCDesc.isBranch()) {
+        uint64_t Target = 0;
+        if (MIA->evaluateBranch(Inst, Address, Size, Target))
+          BranchTargetAddressSet.insert(Target);
       }
 
       // Record potential call targets for tail frame inference later-on.

--- a/llvm/tools/llvm-profgen/ProfiledBinary.h
+++ b/llvm/tools/llvm-profgen/ProfiledBinary.h
@@ -282,6 +282,10 @@ class ProfiledBinary {
   std::set<uint64_t> UncondBranchAddrSet;
   // A set of branch instruction addresses.
   std::unordered_set<uint64_t> BranchAddressSet;
+  // A set of indirect branch instruction addresses.
+  std::unordered_set<uint64_t> IndirectBranchAddressSet;
+  // A set of branch target addresses (destinations of branches/calls).
+  std::unordered_set<uint64_t> BranchTargetAddressSet;
 
   // Estimate and track function prolog and epilog ranges.
   PrologEpilogTracker ProEpilogTracker;
@@ -465,6 +469,12 @@ public:
     return ProEpilogTracker.PrologEpilogSet.count(Address);
   }
 
+  bool addressIsBranchTarget(uint64_t Address) const {
+    return BranchTargetAddressSet.count(Address);
+  }
+  bool addressIsIndirectBranch(uint64_t Address) const {
+    return IndirectBranchAddressSet.count(Address);
+  }
   bool addressIsTransfer(uint64_t Address) {
     return BranchAddressSet.count(Address) || RetAddressSet.count(Address) ||
            CallAddressSet.count(Address);


### PR DESCRIPTION
Add extra branch source and target validation checks for LBR samples. This is to check whether there are branch source samples that do not match a call/branch/ret instruction in the binary, and branch target samples that do not match a resolved Imm target address, or a function start address (in case of an indirect call).

Example output:
```
# X86
warning: 0.01%(27/376876) of sampled target addresses do not match the binary.
# AArch64
warning: 0.01%(63782/795824826) of branch samples do not match the binary.
warning: 0.01%(70468/795824826) of branch targets do not match the binary.
```
Run time overhead:
```
Before:
real    61m38.081s
user    60m50.768s
sys     0m42.931s

After:
real    62m33.176s
user    61m47.650s
sys     0m42.204s
```