### PR TITLE
[MLIR][SparseTensor] Add #undef FAILURE_IF_FAILED and ERROR_IF

### DIFF
--- a/mlir/lib/Dialect/SparseTensor/IR/Detail/DimLvlMapParser.cpp
+++ b/mlir/lib/Dialect/SparseTensor/IR/Detail/DimLvlMapParser.cpp
@@ -305,3 +305,6 @@ ParseResult DimLvlMapParser::parseLvlSpec(bool requireLvlVarBinding) {
 }
 
 //===----------------------------------------------------------------------===//
+
+#undef FAILURE_IF_FAILED
+#undef ERROR_IF

--- a/mlir/lib/Dialect/SparseTensor/IR/Detail/LvlTypeParser.cpp
+++ b/mlir/lib/Dialect/SparseTensor/IR/Detail/LvlTypeParser.cpp
@@ -125,3 +125,6 @@ LvlTypeParser::parseStructured(AsmParser &parser,
 }
 
 //===----------------------------------------------------------------------===//
+
+#undef FAILURE_IF_FAILED
+#undef ERROR_IF


### PR DESCRIPTION
Both DimLvlMapParser.cpp and LvlTypeParser.cpp define FAILURE_IF_FAILED and ERROR_IF macros that are never undefined, which can leak into subsequent translation units in unity builds. Add #undef at the end of each file. See https://discourse.llvm.org/t/rfc-enabling-unity-build/90306 for more info.

"clauded" not coded