### PR TITLE
[CIR][NFC] Upstream IR roundtrip tests for branch and loop ops

### DIFF
--- a/clang/test/CIR/IR/branch.cir
+++ b/clang/test/CIR/IR/branch.cir
@@ -1,0 +1,33 @@
+// RUN: cir-opt %s --verify-roundtrip | FileCheck %s
+
+cir.func @branch_with_block_argument(%cond: !cir.bool) {
+  cir.br ^bb1
+^bb1:
+  cir.br ^bb2(%cond : !cir.bool)
+^bb2(%value: !cir.bool):
+  cir.return
+}
+
+// CHECK-LABEL: cir.func @branch_with_block_argument
+// CHECK-SAME: %[[COND:.*]]: !cir.bool
+// CHECK-NEXT:   cir.br ^bb1
+// CHECK-NEXT: ^bb1:
+// CHECK-NEXT:   cir.br ^bb2(%[[COND]] : !cir.bool)
+// CHECK-NEXT: ^bb2(%{{.*}}: !cir.bool):
+// CHECK-NEXT:   cir.return
+
+cir.func @conditional_branch(%cond : !cir.bool) {
+  cir.brcond %cond ^bb1, ^bb2
+^bb1:
+  cir.return
+^bb2:
+  cir.return
+}
+
+// CHECK-LABEL: cir.func @conditional_branch
+// CHECK-SAME: %[[COND:.*]]: !cir.bool
+// CHECK-NEXT:   cir.brcond %[[COND]] ^bb1, ^bb2
+// CHECK-NEXT: ^bb1:
+// CHECK-NEXT:   cir.return
+// CHECK-NEXT: ^bb2:
+// CHECK-NEXT:   cir.return

--- a/clang/test/CIR/IR/do-while.cir
+++ b/clang/test/CIR/IR/do-while.cir
@@ -1,0 +1,17 @@
+// RUN: cir-opt %s --verify-roundtrip | FileCheck %s
+
+cir.func @do_while_loop(%cond : !cir.bool) -> !cir.void {
+  cir.do {
+    cir.yield
+  } while {
+    cir.condition(%cond)
+  }
+  cir.return
+}
+
+// CHECK-LABEL: cir.func @do_while_loop
+// CHECK-SAME: %[[COND:.*]]: !cir.bool
+// CHECK:       cir.do
+// CHECK-NEXT:    cir.yield
+// CHECK-NEXT:  while
+// CHECK-NEXT:    cir.condition(%[[COND]])

--- a/clang/test/CIR/IR/for.cir
+++ b/clang/test/CIR/IR/for.cir
@@ -1,0 +1,21 @@
+// RUN: cir-opt %s --verify-roundtrip | FileCheck %s
+
+cir.func @for_loop(%cond : !cir.bool) {
+  cir.for : cond {
+    cir.condition(%cond)
+  } body {
+    cir.yield
+  } step {
+    cir.yield
+  }
+  cir.return
+}
+
+// CHECK-LABEL: cir.func @for_loop
+// CHECK-SAME: %[[COND:.*]]: !cir.bool
+// CHECK:       cir.for : cond
+// CHECK-NEXT:    cir.condition(%[[COND]])
+// CHECK-NEXT:  body
+// CHECK-NEXT:    cir.yield
+// CHECK-NEXT:  step
+// CHECK-NEXT:    cir.yield

--- a/clang/test/CIR/IR/while.cir
+++ b/clang/test/CIR/IR/while.cir
@@ -1,0 +1,17 @@
+// RUN: cir-opt %s --verify-roundtrip | FileCheck %s
+
+cir.func @while_loop(%cond : !cir.bool) {
+  cir.while {
+    cir.condition(%cond)
+  } do {
+    cir.yield
+  }
+  cir.return
+}
+
+// CHECK-LABEL: cir.func @while_loop
+// CHECK-SAME: %[[COND:.*]]: !cir.bool
+// CHECK:       cir.while
+// CHECK-NEXT:    cir.condition(%[[COND]])
+// CHECK-NEXT:  do
+// CHECK-NEXT:    cir.yield


### PR DESCRIPTION
Add `clang/test/CIR/IR` roundtrip tests for `cir.br`, `cir.brcond`, `cir.for`, `cir.while`, and `cir.do`.

This adds parser/printer coverage for the textual forms of these control-flow operations.

Partially addresses #156747.