### PR TITLE
[MLIR][ArithToSPIRV] Guard NoSignedWrap/NoUnsignedWrap behind extension/version check

### DIFF
--- a/mlir/lib/Conversion/ArithToSPIRV/ArithToSPIRV.cpp
+++ b/mlir/lib/Conversion/ArithToSPIRV/ArithToSPIRV.cpp
@@ -200,9 +200,18 @@ struct ElementwiseArithOpPattern final : OpConversionPattern<Op> {
     auto overflowFlags = arith::IntegerOverflowFlags::none;
     if (auto overflowIface =
             dyn_cast<arith::ArithIntegerOverflowFlagsInterface>(*op)) {
-      if (converter->getTargetEnv().allows(
-              spirv::Extension::SPV_KHR_no_integer_wrap_decoration))
-        overflowFlags = overflowIface.getOverflowAttr().getValue();
+      overflowFlags = overflowIface.getOverflowAttr().getValue();
+      if (overflowFlags != arith::IntegerOverflowFlags::none) {
+        const auto &targetEnv = converter->getTargetEnv();
+        bool wrapDecorationAvailable =
+            targetEnv.getVersion() >= spirv::Version::V_1_4 ||
+            targetEnv.allows(
+                spirv::Extension::SPV_KHR_no_integer_wrap_decoration);
+        if (!wrapDecorationAvailable)
+          return rewriter.notifyMatchFailure(
+              op->getLoc(), "overflow flags require SPIR-V >= v1.4 or "
+                            "SPV_KHR_no_integer_wrap_decoration extension");
+      }
     }
 
     auto newOp = rewriter.template replaceOpWithNewOp<SPIRVOp>(

--- a/mlir/test/Conversion/ArithToSPIRV/arith-to-spirv-unsupported.mlir
+++ b/mlir/test/Conversion/ArithToSPIRV/arith-to-spirv-unsupported.mlir
@@ -209,3 +209,51 @@ func.func @type_conversion_failure(%arg0: i32) {
 }
 
 } // end module
+
+// -----
+
+// Overflow flags require SPIR-V >= v1.4 or SPV_KHR_no_integer_wrap_decoration.
+// Without either, ops with nsw/nuw flags must fail.
+
+module attributes {
+  spirv.target_env = #spirv.target_env<
+    #spirv.vce<v1.0, [Int8, Int16, Int64, Float16, Float64, Shader], []>, #spirv.resource_limits<>>
+} {
+
+func.func @addi_nsw_no_ext(%arg0: i64, %arg1: i64) -> i64 {
+  // expected-error@+1 {{failed to legalize operation 'arith.addi'}}
+  %0 = arith.addi %arg0, %arg1 overflow<nsw> : i64
+  return %0 : i64
+}
+
+} // end module
+
+// -----
+
+module attributes {
+  spirv.target_env = #spirv.target_env<
+    #spirv.vce<v1.0, [Int8, Int16, Int64, Float16, Float64, Shader], []>, #spirv.resource_limits<>>
+} {
+
+func.func @subi_nuw_no_ext(%arg0: i64, %arg1: i64) -> i64 {
+  // expected-error@+1 {{failed to legalize operation 'arith.subi'}}
+  %0 = arith.subi %arg0, %arg1 overflow<nuw> : i64
+  return %0 : i64
+}
+
+} // end module
+
+// -----
+
+module attributes {
+  spirv.target_env = #spirv.target_env<
+    #spirv.vce<v1.0, [Int8, Int16, Int64, Float16, Float64, Shader], []>, #spirv.resource_limits<>>
+} {
+
+func.func @muli_nsw_nuw_no_ext(%arg0: i64, %arg1: i64) -> i64 {
+  // expected-error@+1 {{failed to legalize operation 'arith.muli'}}
+  %0 = arith.muli %arg0, %arg1 overflow<nsw, nuw> : i64
+  return %0 : i64
+}
+
+} // end module

--- a/mlir/test/Conversion/ArithToSPIRV/arith-to-spirv.mlir
+++ b/mlir/test/Conversion/ArithToSPIRV/arith-to-spirv.mlir
@@ -1578,20 +1578,20 @@ func.func @ops_flags(%arg0: i64, %arg1: i64) {
 // -----
 
 module attributes {
-  spirv.target_env = #spirv.target_env<#spirv.vce<v1.0, [Int8, Int16, Int64, Float16, Float64], []>, #spirv.resource_limits<>>
+  spirv.target_env = #spirv.target_env<#spirv.vce<v1.4, [Int8, Int16, Int64, Float16, Float64, Shader], []>, #spirv.resource_limits<>>
 } {
 
-// No decorations should be generated is corresponding Extensions/Capabilities are missing
-// CHECK-LABEL: @ops_flags
-func.func @ops_flags(%arg0: i64, %arg1: i64) {
-  // CHECK: %{{.*}} = spirv.IAdd %{{.*}}, %{{.*}} : i64
+// Decorations should be generated with SPIR-V >= v1.4 even without the extension.
+// CHECK-LABEL: @ops_flags_v1_4
+func.func @ops_flags_v1_4(%arg0: i64, %arg1: i64) {
+  // CHECK: %{{.*}} = spirv.IAdd %{{.*}}, %{{.*}} {no_signed_wrap} : i64
   %0 = arith.addi %arg0, %arg1 overflow<nsw> : i64
-  // CHECK: %{{.*}} = spirv.ISub %{{.*}}, %{{.*}} : i64
+  // CHECK: %{{.*}} = spirv.ISub %{{.*}}, %{{.*}} {no_unsigned_wrap} : i64
   %1 = arith.subi %arg0, %arg1 overflow<nuw> : i64
-  // CHECK: %{{.*}} = spirv.IMul %{{.*}}, %{{.*}} : i64
+  // CHECK: %{{.*}} = spirv.IMul %{{.*}}, %{{.*}} {no_signed_wrap, no_unsigned_wrap} : i64
   %2 = arith.muli %arg0, %arg1 overflow<nsw, nuw> : i64
-  // CHECK: %{{.*}} = spirv.IMul %{{.*}}, %{{.*}} : i64
-  %3 = arith.muli %arg0, %arg1 overflow<nsw, nuw> : i64
+  // CHECK: %{{.*}} = spirv.ShiftLeftLogical %{{.*}}, %{{.*}} {no_signed_wrap, no_unsigned_wrap} : i64
+  %3 = arith.shli %arg0, %arg1 overflow<nsw, nuw> : i64
   return
 }
 


### PR DESCRIPTION
The `ElementwiseArithOpPattern` in ArithToSPIRV was silently dropping `nsw`/`nuw` overflow flags when converting arith ops to SPIR-V if the `SPV_KHR_no_integer_wrap_decoration` extension was not available. This loses the semantics of the overflow flags without any diagnostic.

The fix changes this to:
1. Check if the target environment allows `SPV_KHR_no_integer_wrap_decoration` OR the SPIR-V version is >= 1.4 (where these decorations are core).
2. If neither condition is met and the op has nsw/nuw flags, return `notifyMatchFailure` so the conversion framework can diagnose the issue.

Adds tests for:
- Successful lowering with SPIR-V >= v1.4 without the extension
- Failed lowering of arith.addi/subi/muli with nsw/nuw on v1.0 without extension

Fixes #187450

Assisted-by: Claude Code