### PR TITLE
[LangRef] Allow monotonic & seq_cst accesses to inter-operate with other accesses

### DIFF
--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -3976,17 +3976,18 @@ For a simpler introduction to the ordering constraints, see the
     address. All modification orders must be compatible with the
     happens-before order. There is no guarantee that the modification
     orders can be combined to a global total order for the whole program
-    (and this often will not be possible). The read in an atomic
-    read-modify-write operation (:ref:`cmpxchg <i_cmpxchg>` and
-    :ref:`atomicrmw <i_atomicrmw>`) reads the value in the modification
-    order immediately before the value it writes. If one atomic read
-    happens before another atomic read of the same address, the later
-    read must see the same value or a later value in the address's
-    modification order. This disallows reordering of ``monotonic`` (or
-    stronger) operations on the same address. If an address is written
-    ``monotonic``-ally by one thread, and other threads ``monotonic``-ally
-    read that address repeatedly, the other threads must eventually see
-    the write. This corresponds to the C/C++ ``memory_order_relaxed``.
+    (and this often will not be possible). If the read in an atomic
+    read-modify-write operation M (:ref:`cmpxchg <i_cmpxchg>` and
+    :ref:`atomicrmw <i_atomicrmw>`) reads from a ``monotonic`` write W,
+    W must be immediately before M in the address's modification order.
+    If one atomic read happens before another atomic read of the same
+    address and both are at least ``monotonic``, the later read must not
+    see an earlier value in the address's modification order. This
+    disallows reordering of ``monotonic`` (or stronger) operations on
+    the same address. If an address is written ``monotonic``-ally by one
+    thread, and other threads ``monotonic``-ally read that address
+    repeatedly, the other threads must eventually see the write. This
+    corresponds to the C/C++ ``memory_order_relaxed``.
 ``acquire``
     In addition to the guarantees of ``monotonic``, a
     *synchronizes-with* edge may be formed with a ``release`` operation.
@@ -4007,10 +4008,11 @@ For a simpler introduction to the ordering constraints, see the
     In addition to the guarantees of ``acq_rel`` (``acquire`` for an
     operation that only reads, ``release`` for an operation that only
     writes), there is a global total order on all
-    sequentially-consistent operations on all addresses. Each
-    sequentially-consistent read sees the last preceding write to the
-    same address in this global order. This corresponds to the C/C++
-    ``memory_order_seq_cst`` and Java ``volatile``.
+    sequentially-consistent operations on all addresses. If an address
+    is only accessed through sequentially-consistent operations, each
+    sequentially-consistent read of that address sees the last preceding
+    write to the same address in this global order. This corresponds to
+    the C/C++ ``memory_order_seq_cst`` and Java ``volatile``.
 
     Note: this global total order is *not* guaranteed to be fully
     consistent with the *happens-before* partial order if

--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -3978,16 +3978,16 @@ For a simpler introduction to the ordering constraints, see the
     orders can be combined to a global total order for the whole program
     (and this often will not be possible). If the read in an atomic
     read-modify-write operation M (:ref:`cmpxchg <i_cmpxchg>` and
-    :ref:`atomicrmw <i_atomicrmw>`) reads from a ``monotonic`` write W,
-    W must be immediately before M in the address's modification order.
-    If one atomic read happens before another atomic read of the same
-    address and both are at least ``monotonic``, the later read must not
-    see an earlier value in the address's modification order. This
-    disallows reordering of ``monotonic`` (or stronger) operations on
-    the same address. If an address is written ``monotonic``-ally by one
-    thread, and other threads ``monotonic``-ally read that address
-    repeatedly, the other threads must eventually see the write. This
-    corresponds to the C/C++ ``memory_order_relaxed``.
+    :ref:`atomicrmw <i_atomicrmw>`) reads from a ``monotonic`` (or
+    stronger) write W, W must be immediately before M in the address's
+    modification order. If one atomic read happens before another atomic
+    read of the same address and both are at least ``monotonic``, the
+    later read must not see an earlier value in the address's
+    modification order. This disallows reordering of ``monotonic`` (or
+    stronger) operations on the same address. If an address is written
+    ``monotonic``-ally by one thread, and other threads ``monotonic``-ally
+    read that address repeatedly, the other threads must eventually see
+    the write. This corresponds to the C/C++ ``memory_order_relaxed``.
 ``acquire``
     In addition to the guarantees of ``monotonic``, a
     *synchronizes-with* edge may be formed with a ``release`` operation.


### PR DESCRIPTION
Currently, the LangRef says that atomic operations (which includes `unordered`
operations, which don't participate in the monotonic modification order) must
read a value from the modification order of monotonic operations.

In the following example, this means that the load does not have a store it
could read from, because all stores it may see do not participate in the
monotonic modification order:

```
; thread 0:
  store atomic i32 1, ptr %p unordered, align 4

; thread 1:
  store atomic i32 2, ptr %p unordered, align 4
  load atomic i32, ptr %p unordered, align 4
```

The same applies if the load is monotonic instead of unordered (or if it is
replaced by a monotonic RMW operation). Either case seems wrong.

Similarly, the LangRef currently says "Each sequentially-consistent read sees
the last preceding write to the same address in this global order [of seq_cst
operations]." Strictly read, this means that the load in the following example
must read from the first store (or at least cannot read the second one),
because the second one is not sequentially consistent and therefore not in the
seq_cst order. That also seems wrong.

```
; thread 0
  store atomic i32 1, ptr %p seq_cst, align 4
  store atomic i32 2, ptr %p monotonic, align 4
  load atomic i32, ptr %p seq_cst, align 4
```

This patch aims to resolve these inconsistencies.

Related RFC: https://discourse.llvm.org/t/rfc-clarifying-llvm-irs-concurrent-memory-model/90480