### PR TITLE
[Clang] Add selftest for macro __BPF_FEATURE_ATOMIC_MEM_ORDERING

### DIFF
--- a/clang/test/Preprocessor/bpf-predefined-macros.c
+++ b/clang/test/Preprocessor/bpf-predefined-macros.c
@@ -73,6 +73,9 @@ int v;
 #ifdef __BPF_FEATURE_GOTOX
 int w;
 #endif
+#ifdef __BPF_FEATURE_ATOMIC_MEM_ORDERING
+int x;
+#endif
 
 // CHECK: int b;
 // CHECK: int c;
@@ -114,6 +117,11 @@ int w;
 
 // CPU_V4: int v;
 // CPU_V4: int w;
+
+// CPU_V1: int x;
+// CPU_V2: int x;
+// CPU_V3: int x;
+// CPU_V4: int x;
 
 // CPU_GENERIC: int g;
 


### PR DESCRIPTION
Add selftest for macro __BPF_FEATURE_ATOMIC_MEM_ORDERING as the pull request [1] missed the test.

  [1] https://github.com/llvm/llvm-project/pull/107343