### PR TITLE
[lldb][Module][NFC] Remove redundant FileSpec validity check

### DIFF
--- a/lldb/source/Core/Module.cpp
+++ b/lldb/source/Core/Module.cpp
@@ -1463,7 +1463,7 @@ bool Module::LoadScriptingResourceInTarget(Target *target, Status &error) {
 
   for (uint32_t i = 0; i < num_specs; ++i) {
     FileSpec scripting_fspec(file_specs.GetFileSpecAtIndex(i));
-    if (!scripting_fspec && !FileSystem::Instance().Exists(scripting_fspec))
+    if (!FileSystem::Instance().Exists(scripting_fspec))
       continue;
 
     if (should_load == eLoadScriptFromSymFileWarn) {


### PR DESCRIPTION
We already do the validity check inside of `FileSystem::Instance().Exists`.