### PR TITLE
[ORC] Move DylibManager ownership out of ExecutorProcessControl.

### DIFF
--- a/clang/lib/Interpreter/OrcIncrementalExecutor.cpp
+++ b/clang/lib/Interpreter/OrcIncrementalExecutor.cpp
@@ -109,7 +109,8 @@ llvm::Error OrcIncrementalExecutor::LoadDynamicLibrary(const char *name) {
   // FIXME: Eventually we should put each library in its own JITDylib and
   //        turn off process symbols by default.
   llvm::orc::ExecutionSession &ES = Jit->getExecutionSession();
-  auto DLSGOrErr = llvm::orc::EPCDynamicLibrarySearchGenerator::Load(ES, name);
+  auto DLSGOrErr = llvm::orc::EPCDynamicLibrarySearchGenerator::Load(
+      ES, Jit->getDylibMgr(), name);
   if (!DLSGOrErr)
     return DLSGOrErr.takeError();
 

--- a/llvm/examples/OrcV2Examples/LLJITWithRemoteDebugging/LLJITWithRemoteDebugging.cpp
+++ b/llvm/examples/OrcV2Examples/LLJITWithRemoteDebugging/LLJITWithRemoteDebugging.cpp
@@ -187,7 +187,7 @@ int main(int argc, char *argv[]) {
   // for each of it, so the compiler can lookup their symbols.
   for (const std::string &Path : Dylibs)
     J->getMainJITDylib().addGenerator(
-        ExitOnErr(loadDylib(J->getExecutionSession(), Path)));
+        ExitOnErr(loadDylib(J->getExecutionSession(), J->getDylibMgr(), Path)));
 
   // Add the loaded IR module to the JIT. This will set up symbol tables and
   // prepare for materialization.

--- a/llvm/examples/OrcV2Examples/LLJITWithRemoteDebugging/RemoteJITUtils.cpp
+++ b/llvm/examples/OrcV2Examples/LLJITWithRemoteDebugging/RemoteJITUtils.cpp
@@ -27,10 +27,10 @@ using namespace llvm;
 using namespace llvm::orc;
 
 Expected<std::unique_ptr<DefinitionGenerator>>
-loadDylib(ExecutionSession &ES, StringRef RemotePath) {
-  if (auto Handle = ES.getExecutorProcessControl().getDylibMgr().loadDylib(
-          RemotePath.data()))
-    return std::make_unique<EPCDynamicLibrarySearchGenerator>(ES, *Handle);
+loadDylib(ExecutionSession &ES, DylibManager &DylibMgr, StringRef RemotePath) {
+  if (auto Handle = DylibMgr.loadDylib(RemotePath.data()))
+    return std::make_unique<EPCDynamicLibrarySearchGenerator>(ES, DylibMgr,
+                                                              *Handle);
   else
     return Handle.takeError();
 }

--- a/llvm/examples/OrcV2Examples/LLJITWithRemoteDebugging/RemoteJITUtils.h
+++ b/llvm/examples/OrcV2Examples/LLJITWithRemoteDebugging/RemoteJITUtils.h
@@ -16,6 +16,7 @@
 
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ExecutionEngine/Orc/Core.h"
+#include "llvm/ExecutionEngine/Orc/DylibManager.h"
 #include "llvm/ExecutionEngine/Orc/Layer.h"
 #include "llvm/ExecutionEngine/Orc/SimpleRemoteEPC.h"
 #include "llvm/Support/Error.h"
@@ -37,6 +38,7 @@ llvm::Expected<std::unique_ptr<llvm::orc::SimpleRemoteEPC>>
 connectTCPSocket(llvm::StringRef NetworkAddress);
 
 llvm::Expected<std::unique_ptr<llvm::orc::DefinitionGenerator>>
-loadDylib(llvm::orc::ExecutionSession &ES, llvm::StringRef RemotePath);
+loadDylib(llvm::orc::ExecutionSession &ES, llvm::orc::DylibManager &DylibMgr,
+          llvm::StringRef RemotePath);
 
 #endif

--- a/llvm/include/llvm/ExecutionEngine/Orc/EPCDynamicLibrarySearchGenerator.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/EPCDynamicLibrarySearchGenerator.h
@@ -16,6 +16,7 @@
 
 #include "llvm/ADT/FunctionExtras.h"
 #include "llvm/ExecutionEngine/Orc/Core.h"
+#include "llvm/ExecutionEngine/Orc/DylibManager.h"
 #include "llvm/Support/Compiler.h"
 
 namespace llvm {
@@ -38,10 +39,10 @@ public:
   /// If \p AddAbsoluteSymbols is provided, it is used to add the symbols to the
   /// \c JITDylib; otherwise it uses JD.define(absoluteSymbols(...)).
   EPCDynamicLibrarySearchGenerator(
-      ExecutionSession &ES, tpctypes::DylibHandle H,
+      ExecutionSession &ES, DylibManager &DylibMgr, tpctypes::DylibHandle H,
       SymbolPredicate Allow = SymbolPredicate(),
       AddAbsoluteSymbolsFn AddAbsoluteSymbols = nullptr)
-      : EPC(ES.getExecutorProcessControl()), H(H), Allow(std::move(Allow)),
+      : ES(ES), DylibMgr(DylibMgr), H(H), Allow(std::move(Allow)),
         AddAbsoluteSymbols(std::move(AddAbsoluteSymbols)) {}
 
   /// Create an EPCDynamicLibrarySearchGenerator that resolves all symbols
@@ -52,9 +53,9 @@ public:
   /// "missing symbol" behavior in ORC. This distinction shouldn't matter for
   /// most use-cases).
   EPCDynamicLibrarySearchGenerator(
-      ExecutionSession &ES, SymbolPredicate Allow,
+      ExecutionSession &ES, DylibManager &DylibMgr, SymbolPredicate Allow,
       AddAbsoluteSymbolsFn AddAbsoluteSymbols = nullptr)
-      : EPC(ES.getExecutorProcessControl()), Allow(std::move(Allow)),
+      : ES(ES), DylibMgr(DylibMgr), Allow(std::move(Allow)),
         AddAbsoluteSymbols(std::move(AddAbsoluteSymbols)) {}
 
   /// Permanently loads the library at the given path and, on success, returns
@@ -62,17 +63,18 @@ public:
   /// definitions in the library. On failure returns the reason the library
   /// failed to load.
   static Expected<std::unique_ptr<EPCDynamicLibrarySearchGenerator>>
-  Load(ExecutionSession &ES, const char *LibraryPath,
+  Load(ExecutionSession &ES, DylibManager &DylibMgr, const char *LibraryPath,
        SymbolPredicate Allow = SymbolPredicate(),
        AddAbsoluteSymbolsFn AddAbsoluteSymbols = nullptr);
 
   /// Creates a EPCDynamicLibrarySearchGenerator that searches for symbols in
   /// the target process.
   static Expected<std::unique_ptr<EPCDynamicLibrarySearchGenerator>>
-  GetForTargetProcess(ExecutionSession &ES,
+  GetForTargetProcess(ExecutionSession &ES, DylibManager &DylibMgr,
                       SymbolPredicate Allow = SymbolPredicate(),
                       AddAbsoluteSymbolsFn AddAbsoluteSymbols = nullptr) {
-    return Load(ES, nullptr, std::move(Allow), std::move(AddAbsoluteSymbols));
+    return Load(ES, DylibMgr, nullptr, std::move(Allow),
+                std::move(AddAbsoluteSymbols));
   }
 
   Error tryToGenerate(LookupState &LS, LookupKind K, JITDylib &JD,
@@ -82,7 +84,8 @@ public:
 private:
   Error addAbsolutes(JITDylib &JD, SymbolMap Symbols);
 
-  ExecutorProcessControl &EPC;
+  ExecutionSession &ES;
+  DylibManager &DylibMgr;
   std::optional<tpctypes::DylibHandle> H;
   SymbolPredicate Allow;
   AddAbsoluteSymbolsFn AddAbsoluteSymbols;

--- a/llvm/include/llvm/ExecutionEngine/Orc/ExecutorProcessControl.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/ExecutorProcessControl.h
@@ -146,11 +146,8 @@ public:
     return *MemMgr;
   }
 
-  /// Return the DylibManager for the target process.
-  DylibManager &getDylibMgr() const {
-    assert(DylibMgr && "No DylibMgr object set");
-    return *DylibMgr;
-  }
+  /// Create a default DylibManager for the target process.
+  virtual Expected<std::unique_ptr<DylibManager>> createDefaultDylibMgr() = 0;
 
   /// Returns the bootstrap map.
   const StringMap<std::vector<char>> &getBootstrapMap() const {
@@ -317,7 +314,6 @@ protected:
   JITDispatchInfo JDI;
   MemoryAccess *MemAccess = nullptr;
   jitlink::JITLinkMemoryManager *MemMgr = nullptr;
-  DylibManager *DylibMgr = nullptr;
   StringMap<std::vector<char>> BootstrapMap;
   StringMap<ExecutorAddr> BootstrapSymbols;
 };

--- a/llvm/include/llvm/ExecutionEngine/Orc/ExecutorResolutionGenerator.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/ExecutorResolutionGenerator.h
@@ -18,6 +18,7 @@
 #include "llvm/ADT/FunctionExtras.h"
 #include "llvm/ExecutionEngine/Orc/AbsoluteSymbols.h"
 #include "llvm/ExecutionEngine/Orc/Core.h"
+#include "llvm/ExecutionEngine/Orc/DylibManager.h"
 
 namespace llvm::orc {
 
@@ -28,16 +29,17 @@ public:
       unique_function<std::unique_ptr<MaterializationUnit>(SymbolMap)>;
 
   ExecutorResolutionGenerator(
-      ExecutionSession &ES, tpctypes::ResolverHandle H,
+      ExecutionSession &ES, DylibManager &DylibMgr, tpctypes::ResolverHandle H,
       SymbolPredicate Allow = SymbolPredicate(),
       AbsoluteSymbolsFn AbsoluteSymbols = absoluteSymbols)
-      : EPC(ES.getExecutorProcessControl()), H(H), Allow(std::move(Allow)),
+      : ES(ES), DylibMgr(DylibMgr), H(H), Allow(std::move(Allow)),
         AbsoluteSymbols(std::move(AbsoluteSymbols)) {}
 
   ExecutorResolutionGenerator(
-      ExecutionSession &ES, SymbolPredicate Allow = SymbolPredicate(),
+      ExecutionSession &ES, DylibManager &DylibMgr,
+      SymbolPredicate Allow = SymbolPredicate(),
       AbsoluteSymbolsFn AbsoluteSymbols = absoluteSymbols)
-      : EPC(ES.getExecutorProcessControl()), Allow(std::move(Allow)),
+      : ES(ES), DylibMgr(DylibMgr), Allow(std::move(Allow)),
         AbsoluteSymbols(std::move(AbsoluteSymbols)) {}
 
   /// Permanently loads the library at the given path and, on success, returns
@@ -45,17 +47,18 @@ public:
   /// definitions in the library. On failure returns the reason the library
   /// failed to load.
   static Expected<std::unique_ptr<ExecutorResolutionGenerator>>
-  Load(ExecutionSession &ES, const char *LibraryPath,
+  Load(ExecutionSession &ES, DylibManager &DylibMgr, const char *LibraryPath,
        SymbolPredicate Allow = SymbolPredicate(),
        AbsoluteSymbolsFn AbsoluteSymbols = absoluteSymbols);
 
   /// Creates a ExecutorResolutionGenerator that searches for symbols in
   /// the target process.
   static Expected<std::unique_ptr<ExecutorResolutionGenerator>>
-  GetForTargetProcess(ExecutionSession &ES,
+  GetForTargetProcess(ExecutionSession &ES, DylibManager &DylibMgr,
                       SymbolPredicate Allow = SymbolPredicate(),
                       AbsoluteSymbolsFn AbsoluteSymbols = absoluteSymbols) {
-    return Load(ES, nullptr, std::move(Allow), std::move(AbsoluteSymbols));
+    return Load(ES, DylibMgr, nullptr, std::move(Allow),
+                std::move(AbsoluteSymbols));
   }
 
   Error tryToGenerate(LookupState &LS, LookupKind K, JITDylib &JD,
@@ -63,7 +66,8 @@ public:
                       const SymbolLookupSet &LookupSet) override;
 
 private:
-  ExecutorProcessControl &EPC;
+  ExecutionSession &ES;
+  DylibManager &DylibMgr;
   tpctypes::ResolverHandle H;
   SymbolPredicate Allow;
   AbsoluteSymbolsFn AbsoluteSymbols;

--- a/llvm/include/llvm/ExecutionEngine/Orc/LLJIT.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/LLJIT.h
@@ -17,6 +17,7 @@
 #include "llvm/ExecutionEngine/Orc/AbsoluteSymbols.h"
 #include "llvm/ExecutionEngine/Orc/CompileOnDemandLayer.h"
 #include "llvm/ExecutionEngine/Orc/CompileUtils.h"
+#include "llvm/ExecutionEngine/Orc/DylibManager.h"
 #include "llvm/ExecutionEngine/Orc/ExecutionUtils.h"
 #include "llvm/ExecutionEngine/Orc/IRCompileLayer.h"
 #include "llvm/ExecutionEngine/Orc/IRPartitionLayer.h"
@@ -213,6 +214,12 @@ public:
     return PS->deinitialize(JD);
   }
 
+  /// Returns a reference to the DylibManager for the target process.
+  DylibManager &getDylibMgr() {
+    assert(DylibMgr && "No DylibMgr set");
+    return *DylibMgr;
+  }
+
   /// Returns a reference to the ObjLinkingLayer
   ObjectLayer &getObjLinkingLayer() { return *ObjLinkingLayer; }
 
@@ -247,6 +254,7 @@ protected:
 
   std::unique_ptr<ExecutionSession> ES;
   std::unique_ptr<PlatformSupport> PS;
+  std::unique_ptr<DylibManager> DylibMgr;
 
   JITDylib *ProcessSymbols = nullptr;
   JITDylib *Platform = nullptr;

--- a/llvm/include/llvm/ExecutionEngine/Orc/LookupAndRecordAddrs.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/LookupAndRecordAddrs.h
@@ -18,6 +18,7 @@
 
 #include "llvm/ADT/FunctionExtras.h"
 #include "llvm/ExecutionEngine/Orc/Core.h"
+#include "llvm/ExecutionEngine/Orc/DylibManager.h"
 #include "llvm/ExecutionEngine/Orc/Shared/ExecutorAddress.h"
 #include "llvm/Support/Compiler.h"
 
@@ -53,15 +54,6 @@ LLVM_ABI void lookupAndRecordAddrs(
 /// Blocking version.
 LLVM_ABI Error lookupAndRecordAddrs(
     ExecutionSession &ES, LookupKind K, const JITDylibSearchOrder &SearchOrder,
-    std::vector<std::pair<SymbolStringPtr, ExecutorAddr *>> Pairs,
-    SymbolLookupFlags LookupFlags = SymbolLookupFlags::RequiredSymbol);
-
-/// Record addresses of given symbols in the given ExecutorAddrs.
-///
-/// ExecutorProcessControl lookup version. Lookups are always implicitly
-/// weak.
-LLVM_ABI Error lookupAndRecordAddrs(
-    ExecutorProcessControl &EPC, tpctypes::DylibHandle H,
     std::vector<std::pair<SymbolStringPtr, ExecutorAddr *>> Pairs,
     SymbolLookupFlags LookupFlags = SymbolLookupFlags::RequiredSymbol);
 

--- a/llvm/include/llvm/ExecutionEngine/Orc/SelfExecutorProcessControl.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/SelfExecutorProcessControl.h
@@ -50,6 +50,8 @@ public:
                         IncomingWFRHandler OnComplete,
                         ArrayRef<char> ArgBuffer) override;
 
+  Expected<std::unique_ptr<DylibManager>> createDefaultDylibMgr() override;
+
   Error disconnect() override;
 
 private:
@@ -74,7 +76,6 @@ private:
   std::unique_ptr<UnwindInfoManager> UnwindInfoMgr;
 #endif // __APPLE__
   InProcessMemoryAccess IPMA;
-  InProcessDylibManager IPDM;
 };
 
 } // namespace llvm::orc

--- a/llvm/include/llvm/ExecutionEngine/Orc/SimpleRemoteEPC.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/SimpleRemoteEPC.h
@@ -15,7 +15,6 @@
 
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/FunctionExtras.h"
-#include "llvm/ExecutionEngine/Orc/EPCGenericDylibManager.h"
 #include "llvm/ExecutionEngine/Orc/EPCGenericJITLinkMemoryManager.h"
 #include "llvm/ExecutionEngine/Orc/EPCGenericMemoryAccess.h"
 #include "llvm/ExecutionEngine/Orc/ExecutorProcessControl.h"
@@ -81,6 +80,8 @@ public:
                         IncomingWFRHandler OnComplete,
                         ArrayRef<char> ArgBuffer) override;
 
+  Expected<std::unique_ptr<DylibManager>> createDefaultDylibMgr() override;
+
   Error disconnect() override;
 
   Expected<HandleMessageAction>
@@ -127,7 +128,6 @@ private:
   std::unique_ptr<jitlink::JITLinkMemoryManager> OwnedMemMgr;
   std::unique_ptr<MemoryAccess> OwnedMemAccess;
 
-  std::unique_ptr<EPCGenericDylibManager> EPCDylibMgr;
   ExecutorAddr RunAsMainAddr;
   ExecutorAddr RunAsVoidFunctionAddr;
   ExecutorAddr RunAsIntFunctionAddr;

--- a/llvm/lib/ExecutionEngine/Orc/EPCDynamicLibrarySearchGenerator.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/EPCDynamicLibrarySearchGenerator.cpp
@@ -19,15 +19,14 @@ namespace orc {
 
 Expected<std::unique_ptr<EPCDynamicLibrarySearchGenerator>>
 EPCDynamicLibrarySearchGenerator::Load(
-    ExecutionSession &ES, const char *LibraryPath, SymbolPredicate Allow,
-    AddAbsoluteSymbolsFn AddAbsoluteSymbols) {
-  auto Handle =
-      ES.getExecutorProcessControl().getDylibMgr().loadDylib(LibraryPath);
+    ExecutionSession &ES, DylibManager &DylibMgr, const char *LibraryPath,
+    SymbolPredicate Allow, AddAbsoluteSymbolsFn AddAbsoluteSymbols) {
+  auto Handle = DylibMgr.loadDylib(LibraryPath);
   if (!Handle)
     return Handle.takeError();
 
   return std::make_unique<EPCDynamicLibrarySearchGenerator>(
-      ES, *Handle, std::move(Allow), std::move(AddAbsoluteSymbols));
+      ES, DylibMgr, *Handle, std::move(Allow), std::move(AddAbsoluteSymbols));
 }
 
 Error EPCDynamicLibrarySearchGenerator::tryToGenerate(
@@ -65,9 +64,8 @@ Error EPCDynamicLibrarySearchGenerator::tryToGenerate(
 
   DylibManager::LookupRequest Request(*H, LookupSymbols);
   // Copy-capture LookupSymbols, since LookupRequest keeps a reference.
-  EPC.getDylibMgr().lookupSymbolsAsync(Request, [this, &JD, LS = std::move(LS),
-                                                 LookupSymbols](
-                                                    auto Result) mutable {
+  DylibMgr.lookupSymbolsAsync(Request, [this, &JD, LS = std::move(LS),
+                                        LookupSymbols](auto Result) mutable {
     if (!Result) {
       LLVM_DEBUG({
         dbgs() << "EPCDynamicLibrarySearchGenerator lookup failed due to error";
@@ -102,7 +100,7 @@ Error EPCDynamicLibrarySearchGenerator::tryToGenerate(
 
     if (LLVM_UNLIKELY(!MissingSymbols.empty()))
       return LS.continueLookup(make_error<SymbolsNotFound>(
-          this->EPC.getSymbolStringPool(), std::move(MissingSymbols)));
+          this->ES.getSymbolStringPool(), std::move(MissingSymbols)));
 
     // Define resolved symbols.
     Error Err = addAbsolutes(JD, std::move(NewSymbols));

--- a/llvm/lib/ExecutionEngine/Orc/ExecutorResolutionGenerator.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/ExecutorResolutionGenerator.cpp
@@ -18,14 +18,15 @@ namespace llvm {
 namespace orc {
 
 Expected<std::unique_ptr<ExecutorResolutionGenerator>>
-ExecutorResolutionGenerator::Load(ExecutionSession &ES, const char *LibraryPath,
+ExecutorResolutionGenerator::Load(ExecutionSession &ES, DylibManager &DylibMgr,
+                                  const char *LibraryPath,
                                   SymbolPredicate Allow,
                                   AbsoluteSymbolsFn AbsoluteSymbols) {
-  auto H = ES.getExecutorProcessControl().getDylibMgr().loadDylib(LibraryPath);
+  auto H = DylibMgr.loadDylib(LibraryPath);
   if (H)
     return H.takeError();
   return std::make_unique<ExecutorResolutionGenerator>(
-      ES, *H, std::move(Allow), std::move(AbsoluteSymbols));
+      ES, DylibMgr, *H, std::move(Allow), std::move(AbsoluteSymbols));
 }
 
 Error ExecutorResolutionGenerator::tryToGenerate(
@@ -48,7 +49,7 @@ Error ExecutorResolutionGenerator::tryToGenerate(
   }
 
   DylibManager::LookupRequest LR(H, LookupSymbols);
-  EPC.getDylibMgr().lookupSymbolsAsync(
+  DylibMgr.lookupSymbolsAsync(
       LR, [this, LS = std::move(LS), JD = JITDylibSP(&JD),
            LookupSymbols](auto Result) mutable {
         if (Result) {
@@ -86,7 +87,7 @@ Error ExecutorResolutionGenerator::tryToGenerate(
 
         if (LLVM_UNLIKELY(!MissingSymbols.empty()))
           return LS.continueLookup(make_error<SymbolsNotFound>(
-              this->EPC.getSymbolStringPool(), std::move(MissingSymbols)));
+              this->ES.getSymbolStringPool(), std::move(MissingSymbols)));
 
         LS.continueLookup(JD->define(AbsoluteSymbols(std::move(NewSyms))));
       });

--- a/llvm/lib/ExecutionEngine/Orc/LLJIT.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/LLJIT.cpp
@@ -843,7 +843,7 @@ Error LLJITBuilderState::prepareForConstruction() {
       auto &JD =
           J.getExecutionSession().createBareJITDylib("<Process Symbols>");
       auto G = EPCDynamicLibrarySearchGenerator::GetForTargetProcess(
-          J.getExecutionSession());
+          J.getExecutionSession(), J.getDylibMgr());
       if (!G)
         return G.takeError();
       JD.addGenerator(std::move(*G));
@@ -873,7 +873,7 @@ Expected<JITDylib &> LLJIT::createJITDylib(std::string Name) {
 }
 
 Expected<JITDylib &> LLJIT::loadPlatformDynamicLibrary(const char *Path) {
-  auto G = EPCDynamicLibrarySearchGenerator::Load(*ES, Path);
+  auto G = EPCDynamicLibrarySearchGenerator::Load(*ES, *DylibMgr, Path);
   if (!G)
     return G.takeError();
 
@@ -1010,6 +1010,13 @@ LLJIT::LLJIT(LLJITBuilderState &S, Error &Err)
       Err = EPC.takeError();
       return;
     }
+  }
+
+  if (auto DM = ES->getExecutorProcessControl().createDefaultDylibMgr())
+    DylibMgr = std::move(*DM);
+  else {
+    Err = DM.takeError();
+    return;
   }
 
   auto ObjLayer = createObjectLinkingLayer(S, *ES);

--- a/llvm/lib/ExecutionEngine/Orc/LookupAndRecordAddrs.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/LookupAndRecordAddrs.cpp
@@ -51,33 +51,5 @@ Error lookupAndRecordAddrs(
   return ResultF.get();
 }
 
-Error lookupAndRecordAddrs(
-    ExecutorProcessControl &EPC, tpctypes::DylibHandle H,
-    std::vector<std::pair<SymbolStringPtr, ExecutorAddr *>> Pairs,
-    SymbolLookupFlags LookupFlags) {
-
-  SymbolLookupSet Symbols;
-  for (auto &KV : Pairs)
-    Symbols.add(KV.first, LookupFlags);
-
-  DylibManager::LookupRequest LR(H, Symbols);
-  auto Result = EPC.getDylibMgr().lookupSymbols(LR);
-  if (!Result)
-    return Result.takeError();
-
-  if (Result->size() != 1)
-    return make_error<StringError>("Error in lookup result",
-                                   inconvertibleErrorCode());
-  if (Result->front().size() != Pairs.size())
-    return make_error<StringError>("Error in lookup result elements",
-                                   inconvertibleErrorCode());
-
-  for (unsigned I = 0; I != Pairs.size(); ++I) {
-    if (Result->front()[I])
-      *Pairs[I].second = Result->front()[I]->getAddress();
-  }
-  return Error::success();
-}
-
 } // End namespace orc.
 } // End namespace llvm.

--- a/llvm/lib/ExecutionEngine/Orc/SelfExecutorProcessControl.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/SelfExecutorProcessControl.cpp
@@ -24,8 +24,7 @@ SelfExecutorProcessControl::SelfExecutorProcessControl(
     Triple TargetTriple, unsigned PageSize,
     std::unique_ptr<jitlink::JITLinkMemoryManager> MemMgr)
     : ExecutorProcessControl(std::move(SSP), std::move(D)),
-      IPMA(TargetTriple.isArch64Bit()),
-      IPDM(TargetTriple.isOSBinFormatMachO() ? '_' : '\0') {
+      IPMA(TargetTriple.isArch64Bit()) {
 
   OwnedMemMgr = std::move(MemMgr);
   if (!OwnedMemMgr)
@@ -36,7 +35,6 @@ SelfExecutorProcessControl::SelfExecutorProcessControl(
   this->PageSize = PageSize;
   this->MemMgr = OwnedMemMgr.get();
   this->MemAccess = &IPMA;
-  this->DylibMgr = &IPDM;
   this->JDI = {ExecutorAddr::fromPtr(jitDispatchViaWrapperFunctionManager),
                ExecutorAddr::fromPtr(this)};
 
@@ -105,6 +103,12 @@ void SelfExecutorProcessControl::callWrapperAsync(ExecutorAddr WrapperFnAddr,
 Error SelfExecutorProcessControl::disconnect() {
   D->shutdown();
   return Error::success();
+}
+
+Expected<std::unique_ptr<DylibManager>>
+SelfExecutorProcessControl::createDefaultDylibMgr() {
+  char Prefix = TargetTriple.isOSBinFormatMachO() ? '_' : '\0';
+  return std::make_unique<InProcessDylibManager>(Prefix);
 }
 
 shared::CWrapperFunctionBuffer

--- a/llvm/lib/ExecutionEngine/Orc/SimpleRemoteEPC.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/SimpleRemoteEPC.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "llvm/ExecutionEngine/Orc/SimpleRemoteEPC.h"
+#include "llvm/ExecutionEngine/Orc/EPCGenericDylibManager.h"
 #include "llvm/ExecutionEngine/Orc/EPCGenericJITLinkMemoryManager.h"
 #include "llvm/ExecutionEngine/Orc/Shared/OrcRTBridge.h"
 #include "llvm/Support/FormatVariadic.h"
@@ -83,6 +84,14 @@ void SimpleRemoteEPC::callWrapperAsync(ExecutorAddr WrapperFnAddr,
 
     getExecutionSession().reportError(std::move(Err));
   }
+}
+
+Expected<std::unique_ptr<DylibManager>>
+SimpleRemoteEPC::createDefaultDylibMgr() {
+  auto DM = EPCGenericDylibManager::CreateWithDefaultBootstrapSymbols(*this);
+  if (!DM)
+    return DM.takeError();
+  return std::make_unique<EPCGenericDylibManager>(std::move(*DM));
 }
 
 Error SimpleRemoteEPC::disconnect() {
@@ -331,14 +340,6 @@ Error SimpleRemoteEPC::setup(Setup S) {
            {RunAsVoidFunctionAddr, rt::RunAsVoidFunctionWrapperName},
            {RunAsIntFunctionAddr, rt::RunAsIntFunctionWrapperName}}))
     return Err;
-
-  if (auto DM =
-          EPCGenericDylibManager::CreateWithDefaultBootstrapSymbols(*this))
-    EPCDylibMgr = std::make_unique<EPCGenericDylibManager>(std::move(*DM));
-  else
-    return DM.takeError();
-
-  this->DylibMgr = EPCDylibMgr.get();
 
   // Set a default CreateMemoryManager if none is specified.
   if (!S.CreateMemoryManager)

--- a/llvm/tools/llvm-jitlink/llvm-jitlink.cpp
+++ b/llvm/tools/llvm-jitlink/llvm-jitlink.cpp
@@ -891,7 +891,7 @@ static Error loadProcessSymbols(Session &S) {
       };
   S.ProcessSymsJD->addGenerator(
       ExitOnErr(orc::EPCDynamicLibrarySearchGenerator::GetForTargetProcess(
-          S.ES, std::move(FilterMainEntryPoint))));
+          S.ES, *S.DylibMgr, std::move(FilterMainEntryPoint))));
 
   return Error::success();
 }
@@ -1222,6 +1222,13 @@ Session::Session(std::unique_ptr<ExecutorProcessControl> EPC, Error &Err)
 
   ErrorAsOutParameter _(&Err);
 
+  if (auto DM = ES.getExecutorProcessControl().createDefaultDylibMgr())
+    DylibMgr = std::move(*DM);
+  else {
+    Err = DM.takeError();
+    return;
+  }
+
   ES.setErrorReporter(reportLLVMJITLinkError);
 
   // Attach WaitingOnGraph recorder if requested.
@@ -1483,7 +1490,8 @@ Expected<JITDylib *> Session::getOrLoadDynamicLibrary(StringRef LibPath) {
   if (It != DynLibJDs.end()) {
     return It->second;
   }
-  auto G = EPCDynamicLibrarySearchGenerator::Load(ES, LibPath.data());
+  auto G =
+      EPCDynamicLibrarySearchGenerator::Load(ES, *DylibMgr, LibPath.data());
   if (!G)
     return G.takeError();
   auto JD = &ES.createBareJITDylib(LibPath.str());
@@ -2245,7 +2253,8 @@ LoadLibraryWeak(Session &S, StringRef Path) {
     return Symbols.takeError();
 
   return std::make_unique<EPCDynamicLibrarySearchGenerator>(
-      S.ES, [Symbols = std::move(*Symbols)](const SymbolStringPtr &Sym) {
+      S.ES, *S.DylibMgr,
+      [Symbols = std::move(*Symbols)](const SymbolStringPtr &Sym) {
         return Symbols.count(Sym);
       });
 }
@@ -2778,12 +2787,12 @@ static Error runChecks(Session &S, Triple TT, SubtargetFeatures Features) {
   LLVM_DEBUG(dbgs() << "Running checks...\n");
 
   auto IsSymbolValid = [&S](StringRef Symbol) {
-    auto InternedSymbol = S.ES.getSymbolStringPool()->intern(Symbol);
+    auto InternedSymbol = S.ES.intern(Symbol);
     return S.isSymbolRegistered(InternedSymbol);
   };
 
   auto GetSymbolInfo = [&S](StringRef Symbol) {
-    auto InternedSymbol = S.ES.getSymbolStringPool()->intern(Symbol);
+    auto InternedSymbol = S.ES.intern(Symbol);
     return S.findSymbolInfo(InternedSymbol, "Can not get symbol info");
   };
 

--- a/llvm/tools/llvm-jitlink/llvm-jitlink.h
+++ b/llvm/tools/llvm-jitlink/llvm-jitlink.h
@@ -16,6 +16,7 @@
 #include "llvm/ADT/StringSet.h"
 #include "llvm/ExecutionEngine/Orc/COFF.h"
 #include "llvm/ExecutionEngine/Orc/Core.h"
+#include "llvm/ExecutionEngine/Orc/DylibManager.h"
 #include "llvm/ExecutionEngine/Orc/ExecutorProcessControl.h"
 #include "llvm/ExecutionEngine/Orc/LazyObjectLinkingLayer.h"
 #include "llvm/ExecutionEngine/Orc/LazyReexports.h"
@@ -74,6 +75,7 @@ struct Session {
   };
 
   orc::ExecutionSession ES;
+  std::unique_ptr<orc::DylibManager> DylibMgr;
   orc::JITDylib *MainJD = nullptr;
   orc::JITDylib *ProcessSymsJD = nullptr;
   orc::JITDylib *PlatformJD = nullptr;

--- a/llvm/unittests/ExecutionEngine/Orc/ObjectLinkingLayerTest.cpp
+++ b/llvm/unittests/ExecutionEngine/Orc/ObjectLinkingLayerTest.cpp
@@ -291,9 +291,7 @@ TEST(ObjectLinkingLayerSearchGeneratorTest, AbsoluteSymbolsObjectLayer) {
   public:
     TestEPC()
         : UnsupportedExecutorProcessControl(nullptr, nullptr,
-                                            "x86_64-apple-darwin") {
-      this->DylibMgr = this;
-    }
+                                            "x86_64-apple-darwin") {}
 
     Expected<tpctypes::DylibHandle> loadDylib(const char *DylibPath) override {
       return ExecutorAddr::fromPtr((void *)nullptr);
@@ -317,15 +315,21 @@ TEST(ObjectLinkingLayerSearchGeneratorTest, AbsoluteSymbolsObjectLayer) {
       }
       Complete(std::vector<tpctypes::LookupResult>{1, Result});
     }
+
+    Expected<std::unique_ptr<DylibManager>> createDefaultDylibMgr() override {
+      llvm_unreachable("Unsupported");
+    }
   };
 
-  ExecutionSession ES{std::make_unique<TestEPC>()};
+  auto TestEPCPtr = std::make_unique<TestEPC>();
+  auto &TestDylibMgr = static_cast<DylibManager &>(*TestEPCPtr);
+  ExecutionSession ES{std::move(TestEPCPtr)};
   JITDylib &JD = ES.createBareJITDylib("main");
   ObjectLinkingLayer ObjLinkingLayer{
       ES, std::make_unique<InProcessMemoryManager>(4096)};
 
   auto G = EPCDynamicLibrarySearchGenerator::GetForTargetProcess(
-      ES, {}, [&](JITDylib &JD, SymbolMap Syms) {
+      ES, TestDylibMgr, {}, [&](JITDylib &JD, SymbolMap Syms) {
         auto G =
             absoluteSymbolsLinkGraph(Triple("x86_64-apple-darwin"),
                                      ES.getSymbolStringPool(), std::move(Syms));

--- a/llvm/unittests/ExecutionEngine/Orc/OrcTestCommon.h
+++ b/llvm/unittests/ExecutionEngine/Orc/OrcTestCommon.h
@@ -121,6 +121,10 @@ public:
     llvm_unreachable("Unsupported");
   }
 
+  Expected<std::unique_ptr<DylibManager>> createDefaultDylibMgr() override {
+    llvm_unreachable("Unsupported");
+  }
+
   Error disconnect() override { return Error::success(); }
 };
 


### PR DESCRIPTION
This removes an unnecessary coupling between ExecutorProcessControl and DylibManager, allowing clients to select DylibManager implementations independently.

To simplify the transition, the ExecutorProcessControl::createDefaultJITDylib method will return an instance of whatever DylibManager the ExecutorProcessControl implementation had been using previously.