### PR TITLE
[LLVM] Set SOVERSION on shared libraries on macOS

### DIFF
--- a/llvm/cmake/modules/AddLLVM.cmake
+++ b/llvm/cmake/modules/AddLLVM.cmake
@@ -796,9 +796,9 @@ function(llvm_add_library name)
         )
     endif()
 
-    # Set SOVERSION on shared libraries that lack explicit SONAME
-    # specifier, on *nix systems that are not Darwin.
-    if(UNIX AND NOT APPLE AND NOT ARG_SONAME)
+    # On *nix systems, set SOVERSION on shared libraries that lack explicit
+    # SONAME specifier.
+    if(UNIX AND NOT ARG_SONAME)
       set_target_properties(${name}
         PROPERTIES
         # Since 18.1.0, the ABI version is indicated by the major and minor version.


### PR DESCRIPTION
`LLVM_VERSION_SUFFIX` currently behaves inconsistently on macOS and other Unix-like systems.

On macOS, libLLVM is emitted as an unversioned library with a compatibility symlink:

```
libLLVM-22-[suffix].dylib -> libLLVM.dylib
libLLVM.dylib
```

On Linux, the library filename itself carries the version suffix, and both the compatibility symlink and the unversioned linker name point to it:

```
libLLVM-22[suffix].so -> libLLVM.so.22.1[suffix]
libLLVM.so -> libLLVM.so.22.1[suffix]
libLLVM.so.22.1[suffix]
```

The macOS layout makes it harder to install multiple LLVM builds side by side without library name collisions.

Make macOS follow the same versioned shared-library naming scheme as other Unix-like systems by setting `SOVERSION` for shared libraries there as well.

Fixes #188963