### PR TITLE
[compiler-rt] Add PTX feature specifically when CUDA is not available

### DIFF
--- a/compiler-rt/lib/profile/CMakeLists.txt
+++ b/compiler-rt/lib/profile/CMakeLists.txt
@@ -162,6 +162,8 @@ if("${COMPILER_RT_DEFAULT_TARGET_ARCH}" MATCHES "amdgcn|nvptx")
   if("${COMPILER_RT_DEFAULT_TARGET_ARCH}" MATCHES "amdgcn")
     append_list_if(COMPILER_RT_HAS_CODE_OBJECT_VERSION_FLAG
                    "SHELL:-Xclang -mcode-object-version=none" EXTRA_FLAGS)
+  elseif("${COMPILER_RT_DEFAULT_TARGET_ARCH}" MATCHES "nvptx")
+    list(APPEND EXTRA_FLAGS --cuda-feature=+ptx63)
   endif()
 endif()
 


### PR DESCRIPTION
Summary:
People need to be able to build this without a CUDA installation.

Long term we should bump up the minimum version as I'm pretty sure every
architecture before this has been deprecated by NVIDIA.
