### PR TITLE
[X86] handle vector floating point extension from scalar in inline assembly

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.cpp
@@ -537,7 +537,13 @@ getCopyToParts(SelectionDAG &DAG, const SDLoc &DL, SDValue Val, SDValue *Parts,
     // If the parts cover more bits than the value has, promote the value.
     if (PartVT.isFloatingPoint() && ValueVT.isFloatingPoint()) {
       assert(NumParts == 1 && "Do not know what to promote to!");
-      Val = DAG.getNode(ISD::FP_EXTEND, DL, PartVT, Val);
+      if (PartVT.isVector()) {
+        ValueVT = EVT::getFloatingPointVT(PartBits);
+        Val = DAG.getNode(ISD::FP_EXTEND, DL, ValueVT, Val);
+        Val = DAG.getNode(ISD::BITCAST, DL, PartVT, Val);
+      } else {
+        Val = DAG.getNode(ISD::FP_EXTEND, DL, PartVT, Val);
+      }
     } else {
       if (ValueVT.isFloatingPoint()) {
         // FP values need to be bitcast, then extended if they are being put

--- a/llvm/test/CodeGen/X86/inline-asm-vector-fp-extend.ll
+++ b/llvm/test/CodeGen/X86/inline-asm-vector-fp-extend.ll
@@ -1,0 +1,20 @@
+; RUN: llc < %s -mtriple=x86_64-pc-linux-gnu | FileCheck %s
+
+; Test for vector floating point extension in inline assembly.
+; gh184180
+
+define <2 x double> @test(double %0) {
+L.entry:
+; CHECK-LABEL: test:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    pushq %rax
+; CHECK-NEXT:    .cfi_def_cfa_offset 16
+; CHECK-NEXT:    callq __extenddftf2@PLT
+; CHECK-NEXT:    #APP
+; CHECK-NEXT:    #NO_APP
+; CHECK-NEXT:    popq %rax
+; CHECK-NEXT:    .cfi_def_cfa_offset 8
+; CHECK-NEXT:    retq
+  %1 = call <2 x double> asm sideeffect "", "=x,0"(double %0)
+  ret <2 x double> %1
+}


### PR DESCRIPTION
When promoting floating point values to match register class sizes, we need to
handle the case where the target PartVT is a vector type.

The fix:
- Check if `PartVT` is a vector
- If so, get the appropriate floating point scalar type with matching bit width
- Extend to the scalar type first, then bitcast to the vector type

Fixed #184180 