### PR TITLE
[lldb] Reduce the number of arguments to MemoryRegionInfo constructor

### DIFF
--- a/lldb/include/lldb/Target/MemoryRegionInfo.h
+++ b/lldb/include/lldb/Target/MemoryRegionInfo.h
@@ -27,11 +27,9 @@ public:
   MemoryRegionInfo() = default;
   MemoryRegionInfo(RangeType range, OptionalBool read, OptionalBool write,
                    OptionalBool execute, OptionalBool shared,
-                   OptionalBool mapped, ConstString name, OptionalBool flash,
-                   lldb::offset_t blocksize)
+                   OptionalBool mapped, ConstString name)
       : m_range(range), m_read(read), m_write(write), m_execute(execute),
-        m_shared(shared), m_mapped(mapped), m_name(name), m_flash(flash),
-        m_blocksize(blocksize) {}
+        m_shared(shared), m_mapped(mapped), m_name(name) {}
 
   RangeType &GetRange() { return m_range; }
 

--- a/lldb/include/lldb/Target/MemoryRegionInfo.h
+++ b/lldb/include/lldb/Target/MemoryRegionInfo.h
@@ -29,11 +29,11 @@ public:
                    OptionalBool execute, OptionalBool shared,
                    OptionalBool mapped, ConstString name, OptionalBool flash,
                    lldb::offset_t blocksize, OptionalBool memory_tagged,
-                   OptionalBool stack_memory, OptionalBool shadow_stack)
+                   OptionalBool stack_memory)
       : m_range(range), m_read(read), m_write(write), m_execute(execute),
         m_shared(shared), m_mapped(mapped), m_name(name), m_flash(flash),
         m_blocksize(blocksize), m_memory_tagged(memory_tagged),
-        m_is_stack_memory(stack_memory), m_is_shadow_stack(shadow_stack) {}
+        m_is_stack_memory(stack_memory) {}
 
   RangeType &GetRange() { return m_range; }
 
@@ -79,7 +79,10 @@ public:
 
   void SetMemoryTagged(OptionalBool val) { m_memory_tagged = val; }
 
-  void SetIsShadowStack(OptionalBool val) { m_is_shadow_stack = val; }
+  MemoryRegionInfo &SetIsShadowStack(OptionalBool val) {
+    m_is_shadow_stack = val;
+    return *this;
+  }
 
   // Get permissions as a uint32_t that is a mask of one or more bits from the
   // lldb::Permissions

--- a/lldb/include/lldb/Target/MemoryRegionInfo.h
+++ b/lldb/include/lldb/Target/MemoryRegionInfo.h
@@ -28,10 +28,10 @@ public:
   MemoryRegionInfo(RangeType range, OptionalBool read, OptionalBool write,
                    OptionalBool execute, OptionalBool shared,
                    OptionalBool mapped, ConstString name, OptionalBool flash,
-                   lldb::offset_t blocksize, OptionalBool memory_tagged)
+                   lldb::offset_t blocksize)
       : m_range(range), m_read(read), m_write(write), m_execute(execute),
         m_shared(shared), m_mapped(mapped), m_name(name), m_flash(flash),
-        m_blocksize(blocksize), m_memory_tagged(memory_tagged) {}
+        m_blocksize(blocksize) {}
 
   RangeType &GetRange() { return m_range; }
 
@@ -75,7 +75,10 @@ public:
 
   void SetBlocksize(lldb::offset_t blocksize) { m_blocksize = blocksize; }
 
-  void SetMemoryTagged(OptionalBool val) { m_memory_tagged = val; }
+  MemoryRegionInfo &SetMemoryTagged(OptionalBool val) {
+    m_memory_tagged = val;
+    return *this;
+  }
 
   MemoryRegionInfo &SetIsShadowStack(OptionalBool val) {
     m_is_shadow_stack = val;

--- a/lldb/include/lldb/Target/MemoryRegionInfo.h
+++ b/lldb/include/lldb/Target/MemoryRegionInfo.h
@@ -28,12 +28,10 @@ public:
   MemoryRegionInfo(RangeType range, OptionalBool read, OptionalBool write,
                    OptionalBool execute, OptionalBool shared,
                    OptionalBool mapped, ConstString name, OptionalBool flash,
-                   lldb::offset_t blocksize, OptionalBool memory_tagged,
-                   OptionalBool stack_memory)
+                   lldb::offset_t blocksize, OptionalBool memory_tagged)
       : m_range(range), m_read(read), m_write(write), m_execute(execute),
         m_shared(shared), m_mapped(mapped), m_name(name), m_flash(flash),
-        m_blocksize(blocksize), m_memory_tagged(memory_tagged),
-        m_is_stack_memory(stack_memory) {}
+        m_blocksize(blocksize), m_memory_tagged(memory_tagged) {}
 
   RangeType &GetRange() { return m_range; }
 

--- a/lldb/unittests/Process/Utility/LinuxProcMapsTest.cpp
+++ b/lldb/unittests/Process/Utility/LinuxProcMapsTest.cpp
@@ -87,12 +87,12 @@ INSTANTIATE_TEST_SUITE_P(
             "0-0 rwzp 00000000 00:00 0\n"
             "2-3 r-xp 00000000 00:00 0 [def]\n",
             MemoryRegionInfos{
-                MemoryRegionInfo(
-                    make_range(0, 1), MemoryRegionInfo::eYes,
-                    MemoryRegionInfo::eYes, MemoryRegionInfo::eNo,
-                    MemoryRegionInfo::eNo, MemoryRegionInfo::eYes,
-                    ConstString("[abc]"), MemoryRegionInfo::eDontKnow, 0,
-                    MemoryRegionInfo::eDontKnow, MemoryRegionInfo::eDontKnow),
+                MemoryRegionInfo(make_range(0, 1), MemoryRegionInfo::eYes,
+                                 MemoryRegionInfo::eYes, MemoryRegionInfo::eNo,
+                                 MemoryRegionInfo::eNo, MemoryRegionInfo::eYes,
+                                 ConstString("[abc]"),
+                                 MemoryRegionInfo::eDontKnow, 0,
+                                 MemoryRegionInfo::eDontKnow),
             },
             "unexpected /proc/{pid}/maps exec permission char"),
         // Single entry
@@ -104,7 +104,6 @@ INSTANTIATE_TEST_SUITE_P(
                                  MemoryRegionInfo::eNo, MemoryRegionInfo::eNo,
                                  MemoryRegionInfo::eYes, ConstString("[heap]"),
                                  MemoryRegionInfo::eDontKnow, 0,
-                                 MemoryRegionInfo::eDontKnow,
                                  MemoryRegionInfo::eDontKnow),
             },
             ""),
@@ -120,21 +119,19 @@ INSTANTIATE_TEST_SUITE_P(
                                  MemoryRegionInfo::eNo, MemoryRegionInfo::eNo,
                                  MemoryRegionInfo::eYes, ConstString(nullptr),
                                  MemoryRegionInfo::eDontKnow, 0,
-                                 MemoryRegionInfo::eDontKnow,
                                  MemoryRegionInfo::eDontKnow),
                 MemoryRegionInfo(make_range(0x7fc094000000, 0x7fc094a00000),
                                  MemoryRegionInfo::eNo, MemoryRegionInfo::eNo,
                                  MemoryRegionInfo::eNo, MemoryRegionInfo::eYes,
                                  MemoryRegionInfo::eYes, ConstString(nullptr),
                                  MemoryRegionInfo::eDontKnow, 0,
-                                 MemoryRegionInfo::eDontKnow,
                                  MemoryRegionInfo::eDontKnow),
                 MemoryRegionInfo(
                     make_range(0xffffffffff600000, 0xffffffffff601000),
                     MemoryRegionInfo::eYes, MemoryRegionInfo::eNo,
                     MemoryRegionInfo::eYes, MemoryRegionInfo::eNo,
                     MemoryRegionInfo::eYes, ConstString("[vsyscall]"),
-                    MemoryRegionInfo::eDontKnow, 0, MemoryRegionInfo::eDontKnow,
+                    MemoryRegionInfo::eDontKnow, 0,
                     MemoryRegionInfo::eDontKnow),
             },
             "")));
@@ -156,12 +153,12 @@ INSTANTIATE_TEST_SUITE_P(
             "1111-2222 rw-p 00000000 00:00 0 [foo]\n"
             "0/0 rw-p 00000000 00:00 0",
             MemoryRegionInfos{
-                MemoryRegionInfo(
-                    make_range(0x1111, 0x2222), MemoryRegionInfo::eYes,
-                    MemoryRegionInfo::eYes, MemoryRegionInfo::eNo,
-                    MemoryRegionInfo::eNo, MemoryRegionInfo::eYes,
-                    ConstString("[foo]"), MemoryRegionInfo::eDontKnow, 0,
-                    MemoryRegionInfo::eDontKnow, MemoryRegionInfo::eDontKnow),
+                MemoryRegionInfo(make_range(0x1111, 0x2222),
+                                 MemoryRegionInfo::eYes, MemoryRegionInfo::eYes,
+                                 MemoryRegionInfo::eNo, MemoryRegionInfo::eNo,
+                                 MemoryRegionInfo::eYes, ConstString("[foo]"),
+                                 MemoryRegionInfo::eDontKnow, 0,
+                                 MemoryRegionInfo::eDontKnow),
             },
             "malformed /proc/{pid}/smaps entry, missing dash between address "
             "range"),
@@ -176,24 +173,24 @@ INSTANTIATE_TEST_SUITE_P(
         std::make_tuple(
             "1111-2222 rw-p 00000000 00:00 0    [foo]",
             MemoryRegionInfos{
-                MemoryRegionInfo(
-                    make_range(0x1111, 0x2222), MemoryRegionInfo::eYes,
-                    MemoryRegionInfo::eYes, MemoryRegionInfo::eNo,
-                    MemoryRegionInfo::eNo, MemoryRegionInfo::eYes,
-                    ConstString("[foo]"), MemoryRegionInfo::eDontKnow, 0,
-                    MemoryRegionInfo::eDontKnow, MemoryRegionInfo::eDontKnow),
+                MemoryRegionInfo(make_range(0x1111, 0x2222),
+                                 MemoryRegionInfo::eYes, MemoryRegionInfo::eYes,
+                                 MemoryRegionInfo::eNo, MemoryRegionInfo::eNo,
+                                 MemoryRegionInfo::eYes, ConstString("[foo]"),
+                                 MemoryRegionInfo::eDontKnow, 0,
+                                 MemoryRegionInfo::eDontKnow),
             },
             ""),
         // Single shared region parses, has no flags
         std::make_tuple(
             "1111-2222 rw-s 00000000 00:00 0    [foo]",
             MemoryRegionInfos{
-                MemoryRegionInfo(
-                    make_range(0x1111, 0x2222), MemoryRegionInfo::eYes,
-                    MemoryRegionInfo::eYes, MemoryRegionInfo::eNo,
-                    MemoryRegionInfo::eYes, MemoryRegionInfo::eYes,
-                    ConstString("[foo]"), MemoryRegionInfo::eDontKnow, 0,
-                    MemoryRegionInfo::eDontKnow, MemoryRegionInfo::eDontKnow),
+                MemoryRegionInfo(make_range(0x1111, 0x2222),
+                                 MemoryRegionInfo::eYes, MemoryRegionInfo::eYes,
+                                 MemoryRegionInfo::eNo, MemoryRegionInfo::eYes,
+                                 MemoryRegionInfo::eYes, ConstString("[foo]"),
+                                 MemoryRegionInfo::eDontKnow, 0,
+                                 MemoryRegionInfo::eDontKnow),
             },
             ""),
         // Single region with flags, other lines ignored
@@ -203,12 +200,12 @@ INSTANTIATE_TEST_SUITE_P(
             "AnonHugePages:         0 kB\n"
             "VmFlags: mt",
             MemoryRegionInfos{
-                MemoryRegionInfo(
-                    make_range(0x1111, 0x2222), MemoryRegionInfo::eYes,
-                    MemoryRegionInfo::eYes, MemoryRegionInfo::eNo,
-                    MemoryRegionInfo::eNo, MemoryRegionInfo::eYes,
-                    ConstString("[foo]"), MemoryRegionInfo::eDontKnow, 0,
-                    MemoryRegionInfo::eYes, MemoryRegionInfo::eDontKnow)
+                MemoryRegionInfo(make_range(0x1111, 0x2222),
+                                 MemoryRegionInfo::eYes, MemoryRegionInfo::eYes,
+                                 MemoryRegionInfo::eNo, MemoryRegionInfo::eNo,
+                                 MemoryRegionInfo::eYes, ConstString("[foo]"),
+                                 MemoryRegionInfo::eDontKnow, 0,
+                                 MemoryRegionInfo::eYes)
                     .SetIsShadowStack(MemoryRegionInfo::eNo),
             },
             ""),
@@ -217,12 +214,12 @@ INSTANTIATE_TEST_SUITE_P(
             "0-0 rw-p 00000000 00:00 0\n"
             "VmFlags:      mt      ",
             MemoryRegionInfos{
-                MemoryRegionInfo(
-                    make_range(0, 0), MemoryRegionInfo::eYes,
-                    MemoryRegionInfo::eYes, MemoryRegionInfo::eNo,
-                    MemoryRegionInfo::eNo, MemoryRegionInfo::eYes,
-                    ConstString(nullptr), MemoryRegionInfo::eDontKnow, 0,
-                    MemoryRegionInfo::eYes, MemoryRegionInfo::eDontKnow)
+                MemoryRegionInfo(make_range(0, 0), MemoryRegionInfo::eYes,
+                                 MemoryRegionInfo::eYes, MemoryRegionInfo::eNo,
+                                 MemoryRegionInfo::eNo, MemoryRegionInfo::eYes,
+                                 ConstString(nullptr),
+                                 MemoryRegionInfo::eDontKnow, 0,
+                                 MemoryRegionInfo::eYes)
                     .SetIsShadowStack(MemoryRegionInfo::eNo),
             },
             ""),
@@ -231,12 +228,12 @@ INSTANTIATE_TEST_SUITE_P(
             "0-0 rw-p 00000000 00:00 0\n"
             "VmFlags:         ",
             MemoryRegionInfos{
-                MemoryRegionInfo(
-                    make_range(0, 0), MemoryRegionInfo::eYes,
-                    MemoryRegionInfo::eYes, MemoryRegionInfo::eNo,
-                    MemoryRegionInfo::eNo, MemoryRegionInfo::eYes,
-                    ConstString(nullptr), MemoryRegionInfo::eDontKnow, 0,
-                    MemoryRegionInfo::eNo, MemoryRegionInfo::eDontKnow)
+                MemoryRegionInfo(make_range(0, 0), MemoryRegionInfo::eYes,
+                                 MemoryRegionInfo::eYes, MemoryRegionInfo::eNo,
+                                 MemoryRegionInfo::eNo, MemoryRegionInfo::eYes,
+                                 ConstString(nullptr),
+                                 MemoryRegionInfo::eDontKnow, 0,
+                                 MemoryRegionInfo::eNo)
                     .SetIsShadowStack(MemoryRegionInfo::eNo),
             },
             ""),
@@ -248,18 +245,18 @@ INSTANTIATE_TEST_SUITE_P(
             "3333-4444 r-xp 00000000 00:00 0    [bar]\n"
             "VmFlags: mt",
             MemoryRegionInfos{
-                MemoryRegionInfo(
-                    make_range(0x1111, 0x2222), MemoryRegionInfo::eYes,
-                    MemoryRegionInfo::eYes, MemoryRegionInfo::eNo,
-                    MemoryRegionInfo::eNo, MemoryRegionInfo::eYes,
-                    ConstString("[foo]"), MemoryRegionInfo::eDontKnow, 0,
-                    MemoryRegionInfo::eDontKnow, MemoryRegionInfo::eDontKnow),
-                MemoryRegionInfo(
-                    make_range(0x3333, 0x4444), MemoryRegionInfo::eYes,
-                    MemoryRegionInfo::eNo, MemoryRegionInfo::eYes,
-                    MemoryRegionInfo::eNo, MemoryRegionInfo::eYes,
-                    ConstString("[bar]"), MemoryRegionInfo::eDontKnow, 0,
-                    MemoryRegionInfo::eYes, MemoryRegionInfo::eDontKnow)
+                MemoryRegionInfo(make_range(0x1111, 0x2222),
+                                 MemoryRegionInfo::eYes, MemoryRegionInfo::eYes,
+                                 MemoryRegionInfo::eNo, MemoryRegionInfo::eNo,
+                                 MemoryRegionInfo::eYes, ConstString("[foo]"),
+                                 MemoryRegionInfo::eDontKnow, 0,
+                                 MemoryRegionInfo::eDontKnow),
+                MemoryRegionInfo(make_range(0x3333, 0x4444),
+                                 MemoryRegionInfo::eYes, MemoryRegionInfo::eNo,
+                                 MemoryRegionInfo::eYes, MemoryRegionInfo::eNo,
+                                 MemoryRegionInfo::eYes, ConstString("[bar]"),
+                                 MemoryRegionInfo::eDontKnow, 0,
+                                 MemoryRegionInfo::eYes)
                     .SetIsShadowStack(MemoryRegionInfo::eNo),
             },
             ""),
@@ -272,18 +269,18 @@ INSTANTIATE_TEST_SUITE_P(
             "KernelPageSize:        4 kB\n"
             "MMUPageSize:           4 kB\n",
             MemoryRegionInfos{
-                MemoryRegionInfo(
-                    make_range(0x1111, 0x2222), MemoryRegionInfo::eYes,
-                    MemoryRegionInfo::eYes, MemoryRegionInfo::eNo,
-                    MemoryRegionInfo::eNo, MemoryRegionInfo::eYes,
-                    ConstString(nullptr), MemoryRegionInfo::eDontKnow, 0,
-                    MemoryRegionInfo::eDontKnow, MemoryRegionInfo::eDontKnow),
-                MemoryRegionInfo(
-                    make_range(0x3333, 0x4444), MemoryRegionInfo::eYes,
-                    MemoryRegionInfo::eNo, MemoryRegionInfo::eYes,
-                    MemoryRegionInfo::eNo, MemoryRegionInfo::eYes,
-                    ConstString(nullptr), MemoryRegionInfo::eDontKnow, 0,
-                    MemoryRegionInfo::eDontKnow, MemoryRegionInfo::eDontKnow),
+                MemoryRegionInfo(make_range(0x1111, 0x2222),
+                                 MemoryRegionInfo::eYes, MemoryRegionInfo::eYes,
+                                 MemoryRegionInfo::eNo, MemoryRegionInfo::eNo,
+                                 MemoryRegionInfo::eYes, ConstString(nullptr),
+                                 MemoryRegionInfo::eDontKnow, 0,
+                                 MemoryRegionInfo::eDontKnow),
+                MemoryRegionInfo(make_range(0x3333, 0x4444),
+                                 MemoryRegionInfo::eYes, MemoryRegionInfo::eNo,
+                                 MemoryRegionInfo::eYes, MemoryRegionInfo::eNo,
+                                 MemoryRegionInfo::eYes, ConstString(nullptr),
+                                 MemoryRegionInfo::eDontKnow, 0,
+                                 MemoryRegionInfo::eDontKnow),
             },
             ""),
         // We must look for exact flag strings, ignoring substrings of longer
@@ -292,12 +289,12 @@ INSTANTIATE_TEST_SUITE_P(
             "0-0 rw-p 00000000 00:00 0\n"
             "VmFlags: amt mtb amtb",
             MemoryRegionInfos{
-                MemoryRegionInfo(
-                    make_range(0, 0), MemoryRegionInfo::eYes,
-                    MemoryRegionInfo::eYes, MemoryRegionInfo::eNo,
-                    MemoryRegionInfo::eNo, MemoryRegionInfo::eYes,
-                    ConstString(nullptr), MemoryRegionInfo::eDontKnow, 0,
-                    MemoryRegionInfo::eNo, MemoryRegionInfo::eDontKnow)
+                MemoryRegionInfo(make_range(0, 0), MemoryRegionInfo::eYes,
+                                 MemoryRegionInfo::eYes, MemoryRegionInfo::eNo,
+                                 MemoryRegionInfo::eNo, MemoryRegionInfo::eYes,
+                                 ConstString(nullptr),
+                                 MemoryRegionInfo::eDontKnow, 0,
+                                 MemoryRegionInfo::eNo)
                     .SetIsShadowStack(MemoryRegionInfo::eNo),
             },
             ""),
@@ -306,12 +303,12 @@ INSTANTIATE_TEST_SUITE_P(
             "0-0 rw-p 00000000 00:00 0\n"
             "VmFlags: ss",
             MemoryRegionInfos{
-                MemoryRegionInfo(
-                    make_range(0, 0), MemoryRegionInfo::eYes,
-                    MemoryRegionInfo::eYes, MemoryRegionInfo::eNo,
-                    MemoryRegionInfo::eNo, MemoryRegionInfo::eYes,
-                    ConstString(nullptr), MemoryRegionInfo::eDontKnow, 0,
-                    MemoryRegionInfo::eNo, MemoryRegionInfo::eDontKnow)
+                MemoryRegionInfo(make_range(0, 0), MemoryRegionInfo::eYes,
+                                 MemoryRegionInfo::eYes, MemoryRegionInfo::eNo,
+                                 MemoryRegionInfo::eNo, MemoryRegionInfo::eYes,
+                                 ConstString(nullptr),
+                                 MemoryRegionInfo::eDontKnow, 0,
+                                 MemoryRegionInfo::eNo)
                     .SetIsShadowStack(MemoryRegionInfo::eYes),
             },
             "")));

--- a/lldb/unittests/Process/Utility/LinuxProcMapsTest.cpp
+++ b/lldb/unittests/Process/Utility/LinuxProcMapsTest.cpp
@@ -90,8 +90,7 @@ INSTANTIATE_TEST_SUITE_P(
                 MemoryRegionInfo(make_range(0, 1), MemoryRegionInfo::eYes,
                                  MemoryRegionInfo::eYes, MemoryRegionInfo::eNo,
                                  MemoryRegionInfo::eNo, MemoryRegionInfo::eYes,
-                                 ConstString("[abc]"),
-                                 MemoryRegionInfo::eDontKnow, 0),
+                                 ConstString("[abc]")),
             },
             "unexpected /proc/{pid}/maps exec permission char"),
         // Single entry
@@ -101,8 +100,7 @@ INSTANTIATE_TEST_SUITE_P(
                 MemoryRegionInfo(make_range(0x55a4512f7000, 0x55a451b68000),
                                  MemoryRegionInfo::eYes, MemoryRegionInfo::eYes,
                                  MemoryRegionInfo::eNo, MemoryRegionInfo::eNo,
-                                 MemoryRegionInfo::eYes, ConstString("[heap]"),
-                                 MemoryRegionInfo::eDontKnow, 0),
+                                 MemoryRegionInfo::eYes, ConstString("[heap]")),
             },
             ""),
         // Multiple entries
@@ -115,19 +113,16 @@ INSTANTIATE_TEST_SUITE_P(
                 MemoryRegionInfo(make_range(0x7fc090021000, 0x7fc094000000),
                                  MemoryRegionInfo::eNo, MemoryRegionInfo::eNo,
                                  MemoryRegionInfo::eNo, MemoryRegionInfo::eNo,
-                                 MemoryRegionInfo::eYes, ConstString(nullptr),
-                                 MemoryRegionInfo::eDontKnow, 0),
+                                 MemoryRegionInfo::eYes, ConstString(nullptr)),
                 MemoryRegionInfo(make_range(0x7fc094000000, 0x7fc094a00000),
                                  MemoryRegionInfo::eNo, MemoryRegionInfo::eNo,
                                  MemoryRegionInfo::eNo, MemoryRegionInfo::eYes,
-                                 MemoryRegionInfo::eYes, ConstString(nullptr),
-                                 MemoryRegionInfo::eDontKnow, 0),
+                                 MemoryRegionInfo::eYes, ConstString(nullptr)),
                 MemoryRegionInfo(
                     make_range(0xffffffffff600000, 0xffffffffff601000),
                     MemoryRegionInfo::eYes, MemoryRegionInfo::eNo,
                     MemoryRegionInfo::eYes, MemoryRegionInfo::eNo,
-                    MemoryRegionInfo::eYes, ConstString("[vsyscall]"),
-                    MemoryRegionInfo::eDontKnow, 0),
+                    MemoryRegionInfo::eYes, ConstString("[vsyscall]")),
             },
             "")));
 
@@ -151,8 +146,7 @@ INSTANTIATE_TEST_SUITE_P(
                 MemoryRegionInfo(make_range(0x1111, 0x2222),
                                  MemoryRegionInfo::eYes, MemoryRegionInfo::eYes,
                                  MemoryRegionInfo::eNo, MemoryRegionInfo::eNo,
-                                 MemoryRegionInfo::eYes, ConstString("[foo]"),
-                                 MemoryRegionInfo::eDontKnow, 0),
+                                 MemoryRegionInfo::eYes, ConstString("[foo]")),
             },
             "malformed /proc/{pid}/smaps entry, missing dash between address "
             "range"),
@@ -170,8 +164,7 @@ INSTANTIATE_TEST_SUITE_P(
                 MemoryRegionInfo(make_range(0x1111, 0x2222),
                                  MemoryRegionInfo::eYes, MemoryRegionInfo::eYes,
                                  MemoryRegionInfo::eNo, MemoryRegionInfo::eNo,
-                                 MemoryRegionInfo::eYes, ConstString("[foo]"),
-                                 MemoryRegionInfo::eDontKnow, 0),
+                                 MemoryRegionInfo::eYes, ConstString("[foo]")),
             },
             ""),
         // Single shared region parses, has no flags
@@ -181,8 +174,7 @@ INSTANTIATE_TEST_SUITE_P(
                 MemoryRegionInfo(make_range(0x1111, 0x2222),
                                  MemoryRegionInfo::eYes, MemoryRegionInfo::eYes,
                                  MemoryRegionInfo::eNo, MemoryRegionInfo::eYes,
-                                 MemoryRegionInfo::eYes, ConstString("[foo]"),
-                                 MemoryRegionInfo::eDontKnow, 0),
+                                 MemoryRegionInfo::eYes, ConstString("[foo]")),
             },
             ""),
         // Single region with flags, other lines ignored
@@ -195,8 +187,7 @@ INSTANTIATE_TEST_SUITE_P(
                 MemoryRegionInfo(make_range(0x1111, 0x2222),
                                  MemoryRegionInfo::eYes, MemoryRegionInfo::eYes,
                                  MemoryRegionInfo::eNo, MemoryRegionInfo::eNo,
-                                 MemoryRegionInfo::eYes, ConstString("[foo]"),
-                                 MemoryRegionInfo::eDontKnow, 0)
+                                 MemoryRegionInfo::eYes, ConstString("[foo]"))
                     .SetIsShadowStack(MemoryRegionInfo::eNo)
                     .SetMemoryTagged(MemoryRegionInfo::eYes),
             },
@@ -209,8 +200,7 @@ INSTANTIATE_TEST_SUITE_P(
                 MemoryRegionInfo(make_range(0, 0), MemoryRegionInfo::eYes,
                                  MemoryRegionInfo::eYes, MemoryRegionInfo::eNo,
                                  MemoryRegionInfo::eNo, MemoryRegionInfo::eYes,
-                                 ConstString(nullptr),
-                                 MemoryRegionInfo::eDontKnow, 0)
+                                 ConstString(nullptr))
                     .SetIsShadowStack(MemoryRegionInfo::eNo)
                     .SetMemoryTagged(MemoryRegionInfo::eYes),
             },
@@ -223,8 +213,7 @@ INSTANTIATE_TEST_SUITE_P(
                 MemoryRegionInfo(make_range(0, 0), MemoryRegionInfo::eYes,
                                  MemoryRegionInfo::eYes, MemoryRegionInfo::eNo,
                                  MemoryRegionInfo::eNo, MemoryRegionInfo::eYes,
-                                 ConstString(nullptr),
-                                 MemoryRegionInfo::eDontKnow, 0)
+                                 ConstString(nullptr))
                     .SetIsShadowStack(MemoryRegionInfo::eNo)
                     .SetMemoryTagged(MemoryRegionInfo::eNo),
             },
@@ -240,13 +229,11 @@ INSTANTIATE_TEST_SUITE_P(
                 MemoryRegionInfo(make_range(0x1111, 0x2222),
                                  MemoryRegionInfo::eYes, MemoryRegionInfo::eYes,
                                  MemoryRegionInfo::eNo, MemoryRegionInfo::eNo,
-                                 MemoryRegionInfo::eYes, ConstString("[foo]"),
-                                 MemoryRegionInfo::eDontKnow, 0),
+                                 MemoryRegionInfo::eYes, ConstString("[foo]")),
                 MemoryRegionInfo(make_range(0x3333, 0x4444),
                                  MemoryRegionInfo::eYes, MemoryRegionInfo::eNo,
                                  MemoryRegionInfo::eYes, MemoryRegionInfo::eNo,
-                                 MemoryRegionInfo::eYes, ConstString("[bar]"),
-                                 MemoryRegionInfo::eDontKnow, 0)
+                                 MemoryRegionInfo::eYes, ConstString("[bar]"))
                     .SetIsShadowStack(MemoryRegionInfo::eNo)
                     .SetMemoryTagged(MemoryRegionInfo::eYes),
             },
@@ -263,13 +250,11 @@ INSTANTIATE_TEST_SUITE_P(
                 MemoryRegionInfo(make_range(0x1111, 0x2222),
                                  MemoryRegionInfo::eYes, MemoryRegionInfo::eYes,
                                  MemoryRegionInfo::eNo, MemoryRegionInfo::eNo,
-                                 MemoryRegionInfo::eYes, ConstString(nullptr),
-                                 MemoryRegionInfo::eDontKnow, 0),
+                                 MemoryRegionInfo::eYes, ConstString(nullptr)),
                 MemoryRegionInfo(make_range(0x3333, 0x4444),
                                  MemoryRegionInfo::eYes, MemoryRegionInfo::eNo,
                                  MemoryRegionInfo::eYes, MemoryRegionInfo::eNo,
-                                 MemoryRegionInfo::eYes, ConstString(nullptr),
-                                 MemoryRegionInfo::eDontKnow, 0),
+                                 MemoryRegionInfo::eYes, ConstString(nullptr)),
             },
             ""),
         // We must look for exact flag strings, ignoring substrings of longer
@@ -281,8 +266,7 @@ INSTANTIATE_TEST_SUITE_P(
                 MemoryRegionInfo(make_range(0, 0), MemoryRegionInfo::eYes,
                                  MemoryRegionInfo::eYes, MemoryRegionInfo::eNo,
                                  MemoryRegionInfo::eNo, MemoryRegionInfo::eYes,
-                                 ConstString(nullptr),
-                                 MemoryRegionInfo::eDontKnow, 0)
+                                 ConstString(nullptr))
                     .SetIsShadowStack(MemoryRegionInfo::eNo)
                     .SetMemoryTagged(MemoryRegionInfo::eNo),
             },
@@ -295,8 +279,7 @@ INSTANTIATE_TEST_SUITE_P(
                 MemoryRegionInfo(make_range(0, 0), MemoryRegionInfo::eYes,
                                  MemoryRegionInfo::eYes, MemoryRegionInfo::eNo,
                                  MemoryRegionInfo::eNo, MemoryRegionInfo::eYes,
-                                 ConstString(nullptr),
-                                 MemoryRegionInfo::eDontKnow, 0)
+                                 ConstString(nullptr))
                     .SetIsShadowStack(MemoryRegionInfo::eYes)
                     .SetMemoryTagged(MemoryRegionInfo::eNo),
             },

--- a/lldb/unittests/Process/Utility/LinuxProcMapsTest.cpp
+++ b/lldb/unittests/Process/Utility/LinuxProcMapsTest.cpp
@@ -91,8 +91,7 @@ INSTANTIATE_TEST_SUITE_P(
                                  MemoryRegionInfo::eYes, MemoryRegionInfo::eNo,
                                  MemoryRegionInfo::eNo, MemoryRegionInfo::eYes,
                                  ConstString("[abc]"),
-                                 MemoryRegionInfo::eDontKnow, 0,
-                                 MemoryRegionInfo::eDontKnow),
+                                 MemoryRegionInfo::eDontKnow, 0),
             },
             "unexpected /proc/{pid}/maps exec permission char"),
         // Single entry
@@ -103,8 +102,7 @@ INSTANTIATE_TEST_SUITE_P(
                                  MemoryRegionInfo::eYes, MemoryRegionInfo::eYes,
                                  MemoryRegionInfo::eNo, MemoryRegionInfo::eNo,
                                  MemoryRegionInfo::eYes, ConstString("[heap]"),
-                                 MemoryRegionInfo::eDontKnow, 0,
-                                 MemoryRegionInfo::eDontKnow),
+                                 MemoryRegionInfo::eDontKnow, 0),
             },
             ""),
         // Multiple entries
@@ -118,21 +116,18 @@ INSTANTIATE_TEST_SUITE_P(
                                  MemoryRegionInfo::eNo, MemoryRegionInfo::eNo,
                                  MemoryRegionInfo::eNo, MemoryRegionInfo::eNo,
                                  MemoryRegionInfo::eYes, ConstString(nullptr),
-                                 MemoryRegionInfo::eDontKnow, 0,
-                                 MemoryRegionInfo::eDontKnow),
+                                 MemoryRegionInfo::eDontKnow, 0),
                 MemoryRegionInfo(make_range(0x7fc094000000, 0x7fc094a00000),
                                  MemoryRegionInfo::eNo, MemoryRegionInfo::eNo,
                                  MemoryRegionInfo::eNo, MemoryRegionInfo::eYes,
                                  MemoryRegionInfo::eYes, ConstString(nullptr),
-                                 MemoryRegionInfo::eDontKnow, 0,
-                                 MemoryRegionInfo::eDontKnow),
+                                 MemoryRegionInfo::eDontKnow, 0),
                 MemoryRegionInfo(
                     make_range(0xffffffffff600000, 0xffffffffff601000),
                     MemoryRegionInfo::eYes, MemoryRegionInfo::eNo,
                     MemoryRegionInfo::eYes, MemoryRegionInfo::eNo,
                     MemoryRegionInfo::eYes, ConstString("[vsyscall]"),
-                    MemoryRegionInfo::eDontKnow, 0,
-                    MemoryRegionInfo::eDontKnow),
+                    MemoryRegionInfo::eDontKnow, 0),
             },
             "")));
 
@@ -157,8 +152,7 @@ INSTANTIATE_TEST_SUITE_P(
                                  MemoryRegionInfo::eYes, MemoryRegionInfo::eYes,
                                  MemoryRegionInfo::eNo, MemoryRegionInfo::eNo,
                                  MemoryRegionInfo::eYes, ConstString("[foo]"),
-                                 MemoryRegionInfo::eDontKnow, 0,
-                                 MemoryRegionInfo::eDontKnow),
+                                 MemoryRegionInfo::eDontKnow, 0),
             },
             "malformed /proc/{pid}/smaps entry, missing dash between address "
             "range"),
@@ -177,8 +171,7 @@ INSTANTIATE_TEST_SUITE_P(
                                  MemoryRegionInfo::eYes, MemoryRegionInfo::eYes,
                                  MemoryRegionInfo::eNo, MemoryRegionInfo::eNo,
                                  MemoryRegionInfo::eYes, ConstString("[foo]"),
-                                 MemoryRegionInfo::eDontKnow, 0,
-                                 MemoryRegionInfo::eDontKnow),
+                                 MemoryRegionInfo::eDontKnow, 0),
             },
             ""),
         // Single shared region parses, has no flags
@@ -189,8 +182,7 @@ INSTANTIATE_TEST_SUITE_P(
                                  MemoryRegionInfo::eYes, MemoryRegionInfo::eYes,
                                  MemoryRegionInfo::eNo, MemoryRegionInfo::eYes,
                                  MemoryRegionInfo::eYes, ConstString("[foo]"),
-                                 MemoryRegionInfo::eDontKnow, 0,
-                                 MemoryRegionInfo::eDontKnow),
+                                 MemoryRegionInfo::eDontKnow, 0),
             },
             ""),
         // Single region with flags, other lines ignored
@@ -204,9 +196,9 @@ INSTANTIATE_TEST_SUITE_P(
                                  MemoryRegionInfo::eYes, MemoryRegionInfo::eYes,
                                  MemoryRegionInfo::eNo, MemoryRegionInfo::eNo,
                                  MemoryRegionInfo::eYes, ConstString("[foo]"),
-                                 MemoryRegionInfo::eDontKnow, 0,
-                                 MemoryRegionInfo::eYes)
-                    .SetIsShadowStack(MemoryRegionInfo::eNo),
+                                 MemoryRegionInfo::eDontKnow, 0)
+                    .SetIsShadowStack(MemoryRegionInfo::eNo)
+                    .SetMemoryTagged(MemoryRegionInfo::eYes),
             },
             ""),
         // Whitespace ignored
@@ -218,9 +210,9 @@ INSTANTIATE_TEST_SUITE_P(
                                  MemoryRegionInfo::eYes, MemoryRegionInfo::eNo,
                                  MemoryRegionInfo::eNo, MemoryRegionInfo::eYes,
                                  ConstString(nullptr),
-                                 MemoryRegionInfo::eDontKnow, 0,
-                                 MemoryRegionInfo::eYes)
-                    .SetIsShadowStack(MemoryRegionInfo::eNo),
+                                 MemoryRegionInfo::eDontKnow, 0)
+                    .SetIsShadowStack(MemoryRegionInfo::eNo)
+                    .SetMemoryTagged(MemoryRegionInfo::eYes),
             },
             ""),
         // VmFlags line means it has flag info, but nothing is set
@@ -232,9 +224,9 @@ INSTANTIATE_TEST_SUITE_P(
                                  MemoryRegionInfo::eYes, MemoryRegionInfo::eNo,
                                  MemoryRegionInfo::eNo, MemoryRegionInfo::eYes,
                                  ConstString(nullptr),
-                                 MemoryRegionInfo::eDontKnow, 0,
-                                 MemoryRegionInfo::eNo)
-                    .SetIsShadowStack(MemoryRegionInfo::eNo),
+                                 MemoryRegionInfo::eDontKnow, 0)
+                    .SetIsShadowStack(MemoryRegionInfo::eNo)
+                    .SetMemoryTagged(MemoryRegionInfo::eNo),
             },
             ""),
         // Handle some pages not having a flags line
@@ -249,15 +241,14 @@ INSTANTIATE_TEST_SUITE_P(
                                  MemoryRegionInfo::eYes, MemoryRegionInfo::eYes,
                                  MemoryRegionInfo::eNo, MemoryRegionInfo::eNo,
                                  MemoryRegionInfo::eYes, ConstString("[foo]"),
-                                 MemoryRegionInfo::eDontKnow, 0,
-                                 MemoryRegionInfo::eDontKnow),
+                                 MemoryRegionInfo::eDontKnow, 0),
                 MemoryRegionInfo(make_range(0x3333, 0x4444),
                                  MemoryRegionInfo::eYes, MemoryRegionInfo::eNo,
                                  MemoryRegionInfo::eYes, MemoryRegionInfo::eNo,
                                  MemoryRegionInfo::eYes, ConstString("[bar]"),
-                                 MemoryRegionInfo::eDontKnow, 0,
-                                 MemoryRegionInfo::eYes)
-                    .SetIsShadowStack(MemoryRegionInfo::eNo),
+                                 MemoryRegionInfo::eDontKnow, 0)
+                    .SetIsShadowStack(MemoryRegionInfo::eNo)
+                    .SetMemoryTagged(MemoryRegionInfo::eYes),
             },
             ""),
         // Handle no pages having a flags line (older kernels)
@@ -273,14 +264,12 @@ INSTANTIATE_TEST_SUITE_P(
                                  MemoryRegionInfo::eYes, MemoryRegionInfo::eYes,
                                  MemoryRegionInfo::eNo, MemoryRegionInfo::eNo,
                                  MemoryRegionInfo::eYes, ConstString(nullptr),
-                                 MemoryRegionInfo::eDontKnow, 0,
-                                 MemoryRegionInfo::eDontKnow),
+                                 MemoryRegionInfo::eDontKnow, 0),
                 MemoryRegionInfo(make_range(0x3333, 0x4444),
                                  MemoryRegionInfo::eYes, MemoryRegionInfo::eNo,
                                  MemoryRegionInfo::eYes, MemoryRegionInfo::eNo,
                                  MemoryRegionInfo::eYes, ConstString(nullptr),
-                                 MemoryRegionInfo::eDontKnow, 0,
-                                 MemoryRegionInfo::eDontKnow),
+                                 MemoryRegionInfo::eDontKnow, 0),
             },
             ""),
         // We must look for exact flag strings, ignoring substrings of longer
@@ -293,9 +282,9 @@ INSTANTIATE_TEST_SUITE_P(
                                  MemoryRegionInfo::eYes, MemoryRegionInfo::eNo,
                                  MemoryRegionInfo::eNo, MemoryRegionInfo::eYes,
                                  ConstString(nullptr),
-                                 MemoryRegionInfo::eDontKnow, 0,
-                                 MemoryRegionInfo::eNo)
-                    .SetIsShadowStack(MemoryRegionInfo::eNo),
+                                 MemoryRegionInfo::eDontKnow, 0)
+                    .SetIsShadowStack(MemoryRegionInfo::eNo)
+                    .SetMemoryTagged(MemoryRegionInfo::eNo),
             },
             ""),
         // "ss" means shadow stack.
@@ -307,9 +296,9 @@ INSTANTIATE_TEST_SUITE_P(
                                  MemoryRegionInfo::eYes, MemoryRegionInfo::eNo,
                                  MemoryRegionInfo::eNo, MemoryRegionInfo::eYes,
                                  ConstString(nullptr),
-                                 MemoryRegionInfo::eDontKnow, 0,
-                                 MemoryRegionInfo::eNo)
-                    .SetIsShadowStack(MemoryRegionInfo::eYes),
+                                 MemoryRegionInfo::eDontKnow, 0)
+                    .SetIsShadowStack(MemoryRegionInfo::eYes)
+                    .SetMemoryTagged(MemoryRegionInfo::eNo),
             },
             "")));
 

--- a/lldb/unittests/Process/Utility/LinuxProcMapsTest.cpp
+++ b/lldb/unittests/Process/Utility/LinuxProcMapsTest.cpp
@@ -92,21 +92,20 @@ INSTANTIATE_TEST_SUITE_P(
                     MemoryRegionInfo::eYes, MemoryRegionInfo::eNo,
                     MemoryRegionInfo::eNo, MemoryRegionInfo::eYes,
                     ConstString("[abc]"), MemoryRegionInfo::eDontKnow, 0,
-                    MemoryRegionInfo::eDontKnow, MemoryRegionInfo::eDontKnow,
-                    MemoryRegionInfo::eDontKnow),
+                    MemoryRegionInfo::eDontKnow, MemoryRegionInfo::eDontKnow),
             },
             "unexpected /proc/{pid}/maps exec permission char"),
         // Single entry
         std::make_tuple(
             "55a4512f7000-55a451b68000 rw-p 00000000 00:00 0    [heap]",
             MemoryRegionInfos{
-                MemoryRegionInfo(
-                    make_range(0x55a4512f7000, 0x55a451b68000),
-                    MemoryRegionInfo::eYes, MemoryRegionInfo::eYes,
-                    MemoryRegionInfo::eNo, MemoryRegionInfo::eNo,
-                    MemoryRegionInfo::eYes, ConstString("[heap]"),
-                    MemoryRegionInfo::eDontKnow, 0, MemoryRegionInfo::eDontKnow,
-                    MemoryRegionInfo::eDontKnow, MemoryRegionInfo::eDontKnow),
+                MemoryRegionInfo(make_range(0x55a4512f7000, 0x55a451b68000),
+                                 MemoryRegionInfo::eYes, MemoryRegionInfo::eYes,
+                                 MemoryRegionInfo::eNo, MemoryRegionInfo::eNo,
+                                 MemoryRegionInfo::eYes, ConstString("[heap]"),
+                                 MemoryRegionInfo::eDontKnow, 0,
+                                 MemoryRegionInfo::eDontKnow,
+                                 MemoryRegionInfo::eDontKnow),
             },
             ""),
         // Multiple entries
@@ -116,27 +115,27 @@ INSTANTIATE_TEST_SUITE_P(
             "ffffffffff600000-ffffffffff601000 r-xp 00000000 00:00 0 "
             "[vsyscall]",
             MemoryRegionInfos{
-                MemoryRegionInfo(
-                    make_range(0x7fc090021000, 0x7fc094000000),
-                    MemoryRegionInfo::eNo, MemoryRegionInfo::eNo,
-                    MemoryRegionInfo::eNo, MemoryRegionInfo::eNo,
-                    MemoryRegionInfo::eYes, ConstString(nullptr),
-                    MemoryRegionInfo::eDontKnow, 0, MemoryRegionInfo::eDontKnow,
-                    MemoryRegionInfo::eDontKnow, MemoryRegionInfo::eDontKnow),
-                MemoryRegionInfo(
-                    make_range(0x7fc094000000, 0x7fc094a00000),
-                    MemoryRegionInfo::eNo, MemoryRegionInfo::eNo,
-                    MemoryRegionInfo::eNo, MemoryRegionInfo::eYes,
-                    MemoryRegionInfo::eYes, ConstString(nullptr),
-                    MemoryRegionInfo::eDontKnow, 0, MemoryRegionInfo::eDontKnow,
-                    MemoryRegionInfo::eDontKnow, MemoryRegionInfo::eDontKnow),
+                MemoryRegionInfo(make_range(0x7fc090021000, 0x7fc094000000),
+                                 MemoryRegionInfo::eNo, MemoryRegionInfo::eNo,
+                                 MemoryRegionInfo::eNo, MemoryRegionInfo::eNo,
+                                 MemoryRegionInfo::eYes, ConstString(nullptr),
+                                 MemoryRegionInfo::eDontKnow, 0,
+                                 MemoryRegionInfo::eDontKnow,
+                                 MemoryRegionInfo::eDontKnow),
+                MemoryRegionInfo(make_range(0x7fc094000000, 0x7fc094a00000),
+                                 MemoryRegionInfo::eNo, MemoryRegionInfo::eNo,
+                                 MemoryRegionInfo::eNo, MemoryRegionInfo::eYes,
+                                 MemoryRegionInfo::eYes, ConstString(nullptr),
+                                 MemoryRegionInfo::eDontKnow, 0,
+                                 MemoryRegionInfo::eDontKnow,
+                                 MemoryRegionInfo::eDontKnow),
                 MemoryRegionInfo(
                     make_range(0xffffffffff600000, 0xffffffffff601000),
                     MemoryRegionInfo::eYes, MemoryRegionInfo::eNo,
                     MemoryRegionInfo::eYes, MemoryRegionInfo::eNo,
                     MemoryRegionInfo::eYes, ConstString("[vsyscall]"),
                     MemoryRegionInfo::eDontKnow, 0, MemoryRegionInfo::eDontKnow,
-                    MemoryRegionInfo::eDontKnow, MemoryRegionInfo::eDontKnow),
+                    MemoryRegionInfo::eDontKnow),
             },
             "")));
 
@@ -162,8 +161,7 @@ INSTANTIATE_TEST_SUITE_P(
                     MemoryRegionInfo::eYes, MemoryRegionInfo::eNo,
                     MemoryRegionInfo::eNo, MemoryRegionInfo::eYes,
                     ConstString("[foo]"), MemoryRegionInfo::eDontKnow, 0,
-                    MemoryRegionInfo::eDontKnow, MemoryRegionInfo::eDontKnow,
-                    MemoryRegionInfo::eDontKnow),
+                    MemoryRegionInfo::eDontKnow, MemoryRegionInfo::eDontKnow),
             },
             "malformed /proc/{pid}/smaps entry, missing dash between address "
             "range"),
@@ -183,8 +181,7 @@ INSTANTIATE_TEST_SUITE_P(
                     MemoryRegionInfo::eYes, MemoryRegionInfo::eNo,
                     MemoryRegionInfo::eNo, MemoryRegionInfo::eYes,
                     ConstString("[foo]"), MemoryRegionInfo::eDontKnow, 0,
-                    MemoryRegionInfo::eDontKnow, MemoryRegionInfo::eDontKnow,
-                    MemoryRegionInfo::eDontKnow),
+                    MemoryRegionInfo::eDontKnow, MemoryRegionInfo::eDontKnow),
             },
             ""),
         // Single shared region parses, has no flags
@@ -196,8 +193,7 @@ INSTANTIATE_TEST_SUITE_P(
                     MemoryRegionInfo::eYes, MemoryRegionInfo::eNo,
                     MemoryRegionInfo::eYes, MemoryRegionInfo::eYes,
                     ConstString("[foo]"), MemoryRegionInfo::eDontKnow, 0,
-                    MemoryRegionInfo::eDontKnow, MemoryRegionInfo::eDontKnow,
-                    MemoryRegionInfo::eDontKnow),
+                    MemoryRegionInfo::eDontKnow, MemoryRegionInfo::eDontKnow),
             },
             ""),
         // Single region with flags, other lines ignored
@@ -212,8 +208,8 @@ INSTANTIATE_TEST_SUITE_P(
                     MemoryRegionInfo::eYes, MemoryRegionInfo::eNo,
                     MemoryRegionInfo::eNo, MemoryRegionInfo::eYes,
                     ConstString("[foo]"), MemoryRegionInfo::eDontKnow, 0,
-                    MemoryRegionInfo::eYes, MemoryRegionInfo::eDontKnow,
-                    MemoryRegionInfo::eNo),
+                    MemoryRegionInfo::eYes, MemoryRegionInfo::eDontKnow)
+                    .SetIsShadowStack(MemoryRegionInfo::eNo),
             },
             ""),
         // Whitespace ignored
@@ -226,8 +222,8 @@ INSTANTIATE_TEST_SUITE_P(
                     MemoryRegionInfo::eYes, MemoryRegionInfo::eNo,
                     MemoryRegionInfo::eNo, MemoryRegionInfo::eYes,
                     ConstString(nullptr), MemoryRegionInfo::eDontKnow, 0,
-                    MemoryRegionInfo::eYes, MemoryRegionInfo::eDontKnow,
-                    MemoryRegionInfo::eNo),
+                    MemoryRegionInfo::eYes, MemoryRegionInfo::eDontKnow)
+                    .SetIsShadowStack(MemoryRegionInfo::eNo),
             },
             ""),
         // VmFlags line means it has flag info, but nothing is set
@@ -240,8 +236,8 @@ INSTANTIATE_TEST_SUITE_P(
                     MemoryRegionInfo::eYes, MemoryRegionInfo::eNo,
                     MemoryRegionInfo::eNo, MemoryRegionInfo::eYes,
                     ConstString(nullptr), MemoryRegionInfo::eDontKnow, 0,
-                    MemoryRegionInfo::eNo, MemoryRegionInfo::eDontKnow,
-                    MemoryRegionInfo::eNo),
+                    MemoryRegionInfo::eNo, MemoryRegionInfo::eDontKnow)
+                    .SetIsShadowStack(MemoryRegionInfo::eNo),
             },
             ""),
         // Handle some pages not having a flags line
@@ -257,15 +253,14 @@ INSTANTIATE_TEST_SUITE_P(
                     MemoryRegionInfo::eYes, MemoryRegionInfo::eNo,
                     MemoryRegionInfo::eNo, MemoryRegionInfo::eYes,
                     ConstString("[foo]"), MemoryRegionInfo::eDontKnow, 0,
-                    MemoryRegionInfo::eDontKnow, MemoryRegionInfo::eDontKnow,
-                    MemoryRegionInfo::eDontKnow),
+                    MemoryRegionInfo::eDontKnow, MemoryRegionInfo::eDontKnow),
                 MemoryRegionInfo(
                     make_range(0x3333, 0x4444), MemoryRegionInfo::eYes,
                     MemoryRegionInfo::eNo, MemoryRegionInfo::eYes,
                     MemoryRegionInfo::eNo, MemoryRegionInfo::eYes,
                     ConstString("[bar]"), MemoryRegionInfo::eDontKnow, 0,
-                    MemoryRegionInfo::eYes, MemoryRegionInfo::eDontKnow,
-                    MemoryRegionInfo::eNo),
+                    MemoryRegionInfo::eYes, MemoryRegionInfo::eDontKnow)
+                    .SetIsShadowStack(MemoryRegionInfo::eNo),
             },
             ""),
         // Handle no pages having a flags line (older kernels)
@@ -282,15 +277,13 @@ INSTANTIATE_TEST_SUITE_P(
                     MemoryRegionInfo::eYes, MemoryRegionInfo::eNo,
                     MemoryRegionInfo::eNo, MemoryRegionInfo::eYes,
                     ConstString(nullptr), MemoryRegionInfo::eDontKnow, 0,
-                    MemoryRegionInfo::eDontKnow, MemoryRegionInfo::eDontKnow,
-                    MemoryRegionInfo::eDontKnow),
+                    MemoryRegionInfo::eDontKnow, MemoryRegionInfo::eDontKnow),
                 MemoryRegionInfo(
                     make_range(0x3333, 0x4444), MemoryRegionInfo::eYes,
                     MemoryRegionInfo::eNo, MemoryRegionInfo::eYes,
                     MemoryRegionInfo::eNo, MemoryRegionInfo::eYes,
                     ConstString(nullptr), MemoryRegionInfo::eDontKnow, 0,
-                    MemoryRegionInfo::eDontKnow, MemoryRegionInfo::eDontKnow,
-                    MemoryRegionInfo::eDontKnow),
+                    MemoryRegionInfo::eDontKnow, MemoryRegionInfo::eDontKnow),
             },
             ""),
         // We must look for exact flag strings, ignoring substrings of longer
@@ -304,8 +297,22 @@ INSTANTIATE_TEST_SUITE_P(
                     MemoryRegionInfo::eYes, MemoryRegionInfo::eNo,
                     MemoryRegionInfo::eNo, MemoryRegionInfo::eYes,
                     ConstString(nullptr), MemoryRegionInfo::eDontKnow, 0,
-                    MemoryRegionInfo::eNo, MemoryRegionInfo::eDontKnow,
-                    MemoryRegionInfo::eNo),
+                    MemoryRegionInfo::eNo, MemoryRegionInfo::eDontKnow)
+                    .SetIsShadowStack(MemoryRegionInfo::eNo),
+            },
+            ""),
+        // "ss" means shadow stack.
+        std::make_tuple(
+            "0-0 rw-p 00000000 00:00 0\n"
+            "VmFlags: ss",
+            MemoryRegionInfos{
+                MemoryRegionInfo(
+                    make_range(0, 0), MemoryRegionInfo::eYes,
+                    MemoryRegionInfo::eYes, MemoryRegionInfo::eNo,
+                    MemoryRegionInfo::eNo, MemoryRegionInfo::eYes,
+                    ConstString(nullptr), MemoryRegionInfo::eDontKnow, 0,
+                    MemoryRegionInfo::eNo, MemoryRegionInfo::eDontKnow)
+                    .SetIsShadowStack(MemoryRegionInfo::eYes),
             },
             "")));
 

--- a/lldb/unittests/Process/Utility/MemoryTagManagerAArch64MTETest.cpp
+++ b/lldb/unittests/Process/Utility/MemoryTagManagerAArch64MTETest.cpp
@@ -235,8 +235,7 @@ static MemoryRegionInfo MakeRegionInfo(lldb::addr_t base, lldb::addr_t size,
       MemoryRegionInfo::eYes, MemoryRegionInfo::eYes, MemoryRegionInfo::eNo,
       MemoryRegionInfo::eYes, ConstString(), MemoryRegionInfo::eNo, 0,
       /*memory_tagged=*/
-      tagged ? MemoryRegionInfo::eYes : MemoryRegionInfo::eNo,
-      MemoryRegionInfo::eDontKnow);
+      tagged ? MemoryRegionInfo::eYes : MemoryRegionInfo::eNo);
 }
 
 TEST(MemoryTagManagerAArch64MTETest, MakeTaggedRange) {

--- a/lldb/unittests/Process/Utility/MemoryTagManagerAArch64MTETest.cpp
+++ b/lldb/unittests/Process/Utility/MemoryTagManagerAArch64MTETest.cpp
@@ -233,8 +233,7 @@ static MemoryRegionInfo MakeRegionInfo(lldb::addr_t base, lldb::addr_t size,
   return MemoryRegionInfo(MemoryRegionInfo::RangeType(base, size),
                           MemoryRegionInfo::eYes, MemoryRegionInfo::eYes,
                           MemoryRegionInfo::eYes, MemoryRegionInfo::eNo,
-                          MemoryRegionInfo::eYes, ConstString(),
-                          MemoryRegionInfo::eNo, 0)
+                          MemoryRegionInfo::eYes, ConstString())
       .SetMemoryTagged(tagged ? MemoryRegionInfo::eYes : MemoryRegionInfo::eNo);
 }
 

--- a/lldb/unittests/Process/Utility/MemoryTagManagerAArch64MTETest.cpp
+++ b/lldb/unittests/Process/Utility/MemoryTagManagerAArch64MTETest.cpp
@@ -236,7 +236,7 @@ static MemoryRegionInfo MakeRegionInfo(lldb::addr_t base, lldb::addr_t size,
       MemoryRegionInfo::eYes, ConstString(), MemoryRegionInfo::eNo, 0,
       /*memory_tagged=*/
       tagged ? MemoryRegionInfo::eYes : MemoryRegionInfo::eNo,
-      MemoryRegionInfo::eDontKnow, MemoryRegionInfo::eDontKnow);
+      MemoryRegionInfo::eDontKnow);
 }
 
 TEST(MemoryTagManagerAArch64MTETest, MakeTaggedRange) {

--- a/lldb/unittests/Process/Utility/MemoryTagManagerAArch64MTETest.cpp
+++ b/lldb/unittests/Process/Utility/MemoryTagManagerAArch64MTETest.cpp
@@ -230,12 +230,12 @@ TEST(MemoryTagManagerAArch64MTETest, ExpandToGranule) {
 
 static MemoryRegionInfo MakeRegionInfo(lldb::addr_t base, lldb::addr_t size,
                                        bool tagged) {
-  return MemoryRegionInfo(
-      MemoryRegionInfo::RangeType(base, size), MemoryRegionInfo::eYes,
-      MemoryRegionInfo::eYes, MemoryRegionInfo::eYes, MemoryRegionInfo::eNo,
-      MemoryRegionInfo::eYes, ConstString(), MemoryRegionInfo::eNo, 0,
-      /*memory_tagged=*/
-      tagged ? MemoryRegionInfo::eYes : MemoryRegionInfo::eNo);
+  return MemoryRegionInfo(MemoryRegionInfo::RangeType(base, size),
+                          MemoryRegionInfo::eYes, MemoryRegionInfo::eYes,
+                          MemoryRegionInfo::eYes, MemoryRegionInfo::eNo,
+                          MemoryRegionInfo::eYes, ConstString(),
+                          MemoryRegionInfo::eNo, 0)
+      .SetMemoryTagged(tagged ? MemoryRegionInfo::eYes : MemoryRegionInfo::eNo);
 }
 
 TEST(MemoryTagManagerAArch64MTETest, MakeTaggedRange) {

--- a/lldb/unittests/Process/minidump/MinidumpParserTest.cpp
+++ b/lldb/unittests/Process/minidump/MinidumpParserTest.cpp
@@ -385,15 +385,15 @@ Streams:
       testing::Pair(
           testing::ElementsAre(
               MemoryRegionInfo({0x0, 0x10000}, no, no, no, unknown, no,
-                               ConstString(), unknown, 0, unknown),
+                               ConstString(), unknown, 0),
               MemoryRegionInfo({0x10000, 0x21000}, yes, yes, no, unknown, yes,
-                               ConstString(), unknown, 0, unknown),
+                               ConstString(), unknown, 0),
               MemoryRegionInfo({0x40000, 0x1000}, yes, no, no, unknown, yes,
-                               ConstString(), unknown, 0, unknown),
+                               ConstString(), unknown, 0),
               MemoryRegionInfo({0x7ffe0000, 0x1000}, yes, no, no, unknown, yes,
-                               ConstString(), unknown, 0, unknown),
+                               ConstString(), unknown, 0),
               MemoryRegionInfo({0x7ffe1000, 0xf000}, no, no, no, unknown, yes,
-                               ConstString(), unknown, 0, unknown)),
+                               ConstString(), unknown, 0)),
           true));
 }
 
@@ -419,9 +419,9 @@ Streams:
       testing::Pair(
           testing::ElementsAre(
               MemoryRegionInfo({0x1000, 0x10}, yes, unknown, unknown, unknown,
-                               yes, ConstString(), unknown, 0, unknown),
+                               yes, ConstString(), unknown, 0),
               MemoryRegionInfo({0x2000, 0x20}, yes, unknown, unknown, unknown,
-                               yes, ConstString(), unknown, 0, unknown)),
+                               yes, ConstString(), unknown, 0)),
           false));
 }
 
@@ -435,9 +435,9 @@ TEST_F(MinidumpParserTest, GetMemoryRegionInfoFromMemory64List) {
       testing::Pair(
           testing::ElementsAre(
               MemoryRegionInfo({0x1000, 0x10}, yes, unknown, unknown, unknown,
-                               yes, ConstString(), unknown, 0, unknown),
+                               yes, ConstString(), unknown, 0),
               MemoryRegionInfo({0x2000, 0x20}, yes, unknown, unknown, unknown,
-                               yes, ConstString(), unknown, 0, unknown)),
+                               yes, ConstString(), unknown, 0)),
           false));
 }
 
@@ -462,22 +462,22 @@ Streams:
   ConstString app_process("/system/bin/app_process");
   ConstString linker("/system/bin/linker");
   ConstString liblog("/system/lib/liblog.so");
-  EXPECT_THAT(parser->BuildMemoryRegions(),
-              testing::Pair(
-                  testing::ElementsAre(
-                      MemoryRegionInfo({0x400d9000, 0x2000}, yes, no, yes, no,
-                                       yes, app_process, unknown, 0, unknown),
-                      MemoryRegionInfo({0x400db000, 0x1000}, yes, no, no, no,
-                                       yes, app_process, unknown, 0, unknown),
-                      MemoryRegionInfo({0x400dc000, 0x1000}, yes, yes, no, no,
-                                       yes, ConstString(), unknown, 0, unknown),
-                      MemoryRegionInfo({0x400ec000, 0x1000}, yes, no, no, no,
-                                       yes, ConstString(), unknown, 0, unknown),
-                      MemoryRegionInfo({0x400ee000, 0x1000}, yes, yes, no, no,
-                                       yes, linker, unknown, 0, unknown),
-                      MemoryRegionInfo({0x400fc000, 0x1000}, yes, yes, yes, no,
-                                       yes, liblog, unknown, 0, unknown)),
-                  true));
+  EXPECT_THAT(
+      parser->BuildMemoryRegions(),
+      testing::Pair(testing::ElementsAre(
+                        MemoryRegionInfo({0x400d9000, 0x2000}, yes, no, yes, no,
+                                         yes, app_process, unknown, 0),
+                        MemoryRegionInfo({0x400db000, 0x1000}, yes, no, no, no,
+                                         yes, app_process, unknown, 0),
+                        MemoryRegionInfo({0x400dc000, 0x1000}, yes, yes, no, no,
+                                         yes, ConstString(), unknown, 0),
+                        MemoryRegionInfo({0x400ec000, 0x1000}, yes, no, no, no,
+                                         yes, ConstString(), unknown, 0),
+                        MemoryRegionInfo({0x400ee000, 0x1000}, yes, yes, no, no,
+                                         yes, linker, unknown, 0),
+                        MemoryRegionInfo({0x400fc000, 0x1000}, yes, yes, yes,
+                                         no, yes, liblog, unknown, 0)),
+                    true));
 }
 
 TEST_F(MinidumpParserTest, GetMemoryRegionInfoLinuxMapsError) {
@@ -496,7 +496,7 @@ Streams:
   EXPECT_THAT(parser->BuildMemoryRegions(),
               testing::Pair(testing::ElementsAre(MemoryRegionInfo(
                                 {0x400fc000, 0x1000}, yes, yes, yes, no, yes,
-                                ConstString(nullptr), unknown, 0, unknown)),
+                                ConstString(nullptr), unknown, 0)),
                             true));
 }
 

--- a/lldb/unittests/Process/minidump/MinidumpParserTest.cpp
+++ b/lldb/unittests/Process/minidump/MinidumpParserTest.cpp
@@ -382,23 +382,19 @@ Streams:
 
   EXPECT_THAT(
       parser->BuildMemoryRegions(),
-      testing::Pair(testing::ElementsAre(
-                        MemoryRegionInfo({0x0, 0x10000}, no, no, no, unknown,
-                                         no, ConstString(), unknown, 0, unknown,
-                                         unknown, unknown),
-                        MemoryRegionInfo({0x10000, 0x21000}, yes, yes, no,
-                                         unknown, yes, ConstString(), unknown,
-                                         0, unknown, unknown, unknown),
-                        MemoryRegionInfo({0x40000, 0x1000}, yes, no, no,
-                                         unknown, yes, ConstString(), unknown,
-                                         0, unknown, unknown, unknown),
-                        MemoryRegionInfo({0x7ffe0000, 0x1000}, yes, no, no,
-                                         unknown, yes, ConstString(), unknown,
-                                         0, unknown, unknown, unknown),
-                        MemoryRegionInfo({0x7ffe1000, 0xf000}, no, no, no,
-                                         unknown, yes, ConstString(), unknown,
-                                         0, unknown, unknown, unknown)),
-                    true));
+      testing::Pair(
+          testing::ElementsAre(
+              MemoryRegionInfo({0x0, 0x10000}, no, no, no, unknown, no,
+                               ConstString(), unknown, 0, unknown, unknown),
+              MemoryRegionInfo({0x10000, 0x21000}, yes, yes, no, unknown, yes,
+                               ConstString(), unknown, 0, unknown, unknown),
+              MemoryRegionInfo({0x40000, 0x1000}, yes, no, no, unknown, yes,
+                               ConstString(), unknown, 0, unknown, unknown),
+              MemoryRegionInfo({0x7ffe0000, 0x1000}, yes, no, no, unknown, yes,
+                               ConstString(), unknown, 0, unknown, unknown),
+              MemoryRegionInfo({0x7ffe1000, 0xf000}, no, no, no, unknown, yes,
+                               ConstString(), unknown, 0, unknown, unknown)),
+          true));
 }
 
 TEST_F(MinidumpParserTest, GetMemoryRegionInfoFromMemoryList) {
@@ -423,10 +419,10 @@ Streams:
       testing::Pair(testing::ElementsAre(
                         MemoryRegionInfo({0x1000, 0x10}, yes, unknown, unknown,
                                          unknown, yes, ConstString(), unknown,
-                                         0, unknown, unknown, unknown),
+                                         0, unknown, unknown),
                         MemoryRegionInfo({0x2000, 0x20}, yes, unknown, unknown,
                                          unknown, yes, ConstString(), unknown,
-                                         0, unknown, unknown, unknown)),
+                                         0, unknown, unknown)),
                     false));
 }
 
@@ -440,10 +436,10 @@ TEST_F(MinidumpParserTest, GetMemoryRegionInfoFromMemory64List) {
       testing::Pair(testing::ElementsAre(
                         MemoryRegionInfo({0x1000, 0x10}, yes, unknown, unknown,
                                          unknown, yes, ConstString(), unknown,
-                                         0, unknown, unknown, unknown),
+                                         0, unknown, unknown),
                         MemoryRegionInfo({0x2000, 0x20}, yes, unknown, unknown,
                                          unknown, yes, ConstString(), unknown,
-                                         0, unknown, unknown, unknown)),
+                                         0, unknown, unknown)),
                     false));
 }
 
@@ -473,21 +469,17 @@ Streams:
       testing::Pair(
           testing::ElementsAre(
               MemoryRegionInfo({0x400d9000, 0x2000}, yes, no, yes, no, yes,
-                               app_process, unknown, 0, unknown, unknown,
-                               unknown),
+                               app_process, unknown, 0, unknown, unknown),
               MemoryRegionInfo({0x400db000, 0x1000}, yes, no, no, no, yes,
-                               app_process, unknown, 0, unknown, unknown,
-                               unknown),
+                               app_process, unknown, 0, unknown, unknown),
               MemoryRegionInfo({0x400dc000, 0x1000}, yes, yes, no, no, yes,
-                               ConstString(), unknown, 0, unknown, unknown,
-                               unknown),
+                               ConstString(), unknown, 0, unknown, unknown),
               MemoryRegionInfo({0x400ec000, 0x1000}, yes, no, no, no, yes,
-                               ConstString(), unknown, 0, unknown, unknown,
-                               unknown),
+                               ConstString(), unknown, 0, unknown, unknown),
               MemoryRegionInfo({0x400ee000, 0x1000}, yes, yes, no, no, yes,
-                               linker, unknown, 0, unknown, unknown, unknown),
+                               linker, unknown, 0, unknown, unknown),
               MemoryRegionInfo({0x400fc000, 0x1000}, yes, yes, yes, no, yes,
-                               liblog, unknown, 0, unknown, unknown, unknown)),
+                               liblog, unknown, 0, unknown, unknown)),
           true));
 }
 
@@ -504,12 +496,12 @@ Streams:
                     llvm::Succeeded());
   // Test that when a /proc/maps region fails to parse
   // we handle the error and continue with the rest.
-  EXPECT_THAT(parser->BuildMemoryRegions(),
-              testing::Pair(testing::ElementsAre(MemoryRegionInfo(
-                                {0x400fc000, 0x1000}, yes, yes, yes, no, yes,
-                                ConstString(nullptr), unknown, 0, unknown,
-                                unknown, unknown)),
-                            true));
+  EXPECT_THAT(
+      parser->BuildMemoryRegions(),
+      testing::Pair(testing::ElementsAre(MemoryRegionInfo(
+                        {0x400fc000, 0x1000}, yes, yes, yes, no, yes,
+                        ConstString(nullptr), unknown, 0, unknown, unknown)),
+                    true));
 }
 
 // Windows Minidump tests

--- a/lldb/unittests/Process/minidump/MinidumpParserTest.cpp
+++ b/lldb/unittests/Process/minidump/MinidumpParserTest.cpp
@@ -382,19 +382,18 @@ Streams:
 
   EXPECT_THAT(
       parser->BuildMemoryRegions(),
-      testing::Pair(
-          testing::ElementsAre(
-              MemoryRegionInfo({0x0, 0x10000}, no, no, no, unknown, no,
-                               ConstString(), unknown, 0),
-              MemoryRegionInfo({0x10000, 0x21000}, yes, yes, no, unknown, yes,
-                               ConstString(), unknown, 0),
-              MemoryRegionInfo({0x40000, 0x1000}, yes, no, no, unknown, yes,
-                               ConstString(), unknown, 0),
-              MemoryRegionInfo({0x7ffe0000, 0x1000}, yes, no, no, unknown, yes,
-                               ConstString(), unknown, 0),
-              MemoryRegionInfo({0x7ffe1000, 0xf000}, no, no, no, unknown, yes,
-                               ConstString(), unknown, 0)),
-          true));
+      testing::Pair(testing::ElementsAre(
+                        MemoryRegionInfo({0x0, 0x10000}, no, no, no, unknown,
+                                         no, ConstString()),
+                        MemoryRegionInfo({0x10000, 0x21000}, yes, yes, no,
+                                         unknown, yes, ConstString()),
+                        MemoryRegionInfo({0x40000, 0x1000}, yes, no, no,
+                                         unknown, yes, ConstString()),
+                        MemoryRegionInfo({0x7ffe0000, 0x1000}, yes, no, no,
+                                         unknown, yes, ConstString()),
+                        MemoryRegionInfo({0x7ffe1000, 0xf000}, no, no, no,
+                                         unknown, yes, ConstString())),
+                    true));
 }
 
 TEST_F(MinidumpParserTest, GetMemoryRegionInfoFromMemoryList) {
@@ -416,13 +415,12 @@ Streams:
 
   EXPECT_THAT(
       parser->BuildMemoryRegions(),
-      testing::Pair(
-          testing::ElementsAre(
-              MemoryRegionInfo({0x1000, 0x10}, yes, unknown, unknown, unknown,
-                               yes, ConstString(), unknown, 0),
-              MemoryRegionInfo({0x2000, 0x20}, yes, unknown, unknown, unknown,
-                               yes, ConstString(), unknown, 0)),
-          false));
+      testing::Pair(testing::ElementsAre(
+                        MemoryRegionInfo({0x1000, 0x10}, yes, unknown, unknown,
+                                         unknown, yes, ConstString()),
+                        MemoryRegionInfo({0x2000, 0x20}, yes, unknown, unknown,
+                                         unknown, yes, ConstString())),
+                    false));
 }
 
 TEST_F(MinidumpParserTest, GetMemoryRegionInfoFromMemory64List) {
@@ -432,13 +430,12 @@ TEST_F(MinidumpParserTest, GetMemoryRegionInfoFromMemory64List) {
   // we don't have a MemoryInfoListStream.
   EXPECT_THAT(
       parser->BuildMemoryRegions(),
-      testing::Pair(
-          testing::ElementsAre(
-              MemoryRegionInfo({0x1000, 0x10}, yes, unknown, unknown, unknown,
-                               yes, ConstString(), unknown, 0),
-              MemoryRegionInfo({0x2000, 0x20}, yes, unknown, unknown, unknown,
-                               yes, ConstString(), unknown, 0)),
-          false));
+      testing::Pair(testing::ElementsAre(
+                        MemoryRegionInfo({0x1000, 0x10}, yes, unknown, unknown,
+                                         unknown, yes, ConstString()),
+                        MemoryRegionInfo({0x2000, 0x20}, yes, unknown, unknown,
+                                         unknown, yes, ConstString())),
+                    false));
 }
 
 TEST_F(MinidumpParserTest, GetMemoryRegionInfoLinuxMaps) {
@@ -462,22 +459,21 @@ Streams:
   ConstString app_process("/system/bin/app_process");
   ConstString linker("/system/bin/linker");
   ConstString liblog("/system/lib/liblog.so");
-  EXPECT_THAT(
-      parser->BuildMemoryRegions(),
-      testing::Pair(testing::ElementsAre(
-                        MemoryRegionInfo({0x400d9000, 0x2000}, yes, no, yes, no,
-                                         yes, app_process, unknown, 0),
-                        MemoryRegionInfo({0x400db000, 0x1000}, yes, no, no, no,
-                                         yes, app_process, unknown, 0),
-                        MemoryRegionInfo({0x400dc000, 0x1000}, yes, yes, no, no,
-                                         yes, ConstString(), unknown, 0),
-                        MemoryRegionInfo({0x400ec000, 0x1000}, yes, no, no, no,
-                                         yes, ConstString(), unknown, 0),
-                        MemoryRegionInfo({0x400ee000, 0x1000}, yes, yes, no, no,
-                                         yes, linker, unknown, 0),
-                        MemoryRegionInfo({0x400fc000, 0x1000}, yes, yes, yes,
-                                         no, yes, liblog, unknown, 0)),
-                    true));
+  EXPECT_THAT(parser->BuildMemoryRegions(),
+              testing::Pair(testing::ElementsAre(
+                                MemoryRegionInfo({0x400d9000, 0x2000}, yes, no,
+                                                 yes, no, yes, app_process),
+                                MemoryRegionInfo({0x400db000, 0x1000}, yes, no,
+                                                 no, no, yes, app_process),
+                                MemoryRegionInfo({0x400dc000, 0x1000}, yes, yes,
+                                                 no, no, yes, ConstString()),
+                                MemoryRegionInfo({0x400ec000, 0x1000}, yes, no,
+                                                 no, no, yes, ConstString()),
+                                MemoryRegionInfo({0x400ee000, 0x1000}, yes, yes,
+                                                 no, no, yes, linker),
+                                MemoryRegionInfo({0x400fc000, 0x1000}, yes, yes,
+                                                 yes, no, yes, liblog)),
+                            true));
 }
 
 TEST_F(MinidumpParserTest, GetMemoryRegionInfoLinuxMapsError) {
@@ -496,7 +492,7 @@ Streams:
   EXPECT_THAT(parser->BuildMemoryRegions(),
               testing::Pair(testing::ElementsAre(MemoryRegionInfo(
                                 {0x400fc000, 0x1000}, yes, yes, yes, no, yes,
-                                ConstString(nullptr), unknown, 0)),
+                                ConstString(nullptr))),
                             true));
 }
 

--- a/lldb/unittests/Process/minidump/MinidumpParserTest.cpp
+++ b/lldb/unittests/Process/minidump/MinidumpParserTest.cpp
@@ -385,15 +385,15 @@ Streams:
       testing::Pair(
           testing::ElementsAre(
               MemoryRegionInfo({0x0, 0x10000}, no, no, no, unknown, no,
-                               ConstString(), unknown, 0, unknown, unknown),
+                               ConstString(), unknown, 0, unknown),
               MemoryRegionInfo({0x10000, 0x21000}, yes, yes, no, unknown, yes,
-                               ConstString(), unknown, 0, unknown, unknown),
+                               ConstString(), unknown, 0, unknown),
               MemoryRegionInfo({0x40000, 0x1000}, yes, no, no, unknown, yes,
-                               ConstString(), unknown, 0, unknown, unknown),
+                               ConstString(), unknown, 0, unknown),
               MemoryRegionInfo({0x7ffe0000, 0x1000}, yes, no, no, unknown, yes,
-                               ConstString(), unknown, 0, unknown, unknown),
+                               ConstString(), unknown, 0, unknown),
               MemoryRegionInfo({0x7ffe1000, 0xf000}, no, no, no, unknown, yes,
-                               ConstString(), unknown, 0, unknown, unknown)),
+                               ConstString(), unknown, 0, unknown)),
           true));
 }
 
@@ -416,14 +416,13 @@ Streams:
 
   EXPECT_THAT(
       parser->BuildMemoryRegions(),
-      testing::Pair(testing::ElementsAre(
-                        MemoryRegionInfo({0x1000, 0x10}, yes, unknown, unknown,
-                                         unknown, yes, ConstString(), unknown,
-                                         0, unknown, unknown),
-                        MemoryRegionInfo({0x2000, 0x20}, yes, unknown, unknown,
-                                         unknown, yes, ConstString(), unknown,
-                                         0, unknown, unknown)),
-                    false));
+      testing::Pair(
+          testing::ElementsAre(
+              MemoryRegionInfo({0x1000, 0x10}, yes, unknown, unknown, unknown,
+                               yes, ConstString(), unknown, 0, unknown),
+              MemoryRegionInfo({0x2000, 0x20}, yes, unknown, unknown, unknown,
+                               yes, ConstString(), unknown, 0, unknown)),
+          false));
 }
 
 TEST_F(MinidumpParserTest, GetMemoryRegionInfoFromMemory64List) {
@@ -433,14 +432,13 @@ TEST_F(MinidumpParserTest, GetMemoryRegionInfoFromMemory64List) {
   // we don't have a MemoryInfoListStream.
   EXPECT_THAT(
       parser->BuildMemoryRegions(),
-      testing::Pair(testing::ElementsAre(
-                        MemoryRegionInfo({0x1000, 0x10}, yes, unknown, unknown,
-                                         unknown, yes, ConstString(), unknown,
-                                         0, unknown, unknown),
-                        MemoryRegionInfo({0x2000, 0x20}, yes, unknown, unknown,
-                                         unknown, yes, ConstString(), unknown,
-                                         0, unknown, unknown)),
-                    false));
+      testing::Pair(
+          testing::ElementsAre(
+              MemoryRegionInfo({0x1000, 0x10}, yes, unknown, unknown, unknown,
+                               yes, ConstString(), unknown, 0, unknown),
+              MemoryRegionInfo({0x2000, 0x20}, yes, unknown, unknown, unknown,
+                               yes, ConstString(), unknown, 0, unknown)),
+          false));
 }
 
 TEST_F(MinidumpParserTest, GetMemoryRegionInfoLinuxMaps) {
@@ -464,23 +462,22 @@ Streams:
   ConstString app_process("/system/bin/app_process");
   ConstString linker("/system/bin/linker");
   ConstString liblog("/system/lib/liblog.so");
-  EXPECT_THAT(
-      parser->BuildMemoryRegions(),
-      testing::Pair(
-          testing::ElementsAre(
-              MemoryRegionInfo({0x400d9000, 0x2000}, yes, no, yes, no, yes,
-                               app_process, unknown, 0, unknown, unknown),
-              MemoryRegionInfo({0x400db000, 0x1000}, yes, no, no, no, yes,
-                               app_process, unknown, 0, unknown, unknown),
-              MemoryRegionInfo({0x400dc000, 0x1000}, yes, yes, no, no, yes,
-                               ConstString(), unknown, 0, unknown, unknown),
-              MemoryRegionInfo({0x400ec000, 0x1000}, yes, no, no, no, yes,
-                               ConstString(), unknown, 0, unknown, unknown),
-              MemoryRegionInfo({0x400ee000, 0x1000}, yes, yes, no, no, yes,
-                               linker, unknown, 0, unknown, unknown),
-              MemoryRegionInfo({0x400fc000, 0x1000}, yes, yes, yes, no, yes,
-                               liblog, unknown, 0, unknown, unknown)),
-          true));
+  EXPECT_THAT(parser->BuildMemoryRegions(),
+              testing::Pair(
+                  testing::ElementsAre(
+                      MemoryRegionInfo({0x400d9000, 0x2000}, yes, no, yes, no,
+                                       yes, app_process, unknown, 0, unknown),
+                      MemoryRegionInfo({0x400db000, 0x1000}, yes, no, no, no,
+                                       yes, app_process, unknown, 0, unknown),
+                      MemoryRegionInfo({0x400dc000, 0x1000}, yes, yes, no, no,
+                                       yes, ConstString(), unknown, 0, unknown),
+                      MemoryRegionInfo({0x400ec000, 0x1000}, yes, no, no, no,
+                                       yes, ConstString(), unknown, 0, unknown),
+                      MemoryRegionInfo({0x400ee000, 0x1000}, yes, yes, no, no,
+                                       yes, linker, unknown, 0, unknown),
+                      MemoryRegionInfo({0x400fc000, 0x1000}, yes, yes, yes, no,
+                                       yes, liblog, unknown, 0, unknown)),
+                  true));
 }
 
 TEST_F(MinidumpParserTest, GetMemoryRegionInfoLinuxMapsError) {
@@ -496,12 +493,11 @@ Streams:
                     llvm::Succeeded());
   // Test that when a /proc/maps region fails to parse
   // we handle the error and continue with the rest.
-  EXPECT_THAT(
-      parser->BuildMemoryRegions(),
-      testing::Pair(testing::ElementsAre(MemoryRegionInfo(
-                        {0x400fc000, 0x1000}, yes, yes, yes, no, yes,
-                        ConstString(nullptr), unknown, 0, unknown, unknown)),
-                    true));
+  EXPECT_THAT(parser->BuildMemoryRegions(),
+              testing::Pair(testing::ElementsAre(MemoryRegionInfo(
+                                {0x400fc000, 0x1000}, yes, yes, yes, no, yes,
+                                ConstString(nullptr), unknown, 0, unknown)),
+                            true));
 }
 
 // Windows Minidump tests


### PR DESCRIPTION
This was requested on https://github.com/llvm/llvm-project/pull/182246 where I am adding yet another memory region property.

This PR contains several individual commits that I intend to push separately if they pass review. I have uploaded them as one PR so reviewers can be confident with the direction I'm going in.

I suggest you look at the complete changes to see the end goal, and the individual commits for anything more detailed.

The two types of change are:
* Removing arguments that were only ever set to default values.
* Anything that was sometimes set to a non-default value, I have changed the setter into a builder function.