### PR TITLE
[clang][analyzer] Add location to CTU failure diagnostics

### DIFF
--- a/clang/include/clang/CrossTU/CrossTranslationUnit.h
+++ b/clang/include/clang/CrossTU/CrossTranslationUnit.h
@@ -184,7 +184,7 @@ public:
   static std::optional<std::string> getLookupName(const Decl *D);
 
   /// Emit diagnostics for the user for potential configuration errors.
-  void emitCrossTUDiagnostics(const IndexError &IE);
+  void emitCrossTUDiagnostics(const IndexError &IE, SourceLocation Loc);
 
   /// Returns the MacroExpansionContext for the imported TU to which the given
   /// source-location corresponds.

--- a/clang/lib/CrossTU/CrossTranslationUnit.cpp
+++ b/clang/lib/CrossTU/CrossTranslationUnit.cpp
@@ -379,22 +379,23 @@ CrossTranslationUnitContext::getCrossTUDefinition(const VarDecl *VD,
                                   DisplayCTUProgress);
 }
 
-void CrossTranslationUnitContext::emitCrossTUDiagnostics(const IndexError &IE) {
+void CrossTranslationUnitContext::emitCrossTUDiagnostics(const IndexError &IE,
+                                                         SourceLocation Loc) {
   switch (IE.getCode()) {
   case index_error_code::missing_index_file:
-    Context.getDiagnostics().Report(diag::err_ctu_error_opening)
+    Context.getDiagnostics().Report(Loc, diag::err_ctu_error_opening)
         << IE.getFileName();
     return;
   case index_error_code::invalid_index_format:
-    Context.getDiagnostics().Report(diag::err_extdefmap_parsing)
+    Context.getDiagnostics().Report(Loc, diag::err_extdefmap_parsing)
         << IE.getFileName() << IE.getLineNum();
     return;
   case index_error_code::multiple_definitions:
-    Context.getDiagnostics().Report(diag::err_multiple_def_index)
+    Context.getDiagnostics().Report(Loc, diag::err_multiple_def_index)
         << IE.getLineNum();
     return;
   case index_error_code::triple_mismatch:
-    Context.getDiagnostics().Report(diag::warn_ctu_incompat_triple)
+    Context.getDiagnostics().Report(Loc, diag::warn_ctu_incompat_triple)
         << IE.getFileName() << IE.getTripleToName() << IE.getTripleFromName();
     return;
   case index_error_code::success:

--- a/clang/lib/StaticAnalyzer/Core/CallEvent.cpp
+++ b/clang/lib/StaticAnalyzer/Core/CallEvent.cpp
@@ -623,7 +623,9 @@ RuntimeDefinition AnyFunctionCall::getRuntimeDefinition() const {
   if (!CTUDeclOrError) {
     handleAllErrors(CTUDeclOrError.takeError(),
                     [&](const cross_tu::IndexError &IE) {
-                      CTUCtx.emitCrossTUDiagnostics(IE);
+                      auto Loc = getOriginExpr() ? getOriginExpr()->getExprLoc()
+                                                 : FD->getLocation();
+                      CTUCtx.emitCrossTUDiagnostics(IE, Loc);
                     });
     return {};
   }

--- a/clang/lib/StaticAnalyzer/Frontend/AnalysisConsumer.cpp
+++ b/clang/lib/StaticAnalyzer/Frontend/AnalysisConsumer.cpp
@@ -309,7 +309,7 @@ public:
     if (!CTUDeclOrError) {
       handleAllErrors(CTUDeclOrError.takeError(),
                       [&](const cross_tu::IndexError &IE) {
-                        CTU.emitCrossTUDiagnostics(IE);
+                        CTU.emitCrossTUDiagnostics(IE, VD->getLocation());
                       });
     }
 

--- a/clang/test/Analysis/ctu/diag/invalid-index.cpp
+++ b/clang/test/Analysis/ctu/diag/invalid-index.cpp
@@ -8,11 +8,8 @@
 // RUN:   -analyzer-config ctu-dir=%t \
 // RUN:   -verify %s
 
-// We expect an error in this file, but without a location.
-// expected-error-re@./invalid-index.cpp:*{{error parsing index file: '{{.+}}externalDefMap.txt' line: 1 '<USR-Length>:<USR> <File-Path>' format expected}}
-
 int foo(int);
 
 void test() {
-  foo(1);
+  foo(1); // expected-error-re{{error parsing index file: '{{.+}}externalDefMap.txt' line: 1 '<USR-Length>:<USR> <File-Path>' format expected}}
 }

--- a/clang/test/Analysis/ctu/diag/missing-index.cpp
+++ b/clang/test/Analysis/ctu/diag/missing-index.cpp
@@ -8,11 +8,8 @@
 // RUN:   -analyzer-config ctu-index-name=non-existing.txt \
 // RUN:   -verify %s
 
-// We expect an error in this file, but without a location.
-// expected-error-re@./missing-index.cpp:*{{error opening '{{.+}}non-existing.txt': required by the CrossTU functionality}}
-
 int foo(int);
 
 void test() {
-  foo(1);
+  foo(1); // expected-error-re{{error opening '{{.+}}non-existing.txt': required by the CrossTU functionality}}
 }

--- a/clang/test/Analysis/ctu/different-triples.cpp
+++ b/clang/test/Analysis/ctu/different-triples.cpp
@@ -10,11 +10,8 @@
 // RUN:   -Werror=ctu \
 // RUN:   -verify %s
 
-// We expect an error in this file, but without a location.
-// expected-error-re@./different-triples.cpp:*{{imported AST from {{.*}} had been generated for a different target, current: powerpc64-montavista-linux-gnu, imported: x86_64-pc-linux-gnu}}
-
 int f(int);
 
 int main() {
-  return f(5);
+  return f(5); // expected-error-re{{imported AST from '{{.*}}' had been generated for a different target, current: powerpc64-montavista-linux-gnu, imported: x86_64-pc-linux-gnu}}
 }


### PR DESCRIPTION
Report CTU import failures at the place where the imported symbol would be used. This helps to quicker understand why CSA might miss a certain expected CTU bug.

--
CPP-7804