### PR TITLE
[Clang] [Sema] Don't diagnose multidimensional subscript operators on dependent types

### DIFF
--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -5173,7 +5173,8 @@ ExprResult Sema::ActOnArraySubscriptExpr(Scope *S, Expr *base,
   // Issue a better diagnostic if we tried to pass multiple arguments to
   // a builtin subscript operator rather than diagnosing this as a generic
   // overload resolution failure.
-  if (ArgExprs.size() != 1 && !base->getType()->isRecordType() &&
+  if (ArgExprs.size() != 1 && !base->getType()->isDependentType() &&
+      !base->getType()->isRecordType() &&
       !base->getType()->isObjCObjectPointerType()) {
     Diag(base->getExprLoc(), diag::err_ovl_builtin_subscript_expects_single_arg)
         << base->getType() << base->getSourceRange();

--- a/clang/test/SemaCXX/cxx23-builtin-subscript.cpp
+++ b/clang/test/SemaCXX/cxx23-builtin-subscript.cpp
@@ -62,3 +62,6 @@ void f() {
   p.three[1, 2][3] = 4; // expected-error {{property subscript expects exactly one argument}}
   p.three[1][2, 3] = 4; // expected-error {{property subscript expects exactly one argument}}
 }
+
+template<class T>
+void dependent(T x) { x[0, 0]; }


### PR DESCRIPTION
I forgot to check for dependent types in #187828; we somehow didn’t have tests for this so CI didn’t catch this...