### PR TITLE
[libc][math] Fix: Missed adding log2p1f16 to shared math

### DIFF
--- a/libc/shared/math.h
+++ b/libc/shared/math.h
@@ -193,6 +193,7 @@
 #include "math/log2.h"
 #include "math/log2f.h"
 #include "math/log2f16.h"
+#include "math/log2p1f16.h"
 #include "math/log_bf16.h"
 #include "math/logb.h"
 #include "math/logbf.h"

--- a/libc/shared/math/log2p1f16.h
+++ b/libc/shared/math/log2p1f16.h
@@ -1,0 +1,29 @@
+//===-- Shared log2p1f16 function -------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SHARED_MATH_LOG2P1F16_H
+#define LLVM_LIBC_SHARED_MATH_LOG2P1F16_H
+
+#include "include/llvm-libc-macros/float16-macros.h"
+
+#ifdef LIBC_TYPES_HAS_FLOAT16
+
+#include "shared/libc_common.h"
+#include "src/__support/math/log2p1f16.h"
+
+namespace LIBC_NAMESPACE_DECL {
+namespace shared {
+
+using math::log2p1f16;
+
+} // namespace shared
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LIBC_TYPES_HAS_FLOAT16
+
+#endif // LLVM_LIBC_SHARED_MATH_LOG2P1F16_H

--- a/libc/test/shared/CMakeLists.txt
+++ b/libc/test/shared/CMakeLists.txt
@@ -185,6 +185,7 @@ add_fp_unittest(
     libc.src.__support.math.logb
     libc.src.__support.math.log2f
     libc.src.__support.math.log2f16
+    libc.src.__support.math.log2p1f16
     libc.src.__support.math.logbf
     libc.src.__support.math.logbf128
     libc.src.__support.math.logbf16

--- a/libc/test/shared/shared_math_test.cpp
+++ b/libc/test/shared/shared_math_test.cpp
@@ -55,6 +55,7 @@ TEST(LlvmLibcSharedMathTest, AllFloat16) {
   EXPECT_EQ(0, LIBC_NAMESPACE::shared::ilogbf16(1.0f16));
   EXPECT_FP_EQ(1.0f16, LIBC_NAMESPACE::shared::log10f16(10.0f16));
   EXPECT_FP_EQ(1.0f16, LIBC_NAMESPACE::shared::log2f16(2.0f16));
+  EXPECT_FP_EQ(1.0f16, LIBC_NAMESPACE::shared::log2p1f16(1.0f16));
   EXPECT_FP_EQ(0.0f16, LIBC_NAMESPACE::shared::logbf16(1.0f16));
   EXPECT_EQ(0L, LIBC_NAMESPACE::shared::llogbf16(1.0f16));
 

--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -5294,6 +5294,27 @@ libc_support_library(
 )
 
 libc_support_library(
+    name = "__support_math_log2p1f16",
+    hdrs = ["src/__support/math/log2p1f16.h"],
+    deps = [
+        ":__support_common",
+        ":__support_fputil_cast",
+        ":__support_fputil_except_value_utils",
+        ":__support_fputil_fenv_impl",
+        ":__support_fputil_fp_bits",
+        ":__support_fputil_multiply_add",
+        ":__support_fputil_poly_eval",
+        ":__support_macros_config",
+        ":__support_macros_optimization",
+        ":__support_macros_properties_cpu_features",
+        ":__support_math_expxf16_utils",
+        ":hdr_errno_macros",
+        ":hdr_fenv_macros",
+        ":llvm_libc_macros_float16_macros",
+    ],
+)
+
+libc_support_library(
     name = "__support_math_log2f",
     hdrs = ["src/__support/math/log2f.h"],
     deps = [
@@ -8014,6 +8035,13 @@ libc_math_function(
     name = "log2f16",
     additional_deps = [
         ":__support_math_log2f16",
+    ],
+)
+
+libc_math_function(
+    name = "log2p1f16",
+    additional_deps = [
+        ":__support_math_log2p1f16",
     ],
 )
 


### PR DESCRIPTION
This PR intends to add the log2p1f16 function to shared math, along with adding tests for it and bazel which was missed in [f0ce26d](https://github.com/llvm/llvm-project/commit/f0ce26d06d822fd6985d227dc1be9d218977e334).