### PR TITLE
[libc++] Use --merge append when submitting to LNT

### DIFF
--- a/libcxx/utils/ci/lnt/run-benchmarks
+++ b/libcxx/utils/ci/lnt/run-benchmarks
@@ -166,7 +166,8 @@ def main(argv):
 
         logging.info(f'Submitting results to {args.lnt_url}')
         submission_url = f'{args.lnt_url}/db_default/v4/{args.test_suite}/submitRun'
-        run([build_dir / '.venv/bin/lnt', 'submit', '--ignore-regressions', submission_url, build_dir / 'benchmarks.json'])
+        run([build_dir / '.venv/bin/lnt', 'submit', '--ignore-regressions', '--merge', 'append',
+                                                    submission_url, build_dir / 'benchmarks.json'])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This ensures that we can easily gather additional runs of the same commit to reduce noise.