### PR TITLE
[IR] Store fast-math flags in Instruction

### DIFF
--- a/llvm/include/llvm/IR/FMF.h
+++ b/llvm/include/llvm/IR/FMF.h
@@ -22,7 +22,7 @@ class raw_ostream;
 /// Convenience struct for specifying and reasoning about fast-math flags.
 class FastMathFlags {
 private:
-  friend class FPMathOperator;
+  friend class Instruction;
 
   unsigned Flags = 0;
 

--- a/llvm/include/llvm/IR/Instruction.h
+++ b/llvm/include/llvm/IR/Instruction.h
@@ -114,6 +114,9 @@ private:
   /// O(1) local dominance checks between instructions.
   mutable unsigned Order = 0;
 
+protected:
+  unsigned short FMFValue = 0; // fast-math flag values
+
 public:
   /// Optional marker recording the position for debugging information that
   /// takes effect immediately before this instruction. Null unless there is

--- a/llvm/include/llvm/IR/Operator.h
+++ b/llvm/include/llvm/IR/Operator.h
@@ -213,57 +213,52 @@ private:
   }
 
   void setHasAllowReassoc(bool B) {
-    SubclassOptionalData =
-    (SubclassOptionalData & ~FastMathFlags::AllowReassoc) |
-    (B * FastMathFlags::AllowReassoc);
+    auto *I = dyn_cast<Instruction>(this);
+    I->setHasAllowReassoc(B);
   }
 
   void setHasNoNaNs(bool B) {
-    SubclassOptionalData =
-      (SubclassOptionalData & ~FastMathFlags::NoNaNs) |
-      (B * FastMathFlags::NoNaNs);
+    auto *I = dyn_cast<Instruction>(this);
+    I->setHasNoNaNs(B);
   }
 
   void setHasNoInfs(bool B) {
-    SubclassOptionalData =
-      (SubclassOptionalData & ~FastMathFlags::NoInfs) |
-      (B * FastMathFlags::NoInfs);
+    auto *I = dyn_cast<Instruction>(this);
+    I->setHasNoInfs(B);
   }
 
   void setHasNoSignedZeros(bool B) {
-    SubclassOptionalData =
-      (SubclassOptionalData & ~FastMathFlags::NoSignedZeros) |
-      (B * FastMathFlags::NoSignedZeros);
+    auto *I = dyn_cast<Instruction>(this);
+    I->setHasNoSignedZeros(B);
   }
 
   void setHasAllowReciprocal(bool B) {
-    SubclassOptionalData =
-      (SubclassOptionalData & ~FastMathFlags::AllowReciprocal) |
-      (B * FastMathFlags::AllowReciprocal);
+    auto *I = dyn_cast<Instruction>(this);
+    I->setHasAllowReciprocal(B);
   }
 
   void setHasAllowContract(bool B) {
-    SubclassOptionalData =
-        (SubclassOptionalData & ~FastMathFlags::AllowContract) |
-        (B * FastMathFlags::AllowContract);
+    auto *I = dyn_cast<Instruction>(this);
+    I->setHasAllowContract(B);
   }
 
   void setHasApproxFunc(bool B) {
-    SubclassOptionalData =
-        (SubclassOptionalData & ~FastMathFlags::ApproxFunc) |
-        (B * FastMathFlags::ApproxFunc);
+    auto *I = dyn_cast<Instruction>(this);
+    I->setHasApproxFunc(B);
   }
 
   /// Convenience function for setting multiple fast-math flags.
   /// FMF is a mask of the bits to set.
   void setFastMathFlags(FastMathFlags FMF) {
-    SubclassOptionalData |= FMF.Flags;
+    auto *I = dyn_cast<Instruction>(this);
+    I->setFastMathFlags(FMF);
   }
 
   /// Convenience function for copying all fast-math flags.
   /// All values in FMF are transferred to this operator.
   void copyFastMathFlags(FastMathFlags FMF) {
-    SubclassOptionalData = FMF.Flags;
+    auto *I = dyn_cast<Instruction>(this);
+    I->copyFastMathFlags(FMF);
   }
 
   /// Returns true if `Ty` is composed of a single kind of float-poing type
@@ -284,54 +279,57 @@ private:
 public:
   /// Test if this operation allows all non-strict floating-point transforms.
   bool isFast() const {
-    return ((SubclassOptionalData & FastMathFlags::AllowReassoc) != 0 &&
-            (SubclassOptionalData & FastMathFlags::NoNaNs) != 0 &&
-            (SubclassOptionalData & FastMathFlags::NoInfs) != 0 &&
-            (SubclassOptionalData & FastMathFlags::NoSignedZeros) != 0 &&
-            (SubclassOptionalData & FastMathFlags::AllowReciprocal) != 0 &&
-            (SubclassOptionalData & FastMathFlags::AllowContract) != 0 &&
-            (SubclassOptionalData & FastMathFlags::ApproxFunc) != 0);
+    const auto *I = dyn_cast<Instruction>(this);
+    return I->isFast();
   }
 
   /// Test if this operation may be simplified with reassociative transforms.
   bool hasAllowReassoc() const {
-    return (SubclassOptionalData & FastMathFlags::AllowReassoc) != 0;
+    const auto *I = dyn_cast<Instruction>(this);
+    return I->hasAllowReassoc();
   }
 
   /// Test if this operation's arguments and results are assumed not-NaN.
   bool hasNoNaNs() const {
-    return (SubclassOptionalData & FastMathFlags::NoNaNs) != 0;
+    const auto *I = dyn_cast<Instruction>(this);
+    return I->hasNoNaNs();
   }
 
   /// Test if this operation's arguments and results are assumed not-infinite.
   bool hasNoInfs() const {
-    return (SubclassOptionalData & FastMathFlags::NoInfs) != 0;
+    const auto *I = dyn_cast<Instruction>(this);
+    return I->hasNoInfs();
   }
 
   /// Test if this operation can ignore the sign of zero.
   bool hasNoSignedZeros() const {
-    return (SubclassOptionalData & FastMathFlags::NoSignedZeros) != 0;
+    const auto *I = dyn_cast<Instruction>(this);
+    return I->hasNoSignedZeros();
   }
 
   /// Test if this operation can use reciprocal multiply instead of division.
   bool hasAllowReciprocal() const {
-    return (SubclassOptionalData & FastMathFlags::AllowReciprocal) != 0;
+    const auto *I = dyn_cast<Instruction>(this);
+    return I->hasAllowReciprocal();
   }
 
   /// Test if this operation can be floating-point contracted (FMA).
   bool hasAllowContract() const {
-    return (SubclassOptionalData & FastMathFlags::AllowContract) != 0;
+    const auto *I = dyn_cast<Instruction>(this);
+    return I->hasAllowContract();
   }
 
   /// Test if this operation allows approximations of math library functions or
   /// intrinsics.
   bool hasApproxFunc() const {
-    return (SubclassOptionalData & FastMathFlags::ApproxFunc) != 0;
+    const auto *I = dyn_cast<Instruction>(this);
+    return I->hasApproxFunc();
   }
 
   /// Convenience function for getting all the fast-math flags
   FastMathFlags getFastMathFlags() const {
-    return FastMathFlags(SubclassOptionalData);
+    const auto *I = dyn_cast<Instruction>(this);
+    return I->getFastMathFlags();
   }
 
   /// Get the maximum error permitted by this operation in ULPs. An accuracy of

--- a/llvm/lib/IR/Instruction.cpp
+++ b/llvm/lib/IR/Instruction.cpp
@@ -616,92 +616,99 @@ void Instruction::setFast(bool B) {
 
 void Instruction::setHasAllowReassoc(bool B) {
   assert(isa<FPMathOperator>(this) && "setting fast-math flag on invalid op");
-  cast<FPMathOperator>(this)->setHasAllowReassoc(B);
+  FMFValue = (FMFValue & ~FastMathFlags::AllowReassoc) |
+             (B * FastMathFlags::AllowReassoc);
 }
 
 void Instruction::setHasNoNaNs(bool B) {
   assert(isa<FPMathOperator>(this) && "setting fast-math flag on invalid op");
-  cast<FPMathOperator>(this)->setHasNoNaNs(B);
+  FMFValue = (FMFValue & ~FastMathFlags::NoNaNs) | (B * FastMathFlags::NoNaNs);
 }
 
 void Instruction::setHasNoInfs(bool B) {
   assert(isa<FPMathOperator>(this) && "setting fast-math flag on invalid op");
-  cast<FPMathOperator>(this)->setHasNoInfs(B);
+  FMFValue = (FMFValue & ~FastMathFlags::NoInfs) | (B * FastMathFlags::NoInfs);
 }
 
 void Instruction::setHasNoSignedZeros(bool B) {
   assert(isa<FPMathOperator>(this) && "setting fast-math flag on invalid op");
-  cast<FPMathOperator>(this)->setHasNoSignedZeros(B);
+  FMFValue = (FMFValue & ~FastMathFlags::NoSignedZeros) |
+             (B * FastMathFlags::NoSignedZeros);
 }
 
 void Instruction::setHasAllowReciprocal(bool B) {
   assert(isa<FPMathOperator>(this) && "setting fast-math flag on invalid op");
-  cast<FPMathOperator>(this)->setHasAllowReciprocal(B);
+  FMFValue = (FMFValue & ~FastMathFlags::AllowReciprocal) |
+             (B * FastMathFlags::AllowReciprocal);
 }
 
 void Instruction::setHasAllowContract(bool B) {
   assert(isa<FPMathOperator>(this) && "setting fast-math flag on invalid op");
-  cast<FPMathOperator>(this)->setHasAllowContract(B);
+  FMFValue = (FMFValue & ~FastMathFlags::AllowContract) |
+             (B * FastMathFlags::AllowContract);
 }
 
 void Instruction::setHasApproxFunc(bool B) {
   assert(isa<FPMathOperator>(this) && "setting fast-math flag on invalid op");
-  cast<FPMathOperator>(this)->setHasApproxFunc(B);
+  FMFValue =
+      (FMFValue & ~FastMathFlags::ApproxFunc) | (B * FastMathFlags::ApproxFunc);
 }
 
 void Instruction::setFastMathFlags(FastMathFlags FMF) {
   assert(isa<FPMathOperator>(this) && "setting fast-math flag on invalid op");
-  cast<FPMathOperator>(this)->setFastMathFlags(FMF);
+  FMFValue |= FMF.Flags;
 }
 
 void Instruction::copyFastMathFlags(FastMathFlags FMF) {
   assert(isa<FPMathOperator>(this) && "copying fast-math flag on invalid op");
-  cast<FPMathOperator>(this)->copyFastMathFlags(FMF);
+  FMFValue = FMF.Flags;
 }
 
 bool Instruction::isFast() const {
   assert(isa<FPMathOperator>(this) && "getting fast-math flag on invalid op");
-  return cast<FPMathOperator>(this)->isFast();
+  return hasAllowReassoc() && hasNoNaNs() && hasNoInfs() &&
+         hasNoSignedZeros() && hasAllowReciprocal() && hasAllowContract() &&
+         hasApproxFunc();
 }
 
 bool Instruction::hasAllowReassoc() const {
   assert(isa<FPMathOperator>(this) && "getting fast-math flag on invalid op");
-  return cast<FPMathOperator>(this)->hasAllowReassoc();
+  return FMFValue & FastMathFlags::AllowReassoc;
 }
 
 bool Instruction::hasNoNaNs() const {
   assert(isa<FPMathOperator>(this) && "getting fast-math flag on invalid op");
-  return cast<FPMathOperator>(this)->hasNoNaNs();
+  return FMFValue & FastMathFlags::NoNaNs;
 }
 
 bool Instruction::hasNoInfs() const {
   assert(isa<FPMathOperator>(this) && "getting fast-math flag on invalid op");
-  return cast<FPMathOperator>(this)->hasNoInfs();
+  return FMFValue & FastMathFlags::NoInfs;
 }
 
 bool Instruction::hasNoSignedZeros() const {
   assert(isa<FPMathOperator>(this) && "getting fast-math flag on invalid op");
-  return cast<FPMathOperator>(this)->hasNoSignedZeros();
+  return FMFValue & FastMathFlags::NoSignedZeros;
 }
 
 bool Instruction::hasAllowReciprocal() const {
   assert(isa<FPMathOperator>(this) && "getting fast-math flag on invalid op");
-  return cast<FPMathOperator>(this)->hasAllowReciprocal();
+  return FMFValue & FastMathFlags::AllowReciprocal;
 }
 
 bool Instruction::hasAllowContract() const {
   assert(isa<FPMathOperator>(this) && "getting fast-math flag on invalid op");
-  return cast<FPMathOperator>(this)->hasAllowContract();
+  return FMFValue & FastMathFlags::AllowContract;
 }
 
 bool Instruction::hasApproxFunc() const {
   assert(isa<FPMathOperator>(this) && "getting fast-math flag on invalid op");
-  return cast<FPMathOperator>(this)->hasApproxFunc();
+  return FMFValue & FastMathFlags::ApproxFunc;
 }
 
 FastMathFlags Instruction::getFastMathFlags() const {
   assert(isa<FPMathOperator>(this) && "getting fast-math flag on invalid op");
-  return cast<FPMathOperator>(this)->getFastMathFlags();
+  return FMFValue;
 }
 
 void Instruction::copyFastMathFlags(const Instruction *I) {
@@ -1436,6 +1443,7 @@ Instruction *Instruction::clone() const {
 #undef HANDLE_INST
   }
 
+  New->FMFValue = FMFValue;
   New->SubclassOptionalData = SubclassOptionalData;
   New->copyMetadata(*this);
   return New;

--- a/llvm/lib/IR/Instructions.cpp
+++ b/llvm/lib/IR/Instructions.cpp
@@ -802,6 +802,7 @@ CallInst::CallInst(const CallInst &CI, AllocInfo AllocInfo)
   std::copy(CI.bundle_op_info_begin(), CI.bundle_op_info_end(),
             bundle_op_info_begin());
   SubclassOptionalData = CI.SubclassOptionalData;
+  FMFValue = CI.FMFValue;
 }
 
 CallInst *CallInst::Create(CallInst *CI, ArrayRef<OperandBundleDef> OpB,
@@ -813,6 +814,7 @@ CallInst *CallInst::Create(CallInst *CI, ArrayRef<OperandBundleDef> OpB,
   NewCI->setTailCallKind(CI->getTailCallKind());
   NewCI->setCallingConv(CI->getCallingConv());
   NewCI->SubclassOptionalData = CI->SubclassOptionalData;
+  NewCI->FMFValue = CI->FMFValue;
   NewCI->setAttributes(CI->getAttributes());
   NewCI->setDebugLoc(CI->getDebugLoc());
   return NewCI;


### PR DESCRIPTION
Currently it is impossible to add fast-math flags for `load` and `uitofp` instructions, because `Value::SubclassOptionalData` is occupied by other flags.
This PR moves fast-math flags storage to padding part of `Instruction`, so we can have more bits and fast-math flags will no longer conflict with other flags.