### PR TITLE
[compiler-rt][msan] Fix 32-bit overflow in CheckMemoryLayoutSanity

### DIFF
--- a/compiler-rt/lib/msan/msan_linux.cpp
+++ b/compiler-rt/lib/msan/msan_linux.cpp
@@ -90,7 +90,8 @@ static void CheckMemoryLayoutSanity() {
     CHECK_LT(start, end);
     CHECK_EQ(prev_end, start);
     CHECK(addr_is_type(start, type));
-    CHECK(addr_is_type((start + end) / 2, type));
+    // Use start + (end - start) / 2 to avoid overflow on 32-bit.
+    CHECK(addr_is_type(start + (end - start) / 2, type));
     CHECK(addr_is_type(end - 1, type));
     if (type == MappingDesc::APP || type == MappingDesc::ALLOCATOR) {
       uptr addr = start;
@@ -98,7 +99,7 @@ static void CheckMemoryLayoutSanity() {
       CHECK(MEM_IS_ORIGIN(MEM_TO_ORIGIN(addr)));
       CHECK_EQ(MEM_TO_ORIGIN(addr), SHADOW_TO_ORIGIN(MEM_TO_SHADOW(addr)));
 
-      addr = (start + end) / 2;
+      addr = start + (end - start) / 2;
       CHECK(MEM_IS_SHADOW(MEM_TO_SHADOW(addr)));
       CHECK(MEM_IS_ORIGIN(MEM_TO_ORIGIN(addr)));
       CHECK_EQ(MEM_TO_ORIGIN(addr), SHADOW_TO_ORIGIN(MEM_TO_SHADOW(addr)));


### PR DESCRIPTION
Use start + (end - start) / 2 instead of (start + end) / 2 to compute the midpoint address.  The original expression overflows when start + end exceeds UPTR_MAX, which happens on 32-bit targets whose memory layout includes regions above 0x80000000.