### PR TITLE
[Hexagon] Clean up library and include paths and fix --sysroot

### DIFF
--- a/clang/lib/Driver/ToolChains/Hexagon.cpp
+++ b/clang/lib/Driver/ToolChains/Hexagon.cpp
@@ -277,7 +277,6 @@ constructHexagonLinkArgs(Compilation &C, const JobAction &JA,
   bool IncStdLib = !Args.hasArg(options::OPT_nostdlib);
   bool IncStartFiles = !Args.hasArg(options::OPT_nostartfiles);
   bool IncDefLibs = !Args.hasArg(options::OPT_nodefaultlibs);
-  bool UseG0 = false;
   bool UseLLD = false;
   const char *Exec = Args.MakeArgString(HTC.GetLinkerPath(&UseLLD));
   UseLLD = UseLLD || llvm::sys::path::filename(Exec).ends_with("ld.lld") ||
@@ -327,10 +326,8 @@ constructHexagonLinkArgs(Compilation &C, const JobAction &JA,
   if (IsPIE && !IsShared)
     CmdArgs.push_back("-pie");
 
-  if (auto G = toolchains::HexagonToolChain::getSmallDataThreshold(Args)) {
+  if (auto G = toolchains::HexagonToolChain::getSmallDataThreshold(Args))
     CmdArgs.push_back(Args.MakeArgString("-G" + Twine(*G)));
-    UseG0 = *G == 0;
-  }
 
   CmdArgs.push_back("-o");
   CmdArgs.push_back(Output.getFilename());
@@ -397,34 +394,22 @@ constructHexagonLinkArgs(Compilation &C, const JobAction &JA,
   //----------------------------------------------------------------------------
   // Start Files
   //----------------------------------------------------------------------------
-  const std::string MCpuSuffix = "/" + CpuVer.str();
-  const std::string MCpuG0Suffix = MCpuSuffix + "/G0";
-  const std::string RootDir =
-      HTC.getHexagonTargetDir(D.Dir, D.PrefixDirs) + "/";
-  const std::string StartSubDir =
-      "hexagon/lib" + (UseG0 ? MCpuG0Suffix : MCpuSuffix);
-
-  auto Find = [&HTC] (const std::string &RootDir, const std::string &SubDir,
-                      const char *Name) -> std::string {
-    std::string RelName = SubDir + Name;
-    std::string P = HTC.GetFilePath(RelName.c_str());
-    if (llvm::sys::fs::exists(P))
-      return P;
-    return RootDir + RelName;
-  };
+  SmallString<128> LibraryDir;
+  HTC.getLibraryDir(Args, LibraryDir);
 
   if (IncStdLib && IncStartFiles) {
     if (!IsShared) {
       if (HasStandalone) {
-        std::string Crt0SA = Find(RootDir, StartSubDir, "/crt0_standalone.o");
+        SmallString<128> Crt0SA = LibraryDir;
+        llvm::sys::path::append(Crt0SA, "crt0_standalone.o");
         CmdArgs.push_back(Args.MakeArgString(Crt0SA));
       }
-      std::string Crt0 = Find(RootDir, StartSubDir, "/crt0.o");
+      SmallString<128> Crt0 = LibraryDir;
+      llvm::sys::path::append(Crt0, "crt0.o");
       CmdArgs.push_back(Args.MakeArgString(Crt0));
     }
-    std::string Init = UseShared
-          ? Find(RootDir, StartSubDir + "/pic", "/initS.o")
-          : Find(RootDir, StartSubDir, "/init.o");
+    SmallString<128> Init = LibraryDir;
+    llvm::sys::path::append(Init, UseShared ? "initS.o" : "init.o");
     CmdArgs.push_back(Args.MakeArgString(Init));
   }
 
@@ -471,9 +456,8 @@ constructHexagonLinkArgs(Compilation &C, const JobAction &JA,
   // End files
   //----------------------------------------------------------------------------
   if (IncStdLib && IncStartFiles) {
-    std::string Fini = UseShared
-          ? Find(RootDir, StartSubDir + "/pic", "/finiS.o")
-          : Find(RootDir, StartSubDir, "/fini.o");
+    SmallString<128> Fini = LibraryDir;
+    llvm::sys::path::append(Fini, UseShared ? "finiS.o" : "fini.o");
     CmdArgs.push_back(Args.MakeArgString(Fini));
   }
 }
@@ -509,10 +493,64 @@ std::string HexagonToolChain::getHexagonTargetDir(
     if (D.getVFS().exists(I))
       return I;
 
-  if (getVFS().exists(InstallRelDir = InstalledDir + "/../target"))
-    return InstallRelDir;
+  SmallString<128> Dir(InstalledDir);
+  llvm::sys::path::append(Dir, "..", "target");
+  return std::string(Dir);
+}
 
-  return InstalledDir;
+SmallString<128> HexagonToolChain::getEffectiveSysRoot() const {
+  const Driver &D = getDriver();
+  // The user-specified `--sysroot` always takes precedence.
+  if (!D.SysRoot.empty())
+    return SmallString<128>(D.SysRoot);
+  // Otherwise, pick a path relative to the install directory. Try a triple
+  // subdirectory first.
+  SmallString<128> Dir(getHexagonTargetDir(D.Dir, D.PrefixDirs));
+  llvm::sys::path::append(Dir, getTriple().normalize());
+  if (getVFS().exists(Dir))
+    return Dir;
+  // Otherwise, fall back to "../target/hexagon".
+  Dir = getHexagonTargetDir(D.Dir, D.PrefixDirs);
+  llvm::sys::path::append(Dir, "hexagon");
+  return Dir;
+}
+
+void HexagonToolChain::getLibraryDir(const ArgList &Args,
+                                     llvm::SmallString<128> &Dir) const {
+  bool IsLinuxMusl = getTriple().isMusl() && getTriple().isOSLinux();
+  const llvm::SmallString<128> SysRoot = getEffectiveSysRoot();
+  // Linux toolchain uses "usr/lib" but it also should accept "lib" in case an
+  // external sysroot is used. Similar logic is for include paths.
+  if (IsLinuxMusl) {
+    Dir = SysRoot;
+    llvm::sys::path::append(Dir, "usr", "lib");
+  }
+  if (!IsLinuxMusl || !getVFS().exists(Dir)) {
+    Dir = SysRoot;
+    llvm::sys::path::append(Dir, "lib");
+  }
+  std::string CpuVer = GetTargetCPUVersion(Args).str();
+  llvm::sys::path::append(Dir, CpuVer);
+  if (auto G = toolchains::HexagonToolChain::getSmallDataThreshold(Args))
+    if (*G == 0)
+      llvm::sys::path::append(Dir, "G0");
+  bool IsStatic = Args.hasArg(options::OPT_static);
+  bool IsShared = Args.hasArg(options::OPT_shared);
+  if (IsShared && !IsStatic)
+    llvm::sys::path::append(Dir, "pic");
+}
+
+void HexagonToolChain::getBaseIncludeDir(llvm::SmallString<128> &Dir) const {
+  bool IsLinuxMusl = getTriple().isMusl() && getTriple().isOSLinux();
+  const llvm::SmallString<128> SysRoot = getEffectiveSysRoot();
+  if (IsLinuxMusl) {
+    Dir = SysRoot;
+    llvm::sys::path::append(Dir, "usr", "include");
+  }
+  if (!IsLinuxMusl || !getVFS().exists(Dir)) {
+    Dir = SysRoot;
+    llvm::sys::path::append(Dir, "include");
+  }
 }
 
 std::optional<unsigned>
@@ -558,9 +596,9 @@ void HexagonToolChain::getHexagonLibraryPaths(const ArgList &Args,
   std::copy(D.PrefixDirs.begin(), D.PrefixDirs.end(),
             std::back_inserter(RootDirs));
 
-  std::string TargetDir = getHexagonTargetDir(D.Dir, D.PrefixDirs);
-  if (!llvm::is_contained(RootDirs, TargetDir))
-    RootDirs.push_back(TargetDir);
+  std::string SysRoot(getEffectiveSysRoot());
+  if (!llvm::is_contained(RootDirs, SysRoot))
+    RootDirs.push_back(SysRoot);
 
   bool HasPIC = Args.hasArg(options::OPT_fpic, options::OPT_fPIC);
   // Assume G0 with -shared.
@@ -570,7 +608,7 @@ void HexagonToolChain::getHexagonLibraryPaths(const ArgList &Args,
 
   const std::string CpuVer = GetTargetCPUVersion(Args).str();
   for (auto &Dir : RootDirs) {
-    std::string LibDir = Dir + "/hexagon/lib";
+    std::string LibDir = Dir + "/lib";
     std::string LibDirCpu = LibDir + '/' + CpuVer;
     if (HasG0) {
       if (HasPIC)
@@ -585,14 +623,6 @@ void HexagonToolChain::getHexagonLibraryPaths(const ArgList &Args,
 HexagonToolChain::HexagonToolChain(const Driver &D, const llvm::Triple &Triple,
                                    const llvm::opt::ArgList &Args)
     : Linux(D, Triple, Args) {
-  const std::string TargetDir = getHexagonTargetDir(D.Dir, D.PrefixDirs);
-
-  // Note: Generic_GCC::Generic_GCC adds InstalledDir and getDriver().Dir to
-  // program paths
-  const std::string BinDir(TargetDir + "/bin");
-  if (D.getVFS().exists(BinDir))
-    getProgramPaths().push_back(BinDir);
-
   ToolChain::path_list &LibPaths = getFilePaths();
 
   // Remove paths added by Linux toolchain. Currently Hexagon_TC really targets
@@ -694,58 +724,42 @@ void HexagonToolChain::AddClangSystemIncludeArgs(const ArgList &DriverArgs,
 
   const Driver &D = getDriver();
   const bool UseBuiltins = !DriverArgs.hasArg(options::OPT_nobuiltininc);
-  const bool HasSysRoot = !D.SysRoot.empty();
-  const bool IsLinuxMusl = getTriple().isMusl() && getTriple().isOSLinux();
-
   if (UseBuiltins) {
     SmallString<128> ResourceDirInclude(D.ResourceDir);
     llvm::sys::path::append(ResourceDirInclude, "include");
     addSystemInclude(DriverArgs, CC1Args, ResourceDirInclude);
   }
-  if (DriverArgs.hasArg(options::OPT_nostdlibinc))
-    return;
-  if (HasSysRoot) {
-    SmallString<128> P(D.SysRoot);
-    if (IsLinuxMusl)
-      llvm::sys::path::append(P, "usr/include");
-    else
-      llvm::sys::path::append(P, "include");
-
-    addExternCSystemInclude(DriverArgs, CC1Args, P.str());
-    // LOCAL_INCLUDE_DIR
-    addSystemInclude(DriverArgs, CC1Args, P + "/usr/local/include");
+  if (!DriverArgs.hasArg(options::OPT_nostdlibinc)) {
+    SmallString<128> CIncludeDir;
+    getBaseIncludeDir(CIncludeDir);
+    addExternCSystemInclude(DriverArgs, CC1Args, std::string(CIncludeDir));
+    bool IsLinuxMusl = getTriple().isMusl() && getTriple().isOSLinux();
+    if (IsLinuxMusl) {
+      SmallString<128> LocalIncludeDir = getEffectiveSysRoot();
+      llvm::sys::path::append(LocalIncludeDir, "usr", "local", "include");
+      addSystemInclude(DriverArgs, CC1Args, LocalIncludeDir);
+    }
     // TOOL_INCLUDE_DIR
     AddMultilibIncludeArgs(DriverArgs, CC1Args);
-  } else {
-    std::string TargetDir = getHexagonTargetDir(D.Dir, D.PrefixDirs);
-    addExternCSystemInclude(DriverArgs, CC1Args,
-                            TargetDir + "/hexagon/include");
   }
 }
 
 void HexagonToolChain::addLibCxxIncludePaths(
     const llvm::opt::ArgList &DriverArgs,
     llvm::opt::ArgStringList &CC1Args) const {
-  const Driver &D = getDriver();
-  if (!D.SysRoot.empty() && getTriple().isMusl())
-    addLibStdCXXIncludePaths(D.SysRoot + "/usr/include/c++/v1", "", "",
-                             DriverArgs, CC1Args);
-  else if (getTriple().isMusl())
-    addLibStdCXXIncludePaths("/usr/include/c++/v1", "", "", DriverArgs,
-                             CC1Args);
-  else {
-    std::string TargetDir = getHexagonTargetDir(D.Dir, D.PrefixDirs);
-    addLibStdCXXIncludePaths(TargetDir + "/hexagon/include/c++/v1", "", "",
-                             DriverArgs, CC1Args);
-  }
+  SmallString<128> Dir;
+  getBaseIncludeDir(Dir);
+  llvm::sys::path::append(Dir, "c++", "v1");
+  addLibStdCXXIncludePaths(Dir, "", "", DriverArgs, CC1Args);
 }
+
 void HexagonToolChain::addLibStdCxxIncludePaths(
     const llvm::opt::ArgList &DriverArgs,
     llvm::opt::ArgStringList &CC1Args) const {
-  const Driver &D = getDriver();
-  std::string TargetDir = getHexagonTargetDir(D.Dir, D.PrefixDirs);
-  addLibStdCXXIncludePaths(TargetDir + "/hexagon/include/c++", "", "",
-                           DriverArgs, CC1Args);
+  SmallString<128> Dir;
+  getBaseIncludeDir(Dir);
+  llvm::sys::path::append(Dir, "c++");
+  addLibStdCXXIncludePaths(Dir, "", "", DriverArgs, CC1Args);
 }
 
 ToolChain::CXXStdlibType

--- a/clang/lib/Driver/ToolChains/Hexagon.h
+++ b/clang/lib/Driver/ToolChains/Hexagon.h
@@ -102,8 +102,12 @@ public:
   std::string getHexagonTargetDir(
       const std::string &InstalledDir,
       const SmallVectorImpl<std::string> &PrefixDirs) const;
+  SmallString<128> getEffectiveSysRoot() const;
+  void getBaseIncludeDir(llvm::SmallString<128> &) const;
+  void getLibraryDir(const llvm::opt::ArgList &Args,
+                     llvm::SmallString<128> &) const;
   void getHexagonLibraryPaths(const llvm::opt::ArgList &Args,
-      ToolChain::path_list &LibPaths) const;
+                              ToolChain::path_list &LibPaths) const;
 
   std::string getCompilerRTPath() const override;
 

--- a/clang/test/Driver/hexagon-toolchain-elf.c
+++ b/clang/test/Driver/hexagon-toolchain-elf.c
@@ -4,12 +4,12 @@
 
 // RUN: %clang -### --target=hexagon-unknown-elf \
 // RUN:   -ccc-install-dir %S/Inputs/hexagon_tree/Tools/bin %s 2>&1 | FileCheck -check-prefix=CHECK000 %s
-// CHECK000: "-cc1" {{.*}} "-internal-externc-isystem" "{{.*}}/Inputs/hexagon_tree/Tools/bin/../target/hexagon/include"
+// CHECK000: "-cc1" {{.*}} "-internal-externc-isystem" "{{.*}}/Inputs/hexagon_tree/Tools/bin{{/|\\\\}}..{{/|\\\\}}target{{/|\\\\}}hexagon{{/|\\\\}}include"
 
 // RUN: %clangxx -### --target=hexagon-unknown-elf \
 // RUN:   -ccc-install-dir %S/Inputs/hexagon_tree/Tools/bin %s 2>&1 | FileCheck -check-prefix=CHECK001 %s
-// CHECK001: "-cc1" {{.*}} "-internal-isystem" "{{.*}}/Inputs/hexagon_tree/Tools/bin/../target/hexagon/include/c++"
-// CHECK001:   "-internal-externc-isystem" "{{.*}}/Inputs/hexagon_tree/Tools/bin/../target/hexagon/include"
+// CHECK001: "-cc1" {{.*}} "-internal-isystem" "{{.*}}/Inputs/hexagon_tree/Tools/bin{{/|\\\\}}..{{/|\\\\}}target{{/|\\\\}}hexagon{{/|\\\\}}include{{/|\\\\}}c++"
+// CHECK001:   "-internal-externc-isystem" "{{.*}}/Inputs/hexagon_tree/Tools/bin{{/|\\\\}}..{{/|\\\\}}target{{/|\\\\}}hexagon{{/|\\\\}}include"
 
 // -----------------------------------------------------------------------------
 // Test -nostdinc, -nostdlibinc, -nostdinc++
@@ -34,7 +34,7 @@
 // CHECK-RESOURCE-DIR: "-cc1"
 // CHECK-RESOURCE-DIR: "-resource-dir" "[[RESOURCE:[^"]+]]"
 // CHECK-RESOURCE-DIR: "-internal-isystem" "[[RESOURCE]]{{/|\\\\}}include"
-// CHECK-RESOURCE-DIR: "-internal-externc-isystem" "{{.*}}/Inputs/hexagon_tree/Tools/bin/../target/hexagon/include"
+// CHECK-RESOURCE-DIR: "-internal-externc-isystem" "{{.*}}/Inputs/hexagon_tree/Tools/bin{{/|\\\\}}..{{/|\\\\}}target{{/|\\\\}}hexagon{{/|\\\\}}include"
 
 // RUN: %clangxx -### --target=hexagon-unknown-elf \
 // RUN:   -ccc-install-dir %S/Inputs/hexagon_tree/Tools/bin \
@@ -44,7 +44,7 @@
 // CHECK112: "-resource-dir" "[[RESOURCE:[^"]+]]"
 // CHECK112: "-internal-isystem" "[[RESOURCE]]{{/|\\\\}}include"
 // CHECK112-NOT: "-internal-isystem"
-// CHECK112-DAG: "-internal-externc-isystem" "{{.*}}/Inputs/hexagon_tree/Tools/bin/../target/hexagon/include"
+// CHECK112-DAG: "-internal-externc-isystem" "{{.*}}/Inputs/hexagon_tree/Tools/bin{{/|\\\\}}..{{/|\\\\}}target{{/|\\\\}}hexagon{{/|\\\\}}include"
 
 // RUN: %clangxx -### --target=hexagon-unknown-elf -fno-integrated-as    \
 // RUN:   -ccc-install-dir %S/Inputs/hexagon_tree/qc/bin \
@@ -63,37 +63,37 @@
 // RUN:   -ccc-install-dir %S/Inputs/hexagon_tree/Tools/bin \
 // RUN:   -mcpu=hexagonv5 %s 2>&1 | FileCheck -check-prefix=CHECK221 %s
 // CHECK221: "-cc1" {{.*}} "-target-cpu" "hexagonv5"
-// CHECK221: {{hexagon-link|ld}}{{.*}}/Inputs/hexagon_tree/Tools/bin/../target/hexagon/lib/v5/crt0
+// CHECK221: {{hexagon-link|ld}}{{.*}}/Inputs/hexagon_tree/Tools/bin{{/|\\\\}}..{{/|\\\\}}target{{/|\\\\}}hexagon{{/|\\\\}}lib{{/|\\\\}}v5{{/|\\\\}}crt0
 
 // RUN: %clang -### --target=hexagon-unknown-elf \
 // RUN:   -ccc-install-dir %S/Inputs/hexagon_tree/Tools/bin \
 // RUN:   -mcpu=hexagonv55 %s 2>&1 | FileCheck -check-prefix=CHECK222 %s
 // CHECK222: "-cc1" {{.*}} "-target-cpu" "hexagonv55"
-// CHECK222: {{hexagon-link|ld}}{{.*}}/Inputs/hexagon_tree/Tools/bin/../target/hexagon/lib/v55/crt0
+// CHECK222: {{hexagon-link|ld}}{{.*}}/Inputs/hexagon_tree/Tools/bin{{/|\\\\}}..{{/|\\\\}}target{{/|\\\\}}hexagon{{/|\\\\}}lib{{/|\\\\}}v55{{/|\\\\}}crt0
 
 // RUN: %clang -### --target=hexagon-unknown-elf \
 // RUN:   -ccc-install-dir %S/Inputs/hexagon_tree/Tools/bin \
 // RUN:   -mcpu=hexagonv60 %s 2>&1 | FileCheck -check-prefix=CHECK223 %s
 // CHECK223: "-cc1" {{.*}} "-target-cpu" "hexagonv60"
-// CHECK223: {{hexagon-link|ld}}{{.*}}/Inputs/hexagon_tree/Tools/bin/../target/hexagon/lib/v60/crt0
+// CHECK223: {{hexagon-link|ld}}{{.*}}/Inputs/hexagon_tree/Tools/bin{{/|\\\\}}..{{/|\\\\}}target{{/|\\\\}}hexagon{{/|\\\\}}lib{{/|\\\\}}v60{{/|\\\\}}crt0
 
 // RUN: %clang -### --target=hexagon-unknown-elf \
 // RUN:   -ccc-install-dir %S/Inputs/hexagon_tree/Tools/bin \
 // RUN:   -mcpu=hexagonv62 %s 2>&1 | FileCheck -check-prefix=CHECK224 %s
 // CHECK224: "-cc1" {{.*}} "-target-cpu" "hexagonv62"
-// CHECK224: {{hexagon-link|ld}}{{.*}}/Inputs/hexagon_tree/Tools/bin/../target/hexagon/lib/v62/crt0
+// CHECK224: {{hexagon-link|ld}}{{.*}}/Inputs/hexagon_tree/Tools/bin{{/|\\\\}}..{{/|\\\\}}target{{/|\\\\}}hexagon{{/|\\\\}}lib{{/|\\\\}}v62{{/|\\\\}}crt0
 
 // RUN: %clang -### --target=hexagon-unknown-elf \
 // RUN:   -ccc-install-dir %S/Inputs/hexagon_tree/Tools/bin \
 // RUN:   -mcpu=hexagonv65 %s 2>&1 | FileCheck -check-prefix=CHECK225 %s
 // CHECK225: "-cc1" {{.*}} "-target-cpu" "hexagonv65"
-// CHECK225: {{hexagon-link|ld}}{{.*}}/Inputs/hexagon_tree/Tools/bin/../target/hexagon/lib/v65/crt0
+// CHECK225: {{hexagon-link|ld}}{{.*}}/Inputs/hexagon_tree/Tools/bin{{/|\\\\}}..{{/|\\\\}}target{{/|\\\\}}hexagon{{/|\\\\}}lib{{/|\\\\}}v65{{/|\\\\}}crt0
 
 // RUN: %clang -### --target=hexagon-unknown-elf \
 // RUN:   -ccc-install-dir %S/Inputs/hexagon_tree/Tools/bin \
 // RUN:   -mcpu=hexagonv66 %s 2>&1 | FileCheck -check-prefix=CHECK226 %s
 // CHECK226: "-cc1" {{.*}} "-target-cpu" "hexagonv66"
-// CHECK226: {{hexagon-link|ld}}{{.*}}/Inputs/hexagon_tree/Tools/bin/../target/hexagon/lib/v66/crt0
+// CHECK226: {{hexagon-link|ld}}{{.*}}/Inputs/hexagon_tree/Tools/bin{{/|\\\\}}..{{/|\\\\}}target{{/|\\\\}}hexagon{{/|\\\\}}lib{{/|\\\\}}v66{{/|\\\\}}crt0
 
 // RUN: %clang -### --target=hexagon-unknown-elf \
 // RUN:   -ccc-install-dir %S/Inputs/hexagon_tree/Tools/bin \
@@ -116,77 +116,77 @@
 // RUN:   -mv65 -march=hexagon\
 // RUN:   %s 2>&1 | FileCheck -check-prefix=CHECK229 %s
 // CHECK229: "-cc1" {{.*}} "-target-cpu" "hexagonv65"
-// CHECK229: {{hexagon-link|ld}}{{.*}}/Inputs/hexagon_tree/Tools/bin/../target/hexagon/lib/v65/crt0
+// CHECK229: {{hexagon-link|ld}}{{.*}}/Inputs/hexagon_tree/Tools/bin{{/|\\\\}}..{{/|\\\\}}target{{/|\\\\}}hexagon{{/|\\\\}}lib{{/|\\\\}}v65{{/|\\\\}}crt0
 
 // RUN: not %clang -### --target=hexagon-unknown-elf \
 // RUN:   -ccc-install-dir %S/Inputs/hexagon_tree/Tools/bin \
 // RUN:   -mcpu=hexagonv67 -fuse-ld=hexagon-link \
 // RUN:   %s 2>&1 | FileCheck -check-prefix=CHECK22A %s
 // CHECK22A: "-cc1" {{.*}} "-target-cpu" "hexagonv67"
-// CHECK22A: hexagon-link{{.*}}/Inputs/hexagon_tree/Tools/bin/../target/hexagon/lib/v67/crt0
+// CHECK22A: hexagon-link{{.*}}/Inputs/hexagon_tree/Tools/bin{{/|\\\\}}..{{/|\\\\}}target{{/|\\\\}}hexagon{{/|\\\\}}lib{{/|\\\\}}v67{{/|\\\\}}crt0
 
 // RUN: not %clang -### --target=hexagon-unknown-elf \
 // RUN:   -ccc-install-dir %S/Inputs/hexagon_tree/Tools/bin \
 // RUN:   -mcpu=hexagonv67t \
 // RUN:   -fuse-ld=fake-value-to-ignore-CLANG_DEFAULT_LINKER %s 2>&1 | FileCheck -check-prefix=CHECK22B %s
 // CHECK22B: "-cc1" {{.*}} "-target-cpu" "hexagonv67t"
-// CHECK22B: hexagon-link{{.*}}/Inputs/hexagon_tree/Tools/bin/../target/hexagon/lib/v67t/crt0
+// CHECK22B: hexagon-link{{.*}}/Inputs/hexagon_tree/Tools/bin{{/|\\\\}}..{{/|\\\\}}target{{/|\\\\}}hexagon{{/|\\\\}}lib{{/|\\\\}}v67t{{/|\\\\}}crt0
 
 // RUN: not %clang -### --target=hexagon-unknown-elf \
 // RUN:   -ccc-install-dir %S/Inputs/hexagon_tree/Tools/bin \
 // RUN:   -mcpu=hexagonv68 -fuse-ld=hexagon-link \
 // RUN:   %s 2>&1 | FileCheck -check-prefix=CHECK22C %s
 // CHECK22C: "-cc1" {{.*}} "-target-cpu" "hexagonv68"
-// CHECK22C: hexagon-link{{.*}}/Inputs/hexagon_tree/Tools/bin/../target/hexagon/lib/v68/crt0
+// CHECK22C: hexagon-link{{.*}}/Inputs/hexagon_tree/Tools/bin{{/|\\\\}}..{{/|\\\\}}target{{/|\\\\}}hexagon{{/|\\\\}}lib{{/|\\\\}}v68{{/|\\\\}}crt0
 
 // RUN: not %clang -### --target=hexagon-unknown-elf \
 // RUN:   -ccc-install-dir %S/Inputs/hexagon_tree/Tools/bin \
 // RUN:   -mcpu=hexagonv69 -fuse-ld=hexagon-link \
 // RUN:   %s 2>&1 | FileCheck -check-prefix=CHECK22D %s
 // CHECK22D: "-cc1" {{.*}} "-target-cpu" "hexagonv69"
-// CHECK22D: hexagon-link{{.*}}/Inputs/hexagon_tree/Tools/bin/../target/hexagon/lib/v69/crt0
+// CHECK22D: hexagon-link{{.*}}/Inputs/hexagon_tree/Tools/bin{{/|\\\\}}..{{/|\\\\}}target{{/|\\\\}}hexagon{{/|\\\\}}lib{{/|\\\\}}v69{{/|\\\\}}crt0
 
 // RUN: not %clang -### --target=hexagon-unknown-elf \
 // RUN:   -ccc-install-dir %S/Inputs/hexagon_tree/Tools/bin \
 // RUN:   -mcpu=hexagonv71 -fuse-ld=hexagon-link \
 // RUN:   %s 2>&1 | FileCheck -check-prefix=CHECK22E %s
 // CHECK22E: "-cc1" {{.*}} "-target-cpu" "hexagonv71"
-// CHECK22E: hexagon-link{{.*}}/Inputs/hexagon_tree/Tools/bin/../target/hexagon/lib/v71/crt0
+// CHECK22E: hexagon-link{{.*}}/Inputs/hexagon_tree/Tools/bin{{/|\\\\}}..{{/|\\\\}}target{{/|\\\\}}hexagon{{/|\\\\}}lib{{/|\\\\}}v71{{/|\\\\}}crt0
 
 // RUN: not %clang -### --target=hexagon-unknown-elf \
 // RUN:   -ccc-install-dir %S/Inputs/hexagon_tree/Tools/bin \
 // RUN:   -mcpu=hexagonv71t -fuse-ld=hexagon-link \
 // RUN:   %s 2>&1 | FileCheck -check-prefix=CHECK22F %s
 // CHECK22F: "-cc1" {{.*}} "-target-cpu" "hexagonv71t"
-// CHECK22F: hexagon-link{{.*}}/Inputs/hexagon_tree/Tools/bin/../target/hexagon/lib/v71t/crt0
+// CHECK22F: hexagon-link{{.*}}/Inputs/hexagon_tree/Tools/bin{{/|\\\\}}..{{/|\\\\}}target{{/|\\\\}}hexagon{{/|\\\\}}lib{{/|\\\\}}v71t{{/|\\\\}}crt0
 
 // RUN: not %clang -### --target=hexagon-unknown-elf \
 // RUN:   -ccc-install-dir %S/Inputs/hexagon_tree/Tools/bin \
 // RUN:   -mcpu=hexagonv73 -fuse-ld=hexagon-link \
 // RUN:   %s 2>&1 | FileCheck -check-prefix=CHECK230 %s
 // CHECK230: "-cc1" {{.*}} "-target-cpu" "hexagonv73"
-// CHECK230: hexagon-link{{.*}}/Inputs/hexagon_tree/Tools/bin/../target/hexagon/lib/v73/crt0
+// CHECK230: hexagon-link{{.*}}/Inputs/hexagon_tree/Tools/bin{{/|\\\\}}..{{/|\\\\}}target{{/|\\\\}}hexagon{{/|\\\\}}lib{{/|\\\\}}v73{{/|\\\\}}crt0
 
 // RUN: not %clang -### --target=hexagon-unknown-elf \
 // RUN:   -ccc-install-dir %S/Inputs/hexagon_tree/Tools/bin \
 // RUN:   -mcpu=hexagonv75 -fuse-ld=hexagon-link \
 // RUN:   %s 2>&1 | FileCheck -check-prefix=CHECK240 %s
 // CHECK240: "-cc1" {{.*}} "-target-cpu" "hexagonv75"
-// CHECK240: hexagon-link{{.*}}/Inputs/hexagon_tree/Tools/bin/../target/hexagon/lib/v75/crt0
+// CHECK240: hexagon-link{{.*}}/Inputs/hexagon_tree/Tools/bin{{/|\\\\}}..{{/|\\\\}}target{{/|\\\\}}hexagon{{/|\\\\}}lib{{/|\\\\}}v75{{/|\\\\}}crt0
 
 // RUN: not %clang -### --target=hexagon-unknown-elf \
 // RUN:   -ccc-install-dir %S/Inputs/hexagon_tree/Tools/bin \
 // RUN:   -mcpu=hexagonv79 -fuse-ld=hexagon-link \
 // RUN:   %s 2>&1 | FileCheck -check-prefix=CHECK250 %s
 // CHECK250: "-cc1" {{.*}} "-target-cpu" "hexagonv79"
-// CHECK250: hexagon-link{{.*}}/Inputs/hexagon_tree/Tools/bin/../target/hexagon/lib/v79/crt0
+// CHECK250: hexagon-link{{.*}}/Inputs/hexagon_tree/Tools/bin{{/|\\\\}}..{{/|\\\\}}target{{/|\\\\}}hexagon{{/|\\\\}}lib{{/|\\\\}}v79{{/|\\\\}}crt0
 
 // RUN: not %clang -### --target=hexagon-unknown-elf \
 // RUN:   -ccc-install-dir %S/Inputs/hexagon_tree/Tools/bin \
 // RUN:   -mcpu=hexagonv81 -fuse-ld=hexagon-link \
 // RUN:   %s 2>&1 | FileCheck -check-prefix=CHECK260 %s
 // CHECK260: "-cc1" {{.*}} "-target-cpu" "hexagonv81"
-// CHECK260: hexagon-link{{.*}}/Inputs/hexagon_tree/Tools/bin/../target/hexagon/lib/v81/crt0
+// CHECK260: hexagon-link{{.*}}/Inputs/hexagon_tree/Tools/bin{{/|\\\\}}..{{/|\\\\}}target{{/|\\\\}}hexagon{{/|\\\\}}lib{{/|\\\\}}v81{{/|\\\\}}crt0
 
 // -----------------------------------------------------------------------------
 // Test Linker related args
@@ -202,14 +202,14 @@
 // CHECK330: {{hexagon-link|ld}}
 // CHECK330-NOT: "-static"
 // CHECK330-NOT: "-shared"
-// CHECK330: "{{.*}}/Inputs/hexagon_tree/Tools/bin/../target/hexagon/lib/v60/crt0_standalone.o"
-// CHECK330: "{{.*}}/Inputs/hexagon_tree/Tools/bin/../target/hexagon/lib/v60/crt0.o"
-// CHECK330: "{{.*}}/Inputs/hexagon_tree/Tools/bin/../target/hexagon/lib/v60/init.o"
-// CHECK330: "-L{{.*}}/Inputs/hexagon_tree/Tools/bin/../target/hexagon/lib/v60"
-// CHECK330: "-L{{.*}}/Inputs/hexagon_tree/Tools/bin/../target/hexagon/lib"
+// CHECK330: "{{.*}}/Inputs/hexagon_tree/Tools/bin{{/|\\\\}}..{{/|\\\\}}target{{/|\\\\}}hexagon{{/|\\\\}}lib{{/|\\\\}}v60{{/|\\\\}}crt0_standalone.o"
+// CHECK330: "{{.*}}/Inputs/hexagon_tree/Tools/bin{{/|\\\\}}..{{/|\\\\}}target{{/|\\\\}}hexagon{{/|\\\\}}lib{{/|\\\\}}v60{{/|\\\\}}crt0.o"
+// CHECK330: "{{.*}}/Inputs/hexagon_tree/Tools/bin{{/|\\\\}}..{{/|\\\\}}target{{/|\\\\}}hexagon{{/|\\\\}}lib{{/|\\\\}}v60{{/|\\\\}}init.o"
+// CHECK330: "-L{{.*}}/Inputs/hexagon_tree/Tools/bin{{/|\\\\}}..{{/|\\\\}}target{{/|\\\\}}hexagon{{/|\\\\}}lib{{/|\\\\}}v60"
+// CHECK330: "-L{{.*}}/Inputs/hexagon_tree/Tools/bin{{/|\\\\}}..{{/|\\\\}}target{{/|\\\\}}hexagon{{/|\\\\}}lib"
 // CHECK330: "{{[^"]+}}.o"
 // CHECK330: "--start-group" "-lstandalone" "-lc" "-lgcc" "--end-group"
-// CHECK330: "{{.*}}/Inputs/hexagon_tree/Tools/bin/../target/hexagon/lib/v60/fini.o"
+// CHECK330: "{{.*}}/Inputs/hexagon_tree/Tools/bin{{/|\\\\}}..{{/|\\\\}}target{{/|\\\\}}hexagon{{/|\\\\}}lib{{/|\\\\}}v60{{/|\\\\}}fini.o"
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 // Defaults for C++
@@ -221,14 +221,14 @@
 // CHECK331: {{hexagon-link|ld}}
 // CHECK331-NOT: "-static"
 // CHECK331-NOT: "-shared"
-// CHECK331: "{{.*}}/Inputs/hexagon_tree/Tools/bin/../target/hexagon/lib/v60/crt0_standalone.o"
-// CHECK331-SAME: "{{.*}}/Inputs/hexagon_tree/Tools/bin/../target/hexagon/lib/v60/crt0.o"
-// CHECK331-SAME: "{{.*}}/Inputs/hexagon_tree/Tools/bin/../target/hexagon/lib/v60/init.o"
-// CHECK331-SAME: "-L{{.*}}/Inputs/hexagon_tree/Tools/bin/../target/hexagon/lib/v60"
-// CHECK331-SAME: "-L{{.*}}/Inputs/hexagon_tree/Tools/bin/../target/hexagon/lib"
+// CHECK331: "{{.*}}/Inputs/hexagon_tree/Tools/bin{{/|\\\\}}..{{/|\\\\}}target{{/|\\\\}}hexagon{{/|\\\\}}lib{{/|\\\\}}v60{{/|\\\\}}crt0_standalone.o"
+// CHECK331-SAME: "{{.*}}/Inputs/hexagon_tree/Tools/bin{{/|\\\\}}..{{/|\\\\}}target{{/|\\\\}}hexagon{{/|\\\\}}lib{{/|\\\\}}v60{{/|\\\\}}crt0.o"
+// CHECK331-SAME: "{{.*}}/Inputs/hexagon_tree/Tools/bin{{/|\\\\}}..{{/|\\\\}}target{{/|\\\\}}hexagon{{/|\\\\}}lib{{/|\\\\}}v60{{/|\\\\}}init.o"
+// CHECK331-SAME: "-L{{.*}}/Inputs/hexagon_tree/Tools/bin{{/|\\\\}}..{{/|\\\\}}target{{/|\\\\}}hexagon{{/|\\\\}}lib{{/|\\\\}}v60"
+// CHECK331-SAME: "-L{{.*}}/Inputs/hexagon_tree/Tools/bin{{/|\\\\}}..{{/|\\\\}}target{{/|\\\\}}hexagon{{/|\\\\}}lib"
 // CHECK331-SAME: "{{[^"]+}}.o"
 // CHECK331-SAME: "-lstdc++" "-lm" "--start-group" "-lstandalone" "-lc" "-lgcc" "--end-group"
-// CHECK331-SAME: "{{.*}}/Inputs/hexagon_tree/Tools/bin/../target/hexagon/lib/v60/fini.o"
+// CHECK331-SAME: "{{.*}}/Inputs/hexagon_tree/Tools/bin{{/|\\\\}}..{{/|\\\\}}target{{/|\\\\}}hexagon{{/|\\\\}}lib{{/|\\\\}}v60{{/|\\\\}}fini.o"
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 // Additional Libraries (-L)
@@ -241,15 +241,15 @@
 // CHECK332: {{hexagon-link|ld}}
 // CHECK332-NOT: "-static"
 // CHECK332-NOT: "-shared"
-// CHECK332: "{{.*}}/Inputs/hexagon_tree/Tools/bin/../target/hexagon/lib/v60/crt0_standalone.o"
-// CHECK332: "{{.*}}/Inputs/hexagon_tree/Tools/bin/../target/hexagon/lib/v60/crt0.o"
-// CHECK332: "{{.*}}/Inputs/hexagon_tree/Tools/bin/../target/hexagon/lib/v60/init.o"
+// CHECK332: "{{.*}}/Inputs/hexagon_tree/Tools/bin{{/|\\\\}}..{{/|\\\\}}target{{/|\\\\}}hexagon{{/|\\\\}}lib{{/|\\\\}}v60{{/|\\\\}}crt0_standalone.o"
+// CHECK332: "{{.*}}/Inputs/hexagon_tree/Tools/bin{{/|\\\\}}..{{/|\\\\}}target{{/|\\\\}}hexagon{{/|\\\\}}lib{{/|\\\\}}v60{{/|\\\\}}crt0.o"
+// CHECK332: "{{.*}}/Inputs/hexagon_tree/Tools/bin{{/|\\\\}}..{{/|\\\\}}target{{/|\\\\}}hexagon{{/|\\\\}}lib{{/|\\\\}}v60{{/|\\\\}}init.o"
 // CHECK332: "-Lone" "-Ltwo" "-Lthree"
-// CHECK332: "-L{{.*}}/Inputs/hexagon_tree/Tools/bin/../target/hexagon/lib/v60"
-// CHECK332: "-L{{.*}}/Inputs/hexagon_tree/Tools/bin/../target/hexagon/lib"
+// CHECK332: "-L{{.*}}/Inputs/hexagon_tree/Tools/bin{{/|\\\\}}..{{/|\\\\}}target{{/|\\\\}}hexagon{{/|\\\\}}lib{{/|\\\\}}v60"
+// CHECK332: "-L{{.*}}/Inputs/hexagon_tree/Tools/bin{{/|\\\\}}..{{/|\\\\}}target{{/|\\\\}}hexagon{{/|\\\\}}lib"
 // CHECK332: "{{[^"]+}}.o"
 // CHECK332: "--start-group" "-lstandalone" "-lc" "-lgcc" "--end-group"
-// CHECK332: "{{.*}}/Inputs/hexagon_tree/Tools/bin/../target/hexagon/lib/v60/fini.o"
+// CHECK332: "{{.*}}/Inputs/hexagon_tree/Tools/bin{{/|\\\\}}..{{/|\\\\}}target{{/|\\\\}}hexagon{{/|\\\\}}lib{{/|\\\\}}v60{{/|\\\\}}fini.o"
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 // -static, -shared
@@ -261,14 +261,14 @@
 // CHECK333: "-cc1"
 // CHECK333: {{hexagon-link|ld}}
 // CHECK333: "-static"
-// CHECK333: "{{.*}}/Inputs/hexagon_tree/Tools/bin/../target/hexagon/lib/v60/crt0_standalone.o"
-// CHECK333: "{{.*}}/Inputs/hexagon_tree/Tools/bin/../target/hexagon/lib/v60/crt0.o"
-// CHECK333: "{{.*}}/Inputs/hexagon_tree/Tools/bin/../target/hexagon/lib/v60/init.o"
-// CHECK333: "-L{{.*}}/Inputs/hexagon_tree/Tools/bin/../target/hexagon/lib/v60"
-// CHECK333: "-L{{.*}}/Inputs/hexagon_tree/Tools/bin/../target/hexagon/lib"
+// CHECK333: "{{.*}}/Inputs/hexagon_tree/Tools/bin{{/|\\\\}}..{{/|\\\\}}target{{/|\\\\}}hexagon{{/|\\\\}}lib{{/|\\\\}}v60{{/|\\\\}}crt0_standalone.o"
+// CHECK333: "{{.*}}/Inputs/hexagon_tree/Tools/bin{{/|\\\\}}..{{/|\\\\}}target{{/|\\\\}}hexagon{{/|\\\\}}lib{{/|\\\\}}v60{{/|\\\\}}crt0.o"
+// CHECK333: "{{.*}}/Inputs/hexagon_tree/Tools/bin{{/|\\\\}}..{{/|\\\\}}target{{/|\\\\}}hexagon{{/|\\\\}}lib{{/|\\\\}}v60{{/|\\\\}}init.o"
+// CHECK333: "-L{{.*}}/Inputs/hexagon_tree/Tools/bin{{/|\\\\}}..{{/|\\\\}}target{{/|\\\\}}hexagon{{/|\\\\}}lib{{/|\\\\}}v60"
+// CHECK333: "-L{{.*}}/Inputs/hexagon_tree/Tools/bin{{/|\\\\}}..{{/|\\\\}}target{{/|\\\\}}hexagon{{/|\\\\}}lib"
 // CHECK333: "{{[^"]+}}.o"
 // CHECK333: "--start-group" "-lstandalone" "-lc" "-lgcc" "--end-group"
-// CHECK333: "{{.*}}/Inputs/hexagon_tree/Tools/bin/../target/hexagon/lib/v60/fini.o"
+// CHECK333: "{{.*}}/Inputs/hexagon_tree/Tools/bin{{/|\\\\}}..{{/|\\\\}}target{{/|\\\\}}hexagon{{/|\\\\}}lib{{/|\\\\}}v60{{/|\\\\}}fini.o"
 
 // RUN: %clang -### --target=hexagon-unknown-elf \
 // RUN:   -ccc-install-dir %S/Inputs/hexagon_tree/Tools/bin \
@@ -279,17 +279,17 @@
 // CHECK334: "-shared" "-call_shared"
 // CHECK334-NOT: crt0_standalone.o
 // CHECK334-NOT: crt0.o
-// CHECK334: "{{.*}}/Inputs/hexagon_tree/Tools/bin/../target/hexagon/lib/v60/G0/pic/initS.o"
-// CHECK334: "-L{{.*}}/Inputs/hexagon_tree/Tools/bin/../target/hexagon/lib/v60/G0"
-// CHECK334: "-L{{.*}}/Inputs/hexagon_tree/Tools/bin/../target/hexagon/lib/v60"
-// CHECK334: "-L{{.*}}/Inputs/hexagon_tree/Tools/bin/../target/hexagon/lib"
+// CHECK334: "{{.*}}/Inputs/hexagon_tree/Tools/bin{{/|\\\\}}..{{/|\\\\}}target{{/|\\\\}}hexagon{{/|\\\\}}lib{{/|\\\\}}v60{{/|\\\\}}G0{{/|\\\\}}pic{{/|\\\\}}initS.o"
+// CHECK334: "-L{{.*}}/Inputs/hexagon_tree/Tools/bin{{/|\\\\}}..{{/|\\\\}}target{{/|\\\\}}hexagon{{/|\\\\}}lib{{/|\\\\}}v60{{/|\\\\}}G0"
+// CHECK334: "-L{{.*}}/Inputs/hexagon_tree/Tools/bin{{/|\\\\}}..{{/|\\\\}}target{{/|\\\\}}hexagon{{/|\\\\}}lib{{/|\\\\}}v60"
+// CHECK334: "-L{{.*}}/Inputs/hexagon_tree/Tools/bin{{/|\\\\}}..{{/|\\\\}}target{{/|\\\\}}hexagon{{/|\\\\}}lib"
 // CHECK334: "{{[^"]+}}.o"
 // CHECK334: "--start-group"
 // CHECK334-NOT: "-lstandalone"
 // CHECK334-NOT: "-lc"
 // CHECK334: "-lgcc"
 // CHECK334: "--end-group"
-// CHECK334: "{{.*}}/Inputs/hexagon_tree/Tools/bin/../target/hexagon/lib/v60/G0/pic/finiS.o"
+// CHECK334: "{{.*}}/Inputs/hexagon_tree/Tools/bin{{/|\\\\}}..{{/|\\\\}}target{{/|\\\\}}hexagon{{/|\\\\}}lib{{/|\\\\}}v60{{/|\\\\}}G0{{/|\\\\}}pic{{/|\\\\}}finiS.o"
 
 // RUN: %clang -### --target=hexagon-unknown-elf \
 // RUN:   -ccc-install-dir %S/Inputs/hexagon_tree/Tools/bin \
@@ -301,16 +301,16 @@
 // CHECK335: "-shared" "-call_shared" "-static"
 // CHECK335-NOT: crt0_standalone.o
 // CHECK335-NOT: crt0.o
-// CHECK335: "{{.*}}/Inputs/hexagon_tree/Tools/bin/../target/hexagon/lib/v60/G0/init.o"
-// CHECK335-SAME: "-L{{.*}}/Inputs/hexagon_tree/Tools/bin/../target/hexagon/lib/v60/G0"
-// CHECK335-SAME: "-L{{.*}}/Inputs/hexagon_tree/Tools/bin/../target/hexagon/lib/v60"
-// CHECK335-SAME: "-L{{.*}}/Inputs/hexagon_tree/Tools/bin/../target/hexagon/lib"
+// CHECK335: "{{.*}}/Inputs/hexagon_tree/Tools/bin{{/|\\\\}}..{{/|\\\\}}target{{/|\\\\}}hexagon{{/|\\\\}}lib{{/|\\\\}}v60{{/|\\\\}}G0{{/|\\\\}}init.o"
+// CHECK335-SAME: "-L{{.*}}/Inputs/hexagon_tree/Tools/bin{{/|\\\\}}..{{/|\\\\}}target{{/|\\\\}}hexagon{{/|\\\\}}lib{{/|\\\\}}v60{{/|\\\\}}G0"
+// CHECK335-SAME: "-L{{.*}}/Inputs/hexagon_tree/Tools/bin{{/|\\\\}}..{{/|\\\\}}target{{/|\\\\}}hexagon{{/|\\\\}}lib{{/|\\\\}}v60"
+// CHECK335-SAME: "-L{{.*}}/Inputs/hexagon_tree/Tools/bin{{/|\\\\}}..{{/|\\\\}}target{{/|\\\\}}hexagon{{/|\\\\}}lib"
 // CHECK335-SAME: "{{[^"]+}}.o"
 // CHECK335-SAME: "--start-group"
 // CHECK335-NOT: "-lstandalone"
 // CHECK335-NOT: "-lc"
 // CHECK335-SAME: "-lgcc" "--end-group"
-// CHECK335-SAME: "{{.*}}/Inputs/hexagon_tree/Tools/bin/../target/hexagon/lib/v60/G0/fini.o"
+// CHECK335-SAME: "{{.*}}/Inputs/hexagon_tree/Tools/bin{{/|\\\\}}..{{/|\\\\}}target{{/|\\\\}}hexagon{{/|\\\\}}lib{{/|\\\\}}v60{{/|\\\\}}G0{{/|\\\\}}fini.o"
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 // -nostdlib, -nostartfiles, -nodefaultlibs, -nolibc
@@ -324,8 +324,8 @@
 // CHECK336-NOT: crt0_standalone.o
 // CHECK336-NOT: crt0.o
 // CHECK336-NOT: init.o
-// CHECK336: "-L{{.*}}/Inputs/hexagon_tree/Tools/bin/../target/hexagon/lib/v60"
-// CHECK336: "-L{{.*}}/Inputs/hexagon_tree/Tools/bin/../target/hexagon/lib"
+// CHECK336: "-L{{.*}}/Inputs/hexagon_tree/Tools/bin{{/|\\\\}}..{{/|\\\\}}target{{/|\\\\}}hexagon{{/|\\\\}}lib{{/|\\\\}}v60"
+// CHECK336: "-L{{.*}}/Inputs/hexagon_tree/Tools/bin{{/|\\\\}}..{{/|\\\\}}target{{/|\\\\}}hexagon{{/|\\\\}}lib"
 // CHECK336: "{{[^"]+}}.o"
 // CHECK336-NOT: "-lstdc++"
 // CHECK336-NOT: "-lm"
@@ -345,8 +345,8 @@
 // CHECK337-NOT: crt0_standalone.o
 // CHECK337-NOT: crt0.o
 // CHECK337-NOT: init.o
-// CHECK337: "-L{{.*}}/Inputs/hexagon_tree/Tools/bin/../target/hexagon/lib/v60"
-// CHECK337: "-L{{.*}}/Inputs/hexagon_tree/Tools/bin/../target/hexagon/lib"
+// CHECK337: "-L{{.*}}/Inputs/hexagon_tree/Tools/bin{{/|\\\\}}..{{/|\\\\}}target{{/|\\\\}}hexagon{{/|\\\\}}lib{{/|\\\\}}v60"
+// CHECK337: "-L{{.*}}/Inputs/hexagon_tree/Tools/bin{{/|\\\\}}..{{/|\\\\}}target{{/|\\\\}}hexagon{{/|\\\\}}lib"
 // CHECK337: "{{[^"]+}}.o"
 // CHECK337: "-lstdc++" "-lm" "--start-group" "-lstandalone" "-lc" "-lgcc" "--end-group"
 // CHECK337-NOT: fini.o
@@ -357,11 +357,11 @@
 // RUN:   -nodefaultlibs %s 2>&1 | FileCheck -check-prefix=CHECK338 %s
 // CHECK338: "-cc1"
 // CHECK338: {{hexagon-link|ld}}
-// CHECK338: "{{.*}}/Inputs/hexagon_tree/Tools/bin/../target/hexagon/lib/v60/crt0_standalone.o"
-// CHECK338: "{{.*}}/Inputs/hexagon_tree/Tools/bin/../target/hexagon/lib/v60/crt0.o"
-// CHECK338: "{{.*}}/Inputs/hexagon_tree/Tools/bin/../target/hexagon/lib/v60/init.o"
-// CHECK338: "-L{{.*}}/Inputs/hexagon_tree/Tools/bin/../target/hexagon/lib/v60"
-// CHECK338: "-L{{.*}}/Inputs/hexagon_tree/Tools/bin/../target/hexagon/lib"
+// CHECK338: "{{.*}}/Inputs/hexagon_tree/Tools/bin{{/|\\\\}}..{{/|\\\\}}target{{/|\\\\}}hexagon{{/|\\\\}}lib{{/|\\\\}}v60{{/|\\\\}}crt0_standalone.o"
+// CHECK338: "{{.*}}/Inputs/hexagon_tree/Tools/bin{{/|\\\\}}..{{/|\\\\}}target{{/|\\\\}}hexagon{{/|\\\\}}lib{{/|\\\\}}v60{{/|\\\\}}crt0.o"
+// CHECK338: "{{.*}}/Inputs/hexagon_tree/Tools/bin{{/|\\\\}}..{{/|\\\\}}target{{/|\\\\}}hexagon{{/|\\\\}}lib{{/|\\\\}}v60{{/|\\\\}}init.o"
+// CHECK338: "-L{{.*}}/Inputs/hexagon_tree/Tools/bin{{/|\\\\}}..{{/|\\\\}}target{{/|\\\\}}hexagon{{/|\\\\}}lib{{/|\\\\}}v60"
+// CHECK338: "-L{{.*}}/Inputs/hexagon_tree/Tools/bin{{/|\\\\}}..{{/|\\\\}}target{{/|\\\\}}hexagon{{/|\\\\}}lib"
 // CHECK338: "{{[^"]+}}.o"
 // CHECK338-NOT: "-lstdc++"
 // CHECK338-NOT: "-lm"
@@ -370,18 +370,18 @@
 // CHECK338-NOT: "-lc"
 // CHECK338-NOT: "-lgcc"
 // CHECK338-NOT: "--end-group"
-// CHECK338: "{{.*}}/Inputs/hexagon_tree/Tools/bin/../target/hexagon/lib/v60/fini.o"
+// CHECK338: "{{.*}}/Inputs/hexagon_tree/Tools/bin{{/|\\\\}}..{{/|\\\\}}target{{/|\\\\}}hexagon{{/|\\\\}}lib{{/|\\\\}}v60{{/|\\\\}}fini.o"
 
 // RUN: %clangxx -### --target=hexagon-unknown-elf \
 // RUN:   -ccc-install-dir %S/Inputs/hexagon_tree/Tools/bin -mcpu=hexagonv60 \
 // RUN:   -fuse-ld=lld -nolibc %s 2>&1 | FileCheck -check-prefix=CHECK-NOLIBC %s
 // CHECK-NOLIBC: "-cc1"
 // CHECK-NOLIBC: ld.lld
-// CHECK-NOLIBC-SAME: "{{.*}}/Inputs/hexagon_tree/Tools/bin/../target/hexagon/lib/v60/crt0_standalone.o"
-// CHECK-NOLIBC-SAME: "{{.*}}/Inputs/hexagon_tree/Tools/bin/../target/hexagon/lib/v60/crt0.o"
-// CHECK-NOLIBC-SAME: "{{.*}}/Inputs/hexagon_tree/Tools/bin/../target/hexagon/lib/v60/init.o"
-// CHECK-NOLIBC-SAME: "-L{{.*}}/Inputs/hexagon_tree/Tools/bin/../target/hexagon/lib/v60"
-// CHECK-NOLIBC-SAME: "-L{{.*}}/Inputs/hexagon_tree/Tools/bin/../target/hexagon/lib"
+// CHECK-NOLIBC-SAME: "{{.*}}/Inputs/hexagon_tree/Tools/bin{{/|\\\\}}..{{/|\\\\}}target{{/|\\\\}}hexagon{{/|\\\\}}lib{{/|\\\\}}v60{{/|\\\\}}crt0_standalone.o"
+// CHECK-NOLIBC-SAME: "{{.*}}/Inputs/hexagon_tree/Tools/bin{{/|\\\\}}..{{/|\\\\}}target{{/|\\\\}}hexagon{{/|\\\\}}lib{{/|\\\\}}v60{{/|\\\\}}crt0.o"
+// CHECK-NOLIBC-SAME: "{{.*}}/Inputs/hexagon_tree/Tools/bin{{/|\\\\}}..{{/|\\\\}}target{{/|\\\\}}hexagon{{/|\\\\}}lib{{/|\\\\}}v60{{/|\\\\}}init.o"
+// CHECK-NOLIBC-SAME: "-L{{.*}}/Inputs/hexagon_tree/Tools/bin{{/|\\\\}}..{{/|\\\\}}target{{/|\\\\}}hexagon{{/|\\\\}}lib{{/|\\\\}}v60"
+// CHECK-NOLIBC-SAME: "-L{{.*}}/Inputs/hexagon_tree/Tools/bin{{/|\\\\}}..{{/|\\\\}}target{{/|\\\\}}hexagon{{/|\\\\}}lib"
 // CHECK-NOLIBC-SAME: "{{[^"]+}}.o"
 // CHECK-NOLIBC-SAME: "-lstdc++"
 // CHECK-NOLIBC-SAME: "-lm"
@@ -390,7 +390,7 @@
 // CHECK-NOLIBC-NOT: "-lc"
 // CHECK-NOLIBC-SAME: "-lgcc"
 // CHECK-NOLIBC-SAME: "--end-group"
-// CHECK-NOLIBC-SAME: "{{.*}}/Inputs/hexagon_tree/Tools/bin/../target/hexagon/lib/v60/fini.o"
+// CHECK-NOLIBC-SAME: "{{.*}}/Inputs/hexagon_tree/Tools/bin{{/|\\\\}}..{{/|\\\\}}target{{/|\\\\}}hexagon{{/|\\\\}}lib{{/|\\\\}}v60{{/|\\\\}}fini.o"
 
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -405,15 +405,15 @@
 // CHECK339-NOT: "-static"
 // CHECK339-NOT: "-shared"
 // CHECK339-NOT: crt0_standalone.o
-// CHECK339: "{{.*}}/Inputs/hexagon_tree/Tools/bin/../target/hexagon/lib/v60/crt0.o"
-// CHECK339-SAME: "{{.*}}/Inputs/hexagon_tree/Tools/bin/../target/hexagon/lib/v60/init.o"
-// CHECK339-SAME: "-L{{.*}}/Inputs/hexagon_tree/Tools/bin/../target/hexagon/lib/v60"
-// CHECK339-SAME: "-L{{.*}}/Inputs/hexagon_tree/Tools/bin/../target/hexagon/lib"
+// CHECK339: "{{.*}}/Inputs/hexagon_tree/Tools/bin{{/|\\\\}}..{{/|\\\\}}target{{/|\\\\}}hexagon{{/|\\\\}}lib{{/|\\\\}}v60{{/|\\\\}}crt0.o"
+// CHECK339-SAME: "{{.*}}/Inputs/hexagon_tree/Tools/bin{{/|\\\\}}..{{/|\\\\}}target{{/|\\\\}}hexagon{{/|\\\\}}lib{{/|\\\\}}v60{{/|\\\\}}init.o"
+// CHECK339-SAME: "-L{{.*}}/Inputs/hexagon_tree/Tools/bin{{/|\\\\}}..{{/|\\\\}}target{{/|\\\\}}hexagon{{/|\\\\}}lib{{/|\\\\}}v60"
+// CHECK339-SAME: "-L{{.*}}/Inputs/hexagon_tree/Tools/bin{{/|\\\\}}..{{/|\\\\}}target{{/|\\\\}}hexagon{{/|\\\\}}lib"
 // CHECK339-SAME: "{{[^"]+}}.o"
 // CHECK339-SAME: "--start-group" "-lfirst" "-lsecond"
 // CHECK339-NOT: "-lstandalone"
 // CHECK339-SAME: "-lc" "-lgcc" "--end-group"
-// CHECK339-SAME: "{{.*}}/Inputs/hexagon_tree/Tools/bin/../target/hexagon/lib/v60/fini.o"
+// CHECK339-SAME: "{{.*}}/Inputs/hexagon_tree/Tools/bin{{/|\\\\}}..{{/|\\\\}}target{{/|\\\\}}hexagon{{/|\\\\}}lib{{/|\\\\}}v60{{/|\\\\}}fini.o"
 
 // RUN: %clang -### --target=hexagon-unknown-elf \
 // RUN:   -ccc-install-dir %S/Inputs/hexagon_tree/Tools/bin \
@@ -423,17 +423,17 @@
 // CHECK33A: {{hexagon-link|ld}}
 // CHECK33A-NOT: "-static"
 // CHECK33A-NOT: "-shared"
-// CHECK33A:      "{{.*}}/Inputs/hexagon_tree/Tools/bin/../target/hexagon/lib/v60/crt0_standalone.o"
-// CHECK33A-SAME: "{{.*}}/Inputs/hexagon_tree/Tools/bin/../target/hexagon/lib/v60/crt0.o"
-// CHECK33A-SAME: "{{.*}}/Inputs/hexagon_tree/Tools/bin/../target/hexagon/lib/v60/init.o"
-// CHECK33A-SAME: "-L{{.*}}/Inputs/hexagon_tree/Tools/bin/../target/hexagon/lib/v60"
-// CHECK33A-SAME: "-L{{.*}}/Inputs/hexagon_tree/Tools/bin/../target/hexagon/lib"
+// CHECK33A:      "{{.*}}/Inputs/hexagon_tree/Tools/bin{{/|\\\\}}..{{/|\\\\}}target{{/|\\\\}}hexagon{{/|\\\\}}lib{{/|\\\\}}v60{{/|\\\\}}crt0_standalone.o"
+// CHECK33A-SAME: "{{.*}}/Inputs/hexagon_tree/Tools/bin{{/|\\\\}}..{{/|\\\\}}target{{/|\\\\}}hexagon{{/|\\\\}}lib{{/|\\\\}}v60{{/|\\\\}}crt0.o"
+// CHECK33A-SAME: "{{.*}}/Inputs/hexagon_tree/Tools/bin{{/|\\\\}}..{{/|\\\\}}target{{/|\\\\}}hexagon{{/|\\\\}}lib{{/|\\\\}}v60{{/|\\\\}}init.o"
+// CHECK33A-SAME: "-L{{.*}}/Inputs/hexagon_tree/Tools/bin{{/|\\\\}}..{{/|\\\\}}target{{/|\\\\}}hexagon{{/|\\\\}}lib{{/|\\\\}}v60"
+// CHECK33A-SAME: "-L{{.*}}/Inputs/hexagon_tree/Tools/bin{{/|\\\\}}..{{/|\\\\}}target{{/|\\\\}}hexagon{{/|\\\\}}lib"
 // CHECK33A-SAME: "{{[^"]+}}.o"
 // CHECK33A-SAME: "--start-group"
 // CHECK33A-SAME: "-lfirst" "-lsecond"
 // CHECK33A-SAME: "-lstandalone"
 // CHECK33A-SAME: "-lc" "-lgcc" "--end-group"
-// CHECK33A-SAME: "{{.*}}/Inputs/hexagon_tree/Tools/bin/../target/hexagon/lib/v60/fini.o"
+// CHECK33A-SAME: "{{.*}}/Inputs/hexagon_tree/Tools/bin{{/|\\\\}}..{{/|\\\\}}target{{/|\\\\}}hexagon{{/|\\\\}}lib{{/|\\\\}}v60{{/|\\\\}}fini.o"
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 // Other args to pass to linker
@@ -444,15 +444,15 @@
 // RUN:   -s -t -e start_here -uFoo -undefined Bar %s 2>&1 | FileCheck -check-prefix=CHECK33B %s
 // CHECK33B:      "-cc1"
 // CHECK33B:      ld.lld
-// CHECK33B-SAME: "{{.*}}/Inputs/hexagon_tree/Tools/bin/../target/hexagon/lib/v60/crt0_standalone.o"
-// CHECK33B-SAME: "{{.*}}/Inputs/hexagon_tree/Tools/bin/../target/hexagon/lib/v60/crt0.o"
-// CHECK33B-SAME: "{{.*}}/Inputs/hexagon_tree/Tools/bin/../target/hexagon/lib/v60/init.o"
-// CHECK33B-SAME: "-L{{.*}}/Inputs/hexagon_tree/Tools/bin/../target/hexagon/lib/v60"
-// CHECK33B-SAME: "-L{{.*}}/Inputs/hexagon_tree/Tools/bin/../target/hexagon/lib"
+// CHECK33B-SAME: "{{.*}}/Inputs/hexagon_tree/Tools/bin{{/|\\\\}}..{{/|\\\\}}target{{/|\\\\}}hexagon{{/|\\\\}}lib{{/|\\\\}}v60{{/|\\\\}}crt0_standalone.o"
+// CHECK33B-SAME: "{{.*}}/Inputs/hexagon_tree/Tools/bin{{/|\\\\}}..{{/|\\\\}}target{{/|\\\\}}hexagon{{/|\\\\}}lib{{/|\\\\}}v60{{/|\\\\}}crt0.o"
+// CHECK33B-SAME: "{{.*}}/Inputs/hexagon_tree/Tools/bin{{/|\\\\}}..{{/|\\\\}}target{{/|\\\\}}hexagon{{/|\\\\}}lib{{/|\\\\}}v60{{/|\\\\}}init.o"
+// CHECK33B-SAME: "-L{{.*}}/Inputs/hexagon_tree/Tools/bin{{/|\\\\}}..{{/|\\\\}}target{{/|\\\\}}hexagon{{/|\\\\}}lib{{/|\\\\}}v60"
+// CHECK33B-SAME: "-L{{.*}}/Inputs/hexagon_tree/Tools/bin{{/|\\\\}}..{{/|\\\\}}target{{/|\\\\}}hexagon{{/|\\\\}}lib"
 // CHECK33B-SAME: "-s" "-t" "-u" "Foo" "-undefined" "Bar"
 // CHECK33B-SAME: "{{[^"]+}}.o"
 // CHECK33B-SAME: "-lstdc++" "-lm" "--start-group" "-lstandalone" "-lc" "-lgcc" "--end-group"
-// CHECK33B-SAME: "{{.*}}/Inputs/hexagon_tree/Tools/bin/../target/hexagon/lib/v60/fini.o"
+// CHECK33B-SAME: "{{.*}}/Inputs/hexagon_tree/Tools/bin{{/|\\\\}}..{{/|\\\\}}target{{/|\\\\}}hexagon{{/|\\\\}}lib{{/|\\\\}}v60{{/|\\\\}}fini.o"
 
 // -----------------------------------------------------------------------------
 // pic, small data threshold
@@ -589,6 +589,8 @@
 // RUN:   --sysroot=/hexagon %s 2>&1 | FileCheck -check-prefix=CHECK383 %s
 // CHECK383:          "-isysroot" "/hexagon"
 // CHECK383:          "-internal-externc-isystem" "/hexagon{{/|\\\\}}include"
+// CHECK383:          "-L/hexagon{{/|\\\\}}lib{{/|\\\\}}v60"
+// CHECK383:          "-L/hexagon{{/|\\\\}}lib"
 // -----------------------------------------------------------------------------
 // Passing -fno-use-init-array
 // -----------------------------------------------------------------------------

--- a/clang/test/Driver/hexagon-toolchain-linux.c
+++ b/clang/test/Driver/hexagon-toolchain-linux.c
@@ -1,5 +1,3 @@
-// UNSUPPORTED: system-windows
-
 // -----------------------------------------------------------------------------
 // Passing --musl
 // -----------------------------------------------------------------------------
@@ -12,6 +10,9 @@
 // CHECK000:      "-dynamic-linker={{/|\\\\}}lib{{/|\\\\}}ld-musl-hexagon.so.1"
 // CHECK000:      "{{.*}}basic_linux_libcxx_tree{{/|\\\\}}usr{{/|\\\\}}lib{{/|\\\\}}crt1.o"
 // CHECK000:      "-lc" "-lclang_rt.builtins-hexagon"
+// CHECK000:          "-L{{.*}}/Inputs/basic_linux_libcxx_tree{{/|\\\\}}lib{{/|\\\\}}v60"
+// CHECK000:          "-L{{.*}}/Inputs/basic_linux_libcxx_tree{{/|\\\\}}lib"
+
 // -----------------------------------------------------------------------------
 // Passing --musl --shared
 // -----------------------------------------------------------------------------
@@ -97,23 +98,20 @@
 // RUN: %clang -### --target=hexagon-unknown-linux-musl \
 // RUN:   -ccc-install-dir %S/Inputs/hexagon_tree/Tools/bin \
 // RUN:   -resource-dir=%S/Inputs/resource_dir %s 2>&1 | FileCheck -check-prefix=CHECK008 %s
-// CHECK008:   InstalledDir: [[INSTALLED_DIR:.+]]
 // CHECK008:   "-resource-dir" "[[RESOURCE:[^"]+]]"
-// CHECK008-SAME: {{^}} "-internal-isystem" "[[RESOURCE]]/include"
-// CHECK008-SAME: {{^}} "-internal-externc-isystem" "[[INSTALLED_DIR]]/../target/hexagon/include"
+// CHECK008-SAME: {{^}} "-internal-isystem" "[[RESOURCE]]{{/|\\\\}}include"
+// CHECK008-SAME: {{^}} "-internal-externc-isystem" "{{.*}}/Inputs/hexagon_tree/Tools/bin{{/|\\\\}}..{{/|\\\\}}target{{/|\\\\}}hexagon{{/|\\\\}}include"
 
 // RUN: %clang -### --target=hexagon-unknown-linux \
 // RUN:   -ccc-install-dir %S/Inputs/hexagon_tree/Tools/bin \
 // RUN:   -resource-dir=%S/Inputs/resource_dir %s 2>&1 | FileCheck -check-prefix=CHECK009 %s
-// CHECK009:   InstalledDir: [[INSTALLED_DIR:.+]]
 // CHECK009:   "-resource-dir" "[[RESOURCE:[^"]+]]"
-// CHECK009-SAME: {{^}} "-internal-isystem" "[[RESOURCE]]/include"
-// CHECK009-SAME: {{^}} "-internal-externc-isystem" "[[INSTALLED_DIR]]/../target/hexagon/include"
+// CHECK009-SAME: {{^}} "-internal-isystem" "[[RESOURCE]]{{/|\\\\}}include"
+// CHECK009-SAME: {{^}} "-internal-externc-isystem" "{{.*}}/Inputs/hexagon_tree/Tools/bin{{/|\\\\}}..{{/|\\\\}}target{{/|\\\\}}hexagon{{/|\\\\}}include"
 
 // RUN: %clang -Werror -L/tmp \
 // RUN:    --target=hexagon-unknown-linux-musl %s -### 2>&1 \
 // RUN:    | FileCheck -check-prefix=CHECK010 %s
-// CHECK010:   InstalledDir: [[INSTALLED_DIR:.+]]
 // CHECK010-NOT:  "-lstandalone"
 // CHECK010-NOT:  crt0_standalone.o
 // CHECK010:   crt1.o
@@ -126,7 +124,6 @@
 // RUN: %clangxx --unwindlib=none \
 // RUN:    --target=hexagon-unknown-linux-musl %s -### 2>&1 \
 // RUN:    | FileCheck -check-prefix=CHECK011 %s
-// CHECK011:   InstalledDir: [[INSTALLED_DIR:.+]]
 // CHECK011:   "--eh-frame-hdr"
 // CHECK011:   crt1.o
 // CHECK011-NOT:  "-lunwind"
@@ -140,7 +137,6 @@
 // RUN: %clangxx \
 // RUN:    --target=hexagon-unknown-linux-musl %s -### 2>&1 \
 // RUN:    | FileCheck -check-prefix=CHECK012 %s
-// CHECK012:   InstalledDir: [[INSTALLED_DIR:.+]]
 // CHECK012:   crt1.o
 // CHECK012:  "-lunwind"
 // CHECK012-NOT:  "-lgcc_eh"


### PR DESCRIPTION
Unify include and library paths by reusing common code to compute path
prefixes. First, determine the effective sysroot by choosing a
user-provided sysroot, "../target/<triple>", or "../target/hexagon",
in the order of precedence. Based on the sysroot, derive the standard
include path, C++ include path, and base library path.

Fix the default -L library paths so they are taken from the external
sysroot, when one specified. Previously, these paths were always
relative to the install directory and sysroot was ignored.

Remove certain locations from considerations, as there are never used
for the corresponding purpose in existing sysroots:
- fallback to install path, typically "../target/bin", as the base path
  when other sysroot cannot be found;
- similarly, fallback to "../target/" for startup files;
- "../target/bin" for program paths as there are no program files in
  current sysroots.

Other minor changes:
- use windows-correct path delimiting;
- enable hexagon-toolchain-linux.c test for windows hosts.