### PR TITLE
[libc][math] Fix: Missed adding log10p1f16 to shared math

### DIFF
--- a/libc/shared/math.h
+++ b/libc/shared/math.h
@@ -188,6 +188,7 @@
 #include "math/log10.h"
 #include "math/log10f.h"
 #include "math/log10f16.h"
+#include "math/log10p1f16.h"
 #include "math/log1p.h"
 #include "math/log1pf.h"
 #include "math/log2.h"

--- a/libc/shared/math/log10p1f16.h
+++ b/libc/shared/math/log10p1f16.h
@@ -1,0 +1,29 @@
+//===-- Shared log10p1f16 function ------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SHARED_MATH_LOG10P1F16_H
+#define LLVM_LIBC_SHARED_MATH_LOG10P1F16_H
+
+#include "include/llvm-libc-macros/float16-macros.h"
+
+#ifdef LIBC_TYPES_HAS_FLOAT16
+
+#include "shared/libc_common.h"
+#include "src/__support/math/log10p1f16.h"
+
+namespace LIBC_NAMESPACE_DECL {
+namespace shared {
+
+using math::log10p1f16;
+
+} // namespace shared
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LIBC_TYPES_HAS_FLOAT16
+
+#endif // LLVM_LIBC_SHARED_MATH_LOG10P1F16_H

--- a/libc/test/shared/CMakeLists.txt
+++ b/libc/test/shared/CMakeLists.txt
@@ -178,6 +178,7 @@ add_fp_unittest(
     libc.src.__support.math.log
     libc.src.__support.math.log10
     libc.src.__support.math.log10f16
+    libc.src.__support.math.log10p1f16
     libc.src.__support.math.log10f
     libc.src.__support.math.log1p
     libc.src.__support.math.log1pf

--- a/libc/test/shared/shared_math_test.cpp
+++ b/libc/test/shared/shared_math_test.cpp
@@ -53,10 +53,10 @@ TEST(LlvmLibcSharedMathTest, AllFloat16) {
   EXPECT_EQ(exponent, 5);
 
   EXPECT_EQ(0, LIBC_NAMESPACE::shared::ilogbf16(1.0f16));
-  EXPECT_FP_EQ(0x1p+0f16, LIBC_NAMESPACE::shared::log10f16(10.0f16));
-  EXPECT_FP_EQ(0x1p+0f16, LIBC_NAMESPACE::shared::log10p1f16(9.0f16));
-  EXPECT_FP_EQ(0x1p+0f16, LIBC_NAMESPACE::shared::log2f16(2.0f16));
-  EXPECT_FP_EQ(0x0p+0f16, LIBC_NAMESPACE::shared::logbf16(1.0f16));
+  EXPECT_FP_EQ(1.0f16, LIBC_NAMESPACE::shared::log10f16(10.0f16));
+  EXPECT_FP_EQ(1.0f16, LIBC_NAMESPACE::shared::log10p1f16(9.0f16));
+  EXPECT_FP_EQ(1.0f16, LIBC_NAMESPACE::shared::log2f16(2.0f16));
+  EXPECT_FP_EQ(0.0f16, LIBC_NAMESPACE::shared::logbf16(1.0f16));
   EXPECT_EQ(0L, LIBC_NAMESPACE::shared::llogbf16(1.0f16));
 
   EXPECT_FP_EQ(0x1.921fb6p+0f16, LIBC_NAMESPACE::shared::acosf16(0.0f16));

--- a/libc/test/shared/shared_math_test.cpp
+++ b/libc/test/shared/shared_math_test.cpp
@@ -53,9 +53,10 @@ TEST(LlvmLibcSharedMathTest, AllFloat16) {
   EXPECT_EQ(exponent, 5);
 
   EXPECT_EQ(0, LIBC_NAMESPACE::shared::ilogbf16(1.0f16));
-  EXPECT_FP_EQ(1.0f16, LIBC_NAMESPACE::shared::log10f16(10.0f16));
-  EXPECT_FP_EQ(1.0f16, LIBC_NAMESPACE::shared::log2f16(2.0f16));
-  EXPECT_FP_EQ(0.0f16, LIBC_NAMESPACE::shared::logbf16(1.0f16));
+  EXPECT_FP_EQ(0x1p+0f16, LIBC_NAMESPACE::shared::log10f16(10.0f16));
+  EXPECT_FP_EQ(0x1p+0f16, LIBC_NAMESPACE::shared::log10p1f16(9.0f16));
+  EXPECT_FP_EQ(0x1p+0f16, LIBC_NAMESPACE::shared::log2f16(2.0f16));
+  EXPECT_FP_EQ(0x0p+0f16, LIBC_NAMESPACE::shared::logbf16(1.0f16));
   EXPECT_EQ(0L, LIBC_NAMESPACE::shared::llogbf16(1.0f16));
 
   EXPECT_FP_EQ(0x1.921fb6p+0f16, LIBC_NAMESPACE::shared::acosf16(0.0f16));

--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -5255,6 +5255,28 @@ libc_support_library(
 )
 
 libc_support_library(
+    name = "__support_math_log10p1f16",
+    hdrs = ["src/__support/math/log10p1f16.h"],
+    deps = [
+        ":__support_common",
+        ":__support_fputil_cast",
+        ":__support_fputil_except_value_utils",
+        ":__support_fputil_fenv_impl",
+        ":__support_fputil_fp_bits",
+        ":__support_fputil_multiply_add",
+        ":__support_fputil_poly_eval",
+        ":__support_macros_config",
+        ":__support_macros_optimization",
+        ":__support_macros_properties_cpu_features",
+        ":__support_math_exp10_float16_constants",
+        ":__support_math_expxf16_utils",
+        ":hdr_errno_macros",
+        ":hdr_fenv_macros",
+        ":llvm_libc_macros_float16_macros",
+    ],
+)
+
+libc_support_library(
     name = "__support_math_log10f",
     hdrs = ["src/__support/math/log10f.h"],
     deps = [
@@ -7983,6 +8005,13 @@ libc_math_function(
     name = "log10f16",
     additional_deps = [
         ":__support_math_log10f16",
+    ],
+)
+
+libc_math_function(
+    name = "log10p1f16",
+    additional_deps = [
+        ":__support_math_log10p1f16",
     ],
 )
 


### PR DESCRIPTION
This PR intends to add the log10p1f16 function to shared math, along with adding tests for it and Bazel which was missed in [a7d1a87](https://github.com/llvm/llvm-project/commit/a7d1a87b30ce626678d33fe1c12e647f7ce4fb20).
