### PR TITLE
[CodeGen] Fix profiled triangular CFG threshold in MachineBlockPlacement

### DIFF
--- a/llvm/lib/CodeGen/MachineBlockPlacement.cpp
+++ b/llvm/lib/CodeGen/MachineBlockPlacement.cpp
@@ -1452,11 +1452,22 @@ getLayoutSuccessorProbThreshold(const MachineBasicBlock *BB) {
        *   So the threshold T in the calculation below
        *   (1-T) * Prob(BB->Succ) > T * Prob(BB->Pred)
        *   So T / (1 - T) = 2, Yielding T = 2/3
-       * Also adding user specified branch bias, we have
-       *   T = (2/3)*(ProfileLikelyProb/50)
-       *     = (2*ProfileLikelyProb)/150)
+       *
+       * We then remap the user-controlled ProfileLikelyProb into
+       * a triangle-specific threshold T. We use a piecewise-linear mapping:
+       * - for ProfileLikelyProb in [0, 50], map linearly from 0 to 2/3;
+       *   T = (2/3) * (ProfileLikelyProb / 50)
+       *     = (2 * ProfileLikelyProb) / 150
+       * - for ProfileLikelyProb in [50, 100], map linearly from 2/3 to 1.
+       *   T = 1/3 + (2/3) * (ProfileLikelyProb / 100)
+       *     = (100 + 2 * ProfileLikelyProb) / 300
+       *
+       * This keeps T in [0, 1] and preserves T = 2/3 at ProfileLikelyProb = 50.
        */
-      return BranchProbability(2 * ProfileLikelyProb, 150);
+      if (ProfileLikelyProb <= 50)
+        return BranchProbability(2 * ProfileLikelyProb, 150);
+      else
+        return BranchProbability(100 + 2 * ProfileLikelyProb, 300);
     }
   }
   return BranchProbability(ProfileLikelyProb, 100);

--- a/llvm/lib/CodeGen/MachineBlockPlacement.cpp
+++ b/llvm/lib/CodeGen/MachineBlockPlacement.cpp
@@ -1453,21 +1453,14 @@ getLayoutSuccessorProbThreshold(const MachineBasicBlock *BB) {
        *   (1-T) * Prob(BB->Succ) > T * Prob(BB->Pred)
        *   So T / (1 - T) = 2, Yielding T = 2/3
        *
-       * We then remap the user-controlled ProfileLikelyProb into
-       * a triangle-specific threshold T. We use a piecewise-linear mapping:
-       * - for ProfileLikelyProb in [0, 50], map linearly from 0 to 2/3;
+       * Then remap the user-controlled ProfileLikelyProb into 
+       * a triangle-specific threshold T. 
        *   T = (2/3) * (ProfileLikelyProb / 50)
        *     = (2 * ProfileLikelyProb) / 150
-       * - for ProfileLikelyProb in [50, 100], map linearly from 2/3 to 1.
-       *   T = 1/3 + (2/3) * (ProfileLikelyProb / 100)
-       *     = (100 + 2 * ProfileLikelyProb) / 300
-       *
-       * This keeps T in [0, 1] and preserves T = 2/3 at ProfileLikelyProb = 50.
+       * This preserves T = 2/3 at ProfileLikelyProb = 50.
+       * The result is capped at 1.
        */
-      if (ProfileLikelyProb <= 50)
-        return BranchProbability(2 * ProfileLikelyProb, 150);
-      else
-        return BranchProbability(100 + 2 * ProfileLikelyProb, 300);
+      return BranchProbability(ProfileLikelyProb, 150) * 2;
     }
   }
   return BranchProbability(ProfileLikelyProb, 100);

--- a/llvm/lib/CodeGen/MachineBlockPlacement.cpp
+++ b/llvm/lib/CodeGen/MachineBlockPlacement.cpp
@@ -1453,8 +1453,8 @@ getLayoutSuccessorProbThreshold(const MachineBasicBlock *BB) {
        *   (1-T) * Prob(BB->Succ) > T * Prob(BB->Pred)
        *   So T / (1 - T) = 2, Yielding T = 2/3
        *
-       * Then remap the user-controlled ProfileLikelyProb into 
-       * a triangle-specific threshold T. 
+       * Then remap the user-controlled ProfileLikelyProb into
+       * a triangle-specific threshold T.
        *   T = (2/3) * (ProfileLikelyProb / 50)
        *     = (2 * ProfileLikelyProb) / 150
        * This preserves T = 2/3 at ProfileLikelyProb = 50.

--- a/llvm/test/CodeGen/X86/block-placement-triangle-profile-likely-prob.mir
+++ b/llvm/test/CodeGen/X86/block-placement-triangle-profile-likely-prob.mir
@@ -4,12 +4,7 @@
 # Verify that a large ProfileLikelyProb value does not fail compilation
 
 --- |
-  ; ModuleID = 'triangle.ll'
-  source_filename = "triangle.c"
-  target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-  target triple = "x86_64-unknown-linux-gnu"
-
-  define dso_local i32 @main(i32 %argc, ptr %argv) #0 !prof !0 {
+  define i32 @main(i32 %argc, ptr %argv) #0 !prof !0 {
   entry:
     %cmp = icmp sgt i32 %argc, 1
     br i1 %cmp, label %pred, label %succ, !prof !1

--- a/llvm/test/CodeGen/X86/block-placement-triangle-profile-likely-prob.mir
+++ b/llvm/test/CodeGen/X86/block-placement-triangle-profile-likely-prob.mir
@@ -1,0 +1,57 @@
+# RUN: llc -mtriple=x86_64-unknown-linux-gnu -run-pass=block-placement -profile-likely-prob=80 %s -o - | FileCheck %s
+#
+# Test for profiled triangular CFG handling in MachineBlockPlacement
+# Verify that a large ProfileLikelyProb value does not fail compilation
+
+--- |
+  ; ModuleID = 'triangle.ll'
+  source_filename = "triangle.c"
+  target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
+  target triple = "x86_64-unknown-linux-gnu"
+
+  define dso_local i32 @main(i32 %argc, ptr %argv) #0 !prof !0 {
+  entry:
+    %cmp = icmp sgt i32 %argc, 1
+    br i1 %cmp, label %pred, label %succ, !prof !1
+
+  succ:
+    ret i32 0
+
+  pred:
+    br label %succ
+  }
+
+  attributes #0 = { nounwind "use-sample-profile" }
+
+  !0 = !{!"function_entry_count", i64 1}
+  !1 = !{!"branch_weights", i32 0, i32 1}
+...
+---
+name:            main
+alignment:       1
+tracksRegLiveness: true
+noPhis:          true
+isSSA:           false
+noVRegs:         true
+liveins:
+  - { reg: '$edi', virtual-reg: '' }
+body:             |
+  bb.0.entry:
+    successors: %bb.1(0x00000000), %bb.2(0x80000000)
+    liveins: $edi
+
+    CMP32ri killed renamable $edi, 1, implicit-def $eflags
+    JCC_1 %bb.2, 15, implicit killed $eflags
+
+  bb.1.succ:
+    $eax = MOV32ri 0
+    RET64 $eax
+
+  bb.2.pred:
+    successors: %bb.1(0x80000000)
+
+    JMP_1 %bb.1
+...
+
+# CHECK: name: main
+# CHECK: bb.0.entry

--- a/llvm/test/CodeGen/X86/block-placement-triangle-profile-likely-prob.mir
+++ b/llvm/test/CodeGen/X86/block-placement-triangle-profile-likely-prob.mir
@@ -49,4 +49,11 @@ body:             |
 ...
 
 # CHECK: name: main
-# CHECK: bb.0.entry
+# CHECK: bb.0.entry:
+# CHECK: successors: %bb.1
+# CHECK-SAME: %bb.2
+# CHECK: JCC_1 %bb.1
+# CHECK: bb.2.pred:
+# CHECK: successors: %bb.1
+# CHECK: bb.1.succ:
+# CHECK: RET64

--- a/llvm/test/CodeGen/X86/block-placement-triangle-profile-likely-prob.mir
+++ b/llvm/test/CodeGen/X86/block-placement-triangle-profile-likely-prob.mir
@@ -57,3 +57,4 @@ body:             |
 # CHECK: successors: %bb.1
 # CHECK: bb.1.succ:
 # CHECK: RET64
+


### PR DESCRIPTION
Fix an assertion failure in MachineBlockPlacement for profiled triangular CFGs with large -profile-likely-prob values.

The existing triangular-CFG threshold scaling can produce a BranchProbability greater than 1. Capping to `BranchProbability(100, 100)` added.
