### PR TITLE
[compiler-rt][msan] Guard shmat interceptor w SANITIZER_INTERCEPT_SHMCTL

### DIFF
--- a/compiler-rt/lib/msan/msan_interceptors.cpp
+++ b/compiler-rt/lib/msan/msan_interceptors.cpp
@@ -1672,6 +1672,7 @@ static int msan_dl_iterate_phdr_cb(__sanitizer_dl_phdr_info *info, SIZE_T size,
   return cbdata->callback(info, size, cbdata->data);
 }
 
+#if SANITIZER_INTERCEPT_SHMCTL
 INTERCEPTOR(void *, shmat, int shmid, const void *shmaddr, int shmflg) {
   ENSURE_MSAN_INITED();
   void *p = REAL(shmat)(shmid, shmaddr, shmflg);
@@ -1684,6 +1685,10 @@ INTERCEPTOR(void *, shmat, int shmid, const void *shmaddr, int shmflg) {
   }
   return p;
 }
+#  define MSAN_MAYBE_INTERCEPT_SHMAT INTERCEPT_FUNCTION(shmat)
+#else
+#  define MSAN_MAYBE_INTERCEPT_SHMAT
+#endif
 
 INTERCEPTOR(int, dl_iterate_phdr, dl_iterate_phdr_cb callback, void *data) {
   void *ctx;
@@ -1944,7 +1949,7 @@ void InitializeInterceptors() {
   INTERCEPT_FUNCTION(tzset);
   INTERCEPT_FUNCTION(atexit);
   INTERCEPT_FUNCTION(__cxa_atexit);
-  INTERCEPT_FUNCTION(shmat);
+  MSAN_MAYBE_INTERCEPT_SHMAT;
   MSAN_MAYBE_INTERCEPT_OPENPTY;
   MSAN_MAYBE_INTERCEPT_FORKPTY;
 

--- a/compiler-rt/lib/msan/msan_interceptors.cpp
+++ b/compiler-rt/lib/msan/msan_interceptors.cpp
@@ -1672,7 +1672,7 @@ static int msan_dl_iterate_phdr_cb(__sanitizer_dl_phdr_info *info, SIZE_T size,
   return cbdata->callback(info, size, cbdata->data);
 }
 
-#if SANITIZER_INTERCEPT_SHMCTL
+#if SANITIZER_INTERCEPT_SHMAT
 INTERCEPTOR(void *, shmat, int shmid, const void *shmaddr, int shmflg) {
   ENSURE_MSAN_INITED();
   void *p = REAL(shmat)(shmid, shmaddr, shmflg);

--- a/compiler-rt/lib/sanitizer_common/sanitizer_platform_interceptors.h
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_platform_interceptors.h
@@ -393,6 +393,8 @@ SANITIZER_WEAK_IMPORT void *aligned_alloc(__sanitizer::usize __alignment,
 #define SANITIZER_INTERCEPT_SHMCTL                                       \
   (((SI_FREEBSD || SI_LINUX_NOT_ANDROID) && SANITIZER_WORDSIZE == 64) || \
    SI_NETBSD || SI_SOLARIS)
+// shmat calls REAL(shmctl), so it requires shmctl interception.
+#define SANITIZER_INTERCEPT_SHMAT SANITIZER_INTERCEPT_SHMCTL
 #define SANITIZER_INTERCEPT_RANDOM_R SI_GLIBC
 #define SANITIZER_INTERCEPT_PTHREAD_ATTR_GET SI_POSIX
 #define SANITIZER_INTERCEPT_PTHREAD_ATTR_GETINHERITSCHED \


### PR DESCRIPTION
The shmat interceptor calls REAL(shmctl), but shmctl is not intercepted on all targets (e.g. 32-bit Linux with musl).  Guard shmat behind SANITIZER_INTERCEPT_SHMCTL and use a MSAN_MAYBE_INTERCEPT pattern consistent with other conditional interceptors.