### PR TITLE
[UnsafeBufferUsage] Check for uninstantiated default arguments to prevent crash.

### DIFF
--- a/clang/lib/Analysis/UnsafeBufferUsage.cpp
+++ b/clang/lib/Analysis/UnsafeBufferUsage.cpp
@@ -2960,7 +2960,8 @@ static void populateStmtsForFindingGadgets(SmallVector<const Stmt *> &Stmts,
   if (const auto *FD = dyn_cast<FunctionDecl>(D)) {
     AddStmt(FD->getBody());
     for (const auto *PD : FD->parameters())
-      AddStmt(PD->getDefaultArg());
+      if (PD->hasDefaultArg() && !PD->hasUninstantiatedDefaultArg())
+        AddStmt(PD->getDefaultArg());
     if (const auto *CtorD = dyn_cast<CXXConstructorDecl>(FD))
       llvm::append_range(
           Stmts, llvm::map_range(CtorD->inits(),

--- a/clang/test/SemaCXX/warn-unsafe-buffer-usage-default-arg-uninstantiated-crash.cpp
+++ b/clang/test/SemaCXX/warn-unsafe-buffer-usage-default-arg-uninstantiated-crash.cpp
@@ -1,0 +1,13 @@
+// RUN: %clang_cc1 -Wunsafe-buffer-usage -std=c++23 %s -verify
+
+// expected-no-diagnostics
+
+template <class _CharT> struct basic_string {
+  struct __rep {
+    __rep(int);
+  };
+  basic_string(_CharT, __rep = int()) {}
+};
+char16_t operators___str;
+decltype(sizeof(int)) operators___len;
+void operators() { basic_string(operators___str, operators___len); }


### PR DESCRIPTION
Fix a crash introduced by https://github.com/llvm/llvm-project/pull/184899

The -Wunsafe-buffer-usage analysis was crashing when it encountered a template function with a default argument that hadn't been instantiated yet. This occurred in populateStmtsForFindingGadgets when it attempted to access the default argument of each parameter.

This fix adds a check to ensure the default argument is instantiated before attempting to access it.

Assisted-by: Gemini