### PR TITLE
[clang-format] Add pre-commit CI env var support to git-clang-format

### DIFF
--- a/clang/tools/clang-format/git-clang-format
+++ b/clang/tools/clang-format/git-clang-format
@@ -58,6 +58,11 @@ The following git-config settings set the default of the corresponding option:
   clangFormat.commit
   clangFormat.extensions
   clangFormat.style
+
+When running inside a pre-commit CI environment (i.e., no commits are given
+on the command line and the PRE_COMMIT_FROM_REF and PRE_COMMIT_TO_REF
+environment variables are set), the diff range is taken from those variables
+and --diff is implied.
 """
 
 # Name of the temporary index file in which save the output of clang-format.
@@ -222,6 +227,16 @@ def main():
         help="if specified, only consider differences in these files",
     )
     opts = p.parse_args(argv)
+
+    # When no commits are given explicitly and the pre-commit CI framework's
+    # environment variables are set, use them to define the diff range.
+    if not opts.args and not dash_dash:
+        from_ref = os.environ.get('PRE_COMMIT_FROM_REF')
+        to_ref = os.environ.get('PRE_COMMIT_TO_REF')
+        if from_ref and to_ref:
+            opts.args = [from_ref, to_ref]
+            if not opts.diff and not opts.diffstat:
+                opts.diff = True
 
     opts.verbose -= opts.quiet
     del opts.quiet


### PR DESCRIPTION
When git-clang-format is invoked with no explicit commit arguments and both PRE_COMMIT_FROM_REF and PRE_COMMIT_TO_REF are set, the script automatically uses those refs as the diff range and implies --diff. If the variables are absent, existing behavior is fully preserved.

This allows projects to use `git-clang-format` directly inside CI pipelines via the [pre-commit](https://pre-commit.com/) framework without any wrapper scripts or extra configuration.


Closes: #188813

No existing lit test suite for this script. Verified manually that env vars activate two-commit diff mode, existing behavior is preserved without them, and explicit CLI args always override them.