### PR TITLE
[MLIR][SCF] Prioritize single-iteration loop inlining

### DIFF
--- a/mlir/lib/Dialect/SCF/IR/SCF.cpp
+++ b/mlir/lib/Dialect/SCF/IR/SCF.cpp
@@ -1009,9 +1009,13 @@ void ForOp::getCanonicalizationPatterns(RewritePatternSet &results,
   results.add<ForOpTensorCastFolder>(context);
   populateRegionBranchOpInterfaceCanonicalizationPatterns(
       results, ForOp::getOperationName());
+  // Inline single-iteration loops before applying the generic region branch op
+  // canonicalizations, which may otherwise remove tied iter_args and results
+  // independently.
   populateRegionBranchOpInterfaceInliningPattern(
       results, ForOp::getOperationName(),
-      /*replBuilderFn=*/[](OpBuilder &builder, Location loc, Value value) {
+      /*replBuilderFn=*/
+      [](OpBuilder &builder, Location loc, Value value) {
         // scf.for has only one non-successor input value: the loop induction
         // variable. In case of a single acyclic path through the op, the IV can
         // be safely replaced with the lower bound.
@@ -1019,7 +1023,9 @@ void ForOp::getCanonicalizationPatterns(RewritePatternSet &results,
         assert(blockArg.getArgNumber() == 0 && "expected induction variable");
         auto forOp = cast<ForOp>(blockArg.getOwner()->getParentOp());
         return forOp.getLowerBound();
-      });
+      },
+      /*matcherFn=*/::mlir::detail::defaultMatcherFn,
+      /*benefit=*/2);
 }
 
 std::optional<APInt> ForOp::getConstantStep() {

--- a/mlir/lib/Interfaces/ControlFlowInterfaces.cpp
+++ b/mlir/lib/Interfaces/ControlFlowInterfaces.cpp
@@ -783,8 +783,9 @@ static BitVector &lookupOrCreateBitVector(MappingTy &mapping, KeyTy key,
 ///   ...
 /// }
 /// There are two sets: {{%r0, %arg0}, {%r1, %arg1}}.
-static llvm::EquivalenceClasses<Value> computeTiedSuccessorInputs(
-    const RegionBranchSuccessorMapping &operandToInputs) {
+static llvm::EquivalenceClasses<Value>
+computeTiedSuccessorInputs(const RegionBranchSuccessorMapping &operandToInputs,
+                           RegionBranchOpInterface branchOp) {
   llvm::EquivalenceClasses<Value> tiedSuccessorInputs;
   for (const auto &[operand, inputs] : operandToInputs) {
     assert(!inputs.empty() && "expected non-empty inputs");
@@ -794,6 +795,75 @@ static llvm::EquivalenceClasses<Value> computeTiedSuccessorInputs(
       // As we explore more successor operand to successor input mappings,
       // existing sets may get merged.
       tiedSuccessorInputs.unionSets(firstInput, nextInput);
+    }
+  }
+
+  // Also tie region entry block args with op results at the same slot index
+  // when the back-edge has been optimized away for a single-iteration loop.
+  //
+  // In the general case (e.g., scf.for with tripCount > 1), a single yield
+  // operand maps to BOTH the body block arg (back-edge) AND the result (exit),
+  // so they end up in the same equivalence class via the loop above. When a
+  // trip-count optimization removes the back-edge (e.g., scf.for with
+  // tripCount == 1), the yield only maps to the result, and the body block arg
+  // is only mapped from the init operand — leaving them in separate classes.
+  // Without the explicit tying below, RemoveDeadRegionBranchOpSuccessorInputs
+  // could remove a body block arg and its init operand independently from the
+  // corresponding result, leaving the op structurally invalid.
+  //
+  // Detection: if a region's terminator exits ONLY to parent (single successor,
+  // indicating a trip-count optimization removed the back-edge), but the parent
+  // CAN enter the region (so the region is reachable), and the region inputs
+  // and parent inputs have matching counts, then they are positionally tied.
+  //
+  // Crucially, this does NOT apply to scf.while's before-region, whose
+  // terminator (scf.condition) always exits to both the after-region AND parent
+  // simultaneously. That case has two successors and is correctly excluded.
+  ValueRange parentInputs =
+      branchOp.getSuccessorInputs(RegionSuccessor::parent());
+  if (!parentInputs.empty()) {
+    // Collect regions that parent can enter.
+    SmallVector<RegionSuccessor> parentSuccessors;
+    branchOp.getSuccessorRegions(RegionBranchPoint::parent(), parentSuccessors);
+
+    for (Region &region : branchOp.getOperation()->getRegions()) {
+      // Check that the region is reachable from the parent.
+      bool parentCanEnter =
+          llvm::any_of(parentSuccessors, [&](const RegionSuccessor &s) {
+            return !s.isParent() && s.getSuccessor() == &region;
+          });
+      if (!parentCanEnter)
+        continue;
+
+      // Get the entry block's terminator, if it implements
+      // RegionBranchTerminatorOpInterface (otherwise we can't query
+      // successors).
+      if (region.empty() || region.front().empty())
+        continue;
+      auto terminator =
+          dyn_cast<RegionBranchTerminatorOpInterface>(region.front().back());
+      if (!terminator)
+        continue;
+
+      // Check whether the terminator exits ONLY to parent (i.e., the back-edge
+      // has been removed by a single-iteration optimization).
+      SmallVector<RegionSuccessor> terminatorSuccessors;
+      branchOp.getSuccessorRegions(RegionBranchPoint(terminator),
+                                   terminatorSuccessors);
+      if (terminatorSuccessors.size() != 1 ||
+          !terminatorSuccessors.front().isParent())
+        continue;
+
+      // The terminator exits only to parent, while the region is still
+      // reachable from parent. Tie the region inputs with the parent inputs.
+      ValueRange regionInputs =
+          branchOp.getSuccessorInputs(RegionSuccessor(&region));
+      if (regionInputs.size() != parentInputs.size())
+        continue;
+
+      for (auto [regionInput, parentInput] :
+           llvm::zip(regionInputs, parentInputs))
+        tiedSuccessorInputs.unionSets(regionInput, parentInput);
     }
   }
   return tiedSuccessorInputs;
@@ -855,7 +925,7 @@ struct RemoveDeadRegionBranchOpSuccessorInputs : public RewritePattern {
     RegionBranchSuccessorMapping operandToInputs;
     regionBranchOp.getSuccessorOperandInputMapping(operandToInputs);
     llvm::EquivalenceClasses<Value> tiedSuccessorInputs =
-        computeTiedSuccessorInputs(operandToInputs);
+        computeTiedSuccessorInputs(operandToInputs, regionBranchOp);
 
     // Determine which values to remove and group them by block and operation.
     SmallVector<Value> valuesToRemove;

--- a/mlir/test/Dialect/Linalg/continuous-tiling-full.mlir
+++ b/mlir/test/Dialect/Linalg/continuous-tiling-full.mlir
@@ -1,6 +1,5 @@
 // RUN: mlir-opt --transform-interpreter --canonicalize --split-input-file %s | FileCheck %s
 
-// XFAIL: mlir-expensive-checks
 
 module attributes {transform.with_named_sequence} {
   transform.named_sequence @__transform_main(%arg1: !transform.any_op {transform.readonly}) {

--- a/mlir/test/Dialect/Linalg/decompose-pack-tile.mlir
+++ b/mlir/test/Dialect/Linalg/decompose-pack-tile.mlir
@@ -3,7 +3,6 @@
 // RUN: -transform-interpreter=entry-point=decompose_pack \
 // RUN: -transform-interpreter  %s | FileCheck %s
 
-// XFAIL: mlir-expensive-checks
 
 func.func @KCRS_to_KCRSsr(%arg0: tensor<1x1x128x64xf32>, %arg1: tensor<1x1x4x8x8x32xf32>) -> tensor<1x1x4x8x8x32xf32> {
   %0 = linalg.pack %arg0 inner_dims_pos = [3, 2] inner_tiles = [8, 32] into %arg1 : tensor<1x1x128x64xf32> -> tensor<1x1x4x8x8x32xf32>

--- a/mlir/test/Dialect/Linalg/decompose-unpack-tile.mlir
+++ b/mlir/test/Dialect/Linalg/decompose-unpack-tile.mlir
@@ -3,7 +3,6 @@
 // RUN: -transform-interpreter=entry-point=decompose_unpack \
 // RUN: -transform-interpreter  %s | FileCheck %s
 
-// XFAIL: mlir-expensive-checks
 
 func.func @KCRSsr_to_KCRS(%arg0: tensor<1x1x4x8x8x32xf32>, %arg1: tensor<1x1x128x64xf32>) -> tensor<1x1x128x64xf32> {
   %0 = linalg.unpack %arg0 inner_dims_pos = [3, 2] inner_tiles = [8, 32] into %arg1 : tensor<1x1x4x8x8x32xf32> -> tensor<1x1x128x64xf32>

--- a/mlir/test/Dialect/Linalg/transform-op-peel-and-vectorize-conv.mlir
+++ b/mlir/test/Dialect/Linalg/transform-op-peel-and-vectorize-conv.mlir
@@ -1,6 +1,5 @@
 // RUN: mlir-opt %s --transform-interpreter --split-input-file -resolve-shaped-type-result-dims -canonicalize | FileCheck %s
 
-// XFAIL: mlir-expensive-checks
 
 // Demonstrates what happens when peeling the 4th loop (that corresponds to the
 // "depth" dimension in depthwise convs) followed by vectorization in the

--- a/mlir/test/Dialect/Linalg/transform-op-tile-pack-unpack.mlir
+++ b/mlir/test/Dialect/Linalg/transform-op-tile-pack-unpack.mlir
@@ -1,6 +1,5 @@
 // RUN: mlir-opt %s -transform-interpreter -canonicalize -cse -split-input-file | FileCheck %s
 
-// XFAIL: mlir-expensive-checks
 
 // CHECK-DAG:   #[[MAP0:.+]] = affine_map<(d0) -> (d0 * 32)>
 // CHECK:       func.func @NC_to_NCnc

--- a/mlir/test/Dialect/Linalg/transform-tile-and-winograd-rewrite.mlir
+++ b/mlir/test/Dialect/Linalg/transform-tile-and-winograd-rewrite.mlir
@@ -1,6 +1,5 @@
 // RUN: mlir-opt %s -transform-interpreter -canonicalize --split-input-file | FileCheck %s
 
-// XFAIL: mlir-expensive-checks
 
 func.func @conv2d(%arg0: tensor<2x10x10x5xf32>, %arg1: tensor<2x3x3x5xf32>, %arg2: tensor<2x8x8x2xf32>) -> tensor<2x8x8x2xf32> {
   %0 = tensor.empty() : tensor<6x6x5x2xf32>

--- a/mlir/test/Dialect/SCF/canonicalize.mlir
+++ b/mlir/test/Dialect/SCF/canonicalize.mlir
@@ -1,6 +1,5 @@
 // RUN: mlir-opt %s -pass-pipeline='builtin.module(func.func(canonicalize{test-convergence}))' -split-input-file | FileCheck %s
 
-// XFAIL: mlir-expensive-checks
 
 func.func @single_iteration_some(%A: memref<?x?x?xi32>) {
   %c0 = arith.constant 0 : index

--- a/mlir/test/Dialect/SCF/for-loop-peeling.mlir
+++ b/mlir/test/Dialect/SCF/for-loop-peeling.mlir
@@ -1,7 +1,6 @@
 // RUN: mlir-opt %s -scf-for-loop-peeling -canonicalize -split-input-file -verify-diagnostics | FileCheck %s
 // RUN: mlir-opt %s -scf-for-loop-peeling=skip-partial=false -canonicalize -split-input-file -verify-diagnostics | FileCheck %s -check-prefix=CHECK-NO-SKIP
 
-// XFAIL: mlir-expensive-checks
 
 //  CHECK-DAG: #[[MAP0:.*]] = affine_map<()[s0, s1, s2] -> (s1 - (-s0 + s1) mod s2)>
 //  CHECK-DAG: #[[MAP1:.*]] = affine_map<(d0)[s0] -> (-d0 + s0)>
@@ -378,4 +377,3 @@ func.func @zero_step(%arg0: memref<i64>) {
   }
   return
 }
-

--- a/mlir/test/Dialect/SparseTensor/fuse_sparse_convert_into_producer.mlir
+++ b/mlir/test/Dialect/SparseTensor/fuse_sparse_convert_into_producer.mlir
@@ -1,7 +1,6 @@
 // RUN: mlir-opt %s --pre-sparsification-rewrite --sparse-reinterpret-map  | FileCheck %s --check-prefix=CHECK-FOLD
 // RUN: mlir-opt %s --pre-sparsification-rewrite --sparse-reinterpret-map --sparsification | FileCheck %s
 
-// XFAIL: mlir-expensive-checks
 
 #trait = {
   indexing_maps = [

--- a/mlir/test/Integration/Dialect/Linalg/CPU/mmt4d.mlir
+++ b/mlir/test/Integration/Dialect/Linalg/CPU/mmt4d.mlir
@@ -1,4 +1,3 @@
-// XFAIL: mlir-expensive-checks
 
 // DEFINE: %{compile} =  mlir-opt %s \
 // DEFINE:    -transform-interpreter -test-transform-dialect-erase-schedule \

--- a/mlir/test/Integration/Dialect/Linalg/CPU/pack-dynamic-inner-tile.mlir
+++ b/mlir/test/Integration/Dialect/Linalg/CPU/pack-dynamic-inner-tile.mlir
@@ -1,4 +1,3 @@
-// XFAIL: mlir-expensive-checks
 
 // DEFINE: %{compile} =  mlir-opt %s \
 // DEFINE:  -transform-interpreter -test-transform-dialect-erase-schedule |\

--- a/mlir/test/Integration/Dialect/Linalg/CPU/pack-unpack-mmt4d.mlir
+++ b/mlir/test/Integration/Dialect/Linalg/CPU/pack-unpack-mmt4d.mlir
@@ -1,4 +1,3 @@
-// XFAIL: mlir-expensive-checks
 
 // DEFINE: %{compile} =  mlir-opt %s \
 // DEFINE:    -transform-interpreter -test-transform-dialect-erase-schedule \

--- a/mlir/test/Integration/Dialect/Linalg/CPU/unpack-dynamic-inner-tile.mlir
+++ b/mlir/test/Integration/Dialect/Linalg/CPU/unpack-dynamic-inner-tile.mlir
@@ -1,4 +1,3 @@
-// XFAIL: mlir-expensive-checks
 
 // DEFINE: %{compile} =  mlir-opt %s \
 // DEFINE:  -transform-interpreter -test-transform-dialect-erase-schedule \

--- a/mlir/test/Integration/Dialect/SparseTensor/CPU/dual_sparse_conv_2d.mlir
+++ b/mlir/test/Integration/Dialect/SparseTensor/CPU/dual_sparse_conv_2d.mlir
@@ -1,4 +1,3 @@
-// XFAIL: mlir-expensive-checks
 
 //--------------------------------------------------------------------------------------------------
 // WHEN CREATING A NEW TEST, PLEASE JUST COPY & PASTE WITHOUT EDITS.

--- a/mlir/test/Integration/Dialect/SparseTensor/CPU/sparse_block_matmul.mlir
+++ b/mlir/test/Integration/Dialect/SparseTensor/CPU/sparse_block_matmul.mlir
@@ -1,4 +1,3 @@
-// XFAIL: mlir-expensive-checks
 
 //--------------------------------------------------------------------------------------------------
 // WHEN CREATING A NEW TEST, PLEASE JUST COPY & PASTE WITHOUT EDITS.

--- a/mlir/test/Integration/Dialect/SparseTensor/CPU/sparse_conv_1d_nwc_wcf.mlir
+++ b/mlir/test/Integration/Dialect/SparseTensor/CPU/sparse_conv_1d_nwc_wcf.mlir
@@ -1,4 +1,3 @@
-// XFAIL: mlir-expensive-checks
 
 //--------------------------------------------------------------------------------------------------
 // WHEN CREATING A NEW TEST, PLEASE JUST COPY & PASTE WITHOUT EDITS.

--- a/mlir/test/Integration/Dialect/SparseTensor/CPU/sparse_conv_2d.mlir
+++ b/mlir/test/Integration/Dialect/SparseTensor/CPU/sparse_conv_2d.mlir
@@ -1,4 +1,3 @@
-// XFAIL: mlir-expensive-checks
 
 //--------------------------------------------------------------------------------------------------
 // WHEN CREATING A NEW TEST, PLEASE JUST COPY & PASTE WITHOUT EDITS.

--- a/mlir/test/Integration/Dialect/SparseTensor/CPU/sparse_conv_2d_55.mlir
+++ b/mlir/test/Integration/Dialect/SparseTensor/CPU/sparse_conv_2d_55.mlir
@@ -1,4 +1,3 @@
-// XFAIL: mlir-expensive-checks
 
 //--------------------------------------------------------------------------------------------------
 // WHEN CREATING A NEW TEST, PLEASE JUST COPY & PASTE WITHOUT EDITS.

--- a/mlir/test/Integration/Dialect/SparseTensor/CPU/sparse_conv_2d_nchw_fchw.mlir
+++ b/mlir/test/Integration/Dialect/SparseTensor/CPU/sparse_conv_2d_nchw_fchw.mlir
@@ -1,4 +1,3 @@
-// XFAIL: mlir-expensive-checks
 
 //--------------------------------------------------------------------------------------------------
 // WHEN CREATING A NEW TEST, PLEASE JUST COPY & PASTE WITHOUT EDITS.

--- a/mlir/test/Integration/Dialect/SparseTensor/CPU/sparse_conv_2d_nhwc_hwcf.mlir
+++ b/mlir/test/Integration/Dialect/SparseTensor/CPU/sparse_conv_2d_nhwc_hwcf.mlir
@@ -1,4 +1,3 @@
-// XFAIL: mlir-expensive-checks
 
 //--------------------------------------------------------------------------------------------------
 // WHEN CREATING A NEW TEST, PLEASE JUST COPY & PASTE WITHOUT EDITS.

--- a/mlir/test/Integration/Dialect/SparseTensor/CPU/sparse_conv_3d.mlir
+++ b/mlir/test/Integration/Dialect/SparseTensor/CPU/sparse_conv_3d.mlir
@@ -1,4 +1,3 @@
-// XFAIL: mlir-expensive-checks
 
 //--------------------------------------------------------------------------------------------------
 // WHEN CREATING A NEW TEST, PLEASE JUST COPY & PASTE WITHOUT EDITS.

--- a/mlir/test/Integration/Dialect/SparseTensor/CPU/sparse_conv_3d_ndhwc_dhwcf.mlir
+++ b/mlir/test/Integration/Dialect/SparseTensor/CPU/sparse_conv_3d_ndhwc_dhwcf.mlir
@@ -1,4 +1,3 @@
-// XFAIL: mlir-expensive-checks
 
 //--------------------------------------------------------------------------------------------------
 // WHEN CREATING A NEW TEST, PLEASE JUST COPY & PASTE WITHOUT EDITS.

--- a/mlir/test/Integration/Dialect/SparseTensor/CPU/sparse_conversion_block.mlir
+++ b/mlir/test/Integration/Dialect/SparseTensor/CPU/sparse_conversion_block.mlir
@@ -1,4 +1,3 @@
-// XFAIL: mlir-expensive-checks
 
 //--------------------------------------------------------------------------------------------------
 // WHEN CREATING A NEW TEST, PLEASE JUST COPY & PASTE WITHOUT EDITS.

--- a/mlir/test/Integration/Dialect/SparseTensor/CPU/sparse_dilated_conv_2d_nhwc_hwcf.mlir
+++ b/mlir/test/Integration/Dialect/SparseTensor/CPU/sparse_dilated_conv_2d_nhwc_hwcf.mlir
@@ -1,4 +1,3 @@
-// XFAIL: mlir-expensive-checks
 
 //--------------------------------------------------------------------------------------------------
 // WHEN CREATING A NEW TEST, PLEASE JUST COPY & PASTE WITHOUT EDITS.

--- a/mlir/test/Integration/Dialect/SparseTensor/CPU/sparse_pooling_nhwc.mlir
+++ b/mlir/test/Integration/Dialect/SparseTensor/CPU/sparse_pooling_nhwc.mlir
@@ -1,4 +1,3 @@
-// XFAIL: mlir-expensive-checks
 
 //--------------------------------------------------------------------------------------------------
 // WHEN CREATING A NEW TEST, PLEASE JUST COPY & PASTE WITHOUT EDITS.

--- a/mlir/test/Integration/Dialect/SparseTensor/CPU/sparse_strided_conv_2d_nhwc_hwcf.mlir
+++ b/mlir/test/Integration/Dialect/SparseTensor/CPU/sparse_strided_conv_2d_nhwc_hwcf.mlir
@@ -1,4 +1,3 @@
-// XFAIL: mlir-expensive-checks
 
 //--------------------------------------------------------------------------------------------------
 // WHEN CREATING A NEW TEST, PLEASE JUST COPY & PASTE WITHOUT EDITS.


### PR DESCRIPTION
Loops with a statically known trip count of one expose a single acyclic
path and can be handled by the existing region branch op inliner.

Give that rewrite a higher benefit than the generic region branch op
canonicalizations. This ensures that the loop is inlined before dead
successor inputs can be removed independently and temporarily invalidate
the op under expensive pattern API checks.

This fixes some tests with MLIR_ENABLE_EXPENSIVE_PATTERN_API_CHECKS enabled.

Assisted-by: Codex
