### PR TITLE
libclc: Simplify fract implementation

### DIFF
--- a/libclc/clc/lib/generic/math/clc_fract.inc
+++ b/libclc/clc/lib/generic/math/clc_fract.inc
@@ -17,9 +17,9 @@
 _CLC_OVERLOAD _CLC_DEF __CLC_GENTYPE __clc_fract(__CLC_GENTYPE x,
                                                  private __CLC_GENTYPE *iptr) {
   *iptr = __clc_floor(x);
-  __CLC_GENTYPE r = __clc_fmin(x - *iptr, MIN_CONSTANT);
+  __CLC_GENTYPE sub = x - *iptr;
+  __CLC_GENTYPE r = sub >= MIN_CONSTANT ? MIN_CONSTANT : sub;
   r = __clc_isinf(x) ? __CLC_FP_LIT(0.0) : r;
-  r = __clc_isnan(x) ? x : r;
   return r;
 }
 


### PR DESCRIPTION
This is nan propagating, so it's unnatural to implement it
in terms of the nan avoiding fmin. Implement with compare and
select, which is the least constrained way to implement the clamp.