### PR TITLE
[Dexter][Dbgeng] Don't replace '.' with '->' in expressions

### DIFF
--- a/cross-project-tests/debuginfo-tests/dexter/dex/debugger/dbgeng/dbgeng.py
+++ b/cross-project-tests/debuginfo-tests/dexter/dex/debugger/dbgeng/dbgeng.py
@@ -176,16 +176,12 @@ class DbgEng(DebuggerBase):
         return self.finished
 
     def evaluate_expression(self, expression, frame_idx=0):
-        # XXX: cdb insists on using '->' to examine fields of structures,
-        # as it appears to reserve '.' for other purposes.
-        fixed_expr = expression.replace(".", "->")
-
         orig_scope_idx = self.client.Symbols.GetCurrentScopeFrameIndex()
         self.client.Symbols.SetScopeFrameByIndex(frame_idx)
 
-        res = self.client.Control.Evaluate(fixed_expr)
+        res = self.client.Control.Evaluate(expression)
         if res is not None:
-            result, typename = self.client.Control.Evaluate(fixed_expr)
+            result, typename = self.client.Control.Evaluate(expression)
             could_eval = True
         else:
             result, typename = (None, None)


### PR DESCRIPTION
After #187709, the [nrvo.cpp](https://github.com/llvm/llvm-project/blob/3a56470a0ee68b26ffe93f5079de58ed22f5dc18/cross-project-tests/debuginfo-tests/dexter-tests/nrvo.cpp) test failed (e.g. https://lab.llvm.org/buildbot/#/builders/46/builds/32858), because it couldn't evaluate the expression `result.i` anymore. This was because it actually evaluated `result->i`, which doesn't work anymore as `result` is not a pointer or reference. Before #187709, `result` was declared as a reference that lives at `frame-pointer+offset`.
Now it's no longer a reference, but the location is `*(frame-pointer+offset) + 0`.

There weren't any other tests that were accessing struct fields and used dbgeng as the debugger.