### PR TITLE
[lldb][windows] fix invalid indexes in LLDB_LOG call

### DIFF
--- a/lldb/source/Plugins/ObjectFile/COFF/ObjectFileCOFF.cpp
+++ b/lldb/source/Plugins/ObjectFile/COFF/ObjectFileCOFF.cpp
@@ -93,7 +93,7 @@ ObjectFileCOFF::CreateInstance(const ModuleSP &module_sp,
     return nullptr;
   }
 
-  LLDB_LOG(log, "ObjectFileCOFF::ObjectFileCOFF module = {1} ({2}), file = {3}",
+  LLDB_LOG(log, "ObjectFileCOFF::ObjectFileCOFF module = {0} ({1}), file = {2}",
            module_sp.get(), module_sp->GetSpecificationDescription(),
            file->GetPath());
 


### PR DESCRIPTION
This patch shifts the indexes of the `LLDB_LOG` call by -1 so that they start at 0. Otherwise, the call expects 4 arguments.