### PR TITLE
[LLVM] Add #undef RETURN_IF_ERROR to files that define it

### DIFF
--- a/llvm/lib/Object/COFFObjectFile.cpp
+++ b/llvm/lib/Object/COFFObjectFile.cpp
@@ -2399,3 +2399,5 @@ ResourceSectionRef::getContents(const coff_resource_data_entry &Entry) {
                              "address not found in image");
   }
 }
+
+#undef RETURN_IF_ERROR

--- a/llvm/lib/Object/WindowsResource.cpp
+++ b/llvm/lib/Object/WindowsResource.cpp
@@ -1012,3 +1012,5 @@ writeWindowsResourceCOFF(COFF::MachineTypes MachineType,
 
 } // namespace object
 } // namespace llvm
+
+#undef RETURN_IF_ERROR

--- a/llvm/tools/llvm-rc/ResourceFileWriter.cpp
+++ b/llvm/tools/llvm-rc/ResourceFileWriter.cpp
@@ -1625,3 +1625,5 @@ ResourceFileWriter::loadFile(StringRef File) const {
 
 } // namespace rc
 } // namespace llvm
+
+#undef RETURN_IF_ERROR

--- a/llvm/tools/llvm-rc/ResourceScriptParser.cpp
+++ b/llvm/tools/llvm-rc/ResourceScriptParser.cpp
@@ -1006,3 +1006,5 @@ Error RCParser::getExpectedError(const Twine &Message, bool IsAlreadyRead) {
 
 } // namespace rc
 } // namespace llvm
+
+#undef RETURN_IF_ERROR

--- a/llvm/unittests/tools/llvm-profdata/OutputSizeLimitTest.cpp
+++ b/llvm/unittests/tools/llvm-profdata/OutputSizeLimitTest.cpp
@@ -168,3 +168,5 @@ TEST(TestOutputSizeLimit, TestOutputSizeLimitExtBinaryCompressed) {
                          Succeeded());
 }
 #endif
+
+#undef RETURN_IF_ERROR


### PR DESCRIPTION
Five files define a RETURN_IF_ERROR macro that is never undefined, which can leak into subsequent translation units in unity builds. Add #undef RETURN_IF_ERROR at the end of each file. See https://discourse.llvm.org/t/rfc-enabling-unity-build/90306 for more info.

"clauded" not coded