### PR TITLE
[scudo] Add Last entry to ReleaseToOS enum.

### DIFF
--- a/compiler-rt/lib/scudo/standalone/common.h
+++ b/compiler-rt/lib/scudo/standalone/common.h
@@ -248,6 +248,7 @@ enum class ReleaseToOS : u8 {
              // take.
   ForceFast, // Force release pages to the OS, but do it quickly and skip any
              // cases where a lock is held by another thread.
+  Last = ForceFast, // Must be set to the last entry in the enum.
 };
 
 constexpr unsigned char PatternFillByte = 0xAB;


### PR DESCRIPTION
This allows static asserts to be set in tracing code that might use the ReleaseToOS values as indexes.

This would have caused a compile failure instead of a runtime crash when I added the use of a new ReleaseToOS value.