### PR TITLE
[Driver][HIP] Fix bundled -S emitting bitcode instead of assembly for device

### DIFF
--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -5373,6 +5373,8 @@ Action *Driver::ConstructPhaseAction(
            (Args.hasFlag(options::OPT_offload_new_driver,
                          options::OPT_no_offload_new_driver,
                          C.getActiveOffloadKinds() != Action::OFK_None) &&
+            !(Args.hasArg(options::OPT_S) &&
+              !Args.hasArg(options::OPT_emit_llvm)) &&
             (!offloadDeviceOnly() ||
              (Input->getOffloadingToolChain() &&
               TargetDeviceOffloadKind == Action::OFK_HIP &&

--- a/clang/test/Driver/hip-phases.hip
+++ b/clang/test/Driver/hip-phases.hip
@@ -73,6 +73,7 @@
 // ASM-DAG: [[P0:[0-9]+]]: input, "{{.*}}hip-phases.hip", [[T:hip]], (device-[[T]], [[ARCH:gfx803]])
 // ASM-DAG: [[P1:[0-9]+]]: preprocessor, {[[P0]]}, [[T]]-cpp-output, (device-[[T]], [[ARCH]])
 // ASM-DAG: [[P2:[0-9]+]]: compiler, {[[P1]]}, ir, (device-[[T]], [[ARCH]])
+// ASM-DAG: [[P3:[0-9]+]]: backend, {[[P2]]}, assembler, (device-[[T]], [[ARCH]])
 
 // ASM-DAG: [[P5:[0-9]+]]: input, "{{.*}}hip-phases.hip", [[T]], (host-[[T]])
 // ASM-DAG: [[P6:[0-9]+]]: preprocessor, {[[P5]]}, [[T]]-cpp-output, (host-[[T]])


### PR DESCRIPTION
[Driver][HIP] Fix bundled -S emitting bitcode instead of assembly for device

PR #188262 added support for bundling HIP -S output under the new
offload driver, but the device backend still entered the
bitcode-emitting path in ConstructPhaseAction. The condition at the
Backend phase checked for the new offload driver and directed device
code to emit TY_LLVM_BC, without excluding the -S case. This caused
the device section in the bundled .s to contain LLVM bitcode instead
of textual AMDGPU assembly.

This broke the HIP UT CheckCodeObjAttr test which greps
copyKernel.s for "uniform_work_group_size" — a string that only
appears in textual assembly, not in bitcode.

Fix by excluding -S (without -emit-llvm) from the new-driver
bitcode path, so the device backend falls through to emit TY_PP_Asm
(textual assembly). Also add a missing lit test check that the
device backend produces assembler output for the bundled -S case.

Fixes: LCOMPILER-553

