### PR TITLE
[MLIR][DataFlow] Guard getTerminator() with mightHaveTerminator() check

### DIFF
--- a/mlir/lib/Analysis/DataFlow/DeadCodeAnalysis.cpp
+++ b/mlir/lib/Analysis/DataFlow/DeadCodeAnalysis.cpp
@@ -249,6 +249,7 @@ void DeadCodeAnalysis::initializeSymbolCallables(Operation *top) {
 static bool isRegionOrCallableReturn(Operation *op) {
   return op->getBlock() != nullptr && !op->getNumSuccessors() &&
          isa<RegionBranchOpInterface, CallableOpInterface>(op->getParentOp()) &&
+         op->getBlock()->mightHaveTerminator() &&
          op->getBlock()->getTerminator() == op;
 }
 

--- a/mlir/test/Analysis/DataFlow/test-dead-code-analysis-no-terminator.mlir
+++ b/mlir/test/Analysis/DataFlow/test-dead-code-analysis-no-terminator.mlir
@@ -1,0 +1,17 @@
+// RUN: mlir-opt --sccp %s | FileCheck %s
+
+// Regression test for https://github.com/llvm/llvm-project/issues/188408
+// DeadCodeAnalysis crashed when visiting a block inside a region with the
+// NoTerminator trait (e.g. acc.kernel_environment) because
+// isRegionOrCallableReturn called Block::getTerminator() without first
+// checking Block::mightHaveTerminator().
+
+// CHECK-LABEL: func.func @f
+func.func @f(%arg0: memref<8xi32>) {
+  acc.kernel_environment {
+    acc.compute_region {
+      acc.yield
+    } {origin = "acc.parallel"}
+  }
+  return
+}


### PR DESCRIPTION
`isRegionOrCallableReturn` in `DeadCodeAnalysis.cpp` called `Block::getTerminator()` without first checking
`Block::mightHaveTerminator()`. For regions with the `NoTerminator` trait (e.g. `acc.kernel_environment`), blocks do not have a terminator and `getTerminator()` asserts.

Add a `mightHaveTerminator()` guard before calling `getTerminator()`.

Fixes #188408

Assisted-by: Claude Code