### PR TITLE
[mlir][reducer] Fix the reduce undefined symbol problem

### DIFF
--- a/mlir/lib/Reducer/CMakeLists.txt
+++ b/mlir/lib/Reducer/CMakeLists.txt
@@ -9,6 +9,7 @@ add_mlir_library(MLIRReduce
    MLIRPass
    MLIRRewrite
    MLIRTransformUtils
+   MLIRControlFlowDialect
 
    DEPENDS
    MLIRReducerIncGen


### PR DESCRIPTION
This PR https://github.com/llvm/llvm-project/pull/187864 make bot https://lab.llvm.org/buildbot/#/builders/138/builds/27662 build failed. Fix it by adding MLIRControlFlowDialect to MLIRReduce.