### PR TITLE
[LLDB][DWARFASTParserClang] Remove assert.

### DIFF
--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserClang.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserClang.cpp
@@ -2036,7 +2036,6 @@ static std::optional<clang::APValue> MakeAPValue(const clang::ASTContext &ast,
       "error: unsupported template value type in die {0:x16}, "
       "please file a bug",
       die.GetOffset());
-  lldbassert(false && "Unsupported type for non-type template parameter");
 
   return std::nullopt;
 }


### PR DESCRIPTION
Removing an assert added by https://github.com/llvm/llvm-project/pull/187598 that is guaranteed to always fail, preventing MakeAPValue from ever returning std::nullopt. I suspect this was not intended to be left in the final commit, as it ensures all code past the assert is unreachable.