### PR TITLE
[lldb] Use ArrayRef instead of pointer+size (NFC)

### DIFF
--- a/lldb/include/lldb/Target/Thread.h
+++ b/lldb/include/lldb/Target/Thread.h
@@ -1005,7 +1005,7 @@ public:
                                  bool stop_other_threads, Status &status);
 
   virtual lldb::ThreadPlanSP QueueThreadPlanForStepUntil(
-      bool abort_other_plans, lldb::addr_t *address_list, size_t num_addresses,
+      bool abort_other_plans, llvm::ArrayRef<lldb::addr_t> address_list,
       bool stop_others, uint32_t frame_idx, Status &status);
 
   virtual lldb::ThreadPlanSP

--- a/lldb/include/lldb/Target/ThreadPlanStepUntil.h
+++ b/lldb/include/lldb/Target/ThreadPlanStepUntil.h
@@ -16,6 +16,9 @@ namespace lldb_private {
 
 class ThreadPlanStepUntil : public ThreadPlan {
 public:
+  ThreadPlanStepUntil(Thread &thread, llvm::ArrayRef<lldb::addr_t> address_list,
+                      bool stop_others, uint32_t frame_idx = 0);
+
   ~ThreadPlanStepUntil() override;
 
   void GetDescription(Stream *s, lldb::DescriptionLevel level) override;
@@ -29,10 +32,6 @@ public:
 protected:
   bool DoWillResume(lldb::StateType resume_state, bool current_plan) override;
   bool DoPlanExplainsStop(Event *event_ptr) override;
-
-  ThreadPlanStepUntil(Thread &thread, lldb::addr_t *address_list,
-                      size_t num_addresses, bool stop_others,
-                      uint32_t frame_idx = 0);
 
   void AnalyzeStop();
 
@@ -51,10 +50,6 @@ private:
   bool m_stop_others;
 
   void Clear();
-
-  friend lldb::ThreadPlanSP Thread::QueueThreadPlanForStepUntil(
-      bool abort_other_plans, lldb::addr_t *address_list, size_t num_addresses,
-      bool stop_others, uint32_t frame_idx, Status &status);
 
   // Need an appropriate marker for the current stack so we can tell step out
   // from step in.

--- a/lldb/source/API/SBThread.cpp
+++ b/lldb/source/API/SBThread.cpp
@@ -846,10 +846,9 @@ SBError SBThread::StepOverUntil(lldb::SBFrame &sb_frame,
             "step until target not in current function");
     } else {
       Status new_plan_status;
-      ThreadPlanSP new_plan_sp(thread->QueueThreadPlanForStepUntil(
-          abort_other_plans, &step_over_until_addrs[0],
-          step_over_until_addrs.size(), stop_other_threads,
-          frame_sp->GetFrameIndex(), new_plan_status));
+      ThreadPlanSP new_plan_sp = thread->QueueThreadPlanForStepUntil(
+          abort_other_plans, step_over_until_addrs, stop_other_threads,
+          frame_sp->GetFrameIndex(), new_plan_status);
 
       if (new_plan_status.Success())
         sb_error = ResumeNewPlan(std::move(*exe_ctx), new_plan_sp.get());

--- a/lldb/source/Commands/CommandObjectThread.cpp
+++ b/lldb/source/Commands/CommandObjectThread.cpp
@@ -1026,8 +1026,8 @@ protected:
         }
 
         new_plan_sp = thread->QueueThreadPlanForStepUntil(
-            abort_other_plans, &address_list.front(), address_list.size(),
-            m_options.m_stop_others, m_options.m_frame_idx, new_plan_status);
+            abort_other_plans, address_list, m_options.m_stop_others,
+            m_options.m_frame_idx, new_plan_status);
         if (new_plan_sp) {
           // User level plans should be controlling plans so they can be
           // interrupted

--- a/lldb/source/Target/Thread.cpp
+++ b/lldb/source/Target/Thread.cpp
@@ -1415,10 +1415,10 @@ ThreadPlanSP Thread::QueueThreadPlanForRunToAddress(bool abort_other_plans,
 }
 
 ThreadPlanSP Thread::QueueThreadPlanForStepUntil(
-    bool abort_other_plans, lldb::addr_t *address_list, size_t num_addresses,
+    bool abort_other_plans, llvm::ArrayRef<addr_t> address_list,
     bool stop_other_threads, uint32_t frame_idx, Status &status) {
-  ThreadPlanSP thread_plan_sp(new ThreadPlanStepUntil(
-      *this, address_list, num_addresses, stop_other_threads, frame_idx));
+  ThreadPlanSP thread_plan_sp = std::make_shared<ThreadPlanStepUntil>(
+      *this, address_list, stop_other_threads, frame_idx);
 
   status = QueueThreadPlan(thread_plan_sp, abort_other_plans);
   return thread_plan_sp;

--- a/lldb/source/Target/ThreadPlanStepUntil.cpp
+++ b/lldb/source/Target/ThreadPlanStepUntil.cpp
@@ -24,9 +24,8 @@ using namespace lldb_private;
 // the current frame
 
 ThreadPlanStepUntil::ThreadPlanStepUntil(Thread &thread,
-                                         lldb::addr_t *address_list,
-                                         size_t num_addresses, bool stop_others,
-                                         uint32_t frame_idx)
+                                         llvm::ArrayRef<addr_t> address_list,
+                                         bool stop_others, uint32_t frame_idx)
     : ThreadPlan(ThreadPlan::eKindStepUntil, "Step until", thread,
                  eVoteNoOpinion, eVoteNoOpinion),
       m_step_from_insn(LLDB_INVALID_ADDRESS),
@@ -63,15 +62,15 @@ ThreadPlanStepUntil::ThreadPlanStepUntil(Thread &thread,
     m_stack_id = frame_sp->GetStackID();
 
     // Now set breakpoints on all our return addresses:
-    for (size_t i = 0; i < num_addresses; i++) {
+    for (addr_t address : address_list) {
       Breakpoint *until_bp =
-          target_sp->CreateBreakpoint(address_list[i], true, false).get();
+          target_sp->CreateBreakpoint(address, true, false).get();
       if (until_bp != nullptr) {
         until_bp->SetThreadID(m_tid);
-        m_until_points[address_list[i]] = until_bp->GetID();
+        m_until_points[address] = until_bp->GetID();
         until_bp->SetBreakpointKind("until-target");
       } else {
-        m_until_points[address_list[i]] = LLDB_INVALID_BREAK_ID;
+        m_until_points[address] = LLDB_INVALID_BREAK_ID;
       }
     }
   }


### PR DESCRIPTION
While here:
* Move the constructor to the public section. Almost all ThreadPlan classes have public constructors.
* Use `std::make_shared()`. It is modern and more efficient.