### PR TITLE
[llvm] Add DEBUGINFOD_VERBOSE and log dropped error to stderr

### DIFF
--- a/llvm/lib/Debuginfod/BuildIDFetcher.cpp
+++ b/llvm/lib/Debuginfod/BuildIDFetcher.cpp
@@ -28,8 +28,7 @@ DebuginfodFetcher::fetch(ArrayRef<uint8_t> BuildID) const {
     return *PathOrErr;
   Error Err = PathOrErr.takeError();
   if (std::getenv("DEBUGINFOD_VERBOSE"))
-    llvm::errs() << "Debuginfod error: " << Err << "\n";
-  else
-    consumeError(std::move(Err));
+    logAllUnhandledErrors(std::move(Err), llvm::errs(), "Debuginfod error: ");
+  consumeError(std::move(Err));
   return std::nullopt;
 }

--- a/llvm/lib/Debuginfod/BuildIDFetcher.cpp
+++ b/llvm/lib/Debuginfod/BuildIDFetcher.cpp
@@ -26,6 +26,10 @@ DebuginfodFetcher::fetch(ArrayRef<uint8_t> BuildID) const {
   Expected<std::string> PathOrErr = getCachedOrDownloadDebuginfo(BuildID);
   if (PathOrErr)
     return *PathOrErr;
-  consumeError(PathOrErr.takeError());
+  Error Err = PathOrErr.takeError();
+  if (std::getenv("DEBUGINFOD_VERBOSE"))
+    llvm::errs() << "Debuginfod error: " << Err << "\n";
+  else
+    consumeError(std::move(Err));
   return std::nullopt;
 }

--- a/llvm/lib/Debuginfod/BuildIDFetcher.cpp
+++ b/llvm/lib/Debuginfod/BuildIDFetcher.cpp
@@ -29,6 +29,7 @@ DebuginfodFetcher::fetch(ArrayRef<uint8_t> BuildID) const {
   Error Err = PathOrErr.takeError();
   if (std::getenv("DEBUGINFOD_VERBOSE"))
     logAllUnhandledErrors(std::move(Err), llvm::errs(), "Debuginfod error: ");
-  consumeError(std::move(Err));
+  else
+    consumeError(std::move(Err));
   return std::nullopt;
 }

--- a/llvm/test/tools/llvm-debuginfod-find/headers-winhttp.test
+++ b/llvm/test/tools/llvm-debuginfod-find/headers-winhttp.test
@@ -7,15 +7,15 @@ RUN: rm -rf %t
 RUN: mkdir -p %t/debuginfod-cache
 RUN: %python %S/Inputs/capture_req.py llvm-debuginfod-find --debuginfo 0 \
 RUN:   | FileCheck --check-prefix NO-HEADERS %s
-RUN: env DEBUGINFOD_CACHE=%t/debuginfod-cache DEBUGINFOD_HEADERS_FILE=bad %python %S/Inputs/capture_req.py \
+RUN: env DEBUGINFOD_VERBOSE=1 env DEBUGINFOD_CACHE=%t/debuginfod-cache DEBUGINFOD_HEADERS_FILE=bad %python %S/Inputs/capture_req.py \
 RUN:   llvm-debuginfod-find --debuginfo 0 \
 RUN:   | FileCheck --check-prefix NO-HEADERS %s
 RUN: rm -rf %t/debuginfod-cache/*
-RUN: env DEBUGINFOD_CACHE=%t/debuginfod-cache DEBUGINFOD_HEADERS_FILE=%S/Inputs/headers %python %S/Inputs/capture_req.py \
+RUN: env DEBUGINFOD_VERBOSE=1 env DEBUGINFOD_CACHE=%t/debuginfod-cache DEBUGINFOD_HEADERS_FILE=%S/Inputs/headers %python %S/Inputs/capture_req.py \
 RUN:   llvm-debuginfod-find --debuginfo 0 \
 RUN:   | FileCheck --check-prefix HEADERS %s
 RUN: rm -rf %t/debuginfod-cache/*
-RUN: env DEBUGINFOD_CACHE=%t/debuginfod-cache DEBUGINFOD_HEADERS_FILE=%S/Inputs/headers DEBUGINFOD_URLS=fake not llvm-debuginfod-find --debuginfo 0 2>&1 \
+RUN: env DEBUGINFOD_VERBOSE=1 env DEBUGINFOD_CACHE=%t/debuginfod-cache DEBUGINFOD_HEADERS_FILE=%S/Inputs/headers DEBUGINFOD_URLS=fake not llvm-debuginfod-find --debuginfo 0 2>&1 \
 RUN:   | FileCheck --check-prefix ERR -DHEADER_FILE=%S/Inputs/headers %s
 
 NO-HEADERS:      User-Agent: LLVM-HTTPClient/1.0


### PR DESCRIPTION
Allow tests to print errors from Debuginfod's getCachedOrDownloadDebuginfo() to stderr