### PR TITLE
[lldb][test] Add semicolon to @import expressions

### DIFF
--- a/lldb/test/API/commands/expression/diagnostics/TestExprDiagnostics.py
+++ b/lldb/test/API/commands/expression/diagnostics/TestExprDiagnostics.py
@@ -172,7 +172,7 @@ note: candidate function not viable: requires single argument 'x', but 2 argumen
 
         # Import foundation so that the Obj-C module is loaded (which contains source locations
         # that can be used by LLDB).
-        self.runCmd("expr --language objective-c++ -- @import Foundation")
+        self.runCmd("expr --language objective-c++ -- @import Foundation;")
         value = frame.EvaluateExpression("NSLog(1);")
         self.assertFalse(value.GetError().Success())
         # LLDB should print the source line that defines NSLog. To not rely on any

--- a/lldb/test/API/commands/expression/weak_symbols/TestWeakSymbols.py
+++ b/lldb/test/API/commands/expression/weak_symbols/TestWeakSymbols.py
@@ -75,7 +75,7 @@ class TestWeakSymbolsInExpressions(TestBase):
         self.assertTrue(self.frame.IsValid(), "Got a good frame")
         options = lldb.SBExpressionOptions()
         options.SetLanguage(lldb.eLanguageTypeObjC)
-        result = self.frame.EvaluateExpression("@import Dylib", options)
+        result = self.frame.EvaluateExpression("@import Dylib;", options)
 
         # Now run an expression that references an absent weak symbol:
         self.run_weak_var_check("absent_weak_int", False)

--- a/lldb/test/API/commands/target/dump-pcm-info/TestDumpPCMInfo.py
+++ b/lldb/test/API/commands/target/dump-pcm-info/TestDumpPCMInfo.py
@@ -26,7 +26,7 @@ class TestCase(TestBase):
         self.runCmd(f"settings set symbols.clang-modules-cache-path '{mod_cache}'")
 
         # Cause lldb to generate a Darwin-*.pcm
-        self.runCmd("expression @import Darwin")
+        self.runCmd("expression @import Darwin;")
 
         # root/<config-hash>/<module-name>-<modulemap-path-hash>.pcm
         pcm_paths = glob.glob(os.path.join(mod_cache, "*", "Darwin-*.pcm"))

--- a/lldb/test/API/functionalities/progress_reporting/clang_modules/TestClangModuleBuildProgress.py
+++ b/lldb/test/API/functionalities/progress_reporting/clang_modules/TestClangModuleBuildProgress.py
@@ -38,7 +38,7 @@ class TestCase(TestBase):
         )
 
         # Trigger module builds.
-        self.expect("expression @import MyModule")
+        self.expect("expression @import MyModule;")
 
         event = lldbutil.fetch_next_event(self, listener, broadcaster)
         payload = lldb.SBDebugger.GetProgressFromEvent(event)

--- a/lldb/test/API/lang/cpp/modules-import/TestCXXModulesImport.py
+++ b/lldb/test/API/lang/cpp/modules-import/TestCXXModulesImport.py
@@ -28,10 +28,10 @@ class CXXModulesImportTestCase(TestBase):
             self, "break here", lldb.SBFileSpec("main.cpp")
         )
 
-        self.expect("expr -l Objective-C++ -- @import Bar")
+        self.expect("expr -l Objective-C++ -- @import Bar;")
         self.expect("expr -- Bar()", substrs=["success"])
         self.expect(
-            "expr -l Objective-C++ -- @import THIS_MODULE_DOES_NOT_EXIST", error=True
+            "expr -l Objective-C++ -- @import THIS_MODULE_DOES_NOT_EXIST;", error=True
         )
 
     @skipUnlessDarwin
@@ -44,4 +44,4 @@ class CXXModulesImportTestCase(TestBase):
             self, "break here", lldb.SBFileSpec("main.cpp")
         )
 
-        self.expect("expr -l Objective-C++ -- @import Bar", error=True)
+        self.expect("expr -l Objective-C++ -- @import Bar;", error=True)

--- a/lldb/test/API/lang/objc/modules-cache/TestClangModulesCache.py
+++ b/lldb/test/API/lang/objc/modules-cache/TestClangModulesCache.py
@@ -28,5 +28,5 @@ class ObjCModulesTestCase(TestBase):
         (target, process, thread, bkpt) = lldbutil.run_to_source_breakpoint(
             self, "Set breakpoint here", self.main_source_file
         )
-        self.runCmd("expr @import Foo")
+        self.runCmd("expr @import Foo;")
         self.assertTrue(os.path.isdir(mod_cache), "module cache exists")

--- a/lldb/test/API/lang/objc/modules-non-objc-target/TestObjCModulesNonObjCTarget.py
+++ b/lldb/test/API/lang/objc/modules-non-objc-target/TestObjCModulesNonObjCTarget.py
@@ -16,7 +16,7 @@ class TestCase(TestBase):
         )
 
         # Import foundation to get some ObjC types.
-        self.expect("expr --lang objc -- @import Foundation")
+        self.expect("expr --lang objc -- @import Foundation;")
         # Do something with NSString (which requires special handling when
         # preparing to run in the target). The expression most likely can't
         # be prepared to run in the target but it should at least not crash LLDB.

--- a/lldb/test/API/lang/objc/modules-objc-property/TestModulesObjCProperty.py
+++ b/lldb/test/API/lang/objc/modules-objc-property/TestModulesObjCProperty.py
@@ -20,6 +20,6 @@ class TestCase(TestBase):
             + '"'
         )
 
-        self.runCmd("expr @import myModule")
+        self.runCmd("expr @import myModule;")
         self.expect_expr("m.propConflict", result_value="5")
         self.expect_expr("MyClass.propConflict", result_value="6")


### PR DESCRIPTION
Add a terminating `;` to `@import` statements being evaluated as expressions in lldb tests. It seems this was part of why https://github.com/llvm/llvm-project/pull/157726 broke lldb tests.