### PR TITLE
[VPlan] Tweak getUnderlyingInstr to improve code (NFC)

### DIFF
--- a/llvm/lib/Transforms/Vectorize/LoopVectorize.cpp
+++ b/llvm/lib/Transforms/Vectorize/LoopVectorize.cpp
@@ -7125,7 +7125,7 @@ static bool planContainsAdditionalSimplifications(VPlan &Plan,
   // First collect all instructions for the recipes in Plan.
   auto GetInstructionForCost = [](const VPRecipeBase *R) -> Instruction * {
     if (auto *S = dyn_cast<VPSingleDefRecipe>(R))
-      return dyn_cast_or_null<Instruction>(S->getUnderlyingValue());
+      return S->getUnderlyingInstr();
     if (auto *WidenMem = dyn_cast<VPWidenMemoryRecipe>(R))
       return &WidenMem->getIngredient();
     return nullptr;
@@ -8283,13 +8283,14 @@ VPlanPtr LoopVectorizationPlanner::tryToBuildVPlanWithVPRecipes(
       if (isa<VPWidenCanonicalIVRecipe, VPBlendRecipe, VPReductionRecipe>(&R))
         continue;
       auto *VPI = cast<VPInstruction>(&R);
-      if (!VPI->getUnderlyingValue())
-        continue;
 
       // TODO: Gradually replace uses of underlying instruction by analyses on
       // VPlan. Migrate code relying on the underlying instruction from VPlan0
       // to construct recipes below to not use the underlying instruction.
-      Instruction *Instr = cast<Instruction>(VPI->getUnderlyingValue());
+      Instruction *Instr = VPI->getUnderlyingInstr();
+      if (!Instr)
+        continue;
+
       Builder.setInsertPoint(VPI);
 
       // The stores with invariant address inside the loop will be deleted, and

--- a/llvm/lib/Transforms/Vectorize/VPlan.h
+++ b/llvm/lib/Transforms/Vectorize/VPlan.h
@@ -671,14 +671,6 @@ public:
 
   VPSingleDefRecipe *clone() override = 0;
 
-  /// Returns the underlying instruction.
-  Instruction *getUnderlyingInstr() {
-    return cast<Instruction>(getUnderlyingValue());
-  }
-  const Instruction *getUnderlyingInstr() const {
-    return cast<Instruction>(getUnderlyingValue());
-  }
-
 #if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   /// Print this VPSingleDefRecipe to dbgs() (for debugging).
   LLVM_ABI_FOR_TEST LLVM_DUMP_METHOD void dump() const;

--- a/llvm/lib/Transforms/Vectorize/VPlanTransforms.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanTransforms.cpp
@@ -63,10 +63,9 @@ bool VPlanTransforms::tryToConvertVPInstructionsToVPRecipes(
          make_early_inc_range(make_range(VPBB->begin(), EndIter))) {
 
       VPValue *VPV = Ingredient.getVPSingleValue();
-      if (!VPV->getUnderlyingValue())
+      Instruction *Inst = VPV->getUnderlyingInstr();
+      if (!Inst)
         continue;
-
-      Instruction *Inst = cast<Instruction>(VPV->getUnderlyingValue());
 
       VPRecipeBase *NewRecipe = nullptr;
       if (auto *PhiR = dyn_cast<VPPhi>(&Ingredient)) {
@@ -2755,7 +2754,7 @@ void VPlanTransforms::truncateToMinimalBitwidths(
         continue;
 
       VPValue *ResultVPV = R.getVPSingleValue();
-      auto *UI = cast_or_null<Instruction>(ResultVPV->getUnderlyingValue());
+      auto *UI = ResultVPV->getUnderlyingInstr();
       unsigned NewResSizeInBits = MinBWs.lookup(UI);
       if (!NewResSizeInBits)
         continue;
@@ -3588,9 +3587,8 @@ void VPlanTransforms::dropPoisonGeneratingRecipes(
         } else
           RecWithFlags->dropPoisonGeneratingFlags();
       } else {
-        Instruction *Instr = dyn_cast_or_null<Instruction>(
-            CurRec->getVPSingleValue()->getUnderlyingValue());
-        (void)Instr;
+        [[maybe_unused]] Instruction *Instr =
+            CurRec->getVPSingleValue()->getUnderlyingInstr();
         assert((!Instr || !Instr->hasPoisonGeneratingFlags()) &&
                "found instruction with poison generating flags not covered by "
                "VPRecipeWithIRFlags");

--- a/llvm/lib/Transforms/Vectorize/VPlanTransforms.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanTransforms.cpp
@@ -2754,7 +2754,7 @@ void VPlanTransforms::truncateToMinimalBitwidths(
         continue;
 
       VPValue *ResultVPV = R.getVPSingleValue();
-      auto *UI = ResultVPV->getUnderlyingInstr();
+      Instruction *UI = ResultVPV->getUnderlyingInstr();
       unsigned NewResSizeInBits = MinBWs.lookup(UI);
       if (!NewResSizeInBits)
         continue;

--- a/llvm/lib/Transforms/Vectorize/VPlanValue.h
+++ b/llvm/lib/Transforms/Vectorize/VPlanValue.h
@@ -69,6 +69,11 @@ public:
   /// Return the underlying Value attached to this VPValue.
   Value *getUnderlyingValue() const { return UnderlyingVal; }
 
+  /// Return the underlying Instruction attached to this VPValue.
+  Instruction *getUnderlyingInstr() const {
+    return cast_or_null<Instruction>(UnderlyingVal);
+  }
+
   /// Return the underlying IR value for a VPIRValue.
   Value *getLiveInIRValue() const;
 


### PR DESCRIPTION
Move the helper to VPValue, and replace asserting-cast with cast_or_null.