### PR TITLE
[msan] Disambiguate "Strict" vs. "Heuristic" when dumping instructions

### DIFF
--- a/llvm/lib/Transforms/Instrumentation/MemorySanitizer.cpp
+++ b/llvm/lib/Transforms/Instrumentation/MemorySanitizer.cpp
@@ -7744,7 +7744,8 @@ struct MemorySanitizerVisitor : public InstVisitor<MemorySanitizerVisitor> {
     //
     // e.g., "call llvm.aarch64.neon.uqsub.v16i8"
     if (CallInst *CI = dyn_cast<CallInst>(&I)) {
-      errs() << "ZZZ:" << Prefix << " call " << CI->getCalledFunction()->getName() << "\n";
+      errs() << "ZZZ:" << Prefix << " call "
+             << CI->getCalledFunction()->getName() << "\n";
     } else {
       errs() << "ZZZ:" << Prefix << " " << I.getOpcodeName() << "\n";
     }
@@ -7767,7 +7768,8 @@ struct MemorySanitizerVisitor : public InstVisitor<MemorySanitizerVisitor> {
       // The last operand of a CallInst is the function itself.
       NumOperands--;
     } else
-      errs() << "YYY:" << Prefix << " " << *I.getType() << " " << I.getOpcodeName() << "(";
+      errs() << "YYY:" << Prefix << " " << *I.getType() << " "
+             << I.getOpcodeName() << "(";
 
     for (size_t i = 0; i < NumOperands; i++) {
       if (i > 0)

--- a/llvm/lib/Transforms/Instrumentation/MemorySanitizer.cpp
+++ b/llvm/lib/Transforms/Instrumentation/MemorySanitizer.cpp
@@ -3464,7 +3464,7 @@ struct MemorySanitizerVisitor : public InstVisitor<MemorySanitizerVisitor> {
   bool maybeHandleUnknownIntrinsic(IntrinsicInst &I) {
     if (maybeHandleUnknownIntrinsicUnlogged(I)) {
       if (ClDumpHeuristicInstructions)
-        dumpInst(I);
+        dumpInst(I, "Heuristic");
 
       LLVM_DEBUG(dbgs() << "UNKNOWN INSTRUCTION HANDLED HEURISTICALLY: " << I
                         << "\n");
@@ -7738,15 +7738,15 @@ struct MemorySanitizerVisitor : public InstVisitor<MemorySanitizerVisitor> {
     setOriginForNaryOp(I);
   }
 
-  void dumpInst(Instruction &I) {
+  void dumpInst(Instruction &I, const Twine &Prefix) {
     // Instruction name only
     // For intrinsics, the full/overloaded name is used
     //
     // e.g., "call llvm.aarch64.neon.uqsub.v16i8"
     if (CallInst *CI = dyn_cast<CallInst>(&I)) {
-      errs() << "ZZZ call " << CI->getCalledFunction()->getName() << "\n";
+      errs() << "ZZZ:" << Prefix << " call " << CI->getCalledFunction()->getName() << "\n";
     } else {
-      errs() << "ZZZ " << I.getOpcodeName() << "\n";
+      errs() << "ZZZ:" << Prefix << " " << I.getOpcodeName() << "\n";
     }
 
     // Instruction prototype (including return type and parameter types)
@@ -7755,7 +7755,7 @@ struct MemorySanitizerVisitor : public InstVisitor<MemorySanitizerVisitor> {
     // e.g., "call <16 x i8> @llvm.aarch64.neon.uqsub(<16 x i8>, <16 x i8>)"
     unsigned NumOperands = I.getNumOperands();
     if (CallInst *CI = dyn_cast<CallInst>(&I)) {
-      errs() << "YYY call " << *I.getType() << " @";
+      errs() << "YYY:" << Prefix << " call " << *I.getType() << " @";
 
       if (IntrinsicInst *II = dyn_cast<IntrinsicInst>(CI))
         errs() << Intrinsic::getBaseName(II->getIntrinsicID());
@@ -7767,7 +7767,7 @@ struct MemorySanitizerVisitor : public InstVisitor<MemorySanitizerVisitor> {
       // The last operand of a CallInst is the function itself.
       NumOperands--;
     } else
-      errs() << "YYY " << *I.getType() << " " << I.getOpcodeName() << "(";
+      errs() << "YYY:" << Prefix << " " << *I.getType() << " " << I.getOpcodeName() << "(";
 
     for (size_t i = 0; i < NumOperands; i++) {
       if (i > 0)
@@ -7784,7 +7784,7 @@ struct MemorySanitizerVisitor : public InstVisitor<MemorySanitizerVisitor> {
     // e.g., "%vqsubq_v.i15 = call noundef <16 x i8>
     //            @llvm.aarch64.neon.uqsub.v16i8(<16 x i8> %vext21.i,
     //            <16 x i8> splat (i8 1)), !dbg !66"
-    errs() << "QQQ " << I << "\n";
+    errs() << "QQQ:" << Prefix << " " << I << "\n";
   }
 
   void visitResumeInst(ResumeInst &I) {
@@ -7916,7 +7916,7 @@ struct MemorySanitizerVisitor : public InstVisitor<MemorySanitizerVisitor> {
   void visitInstruction(Instruction &I) {
     // Everything else: stop propagating and check for poisoned shadow.
     if (ClDumpStrictInstructions)
-      dumpInst(I);
+      dumpInst(I, "Strict");
     LLVM_DEBUG(dbgs() << "DEFAULT: " << I << "\n");
     for (size_t i = 0, n = I.getNumOperands(); i < n; i++) {
       Value *Operand = I.getOperand(i);


### PR DESCRIPTION
When -msan-dump-strict-instructions and -msan-dump-heuristic-instructions are simultaneously enabled, it is unclear from the output whether each instruction is strictly vs. heuristically handled. [*] This patch fixes the issue by tagging the output.

The actual instrumentation of the code is unaffected by this change.

[*] A workaround is to compile the code once with only -msan-dump-strict-instructions, and a second time with -msan-dump-heuristic-instructions, but this unnecessarily doubles the compilation time.