### PR TITLE
[LLVM][Transforms][Attributor] - Improvements in AAIntraFnReachability::isReachableImpl

### DIFF
--- a/llvm/lib/Transforms/IPO/AttributorAttributes.cpp
+++ b/llvm/lib/Transforms/IPO/AttributorAttributes.cpp
@@ -3697,15 +3697,50 @@ struct AAIntraFnReachabilityFunction final
                             IsTemporaryRQI);
     }
 
-    SmallPtrSet<const BasicBlock *, 16> Visited;
+    // Optimization: Use DT DFS numbers for visited set if available.
+    // This avoids SmallPtrSet allocation and hashing overhead.
+    if (DT) {
+      if (VisitedMap.empty()) {
+        // Resize once.
+        if (auto *Root = DT->getRootNode())
+          VisitedMap.resize(Root->getDFSNumOut() + 1, 0);
+      }
+      // Increment query ID.
+      CurrentQueryID++;
+      if (CurrentQueryID == 0) {
+        // Wrap around handling: clear map.
+        std::fill(VisitedMap.begin(), VisitedMap.end(), 0);
+        CurrentQueryID = 1;
+      }
+    }
+
     SmallVector<const BasicBlock *, 16> Worklist;
     Worklist.push_back(FromBB);
+
+    // Fallback visited set if DT is not available.
+    SmallPtrSet<const BasicBlock *, 16> VisitedFallback;
 
     DenseSet<std::pair<const BasicBlock *, const BasicBlock *>> LocalDeadEdges;
     while (!Worklist.empty()) {
       const BasicBlock *BB = Worklist.pop_back_val();
-      if (!Visited.insert(BB).second)
-        continue;
+
+      bool IsVisited;
+      if (DT) {
+        unsigned DFSNum = DT->getNode(BB)->getDFSNumIn();
+        if (DFSNum < VisitedMap.size()) {
+          if (VisitedMap[DFSNum] == CurrentQueryID)
+            continue;
+          VisitedMap[DFSNum] = CurrentQueryID;
+          IsVisited = false; // Just marked it.
+        } else {
+          // Should not happen if DT is consistent, but fallback safely.
+          if (!VisitedFallback.insert(BB).second)
+            continue;
+        }
+      } else {
+        if (!VisitedFallback.insert(BB).second)
+          continue;
+      }
       for (const BasicBlock *SuccBB : successors(BB)) {
         if (LivenessAA && LivenessAA->isEdgeDead(BB, SuccBB)) {
           LocalDeadEdges.insert({BB, SuccBB});
@@ -3746,6 +3781,12 @@ private:
 
   /// The dominator tree of the function to short-circuit reasoning.
   const DominatorTree *DT = nullptr;
+
+  /// Visited map for graph traversal using DT DFS numbers.
+  std::vector<unsigned> VisitedMap;
+
+  /// Current query ID for VisitedMap.
+  unsigned CurrentQueryID = 0;
 };
 } // namespace
 

--- a/llvm/lib/Transforms/IPO/AttributorAttributes.cpp
+++ b/llvm/lib/Transforms/IPO/AttributorAttributes.cpp
@@ -3724,14 +3724,12 @@ struct AAIntraFnReachabilityFunction final
     while (!Worklist.empty()) {
       const BasicBlock *BB = Worklist.pop_back_val();
 
-      bool IsVisited;
       if (DT) {
         unsigned DFSNum = DT->getNode(BB)->getDFSNumIn();
         if (DFSNum < VisitedMap.size()) {
           if (VisitedMap[DFSNum] == CurrentQueryID)
             continue;
           VisitedMap[DFSNum] = CurrentQueryID;
-          IsVisited = false; // Just marked it.
         } else {
           // Should not happen if DT is consistent, but fallback safely.
           if (!VisitedFallback.insert(BB).second)

--- a/llvm/lib/Transforms/IPO/AttributorAttributes.cpp
+++ b/llvm/lib/Transforms/IPO/AttributorAttributes.cpp
@@ -3491,6 +3491,66 @@ DefineKeys(Instruction) DefineKeys(Function)
 
 namespace {
 
+/// Tracks which basic blocks have been visited during a single traversal.
+///
+/// When a DominatorTree is available, visited state is stored in a persistent
+/// vector indexed by the block's DT DFS-in number. A monotonically increasing
+/// per-query ID lets us reuse the vector across queries without clearing it:
+/// a block is considered visited iff its slot equals the current query ID.
+/// This avoids the per-query allocation, hashing, and teardown cost of a
+/// SmallPtrSet when the same AA object runs many reachability queries. If no
+/// DominatorTree is available (or a block has no DT node), we transparently
+/// fall back to a SmallPtrSet scoped to the current query.
+class DFSNumVisitedTracker {
+public:
+  explicit DFSNumVisitedTracker(const DominatorTree *DT) : DT(DT) {}
+
+  /// Start a new traversal. Must be called before any call to markVisited()
+  /// for a given query.
+  void beginQuery() {
+    Fallback.clear();
+    if (!DT)
+      return;
+    if (VisitedMap.empty()) {
+      if (auto *Root = DT->getRootNode())
+        VisitedMap.resize(Root->getDFSNumOut() + 1, 0);
+    }
+    if (++CurrentQueryID == 0) {
+      // Query-ID wraparound: reset the map and start over at 1.
+      std::fill(VisitedMap.begin(), VisitedMap.end(), 0);
+      CurrentQueryID = 1;
+    }
+  }
+
+  /// Record that \p BB has been visited by the current query. Returns true if
+  /// this call transitioned \p BB from unvisited to visited (i.e. the caller
+  /// should process it), and false if \p BB was already visited.
+  bool markVisited(const BasicBlock *BB) {
+    if (DT) {
+      if (auto *Node = DT->getNode(BB)) {
+        unsigned DFSNum = Node->getDFSNumIn();
+        if (DFSNum < VisitedMap.size()) {
+          if (VisitedMap[DFSNum] == CurrentQueryID)
+            return false;
+          VisitedMap[DFSNum] = CurrentQueryID;
+          return true;
+        }
+      }
+    }
+    return Fallback.insert(BB).second;
+  }
+
+private:
+  const DominatorTree *DT;
+  /// Per-block visited slots, indexed by DT DFS-in number. A block is visited
+  /// by the current query iff VisitedMap[DFSNum] == CurrentQueryID.
+  std::vector<unsigned> VisitedMap;
+  /// Monotonically increasing query ID; 0 means "unvisited".
+  unsigned CurrentQueryID = 0;
+  /// Used only when DT is null or a block lacks a DT node.
+  SmallPtrSet<const BasicBlock *, 16> Fallback;
+};
+
 template <typename BaseTy, typename ToTy>
 struct CachedReachabilityAA : public BaseTy {
   using RQITy = ReachabilityQueryInfo<ToTy>;
@@ -3599,10 +3659,10 @@ struct AAIntraFnReachabilityFunction final
     : public CachedReachabilityAA<AAIntraFnReachability, Instruction> {
   using Base = CachedReachabilityAA<AAIntraFnReachability, Instruction>;
   AAIntraFnReachabilityFunction(const IRPosition &IRP, Attributor &A)
-      : Base(IRP, A) {
-    DT = A.getInfoCache().getAnalysisResultForFunction<DominatorTreeAnalysis>(
-        *IRP.getAssociatedFunction());
-  }
+      : Base(IRP, A),
+        DT(A.getInfoCache().getAnalysisResultForFunction<DominatorTreeAnalysis>(
+            *IRP.getAssociatedFunction())),
+        VisitedTracker(DT) {}
 
   bool isAssumedReachable(
       Attributor &A, const Instruction &From, const Instruction &To,
@@ -3697,48 +3757,19 @@ struct AAIntraFnReachabilityFunction final
                             IsTemporaryRQI);
     }
 
-    // Optimization: Use DT DFS numbers for visited set if available.
-    // This avoids SmallPtrSet allocation and hashing overhead.
-    if (DT) {
-      if (VisitedMap.empty()) {
-        // Resize once.
-        if (auto *Root = DT->getRootNode())
-          VisitedMap.resize(Root->getDFSNumOut() + 1, 0);
-      }
-      // Increment query ID.
-      CurrentQueryID++;
-      if (CurrentQueryID == 0) {
-        // Wrap around handling: clear map.
-        std::fill(VisitedMap.begin(), VisitedMap.end(), 0);
-        CurrentQueryID = 1;
-      }
-    }
+    // Use a Dominator Tree DFS-number-backed visited tracker to avoid
+    // per-query SmallPtrSet allocation/hashing when we run many reachability
+    // queries.
+    VisitedTracker.beginQuery();
 
     SmallVector<const BasicBlock *, 16> Worklist;
     Worklist.push_back(FromBB);
 
-    // Fallback visited set if DT is not available.
-    SmallPtrSet<const BasicBlock *, 16> VisitedFallback;
-
     DenseSet<std::pair<const BasicBlock *, const BasicBlock *>> LocalDeadEdges;
     while (!Worklist.empty()) {
       const BasicBlock *BB = Worklist.pop_back_val();
-
-      if (DT) {
-        unsigned DFSNum = DT->getNode(BB)->getDFSNumIn();
-        if (DFSNum < VisitedMap.size()) {
-          if (VisitedMap[DFSNum] == CurrentQueryID)
-            continue;
-          VisitedMap[DFSNum] = CurrentQueryID;
-        } else {
-          // Should not happen if DT is consistent, but fallback safely.
-          if (!VisitedFallback.insert(BB).second)
-            continue;
-        }
-      } else {
-        if (!VisitedFallback.insert(BB).second)
-          continue;
-      }
+      if (!VisitedTracker.markVisited(BB))
+        continue;
       for (const BasicBlock *SuccBB : successors(BB)) {
         if (LivenessAA && LivenessAA->isEdgeDead(BB, SuccBB)) {
           LocalDeadEdges.insert({BB, SuccBB});
@@ -3780,11 +3811,8 @@ private:
   /// The dominator tree of the function to short-circuit reasoning.
   const DominatorTree *DT = nullptr;
 
-  /// Visited map for graph traversal using DT DFS numbers.
-  std::vector<unsigned> VisitedMap;
-
-  /// Current query ID for VisitedMap.
-  unsigned CurrentQueryID = 0;
+  /// Tracks visited blocks across reachability queries on this AA.
+  DFSNumVisitedTracker VisitedTracker;
 };
 } // namespace
 


### PR DESCRIPTION
Reduce overhead in the Attributor's reachability (intra-function) analysis.

Improve AAIntraFnReachabilityFunction::isReachableImpl - Replace per-query SmallPtrSet<BasicBlock*> visited set with a persistent vector<unsigned> indexed by DominatorTree DFS numbers. Each basic block has a unique DFSNumIn in [0, N), making it a perfect dense array index. A monotonically increasing query ID avoids clearing the vector between queries: a block is "visited" iff `VisitedMap[DFSNumIn] == CurrentQueryID`. This eliminates per-query allocation, pointer hashing, and destruction of the visited set.
Motivated by a representative workload where we were seeing ~381K reachability traverals during LTO with many GPU kernels (e.g., Fortran OpenMP offloading applications).