### PR TITLE
[MLIR][MPI] Fix direct getRefMutable().assign() bypassing rewriter in FoldCast

### DIFF
--- a/mlir/lib/Dialect/MPI/IR/MPIOps.cpp
+++ b/mlir/lib/Dialect/MPI/IR/MPIOps.cpp
@@ -52,7 +52,7 @@ struct FoldCast final : public mlir::OpRewritePattern<OpT> {
     if (!src.getType().hasStaticShape()) {
       return mlir::failure();
     }
-    op.getRefMutable().assign(src);
+    b.modifyOpInPlace(op, [&]() { op.getRefMutable().assign(src); });
     return mlir::success();
   }
 };


### PR DESCRIPTION
The FoldCast canonicalization pattern was calling op.getRefMutable().assign(src) directly, bypassing the rewriter. This violates the pattern API contract and causes fingerprint change failures when
MLIR_ENABLE_EXPENSIVE_PATTERN_API_CHECKS is enabled. Wrap the modification with b.modifyOpInPlace() to properly notify the rewriter of the changes.

Assisted-by: Claude Code
Fix a failure present with MLIR_ENABLE_EXPENSIVE_PATTERN_API_CHECKS=ON.