### PR TITLE
[clang-doc] Flatten repeated @return and @brief comment arrays

### DIFF
--- a/clang-tools-extra/clang-doc/JSONGenerator.cpp
+++ b/clang-tools-extra/clang-doc/JSONGenerator.cpp
@@ -167,15 +167,15 @@ static void insertComment(Object &Description, json::Value &Comment,
   }
 
   auto DescriptionIt = Description.find(Key);
-
   if (DescriptionIt == Description.end()) {
-    auto CommentsArray = json::Array();
-    CommentsArray.push_back(Comment);
+    json::Array CommentsArray;
+    CommentsArray.push_back(std::move(Comment));
     Description[Key] = std::move(CommentsArray);
     Description["Has" + Key.str()] = true;
-  } else {
-    DescriptionIt->getSecond().getAsArray()->push_back(Comment);
+    return;
   }
+  json::Array &DestArray = *DescriptionIt->getSecond().getAsArray();
+  DestArray.push_back(std::move(Comment));
 }
 
 /// Takes the nested "Children" array from a comment Object.
@@ -200,6 +200,40 @@ static json::Value extractTextComments(Object *ParagraphComment) {
     ++ChildrenIt;
   }
   return ChildrenArray;
+}
+
+/// Extract text comments from a ParagraphComment and append them flat into
+/// the appropriate Description key for single-paragraph block commands.
+///
+/// Used for \\brief, \\return and their aliases, where every occurrence is
+/// logically one paragraph, so repeated uses should accumulate into a single
+/// flat array of text comments. The destination key is chosen from
+/// \p I.Name. If \p I.Name is not a recognized single-paragraph command,
+/// this is a no-op.
+static void extractTextComments(Object *ParagraphComment, Object &Description,
+                                const CommentInfo &I) {
+  StringRef Key;
+  if (I.Name == "brief" || I.Name == "short")
+    Key = "BriefComments";
+  else if (I.Name == "return" || I.Name == "returns" || I.Name == "result")
+    Key = "ReturnComments";
+  else
+    return;
+
+  json::Value Extracted = extractTextComments(ParagraphComment);
+  json::Array *Children = Extracted.getAsArray();
+  if (!Children || Children->empty())
+    return;
+
+  auto DescriptionIt = Description.find(Key);
+  if (DescriptionIt == Description.end()) {
+    Description[Key] = std::move(Extracted);
+    Description["Has" + Key.str()] = true;
+    return;
+  }
+  json::Array &DestArray = *DescriptionIt->getSecond().getAsArray();
+  for (auto &Element : *Children)
+    DestArray.push_back(std::move(Element));
 }
 
 static json::Value extractVerbatimComments(json::Array VerbatimLines) {
@@ -235,16 +269,13 @@ static Object serializeComment(const CommentInfo &I, Object &Description) {
   }
 
   case CommentKind::CK_BlockCommandComment: {
-    auto TextCommentsArray = extractTextComments(CARef.front().getAsObject());
-    if (I.Name == "brief")
-      insertComment(Description, TextCommentsArray, "BriefComments");
-    else if (I.Name == "return")
-      insertComment(Description, TextCommentsArray, "ReturnComments");
-    else if (I.Name == "throws" || I.Name == "throw") {
+    Object *Paragraph = CARef.front().getAsObject();
+    extractTextComments(Paragraph, Description, I);
+    if (I.Name == "throws" || I.Name == "throw") {
       json::Value ThrowsVal = Object();
       auto &ThrowsObj = *ThrowsVal.getAsObject();
       ThrowsObj["Exception"] = I.Args.front();
-      ThrowsObj["Children"] = TextCommentsArray;
+      ThrowsObj["Children"] = extractTextComments(Paragraph);
       insertComment(Description, ThrowsVal, "ThrowsComments");
     }
     return Obj;

--- a/clang-tools-extra/test/clang-doc/enum.cpp
+++ b/clang-tools-extra/test/clang-doc/enum.cpp
@@ -22,11 +22,9 @@
 // JSON-INDEX-NEXT:    {
 // JSON-INDEX-NEXT:      "Description": {
 // JSON-INDEX-NEXT:        "BriefComments": [
-// JSON-INDEX-NEXT:          [
-// JSON-INDEX-NEXT:            {
-// JSON-INDEX-NEXT:              "TextComment": "For specifying RGB colors"
-// JSON-INDEX-NEXT:            }
-// JSON-INDEX-NEXT:          ]
+// JSON-INDEX-NEXT:          {
+// JSON-INDEX-NEXT:            "TextComment": "For specifying RGB colors"
+// JSON-INDEX-NEXT:          }
 // JSON-INDEX-NEXT:        ],
 // JSON-INDEX-NEXT:        "HasBriefComments": true
 // JSON-INDEX-NEXT:      },
@@ -91,11 +89,9 @@
 // JSON-INDEX-NEXT:    {
 // JSON-INDEX-NEXT:      "Description": {
 // JSON-INDEX-NEXT:        "BriefComments": [
-// JSON-INDEX-NEXT:          [
-// JSON-INDEX-NEXT:            {
-// JSON-INDEX-NEXT:              "TextComment": "Shape Types"
-// JSON-INDEX-NEXT:            }
-// JSON-INDEX-NEXT:          ]
+// JSON-INDEX-NEXT:          {
+// JSON-INDEX-NEXT:            "TextComment": "Shape Types"
+// JSON-INDEX-NEXT:          }
 // JSON-INDEX-NEXT:        ],
 // JSON-INDEX-NEXT:        "HasBriefComments": true
 // JSON-INDEX-NEXT:      },
@@ -165,11 +161,9 @@
 // JSON-INDEX-NEXT:      },
 // JSON-INDEX-NEXT:      "Description": {
 // JSON-INDEX-NEXT:        "BriefComments": [
-// JSON-INDEX-NEXT:          [
-// JSON-INDEX-NEXT:            {
-// JSON-INDEX-NEXT:              "TextComment": "Specify the size"
-// JSON-INDEX-NEXT:            }
-// JSON-INDEX-NEXT:          ]
+// JSON-INDEX-NEXT:          {
+// JSON-INDEX-NEXT:            "TextComment": "Specify the size"
+// JSON-INDEX-NEXT:          }
 // JSON-INDEX-NEXT:        ],
 // JSON-INDEX-NEXT:        "HasBriefComments": true
 // JSON-INDEX-NEXT:      },
@@ -206,11 +200,9 @@
 // JSON-INDEX-NEXT:        {
 // JSON-INDEX-NEXT:          "Description": {
 // JSON-INDEX-NEXT:            "BriefComments": [
-// JSON-INDEX-NEXT:              [
-// JSON-INDEX-NEXT:                {
-// JSON-INDEX-NEXT:                  "TextComment": "A tennis ball."
-// JSON-INDEX-NEXT:                }
-// JSON-INDEX-NEXT:              ]
+// JSON-INDEX-NEXT:              {
+// JSON-INDEX-NEXT:                "TextComment": "A tennis ball."
+// JSON-INDEX-NEXT:              }
 // JSON-INDEX-NEXT:            ],
 // JSON-INDEX-NEXT:            "HasBriefComments": true
 // JSON-INDEX-NEXT:          },
@@ -247,11 +239,9 @@
 // JSON-INDEX-NEXT:      },
 // JSON-INDEX-NEXT:      "Description": {
 // JSON-INDEX-NEXT:        "BriefComments": [
-// JSON-INDEX-NEXT:          [
-// JSON-INDEX-NEXT:            {
-// JSON-INDEX-NEXT:              "TextComment": "Very long number"
-// JSON-INDEX-NEXT:            }
-// JSON-INDEX-NEXT:          ]
+// JSON-INDEX-NEXT:          {
+// JSON-INDEX-NEXT:            "TextComment": "Very long number"
+// JSON-INDEX-NEXT:          }
 // JSON-INDEX-NEXT:        ],
 // JSON-INDEX-NEXT:        "HasBriefComments": true
 // JSON-INDEX-NEXT:      },
@@ -763,11 +753,9 @@
 // JSON-VEHICLES-INDEX-NEXT:      {
 // JSON-VEHICLES-INDEX-NEXT:        "Description": {
 // JSON-VEHICLES-INDEX-NEXT:          "BriefComments": [
-// JSON-VEHICLES-INDEX-NEXT:            [
-// JSON-VEHICLES-INDEX-NEXT:              {
-// JSON-VEHICLES-INDEX-NEXT:                "TextComment": "specify type of car"
-// JSON-VEHICLES-INDEX-NEXT:              }
-// JSON-VEHICLES-INDEX-NEXT:            ]
+// JSON-VEHICLES-INDEX-NEXT:            {
+// JSON-VEHICLES-INDEX-NEXT:              "TextComment": "specify type of car"
+// JSON-VEHICLES-INDEX-NEXT:            }
 // JSON-VEHICLES-INDEX-NEXT:          ],
 // JSON-VEHICLES-INDEX-NEXT:          "HasBriefComments": true
 // JSON-VEHICLES-INDEX-NEXT:        },

--- a/clang-tools-extra/test/clang-doc/json/class.cpp
+++ b/clang-tools-extra/test/clang-doc/json/class.cpp
@@ -50,9 +50,8 @@ private:
 // CHECK-NEXT:    ],
 // CHECK-NEXT:    "Description": {
 // CHECK-NEXT:      "BriefComments": [
-// CHECK-NEXT:        [
-// CHECK-NEXT:          {
-// CHECK-NEXT:            "TextComment": "This is a brief description."
+// CHECK-NEXT:        {
+// CHECK-NEXT:          "TextComment": "This is a brief description."
 // CHECK:           "HasBriefComments": true,
 // CHECK-NEXT:      "HasParagraphComments": true,
 // CHECK-NEXT:      "ParagraphComments": [

--- a/clang-tools-extra/test/clang-doc/json/multiple-return-comments.cpp
+++ b/clang-tools-extra/test/clang-doc/json/multiple-return-comments.cpp
@@ -1,0 +1,30 @@
+// RUN: rm -rf %t && mkdir -p %t
+// RUN: clang-doc --output=%t --format=json --executor=standalone %s
+// RUN: FileCheck %s < %t/json/GlobalNamespace/index.json
+
+/// @brief Test function for multiple return comments
+///
+/// @return First return value description
+/// @return Second return value description
+int testMultipleReturns() {
+  return 42;
+}
+
+// CHECK:      "Functions": [
+// CHECK-NEXT:   {
+// CHECK:        "Description": {
+// CHECK:          "BriefComments": [
+// CHECK-NEXT:       {
+// CHECK-NEXT:         "TextComment": "Test function for multiple return comments"
+// CHECK-NEXT:       }
+// CHECK-NEXT:     ],
+// CHECK:          "HasReturnComments": true,
+// CHECK:          "ReturnComments": [
+// CHECK-NEXT:       {
+// CHECK-NEXT:         "TextComment": "First return value description"
+// CHECK-NEXT:       },
+// CHECK-NEXT:       {
+// CHECK-NEXT:         "TextComment": "Second return value description"
+// CHECK-NEXT:       }
+// CHECK-NEXT:     ]
+// CHECK:        }


### PR DESCRIPTION
Multiple occurrences of \return or \brief in a doc comment were emitted
as nested arrays in the JSON output instead of a single flat array.

Also handles \returns, \result (aliases for \return) and \short (alias
for \brief).

Fixes #169006
