### PR TITLE
[clang-tidy] Diagnose NULL macro expansions in implicit-bool-conversion

### DIFF
--- a/clang-tools-extra/clang-tidy/readability/ImplicitBoolConversionCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/ImplicitBoolConversionCheck.cpp
@@ -382,7 +382,8 @@ void ImplicitBoolConversionCheck::handleCastToBool(const ImplicitCastExpr *Cast,
     return;
   }
 
-  auto Diag = diag(Cast->getBeginLoc(), "implicit conversion %0 -> 'bool'")
+  auto Diag = diag(Context.getSourceManager().getFileLoc(Cast->getBeginLoc()),
+                   "implicit conversion %0 -> 'bool'")
               << Cast->getSubExpr()->getType();
 
   const StringRef EquivalentLiteral =
@@ -400,7 +401,8 @@ void ImplicitBoolConversionCheck::handleCastFromBool(
     ASTContext &Context) {
   const QualType DestType =
       NextImplicitCast ? NextImplicitCast->getType() : Cast->getType();
-  auto Diag = diag(Cast->getBeginLoc(), "implicit conversion 'bool' -> %0")
+  auto Diag = diag(Context.getSourceManager().getFileLoc(Cast->getBeginLoc()),
+                   "implicit conversion 'bool' -> %0")
               << DestType;
 
   if (const auto *BoolLiteral =

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -396,11 +396,14 @@ Changes in existing checks
   it easier to see which specific enumerators need explicit initialization.
 
 - Improved :doc:`readability-implicit-bool-conversion
-  <clang-tidy/checks/readability/implicit-bool-conversion>` check by fixing a
-  false positive where `AllowPointerConditions` and `AllowIntegerConditions`
-  options did not suppress warnings when the condition expression involved
-  temporaries (e.g. passing a string literal to a ``const std::string&``
-  parameter)
+  <clang-tidy/checks/readability/implicit-bool-conversion>` check:
+
+  - Fixed a false positive where `AllowPointerConditions` and
+    `AllowIntegerConditions` options did not suppress warnings when the
+    condition expression involved temporaries (e.g. passing a string literal to
+    a ``const std::string&`` parameter).
+
+  - Warn and provide fix-its when ``NULL`` is defined in system headers.
 
 - Improved :doc:`readability-non-const-parameter
   <clang-tidy/checks/readability/non-const-parameter>` check by avoiding false

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -403,7 +403,8 @@ Changes in existing checks
     condition expression involved temporaries (e.g. passing a string literal to
     a ``const std::string&`` parameter).
 
-  - Warn and provide fix-its when ``NULL`` is defined in system headers.
+  - Warn and provide fix-its when a macro defined in a system header (e.g.
+    ``NULL``) is implicitly converted to ``bool``.
 
 - Improved :doc:`readability-non-const-parameter
   <clang-tidy/checks/readability/non-const-parameter>` check by avoiding false

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/implicit-bool-conversion.c
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/implicit-bool-conversion.c
@@ -1,5 +1,5 @@
-// RUN: %check_clang_tidy -std=c23-or-later %s readability-implicit-bool-conversion %t --system-headers
-// RUN: %check_clang_tidy -std=c23-or-later -check-suffix=UPPER-CASE %s readability-implicit-bool-conversion %t -- --system-headers \
+// RUN: %check_clang_tidy -std=c23-or-later %s readability-implicit-bool-conversion %t
+// RUN: %check_clang_tidy -std=c23-or-later -check-suffix=UPPER-CASE %s readability-implicit-bool-conversion %t -- \
 // RUN:     -config='{CheckOptions: { \
 // RUN:         readability-implicit-bool-conversion.UseUpperCaseLiteralSuffix: true \
 // RUN:     }}'

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/implicit-bool-conversion.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/implicit-bool-conversion.cpp
@@ -1,5 +1,5 @@
-// RUN: %check_clang_tidy %s readability-implicit-bool-conversion %t -- --system-headers
-// RUN: %check_clang_tidy -check-suffix=UPPER-CASE %s readability-implicit-bool-conversion %t -- --system-headers \
+// RUN: %check_clang_tidy %s readability-implicit-bool-conversion %t --
+// RUN: %check_clang_tidy -check-suffix=UPPER-CASE %s readability-implicit-bool-conversion %t -- \
 // RUN:     -config='{CheckOptions: { \
 // RUN:         readability-implicit-bool-conversion.UseUpperCaseLiteralSuffix: true \
 // RUN:     }}'


### PR DESCRIPTION
 The check can't find `NULL` from system headers, this is not the default behaviour we want. This commit fixes the problem.

https://clang-tidy.godbolt.org/z/Exd4bzqaT

Related discussion in: https://github.com/llvm/llvm-project/pull/188399#discussion_r2985381743