### PR TITLE
[ClangLinkerWrapper] Fix `-v` for newer CMake passing it directly

### DIFF
--- a/clang/tools/clang-linker-wrapper/ClangLinkerWrapper.cpp
+++ b/clang/tools/clang-linker-wrapper/ClangLinkerWrapper.cpp
@@ -1332,7 +1332,7 @@ int main(int Argc, char **Argv) {
         Args.hasArg(OPT_help_hidden), Args.hasArg(OPT_help_hidden));
     return EXIT_SUCCESS;
   }
-  if (Args.hasArg(OPT_v)) {
+  if (Args.hasArg(OPT_version)) {
     printVersion(outs());
     return EXIT_SUCCESS;
   }

--- a/clang/tools/clang-linker-wrapper/LinkerWrapperOpts.td
+++ b/clang/tools/clang-linker-wrapper/LinkerWrapperOpts.td
@@ -127,8 +127,7 @@ def library_EQ : Joined<["--", "-"], "library=">, Flags<[HelpHidden]>,
 def rpath : Separate<["--", "-"], "rpath">;
 def rpath_EQ : Joined<["--", "-"], "rpath=">, Flags<[HelpHidden]>, Alias<rpath>;
 
-def v : Flag<["--", "-"], "v">, HelpText<"Display the version number and exit">;
-def version : Flag<["--", "-"], "version">, Flags<[HelpHidden]>, Alias<v>;
+def version : Flag<["--", "-"], "version">, Flags<[HelpHidden]>;
 
 def whole_archive : Flag<["--", "-"], "whole-archive">, Flags<[HelpHidden]>;
 def no_whole_archive : Flag<["--", "-"], "no-whole-archive">, Flags<[HelpHidden]>;


### PR DESCRIPTION
Summary:
Normally `-v` is version for tools, but it's also verbose for the
linker. CMake tries to identify the linker by passing `-Wl,-v` which
goes to the linker wrapper instead. Make this only print version on
`--version` and forward the other one to the linker so it appears
transparent to the host ABI. A bit of a hack, but it should work.
