### PR TITLE
[LLVM][Support] Add #undef GOODFLAGS to regcomp.c and regexec.c

### DIFF
--- a/llvm/lib/Support/regcomp.c
+++ b/llvm/lib/Support/regcomp.c
@@ -1656,3 +1656,5 @@ pluscount(struct parse *p, struct re_guts *g) {
     g->iflags |= REGEX_BAD;
   return (maxnest);
 }
+
+#undef GOODFLAGS

--- a/llvm/lib/Support/regexec.c
+++ b/llvm/lib/Support/regexec.c
@@ -160,3 +160,5 @@ llvm_regexec(const llvm_regex_t *preg, const char *string, size_t nmatch,
 	else
 		return(lmatcher(g, string, nmatch, pmatch, eflags));
 }
+
+#undef GOODFLAGS


### PR DESCRIPTION
Both files define a GOODFLAGS macro that is never undefined, which can leak into subsequent translation units in unity builds. Add #undef GOODFLAGS at the end of each file. See https://discourse.llvm.org/t/rfc-enabling-unity-build/90306 for more info.

"clauded" not coded