### PR TITLE
[LLVM][MLIR] Add #undef PASS_NAME to all files that define it

### DIFF
--- a/llvm/lib/CodeGen/TypePromotion.cpp
+++ b/llvm/lib/CodeGen/TypePromotion.cpp
@@ -1061,3 +1061,5 @@ PreservedAnalyses TypePromotionPass::run(Function &F,
   PA.preserve<LoopAnalysis>();
   return PA;
 }
+
+#undef PASS_NAME

--- a/llvm/lib/Target/AArch64/AArch64ISelDAGToDAG.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ISelDAGToDAG.cpp
@@ -8007,3 +8007,5 @@ void AArch64DAGToDAGISel::PreprocessISelDAG() {
 
   SelectionDAGISel::PreprocessISelDAG();
 }
+
+#undef PASS_NAME

--- a/llvm/lib/Target/AArch64/AArch64SRLTDefineSuperRegs.cpp
+++ b/llvm/lib/Target/AArch64/AArch64SRLTDefineSuperRegs.cpp
@@ -246,3 +246,5 @@ bool AArch64SRLTDefineSuperRegs::runOnMachineFunction(MachineFunction &MF) {
 FunctionPass *llvm::createAArch64SRLTDefineSuperRegsPass() {
   return new AArch64SRLTDefineSuperRegs();
 }
+
+#undef PASS_NAME

--- a/llvm/lib/Target/AMDGPU/SIMemoryLegalizer.cpp
+++ b/llvm/lib/Target/AMDGPU/SIMemoryLegalizer.cpp
@@ -2514,3 +2514,5 @@ char &llvm::SIMemoryLegalizerID = SIMemoryLegalizerLegacy::ID;
 FunctionPass *llvm::createSIMemoryLegalizerPass() {
   return new SIMemoryLegalizerLegacy();
 }
+
+#undef PASS_NAME

--- a/llvm/lib/Target/ARC/ARCISelDAGToDAG.cpp
+++ b/llvm/lib/Target/ARC/ARCISelDAGToDAG.cpp
@@ -187,3 +187,5 @@ void ARCDAGToDAGISel::Select(SDNode *N) {
   }
   SelectCode(N);
 }
+
+#undef PASS_NAME

--- a/llvm/lib/Target/ARM/ARMISelDAGToDAG.cpp
+++ b/llvm/lib/Target/ARM/ARMISelDAGToDAG.cpp
@@ -5794,3 +5794,5 @@ FunctionPass *llvm::createARMISelDag(ARMBaseTargetMachine &TM,
                                      CodeGenOptLevel OptLevel) {
   return new ARMDAGToDAGISelLegacy(TM, OptLevel);
 }
+
+#undef PASS_NAME

--- a/llvm/lib/Target/ARM/Thumb2ITBlockPass.cpp
+++ b/llvm/lib/Target/ARM/Thumb2ITBlockPass.cpp
@@ -304,3 +304,5 @@ bool Thumb2ITBlock::runOnMachineFunction(MachineFunction &Fn) {
 /// createThumb2ITBlockPass - Returns an instance of the Thumb2 IT blocks
 /// insertion pass.
 FunctionPass *llvm::createThumb2ITBlockPass() { return new Thumb2ITBlock(); }
+
+#undef PASS_NAME

--- a/llvm/lib/Target/AVR/AVRISelDAGToDAG.cpp
+++ b/llvm/lib/Target/AVR/AVRISelDAGToDAG.cpp
@@ -597,3 +597,5 @@ FunctionPass *llvm::createAVRISelDag(AVRTargetMachine &TM,
                                      CodeGenOptLevel OptLevel) {
   return new AVRDAGToDAGISelLegacy(TM, OptLevel);
 }
+
+#undef PASS_NAME

--- a/llvm/lib/Target/BPF/BPFISelDAGToDAG.cpp
+++ b/llvm/lib/Target/BPF/BPFISelDAGToDAG.cpp
@@ -471,3 +471,5 @@ void BPFDAGToDAGISel::PreprocessTrunc(SDNode *Node,
 FunctionPass *llvm::createBPFISelDag(BPFTargetMachine &TM) {
   return new BPFDAGToDAGISelLegacy(TM);
 }
+
+#undef PASS_NAME

--- a/llvm/lib/Target/CSKY/CSKYISelDAGToDAG.cpp
+++ b/llvm/lib/Target/CSKY/CSKYISelDAGToDAG.cpp
@@ -410,3 +410,5 @@ FunctionPass *llvm::createCSKYISelDag(CSKYTargetMachine &TM,
                                       CodeGenOptLevel OptLevel) {
   return new CSKYDAGToDAGISelLegacy(TM, OptLevel);
 }
+
+#undef PASS_NAME

--- a/llvm/lib/Target/Hexagon/HexagonISelDAGToDAG.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonISelDAGToDAG.cpp
@@ -2523,3 +2523,5 @@ void HexagonDAGToDAGISel::rebalanceAddressTrees() {
   RootHeights.clear();
   RootWeights.clear();
 }
+
+#undef PASS_NAME

--- a/llvm/lib/Target/Lanai/LanaiISelDAGToDAG.cpp
+++ b/llvm/lib/Target/Lanai/LanaiISelDAGToDAG.cpp
@@ -360,3 +360,5 @@ void LanaiDAGToDAGISel::selectFrameIndex(SDNode *Node) {
 FunctionPass *llvm::createLanaiISelDag(LanaiTargetMachine &TM) {
   return new LanaiDAGToDAGISelLegacy(TM);
 }
+
+#undef PASS_NAME

--- a/llvm/lib/Target/LoongArch/LoongArchISelDAGToDAG.cpp
+++ b/llvm/lib/Target/LoongArch/LoongArchISelDAGToDAG.cpp
@@ -473,3 +473,5 @@ FunctionPass *llvm::createLoongArchISelDag(LoongArchTargetMachine &TM,
                                            CodeGenOptLevel OptLevel) {
   return new LoongArchDAGToDAGISelLegacy(TM, OptLevel);
 }
+
+#undef PASS_NAME

--- a/llvm/lib/Target/M68k/M68kCollapseMOVEMPass.cpp
+++ b/llvm/lib/Target/M68k/M68kCollapseMOVEMPass.cpp
@@ -311,3 +311,5 @@ INITIALIZE_PASS(M68kCollapseMOVEM, DEBUG_TYPE, PASS_NAME, false, false)
 FunctionPass *llvm::createM68kCollapseMOVEMPass() {
   return new M68kCollapseMOVEM();
 }
+
+#undef PASS_NAME

--- a/llvm/lib/Target/M68k/M68kExpandPseudo.cpp
+++ b/llvm/lib/Target/M68k/M68kExpandPseudo.cpp
@@ -319,3 +319,5 @@ bool M68kExpandPseudo::runOnMachineFunction(MachineFunction &MF) {
 FunctionPass *llvm::createM68kExpandPseudoPass() {
   return new M68kExpandPseudo();
 }
+
+#undef PASS_NAME

--- a/llvm/lib/Target/M68k/M68kISelDAGToDAG.cpp
+++ b/llvm/lib/Target/M68k/M68kISelDAGToDAG.cpp
@@ -1144,3 +1144,5 @@ bool M68kDAGToDAGISel::SelectInlineAsmMemoryOperand(
     return true;
   }
 }
+
+#undef PASS_NAME

--- a/llvm/lib/Target/M68k/M68kInstrInfo.cpp
+++ b/llvm/lib/Target/M68k/M68kInstrInfo.cpp
@@ -949,3 +949,5 @@ INITIALIZE_PASS(M68kGlobalBaseReg, DEBUG_TYPE, PASS_NAME, false, false)
 FunctionPass *llvm::createM68kGlobalBaseRegPass() {
   return new M68kGlobalBaseReg();
 }
+
+#undef PASS_NAME

--- a/llvm/lib/Target/MSP430/MSP430ISelDAGToDAG.cpp
+++ b/llvm/lib/Target/MSP430/MSP430ISelDAGToDAG.cpp
@@ -462,3 +462,5 @@ void MSP430DAGToDAGISel::Select(SDNode *Node) {
   // Select the default instruction
   SelectCode(Node);
 }
+
+#undef PASS_NAME

--- a/llvm/lib/Target/Mips/MipsISelDAGToDAG.cpp
+++ b/llvm/lib/Target/Mips/MipsISelDAGToDAG.cpp
@@ -310,3 +310,5 @@ MipsDAGToDAGISelLegacy::MipsDAGToDAGISelLegacy(
     : SelectionDAGISelLegacy(ID, std::move(S)) {}
 
 INITIALIZE_PASS(MipsDAGToDAGISelLegacy, DEBUG_TYPE, PASS_NAME, false, false)
+
+#undef PASS_NAME

--- a/llvm/lib/Target/NVPTX/NVPTXISelDAGToDAG.cpp
+++ b/llvm/lib/Target/NVPTX/NVPTXISelDAGToDAG.cpp
@@ -2319,3 +2319,5 @@ void NVPTXDAGToDAGISel::selectBR_JT(SDNode *N) {
 
   ReplaceNode(N, BrxEnd);
 }
+
+#undef PASS_NAME

--- a/llvm/lib/Target/PowerPC/PPCISelDAGToDAG.cpp
+++ b/llvm/lib/Target/PowerPC/PPCISelDAGToDAG.cpp
@@ -7970,3 +7970,5 @@ FunctionPass *llvm::createPPCISelDag(PPCTargetMachine &TM,
                                      CodeGenOptLevel OptLevel) {
   return new PPCDAGToDAGISelLegacy(TM, OptLevel);
 }
+
+#undef PASS_NAME

--- a/llvm/lib/Target/RISCV/RISCVCodeGenPrepare.cpp
+++ b/llvm/lib/Target/RISCV/RISCVCodeGenPrepare.cpp
@@ -327,3 +327,5 @@ PreservedAnalyses RISCVCodeGenPreparePass::run(Function &F,
   PA.preserveSet<CFGAnalyses>();
   return PA;
 }
+
+#undef PASS_NAME

--- a/llvm/lib/Target/RISCV/RISCVISelDAGToDAG.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelDAGToDAG.cpp
@@ -4947,3 +4947,5 @@ RISCVDAGToDAGISelLegacy::RISCVDAGToDAGISelLegacy(RISCVTargetMachine &TM,
           ID, std::make_unique<RISCVDAGToDAGISel>(TM, OptLevel)) {}
 
 INITIALIZE_PASS(RISCVDAGToDAGISelLegacy, DEBUG_TYPE, PASS_NAME, false, false)
+
+#undef PASS_NAME

--- a/llvm/lib/Target/RISCV/RISCVIndirectBranchTracking.cpp
+++ b/llvm/lib/Target/RISCV/RISCVIndirectBranchTracking.cpp
@@ -128,3 +128,5 @@ bool RISCVIndirectBranchTracking::runOnMachineFunction(MachineFunction &MF) {
 
   return Changed;
 }
+
+#undef PASS_NAME

--- a/llvm/lib/Target/RISCV/RISCVLandingPadSetup.cpp
+++ b/llvm/lib/Target/RISCV/RISCVLandingPadSetup.cpp
@@ -86,3 +86,5 @@ char RISCVLandingPadSetup::ID = 0;
 FunctionPass *llvm::createRISCVLandingPadSetupPass() {
   return new RISCVLandingPadSetup();
 }
+
+#undef PASS_NAME

--- a/llvm/lib/Target/RISCV/RISCVVLOptimizer.cpp
+++ b/llvm/lib/Target/RISCV/RISCVVLOptimizer.cpp
@@ -1357,3 +1357,5 @@ bool RISCVVLOptimizer::runOnMachineFunction(MachineFunction &MF) {
   DemandedVLs.clear();
   return MadeChange;
 }
+
+#undef PASS_NAME

--- a/llvm/lib/Target/RISCV/RISCVZacasABIFix.cpp
+++ b/llvm/lib/Target/RISCV/RISCVZacasABIFix.cpp
@@ -92,3 +92,5 @@ char RISCVZacasABIFix::ID = 0;
 FunctionPass *llvm::createRISCVZacasABIFixPass() {
   return new RISCVZacasABIFix();
 }
+
+#undef PASS_NAME

--- a/llvm/lib/Target/Sparc/SparcISelDAGToDAG.cpp
+++ b/llvm/lib/Target/Sparc/SparcISelDAGToDAG.cpp
@@ -403,3 +403,5 @@ bool SparcDAGToDAGISel::SelectInlineAsmMemoryOperand(
 FunctionPass *llvm::createSparcISelDag(SparcTargetMachine &TM) {
   return new SparcDAGToDAGISelLegacy(TM);
 }
+
+#undef PASS_NAME

--- a/llvm/lib/Target/SystemZ/SystemZISelDAGToDAG.cpp
+++ b/llvm/lib/Target/SystemZ/SystemZISelDAGToDAG.cpp
@@ -2115,3 +2115,5 @@ void SystemZDAGToDAGISel::PreprocessISelDAG() {
   if (MadeChange)
     CurDAG->RemoveDeadNodes();
 }
+
+#undef PASS_NAME

--- a/llvm/lib/Target/VE/VEISelDAGToDAG.cpp
+++ b/llvm/lib/Target/VE/VEISelDAGToDAG.cpp
@@ -339,3 +339,5 @@ SDNode *VEDAGToDAGISel::getGlobalBaseReg() {
 FunctionPass *llvm::createVEISelDag(VETargetMachine &TM) {
   return new VEDAGToDAGISelLegacy(TM);
 }
+
+#undef PASS_NAME

--- a/llvm/lib/Target/WebAssembly/WebAssemblyISelDAGToDAG.cpp
+++ b/llvm/lib/Target/WebAssembly/WebAssemblyISelDAGToDAG.cpp
@@ -643,3 +643,5 @@ FunctionPass *llvm::createWebAssemblyISelDag(WebAssemblyTargetMachine &TM,
                                              CodeGenOptLevel OptLevel) {
   return new WebAssemblyDAGToDAGISelLegacy(TM, OptLevel);
 }
+
+#undef PASS_NAME

--- a/llvm/lib/Target/X86/X86ISelDAGToDAG.cpp
+++ b/llvm/lib/Target/X86/X86ISelDAGToDAG.cpp
@@ -6890,3 +6890,5 @@ FunctionPass *llvm::createX86ISelDag(X86TargetMachine &TM,
                                      CodeGenOptLevel OptLevel) {
   return new X86DAGToDAGISelLegacy(TM, OptLevel);
 }
+
+#undef PASS_NAME

--- a/llvm/lib/Target/XCore/XCoreISelDAGToDAG.cpp
+++ b/llvm/lib/Target/XCore/XCoreISelDAGToDAG.cpp
@@ -247,3 +247,5 @@ bool XCoreDAGToDAGISel::tryBRIND(SDNode *N) {
   CurDAG->SelectNodeTo(N, XCore::BAU_1r, MVT::Other, nextAddr, Glue);
   return true;
 }
+
+#undef PASS_NAME

--- a/mlir/lib/Conversion/ControlFlowToLLVM/ControlFlowToLLVM.cpp
+++ b/mlir/lib/Conversion/ControlFlowToLLVM/ControlFlowToLLVM.cpp
@@ -322,3 +322,5 @@ void mlir::cf::registerConvertControlFlowToLLVMInterface(
     dialect->addInterfaces<ControlFlowToLLVMDialectInterface>();
   });
 }
+
+#undef PASS_NAME

--- a/mlir/lib/Conversion/FuncToLLVM/FuncToLLVM.cpp
+++ b/mlir/lib/Conversion/FuncToLLVM/FuncToLLVM.cpp
@@ -890,3 +890,5 @@ void mlir::registerConvertFuncToLLVMInterface(DialectRegistry &registry) {
     dialect->addInterfaces<FuncToLLVMDialectInterface>();
   });
 }
+
+#undef PASS_NAME

--- a/mlir/lib/Dialect/Affine/Transforms/LoopCoalescing.cpp
+++ b/mlir/lib/Dialect/Affine/Transforms/LoopCoalescing.cpp
@@ -48,3 +48,5 @@ std::unique_ptr<OperationPass<func::FuncOp>>
 mlir::affine::createLoopCoalescingPass() {
   return std::make_unique<LoopCoalescingPass>();
 }
+
+#undef PASS_NAME

--- a/mlir/test/lib/Dialect/Affine/TestAccessAnalysis.cpp
+++ b/mlir/test/lib/Dialect/Affine/TestAccessAnalysis.cpp
@@ -88,3 +88,5 @@ void registerTestAffineAccessAnalysisPass() {
   PassRegistration<TestAccessAnalysis>();
 }
 } // namespace mlir
+
+#undef PASS_NAME

--- a/mlir/test/lib/Dialect/Affine/TestAffineDataCopy.cpp
+++ b/mlir/test/lib/Dialect/Affine/TestAffineDataCopy.cpp
@@ -153,3 +153,5 @@ void registerTestAffineDataCopyPass() {
   PassRegistration<TestAffineDataCopy>();
 }
 } // namespace mlir
+
+#undef PASS_NAME

--- a/mlir/test/lib/Dialect/Affine/TestAffineLoopUnswitching.cpp
+++ b/mlir/test/lib/Dialect/Affine/TestAffineLoopUnswitching.cpp
@@ -64,3 +64,5 @@ void registerTestAffineLoopUnswitchingPass() {
   PassRegistration<TestAffineLoopUnswitching>();
 }
 } // namespace mlir
+
+#undef PASS_NAME

--- a/mlir/test/lib/Dialect/Affine/TestDecomposeAffineOps.cpp
+++ b/mlir/test/lib/Dialect/Affine/TestDecomposeAffineOps.cpp
@@ -55,3 +55,5 @@ void registerTestDecomposeAffineOpPass() {
   PassRegistration<TestDecomposeAffineOps>();
 }
 } // namespace mlir
+
+#undef PASS_NAME

--- a/mlir/test/lib/Dialect/Affine/TestLoopPermutation.cpp
+++ b/mlir/test/lib/Dialect/Affine/TestLoopPermutation.cpp
@@ -79,3 +79,5 @@ void registerTestLoopPermutationPass() {
   PassRegistration<TestLoopPermutation>();
 }
 } // namespace mlir
+
+#undef PASS_NAME

--- a/mlir/test/lib/Dialect/Affine/TestReifyValueBounds.cpp
+++ b/mlir/test/lib/Dialect/Affine/TestReifyValueBounds.cpp
@@ -234,3 +234,5 @@ void registerTestAffineReifyValueBoundsPass() {
   PassRegistration<TestReifyValueBounds>();
 }
 } // namespace mlir
+
+#undef PASS_NAME

--- a/mlir/test/lib/Dialect/Tosa/TosaTestPasses.cpp
+++ b/mlir/test/lib/Dialect/Tosa/TosaTestPasses.cpp
@@ -226,3 +226,5 @@ void registerTosaTestQuantUtilAPIPass() {
   PassRegistration<TosaTestQuantUtilAPI>();
 }
 } // namespace mlir
+
+#undef PASS_NAME


### PR DESCRIPTION
43 source files define a PASS_NAME macro that is never undefined, which can leak into subsequent translation units in unity builds. Add #undef PASS_NAME at the end of each file.

"clauded" not coded