### PR TITLE
[cross-project-tests] Add `has-gdb` LIT feature

### DIFF
--- a/cross-project-tests/debuginfo-tests/llgdb-tests/forward-declare-class.cpp
+++ b/cross-project-tests/debuginfo-tests/llgdb-tests/forward-declare-class.cpp
@@ -1,6 +1,7 @@
 // RUN: %clangxx %target_itanium_abi_host_triple -O0 -g %s -c -o %t.o
 // RUN: %test_debuginfo %s %t.o
 // Radar 9168773
+// REQUIRES: system-darwin || has-gdb
 // XFAIL: !system-darwin && gdb-clang-incompatibility
 
 // DEBUGGER: ptype A

--- a/cross-project-tests/debuginfo-tests/llgdb-tests/nested-struct.cpp
+++ b/cross-project-tests/debuginfo-tests/llgdb-tests/nested-struct.cpp
@@ -1,3 +1,5 @@
+// REQUIRES: system-darwin || has-gdb
+//
 // RUN: %clangxx %target_itanium_abi_host_triple -O0 -g %s -c -o %t.o
 // RUN: %test_debuginfo %s %t.o
 // XFAIL: !system-darwin && gdb-clang-incompatibility

--- a/cross-project-tests/debuginfo-tests/llgdb-tests/nrvo-string.cpp
+++ b/cross-project-tests/debuginfo-tests/llgdb-tests/nrvo-string.cpp
@@ -1,3 +1,5 @@
+// REQUIRES: system-darwin || has-gdb
+//
 // This ensures that DW_OP_deref is inserted when necessary, such as when NRVO
 // of a string object occurs in C++.
 //

--- a/cross-project-tests/debuginfo-tests/llgdb-tests/nrvo-string.cpp
+++ b/cross-project-tests/debuginfo-tests/llgdb-tests/nrvo-string.cpp
@@ -3,10 +3,14 @@
 // This ensures that DW_OP_deref is inserted when necessary, such as when NRVO
 // of a string object occurs in C++.
 //
-// RUN: %clangxx -O0 -fno-exceptions %target_itanium_abi_host_triple %s -o %t.out -g
+// RUN: %clangxx -O0 -fno-exceptions %target_itanium_abi_host_triple %s \
+// RUN:    -o %t.out -g
 // RUN: %test_debuginfo %s %t.out
-// RUN: %clangxx -O1 -fno-exceptions %target_itanium_abi_host_triple %s -o %t.out -g
+
+// RUN: %clangxx -O1 -fno-exceptions %target_itanium_abi_host_triple %s \
+// RUN:     -o %t.out -g
 // RUN: %test_debuginfo %s %t.out
+
 // XFAIL: !system-darwin && gdb-clang-incompatibility
 // PR34513
 volatile int sideeffect = 0;

--- a/cross-project-tests/debuginfo-tests/llgdb-tests/sret.cpp
+++ b/cross-project-tests/debuginfo-tests/llgdb-tests/sret.cpp
@@ -1,3 +1,5 @@
+// REQUIRES: system-darwin || has-gdb
+//
 // RUN: %clangxx %target_itanium_abi_host_triple -O0 -g %s -c -o %t.o
 // RUN: %clangxx %target_itanium_abi_host_triple %t.o -o %t.out
 // RUN: %test_debuginfo %s %t.out

--- a/cross-project-tests/debuginfo-tests/llgdb-tests/static-member-2.cpp
+++ b/cross-project-tests/debuginfo-tests/llgdb-tests/static-member-2.cpp
@@ -1,3 +1,5 @@
+// REQUIRES: system-darwin || has-gdb
+//
 // RUN: %clangxx %target_itanium_abi_host_triple -O0 -g %s -o %t -c
 // RUN: %clangxx %target_itanium_abi_host_triple %t -o %t.out
 // RUN: %test_debuginfo %s %t.out

--- a/cross-project-tests/debuginfo-tests/llgdb-tests/static-member.cpp
+++ b/cross-project-tests/debuginfo-tests/llgdb-tests/static-member.cpp
@@ -1,3 +1,5 @@
+// REQUIRES: system-darwin || has-gdb
+//
 // RUN: %clangxx %target_itanium_abi_host_triple -O0 -g %s -o %t -c
 // RUN: %clangxx %target_itanium_abi_host_triple %t -o %t.out
 // RUN: %test_debuginfo %s %t.out

--- a/cross-project-tests/lit.cfg.py
+++ b/cross-project-tests/lit.cfg.py
@@ -357,6 +357,19 @@ def set_apple_lldb_pre_1000_feature():
 # platform and the installed gdb version.
 dwarf_version_string = get_clang_default_dwarf_version_string(config.host_triple)
 gdb_version_string = get_gdb_version_string()
+
+if gdb_version_string:
+    config.available_features.add("has-gdb")
+    print(
+        f"Found GDB version '{gdb_version_string}'",
+        file=sys.stderr,
+    )
+else:
+    print(
+        "No GDB found on host. Skipping tests that require GDB.",
+        file=sys.stderr,
+    )
+
 if dwarf_version_string and gdb_version_string:
     if int(dwarf_version_string) >= 5:
         try:


### PR DESCRIPTION
This patch adds a `has-gdb` LIT feature that I then use in the `REQUIRES` clause for `llgdb` tests.

These tests were failing because `llgdb.py` couldn't find `gdb` on the host when I tried enabling these tests on PR CI (https://github.com/llvm/llvm-project/issues/188775).

We should get `gdb` installed on the buildbots. But we should also be able to run the rest of the `cross-project-tests` in the meantime even if gdb isn't installed.