### PR TITLE
[libc][docs] Fix POSIX basedefs links for nested headers

### DIFF
--- a/libc/utils/docgen/docgen.py
+++ b/libc/utils/docgen/docgen.py
@@ -149,6 +149,12 @@ def print_functions_rst(header: Header, functions: Dict):
             print("    -")
 
 
+def posix_basedefs_url(header: Header) -> str:
+    """Return the Open Group basedefs URL for a header."""
+    posix_header_name = header.name.replace("/", "_")
+    return f"https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/{posix_header_name}.html"
+
+
 def print_macros_rst(header: Header, macros: Dict):
     tbl_hdr = "Macros"
     print(tbl_hdr)
@@ -170,9 +176,7 @@ def print_macros_rst(header: Header, macros: Dict):
             print("    -")
 
         if "in-latest-posix" in macros[name]:
-            print(
-                f"    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/{header.name}.html>`__"
-            )
+            print(f"    - `POSIX.1-2024 <{posix_basedefs_url(header)}>`__")
         else:
             print("    -")
     print()


### PR DESCRIPTION
Fix broken POSIX basedefs links for nested headers in llvm-libc docs.

The docgen script currently emits paths like `sys/wait.h.html`, but the Open Group uses `sys_wait.h.html`, for example:
  - https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/sys_wait.h.html

This updates nested-header link generation while leaving flat headers unchanged.