### PR TITLE
[libc][docs] Document libc-shared-tests ninja target

### DIFF
--- a/libc/docs/build_and_test.rst
+++ b/libc/docs/build_and_test.rst
@@ -38,6 +38,12 @@ The libc can be built and tested in two different modes:
 
         $> ninja libc-integration-tests
 
+   #. Shared tests - You can run tests for shared, standalone components (like math primitives) without needing the full libc runtime by the command:
+
+      .. code-block:: sh
+
+        $> ninja libc-shared-tests
+
 Building with VSCode
 ====================
 


### PR DESCRIPTION
Added a brief description of the libc-shared-tests target to the Building and Testing page.

This target allows running tests for shared standalone components like math primitives without the full libc runtime.