### PR TITLE
[LLVM][Support] add nonNull function helper

### DIFF
--- a/llvm/docs/ProgrammersManual.rst
+++ b/llvm/docs/ProgrammersManual.rst
@@ -453,14 +453,14 @@ violations even in builds that do not enable assertions:
     reportFatalInternalError("Analysis 'foo' not preserved");
   }
 
-Additionally, ``nonNull`` can be used to check/document that a pointer
+Additionally, ``checkNotNull`` can be used to check/document that a pointer
 is never supposed to be null inline.
 
 .. code-block:: c++
 
     setMyPointer("key", Pointer);
     // [...]
-    Type *P = nonNull(getMyPointer("key"));
+    Type *P = checkNotNull(getMyPointer("key"));
 
 Recoverable Errors
 ^^^^^^^^^^^^^^^^^^

--- a/llvm/docs/ProgrammersManual.rst
+++ b/llvm/docs/ProgrammersManual.rst
@@ -457,6 +457,7 @@ Additionally, ``nonNull`` can be used to check/document that a pointer
 is never supposed to be null inline.
 
 .. code-block:: c++
+
     setMyPointer("key", Pointer);
     // [...]
     Type *P = nonNull(getMyPointer("key"));

--- a/llvm/docs/ProgrammersManual.rst
+++ b/llvm/docs/ProgrammersManual.rst
@@ -453,6 +453,14 @@ violations even in builds that do not enable assertions:
     reportFatalInternalError("Analysis 'foo' not preserved");
   }
 
+Additionally, ``nonNull`` can be used to check/document that a pointer
+is never supposed to be null inline.
+
+.. code-block:: c++
+    setMyPointer("key", Pointer);
+    // [...]
+    Type *P = nonNull(getMyPointer("key"));
+
 Recoverable Errors
 ^^^^^^^^^^^^^^^^^^
 

--- a/llvm/include/llvm/Support/Error.h
+++ b/llvm/include/llvm/Support/Error.h
@@ -813,14 +813,15 @@ T cantFail(Expected<T> ValOrErr, const char *Msg = nullptr) {
 
 /// Calls llvm_unreachable if Pointer is null, otherwise returns the
 /// pointer as is.
-template <typename T>
-LLVM_ATTRIBUTE_RETURNS_NONNULL T *checkNotNull(T *Pointer,
-                                               const char *Msg = nullptr) {
-  if (Pointer)
+template <typename T, typename = std::enable_if_t<
+                          std::is_pointer_v<T> ||
+                          std::is_constructible_v<T, std::nullptr_t>>>
+[[nodiscard]] T checkNotNull(
+    T Pointer,
+    const char *Msg = "Expected a non-null pointer but got a null pointer") {
+  assert(Msg);
+  if (Pointer != nullptr)
     return Pointer;
-
-  if (!Msg)
-    Msg = "Expected a non-null pointer but got a null pointer";
   llvm_unreachable(Msg);
 }
 

--- a/llvm/include/llvm/Support/Error.h
+++ b/llvm/include/llvm/Support/Error.h
@@ -814,8 +814,8 @@ T cantFail(Expected<T> ValOrErr, const char *Msg = nullptr) {
 /// Calls llvm_unreachable if Pointer is null, otherwise returns the
 /// pointer as is.
 template <typename T>
-LLVM_ATTRIBUTE_RETURNS_NONNULL T *nonNull(T *Pointer,
-                                          const char *Msg = nullptr) {
+LLVM_ATTRIBUTE_RETURNS_NONNULL T *checkNotNull(T *Pointer,
+                                               const char *Msg = nullptr) {
   if (Pointer)
     return Pointer;
 

--- a/llvm/include/llvm/Support/Error.h
+++ b/llvm/include/llvm/Support/Error.h
@@ -813,15 +813,14 @@ T cantFail(Expected<T> ValOrErr, const char *Msg = nullptr) {
 
 /// Calls llvm_unreachable if Pointer is null, otherwise returns the
 /// pointer as is.
-template <typename T, typename = std::enable_if_t<
-                          std::is_pointer_v<T> ||
-                          std::is_constructible_v<T, std::nullptr_t>>>
-[[nodiscard]] T checkNotNull(
-    T Pointer,
+template <typename T, typename = std::enable_if_t<std::is_convertible_v<
+                          decltype(std::declval<T>() != nullptr), bool>>>
+[[nodiscard]] T &&checkNotNull(
+    T &&Pointer,
     const char *Msg = "Expected a non-null pointer but got a null pointer") {
   assert(Msg);
   if (Pointer != nullptr)
-    return Pointer;
+    return std::forward<T>(Pointer);
   llvm_unreachable(Msg);
 }
 

--- a/llvm/include/llvm/Support/Error.h
+++ b/llvm/include/llvm/Support/Error.h
@@ -815,7 +815,7 @@ T cantFail(Expected<T> ValOrErr, const char *Msg = nullptr) {
 /// pointer as is.
 template <typename T, typename = std::enable_if_t<std::is_convertible_v<
                           decltype(std::declval<T>() != nullptr), bool>>>
-[[nodiscard]] T &&checkNotNull(
+[[nodiscard]] decltype(auto) checkNotNull(
     T &&Pointer,
     const char *Msg = "Expected a non-null pointer but got a null pointer") {
   assert(Msg);

--- a/llvm/include/llvm/Support/Error.h
+++ b/llvm/include/llvm/Support/Error.h
@@ -811,10 +811,16 @@ T cantFail(Expected<T> ValOrErr, const char *Msg = nullptr) {
   }
 }
 
+template <typename T>
+using compare_nullptr_t = decltype(std::declval<T &>() == nullptr);
+
+template <typename T>
+using is_nullptr_comparable = llvm::is_detected<compare_nullptr_t, T>;
+
 /// Calls llvm_unreachable if Pointer is null, otherwise returns the
 /// pointer as is.
-template <typename T, typename = std::enable_if_t<std::is_convertible_v<
-                          decltype(std::declval<T>() != nullptr), bool>>>
+template <typename T,
+          typename = std::enable_if_t<is_nullptr_comparable<T>::value>>
 [[nodiscard]] decltype(auto) checkNotNull(
     T &&Pointer,
     const char *Msg = "Expected a non-null pointer but got a null pointer") {

--- a/llvm/include/llvm/Support/Error.h
+++ b/llvm/include/llvm/Support/Error.h
@@ -811,16 +811,20 @@ T cantFail(Expected<T> ValOrErr, const char *Msg = nullptr) {
   }
 }
 
+namespace detail {
+
 template <typename T>
 using compare_nullptr_t = decltype(std::declval<T &>() == nullptr);
 
 template <typename T>
 using is_nullptr_comparable = llvm::is_detected<compare_nullptr_t, T>;
 
+} // namespace detail
+
 /// Calls llvm_unreachable if Pointer is null, otherwise returns the
 /// pointer as is.
 template <typename T,
-          typename = std::enable_if_t<is_nullptr_comparable<T>::value>>
+          typename = std::enable_if_t<detail::is_nullptr_comparable<T>::value>>
 [[nodiscard]] decltype(auto) checkNotNull(
     T &&Pointer,
     const char *Msg = "Expected a non-null pointer but got a null pointer") {

--- a/llvm/include/llvm/Support/Error.h
+++ b/llvm/include/llvm/Support/Error.h
@@ -811,6 +811,18 @@ T cantFail(Expected<T> ValOrErr, const char *Msg = nullptr) {
   }
 }
 
+/// Calls llvm_unreachable if Pointer is null, otherwise returns the
+/// pointer as is.
+template<typename T>
+LLVM_ATTRIBUTE_RETURNS_NONNULL T* nonNull(T* Pointer, const char *Msg = nullptr) {
+  if (Pointer)
+    return Pointer;
+
+  if (!Msg)
+    Msg = "Expected a non-null pointer but got a null pointer";
+  llvm_unreachable(Msg);
+}
+
 /// Report a fatal error if ValOrErr is a failure value, otherwise unwraps and
 /// returns the contained reference.
 ///

--- a/llvm/include/llvm/Support/Error.h
+++ b/llvm/include/llvm/Support/Error.h
@@ -813,8 +813,9 @@ T cantFail(Expected<T> ValOrErr, const char *Msg = nullptr) {
 
 /// Calls llvm_unreachable if Pointer is null, otherwise returns the
 /// pointer as is.
-template<typename T>
-LLVM_ATTRIBUTE_RETURNS_NONNULL T* nonNull(T* Pointer, const char *Msg = nullptr) {
+template <typename T>
+LLVM_ATTRIBUTE_RETURNS_NONNULL T *nonNull(T *Pointer,
+                                          const char *Msg = nullptr) {
   if (Pointer)
     return Pointer;
 

--- a/llvm/unittests/Support/ErrorTest.cpp
+++ b/llvm/unittests/Support/ErrorTest.cpp
@@ -1226,21 +1226,21 @@ TEST(Error, NonNullSuccess) {
   const int *cptr = ptr;
   const int *const ccptr = ptr;
 
-  EXPECT_EQ(ptr, nonNull(&tmp));
-  EXPECT_EQ(ptr, nonNull(ptr));
-  EXPECT_EQ(ptr, nonNull(cptr));
-  EXPECT_EQ(ptr, nonNull(ccptr));
+  EXPECT_EQ(ptr, checkNotNull(&tmp));
+  EXPECT_EQ(ptr, checkNotNull(ptr));
+  EXPECT_EQ(ptr, checkNotNull(cptr));
+  EXPECT_EQ(ptr, checkNotNull(ccptr));
 }
 
 #if !defined(NDEBUG) && GTEST_HAS_DEATH_TEST
 TEST(Error, NonNullFails) {
   int *NullPtr = nullptr;
-  EXPECT_DEATH(nonNull(NullPtr),
+  EXPECT_DEATH(checkNotNull(NullPtr),
                "Expected a non-null pointer but got a null pointer")
-      << "nonNull(NullPtr) did not cause an abort for null pointer";
+      << "checkNotNull(NullPtr) did not cause an abort for null pointer";
 
-  EXPECT_DEATH(nonNull(NullPtr, "custom message"), "custom message")
-      << "nonNull(nullptr) did not cause an abort for null pointer";
+  EXPECT_DEATH(checkNotNull(NullPtr, "custom message"), "custom message")
+      << "checkNotNull(nullptr) did not cause an abort for null pointer";
 }
 #endif
 

--- a/llvm/unittests/Support/ErrorTest.cpp
+++ b/llvm/unittests/Support/ErrorTest.cpp
@@ -1225,11 +1225,13 @@ TEST(Error, NonNullSuccess) {
   int *ptr = &tmp;
   const int *cptr = ptr;
   const int *const ccptr = ptr;
+  auto uptr = std::make_unique<int>(0);
 
   EXPECT_EQ(ptr, checkNotNull(&tmp));
   EXPECT_EQ(ptr, checkNotNull(ptr));
   EXPECT_EQ(ptr, checkNotNull(cptr));
   EXPECT_EQ(ptr, checkNotNull(ccptr));
+  EXPECT_EQ(uptr, checkNotNull(std::move(uptr)));
 }
 
 #if !defined(NDEBUG) && GTEST_HAS_DEATH_TEST
@@ -1240,6 +1242,12 @@ TEST(Error, NonNullFails) {
       << "checkNotNull(NullPtr) did not cause an abort for null pointer";
 
   EXPECT_DEATH(NullPtr = checkNotNull(nullptr),
+               "Expected a non-null pointer but got a null pointer")
+      << "checkNotNull(NullPtr) did not cause an abort for null pointer";
+
+  auto UniquePtr = std::make_unique<int>(0);
+  UniquePtr.release();
+  EXPECT_DEATH(auto TmpUniquePtr = checkNotNull(std::move(UniquePtr)),
                "Expected a non-null pointer but got a null pointer")
       << "checkNotNull(NullPtr) did not cause an abort for null pointer";
 

--- a/llvm/unittests/Support/ErrorTest.cpp
+++ b/llvm/unittests/Support/ErrorTest.cpp
@@ -1235,7 +1235,8 @@ TEST(Error, NonNullSuccess) {
 #if LLVM_ENABLE_ABI_BREAKING_CHECKS && !defined(NDEBUG)
 TEST(Error, NonNullFails) {
   int *NullPtr = nullptr;
-  EXPECT_DEATH(nonNull(NullPtr), "Expected a non-null pointer but got a null pointer")
+  EXPECT_DEATH(nonNull(NullPtr),
+               "Expected a non-null pointer but got a null pointer")
       << "nonNull(NullPtr) did not cause an abort for null pointer";
 
   EXPECT_DEATH(nonNull(NullPtr, "custom message"), "custom message")

--- a/llvm/unittests/Support/ErrorTest.cpp
+++ b/llvm/unittests/Support/ErrorTest.cpp
@@ -1232,7 +1232,7 @@ TEST(Error, NonNullSuccess) {
   EXPECT_EQ(ptr, nonNull(ccptr));
 }
 
-#if LLVM_ENABLE_ABI_BREAKING_CHECKS && !defined(NDEBUG)
+#if !defined(NDEBUG) && GTEST_HAS_DEATH_TEST
 TEST(Error, NonNullFails) {
   int *NullPtr = nullptr;
   EXPECT_DEATH(nonNull(NullPtr),

--- a/llvm/unittests/Support/ErrorTest.cpp
+++ b/llvm/unittests/Support/ErrorTest.cpp
@@ -1219,4 +1219,28 @@ TEST(Error, ForwardToExpected) {
   EXPECT_THAT_ERROR(ExpectedReturningFct(false).moveInto(MaybeV), Succeeded());
   EXPECT_EQ(*MaybeV, 42);
 }
+
+TEST(Error, NonNullSuccess) {
+  int tmp = 0;
+  int *ptr = &tmp;
+  const int *cptr = ptr;
+  const int *const ccptr = ptr;
+
+  EXPECT_EQ(ptr, nonNull(&tmp));
+  EXPECT_EQ(ptr, nonNull(ptr));
+  EXPECT_EQ(ptr, nonNull(cptr));
+  EXPECT_EQ(ptr, nonNull(ccptr));
+}
+
+#if LLVM_ENABLE_ABI_BREAKING_CHECKS && !defined(NDEBUG)
+TEST(Error, NonNullFails) {
+  int *NullPtr = nullptr;
+  EXPECT_DEATH(nonNull(NullPtr), "Expected a non-null pointer but got a null pointer")
+      << "nonNull(NullPtr) did not cause an abort for null pointer";
+
+  EXPECT_DEATH(nonNull(NullPtr, "custom message"), "custom message")
+      << "nonNull(nullptr) did not cause an abort for null pointer";
+}
+#endif
+
 } // namespace

--- a/llvm/unittests/Support/ErrorTest.cpp
+++ b/llvm/unittests/Support/ErrorTest.cpp
@@ -1235,11 +1235,16 @@ TEST(Error, NonNullSuccess) {
 #if !defined(NDEBUG) && GTEST_HAS_DEATH_TEST
 TEST(Error, NonNullFails) {
   int *NullPtr = nullptr;
-  EXPECT_DEATH(checkNotNull(NullPtr),
+  EXPECT_DEATH(NullPtr = checkNotNull(NullPtr),
                "Expected a non-null pointer but got a null pointer")
       << "checkNotNull(NullPtr) did not cause an abort for null pointer";
 
-  EXPECT_DEATH(checkNotNull(NullPtr, "custom message"), "custom message")
+  EXPECT_DEATH(NullPtr = checkNotNull(nullptr),
+               "Expected a non-null pointer but got a null pointer")
+      << "checkNotNull(NullPtr) did not cause an abort for null pointer";
+
+  EXPECT_DEATH(NullPtr = checkNotNull(NullPtr, "custom message"),
+               "custom message")
       << "checkNotNull(nullptr) did not cause an abort for null pointer";
 }
 #endif


### PR DESCRIPTION
We often see a pattern like:
```
T *ptr = doSomething()
assert(ptr && "doSomething() shouldn't return nullptr");
```

We also have functions like `cantFail`, but those are working with Expected types.
This commits adds a `nonNull` function, which can be used inline. In practice, one could use:

```
T *ptr = cast<T>(functionReturningT());
```

But it conveys the meaning that `functionReturningT` might return a subtype/supertype that we actually cast.

Function behaves like the other error kinds: calls llvm_unreachable, which may or may not trap depending on the build options. Calling this function with `nullptr` won't build, but it makes no sense to do so.