### PR TITLE
[msan] Fix bfmmla instrumentation incompatibility issue

### DIFF
--- a/llvm/lib/Transforms/Instrumentation/MemorySanitizer.cpp
+++ b/llvm/lib/Transforms/Instrumentation/MemorySanitizer.cpp
@@ -5541,21 +5541,21 @@ struct MemorySanitizerVisitor : public InstVisitor<MemorySanitizerVisitor> {
 
   // Integer matrix multiplication:
   // - <4 x i32> @llvm.aarch64.neon.{s,u,us}mmla.v4i32.v16i8
-  //                 (<4 x i32> %R, <16 x i8> %X, <16 x i8> %Y)
+  //                 (<4 x i32> %R, <16 x i8> %A, <16 x i8> %B)
   //   - <4 x i32> is a 2x2 matrix
-  //   - <16 x i8> %X and %Y are 2x8 and 8x2 matrices respectively
+  //   - <16 x i8> %A and %B are 2x8 and 8x2 matrices respectively
   //
   // Floating-point matrix multiplication:
   // - <4 x float> @llvm.aarch64.neon.bfmmla
-  //                   (<4 x float> %R, <8 x bfloat> %X, <8 x bfloat> %Y)
+  //                   (<4 x float> %R, <8 x bfloat> %A, <8 x bfloat> %B)
   //   - <4 x float> is a 2x2 matrix
-  //   - <8 x bfloat> %X and %Y are 2x4 and 4x2 matrices respectively
+  //   - <8 x bfloat> %A and %B are 2x4 and 4x2 matrices respectively
   //
   // The general shadow propagation approach is:
-  // 1) get the shadows of the input matrices %X and %Y
+  // 1) get the shadows of the input matrices %A and %B
   // 2) map each shadow value to 0x1 if the corresponding value is fully
   //    initialized, and 0x0 otherwise
-  // 3) perform a matrix multiplication on the shadows of %X and %Y [*].
+  // 3) perform a matrix multiplication on the shadows of %A and %B [*].
   //    The output will be a 2x2 matrix. For each element, a value of 0x8
   //    (for {s,u,us}mmla) or 0x4 (for bfmmla) means all the corresponding
   //    inputs were clean; if so, set the shadow to zero, otherwise set to -1.

--- a/llvm/lib/Transforms/Instrumentation/MemorySanitizer.cpp
+++ b/llvm/lib/Transforms/Instrumentation/MemorySanitizer.cpp
@@ -5611,35 +5611,29 @@ struct MemorySanitizerVisitor : public InstVisitor<MemorySanitizerVisitor> {
       // If the value is fully initialized, the shadow will be 000...001.
       // Otherwise, the shadow will be all zero.
       // (This is the opposite of how we typically handle shadows.)
-      ShadowA =
-          IRB.CreateZExt(IRB.CreateICmpEQ(ShadowA, getCleanShadow(ATy)),
-                         getShadowTy(ATy));
-      ShadowB =
-          IRB.CreateZExt(IRB.CreateICmpEQ(ShadowB, getCleanShadow(BTy)),
-                       getShadowTy(BTy));
+      ShadowA = IRB.CreateZExt(IRB.CreateICmpEQ(ShadowA, getCleanShadow(ATy)),
+                               getShadowTy(ATy));
+      ShadowB = IRB.CreateZExt(IRB.CreateICmpEQ(ShadowB, getCleanShadow(BTy)),
+                               getShadowTy(BTy));
       // TODO: the CreateSelect approach used below for floating-point is more
       //       generic than CreateZExt. Investigate whether it is worthwhile
       //       unifying the two approaches.
 
-      ShadowAB =
-          IRB.CreateIntrinsic(RTy, Intrinsic::aarch64_neon_ummla,
-                              {getCleanShadow(RTy), ShadowA, ShadowB});
+      ShadowAB = IRB.CreateIntrinsic(RTy, Intrinsic::aarch64_neon_ummla,
+                                     {getCleanShadow(RTy), ShadowA, ShadowB});
 
       // ummla multiplies a 2x8 matrix with an 8x2 matrix. If all entries of the
       // input matrices are equal to 0x1, all entries of the output matrix will
       // be 0x8.
       FullyInit = ConstantVector::getSplat(
-        RTy->getElementCount(),
-        ConstantInt::get(RTy->getElementType(), 0x8));
+          RTy->getElementCount(), ConstantInt::get(RTy->getElementType(), 0x8));
 
       ShadowAB = IRB.CreateICmpNE(ShadowAB, FullyInit);
     } else {
-      Constant* ABZeros = ConstantVector::getSplat(
-                         ATy->getElementCount(),
-                         ConstantFP::get(ATy->getElementType(), 0));
-      Constant* ABOnes = ConstantVector::getSplat(
-                         ATy->getElementCount(),
-                         ConstantFP::get(ATy->getElementType(), 1));
+      Constant *ABZeros = ConstantVector::getSplat(
+          ATy->getElementCount(), ConstantFP::get(ATy->getElementType(), 0));
+      Constant *ABOnes = ConstantVector::getSplat(
+          ATy->getElementCount(), ConstantFP::get(ATy->getElementType(), 1));
 
       // As per the integer case, if the shadow is clean, we store 0x1,
       // otherwise we store 0x0 (the opposite of usual shadow arithmetic).
@@ -5648,20 +5642,18 @@ struct MemorySanitizerVisitor : public InstVisitor<MemorySanitizerVisitor> {
       ShadowB = IRB.CreateSelect(IRB.CreateICmpEQ(ShadowB, getCleanShadow(BTy)),
                                  ABOnes, ABZeros);
 
-      Constant* RZeros = ConstantVector::getSplat(
-                         RTy->getElementCount(),
-                         ConstantFP::get(RTy->getElementType(), 0));
+      Constant *RZeros = ConstantVector::getSplat(
+          RTy->getElementCount(), ConstantFP::get(RTy->getElementType(), 0));
 
-      ShadowAB =
-          IRB.CreateIntrinsic(RTy, Intrinsic::aarch64_neon_bfmmla,
-                              {RZeros, ShadowA, ShadowB});
+      ShadowAB = IRB.CreateIntrinsic(RTy, Intrinsic::aarch64_neon_bfmmla,
+                                     {RZeros, ShadowA, ShadowB});
 
-      // bfmmla multiplies a 2x4 matrix with an 4x2 matrix. If all entries of the
-      // input matrices are equal to 0x1, all entries of the output matrix will
-      // be 4.0. (To avoid floating-point error, we check if each entry < 3.5.)
+      // bfmmla multiplies a 2x4 matrix with an 4x2 matrix. If all entries of
+      // the input matrices are equal to 0x1, all entries of the output matrix
+      // will be 4.0. (To avoid floating-point error, we check if each entry
+      // < 3.5.)
       FullyInit = ConstantVector::getSplat(
-        RTy->getElementCount(),
-        ConstantFP::get(RTy->getElementType(), 3.5));
+          RTy->getElementCount(), ConstantFP::get(RTy->getElementType(), 3.5));
 
       // FCmpULT: "yields true if either operand is a QNAN or op1 is less than"
       //           op2"

--- a/llvm/lib/Transforms/Instrumentation/MemorySanitizer.cpp
+++ b/llvm/lib/Transforms/Instrumentation/MemorySanitizer.cpp
@@ -5540,62 +5540,33 @@ struct MemorySanitizerVisitor : public InstVisitor<MemorySanitizerVisitor> {
   }
 
   // Integer matrix multiplication:
-  // - <4 x i32> @llvm.aarch64.neon.smmla.v4i32.v16i8
+  // - <4 x i32> @llvm.aarch64.neon.{s,u,us}mmla.v4i32.v16i8
   //                 (<4 x i32> %R, <16 x i8> %X, <16 x i8> %Y)
-  // - <4 x i32> @llvm.aarch64.neon.ummla.v4i32.v16i8
-  //                 (<4 x i32> %R, <16 x i8> %X, <16 x i8> %Y)
-  // - <4 x i32> @llvm.aarch64.neon.usmmla.v4i32.v16i8
-  //                 (<4 x i32> %R, <16 x i8> %X, <16 x i8> %Y)
-  //
-  // Note:
-  // - <4 x i32> is a 2x2 matrix
-  // - <16 x i8> %X and %Y are 2x8 and 8x2 matrices respectively
-  //
-  //   2x8 %X                                8x2 %Y
-  //   [ X01 X02 X03 X04 X05 X06 X07 X08 ]   [ Y01 Y09 ]
-  //   [ X09 X10 X11 X12 X13 X14 X15 X16 ] x [ Y02 Y10 ]
-  //                                         [ Y03 Y11 ]
-  //                                         [ Y04 Y12 ]
-  //                                         [ Y05 Y13 ]
-  //                                         [ Y06 Y14 ]
-  //                                         [ Y07 Y15 ]
-  //                                         [ Y08 Y16 ]
-  //
-  // The general shadow propagation approach is:
-  // 1) get the shadows of the input matrices %X and %Y
-  // 2) change the shadow values to 0x1 if the corresponding value is fully
-  //    initialized, and 0x0 otherwise
-  // 3) perform a matrix multiplication on the shadows of %X and %Y. The output
-  //    will be a 2x2 matrix; for each element, a value of 0x8 means all the
-  //    corresponding inputs were clean.
-  // 4) blend in the shadow of %R
-  //
-  // TODO: consider allowing multiplication of zero with an uninitialized value
-  //       to result in an initialized value.
+  //   - <4 x i32> is a 2x2 matrix
+  //   - <16 x i8> %X and %Y are 2x8 and 8x2 matrices respectively
   //
   // Floating-point matrix multiplication:
   // - <4 x float> @llvm.aarch64.neon.bfmmla
   //                   (<4 x float> %R, <8 x bfloat> %X, <8 x bfloat> %Y)
-  //   %X and %Y are 2x4 and 4x2 matrices respectively
+  //   - <4 x float> is a 2x2 matrix
+  //   - <8 x bfloat> %X and %Y are 2x4 and 4x2 matrices respectively
   //
-  // Although there are half as many elements of %X and %Y compared to the
-  // integer case, each element is twice the bit-width. Thus, we can reuse the
-  // shadow propagation logic if we cast the shadows to the same type as the
-  // integer case, and apply ummla to the shadows:
+  // The general shadow propagation approach is:
+  // 1) get the shadows of the input matrices %X and %Y
+  // 2) map each shadow value to 0x1 if the corresponding value is fully
+  //    initialized, and 0x0 otherwise
+  // 3) perform a matrix multiplication on the shadows of %X and %Y [*].
+  //    The output will be a 2x2 matrix. For each element, a value of 0x8
+  //    (for {s,u,us}mmla) or 0x4 (for bfmmla) means all the corresponding
+  //    inputs were clean; if so, set the shadow to zero, otherwise set to -1.
+  // 4) blend in the shadow of %R
   //
-  //   2x4 %X                                4x2 %Y
-  //   [ A01:A02 A03:A04 A05:A06 A07:A08 ]   [ B01:B02 B09:B10 ]
-  //   [ A09:A10 A11:A12 A13:A14 A15:A16 ] x [ B03:B04 B11:B12 ]
-  //                                         [ B05:B06 B13:B14 ]
-  //                                         [ B07:B08 B15:B16 ]
+  // [*] Since shadows are integral, the obvious approach is to always apply
+  //     ummla to the shadows. Unfortunately, Armv8.2+bf16 supports bfmmla,
+  //     but not ummla. Thus, for bfmmla, our instrumentation reuses bfmmla.
   //
-  // For example, consider multiplying the first row of %X with the first
-  // column of Y. We want to know if
-  // A01:A02*B01:B02 + A03:A04*B03:B04 + A05:A06*B06:B06 + A07:A08*B07:B08 is
-  // fully initialized, which will be true if and only if (A01, A02, ..., A08)
-  // and (B01, B02, ..., B08) are each fully initialized. This latter condition
-  // is equivalent to what is tested by the instrumentation for the integer
-  // form.
+  // TODO: consider allowing multiplication of zero with an uninitialized value
+  //       to result in an initialized value.
   void handleNEONMatrixMultiply(IntrinsicInst &I) {
     IRBuilder<> IRB(&I);
 
@@ -5610,75 +5581,98 @@ struct MemorySanitizerVisitor : public InstVisitor<MemorySanitizerVisitor> {
     assert(isa<FixedVectorType>(A->getType()));
     assert(isa<FixedVectorType>(B->getType()));
 
-    [[maybe_unused]] FixedVectorType *RTy = cast<FixedVectorType>(R->getType());
-    [[maybe_unused]] FixedVectorType *ATy = cast<FixedVectorType>(A->getType());
-    [[maybe_unused]] FixedVectorType *BTy = cast<FixedVectorType>(B->getType());
+    FixedVectorType *RTy = cast<FixedVectorType>(R->getType());
+    FixedVectorType *ATy = cast<FixedVectorType>(A->getType());
+    FixedVectorType *BTy = cast<FixedVectorType>(B->getType());
+    assert(ATy->getElementType() == BTy->getElementType());
+
+    if (RTy->getElementType()->isIntegerTy()) {
+      // <4 x i32> @llvm.aarch64.neon.ummla.v4i32.v16i8
+      //               (<4 x i32> %R, <16 x i8> %X, <16 x i8> %Y)
+      assert(RTy == FixedVectorType::get(IntegerType::get(*MS.C, 32), 4));
+      assert(ATy == FixedVectorType::get(IntegerType::get(*MS.C, 8), 16));
+      assert(BTy == FixedVectorType::get(IntegerType::get(*MS.C, 8), 16));
+    } else {
+      // <4 x float> @llvm.aarch64.neon.bfmmla
+      //                 (<4 x float> %R, <8 x bfloat> %X, <8 x bfloat> %Y)
+      assert(RTy == FixedVectorType::get(Type::getFloatTy(*MS.C), 4));
+      assert(ATy == FixedVectorType::get(Type::getBFloatTy(*MS.C), 8));
+      assert(BTy == FixedVectorType::get(Type::getBFloatTy(*MS.C), 8));
+    }
 
     Value *ShadowR = getShadow(&I, 0);
     Value *ShadowA = getShadow(&I, 1);
     Value *ShadowB = getShadow(&I, 2);
 
-    // We will use ummla to compute the shadow. These are the types it expects.
-    // These are also the types of the corresponding shadows.
-    FixedVectorType *ExpectedRTy =
-        FixedVectorType::get(IntegerType::get(*MS.C, 32), 4);
-    FixedVectorType *ExpectedATy =
-        FixedVectorType::get(IntegerType::get(*MS.C, 8), 16);
-    FixedVectorType *ExpectedBTy =
-        FixedVectorType::get(IntegerType::get(*MS.C, 8), 16);
+    Value *ShadowAB;
+    Value *FullyInit;
 
     if (RTy->getElementType()->isIntegerTy()) {
-      // Types of R and A/B are not identical e.g., <4 x i32> %R, <16 x i8> %A
-      assert(ATy->getElementType()->isIntegerTy());
+      // If the value is fully initialized, the shadow will be 000...001.
+      // Otherwise, the shadow will be all zero.
+      // (This is the opposite of how we typically handle shadows.)
+      ShadowA =
+          IRB.CreateZExt(IRB.CreateICmpEQ(ShadowA, getCleanShadow(ATy)),
+                         getShadowTy(ATy));
+      ShadowB =
+          IRB.CreateZExt(IRB.CreateICmpEQ(ShadowB, getCleanShadow(BTy)),
+                       getShadowTy(BTy));
+      // TODO: the CreateSelect approach used below for floating-point is more
+      //       generic than CreateZExt. Investigate whether it is worthwhile
+      //       unifying the two approaches.
 
-      assert(RTy == ExpectedRTy);
-      assert(ATy == ExpectedATy);
-      assert(BTy == ExpectedBTy);
+      ShadowAB =
+          IRB.CreateIntrinsic(RTy, Intrinsic::aarch64_neon_ummla,
+                              {getCleanShadow(RTy), ShadowA, ShadowB});
+
+      // ummla multiplies a 2x8 matrix with an 8x2 matrix. If all entries of the
+      // input matrices are equal to 0x1, all entries of the output matrix will
+      // be 0x8.
+      FullyInit = ConstantVector::getSplat(
+        RTy->getElementCount(),
+        ConstantInt::get(RTy->getElementType(), 0x8));
+
+      ShadowAB = IRB.CreateICmpNE(ShadowAB, FullyInit);
     } else {
-      assert(ATy->getElementType()->isFloatingPointTy());
-      assert(BTy->getElementType()->isFloatingPointTy());
+      Constant* ABZeros = ConstantVector::getSplat(
+                         ATy->getElementCount(),
+                         ConstantFP::get(ATy->getElementType(), 0));
+      Constant* ABOnes = ConstantVector::getSplat(
+                         ATy->getElementCount(),
+                         ConstantFP::get(ATy->getElementType(), 1));
 
-      // Technically, what we care about is that:
-      //   getShadowTy(RTy)->canLosslesslyBitCastTo(ExpectedRTy)) etc.
-      // but that is equivalent.
-      assert(RTy->canLosslesslyBitCastTo(ExpectedRTy));
-      assert(ATy->canLosslesslyBitCastTo(ExpectedATy));
-      assert(BTy->canLosslesslyBitCastTo(ExpectedBTy));
+      // As per the integer case, if the shadow is clean, we store 0x1,
+      // otherwise we store 0x0 (the opposite of usual shadow arithmetic).
+      ShadowA = IRB.CreateSelect(IRB.CreateICmpEQ(ShadowA, getCleanShadow(ATy)),
+                                 ABOnes, ABZeros);
+      ShadowB = IRB.CreateSelect(IRB.CreateICmpEQ(ShadowB, getCleanShadow(BTy)),
+                                 ABOnes, ABZeros);
 
-      ShadowA = IRB.CreateBitCast(ShadowA, getShadowTy(ExpectedATy));
-      ShadowB = IRB.CreateBitCast(ShadowB, getShadowTy(ExpectedBTy));
+      Constant* RZeros = ConstantVector::getSplat(
+                         RTy->getElementCount(),
+                         ConstantFP::get(RTy->getElementType(), 0));
+
+      ShadowAB =
+          IRB.CreateIntrinsic(RTy, Intrinsic::aarch64_neon_bfmmla,
+                              {RZeros, ShadowA, ShadowB});
+
+      // bfmmla multiplies a 2x4 matrix with an 4x2 matrix. If all entries of the
+      // input matrices are equal to 0x1, all entries of the output matrix will
+      // be 4.0. (To avoid floating-point error, we check if each entry < 3.5.)
+      FullyInit = ConstantVector::getSplat(
+        RTy->getElementCount(),
+        ConstantFP::get(RTy->getElementType(), 3.5));
+
+      // FCmpULT: "yields true if either operand is a QNAN or op1 is less than"
+      //           op2"
+      ShadowAB = IRB.CreateFCmpULT(ShadowAB, FullyInit);
     }
-    assert(ATy->getElementType() == BTy->getElementType());
 
-    // From this point on, use Expected{R,A,B}Type.
-
-    // If the value is fully initialized, the shadow will be 000...001.
-    // Otherwise, the shadow will be all zero.
-    // (This is the opposite of how we typically handle shadows.)
-    ShadowA =
-        IRB.CreateZExt(IRB.CreateICmpEQ(ShadowA, getCleanShadow(ExpectedATy)),
-                       getShadowTy(ExpectedATy));
-    ShadowB =
-        IRB.CreateZExt(IRB.CreateICmpEQ(ShadowB, getCleanShadow(ExpectedBTy)),
-                       getShadowTy(ExpectedBTy));
-
-    Value *ShadowAB =
-        IRB.CreateIntrinsic(ExpectedRTy, Intrinsic::aarch64_neon_ummla,
-                            {getCleanShadow(ExpectedRTy), ShadowA, ShadowB});
-
-    // ummla multiplies a 2x8 matrix with an 8x2 matrix. If all entries of the
-    // input matrices are equal to 0x1, all entries of the output matrix will
-    // be 0x8.
-    Value *FullyInit = ConstantVector::getSplat(
-        ExpectedRTy->getElementCount(),
-        ConstantInt::get(ExpectedRTy->getElementType(), 0x8));
-
-    ShadowAB = IRB.CreateICmpNE(ShadowAB, FullyInit);
-
-    ShadowR = IRB.CreateICmpNE(ShadowR, getCleanShadow(ExpectedRTy));
+    ShadowR = IRB.CreateICmpNE(ShadowR, getCleanShadow(RTy));
     ShadowR = IRB.CreateOr(ShadowAB, ShadowR);
 
-    setShadow(&I, IRB.CreateSExt(ShadowR, ExpectedRTy));
+    setShadow(&I, IRB.CreateSExt(ShadowR, getShadowTy(RTy)));
+
     setOriginForNaryOp(I);
   }
 

--- a/llvm/test/Instrumentation/MemorySanitizer/AArch64/aarch64-bf16-dotprod-intrinsics.ll
+++ b/llvm/test/Instrumentation/MemorySanitizer/AArch64/aarch64-bf16-dotprod-intrinsics.ll
@@ -70,14 +70,12 @@ define <4 x float> @test_vbfmmlaq_f32(<4 x float> %r, <8 x bfloat> %a, <8 x bflo
 ; CHECK-NEXT:    [[TMP1:%.*]] = load <8 x i16>, ptr getelementptr (i8, ptr @__msan_param_tls, i64 16), align 8
 ; CHECK-NEXT:    [[TMP2:%.*]] = load <8 x i16>, ptr getelementptr (i8, ptr @__msan_param_tls, i64 32), align 8
 ; CHECK-NEXT:    call void @llvm.donothing()
-; CHECK-NEXT:    [[TMP3:%.*]] = bitcast <8 x i16> [[TMP1]] to <16 x i8>
-; CHECK-NEXT:    [[TMP4:%.*]] = bitcast <8 x i16> [[TMP2]] to <16 x i8>
-; CHECK-NEXT:    [[TMP5:%.*]] = icmp eq <16 x i8> [[TMP3]], zeroinitializer
-; CHECK-NEXT:    [[TMP6:%.*]] = zext <16 x i1> [[TMP5]] to <16 x i8>
-; CHECK-NEXT:    [[TMP7:%.*]] = icmp eq <16 x i8> [[TMP4]], zeroinitializer
-; CHECK-NEXT:    [[TMP8:%.*]] = zext <16 x i1> [[TMP7]] to <16 x i8>
-; CHECK-NEXT:    [[TMP9:%.*]] = call <4 x i32> @llvm.aarch64.neon.ummla.v4i32.v16i8(<4 x i32> zeroinitializer, <16 x i8> [[TMP6]], <16 x i8> [[TMP8]])
-; CHECK-NEXT:    [[TMP10:%.*]] = icmp ne <4 x i32> [[TMP9]], splat (i32 8)
+; CHECK-NEXT:    [[TMP3:%.*]] = icmp eq <8 x i16> [[TMP1]], zeroinitializer
+; CHECK-NEXT:    [[TMP4:%.*]] = select <8 x i1> [[TMP3]], <8 x bfloat> splat (bfloat 0xR3F80), <8 x bfloat> zeroinitializer
+; CHECK-NEXT:    [[TMP5:%.*]] = icmp eq <8 x i16> [[TMP2]], zeroinitializer
+; CHECK-NEXT:    [[TMP6:%.*]] = select <8 x i1> [[TMP5]], <8 x bfloat> splat (bfloat 0xR3F80), <8 x bfloat> zeroinitializer
+; CHECK-NEXT:    [[TMP7:%.*]] = call <4 x float> @llvm.aarch64.neon.bfmmla(<4 x float> zeroinitializer, <8 x bfloat> [[TMP4]], <8 x bfloat> [[TMP6]])
+; CHECK-NEXT:    [[TMP10:%.*]] = fcmp ult <4 x float> [[TMP7]], splat (float 3.500000e+00)
 ; CHECK-NEXT:    [[TMP12:%.*]] = icmp ne <4 x i32> [[TMP0]], zeroinitializer
 ; CHECK-NEXT:    [[TMP13:%.*]] = or <4 x i1> [[TMP10]], [[TMP12]]
 ; CHECK-NEXT:    [[TMP14:%.*]] = sext <4 x i1> [[TMP13]] to <4 x i32>


### PR DESCRIPTION
#176264 instrumented bfmmla by applying ummla to the shadows. However, Armv8.2+bf16 (as an example) supports bfmmla but not ummla, thus the instrumentation is not always compatible.

This patch changes the bfmmla instrumentation to use bfmmla and basic LLVM intrinsics, thus guaranteeing backend compatibility. The key insights are that we can 1) use CreateSelect to convert the integer shadows to bf16 2) apply bfmmla to these "shadows" 3) use FCmpULT to check that the matrix entries denote fully initialized outputs.

This patch significantly refactors `handleNEONMatrixMultiply`, which is also used for {s,u,su}mmla instrumentation, but the output is unaffected for {s,u,su}mmla.