### PR TITLE
[CMake] Remove logic that's no longer needed

### DIFF
--- a/llvm/CMakeLists.txt
+++ b/llvm/CMakeLists.txt
@@ -85,20 +85,6 @@ Learn more about the options in our documentation at https://llvm.org/docs/CMake
   set(CMAKE_BUILD_TYPE Release CACHE STRING "Choose the type of build, options are: None Debug Release RelWithDebInfo MinSizeRel" FORCE)
 endif()
 
-# Set default build type for cmake's try_compile module.
-# CMake 3.17 or newer sets CMAKE_DEFAULT_BUILD_TYPE to one of the
-# items from CMAKE_CONFIGURATION_TYPES. Logic below can be further
-# simplified once LLVM's minimum CMake version is updated to 3.17.
-if(CMAKE_DEFAULT_BUILD_TYPE)
-  set(CMAKE_TRY_COMPILE_CONFIGURATION ${CMAKE_DEFAULT_BUILD_TYPE})
-else()
-  if(CMAKE_CONFIGURATION_TYPES)
-    list(GET CMAKE_CONFIGURATION_TYPES 0 CMAKE_TRY_COMPILE_CONFIGURATION)
-  elseif(CMAKE_BUILD_TYPE)
-    set(CMAKE_TRY_COMPILE_CONFIGURATION ${CMAKE_BUILD_TYPE})
-  endif()
-endif()
-
 # Side-by-side subprojects layout: automatically set the
 # LLVM_EXTERNAL_${project}_SOURCE_DIR using LLVM_ALL_PROJECTS
 # This allows an easy way of setting up a build directory for llvm and another


### PR DESCRIPTION
The minimum CMake version is 3.20 so this logic is no longer needed.