### PR TITLE
[libc][NFC] Add LIBC_INLINE and cleanup wchar internals

### DIFF
--- a/libc/src/__support/wchar/CMakeLists.txt
+++ b/libc/src/__support/wchar/CMakeLists.txt
@@ -15,6 +15,8 @@ add_header_library(
     libc.hdr.types.char8_t
     libc.hdr.types.char32_t
     libc.hdr.types.size_t
+    libc.src.__support.common
+    libc.src.__support.CPP.type_traits
     libc.src.__support.error_or
     .mbstate
     .character_converter 
@@ -29,7 +31,10 @@ add_header_library(
     libc.hdr.types.char8_t
     libc.hdr.types.char32_t
     libc.hdr.types.size_t
+    libc.src.__support.common
+    libc.src.__support.CPP.type_traits
     libc.src.__support.error_or
+    libc.src.__support.macros.config
     libc.src.__support.math_extras
     .mbstate
 )
@@ -43,8 +48,9 @@ add_header_library(
     libc.hdr.types.char32_t
     libc.hdr.types.size_t
     libc.hdr.types.wchar_t
-    libc.src.__support.error_or
     libc.src.__support.common
+    libc.src.__support.error_or
+    libc.src.__support.libc_assert
     libc.src.__support.macros.null_check
     .character_converter
     .mbstate
@@ -94,8 +100,10 @@ add_header_library(
     libc.hdr.types.char32_t
     libc.hdr.types.size_t
     libc.hdr.types.wchar_t
-    libc.src.__support.error_or
     libc.src.__support.common
+    libc.src.__support.error_or
+    libc.src.__support.macros.config
+    libc.src.__support.macros.null_check
     .string_converter
     .character_converter
     .mbstate

--- a/libc/src/__support/wchar/character_converter.h
+++ b/libc/src/__support/wchar/character_converter.h
@@ -42,17 +42,17 @@ private:
   static constexpr int MAX_UTF8_LENGTH = 4;
 
 public:
-  CharacterConverter(mbstate *mbstate) : state(mbstate) {}
+  explicit LIBC_INLINE CharacterConverter(mbstate *state_ptr) : state(state_ptr) {}
 
-  void clear() {
+  LIBC_INLINE void clear() {
     state->partial = 0;
     state->bytes_stored = 0;
     state->total_bytes = 0;
   }
-  bool isFull() {
+  LIBC_INLINE bool isFull() {
     return state->bytes_stored == state->total_bytes && state->total_bytes != 0;
   }
-  bool isEmpty() { return state->bytes_stored == 0; }
+  LIBC_INLINE bool isEmpty() { return state->bytes_stored == 0; }
   bool isValidState();
 
   template <typename CharType> size_t sizeAs();

--- a/libc/src/__support/wchar/character_converter.h
+++ b/libc/src/__support/wchar/character_converter.h
@@ -42,7 +42,8 @@ private:
   static constexpr int MAX_UTF8_LENGTH = 4;
 
 public:
-  explicit LIBC_INLINE CharacterConverter(mbstate *state_ptr) : state(state_ptr) {}
+  explicit LIBC_INLINE CharacterConverter(mbstate *state_ptr)
+      : state(state_ptr) {}
 
   LIBC_INLINE void clear() {
     state->partial = 0;

--- a/libc/src/__support/wchar/mbrtowc.cpp
+++ b/libc/src/__support/wchar/mbrtowc.cpp
@@ -19,17 +19,17 @@
 namespace LIBC_NAMESPACE_DECL {
 namespace internal {
 
-ErrorOr<size_t> mbrtowc(wchar_t *__restrict pwc, const char *__restrict s,
-                        size_t n, mbstate *__restrict ps) {
+ErrorOr<size_t> mbrtowc(wchar_t *__restrict pwc, const char *__restrict src_ptr,
+                        size_t max_src_bytes, mbstate *__restrict ps) {
   CharacterConverter char_conv(ps);
   if (!char_conv.isValidState())
     return Error(EINVAL);
-  if (s == nullptr)
+  if (src_ptr == nullptr)
     return 0;
   size_t i = 0;
   // Reading in bytes until we have a complete wc or error
-  for (; i < n && !char_conv.isFull(); ++i) {
-    int err = char_conv.push(static_cast<char8_t>(s[i]));
+  for (; i < max_src_bytes && !char_conv.isFull(); ++i) {
+    int err = char_conv.push(static_cast<char8_t>(src_ptr[i]));
     // Encoding error
     if (err == EILSEQ)
       return Error(err);

--- a/libc/src/__support/wchar/mbrtowc.h
+++ b/libc/src/__support/wchar/mbrtowc.h
@@ -19,8 +19,8 @@
 namespace LIBC_NAMESPACE_DECL {
 namespace internal {
 
-ErrorOr<size_t> mbrtowc(wchar_t *__restrict pwc, const char *__restrict s,
-                        size_t n, mbstate *__restrict ps);
+ErrorOr<size_t> mbrtowc(wchar_t *__restrict pwc, const char *__restrict src_ptr,
+                        size_t max_src_bytes, mbstate *__restrict ps);
 
 } // namespace internal
 

--- a/libc/src/__support/wchar/mbsnrtowcs.h
+++ b/libc/src/__support/wchar/mbsnrtowcs.h
@@ -25,16 +25,15 @@ namespace internal {
 
 LIBC_INLINE static ErrorOr<size_t> mbsnrtowcs(wchar_t *__restrict dst,
                                               const char **__restrict src,
-                                              size_t nmc, size_t len,
+                                              size_t max_src_bytes, size_t max_dst_chars,
                                               mbstate *__restrict ps) {
   LIBC_CRASH_ON_NULLPTR(src);
-  // Checking if mbstate is valid
   CharacterConverter char_conv(ps);
   if (!char_conv.isValidState())
     return Error(EINVAL);
 
   StringConverter<char8_t> str_conv(reinterpret_cast<const char8_t *>(*src), ps,
-                                    len, nmc);
+                                    max_dst_chars, max_src_bytes);
   size_t dst_idx = 0;
   ErrorOr<char32_t> converted = str_conv.pop<char32_t>();
   while (converted.has_value()) {

--- a/libc/src/__support/wchar/mbsnrtowcs.h
+++ b/libc/src/__support/wchar/mbsnrtowcs.h
@@ -23,10 +23,9 @@
 namespace LIBC_NAMESPACE_DECL {
 namespace internal {
 
-LIBC_INLINE static ErrorOr<size_t> mbsnrtowcs(wchar_t *__restrict dst,
-                                              const char **__restrict src,
-                                              size_t max_src_bytes, size_t max_dst_chars,
-                                              mbstate *__restrict ps) {
+LIBC_INLINE static ErrorOr<size_t>
+mbsnrtowcs(wchar_t *__restrict dst, const char **__restrict src,
+           size_t max_src_bytes, size_t max_dst_chars, mbstate *__restrict ps) {
   LIBC_CRASH_ON_NULLPTR(src);
   CharacterConverter char_conv(ps);
   if (!char_conv.isValidState())

--- a/libc/src/__support/wchar/string_converter.h
+++ b/libc/src/__support/wchar/string_converter.h
@@ -31,7 +31,7 @@ private:
   // # of pops we are allowed to perform (essentially size of the dest buffer)
   size_t num_to_write;
 
-  ErrorOr<size_t> pushFullCharacter() {
+  LIBC_INLINE ErrorOr<size_t> pushFullCharacter() {
     size_t num_pushed;
     for (num_pushed = 0; !cr.isFull() && src_idx + num_pushed < src_len;
          ++num_pushed) {
@@ -50,11 +50,11 @@ private:
   }
 
 public:
-  StringConverter(const T *s, mbstate *ps, size_t dstlen,
+  LIBC_INLINE StringConverter(const T *s, mbstate *ps, size_t dstlen,
                   size_t srclen = SIZE_MAX)
       : cr(ps), src(s), src_len(srclen), src_idx(0), num_to_write(dstlen) {}
 
-  template <typename CharType> ErrorOr<CharType> pop() {
+  template <typename CharType> LIBC_INLINE ErrorOr<CharType> pop() {
     if (num_to_write == 0)
       return Error(-1);
 
@@ -81,7 +81,7 @@ public:
     return out;
   }
 
-  size_t getSourceIndex() { return src_idx; }
+  LIBC_INLINE size_t getSourceIndex() { return src_idx; }
 };
 
 } // namespace internal

--- a/libc/src/__support/wchar/string_converter.h
+++ b/libc/src/__support/wchar/string_converter.h
@@ -51,7 +51,7 @@ private:
 
 public:
   LIBC_INLINE StringConverter(const T *s, mbstate *ps, size_t dstlen,
-                  size_t srclen = SIZE_MAX)
+                              size_t srclen = SIZE_MAX)
       : cr(ps), src(s), src_len(srclen), src_idx(0), num_to_write(dstlen) {}
 
   template <typename CharType> LIBC_INLINE ErrorOr<CharType> pop() {

--- a/libc/src/__support/wchar/wcrtomb.h
+++ b/libc/src/__support/wchar/wcrtomb.h
@@ -24,9 +24,9 @@
 namespace LIBC_NAMESPACE_DECL {
 namespace internal {
 
-LIBC_INLINE ErrorOr<size_t> wcrtomb(char *__restrict s, wchar_t wc,
+LIBC_INLINE ErrorOr<size_t> wcrtomb(char *__restrict dest_ptr, wchar_t wc,
                                     mbstate *__restrict ps) {
-  LIBC_CRASH_ON_NULLPTR(s);
+  LIBC_CRASH_ON_NULLPTR(dest_ptr);
   LIBC_CRASH_ON_NULLPTR(ps);
   static_assert(sizeof(wchar_t) == 4);
 
@@ -44,8 +44,8 @@ LIBC_INLINE ErrorOr<size_t> wcrtomb(char *__restrict s, wchar_t wc,
     auto utf8 = cr.pop_utf8(); // can never fail as long as the push succeeded
     LIBC_ASSERT(utf8.has_value());
 
-    *s = utf8.value();
-    s++;
+    *dest_ptr = utf8.value();
+    dest_ptr++;
     count++;
   }
   return count;

--- a/libc/src/__support/wchar/wcsnrtombs.h
+++ b/libc/src/__support/wchar/wcsnrtombs.h
@@ -10,10 +10,10 @@
 #define LLVM_LIBC_SRC__SUPPORT_WCHAR_WCSNRTOMBS_H
 
 #include "hdr/types/char32_t.h"
+#include "hdr/types/char8_t.h"
 #include "hdr/types/size_t.h"
 #include "hdr/types/wchar_t.h"
 #include "src/__support/common.h"
-#include "src/__support/libc_errno.h"
 #include "src/__support/macros/config.h"
 #include "src/__support/macros/null_check.h"
 #include "src/__support/wchar/mbstate.h"


### PR DESCRIPTION
Some of the functions were missing LIBC_INLINE and some of the variable
names were less descriptive than I liked. This PR fixes both as well as
cleaning up dependencies.
