### PR TITLE
Produce back-references for anonymous namespaces

### DIFF
--- a/clang/lib/AST/MicrosoftMangle.cpp
+++ b/clang/lib/AST/MicrosoftMangle.cpp
@@ -1180,7 +1180,9 @@ void MicrosoftCXXNameMangler::mangleUnqualifiedName(GlobalDecl GD,
 
       if (const NamespaceDecl *NS = dyn_cast<NamespaceDecl>(ND)) {
         if (NS->isAnonymousNamespace()) {
-          Out << "?A0x" << Context.getAnonymousNamespaceHash() << '@';
+          llvm::SmallString<16> Name("?A0x");
+          Name += Context.getAnonymousNamespaceHash();
+          mangleSourceName(Name);
           break;
         }
       }

--- a/clang/test/CodeGenCXX/cfi-icall.cpp
+++ b/clang/test/CodeGenCXX/cfi-icall.cpp
@@ -21,7 +21,7 @@ void g() {
 }
 
 // ITANIUM: define internal void @_ZN12_GLOBAL__N_11fENS_1SE({{.*}} !type [[TS1:![0-9]+]] !type [[TS2:![0-9]+]]
-// MS: define internal void @"?f@?A0x{{[^@]*}}@@YAXUS@?A0x{{[^@]*}}@@@Z"({{.*}} !type [[TS1:![0-9]+]] !type [[TS2:![0-9]+]]
+// MS: define internal void @"?f@?A0x{{[^@]*}}@@YAXUS@1@@Z"({{.*}} !type [[TS1:![0-9]+]] !type [[TS2:![0-9]+]]
 
 // CHECK: [[VOIDS1]] = distinct !{}
 // CHECK: [[TS1]] = !{i64 0, [[VOIDS1]]}

--- a/clang/test/CodeGenCXX/mangle-ms.cpp
+++ b/clang/test/CodeGenCXX/mangle-ms.cpp
@@ -18,13 +18,18 @@ namespace N {
   namespace {
     int anonymous;
 // CHECK-DAG: @"?anonymous@?A0x{{[^@]*}}@N@@3HA"
+
+    namespace {
+      int nested_anonymous;
+// CHECK-DAG: @"?nested_anonymous@?A0x{{[^@]*}}@1N@@3HA"
+    }
   }
 }
 
 static int c;
 // CHECK-DAG: @c
 
-int _c(void) {return N::anonymous + c;}
+int _c(void) {return N::anonymous + N::nested_anonymous + c;}
 // CHECK-DAG: @"?_c@@YAHXZ"
 // X64-DAG:   @"?_c@@YAHXZ"
 

--- a/clang/test/CodeGenCXX/mangle-ms.cpp
+++ b/clang/test/CodeGenCXX/mangle-ms.cpp
@@ -15,9 +15,16 @@ namespace N {
   int b;
 // CHECK-DAG: @"?b@N@@3HA"
 
+  struct O {
+    int v;
+  };
+
   namespace {
     int anonymous;
 // CHECK-DAG: @"?anonymous@?A0x{{[^@]*}}@N@@3HA"
+
+    O get() { return O(); }
+// CHECK-DAG: @"?get@?A0x{{[^@]*}}@N@@YA?AUO@2@XZ"
 
     namespace {
       int nested_anonymous;
@@ -29,7 +36,7 @@ namespace N {
 static int c;
 // CHECK-DAG: @c
 
-int _c(void) {return N::anonymous + N::nested_anonymous + c;}
+int _c(void) {return N::anonymous + N::nested_anonymous + N::get().v + c;}
 // CHECK-DAG: @"?_c@@YAHXZ"
 // X64-DAG:   @"?_c@@YAHXZ"
 


### PR DESCRIPTION
Resolves #37999

The Microsoft mangle implementation does not produce back-references for anonymous namespaces, which results in nonsensical output from both `undname` and `llvm-undname`. Consider the following example (https://godbolt.org/z/eqKnM33xr):

```
namespace {
    struct X {};
    X foo(X, X);
}

int main() {
    foo({}, {});
}
```

Clang 22.1.0
```
?foo@?A0xC9C482F4@@YA?AUX@?A0xC9C482F4@@U1?A0xC9C482F4@@0@Z

undname:
struct `anonymous namespace'::X __cdecl `anonymous namespace'::foo(struct `anonymous namespace'::A0xC9C482F4,struct `anonymous namespace'::A0xC9C482F4)

llvm-undname:
struct `anonymous namespace'::X __cdecl `anonymous namespace'::foo(struct `anonymous namespace'::0xC9C482F4, struct `anonymous namespace'::0xC9C482F4)
```

MSVC 19.50
```
?foo@?A0xa6a4f20e@@YA?AUX@1@U21@0@Z

undname:
struct A0xa6a4f20e::X __cdecl `anonymous namespace'::foo(struct A0xa6a4f20e::X,struct A0xa6a4f20e::X)

llvm-undname:
struct 0xa6a4f20e::X __cdecl `anonymous namespace'::foo(struct 0xa6a4f20e::X, struct 0xa6a4f20e::X)
```

As seen in the undname output for Clang's mangling, not recording a name back-reference for the anonymous namespace when mangling results in references to the anonymous namespace's hash in-place of the struct's name.

When recompiling the example with the changes, Clang yields `?foo@?A0x69FA3AC2@@YA?AUX@1@U21@0@Z`. Aside from the meaningless discrepancy with the hash, this is identical to what is produced by MSVC.