### PR TITLE
[LFI][MC] Call setLFIRewriter during LFIMCStreamer initialization

### DIFF
--- a/llvm/include/llvm/MC/MCLFI.h
+++ b/llvm/include/llvm/MC/MCLFI.h
@@ -22,4 +22,6 @@ class Triple;
 LLVM_ABI void initializeLFIMCStreamer(MCStreamer &Streamer, MCContext &Ctx,
                                       const Triple &TheTriple);
 
+LLVM_ABI void emitLFINoteSection(MCStreamer &Streamer, MCContext &Ctx);
+
 } // namespace llvm

--- a/llvm/include/llvm/MC/TargetRegistry.h
+++ b/llvm/include/llvm/MC/TargetRegistry.h
@@ -239,7 +239,7 @@ public:
                                   const MCInstrInfo &MCII);
 
   using MCLFIRewriterCtorTy =
-      MCLFIRewriter *(*)(MCStreamer & S,
+      MCLFIRewriter *(*)(MCContext &Ctx,
                          std::unique_ptr<MCRegisterInfo> &&RegInfo,
                          std::unique_ptr<MCInstrInfo> &&InstInfo);
 
@@ -576,11 +576,12 @@ public:
     return nullptr;
   }
 
-  void createMCLFIRewriter(MCStreamer &S,
-                           std::unique_ptr<MCRegisterInfo> &&RegInfo,
-                           std::unique_ptr<MCInstrInfo> &&InstInfo) const {
+  MCLFIRewriter *
+  createMCLFIRewriter(MCContext &Ctx, std::unique_ptr<MCRegisterInfo> &&RegInfo,
+                      std::unique_ptr<MCInstrInfo> &&InstInfo) const {
     if (MCLFIRewriterCtorFn)
-      MCLFIRewriterCtorFn(S, std::move(RegInfo), std::move(InstInfo));
+      return MCLFIRewriterCtorFn(Ctx, std::move(RegInfo), std::move(InstInfo));
+    return nullptr;
   }
 
   /// createMCRelocationInfo - Create a target specific MCRelocationInfo.

--- a/llvm/include/llvm/MC/TargetRegistry.h
+++ b/llvm/include/llvm/MC/TargetRegistry.h
@@ -239,7 +239,7 @@ public:
                                   const MCInstrInfo &MCII);
 
   using MCLFIRewriterCtorTy =
-      MCLFIRewriter *(*)(MCContext &Ctx,
+      MCLFIRewriter *(*)(MCContext & Ctx,
                          std::unique_ptr<MCRegisterInfo> &&RegInfo,
                          std::unique_ptr<MCInstrInfo> &&InstInfo);
 

--- a/llvm/lib/MC/MCAsmStreamer.cpp
+++ b/llvm/lib/MC/MCAsmStreamer.cpp
@@ -19,6 +19,7 @@
 #include "llvm/MC/MCExpr.h"
 #include "llvm/MC/MCInst.h"
 #include "llvm/MC/MCInstPrinter.h"
+#include "llvm/MC/MCLFI.h"
 #include "llvm/MC/MCLFIRewriter.h"
 #include "llvm/MC/MCObjectFileInfo.h"
 #include "llvm/MC/MCObjectWriter.h"
@@ -2581,6 +2582,9 @@ void MCAsmStreamer::emitRawTextImpl(StringRef String) {
 }
 
 void MCAsmStreamer::finishImpl() {
+  if (getContext().getTargetTriple().isLFI())
+    emitLFINoteSection(*this, getContext());
+
   // If we are generating dwarf for assembly source files dump out the sections.
   if (getContext().getGenDwarfForAssembly())
     MCGenDwarfInfo::Emit(this);

--- a/llvm/lib/MC/MCELFStreamer.cpp
+++ b/llvm/lib/MC/MCELFStreamer.cpp
@@ -22,6 +22,7 @@
 #include "llvm/MC/MCELFObjectWriter.h"
 #include "llvm/MC/MCExpr.h"
 #include "llvm/MC/MCFixup.h"
+#include "llvm/MC/MCLFI.h"
 #include "llvm/MC/MCObjectFileInfo.h"
 #include "llvm/MC/MCObjectWriter.h"
 #include "llvm/MC/MCSection.h"
@@ -372,6 +373,9 @@ void MCELFStreamer::finishImpl() {
     createAttributesSection("gnu", ".gnu.attributes", ELF::SHT_GNU_ATTRIBUTES,
                             DummyAttributeSection, GNUAttributes);
   }
+
+  if (Ctx.getTargetTriple().isLFI())
+    emitLFINoteSection(*this, Ctx);
 
   finalizeCGProfile();
   emitFrames();

--- a/llvm/lib/MC/MCLFI.cpp
+++ b/llvm/lib/MC/MCLFI.cpp
@@ -12,10 +12,10 @@
 //===----------------------------------------------------------------------===//
 
 #include "llvm/MC/MCLFI.h"
-#include "llvm/MC/MCLFIRewriter.h"
 #include "llvm/BinaryFormat/ELF.h"
 #include "llvm/MC/MCContext.h"
 #include "llvm/MC/MCInstrInfo.h"
+#include "llvm/MC/MCLFIRewriter.h"
 #include "llvm/MC/MCRegisterInfo.h"
 #include "llvm/MC/MCSectionELF.h"
 #include "llvm/MC/MCStreamer.h"

--- a/llvm/lib/MC/MCLFI.cpp
+++ b/llvm/lib/MC/MCLFI.cpp
@@ -12,6 +12,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "llvm/MC/MCLFI.h"
+#include "llvm/MC/MCLFIRewriter.h"
 #include "llvm/BinaryFormat/ELF.h"
 #include "llvm/MC/MCContext.h"
 #include "llvm/MC/MCInstrInfo.h"

--- a/llvm/lib/MC/MCLFI.cpp
+++ b/llvm/lib/MC/MCLFI.cpp
@@ -51,10 +51,12 @@ void initializeLFIMCStreamer(MCStreamer &Streamer, MCContext &Ctx,
   // Create the Target specific MCLFIRewriter.
   assert(TheTarget != nullptr);
   if (FlagEnableRewriting) {
-    TheTarget->createMCLFIRewriter(
-        Streamer,
-        std::unique_ptr<MCRegisterInfo>(TheTarget->createMCRegInfo(TheTriple)),
-        std::unique_ptr<MCInstrInfo>(TheTarget->createMCInstrInfo()));
+    Streamer.setLFIRewriter(
+        std::unique_ptr<MCLFIRewriter>(TheTarget->createMCLFIRewriter(
+            Ctx,
+            std::unique_ptr<MCRegisterInfo>(
+                TheTarget->createMCRegInfo(TheTriple)),
+            std::unique_ptr<MCInstrInfo>(TheTarget->createMCInstrInfo()))));
   }
 
   // Emit an ELF Note section in its own COMDAT group which identifies LFI

--- a/llvm/lib/MC/MCLFI.cpp
+++ b/llvm/lib/MC/MCLFI.cpp
@@ -52,12 +52,11 @@ void initializeLFIMCStreamer(MCStreamer &Streamer, MCContext &Ctx,
   // Create the Target specific MCLFIRewriter.
   assert(TheTarget != nullptr);
   if (FlagEnableRewriting) {
-    Streamer.setLFIRewriter(
-        std::unique_ptr<MCLFIRewriter>(TheTarget->createMCLFIRewriter(
-            Ctx,
-            std::unique_ptr<MCRegisterInfo>(
-                TheTarget->createMCRegInfo(TheTriple)),
-            std::unique_ptr<MCInstrInfo>(TheTarget->createMCInstrInfo()))));
+    auto MRI =
+        std::unique_ptr<MCRegisterInfo>(TheTarget->createMCRegInfo(TheTriple));
+    auto MII = std::unique_ptr<MCInstrInfo>(TheTarget->createMCInstrInfo());
+    Streamer.setLFIRewriter(std::unique_ptr<MCLFIRewriter>(
+        TheTarget->createMCLFIRewriter(Ctx, std::move(MRI), std::move(MII))));
   }
 
   // Emit an ELF Note section in its own COMDAT group which identifies LFI

--- a/llvm/lib/MC/MCLFI.cpp
+++ b/llvm/lib/MC/MCLFI.cpp
@@ -35,16 +35,6 @@ cl::opt<bool> FlagEnableRewriting("lfi-enable-rewriter",
 void initializeLFIMCStreamer(MCStreamer &Streamer, MCContext &Ctx,
                              const Triple &TheTriple) {
   assert(TheTriple.isLFI());
-  const char *NoteName;
-  const char *NoteArch;
-  switch (TheTriple.getArch()) {
-  case Triple::aarch64:
-    NoteName = ".note.LFI.ABI.aarch64";
-    NoteArch = "aarch64";
-    break;
-  default:
-    reportFatalUsageError("Unsupported architecture for LFI");
-  }
 
   std::string Error; // empty
   const Target *TheTarget = TargetRegistry::lookupTarget(TheTriple, Error);
@@ -58,6 +48,22 @@ void initializeLFIMCStreamer(MCStreamer &Streamer, MCContext &Ctx,
     Streamer.setLFIRewriter(std::unique_ptr<MCLFIRewriter>(
         TheTarget->createMCLFIRewriter(Ctx, std::move(MRI), std::move(MII))));
   }
+}
+
+void emitLFINoteSection(MCStreamer &Streamer, MCContext &Ctx) {
+  const Triple &TheTriple = Ctx.getTargetTriple();
+  assert(TheTriple.isLFI());
+
+  const char *NoteName;
+  const char *NoteArch;
+  switch (TheTriple.getArch()) {
+  case Triple::aarch64:
+    NoteName = ".note.LFI.ABI.aarch64";
+    NoteArch = "aarch64";
+    break;
+  default:
+    reportFatalUsageError("Unsupported architecture for LFI");
+  }
 
   // Emit an ELF Note section in its own COMDAT group which identifies LFI
   // object files.
@@ -65,7 +71,6 @@ void initializeLFIMCStreamer(MCStreamer &Streamer, MCContext &Ctx,
                                          ELF::SHF_ALLOC | ELF::SHF_GROUP, 0,
                                          NoteName, /*IsComdat=*/true);
 
-  Streamer.pushSection();
   Streamer.switchSection(Note);
   Streamer.emitIntValue(strlen(NoteNamespace) + 1, 4);
   Streamer.emitIntValue(strlen(NoteArch) + 1, 4);
@@ -76,7 +81,6 @@ void initializeLFIMCStreamer(MCStreamer &Streamer, MCContext &Ctx,
   Streamer.emitBytes(NoteArch);
   Streamer.emitIntValue(0, 1); // NUL terminator
   Streamer.emitValueToAlignment(Align(4));
-  Streamer.popSection();
 }
 
 } // namespace llvm

--- a/llvm/lib/MC/MCLFI.cpp
+++ b/llvm/lib/MC/MCLFI.cpp
@@ -36,10 +36,10 @@ void initializeLFIMCStreamer(MCStreamer &Streamer, MCContext &Ctx,
                              const Triple &TheTriple) {
   assert(TheTriple.isLFI());
 
-  std::string Error; // empty
+  std::string Error;
   const Target *TheTarget = TargetRegistry::lookupTarget(TheTriple, Error);
 
-  // Create the Target specific MCLFIRewriter.
+  // Create the target-specific MCLFIRewriter.
   assert(TheTarget != nullptr);
   if (FlagEnableRewriting) {
     auto MRI =

--- a/llvm/test/MC/AArch64/LFI/abi-note.s
+++ b/llvm/test/MC/AArch64/LFI/abi-note.s
@@ -1,13 +1,13 @@
 // RUN: llvm-mc -triple aarch64_lfi %s | FileCheck %s
 
-// CHECK:      .section        .note.LFI.ABI.aarch64,"aG",@note,.note.LFI.ABI.aarch64,comdat
-// CHECK-NEXT: .word   4
-// CHECK-NEXT: .word   8
-// CHECK-NEXT: .word   1
-// CHECK-NEXT: .ascii  "LFI"
-// CHECK-NEXT: .byte   0
-// CHECK-NEXT: .p2align        2, 0x0
-// CHECK-NEXT: .ascii  "aarch64"
-// CHECK-NEXT: .byte   0
-// CHECK-NEXT: .p2align        2, 0x0
+// CHECK:      .section .note.LFI.ABI.aarch64,"aG",@note,.note.LFI.ABI.aarch64,comdat
+// CHECK-NEXT: .word 4
+// CHECK-NEXT: .word 8
+// CHECK-NEXT: .word 1
+// CHECK-NEXT: .ascii "LFI"
+// CHECK-NEXT: .byte 0
+// CHECK-NEXT: .p2align 2, 0x0
+// CHECK-NEXT: .ascii "aarch64"
+// CHECK-NEXT: .byte 0
+// CHECK-NEXT: .p2align 2, 0x0
 // CHECK-NEXT: .text

--- a/llvm/test/MC/AArch64/LFI/abi-note.s
+++ b/llvm/test/MC/AArch64/LFI/abi-note.s
@@ -1,0 +1,13 @@
+// RUN: llvm-mc -triple aarch64_lfi %s | FileCheck %s
+
+// CHECK:      .section        .note.LFI.ABI.aarch64,"aG",@note,.note.LFI.ABI.aarch64,comdat
+// CHECK-NEXT: .word   4
+// CHECK-NEXT: .word   8
+// CHECK-NEXT: .word   1
+// CHECK-NEXT: .ascii  "LFI"
+// CHECK-NEXT: .byte   0
+// CHECK-NEXT: .p2align        2, 0x0
+// CHECK-NEXT: .ascii  "aarch64"
+// CHECK-NEXT: .byte   0
+// CHECK-NEXT: .p2align        2, 0x0
+// CHECK-NEXT: .text

--- a/llvm/test/MC/AArch64/LFI/abi-note.s
+++ b/llvm/test/MC/AArch64/LFI/abi-note.s
@@ -1,4 +1,5 @@
 // RUN: llvm-mc -triple aarch64_lfi %s | FileCheck %s
+// RUN: llvm-mc -filetype=obj -triple aarch64_lfi %s | llvm-readelf -S - | FileCheck %s --check-prefix=ELF
 
 // CHECK:      .section .note.LFI.ABI.aarch64,"aG",@note,.note.LFI.ABI.aarch64,comdat
 // CHECK-NEXT: .word 4
@@ -10,4 +11,5 @@
 // CHECK-NEXT: .ascii "aarch64"
 // CHECK-NEXT: .byte 0
 // CHECK-NEXT: .p2align 2, 0x0
-// CHECK-NEXT: .text
+
+// ELF: .note.LFI.ABI.aarch64 NOTE {{.*}} AG

--- a/llvm/tools/llvm-mc/llvm-mc.cpp
+++ b/llvm/tools/llvm-mc/llvm-mc.cpp
@@ -632,8 +632,10 @@ int main(int argc, char **argv) {
                                            std::move(CE), std::move(MAB)));
 
     Triple T(TripleName);
-    if (T.isLFI())
+    if (T.isLFI()) {
+      Str->initSections(NoExecStack, *STI);
       initializeLFIMCStreamer(*Str.get(), Ctx, T);
+    }
   } else if (FileType == OFT_Null) {
     Str.reset(TheTarget->createNullStreamer(Ctx));
   } else {

--- a/llvm/tools/llvm-mc/llvm-mc.cpp
+++ b/llvm/tools/llvm-mc/llvm-mc.cpp
@@ -632,10 +632,8 @@ int main(int argc, char **argv) {
                                            std::move(CE), std::move(MAB)));
 
     Triple T(TripleName);
-    if (T.isLFI()) {
-      Str->initSections(*STI);
+    if (T.isLFI())
       initializeLFIMCStreamer(*Str.get(), Ctx, T);
-    }
   } else if (FileType == OFT_Null) {
     Str.reset(TheTarget->createNullStreamer(Ctx));
   } else {

--- a/llvm/tools/llvm-mc/llvm-mc.cpp
+++ b/llvm/tools/llvm-mc/llvm-mc.cpp
@@ -633,7 +633,7 @@ int main(int argc, char **argv) {
 
     Triple T(TripleName);
     if (T.isLFI()) {
-      Str->initSections(NoExecStack, *STI);
+      Str->initSections(*STI);
       initializeLFIMCStreamer(*Str.get(), Ctx, T);
     }
   } else if (FileType == OFT_Null) {


### PR DESCRIPTION
Calls `Streamer.setLFIRewriter` during generic LFIMCStreamer initialization rather than requiring it to be done during backend-specific initialization. This better follows the existing conventions in `create*` functions in `TargetRegistry.h`.

Also re-adds the call to initSections for LFI in `llvm-mc.cpp` (necessary in order to emit the ABI Note section), along with a test to make sure ABI note emission with the rewriter is working.