### PR TITLE
[OpenACC] Fix IR verification failures in acc-specialize passes

### DIFF
--- a/mlir/include/mlir/Dialect/OpenACC/Transforms/ACCSpecializePatterns.h
+++ b/mlir/include/mlir/Dialect/OpenACC/Transforms/ACCSpecializePatterns.h
@@ -48,6 +48,16 @@ class ACCOpReplaceWithVarConversion : public OpRewritePattern<OpTy> {
 public:
   LogicalResult matchAndRewrite(OpTy op,
                                 PatternRewriter &rewriter) const override {
+    // Defer if any user validates its operands as data entry ops (e.g.
+    // acc.data, acc.parallel, acc.declare_enter). Replacing the data entry
+    // op before these are processed would leave them with an invalid operand
+    // and fail IR verification.
+    for (Operation *user : op->getUsers()) {
+      if (isa<acc::DataOp, acc::HostDataOp, acc::KernelEnvironmentOp,
+              acc::ParallelOp, acc::SerialOp, acc::KernelsOp,
+              acc::DeclareEnterOp, acc::EnterDataOp>(user))
+        return failure();
+    }
     // Replace this op with its var operand; it's possible the op has no uses
     // if the op that had previously used it was already converted.
     if (op->use_empty())


### PR DESCRIPTION
When MLIR_ENABLE_EXPENSIVE_PATTERN_API_CHECKS is enabled, the greedy driver verifies the IR after each pattern application. The specialize passes failed because ACCOpReplaceWithVarConversion would run on a data entry op (e.g. acc.create) before container ops that use it in their dataOperands were processed. After replacement, the container op held a non-data-entry operand (e.g. a func arg), failing the acc dialect's dataOperands verifier.

Fix: in ACCOpReplaceWithVarConversion, defer by returning failure() when any user of the data entry op's result is a container op that validates its operands as data entry ops (acc.data, acc.parallel, acc.serial, acc.kernels, acc.host_data, acc.kernel_environment, acc.declare_enter, acc.enter_data). The greedy driver will process the container op first (via ACCRegionUnwrapConversion or ACCDeclareEnterOpConversion), removing the use, after which the data entry op can be safely replaced.

Assisted-by: Claude Code
Fix a failure present with MLIR_ENABLE_EXPENSIVE_PATTERN_API_CHECKS=ON.