### PR TITLE
ValueTracking: llvm.amdgcn.fract cannot introduce overflow

### DIFF
--- a/llvm/lib/Analysis/ValueTracking.cpp
+++ b/llvm/lib/Analysis/ValueTracking.cpp
@@ -4978,7 +4978,8 @@ static constexpr KnownFPClass::MinMaxKind getMinMaxKind(Intrinsic::ID IID) {
 /// magnitude smaller than 1. i.e., fabs(X) <= 1.0
 static bool isAbsoluteValueLessEqualOne(const Value *V) {
   // TODO: Handle frexp and x - floor(x)?
-  return match(V, m_Intrinsic<Intrinsic::amdgcn_trig_preop>(m_Value()));
+  return match(V, m_Intrinsic<Intrinsic::amdgcn_trig_preop>(m_Value())) ||
+         match(V, m_Intrinsic<Intrinsic::amdgcn_fract>(m_Value()));
 }
 
 void computeKnownFPClass(const Value *V, const APInt &DemandedElts,

--- a/llvm/test/Transforms/Attributor/AMDGPU/nofpclass-amdgcn-fract.ll
+++ b/llvm/test/Transforms/Attributor/AMDGPU/nofpclass-amdgcn-fract.ll
@@ -63,4 +63,30 @@ define double @ret_fract_no_nan_no_inf(double nofpclass(inf nan) %x) {
   ret double %fract
 }
 
+; Fract must be <= 1, so this cannot introduce overfloww
+define float @ret_not_inf__fmul__fract(float nofpclass(inf) %not.inf, float %x) {
+; CHECK-LABEL: define nofpclass(inf) float @ret_not_inf__fmul__fract(
+; CHECK-SAME: float nofpclass(inf) [[NOT_INF:%.*]], float [[X:%.*]]) #[[ATTR1]] {
+; CHECK-NEXT:    [[FRACT:%.*]] = call float @llvm.amdgcn.fract.f32(float [[X]]) #[[ATTR2]]
+; CHECK-NEXT:    [[MUL:%.*]] = fmul float [[NOT_INF]], [[FRACT]]
+; CHECK-NEXT:    ret float [[MUL]]
+;
+  %fract = call float @llvm.amdgcn.fract.f32(float %x)
+  %mul = fmul float %not.inf, %fract
+  ret float %mul
+}
+
+; Commuted
+define float @ret_fract__fmul__not_inf(float nofpclass(inf) %not.inf, float %x) {
+; CHECK-LABEL: define nofpclass(inf) float @ret_fract__fmul__not_inf(
+; CHECK-SAME: float nofpclass(inf) [[NOT_INF:%.*]], float [[X:%.*]]) #[[ATTR1]] {
+; CHECK-NEXT:    [[FRACT:%.*]] = call float @llvm.amdgcn.fract.f32(float [[X]]) #[[ATTR2]]
+; CHECK-NEXT:    [[MUL:%.*]] = fmul float [[FRACT]], [[NOT_INF]]
+; CHECK-NEXT:    ret float [[MUL]]
+;
+  %fract = call float @llvm.amdgcn.fract.f32(float %x)
+  %mul = fmul float %fract, %not.inf
+  ret float %mul
+}
+
 attributes #0 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }

--- a/llvm/test/Transforms/Attributor/AMDGPU/nofpclass-amdgcn-fract.ll
+++ b/llvm/test/Transforms/Attributor/AMDGPU/nofpclass-amdgcn-fract.ll
@@ -63,7 +63,7 @@ define double @ret_fract_no_nan_no_inf(double nofpclass(inf nan) %x) {
   ret double %fract
 }
 
-; Fract must be <= 1, so this cannot introduce overfloww
+; Fract must be < 1, so this cannot introduce overflow
 define float @ret_not_inf__fmul__fract(float nofpclass(inf) %not.inf, float %x) {
 ; CHECK-LABEL: define nofpclass(inf) float @ret_not_inf__fmul__fract(
 ; CHECK-SAME: float nofpclass(inf) [[NOT_INF:%.*]], float [[X:%.*]]) #[[ATTR1]] {


### PR DESCRIPTION
This returns a value with an absolute value less than 1.