### PR TITLE
[Scudo] Disable ScudoCombinedTests.NewType

### DIFF
--- a/compiler-rt/lib/scudo/standalone/tests/combined_test.cpp
+++ b/compiler-rt/lib/scudo/standalone/tests/combined_test.cpp
@@ -1728,7 +1728,7 @@ TEST(ScudoCombinedDeathTest, AlignTypeMismatch) {
 
 // Scudo currently cannot verify that a pointer allocated with an aligned
 // new/new [] is deallocated with an aligned delete/delete [].
-TEST(ScudoCombinedTest, NewType) {
+TEST(ScudoCombinedTest, DISABLED_NewType) {
   ScopedScudoOptions Options("dealloc_type_mismatch=true");
 
   using AllocatorT = scudo::Allocator<TestMatchConfig>;


### PR DESCRIPTION
This is failing in some configurations on AArch64 Linux. Given there are a lot of follow-up commits that makes this hard to revert, just disable it for now pending future investigation.