### PR TITLE
[mlir][ods] Document and test DefaultValuedProp elision in prop-dict format

### DIFF
--- a/mlir/docs/DefiningDialects/Operations.md
+++ b/mlir/docs/DefiningDialects/Operations.md
@@ -349,6 +349,10 @@ for example, in the case of array properties (which are stored as `SmallVector`s
 but use `ArrayRef` as an interface type), add the storage-type equivalent
 of the default value as the third argument.
 
+When using the `prop-dict` directive in an assembly format, the generated
+operation printing function will not print default-valued properties when the
+property value is equal to the default.
+
 To declare an optional property, use `OptionalProp<...>`.
 This wraps the underlying property in an `std::optional` and gives it a
 default value of `std::nullopt`.

--- a/mlir/test/IR/properties.mlir
+++ b/mlir/test/IR/properties.mlir
@@ -97,3 +97,27 @@ test.with_optional_properties nested = some<none>
 // CHECK-SAME: ints = [1, 2] strings = ["a", "b"] nested = {{\[}}[1, 2], [3, 4]] opt = [-1, -2] explicitOptions = [none, 0] explicitUnits = [unit, unit_absent]
 // GENERIC: "test.with_array_properties"()
 test.with_array_properties ints = [1, 2] strings = ["a", "b"] nested = [[1, 2], [3, 4]] opt = [-1, -2] explicitOptions = [none, 0] explicitUnits = [unit, unit_absent] [] thats_has_default
+
+// Tests that DefaultValuedProp is elided from prop-dict when value equals default.
+// CHECK: test.op_with_property_predicates
+// CHECK-SAME: <{array = [], more_constrained = 1 : i64, non_empty_constrained = [1], non_empty_unconstrained = [1], scalar = 1 : i64, unconstrained = 0 : i64}>
+// CHECK-NOT: defaulted
+test.op_with_property_predicates <{
+  scalar = 1 : i64,
+  more_constrained = 1 : i64,
+  array = [],
+  non_empty_unconstrained = [1],
+  non_empty_constrained = [1],
+  unconstrained = 0 : i64}>
+
+// Tests that DefaultValuedProp is printed when value differs from default.
+// CHECK: test.op_with_property_predicates
+// CHECK-SAME: defaulted = 3
+test.op_with_property_predicates <{
+  scalar = 1 : i64,
+  defaulted = 3 : i64,
+  more_constrained = 1 : i64,
+  array = [],
+  non_empty_unconstrained = [1],
+  non_empty_constrained = [1],
+  unconstrained = 0 : i64}>


### PR DESCRIPTION
Issue #152743 reports that DefaultValuedProp is printed even when the
property value equals the default, unlike DefaultValuedAttr which is not
printed in that case.

The fix for this was already present in the codebase since commit
8955e285e1ac ("[mlir] Add property combinators, initial ODS support"),
which added elision of default-valued properties in the genPropDictPrinter
function in OpFormatGen.cpp.

This commit adds:
- Documentation in Operations.md clarifying that DefaultValuedProp is
  also elided from prop-dict output when the value equals the default,
  consistent with the existing documentation for DefaultValuedAttr.
- An explicit test in properties.mlir verifying that DefaultValuedProp
  with value equal to default is elided from prop-dict output, and that
  DefaultValuedProp with a non-default value is still printed.

Fixes #152743

Assisted-by: Claude Code