### PR TITLE
[clang] Introduce `ModuleCache::read()`

### DIFF
--- a/clang/include/clang/Serialization/ModuleCache.h
+++ b/clang/include/clang/Serialization/ModuleCache.h
@@ -10,11 +10,14 @@
 #define LLVM_CLANG_SERIALIZATION_MODULECACHE_H
 
 #include "clang/Basic/LLVM.h"
+#include "llvm/Support/ErrorOr.h"
 
 #include <ctime>
+#include <memory>
 
 namespace llvm {
 class AdvisoryLock;
+class MemoryBuffer;
 } // namespace llvm
 
 namespace clang {
@@ -52,7 +55,10 @@ public:
   virtual InMemoryModuleCache &getInMemoryModuleCache() = 0;
   virtual const InMemoryModuleCache &getInMemoryModuleCache() const = 0;
 
-  // TODO: Virtualize writing/reading PCM files, etc.
+  // TODO: Virtualize writing PCM files.
+
+  virtual llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>>
+  read(StringRef FileName, off_t &Size, time_t &ModTime) = 0;
 
   virtual ~ModuleCache() = default;
 };
@@ -65,6 +71,10 @@ std::shared_ptr<ModuleCache> createCrossProcessModuleCache();
 
 /// Shared implementation of `ModuleCache::maybePrune()`.
 void maybePruneImpl(StringRef Path, time_t PruneInterval, time_t PruneAfter);
+
+/// Shared implementation of `ModuleCache::load()`.
+llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>>
+readImpl(StringRef FileName, off_t &Size, time_t &ModTime);
 } // namespace clang
 
 #endif

--- a/clang/include/clang/Serialization/ModuleCache.h
+++ b/clang/include/clang/Serialization/ModuleCache.h
@@ -57,7 +57,7 @@ public:
 
   // TODO: Virtualize writing PCM files.
 
-  virtual llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>>
+  virtual Expected<std::unique_ptr<llvm::MemoryBuffer>>
   read(StringRef FileName, off_t &Size, time_t &ModTime) = 0;
 
   virtual ~ModuleCache() = default;
@@ -72,8 +72,8 @@ std::shared_ptr<ModuleCache> createCrossProcessModuleCache();
 /// Shared implementation of `ModuleCache::maybePrune()`.
 void maybePruneImpl(StringRef Path, time_t PruneInterval, time_t PruneAfter);
 
-/// Shared implementation of `ModuleCache::load()`.
-llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>>
+/// Shared implementation of `ModuleCache::read()`.
+Expected<std::unique_ptr<llvm::MemoryBuffer>>
 readImpl(StringRef FileName, off_t &Size, time_t &ModTime);
 } // namespace clang
 

--- a/clang/include/clang/Serialization/ModuleCache.h
+++ b/clang/include/clang/Serialization/ModuleCache.h
@@ -10,7 +10,6 @@
 #define LLVM_CLANG_SERIALIZATION_MODULECACHE_H
 
 #include "clang/Basic/LLVM.h"
-#include "llvm/Support/ErrorOr.h"
 
 #include <ctime>
 #include <memory>

--- a/clang/lib/DependencyScanning/InProcessModuleCache.cpp
+++ b/clang/lib/DependencyScanning/InProcessModuleCache.cpp
@@ -132,7 +132,7 @@ public:
     return InMemory;
   }
 
-  llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>>
+  Expected<std::unique_ptr<llvm::MemoryBuffer>>
   read(StringRef FileName, off_t &Size, time_t &ModTime) override {
     // FIXME: This only needs to go to disk once per build, not in every
     // compilation. Introduce in-memory cache.

--- a/clang/lib/DependencyScanning/InProcessModuleCache.cpp
+++ b/clang/lib/DependencyScanning/InProcessModuleCache.cpp
@@ -131,6 +131,13 @@ public:
   const InMemoryModuleCache &getInMemoryModuleCache() const override {
     return InMemory;
   }
+
+  llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>>
+  read(StringRef FileName, off_t &Size, time_t &ModTime) override {
+    // FIXME: This only needs to go to disk once per build, not in every
+    // compilation. Introduce in-memory cache.
+    return readImpl(FileName, Size, ModTime);
+  }
 };
 } // namespace
 

--- a/clang/lib/DependencyScanning/InProcessModuleCache.cpp
+++ b/clang/lib/DependencyScanning/InProcessModuleCache.cpp
@@ -11,6 +11,8 @@
 #include "clang/Serialization/InMemoryModuleCache.h"
 #include "llvm/Support/AdvisoryLock.h"
 #include "llvm/Support/Chrono.h"
+#include "llvm/Support/Error.h"
+#include "llvm/Support/IOSandbox.h"
 
 using namespace clang;
 using namespace dependencies;
@@ -134,6 +136,9 @@ public:
 
   Expected<std::unique_ptr<llvm::MemoryBuffer>>
   read(StringRef FileName, off_t &Size, time_t &ModTime) override {
+    // This is a compiler-internal input/output, let's bypass the sandbox.
+    auto BypassSandbox = llvm::sys::sandbox::scopedDisable();
+
     // FIXME: This only needs to go to disk once per build, not in every
     // compilation. Introduce in-memory cache.
     return readImpl(FileName, Size, ModTime);

--- a/clang/lib/Serialization/ModuleCache.cpp
+++ b/clang/lib/Serialization/ModuleCache.cpp
@@ -101,22 +101,24 @@ void clang::maybePruneImpl(StringRef Path, time_t PruneInterval,
   }
 }
 
-llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>>
+Expected<std::unique_ptr<llvm::MemoryBuffer>>
 clang::readImpl(StringRef FileName, off_t &Size, time_t &ModTime) {
+  Expected<llvm::sys::fs::file_t> FD =
+      llvm::sys::fs::openNativeFileForRead(FileName);
+  if (!FD)
+    return FD.takeError();
   std::error_code EC;
-  llvm::sys::fs::file_t FD;
-  if ((EC = llvm::sys::fs::openFileForRead(FileName, FD)))
-    return EC;
   llvm::sys::fs::file_status Status;
-  if ((EC = llvm::sys::fs::status(FD, Status)))
-    return EC;
-  auto BufOrErr = llvm::MemoryBuffer::getOpenFile(
-      FD, FileName, Status.getSize(), /*RequiresNullTerminator=*/false);
-  if (!BufOrErr)
-    return BufOrErr.getError();
+  if ((EC = llvm::sys::fs::status(*FD, Status)))
+    return llvm::errorCodeToError(EC);
+  llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>> Buf =
+      llvm::MemoryBuffer::getOpenFile(*FD, FileName, Status.getSize(),
+                                      /*RequiresNullTerminator=*/false);
+  if (!Buf)
+    return llvm::errorCodeToError(Buf.getError());
   Size = Status.getSize();
   ModTime = llvm::sys::toTimeT(Status.getLastModificationTime());
-  return std::move(*BufOrErr);
+  return std::move(*Buf);
 }
 
 namespace {
@@ -180,7 +182,7 @@ public:
     return InMemory;
   }
 
-  llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>>
+  Expected<std::unique_ptr<llvm::MemoryBuffer>>
   read(StringRef FileName, off_t &Size, time_t &ModTime) override {
     // This is a compiler-internal input/output, let's bypass the sandbox.
     auto BypassSandbox = llvm::sys::sandbox::scopedDisable();

--- a/clang/lib/Serialization/ModuleCache.cpp
+++ b/clang/lib/Serialization/ModuleCache.cpp
@@ -101,6 +101,24 @@ void clang::maybePruneImpl(StringRef Path, time_t PruneInterval,
   }
 }
 
+llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>>
+clang::readImpl(StringRef FileName, off_t &Size, time_t &ModTime) {
+  std::error_code EC;
+  int FD;
+  if ((EC = llvm::sys::fs::openFileForRead(FileName, FD)))
+    return EC;
+  llvm::sys::fs::file_status Status;
+  if ((EC = llvm::sys::fs::status(FD, Status)))
+    return EC;
+  auto BufOrErr = llvm::MemoryBuffer::getOpenFile(
+      FD, FileName, Status.getSize(), /*RequiresNullTerminator=*/false);
+  if (!BufOrErr)
+    return BufOrErr.getError();
+  Size = Status.getSize();
+  ModTime = llvm::sys::toTimeT(Status.getLastModificationTime());
+  return std::move(*BufOrErr);
+}
+
 namespace {
 class CrossProcessModuleCache : public ModuleCache {
   InMemoryModuleCache InMemory;
@@ -160,6 +178,14 @@ public:
   InMemoryModuleCache &getInMemoryModuleCache() override { return InMemory; }
   const InMemoryModuleCache &getInMemoryModuleCache() const override {
     return InMemory;
+  }
+
+  llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>>
+  read(StringRef FileName, off_t &Size, time_t &ModTime) override {
+    // This is a compiler-internal input/output, let's bypass the sandbox.
+    auto BypassSandbox = llvm::sys::sandbox::scopedDisable();
+
+    return readImpl(FileName, Size, ModTime);
   }
 };
 } // namespace

--- a/clang/lib/Serialization/ModuleCache.cpp
+++ b/clang/lib/Serialization/ModuleCache.cpp
@@ -104,7 +104,7 @@ void clang::maybePruneImpl(StringRef Path, time_t PruneInterval,
 llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>>
 clang::readImpl(StringRef FileName, off_t &Size, time_t &ModTime) {
   std::error_code EC;
-  int FD;
+  llvm::sys::fs::file_t FD;
   if ((EC = llvm::sys::fs::openFileForRead(FileName, FD)))
     return EC;
   llvm::sys::fs::file_status Status;

--- a/clang/lib/Serialization/ModuleCache.cpp
+++ b/clang/lib/Serialization/ModuleCache.cpp
@@ -108,9 +108,8 @@ clang::readImpl(StringRef FileName, off_t &Size, time_t &ModTime) {
       llvm::sys::fs::openNativeFileForRead(FileName);
   if (!FD)
     return FD.takeError();
-  std::error_code EC;
   llvm::sys::fs::file_status Status;
-  if ((EC = llvm::sys::fs::status(*FD, Status)))
+  if (std::error_code EC = llvm::sys::fs::status(*FD, Status))
     return llvm::errorCodeToError(EC);
   llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>> Buf =
       llvm::MemoryBuffer::getOpenFile(*FD, FileName, Status.getSize(),

--- a/clang/lib/Serialization/ModuleCache.cpp
+++ b/clang/lib/Serialization/ModuleCache.cpp
@@ -10,6 +10,7 @@
 
 #include "clang/Serialization/InMemoryModuleCache.h"
 #include "clang/Serialization/ModuleFile.h"
+#include "llvm/Support/Error.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/IOSandbox.h"
 #include "llvm/Support/LockFileManager.h"

--- a/clang/lib/Serialization/ModuleManager.cpp
+++ b/clang/lib/Serialization/ModuleManager.cpp
@@ -188,33 +188,34 @@ ModuleManager::AddModuleResult ModuleManager::addModule(
     // import it earlier.
     return OutOfDate;
   } else {
-    OptionalFileEntryRef Entry =
-        expectedToOptional(FileName == StringRef("-")
-                               ? FileMgr.getSTDIN()
-                               : FileMgr.getFileRef(FileName, /*OpenFile=*/true,
-                                                    /*CacheFailure=*/false));
-    if (!Entry) {
-      ErrorStr = "module file not found";
-      return Missing;
-    }
+    llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>> Buf = nullptr;
+    if (FileName.getImplicitModuleSuffixLength()) {
+      Buf = ModCache.read(FileName, Size, ModTime);
+    } else {
+      OptionalFileEntryRef Entry = expectedToOptional(
+          FileName == StringRef("-")
+              ? FileMgr.getSTDIN()
+              : FileMgr.getFileRef(FileName, /*OpenFile=*/true,
+                                   /*CacheFailure=*/false));
+      if (!Entry) {
+        ErrorStr = "module file not found";
+        return Missing;
+      }
 
-    // Get a buffer of the file and close the file descriptor when done.
-    // The file is volatile because in a parallel build we expect multiple
-    // compiler processes to use the same module file rebuilding it if needed.
-    //
-    // RequiresNullTerminator is false because module files don't need it, and
-    // this allows the file to still be mmapped.
-    auto Buf = FileMgr.getBufferForFile(*Entry,
-                                        /*IsVolatile=*/true,
-                                        /*RequiresNullTerminator=*/false);
+      Size = Entry->getSize();
+      ModTime = Entry->getModificationTime();
+
+      // RequiresNullTerminator is false because module files don't need it, and
+      // this allows the file to still be mmapped.
+      Buf = FileMgr.getBufferForFile(*Entry, /*IsVolatile=*/false,
+                                     /*RequiresNullTerminator=*/false);
+    }
 
     if (!Buf) {
       ErrorStr = Buf.getError().message();
       return Missing;
     }
 
-    Size = Entry->getSize();
-    ModTime = Entry->getModificationTime();
     NewFileBuffer = std::move(*Buf);
     ModuleBuffer = NewFileBuffer.get();
   }

--- a/clang/lib/Serialization/ModuleManager.cpp
+++ b/clang/lib/Serialization/ModuleManager.cpp
@@ -188,31 +188,30 @@ ModuleManager::AddModuleResult ModuleManager::addModule(
     // import it earlier.
     return OutOfDate;
   } else {
-    llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>> Buf = nullptr;
-    if (FileName.getImplicitModuleSuffixLength()) {
-      Buf = ModCache.read(FileName, Size, ModTime);
-    } else {
-      OptionalFileEntryRef Entry = expectedToOptional(
+    auto Buf = [&]() -> Expected<std::unique_ptr<llvm::MemoryBuffer>> {
+      if (FileName.getImplicitModuleSuffixLength())
+        return ModCache.read(FileName, Size, ModTime);
+
+      Expected<FileEntryRef> Entry =
           FileName == StringRef("-")
               ? FileMgr.getSTDIN()
               : FileMgr.getFileRef(FileName, /*OpenFile=*/true,
-                                   /*CacheFailure=*/false));
-      if (!Entry) {
-        ErrorStr = "module file not found";
-        return Missing;
-      }
+                                   /*CacheFailure=*/false);
+      if (!Entry)
+        return Entry.takeError();
 
       Size = Entry->getSize();
       ModTime = Entry->getModificationTime();
 
       // RequiresNullTerminator is false because module files don't need it, and
       // this allows the file to still be mmapped.
-      Buf = FileMgr.getBufferForFile(*Entry, /*IsVolatile=*/false,
-                                     /*RequiresNullTerminator=*/false);
-    }
+      return llvm::errorOrToExpected(
+          FileMgr.getBufferForFile(*Entry, /*IsVolatile=*/false,
+                                   /*RequiresNullTerminator=*/false));
+    }();
 
     if (!Buf) {
-      ErrorStr = Buf.getError().message();
+      ErrorStr = llvm::toString(Buf.takeError());
       return Missing;
     }
 

--- a/clang/lib/Serialization/ModuleManager.cpp
+++ b/clang/lib/Serialization/ModuleManager.cpp
@@ -28,6 +28,7 @@
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/iterator.h"
 #include "llvm/Support/DOTGraphTraits.h"
+#include "llvm/Support/Error.h"
 #include "llvm/Support/ErrorOr.h"
 #include "llvm/Support/GraphWriter.h"
 #include "llvm/Support/MemoryBuffer.h"

--- a/clang/lib/Serialization/ModuleManager.cpp
+++ b/clang/lib/Serialization/ModuleManager.cpp
@@ -189,9 +189,12 @@ ModuleManager::AddModuleResult ModuleManager::addModule(
     return OutOfDate;
   } else {
     auto Buf = [&]() -> Expected<std::unique_ptr<llvm::MemoryBuffer>> {
+      // Implicit modules live in the module cache.
       if (FileName.getImplicitModuleSuffixLength())
         return ModCache.read(FileName, Size, ModTime);
 
+      // Explicit modules are treated as any other compiler input file, load
+      // them via FileManager.
       Expected<FileEntryRef> Entry =
           FileName == StringRef("-")
               ? FileMgr.getSTDIN()


### PR DESCRIPTION
This PR introduces new `ModuleCache` API for reading PCM files. This makes it so that we don't go through the `FileManager` and VFS, which is problematic downstream. We interpose a VFS that unintentionally shuffles implicitly-built modules in and out of the CAS database, leading to some unnecessary storage and runtime overhead. Moreover, this (together with a reading API) will enable adding a caching layer into the `InProcessModuleCache` implementation, hopefully reducing IO cost.