### PR TITLE
[lldb] Use Address(section, offset) constructor in more places (NFC)

### DIFF
--- a/lldb/include/lldb/Core/Address.h
+++ b/lldb/include/lldb/Core/Address.h
@@ -457,18 +457,6 @@ public:
     return false;
   }
 
-  /// Set accessor for the section.
-  ///
-  /// \param[in] section_sp
-  ///     A new lldb::Section pointer to use as the section base. Can
-  ///     be NULL for absolute addresses that are not relative to
-  ///     any section.
-  void SetSection(const lldb::SectionSP &section_sp) {
-    m_section_wp = section_sp;
-  }
-
-  void ClearSection() { m_section_wp.reset(); }
-
   /// Reconstruct a symbol context from an address.
   ///
   /// This class doesn't inherit from SymbolContextScope because many address

--- a/lldb/source/API/SBAddress.cpp
+++ b/lldb/source/API/SBAddress.cpp
@@ -89,8 +89,7 @@ void SBAddress::SetAddress(lldb::SBSection section, lldb::addr_t offset) {
   LLDB_INSTRUMENT_VA(this, section, offset);
 
   Address &addr = ref();
-  addr.SetSection(section.GetSP());
-  addr.SetOffset(offset);
+  addr = Address(section.GetSP(), offset);
 }
 
 void SBAddress::SetAddress(const Address &address) { ref() = address; }

--- a/lldb/source/Core/Section.cpp
+++ b/lldb/source/Core/Section.cpp
@@ -254,8 +254,7 @@ bool Section::ResolveContainedAddress(addr_t offset, Address &so_addr,
       return child_section->ResolveContainedAddress(offset - child_offset,
                                                     so_addr, allow_section_end);
   }
-  so_addr.SetOffset(offset);
-  so_addr.SetSection(const_cast<Section *>(this)->shared_from_this());
+  so_addr = Address(const_cast<Section *>(this)->shared_from_this(), offset);
 
   // Ensure that there are no orphaned (i.e., moduleless) sections.
   assert(GetModule().get());

--- a/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.cpp
+++ b/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.cpp
@@ -3522,10 +3522,8 @@ void ObjectFileMachO::ParseSymtab(Symtab &symtab) {
                                 // Copy the address, because often the N_GSYM
                                 // address has an invalid address of zero
                                 // when the global is a common symbol
-                                sym[GSYM_sym_idx].GetAddressRef().SetSection(
-                                    symbol_section);
-                                sym[GSYM_sym_idx].GetAddressRef().SetOffset(
-                                    symbol_value);
+                                sym[GSYM_sym_idx].GetAddressRef() =
+                                    Address(symbol_section, symbol_value);
                                 add_symbol_addr(sym[GSYM_sym_idx]
                                                     .GetAddress()
                                                     .GetFileAddress());
@@ -3546,8 +3544,8 @@ void ObjectFileMachO::ParseSymtab(Symtab &symtab) {
                       sym[sym_idx].SetID(nlist_idx);
                       sym[sym_idx].SetType(type);
                       if (set_value) {
-                        sym[sym_idx].GetAddressRef().SetSection(symbol_section);
-                        sym[sym_idx].GetAddressRef().SetOffset(symbol_value);
+                        sym[sym_idx].GetAddressRef() =
+                            Address(symbol_section, symbol_value);
                         add_symbol_addr(
                             sym[sym_idx].GetAddress().GetFileAddress());
                       }
@@ -4259,8 +4257,8 @@ void ObjectFileMachO::ParseSymtab(Symtab &symtab) {
                 m_nlist_idx_to_sym_idx[nlist_idx] = GSYM_sym_idx;
                 // Copy the address, because often the N_GSYM address has an
                 // invalid address of zero when the global is a common symbol.
-                sym[GSYM_sym_idx].GetAddressRef().SetSection(symbol_section);
-                sym[GSYM_sym_idx].GetAddressRef().SetOffset(symbol_value);
+                sym[GSYM_sym_idx].GetAddressRef() =
+                    Address(symbol_section, symbol_value);
                 add_symbol_addr(
                     sym[GSYM_sym_idx].GetAddress().GetFileAddress());
                 // We just need the flags from the linker symbol, so put these
@@ -4278,8 +4276,7 @@ void ObjectFileMachO::ParseSymtab(Symtab &symtab) {
       sym[sym_idx].SetID(nlist_idx);
       sym[sym_idx].SetType(type);
       if (set_value) {
-        sym[sym_idx].GetAddressRef().SetSection(symbol_section);
-        sym[sym_idx].GetAddressRef().SetOffset(symbol_value);
+        sym[sym_idx].GetAddressRef() = Address(symbol_section, symbol_value);
         if (symbol_section)
           add_symbol_addr(sym[sym_idx].GetAddress().GetFileAddress());
       }
@@ -5171,10 +5168,8 @@ lldb_private::Address ObjectFileMachO::GetBaseAddress() {
   if (section_list) {
     SectionSP text_segment_sp(
         section_list->FindSectionByName(GetSegmentNameTEXT()));
-    if (text_segment_sp) {
-      header_addr.SetSection(text_segment_sp);
-      header_addr.SetOffset(0);
-    }
+    if (text_segment_sp)
+      header_addr = Address(text_segment_sp, /*offset=*/0);
   }
   return header_addr;
 }

--- a/lldb/unittests/Symbol/SymbolTest.cpp
+++ b/lldb/unittests/Symbol/SymbolTest.cpp
@@ -131,6 +131,6 @@ TEST(SymbolTest, EncodeDecodeSymbol) {
   symbol.SetIsWeak(false);
 
   // Test encoding a symbol with no address.
-  symbol.GetAddressRef().SetSection(SectionSP());
+  symbol.GetAddressRef() = Address(SectionSP(), /*offset=*/0);
   EncodeDecode(symbol, &sect_list);
 }


### PR DESCRIPTION
After this change, Address::SetSection() had only one use left (in a unit test) and was removed. Address::ClearSection() had no uses, now also removed. (It is unlikely that someone needs to change the section without simultaneously changing the section offset, and for that we have a constructor.)
