### PR TITLE
[Hexagon] Add HVX caller-save remark pass for call-site diagnostics

### DIFF
--- a/llvm/lib/Target/Hexagon/CMakeLists.txt
+++ b/llvm/lib/Target/Hexagon/CMakeLists.txt
@@ -42,6 +42,7 @@ add_llvm_target(HexagonCodeGen
   HexagonGlobalScheduler.cpp
   HexagonLiveVariables.cpp
   HexagonHardwareLoops.cpp
+  HexagonHVXSaveRemark.cpp
   HexagonHazardRecognizer.cpp
   HexagonInstrInfo.cpp
   HexagonISelDAGToDAG.cpp

--- a/llvm/lib/Target/Hexagon/Hexagon.h
+++ b/llvm/lib/Target/Hexagon/Hexagon.h
@@ -43,6 +43,7 @@ void initializeHexagonGenMemAbsolutePass(PassRegistry &);
 void initializeHexagonGenMuxPass(PassRegistry &);
 void initializeHexagonGlobalSchedulerPass(PassRegistry &);
 void initializeHexagonHardwareLoopsPass(PassRegistry &);
+void initializeHexagonHVXSaveRemarkPass(PassRegistry &);
 void initializeHexagonLiveVariablesPass(PassRegistry &);
 void initializeHexagonLoopIdiomRecognizeLegacyPassPass(PassRegistry &);
 void initializeHexagonLoopAlignPass(PassRegistry &);
@@ -97,6 +98,7 @@ FunctionPass *createHexagonGenMux();
 FunctionPass *createHexagonGenPredicate();
 FunctionPass *createHexagonGlobalScheduler();
 FunctionPass *createHexagonHardwareLoops();
+FunctionPass *createHexagonHVXSaveRemark();
 FunctionPass *createHexagonISelDag(HexagonTargetMachine &TM,
                                    CodeGenOptLevel OptLevel);
 FunctionPass *createHexagonLoopAlign();

--- a/llvm/lib/Target/Hexagon/HexagonHVXSaveRemark.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonHVXSaveRemark.cpp
@@ -18,10 +18,10 @@
 
 #include "HexagonSubtarget.h"
 #include "llvm/Analysis/OptimizationRemarkEmitter.h"
-#include "llvm/CodeGen/MachineFrameInfo.h"
 #include "llvm/CodeGen/MachineFunction.h"
 #include "llvm/CodeGen/MachineFunctionPass.h"
 #include "llvm/CodeGen/MachineOptimizationRemarkEmitter.h"
+#include "llvm/CodeGen/PseudoSourceValue.h"
 #include "llvm/InitializePasses.h"
 #include "llvm/Pass.h"
 #include "llvm/Support/CommandLine.h"
@@ -32,8 +32,9 @@ using namespace llvm;
 #define DEBUG_TYPE "hexagon-hvx-save"
 
 static cl::opt<unsigned> HVXSaveThreshold(
-    "hexagon-hvx-save-threshold", cl::Hidden, cl::init(1024),
-    cl::desc("Minimum bytes of HVX caller-saves to trigger a remark"));
+    "hexagon-hvx-save-threshold", cl::Hidden, cl::init(8),
+    cl::desc("Minimum number of HVX caller-saved registers live across a call "
+             "to trigger a remark"));
 
 namespace {
 
@@ -41,6 +42,34 @@ struct HexagonHVXSaveRemark : public MachineFunctionPass {
   static char ID;
 
   HexagonHVXSaveRemark() : MachineFunctionPass(ID) {}
+
+  /// Return true if MI is an HVX vector spill to a stack slot.
+  static bool isHVXSpill(const MachineInstr &MI, unsigned HVXLen) {
+    if (MI.mayStore() && MI.hasOneMemOperand()) {
+      const MachineMemOperand *MMO = *MI.memoperands_begin();
+      if (MMO->getSize().hasValue() && MMO->getPseudoValue() &&
+          isa<FixedStackPseudoSourceValue>(MMO->getPseudoValue()))
+        return MMO->getSize().getValue() == HVXLen ||
+               MMO->getSize().getValue() == 2 * HVXLen;
+    }
+    return false;
+  }
+
+  /// Count HVX spills in a bundle or single instruction that contains a call.
+  static unsigned countSpillsInBundle(const MachineInstr &BundleOrMI,
+                                      unsigned HVXLen) {
+    unsigned Count = 0;
+    if (BundleOrMI.isBundle()) {
+      auto MII = BundleOrMI.getIterator();
+      for (++MII; MII->isBundledWithPred(); ++MII)
+        if (isHVXSpill(*MII, HVXLen))
+          ++Count;
+    } else {
+      if (isHVXSpill(BundleOrMI, HVXLen))
+        ++Count;
+    }
+    return Count;
+  }
 
   bool runOnMachineFunction(MachineFunction &MF) override {
     auto &MORE = getAnalysis<MachineOptimizationRemarkEmitterPass>().getORE();
@@ -51,45 +80,44 @@ struct HexagonHVXSaveRemark : public MachineFunctionPass {
     if (!HST.useHVXOps())
       return false;
 
-    // Identify HVX caller-save slots by matching stack-slot sizes against
-    // the HVX vector length (single vectors and vector pairs).
-    const MachineFrameInfo &MFI = MF.getFrameInfo();
     unsigned HVXLen = HST.getVectorLength();
-    unsigned NumVecSaves = 0;
-    unsigned NumPairSaves = 0;
 
-    for (int I = MFI.getObjectIndexBegin(), E = MFI.getObjectIndexEnd(); I < E;
-         ++I) {
-      if (!MFI.isSpillSlotObjectIndex(I))
-        continue;
-      int64_t Size = MFI.getObjectSize(I);
-      if (Size == (int64_t)HVXLen)
-        ++NumVecSaves;
-      else if (Size == (int64_t)(2 * HVXLen))
-        ++NumPairSaves;
-    }
-
-    unsigned TotalSaves = NumVecSaves + NumPairSaves;
-    unsigned TotalBytes = NumVecSaves * HVXLen + NumPairSaves * 2 * HVXLen;
-
-    if (TotalBytes < HVXSaveThreshold)
-      return false;
-
-    // Emit a remark on each call site.
     for (const MachineBasicBlock &MBB : MF) {
-      for (const MachineInstr &MI : MBB) {
-        if (!MI.isCall())
+      for (auto I = MBB.instr_begin(), E = MBB.instr_end(); I != E; ++I) {
+        const MachineInstr &MI = *I;
+        if (!MI.isCall() || MI.isBundledWithPred())
           continue;
 
-        MORE.emit([&]() {
-          using namespace ore;
-          MachineOptimizationRemarkAnalysis R(DEBUG_TYPE, "HVXSaveAroundCall",
-                                              MI.getDebugLoc(), &MBB);
-          R << NV("NumSaves", TotalSaves) << " HVX caller-saved register(s) ("
-            << NV("TotalBytes", TotalBytes)
-            << " bytes) saved and restored around call";
-          return R;
-        });
+        // Count HVX spills in the bundle containing this call (spills are
+        // often packetized together with the call instruction).
+        unsigned NumSpills = countSpillsInBundle(MI, HVXLen);
+
+        // Also count HVX spills in immediately preceding bundles/instructions
+        // that are purely spill operations.
+        auto BundleIt = MachineBasicBlock::const_iterator(MI);
+        while (BundleIt != MBB.begin()) {
+          --BundleIt;
+          unsigned PrevSpills = countSpillsInBundle(*BundleIt, HVXLen);
+          if (PrevSpills == 0)
+            break;
+          NumSpills += PrevSpills;
+        }
+
+        LLVM_DEBUG(dbgs() << "HVXSaveRemark: call in " << MF.getName()
+                          << " has " << NumSpills << " HVX spills\n");
+
+        if (NumSpills >= HVXSaveThreshold) {
+          unsigned TotalBytes = NumSpills * HVXLen;
+          MORE.emit([&]() {
+            MachineOptimizationRemarkAnalysis R(DEBUG_TYPE, "HVXSaveAroundCall",
+                                                MI.getDebugLoc(), &MBB);
+            R << ore::NV("NumSaves", NumSpills)
+              << " HVX caller-saved register(s) ("
+              << ore::NV("TotalBytes", TotalBytes)
+              << " bytes) live across call";
+            return R;
+          });
+        }
       }
     }
 

--- a/llvm/lib/Target/Hexagon/HexagonHVXSaveRemark.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonHVXSaveRemark.cpp
@@ -43,7 +43,7 @@ struct HexagonHVXSaveRemark : public MachineFunctionPass {
   HexagonHVXSaveRemark() : MachineFunctionPass(ID) {}
 
   bool runOnMachineFunction(MachineFunction &MF) override {
-    MachineOptimizationRemarkEmitter MORE(MF, nullptr);
+    auto &MORE = getAnalysis<MachineOptimizationRemarkEmitterPass>().getORE();
     if (!MORE.allowExtraAnalysis(DEBUG_TYPE))
       return false;
 
@@ -99,6 +99,7 @@ struct HexagonHVXSaveRemark : public MachineFunctionPass {
   StringRef getPassName() const override { return "Hexagon HVX Save Remarks"; }
 
   void getAnalysisUsage(AnalysisUsage &AU) const override {
+    AU.addRequired<MachineOptimizationRemarkEmitterPass>();
     AU.setPreservesAll();
     MachineFunctionPass::getAnalysisUsage(AU);
   }

--- a/llvm/lib/Target/Hexagon/HexagonHVXSaveRemark.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonHVXSaveRemark.cpp
@@ -7,21 +7,27 @@
 //===----------------------------------------------------------------------===//
 //
 // Diagnostic pass that emits optimization remarks when HVX vector registers
-// must be saved and restored around function calls.  All HVX registers are
-// caller-saved (Section 5.3 of the Hexagon ABI), so every HVX value that is
-// live across a call requires a save/restore pair on the stack.  Each HVX
-// vector is 64 or 128 bytes (depending on the mode), making this overhead
-// expensive.  The remarks help programmers identify call sites where inlining,
-// hoisting, or sinking the call could reduce the save/restore cost.
+// are live across function calls.  All HVX registers are caller-saved
+// (Section 5.3 of the Hexagon ABI), so every HVX value that is live across a
+// call requires a save/restore pair on the stack.  Each HVX vector is 64 or
+// 128 bytes (depending on the mode), making this overhead expensive.  The
+// remarks help programmers identify call sites where inlining, hoisting, or
+// sinking the call could reduce the save/restore cost.
+//
+// The pass runs before register allocation while values are still in virtual
+// registers.  A backward liveness scan over each basic block counts the HVX
+// virtual registers (and their corresponding byte cost) live at each call
+// instruction.
 //
 //===----------------------------------------------------------------------===//
 
 #include "HexagonSubtarget.h"
+#include "llvm/ADT/SmallSet.h"
 #include "llvm/Analysis/OptimizationRemarkEmitter.h"
 #include "llvm/CodeGen/MachineFunction.h"
 #include "llvm/CodeGen/MachineFunctionPass.h"
 #include "llvm/CodeGen/MachineOptimizationRemarkEmitter.h"
-#include "llvm/CodeGen/PseudoSourceValue.h"
+#include "llvm/CodeGen/MachineRegisterInfo.h"
 #include "llvm/InitializePasses.h"
 #include "llvm/Pass.h"
 #include "llvm/Support/CommandLine.h"
@@ -32,9 +38,10 @@ using namespace llvm;
 #define DEBUG_TYPE "hexagon-hvx-save"
 
 static cl::opt<unsigned> HVXSaveThreshold(
-    "hexagon-hvx-save-threshold", cl::Hidden, cl::init(8),
-    cl::desc("Minimum number of HVX caller-saved registers live across a call "
-             "to trigger a remark"));
+    "hexagon-hvx-save-threshold", cl::Hidden, cl::init(128 * 8),
+    cl::desc("Minimum number of bytes of HVX caller-saved register data live "
+             "across a call to trigger a remark (default: 8 x 128-byte "
+             "vectors)"));
 
 namespace {
 
@@ -42,34 +49,6 @@ struct HexagonHVXSaveRemark : public MachineFunctionPass {
   static char ID;
 
   HexagonHVXSaveRemark() : MachineFunctionPass(ID) {}
-
-  /// Return true if MI is an HVX vector spill to a stack slot.
-  static bool isHVXSpill(const MachineInstr &MI, unsigned HVXLen) {
-    if (MI.mayStore() && MI.hasOneMemOperand()) {
-      const MachineMemOperand *MMO = *MI.memoperands_begin();
-      if (MMO->getSize().hasValue() && MMO->getPseudoValue() &&
-          isa<FixedStackPseudoSourceValue>(MMO->getPseudoValue()))
-        return MMO->getSize().getValue() == HVXLen ||
-               MMO->getSize().getValue() == 2 * HVXLen;
-    }
-    return false;
-  }
-
-  /// Count HVX spills in a bundle or single instruction that contains a call.
-  static unsigned countSpillsInBundle(const MachineInstr &BundleOrMI,
-                                      unsigned HVXLen) {
-    unsigned Count = 0;
-    if (BundleOrMI.isBundle()) {
-      auto MII = BundleOrMI.getIterator();
-      for (++MII; MII->isBundledWithPred(); ++MII)
-        if (isHVXSpill(*MII, HVXLen))
-          ++Count;
-    } else {
-      if (isHVXSpill(BundleOrMI, HVXLen))
-        ++Count;
-    }
-    return Count;
-  }
 
   bool runOnMachineFunction(MachineFunction &MF) override {
     auto &MORE = getAnalysis<MachineOptimizationRemarkEmitterPass>().getORE();
@@ -80,43 +59,72 @@ struct HexagonHVXSaveRemark : public MachineFunctionPass {
     if (!HST.useHVXOps())
       return false;
 
+    const MachineRegisterInfo &MRI = MF.getRegInfo();
     unsigned HVXLen = HST.getVectorLength();
 
     for (const MachineBasicBlock &MBB : MF) {
-      for (auto I = MBB.instr_begin(), E = MBB.instr_end(); I != E; ++I) {
-        const MachineInstr &MI = *I;
-        if (!MI.isCall() || MI.isBundledWithPred())
-          continue;
+      // Backward liveness scan over virtual registers.  We track which
+      // virtual registers are live at each point, then at call instructions
+      // count those with HVX register classes.
+      //
+      // Use a SmallSet of virtual register numbers.  When walking backwards:
+      //   - a def removes a vreg from the live set
+      //   - a use adds a vreg to the live set
+      // At each call, the live set holds vregs live AFTER the call (i.e., the
+      // values that must survive across it and therefore need save/restore).
+      SmallSet<Register, 32> LiveVRegs;
 
-        // Count HVX spills in the bundle containing this call (spills are
-        // often packetized together with the call instruction).
-        unsigned NumSpills = countSpillsInBundle(MI, HVXLen);
+      // Seed with live-outs of the block (vregs used by successors).
+      for (const MachineBasicBlock *Succ : MBB.successors()) {
+        for (const auto &LI : Succ->liveins()) {
+          Register R = LI.PhysReg;
+          if (R.isVirtual())
+            LiveVRegs.insert(R);
+        }
+      }
 
-        // Also count HVX spills in immediately preceding bundles/instructions
-        // that are purely spill operations.
-        auto BundleIt = MachineBasicBlock::const_iterator(MI);
-        while (BundleIt != MBB.begin()) {
-          --BundleIt;
-          unsigned PrevSpills = countSpillsInBundle(*BundleIt, HVXLen);
-          if (PrevSpills == 0)
-            break;
-          NumSpills += PrevSpills;
+      for (const MachineInstr &MI : llvm::reverse(MBB)) {
+        if (MI.isCall()) {
+          // Count HVX virtual registers live after (and thus across) this
+          // call.  HvxVR holds one vector (HVXLen bytes); HvxWR holds two
+          // (2 * HVXLen bytes).
+          unsigned NumVecs = 0;
+          for (Register VReg : LiveVRegs) {
+            if (!VReg.isVirtual())
+              continue;
+            const TargetRegisterClass *RC = MRI.getRegClass(VReg);
+            if (RC == &Hexagon::HvxWRRegClass)
+              NumVecs += 2;
+            else if (RC == &Hexagon::HvxVRRegClass)
+              NumVecs += 1;
+          }
+          unsigned TotalBytes = NumVecs * HVXLen;
+
+          LLVM_DEBUG(dbgs() << "HVXSaveRemark: call in " << MF.getName()
+                            << " has " << NumVecs << " HVX vector(s) live ("
+                            << TotalBytes << " bytes)\n");
+
+          if (TotalBytes >= HVXSaveThreshold) {
+            MORE.emit([&]() {
+              MachineOptimizationRemarkAnalysis R(
+                  DEBUG_TYPE, "HVXSaveAroundCall", MI.getDebugLoc(), &MBB);
+              R << ore::NV("NumVecs", NumVecs)
+                << " HVX caller-saved register(s) ("
+                << ore::NV("TotalBytes", TotalBytes)
+                << " bytes) live across call";
+              return R;
+            });
+          }
         }
 
-        LLVM_DEBUG(dbgs() << "HVXSaveRemark: call in " << MF.getName()
-                          << " has " << NumSpills << " HVX spills\n");
-
-        if (NumSpills >= HVXSaveThreshold) {
-          unsigned TotalBytes = NumSpills * HVXLen;
-          MORE.emit([&]() {
-            MachineOptimizationRemarkAnalysis R(DEBUG_TYPE, "HVXSaveAroundCall",
-                                                MI.getDebugLoc(), &MBB);
-            R << ore::NV("NumSaves", NumSpills)
-              << " HVX caller-saved register(s) ("
-              << ore::NV("TotalBytes", TotalBytes)
-              << " bytes) live across call";
-            return R;
-          });
+        // Update liveness: defs kill vregs, uses add them.
+        for (const MachineOperand &MO : MI.operands()) {
+          if (!MO.isReg() || !MO.getReg().isVirtual())
+            continue;
+          if (MO.isDef())
+            LiveVRegs.erase(MO.getReg());
+          else if (MO.isUse())
+            LiveVRegs.insert(MO.getReg());
         }
       }
     }

--- a/llvm/lib/Target/Hexagon/HexagonHVXSaveRemark.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonHVXSaveRemark.cpp
@@ -1,0 +1,116 @@
+//===- HexagonHVXSaveRemark.cpp - Remark on HVX saves around calls --------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Diagnostic pass that emits optimization remarks when HVX vector registers
+// must be saved and restored around function calls.  All HVX registers are
+// caller-saved (Section 5.3 of the Hexagon ABI), so every HVX value that is
+// live across a call requires a save/restore pair on the stack.  Each HVX
+// vector is 64 or 128 bytes (depending on the mode), making this overhead
+// expensive.  The remarks help programmers identify call sites where inlining,
+// hoisting, or sinking the call could reduce the save/restore cost.
+//
+//===----------------------------------------------------------------------===//
+
+#include "HexagonSubtarget.h"
+#include "llvm/Analysis/OptimizationRemarkEmitter.h"
+#include "llvm/CodeGen/MachineFrameInfo.h"
+#include "llvm/CodeGen/MachineFunction.h"
+#include "llvm/CodeGen/MachineFunctionPass.h"
+#include "llvm/CodeGen/MachineOptimizationRemarkEmitter.h"
+#include "llvm/InitializePasses.h"
+#include "llvm/Pass.h"
+#include "llvm/Support/CommandLine.h"
+#include "llvm/Support/Debug.h"
+
+using namespace llvm;
+
+#define DEBUG_TYPE "hexagon-hvx-save"
+
+static cl::opt<unsigned> HVXSaveThreshold(
+    "hexagon-hvx-save-threshold", cl::Hidden, cl::init(1024),
+    cl::desc("Minimum bytes of HVX caller-saves to trigger a remark"));
+
+namespace {
+
+struct HexagonHVXSaveRemark : public MachineFunctionPass {
+  static char ID;
+
+  HexagonHVXSaveRemark() : MachineFunctionPass(ID) {}
+
+  bool runOnMachineFunction(MachineFunction &MF) override {
+    MachineOptimizationRemarkEmitter MORE(MF, nullptr);
+    if (!MORE.allowExtraAnalysis(DEBUG_TYPE))
+      return false;
+
+    const HexagonSubtarget &HST = MF.getSubtarget<HexagonSubtarget>();
+    if (!HST.useHVXOps())
+      return false;
+
+    // Identify HVX caller-save slots by matching stack-slot sizes against
+    // the HVX vector length (single vectors and vector pairs).
+    const MachineFrameInfo &MFI = MF.getFrameInfo();
+    unsigned HVXLen = HST.getVectorLength();
+    unsigned NumVecSaves = 0;
+    unsigned NumPairSaves = 0;
+
+    for (int I = MFI.getObjectIndexBegin(), E = MFI.getObjectIndexEnd(); I < E;
+         ++I) {
+      if (!MFI.isSpillSlotObjectIndex(I))
+        continue;
+      int64_t Size = MFI.getObjectSize(I);
+      if (Size == (int64_t)HVXLen)
+        ++NumVecSaves;
+      else if (Size == (int64_t)(2 * HVXLen))
+        ++NumPairSaves;
+    }
+
+    unsigned TotalSaves = NumVecSaves + NumPairSaves;
+    unsigned TotalBytes = NumVecSaves * HVXLen + NumPairSaves * 2 * HVXLen;
+
+    if (TotalBytes < HVXSaveThreshold)
+      return false;
+
+    // Emit a remark on each call site.
+    for (const MachineBasicBlock &MBB : MF) {
+      for (const MachineInstr &MI : MBB) {
+        if (!MI.isCall())
+          continue;
+
+        MORE.emit([&]() {
+          using namespace ore;
+          MachineOptimizationRemarkAnalysis R(DEBUG_TYPE, "HVXSaveAroundCall",
+                                              MI.getDebugLoc(), &MBB);
+          R << NV("NumSaves", TotalSaves) << " HVX caller-saved register(s) ("
+            << NV("TotalBytes", TotalBytes)
+            << " bytes) saved and restored around call";
+          return R;
+        });
+      }
+    }
+
+    return false;
+  }
+
+  StringRef getPassName() const override { return "Hexagon HVX Save Remarks"; }
+
+  void getAnalysisUsage(AnalysisUsage &AU) const override {
+    AU.setPreservesAll();
+    MachineFunctionPass::getAnalysisUsage(AU);
+  }
+};
+
+char HexagonHVXSaveRemark::ID = 0;
+
+} // end anonymous namespace
+
+INITIALIZE_PASS(HexagonHVXSaveRemark, DEBUG_TYPE, "Hexagon HVX Save Remarks",
+                false, false)
+
+FunctionPass *llvm::createHexagonHVXSaveRemark() {
+  return new HexagonHVXSaveRemark();
+}

--- a/llvm/lib/Target/Hexagon/HexagonHVXSaveRemark.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonHVXSaveRemark.cpp
@@ -23,6 +23,7 @@
 
 #include "HexagonSubtarget.h"
 #include "llvm/ADT/SmallSet.h"
+#include "llvm/ADT/SmallVector.h"
 #include "llvm/Analysis/OptimizationRemarkEmitter.h"
 #include "llvm/CodeGen/MachineFunction.h"
 #include "llvm/CodeGen/MachineFunctionPass.h"
@@ -50,6 +51,17 @@ struct HexagonHVXSaveRemark : public MachineFunctionPass {
 
   HexagonHVXSaveRemark() : MachineFunctionPass(ID) {}
 
+  // Returns the number of HVX vectors represented by VReg: 2 for HvxWR
+  // (vector pair), 1 for HvxVR (single vector), 0 for non-HVX registers.
+  static unsigned hvxVecCount(Register VReg, const MachineRegisterInfo &MRI) {
+    const TargetRegisterClass *RC = MRI.getRegClass(VReg);
+    if (RC == &Hexagon::HvxWRRegClass)
+      return 2;
+    if (RC == &Hexagon::HvxVRRegClass)
+      return 1;
+    return 0;
+  }
+
   bool runOnMachineFunction(MachineFunction &MF) override {
     auto &MORE = getAnalysis<MachineOptimizationRemarkEmitterPass>().getORE();
     if (!MORE.allowExtraAnalysis(DEBUG_TYPE))
@@ -62,26 +74,96 @@ struct HexagonHVXSaveRemark : public MachineFunctionPass {
     const MachineRegisterInfo &MRI = MF.getRegInfo();
     unsigned HVXLen = HST.getVectorLength();
 
+    // Compute LiveOut[B] for each block: the set of HVX virtual registers
+    // that are live on exit from B.  We use a standard backward dataflow
+    // fixed-point:
+    //
+    //   LiveIn[B]  = UEVar[B] union (LiveOut[B] - Def[B])
+    //   LiveOut[B] = union over successors S of LiveIn[S]
+    //
+    // where UEVar[B] is the set of HVX vregs that are used in B before any
+    // definition of that vreg in B (upward-exposed uses), and Def[B] is the
+    // set of HVX vregs defined in B.
+    //
+    // Because MachineBasicBlock::liveins() only contains physical registers,
+    // we cannot seed cross-block virtual register liveness from successor
+    // liveins -- we must compute it ourselves.
+
+    unsigned NumBlocks = MF.getNumBlockIDs();
+    using VRegSet = SmallSet<Register, 8>;
+
+    // Per-block UEVar and Def sets (HVX vregs only).
+    SmallVector<VRegSet, 16> UEVar(NumBlocks), BlockDef(NumBlocks);
+
+    for (const MachineBasicBlock &MBB : MF) {
+      unsigned BN = MBB.getNumber();
+      VRegSet Defs;
+      for (const MachineInstr &MI : MBB) {
+        for (const MachineOperand &MO : MI.operands()) {
+          if (!MO.isReg())
+            continue;
+          Register R = MO.getReg();
+          if (!R.isVirtual() || !hvxVecCount(R, MRI))
+            continue;
+          if (MO.isDef()) {
+            Defs.insert(R);
+          } else if (MO.isUse() && !Defs.count(R)) {
+            UEVar[BN].insert(R); // upward-exposed use
+          }
+        }
+      }
+      BlockDef[BN] = Defs;
+    }
+
+    // LiveOut[B] and LiveIn[B] maps.
+    SmallVector<VRegSet, 16> LiveOut(NumBlocks), LiveIn(NumBlocks);
+
+    // Seed LiveIn from UEVar and iterate until stable.
+    for (unsigned I = 0; I < NumBlocks; ++I)
+      LiveIn[I] = UEVar[I];
+
+    bool Changed = true;
+    while (Changed) {
+      Changed = false;
+      for (const MachineBasicBlock &MBB : MF) {
+        unsigned BN = MBB.getNumber();
+
+        // LiveOut[B] = union of LiveIn[S] for each successor S.
+        VRegSet NewLiveOut;
+        for (const MachineBasicBlock *Succ : MBB.successors())
+          for (Register R : LiveIn[Succ->getNumber()])
+            NewLiveOut.insert(R);
+
+        if (NewLiveOut != LiveOut[BN]) {
+          LiveOut[BN] = NewLiveOut;
+          Changed = true;
+        }
+
+        // LiveIn[B] = UEVar[B] union (LiveOut[B] - Def[B]).
+        VRegSet NewLiveIn = UEVar[BN];
+        for (Register R : LiveOut[BN])
+          if (!BlockDef[BN].count(R))
+            NewLiveIn.insert(R);
+
+        if (NewLiveIn != LiveIn[BN]) {
+          LiveIn[BN] = NewLiveIn;
+          Changed = true;
+        }
+      }
+    }
+
+    // Now do the backward scan over each block, seeded from LiveOut[B].
     for (const MachineBasicBlock &MBB : MF) {
       // Backward liveness scan over virtual registers.  We track which
       // virtual registers are live at each point, then at call instructions
       // count those with HVX register classes.
       //
-      // Use a SmallSet of virtual register numbers.  When walking backwards:
+      // When walking backwards:
       //   - a def removes a vreg from the live set
       //   - a use adds a vreg to the live set
-      // At each call, the live set holds vregs live AFTER the call (i.e., the
+      // At each call, the live set holds vregs live after the call (i.e., the
       // values that must survive across it and therefore need save/restore).
-      SmallSet<Register, 32> LiveVRegs;
-
-      // Seed with live-outs of the block (vregs used by successors).
-      for (const MachineBasicBlock *Succ : MBB.successors()) {
-        for (const auto &LI : Succ->liveins()) {
-          Register R = LI.PhysReg;
-          if (R.isVirtual())
-            LiveVRegs.insert(R);
-        }
-      }
+      VRegSet LiveVRegs = LiveOut[MBB.getNumber()];
 
       for (const MachineInstr &MI : llvm::reverse(MBB)) {
         if (MI.isCall()) {
@@ -89,15 +171,8 @@ struct HexagonHVXSaveRemark : public MachineFunctionPass {
           // call.  HvxVR holds one vector (HVXLen bytes); HvxWR holds two
           // (2 * HVXLen bytes).
           unsigned NumVecs = 0;
-          for (Register VReg : LiveVRegs) {
-            if (!VReg.isVirtual())
-              continue;
-            const TargetRegisterClass *RC = MRI.getRegClass(VReg);
-            if (RC == &Hexagon::HvxWRRegClass)
-              NumVecs += 2;
-            else if (RC == &Hexagon::HvxVRRegClass)
-              NumVecs += 1;
-          }
+          for (Register VReg : LiveVRegs)
+            NumVecs += hvxVecCount(VReg, MRI);
           unsigned TotalBytes = NumVecs * HVXLen;
 
           LLVM_DEBUG(dbgs() << "HVXSaveRemark: call in " << MF.getName()

--- a/llvm/lib/Target/Hexagon/HexagonTargetMachine.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonTargetMachine.cpp
@@ -199,6 +199,7 @@ LLVMInitializeHexagonTarget() {
   initializeHexagonGlobalSchedulerPass(PR);
   initializeHexagonLiveVariablesPass(PR);
   initializeHexagonHardwareLoopsPass(PR);
+  initializeHexagonHVXSaveRemarkPass(PR);
   initializeHexagonLoopIdiomRecognizeLegacyPassPass(PR);
   initializeHexagonNewValueJumpPass(PR);
   initializeHexagonOptAddrModePass(PR);
@@ -520,6 +521,8 @@ void HexagonPassConfig::addPreEmitPass() {
 
   if (EnableVectorPrint)
     addPass(createHexagonVectorPrint());
+
+  addPass(createHexagonHVXSaveRemark());
 
   // Add CFI instructions if necessary.
   addPass(createHexagonCallFrameInformation());

--- a/llvm/lib/Target/Hexagon/HexagonTargetMachine.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonTargetMachine.cpp
@@ -464,6 +464,7 @@ void HexagonPassConfig::addPreRegAlloc() {
   }
   if (TM->getOptLevel() >= CodeGenOptLevel::Default)
     addPass(&MachinePipelinerID);
+  addPass(createHexagonHVXSaveRemark());
 }
 
 void HexagonPassConfig::addPostRegAlloc() {
@@ -521,8 +522,6 @@ void HexagonPassConfig::addPreEmitPass() {
 
   if (EnableVectorPrint)
     addPass(createHexagonVectorPrint());
-
-  addPass(createHexagonHVXSaveRemark());
 
   // Add CFI instructions if necessary.
   addPass(createHexagonCallFrameInformation());

--- a/llvm/lib/Target/Hexagon/HexagonTargetMachine.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonTargetMachine.cpp
@@ -198,6 +198,7 @@ LLVMInitializeHexagonTarget() {
   initializeHexagonGlobalSchedulerPass(PR);
   initializeHexagonLiveVariablesPass(PR);
   initializeHexagonHardwareLoopsPass(PR);
+  initializeHexagonHVXSaveRemarkPass(PR);
   initializeHexagonLoopIdiomRecognizeLegacyPassPass(PR);
   initializeHexagonNewValueJumpPass(PR);
   initializeHexagonOptAddrModePass(PR);
@@ -489,6 +490,8 @@ void HexagonPassConfig::addPreEmitPass() {
 
   if (EnableVectorPrint)
     addPass(createHexagonVectorPrint());
+
+  addPass(createHexagonHVXSaveRemark());
 
   // Add CFI instructions if necessary.
   addPass(createHexagonCallFrameInformation());

--- a/llvm/test/CodeGen/Hexagon/hvx-save-remarks.ll
+++ b/llvm/test/CodeGen/Hexagon/hvx-save-remarks.ll
@@ -4,10 +4,10 @@
 
 ;; Test that the HVX save remark pass reports caller-save costs around calls.
 ;; All HVX registers are caller-saved, so any HVX value live across a call
-;; requires a save/restore pair on the stack.  The default threshold is 1024
-;; bytes, so we need at least 8 x 128-byte vectors live across the call.
+;; requires a save/restore pair on the stack.  The default threshold is 8
+;; registers, so we need at least 8 HVX vectors live across the call.
 
-; CHECK: remark: {{.*}} HVX caller-saved register(s) ({{[0-9]+}} bytes) saved and restored around call
+; CHECK: remark: {{.*}} 8 HVX caller-saved register(s) (1024 bytes) live across call
 ; CHECK-NOT: remark:
 
 declare void @bar()

--- a/llvm/test/CodeGen/Hexagon/hvx-save-remarks.ll
+++ b/llvm/test/CodeGen/Hexagon/hvx-save-remarks.ll
@@ -13,9 +13,13 @@
 ;; bytes (8 x 128-byte vectors).
 
 ; CHECK: remark: {{.*}} 8 HVX caller-saved register(s) (1024 bytes) live across call
+; CHECK: remark: {{.*}} 8 HVX caller-saved register(s) (1024 bytes) live across call
+; CHECK: remark: {{.*}} 8 HVX caller-saved register(s) (1024 bytes) live across call
 ; CHECK-NOT: remark:
 
 ; LOW: remark: {{.*}} 4 HVX caller-saved register(s) (512 bytes) live across call
+; LOW: remark: {{.*}} 8 HVX caller-saved register(s) (1024 bytes) live across call
+; LOW: remark: {{.*}} 8 HVX caller-saved register(s) (1024 bytes) live across call
 ; LOW: remark: {{.*}} 8 HVX caller-saved register(s) (1024 bytes) live across call
 ; LOW-NOT: remark:
 
@@ -68,5 +72,70 @@ entry:
   %v = load <32 x i32>, ptr %p, align 128
   call void @bar()
   store <32 x i32> %v, ptr %p, align 128
+  ret void
+}
+
+;; 8 HVX vectors loaded in entry, call in a separate call_block, stores in
+;; exit.  The vectors are live out of entry and must be counted as live at
+;; the call even though the call is in a different basic block.
+define void @test_cross_block(ptr %p0, ptr %p1, ptr %p2, ptr %p3,
+                              ptr %p4, ptr %p5, ptr %p6, ptr %p7,
+                              i1 %cond) {
+entry:
+  %v0 = load <32 x i32>, ptr %p0, align 128
+  %v1 = load <32 x i32>, ptr %p1, align 128
+  %v2 = load <32 x i32>, ptr %p2, align 128
+  %v3 = load <32 x i32>, ptr %p3, align 128
+  %v4 = load <32 x i32>, ptr %p4, align 128
+  %v5 = load <32 x i32>, ptr %p5, align 128
+  %v6 = load <32 x i32>, ptr %p6, align 128
+  %v7 = load <32 x i32>, ptr %p7, align 128
+  br label %call_block
+call_block:
+  call void @bar()
+  br label %exit
+exit:
+  store <32 x i32> %v0, ptr %p0, align 128
+  store <32 x i32> %v1, ptr %p1, align 128
+  store <32 x i32> %v2, ptr %p2, align 128
+  store <32 x i32> %v3, ptr %p3, align 128
+  store <32 x i32> %v4, ptr %p4, align 128
+  store <32 x i32> %v5, ptr %p5, align 128
+  store <32 x i32> %v6, ptr %p6, align 128
+  store <32 x i32> %v7, ptr %p7, align 128
+  ret void
+}
+
+;; 8 HVX vectors live across a call inside a loop body.  This is the
+;; canonical high-cost pattern: the vectors are loaded before the loop,
+;; the loop body calls bar(), and the vectors are used after the loop.
+define void @test_loop_call(ptr %p0, ptr %p1, ptr %p2, ptr %p3,
+                            ptr %p4, ptr %p5, ptr %p6, ptr %p7,
+                            i32 %n) {
+entry:
+  %v0 = load <32 x i32>, ptr %p0, align 128
+  %v1 = load <32 x i32>, ptr %p1, align 128
+  %v2 = load <32 x i32>, ptr %p2, align 128
+  %v3 = load <32 x i32>, ptr %p3, align 128
+  %v4 = load <32 x i32>, ptr %p4, align 128
+  %v5 = load <32 x i32>, ptr %p5, align 128
+  %v6 = load <32 x i32>, ptr %p6, align 128
+  %v7 = load <32 x i32>, ptr %p7, align 128
+  br label %loop
+loop:
+  %i = phi i32 [ 0, %entry ], [ %i.next, %loop ]
+  call void @bar()
+  %i.next = add i32 %i, 1
+  %done = icmp eq i32 %i.next, %n
+  br i1 %done, label %exit, label %loop
+exit:
+  store <32 x i32> %v0, ptr %p0, align 128
+  store <32 x i32> %v1, ptr %p1, align 128
+  store <32 x i32> %v2, ptr %p2, align 128
+  store <32 x i32> %v3, ptr %p3, align 128
+  store <32 x i32> %v4, ptr %p4, align 128
+  store <32 x i32> %v5, ptr %p5, align 128
+  store <32 x i32> %v6, ptr %p6, align 128
+  store <32 x i32> %v7, ptr %p7, align 128
   ret void
 }

--- a/llvm/test/CodeGen/Hexagon/hvx-save-remarks.ll
+++ b/llvm/test/CodeGen/Hexagon/hvx-save-remarks.ll
@@ -1,18 +1,44 @@
 ; RUN: llc -mtriple=hexagon -mcpu=hexagonv68 -mattr=+hvxv68,+hvx-length128b \
 ; RUN:   -pass-remarks-analysis=hexagon-hvx-save %s -o /dev/null 2>&1 \
 ; RUN:   | FileCheck %s
+;
+; RUN: llc -mtriple=hexagon -mcpu=hexagonv68 -mattr=+hvxv68,+hvx-length128b \
+; RUN:   -pass-remarks-analysis=hexagon-hvx-save \
+; RUN:   -hexagon-hvx-save-threshold=256 %s -o /dev/null 2>&1 \
+; RUN:   | FileCheck %s --check-prefix=LOW
 
-;; Test that the HVX save remark pass reports caller-save costs around calls.
+;; Test that the HVX save remark pass reports HVX registers live across calls.
 ;; All HVX registers are caller-saved, so any HVX value live across a call
-;; requires a save/restore pair on the stack.  The default threshold is 8
-;; registers, so we need at least 8 HVX vectors live across the call.
+;; requires a save/restore pair on the stack.  The default threshold is 1024
+;; bytes (8 x 128-byte vectors).
 
 ; CHECK: remark: {{.*}} 8 HVX caller-saved register(s) (1024 bytes) live across call
 ; CHECK-NOT: remark:
 
+; LOW: remark: {{.*}} 4 HVX caller-saved register(s) (512 bytes) live across call
+; LOW: remark: {{.*}} 8 HVX caller-saved register(s) (1024 bytes) live across call
+; LOW-NOT: remark:
+
 declare void @bar()
 
-;; 8 HVX vectors live across a call (8 x 128 = 1024 bytes) -- meets threshold.
+;; 4 HVX vectors live across a call (4 x 128 = 512 bytes) -- above LOW threshold,
+;; but below the default 1024-byte threshold.
+define void @test_four_vecs(ptr %p0, ptr %p1, ptr %p2, ptr %p3) {
+entry:
+  %v0 = load <32 x i32>, ptr %p0, align 128
+  %v1 = load <32 x i32>, ptr %p1, align 128
+  %v2 = load <32 x i32>, ptr %p2, align 128
+  %v3 = load <32 x i32>, ptr %p3, align 128
+  call void @bar()
+  store <32 x i32> %v0, ptr %p0, align 128
+  store <32 x i32> %v1, ptr %p1, align 128
+  store <32 x i32> %v2, ptr %p2, align 128
+  store <32 x i32> %v3, ptr %p3, align 128
+  ret void
+}
+
+;; 8 HVX vectors live across a call (8 x 128 = 1024 bytes) -- meets default
+;; threshold.
 define void @test_hvx_save_around_call(ptr %p0, ptr %p1, ptr %p2, ptr %p3,
                                        ptr %p4, ptr %p5, ptr %p6, ptr %p7) {
 entry:

--- a/llvm/test/CodeGen/Hexagon/hvx-save-remarks.ll
+++ b/llvm/test/CodeGen/Hexagon/hvx-save-remarks.ll
@@ -1,0 +1,46 @@
+; RUN: llc -mtriple=hexagon -mcpu=hexagonv68 -mattr=+hvxv68,+hvx-length128b \
+; RUN:   -pass-remarks-analysis=hexagon-hvx-save %s -o /dev/null 2>&1 \
+; RUN:   | FileCheck %s
+
+;; Test that the HVX save remark pass reports caller-save costs around calls.
+;; All HVX registers are caller-saved, so any HVX value live across a call
+;; requires a save/restore pair on the stack.  The default threshold is 1024
+;; bytes, so we need at least 8 x 128-byte vectors live across the call.
+
+; CHECK: remark: {{.*}} HVX caller-saved register(s) ({{[0-9]+}} bytes) saved and restored around call
+; CHECK-NOT: remark:
+
+declare void @bar()
+
+;; 8 HVX vectors live across a call (8 x 128 = 1024 bytes) -- meets threshold.
+define void @test_hvx_save_around_call(ptr %p0, ptr %p1, ptr %p2, ptr %p3,
+                                       ptr %p4, ptr %p5, ptr %p6, ptr %p7) {
+entry:
+  %v0 = load <32 x i32>, ptr %p0, align 128
+  %v1 = load <32 x i32>, ptr %p1, align 128
+  %v2 = load <32 x i32>, ptr %p2, align 128
+  %v3 = load <32 x i32>, ptr %p3, align 128
+  %v4 = load <32 x i32>, ptr %p4, align 128
+  %v5 = load <32 x i32>, ptr %p5, align 128
+  %v6 = load <32 x i32>, ptr %p6, align 128
+  %v7 = load <32 x i32>, ptr %p7, align 128
+  call void @bar()
+  store <32 x i32> %v0, ptr %p0, align 128
+  store <32 x i32> %v1, ptr %p1, align 128
+  store <32 x i32> %v2, ptr %p2, align 128
+  store <32 x i32> %v3, ptr %p3, align 128
+  store <32 x i32> %v4, ptr %p4, align 128
+  store <32 x i32> %v5, ptr %p5, align 128
+  store <32 x i32> %v6, ptr %p6, align 128
+  store <32 x i32> %v7, ptr %p7, align 128
+  ret void
+}
+
+;; Single HVX vector live across call (128 bytes) -- below threshold.
+define void @test_below_threshold(ptr %p) {
+entry:
+  %v = load <32 x i32>, ptr %p, align 128
+  call void @bar()
+  store <32 x i32> %v, ptr %p, align 128
+  ret void
+}


### PR DESCRIPTION
Add a new MachineFunctionPass (HexagonHVXSaveRemark) that emits optimization analysis remarks when HVX vector registers must be saved and restored around function calls.  All HVX registers are caller-saved (Section 5.3 of the Hexagon ABI), so any HVX value live across a call requires a save/restore pair on the stack. Each HVX vector is 64 or 128 bytes, making this overhead expensive.

The pass exits when remarks are not requested (-Rpass-analysis=hexagon-hvx-save) or when HVX is not enabled.  A byte threshold (default 1024, tunable via -hexagon-hvx-save-threshold) filters out functions with only a small number of saves.  The remarks help programmers identify call sites where inlining, hoisting, or sinking could reduce the save/restore cost.