### PR TITLE
[mlir][bufferization] Fix to_buffer being incorrectly hoisted by LICM

### DIFF
--- a/mlir/include/mlir/Dialect/Bufferization/IR/BufferizationOps.td
+++ b/mlir/include/mlir/Dialect/Bufferization/IR/BufferizationOps.td
@@ -503,7 +503,8 @@ def Bufferization_ToBufferOp : Bufferization_Op<"to_buffer", [
     BufferizableOpInterface,
     SameOperandsAndResultShape,
     SameOperandsAndResultElementType,
-    Pure,
+    AlwaysSpeculatable,
+    DeclareOpInterfaceMethods<MemoryEffectsOpInterface, ["getEffects"]>,
     Bufferization_TensorAndBufferMatch<"tensor", "buffer">
   ]> {
   let summary = "cast a tensor-like type to buffer-like type";
@@ -522,6 +523,12 @@ def Bufferization_ToBufferOp : Bufferization_Op<"to_buffer", [
     The `read_only` attribute can optionally be set, indicating to the
     bufferization that the buffer returned by this op (or an alias created from
     the returned buffer) will not be written to.
+
+    Memory effects: when `read_only` is not set, this op declares a write
+    effect on its result to prevent passes such as LICM from hoisting it out of
+    loops. (Hoisting would cause all loop iterations to share the same backing
+    buffer.) When `read_only` is set, no write effect is declared and the op
+    may be freely hoisted or CSE'd.
   }];
 
   let arguments = (ins Bufferization_TensorLikeTypeInterface:$tensor, UnitAttr:$read_only);

--- a/mlir/lib/Dialect/Bufferization/IR/BufferizableOpInterface.cpp
+++ b/mlir/lib/Dialect/Bufferization/IR/BufferizableOpInterface.cpp
@@ -704,6 +704,24 @@ FailureOr<Value> bufferization::getBuffer(RewriterBase &rewriter, Value value,
   if (failed(bufferType))
     return failure();
 
+  // Reuse an existing to_buffer op for the same tensor and buffer type in the
+  // same block to avoid emitting duplicate ops. Two to_buffer ops on the same
+  // tensor always alias the same underlying buffer, so they are
+  // interchangeable. Only reuse non-read_only ops: getBuffer() is called when
+  // a writable buffer is needed, so a read_only variant must not be
+  // substituted.
+  Block *insertionBlock = rewriter.getInsertionBlock();
+  for (Operation *user : value.getUsers()) {
+    auto existing = dyn_cast<bufferization::ToBufferOp>(user);
+    if (!existing || existing->getBlock() != insertionBlock)
+      continue;
+    if (existing.getType() != *bufferType)
+      continue;
+    if (existing.getReadOnly())
+      continue;
+    return existing.getResult();
+  }
+
   return bufferization::ToBufferOp::create(rewriter, value.getLoc(),
                                            *bufferType, value)
       .getResult();

--- a/mlir/lib/Dialect/Bufferization/IR/BufferizationOps.cpp
+++ b/mlir/lib/Dialect/Bufferization/IR/BufferizationOps.cpp
@@ -874,12 +874,59 @@ struct DimOfCastOp : public OpRewritePattern<memref::DimOp> {
   }
 };
 
+/// Deduplicate bufferization.to_buffer operations with the same tensor operand,
+/// result type, and read_only attribute within the same block. Two to_buffer
+/// ops on the same tensor always alias the same underlying buffer, so a later
+/// op can be replaced by an earlier one that comes before it in the same block.
+struct DeduplicateToBuffer : public OpRewritePattern<ToBufferOp> {
+  using OpRewritePattern<ToBufferOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(ToBufferOp toBuffer,
+                                PatternRewriter &rewriter) const override {
+    Value tensor = toBuffer.getTensor();
+    for (Operation *user : tensor.getUsers()) {
+      auto otherToBuffer = dyn_cast<ToBufferOp>(user);
+      if (!otherToBuffer || otherToBuffer == toBuffer)
+        continue;
+      if (otherToBuffer->getBlock() != toBuffer->getBlock())
+        continue;
+      if (!otherToBuffer->isBeforeInBlock(toBuffer))
+        continue;
+      if (otherToBuffer.getType() != toBuffer.getType())
+        continue;
+      if (otherToBuffer.getReadOnly() != toBuffer.getReadOnly())
+        continue;
+      rewriter.replaceOp(toBuffer, otherToBuffer.getResult());
+      return success();
+    }
+    return failure();
+  }
+};
+
 } // namespace
 
 void ToBufferOp::getCanonicalizationPatterns(RewritePatternSet &results,
                                              MLIRContext *context) {
-  results.add<DimOfCastOp, LoadOfToBuffer, ToBufferOfCast,
+  results.add<DeduplicateToBuffer, DimOfCastOp, LoadOfToBuffer, ToBufferOfCast,
               ToBufferToTensorFolding>(context);
+}
+
+void ToBufferOp::getEffects(
+    SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
+        &effects) {
+  // Declare a write effect on the result memref when read_only is not set.
+  // This prevents passes such as LICM from hoisting to_buffer ops out of
+  // loops: if to_buffer were hoisted, all iterations would share the same
+  // backing buffer, so writes from one iteration would corrupt another's view
+  // of the tensor's storage.
+  //
+  // When read_only is set, no writes can occur through the returned buffer so
+  // sharing across loop iterations is safe and no effects are declared, making
+  // the op eligible for hoisting/CSE.
+  if (!getReadOnly())
+    effects.emplace_back(MemoryEffects::Write::get(),
+                         mlir::cast<OpResult>(getBuffer()),
+                         SideEffects::DefaultResource::get());
 }
 
 LogicalResult ToBufferOp::bufferize(RewriterBase &rewriter,

--- a/mlir/test/Dialect/Bufferization/Transforms/one-shot-bufferize-encodings.mlir
+++ b/mlir/test/Dialect/Bufferization/Transforms/one-shot-bufferize-encodings.mlir
@@ -84,9 +84,8 @@ func.func @alloc_tesor_copy_from_non_default_space_no_cast(%arg0: tensor<128xf32
 //  CHECK-SAME: (%[[arg0:.+]]: tensor<128xf32, 1 : i64>, %[[arg1:.+]]: tensor<4xf32, 1 : i64>) -> tensor<128xf32, 1 : i64> {
 //       CHECK:     %[[v0:.+]] = bufferization.to_buffer %[[arg1]] : tensor<4xf32, 1 : i64> to memref<4xf32, strided<[?], offset: ?>, 1>
 //       CHECK:     %[[v1:.+]] = bufferization.to_buffer %[[arg0]] : tensor<128xf32, 1 : i64> to memref<128xf32, strided<[?], offset: ?>, 1>
-//       CHECK:     %[[v2:.+]] = bufferization.to_buffer %[[arg0]] : tensor<128xf32, 1 : i64> to memref<128xf32, strided<[?], offset: ?>, 1>
 //       CHECK:     %[[alloc:.+]] = memref.alloc() {alignment = 64 : i64} : memref<128xf32, 2>
-//       CHECK:     memref.copy %[[v2]], %[[alloc]] : memref<128xf32, strided<[?], offset: ?>, 1> to memref<128xf32, 2>
+//       CHECK:     memref.copy %[[v1]], %[[alloc]] : memref<128xf32, strided<[?], offset: ?>, 1> to memref<128xf32, 2>
 //       CHECK:     %[[v3:.+]] = bufferization.to_tensor %[[alloc]] : memref<128xf32, 2> to tensor<128xf32, 1 : i64>
 //       CHECK:     %[[alloc_0:.+]] = memref.alloc() {alignment = 64 : i64} : memref<128xf32, 1>
 //       CHECK:     memref.copy %[[v1]], %[[alloc_0]] : memref<128xf32, strided<[?], offset: ?>, 1> to memref<128xf32, 1>

--- a/mlir/test/Dialect/Bufferization/canonicalize.mlir
+++ b/mlir/test/Dialect/Bufferization/canonicalize.mlir
@@ -438,3 +438,42 @@ func.func @negative_input() -> tensor<?x?x?xf16> {
   %11 = bufferization.alloc_tensor(%c10, %idx-3, %idx27) : tensor<?x?x?xf16>
   return %11 : tensor<?x?x?xf16>
 }
+
+// -----
+
+// DeduplicateToBuffer: a second to_buffer on the same tensor in the same block
+// folds to the first.
+// CHECK-LABEL: func @deduplicate_to_buffer(
+// CHECK:         %[[BUF:.+]] = bufferization.to_buffer
+// CHECK-NOT:     bufferization.to_buffer
+// CHECK:         return %[[BUF]], %[[BUF]]
+func.func @deduplicate_to_buffer(%arg0: tensor<32xi32>) -> (memref<32xi32>, memref<32xi32>) {
+  %0 = bufferization.to_buffer %arg0 : tensor<32xi32> to memref<32xi32>
+  %1 = bufferization.to_buffer %arg0 : tensor<32xi32> to memref<32xi32>
+  return %0, %1 : memref<32xi32>, memref<32xi32>
+}
+
+// -----
+
+// DeduplicateToBuffer: read_only and non-read_only ops are NOT deduplicated
+// against each other (different semantics).
+// CHECK-LABEL: func @no_deduplicate_to_buffer_mixed_readonly(
+// CHECK-COUNT-2: bufferization.to_buffer
+func.func @no_deduplicate_to_buffer_mixed_readonly(%arg0: tensor<32xi32>) -> (memref<32xi32>, memref<32xi32>) {
+  %0 = bufferization.to_buffer %arg0 : tensor<32xi32> to memref<32xi32>
+  %1 = bufferization.to_buffer %arg0 read_only : tensor<32xi32> to memref<32xi32>
+  return %0, %1 : memref<32xi32>, memref<32xi32>
+}
+
+// -----
+
+// DeduplicateToBuffer: read_only ops are deduplicated with each other.
+// CHECK-LABEL: func @deduplicate_to_buffer_readonly(
+// CHECK:         %[[BUF:.+]] = bufferization.to_buffer {{.*}} read_only
+// CHECK-NOT:     bufferization.to_buffer
+// CHECK:         return %[[BUF]], %[[BUF]]
+func.func @deduplicate_to_buffer_readonly(%arg0: tensor<32xi32>) -> (memref<32xi32>, memref<32xi32>) {
+  %0 = bufferization.to_buffer %arg0 read_only : tensor<32xi32> to memref<32xi32>
+  %1 = bufferization.to_buffer %arg0 read_only : tensor<32xi32> to memref<32xi32>
+  return %0, %1 : memref<32xi32>, memref<32xi32>
+}

--- a/mlir/test/Dialect/Bufferization/side-effects.mlir
+++ b/mlir/test/Dialect/Bufferization/side-effects.mlir
@@ -7,3 +7,17 @@ func.func @test_side_effects(%arg0: memref<2xi32>) -> memref<2xi32> {
   %0 = bufferization.clone %arg0 : memref<2xi32> to memref<2xi32>
   return %0 : memref<2xi32>
 }
+
+// to_buffer without read_only has a write effect on the result (prevents LICM).
+func.func @test_to_buffer_write_effect(%arg0: tensor<2xi32>) -> memref<2xi32> {
+  // expected-remark @below {{found an instance of 'write' on op result 0, on resource '<Default>'}}
+  %0 = bufferization.to_buffer %arg0 : tensor<2xi32> to memref<2xi32>
+  return %0 : memref<2xi32>
+}
+
+// to_buffer with read_only has no side effects.
+func.func @test_to_buffer_readonly_no_effect(%arg0: tensor<2xi32>) -> memref<2xi32> {
+  // expected-remark @below {{operation has no memory effects}}
+  %0 = bufferization.to_buffer %arg0 read_only : tensor<2xi32> to memref<2xi32>
+  return %0 : memref<2xi32>
+}

--- a/mlir/test/Dialect/Transform/test-promote-tensors.mlir
+++ b/mlir/test/Dialect/Transform/test-promote-tensors.mlir
@@ -60,8 +60,6 @@ module attributes {transform.with_named_sequence} {
 func.func @promote_in0_out_bufferize(%arg0: tensor<?x42xf32>, %arg1: tensor<42x?xf32>, %arg2: tensor<?x?xf32>) -> tensor<?x?xf32> {
     // CHECK:  %[[IN1:.+]] = bufferization.to_buffer %arg1 : tensor<42x?xf32> to memref<42x?xf32, strided<[?, ?], offset: ?>>
     // CHECK:  %[[IN0:.+]] = bufferization.to_buffer %arg0 : tensor<?x42xf32> to memref<?x42xf32, strided<[?, ?], offset: ?>>
-    // CHECK:  %{{.+}} = bufferization.to_buffer %arg0 : tensor<?x42xf32> to memref<?x42xf32, strided<[?, ?], offset: ?>>
-    // CHECK:  %{{.+}} = bufferization.to_buffer %arg2 : tensor<?x?xf32> to memref<?x?xf32, strided<[?, ?], offset: ?>>
     // CHECK:  %{{.+}} = bufferization.to_buffer %arg2 : tensor<?x?xf32> to memref<?x?xf32, strided<[?, ?], offset: ?>>
     // CHECK:  %[[C0:.+]] = arith.constant 0 : index
     // CHECK:  %{{.+}} = memref.dim %{{.+}}, %[[C0]] : memref<?x?xf32, strided<[?, ?], offset: ?>>

--- a/mlir/test/Transforms/loop-invariant-code-motion.mlir
+++ b/mlir/test/Transforms/loop-invariant-code-motion.mlir
@@ -1582,3 +1582,82 @@ func.func @do_not_hoist_vector_transfer_ops_memref(
   }
   func.return %final : vector<4x4xf32>
 }
+
+// -----
+
+// bufferization.to_buffer (without read_only) should not be hoisted out of
+// loops, as it may be used to write to the tensor's buffer.
+// https://github.com/llvm/llvm-project/issues/156032
+
+// CHECK-LABEL: func @do_not_hoist_to_buffer
+// CHECK-NOT: bufferization.to_buffer
+// CHECK: scf.for
+// CHECK:   bufferization.to_buffer
+// CHECK:   linalg.fill
+func.func @do_not_hoist_to_buffer(%arg0: tensor<32xi32>, %lb: index, %ub: index, %step: index) {
+  scf.for %i = %lb to %ub step %step {
+    %buf = bufferization.to_buffer %arg0 : tensor<32xi32> to memref<32xi32>
+    %c = arith.index_cast %i : index to i32
+    linalg.fill ins(%c : i32) outs(%buf : memref<32xi32>)
+  }
+  return
+}
+
+// -----
+
+// bufferization.to_buffer with read_only attribute has no write effects and
+// may be hoisted.
+
+// CHECK-LABEL: func @hoist_to_buffer_readonly
+// CHECK: bufferization.to_buffer{{.*}}read_only
+// CHECK: scf.for
+func.func @hoist_to_buffer_readonly(%arg0: tensor<32xi32>, %lb: index, %ub: index, %step: index) {
+  scf.for %i = %lb to %ub step %step {
+    %buf = bufferization.to_buffer %arg0 read_only : tensor<32xi32> to memref<32xi32>
+    func.call @use(%buf) : (memref<32xi32>) -> ()
+  }
+  return
+}
+func.func private @use(memref<32xi32>)
+
+// -----
+
+// to_buffer (without read_only) should not be hoisted out of scf.forall either.
+// This is the original bug pattern from #156032: tensor.empty + to_buffer
+// inside a parallel loop.
+
+// CHECK-LABEL: func @do_not_hoist_to_buffer_forall
+// CHECK-NOT: bufferization.to_buffer
+// CHECK: scf.forall
+// CHECK:   bufferization.to_buffer
+// CHECK:   linalg.fill
+func.func @do_not_hoist_to_buffer_forall(%n: index) {
+  scf.forall (%i) in (%n) {
+    %t = tensor.empty() : tensor<32xi32>
+    %buf = bufferization.to_buffer %t : tensor<32xi32> to memref<32xi32>
+    %c = arith.index_cast %i : index to i32
+    linalg.fill ins(%c : i32) outs(%buf : memref<32xi32>)
+  }
+  return
+}
+
+// -----
+
+// to_buffer (without read_only) in a nested loop should not be hoisted out of
+// either loop.
+
+// CHECK-LABEL: func @do_not_hoist_to_buffer_nested
+// CHECK-NOT: bufferization.to_buffer
+// CHECK: scf.for
+// CHECK:   scf.for
+// CHECK:     bufferization.to_buffer
+func.func @do_not_hoist_to_buffer_nested(%arg0: tensor<32xi32>, %lb: index, %ub: index, %step: index) {
+  scf.for %i = %lb to %ub step %step {
+    scf.for %j = %lb to %ub step %step {
+      %buf = bufferization.to_buffer %arg0 : tensor<32xi32> to memref<32xi32>
+      %c = arith.index_cast %j : index to i32
+      linalg.fill ins(%c : i32) outs(%buf : memref<32xi32>)
+    }
+  }
+  return
+}


### PR DESCRIPTION
bufferization.to_buffer was marked as Pure, which caused LICM to hoist
it out of loops even when the returned memref is later written to. This
is incorrect: when multiple loop iterations share the same backing
buffer, writes from one iteration corrupt another's view of the tensor's
storage.

Fix by replacing Pure with AlwaysSpeculatable (to preserve speculation
behavior) and a custom getEffects that declares a MemoryEffects::Write
effect on the result when read_only is not set. With the write effect,
LICM correctly treats to_buffer as having observable side effects and
refrains from hoisting it.

When read_only is set, getEffects returns no effects, preserving the
ability to hoist and CSE such ops.

Since to_buffer now has a write effect (preventing CSE from deduplicating
it), getBuffer() in BufferizableOpInterface is updated to reuse an
already-created non-read_only to_buffer for the same tensor value in the
same block rather than emitting a fresh op each call. Two to_buffer ops
on the same tensor always alias the same underlying buffer, so reuse is
always safe. read_only ops are excluded from reuse since getBuffer() is
called when a writable buffer is needed. A companion DeduplicateToBuffer
canonicalization pattern handles any remaining duplicates within a block,
matching on tensor operand, result type, and read_only attribute.

Tests added:
- side-effects.mlir: verify write effect present/absent based on read_only
- loop-invariant-code-motion.mlir: verify to_buffer is not hoisted from
  scf.for, scf.forall, or nested loops; verify read_only variant is hoisted
- canonicalize.mlir: verify DeduplicateToBuffer folds duplicate to_buffer ops
  and does not fold across mismatched read_only attributes

Update one test that expected a now-eliminated duplicate to_buffer.


Fixes #156032

Assisted-by: Claude Code