### PR TITLE
[SystemZ] Enable liveness reduction in pre-RA sched strategy.

### DIFF
--- a/llvm/lib/Target/SystemZ/SystemZMachineScheduler.cpp
+++ b/llvm/lib/Target/SystemZ/SystemZMachineScheduler.cpp
@@ -59,16 +59,11 @@ bool SystemZPreRASchedStrategy::closesLiveRange(const SUnit *SU,
       GRX32PChange = PC.getUnitInc();
   }
 
-  // Return true for a (vreg) def when no uses become live. Prioritize
+  // Return true for a (vreg) def when register pressure is reduced. Prioritize
   // FP/vector regs over GPRs.
-  const MachineOperand &MO0 = SU->getInstr()->getOperand(0);
-  if (isRegDef(MO0)) {
-    const TargetRegisterClass *RC = DAG->MRI.getRegClass(MO0.getReg());
-    int RegWeight = TRI->getRegClassWeight(RC).RegWeight;
-    bool VR16DefNoKill = VR16PChange == -RegWeight;
-    bool GRX32DefNoKill = GRX32PChange == -RegWeight;
-    return VR16DefNoKill || (!VR16PChange && GRX32DefNoKill);
-  }
+  if (isRegDef(SU->getInstr()->getOperand(0)))
+    return VR16PChange < 0 || (!VR16PChange && GRX32PChange < 0);
+
   return false;
 }
 

--- a/llvm/lib/Target/SystemZ/SystemZMachineScheduler.cpp
+++ b/llvm/lib/Target/SystemZ/SystemZMachineScheduler.cpp
@@ -63,8 +63,6 @@ bool SystemZPreRASchedStrategy::closesLiveRange(const SUnit *SU,
   return VR16PChange < 0 || (!VR16PChange && GRX32PChange < 0);
 }
 
-static cl::opt<unsigned> LatMinLat("latency-minlat", cl::init(0));
-static cl::opt<unsigned> LatMinRegion("latency-minregion", cl::init(0));
 bool SystemZPreRASchedStrategy::tryCandidate(SchedCandidate &Cand,
                                              SchedCandidate &TryCand,
                                              SchedBoundary *Zone) const {
@@ -98,18 +96,11 @@ bool SystemZPreRASchedStrategy::tryCandidate(SchedCandidate &Cand,
                                                              : nullptr)
       if (HigherSU->getHeight() > Zone->getScheduledLatency() &&
           HigherSU->getDepth() < computeRemLatency(*Zone)) {
-
-        unsigned MaxLat = std::max(TryCand.SU->Latency, Cand.SU->Latency);
-        unsigned RegionSize = DAG->SUnits.size();
-
-        if ((MaxLat >= LatMinLat) &&
-            (RegionSize >= LatMinRegion || DoLatencyReduction)) {
-          // The higher SU increases the scheduled latency but is not on the
-          // Critical Path by Depth, so put it above the other one.
-          tryLess(TryCand.SU->getHeight(), Cand.SU->getHeight(), TryCand, Cand,
-                  GenericSchedulerBase::BotHeightReduce);
-          return TryCand.Reason != NoCand;
-        }
+        // The higher SU increases the scheduled latency but is not on the
+        // Critical Path by Depth, so put it above the other one.
+        tryLess(TryCand.SU->getHeight(), Cand.SU->getHeight(), TryCand, Cand,
+                GenericSchedulerBase::BotHeightReduce);
+        return TryCand.Reason != NoCand;
       }
 
   // Weak edges help copy coalescing.
@@ -146,21 +137,14 @@ void SystemZPreRASchedStrategy::initPolicy(MachineBasicBlock::iterator Begin,
   this->NumRegionInstrs = NumRegionInstrs;
 }
 
-static cl::opt<unsigned> LatMinSumLat("latency-minsumlat", cl::init(~0));
-
 void SystemZPreRASchedStrategy::initialize(ScheduleDAGMI *dag) {
   GenericScheduler::initialize(dag);
 
   Cmp0SrcReg = SystemZ::NoRegister;
 
   unsigned DAGHeight = 0;
-  unsigned SumLat = 0;
-  for (unsigned Idx = 0, End = DAG->SUnits.size(); Idx != End; ++Idx) {
+  for (unsigned Idx = 0, End = DAG->SUnits.size(); Idx != End; ++Idx)
     DAGHeight = std::max(DAGHeight, DAG->SUnits[Idx].getHeight());
-    SumLat += DAG->SUnits[Idx].Latency;
-  }
-
-  DoLatencyReduction = SumLat >= LatMinSumLat;
 
   if (RegionPolicy.ShouldTrackPressure)
     LivenessHeightCutOff = DAGHeight / (DAG->SUnits.size() < 50 ? 4 : 2);

--- a/llvm/lib/Target/SystemZ/SystemZMachineScheduler.cpp
+++ b/llvm/lib/Target/SystemZ/SystemZMachineScheduler.cpp
@@ -15,15 +15,6 @@ using namespace llvm;
 
 /// Pre-RA scheduling ///
 
-// Options needed for testing.
-// TopRegionSUs is the number of SUs that are considered to be part of the
-// "top" of a region. Liveness reduction is not done in regions smaller than
-// this. The idea is to prioritize latency more after branches and help
-// liveness only when the decoder is ahead of execution anyway.
-static cl::opt<unsigned> TopRegionSUs("top-region", cl::Hidden, cl::init(36));
-static cl::opt<bool> DisableLatency("disable-latency", cl::Hidden,
-                                    cl::init(false));
-
 static bool isRegDef(const MachineOperand &MO) {
   return MO.isReg() && MO.isDef();
 }
@@ -125,6 +116,12 @@ bool SystemZPreRASchedStrategy::tryCandidate(SchedCandidate &Cand,
 void SystemZPreRASchedStrategy::initPolicy(MachineBasicBlock::iterator Begin,
                                            MachineBasicBlock::iterator End,
                                            unsigned NumRegionInstrs) {
+  // TopRegionSUs is the number of SUs that is considered to be part of the
+  // "top" of a region. Liveness reduction is not done in regions smaller than
+  // this. The idea is to prioritize latency more after branches and help
+  // liveness only when the decoder is ahead of execution anyway.
+  static const unsigned TopRegionSUs = 36;
+
   // Avoid setting up the register pressure tracker unless needed to save
   // compile time.
   RegionPolicy.ShouldTrackPressure = NumRegionInstrs > TopRegionSUs;
@@ -149,13 +146,10 @@ void SystemZPreRASchedStrategy::initialize(ScheduleDAGMI *dag) {
   if (RegionPolicy.ShouldTrackPressure)
     LivenessHeightCutOff = DAGHeight / (DAG->SUnits.size() < 50 ? 4 : 2);
 
-  if (DisableLatency)
-    RegionPolicy.DisableLatencyHeuristic = true;
-  else
-    // Disable latency reduction if region has many SUs relative to the
-    // overall height.
-    RegionPolicy.DisableLatencyHeuristic =
-        DAG->SUnits.size() >= 3 * std::max(DAGHeight, 1u);
+  // Disable latency reduction if region has many SUs relative to the
+  // overall height.
+  RegionPolicy.DisableLatencyHeuristic =
+    DAG->SUnits.size() >= 3 * std::max(DAGHeight, 1u);
 }
 
 void SystemZPreRASchedStrategy::schedNode(SUnit *SU, bool IsTopNode) {

--- a/llvm/lib/Target/SystemZ/SystemZMachineScheduler.cpp
+++ b/llvm/lib/Target/SystemZ/SystemZMachineScheduler.cpp
@@ -149,7 +149,7 @@ void SystemZPreRASchedStrategy::initialize(ScheduleDAGMI *dag) {
   // Disable latency reduction if region has many SUs relative to the
   // overall height.
   RegionPolicy.DisableLatencyHeuristic =
-    DAG->SUnits.size() >= 3 * std::max(DAGHeight, 1u);
+      DAG->SUnits.size() >= 3 * std::max(DAGHeight, 1u);
 }
 
 void SystemZPreRASchedStrategy::schedNode(SUnit *SU, bool IsTopNode) {

--- a/llvm/lib/Target/SystemZ/SystemZMachineScheduler.cpp
+++ b/llvm/lib/Target/SystemZ/SystemZMachineScheduler.cpp
@@ -90,8 +90,7 @@ bool SystemZPreRASchedStrategy::tryCandidate(SchedCandidate &Cand,
   if (RegionPolicy.ShouldTrackPressure) {
     auto schedLow = [&](const SUnit *SU) {
       return SU->getHeight() <= Zone->getScheduledLatency() &&
-             SU->getHeight() < LivenessHeightCutOff &&
-             closesLiveRange(SU, DAG);
+             SU->getHeight() < LivenessHeightCutOff && closesLiveRange(SU, DAG);
     };
     // One SU closes a live range while preserving the scheduled latency.
     if (tryGreater(schedLow(TryCand.SU), schedLow(Cand.SU), TryCand, Cand,
@@ -167,7 +166,7 @@ void SystemZPreRASchedStrategy::initialize(ScheduleDAGMI *dag) {
     // Disable latency reduction if region has many SUs relative to the
     // overall height.
     RegionPolicy.DisableLatencyHeuristic =
-      DAG->SUnits.size() >= 3 * std::max(DAGHeight, 1u);
+        DAG->SUnits.size() >= 3 * std::max(DAGHeight, 1u);
 }
 
 void SystemZPreRASchedStrategy::schedNode(SUnit *SU, bool IsTopNode) {

--- a/llvm/lib/Target/SystemZ/SystemZMachineScheduler.cpp
+++ b/llvm/lib/Target/SystemZ/SystemZMachineScheduler.cpp
@@ -155,10 +155,8 @@ void SystemZPreRASchedStrategy::initialize(ScheduleDAGMI *dag) {
   for (unsigned Idx = 0, End = DAG->SUnits.size(); Idx != End; ++Idx)
     DAGHeight = std::max(DAGHeight, DAG->SUnits[Idx].getHeight());
 
-  if (RegionPolicy.ShouldTrackPressure) {
-    float Ratio = DAG->SUnits.size() < 50 ? 0.25 : 0.5;
-    LivenessHeightCutOff = std::floor(Ratio * float(DAGHeight));
-  }
+  if (RegionPolicy.ShouldTrackPressure)
+    LivenessHeightCutOff = DAGHeight / (DAG->SUnits.size() < 50 ? 4 : 2);
 
   if (DisableLatency)
     RegionPolicy.DisableLatencyHeuristic = true;

--- a/llvm/lib/Target/SystemZ/SystemZMachineScheduler.cpp
+++ b/llvm/lib/Target/SystemZ/SystemZMachineScheduler.cpp
@@ -8,6 +8,7 @@
 
 #include "SystemZMachineScheduler.h"
 #include "llvm/CodeGen/MachineLoopInfo.h"
+#include <cmath>
 
 using namespace llvm;
 
@@ -15,57 +16,17 @@ using namespace llvm;
 
 /// Pre-RA scheduling ///
 
+// Options needed for testing.
+// TopRegionSUs is the number of SUs that are considered to be part of the
+// "top" of a region. Liveness reduction is not done in regions smaller than
+// this. The idea is to prioritize latency more after branches and help
+// liveness only when the decoder is ahead of execution anyway.
+static cl::opt<unsigned> TopRegionSUs("top-region", cl::Hidden, cl::init(36));
+static cl::opt<bool> DisableLatency("disable-latency", cl::Hidden,
+                                    cl::init(false));
+
 static bool isRegDef(const MachineOperand &MO) {
   return MO.isReg() && MO.isDef();
-}
-
-void SystemZPreRASchedStrategy::initializeLatencyReduction() {
-  // Enable latency reduction for a region that has a considerable amount of
-  // data sequences that should be interlaved. These are SUs that only have
-  // one data predecessor / successor edge(s) to their adjacent instruction(s)
-  // in the input order. Disable if region has many SUs relative to the
-  // overall height.
-  unsigned DAGHeight = 0;
-  for (unsigned Idx = 0, End = DAG->SUnits.size(); Idx != End; ++Idx)
-    DAGHeight = std::max(DAGHeight, DAG->SUnits[Idx].getHeight());
-  RegionPolicy.DisableLatencyHeuristic =
-      DAG->SUnits.size() >= 3 * std::max(DAGHeight, 1u);
-  if ((HasDataSequences = !RegionPolicy.DisableLatencyHeuristic)) {
-    unsigned CurrSequence = 0, NumSeqNodes = 0;
-    auto countSequence = [&CurrSequence, &NumSeqNodes]() {
-      if (CurrSequence >= 2)
-        NumSeqNodes += CurrSequence;
-      CurrSequence = 0;
-    };
-    for (unsigned Idx = 0, End = DAG->SUnits.size(); Idx != End; ++Idx) {
-      const SUnit *SU = &DAG->SUnits[Idx];
-      bool InDataSequence = true;
-      // One Data pred to MI just above, or no preds.
-      unsigned NumPreds = 0;
-      for (const SDep &Pred : SU->Preds)
-        if (++NumPreds != 1 || Pred.getKind() != SDep::Data ||
-            Pred.getSUnit()->NodeNum != Idx - 1)
-          InDataSequence = false;
-      // One Data succ or no succs (ignoring ExitSU).
-      unsigned NumSuccs = 0;
-      for (const SDep &Succ : SU->Succs)
-        if (Succ.getSUnit() != &DAG->ExitSU &&
-            (++NumSuccs != 1 || Succ.getKind() != SDep::Data))
-          InDataSequence = false;
-      // Another type of node or one that does not have a single data pred
-      // ends any previous sequence.
-      if (!InDataSequence || !NumPreds)
-        countSequence();
-      if (InDataSequence)
-        CurrSequence++;
-    }
-    countSequence();
-    if (NumSeqNodes >= std::max(size_t(4), DAG->SUnits.size() / 4)) {
-      LLVM_DEBUG(dbgs() << "Number of nodes in def-use sequences: "
-                        << NumSeqNodes << ". ";);
-    } else
-      HasDataSequences = false;
-  }
 }
 
 bool SystemZPreRASchedStrategy::definesCmp0Src(const MachineInstr *MI,
@@ -75,6 +36,38 @@ bool SystemZPreRASchedStrategy::definesCmp0Src(const MachineInstr *MI,
     const MachineOperand &MO0 = MI->getOperand(0);
     if (isRegDef(MO0) && MO0.getReg() == Cmp0SrcReg)
       return true;
+  }
+  return false;
+}
+
+bool SystemZPreRASchedStrategy::closesLiveRange(const SUnit *SU,
+                                                ScheduleDAGMILive *DAG) const {
+  if (SU->getInstr()->isCopy())
+    return false;
+
+  // Extract the PressureChanges that all fp/vector or GR64/GR32/GRH32 regs
+  // affect respectively. misched-prera-pdiffs.mir tests against any future
+  // change in the PressureSets modelling, so simply hard-code them here.
+  int VR16PChange = 0, GRX32PChange = 0;
+  const PressureDiff &PDiff = DAG->getPressureDiff(SU);
+  for (const PressureChange &PC : PDiff) {
+    if (!PC.isValid())
+      break;
+    if (PC.getPSet() == SystemZ::VR16Bit)
+      VR16PChange = PC.getUnitInc();
+    else if (PC.getPSet() == SystemZ::GRX32Bit)
+      GRX32PChange = PC.getUnitInc();
+  }
+
+  // Return true for a (vreg) def when no uses become live. Prioritize
+  // FP/vector regs over GPRs.
+  const MachineOperand &MO0 = SU->getInstr()->getOperand(0);
+  if (isRegDef(MO0)) {
+    const TargetRegisterClass *RC = DAG->MRI.getRegClass(MO0.getReg());
+    int RegWeight = TRI->getRegClassWeight(RC).RegWeight;
+    bool VR16DefNoKill = VR16PChange == -RegWeight;
+    bool GRX32DefNoKill = GRX32PChange == -RegWeight;
+    return VR16DefNoKill || (!VR16PChange && GRX32DefNoKill);
   }
   return false;
 }
@@ -94,20 +87,27 @@ bool SystemZPreRASchedStrategy::tryCandidate(SchedCandidate &Cand,
   if (tryBiasPhysRegs(TryCand, Cand, Zone, /*BiasPRegsExtra=*/true))
     return TryCand.Reason != NoCand;
 
-  // Don't extend the scheduled latency in regions with many nodes in data
-  // sequences, or for (single block loop) regions that are acyclically
-  // (within a single loop iteration) latency limited. IsAcyclicLatencyLimited
-  // is set only after initialization in registerRoots(), which is why it is
-  // checked here instead of earlier.
-  if (!RegionPolicy.DisableLatencyHeuristic &&
-      (HasDataSequences || Rem.IsAcyclicLatencyLimited))
+  if (RegionPolicy.ShouldTrackPressure) {
+    auto schedLow = [&](const SUnit *SU) {
+      return SU->getHeight() <= Zone->getScheduledLatency() &&
+             SU->getHeight() < LivenessHeightCutOff &&
+             closesLiveRange(SU, DAG);
+    };
+    // One SU closes a live range while preserving the scheduled latency.
+    if (tryGreater(schedLow(TryCand.SU), schedLow(Cand.SU), TryCand, Cand,
+                   RegExcess))
+      return TryCand.Reason != NoCand;
+  }
+
+  if (!RegionPolicy.DisableLatencyHeuristic)
     if (const SUnit *HigherSU =
             TryCand.SU->getHeight() > Cand.SU->getHeight()   ? TryCand.SU
             : TryCand.SU->getHeight() < Cand.SU->getHeight() ? Cand.SU
                                                              : nullptr)
       if (HigherSU->getHeight() > Zone->getScheduledLatency() &&
           HigherSU->getDepth() < computeRemLatency(*Zone)) {
-        // One or both SUs increase the scheduled latency.
+        // The higher SU increases the scheduled latency but is not on the
+        // Critical Path by Depth, so put it above the other one.
         tryLess(TryCand.SU->getHeight(), Cand.SU->getHeight(), TryCand, Cand,
                 GenericSchedulerBase::BotHeightReduce);
         return TryCand.Reason != NoCand;
@@ -135,16 +135,14 @@ bool SystemZPreRASchedStrategy::tryCandidate(SchedCandidate &Cand,
 void SystemZPreRASchedStrategy::initPolicy(MachineBasicBlock::iterator Begin,
                                            MachineBasicBlock::iterator End,
                                            unsigned NumRegionInstrs) {
-  // Avoid setting up the register pressure tracker for small regions to save
-  // compile time. Currently only used for computeCyclicCriticalPath() which
-  // is used for single block loops.
-  MachineBasicBlock *MBB = Begin->getParent();
-  RegionPolicy.ShouldTrackPressure =
-      MBB->isSuccessor(MBB) && NumRegionInstrs >= 8;
+  // Avoid setting up the register pressure tracker unless needed to save
+  // compile time.
+  RegionPolicy.ShouldTrackPressure = NumRegionInstrs > TopRegionSUs;
 
   // These heuristics has so far seemed to work better without adding a
   // top-down boundary.
   RegionPolicy.OnlyBottomUp = true;
+
   BotIdx = NumRegionInstrs - 1;
   this->NumRegionInstrs = NumRegionInstrs;
 }
@@ -154,9 +152,22 @@ void SystemZPreRASchedStrategy::initialize(ScheduleDAGMI *dag) {
 
   Cmp0SrcReg = SystemZ::NoRegister;
 
-  initializeLatencyReduction();
-  LLVM_DEBUG(dbgs() << "Latency scheduling " << (HasDataSequences ? "" : "not ")
-                    << "enabled for data sequences.\n";);
+  unsigned DAGHeight = 0;
+  for (unsigned Idx = 0, End = DAG->SUnits.size(); Idx != End; ++Idx)
+    DAGHeight = std::max(DAGHeight, DAG->SUnits[Idx].getHeight());
+
+  if (RegionPolicy.ShouldTrackPressure) {
+    float Ratio = DAG->SUnits.size() < 50 ? 0.25 : 0.5;
+    LivenessHeightCutOff = std::floor(Ratio * float(DAGHeight));
+  }
+
+  if (DisableLatency)
+    RegionPolicy.DisableLatencyHeuristic = true;
+  else
+    // Disable latency reduction if region has many SUs relative to the
+    // overall height.
+    RegionPolicy.DisableLatencyHeuristic =
+      DAG->SUnits.size() >= 3 * std::max(DAGHeight, 1u);
 }
 
 void SystemZPreRASchedStrategy::schedNode(SUnit *SU, bool IsTopNode) {

--- a/llvm/lib/Target/SystemZ/SystemZMachineScheduler.cpp
+++ b/llvm/lib/Target/SystemZ/SystemZMachineScheduler.cpp
@@ -8,7 +8,6 @@
 
 #include "SystemZMachineScheduler.h"
 #include "llvm/CodeGen/MachineLoopInfo.h"
-#include <cmath>
 
 using namespace llvm;
 
@@ -61,10 +60,7 @@ bool SystemZPreRASchedStrategy::closesLiveRange(const SUnit *SU,
 
   // Return true for a (vreg) def when register pressure is reduced. Prioritize
   // FP/vector regs over GPRs.
-  if (isRegDef(SU->getInstr()->getOperand(0)))
-    return VR16PChange < 0 || (!VR16PChange && GRX32PChange < 0);
-
-  return false;
+  return VR16PChange < 0 || (!VR16PChange && GRX32PChange < 0);
 }
 
 bool SystemZPreRASchedStrategy::tryCandidate(SchedCandidate &Cand,

--- a/llvm/lib/Target/SystemZ/SystemZMachineScheduler.cpp
+++ b/llvm/lib/Target/SystemZ/SystemZMachineScheduler.cpp
@@ -63,6 +63,8 @@ bool SystemZPreRASchedStrategy::closesLiveRange(const SUnit *SU,
   return VR16PChange < 0 || (!VR16PChange && GRX32PChange < 0);
 }
 
+static cl::opt<unsigned> LatMinLat("latency-minlat", cl::init(0));
+static cl::opt<unsigned> LatMinRegion("latency-minregion", cl::init(0));
 bool SystemZPreRASchedStrategy::tryCandidate(SchedCandidate &Cand,
                                              SchedCandidate &TryCand,
                                              SchedBoundary *Zone) const {
@@ -96,11 +98,18 @@ bool SystemZPreRASchedStrategy::tryCandidate(SchedCandidate &Cand,
                                                              : nullptr)
       if (HigherSU->getHeight() > Zone->getScheduledLatency() &&
           HigherSU->getDepth() < computeRemLatency(*Zone)) {
-        // The higher SU increases the scheduled latency but is not on the
-        // Critical Path by Depth, so put it above the other one.
-        tryLess(TryCand.SU->getHeight(), Cand.SU->getHeight(), TryCand, Cand,
-                GenericSchedulerBase::BotHeightReduce);
-        return TryCand.Reason != NoCand;
+
+        unsigned MaxLat = std::max(TryCand.SU->Latency, Cand.SU->Latency);
+        unsigned RegionSize = DAG->SUnits.size();
+
+        if ((MaxLat >= LatMinLat) &&
+            (RegionSize >= LatMinRegion || DoLatencyReduction)) {
+          // The higher SU increases the scheduled latency but is not on the
+          // Critical Path by Depth, so put it above the other one.
+          tryLess(TryCand.SU->getHeight(), Cand.SU->getHeight(), TryCand, Cand,
+                  GenericSchedulerBase::BotHeightReduce);
+          return TryCand.Reason != NoCand;
+        }
       }
 
   // Weak edges help copy coalescing.
@@ -137,14 +146,21 @@ void SystemZPreRASchedStrategy::initPolicy(MachineBasicBlock::iterator Begin,
   this->NumRegionInstrs = NumRegionInstrs;
 }
 
+static cl::opt<unsigned> LatMinSumLat("latency-minsumlat", cl::init(~0));
+
 void SystemZPreRASchedStrategy::initialize(ScheduleDAGMI *dag) {
   GenericScheduler::initialize(dag);
 
   Cmp0SrcReg = SystemZ::NoRegister;
 
   unsigned DAGHeight = 0;
-  for (unsigned Idx = 0, End = DAG->SUnits.size(); Idx != End; ++Idx)
+  unsigned SumLat = 0;
+  for (unsigned Idx = 0, End = DAG->SUnits.size(); Idx != End; ++Idx) {
     DAGHeight = std::max(DAGHeight, DAG->SUnits[Idx].getHeight());
+    SumLat += DAG->SUnits[Idx].Latency;
+  }
+
+  DoLatencyReduction = SumLat >= LatMinSumLat;
 
   if (RegionPolicy.ShouldTrackPressure)
     LivenessHeightCutOff = DAGHeight / (DAG->SUnits.size() < 50 ? 4 : 2);

--- a/llvm/lib/Target/SystemZ/SystemZMachineScheduler.h
+++ b/llvm/lib/Target/SystemZ/SystemZMachineScheduler.h
@@ -50,8 +50,6 @@ class SystemZPreRASchedStrategy : public GenericScheduler {
   // are already live.
   bool closesLiveRange(const SUnit *SU, ScheduleDAGMILive *DAG) const;
 
-  bool DoLatencyReduction;
-
 protected:
   bool tryCandidate(SchedCandidate &Cand, SchedCandidate &TryCand,
                     SchedBoundary *Zone) const override;

--- a/llvm/lib/Target/SystemZ/SystemZMachineScheduler.h
+++ b/llvm/lib/Target/SystemZ/SystemZMachineScheduler.h
@@ -50,6 +50,8 @@ class SystemZPreRASchedStrategy : public GenericScheduler {
   // are already live.
   bool closesLiveRange(const SUnit *SU, ScheduleDAGMILive *DAG) const;
 
+  bool DoLatencyReduction;
+
 protected:
   bool tryCandidate(SchedCandidate &Cand, SchedCandidate &TryCand,
                     SchedBoundary *Zone) const override;

--- a/llvm/lib/Target/SystemZ/SystemZMachineScheduler.h
+++ b/llvm/lib/Target/SystemZ/SystemZMachineScheduler.h
@@ -8,9 +8,12 @@
 
 // -------------------------- Pre RA scheduling ----------------------------- //
 //
-// SystemZPreRASchedStrategy performs latency scheduling in certain types of
-// regions where this is beneficial, and also helps copy coalescing and
-// comparison elimination.
+// SystemZPreRASchedStrategy reduces register pressure by scheduling a (live)
+// definition low if it does not cause another register to become live (all
+// uses live). In most regions it then reduces the scheduled latency but only
+// if the SU that is higher (by Height) than the scheduled latency is as well
+// lower (by Depth) than the remaining latency. It also helps copy coalescing
+// and comparison elimination.
 //
 // -------------------------- Post RA scheduling ---------------------------- //
 //
@@ -34,16 +37,18 @@ namespace llvm {
 
 /// A MachineSchedStrategy implementation for SystemZ pre RA scheduling.
 class SystemZPreRASchedStrategy : public GenericScheduler {
-  void initializeLatencyReduction();
-
   Register Cmp0SrcReg;
   // Return true if MI defines the Cmp0SrcReg that is used by a scheduled
   // compare with 0. If CCDef is true MI must also have an implicit def of CC.
   bool definesCmp0Src(const MachineInstr *MI, bool CCDef = true) const;
 
-  // True if the region has many instructions in def-use sequences and would
-  // likely benefit from latency reduction.
-  bool HasDataSequences;
+  // SUs that have a Height of at least this value will not be scheduled
+  // "low" to reduce liveness.
+  unsigned LivenessHeightCutOff;
+
+  // Return true if the instruction defines a register while all use operands
+  // are already live.
+  bool closesLiveRange(const SUnit *SU, ScheduleDAGMILive *DAG) const;
 
 protected:
   bool tryCandidate(SchedCandidate &Cand, SchedCandidate &TryCand,

--- a/llvm/test/CodeGen/SystemZ/args-22.ll
+++ b/llvm/test/CodeGen/SystemZ/args-22.ll
@@ -124,8 +124,8 @@ define void @arg1(%Ty1 %A) {
 ; VECTOR-NEXT:    lgrl %r1, Dst@GOT
 ; VECTOR-NEXT:    vrepib %v1, 8
 ; VECTOR-NEXT:    vsteb %v0, 8(%r1), 15
-; VECTOR-NEXT:    vsrlb %v0, %v0, %v1
-; VECTOR-NEXT:    vsteg %v0, 0(%r1), 1
+; VECTOR-NEXT:    vsrlb %v1, %v0, %v1
+; VECTOR-NEXT:    vsteg %v1, 0(%r1), 1
 ; VECTOR-NEXT:    br %r14
   store %Ty1 %A, ptr @Dst
   ret void
@@ -351,14 +351,14 @@ define void @arg3(%Ty3 %A) {
 ;
 ; VECTOR-LABEL: arg3:
 ; VECTOR:       # %bb.0:
-; VECTOR-NEXT:    vl %v0, 0(%r3), 3
+; VECTOR-NEXT:    vl %v0, 0(%r2), 3
+; VECTOR-NEXT:    vl %v1, 0(%r3), 3
 ; VECTOR-NEXT:    lgrl %r1, Dst@GOT
-; VECTOR-NEXT:    vl %v1, 0(%r2), 3
-; VECTOR-NEXT:    vsteb %v1, 8(%r1), 15
-; VECTOR-NEXT:    vst %v0, 16(%r1), 3
-; VECTOR-NEXT:    vrepib %v0, 8
-; VECTOR-NEXT:    vsrlb %v0, %v1, %v0
-; VECTOR-NEXT:    vsteg %v0, 0(%r1), 1
+; VECTOR-NEXT:    vsteb %v0, 8(%r1), 15
+; VECTOR-NEXT:    vrepib %v2, 8
+; VECTOR-NEXT:    vsrlb %v2, %v0, %v2
+; VECTOR-NEXT:    vst %v1, 16(%r1), 3
+; VECTOR-NEXT:    vsteg %v2, 0(%r1), 1
 ; VECTOR-NEXT:    br %r14
   store %Ty3 %A, ptr @Dst
   ret void
@@ -402,11 +402,11 @@ define void @call3() {
 ; VECTOR-NEXT:    vlrepg %v1, 0(%r1)
 ; VECTOR-NEXT:    vrepib %v2, 8
 ; VECTOR-NEXT:    vslb %v1, %v1, %v2
+; VECTOR-NEXT:    vl %v2, 16(%r1), 3
 ; VECTOR-NEXT:    vo %v0, %v0, %v1
-; VECTOR-NEXT:    vl %v1, 16(%r1), 3
 ; VECTOR-NEXT:    la %r2, 176(%r15)
 ; VECTOR-NEXT:    la %r3, 160(%r15)
-; VECTOR-NEXT:    vst %v1, 160(%r15), 3
+; VECTOR-NEXT:    vst %v2, 160(%r15), 3
 ; VECTOR-NEXT:    vst %v0, 176(%r15), 3
 ; VECTOR-NEXT:    brasl %r14, Fnptr@PLT
 ; VECTOR-NEXT:    lmg %r14, %r15, 304(%r15)
@@ -601,15 +601,15 @@ define %Ty4 @ret4() {
 ; VECTOR-NEXT:    brasl %r14, Fnptr@PLT
 ; VECTOR-NEXT:    lb %r0, 164(%r15)
 ; VECTOR-NEXT:    lh %r1, 166(%r15)
-; VECTOR-NEXT:    lb %r4, 200(%r15)
+; VECTOR-NEXT:    lb %r2, 200(%r15)
 ; VECTOR-NEXT:    lde %f0, 160(%r15)
-; VECTOR-NEXT:    l %r2, 168(%r15)
-; VECTOR-NEXT:    lg %r3, 176(%r15)
+; VECTOR-NEXT:    l %r3, 168(%r15)
+; VECTOR-NEXT:    lg %r4, 176(%r15)
 ; VECTOR-NEXT:    vl %v1, 184(%r15), 3
-; VECTOR-NEXT:    stc %r4, 40(%r13)
+; VECTOR-NEXT:    stc %r2, 40(%r13)
 ; VECTOR-NEXT:    vst %v1, 24(%r13), 3
-; VECTOR-NEXT:    stg %r3, 16(%r13)
-; VECTOR-NEXT:    st %r2, 8(%r13)
+; VECTOR-NEXT:    stg %r4, 16(%r13)
+; VECTOR-NEXT:    st %r3, 8(%r13)
 ; VECTOR-NEXT:    sth %r1, 6(%r13)
 ; VECTOR-NEXT:    stc %r0, 4(%r13)
 ; VECTOR-NEXT:    ste %f0, 0(%r13)
@@ -810,10 +810,10 @@ define void @arg6(%Ty6 %A) {
 ; VECTOR-NEXT:    vsteb %v1, 24(%r1), 15
 ; VECTOR-NEXT:    vrepib %v2, 8
 ; VECTOR-NEXT:    vsteb %v0, 8(%r1), 15
-; VECTOR-NEXT:    vsrlb %v1, %v1, %v2
-; VECTOR-NEXT:    vsrlb %v0, %v0, %v2
-; VECTOR-NEXT:    vsteg %v1, 16(%r1), 1
-; VECTOR-NEXT:    vsteg %v0, 0(%r1), 1
+; VECTOR-NEXT:    vsrlb %v3, %v1, %v2
+; VECTOR-NEXT:    vsrlb %v2, %v0, %v2
+; VECTOR-NEXT:    vsteg %v3, 16(%r1), 1
+; VECTOR-NEXT:    vsteg %v2, 0(%r1), 1
 ; VECTOR-NEXT:    br %r14
   store %Ty6 %A, ptr @Dst
   ret void
@@ -854,17 +854,17 @@ define void @call6() {
 ; VECTOR-NEXT:    aghi %r15, -192
 ; VECTOR-NEXT:    .cfi_def_cfa_offset 352
 ; VECTOR-NEXT:    lgrl %r1, Src@GOT
+; VECTOR-NEXT:    vgbm %v0, 0
 ; VECTOR-NEXT:    vgbm %v1, 0
 ; VECTOR-NEXT:    vleb %v1, 8(%r1), 15
 ; VECTOR-NEXT:    vlrepg %v2, 0(%r1)
-; VECTOR-NEXT:    vrepib %v3, 8
-; VECTOR-NEXT:    vslb %v2, %v2, %v3
-; VECTOR-NEXT:    vgbm %v0, 0
-; VECTOR-NEXT:    vo %v1, %v1, %v2
 ; VECTOR-NEXT:    vleb %v0, 24(%r1), 15
-; VECTOR-NEXT:    vlrepg %v2, 16(%r1)
-; VECTOR-NEXT:    vslb %v2, %v2, %v3
-; VECTOR-NEXT:    vo %v0, %v0, %v2
+; VECTOR-NEXT:    vlrepg %v3, 16(%r1)
+; VECTOR-NEXT:    vrepib %v4, 8
+; VECTOR-NEXT:    vslb %v2, %v2, %v4
+; VECTOR-NEXT:    vslb %v3, %v3, %v4
+; VECTOR-NEXT:    vo %v1, %v1, %v2
+; VECTOR-NEXT:    vo %v0, %v0, %v3
 ; VECTOR-NEXT:    la %r2, 176(%r15)
 ; VECTOR-NEXT:    la %r3, 160(%r15)
 ; VECTOR-NEXT:    vst %v0, 160(%r15), 3

--- a/llvm/test/CodeGen/SystemZ/atomicrmw-ops-i128.ll
+++ b/llvm/test/CodeGen/SystemZ/atomicrmw-ops-i128.ll
@@ -335,10 +335,10 @@ define i128 @atomicrmw_uinc_wrap(ptr %src, i128 %b) {
 ; CHECK-LABEL: atomicrmw_uinc_wrap:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    vl %v0, 0(%r4), 3
+; CHECK-NEXT:    larl %r4, .LCPI11_0
+; CHECK-NEXT:    vl %v1, 0(%r4), 3
 ; CHECK-NEXT:    lpq %r0, 0(%r3)
 ; CHECK-NEXT:    vlvgp %v2, %r0, %r1
-; CHECK-NEXT:    larl %r1, .LCPI11_0
-; CHECK-NEXT:    vl %v1, 0(%r1), 3
 ; CHECK-NEXT:    j .LBB11_2
 ; CHECK-NEXT:  .LBB11_1: # %atomicrmw.start
 ; CHECK-NEXT:    # in Loop: Header=BB11_2 Depth=1
@@ -376,11 +376,11 @@ define i128 @atomicrmw_udec_wrap(ptr %src, i128 %b) {
 ; CHECK-LABEL: atomicrmw_udec_wrap:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    vl %v0, 0(%r4), 3
-; CHECK-NEXT:    vgbm %v2, 65535
+; CHECK-NEXT:    larl %r4, .LCPI12_0
+; CHECK-NEXT:    vl %v1, 0(%r4), 3
 ; CHECK-NEXT:    lpq %r0, 0(%r3)
 ; CHECK-NEXT:    vlvgp %v3, %r0, %r1
-; CHECK-NEXT:    larl %r1, .LCPI12_0
-; CHECK-NEXT:    vl %v1, 0(%r1), 3
+; CHECK-NEXT:    vgbm %v2, 65535
 ; CHECK-NEXT:    j .LBB12_2
 ; CHECK-NEXT:  .LBB12_1: # %atomicrmw.start
 ; CHECK-NEXT:    # in Loop: Header=BB12_2 Depth=1

--- a/llvm/test/CodeGen/SystemZ/atomicrmw-ops-i128.ll
+++ b/llvm/test/CodeGen/SystemZ/atomicrmw-ops-i128.ll
@@ -111,11 +111,11 @@ define i128 @atomicrmw_nand(ptr %src, i128 %b) {
 ; CHECK-NEXT:    vlvgp %v1, %r0, %r1
 ; CHECK-NEXT:  .LBB4_1: # %atomicrmw.start
 ; CHECK-NEXT:    # =>This Inner Loop Header: Depth=1
+; CHECK-NEXT:    vnn %v2, %v1, %v0
 ; CHECK-NEXT:    vlgvg %r1, %v1, 1
 ; CHECK-NEXT:    vlgvg %r0, %v1, 0
-; CHECK-NEXT:    vnn %v1, %v1, %v0
-; CHECK-NEXT:    vlgvg %r5, %v1, 1
-; CHECK-NEXT:    vlgvg %r4, %v1, 0
+; CHECK-NEXT:    vlgvg %r5, %v2, 1
+; CHECK-NEXT:    vlgvg %r4, %v2, 0
 ; CHECK-NEXT:    cdsg %r0, %r4, 0(%r3)
 ; CHECK-NEXT:    vlvgp %v1, %r0, %r1
 ; CHECK-NEXT:    jl .LBB4_1

--- a/llvm/test/CodeGen/SystemZ/bswap-09.ll
+++ b/llvm/test/CodeGen/SystemZ/bswap-09.ll
@@ -9,14 +9,14 @@ declare i128 @llvm.bswap.i128(i128 %a)
 define i128 @f1(i128 %a, i128 %b, i128 %c) {
 ; CHECK-LABEL: f1:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vl %v1, 0(%r4), 3
-; CHECK-NEXT:    vl %v2, 0(%r3), 3
+; CHECK-NEXT:    vl %v0, 0(%r4), 3
+; CHECK-NEXT:    vl %v1, 0(%r3), 3
 ; CHECK-NEXT:    larl %r1, .LCPI0_0
-; CHECK-NEXT:    vaq %v1, %v2, %v1
 ; CHECK-NEXT:    vl %v2, 0(%r1), 3
-; CHECK-NEXT:    vl %v0, 0(%r5), 3
-; CHECK-NEXT:    vperm %v1, %v1, %v1, %v2
+; CHECK-NEXT:    vl %v3, 0(%r5), 3
 ; CHECK-NEXT:    vaq %v0, %v1, %v0
+; CHECK-NEXT:    vperm %v0, %v0, %v0, %v2
+; CHECK-NEXT:    vaq %v0, %v0, %v3
 ; CHECK-NEXT:    vst %v0, 0(%r2), 3
 ; CHECK-NEXT:    br %r14
   %in = add i128 %a, %b
@@ -32,9 +32,9 @@ define i128 @f2(i128 %a, i128 %b) {
 ; CHECK-NEXT:    vl %v0, 0(%r4), 3
 ; CHECK-NEXT:    vl %v1, 0(%r3), 3
 ; CHECK-NEXT:    larl %r1, .LCPI1_0
+; CHECK-NEXT:    vl %v2, 0(%r1), 3
 ; CHECK-NEXT:    vaq %v0, %v1, %v0
-; CHECK-NEXT:    vl %v1, 0(%r1), 3
-; CHECK-NEXT:    vperm %v0, %v0, %v0, %v1
+; CHECK-NEXT:    vperm %v0, %v0, %v0, %v2
 ; CHECK-NEXT:    vst %v0, 0(%r2), 3
 ; CHECK-NEXT:    br %r14
   %in = add i128 %a, %b
@@ -47,11 +47,11 @@ define i128 @f3(i128 %a, i128 %b) {
 ; CHECK-LABEL: f3:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    larl %r1, .LCPI2_0
-; CHECK-NEXT:    vl %v1, 0(%r3), 3
-; CHECK-NEXT:    vl %v2, 0(%r1), 3
-; CHECK-NEXT:    vl %v0, 0(%r4), 3
-; CHECK-NEXT:    vperm %v1, %v1, %v1, %v2
-; CHECK-NEXT:    vaq %v0, %v1, %v0
+; CHECK-NEXT:    vl %v0, 0(%r3), 3
+; CHECK-NEXT:    vl %v1, 0(%r1), 3
+; CHECK-NEXT:    vl %v2, 0(%r4), 3
+; CHECK-NEXT:    vperm %v0, %v0, %v0, %v1
+; CHECK-NEXT:    vaq %v0, %v0, %v2
 ; CHECK-NEXT:    vst %v0, 0(%r2), 3
 ; CHECK-NEXT:    br %r14
   %swapped = call i128 @llvm.bswap.i128(i128 %a)

--- a/llvm/test/CodeGen/SystemZ/bswap-10.ll
+++ b/llvm/test/CodeGen/SystemZ/bswap-10.ll
@@ -9,14 +9,14 @@ declare i128 @llvm.bswap.i128(i128 %a)
 define i128 @f1(i128 %a, i128 %b, i128 %c) {
 ; CHECK-LABEL: f1:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vl %v1, 0(%r4), 3
-; CHECK-NEXT:    vl %v2, 0(%r3), 3
+; CHECK-NEXT:    vl %v0, 0(%r4), 3
+; CHECK-NEXT:    vl %v1, 0(%r3), 3
 ; CHECK-NEXT:    larl %r1, .LCPI0_0
-; CHECK-NEXT:    vaq %v1, %v2, %v1
 ; CHECK-NEXT:    vl %v2, 0(%r1), 3
-; CHECK-NEXT:    vl %v0, 0(%r5), 3
-; CHECK-NEXT:    vperm %v1, %v1, %v1, %v2
+; CHECK-NEXT:    vl %v3, 0(%r5), 3
 ; CHECK-NEXT:    vaq %v0, %v1, %v0
+; CHECK-NEXT:    vperm %v0, %v0, %v0, %v2
+; CHECK-NEXT:    vaq %v0, %v0, %v3
 ; CHECK-NEXT:    vst %v0, 0(%r2), 3
 ; CHECK-NEXT:    br %r14
   %in = add i128 %a, %b

--- a/llvm/test/CodeGen/SystemZ/call-zos-vec.ll
+++ b/llvm/test/CodeGen/SystemZ/call-zos-vec.ll
@@ -9,15 +9,15 @@ entry:
 }
 
 ; CHECK-LABEL: sum_vecs1
-; CHECK: vaf 1,24,25
-; CHECK: vaf 1,1,26
-; CHECK: vaf 1,1,27
-; CHECK: vaf 1,1,28
-; CHECK: vaf 1,1,29
-; CHECK: vl  0,2304(4),4
-; CHECK: vaf 1,1,30
-; CHECK: vaf 1,1,31
-; CHECK: vaf 24,1,0
+; CHECK: vaf 0,24,25
+; CHECK: vaf 0,0,26
+; CHECK: vaf 0,0,27
+; CHECK: vaf 0,0,28
+; CHECK: vaf 0,0,29
+; CHECK: vl  1,2304(4),4
+; CHECK: vaf 0,0,30
+; CHECK: vaf 0,0,31
+; CHECK: vaf 24,0,1
 define <4 x i32> @sum_vecs1(<4 x i32> %v1, <4 x i32> %v2, <4 x i32> %v3, <4 x i32> %v4, <4 x i32> %v5, <4 x i32> %v6, <4 x i32> %v7, <4 x i32> %v8, <4 x i32> %v9) {
 entry:
   %add0 = add <4 x i32> %v1, %v2

--- a/llvm/test/CodeGen/SystemZ/canonicalize-vars.ll
+++ b/llvm/test/CodeGen/SystemZ/canonicalize-vars.ll
@@ -129,13 +129,13 @@ define <8 x half> @canonicalize_v8f16(<8 x half> %a) nounwind {
 ; Z16-NEXT:    vgmf %v1, 2, 8
 ; Z16-NEXT:    meebr %f0, %f1
 ; Z16-NEXT:    brasl %r14, __truncsfhf2@PLT
-; Z16-NEXT:    vl %v1, 192(%r15), 3 # 16-byte Reload
+; Z16-NEXT:    vl %v1, 160(%r15), 3 # 16-byte Reload
+; Z16-NEXT:    vl %v2, 192(%r15), 3 # 16-byte Reload
 ; Z16-NEXT:    # kill: def $f0h killed $f0h def $v0
-; Z16-NEXT:    vmrhh %v0, %v0, %v1
+; Z16-NEXT:    vreph %v1, %v1, 5
+; Z16-NEXT:    vmrhh %v0, %v0, %v2
 ; Z16-NEXT:    vst %v0, 192(%r15), 3 # 16-byte Spill
-; Z16-NEXT:    vl %v0, 160(%r15), 3 # 16-byte Reload
-; Z16-NEXT:    vreph %v0, %v0, 5
-; Z16-NEXT:    # kill: def $f0h killed $f0h killed $v0
+; Z16-NEXT:    ldr %f0, %f1
 ; Z16-NEXT:    brasl %r14, __extendhfsf2@PLT
 ; Z16-NEXT:    vgmf %v1, 2, 8
 ; Z16-NEXT:    meebr %f0, %f1
@@ -150,13 +150,13 @@ define <8 x half> @canonicalize_v8f16(<8 x half> %a) nounwind {
 ; Z16-NEXT:    meebr %f0, %f1
 ; Z16-NEXT:    brasl %r14, __truncsfhf2@PLT
 ; Z16-NEXT:    vl %v1, 176(%r15), 3 # 16-byte Reload
+; Z16-NEXT:    vl %v2, 192(%r15), 3 # 16-byte Reload
 ; Z16-NEXT:    # kill: def $f0h killed $f0h def $v0
-; Z16-NEXT:    vmrhh %v0, %v0, %v1
-; Z16-NEXT:    vl %v1, 192(%r15), 3 # 16-byte Reload
-; Z16-NEXT:    vmrhf %v0, %v0, %v1
-; Z16-NEXT:    vst %v0, 192(%r15), 3 # 16-byte Spill
+; Z16-NEXT:    vmrhh %v1, %v0, %v1
 ; Z16-NEXT:    vl %v0, 160(%r15), 3 # 16-byte Reload
+; Z16-NEXT:    vmrhf %v1, %v1, %v2
 ; Z16-NEXT:    vreph %v0, %v0, 3
+; Z16-NEXT:    vst %v1, 192(%r15), 3 # 16-byte Spill
 ; Z16-NEXT:    # kill: def $f0h killed $f0h killed $v0
 ; Z16-NEXT:    brasl %r14, __extendhfsf2@PLT
 ; Z16-NEXT:    vgmf %v1, 2, 8
@@ -262,13 +262,13 @@ define void @canonicalize_ptr_v8f16(ptr %out) nounwind {
 ; Z16-NEXT:    vgmf %v1, 2, 8
 ; Z16-NEXT:    meebr %f0, %f1
 ; Z16-NEXT:    brasl %r14, __truncsfhf2@PLT
-; Z16-NEXT:    vl %v1, 192(%r15), 3 # 16-byte Reload
+; Z16-NEXT:    vl %v1, 160(%r15), 3 # 16-byte Reload
+; Z16-NEXT:    vl %v2, 192(%r15), 3 # 16-byte Reload
 ; Z16-NEXT:    # kill: def $f0h killed $f0h def $v0
-; Z16-NEXT:    vmrhh %v0, %v0, %v1
+; Z16-NEXT:    vreph %v1, %v1, 5
+; Z16-NEXT:    vmrhh %v0, %v0, %v2
 ; Z16-NEXT:    vst %v0, 192(%r15), 3 # 16-byte Spill
-; Z16-NEXT:    vl %v0, 160(%r15), 3 # 16-byte Reload
-; Z16-NEXT:    vreph %v0, %v0, 5
-; Z16-NEXT:    # kill: def $f0h killed $f0h killed $v0
+; Z16-NEXT:    ldr %f0, %f1
 ; Z16-NEXT:    brasl %r14, __extendhfsf2@PLT
 ; Z16-NEXT:    vgmf %v1, 2, 8
 ; Z16-NEXT:    meebr %f0, %f1
@@ -283,13 +283,13 @@ define void @canonicalize_ptr_v8f16(ptr %out) nounwind {
 ; Z16-NEXT:    meebr %f0, %f1
 ; Z16-NEXT:    brasl %r14, __truncsfhf2@PLT
 ; Z16-NEXT:    vl %v1, 176(%r15), 3 # 16-byte Reload
+; Z16-NEXT:    vl %v2, 192(%r15), 3 # 16-byte Reload
 ; Z16-NEXT:    # kill: def $f0h killed $f0h def $v0
-; Z16-NEXT:    vmrhh %v0, %v0, %v1
-; Z16-NEXT:    vl %v1, 192(%r15), 3 # 16-byte Reload
-; Z16-NEXT:    vmrhf %v0, %v0, %v1
-; Z16-NEXT:    vst %v0, 192(%r15), 3 # 16-byte Spill
+; Z16-NEXT:    vmrhh %v1, %v0, %v1
 ; Z16-NEXT:    vl %v0, 160(%r15), 3 # 16-byte Reload
+; Z16-NEXT:    vmrhf %v1, %v1, %v2
 ; Z16-NEXT:    vreph %v0, %v0, 3
+; Z16-NEXT:    vst %v1, 192(%r15), 3 # 16-byte Spill
 ; Z16-NEXT:    # kill: def $f0h killed $f0h killed $v0
 ; Z16-NEXT:    brasl %r14, __extendhfsf2@PLT
 ; Z16-NEXT:    vgmf %v1, 2, 8

--- a/llvm/test/CodeGen/SystemZ/codegenprepare-sink-and-for-tm.ll
+++ b/llvm/test/CodeGen/SystemZ/codegenprepare-sink-and-for-tm.ll
@@ -7,8 +7,8 @@
 define void @fun(i32 %Arg) {
 ; CHECK-LABEL: fun:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    ahi %r2, 1
 ; CHECK-NEXT:    lhi %r0, 0
+; CHECK-NEXT:    ahi %r2, 1
 ; CHECK-NEXT:    cijlh %r0, 0, .LBB0_2
 ; CHECK-NEXT:  # %bb.1: # %bb1
 ; CHECK-NEXT:    tmll %r2, 16

--- a/llvm/test/CodeGen/SystemZ/dag-combine-05.ll
+++ b/llvm/test/CodeGen/SystemZ/dag-combine-05.ll
@@ -9,18 +9,18 @@
 define void @fun(i16 %arg0, ptr %src, ptr %dst) {
 ; CHECK-LABEL: fun:
 ; CHECK:       # %bb.0: # %bb
-; CHECK-NEXT:    llhr %r0, %r2
-; CHECK-NEXT:    llh %r2, 0(%r3)
-; CHECK-NEXT:    chi %r0, 9616
+; CHECK-NEXT:    llh %r0, 0(%r3)
+; CHECK-NEXT:    llhr %r1, %r2
+; CHECK-NEXT:    chi %r1, 9616
 ; CHECK-NEXT:    lhi %r1, 0
 ; CHECK-NEXT:    lochil %r1, 1
-; CHECK-NEXT:    afi %r2, 65535
-; CHECK-NEXT:    llhr %r3, %r2
-; CHECK-NEXT:    lhi %r0, 0
-; CHECK-NEXT:    cr %r3, %r2
-; CHECK-NEXT:    lochilh %r0, 1
-; CHECK-NEXT:    ar %r0, %r1
-; CHECK-NEXT:    st %r0, 0(%r4)
+; CHECK-NEXT:    afi %r0, 65535
+; CHECK-NEXT:    llhr %r2, %r0
+; CHECK-NEXT:    lhi %r3, 0
+; CHECK-NEXT:    cr %r2, %r0
+; CHECK-NEXT:    lochilh %r3, 1
+; CHECK-NEXT:    ar %r1, %r3
+; CHECK-NEXT:    st %r1, 0(%r4)
 ; CHECK-NEXT:    br %r14
 bb:
   %tmp = icmp ult i16 %arg0, 9616

--- a/llvm/test/CodeGen/SystemZ/dag-combine-07.ll
+++ b/llvm/test/CodeGen/SystemZ/dag-combine-07.ll
@@ -11,11 +11,11 @@ define void @func_5(ptr %Dst) {
 ; CHECK-LABEL: func_5:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    lgrl %r1, G2@GOT
+; CHECK-NEXT:    lgrl %r3, G1@GOT
 ; CHECK-NEXT:    llihl %r0, 50
 ; CHECK-NEXT:    oill %r0, 2
 ; CHECK-NEXT:    stg %r0, 0(%r1)
-; CHECK-NEXT:    lgrl %r1, G1@GOT
-; CHECK-NEXT:    stg %r0, 0(%r1)
+; CHECK-NEXT:    stg %r0, 0(%r3)
 ; CHECK-NEXT:    mvhi 0(%r2), 2
 ; CHECK-NEXT:    br %r14
   store i64 214748364802, ptr @G2, align 8

--- a/llvm/test/CodeGen/SystemZ/fold-masked-merge.ll
+++ b/llvm/test/CodeGen/SystemZ/fold-masked-merge.ll
@@ -96,17 +96,17 @@ define i32 @not_a_masked_merge0(i32 %a0, i32 %a1, i32 %a2) {
 ; NO-MISC3-LABEL: not_a_masked_merge0:
 ; NO-MISC3:       # %bb.0:
 ; NO-MISC3-NEXT:    lcr %r0, %r2
-; NO-MISC3-NEXT:    nr %r3, %r2
+; NO-MISC3-NEXT:    nr %r2, %r3
 ; NO-MISC3-NEXT:    nr %r0, %r4
-; NO-MISC3-NEXT:    ork %r2, %r3, %r0
+; NO-MISC3-NEXT:    or %r2, %r0
 ; NO-MISC3-NEXT:    br %r14
 ;
 ; MISC3-LABEL: not_a_masked_merge0:
 ; MISC3:       # %bb.0:
 ; MISC3-NEXT:    lcr %r0, %r2
-; MISC3-NEXT:    nr %r3, %r2
+; MISC3-NEXT:    nr %r2, %r3
 ; MISC3-NEXT:    nr %r0, %r4
-; MISC3-NEXT:    ork %r2, %r3, %r0
+; MISC3-NEXT:    or %r2, %r0
 ; MISC3-NEXT:    br %r14
   %and0 = and i32 %a0, %a1
   %not_a_not = sub i32 0, %a0
@@ -162,10 +162,10 @@ define i32 @not_a_masked_merge2(i32 %a0, i32 %a1, i32 %a2) {
 define i32 @not_a_masked_merge3(i32 %a0, i32 %a1, i32 %a2) {
 ; NO-MISC3-LABEL: not_a_masked_merge3:
 ; NO-MISC3:       # %bb.0:
-; NO-MISC3-NEXT:    nr %r3, %r2
-; NO-MISC3-NEXT:    xr %r2, %r4
-; NO-MISC3-NEXT:    xilf %r2, 4294967295
-; NO-MISC3-NEXT:    or %r2, %r3
+; NO-MISC3-NEXT:    xr %r4, %r2
+; NO-MISC3-NEXT:    nr %r2, %r3
+; NO-MISC3-NEXT:    xilf %r4, 4294967295
+; NO-MISC3-NEXT:    or %r2, %r4
 ; NO-MISC3-NEXT:    br %r14
 ;
 ; MISC3-LABEL: not_a_masked_merge3:
@@ -238,8 +238,8 @@ define i32 @masked_merge_no_transform1(i32 %a0, i32 %a1, i32 %a2, ptr %p1) {
 ; MISC3:       # %bb.0:
 ; MISC3-NEXT:    nrk %r0, %r2, %r3
 ; MISC3-NEXT:    ncrk %r1, %r4, %r2
-; MISC3-NEXT:    xilf %r2, 4294967295
 ; MISC3-NEXT:    or %r0, %r1
+; MISC3-NEXT:    xilf %r2, 4294967295
 ; MISC3-NEXT:    st %r2, 0(%r5)
 ; MISC3-NEXT:    lr %r2, %r0
 ; MISC3-NEXT:    br %r14

--- a/llvm/test/CodeGen/SystemZ/fp-copysign-03.ll
+++ b/llvm/test/CodeGen/SystemZ/fp-copysign-03.ll
@@ -209,16 +209,16 @@ define fp128 @f13(fp128 %a, float %b) {
 ;
 ; Z16-LABEL: f13:
 ; Z16:       # %bb.0:
-; Z16-NEXT:    vl %v1, 0(%r3), 3
 ; Z16-NEXT:    vlgvf %r0, %v0, 0
+; Z16-NEXT:    vl %v0, 0(%r3), 3
 ; Z16-NEXT:    tmlh %r0, 32768
 ; Z16-NEXT:    je .LBB13_2
 ; Z16-NEXT:  # %bb.1:
-; Z16-NEXT:    wflnxb %v0, %v1
+; Z16-NEXT:    wflnxb %v0, %v0
 ; Z16-NEXT:    vst %v0, 0(%r2), 3
 ; Z16-NEXT:    br %r14
 ; Z16-NEXT:  .LBB13_2:
-; Z16-NEXT:    wflpxb %v0, %v1
+; Z16-NEXT:    wflpxb %v0, %v0
 ; Z16-NEXT:    vst %v0, 0(%r2), 3
 ; Z16-NEXT:    br %r14
   %b128 = fpext float %b to fp128
@@ -239,16 +239,16 @@ define fp128 @f14(fp128 %a, double %b) {
 ;
 ; Z16-LABEL: f14:
 ; Z16:       # %bb.0:
-; Z16-NEXT:    vl %v1, 0(%r3), 3
 ; Z16-NEXT:    lgdr %r0, %f0
+; Z16-NEXT:    vl %v0, 0(%r3), 3
 ; Z16-NEXT:    tmhh %r0, 32768
 ; Z16-NEXT:    je .LBB14_2
 ; Z16-NEXT:  # %bb.1:
-; Z16-NEXT:    wflnxb %v0, %v1
+; Z16-NEXT:    wflnxb %v0, %v0
 ; Z16-NEXT:    vst %v0, 0(%r2), 3
 ; Z16-NEXT:    br %r14
 ; Z16-NEXT:  .LBB14_2:
-; Z16-NEXT:    wflpxb %v0, %v1
+; Z16-NEXT:    wflpxb %v0, %v0
 ; Z16-NEXT:    vst %v0, 0(%r2), 3
 ; Z16-NEXT:    br %r14
   %b128 = fpext double %b to fp128

--- a/llvm/test/CodeGen/SystemZ/fp-half-vector-binops.ll
+++ b/llvm/test/CodeGen/SystemZ/fp-half-vector-binops.ll
@@ -198,10 +198,10 @@ define void @fun0(ptr %Src, ptr %Dst) {
 ; VECTOR-NEXT:    std %f8, 240(%r15) # 8-byte Spill
 ; VECTOR-NEXT:    .cfi_offset %f8, -168
 ; VECTOR-NEXT:    vl %v0, 16(%r2), 3
-; VECTOR-NEXT:    mvc 160(16,%r15), 0(%r2) # 16-byte Folded Spill
 ; VECTOR-NEXT:    lgr %r13, %r3
 ; VECTOR-NEXT:    vst %v0, 176(%r15), 3 # 16-byte Spill
 ; VECTOR-NEXT:    vreph %v0, %v0, 7
+; VECTOR-NEXT:    mvc 160(16,%r15), 0(%r2) # 16-byte Folded Spill
 ; VECTOR-NEXT:    # kill: def $f0h killed $f0h killed $v0
 ; VECTOR-NEXT:    brasl %r14, __extendhfsf2@PLT
 ; VECTOR-NEXT:    ldr %f8, %f0
@@ -224,13 +224,13 @@ define void @fun0(ptr %Src, ptr %Dst) {
 ; VECTOR-NEXT:    brasl %r14, __extendhfsf2@PLT
 ; VECTOR-NEXT:    aebr %f0, %f8
 ; VECTOR-NEXT:    brasl %r14, __truncsfhf2@PLT
-; VECTOR-NEXT:    vl %v1, 208(%r15), 3 # 16-byte Reload
+; VECTOR-NEXT:    vl %v1, 176(%r15), 3 # 16-byte Reload
+; VECTOR-NEXT:    vl %v2, 208(%r15), 3 # 16-byte Reload
 ; VECTOR-NEXT:    # kill: def $f0h killed $f0h def $v0
-; VECTOR-NEXT:    vmrhh %v0, %v0, %v1
+; VECTOR-NEXT:    vreph %v1, %v1, 5
+; VECTOR-NEXT:    vmrhh %v0, %v0, %v2
 ; VECTOR-NEXT:    vst %v0, 208(%r15), 3 # 16-byte Spill
-; VECTOR-NEXT:    vl %v0, 176(%r15), 3 # 16-byte Reload
-; VECTOR-NEXT:    vreph %v0, %v0, 5
-; VECTOR-NEXT:    # kill: def $f0h killed $f0h killed $v0
+; VECTOR-NEXT:    ldr %f0, %f1
 ; VECTOR-NEXT:    brasl %r14, __extendhfsf2@PLT
 ; VECTOR-NEXT:    ldr %f8, %f0
 ; VECTOR-NEXT:    vl %v0, 160(%r15), 3 # 16-byte Reload
@@ -253,13 +253,13 @@ define void @fun0(ptr %Src, ptr %Dst) {
 ; VECTOR-NEXT:    aebr %f0, %f8
 ; VECTOR-NEXT:    brasl %r14, __truncsfhf2@PLT
 ; VECTOR-NEXT:    vl %v1, 192(%r15), 3 # 16-byte Reload
+; VECTOR-NEXT:    vl %v2, 208(%r15), 3 # 16-byte Reload
 ; VECTOR-NEXT:    # kill: def $f0h killed $f0h def $v0
-; VECTOR-NEXT:    vmrhh %v0, %v0, %v1
-; VECTOR-NEXT:    vl %v1, 208(%r15), 3 # 16-byte Reload
-; VECTOR-NEXT:    vmrhf %v0, %v0, %v1
-; VECTOR-NEXT:    vst %v0, 208(%r15), 3 # 16-byte Spill
+; VECTOR-NEXT:    vmrhh %v1, %v0, %v1
 ; VECTOR-NEXT:    vl %v0, 176(%r15), 3 # 16-byte Reload
+; VECTOR-NEXT:    vmrhf %v1, %v1, %v2
 ; VECTOR-NEXT:    vreph %v0, %v0, 3
+; VECTOR-NEXT:    vst %v1, 208(%r15), 3 # 16-byte Spill
 ; VECTOR-NEXT:    # kill: def $f0h killed $f0h killed $v0
 ; VECTOR-NEXT:    brasl %r14, __extendhfsf2@PLT
 ; VECTOR-NEXT:    ldr %f8, %f0

--- a/llvm/test/CodeGen/SystemZ/fp-half-vector-fcmp-select.ll
+++ b/llvm/test/CodeGen/SystemZ/fp-half-vector-fcmp-select.ll
@@ -242,10 +242,10 @@ define void @fun0(ptr %Src, ptr %Dst) {
 ; VECTOR-NEXT:    std %f8, 208(%r15) # 8-byte Spill
 ; VECTOR-NEXT:    .cfi_offset %f8, -168
 ; VECTOR-NEXT:    vl %v0, 16(%r2), 3
-; VECTOR-NEXT:    mvc 176(16,%r15), 0(%r2) # 16-byte Folded Spill
 ; VECTOR-NEXT:    lgr %r13, %r3
 ; VECTOR-NEXT:    vst %v0, 192(%r15), 3 # 16-byte Spill
 ; VECTOR-NEXT:    vreph %v0, %v0, 7
+; VECTOR-NEXT:    mvc 176(16,%r15), 0(%r2) # 16-byte Folded Spill
 ; VECTOR-NEXT:    # kill: def $f0h killed $f0h killed $v0
 ; VECTOR-NEXT:    brasl %r14, __extendhfsf2@PLT
 ; VECTOR-NEXT:    ldr %f8, %f0
@@ -256,9 +256,9 @@ define void @fun0(ptr %Src, ptr %Dst) {
 ; VECTOR-NEXT:    cebr %f0, %f8
 ; VECTOR-NEXT:    vl %v0, 192(%r15), 3 # 16-byte Reload
 ; VECTOR-NEXT:    lhi %r11, 0
+; VECTOR-NEXT:    vreph %v0, %v0, 3
 ; VECTOR-NEXT:    lhi %r12, 0
 ; VECTOR-NEXT:    lochie %r11, -1
-; VECTOR-NEXT:    vreph %v0, %v0, 3
 ; VECTOR-NEXT:    # kill: def $f0h killed $f0h killed $v0
 ; VECTOR-NEXT:    brasl %r14, __extendhfsf2@PLT
 ; VECTOR-NEXT:    ldr %f8, %f0
@@ -279,28 +279,28 @@ define void @fun0(ptr %Src, ptr %Dst) {
 ; VECTOR-NEXT:    # kill: def $f0h killed $f0h killed $v0
 ; VECTOR-NEXT:    brasl %r14, __extendhfsf2@PLT
 ; VECTOR-NEXT:    cebr %f0, %f8
-; VECTOR-NEXT:    vl %v0, 160(%r15), 3 # 16-byte Reload
+; VECTOR-NEXT:    vl %v1, 160(%r15), 3 # 16-byte Reload
 ; VECTOR-NEXT:    lhi %r0, 0
-; VECTOR-NEXT:    lochie %r0, -1
-; VECTOR-NEXT:    vlvgh %v0, %r0, 0
-; VECTOR-NEXT:    vst %v0, 160(%r15), 3 # 16-byte Spill
 ; VECTOR-NEXT:    vl %v0, 192(%r15), 3 # 16-byte Reload
+; VECTOR-NEXT:    lochie %r0, -1
+; VECTOR-NEXT:    vlvgh %v1, %r0, 0
+; VECTOR-NEXT:    vreph %v0, %v0, 1
+; VECTOR-NEXT:    vst %v1, 160(%r15), 3 # 16-byte Spill
+; VECTOR-NEXT:    # kill: def $f0h killed $f0h killed $v0
+; VECTOR-NEXT:    brasl %r14, __extendhfsf2@PLT
+; VECTOR-NEXT:    ldr %f8, %f0
+; VECTOR-NEXT:    vl %v0, 176(%r15), 3 # 16-byte Reload
 ; VECTOR-NEXT:    vreph %v0, %v0, 1
 ; VECTOR-NEXT:    # kill: def $f0h killed $f0h killed $v0
 ; VECTOR-NEXT:    brasl %r14, __extendhfsf2@PLT
-; VECTOR-NEXT:    ldr %f8, %f0
-; VECTOR-NEXT:    vl %v0, 176(%r15), 3 # 16-byte Reload
-; VECTOR-NEXT:    vreph %v0, %v0, 1
-; VECTOR-NEXT:    # kill: def $f0h killed $f0h killed $v0
-; VECTOR-NEXT:    brasl %r14, __extendhfsf2@PLT
 ; VECTOR-NEXT:    cebr %f0, %f8
-; VECTOR-NEXT:    vl %v0, 160(%r15), 3 # 16-byte Reload
+; VECTOR-NEXT:    vl %v1, 160(%r15), 3 # 16-byte Reload
 ; VECTOR-NEXT:    lhi %r0, 0
-; VECTOR-NEXT:    lochie %r0, -1
-; VECTOR-NEXT:    vlvgh %v0, %r0, 1
-; VECTOR-NEXT:    vst %v0, 160(%r15), 3 # 16-byte Spill
 ; VECTOR-NEXT:    vl %v0, 192(%r15), 3 # 16-byte Reload
+; VECTOR-NEXT:    lochie %r0, -1
+; VECTOR-NEXT:    vlvgh %v1, %r0, 1
 ; VECTOR-NEXT:    vreph %v0, %v0, 2
+; VECTOR-NEXT:    vst %v1, 160(%r15), 3 # 16-byte Spill
 ; VECTOR-NEXT:    # kill: def $f0h killed $f0h killed $v0
 ; VECTOR-NEXT:    brasl %r14, __extendhfsf2@PLT
 ; VECTOR-NEXT:    ldr %f8, %f0
@@ -309,13 +309,13 @@ define void @fun0(ptr %Src, ptr %Dst) {
 ; VECTOR-NEXT:    # kill: def $f0h killed $f0h killed $v0
 ; VECTOR-NEXT:    brasl %r14, __extendhfsf2@PLT
 ; VECTOR-NEXT:    cebr %f0, %f8
-; VECTOR-NEXT:    vl %v0, 160(%r15), 3 # 16-byte Reload
+; VECTOR-NEXT:    vl %v1, 160(%r15), 3 # 16-byte Reload
 ; VECTOR-NEXT:    lhi %r0, 0
-; VECTOR-NEXT:    lochie %r0, -1
-; VECTOR-NEXT:    vlvgh %v0, %r0, 2
-; VECTOR-NEXT:    vst %v0, 160(%r15), 3 # 16-byte Spill
 ; VECTOR-NEXT:    vl %v0, 192(%r15), 3 # 16-byte Reload
+; VECTOR-NEXT:    lochie %r0, -1
+; VECTOR-NEXT:    vlvgh %v1, %r0, 2
 ; VECTOR-NEXT:    vreph %v0, %v0, 4
+; VECTOR-NEXT:    vst %v1, 160(%r15), 3 # 16-byte Spill
 ; VECTOR-NEXT:    # kill: def $f0h killed $f0h killed $v0
 ; VECTOR-NEXT:    brasl %r14, __extendhfsf2@PLT
 ; VECTOR-NEXT:    ldr %f8, %f0
@@ -324,13 +324,13 @@ define void @fun0(ptr %Src, ptr %Dst) {
 ; VECTOR-NEXT:    # kill: def $f0h killed $f0h killed $v0
 ; VECTOR-NEXT:    brasl %r14, __extendhfsf2@PLT
 ; VECTOR-NEXT:    cebr %f0, %f8
-; VECTOR-NEXT:    vl %v0, 160(%r15), 3 # 16-byte Reload
+; VECTOR-NEXT:    vl %v1, 160(%r15), 3 # 16-byte Reload
 ; VECTOR-NEXT:    lhi %r0, 0
-; VECTOR-NEXT:    lochie %r0, -1
-; VECTOR-NEXT:    vlvgh %v0, %r0, 4
-; VECTOR-NEXT:    vst %v0, 160(%r15), 3 # 16-byte Spill
 ; VECTOR-NEXT:    vl %v0, 192(%r15), 3 # 16-byte Reload
+; VECTOR-NEXT:    lochie %r0, -1
+; VECTOR-NEXT:    vlvgh %v1, %r0, 4
 ; VECTOR-NEXT:    vreph %v0, %v0, 5
+; VECTOR-NEXT:    vst %v1, 160(%r15), 3 # 16-byte Spill
 ; VECTOR-NEXT:    # kill: def $f0h killed $f0h killed $v0
 ; VECTOR-NEXT:    brasl %r14, __extendhfsf2@PLT
 ; VECTOR-NEXT:    ldr %f8, %f0
@@ -339,13 +339,13 @@ define void @fun0(ptr %Src, ptr %Dst) {
 ; VECTOR-NEXT:    # kill: def $f0h killed $f0h killed $v0
 ; VECTOR-NEXT:    brasl %r14, __extendhfsf2@PLT
 ; VECTOR-NEXT:    cebr %f0, %f8
-; VECTOR-NEXT:    vl %v0, 160(%r15), 3 # 16-byte Reload
+; VECTOR-NEXT:    vl %v1, 160(%r15), 3 # 16-byte Reload
 ; VECTOR-NEXT:    lhi %r0, 0
-; VECTOR-NEXT:    lochie %r0, -1
-; VECTOR-NEXT:    vlvgh %v0, %r0, 5
-; VECTOR-NEXT:    vst %v0, 160(%r15), 3 # 16-byte Spill
 ; VECTOR-NEXT:    vl %v0, 192(%r15), 3 # 16-byte Reload
+; VECTOR-NEXT:    lochie %r0, -1
+; VECTOR-NEXT:    vlvgh %v1, %r0, 5
 ; VECTOR-NEXT:    vreph %v0, %v0, 6
+; VECTOR-NEXT:    vst %v1, 160(%r15), 3 # 16-byte Spill
 ; VECTOR-NEXT:    # kill: def $f0h killed $f0h killed $v0
 ; VECTOR-NEXT:    brasl %r14, __extendhfsf2@PLT
 ; VECTOR-NEXT:    ldr %f8, %f0
@@ -460,31 +460,31 @@ define void @fun1(ptr %Src, ptr %Dst) {
 ; VECTOR-NEXT:    vlreph %v0, 4(%r2)
 ; VECTOR-NEXT:    vlreph %v8, 2(%r2)
 ; VECTOR-NEXT:    vlreph %v11, 0(%r2)
-; VECTOR-NEXT:    vlreph %v9, 6(%r2)
+; VECTOR-NEXT:    vlreph %v10, 6(%r2)
 ; VECTOR-NEXT:    lgr %r13, %r3
 ; VECTOR-NEXT:    brasl %r14, __extendhfsf2@PLT
-; VECTOR-NEXT:    ldr %f10, %f0
+; VECTOR-NEXT:    ldr %f9, %f0
 ; VECTOR-NEXT:    ldr %f0, %f11
 ; VECTOR-NEXT:    brasl %r14, __extendhfsf2@PLT
-; VECTOR-NEXT:    cebr %f0, %f10
+; VECTOR-NEXT:    cebr %f0, %f9
 ; VECTOR-NEXT:    je .LBB1_2
 ; VECTOR-NEXT:  # %bb.1:
-; VECTOR-NEXT:    ldr %f0, %f10
+; VECTOR-NEXT:    ldr %f0, %f9
 ; VECTOR-NEXT:  .LBB1_2:
 ; VECTOR-NEXT:    brasl %r14, __truncsfhf2@PLT
-; VECTOR-NEXT:    ldr %f10, %f0
-; VECTOR-NEXT:    ldr %f0, %f9
-; VECTOR-NEXT:    brasl %r14, __extendhfsf2@PLT
 ; VECTOR-NEXT:    ldr %f9, %f0
+; VECTOR-NEXT:    ldr %f0, %f10
+; VECTOR-NEXT:    brasl %r14, __extendhfsf2@PLT
+; VECTOR-NEXT:    ldr %f10, %f0
 ; VECTOR-NEXT:    ldr %f0, %f8
 ; VECTOR-NEXT:    brasl %r14, __extendhfsf2@PLT
-; VECTOR-NEXT:    cebr %f0, %f9
+; VECTOR-NEXT:    cebr %f0, %f10
 ; VECTOR-NEXT:    je .LBB1_4
 ; VECTOR-NEXT:  # %bb.3:
-; VECTOR-NEXT:    ldr %f0, %f9
+; VECTOR-NEXT:    ldr %f0, %f10
 ; VECTOR-NEXT:  .LBB1_4:
 ; VECTOR-NEXT:    brasl %r14, __truncsfhf2@PLT
-; VECTOR-NEXT:    vsteh %v10, 0(%r13), 0
+; VECTOR-NEXT:    vsteh %v9, 0(%r13), 0
 ; VECTOR-NEXT:    ld %f8, 184(%r15) # 8-byte Reload
 ; VECTOR-NEXT:    ld %f9, 176(%r15) # 8-byte Reload
 ; VECTOR-NEXT:    ld %f10, 168(%r15) # 8-byte Reload

--- a/llvm/test/CodeGen/SystemZ/inline-asm-fp-int-casting-explicit-regs-zEC12.ll
+++ b/llvm/test/CodeGen/SystemZ/inline-asm-fp-int-casting-explicit-regs-zEC12.ll
@@ -212,13 +212,13 @@ define <4 x i32> @vec128_and_f(<4 x i32> %cc_dep1) {
 ; CHECK-NEXT:    aghi %r15, -176
 ; CHECK-NEXT:    .cfi_def_cfa_offset 336
 ; CHECK-NEXT:    # kill: def $r4l killed $r4l def $r4d
+; CHECK-NEXT:    # kill: def $r2l killed $r2l def $r2d
 ; CHECK-NEXT:    sllg %r0, %r4, 32
 ; CHECK-NEXT:    lr %r0, %r5
-; CHECK-NEXT:    # kill: def $r2l killed $r2l def $r2d
+; CHECK-NEXT:    sllg %r1, %r2, 32
+; CHECK-NEXT:    lr %r1, %r3
 ; CHECK-NEXT:    stg %r0, 168(%r15)
-; CHECK-NEXT:    sllg %r0, %r2, 32
-; CHECK-NEXT:    lr %r0, %r3
-; CHECK-NEXT:    stg %r0, 160(%r15)
+; CHECK-NEXT:    stg %r1, 160(%r15)
 ; CHECK-NEXT:    ld %f0, 160(%r15)
 ; CHECK-NEXT:    ld %f2, 168(%r15)
 ; CHECK-NEXT:    #APP

--- a/llvm/test/CodeGen/SystemZ/inline-asm-fp-int-casting-zEC12.ll
+++ b/llvm/test/CodeGen/SystemZ/inline-asm-fp-int-casting-zEC12.ll
@@ -205,13 +205,13 @@ define <4 x i32> @vec128_and_f(<4 x i32> %cc_dep1) {
 ; CHECK-NEXT:    aghi %r15, -176
 ; CHECK-NEXT:    .cfi_def_cfa_offset 336
 ; CHECK-NEXT:    # kill: def $r4l killed $r4l def $r4d
+; CHECK-NEXT:    # kill: def $r2l killed $r2l def $r2d
 ; CHECK-NEXT:    sllg %r0, %r4, 32
 ; CHECK-NEXT:    lr %r0, %r5
-; CHECK-NEXT:    # kill: def $r2l killed $r2l def $r2d
+; CHECK-NEXT:    sllg %r1, %r2, 32
+; CHECK-NEXT:    lr %r1, %r3
 ; CHECK-NEXT:    stg %r0, 168(%r15)
-; CHECK-NEXT:    sllg %r0, %r2, 32
-; CHECK-NEXT:    lr %r0, %r3
-; CHECK-NEXT:    stg %r0, 160(%r15)
+; CHECK-NEXT:    stg %r1, 160(%r15)
 ; CHECK-NEXT:    ld %f0, 160(%r15)
 ; CHECK-NEXT:    ld %f2, 168(%r15)
 ; CHECK-NEXT:    #APP

--- a/llvm/test/CodeGen/SystemZ/int-cmp-65.ll
+++ b/llvm/test/CodeGen/SystemZ/int-cmp-65.ll
@@ -247,10 +247,10 @@ define i128 @i128_addc_xor_inv(i128 %a, i128 %b) {
 ;
 ; Z13-LABEL: i128_addc_xor_inv:
 ; Z13:       # %bb.0:
-; Z13-NEXT:    vl %v1, 0(%r4), 3
-; Z13-NEXT:    vl %v0, 0(%r3), 3
-; Z13-NEXT:    vno %v1, %v1, %v1
-; Z13-NEXT:    vscbiq %v0, %v1, %v0
+; Z13-NEXT:    vl %v0, 0(%r4), 3
+; Z13-NEXT:    vl %v1, 0(%r3), 3
+; Z13-NEXT:    vno %v0, %v0, %v0
+; Z13-NEXT:    vscbiq %v0, %v0, %v1
 ; Z13-NEXT:    vst %v0, 0(%r2), 3
 ; Z13-NEXT:    br %r14
   %b.not = xor i128 %b, -1

--- a/llvm/test/CodeGen/SystemZ/int-conv-14.ll
+++ b/llvm/test/CodeGen/SystemZ/int-conv-14.ll
@@ -332,9 +332,9 @@ define i128 @f25(i1 %a) {
 ; CHECK-LABEL: f25:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    larl %r1, .LCPI24_0
-; CHECK-NEXT:    vl %v1, 0(%r1), 3
-; CHECK-NEXT:    vlvgp %v0, %r3, %r3
-; CHECK-NEXT:    vn %v0, %v0, %v1
+; CHECK-NEXT:    vl %v0, 0(%r1), 3
+; CHECK-NEXT:    vlvgp %v1, %r3, %r3
+; CHECK-NEXT:    vn %v0, %v1, %v0
 ; CHECK-NEXT:    vgbm %v1, 0
 ; CHECK-NEXT:    vsq %v0, %v1, %v0
 ; CHECK-NEXT:    vst %v0, 0(%r2), 3
@@ -347,13 +347,13 @@ define i128 @f25(i1 %a) {
 define i128 @f26(ptr %ptr) {
 ; CHECK-LABEL: f26:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vgbm %v1, 0
-; CHECK-NEXT:    vleb %v1, 0(%r3), 15
-; CHECK-NEXT:    larl %r1, .LCPI25_0
-; CHECK-NEXT:    vl %v2, 0(%r1), 3
 ; CHECK-NEXT:    vgbm %v0, 0
-; CHECK-NEXT:    vn %v1, %v1, %v2
-; CHECK-NEXT:    vsq %v0, %v0, %v1
+; CHECK-NEXT:    vleb %v0, 0(%r3), 15
+; CHECK-NEXT:    larl %r1, .LCPI25_0
+; CHECK-NEXT:    vl %v1, 0(%r1), 3
+; CHECK-NEXT:    vgbm %v2, 0
+; CHECK-NEXT:    vn %v0, %v0, %v1
+; CHECK-NEXT:    vsq %v0, %v2, %v0
 ; CHECK-NEXT:    vst %v0, 0(%r2), 3
 ; CHECK-NEXT:    br %r14
   %a = load i1, ptr %ptr
@@ -366,9 +366,9 @@ define i128 @f27(i1 %a) {
 ; CHECK-LABEL: f27:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    larl %r1, .LCPI26_0
-; CHECK-NEXT:    vl %v1, 0(%r1), 3
-; CHECK-NEXT:    vlvgp %v0, %r3, %r3
-; CHECK-NEXT:    vn %v0, %v0, %v1
+; CHECK-NEXT:    vl %v0, 0(%r1), 3
+; CHECK-NEXT:    vlvgp %v1, %r3, %r3
+; CHECK-NEXT:    vn %v0, %v1, %v0
 ; CHECK-NEXT:    vst %v0, 0(%r2), 3
 ; CHECK-NEXT:    br %r14
   %res = zext i1 %a to i128

--- a/llvm/test/CodeGen/SystemZ/int-conv-15.ll
+++ b/llvm/test/CodeGen/SystemZ/int-conv-15.ll
@@ -332,9 +332,9 @@ define i128 @f25(i1 %a) {
 ; CHECK-LABEL: f25:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    larl %r1, .LCPI24_0
-; CHECK-NEXT:    vl %v1, 0(%r1), 3
-; CHECK-NEXT:    vlvgp %v0, %r3, %r3
-; CHECK-NEXT:    vn %v0, %v0, %v1
+; CHECK-NEXT:    vl %v0, 0(%r1), 3
+; CHECK-NEXT:    vlvgp %v1, %r3, %r3
+; CHECK-NEXT:    vn %v0, %v1, %v0
 ; CHECK-NEXT:    vlcq %v0, %v0
 ; CHECK-NEXT:    vst %v0, 0(%r2), 3
 ; CHECK-NEXT:    br %r14
@@ -364,9 +364,9 @@ define i128 @f27(i1 %a) {
 ; CHECK-LABEL: f27:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    larl %r1, .LCPI26_0
-; CHECK-NEXT:    vl %v1, 0(%r1), 3
-; CHECK-NEXT:    vlvgp %v0, %r3, %r3
-; CHECK-NEXT:    vn %v0, %v0, %v1
+; CHECK-NEXT:    vl %v0, 0(%r1), 3
+; CHECK-NEXT:    vlvgp %v1, %r3, %r3
+; CHECK-NEXT:    vn %v0, %v1, %v0
 ; CHECK-NEXT:    vst %v0, 0(%r2), 3
 ; CHECK-NEXT:    br %r14
   %res = zext i1 %a to i128

--- a/llvm/test/CodeGen/SystemZ/int-mul-12.ll
+++ b/llvm/test/CodeGen/SystemZ/int-mul-12.ll
@@ -7,21 +7,20 @@
 define i128 @f1(i128 %a, i128 %b) {
 ; CHECK-LABEL: f1:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    stmg %r12, %r15, 96(%r15)
-; CHECK-NEXT:    .cfi_offset %r12, -64
-; CHECK-NEXT:    .cfi_offset %r13, -56
+; CHECK-NEXT:    stmg %r14, %r15, 112(%r15)
+; CHECK-NEXT:    .cfi_offset %r14, -48
 ; CHECK-NEXT:    .cfi_offset %r15, -40
-; CHECK-NEXT:    lg %r13, 8(%r3)
-; CHECK-NEXT:    lg %r0, 8(%r4)
-; CHECK-NEXT:    lgr %r1, %r13
-; CHECK-NEXT:    mlgr %r12, %r0
-; CHECK-NEXT:    msg %r1, 0(%r4)
-; CHECK-NEXT:    msg %r0, 0(%r3)
-; CHECK-NEXT:    agr %r1, %r12
-; CHECK-NEXT:    agr %r0, %r1
-; CHECK-NEXT:    stg %r13, 8(%r2)
-; CHECK-NEXT:    stg %r0, 0(%r2)
-; CHECK-NEXT:    lmg %r12, %r15, 96(%r15)
+; CHECK-NEXT:    lg %r1, 8(%r3)
+; CHECK-NEXT:    lg %r5, 8(%r4)
+; CHECK-NEXT:    lgr %r14, %r1
+; CHECK-NEXT:    mlgr %r0, %r5
+; CHECK-NEXT:    msg %r14, 0(%r4)
+; CHECK-NEXT:    msg %r5, 0(%r3)
+; CHECK-NEXT:    agr %r14, %r0
+; CHECK-NEXT:    agr %r5, %r14
+; CHECK-NEXT:    stg %r1, 8(%r2)
+; CHECK-NEXT:    stg %r5, 0(%r2)
+; CHECK-NEXT:    lmg %r14, %r15, 112(%r15)
 ; CHECK-NEXT:    br %r14
   %res = mul i128 %a, %b
   ret i128 %res

--- a/llvm/test/CodeGen/SystemZ/int-mul-13.ll
+++ b/llvm/test/CodeGen/SystemZ/int-mul-13.ll
@@ -24,12 +24,12 @@ define i64 @f1(i64 %dummy, i64 %a, i64 %b) {
 define i64 @f2(i64 %dummy, i64 %a, i64 %b) {
 ; CHECK-LABEL: f2:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    srag %r1, %r4, 63
+; CHECK-NEXT:    srag %r0, %r4, 63
 ; CHECK-NEXT:    # kill: def $r3d killed $r3d def $r2q
-; CHECK-NEXT:    srag %r0, %r3, 63
-; CHECK-NEXT:    ngr %r1, %r3
+; CHECK-NEXT:    srag %r1, %r3, 63
+; CHECK-NEXT:    ngr %r0, %r3
 ; CHECK-NEXT:    mlgr %r2, %r4
-; CHECK-NEXT:    ngr %r0, %r4
+; CHECK-NEXT:    ngr %r1, %r4
 ; CHECK-NEXT:    agr %r0, %r1
 ; CHECK-NEXT:    sgr %r2, %r0
 ; CHECK-NEXT:    br %r14

--- a/llvm/test/CodeGen/SystemZ/int-uadd-14.ll
+++ b/llvm/test/CodeGen/SystemZ/int-uadd-14.ll
@@ -6,17 +6,17 @@
 define zeroext i1 @f1(i256 %a, i256 %b, ptr %res) {
 ; CHECK-LABEL: f1:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vl %v2, 16(%r3), 3
-; CHECK-NEXT:    vl %v3, 16(%r2), 3
-; CHECK-NEXT:    vl %v0, 0(%r3), 3
-; CHECK-NEXT:    vl %v1, 0(%r2), 3
-; CHECK-NEXT:    vaccq %v4, %v3, %v2
-; CHECK-NEXT:    vacccq %v5, %v1, %v0, %v4
+; CHECK-NEXT:    vl %v0, 16(%r3), 3
+; CHECK-NEXT:    vl %v1, 16(%r2), 3
+; CHECK-NEXT:    vl %v2, 0(%r3), 3
+; CHECK-NEXT:    vl %v3, 0(%r2), 3
+; CHECK-NEXT:    vaccq %v4, %v1, %v0
+; CHECK-NEXT:    vaq %v0, %v1, %v0
+; CHECK-NEXT:    vacccq %v5, %v3, %v2, %v4
 ; CHECK-NEXT:    vlgvg %r2, %v5, 1
-; CHECK-NEXT:    vacq %v0, %v1, %v0, %v4
-; CHECK-NEXT:    vaq %v1, %v3, %v2
-; CHECK-NEXT:    vst %v1, 16(%r4), 3
-; CHECK-NEXT:    vst %v0, 0(%r4), 3
+; CHECK-NEXT:    vacq %v2, %v3, %v2, %v4
+; CHECK-NEXT:    vst %v0, 16(%r4), 3
+; CHECK-NEXT:    vst %v2, 0(%r4), 3
 ; CHECK-NEXT:    br %r14
   %t = call {i256, i1} @llvm.uadd.with.overflow.i256(i256 %a, i256 %b)
   %val = extractvalue {i256, i1} %t, 0
@@ -28,12 +28,12 @@ define zeroext i1 @f1(i256 %a, i256 %b, ptr %res) {
 define zeroext i1 @f2(i256 %a, i256 %b) {
 ; CHECK-LABEL: f2:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vl %v2, 16(%r3), 3
-; CHECK-NEXT:    vl %v3, 16(%r2), 3
-; CHECK-NEXT:    vl %v0, 0(%r3), 3
-; CHECK-NEXT:    vl %v1, 0(%r2), 3
-; CHECK-NEXT:    vaccq %v2, %v3, %v2
-; CHECK-NEXT:    vacccq %v0, %v1, %v0, %v2
+; CHECK-NEXT:    vl %v0, 16(%r3), 3
+; CHECK-NEXT:    vl %v1, 16(%r2), 3
+; CHECK-NEXT:    vl %v2, 0(%r3), 3
+; CHECK-NEXT:    vl %v3, 0(%r2), 3
+; CHECK-NEXT:    vaccq %v0, %v1, %v0
+; CHECK-NEXT:    vacccq %v0, %v3, %v2, %v0
 ; CHECK-NEXT:    vlgvg %r2, %v0, 1
 ; CHECK-NEXT:    br %r14
   %t = call {i256, i1} @llvm.uadd.with.overflow.i256(i256 %a, i256 %b)
@@ -44,15 +44,15 @@ define zeroext i1 @f2(i256 %a, i256 %b) {
 define i256 @f3(i256 %a, i256 %b) {
 ; CHECK-LABEL: f3:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vl %v2, 16(%r4), 3
-; CHECK-NEXT:    vl %v3, 16(%r3), 3
-; CHECK-NEXT:    vl %v0, 0(%r4), 3
-; CHECK-NEXT:    vl %v1, 0(%r3), 3
-; CHECK-NEXT:    vaccq %v4, %v3, %v2
-; CHECK-NEXT:    vacq %v0, %v1, %v0, %v4
-; CHECK-NEXT:    vaq %v1, %v3, %v2
-; CHECK-NEXT:    vst %v1, 16(%r2), 3
-; CHECK-NEXT:    vst %v0, 0(%r2), 3
+; CHECK-NEXT:    vl %v0, 16(%r4), 3
+; CHECK-NEXT:    vl %v1, 16(%r3), 3
+; CHECK-NEXT:    vl %v2, 0(%r4), 3
+; CHECK-NEXT:    vl %v3, 0(%r3), 3
+; CHECK-NEXT:    vaccq %v4, %v1, %v0
+; CHECK-NEXT:    vaq %v0, %v1, %v0
+; CHECK-NEXT:    vacq %v2, %v3, %v2, %v4
+; CHECK-NEXT:    vst %v0, 16(%r2), 3
+; CHECK-NEXT:    vst %v2, 0(%r2), 3
 ; CHECK-NEXT:    br %r14
   %t = call {i256, i1} @llvm.uadd.with.overflow.i256(i256 %a, i256 %b)
   %val = extractvalue {i256, i1} %t, 0

--- a/llvm/test/CodeGen/SystemZ/int-usub-13.ll
+++ b/llvm/test/CodeGen/SystemZ/int-usub-13.ll
@@ -6,18 +6,18 @@
 define zeroext i1 @f1(i256 %a, i256 %b, ptr %res) {
 ; CHECK-LABEL: f1:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vl %v2, 16(%r3), 3
-; CHECK-NEXT:    vl %v3, 16(%r2), 3
-; CHECK-NEXT:    vl %v0, 0(%r3), 3
-; CHECK-NEXT:    vl %v1, 0(%r2), 3
-; CHECK-NEXT:    vscbiq %v4, %v3, %v2
-; CHECK-NEXT:    vsbcbiq %v5, %v1, %v0, %v4
+; CHECK-NEXT:    vl %v0, 16(%r3), 3
+; CHECK-NEXT:    vl %v1, 16(%r2), 3
+; CHECK-NEXT:    vl %v2, 0(%r3), 3
+; CHECK-NEXT:    vl %v3, 0(%r2), 3
+; CHECK-NEXT:    vscbiq %v4, %v1, %v0
+; CHECK-NEXT:    vsq %v0, %v1, %v0
+; CHECK-NEXT:    vsbcbiq %v5, %v3, %v2, %v4
 ; CHECK-NEXT:    vlgvg %r2, %v5, 1
-; CHECK-NEXT:    vsbiq %v0, %v1, %v0, %v4
-; CHECK-NEXT:    vsq %v1, %v3, %v2
+; CHECK-NEXT:    vsbiq %v2, %v3, %v2, %v4
 ; CHECK-NEXT:    xilf %r2, 1
-; CHECK-NEXT:    vst %v1, 16(%r4), 3
-; CHECK-NEXT:    vst %v0, 0(%r4), 3
+; CHECK-NEXT:    vst %v0, 16(%r4), 3
+; CHECK-NEXT:    vst %v2, 0(%r4), 3
 ; CHECK-NEXT:    br %r14
   %t = call {i256, i1} @llvm.usub.with.overflow.i256(i256 %a, i256 %b)
   %val = extractvalue {i256, i1} %t, 0
@@ -29,12 +29,12 @@ define zeroext i1 @f1(i256 %a, i256 %b, ptr %res) {
 define zeroext i1 @f2(i256 %a, i256 %b) {
 ; CHECK-LABEL: f2:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vl %v2, 16(%r3), 3
-; CHECK-NEXT:    vl %v3, 16(%r2), 3
-; CHECK-NEXT:    vl %v0, 0(%r3), 3
-; CHECK-NEXT:    vl %v1, 0(%r2), 3
-; CHECK-NEXT:    vscbiq %v2, %v3, %v2
-; CHECK-NEXT:    vsbcbiq %v0, %v1, %v0, %v2
+; CHECK-NEXT:    vl %v0, 16(%r3), 3
+; CHECK-NEXT:    vl %v1, 16(%r2), 3
+; CHECK-NEXT:    vl %v2, 0(%r3), 3
+; CHECK-NEXT:    vl %v3, 0(%r2), 3
+; CHECK-NEXT:    vscbiq %v0, %v1, %v0
+; CHECK-NEXT:    vsbcbiq %v0, %v3, %v2, %v0
 ; CHECK-NEXT:    vlgvg %r2, %v0, 1
 ; CHECK-NEXT:    xilf %r2, 1
 ; CHECK-NEXT:    br %r14
@@ -46,15 +46,15 @@ define zeroext i1 @f2(i256 %a, i256 %b) {
 define i256 @f3(i256 %a, i256 %b) {
 ; CHECK-LABEL: f3:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vl %v2, 16(%r4), 3
-; CHECK-NEXT:    vl %v3, 16(%r3), 3
-; CHECK-NEXT:    vl %v0, 0(%r4), 3
-; CHECK-NEXT:    vl %v1, 0(%r3), 3
-; CHECK-NEXT:    vscbiq %v4, %v3, %v2
-; CHECK-NEXT:    vsbiq %v0, %v1, %v0, %v4
-; CHECK-NEXT:    vsq %v1, %v3, %v2
-; CHECK-NEXT:    vst %v1, 16(%r2), 3
-; CHECK-NEXT:    vst %v0, 0(%r2), 3
+; CHECK-NEXT:    vl %v0, 16(%r4), 3
+; CHECK-NEXT:    vl %v1, 16(%r3), 3
+; CHECK-NEXT:    vl %v2, 0(%r4), 3
+; CHECK-NEXT:    vl %v3, 0(%r3), 3
+; CHECK-NEXT:    vscbiq %v4, %v1, %v0
+; CHECK-NEXT:    vsq %v0, %v1, %v0
+; CHECK-NEXT:    vsbiq %v2, %v3, %v2, %v4
+; CHECK-NEXT:    vst %v0, 16(%r2), 3
+; CHECK-NEXT:    vst %v2, 0(%r2), 3
 ; CHECK-NEXT:    br %r14
   %t = call {i256, i1} @llvm.usub.with.overflow.i256(i256 %a, i256 %b)
   %val = extractvalue {i256, i1} %t, 0

--- a/llvm/test/CodeGen/SystemZ/machine-combiner-reassoc-fp.ll
+++ b/llvm/test/CodeGen/SystemZ/machine-combiner-reassoc-fp.ll
@@ -11,11 +11,11 @@ define double @fun0_fadd(ptr %x) {
 ; CHECK-NEXT:    adb %f0, 8(%r2)
 ; CHECK-NEXT:    ld %f1, 24(%r2)
 ; CHECK-NEXT:    adb %f1, 16(%r2)
+; CHECK-NEXT:    ld %f2, 40(%r2)
+; CHECK-NEXT:    adb %f2, 32(%r2)
+; CHECK-NEXT:    adb %f2, 48(%r2)
 ; CHECK-NEXT:    adbr %f0, %f1
-; CHECK-NEXT:    ld %f1, 40(%r2)
-; CHECK-NEXT:    adb %f1, 32(%r2)
-; CHECK-NEXT:    adb %f1, 48(%r2)
-; CHECK-NEXT:    adbr %f0, %f1
+; CHECK-NEXT:    adbr %f0, %f2
 ; CHECK-NEXT:    adb %f0, 56(%r2)
 ; CHECK-NEXT:    br %r14
 entry:
@@ -51,11 +51,11 @@ define float @fun1_fadd(ptr %x) {
 ; CHECK-NEXT:    aeb %f0, 4(%r2)
 ; CHECK-NEXT:    lde %f1, 12(%r2)
 ; CHECK-NEXT:    aeb %f1, 8(%r2)
+; CHECK-NEXT:    lde %f2, 20(%r2)
+; CHECK-NEXT:    aeb %f2, 16(%r2)
+; CHECK-NEXT:    aeb %f2, 24(%r2)
 ; CHECK-NEXT:    aebr %f0, %f1
-; CHECK-NEXT:    lde %f1, 20(%r2)
-; CHECK-NEXT:    aeb %f1, 16(%r2)
-; CHECK-NEXT:    aeb %f1, 24(%r2)
-; CHECK-NEXT:    aebr %f0, %f1
+; CHECK-NEXT:    aebr %f0, %f2
 ; CHECK-NEXT:    aeb %f0, 28(%r2)
 ; CHECK-NEXT:    br %r14
 entry:
@@ -89,16 +89,16 @@ define fp128 @fun2_fadd(ptr %x) {
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vl %v0, 0(%r3), 3
 ; CHECK-NEXT:    vl %v1, 16(%r3), 3
+; CHECK-NEXT:    vl %v2, 32(%r3), 3
+; CHECK-NEXT:    vl %v3, 48(%r3), 3
+; CHECK-NEXT:    vl %v4, 64(%r3), 3
+; CHECK-NEXT:    vl %v5, 80(%r3), 3
 ; CHECK-NEXT:    wfaxb %v0, %v1, %v0
-; CHECK-NEXT:    vl %v1, 32(%r3), 3
-; CHECK-NEXT:    vl %v2, 48(%r3), 3
-; CHECK-NEXT:    wfaxb %v1, %v1, %v2
+; CHECK-NEXT:    wfaxb %v1, %v2, %v3
+; CHECK-NEXT:    wfaxb %v2, %v4, %v5
+; CHECK-NEXT:    vl %v3, 96(%r3), 3
 ; CHECK-NEXT:    wfaxb %v0, %v0, %v1
-; CHECK-NEXT:    vl %v1, 64(%r3), 3
-; CHECK-NEXT:    vl %v2, 80(%r3), 3
-; CHECK-NEXT:    wfaxb %v1, %v1, %v2
-; CHECK-NEXT:    vl %v2, 96(%r3), 3
-; CHECK-NEXT:    wfaxb %v1, %v1, %v2
+; CHECK-NEXT:    wfaxb %v1, %v2, %v3
 ; CHECK-NEXT:    wfaxb %v0, %v0, %v1
 ; CHECK-NEXT:    vl %v1, 112(%r3), 3
 ; CHECK-NEXT:    wfaxb %v0, %v0, %v1
@@ -135,16 +135,16 @@ define <2 x double> @fun3_fadd(ptr %x) {
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vl %v0, 0(%r2), 3
 ; CHECK-NEXT:    vl %v1, 16(%r2), 3
+; CHECK-NEXT:    vl %v2, 32(%r2), 3
+; CHECK-NEXT:    vl %v3, 48(%r2), 3
+; CHECK-NEXT:    vl %v4, 64(%r2), 3
+; CHECK-NEXT:    vl %v5, 80(%r2), 3
 ; CHECK-NEXT:    vfadb %v0, %v1, %v0
-; CHECK-NEXT:    vl %v1, 32(%r2), 3
-; CHECK-NEXT:    vl %v2, 48(%r2), 3
-; CHECK-NEXT:    vfadb %v1, %v1, %v2
+; CHECK-NEXT:    vfadb %v1, %v2, %v3
+; CHECK-NEXT:    vfadb %v2, %v4, %v5
+; CHECK-NEXT:    vl %v3, 96(%r2), 3
 ; CHECK-NEXT:    vfadb %v0, %v0, %v1
-; CHECK-NEXT:    vl %v1, 64(%r2), 3
-; CHECK-NEXT:    vl %v2, 80(%r2), 3
-; CHECK-NEXT:    vfadb %v1, %v1, %v2
-; CHECK-NEXT:    vl %v2, 96(%r2), 3
-; CHECK-NEXT:    vfadb %v1, %v1, %v2
+; CHECK-NEXT:    vfadb %v1, %v2, %v3
 ; CHECK-NEXT:    vfadb %v0, %v0, %v1
 ; CHECK-NEXT:    vl %v1, 112(%r2), 3
 ; CHECK-NEXT:    vfadb %v24, %v0, %v1
@@ -180,16 +180,16 @@ define <4 x float> @fun4_fadd(ptr %x) {
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vl %v0, 0(%r2), 3
 ; CHECK-NEXT:    vl %v1, 16(%r2), 3
+; CHECK-NEXT:    vl %v2, 32(%r2), 3
+; CHECK-NEXT:    vl %v3, 48(%r2), 3
+; CHECK-NEXT:    vl %v4, 64(%r2), 3
+; CHECK-NEXT:    vl %v5, 80(%r2), 3
 ; CHECK-NEXT:    vfasb %v0, %v1, %v0
-; CHECK-NEXT:    vl %v1, 32(%r2), 3
-; CHECK-NEXT:    vl %v2, 48(%r2), 3
-; CHECK-NEXT:    vfasb %v1, %v1, %v2
+; CHECK-NEXT:    vfasb %v1, %v2, %v3
+; CHECK-NEXT:    vfasb %v2, %v4, %v5
+; CHECK-NEXT:    vl %v3, 96(%r2), 3
 ; CHECK-NEXT:    vfasb %v0, %v0, %v1
-; CHECK-NEXT:    vl %v1, 64(%r2), 3
-; CHECK-NEXT:    vl %v2, 80(%r2), 3
-; CHECK-NEXT:    vfasb %v1, %v1, %v2
-; CHECK-NEXT:    vl %v2, 96(%r2), 3
-; CHECK-NEXT:    vfasb %v1, %v1, %v2
+; CHECK-NEXT:    vfasb %v1, %v2, %v3
 ; CHECK-NEXT:    vfasb %v0, %v0, %v1
 ; CHECK-NEXT:    vl %v1, 112(%r2), 3
 ; CHECK-NEXT:    vfasb %v24, %v0, %v1
@@ -227,11 +227,11 @@ define double @fun5_fsub(ptr %x) {
 ; CHECK-NEXT:    sdb %f0, 8(%r2)
 ; CHECK-NEXT:    ld %f1, 24(%r2)
 ; CHECK-NEXT:    adb %f1, 16(%r2)
+; CHECK-NEXT:    ld %f2, 40(%r2)
+; CHECK-NEXT:    adb %f2, 32(%r2)
+; CHECK-NEXT:    adb %f2, 48(%r2)
 ; CHECK-NEXT:    sdbr %f0, %f1
-; CHECK-NEXT:    ld %f1, 40(%r2)
-; CHECK-NEXT:    adb %f1, 32(%r2)
-; CHECK-NEXT:    adb %f1, 48(%r2)
-; CHECK-NEXT:    sdbr %f0, %f1
+; CHECK-NEXT:    sdbr %f0, %f2
 ; CHECK-NEXT:    sdb %f0, 56(%r2)
 ; CHECK-NEXT:    br %r14
 entry:
@@ -267,11 +267,11 @@ define float @fun6_fsub(ptr %x) {
 ; CHECK-NEXT:    seb %f0, 4(%r2)
 ; CHECK-NEXT:    lde %f1, 12(%r2)
 ; CHECK-NEXT:    aeb %f1, 8(%r2)
+; CHECK-NEXT:    lde %f2, 20(%r2)
+; CHECK-NEXT:    aeb %f2, 16(%r2)
+; CHECK-NEXT:    aeb %f2, 24(%r2)
 ; CHECK-NEXT:    sebr %f0, %f1
-; CHECK-NEXT:    lde %f1, 20(%r2)
-; CHECK-NEXT:    aeb %f1, 16(%r2)
-; CHECK-NEXT:    aeb %f1, 24(%r2)
-; CHECK-NEXT:    sebr %f0, %f1
+; CHECK-NEXT:    sebr %f0, %f2
 ; CHECK-NEXT:    seb %f0, 28(%r2)
 ; CHECK-NEXT:    br %r14
 entry:
@@ -305,16 +305,16 @@ define fp128 @fun7_fsub(ptr %x) {
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vl %v0, 0(%r3), 3
 ; CHECK-NEXT:    vl %v1, 16(%r3), 3
+; CHECK-NEXT:    vl %v2, 32(%r3), 3
+; CHECK-NEXT:    vl %v3, 48(%r3), 3
+; CHECK-NEXT:    vl %v4, 64(%r3), 3
+; CHECK-NEXT:    vl %v5, 80(%r3), 3
 ; CHECK-NEXT:    wfsxb %v0, %v0, %v1
-; CHECK-NEXT:    vl %v1, 32(%r3), 3
-; CHECK-NEXT:    vl %v2, 48(%r3), 3
-; CHECK-NEXT:    wfaxb %v1, %v1, %v2
+; CHECK-NEXT:    wfaxb %v1, %v2, %v3
+; CHECK-NEXT:    wfaxb %v2, %v4, %v5
+; CHECK-NEXT:    vl %v3, 96(%r3), 3
 ; CHECK-NEXT:    wfsxb %v0, %v0, %v1
-; CHECK-NEXT:    vl %v1, 64(%r3), 3
-; CHECK-NEXT:    vl %v2, 80(%r3), 3
-; CHECK-NEXT:    wfaxb %v1, %v1, %v2
-; CHECK-NEXT:    vl %v2, 96(%r3), 3
-; CHECK-NEXT:    wfaxb %v1, %v1, %v2
+; CHECK-NEXT:    wfaxb %v1, %v2, %v3
 ; CHECK-NEXT:    wfsxb %v0, %v0, %v1
 ; CHECK-NEXT:    vl %v1, 112(%r3), 3
 ; CHECK-NEXT:    wfsxb %v0, %v0, %v1
@@ -351,16 +351,16 @@ define <2 x double> @fun8_fsub(ptr %x) {
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vl %v0, 0(%r2), 3
 ; CHECK-NEXT:    vl %v1, 16(%r2), 3
+; CHECK-NEXT:    vl %v2, 32(%r2), 3
+; CHECK-NEXT:    vl %v3, 48(%r2), 3
+; CHECK-NEXT:    vl %v4, 64(%r2), 3
+; CHECK-NEXT:    vl %v5, 80(%r2), 3
 ; CHECK-NEXT:    vfsdb %v0, %v0, %v1
-; CHECK-NEXT:    vl %v1, 32(%r2), 3
-; CHECK-NEXT:    vl %v2, 48(%r2), 3
-; CHECK-NEXT:    vfadb %v1, %v1, %v2
+; CHECK-NEXT:    vfadb %v1, %v2, %v3
+; CHECK-NEXT:    vfadb %v2, %v4, %v5
+; CHECK-NEXT:    vl %v3, 96(%r2), 3
 ; CHECK-NEXT:    vfsdb %v0, %v0, %v1
-; CHECK-NEXT:    vl %v1, 64(%r2), 3
-; CHECK-NEXT:    vl %v2, 80(%r2), 3
-; CHECK-NEXT:    vfadb %v1, %v1, %v2
-; CHECK-NEXT:    vl %v2, 96(%r2), 3
-; CHECK-NEXT:    vfadb %v1, %v1, %v2
+; CHECK-NEXT:    vfadb %v1, %v2, %v3
 ; CHECK-NEXT:    vfsdb %v0, %v0, %v1
 ; CHECK-NEXT:    vl %v1, 112(%r2), 3
 ; CHECK-NEXT:    vfsdb %v24, %v0, %v1
@@ -396,16 +396,16 @@ define <4 x float> @fun9_fsub(ptr %x) {
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vl %v0, 0(%r2), 3
 ; CHECK-NEXT:    vl %v1, 16(%r2), 3
+; CHECK-NEXT:    vl %v2, 32(%r2), 3
+; CHECK-NEXT:    vl %v3, 48(%r2), 3
+; CHECK-NEXT:    vl %v4, 64(%r2), 3
+; CHECK-NEXT:    vl %v5, 80(%r2), 3
 ; CHECK-NEXT:    vfssb %v0, %v0, %v1
-; CHECK-NEXT:    vl %v1, 32(%r2), 3
-; CHECK-NEXT:    vl %v2, 48(%r2), 3
-; CHECK-NEXT:    vfasb %v1, %v1, %v2
+; CHECK-NEXT:    vfasb %v1, %v2, %v3
+; CHECK-NEXT:    vfasb %v2, %v4, %v5
+; CHECK-NEXT:    vl %v3, 96(%r2), 3
 ; CHECK-NEXT:    vfssb %v0, %v0, %v1
-; CHECK-NEXT:    vl %v1, 64(%r2), 3
-; CHECK-NEXT:    vl %v2, 80(%r2), 3
-; CHECK-NEXT:    vfasb %v1, %v1, %v2
-; CHECK-NEXT:    vl %v2, 96(%r2), 3
-; CHECK-NEXT:    vfasb %v1, %v1, %v2
+; CHECK-NEXT:    vfasb %v1, %v2, %v3
 ; CHECK-NEXT:    vfssb %v0, %v0, %v1
 ; CHECK-NEXT:    vl %v1, 112(%r2), 3
 ; CHECK-NEXT:    vfssb %v24, %v0, %v1
@@ -443,11 +443,11 @@ define double @fun10_fmul(ptr %x) {
 ; CHECK-NEXT:    mdb %f0, 0(%r2)
 ; CHECK-NEXT:    ld %f1, 24(%r2)
 ; CHECK-NEXT:    mdb %f1, 16(%r2)
+; CHECK-NEXT:    ld %f2, 40(%r2)
+; CHECK-NEXT:    mdb %f2, 32(%r2)
+; CHECK-NEXT:    mdb %f2, 48(%r2)
 ; CHECK-NEXT:    mdbr %f0, %f1
-; CHECK-NEXT:    ld %f1, 40(%r2)
-; CHECK-NEXT:    mdb %f1, 32(%r2)
-; CHECK-NEXT:    mdb %f1, 48(%r2)
-; CHECK-NEXT:    mdbr %f0, %f1
+; CHECK-NEXT:    mdbr %f0, %f2
 ; CHECK-NEXT:    mdb %f0, 56(%r2)
 ; CHECK-NEXT:    br %r14
 entry:
@@ -483,11 +483,11 @@ define float @fun11_fmul(ptr %x) {
 ; CHECK-NEXT:    meeb %f0, 0(%r2)
 ; CHECK-NEXT:    lde %f1, 12(%r2)
 ; CHECK-NEXT:    meeb %f1, 8(%r2)
+; CHECK-NEXT:    lde %f2, 20(%r2)
+; CHECK-NEXT:    meeb %f2, 16(%r2)
+; CHECK-NEXT:    meeb %f2, 24(%r2)
 ; CHECK-NEXT:    meebr %f0, %f1
-; CHECK-NEXT:    lde %f1, 20(%r2)
-; CHECK-NEXT:    meeb %f1, 16(%r2)
-; CHECK-NEXT:    meeb %f1, 24(%r2)
-; CHECK-NEXT:    meebr %f0, %f1
+; CHECK-NEXT:    meebr %f0, %f2
 ; CHECK-NEXT:    meeb %f0, 28(%r2)
 ; CHECK-NEXT:    br %r14
 entry:
@@ -521,16 +521,16 @@ define fp128 @fun12_fmul(ptr %x) {
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vl %v0, 0(%r3), 3
 ; CHECK-NEXT:    vl %v1, 16(%r3), 3
+; CHECK-NEXT:    vl %v2, 32(%r3), 3
+; CHECK-NEXT:    vl %v3, 48(%r3), 3
+; CHECK-NEXT:    vl %v4, 64(%r3), 3
+; CHECK-NEXT:    vl %v5, 80(%r3), 3
 ; CHECK-NEXT:    wfmxb %v0, %v0, %v1
-; CHECK-NEXT:    vl %v1, 32(%r3), 3
-; CHECK-NEXT:    vl %v2, 48(%r3), 3
-; CHECK-NEXT:    wfmxb %v1, %v1, %v2
+; CHECK-NEXT:    wfmxb %v1, %v2, %v3
+; CHECK-NEXT:    wfmxb %v2, %v4, %v5
+; CHECK-NEXT:    vl %v3, 96(%r3), 3
 ; CHECK-NEXT:    wfmxb %v0, %v0, %v1
-; CHECK-NEXT:    vl %v1, 64(%r3), 3
-; CHECK-NEXT:    vl %v2, 80(%r3), 3
-; CHECK-NEXT:    wfmxb %v1, %v1, %v2
-; CHECK-NEXT:    vl %v2, 96(%r3), 3
-; CHECK-NEXT:    wfmxb %v1, %v1, %v2
+; CHECK-NEXT:    wfmxb %v1, %v2, %v3
 ; CHECK-NEXT:    wfmxb %v0, %v0, %v1
 ; CHECK-NEXT:    vl %v1, 112(%r3), 3
 ; CHECK-NEXT:    wfmxb %v0, %v0, %v1
@@ -567,16 +567,16 @@ define <2 x double> @fun13_fmul(ptr %x) {
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vl %v0, 0(%r2), 3
 ; CHECK-NEXT:    vl %v1, 16(%r2), 3
+; CHECK-NEXT:    vl %v2, 32(%r2), 3
+; CHECK-NEXT:    vl %v3, 48(%r2), 3
+; CHECK-NEXT:    vl %v4, 64(%r2), 3
+; CHECK-NEXT:    vl %v5, 80(%r2), 3
 ; CHECK-NEXT:    vfmdb %v0, %v0, %v1
-; CHECK-NEXT:    vl %v1, 32(%r2), 3
-; CHECK-NEXT:    vl %v2, 48(%r2), 3
-; CHECK-NEXT:    vfmdb %v1, %v1, %v2
+; CHECK-NEXT:    vfmdb %v1, %v2, %v3
+; CHECK-NEXT:    vfmdb %v2, %v4, %v5
+; CHECK-NEXT:    vl %v3, 96(%r2), 3
 ; CHECK-NEXT:    vfmdb %v0, %v0, %v1
-; CHECK-NEXT:    vl %v1, 64(%r2), 3
-; CHECK-NEXT:    vl %v2, 80(%r2), 3
-; CHECK-NEXT:    vfmdb %v1, %v1, %v2
-; CHECK-NEXT:    vl %v2, 96(%r2), 3
-; CHECK-NEXT:    vfmdb %v1, %v1, %v2
+; CHECK-NEXT:    vfmdb %v1, %v2, %v3
 ; CHECK-NEXT:    vfmdb %v0, %v0, %v1
 ; CHECK-NEXT:    vl %v1, 112(%r2), 3
 ; CHECK-NEXT:    vfmdb %v24, %v0, %v1
@@ -612,16 +612,16 @@ define <4 x float> @fun14_fmul(ptr %x) {
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vl %v0, 0(%r2), 3
 ; CHECK-NEXT:    vl %v1, 16(%r2), 3
+; CHECK-NEXT:    vl %v2, 32(%r2), 3
+; CHECK-NEXT:    vl %v3, 48(%r2), 3
+; CHECK-NEXT:    vl %v4, 64(%r2), 3
+; CHECK-NEXT:    vl %v5, 80(%r2), 3
 ; CHECK-NEXT:    vfmsb %v0, %v0, %v1
-; CHECK-NEXT:    vl %v1, 32(%r2), 3
-; CHECK-NEXT:    vl %v2, 48(%r2), 3
-; CHECK-NEXT:    vfmsb %v1, %v1, %v2
+; CHECK-NEXT:    vfmsb %v1, %v2, %v3
+; CHECK-NEXT:    vfmsb %v2, %v4, %v5
+; CHECK-NEXT:    vl %v3, 96(%r2), 3
 ; CHECK-NEXT:    vfmsb %v0, %v0, %v1
-; CHECK-NEXT:    vl %v1, 64(%r2), 3
-; CHECK-NEXT:    vl %v2, 80(%r2), 3
-; CHECK-NEXT:    vfmsb %v1, %v1, %v2
-; CHECK-NEXT:    vl %v2, 96(%r2), 3
-; CHECK-NEXT:    vfmsb %v1, %v1, %v2
+; CHECK-NEXT:    vfmsb %v1, %v2, %v3
 ; CHECK-NEXT:    vfmsb %v0, %v0, %v1
 ; CHECK-NEXT:    vl %v1, 112(%r2), 3
 ; CHECK-NEXT:    vfmsb %v24, %v0, %v1

--- a/llvm/test/CodeGen/SystemZ/misched-prera-cmp-elim.mir
+++ b/llvm/test/CodeGen/SystemZ/misched-prera-cmp-elim.mir
@@ -3,37 +3,54 @@
 # RUN:   | FileCheck %s
 # REQUIRES: asserts
 
-# Schedule the AGHIK that defines the compare source low to help comparison
+# Schedule the NRK that defines the compare source low to help comparison
 # elimination.
 # CHECK:      ********** MI Scheduling **********
 # CHECK-NEXT: fun0:%bb.0
 # CHECK:      ********** MI Scheduling **********
 # CHECK-NEXT: fun0:%bb.1
-# CHECK:      Queue BotQ.A: 1 0
-# CHECK-NEXT:   Cand SU(1) FIRST
-# CHECK-NEXT:   Cand SU(0) WEAK
+# CHECK:      Queue BotQ.A: 4 5
+# CHECK-NEXT:   Cand SU(4) FIRST
 # CHECK-NEXT: Pick Bot WEAK       [pre-RA]
-# CHECK-NEXT: Scheduling SU(0) %2:gr64bit = AGHIK %0:gr64bit, -1, impl
+# CHECK-NEXT: Scheduling SU(4) %7:gr32bit = NRK %6:gr32bit, %0:gr32bit, implicit-def dead $cc
 # CHECK:      *** Final schedule for %bb.1 ***
-# CHECK-NEXT: SU(1):   dead %3:gr64bit = AGHIK %1:gr64bit, 1, implicit-def dead $cc
-# CHECK-NEXT: SU(0):   %2:gr64bit = AGHIK %0:gr64bit, -1, implicit-def dead $cc
-# CHECK-NEXT: SU(2):   CGHI %2:gr64bit, 0, implicit-def $cc
+# CHECK-NEXT: SU(0):   %5:gr32bit = NRK %2:gr32bit, %0:gr32bit, implicit-def dead $cc
+# CHECK-NEXT: SU(1):   CHIMux %5:gr32bit, 0, implicit-def $cc
+# CHECK-NEXT: SU(2):   %6:gr32bit = LHIMux 0
+# CHECK-NEXT: SU(3):   %6:gr32bit = LOCHIMux %6:gr32bit(tied-def 0), 1, 14, 8, implicit $cc
+# CHECK-NEXT: SU(5):   %3:addr32bit = OILMux %3:addr32bit(tied-def 0), 1, implicit-def dead $cc
+# CHECK-NEXT: SU(4):   %7:gr32bit = NRK %6:gr32bit, %0:gr32bit, implicit-def dead $cc
+# CHECK-NEXT: SU(6):   %8:gr32bit = SLLK %1:gr32bit, %3:addr32bit, 0
+# CHECK-NEXT: SU(7):   CHIMux %7:gr32bit, 0, implicit-def $cc
+# CHECK-NEXT: SU(8):   %8:gr32bit = LOCHIMux %8:gr32bit(tied-def 0), 0, 14, 8, implicit $cc
+# CHECK-NEXT: SU(9):   %4:gr32bit = ORK %8:gr32bit, %4:gr32bit, implicit-def dead $cc
+# CHECK-NEXT: SU(10):  %2:gr32bit = LHIMux 1
+# CHECK-NEXT: SU(11):  %3:addr32bit = LHIMux 0
 ---
 name:            fun0
 tracksRegLiveness: true
 body:             |
   bb.0:
-    liveins: $r2d, $r3d
+    liveins: $r2l
 
-    %0:gr64bit = COPY $r2d
-    %1:gr64bit = COPY $r3d
+    %0:gr32bit = COPY $r2l
+    %1:gr32bit = LHIMux 1
+    %2:gr32bit = LHIMux 0
+    %3:addr32bit = LHIMux 1
+    %4:gr32bit = LHIMux 0
 
   bb.1:
-    %2:gr64bit = AGHIK %0, -1, implicit-def dead $cc
-    %3:gr64bit = AGHIK %1, 1, implicit-def dead $cc
-    CGHI %2:gr64bit, 0, implicit-def $cc
-    BRC 14, 8, %bb.1, implicit killed $cc
-
-  bb.2:
-    Return
+    %5:gr32bit = NRK %2, %0, implicit-def dead $cc
+    CHIMux %5, 0, implicit-def $cc
+    %6:gr32bit = LHIMux 0
+    %6:gr32bit = LOCHIMux %6, 1, 14, 8, implicit killed $cc
+    %7:gr32bit = NRK %6, %0, implicit-def dead $cc
+    %3:addr32bit = OILMux %3, 1, implicit-def dead $cc
+    %8:gr32bit = SLLK %1, %3, 0
+    CHIMux %7, 0, implicit-def $cc
+    %8:gr32bit = LOCHIMux %8, 0, 14, 8, implicit killed $cc
+    %4:gr32bit = ORK %8, %4, implicit-def dead $cc
+    %2:gr32bit = LHIMux 1
+    %3:addr32bit = LHIMux 0
+    J %bb.1
 ...

--- a/llvm/test/CodeGen/SystemZ/misched-prera-latencies.mir
+++ b/llvm/test/CodeGen/SystemZ/misched-prera-latencies.mir
@@ -8,7 +8,6 @@
 # CHECK-NEXT: fun0:%bb.0
 # CHECK:      ********** MI Scheduling **********
 # CHECK-NEXT: fun0:%bb.1
-# CHECK: Number of nodes in def-use sequences: 10. Latency scheduling enabled for data sequences.
 # CHECK:      *** Final schedule for %bb.1 ***
 # CHECK-NEXT: SU(0):   %4:fp64bit = LZDR
 # CHECK-NEXT: SU(5):   %9:fp64bit = LZDR
@@ -53,7 +52,6 @@ body:             |
 # This function has a data flow sequence and latency scheduling puts the WFDDB high.
 # CHECK:      ********** MI Scheduling **********
 # CHECK-NEXT: fun1:%bb.0
-# CHECK:      Number of nodes in def-use sequences: 4. Latency scheduling enabled for data sequences.
 # CHECK:      *** Final schedule for %bb.0 ***
 # CHECK-NEXT: SU(1):   undef %1.subreg_h64:vr128bit = WFDDB undef %2:fp64bit, undef %3:fp64bit, implicit $fpc
 # CHECK-NEXT: SU(2):   %4:fp64bit = COPY %1.subreg_h64:vr128bit
@@ -73,33 +71,12 @@ body:             |
     Return
 ...
 
-# Same, but there is no sequence, so no latency scheduling is done.
+# Single block loop that should also have latency enabled.
 # CHECK:      ********** MI Scheduling **********
-# CHECK-NEXT: fun2:%bb.0
-# CHECK:      Latency scheduling not enabled for data sequences.
-# CHECK:      *** Final schedule for %bb.0 ***
-# CHECK-NEXT: SU(0):   dead %0:fp64bit = LZDR
-# CHECK-NEXT: SU(1):   undef %1.subreg_h64:vr128bit = WFDDB undef %2:fp64bit, undef %3:fp64bit, implicit $fpc
-# CHECK-NEXT: SU(2):   VST64 %1.subreg_h64:vr128bit, $noreg, 0, $noreg :: (store (s128) into `ptr null`, align 8)
----
-name:            fun2
-tracksRegLiveness: true
-body:             |
-  bb.0:
-    %0:fp64bit = LZDR
-    undef %1.subreg_h64:vr128bit = WFDDB undef %2:fp64bit, undef %3:fp64bit, implicit $fpc
-    VST64 %1.subreg_h64:vr128bit , $noreg, 0, $noreg :: (store (s128) into `ptr null`, align 8)
-    Return
-...
-
-# Use the GenericScheduler latency heuristic for this single block loop.
-# CHECK:      ********** MI Scheduling **********
-# CHECK-NEXT: fun3:%bb.1
-# CHECK: Latency scheduling not enabled for data sequences.
-# CHECK: ACYCLIC LATENCY LIMIT
+# CHECK-NEXT: fun2:%bb.1
 # CHECK: Pick Bot BOT-HEIGHT [pre-RA]
 ---
-name:            fun3
+name:            fun2
 tracksRegLiveness: true
 body:             |
   bb.0:
@@ -128,8 +105,7 @@ body:             |
 # "wide".  Don't interleave the data flows in cases like this, as it could
 # result in too much ILP and spilling.
 # CHECK:      ********** MI Scheduling **********
-# CHECK-NEXT: fun4:%bb.0
-# CHECK:      Latency scheduling not enabled for data sequences.
+# CHECK-NEXT: fun3:%bb.0
 # CHECK:      *** Final schedule for %bb.0 ***
 # CHECK-NEXT: SU(0):   %0:gr64bit = COPY undef %1:gr64bit
 # CHECK-NEXT: SU(1):   dead %2:gr64bit = AGRK %0:gr64bit, %0:gr64bit,
@@ -144,7 +120,7 @@ body:             |
 # CHECK-NEXT: SU(10):  %11:gr64bit = COPY undef %1:gr64bit
 # CHECK-NEXT: SU(11):  dead %12:gr64bit = AGRK %11:gr64bit, %11:gr64bit,
 ---
-name:            fun4
+name:            fun3
 tracksRegLiveness: true
 body:             |
   bb.0:
@@ -166,10 +142,9 @@ body:             |
 # The TMLL64 should be scheduled first even though the LA is available and of
 # lesser height, because the TMLL64 Depth equals the remaining latency (on CP).
 # CHECK:      ********** MI Scheduling **********
-# CHECK-NEXT: fun5:%bb.0
+# CHECK-NEXT: fun4:%bb.0
 # CHECK:      ********** MI Scheduling **********
-# CHECK-NEXT: fun5:%bb.1
-# CHECK:      Number of nodes in def-use sequences: 4. Latency scheduling enabled for data sequences.
+# CHECK-NEXT: fun4:%bb.1
 # CHECK:      SU(0):   dead %2:addr64bit = LA %0:addr64bit, 1, $noreg
 # CHECK-NEXT:   # preds left       : 0
 # CHECK-NEXT:   # succs left       : 0
@@ -192,7 +167,7 @@ body:             |
 # CHECK-NEXT: SU(0):   dead %2:addr64bit = LA %0:addr64bit, 1, $noreg
 # CHECK-NEXT: SU(4):   TMLL64 %5:gr64bit, 1, implicit-def $cc
 ---
-name:            fun5
+name:            fun4
 tracksRegLiveness: true
 body:             |
   bb.0:

--- a/llvm/test/CodeGen/SystemZ/misched-prera-loads.mir
+++ b/llvm/test/CodeGen/SystemZ/misched-prera-loads.mir
@@ -1,0 +1,299 @@
+# RUN: llc -o - %s -mtriple=s390x-linux-gnu -mcpu=z16 -verify-machineinstrs \
+# RUN:   -run-pass=machine-scheduler -debug-only=machine-scheduler \
+# RUN:   -top-region=12 -disable-latency 2>&1 | FileCheck %s
+
+--- |
+
+  define void @fun0() { ret void }
+  define void @fun1() { ret void }
+  define void @fun2() { ret void }
+  define void @fun3() { ret void }
+  define void @fun4() { ret void }
+  define void @fun5(ptr %Arg) { ret void }
+...
+
+# Don't schedule the LG low as it in this case is among the highest SUs.
+# CHECK:      ********** MI Scheduling **********
+# CHECK-NEXT: fun0:%bb.0
+# CHECK:        SU(1):   %1:addr64bit = LG $noreg, 0, $noreg
+# CHECK:        Height             : 4
+# CHECK:        SU(2):
+# CHECK:        SU(7):   dead %7:gr64bit = AG %6:gr64bit(tied-def 0),
+# CHECK:        Height             : 4
+# CHECK:        SU(8):
+# CHECK:      *** Final schedule for %bb.0 ***
+# CHECK-NEXT: SU(0):   %0:addr64bit = COPY $r2d
+# CHECK-NEXT: SU(1):   %1:addr64bit = LG $noreg, 0, $noreg
+# CHECK-NEXT: SU(2):   %2:gr64bit = COPY %0:addr64bit
+# CHECK-NEXT: SU(3):   %3:gr64bit = LGHI 1
+# CHECK-NEXT: SU(4):   %4:gr64bit = COPY %3:gr64bit
+# CHECK-NEXT: SU(5):   %5:gr64bit = COPY %4:gr64bit
+# CHECK-NEXT: SU(6):   %6:gr64bit = AGRK %2:gr64bit, %5:gr64bit, implicit-def $cc
+# CHECK-NEXT: SU(7):   dead %7:gr64bit = AG %6:gr64bit(tied-def 0),
+# CHECK-NEXT: SU(8):   dead %8:addr64bit = LGHI 0
+# CHECK-NEXT: SU(9):   STG %1:addr64bit, $noreg, 0, $noreg
+# CHECK-NEXT: SU(10):  $r2d = LGHI 0
+---
+name:            fun0
+tracksRegLiveness: true
+body:             |
+  bb.0:
+    liveins: $r2d
+
+    %0:addr64bit = COPY $r2d
+    %1:addr64bit = LG $noreg, 0, $noreg
+    %2:gr64bit = COPY %0
+    %3:gr64bit = LGHI 1
+    %4:gr64bit = COPY %3
+    %5:gr64bit = COPY %4
+    %6:gr64bit = AGRK %2, %5, implicit-def $cc
+    dead %7:gr64bit = AG %6, $noreg, 0, $noreg, implicit-def dead $cc
+    dead %8:addr64bit = LGHI 0
+    STG %1, $noreg, 0, $noreg
+    $r2d = LGHI 0
+    Return
+...
+
+# Schedule the LG low. The heuristic to move a load down to its user to
+# shorten the live range makes sure to not increase the scheduled latency, so
+# therefore it ends up above the AG.
+# CHECK:      ********** MI Scheduling **********
+# CHECK-NEXT: fun1:%bb.0
+# CHECK:        SU(13):   %26:addr64bit = LG $noreg, 0, $noreg
+# CHECK:        Height             : 4
+# CHECK:        SU(14):
+# CHECK:        SU(19):   dead %32:gr64bit = AG %31:gr64bit(tied-def 0),
+# CHECK:        Height             : 4
+# CHECK:        SU(20):
+# CHECK:      *** Final schedule for %bb.0 ***
+# CHECK:      SU(13):   %26:addr64bit = LG $noreg, 0, $noreg
+# CHECK-NEXT: SU(19):   dead %32:gr64bit = AG %31:gr64bit(tied-def 0),
+# CHECK-NEXT: SU(20):   dead %33:addr64bit = LGHI 0
+# CHECK-NEXT: SU(21):   STG %26:addr64bit, $noreg, 0, $noreg
+# CHECK-NEXT: SU(22):  $r2d = LGHI 0
+---
+name:            fun1
+tracksRegLiveness: true
+body:             |
+  bb.0:
+    liveins: $r2d
+
+    %0:addr64bit = COPY $r2d
+
+    ; Make for a top of region in terms of height, enabling heuristic for lower SUs.
+    %M0:vr64bit = nofpexcept WFMDB undef %LHS0:fp64bit, undef %RHS0:fp64bit, implicit $fpc
+    %M1:vr64bit = nofpexcept WFMDB %M0:vr64bit, undef %RHS1:fp64bit, implicit $fpc
+    %M2:vr64bit = nofpexcept WFMDB %M1:vr64bit, undef %RHS2:fp64bit, implicit $fpc
+    %M3:vr64bit = nofpexcept WFMDB %M2:vr64bit, undef %RHS3:fp64bit, implicit $fpc
+    %M4:vr64bit = nofpexcept WFMDB %M3:vr64bit, undef %RHS4:fp64bit, implicit $fpc
+    %M5:vr64bit = nofpexcept WFMDB %M4:vr64bit, undef %RHS5:fp64bit, implicit $fpc
+    %M6:vr64bit = nofpexcept WFMDB %M5:vr64bit, undef %RHS6:fp64bit, implicit $fpc
+    %M7:vr64bit = nofpexcept WFMDB %M6:vr64bit, undef %RHS7:fp64bit, implicit $fpc
+    %M8:vr64bit = nofpexcept WFMDB %M7:vr64bit, undef %RHS8:fp64bit, implicit $fpc
+    %M9:vr64bit = nofpexcept WFMDB %M8:vr64bit, undef %RHS9:fp64bit, implicit $fpc
+    %M10:vr64bit = nofpexcept WFMDB %M9:vr64bit, undef %RHS10:fp64bit, implicit $fpc
+    %M11:vr64bit = nofpexcept WFMDB %M10:vr64bit, undef %RHS11:fp64bit, implicit $fpc
+
+    %26:addr64bit = LG $noreg, 0, $noreg
+    %27:gr64bit = COPY %0
+    %28:gr64bit = LGHI 1
+    %29:gr64bit = COPY %28 ; Make region non-tiny.
+    %30:gr64bit = COPY %29 ;
+    %31:gr64bit = AGRK %27, %30, implicit-def $cc
+    dead %32:gr64bit = AG %31, $noreg, 0, $noreg, implicit-def dead $cc
+    dead %33:addr64bit = LGHI 0
+    STG %26, $noreg, 0, $noreg
+    $r2d = LGHI 0
+    Return
+...
+
+# Schedule the '%37 = WFMDB' as soon as its use operand is already live.
+# CHECK:      ********** MI Scheduling **********
+# CHECK-NEXT: fun2:%bb.0
+# CHECK:      *** Final schedule for %bb.0 ***
+# CHECK:      SU(13):   %26:vr64bit = nofpexcept WFMDB %25:fp64bit, %25:fp64bit, impl
+# CHECK-NEXT: SU(17):   %30:vr64bit = nofpexcept WFMDB %25:fp64bit, %29:vr64bit, impl
+# CHECK-NEXT: SU(18):   %31:vr64bit = nofpexcept WFMDB %30:vr64bit, %30:vr64bit, impl
+# CHECK-NEXT: SU(19):   dead %32:vr64bit = nofpexcept WFMDB %31:vr64bit, %26:vr64bit
+---
+name:            fun2
+tracksRegLiveness: true
+body:             |
+  bb.0:
+
+    ; Make for a top of region in terms of height, enabling heuristic for lower SUs.
+    %M0:vr64bit = nofpexcept WFDDB undef %LHS0:fp64bit, undef %RHS0:fp64bit, implicit $fpc
+    %M1:vr64bit = nofpexcept WFDDB %M0:vr64bit, undef %RHS1:fp64bit, implicit $fpc
+    %M2:vr64bit = nofpexcept WFDDB %M1:vr64bit, undef %RHS2:fp64bit, implicit $fpc
+    %M3:vr64bit = nofpexcept WFDDB %M2:vr64bit, undef %RHS3:fp64bit, implicit $fpc
+    %M4:vr64bit = nofpexcept WFDDB %M3:vr64bit, undef %RHS4:fp64bit, implicit $fpc
+    %M5:vr64bit = nofpexcept WFDDB %M4:vr64bit, undef %RHS5:fp64bit, implicit $fpc
+    %M6:vr64bit = nofpexcept WFDDB %M5:vr64bit, undef %RHS6:fp64bit, implicit $fpc
+    %M7:vr64bit = nofpexcept WFDDB %M6:vr64bit, undef %RHS7:fp64bit, implicit $fpc
+    %M8:vr64bit = nofpexcept WFDDB %M7:vr64bit, undef %RHS8:fp64bit, implicit $fpc
+    %M9:vr64bit = nofpexcept WFDDB %M8:vr64bit, undef %RHS9:fp64bit, implicit $fpc
+    %M10:vr64bit = nofpexcept WFDDB %M9:vr64bit, undef %RHS10:fp64bit, implicit $fpc
+    %M11:vr64bit = nofpexcept WFDDB %M10:vr64bit, undef %RHS11:fp64bit, implicit $fpc
+
+    %25:fp64bit = LZDR
+    %26:vr64bit = nofpexcept WFMDB %25, %25, implicit $fpc
+    %27:vr64bit = nofpexcept WFMDB %25, %25, implicit $fpc
+    %28:vr64bit = nofpexcept WFMDB %25, %27, implicit $fpc
+    %29:vr64bit = nofpexcept WFMDB %25, %28, implicit $fpc
+    %30:vr64bit = nofpexcept WFMDB %25, %29, implicit $fpc
+    %31:vr64bit = nofpexcept WFMDB %30, %30, implicit $fpc
+    %32:vr64bit = nofpexcept WFMDB %31, %26, implicit $fpc
+    VST64 %30, $noreg, 0, $noreg :: (store (s64) into `ptr null`)
+    $f0d = COPY %30
+    Return implicit $f0d
+...
+
+# Same, with GPR registers.
+# CHECK:      ********** MI Scheduling **********
+# CHECK-NEXT: fun3:%bb.0
+# CHECK:      *** Final schedule for %bb.0 ***
+# CHECK:      SU(13):   %37:gr64bit = AGRK %36:gr64bit, %36:gr64bit, implicit-def dead $cc
+# CHECK-NEXT: SU(17):   %41:gr64bit = AGRK %36:gr64bit, %40:gr64bit, implicit-def dead $cc
+# CHECK-NEXT: SU(18):   %42:gr64bit = AGRK %41:gr64bit, %41:gr64bit, implicit-def dead $cc
+# CHECK-NEXT: SU(19):   dead %43:gr64bit = AGRK %42:gr64bit, %37:gr64bit, implicit-def dead $cc
+# CHECK-NEXT: SU(20):   STG %41:gr64bit, $noreg, 0, $noreg :: (store (s64) into `ptr null`)
+# CHECK-NEXT: SU(21):   $r2d = COPY %41:gr64bit
+---
+name:            fun3
+tracksRegLiveness: true
+body:             |
+  bb.0:
+    ; Make for a top of region in terms of height, enabling heuristic for lower SUs.
+    %M0:vr64bit = nofpexcept WFDDB undef %LHS0:fp64bit, undef %RHS0:fp64bit, implicit $fpc
+    %M1:vr64bit = nofpexcept WFDDB undef %LHS1:fp64bit, undef %RHS1:fp64bit, implicit $fpc
+    %M2:vr64bit = nofpexcept WFDDB undef %LHS2:fp64bit, undef %RHS2:fp64bit, implicit $fpc
+    %M3:vr64bit = nofpexcept WFDDB undef %LHS3:fp64bit, undef %RHS3:fp64bit, implicit $fpc
+    %M4:vr64bit = nofpexcept WFDDB undef %LHS4:fp64bit, undef %RHS4:fp64bit, implicit $fpc
+    %M5:vr64bit = nofpexcept WFDDB undef %LHS5:fp64bit, undef %RHS5:fp64bit, implicit $fpc
+    %M6:vr64bit = nofpexcept WFDDB undef %LHS6:fp64bit, undef %RHS6:fp64bit, implicit $fpc
+    %M7:vr64bit = nofpexcept WFDDB undef %LHS7:fp64bit, undef %RHS7:fp64bit, implicit $fpc
+    %M8:vr64bit = nofpexcept WFDDB undef %LHS8:fp64bit, undef %RHS8:fp64bit, implicit $fpc
+    %M9:vr64bit = nofpexcept WFDDB undef %LHS9:fp64bit, undef %RHS9:fp64bit, implicit $fpc
+    %M10:vr64bit = nofpexcept WFDDB undef %LHS10:fp64bit, undef %RHS10:fp64bit, implicit $fpc
+    %M11:vr64bit = nofpexcept WFDDB undef %LHS11:fp64bit, undef %RHS11:fp64bit, implicit $fpc
+
+    %36:gr64bit = LGHI 1
+    %37:gr64bit = AGRK %36, %36, implicit-def dead $cc
+    %38:gr64bit = AGRK %36, %36, implicit-def dead $cc
+    %39:gr64bit = AGRK %36, %38, implicit-def dead $cc
+    %40:gr64bit = AGRK %36, %39, implicit-def dead $cc
+    %41:gr64bit = AGRK %36, %40, implicit-def dead $cc
+    %42:gr64bit = AGRK %41, %41, implicit-def dead $cc
+    %43:gr64bit = AGRK %42, %37, implicit-def dead $cc
+    STG %41, $noreg, 0, $noreg :: (store (s64) into `ptr null`)
+    $r2d = COPY %41
+    Return implicit $r2d
+...
+
+# *Don't* schedule the AGR low since %1 continues to be live above it.
+# CHECK:      ********** MI Scheduling **********
+# CHECK-NEXT: fun4:%bb.0
+# CHECK:      *** Final schedule for %bb.0 ***
+# CHECK:      SU(14):   %1:gr64bit = AGR %1:gr64bit(tied-def 0), %0:gr64bit, implicit-def $cc
+# CHECK-NEXT: SU(15):   dead %38:gr64bit = COPY undef %39:gr64bit
+# CHECK-NEXT: SU(16):   dead %40:gr64bit = COPY undef %39:gr64bit
+# CHECK-NEXT: SU(17):   dead %41:gr64bit = COPY undef %39:gr64bit
+# CHECK-NEXT: SU(18):   dead %42:gr64bit = COPY undef %39:gr64bit
+# CHECK-NEXT: SU(19):   dead %43:gr64bit = COPY undef %39:gr64bit
+# CHECK-NEXT: SU(20):   %44:gr64bit = COPY undef %39:gr64bit
+# CHECK-NEXT: SU(21):   STG %44:gr64bit, $noreg, 0, $noreg
+# CHECK-NEXT: SU(22):   STG %1:gr64bit, $noreg, 0, $noreg
+---
+name:            fun4
+tracksRegLiveness: true
+body:             |
+  bb.0:
+    liveins: $r2d, $r3d
+
+    %0:gr64bit = COPY $r2d
+    %1:gr64bit = COPY $r3d
+
+    ; Make for a top of region in terms of height, enabling heuristic for lower SUs.
+    %M0:vr64bit = nofpexcept WFDDB undef %LHS0:fp64bit, undef %RHS0:fp64bit, implicit $fpc
+    %M1:vr64bit = nofpexcept WFDDB undef %LHS1:fp64bit, undef %RHS1:fp64bit, implicit $fpc
+    %M2:vr64bit = nofpexcept WFDDB undef %LHS2:fp64bit, undef %RHS2:fp64bit, implicit $fpc
+    %M3:vr64bit = nofpexcept WFDDB undef %LHS3:fp64bit, undef %RHS3:fp64bit, implicit $fpc
+    %M4:vr64bit = nofpexcept WFDDB undef %LHS4:fp64bit, undef %RHS4:fp64bit, implicit $fpc
+    %M5:vr64bit = nofpexcept WFDDB undef %LHS5:fp64bit, undef %RHS5:fp64bit, implicit $fpc
+    %M6:vr64bit = nofpexcept WFDDB undef %LHS6:fp64bit, undef %RHS6:fp64bit, implicit $fpc
+    %M7:vr64bit = nofpexcept WFDDB undef %LHS7:fp64bit, undef %RHS7:fp64bit, implicit $fpc
+    %M8:vr64bit = nofpexcept WFDDB undef %LHS8:fp64bit, undef %RHS8:fp64bit, implicit $fpc
+    %M9:vr64bit = nofpexcept WFDDB undef %LHS9:fp64bit, undef %RHS9:fp64bit, implicit $fpc
+    %M10:vr64bit = nofpexcept WFDDB undef %LHS10:fp64bit, undef %RHS10:fp64bit, implicit $fpc
+    %M11:vr64bit = nofpexcept WFDDB undef %LHS11:fp64bit, undef %RHS11:fp64bit, implicit $fpc
+
+    %1:gr64bit = AGR %1, %0, implicit-def $cc
+    %38:gr64bit = COPY undef %39:gr64bit
+    %40:gr64bit = COPY undef %39:gr64bit
+    %41:gr64bit = COPY undef %39:gr64bit
+    %42:gr64bit = COPY undef %39:gr64bit
+    %43:gr64bit = COPY undef %39:gr64bit
+    %44:gr64bit = COPY undef %39:gr64bit
+    STG %44, $noreg, 0, $noreg
+    STG %1, $noreg, 0, $noreg
+    STG %0, $noreg, 0, $noreg
+    Return
+...
+
+# Schedule the VL64 low, above the first LG. It is loading a (live out) vr64,
+# which is prioritized, so even if %1 isn't live, that's ok as that is a GPR
+# register. This heuristic is guarded to not increment the scheduled latency,
+# which makes it wait until the first LG is scheduled.
+# CHECK:      ********** MI Scheduling **********
+# CHECK-NEXT: fun5:%bb.0
+# CHECK:      Live Out: %40 %39 %38
+#
+# CHECK:      Queue BotQ.A: 2 3 4 5 6 7 8 15 14 13 12 11 10 9 0
+# CHECK:      Cand SU(14) REG-EXCESS
+# CHECK:      Scheduling SU(14) %38:vr64bit = VL64 %1:addr64bit, 0, $noreg ::
+# CHECK:      LiveReg: %1
+#
+# CHECK:      *** Final schedule for %bb.0 ***
+# CHECK:      SU(14):   %38:vr64bit = VL64 %1:addr64bit, 0, $noreg :: (load (s64) from %ir.Arg)
+# CHECK-NEXT: SU(16):   %40:addr64bit = LG %0:addr64bit, 0, $noreg :: (load (s64) from %ir.Arg)
+# CHECK-NEXT: SU(17):   dead %41:gr64bit = COPY undef %42:gr64bit
+
+---
+name:            fun5
+tracksRegLiveness: true
+body:             |
+  bb.0:
+    liveins: $r2d, $r3d
+  
+    %0:addr64bit = COPY $r3d
+    %1:addr64bit = COPY $r2d
+
+    ; Make for a top of region in terms of height, enabling heuristic for lower SUs.
+    %M0:vr64bit = nofpexcept WFDDB undef %LHS0:fp64bit, undef %RHS0:fp64bit, implicit $fpc
+    %M1:vr64bit = nofpexcept WFDDB undef %LHS1:fp64bit, undef %RHS1:fp64bit, implicit $fpc
+    %M2:vr64bit = nofpexcept WFDDB undef %LHS2:fp64bit, undef %RHS2:fp64bit, implicit $fpc
+    %M3:vr64bit = nofpexcept WFDDB undef %LHS3:fp64bit, undef %RHS3:fp64bit, implicit $fpc
+    %M4:vr64bit = nofpexcept WFDDB undef %LHS4:fp64bit, undef %RHS4:fp64bit, implicit $fpc
+    %M5:vr64bit = nofpexcept WFDDB undef %LHS5:fp64bit, undef %RHS5:fp64bit, implicit $fpc
+    %M6:vr64bit = nofpexcept WFDDB undef %LHS6:fp64bit, undef %RHS6:fp64bit, implicit $fpc
+    %M7:vr64bit = nofpexcept WFDDB undef %LHS7:fp64bit, undef %RHS7:fp64bit, implicit $fpc
+    %M8:vr64bit = nofpexcept WFDDB undef %LHS8:fp64bit, undef %RHS8:fp64bit, implicit $fpc
+    %M9:vr64bit = nofpexcept WFDDB undef %LHS9:fp64bit, undef %RHS9:fp64bit, implicit $fpc
+    %M10:vr64bit = nofpexcept WFDDB undef %LHS10:fp64bit, undef %RHS10:fp64bit, implicit $fpc
+    %M11:vr64bit = nofpexcept WFDDB undef %LHS11:fp64bit, undef %RHS11:fp64bit, implicit $fpc
+
+    %38:vr64bit = VL64 %1, 0, $noreg :: (load (s64) from %ir.Arg)
+    %39:addr64bit = LG %1, 0, $noreg :: (load (s64) from `ptr null`)
+    %40:addr64bit = LG %0, 0, $noreg :: (load (s64) from %ir.Arg)
+    %41:gr64bit = COPY undef %42:gr64bit
+    %42:gr64bit = COPY undef %42:gr64bit
+    %43:gr64bit = COPY undef %42:gr64bit
+    %44:gr64bit = COPY undef %42:gr64bit
+    %45:gr64bit = COPY undef %42:gr64bit
+    %46:gr64bit = COPY undef %42:gr64bit
+    CallBASR implicit-def dead $r14d, implicit-def dead $cc, implicit $fpc
+    STG %39, $noreg, 0, $noreg
+    VST64 %38, $noreg, 0, $noreg
+    STG %40, $noreg, 0, $noreg
+    Return
+...

--- a/llvm/test/CodeGen/SystemZ/misched-prera-loads.mir
+++ b/llvm/test/CodeGen/SystemZ/misched-prera-loads.mir
@@ -1,6 +1,6 @@
-# RUN: llc -o - %s -mtriple=s390x-linux-gnu -mcpu=z16 -verify-machineinstrs \
+# RUN: llc -o - %s -mtriple=s390x-linux-gnu -mcpu=z17 -verify-machineinstrs \
 # RUN:   -run-pass=machine-scheduler -debug-only=machine-scheduler \
-# RUN:   -top-region=12 -disable-latency 2>&1 | FileCheck %s
+# RUN:   2>&1 | FileCheck %s
 
 --- |
 
@@ -9,257 +9,570 @@
   define void @fun2() { ret void }
   define void @fun3() { ret void }
   define void @fun4() { ret void }
-  define void @fun5(ptr %Arg) { ret void }
+  define void @fun5() { ret void }
+  define void @fun6(ptr %Arg) { ret void }
 ...
 
-# Don't schedule the LG low as it in this case is among the highest SUs.
+# The LHIMux could be scheduled below the CGHI to avoid the overlap of %0 and
+# %3, but this is not done in small regions like this.
 # CHECK:      ********** MI Scheduling **********
 # CHECK-NEXT: fun0:%bb.0
-# CHECK:        SU(1):   %1:addr64bit = LG $noreg, 0, $noreg
-# CHECK:        Height             : 4
-# CHECK:        SU(2):
-# CHECK:        SU(7):   dead %7:gr64bit = AG %6:gr64bit(tied-def 0),
-# CHECK:        Height             : 4
-# CHECK:        SU(8):
+# CHECK-NOT:  Pick Bot REG-EXCESS [pre-RA]
 # CHECK:      *** Final schedule for %bb.0 ***
-# CHECK-NEXT: SU(0):   %0:addr64bit = COPY $r2d
-# CHECK-NEXT: SU(1):   %1:addr64bit = LG $noreg, 0, $noreg
-# CHECK-NEXT: SU(2):   %2:gr64bit = COPY %0:addr64bit
-# CHECK-NEXT: SU(3):   %3:gr64bit = LGHI 1
-# CHECK-NEXT: SU(4):   %4:gr64bit = COPY %3:gr64bit
-# CHECK-NEXT: SU(5):   %5:gr64bit = COPY %4:gr64bit
-# CHECK-NEXT: SU(6):   %6:gr64bit = AGRK %2:gr64bit, %5:gr64bit, implicit-def $cc
-# CHECK-NEXT: SU(7):   dead %7:gr64bit = AG %6:gr64bit(tied-def 0),
-# CHECK-NEXT: SU(8):   dead %8:addr64bit = LGHI 0
-# CHECK-NEXT: SU(9):   STG %1:addr64bit, $noreg, 0, $noreg
-# CHECK-NEXT: SU(10):  $r2d = LGHI 0
+# CHECK-NEXT: SU(0):   %0:gr64bit = COPY $r2d
+# CHECK-NEXT: SU(2):   %2:gr64bit = LCGR %0:gr64bit, implicit-def dead $cc
+# CHECK-NEXT: SU(3):   %3:gr64bit = RISBGN undef %3:gr64bit(tied-def 0), %2:gr64bit, 29, 188, 0
+# CHECK-NEXT: SU(1):   %1:gr32bit = LHIMux 1
+# CHECK-NEXT: SU(4):   CGHI %3:gr64bit, 0, implicit-def $cc
+# CHECK: fun0:%bb.1
 ---
 name:            fun0
 tracksRegLiveness: true
 body:             |
   bb.0:
+    successors: %bb.2(0x30000000), %bb.1(0x50000000)
     liveins: $r2d
 
-    %0:addr64bit = COPY $r2d
-    %1:addr64bit = LG $noreg, 0, $noreg
-    %2:gr64bit = COPY %0
-    %3:gr64bit = LGHI 1
-    %4:gr64bit = COPY %3
-    %5:gr64bit = COPY %4
-    %6:gr64bit = AGRK %2, %5, implicit-def $cc
-    dead %7:gr64bit = AG %6, $noreg, 0, $noreg, implicit-def dead $cc
-    dead %8:addr64bit = LGHI 0
-    STG %1, $noreg, 0, $noreg
+    %0:gr64bit = COPY $r2d
+    %1:gr32bit = LHIMux 1
+    %2:gr64bit = LCGR %0, implicit-def dead $cc
+    %3:gr64bit = RISBGN undef %3, %2, 29, 188, 0
+    CGHI %3, 0, implicit-def $cc
+    BRC 14, 8, %bb.2, implicit killed $cc
+    J %bb.1
+
+  bb.1:
+    %5:gr64bit = LLGFR %1
+    $r2d = COPY %5
+    Return implicit $r2d
+
+  bb.2:
     $r2d = LGHI 0
-    Return
-...
-
-# Schedule the LG low. The heuristic to move a load down to its user to
-# shorten the live range makes sure to not increase the scheduled latency, so
-# therefore it ends up above the AG.
-# CHECK:      ********** MI Scheduling **********
-# CHECK-NEXT: fun1:%bb.0
-# CHECK:        SU(13):   %26:addr64bit = LG $noreg, 0, $noreg
-# CHECK:        Height             : 4
-# CHECK:        SU(14):
-# CHECK:        SU(19):   dead %32:gr64bit = AG %31:gr64bit(tied-def 0),
-# CHECK:        Height             : 4
-# CHECK:        SU(20):
-# CHECK:      *** Final schedule for %bb.0 ***
-# CHECK:      SU(13):   %26:addr64bit = LG $noreg, 0, $noreg
-# CHECK-NEXT: SU(19):   dead %32:gr64bit = AG %31:gr64bit(tied-def 0),
-# CHECK-NEXT: SU(20):   dead %33:addr64bit = LGHI 0
-# CHECK-NEXT: SU(21):   STG %26:addr64bit, $noreg, 0, $noreg
-# CHECK-NEXT: SU(22):  $r2d = LGHI 0
----
-name:            fun1
-tracksRegLiveness: true
-body:             |
-  bb.0:
-    liveins: $r2d
-
-    %0:addr64bit = COPY $r2d
-
-    ; Make for a top of region in terms of height, enabling heuristic for lower SUs.
-    %M0:vr64bit = nofpexcept WFMDB undef %LHS0:fp64bit, undef %RHS0:fp64bit, implicit $fpc
-    %M1:vr64bit = nofpexcept WFMDB %M0:vr64bit, undef %RHS1:fp64bit, implicit $fpc
-    %M2:vr64bit = nofpexcept WFMDB %M1:vr64bit, undef %RHS2:fp64bit, implicit $fpc
-    %M3:vr64bit = nofpexcept WFMDB %M2:vr64bit, undef %RHS3:fp64bit, implicit $fpc
-    %M4:vr64bit = nofpexcept WFMDB %M3:vr64bit, undef %RHS4:fp64bit, implicit $fpc
-    %M5:vr64bit = nofpexcept WFMDB %M4:vr64bit, undef %RHS5:fp64bit, implicit $fpc
-    %M6:vr64bit = nofpexcept WFMDB %M5:vr64bit, undef %RHS6:fp64bit, implicit $fpc
-    %M7:vr64bit = nofpexcept WFMDB %M6:vr64bit, undef %RHS7:fp64bit, implicit $fpc
-    %M8:vr64bit = nofpexcept WFMDB %M7:vr64bit, undef %RHS8:fp64bit, implicit $fpc
-    %M9:vr64bit = nofpexcept WFMDB %M8:vr64bit, undef %RHS9:fp64bit, implicit $fpc
-    %M10:vr64bit = nofpexcept WFMDB %M9:vr64bit, undef %RHS10:fp64bit, implicit $fpc
-    %M11:vr64bit = nofpexcept WFMDB %M10:vr64bit, undef %RHS11:fp64bit, implicit $fpc
-
-    %26:addr64bit = LG $noreg, 0, $noreg
-    %27:gr64bit = COPY %0
-    %28:gr64bit = LGHI 1
-    %29:gr64bit = COPY %28 ; Make region non-tiny.
-    %30:gr64bit = COPY %29 ;
-    %31:gr64bit = AGRK %27, %30, implicit-def $cc
-    dead %32:gr64bit = AG %31, $noreg, 0, $noreg, implicit-def dead $cc
-    dead %33:addr64bit = LGHI 0
-    STG %26, $noreg, 0, $noreg
-    $r2d = LGHI 0
-    Return
-...
-
-# Schedule the '%37 = WFMDB' as soon as its use operand is already live.
-# CHECK:      ********** MI Scheduling **********
-# CHECK-NEXT: fun2:%bb.0
-# CHECK:      *** Final schedule for %bb.0 ***
-# CHECK:      SU(13):   %26:vr64bit = nofpexcept WFMDB %25:fp64bit, %25:fp64bit, impl
-# CHECK-NEXT: SU(17):   %30:vr64bit = nofpexcept WFMDB %25:fp64bit, %29:vr64bit, impl
-# CHECK-NEXT: SU(18):   %31:vr64bit = nofpexcept WFMDB %30:vr64bit, %30:vr64bit, impl
-# CHECK-NEXT: SU(19):   dead %32:vr64bit = nofpexcept WFMDB %31:vr64bit, %26:vr64bit
----
-name:            fun2
-tracksRegLiveness: true
-body:             |
-  bb.0:
-
-    ; Make for a top of region in terms of height, enabling heuristic for lower SUs.
-    %M0:vr64bit = nofpexcept WFDDB undef %LHS0:fp64bit, undef %RHS0:fp64bit, implicit $fpc
-    %M1:vr64bit = nofpexcept WFDDB %M0:vr64bit, undef %RHS1:fp64bit, implicit $fpc
-    %M2:vr64bit = nofpexcept WFDDB %M1:vr64bit, undef %RHS2:fp64bit, implicit $fpc
-    %M3:vr64bit = nofpexcept WFDDB %M2:vr64bit, undef %RHS3:fp64bit, implicit $fpc
-    %M4:vr64bit = nofpexcept WFDDB %M3:vr64bit, undef %RHS4:fp64bit, implicit $fpc
-    %M5:vr64bit = nofpexcept WFDDB %M4:vr64bit, undef %RHS5:fp64bit, implicit $fpc
-    %M6:vr64bit = nofpexcept WFDDB %M5:vr64bit, undef %RHS6:fp64bit, implicit $fpc
-    %M7:vr64bit = nofpexcept WFDDB %M6:vr64bit, undef %RHS7:fp64bit, implicit $fpc
-    %M8:vr64bit = nofpexcept WFDDB %M7:vr64bit, undef %RHS8:fp64bit, implicit $fpc
-    %M9:vr64bit = nofpexcept WFDDB %M8:vr64bit, undef %RHS9:fp64bit, implicit $fpc
-    %M10:vr64bit = nofpexcept WFDDB %M9:vr64bit, undef %RHS10:fp64bit, implicit $fpc
-    %M11:vr64bit = nofpexcept WFDDB %M10:vr64bit, undef %RHS11:fp64bit, implicit $fpc
-
-    %25:fp64bit = LZDR
-    %26:vr64bit = nofpexcept WFMDB %25, %25, implicit $fpc
-    %27:vr64bit = nofpexcept WFMDB %25, %25, implicit $fpc
-    %28:vr64bit = nofpexcept WFMDB %25, %27, implicit $fpc
-    %29:vr64bit = nofpexcept WFMDB %25, %28, implicit $fpc
-    %30:vr64bit = nofpexcept WFMDB %25, %29, implicit $fpc
-    %31:vr64bit = nofpexcept WFMDB %30, %30, implicit $fpc
-    %32:vr64bit = nofpexcept WFMDB %31, %26, implicit $fpc
-    VST64 %30, $noreg, 0, $noreg :: (store (s64) into `ptr null`)
-    $f0d = COPY %30
-    Return implicit $f0d
-...
-
-# Same, with GPR registers.
-# CHECK:      ********** MI Scheduling **********
-# CHECK-NEXT: fun3:%bb.0
-# CHECK:      *** Final schedule for %bb.0 ***
-# CHECK:      SU(13):   %37:gr64bit = AGRK %36:gr64bit, %36:gr64bit, implicit-def dead $cc
-# CHECK-NEXT: SU(17):   %41:gr64bit = AGRK %36:gr64bit, %40:gr64bit, implicit-def dead $cc
-# CHECK-NEXT: SU(18):   %42:gr64bit = AGRK %41:gr64bit, %41:gr64bit, implicit-def dead $cc
-# CHECK-NEXT: SU(19):   dead %43:gr64bit = AGRK %42:gr64bit, %37:gr64bit, implicit-def dead $cc
-# CHECK-NEXT: SU(20):   STG %41:gr64bit, $noreg, 0, $noreg :: (store (s64) into `ptr null`)
-# CHECK-NEXT: SU(21):   $r2d = COPY %41:gr64bit
----
-name:            fun3
-tracksRegLiveness: true
-body:             |
-  bb.0:
-    ; Make for a top of region in terms of height, enabling heuristic for lower SUs.
-    %M0:vr64bit = nofpexcept WFDDB undef %LHS0:fp64bit, undef %RHS0:fp64bit, implicit $fpc
-    %M1:vr64bit = nofpexcept WFDDB undef %LHS1:fp64bit, undef %RHS1:fp64bit, implicit $fpc
-    %M2:vr64bit = nofpexcept WFDDB undef %LHS2:fp64bit, undef %RHS2:fp64bit, implicit $fpc
-    %M3:vr64bit = nofpexcept WFDDB undef %LHS3:fp64bit, undef %RHS3:fp64bit, implicit $fpc
-    %M4:vr64bit = nofpexcept WFDDB undef %LHS4:fp64bit, undef %RHS4:fp64bit, implicit $fpc
-    %M5:vr64bit = nofpexcept WFDDB undef %LHS5:fp64bit, undef %RHS5:fp64bit, implicit $fpc
-    %M6:vr64bit = nofpexcept WFDDB undef %LHS6:fp64bit, undef %RHS6:fp64bit, implicit $fpc
-    %M7:vr64bit = nofpexcept WFDDB undef %LHS7:fp64bit, undef %RHS7:fp64bit, implicit $fpc
-    %M8:vr64bit = nofpexcept WFDDB undef %LHS8:fp64bit, undef %RHS8:fp64bit, implicit $fpc
-    %M9:vr64bit = nofpexcept WFDDB undef %LHS9:fp64bit, undef %RHS9:fp64bit, implicit $fpc
-    %M10:vr64bit = nofpexcept WFDDB undef %LHS10:fp64bit, undef %RHS10:fp64bit, implicit $fpc
-    %M11:vr64bit = nofpexcept WFDDB undef %LHS11:fp64bit, undef %RHS11:fp64bit, implicit $fpc
-
-    %36:gr64bit = LGHI 1
-    %37:gr64bit = AGRK %36, %36, implicit-def dead $cc
-    %38:gr64bit = AGRK %36, %36, implicit-def dead $cc
-    %39:gr64bit = AGRK %36, %38, implicit-def dead $cc
-    %40:gr64bit = AGRK %36, %39, implicit-def dead $cc
-    %41:gr64bit = AGRK %36, %40, implicit-def dead $cc
-    %42:gr64bit = AGRK %41, %41, implicit-def dead $cc
-    %43:gr64bit = AGRK %42, %37, implicit-def dead $cc
-    STG %41, $noreg, 0, $noreg :: (store (s64) into `ptr null`)
-    $r2d = COPY %41
     Return implicit $r2d
 ...
 
-# *Don't* schedule the AGR low since %1 continues to be live above it.
+# This test tries to capture that one of the higher SUs is not scheduled low
+# for the sake of closing a live range. The %4 DLGR is such a node where the
+# result is live out and all operands are already live. It is still later
+# scheduled relative low (although not as low as possible), but for the
+# reason of latency reduction, below SU(33) which is higher.
+# CHECK:      ********** MI Scheduling **********
+# CHECK-NEXT: fun1:%bb.0
+# CHECK:      SU(5):   %4:gr128bit = DLGR %3:gr128bit(tied-def 0), %1:gr64bit
+# CHECK:      Height             : 29
+# CHECK:      Pressure Diff      : GRX32Bit -4
+# CHECK:      SU(6):
+# CHECK:      SU(33):   %32:gr64bit = AGFI %31:gr64bit(tied-def 0), 1, implicit-def $cc
+# CHECK:      Height             : 35
+# CHECK:      SU(34):
+#
+# CHECK:      Move SU(5) into Available Q
+# CHECK:      Queue BotQ.A: 39 5
+# CHECK-NOT:  Cand SU(5) REG-EXCESS
+# CHECK-NOT:  Scheduling SU(5)
+# CHECK:      Scheduling SU(39)
+#
+# CHECK:      Queue BotQ.A: 33 5
+# CHECK:      Pick Bot BOT-HEIGHT [pre-RA]
+# CHECK-NEXT: Scheduling SU(5)
+#
+# CHECK:      *** Final schedule for %bb.0 ***
+# CHECK:      SU(5):    %4:gr128bit = DLGR %3:gr128bit(tied-def 0), %1:gr64bit
+# CHECK-NEXT: SU(34):   %33:gr64bit = AGFI %32:gr64bit(tied-def 0), 1, implicit-def $cc
+# CHECK-NEXT: SU(35):   %34:gr64bit = AGFI %33:gr64bit(tied-def 0), 1, implicit-def $cc
+# CHECK-NEXT: SU(36):   %35:gr64bit = AGFI %34:gr64bit(tied-def 0), 1, implicit-def $cc
+# CHECK-NEXT: SU(37):   undef %36.subreg_h64:gr128bit = LLILL 0
+# CHECK-NEXT: SU(38):   %36.subreg_l64:gr128bit = COPY %35:gr64bit
+# CHECK-NEXT: SU(39):   %37:gr128bit = COPY %36:gr128bit
+# CHECK-NEXT: SU(40):   dead %38:gr128bit = DLGR %37:gr128bit(tied-def 0), %1:gr64bit
+# CHECK: fun1:%bb.1
+---
+name:            fun1
+tracksRegLiveness: true
+machineFunctionInfo: {}
+body:             |
+  bb.0:
+    liveins: $r2d, $r3d
+  %0:gr64bit = COPY $r2d
+  %1:gr64bit = COPY $r3d
+
+  undef %2.subreg_h64:gr128bit = LLILL 0
+  %2.subreg_l64:gr128bit = COPY %0
+  %3:gr128bit = COPY %2
+  %4:gr128bit = DLGR %3, %1
+
+  %5:gr64bit = AGFI %0, 1, implicit-def $cc
+  %6:gr64bit = AGFI %5, 1, implicit-def $cc
+  %7:gr64bit = AGFI %6, 1, implicit-def $cc
+  %8:gr64bit = AGFI %7, 1, implicit-def $cc
+  %9:gr64bit = AGFI %8, 1, implicit-def $cc
+  %10:gr64bit = AGFI %9, 1, implicit-def $cc
+  %11:gr64bit = AGFI %10, 1, implicit-def $cc
+  %12:gr64bit = AGFI %11, 1, implicit-def $cc
+  %13:gr64bit = AGFI %12, 1, implicit-def $cc
+  %14:gr64bit = AGFI %13, 1, implicit-def $cc
+  %15:gr64bit = AGFI %14, 1, implicit-def $cc
+  %16:gr64bit = AGFI %15, 1, implicit-def $cc
+  %17:gr64bit = AGFI %16, 1, implicit-def $cc
+  %18:gr64bit = AGFI %17, 1, implicit-def $cc
+  %19:gr64bit = AGFI %18, 1, implicit-def $cc
+  %20:gr64bit = AGFI %19, 1, implicit-def $cc
+  %21:gr64bit = AGFI %20, 1, implicit-def $cc
+  %22:gr64bit = AGFI %21, 1, implicit-def $cc
+  %23:gr64bit = AGFI %22, 1, implicit-def $cc
+  %24:gr64bit = AGFI %23, 1, implicit-def $cc
+  %25:gr64bit = AGFI %24, 1, implicit-def $cc
+  %26:gr64bit = AGFI %25, 1, implicit-def $cc
+  %27:gr64bit = AGFI %26, 1, implicit-def $cc
+  %28:gr64bit = AGFI %27, 1, implicit-def $cc
+  %29:gr64bit = AGFI %28, 1, implicit-def $cc
+  %30:gr64bit = AGFI %29, 1, implicit-def $cc
+  %31:gr64bit = AGFI %30, 1, implicit-def $cc
+  %32:gr64bit = AGFI %31, 1, implicit-def $cc
+  %33:gr64bit = AGFI %32, 1, implicit-def $cc
+  %34:gr64bit = AGFI %33, 1, implicit-def $cc
+  %35:gr64bit = AGFI %34, 1, implicit-def $cc
+
+  undef %36.subreg_h64:gr128bit = LLILL 0
+  %36.subreg_l64:gr128bit = COPY %35
+  %37:gr128bit = COPY %36
+  %38:gr128bit = DLGR %37, %1
+
+  bb.1:
+  STG %35:gr64bit, undef %101:addr64bit, 0, undef %102:addr64bit
+
+  STG %1:gr64bit, undef %101:addr64bit, 0, undef %102:addr64bit
+  %100:gr64bit = COPY %3.subreg_h64:gr128bit
+  STG %100:gr64bit, undef %101:addr64bit, 0, undef %102:addr64bit
+  %103:gr64bit = COPY %4.subreg_h64:gr128bit
+  STG %103:gr64bit, undef %101:addr64bit, 0, undef %102:addr64bit
+  Return
+...
+
+# In this test, instead of a DLGR an MSGRKC with shorter latency is high in
+# the input order with result and uses live. This node should be scheduled
+# low to close the live range, but should also wait until it does not extend
+# the scheduled latency.
+# CHECK:      ********** MI Scheduling **********
+# CHECK-NEXT: fun2:%bb.0
+# CHECK:      SU(2):   %2:gr64bit = MSGRKC %0:gr64bit, %1:gr64bit, implicit-def dead $cc
+# CHECK:      Height             : 3
+# CHECK:      Pressure Diff      : GRX32Bit -2
+# CHECK:      SU(3):
+# CHECK:      SU(33):   %33:gr64bit = AGFI %32:gr64bit(tied-def 0), 1, implicit-def dead $cc
+# CHECK:      Height             : 3
+# CHECK:      SU(34):   %34:gr64bit = AGFI %33:gr64bit(tied-def 0), 1, implicit-def dead $cc
+# CHECK:      Height             : 2
+# CHECK:      SU(35):
+# CHECK:      SU(36):   %36:gr64bit = AGFI %35:gr64bit(tied-def 0), 1, implicit-def dead $cc
+# CHECK:      Height             : 0
+#
+# CHECK:      Queue BotQ.A: 36 2
+# CHECK-NOT:  Cand SU(2) REG-EXCESS
+# CHECK-NOT:  Scheduling SU(2)
+# CHECK:      Pick Bot BOT-HEIGHT [pre-RA]
+# CHECK-NEXT: Scheduling SU(36)
+# CHECK:      Queue BotQ.A: 2 32
+# CHECK:      Pick Bot REG-EXCESS [pre-RA]
+# CHECK-NEXT: Scheduling SU(2)
+#
+# CHECK:      *** Final schedule for %bb.0 ***
+# CHECK:      SU(32):   %32:gr64bit = AGFI %31:gr64bit(tied-def 0), 1, implicit-def dead $cc
+# CHECK-NEXT: SU(2):    %2:gr64bit = MSGRKC %0:gr64bit, %1:gr64bit, implicit-def dead $cc
+# CHECK-NEXT: SU(33):   %33:gr64bit = AGFI %32:gr64bit(tied-def 0), 1, implicit-def dead $cc
+# CHECK-NEXT: SU(34):   %34:gr64bit = AGFI %33:gr64bit(tied-def 0), 1, implicit-def dead $cc
+# CHECK-NEXT: SU(35):   %35:gr64bit = AGFI %34:gr64bit(tied-def 0), 1, implicit-def dead $cc
+# CHECK-NEXT: SU(36):   %36:gr64bit = AGFI %35:gr64bit(tied-def 0), 1, implicit-def dead $cc
+# CHECK: fun2:%bb.1
+---
+name:            fun2
+tracksRegLiveness: true
+machineFunctionInfo: {}
+body:             |
+  bb.0:
+    liveins: $r2d, $r3d
+  %0:gr64bit = COPY $r2d
+  %1:gr64bit = COPY $r3d
+
+  %2:gr64bit = MSGRKC %0, %1, implicit-def dead $cc
+
+  %5:gr64bit = AGFI %0, 1, implicit-def dead $cc
+  %6:gr64bit = AGFI %5, 1, implicit-def dead $cc
+  %7:gr64bit = AGFI %6, 1, implicit-def dead $cc
+  %8:gr64bit = AGFI %7, 1, implicit-def dead $cc
+  %9:gr64bit = AGFI %8, 1, implicit-def dead $cc
+  %10:gr64bit = AGFI %9, 1, implicit-def dead $cc
+  %11:gr64bit = AGFI %10, 1, implicit-def dead $cc
+  %12:gr64bit = AGFI %11, 1, implicit-def dead $cc
+  %13:gr64bit = AGFI %12, 1, implicit-def dead $cc
+  %14:gr64bit = AGFI %13, 1, implicit-def dead $cc
+  %15:gr64bit = AGFI %14, 1, implicit-def dead $cc
+  %16:gr64bit = AGFI %15, 1, implicit-def dead $cc
+  %17:gr64bit = AGFI %16, 1, implicit-def dead $cc
+  %18:gr64bit = AGFI %17, 1, implicit-def dead $cc
+  %19:gr64bit = AGFI %18, 1, implicit-def dead $cc
+  %20:gr64bit = AGFI %19, 1, implicit-def dead $cc
+  %21:gr64bit = AGFI %20, 1, implicit-def dead $cc
+  %22:gr64bit = AGFI %21, 1, implicit-def dead $cc
+  %23:gr64bit = AGFI %22, 1, implicit-def dead $cc
+  %24:gr64bit = AGFI %23, 1, implicit-def dead $cc
+  %25:gr64bit = AGFI %24, 1, implicit-def dead $cc
+  %26:gr64bit = AGFI %25, 1, implicit-def dead $cc
+  %27:gr64bit = AGFI %26, 1, implicit-def dead $cc
+  %28:gr64bit = AGFI %27, 1, implicit-def dead $cc
+  %29:gr64bit = AGFI %28, 1, implicit-def dead $cc
+  %30:gr64bit = AGFI %29, 1, implicit-def dead $cc
+  %31:gr64bit = AGFI %30, 1, implicit-def dead $cc
+  %32:gr64bit = AGFI %31, 1, implicit-def dead $cc
+  %33:gr64bit = AGFI %32, 1, implicit-def dead $cc
+  %34:gr64bit = AGFI %33, 1, implicit-def dead $cc
+  %35:gr64bit = AGFI %34, 1, implicit-def dead $cc
+  %36:gr64bit = AGFI %35, 1, implicit-def dead $cc
+  %37:gr64bit = AGFI %36, 1, implicit-def dead $cc
+  %38:gr64bit = AGFI %37, 1, implicit-def dead $cc
+
+  bb.1:
+  STG %0:gr64bit, undef %101:addr64bit, 0, undef %102:addr64bit
+  STG %1:gr64bit, undef %101:addr64bit, 0, undef %102:addr64bit
+  STG %2:gr64bit, undef %101:addr64bit, 0, undef %102:addr64bit
+  STG %38:gr64bit, undef %101:addr64bit, 0, undef %102:addr64bit
+  Return
+...
+
+# Check a case (AGR) where a use is tied to the def which means the register
+# is live into the instruction and there is no point in scheduling it low
+# (pressure diff is empty). It still ends up low in the final schedule due to
+# the latency reduction heuristic.
+# CHECK:      ********** MI Scheduling **********
+# CHECK-NEXT: fun3:%bb.0
+#
+# CHECK:      SU(3):   %2:gr64bit = AGR %2:gr64bit(tied-def 0), %1:gr64bit, implicit-def dead $cc
+# CHECK:      Height             : 0
+# CHECK:      Pressure Diff      : {{$}}
+# CHECK:      SU(36):   %35:gr64bit = AGFI %34:gr64bit(tied-def 0), 1, implicit-def dead $cc
+# CHECK:      Height             : 1
+# CHECK:      Pressure Diff      : {{$}}
+# CHECK:      SU(37):   %36:gr64bit = AGFI %35:gr64bit(tied-def 0), 1, implicit-def dead $cc
+# CHECK:      Height             : 0
+# CHECK:      Pressure Diff      : {{$}}
+#
+# CHECK:      Queue BotQ.A: 37 3
+# CHECK:      Scheduling SU(37)
+# CHECK:      Queue BotQ.A: 3 36
+# CHECK:      Pick Bot BOT-HEIGHT [pre-RA]
+# CHECK-NEXT: Scheduling SU(3)
+#
+# CHECK:      *** Final schedule for %bb.0 ***
+# CHECK:      SU(36):  %35:gr64bit = AGFI %34:gr64bit(tied-def 0), 1, implicit-def dead $cc
+# CHECK-NEXT: SU(3):   %2:gr64bit = AGR %2:gr64bit(tied-def 0), %1:gr64bit, implicit-def dead $cc
+# CHECK-NEXT: SU(37):  %36:gr64bit = AGFI %35:gr64bit(tied-def 0), 1, implicit-def dead $cc
+# CHECK: fun3:%bb.1
+---
+name:            fun3
+tracksRegLiveness: true
+machineFunctionInfo: {}
+body:             |
+  bb.0:
+    liveins: $r2d, $r3d
+  %0:gr64bit = COPY $r2d
+  %1:gr64bit = COPY $r3d
+
+  %2:gr64bit = COPY %1
+  %2:gr64bit = AGR %2, %1, implicit-def dead $cc
+
+  %3:gr64bit = AGFI %0, 1, implicit-def dead $cc
+  %4:gr64bit = AGFI %3, 1, implicit-def dead $cc
+  %5:gr64bit = AGFI %4, 1, implicit-def dead $cc
+  %6:gr64bit = AGFI %5, 1, implicit-def dead $cc
+  %7:gr64bit = AGFI %6, 1, implicit-def dead $cc
+  %8:gr64bit = AGFI %7, 1, implicit-def dead $cc
+  %9:gr64bit = AGFI %8, 1, implicit-def dead $cc
+  %10:gr64bit = AGFI %9, 1, implicit-def dead $cc
+  %11:gr64bit = AGFI %10, 1, implicit-def dead $cc
+  %12:gr64bit = AGFI %11, 1, implicit-def dead $cc
+  %13:gr64bit = AGFI %12, 1, implicit-def dead $cc
+  %14:gr64bit = AGFI %13, 1, implicit-def dead $cc
+  %15:gr64bit = AGFI %14, 1, implicit-def dead $cc
+  %16:gr64bit = AGFI %15, 1, implicit-def dead $cc
+  %17:gr64bit = AGFI %16, 1, implicit-def dead $cc
+  %18:gr64bit = AGFI %17, 1, implicit-def dead $cc
+  %19:gr64bit = AGFI %18, 1, implicit-def dead $cc
+  %20:gr64bit = AGFI %19, 1, implicit-def dead $cc
+  %21:gr64bit = AGFI %20, 1, implicit-def dead $cc
+  %22:gr64bit = AGFI %21, 1, implicit-def dead $cc
+  %23:gr64bit = AGFI %22, 1, implicit-def dead $cc
+  %24:gr64bit = AGFI %23, 1, implicit-def dead $cc
+  %25:gr64bit = AGFI %24, 1, implicit-def dead $cc
+  %26:gr64bit = AGFI %25, 1, implicit-def dead $cc
+  %27:gr64bit = AGFI %26, 1, implicit-def dead $cc
+  %28:gr64bit = AGFI %27, 1, implicit-def dead $cc
+  %29:gr64bit = AGFI %28, 1, implicit-def dead $cc
+  %30:gr64bit = AGFI %29, 1, implicit-def dead $cc
+  %31:gr64bit = AGFI %30, 1, implicit-def dead $cc
+  %32:gr64bit = AGFI %31, 1, implicit-def dead $cc
+  %33:gr64bit = AGFI %32, 1, implicit-def dead $cc
+  %34:gr64bit = AGFI %33, 1, implicit-def dead $cc
+  %35:gr64bit = AGFI %34, 1, implicit-def dead $cc
+  %36:gr64bit = AGFI %35, 1, implicit-def dead $cc
+
+  bb.1:
+  STG %1:gr64bit, undef %101:addr64bit, 0, undef %102:addr64bit
+  STG %2:gr64bit, undef %101:addr64bit, 0, undef %102:addr64bit
+  STG %36:gr64bit, undef %101:addr64bit, 0, undef %102:addr64bit
+  Return
+...
+
+# Test that an instruction gets scheduled low as soon as its use operands
+# become live, and not before.
 # CHECK:      ********** MI Scheduling **********
 # CHECK-NEXT: fun4:%bb.0
+#
+# CHECK:      SU(30):   %M0:vr64bit = nofpexcept WFMDB %Z0:fp64bit, %Z0:fp64bit, implicit $fpc
+# CHECK:      Height             : 6
+# CHECK:      Pressure Diff      : FP16Bit 1
+# CHECK:      SU(31):   %M1:vr64bit = nofpexcept WFMDB %Z1:fp64bit, %Z1:fp64bit, implicit $fpc
+# CHECK:      Height             : 6
+# CHECK:      Pressure Diff      : FP16Bit 1
+# CHECK:      SU(32):   %M2:vr64bit = nofpexcept WFMDB %Z1:fp64bit, %Z1:fp64bit, implicit $fpc
+# CHECK:      Height             : 6
+# CHECK:      Pressure Diff      : FP16Bit 1
+# CHECK:      SU(33):   %M3:vr64bit = nofpexcept WFMDB %Z1:fp64bit, %Z1:fp64bit, implicit $fpc
+# CHECK:      Height             : 6
+# CHECK:      SU(36):   %M6:vr64bit = nofpexcept WFMDB %M5:vr64bit, %Z0:fp64bit, implicit $fpc
+# CHECK:      Height             : 6
+# CHECK:      SU(37):
+# CHECK:      SU(38):   %M9:vr64bit = nofpexcept WFMDB %M7:vr64bit, %M7:vr64bit, implicit $fpc
+# CHECK:      Height             : 6
+#
+# CHECK:      Queue BotQ.A: 27 38 36 34 33 32 31 30
+# CHECK:      Pick Bot ORDER      [pre-RA]
+# CHECK-NEXT: Scheduling SU(38)
+# CHECK:      Queue BotQ.A: 27 30 36 34 33 32 31 37
+# CHECK:      Pick Bot BOT-HEIGHT [pre-RA]
+# CHECK-NEXT: Scheduling SU(36)
+# CHECK:      Queue BotQ.A: 27 30 37 34 33 32 31 35
+# CHECK:      Pick Bot REG-EXCESS [pre-RA]
+# CHECK-NEXT: Scheduling SU(30)
+#
 # CHECK:      *** Final schedule for %bb.0 ***
-# CHECK:      SU(14):   %1:gr64bit = AGR %1:gr64bit(tied-def 0), %0:gr64bit, implicit-def $cc
-# CHECK-NEXT: SU(15):   dead %38:gr64bit = COPY undef %39:gr64bit
-# CHECK-NEXT: SU(16):   dead %40:gr64bit = COPY undef %39:gr64bit
-# CHECK-NEXT: SU(17):   dead %41:gr64bit = COPY undef %39:gr64bit
-# CHECK-NEXT: SU(18):   dead %42:gr64bit = COPY undef %39:gr64bit
-# CHECK-NEXT: SU(19):   dead %43:gr64bit = COPY undef %39:gr64bit
-# CHECK-NEXT: SU(20):   %44:gr64bit = COPY undef %39:gr64bit
-# CHECK-NEXT: SU(21):   STG %44:gr64bit, $noreg, 0, $noreg
-# CHECK-NEXT: SU(22):   STG %1:gr64bit, $noreg, 0, $noreg
+# CHECK:      SU(28):   %Z0:fp64bit = LZDR
+# CHECK-NEXT: SU(29):   %Z1:fp64bit = LZDR
+# CHECK-NEXT: SU(31):   %M1:vr64bit = nofpexcept WFMDB %Z1:fp64bit, %Z1:fp64bit, implicit $fpc
+# CHECK-NEXT: SU(32):   %M2:vr64bit = nofpexcept WFMDB %Z1:fp64bit, %Z1:fp64bit, implicit $fpc
+# CHECK-NEXT: SU(33):   %M3:vr64bit = nofpexcept WFMDB %Z1:fp64bit, %Z1:fp64bit, implicit $fpc
+# CHECK-NEXT: SU(34):   %M4:vr64bit = nofpexcept WFMDB %Z1:fp64bit, %Z1:fp64bit, implicit $fpc
+# CHECK-NEXT: SU(30):   %M0:vr64bit = nofpexcept WFMDB %Z0:fp64bit, %Z0:fp64bit, implicit $fpc
+# CHECK-NEXT: SU(36):   %M6:vr64bit = nofpexcept WFMDB %M5:vr64bit, %Z0:fp64bit, implicit $fpc
+# CHECK-NEXT: SU(38):   %M9:vr64bit = nofpexcept WFMDB %M7:vr64bit, %M7:vr64bit, implicit $fpc
+# CHECK-NEXT: SU(39):   VST64 %M0:vr64bit, $noreg, 0, $noreg :: (store (s64) into `ptr null`)
+# CHECK-NEXT: SU(40):   VST64 %M1:vr64bit, $noreg, 0, $noreg :: (store (s64) into `ptr null`)
+# CHECK-NEXT: SU(41):   VST64 %M2:vr64bit, $noreg, 0, $noreg :: (store (s64) into `ptr null`)
+# CHECK-NEXT: SU(42):   VST64 %M3:vr64bit, $noreg, 0, $noreg :: (store (s64) into `ptr null`)
+# CHECK-NEXT: SU(43):   VST64 %M4:vr64bit, $noreg, 0, $noreg :: (store (s64) into `ptr null`)
+# CHECK-NEXT: SU(44):   VST64 %M6:vr64bit, $noreg, 0, $noreg :: (store (s64) into `ptr null`)
+# CHECK-NEXT: SU(45):   VST64 %M9:vr64bit, $noreg, 0, $noreg :: (store (s64) into `ptr null`)
+# CHECK-NEXT: SU(46):   $f0d = LZDR
 ---
 name:            fun4
 tracksRegLiveness: true
 body:             |
   bb.0:
-    liveins: $r2d, $r3d
-
-    %0:gr64bit = COPY $r2d
-    %1:gr64bit = COPY $r3d
 
     ; Make for a top of region in terms of height, enabling heuristic for lower SUs.
-    %M0:vr64bit = nofpexcept WFDDB undef %LHS0:fp64bit, undef %RHS0:fp64bit, implicit $fpc
-    %M1:vr64bit = nofpexcept WFDDB undef %LHS1:fp64bit, undef %RHS1:fp64bit, implicit $fpc
-    %M2:vr64bit = nofpexcept WFDDB undef %LHS2:fp64bit, undef %RHS2:fp64bit, implicit $fpc
-    %M3:vr64bit = nofpexcept WFDDB undef %LHS3:fp64bit, undef %RHS3:fp64bit, implicit $fpc
-    %M4:vr64bit = nofpexcept WFDDB undef %LHS4:fp64bit, undef %RHS4:fp64bit, implicit $fpc
-    %M5:vr64bit = nofpexcept WFDDB undef %LHS5:fp64bit, undef %RHS5:fp64bit, implicit $fpc
-    %M6:vr64bit = nofpexcept WFDDB undef %LHS6:fp64bit, undef %RHS6:fp64bit, implicit $fpc
-    %M7:vr64bit = nofpexcept WFDDB undef %LHS7:fp64bit, undef %RHS7:fp64bit, implicit $fpc
-    %M8:vr64bit = nofpexcept WFDDB undef %LHS8:fp64bit, undef %RHS8:fp64bit, implicit $fpc
-    %M9:vr64bit = nofpexcept WFDDB undef %LHS9:fp64bit, undef %RHS9:fp64bit, implicit $fpc
-    %M10:vr64bit = nofpexcept WFDDB undef %LHS10:fp64bit, undef %RHS10:fp64bit, implicit $fpc
-    %M11:vr64bit = nofpexcept WFDDB undef %LHS11:fp64bit, undef %RHS11:fp64bit, implicit $fpc
+    %D0:vr64bit = nofpexcept WFDDB undef %LHS0:fp64bit, undef %RHS0:fp64bit, implicit $fpc
+    %D1:vr64bit = nofpexcept WFDDB %D0:vr64bit, undef %RHS1:fp64bit, implicit $fpc
+    %D2:vr64bit = nofpexcept WFDDB %D1:vr64bit, undef %RHS2:fp64bit, implicit $fpc
+    %D3:vr64bit = nofpexcept WFDDB %D2:vr64bit, undef %RHS3:fp64bit, implicit $fpc
+    %D4:vr64bit = nofpexcept WFDDB %D3:vr64bit, undef %RHS4:fp64bit, implicit $fpc
+    %D5:vr64bit = nofpexcept WFDDB %D4:vr64bit, undef %RHS5:fp64bit, implicit $fpc
+    %D6:vr64bit = nofpexcept WFDDB %D5:vr64bit, undef %RHS6:fp64bit, implicit $fpc
+    %D7:vr64bit = nofpexcept WFDDB %D6:vr64bit, undef %RHS7:fp64bit, implicit $fpc
+    %D8:vr64bit = nofpexcept WFDDB %D7:vr64bit, undef %RHS8:fp64bit, implicit $fpc
+    %D9:vr64bit = nofpexcept WFDDB %D8:vr64bit, undef %RHS9:fp64bit, implicit $fpc
+    %D10:vr64bit = nofpexcept WFDDB %D9:vr64bit, undef %RHS10:fp64bit, implicit $fpc
+    %D11:vr64bit = nofpexcept WFDDB %D10:vr64bit, undef %RHS11:fp64bit, implicit $fpc
+    %D12:vr64bit = nofpexcept WFDDB %D11:vr64bit, undef %RHS12:fp64bit, implicit $fpc
+    %D13:vr64bit = nofpexcept WFDDB %D12:vr64bit, undef %RHS13:fp64bit, implicit $fpc
+    %D14:vr64bit = nofpexcept WFDDB %D13:vr64bit, undef %RHS14:fp64bit, implicit $fpc
+    %D15:vr64bit = nofpexcept WFDDB %D14:vr64bit, undef %RHS15:fp64bit, implicit $fpc
+    %D16:vr64bit = nofpexcept WFDDB %D15:vr64bit, undef %RHS16:fp64bit, implicit $fpc
+    %D17:vr64bit = nofpexcept WFDDB %D16:vr64bit, undef %RHS17:fp64bit, implicit $fpc
+    %D18:vr64bit = nofpexcept WFDDB %D17:vr64bit, undef %RHS18:fp64bit, implicit $fpc
+    %D19:vr64bit = nofpexcept WFDDB %D18:vr64bit, undef %RHS19:fp64bit, implicit $fpc
+    %D20:vr64bit = nofpexcept WFDDB %D19:vr64bit, undef %RHS20:fp64bit, implicit $fpc
+    %D21:vr64bit = nofpexcept WFDDB %D20:vr64bit, undef %RHS21:fp64bit, implicit $fpc
+    %D22:vr64bit = nofpexcept WFDDB %D21:vr64bit, undef %RHS22:fp64bit, implicit $fpc
+    %D23:vr64bit = nofpexcept WFDDB %D22:vr64bit, undef %RHS23:fp64bit, implicit $fpc
+    %D24:vr64bit = nofpexcept WFDDB %D23:vr64bit, undef %RHS24:fp64bit, implicit $fpc
+    %D25:vr64bit = nofpexcept WFDDB %D24:vr64bit, undef %RHS25:fp64bit, implicit $fpc
+    %D26:vr64bit = nofpexcept WFDDB %D25:vr64bit, undef %RHS26:fp64bit, implicit $fpc
+    %D27:vr64bit = nofpexcept WFDDB %D26:vr64bit, undef %RHS27:fp64bit, implicit $fpc
 
-    %1:gr64bit = AGR %1, %0, implicit-def $cc
-    %38:gr64bit = COPY undef %39:gr64bit
-    %40:gr64bit = COPY undef %39:gr64bit
-    %41:gr64bit = COPY undef %39:gr64bit
-    %42:gr64bit = COPY undef %39:gr64bit
-    %43:gr64bit = COPY undef %39:gr64bit
-    %44:gr64bit = COPY undef %39:gr64bit
-    STG %44, $noreg, 0, $noreg
-    STG %1, $noreg, 0, $noreg
-    STG %0, $noreg, 0, $noreg
-    Return
+    %Z0:fp64bit = LZDR
+    %Z1:fp64bit = LZDR
+    %M0:vr64bit = nofpexcept WFMDB %Z0, %Z0, implicit $fpc
+    %M1:vr64bit = nofpexcept WFMDB %Z1, %Z1, implicit $fpc
+    %M2:vr64bit = nofpexcept WFMDB %Z1, %Z1, implicit $fpc
+    %M3:vr64bit = nofpexcept WFMDB %Z1, %Z1, implicit $fpc
+    %M4:vr64bit = nofpexcept WFMDB %Z1, %Z1, implicit $fpc
+
+    %M5:vr64bit = nofpexcept WFMDB undef %F0:vr64bit, undef %F0, implicit $fpc
+    %M6:vr64bit = nofpexcept WFMDB %M5, %Z0, implicit $fpc
+
+    %M7:vr64bit = nofpexcept WFMDB undef %F1:vr64bit, undef %F1, implicit $fpc
+    %M9:vr64bit = nofpexcept WFMDB %M7, %M7, implicit $fpc
+
+    VST64 %M0, $noreg, 0, $noreg :: (store (s64) into `ptr null`)
+    VST64 %M1, $noreg, 0, $noreg :: (store (s64) into `ptr null`)
+    VST64 %M2, $noreg, 0, $noreg :: (store (s64) into `ptr null`)
+    VST64 %M3, $noreg, 0, $noreg :: (store (s64) into `ptr null`)
+    VST64 %M4, $noreg, 0, $noreg :: (store (s64) into `ptr null`)
+    VST64 %M6, $noreg, 0, $noreg :: (store (s64) into `ptr null`)
+    VST64 %M9, $noreg, 0, $noreg :: (store (s64) into `ptr null`)
+
+    $f0d = LZDR
+    Return implicit $f0d
 ...
 
-# Schedule the VL64 low, above the first LG. It is loading a (live out) vr64,
-# which is prioritized, so even if %1 isn't live, that's ok as that is a GPR
-# register. This heuristic is guarded to not increment the scheduled latency,
-# which makes it wait until the first LG is scheduled.
+# Same, with GPR registers.
 # CHECK:      ********** MI Scheduling **********
 # CHECK-NEXT: fun5:%bb.0
-# CHECK:      Live Out: %40 %39 %38
 #
-# CHECK:      Queue BotQ.A: 2 3 4 5 6 7 8 15 14 13 12 11 10 9 0
-# CHECK:      Cand SU(14) REG-EXCESS
-# CHECK:      Scheduling SU(14) %38:vr64bit = VL64 %1:addr64bit, 0, $noreg ::
-# CHECK:      LiveReg: %1
+# CHECK:      SU(30):   %A0:gr64bit = AGRK %Z0:gr64bit, %Z0:gr64bit, implicit-def dead $cc
+# CHECK:      Height             : 1
+# CHECK:      SU(31):   %A1:gr64bit = AGRK %Z1:gr64bit, %Z1:gr64bit, implicit-def dead $cc
+# CHECK:      Height             : 1
+# CHECK:      SU(32):
+# CHECK:      SU(36):   %A6:gr64bit = AGRK %A5:gr64bit, %Z0:gr64bit, implicit-def dead $cc
+# CHECK:      Height             : 1
+# CHECK:      SU(37):
+# CHECK:      SU(38):   %A9:gr64bit = AGRK %A7:gr64bit, %A7:gr64bit, implicit-def dead $cc
+# CHECK:      Height             : 1
+# CHECK:      SU(39):
+#
+# CHECK:      Queue BotQ.A: 27 38 36 34 33 32 31 30
+# CHECK:      Pick Bot ORDER      [pre-RA]
+# CHECK-NEXT: Scheduling SU(38)
+# CHECK:      Queue BotQ.A: 27 30 36 34 33 32 31 37
+# CHECK:      Pick Bot BOT-HEIGHT [pre-RA]
+# CHECK-NEXT: Scheduling SU(36)
+# CHECK:      Queue BotQ.A: 27 30 37 34 33 32 31 35
+# CHECK:      Pick Bot REG-EXCESS [pre-RA]
+# CHECK-NEXT: Scheduling SU(30)
 #
 # CHECK:      *** Final schedule for %bb.0 ***
-# CHECK:      SU(14):   %38:vr64bit = VL64 %1:addr64bit, 0, $noreg :: (load (s64) from %ir.Arg)
-# CHECK-NEXT: SU(16):   %40:addr64bit = LG %0:addr64bit, 0, $noreg :: (load (s64) from %ir.Arg)
-# CHECK-NEXT: SU(17):   dead %41:gr64bit = COPY undef %42:gr64bit
-
+# CHECK:      SU(28):   %Z0:gr64bit = LGHI 1
+# CHECK-NEXT: SU(29):   %Z1:gr64bit = LGHI 1
+# CHECK-NEXT: SU(31):   %A1:gr64bit = AGRK %Z1:gr64bit, %Z1:gr64bit, implicit-def dead $cc
+# CHECK-NEXT: SU(32):   %A2:gr64bit = AGRK %Z1:gr64bit, %Z1:gr64bit, implicit-def dead $cc
+# CHECK-NEXT: SU(33):   %A3:gr64bit = AGRK %Z1:gr64bit, %Z1:gr64bit, implicit-def dead $cc
+# CHECK-NEXT: SU(35):   %A5:gr64bit = AGRK undef %F0:gr64bit, undef %F0:gr64bit, implicit-def dead $cc
+# CHECK-NEXT: SU(37):   %A7:gr64bit = AGRK undef %F1:gr64bit, undef %F1:gr64bit, implicit-def dead $cc
+# CHECK-NEXT: SU(34):   %A4:gr64bit = AGRK %Z1:gr64bit, %Z1:gr64bit, implicit-def dead $cc
+# CHECK-NEXT: SU(30):   %A0:gr64bit = AGRK %Z0:gr64bit, %Z0:gr64bit, implicit-def dead $cc
+# CHECK-NEXT: SU(36):   %A6:gr64bit = AGRK %A5:gr64bit, %Z0:gr64bit, implicit-def dead $cc
+# CHECK-NEXT: SU(38):   %A9:gr64bit = AGRK %A7:gr64bit, %A7:gr64bit, implicit-def dead $cc
+# CHECK-NEXT: SU(39):   STG %A0:gr64bit, $noreg, 0, $noreg :: (store (s64) into `ptr null`)
+# CHECK-NEXT: SU(40):   STG %A1:gr64bit, $noreg, 0, $noreg :: (store (s64) into `ptr null`)
+# CHECK-NEXT: SU(41):   STG %A2:gr64bit, $noreg, 0, $noreg :: (store (s64) into `ptr null`)
+# CHECK-NEXT: SU(42):   STG %A3:gr64bit, $noreg, 0, $noreg :: (store (s64) into `ptr null`)
+# CHECK-NEXT: SU(43):   STG %A4:gr64bit, $noreg, 0, $noreg :: (store (s64) into `ptr null`)
+# CHECK-NEXT: SU(44):   STG %A6:gr64bit, $noreg, 0, $noreg :: (store (s64) into `ptr null`)
+# CHECK-NEXT: SU(45):   STG %A9:gr64bit, $noreg, 0, $noreg :: (store (s64) into `ptr null`)
+# CHECK-NEXT: SU(46):   $r2d = LGHI 0
 ---
 name:            fun5
+tracksRegLiveness: true
+body:             |
+  bb.0:
+
+    ; Make for a top of region in terms of height, enabling heuristic for lower SUs.
+    %D0:vr64bit = nofpexcept WFDDB undef %LHS0:fp64bit, undef %RHS0:fp64bit, implicit $fpc
+    %D1:vr64bit = nofpexcept WFDDB %D0:vr64bit, undef %RHS1:fp64bit, implicit $fpc
+    %D2:vr64bit = nofpexcept WFDDB %D1:vr64bit, undef %RHS2:fp64bit, implicit $fpc
+    %D3:vr64bit = nofpexcept WFDDB %D2:vr64bit, undef %RHS3:fp64bit, implicit $fpc
+    %D4:vr64bit = nofpexcept WFDDB %D3:vr64bit, undef %RHS4:fp64bit, implicit $fpc
+    %D5:vr64bit = nofpexcept WFDDB %D4:vr64bit, undef %RHS5:fp64bit, implicit $fpc
+    %D6:vr64bit = nofpexcept WFDDB %D5:vr64bit, undef %RHS6:fp64bit, implicit $fpc
+    %D7:vr64bit = nofpexcept WFDDB %D6:vr64bit, undef %RHS7:fp64bit, implicit $fpc
+    %D8:vr64bit = nofpexcept WFDDB %D7:vr64bit, undef %RHS8:fp64bit, implicit $fpc
+    %D9:vr64bit = nofpexcept WFDDB %D8:vr64bit, undef %RHS9:fp64bit, implicit $fpc
+    %D10:vr64bit = nofpexcept WFDDB %D9:vr64bit, undef %RHS10:fp64bit, implicit $fpc
+    %D11:vr64bit = nofpexcept WFDDB %D10:vr64bit, undef %RHS11:fp64bit, implicit $fpc
+    %D12:vr64bit = nofpexcept WFDDB %D11:vr64bit, undef %RHS12:fp64bit, implicit $fpc
+    %D13:vr64bit = nofpexcept WFDDB %D12:vr64bit, undef %RHS13:fp64bit, implicit $fpc
+    %D14:vr64bit = nofpexcept WFDDB %D13:vr64bit, undef %RHS14:fp64bit, implicit $fpc
+    %D15:vr64bit = nofpexcept WFDDB %D14:vr64bit, undef %RHS15:fp64bit, implicit $fpc
+    %D16:vr64bit = nofpexcept WFDDB %D15:vr64bit, undef %RHS16:fp64bit, implicit $fpc
+    %D17:vr64bit = nofpexcept WFDDB %D16:vr64bit, undef %RHS17:fp64bit, implicit $fpc
+    %D18:vr64bit = nofpexcept WFDDB %D17:vr64bit, undef %RHS18:fp64bit, implicit $fpc
+    %D19:vr64bit = nofpexcept WFDDB %D18:vr64bit, undef %RHS19:fp64bit, implicit $fpc
+    %D20:vr64bit = nofpexcept WFDDB %D19:vr64bit, undef %RHS20:fp64bit, implicit $fpc
+    %D21:vr64bit = nofpexcept WFDDB %D20:vr64bit, undef %RHS21:fp64bit, implicit $fpc
+    %D22:vr64bit = nofpexcept WFDDB %D21:vr64bit, undef %RHS22:fp64bit, implicit $fpc
+    %D23:vr64bit = nofpexcept WFDDB %D22:vr64bit, undef %RHS23:fp64bit, implicit $fpc
+    %D24:vr64bit = nofpexcept WFDDB %D23:vr64bit, undef %RHS24:fp64bit, implicit $fpc
+    %D25:vr64bit = nofpexcept WFDDB %D24:vr64bit, undef %RHS25:fp64bit, implicit $fpc
+    %D26:vr64bit = nofpexcept WFDDB %D25:vr64bit, undef %RHS26:fp64bit, implicit $fpc
+    %D27:vr64bit = nofpexcept WFDDB %D26:vr64bit, undef %RHS27:fp64bit, implicit $fpc
+
+    %Z0:gr64bit = LGHI 1
+    %Z1:gr64bit = LGHI 1
+    %A0:gr64bit = AGRK %Z0, %Z0, implicit-def dead $cc
+    %A1:gr64bit = AGRK %Z1, %Z1, implicit-def dead $cc
+    %A2:gr64bit = AGRK %Z1, %Z1, implicit-def dead $cc
+    %A3:gr64bit = AGRK %Z1, %Z1, implicit-def dead $cc
+    %A4:gr64bit = AGRK %Z1, %Z1, implicit-def dead $cc
+
+    %A5:gr64bit = AGRK undef %F0:gr64bit, undef %F0, implicit-def dead $cc
+    %A6:gr64bit = AGRK %A5, %Z0, implicit-def dead $cc
+
+    %A7:gr64bit = AGRK undef %F1:gr64bit, undef %F1, implicit-def dead $cc
+    %A9:gr64bit = AGRK %A7, %A7, implicit-def dead $cc
+
+    STG %A0, $noreg, 0, $noreg :: (store (s64) into `ptr null`)
+    STG %A1, $noreg, 0, $noreg :: (store (s64) into `ptr null`)
+    STG %A2, $noreg, 0, $noreg :: (store (s64) into `ptr null`)
+    STG %A3, $noreg, 0, $noreg :: (store (s64) into `ptr null`)
+    STG %A4, $noreg, 0, $noreg :: (store (s64) into `ptr null`)
+    STG %A6, $noreg, 0, $noreg :: (store (s64) into `ptr null`)
+    STG %A9, $noreg, 0, $noreg :: (store (s64) into `ptr null`)
+
+    $r2d = LGHI 0
+    Return implicit $r2d
+...
+
+# Test the priorization of vector (/fp) registers over GPRs. The VL64 is
+# scheduled low to close the vr64 live range, even though the address
+# register %1 becomes live.
+# CHECK:      ********** MI Scheduling **********
+# CHECK-NEXT: fun6:%bb.0
+# CHECK:      ********** MI Scheduling **********
+# CHECK-NEXT: fun6:%bb.0
+#
+# CHECK:      SU(35):   %L0:vr64bit = VL64 %1:addr64bit, 0, $noreg :: (load (s64) from %ir.Arg)
+# CHECK:      Height             : 3
+# CHECK:      Pressure Diff      : VR16Bit -1    GRX32Bit 2
+# CHECK:      SU(36):   %L1:addr64bit = LG %1:addr64bit, 0, $noreg :: (load (s64) from `ptr null`)
+# CHECK:      Height             : 3
+# CHECK:      Pressure Diff      : {{$}}
+# CHECK:      SU(37):   %L2:addr64bit = LG %0:addr64bit, 0, $noreg :: (load (s64) from %ir.Arg)
+# CHECK:      Height             : 3
+# CHECK:      Pressure Diff      : {{$}}
+#
+# CHECK:      Queue BotQ.A: 37 36 35 34
+# CHECK:      Cand SU(37) FIRST
+# CHECK:      Scheduling SU(37)
+# CHECK:      Queue BotQ.A: 34 36 35 0
+# CHECK:      Cand SU(35) REG-EXCESS
+# CHECK:      Scheduling SU(35)
+#
+# CHECK:      *** Final schedule for %bb.0 ***
+# CHECK:      SU(36):   %L1:addr64bit = LG %1:addr64bit, 0, $noreg :: (load (s64) from `ptr null`)
+# CHECK-NEXT: SU(35):   %L0:vr64bit = VL64 %1:addr64bit, 0, $noreg :: (load (s64) from %ir.Arg)
+# CHECK-NEXT: SU(37):   %L2:addr64bit = LG %0:addr64bit, 0, $noreg :: (load (s64) from %ir.Arg)
+---
+name:            fun6
 tracksRegLiveness: true
 body:             |
   bb.0:
@@ -269,31 +582,46 @@ body:             |
     %1:addr64bit = COPY $r2d
 
     ; Make for a top of region in terms of height, enabling heuristic for lower SUs.
-    %M0:vr64bit = nofpexcept WFDDB undef %LHS0:fp64bit, undef %RHS0:fp64bit, implicit $fpc
-    %M1:vr64bit = nofpexcept WFDDB undef %LHS1:fp64bit, undef %RHS1:fp64bit, implicit $fpc
-    %M2:vr64bit = nofpexcept WFDDB undef %LHS2:fp64bit, undef %RHS2:fp64bit, implicit $fpc
-    %M3:vr64bit = nofpexcept WFDDB undef %LHS3:fp64bit, undef %RHS3:fp64bit, implicit $fpc
-    %M4:vr64bit = nofpexcept WFDDB undef %LHS4:fp64bit, undef %RHS4:fp64bit, implicit $fpc
-    %M5:vr64bit = nofpexcept WFDDB undef %LHS5:fp64bit, undef %RHS5:fp64bit, implicit $fpc
-    %M6:vr64bit = nofpexcept WFDDB undef %LHS6:fp64bit, undef %RHS6:fp64bit, implicit $fpc
-    %M7:vr64bit = nofpexcept WFDDB undef %LHS7:fp64bit, undef %RHS7:fp64bit, implicit $fpc
-    %M8:vr64bit = nofpexcept WFDDB undef %LHS8:fp64bit, undef %RHS8:fp64bit, implicit $fpc
-    %M9:vr64bit = nofpexcept WFDDB undef %LHS9:fp64bit, undef %RHS9:fp64bit, implicit $fpc
-    %M10:vr64bit = nofpexcept WFDDB undef %LHS10:fp64bit, undef %RHS10:fp64bit, implicit $fpc
-    %M11:vr64bit = nofpexcept WFDDB undef %LHS11:fp64bit, undef %RHS11:fp64bit, implicit $fpc
+    %D0:vr64bit = nofpexcept WFDDB undef %LHS0:fp64bit, undef %RHS0:fp64bit, implicit $fpc
+    %D1:vr64bit = nofpexcept WFDDB %D0:vr64bit, undef %RHS1:fp64bit, implicit $fpc
+    %D2:vr64bit = nofpexcept WFDDB %D1:vr64bit, undef %RHS2:fp64bit, implicit $fpc
+    %D3:vr64bit = nofpexcept WFDDB %D2:vr64bit, undef %RHS3:fp64bit, implicit $fpc
+    %D4:vr64bit = nofpexcept WFDDB %D3:vr64bit, undef %RHS4:fp64bit, implicit $fpc
+    %D5:vr64bit = nofpexcept WFDDB %D4:vr64bit, undef %RHS5:fp64bit, implicit $fpc
+    %D6:vr64bit = nofpexcept WFDDB %D5:vr64bit, undef %RHS6:fp64bit, implicit $fpc
+    %D7:vr64bit = nofpexcept WFDDB %D6:vr64bit, undef %RHS7:fp64bit, implicit $fpc
+    %D8:vr64bit = nofpexcept WFDDB %D7:vr64bit, undef %RHS8:fp64bit, implicit $fpc
+    %D9:vr64bit = nofpexcept WFDDB %D8:vr64bit, undef %RHS9:fp64bit, implicit $fpc
+    %D10:vr64bit = nofpexcept WFDDB %D9:vr64bit, undef %RHS10:fp64bit, implicit $fpc
+    %D11:vr64bit = nofpexcept WFDDB %D10:vr64bit, undef %RHS11:fp64bit, implicit $fpc
+    %D12:vr64bit = nofpexcept WFDDB %D11:vr64bit, undef %RHS12:fp64bit, implicit $fpc
+    %D13:vr64bit = nofpexcept WFDDB %D12:vr64bit, undef %RHS13:fp64bit, implicit $fpc
+    %D14:vr64bit = nofpexcept WFDDB %D13:vr64bit, undef %RHS14:fp64bit, implicit $fpc
+    %D15:vr64bit = nofpexcept WFDDB %D14:vr64bit, undef %RHS15:fp64bit, implicit $fpc
+    %D16:vr64bit = nofpexcept WFDDB %D15:vr64bit, undef %RHS16:fp64bit, implicit $fpc
+    %D17:vr64bit = nofpexcept WFDDB %D16:vr64bit, undef %RHS17:fp64bit, implicit $fpc
+    %D18:vr64bit = nofpexcept WFDDB %D17:vr64bit, undef %RHS18:fp64bit, implicit $fpc
+    %D19:vr64bit = nofpexcept WFDDB %D18:vr64bit, undef %RHS19:fp64bit, implicit $fpc
+    %D20:vr64bit = nofpexcept WFDDB %D19:vr64bit, undef %RHS20:fp64bit, implicit $fpc
+    %D21:vr64bit = nofpexcept WFDDB %D20:vr64bit, undef %RHS21:fp64bit, implicit $fpc
+    %D22:vr64bit = nofpexcept WFDDB %D21:vr64bit, undef %RHS22:fp64bit, implicit $fpc
+    %D23:vr64bit = nofpexcept WFDDB %D22:vr64bit, undef %RHS23:fp64bit, implicit $fpc
+    %D24:vr64bit = nofpexcept WFDDB %D23:vr64bit, undef %RHS24:fp64bit, implicit $fpc
+    %D25:vr64bit = nofpexcept WFDDB %D24:vr64bit, undef %RHS25:fp64bit, implicit $fpc
+    %D26:vr64bit = nofpexcept WFDDB %D25:vr64bit, undef %RHS26:fp64bit, implicit $fpc
+    %D27:vr64bit = nofpexcept WFDDB %D26:vr64bit, undef %RHS27:fp64bit, implicit $fpc
+    %D28:vr64bit = nofpexcept WFDDB %D27:vr64bit, undef %RHS28:fp64bit, implicit $fpc
+    %D29:vr64bit = nofpexcept WFDDB %D28:vr64bit, undef %RHS29:fp64bit, implicit $fpc
+    %D30:vr64bit = nofpexcept WFDDB %D29:vr64bit, undef %RHS3:fp64bit, implicit $fpc
+    %D31:vr64bit = nofpexcept WFDDB %D30:vr64bit, undef %RHS31:fp64bit, implicit $fpc
+    %D32:vr64bit = nofpexcept WFDDB %D31:vr64bit, undef %RHS32:fp64bit, implicit $fpc
 
-    %38:vr64bit = VL64 %1, 0, $noreg :: (load (s64) from %ir.Arg)
-    %39:addr64bit = LG %1, 0, $noreg :: (load (s64) from `ptr null`)
-    %40:addr64bit = LG %0, 0, $noreg :: (load (s64) from %ir.Arg)
-    %41:gr64bit = COPY undef %42:gr64bit
-    %42:gr64bit = COPY undef %42:gr64bit
-    %43:gr64bit = COPY undef %42:gr64bit
-    %44:gr64bit = COPY undef %42:gr64bit
-    %45:gr64bit = COPY undef %42:gr64bit
-    %46:gr64bit = COPY undef %42:gr64bit
+    %L0:vr64bit = VL64 %1, 0, $noreg :: (load (s64) from %ir.Arg)
+    %L1:addr64bit = LG %1, 0, $noreg :: (load (s64) from `ptr null`)
+    %L2:addr64bit = LG %0, 0, $noreg :: (load (s64) from %ir.Arg)
     CallBASR implicit-def dead $r14d, implicit-def dead $cc, implicit $fpc
-    STG %39, $noreg, 0, $noreg
-    VST64 %38, $noreg, 0, $noreg
-    STG %40, $noreg, 0, $noreg
+    STG %L1, $noreg, 0, $noreg
+    VST64 %L0, $noreg, 0, $noreg
+    STG %L2, $noreg, 0, $noreg
     Return
 ...

--- a/llvm/test/CodeGen/SystemZ/misched-prera-pdiffs.mir
+++ b/llvm/test/CodeGen/SystemZ/misched-prera-pdiffs.mir
@@ -1,0 +1,151 @@
+# RUN: llc -o - %s -mtriple=s390x-linux-gnu -mcpu=z16 -verify-machineinstrs \
+# RUN:   -run-pass=machine-scheduler -debug-only=machine-scheduler 2>&1\
+# RUN:   | FileCheck %s
+
+# Some tests for Pressure Diffs of scheduling units. Each interesting register
+# class is used in a def-use sequence and the initial Pressure Diff of each SU
+# is checked. For all GPRs the GRX32Bit PressureSet should be present, and for
+# all FP/Vector regs the VR16Bit PressureSet should be affected.
+
+--- |
+
+  define void @fun0() { ret void }
+...
+
+
+# GR64Bit => GRX32Bit 2
+#
+# CHECK:      ********** MI Scheduling **********
+# CHECK-NEXT: fun0:%bb.0
+# CHECK:      SU(0):   %0:gr64bit = LGHI 0
+# CHECK:        Pressure Diff      : GRX32Bit -2
+# CHECK:      SU(1):   STG %0:gr64bit, $noreg, 0, $noreg
+# CHECK:        Pressure Diff      : GRX32Bit 2
+# CHECK:      SU(2):   %1:grx32bit = LHIMux 0
+# CHECK:        Pressure Diff      : GRX32Bit -1
+# CHECK:      SU(3):   STMux %1:grx32bit, $noreg, 0, $noreg
+# CHECK:        Pressure Diff      : GRX32Bit 1
+# CHECK:      SU(4):   %2:gr32bit = LHI 0
+# CHECK:        Pressure Diff      : GR32Bit -1    GRX32Bit -1
+# CHECK:      SU(5):   ST %2:gr32bit, $noreg, 0, $noreg
+# CHECK:        Pressure Diff      : GR32Bit 1    GRX32Bit 1
+# CHECK:      SU(6):   %3:grh32bit = IIHF 0
+# CHECK:        Pressure Diff      : GRH32Bit -1    GRX32Bit -1
+# CHECK:      SU(7):   STFH %3:grh32bit, $noreg, 0, $noreg
+# CHECK:        Pressure Diff      : GRH32Bit 1    GRX32Bit 1
+# CHECK:      SU(8):   %4:addr64bit = LGHI 0
+# CHECK:        Pressure Diff      : GRX32Bit -2
+# CHECK:      SU(9):   STG %4:addr64bit, $noreg, 0, $noreg
+# CHECK:        Pressure Diff      : GRX32Bit 2
+# CHECK:      SU(10):   %5:addr32bit = LHI 0
+# CHECK:        Pressure Diff      : GR32Bit -1    GRX32Bit -1
+# CHECK:      SU(11):   ST %5:addr32bit, $noreg, 0, $noreg
+# CHECK:        Pressure Diff      : GR32Bit 1    GRX32Bit 1
+# CHECK:      SU(12):   %6:gr128bit = L128 $noreg, 0, $noreg
+# CHECK:        Pressure Diff      : GRX32Bit -4
+# CHECK:      SU(13):   ST128 %6:gr128bit, $noreg, 0, $noreg
+# CHECK:        Pressure Diff      : GRX32Bit 4
+# CHECK:      SU(14):   %7:addr128bit = L128 $noreg, 0, $noreg
+# CHECK:        Pressure Diff      : GRX32Bit -4
+# CHECK:      SU(15):   ST128 %7:addr128bit, $noreg, 0, $noreg
+# CHECK:        Pressure Diff      : GRX32Bit 4
+# CHECK:      SU(16):   %8:vr16bit = LEFR_16 undef %9:gr32bit
+# CHECK:        Pressure Diff      : VR16Bit -1
+# CHECK:      SU(17):   dead %9:gr32bit = LFER_16 %8:vr16bit
+# CHECK:        Pressure Diff      : VR16Bit 1
+# CHECK:      SU(18):   %10:vr32bit = LEFR undef %11:gr32bit
+# CHECK:        Pressure Diff      : VR16Bit -1
+# CHECK:      SU(19):   dead %12:gr64bit = LFER %10:vr32bit
+# CHECK:        Pressure Diff      : VR16Bit 1
+# CHECK:      SU(20):   %13:vr64bit = SelectVR64 undef %14:vr64bit, undef %15:vr64bit
+# CHECK:        Pressure Diff      : VR16Bit -1
+# CHECK:      SU(21):   VST64 %13:vr64bit, $noreg, 0, $noreg
+# CHECK:        Pressure Diff      : VR16Bit 1
+# CHECK:      SU(22):   %16:vr128bit = VZERO
+# CHECK:        Pressure Diff      : VR16Bit -1
+# CHECK:      SU(23):   VST %16:vr128bit, $noreg, 0, $noreg
+# CHECK:        Pressure Diff      : VR16Bit 1
+# CHECK:      SU(24):   %17:fp16bit = LZER_16
+# CHECK:        Pressure Diff      : FP16Bit -1    VR16Bit -1
+# CHECK:      SU(25):   STE16 %17:fp16bit, $noreg, 0, $noreg
+# CHECK:        Pressure Diff      : FP16Bit 1    VR16Bit 1
+# CHECK:      SU(26):   %18:fp32bit = LZER
+# CHECK:        Pressure Diff      : FP16Bit -1    VR16Bit -1
+# CHECK:      SU(27):   STE %18:fp32bit, $noreg, 0, $noreg
+# CHECK:        Pressure Diff      : FP16Bit 1    VR16Bit 1
+# CHECK:      SU(28):   %19:fp64bit = LZDR
+# CHECK:        Pressure Diff      : FP16Bit -1    VR16Bit -1
+# CHECK:      SU(29):   STD %19:fp64bit, $noreg, 0, $noreg
+# CHECK:        Pressure Diff      : FP16Bit 1    VR16Bit 1
+# CHECK:      SU(30):   %20:vf128bit = VL $noreg, 0, $noreg
+# CHECK:        Pressure Diff      : FP16Bit -1    VR16Bit -1
+# CHECK:      SU(31):   VST %20:vf128bit, $noreg, 0, $noreg
+# CHECK:        Pressure Diff      : FP16Bit 1    VR16Bit 1
+# CHECK:      SU(32):   %21:fp128bit = LZXR
+# CHECK:        Pressure Diff      : FP16Bit -2    VR16Bit -2
+# CHECK:      SU(33):   STX %21:fp128bit, $noreg, 0, $noreg
+# CHECK:        Pressure Diff      : FP16Bit 2    VR16Bit 2
+---
+name:            fun0
+tracksRegLiveness: true
+body:             |
+  bb.0:
+
+    %0:gr64bit = LGHI 0
+    STG %0, $noreg, 0, $noreg
+
+    %1:grx32bit = LHIMux 0
+    STMux %1, $noreg, 0, $noreg
+
+    %2:gr32bit = LHI 0
+    ST %2, $noreg, 0, $noreg
+
+    %3:grh32bit = IIHF 0
+    STFH %3, $noreg, 0, $noreg
+
+    %4:addr64bit = LGHI 0
+    STG %4, $noreg, 0, $noreg
+
+    %5:addr32bit = LHI 0
+    ST %5, $noreg, 0, $noreg
+
+    %6:gr128bit = L128 $noreg, 0, $noreg
+    ST128 %6, $noreg, 0, $noreg
+
+    %7:addr128bit = L128 $noreg, 0, $noreg
+    ST128 %7, $noreg, 0, $noreg
+
+    %8:vr16bit = LEFR_16 undef %9:gr32bit
+    %9:gr32bit = LFER_16 %8
+
+    %11:vr32bit = LEFR undef %10:gr32bit
+    %12:gr64bit = LFER %11
+
+    %13:vr64bit = SelectVR64 undef %14:vr64bit, undef %15:vr64bit, 0, 0, implicit undef $cc
+    VST64 %13, $noreg, 0, $noreg
+
+    %16:vr128bit = VZERO
+    VST %16, $noreg, 0, $noreg
+
+    %17:fp16bit = LZER_16
+    STE16 %17, $noreg, 0, $noreg
+
+    %18:fp32bit = LZER
+    STE %18, $noreg, 0, $noreg
+
+    %19:fp64bit = LZDR
+    STD %19, $noreg, 0, $noreg
+
+    %20:vf128bit = VL $noreg, 0, $noreg
+    VST %20, $noreg, 0, $noreg
+
+    %21:fp128bit = LZXR
+    STX %21, $noreg, 0, $noreg
+
+    NOP $noreg, 0, $noreg ; enable reg pressure tracking (>36 instrs).
+    NOP $noreg, 0, $noreg
+    NOP $noreg, 0, $noreg
+    NOP $noreg, 0, $noreg
+
+    Return
+...

--- a/llvm/test/CodeGen/SystemZ/regcoal-subranges-update.mir
+++ b/llvm/test/CodeGen/SystemZ/regcoal-subranges-update.mir
@@ -25,11 +25,11 @@ body:             |
 
     ; CHECK-LABEL: name: main
     ; CHECK: [[LGHI:%[0-9]+]]:gr64bit = LGHI 43
+    ; CHECK-NEXT: undef [[LGHI:%[0-9]+]].subreg_l32:gr64bit = MSR [[LGHI]].subreg_l32, [[LGHI]].subreg_l32
+    ; CHECK-NEXT: [[LGHI:%[0-9]+]].subreg_l32:gr64bit = AHIMux [[LGHI]].subreg_l32, 9, implicit-def dead $cc
     ; CHECK-NEXT: [[LGHI1:%[0-9]+]]:gr64bit = LGHI 43
-    ; CHECK-NEXT: undef [[LGHI1:%[0-9]+]].subreg_l32:gr64bit = MSR [[LGHI1]].subreg_l32, [[LGHI1]].subreg_l32
-    ; CHECK-NEXT: [[LGHI1:%[0-9]+]].subreg_l32:gr64bit = AHIMux [[LGHI1]].subreg_l32, 9, implicit-def dead $cc
-    ; CHECK-NEXT: undef [[LGFI:%[0-9]+]].subreg_l64:gr128bit = LGFI -245143785, implicit [[LGHI1]].subreg_l32
-    ; CHECK-NEXT: [[LGFI:%[0-9]+]]:gr128bit = DLGR [[LGFI]], [[LGHI]]
+    ; CHECK-NEXT: undef [[LGFI:%[0-9]+]].subreg_l64:gr128bit = LGFI -245143785, implicit [[LGHI]].subreg_l32
+    ; CHECK-NEXT: [[LGFI:%[0-9]+]]:gr128bit = DLGR [[LGFI]], [[LGHI1]]
     ; CHECK-NEXT: Return implicit [[LGFI]]
     %0:gr64bit = LGHI 43
     %1:gr32bit = COPY %0.subreg_l32

--- a/llvm/test/CodeGen/SystemZ/regcoal_remat_empty_subrange.ll
+++ b/llvm/test/CodeGen/SystemZ/regcoal_remat_empty_subrange.ll
@@ -14,10 +14,10 @@
 define void @main(i16 %in) {
 ; CHECK-LABEL: main:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    lhr %r2, %r2
+; CHECK-NEXT:    lhr %r0, %r2
 ; CHECK-NEXT:    larl %r1, g_151
 ; CHECK-NEXT:    lghi %r3, 0
-; CHECK-NEXT:    chi %r2, 0
+; CHECK-NEXT:    chi %r0, 0
 ; CHECK-NEXT:    lhi %r0, 1
 ; CHECK-NEXT:    locghile %r3, 1
 ; CHECK-NEXT:    o %r0, 0(%r1)

--- a/llvm/test/CodeGen/SystemZ/risbg-04.ll
+++ b/llvm/test/CodeGen/SystemZ/risbg-04.ll
@@ -252,14 +252,16 @@ define i64 @f20(i64 %foo) {
 }
 
 ; Now try an arithmetic right shift in which the sign bits aren't needed.
-; Introduce a second use of %shr so that the ashr doesn't decompose to
-; an lshr.
+; Introduce a second use of %shr so that the ashr doesn't decompose to an
+; lshr. TODO: Maybe better if pre-ra scheduler put the risblg below the the
+; other use of %r2.
 define i32 @f21(i32 %foo, ptr %dest) {
 ; CHECK-LABEL: f21:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    srak %r0, %r2, 28
-; CHECK-NEXT:    risblg %r2, %r2, 28, 158, 36
-; CHECK-NEXT:    st %r0, 0(%r3)
+; CHECK-NEXT:    risblg %r0, %r2, 28, 158, 36
+; CHECK-NEXT:    sra %r2, 28
+; CHECK-NEXT:    st %r2, 0(%r3)
+; CHECK-NEXT:    lr %r2, %r0
 ; CHECK-NEXT:    br %r14
   %shr = ashr i32 %foo, 28
   store i32 %shr, ptr %dest
@@ -271,9 +273,10 @@ define i32 @f21(i32 %foo, ptr %dest) {
 define i64 @f22(i64 %foo, ptr %dest) {
 ; CHECK-LABEL: f22:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    srag %r0, %r2, 60
-; CHECK-NEXT:    risbg %r2, %r2, 60, 190, 4
-; CHECK-NEXT:    stg %r0, 0(%r3)
+; CHECK-NEXT:    risbg %r0, %r2, 60, 190, 4
+; CHECK-NEXT:    srag %r1, %r2, 60
+; CHECK-NEXT:    lgr %r2, %r0
+; CHECK-NEXT:    stg %r1, 0(%r3)
 ; CHECK-NEXT:    br %r14
   %shr = ashr i64 %foo, 60
   store i64 %shr, ptr %dest
@@ -484,9 +487,10 @@ define i64 @f38(i64 %foo) {
 define i64 @f39(i64 %foo, ptr %dest) {
 ; CHECK-LABEL: f39:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    srag %r0, %r2, 35
-; CHECK-NEXT:    risbg %r2, %r2, 33, 189, 31
-; CHECK-NEXT:    stg %r0, 0(%r3)
+; CHECK-NEXT:    risbg %r0, %r2, 33, 189, 31
+; CHECK-NEXT:    srag %r1, %r2, 35
+; CHECK-NEXT:    lgr %r2, %r0
+; CHECK-NEXT:    stg %r1, 0(%r3)
 ; CHECK-NEXT:    br %r14
   %ashr = ashr i64 %foo, 35
   store i64 %ashr, ptr %dest

--- a/llvm/test/CodeGen/SystemZ/rot-03.ll
+++ b/llvm/test/CodeGen/SystemZ/rot-03.ll
@@ -8,10 +8,10 @@ define i128 @f1(i128 %val) {
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    vl %v0, 0(%r3), 3
 ; CHECK-NEXT:    vrepib %v1, 100
-; CHECK-NEXT:    vsrlb %v2, %v0, %v1
-; CHECK-NEXT:    vsrl %v1, %v2, %v1
 ; CHECK-NEXT:    vrepib %v2, 28
+; CHECK-NEXT:    vsrlb %v3, %v0, %v1
 ; CHECK-NEXT:    vslb %v0, %v0, %v2
+; CHECK-NEXT:    vsrl %v1, %v3, %v1
 ; CHECK-NEXT:    vsl %v0, %v0, %v2
 ; CHECK-NEXT:    vo %v0, %v0, %v1
 ; CHECK-NEXT:    vst %v0, 0(%r2), 3
@@ -47,19 +47,19 @@ define i128 @f3(i128 %val, i128 %amt) {
 ; CHECK-LABEL: f3:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    l %r0, 12(%r4)
-; CHECK-NEXT:    vlvgp %v1, %r0, %r0
 ; CHECK-NEXT:    vl %v0, 0(%r3), 3
-; CHECK-NEXT:    vrepb %v1, %v1, 15
-; CHECK-NEXT:    vslb %v2, %v0, %v1
-; CHECK-NEXT:    vsl %v1, %v2, %v1
-; CHECK-NEXT:    vrepib %v2, 1
+; CHECK-NEXT:    vlvgp %v1, %r0, %r0
 ; CHECK-NEXT:    xilf %r0, 4294967295
-; CHECK-NEXT:    vsrl %v0, %v0, %v2
 ; CHECK-NEXT:    vlvgp %v2, %r0, %r0
+; CHECK-NEXT:    vrepib %v3, 1
+; CHECK-NEXT:    vrepb %v1, %v1, 15
+; CHECK-NEXT:    vsrl %v3, %v0, %v3
 ; CHECK-NEXT:    vrepb %v2, %v2, 15
-; CHECK-NEXT:    vsrlb %v0, %v0, %v2
-; CHECK-NEXT:    vsrl %v0, %v0, %v2
-; CHECK-NEXT:    vo %v0, %v1, %v0
+; CHECK-NEXT:    vslb %v0, %v0, %v1
+; CHECK-NEXT:    vsrlb %v3, %v3, %v2
+; CHECK-NEXT:    vsl %v0, %v0, %v1
+; CHECK-NEXT:    vsrl %v1, %v3, %v2
+; CHECK-NEXT:    vo %v0, %v0, %v1
 ; CHECK-NEXT:    vst %v0, 0(%r2), 3
 ; CHECK-NEXT:    br %r14
 

--- a/llvm/test/CodeGen/SystemZ/shift-12.ll
+++ b/llvm/test/CodeGen/SystemZ/shift-12.ll
@@ -122,11 +122,11 @@ define i32 @f10(i32 %a, i32 %sh) {
 define i128 @f11(i128 %a, i32 %sh) {
 ; CHECK-LABEL: f11:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vlvgp %v1, %r4, %r4
-; CHECK-NEXT:    vl %v0, 0(%r3), 3
-; CHECK-NEXT:    vrepb %v1, %v1, 15
-; CHECK-NEXT:    vslb %v0, %v0, %v1
-; CHECK-NEXT:    vsl %v0, %v0, %v1
+; CHECK-NEXT:    vlvgp %v0, %r4, %r4
+; CHECK-NEXT:    vl %v1, 0(%r3), 3
+; CHECK-NEXT:    vrepb %v0, %v0, 15
+; CHECK-NEXT:    vslb %v1, %v1, %v0
+; CHECK-NEXT:    vsl %v0, %v1, %v0
 ; CHECK-NEXT:    vst %v0, 0(%r2), 3
 ; CHECK-NEXT:    br %r14
   %and = and i32 %sh, 127
@@ -138,11 +138,11 @@ define i128 @f11(i128 %a, i32 %sh) {
 define i128 @f12(i128 %a, i32 %sh) {
 ; CHECK-LABEL: f12:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vlvgp %v1, %r4, %r4
-; CHECK-NEXT:    vl %v0, 0(%r3), 3
-; CHECK-NEXT:    vrepb %v1, %v1, 15
-; CHECK-NEXT:    vsrlb %v0, %v0, %v1
-; CHECK-NEXT:    vsrl %v0, %v0, %v1
+; CHECK-NEXT:    vlvgp %v0, %r4, %r4
+; CHECK-NEXT:    vl %v1, 0(%r3), 3
+; CHECK-NEXT:    vrepb %v0, %v0, 15
+; CHECK-NEXT:    vsrlb %v1, %v1, %v0
+; CHECK-NEXT:    vsrl %v0, %v1, %v0
 ; CHECK-NEXT:    vst %v0, 0(%r2), 3
 ; CHECK-NEXT:    br %r14
   %and = and i32 %sh, 127
@@ -154,11 +154,11 @@ define i128 @f12(i128 %a, i32 %sh) {
 define i128 @f13(i128 %a, i32 %sh) {
 ; CHECK-LABEL: f13:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vlvgp %v1, %r4, %r4
-; CHECK-NEXT:    vl %v0, 0(%r3), 3
-; CHECK-NEXT:    vrepb %v1, %v1, 15
-; CHECK-NEXT:    vsrab %v0, %v0, %v1
-; CHECK-NEXT:    vsra %v0, %v0, %v1
+; CHECK-NEXT:    vlvgp %v0, %r4, %r4
+; CHECK-NEXT:    vl %v1, 0(%r3), 3
+; CHECK-NEXT:    vrepb %v0, %v0, 15
+; CHECK-NEXT:    vsrab %v1, %v1, %v0
+; CHECK-NEXT:    vsra %v0, %v1, %v0
 ; CHECK-NEXT:    vst %v0, 0(%r2), 3
 ; CHECK-NEXT:    br %r14
   %and = and i32 %sh, 127

--- a/llvm/test/CodeGen/SystemZ/shift-13.ll
+++ b/llvm/test/CodeGen/SystemZ/shift-13.ll
@@ -48,11 +48,11 @@ define i128 @f4(i128 %a, i128 %sh) {
 ; CHECK-LABEL: f4:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    l %r0, 12(%r4)
-; CHECK-NEXT:    vlvgp %v1, %r0, %r0
-; CHECK-NEXT:    vl %v0, 0(%r3), 3
-; CHECK-NEXT:    vrepb %v1, %v1, 15
-; CHECK-NEXT:    vslb %v0, %v0, %v1
-; CHECK-NEXT:    vsl %v0, %v0, %v1
+; CHECK-NEXT:    vlvgp %v0, %r0, %r0
+; CHECK-NEXT:    vl %v1, 0(%r3), 3
+; CHECK-NEXT:    vrepb %v0, %v0, 15
+; CHECK-NEXT:    vslb %v1, %v1, %v0
+; CHECK-NEXT:    vsl %v0, %v1, %v0
 ; CHECK-NEXT:    vst %v0, 0(%r2), 3
 ; CHECK-NEXT:    br %r14
   %res = shl i128 %a, %sh
@@ -64,11 +64,11 @@ define i128 @f5(i128 %a, i128 %sh) {
 ; CHECK-LABEL: f5:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    l %r0, 12(%r4)
-; CHECK-NEXT:    vlvgp %v1, %r0, %r0
-; CHECK-NEXT:    vl %v0, 0(%r3), 3
-; CHECK-NEXT:    vrepb %v1, %v1, 15
-; CHECK-NEXT:    vslb %v0, %v0, %v1
-; CHECK-NEXT:    vsl %v0, %v0, %v1
+; CHECK-NEXT:    vlvgp %v0, %r0, %r0
+; CHECK-NEXT:    vl %v1, 0(%r3), 3
+; CHECK-NEXT:    vrepb %v0, %v0, 15
+; CHECK-NEXT:    vslb %v1, %v1, %v0
+; CHECK-NEXT:    vsl %v0, %v1, %v0
 ; CHECK-NEXT:    vst %v0, 0(%r2), 3
 ; CHECK-NEXT:    br %r14
   %and = and i128 %sh, 127
@@ -81,11 +81,11 @@ define i128 @f6(i128 %a, i128 %sh) {
 ; CHECK-LABEL: f6:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    l %r0, 12(%r4)
-; CHECK-NEXT:    vlvgp %v1, %r0, %r0
-; CHECK-NEXT:    vl %v0, 0(%r3), 3
-; CHECK-NEXT:    vrepb %v1, %v1, 15
-; CHECK-NEXT:    vslb %v0, %v0, %v1
-; CHECK-NEXT:    vsl %v0, %v0, %v1
+; CHECK-NEXT:    vlvgp %v0, %r0, %r0
+; CHECK-NEXT:    vl %v1, 0(%r3), 3
+; CHECK-NEXT:    vrepb %v0, %v0, 15
+; CHECK-NEXT:    vslb %v1, %v1, %v0
+; CHECK-NEXT:    vsl %v0, %v1, %v0
 ; CHECK-NEXT:    vst %v0, 0(%r2), 3
 ; CHECK-NEXT:    br %r14
   %and = and i128 %sh, 511
@@ -99,11 +99,11 @@ define i128 @f7(i128 %a, i128 %sh) {
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    lhi %r0, 63
 ; CHECK-NEXT:    n %r0, 12(%r4)
-; CHECK-NEXT:    vlvgp %v1, %r0, %r0
-; CHECK-NEXT:    vl %v0, 0(%r3), 3
-; CHECK-NEXT:    vrepb %v1, %v1, 15
-; CHECK-NEXT:    vslb %v0, %v0, %v1
-; CHECK-NEXT:    vsl %v0, %v0, %v1
+; CHECK-NEXT:    vlvgp %v0, %r0, %r0
+; CHECK-NEXT:    vl %v1, 0(%r3), 3
+; CHECK-NEXT:    vrepb %v0, %v0, 15
+; CHECK-NEXT:    vslb %v1, %v1, %v0
+; CHECK-NEXT:    vsl %v0, %v1, %v0
 ; CHECK-NEXT:    vst %v0, 0(%r2), 3
 ; CHECK-NEXT:    br %r14
   %and = and i128 %sh, 63
@@ -115,15 +115,15 @@ define i128 @f7(i128 %a, i128 %sh) {
 define i128 @f8(i128 %a, i128 %b, i128 %sh) {
 ; CHECK-LABEL: f8:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vl %v1, 0(%r4), 3
-; CHECK-NEXT:    vl %v2, 0(%r5), 3
-; CHECK-NEXT:    vn %v1, %v2, %v1
-; CHECK-NEXT:    vlgvf %r0, %v1, 3
-; CHECK-NEXT:    vlvgp %v1, %r0, %r0
-; CHECK-NEXT:    vl %v0, 0(%r3), 3
-; CHECK-NEXT:    vrepb %v1, %v1, 15
-; CHECK-NEXT:    vslb %v0, %v0, %v1
-; CHECK-NEXT:    vsl %v0, %v0, %v1
+; CHECK-NEXT:    vl %v0, 0(%r4), 3
+; CHECK-NEXT:    vl %v1, 0(%r5), 3
+; CHECK-NEXT:    vn %v0, %v1, %v0
+; CHECK-NEXT:    vlgvf %r0, %v0, 3
+; CHECK-NEXT:    vlvgp %v0, %r0, %r0
+; CHECK-NEXT:    vl %v1, 0(%r3), 3
+; CHECK-NEXT:    vrepb %v0, %v0, 15
+; CHECK-NEXT:    vslb %v1, %v1, %v0
+; CHECK-NEXT:    vsl %v0, %v1, %v0
 ; CHECK-NEXT:    vst %v0, 0(%r2), 3
 ; CHECK-NEXT:    br %r14
   %and = and i128 %sh, %b

--- a/llvm/test/CodeGen/SystemZ/shift-14.ll
+++ b/llvm/test/CodeGen/SystemZ/shift-14.ll
@@ -48,11 +48,11 @@ define i128 @f4(i128 %a, i128 %sh) {
 ; CHECK-LABEL: f4:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    l %r0, 12(%r4)
-; CHECK-NEXT:    vlvgp %v1, %r0, %r0
-; CHECK-NEXT:    vl %v0, 0(%r3), 3
-; CHECK-NEXT:    vrepb %v1, %v1, 15
-; CHECK-NEXT:    vsrlb %v0, %v0, %v1
-; CHECK-NEXT:    vsrl %v0, %v0, %v1
+; CHECK-NEXT:    vlvgp %v0, %r0, %r0
+; CHECK-NEXT:    vl %v1, 0(%r3), 3
+; CHECK-NEXT:    vrepb %v0, %v0, 15
+; CHECK-NEXT:    vsrlb %v1, %v1, %v0
+; CHECK-NEXT:    vsrl %v0, %v1, %v0
 ; CHECK-NEXT:    vst %v0, 0(%r2), 3
 ; CHECK-NEXT:    br %r14
   %res = lshr i128 %a, %sh
@@ -64,11 +64,11 @@ define i128 @f5(i128 %a, i128 %sh) {
 ; CHECK-LABEL: f5:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    l %r0, 12(%r4)
-; CHECK-NEXT:    vlvgp %v1, %r0, %r0
-; CHECK-NEXT:    vl %v0, 0(%r3), 3
-; CHECK-NEXT:    vrepb %v1, %v1, 15
-; CHECK-NEXT:    vsrlb %v0, %v0, %v1
-; CHECK-NEXT:    vsrl %v0, %v0, %v1
+; CHECK-NEXT:    vlvgp %v0, %r0, %r0
+; CHECK-NEXT:    vl %v1, 0(%r3), 3
+; CHECK-NEXT:    vrepb %v0, %v0, 15
+; CHECK-NEXT:    vsrlb %v1, %v1, %v0
+; CHECK-NEXT:    vsrl %v0, %v1, %v0
 ; CHECK-NEXT:    vst %v0, 0(%r2), 3
 ; CHECK-NEXT:    br %r14
   %and = and i128 %sh, 127
@@ -81,11 +81,11 @@ define i128 @f6(i128 %a, i128 %sh) {
 ; CHECK-LABEL: f6:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    l %r0, 12(%r4)
-; CHECK-NEXT:    vlvgp %v1, %r0, %r0
-; CHECK-NEXT:    vl %v0, 0(%r3), 3
-; CHECK-NEXT:    vrepb %v1, %v1, 15
-; CHECK-NEXT:    vsrlb %v0, %v0, %v1
-; CHECK-NEXT:    vsrl %v0, %v0, %v1
+; CHECK-NEXT:    vlvgp %v0, %r0, %r0
+; CHECK-NEXT:    vl %v1, 0(%r3), 3
+; CHECK-NEXT:    vrepb %v0, %v0, 15
+; CHECK-NEXT:    vsrlb %v1, %v1, %v0
+; CHECK-NEXT:    vsrl %v0, %v1, %v0
 ; CHECK-NEXT:    vst %v0, 0(%r2), 3
 ; CHECK-NEXT:    br %r14
   %and = and i128 %sh, 511
@@ -99,11 +99,11 @@ define i128 @f7(i128 %a, i128 %sh) {
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    lhi %r0, 63
 ; CHECK-NEXT:    n %r0, 12(%r4)
-; CHECK-NEXT:    vlvgp %v1, %r0, %r0
-; CHECK-NEXT:    vl %v0, 0(%r3), 3
-; CHECK-NEXT:    vrepb %v1, %v1, 15
-; CHECK-NEXT:    vsrlb %v0, %v0, %v1
-; CHECK-NEXT:    vsrl %v0, %v0, %v1
+; CHECK-NEXT:    vlvgp %v0, %r0, %r0
+; CHECK-NEXT:    vl %v1, 0(%r3), 3
+; CHECK-NEXT:    vrepb %v0, %v0, 15
+; CHECK-NEXT:    vsrlb %v1, %v1, %v0
+; CHECK-NEXT:    vsrl %v0, %v1, %v0
 ; CHECK-NEXT:    vst %v0, 0(%r2), 3
 ; CHECK-NEXT:    br %r14
   %and = and i128 %sh, 63
@@ -115,15 +115,15 @@ define i128 @f7(i128 %a, i128 %sh) {
 define i128 @f8(i128 %a, i128 %b, i128 %sh) {
 ; CHECK-LABEL: f8:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vl %v1, 0(%r4), 3
-; CHECK-NEXT:    vl %v2, 0(%r5), 3
-; CHECK-NEXT:    vn %v1, %v2, %v1
-; CHECK-NEXT:    vlgvf %r0, %v1, 3
-; CHECK-NEXT:    vlvgp %v1, %r0, %r0
-; CHECK-NEXT:    vl %v0, 0(%r3), 3
-; CHECK-NEXT:    vrepb %v1, %v1, 15
-; CHECK-NEXT:    vsrlb %v0, %v0, %v1
-; CHECK-NEXT:    vsrl %v0, %v0, %v1
+; CHECK-NEXT:    vl %v0, 0(%r4), 3
+; CHECK-NEXT:    vl %v1, 0(%r5), 3
+; CHECK-NEXT:    vn %v0, %v1, %v0
+; CHECK-NEXT:    vlgvf %r0, %v0, 3
+; CHECK-NEXT:    vlvgp %v0, %r0, %r0
+; CHECK-NEXT:    vl %v1, 0(%r3), 3
+; CHECK-NEXT:    vrepb %v0, %v0, 15
+; CHECK-NEXT:    vsrlb %v1, %v1, %v0
+; CHECK-NEXT:    vsrl %v0, %v1, %v0
 ; CHECK-NEXT:    vst %v0, 0(%r2), 3
 ; CHECK-NEXT:    br %r14
   %and = and i128 %sh, %b

--- a/llvm/test/CodeGen/SystemZ/shift-15.ll
+++ b/llvm/test/CodeGen/SystemZ/shift-15.ll
@@ -48,11 +48,11 @@ define i128 @f4(i128 %a, i128 %sh) {
 ; CHECK-LABEL: f4:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    l %r0, 12(%r4)
-; CHECK-NEXT:    vlvgp %v1, %r0, %r0
-; CHECK-NEXT:    vl %v0, 0(%r3), 3
-; CHECK-NEXT:    vrepb %v1, %v1, 15
-; CHECK-NEXT:    vsrab %v0, %v0, %v1
-; CHECK-NEXT:    vsra %v0, %v0, %v1
+; CHECK-NEXT:    vlvgp %v0, %r0, %r0
+; CHECK-NEXT:    vl %v1, 0(%r3), 3
+; CHECK-NEXT:    vrepb %v0, %v0, 15
+; CHECK-NEXT:    vsrab %v1, %v1, %v0
+; CHECK-NEXT:    vsra %v0, %v1, %v0
 ; CHECK-NEXT:    vst %v0, 0(%r2), 3
 ; CHECK-NEXT:    br %r14
   %res = ashr i128 %a, %sh
@@ -64,11 +64,11 @@ define i128 @f5(i128 %a, i128 %sh) {
 ; CHECK-LABEL: f5:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    l %r0, 12(%r4)
-; CHECK-NEXT:    vlvgp %v1, %r0, %r0
-; CHECK-NEXT:    vl %v0, 0(%r3), 3
-; CHECK-NEXT:    vrepb %v1, %v1, 15
-; CHECK-NEXT:    vsrab %v0, %v0, %v1
-; CHECK-NEXT:    vsra %v0, %v0, %v1
+; CHECK-NEXT:    vlvgp %v0, %r0, %r0
+; CHECK-NEXT:    vl %v1, 0(%r3), 3
+; CHECK-NEXT:    vrepb %v0, %v0, 15
+; CHECK-NEXT:    vsrab %v1, %v1, %v0
+; CHECK-NEXT:    vsra %v0, %v1, %v0
 ; CHECK-NEXT:    vst %v0, 0(%r2), 3
 ; CHECK-NEXT:    br %r14
   %and = and i128 %sh, 127
@@ -81,11 +81,11 @@ define i128 @f6(i128 %a, i128 %sh) {
 ; CHECK-LABEL: f6:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    l %r0, 12(%r4)
-; CHECK-NEXT:    vlvgp %v1, %r0, %r0
-; CHECK-NEXT:    vl %v0, 0(%r3), 3
-; CHECK-NEXT:    vrepb %v1, %v1, 15
-; CHECK-NEXT:    vsrab %v0, %v0, %v1
-; CHECK-NEXT:    vsra %v0, %v0, %v1
+; CHECK-NEXT:    vlvgp %v0, %r0, %r0
+; CHECK-NEXT:    vl %v1, 0(%r3), 3
+; CHECK-NEXT:    vrepb %v0, %v0, 15
+; CHECK-NEXT:    vsrab %v1, %v1, %v0
+; CHECK-NEXT:    vsra %v0, %v1, %v0
 ; CHECK-NEXT:    vst %v0, 0(%r2), 3
 ; CHECK-NEXT:    br %r14
   %and = and i128 %sh, 511
@@ -99,11 +99,11 @@ define i128 @f7(i128 %a, i128 %sh) {
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    lhi %r0, 63
 ; CHECK-NEXT:    n %r0, 12(%r4)
-; CHECK-NEXT:    vlvgp %v1, %r0, %r0
-; CHECK-NEXT:    vl %v0, 0(%r3), 3
-; CHECK-NEXT:    vrepb %v1, %v1, 15
-; CHECK-NEXT:    vsrab %v0, %v0, %v1
-; CHECK-NEXT:    vsra %v0, %v0, %v1
+; CHECK-NEXT:    vlvgp %v0, %r0, %r0
+; CHECK-NEXT:    vl %v1, 0(%r3), 3
+; CHECK-NEXT:    vrepb %v0, %v0, 15
+; CHECK-NEXT:    vsrab %v1, %v1, %v0
+; CHECK-NEXT:    vsra %v0, %v1, %v0
 ; CHECK-NEXT:    vst %v0, 0(%r2), 3
 ; CHECK-NEXT:    br %r14
   %and = and i128 %sh, 63
@@ -115,15 +115,15 @@ define i128 @f7(i128 %a, i128 %sh) {
 define i128 @f8(i128 %a, i128 %b, i128 %sh) {
 ; CHECK-LABEL: f8:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vl %v1, 0(%r4), 3
-; CHECK-NEXT:    vl %v2, 0(%r5), 3
-; CHECK-NEXT:    vn %v1, %v2, %v1
-; CHECK-NEXT:    vlgvf %r0, %v1, 3
-; CHECK-NEXT:    vlvgp %v1, %r0, %r0
-; CHECK-NEXT:    vl %v0, 0(%r3), 3
-; CHECK-NEXT:    vrepb %v1, %v1, 15
-; CHECK-NEXT:    vsrab %v0, %v0, %v1
-; CHECK-NEXT:    vsra %v0, %v0, %v1
+; CHECK-NEXT:    vl %v0, 0(%r4), 3
+; CHECK-NEXT:    vl %v1, 0(%r5), 3
+; CHECK-NEXT:    vn %v0, %v1, %v0
+; CHECK-NEXT:    vlgvf %r0, %v0, 3
+; CHECK-NEXT:    vlvgp %v0, %r0, %r0
+; CHECK-NEXT:    vl %v1, 0(%r3), 3
+; CHECK-NEXT:    vrepb %v0, %v0, 15
+; CHECK-NEXT:    vsrab %v1, %v1, %v0
+; CHECK-NEXT:    vsra %v0, %v1, %v0
 ; CHECK-NEXT:    vst %v0, 0(%r2), 3
 ; CHECK-NEXT:    br %r14
   %and = and i128 %sh, %b

--- a/llvm/test/CodeGen/SystemZ/shift-16.ll
+++ b/llvm/test/CodeGen/SystemZ/shift-16.ll
@@ -7,26 +7,26 @@
 define i256 @f1(i256 %a, i256 %sh) {
 ; CHECK-LABEL: f1:
 ; CHECK:       # %bb.0:
+; CHECK-NEXT:    l %r0, 28(%r4)
 ; CHECK-NEXT:    vl %v1, 16(%r3), 3
 ; CHECK-NEXT:    vl %v0, 0(%r3), 3
-; CHECK-NEXT:    l %r0, 28(%r4)
 ; CHECK-NEXT:    clijhe %r0, 128, .LBB0_2
 ; CHECK-NEXT:  # %bb.1:
 ; CHECK-NEXT:    lr %r1, %r0
 ; CHECK-NEXT:    xilf %r1, 4294967295
 ; CHECK-NEXT:    vlvgp %v2, %r0, %r0
-; CHECK-NEXT:    vlvgp %v5, %r1, %r1
+; CHECK-NEXT:    vlvgp %v3, %r1, %r1
 ; CHECK-NEXT:    vrepib %v4, 1
-; CHECK-NEXT:    vrepb %v3, %v2, 15
-; CHECK-NEXT:    vsrl %v4, %v1, %v4
-; CHECK-NEXT:    vrepb %v5, %v5, 15
-; CHECK-NEXT:    vslb %v2, %v0, %v3
-; CHECK-NEXT:    vsrlb %v4, %v4, %v5
-; CHECK-NEXT:    vslb %v1, %v1, %v3
-; CHECK-NEXT:    vsl %v2, %v2, %v3
-; CHECK-NEXT:    vsrl %v4, %v4, %v5
-; CHECK-NEXT:    vo %v2, %v2, %v4
-; CHECK-NEXT:    vsl %v1, %v1, %v3
+; CHECK-NEXT:    vrepb %v5, %v2, 15
+; CHECK-NEXT:    vsrl %v2, %v1, %v4
+; CHECK-NEXT:    vrepb %v3, %v3, 15
+; CHECK-NEXT:    vslb %v4, %v0, %v5
+; CHECK-NEXT:    vsrlb %v2, %v2, %v3
+; CHECK-NEXT:    vslb %v1, %v1, %v5
+; CHECK-NEXT:    vsl %v4, %v4, %v5
+; CHECK-NEXT:    vsrl %v2, %v2, %v3
+; CHECK-NEXT:    vo %v2, %v4, %v2
+; CHECK-NEXT:    vsl %v1, %v1, %v5
 ; CHECK-NEXT:    cijlh %r0, 0, .LBB0_3
 ; CHECK-NEXT:    j .LBB0_4
 ; CHECK-NEXT:  .LBB0_2:
@@ -51,26 +51,26 @@ define i256 @f1(i256 %a, i256 %sh) {
 define i256 @f2(i256 %a, i256 %sh) {
 ; CHECK-LABEL: f2:
 ; CHECK:       # %bb.0:
+; CHECK-NEXT:    l %r0, 28(%r4)
 ; CHECK-NEXT:    vl %v1, 0(%r3), 3
 ; CHECK-NEXT:    vl %v0, 16(%r3), 3
-; CHECK-NEXT:    l %r0, 28(%r4)
 ; CHECK-NEXT:    clijhe %r0, 128, .LBB1_2
 ; CHECK-NEXT:  # %bb.1:
 ; CHECK-NEXT:    lr %r1, %r0
 ; CHECK-NEXT:    xilf %r1, 4294967295
 ; CHECK-NEXT:    vlvgp %v2, %r0, %r0
-; CHECK-NEXT:    vlvgp %v5, %r1, %r1
+; CHECK-NEXT:    vlvgp %v3, %r1, %r1
 ; CHECK-NEXT:    vrepib %v4, 1
-; CHECK-NEXT:    vrepb %v3, %v2, 15
-; CHECK-NEXT:    vsl %v4, %v1, %v4
-; CHECK-NEXT:    vrepb %v5, %v5, 15
-; CHECK-NEXT:    vsrlb %v2, %v0, %v3
-; CHECK-NEXT:    vslb %v4, %v4, %v5
-; CHECK-NEXT:    vsrlb %v1, %v1, %v3
-; CHECK-NEXT:    vsrl %v2, %v2, %v3
-; CHECK-NEXT:    vsl %v4, %v4, %v5
-; CHECK-NEXT:    vo %v2, %v4, %v2
-; CHECK-NEXT:    vsrl %v1, %v1, %v3
+; CHECK-NEXT:    vrepb %v5, %v2, 15
+; CHECK-NEXT:    vsl %v2, %v1, %v4
+; CHECK-NEXT:    vrepb %v3, %v3, 15
+; CHECK-NEXT:    vsrlb %v4, %v0, %v5
+; CHECK-NEXT:    vslb %v2, %v2, %v3
+; CHECK-NEXT:    vsrlb %v1, %v1, %v5
+; CHECK-NEXT:    vsrl %v4, %v4, %v5
+; CHECK-NEXT:    vsl %v2, %v2, %v3
+; CHECK-NEXT:    vo %v2, %v2, %v4
+; CHECK-NEXT:    vsrl %v1, %v1, %v5
 ; CHECK-NEXT:    cijlh %r0, 0, .LBB1_3
 ; CHECK-NEXT:    j .LBB1_4
 ; CHECK-NEXT:  .LBB1_2:
@@ -95,37 +95,37 @@ define i256 @f2(i256 %a, i256 %sh) {
 define i256 @f3(i256 %a, i256 %sh) {
 ; CHECK-LABEL: f3:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vl %v0, 16(%r3), 3
 ; CHECK-NEXT:    l %r0, 28(%r4)
-; CHECK-NEXT:    vl %v2, 0(%r3), 3
+; CHECK-NEXT:    vl %v0, 16(%r3), 3
+; CHECK-NEXT:    vl %v1, 0(%r3), 3
 ; CHECK-NEXT:    clijhe %r0, 128, .LBB2_2
 ; CHECK-NEXT:  # %bb.1:
-; CHECK-NEXT:    vlvgp %v1, %r0, %r0
-; CHECK-NEXT:    vrepb %v3, %v1, 15
-; CHECK-NEXT:    vsrab %v1, %v2, %v3
-; CHECK-NEXT:    vsrlb %v4, %v0, %v3
-; CHECK-NEXT:    vsra %v1, %v1, %v3
 ; CHECK-NEXT:    lr %r1, %r0
-; CHECK-NEXT:    vsrl %v3, %v4, %v3
-; CHECK-NEXT:    vrepib %v4, 1
 ; CHECK-NEXT:    xilf %r1, 4294967295
-; CHECK-NEXT:    vsl %v2, %v2, %v4
-; CHECK-NEXT:    vlvgp %v4, %r1, %r1
-; CHECK-NEXT:    vrepb %v4, %v4, 15
-; CHECK-NEXT:    vslb %v2, %v2, %v4
-; CHECK-NEXT:    vsl %v2, %v2, %v4
-; CHECK-NEXT:    vo %v2, %v2, %v3
+; CHECK-NEXT:    vlvgp %v2, %r0, %r0
+; CHECK-NEXT:    vlvgp %v3, %r1, %r1
+; CHECK-NEXT:    vrepib %v4, 1
+; CHECK-NEXT:    vrepb %v2, %v2, 15
+; CHECK-NEXT:    vsl %v4, %v1, %v4
+; CHECK-NEXT:    vrepb %v3, %v3, 15
+; CHECK-NEXT:    vsrlb %v5, %v0, %v2
+; CHECK-NEXT:    vslb %v4, %v4, %v3
+; CHECK-NEXT:    vsrab %v1, %v1, %v2
+; CHECK-NEXT:    vsrl %v5, %v5, %v2
+; CHECK-NEXT:    vsl %v3, %v4, %v3
+; CHECK-NEXT:    vsra %v1, %v1, %v2
+; CHECK-NEXT:    vo %v2, %v3, %v5
 ; CHECK-NEXT:    cijlh %r0, 0, .LBB2_3
 ; CHECK-NEXT:    j .LBB2_4
 ; CHECK-NEXT:  .LBB2_2:
-; CHECK-NEXT:    vrepib %v1, 127
-; CHECK-NEXT:    vsrab %v3, %v2, %v1
 ; CHECK-NEXT:    ahik %r1, %r0, -128
-; CHECK-NEXT:    vsra %v1, %v3, %v1
-; CHECK-NEXT:    vlvgp %v3, %r1, %r1
-; CHECK-NEXT:    vrepb %v3, %v3, 15
-; CHECK-NEXT:    vsrab %v2, %v2, %v3
-; CHECK-NEXT:    vsra %v2, %v2, %v3
+; CHECK-NEXT:    vlvgp %v2, %r1, %r1
+; CHECK-NEXT:    vrepib %v3, 127
+; CHECK-NEXT:    vrepb %v2, %v2, 15
+; CHECK-NEXT:    vsrab %v4, %v1, %v3
+; CHECK-NEXT:    vsrab %v5, %v1, %v2
+; CHECK-NEXT:    vsra %v1, %v4, %v3
+; CHECK-NEXT:    vsra %v2, %v5, %v2
 ; CHECK-NEXT:    cije %r0, 0, .LBB2_4
 ; CHECK-NEXT:  .LBB2_3:
 ; CHECK-NEXT:    vlr %v0, %v2

--- a/llvm/test/CodeGen/SystemZ/shift-17.ll
+++ b/llvm/test/CodeGen/SystemZ/shift-17.ll
@@ -32,14 +32,14 @@ define i128 @f1(i128 %a, i128 %b) {
 define i128 @f2(i128 %a, i128 %b) {
 ; CHECK-LABEL: f2:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vl %v1, 0(%r3), 3
 ; CHECK-NEXT:    vl %v0, 0(%r4), 3
-; CHECK-NEXT:    vrepib %v2, 5
-; CHECK-NEXT:    vsl %v1, %v1, %v2
-; CHECK-NEXT:    vrepib %v2, 123
-; CHECK-NEXT:    vsrlb %v0, %v0, %v2
-; CHECK-NEXT:    vsrl %v0, %v0, %v2
-; CHECK-NEXT:    vo %v0, %v1, %v0
+; CHECK-NEXT:    vrepib %v1, 123
+; CHECK-NEXT:    vl %v2, 0(%r3), 3
+; CHECK-NEXT:    vsrlb %v0, %v0, %v1
+; CHECK-NEXT:    vrepib %v3, 5
+; CHECK-NEXT:    vsl %v2, %v2, %v3
+; CHECK-NEXT:    vsrl %v0, %v0, %v1
+; CHECK-NEXT:    vo %v0, %v2, %v0
 ; CHECK-NEXT:    vst %v0, 0(%r2), 3
 ; CHECK-NEXT:    br %r14
 ;
@@ -58,14 +58,14 @@ define i128 @f2(i128 %a, i128 %b) {
 define i128 @f3(i128 %a, i128 %b) {
 ; CHECK-LABEL: f3:
 ; CHECK:       # %bb.0:
+; CHECK-NEXT:    vl %v0, 0(%r3), 3
 ; CHECK-NEXT:    vl %v1, 0(%r4), 3
 ; CHECK-NEXT:    vrepib %v2, 86
+; CHECK-NEXT:    vrepib %v3, 42
 ; CHECK-NEXT:    vsrlb %v1, %v1, %v2
-; CHECK-NEXT:    vl %v0, 0(%r3), 3
+; CHECK-NEXT:    vslb %v0, %v0, %v3
 ; CHECK-NEXT:    vsrl %v1, %v1, %v2
-; CHECK-NEXT:    vrepib %v2, 42
-; CHECK-NEXT:    vslb %v0, %v0, %v2
-; CHECK-NEXT:    vsl %v0, %v0, %v2
+; CHECK-NEXT:    vsl %v0, %v0, %v3
 ; CHECK-NEXT:    vo %v0, %v0, %v1
 ; CHECK-NEXT:    vst %v0, 0(%r2), 3
 ; CHECK-NEXT:    br %r14
@@ -88,18 +88,18 @@ define i128 @f4(i128 %a, i128 %b, i128 %sh) {
 ; CHECK-LABEL: f4:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    l %r0, 12(%r5)
-; CHECK-NEXT:    vlvgp %v2, %r0, %r0
-; CHECK-NEXT:    vl %v1, 0(%r3), 3
-; CHECK-NEXT:    vrepb %v2, %v2, 15
-; CHECK-NEXT:    vslb %v1, %v1, %v2
 ; CHECK-NEXT:    vl %v0, 0(%r4), 3
-; CHECK-NEXT:    vsl %v1, %v1, %v2
-; CHECK-NEXT:    vrepib %v2, 1
+; CHECK-NEXT:    vlvgp %v1, %r0, %r0
 ; CHECK-NEXT:    xilf %r0, 4294967295
-; CHECK-NEXT:    vsrl %v0, %v0, %v2
 ; CHECK-NEXT:    vlvgp %v2, %r0, %r0
+; CHECK-NEXT:    vl %v3, 0(%r3), 3
+; CHECK-NEXT:    vrepib %v4, 1
+; CHECK-NEXT:    vrepb %v1, %v1, 15
+; CHECK-NEXT:    vsrl %v0, %v0, %v4
 ; CHECK-NEXT:    vrepb %v2, %v2, 15
+; CHECK-NEXT:    vslb %v3, %v3, %v1
 ; CHECK-NEXT:    vsrlb %v0, %v0, %v2
+; CHECK-NEXT:    vsl %v1, %v3, %v1
 ; CHECK-NEXT:    vsrl %v0, %v0, %v2
 ; CHECK-NEXT:    vo %v0, %v1, %v0
 ; CHECK-NEXT:    vst %v0, 0(%r2), 3
@@ -108,18 +108,18 @@ define i128 @f4(i128 %a, i128 %b, i128 %sh) {
 ; Z15-LABEL: f4:
 ; Z15:       # %bb.0:
 ; Z15-NEXT:    l %r0, 12(%r5)
-; Z15-NEXT:    vlvgp %v2, %r0, %r0
-; Z15-NEXT:    vl %v1, 0(%r3), 3
-; Z15-NEXT:    vrepb %v2, %v2, 15
 ; Z15-NEXT:    vl %v0, 0(%r4), 3
-; Z15-NEXT:    vslb %v1, %v1, %v2
-; Z15-NEXT:    vsl %v1, %v1, %v2
-; Z15-NEXT:    vrepib %v2, 1
+; Z15-NEXT:    vlvgp %v1, %r0, %r0
 ; Z15-NEXT:    xilf %r0, 4294967295
-; Z15-NEXT:    vsrl %v0, %v0, %v2
 ; Z15-NEXT:    vlvgp %v2, %r0, %r0
+; Z15-NEXT:    vl %v3, 0(%r3), 3
+; Z15-NEXT:    vrepib %v4, 1
+; Z15-NEXT:    vrepb %v1, %v1, 15
+; Z15-NEXT:    vsrl %v0, %v0, %v4
 ; Z15-NEXT:    vrepb %v2, %v2, 15
+; Z15-NEXT:    vslb %v3, %v3, %v1
 ; Z15-NEXT:    vsrlb %v0, %v0, %v2
+; Z15-NEXT:    vsl %v1, %v3, %v1
 ; Z15-NEXT:    vsrl %v0, %v0, %v2
 ; Z15-NEXT:    vo %v0, %v1, %v0
 ; Z15-NEXT:    vst %v0, 0(%r2), 3
@@ -153,14 +153,14 @@ define i128 @f5(i128 %a, i128 %b) {
 define i128 @f6(i128 %a, i128 %b) {
 ; CHECK-LABEL: f6:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vl %v1, 0(%r4), 3
 ; CHECK-NEXT:    vl %v0, 0(%r3), 3
-; CHECK-NEXT:    vrepib %v2, 5
-; CHECK-NEXT:    vsrl %v1, %v1, %v2
-; CHECK-NEXT:    vrepib %v2, 123
-; CHECK-NEXT:    vslb %v0, %v0, %v2
-; CHECK-NEXT:    vsl %v0, %v0, %v2
-; CHECK-NEXT:    vo %v0, %v0, %v1
+; CHECK-NEXT:    vrepib %v1, 123
+; CHECK-NEXT:    vl %v2, 0(%r4), 3
+; CHECK-NEXT:    vslb %v0, %v0, %v1
+; CHECK-NEXT:    vrepib %v3, 5
+; CHECK-NEXT:    vsrl %v2, %v2, %v3
+; CHECK-NEXT:    vsl %v0, %v0, %v1
+; CHECK-NEXT:    vo %v0, %v0, %v2
 ; CHECK-NEXT:    vst %v0, 0(%r2), 3
 ; CHECK-NEXT:    br %r14
 ;
@@ -179,14 +179,14 @@ define i128 @f6(i128 %a, i128 %b) {
 define i128 @f7(i128 %a, i128 %b) {
 ; CHECK-LABEL: f7:
 ; CHECK:       # %bb.0:
+; CHECK-NEXT:    vl %v0, 0(%r3), 3
 ; CHECK-NEXT:    vl %v1, 0(%r4), 3
 ; CHECK-NEXT:    vrepib %v2, 42
+; CHECK-NEXT:    vrepib %v3, 86
 ; CHECK-NEXT:    vsrlb %v1, %v1, %v2
-; CHECK-NEXT:    vl %v0, 0(%r3), 3
+; CHECK-NEXT:    vslb %v0, %v0, %v3
 ; CHECK-NEXT:    vsrl %v1, %v1, %v2
-; CHECK-NEXT:    vrepib %v2, 86
-; CHECK-NEXT:    vslb %v0, %v0, %v2
-; CHECK-NEXT:    vsl %v0, %v0, %v2
+; CHECK-NEXT:    vsl %v0, %v0, %v3
 ; CHECK-NEXT:    vo %v0, %v0, %v1
 ; CHECK-NEXT:    vst %v0, 0(%r2), 3
 ; CHECK-NEXT:    br %r14
@@ -209,18 +209,18 @@ define i128 @f8(i128 %a, i128 %b, i128 %sh) {
 ; CHECK-LABEL: f8:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    l %r0, 12(%r5)
-; CHECK-NEXT:    vlvgp %v2, %r0, %r0
-; CHECK-NEXT:    vl %v1, 0(%r4), 3
-; CHECK-NEXT:    vrepb %v2, %v2, 15
-; CHECK-NEXT:    vsrlb %v1, %v1, %v2
 ; CHECK-NEXT:    vl %v0, 0(%r3), 3
-; CHECK-NEXT:    vsrl %v1, %v1, %v2
-; CHECK-NEXT:    vrepib %v2, 1
+; CHECK-NEXT:    vlvgp %v1, %r0, %r0
 ; CHECK-NEXT:    xilf %r0, 4294967295
-; CHECK-NEXT:    vsl %v0, %v0, %v2
 ; CHECK-NEXT:    vlvgp %v2, %r0, %r0
+; CHECK-NEXT:    vl %v3, 0(%r4), 3
+; CHECK-NEXT:    vrepib %v4, 1
+; CHECK-NEXT:    vrepb %v1, %v1, 15
+; CHECK-NEXT:    vsl %v0, %v0, %v4
 ; CHECK-NEXT:    vrepb %v2, %v2, 15
+; CHECK-NEXT:    vsrlb %v3, %v3, %v1
 ; CHECK-NEXT:    vslb %v0, %v0, %v2
+; CHECK-NEXT:    vsrl %v1, %v3, %v1
 ; CHECK-NEXT:    vsl %v0, %v0, %v2
 ; CHECK-NEXT:    vo %v0, %v0, %v1
 ; CHECK-NEXT:    vst %v0, 0(%r2), 3
@@ -229,18 +229,18 @@ define i128 @f8(i128 %a, i128 %b, i128 %sh) {
 ; Z15-LABEL: f8:
 ; Z15:       # %bb.0:
 ; Z15-NEXT:    l %r0, 12(%r5)
-; Z15-NEXT:    vlvgp %v2, %r0, %r0
-; Z15-NEXT:    vl %v1, 0(%r4), 3
-; Z15-NEXT:    vrepb %v2, %v2, 15
 ; Z15-NEXT:    vl %v0, 0(%r3), 3
-; Z15-NEXT:    vsrlb %v1, %v1, %v2
-; Z15-NEXT:    vsrl %v1, %v1, %v2
-; Z15-NEXT:    vrepib %v2, 1
+; Z15-NEXT:    vlvgp %v1, %r0, %r0
 ; Z15-NEXT:    xilf %r0, 4294967295
-; Z15-NEXT:    vsl %v0, %v0, %v2
 ; Z15-NEXT:    vlvgp %v2, %r0, %r0
+; Z15-NEXT:    vl %v3, 0(%r4), 3
+; Z15-NEXT:    vrepib %v4, 1
+; Z15-NEXT:    vrepb %v1, %v1, 15
+; Z15-NEXT:    vsl %v0, %v0, %v4
 ; Z15-NEXT:    vrepb %v2, %v2, 15
+; Z15-NEXT:    vsrlb %v3, %v3, %v1
 ; Z15-NEXT:    vslb %v0, %v0, %v2
+; Z15-NEXT:    vsrl %v1, %v3, %v1
 ; Z15-NEXT:    vsl %v0, %v0, %v2
 ; Z15-NEXT:    vo %v0, %v0, %v1
 ; Z15-NEXT:    vst %v0, 0(%r2), 3
@@ -253,14 +253,14 @@ define i128 @f8(i128 %a, i128 %b, i128 %sh) {
 define i128 @f9(i128 %a, i128 %b) {
 ; CHECK-LABEL: f9:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vl %v1, 0(%r4), 3
 ; CHECK-NEXT:    vl %v0, 0(%r3), 3
-; CHECK-NEXT:    vrepib %v2, 5
-; CHECK-NEXT:    vsrl %v1, %v1, %v2
-; CHECK-NEXT:    vrepib %v2, 123
-; CHECK-NEXT:    vslb %v0, %v0, %v2
-; CHECK-NEXT:    vsl %v0, %v0, %v2
-; CHECK-NEXT:    vo %v0, %v0, %v1
+; CHECK-NEXT:    vrepib %v1, 123
+; CHECK-NEXT:    vl %v2, 0(%r4), 3
+; CHECK-NEXT:    vslb %v0, %v0, %v1
+; CHECK-NEXT:    vrepib %v3, 5
+; CHECK-NEXT:    vsrl %v2, %v2, %v3
+; CHECK-NEXT:    vsl %v0, %v0, %v1
+; CHECK-NEXT:    vo %v0, %v0, %v2
 ; CHECK-NEXT:    vst %v0, 0(%r2), 3
 ; CHECK-NEXT:    br %r14
 ;
@@ -279,14 +279,14 @@ define i128 @f9(i128 %a, i128 %b) {
 define i128 @f10(i128 %a, i128 %b) {
 ; CHECK-LABEL: f10:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vl %v1, 0(%r3), 3
 ; CHECK-NEXT:    vl %v0, 0(%r4), 3
-; CHECK-NEXT:    vrepib %v2, 5
-; CHECK-NEXT:    vsl %v1, %v1, %v2
-; CHECK-NEXT:    vrepib %v2, 123
-; CHECK-NEXT:    vsrlb %v0, %v0, %v2
-; CHECK-NEXT:    vsrl %v0, %v0, %v2
-; CHECK-NEXT:    vo %v0, %v1, %v0
+; CHECK-NEXT:    vrepib %v1, 123
+; CHECK-NEXT:    vl %v2, 0(%r3), 3
+; CHECK-NEXT:    vsrlb %v0, %v0, %v1
+; CHECK-NEXT:    vrepib %v3, 5
+; CHECK-NEXT:    vsl %v2, %v2, %v3
+; CHECK-NEXT:    vsrl %v0, %v0, %v1
+; CHECK-NEXT:    vo %v0, %v2, %v0
 ; CHECK-NEXT:    vst %v0, 0(%r2), 3
 ; CHECK-NEXT:    br %r14
 ;

--- a/llvm/test/CodeGen/SystemZ/soft-float-args.ll
+++ b/llvm/test/CodeGen/SystemZ/soft-float-args.ll
@@ -56,8 +56,9 @@ define fp128 @f2_fp128(fp128 %arg) {
 define <2 x double> @f3(<2 x double> %arg) {
 ; CHECK-LABEL: f3:
 ; CHECK-NOT: %{{[fv]}}
-; CHECK: lg      %r13, 8(%r2)
-; CHECK-NEXT: lg      %r2, 0(%r2)
+; CHECK: lg      %r0, 0(%r2)
+; CHECK-NEXT: lg      %r13, 8(%r2)
+; CHECK-NEXT: lgr     %r2, %r0
 ; CHECK-NEXT: llihh   %r3, 16368
 ; CHECK-NEXT: brasl   %r14, __adddf3@PLT
 ; CHECK-NEXT: lgr     %r12, %r2
@@ -156,10 +157,11 @@ define <2 x double> @f9(<2 x double> %A, <2 x double> %B, <2 x double> %C,
 ; CHECK: aghi    %r15, -160
 ; CHECK-NEXT: .cfi_def_cfa_offset 320
 ; CHECK-NEXT: lg      %r1, 344(%r15)
-; CHECK-NEXT: lg      %r13, 8(%r2)
-; CHECK-NEXT: lg      %r2, 0(%r2)
+; CHECK-NEXT: lg      %r0, 0(%r2)
 ; CHECK-NEXT: lg      %r3, 0(%r1)
+; CHECK-NEXT: lg      %r13, 8(%r2)
 ; CHECK-NEXT: lg      %r12, 8(%r1)
+; CHECK-NEXT: lgr     %r2, %r0
 ; CHECK-NEXT: brasl   %r14, __adddf3@PLT
 ; CHECK-NEXT: lgr     %r11, %r2
 ; CHECK-NEXT: lgr     %r2, %r13

--- a/llvm/test/CodeGen/SystemZ/store_nonbytesized_vecs.ll
+++ b/llvm/test/CodeGen/SystemZ/store_nonbytesized_vecs.ll
@@ -5,34 +5,34 @@
 define void @fun0(<4 x i31> %src, ptr %p)
 ; CHECK-LABEL: fun0:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vlgvf %r0, %v24, 0
-; CHECK-NEXT:    vlvgp %v0, %r0, %r0
-; CHECK-NEXT:    vrepib %v1, 93
 ; CHECK-NEXT:    vlgvf %r0, %v24, 1
-; CHECK-NEXT:    vslb %v0, %v0, %v1
-; CHECK-NEXT:    larl %r1, .LCPI0_0
-; CHECK-NEXT:    vl %v2, 0(%r1), 3
-; CHECK-NEXT:    vsl %v0, %v0, %v1
+; CHECK-NEXT:    vlgvf %r1, %v24, 0
+; CHECK-NEXT:    larl %r3, .LCPI0_0
+; CHECK-NEXT:    vlgvf %r4, %v24, 2
+; CHECK-NEXT:    vl %v0, 0(%r3), 3
 ; CHECK-NEXT:    vlvgp %v1, %r0, %r0
-; CHECK-NEXT:    vn %v1, %v1, %v2
-; CHECK-NEXT:    vrepib %v3, 62
-; CHECK-NEXT:    vslb %v1, %v1, %v3
-; CHECK-NEXT:    vlgvf %r0, %v24, 2
-; CHECK-NEXT:    vsl %v1, %v1, %v3
-; CHECK-NEXT:    vo %v0, %v0, %v1
-; CHECK-NEXT:    vlvgp %v1, %r0, %r0
-; CHECK-NEXT:    vn %v1, %v1, %v2
-; CHECK-NEXT:    vrepib %v3, 31
-; CHECK-NEXT:    vslb %v1, %v1, %v3
+; CHECK-NEXT:    vlvgp %v2, %r1, %r1
+; CHECK-NEXT:    vlvgp %v3, %r4, %r4
+; CHECK-NEXT:    vrepib %v4, 93
+; CHECK-NEXT:    vn %v1, %v1, %v0
+; CHECK-NEXT:    vrepib %v5, 62
+; CHECK-NEXT:    vslb %v2, %v2, %v4
+; CHECK-NEXT:    vslb %v1, %v1, %v5
+; CHECK-NEXT:    vn %v3, %v3, %v0
+; CHECK-NEXT:    vrepib %v6, 31
 ; CHECK-NEXT:    vlgvf %r0, %v24, 3
-; CHECK-NEXT:    vsl %v1, %v1, %v3
-; CHECK-NEXT:    vo %v0, %v0, %v1
-; CHECK-NEXT:    vlvgp %v1, %r0, %r0
+; CHECK-NEXT:    vslb %v3, %v3, %v6
+; CHECK-NEXT:    vsl %v2, %v2, %v4
+; CHECK-NEXT:    vsl %v1, %v1, %v5
+; CHECK-NEXT:    vlvgp %v4, %r0, %r0
 ; CHECK-NEXT:    larl %r1, .LCPI0_1
-; CHECK-NEXT:    vn %v1, %v1, %v2
-; CHECK-NEXT:    vo %v0, %v0, %v1
-; CHECK-NEXT:    vl %v1, 0(%r1), 3
-; CHECK-NEXT:    vn %v0, %v0, %v1
+; CHECK-NEXT:    vo %v1, %v2, %v1
+; CHECK-NEXT:    vsl %v2, %v3, %v6
+; CHECK-NEXT:    vo %v1, %v1, %v2
+; CHECK-NEXT:    vl %v2, 0(%r1), 3
+; CHECK-NEXT:    vn %v0, %v4, %v0
+; CHECK-NEXT:    vo %v0, %v1, %v0
+; CHECK-NEXT:    vn %v0, %v0, %v2
 ; CHECK-NEXT:    vst %v0, 0(%r2), 4
 ; CHECK-NEXT:    br %r14
 {
@@ -49,34 +49,34 @@ define i16 @fun1(<16 x i1> %src)
 ; CHECK-NEXT:    vlgvb %r0, %v24, 0
 ; CHECK-NEXT:    vlgvb %r1, %v24, 1
 ; CHECK-NEXT:    risblg %r0, %r0, 16, 144, 15
+; CHECK-NEXT:    vlgvb %r2, %v24, 2
 ; CHECK-NEXT:    rosbg %r0, %r1, 49, 49, 14
-; CHECK-NEXT:    vlgvb %r1, %v24, 2
-; CHECK-NEXT:    rosbg %r0, %r1, 50, 50, 13
 ; CHECK-NEXT:    vlgvb %r1, %v24, 3
+; CHECK-NEXT:    rosbg %r0, %r2, 50, 50, 13
+; CHECK-NEXT:    vlgvb %r2, %v24, 4
 ; CHECK-NEXT:    rosbg %r0, %r1, 51, 51, 12
-; CHECK-NEXT:    vlgvb %r1, %v24, 4
-; CHECK-NEXT:    rosbg %r0, %r1, 52, 52, 11
 ; CHECK-NEXT:    vlgvb %r1, %v24, 5
+; CHECK-NEXT:    rosbg %r0, %r2, 52, 52, 11
+; CHECK-NEXT:    vlgvb %r2, %v24, 6
 ; CHECK-NEXT:    rosbg %r0, %r1, 53, 53, 10
-; CHECK-NEXT:    vlgvb %r1, %v24, 6
-; CHECK-NEXT:    rosbg %r0, %r1, 54, 54, 9
 ; CHECK-NEXT:    vlgvb %r1, %v24, 7
+; CHECK-NEXT:    rosbg %r0, %r2, 54, 54, 9
+; CHECK-NEXT:    vlgvb %r2, %v24, 8
 ; CHECK-NEXT:    rosbg %r0, %r1, 55, 55, 8
-; CHECK-NEXT:    vlgvb %r1, %v24, 8
-; CHECK-NEXT:    rosbg %r0, %r1, 56, 56, 7
 ; CHECK-NEXT:    vlgvb %r1, %v24, 9
+; CHECK-NEXT:    rosbg %r0, %r2, 56, 56, 7
+; CHECK-NEXT:    vlgvb %r2, %v24, 10
 ; CHECK-NEXT:    rosbg %r0, %r1, 57, 57, 6
-; CHECK-NEXT:    vlgvb %r1, %v24, 10
-; CHECK-NEXT:    rosbg %r0, %r1, 58, 58, 5
 ; CHECK-NEXT:    vlgvb %r1, %v24, 11
+; CHECK-NEXT:    rosbg %r0, %r2, 58, 58, 5
+; CHECK-NEXT:    vlgvb %r2, %v24, 12
 ; CHECK-NEXT:    rosbg %r0, %r1, 59, 59, 4
-; CHECK-NEXT:    vlgvb %r1, %v24, 12
-; CHECK-NEXT:    rosbg %r0, %r1, 60, 60, 3
 ; CHECK-NEXT:    vlgvb %r1, %v24, 13
+; CHECK-NEXT:    rosbg %r0, %r2, 60, 60, 3
+; CHECK-NEXT:    vlgvb %r2, %v24, 14
 ; CHECK-NEXT:    rosbg %r0, %r1, 61, 61, 2
-; CHECK-NEXT:    vlgvb %r1, %v24, 14
-; CHECK-NEXT:    rosbg %r0, %r1, 62, 62, 1
 ; CHECK-NEXT:    vlgvb %r1, %v24, 15
+; CHECK-NEXT:    rosbg %r0, %r2, 62, 62, 1
 ; CHECK-NEXT:    rosbg %r0, %r1, 63, 63, 0
 ; CHECK-NEXT:    llhr %r2, %r0
 ; CHECK-NEXT:    aghi %r15, 168
@@ -179,9 +179,9 @@ define void @fun3(ptr %src, ptr %p)
 ; CHECK-NEXT:    vrepib %v2, 32
 ; CHECK-NEXT:    vslb %v0, %v0, %v2
 ; CHECK-NEXT:    vo %v0, %v1, %v0
+; CHECK-NEXT:    vsrlb %v1, %v0, %v2
 ; CHECK-NEXT:    vstef %v0, 8(%r3), 3
-; CHECK-NEXT:    vsrlb %v0, %v0, %v2
-; CHECK-NEXT:    vsteg %v0, 0(%r3), 1
+; CHECK-NEXT:    vsteg %v1, 0(%r3), 1
 ; CHECK-NEXT:    br %r14
 {
   %tmp = load <3 x i31>, ptr %src

--- a/llvm/test/CodeGen/SystemZ/vec-cmp-cmp-logic-select.ll
+++ b/llvm/test/CodeGen/SystemZ/vec-cmp-cmp-logic-select.ll
@@ -63,7 +63,7 @@ define <16 x i16> @fun3(<16 x i8> %val1, <16 x i8> %val2, <16 x i16> %val3, <16 
 ; CHECK-DAG:     vceqh [[REG4:%v[0-9]+]], %v30, %v27
 ; CHECK-DAG:     vl [[REG5:%v[0-9]+]], 176(%r15)
 ; CHECK-DAG:     vl [[REG6:%v[0-9]+]], 160(%r15)
-; CHECK-DAG:     vo [[REG7:%v[0-9]+]], %v2, [[REG4]]
+; CHECK-DAG:     vo [[REG7:%v[0-9]+]], %v0, [[REG4]]
 ; CHECK-DAG:     vo [[REG8:%v[0-9]+]], [[REG2]], [[REG3]]
 ; CHECK-DAG:     vsel %v24, %v29, [[REG6]], [[REG8]]
 ; CHECK-DAG:     vsel %v26, %v31, [[REG5]], [[REG7]]
@@ -117,10 +117,10 @@ define <2 x i8> @fun5(<2 x i16> %val1, <2 x i16> %val2, <2 x i8> %val3, <2 x i8>
 define <2 x i16> @fun6(<2 x i16> %val1, <2 x i16> %val2, <2 x i8> %val3, <2 x i8> %val4, <2 x i16> %val5, <2 x i16> %val6) {
 ; CHECK-LABEL: fun6:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vceqb %v1, %v28, %v30
-; CHECK-NEXT:    vceqh %v0, %v24, %v26
-; CHECK-NEXT:    vuphb %v1, %v1
-; CHECK-NEXT:    vo %v0, %v0, %v1
+; CHECK-NEXT:    vceqb %v0, %v28, %v30
+; CHECK-NEXT:    vceqh %v1, %v24, %v26
+; CHECK-NEXT:    vuphb %v0, %v0
+; CHECK-NEXT:    vo %v0, %v1, %v0
 ; CHECK-NEXT:    vsel %v24, %v25, %v27, %v0
 ; CHECK-NEXT:    br %r14
   %cmp0 = icmp eq <2 x i16> %val1, %val2
@@ -133,10 +133,10 @@ define <2 x i16> @fun6(<2 x i16> %val1, <2 x i16> %val2, <2 x i8> %val3, <2 x i8
 define <2 x i32> @fun7(<2 x i16> %val1, <2 x i16> %val2, <2 x i8> %val3, <2 x i8> %val4, <2 x i32> %val5, <2 x i32> %val6) {
 ; CHECK-LABEL: fun7:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vceqb %v1, %v28, %v30
-; CHECK-NEXT:    vceqh %v0, %v24, %v26
-; CHECK-NEXT:    vuphb %v1, %v1
-; CHECK-NEXT:    vo %v0, %v0, %v1
+; CHECK-NEXT:    vceqb %v0, %v28, %v30
+; CHECK-NEXT:    vceqh %v1, %v24, %v26
+; CHECK-NEXT:    vuphb %v0, %v0
+; CHECK-NEXT:    vo %v0, %v1, %v0
 ; CHECK-NEXT:    vuphh %v0, %v0
 ; CHECK-NEXT:    vsel %v24, %v25, %v27, %v0
 ; CHECK-NEXT:    br %r14
@@ -259,10 +259,10 @@ define <16 x i16> @fun12(<16 x i16> %val1, <16 x i16> %val2, <16 x i32> %val3, <
 define <2 x i16> @fun13(<2 x i32> %val1, <2 x i32> %val2, <2 x i64> %val3, <2 x i64> %val4, <2 x i16> %val5, <2 x i16> %val6) {
 ; CHECK-LABEL: fun13:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vceqg %v1, %v28, %v30
-; CHECK-NEXT:    vceqf %v0, %v24, %v26
-; CHECK-NEXT:    vpkg %v1, %v1, %v1
-; CHECK-NEXT:    vx %v0, %v0, %v1
+; CHECK-NEXT:    vceqg %v0, %v28, %v30
+; CHECK-NEXT:    vceqf %v1, %v24, %v26
+; CHECK-NEXT:    vpkg %v0, %v0, %v0
+; CHECK-NEXT:    vx %v0, %v1, %v0
 ; CHECK-NEXT:    vpkf %v0, %v0, %v0
 ; CHECK-NEXT:    vsel %v24, %v25, %v27, %v0
 ; CHECK-NEXT:    br %r14
@@ -276,10 +276,10 @@ define <2 x i16> @fun13(<2 x i32> %val1, <2 x i32> %val2, <2 x i64> %val3, <2 x 
 define <2 x i32> @fun14(<2 x i32> %val1, <2 x i32> %val2, <2 x i64> %val3, <2 x i64> %val4, <2 x i32> %val5, <2 x i32> %val6) {
 ; CHECK-LABEL: fun14:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vceqg %v1, %v28, %v30
-; CHECK-NEXT:    vceqf %v0, %v24, %v26
-; CHECK-NEXT:    vpkg %v1, %v1, %v1
-; CHECK-NEXT:    vx %v0, %v0, %v1
+; CHECK-NEXT:    vceqg %v0, %v28, %v30
+; CHECK-NEXT:    vceqf %v1, %v24, %v26
+; CHECK-NEXT:    vpkg %v0, %v0, %v0
+; CHECK-NEXT:    vx %v0, %v1, %v0
 ; CHECK-NEXT:    vsel %v24, %v25, %v27, %v0
 ; CHECK-NEXT:    br %r14
   %cmp0 = icmp eq <2 x i32> %val1, %val2
@@ -324,10 +324,10 @@ define <4 x i16> @fun16(<4 x i32> %val1, <4 x i32> %val2, <4 x i16> %val3, <4 x 
 define <4 x i32> @fun17(<4 x i32> %val1, <4 x i32> %val2, <4 x i16> %val3, <4 x i16> %val4, <4 x i32> %val5, <4 x i32> %val6) {
 ; CHECK-LABEL: fun17:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vceqh %v1, %v28, %v30
-; CHECK-NEXT:    vceqf %v0, %v24, %v26
-; CHECK-NEXT:    vuphh %v1, %v1
-; CHECK-NEXT:    vn %v0, %v0, %v1
+; CHECK-NEXT:    vceqh %v0, %v28, %v30
+; CHECK-NEXT:    vceqf %v1, %v24, %v26
+; CHECK-NEXT:    vuphh %v0, %v0
+; CHECK-NEXT:    vn %v0, %v1, %v0
 ; CHECK-NEXT:    vsel %v24, %v25, %v27, %v0
 ; CHECK-NEXT:    br %r14
   %cmp0 = icmp eq <4 x i32> %val1, %val2
@@ -340,10 +340,10 @@ define <4 x i32> @fun17(<4 x i32> %val1, <4 x i32> %val2, <4 x i16> %val3, <4 x 
 define <4 x i64> @fun18(<4 x i32> %val1, <4 x i32> %val2, <4 x i16> %val3, <4 x i16> %val4, <4 x i64> %val5, <4 x i64> %val6) {
 ; CHECK-LABEL: fun18:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vceqh %v1, %v28, %v30
-; CHECK-NEXT:    vceqf %v0, %v24, %v26
-; CHECK-NEXT:    vuphh %v1, %v1
-; CHECK-NEXT:    vn %v0, %v0, %v1
+; CHECK-NEXT:    vceqh %v0, %v28, %v30
+; CHECK-NEXT:    vceqf %v1, %v24, %v26
+; CHECK-NEXT:    vuphh %v0, %v0
+; CHECK-NEXT:    vn %v0, %v1, %v0
 ; CHECK-DAG:     vuphf [[REG0:%v[0-9]+]], %v0
 ; CHECK-DAG:     vuplf [[REG1:%v[0-9]+]], %v0
 ; CHECK-NEXT:    vsel %v24, %v25, %v29, [[REG0]]
@@ -475,27 +475,27 @@ define <2 x float> @fun25(<2 x float> %val1, <2 x float> %val2, <2 x double> %va
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    vmrlf %v0, %v26, %v26
 ; CHECK-NEXT:    vmrlf %v1, %v24, %v24
+; CHECK-NEXT:    vmrhf %v2, %v26, %v26
+; CHECK-NEXT:    vmrhf %v3, %v24, %v24
 ; CHECK-NEXT:    vldeb %v0, %v0
 ; CHECK-NEXT:    vldeb %v1, %v1
-; CHECK-NEXT:    vfchdb %v0, %v1, %v0
-; CHECK-NEXT:    vmrhf %v1, %v26, %v26
-; CHECK-NEXT:    vmrhf %v2, %v24, %v24
-; CHECK-NEXT:    vldeb %v1, %v1
 ; CHECK-NEXT:    vldeb %v2, %v2
-; CHECK-NEXT:    vfchdb %v1, %v2, %v1
+; CHECK-NEXT:    vldeb %v3, %v3
+; CHECK-NEXT:    vfchdb %v0, %v1, %v0
+; CHECK-NEXT:    vfchdb %v1, %v3, %v2
+; CHECK-NEXT:    vfchdb %v2, %v28, %v30
 ; CHECK-NEXT:    vpkg %v0, %v1, %v0
-; CHECK-NEXT:    vfchdb %v1, %v28, %v30
-; CHECK-NEXT:    vpkg %v1, %v1, %v1
+; CHECK-NEXT:    vpkg %v1, %v2, %v2
 ; CHECK-NEXT:    vo %v0, %v0, %v1
 ; CHECK-NEXT:    vsel %v24, %v25, %v27, %v0
 ; CHECK-NEXT:    br %r14
 ;
 ; CHECK-Z14-LABEL: fun25:
 ; CHECK-Z14:       # %bb.0:
-; CHECK-Z14-NEXT:    vfchdb %v1, %v28, %v30
-; CHECK-Z14-NEXT:    vfchsb %v0, %v24, %v26
-; CHECK-Z14-NEXT:    vpkg %v1, %v1, %v1
-; CHECK-Z14-NEXT:    vo %v0, %v0, %v1
+; CHECK-Z14-NEXT:    vfchdb %v0, %v28, %v30
+; CHECK-Z14-NEXT:    vfchsb %v1, %v24, %v26
+; CHECK-Z14-NEXT:    vpkg %v0, %v0, %v0
+; CHECK-Z14-NEXT:    vo %v0, %v1, %v0
 ; CHECK-Z14-NEXT:    vsel %v24, %v25, %v27, %v0
 ; CHECK-Z14-NEXT:    br %r14
   %cmp0 = fcmp ogt <2 x float> %val1, %val2
@@ -510,14 +510,14 @@ define <2 x double> @fun26(<2 x float> %val1, <2 x float> %val2, <2 x double> %v
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    vmrlf %v0, %v26, %v26
 ; CHECK-NEXT:    vmrlf %v1, %v24, %v24
+; CHECK-NEXT:    vmrhf %v2, %v26, %v26
+; CHECK-NEXT:    vmrhf %v3, %v24, %v24
 ; CHECK-NEXT:    vldeb %v0, %v0
 ; CHECK-NEXT:    vldeb %v1, %v1
-; CHECK-NEXT:    vfchdb %v0, %v1, %v0
-; CHECK-NEXT:    vmrhf %v1, %v26, %v26
-; CHECK-NEXT:    vmrhf %v2, %v24, %v24
-; CHECK-NEXT:    vldeb %v1, %v1
 ; CHECK-NEXT:    vldeb %v2, %v2
-; CHECK-NEXT:    vfchdb %v1, %v2, %v1
+; CHECK-NEXT:    vldeb %v3, %v3
+; CHECK-NEXT:    vfchdb %v0, %v1, %v0
+; CHECK-NEXT:    vfchdb %v1, %v3, %v2
 ; CHECK-NEXT:    vpkg %v0, %v1, %v0
 ; CHECK-NEXT:    vuphf %v0, %v0
 ; CHECK-NEXT:    vfchdb %v1, %v28, %v30
@@ -581,8 +581,8 @@ define <4 x float> @fun28(<4 x float> %val1, <4 x float> %val2, <4 x float> %val
 ; CHECK-DAG:     vmrhf [[REG17:%v[0-9]+]], %v30, %v30
 ; CHECK-DAG:     vldeb [[REG19:%v[0-9]+]], [[REG17]]
 ; CHECK-DAG:     vldeb [[REG20:%v[0-9]+]], [[REG8]]
-; CHECK-NEXT:    vfchdb %v2, [[REG20]], [[REG19]]
-; CHECK-NEXT:    vpkg [[REG21:%v[0-9]+]], %v2, [[REG16]]
+; CHECK-NEXT:    vfchdb %v3, [[REG20]], [[REG19]]
+; CHECK-NEXT:    vpkg [[REG21:%v[0-9]+]], %v3, [[REG16]]
 ; CHECK-NEXT:    vx %v0, [[REG11]], [[REG21]]
 ; CHECK-NEXT:    vsel %v24, %v25, %v27, %v0
 ; CHECK-NEXT:    br %r14
@@ -606,26 +606,26 @@ define <4 x double> @fun29(<4 x float> %val1, <4 x float> %val2, <4 x float> %va
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    vmrlf %v0, %v26, %v26
 ; CHECK-NEXT:    vmrlf %v1, %v24, %v24
+; CHECK-NEXT:    vmrhf %v2, %v26, %v26
+; CHECK-NEXT:    vmrhf %v3, %v24, %v24
+; CHECK-NEXT:    vmrlf %v4, %v30, %v30
+; CHECK-NEXT:    vmrlf %v5, %v28, %v28
+; CHECK-NEXT:    vmrhf %v6, %v30, %v30
+; CHECK-NEXT:    vmrhf %v7, %v28, %v28
 ; CHECK-NEXT:    vldeb %v0, %v0
 ; CHECK-NEXT:    vldeb %v1, %v1
 ; CHECK-NEXT:    vfchdb %v0, %v1, %v0
-; CHECK-NEXT:    vmrhf %v1, %v26, %v26
-; CHECK-NEXT:    vmrhf %v2, %v24, %v24
-; CHECK-NEXT:    vldeb %v1, %v1
-; CHECK-NEXT:    vmrhf %v3, %v28, %v28
-; CHECK-NEXT:    vldeb %v2, %v2
-; CHECK-NEXT:    vfchdb %v1, %v2, %v1
-; CHECK-NEXT:    vpkg %v0, %v1, %v0
-; CHECK-NEXT:    vmrlf %v1, %v30, %v30
-; CHECK-NEXT:    vmrlf %v2, %v28, %v28
-; CHECK-NEXT:    vldeb %v1, %v1
-; CHECK-NEXT:    vldeb %v2, %v2
-; CHECK-NEXT:    vfchdb %v1, %v2, %v1
-; CHECK-NEXT:    vmrhf %v2, %v30, %v30
 ; CHECK-NEXT:    vldeb %v2, %v2
 ; CHECK-NEXT:    vldeb %v3, %v3
-; CHECK-NEXT:    vfchdb %v2, %v3, %v2
-; CHECK-NEXT:    vpkg %v1, %v2, %v1
+; CHECK-NEXT:    vfchdb %v1, %v3, %v2
+; CHECK-NEXT:    vpkg %v0, %v1, %v0
+; CHECK-NEXT:    vldeb %v4, %v4
+; CHECK-NEXT:    vldeb %v5, %v5
+; CHECK-NEXT:    vfchdb %v2, %v5, %v4
+; CHECK-NEXT:    vldeb %v6, %v6
+; CHECK-NEXT:    vldeb %v7, %v7
+; CHECK-NEXT:    vfchdb %v3, %v7, %v6
+; CHECK-NEXT:    vpkg %v1, %v3, %v2
 ; CHECK-NEXT:    vx %v0, %v0, %v1
 ; CHECK-NEXT:    vuplf %v1, %v0
 ; CHECK-NEXT:    vuphf %v0, %v0
@@ -653,71 +653,71 @@ define <4 x double> @fun29(<4 x float> %val1, <4 x float> %val2, <4 x float> %va
 define <8 x float> @fun30(<8 x float> %val1, <8 x float> %val2, <8 x double> %val3, <8 x double> %val4, <8 x float> %val5, <8 x float> %val6) {
 ; CHECK-LABEL: fun30:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vmrlf %v16, %v28, %v28
-; CHECK-NEXT:    vmrlf %v17, %v24, %v24
-; CHECK-NEXT:    vldeb %v16, %v16
-; CHECK-NEXT:    vldeb %v17, %v17
-; CHECK-NEXT:    vfchdb %v16, %v17, %v16
-; CHECK-NEXT:    vmrhf %v17, %v28, %v28
-; CHECK-NEXT:    vmrhf %v18, %v24, %v24
-; CHECK-NEXT:    vldeb %v17, %v17
-; CHECK-NEXT:    vl %v4, 192(%r15)
-; CHECK-NEXT:    vldeb %v18, %v18
-; CHECK-NEXT:    vl %v5, 208(%r15)
-; CHECK-NEXT:    vl %v6, 160(%r15)
-; CHECK-NEXT:    vl %v7, 176(%r15)
-; CHECK-NEXT:    vl %v0, 272(%r15)
-; CHECK-NEXT:    vl %v1, 240(%r15)
-; CHECK-NEXT:    vfchdb %v17, %v18, %v17
-; CHECK-NEXT:    vl %v2, 256(%r15)
-; CHECK-NEXT:    vl %v3, 224(%r15)
-; CHECK-NEXT:    vpkg %v16, %v17, %v16
-; CHECK-NEXT:    vmrlf %v17, %v30, %v30
-; CHECK-NEXT:    vmrlf %v18, %v26, %v26
-; CHECK-NEXT:    vmrhf %v19, %v26, %v26
-; CHECK-NEXT:    vfchdb %v7, %v27, %v7
-; CHECK-NEXT:    vfchdb %v6, %v25, %v6
-; CHECK-NEXT:    vfchdb %v5, %v31, %v5
-; CHECK-NEXT:    vfchdb %v4, %v29, %v4
-; CHECK-NEXT:    vpkg %v6, %v6, %v7
-; CHECK-NEXT:    vpkg %v4, %v4, %v5
-; CHECK-NEXT:    vn %v5, %v16, %v6
-; CHECK-DAG:     vsel %v24, %v3, %v2, %v5
-; CHECK-DAG:     vldeb %v17, %v17
-; CHECK-NEXT:    vldeb %v18, %v18
-; CHECK-NEXT:    vfchdb %v17, %v18, %v17
-; CHECK-NEXT:    vmrhf %v18, %v30, %v30
-; CHECK-NEXT:    vldeb %v18, %v18
-; CHECK-NEXT:    vldeb %v19, %v19
-; CHECK-NEXT:    vfchdb %v18, %v19, %v18
-; CHECK-NEXT:    vpkg %v17, %v18, %v17
-; CHECK-NEXT:    vn %v4, %v17, %v4
-; CHECK-NEXT:    vsel %v26, %v1, %v0, %v4
-; CHECK-NEXT:    br %r14
+; CHECK-NEXT:    vmrlf   %v0, %v28, %v28
+; CHECK-NEXT:    vmrlf   %v1, %v24, %v24
+; CHECK-NEXT:    vmrhf   %v2, %v28, %v28
+; CHECK-NEXT:    vmrhf   %v3, %v24, %v24
+; CHECK-NEXT:    vmrlf   %v4, %v30, %v30
+; CHECK-NEXT:    vmrlf   %v5, %v26, %v26
+; CHECK-NEXT:    vmrhf   %v6, %v30, %v30
+; CHECK-NEXT:    vmrhf   %v7, %v26, %v26
+; CHECK-NEXT:    vldeb   %v0, %v0
+; CHECK-NEXT:    vldeb   %v1, %v1
+; CHECK-NEXT:    vl      %v16, 192(%r15), 3
+; CHECK-NEXT:    vl      %v17, 208(%r15), 3
+; CHECK-NEXT:    vldeb   %v2, %v2
+; CHECK-NEXT:    vl      %v18, 160(%r15), 3
+; CHECK-NEXT:    vl      %v19, 176(%r15), 3
+; CHECK-NEXT:    vfchdb  %v0, %v1, %v0
+; CHECK-NEXT:    vldeb   %v3, %v3
+; CHECK-NEXT:    vfchdb  %v1, %v3, %v2
+; CHECK-NEXT:    vpkg    %v0, %v1, %v0
+; CHECK-NEXT:    vldeb   %v4, %v4
+; CHECK-NEXT:    vldeb   %v5, %v5
+; CHECK-NEXT:    vfchdb  %v2, %v5, %v4
+; CHECK-NEXT:    vfchdb  %v4, %v27, %v19
+; CHECK-NEXT:    vfchdb  %v5, %v25, %v18
+; CHECK-NEXT:    vldeb   %v6, %v6
+; CHECK-NEXT:    vldeb   %v7, %v7
+; CHECK-NEXT:    vfchdb  %v3, %v7, %v6
+; CHECK-NEXT:    vfchdb  %v6, %v31, %v17
+; CHECK-NEXT:    vfchdb  %v7, %v29, %v16
+; CHECK-NEXT:    vl      %v16, 224(%r15), 3
+; CHECK-NEXT:    vpkg    %v1, %v3, %v2
+; CHECK-NEXT:    vl      %v3, 272(%r15), 3
+; CHECK-NEXT:    vpkg    %v2, %v5, %v4
+; CHECK-NEXT:    vl      %v4, 240(%r15), 3
+; CHECK-NEXT:    vl      %v5, 256(%r15), 3
+; CHECK-NEXT:    vpkg    %v6, %v7, %v6
+; CHECK-NEXT:    vn      %v1, %v1, %v6
+; CHECK-NEXT:    vn      %v0, %v0, %v2
+; CHECK-NEXT:    vsel    %v24, %v16, %v5, %v0
+; CHECK-NEXT:    vsel    %v26, %v4, %v3, %v1
+; CHECK-NEXT:    br      %r14
 ;
 ; CHECK-Z14-LABEL: fun30:
 ; CHECK-Z14:       # %bb.0:
-; CHECK-Z14-NEXT:    vl %v4, 192(%r15)
-; CHECK-Z14-NEXT:    vl %v5, 208(%r15)
-; CHECK-Z14-NEXT:    vl %v6, 160(%r15)
-; CHECK-Z14-NEXT:    vl %v7, 176(%r15)
-; CHECK-Z14-NEXT:    vfchdb %v7, %v27, %v7
-; CHECK-Z14-NEXT:    vfchdb %v6, %v25, %v6
-; CHECK-Z14-NEXT:    vfchdb %v5, %v31, %v5
-; CHECK-Z14-NEXT:    vfchdb %v4, %v29, %v4
-; CHECK-Z14-DAG:     vfchsb %v16, %v24, %v28
-; CHECK-Z14-DAG:     vfchsb %v17, %v26, %v30
-; CHECK-Z14-DAG:     vpkg %v6, %v6, %v7
-; CHECK-Z14-DAG:     vpkg %v4, %v4, %v5
-; CHECK-Z14-DAG:     vl %v0, 272(%r15)
-; CHECK-Z14-DAG:     vl %v1, 240(%r15)
-; CHECK-Z14-DAG:     vl %v2, 256(%r15)
-; CHECK-Z14-DAG:     vl %v3, 224(%r15)
-; CHECK-Z14-NEXT:    vn %v4, %v17, %v4
-; CHECK-Z14-NEXT:    vn %v5, %v16, %v6
-; CHECK-Z14-NEXT:    vsel %v24, %v3, %v2, %v5
-; CHECK-Z14-NEXT:    vsel %v26, %v1, %v0, %v4
-; CHECK-Z14-NEXT:    br %r14
+; CHECK-Z14-NEXT:    vl      %v0, 192(%r15), 3
+; CHECK-Z14-NEXT:    vl      %v1, 208(%r15), 3
+; CHECK-Z14-NEXT:    vl      %v2, 160(%r15), 3
+; CHECK-Z14-NEXT:    vl      %v3, 176(%r15), 3
+; CHECK-Z14-NEXT:    vfchdb  %v3, %v27, %v3
+; CHECK-Z14-NEXT:    vfchdb  %v2, %v25, %v2
+; CHECK-Z14-NEXT:    vfchdb  %v1, %v31, %v1
+; CHECK-Z14-NEXT:    vfchdb  %v0, %v29, %v0
+; CHECK-Z14-NEXT:    vl      %v4, 272(%r15), 3
+; CHECK-Z14-NEXT:    vl      %v5, 240(%r15), 3
+; CHECK-Z14-NEXT:    vl      %v6, 256(%r15), 3
+; CHECK-Z14-NEXT:    vl      %v7, 224(%r15), 3
+; CHECK-Z14-NEXT:    vfchsb  %v16, %v24, %v28
+; CHECK-Z14-NEXT:    vfchsb  %v17, %v26, %v30
+; CHECK-Z14-NEXT:    vpkg    %v2, %v2, %v3
+; CHECK-Z14-NEXT:    vpkg    %v0, %v0, %v1
+; CHECK-Z14-NEXT:    vn      %v0, %v17, %v0
+; CHECK-Z14-NEXT:    vn      %v1, %v16, %v2
+; CHECK-Z14-NEXT:    vsel    %v24, %v7, %v6, %v1
+; CHECK-Z14-NEXT:    vsel    %v26, %v5, %v4, %v0
+; CHECK-Z14-NEXT:    br      %r14
   %cmp0 = fcmp ogt <8 x float> %val1, %val2
   %cmp1 = fcmp ogt <8 x double> %val3, %val4
   %and = and <8 x i1> %cmp0, %cmp1
@@ -759,22 +759,22 @@ define <2 x double> @fun32(<2 x double> %val1, <2 x double> %val2, <2 x double> 
 define <4 x float> @fun33(<4 x double> %val1, <4 x double> %val2, <4 x float> %val3, <4 x float> %val4, <4 x float> %val5, <4 x float> %val6) {
 ; CHECK-LABEL: fun33:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vfchdb %v0, %v26, %v30
-; CHECK-NEXT:    vfchdb %v1, %v24, %v28
-; CHECK-NEXT:    vpkg %v0, %v1, %v0
-; CHECK-NEXT:    vmrlf %v1, %v27, %v27
-; CHECK-NEXT:    vmrlf %v2, %v25, %v25
-; CHECK-NEXT:    vldeb %v1, %v1
-; CHECK-NEXT:    vldeb %v2, %v2
-; CHECK-NEXT:    vfchdb %v1, %v2, %v1
-; CHECK-NEXT:    vmrhf %v2, %v27, %v27
-; CHECK-NEXT:    vmrhf %v3, %v25, %v25
-; CHECK-NEXT:    vldeb %v2, %v2
-; CHECK-NEXT:    vldeb %v3, %v3
-; CHECK-NEXT:    vfchdb %v2, %v3, %v2
-; CHECK-NEXT:    vpkg %v1, %v2, %v1
-; CHECK-NEXT:    vn %v0, %v0, %v1
-; CHECK-NEXT:    vsel %v24, %v29, %v31, %v0
+; CHECK-NEXT:    vmrlf   %v0, %v27, %v27
+; CHECK-NEXT:    vmrlf   %v1, %v25, %v25
+; CHECK-NEXT:    vmrhf   %v2, %v27, %v27
+; CHECK-NEXT:    vmrhf   %v3, %v25, %v25
+; CHECK-NEXT:    vldeb   %v0, %v0
+; CHECK-NEXT:    vldeb   %v1, %v1
+; CHECK-NEXT:    vldeb   %v2, %v2
+; CHECK-NEXT:    vldeb   %v3, %v3
+; CHECK-NEXT:    vfchdb  %v4, %v26, %v30
+; CHECK-NEXT:    vfchdb  %v5, %v24, %v28
+; CHECK-NEXT:    vfchdb  %v0, %v1, %v0
+; CHECK-NEXT:    vfchdb  %v1, %v3, %v2
+; CHECK-NEXT:    vpkg    %v2, %v5, %v4
+; CHECK-NEXT:    vpkg    %v0, %v1, %v0
+; CHECK-NEXT:    vn      %v0, %v2, %v0
+; CHECK-NEXT:    vsel    %v24, %v29, %v31, %v0
 ; CHECK-NEXT:    br %r14
 ;
 ; CHECK-Z14-LABEL: fun33:
@@ -796,43 +796,43 @@ define <4 x float> @fun33(<4 x double> %val1, <4 x double> %val2, <4 x float> %v
 define <4 x double> @fun34(<4 x double> %val1, <4 x double> %val2, <4 x float> %val3, <4 x float> %val4, <4 x double> %val5, <4 x double> %val6) {
 ; CHECK-LABEL: fun34:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vmrlf [[REG0:%v[0-9]+]], %v27, %v27
-; CHECK-NEXT:    vmrlf [[REG1:%v[0-9]+]], %v25, %v25
-; CHECK-NEXT:    vldeb [[REG2:%v[0-9]+]], [[REG0]]
-; CHECK-NEXT:    vldeb [[REG3:%v[0-9]+]], [[REG1]]
-; CHECK-NEXT:    vfchdb [[REG4:%v[0-9]+]], [[REG3]], [[REG2]]
-; CHECK-NEXT:    vmrhf [[REG5:%v[0-9]+]], %v27, %v27
-; CHECK-NEXT:    vmrhf [[REG6:%v[0-9]+]], %v25, %v25
-; CHECK-DAG:     vldeb [[REG7:%v[0-9]+]], [[REG5]]
-; CHECK-DAG:     vl [[REG8:%v[0-9]+]], 176(%r15)
-; CHECK-DAG:     vldeb [[REG9:%v[0-9]+]], [[REG6]]
-; CHECK-DAG:     vl [[REG10:%v[0-9]+]], 160(%r15)
-; CHECK-DAG:     vfchdb [[REG11:%v[0-9]+]], [[REG9]], [[REG7]]
-; CHECK-DAG:     vpkg [[REG12:%v[0-9]+]], [[REG11]], [[REG4]]
-; CHECK-DAG:     vuphf [[REG13:%v[0-9]+]], [[REG12]]
-; CHECK-DAG:     vuplf [[REG14:%v[0-9]+]], [[REG12]]
-; CHECK-DAG:     vfchdb [[REG15:%v[0-9]+]], %v24, %v28
-; CHECK-DAG:     vfchdb [[REG16:%v[0-9]+]], %v26, %v30
-; CHECK-NEXT:    vn [[REG18:%v[0-9]+]], [[REG16]], [[REG14]]
-; CHECK-NEXT:    vn [[REG19:%v[0-9]+]], [[REG15]], [[REG13]]
-; CHECK-NEXT:    vsel %v24, %v29, [[REG10]], [[REG19]]
-; CHECK-NEXT:    vsel %v26, %v31, [[REG8]], [[REG18]]
-; CHECK-NEXT:    br %r14
+; CHECK-NEXT:    vmrlf   %v0, %v27, %v27
+; CHECK-NEXT:    vmrlf   %v1, %v25, %v25
+; CHECK-NEXT:    vmrhf   %v2, %v27, %v27
+; CHECK-NEXT:    vmrhf   %v3, %v25, %v25
+; CHECK-NEXT:    vldeb   %v0, %v0
+; CHECK-NEXT:    vldeb   %v1, %v1
+; CHECK-NEXT:    vldeb   %v2, %v2
+; CHECK-NEXT:    vldeb   %v3, %v3
+; CHECK-NEXT:    vfchdb  %v0, %v1, %v0
+; CHECK-NEXT:    vfchdb  %v1, %v3, %v2
+; CHECK-NEXT:    vl      %v2, 160(%r15), 3
+; CHECK-NEXT:    vpkg    %v0, %v1, %v0
+; CHECK-NEXT:    vl      %v1, 176(%r15), 3
+; CHECK-NEXT:    vfchdb  %v3, %v24, %v28
+; CHECK-NEXT:    vfchdb  %v4, %v26, %v30
+; CHECK-NEXT:    vuphf   %v5, %v0
+; CHECK-NEXT:    vuplf   %v0, %v0
+; CHECK-NEXT:    vn      %v0, %v4, %v0
+; CHECK-NEXT:    vn      %v3, %v3, %v5
+; CHECK-NEXT:    vsel    %v24, %v29, %v2, %v3
+; CHECK-NEXT:    vsel    %v26, %v31, %v1, %v0
+; CHECK-NEXT:    br      %r14
 ;
 ; CHECK-Z14-LABEL: fun34:
 ; CHECK-Z14:       # %bb.0:
-; CHECK-Z14-NEXT:    vfchsb %v4, %v25, %v27
-; CHECK-Z14-NEXT:    vl %v0, 176(%r15)
-; CHECK-Z14-NEXT:    vl %v1, 160(%r15)
-; CHECK-Z14-NEXT:    vfchdb %v2, %v24, %v28
-; CHECK-Z14-NEXT:    vfchdb %v3, %v26, %v30
-; CHECK-Z14-NEXT:    vuphf %v5, %v4
-; CHECK-Z14-NEXT:    vuplf %v4, %v4
-; CHECK-Z14-NEXT:    vn %v3, %v3, %v4
-; CHECK-Z14-NEXT:    vn %v2, %v2, %v5
-; CHECK-Z14-NEXT:    vsel %v24, %v29, %v1, %v2
-; CHECK-Z14-NEXT:    vsel %v26, %v31, %v0, %v3
-; CHECK-Z14-NEXT:    br %r14
+; CHECK-Z14-NEXT:    vfchsb  %v0, %v25, %v27
+; CHECK-Z14-NEXT:    vl      %v1, 176(%r15), 3
+; CHECK-Z14-NEXT:    vl      %v2, 160(%r15), 3
+; CHECK-Z14-NEXT:    vfchdb  %v3, %v24, %v28
+; CHECK-Z14-NEXT:    vfchdb  %v4, %v26, %v30
+; CHECK-Z14-NEXT:    vuphf   %v5, %v0
+; CHECK-Z14-NEXT:    vuplf   %v0, %v0
+; CHECK-Z14-NEXT:    vn      %v0, %v4, %v0
+; CHECK-Z14-NEXT:    vn      %v3, %v3, %v5
+; CHECK-Z14-NEXT:    vsel    %v24, %v29, %v2, %v3
+; CHECK-Z14-NEXT:    vsel    %v26, %v31, %v1, %v0
+; CHECK-Z14-NEXT:    br      %r14
   %cmp0 = fcmp ogt <4 x double> %val1, %val2
   %cmp1 = fcmp ogt <4 x float> %val3, %val4
   %and = and <4 x i1> %cmp0, %cmp1

--- a/llvm/test/CodeGen/SystemZ/vec-cmpsel-01.ll
+++ b/llvm/test/CodeGen/SystemZ/vec-cmpsel-01.ll
@@ -315,14 +315,14 @@ define <2 x float> @fun25(<2 x float> %val1, <2 x float> %val2, <2 x float> %val
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    vmrlf %v0, %v26, %v26
 ; CHECK-NEXT:    vmrlf %v1, %v24, %v24
+; CHECK-NEXT:    vmrhf %v2, %v26, %v26
+; CHECK-NEXT:    vmrhf %v3, %v24, %v24
 ; CHECK-NEXT:    vldeb %v0, %v0
 ; CHECK-NEXT:    vldeb %v1, %v1
-; CHECK-NEXT:    vfchdb %v0, %v1, %v0
-; CHECK-NEXT:    vmrhf %v1, %v26, %v26
-; CHECK-NEXT:    vmrhf %v2, %v24, %v24
-; CHECK-NEXT:    vldeb %v1, %v1
 ; CHECK-NEXT:    vldeb %v2, %v2
-; CHECK-NEXT:    vfchdb %v1, %v2, %v1
+; CHECK-NEXT:    vldeb %v3, %v3
+; CHECK-NEXT:    vfchdb %v0, %v1, %v0
+; CHECK-NEXT:    vfchdb %v1, %v3, %v2
 ; CHECK-NEXT:    vpkg %v0, %v1, %v0
 ; CHECK-NEXT:    vsel %v24, %v28, %v30, %v0
 ; CHECK-NEXT:    br %r14
@@ -336,14 +336,14 @@ define <2 x double> @fun26(<2 x float> %val1, <2 x float> %val2, <2 x double> %v
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    vmrlf %v0, %v26, %v26
 ; CHECK-NEXT:    vmrlf %v1, %v24, %v24
+; CHECK-NEXT:    vmrhf %v2, %v26, %v26
+; CHECK-NEXT:    vmrhf %v3, %v24, %v24
 ; CHECK-NEXT:    vldeb %v0, %v0
 ; CHECK-NEXT:    vldeb %v1, %v1
-; CHECK-NEXT:    vfchdb %v0, %v1, %v0
-; CHECK-NEXT:    vmrhf %v1, %v26, %v26
-; CHECK-NEXT:    vmrhf %v2, %v24, %v24
-; CHECK-NEXT:    vldeb %v1, %v1
 ; CHECK-NEXT:    vldeb %v2, %v2
-; CHECK-NEXT:    vfchdb %v1, %v2, %v1
+; CHECK-NEXT:    vldeb %v3, %v3
+; CHECK-NEXT:    vfchdb %v0, %v1, %v0
+; CHECK-NEXT:    vfchdb %v1, %v3, %v2
 ; CHECK-NEXT:    vpkg %v0, %v1, %v0
 ; CHECK-NEXT:    vuphf %v0, %v0
 ; CHECK-NEXT:    vsel %v24, %v28, %v30, %v0
@@ -373,14 +373,14 @@ define <4 x float> @fun28(<4 x float> %val1, <4 x float> %val2, <4 x float> %val
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    vmrlf %v0, %v26, %v26
 ; CHECK-NEXT:    vmrlf %v1, %v24, %v24
+; CHECK-NEXT:    vmrhf %v2, %v26, %v26
+; CHECK-NEXT:    vmrhf %v3, %v24, %v24
 ; CHECK-NEXT:    vldeb %v0, %v0
 ; CHECK-NEXT:    vldeb %v1, %v1
-; CHECK-NEXT:    vfchdb %v0, %v1, %v0
-; CHECK-NEXT:    vmrhf %v1, %v26, %v26
-; CHECK-NEXT:    vmrhf %v2, %v24, %v24
-; CHECK-NEXT:    vldeb %v1, %v1
 ; CHECK-NEXT:    vldeb %v2, %v2
-; CHECK-NEXT:    vfchdb %v1, %v2, %v1
+; CHECK-NEXT:    vldeb %v3, %v3
+; CHECK-NEXT:    vfchdb %v0, %v1, %v0
+; CHECK-NEXT:    vfchdb %v1, %v3, %v2
 ; CHECK-NEXT:    vpkg %v0, %v1, %v0
 ; CHECK-NEXT:    vsel %v24, %v28, %v30, %v0
 ; CHECK-NEXT:    br %r14
@@ -394,14 +394,14 @@ define <4 x double> @fun29(<4 x float> %val1, <4 x float> %val2, <4 x double> %v
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    vmrlf %v0, %v26, %v26
 ; CHECK-NEXT:    vmrlf %v1, %v24, %v24
+; CHECK-NEXT:    vmrhf %v2, %v26, %v26
+; CHECK-NEXT:    vmrhf %v3, %v24, %v24
 ; CHECK-NEXT:    vldeb %v0, %v0
 ; CHECK-NEXT:    vldeb %v1, %v1
-; CHECK-NEXT:    vfchdb %v0, %v1, %v0
-; CHECK-NEXT:    vmrhf %v1, %v26, %v26
-; CHECK-NEXT:    vmrhf %v2, %v24, %v24
-; CHECK-NEXT:    vldeb %v1, %v1
 ; CHECK-NEXT:    vldeb %v2, %v2
-; CHECK-NEXT:    vfchdb %v1, %v2, %v1
+; CHECK-NEXT:    vldeb %v3, %v3
+; CHECK-NEXT:    vfchdb %v0, %v1, %v0
+; CHECK-NEXT:    vfchdb %v1, %v3, %v2
 ; CHECK-NEXT:    vpkg %v0, %v1, %v0
 ; CHECK-NEXT:    vuplf %v1, %v0
 ; CHECK-NEXT:    vuphf %v0, %v0
@@ -419,27 +419,27 @@ define <8 x float> @fun30(<8 x float> %val1, <8 x float> %val2, <8 x float> %val
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    vmrlf %v0, %v30, %v30
 ; CHECK-NEXT:    vmrlf %v1, %v26, %v26
+; CHECK-NEXT:    vmrhf %v2, %v30, %v30
+; CHECK-NEXT:    vmrhf %v3, %v26, %v26
+; CHECK-NEXT:    vmrlf %v4, %v28, %v28
+; CHECK-NEXT:    vmrlf %v5, %v24, %v24
+; CHECK-NEXT:    vmrhf %v6, %v28, %v28
+; CHECK-NEXT:    vmrhf %v7, %v24, %v24
 ; CHECK-NEXT:    vldeb %v0, %v0
 ; CHECK-NEXT:    vldeb %v1, %v1
 ; CHECK-NEXT:    vfchdb %v0, %v1, %v0
-; CHECK-NEXT:    vmrhf %v1, %v30, %v30
-; CHECK-NEXT:    vmrhf %v2, %v26, %v26
-; CHECK-NEXT:    vldeb %v1, %v1
-; CHECK-NEXT:    vmrhf %v3, %v24, %v24
-; CHECK-NEXT:    vldeb %v2, %v2
-; CHECK-NEXT:    vfchdb %v1, %v2, %v1
-; CHECK-NEXT:    vpkg %v0, %v1, %v0
-; CHECK-NEXT:    vmrlf %v1, %v28, %v28
-; CHECK-NEXT:    vmrlf %v2, %v24, %v24
-; CHECK-NEXT:    vldeb %v1, %v1
-; CHECK-NEXT:    vsel %v26, %v27, %v31, %v0
-; CHECK-NEXT:    vldeb %v2, %v2
-; CHECK-NEXT:    vfchdb %v1, %v2, %v1
-; CHECK-NEXT:    vmrhf %v2, %v28, %v28
 ; CHECK-NEXT:    vldeb %v2, %v2
 ; CHECK-NEXT:    vldeb %v3, %v3
-; CHECK-NEXT:    vfchdb %v2, %v3, %v2
-; CHECK-NEXT:    vpkg %v1, %v2, %v1
+; CHECK-NEXT:    vfchdb %v1, %v3, %v2
+; CHECK-NEXT:    vpkg %v0, %v1, %v0
+; CHECK-NEXT:    vsel %v26, %v27, %v31, %v0
+; CHECK-NEXT:    vldeb %v4, %v4
+; CHECK-NEXT:    vldeb %v5, %v5
+; CHECK-NEXT:    vfchdb %v2, %v5, %v4
+; CHECK-NEXT:    vldeb %v6, %v6
+; CHECK-NEXT:    vldeb %v7, %v7
+; CHECK-NEXT:    vfchdb %v3, %v7, %v6
+; CHECK-NEXT:    vpkg %v1, %v3, %v2
 ; CHECK-NEXT:    vsel %v24, %v25, %v29, %v1
 ; CHECK-NEXT:    br %r14
   %cmp = fcmp ogt <8 x float> %val1, %val2

--- a/llvm/test/CodeGen/SystemZ/vec-eval.ll
+++ b/llvm/test/CodeGen/SystemZ/vec-eval.ll
@@ -596,10 +596,10 @@ entry:
 define <16 x i8> @eval45(<16 x i8> %src1, <16 x i8> %src2, <16 x i8> %src3) {
 ; CHECK-LABEL: eval45:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    veval %v1, %v26, %v24, %v28, 1
-; CHECK-NEXT:    vo %v0, %v28, %v24
-; CHECK-NEXT:    veval %v1, %v1, %v24, %v26, 47
-; CHECK-NEXT:    veval %v24, %v1, %v26, %v0, 47
+; CHECK-NEXT:    veval %v0, %v26, %v24, %v28, 1
+; CHECK-NEXT:    vo %v1, %v28, %v24
+; CHECK-NEXT:    veval %v0, %v0, %v24, %v26, 47
+; CHECK-NEXT:    veval %v24, %v0, %v26, %v1, 47
 ; CHECK-NEXT:    br %r14
 entry:
   %0 = or <16 x i8> %src3, %src1
@@ -770,10 +770,10 @@ entry:
 define <16 x i8> @eval57(<16 x i8> %src1, <16 x i8> %src2, <16 x i8> %src3) {
 ; CHECK-LABEL: eval57:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    veval %v1, %v26, %v24, %v28, 1
-; CHECK-NEXT:    vo %v0, %v28, %v26
-; CHECK-NEXT:    veval %v1, %v1, %v26, %v24, 47
-; CHECK-NEXT:    veval %v24, %v1, %v24, %v0, 47
+; CHECK-NEXT:    veval %v0, %v26, %v24, %v28, 1
+; CHECK-NEXT:    vo %v1, %v28, %v26
+; CHECK-NEXT:    veval %v0, %v0, %v26, %v24, 47
+; CHECK-NEXT:    veval %v24, %v0, %v24, %v1, 47
 ; CHECK-NEXT:    br %r14
 entry:
   %not = xor <16 x i8> %src1, splat(i8 -1)
@@ -1541,8 +1541,8 @@ define <16 x i8> @eval109(<16 x i8> %src1, <16 x i8> %src2, <16 x i8> %src3) {
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vgbm %v0, 65535
 ; CHECK-NEXT:    veval %v0, %v24, %v0, %v26, 40
-; CHECK-NEXT:    vn %v2, %v26, %v24
-; CHECK-NEXT:    veval %v0, %v28, %v0, %v2, 7
+; CHECK-NEXT:    vn %v1, %v26, %v24
+; CHECK-NEXT:    veval %v0, %v28, %v0, %v1, 7
 ; CHECK-NEXT:    vo %v1, %v28, %v24
 ; CHECK-NEXT:    veval %v0, %v0, %v24, %v26, 47
 ; CHECK-NEXT:    veval %v24, %v0, %v26, %v1, 47
@@ -1754,8 +1754,8 @@ define <16 x i8> @eval121(<16 x i8> %src1, <16 x i8> %src2, <16 x i8> %src3) {
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vgbm %v0, 65535
 ; CHECK-NEXT:    veval %v0, %v24, %v0, %v26, 40
-; CHECK-NEXT:    vn %v2, %v26, %v24
-; CHECK-NEXT:    veval %v0, %v28, %v0, %v2, 7
+; CHECK-NEXT:    vn %v1, %v26, %v24
+; CHECK-NEXT:    veval %v0, %v28, %v0, %v1, 7
 ; CHECK-NEXT:    vo %v1, %v28, %v26
 ; CHECK-NEXT:    veval %v0, %v0, %v26, %v24, 47
 ; CHECK-NEXT:    veval %v24, %v0, %v24, %v1, 47
@@ -2084,10 +2084,10 @@ entry:
 define <16 x i8> @eval141(<16 x i8> %src1, <16 x i8> %src2, <16 x i8> %src3) {
 ; CHECK-LABEL: eval141:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    veval %v1, %v26, %v24, %v28, 1
-; CHECK-NEXT:    vo %v0, %v26, %v24
-; CHECK-NEXT:    veval %v1, %v1, %v24, %v26, 47
-; CHECK-NEXT:    veval %v24, %v1, %v0, %v28, 143
+; CHECK-NEXT:    veval %v0, %v26, %v24, %v28, 1
+; CHECK-NEXT:    vo %v1, %v26, %v24
+; CHECK-NEXT:    veval %v0, %v0, %v24, %v26, 47
+; CHECK-NEXT:    veval %v24, %v0, %v1, %v28, 143
 ; CHECK-NEXT:    br %r14
 entry:
   %not1 = xor <16 x i8> %src2, splat(i8 -1)
@@ -2253,10 +2253,10 @@ entry:
 define <16 x i8> @eval151(<16 x i8> %src1, <16 x i8> %src2, <16 x i8> %src3) {
 ; CHECK-LABEL: eval151:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    veval %v1, %v24, %v28, %v26, 2
-; CHECK-NEXT:    vx %v0, %v28, %v26
-; CHECK-NEXT:    veval %v1, %v1, %v26, %v24, 31
-; CHECK-NEXT:    veval %v24, %v1, %v0, %v24, 143
+; CHECK-NEXT:    veval %v0, %v24, %v28, %v26, 2
+; CHECK-NEXT:    vx %v1, %v28, %v26
+; CHECK-NEXT:    veval %v0, %v0, %v26, %v24, 31
+; CHECK-NEXT:    veval %v24, %v0, %v1, %v24, 143
 ; CHECK-NEXT:    br %r14
 entry:
   %not1 = xor <16 x i8> %src2, splat(i8 -1)
@@ -2365,10 +2365,10 @@ entry:
 define <16 x i8> @eval157(<16 x i8> %src1, <16 x i8> %src2, <16 x i8> %src3) {
 ; CHECK-LABEL: eval157:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    veval %v1, %v26, %v24, %v28, 1
-; CHECK-NEXT:    vx %v0, %v28, %v26
-; CHECK-NEXT:    veval %v1, %v1, %v24, %v26, 47
-; CHECK-NEXT:    veval %v24, %v1, %v0, %v24, 143
+; CHECK-NEXT:    veval %v0, %v26, %v24, %v28, 1
+; CHECK-NEXT:    vx %v1, %v28, %v26
+; CHECK-NEXT:    veval %v0, %v0, %v24, %v26, 47
+; CHECK-NEXT:    veval %v24, %v0, %v1, %v24, 143
 ; CHECK-NEXT:    br %r14
 entry:
   %not1 = xor <16 x i8> %src2, splat(i8 -1)
@@ -2778,10 +2778,10 @@ entry:
 define <16 x i8> @eval183(<16 x i8> %src1, <16 x i8> %src2, <16 x i8> %src3) {
 ; CHECK-LABEL: eval183:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    veval %v1, %v24, %v28, %v26, 2
-; CHECK-NEXT:    voc %v0, %v26, %v28
-; CHECK-NEXT:    veval %v1, %v1, %v26, %v24, 31
-; CHECK-NEXT:    veval %v24, %v1, %v0, %v24, 47
+; CHECK-NEXT:    veval %v0, %v24, %v28, %v26, 2
+; CHECK-NEXT:    voc %v1, %v26, %v28
+; CHECK-NEXT:    veval %v0, %v0, %v26, %v24, 31
+; CHECK-NEXT:    veval %v24, %v0, %v1, %v24, 47
 ; CHECK-NEXT:    br %r14
 entry:
   %not = xor <16 x i8> %src1, splat(i8 -1)
@@ -2884,10 +2884,10 @@ entry:
 define <16 x i8> @eval189(<16 x i8> %src1, <16 x i8> %src2, <16 x i8> %src3) {
 ; CHECK-LABEL: eval189:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    veval %v1, %v26, %v24, %v28, 1
-; CHECK-NEXT:    voc %v0, %v26, %v28
-; CHECK-NEXT:    veval %v1, %v1, %v24, %v26, 47
-; CHECK-NEXT:    veval %v24, %v1, %v0, %v24, 47
+; CHECK-NEXT:    veval %v0, %v26, %v24, %v28, 1
+; CHECK-NEXT:    voc %v1, %v26, %v28
+; CHECK-NEXT:    veval %v0, %v0, %v24, %v26, 47
+; CHECK-NEXT:    veval %v24, %v0, %v1, %v24, 47
 ; CHECK-NEXT:    br %r14
 entry:
   %not = xor <16 x i8> %src1, splat(i8 -1)
@@ -3480,10 +3480,10 @@ define <16 x i8> @eval228(<16 x i8> %src1, <16 x i8> %src2, <16 x i8> %src3) {
 ; CHECK-LABEL: eval228:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vno %v0, %v26, %v26
-; CHECK-NEXT:    veval %v2, %v24, %v28, %v26, 2
-; CHECK-NEXT:    vo %v1, %v28, %v24
-; CHECK-NEXT:    veval %v0, %v2, %v0, %v24, 47
-; CHECK-NEXT:    veval %v24, %v0, %v26, %v1, 47
+; CHECK-NEXT:    veval %v1, %v24, %v28, %v26, 2
+; CHECK-NEXT:    vo %v2, %v28, %v24
+; CHECK-NEXT:    veval %v0, %v1, %v0, %v24, 47
+; CHECK-NEXT:    veval %v24, %v0, %v26, %v2, 47
 ; CHECK-NEXT:    br %r14
 entry:
   %not = xor <16 x i8> %src1, splat(i8 -1)
@@ -3539,11 +3539,11 @@ define <16 x i8> @eval231(<16 x i8> %src1, <16 x i8> %src2, <16 x i8> %src3) {
 ; CHECK-LABEL: eval231:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vno %v0, %v26, %v26
-; CHECK-NEXT:    vnc %v2, %v24, %v26
-; CHECK-NEXT:    vo %v1, %v28, %v24
+; CHECK-NEXT:    vnc %v1, %v24, %v26
+; CHECK-NEXT:    vo %v2, %v28, %v24
 ; CHECK-NEXT:    vsel %v0, %v26, %v0, %v24
-; CHECK-NEXT:    veval %v0, %v0, %v2, %v28, 31
-; CHECK-NEXT:    veval %v24, %v0, %v26, %v1, 47
+; CHECK-NEXT:    veval %v0, %v0, %v1, %v28, 31
+; CHECK-NEXT:    veval %v24, %v0, %v26, %v2, 47
 ; CHECK-NEXT:    br %r14
 entry:
   %not = xor <16 x i8> %src1, splat(i8 -1)

--- a/llvm/test/CodeGen/SystemZ/vec-move-23.ll
+++ b/llvm/test/CodeGen/SystemZ/vec-move-23.ll
@@ -42,20 +42,20 @@ define void @fun2(<2 x i32> %Src, ptr %Dst) {
 define void @fun3(<4 x i16> %Src, ptr %Dst) {
 ; CHECK-LABEL: fun3:
 
-; Z14:      vuphh	%v0, %v24
-; Z14-NEXT: vlgvf	%r0, %v0, 3
-; Z14-NEXT: cefbr	%f1, %r0
-; Z14-NEXT: vlgvf	%r0, %v0, 2
-; Z14-NEXT: cefbr	%f2, %r0
-; Z14-NEXT: vlgvf	%r0, %v0, 1
-; Z14-NEXT: vmrhf	%v1, %v2, %v1
-; Z14-NEXT: cefbr	%f2, %r0
-; Z14-NEXT: vlgvf	%r0, %v0, 0
-; Z14-NEXT: cefbr	%f0, %r0
-; Z14-NEXT: vmrhf	%v0, %v0, %v2
-; Z14-NEXT: vmrhg	%v0, %v0, %v1
-; Z14-NEXT: vst	%v0, 0(%r2), 3
-; Z14-NEXT: br	%r14
+; Z14:        vuphh   %v0, %v24
+; Z14-NEXT:   vlgvf   %r0, %v0, 3
+; Z14-NEXT:   vlgvf   %r1, %v0, 2
+; Z14-NEXT:   cefbr   %f1, %r1
+; Z14-NEXT:   vlgvf   %r3, %v0, 1
+; Z14-NEXT:   cefbr   %f2, %r3
+; Z14-NEXT:   vlgvf   %r4, %v0, 0
+; Z14-NEXT:   cefbr   %f0, %r0
+; Z14-NEXT:   vmrhf   %v0, %v1, %v0
+; Z14-NEXT:   cefbr   %f3, %r4
+; Z14-NEXT:   vmrhf   %v1, %v3, %v2
+; Z14-NEXT:   vmrhg   %v0, %v1, %v0
+; Z14-NEXT:   vst     %v0, 0(%r2), 3
+; Z14-NEXT:   br      %r14
 
 ; Z15:      vuphh	%v0, %v24
 ; Z15-NEXT: vcefb	%v0, %v0, 0, 0
@@ -106,20 +106,20 @@ define void @fun6(<2 x i32> %Src, ptr %Dst) {
 define void @fun7(<4 x i16> %Src, ptr %Dst) {
 ; CHECK-LABEL: fun7:
 
-; Z14:      vuplhh	%v0, %v24
-; Z14-NEXT: vlgvf	%r0, %v0, 3
-; Z14-NEXT: celfbr	%f1, 0, %r0, 0
-; Z14-NEXT: vlgvf	%r0, %v0, 2
-; Z14-NEXT: celfbr	%f2, 0, %r0, 0
-; Z14-NEXT: vlgvf	%r0, %v0, 1
-; Z14-NEXT: vmrhf	%v1, %v2, %v1
-; Z14-NEXT: celfbr	%f2, 0, %r0, 0
-; Z14-NEXT: vlgvf	%r0, %v0, 0
-; Z14-NEXT: celfbr	%f0, 0, %r0, 0
-; Z14-NEXT: vmrhf	%v0, %v0, %v2
-; Z14-NEXT: vmrhg	%v0, %v0, %v1
-; Z14-NEXT: vst	%v0, 0(%r2), 3
-; Z14-NEXT: br	%r14
+; Z14:      vuplhh  %v0, %v24
+; Z14-NEXT: vlgvf   %r0, %v0, 3
+; Z14-NEXT: vlgvf   %r1, %v0, 2
+; Z14-NEXT: celfbr  %f1, 0, %r1, 0
+; Z14-NEXT: vlgvf   %r3, %v0, 1
+; Z14-NEXT: celfbr  %f2, 0, %r3, 0
+; Z14-NEXT: vlgvf   %r4, %v0, 0
+; Z14-NEXT: celfbr  %f0, 0, %r0, 0
+; Z14-NEXT: vmrhf   %v0, %v1, %v0
+; Z14-NEXT: celfbr  %f3, 0, %r4, 0
+; Z14-NEXT: vmrhf   %v1, %v3, %v2
+; Z14-NEXT: vmrhg   %v0, %v1, %v0
+; Z14-NEXT: vst     %v0, 0(%r2), 3
+; Z14-NEXT: br      %r14
 
 ; Z15:      vuplhh	%v0, %v24
 ; Z15-NEXT: vcelfb	%v0, %v0, 0, 0

--- a/llvm/test/CodeGen/SystemZ/vec-mul-07.ll
+++ b/llvm/test/CodeGen/SystemZ/vec-mul-07.ll
@@ -192,11 +192,11 @@ define <2 x i64> @f9_not(<4 x i32> %val1, <4 x i32> %val2) {
 ; CHECK-NEXT:    vuplhf %v1, %v26
 ; CHECK-NEXT:    vlgvg %r0, %v1, 1
 ; CHECK-NEXT:    vlgvg %r1, %v0, 1
+; CHECK-NEXT:    vlgvg %r2, %v1, 0
+; CHECK-NEXT:    vlgvg %r3, %v0, 0
 ; CHECK-NEXT:    msgr %r1, %r0
-; CHECK-NEXT:    vlgvg %r0, %v1, 0
-; CHECK-NEXT:    vlgvg %r2, %v0, 0
-; CHECK-NEXT:    msgr %r2, %r0
-; CHECK-NEXT:    vlvgp %v24, %r2, %r1
+; CHECK-NEXT:    msgr %r3, %r2
+; CHECK-NEXT:    vlvgp %v24, %r3, %r1
 ; CHECK-NEXT:    br %r14
   %shuf1 = shufflevector <4 x i32> %val1, <4 x i32> poison, <2 x i32> <i32 0, i32 1>
   %zext1 = zext <2 x i32> %shuf1 to <2 x i64>
@@ -243,11 +243,11 @@ define <2 x i64> @f11_not(<4 x i32> %val1, <4 x i32> %val2) {
 ; CHECK-NEXT:    vuphf %v1, %v26
 ; CHECK-NEXT:    vlgvg %r0, %v1, 1
 ; CHECK-NEXT:    vlgvg %r1, %v0, 1
+; CHECK-NEXT:    vlgvg %r2, %v1, 0
+; CHECK-NEXT:    vlgvg %r3, %v0, 0
 ; CHECK-NEXT:    msgr %r1, %r0
-; CHECK-NEXT:    vlgvg %r0, %v1, 0
-; CHECK-NEXT:    vlgvg %r2, %v0, 0
-; CHECK-NEXT:    msgr %r2, %r0
-; CHECK-NEXT:    vlvgp %v24, %r2, %r1
+; CHECK-NEXT:    msgr %r3, %r2
+; CHECK-NEXT:    vlvgp %v24, %r3, %r1
 ; CHECK-NEXT:    br %r14
   %shuf1 = shufflevector <4 x i32> %val1, <4 x i32> poison, <2 x i32> <i32 0, i32 1>
   %sext1 = sext <2 x i32> %shuf1 to <2 x i64>

--- a/llvm/test/CodeGen/SystemZ/vec-perm-12.ll
+++ b/llvm/test/CodeGen/SystemZ/vec-perm-12.ll
@@ -10,17 +10,17 @@ define <4 x i32> @f1(<4 x i32> %x, i64 %y) {
 ; CHECK-CODE-LABEL: f1:
 ; CHECK-CODE:       # %bb.0:
 ; CHECK-CODE-NEXT:    larl %r1, .LCPI0_0
-; CHECK-CODE-NEXT:    vl %v1, 0(%r1), 3
-; CHECK-CODE-NEXT:    vlvgf %v0, %r2, 0
-; CHECK-CODE-NEXT:    vperm %v24, %v24, %v0, %v1
+; CHECK-CODE-NEXT:    vl %v0, 0(%r1), 3
+; CHECK-CODE-NEXT:    vlvgf %v1, %r2, 0
+; CHECK-CODE-NEXT:    vperm %v24, %v24, %v1, %v0
 ; CHECK-CODE-NEXT:    br %r14
 ;
 ; CHECK-VECTOR-LABEL: f1:
 ; CHECK-VECTOR:       # %bb.0:
 ; CHECK-VECTOR-NEXT:    larl %r1, .LCPI0_0
-; CHECK-VECTOR-NEXT:    vl %v1, 0(%r1), 3
-; CHECK-VECTOR-NEXT:    vlvgf %v0, %r2, 0
-; CHECK-VECTOR-NEXT:    vperm %v24, %v24, %v0, %v1
+; CHECK-VECTOR-NEXT:    vl %v0, 0(%r1), 3
+; CHECK-VECTOR-NEXT:    vlvgf %v1, %r2, 0
+; CHECK-VECTOR-NEXT:    vperm %v24, %v24, %v1, %v0
 ; CHECK-VECTOR-NEXT:    br %r14
 
 

--- a/llvm/test/CodeGen/SystemZ/vec-trunc-to-i16.ll
+++ b/llvm/test/CodeGen/SystemZ/vec-trunc-to-i16.ll
@@ -23,11 +23,11 @@ define fastcc void @test_shuffle_with_trunc() {
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    lh %r1, 0
 ; CHECK-NEXT:    l %r0, 0
-; CHECK-NEXT:    vlvgh %v1, %r1, 0
-; CHECK-NEXT:    larl %r1, .LCPI1_0
-; CHECK-NEXT:    vl %v2, 0(%r1), 3
-; CHECK-NEXT:    vlvgf %v0, %r0, 0
-; CHECK-NEXT:    vperm %v0, %v0, %v1, %v2
+; CHECK-NEXT:    larl %r2, .LCPI1_0
+; CHECK-NEXT:    vl %v0, 0(%r2), 3
+; CHECK-NEXT:    vlvgf %v1, %r0, 0
+; CHECK-NEXT:    vlvgh %v2, %r1, 0
+; CHECK-NEXT:    vperm %v0, %v1, %v2, %v0
 ; CHECK-NEXT:    vst %v0, 0, 3
 ; CHECK-NEXT:    br %r14
   %1 = load i32, ptr null, align 8

--- a/llvm/test/CodeGen/SystemZ/vector-constrained-fp-intrinsics.ll
+++ b/llvm/test/CodeGen/SystemZ/vector-constrained-fp-intrinsics.ll
@@ -76,9 +76,9 @@ define <3 x float> @constrained_vector_fdiv_v3f32() #0 {
 ; SZ13-LABEL: constrained_vector_fdiv_v3f32:
 ; SZ13:       # %bb.0: # %entry
 ; SZ13-NEXT:    larl %r1, .LCPI2_0
+; SZ13-NEXT:    larl %r2, .LCPI2_1
 ; SZ13-NEXT:    lde %f0, 0(%r1)
-; SZ13-NEXT:    larl %r1, .LCPI2_1
-; SZ13-NEXT:    lde %f1, 0(%r1)
+; SZ13-NEXT:    lde %f1, 0(%r2)
 ; SZ13-NEXT:    debr %f1, %f0
 ; SZ13-NEXT:    vgmf %v2, 2, 8
 ; SZ13-NEXT:    vgmf %v3, 1, 1
@@ -116,15 +116,15 @@ define void @constrained_vector_fdiv_v3f64(ptr %a) #0 {
 ;
 ; SZ13-LABEL: constrained_vector_fdiv_v3f64:
 ; SZ13:       # %bb.0: # %entry
-; SZ13-NEXT:    larl %r1, .LCPI3_0
-; SZ13-NEXT:    ld %f1, 0(%r1)
-; SZ13-NEXT:    ddb %f1, 16(%r2)
 ; SZ13-NEXT:    larl %r1, .LCPI3_1
 ; SZ13-NEXT:    vl %v0, 0(%r2), 4
-; SZ13-NEXT:    vl %v2, 0(%r1), 3
-; SZ13-NEXT:    std %f1, 16(%r2)
-; SZ13-NEXT:    vfddb %v0, %v2, %v0
+; SZ13-NEXT:    vl %v1, 0(%r1), 3
+; SZ13-NEXT:    vfddb %v0, %v1, %v0
+; SZ13-NEXT:    larl %r1, .LCPI3_0
+; SZ13-NEXT:    ld %f2, 0(%r1)
+; SZ13-NEXT:    ddb %f2, 16(%r2)
 ; SZ13-NEXT:    vst %v0, 0(%r2), 4
+; SZ13-NEXT:    std %f2, 16(%r2)
 ; SZ13-NEXT:    br %r14
 entry:
   %b = load <3 x double>, ptr %a
@@ -432,12 +432,13 @@ define void @constrained_vector_frem_v3f64(ptr %a) #0 {
 ; SZ13-NEXT:    vgmg %v0, 1, 1
 ; SZ13-NEXT:    # kill: def $f2d killed $f2d killed $v2
 ; SZ13-NEXT:    brasl %r14, fmod@PLT
-; SZ13-NEXT:    vl %v1, 160(%r15), 3 # 16-byte Reload
-; SZ13-NEXT:    # kill: def $f0d killed $f0d def $v0
-; SZ13-NEXT:    vmrhg %v0, %v1, %v0
+; SZ13-NEXT:    vl %v2, 160(%r15), 3 # 16-byte Reload
 ; SZ13-NEXT:    larl %r1, .LCPI8_0
+; SZ13-NEXT:    ld %f1, 0(%r1)
+; SZ13-NEXT:    # kill: def $f0d killed $f0d def $v0
+; SZ13-NEXT:    vmrhg %v0, %v2, %v0
 ; SZ13-NEXT:    vst %v0, 160(%r15), 3 # 16-byte Spill
-; SZ13-NEXT:    ld %f0, 0(%r1)
+; SZ13-NEXT:    ldr %f0, %f1
 ; SZ13-NEXT:    ldr %f2, %f8
 ; SZ13-NEXT:    brasl %r14, fmod@PLT
 ; SZ13-NEXT:    mvc 0(16,%r13), 160(%r15) # 16-byte Folded Reload
@@ -525,12 +526,13 @@ define <4 x double> @constrained_vector_frem_v4f64() #0 {
 ; SZ13-NEXT:    vgmg %v0, 2, 11
 ; SZ13-NEXT:    ldr %f2, %f8
 ; SZ13-NEXT:    brasl %r14, fmod@PLT
-; SZ13-NEXT:    vl %v1, 160(%r15), 3 # 16-byte Reload
-; SZ13-NEXT:    # kill: def $f0d killed $f0d def $v0
-; SZ13-NEXT:    vmrhg %v0, %v0, %v1
+; SZ13-NEXT:    vl %v2, 160(%r15), 3 # 16-byte Reload
 ; SZ13-NEXT:    larl %r1, .LCPI9_1
+; SZ13-NEXT:    ld %f1, 0(%r1)
+; SZ13-NEXT:    # kill: def $f0d killed $f0d def $v0
+; SZ13-NEXT:    vmrhg %v0, %v0, %v2
 ; SZ13-NEXT:    vst %v0, 160(%r15), 3 # 16-byte Spill
-; SZ13-NEXT:    ld %f0, 0(%r1)
+; SZ13-NEXT:    ldr %f0, %f1
 ; SZ13-NEXT:    ldr %f2, %f8
 ; SZ13-NEXT:    brasl %r14, fmod@PLT
 ; SZ13-NEXT:    larl %r1, .LCPI9_2
@@ -628,15 +630,15 @@ define <3 x float> @constrained_vector_fmul_v3f32() #0 {
 ; SZ13-LABEL: constrained_vector_fmul_v3f32:
 ; SZ13:       # %bb.0: # %entry
 ; SZ13-NEXT:    vgmf %v0, 1, 8
+; SZ13-NEXT:    vgmf %v1, 2, 8
 ; SZ13-NEXT:    larl %r1, .LCPI12_0
-; SZ13-NEXT:    vgmf %v2, 2, 8
-; SZ13-NEXT:    vgmf %v1, 1, 8
-; SZ13-NEXT:    meeb %f1, 0(%r1)
-; SZ13-NEXT:    larl %r1, .LCPI12_1
-; SZ13-NEXT:    meebr %f2, %f0
-; SZ13-NEXT:    meeb %f0, 0(%r1)
-; SZ13-NEXT:    vmrhf %v0, %v2, %v0
-; SZ13-NEXT:    vrepf %v1, %v1, 0
+; SZ13-NEXT:    larl %r2, .LCPI12_1
+; SZ13-NEXT:    vgmf %v2, 1, 8
+; SZ13-NEXT:    meeb %f2, 0(%r1)
+; SZ13-NEXT:    meebr %f1, %f0
+; SZ13-NEXT:    meeb %f0, 0(%r2)
+; SZ13-NEXT:    vmrhf %v0, %v1, %v0
+; SZ13-NEXT:    vrepf %v1, %v2, 0
 ; SZ13-NEXT:    vmrhg %v24, %v0, %v1
 ; SZ13-NEXT:    br %r14
 entry:
@@ -666,15 +668,15 @@ define void @constrained_vector_fmul_v3f64(ptr %a) #0 {
 ;
 ; SZ13-LABEL: constrained_vector_fmul_v3f64:
 ; SZ13:       # %bb.0: # %entry
-; SZ13-NEXT:    larl %r1, .LCPI13_0
-; SZ13-NEXT:    ld %f1, 0(%r1)
 ; SZ13-NEXT:    larl %r1, .LCPI13_1
 ; SZ13-NEXT:    vl %v0, 0(%r2), 4
-; SZ13-NEXT:    vl %v2, 0(%r1), 3
-; SZ13-NEXT:    mdb %f1, 16(%r2)
-; SZ13-NEXT:    vfmdb %v0, %v2, %v0
+; SZ13-NEXT:    larl %r3, .LCPI13_0
+; SZ13-NEXT:    vl %v1, 0(%r1), 3
+; SZ13-NEXT:    ld %f2, 0(%r3)
+; SZ13-NEXT:    mdb %f2, 16(%r2)
+; SZ13-NEXT:    vfmdb %v0, %v1, %v0
 ; SZ13-NEXT:    vst %v0, 0(%r2), 4
-; SZ13-NEXT:    std %f1, 16(%r2)
+; SZ13-NEXT:    std %f2, 16(%r2)
 ; SZ13-NEXT:    br %r14
 entry:
   %b = load <3 x double>, ptr %a
@@ -799,14 +801,14 @@ define <3 x float> @constrained_vector_fadd_v3f32() #0 {
 ; SZ13-LABEL: constrained_vector_fadd_v3f32:
 ; SZ13:       # %bb.0: # %entry
 ; SZ13-NEXT:    vgbm %v0, 61440
-; SZ13-NEXT:    vgmf %v2, 1, 1
-; SZ13-NEXT:    vgmf %v3, 2, 8
-; SZ13-NEXT:    lzer %f1
+; SZ13-NEXT:    vgmf %v1, 1, 1
+; SZ13-NEXT:    vgmf %v2, 2, 8
+; SZ13-NEXT:    lzer %f3
+; SZ13-NEXT:    aebr %f3, %f0
 ; SZ13-NEXT:    aebr %f1, %f0
 ; SZ13-NEXT:    aebr %f2, %f0
-; SZ13-NEXT:    aebr %f3, %f0
-; SZ13-NEXT:    vmrhf %v0, %v2, %v3
-; SZ13-NEXT:    vrepf %v1, %v1, 0
+; SZ13-NEXT:    vmrhf %v0, %v1, %v2
+; SZ13-NEXT:    vrepf %v1, %v3, 0
 ; SZ13-NEXT:    vmrhg %v24, %v0, %v1
 ; SZ13-NEXT:    br %r14
 entry:
@@ -836,15 +838,15 @@ define void @constrained_vector_fadd_v3f64(ptr %a) #0 {
 ;
 ; SZ13-LABEL: constrained_vector_fadd_v3f64:
 ; SZ13:       # %bb.0: # %entry
-; SZ13-NEXT:    larl %r1, .LCPI18_0
-; SZ13-NEXT:    ld %f1, 0(%r1)
 ; SZ13-NEXT:    larl %r1, .LCPI18_1
 ; SZ13-NEXT:    vl %v0, 0(%r2), 4
-; SZ13-NEXT:    vl %v2, 0(%r1), 3
-; SZ13-NEXT:    adb %f1, 16(%r2)
-; SZ13-NEXT:    vfadb %v0, %v2, %v0
+; SZ13-NEXT:    larl %r3, .LCPI18_0
+; SZ13-NEXT:    vl %v1, 0(%r1), 3
+; SZ13-NEXT:    ld %f2, 0(%r3)
+; SZ13-NEXT:    adb %f2, 16(%r2)
+; SZ13-NEXT:    vfadb %v0, %v1, %v0
 ; SZ13-NEXT:    vst %v0, 0(%r2), 4
-; SZ13-NEXT:    std %f1, 16(%r2)
+; SZ13-NEXT:    std %f2, 16(%r2)
 ; SZ13-NEXT:    br %r14
 entry:
   %b = load <3 x double>, ptr %a
@@ -968,17 +970,17 @@ define <3 x float> @constrained_vector_fsub_v3f32() #0 {
 ;
 ; SZ13-LABEL: constrained_vector_fsub_v3f32:
 ; SZ13:       # %bb.0: # %entry
-; SZ13-NEXT:    vgbm %v2, 61440
-; SZ13-NEXT:    lzer %f1
-; SZ13-NEXT:    sebr %f2, %f1
-; SZ13-NEXT:    vgmf %v1, 1, 1
-; SZ13-NEXT:    vgbm %v3, 61440
 ; SZ13-NEXT:    vgbm %v0, 61440
-; SZ13-NEXT:    sebr %f3, %f1
-; SZ13-NEXT:    vgmf %v1, 2, 8
-; SZ13-NEXT:    sebr %f0, %f1
+; SZ13-NEXT:    vgbm %v1, 61440
+; SZ13-NEXT:    vgmf %v2, 1, 1
+; SZ13-NEXT:    vgbm %v3, 61440
+; SZ13-NEXT:    vgmf %v4, 2, 8
+; SZ13-NEXT:    lzer %f5
+; SZ13-NEXT:    sebr %f1, %f5
+; SZ13-NEXT:    sebr %f3, %f2
+; SZ13-NEXT:    sebr %f0, %f4
 ; SZ13-NEXT:    vmrhf %v0, %v3, %v0
-; SZ13-NEXT:    vrepf %v1, %v2, 0
+; SZ13-NEXT:    vrepf %v1, %v1, 0
 ; SZ13-NEXT:    vmrhg %v24, %v0, %v1
 ; SZ13-NEXT:    br %r14
 entry:
@@ -1009,12 +1011,12 @@ define void @constrained_vector_fsub_v3f64(ptr %a) #0 {
 ; SZ13-LABEL: constrained_vector_fsub_v3f64:
 ; SZ13:       # %bb.0: # %entry
 ; SZ13-NEXT:    vl %v0, 0(%r2), 4
-; SZ13-NEXT:    vgmg %v2, 12, 10
-; SZ13-NEXT:    sdb %f2, 16(%r2)
 ; SZ13-NEXT:    vgmg %v1, 12, 10
-; SZ13-NEXT:    vfsdb %v0, %v1, %v0
+; SZ13-NEXT:    sdb %f1, 16(%r2)
+; SZ13-NEXT:    vgmg %v2, 12, 10
+; SZ13-NEXT:    vfsdb %v0, %v2, %v0
 ; SZ13-NEXT:    vst %v0, 0(%r2), 4
-; SZ13-NEXT:    std %f2, 16(%r2)
+; SZ13-NEXT:    std %f1, 16(%r2)
 ; SZ13-NEXT:    br %r14
 entry:
   %b = load <3 x double>, ptr %a
@@ -1450,10 +1452,10 @@ define void @constrained_vector_pow_v3f64(ptr %a) #0 {
 ; SZ13-NEXT:    .cfi_offset %f8, -168
 ; SZ13-NEXT:    .cfi_offset %f9, -176
 ; SZ13-NEXT:    larl %r1, .LCPI33_0
-; SZ13-NEXT:    ld %f9, 0(%r1)
+; SZ13-NEXT:    ld %f8, 0(%r1)
 ; SZ13-NEXT:    vl %v0, 0(%r2), 4
-; SZ13-NEXT:    ld %f8, 16(%r2)
-; SZ13-NEXT:    ldr %f2, %f9
+; SZ13-NEXT:    ld %f9, 16(%r2)
+; SZ13-NEXT:    ldr %f2, %f8
 ; SZ13-NEXT:    lgr %r13, %r2
 ; SZ13-NEXT:    vst %v0, 176(%r15), 3 # 16-byte Spill
 ; SZ13-NEXT:    # kill: def $f0d killed $f0d killed $v0
@@ -1461,7 +1463,7 @@ define void @constrained_vector_pow_v3f64(ptr %a) #0 {
 ; SZ13-NEXT:    # kill: def $f0d killed $f0d def $v0
 ; SZ13-NEXT:    vst %v0, 160(%r15), 3 # 16-byte Spill
 ; SZ13-NEXT:    vl %v0, 176(%r15), 3 # 16-byte Reload
-; SZ13-NEXT:    ldr %f2, %f9
+; SZ13-NEXT:    ldr %f2, %f8
 ; SZ13-NEXT:    vrepg %v0, %v0, 1
 ; SZ13-NEXT:    # kill: def $f0d killed $f0d killed $v0
 ; SZ13-NEXT:    brasl %r14, pow@PLT
@@ -1469,8 +1471,8 @@ define void @constrained_vector_pow_v3f64(ptr %a) #0 {
 ; SZ13-NEXT:    # kill: def $f0d killed $f0d def $v0
 ; SZ13-NEXT:    vmrhg %v0, %v1, %v0
 ; SZ13-NEXT:    vst %v0, 160(%r15), 3 # 16-byte Spill
-; SZ13-NEXT:    ldr %f0, %f8
-; SZ13-NEXT:    ldr %f2, %f9
+; SZ13-NEXT:    ldr %f0, %f9
+; SZ13-NEXT:    ldr %f2, %f8
 ; SZ13-NEXT:    brasl %r14, pow@PLT
 ; SZ13-NEXT:    mvc 0(16,%r13), 160(%r15) # 16-byte Folded Reload
 ; SZ13-NEXT:    ld %f8, 200(%r15) # 8-byte Reload
@@ -1560,12 +1562,13 @@ define <4 x double> @constrained_vector_pow_v4f64() #0 {
 ; SZ13-NEXT:    ld %f0, 0(%r1)
 ; SZ13-NEXT:    ldr %f2, %f8
 ; SZ13-NEXT:    brasl %r14, pow@PLT
-; SZ13-NEXT:    vl %v1, 160(%r15), 3 # 16-byte Reload
-; SZ13-NEXT:    # kill: def $f0d killed $f0d def $v0
-; SZ13-NEXT:    vmrhg %v0, %v0, %v1
+; SZ13-NEXT:    vl %v2, 160(%r15), 3 # 16-byte Reload
 ; SZ13-NEXT:    larl %r1, .LCPI34_3
+; SZ13-NEXT:    ld %f1, 0(%r1)
+; SZ13-NEXT:    # kill: def $f0d killed $f0d def $v0
+; SZ13-NEXT:    vmrhg %v0, %v0, %v2
 ; SZ13-NEXT:    vst %v0, 160(%r15), 3 # 16-byte Spill
-; SZ13-NEXT:    ld %f0, 0(%r1)
+; SZ13-NEXT:    ldr %f0, %f1
 ; SZ13-NEXT:    ldr %f2, %f8
 ; SZ13-NEXT:    brasl %r14, pow@PLT
 ; SZ13-NEXT:    larl %r1, .LCPI34_4
@@ -1819,12 +1822,13 @@ define void @constrained_vector_powi_v3f64(ptr %a) #0 {
 ; SZ13-NEXT:    ld %f0, 0(%r1)
 ; SZ13-NEXT:    lghi %r2, 3
 ; SZ13-NEXT:    brasl %r14, __powidf2@PLT
-; SZ13-NEXT:    vl %v1, 160(%r15), 3 # 16-byte Reload
-; SZ13-NEXT:    # kill: def $f0d killed $f0d def $v0
-; SZ13-NEXT:    vmrhg %v0, %v0, %v1
+; SZ13-NEXT:    vl %v2, 160(%r15), 3 # 16-byte Reload
 ; SZ13-NEXT:    larl %r1, .LCPI38_2
+; SZ13-NEXT:    ld %f1, 0(%r1)
+; SZ13-NEXT:    # kill: def $f0d killed $f0d def $v0
+; SZ13-NEXT:    vmrhg %v0, %v0, %v2
 ; SZ13-NEXT:    vst %v0, 160(%r15), 3 # 16-byte Spill
-; SZ13-NEXT:    ld %f0, 0(%r1)
+; SZ13-NEXT:    ldr %f0, %f1
 ; SZ13-NEXT:    lghi %r2, 3
 ; SZ13-NEXT:    brasl %r14, __powidf2@PLT
 ; SZ13-NEXT:    mvc 0(16,%r13), 160(%r15) # 16-byte Folded Reload
@@ -1904,12 +1908,13 @@ define <4 x double> @constrained_vector_powi_v4f64() #0 {
 ; SZ13-NEXT:    ld %f0, 0(%r1)
 ; SZ13-NEXT:    lghi %r2, 3
 ; SZ13-NEXT:    brasl %r14, __powidf2@PLT
-; SZ13-NEXT:    vl %v1, 160(%r15), 3 # 16-byte Reload
-; SZ13-NEXT:    # kill: def $f0d killed $f0d def $v0
-; SZ13-NEXT:    vmrhg %v0, %v0, %v1
+; SZ13-NEXT:    vl %v2, 160(%r15), 3 # 16-byte Reload
 ; SZ13-NEXT:    larl %r1, .LCPI39_2
+; SZ13-NEXT:    ld %f1, 0(%r1)
+; SZ13-NEXT:    # kill: def $f0d killed $f0d def $v0
+; SZ13-NEXT:    vmrhg %v0, %v0, %v2
 ; SZ13-NEXT:    vst %v0, 160(%r15), 3 # 16-byte Spill
-; SZ13-NEXT:    ld %f0, 0(%r1)
+; SZ13-NEXT:    ldr %f0, %f1
 ; SZ13-NEXT:    lghi %r2, 3
 ; SZ13-NEXT:    brasl %r14, __powidf2@PLT
 ; SZ13-NEXT:    larl %r1, .LCPI39_3
@@ -2223,12 +2228,13 @@ define <4 x double> @constrained_vector_sin_v4f64() #0 {
 ; SZ13-NEXT:    vst %v0, 160(%r15), 3 # 16-byte Spill
 ; SZ13-NEXT:    ld %f0, 0(%r1)
 ; SZ13-NEXT:    brasl %r14, sin@PLT
-; SZ13-NEXT:    vl %v1, 160(%r15), 3 # 16-byte Reload
-; SZ13-NEXT:    # kill: def $f0d killed $f0d def $v0
-; SZ13-NEXT:    vmrhg %v0, %v0, %v1
+; SZ13-NEXT:    vl %v2, 160(%r15), 3 # 16-byte Reload
 ; SZ13-NEXT:    larl %r1, .LCPI44_2
+; SZ13-NEXT:    ld %f1, 0(%r1)
+; SZ13-NEXT:    # kill: def $f0d killed $f0d def $v0
+; SZ13-NEXT:    vmrhg %v0, %v0, %v2
 ; SZ13-NEXT:    vst %v0, 160(%r15), 3 # 16-byte Spill
-; SZ13-NEXT:    ld %f0, 0(%r1)
+; SZ13-NEXT:    ldr %f0, %f1
 ; SZ13-NEXT:    brasl %r14, sin@PLT
 ; SZ13-NEXT:    larl %r1, .LCPI44_3
 ; SZ13-NEXT:    # kill: def $f0d killed $f0d def $v0
@@ -2539,12 +2545,13 @@ define <4 x double> @constrained_vector_cos_v4f64() #0 {
 ; SZ13-NEXT:    vst %v0, 160(%r15), 3 # 16-byte Spill
 ; SZ13-NEXT:    ld %f0, 0(%r1)
 ; SZ13-NEXT:    brasl %r14, cos@PLT
-; SZ13-NEXT:    vl %v1, 160(%r15), 3 # 16-byte Reload
-; SZ13-NEXT:    # kill: def $f0d killed $f0d def $v0
-; SZ13-NEXT:    vmrhg %v0, %v0, %v1
+; SZ13-NEXT:    vl %v2, 160(%r15), 3 # 16-byte Reload
 ; SZ13-NEXT:    larl %r1, .LCPI49_2
+; SZ13-NEXT:    ld %f1, 0(%r1)
+; SZ13-NEXT:    # kill: def $f0d killed $f0d def $v0
+; SZ13-NEXT:    vmrhg %v0, %v0, %v2
 ; SZ13-NEXT:    vst %v0, 160(%r15), 3 # 16-byte Spill
-; SZ13-NEXT:    ld %f0, 0(%r1)
+; SZ13-NEXT:    ldr %f0, %f1
 ; SZ13-NEXT:    brasl %r14, cos@PLT
 ; SZ13-NEXT:    larl %r1, .LCPI49_3
 ; SZ13-NEXT:    # kill: def $f0d killed $f0d def $v0
@@ -2855,12 +2862,13 @@ define <4 x double> @constrained_vector_exp_v4f64() #0 {
 ; SZ13-NEXT:    vst %v0, 160(%r15), 3 # 16-byte Spill
 ; SZ13-NEXT:    ld %f0, 0(%r1)
 ; SZ13-NEXT:    brasl %r14, exp@PLT
-; SZ13-NEXT:    vl %v1, 160(%r15), 3 # 16-byte Reload
-; SZ13-NEXT:    # kill: def $f0d killed $f0d def $v0
-; SZ13-NEXT:    vmrhg %v0, %v0, %v1
+; SZ13-NEXT:    vl %v2, 160(%r15), 3 # 16-byte Reload
 ; SZ13-NEXT:    larl %r1, .LCPI54_2
+; SZ13-NEXT:    ld %f1, 0(%r1)
+; SZ13-NEXT:    # kill: def $f0d killed $f0d def $v0
+; SZ13-NEXT:    vmrhg %v0, %v0, %v2
 ; SZ13-NEXT:    vst %v0, 160(%r15), 3 # 16-byte Spill
-; SZ13-NEXT:    ld %f0, 0(%r1)
+; SZ13-NEXT:    ldr %f0, %f1
 ; SZ13-NEXT:    brasl %r14, exp@PLT
 ; SZ13-NEXT:    larl %r1, .LCPI54_3
 ; SZ13-NEXT:    # kill: def $f0d killed $f0d def $v0
@@ -3171,12 +3179,13 @@ define <4 x double> @constrained_vector_exp2_v4f64() #0 {
 ; SZ13-NEXT:    vst %v0, 160(%r15), 3 # 16-byte Spill
 ; SZ13-NEXT:    ld %f0, 0(%r1)
 ; SZ13-NEXT:    brasl %r14, exp2@PLT
-; SZ13-NEXT:    vl %v1, 160(%r15), 3 # 16-byte Reload
-; SZ13-NEXT:    # kill: def $f0d killed $f0d def $v0
-; SZ13-NEXT:    vmrhg %v0, %v0, %v1
+; SZ13-NEXT:    vl %v2, 160(%r15), 3 # 16-byte Reload
 ; SZ13-NEXT:    larl %r1, .LCPI59_2
+; SZ13-NEXT:    ld %f1, 0(%r1)
+; SZ13-NEXT:    # kill: def $f0d killed $f0d def $v0
+; SZ13-NEXT:    vmrhg %v0, %v0, %v2
 ; SZ13-NEXT:    vst %v0, 160(%r15), 3 # 16-byte Spill
-; SZ13-NEXT:    ld %f0, 0(%r1)
+; SZ13-NEXT:    ldr %f0, %f1
 ; SZ13-NEXT:    brasl %r14, exp2@PLT
 ; SZ13-NEXT:    larl %r1, .LCPI59_3
 ; SZ13-NEXT:    # kill: def $f0d killed $f0d def $v0
@@ -3487,12 +3496,13 @@ define <4 x double> @constrained_vector_log_v4f64() #0 {
 ; SZ13-NEXT:    vst %v0, 160(%r15), 3 # 16-byte Spill
 ; SZ13-NEXT:    ld %f0, 0(%r1)
 ; SZ13-NEXT:    brasl %r14, log@PLT
-; SZ13-NEXT:    vl %v1, 160(%r15), 3 # 16-byte Reload
-; SZ13-NEXT:    # kill: def $f0d killed $f0d def $v0
-; SZ13-NEXT:    vmrhg %v0, %v0, %v1
+; SZ13-NEXT:    vl %v2, 160(%r15), 3 # 16-byte Reload
 ; SZ13-NEXT:    larl %r1, .LCPI64_2
+; SZ13-NEXT:    ld %f1, 0(%r1)
+; SZ13-NEXT:    # kill: def $f0d killed $f0d def $v0
+; SZ13-NEXT:    vmrhg %v0, %v0, %v2
 ; SZ13-NEXT:    vst %v0, 160(%r15), 3 # 16-byte Spill
-; SZ13-NEXT:    ld %f0, 0(%r1)
+; SZ13-NEXT:    ldr %f0, %f1
 ; SZ13-NEXT:    brasl %r14, log@PLT
 ; SZ13-NEXT:    larl %r1, .LCPI64_3
 ; SZ13-NEXT:    # kill: def $f0d killed $f0d def $v0
@@ -3803,12 +3813,13 @@ define <4 x double> @constrained_vector_log10_v4f64() #0 {
 ; SZ13-NEXT:    vst %v0, 160(%r15), 3 # 16-byte Spill
 ; SZ13-NEXT:    ld %f0, 0(%r1)
 ; SZ13-NEXT:    brasl %r14, log10@PLT
-; SZ13-NEXT:    vl %v1, 160(%r15), 3 # 16-byte Reload
-; SZ13-NEXT:    # kill: def $f0d killed $f0d def $v0
-; SZ13-NEXT:    vmrhg %v0, %v0, %v1
+; SZ13-NEXT:    vl %v2, 160(%r15), 3 # 16-byte Reload
 ; SZ13-NEXT:    larl %r1, .LCPI69_2
+; SZ13-NEXT:    ld %f1, 0(%r1)
+; SZ13-NEXT:    # kill: def $f0d killed $f0d def $v0
+; SZ13-NEXT:    vmrhg %v0, %v0, %v2
 ; SZ13-NEXT:    vst %v0, 160(%r15), 3 # 16-byte Spill
-; SZ13-NEXT:    ld %f0, 0(%r1)
+; SZ13-NEXT:    ldr %f0, %f1
 ; SZ13-NEXT:    brasl %r14, log10@PLT
 ; SZ13-NEXT:    larl %r1, .LCPI69_3
 ; SZ13-NEXT:    # kill: def $f0d killed $f0d def $v0
@@ -4119,12 +4130,13 @@ define <4 x double> @constrained_vector_log2_v4f64() #0 {
 ; SZ13-NEXT:    vst %v0, 160(%r15), 3 # 16-byte Spill
 ; SZ13-NEXT:    ld %f0, 0(%r1)
 ; SZ13-NEXT:    brasl %r14, log2@PLT
-; SZ13-NEXT:    vl %v1, 160(%r15), 3 # 16-byte Reload
-; SZ13-NEXT:    # kill: def $f0d killed $f0d def $v0
-; SZ13-NEXT:    vmrhg %v0, %v0, %v1
+; SZ13-NEXT:    vl %v2, 160(%r15), 3 # 16-byte Reload
 ; SZ13-NEXT:    larl %r1, .LCPI74_2
+; SZ13-NEXT:    ld %f1, 0(%r1)
+; SZ13-NEXT:    # kill: def $f0d killed $f0d def $v0
+; SZ13-NEXT:    vmrhg %v0, %v0, %v2
 ; SZ13-NEXT:    vst %v0, 160(%r15), 3 # 16-byte Spill
-; SZ13-NEXT:    ld %f0, 0(%r1)
+; SZ13-NEXT:    ldr %f0, %f1
 ; SZ13-NEXT:    brasl %r14, log2@PLT
 ; SZ13-NEXT:    larl %r1, .LCPI74_3
 ; SZ13-NEXT:    # kill: def $f0d killed $f0d def $v0
@@ -4765,8 +4777,8 @@ define void @constrained_vector_log10_maxnum_v3f64(ptr %a) #0 {
 ; SZ13-NEXT:    larl %r1, .LCPI88_1
 ; SZ13-NEXT:    # kill: def $f0d killed $f0d def $v0
 ; SZ13-NEXT:    vst %v0, 160(%r15), 3 # 16-byte Spill
-; SZ13-NEXT:    vl %v0, 176(%r15), 3 # 16-byte Reload
 ; SZ13-NEXT:    ld %f2, 0(%r1)
+; SZ13-NEXT:    vl %v0, 176(%r15), 3 # 16-byte Reload
 ; SZ13-NEXT:    vrepg %v0, %v0, 1
 ; SZ13-NEXT:    # kill: def $f0d killed $f0d killed $v0
 ; SZ13-NEXT:    brasl %r14, fmax@PLT
@@ -5133,10 +5145,10 @@ define void @constrained_vector_minnum_v3f64(ptr %a) #0 {
 ; SZ13-NEXT:    .cfi_offset %f8, -168
 ; SZ13-NEXT:    .cfi_offset %f9, -176
 ; SZ13-NEXT:    larl %r1, .LCPI93_0
-; SZ13-NEXT:    ld %f9, 0(%r1)
+; SZ13-NEXT:    ld %f8, 0(%r1)
 ; SZ13-NEXT:    vl %v0, 0(%r2), 4
-; SZ13-NEXT:    ld %f8, 16(%r2)
-; SZ13-NEXT:    ldr %f2, %f9
+; SZ13-NEXT:    ld %f9, 16(%r2)
+; SZ13-NEXT:    ldr %f2, %f8
 ; SZ13-NEXT:    lgr %r13, %r2
 ; SZ13-NEXT:    vst %v0, 176(%r15), 3 # 16-byte Spill
 ; SZ13-NEXT:    # kill: def $f0d killed $f0d killed $v0
@@ -5144,7 +5156,7 @@ define void @constrained_vector_minnum_v3f64(ptr %a) #0 {
 ; SZ13-NEXT:    # kill: def $f0d killed $f0d def $v0
 ; SZ13-NEXT:    vst %v0, 160(%r15), 3 # 16-byte Spill
 ; SZ13-NEXT:    vl %v0, 176(%r15), 3 # 16-byte Reload
-; SZ13-NEXT:    ldr %f2, %f9
+; SZ13-NEXT:    ldr %f2, %f8
 ; SZ13-NEXT:    vrepg %v0, %v0, 1
 ; SZ13-NEXT:    # kill: def $f0d killed $f0d killed $v0
 ; SZ13-NEXT:    brasl %r14, fmin@PLT
@@ -5152,8 +5164,8 @@ define void @constrained_vector_minnum_v3f64(ptr %a) #0 {
 ; SZ13-NEXT:    # kill: def $f0d killed $f0d def $v0
 ; SZ13-NEXT:    vmrhg %v0, %v1, %v0
 ; SZ13-NEXT:    vst %v0, 160(%r15), 3 # 16-byte Spill
-; SZ13-NEXT:    ldr %f0, %f8
-; SZ13-NEXT:    ldr %f2, %f9
+; SZ13-NEXT:    ldr %f0, %f9
+; SZ13-NEXT:    ldr %f2, %f8
 ; SZ13-NEXT:    brasl %r14, fmin@PLT
 ; SZ13-NEXT:    mvc 0(16,%r13), 160(%r15) # 16-byte Folded Reload
 ; SZ13-NEXT:    ld %f8, 200(%r15) # 8-byte Reload
@@ -5344,15 +5356,15 @@ define void @constrained_vector_fptrunc_v3f64(ptr %src, ptr %dest) #0 {
 ;
 ; SZ13-LABEL: constrained_vector_fptrunc_v3f64:
 ; SZ13:       # %bb.0: # %entry
-; SZ13-NEXT:    vl %v1, 0(%r2), 4
-; SZ13-NEXT:    ld %f0, 16(%r2)
-; SZ13-NEXT:    vledb %v1, %v1, 0, 0
+; SZ13-NEXT:    vl %v0, 0(%r2), 4
+; SZ13-NEXT:    ld %f1, 16(%r2)
+; SZ13-NEXT:    vledb %v0, %v0, 0, 0
 ; SZ13-NEXT:    larl %r1, .LCPI97_0
-; SZ13-NEXT:    ledbra %f0, 0, %f0, 0
+; SZ13-NEXT:    ledbra %f1, 0, %f1, 0
 ; SZ13-NEXT:    vl %v2, 0(%r1), 3
-; SZ13-NEXT:    vperm %v1, %v1, %v1, %v2
-; SZ13-NEXT:    ste %f0, 8(%r3)
-; SZ13-NEXT:    vsteg %v1, 0(%r3), 0
+; SZ13-NEXT:    vperm %v0, %v0, %v0, %v2
+; SZ13-NEXT:    ste %f1, 8(%r3)
+; SZ13-NEXT:    vsteg %v0, 0(%r3), 0
 ; SZ13-NEXT:    br %r14
 entry:
   %b = load <3 x double>, ptr %src
@@ -6673,12 +6685,13 @@ define <4 x double> @constrained_vector_tan_v4f64() #0 {
 ; SZ13-NEXT:    vst %v0, 160(%r15), 3 # 16-byte Spill
 ; SZ13-NEXT:    ld %f0, 0(%r1)
 ; SZ13-NEXT:    brasl %r14, tan@PLT
-; SZ13-NEXT:    vl %v1, 160(%r15), 3 # 16-byte Reload
-; SZ13-NEXT:    # kill: def $f0d killed $f0d def $v0
-; SZ13-NEXT:    vmrhg %v0, %v0, %v1
+; SZ13-NEXT:    vl %v2, 160(%r15), 3 # 16-byte Reload
 ; SZ13-NEXT:    larl %r1, .LCPI127_2
+; SZ13-NEXT:    ld %f1, 0(%r1)
+; SZ13-NEXT:    # kill: def $f0d killed $f0d def $v0
+; SZ13-NEXT:    vmrhg %v0, %v0, %v2
 ; SZ13-NEXT:    vst %v0, 160(%r15), 3 # 16-byte Spill
-; SZ13-NEXT:    ld %f0, 0(%r1)
+; SZ13-NEXT:    ldr %f0, %f1
 ; SZ13-NEXT:    brasl %r14, tan@PLT
 ; SZ13-NEXT:    larl %r1, .LCPI127_3
 ; SZ13-NEXT:    # kill: def $f0d killed $f0d def $v0


### PR DESCRIPTION
Remove the "data-sequnces" check for latency reduction - this makes latency reduction happen in more regions.
 
Add some handling of liveness reduction by means of scheduling an SU that closes a live range "low".

* The wrapping of computeRemLatency() in getRemLat(): With increased usage of the latency heuristic, this gives a slight improvement: Worst case is the same (also against main), but on average, the pass time goes from 1.61% vs 1.67% without it. Not sure if this could simply be dropped still (given the marginal improvement), and/or be suggested for GenericScheduler (common-code).

* Testing: In order to use the test for liveness handling I had since before (misched-prera-loads.mir), two options were needed. TopRegionsSUs and DisableLatency were added just for this test, and I am not sure if that is ok or not:

  A. Keep as is: It makes sense in a way to have these options and do the test this way: with a smaller top region (12 instead of 36 instructions), the tests become more manageable, and disabling the latency - that now happens more often - is also useful as it would likely interfere.

  B. Remove these options and try to have *some* testing for liveness even if it means bigger regions (+36 instructions) and maybe not as readable and detailed (some new tests).

  C. Just remove the options and skip these scheduling tests. They have been great during experiments, but they are probably covered implicitly by all the other non-related tests that have been updated. TopRegionSUS would then just be a constant.

* Statistics:

```
main (4e383ec):
    162071                       regalloc - Number of spilled live ranges
    193327           systemz-elim-compare - Number of eliminated comparisons

this patch:
    166434                       regalloc - Number of spilled live ranges (+2.7%)
    184566           systemz-elim-compare - Number of eliminated comparisons

GenericScheduler (common-code):
    161988                       regalloc - Number of spilled live ranges
    191604           systemz-elim-compare - Number of eliminated comparisons

disabled (no pre-RA scheduling):
    160730                       regalloc - Number of spilled live ranges
    191871           systemz-elim-compare - Number of eliminated comparisons

```
Conclusion: Just like last time this was tried without the data-sequences heuristic these numbers deteriorate somewhat. However, performance measurements indicate that this does not matter in the end - the handling of latencies and "top-of-region" seems to be beneficial in this regard despite these numbers. As a follow-up it may be of interest to try to either improve on the cmp-elim results (did not work last time), or perhaps remove that handling if it doesn't help much.

* Improvement available for phys-reg coalescing, but probably very little performance impact (see e.g. risbg-04.ll / f21). I have already handled this once during experiments, but that did not matter so it was simplified away (then as a heuristic in SystemZPreRASchedStrategy). Since it is not critical but still good to have probably, maybe it would instead be worth a try in GenericScheduler/common-code at some point. This is the case of a vreg being copied to/from a preg when there are multiple uses of the vreg where it would be possible to have the user re-defining the vreg bottom-most (for COPY to preg) and avoid the overlap. Maybe this could be a DAG-mutator or somtheing like that (it seems the DAG-mutator for vregs copy-coalescing is not handling this type of case).

(Before rebase, 3dfeeff was NFC with 19c0077.)