### PR TITLE
[Clang] Implement consteval blocks for C++26

### DIFF
--- a/clang/docs/LanguageExtensions.rst
+++ b/clang/docs/LanguageExtensions.rst
@@ -1969,6 +1969,7 @@ Pack Indexing                                 __cpp_pack_indexing              C
 ``= delete ("should have a reason");``        __cpp_deleted_function           C++26         C++03
 Variadic Friends                              __cpp_variadic_friend            C++26         C++03
 Trivial Relocatability                        __cpp_trivial_relocatability     C++26         C++03
+``consteval`` Blocks                                                           C++26         C++20
 --------------------------------------------- -------------------------------- ------------- -------------
 Designated initializers (N494)                                                 C99           C89
 ``_Complex`` (N693)                                                            C99           C89, C++

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -124,6 +124,9 @@ C++ Language Changes
 C++2c Feature Support
 ^^^^^^^^^^^^^^^^^^^^^
 
+- Clang now supports more parts of `P2996 <https://wg21.link/p2996>`_ Reflection for C++26, including
+  ``consteval`` blocks.
+
 C++23 Feature Support
 ^^^^^^^^^^^^^^^^^^^^^
 

--- a/clang/include/clang/AST/ASTNodeTraverser.h
+++ b/clang/include/clang/AST/ASTNodeTraverser.h
@@ -683,6 +683,10 @@ public:
     Visit(D->getMessage());
   }
 
+  void VisitConstevalBlockDecl(const ConstevalBlockDecl *D) {
+    Visit(D->getCallExpr());
+  }
+
   void VisitFunctionTemplateDecl(const FunctionTemplateDecl *D) {
     dumpTemplateDecl(D);
   }

--- a/clang/include/clang/AST/DeclCXX.h
+++ b/clang/include/clang/AST/DeclCXX.h
@@ -4191,8 +4191,7 @@ public:
 class ConstevalBlockDecl : public Decl {
   Expr *Call;
 
-  ConstevalBlockDecl(DeclContext *DC, SourceLocation ConstevalLoc,
-                     Expr *Call)
+  ConstevalBlockDecl(DeclContext *DC, SourceLocation ConstevalLoc, Expr *Call)
       : Decl(ConstevalBlock, DC, ConstevalLoc), Call(Call) {}
 
   virtual void anchor();
@@ -4201,8 +4200,7 @@ public:
   friend class ASTDeclReader;
 
   static ConstevalBlockDecl *Create(ASTContext &C, DeclContext *DC,
-                                    SourceLocation ConstevalLoc,
-                                    Expr *Expr);
+                                    SourceLocation ConstevalLoc, Expr *Expr);
   static ConstevalBlockDecl *CreateDeserialized(ASTContext &C, GlobalDeclID ID);
 
   /// Get the call expression that invokes the lambda that is the body of this
@@ -4211,7 +4209,7 @@ public:
   const Expr *getCallExpr() const { return Call; }
 
   /// Get the lambda that corresponds to the body of the consteval block.
-  LambdaExpr* getLambda();
+  LambdaExpr *getLambda();
   const LambdaExpr *getLambda() const {
     return const_cast<ConstevalBlockDecl *>(this)->getLambda();
   }

--- a/clang/include/clang/AST/DeclCXX.h
+++ b/clang/include/clang/AST/DeclCXX.h
@@ -397,6 +397,10 @@ private:
     LLVM_PREFERRED_TYPE(bool)
     unsigned IsGenericLambda : 1;
 
+    /// Whether this is the body of a C++26 consteval-block-declaration.
+    LLVM_PREFERRED_TYPE(bool)
+    unsigned IsConstevalBlock : 1;
+
     /// The Default Capture.
     LLVM_PREFERRED_TYPE(LambdaCaptureDefault)
     unsigned CaptureDefault : 2;
@@ -435,11 +439,12 @@ private:
     TypeSourceInfo *MethodTyInfo;
 
     LambdaDefinitionData(CXXRecordDecl *D, TypeSourceInfo *Info, unsigned DK,
-                         bool IsGeneric, LambdaCaptureDefault CaptureDefault)
+                         bool IsGeneric, bool IsConstevalBlock,
+                         LambdaCaptureDefault CaptureDefault)
         : DefinitionData(D), DependencyKind(DK), IsGenericLambda(IsGeneric),
-          CaptureDefault(CaptureDefault), NumCaptures(0),
-          NumExplicitCaptures(0), HasKnownInternalLinkage(0), ManglingNumber(0),
-          IndexInContext(0), MethodTyInfo(Info) {
+          IsConstevalBlock(IsConstevalBlock), CaptureDefault(CaptureDefault),
+          NumCaptures(0), NumExplicitCaptures(0), HasKnownInternalLinkage(0),
+          ManglingNumber(0), IndexInContext(0), MethodTyInfo(Info) {
       IsLambda = true;
 
       // C++1z [expr.prim.lambda]p4:
@@ -567,6 +572,7 @@ public:
   static CXXRecordDecl *CreateLambda(const ASTContext &C, DeclContext *DC,
                                      TypeSourceInfo *Info, SourceLocation Loc,
                                      unsigned DependencyKind, bool IsGeneric,
+                                     bool IsConstevalBlock,
                                      LambdaCaptureDefault CaptureDefault);
   static CXXRecordDecl *CreateDeserialized(const ASTContext &C,
                                            GlobalDeclID ID);
@@ -1025,6 +1031,10 @@ public:
   /// lambda function object (i.e. function call operator is
   /// a template).
   bool isGenericLambda() const;
+
+  /// Determine whether this class describes a lambda that is the body
+  /// of a C++26 consteval-block-declaration.
+  bool isLambdaForConstevalBlock() const;
 
   /// Determine whether this lambda should have an implicit default constructor
   /// and copy and move assignment operators.
@@ -4175,6 +4185,41 @@ public:
 
   static bool classof(const Decl *D) { return classofKind(D->getKind()); }
   static bool classofKind(Kind K) { return K == StaticAssert; }
+};
+
+/// A C++26 consteval block declaration.
+class ConstevalBlockDecl : public Decl {
+  Expr *Call;
+
+  ConstevalBlockDecl(DeclContext *DC, SourceLocation ConstevalLoc,
+                     Expr *Call)
+      : Decl(ConstevalBlock, DC, ConstevalLoc), Call(Call) {}
+
+  virtual void anchor();
+
+public:
+  friend class ASTDeclReader;
+
+  static ConstevalBlockDecl *Create(ASTContext &C, DeclContext *DC,
+                                    SourceLocation ConstevalLoc,
+                                    Expr *Expr);
+  static ConstevalBlockDecl *CreateDeserialized(ASTContext &C, GlobalDeclID ID);
+
+  /// Get the call expression that invokes the lambda that is the body of this
+  /// consteval block.
+  Expr *getCallExpr() { return Call; }
+  const Expr *getCallExpr() const { return Call; }
+
+  /// Get the lambda that corresponds to the body of the consteval block.
+  LambdaExpr* getLambda();
+  const LambdaExpr *getLambda() const {
+    return const_cast<ConstevalBlockDecl *>(this)->getLambda();
+  }
+
+  SourceRange getSourceRange() const override LLVM_READONLY;
+
+  static bool classof(const Decl *D) { return classofKind(D->getKind()); }
+  static bool classofKind(Kind K) { return K == ConstevalBlock; }
 };
 
 /// A binding in a decomposition declaration. For instance, given:

--- a/clang/include/clang/AST/Expr.h
+++ b/clang/include/clang/AST/Expr.h
@@ -762,6 +762,8 @@ public:
     /// evaluation is not part of the evaluation, but all other temporaries
     /// are destroyed.
     ImmediateInvocation,
+    /// A consteval block.
+    ConstevalBlock,
   };
 
   /// Evaluate an expression that is required to be a constant expression. Does

--- a/clang/include/clang/AST/ODRDiagsEmitter.h
+++ b/clang/include/clang/AST/ODRDiagsEmitter.h
@@ -99,12 +99,15 @@ private:
   // err_module_odr_violation_mismatch_decl_unknown,
   // and note_module_odr_violation_mismatch_decl_unknown
   // This list should be the same Decl's as in ODRHash::isSubDeclToBeProcessed
+  //
+  // FIXME: Use %enum_select for this.
   enum ODRMismatchDecl {
     EndOfClass,
     PublicSpecifer,
     PrivateSpecifer,
     ProtectedSpecifer,
     StaticAssert,
+    ConstevalBlock,
     Field,
     CXXMethod,
     TypeAlias,

--- a/clang/include/clang/AST/RecursiveASTVisitor.h
+++ b/clang/include/clang/AST/RecursiveASTVisitor.h
@@ -1748,9 +1748,8 @@ DEF_TRAVERSE_DECL(StaticAssertDecl, {
   TRY_TO(TraverseStmt(D->getMessage()));
 })
 
-DEF_TRAVERSE_DECL(ConstevalBlockDecl, {
-  TRY_TO(TraverseStmt(D->getCallExpr()));
-})
+DEF_TRAVERSE_DECL(ConstevalBlockDecl,
+                  { TRY_TO(TraverseStmt(D->getCallExpr())); })
 
 DEF_TRAVERSE_DECL(TranslationUnitDecl, {
   // Code in an unnamed namespace shows up automatically in

--- a/clang/include/clang/AST/RecursiveASTVisitor.h
+++ b/clang/include/clang/AST/RecursiveASTVisitor.h
@@ -1748,6 +1748,10 @@ DEF_TRAVERSE_DECL(StaticAssertDecl, {
   TRY_TO(TraverseStmt(D->getMessage()));
 })
 
+DEF_TRAVERSE_DECL(ConstevalBlockDecl, {
+  TRY_TO(TraverseStmt(D->getCallExpr()));
+})
+
 DEF_TRAVERSE_DECL(TranslationUnitDecl, {
   // Code in an unnamed namespace shows up automatically in
   // decls_begin()/decls_end().  Thus we don't need to recurse on

--- a/clang/include/clang/Basic/DeclNodes.td
+++ b/clang/include/clang/Basic/DeclNodes.td
@@ -101,6 +101,7 @@ def AccessSpec : DeclNode<Decl>;
 def Friend : DeclNode<Decl>;
 def FriendTemplate : DeclNode<Decl>;
 def StaticAssert : DeclNode<Decl>;
+def ConstevalBlock : DeclNode<Decl>;
 def Block : DeclNode<Decl, "blocks">, DeclContext;
 def OutlinedFunction : DeclNode<Decl>, DeclContext;
 def Captured : DeclNode<Decl>, DeclContext;

--- a/clang/include/clang/Basic/DiagnosticASTKinds.td
+++ b/clang/include/clang/Basic/DiagnosticASTKinds.td
@@ -700,13 +700,13 @@ def err_module_odr_violation_mismatch_decl : Error<
   "%q0 has different definitions in different modules; first difference is "
   "%select{definition in module '%2'|defined here}1 found "
   "%select{end of class|public access specifier|private access specifier|"
-  "protected access specifier|static assert|field|method|type alias|typedef|"
+  "protected access specifier|static assert|consteval block|field|method|type alias|typedef|"
   "data member|friend declaration|function template|method|instance variable|"
   "property}3">;
 def note_module_odr_violation_mismatch_decl : Note<
   "but in %select{'%1'|definition here}0 found "
   "%select{end of class|public access specifier|private access specifier|"
-  "protected access specifier|static assert|field|method|type alias|typedef|"
+  "protected access specifier|static assert|consteval block|field|method|type alias|typedef|"
   "data member|friend declaration|function template|method|instance variable|"
   "property}2">;
 
@@ -717,6 +717,7 @@ def err_module_odr_violation_record : Error<
   "static assert with condition|"
   "static assert with message|"
   "static assert with %select{|no }4message|"
+  "consteval block|"
   "%select{method %5|constructor|destructor}4|"
   "%select{method %5|constructor|destructor}4 "
     "is %select{not deleted|deleted}6|"
@@ -768,6 +769,7 @@ def note_module_odr_violation_record : Note<"but in '%0' found "
   "static assert with different condition|"
   "static assert with different message|"
   "static assert with %select{|no }2message|"
+  "consteval block with different body|"
   "%select{method %3|constructor|destructor}2|"
   "%select{method %3|constructor|destructor}2 "
     "is %select{not deleted|deleted}4|"
@@ -1003,12 +1005,12 @@ def note_module_odr_violation_objc_property : Note<
 def err_module_odr_violation_mismatch_decl_unknown : Error<
   "%q0 %select{with definition in module '%2'|defined here}1 has different "
   "definitions in different modules; first difference is this "
-  "%select{||||static assert|field|method|type alias|typedef|data member|"
+  "%select{||||static assert|consteval block|field|method|type alias|typedef|data member|"
   "friend declaration|function template|method|instance variable|"
   "property|unexpected decl}3">;
 def note_module_odr_violation_mismatch_decl_unknown : Note<
   "but in %select{'%1'|definition here}0 found "
-  "%select{||||different static assert|different field|different method|"
+  "%select{||||different static assert|different consteval block|different field|different method|"
   "different type alias|different typedef|different data member|"
   "different friend declaration|different function template|different method|"
   "different instance variable|different property|another unexpected decl}2">;

--- a/clang/include/clang/Basic/DiagnosticParseKinds.td
+++ b/clang/include/clang/Basic/DiagnosticParseKinds.td
@@ -894,7 +894,7 @@ def warn_cxx98_compat_two_right_angle_brackets : Warning<
   "consecutive right angle brackets are incompatible with C++98 (use '> >')">,
   InGroup<CXX98Compat>, DefaultIgnore;
 def err_templated_invalid_declaration : Error<
-  "a static_assert declaration cannot be a template">;
+  "a %select{static_assert|consteval block}0 declaration cannot be a template">;
 def err_multiple_template_declarators : Error<
   "%select{|a template declaration|an explicit template specialization|"
   "an explicit template instantiation}0 can "

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -61,6 +61,7 @@ defm constexpr_static_var : CXX23Compat<
 
 // C++26 compatibility with C++23 and earlier.
 defm decomp_decl_cond : CXX26Compat<"structured binding declaration in a condition is">;
+defm consteval_block : CXX26Compat<"consteval blocks are">;
 
 // Compatibility warnings duplicated across multiple language versions.
 foreach std = [14, 20, 23] in {
@@ -1756,7 +1757,8 @@ def err_static_assert_requirement_failed : Error<
   "static assertion failed due to requirement '%0'%select{: %2|}1">;
 def note_expr_evaluates_to : Note<
   "expression evaluates to '%0 %1 %2'">;
-
+def err_consteval_block_eval_failed : Error<
+  "could not evaluate consteval block">;
 
 def subst_user_defined_msg : TextSubstitution<
   "%select{the message|the expression}0 in "
@@ -6214,7 +6216,7 @@ def err_unexpanded_parameter_pack : Error<
   "using declaration|friend declaration|qualifier|initializer|default argument|"
   "non-type template parameter type|exception type|explicit specialization|"
   "partial specialization|__if_exists name|__if_not_exists name|lambda|block|"
-  "type constraint|requirement|requires clause}0 "
+  "type constraint|requirement|requires clause|consteval block}0 "
   "contains%plural{0: an|:}1 unexpanded parameter pack"
   "%plural{0:|1: %2|2:s %2 and %3|:s %2, %3, ...}1">;
 
@@ -7433,7 +7435,7 @@ def err_illegal_decl_mempointer_in_nonclass
 def err_reference_to_void : Error<"cannot form a reference to 'void'">;
 def err_nonfunction_block_type : Error<
   "block pointer to non-function type is invalid">;
-def err_return_block_has_expr : Error<"void block should not return a value">;
+def err_return_block_has_expr : Error<"%select{void|consteval}0 block should not return a value">;
 def err_block_return_missing_expr : Error<
   "non-void block should return a value">;
 def err_func_def_incomplete_result : Error<
@@ -8867,11 +8869,16 @@ let CategoryName = "Lambda Issue" in {
   def err_lambda_impcap : Error<
     "variable %0 cannot be implicitly captured in a lambda with no "
     "capture-default specified">;
+  def err_consteval_block_capture : Error<
+    "cannot capture variable %0 in consteval block">;
+  def err_consteval_block_this_invalid : Error<
+    "cannot capture 'this' in consteval block">;
   def note_lambda_variable_capture_fixit : Note<
     "capture %0 by %select{value|reference}1">;
   def note_lambda_default_capture_fixit : Note<
     "default capture by %select{value|reference}0">;
   def note_lambda_decl : Note<"lambda expression begins here">;
+  def note_consteval_block : Note<"consteval block begins here">;
   def err_lambda_unevaluated_operand : Error<
     "lambda expression in an unevaluated operand">;
   def err_lambda_in_constant_expression : Error<

--- a/clang/include/clang/Parse/Parser.h
+++ b/clang/include/clang/Parse/Parser.h
@@ -4694,8 +4694,18 @@ private:
                         LambdaIntroducerTentativeParse *Tentative = nullptr);
 
   /// ParseLambdaExpressionAfterIntroducer - Parse the rest of a lambda
-  /// expression.
-  ExprResult ParseLambdaExpressionAfterIntroducer(LambdaIntroducer &Intro);
+  /// expression. If ConstevalBlockStart is valid, we're parsing the body
+  /// of a C++26 consteval block.
+  ExprResult ParseLambdaExpressionAfterIntroducer(LambdaIntroducer &Intro,
+    SourceLocation ConstevalBlockStart = {});
+
+  /// ParseConstevalBlockDeclaration - Parse a C++26 'consteval' block.
+  ///
+  /// \verbatim
+  ///       consteval-block-declaration:
+  //          consteval compound-statement
+  /// \endverbatim
+  Decl *ParseConstevalBlockDeclaration(SourceLocation &DeclEnd);
 
   //===--------------------------------------------------------------------===//
   // C++ 5.2p1: C++ Casts

--- a/clang/include/clang/Parse/Parser.h
+++ b/clang/include/clang/Parse/Parser.h
@@ -4696,8 +4696,9 @@ private:
   /// ParseLambdaExpressionAfterIntroducer - Parse the rest of a lambda
   /// expression. If ConstevalBlockStart is valid, we're parsing the body
   /// of a C++26 consteval block.
-  ExprResult ParseLambdaExpressionAfterIntroducer(LambdaIntroducer &Intro,
-    SourceLocation ConstevalBlockStart = {});
+  ExprResult
+  ParseLambdaExpressionAfterIntroducer(LambdaIntroducer &Intro,
+                                       SourceLocation ConstevalBlockStart = {});
 
   /// ParseConstevalBlockDeclaration - Parse a C++26 'consteval' block.
   ///

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -6051,6 +6051,9 @@ public:
                                      Expr *AssertExpr, Expr *AssertMessageExpr,
                                      SourceLocation RParenLoc, bool Failed);
 
+  Decl *ActOnConstevalBlockDeclaration(SourceLocation ConstevalLoc, Expr *Call);
+  Decl *BuildConstevalBlockDeclaration(SourceLocation ConstevalLoc, Expr *Call);
+
   /// Try to print more useful information about a failed static_assert
   /// with expression \E
   void DiagnoseStaticAssertDetails(const Expr *E);
@@ -9143,6 +9146,7 @@ public:
   CXXRecordDecl *createLambdaClosureType(SourceRange IntroducerRange,
                                          TypeSourceInfo *Info,
                                          unsigned LambdaDependencyKind,
+                                         bool ForConstevalBlock,
                                          LambdaCaptureDefault CaptureDefault);
 
   /// Number lambda for linkage purposes if necessary.
@@ -9218,6 +9222,7 @@ public:
   /// We do the capture lookup here, but they are not actually captured until
   /// after we know what the qualifiers of the call operator are.
   void ActOnLambdaExpressionAfterIntroducer(LambdaIntroducer &Intro,
+                                            bool ForConstevalBlock,
                                             Scope *CurContext);
 
   /// This is called after parsing the explicit template parameter list
@@ -14561,6 +14566,9 @@ public:
 
     // A requires-clause.
     UPPC_RequiresClause,
+
+    /// The body of a consteval block.
+    UPPC_ConstevalBlock,
   };
 
   /// Diagnose unexpanded parameter packs.

--- a/clang/include/clang/Serialization/ASTBitCodes.h
+++ b/clang/include/clang/Serialization/ASTBitCodes.h
@@ -1463,6 +1463,9 @@ enum DeclCode {
   /// \brief A StaticAssertDecl record.
   DECL_STATIC_ASSERT,
 
+  /// A ConstevalBlockDecl record.
+  DECL_CONSTEVAL_BLOCK,
+
   /// A record containing CXXBaseSpecifiers.
   DECL_CXX_BASE_SPECIFIERS,
 

--- a/clang/lib/AST/ASTImporter.cpp
+++ b/clang/lib/AST/ASTImporter.cpp
@@ -516,6 +516,7 @@ namespace clang {
     ExpectedDecl VisitEmptyDecl(EmptyDecl *D);
     ExpectedDecl VisitAccessSpecDecl(AccessSpecDecl *D);
     ExpectedDecl VisitStaticAssertDecl(StaticAssertDecl *D);
+    ExpectedDecl VisitConstevalBlockDecl(ConstevalBlockDecl *D);
     ExpectedDecl VisitTranslationUnitDecl(TranslationUnitDecl *D);
     ExpectedDecl VisitBindingDecl(BindingDecl *D);
     ExpectedDecl VisitNamespaceDecl(NamespaceDecl *D);
@@ -2863,6 +2864,29 @@ ExpectedDecl ASTNodeImporter::VisitStaticAssertDecl(StaticAssertDecl *D) {
   return ToD;
 }
 
+ExpectedDecl ASTNodeImporter::VisitConstevalBlockDecl(ConstevalBlockDecl *D) {
+  auto DCOrErr = Importer.ImportContext(D->getDeclContext());
+  if (!DCOrErr)
+    return DCOrErr.takeError();
+  DeclContext *DC = *DCOrErr;
+  DeclContext *LexicalDC = DC;
+
+  Error Err = Error::success();
+  auto ToLocation = importChecked(Err, D->getLocation());
+  auto ToCallExpr = importChecked(Err, D->getCallExpr());
+  if (Err)
+    return std::move(Err);
+
+  ConstevalBlockDecl *ToD;
+  if (GetImportedOrCreateDecl(ToD, D, Importer.getToContext(), DC, ToLocation,
+                              ToCallExpr))
+    return ToD;
+
+  ToD->setLexicalDeclContext(LexicalDC);
+  LexicalDC->addDeclInternal(ToD);
+  return ToD;
+}
+
 ExpectedDecl ASTNodeImporter::VisitNamespaceDecl(NamespaceDecl *D) {
   // Import the major distinguishing characteristics of this namespace.
   DeclContext *DC, *LexicalDC;
@@ -3442,7 +3466,8 @@ ExpectedDecl ASTNodeImporter::VisitRecordDecl(RecordDecl *D) {
       if (GetImportedOrCreateSpecialDecl(
               D2CXX, CXXRecordDecl::CreateLambda, D, Importer.getToContext(),
               DC, *TInfoOrErr, Loc, DCXX->getLambdaDependencyKind(),
-              DCXX->isGenericLambda(), DCXX->getLambdaCaptureDefault()))
+              DCXX->isGenericLambda(), DCXX->isLambdaForConstevalBlock(),
+              DCXX->getLambdaCaptureDefault()))
         return D2CXX;
       Decl *ContextDecl = DCXX->getLambdaContextDecl();
       ExpectedDecl CDeclOrErr = import(ContextDecl);

--- a/clang/lib/AST/ByteCode/Compiler.cpp
+++ b/clang/lib/AST/ByteCode/Compiler.cpp
@@ -5966,8 +5966,9 @@ template <class Emitter>
 bool Compiler<Emitter>::visitDeclStmt(const DeclStmt *DS,
                                       bool EvaluateConditionDecl) {
   for (const auto *D : DS->decls()) {
-    if (isa<StaticAssertDecl, TagDecl, TypedefNameDecl, BaseUsingDecl,
-            FunctionDecl, NamespaceAliasDecl, UsingDirectiveDecl>(D))
+    if (isa<StaticAssertDecl, ConstevalBlockDecl, TagDecl, TypedefNameDecl,
+            BaseUsingDecl, FunctionDecl, NamespaceAliasDecl,
+            UsingDirectiveDecl>(D))
       continue;
 
     const auto *VD = dyn_cast<VarDecl>(D);

--- a/clang/lib/AST/ByteCode/State.cpp
+++ b/clang/lib/AST/ByteCode/State.cpp
@@ -137,6 +137,11 @@ void State::addCallStack(unsigned Limit) {
       continue;
     }
 
+    // Don't print 'in call to operator()()' for consteval blocks.
+    if (const auto *MD = dyn_cast<CXXMethodDecl>(F->getCallee());
+        MD && MD->getParent()->isLambdaForConstevalBlock())
+      continue;
+
     // Use a different note for an inheriting constructor, because from the
     // user's perspective it's not really a function at all.
     if (const auto *CD =

--- a/clang/lib/AST/DeclBase.cpp
+++ b/clang/lib/AST/DeclBase.cpp
@@ -984,6 +984,7 @@ unsigned Decl::getIdentifierNamespaceForKind(Kind DeclKind) {
     case FileScopeAsm:
     case TopLevelStmt:
     case StaticAssert:
+    case ConstevalBlock:
     case ObjCPropertyImpl:
     case PragmaComment:
     case PragmaDetectMismatch:
@@ -1120,13 +1121,14 @@ bool Decl::AccessDeclContextCheck() const {
   // 3. this is a non-type template parameter
   // 4. the context is not a record
   // 5. it's invalid
-  // 6. it's a C++0x static_assert.
+  // 6. it's a C++0x static_assert or C++26 consteval block
   // 7. it's a block literal declaration
   // 8. it's a temporary with lifetime extended due to being default value.
   if (isa<TranslationUnitDecl>(this) || isa<TemplateTypeParmDecl>(this) ||
       isa<NonTypeTemplateParmDecl>(this) || !getDeclContext() ||
       !isa<CXXRecordDecl>(getDeclContext()) || isInvalidDecl() ||
-      isa<StaticAssertDecl>(this) || isa<BlockDecl>(this) ||
+      isa<StaticAssertDecl>(this) || isa<ConstevalBlockDecl>(this) ||
+      isa<BlockDecl>(this) ||
       // FIXME: a ParmVarDecl can have ClassTemplateSpecialization
       // as DeclContext (?).
       isa<ParmVarDecl>(this) ||

--- a/clang/lib/AST/DeclCXX.cpp
+++ b/clang/lib/AST/DeclCXX.cpp
@@ -141,12 +141,13 @@ CXXRecordDecl *
 CXXRecordDecl::CreateLambda(const ASTContext &C, DeclContext *DC,
                             TypeSourceInfo *Info, SourceLocation Loc,
                             unsigned DependencyKind, bool IsGeneric,
+                            bool IsConstevalBlock,
                             LambdaCaptureDefault CaptureDefault) {
   auto *R = new (C, DC) CXXRecordDecl(CXXRecord, TagTypeKind::Class, C, DC, Loc,
                                       Loc, nullptr, nullptr);
   R->setBeingDefined(true);
   R->DefinitionData = new (C) struct LambdaDefinitionData(
-      R, Info, DependencyKind, IsGeneric, CaptureDefault);
+      R, Info, DependencyKind, IsGeneric, IsConstevalBlock, CaptureDefault);
   R->setImplicit(true);
   return R;
 }
@@ -1679,6 +1680,11 @@ bool CXXRecordDecl::isCLike() const {
 bool CXXRecordDecl::isGenericLambda() const {
   if (!isLambda()) return false;
   return getLambdaData().IsGenericLambda;
+}
+
+bool CXXRecordDecl::isLambdaForConstevalBlock() const {
+  if (!isLambda()) return false;
+  return getLambdaData().IsConstevalBlock;
 }
 
 #ifndef NDEBUG
@@ -3648,6 +3654,48 @@ StaticAssertDecl *StaticAssertDecl::CreateDeserialized(ASTContext &C,
                                                        GlobalDeclID ID) {
   return new (C, ID) StaticAssertDecl(nullptr, SourceLocation(), nullptr,
                                       nullptr, SourceLocation(), false);
+}
+
+void ConstevalBlockDecl::anchor() {}
+
+ConstevalBlockDecl *ConstevalBlockDecl::Create(ASTContext &C, DeclContext *DC,
+                                               SourceLocation ConstevalLoc,
+                                               Expr *Call) {
+  assert(Call);
+  return new (C, DC) ConstevalBlockDecl(DC, ConstevalLoc, Call);
+}
+
+ConstevalBlockDecl *ConstevalBlockDecl::CreateDeserialized(ASTContext &C,
+                                                           GlobalDeclID ID) {
+  return new (C, ID) ConstevalBlockDecl(nullptr, SourceLocation(), nullptr);
+}
+
+SourceRange ConstevalBlockDecl::getSourceRange() const {
+  assert(Call && "should not be called before deserialization is complete");
+  return {getLocation(), Call->getEndLoc()};
+}
+
+LambdaExpr* ConstevalBlockDecl::getLambda() {
+  auto *CE = cast<CallExpr>(Call);
+
+  // Since the call expression always calls a 'static consteval' lambda with
+  // type 'void()', the AST is very predictable. In a template, we have:
+  //
+  // `-CallExpr
+  //   `-LambdaExpr
+  //
+  if (auto* Lambda = dyn_cast<LambdaExpr>(CE->getCallee()))
+    return Lambda;
+
+  // And outside a template, we end up with:
+  //
+  // CXXOperatorCallExpr
+  //   |-ImplicitCastExpr
+  //   | `-DeclRefExpr (lambda call operator)
+  //   `-MaterializeTemporaryExpr
+  //     `-LambdaExpr
+  //
+  return cast<LambdaExpr>(CE->getArg(0)->IgnoreUnlessSpelledInSource());
 }
 
 VarDecl *ValueDecl::getPotentiallyDecomposedVarDecl() {

--- a/clang/lib/AST/DeclCXX.cpp
+++ b/clang/lib/AST/DeclCXX.cpp
@@ -137,12 +137,10 @@ CXXRecordDecl *CXXRecordDecl::Create(const ASTContext &C, TagKind TK,
       CXXRecordDecl(CXXRecord, TK, C, DC, StartLoc, IdLoc, Id, PrevDecl);
 }
 
-CXXRecordDecl *
-CXXRecordDecl::CreateLambda(const ASTContext &C, DeclContext *DC,
-                            TypeSourceInfo *Info, SourceLocation Loc,
-                            unsigned DependencyKind, bool IsGeneric,
-                            bool IsConstevalBlock,
-                            LambdaCaptureDefault CaptureDefault) {
+CXXRecordDecl *CXXRecordDecl::CreateLambda(
+    const ASTContext &C, DeclContext *DC, TypeSourceInfo *Info,
+    SourceLocation Loc, unsigned DependencyKind, bool IsGeneric,
+    bool IsConstevalBlock, LambdaCaptureDefault CaptureDefault) {
   auto *R = new (C, DC) CXXRecordDecl(CXXRecord, TagTypeKind::Class, C, DC, Loc,
                                       Loc, nullptr, nullptr);
   R->setBeingDefined(true);
@@ -1683,7 +1681,8 @@ bool CXXRecordDecl::isGenericLambda() const {
 }
 
 bool CXXRecordDecl::isLambdaForConstevalBlock() const {
-  if (!isLambda()) return false;
+  if (!isLambda())
+    return false;
   return getLambdaData().IsConstevalBlock;
 }
 
@@ -3675,7 +3674,7 @@ SourceRange ConstevalBlockDecl::getSourceRange() const {
   return {getLocation(), Call->getEndLoc()};
 }
 
-LambdaExpr* ConstevalBlockDecl::getLambda() {
+LambdaExpr *ConstevalBlockDecl::getLambda() {
   auto *CE = cast<CallExpr>(Call);
 
   // Since the call expression always calls a 'static consteval' lambda with
@@ -3684,7 +3683,7 @@ LambdaExpr* ConstevalBlockDecl::getLambda() {
   // `-CallExpr
   //   `-LambdaExpr
   //
-  if (auto* Lambda = dyn_cast<LambdaExpr>(CE->getCallee()))
+  if (auto *Lambda = dyn_cast<LambdaExpr>(CE->getCallee()))
     return Lambda;
 
   // And outside a template, we end up with:

--- a/clang/lib/AST/DeclPrinter.cpp
+++ b/clang/lib/AST/DeclPrinter.cpp
@@ -78,6 +78,7 @@ namespace {
     void VisitTopLevelStmtDecl(TopLevelStmtDecl *D);
     void VisitImportDecl(ImportDecl *D);
     void VisitStaticAssertDecl(StaticAssertDecl *D);
+    void VisitConstevalBlockDecl(ConstevalBlockDecl *D);
     void VisitNamespaceDecl(NamespaceDecl *D);
     void VisitUsingDirectiveDecl(UsingDirectiveDecl *D);
     void VisitNamespaceAliasDecl(NamespaceAliasDecl *D);
@@ -538,7 +539,7 @@ void DeclPrinter::VisitDeclContext(DeclContext *DC, bool Indent) {
         Terminator = ";";
     } else if (isa<NamespaceDecl, LinkageSpecDecl, ObjCImplementationDecl,
                    ObjCInterfaceDecl, ObjCProtocolDecl, ObjCCategoryImplDecl,
-                   ObjCCategoryDecl, HLSLBufferDecl>(*D))
+                   ObjCCategoryDecl, HLSLBufferDecl, ConstevalBlockDecl>(*D))
       Terminator = nullptr;
     else if (isa<EnumConstantDecl>(*D)) {
       DeclContext::decl_iterator Next = D;
@@ -1058,6 +1059,12 @@ void DeclPrinter::VisitStaticAssertDecl(StaticAssertDecl *D) {
     E->printPretty(Out, nullptr, Policy, Indentation, "\n", &Context);
   }
   Out << ")";
+}
+
+void DeclPrinter::VisitConstevalBlockDecl(ConstevalBlockDecl *D) {
+  Out << "consteval";
+  D->getLambda()->getBody()->printPrettyControlled(Out, nullptr, Policy,
+                                                   Indentation, "\n", &Context);
 }
 
 //----------------------------------------------------------------------------

--- a/clang/lib/AST/ExprConstant.cpp
+++ b/clang/lib/AST/ExprConstant.cpp
@@ -151,6 +151,7 @@ namespace {
   static bool isForManglingOnly(ConstantExprKind Kind) {
     switch (Kind) {
     case ConstantExprKind::Normal:
+    case ConstantExprKind::ConstevalBlock:
     case ConstantExprKind::ClassTemplateArgument:
     case ConstantExprKind::ImmediateInvocation:
       // Note that non-type template arguments of class type are emitted as
@@ -166,6 +167,7 @@ namespace {
   static bool isTemplateArgument(ConstantExprKind Kind) {
     switch (Kind) {
     case ConstantExprKind::Normal:
+    case ConstantExprKind::ConstevalBlock:
     case ConstantExprKind::ImmediateInvocation:
       return false;
 

--- a/clang/lib/AST/ODRDiagsEmitter.cpp
+++ b/clang/lib/AST/ODRDiagsEmitter.cpp
@@ -597,6 +597,8 @@ ODRDiagsEmitter::FindTypeDiffs(DeclHashes &FirstHashes,
       llvm_unreachable("Invalid access specifier");
     case Decl::StaticAssert:
       return StaticAssert;
+    case Decl::ConstevalBlock:
+      return ConstevalBlock;
     case Decl::Field:
       return Field;
     case Decl::CXXMethod:
@@ -923,10 +925,13 @@ bool ODRDiagsEmitter::diagnoseMismatch(
 
   // Used with err_module_odr_violation_record and
   // note_module_odr_violation_record
+  //
+  // FIXME: This should use %enum_select.
   enum ODRCXXRecordDifference {
     StaticAssertCondition,
     StaticAssertMessage,
     StaticAssertOnlyMessage,
+    ConstevalBlockBody,
     MethodName,
     MethodDeleted,
     MethodDefaulted,
@@ -1031,6 +1036,25 @@ bool ODRDiagsEmitter::diagnoseMismatch(
                  StaticAssertMessage);
         return true;
       }
+    }
+    break;
+  }
+
+  case ConstevalBlock: {
+    const ConstevalBlockDecl *FirstBlock = cast<ConstevalBlockDecl>(FirstDecl);
+    const ConstevalBlockDecl *SecondBlock =
+        cast<ConstevalBlockDecl>(SecondDecl);
+
+    const Expr *FirstExpr = FirstBlock->getCallExpr();
+    const Expr *SecondExpr = SecondBlock->getCallExpr();
+    unsigned FirstODRHash = computeODRHash(FirstExpr);
+    unsigned SecondODRHash = computeODRHash(SecondExpr);
+    if (FirstODRHash != SecondODRHash) {
+      DiagError(FirstExpr->getBeginLoc(), FirstExpr->getSourceRange(),
+                ConstevalBlockBody);
+      DiagNote(SecondExpr->getBeginLoc(), SecondExpr->getSourceRange(),
+               ConstevalBlockBody);
+      return true;
     }
     break;
   }
@@ -1611,6 +1635,7 @@ bool ODRDiagsEmitter::diagnoseMismatch(const RecordDecl *FirstRecord,
   case PrivateSpecifer:
   case ProtectedSpecifer:
   case StaticAssert:
+  case ConstevalBlock:
   case CXXMethod:
   case TypeAlias:
   case Friend:
@@ -1663,6 +1688,7 @@ bool ODRDiagsEmitter::diagnoseMismatch(
     return false;
 
   // Keep in sync with select options in err_module_odr_violation_function.
+  // FIXME: Use %enum_select for this.
   enum ODRFunctionDifference {
     ReturnType,
     ParameterName,
@@ -2053,6 +2079,7 @@ bool ODRDiagsEmitter::diagnoseMismatch(
   case PrivateSpecifer:
   case ProtectedSpecifer:
   case StaticAssert:
+  case ConstevalBlock:
   case CXXMethod:
   case TypeAlias:
   case Friend:
@@ -2182,6 +2209,7 @@ bool ODRDiagsEmitter::diagnoseMismatch(
   case PrivateSpecifer:
   case ProtectedSpecifer:
   case StaticAssert:
+  case ConstevalBlock:
   case CXXMethod:
   case TypeAlias:
   case Friend:

--- a/clang/lib/AST/ODRHash.cpp
+++ b/clang/lib/AST/ODRHash.cpp
@@ -349,6 +349,11 @@ public:
     Inherited::VisitStaticAssertDecl(D);
   }
 
+  void VisitConstevalBlockDecl(const ConstevalBlockDecl *D) {
+    AddStmt(D->getCallExpr());
+    Inherited::VisitConstevalBlockDecl(D);
+  }
+
   void VisitFieldDecl(const FieldDecl *D) {
     const bool IsBitfield = D->isBitField();
     Hash.AddBoolean(IsBitfield);
@@ -559,6 +564,7 @@ bool ODRHash::isSubDeclToBeProcessed(const Decl *D, const DeclContext *Parent) {
     case Decl::Friend:
     case Decl::FunctionTemplate:
     case Decl::StaticAssert:
+    case Decl::ConstevalBlock:
     case Decl::TypeAlias:
     case Decl::Typedef:
     case Decl::Var:

--- a/clang/lib/AST/Randstruct.cpp
+++ b/clang/lib/AST/Randstruct.cpp
@@ -180,7 +180,7 @@ bool randomizeStructureLayout(const ASTContext &Context, RecordDecl *RD,
     ++TotalNumFields;
     if (auto *FD = dyn_cast<FieldDecl>(D))
       RandomizedFields.push_back(FD);
-    else if (isa<StaticAssertDecl>(D) || isa<IndirectFieldDecl>(D))
+    else if (isa<StaticAssertDecl, ConstevalBlockDecl, IndirectFieldDecl>(D))
       PostRandomizedFields.push_back(D);
     else
       FinalOrdering.push_back(D);

--- a/clang/lib/AST/StmtPrinter.cpp
+++ b/clang/lib/AST/StmtPrinter.cpp
@@ -263,7 +263,8 @@ void StmtPrinter::VisitDeclStmt(DeclStmt *Node) {
   PrintRawDeclStmt(Node);
   // Certain pragma declarations shouldn't have a semi-colon after them.
   if (!Node->isSingleDecl() ||
-      !isa<OpenACCDeclareDecl, OpenACCRoutineDecl>(Node->getSingleDecl()))
+      !isa<OpenACCDeclareDecl, OpenACCRoutineDecl, ConstevalBlockDecl>(
+          Node->getSingleDecl()))
     OS << ";";
   OS << NL;
 }

--- a/clang/lib/CIR/CodeGen/CIRGenDecl.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenDecl.cpp
@@ -832,6 +832,7 @@ void CIRGenFunction::emitDecl(const Decl &d, bool evaluateConditionDecl) {
   case Decl::Function:     // void X();
   case Decl::EnumConstant: // enum ? { X = ? }
   case Decl::StaticAssert: // static_assert(X, ""); [C++0x]
+  case Decl::ConstevalBlock:
   case Decl::Label:        // __label__ x;
   case Decl::Import:
   case Decl::MSGuid: // __declspec(uuid("..."))

--- a/clang/lib/CIR/CodeGen/CIRGenModule.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.cpp
@@ -1998,6 +1998,7 @@ void CIRGenModule::emitTopLevelDecl(Decl *decl) {
   case Decl::Empty:
   case Decl::FunctionTemplate:
   case Decl::StaticAssert:
+  case Decl::ConstevalBlock:
   case Decl::TypeAliasTemplate:
   case Decl::UsingShadow:
   case Decl::VarTemplate:

--- a/clang/lib/CodeGen/CGDecl.cpp
+++ b/clang/lib/CodeGen/CGDecl.cpp
@@ -125,6 +125,7 @@ void CodeGenFunction::EmitDecl(const Decl &D, bool EvaluateConditionDecl) {
   case Decl::Function:     // void X();
   case Decl::EnumConstant: // enum ? { X = ? }
   case Decl::StaticAssert: // static_assert(X, ""); [C++0x]
+  case Decl::ConstevalBlock:
   case Decl::Label:        // __label__ x;
   case Decl::Import:
   case Decl::MSGuid:    // __declspec(uuid("..."))

--- a/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/clang/lib/CodeGen/CodeGenModule.cpp
@@ -7751,6 +7751,7 @@ void CodeGenModule::EmitTopLevelDecl(Decl *D) {
     break;
 
   case Decl::StaticAssert:
+  case Decl::ConstevalBlock:
     // Nothing to do.
     break;
 

--- a/clang/lib/Index/IndexDecl.cpp
+++ b/clang/lib/Index/IndexDecl.cpp
@@ -773,6 +773,13 @@ public:
                        D->getLexicalDeclContext());
     return true;
   }
+
+  bool VisitConstevalBlockDecl(const ConstevalBlockDecl *D) {
+    IndexCtx.indexBody(D->getCallExpr(),
+                       dyn_cast<NamedDecl>(D->getDeclContext()),
+                       D->getLexicalDeclContext());
+    return true;
+  }
 };
 
 } // anonymous namespace

--- a/clang/lib/Parse/ParseDecl.cpp
+++ b/clang/lib/Parse/ParseDecl.cpp
@@ -1917,6 +1917,15 @@ Parser::DeclGroupPtrTy Parser::ParseDeclaration(DeclaratorContext Context,
     ProhibitAttributes(DeclSpecAttrs);
     SingleDecl = ParseStaticAssertDeclaration(DeclEnd);
     break;
+  case tok::kw_consteval:
+    if (NextToken().is(tok::l_brace)) {
+      ProhibitAttributes(DeclAttrs);
+      ProhibitAttributes(DeclSpecAttrs);
+      SingleDecl = ParseConstevalBlockDeclaration(DeclEnd);
+      break;
+    }
+    return ParseSimpleDeclaration(Context, DeclEnd, DeclAttrs, DeclSpecAttrs,
+                                  true, nullptr, DeclSpecStart);
   default:
     return ParseSimpleDeclaration(Context, DeclEnd, DeclAttrs, DeclSpecAttrs,
                                   true, nullptr, DeclSpecStart);
@@ -4237,6 +4246,9 @@ void Parser::ParseDeclarationSpecifiers(
                                       PrevSpec, DiagID);
       break;
     case tok::kw_consteval:
+      if (NextToken().is(tok::l_brace))
+        goto DoneWithDeclSpec;
+
       isInvalid = DS.SetConstexprSpec(ConstexprSpecKind::Consteval, Loc,
                                       PrevSpec, DiagID);
       break;
@@ -4897,6 +4909,13 @@ void Parser::ParseStructUnionBody(SourceLocation RecordLoc,
     if (Tok.isOneOf(tok::kw__Static_assert, tok::kw_static_assert)) {
       SourceLocation DeclEnd;
       ParseStaticAssertDeclaration(DeclEnd);
+      continue;
+    }
+
+    // Parse consteval block.
+    if (Tok.is(tok::kw_consteval) && NextToken().is(tok::l_brace)) {
+      SourceLocation DeclEnd;
+      ParseConstevalBlockDeclaration(DeclEnd);
       continue;
     }
 
@@ -5910,13 +5929,16 @@ bool Parser::isDeclarationSpecifier(
   case tok::annot_pack_indexing_type:
   case tok::kw_constexpr:
 
-    // C++20 consteval and constinit.
-  case tok::kw_consteval:
+    // C++20 constinit.
   case tok::kw_constinit:
 
     // C11 _Atomic
   case tok::kw__Atomic:
     return true;
+
+    // Do not treat consteval as a specifier if it starts a consteval block.
+  case tok::kw_consteval:
+    return NextToken().isNot(tok::l_brace);
 
   case tok::kw_alignas:
     // alignas is a type-specifier-qualifier in C23, which is a kind of

--- a/clang/lib/Parse/ParseDeclCXX.cpp
+++ b/clang/lib/Parse/ParseDeclCXX.cpp
@@ -1021,6 +1021,41 @@ Decl *Parser::ParseStaticAssertDeclaration(SourceLocation &DeclEnd) {
                                               T.getCloseLocation());
 }
 
+Decl *Parser::ParseConstevalBlockDeclaration(SourceLocation &DeclEnd) {
+  assert(Tok.is(tok::kw_consteval) && NextToken().is(tok::l_brace) &&
+         "not a consteval block declaration");
+
+  SourceLocation ConstevalLoc = ConsumeToken();
+
+  // C++26 [dcl.pre]: For a consteval-block-declaration D, the expression E
+  // corresponding to D is:
+  //
+  //     [] static consteval -> void compound-statement ()
+  //
+  EnterExpressionEvaluationContext ConstantEvaluated(
+      Actions, Sema::ExpressionEvaluationContext::ConstantEvaluated);
+
+  // Fabricate a fake lambda introducer.
+  LambdaIntroducer Intro;
+  Intro.Range = SourceRange(ConstevalLoc, ConstevalLoc);
+
+  // Parse the body and call the resulting lambda.
+  ExprResult Lambda = ParseLambdaExpressionAfterIntroducer(Intro, ConstevalLoc);
+  if (Lambda.isInvalid())
+    return nullptr;
+
+  ExprResult Call =
+      Actions.ActOnCallExpr(getCurScope(), Lambda.get(), ConstevalLoc,
+                            /*ArgExprs=*/MultiExprArg(), ConstevalLoc);
+
+  Call = Actions.ActOnConstantExpression(Call);
+  if (Call.isInvalid())
+    return nullptr;
+
+  DeclEnd = Tok.getLocation();
+  return Actions.ActOnConstevalBlockDeclaration(ConstevalLoc, Call.get());
+}
+
 SourceLocation Parser::ParseDecltypeSpecifier(DeclSpec &DS) {
   assert(Tok.isOneOf(tok::kw_decltype, tok::annot_decltype) &&
          "Not a decltype specifier");
@@ -2716,6 +2751,14 @@ Parser::DeclGroupPtrTy Parser::ParseCXXClassMemberDeclaration(
     SourceLocation DeclEnd;
     return DeclGroupPtrTy::make(
         DeclGroupRef(ParseStaticAssertDeclaration(DeclEnd)));
+  }
+
+  // consteval-block-declaration.
+  if (TemplateInfo.Kind == ParsedTemplateKind::NonTemplate &&
+      Tok.is(tok::kw_consteval) && NextToken().is(tok::l_brace)) {
+    SourceLocation DeclEnd;
+    return DeclGroupPtrTy::make(
+        DeclGroupRef(ParseConstevalBlockDeclaration(DeclEnd)));
   }
 
   if (Tok.is(tok::kw_template)) {

--- a/clang/lib/Parse/ParseExprCXX.cpp
+++ b/clang/lib/Parse/ParseExprCXX.cpp
@@ -1138,11 +1138,13 @@ static void tryConsumeLambdaSpecifierToken(Parser &P,
 }
 
 static void addStaticToLambdaDeclSpecifier(Parser &P, SourceLocation StaticLoc,
-                                           DeclSpec &DS) {
+                                           DeclSpec &DS,
+                                           bool ForConstevalBlock = false) {
   if (StaticLoc.isValid()) {
-    P.Diag(StaticLoc, !P.getLangOpts().CPlusPlus23
-                          ? diag::err_static_lambda
-                          : diag::warn_cxx20_compat_static_lambda);
+    if (!ForConstevalBlock)
+      P.Diag(StaticLoc, !P.getLangOpts().CPlusPlus23
+                            ? diag::err_static_lambda
+                            : diag::warn_cxx20_compat_static_lambda);
     const char *PrevSpec = nullptr;
     unsigned DiagID = 0;
     DS.SetStorageClassSpec(P.getActions(), DeclSpec::SCS_static, StaticLoc,
@@ -1171,9 +1173,11 @@ addConstexprToLambdaDeclSpecifier(Parser &P, SourceLocation ConstexprLoc,
 
 static void addConstevalToLambdaDeclSpecifier(Parser &P,
                                               SourceLocation ConstevalLoc,
-                                              DeclSpec &DS) {
+                                              DeclSpec &DS,
+                                              bool ForConstevalBlock = false) {
   if (ConstevalLoc.isValid()) {
-    P.Diag(ConstevalLoc, diag::warn_cxx20_compat_consteval);
+    if (!ForConstevalBlock)
+      P.Diag(ConstevalLoc, diag::warn_cxx20_compat_consteval);
     const char *PrevSpec = nullptr;
     unsigned DiagID = 0;
     DS.SetConstexprSpec(ConstexprSpecKind::Consteval, ConstevalLoc, PrevSpec,
@@ -1201,8 +1205,10 @@ static void DiagnoseStaticSpecifierRestrictions(Parser &P,
   }
 }
 
-ExprResult Parser::ParseLambdaExpressionAfterIntroducer(
-                     LambdaIntroducer &Intro) {
+ExprResult
+Parser::ParseLambdaExpressionAfterIntroducer(LambdaIntroducer &Intro,
+                                             SourceLocation ConstevalBlockStart) {
+  assert(!ConstevalBlockStart.isValid() || Tok.is(tok::l_brace));
   SourceLocation LambdaBeginLoc = Intro.Range.getBegin();
   if (getLangOpts().HLSL)
     Diag(LambdaBeginLoc, diag::ext_hlsl_lambda) << /*HLSL*/ 1;
@@ -1227,7 +1233,8 @@ ExprResult Parser::ParseLambdaExpressionAfterIntroducer(
   Actions.PushLambdaScope();
   SourceLocation DeclLoc = Tok.getLocation();
 
-  Actions.ActOnLambdaExpressionAfterIntroducer(Intro, getCurScope());
+  Actions.ActOnLambdaExpressionAfterIntroducer(
+      Intro, ConstevalBlockStart.isValid(), getCurScope());
 
   ParsedAttributes Attributes(AttrFactory);
   if (getLangOpts().CUDA) {
@@ -1365,7 +1372,12 @@ ExprResult Parser::ParseLambdaExpressionAfterIntroducer(
         << FixItHint::CreateInsertion(Tok.getLocation(), "() ");
   }
 
-  if (HasParentheses || HasSpecifiers) {
+  if (ConstevalBlockStart.isValid()) {
+    addStaticToLambdaDeclSpecifier(*this, ConstevalBlockStart, DS,
+                                   /*ForConstevalBlock=*/true);
+    addConstevalToLambdaDeclSpecifier(*this, ConstevalBlockStart, DS,
+                                      /*ForConstevalBlock=*/true);
+  } else if (HasParentheses || HasSpecifiers) {
     // GNU-style attributes must be parsed before the mutable specifier to
     // be compatible with GCC. MSVC-style attributes must be parsed before
     // the mutable specifier to be compatible with MSVC.
@@ -1391,7 +1403,7 @@ ExprResult Parser::ParseLambdaExpressionAfterIntroducer(
   if (!HasParentheses)
     Actions.ActOnLambdaClosureQualifiers(Intro, MutableLoc);
 
-  if (HasSpecifiers || HasParentheses) {
+  if (HasSpecifiers || HasParentheses || ConstevalBlockStart.isValid()) {
     // Parse exception-specification[opt].
     ExceptionSpecificationType ESpecType = EST_None;
     SourceRange ESpecRange;
@@ -1434,6 +1446,9 @@ ExprResult Parser::ParseLambdaExpressionAfterIntroducer(
       TrailingReturnTypeLoc = Range.getBegin();
       if (Range.getEnd().isValid())
         DeclEndLoc = Range.getEnd();
+    } else if (ConstevalBlockStart.isValid()) {
+      TrailingReturnType = ParsedType::make(Actions.Context.VoidTy);
+      TrailingReturnTypeLoc = ConstevalBlockStart;
     }
 
     SourceLocation NoLoc;

--- a/clang/lib/Parse/ParseExprCXX.cpp
+++ b/clang/lib/Parse/ParseExprCXX.cpp
@@ -1205,9 +1205,8 @@ static void DiagnoseStaticSpecifierRestrictions(Parser &P,
   }
 }
 
-ExprResult
-Parser::ParseLambdaExpressionAfterIntroducer(LambdaIntroducer &Intro,
-                                             SourceLocation ConstevalBlockStart) {
+ExprResult Parser::ParseLambdaExpressionAfterIntroducer(
+    LambdaIntroducer &Intro, SourceLocation ConstevalBlockStart) {
   assert(!ConstevalBlockStart.isValid() || Tok.is(tok::l_brace));
   SourceLocation LambdaBeginLoc = Intro.Range.getBegin();
   if (getLangOpts().HLSL)

--- a/clang/lib/Parse/ParseTemplate.cpp
+++ b/clang/lib/Parse/ParseTemplate.cpp
@@ -165,7 +165,7 @@ Parser::DeclGroupPtrTy Parser::ParseDeclarationAfterTemplate(
   if (Tok.is(tok::kw_static_assert)) {
     // A static_assert declaration may not be templated.
     Diag(Tok.getLocation(), diag::err_templated_invalid_declaration)
-      << 0 /*static_assert*/ << TemplateInfo.getSourceRange();
+        << 0 /*static_assert*/ << TemplateInfo.getSourceRange();
     // Parse the static_assert declaration to improve error recovery.
     return Actions.ConvertDeclToDeclGroup(
         ParseStaticAssertDeclaration(DeclEnd));
@@ -174,7 +174,7 @@ Parser::DeclGroupPtrTy Parser::ParseDeclarationAfterTemplate(
   // The same applies to consteval blocks.
   if (Tok.is(tok::kw_consteval) && NextToken().is(tok::l_brace)) {
     Diag(Tok.getLocation(), diag::err_templated_invalid_declaration)
-      << 1 /*consteval block*/ << TemplateInfo.getSourceRange();
+        << 1 /*consteval block*/ << TemplateInfo.getSourceRange();
     // Parse the consteval block declaration to improve error recovery.
     return Actions.ConvertDeclToDeclGroup(
         ParseConstevalBlockDeclaration(DeclEnd));

--- a/clang/lib/Parse/ParseTemplate.cpp
+++ b/clang/lib/Parse/ParseTemplate.cpp
@@ -165,10 +165,19 @@ Parser::DeclGroupPtrTy Parser::ParseDeclarationAfterTemplate(
   if (Tok.is(tok::kw_static_assert)) {
     // A static_assert declaration may not be templated.
     Diag(Tok.getLocation(), diag::err_templated_invalid_declaration)
-      << TemplateInfo.getSourceRange();
+      << 0 /*static_assert*/ << TemplateInfo.getSourceRange();
     // Parse the static_assert declaration to improve error recovery.
     return Actions.ConvertDeclToDeclGroup(
         ParseStaticAssertDeclaration(DeclEnd));
+  }
+
+  // The same applies to consteval blocks.
+  if (Tok.is(tok::kw_consteval) && NextToken().is(tok::l_brace)) {
+    Diag(Tok.getLocation(), diag::err_templated_invalid_declaration)
+      << 1 /*consteval block*/ << TemplateInfo.getSourceRange();
+    // Parse the consteval block declaration to improve error recovery.
+    return Actions.ConvertDeclToDeclGroup(
+        ParseConstevalBlockDeclaration(DeclEnd));
   }
 
   // We are parsing a member template.

--- a/clang/lib/Parse/ParseTentative.cpp
+++ b/clang/lib/Parse/ParseTentative.cpp
@@ -32,6 +32,11 @@ bool Parser::isCXXDeclarationStatement(
   case tok::kw_static_assert:
   case tok::kw__Static_assert:
     return true;
+    // consteval-block-declaration
+  case tok::kw_consteval:
+    if (NextToken().is(tok::l_brace))
+      return true;
+    goto default_case;
   case tok::coloncolon:
   case tok::identifier: {
     if (DisambiguatingWithExpression) {
@@ -79,6 +84,7 @@ bool Parser::isCXXDeclarationStatement(
     [[fallthrough]];
     // simple-declaration
   default:
+  default_case:
 
     if (DisambiguatingWithExpression) {
       TentativeParsingAction TPA(*this, /*Unannotated=*/true);
@@ -1168,6 +1174,10 @@ Parser::isCXXDeclarationSpecifier(ImplicitTypenameContext AllowImplicitTypename,
     return isCXXDeclarationSpecifier(AllowImplicitTypename, BracedCastResult,
                                      InvalidAsDeclSpec);
 
+    // 'consteval' in a consteval-block-declaration is not a specifier.
+  case tok::kw_consteval:
+    return NextToken().is(tok::l_brace) ? TPResult::False : TPResult::True;
+
     // decl-specifier:
     //   storage-class-specifier
     //   type-specifier
@@ -1178,7 +1188,6 @@ Parser::isCXXDeclarationSpecifier(ImplicitTypenameContext AllowImplicitTypename,
   case tok::kw_friend:
   case tok::kw_typedef:
   case tok::kw_constexpr:
-  case tok::kw_consteval:
   case tok::kw_constinit:
     // storage-class-specifier
   case tok::kw_register:

--- a/clang/lib/Parse/Parser.cpp
+++ b/clang/lib/Parse/Parser.cpp
@@ -913,6 +913,16 @@ Parser::ParseExternalDeclaration(ParsedAttributes &Attrs,
                               DeclSpecAttrs);
     }
 
+  case tok::kw_consteval: {
+    // consteval blocks are not parsed as functions.
+    if (NextToken().is(tok::l_brace)) {
+      SourceLocation DeclEnd;
+      return ParseDeclaration(DeclaratorContext::File, DeclEnd, Attrs,
+                              DeclSpecAttrs);
+    }
+    goto dont_know;
+  }
+
   case tok::kw_cbuffer:
   case tok::kw_tbuffer:
     if (getLangOpts().HLSL) {

--- a/clang/lib/Sema/SemaCodeComplete.cpp
+++ b/clang/lib/Sema/SemaCodeComplete.cpp
@@ -4452,6 +4452,8 @@ CXCursorKind clang::getCursorKindForDecl(const Decl *D) {
     return CXCursor_UsingDirective;
   case Decl::StaticAssert:
     return CXCursor_StaticAssert;
+  case Decl::ConstevalBlock:
+    return CXCursor_UnexposedDecl;
   case Decl::Friend:
     return CXCursor_FriendDecl;
   case Decl::TranslationUnit:

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -5117,8 +5117,8 @@ static NonCLikeKind getNonCLikeKindForAnonymousStruct(const CXXRecordDecl *RD) {
 
     //  -- declare any members other than non-static data members, member
     //     enumerations, or member classes,
-    if (isa<StaticAssertDecl>(D) || isa<IndirectFieldDecl>(D) ||
-        isa<EnumDecl>(D))
+    if (isa<StaticAssertDecl, ConstevalBlockDecl>(D) ||
+        isa<IndirectFieldDecl>(D) || isa<EnumDecl>(D))
       continue;
     auto *MemberRD = dyn_cast<CXXRecordDecl>(D);
     if (!MemberRD) {
@@ -5830,7 +5830,7 @@ Decl *Sema::BuildAnonymousStructOrUnion(Scope *S, DeclSpec &DS,
         }
       } else if (isa<AccessSpecDecl>(Mem)) {
         // Any access specifier is fine.
-      } else if (isa<StaticAssertDecl>(Mem)) {
+      } else if (isa<StaticAssertDecl, ConstevalBlockDecl>(Mem)) {
         // In C++1z, static_assert declarations are also fine.
       } else {
         // We have something that isn't a non-static data

--- a/clang/lib/Sema/SemaDeclCXX.cpp
+++ b/clang/lib/Sema/SemaDeclCXX.cpp
@@ -2015,6 +2015,7 @@ static bool CheckConstexprDeclStmt(Sema &SemaRef, const FunctionDecl *Dcl,
   for (const auto *DclIt : DS->decls()) {
     switch (DclIt->getKind()) {
     case Decl::StaticAssert:
+    case Decl::ConstevalBlock:
     case Decl::Using:
     case Decl::UsingShadow:
     case Decl::UsingDirective:
@@ -18031,6 +18032,43 @@ Decl *Sema::BuildStaticAssertDeclaration(SourceLocation StaticAssertLoc,
 
   CurContext->addDecl(Decl);
   return Decl;
+}
+
+Decl *Sema::ActOnConstevalBlockDeclaration(SourceLocation ConstevalLoc,
+                                           Expr *Call) {
+  DiagCompat(ConstevalLoc, diag_compat::consteval_block);
+
+  if (DiagnoseUnexpandedParameterPack(Call, UPPC_ConstevalBlock))
+    return nullptr;
+
+  return BuildConstevalBlockDeclaration(ConstevalLoc, Call);
+}
+
+Decl *Sema::BuildConstevalBlockDeclaration(SourceLocation ConstevalLoc,
+                                           Expr *Call) {
+  ExprResult FullExpr = ActOnFinishFullExpr(Call, ConstevalLoc,
+                                            /*DiscardedValue=*/false,
+                                            /*IsConstexpr=*/true);
+  if (FullExpr.isInvalid())
+    return nullptr;
+
+  Expr* E = FullExpr.get();
+  Decl* D = ConstevalBlockDecl::Create(Context, CurContext, ConstevalLoc, Call);
+  CurContext->addDecl(D);
+
+  if (!E->isTypeDependent() && !E->isValueDependent()) {
+    SmallVector<PartialDiagnosticAt, 4> PDiags;
+    Expr::EvalResult ER;
+    ER.Diag = &PDiags;
+    if (!Call->EvaluateAsConstantExpr(ER, Context,
+                                      ConstantExprKind::ConstevalBlock)) {
+      Diag(ConstevalLoc, diag::err_consteval_block_eval_failed);
+      for (PartialDiagnosticAt PD : PDiags)
+        Diag(PD.first, PD.second);
+    }
+  }
+
+  return D;
 }
 
 DeclResult Sema::ActOnTemplatedFriendTag(

--- a/clang/lib/Sema/SemaDeclCXX.cpp
+++ b/clang/lib/Sema/SemaDeclCXX.cpp
@@ -18052,8 +18052,8 @@ Decl *Sema::BuildConstevalBlockDeclaration(SourceLocation ConstevalLoc,
   if (FullExpr.isInvalid())
     return nullptr;
 
-  Expr* E = FullExpr.get();
-  Decl* D = ConstevalBlockDecl::Create(Context, CurContext, ConstevalLoc, Call);
+  Expr *E = FullExpr.get();
+  Decl *D = ConstevalBlockDecl::Create(Context, CurContext, ConstevalLoc, Call);
   CurContext->addDecl(D);
 
   if (!E->isTypeDependent() && !E->isValueDependent()) {

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -19810,6 +19810,17 @@ bool Sema::tryCaptureVariable(
         Parm && Parm->getDeclContext() == DC)
       return true;
 
+    // Issue a more specific diagnostics (and don't suggest any fixits) if
+    // we're in a consteval block.
+    if (LSI && LSI->Lambda->isLambdaForConstevalBlock()) {
+      if (BuildAndDiagnose) {
+        Diag(ExprLoc, diag::err_consteval_block_capture) << Var;
+        Diag(Var->getLocation(), diag::note_previous_decl) << Var;
+        Diag(LSI->Lambda->getBeginLoc(), diag::note_consteval_block);
+      }
+      return true;
+    }
+
     // If we are instantiating a generic lambda call operator body,
     // we do not want to capture new variables.  What was captured
     // during either a lambdas transformation or initial parsing

--- a/clang/lib/Sema/SemaExprCXX.cpp
+++ b/clang/lib/Sema/SemaExprCXX.cpp
@@ -1332,6 +1332,11 @@ bool Sema::CheckCXXThisCapture(SourceLocation Loc, const bool Explicit,
         break;
       }
       LambdaScopeInfo *LSI = dyn_cast<LambdaScopeInfo>(CSI);
+      if (LSI && LSI->Lambda->isLambdaForConstevalBlock()) {
+        if (BuildAndDiagnose)
+          Diag(Loc, diag::err_consteval_block_this_invalid);
+        return true;
+      }
       if (LSI && isGenericLambdaCallOperatorSpecialization(LSI->CallOperator)) {
         // This context can't implicitly capture 'this'; fail out.
         if (BuildAndDiagnose) {

--- a/clang/lib/Sema/SemaLambda.cpp
+++ b/clang/lib/Sema/SemaLambda.cpp
@@ -246,7 +246,7 @@ getGenericLambdaTemplateParameterList(LambdaScopeInfo *LSI, Sema &SemaRef) {
 
 CXXRecordDecl *
 Sema::createLambdaClosureType(SourceRange IntroducerRange, TypeSourceInfo *Info,
-                              unsigned LambdaDependencyKind,
+                              unsigned LambdaDependencyKind, bool ForConstevalBlock,
                               LambdaCaptureDefault CaptureDefault) {
   DeclContext *DC = CurContext;
 
@@ -255,7 +255,7 @@ Sema::createLambdaClosureType(SourceRange IntroducerRange, TypeSourceInfo *Info,
   // Start constructing the lambda class.
   CXXRecordDecl *Class = CXXRecordDecl::CreateLambda(
       Context, DC, Info, IntroducerRange.getBegin(), LambdaDependencyKind,
-      IsGenericLambda, CaptureDefault);
+      IsGenericLambda, ForConstevalBlock, CaptureDefault);
   DC->addDecl(Class);
 
   return Class;
@@ -1103,6 +1103,7 @@ void Sema::CompleteLambdaCallOperator(
 }
 
 void Sema::ActOnLambdaExpressionAfterIntroducer(LambdaIntroducer &Intro,
+                                                bool ForConstevalBlock,
                                                 Scope *CurrentScope) {
 
   LambdaScopeInfo *LSI = getCurLambda();
@@ -1150,7 +1151,8 @@ void Sema::ActOnLambdaExpressionAfterIntroducer(LambdaIntroducer &Intro,
   }
 
   CXXRecordDecl *Class = createLambdaClosureType(
-      Intro.Range, /*Info=*/nullptr, LambdaDependencyKind, Intro.Default);
+      Intro.Range, /*Info=*/nullptr, LambdaDependencyKind, ForConstevalBlock,
+      Intro.Default);
   LSI->Lambda = Class;
 
   CXXMethodDecl *Method = CreateLambdaCallOperator(Intro.Range, Class);

--- a/clang/lib/Sema/SemaLambda.cpp
+++ b/clang/lib/Sema/SemaLambda.cpp
@@ -246,7 +246,8 @@ getGenericLambdaTemplateParameterList(LambdaScopeInfo *LSI, Sema &SemaRef) {
 
 CXXRecordDecl *
 Sema::createLambdaClosureType(SourceRange IntroducerRange, TypeSourceInfo *Info,
-                              unsigned LambdaDependencyKind, bool ForConstevalBlock,
+                              unsigned LambdaDependencyKind,
+                              bool ForConstevalBlock,
                               LambdaCaptureDefault CaptureDefault) {
   DeclContext *DC = CurContext;
 

--- a/clang/lib/Sema/SemaStmt.cpp
+++ b/clang/lib/Sema/SemaStmt.cpp
@@ -3715,6 +3715,9 @@ StmtResult Sema::ActOnCapScopeReturnStmt(SourceLocation ReturnLoc,
     // Delay processing for now.  TODO: there are lots of dependent
     // types we can conclusively prove aren't void.
   } else if (FnRetType->isVoidType()) {
+    // FIXME: This currently causes '[] () -> void { return {1}; };' to compile,
+    // which is almost surely not something we want. Blocks suffer from the same
+    // issue. See https://github.com/llvm/llvm-project/issues/188661.
     if (RetValExp && !isa<InitListExpr>(RetValExp) &&
         !(getLangOpts().CPlusPlus &&
           (RetValExp->isTypeDependent() ||
@@ -3722,8 +3725,13 @@ StmtResult Sema::ActOnCapScopeReturnStmt(SourceLocation ReturnLoc,
       if (!getLangOpts().CPlusPlus &&
           RetValExp->getType()->isVoidType())
         Diag(ReturnLoc, diag::ext_return_has_void_expr) << "literal" << 2;
-      else {
-        Diag(ReturnLoc, diag::err_return_block_has_expr);
+      else if (CurLambda && CurLambda->Lambda->isLambdaForConstevalBlock()) {
+        Diag(ReturnLoc, diag::err_return_block_has_expr)
+            << /*IsConstevalBlock=*/true;
+        RetValExp = nullptr;
+      } else {
+        Diag(ReturnLoc, diag::err_return_block_has_expr)
+            << /*IsConstevalBlock=*/false;
         RetValExp = nullptr;
       }
     }

--- a/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp
+++ b/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp
@@ -2617,8 +2617,8 @@ Decl *TemplateDeclInstantiator::VisitCXXRecordDecl(CXXRecordDecl *D) {
   if (D->isLambda())
     Record = CXXRecordDecl::CreateLambda(
         SemaRef.Context, Owner, D->getLambdaTypeInfo(), D->getLocation(),
-        D->getLambdaDependencyKind(), D->isGenericLambda(), D->isLambdaForConstevalBlock(),
-        D->getLambdaCaptureDefault());
+        D->getLambdaDependencyKind(), D->isGenericLambda(),
+        D->isLambdaForConstevalBlock(), D->getLambdaCaptureDefault());
   else
     Record = CXXRecordDecl::Create(SemaRef.Context, D->getTagKind(), Owner,
                                    D->getBeginLoc(), D->getLocation(),

--- a/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp
+++ b/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp
@@ -2101,6 +2101,17 @@ Decl *TemplateDeclInstantiator::VisitStaticAssertDecl(StaticAssertDecl *D) {
       InstantiatedMessageExpr.get(), D->getRParenLoc(), D->isFailed());
 }
 
+Decl *TemplateDeclInstantiator::VisitConstevalBlockDecl(ConstevalBlockDecl *D) {
+  EnterExpressionEvaluationContext Unevaluated(
+      SemaRef, Sema::ExpressionEvaluationContext::ConstantEvaluated);
+
+  ExprResult Call = SemaRef.SubstExpr(D->getCallExpr(), TemplateArgs);
+  if (Call.isInvalid())
+    return nullptr;
+
+  return SemaRef.BuildConstevalBlockDeclaration(D->getLocation(), Call.get());
+}
+
 Decl *TemplateDeclInstantiator::VisitEnumDecl(EnumDecl *D) {
   EnumDecl *PrevDecl = nullptr;
   if (EnumDecl *PatternPrev = getPreviousDeclForInstantiation(D)) {
@@ -2606,7 +2617,7 @@ Decl *TemplateDeclInstantiator::VisitCXXRecordDecl(CXXRecordDecl *D) {
   if (D->isLambda())
     Record = CXXRecordDecl::CreateLambda(
         SemaRef.Context, Owner, D->getLambdaTypeInfo(), D->getLocation(),
-        D->getLambdaDependencyKind(), D->isGenericLambda(),
+        D->getLambdaDependencyKind(), D->isGenericLambda(), D->isLambdaForConstevalBlock(),
         D->getLambdaCaptureDefault());
   else
     Record = CXXRecordDecl::Create(SemaRef.Context, D->getTagKind(), Owner,

--- a/clang/lib/Sema/TreeTransform.h
+++ b/clang/lib/Sema/TreeTransform.h
@@ -15820,7 +15820,7 @@ TreeTransform<Derived>::TransformLambdaExpr(LambdaExpr *E) {
   CXXRecordDecl *OldClass = E->getLambdaClass();
   CXXRecordDecl *Class = getSema().createLambdaClosureType(
       E->getIntroducerRange(), /*Info=*/nullptr, DependencyKind,
-      E->getCaptureDefault());
+      OldClass->isLambdaForConstevalBlock(), E->getCaptureDefault());
   getDerived().transformedLocalDecl(OldClass, {Class});
 
   CXXMethodDecl *NewCallOperator =

--- a/clang/lib/Serialization/ASTCommon.cpp
+++ b/clang/lib/Serialization/ASTCommon.cpp
@@ -436,6 +436,7 @@ bool serialization::isRedeclarableDeclKind(unsigned Kind) {
   case Decl::Friend:
   case Decl::FriendTemplate:
   case Decl::StaticAssert:
+  case Decl::ConstevalBlock:
   case Decl::Block:
   case Decl::OutlinedFunction:
   case Decl::Captured:

--- a/clang/lib/Serialization/ASTReaderDecl.cpp
+++ b/clang/lib/Serialization/ASTReaderDecl.cpp
@@ -2147,7 +2147,8 @@ void ASTDeclMerger::MergeDefinitionData(
     auto &Lambda2 = static_cast<CXXRecordDecl::LambdaDefinitionData &>(MergeDD);
     DetectedOdrViolation |= Lambda1.DependencyKind != Lambda2.DependencyKind;
     DetectedOdrViolation |= Lambda1.IsGenericLambda != Lambda2.IsGenericLambda;
-    DetectedOdrViolation |= Lambda1.IsConstevalBlock != Lambda2.IsConstevalBlock;
+    DetectedOdrViolation |=
+        Lambda1.IsConstevalBlock != Lambda2.IsConstevalBlock;
     DetectedOdrViolation |= Lambda1.CaptureDefault != Lambda2.CaptureDefault;
     DetectedOdrViolation |= Lambda1.NumCaptures != Lambda2.NumCaptures;
     DetectedOdrViolation |=

--- a/clang/lib/Serialization/ASTReaderDecl.cpp
+++ b/clang/lib/Serialization/ASTReaderDecl.cpp
@@ -405,6 +405,7 @@ public:
   void VisitFriendDecl(FriendDecl *D);
   void VisitFriendTemplateDecl(FriendTemplateDecl *D);
   void VisitStaticAssertDecl(StaticAssertDecl *D);
+  void VisitConstevalBlockDecl(ConstevalBlockDecl *D);
   void VisitBlockDecl(BlockDecl *BD);
   void VisitOutlinedFunctionDecl(OutlinedFunctionDecl *D);
   void VisitCapturedDecl(CapturedDecl *CD);
@@ -2034,6 +2035,7 @@ void ASTDeclReader::ReadCXXDefinitionData(
     BitsUnpacker LambdaBits(Record.readInt());
     Lambda.DependencyKind = LambdaBits.getNextBits(/*Width=*/2);
     Lambda.IsGenericLambda = LambdaBits.getNextBit();
+    Lambda.IsConstevalBlock = LambdaBits.getNextBit();
     Lambda.CaptureDefault = LambdaBits.getNextBits(/*Width=*/2);
     Lambda.NumCaptures = LambdaBits.getNextBits(/*Width=*/15);
     Lambda.HasKnownInternalLinkage = LambdaBits.getNextBit();
@@ -2145,6 +2147,7 @@ void ASTDeclMerger::MergeDefinitionData(
     auto &Lambda2 = static_cast<CXXRecordDecl::LambdaDefinitionData &>(MergeDD);
     DetectedOdrViolation |= Lambda1.DependencyKind != Lambda2.DependencyKind;
     DetectedOdrViolation |= Lambda1.IsGenericLambda != Lambda2.IsGenericLambda;
+    DetectedOdrViolation |= Lambda1.IsConstevalBlock != Lambda2.IsConstevalBlock;
     DetectedOdrViolation |= Lambda1.CaptureDefault != Lambda2.CaptureDefault;
     DetectedOdrViolation |= Lambda1.NumCaptures != Lambda2.NumCaptures;
     DetectedOdrViolation |=
@@ -2189,7 +2192,7 @@ void ASTDeclReader::ReadCXXRecordDefinition(CXXRecordDecl *D, bool Update,
          "lambda definition should not be added by update record");
   if (IsLambda)
     DD = new (C) CXXRecordDecl::LambdaDefinitionData(
-        D, nullptr, CXXRecordDecl::LDK_Unknown, false, LCD_None);
+        D, nullptr, CXXRecordDecl::LDK_Unknown, false, false, LCD_None);
   else
     DD = new (C) struct CXXRecordDecl::DefinitionData(D);
 
@@ -2782,6 +2785,11 @@ void ASTDeclReader::VisitStaticAssertDecl(StaticAssertDecl *D) {
   D->AssertExprAndFailed.setInt(Record.readInt());
   D->Message = cast_or_null<StringLiteral>(Record.readExpr());
   D->RParenLoc = readSourceLocation();
+}
+
+void ASTDeclReader::VisitConstevalBlockDecl(ConstevalBlockDecl *D) {
+  VisitDecl(D);
+  D->Call = Record.readExpr();
 }
 
 void ASTDeclReader::VisitEmptyDecl(EmptyDecl *D) {
@@ -4105,6 +4113,9 @@ Decl *ASTReader::ReadDeclRecord(GlobalDeclID ID) {
     break;
   case DECL_STATIC_ASSERT:
     D = StaticAssertDecl::CreateDeserialized(Context, ID);
+    break;
+  case DECL_CONSTEVAL_BLOCK:
+    D = ConstevalBlockDecl::CreateDeserialized(Context, ID);
     break;
   case DECL_OBJC_METHOD:
     D = ObjCMethodDecl::CreateDeserialized(Context, ID);

--- a/clang/lib/Serialization/ASTWriter.cpp
+++ b/clang/lib/Serialization/ASTWriter.cpp
@@ -7439,6 +7439,7 @@ void ASTRecordWriter::AddCXXDefinitionData(const CXXRecordDecl *D) {
     BitsPacker LambdaBits;
     LambdaBits.addBits(Lambda.DependencyKind, /*Width=*/2);
     LambdaBits.addBit(Lambda.IsGenericLambda);
+    LambdaBits.addBit(Lambda.IsConstevalBlock);
     LambdaBits.addBits(Lambda.CaptureDefault, /*Width=*/2);
     LambdaBits.addBits(Lambda.NumCaptures, /*Width=*/15);
     LambdaBits.addBit(Lambda.HasKnownInternalLinkage);

--- a/clang/lib/Serialization/ASTWriterDecl.cpp
+++ b/clang/lib/Serialization/ASTWriterDecl.cpp
@@ -144,6 +144,7 @@ namespace clang {
     void VisitFriendDecl(FriendDecl *D);
     void VisitFriendTemplateDecl(FriendTemplateDecl *D);
     void VisitStaticAssertDecl(StaticAssertDecl *D);
+    void VisitConstevalBlockDecl(ConstevalBlockDecl *D);
     void VisitBlockDecl(BlockDecl *D);
     void VisitOutlinedFunctionDecl(OutlinedFunctionDecl *D);
     void VisitCapturedDecl(CapturedDecl *D);
@@ -2173,6 +2174,12 @@ void ASTDeclWriter::VisitStaticAssertDecl(StaticAssertDecl *D) {
   Record.AddStmt(D->getMessage());
   Record.AddSourceLocation(D->getRParenLoc());
   Code = serialization::DECL_STATIC_ASSERT;
+}
+
+void ASTDeclWriter::VisitConstevalBlockDecl(ConstevalBlockDecl *D) {
+  VisitDecl(D);
+  Record.AddStmt(D->getCallExpr());
+  Code = serialization::DECL_CONSTEVAL_BLOCK;
 }
 
 /// Emit the DeclContext part of a declaration context decl.

--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.cpp
@@ -759,6 +759,11 @@ public:
     return true;
   }
 
+  bool VisitConstevalBlockDecl(const ConstevalBlockDecl *SAD) {
+    // Any consteval block is considered trivial.
+    return true;
+  }
+
   bool VisitCallExpr(const CallExpr *CE) {
     if (!checkArguments(CE))
       return false;

--- a/clang/test/AST/cxx2c-consteval-blocks-ast-print.cpp
+++ b/clang/test/AST/cxx2c-consteval-blocks-ast-print.cpp
@@ -1,0 +1,47 @@
+// Test without serialization:
+// RUN: %clang_cc1 -triple x86_64-unknown-unknown -std=c++26 -ast-print %s \
+// RUN: | FileCheck %s
+//
+// Test with serialization:
+// RUN: %clang_cc1 -triple x86_64-unknown-unknown -std=c++26 -emit-pch -o %t %s
+// RUN: %clang_cc1 -x c++ -triple x86_64-unknown-unknown -std=c++26 -include-pch %t -ast-print /dev/null \
+// RUN: | sed -e "s/ <undeserialized declarations>//" -e "s/ imported//" \
+// RUN: | FileCheck %s
+
+constexpr void f() {}
+
+// CHECK: consteval {
+// CHECK: }
+consteval {}
+
+// CHECK: consteval {
+// CHECK:     f();
+// CHECK: }
+consteval {
+  f();
+}
+
+// CHECK: consteval {
+// CHECK:     consteval {
+// CHECK:         f();
+// CHECK:         f();
+// CHECK:     }
+// CHECK: }
+consteval {
+  consteval {
+    f();
+    f();
+  }
+}
+
+// CHECK: template <typename T> void g() {
+// CHECK:     consteval {
+// CHECK:         f();
+// CHECK:     }
+// CHECK: }
+template <typename T>
+void g() {
+  consteval {
+    f();
+  }
+}

--- a/clang/test/Parser/cxx2c-consteval-blocks.cpp
+++ b/clang/test/Parser/cxx2c-consteval-blocks.cpp
@@ -1,0 +1,31 @@
+// RUN: %clang_cc1 -std=c++26 -verify %s
+
+template <typename>
+consteval {} // expected-error {{a consteval block declaration cannot be a template}}
+
+struct X0 {
+  template <typename>
+  consteval {} // expected-error {{a consteval block declaration cannot be a template}}
+};
+
+void f1() {
+  template <typename>
+  consteval {} // expected-error {{a consteval block declaration cannot be a template}}
+}
+
+inline consteval {} // expected-error {{expected unqualified-id}}
+static consteval {} // expected-error {{expected unqualified-id}}
+consteval inline {} // expected-error {{expected unqualified-id}}
+consteval static {} // expected-error {{expected unqualified-id}}
+
+struct X1 { inline consteval {} }; // expected-error {{expected member name or ';' after declaration specifiers}}
+struct X2 { static consteval {} }; // expected-error {{expected member name or ';' after declaration specifiers}}
+struct X3 { consteval inline {} }; // expected-error {{expected member name or ';' after declaration specifiers}}
+struct X4 { consteval static {} }; // expected-error {{expected member name or ';' after declaration specifiers}}
+
+void f2() {
+  inline consteval {} // expected-error {{expected unqualified-id}}
+  static consteval {} // expected-error {{expected unqualified-id}}
+  consteval inline {} // expected-error {{expected unqualified-id}}
+  consteval static {} // expected-error {{expected unqualified-id}}
+}

--- a/clang/test/SemaCXX/cxx2c-consteval-blocks-compat.cpp
+++ b/clang/test/SemaCXX/cxx2c-consteval-blocks-compat.cpp
@@ -1,0 +1,10 @@
+// RUN: %clang_cc1 -std=c++20 -verify=pre26 -Wc++23-extensions -Wc++20-extensions %s
+// RUN: %clang_cc1 -std=c++23 -verify=pre26 -Wc++23-extensions -Wc++20-extensions %s
+// RUN: %clang_cc1 -std=c++26 -verify=cxx26 -Wc++23-extensions -Wc++20-extensions -Wpre-c++26-compat %s
+
+// This test also checks that we don't warn about the lambda that we internally
+// create for this being 'static' and 'consteval', which are C++23 and C++20
+// extensions, even if the corresponding extension warnings are enabled.
+
+consteval {} // pre26-warning {{consteval blocks are a C++2c extension}} \
+                cxx26-warning {{consteval blocks are incompatible with C++ standards before C++2c}}

--- a/clang/test/SemaCXX/cxx2c-consteval-blocks.cpp
+++ b/clang/test/SemaCXX/cxx2c-consteval-blocks.cpp
@@ -1,0 +1,126 @@
+// RUN: %clang_cc1 -std=c++26 -verify=expected,old-interp %s
+// RUN: %clang_cc1 -std=c++26 -verify -fexperimental-new-constant-interpreter %s
+
+constexpr void foo(int) {}
+void bar(int) {} // expected-note 7 {{declared here}}
+
+consteval { foo(1); }
+consteval { // expected-error {{could not evaluate consteval block}}
+  bar(1); // expected-note {{non-constexpr function 'bar' cannot be used in a constant expression}}
+}
+
+struct X {
+  consteval { foo(2); }
+  consteval { // expected-error {{could not evaluate consteval block}}
+    bar(2); // expected-note {{non-constexpr function 'bar' cannot be used in a constant expression}}
+  }
+
+  void f() {
+    consteval { foo(3); }
+    consteval { // expected-error {{could not evaluate consteval block}}
+      bar(3); // expected-note {{non-constexpr function 'bar' cannot be used in a constant expression}}
+    }
+  }
+};
+
+void f1() {
+  consteval { foo(4); }
+  consteval { // expected-error {{could not evaluate consteval block}}
+    bar(4); // expected-note {{non-constexpr function 'bar' cannot be used in a constant expression}}
+  }
+}
+
+union U {
+  consteval { foo(5); }
+  consteval { // expected-error {{could not evaluate consteval block}}
+    bar(5); // expected-note {{non-constexpr function 'bar' cannot be used in a constant expression}}
+  }
+};
+
+consteval {
+  consteval { // expected-error {{could not evaluate consteval block}}
+    foo(6);
+    bar(6); // expected-note {{non-constexpr function 'bar' cannot be used in a constant expression}}
+  }
+}
+
+template <typename T>
+constexpr void t1() {
+  consteval { foo(5); }
+  consteval { // expected-error {{could not evaluate consteval block}}
+    bar(5); // expected-note {{non-constexpr function 'bar' cannot be used in a constant expression}}
+  }
+}
+
+template void t1<int>(); // expected-note {{in instantiation of function template specialization 't1<int>'}}
+
+template <typename ...Ts>
+void t2() {
+  consteval { Ts t; } // expected-error {{consteval block contains unexpanded parameter pack 'Ts'}}
+}
+
+void f2() {
+  int x1; // expected-note {{'x1' declared here}}
+  consteval { // expected-note {{consteval block begins here}}
+    decltype(x1) y = 4;
+    (void)&x1; // expected-error {{cannot capture variable 'x1' in consteval block}}
+  }
+
+  static int x2;
+  consteval {
+    decltype(x2) y = 4;
+    (void)&x2;
+  }
+
+  constexpr int x3 = 4; // expected-note {{'x3' declared here}}
+  consteval { // expected-note {{consteval block begins here}}
+    decltype(x3) y = 4;
+    (void)&x3; // expected-error {{cannot capture variable 'x3' in consteval block}}
+  }
+
+  static constexpr int x4 = 4;
+  consteval {
+    decltype(x4) y = 4;
+    (void)&x4;
+  }
+}
+
+struct S {
+  int x1;
+  static int x2;
+  static constexpr int x3 = 4;
+
+  void f() {
+    consteval { // old-interp-error {{could not evaluate consteval block}}
+      decltype(x1) y = 4;
+      (void) &x1; // expected-error {{cannot capture 'this' in consteval block}} old-interp-note {{implicit use of 'this' pointer}}
+    }
+
+    consteval {
+      decltype(x2) y = 4;
+      (void) &x2;
+    }
+
+    consteval {
+      decltype(x3) y = 4;
+      (void) &x3;
+    }
+  }
+};
+
+constexpr void g() {}
+
+consteval { return; }
+consteval { return g(); }
+consteval { return static_cast<void>(4); }
+
+consteval { return 4; } // expected-error {{consteval block should not return a value}}
+consteval { return "foobar"; } // expected-error {{consteval block should not return a value}}
+
+// FIXME: We should diagnose this; this is https://github.com/llvm/llvm-project/issues/188661.
+consteval { return {}; }
+
+// FIXME: The diagnostics for these are weird, probably due to the same issue.
+consteval { return {1}; } // expected-error {{could not evaluate consteval block}} expected-note {{subexpression not valid in a constant expression}}
+consteval { return {1, 2}; } // expected-error {{could not evaluate consteval block}} expected-note {{subexpression not valid in a constant expression}}
+consteval { return {"foobar"}; } // expected-error {{could not evaluate consteval block}} expected-note {{subexpression not valid in a constant expression}}

--- a/clang/tools/libclang/CIndex.cpp
+++ b/clang/tools/libclang/CIndex.cpp
@@ -7257,6 +7257,7 @@ CXCursor clang_getCursorDefinition(CXCursor C) {
   case Decl::FileScopeAsm:
   case Decl::TopLevelStmt:
   case Decl::StaticAssert:
+  case Decl::ConstevalBlock:
   case Decl::Block:
   case Decl::OutlinedFunction:
   case Decl::Captured:


### PR DESCRIPTION
This adds support for `consteval` block declarations, which are part of [Reflection for C++26](https://wg21.link/p2996). 

A `consteval` block consists of the keyword `consteval` followed by a compound-statement. That compound-statement is used as the body of an immediately-invoked `static consteval` lambda with no captures and a return type of `void`. `consteval` blocks can be used pretty much in the same contexts as `static_assert` declarations.

We implement this by fabricating a fake `LambdaIntroducer` and then just calling `ParseLambdaExpressionAfterIntroducer()` to parse the compound-statement as a lambda body. This takes care of all the complicated parts, though I did have to update that function to set the return type and make the lambda `static` and `consteval`. 

The lambda is then wrapped in a call which is evaluated in `BuildConstevalBlockDecl()`. I’ve added a new `ConstantExprKind` of `ConstevalBlock` for this. It isn’t really used for anything at the moment, but iirc we’ll need some way to figure out whether we’re evaluating a consteval block for `define_aggregate()` and friends, which is what this is intended for.

The `CXXRecordDecl` of a lambda now also tracks whether it is a consteval block; this is only used to control diagnostic behaviour (e.g. we don’t want to emit fixits that suggest adding captures to a ‘lambda’ that is actually a consteval block).

The feature is backported to C++20 because that’s the earliest language mode in which we support the `consteval` keyword.