### PR TITLE
[lldb] guard Module::GetSectionList with a mutex

### DIFF
--- a/lldb/source/Core/Module.cpp
+++ b/lldb/source/Core/Module.cpp
@@ -1225,6 +1225,7 @@ ObjectFile *Module::GetObjectFile() {
 
 SectionList *Module::GetSectionList() {
   // Populate m_sections_up with sections from objfile.
+  std::lock_guard<std::recursive_mutex> guard(m_mutex);
   if (!m_sections_up) {
     ObjectFile *obj_file = GetObjectFile();
     if (obj_file != nullptr)


### PR DESCRIPTION
Without the lock, 2 threads could both build their own `SectionList`, and each call `m_sections_up = std::move(sections_up)`.

As a result, the thread that ran `ObjectFile::SetSectionLoadAddress` first registered its `SectionSP` objects. But the last thread to write `m_sections_up` wins, so `GetSectionList()->GetSectionAtIndex(0)` could return a `SectionSP` whose raw pointer was never registered in `SectionLoadList`. The lookup then returns `INVALID_ADDRESS`.

The mutex ensures that only one thread ever builds and assigns the `SectionList`. The thread that wins the lock also owns the `SectionSP` objects, so the pointers in `m_sections_up` and in `SectionLoadList` are always the same set.