### PR TITLE
[MLIR] convert ConvertToEmitCPatternInterface to ODS

### DIFF
--- a/mlir/include/mlir/Conversion/CMakeLists.txt
+++ b/mlir/include/mlir/Conversion/CMakeLists.txt
@@ -8,3 +8,4 @@ add_mlir_generic_tablegen_target(MLIRConversionPassIncGen)
 add_mlir_doc(Passes ConversionPasses ./ -gen-pass-doc)
 
 add_subdirectory(ConvertToLLVM)
+add_subdirectory(ConvertToEmitC)

--- a/mlir/include/mlir/Conversion/ConvertToEmitC/CMakeLists.txt
+++ b/mlir/include/mlir/Conversion/ConvertToEmitC/CMakeLists.txt
@@ -1,0 +1,3 @@
+set(LLVM_TARGET_DEFINITIONS ConvertToEmitCPatternInterface.td)
+mlir_tablegen(ConvertToEmitCPatternInterface.h.inc -gen-dialect-interface-decls)
+add_mlir_generic_tablegen_target(MLIRConvertToEmitCPatternInterfaceIncGen)

--- a/mlir/include/mlir/Conversion/ConvertToEmitC/ConvertToEmitCPatternInterface.td
+++ b/mlir/include/mlir/Conversion/ConvertToEmitC/ConvertToEmitCPatternInterface.td
@@ -1,0 +1,22 @@
+#ifndef MLIR_INTERFACES_CONVERTTOEMITCPATTERNINTERFACE
+#define MLIR_INTERFACES_CONVERTTOEMITCPATTERNINTERFACE
+
+include "mlir/IR/Interfaces.td"
+
+def ConvertToEmitCPatternInterface : DialectInterface<"ConvertToEmitCPatternInterface"> {
+  let description = [{}];
+  let cppNamespace = "::mlir";
+
+  let methods = [
+    PureVirtualInterfaceMethod<[{
+        Hook for derived dialect interface to provide conversion patterns
+        and mark dialect legal for the conversion target.
+      }],
+      "void", "populateConvertToEmitCConversionPatterns",
+      (ins "::mlir::ConversionTarget &":$target, "::mlir::TypeConverter &":$typeConverter,
+           "::mlir::RewritePatternSet &":$patterns)
+    >
+  ];
+}
+
+#endif

--- a/mlir/include/mlir/Conversion/ConvertToEmitC/ToEmitCInterface.h
+++ b/mlir/include/mlir/Conversion/ConvertToEmitC/ToEmitCInterface.h
@@ -20,19 +20,6 @@ class MLIRContext;
 class Operation;
 class RewritePatternSet;
 class AnalysisManager;
-
-class ConvertToEmitCPatternInterface
-    : public DialectInterface::Base<ConvertToEmitCPatternInterface> {
-public:
-  ConvertToEmitCPatternInterface(Dialect *dialect) : Base(dialect) {}
-
-  /// Hook for derived dialect interface to provide conversion patterns
-  /// and mark dialect legal for the conversion target.
-  virtual void populateConvertToEmitCConversionPatterns(
-      ConversionTarget &target, TypeConverter &typeConverter,
-      RewritePatternSet &patterns) const = 0;
-};
-
 /// Recursively walk the IR and collect all dialects implementing the interface,
 /// and populate the conversion patterns.
 void populateConversionTargetFromOperation(Operation *op,
@@ -41,5 +28,7 @@ void populateConversionTargetFromOperation(Operation *op,
                                            RewritePatternSet &patterns);
 
 } // namespace mlir
+
+#include "mlir/Conversion/ConvertToEmitC/ConvertToEmitCPatternInterface.h.inc"
 
 #endif // MLIR_CONVERSION_CONVERTTOEMITC_TOEMITCINTERFACE_H

--- a/mlir/lib/Conversion/ArithToEmitC/ArithToEmitC.cpp
+++ b/mlir/lib/Conversion/ArithToEmitC/ArithToEmitC.cpp
@@ -26,7 +26,8 @@ using namespace mlir;
 namespace {
 /// Implement the interface to convert Arith to EmitC.
 struct ArithToEmitCDialectInterface : public ConvertToEmitCPatternInterface {
-  using ConvertToEmitCPatternInterface::ConvertToEmitCPatternInterface;
+  ArithToEmitCDialectInterface(Dialect *dialect)
+      : ConvertToEmitCPatternInterface(dialect) {}
 
   /// Hook for derived dialect interface to provide conversion patterns
   /// and mark dialect legal for the conversion target.

--- a/mlir/lib/Conversion/ConvertToEmitC/CMakeLists.txt
+++ b/mlir/lib/Conversion/ConvertToEmitC/CMakeLists.txt
@@ -6,6 +6,7 @@ add_mlir_conversion_library(MLIRConvertToEmitC
 
   DEPENDS
   MLIRConversionPassIncGen
+  MLIRConvertToEmitCPatternInterfaceIncGen
 
   LINK_LIBS PUBLIC
   MLIRArithToEmitC

--- a/mlir/lib/Conversion/FuncToEmitC/FuncToEmitC.cpp
+++ b/mlir/lib/Conversion/FuncToEmitC/FuncToEmitC.cpp
@@ -24,7 +24,8 @@ namespace {
 
 /// Implement the interface to convert Func to EmitC.
 struct FuncToEmitCDialectInterface : public ConvertToEmitCPatternInterface {
-  using ConvertToEmitCPatternInterface::ConvertToEmitCPatternInterface;
+  FuncToEmitCDialectInterface(Dialect *dialect)
+      : ConvertToEmitCPatternInterface(dialect) {}
 
   /// Hook for derived dialect interface to provide conversion patterns
   /// and mark dialect legal for the conversion target.

--- a/mlir/lib/Conversion/MemRefToEmitC/MemRefToEmitC.cpp
+++ b/mlir/lib/Conversion/MemRefToEmitC/MemRefToEmitC.cpp
@@ -37,7 +37,8 @@ static bool isMemRefTypeLegalForEmitC(MemRefType memRefType) {
 namespace {
 /// Implement the interface to convert MemRef to EmitC.
 struct MemRefToEmitCDialectInterface : public ConvertToEmitCPatternInterface {
-  using ConvertToEmitCPatternInterface::ConvertToEmitCPatternInterface;
+  MemRefToEmitCDialectInterface(Dialect *dialect)
+      : ConvertToEmitCPatternInterface(dialect) {}
 
   /// Hook for derived dialect interface to provide conversion patterns
   /// and mark dialect legal for the conversion target.

--- a/mlir/lib/Conversion/SCFToEmitC/SCFToEmitC.cpp
+++ b/mlir/lib/Conversion/SCFToEmitC/SCFToEmitC.cpp
@@ -35,7 +35,8 @@ namespace {
 
 /// Implement the interface to convert SCF to EmitC.
 struct SCFToEmitCDialectInterface : public ConvertToEmitCPatternInterface {
-  using ConvertToEmitCPatternInterface::ConvertToEmitCPatternInterface;
+  SCFToEmitCDialectInterface(Dialect *dialect)
+      : ConvertToEmitCPatternInterface(dialect) {}
 
   /// Hook for derived dialect interface to provide conversion patterns
   /// and mark dialect legal for the conversion target.

--- a/utils/bazel/llvm-project-overlay/mlir/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/mlir/BUILD.bazel
@@ -8211,12 +8211,23 @@ cc_library(
     ],
 )
 
+gentbl_cc_library(
+    name = "ConvertToEmitCPatternInterfaceIncGen",
+    tbl_outs = {
+        "include/mlir/Conversion/ConvertToEmitC/ConvertToEmitCPatternInterface.h.inc": ["-gen-dialect-interface-decls"],
+    },
+    tblgen = ":mlir-tblgen",
+    td_file = "include/mlir/Conversion/ConvertToEmitC/ConvertToEmitCPatternInterface.td",
+    deps = [":OpBaseTdFiles"],
+)
+
 cc_library(
     name = "ConvertToEmitCInterface",
     hdrs = ["include/mlir/Conversion/ConvertToEmitC/ToEmitCInterface.h"],
     includes = ["include"],
     deps = [
         ":ConversionPassIncGen",
+        ":ConvertToEmitCPatternInterfaceIncGen",
         ":IR",
         "//llvm:Support",
     ],


### PR DESCRIPTION
This PR converts `ConvertToEmitCPatternInterface` dialect interface to tablegen generated format using ODS.
Also makes changes to derived classes. 