### PR TITLE
[XRay] Always register constructor(0) alongside .preinit_array

### DIFF
--- a/compiler-rt/lib/xray/xray_init.cpp
+++ b/compiler-rt/lib/xray/xray_init.cpp
@@ -252,11 +252,15 @@ __xray_deregister_dso(int32_t ObjId) XRAY_NEVER_INSTRUMENT {
 // Only add the preinit array initialization if the sanitizers can.
 __attribute__((section(".preinit_array"),
                used)) void (*__local_xray_preinit)(void) = __xray_init;
-#else
-// If we cannot use the .preinit_array section, we should instead use dynamic
-// initialisation.
-__attribute__ ((constructor (0)))
-static void __local_xray_dyninit() {
+#endif
+
+// Always register a constructor as well.  On platforms where .preinit_array
+// works (glibc), __xray_init will have already run and the constructor returns
+// immediately.  On platforms where .preinit_array is not processed (e.g. musl),
+// the constructor ensures __xray_init runs before other .init_array entries
+// that depend on XRay flags being initialized.
+#if !defined(XRAY_NO_PREINIT)
+__attribute__((constructor(0))) static void __local_xray_dyninit() {
   __xray_init();
 }
 #endif

--- a/compiler-rt/lib/xray/xray_interface_internal.h
+++ b/compiler-rt/lib/xray/xray_interface_internal.h
@@ -21,6 +21,12 @@
 #include <utility>
 
 extern "C" {
+
+// Ensure XRay is initialized. Safe to call multiple times; the first call
+// performs flag parsing, sled registration, and (if requested) pre-main
+// patching.  Subsequent calls return immediately.
+extern void __xray_init();
+
 // The following functions have to be defined in assembler, on a per-platform
 // basis. See xray_trampoline_*.S files for implementations.
 extern void __xray_FunctionEntry();

--- a/compiler-rt/lib/xray/xray_interface_internal.h
+++ b/compiler-rt/lib/xray/xray_interface_internal.h
@@ -21,12 +21,6 @@
 #include <utility>
 
 extern "C" {
-
-// Ensure XRay is initialized. Safe to call multiple times; the first call
-// performs flag parsing, sled registration, and (if requested) pre-main
-// patching.  Subsequent calls return immediately.
-extern void __xray_init();
-
 // The following functions have to be defined in assembler, on a per-platform
 // basis. See xray_trampoline_*.S files for implementations.
 extern void __xray_FunctionEntry();


### PR DESCRIPTION
On musl-based systems the dynamic linker does not process DT_PREINIT_ARRAY, so the .preinit_array entry alone never calls __xray_init().  Without initialization, the global XRay Flags struct is zero-initialized and flags()->xray_mode is NULL.  When the basic-mode or FDR-mode static initializers run from .init_array and call internal_strcmp(flags()->xray_mode, ...), they dereference NULL and crash.

Fix this by always registering a constructor(0) in addition to the .preinit_array entry.  On glibc where .preinit_array works, __xray_init() will have already run and the constructor returns immediately (the function is idempotent).  On musl, the constructor ensures __xray_init() runs before other .init_array entries that depend on XRay flags being initialized.