### PR TITLE
[Hexagon] Fix infinite loop in scheduler for RELOC_NONE instruction

### DIFF
--- a/llvm/include/llvm/Target/Target.td
+++ b/llvm/include/llvm/Target/Target.td
@@ -1667,6 +1667,7 @@ def RELOC_NONE : StandardPseudoInstruction {
   let OutOperandList = (outs);
   let InOperandList = (ins unknown:$symbol);
   let hasSideEffects = true;
+  let isMeta = true;
 }
 
 let hasSideEffects = false, isMeta = true, isConvergent = true in {

--- a/llvm/lib/Target/Hexagon/HexagonHazardRecognizer.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonHazardRecognizer.cpp
@@ -38,7 +38,7 @@ void HexagonHazardRecognizer::Reset() {
 ScheduleHazardRecognizer::HazardType
 HexagonHazardRecognizer::getHazardType(SUnit *SU, int stalls) {
   MachineInstr *MI = SU->getInstr();
-  if (!MI || TII->isZeroCost(MI->getOpcode()))
+  if (!MI || TII->isZeroCost(MI->getOpcode()) || MI->isMetaInstruction())
     return NoHazard;
 
   if (!Resources->canReserveResources(*MI)) {
@@ -120,7 +120,7 @@ void HexagonHazardRecognizer::EmitInstruction(SUnit *SU) {
     if (MO.isReg() && MO.isDef() && !MO.isImplicit())
       RegDefs.insert(MO.getReg());
 
-  if (TII->isZeroCost(MI->getOpcode()))
+  if (TII->isZeroCost(MI->getOpcode()) || MI->isMetaInstruction())
     return;
 
   if (!Resources->canReserveResources(*MI) || isNewStore(*MI)) {

--- a/llvm/test/CodeGen/Generic/reloc-none.ll
+++ b/llvm/test/CodeGen/Generic/reloc-none.ll
@@ -1,7 +1,6 @@
 ; RUN: llc < %s | FileCheck %s
 
 ; CHECK: .reloc {{.*}}, BFD_RELOC_NONE, foo
-; UNSUPPORTED: target=hexagon{{.*}}
 
 define void @test_reloc_none() {
   call void @llvm.reloc.none(metadata !"foo")


### PR DESCRIPTION
The llvm.reloc.none intrinsic (introduced in 5f08fb4d72f6) causes an infinite loop when compiling for Hexagon target. The Hexagon scheduler's hazard recognizer enters an infinite loop because RELOC_NONE

RELOC_NONE is a pseudo-instruction that doesn't correspond to real hardware, but the Hexagon hazard recognizer was treating it as a regular instruction requiring hardware resource allocation.

Mark RELOC_NONE as a meta-instruction and update Hexagon's hazard recognizer to skip resource checks for meta-instructions, similar to how it handles zero-cost instructions.