### PR TITLE
[MLIR][Transform] Replace NDEBUG guard with LLVM_ENABLE_ABI_BREAKING_CHECKS for checkImplementsTransform

### DIFF
--- a/mlir/include/mlir/Dialect/Transform/IR/TransformDialect.h
+++ b/mlir/include/mlir/Dialect/Transform/IR/TransformDialect.h
@@ -66,7 +66,7 @@ protected:
       : TransformDialectDataBase(TypeID::get<DerivedTy>(), ctx) {}
 };
 
-#ifndef NDEBUG
+#if LLVM_ENABLE_ABI_BREAKING_CHECKS
 namespace detail {
 /// Asserts that the operations provided as template arguments implement the
 /// TransformOpInterface and MemoryEffectsOpInterface. This must be a dynamic
@@ -79,7 +79,7 @@ void checkImplementsTransformOpInterface(StringRef name, MLIRContext *context);
 void checkImplementsTransformHandleTypeInterface(TypeID typeID,
                                                  MLIRContext *context);
 } // namespace detail
-#endif // NDEBUG
+#endif // LLVM_ENABLE_ABI_BREAKING_CHECKS
 } // namespace transform
 } // namespace mlir
 
@@ -256,10 +256,10 @@ void TransformDialect::addOperationIfNotRegistered() {
       RegisteredOperationName::lookup(TypeID::get<OpTy>(), getContext());
   if (!opName) {
     addOperations<OpTy>();
-#ifndef NDEBUG
+#if LLVM_ENABLE_ABI_BREAKING_CHECKS
     StringRef name = OpTy::getOperationName();
     detail::checkImplementsTransformOpInterface(name, getContext());
-#endif // NDEBUG
+#endif // LLVM_ENABLE_ABI_BREAKING_CHECKS
     return;
   }
 
@@ -289,10 +289,10 @@ void TransformDialect::addTypeIfNotRegistered() {
       });
   addTypes<Type>();
 
-#ifndef NDEBUG
+#if LLVM_ENABLE_ABI_BREAKING_CHECKS
   detail::checkImplementsTransformHandleTypeInterface(TypeID::get<Type>(),
                                                       getContext());
-#endif // NDEBUG
+#endif // LLVM_ENABLE_ABI_BREAKING_CHECKS
 }
 
 template <typename DataTy>

--- a/mlir/lib/Dialect/Transform/IR/TransformDialect.cpp
+++ b/mlir/lib/Dialect/Transform/IR/TransformDialect.cpp
@@ -24,7 +24,7 @@ using namespace mlir;
 #define GET_ATTRDEF_CLASSES
 #include "mlir/Dialect/Transform/IR/TransformAttrs.cpp.inc"
 
-#ifndef NDEBUG
+#if LLVM_ENABLE_ABI_BREAKING_CHECKS
 void transform::detail::checkImplementsTransformOpInterface(
     StringRef name, MLIRContext *context) {
   // Since the operation is being inserted into the Transform dialect and the
@@ -61,7 +61,7 @@ void transform::detail::checkImplementsTransformHandleTypeInterface(
          "expected Transform dialect type to implement one of the three "
          "interfaces");
 }
-#endif // NDEBUG
+#endif // LLVM_ENABLE_ABI_BREAKING_CHECKS
 
 void transform::TransformDialect::initialize() {
   // Using the checked versions to enable the same assertions as for the ops


### PR DESCRIPTION
NDEBUG shouldn't be used for guarding ABI changes in header.

Fixes #186552

Assisted-by: Claude Code