### PR TITLE
[llvm][HTTP] Apply WinHTTP timeout setting after WinHttpOpen

### DIFF
--- a/llvm/lib/Debuginfod/BuildIDFetcher.cpp
+++ b/llvm/lib/Debuginfod/BuildIDFetcher.cpp
@@ -24,7 +24,7 @@ DebuginfodFetcher::fetch(ArrayRef<uint8_t> BuildID) const {
   Expected<std::string> Path = BuildIDFetcher::fetch(BuildID);
   if (Path)
     return Path;
-  // Most users will not care why this failed.
+  // Not available locally, so try and download it now.
   assert(errorToErrorCode(Path.takeError()) ==
              std::errc::no_such_file_or_directory &&
          "BuildIDFetcher::fetch() failed in an unexpected way");

--- a/llvm/lib/HTTP/HTTPClient.cpp
+++ b/llvm/lib/HTTP/HTTPClient.cpp
@@ -154,6 +154,7 @@ struct WinHTTPSession {
   HINTERNET ConnectHandle = nullptr;
   HINTERNET RequestHandle = nullptr;
   DWORD ResponseCode = 0;
+  DWORD TimeoutMs = 30000;
 
   ~WinHTTPSession() {
     if (RequestHandle)
@@ -225,15 +226,7 @@ void HTTPClient::cleanup() {
 
 void HTTPClient::setTimeout(std::chrono::milliseconds Timeout) {
   WinHTTPSession *Session = static_cast<WinHTTPSession *>(Handle);
-  if (Session && Session->SessionHandle) {
-    DWORD TimeoutMs = static_cast<DWORD>(Timeout.count());
-    WinHttpSetOption(Session->SessionHandle, WINHTTP_OPTION_CONNECT_TIMEOUT,
-                     &TimeoutMs, sizeof(TimeoutMs));
-    WinHttpSetOption(Session->SessionHandle, WINHTTP_OPTION_RECEIVE_TIMEOUT,
-                     &TimeoutMs, sizeof(TimeoutMs));
-    WinHttpSetOption(Session->SessionHandle, WINHTTP_OPTION_SEND_TIMEOUT,
-                     &TimeoutMs, sizeof(TimeoutMs));
-  }
+  Session->TimeoutMs = static_cast<DWORD>(Timeout.count());
 }
 
 Error HTTPClient::perform(const HTTPRequest &Request,
@@ -264,6 +257,12 @@ Error HTTPClient::perform(const HTTPRequest &Request,
                   WINHTTP_NO_PROXY_NAME, WINHTTP_NO_PROXY_BYPASS, 0);
   if (!Session->SessionHandle)
     return createStringError(errc::io_error, "Failed to open WinHTTP session");
+
+  // Set timeouts for all 4 phases: resolve, connect, send and receive. Resolve
+  // and connect are hard-coded since they don't vary with different payloads.
+  // Send and receive is configurable and defaults to 30000.
+  WinHttpSetTimeouts(Session->SessionHandle, 5000, 10000, Session->TimeoutMs,
+                     Session->TimeoutMs);
 
   // Prevent fallback to TLS 1.0/1.1
   DWORD SecureProtocols =
@@ -326,12 +325,20 @@ Error HTTPClient::perform(const HTTPRequest &Request,
 
   // Send request
   if (!WinHttpSendRequest(Session->RequestHandle, WINHTTP_NO_ADDITIONAL_HEADERS,
-                          0, nullptr, 0, 0, 0))
-    return createStringError(errc::io_error, "Failed to send HTTP request");
+                          0, nullptr, 0, 0, 0)) {
+    bool TimedOut = GetLastError() == ERROR_WINHTTP_TIMEOUT;
+    return createStringError(errc::io_error,
+                             TimedOut ? "Timeout was reached"
+                                      : "Failed to send HTTP request");
+  }
 
   // Receive response
-  if (!WinHttpReceiveResponse(Session->RequestHandle, nullptr))
-    return createStringError(errc::io_error, "Failed to receive HTTP response");
+  if (!WinHttpReceiveResponse(Session->RequestHandle, nullptr)) {
+    bool TimedOut = GetLastError() == ERROR_WINHTTP_TIMEOUT;
+    return createStringError(errc::io_error,
+                             TimedOut ? "Timeout was reached"
+                                      : "Failed to receive HTTP response");
+  }
 
   // Get response code
   DWORD CodeSize = sizeof(Session->ResponseCode);

--- a/llvm/lib/HTTP/HTTPClient.cpp
+++ b/llvm/lib/HTTP/HTTPClient.cpp
@@ -261,8 +261,9 @@ Error HTTPClient::perform(const HTTPRequest &Request,
   // Set timeouts for all 4 phases: resolve, connect, send and receive. Resolve
   // and connect are hard-coded since they don't vary with different payloads.
   // Send and receive is configurable and defaults to 30000.
-  WinHttpSetTimeouts(Session->SessionHandle, 5000, 10000, Session->TimeoutMs,
-                     Session->TimeoutMs);
+  if (!WinHttpSetTimeouts(Session->SessionHandle, 5000, 10000,
+                          Session->TimeoutMs, Session->TimeoutMs))
+    return createStringError(errc::io_error, "Failed to set WinHTTP timeout");
 
   // Prevent fallback to TLS 1.0/1.1
   DWORD SecureProtocols =

--- a/llvm/test/tools/llvm-debuginfod-find/Inputs/delay_req.py
+++ b/llvm/test/tools/llvm-debuginfod-find/Inputs/delay_req.py
@@ -1,0 +1,26 @@
+import http.server
+import os
+import subprocess
+import sys
+import threading
+import time
+
+
+class DelayingHandler(http.server.BaseHTTPRequestHandler):
+    def do_GET(self):
+        # The test sets DEBUGINFOD_TIMEOUT=1
+        time.sleep(2)
+        self.send_response(501)
+
+
+httpd = http.server.HTTPServer(("localhost", 0), DelayingHandler)
+port = httpd.socket.getsockname()[1]
+
+try:
+    t = threading.Thread(target=httpd.serve_forever).start()
+    os.environ["DEBUGINFOD_URLS"] = f"http://localhost:{port}"
+    result = subprocess.run(sys.argv[1:], capture_output=True)
+    # e.g. Build ID 00: curl_easy_perform() failed: Timeout was reached
+    print(result.stderr.decode())
+finally:
+    httpd.shutdown()

--- a/llvm/test/tools/llvm-debuginfod-find/headers-winhttp.test
+++ b/llvm/test/tools/llvm-debuginfod-find/headers-winhttp.test
@@ -1,7 +1,7 @@
 REQUIRES: system-windows, http-server, disabled-temp
 
 RUN: not llvm-debuginfod-find --debuginfo 0 2>&1 | FileCheck %s --check-prefix CHECK-STDOUT
-CHECK-STDOUT: Build ID 00 could not be found
+CHECK-STDOUT: Build ID 00: build id not found
 
 RUN: rm -rf %t
 RUN: mkdir -p %t/debuginfod-cache

--- a/llvm/test/tools/llvm-debuginfod-find/timeout.test
+++ b/llvm/test/tools/llvm-debuginfod-find/timeout.test
@@ -1,0 +1,12 @@
+REQUIRES: curl || system-windows, http-server
+
+RUN: rm -rf %t
+RUN: mkdir -p %t/debuginfod-cache
+
+# We hit the timeout because the Python script delays the response by 2 seconds
+RUN: env DEBUGINFOD_TIMEOUT=1 \
+RUN: env DEBUGINFOD_CACHE=%t/debuginfod-cache \
+RUN: env DEBUGINFOD_HEADERS_FILE=%S/Inputs/headers \
+RUN:   %python %S/Inputs/delay_req.py llvm-debuginfod-find --debuginfo 0 | FileCheck %s
+
+CHECK: Build ID 00: Timeout was reached

--- a/llvm/tools/llvm-debuginfod-find/llvm-debuginfod-find.cpp
+++ b/llvm/tools/llvm-debuginfod-find/llvm-debuginfod-find.cpp
@@ -152,12 +152,11 @@ int llvm_debuginfod_find_main(int argc, char **argv,
 
 // Find a debug file in local build ID directories and via debuginfod.
 std::string fetchDebugInfo(object::BuildIDRef BuildID) {
-  Expected<std::string> PathOrErr =
+  Expected<std::string> Path =
       DebuginfodFetcher(DebugFileDirectory).fetch(BuildID);
-  if (PathOrErr)
-    return *PathOrErr;
+  if (Path)
+    return *Path;
   errs() << "Build ID " << llvm::toHex(BuildID, /*Lowercase=*/true) << ": "
-         << " could not be found.\n";
-  consumeError(PathOrErr.takeError());
+         << toString(Path.takeError()) << "\n";
   exit(1);
 }


### PR DESCRIPTION
`setTimeout()` required the session handle, but it was only created inside `HTTPClient::perform()`. This patch stores the incoming value and applies it after the session handle is created with `WinHttpOpen()`.