### PR TITLE
[libc++] Don't upload Docker image tarballs as artifacts

### DIFF
--- a/.github/workflows/libcxx-build-containers.yml
+++ b/.github/workflows/libcxx-build-containers.yml
@@ -69,18 +69,3 @@ jobs:
       run: docker compose --file libcxx/utils/ci/docker/docker-compose.yml push libcxx-linux-builder-base libcxx-linux-builder libcxx-android-builder
       env:
         TAG: ${{ github.sha }}
-
-    # We create tarballs with the images and upload them as artifacts, since that's useful for testing
-    # the images when making changes.
-    - name: Create image tarballs
-      run: |
-        docker image save ghcr.io/llvm/libcxx-linux-builder-base:${{ github.sha }} | gzip > libcxx-linux-builder-base.tar.gz
-        docker image save ghcr.io/llvm/libcxx-linux-builder:${{ github.sha }} | gzip > libcxx-linux-builder.tar.gz
-        docker image save ghcr.io/llvm/libcxx-android-builder:${{ github.sha }} | gzip > libcxx-android-builder.tar.gz
-    - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
-      with:
-          name: libcxx-docker-images
-          path: |
-            libcxx-linux-builder-base.tar.gz
-            libcxx-linux-builder.tar.gz
-            libcxx-android-builder.tar.gz


### PR DESCRIPTION
These steps fail because the tarballs are too large, so we might as well just not do it.