### PR TITLE
[lit] dealloc ApplyResult objects as they're waited on

### DIFF
--- a/llvm/utils/lit/lit/run.py
+++ b/llvm/utils/lit/lit/run.py
@@ -142,8 +142,10 @@ class Run(object):
 
     def _wait_for(self, async_results, deadline):
         timeout = deadline - time.time()
-        for idx, ar in enumerate(async_results):
+        idx = 0
+        while len(async_results) > 0:
             try:
+                ar = async_results.pop(0)
                 test = ar.get(timeout)
             except multiprocessing.TimeoutError:
                 raise TimeoutError()
@@ -153,6 +155,7 @@ class Run(object):
                     self.failures += 1
                     if self.failures == self.max_failures:
                         raise MaxFailuresError()
+            idx += 1
 
     # Update local test object "in place" from remote test object.  This
     # ensures that the original test object which is used for printing test


### PR DESCRIPTION
In _wait_for(), all async tasks are waited for. However, the objects
are held in the async_result list until the function calls complete.
This leads to about 3.6gig mem usage on my system when running
check-llvm, even though these objects aren't needed after the ar.get()
call.

Dealloc them as we go instead.

Addresses #188641
