### PR TITLE
[MLIR][X86] Fix direct use.set() bypassing rewriter in rewriteUses

### DIFF
--- a/mlir/lib/Dialect/X86/Transforms/VectorContractToPackedTypeDotProduct.cpp
+++ b/mlir/lib/Dialect/X86/Transforms/VectorContractToPackedTypeDotProduct.cpp
@@ -49,11 +49,10 @@ static void rewriteUses(mlir::Value oldVal, mlir::Value newVal,
                         mlir::Operation *targetContract,
                         mlir::PatternRewriter &rewriter) {
   for (mlir::OpOperand &use : llvm::make_early_inc_range(oldVal.getUses())) {
-
     mlir::Operation *user = use.getOwner();
     if (mlir::isa<mlir::vector::ContractionOp>(user) ||
         mlir::isa<mlir::scf::ForOp>(user)) {
-      use.set(newVal);
+      rewriter.modifyOpInPlace(user, [&]() { use.set(newVal); });
     }
   }
 }


### PR DESCRIPTION
rewriteUses was calling use.set(newVal) directly on OpOperand references, bypassing the rewriter. This violates the pattern API contract and causes fingerprint change failures when MLIR_ENABLE_EXPENSIVE_PATTERN_API_CHECKS is enabled. Wrap the modification with rewriter.modifyOpInPlace() to properly notify the rewriter of the changes.

Assisted-by: Claude Code
Fix a failure present with MLIR_ENABLE_EXPENSIVE_PATTERN_API_CHECKS=ON.