### PR TITLE
[LLVM] Add missing #undef DEBUG_TYPE to headers that #define it

### DIFF
--- a/lld/wasm/Relocations.cpp
+++ b/lld/wasm/Relocations.cpp
@@ -13,6 +13,8 @@
 #include "SymbolTable.h"
 #include "SyntheticSections.h"
 
+#define DEBUG_TYPE "lld-wasm-relocations"
+
 using namespace llvm;
 using namespace llvm::wasm;
 

--- a/lld/wasm/SyntheticSections.cpp
+++ b/lld/wasm/SyntheticSections.cpp
@@ -20,6 +20,8 @@
 #include "llvm/Support/Path.h"
 #include <optional>
 
+#define DEBUG_TYPE "lld-wasm-synthetic-sections"
+
 using namespace llvm;
 using namespace llvm::wasm;
 

--- a/lld/wasm/SyntheticSections.h
+++ b/lld/wasm/SyntheticSections.h
@@ -492,4 +492,6 @@ extern OutStruct out;
 } // namespace wasm
 } // namespace lld
 
+#undef DEBUG_TYPE
+
 #endif

--- a/llvm/include/llvm/CodeGen/GlobalISel/LegalizationArtifactCombiner.h
+++ b/llvm/include/llvm/CodeGen/GlobalISel/LegalizationArtifactCombiner.h
@@ -1580,4 +1580,6 @@ private:
 
 } // namespace llvm
 
+#undef DEBUG_TYPE
+
 #endif // LLVM_CODEGEN_GLOBALISEL_LEGALIZATIONARTIFACTCOMBINER_H

--- a/llvm/lib/ExecutionEngine/JITLink/COFFLinkGraphBuilder.h
+++ b/llvm/lib/ExecutionEngine/JITLink/COFFLinkGraphBuilder.h
@@ -235,4 +235,6 @@ private:
 } // end namespace jitlink
 } // end namespace llvm
 
+#undef DEBUG_TYPE
+
 #endif // LIB_EXECUTIONENGINE_JITLINK_COFFLINKGRAPHBUILDER_H

--- a/llvm/lib/ExecutionEngine/RuntimeDyld/Targets/RuntimeDyldCOFFI386.h
+++ b/llvm/lib/ExecutionEngine/RuntimeDyld/Targets/RuntimeDyldCOFFI386.h
@@ -224,5 +224,7 @@ public:
 
 }
 
+#undef DEBUG_TYPE
+
 #endif
 

--- a/llvm/lib/ExecutionEngine/RuntimeDyld/Targets/RuntimeDyldCOFFThumb.h
+++ b/llvm/lib/ExecutionEngine/RuntimeDyld/Targets/RuntimeDyldCOFFThumb.h
@@ -345,4 +345,6 @@ public:
 
 }
 
+#undef DEBUG_TYPE
+
 #endif

--- a/llvm/lib/IR/ConstantsContext.h
+++ b/llvm/lib/IR/ConstantsContext.h
@@ -693,4 +693,6 @@ template <> inline void ConstantUniqueMap<InlineAsm>::freeConstants() {
 
 } // end namespace llvm
 
+#undef DEBUG_TYPE
+
 #endif // LLVM_LIB_IR_CONSTANTSCONTEXT_H

--- a/llvm/lib/IR/DebugInfo.cpp
+++ b/llvm/lib/IR/DebugInfo.cpp
@@ -41,6 +41,8 @@
 #include <cassert>
 #include <optional>
 
+#define DEBUG_TYPE "debug-info"
+
 using namespace llvm;
 using namespace llvm::at;
 using namespace llvm::dwarf;
@@ -2195,7 +2197,7 @@ static void emitDbgAssign(AssignmentInfo Info, Value *Val, Value *Dest,
   LLVM_DEBUG(if (Assign) errs() << " > INSERT: " << *Assign << "\n");
 }
 
-#undef DEBUG_TYPE // Silence redefinition warning (from ConstantsContext.h).
+#undef DEBUG_TYPE
 #define DEBUG_TYPE "assignment-tracking"
 
 void at::trackAssignments(Function::iterator Start, Function::iterator End,

--- a/llvm/lib/IR/Instructions.cpp
+++ b/llvm/lib/IR/Instructions.cpp
@@ -51,6 +51,8 @@
 #include <optional>
 #include <vector>
 
+#define DEBUG_TYPE "instructions"
+
 using namespace llvm;
 
 static cl::opt<bool> DisableI2pP2iOpt(

--- a/llvm/tools/llvm-ir2vec/lib/Utils.h
+++ b/llvm/tools/llvm-ir2vec/lib/Utils.h
@@ -218,4 +218,6 @@ struct MIRContext {
 
 } // namespace llvm
 
+#undef DEBUG_TYPE
+
 #endif // LLVM_TOOLS_LLVM_IR2VEC_UTILS_UTILS_H

--- a/llvm/tools/llvm-mca/PipelinePrinter.h
+++ b/llvm/tools/llvm-mca/PipelinePrinter.h
@@ -66,4 +66,6 @@ public:
 } // namespace mca
 } // namespace llvm
 
+#undef DEBUG_TYPE
+
 #endif // LLVM_TOOLS_LLVM_MCA_PIPELINEPRINTER_H

--- a/llvm/tools/llvm-mca/Views/InstructionInfoView.h
+++ b/llvm/tools/llvm-mca/Views/InstructionInfoView.h
@@ -109,4 +109,6 @@ public:
 } // namespace mca
 } // namespace llvm
 
+#undef DEBUG_TYPE
+
 #endif


### PR DESCRIPTION
Several headers define DEBUG_TYPE but never undefine it before the closing include guard. This means any translation unit that includes these headers (directly or transitively) gets the header's DEBUG_TYPE leaked into its scope, which can silently override or conflict with the file's own DEBUG_TYPE.

Add the missing #undef DEBUG_TYPE before the final #endif in each affected header, matching the convention used by the majority of LLVM/Clang/LLD headers that define DEBUG_TYPE.

See https://discourse.llvm.org/t/rfc-enabling-unity-build/90306 for more info.

"clauded" not coded