### PR TITLE
[MLIR] Fix crash in test-bytecode-roundtrip when test dialect is absent

### DIFF
--- a/mlir/test/Bytecode/bytecode_callback.mlir
+++ b/mlir/test/Bytecode/bytecode_callback.mlir
@@ -1,5 +1,6 @@
 // RUN: mlir-opt %s --test-bytecode-roundtrip="test-dialect-version=1.2" -verify-diagnostics | FileCheck %s --check-prefix=VERSION_1_2
 // RUN: mlir-opt %s --test-bytecode-roundtrip="test-dialect-version=2.0" -verify-diagnostics | FileCheck %s --check-prefix=VERSION_2_0
+// RUN: mlir-opt %s --split-input-file --test-bytecode-roundtrip="test-dialect-version=2.0" -verify-diagnostics | FileCheck %s --check-prefix=NO_TEST_DIALECT
 
 func.func @base_test(%arg0 : i32) -> f32 {
   %0 = "test.addi"(%arg0, %arg0) : (i32, i32) -> i32
@@ -12,3 +13,15 @@ func.func @base_test(%arg0 : i32) -> f32 {
 
 // VERSION_2_0-NOT: Overriding IntegerType encoding...
 // VERSION_2_0-NOT: Overriding parsing of IntegerType encoding...
+
+// -----
+
+// Regression test for https://github.com/llvm/llvm-project/issues/128321:
+// test-bytecode-roundtrip must not crash when the test dialect is absent from
+// the module (i.e., no test dialect types are present in the bytecode).
+
+// NO_TEST_DIALECT-NOT: Overriding IntegerType encoding...
+// NO_TEST_DIALECT: func.func @no_test_dialect_ops
+func.func @no_test_dialect_ops() {
+  return
+}

--- a/mlir/test/lib/IR/TestBytecodeRoundtrip.cpp
+++ b/mlir/test/lib/IR/TestBytecodeRoundtrip.cpp
@@ -166,10 +166,12 @@ private:
     parseConfig.getBytecodeReaderConfig().attachTypeCallback(
         [&](DialectBytecodeReader &reader, StringRef dialectName,
             Type &entry) -> LogicalResult {
-          // Get test dialect version from the version map.
+          // Get test dialect version from the version map. If the test dialect
+          // is not present in the bytecode (e.g., the module contains no test
+          // dialect types), version info will be absent -- just skip.
           auto versionOr = reader.getDialectVersion<test::TestDialect>();
-          assert(succeeded(versionOr) && "expected reader to be able to access "
-                                         "the version for test dialect");
+          if (failed(versionOr))
+            return success();
           const auto *version =
               reinterpret_cast<const test::TestDialectVersion *>(*versionOr);
           if (version->major_ >= 2)


### PR DESCRIPTION
When invoking `-test-bytecode-roundtrip=test-dialect-version=X.Y` on a module that contains no test dialect operations, the reader type callback in `runTest0` called `reader.getDialectVersion<test::TestDialect>()` and then immediately asserted that it succeeded. However, if the test dialect was never referenced in the bytecode (because no test dialect types appear in the module), the dialect's version information is not stored in the bytecode, so `getDialectVersion` legitimately returns failure.

When the test dialect version is unavailable in the bytecode being read, the module contains no test dialect types, so no "funky"-group overrides are needed and the callback can safely skip by returning `success()`.

A regression test is added with a module that has no test dialect ops, exercising the `test-dialect-version=2.0` path that previously crashed.

Fixes #128321
Fixes #128325

Assisted-by: Claude Code