### PR TITLE
[AArch64] ConditionOptimizer: modify intra-block path to use tryOptimizePair

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64ConditionOptimizer.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ConditionOptimizer.cpp
@@ -597,52 +597,21 @@ bool AArch64ConditionOptimizerImpl::optimizeIntraBlock(MachineBasicBlock &MBB) {
   }
 
   // Extract condition codes from both CSINCs (operand 3)
-  AArch64CC::CondCode FirstCond =
+  AArch64CC::CondCode FirstCondCode =
       (AArch64CC::CondCode)(int)FirstCSINC->getOperand(3).getImm();
-  AArch64CC::CondCode SecondCond =
+  AArch64CC::CondCode SecondCondCode =
       (AArch64CC::CondCode)(int)SecondCSINC->getOperand(3).getImm();
 
-  const int FirstImm = (int)FirstCmpMI->getOperand(2).getImm();
-  const int SecondImm = (int)SecondCmpMI->getOperand(2).getImm();
-
   LLVM_DEBUG(dbgs() << "Comparing intra-block CSINCs: "
-                    << AArch64CC::getCondCodeName(FirstCond) << " #" << FirstImm
-                    << " and " << AArch64CC::getCondCodeName(SecondCond) << " #"
-                    << SecondImm << '\n');
+                    << AArch64CC::getCondCodeName(FirstCondCode) << " #"
+                    << FirstCmpMI->getOperand(2).getImm() << " and "
+                    << AArch64CC::getCondCodeName(SecondCondCode) << " #"
+                    << SecondCmpMI->getOperand(2).getImm() << '\n');
 
-  // Check if both conditions are the same (GT/GT, LT/LT, HI/HI, LO/LO)
-  // and immediates differ by 1.
-  if (FirstCond == SecondCond &&
-      (isGreaterThan(FirstCond) || isLessThan(FirstCond)) &&
-      std::abs(SecondImm - FirstImm) == 1) {
-    // Pick which comparison to adjust to match the other
-    // For GT/HI: adjust the one with smaller immediate
-    // For LT/LO: adjust the one with larger immediate
-    bool adjustFirst = (FirstImm < SecondImm);
-    if (isLessThan(FirstCond)) {
-      adjustFirst = !adjustFirst;
-    }
+  CmpCondPair First{FirstCmpMI, FirstCSINC, FirstCondCode};
+  CmpCondPair Second{SecondCmpMI, SecondCSINC, SecondCondCode};
 
-    MachineInstr *CmpToAdjust = adjustFirst ? FirstCmpMI : SecondCmpMI;
-    MachineInstr *CSINCToAdjust = adjustFirst ? FirstCSINC : SecondCSINC;
-    AArch64CC::CondCode CondToAdjust = adjustFirst ? FirstCond : SecondCond;
-    int TargetImm = adjustFirst ? SecondImm : FirstImm;
-
-    CmpInfo Adj = getAdjustedCmpInfo(CmpToAdjust, CondToAdjust);
-
-    if (Adj.Imm == TargetImm &&
-        Adj.Opc == (adjustFirst ? SecondCmpMI : FirstCmpMI)->getOpcode()) {
-      LLVM_DEBUG(dbgs() << "Successfully optimizing intra-block CSINC pair\n");
-
-      // Modify the selected CMP and CSINC
-      CmpCondPair ToChange{CmpToAdjust, CSINCToAdjust, CondToAdjust};
-      applyCmpAdjustment(ToChange, Adj);
-
-      return true;
-    }
-  }
-
-  return false;
+  return tryOptimizePair(First, Second);
 }
 
 // Optimizes CMP+Bcc pairs across two basic blocks in the dominator tree.

--- a/llvm/test/CodeGen/AArch64/aarch64-condopt-unsigned.mir
+++ b/llvm/test/CodeGen/AArch64/aarch64-condopt-unsigned.mir
@@ -279,6 +279,37 @@ body:             |
 ...
 
 ---
+# CSINC/CSINC with HI/LO (unsigned > and <): imm differs by 2
+# First:  cmp w0, #10; csinc ..., hi  (w0 > 10 unsigned)
+# Second: cmp w0, #12; csinc ..., lo  (w0 < 12 unsigned)
+# Expected: Both adjusted to use immediate 11 with HS/LS respectively
+name:            csinc_hi_lo_intrablock
+tracksRegLiveness: true
+body:             |
+  bb.0:
+    liveins: $w0
+    ; CHECK-LABEL: name: csinc_hi_lo_intrablock
+    ; CHECK: liveins: $w0
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:gpr32common = COPY $w0
+    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:gpr32 = COPY [[COPY]]
+    ; CHECK-NEXT: [[SUBSWri:%[0-9]+]]:gpr32 = SUBSWri [[COPY]], 11, 0, implicit-def $nzcv
+    ; CHECK-NEXT: [[CSINCWr:%[0-9]+]]:gpr32 = CSINCWr [[COPY1]], $wzr, 2, implicit $nzcv
+    ; CHECK-NEXT: [[SUBSWri1:%[0-9]+]]:gpr32 = SUBSWri [[COPY]], 11, 0, implicit-def $nzcv
+    ; CHECK-NEXT: [[CSINCWr1:%[0-9]+]]:gpr32 = CSINCWr [[COPY1]], $wzr, 9, implicit $nzcv
+    ; CHECK-NEXT: $w0 = COPY [[CSINCWr1]]
+    ; CHECK-NEXT: RET undef $lr, implicit $w0
+    %0:gpr32common = COPY $w0
+    %1:gpr32 = COPY %0
+    %2:gpr32 = SUBSWri %0, 10, 0, implicit-def $nzcv
+    %3:gpr32 = CSINCWr %1, $wzr, 8, implicit $nzcv
+    %4:gpr32 = SUBSWri %0, 12, 0, implicit-def $nzcv
+    %5:gpr32 = CSINCWr %1, $wzr, 3, implicit $nzcv
+    $w0 = COPY %5
+    RET undef $lr, implicit $w0
+...
+
+---
 # Test: HI with immediate 0 can be optimized by adjusting upward
 # Head: cmp w0, #0; b.hi  (w0 > 0 unsigned)
 # True: cmp w0, #1; b.hi  (w0 > 1 unsigned)


### PR DESCRIPTION
Update `optimizeIntraBlock` to use the `tryOptimizePair` method instead of attempting to optimise directly. This unifies optimisation logic between the intra- and cross-block paths and extends intra-block to support the differs-by-two case