### PR TITLE
[libc] Increase the maximum RPC port size for future hardware

### DIFF
--- a/libc/shared/rpc.h
+++ b/libc/shared/rpc.h
@@ -69,7 +69,9 @@ struct Header {
 };
 
 /// The maximum number of parallel ports that the RPC interface can support.
-constexpr static uint64_t MAX_PORT_COUNT = 4096;
+/// This should be greater than the expected hardware's occupancy to ensure the
+/// interface is non-blocking.
+constexpr static uint64_t MAX_PORT_COUNT = 16384;
 
 /// A common process used to synchronize communication between a client and a
 /// server. The process contains a read-only inbox and a write-only outbox used


### PR DESCRIPTION
Summary:
We store the locks in local device memory for performance and
simplicity. The number here needs to correspond to the maximum occupancy
so that we never have a situation where a GPU thread is blocking another
GPU thread.

The number now is sufficient for most hardware, but modern compute chips
like the MI300x are already pushing ~12000 resident waves. This has ABI
impliciations so I'd like to bump it up sooner rather than later. The
ABI change is within what OpenMP expects, LLVM major versions, and it
will be caught statically so there's no risk of silent corruption (size
doesn't match).
