### PR TITLE
[clang] Fix AArch64 -ffixed-x help text

### DIFF
--- a/clang/include/clang/Options/Options.td
+++ b/clang/include/clang/Options/Options.td
@@ -5457,9 +5457,13 @@ def mno_bti_at_return_twice : Flag<["-"], "mno-bti-at-return-twice">,
   HelpText<"Do not add a BTI instruction after a setjmp or other"
            " return-twice construct (Arm/AArch64 only)">;
 
-foreach i = {1-31} in
+foreach i = {1-7,9-15,18,20-28} in
   def ffixed_x#i : Flag<["-"], "ffixed-x"#i>, Group<m_Group>,
     HelpText<"Reserve the x"#i#" register (AArch64/RISC-V only)">;
+
+foreach i = {8,16,17,19,29-31} in
+  def ffixed_x#i : Flag<["-"], "ffixed-x"#i>, Group<m_Group>,
+    HelpText<"Reserve the x"#i#" register (RISC-V only)">;
 
 def mlr_for_calls_only : Flag<["-"], "mlr-for-calls-only">, Group<m_aarch64_Features_Group>,
   HelpText<"Do not allocate the LR register for general purpose usage, only for calls. (AArch64 only)">;

--- a/clang/test/Driver/aarch64-fixed-x-register.c
+++ b/clang/test/Driver/aarch64-fixed-x-register.c
@@ -58,9 +58,21 @@
 // RUN: FileCheck --check-prefix=CHECK-FIXED-X15 < %t %s
 // CHECK-FIXED-X15: "-target-feature" "+reserve-x15"
 
+// RUN: not %clang --target=aarch64-none-gnu -ffixed-x16 -### %s 2>&1 | FileCheck --check-prefix=CHECK-NO-FIXED-X16 %s
+// CHECK-NO-FIXED-X16: error: unsupported option '-ffixed-x16' for target 'aarch64-none-gnu'
+// CHECK-NO-FIXED-X16-NOT: "+reserve-x16"
+
+// RUN: not %clang --target=aarch64-none-gnu -ffixed-x17 -### %s 2>&1 | FileCheck --check-prefix=CHECK-NO-FIXED-X17 %s
+// CHECK-NO-FIXED-X17: error: unsupported option '-ffixed-x17' for target 'aarch64-none-gnu'
+// CHECK-NO-FIXED-X17-NOT: "+reserve-x17"
+
 // RUN: %clang --target=aarch64-none-gnu -ffixed-x18 -### %s 2> %t
 // RUN: FileCheck --check-prefix=CHECK-FIXED-X18 < %t %s
 // CHECK-FIXED-X18: "-target-feature" "+reserve-x18"
+
+// RUN: not %clang --target=aarch64-none-gnu -ffixed-x19 -### %s 2>&1 | FileCheck --check-prefix=CHECK-NO-FIXED-X19 %s
+// CHECK-NO-FIXED-X19: error: unsupported option '-ffixed-x19' for target 'aarch64-none-gnu'
+// CHECK-NO-FIXED-X19-NOT: "+reserve-x19"
 
 // RUN: %clang --target=aarch64-none-gnu -ffixed-x20 -### %s 2> %t
 // RUN: FileCheck --check-prefix=CHECK-FIXED-X20 < %t %s
@@ -97,6 +109,18 @@
 // RUN: %clang --target=aarch64-none-gnu -ffixed-x28 -### %s 2> %t
 // RUN: FileCheck --check-prefix=CHECK-FIXED-X28 < %t %s
 // CHECK-FIXED-X28: "-target-feature" "+reserve-x28"
+
+// RUN: not %clang --target=aarch64-none-gnu -ffixed-x29 -### %s 2>&1 | FileCheck --check-prefix=CHECK-NO-FIXED-X29 %s
+// CHECK-NO-FIXED-X29: error: unsupported option '-ffixed-x29' for target 'aarch64-none-gnu'
+// CHECK-NO-FIXED-X29-NOT: "+reserve-x29"
+
+// RUN: not %clang --target=aarch64-none-gnu -ffixed-x30 -### %s 2>&1 | FileCheck --check-prefix=CHECK-NO-FIXED-X30 %s
+// CHECK-NO-FIXED-X30: error: unsupported option '-ffixed-x30' for target 'aarch64-none-gnu'
+// CHECK-NO-FIXED-X30-NOT: "+reserve-x30"
+
+// RUN: not %clang --target=aarch64-none-gnu -ffixed-x31 -### %s 2>&1 | FileCheck --check-prefix=CHECK-NO-FIXED-X31 %s
+// CHECK-NO-FIXED-X31: error: unsupported option '-ffixed-x31' for target 'aarch64-none-gnu'
+// CHECK-NO-FIXED-X31-NOT: "+reserve-x31"
 
 // Test multiple of reserve-x# options together.
 // RUN: %clang --target=aarch64-none-gnu \

--- a/clang/test/Driver/aarch64-fixed-x-register.c
+++ b/clang/test/Driver/aarch64-fixed-x-register.c
@@ -26,6 +26,10 @@
 // RUN: FileCheck --check-prefix=CHECK-FIXED-X7 < %t %s
 // CHECK-FIXED-X7: "-target-feature" "+reserve-x7"
 
+// RUN: not %clang --target=aarch64-none-gnu -ffixed-x8 -### %s 2>&1 | FileCheck --check-prefix=CHECK-NO-FIXED-X8 %s
+// CHECK-NO-FIXED-X8: error: unsupported option '-ffixed-x8' for target 'aarch64-none-gnu'
+// CHECK-NO-FIXED-X8-NOT: "+reserve-x8"
+
 // RUN: %clang --target=aarch64-none-gnu -ffixed-x9 -### %s 2> %t
 // RUN: FileCheck --check-prefix=CHECK-FIXED-X9 < %t %s
 // CHECK-FIXED-X9: "-target-feature" "+reserve-x9"


### PR DESCRIPTION
Fix the documented support set for AArch64 `-ffixed-xN` options to match the current implementation.

This updates the generated option help text so that only the registers actually supported by AArch64 are listed as `AArch64/RISC-V only`, and marks `x8`, `x16`, `x17`, `x19`, and `x29`-`x31` as `RISC-V only`.

It also adds a driver test to cover the representative unsupported AArch64 case for `-ffixed-x8`.

Fixes #186620.

Tests: `build-cir/bin/llvm-lit -sv clang/test/Driver/aarch64-fixed-x-register.c`