### PR TITLE
[mlir] Use Repeated<T> in more places to avoid temporary vectors. NFC.

### DIFF
--- a/mlir/lib/Dialect/MemRef/Transforms/ElideReinterpretCast.cpp
+++ b/mlir/lib/Dialect/MemRef/Transforms/ElideReinterpretCast.cpp
@@ -13,6 +13,7 @@
 #include "mlir/Dialect/MemRef/Transforms/Transforms.h"
 #include "mlir/IR/TypeUtilities.h"
 #include "mlir/Transforms/DialectConversion.h"
+#include "llvm/ADT/Repeated.h"
 #include <cassert>
 
 namespace mlir {
@@ -174,7 +175,7 @@ public:
     Value zero = arith::ConstantIndexOp::create(rewriter, loc, 0);
 
     auto srcType = cast<MemRefType>(src.getType());
-    SmallVector<Value> loadIndices(srcType.getRank(), zero);
+    Repeated<Value> loadIndices(srcType.getRank(), zero);
     auto offsets = rc.getMixedOffsets();
     assert(offsets.size() == 1 && "Expecting single offset");
     OpFoldResult offset = offsets[0];

--- a/mlir/lib/Dialect/MemRef/Transforms/ExtractAddressComputations.cpp
+++ b/mlir/lib/Dialect/MemRef/Transforms/ExtractAddressComputations.cpp
@@ -20,6 +20,7 @@
 #include "mlir/Dialect/Utils/StaticValueUtils.h"
 #include "mlir/Dialect/Vector/IR/VectorOps.h"
 #include "mlir/IR/PatternMatch.h"
+#include "llvm/ADT/Repeated.h"
 
 using namespace mlir;
 
@@ -40,7 +41,7 @@ static FailureOr<Value> getLoadOpSrcMemRef(memref::LoadOp loadOp) {
 // \see LoadStoreLikeOpRewriter.
 static memref::LoadOp rebuildLoadOp(RewriterBase &rewriter,
                                     memref::LoadOp loadOp, Value srcMemRef,
-                                    ArrayRef<Value> indices) {
+                                    ValueRange indices) {
   Location loc = loadOp.getLoc();
   return memref::LoadOp::create(rewriter, loc, srcMemRef, indices,
                                 loadOp.getNontemporal());
@@ -70,7 +71,7 @@ static FailureOr<Value> getStoreOpSrcMemRef(memref::StoreOp storeOp) {
 // \see LoadStoreLikeOpRewriter.
 static memref::StoreOp rebuildStoreOp(RewriterBase &rewriter,
                                       memref::StoreOp storeOp, Value srcMemRef,
-                                      ArrayRef<Value> indices) {
+                                      ValueRange indices) {
   Location loc = storeOp.getLoc();
   return memref::StoreOp::create(rewriter, loc, storeOp.getValueToStore(),
                                  srcMemRef, indices, storeOp.getNontemporal());
@@ -101,7 +102,7 @@ static FailureOr<Value> getLdMatrixOpSrcMemRef(nvgpu::LdMatrixOp ldMatrixOp) {
 static nvgpu::LdMatrixOp rebuildLdMatrixOp(RewriterBase &rewriter,
                                            nvgpu::LdMatrixOp ldMatrixOp,
                                            Value srcMemRef,
-                                           ArrayRef<Value> indices) {
+                                           ValueRange indices) {
   Location loc = ldMatrixOp.getLoc();
   return nvgpu::LdMatrixOp::create(
       rewriter, loc, ldMatrixOp.getResult().getType(), srcMemRef, indices,
@@ -129,7 +130,7 @@ getTransferLikeOpSrcMemRef(TransferLikeOp transferLikeOp) {
 static vector::TransferReadOp
 rebuildTransferReadOp(RewriterBase &rewriter,
                       vector::TransferReadOp transferReadOp, Value srcMemRef,
-                      ArrayRef<Value> indices) {
+                      ValueRange indices) {
   Location loc = transferReadOp.getLoc();
   return vector::TransferReadOp::create(
       rewriter, loc, transferReadOp.getResult().getType(), srcMemRef, indices,
@@ -147,7 +148,7 @@ rebuildTransferReadOp(RewriterBase &rewriter,
 static vector::TransferWriteOp
 rebuildTransferWriteOp(RewriterBase &rewriter,
                        vector::TransferWriteOp transferWriteOp, Value srcMemRef,
-                       ArrayRef<Value> indices) {
+                       ValueRange indices) {
   Location loc = transferWriteOp.getLoc();
   return vector::TransferWriteOp::create(
       rewriter, loc, transferWriteOp.getValue(), srcMemRef, indices,
@@ -221,7 +222,7 @@ template <typename LoadStoreLikeOp,
           FailureOr<Value> (*getFailureOrSrcMemRef)(LoadStoreLikeOp),
           LoadStoreLikeOp (*rebuildOpFromAddressAndIndices)(
               RewriterBase & /*rewriter*/, LoadStoreLikeOp /*loadStoreOp*/,
-              Value /*srcMemRef*/, ArrayRef<Value> /*indices*/),
+              Value /*srcMemRef*/, ValueRange /*indices*/),
           SmallVector<OpFoldResult> (*getViewSizeForEachDim)(
               RewriterBase & /*rewriter*/, LoadStoreLikeOp /*loadStoreOp*/) =
               getGenericOpViewSizeForEachDim<
@@ -269,8 +270,8 @@ struct LoadStoreLikeOpRewriter : public OpRewritePattern<LoadStoreLikeOp> {
                                   /*offsets=*/indices,
                                   /*sizes=*/sizes, /*strides=*/ones);
     // Rewrite the load/store with the subview as the base pointer.
-    SmallVector<Value> zeros(loadStoreRank,
-                             arith::ConstantIndexOp::create(rewriter, loc, 0));
+    Repeated<Value> zeros(loadStoreRank,
+                          arith::ConstantIndexOp::create(rewriter, loc, 0));
     LoadStoreLikeOp newLoadStore = rebuildOpFromAddressAndIndices(
         rewriter, loadStoreLikeOp, subview.getResult(), zeros);
     rewriter.replaceOp(loadStoreLikeOp, newLoadStore->getResults());

--- a/mlir/lib/Dialect/Tensor/IR/TensorOps.cpp
+++ b/mlir/lib/Dialect/Tensor/IR/TensorOps.cpp
@@ -32,6 +32,7 @@
 #include "mlir/Interfaces/ViewLikeInterface.h"
 #include "mlir/Support/LLVM.h"
 #include "llvm/ADT/DenseSet.h"
+#include "llvm/ADT/Repeated.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallBitVector.h"
 #include "llvm/ADT/SmallVectorExtras.h"
@@ -3379,7 +3380,7 @@ void PadOp::build(OpBuilder &b, OperationState &result, Type resultType,
   // Add a region and a block to yield the pad value.
   Region *region = result.regions[0].get();
   int sourceRank = llvm::cast<RankedTensorType>(source.getType()).getRank();
-  SmallVector<Type> blockArgTypes(sourceRank, b.getIndexType());
+  Repeated<Type> blockArgTypes(sourceRank, b.getIndexType());
   SmallVector<Location> blockArgLocs(sourceRank, result.location);
 
   // `builder.createBlock` changes the insertion point within the block. Create

--- a/mlir/lib/Dialect/Vector/IR/VectorOps.cpp
+++ b/mlir/lib/Dialect/Vector/IR/VectorOps.cpp
@@ -40,6 +40,7 @@
 #include "mlir/Support/LLVM.h"
 #include "mlir/Transforms/InliningUtils.h"
 #include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/Repeated.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/SmallVectorExtras.h"
@@ -3721,8 +3722,8 @@ public:
         continue;
       }
 
-      SmallVector<Type> elementToInsertTypes(insertSize,
-                                             srcVectorType.getElementType());
+      Repeated<Type> elementToInsertTypes(insertSize,
+                                          srcVectorType.getElementType());
       // Get all elements from the vector in row-major order.
       auto elementsToInsert = vector::ToElementsOp::create(
           rewriter, op.getLoc(), elementToInsertTypes, valueToStore);


### PR DESCRIPTION
Replace `SmallVector<Type/Value>(n, x)` with `Repeated<Type/Value>(n, x)`. This avoids heap allocations for repeated values.

Also change `ExtractAddressComputations` rebuild callbacks from `ArrayRef<Value>` to `ValueRange` to enable `Repeated<Value>` passthrough.