### PR TITLE
[CFG] Add shortcut if CycleInfo is available

### DIFF
--- a/llvm/lib/Analysis/CFG.cpp
+++ b/llvm/lib/Analysis/CFG.cpp
@@ -235,10 +235,19 @@ static bool isReachableImpl(SmallVectorImpl<BasicBlock *> &Worklist,
     const Cycle *OuterC = nullptr;
     if (CI) {
       OuterC = CI->getTopLevelParentCycle(BB);
+      bool InCycle = OuterC != nullptr;
       if (CyclesWithHoles.count(OuterC))
         OuterC = nullptr;
       else if (StopCycles.contains(OuterC))
         return true;
+      // If BB is not part of a cycle, then it can't reach any block that
+      // dominates it. An exception is if the block is unreachable, as all
+      // reachable blocks dominate an unreachable block.
+      if (!InCycle && DT &&
+          llvm::all_of(StopSet, [&](const BasicBlock *StopBB) {
+            return DT->isReachableFromEntry(BB) && DT->dominates(StopBB, BB);
+          }))
+        continue;
     }
 
     if (!--Limit) {

--- a/llvm/lib/Analysis/CFG.cpp
+++ b/llvm/lib/Analysis/CFG.cpp
@@ -235,19 +235,21 @@ static bool isReachableImpl(SmallVectorImpl<BasicBlock *> &Worklist,
     const Cycle *OuterC = nullptr;
     if (CI) {
       OuterC = CI->getTopLevelParentCycle(BB);
-      bool InCycle = OuterC != nullptr;
-      if (CyclesWithHoles.count(OuterC))
-        OuterC = nullptr;
-      else if (StopCycles.contains(OuterC))
-        return true;
-      // If BB is not part of a cycle, then it can't reach any block that
-      // dominates it. An exception is if the block is unreachable, as all
-      // reachable blocks dominate an unreachable block.
-      if (!InCycle && DT && DT->isReachableFromEntry(BB) &&
-          llvm::all_of(StopSet, [&](const BasicBlock *StopBB) {
-            return DT->dominates(StopBB, BB);
-          }))
-        continue;
+      if (OuterC) {
+        if (CyclesWithHoles.count(OuterC))
+          OuterC = nullptr;
+        else if (StopCycles.contains(OuterC))
+          return true;
+      } else {
+        // If BB is not part of a cycle, then it can't reach any block that
+        // dominates it. An exception is if the block is unreachable, as all
+        // reachable blocks dominate an unreachable block.
+        if (DT && DT->isReachableFromEntry(BB) &&
+            llvm::all_of(StopSet, [&](const BasicBlock *StopBB) {
+              return DT->dominates(StopBB, BB);
+            }))
+          continue;
+      }
     }
 
     if (!--Limit) {

--- a/llvm/lib/Analysis/CFG.cpp
+++ b/llvm/lib/Analysis/CFG.cpp
@@ -243,9 +243,9 @@ static bool isReachableImpl(SmallVectorImpl<BasicBlock *> &Worklist,
       // If BB is not part of a cycle, then it can't reach any block that
       // dominates it. An exception is if the block is unreachable, as all
       // reachable blocks dominate an unreachable block.
-      if (!InCycle && DT &&
+      if (!InCycle && DT && DT->isReachableFromEntry(BB) &&
           llvm::all_of(StopSet, [&](const BasicBlock *StopBB) {
-            return DT->isReachableFromEntry(BB) && DT->dominates(StopBB, BB);
+            return DT->dominates(StopBB, BB);
           }))
         continue;
     }


### PR DESCRIPTION
isPotentiallyReachable() currently returns "reachable" early if BB dominates StopBB. If CycleInfo is available, and BB is not part of a cycle, we can also perform the reverse inference: Return "not reachable" if StopBB dominates BB.

This both allows aborting the walk earlier, and provides a more precise result.