### PR TITLE
[flang] Don't defer namelist processing under -pedantic

### DIFF
--- a/flang/docs/Extensions.md
+++ b/flang/docs/Extensions.md
@@ -833,7 +833,8 @@ end module
   has resolved all of the names in that scope.  This means that names
   that appear before their local declarations do not resolve to host
   associated objects and do not elicit errors about improper redeclarations
-  of implicitly typed entities.
+  of implicitly typed entities. This can be disabled with `-Wno-namelist-no-defer`,
+  which is implicitly enabled under `-pedantic`.
 
 * Standard Fortran allows forward references to derived types, which
   can lead to ambiguity when combined with host association.

--- a/flang/include/flang/Support/Fortran-features.h
+++ b/flang/include/flang/Support/Fortran-features.h
@@ -84,7 +84,7 @@ ENUM_CLASS(UsageWarning, Portability, PointerToUndefinable,
     HostAssociatedIntentOutInSpecExpr, NonVolatilePointerToVolatile,
     RealConstantWidening, VolatileOrAsynchronousTemporary, UnusedVariable,
     UsedUndefinedVariable, BadValueInDeadCode, AssumedTypeSizeDummy,
-    MisplacedIgnoreTKR, NamelistParameter, ImpureFinalInPure)
+    MisplacedIgnoreTKR, NamelistParameter, ImpureFinalInPure, NamelistNoDefer)
 
 using LanguageFeatures = EnumSet<LanguageFeature, LanguageFeature_enumSize>;
 using UsageWarnings = EnumSet<UsageWarning, UsageWarning_enumSize>;

--- a/flang/lib/Semantics/resolve-names.cpp
+++ b/flang/lib/Semantics/resolve-names.cpp
@@ -7239,6 +7239,14 @@ bool DeclarationVisitor::Pre(const parser::NamelistStmt::Group &x) {
     groupSymbol = &MakeSymbol(groupName, NamelistDetails{});
     groupSymbol->ReplaceName(groupName.source);
   }
+  // don't defer namelist processing with -pedantic
+  if(context().ShouldWarn(common::UsageWarning::NamelistNoDefer)) {
+    context().Warn(common::UsageWarning::NamelistNoDefer, "Namelist processing not deferred"_port_en_US);
+    for (const auto &name : std::get<std::list<parser::Name>>(x.t)) {
+      ResolveName(name);
+    }
+  }
+  
   // Name resolution of group items is deferred to FinishNamelists()
   // so that host association is handled correctly.
   GetDeferredDeclarationState(true)->namelistGroups.emplace_back(&x);

--- a/flang/test/Semantics/io16.f90
+++ b/flang/test/Semantics/io16.f90
@@ -1,4 +1,4 @@
-! RUN: %python %S/test_errors.py %s %flang_fc1 -pedantic
+! RUN: %python %S/test_errors.py %s %flang_fc1 -pedantic -Wno-namelist-no-defer
 subroutine assumedRank(x, y)
   real x(..), y(*)
   !PORTABILITY: Assumed-rank object 'x' should not be a namelist group item [-Wassumed-rank-io-item]

--- a/flang/test/Semantics/namelist02.f90
+++ b/flang/test/Semantics/namelist02.f90
@@ -1,4 +1,4 @@
-! RUN: %python %S/test_errors.py %s %flang_fc1 -pedantic -Werror
+! RUN: %python %S/test_errors.py %s %flang_fc1 -pedantic -Werror -Wno-namelist-no-defer
 
 module m
   implicit none

--- a/flang/test/Semantics/namelist03.f90
+++ b/flang/test/Semantics/namelist03.f90
@@ -1,0 +1,14 @@
+! RUN: %python %S/test_errors.py %s %flang_fc1 -pedantic
+! Namelist processing deferred under -pedantic. Therefore,
+! x should be implicitly (default) typed as a real, and i
+! should be implicitly typed as an integer (because it starts
+! with i-n). Both should print a type error at their explicit
+! declarations which must agree with their implicit typing.
+subroutine s 
+  !PORTABILITY: Namelist processing not deferred [-Wnamelist-no-defer]
+  namelist /nl/ x, i 
+  !ERROR: The type of 'x' has already been implicitly declared as REAL(4)
+  integer :: x 
+  !ERROR: The type of 'i' has already been implicitly declared as INTEGER(4)
+  real :: i
+end subroutine 

--- a/flang/test/Semantics/pointer01.f90
+++ b/flang/test/Semantics/pointer01.f90
@@ -1,4 +1,4 @@
-! RUN: %python %S/test_errors.py %s %flang_fc1 -pedantic
+! RUN: %python %S/test_errors.py %s %flang_fc1 -pedantic -Wno-namelist-no-defer
 module m
   real mobj
  contains


### PR DESCRIPTION
Implementation started on the following PR by @jotken: https://github.com/llvm/llvm-project/pull/179599
This PR applies the suggested comments, namely, put this restriction behind `-pedantic` flag (or `-Wno-namelist-no-defer` if you want to enable this without everything else under `-pedantic`). 

There were 3 other tests using namelists and -pedantic, so this new message caused them to fail. Disable on those tests using `-Wno-namelist-no-defer`. 