### PR TITLE
[clang] Suggest using __VA_OPT__(,) instead of GNU zero variadic macro argument

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -323,6 +323,9 @@ Improvements to Clang's diagnostics
   ``-Wunused-private-field`` no longer emits a warning for annotated private
   fields.
 
+- Improved ``-Wgnu-zero-variadic-macro-arguments`` to suggest using
+  ``__VA_OPT__`` if the current language version supports it(#GH188624)
+
 Improvements to Clang's time-trace
 ----------------------------------
 

--- a/clang/include/clang/Basic/DiagnosticLexKinds.td
+++ b/clang/include/clang/Basic/DiagnosticLexKinds.td
@@ -769,7 +769,8 @@ def err_paste_at_start : Error<
   "'##' cannot appear at start of macro expansion">;
 def err_paste_at_end : Error<"'##' cannot appear at end of macro expansion">;
 def ext_paste_comma : Extension<
-  "token pasting of ',' and __VA_ARGS__ is a GNU extension">, InGroup<GNUZeroVariadicMacroArguments>;
+  "token pasting of ',' and __VA_ARGS__ is a GNU extension.%select{| Consider using __VA_OPT__(,) instead}0">,
+  InGroup<GNUZeroVariadicMacroArguments>;
 def err_unterm_macro_invoc : Error<
   "unterminated function-like macro invocation">;
 def err_too_many_args_in_macro_invoc : Error<

--- a/clang/include/clang/Basic/DiagnosticLexKinds.td
+++ b/clang/include/clang/Basic/DiagnosticLexKinds.td
@@ -769,7 +769,7 @@ def err_paste_at_start : Error<
   "'##' cannot appear at start of macro expansion">;
 def err_paste_at_end : Error<"'##' cannot appear at end of macro expansion">;
 def ext_paste_comma : Extension<
-  "token pasting of ',' and __VA_ARGS__ is a GNU extension.%select{| Consider using __VA_OPT__(,) instead}0">,
+  "token pasting of ',' and __VA_ARGS__ is a GNU extension%select{|; consider using __VA_OPT__(,) instead}0">,
   InGroup<GNUZeroVariadicMacroArguments>;
 def err_unterm_macro_invoc : Error<
   "unterminated function-like macro invocation">;

--- a/clang/include/clang/Basic/DiagnosticLexKinds.td
+++ b/clang/include/clang/Basic/DiagnosticLexKinds.td
@@ -769,7 +769,8 @@ def err_paste_at_start : Error<
   "'##' cannot appear at start of macro expansion">;
 def err_paste_at_end : Error<"'##' cannot appear at end of macro expansion">;
 def ext_paste_comma : Extension<
-  "token pasting of ',' and __VA_ARGS__ is a GNU extension%select{|; consider using __VA_OPT__(,) instead}0">,
+  "token pasting of ',' and '__VA_ARGS__' is a GNU extension%select{|; "
+  "consider using '__VA_OPT__(,)' instead}0">,
   InGroup<GNUZeroVariadicMacroArguments>;
 def err_unterm_macro_invoc : Error<
   "unterminated function-like macro invocation">;

--- a/clang/lib/Lex/TokenLexer.cpp
+++ b/clang/lib/Lex/TokenLexer.cpp
@@ -523,12 +523,13 @@ void TokenLexer::ExpandFunctionArguments() {
           Macro->isVariadic()) {
         VaArgsPseudoPaste = true;
         // Remove the paste operator, report use of the extension.
-        const bool hint = PP.getLangOpts().C23 || PP.getLangOpts().CPlusPlus20;
-        auto diag = PP.Diag(ResultToks.pop_back_val().getLocation(),
+        const unsigned hint =
+            (PP.getLangOpts().C23 || PP.getLangOpts().CPlusPlus20) ? 1u : 0u;
+        auto Diag = PP.Diag(ResultToks.pop_back_val().getLocation(),
                             diag::ext_paste_comma)
                     << hint;
         if (hint) {
-          diag << FixItHint::CreateReplacement(
+          Diag << FixItHint::CreateReplacement(
               SourceRange(ResultToks[ResultToks.size() - 1].getLocation(),
                           CurTok.getLocation()),
               " __VA_OPT__(,) __VA_ARGS__");

--- a/clang/lib/Lex/TokenLexer.cpp
+++ b/clang/lib/Lex/TokenLexer.cpp
@@ -530,7 +530,7 @@ void TokenLexer::ExpandFunctionArguments() {
                     << Hint;
         if (Hint) {
           Diag << FixItHint::CreateReplacement(
-              SourceRange(ResultToks[ResultToks.size() - 1].getLocation(),
+              SourceRange(ResultToks.back().getLocation(),
                           CurTok.getLocation()),
               " __VA_OPT__(,) __VA_ARGS__");
         }

--- a/clang/lib/Lex/TokenLexer.cpp
+++ b/clang/lib/Lex/TokenLexer.cpp
@@ -523,7 +523,16 @@ void TokenLexer::ExpandFunctionArguments() {
           Macro->isVariadic()) {
         VaArgsPseudoPaste = true;
         // Remove the paste operator, report use of the extension.
-        PP.Diag(ResultToks.pop_back_val().getLocation(), diag::ext_paste_comma);
+        const bool hint = PP.getLangOpts().C23 || PP.getLangOpts().CPlusPlus20;
+        auto diag = PP.Diag(ResultToks.pop_back_val().getLocation(),
+                            diag::ext_paste_comma)
+                    << hint;
+        if (hint) {
+          diag << FixItHint::CreateReplacement(
+              SourceRange(ResultToks[ResultToks.size() - 1].getLocation(),
+                          CurTok.getLocation()),
+              " __VA_OPT__(,) __VA_ARGS__");
+        }
       }
 
       ResultToks.append(ArgToks, ArgToks+NumToks);

--- a/clang/lib/Lex/TokenLexer.cpp
+++ b/clang/lib/Lex/TokenLexer.cpp
@@ -137,6 +137,10 @@ void TokenLexer::destroy() {
   if (ActualArgs) ActualArgs->destroy(PP);
 }
 
+static bool hasVaOptSupport(const LangOptions &LangOpts) {
+  return LangOpts.C23 || LangOpts.CPlusPlus20;
+}
+
 bool TokenLexer::MaybeRemoveCommaBeforeVaArgs(
     SmallVectorImpl<Token> &ResultToks, bool HasPasteOperator, MacroInfo *Macro,
     unsigned MacroArgNo, Preprocessor &PP) {
@@ -164,8 +168,11 @@ bool TokenLexer::MaybeRemoveCommaBeforeVaArgs(
     return false;
 
   // Issue an extension diagnostic for the paste operator.
-  if (HasPasteOperator)
-    PP.Diag(ResultToks.back().getLocation(), diag::ext_paste_comma);
+  if (HasPasteOperator) {
+    const bool VaOptSupport = hasVaOptSupport(PP.getLangOpts());
+    PP.Diag(ResultToks.back().getLocation(), diag::ext_paste_comma)
+        << VaOptSupport;
+  }
 
   // Remove the comma.
   ResultToks.pop_back();
@@ -523,12 +530,11 @@ void TokenLexer::ExpandFunctionArguments() {
           Macro->isVariadic()) {
         VaArgsPseudoPaste = true;
         // Remove the paste operator, report use of the extension.
-        const unsigned Hint =
-            (PP.getLangOpts().C23 || PP.getLangOpts().CPlusPlus20) ? 1u : 0u;
+        const bool VaOptSupport = hasVaOptSupport(PP.getLangOpts());
         auto Diag = PP.Diag(ResultToks.pop_back_val().getLocation(),
                             diag::ext_paste_comma)
-                    << Hint;
-        if (Hint) {
+                    << VaOptSupport;
+        if (VaOptSupport) {
           Diag << FixItHint::CreateReplacement(
               SourceRange(ResultToks.back().getLocation(),
                           CurTok.getLocation()),

--- a/clang/lib/Lex/TokenLexer.cpp
+++ b/clang/lib/Lex/TokenLexer.cpp
@@ -523,12 +523,12 @@ void TokenLexer::ExpandFunctionArguments() {
           Macro->isVariadic()) {
         VaArgsPseudoPaste = true;
         // Remove the paste operator, report use of the extension.
-        const unsigned hint =
+        const unsigned Hint =
             (PP.getLangOpts().C23 || PP.getLangOpts().CPlusPlus20) ? 1u : 0u;
         auto Diag = PP.Diag(ResultToks.pop_back_val().getLocation(),
                             diag::ext_paste_comma)
-                    << hint;
-        if (hint) {
+                    << Hint;
+        if (Hint) {
           Diag << FixItHint::CreateReplacement(
               SourceRange(ResultToks[ResultToks.size() - 1].getLocation(),
                           CurTok.getLocation()),

--- a/clang/lib/Lex/TokenLexer.cpp
+++ b/clang/lib/Lex/TokenLexer.cpp
@@ -169,9 +169,8 @@ bool TokenLexer::MaybeRemoveCommaBeforeVaArgs(
 
   // Issue an extension diagnostic for the paste operator.
   if (HasPasteOperator) {
-    const bool VaOptSupport = hasVaOptSupport(PP.getLangOpts());
     PP.Diag(ResultToks.back().getLocation(), diag::ext_paste_comma)
-        << VaOptSupport;
+        << hasVaOptSupport(PP.getLangOpts());
   }
 
   // Remove the comma.
@@ -530,7 +529,7 @@ void TokenLexer::ExpandFunctionArguments() {
           Macro->isVariadic()) {
         VaArgsPseudoPaste = true;
         // Remove the paste operator, report use of the extension.
-        const bool VaOptSupport = hasVaOptSupport(PP.getLangOpts());
+        bool VaOptSupport = hasVaOptSupport(PP.getLangOpts());
         auto Diag = PP.Diag(ResultToks.pop_back_val().getLocation(),
                             diag::ext_paste_comma)
                     << VaOptSupport;

--- a/clang/test/Lexer/gnu-flags.c
+++ b/clang/test/Lexer/gnu-flags.c
@@ -18,7 +18,7 @@
 #if ALL || ZEROARGS
 // expected-warning@+9 {{passing no argument for the '...' parameter of a variadic macro is a C23 extension}}
 // expected-note@+4 {{macro 'efoo' defined here}}
-// expected-warning@+3 {{token pasting of ',' and __VA_ARGS__ is a GNU extension}}
+// expected-warning@+3 {{token pasting of ',' and '__VA_ARGS__' is a GNU extension}}
 #endif
 
 #define efoo(format, args...) foo(format , ##args)

--- a/clang/test/Lexer/gnu-zero-variadic-macro-argument-fixit.c
+++ b/clang/test/Lexer/gnu-zero-variadic-macro-argument-fixit.c
@@ -1,0 +1,9 @@
+// RUN: %clang_cc1 -fsyntax-only -verify -fdiagnostics-parseable-fixits %s -Wgnu-zero-variadic-macro-arguments -std=c23
+
+void foo(const char* fmt, ...);
+// expected-warning@+1 {{token pasting of ',' and __VA_ARGS__ is a GNU extension. Consider using __VA_OPT__(,) instead}}
+#define FOO(format, ...) foo(format, ##__VA_ARGS__)
+
+void bar(void) {
+  FOO("", 0);
+}

--- a/clang/test/Lexer/gnu-zero-variadic-macro-argument-fixit.c
+++ b/clang/test/Lexer/gnu-zero-variadic-macro-argument-fixit.c
@@ -1,7 +1,9 @@
-// RUN: %clang_cc1 -fsyntax-only -verify -fdiagnostics-parseable-fixits %s -Wgnu-zero-variadic-macro-arguments -std=c23
+// RUN: %clang_cc1 -fsyntax-only -verify %s -Wgnu-zero-variadic-macro-arguments -std=c23
+// RUN: %clang_cc1 -fsyntax-only -fdiagnostics-parseable-fixits %s -Wgnu-zero-variadic-macro-arguments -std=c23 2>&1 | FileCheck %s
 
 void foo(const char* fmt, ...);
-// expected-warning@+1 {{token pasting of ',' and __VA_ARGS__ is a GNU extension. Consider using __VA_OPT__(,) instead}}
+// CHECK: fix-it:"{{.*}}":{[[@LINE+2]]:36-[[@LINE+2]]:51}:" __VA_OPT__(,) __VA_ARGS__"
+// expected-warning@+1 {{token pasting of ',' and __VA_ARGS__ is a GNU extension; consider using __VA_OPT__(,) instead}}
 #define FOO(format, ...) foo(format, ##__VA_ARGS__)
 
 void bar(void) {

--- a/clang/test/Lexer/gnu-zero-variadic-macro-argument-fixit.c
+++ b/clang/test/Lexer/gnu-zero-variadic-macro-argument-fixit.c
@@ -1,5 +1,7 @@
 // RUN: %clang_cc1 -fsyntax-only -verify %s -Wgnu-zero-variadic-macro-arguments -std=c23
 // RUN: %clang_cc1 -fsyntax-only -fdiagnostics-parseable-fixits %s -Wgnu-zero-variadic-macro-arguments -std=c23 2>&1 | FileCheck %s
+// RUN: %clang_cc1 -fsyntax-only -verify %s -Wgnu-zero-variadic-macro-arguments -xc++ -std=c++20
+// RUN: %clang_cc1 -fsyntax-only -fdiagnostics-parseable-fixits %s -Wgnu-zero-variadic-macro-arguments -xc++ -std=c++20 2>&1 | FileCheck %s
 
 void foo(const char* fmt, ...);
 // CHECK: fix-it:"{{.*}}":{[[@LINE+2]]:36-[[@LINE+2]]:51}:" __VA_OPT__(,) __VA_ARGS__"

--- a/clang/test/Lexer/gnu-zero-variadic-macro-argument-fixit.c
+++ b/clang/test/Lexer/gnu-zero-variadic-macro-argument-fixit.c
@@ -5,7 +5,7 @@
 
 void foo(const char* fmt, ...);
 // CHECK: fix-it:"{{.*}}":{[[@LINE+2]]:36-[[@LINE+2]]:51}:" __VA_OPT__(,) __VA_ARGS__"
-// expected-warning@+1 {{token pasting of ',' and __VA_ARGS__ is a GNU extension; consider using __VA_OPT__(,) instead}}
+// expected-warning@+1 {{token pasting of ',' and '__VA_ARGS__' is a GNU extension; consider using '__VA_OPT__(,)' instead}}
 #define FOO(format, ...) foo(format, ##__VA_ARGS__)
 
 void bar(void) {

--- a/clang/test/Preprocessor/macro_fn.c
+++ b/clang/test/Preprocessor/macro_fn.c
@@ -60,7 +60,7 @@ one_dot()   /* empty first argument, elided ... */
     SomeComplicatedStuff((desc), ##__VA_ARGS__)
 
 #ifndef VARIADIC_MACRO_ARGS_REMOVE_COMMA
-/* expected-warning@-3 {{token pasting of ',' and __VA_ARGS__ is a GNU extension}} */
+/* expected-warning@-3 {{token pasting of ',' and '__VA_ARGS__' is a GNU extension}} */
 #endif
 
 NSAssert(somecond, somedesc)


### PR DESCRIPTION
Also provide an appropriate fixit.