### PR TITLE
[BOLT] Gadget scanner: add less strict version of tail call checker

### DIFF
--- a/bolt/docs/BinaryAnalysis.md
+++ b/bolt/docs/BinaryAnalysis.md
@@ -189,10 +189,12 @@ GS-PAUTH: signing oracle found in function function_name, basic block .LBB016, a
 
 Pointer Authentication analysis is able to search for a number of gadget kinds,
 with the specific set depending on command line options:
-* [`ptrauth-pac-ret`](#return-address-protection-ptrauth-pac-ret) -
+* [`ptrauth-backward-cf`](#return-address-protection-ptrauth-backward-cf) -
   non-protected return instruction
-* [`ptrauth-tail-calls`](#return-address-protection-before-tail-call-ptrauth-tail-calls) -
-  performing a tail call with an untrusted value in the link register
+  * [`ptrauth-pac-ret`](#ptrauth-pac-ret-combination) checks tail calls in
+    addition to regular return instructions
+* [`ptrauth-tail-calls` and `ptrauth-tail-calls-strict`](#return-address-protection-before-tail-call-ptrauth-tail-calls) -
+  performing a tail call with the value in the link register not being protected enough
 * [`ptrauth-forward-cf`](#indirect-branch-call-target-protection-ptrauth-forward-cf) -
   non-protected destination of branch or call instruction
 * [`ptrauth-sign-oracles`](#signing-oracles-ptrauth-sign-oracles) -
@@ -246,7 +248,7 @@ the descriptions refer to AArch64 for simplicity, the implementation of gadget
 detectors in `llvm-bolt-binary-analysis` attempts to be target-neutral by
 isolating AArch64 specifics in target-dependent hooks.
 
-### Return address protection (`ptrauth-pac-ret`)
+### Return address protection (`ptrauth-backward-cf`)
 
 **Instructions:** Return instructions without built-in authentication:
 either `ret` (implicit `x30` register) or `ret <reg>`, but not `retaa` and
@@ -320,19 +322,32 @@ bad_clobber:
 
 ### Return address protection before tail call (`ptrauth-tail-calls`)
 
+This gadget kind exists in two variants: `ptrauth-tail-calls` and
+`ptrauth-tail-calls-strict`.
+
 **Instructions:** Branch instructions (both direct and indirect, regular or
 with built-in authentication), classified as tail calls either by BOLT or by
 PtrAuth gadget scanner's heuristic.
 
-**Property:** link register (`x30` on AArch64) must be trusted.
+**Property:** link register (`x30` on AArch64) must be safe-to-dereference
+(`ptrauth-tail-calls`) or trusted (`ptrauth-tail-calls-strict`).
 
 **Notes:** Heuristics are involved to classify instructions either as a tail
 call or as another kind of branch (such as jump table or computed goto).
 
-A report is generated if a tail call is performed with an untrusted link register.
+The `-strict` variant of this report is generated if a tail call is performed with an untrusted link register.
 This basically means that the tail-called function would have the link register
 untrusted on its entry (unlike the inherently correct address placed in the link
 register by one of the `bl*` instructions when a non-tail call is performed).
+Depending on the assumptions being made on the target environment, enforcing this
+invariant may require inserting an expensive instruction sequence before each
+tail call by the compiler.
+
+On the other hand, as tail call is logically a combination of call and return
+instruction, there is no reason to skip regular link register authentication
+in function's epilogue just before the tail call is performed. The non-`strict`
+variant of this gadget follows the idea of `ptrauth-backward-cf` extended to the
+branch instructions identified as tail calls by the heuristics.
 
 ```asm
 non_protected_tail_call:
@@ -369,6 +384,16 @@ Properly mitigating this issue would usually require inserting an explicit
 check after a regular authentication instruction, which may be either too
 expensive (if a fully-generic XPAC-based sequence is being used) on one hand,
 or not required at all (if `FEAT_FPAC` is known to be implemented) on the other hand.
+
+### `ptrauth-pac-ret` combination
+
+When the `pac-ret` hardening is enabled in the compiler, the link register is
+signed in function's prologue and authenticated in its epilogue, whether the
+function is exited via regular return instruction or a tail call. For that
+reason, a `ptrauth-pac-ret` preset is defined in `llvm-bolt-binary-analysis`
+which enables both `ptrauth-backward-cf` and `ptrauth-tail-calls`. This way,
+it is possible to enable a sensible preset for `pac-ret` hardening by default
+and opt-out of tail call checking in case it results in false positives.
 
 ### Indirect branch / call target protection (`ptrauth-forward-cf`)
 
@@ -713,9 +738,6 @@ which is also supported by Clang.
 
 #### Other known issues
 
-* No lightweight variant of [`ptrauth-tail-calls`](#return-address-protection-before-tail-call-ptrauth-tail-calls),
-  see issue [#186204](https://github.com/llvm/llvm-project/issues/186204)
-  for the details.
 * Not handling "no-return" functions. See issue
   [#115154](https://github.com/llvm/llvm-project/issues/115154) for details and
   pointers to open PRs to fix this.

--- a/bolt/include/bolt/Utils/CommandLineOpts.h
+++ b/bolt/include/bolt/Utils/CommandLineOpts.h
@@ -134,19 +134,26 @@ bool shouldDumpDot(const llvm::bolt::BinaryFunction &Function);
 enum GadgetKindBitmask : unsigned {
   /// Scan for unprotected backward control-flow (return instructions).
   GS_PTRAUTH_RETURN_TARGETS = (1 << 0),
-  /// Scan for tail calls performed with untrusted link register.
-  GS_PTRAUTH_TAIL_CALLS = (1 << 1),
+  /// Scan for tail calls performed with completely unprotected link register
+  /// (suitable for pac-ret validation).
+  GS_PTRAUTH_TAIL_CALLS_BASIC = (1 << 1),
+  /// Scan for tail calls performed with not fully trusted link register
+  /// (may require inserting expensive checks by the compiler).
+  GS_PTRAUTH_TAIL_CALLS_STRICT = (1 << 2),
   /// Scan for unprotected forward control-flow (branch and call instructions).
-  GS_PTRAUTH_BRANCH_AND_CALL_TARGETS = (1 << 2),
+  GS_PTRAUTH_BRANCH_AND_CALL_TARGETS = (1 << 3),
   /// Scan for signing oracles.
-  GS_PTRAUTH_SIGN_ORACLES = (1 << 3),
+  GS_PTRAUTH_SIGN_ORACLES = (1 << 4),
   /// Scan for authentication oracles.
-  GS_PTRAUTH_AUTH_ORACLES = (1 << 4),
+  GS_PTRAUTH_AUTH_ORACLES = (1 << 5),
 
+  /// Scan for pac-ret issues.
+  GS_PTRAUTH_PAC_RET = GS_PTRAUTH_RETURN_TARGETS | GS_PTRAUTH_TAIL_CALLS_BASIC,
   /// Scan for all Pointer Authentication issues.
-  GS_PTRAUTH_ALL_MASK = GS_PTRAUTH_RETURN_TARGETS | GS_PTRAUTH_TAIL_CALLS |
-                        GS_PTRAUTH_BRANCH_AND_CALL_TARGETS |
-                        GS_PTRAUTH_SIGN_ORACLES | GS_PTRAUTH_AUTH_ORACLES,
+  GS_PTRAUTH_ALL_MASK =
+      GS_PTRAUTH_RETURN_TARGETS | GS_PTRAUTH_TAIL_CALLS_BASIC |
+      GS_PTRAUTH_TAIL_CALLS_STRICT | GS_PTRAUTH_BRANCH_AND_CALL_TARGETS |
+      GS_PTRAUTH_SIGN_ORACLES | GS_PTRAUTH_AUTH_ORACLES,
 
   /// Run all implemented scanners.
   GS_ALL_MASK = GS_PTRAUTH_ALL_MASK,

--- a/bolt/lib/Passes/PAuthGadgetScanner.cpp
+++ b/bolt/lib/Passes/PAuthGadgetScanner.cpp
@@ -1419,11 +1419,26 @@ static bool shouldAnalyzeTailCallInst(const BinaryContext &BC,
   return false;
 }
 
+// As tail call instruction is a function call, it may be desired to make sure
+// that the callee is entered with trusted link register, same as for a regular
+// call instruction. Depending on the particular assumptions made about the
+// target environment, this might require expensive checks to be inserted by
+// the compiler, thus it is a security vs. performance trade-off.
+//
+// Nevertheless, a tail call is virtually a return from the current function,
+// so it is worth checking at this point that at least pac-ret is implemented
+// properly. However, checking tail calls involves heuristics to classify
+// branch instructions either as tail call or not, unlike regular return
+// instructions. Thus it may be useful to be able to disable tail call checking
+// while keeping regular pac-ret validation in case of false positives.
 static std::optional<PartialReport<MCPhysReg>>
 shouldReportUnsafeTailCall(const BinaryContext &BC, const BinaryFunction &BF,
-                           const MCInstReference &Inst, const SrcState &S) {
+                           bool Strict, const MCInstReference &Inst,
+                           const SrcState &S) {
+  static const GadgetKind UnauthenticatedLRKind(
+      "unauthenticated link register found before tail call");
   static const GadgetKind UntrustedLRKind(
-      "untrusted link register found before tail call");
+      "not fully trusted link register found before tail call");
 
   if (!shouldAnalyzeTailCallInst(BC, BF, Inst))
     return std::nullopt;
@@ -1458,9 +1473,12 @@ shouldReportUnsafeTailCall(const BinaryContext &BC, const BinaryFunction &BF,
   }
 
   // Returns at most one report per instruction - this is probably OK...
-  for (auto Reg : RegsToCheck)
-    if (!S.TrustedRegs[Reg])
+  for (auto Reg : RegsToCheck) {
+    if (!S.SafeToDerefRegs[Reg])
+      return make_gadget_report(UnauthenticatedLRKind, Inst, Reg);
+    if (Strict && !S.TrustedRegs[Reg])
       return make_gadget_report(UntrustedLRKind, Inst, Reg);
+  }
 
   return std::nullopt;
 }
@@ -1626,8 +1644,11 @@ void FunctionAnalysisContext::findUnsafeUses(
       if (auto Report = shouldReportReturnGadget(BC, Inst, S))
         Reports.push_back(*Report);
     }
-    if (EnabledDetectors & opts::GS_PTRAUTH_TAIL_CALLS) {
-      if (auto Report = shouldReportUnsafeTailCall(BC, BF, Inst, S))
+    const auto TailCallCheckers =
+        opts::GS_PTRAUTH_TAIL_CALLS_BASIC | opts::GS_PTRAUTH_TAIL_CALLS_STRICT;
+    if (EnabledDetectors & TailCallCheckers) {
+      bool Strict = EnabledDetectors & opts::GS_PTRAUTH_TAIL_CALLS_STRICT;
+      if (auto Report = shouldReportUnsafeTailCall(BC, BF, Strict, Inst, S))
         Reports.push_back(*Report);
     }
     if (EnabledDetectors & opts::GS_PTRAUTH_BRANCH_AND_CALL_TARGETS) {

--- a/bolt/lib/Rewrite/RewriteInstance.cpp
+++ b/bolt/lib/Rewrite/RewriteInstance.cpp
@@ -290,12 +290,18 @@ static cl::opt<bool> WriteBoltInfoSection(
 static cl::list<GadgetKindBitmask> GadgetScannersToRun(
     "scanners", cl::desc("Which gadget scanners to run"),
     cl::values(
-        clEnumValN(GS_PTRAUTH_RETURN_TARGETS, "ptrauth-pac-ret",
-                   "Unprotected returns (pac-ret)"),
-        clEnumValN(GS_PTRAUTH_TAIL_CALLS, "ptrauth-tail-calls",
-                   "Tail calls performed with unprotected link register"),
+        clEnumValN(GS_PTRAUTH_PAC_RET, "ptrauth-pac-ret",
+                   "Returning from a function with unprotected link register "
+                   "(backward-cf + tail-calls)"),
+
+        clEnumValN(GS_PTRAUTH_TAIL_CALLS_BASIC, "ptrauth-tail-calls",
+                   "Tail calls performed with unauthenticated link register"),
+        clEnumValN(GS_PTRAUTH_TAIL_CALLS_STRICT, "ptrauth-tail-calls-strict",
+                   "Tail calls performed with not fully trusted link register"),
+        clEnumValN(GS_PTRAUTH_RETURN_TARGETS, "ptrauth-backward-cf",
+                   "Unprotected return targets (backward control flow)"),
         clEnumValN(GS_PTRAUTH_BRANCH_AND_CALL_TARGETS, "ptrauth-forward-cf",
-                   "Unprotected calls and branches (forward control-flow)"),
+                   "Unprotected call or branch targets (forward control flow)"),
         clEnumValN(GS_PTRAUTH_SIGN_ORACLES, "ptrauth-sign-oracles",
                    "Signing of untrusted pointers (signing oracles)"),
         clEnumValN(GS_PTRAUTH_AUTH_ORACLES, "ptrauth-auth-oracles",

--- a/bolt/test/binary-analysis/AArch64/cmdline-args.test
+++ b/bolt/test/binary-analysis/AArch64/cmdline-args.test
@@ -35,13 +35,15 @@ HELP-NEXT:  BinaryAnalysis options:
 HELP-EMPTY:
 HELP-NEXT:   --auth-traps-on-failure - Assume authentication instructions always trap on failure
 HELP-NEXT:   --scanners=<value> - Which gadget scanners to run
-HELP-NEXT:   =ptrauth-pac-ret        -   Unprotected returns (pac-ret)
-HELP-NEXT:   =ptrauth-tail-calls     -   Tail calls performed with unprotected link register
-HELP-NEXT:   =ptrauth-forward-cf     -   Unprotected calls and branches (forward control-flow)
-HELP-NEXT:   =ptrauth-sign-oracles   -   Signing of untrusted pointers (signing oracles)
-HELP-NEXT:   =ptrauth-auth-oracles   -   Authentication oracles
-HELP-NEXT:   =ptrauth-all            -   All Pointer Authentication scanners
-HELP-NEXT:   =all                    -   All implemented scanners
+HELP-NEXT:   =ptrauth-pac-ret           -   Returning from a function with unprotected link register (backward-cf + tail-calls)
+HELP-NEXT:   =ptrauth-tail-calls        -   Tail calls performed with unauthenticated link register
+HELP-NEXT:   =ptrauth-tail-calls-strict -   Tail calls performed with not fully trusted link register
+HELP-NEXT:   =ptrauth-backward-cf       -   Unprotected return targets (backward control flow)
+HELP-NEXT:   =ptrauth-forward-cf        -   Unprotected call or branch targets (forward control flow)
+HELP-NEXT:   =ptrauth-sign-oracles      -   Signing of untrusted pointers (signing oracles)
+HELP-NEXT:   =ptrauth-auth-oracles      -   Authentication oracles
+HELP-NEXT:   =ptrauth-all               -   All Pointer Authentication scanners
+HELP-NEXT:   =all                       -   All implemented scanners
 
 HELP-EMPTY:
 HELP-NEXT:  Generic Options:

--- a/bolt/test/binary-analysis/AArch64/gs-pacret-autiasp.s
+++ b/bolt/test/binary-analysis/AArch64/gs-pacret-autiasp.s
@@ -1,5 +1,6 @@
 // RUN: %clang %cflags -march=armv9.5-a+pauth-lr -mbranch-protection=pac-ret %s %p/../../Inputs/asm_main.c -o %t.exe
-// RUN: llvm-bolt-binary-analysis --scanners=ptrauth-pac-ret %t.exe 2>&1 | FileCheck %s
+// RUN: llvm-bolt-binary-analysis --scanners=ptrauth-pac-ret %t.exe 2>&1     | FileCheck %s --check-prefixes=CHECK,FULL
+// RUN: llvm-bolt-binary-analysis --scanners=ptrauth-backward-cf %t.exe 2>&1 | FileCheck %s --check-prefixes=CHECK,RET-ONLY
 
         .text
 
@@ -173,9 +174,15 @@ f_nonx30_ret_ok:
 f_detect_clobbered_x30_passed_to_other:
         str x30, [sp]
         ldr x30, [sp]
-// FIXME: Ideally, the pac-ret scanner would report on the following instruction, which
-// performs a tail call, that x30 might be attacker-controlled.
-// CHECK-NOT: function f_detect_clobbered_x30_passed_to_other
+// RET-ONLY-NOT: function f_detect_clobbered_x30_passed_to_other
+// FULL-LABEL: GS-PAUTH: unauthenticated link register found before tail call in function f_detect_clobbered_x30_passed_to_other, basic block {{[0-9a-zA-Z.]+}}, at address
+// FULL-NEXT:  The instruction is     {{[0-9a-f]+}}:       b       f_tail_called
+// FULL-NEXT:  The 1 instructions that write to the affected registers after any authentication are:
+// FULL-NEXT:  1.     {{[0-9a-f]+}}:      ldr     x30, [sp]
+// FULL-NEXT:  This happens in the following basic block:
+// FULL-NEXT:  {{[0-9a-f]+}}:   str     x30, [sp]
+// FULL-NEXT:  {{[0-9a-f]+}}:   ldr     x30, [sp]
+// FULL-NEXT:  {{[0-9a-f]+}}:   b       f_tail_called
         b   f_tail_called
         .size f_detect_clobbered_x30_passed_to_other, .-f_detect_clobbered_x30_passed_to_other
 

--- a/bolt/test/binary-analysis/AArch64/gs-pauth-scanners.s
+++ b/bolt/test/binary-analysis/AArch64/gs-pauth-scanners.s
@@ -2,12 +2,15 @@
 
 // Select single detector:
 //
-// RUN: llvm-bolt-binary-analysis --scanners=ptrauth-pac-ret      %t.exe 2>&1 | \
+// RUN: llvm-bolt-binary-analysis --scanners=ptrauth-backward-cf  %t.exe 2>&1 | \
 // RUN:     FileCheck %s --implicit-check-not="found in function" \
-// RUN:                  --check-prefixes=PACRET
+// RUN:                  --check-prefixes=BACKWARD-CF
 // RUN: llvm-bolt-binary-analysis --scanners=ptrauth-tail-calls   %t.exe 2>&1 | \
 // RUN:     FileCheck %s --implicit-check-not="found in function" \
-// RUN:                  --check-prefixes=TAIL-CALLS-COMMON,TAIL-CALLS-NOFPAC
+// RUN:                  --check-prefixes=TAIL-CALLS-BASIC
+// RUN: llvm-bolt-binary-analysis --scanners=ptrauth-tail-calls-strict %t.exe 2>&1 | \
+// RUN:     FileCheck %s --implicit-check-not="found in function" \
+// RUN:                  --check-prefixes=TAIL-CALLS-BASIC,TAIL-CALLS-NOFPAC-STRICT
 // RUN: llvm-bolt-binary-analysis --scanners=ptrauth-forward-cf   %t.exe 2>&1 | \
 // RUN:     FileCheck %s --implicit-check-not="found in function" \
 // RUN:                  --check-prefixes=FORWARD-CF
@@ -20,33 +23,36 @@
 
 // Select multiple options (either disjoint or not):
 //
-// RUN: llvm-bolt-binary-analysis --scanners=ptrauth-pac-ret,ptrauth-forward-cf %t.exe 2>&1 | \
+// RUN: llvm-bolt-binary-analysis --scanners=ptrauth-backward-cf,ptrauth-forward-cf %t.exe 2>&1 | \
 // RUN:     FileCheck %s --implicit-check-not="found in function" \
-// RUN:                  --check-prefixes=PACRET,FORWARD-CF
-// RUN: llvm-bolt-binary-analysis --scanners=ptrauth-pac-ret,ptrauth-all %t.exe 2>&1 | \
+// RUN:                  --check-prefixes=BACKWARD-CF,FORWARD-CF
+// RUN: llvm-bolt-binary-analysis --scanners=ptrauth-backward-cf,ptrauth-all %t.exe 2>&1 | \
 // RUN:     FileCheck %s --implicit-check-not="found in function" \
-// RUN:                  --check-prefixes=PACRET,TAIL-CALLS-COMMON,TAIL-CALLS-NOFPAC,FORWARD-CF,SIGN-ORACLES-COMMON,SIGN-ORACLES-NOFPAC,AUTH-ORACLES-NOFPAC
+// RUN:                  --check-prefixes=BACKWARD-CF,TAIL-CALLS-BASIC,TAIL-CALLS-NOFPAC-STRICT,FORWARD-CF,SIGN-ORACLES-COMMON,SIGN-ORACLES-NOFPAC,AUTH-ORACLES-NOFPAC
 
-// Select one of "all" options:
+// Select one of preset options:
 //
+// RUN: llvm-bolt-binary-analysis --scanners=ptrauth-pac-ret %t.exe 2>&1 | \
+// RUN:     FileCheck %s --implicit-check-not="found in function" \
+// RUN:                  --check-prefixes=BACKWARD-CF,TAIL-CALLS-BASIC
 // RUN: llvm-bolt-binary-analysis --scanners=ptrauth-all %t.exe 2>&1 | \
 // RUN:     FileCheck %s --implicit-check-not="found in function" \
-// RUN:                  --check-prefixes=PACRET,TAIL-CALLS-COMMON,TAIL-CALLS-NOFPAC,FORWARD-CF,SIGN-ORACLES-COMMON,SIGN-ORACLES-NOFPAC,AUTH-ORACLES-NOFPAC
+// RUN:                  --check-prefixes=BACKWARD-CF,TAIL-CALLS-BASIC,TAIL-CALLS-NOFPAC-STRICT,FORWARD-CF,SIGN-ORACLES-COMMON,SIGN-ORACLES-NOFPAC,AUTH-ORACLES-NOFPAC
 // RUN: llvm-bolt-binary-analysis --scanners=all %t.exe 2>&1 | \
 // RUN:     FileCheck %s --implicit-check-not="found in function" \
-// RUN:                  --check-prefixes=PACRET,TAIL-CALLS-COMMON,TAIL-CALLS-NOFPAC,FORWARD-CF,SIGN-ORACLES-COMMON,SIGN-ORACLES-NOFPAC,AUTH-ORACLES-NOFPAC
+// RUN:                  --check-prefixes=BACKWARD-CF,TAIL-CALLS-BASIC,TAIL-CALLS-NOFPAC-STRICT,FORWARD-CF,SIGN-ORACLES-COMMON,SIGN-ORACLES-NOFPAC,AUTH-ORACLES-NOFPAC
 
 // Implicitly select all scanners by omitting --scanners=... argument.
 //
 // RUN: llvm-bolt-binary-analysis %t.exe 2>&1 | \
 // RUN:     FileCheck %s --implicit-check-not="found in function" \
-// RUN:                  --check-prefixes=PACRET,TAIL-CALLS-COMMON,TAIL-CALLS-NOFPAC,FORWARD-CF,SIGN-ORACLES-COMMON,SIGN-ORACLES-NOFPAC,AUTH-ORACLES-NOFPAC
+// RUN:                  --check-prefixes=BACKWARD-CF,TAIL-CALLS-BASIC,TAIL-CALLS-NOFPAC-STRICT,FORWARD-CF,SIGN-ORACLES-COMMON,SIGN-ORACLES-NOFPAC,AUTH-ORACLES-NOFPAC
 
 // Test FPAC handling:
 //
 // RUN: llvm-bolt-binary-analysis --auth-traps-on-failure --scanners=ptrauth-all %t.exe 2>&1 | \
 // RUN:     FileCheck %s --implicit-check-not="found in function" \
-// RUN:                  --check-prefixes=PACRET,TAIL-CALLS-COMMON,FORWARD-CF,SIGN-ORACLES-COMMON
+// RUN:                  --check-prefixes=BACKWARD-CF,TAIL-CALLS-BASIC,FORWARD-CF,SIGN-ORACLES-COMMON
 // RUN: llvm-bolt-binary-analysis --auth-traps-on-failure --scanners=ptrauth-auth-oracles %t.exe 2>&1 | \
 // RUN:     FileCheck %s --check-prefixes=NO-REPORTS
 
@@ -63,7 +69,7 @@ callee:
         .globl  bad_pacret
         .type   bad_pacret,@function
 bad_pacret:
-// PACRET: GS-PAUTH: non-protected ret found in function bad_pacret
+// BACKWARD-CF: GS-PAUTH: non-protected ret found in function bad_pacret
         stp     x29, x30, [sp, #-16]!
         mov     x29, sp
 
@@ -74,7 +80,7 @@ bad_pacret:
         .globl  bad_tail_call_common
         .type   bad_tail_call_common,@function
 bad_tail_call_common:
-// TAIL-CALLS-COMMON: GS-PAUTH: untrusted link register found before tail call in function bad_tail_call_common
+// TAIL-CALLS-BASIC: GS-PAUTH: unauthenticated link register found before tail call in function bad_tail_call_common
         stp     x29, x30, [sp, #-16]!
         mov     x29, sp
 
@@ -85,8 +91,8 @@ bad_tail_call_common:
         .globl  bad_tail_call_nofpac
         .type   bad_tail_call_nofpac,@function
 bad_tail_call_nofpac:
-// TAIL-CALLS-NOFPAC:   GS-PAUTH: untrusted link register found before tail call in function bad_tail_call_nofpac
-// AUTH-ORACLES-NOFPAC: GS-PAUTH: authentication oracle found in function bad_tail_call_nofpac
+// TAIL-CALLS-NOFPAC-STRICT: GS-PAUTH: not fully trusted link register found before tail call in function bad_tail_call_nofpac
+// AUTH-ORACLES-NOFPAC:      GS-PAUTH: authentication oracle found in function bad_tail_call_nofpac
         paciasp
         stp     x29, x30, [sp, #-16]!
         mov     x29, sp

--- a/bolt/test/binary-analysis/AArch64/gs-pauth-tail-calls.s
+++ b/bolt/test/binary-analysis/AArch64/gs-pauth-tail-calls.s
@@ -1,9 +1,14 @@
 // RUN: %clang %cflags -Wl,--entry=_custom_start -march=armv8.3-a %s -o %t.exe
-// RUN: llvm-bolt-binary-analysis --scanners=ptrauth-tail-calls                                %t.exe 2>&1 | FileCheck -check-prefixes=CHECK,FPAC %s
-// RUN: llvm-bolt-binary-analysis --scanners=ptrauth-tail-calls-strict --auth-traps-on-failure %t.exe 2>&1 | FileCheck -check-prefixes=CHECK,FPAC %s
-// RUN: llvm-bolt-binary-analysis --scanners=ptrauth-tail-calls-strict                         %t.exe 2>&1 | FileCheck -check-prefixes=CHECK,NOFPAC %s
-// RUN: llvm-bolt-binary-analysis --scanners=ptrauth-tail-calls-strict,ptrauth-auth-oracles    %t.exe 2>&1 | FileCheck -check-prefixes=CHECK,NOFPAC,AUTH-ORACLES %s
-// RUN: llvm-bolt-binary-analysis --scanners=ptrauth-all                                       %t.exe 2>&1 | FileCheck -check-prefixes=CHECK,PTRAUTH-ALL %s
+// RUN: llvm-bolt-binary-analysis --scanners=ptrauth-tail-calls                                %t.exe 2>&1 | \
+// RUN:     FileCheck %s --implicit-check-not=GS-PAUTH --check-prefixes=CHECK,TAIL-NOSTRICT
+// RUN: llvm-bolt-binary-analysis --scanners=ptrauth-tail-calls-strict --auth-traps-on-failure %t.exe 2>&1 | \
+// RUN:     FileCheck %s --implicit-check-not=GS-PAUTH --check-prefixes=CHECK,TAIL-NOSTRICT
+// RUN: llvm-bolt-binary-analysis --scanners=ptrauth-tail-calls-strict                         %t.exe 2>&1 | \
+// RUN:     FileCheck %s --implicit-check-not=GS-PAUTH --check-prefixes=CHECK,TAIL-STRICT
+// RUN: llvm-bolt-binary-analysis --scanners=ptrauth-tail-calls-strict,ptrauth-auth-oracles    %t.exe 2>&1 | \
+// RUN:     FileCheck %s --implicit-check-not=GS-PAUTH --check-prefixes=CHECK,TAIL-STRICT,AUTH-ORACLES
+// RUN: llvm-bolt-binary-analysis --scanners=ptrauth-all                                       %t.exe 2>&1 | \
+// RUN:     FileCheck %s --implicit-check-not=GS-PAUTH --check-prefixes=CHECK,TAIL-STRICT,AUTH-ORACLES,PTRAUTH-ALL
 
         .text
 
@@ -90,10 +95,10 @@ bad_indirect_tailcall_not_auted:
         .globl  bad_direct_tailcall_untrusted
         .type   bad_direct_tailcall_untrusted,@function
 bad_direct_tailcall_untrusted:
-// FPAC-NOT: bad_direct_tailcall_untrusted
-// NOFPAC-LABEL: GS-PAUTH: not fully trusted link register found before tail call in function bad_direct_tailcall_untrusted, basic block {{[^,]+}}, at address
-// NOFPAC-NEXT:  The instruction is     {{[0-9a-f]+}}:      b       callee # TAILCALL
-// NOFPAC-NEXT:  The 0 instructions that write to the affected registers after any authentication are:
+// TAIL-NOSTRICT-NOT: bad_direct_tailcall_untrusted
+// TAIL-STRICT-LABEL: GS-PAUTH: not fully trusted link register found before tail call in function bad_direct_tailcall_untrusted, basic block {{[^,]+}}, at address
+// TAIL-STRICT-NEXT:  The instruction is     {{[0-9a-f]+}}:      b       callee # TAILCALL
+// TAIL-STRICT-NEXT:  The 0 instructions that write to the affected registers after any authentication are:
 // AUTH-ORACLES-LABEL: GS-PAUTH: authentication oracle found in function bad_direct_tailcall_untrusted, basic block {{[^,]+}}, at address
 // AUTH-ORACLES-NEXT:  The instruction is     {{[0-9a-f]+}}:      autiasp
 // AUTH-ORACLES-NEXT:  The 1 instructions that leak the affected registers are:
@@ -116,10 +121,10 @@ bad_direct_tailcall_untrusted:
 bad_plt_tailcall_untrusted:
 // FIXME: Calls via PLT are disassembled incorrectly. Nevertheless, they are
 //        still detected as tail calls.
-// FPAC-NOT: bad_plt_tailcall_untrusted
-// NOFPAC-LABEL: GS-PAUTH: not fully trusted link register found before tail call in function bad_plt_tailcall_untrusted, basic block {{[^,]+}}, at address
-// NOFPAC-NEXT:  The instruction is     {{[0-9a-f]+}}:      b       bad_indirect_tailcall_untrusted # TAILCALL
-// NOFPAC-NEXT:  The 0 instructions that write to the affected registers after any authentication are:
+// TAIL-NOSTRICT-NOT: bad_plt_tailcall_untrusted
+// TAIL-STRICT-LABEL: GS-PAUTH: not fully trusted link register found before tail call in function bad_plt_tailcall_untrusted, basic block {{[^,]+}}, at address
+// TAIL-STRICT-NEXT:  The instruction is     {{[0-9a-f]+}}:      b       bad_indirect_tailcall_untrusted # TAILCALL
+// TAIL-STRICT-NEXT:  The 0 instructions that write to the affected registers after any authentication are:
 // AUTH-ORACLES-LABEL: GS-PAUTH: authentication oracle found in function bad_plt_tailcall_untrusted, basic block {{[^,]+}}, at address
 // AUTH-ORACLES-NEXT:  The instruction is     {{[0-9a-f]+}}:      autiasp
 // AUTH-ORACLES-NEXT:  The 1 instructions that leak the affected registers are:
@@ -140,10 +145,10 @@ bad_plt_tailcall_untrusted:
         .globl  bad_indirect_tailcall_untrusted
         .type   bad_indirect_tailcall_untrusted,@function
 bad_indirect_tailcall_untrusted:
-// FPAC-NOT: bad_indirect_tailcall_untrusted
-// NOFPAC-LABEL: GS-PAUTH: not fully trusted link register found before tail call in function bad_indirect_tailcall_untrusted, basic block {{[^,]+}}, at address
-// NOFPAC-NEXT:  The instruction is     {{[0-9a-f]+}}:      br      x0 # TAILCALL
-// NOFPAC-NEXT:  The 0 instructions that write to the affected registers after any authentication are:
+// TAIL-NOSTRICT-NOT: bad_indirect_tailcall_untrusted
+// TAIL-STRICT-LABEL: GS-PAUTH: not fully trusted link register found before tail call in function bad_indirect_tailcall_untrusted, basic block {{[^,]+}}, at address
+// TAIL-STRICT-NEXT:  The instruction is     {{[0-9a-f]+}}:      br      x0 # TAILCALL
+// TAIL-STRICT-NEXT:  The 0 instructions that write to the affected registers after any authentication are:
 // AUTH-ORACLES-LABEL: GS-PAUTH: authentication oracle found in function bad_indirect_tailcall_untrusted, basic block {{[^,]+}}, at address
 // AUTH-ORACLES-NEXT:  The instruction is     {{[0-9a-f]+}}:      autiasp
 // AUTH-ORACLES-NEXT:  The 1 instructions that leak the affected registers are:
@@ -255,10 +260,10 @@ bad_indirect_tailcall_not_auted_multi_bb:
         .globl  bad_direct_tailcall_untrusted_multi_bb
         .type   bad_direct_tailcall_untrusted_multi_bb,@function
 bad_direct_tailcall_untrusted_multi_bb:
-// FPAC-NOT: bad_direct_tailcall_untrusted_multi_bb
-// NOFPAC-LABEL: GS-PAUTH: not fully trusted link register found before tail call in function bad_direct_tailcall_untrusted_multi_bb, basic block {{[^,]+}}, at address
-// NOFPAC-NEXT:  The instruction is     {{[0-9a-f]+}}:      b       callee # TAILCALL
-// NOFPAC-NEXT:  The 0 instructions that write to the affected registers after any authentication are:
+// TAIL-NOSTRICT-NOT: bad_direct_tailcall_untrusted_multi_bb
+// TAIL-STRICT-LABEL: GS-PAUTH: not fully trusted link register found before tail call in function bad_direct_tailcall_untrusted_multi_bb, basic block {{[^,]+}}, at address
+// TAIL-STRICT-NEXT:  The instruction is     {{[0-9a-f]+}}:      b       callee # TAILCALL
+// TAIL-STRICT-NEXT:  The 0 instructions that write to the affected registers after any authentication are:
 // AUTH-ORACLES-LABEL: GS-PAUTH: authentication oracle found in function bad_direct_tailcall_untrusted_multi_bb, basic block {{[^,]+}}, at address
 // AUTH-ORACLES-NEXT:  The instruction is     {{[0-9a-f]+}}:      autiasp
 // AUTH-ORACLES-NEXT:  The 1 instructions that leak the affected registers are:
@@ -276,10 +281,10 @@ bad_direct_tailcall_untrusted_multi_bb:
         .globl  bad_indirect_tailcall_untrusted_multi_bb
         .type   bad_indirect_tailcall_untrusted_multi_bb,@function
 bad_indirect_tailcall_untrusted_multi_bb:
-// FPAC-NOT: bad_indirect_tailcall_untrusted_multi_bb
-// NOFPAC-LABEL: GS-PAUTH: not fully trusted link register found before tail call in function bad_indirect_tailcall_untrusted_multi_bb, basic block {{[^,]+}}, at address
-// NOFPAC-NEXT:  The instruction is     {{[0-9a-f]+}}:      br      x0 # UNKNOWN CONTROL FLOW
-// NOFPAC-NEXT:  The 0 instructions that write to the affected registers after any authentication are:
+// TAIL-NOSTRICT-NOT: bad_indirect_tailcall_untrusted_multi_bb
+// TAIL-STRICT-LABEL: GS-PAUTH: not fully trusted link register found before tail call in function bad_indirect_tailcall_untrusted_multi_bb, basic block {{[^,]+}}, at address
+// TAIL-STRICT-NEXT:  The instruction is     {{[0-9a-f]+}}:      br      x0 # UNKNOWN CONTROL FLOW
+// TAIL-STRICT-NEXT:  The 0 instructions that write to the affected registers after any authentication are:
 // AUTH-ORACLES-LABEL: GS-PAUTH: authentication oracle found in function bad_indirect_tailcall_untrusted_multi_bb, basic block {{[^,]+}}, at address
 // AUTH-ORACLES-NEXT:  The instruction is     {{[0-9a-f]+}}:      autiasp
 // AUTH-ORACLES-NEXT:  The 0 instructions that leak the affected registers are:
@@ -403,10 +408,10 @@ bad_indirect_tailcall_not_auted_nocfg:
         .globl  bad_direct_tailcall_untrusted_nocfg
         .type   bad_direct_tailcall_untrusted_nocfg,@function
 bad_direct_tailcall_untrusted_nocfg:
-// FPAC-NOT: bad_direct_tailcall_untrusted_nocfg
-// NOFPAC-LABEL: GS-PAUTH: not fully trusted link register found before tail call in function bad_direct_tailcall_untrusted_nocfg, at address
-// NOFPAC-NEXT:  The instruction is     {{[0-9a-f]+}}:      b       callee # TAILCALL
-// NOFPAC-NEXT:  The 0 instructions that write to the affected registers after any authentication are:
+// TAIL-NOSTRICT-NOT: bad_direct_tailcall_untrusted_nocfg
+// TAIL-STRICT-LABEL: GS-PAUTH: not fully trusted link register found before tail call in function bad_direct_tailcall_untrusted_nocfg, at address
+// TAIL-STRICT-NEXT:  The instruction is     {{[0-9a-f]+}}:      b       callee # TAILCALL
+// TAIL-STRICT-NEXT:  The 0 instructions that write to the affected registers after any authentication are:
 // AUTH-ORACLES-LABEL: GS-PAUTH: authentication oracle found in function bad_direct_tailcall_untrusted_nocfg, at address
 // AUTH-ORACLES-NEXT:  The instruction is     {{[0-9a-f]+}}:      autiasp
 // AUTH-ORACLES-NEXT:  The 1 instructions that leak the affected registers are:
@@ -426,10 +431,10 @@ bad_direct_tailcall_untrusted_nocfg:
 bad_plt_tailcall_untrusted_nocfg:
 // FIXME: Calls via PLT are disassembled incorrectly. Nevertheless, they are
 //        still detected as tail calls.
-// FPAC-NOT: bad_plt_tailcall_untrusted_nocfg
-// NOFPAC-LABEL: GS-PAUTH: not fully trusted link register found before tail call in function bad_plt_tailcall_untrusted_nocfg, at address
-// NOFPAC-NEXT:  The instruction is     {{[0-9a-f]+}}:      b       bad_indirect_tailcall_untrusted_nocfg # TAILCALL
-// NOFPAC-NEXT:  The 0 instructions that write to the affected registers after any authentication are:
+// TAIL-NOSTRICT-NOT: bad_plt_tailcall_untrusted_nocfg
+// TAIL-STRICT-LABEL: GS-PAUTH: not fully trusted link register found before tail call in function bad_plt_tailcall_untrusted_nocfg, at address
+// TAIL-STRICT-NEXT:  The instruction is     {{[0-9a-f]+}}:      b       bad_indirect_tailcall_untrusted_nocfg # TAILCALL
+// TAIL-STRICT-NEXT:  The 0 instructions that write to the affected registers after any authentication are:
 // AUTH-ORACLES-LABEL: GS-PAUTH: authentication oracle found in function bad_plt_tailcall_untrusted_nocfg, at address
 // AUTH-ORACLES-NEXT:  The instruction is     {{[0-9a-f]+}}:      autiasp
 // AUTH-ORACLES-NEXT:  The 1 instructions that leak the affected registers are:
@@ -449,12 +454,11 @@ bad_plt_tailcall_untrusted_nocfg:
 bad_indirect_tailcall_untrusted_nocfg:
 // Known false negative: ignoring UNKNOWN CONTROL FLOW without CFG.
 // Authentication oracle is found by a generic checker, though.
-// FPAC-NOT: bad_indirect_tailcall_untrusted_nocfg
-// NOFPAC-NOT: untrusted link register{{.*}}bad_indirect_tailcall_untrusted_nocfg
+// CHECK-NOT: bad_indirect_tailcall_untrusted_nocfg
 // AUTH-ORACLES-LABEL: GS-PAUTH: authentication oracle found in function bad_indirect_tailcall_untrusted_nocfg, at address
 // AUTH-ORACLES-NEXT:  The instruction is     {{[0-9a-f]+}}:      autiasp
 // AUTH-ORACLES-NEXT:  The 0 instructions that leak the affected registers are:
-// NOFPAC-NOT: untrusted link register{{.*}}bad_indirect_tailcall_untrusted_nocfg
+// CHECK-NOT: bad_indirect_tailcall_untrusted_nocfg
         paciasp
         stp     x29, x30, [sp, #-0x10]!
         adr     x3, 1f
@@ -524,10 +528,10 @@ good_indirect_tailcall_no_clobber_v83:
         .globl  bad_indirect_tailcall_untrusted_v83
         .type   bad_indirect_tailcall_untrusted_v83,@function
 bad_indirect_tailcall_untrusted_v83:
-// FPAC-NOT: bad_indirect_tailcall_untrusted_v83
-// NOFPAC-LABEL: GS-PAUTH: not fully trusted link register found before tail call in function bad_indirect_tailcall_untrusted_v83, basic block {{[^,]+}}, at address
-// NOFPAC-NEXT:  The instruction is     {{[0-9a-f]+}}:      braa    x0, x1 # TAILCALL
-// NOFPAC-NEXT:  The 0 instructions that write to the affected registers after any authentication are:
+// TAIL-NOSTRICT-NOT: bad_indirect_tailcall_untrusted_v83
+// TAIL-STRICT-LABEL: GS-PAUTH: not fully trusted link register found before tail call in function bad_indirect_tailcall_untrusted_v83, basic block {{[^,]+}}, at address
+// TAIL-STRICT-NEXT:  The instruction is     {{[0-9a-f]+}}:      braa    x0, x1 # TAILCALL
+// TAIL-STRICT-NEXT:  The 0 instructions that write to the affected registers after any authentication are:
 // AUTH-ORACLES-LABEL: GS-PAUTH: authentication oracle found in function bad_indirect_tailcall_untrusted_v83, basic block {{[^,]+}}, at address
 // AUTH-ORACLES-NEXT:  The instruction is     {{[0-9a-f]+}}:      autiasp
 // AUTH-ORACLES-NEXT:  The 1 instructions that leak the affected registers are:

--- a/bolt/test/binary-analysis/AArch64/gs-pauth-tail-calls.s
+++ b/bolt/test/binary-analysis/AArch64/gs-pauth-tail-calls.s
@@ -1,6 +1,9 @@
 // RUN: %clang %cflags -Wl,--entry=_custom_start -march=armv8.3-a %s -o %t.exe
-// RUN: llvm-bolt-binary-analysis --scanners=ptrauth-all --auth-traps-on-failure %t.exe 2>&1 | FileCheck -check-prefixes=CHECK,FPAC %s
-// RUN: llvm-bolt-binary-analysis --scanners=ptrauth-all                         %t.exe 2>&1 | FileCheck -check-prefixes=CHECK,NOFPAC %s
+// RUN: llvm-bolt-binary-analysis --scanners=ptrauth-tail-calls                                %t.exe 2>&1 | FileCheck -check-prefixes=CHECK,FPAC %s
+// RUN: llvm-bolt-binary-analysis --scanners=ptrauth-tail-calls-strict --auth-traps-on-failure %t.exe 2>&1 | FileCheck -check-prefixes=CHECK,FPAC %s
+// RUN: llvm-bolt-binary-analysis --scanners=ptrauth-tail-calls-strict                         %t.exe 2>&1 | FileCheck -check-prefixes=CHECK,NOFPAC %s
+// RUN: llvm-bolt-binary-analysis --scanners=ptrauth-tail-calls-strict,ptrauth-auth-oracles    %t.exe 2>&1 | FileCheck -check-prefixes=CHECK,NOFPAC,AUTH-ORACLES %s
+// RUN: llvm-bolt-binary-analysis --scanners=ptrauth-all                                       %t.exe 2>&1 | FileCheck -check-prefixes=CHECK,PTRAUTH-ALL %s
 
         .text
 
@@ -35,7 +38,7 @@ good_indirect_tailcall_no_clobber:
         .globl  bad_direct_tailcall_not_auted
         .type   bad_direct_tailcall_not_auted,@function
 bad_direct_tailcall_not_auted:
-// CHECK-LABEL: GS-PAUTH: untrusted link register found before tail call in function bad_direct_tailcall_not_auted, basic block {{[^,]+}}, at address
+// CHECK-LABEL: GS-PAUTH: unauthenticated link register found before tail call in function bad_direct_tailcall_not_auted, basic block {{[^,]+}}, at address
 // CHECK-NEXT:  The instruction is     {{[0-9a-f]+}}:      b       callee # TAILCALL
 // CHECK-NEXT:  The 1 instructions that write to the affected registers after any authentication are:
 // CHECK-NEXT:  1.     {{[0-9a-f]+}}:      ldp     x29, x30, [sp], #0x10
@@ -53,7 +56,7 @@ bad_direct_tailcall_not_auted:
 bad_plt_tailcall_not_auted:
 // FIXME: Calls via PLT are disassembled incorrectly. Nevertheless, they are
 //        still detected as tail calls.
-// CHECK-LABEL: GS-PAUTH: untrusted link register found before tail call in function bad_plt_tailcall_not_auted, basic block {{[^,]+}}, at address
+// CHECK-LABEL: GS-PAUTH: unauthenticated link register found before tail call in function bad_plt_tailcall_not_auted, basic block {{[^,]+}}, at address
 // CHECK-NEXT:  The instruction is     {{[0-9a-f]+}}:      b       bad_indirect_tailcall_not_auted # TAILCALL
 // CHECK-NEXT:  The 1 instructions that write to the affected registers after any authentication are:
 // CHECK-NEXT:  1.     {{[0-9a-f]+}}:      ldp     x29, x30, [sp], #0x10
@@ -69,7 +72,7 @@ bad_plt_tailcall_not_auted:
         .globl  bad_indirect_tailcall_not_auted
         .type   bad_indirect_tailcall_not_auted,@function
 bad_indirect_tailcall_not_auted:
-// CHECK-LABEL: GS-PAUTH: untrusted link register found before tail call in function bad_indirect_tailcall_not_auted, basic block {{[^,]+}}, at address
+// CHECK-LABEL: GS-PAUTH: unauthenticated link register found before tail call in function bad_indirect_tailcall_not_auted, basic block {{[^,]+}}, at address
 // CHECK-NEXT:  The instruction is     {{[0-9a-f]+}}:      br      x0 # TAILCALL
 // CHECK-NEXT:  The 1 instructions that write to the affected registers after any authentication are:
 // CHECK-NEXT:  1.     {{[0-9a-f]+}}:      ldp     x29, x30, [sp], #0x10
@@ -88,19 +91,19 @@ bad_indirect_tailcall_not_auted:
         .type   bad_direct_tailcall_untrusted,@function
 bad_direct_tailcall_untrusted:
 // FPAC-NOT: bad_direct_tailcall_untrusted
-// NOFPAC-LABEL: GS-PAUTH: untrusted link register found before tail call in function bad_direct_tailcall_untrusted, basic block {{[^,]+}}, at address
+// NOFPAC-LABEL: GS-PAUTH: not fully trusted link register found before tail call in function bad_direct_tailcall_untrusted, basic block {{[^,]+}}, at address
 // NOFPAC-NEXT:  The instruction is     {{[0-9a-f]+}}:      b       callee # TAILCALL
 // NOFPAC-NEXT:  The 0 instructions that write to the affected registers after any authentication are:
-// NOFPAC-LABEL: GS-PAUTH: authentication oracle found in function bad_direct_tailcall_untrusted, basic block {{[^,]+}}, at address
-// NOFPAC-NEXT:  The instruction is     {{[0-9a-f]+}}:      autiasp
-// NOFPAC-NEXT:  The 1 instructions that leak the affected registers are:
-// NOFPAC-NEXT:  1.     {{[0-9a-f]+}}:      b       callee # TAILCALL
-// NOFPAC-NEXT:  This happens in the following basic block:
-// NOFPAC-NEXT:  {{[0-9a-f]+}}:   paciasp
-// NOFPAC-NEXT:  {{[0-9a-f]+}}:   stp     x29, x30, [sp, #-0x10]!
-// NOFPAC-NEXT:  {{[0-9a-f]+}}:   ldp     x29, x30, [sp], #0x10
-// NOFPAC-NEXT:  {{[0-9a-f]+}}:   autiasp
-// NOFPAC-NEXT:  {{[0-9a-f]+}}:   b       callee # TAILCALL
+// AUTH-ORACLES-LABEL: GS-PAUTH: authentication oracle found in function bad_direct_tailcall_untrusted, basic block {{[^,]+}}, at address
+// AUTH-ORACLES-NEXT:  The instruction is     {{[0-9a-f]+}}:      autiasp
+// AUTH-ORACLES-NEXT:  The 1 instructions that leak the affected registers are:
+// AUTH-ORACLES-NEXT:  1.     {{[0-9a-f]+}}:      b       callee # TAILCALL
+// AUTH-ORACLES-NEXT:  This happens in the following basic block:
+// AUTH-ORACLES-NEXT:  {{[0-9a-f]+}}:   paciasp
+// AUTH-ORACLES-NEXT:  {{[0-9a-f]+}}:   stp     x29, x30, [sp, #-0x10]!
+// AUTH-ORACLES-NEXT:  {{[0-9a-f]+}}:   ldp     x29, x30, [sp], #0x10
+// AUTH-ORACLES-NEXT:  {{[0-9a-f]+}}:   autiasp
+// AUTH-ORACLES-NEXT:  {{[0-9a-f]+}}:   b       callee # TAILCALL
         paciasp
         stp     x29, x30, [sp, #-0x10]!
         ldp     x29, x30, [sp], #0x10
@@ -114,19 +117,19 @@ bad_plt_tailcall_untrusted:
 // FIXME: Calls via PLT are disassembled incorrectly. Nevertheless, they are
 //        still detected as tail calls.
 // FPAC-NOT: bad_plt_tailcall_untrusted
-// NOFPAC-LABEL: GS-PAUTH: untrusted link register found before tail call in function bad_plt_tailcall_untrusted, basic block {{[^,]+}}, at address
+// NOFPAC-LABEL: GS-PAUTH: not fully trusted link register found before tail call in function bad_plt_tailcall_untrusted, basic block {{[^,]+}}, at address
 // NOFPAC-NEXT:  The instruction is     {{[0-9a-f]+}}:      b       bad_indirect_tailcall_untrusted # TAILCALL
 // NOFPAC-NEXT:  The 0 instructions that write to the affected registers after any authentication are:
-// NOFPAC-LABEL: GS-PAUTH: authentication oracle found in function bad_plt_tailcall_untrusted, basic block {{[^,]+}}, at address
-// NOFPAC-NEXT:  The instruction is     {{[0-9a-f]+}}:      autiasp
-// NOFPAC-NEXT:  The 1 instructions that leak the affected registers are:
-// NOFPAC-NEXT:  1.     {{[0-9a-f]+}}:      b       bad_indirect_tailcall_untrusted # TAILCALL
-// NOFPAC-NEXT:  This happens in the following basic block:
-// NOFPAC-NEXT:  {{[0-9a-f]+}}:   paciasp
-// NOFPAC-NEXT:  {{[0-9a-f]+}}:   stp     x29, x30, [sp, #-0x10]!
-// NOFPAC-NEXT:  {{[0-9a-f]+}}:   ldp     x29, x30, [sp], #0x10
-// NOFPAC-NEXT:  {{[0-9a-f]+}}:   autiasp
-// NOFPAC-NEXT:  {{[0-9a-f]+}}:   b       bad_indirect_tailcall_untrusted # TAILCALL
+// AUTH-ORACLES-LABEL: GS-PAUTH: authentication oracle found in function bad_plt_tailcall_untrusted, basic block {{[^,]+}}, at address
+// AUTH-ORACLES-NEXT:  The instruction is     {{[0-9a-f]+}}:      autiasp
+// AUTH-ORACLES-NEXT:  The 1 instructions that leak the affected registers are:
+// AUTH-ORACLES-NEXT:  1.     {{[0-9a-f]+}}:      b       bad_indirect_tailcall_untrusted # TAILCALL
+// AUTH-ORACLES-NEXT:  This happens in the following basic block:
+// AUTH-ORACLES-NEXT:  {{[0-9a-f]+}}:   paciasp
+// AUTH-ORACLES-NEXT:  {{[0-9a-f]+}}:   stp     x29, x30, [sp, #-0x10]!
+// AUTH-ORACLES-NEXT:  {{[0-9a-f]+}}:   ldp     x29, x30, [sp], #0x10
+// AUTH-ORACLES-NEXT:  {{[0-9a-f]+}}:   autiasp
+// AUTH-ORACLES-NEXT:  {{[0-9a-f]+}}:   b       bad_indirect_tailcall_untrusted # TAILCALL
         paciasp
         stp     x29, x30, [sp, #-0x10]!
         ldp     x29, x30, [sp], #0x10
@@ -138,20 +141,20 @@ bad_plt_tailcall_untrusted:
         .type   bad_indirect_tailcall_untrusted,@function
 bad_indirect_tailcall_untrusted:
 // FPAC-NOT: bad_indirect_tailcall_untrusted
-// NOFPAC-LABEL: GS-PAUTH: untrusted link register found before tail call in function bad_indirect_tailcall_untrusted, basic block {{[^,]+}}, at address
+// NOFPAC-LABEL: GS-PAUTH: not fully trusted link register found before tail call in function bad_indirect_tailcall_untrusted, basic block {{[^,]+}}, at address
 // NOFPAC-NEXT:  The instruction is     {{[0-9a-f]+}}:      br      x0 # TAILCALL
 // NOFPAC-NEXT:  The 0 instructions that write to the affected registers after any authentication are:
-// NOFPAC-LABEL: GS-PAUTH: authentication oracle found in function bad_indirect_tailcall_untrusted, basic block {{[^,]+}}, at address
-// NOFPAC-NEXT:  The instruction is     {{[0-9a-f]+}}:      autiasp
-// NOFPAC-NEXT:  The 1 instructions that leak the affected registers are:
-// NOFPAC-NEXT:  1.     {{[0-9a-f]+}}:      br      x0 # TAILCALL
-// NOFPAC-NEXT:  This happens in the following basic block:
-// NOFPAC-NEXT:  {{[0-9a-f]+}}:   paciasp
-// NOFPAC-NEXT:  {{[0-9a-f]+}}:   stp     x29, x30, [sp, #-0x10]!
-// NOFPAC-NEXT:  {{[0-9a-f]+}}:   ldp     x29, x30, [sp], #0x10
-// NOFPAC-NEXT:  {{[0-9a-f]+}}:   autiasp
-// NOFPAC-NEXT:  {{[0-9a-f]+}}:   autia   x0, x1
-// NOFPAC-NEXT:  {{[0-9a-f]+}}:   br      x0 # TAILCALL
+// AUTH-ORACLES-LABEL: GS-PAUTH: authentication oracle found in function bad_indirect_tailcall_untrusted, basic block {{[^,]+}}, at address
+// AUTH-ORACLES-NEXT:  The instruction is     {{[0-9a-f]+}}:      autiasp
+// AUTH-ORACLES-NEXT:  The 1 instructions that leak the affected registers are:
+// AUTH-ORACLES-NEXT:  1.     {{[0-9a-f]+}}:      br      x0 # TAILCALL
+// AUTH-ORACLES-NEXT:  This happens in the following basic block:
+// AUTH-ORACLES-NEXT:  {{[0-9a-f]+}}:   paciasp
+// AUTH-ORACLES-NEXT:  {{[0-9a-f]+}}:   stp     x29, x30, [sp, #-0x10]!
+// AUTH-ORACLES-NEXT:  {{[0-9a-f]+}}:   ldp     x29, x30, [sp], #0x10
+// AUTH-ORACLES-NEXT:  {{[0-9a-f]+}}:   autiasp
+// AUTH-ORACLES-NEXT:  {{[0-9a-f]+}}:   autia   x0, x1
+// AUTH-ORACLES-NEXT:  {{[0-9a-f]+}}:   br      x0 # TAILCALL
         paciasp
         stp     x29, x30, [sp, #-0x10]!
         ldp     x29, x30, [sp], #0x10
@@ -219,7 +222,7 @@ good_indirect_tailcall_no_clobber_multi_bb:
         .globl  bad_direct_tailcall_not_auted_multi_bb
         .type   bad_direct_tailcall_not_auted_multi_bb,@function
 bad_direct_tailcall_not_auted_multi_bb:
-// CHECK-LABEL: GS-PAUTH: untrusted link register found before tail call in function bad_direct_tailcall_not_auted_multi_bb, basic block {{[^,]+}}, at address
+// CHECK-LABEL: GS-PAUTH: unauthenticated link register found before tail call in function bad_direct_tailcall_not_auted_multi_bb, basic block {{[^,]+}}, at address
 // CHECK-NEXT:  The instruction is     {{[0-9a-f]+}}:      b       callee # TAILCALL
 // CHECK-NEXT:  The 1 instructions that write to the affected registers after any authentication are:
 // CHECK-NEXT:  1.     {{[0-9a-f]+}}:      ldp     x29, x30, [sp], #0x10
@@ -235,7 +238,7 @@ bad_direct_tailcall_not_auted_multi_bb:
         .globl  bad_indirect_tailcall_not_auted_multi_bb
         .type   bad_indirect_tailcall_not_auted_multi_bb,@function
 bad_indirect_tailcall_not_auted_multi_bb:
-// CHECK-LABEL: GS-PAUTH: untrusted link register found before tail call in function bad_indirect_tailcall_not_auted_multi_bb, basic block {{[^,]+}}, at address
+// CHECK-LABEL: GS-PAUTH: unauthenticated link register found before tail call in function bad_indirect_tailcall_not_auted_multi_bb, basic block {{[^,]+}}, at address
 // CHECK-NEXT:  The instruction is     {{[0-9a-f]+}}:      br      x0 # UNKNOWN CONTROL FLOW
 // CHECK-NEXT:  The 1 instructions that write to the affected registers after any authentication are:
 // CHECK-NEXT:  1.     {{[0-9a-f]+}}:      ldp     x29, x30, [sp], #0x10
@@ -253,13 +256,13 @@ bad_indirect_tailcall_not_auted_multi_bb:
         .type   bad_direct_tailcall_untrusted_multi_bb,@function
 bad_direct_tailcall_untrusted_multi_bb:
 // FPAC-NOT: bad_direct_tailcall_untrusted_multi_bb
-// NOFPAC-LABEL: GS-PAUTH: untrusted link register found before tail call in function bad_direct_tailcall_untrusted_multi_bb, basic block {{[^,]+}}, at address
+// NOFPAC-LABEL: GS-PAUTH: not fully trusted link register found before tail call in function bad_direct_tailcall_untrusted_multi_bb, basic block {{[^,]+}}, at address
 // NOFPAC-NEXT:  The instruction is     {{[0-9a-f]+}}:      b       callee # TAILCALL
 // NOFPAC-NEXT:  The 0 instructions that write to the affected registers after any authentication are:
-// NOFPAC-LABEL: GS-PAUTH: authentication oracle found in function bad_direct_tailcall_untrusted_multi_bb, basic block {{[^,]+}}, at address
-// NOFPAC-NEXT:  The instruction is     {{[0-9a-f]+}}:      autiasp
-// NOFPAC-NEXT:  The 1 instructions that leak the affected registers are:
-// NOFPAC-NEXT:  1.     {{[0-9a-f]+}}:      b       callee # TAILCALL
+// AUTH-ORACLES-LABEL: GS-PAUTH: authentication oracle found in function bad_direct_tailcall_untrusted_multi_bb, basic block {{[^,]+}}, at address
+// AUTH-ORACLES-NEXT:  The instruction is     {{[0-9a-f]+}}:      autiasp
+// AUTH-ORACLES-NEXT:  The 1 instructions that leak the affected registers are:
+// AUTH-ORACLES-NEXT:  1.     {{[0-9a-f]+}}:      b       callee # TAILCALL
         paciasp
         stp     x29, x30, [sp, #-0x10]!
         ldp     x29, x30, [sp], #0x10
@@ -274,12 +277,12 @@ bad_direct_tailcall_untrusted_multi_bb:
         .type   bad_indirect_tailcall_untrusted_multi_bb,@function
 bad_indirect_tailcall_untrusted_multi_bb:
 // FPAC-NOT: bad_indirect_tailcall_untrusted_multi_bb
-// NOFPAC-LABEL: GS-PAUTH: untrusted link register found before tail call in function bad_indirect_tailcall_untrusted_multi_bb, basic block {{[^,]+}}, at address
+// NOFPAC-LABEL: GS-PAUTH: not fully trusted link register found before tail call in function bad_indirect_tailcall_untrusted_multi_bb, basic block {{[^,]+}}, at address
 // NOFPAC-NEXT:  The instruction is     {{[0-9a-f]+}}:      br      x0 # UNKNOWN CONTROL FLOW
 // NOFPAC-NEXT:  The 0 instructions that write to the affected registers after any authentication are:
-// NOFPAC-LABEL: GS-PAUTH: authentication oracle found in function bad_indirect_tailcall_untrusted_multi_bb, basic block {{[^,]+}}, at address
-// NOFPAC-NEXT:  The instruction is     {{[0-9a-f]+}}:      autiasp
-// NOFPAC-NEXT:  The 0 instructions that leak the affected registers are:
+// AUTH-ORACLES-LABEL: GS-PAUTH: authentication oracle found in function bad_indirect_tailcall_untrusted_multi_bb, basic block {{[^,]+}}, at address
+// AUTH-ORACLES-NEXT:  The instruction is     {{[0-9a-f]+}}:      autiasp
+// AUTH-ORACLES-NEXT:  The 0 instructions that leak the affected registers are:
         paciasp
         stp     x29, x30, [sp, #-0x10]!
         ldp     x29, x30, [sp], #0x10
@@ -354,7 +357,7 @@ good_indirect_tailcall_no_clobber_nocfg:
         .globl  bad_direct_tailcall_not_auted_nocfg
         .type   bad_direct_tailcall_not_auted_nocfg,@function
 bad_direct_tailcall_not_auted_nocfg:
-// CHECK-LABEL: GS-PAUTH: untrusted link register found before tail call in function bad_direct_tailcall_not_auted_nocfg, at address
+// CHECK-LABEL: GS-PAUTH: unauthenticated link register found before tail call in function bad_direct_tailcall_not_auted_nocfg, at address
 // CHECK-NEXT:  The instruction is     {{[0-9a-f]+}}:      b       callee # TAILCALL
 // CHECK-NEXT:  The 1 instructions that write to the affected registers after any authentication are:
 // CHECK-NEXT:  1.     {{[0-9a-f]+}}:      ldp     x29, x30, [sp], #0x10
@@ -371,7 +374,7 @@ bad_direct_tailcall_not_auted_nocfg:
 bad_plt_tailcall_not_auted_nocfg:
 // FIXME: Calls via PLT are disassembled incorrectly. Nevertheless, they are
 //        still detected as tail calls.
-// CHECK-LABEL: GS-PAUTH: untrusted link register found before tail call in function bad_plt_tailcall_not_auted_nocfg, at address
+// CHECK-LABEL: GS-PAUTH: unauthenticated link register found before tail call in function bad_plt_tailcall_not_auted_nocfg, at address
 // CHECK-NEXT:  The instruction is     {{[0-9a-f]+}}:      b       bad_indirect_tailcall_not_auted_nocfg # TAILCALL
 // CHECK-NEXT:  The 1 instructions that write to the affected registers after any authentication are:
 // CHECK-NEXT:  1.     {{[0-9a-f]+}}:      ldp     x29, x30, [sp], #0x10
@@ -401,13 +404,13 @@ bad_indirect_tailcall_not_auted_nocfg:
         .type   bad_direct_tailcall_untrusted_nocfg,@function
 bad_direct_tailcall_untrusted_nocfg:
 // FPAC-NOT: bad_direct_tailcall_untrusted_nocfg
-// NOFPAC-LABEL: GS-PAUTH: untrusted link register found before tail call in function bad_direct_tailcall_untrusted_nocfg, at address
+// NOFPAC-LABEL: GS-PAUTH: not fully trusted link register found before tail call in function bad_direct_tailcall_untrusted_nocfg, at address
 // NOFPAC-NEXT:  The instruction is     {{[0-9a-f]+}}:      b       callee # TAILCALL
 // NOFPAC-NEXT:  The 0 instructions that write to the affected registers after any authentication are:
-// NOFPAC-LABEL: GS-PAUTH: authentication oracle found in function bad_direct_tailcall_untrusted_nocfg, at address
-// NOFPAC-NEXT:  The instruction is     {{[0-9a-f]+}}:      autiasp
-// NOFPAC-NEXT:  The 1 instructions that leak the affected registers are:
-// NOFPAC-NEXT:  1.     {{[0-9a-f]+}}:      b       callee # TAILCALL
+// AUTH-ORACLES-LABEL: GS-PAUTH: authentication oracle found in function bad_direct_tailcall_untrusted_nocfg, at address
+// AUTH-ORACLES-NEXT:  The instruction is     {{[0-9a-f]+}}:      autiasp
+// AUTH-ORACLES-NEXT:  The 1 instructions that leak the affected registers are:
+// AUTH-ORACLES-NEXT:  1.     {{[0-9a-f]+}}:      b       callee # TAILCALL
         paciasp
         stp     x29, x30, [sp, #-0x10]!
         adr     x3, 1f
@@ -424,13 +427,13 @@ bad_plt_tailcall_untrusted_nocfg:
 // FIXME: Calls via PLT are disassembled incorrectly. Nevertheless, they are
 //        still detected as tail calls.
 // FPAC-NOT: bad_plt_tailcall_untrusted_nocfg
-// NOFPAC-LABEL: GS-PAUTH: untrusted link register found before tail call in function bad_plt_tailcall_untrusted_nocfg, at address
+// NOFPAC-LABEL: GS-PAUTH: not fully trusted link register found before tail call in function bad_plt_tailcall_untrusted_nocfg, at address
 // NOFPAC-NEXT:  The instruction is     {{[0-9a-f]+}}:      b       bad_indirect_tailcall_untrusted_nocfg # TAILCALL
 // NOFPAC-NEXT:  The 0 instructions that write to the affected registers after any authentication are:
-// NOFPAC-LABEL: GS-PAUTH: authentication oracle found in function bad_plt_tailcall_untrusted_nocfg, at address
-// NOFPAC-NEXT:  The instruction is     {{[0-9a-f]+}}:      autiasp
-// NOFPAC-NEXT:  The 1 instructions that leak the affected registers are:
-// NOFPAC-NEXT:  1.     {{[0-9a-f]+}}:      b       bad_indirect_tailcall_untrusted_nocfg # TAILCALL
+// AUTH-ORACLES-LABEL: GS-PAUTH: authentication oracle found in function bad_plt_tailcall_untrusted_nocfg, at address
+// AUTH-ORACLES-NEXT:  The instruction is     {{[0-9a-f]+}}:      autiasp
+// AUTH-ORACLES-NEXT:  The 1 instructions that leak the affected registers are:
+// AUTH-ORACLES-NEXT:  1.     {{[0-9a-f]+}}:      b       bad_indirect_tailcall_untrusted_nocfg # TAILCALL
         paciasp
         stp     x29, x30, [sp, #-0x10]!
         adr     x3, 1f
@@ -448,9 +451,9 @@ bad_indirect_tailcall_untrusted_nocfg:
 // Authentication oracle is found by a generic checker, though.
 // FPAC-NOT: bad_indirect_tailcall_untrusted_nocfg
 // NOFPAC-NOT: untrusted link register{{.*}}bad_indirect_tailcall_untrusted_nocfg
-// NOFPAC-LABEL: GS-PAUTH: authentication oracle found in function bad_indirect_tailcall_untrusted_nocfg, at address
-// NOFPAC-NEXT:  The instruction is     {{[0-9a-f]+}}:      autiasp
-// NOFPAC-NEXT:  The 0 instructions that leak the affected registers are:
+// AUTH-ORACLES-LABEL: GS-PAUTH: authentication oracle found in function bad_indirect_tailcall_untrusted_nocfg, at address
+// AUTH-ORACLES-NEXT:  The instruction is     {{[0-9a-f]+}}:      autiasp
+// AUTH-ORACLES-NEXT:  The 0 instructions that leak the affected registers are:
 // NOFPAC-NOT: untrusted link register{{.*}}bad_indirect_tailcall_untrusted_nocfg
         paciasp
         stp     x29, x30, [sp, #-0x10]!
@@ -522,19 +525,19 @@ good_indirect_tailcall_no_clobber_v83:
         .type   bad_indirect_tailcall_untrusted_v83,@function
 bad_indirect_tailcall_untrusted_v83:
 // FPAC-NOT: bad_indirect_tailcall_untrusted_v83
-// NOFPAC-LABEL: GS-PAUTH: untrusted link register found before tail call in function bad_indirect_tailcall_untrusted_v83, basic block {{[^,]+}}, at address
+// NOFPAC-LABEL: GS-PAUTH: not fully trusted link register found before tail call in function bad_indirect_tailcall_untrusted_v83, basic block {{[^,]+}}, at address
 // NOFPAC-NEXT:  The instruction is     {{[0-9a-f]+}}:      braa    x0, x1 # TAILCALL
 // NOFPAC-NEXT:  The 0 instructions that write to the affected registers after any authentication are:
-// NOFPAC-LABEL: GS-PAUTH: authentication oracle found in function bad_indirect_tailcall_untrusted_v83, basic block {{[^,]+}}, at address
-// NOFPAC-NEXT:  The instruction is     {{[0-9a-f]+}}:      autiasp
-// NOFPAC-NEXT:  The 1 instructions that leak the affected registers are:
-// NOFPAC-NEXT:  1.     {{[0-9a-f]+}}:      braa    x0, x1 # TAILCALL
-// NOFPAC-NEXT:  This happens in the following basic block:
-// NOFPAC-NEXT:  {{[0-9a-f]+}}:   paciasp
-// NOFPAC-NEXT:  {{[0-9a-f]+}}:   stp     x29, x30, [sp, #-0x10]!
-// NOFPAC-NEXT:  {{[0-9a-f]+}}:   ldp     x29, x30, [sp], #0x10
-// NOFPAC-NEXT:  {{[0-9a-f]+}}:   autiasp
-// NOFPAC-NEXT:  {{[0-9a-f]+}}:   braa    x0, x1 # TAILCALL
+// AUTH-ORACLES-LABEL: GS-PAUTH: authentication oracle found in function bad_indirect_tailcall_untrusted_v83, basic block {{[^,]+}}, at address
+// AUTH-ORACLES-NEXT:  The instruction is     {{[0-9a-f]+}}:      autiasp
+// AUTH-ORACLES-NEXT:  The 1 instructions that leak the affected registers are:
+// AUTH-ORACLES-NEXT:  1.     {{[0-9a-f]+}}:      braa    x0, x1 # TAILCALL
+// AUTH-ORACLES-NEXT:  This happens in the following basic block:
+// AUTH-ORACLES-NEXT:  {{[0-9a-f]+}}:   paciasp
+// AUTH-ORACLES-NEXT:  {{[0-9a-f]+}}:   stp     x29, x30, [sp, #-0x10]!
+// AUTH-ORACLES-NEXT:  {{[0-9a-f]+}}:   ldp     x29, x30, [sp], #0x10
+// AUTH-ORACLES-NEXT:  {{[0-9a-f]+}}:   autiasp
+// AUTH-ORACLES-NEXT:  {{[0-9a-f]+}}:   braa    x0, x1 # TAILCALL
         paciasp
         stp     x29, x30, [sp, #-0x10]!
         ldp     x29, x30, [sp], #0x10
@@ -548,7 +551,7 @@ bad_indirect_tailcall_untrusted_v83:
         .globl  _start
         .type   _start,@function
 _start:
-// CHECK-LABEL: GS-PAUTH: untrusted link register found before tail call in function _start, basic block {{[^,]+}}, at address
+// CHECK-LABEL: GS-PAUTH: unauthenticated link register found before tail call in function _start, basic block {{[^,]+}}, at address
 // CHECK-NEXT:  The instruction is     {{[0-9a-f]+}}:      b       callee # TAILCALL
 // CHECK-NEXT:  The 1 instructions that write to the affected registers after any authentication are:
 // CHECK-NEXT:  1.     {{[0-9a-f]+}}:      mov     x30, #0x0
@@ -572,7 +575,7 @@ _custom_start:
         .globl  bad_non_protected_indirect_tailcall_not_auted
         .type   bad_non_protected_indirect_tailcall_not_auted,@function
 bad_non_protected_indirect_tailcall_not_auted:
-// CHECK-LABEL: GS-PAUTH: untrusted link register found before tail call in function bad_non_protected_indirect_tailcall_not_auted, basic block {{[^,]+}}, at address
+// CHECK-LABEL: GS-PAUTH: unauthenticated link register found before tail call in function bad_non_protected_indirect_tailcall_not_auted, basic block {{[^,]+}}, at address
 // CHECK-NEXT:  The instruction is     {{[0-9a-f]+}}:      br      x0 # TAILCALL
 // CHECK-NEXT:  The 1 instructions that write to the affected registers after any authentication are:
 // CHECK-NEXT:  1.     {{[0-9a-f]+}}:      ldp     x29, x30, [sp], #0x10
@@ -581,15 +584,15 @@ bad_non_protected_indirect_tailcall_not_auted:
 // CHECK-NEXT:  {{[0-9a-f]+}}:   ldp     x29, x30, [sp], #0x10
 // CHECK-NEXT:  {{[0-9a-f]+}}:   ldr     x0, [x1]
 // CHECK-NEXT:  {{[0-9a-f]+}}:   br      x0 # TAILCALL
-// CHECK-LABEL: GS-PAUTH: non-protected call found in function bad_non_protected_indirect_tailcall_not_auted, basic block {{[^,]+}}, at address
-// CHECK-NEXT:  The instruction is     {{[0-9a-f]+}}:      br      x0 # TAILCALL
-// CHECK-NEXT:  The 1 instructions that write to the affected registers after any authentication are:
-// CHECK-NEXT:  1.     {{[0-9a-f]+}}:      ldr     x0, [x1]
-// CHECK-NEXT:  This happens in the following basic block:
-// CHECK-NEXT:  {{[0-9a-f]+}}:   stp     x29, x30, [sp, #-0x10]!
-// CHECK-NEXT:  {{[0-9a-f]+}}:   ldp     x29, x30, [sp], #0x10
-// CHECK-NEXT:  {{[0-9a-f]+}}:   ldr     x0, [x1]
-// CHECK-NEXT:  {{[0-9a-f]+}}:   br      x0 # TAILCALL
+// PTRAUTH-ALL-LABEL: GS-PAUTH: non-protected call found in function bad_non_protected_indirect_tailcall_not_auted, basic block {{[^,]+}}, at address
+// PTRAUTH-ALL-NEXT:  The instruction is     {{[0-9a-f]+}}:      br      x0 # TAILCALL
+// PTRAUTH-ALL-NEXT:  The 1 instructions that write to the affected registers after any authentication are:
+// PTRAUTH-ALL-NEXT:  1.     {{[0-9a-f]+}}:      ldr     x0, [x1]
+// PTRAUTH-ALL-NEXT:  This happens in the following basic block:
+// PTRAUTH-ALL-NEXT:  {{[0-9a-f]+}}:   stp     x29, x30, [sp, #-0x10]!
+// PTRAUTH-ALL-NEXT:  {{[0-9a-f]+}}:   ldp     x29, x30, [sp], #0x10
+// PTRAUTH-ALL-NEXT:  {{[0-9a-f]+}}:   ldr     x0, [x1]
+// PTRAUTH-ALL-NEXT:  {{[0-9a-f]+}}:   br      x0 # TAILCALL
         stp     x29, x30, [sp, #-0x10]!
         ldp     x29, x30, [sp], #0x10
         ldr     x0, [x1]


### PR DESCRIPTION
During tail call, it may be worth making sure the link register is as
trusted as during a regular call, though it may require inserting
expensive checking code by the compiler.

On the other hand, with pac-ret hardening enabled, there should be no
reason not to protect tail-calling functions at least as well as those
exited via regular return instruction.

This commit splits tail call checker into two versions: the basic one
which is suitable to make sure regular `PAC*` + `AUT*` are emitted as
needed, and the strict one, that additionally ensures the authentication
(if any) succeeded.

Resolves #186204.