### PR TITLE
[llvm lib] Read/write non-power-of-two sized unsigned integers (3, 5, 6, 7 bytes) in DataExtractor and FileWriter

### DIFF
--- a/llvm/include/llvm/DebugInfo/GSYM/FileWriter.h
+++ b/llvm/include/llvm/DebugInfo/GSYM/FileWriter.h
@@ -74,6 +74,16 @@ public:
   /// \param   Value The value to write into the stream.
   LLVM_ABI void writeULEB(uint64_t Value);
 
+  /// Write a single unsigned value into the stream at the current file
+  /// position. The value will be byte swapped if needed to match the byte
+  /// order specified during construction. The size of the value is specified
+  /// by the Size parameter.
+  ///
+  /// \param   Value The value to write into the stream. The higher bits which
+  ///          don't fit into ByteSize should be zero.
+  /// \param   ByteSize The size of the value to write in bytes. Can be 1-8.
+  LLVM_ABI void writeUnsigned(uint64_t Value, size_t ByteSize);
+
   /// Write an array of uint8_t values into the stream at the current file
   /// position.
   ///

--- a/llvm/lib/DebugInfo/GSYM/FileWriter.cpp
+++ b/llvm/lib/DebugInfo/GSYM/FileWriter.cpp
@@ -52,7 +52,8 @@ void FileWriter::writeU64(uint64_t U) {
 void FileWriter::writeUnsigned(uint64_t Value, size_t ByteSize) {
   assert(ByteSize <= 8 && "invalid byte size");
   // Make sure the value fits in the number of bytes specified.
-  assert((ByteSize == 8 || (Value & (uint64_t)-1 << (8 * ByteSize)) == 0) && "potential data loss: higher bits are non-zero");
+  assert((ByteSize == 8 || (Value & (uint64_t)-1 << (8 * ByteSize)) == 0) &&
+         "potential data loss: higher bits are non-zero");
   // Swap and shift bytes if endianness doesn't match.
   if (ByteOrder != llvm::endianness::native) {
     // Say ByteSize is 3.

--- a/llvm/lib/DebugInfo/GSYM/FileWriter.cpp
+++ b/llvm/lib/DebugInfo/GSYM/FileWriter.cpp
@@ -49,6 +49,22 @@ void FileWriter::writeU64(uint64_t U) {
   OS.write(reinterpret_cast<const char *>(&Swapped), sizeof(Swapped));
 }
 
+void FileWriter::writeUnsigned(uint64_t Value, size_t ByteSize) {
+  assert(ByteSize <= 8 && "invalid byte size");
+  // Make sure the value fits in the number of bytes specified.
+  assert((ByteSize == 8 || (Value & (uint64_t)-1 << (8 * ByteSize)) == 0) && "potential data loss: higher bits are non-zero");
+  // Swap and shift bytes if endianness doesn't match.
+  if (ByteOrder != llvm::endianness::native) {
+    // Say ByteSize is 3.
+    //                high                low
+    // Input bytes:   00 00 00 00 00 AA BB CC
+    // Swapped bytes: CC BB AA 00 00 00 00 00
+    // Shifted bytes: 00 00 00 00 00 CC BB AA
+    Value = sys::getSwappedBytes(Value) >> (8 * (8 - ByteSize));
+  }
+  OS.write(reinterpret_cast<const char *>(&Value), ByteSize);
+}
+
 void FileWriter::fixup32(uint32_t U, uint64_t Offset) {
   const uint32_t Swapped = support::endian::byte_swap(U, ByteOrder);
   OS.pwrite(reinterpret_cast<const char *>(&Swapped), sizeof(Swapped),

--- a/llvm/lib/Support/DataExtractor.cpp
+++ b/llvm/lib/Support/DataExtractor.cpp
@@ -147,10 +147,10 @@ uint64_t DataExtractor::getUnsigned(uint64_t *offset_ptr, uint32_t byte_size,
   std::memcpy(&val, &Data.data()[offset], byte_size);
   if (sys::IsLittleEndianHost != IsLittleEndian)
     // Say byte_size is 3.
-    //                             high                low
-    // The read value would be:    00 00 00 00 00 AA BB CC
-    // The swapped bytes would be: CC BB AA 00 00 00 00 00
-    // The shifted bytes would be: 00 00 00 00 00 CC BB AA
+    //                high                low
+    // Read bytes:    00 00 00 00 00 AA BB CC
+    // Swapped bytes: CC BB AA 00 00 00 00 00
+    // Shifted bytes: 00 00 00 00 00 CC BB AA
     val = sys::getSwappedBytes(val) >> (8 * (8 - byte_size));
 
   // Advance the offset

--- a/llvm/lib/Support/DataExtractor.cpp
+++ b/llvm/lib/Support/DataExtractor.cpp
@@ -135,7 +135,27 @@ uint64_t DataExtractor::getUnsigned(uint64_t *offset_ptr, uint32_t byte_size,
   case 8:
     return getU64(offset_ptr, Err);
   }
-  llvm_unreachable("getUnsigned unhandled case!");
+
+  // For any other byte size, read the bytes and swap/shift if necessary.
+  ErrorAsOutParameter ErrAsOut(Err);
+  uint64_t val = 0;
+  if (isError(Err))
+    return val;
+  uint64_t offset = *offset_ptr;
+  if (!prepareRead(offset, byte_size, Err))
+    return val;
+  std::memcpy(&val, &Data.data()[offset], byte_size);
+  if (sys::IsLittleEndianHost != IsLittleEndian)
+    // Say byte_size is 3.
+    //                             high                low
+    // The read value would be:    00 00 00 00 00 AA BB CC
+    // The swapped bytes would be: CC BB AA 00 00 00 00 00
+    // The shifted bytes would be: 00 00 00 00 00 CC BB AA
+    val = sys::getSwappedBytes(val) >> (8 * (8 - byte_size));
+
+  // Advance the offset
+  *offset_ptr += byte_size;
+  return val;
 }
 
 int64_t

--- a/llvm/unittests/DebugInfo/GSYM/GSYMTest.cpp
+++ b/llvm/unittests/DebugInfo/GSYM/GSYMTest.cpp
@@ -621,6 +621,43 @@ TEST(GSYMTest, TestFileWriter) {
   TestFileWriterHelper(llvm::endianness::big);
 }
 
+static void TestWriteUnsignedHelper(llvm::endianness ByteOrder) {
+  SmallString<512> Str;
+  raw_svector_ostream OutStrm(Str);
+  FileWriter FW(OutStrm, ByteOrder);
+  const bool IsLittleEndian = ByteOrder == llvm::endianness::little;
+
+  // Write values of sizes 1 through 8.
+  FW.writeUnsigned(0x01, 1);
+  FW.writeUnsigned(0x0102, 2);
+  FW.writeUnsigned(0x010203, 3);
+  FW.writeUnsigned(0x01020304, 4);
+  FW.writeUnsigned(0x0102030405, 5);
+  FW.writeUnsigned(0x010203040506, 6);
+  FW.writeUnsigned(0x01020304050607, 7);
+  FW.writeUnsigned(0x0102030405060708, 8);
+
+  std::string Bytes(OutStrm.str());
+  DataExtractor Data(Bytes, IsLittleEndian, 8);
+  uint64_t Offset = 0;
+
+  EXPECT_EQ(0x01U, Data.getUnsigned(&Offset, 1));
+  EXPECT_EQ(0x0102U, Data.getUnsigned(&Offset, 2));
+  EXPECT_EQ(0x010203U, Data.getUnsigned(&Offset, 3));
+  EXPECT_EQ(0x01020304U, Data.getUnsigned(&Offset, 4));
+  EXPECT_EQ(0x0102030405U, Data.getUnsigned(&Offset, 5));
+  EXPECT_EQ(0x010203040506U, Data.getUnsigned(&Offset, 6));
+  EXPECT_EQ(0x01020304050607U, Data.getUnsigned(&Offset, 7));
+  EXPECT_EQ(0x0102030405060708U, Data.getUnsigned(&Offset, 8));
+  EXPECT_EQ(Offset, Str.size());
+}
+
+TEST(GSYMTest, TestWriteUnsigned) {
+  TestWriteUnsignedHelper(llvm::endianness::little);
+  TestWriteUnsignedHelper(llvm::endianness::big);
+  TestWriteUnsignedHelper(llvm::endianness::native);
+}
+
 TEST(GSYMTest, TestAddressRangeEncodeDecode) {
   // Test encoding and decoding AddressRange objects. AddressRange objects
   // are always stored as offsets from the a base address. The base address

--- a/llvm/unittests/Support/DataExtractorTest.cpp
+++ b/llvm/unittests/Support/DataExtractorTest.cpp
@@ -72,6 +72,92 @@ TEST(DataExtractorTest, UnsignedNumbers) {
   EXPECT_EQ(8U, offset);
 }
 
+TEST(DataExtractorTest, GetUnsigned) {
+  // Use data with distinct byte values so each size produces a unique result.
+  const char data[] = "\x01\x02\x03\x04\x05\x06\x07\x08";
+  uint64_t offset;
+
+  // Big-endian data.
+  DataExtractor DE(StringRef(data, sizeof(data) - 1), false, 8);
+
+  offset = 0;
+  EXPECT_EQ(0x01U, DE.getUnsigned(&offset, 1));
+  EXPECT_EQ(1U, offset);
+
+  offset = 0;
+  EXPECT_EQ(0x0102U, DE.getUnsigned(&offset, 2));
+  EXPECT_EQ(2U, offset);
+
+  offset = 0;
+  EXPECT_EQ(0x010203U, DE.getUnsigned(&offset, 3));
+  EXPECT_EQ(3U, offset);
+
+  offset = 0;
+  EXPECT_EQ(0x01020304U, DE.getUnsigned(&offset, 4));
+  EXPECT_EQ(4U, offset);
+
+  offset = 0;
+  EXPECT_EQ(0x0102030405U, DE.getUnsigned(&offset, 5));
+  EXPECT_EQ(5U, offset);
+
+  offset = 0;
+  EXPECT_EQ(0x010203040506U, DE.getUnsigned(&offset, 6));
+  EXPECT_EQ(6U, offset);
+
+  offset = 0;
+  EXPECT_EQ(0x01020304050607U, DE.getUnsigned(&offset, 7));
+  EXPECT_EQ(7U, offset);
+
+  offset = 0;
+  EXPECT_EQ(0x0102030405060708U, DE.getUnsigned(&offset, 8));
+  EXPECT_EQ(8U, offset);
+
+  // Non-zero starting offset.
+  offset = 3;
+  EXPECT_EQ(0x040506U, DE.getUnsigned(&offset, 3));
+  EXPECT_EQ(6U, offset);
+
+  // Little-endian data.
+  DE = DataExtractor(StringRef(data, sizeof(data) - 1), true, 8);
+
+  offset = 0;
+  EXPECT_EQ(0x01U, DE.getUnsigned(&offset, 1));
+  EXPECT_EQ(1U, offset);
+
+  offset = 0;
+  EXPECT_EQ(0x0201U, DE.getUnsigned(&offset, 2));
+  EXPECT_EQ(2U, offset);
+
+  offset = 0;
+  EXPECT_EQ(0x030201U, DE.getUnsigned(&offset, 3));
+  EXPECT_EQ(3U, offset);
+
+  offset = 0;
+  EXPECT_EQ(0x04030201U, DE.getUnsigned(&offset, 4));
+  EXPECT_EQ(4U, offset);
+
+  offset = 0;
+  EXPECT_EQ(0x0504030201U, DE.getUnsigned(&offset, 5));
+  EXPECT_EQ(5U, offset);
+
+  offset = 0;
+  EXPECT_EQ(0x060504030201U, DE.getUnsigned(&offset, 6));
+  EXPECT_EQ(6U, offset);
+
+  offset = 0;
+  EXPECT_EQ(0x07060504030201U, DE.getUnsigned(&offset, 7));
+  EXPECT_EQ(7U, offset);
+
+  offset = 0;
+  EXPECT_EQ(0x0807060504030201U, DE.getUnsigned(&offset, 8));
+  EXPECT_EQ(8U, offset);
+
+  // Non-zero starting offset.
+  offset = 3;
+  EXPECT_EQ(0x060504U, DE.getUnsigned(&offset, 3));
+  EXPECT_EQ(6U, offset);
+}
+
 TEST(DataExtractorTest, SignedNumbers) {
   DataExtractor DE(StringRef(numberData, sizeof(numberData)-1), false, 8);
   uint64_t offset = 0;

--- a/llvm/unittests/Support/DataExtractorTest.cpp
+++ b/llvm/unittests/Support/DataExtractorTest.cpp
@@ -72,90 +72,41 @@ TEST(DataExtractorTest, UnsignedNumbers) {
   EXPECT_EQ(8U, offset);
 }
 
-TEST(DataExtractorTest, GetUnsigned) {
+static void TestGetUnsignedHelper(bool IsLittleEndian) {
   // Use data with distinct byte values so each size produces a unique result.
   const char data[] = "\x01\x02\x03\x04\x05\x06\x07\x08";
-  uint64_t offset;
+  DataExtractor DE(StringRef(data, sizeof(data) - 1), IsLittleEndian, 8);
 
-  // Big-endian data.
-  DataExtractor DE(StringRef(data, sizeof(data) - 1), false, 8);
+  // Expected values for big-endian: bytes are read high-to-low.
+  // Expected values for little-endian: bytes are read low-to-high.
+  const uint64_t Expected[] = {
+      0,
+      IsLittleEndian ? 0x01U : 0x01U,
+      IsLittleEndian ? 0x0201U : 0x0102U,
+      IsLittleEndian ? 0x030201U : 0x010203U,
+      IsLittleEndian ? 0x04030201U : 0x01020304U,
+      IsLittleEndian ? 0x0504030201U : 0x0102030405U,
+      IsLittleEndian ? 0x060504030201U : 0x010203040506U,
+      IsLittleEndian ? 0x07060504030201U : 0x01020304050607U,
+      IsLittleEndian ? 0x0807060504030201U : 0x0102030405060708U,
+  };
 
-  offset = 0;
-  EXPECT_EQ(0x01U, DE.getUnsigned(&offset, 1));
-  EXPECT_EQ(1U, offset);
-
-  offset = 0;
-  EXPECT_EQ(0x0102U, DE.getUnsigned(&offset, 2));
-  EXPECT_EQ(2U, offset);
-
-  offset = 0;
-  EXPECT_EQ(0x010203U, DE.getUnsigned(&offset, 3));
-  EXPECT_EQ(3U, offset);
-
-  offset = 0;
-  EXPECT_EQ(0x01020304U, DE.getUnsigned(&offset, 4));
-  EXPECT_EQ(4U, offset);
-
-  offset = 0;
-  EXPECT_EQ(0x0102030405U, DE.getUnsigned(&offset, 5));
-  EXPECT_EQ(5U, offset);
-
-  offset = 0;
-  EXPECT_EQ(0x010203040506U, DE.getUnsigned(&offset, 6));
-  EXPECT_EQ(6U, offset);
-
-  offset = 0;
-  EXPECT_EQ(0x01020304050607U, DE.getUnsigned(&offset, 7));
-  EXPECT_EQ(7U, offset);
-
-  offset = 0;
-  EXPECT_EQ(0x0102030405060708U, DE.getUnsigned(&offset, 8));
-  EXPECT_EQ(8U, offset);
+  for (uint32_t Size = 1; Size <= 8; ++Size) {
+    uint64_t Offset = 0;
+    EXPECT_EQ(Expected[Size], DE.getUnsigned(&Offset, Size));
+    EXPECT_EQ(uint64_t(Size), Offset);
+  }
 
   // Non-zero starting offset.
-  offset = 3;
-  EXPECT_EQ(0x040506U, DE.getUnsigned(&offset, 3));
-  EXPECT_EQ(6U, offset);
+  uint64_t Offset = 3;
+  uint64_t ExpectedAt3 = IsLittleEndian ? 0x060504U : 0x040506U;
+  EXPECT_EQ(ExpectedAt3, DE.getUnsigned(&Offset, 3));
+  EXPECT_EQ(6U, Offset);
+}
 
-  // Little-endian data.
-  DE = DataExtractor(StringRef(data, sizeof(data) - 1), true, 8);
-
-  offset = 0;
-  EXPECT_EQ(0x01U, DE.getUnsigned(&offset, 1));
-  EXPECT_EQ(1U, offset);
-
-  offset = 0;
-  EXPECT_EQ(0x0201U, DE.getUnsigned(&offset, 2));
-  EXPECT_EQ(2U, offset);
-
-  offset = 0;
-  EXPECT_EQ(0x030201U, DE.getUnsigned(&offset, 3));
-  EXPECT_EQ(3U, offset);
-
-  offset = 0;
-  EXPECT_EQ(0x04030201U, DE.getUnsigned(&offset, 4));
-  EXPECT_EQ(4U, offset);
-
-  offset = 0;
-  EXPECT_EQ(0x0504030201U, DE.getUnsigned(&offset, 5));
-  EXPECT_EQ(5U, offset);
-
-  offset = 0;
-  EXPECT_EQ(0x060504030201U, DE.getUnsigned(&offset, 6));
-  EXPECT_EQ(6U, offset);
-
-  offset = 0;
-  EXPECT_EQ(0x07060504030201U, DE.getUnsigned(&offset, 7));
-  EXPECT_EQ(7U, offset);
-
-  offset = 0;
-  EXPECT_EQ(0x0807060504030201U, DE.getUnsigned(&offset, 8));
-  EXPECT_EQ(8U, offset);
-
-  // Non-zero starting offset.
-  offset = 3;
-  EXPECT_EQ(0x060504U, DE.getUnsigned(&offset, 3));
-  EXPECT_EQ(6U, offset);
+TEST(DataExtractorTest, GetUnsigned) {
+  TestGetUnsignedHelper(false);
+  TestGetUnsignedHelper(true);
 }
 
 TEST(DataExtractorTest, SignedNumbers) {


### PR DESCRIPTION
This allows tools (like gsymutil) to pack data more efficiently into a file.