### PR TITLE
[LLVM][X86] Add #undef PASS_KEY to files that define it

### DIFF
--- a/llvm/lib/Target/X86/X86FlagsCopyLowering.cpp
+++ b/llvm/lib/Target/X86/X86FlagsCopyLowering.cpp
@@ -949,3 +949,5 @@ X86FlagsCopyLoweringPass::run(MachineFunction &MF,
   return Changed ? PreservedAnalyses::all()
                  : getMachineFunctionPassPreservedAnalyses();
 }
+
+#undef PASS_KEY

--- a/llvm/lib/Target/X86/X86LoadValueInjectionLoadHardening.cpp
+++ b/llvm/lib/Target/X86/X86LoadValueInjectionLoadHardening.cpp
@@ -843,3 +843,5 @@ INITIALIZE_PASS_END(X86LoadValueInjectionLoadHardeningLegacy, PASS_KEY,
 FunctionPass *llvm::createX86LoadValueInjectionLoadHardeningLegacyPass() {
   return new X86LoadValueInjectionLoadHardeningLegacy();
 }
+
+#undef PASS_KEY

--- a/llvm/lib/Target/X86/X86LoadValueInjectionRetHardening.cpp
+++ b/llvm/lib/Target/X86/X86LoadValueInjectionRetHardening.cpp
@@ -131,3 +131,5 @@ INITIALIZE_PASS(X86LoadValueInjectionRetHardeningLegacy, PASS_KEY,
 FunctionPass *llvm::createX86LoadValueInjectionRetHardeningLegacyPass() {
   return new X86LoadValueInjectionRetHardeningLegacy();
 }
+
+#undef PASS_KEY

--- a/llvm/lib/Target/X86/X86ReturnThunks.cpp
+++ b/llvm/lib/Target/X86/X86ReturnThunks.cpp
@@ -114,3 +114,5 @@ INITIALIZE_PASS(X86ReturnThunksLegacy, PASS_KEY, "X86 Return Thunks", false,
 FunctionPass *llvm::createX86ReturnThunksLegacyPass() {
   return new X86ReturnThunksLegacy();
 }
+
+#undef PASS_KEY

--- a/llvm/lib/Target/X86/X86SpeculativeLoadHardening.cpp
+++ b/llvm/lib/Target/X86/X86SpeculativeLoadHardening.cpp
@@ -2289,3 +2289,5 @@ INITIALIZE_PASS_END(X86SpeculativeLoadHardeningLegacy, PASS_KEY,
 FunctionPass *llvm::createX86SpeculativeLoadHardeningLegacyPass() {
   return new X86SpeculativeLoadHardeningLegacy();
 }
+
+#undef PASS_KEY


### PR DESCRIPTION
Five X86 source files define a PASS_KEY macro that is never undefined, which can leak into subsequent translation units in unity builds. Add #undef PASS_KEY at the end of each file. See https://discourse.llvm.org/t/rfc-enabling-unity-build/90306 for more info.

"clauded" not coded