### PR TITLE
Revert "[DTLTO] Speed up temporary file removal in the ThinLTO backed

### DIFF
--- a/llvm/lib/LTO/LTO.cpp
+++ b/llvm/lib/LTO/LTO.cpp
@@ -43,7 +43,6 @@
 #include "llvm/Support/Error.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/JSON.h"
-#include "llvm/Support/ManagedStatic.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/Path.h"
 #include "llvm/Support/Process.h"
@@ -2322,45 +2321,6 @@ std::vector<int> lto::generateModulesOrdering(ArrayRef<BitcodeModule *> R) {
 }
 
 namespace {
-// There can be many temporary files to remove. Performing deletion in
-// the background can save a few seconds on Windows hosts. Experimentation
-// showed that serial deletion is most efficient, hence a single thread.
-struct BackgroundDeletion : llvm::DefaultThreadPool {
-  BackgroundDeletion()
-      : llvm::DefaultThreadPool(llvm::heavyweight_hardware_concurrency(1)) {}
-
-  ~BackgroundDeletion() {
-    wait();
-    for (const std::string &Warning : Warnings)
-      errs() << "warning: could not remove the file " << Warning << "\n";
-  }
-
-  void remove(SmallVector<std::string> &&Files, const Config &Conf) {
-    async([this, Files = std::move(Files), TTE = Conf.TimeTraceEnabled,
-           TTG = Conf.TimeTraceGranularity] {
-      if (LLVM_ENABLE_THREADS && TTE)
-        timeTraceProfilerInitialize(TTG, "Remove DTLTO temporary files");
-      {
-        llvm::TimeTraceScope TimeScope("Remove DTLTO temporary files");
-        for (const auto &F : Files) {
-          std::error_code EC = sys::fs::remove(F, true);
-          if (EC &&
-              EC != std::make_error_code(std::errc::no_such_file_or_directory))
-            Warnings.emplace_back("'" + F + "': " + EC.message());
-        }
-      }
-      if (LLVM_ENABLE_THREADS && TTE)
-        timeTraceProfilerFinishThread();
-    });
-  }
-
-  SmallVector<std::string> Warnings;
-};
-
-// Use a ManagedStatic to allow the thread to run until llvm_shutdown() is
-// called for the current process.
-static llvm::ManagedStatic<BackgroundDeletion> BackgroundDeleter;
-
 /// This out-of-process backend does not perform code generation when invoked
 /// for each task. Instead, it generates the necessary information (e.g., the
 /// summary index shard, import list, etc.) to enable code generation to be
@@ -2693,15 +2653,13 @@ public:
       return std::move(*Err);
 
     llvm::scope_exit CleanPerJobFiles([&] {
-      if (SaveTemps)
-        return;
-      SmallVector<std::string> Files;
-      for (auto &Job : Jobs) {
-        Files.push_back(std::string(Job.NativeObjectPath));
-        if (!ShouldEmitIndexFiles)
-          Files.push_back(std::string(Job.SummaryIndexPath));
-      }
-      BackgroundDeleter->remove(std::move(Files), Conf);
+      llvm::TimeTraceScope TimeScope("Remove DTLTO temporary files");
+      if (!SaveTemps)
+        for (auto &Job : Jobs) {
+          removeFile(Job.NativeObjectPath);
+          if (!ShouldEmitIndexFiles)
+            removeFile(Job.SummaryIndexPath);
+        }
     });
 
     const StringRef BCError = "DTLTO backend compilation: ";

--- a/llvm/tools/llvm-lto2/llvm-lto2.cpp
+++ b/llvm/tools/llvm-lto2/llvm-lto2.cpp
@@ -26,7 +26,6 @@
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/InitLLVM.h"
-#include "llvm/Support/ManagedStatic.h"
 #include "llvm/Support/PluginLoader.h"
 #include "llvm/Support/TargetSelect.h"
 #include "llvm/Support/Threading.h"
@@ -285,11 +284,7 @@ static int run(int argc, char **argv) {
 
   if (TimeTrace)
     timeTraceProfilerInitialize(TimeTraceGranularity, argv[0]);
-  llvm::scope_exit ShutdownScopeExit([]() {
-    // llvm_shutdown must be called before finalizing the time trace to
-    // ensure that time trace scopes from ManagedStatic destructors are
-    // flushed and recorded.
-    llvm::llvm_shutdown();
+  llvm::scope_exit TimeTraceScopeExit([]() {
     if (TimeTrace) {
       check(timeTraceProfilerWrite(TimeTraceFile, OutputFilename),
             "timeTraceProfilerWrite failed");


### PR DESCRIPTION
This reverts commit 11b439c5c5a07c95d30ce25abd6adf7f5fbb7105.

timeTraceProfilerCleanup() can be called before the temporary file deletion has completed in LLD. This causes memory leaks that were flagged up by sanitizer builds, e.g.:
https://lab.llvm.org/buildbot/#/builders/24/builds/18840/steps/11/logs/stdio