### PR TITLE
[MLIR] Fix outdated restriction comment in RemoveDeadValuesPass

### DIFF
--- a/mlir/include/mlir/Transforms/Passes.td
+++ b/mlir/include/mlir/Transforms/Passes.td
@@ -106,12 +106,7 @@ def RemoveDeadValuesPass : Pass<"remove-dead-values"> {
     (C) Removes unneccesary operands, results, region arguments, and region
     terminator operands of region branch ops, and,
     (D) Removes simple and region branch ops that have all non-live results and
-    don't affect memory in any way,
-
-    iff
-
-    the IR doesn't have any non-function symbol ops, non-call symbol user ops
-    and branch ops.
+    don't affect memory in any way.
 
     Here, a "simple op" refers to an op that isn't a symbol op, symbol-user op,
     region branch op, branch op, region branch terminator op, or return-like.

--- a/mlir/lib/Transforms/RemoveDeadValues.cpp
+++ b/mlir/lib/Transforms/RemoveDeadValues.cpp
@@ -19,12 +19,7 @@
 // (C) Removes unneccesary operands, results, region arguments, and region
 // terminator operands of region branch ops, and,
 // (D) Removes simple and region branch ops that have all non-live results and
-// don't affect memory in any way,
-//
-// iff
-//
-// the IR doesn't have any non-function symbol ops, non-call symbol user ops and
-// branch ops.
+// don't affect memory in any way.
 //
 // Here, a "simple op" refers to an op that isn't a symbol op, symbol-user op,
 // region branch op, branch op, region branch terminator op, or return-like.

--- a/mlir/test/Transforms/remove-dead-values.mlir
+++ b/mlir/test/Transforms/remove-dead-values.mlir
@@ -29,6 +29,27 @@ module @named_module_acceptable {
 
 // -----
 
+// Dead function arguments are removed even if the enclosing module defines a
+// symbol (has a sym_name attribute). Fixes #98700.
+//
+// CHECK: func.func private @compute(%arg0: i32) -> i32
+// CHECK-NOT: %dead_arg
+module @named_module_with_dead_args {
+  func.func private @compute(%arg0: i32, %dead_arg: i32) -> i32 {
+    return %arg0 : i32
+  }
+  // CHECK: func.func @main() -> i32
+  func.func @main() -> i32 {
+    %c1 = arith.constant 1 : i32
+    %c2 = arith.constant 2 : i32
+    // CHECK: call @compute(%c1_i32) : (i32) -> i32
+    %result = call @compute(%c1, %c2) : (i32, i32) -> i32
+    return %result : i32
+  }
+}
+
+// -----
+
 // The IR contains both conditional and unconditional branches with a loop
 // in which the last cf.cond_br is referncing the first cf.br
 //


### PR DESCRIPTION
The RemoveDeadValuesPass previously emitted an error and skipped
optimization when the IR contained non-function symbol ops, non-call
symbol user ops, or branch ops. This restriction was later removed, but
the comments in RemoveDeadValues.cpp and Passes.td still described the
pass as operating "iff the IR doesn't have any non-function symbol ops,
non-call symbol user ops and branch ops."

Remove the stale restriction text from both the .cpp file comment and
the Passes.td description. Also add a test that verifies dead function
arguments are correctly removed inside a module that defines a symbol
(has a sym_name attribute), which was the original failure case reported
in issue #98700.

Fixes #98700

Assisted-by: Claude Code