### PR TITLE
[NFC][LLVM] Drop unused field from `IITDescriptor`

### DIFF
--- a/llvm/include/llvm/IR/Intrinsics.h
+++ b/llvm/include/llvm/IR/Intrinsics.h
@@ -184,7 +184,6 @@ namespace Intrinsic {
 
     union {
       unsigned Integer_Width;
-      unsigned Float_Width;
       unsigned Pointer_AddressSpace;
       unsigned Struct_NumElements;
       unsigned Argument_Info;


### PR DESCRIPTION
Drop unused `Float_Width` field from `IITDescriptor`.