### PR TITLE
[TargetLowering][RISCV] Prefer (S/U)MUL_LOHI over MULH(S/U) in expandMULO.

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/TargetLowering.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/TargetLowering.cpp
@@ -12042,15 +12042,15 @@ bool TargetLowering::expandMULO(SDNode *Node, SDValue &Result,
   EVT WideVT = VT.widenIntegerElementType(*DAG.getContext());
 
   static const unsigned Ops[2][3] =
-      { { ISD::MULHU, ISD::UMUL_LOHI, ISD::ZERO_EXTEND },
-        { ISD::MULHS, ISD::SMUL_LOHI, ISD::SIGN_EXTEND }};
+      { { ISD::UMUL_LOHI, ISD::MULHU, ISD::ZERO_EXTEND },
+        { ISD::SMUL_LOHI, ISD::MULHS, ISD::SIGN_EXTEND }};
   if (isOperationLegalOrCustom(Ops[isSigned][0], VT)) {
-    BottomHalf = DAG.getNode(ISD::MUL, dl, VT, LHS, RHS);
-    TopHalf = DAG.getNode(Ops[isSigned][0], dl, VT, LHS, RHS);
-  } else if (isOperationLegalOrCustom(Ops[isSigned][1], VT)) {
-    BottomHalf = DAG.getNode(Ops[isSigned][1], dl, DAG.getVTList(VT, VT), LHS,
+    BottomHalf = DAG.getNode(Ops[isSigned][0], dl, DAG.getVTList(VT, VT), LHS,
                              RHS);
     TopHalf = BottomHalf.getValue(1);
+  } else if (isOperationLegalOrCustom(Ops[isSigned][1], VT)) {
+    BottomHalf = DAG.getNode(ISD::MUL, dl, VT, LHS, RHS);
+    TopHalf = DAG.getNode(Ops[isSigned][1], dl, VT, LHS, RHS);
   } else if (isTypeLegal(WideVT)) {
     LHS = DAG.getNode(Ops[isSigned][2], dl, WideVT, LHS);
     RHS = DAG.getNode(Ops[isSigned][2], dl, WideVT, RHS);

--- a/llvm/test/CodeGen/RISCV/rv32p.ll
+++ b/llvm/test/CodeGen/RISCV/rv32p.ll
@@ -1242,3 +1242,38 @@ define i64 @wsub_from_neg_const(i32 %a) nounwind {
   %sum = add i64 %ext_a, -42
   ret i64 %sum
 }
+
+define zeroext i1 @smulo_i32(i32 %v1, i32 %v2, ptr %res) {
+; CHECK-LABEL: smulo_i32:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    mulh a3, a0, a1
+; CHECK-NEXT:    mul a1, a0, a1
+; CHECK-NEXT:    srai a0, a1, 31
+; CHECK-NEXT:    xor a0, a3, a0
+; CHECK-NEXT:    snez a0, a0
+; CHECK-NEXT:    sw a1, 0(a2)
+; CHECK-NEXT:    ret
+entry:
+  %t = call {i32, i1} @llvm.smul.with.overflow.i32(i32 %v1, i32 %v2)
+  %val = extractvalue {i32, i1} %t, 0
+  %obit = extractvalue {i32, i1} %t, 1
+  store i32 %val, ptr %res
+  ret i1 %obit
+}
+
+define zeroext i1 @umulo_i32(i32 %v1, i32 %v2, ptr %res) {
+; CHECK-LABEL: umulo_i32:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    mulhu a3, a0, a1
+; CHECK-NEXT:    snez a3, a3
+; CHECK-NEXT:    mul a0, a0, a1
+; CHECK-NEXT:    sw a0, 0(a2)
+; CHECK-NEXT:    mv a0, a3
+; CHECK-NEXT:    ret
+entry:
+  %t = call {i32, i1} @llvm.umul.with.overflow.i32(i32 %v1, i32 %v2)
+  %val = extractvalue {i32, i1} %t, 0
+  %obit = extractvalue {i32, i1} %t, 1
+  store i32 %val, ptr %res
+  ret i1 %obit
+}

--- a/llvm/test/CodeGen/RISCV/rv32p.ll
+++ b/llvm/test/CodeGen/RISCV/rv32p.ll
@@ -1246,12 +1246,11 @@ define i64 @wsub_from_neg_const(i32 %a) nounwind {
 define zeroext i1 @smulo_i32(i32 %v1, i32 %v2, ptr %res) {
 ; CHECK-LABEL: smulo_i32:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    mulh a3, a0, a1
-; CHECK-NEXT:    mul a1, a0, a1
-; CHECK-NEXT:    srai a0, a1, 31
-; CHECK-NEXT:    xor a0, a3, a0
+; CHECK-NEXT:    wmul a4, a0, a1
+; CHECK-NEXT:    srai a0, a4, 31
+; CHECK-NEXT:    xor a0, a5, a0
 ; CHECK-NEXT:    snez a0, a0
-; CHECK-NEXT:    sw a1, 0(a2)
+; CHECK-NEXT:    sw a4, 0(a2)
 ; CHECK-NEXT:    ret
 entry:
   %t = call {i32, i1} @llvm.smul.with.overflow.i32(i32 %v1, i32 %v2)
@@ -1264,11 +1263,9 @@ entry:
 define zeroext i1 @umulo_i32(i32 %v1, i32 %v2, ptr %res) {
 ; CHECK-LABEL: umulo_i32:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    mulhu a3, a0, a1
-; CHECK-NEXT:    snez a3, a3
-; CHECK-NEXT:    mul a0, a0, a1
-; CHECK-NEXT:    sw a0, 0(a2)
-; CHECK-NEXT:    mv a0, a3
+; CHECK-NEXT:    wmulu a4, a0, a1
+; CHECK-NEXT:    snez a0, a5
+; CHECK-NEXT:    sw a4, 0(a2)
 ; CHECK-NEXT:    ret
 entry:
   %t = call {i32, i1} @llvm.umul.with.overflow.i32(i32 %v1, i32 %v2)


### PR DESCRIPTION
The RISC-V P extension adds WMUL and WMULU instruction that produce
a full 64-bit product in 2 GPRs. The base ISA already had MULH and
MULHU.