### PR TITLE
[MLIR][SparseTensor] Fix direct op erasure bypassing rewriter in FoldConvertIntoProducer

### DIFF
--- a/mlir/lib/Dialect/SparseTensor/Transforms/SparseTensorRewriting.cpp
+++ b/mlir/lib/Dialect/SparseTensor/Transforms/SparseTensorRewriting.cpp
@@ -309,7 +309,7 @@ public:
     });
 
     rewriter.replaceAllOpUsesWith(op, producer);
-    op->erase();
+    rewriter.eraseOp(op);
 
     return success();
   }


### PR DESCRIPTION
FoldConvertIntoProducer called op->erase() directly instead of going through the rewriter, which triggers an "unsupported erasure" error under MLIR_ENABLE_EXPENSIVE_PATTERN_API_CHECKS.

Assisted-by: Claude Code

Fix a failure present with MLIR_ENABLE_EXPENSIVE_PATTERN_API_CHECKS=ON.