### PR TITLE
[MLIR][build] Fix undefined references in debug shared libs

### DIFF
--- a/mlir/lib/Dialect/LLVMIR/CMakeLists.txt
+++ b/mlir/lib/Dialect/LLVMIR/CMakeLists.txt
@@ -60,11 +60,13 @@ add_mlir_dialect_library(MLIRNVVMDialect
   LINK_COMPONENTS
   AsmParser
   Core
+  TargetParser
 
   LINK_LIBS PUBLIC
   MLIRIR
   MLIRLLVMDialect
   MLIRGPUDialect
+  MLIROpenMPDialect
   MLIRSideEffectInterfaces
   MLIRInferIntRangeInterface
   )
@@ -128,10 +130,12 @@ add_mlir_dialect_library(MLIRXeVMDialect
   LINK_COMPONENTS
   AsmParser
   Core
+  TargetParser
 
   LINK_LIBS PUBLIC
   MLIRDialectUtils
   MLIRIR
   MLIRLLVMDialect
+  MLIROpenMPDialect
   MLIRSideEffectInterfaces
 )

--- a/mlir/lib/Dialect/OpenMP/CMakeLists.txt
+++ b/mlir/lib/Dialect/OpenMP/CMakeLists.txt
@@ -12,6 +12,9 @@ add_mlir_dialect_library(MLIROpenMPDialect
   MLIROpenMPOpsInterfacesIncGen
   MLIROpenMPTypeInterfacesIncGen
 
+  LINK_COMPONENTS
+  TargetParser
+
   LINK_LIBS PUBLIC
   MLIRIR
   MLIRLLVMDialect


### PR DESCRIPTION
Fixes undefined references in debug shared libs when building MLIR:
-DLLVM_ENABLE_PROJECTS="mlir"
-DCMAKE_BUILD_TYPE=Debug
-DBUILD_SHARED_LIBS=1

Debug build (-O0) disables dead code elimination, resulting in undefined references in the following shared libs:

MLIROpenMPDialect (needs to link with TargetParser)
MLIRXeVMDialect (needs to link with TargetParser and MLIROpenMPDialect)
MLIRNVVMDialect (needs to link with TargetParser and MLIROpenMPDialect)

Fixes #189206

Assisted-by: Claude Code

From:
https://github.com/llvm/llvm-project/commit/d7e60d525026f24a3514be34d8e6e56622436823
Utils were added to OpenMP, particularly [[maybe_unused]] setOffloadModuleInterfaceAttributes() which calls llvm::Triple::normalize() creating a new dependency on TargetParser.