### PR TITLE
Revert "[JumpThreading] Put a limit on the PHI nodes when duplicating a BB."

### DIFF
--- a/llvm/lib/Transforms/Scalar/JumpThreading.cpp
+++ b/llvm/lib/Transforms/Scalar/JumpThreading.cpp
@@ -96,11 +96,6 @@ ImplicationSearchThreshold(
            "condition to use to thread over a weaker condition"),
   cl::init(3), cl::Hidden);
 
-static cl::opt<unsigned> PhiDuplicateThreshold(
-    "jump-threading-phi-threshold",
-    cl::desc("Max PHIs in BB to duplicate for jump threading"), cl::init(76),
-    cl::Hidden);
-
 static cl::opt<bool> ThreadAcrossLoopHeaders(
     "jump-threading-across-loop-headers",
     cl::desc("Allow JumpThreading to thread across loop headers, for testing"),
@@ -430,23 +425,8 @@ static unsigned getJumpThreadDuplicationCost(const TargetTransformInfo *TTI,
                                              Instruction *StopAt,
                                              unsigned Threshold) {
   assert(StopAt->getParent() == BB && "Not an instruction from proper BB?");
-
-  // Do not duplicate the BB if it has a lot of PHI nodes.
-  // If a threadable chain is too long then the number of PHI nodes can add up,
-  // leading to a substantial increase in compile time when rewriting the SSA.
-  unsigned PhiCount = 0;
-  Instruction *FirstNonPHI = nullptr;
-  for (Instruction &I : *BB) {
-    if (!isa<PHINode>(&I)) {
-      FirstNonPHI = &I;
-      break;
-    }
-    if (++PhiCount > PhiDuplicateThreshold)
-      return ~0U;
-  }
-
   /// Ignore PHI nodes, these will be flattened when duplication happens.
-  BasicBlock::const_iterator I(FirstNonPHI);
+  BasicBlock::const_iterator I(BB->getFirstNonPHIIt());
 
   // FIXME: THREADING will delete values that are just used to compute the
   // branch, so they shouldn't count against the duplication cost.


### PR DESCRIPTION
This reverts commit 32755786e02083980e177841bda30560dddf7685.

https://github.com/llvm/llvm-project/pull/100281 has reduced the compile time from 12 min to 4 min. I think it justifies removing the limit.

Compile time: https://llvm-compile-time-tracker.com/compare.php?from=45d243df43ee57e68804862e3b37b2ac16be139e&to=9181e21f53e916742653ee92fa38d6789b7a525c&stat=instructions:u.