### PR TITLE
[ADT] implement countl_zero_constexpr and reuse it for countl_zero & bit_width_constexpr

### DIFF
--- a/llvm/include/llvm/ADT/bit.h
+++ b/llvm/include/llvm/ADT/bit.h
@@ -247,10 +247,15 @@ template <typename T> [[nodiscard]] constexpr int countl_zero_constexpr(T Val) {
   Val |= (Val >> 1);
   Val |= (Val >> 2);
   Val |= (Val >> 4);
-  if constexpr (Digits > 8)  Val |= (Val >> 8);
-  if constexpr (Digits > 16) Val |= (Val >> 16);
-  if constexpr (Digits > 32) Val |= (Val >> 32);
-
+  if constexpr (Digits > 8) {
+    Val |= (Val >> 8);
+  }
+  if constexpr (Digits > 16) {
+    Val |= (Val >> 16);
+  }
+  if constexpr (Digits > 32) {
+    Val |= (Val >> 32);
+  }
   return Digits - llvm::popcount(Val);
 }
 

--- a/llvm/include/llvm/ADT/bit.h
+++ b/llvm/include/llvm/ADT/bit.h
@@ -230,6 +230,33 @@ template <typename T> [[nodiscard]] int countr_zero(T Val) {
 /// Count number of 0's from the most significant bit to the least
 ///   stopping at the first 1.
 ///
+/// A constexpr version of countl_zero.
+///
+/// Only unsigned integral types are allowed.
+///
+/// Returns std::numeric_limits<T>::digits on an input of 0.
+template <typename T> [[nodiscard]] constexpr int countl_zero_constexpr(T Val) {
+  static_assert(std::is_unsigned_v<T>,
+                "Only unsigned integral types are allowed.");
+
+  constexpr int Digits = std::numeric_limits<T>::digits;
+
+  if (!Val)
+    return Digits;
+
+  Val |= (Val >> 1);
+  Val |= (Val >> 2);
+  Val |= (Val >> 4);
+  if constexpr (Digits > 8)  Val |= (Val >> 8);
+  if constexpr (Digits > 16) Val |= (Val >> 16);
+  if constexpr (Digits > 32) Val |= (Val >> 32);
+
+  return Digits - llvm::popcount(Val);
+}
+
+/// Count number of 0's from the most significant bit to the least
+///   stopping at the first 1.
+///
 /// Only unsigned integral types are allowed.
 ///
 /// Returns std::numeric_limits<T>::digits on an input of 0.
@@ -258,16 +285,7 @@ template <typename T> [[nodiscard]] int countl_zero(T Val) {
 #endif
   }
 
-  // Fall back to the bisection method.
-  unsigned ZeroBits = 0;
-  for (T Shift = std::numeric_limits<T>::digits >> 1; Shift; Shift >>= 1) {
-    T Tmp = Val >> Shift;
-    if (Tmp)
-      Val = Tmp;
-    else
-      ZeroBits |= Shift;
-  }
-  return ZeroBits;
+  return countl_zero_constexpr(Val);
 }
 
 /// Count the number of ones from the most significant bit to the first

--- a/llvm/include/llvm/ADT/bit.h
+++ b/llvm/include/llvm/ADT/bit.h
@@ -238,6 +238,9 @@ template <typename T> [[nodiscard]] int countr_zero(T Val) {
 template <typename T> [[nodiscard]] constexpr int countl_zero_constexpr(T Val) {
   static_assert(std::is_unsigned_v<T>,
                 "Only unsigned integral types are allowed.");
+  if (!Val)
+    return std::numeric_limits<T>::digits;
+
   unsigned ZeroBits = 0;
   for (T Shift = std::numeric_limits<T>::digits >> 1; Shift; Shift >>= 1) {
     T Tmp = Val >> Shift;

--- a/llvm/include/llvm/ADT/bit.h
+++ b/llvm/include/llvm/ADT/bit.h
@@ -274,7 +274,7 @@ template <typename T> [[nodiscard]] int countl_zero(T Val) {
   // Use the intrinsic if available.
   if constexpr (sizeof(T) <= 4) {
     constexpr int ExtraBits =
-      std::numeric_limits<uint32_t>::digits - std::numeric_limits<T>::digits;
+        std::numeric_limits<uint32_t>::digits - std::numeric_limits<T>::digits;
 #if __has_builtin(__builtin_clz) || defined(__GNUC__)
     return __builtin_clz(Val) - ExtraBits;
 #elif defined(_MSC_VER)

--- a/llvm/include/llvm/ADT/bit.h
+++ b/llvm/include/llvm/ADT/bit.h
@@ -272,7 +272,7 @@ template <typename T> [[nodiscard]] int countl_zero(T Val) {
     return std::numeric_limits<T>::digits;
 
   // Use the intrinsic if available.
-  if constexpr (sizeof(T) == 4) {
+  if constexpr (sizeof(T) <= 4) {
 #if __has_builtin(__builtin_clz) || defined(__GNUC__)
     return __builtin_clz(Val);
 #elif defined(_MSC_VER)

--- a/llvm/include/llvm/ADT/bit.h
+++ b/llvm/include/llvm/ADT/bit.h
@@ -239,24 +239,24 @@ template <typename T> [[nodiscard]] constexpr int countl_zero_constexpr(T Val) {
   static_assert(std::is_unsigned_v<T>,
                 "Only unsigned integral types are allowed.");
 
-  constexpr int Digits = std::numeric_limits<T>::digits;
+  constexpr int BitWidth = std::numeric_limits<T>::digits;
 
   if (!Val)
-    return Digits;
+    return BitWidth;
 
   Val |= (Val >> 1);
   Val |= (Val >> 2);
   Val |= (Val >> 4);
-  if constexpr (Digits > 8) {
+  if constexpr (BitWidth > 8) {
     Val |= (Val >> 8);
   }
-  if constexpr (Digits > 16) {
+  if constexpr (BitWidth > 16) {
     Val |= (Val >> 16);
   }
-  if constexpr (Digits > 32) {
+  if constexpr (BitWidth > 32) {
     Val |= (Val >> 32);
   }
-  return Digits - llvm::popcount(Val);
+  return BitWidth - llvm::popcount(Val);
 }
 
 /// Count number of 0's from the most significant bit to the least
@@ -268,19 +268,21 @@ template <typename T> [[nodiscard]] constexpr int countl_zero_constexpr(T Val) {
 template <typename T> [[nodiscard]] int countl_zero(T Val) {
   static_assert(std::is_unsigned_v<T>,
                 "Only unsigned integral types are allowed.");
+
+  constexpr int BitWidth = std::numeric_limits<T>::digits;
+
   if (!Val)
-    return std::numeric_limits<T>::digits;
+    return BitWidth;
 
   // Use the intrinsic if available.
   if constexpr (sizeof(T) <= 4) {
-    constexpr int ExtraBits =
-        std::numeric_limits<uint32_t>::digits - std::numeric_limits<T>::digits;
 #if __has_builtin(__builtin_clz) || defined(__GNUC__)
-    return __builtin_clz(Val) - ExtraBits;
+    constexpr int Padding = std::numeric_limits<uint32_t>::digits - BitWidth;
+    return __builtin_clz(Val) - Padding;
 #elif defined(_MSC_VER)
     unsigned long Index;
     _BitScanReverse(&Index, Val);
-    return static_cast<int>((std::numeric_limits<T>::digits - 1) - Index);
+    return static_cast<int>((BitWidth - 1) - Index);
 #endif
   } else if constexpr (sizeof(T) == 8) {
 #if __has_builtin(__builtin_clzll) || defined(__GNUC__)

--- a/llvm/include/llvm/ADT/bit.h
+++ b/llvm/include/llvm/ADT/bit.h
@@ -238,25 +238,15 @@ template <typename T> [[nodiscard]] int countr_zero(T Val) {
 template <typename T> [[nodiscard]] constexpr int countl_zero_constexpr(T Val) {
   static_assert(std::is_unsigned_v<T>,
                 "Only unsigned integral types are allowed.");
-
-  constexpr int BitWidth = std::numeric_limits<T>::digits;
-
-  if (!Val)
-    return BitWidth;
-
-  Val |= (Val >> 1);
-  Val |= (Val >> 2);
-  Val |= (Val >> 4);
-  if constexpr (BitWidth > 8) {
-    Val |= (Val >> 8);
+  unsigned ZeroBits = 0;
+  for (T Shift = std::numeric_limits<T>::digits >> 1; Shift; Shift >>= 1) {
+    T Tmp = Val >> Shift;
+    if (Tmp)
+      Val = Tmp;
+    else
+      ZeroBits |= Shift;
   }
-  if constexpr (BitWidth > 16) {
-    Val |= (Val >> 16);
-  }
-  if constexpr (BitWidth > 32) {
-    Val |= (Val >> 32);
-  }
-  return BitWidth - llvm::popcount(Val);
+  return ZeroBits;
 }
 
 /// Count number of 0's from the most significant bit to the least

--- a/llvm/include/llvm/ADT/bit.h
+++ b/llvm/include/llvm/ADT/bit.h
@@ -273,12 +273,14 @@ template <typename T> [[nodiscard]] int countl_zero(T Val) {
 
   // Use the intrinsic if available.
   if constexpr (sizeof(T) <= 4) {
+    constexpr int ExtraBits =
+      std::numeric_limits<uint32_t>::digits - std::numeric_limits<T>::digits;
 #if __has_builtin(__builtin_clz) || defined(__GNUC__)
-    return __builtin_clz(Val);
+    return __builtin_clz(Val) - ExtraBits;
 #elif defined(_MSC_VER)
     unsigned long Index;
     _BitScanReverse(&Index, Val);
-    return Index ^ 31;
+    return static_cast<int>((std::numeric_limits<T>::digits - 1) - Index);
 #endif
   } else if constexpr (sizeof(T) == 8) {
 #if __has_builtin(__builtin_clzll) || defined(__GNUC__)

--- a/llvm/include/llvm/ADT/bit.h
+++ b/llvm/include/llvm/ADT/bit.h
@@ -338,12 +338,7 @@ template <typename T> [[nodiscard]] int bit_width(T Value) {
 template <typename T> [[nodiscard]] constexpr int bit_width_constexpr(T Value) {
   static_assert(std::is_unsigned_v<T>,
                 "Only unsigned integral types are allowed.");
-  int Width = 0;
-  while (Value > 0) {
-    Value >>= 1;
-    ++Width;
-  }
-  return Width;
+  return std::numeric_limits<T>::digits - llvm::countl_zero_constexpr(Value);
 }
 
 /// Returns the largest integral power of two no greater than Value if Value is


### PR DESCRIPTION
Implement constant evaluated `countl_zero_constexpr` similar to [`countr_zero_constexpr`](https://github.com/llvm/llvm-project/blob/eb2ff7101373c2a2f03320ac11b13740b978a6fc/llvm/include/llvm/ADT/bit.h#L188) and use it for `countl_zero` and `bit_width_constexpr` instead bisection loops.

Also, `countl_zero` now use fast intrinsic path for `uint8/uint16` types (use `sizeof(T) <= 4` instead `sizeof(T) == 4`).