### PR TITLE
[lldb] Fix a circular include dependency (NFC)

### DIFF
--- a/lldb/include/lldb/Interpreter/OptionArgParser.h
+++ b/lldb/include/lldb/Interpreter/OptionArgParser.h
@@ -10,7 +10,7 @@
 #define LLDB_INTERPRETER_OPTIONARGPARSER_H
 
 #include "lldb/lldb-private-types.h"
-
+#include "llvm/Support/Error.h"
 #include <optional>
 
 namespace lldb_private {

--- a/lldb/include/lldb/lldb-private-types.h
+++ b/lldb/include/lldb/lldb-private-types.h
@@ -9,11 +9,9 @@
 #ifndef LLDB_LLDB_PRIVATE_TYPES_H
 #define LLDB_LLDB_PRIVATE_TYPES_H
 
-#include "lldb/lldb-private.h"
-
+#include "lldb/lldb-types.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/SmallString.h"
-
 #include <type_traits>
 
 namespace llvm {

--- a/lldb/source/Plugins/Process/Utility/RegisterContextWindows_i386.cpp
+++ b/lldb/source/Plugins/Process/Utility/RegisterContextWindows_i386.cpp
@@ -9,6 +9,7 @@
 #include "RegisterContextWindows_i386.h"
 #include "RegisterContext_x86.h"
 #include "lldb-x86-register-enums.h"
+#include "lldb/lldb-defines.h"
 
 using namespace lldb_private;
 using namespace lldb;

--- a/lldb/source/Plugins/Process/Utility/RegisterContextWindows_x86_64.cpp
+++ b/lldb/source/Plugins/Process/Utility/RegisterContextWindows_x86_64.cpp
@@ -9,6 +9,7 @@
 #include "RegisterContextWindows_x86_64.h"
 #include "RegisterContext_x86.h"
 #include "lldb-x86-register-enums.h"
+#include "lldb/lldb-defines.h"
 
 #include <vector>
 

--- a/lldb/unittests/Utility/ArchSpecTest.cpp
+++ b/lldb/unittests/Utility/ArchSpecTest.cpp
@@ -9,6 +9,7 @@
 #include "gtest/gtest.h"
 
 #include "lldb/Utility/ArchSpec.h"
+#include "lldb/lldb-defines.h"
 #include "llvm/BinaryFormat/ELF.h"
 #include "llvm/BinaryFormat/MachO.h"
 


### PR DESCRIPTION
`lldb-private-types.h` includes `lldb-private.h`, which in turn includes `lldb-private-types.h`. Because of that, `lldb-public.h` included by `lldb-private.h` after `lldb-private-types.h` is not actually included.

The practical consequence of this is that types defined in `lldb-public-types.h` (for example, `addr_t` needed downstream) are not available in `lldb-private-types.h`.

Fix this by "including what you use", which is `lldb-types.h`.