### PR TITLE
TargetLibraryInfo: Disable roundeven variants by default except for GLIBC

### DIFF
--- a/llvm/lib/Analysis/TargetLibraryInfo.cpp
+++ b/llvm/lib/Analysis/TargetLibraryInfo.cpp
@@ -142,6 +142,12 @@ static void initializeLibCalls(TargetLibraryInfoImpl &TLI, const Triple &T,
   TLI.setUnavailable(LibFunc_fputs_unlocked);
   TLI.setUnavailable(LibFunc_fgets_unlocked);
 
+  // Set roundeven variants as unavailable
+  // Set them as available per system below
+  TLI.setUnavailable(LibFunc_roundeven);
+  TLI.setUnavailable(LibFunc_roundevenf);
+  TLI.setUnavailable(LibFunc_roundevenl);
+
   // There is really no runtime library on AMDGPU.
   if (T.isAMDGPU()) {
     TLI.disableAllFunctions();
@@ -674,6 +680,12 @@ static void initializeLibCalls(TargetLibraryInfoImpl &TLI, const Triple &T,
     TLI.setUnavailable(LibFunc_sqrtl_finite);
   }
 
+  if (T.isOSLinux() && T.isGNUEnvironment()) {
+    TLI.setAvailable(LibFunc_roundeven);
+    TLI.setAvailable(LibFunc_roundevenf);
+    TLI.setAvailable(LibFunc_roundevenl);
+  }
+
   if ((T.isOSLinux() && T.isGNUEnvironment()) ||
       (T.isAndroid() && !T.isAndroidVersionLT(28))) {
     // available IO unlocked variants on GNU/Linux and Android P or later
@@ -805,9 +817,6 @@ static void initializeLibCalls(TargetLibraryInfoImpl &TLI, const Triple &T,
     TLI.setUnavailable(LibFunc_ntohs);
     TLI.setUnavailable(LibFunc_reallocarray);
     TLI.setUnavailable(LibFunc_reallocf);
-    TLI.setUnavailable(LibFunc_roundeven);
-    TLI.setUnavailable(LibFunc_roundevenf);
-    TLI.setUnavailable(LibFunc_roundevenl);
     TLI.setUnavailable(LibFunc_stpcpy);
     TLI.setUnavailable(LibFunc_stpncpy);
     TLI.setUnavailable(LibFunc_strlcat);
@@ -838,9 +847,6 @@ static void initializeLibCalls(TargetLibraryInfoImpl &TLI, const Triple &T,
     TLI.setUnavailable(LibFunc_fminimum_num);
     TLI.setUnavailable(LibFunc_fminimum_numf);
     TLI.setUnavailable(LibFunc_fminimum_numl);
-    TLI.setUnavailable(LibFunc_roundeven);
-    TLI.setUnavailable(LibFunc_roundevenf);
-    TLI.setUnavailable(LibFunc_roundevenl);
   }
 
   // As currently implemented in clang, NVPTX code has no standard library to

--- a/llvm/test/Transforms/InferFunctionAttrs/annotate.ll
+++ b/llvm/test/Transforms/InferFunctionAttrs/annotate.ll
@@ -936,13 +936,13 @@ declare float @roundf(float)
 ; CHECK: declare x86_fp80 @roundl(x86_fp80) [[MEMNONE_NOFREE_NOUNWIND_WILLRETURN]]
 declare x86_fp80 @roundl(x86_fp80)
 
-; CHECK: declare double @roundeven(double) [[MEMNONE_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK-LINUX: declare double @roundeven(double) [[MEMNONE_NOFREE_NOUNWIND_WILLRETURN]]
 declare double @roundeven(double)
 
-; CHECK: declare float @roundevenf(float) [[MEMNONE_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK-LINUX: declare float @roundevenf(float) [[MEMNONE_NOFREE_NOUNWIND_WILLRETURN]]
 declare float @roundevenf(float)
 
-; CHECK: declare x86_fp80 @roundevenl(x86_fp80) [[MEMNONE_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK-LINUX: declare x86_fp80 @roundevenl(x86_fp80) [[MEMNONE_NOFREE_NOUNWIND_WILLRETURN]]
 declare x86_fp80 @roundevenl(x86_fp80)
 
 ; CHECK: declare double @scalbln(double, i64) [[ERRNOMEMONLY_NOFREE_NOUNWIND_WILLRETURN]]


### PR DESCRIPTION
roundeven functions are quite new only being added C23. None of the
other major libc's be it from Musl, Bionic, *BSD's libc, Solaris
have these functions.