### PR TITLE
[MLIR][NVVM] Add LLVM IR import support for nvvm.barrier

### DIFF
--- a/mlir/lib/Target/LLVMIR/Dialect/NVVM/LLVMIRToNVVMTranslation.cpp
+++ b/mlir/lib/Target/LLVMIR/Dialect/NVVM/LLVMIRToNVVMTranslation.cpp
@@ -33,18 +33,18 @@ static bool isConvertibleIntrinsic(llvm::Intrinsic::ID id) {
 static ArrayRef<unsigned> getSupportedIntrinsicsImpl() {
   static const SmallVector<unsigned> convertibleIntrinsics = [] {
     SmallVector<unsigned> ids = {
-#include "mlir/Dialect/LLVMIR/NVVMConvertibleLLVMIRIntrinsics.inc"      
+#include "mlir/Dialect/LLVMIR/NVVMConvertibleLLVMIRIntrinsics.inc"
     };
 
-  ids.push_back(llvm::Intrinsic::nvvm_barrier_cta_sync_aligned_all);
-  return ids;
+    ids.push_back(llvm::Intrinsic::nvvm_barrier_cta_sync_aligned_all);
+    return ids;
   }();
   return convertibleIntrinsics;
 }
 
-static LogicalResult convertBarrierAlignedAllIntrinsic(OpBuilder &builder,
-                                                      llvm::CallInst *inst,
-                                                      LLVM::ModuleImport &moduleImport) {
+static LogicalResult
+convertBarrierAlignedAllIntrinsic(OpBuilder &builder, llvm::CallInst *inst,
+                                  LLVM::ModuleImport &moduleImport) {
   if (inst->arg_size() != 1) {
     return failure();
   }

--- a/mlir/lib/Target/LLVMIR/Dialect/NVVM/LLVMIRToNVVMTranslation.cpp
+++ b/mlir/lib/Target/LLVMIR/Dialect/NVVM/LLVMIRToNVVMTranslation.cpp
@@ -14,6 +14,7 @@
 #include "mlir/Dialect/LLVMIR/NVVMDialect.h"
 #include "mlir/Target/LLVMIR/ModuleImport.h"
 #include "llvm/IR/ConstantRange.h"
+#include "llvm/IR/Constants.h"
 
 using namespace mlir;
 using namespace mlir::NVVM;
@@ -30,10 +31,42 @@ static bool isConvertibleIntrinsic(llvm::Intrinsic::ID id) {
 /// Returns the list of LLVM IR intrinsic identifiers that are convertible to
 /// MLIR NVVM dialect intrinsics.
 static ArrayRef<unsigned> getSupportedIntrinsicsImpl() {
-  static const SmallVector<unsigned> convertibleIntrinsics = {
-#include "mlir/Dialect/LLVMIR/NVVMConvertibleLLVMIRIntrinsics.inc"
-  };
+  static const SmallVector<unsigned> convertibleIntrinsics = [] {
+    SmallVector<unsigned> ids = {
+#include "mlir/Dialect/LLVMIR/NVVMConvertibleLLVMIRIntrinsics.inc"      
+    };
+
+  ids.push_back(llvm::Intrinsic::nvvm_barrier_cta_sync_aligned_all);
+  return ids;
+  }();
   return convertibleIntrinsics;
+}
+
+static LogicalResult convertBarrierAlignedAllIntrinsic(OpBuilder &builder,
+                                                      llvm::CallInst *inst,
+                                                      LLVM::ModuleImport &moduleImport) {
+  if (inst->arg_size() != 1) {
+    return failure();
+  }
+
+  Location loc = moduleImport.translateLoc(inst->getDebugLoc());
+  llvm::Value *idArg = inst->getArgOperand(0);
+
+  // Canonicalize all(i32 0) -> nvvm.barrier
+  if (auto *cst = llvm::dyn_cast<llvm::ConstantInt>(idArg);
+      cst && cst->isZero()) {
+    auto op = builder.create<NVVM::BarrierOp>(loc /* no barrier id */);
+    moduleImport.mapNoResultOp(inst, op);
+    return success();
+  }
+
+  FailureOr<Value> barrierId = moduleImport.convertValue(idArg);
+  if (failed(barrierId))
+    return failure();
+
+  auto op = builder.create<NVVM::BarrierOp>(loc, *barrierId);
+  moduleImport.mapNoResultOp(inst, op);
+  return success();
 }
 
 /// Converts the LLVM intrinsic to an MLIR NVVM dialect operation if a
@@ -43,6 +76,12 @@ static LogicalResult convertIntrinsicImpl(OpBuilder &odsBuilder,
                                           LLVM::ModuleImport &moduleImport) {
   llvm::Intrinsic::ID intrinsicID = inst->getIntrinsicID();
 
+  switch (intrinsicID) {
+  case llvm::Intrinsic::nvvm_barrier_cta_sync_aligned_all:
+    return convertBarrierAlignedAllIntrinsic(odsBuilder, inst, moduleImport);
+  default:
+    break;
+  }
   // Check if the intrinsic is convertible to an MLIR dialect counterpart and
   // copy the arguments to an an LLVM operands array reference for conversion.
   if (isConvertibleIntrinsic(intrinsicID)) {

--- a/mlir/test/Target/LLVMIR/Import/nvvmir.ll
+++ b/mlir/test/Target/LLVMIR/Import/nvvmir.ll
@@ -73,8 +73,17 @@ define float @nvvm_rcp(float %0) {
 
 ; CHECK-LABEL: @llvm_nvvm_barrier0()
 define void @llvm_nvvm_barrier0() {
-  ; CHECK: llvm.nvvm.barrier.cta.sync.aligned.all
+  ; CHECK: nvvm.barrier{{$}}
   call void @llvm.nvvm.barrier0()
+  ret void
+}
+
+; CHECK-LABEL: @llvm_nvvm_barrier_cta_sync_aligned_all
+define void @llvm_nvvm_barrier_cta_sync_aligned_all(i32 %id) {
+  ; CHECK: nvvm.barrier{{$}}
+  call void @llvm.nvvm.barrier.cta.sync.aligned.all(i32 0)
+  ; CHECK: nvvm.barrier id = %{{.*}}
+  call void @llvm.nvvm.barrier.cta.sync.aligned.all(i32 %id)
   ret void
 }
 
@@ -268,6 +277,8 @@ declare noundef i32 @llvm.nvvm.read.ptx.sreg.cluster.nctarank()
 declare float @llvm.nvvm.rcp.approx.ftz.f(float)
 
 declare void @llvm.nvvm.barrier0()
+
+declare void @llvm.nvvm.barrier.cta.sync.aligned.all(i32)
 
 declare i32 @llvm.nvvm.shfl.sync.bfly.i32(i32, i32, i32, i32)
 


### PR DESCRIPTION
Add hand-written import handler for `llvm.nvvm.barrier.cta.sync.aligned.all` intrinsic
- `barrier.cta.sync.aligned.all(i32 0)` imports as `nvvm.barrier`
- `barrier.cta.sync.aligned.all(i32 %id)` imports as `nvvm.barrier id = %id`

This PR intentionally does not modify the op as a single fixed LLVM_IntrOpBase mapping. The op already lowers dynamically to different NVVM intrinsic spellings depending on its operands/attributes. To preserve that abstraction, the PR adds explicit LLVM IR import handling for the relevant incoming spellings and normalizes them back to the same MLIR op.