### PR TITLE
AMDGPU: Make VarIndex WeakTrackingVH in AMDGPUPromoteAlloca

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUPromoteAlloca.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUPromoteAlloca.cpp
@@ -90,7 +90,7 @@ static cl::opt<unsigned>
 // VarIndex is A, VarMul is stride, VarShift is shift and ConstIndex is B. All
 // parts are optional.
 struct GEPToVectorIndex {
-  WeakVH VarIndex = nullptr;         // defaults to 0
+  WeakTrackingVH VarIndex = nullptr; // defaults to 0
   ConstantInt *VarMul = nullptr;     // defaults to 1
   ConstantInt *VarShift = nullptr;   // defaults to 0
   ConstantInt *ConstIndex = nullptr; // defaults to 0

--- a/llvm/test/CodeGen/AMDGPU/promote-alloca-proper-value-replacement.ll
+++ b/llvm/test/CodeGen/AMDGPU/promote-alloca-proper-value-replacement.ll
@@ -6,17 +6,17 @@ define void @alloca_value_cross_reference() {
 ; CHECK-NEXT:  [[_ENTRY:.*:]]
 ; CHECK-NEXT:    [[HIT_ORDERED:%.*]] = freeze <4 x float> poison
 ; CHECK-NEXT:    [[HIT_INDEX:%.*]] = freeze <4 x i32> poison
-; CHECK-NEXT:    [[TMP0:%.*]] = insertelement <4 x i32> [[HIT_INDEX]], i32 0, i32 0
+; CHECK-NEXT:    [[TMP0:%.*]] = insertelement <4 x i32> [[HIT_INDEX]], i32 1, i32 0
 ; CHECK-NEXT:    br [[DOTLR_PH5:label %.*]]
 ; CHECK:       [[_LR_PH5:.*:]]
 ; CHECK-NEXT:    [[TMP1:%.*]] = extractelement <4 x i32> [[TMP0]], i32 0
-; CHECK-NEXT:    [[TMP2:%.*]] = insertelement <4 x float> [[HIT_ORDERED]], float 0.000000e+00, i32 0
+; CHECK-NEXT:    [[TMP2:%.*]] = insertelement <4 x float> [[HIT_ORDERED]], float 0.000000e+00, i32 [[TMP1]]
 ; CHECK-NEXT:    ret void
 ;
 .entry:
   %hit_ordered = alloca [4 x float], align 4, addrspace(5)
   %hit_index = alloca [4 x i32], align 4, addrspace(5)
-  store i32 0, ptr addrspace(5) %hit_index, align 4
+  store i32 1, ptr addrspace(5) %hit_index, align 4
   br label %.lr.ph5
 
   ; The separate block is needed to avoid constant-folding on


### PR DESCRIPTION
The test used to look all good, but actually not. The WeakVH just make itself null after the pointed value being replaced. So a zero value was used because VarIndex become null. The test checks looks all good.

Actually only the WeakTrackingVH have the ability to be updated to new value.

Change the test slightly to make that using zero index is wrong.