### PR TITLE
[TestingTools] Add new llvm-testing-tools package

### DIFF
--- a/llvm/utils/llvm-testing-tools/README.md
+++ b/llvm/utils/llvm-testing-tools/README.md
@@ -1,0 +1,6 @@
+# LLVM Testing Utilities
+
+This folder contains the setup for the `llvm-testing-utilities` python package.
+This package provides some utilities like `FileCheck` and `split-file` through
+PyPI with the aim being to support testing requirements for runtimes builds
+without them needing to utilize a bootstrapping build.

--- a/llvm/utils/llvm-testing-tools/pyproject.toml
+++ b/llvm/utils/llvm-testing-tools/pyproject.toml
@@ -1,0 +1,21 @@
+[build-system]
+requires = ["setuptools>=61.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "llvm_testing_tools"
+description = "LLVM Testing Tools"
+readme = "README.md"
+requires-python = ">=3.8"
+version = "23.0.0"
+license = "Apache-2.0 WITH LLVM-exception"
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.setuptools.package-data]
+llvm_testing_tools = ["binaries/*"]
+
+[project.scripts]
+split-file = "llvm_testing_tools.wrapper:run_test_tool"
+FileCheck = "llvm_testing_tools.wrapper:run_test_tool"

--- a/llvm/utils/llvm-testing-tools/src/llvm_testing_tools/wrapper.py
+++ b/llvm/utils/llvm-testing-tools/src/llvm_testing_tools/wrapper.py
@@ -1,0 +1,16 @@
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+"""Wraps the binaries contained in the package."""
+
+import importlib.resources
+import os
+import subprocess
+import sys
+
+
+def run_test_tool():
+    base_path = importlib.resources.files("llvm_testing_tools").joinpath("binaries")
+    binary_path = os.path.join(str(base_path), os.path.basename(sys.argv[0]))
+    result = subprocess.run([binary_path] + sys.argv[1:], stdin=sys.stdin)
+    sys.exit(result.returncode)


### PR DESCRIPTION
This allows for packaging split-file and FileCheck for distribution on
PyPI which will support libc++ wanting to use FileCheck/split-file for
more thorough testing.
