### PR TITLE
[DA] Remove redundant check in the Weak Zero SIV tests (NFCI)

### DIFF
--- a/llvm/lib/Analysis/DependenceAnalysis.cpp
+++ b/llvm/lib/Analysis/DependenceAnalysis.cpp
@@ -1783,14 +1783,6 @@ bool DependenceInfo::weakZeroSIVtestImpl(const SCEVAddRecExpr *AR,
   const SCEV *ARCoeff = AR->getStepRecurrence(*SE);
   const SCEV *ARConst = AR->getStart();
 
-  ConstantRange ARRange = SE->getSignedRange(AR);
-  ConstantRange ConstRange = SE->getSignedRange(Const);
-  if (ARRange.intersectWith(ConstRange).isEmptySet()) {
-    ++WeakZeroSIVindependence;
-    ++WeakZeroSIVsuccesses;
-    return true;
-  }
-
   if (!AR->hasNoSignedWrap())
     return false;
 


### PR DESCRIPTION
The trivial disjoint checks in several dependence tests were consolidated into a single invocation in #187435. However, the duplicated check still remains in the Weak Crossing SIV tests. This is redundant and should be deleted as well.