### PR TITLE
[ProfInfo] Fix integer overflow in getDisjunctionWeights

### DIFF
--- a/llvm/include/llvm/IR/ProfDataUtils.h
+++ b/llvm/include/llvm/IR/ProfDataUtils.h
@@ -256,8 +256,10 @@ getDisjunctionWeights(const SmallVector<T1, 2> &B1,
   // the product of sums, the subtracted one cancels out).
   assert(B1.size() == 2);
   assert(B2.size() == 2);
-  uint64_t FalseWeight = B1[1] * B2[1];
-  uint64_t TrueWeight = B1[0] * (B2[0] + B2[1]) + B1[1] * B2[0];
+  uint64_t FalseWeight = static_cast<uint64_t>(B1[1]) * B2[1];
+  uint64_t TrueWeight =
+      static_cast<uint64_t>(B1[0]) * (static_cast<uint64_t>(B2[0]) + B2[1]) +
+      static_cast<uint64_t>(B1[1]) * B2[0];
   return {TrueWeight, FalseWeight};
 }
 } // namespace llvm

--- a/llvm/include/llvm/IR/ProfDataUtils.h
+++ b/llvm/include/llvm/IR/ProfDataUtils.h
@@ -18,6 +18,7 @@
 #include "llvm/ADT/STLFunctionalExtras.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/IR/Metadata.h"
+#include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Compiler.h"
 #include <cstddef>
 #include <type_traits>
@@ -31,6 +32,8 @@ struct MDProfLabels {
   LLVM_ABI static const char *ExpectedBranchWeights;
   LLVM_ABI static const char *UnknownBranchWeightsMarker;
 };
+
+extern cl::opt<bool> ProfcheckDisableMetadataFixes;
 
 /// Profile-based loop metadata that should be accessed only by using
 /// \c llvm::getLoopEstimatedTripCount and \c llvm::setLoopEstimatedTripCount.
@@ -256,10 +259,18 @@ getDisjunctionWeights(const SmallVector<T1, 2> &B1,
   // the product of sums, the subtracted one cancels out).
   assert(B1.size() == 2);
   assert(B2.size() == 2);
-  uint64_t FalseWeight = static_cast<uint64_t>(B1[1]) * B2[1];
-  uint64_t TrueWeight =
-      static_cast<uint64_t>(B1[0]) * (static_cast<uint64_t>(B2[0]) + B2[1]) +
-      static_cast<uint64_t>(B1[1]) * B2[0];
+
+  uint64_t FalseWeight, TrueWeight;
+
+  if (!ProfcheckDisableMetadataFixes) {
+    FalseWeight = static_cast<uint64_t>(B1[1]) * B2[1];
+    TrueWeight =
+        static_cast<uint64_t>(B1[0]) * (static_cast<uint64_t>(B2[0]) + B2[1]) +
+        static_cast<uint64_t>(B1[1]) * B2[0];
+  } else {
+    FalseWeight = B1[1] * B2[1];
+    TrueWeight = B1[0] * (B2[0] + B2[1]) + B1[1] * B2[0];
+  }
   return {TrueWeight, FalseWeight};
 }
 } // namespace llvm

--- a/llvm/test/Transforms/SimplifyCFG/branch-weight-disjunction-overflow.ll
+++ b/llvm/test/Transforms/SimplifyCFG/branch-weight-disjunction-overflow.ll
@@ -1,0 +1,87 @@
+; RUN: opt -passes=simplifycfg -S %s | FileCheck %s
+;
+; Minimized regression for repeated branch-weight disjunction in SimplifyCFG.
+; We build a test-and-set ladder that SimplifyCFG merges through
+; mergeConditionalStores. The resulting synthesized branch must keep !prof.
+;
+; CHECK-LABEL: define void @test(
+; CHECK-LABEL: entry:
+; CHECK: br i1 %{{[0-9]+}}, label %{{[0-9]+}}, label %{{[0-9]+}}, !prof ![[BW:[0-9]+]]
+; CHECK: ![[BW]] = !{!"branch_weights", i32 {{-?[0-9]+}}, i32 {{-?[0-9]+}}}
+
+define void @test(i1 %c0, i1 %c1, i1 %c2, i1 %c3, i1 %c4, i1 %c5, i1 %c6, i1 %c7, i1 %c8, i1 %c9, ptr %p) {
+entry:
+  br i1 %c0, label %s0, label %n0, !prof !0
+
+s0:
+  store i32 1, ptr %p, align 4
+  br label %n0
+
+n0:
+  br i1 %c1, label %s1, label %n1, !prof !0
+
+s1:
+  store i32 1, ptr %p, align 4
+  br label %n1
+
+n1:
+  br i1 %c2, label %s2, label %n2, !prof !0
+
+s2:
+  store i32 1, ptr %p, align 4
+  br label %n2
+
+n2:
+  br i1 %c3, label %s3, label %n3, !prof !0
+
+s3:
+  store i32 1, ptr %p, align 4
+  br label %n3
+
+n3:
+  br i1 %c4, label %s4, label %n4, !prof !0
+
+s4:
+  store i32 1, ptr %p, align 4
+  br label %n4
+
+n4:
+  br i1 %c5, label %s5, label %n5, !prof !0
+
+s5:
+  store i32 1, ptr %p, align 4
+  br label %n5
+
+n5:
+  br i1 %c6, label %s6, label %n6, !prof !0
+
+s6:
+  store i32 1, ptr %p, align 4
+  br label %n6
+
+n6:
+  br i1 %c7, label %s7, label %n7, !prof !0
+
+s7:
+  store i32 1, ptr %p, align 4
+  br label %n7
+
+n7:
+  br i1 %c8, label %s8, label %n8, !prof !0
+
+s8:
+  store i32 1, ptr %p, align 4
+  br label %n8
+
+n8:
+  br i1 %c9, label %s9, label %exit, !prof !0
+
+s9:
+  store i32 1, ptr %p, align 4
+  br label %exit
+
+exit:
+  ret void
+}
+
+!0 = !{!"branch_weights", i32 2000, i32 0}

--- a/llvm/test/Transforms/SimplifyCFG/branch-weight-disjunction-overflow.ll
+++ b/llvm/test/Transforms/SimplifyCFG/branch-weight-disjunction-overflow.ll
@@ -6,6 +6,7 @@
 ;
 ; CHECK-LABEL: define void @test(
 ; CHECK-LABEL: entry:
+; CHECK-NOT: br i1 %{{[0-9]+}}, label %{{[0-9]+}}, label %{{[0-9]+}}{{$}}
 ; CHECK: br i1 %{{[0-9]+}}, label %{{[0-9]+}}, label %{{[0-9]+}}, !prof ![[BW:[0-9]+]]
 ; CHECK: ![[BW]] = !{!"branch_weights", i32 {{-?[0-9]+}}, i32 {{-?[0-9]+}}}
 

--- a/llvm/test/Transforms/SimplifyCFG/branch-weight-disjunction-overflow.ll
+++ b/llvm/test/Transforms/SimplifyCFG/branch-weight-disjunction-overflow.ll
@@ -6,7 +6,6 @@
 ;
 ; CHECK-LABEL: define void @test(
 ; CHECK-LABEL: entry:
-; CHECK-NOT: br i1 %{{[0-9]+}}, label %{{[0-9]+}}, label %{{[0-9]+}}{{$}}
 ; CHECK: br i1 %{{[0-9]+}}, label %{{[0-9]+}}, label %{{[0-9]+}}, !prof ![[BW:[0-9]+]]
 ; CHECK: ![[BW]] = !{!"branch_weights", i32 {{-?[0-9]+}}, i32 {{-?[0-9]+}}}
 


### PR DESCRIPTION
This PR fixes an integer overflow in [`getDisjunctionWeights`](https://github.com/llvm/llvm-project/blob/main/llvm/include/llvm/IR/ProfDataUtils.h#L241) and adds a regression test to cover the failing case. Casting branch weights before the computations solved the issue.

Issue https://github.com/llvm/llvm-project/issues/189021