### PR TITLE
[clang][Modules] Reject export declarations in implementation partitions

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -46,6 +46,9 @@ C++ Specific Potentially Breaking Changes
 - Clang now more aggressively optimizes away stores to objects after they are
   dead. This behavior can be disabled with ``-fno-lifetime-dse``.
 
+- Clang now correctly rejects ``export`` declarations in module implementation
+  partitions. (#GH107602)
+
 ABI Changes in This Version
 ---------------------------
 

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -9914,9 +9914,10 @@ public:
 
   /// Is the module scope we are an implementation unit?
   bool currentModuleIsImplementation() const {
-    return ModuleScopes.empty()
-               ? false
-               : ModuleScopes.back().Module->isModuleImplementation();
+    if (ModuleScopes.empty())
+      return false;
+    const Module *M = ModuleScopes.back().Module;
+    return M->isModuleImplementation() || M->isModulePartitionImplementation();
   }
 
   // When loading a non-modular PCH files, this is used to restore module

--- a/clang/test/CXX/module/module.interface/p1.cpp
+++ b/clang/test/CXX/module/module.interface/p1.cpp
@@ -4,6 +4,8 @@
 // RUN: %clang_cc1 -std=c++2a %t/errors.cpp -verify
 // RUN: %clang_cc1 -std=c++2a %t/M.cppm -emit-module-interface -o %t/M.pcm
 // RUN: %clang_cc1 -std=c++2a %t/impl.cpp -fmodule-file=M=%t/M.pcm -verify
+// RUN: %clang_cc1 -std=c++2a %t/interface-partition.cppm -emit-module-interface -o %t/L-P1.pcm
+// RUN: %clang_cc1 -std=c++2a %t/implementation-partition.cpp -fmodule-file=L:P1=%t/L-P1.pcm -verify
 
 //--- errors.cpp
 module;
@@ -40,5 +42,21 @@ module M; // #M
 export int b2; // expected-error {{export declaration can only be used within a module interface}}
 namespace N {
   export int c2; // expected-error {{export declaration can only be used within a module interface}}
+}
+// expected-note@#M 2+{{add 'export'}}
+
+//--- interface-partition.cppm
+
+export module L:P1;
+
+//--- implementation-partition.cpp
+
+module L:P2; // #M
+
+export import :P1; // expected-error {{export declaration can only be used within a module interface}}
+
+export int b3; // expected-error {{export declaration can only be used within a module interface}}
+namespace N {
+  export int c3; // expected-error {{export declaration can only be used within a module interface}}
 }
 // expected-note@#M 2+{{add 'export'}}


### PR DESCRIPTION
[[module.interface]/1](https://eel.is/c++draft/module#interface-1) says:

> An [export-declaration](https://eel.is/c++draft/module#nt:export-declaration) shall [...] appear in the purview of a module interface unit.

But clang currently fails to enforce this rule in implementation partitions (https://godbolt.org/z/TvxKq3158).

Partially addresses #107602.