### PR TITLE
[PowerPC] Enhance vec_rl() to generate xvrlw

### DIFF
--- a/llvm/lib/Target/PowerPC/PPCInstrAltivec.td
+++ b/llvm/lib/Target/PowerPC/PPCInstrAltivec.td
@@ -705,7 +705,8 @@ def VXOR : VXForm_1<1220, (outs vrrc:$VD), (ins vrrc:$VA, vrrc:$VB),
 
 def VRLB   : VX1_Int_Ty<   4, "vrlb", int_ppc_altivec_vrlb, v16i8>;
 def VRLH   : VX1_Int_Ty<  68, "vrlh", int_ppc_altivec_vrlh, v8i16>;
-def VRLW   : VX1_Int_Ty< 132, "vrlw", int_ppc_altivec_vrlw, v4i32>;
+def VRLW   : VXForm_1<132, (outs vrrc:$VD), (ins vrrc:$VA, vrrc:$VB),
+                      "vrlw $VD, $VA, $VB", IIC_VecFP, []>;
 
 def VSL    : VX1_Int_Ty< 452, "vsl" , int_ppc_altivec_vsl,  v4i32 >;
 def VSLO   : VX1_Int_Ty<1036, "vslo", int_ppc_altivec_vslo, v4i32>;
@@ -890,9 +891,12 @@ def : Pat<(v16i8 (rotl v16i8:$vA, v16i8:$vB)),
           (v16i8 (VRLB v16i8:$vA, v16i8:$vB))>;
 def : Pat<(v8i16 (rotl v8i16:$vA, v8i16:$vB)),
           (v8i16 (VRLH v8i16:$vA, v8i16:$vB))>;
-let Predicates = [IsNotISAFuture] in
+let Predicates = [IsNotISAFuture] in {
 def : Pat<(v4i32 (rotl v4i32:$vA, v4i32:$vB)),
           (v4i32 (VRLW v4i32:$vA, v4i32:$vB))>;
+def : Pat<(v4i32 (int_ppc_altivec_vrlw v4i32:$vA, v4i32:$vB)),
+          (v4i32 (VRLW v4i32:$vA, v4i32:$vB))>;
+}
 
 // Multiply
 def : Pat<(mul v8i16:$vA, v8i16:$vB), (VMLADDUHM $vA, $vB, (v8i16(V_SET0H)))>;

--- a/llvm/lib/Target/PowerPC/PPCInstrFuture.td
+++ b/llvm/lib/Target/PowerPC/PPCInstrFuture.td
@@ -610,6 +610,8 @@ let Predicates = [HasFutureVector, PairedVectorMemops] in {
 let Predicates = [HasFutureVector] in {
   def : Pat<(v4i32 (rotl v4i32:$vA, v4i32:$vB)), (v4i32 (XVRLW v4i32:$vA,
                                                      v4i32:$vB))>;
+  def : Pat<(v4i32 (int_ppc_altivec_vrlw v4i32:$vA, v4i32:$vB)),
+            (v4i32 (XVRLW v4i32:$vA, v4i32:$vB))>;
 }
 
 //---------------------------- Instruction aliases ---------------------------//

--- a/llvm/test/CodeGen/PowerPC/vector-rotates.ll
+++ b/llvm/test/CodeGen/PowerPC/vector-rotates.ll
@@ -134,11 +134,32 @@ entry:
   ret <4 x i32> %d
 }
 
+; Test int_ppc_altivec_vrlw intrinsic (from vec_rl() builtin)
+define <4 x i32> @rotl_v4i32_intrinsic(<4 x i32> %a, <4 x i32> %b) {
+; CHECK-P8-LABEL: rotl_v4i32_intrinsic:
+; CHECK-P8:       # %bb.0:
+; CHECK-P8-NEXT:    vrlw v2, v2, v3
+; CHECK-P8-NEXT:    blr
+;
+; CHECK-P7-LABEL: rotl_v4i32_intrinsic:
+; CHECK-P7:       # %bb.0:
+; CHECK-P7-NEXT:    vrlw v2, v2, v3
+; CHECK-P7-NEXT:    blr
+;
+; CHECK-FUTURE-LABEL: rotl_v4i32_intrinsic:
+; CHECK-FUTURE:       # %bb.0:
+; CHECK-FUTURE-NEXT:    xvrlw vs34, vs34, vs35
+; CHECK-FUTURE-NEXT:    blr
+  %res = call <4 x i32> @llvm.ppc.altivec.vrlw(<4 x i32> %a, <4 x i32> %b)
+  ret <4 x i32> %res
+}
+declare <4 x i32> @llvm.ppc.altivec.vrlw(<4 x i32>, <4 x i32>)
+
 define <2 x i64> @rotl_v2i64(<2 x i64> %a) {
 ; CHECK-P8-LABEL: rotl_v2i64:
 ; CHECK-P8:       # %bb.0: # %entry
-; CHECK-P8-NEXT:    addis r3, r2, .LCPI4_0@toc@ha
-; CHECK-P8-NEXT:    addi r3, r3, .LCPI4_0@toc@l
+; CHECK-P8-NEXT:    addis r3, r2, .LCPI5_0@toc@ha
+; CHECK-P8-NEXT:    addi r3, r3, .LCPI5_0@toc@l
 ; CHECK-P8-NEXT:    lxvd2x vs0, 0, r3
 ; CHECK-P8-NEXT:    xxswapd vs35, vs0
 ; CHECK-P8-NEXT:    vrld v2, v2, v3
@@ -160,8 +181,8 @@ define <2 x i64> @rotl_v2i64(<2 x i64> %a) {
 ;
 ; CHECK-FUTURE-LABEL: rotl_v2i64:
 ; CHECK-FUTURE:       # %bb.0: # %entry
-; CHECK-FUTURE-NEXT:    addis r3, r2, .LCPI4_0@toc@ha
-; CHECK-FUTURE-NEXT:    addi r3, r3, .LCPI4_0@toc@l
+; CHECK-FUTURE-NEXT:    addis r3, r2, .LCPI5_0@toc@ha
+; CHECK-FUTURE-NEXT:    addi r3, r3, .LCPI5_0@toc@l
 ; CHECK-FUTURE-NEXT:    lxv vs35, 0(r3)
 ; CHECK-FUTURE-NEXT:    vrld v2, v2, v3
 ; CHECK-FUTURE-NEXT:    blr


### PR DESCRIPTION
Enhance existing builtin vec_rl() to generate the new xvrlw, VSX version of vrlw, for cpu=future.