### PR TITLE
[lit] Explicitly unset timer to free thread stack

### DIFF
--- a/llvm/utils/lit/lit/TestRunner.py
+++ b/llvm/utils/lit/lit/TestRunner.py
@@ -126,6 +126,8 @@ class TimeoutHelper(object):
         if not self.active():
             return
         self._timer.cancel()
+        # Break reference cycle so that thread stack is freed immediately.
+        self._timer = None
 
     def active(self):
         return self.timeout > 0


### PR DESCRIPTION
Currently the virtual address space usage of lit fluctuates wildly, with peak usage exceeding 4GB, which results in subsequent thread spawning errors on 32-bit systems.

The cause of this is a circular reference in threading._timer (via the callback), which causes the 8MB thread stack to not be immediately reclaimed when the timer is cancelled.

We can avoid this by explicitly unsetting the timer.