### PR TITLE
Revert "[lldb] [windows] Fix warning about unused static functions"

### DIFF
--- a/lldb/source/Host/windows/PythonPathSetup/PythonPathSetup.cpp
+++ b/lldb/source/Host/windows/PythonPathSetup/PythonPathSetup.cpp
@@ -19,7 +19,6 @@
 
 using namespace llvm;
 
-#ifdef LLDB_PYTHON_DLL_RELATIVE_PATH
 static std::string GetModulePath(HMODULE module) {
   std::vector<WCHAR> buffer(MAX_PATH);
   while (buffer.size() <= PATHCCH_MAX_CCH) {
@@ -41,6 +40,7 @@ static std::string GetModulePath(HMODULE module) {
 /// Returns the full path to the lldb.exe executable.
 static std::string GetPathToExecutable() { return GetModulePath(NULL); }
 
+#ifdef LLDB_PYTHON_DLL_RELATIVE_PATH
 bool AddPythonDLLToSearchPath() {
   std::string path_str = GetPathToExecutable();
   if (path_str.empty())


### PR DESCRIPTION
Reverts llvm/llvm-project#188531.

That change broke some buildbots, e.g. https://lab.llvm.org/buildbot/#/builders/141/builds/16639.

Even though one of the static functions, `GetPathToExecutable`, only was used by the function `AddPythonDLLToSearchPath` below, it turns out that `GetModulePath` is used in another place as well, guarded by a different ifdef.