### PR TITLE
[PDB] Refactor cache strategy for function symbol lookups

### DIFF
--- a/llvm/include/llvm/DebugInfo/PDB/Native/NativeSession.h
+++ b/llvm/include/llvm/DebugInfo/PDB/Native/NativeSession.h
@@ -120,6 +120,10 @@ public:
                                 uint16_t &ModuleIndex) const;
   Expected<ModuleDebugStreamRef> getModuleDebugStream(uint32_t Index) const;
 
+#ifndef NDEBUG
+  const auto &getAddrToModuleIndex() const { return AddrToModuleIndex; }
+#endif
+
 private:
   void initializeExeSymbol();
   void parseSectionContribs();

--- a/llvm/include/llvm/DebugInfo/PDB/Native/NativeSession.h
+++ b/llvm/include/llvm/DebugInfo/PDB/Native/NativeSession.h
@@ -121,7 +121,7 @@ public:
   Expected<ModuleDebugStreamRef> getModuleDebugStream(uint32_t Index) const;
 
 #ifndef NDEBUG
-  const auto &getAddrToModuleIndex() const { return AddrToModuleIndex; }
+  void checkSymbolRange(uint64_t Start, uint64_t Stop) const;
 #endif
 
 private:

--- a/llvm/include/llvm/DebugInfo/PDB/Native/SymbolCache.h
+++ b/llvm/include/llvm/DebugInfo/PDB/Native/SymbolCache.h
@@ -10,6 +10,7 @@
 #define LLVM_DEBUGINFO_PDB_NATIVE_SYMBOLCACHE_H
 
 #include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/IntervalMap.h"
 #include "llvm/DebugInfo/CodeView/CVRecord.h"
 #include "llvm/DebugInfo/CodeView/CodeView.h"
 #include "llvm/DebugInfo/CodeView/Line.h"
@@ -69,8 +70,13 @@ class SymbolCache {
   /// Map from global symbol offset to SymIndexId.
   mutable DenseMap<uint32_t, SymIndexId> GlobalOffsetToSymbolId;
 
-  /// Map from segment and code offset to function symbols.
-  mutable DenseMap<std::pair<uint32_t, uint32_t>, SymIndexId> AddressToSymbolId;
+  /// Map from virtual address range to function symbols.
+  using IMapTy =
+      IntervalMap<uint64_t, SymIndexId, 8, IntervalMapHalfOpenInfo<uint64_t>>;
+  IMapTy::Allocator IMapAllocator;
+  mutable IMapTy AddressToSymbolId;
+  DenseSet<uint16_t> FuncSymCachedModIndexes;
+
   /// Map from segment and code offset to public symbols.
   mutable DenseMap<std::pair<uint32_t, uint32_t>, SymIndexId>
       AddressToPublicSymId;
@@ -116,8 +122,7 @@ class SymbolCache {
   SymIndexId createSimpleType(codeview::TypeIndex TI,
                               codeview::ModifierOptions Mods) const;
 
-  std::unique_ptr<PDBSymbol> findFunctionSymbolBySectOffset(uint32_t Sect,
-                                                            uint32_t Offset);
+  std::unique_ptr<PDBSymbol> findFunctionSymbolByVA(uint64_t VA);
   std::unique_ptr<PDBSymbol> findPublicSymbolBySectOffset(uint32_t Sect,
                                                           uint32_t Offset);
 
@@ -175,8 +180,8 @@ public:
                                               uint16_t Modi,
                                               uint32_t RecordOffset) const;
 
-  LLVM_ABI std::unique_ptr<PDBSymbol>
-  findSymbolBySectOffset(uint32_t Sect, uint32_t Offset, PDB_SymType Type);
+  LLVM_ABI std::unique_ptr<PDBSymbol> findSymbolByVA(uint64_t VA,
+                                                     PDB_SymType Type);
 
   LLVM_ABI std::unique_ptr<IPDBEnumLineNumbers>
   findLineNumbersByVA(uint64_t VA, uint32_t Length) const;

--- a/llvm/lib/DebugInfo/PDB/Native/NativeSession.cpp
+++ b/llvm/lib/DebugInfo/PDB/Native/NativeSession.cpp
@@ -255,27 +255,21 @@ bool NativeSession::addressForRVA(uint32_t RVA, uint32_t &Section,
 
 std::unique_ptr<PDBSymbol>
 NativeSession::findSymbolByAddress(uint64_t Address, PDB_SymType Type) {
-  uint32_t Section;
-  uint32_t Offset;
-  addressForVA(Address, Section, Offset);
-  return findSymbolBySectOffset(Section, Offset, Type);
+  if (AddrToModuleIndex.empty())
+    parseSectionContribs();
+
+  return Cache.findSymbolByVA(Address, Type);
 }
 
 std::unique_ptr<PDBSymbol> NativeSession::findSymbolByRVA(uint32_t RVA,
                                                           PDB_SymType Type) {
-  uint32_t Section;
-  uint32_t Offset;
-  addressForRVA(RVA, Section, Offset);
-  return findSymbolBySectOffset(Section, Offset, Type);
+  return findSymbolByAddress(getLoadAddress() + RVA, Type);
 }
 
 std::unique_ptr<PDBSymbol>
 NativeSession::findSymbolBySectOffset(uint32_t Sect, uint32_t Offset,
                                       PDB_SymType Type) {
-  if (AddrToModuleIndex.empty())
-    parseSectionContribs();
-
-  return Cache.findSymbolBySectOffset(Sect, Offset, Type);
+  return findSymbolByAddress(getVAFromSectOffset(Sect, Offset), Type);
 }
 
 std::unique_ptr<IPDBEnumLineNumbers>

--- a/llvm/lib/DebugInfo/PDB/Native/NativeSession.cpp
+++ b/llvm/lib/DebugInfo/PDB/Native/NativeSession.cpp
@@ -416,6 +416,16 @@ bool NativeSession::moduleIndexForSectOffset(uint32_t Sect, uint32_t Offset,
   return moduleIndexForVA(getVAFromSectOffset(Sect, Offset), ModuleIndex);
 }
 
+#ifndef NDEBUG
+void NativeSession::checkSymbolRange(uint64_t Start, uint64_t Stop) const {
+  auto Iter = AddrToModuleIndex.find(Start);
+  assert(Iter.valid() &&
+         !IMap::KeyTraits::startLess(Start, Iter.start()) &&
+         !IMap::KeyTraits::stopLess(Iter.stop(), Stop - 1) &&
+         "Symbol range is not within a single contiguous module range");
+}
+#endif
+
 void NativeSession::parseSectionContribs() {
   auto Dbi = Pdb->getPDBDbiStream();
   if (!Dbi)

--- a/llvm/lib/DebugInfo/PDB/Native/NativeSession.cpp
+++ b/llvm/lib/DebugInfo/PDB/Native/NativeSession.cpp
@@ -419,8 +419,7 @@ bool NativeSession::moduleIndexForSectOffset(uint32_t Sect, uint32_t Offset,
 #ifndef NDEBUG
 void NativeSession::checkSymbolRange(uint64_t Start, uint64_t Stop) const {
   auto Iter = AddrToModuleIndex.find(Start);
-  assert(Iter.valid() &&
-         !IMap::KeyTraits::startLess(Start, Iter.start()) &&
+  assert(Iter.valid() && !IMap::KeyTraits::startLess(Start, Iter.start()) &&
          !IMap::KeyTraits::stopLess(Iter.stop(), Stop - 1) &&
          "Symbol range is not within a single contiguous module range");
 }

--- a/llvm/lib/DebugInfo/PDB/Native/SymbolCache.cpp
+++ b/llvm/lib/DebugInfo/PDB/Native/SymbolCache.cpp
@@ -76,7 +76,7 @@ static const struct BuiltinTypeEntry {
 };
 
 SymbolCache::SymbolCache(NativeSession &Session, DbiStream *Dbi)
-    : Session(Session), Dbi(Dbi) {
+    : Session(Session), Dbi(Dbi), AddressToSymbolId(IMapAllocator) {
   // Id 0 is reserved for the invalid symbol.
   Cache.push_back(nullptr);
   SourceFiles.push_back(nullptr);
@@ -310,24 +310,26 @@ SymIndexId SymbolCache::getOrCreateInlineSymbol(InlineSiteSym Sym,
   return Id;
 }
 
-std::unique_ptr<PDBSymbol>
-SymbolCache::findSymbolBySectOffset(uint32_t Sect, uint32_t Offset,
-                                    PDB_SymType Type) {
+std::unique_ptr<PDBSymbol> SymbolCache::findSymbolByVA(uint64_t VA,
+                                                       PDB_SymType Type) {
   switch (Type) {
   case PDB_SymType::Function:
-    return findFunctionSymbolBySectOffset(Sect, Offset);
-  case PDB_SymType::PublicSymbol:
+    return findFunctionSymbolByVA(VA);
+  case PDB_SymType::PublicSymbol: {
+    uint32_t Sect, Offset;
+    Session.addressForVA(VA, Sect, Offset);
     return findPublicSymbolBySectOffset(Sect, Offset);
+  }
   case PDB_SymType::Compiland: {
     uint16_t Modi;
-    if (!Session.moduleIndexForSectOffset(Sect, Offset, Modi))
+    if (!Session.moduleIndexForVA(VA, Modi))
       return nullptr;
     return getOrCreateCompiland(Modi);
   }
   case PDB_SymType::None: {
     // FIXME: Implement for PDB_SymType::Data. The symbolizer calls this but
     // only uses it to find the symbol length.
-    if (auto Sym = findFunctionSymbolBySectOffset(Sect, Offset))
+    if (auto Sym = findFunctionSymbolByVA(VA))
       return Sym;
     return nullptr;
   }
@@ -336,17 +338,26 @@ SymbolCache::findSymbolBySectOffset(uint32_t Sect, uint32_t Offset,
   }
 }
 
-std::unique_ptr<PDBSymbol>
-SymbolCache::findFunctionSymbolBySectOffset(uint32_t Sect, uint32_t Offset) {
-  auto Iter = AddressToSymbolId.find({Sect, Offset});
-  if (Iter != AddressToSymbolId.end())
-    return getSymbolById(Iter->second);
-
+std::unique_ptr<PDBSymbol> SymbolCache::findFunctionSymbolByVA(uint64_t VA) {
   if (!Dbi)
     return nullptr;
 
+  auto findIdInCache = [this](uint64_t VA) -> SymIndexId {
+    auto Iter = AddressToSymbolId.find(VA);
+    if (Iter.valid() && !IMapTy::KeyTraits::startLess(VA, Iter.start()))
+      return *Iter;
+    return 0;
+  };
+
+  if (SymIndexId Id = findIdInCache(VA))
+    return getSymbolById(Id);
+
   uint16_t Modi;
-  if (!Session.moduleIndexForSectOffset(Sect, Offset, Modi))
+  if (!Session.moduleIndexForVA(VA, Modi))
+    return nullptr;
+
+  // Module has already been decoded and no cached symbols found.
+  if (!FuncSymCachedModIndexes.insert(Modi).second)
     return nullptr;
 
   Expected<ModuleDebugStreamRef> ExpectedModS =
@@ -355,29 +366,67 @@ SymbolCache::findFunctionSymbolBySectOffset(uint32_t Sect, uint32_t Offset) {
     consumeError(ExpectedModS.takeError());
     return nullptr;
   }
-  CVSymbolArray Syms = ExpectedModS->getSymbolArray();
 
-  // Search for the symbol in this module.
+  // Return empty intervals in AddressToSymbolId from Start to Stop.
+  auto getInsertRanges = [this](uint64_t Start, uint64_t Stop) {
+    SmallVector<std::pair<uint64_t, uint64_t>> Ranges;
+    auto Iter = AddressToSymbolId.find(Start);
+    while (Iter.valid() && IMapTy::KeyTraits::nonEmpty(Start, Stop)) {
+      if (IMapTy::KeyTraits::startLess(Start, Iter.start()))
+        Ranges.push_back({Start, std::min(Iter.start(), Stop)});
+
+      // Same result as Start = std::min(Stop, Iter.stop()).
+      Start = Iter.stop();
+      ++Iter;
+    }
+    if (IMapTy::KeyTraits::nonEmpty(Start, Stop))
+      Ranges.push_back({Start, Stop});
+
+    return Ranges;
+  };
+
+  // Decode symbols in this module.
+  CVSymbolArray Syms = ExpectedModS->getSymbolArray();
   for (auto I = Syms.begin(), E = Syms.end(); I != E; ++I) {
     if (I->kind() != S_LPROC32 && I->kind() != S_GPROC32)
       continue;
-    auto PS = cantFail(SymbolDeserializer::deserializeAs<ProcSym>(*I));
-    if (Sect == PS.Segment && Offset >= PS.CodeOffset &&
-        Offset < PS.CodeOffset + PS.CodeSize) {
-      // Check if the symbol is already cached.
-      auto Found = AddressToSymbolId.find({PS.Segment, PS.CodeOffset});
-      if (Found != AddressToSymbolId.end())
-        return getSymbolById(Found->second);
 
-      // Otherwise, create a new symbol.
+    auto PS = cantFail(SymbolDeserializer::deserializeAs<ProcSym>(*I));
+    uint64_t SymStart = Session.getVAFromSectOffset(PS.Segment, PS.CodeOffset);
+    uint64_t SymStop = SymStart + PS.CodeSize;
+    if (LLVM_UNLIKELY(!IMapTy::KeyTraits::nonEmpty(SymStart, SymStop))) {
+      I = Syms.at(PS.End);
+      continue;
+    }
+#ifndef NDEBUG
+    const auto &AddrToModuleIndex = Session.getAddrToModuleIndex();
+    auto ModIter = AddrToModuleIndex.find(SymStart);
+    using ModKeyTraits =
+        std::remove_reference_t<decltype(AddrToModuleIndex)>::KeyTraits;
+    assert(ModIter.valid() &&
+           !ModKeyTraits::startLess(SymStart, ModIter.start()) &&
+           !ModKeyTraits::stopLess(ModIter.stop(), SymStop - 1) &&
+           "Symbol spans modules");
+#endif
+    // Only care about range that is in this module.
+    uint16_t SymModi;
+    if (!Session.moduleIndexForVA(SymStart, SymModi) || SymModi != Modi)
+      continue;
+
+    auto Ranges = getInsertRanges(SymStart, SymStop);
+    if (!Ranges.empty()) {
       SymIndexId Id = createSymbol<NativeFunctionSymbol>(PS, I.offset());
-      AddressToSymbolId.insert({{PS.Segment, PS.CodeOffset}, Id});
-      return getSymbolById(Id);
+      for (auto [Start, Stop] : Ranges)
+        AddressToSymbolId.insert(Start, Stop, Id);
     }
 
     // Jump to the end of this ProcSym.
     I = Syms.at(PS.End);
   }
+
+  if (SymIndexId Id = findIdInCache(VA))
+    return getSymbolById(Id);
+
   return nullptr;
 }
 

--- a/llvm/lib/DebugInfo/PDB/Native/SymbolCache.cpp
+++ b/llvm/lib/DebugInfo/PDB/Native/SymbolCache.cpp
@@ -399,14 +399,7 @@ std::unique_ptr<PDBSymbol> SymbolCache::findFunctionSymbolByVA(uint64_t VA) {
       continue;
     }
 #ifndef NDEBUG
-    const auto &AddrToModuleIndex = Session.getAddrToModuleIndex();
-    auto ModIter = AddrToModuleIndex.find(SymStart);
-    using ModKeyTraits =
-        std::remove_reference_t<decltype(AddrToModuleIndex)>::KeyTraits;
-    assert(ModIter.valid() &&
-           !ModKeyTraits::startLess(SymStart, ModIter.start()) &&
-           !ModKeyTraits::stopLess(ModIter.stop(), SymStop - 1) &&
-           "Symbol spans modules");
+    Session.checkSymbolRange(SymStart, SymStop);
 #endif
     // Only care about range that is in this module.
     uint16_t SymModi;


### PR DESCRIPTION
The original algorithm only caches the symbols that are being queried.
The module needs to be decoded again and again even when looking up the
same symbol but different address. This is time consuming when looking
for a large amount of symbol info. This patch uses IntervalMap to cache
decoded symbols to avoid duplicate decoding. We tested the symbol lookup
time for all symbols in symtab for Blender. The time was shortened by
258x relative to the original algorithm. This will greatly improve the
experience of loading symbols for pseudo probe on Windows