### PR TITLE
[Hexagon] Add optimization remarks to Hexagon IR and MIR passes

### DIFF
--- a/llvm/lib/Target/Hexagon/HexagonHardwareLoops.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonHardwareLoops.cpp
@@ -115,6 +115,7 @@ namespace {
     void getAnalysisUsage(AnalysisUsage &AU) const override {
       AU.addRequired<MachineDominatorTreeWrapperPass>();
       AU.addRequired<MachineLoopInfoWrapperPass>();
+      AU.addRequired<MachineOptimizationRemarkEmitterPass>();
       MachineFunctionPass::getAnalysisUsage(AU);
     }
 
@@ -386,8 +387,7 @@ bool HexagonHardwareLoops::runOnMachineFunction(MachineFunction &MF) {
   TII = HST.getInstrInfo();
   TRI = HST.getRegisterInfo();
 
-  MachineOptimizationRemarkEmitter ORE(MF, nullptr);
-  MORE = &ORE;
+  MORE = &getAnalysis<MachineOptimizationRemarkEmitterPass>().getORE();
 
   for (auto &L : *MLI)
     if (L->isOutermost()) {

--- a/llvm/lib/Target/Hexagon/HexagonHardwareLoops.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonHardwareLoops.cpp
@@ -41,6 +41,7 @@
 #include "llvm/CodeGen/MachineInstrBuilder.h"
 #include "llvm/CodeGen/MachineLoopInfo.h"
 #include "llvm/CodeGen/MachineOperand.h"
+#include "llvm/CodeGen/MachineOptimizationRemarkEmitter.h"
 #include "llvm/CodeGen/MachineRegisterInfo.h"
 #include "llvm/CodeGen/TargetRegisterInfo.h"
 #include "llvm/IR/DebugLoc.h"
@@ -97,6 +98,7 @@ namespace {
     MachineDominatorTree       *MDT;
     const HexagonInstrInfo     *TII;
     const HexagonRegisterInfo  *TRI;
+    MachineOptimizationRemarkEmitter *MORE;
 #ifndef NDEBUG
     static int Counter;
 #endif
@@ -383,6 +385,9 @@ bool HexagonHardwareLoops::runOnMachineFunction(MachineFunction &MF) {
   const HexagonSubtarget &HST = MF.getSubtarget<HexagonSubtarget>();
   TII = HST.getInstrInfo();
   TRI = HST.getRegisterInfo();
+
+  MachineOptimizationRemarkEmitter ORE(MF, nullptr);
+  MORE = &ORE;
 
   for (auto &L : *MLI)
     if (L->isOutermost()) {
@@ -1211,21 +1216,41 @@ bool HexagonHardwareLoops::convertToHardwareLoop(MachineLoop *L,
 #endif
 
   // Does the loop contain any invalid instructions?
-  if (containsInvalidInstruction(L, IsInnerHWLoop))
+  if (containsInvalidInstruction(L, IsInnerHWLoop)) {
+    MORE->emit([&]() {
+      return MachineOptimizationRemarkMissed(DEBUG_TYPE, "InvalidInstruction",
+                                             L->getStartLoc(), L->getHeader())
+             << "loop contains an instruction that prevents hardware loop "
+                "generation (e.g. a call or hardware loop register definition)";
+    });
     return false;
+  }
 
   MachineBasicBlock *LastMBB = L->findLoopControlBlock();
   // Don't generate hw loop if the loop has more than one exit.
-  if (!LastMBB)
+  if (!LastMBB) {
+    MORE->emit([&]() {
+      return MachineOptimizationRemarkMissed(DEBUG_TYPE, "MultipleExits",
+                                             L->getStartLoc(), L->getHeader())
+             << "loop has multiple exits and cannot be converted to a "
+                "hardware loop";
+    });
     return false;
+  }
 
   MachineBasicBlock::iterator LastI = LastMBB->getFirstTerminator();
   if (LastI == LastMBB->end())
     return false;
 
   // Is the induction variable bump feeding the latch condition?
-  if (!fixupInductionVariable(L))
+  if (!fixupInductionVariable(L)) {
+    MORE->emit([&]() {
+      return MachineOptimizationRemarkMissed(DEBUG_TYPE, "InductionVariable",
+                                             L->getStartLoc(), L->getHeader())
+             << "could not identify or fix up the induction variable";
+    });
     return false;
+  }
 
   // Ensure the loop has a preheader: the loop instruction will be
   // placed there.
@@ -1241,8 +1266,14 @@ bool HexagonHardwareLoops::convertToHardwareLoop(MachineLoop *L,
   SmallVector<MachineInstr*, 2> OldInsts;
   // Are we able to determine the trip count for the loop?
   CountValue *TripCount = getLoopTripCount(L, OldInsts);
-  if (!TripCount)
+  if (!TripCount) {
+    MORE->emit([&]() {
+      return MachineOptimizationRemarkMissed(DEBUG_TYPE, "TripCount",
+                                             L->getStartLoc(), L->getHeader())
+             << "trip count of the loop could not be computed";
+    });
     return false;
+  }
 
   // Is the trip count available in the preheader?
   if (TripCount->isReg()) {
@@ -1250,8 +1281,15 @@ bool HexagonHardwareLoops::convertToHardwareLoop(MachineLoop *L,
     // so make sure that the register is actually defined at that point.
     MachineInstr *TCDef = MRI->getVRegDef(TripCount->getReg());
     MachineBasicBlock *BBDef = TCDef->getParent();
-    if (!MDT->dominates(BBDef, Preheader))
+    if (!MDT->dominates(BBDef, Preheader)) {
+      MORE->emit([&]() {
+        return MachineOptimizationRemarkMissed(DEBUG_TYPE,
+                                               "TripCountNotDominating",
+                                               L->getStartLoc(), L->getHeader())
+               << "trip count register is not available in the loop preheader";
+      });
       return false;
+    }
   }
 
   // Determine the loop start.
@@ -1339,6 +1377,12 @@ bool HexagonHardwareLoops::convertToHardwareLoop(MachineLoop *L,
     removeIfDead(OldInsts[i]);
 
   ++NumHWLoops;
+
+  MORE->emit([&]() {
+    return MachineOptimizationRemark(DEBUG_TYPE, "HardwareLoop",
+                                     L->getStartLoc(), L->getHeader())
+           << "converted loop to hardware loop";
+  });
 
   // Set RecL1used and RecL0used only after hardware loop has been
   // successfully generated. Doing it earlier can cause wrong loop instruction

--- a/llvm/lib/Target/Hexagon/HexagonLoopIdiomRecognition.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonLoopIdiomRecognition.cpp
@@ -20,6 +20,7 @@
 #include "llvm/Analysis/LoopInfo.h"
 #include "llvm/Analysis/LoopPass.h"
 #include "llvm/Analysis/MemoryLocation.h"
+#include "llvm/Analysis/OptimizationRemarkEmitter.h"
 #include "llvm/Analysis/ScalarEvolution.h"
 #include "llvm/Analysis/ScalarEvolutionExpressions.h"
 #include "llvm/Analysis/TargetLibraryInfo.h"
@@ -111,8 +112,9 @@ class HexagonLoopIdiomRecognize {
 public:
   explicit HexagonLoopIdiomRecognize(AliasAnalysis *AA, DominatorTree *DT,
                                      LoopInfo *LF, const TargetLibraryInfo *TLI,
-                                     ScalarEvolution *SE)
-      : AA(AA), DT(DT), LF(LF), TLI(TLI), SE(SE) {}
+                                     ScalarEvolution *SE,
+                                     OptimizationRemarkEmitter &ORE)
+      : AA(AA), DT(DT), LF(LF), TLI(TLI), SE(SE), ORE(ORE) {}
 
   bool run(Loop *L);
 
@@ -133,6 +135,7 @@ private:
   LoopInfo *LF;
   const TargetLibraryInfo *TLI;
   ScalarEvolution *SE;
+  OptimizationRemarkEmitter &ORE;
   bool HasMemcpy, HasMemmove;
 };
 
@@ -154,6 +157,7 @@ public:
     AU.addRequired<ScalarEvolutionWrapperPass>();
     AU.addRequired<DominatorTreeWrapperPass>();
     AU.addRequired<TargetLibraryInfoWrapperPass>();
+    AU.addRequired<OptimizationRemarkEmitterWrapperPass>();
     AU.addPreserved<TargetLibraryInfoWrapperPass>();
   }
 
@@ -266,6 +270,7 @@ INITIALIZE_PASS_DEPENDENCY(ScalarEvolutionWrapperPass)
 INITIALIZE_PASS_DEPENDENCY(DominatorTreeWrapperPass)
 INITIALIZE_PASS_DEPENDENCY(TargetLibraryInfoWrapperPass)
 INITIALIZE_PASS_DEPENDENCY(AAResultsWrapperPass)
+INITIALIZE_PASS_DEPENDENCY(OptimizationRemarkEmitterWrapperPass)
 INITIALIZE_PASS_END(HexagonLoopIdiomRecognizeLegacyPass, "hexagon-loop-idiom",
                     "Recognize Hexagon-specific loop idioms", false, false)
 
@@ -1943,8 +1948,14 @@ bool HexagonLoopIdiomRecognize::isLegalStore(Loop *CurLoop, StoreInst *SI) {
   // loop, which indicates a strided store.  If we have something else, it's a
   // random store we can't handle.
   auto *StoreEv = dyn_cast<SCEVAddRecExpr>(SE->getSCEV(StorePtr));
-  if (!StoreEv || StoreEv->getLoop() != CurLoop || !StoreEv->isAffine())
+  if (!StoreEv || StoreEv->getLoop() != CurLoop || !StoreEv->isAffine()) {
+    ORE.emit([&]() {
+      return OptimizationRemarkMissed(DEBUG_TYPE, "NonAffineStorePtr",
+                                      SI->getDebugLoc(), SI->getParent())
+             << "store pointer is not an affine AddRec";
+    });
     return false;
+  }
 
   // Check to see if the stride matches the size of the store.  If so, then we
   // know that every byte is touched in the loop.
@@ -1952,21 +1963,39 @@ bool HexagonLoopIdiomRecognize::isLegalStore(Loop *CurLoop, StoreInst *SI) {
   if (Stride == 0)
     return false;
   unsigned StoreSize = DL->getTypeStoreSize(SI->getValueOperand()->getType());
-  if (StoreSize != unsigned(std::abs(Stride)))
+  if (StoreSize != unsigned(std::abs(Stride))) {
+    ORE.emit([&]() {
+      return OptimizationRemarkMissed(DEBUG_TYPE, "StrideSizeMismatch",
+                                      SI->getDebugLoc(), SI->getParent())
+             << "stride does not match store size";
+    });
     return false;
+  }
 
   // The store must be feeding a non-volatile load.
   LoadInst *LI = dyn_cast<LoadInst>(SI->getValueOperand());
-  if (!LI || !LI->isSimple())
+  if (!LI || !LI->isSimple()) {
+    ORE.emit([&]() {
+      return OptimizationRemarkMissed(DEBUG_TYPE, "StoreNotFeedingLoad",
+                                      SI->getDebugLoc(), SI->getParent())
+             << "store value is not a simple load";
+    });
     return false;
+  }
 
   // See if the pointer expression is an AddRec like {base,+,1} on the current
   // loop, which indicates a strided load.  If we have something else, it's a
   // random load we can't handle.
   Value *LoadPtr = LI->getPointerOperand();
   auto *LoadEv = dyn_cast<SCEVAddRecExpr>(SE->getSCEV(LoadPtr));
-  if (!LoadEv || LoadEv->getLoop() != CurLoop || !LoadEv->isAffine())
+  if (!LoadEv || LoadEv->getLoop() != CurLoop || !LoadEv->isAffine()) {
+    ORE.emit([&]() {
+      return OptimizationRemarkMissed(DEBUG_TYPE, "NonAffineLoadPtr",
+                                      LI->getDebugLoc(), LI->getParent())
+             << "load pointer is not an affine AddRec";
+    });
     return false;
+  }
 
   // The store and load must share the same stride.
   if (StoreEv->getOperand(1) != LoadEv->getOperand(1))
@@ -2090,6 +2119,11 @@ CleanupAndExit:
     if (mayLoopAccessLocation(StoreBasePtr, ModRefInfo::ModRef, CurLoop,
                               BECount, StoreSize, *AA, Ignore1)) {
       // Still bad. Nothing we can do.
+      ORE.emit([&]() {
+        return OptimizationRemarkMissed(DEBUG_TYPE, "MemoryAlias",
+                                        SI->getDebugLoc(), SI->getParent())
+               << "memory aliasing prevents memcpy/memmove";
+      });
       goto CleanupAndExit;
     }
     // It worked with the load ignored.
@@ -2097,8 +2131,14 @@ CleanupAndExit:
   }
 
   if (!Overlap) {
-    if (DisableMemcpyIdiom || !HasMemcpy)
+    if (DisableMemcpyIdiom || !HasMemcpy) {
+      ORE.emit([&]() {
+        return OptimizationRemarkMissed(DEBUG_TYPE, "MemcpyDisabled",
+                                        SI->getDebugLoc(), SI->getParent())
+               << "memcpy idiom is disabled or unavailable";
+      });
       goto CleanupAndExit;
+    }
   } else {
     // Don't generate memmove if this function will be inlined. This is
     // because the caller will undergo this transformation after inlining.
@@ -2113,14 +2153,32 @@ CleanupAndExit:
     SmallVector<Instruction*,2> Insts;
     Insts.push_back(SI);
     Insts.push_back(LI);
-    if (!coverLoop(CurLoop, Insts))
+    if (!coverLoop(CurLoop, Insts)) {
+      ORE.emit([&]() {
+        return OptimizationRemarkMissed(DEBUG_TYPE, "ExtraLoopInstructions",
+                                        SI->getDebugLoc(), SI->getParent())
+               << "loop contains instructions beyond load/store pair";
+      });
       goto CleanupAndExit;
+    }
 
-    if (DisableMemmoveIdiom || !HasMemmove)
+    if (DisableMemmoveIdiom || !HasMemmove) {
+      ORE.emit([&]() {
+        return OptimizationRemarkMissed(DEBUG_TYPE, "MemmoveDisabled",
+                                        SI->getDebugLoc(), SI->getParent())
+               << "memmove idiom is disabled or unavailable";
+      });
       goto CleanupAndExit;
+    }
     bool IsNested = CurLoop->getParentLoop() != nullptr;
-    if (IsNested && OnlyNonNestedMemmove)
+    if (IsNested && OnlyNonNestedMemmove) {
+      ORE.emit([&]() {
+        return OptimizationRemarkMissed(DEBUG_TYPE, "NestedLoop",
+                                        SI->getDebugLoc(), SI->getParent())
+               << "memmove skipped for nested loop";
+      });
       goto CleanupAndExit;
+    }
   }
 
   // For a memcpy, we have to make sure that the input array is not being
@@ -2306,6 +2364,20 @@ CleanupAndExit:
                     << "    from store ptr=" << *StoreEv << " at: " << *SI
                     << "\n");
 
+  if (Overlap) {
+    ORE.emit([&]() {
+      return OptimizationRemark(DEBUG_TYPE, "LoopToMemmove", DLoc,
+                                CurLoop->getHeader())
+             << "converted loop to memmove";
+    });
+  } else {
+    ORE.emit([&]() {
+      return OptimizationRemark(DEBUG_TYPE, "LoopToMemcpy", DLoc,
+                                CurLoop->getHeader())
+             << "converted loop to memcpy";
+    });
+  }
+
   return true;
 }
 
@@ -2388,8 +2460,14 @@ bool HexagonLoopIdiomRecognize::runOnLoopBlock(Loop *CurLoop, BasicBlock *BB,
 
 bool HexagonLoopIdiomRecognize::runOnCountableLoop(Loop *L) {
   PolynomialMultiplyRecognize PMR(L, *DL, *DT, *TLI, *SE);
-  if (PMR.recognize())
+  if (PMR.recognize()) {
+    ORE.emit([&]() {
+      return OptimizationRemark(DEBUG_TYPE, "PolynomialMultiply",
+                                L->getStartLoc(), L->getHeader())
+             << "recognized polynomial multiply idiom";
+    });
     return true;
+  }
 
   if (!HasMemcpy && !HasMemmove)
     return false;
@@ -2422,8 +2500,14 @@ bool HexagonLoopIdiomRecognize::run(Loop *L) {
 
   // If the loop could not be converted to canonical form, it must have an
   // indirectbr in it, just give up.
-  if (!L->getLoopPreheader())
+  if (!L->getLoopPreheader()) {
+    ORE.emit([&]() {
+      return OptimizationRemarkMissed(DEBUG_TYPE, "NoPreheader",
+                                      L->getStartLoc(), L->getHeader())
+             << "loop not in canonical form (no preheader)";
+    });
     return false;
+  }
 
   // Disable loop idiom recognition if the function's name is a common idiom.
   StringRef Name = L->getHeader()->getParent()->getName();
@@ -2437,6 +2521,12 @@ bool HexagonLoopIdiomRecognize::run(Loop *L) {
 
   if (SE->hasLoopInvariantBackedgeTakenCount(L))
     return runOnCountableLoop(L);
+
+  ORE.emit([&]() {
+    return OptimizationRemarkMissed(DEBUG_TYPE, "NonCountableLoop",
+                                    L->getStartLoc(), L->getHeader())
+           << "backedge-taken count is not loop-invariant";
+  });
   return false;
 }
 
@@ -2451,7 +2541,8 @@ bool HexagonLoopIdiomRecognizeLegacyPass::runOnLoop(Loop *L,
   auto *TLI = &getAnalysis<TargetLibraryInfoWrapperPass>().getTLI(
       *L->getHeader()->getParent());
   auto *SE = &getAnalysis<ScalarEvolutionWrapperPass>().getSE();
-  return HexagonLoopIdiomRecognize(AA, DT, LF, TLI, SE).run(L);
+  auto &ORE = getAnalysis<OptimizationRemarkEmitterWrapperPass>().getORE();
+  return HexagonLoopIdiomRecognize(AA, DT, LF, TLI, SE, ORE).run(L);
 }
 
 Pass *llvm::createHexagonLoopIdiomPass() {
@@ -2462,7 +2553,8 @@ PreservedAnalyses
 HexagonLoopIdiomRecognitionPass::run(Loop &L, LoopAnalysisManager &AM,
                                      LoopStandardAnalysisResults &AR,
                                      LPMUpdater &U) {
-  return HexagonLoopIdiomRecognize(&AR.AA, &AR.DT, &AR.LI, &AR.TLI, &AR.SE)
+  OptimizationRemarkEmitter ORE(L.getHeader()->getParent());
+  return HexagonLoopIdiomRecognize(&AR.AA, &AR.DT, &AR.LI, &AR.TLI, &AR.SE, ORE)
                  .run(&L)
              ? getLoopPassPreservedAnalyses()
              : PreservedAnalyses::all();

--- a/llvm/lib/Target/Hexagon/HexagonVectorCombine.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonVectorCombine.cpp
@@ -23,6 +23,7 @@
 #include "llvm/Analysis/AssumptionCache.h"
 #include "llvm/Analysis/InstSimplifyFolder.h"
 #include "llvm/Analysis/InstructionSimplify.h"
+#include "llvm/Analysis/OptimizationRemarkEmitter.h"
 #include "llvm/Analysis/ScalarEvolutionExpressions.h"
 #include "llvm/Analysis/TargetLibraryInfo.h"
 #include "llvm/Analysis/ValueTracking.h"
@@ -84,10 +85,12 @@ class HexagonVectorCombine {
 public:
   HexagonVectorCombine(Function &F_, AliasAnalysis &AA_, AssumptionCache &AC_,
                        DominatorTree &DT_, ScalarEvolution &SE_,
-                       TargetLibraryInfo &TLI_, const TargetMachine &TM_)
-      : F(F_), DL(F.getDataLayout()), AA(AA_), AC(AC_), DT(DT_),
-        SE(SE_), TLI(TLI_),
-        HST(static_cast<const HexagonSubtarget &>(*TM_.getSubtargetImpl(F))) {}
+                       TargetLibraryInfo &TLI_, const TargetMachine &TM_,
+                       OptimizationRemarkEmitter &ORE_)
+      : F(F_), DL(F.getDataLayout()), AA(AA_), AC(AC_), DT(DT_), SE(SE_),
+        TLI(TLI_),
+        HST(static_cast<const HexagonSubtarget &>(*TM_.getSubtargetImpl(F))),
+        ORE(ORE_) {}
 
   bool run();
 
@@ -181,6 +184,7 @@ public:
   ScalarEvolution &SE;
   TargetLibraryInfo &TLI;
   const HexagonSubtarget &HST;
+  OptimizationRemarkEmitter &ORE;
 
 private:
   Value *getElementRange(IRBuilderBase &Builder, Value *Lo, Value *Hi,
@@ -1003,8 +1007,15 @@ auto AlignVectors::createLoadGroups(const AddrList &Group) const -> MoveList {
 
   auto tryAddTo = [&](const AddrInfo &Info, MoveGroup &Move) {
     assert(!Move.Main.empty() && "Move group should have non-empty Main");
-    if (Move.Main.size() >= SizeLimit)
+    if (Move.Main.size() >= SizeLimit) {
+      HVC.ORE.emit([&]() {
+        return OptimizationRemarkMissed(DEBUG_TYPE, "GroupSizeLimitExceeded",
+                                        Info.Inst->getDebugLoc(),
+                                        Info.Inst->getParent())
+               << "alignment group exceeds size limit";
+      });
       return false;
+    }
     // Don't mix HVX and non-HVX instructions.
     if (Move.IsHvx != isHvx(Info))
       return false;
@@ -1013,8 +1024,15 @@ auto AlignVectors::createLoadGroups(const AddrList &Group) const -> MoveList {
     if (Base->getParent() != Info.Inst->getParent())
       return false;
     // Check if it's safe to move the load.
-    if (!HVC.isSafeToMoveBeforeInBB(*Info.Inst, Base->getIterator()))
+    if (!HVC.isSafeToMoveBeforeInBB(*Info.Inst, Base->getIterator())) {
+      HVC.ORE.emit([&]() {
+        return OptimizationRemarkMissed(DEBUG_TYPE, "UnsafeToRelocate",
+                                        Info.Inst->getDebugLoc(),
+                                        Info.Inst->getParent())
+               << "unsafe to relocate memory access for alignment";
+      });
       return false;
+    }
     // And if it's safe to clone the dependencies.
     auto isSafeToCopyAtBase = [&](const Instruction *I) {
       return HVC.isSafeToMoveBeforeInBB(*I, Base->getIterator()) &&
@@ -1045,8 +1063,18 @@ auto AlignVectors::createLoadGroups(const AddrList &Group) const -> MoveList {
   });
 
   // Erase HVX groups on targets < HvxV62 (due to lack of predicated loads).
-  if (!HVC.HST.useHVXV62Ops())
+  if (!HVC.HST.useHVXV62Ops()) {
+    bool HadHvx =
+        llvm::any_of(LoadGroups, [](const MoveGroup &G) { return G.IsHvx; });
     erase_if(LoadGroups, [](const MoveGroup &G) { return G.IsHvx; });
+    if (HadHvx) {
+      HVC.ORE.emit([&]() {
+        return OptimizationRemarkMissed(DEBUG_TYPE, "HvxVersionTooLow",
+                                        HVC.F.getSubprogram(), &HVC.F.front())
+               << "HVX version too low for predicated load operations";
+      });
+    }
+  }
 
   LLVM_DEBUG(dbgs() << "LoadGroups list: " << LoadGroups);
   return LoadGroups;
@@ -1062,8 +1090,15 @@ auto AlignVectors::createStoreGroups(const AddrList &Group) const -> MoveList {
 
   auto tryAddTo = [&](const AddrInfo &Info, MoveGroup &Move) {
     assert(!Move.Main.empty() && "Move group should have non-empty Main");
-    if (Move.Main.size() >= SizeLimit)
+    if (Move.Main.size() >= SizeLimit) {
+      HVC.ORE.emit([&]() {
+        return OptimizationRemarkMissed(DEBUG_TYPE, "GroupSizeLimitExceeded",
+                                        Info.Inst->getDebugLoc(),
+                                        Info.Inst->getParent())
+               << "alignment group exceeds size limit";
+      });
       return false;
+    }
     // For stores with return values we'd have to collect downward dependencies.
     // There are no such stores that we handle at the moment, so omit that.
     assert(Info.Inst->getType()->isVoidTy() &&
@@ -1077,8 +1112,16 @@ auto AlignVectors::createStoreGroups(const AddrList &Group) const -> MoveList {
     Instruction *Base = Move.Main.front();
     if (Base->getParent() != Info.Inst->getParent())
       return false;
-    if (!HVC.isSafeToMoveBeforeInBB(*Info.Inst, Base->getIterator(), Move.Main))
+    if (!HVC.isSafeToMoveBeforeInBB(*Info.Inst, Base->getIterator(),
+                                    Move.Main)) {
+      HVC.ORE.emit([&]() {
+        return OptimizationRemarkMissed(DEBUG_TYPE, "UnsafeToRelocate",
+                                        Info.Inst->getDebugLoc(),
+                                        Info.Inst->getParent())
+               << "unsafe to relocate memory access for alignment";
+      });
       return false;
+    }
     Move.Main.push_back(Info.Inst);
     return true;
   };
@@ -1097,8 +1140,18 @@ auto AlignVectors::createStoreGroups(const AddrList &Group) const -> MoveList {
   erase_if(StoreGroups, [](const MoveGroup &G) { return G.Main.size() <= 1; });
 
   // Erase HVX groups on targets < HvxV62 (due to lack of predicated loads).
-  if (!HVC.HST.useHVXV62Ops())
+  if (!HVC.HST.useHVXV62Ops()) {
+    bool HadHvx =
+        llvm::any_of(StoreGroups, [](const MoveGroup &G) { return G.IsHvx; });
     erase_if(StoreGroups, [](const MoveGroup &G) { return G.IsHvx; });
+    if (HadHvx) {
+      HVC.ORE.emit([&]() {
+        return OptimizationRemarkMissed(DEBUG_TYPE, "HvxVersionTooLow",
+                                        HVC.F.getSubprogram(), &HVC.F.front())
+               << "HVX version too low for predicated store operations";
+      });
+    }
+  }
 
   // Erase groups where every store is a full HVX vector. The reason is that
   // aligning predicated stores generates complex code that may be less
@@ -1604,6 +1657,13 @@ auto AlignVectors::realignGroup(const MoveGroup &Move) -> bool {
     realignLoadGroup(Builder, VSpan, ScLen, AlignVal, AlignAddr);
   else
     realignStoreGroup(Builder, VSpan, ScLen, AlignVal, AlignAddr);
+
+  Instruction *Front = Move.Main.front();
+  HVC.ORE.emit([&]() {
+    return OptimizationRemark(DEBUG_TYPE, "VectorsAligned",
+                              Front->getDebugLoc(), Front->getParent())
+           << "aligned vector memory operations";
+  });
 
   for (auto *Inst : Move.Main)
     Inst->eraseFromParent();
@@ -4070,6 +4130,7 @@ public:
     AU.addRequired<ScalarEvolutionWrapperPass>();
     AU.addRequired<TargetLibraryInfoWrapperPass>();
     AU.addRequired<TargetPassConfig>();
+    AU.addRequired<OptimizationRemarkEmitterWrapperPass>();
     FunctionPass::getAnalysisUsage(AU);
   }
 
@@ -4084,7 +4145,8 @@ public:
     TargetLibraryInfo &TLI =
         getAnalysis<TargetLibraryInfoWrapperPass>().getTLI(F);
     auto &TM = getAnalysis<TargetPassConfig>().getTM<HexagonTargetMachine>();
-    HexagonVectorCombine HVC(F, AA, AC, DT, SE, TLI, TM);
+    auto &ORE = getAnalysis<OptimizationRemarkEmitterWrapperPass>().getORE();
+    HexagonVectorCombine HVC(F, AA, AC, DT, SE, TLI, TM, ORE);
     return HVC.run();
   }
 };
@@ -4100,6 +4162,7 @@ INITIALIZE_PASS_DEPENDENCY(DominatorTreeWrapperPass)
 INITIALIZE_PASS_DEPENDENCY(ScalarEvolutionWrapperPass)
 INITIALIZE_PASS_DEPENDENCY(TargetLibraryInfoWrapperPass)
 INITIALIZE_PASS_DEPENDENCY(TargetPassConfig)
+INITIALIZE_PASS_DEPENDENCY(OptimizationRemarkEmitterWrapperPass)
 INITIALIZE_PASS_END(HexagonVectorCombineLegacy, DEBUG_TYPE,
                     "Hexagon Vector Combine", false, false)
 

--- a/llvm/lib/Target/Hexagon/HexagonVectorLoopCarriedReuse.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonVectorLoopCarriedReuse.cpp
@@ -20,6 +20,7 @@
 #include "llvm/ADT/Statistic.h"
 #include "llvm/Analysis/LoopInfo.h"
 #include "llvm/Analysis/LoopPass.h"
+#include "llvm/Analysis/OptimizationRemarkEmitter.h"
 #include "llvm/IR/BasicBlock.h"
 #include "llvm/IR/DerivedTypes.h"
 #include "llvm/IR/IRBuilder.h"
@@ -165,6 +166,7 @@ namespace {
     void getAnalysisUsage(AnalysisUsage &AU) const override {
       AU.addRequiredID(LoopSimplifyID);
       AU.addRequiredID(LCSSAID);
+      AU.addRequired<OptimizationRemarkEmitterWrapperPass>();
       AU.addPreservedID(LCSSAID);
       AU.setPreservesCFG();
     }
@@ -174,7 +176,8 @@ namespace {
 
   class HexagonVectorLoopCarriedReuse {
   public:
-    HexagonVectorLoopCarriedReuse(Loop *L) : CurLoop(L){};
+    HexagonVectorLoopCarriedReuse(Loop *L, OptimizationRemarkEmitter &ORE)
+        : CurLoop(L), ORE(ORE) {};
 
     bool run();
 
@@ -182,6 +185,7 @@ namespace {
     SetVector<DepChain *> Dependences;
     std::set<Instruction *> ReplacedInsts;
     Loop *CurLoop;
+    OptimizationRemarkEmitter &ORE;
     ReuseValue ReuseCandidate;
 
     bool doVLCR();
@@ -205,6 +209,7 @@ INITIALIZE_PASS_BEGIN(HexagonVectorLoopCarriedReuseLegacyPass, "hexagon-vlcr",
                       false, false)
 INITIALIZE_PASS_DEPENDENCY(LoopSimplify)
 INITIALIZE_PASS_DEPENDENCY(LCSSAWrapperPass)
+INITIALIZE_PASS_DEPENDENCY(OptimizationRemarkEmitterWrapperPass)
 INITIALIZE_PASS_END(HexagonVectorLoopCarriedReuseLegacyPass, "hexagon-vlcr",
                     "Hexagon-specific predictive commoning for HVX vectors",
                     false, false)
@@ -213,7 +218,8 @@ PreservedAnalyses
 HexagonVectorLoopCarriedReusePass::run(Loop &L, LoopAnalysisManager &LAM,
                                        LoopStandardAnalysisResults &AR,
                                        LPMUpdater &U) {
-  HexagonVectorLoopCarriedReuse Vlcr(&L);
+  OptimizationRemarkEmitter ORE(L.getHeader()->getParent());
+  HexagonVectorLoopCarriedReuse Vlcr(&L, ORE);
   if (!Vlcr.run())
     return PreservedAnalyses::all();
   PreservedAnalyses PA;
@@ -225,21 +231,43 @@ bool HexagonVectorLoopCarriedReuseLegacyPass::runOnLoop(Loop *L,
                                                         LPPassManager &LPM) {
   if (skipLoop(L))
     return false;
-  HexagonVectorLoopCarriedReuse Vlcr(L);
+  auto &ORE = getAnalysis<OptimizationRemarkEmitterWrapperPass>().getORE();
+  HexagonVectorLoopCarriedReuse Vlcr(L, ORE);
   return Vlcr.run();
 }
 
 bool HexagonVectorLoopCarriedReuse::run() {
-  if (!CurLoop->getLoopPreheader())
+  if (!CurLoop->getLoopPreheader()) {
+    ORE.emit([&]() {
+      return OptimizationRemarkMissed(DEBUG_TYPE, "NoPreheader",
+                                      CurLoop->getStartLoc(),
+                                      CurLoop->getHeader())
+             << "loop has no preheader";
+    });
     return false;
+  }
 
   // Work only on innermost loops.
-  if (!CurLoop->getSubLoops().empty())
+  if (!CurLoop->getSubLoops().empty()) {
+    ORE.emit([&]() {
+      return OptimizationRemarkMissed(DEBUG_TYPE, "NotInnermostLoop",
+                                      CurLoop->getStartLoc(),
+                                      CurLoop->getHeader())
+             << "pass only works on innermost loops";
+    });
     return false;
+  }
 
   // Work only on single basic blocks loops.
-  if (CurLoop->getNumBlocks() != 1)
+  if (CurLoop->getNumBlocks() != 1) {
+    ORE.emit([&]() {
+      return OptimizationRemarkMissed(DEBUG_TYPE, "MultipleBlocks",
+                                      CurLoop->getStartLoc(),
+                                      CurLoop->getHeader())
+             << "loop has multiple basic blocks";
+    });
     return false;
+  }
 
   return doVLCR();
 }
@@ -556,6 +584,12 @@ void HexagonVectorLoopCarriedReuse::reuseValue() {
   Inst2Replace->replaceAllUsesWith(NewPhi);
   ReplacedInsts.insert(Inst2Replace);
   ++HexagonNumVectorLoopCarriedReuse;
+  ORE.emit([&]() {
+    return OptimizationRemark(DEBUG_TYPE, "VectorReuse",
+                              Inst2Replace->getDebugLoc(),
+                              Inst2Replace->getParent())
+           << "reused loop-carried vector value";
+  });
 }
 
 bool HexagonVectorLoopCarriedReuse::doVLCR() {
@@ -579,6 +613,13 @@ bool HexagonVectorLoopCarriedReuse::doVLCR() {
       reuseValue();
       Changed = true;
       Continue = true;
+    } else if (!Changed) {
+      ORE.emit([&]() {
+        return OptimizationRemarkMissed(DEBUG_TYPE, "NoCandidateFound",
+                                        CurLoop->getStartLoc(),
+                                        CurLoop->getHeader())
+               << "no loop-carried reuse candidate found";
+      });
     }
     llvm::for_each(Dependences, std::default_delete<DepChain>());
   } while (Continue);

--- a/llvm/test/CodeGen/Hexagon/hvc-remarks.ll
+++ b/llvm/test/CodeGen/Hexagon/hvc-remarks.ll
@@ -1,0 +1,26 @@
+; RUN: opt -hexagon-vc -S -mtriple=hexagon \
+; RUN:   -mcpu=hexagonv68 -mattr=+hvxv68,+hvx-length128b \
+; RUN:   -pass-remarks=hexagon-vc -pass-remarks-missed=hexagon-vc \
+; RUN:   %s -o /dev/null 2>&1 | FileCheck %s
+
+;; Test that HexagonVectorCombine emits optimization remarks.
+
+;; -- Success: aligned vector memory operations --
+; CHECK: remark: {{.*}} aligned vector memory operations
+
+define void @test_align(ptr %p) {
+entry:
+  %p0 = getelementptr i8, ptr %p, i32 0
+  %p1 = getelementptr i8, ptr %p, i32 128
+  %p2 = getelementptr i8, ptr %p, i32 256
+  %p3 = getelementptr i8, ptr %p, i32 384
+  %v0 = load <128 x i8>, ptr %p0, align 1
+  %v1 = load <128 x i8>, ptr %p1, align 1
+  %v2 = load <128 x i8>, ptr %p2, align 1
+  %v3 = load <128 x i8>, ptr %p3, align 1
+  store <128 x i8> %v0, ptr %p0, align 1
+  store <128 x i8> %v1, ptr %p1, align 1
+  store <128 x i8> %v2, ptr %p2, align 1
+  store <128 x i8> %v3, ptr %p3, align 1
+  ret void
+}

--- a/llvm/test/CodeGen/Hexagon/hwloop-remarks.ll
+++ b/llvm/test/CodeGen/Hexagon/hwloop-remarks.ll
@@ -1,0 +1,47 @@
+; RUN: llc -mtriple=hexagon -pass-remarks=hwloops -pass-remarks-missed=hwloops \
+; RUN:   %s -o /dev/null 2>&1 | FileCheck %s
+
+;; Test that HexagonHardwareLoops emits optimization remarks.
+
+;; -- Success: converted loop to hardware loop --
+; CHECK: remark: {{.*}} converted loop to hardware loop
+
+define void @test_hwloop(ptr nocapture %a, i32 %n) {
+entry:
+  %cmp = icmp sgt i32 %n, 0
+  br i1 %cmp, label %for.body, label %for.end
+
+for.body:
+  %i = phi i32 [ 0, %entry ], [ %inc, %for.body ]
+  %arrayidx = getelementptr inbounds i32, ptr %a, i32 %i
+  store i32 %i, ptr %arrayidx, align 4
+  %inc = add nuw nsw i32 %i, 1
+  %exitcond = icmp eq i32 %inc, %n
+  br i1 %exitcond, label %for.end, label %for.body
+
+for.end:
+  ret void
+}
+
+;; -- Missed: loop contains a call --
+; CHECK: remark: {{.*}} loop contains an instruction that prevents hardware loop generation
+
+declare void @bar()
+
+define void @test_call_in_loop(ptr nocapture %a, i32 %n) {
+entry:
+  %cmp = icmp sgt i32 %n, 0
+  br i1 %cmp, label %for.body, label %for.end
+
+for.body:
+  %i = phi i32 [ 0, %entry ], [ %inc, %for.body ]
+  %arrayidx = getelementptr inbounds i32, ptr %a, i32 %i
+  store i32 %i, ptr %arrayidx, align 4
+  call void @bar()
+  %inc = add nuw nsw i32 %i, 1
+  %exitcond = icmp eq i32 %inc, %n
+  br i1 %exitcond, label %for.end, label %for.body
+
+for.end:
+  ret void
+}

--- a/llvm/test/CodeGen/Hexagon/loop-idiom-remarks.ll
+++ b/llvm/test/CodeGen/Hexagon/loop-idiom-remarks.ll
@@ -1,0 +1,84 @@
+; RUN: opt -p hexagon-loop-idiom -S -mtriple hexagon-unknown-elf \
+; RUN:   -pass-remarks=hexagon-lir -pass-remarks-missed=hexagon-lir \
+; RUN:   %s -o /dev/null 2>&1 | FileCheck %s
+
+;; Test that HexagonLoopIdiomRecognition emits optimization remarks.
+
+;; -- Success: loop converted to memmove --
+; CHECK: remark: {{.*}} converted loop to memmove
+
+define void @test_memmove(ptr nocapture %A, ptr nocapture readonly %B, i32 %n) {
+entry:
+  %cmp = icmp sgt i32 %n, 0
+  br i1 %cmp, label %for.body.preheader, label %for.end
+
+for.body.preheader:
+  br label %for.body
+
+for.body:
+  %src.phi = phi ptr [ %B, %for.body.preheader ], [ %src.inc, %for.body ]
+  %dst.phi = phi ptr [ %A, %for.body.preheader ], [ %dst.inc, %for.body ]
+  %i = phi i32 [ %inc, %for.body ], [ 0, %for.body.preheader ]
+  %val = load i32, ptr %src.phi, align 4
+  store i32 %val, ptr %dst.phi, align 4
+  %inc = add nuw nsw i32 %i, 1
+  %exitcond = icmp ne i32 %inc, %n
+  %src.inc = getelementptr i32, ptr %src.phi, i32 1
+  %dst.inc = getelementptr i32, ptr %dst.phi, i32 1
+  br i1 %exitcond, label %for.body, label %for.end.loopexit
+
+for.end.loopexit:
+  br label %for.end
+
+for.end:
+  ret void
+}
+
+;; -- Missed: store value is not a simple load --
+; CHECK: remark: {{.*}} store value is not a simple load
+
+define void @test_no_load(ptr nocapture %A, i32 %n) {
+entry:
+  %cmp = icmp sgt i32 %n, 0
+  br i1 %cmp, label %for.body.preheader, label %for.end
+
+for.body.preheader:
+  br label %for.body
+
+for.body:
+  %dst.phi = phi ptr [ %A, %for.body.preheader ], [ %dst.inc, %for.body ]
+  %i = phi i32 [ %inc, %for.body ], [ 0, %for.body.preheader ]
+  store i32 42, ptr %dst.phi, align 4
+  %inc = add nuw nsw i32 %i, 1
+  %exitcond = icmp ne i32 %inc, %n
+  %dst.inc = getelementptr i32, ptr %dst.phi, i32 1
+  br i1 %exitcond, label %for.body, label %for.end.loopexit
+
+for.end.loopexit:
+  br label %for.end
+
+for.end:
+  ret void
+}
+
+;; -- Missed: non-countable loop --
+; CHECK: remark: {{.*}} backedge-taken count is not loop-invariant
+
+define void @test_non_countable(ptr nocapture %A, ptr nocapture readonly %B,
+                                ptr nocapture readonly %cond) {
+entry:
+  br label %for.body
+
+for.body:
+  %src.phi = phi ptr [ %B, %entry ], [ %src.inc, %for.body ]
+  %dst.phi = phi ptr [ %A, %entry ], [ %dst.inc, %for.body ]
+  %val = load i32, ptr %src.phi, align 4
+  store i32 %val, ptr %dst.phi, align 4
+  %src.inc = getelementptr i32, ptr %src.phi, i32 1
+  %dst.inc = getelementptr i32, ptr %dst.phi, i32 1
+  %flag = load volatile i1, ptr %cond, align 1
+  br i1 %flag, label %for.body, label %for.end
+
+for.end:
+  ret void
+}

--- a/llvm/test/CodeGen/Hexagon/vlcr-remarks.ll
+++ b/llvm/test/CodeGen/Hexagon/vlcr-remarks.ll
@@ -1,0 +1,83 @@
+; RUN: opt -mtriple=hexagon-- -mcpu=hexagonv68 -mattr=+hvxv68,+hvx-length128b \
+; RUN:   -passes='loop(hexagon-vlcr)' -S \
+; RUN:   -pass-remarks=hexagon-vlcr -pass-remarks-missed=hexagon-vlcr \
+; RUN:   %s -o /dev/null 2>&1 | FileCheck %s
+
+;; Test that HexagonVectorLoopCarriedReuse emits optimization remarks.
+
+;; -- Success: reused loop-carried vector value --
+; CHECK: remark: {{.*}} reused loop-carried vector value
+
+@W = external local_unnamed_addr global i32, align 4
+
+define void @test_reuse(ptr noalias nocapture readonly %src, ptr noalias nocapture %dst, i32 %stride) {
+entry:
+  %add.ptr = getelementptr inbounds i8, ptr %src, i32 %stride
+  %0 = load i32, ptr @W, align 4
+  %cmp = icmp sgt i32 %0, 0
+  br i1 %cmp, label %for.body.preheader, label %for.end
+
+for.body.preheader:
+  %1 = load <32 x i32>, ptr %add.ptr, align 128
+  %incdec.ptr1 = getelementptr inbounds i8, ptr %add.ptr, i32 128
+  %2 = load <32 x i32>, ptr %src, align 128
+  %incdec.ptr = getelementptr inbounds i8, ptr %src, i32 128
+  br label %for.body
+
+for.body:
+  %out.phi = phi ptr [ %dst, %for.body.preheader ], [ %out.inc, %for.body ]
+  %p1.phi = phi ptr [ %incdec.ptr1, %for.body.preheader ], [ %p1.inc, %for.body ]
+  %p0.phi = phi ptr [ %incdec.ptr, %for.body.preheader ], [ %p0.inc, %for.body ]
+  %i.phi = phi i32 [ 0, %for.body.preheader ], [ %i.inc, %for.body ]
+  %a.phi = phi <32 x i32> [ %2, %for.body.preheader ], [ %3, %for.body ]
+  %b.phi = phi <32 x i32> [ %1, %for.body.preheader ], [ %4, %for.body ]
+  %p0.inc = getelementptr inbounds <32 x i32>, ptr %p0.phi, i32 1
+  %3 = load <32 x i32>, ptr %p0.phi, align 128
+  %p1.inc = getelementptr inbounds <32 x i32>, ptr %p1.phi, i32 1
+  %4 = load <32 x i32>, ptr %p1.phi, align 128
+  %max1 = tail call <32 x i32> @llvm.hexagon.V6.vmaxub.128B(<32 x i32> %a.phi, <32 x i32> %b.phi)
+  %max2 = tail call <32 x i32> @llvm.hexagon.V6.vmaxub.128B(<32 x i32> %3, <32 x i32> %4)
+  %sum = tail call <32 x i32> @llvm.hexagon.V6.vaddw.128B(<32 x i32> %max1, <32 x i32> %max2)
+  store <32 x i32> %sum, ptr %out.phi, align 128
+  %out.inc = getelementptr inbounds <32 x i32>, ptr %out.phi, i32 1
+  %i.inc = add nuw nsw i32 %i.phi, 1
+  %exitcond = icmp slt i32 %i.inc, %0
+  br i1 %exitcond, label %for.body, label %for.end
+
+for.end:
+  ret void
+}
+
+;; -- Missed: loop has multiple basic blocks --
+; CHECK: remark: {{.*}} loop has multiple basic blocks
+
+define void @test_multi_bb(ptr noalias nocapture readonly %src, ptr noalias nocapture %dst, i32 %n) {
+entry:
+  %cmp = icmp sgt i32 %n, 0
+  br i1 %cmp, label %for.body, label %for.end
+
+for.body:
+  %i = phi i32 [ 0, %entry ], [ %i.inc, %for.latch ]
+  %p = phi ptr [ %src, %entry ], [ %p.inc, %for.latch ]
+  %q = phi ptr [ %dst, %entry ], [ %q.inc, %for.latch ]
+  %val = load <32 x i32>, ptr %p, align 128
+  %check = icmp eq i32 %i, 0
+  br i1 %check, label %if.then, label %for.latch
+
+if.then:
+  store <32 x i32> %val, ptr %q, align 128
+  br label %for.latch
+
+for.latch:
+  %p.inc = getelementptr inbounds <32 x i32>, ptr %p, i32 1
+  %q.inc = getelementptr inbounds <32 x i32>, ptr %q, i32 1
+  %i.inc = add nuw nsw i32 %i, 1
+  %exitcond = icmp ne i32 %i.inc, %n
+  br i1 %exitcond, label %for.body, label %for.end
+
+for.end:
+  ret void
+}
+
+declare <32 x i32> @llvm.hexagon.V6.vmaxub.128B(<32 x i32>, <32 x i32>)
+declare <32 x i32> @llvm.hexagon.V6.vaddw.128B(<32 x i32>, <32 x i32>)


### PR DESCRIPTION
Add OptimizationRemark/OptimizationRemarkMissed emissions to four Hexagon-specific passes, making them observable via the standard -Rpass/-Rpass-missed flags:

- HexagonLoopIdiomRecognition (hexagon-lir): remarks for loop-to-memcpy/ memmove conversions and polynomial multiply recognition, with missed remarks for non-countable loops, aliasing, non-affine pointers, etc.

- HexagonVectorLoopCarriedReuse (hexagon-vlcr): remarks for reused loop-carried vector values, with missed remarks for multi-block loops, non-innermost loops, and missing candidates.

- HexagonVectorCombine (hexagon-vc): remarks for aligned vector memory operations, with missed remarks for group size limits, unsafe relocations, and insufficient HVX version.

- HexagonHardwareLoops (hwloops): remarks for hardware loop conversion, with missed remarks for invalid instructions (calls), multiple exits, induction variable issues, and non-computable trip counts.