### PR TITLE
[libc][docs] Add fcntl.h POSIX header documentation

### DIFF
--- a/libc/docs/CMakeLists.txt
+++ b/libc/docs/CMakeLists.txt
@@ -47,6 +47,7 @@ if (SPHINX_FOUND)
       dirent
       endian
       errno
+      fcntl
       fenv
       float
       glob

--- a/libc/docs/headers/index.rst
+++ b/libc/docs/headers/index.rst
@@ -13,6 +13,7 @@ Implementation Status
    dirent
    endian
    errno
+   fcntl
    fenv
    float
    glob

--- a/libc/docs/headers/index.rst
+++ b/libc/docs/headers/index.rst
@@ -13,7 +13,6 @@ Implementation Status
    dirent
    endian
    errno
-   fcntl
    fenv
    float
    glob
@@ -45,6 +44,4 @@ Implementation Status
    unistd
    wchar
    wctype
-..
-   TODO: https://github.com/llvm/llvm-project/issues/123821
    pthread

--- a/libc/docs/headers/index.rst
+++ b/libc/docs/headers/index.rst
@@ -13,6 +13,7 @@ Implementation Status
    dirent
    endian
    errno
+   fcntl
    fenv
    float
    glob
@@ -44,4 +45,6 @@ Implementation Status
    unistd
    wchar
    wctype
+..
+   TODO: https://github.com/llvm/llvm-project/issues/123821
    pthread

--- a/libc/utils/docgen/fcntl.yaml
+++ b/libc/utils/docgen/fcntl.yaml
@@ -1,0 +1,121 @@
+functions:
+  creat:
+    in-latest-posix: ''
+  fcntl:
+    in-latest-posix: ''
+  open:
+    in-latest-posix: ''
+  openat:
+    in-latest-posix: ''
+  posix_fadvise:
+    in-latest-posix: ''
+  posix_fallocate:
+    in-latest-posix: ''
+
+macros:
+  AT_EACCESS:
+    in-latest-posix: ''
+  AT_FDCWD:
+    in-latest-posix: ''
+  AT_REMOVEDIR:
+    in-latest-posix: ''
+  AT_SYMLINK_FOLLOW:
+    in-latest-posix: ''
+  AT_SYMLINK_NOFOLLOW:
+    in-latest-posix: ''
+  FD_CLOEXEC:
+    in-latest-posix: ''
+  FD_CLOFORK:
+    in-latest-posix: ''
+  F_DUPFD:
+    in-latest-posix: ''
+  F_DUPFD_CLOEXEC:
+    in-latest-posix: ''
+  F_DUPFD_CLOFORK:
+    in-latest-posix: ''
+  F_GETFD:
+    in-latest-posix: ''
+  F_GETFL:
+    in-latest-posix: ''
+  F_GETLK:
+    in-latest-posix: ''
+  F_GETOWN:
+    in-latest-posix: ''
+  F_OFD_GETLK:
+    in-latest-posix: ''
+  F_OFD_SETLK:
+    in-latest-posix: ''
+  F_OFD_SETLKW:
+    in-latest-posix: ''
+  F_OWNER_PGRP:
+    in-latest-posix: ''
+  F_OWNER_PID:
+    in-latest-posix: ''
+  F_RDLCK:
+    in-latest-posix: ''
+  F_SETFD:
+    in-latest-posix: ''
+  F_SETFL:
+    in-latest-posix: ''
+  F_SETLK:
+    in-latest-posix: ''
+  F_SETLKW:
+    in-latest-posix: ''
+  F_SETOWN:
+    in-latest-posix: ''
+  F_UNLCK:
+    in-latest-posix: ''
+  F_WRLCK:
+    in-latest-posix: ''
+  O_ACCMODE:
+    in-latest-posix: ''
+  O_APPEND:
+    in-latest-posix: ''
+  O_CLOEXEC:
+    in-latest-posix: ''
+  O_CLOFORK:
+    in-latest-posix: ''
+  O_CREAT:
+    in-latest-posix: ''
+  O_DIRECTORY:
+    in-latest-posix: ''
+  O_DSYNC:
+    in-latest-posix: ''
+  O_EXCL:
+    in-latest-posix: ''
+  O_EXEC:
+    in-latest-posix: ''
+  O_NOCTTY:
+    in-latest-posix: ''
+  O_NOFOLLOW:
+    in-latest-posix: ''
+  O_NONBLOCK:
+    in-latest-posix: ''
+  O_RDONLY:
+    in-latest-posix: ''
+  O_RDWR:
+    in-latest-posix: ''
+  O_RSYNC:
+    in-latest-posix: ''
+  O_SEARCH:
+    in-latest-posix: ''
+  O_SYNC:
+    in-latest-posix: ''
+  O_TRUNC:
+    in-latest-posix: ''
+  O_TTY_INIT:
+    in-latest-posix: ''
+  O_WRONLY:
+    in-latest-posix: ''
+  POSIX_FADV_DONTNEED:
+    in-latest-posix: ''
+  POSIX_FADV_NORMAL:
+    in-latest-posix: ''
+  POSIX_FADV_NOREUSE:
+    in-latest-posix: ''
+  POSIX_FADV_RANDOM:
+    in-latest-posix: ''
+  POSIX_FADV_SEQUENTIAL:
+    in-latest-posix: ''
+  POSIX_FADV_WILLNEED:
+    in-latest-posix: ''


### PR DESCRIPTION
Add YAML documentation for `fcntl.h` listing all functions and macros as defined in POSIX.1-2024 (IEEE Std 1003.1-2024).

**Functions (6):** creat, fcntl, open, openat, posix_fadvise, posix_fallocate

**Macros (51):** O_RDONLY, O_WRONLY, O_RDWR, O_APPEND, O_CREAT, O_EXCL, O_TRUNC, F_DUPFD, F_GETFD, F_SETFD, F_GETFL, F_SETFL, AT_FDCWD, POSIX_FADV_*, and more.

Part of #122006