### PR TITLE
PatternMatch: Add matchers for positive or negative infinity

### DIFF
--- a/llvm/include/llvm/IR/PatternMatch.h
+++ b/llvm/include/llvm/IR/PatternMatch.h
@@ -763,6 +763,24 @@ struct is_inf {
 /// For vectors, this includes constants with undefined elements.
 inline cstfp_pred_ty<is_inf> m_Inf() { return cstfp_pred_ty<is_inf>(); }
 
+template <bool IsNegative> struct is_signed_inf {
+  bool isValue(const APFloat &C) const {
+    return C.isInfinity() && IsNegative == C.isNegative();
+  }
+};
+
+/// Match a positive infinity FP constant.
+/// For vectors, this includes constants with undefined elements.
+inline cstfp_pred_ty<is_signed_inf<false>> m_PosInf() {
+  return cstfp_pred_ty<is_signed_inf<false>>();
+}
+
+/// Match a negative infinity FP constant.
+/// For vectors, this includes constants with undefined elements.
+inline cstfp_pred_ty<is_signed_inf<true>> m_NegInf() {
+  return cstfp_pred_ty<is_signed_inf<true>>();
+}
+
 struct is_noninf {
   bool isValue(const APFloat &C) const { return !C.isInfinity(); }
 };

--- a/llvm/unittests/IR/PatternMatch.cpp
+++ b/llvm/unittests/IR/PatternMatch.cpp
@@ -1755,6 +1755,12 @@ TEST_F(PatternMatchTest, VectorUndefFloat) {
   EXPECT_TRUE(match(VectorInfPoison, m_Inf()));
   EXPECT_FALSE(match(VectorNaNPoison, m_Inf()));
 
+  EXPECT_TRUE(match(ScalarPosInf, m_PosInf()));
+  EXPECT_FALSE(match(ScalarNegInf, m_PosInf()));
+
+  EXPECT_FALSE(match(ScalarPosInf, m_NegInf()));
+  EXPECT_TRUE(match(ScalarNegInf, m_NegInf()));
+
   EXPECT_FALSE(match(ScalarUndef, m_NonInf()));
   EXPECT_FALSE(match(VectorUndef, m_NonInf()));
   EXPECT_FALSE(match(VectorZeroUndef, m_NonInf()));


### PR DESCRIPTION
The existing m_Inf deceptively matches both positive and negative
infinities. Add variants that match the specific sign.