### PR TITLE
[MLIR][X86] Fix direct setOperand() bypassing rewriter in shuffleBeforeWriteLikeOp

### DIFF
--- a/mlir/lib/Dialect/X86/Utils/X86Utils.cpp
+++ b/mlir/lib/Dialect/X86/Utils/X86Utils.cpp
@@ -324,9 +324,11 @@ LogicalResult shuffleBeforeWriteLikeOp(PatternRewriter &rewriter,
   auto newVecA = vector::ShapeCastOp::create(rewriter, loc, accTy, shuffledLo);
   auto newVecB = vector::ShapeCastOp::create(rewriter, loc, accTy, shuffledHi);
 
-  // Update write operands in place
-  opA->setOperand(0, newVecA.getResult());
-  opB->setOperand(0, newVecB.getResult());
+  // Update write operands in place via the rewriter to notify it of changes.
+  rewriter.modifyOpInPlace(opA,
+                           [&]() { opA->setOperand(0, newVecA.getResult()); });
+  rewriter.modifyOpInPlace(opB,
+                           [&]() { opB->setOperand(0, newVecB.getResult()); });
 
   return success();
 }


### PR DESCRIPTION
shuffleBeforeWriteLikeOp was calling opA->setOperand() and opB->setOperand() directly, bypassing the rewriter. This violates the pattern API contract and causes fingerprint change failures when MLIR_ENABLE_EXPENSIVE_PATTERN_API_CHECKS is enabled. Wrap both modifications with rewriter.modifyOpInPlace() to properly notify the rewriter of the changes.

Assisted-by: Claude Code
Fix a failure present with MLIR_ENABLE_EXPENSIVE_PATTERN_API_CHECKS=ON.