### PR TITLE
[libc++] Add another const_cast to support hash_map copy assignment

### DIFF
--- a/libcxx/include/__hash_table
+++ b/libcxx/include/__hash_table
@@ -1043,7 +1043,9 @@ private:
 
   _LIBCPP_HIDE_FROM_ABI __next_pointer __detach() _NOEXCEPT;
 
-  template <class _From, class _ValueT = _Tp, __enable_if_t<__is_hash_value_type<_ValueT>::value || __is_pair_v<_ValueT>, int> = 0>
+  template <class _From,
+            class _ValueT                                                                    = _Tp,
+            __enable_if_t<__is_hash_value_type<_ValueT>::value || __is_pair_v<_ValueT>, int> = 0>
   _LIBCPP_HIDE_FROM_ABI void __assign_value(__get_hash_node_value_type_t<_Tp>& __lhs, _From&& __rhs) {
     // This is technically UB, since the object was constructed as `const`.
     // Clang doesn't optimize on this currently though.
@@ -1054,7 +1056,9 @@ private:
     __lhs.second                                                      = std::forward<_From>(__rhs).second;
   }
 
-  template <class _From, class _ValueT = _Tp, __enable_if_t<!__is_hash_value_type<_ValueT>::value && !__is_pair_v<_ValueT>, int> = 0>
+  template <class _From,
+            class _ValueT                                                                      = _Tp,
+            __enable_if_t<!__is_hash_value_type<_ValueT>::value && !__is_pair_v<_ValueT>, int> = 0>
   _LIBCPP_HIDE_FROM_ABI void __assign_value(_Tp& __lhs, _From&& __rhs) {
     __lhs = std::forward<_From>(__rhs);
   }

--- a/libcxx/include/__hash_table
+++ b/libcxx/include/__hash_table
@@ -19,6 +19,7 @@
 #include <__cstddef/ptrdiff_t.h>
 #include <__cstddef/size_t.h>
 #include <__functional/hash.h>
+#include <__fwd/pair.h>
 #include <__iterator/iterator_traits.h>
 #include <__math/rounding_functions.h>
 #include <__memory/addressof.h>
@@ -1042,15 +1043,18 @@ private:
 
   _LIBCPP_HIDE_FROM_ABI __next_pointer __detach() _NOEXCEPT;
 
-  template <class _From, class _ValueT = _Tp, __enable_if_t<__is_hash_value_type<_ValueT>::value, int> = 0>
+  template <class _From, class _ValueT = _Tp, __enable_if_t<__is_hash_value_type<_ValueT>::value || __is_pair_v<_ValueT>, int> = 0>
   _LIBCPP_HIDE_FROM_ABI void __assign_value(__get_hash_node_value_type_t<_Tp>& __lhs, _From&& __rhs) {
     // This is technically UB, since the object was constructed as `const`.
     // Clang doesn't optimize on this currently though.
-    const_cast<key_type&>(__lhs.first) = const_cast<__copy_cvref_t<_From, key_type>&&>(__rhs.first);
-    __lhs.second                       = std::forward<_From>(__rhs).second;
+    //
+    // The enable_if check for __is_pair_v is only needed to support
+    // __gnu_cxx::hash_map and may be removed if hash_map is removed.
+    const_cast<__remove_const_t<decltype(__lhs.first)>&>(__lhs.first) = std::forward<_From>(__rhs).first;
+    __lhs.second                                                      = std::forward<_From>(__rhs).second;
   }
 
-  template <class _From, class _ValueT = _Tp, __enable_if_t<!__is_hash_value_type<_ValueT>::value, int> = 0>
+  template <class _From, class _ValueT = _Tp, __enable_if_t<!__is_hash_value_type<_ValueT>::value && !__is_pair_v<_ValueT>, int> = 0>
   _LIBCPP_HIDE_FROM_ABI void __assign_value(_Tp& __lhs, _From&& __rhs) {
     __lhs = std::forward<_From>(__rhs);
   }

--- a/libcxx/test/extensions/gnu/hash_map/copy.pass.cpp
+++ b/libcxx/test/extensions/gnu/hash_map/copy.pass.cpp
@@ -23,5 +23,9 @@ int main(int, char**) {
 
   assert(map2.size() == 2);
 
+  map.insert(std::make_pair(3, 1));
+  map2 = map;
+  assert(map2.size() == 3);
+
   return 0;
 }

--- a/libcxx/test/extensions/gnu/hash_map/copy.pass.cpp
+++ b/libcxx/test/extensions/gnu/hash_map/copy.pass.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// ADDITIONAL_COMPILE_FLAGS: -Wno-deprecated
+// ADDITIONAL_COMPILE_FLAGS: -Wno-deprecated -Wno-deprecated-copy
 
 // hash_map::hash_map(const hash_map&)
 


### PR DESCRIPTION
There was one more const_cast needed after #183223 without which
copy assignment of hash_map was broken. Add it, together with a copy
assignment test.
