### PR TITLE
[MLIR][SparseTensor] Add missing #undef REMUI and DIVUI

### DIFF
--- a/mlir/lib/Dialect/SparseTensor/Transforms/Utils/LoopEmitter.cpp
+++ b/mlir/lib/Dialect/SparseTensor/Transforms/Utils/LoopEmitter.cpp
@@ -990,4 +990,6 @@ std::pair<Operation *, Value> sparse_tensor::genCoIteration(
 #undef ANDI
 #undef SUBI
 #undef MULI
+#undef REMUI
+#undef DIVUI
 #undef SELECT

--- a/mlir/lib/Dialect/SparseTensor/Transforms/Utils/SparseTensorIterator.cpp
+++ b/mlir/lib/Dialect/SparseTensor/Transforms/Utils/SparseTensorIterator.cpp
@@ -1724,4 +1724,6 @@ std::unique_ptr<SparseIterator> sparse_tensor::makeTraverseSubSectIterator(
 #undef ANDI
 #undef SUBI
 #undef MULI
+#undef REMUI
+#undef DIVUI
 #undef SELECT


### PR DESCRIPTION
LoopEmitter.cpp and SparseTensorIterator.cpp define REMUI and DIVUI macros but the existing #undef block at the end of each file omits them. This can leak the macros into subsequent translation units in unity builds. See https://discourse.llvm.org/t/rfc-enabling-unity-build/90306 for more info.

"clauded" not coded