### PR TITLE
[lldb] Disable arm64e tests under ASan

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/decorators.py
+++ b/lldb/packages/Python/lldbsuite/test/decorators.py
@@ -1196,6 +1196,7 @@ def skipUnlessCompilerSupports(flag):
 
     return skipTestIfFn(does_compiler_support_flag)
 
+
 def skipIfAsan(func):
     """Skip this test if the environment is set up to run LLDB *itself* under ASAN."""
     return skipTestIfFn(is_running_under_asan)(func)
@@ -1344,6 +1345,12 @@ def skipUnlessArm64eSupported(func):
         # Need debugserver built with arm64e support.
         if not configuration.arm64e_debugserver:
             return "debugserver not built with arm64e support"
+
+        # Technically ASan is supported, but we need an arm64e sanitizer
+        # runtime and we assume that's not the case unless we run the whole
+        # test suite as arm64e.
+        if is_running_under_asan():
+            return "Sanitizer runtime may not support arm64e"
 
         return None
 


### PR DESCRIPTION
Technically ASan is supported, but we need an arm64e sanitizer runtime. It's still enabled when the whole test suite runs as arm64e, assuming that you need arm64e runtimes regardless.

This will fix https://ci.swift.org/view/all/job/llvm.org/job/lldb-cmake-sanitized-os-verification/

rdar://173313715