### PR TITLE
[clang-format] Add SpaceBeforeEnumUnderlyingTypeColon for enum underlying types

### DIFF
--- a/clang/docs/ClangFormatStyleOptions.rst
+++ b/clang/docs/ClangFormatStyleOptions.rst
@@ -6834,12 +6834,14 @@ the configuration (without a prefix: ``Auto``).
 .. _SpaceBeforeInheritanceColon:
 
 **SpaceBeforeInheritanceColon** (``Boolean``) :versionbadge:`clang-format 7` :ref:`¶ <SpaceBeforeInheritanceColon>`
-  If ``false``, spaces will be removed before inheritance colon.
+  If ``false``, spaces will be removed before inheritance colon
+  and enum underlying type colon.
 
   .. code-block:: c++
 
      true:                                  false:
      class Foo : Bar {}             vs.     class Foo: Bar {}
+     enum E : int {}                        enum E: int {}
 
 .. _SpaceBeforeJsonColon:
 

--- a/clang/docs/ClangFormatStyleOptions.rst
+++ b/clang/docs/ClangFormatStyleOptions.rst
@@ -6822,7 +6822,7 @@ the configuration (without a prefix: ``Auto``).
 
 .. _SpaceBeforeCtorInitializerColon:
 
-**SpaceBeforeCtorInitializerColon** (``Boolean``) :versionbadge:`clang-format 23` :ref:`¶ <SpaceBeforeCtorInitializerColon>`
+**SpaceBeforeCtorInitializerColon** (``Boolean``) :versionbadge:`clang-format 7` :ref:`¶ <SpaceBeforeCtorInitializerColon>`
   If ``false``, spaces will be removed before constructor initializer
   colon.
 
@@ -6833,7 +6833,7 @@ the configuration (without a prefix: ``Auto``).
 
 .. _SpaceBeforeEnumUnderlyingTypeColon:
 
-**SpaceBeforeEnumUnderlyingTypeColon** (``Boolean``) :versionbadge:`clang-format 7` :ref:`¶ <SpaceBeforeEnumUnderlyingTypeColon>`
+**SpaceBeforeEnumUnderlyingTypeColon** (``Boolean``) :versionbadge:`clang-format 23` :ref:`¶ <SpaceBeforeEnumUnderlyingTypeColon>`
   If ``false``, spaces will be removed before enum underlying type colon.
 
   .. code-block:: c++

--- a/clang/docs/ClangFormatStyleOptions.rst
+++ b/clang/docs/ClangFormatStyleOptions.rst
@@ -6831,17 +6831,25 @@ the configuration (without a prefix: ``Auto``).
      true:                                  false:
      Foo::Foo() : a(a) {}                   Foo::Foo(): a(a) {}
 
+.. _SpaceBeforeEnumUnderlyingTypeColon:
+
+**SpaceBeforeEnumUnderlyingTypeColon** (``Boolean``) :versionbadge:`clang-format 7` :ref:`¶ <SpaceBeforeEnumUnderlyingTypeColon>`
+  If ``false``, spaces will be removed before enum underlying type colon.
+
+  .. code-block:: c++
+
+     true:                                  false:
+     enum E : int {}                        enum E: int {}
+
 .. _SpaceBeforeInheritanceColon:
 
 **SpaceBeforeInheritanceColon** (``Boolean``) :versionbadge:`clang-format 7` :ref:`¶ <SpaceBeforeInheritanceColon>`
-  If ``false``, spaces will be removed before inheritance colon
-  and enum underlying type colon.
+  If ``false``, spaces will be removed before inheritance colon.
 
   .. code-block:: c++
 
      true:                                  false:
      class Foo : Bar {}             vs.     class Foo: Bar {}
-     enum E : int {}                        enum E: int {}
 
 .. _SpaceBeforeJsonColon:
 

--- a/clang/docs/ClangFormatStyleOptions.rst
+++ b/clang/docs/ClangFormatStyleOptions.rst
@@ -6822,7 +6822,7 @@ the configuration (without a prefix: ``Auto``).
 
 .. _SpaceBeforeCtorInitializerColon:
 
-**SpaceBeforeCtorInitializerColon** (``Boolean``) :versionbadge:`clang-format 7` :ref:`¶ <SpaceBeforeCtorInitializerColon>`
+**SpaceBeforeCtorInitializerColon** (``Boolean``) :versionbadge:`clang-format 23` :ref:`¶ <SpaceBeforeCtorInitializerColon>`
   If ``false``, spaces will be removed before constructor initializer
   colon.
 

--- a/clang/include/clang/Format/Format.h
+++ b/clang/include/clang/Format/Format.h
@@ -5121,10 +5121,12 @@ struct FormatStyle {
   /// \version 7
   bool SpaceBeforeCtorInitializerColon;
 
-  /// If ``false``, spaces will be removed before inheritance colon.
+  /// If ``false``, spaces will be removed before inheritance colon
+  /// and enum underlying type colon.
   /// \code
   ///    true:                                  false:
   ///    class Foo : Bar {}             vs.     class Foo: Bar {}
+  ///    enum E : int {}                        enum E: int {}
   /// \endcode
   /// \version 7
   bool SpaceBeforeInheritanceColon;

--- a/clang/include/clang/Format/Format.h
+++ b/clang/include/clang/Format/Format.h
@@ -5126,7 +5126,7 @@ struct FormatStyle {
   ///    true:                                  false:
   ///    enum E : int {}                        enum E: int {}
   /// \endcode
-  /// \version 7
+  /// \version 23
   bool SpaceBeforeEnumUnderlyingTypeColon;
 
   /// If ``false``, spaces will be removed before inheritance colon.

--- a/clang/include/clang/Format/Format.h
+++ b/clang/include/clang/Format/Format.h
@@ -5121,12 +5121,18 @@ struct FormatStyle {
   /// \version 7
   bool SpaceBeforeCtorInitializerColon;
 
-  /// If ``false``, spaces will be removed before inheritance colon
-  /// and enum underlying type colon.
+  /// If ``false``, spaces will be removed before enum underlying type colon.
+  /// \code
+  ///    true:                                  false:
+  ///    enum E : int {}                        enum E: int {}
+  /// \endcode
+  /// \version 7
+  bool SpaceBeforeEnumUnderlyingTypeColon;
+
+  /// If ``false``, spaces will be removed before inheritance colon.
   /// \code
   ///    true:                                  false:
   ///    class Foo : Bar {}             vs.     class Foo: Bar {}
-  ///    enum E : int {}                        enum E: int {}
   /// \endcode
   /// \version 7
   bool SpaceBeforeInheritanceColon;

--- a/clang/lib/Format/Format.cpp
+++ b/clang/lib/Format/Format.cpp
@@ -1398,6 +1398,8 @@ template <> struct MappingTraits<FormatStyle> {
                    Style.SpaceBeforeCpp11BracedList);
     IO.mapOptional("SpaceBeforeCtorInitializerColon",
                    Style.SpaceBeforeCtorInitializerColon);
+    IO.mapOptional("SpaceBeforeEnumUnderlyingTypeColon",
+                   Style.SpaceBeforeEnumUnderlyingTypeColon);
     IO.mapOptional("SpaceBeforeInheritanceColon",
                    Style.SpaceBeforeInheritanceColon);
     IO.mapOptional("SpaceBeforeJsonColon", Style.SpaceBeforeJsonColon);
@@ -1918,6 +1920,7 @@ FormatStyle getLLVMStyle(FormatStyle::LanguageKind Language) {
   LLVMStyle.SpaceBeforeCaseColon = false;
   LLVMStyle.SpaceBeforeCpp11BracedList = false;
   LLVMStyle.SpaceBeforeCtorInitializerColon = true;
+  LLVMStyle.SpaceBeforeEnumUnderlyingTypeColon = true;
   LLVMStyle.SpaceBeforeInheritanceColon = true;
   LLVMStyle.SpaceBeforeJsonColon = false;
   LLVMStyle.SpaceBeforeParens = FormatStyle::SBPO_ControlStatements;

--- a/clang/lib/Format/FormatToken.h
+++ b/clang/lib/Format/FormatToken.h
@@ -78,6 +78,7 @@ namespace format {
   TYPE(ElseRBrace)                                                             \
   TYPE(EnumLBrace)                                                             \
   TYPE(EnumRBrace)                                                             \
+  TYPE(EnumUnderlyingTypeColon)                                                \
   TYPE(FatArrow)                                                               \
   TYPE(ForEachMacro)                                                           \
   TYPE(FunctionAnnotationRParen)                                               \

--- a/clang/lib/Format/TokenAnnotator.cpp
+++ b/clang/lib/Format/TokenAnnotator.cpp
@@ -1443,10 +1443,8 @@ private:
                  (Prev->is(TT_StartOfName) && !Scopes.empty() &&
                   Scopes.back() == ST_Class)) {
         Tok->setType(TT_BitFieldColon);
-      } else if (Contexts.size() == 1 &&
-                 Line.getFirstNonComment()->isNoneOf(tok::kw_case,
-                                                     tok::kw_default) &&
-                 !Line.startsWith(tok::kw_typedef)) {
+      } else if (Contexts.size() == 1 && Line.getFirstNonComment()->isNoneOf(
+                                             tok::kw_case, tok::kw_default)) {
         if (Prev->isOneOf(tok::r_paren, tok::kw_noexcept) ||
             Prev->ClosesRequiresClause) {
           Tok->setType(TT_CtorInitializerColon);

--- a/clang/lib/Format/TokenAnnotator.cpp
+++ b/clang/lib/Format/TokenAnnotator.cpp
@@ -1444,9 +1444,9 @@ private:
                   Scopes.back() == ST_Class)) {
         Tok->setType(TT_BitFieldColon);
       } else if (Contexts.size() == 1 &&
-                 Line.getFirstNonComment()->isNoneOf(tok::kw_enum, tok::kw_case,
+                 Line.getFirstNonComment()->isNoneOf(tok::kw_case,
                                                      tok::kw_default) &&
-                 !Line.startsWith(tok::kw_typedef, tok::kw_enum)) {
+                 !Line.startsWith(tok::kw_typedef)) {
         if (Prev->isOneOf(tok::r_paren, tok::kw_noexcept) ||
             Prev->ClosesRequiresClause) {
           Tok->setType(TT_CtorInitializerColon);

--- a/clang/lib/Format/TokenAnnotator.cpp
+++ b/clang/lib/Format/TokenAnnotator.cpp
@@ -5552,7 +5552,7 @@ bool TokenAnnotator::spaceRequiredBefore(const AnnotatedLine &Line,
   if (Right.is(TT_InheritanceColon) && !Style.SpaceBeforeInheritanceColon)
     return false;
   if (Right.is(TT_EnumUnderlyingTypeColon) &&
-      !Style.SpaceBeforeInheritanceColon) {
+      !Style.SpaceBeforeEnumUnderlyingTypeColon) {
     return false;
   }
   if (Right.is(TT_RangeBasedForLoopColon) &&

--- a/clang/lib/Format/TokenAnnotator.cpp
+++ b/clang/lib/Format/TokenAnnotator.cpp
@@ -1443,8 +1443,10 @@ private:
                  (Prev->is(TT_StartOfName) && !Scopes.empty() &&
                   Scopes.back() == ST_Class)) {
         Tok->setType(TT_BitFieldColon);
-      } else if (Contexts.size() == 1 && Line.getFirstNonComment()->isNoneOf(
-                                             tok::kw_case, tok::kw_default)) {
+      } else if (Contexts.size() == 1 &&
+                 Line.getFirstNonComment()->isNoneOf(tok::kw_enum, tok::kw_case,
+                                                     tok::kw_default) &&
+                 !Line.startsWith(tok::kw_typedef, tok::kw_enum)) {
         if (Prev->isOneOf(tok::r_paren, tok::kw_noexcept) ||
             Prev->ClosesRequiresClause) {
           Tok->setType(TT_CtorInitializerColon);
@@ -1456,12 +1458,7 @@ private:
           if (PrevPrev && PrevPrev->isOneOf(tok::r_paren, tok::kw_noexcept))
             Tok->setType(TT_CtorInitializerColon);
         } else {
-          if (Line.startsWith(tok::kw_enum) ||
-              Line.startsWith(tok::kw_typedef, tok::kw_enum)) {
-            Tok->setType(TT_EnumUnderlyingTypeColon);
-          } else {
-            Tok->setType(TT_InheritanceColon);
-          }
+          Tok->setType(TT_InheritanceColon);
           if (Prev->isAccessSpecifierKeyword())
             Line.Type = LT_AccessModifier;
         }

--- a/clang/lib/Format/TokenAnnotator.cpp
+++ b/clang/lib/Format/TokenAnnotator.cpp
@@ -1456,7 +1456,12 @@ private:
           if (PrevPrev && PrevPrev->isOneOf(tok::r_paren, tok::kw_noexcept))
             Tok->setType(TT_CtorInitializerColon);
         } else {
-          Tok->setType(TT_InheritanceColon);
+          if (Line.startsWith(tok::kw_enum) ||
+              Line.startsWith(tok::kw_typedef, tok::kw_enum)) {
+            Tok->setType(TT_EnumUnderlyingTypeColon);
+          } else {
+            Tok->setType(TT_InheritanceColon);
+          }
           if (Prev->isAccessSpecifierKeyword())
             Line.Type = LT_AccessModifier;
         }
@@ -5549,6 +5554,10 @@ bool TokenAnnotator::spaceRequiredBefore(const AnnotatedLine &Line,
     return Style.SpaceBeforeCtorInitializerColon;
   if (Right.is(TT_InheritanceColon) && !Style.SpaceBeforeInheritanceColon)
     return false;
+  if (Right.is(TT_EnumUnderlyingTypeColon) &&
+      !Style.SpaceBeforeInheritanceColon) {
+    return false;
+  }
   if (Right.is(TT_RangeBasedForLoopColon) &&
       !Style.SpaceBeforeRangeBasedForLoopColon) {
     return false;

--- a/clang/lib/Format/UnwrappedLineParser.cpp
+++ b/clang/lib/Format/UnwrappedLineParser.cpp
@@ -3839,7 +3839,7 @@ bool UnwrappedLineParser::parseEnum() {
                             tok::greater, tok::comma, tok::question,
                             tok::l_square)) {
     if (FormatTok->is(tok::colon))
-      FormatTok->setType(TT_EnumUnderlyingTypeColon);
+      FormatTok->setFinalizedType(TT_EnumUnderlyingTypeColon);
     if (Style.isVerilog()) {
       FormatTok->setFinalizedType(TT_VerilogDimensionedTypeName);
       nextToken();

--- a/clang/lib/Format/UnwrappedLineParser.cpp
+++ b/clang/lib/Format/UnwrappedLineParser.cpp
@@ -3838,6 +3838,8 @@ bool UnwrappedLineParser::parseEnum() {
          FormatTok->isOneOf(tok::colon, tok::coloncolon, tok::less,
                             tok::greater, tok::comma, tok::question,
                             tok::l_square)) {
+    if (FormatTok->is(tok::colon))
+      FormatTok->setType(TT_EnumUnderlyingTypeColon);
     if (Style.isVerilog()) {
       FormatTok->setFinalizedType(TT_VerilogDimensionedTypeName);
       nextToken();

--- a/clang/unittests/Format/ConfigParseTest.cpp
+++ b/clang/unittests/Format/ConfigParseTest.cpp
@@ -219,6 +219,7 @@ TEST(ConfigParseTest, ParsesConfigurationBools) {
   CHECK_PARSE_BOOL(SpaceBeforeCaseColon);
   CHECK_PARSE_BOOL(SpaceBeforeCpp11BracedList);
   CHECK_PARSE_BOOL(SpaceBeforeCtorInitializerColon);
+  CHECK_PARSE_BOOL(SpaceBeforeEnumUnderlyingTypeColon);
   CHECK_PARSE_BOOL(SpaceBeforeInheritanceColon);
   CHECK_PARSE_BOOL(SpaceBeforeJsonColon);
   CHECK_PARSE_BOOL(SpaceBeforeRangeBasedForLoopColon);

--- a/clang/unittests/Format/FormatTest.cpp
+++ b/clang/unittests/Format/FormatTest.cpp
@@ -18632,6 +18632,24 @@ TEST_F(FormatTest, ConfigurableSpaceBeforeColon) {
                InvertedSpaceStyle);
 }
 
+TEST_F(FormatTest, EnumUnderlyingTypeUsesInheritanceColonSpacing) {
+  FormatStyle Style = getLLVMStyle();
+
+  Style.SpaceBeforeInheritanceColon = true;
+  verifyFormat("enum A : int {};", Style);
+  verifyFormat("enum class B : int {};", Style);
+  verifyFormat("enum : int { E1 };", Style);
+  verifyFormat("typedef enum : int { E2 } E3;", Style);
+  verifyFormat("typedef enum A : int { E4 } B;", Style);
+
+  Style.SpaceBeforeInheritanceColon = false;
+  verifyFormat("enum A: int {};", Style);
+  verifyFormat("enum class B: int {};", Style);
+  verifyFormat("enum: int { E1 };", Style);
+  verifyFormat("typedef enum: int { E2 } E3;", Style);
+  verifyFormat("typedef enum A: int { E4 } B;", Style);
+}
+
 TEST_F(FormatTest, ConfigurableSpaceAroundPointerQualifiers) {
   FormatStyle Style = getLLVMStyle();
 

--- a/clang/unittests/Format/FormatTest.cpp
+++ b/clang/unittests/Format/FormatTest.cpp
@@ -18632,13 +18632,13 @@ TEST_F(FormatTest, ConfigurableSpaceBeforeColon) {
                InvertedSpaceStyle);
 }
 
-TEST_F(FormatTest, EnumUnderlyingTypeUsesInheritanceColonSpacing) {
+TEST_F(FormatTest, EnumUnderlyingTypeColonSpacing) {
   FormatStyle Style = getLLVMStyle();
 
-  Style.SpaceBeforeInheritanceColon = true;
+  Style.SpaceBeforeEnumUnderlyingTypeColon = true;
   verifyFormat("enum A : int {};", Style);
 
-  Style.SpaceBeforeInheritanceColon = false;
+  Style.SpaceBeforeEnumUnderlyingTypeColon = false;
   verifyFormat("enum A: int {};", Style);
 }
 

--- a/clang/unittests/Format/FormatTest.cpp
+++ b/clang/unittests/Format/FormatTest.cpp
@@ -18637,17 +18637,9 @@ TEST_F(FormatTest, EnumUnderlyingTypeUsesInheritanceColonSpacing) {
 
   Style.SpaceBeforeInheritanceColon = true;
   verifyFormat("enum A : int {};", Style);
-  verifyFormat("enum class B : int {};", Style);
-  verifyFormat("enum : int { E1 };", Style);
-  verifyFormat("typedef enum : int { E2 } E3;", Style);
-  verifyFormat("typedef enum A : int { E4 } B;", Style);
 
   Style.SpaceBeforeInheritanceColon = false;
   verifyFormat("enum A: int {};", Style);
-  verifyFormat("enum class B: int {};", Style);
-  verifyFormat("enum: int { E1 };", Style);
-  verifyFormat("typedef enum: int { E2 } E3;", Style);
-  verifyFormat("typedef enum A: int { E4 } B;", Style);
 }
 
 TEST_F(FormatTest, ConfigurableSpaceAroundPointerQualifiers) {

--- a/clang/unittests/Format/TokenAnnotatorTest.cpp
+++ b/clang/unittests/Format/TokenAnnotatorTest.cpp
@@ -4341,11 +4341,11 @@ TEST_F(TokenAnnotatorTest, UserDefinedLiteral) {
 
 TEST_F(TokenAnnotatorTest, EnumColon) {
   auto Tokens = annotate("enum A : int {};");
-  ASSERT_EQ(Tokens.size(), 7u) << Tokens;
+  ASSERT_EQ(Tokens.size(), 8u) << Tokens;
   EXPECT_TOKEN(Tokens[2], tok::colon, TT_EnumUnderlyingTypeColon);
 
   Tokens = annotate("enum class B : int {};");
-  ASSERT_EQ(Tokens.size(), 8u) << Tokens;
+  ASSERT_EQ(Tokens.size(), 9u) << Tokens;
   EXPECT_TOKEN(Tokens[3], tok::colon, TT_EnumUnderlyingTypeColon);
 
   Tokens = annotate("enum : int { E1 };");

--- a/clang/unittests/Format/TokenAnnotatorTest.cpp
+++ b/clang/unittests/Format/TokenAnnotatorTest.cpp
@@ -4339,10 +4339,26 @@ TEST_F(TokenAnnotatorTest, UserDefinedLiteral) {
   EXPECT_EQ(Tokens[3]->TokenText, "2_$");
 }
 
-TEST_F(TokenAnnotatorTest, EnumColonInTypedef) {
-  auto Tokens = annotate("typedef enum : int {} foo;");
+TEST_F(TokenAnnotatorTest, EnumColon) {
+  auto Tokens = annotate("enum A : int {};");
+  ASSERT_EQ(Tokens.size(), 7u) << Tokens;
+  EXPECT_TOKEN(Tokens[2], tok::colon, TT_EnumUnderlyingTypeColon);
+
+  Tokens = annotate("enum class B : int {};");
+  ASSERT_EQ(Tokens.size(), 8u) << Tokens;
+  EXPECT_TOKEN(Tokens[3], tok::colon, TT_EnumUnderlyingTypeColon);
+
+  Tokens = annotate("enum : int { E1 };");
+  ASSERT_EQ(Tokens.size(), 8u) << Tokens;
+  EXPECT_TOKEN(Tokens[1], tok::colon, TT_EnumUnderlyingTypeColon);
+
+  Tokens = annotate("typedef enum : int {} foo;");
   ASSERT_EQ(Tokens.size(), 9u) << Tokens;
-  EXPECT_TOKEN(Tokens[2], tok::colon, TT_Unknown); // Not TT_InheritanceColon.
+  EXPECT_TOKEN(Tokens[2], tok::colon, TT_EnumUnderlyingTypeColon);
+
+  Tokens = annotate("typedef enum A : int {} foo;");
+  ASSERT_EQ(Tokens.size(), 10u) << Tokens;
+  EXPECT_TOKEN(Tokens[3], tok::colon, TT_EnumUnderlyingTypeColon);
 }
 
 TEST_F(TokenAnnotatorTest, BitFieldColon) {


### PR DESCRIPTION
Introduce a new formatting option to control spacing before enum
underlying type colons. This preserves existing behavior while
allowing independent control from inheritance colon spacing.

Previously, enum underlying type colons were not configurable.
 
Fixes #188734
