### PR TITLE
[clang-format] Don't merge short records with directly created objects

### DIFF
--- a/clang/lib/Format/UnwrappedLineFormatter.cpp
+++ b/clang/lib/Format/UnwrappedLineFormatter.cpp
@@ -988,8 +988,10 @@ private:
         if (I[1]->Last->is(TT_LineComment))
           return 0;
         do {
-          if (Tok->is(tok::l_brace) && Tok->isNot(BK_BracedInit))
+          if (Tok->isOneOf(tok::l_brace, tok::r_brace) &&
+              Tok->isNot(BK_BracedInit)) {
             return 0;
+          }
           Tok = Tok->Next;
         } while (Tok);
 

--- a/clang/unittests/Format/FormatTest.cpp
+++ b/clang/unittests/Format/FormatTest.cpp
@@ -15563,6 +15563,12 @@ TEST_F(FormatTest, AllowShortRecordOnASingleLine) {
   verifyFormat("class foo {};\n"
                "class bar { int i; };",
                Style);
+  verifyFormat("namespace foo {\n"
+               "struct S {\n"
+               "} s;\n"
+               "} // namespace foo",
+               Style);
+
   Style.BreakBeforeBraces = FormatStyle::BS_Custom;
   Style.BraceWrapping.AfterClass = true;
   verifyFormat("class foo\n"


### PR DESCRIPTION
It did merge the wrong brace.

Fixes #189155