### PR TITLE
[SPIR-V] Support for C++ for OpenCL source language

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVModuleAnalysis.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVModuleAnalysis.cpp
@@ -182,6 +182,23 @@ void SPIRVModuleAnalysis::setBaseInfo(const Module &M) {
     // Prevent Major part of OpenCL version to be 0
     MAI.SrcLangVersion =
         (std::max(1U, MajorNum) * 100 + MinorNum) * 1000 + RevNum;
+    // When opencl.cxx.version is also present, validate compatibility
+    // and use C++ for OpenCL as source language with the C++ version.
+    if (auto *CxxVerNode = M.getNamedMetadata("opencl.cxx.version")) {
+      assert(CxxVerNode->getNumOperands() > 0 && "Invalid SPIR");
+      auto *CxxMD = CxxVerNode->getOperand(0);
+      unsigned CxxVer =
+          (getMetadataUInt(CxxMD, 0) * 100 + getMetadataUInt(CxxMD, 1)) * 1000 +
+          getMetadataUInt(CxxMD, 2);
+      if ((MAI.SrcLangVersion == 200000 && CxxVer == 100000) ||
+          (MAI.SrcLangVersion == 300000 && CxxVer == 202100000)) {
+        MAI.SrcLang = SPIRV::SourceLanguage::CPP_for_OpenCL;
+        MAI.SrcLangVersion = CxxVer;
+      } else {
+        report_fatal_error(
+            "opencl cxx version is not compatible with opencl c version!");
+      }
+    }
   } else {
     // If there is no information about OpenCL version we are forced to generate
     // OpenCL 1.0 by default for the OpenCL environment to avoid puzzling

--- a/llvm/lib/Target/SPIRV/SPIRVSymbolicOperands.td
+++ b/llvm/lib/Target/SPIRV/SPIRVSymbolicOperands.td
@@ -662,6 +662,7 @@ defm GLSL : SourceLanguageOperand<2>;
 defm OpenCL_C : SourceLanguageOperand<3>;
 defm OpenCL_CPP : SourceLanguageOperand<4>;
 defm HLSL : SourceLanguageOperand<5>;
+defm CPP_for_OpenCL : SourceLanguageOperand<6>;
 
 //===----------------------------------------------------------------------===//
 // Multiclass used to define AddressingModel enum values and at the same time

--- a/llvm/test/CodeGen/SPIRV/opencl-cxx-version-2021.ll
+++ b/llvm/test/CodeGen/SPIRV/opencl-cxx-version-2021.ll
@@ -6,9 +6,6 @@
 
 ; CHECK: OpSource CPP_for_OpenCL 202100000
 
-target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-G1"
-target triple = "spir64-unknown-unknown"
-
 define spir_kernel void @foo() {
 entry:
   ret void

--- a/llvm/test/CodeGen/SPIRV/opencl-cxx-version-2021.ll
+++ b/llvm/test/CodeGen/SPIRV/opencl-cxx-version-2021.ll
@@ -1,4 +1,5 @@
 ; RUN: llc -O0 -mtriple=spirv64-unknown-unknown %s -o - | FileCheck %s
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv64-unknown-unknown %s -o - -filetype=obj | spirv-val %}
 
 ; When both opencl.ocl.version (3.0) and opencl.cxx.version (2021) are present,
 ; the source language should be OpenCL C++ with version 202100000.

--- a/llvm/test/CodeGen/SPIRV/opencl-cxx-version-2021.ll
+++ b/llvm/test/CodeGen/SPIRV/opencl-cxx-version-2021.ll
@@ -1,0 +1,21 @@
+; RUN: llc -O0 -mtriple=spirv64-unknown-unknown %s -o - | FileCheck %s
+
+; When both opencl.ocl.version (3.0) and opencl.cxx.version (2021) are present,
+; the source language should be OpenCL C++ with version 202100000.
+
+; CHECK: OpSource CPP_for_OpenCL 202100000
+
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-G1"
+target triple = "spir64-unknown-unknown"
+
+define spir_kernel void @foo() {
+entry:
+  ret void
+}
+
+!opencl.ocl.version = !{!0}
+!opencl.cxx.version = !{!1}
+!opencl.spir.version = !{!0}
+
+!0 = !{i32 3, i32 0}
+!1 = !{i32 2021, i32 0}

--- a/llvm/test/CodeGen/SPIRV/opencl-cxx-version-incompatible.ll
+++ b/llvm/test/CodeGen/SPIRV/opencl-cxx-version-incompatible.ll
@@ -5,9 +5,6 @@
 
 ; CHECK: LLVM ERROR: opencl cxx version is not compatible with opencl c version!
 
-target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-G1"
-target triple = "spir64-unknown-unknown"
-
 define spir_kernel void @foo() {
 entry:
   ret void

--- a/llvm/test/CodeGen/SPIRV/opencl-cxx-version-incompatible.ll
+++ b/llvm/test/CodeGen/SPIRV/opencl-cxx-version-incompatible.ll
@@ -1,0 +1,20 @@
+; RUN: not --crash llc -O0 -mtriple=spirv64-unknown-unknown %s -o - 2>&1 | FileCheck %s
+
+; Incompatible OpenCL C and C++ versions should produce a fatal error.
+; OpenCL C 2.0 is not compatible with C++ for OpenCL 2021.
+
+; CHECK: LLVM ERROR: opencl cxx version is not compatible with opencl c version!
+
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-G1"
+target triple = "spir64-unknown-unknown"
+
+define spir_kernel void @foo() {
+entry:
+  ret void
+}
+
+!opencl.ocl.version = !{!0}
+!opencl.cxx.version = !{!1}
+
+!0 = !{i32 2, i32 0}
+!1 = !{i32 2021, i32 0}

--- a/llvm/test/CodeGen/SPIRV/opencl-cxx-version.ll
+++ b/llvm/test/CodeGen/SPIRV/opencl-cxx-version.ll
@@ -6,9 +6,6 @@
 
 ; CHECK: OpSource CPP_for_OpenCL 100000
 
-target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-G1"
-target triple = "spir64-unknown-unknown"
-
 define spir_kernel void @foo() {
 entry:
   ret void

--- a/llvm/test/CodeGen/SPIRV/opencl-cxx-version.ll
+++ b/llvm/test/CodeGen/SPIRV/opencl-cxx-version.ll
@@ -1,0 +1,21 @@
+; RUN: llc -O0 -mtriple=spirv64-unknown-unknown %s -o - | FileCheck %s
+
+; When both opencl.ocl.version (2.0) and opencl.cxx.version (1.0) are present,
+; the source language should be OpenCL C++ with version 100000
+
+; CHECK: OpSource CPP_for_OpenCL 100000
+
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-G1"
+target triple = "spir64-unknown-unknown"
+
+define spir_kernel void @foo() {
+entry:
+  ret void
+}
+
+!opencl.ocl.version = !{!0}
+!opencl.cxx.version = !{!1}
+!opencl.spir.version = !{!0}
+
+!0 = !{i32 2, i32 0}
+!1 = !{i32 1, i32 0}

--- a/llvm/test/CodeGen/SPIRV/opencl-cxx-version.ll
+++ b/llvm/test/CodeGen/SPIRV/opencl-cxx-version.ll
@@ -1,4 +1,5 @@
 ; RUN: llc -O0 -mtriple=spirv64-unknown-unknown %s -o - | FileCheck %s
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv64-unknown-unknown %s -o - -filetype=obj | spirv-val %}
 
 ; When both opencl.ocl.version (2.0) and opencl.cxx.version (1.0) are present,
 ; the source language should be OpenCL C++ with version 100000


### PR DESCRIPTION
- Add CPP_for_OpenCL source language operand
- Handle opencl.cxx.version metadata

Align handling with SPIR-V translator logic and tests presented there