### PR TITLE
[cross-project-tests] un-XFAIL/XFAIL dexter tests on Linux

### DIFF
--- a/cross-project-tests/debuginfo-tests/dexter-tests/memvars/const-branch.c
+++ b/cross-project-tests/debuginfo-tests/dexter-tests/memvars/const-branch.c
@@ -1,4 +1,4 @@
-// XFAIL: !system-darwin || !target-aarch64
+// XFAIL: !system-darwin
 //// Suboptimal coverage, see inlined comments.
 
 // REQUIRES: lldb

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/expect_step_kind/direction.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/expect_step_kind/direction.cpp
@@ -10,6 +10,9 @@
 // TODO: The dbgeng debugger does not support column step reporting at present.
 // XFAIL: system-windows
 //
+// TODO: fails in on Linux CI (https://github.com/llvm/llvm-project/issues/188775)
+// XFAIL: system-linux
+//
 // RUN: %dexter_regression_test_cxx_build %s -o %t
 // RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
 // CHECK: direction.cpp:

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/expect_step_kind/direction.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/expect_step_kind/direction.cpp
@@ -10,7 +10,7 @@
 // TODO: The dbgeng debugger does not support column step reporting at present.
 // XFAIL: system-windows
 //
-// TODO: fails in on Linux CI (https://github.com/llvm/llvm-project/issues/188775)
+// TODO: fails in on Linux CI (llvm-project/issues/188775)
 // XFAIL: system-linux
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t


### PR DESCRIPTION
See https://github.com/llvm/llvm-project/issues/188775 for the XFAILed test.

The other was failing as XPASS on AArch64.

This is part of enabling the tests on PR CI
(https://github.com/llvm/llvm-project/pull/188522)