### PR TITLE
[lldb-dap] Correct attaching by program basename.

### DIFF
--- a/lldb/test/API/tools/lldb-dap/attach/TestDAP_attach.py
+++ b/lldb/test/API/tools/lldb-dap/attach/TestDAP_attach.py
@@ -6,6 +6,7 @@ from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 import lldbdap_testcase
+import os
 import subprocess
 import threading
 import time
@@ -90,6 +91,30 @@ class TestDAP_attach(lldbdap_testcase.DAPTestCaseBase):
         self.spawn_thread.start()
         try:
             self.attach(program=program, waitFor=True)
+            self.continue_and_verify_pid()
+        finally:
+            self.spawn_event.set()
+            if self.spawn_thread.is_alive():
+                self.spawn_thread.join(timeout=10)
+
+    @expectedFailureWindows
+    def test_by_partial_name_waitFor(self):
+        """
+        Tests waiting for and attaching to a process by partial process name
+        that doesn't exist yet.
+        """
+        program = self.build_and_create_debug_adapter_for_attach()
+        self.spawn_event = threading.Event()
+        self.spawn_thread = threading.Thread(
+            target=self.spawn_and_wait,
+            args=(
+                program,
+                1.0,
+            ),
+        )
+        self.spawn_thread.start()
+        try:
+            self.attach(program=os.path.basename(program), waitFor=True)
             self.continue_and_verify_pid()
         finally:
             self.spawn_event.set()

--- a/lldb/tools/lldb-dap/Handler/AttachRequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/AttachRequestHandler.cpp
@@ -16,6 +16,7 @@
 #include "lldb/lldb-defines.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/FileSystem.h"
+#include "llvm/Support/Path.h"
 
 using namespace llvm;
 using namespace lldb_dap::protocol;
@@ -71,8 +72,10 @@ Error AttachRequestHandler::Run(const AttachRequestArguments &args) const {
     target = dap.CreateTarget(error);
   }
 
-  if (error.Fail())
-    return ToError(error);
+  // Fallback to the 'dummy' target if we failed to create a real target, so we
+  // can try to attach.
+  if (!target.IsValid())
+    target = dap.debugger.GetDummyTarget();
 
   dap.SetTarget(target);
 
@@ -82,11 +85,12 @@ Error AttachRequestHandler::Run(const AttachRequestArguments &args) const {
 
   if ((args.pid == LLDB_INVALID_PROCESS_ID ||
        args.gdbRemotePort == LLDB_DAP_INVALID_PORT) &&
-      args.waitFor)
-    dap.SendOutput(OutputType::Console,
-                   llvm::formatv("Waiting to attach to \"{0}\"...\n",
-                                 dap.target.GetExecutable().GetFilename())
-                       .str());
+      args.waitFor && !args.configuration.program.empty())
+    dap.SendOutput(
+        OutputType::Console,
+        llvm::formatv("Waiting to attach to \"{0}\"...\n",
+                      llvm::sys::path::filename(dap.configuration.program))
+            .str());
 
   {
     // Perform the launch in synchronous mode so that we don't have to worry
@@ -127,7 +131,11 @@ Error AttachRequestHandler::Run(const AttachRequestArguments &args) const {
       else if (!dap.configuration.program.empty())
         attach_info.SetExecutable(dap.configuration.program.data());
       attach_info.SetWaitForLaunch(args.waitFor, /*async=*/false);
-      dap.target.Attach(attach_info, error);
+      auto process = dap.target.Attach(attach_info, error);
+      // If we attached by name then we were using the 'Dummy' target, ensure
+      // we update to the real target.
+      if (process.IsValid())
+        dap.SetTarget(process.GetTarget());
     }
 
     if (error.Fail())


### PR DESCRIPTION
Fixes an issue where attaching by program would fail if the program name was a partial name (e.g. "foobar" instead of "/path/to/foobar").

We failed to create the target which caused the attach to fail. Now we fallback to the dummy target and update to the real target after the attach completes.

Here is an example launch configuration that fail:

```
{
  "type": "lldb-dap",
  "name": "Attach (wait)",
  "request": "attach",
  "program": "foobar",
  "waitFor": true
},
```