### PR TITLE
[lldb] Add setting to specify (by name) which module's scripting resources can be auto-loaded

### DIFF
--- a/lldb/include/lldb/Target/Platform.h
+++ b/lldb/include/lldb/Target/Platform.h
@@ -1091,6 +1091,13 @@ protected:
       const ScriptInterpreter::SanitizedScriptingModuleName &sanitized_name,
       const FileSpec &original_fspec, const FileSpec &fspec);
 
+  /// Returns the \c LoadScriptFromSymFile of scripting resource associated
+  /// with the specified module \c FileSpec. If the load style wasn't explicitly
+  /// set for a module, returns the target-wide default.
+  static LoadScriptFromSymFile
+  GetScriptLoadStyleForModule(const FileSpec &module_fspec,
+                              const Target &target);
+
 private:
   typedef std::function<Status(const ModuleSpec &)> ModuleResolver;
 

--- a/lldb/include/lldb/Target/Target.h
+++ b/lldb/include/lldb/Target/Target.h
@@ -239,6 +239,9 @@ public:
 
   LoadScriptFromSymFile GetLoadScriptFromSymbolFile() const;
 
+  /// Set the target-wide target.load-script-from-symbol-file setting.
+  /// See \c SetAutoLoadScriptsForModule for overriding this setting
+  /// per-module.
   void SetLoadScriptFromSymbolFile(LoadScriptFromSymFile load_style);
 
   LoadCWDlldbinitFile GetLoadCWDlldbinitFile() const;
@@ -284,6 +287,10 @@ public:
   std::optional<LoadScriptFromSymFile>
   GetAutoLoadScriptsForModule(llvm::StringRef module_name) const;
 
+  /// Set the \c LoadScriptFromSymFile for a module called \c module_name
+  /// (excluding file extension). LLDB will prefer this over the target-wide
+  /// target.load-script-from-symbol-file setting
+  /// (see \c SetLoadScriptFromSymbolFile).
   void SetAutoLoadScriptsForModule(llvm::StringRef module_name,
                                    LoadScriptFromSymFile load_style);
 

--- a/lldb/include/lldb/Target/Target.h
+++ b/lldb/include/lldb/Target/Target.h
@@ -279,6 +279,11 @@ public:
 
   bool GetDebugUtilityExpression() const;
 
+  OptionValueDictionary *GetAutoLoadScriptsForModules() const;
+
+  void SetAutoLoadScriptsForModules(llvm::StringRef module_name,
+                                    bool should_load);
+
 private:
   std::optional<bool>
   GetExperimentalPropertyValue(size_t prop_idx,

--- a/lldb/include/lldb/Target/Target.h
+++ b/lldb/include/lldb/Target/Target.h
@@ -239,6 +239,8 @@ public:
 
   LoadScriptFromSymFile GetLoadScriptFromSymbolFile() const;
 
+  void SetLoadScriptFromSymbolFile(LoadScriptFromSymFile load_style);
+
   LoadCWDlldbinitFile GetLoadCWDlldbinitFile() const;
 
   Disassembler::HexImmediateStyle GetHexImmediateStyle() const;
@@ -279,10 +281,11 @@ public:
 
   bool GetDebugUtilityExpression() const;
 
-  OptionValueDictionary *GetAutoLoadScriptsForModules() const;
+  std::optional<LoadScriptFromSymFile>
+  GetAutoLoadScriptsForModule(llvm::StringRef module_name) const;
 
-  void SetAutoLoadScriptsForModules(llvm::StringRef module_name,
-                                    bool should_load);
+  void SetAutoLoadScriptsForModule(llvm::StringRef module_name,
+                                   LoadScriptFromSymFile load_style);
 
 private:
   std::optional<bool>

--- a/lldb/source/Plugins/Platform/MacOSX/PlatformDarwin.cpp
+++ b/lldb/source/Plugins/Platform/MacOSX/PlatformDarwin.cpp
@@ -236,8 +236,9 @@ PlatformDarwin::LocateExecutableScriptingResourcesFromDSYM(
                                          orig_script_fspec, script_fspec);
 
     if (FileSystem::Instance().Exists(script_fspec)) {
-      file_specs.try_emplace(std::move(script_fspec),
-                             target.GetLoadScriptFromSymbolFile());
+      LoadScriptFromSymFile load_style =
+          Platform::GetScriptLoadStyleForModule(script_fspec, target);
+      file_specs.try_emplace(std::move(script_fspec), load_style);
       break;
     }
 

--- a/lldb/source/Target/Platform.cpp
+++ b/lldb/source/Target/Platform.cpp
@@ -167,17 +167,9 @@ Platform::GetScriptLoadStyleForModule(const FileSpec &module_fspec,
   LoadScriptFromSymFile default_load_style =
       target.GetLoadScriptFromSymbolFile();
 
-  OptionValueDictionary *names = target.GetAutoLoadScriptsForModules();
-  if (!names)
-    return default_load_style;
-
-  OptionValueSP value_sp =
-      names->GetValueForKey(module_fspec.GetFileNameStrippingExtension());
-  if (!value_sp)
-    return default_load_style;
-
-  return value_sp->GetValueAs<LoadScriptFromSymFile>().value_or(
-      default_load_style);
+  return target
+      .GetAutoLoadScriptsForModule(module_fspec.GetFileNameStrippingExtension())
+      .value_or(default_load_style);
 }
 
 llvm::SmallDenseMap<FileSpec, LoadScriptFromSymFile>

--- a/lldb/source/Target/Platform.cpp
+++ b/lldb/source/Target/Platform.cpp
@@ -24,6 +24,7 @@
 #include "lldb/Host/Host.h"
 #include "lldb/Host/HostInfo.h"
 #include "lldb/Host/OptionParser.h"
+#include "lldb/Interpreter/OptionValueDictionary.h"
 #include "lldb/Interpreter/OptionValueFileSpec.h"
 #include "lldb/Interpreter/OptionValueProperties.h"
 #include "lldb/Interpreter/Property.h"
@@ -40,6 +41,7 @@
 #include "lldb/Utility/Log.h"
 #include "lldb/Utility/Status.h"
 #include "lldb/Utility/StructuredData.h"
+#include "lldb/lldb-private-enumerations.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/FormatVariadic.h"
@@ -159,6 +161,25 @@ Status Platform::GetFileWithUUID(const FileSpec &platform_file,
 
 bool Platform::IsSymbolFileTrusted(Module &module) { return false; }
 
+LoadScriptFromSymFile
+Platform::GetScriptLoadStyleForModule(const FileSpec &module_fspec,
+                                      const Target &target) {
+  LoadScriptFromSymFile default_load_style =
+      target.GetLoadScriptFromSymbolFile();
+
+  OptionValueDictionary *names = target.GetAutoLoadScriptsForModules();
+  if (!names)
+    return default_load_style;
+
+  OptionValueSP value_sp =
+      names->GetValueForKey(module_fspec.GetFileNameStrippingExtension());
+  if (!value_sp)
+    return default_load_style;
+
+  return value_sp->GetValueAs<LoadScriptFromSymFile>().value_or(
+      default_load_style);
+}
+
 llvm::SmallDenseMap<FileSpec, LoadScriptFromSymFile>
 Platform::LocateExecutableScriptingResourcesFromSafePaths(
     Stream &feedback_stream, FileSpec module_spec, const Target &target) {
@@ -200,9 +221,11 @@ Platform::LocateExecutableScriptingResourcesFromSafePaths(
     WarnIfInvalidUnsanitizedScriptExists(feedback_stream, sanitized_name,
                                          orig_script_fspec, script_fspec);
 
-    if (FileSystem::Instance().Exists(script_fspec))
-      file_specs.try_emplace(std::move(script_fspec),
-                             target.GetLoadScriptFromSymbolFile());
+    if (FileSystem::Instance().Exists(script_fspec)) {
+      LoadScriptFromSymFile load_style =
+          Platform::GetScriptLoadStyleForModule(script_fspec, target);
+      file_specs.try_emplace(std::move(script_fspec), load_style);
+    }
 
     // If we successfully found a directory in a safe auto-load path
     // stop looking at any other paths.

--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -5305,7 +5305,8 @@ void TargetProperties::SetAutoLoadScriptsForModule(
     return;
 
   dict->SetValueForKey(module_name,
-                       std::make_shared<OptionValueEnumeration>(g_load_script_from_sym_file_values, load_style));
+                       std::make_shared<OptionValueEnumeration>(
+                           g_load_script_from_sym_file_values, load_style));
 }
 
 // Target::TargetEventData

--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -5275,6 +5275,20 @@ void TargetProperties::SetDebugUtilityExpression(bool debug) {
   SetPropertyAtIndex(idx, debug);
 }
 
+OptionValueDictionary *TargetProperties::GetAutoLoadScriptsForModules() const {
+  return m_collection_sp->GetPropertyAtIndexAsOptionValueDictionary(
+      ePropertyAutoLoadScriptsForModules);
+}
+
+void TargetProperties::SetAutoLoadScriptsForModules(llvm::StringRef module_name,
+                                                    bool should_load) {
+  OptionValueDictionary *dict = GetAutoLoadScriptsForModules();
+  if (!dict)
+    return;
+  dict->SetValueForKey(module_name,
+                       std::make_shared<OptionValueBoolean>(should_load));
+}
+
 // Target::TargetEventData
 
 Target::TargetEventData::TargetEventData(const lldb::TargetSP &target_sp)

--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -40,6 +40,7 @@
 #include "lldb/Interpreter/Interfaces/ScriptedBreakpointInterface.h"
 #include "lldb/Interpreter/Interfaces/ScriptedStopHookInterface.h"
 #include "lldb/Interpreter/OptionGroupWatchpoint.h"
+#include "lldb/Interpreter/OptionValueEnumeration.h"
 #include "lldb/Interpreter/OptionValues.h"
 #include "lldb/Interpreter/Property.h"
 #include "lldb/Symbol/Function.h"
@@ -5105,6 +5106,12 @@ LoadScriptFromSymFile TargetProperties::GetLoadScriptFromSymbolFile() const {
                g_target_properties[idx].default_uint_value));
 }
 
+void TargetProperties::SetLoadScriptFromSymbolFile(
+    LoadScriptFromSymFile load_style) {
+  const uint32_t idx = ePropertyLoadScriptFromSymbolFile;
+  SetPropertyAtIndex(idx, load_style);
+}
+
 LoadCWDlldbinitFile TargetProperties::GetLoadCWDlldbinitFile() const {
   const uint32_t idx = ePropertyLoadCWDlldbinitFile;
   return GetPropertyAtIndexAs<LoadCWDlldbinitFile>(
@@ -5275,18 +5282,30 @@ void TargetProperties::SetDebugUtilityExpression(bool debug) {
   SetPropertyAtIndex(idx, debug);
 }
 
-OptionValueDictionary *TargetProperties::GetAutoLoadScriptsForModules() const {
-  return m_collection_sp->GetPropertyAtIndexAsOptionValueDictionary(
+std::optional<LoadScriptFromSymFile>
+TargetProperties::GetAutoLoadScriptsForModule(
+    llvm::StringRef module_name) const {
+  auto *dict = m_collection_sp->GetPropertyAtIndexAsOptionValueDictionary(
       ePropertyAutoLoadScriptsForModules);
+  if (!dict)
+    return std::nullopt;
+
+  OptionValueSP value_sp = dict->GetValueForKey(module_name);
+  if (!value_sp)
+    return std::nullopt;
+
+  return value_sp->GetValueAs<LoadScriptFromSymFile>();
 }
 
-void TargetProperties::SetAutoLoadScriptsForModules(llvm::StringRef module_name,
-                                                    bool should_load) {
-  OptionValueDictionary *dict = GetAutoLoadScriptsForModules();
+void TargetProperties::SetAutoLoadScriptsForModule(
+    llvm::StringRef module_name, LoadScriptFromSymFile load_style) {
+  auto *dict = m_collection_sp->GetPropertyAtIndexAsOptionValueDictionary(
+      ePropertyAutoLoadScriptsForModules);
   if (!dict)
     return;
+
   dict->SetValueForKey(module_name,
-                       std::make_shared<OptionValueBoolean>(should_load));
+                       std::make_shared<OptionValueEnumeration>(load_style));
 }
 
 // Target::TargetEventData

--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -5305,7 +5305,7 @@ void TargetProperties::SetAutoLoadScriptsForModule(
     return;
 
   dict->SetValueForKey(module_name,
-                       std::make_shared<OptionValueEnumeration>(load_style));
+                       std::make_shared<OptionValueEnumeration>(g_load_script_from_sym_file_values, load_style));
 }
 
 // Target::TargetEventData

--- a/lldb/source/Target/TargetProperties.td
+++ b/lldb/source/Target/TargetProperties.td
@@ -222,6 +222,12 @@ let Definition = "target", Path = "target" in {
   def ParallelModuleLoad: Property<"parallel-module-load", "Boolean">,
     DefaultTrue,
     Desc<"Enable loading of modules in parallel for the dynamic loader.">;
+  def AutoLoadScriptsForModules
+      : Property<"auto-load-scripts-for-modules", "Dictionary">,
+        ElementType<"Enum">,
+        EnumValues<"OptionEnumValues(g_load_script_from_sym_file_values)">,
+        Desc<"A list of module names and whether LLDB will auto-load scripting "
+             "resources for it from safe paths.">;
 }
 
 let Definition = "process_experimental", Path = "target.process.experimental" in {

--- a/lldb/source/Target/TargetProperties.td
+++ b/lldb/source/Target/TargetProperties.td
@@ -226,7 +226,7 @@ let Definition = "target", Path = "target" in {
       : Property<"auto-load-scripts-for-modules", "Dictionary">,
         ElementType<"Enum">,
         EnumValues<"OptionEnumValues(g_load_script_from_sym_file_values)">,
-        Desc<"A list of module names and whether LLDB will auto-load scripting "
+        Desc<"A list of module/image names and whether LLDB should auto-load scripting "
              "resources for it from safe paths.">;
 }
 

--- a/lldb/test/Shell/Platform/AutoLoad/Darwin/dsym-auto-load-modules-false.test
+++ b/lldb/test/Shell/Platform/AutoLoad/Darwin/dsym-auto-load-modules-false.test
@@ -1,0 +1,24 @@
+# REQUIRES: python, system-darwin
+
+# Test that when a module is listed in target.auto-load-scripts-for-modules with 'false',
+# its scripting resources are NOT loaded even when target.load-script-from-symbol-file
+# is true.
+
+# RUN: split-file %s %t
+# RUN: %clang_host -g %t/main.c -o %t/TestModule.out
+# RUN: mkdir -p %t/TestModule.out.dSYM/Contents/Resources/Python
+# RUN: cp %t/dsym_script.py %t/TestModule.out.dSYM/Contents/Resources/Python/TestModule.py
+
+# RUN: %lldb -b \
+# RUN:   -o 'settings set target.load-script-from-symbol-file true' \
+# RUN:   -o 'settings set target.auto-load-scripts-for-modules TestModule=false' \
+# RUN:   -o 'target create %t/TestModule.out' 2>&1 \
+# RUN:   | FileCheck %s --implicit-check-not=AUTOLOAD_SUCCESS --implicit-check-not=warning
+
+#--- main.c
+int main() { return 0; }
+
+#--- dsym_script.py
+import sys
+def __lldb_init_module(debugger, internal_dict):
+    print("AUTOLOAD_SUCCESS", file=sys.stderr)

--- a/lldb/test/Shell/Platform/AutoLoad/Darwin/dsym-auto-load-modules-multiple.test
+++ b/lldb/test/Shell/Platform/AutoLoad/Darwin/dsym-auto-load-modules-multiple.test
@@ -1,0 +1,38 @@
+# REQUIRES: python, system-darwin
+
+# Test that multiple modules listed in target.auto-load-scripts-for-modules are all
+# auto-loaded.
+
+# RUN: split-file %s %t
+# RUN: %clang_host -shared %t/lib.c -o %t/libFoo.dylib
+# RUN: %clang_host %t/main.c -o %t/TestModule.out %t/libFoo.dylib
+# RUN: mkdir -p %t/TestModule.out.dSYM/Contents/Resources/Python
+# RUN: mkdir -p %t/libFoo.out.dSYM/Contents/Resources/Python
+#
+# RUN: cp %t/main_script.py %t/TestModule.out.dSYM/Contents/Resources/Python/TestModule.py
+# RUN: cp %t/lib_script.py %t/libFoo.out.dSYM/Contents/Resources/Python/libFoo.py
+
+# RUN: %lldb -b \
+# RUN:   -o 'settings set target.load-script-from-symbol-file false' \
+# RUN:   -o 'settings set target.auto-load-scripts-for-modules TestModule=true libFoo=true' \
+# RUN:   -o 'target create %t/TestModule.out' 2>&1 | FileCheck %s
+
+# CHECK-DAG: MAIN_AUTOLOAD_SUCCESS
+# CHECK-DAG: LIB_AUTOLOAD_SUCCESS
+
+#--- main.c
+extern int foo(void);
+int main() { return foo(); }
+
+#--- lib.c
+int foo(void) { return 0; }
+
+#--- main_script.py
+import sys
+def __lldb_init_module(debugger, internal_dict):
+    print("MAIN_AUTOLOAD_SUCCESS", file=sys.stderr)
+
+#--- lib_script.py
+import sys
+def __lldb_init_module(debugger, internal_dict):
+    print("LIB_AUTOLOAD_SUCCESS", file=sys.stderr)

--- a/lldb/test/Shell/Platform/AutoLoad/Darwin/dsym-auto-load-modules-not-in-dict.test
+++ b/lldb/test/Shell/Platform/AutoLoad/Darwin/dsym-auto-load-modules-not-in-dict.test
@@ -1,0 +1,27 @@
+# REQUIRES: python, system-darwin
+
+# Test that when a module is NOT in target.auto-load-scripts-for-modules, the existing
+# target.load-script-from-symbol-file setting controls whether scripts load.
+# With load-script-from-symbol-file=true and no dictionary entry, scripts
+# should still load normally.
+
+# RUN: split-file %s %t
+# RUN: %clang_host -g %t/main.c -o %t/TestModule.out
+# RUN: mkdir -p %t/TestModule.out.dSYM/Contents/Resources/Python
+# RUN: cp %t/dsym_script.py %t/TestModule.out.dSYM/Contents/Resources/Python/TestModule.py
+
+## A different module is in the dictionary; TestModule is not.
+# RUN: %lldb -b \
+# RUN:   -o 'settings set target.load-script-from-symbol-file warn' \
+# RUN:   -o 'settings set target.auto-load-scripts-for-modules SomeOtherModule=true' \
+# RUN:   -o 'target create %t/TestModule.out' 2>&1 | FileCheck %s --implicit-check-not=AUTOLOAD_SUCCESS
+
+# CHECK: warning: 'TestModule' contains an untrusted debug script. To run this script in this debug session
+
+#--- main.c
+int main() { return 0; }
+
+#--- dsym_script.py
+import sys
+def __lldb_init_module(debugger, internal_dict):
+    print("AUTOLOAD_SUCCESS", file=sys.stderr)

--- a/lldb/test/Shell/Platform/AutoLoad/Darwin/dsym-auto-load-modules-true.test
+++ b/lldb/test/Shell/Platform/AutoLoad/Darwin/dsym-auto-load-modules-true.test
@@ -1,0 +1,25 @@
+# REQUIRES: python, system-darwin
+
+# Test that when a module is listed in target.auto-load-scripts-for-modules with 'true',
+# its scripting resources are loaded even when target.load-script-from-symbol-file
+# is false.
+
+# RUN: split-file %s %t
+# RUN: %clang_host -g %t/main.c -o %t/TestModule.out
+# RUN: mkdir -p %t/TestModule.out.dSYM/Contents/Resources/Python
+# RUN: cp %t/dsym_script.py %t/TestModule.out.dSYM/Contents/Resources/Python/TestModule.py
+
+# RUN: %lldb -b \
+# RUN:   -o 'settings set target.load-script-from-symbol-file false' \
+# RUN:   -o 'settings set target.auto-load-scripts-for-modules TestModule=true' \
+# RUN:   -o 'target create %t/TestModule.out' 2>&1 | FileCheck %s
+
+# CHECK: AUTOLOAD_SUCCESS
+
+#--- main.c
+int main() { return 0; }
+
+#--- dsym_script.py
+import sys
+def __lldb_init_module(debugger, internal_dict):
+    print("AUTOLOAD_SUCCESS", file=sys.stderr)

--- a/lldb/test/Shell/Platform/AutoLoad/Darwin/dsym-auto-load-modules-warn.test
+++ b/lldb/test/Shell/Platform/AutoLoad/Darwin/dsym-auto-load-modules-warn.test
@@ -1,8 +1,8 @@
 # REQUIRES: python, system-darwin
 
-# Test that when a module is listed in target.auto-load-scripts-for-modules with 'false',
+# Test that when a module is listed in target.auto-load-scripts-for-modules with 'warn',
 # its scripting resources are NOT loaded even when target.load-script-from-symbol-file
-# is true.
+# is true but we still print a warning.
 
 # RUN: split-file %s %t
 # RUN: %clang_host -g %t/main.c -o %t/TestModule.out

--- a/lldb/test/Shell/Platform/AutoLoad/Darwin/dsym-auto-load-modules-warn.test
+++ b/lldb/test/Shell/Platform/AutoLoad/Darwin/dsym-auto-load-modules-warn.test
@@ -1,0 +1,26 @@
+# REQUIRES: python, system-darwin
+
+# Test that when a module is listed in target.auto-load-scripts-for-modules with 'false',
+# its scripting resources are NOT loaded even when target.load-script-from-symbol-file
+# is true.
+
+# RUN: split-file %s %t
+# RUN: %clang_host -g %t/main.c -o %t/TestModule.out
+# RUN: mkdir -p %t/TestModule.out.dSYM/Contents/Resources/Python
+# RUN: cp %t/dsym_script.py %t/TestModule.out.dSYM/Contents/Resources/Python/TestModule.py
+
+# RUN: %lldb -b \
+# RUN:   -o 'settings set target.load-script-from-symbol-file true' \
+# RUN:   -o 'settings set target.auto-load-scripts-for-modules TestModule=warn' \
+# RUN:   -o 'target create %t/TestModule.out' 2>&1 \
+# RUN:   | FileCheck %s --implicit-check-not=AUTOLOAD_SUCCESS
+
+# CHECK-WARN: warning: 'TestModule' contains an untrusted debug script. To run this script in this debug session:
+
+#--- main.c
+int main() { return 0; }
+
+#--- dsym_script.py
+import sys
+def __lldb_init_module(debugger, internal_dict):
+    print("AUTOLOAD_SUCCESS", file=sys.stderr)

--- a/lldb/test/Shell/Platform/AutoLoad/UNIX/auto-load-modules-false.test
+++ b/lldb/test/Shell/Platform/AutoLoad/UNIX/auto-load-modules-false.test
@@ -1,0 +1,25 @@
+# REQUIRES: python, asserts, !system-windows
+
+# Test that when a module is listed in target.auto-load-scripts-for-modules with 'false',
+# its scripting resources are NOT loaded even when target.load-script-from-symbol-file
+# is true.
+
+# RUN: split-file %s %t
+# RUN: %clang_host %t/main.c -o %t/TestModule.out
+# RUN: mkdir -p %t/safe-path/TestModule
+
+# RUN: cp %t/script.py %t/safe-path/TestModule/TestModule.py
+# RUN: %lldb -b \
+# RUN:   -o 'settings set target.load-script-from-symbol-file true' \
+# RUN:   -o 'settings append testing.safe-auto-load-paths %t/safe-path' \
+# RUN:   -o 'settings set target.auto-load-scripts-for-modules TestModule=false' \
+# RUN:   -o 'target create %t/TestModule.out' 2>&1 \
+# RUN:   | FileCheck %s --implicit-check-not=AUTOLOAD_SUCCESS --implicit-check-not=warning
+
+#--- main.c
+int main() { return 0; }
+
+#--- script.py
+import sys
+def __lldb_init_module(debugger, internal_dict):
+    print("AUTOLOAD_SUCCESS", file=sys.stderr)

--- a/lldb/test/Shell/Platform/AutoLoad/UNIX/auto-load-modules-multiple.test
+++ b/lldb/test/Shell/Platform/AutoLoad/UNIX/auto-load-modules-multiple.test
@@ -1,0 +1,38 @@
+# REQUIRES: python, asserts, !system-windows
+
+# Test that multiple modules listed in target.auto-load-scripts-for-modules are all
+# auto-loaded.
+
+# RUN: split-file %s %t
+# RUN: %clang_host -shared %t/lib.c -o %t/libFoo.dylib
+# RUN: %clang_host %t/main.c -o %t/TestModule.out %t/libFoo.dylib
+# RUN: mkdir -p %t/safe-path/TestModule
+# RUN: mkdir -p %t/safe-path/libFoo
+
+# RUN: cp %t/main_script.py %t/safe-path/TestModule/TestModule.py
+# RUN: cp %t/lib_script.py %t/safe-path/libFoo/libFoo.py
+# RUN: %lldb -b \
+# RUN:   -o 'settings set target.load-script-from-symbol-file false' \
+# RUN:   -o 'settings append testing.safe-auto-load-paths %t/safe-path' \
+# RUN:   -o 'settings set target.auto-load-scripts-for-modules TestModule=true libFoo=true' \
+# RUN:   -o 'target create %t/TestModule.out' 2>&1 | FileCheck %s
+
+# CHECK-DAG: MAIN_AUTOLOAD_SUCCESS
+# CHECK-DAG: LIB_AUTOLOAD_SUCCESS
+
+#--- main.c
+extern int foo(void);
+int main() { return foo(); }
+
+#--- lib.c
+int foo(void) { return 0; }
+
+#--- main_script.py
+import sys
+def __lldb_init_module(debugger, internal_dict):
+    print("MAIN_AUTOLOAD_SUCCESS", file=sys.stderr)
+
+#--- lib_script.py
+import sys
+def __lldb_init_module(debugger, internal_dict):
+    print("LIB_AUTOLOAD_SUCCESS", file=sys.stderr)

--- a/lldb/test/Shell/Platform/AutoLoad/UNIX/auto-load-modules-not-in-dict.test
+++ b/lldb/test/Shell/Platform/AutoLoad/UNIX/auto-load-modules-not-in-dict.test
@@ -1,0 +1,29 @@
+# REQUIRES: python, asserts, !system-windows
+
+# Test that when a module is NOT in target.auto-load-scripts-for-modules, the existing
+# target.load-script-from-symbol-file setting controls whether scripts load.
+# With load-script-from-symbol-file=true and no dictionary entry, scripts
+# should still load normally.
+
+# RUN: split-file %s %t
+# RUN: %clang_host %t/main.c -o %t/TestModule.out
+# RUN: mkdir -p %t/safe-path/TestModule
+
+# RUN: cp %t/script.py %t/safe-path/TestModule/TestModule.py
+
+## A different module is in the dictionary; TestModule is not.
+# RUN: %lldb -b \
+# RUN:   -o 'settings set target.load-script-from-symbol-file warn' \
+# RUN:   -o 'settings append testing.safe-auto-load-paths %t/safe-path' \
+# RUN:   -o 'settings set target.auto-load-scripts-for-modules SomeOtherModule=true' \
+# RUN:   -o 'target create %t/TestModule.out' 2>&1 | FileCheck %s --implicit-check-not=AUTOLOAD_SUCCESS
+
+# CHECK: warning: 'TestModule' contains a debug script. To run this script in this debug session
+
+#--- main.c
+int main() { return 0; }
+
+#--- script.py
+import sys
+def __lldb_init_module(debugger, internal_dict):
+    print("AUTOLOAD_SUCCESS", file=sys.stderr)

--- a/lldb/test/Shell/Platform/AutoLoad/UNIX/auto-load-modules-not-in-dict.test
+++ b/lldb/test/Shell/Platform/AutoLoad/UNIX/auto-load-modules-not-in-dict.test
@@ -18,7 +18,7 @@
 # RUN:   -o 'settings set target.auto-load-scripts-for-modules SomeOtherModule=true' \
 # RUN:   -o 'target create %t/TestModule.out' 2>&1 | FileCheck %s --implicit-check-not=AUTOLOAD_SUCCESS
 
-# CHECK: warning: 'TestModule' contains a debug script. To run this script in this debug session
+# CHECK: warning: 'TestModule' contains an untrusted debug script. To run this script in this debug session
 
 #--- main.c
 int main() { return 0; }

--- a/lldb/test/Shell/Platform/AutoLoad/UNIX/auto-load-modules-true.test
+++ b/lldb/test/Shell/Platform/AutoLoad/UNIX/auto-load-modules-true.test
@@ -1,0 +1,26 @@
+# REQUIRES: python, asserts, !system-windows
+
+# Test that when a module is listed in target.auto-load-scripts-for-modules with 'true',
+# its scripting resources are loaded even when target.load-script-from-symbol-file
+# is false.
+
+# RUN: split-file %s %t
+# RUN: %clang_host %t/main.c -o %t/TestModule.out
+# RUN: mkdir -p %t/safe-path/TestModule
+
+# RUN: cp %t/script.py %t/safe-path/TestModule/TestModule.py
+# RUN: %lldb -b \
+# RUN:   -o 'settings set target.load-script-from-symbol-file false' \
+# RUN:   -o 'settings append testing.safe-auto-load-paths %t/safe-path' \
+# RUN:   -o 'settings set target.auto-load-scripts-for-modules TestModule=true' \
+# RUN:   -o 'target create %t/TestModule.out' 2>&1 | FileCheck %s
+
+# CHECK: AUTOLOAD_SUCCESS
+
+#--- main.c
+int main() { return 0; }
+
+#--- script.py
+import sys
+def __lldb_init_module(debugger, internal_dict):
+    print("AUTOLOAD_SUCCESS", file=sys.stderr)

--- a/lldb/test/Shell/Platform/AutoLoad/UNIX/auto-load-modules-warn.test
+++ b/lldb/test/Shell/Platform/AutoLoad/UNIX/auto-load-modules-warn.test
@@ -1,0 +1,27 @@
+# REQUIRES: python, asserts, !system-windows
+
+# Test that when a module is listed in target.auto-load-scripts-for-modules with 'false',
+# its scripting resources are NOT loaded even when target.load-script-from-symbol-file
+# is true.
+
+# RUN: split-file %s %t
+# RUN: %clang_host %t/main.c -o %t/TestModule.out
+# RUN: mkdir -p %t/safe-path/TestModule
+
+# RUN: cp %t/script.py %t/safe-path/TestModule/TestModule.py
+# RUN: %lldb -b \
+# RUN:   -o 'settings set target.load-script-from-symbol-file true' \
+# RUN:   -o 'settings append testing.safe-auto-load-paths %t/safe-path' \
+# RUN:   -o 'settings set target.auto-load-scripts-for-modules TestModule=warn' \
+# RUN:   -o 'target create %t/TestModule.out' 2>&1 \
+# RUN:   | FileCheck %s --implicit-check-not=AUTOLOAD_SUCCESS
+
+# CHECK-WARN: warning: 'TestModule' contains an untrusted debug script. To run this script in this debug session:
+
+#--- main.c
+int main() { return 0; }
+
+#--- script.py
+import sys
+def __lldb_init_module(debugger, internal_dict):
+    print("AUTOLOAD_SUCCESS", file=sys.stderr)

--- a/lldb/test/Shell/Platform/AutoLoad/UNIX/auto-load-modules-warn.test
+++ b/lldb/test/Shell/Platform/AutoLoad/UNIX/auto-load-modules-warn.test
@@ -1,8 +1,8 @@
 # REQUIRES: python, asserts, !system-windows
 
-# Test that when a module is listed in target.auto-load-scripts-for-modules with 'false',
+# Test that when a module is listed in target.auto-load-scripts-for-modules with 'warn',
 # its scripting resources are NOT loaded even when target.load-script-from-symbol-file
-# is true.
+# is true but we print a warning.
 
 # RUN: split-file %s %t
 # RUN: %clang_host %t/main.c -o %t/TestModule.out

--- a/lldb/unittests/Platform/PlatformDarwinTest.cpp
+++ b/lldb/unittests/Platform/PlatformDarwinTest.cpp
@@ -545,6 +545,130 @@ TEST_F(
   EXPECT_TRUE(ss.Empty());
 }
 
+TEST_F(PlatformDarwinLocateTest,
+       LocateExecutableScriptingResourcesFromDSYM_AutoLoadModule_Multiple) {
+  m_target_sp->SetLoadScriptFromSymbolFile(eLoadScriptFromSymFileTrusted);
+  TestingProperties::GetGlobalTestingProperties().AppendSafeAutoLoadPaths(
+      FileSpec(m_tmp_root_dir));
+
+  auto setup_module = [this](llvm::StringRef module_name) {
+    FileSpec module_fspec(
+        CreateFile(llvm::formatv("{0}.o", module_name).str(), m_tmp_root_dir));
+    EXPECT_TRUE(module_fspec);
+
+    FileSpec dsym_module_fpec(CreateFile(
+        llvm::formatv("{0}.o", module_name).str(), m_tmp_dsym_dwarf_dir));
+    EXPECT_TRUE(dsym_module_fpec);
+
+    CreateFile(llvm::formatv("{0}.py", module_name).str(),
+               m_tmp_dsym_python_dir);
+
+    return std::pair{module_fspec, dsym_module_fpec};
+  };
+
+  auto [module_false_fspec, dsym_module_false_fspec] =
+      setup_module("ModuleFalse");
+  m_target_sp->SetAutoLoadScriptsForModule("ModuleFalse",
+                                           eLoadScriptFromSymFileFalse);
+
+  auto [module_true_fspec, dsym_module_true_fspec] = setup_module("ModuleTrue");
+  m_target_sp->SetAutoLoadScriptsForModule("ModuleTrue",
+                                           eLoadScriptFromSymFileTrue);
+
+  auto [module_warn_fspec, dsym_module_warn_fspec] = setup_module("ModuleWarn");
+  m_target_sp->SetAutoLoadScriptsForModule("ModuleWarn",
+                                           eLoadScriptFromSymFileWarn);
+
+  auto [module_trusted_fspec, dsym_module_trusted_fspec] =
+      setup_module("ModuleTrusted");
+  m_target_sp->SetAutoLoadScriptsForModule("ModuleTrusted",
+                                           eLoadScriptFromSymFileTrusted);
+
+  auto [module_another_true_fspec, dsym_module_another_true_fspec] =
+      setup_module("ModuleAnotherTrue");
+  m_target_sp->SetAutoLoadScriptsForModule("ModuleAnotherTrue",
+                                           eLoadScriptFromSymFileTrue);
+
+  auto [module_default_fspec, dsym_module_default_fspec] =
+      setup_module("ModuleDefault");
+
+  {
+    StreamString ss;
+    auto fspecs =
+        std::static_pointer_cast<PlatformDarwin>(m_platform_sp)
+            ->LocateExecutableScriptingResourcesFromDSYM(
+                ss, module_false_fspec, *m_target_sp, dsym_module_false_fspec);
+
+    ASSERT_EQ(fspecs.size(), 1u);
+    ASSERT_TRUE(fspecs.contains(module_false_fspec));
+
+    EXPECT_EQ(fspecs[module_false_fspec], eLoadScriptFromSymFileFalse);
+  }
+
+  {
+    StreamString ss;
+    auto fspecs =
+        std::static_pointer_cast<PlatformDarwin>(m_platform_sp)
+            ->LocateExecutableScriptingResourcesFromDSYM(
+                ss, module_true_fspec, *m_target_sp, dsym_module_true_fspec);
+
+    ASSERT_EQ(fspecs.size(), 1u);
+    ASSERT_TRUE(fspecs.contains(module_true_fspec));
+
+    EXPECT_EQ(fspecs[module_true_fspec], eLoadScriptFromSymFileTrue);
+  }
+
+  {
+    StreamString ss;
+    auto fspecs =
+        std::static_pointer_cast<PlatformDarwin>(m_platform_sp)
+            ->LocateExecutableScriptingResourcesFromDSYM(
+                ss, module_warn_fspec, *m_target_sp, dsym_module_warn_fspec);
+
+    ASSERT_EQ(fspecs.size(), 1u);
+    ASSERT_TRUE(fspecs.contains(module_warn_fspec));
+
+    EXPECT_EQ(fspecs[module_warn_fspec], eLoadScriptFromSymFileWarn);
+  }
+
+  {
+    StreamString ss;
+    auto fspecs = std::static_pointer_cast<PlatformDarwin>(m_platform_sp)
+                      ->LocateExecutableScriptingResourcesFromDSYM(
+                          ss, module_trusted_fspec, *m_target_sp,
+                          dsym_module_trusted_fspec);
+
+    ASSERT_EQ(fspecs.size(), 1u);
+    ASSERT_TRUE(fspecs.contains(module_trusted_fspec));
+
+    EXPECT_EQ(fspecs[module_trusted_fspec], eLoadScriptFromSymFileTrusted);
+  }
+
+  {
+    StreamString ss;
+    auto fspecs = std::static_pointer_cast<PlatformDarwin>(m_platform_sp)
+                      ->LocateExecutableScriptingResourcesFromDSYM(
+                          ss, module_another_true_fspec, *m_target_sp,
+                          dsym_module_another_true_fspec);
+
+    ASSERT_EQ(fspecs.size(), 1u);
+    ASSERT_TRUE(fspecs.contains(module_another_true_fspec));
+
+    EXPECT_EQ(fspecs[module_another_true_fspec], eLoadScriptFromSymFileTrue);
+  }
+
+  {
+    StreamString ss;
+    auto file_specs = Platform::LocateExecutableScriptingResourcesFromSafePaths(
+        ss, module_default_fspec, *m_target_sp);
+
+    ASSERT_EQ(file_specs.size(), 1u);
+    ASSERT_TRUE(file_specs.contains(module_default_fspec));
+
+    EXPECT_EQ(file_specs[module_default_fspec], eLoadScriptFromSymFileTrusted);
+  }
+}
+
 struct SpecialCharTestCase {
   char special_char;
   char replacement;

--- a/lldb/unittests/Platform/PlatformDarwinTest.cpp
+++ b/lldb/unittests/Platform/PlatformDarwinTest.cpp
@@ -546,7 +546,10 @@ TEST_F(
 }
 
 TEST_F(PlatformDarwinLocateTest,
-       LocateExecutableScriptingResourcesFromDSYM_AutoLoadModule_Multiple) {
+       LocateExecutableScriptingResourcesFromDSYM_AutoLoadScriptsForModule) {
+  // Test that the LocateExecutableScriptingResourcesFromDSYM API respects the
+  // target.auto-load-scripts-for-modules setting.
+
   m_target_sp->SetLoadScriptFromSymbolFile(eLoadScriptFromSymFileTrusted);
   TestingProperties::GetGlobalTestingProperties().AppendSafeAutoLoadPaths(
       FileSpec(m_tmp_root_dir));

--- a/lldb/unittests/Platform/PlatformDarwinTest.cpp
+++ b/lldb/unittests/Platform/PlatformDarwinTest.cpp
@@ -563,36 +563,36 @@ TEST_F(PlatformDarwinLocateTest,
         llvm::formatv("{0}.o", module_name).str(), m_tmp_dsym_dwarf_dir));
     EXPECT_TRUE(dsym_module_fpec);
 
-    CreateFile(llvm::formatv("{0}.py", module_name).str(),
-               m_tmp_dsym_python_dir);
+    FileSpec script_fspec(CreateFile(llvm::formatv("{0}.py", module_name).str(),
+                                     m_tmp_dsym_python_dir));
 
-    return std::pair{module_fspec, dsym_module_fpec};
+    return std::pair{script_fspec, dsym_module_fpec};
   };
 
-  auto [module_false_fspec, dsym_module_false_fspec] =
+  auto [script_false_fspec, dsym_module_false_fspec] =
       setup_module("ModuleFalse");
   m_target_sp->SetAutoLoadScriptsForModule("ModuleFalse",
                                            eLoadScriptFromSymFileFalse);
 
-  auto [module_true_fspec, dsym_module_true_fspec] = setup_module("ModuleTrue");
+  auto [script_true_fspec, dsym_module_true_fspec] = setup_module("ModuleTrue");
   m_target_sp->SetAutoLoadScriptsForModule("ModuleTrue",
                                            eLoadScriptFromSymFileTrue);
 
-  auto [module_warn_fspec, dsym_module_warn_fspec] = setup_module("ModuleWarn");
+  auto [script_warn_fspec, dsym_module_warn_fspec] = setup_module("ModuleWarn");
   m_target_sp->SetAutoLoadScriptsForModule("ModuleWarn",
                                            eLoadScriptFromSymFileWarn);
 
-  auto [module_trusted_fspec, dsym_module_trusted_fspec] =
+  auto [script_trusted_fspec, dsym_module_trusted_fspec] =
       setup_module("ModuleTrusted");
   m_target_sp->SetAutoLoadScriptsForModule("ModuleTrusted",
                                            eLoadScriptFromSymFileTrusted);
 
-  auto [module_another_true_fspec, dsym_module_another_true_fspec] =
+  auto [script_another_true_fspec, dsym_module_another_true_fspec] =
       setup_module("ModuleAnotherTrue");
   m_target_sp->SetAutoLoadScriptsForModule("ModuleAnotherTrue",
                                            eLoadScriptFromSymFileTrue);
 
-  auto [module_default_fspec, dsym_module_default_fspec] =
+  auto [script_default_fspec, dsym_module_default_fspec] =
       setup_module("ModuleDefault");
 
   {
@@ -600,12 +600,12 @@ TEST_F(PlatformDarwinLocateTest,
     auto fspecs =
         std::static_pointer_cast<PlatformDarwin>(m_platform_sp)
             ->LocateExecutableScriptingResourcesFromDSYM(
-                ss, module_false_fspec, *m_target_sp, dsym_module_false_fspec);
+                ss, script_false_fspec, *m_target_sp, dsym_module_false_fspec);
 
     ASSERT_EQ(fspecs.size(), 1u);
-    ASSERT_TRUE(fspecs.contains(module_false_fspec));
+    ASSERT_TRUE(fspecs.contains(script_false_fspec));
 
-    EXPECT_EQ(fspecs[module_false_fspec], eLoadScriptFromSymFileFalse);
+    EXPECT_EQ(fspecs[script_false_fspec], eLoadScriptFromSymFileFalse);
   }
 
   {
@@ -613,12 +613,12 @@ TEST_F(PlatformDarwinLocateTest,
     auto fspecs =
         std::static_pointer_cast<PlatformDarwin>(m_platform_sp)
             ->LocateExecutableScriptingResourcesFromDSYM(
-                ss, module_true_fspec, *m_target_sp, dsym_module_true_fspec);
+                ss, script_true_fspec, *m_target_sp, dsym_module_true_fspec);
 
     ASSERT_EQ(fspecs.size(), 1u);
-    ASSERT_TRUE(fspecs.contains(module_true_fspec));
+    ASSERT_TRUE(fspecs.contains(script_true_fspec));
 
-    EXPECT_EQ(fspecs[module_true_fspec], eLoadScriptFromSymFileTrue);
+    EXPECT_EQ(fspecs[script_true_fspec], eLoadScriptFromSymFileTrue);
   }
 
   {
@@ -626,49 +626,51 @@ TEST_F(PlatformDarwinLocateTest,
     auto fspecs =
         std::static_pointer_cast<PlatformDarwin>(m_platform_sp)
             ->LocateExecutableScriptingResourcesFromDSYM(
-                ss, module_warn_fspec, *m_target_sp, dsym_module_warn_fspec);
+                ss, script_warn_fspec, *m_target_sp, dsym_module_warn_fspec);
 
     ASSERT_EQ(fspecs.size(), 1u);
-    ASSERT_TRUE(fspecs.contains(module_warn_fspec));
+    ASSERT_TRUE(fspecs.contains(script_warn_fspec));
 
-    EXPECT_EQ(fspecs[module_warn_fspec], eLoadScriptFromSymFileWarn);
+    EXPECT_EQ(fspecs[script_warn_fspec], eLoadScriptFromSymFileWarn);
   }
 
   {
     StreamString ss;
     auto fspecs = std::static_pointer_cast<PlatformDarwin>(m_platform_sp)
                       ->LocateExecutableScriptingResourcesFromDSYM(
-                          ss, module_trusted_fspec, *m_target_sp,
+                          ss, script_trusted_fspec, *m_target_sp,
                           dsym_module_trusted_fspec);
 
     ASSERT_EQ(fspecs.size(), 1u);
-    ASSERT_TRUE(fspecs.contains(module_trusted_fspec));
+    ASSERT_TRUE(fspecs.contains(script_trusted_fspec));
 
-    EXPECT_EQ(fspecs[module_trusted_fspec], eLoadScriptFromSymFileTrusted);
+    EXPECT_EQ(fspecs[script_trusted_fspec], eLoadScriptFromSymFileTrusted);
   }
 
   {
     StreamString ss;
     auto fspecs = std::static_pointer_cast<PlatformDarwin>(m_platform_sp)
                       ->LocateExecutableScriptingResourcesFromDSYM(
-                          ss, module_another_true_fspec, *m_target_sp,
+                          ss, script_another_true_fspec, *m_target_sp,
                           dsym_module_another_true_fspec);
 
     ASSERT_EQ(fspecs.size(), 1u);
-    ASSERT_TRUE(fspecs.contains(module_another_true_fspec));
+    ASSERT_TRUE(fspecs.contains(script_another_true_fspec));
 
-    EXPECT_EQ(fspecs[module_another_true_fspec], eLoadScriptFromSymFileTrue);
+    EXPECT_EQ(fspecs[script_another_true_fspec], eLoadScriptFromSymFileTrue);
   }
 
   {
     StreamString ss;
-    auto file_specs = Platform::LocateExecutableScriptingResourcesFromSafePaths(
-        ss, module_default_fspec, *m_target_sp);
+    auto fspecs = std::static_pointer_cast<PlatformDarwin>(m_platform_sp)
+                      ->LocateExecutableScriptingResourcesFromDSYM(
+                          ss, script_default_fspec, *m_target_sp,
+                          dsym_module_default_fspec);
 
-    ASSERT_EQ(file_specs.size(), 1u);
-    ASSERT_TRUE(file_specs.contains(module_default_fspec));
+    ASSERT_EQ(fspecs.size(), 1u);
+    ASSERT_TRUE(fspecs.contains(script_default_fspec));
 
-    EXPECT_EQ(file_specs[module_default_fspec], eLoadScriptFromSymFileTrusted);
+    EXPECT_EQ(fspecs[script_default_fspec], eLoadScriptFromSymFileTrusted);
   }
 }
 

--- a/lldb/unittests/Platform/PlatformTest.cpp
+++ b/lldb/unittests/Platform/PlatformTest.cpp
@@ -674,151 +674,105 @@ TEST_F(PlatformLocateSafePathTest,
 }
 
 TEST_F(PlatformLocateSafePathTest,
-       LocateScriptingResourcesFromSafePaths_AutoLoadModule_True) {
-  // When a module is in target.auto-load-scripts-for-modules with value 'true',
-  // its script should be returned in the auto-load list.
-
-  TestingProperties::GetGlobalTestingProperties().AppendSafeAutoLoadPaths(
-      FileSpec(m_tmp_root_dir));
-
-  FileSpec module_fspec(CreateFile("TestModule.o", m_tmp_root_dir));
-  ASSERT_TRUE(module_fspec);
-
-  llvm::SmallString<128> module_dir(m_tmp_root_dir);
-  llvm::sys::path::append(module_dir, "TestModule");
-  ASSERT_FALSE(llvm::sys::fs::create_directory(module_dir));
-
-  CreateFile("TestModule.py", module_dir);
-
-  m_target_sp->SetAutoLoadScriptsForModules("TestModule", true);
-
-  StreamString ss;
-  auto file_specs = Platform::LocateExecutableScriptingResourcesFromSafePaths(
-      ss, module_fspec, *m_target_sp);
-
-  EXPECT_EQ(file_specs.size(), 1u);
-
-  auto [fspec, load_style] = *file_specs.begin();
-
-  EXPECT_EQ(fspec.GetFilename(), "TestModule.py");
-  EXPECT_EQ(load_style, m_target_sp->GetLoadScriptFromSymbolFile());
-}
-
-TEST_F(PlatformLocateSafePathTest,
-       LocateScriptingResourcesFromSafePaths_AutoLoadModule_False) {
-  // When a module is in target.auto-load-scripts-for-modules with value
-  // 'false', its script can still appear in the located list.
-  // We could choose not to locate those scripts for modules which won't
-  // be loaded anyway, but currently we opted to returning the full list
-  // regardless of load-style.
-
-  TestingProperties::GetGlobalTestingProperties().AppendSafeAutoLoadPaths(
-      FileSpec(m_tmp_root_dir));
-
-  FileSpec module_fspec(CreateFile("TestModule.o", m_tmp_root_dir));
-  ASSERT_TRUE(module_fspec);
-
-  llvm::SmallString<128> module_dir(m_tmp_root_dir);
-  llvm::sys::path::append(module_dir, "TestModule");
-  ASSERT_FALSE(llvm::sys::fs::create_directory(module_dir));
-
-  CreateFile("TestModule.py", module_dir);
-
-  m_target_sp->SetAutoLoadScriptsForModules("TestModule", false);
-
-  StreamString ss;
-  auto file_specs = Platform::LocateExecutableScriptingResourcesFromSafePaths(
-      ss, module_fspec, *m_target_sp);
-
-  EXPECT_EQ(file_specs.size(), 1u);
-}
-
-TEST_F(PlatformLocateSafePathTest,
-       LocateScriptingResourcesFromSafePaths_AutoLoadModule_NotInDict) {
-  // When a module is NOT in the dictionary, its script should end up
-  // in the non-auto-load list (the existing behavior).
-
-  TestingProperties::GetGlobalTestingProperties().AppendSafeAutoLoadPaths(
-      FileSpec(m_tmp_root_dir));
-
-  FileSpec module_fspec(CreateFile("TestModule.o", m_tmp_root_dir));
-  ASSERT_TRUE(module_fspec);
-
-  llvm::SmallString<128> module_dir(m_tmp_root_dir);
-  llvm::sys::path::append(module_dir, "TestModule");
-  ASSERT_FALSE(llvm::sys::fs::create_directory(module_dir));
-
-  CreateFile("TestModule.py", module_dir);
-
-  // Set a different module in the dictionary; TestModule is not present.
-  m_target_sp->SetAutoLoadScriptsForModules("SomeOtherModule", true);
-
-  StreamString ss;
-  auto file_specs = Platform::LocateExecutableScriptingResourcesFromSafePaths(
-      ss, module_fspec, *m_target_sp);
-
-  EXPECT_EQ(file_specs.size(), 1u);
-
-  auto [fspec, load_style] = *file_specs.begin();
-
-  EXPECT_EQ(fspec.GetFilename(), "TestModule.py");
-  EXPECT_EQ(load_style, m_target_sp->GetLoadScriptFromSymbolFile());
-}
-
-TEST_F(PlatformLocateSafePathTest,
        LocateScriptingResourcesFromSafePaths_AutoLoadModule_Multiple) {
-  // When multiple modules are in target.auto-load-scripts-for-modules with
-  // value 'true', each module's script should be returned in its respective
-  // auto-load list.
-
+  m_target_sp->SetLoadScriptFromSymbolFile(eLoadScriptFromSymFileTrusted);
   TestingProperties::GetGlobalTestingProperties().AppendSafeAutoLoadPaths(
       FileSpec(m_tmp_root_dir));
 
-  // Set up ModuleA.
-  FileSpec module_a_fspec(CreateFile("ModuleA.o", m_tmp_root_dir));
-  ASSERT_TRUE(module_a_fspec);
+  auto setup_module = [this](llvm::StringRef module_name) {
+    FileSpec module_fspec(
+        CreateFile(llvm::formatv("{0}.o", module_name).str(), m_tmp_root_dir));
+    EXPECT_TRUE(module_fspec);
 
-  llvm::SmallString<128> module_a_dir(m_tmp_root_dir);
-  llvm::sys::path::append(module_a_dir, "ModuleA");
-  ASSERT_FALSE(llvm::sys::fs::create_directory(module_a_dir));
-  CreateFile("ModuleA.py", module_a_dir);
+    llvm::SmallString<128> module_dir(m_tmp_root_dir);
+    llvm::sys::path::append(module_dir, module_name);
+    EXPECT_TRUE(llvm::sys::fs::create_directory(module_dir));
+    CreateFile(llvm::formatv("{0}.py", module_name).str(), module_dir);
 
-  // Set up ModuleB.
-  FileSpec module_b_fspec(CreateFile("ModuleB.o", m_tmp_root_dir));
-  ASSERT_TRUE(module_b_fspec);
+    return module_fspec;
+  };
 
-  llvm::SmallString<128> module_b_dir(m_tmp_root_dir);
-  llvm::sys::path::append(module_b_dir, "ModuleB");
-  ASSERT_FALSE(llvm::sys::fs::create_directory(module_b_dir));
-  CreateFile("ModuleB.py", module_b_dir);
-
-  m_target_sp->SetAutoLoadScriptsForModules("ModuleA", true);
-  m_target_sp->SetAutoLoadScriptsForModules("ModuleB", true);
-
+  FileSpec module_false_fspec = setup_module("ModuleFalse");
+  m_target_sp->SetAutoLoadScriptsForModule("ModuleFalse",
+                                           eLoadScriptFromSymFileFalse);
   {
     StreamString ss;
     auto file_specs = Platform::LocateExecutableScriptingResourcesFromSafePaths(
-        ss, module_a_fspec, *m_target_sp);
+        ss, module_false_fspec, *m_target_sp);
 
-    EXPECT_EQ(file_specs.size(), 1u);
+    ASSERT_EQ(file_specs.size(), 1u);
+    ASSERT_TRUE(file_specs.contains(module_false_fspec));
 
-    auto [fspec, load_style] = *file_specs.begin();
-
-    EXPECT_EQ(fspec.GetFilename(), "ModuleA.py");
-    EXPECT_EQ(load_style, m_target_sp->GetLoadScriptFromSymbolFile());
+    EXPECT_EQ(file_specs[module_false_fspec], eLoadScriptFromSymFileFalse);
   }
 
+  FileSpec module_true_fspec = setup_module("ModuleTrue");
+  m_target_sp->SetAutoLoadScriptsForModule("ModuleTrue",
+                                           eLoadScriptFromSymFileTrue);
   {
     StreamString ss;
     auto file_specs = Platform::LocateExecutableScriptingResourcesFromSafePaths(
-        ss, module_b_fspec, *m_target_sp);
+        ss, module_true_fspec, *m_target_sp);
 
-    EXPECT_EQ(file_specs.size(), 1u);
+    ASSERT_EQ(file_specs.size(), 1u);
+    ASSERT_TRUE(file_specs.contains(module_true_fspec));
 
-    auto [fspec, load_style] = *file_specs.begin();
+    EXPECT_EQ(file_specs[module_true_fspec], eLoadScriptFromSymFileTrue);
+  }
 
-    EXPECT_EQ(fspec.GetFilename(), "ModuleB.py");
-    EXPECT_EQ(load_style, m_target_sp->GetLoadScriptFromSymbolFile());
+  FileSpec module_warn_fspec = setup_module("ModuleWarn");
+  m_target_sp->SetAutoLoadScriptsForModule("ModuleWarn",
+                                           eLoadScriptFromSymFileWarn);
+  {
+    StreamString ss;
+    auto file_specs = Platform::LocateExecutableScriptingResourcesFromSafePaths(
+        ss, module_warn_fspec, *m_target_sp);
+
+    ASSERT_EQ(file_specs.size(), 1u);
+    ASSERT_TRUE(file_specs.contains(module_warn_fspec));
+
+    EXPECT_EQ(file_specs[module_warn_fspec], eLoadScriptFromSymFileWarn);
+  }
+
+  FileSpec module_trusted_fspec = setup_module("ModuleTrusted");
+  m_target_sp->SetAutoLoadScriptsForModule("ModuleTrusted",
+                                           eLoadScriptFromSymFileTrusted);
+  {
+    StreamString ss;
+    auto file_specs = Platform::LocateExecutableScriptingResourcesFromSafePaths(
+        ss, module_trusted_fspec, *m_target_sp);
+
+    ASSERT_EQ(file_specs.size(), 1u);
+    ASSERT_TRUE(file_specs.contains(module_trusted_fspec));
+
+    EXPECT_EQ(file_specs[module_trusted_fspec], eLoadScriptFromSymFileTrusted);
+  }
+
+  FileSpec module_another_true_fspec = setup_module("ModuleAnotherTrue");
+  m_target_sp->SetAutoLoadScriptsForModule("ModuleAnotherTrue",
+                                           eLoadScriptFromSymFileTrue);
+  {
+    StreamString ss;
+    auto file_specs = Platform::LocateExecutableScriptingResourcesFromSafePaths(
+        ss, module_another_true_fspec, *m_target_sp);
+
+    ASSERT_EQ(file_specs.size(), 1u);
+    ASSERT_TRUE(file_specs.contains(module_another_true_fspec));
+
+    EXPECT_EQ(file_specs[module_another_true_fspec],
+              eLoadScriptFromSymFileTrue);
+  }
+
+  FileSpec module_default_fspec = setup_module("ModuleDefault");
+  {
+    StreamString ss;
+    auto file_specs = Platform::LocateExecutableScriptingResourcesFromSafePaths(
+        ss, module_default_fspec, *m_target_sp);
+
+    ASSERT_EQ(file_specs.size(), 1u);
+    ASSERT_TRUE(file_specs.contains(module_default_fspec));
+
+    EXPECT_EQ(file_specs[module_default_fspec], eLoadScriptFromSymFileTrusted);
   }
 }
 #endif // NDEBUG

--- a/lldb/unittests/Platform/PlatformTest.cpp
+++ b/lldb/unittests/Platform/PlatformTest.cpp
@@ -672,4 +672,153 @@ TEST_F(PlatformLocateSafePathTest,
   EXPECT_EQ(file_specs.size(), 1u);
   EXPECT_TRUE(ss.GetString().empty());
 }
+
+TEST_F(PlatformLocateSafePathTest,
+       LocateScriptingResourcesFromSafePaths_AutoLoadModule_True) {
+  // When a module is in target.auto-load-scripts-for-modules with value 'true',
+  // its script should be returned in the auto-load list.
+
+  TestingProperties::GetGlobalTestingProperties().AppendSafeAutoLoadPaths(
+      FileSpec(m_tmp_root_dir));
+
+  FileSpec module_fspec(CreateFile("TestModule.o", m_tmp_root_dir));
+  ASSERT_TRUE(module_fspec);
+
+  llvm::SmallString<128> module_dir(m_tmp_root_dir);
+  llvm::sys::path::append(module_dir, "TestModule");
+  ASSERT_FALSE(llvm::sys::fs::create_directory(module_dir));
+
+  CreateFile("TestModule.py", module_dir);
+
+  m_target_sp->SetAutoLoadScriptsForModules("TestModule", true);
+
+  StreamString ss;
+  auto file_specs = Platform::LocateExecutableScriptingResourcesFromSafePaths(
+      ss, module_fspec, *m_target_sp);
+
+  EXPECT_EQ(file_specs.size(), 1u);
+
+  auto [fspec, load_style] = *file_specs.begin();
+
+  EXPECT_EQ(fspec.GetFilename(), "TestModule.py");
+  EXPECT_EQ(load_style, m_target_sp->GetLoadScriptFromSymbolFile());
+}
+
+TEST_F(PlatformLocateSafePathTest,
+       LocateScriptingResourcesFromSafePaths_AutoLoadModule_False) {
+  // When a module is in target.auto-load-scripts-for-modules with value
+  // 'false', its script can still appear in the located list.
+  // We could choose not to locate those scripts for modules which won't
+  // be loaded anyway, but currently we opted to returning the full list
+  // regardless of load-style.
+
+  TestingProperties::GetGlobalTestingProperties().AppendSafeAutoLoadPaths(
+      FileSpec(m_tmp_root_dir));
+
+  FileSpec module_fspec(CreateFile("TestModule.o", m_tmp_root_dir));
+  ASSERT_TRUE(module_fspec);
+
+  llvm::SmallString<128> module_dir(m_tmp_root_dir);
+  llvm::sys::path::append(module_dir, "TestModule");
+  ASSERT_FALSE(llvm::sys::fs::create_directory(module_dir));
+
+  CreateFile("TestModule.py", module_dir);
+
+  m_target_sp->SetAutoLoadScriptsForModules("TestModule", false);
+
+  StreamString ss;
+  auto file_specs = Platform::LocateExecutableScriptingResourcesFromSafePaths(
+      ss, module_fspec, *m_target_sp);
+
+  EXPECT_EQ(file_specs.size(), 1u);
+}
+
+TEST_F(PlatformLocateSafePathTest,
+       LocateScriptingResourcesFromSafePaths_AutoLoadModule_NotInDict) {
+  // When a module is NOT in the dictionary, its script should end up
+  // in the non-auto-load list (the existing behavior).
+
+  TestingProperties::GetGlobalTestingProperties().AppendSafeAutoLoadPaths(
+      FileSpec(m_tmp_root_dir));
+
+  FileSpec module_fspec(CreateFile("TestModule.o", m_tmp_root_dir));
+  ASSERT_TRUE(module_fspec);
+
+  llvm::SmallString<128> module_dir(m_tmp_root_dir);
+  llvm::sys::path::append(module_dir, "TestModule");
+  ASSERT_FALSE(llvm::sys::fs::create_directory(module_dir));
+
+  CreateFile("TestModule.py", module_dir);
+
+  // Set a different module in the dictionary; TestModule is not present.
+  m_target_sp->SetAutoLoadScriptsForModules("SomeOtherModule", true);
+
+  StreamString ss;
+  auto file_specs = Platform::LocateExecutableScriptingResourcesFromSafePaths(
+      ss, module_fspec, *m_target_sp);
+
+  EXPECT_EQ(file_specs.size(), 1u);
+
+  auto [fspec, load_style] = *file_specs.begin();
+
+  EXPECT_EQ(fspec.GetFilename(), "TestModule.py");
+  EXPECT_EQ(load_style, m_target_sp->GetLoadScriptFromSymbolFile());
+}
+
+TEST_F(PlatformLocateSafePathTest,
+       LocateScriptingResourcesFromSafePaths_AutoLoadModule_Multiple) {
+  // When multiple modules are in target.auto-load-scripts-for-modules with
+  // value 'true', each module's script should be returned in its respective
+  // auto-load list.
+
+  TestingProperties::GetGlobalTestingProperties().AppendSafeAutoLoadPaths(
+      FileSpec(m_tmp_root_dir));
+
+  // Set up ModuleA.
+  FileSpec module_a_fspec(CreateFile("ModuleA.o", m_tmp_root_dir));
+  ASSERT_TRUE(module_a_fspec);
+
+  llvm::SmallString<128> module_a_dir(m_tmp_root_dir);
+  llvm::sys::path::append(module_a_dir, "ModuleA");
+  ASSERT_FALSE(llvm::sys::fs::create_directory(module_a_dir));
+  CreateFile("ModuleA.py", module_a_dir);
+
+  // Set up ModuleB.
+  FileSpec module_b_fspec(CreateFile("ModuleB.o", m_tmp_root_dir));
+  ASSERT_TRUE(module_b_fspec);
+
+  llvm::SmallString<128> module_b_dir(m_tmp_root_dir);
+  llvm::sys::path::append(module_b_dir, "ModuleB");
+  ASSERT_FALSE(llvm::sys::fs::create_directory(module_b_dir));
+  CreateFile("ModuleB.py", module_b_dir);
+
+  m_target_sp->SetAutoLoadScriptsForModules("ModuleA", true);
+  m_target_sp->SetAutoLoadScriptsForModules("ModuleB", true);
+
+  {
+    StreamString ss;
+    auto file_specs = Platform::LocateExecutableScriptingResourcesFromSafePaths(
+        ss, module_a_fspec, *m_target_sp);
+
+    EXPECT_EQ(file_specs.size(), 1u);
+
+    auto [fspec, load_style] = *file_specs.begin();
+
+    EXPECT_EQ(fspec.GetFilename(), "ModuleA.py");
+    EXPECT_EQ(load_style, m_target_sp->GetLoadScriptFromSymbolFile());
+  }
+
+  {
+    StreamString ss;
+    auto file_specs = Platform::LocateExecutableScriptingResourcesFromSafePaths(
+        ss, module_b_fspec, *m_target_sp);
+
+    EXPECT_EQ(file_specs.size(), 1u);
+
+    auto [fspec, load_style] = *file_specs.begin();
+
+    EXPECT_EQ(fspec.GetFilename(), "ModuleB.py");
+    EXPECT_EQ(load_style, m_target_sp->GetLoadScriptFromSymbolFile());
+  }
+}
 #endif // NDEBUG

--- a/lldb/unittests/Platform/PlatformTest.cpp
+++ b/lldb/unittests/Platform/PlatformTest.cpp
@@ -689,99 +689,99 @@ TEST_F(PlatformLocateSafePathTest,
 
     llvm::SmallString<128> module_dir(m_tmp_root_dir);
     llvm::sys::path::append(module_dir, module_name);
-    EXPECT_TRUE(llvm::sys::fs::create_directory(module_dir));
-    CreateFile(llvm::formatv("{0}.py", module_name).str(), module_dir);
+    EXPECT_FALSE(llvm::sys::fs::create_directory(module_dir));
 
-    return module_fspec;
+    return FileSpec(
+        CreateFile(llvm::formatv("{0}.py", module_name).str(), module_dir));
   };
 
-  FileSpec module_false_fspec = setup_module("ModuleFalse");
+  FileSpec script_false_fspec = setup_module("ModuleFalse");
   m_target_sp->SetAutoLoadScriptsForModule("ModuleFalse",
                                            eLoadScriptFromSymFileFalse);
 
-  FileSpec module_true_fspec = setup_module("ModuleTrue");
+  FileSpec script_true_fspec = setup_module("ModuleTrue");
   m_target_sp->SetAutoLoadScriptsForModule("ModuleTrue",
                                            eLoadScriptFromSymFileTrue);
 
-  FileSpec module_warn_fspec = setup_module("ModuleWarn");
+  FileSpec script_warn_fspec = setup_module("ModuleWarn");
   m_target_sp->SetAutoLoadScriptsForModule("ModuleWarn",
                                            eLoadScriptFromSymFileWarn);
 
-  FileSpec module_trusted_fspec = setup_module("ModuleTrusted");
+  FileSpec script_trusted_fspec = setup_module("ModuleTrusted");
   m_target_sp->SetAutoLoadScriptsForModule("ModuleTrusted",
                                            eLoadScriptFromSymFileTrusted);
 
-  FileSpec module_another_true_fspec = setup_module("ModuleAnotherTrue");
+  FileSpec script_another_true_fspec = setup_module("ModuleAnotherTrue");
   m_target_sp->SetAutoLoadScriptsForModule("ModuleAnotherTrue",
                                            eLoadScriptFromSymFileTrue);
 
-  FileSpec module_default_fspec = setup_module("ModuleDefault");
+  FileSpec script_default_fspec = setup_module("ModuleDefault");
 
   {
     StreamString ss;
     auto file_specs = Platform::LocateExecutableScriptingResourcesFromSafePaths(
-        ss, module_false_fspec, *m_target_sp);
+        ss, script_false_fspec, *m_target_sp);
 
     ASSERT_EQ(file_specs.size(), 1u);
-    ASSERT_TRUE(file_specs.contains(module_false_fspec));
+    ASSERT_TRUE(file_specs.contains(script_false_fspec));
 
-    EXPECT_EQ(file_specs[module_false_fspec], eLoadScriptFromSymFileFalse);
+    EXPECT_EQ(file_specs[script_false_fspec], eLoadScriptFromSymFileFalse);
   }
 
   {
     StreamString ss;
     auto file_specs = Platform::LocateExecutableScriptingResourcesFromSafePaths(
-        ss, module_true_fspec, *m_target_sp);
+        ss, script_true_fspec, *m_target_sp);
 
     ASSERT_EQ(file_specs.size(), 1u);
-    ASSERT_TRUE(file_specs.contains(module_true_fspec));
+    ASSERT_TRUE(file_specs.contains(script_true_fspec));
 
-    EXPECT_EQ(file_specs[module_true_fspec], eLoadScriptFromSymFileTrue);
+    EXPECT_EQ(file_specs[script_true_fspec], eLoadScriptFromSymFileTrue);
   }
 
   {
     StreamString ss;
     auto file_specs = Platform::LocateExecutableScriptingResourcesFromSafePaths(
-        ss, module_warn_fspec, *m_target_sp);
+        ss, script_warn_fspec, *m_target_sp);
 
     ASSERT_EQ(file_specs.size(), 1u);
-    ASSERT_TRUE(file_specs.contains(module_warn_fspec));
+    ASSERT_TRUE(file_specs.contains(script_warn_fspec));
 
-    EXPECT_EQ(file_specs[module_warn_fspec], eLoadScriptFromSymFileWarn);
+    EXPECT_EQ(file_specs[script_warn_fspec], eLoadScriptFromSymFileWarn);
   }
 
   {
     StreamString ss;
     auto file_specs = Platform::LocateExecutableScriptingResourcesFromSafePaths(
-        ss, module_trusted_fspec, *m_target_sp);
+        ss, script_trusted_fspec, *m_target_sp);
 
     ASSERT_EQ(file_specs.size(), 1u);
-    ASSERT_TRUE(file_specs.contains(module_trusted_fspec));
+    ASSERT_TRUE(file_specs.contains(script_trusted_fspec));
 
-    EXPECT_EQ(file_specs[module_trusted_fspec], eLoadScriptFromSymFileTrusted);
+    EXPECT_EQ(file_specs[script_trusted_fspec], eLoadScriptFromSymFileTrusted);
   }
 
   {
     StreamString ss;
     auto file_specs = Platform::LocateExecutableScriptingResourcesFromSafePaths(
-        ss, module_another_true_fspec, *m_target_sp);
+        ss, script_another_true_fspec, *m_target_sp);
 
     ASSERT_EQ(file_specs.size(), 1u);
-    ASSERT_TRUE(file_specs.contains(module_another_true_fspec));
+    ASSERT_TRUE(file_specs.contains(script_another_true_fspec));
 
-    EXPECT_EQ(file_specs[module_another_true_fspec],
+    EXPECT_EQ(file_specs[script_another_true_fspec],
               eLoadScriptFromSymFileTrue);
   }
 
   {
     StreamString ss;
     auto file_specs = Platform::LocateExecutableScriptingResourcesFromSafePaths(
-        ss, module_default_fspec, *m_target_sp);
+        ss, script_default_fspec, *m_target_sp);
 
     ASSERT_EQ(file_specs.size(), 1u);
-    ASSERT_TRUE(file_specs.contains(module_default_fspec));
+    ASSERT_TRUE(file_specs.contains(script_default_fspec));
 
-    EXPECT_EQ(file_specs[module_default_fspec], eLoadScriptFromSymFileTrusted);
+    EXPECT_EQ(file_specs[script_default_fspec], eLoadScriptFromSymFileTrusted);
   }
 }
 #endif // NDEBUG

--- a/lldb/unittests/Platform/PlatformTest.cpp
+++ b/lldb/unittests/Platform/PlatformTest.cpp
@@ -674,7 +674,10 @@ TEST_F(PlatformLocateSafePathTest,
 }
 
 TEST_F(PlatformLocateSafePathTest,
-       LocateScriptingResourcesFromSafePaths_AutoLoadModule_Multiple) {
+       LocateScriptingResourcesFromSafePaths_AutoLoadScriptsForModule) {
+  // Test that the LocateScriptingResourcesFromSafePaths API respects the
+  // target.auto-load-scripts-for-modules setting.
+
   m_target_sp->SetLoadScriptFromSymbolFile(eLoadScriptFromSymFileTrusted);
   TestingProperties::GetGlobalTestingProperties().AppendSafeAutoLoadPaths(
       FileSpec(m_tmp_root_dir));

--- a/lldb/unittests/Platform/PlatformTest.cpp
+++ b/lldb/unittests/Platform/PlatformTest.cpp
@@ -695,6 +695,25 @@ TEST_F(PlatformLocateSafePathTest,
   FileSpec module_false_fspec = setup_module("ModuleFalse");
   m_target_sp->SetAutoLoadScriptsForModule("ModuleFalse",
                                            eLoadScriptFromSymFileFalse);
+
+  FileSpec module_true_fspec = setup_module("ModuleTrue");
+  m_target_sp->SetAutoLoadScriptsForModule("ModuleTrue",
+                                           eLoadScriptFromSymFileTrue);
+
+  FileSpec module_warn_fspec = setup_module("ModuleWarn");
+  m_target_sp->SetAutoLoadScriptsForModule("ModuleWarn",
+                                           eLoadScriptFromSymFileWarn);
+
+  FileSpec module_trusted_fspec = setup_module("ModuleTrusted");
+  m_target_sp->SetAutoLoadScriptsForModule("ModuleTrusted",
+                                           eLoadScriptFromSymFileTrusted);
+
+  FileSpec module_another_true_fspec = setup_module("ModuleAnotherTrue");
+  m_target_sp->SetAutoLoadScriptsForModule("ModuleAnotherTrue",
+                                           eLoadScriptFromSymFileTrue);
+
+  FileSpec module_default_fspec = setup_module("ModuleDefault");
+
   {
     StreamString ss;
     auto file_specs = Platform::LocateExecutableScriptingResourcesFromSafePaths(
@@ -706,9 +725,6 @@ TEST_F(PlatformLocateSafePathTest,
     EXPECT_EQ(file_specs[module_false_fspec], eLoadScriptFromSymFileFalse);
   }
 
-  FileSpec module_true_fspec = setup_module("ModuleTrue");
-  m_target_sp->SetAutoLoadScriptsForModule("ModuleTrue",
-                                           eLoadScriptFromSymFileTrue);
   {
     StreamString ss;
     auto file_specs = Platform::LocateExecutableScriptingResourcesFromSafePaths(
@@ -720,9 +736,6 @@ TEST_F(PlatformLocateSafePathTest,
     EXPECT_EQ(file_specs[module_true_fspec], eLoadScriptFromSymFileTrue);
   }
 
-  FileSpec module_warn_fspec = setup_module("ModuleWarn");
-  m_target_sp->SetAutoLoadScriptsForModule("ModuleWarn",
-                                           eLoadScriptFromSymFileWarn);
   {
     StreamString ss;
     auto file_specs = Platform::LocateExecutableScriptingResourcesFromSafePaths(
@@ -734,9 +747,6 @@ TEST_F(PlatformLocateSafePathTest,
     EXPECT_EQ(file_specs[module_warn_fspec], eLoadScriptFromSymFileWarn);
   }
 
-  FileSpec module_trusted_fspec = setup_module("ModuleTrusted");
-  m_target_sp->SetAutoLoadScriptsForModule("ModuleTrusted",
-                                           eLoadScriptFromSymFileTrusted);
   {
     StreamString ss;
     auto file_specs = Platform::LocateExecutableScriptingResourcesFromSafePaths(
@@ -748,9 +758,6 @@ TEST_F(PlatformLocateSafePathTest,
     EXPECT_EQ(file_specs[module_trusted_fspec], eLoadScriptFromSymFileTrusted);
   }
 
-  FileSpec module_another_true_fspec = setup_module("ModuleAnotherTrue");
-  m_target_sp->SetAutoLoadScriptsForModule("ModuleAnotherTrue",
-                                           eLoadScriptFromSymFileTrue);
   {
     StreamString ss;
     auto file_specs = Platform::LocateExecutableScriptingResourcesFromSafePaths(
@@ -763,7 +770,6 @@ TEST_F(PlatformLocateSafePathTest,
               eLoadScriptFromSymFileTrue);
   }
 
-  FileSpec module_default_fspec = setup_module("ModuleDefault");
   {
     StreamString ss;
     auto file_specs = Platform::LocateExecutableScriptingResourcesFromSafePaths(


### PR DESCRIPTION
* Depends on: https://github.com/llvm/llvm-project/pull/189696

This is part of [this RFC](https://discourse.llvm.org/t/rfc-lldb-moving-libc-data-formatters-out-of-lldb/89591) which is about turning the libc++ data-formatters into auto-loadable Python scripts.

Eventually we want the Python data-formatters for `libc++` to be automatically loaded without requiring user opt-in (since that's how the builtin formatters have always worked and, in my opinion, we can't transition to an opt-in model if users have always had the data-formatters available). To do so we need a way to distinguish which modules we can *always* auto-load from safe-paths, and which require `target.load-script-from-symbol-file` to be set to `true`.

This patch adds a setting (`target.auto-load-modules`) that is a dictionary from module-name to the `LoadScriptFromSymFile` enum, indicating how the scripts for that module are to be loaded.

Making this a setting also means a user can disable any auto-loading by clearing it. By default the setting is currently empty. Eventually we'll want it to contain `libc++.1=true` (and possibly other names which the `libc++` dylib can commonly have).

**Considerations**:
* I thought about adding an `IsAutoLoadable` API to `FileSpec` and set it for those that can be auto-loaded. Then we wouldn't have to return two lists from `LocateExecutableScriptingResources`. I just felt like `FileSpec` was too high-level of a structure to hold such information so I opted for the `llvm::SmallDenseMap<FileSpec, LoadScriptFromSymFile>`. If people favour one approach over the other, I'm happy to reconsider

**AI Usage**:
* Used Claude to generate the unit-test cases and shell tests. Reviewed and cleaned them up myself.