### PR TITLE
[CIR] Fix incorrect ConstArrayAttr trailing_zeros parsing

### DIFF
--- a/clang/lib/CIR/Dialect/IR/CIRAttrs.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRAttrs.cpp
@@ -616,13 +616,12 @@ Attribute ConstArrayAttr::parse(AsmParser &parser, Type type) {
   unsigned zeros = 0;
   if (parser.parseOptionalComma().succeeded()) {
     if (parser.parseOptionalKeyword("trailing_zeros").succeeded()) {
-      unsigned typeSize =
-          mlir::cast<cir::ArrayType>(resultTy.value()).getSize();
+      unsigned totalSize = mlir::cast<cir::ArrayType>(type).getSize();
       mlir::Attribute elts = resultVal.value();
       if (auto str = mlir::dyn_cast<mlir::StringAttr>(elts))
-        zeros = typeSize - str.size();
+        zeros = totalSize - str.size();
       else
-        zeros = typeSize - mlir::cast<mlir::ArrayAttr>(elts).size();
+        zeros = totalSize - mlir::cast<mlir::ArrayAttr>(elts).size();
     } else {
       return {};
     }
@@ -632,9 +631,9 @@ Attribute ConstArrayAttr::parse(AsmParser &parser, Type type) {
   if (parser.parseGreater())
     return {};
 
-  return parser.getChecked<ConstArrayAttr>(
-      parser.getCurrentLocation(), parser.getContext(), resultTy.value(),
-      resultVal.value(), zeros);
+  return parser.getChecked<ConstArrayAttr>(parser.getCurrentLocation(),
+                                           parser.getContext(), type,
+                                           resultVal.value(), zeros);
 }
 
 void ConstArrayAttr::print(AsmPrinter &printer) const {

--- a/clang/test/CIR/IR/string-trailing-zeros.cir
+++ b/clang/test/CIR/IR/string-trailing-zeros.cir
@@ -1,0 +1,20 @@
+// RUN: cir-opt %s --verify-roundtrip | FileCheck %s
+
+!s8i = !cir.int<s, 8>
+module {
+  cir.global "private" constant cir_private @__const.test.b = #cir.const_array<"qwe" : !cir.array<!s8i x 3>, trailing_zeros> : !cir.array<!s8i x 100>
+  // CHECK: cir.global "private" constant cir_private @__const.test.b = #cir.const_array<"qwe" : !cir.array<!s8i x 3>, trailing_zeros> : !cir.array<!s8i x 100>
+
+  cir.global "private" constant cir_private dso_local @".str" = #cir.const_array<"qwe" : !cir.array<!s8i x 3>, trailing_zeros> : !cir.array<!s8i x 4> {alignment = 1 : i64}
+  // CHECK: cir.global "private" constant cir_private dso_local @".str" = #cir.const_array<"qwe" : !cir.array<!s8i x 3>, trailing_zeros> : !cir.array<!s8i x 4> {alignment = 1 : i64}
+
+  cir.func @test_string_trailing_zeros() {
+    %2 = cir.get_global @".str" : !cir.ptr<!cir.array<!s8i x 4>>
+    %3 = cir.get_global @__const.test.b : !cir.ptr<!cir.array<!s8i x 100>>
+    cir.return
+  }
+  // CHECK: cir.func @test_string_trailing_zeros()
+  // CHECK:   %{{.*}} = cir.get_global @".str" : !cir.ptr<!cir.array<!s8i x 4>>
+  // CHECK:   %{{.*}} = cir.get_global @__const.test.b : !cir.ptr<!cir.array<!s8i x 100>>
+  // CHECK:   cir.return
+}


### PR DESCRIPTION
Closes #187699 .

Fix incorrect parsing of `ConstArrayAttr`. `parse` method incorrectly used type of `elts` parameter as type of the whole array. This means that when reading back text or bytecode clangir files attribute did not have correct type and correct `trailingZerosNum`. Type was always of inner `elts`, meaning smaller then  actual type if any trailing zeros were present and `trailingZerosNum` was always zero.