### PR TITLE
[offload][L0] Remove XFAIL from XPASSING test strided_offset_multidim_update.c

### DIFF
--- a/offload/test/offloading/strided_offset_multidim_update.c
+++ b/offload/test/offloading/strided_offset_multidim_update.c
@@ -1,5 +1,4 @@
 // RUN: %libomptarget-compile-run-and-check-generic
-// XFAIL: intelgpu
 
 // Make sure multi-dimensional strided offset update works correctly.
 


### PR DESCRIPTION
Passing now I guess

https://lab.llvm.org/buildbot/#/builders/225/builds/4729

```
********************
Unexpectedly Passed Tests (1):
  libomptarget :: spirv64-intel :: offloading/strided_offset_multidim_update.c
```