### PR TITLE
[lldb] Remove data_offset arg from GetModuleSpecifications

### DIFF
--- a/lldb/include/lldb/Expression/ObjectFileJIT.h
+++ b/lldb/include/lldb/Expression/ObjectFileJIT.h
@@ -61,7 +61,6 @@ public:
   static ModuleSpecList
   GetModuleSpecifications(const lldb_private::FileSpec &file,
                           lldb::DataExtractorSP &extractor_sp,
-                          lldb::offset_t data_offset,
                           lldb::offset_t file_offset, lldb::offset_t length);
 
   // LLVM RTTI support

--- a/lldb/include/lldb/Symbol/ObjectFile.h
+++ b/lldb/include/lldb/Symbol/ObjectFile.h
@@ -182,7 +182,6 @@ public:
   static ModuleSpecList
   GetModuleSpecifications(const lldb_private::FileSpec &file,
                           lldb::DataExtractorSP &extractor_sp,
-                          lldb::offset_t data_offset,
                           lldb::offset_t file_offset, lldb::offset_t file_size);
   static bool IsObjectFile(lldb_private::FileSpec file_spec);
   /// Split a path into a file path with object name.

--- a/lldb/include/lldb/lldb-private-interfaces.h
+++ b/lldb/include/lldb/lldb-private-interfaces.h
@@ -48,8 +48,7 @@ typedef ObjectContainer *(*ObjectContainerCreateMemoryInstance)(
     const lldb::ProcessSP &process_sp, lldb::addr_t offset);
 typedef ModuleSpecList (*ObjectFileGetModuleSpecifications)(
     const FileSpec &file, lldb::DataExtractorSP &extractor_sp,
-    lldb::offset_t data_offset, lldb::offset_t file_offset,
-    lldb::offset_t length);
+    lldb::offset_t file_offset, lldb::offset_t length);
 typedef ObjectFile *(*ObjectFileCreateInstance)(
     const lldb::ModuleSP &module_sp, lldb::DataExtractorSP extractor_sp,
     lldb::offset_t data_offset, const FileSpec *file,

--- a/lldb/source/Expression/ObjectFileJIT.cpp
+++ b/lldb/source/Expression/ObjectFileJIT.cpp
@@ -62,8 +62,7 @@ ObjectFile *ObjectFileJIT::CreateMemoryInstance(const lldb::ModuleSP &module_sp,
 
 ModuleSpecList ObjectFileJIT::GetModuleSpecifications(
     const lldb_private::FileSpec &file, lldb::DataExtractorSP &extractor_sp,
-    lldb::offset_t data_offset, lldb::offset_t file_offset,
-    lldb::offset_t length) {
+    lldb::offset_t file_offset, lldb::offset_t length) {
   // JIT'ed object file can't be read from a file on disk
   return {};
 }

--- a/lldb/source/Plugins/ObjectContainer/BSD-Archive/ObjectContainerBSDArchive.cpp
+++ b/lldb/source/Plugins/ObjectContainer/BSD-Archive/ObjectContainerBSDArchive.cpp
@@ -436,18 +436,15 @@ ObjectFileSP ObjectContainerBSDArchive::GetObjectFile(const FileSpec *file) {
 
 ModuleSpecList ObjectContainerBSDArchive::GetModuleSpecifications(
     const FileSpec &file, lldb::DataExtractorSP &extractor_sp,
-    lldb::offset_t data_offset, lldb::offset_t file_offset,
-    lldb::offset_t file_size) {
+    lldb::offset_t file_offset, lldb::offset_t file_size) {
 
   if (!file || !extractor_sp)
     return {};
 
-  DataExtractorSP data_extractor_sp =
-      extractor_sp->GetSubsetExtractorSP(data_offset);
   // We have data, which means this is the first 512 bytes of the file Check to
   // see if the magic bytes match and if they do, read the entire table of
   // contents for the archive and cache it
-  ArchiveType archive_type = MagicBytesMatch(*data_extractor_sp);
+  ArchiveType archive_type = MagicBytesMatch(*extractor_sp);
   if (archive_type == ArchiveType::Invalid)
     return {};
 

--- a/lldb/source/Plugins/ObjectContainer/BSD-Archive/ObjectContainerBSDArchive.h
+++ b/lldb/source/Plugins/ObjectContainer/BSD-Archive/ObjectContainerBSDArchive.h
@@ -58,7 +58,6 @@ public:
   static lldb_private::ModuleSpecList
   GetModuleSpecifications(const lldb_private::FileSpec &file,
                           lldb::DataExtractorSP &extractor_sp,
-                          lldb::offset_t data_offset,
                           lldb::offset_t file_offset, lldb::offset_t length);
 
   static ArchiveType

--- a/lldb/source/Plugins/ObjectContainer/Big-Archive/ObjectContainerBigArchive.cpp
+++ b/lldb/source/Plugins/ObjectContainer/Big-Archive/ObjectContainerBigArchive.cpp
@@ -45,8 +45,7 @@ ObjectContainer *ObjectContainerBigArchive::CreateInstance(
 
 ModuleSpecList ObjectContainerBigArchive::GetModuleSpecifications(
     const lldb_private::FileSpec &file, lldb::DataExtractorSP &extractor_sp,
-    lldb::offset_t data_offset, lldb::offset_t file_offset,
-    lldb::offset_t file_size) {
+    lldb::offset_t file_offset, lldb::offset_t file_size) {
   return {};
 }
 

--- a/lldb/source/Plugins/ObjectContainer/Big-Archive/ObjectContainerBigArchive.h
+++ b/lldb/source/Plugins/ObjectContainer/Big-Archive/ObjectContainerBigArchive.h
@@ -47,7 +47,6 @@ public:
   static lldb_private::ModuleSpecList
   GetModuleSpecifications(const lldb_private::FileSpec &file,
                           lldb::DataExtractorSP &extractor_sp,
-                          lldb::offset_t data_offset,
                           lldb::offset_t file_offset, lldb::offset_t length);
 
   // Member Functions

--- a/lldb/source/Plugins/ObjectContainer/Mach-O-Fileset/ObjectContainerMachOFileset.cpp
+++ b/lldb/source/Plugins/ObjectContainer/Mach-O-Fileset/ObjectContainerMachOFileset.cpp
@@ -221,19 +221,14 @@ bool ObjectContainerMachOFileset::ParseHeader() {
 
 ModuleSpecList ObjectContainerMachOFileset::GetModuleSpecifications(
     const lldb_private::FileSpec &file, lldb::DataExtractorSP &extractor_sp,
-    lldb::offset_t data_offset, lldb::offset_t file_offset,
-    lldb::offset_t file_size) {
+    lldb::offset_t file_offset, lldb::offset_t file_size) {
   if (!extractor_sp)
     return {};
 
-  DataExtractorSP data_extractor_sp =
-      extractor_sp->GetSubsetExtractorSP(data_offset);
-  if (!data_extractor_sp)
-    return {};
   ModuleSpecList specs;
-  if (MagicBytesMatch(*data_extractor_sp)) {
+  if (MagicBytesMatch(*extractor_sp)) {
     std::vector<Entry> entries;
-    if (ParseHeader(*data_extractor_sp, file, file_offset, entries)) {
+    if (ParseHeader(*extractor_sp, file, file_offset, entries)) {
       for (const Entry &entry : entries) {
         const lldb::offset_t entry_offset = entry.fileoff + file_offset;
         ModuleSpecList entry_specs = ObjectFile::GetModuleSpecifications(

--- a/lldb/source/Plugins/ObjectContainer/Mach-O-Fileset/ObjectContainerMachOFileset.h
+++ b/lldb/source/Plugins/ObjectContainer/Mach-O-Fileset/ObjectContainerMachOFileset.h
@@ -51,7 +51,6 @@ public:
   static ModuleSpecList
   GetModuleSpecifications(const lldb_private::FileSpec &file,
                           lldb::DataExtractorSP &extractor_sp,
-                          lldb::offset_t data_offset,
                           lldb::offset_t file_offset, lldb::offset_t length);
 
   static bool MagicBytesMatch(const lldb_private::DataExtractor &data);

--- a/lldb/source/Plugins/ObjectContainer/Universal-Mach-O/ObjectContainerUniversalMachO.cpp
+++ b/lldb/source/Plugins/ObjectContainer/Universal-Mach-O/ObjectContainerUniversalMachO.cpp
@@ -190,15 +190,12 @@ ObjectContainerUniversalMachO::GetObjectFile(const FileSpec *file) {
 
 ModuleSpecList ObjectContainerUniversalMachO::GetModuleSpecifications(
     const lldb_private::FileSpec &file, lldb::DataExtractorSP &extractor_sp,
-    lldb::offset_t data_offset, lldb::offset_t file_offset,
-    lldb::offset_t file_size) {
+    lldb::offset_t file_offset, lldb::offset_t file_size) {
   if (!extractor_sp)
     return {};
 
   ModuleSpecList specs;
-  DataExtractorSP data_extractor_sp =
-      extractor_sp->GetSubsetExtractorSP(data_offset);
-  if (ObjectContainerUniversalMachO::MagicBytesMatch(*data_extractor_sp)) {
+  if (ObjectContainerUniversalMachO::MagicBytesMatch(*extractor_sp)) {
     llvm::MachO::fat_header header;
     std::vector<FatArch> fat_archs;
     if (ParseHeader(*data_extractor_sp, header, fat_archs)) {

--- a/lldb/source/Plugins/ObjectContainer/Universal-Mach-O/ObjectContainerUniversalMachO.cpp
+++ b/lldb/source/Plugins/ObjectContainer/Universal-Mach-O/ObjectContainerUniversalMachO.cpp
@@ -198,7 +198,7 @@ ModuleSpecList ObjectContainerUniversalMachO::GetModuleSpecifications(
   if (ObjectContainerUniversalMachO::MagicBytesMatch(*extractor_sp)) {
     llvm::MachO::fat_header header;
     std::vector<FatArch> fat_archs;
-    if (ParseHeader(*data_extractor_sp, header, fat_archs)) {
+    if (ParseHeader(*extractor_sp, header, fat_archs)) {
       for (const FatArch &fat_arch : fat_archs) {
         const lldb::offset_t slice_file_offset =
             fat_arch.GetOffset() + file_offset;

--- a/lldb/source/Plugins/ObjectContainer/Universal-Mach-O/ObjectContainerUniversalMachO.h
+++ b/lldb/source/Plugins/ObjectContainer/Universal-Mach-O/ObjectContainerUniversalMachO.h
@@ -42,7 +42,6 @@ public:
   static lldb_private::ModuleSpecList
   GetModuleSpecifications(const lldb_private::FileSpec &file,
                           lldb::DataExtractorSP &extractor_sp,
-                          lldb::offset_t data_offset,
                           lldb::offset_t file_offset, lldb::offset_t length);
 
   static bool MagicBytesMatch(const lldb_private::DataExtractor &data);

--- a/lldb/source/Plugins/ObjectFile/Breakpad/ObjectFileBreakpad.cpp
+++ b/lldb/source/Plugins/ObjectFile/Breakpad/ObjectFileBreakpad.cpp
@@ -102,8 +102,8 @@ ObjectFile *ObjectFileBreakpad::CreateMemoryInstance(
 }
 
 ModuleSpecList ObjectFileBreakpad::GetModuleSpecifications(
-    const FileSpec &file, DataExtractorSP &extractor_sp, offset_t data_offset,
-    offset_t file_offset, offset_t length) {
+    const FileSpec &file, DataExtractorSP &extractor_sp, offset_t file_offset,
+    offset_t length) {
   if (!extractor_sp || !extractor_sp->HasData())
     return {};
   // If this is opearting on a VirtualDataExtractor, it can have

--- a/lldb/source/Plugins/ObjectFile/Breakpad/ObjectFileBreakpad.h
+++ b/lldb/source/Plugins/ObjectFile/Breakpad/ObjectFileBreakpad.h
@@ -41,7 +41,6 @@ public:
   static ModuleSpecList
   GetModuleSpecifications(const FileSpec &file,
                           lldb::DataExtractorSP &extractor_sp,
-                          lldb::offset_t data_offset,
                           lldb::offset_t file_offset, lldb::offset_t length);
 
   // PluginInterface protocol

--- a/lldb/source/Plugins/ObjectFile/COFF/ObjectFileCOFF.cpp
+++ b/lldb/source/Plugins/ObjectFile/COFF/ObjectFileCOFF.cpp
@@ -113,9 +113,10 @@ lldb_private::ObjectFile *ObjectFileCOFF::CreateMemoryInstance(
   return nullptr;
 }
 
-ModuleSpecList ObjectFileCOFF::GetModuleSpecifications(
-    const FileSpec &file, DataExtractorSP &extractor_sp,
-    offset_t file_offset, offset_t length) {
+ModuleSpecList
+ObjectFileCOFF::GetModuleSpecifications(const FileSpec &file,
+                                        DataExtractorSP &extractor_sp,
+                                        offset_t file_offset, offset_t length) {
   if (!extractor_sp || !extractor_sp->HasData())
     return {};
 

--- a/lldb/source/Plugins/ObjectFile/COFF/ObjectFileCOFF.cpp
+++ b/lldb/source/Plugins/ObjectFile/COFF/ObjectFileCOFF.cpp
@@ -114,7 +114,7 @@ lldb_private::ObjectFile *ObjectFileCOFF::CreateMemoryInstance(
 }
 
 ModuleSpecList ObjectFileCOFF::GetModuleSpecifications(
-    const FileSpec &file, DataExtractorSP &extractor_sp, offset_t data_offset,
+    const FileSpec &file, DataExtractorSP &extractor_sp,
     offset_t file_offset, offset_t length) {
   if (!extractor_sp || !extractor_sp->HasData())
     return {};

--- a/lldb/source/Plugins/ObjectFile/COFF/ObjectFileCOFF.h
+++ b/lldb/source/Plugins/ObjectFile/COFF/ObjectFileCOFF.h
@@ -57,7 +57,6 @@ public:
   static lldb_private::ModuleSpecList
   GetModuleSpecifications(const lldb_private::FileSpec &file,
                           lldb::DataExtractorSP &extractor_sp,
-                          lldb::offset_t data_offset,
                           lldb::offset_t file_offset, lldb::offset_t length);
 
   // LLVM RTTI support

--- a/lldb/source/Plugins/ObjectFile/ELF/ObjectFileELF.cpp
+++ b/lldb/source/Plugins/ObjectFile/ELF/ObjectFileELF.cpp
@@ -694,8 +694,8 @@ ModuleSpecList ObjectFileELF::GetModuleSpecifications(
               ProgramHeaderColl program_headers;
               GetProgramHeaderInfo(program_headers, *extractor_sp, header);
 
-              core_notes_crc =
-                  CalculateELFNotesSegmentsCRC32(program_headers, *extractor_sp);
+              core_notes_crc = CalculateELFNotesSegmentsCRC32(program_headers,
+                                                              *extractor_sp);
             } else {
               gnu_debuglink_crc = calc_crc32(0, *extractor_sp);
             }

--- a/lldb/source/Plugins/ObjectFile/ELF/ObjectFileELF.cpp
+++ b/lldb/source/Plugins/ObjectFile/ELF/ObjectFileELF.cpp
@@ -593,22 +593,16 @@ static bool GetOsFromOSABI(unsigned char osabi_byte,
 
 ModuleSpecList ObjectFileELF::GetModuleSpecifications(
     const lldb_private::FileSpec &file, lldb::DataExtractorSP &extractor_sp,
-    lldb::offset_t data_offset, lldb::offset_t file_offset,
-    lldb::offset_t length) {
+    lldb::offset_t file_offset, lldb::offset_t length) {
   Log *log = GetLog(LLDBLog::Modules);
 
   if (!extractor_sp || !extractor_sp->HasData())
     return {};
   if (ObjectFileELF::MagicBytesMatch(extractor_sp->GetSharedDataBuffer(), 0,
                                      extractor_sp->GetByteSize())) {
-    DataExtractor data;
-    if (extractor_sp && extractor_sp->HasData()) {
-      data = *extractor_sp->GetSubsetExtractorSP(data_offset);
-      data_offset = 0;
-    }
     elf::ELFHeader header;
-    lldb::offset_t header_offset = data_offset;
-    if (header.Parse(data, &header_offset)) {
+    lldb::offset_t header_offset = 0;
+    if (header.Parse(*extractor_sp, &header_offset)) {
       ModuleSpec spec(file);
       // In Android API level 23 and above, bionic dynamic linker is able to
       // load .so file directly from zip file. In that case, .so file is
@@ -653,18 +647,17 @@ ModuleSpecList ObjectFileELF::GetModuleSpecifications(
         // calculate CRC32 with this data file_offset and
         // length. It is important for Android zip .so file, which is a slice
         // of a file, to not access the outside of the file slice range.
-        if (data.GetByteSize() < length)
+        if (extractor_sp->GetByteSize() < length)
           if (DataBufferSP data_sp = MapFileData(file, length, file_offset)) {
-            data.SetData(data_sp);
-            data_offset = 0;
+            extractor_sp->SetData(data_sp);
           }
         // In case there is header extension in the section #0, the header we
         // parsed above could have sentinel values for e_phnum, e_shnum, and
         // e_shstrndx.  In this case we need to reparse the header with a
         // bigger data source to get the actual values.
         if (header.HasHeaderExtension()) {
-          lldb::offset_t header_offset = data_offset;
-          header.Parse(data, &header_offset);
+          lldb::offset_t header_offset = 0;
+          header.Parse(*extractor_sp, &header_offset);
         }
 
         uint32_t gnu_debuglink_crc = 0;
@@ -672,7 +665,7 @@ ModuleSpecList ObjectFileELF::GetModuleSpecifications(
         SectionHeaderColl section_headers;
         lldb_private::UUID &uuid = spec.GetUUID();
 
-        GetSectionHeaderInfo(section_headers, data, header, uuid,
+        GetSectionHeaderInfo(section_headers, *extractor_sp, header, uuid,
                              gnu_debuglink_file, gnu_debuglink_crc,
                              spec.GetArchitecture());
 
@@ -699,12 +692,12 @@ ModuleSpecList ObjectFileELF::GetModuleSpecifications(
             // to fallback to something simpler.
             if (header.e_type == llvm::ELF::ET_CORE) {
               ProgramHeaderColl program_headers;
-              GetProgramHeaderInfo(program_headers, data, header);
+              GetProgramHeaderInfo(program_headers, *extractor_sp, header);
 
               core_notes_crc =
-                  CalculateELFNotesSegmentsCRC32(program_headers, data);
+                  CalculateELFNotesSegmentsCRC32(program_headers, *extractor_sp);
             } else {
-              gnu_debuglink_crc = calc_crc32(0, data);
+              gnu_debuglink_crc = calc_crc32(0, *extractor_sp);
             }
           }
           using u32le = llvm::support::ulittle32_t;

--- a/lldb/source/Plugins/ObjectFile/ELF/ObjectFileELF.h
+++ b/lldb/source/Plugins/ObjectFile/ELF/ObjectFileELF.h
@@ -81,7 +81,6 @@ public:
   static lldb_private::ModuleSpecList
   GetModuleSpecifications(const lldb_private::FileSpec &file,
                           lldb::DataExtractorSP &extractor_sp,
-                          lldb::offset_t data_offset,
                           lldb::offset_t file_offset, lldb::offset_t length);
 
   static bool MagicBytesMatch(lldb::DataBufferSP data_sp, lldb::addr_t offset,

--- a/lldb/source/Plugins/ObjectFile/JSON/ObjectFileJSON.cpp
+++ b/lldb/source/Plugins/ObjectFile/JSON/ObjectFileJSON.cpp
@@ -108,11 +108,11 @@ ObjectFile *ObjectFileJSON::CreateMemoryInstance(const ModuleSP &module_sp,
   return nullptr;
 }
 
-ModuleSpecList ObjectFileJSON::GetModuleSpecifications(
-    const FileSpec &file, DataExtractorSP &extractor_sp, offset_t data_offset,
-    offset_t file_offset, offset_t length) {
-  if (!extractor_sp ||
-      !MagicBytesMatch(extractor_sp->GetSubsetExtractorSP(data_offset)))
+ModuleSpecList
+ObjectFileJSON::GetModuleSpecifications(const FileSpec &file,
+                                        DataExtractorSP &extractor_sp,
+                                        offset_t file_offset, offset_t length) {
+  if (!extractor_sp || !MagicBytesMatch(extractor_sp))
     return {};
 
   // Update the data to contain the entire file if it doesn't already.
@@ -121,7 +121,6 @@ ModuleSpecList ObjectFileJSON::GetModuleSpecifications(
       extractor_sp->SetData(file_data_sp);
     if (!extractor_sp->HasData())
       return {};
-    data_offset = 0;
   }
 
   Log *log = GetLog(LLDBLog::Symbols);

--- a/lldb/source/Plugins/ObjectFile/JSON/ObjectFileJSON.h
+++ b/lldb/source/Plugins/ObjectFile/JSON/ObjectFileJSON.h
@@ -41,7 +41,6 @@ public:
   static ModuleSpecList
   GetModuleSpecifications(const FileSpec &file,
                           lldb::DataExtractorSP &extractor_sp,
-                          lldb::offset_t data_offset,
                           lldb::offset_t file_offset, lldb::offset_t length);
 
   llvm::StringRef GetPluginName() override { return GetPluginNameStatic(); }

--- a/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.cpp
+++ b/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.cpp
@@ -829,8 +829,7 @@ ObjectFile *ObjectFileMachO::CreateMemoryInstance(
 
 ModuleSpecList ObjectFileMachO::GetModuleSpecifications(
     const lldb_private::FileSpec &file, lldb::DataExtractorSP &extractor_sp,
-    lldb::offset_t data_offset, lldb::offset_t file_offset,
-    lldb::offset_t length) {
+    lldb::offset_t file_offset, lldb::offset_t length) {
   if (!extractor_sp || !extractor_sp->HasData())
     return {};
 
@@ -838,6 +837,7 @@ ModuleSpecList ObjectFileMachO::GetModuleSpecifications(
   if (ObjectFileMachO::MagicBytesMatch(extractor_sp, 0,
                                        extractor_sp->GetByteSize())) {
     llvm::MachO::mach_header header;
+    offset_t data_offset = 0;
     if (ParseHeader(extractor_sp, &data_offset, header)) {
       size_t header_and_load_cmds =
           header.sizeofcmds + MachHeaderSizeFromMagic(header.magic);

--- a/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.h
+++ b/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.h
@@ -60,7 +60,6 @@ public:
   static lldb_private::ModuleSpecList
   GetModuleSpecifications(const lldb_private::FileSpec &file,
                           lldb::DataExtractorSP &extractor_sp,
-                          lldb::offset_t data_offset,
                           lldb::offset_t file_offset, lldb::offset_t length);
 
   static bool SaveCore(const lldb::ProcessSP &process_sp,

--- a/lldb/source/Plugins/ObjectFile/Minidump/ObjectFileMinidump.cpp
+++ b/lldb/source/Plugins/ObjectFile/Minidump/ObjectFileMinidump.cpp
@@ -49,8 +49,7 @@ ObjectFile *ObjectFileMinidump::CreateMemoryInstance(
 
 ModuleSpecList ObjectFileMinidump::GetModuleSpecifications(
     const lldb_private::FileSpec &file, lldb::DataExtractorSP &extractor_sp,
-    lldb::offset_t data_offset, lldb::offset_t file_offset,
-    lldb::offset_t length) {
+    lldb::offset_t file_offset, lldb::offset_t length) {
   return {};
 }
 

--- a/lldb/source/Plugins/ObjectFile/Minidump/ObjectFileMinidump.h
+++ b/lldb/source/Plugins/ObjectFile/Minidump/ObjectFileMinidump.h
@@ -51,7 +51,6 @@ public:
   static lldb_private::ModuleSpecList
   GetModuleSpecifications(const lldb_private::FileSpec &file,
                           lldb::DataExtractorSP &extractor_sp,
-                          lldb::offset_t data_offset,
                           lldb::offset_t file_offset, lldb::offset_t length);
 
   // Saves dump in Minidump file format

--- a/lldb/source/Plugins/ObjectFile/PDB/ObjectFilePDB.cpp
+++ b/lldb/source/Plugins/ObjectFile/PDB/ObjectFilePDB.cpp
@@ -111,9 +111,10 @@ ObjectFile *ObjectFilePDB::CreateMemoryInstance(const ModuleSP &module_sp,
   return nullptr;
 }
 
-ModuleSpecList ObjectFilePDB::GetModuleSpecifications(
-    const FileSpec &file, DataExtractorSP &extractor_sp, offset_t data_offset,
-    offset_t file_offset, offset_t length) {
+ModuleSpecList
+ObjectFilePDB::GetModuleSpecifications(const FileSpec &file,
+                                       DataExtractorSP &extractor_sp,
+                                       offset_t file_offset, offset_t length) {
   ModuleSpec module_spec(file);
   llvm::BumpPtrAllocator allocator;
   std::unique_ptr<PDBFile> pdb_file = loadPDBFile(file.GetPath(), allocator);

--- a/lldb/source/Plugins/ObjectFile/PDB/ObjectFilePDB.h
+++ b/lldb/source/Plugins/ObjectFile/PDB/ObjectFilePDB.h
@@ -45,7 +45,6 @@ public:
   static ModuleSpecList
   GetModuleSpecifications(const FileSpec &file,
                           lldb::DataExtractorSP &extractor_sp,
-                          lldb::offset_t data_offset,
                           lldb::offset_t file_offset, lldb::offset_t length);
 
   // PluginInterface protocol

--- a/lldb/source/Plugins/ObjectFile/PECOFF/ObjectFilePECOFF.cpp
+++ b/lldb/source/Plugins/ObjectFile/PECOFF/ObjectFilePECOFF.cpp
@@ -256,8 +256,7 @@ ObjectFile *ObjectFilePECOFF::CreateMemoryInstance(
 
 ModuleSpecList ObjectFilePECOFF::GetModuleSpecifications(
     const lldb_private::FileSpec &file, lldb::DataExtractorSP &extractor_sp,
-    lldb::offset_t data_offset, lldb::offset_t file_offset,
-    lldb::offset_t length) {
+    lldb::offset_t file_offset, lldb::offset_t length) {
   if (!extractor_sp || !extractor_sp->HasData() ||
       !ObjectFilePECOFF::MagicBytesMatch(extractor_sp))
     return {};

--- a/lldb/source/Plugins/ObjectFile/PECOFF/ObjectFilePECOFF.h
+++ b/lldb/source/Plugins/ObjectFile/PECOFF/ObjectFilePECOFF.h
@@ -81,7 +81,6 @@ public:
   static lldb_private::ModuleSpecList
   GetModuleSpecifications(const lldb_private::FileSpec &file,
                           lldb::DataExtractorSP &extractor_sp,
-                          lldb::offset_t data_offset,
                           lldb::offset_t file_offset, lldb::offset_t length);
 
   static bool SaveCore(const lldb::ProcessSP &process_sp,

--- a/lldb/source/Plugins/ObjectFile/XCOFF/ObjectFileXCOFF.cpp
+++ b/lldb/source/Plugins/ObjectFile/XCOFF/ObjectFileXCOFF.cpp
@@ -128,8 +128,7 @@ ObjectFile *ObjectFileXCOFF::CreateMemoryInstance(
 
 ModuleSpecList ObjectFileXCOFF::GetModuleSpecifications(
     const lldb_private::FileSpec &file, lldb::DataExtractorSP &extractor_sp,
-    lldb::offset_t data_offset, lldb::offset_t file_offset,
-    lldb::offset_t length) {
+    lldb::offset_t file_offset, lldb::offset_t length) {
   if (!extractor_sp || !extractor_sp->HasData())
     return {};
 

--- a/lldb/source/Plugins/ObjectFile/XCOFF/ObjectFileXCOFF.h
+++ b/lldb/source/Plugins/ObjectFile/XCOFF/ObjectFileXCOFF.h
@@ -50,7 +50,6 @@ public:
   static lldb_private::ModuleSpecList
   GetModuleSpecifications(const lldb_private::FileSpec &file,
                           lldb::DataExtractorSP &extractor_sp,
-                          lldb::offset_t data_offset,
                           lldb::offset_t file_offset, lldb::offset_t length);
 
   static bool MagicBytesMatch(lldb::DataExtractorSP &extractor_sp,

--- a/lldb/source/Plugins/ObjectFile/wasm/ObjectFileWasm.cpp
+++ b/lldb/source/Plugins/ObjectFile/wasm/ObjectFileWasm.cpp
@@ -273,9 +273,10 @@ bool ObjectFileWasm::DecodeSections() {
   return true;
 }
 
-ModuleSpecList ObjectFileWasm::GetModuleSpecifications(
-    const FileSpec &file, DataExtractorSP &extractor_sp, offset_t data_offset,
-    offset_t file_offset, offset_t length) {
+ModuleSpecList
+ObjectFileWasm::GetModuleSpecifications(const FileSpec &file,
+                                        DataExtractorSP &extractor_sp,
+                                        offset_t file_offset, offset_t length) {
   if (!ValidateModuleHeader(extractor_sp->GetData()))
     return {};
 

--- a/lldb/source/Plugins/ObjectFile/wasm/ObjectFileWasm.h
+++ b/lldb/source/Plugins/ObjectFile/wasm/ObjectFileWasm.h
@@ -45,7 +45,6 @@ public:
   static ModuleSpecList
   GetModuleSpecifications(const FileSpec &file,
                           lldb::DataExtractorSP &extractor_sp,
-                          lldb::offset_t data_offset,
                           lldb::offset_t file_offset, lldb::offset_t length);
 
   /// PluginInterface protocol.

--- a/lldb/source/Symbol/ObjectFile.cpp
+++ b/lldb/source/Symbol/ObjectFile.cpp
@@ -211,8 +211,7 @@ ModuleSpecList ObjectFile::GetModuleSpecifications(
       if (actual_file_size > file_offset)
         file_size = actual_file_size - file_offset;
     }
-    return ObjectFile::GetModuleSpecifications(file, extractor_sp,
-                                               /*data_offset=*/0, file_offset,
+    return ObjectFile::GetModuleSpecifications(file, extractor_sp, file_offset,
                                                file_size);
   }
   return {};
@@ -220,12 +219,11 @@ ModuleSpecList ObjectFile::GetModuleSpecifications(
 
 ModuleSpecList ObjectFile::GetModuleSpecifications(
     const lldb_private::FileSpec &file, lldb::DataExtractorSP &extractor_sp,
-    lldb::offset_t data_offset, lldb::offset_t file_offset,
-    lldb::offset_t file_size) {
+    lldb::offset_t file_offset, lldb::offset_t file_size) {
   // Try the ObjectFile plug-ins
   for (auto &cbs : PluginManager::GetObjectFileCallbacks()) {
     ModuleSpecList specs = cbs.get_module_specifications(
-        file, extractor_sp, data_offset, file_offset, file_size);
+        file, extractor_sp, file_offset, file_size);
     if (specs.GetSize() > 0)
       return specs;
   }
@@ -233,7 +231,7 @@ ModuleSpecList ObjectFile::GetModuleSpecifications(
   // Try the ObjectContainer plug-ins
   for (auto &cbs : PluginManager::GetObjectContainerCallbacks()) {
     ModuleSpecList specs = cbs.get_module_specifications(
-        file, extractor_sp, data_offset, file_offset, file_size);
+        file, extractor_sp, file_offset, file_size);
     if (specs.GetSize() > 0)
       return specs;
   }


### PR DESCRIPTION
- it is always passed as zero
- a lot of plugins aren't using it correctly
- the data extractor class already has the capability to look at a subset of bytes