### PR TITLE
[compiler-rt][sanitizer] Add struct_rlimit64_sz for musl

### DIFF
--- a/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.cpp
@@ -305,9 +305,12 @@ namespace __sanitizer {
   unsigned struct_ustat_sz = SIZEOF_STRUCT_USTAT;
   unsigned struct_rlimit64_sz = sizeof(struct rlimit64);
   unsigned struct_statvfs64_sz = sizeof(struct statvfs64);
-#endif // SANITIZER_GLIBC
+#  elif SANITIZER_MUSL
+  // On musl, rlimit64 is an alias for rlimit.
+  unsigned struct_rlimit64_sz = sizeof(struct rlimit);
+#  endif  // SANITIZER_GLIBC
 
-#if SANITIZER_LINUX && !SANITIZER_ANDROID
+#  if SANITIZER_LINUX && !SANITIZER_ANDROID
   unsigned struct_timex_sz = sizeof(struct timex);
   unsigned struct_msqid_ds_sz = sizeof(struct msqid_ds);
   unsigned struct_mq_attr_sz = sizeof(struct mq_attr);


### PR DESCRIPTION
On musl, rlimit64 is an alias for rlimit rather than a distinct type provided by glibc.  Add a SANITIZER_MUSL elif branch so that struct_rlimit64_sz is defined for musl-based Linux targets.