### PR TITLE
[Hexagon] Shrink __builtin_trap lowering from two words to one

### DIFF
--- a/llvm/lib/Target/Hexagon/Disassembler/HexagonDisassembler.cpp
+++ b/llvm/lib/Target/Hexagon/Disassembler/HexagonDisassembler.cpp
@@ -250,6 +250,17 @@ DecodeStatus HexagonDisassembler::getInstruction(MCInst &MI, uint64_t &Size,
   uint64_t BytesToSkip = 0;
 
   if (!CurrentBundle) {
+    // DUPLEX_LOAD_R1R1 is used by PS_crash (__builtin_trap).  It encodes
+    // a duplex where both slots write R1, so the hardware raises a
+    // "multiple writes to register" exception.  Intercept it here because
+    // makeBundle's packet checker would (correctly) reject the duplicate
+    // destination and return a decode failure.
+    if (Bytes.size() >= HEXAGON_INSTR_SIZE &&
+        support::endian::read32le(Bytes.data()) == DUPLEX_LOAD_R1R1) {
+      MI.setOpcode(Hexagon::PS_crash);
+      Size = HEXAGON_INSTR_SIZE;
+      return MCDisassembler::Success;
+    }
     if (!makeBundle(Bytes, Address, BytesToSkip, CS)) {
       Size = BytesToSkip;
       resetBundle();
@@ -274,6 +285,18 @@ DecodeStatus HexagonDisassembler::getInstructionBundle(MCInst &MI,
   Size = 0;
   uint64_t BytesToSkip = 0;
   assert(!CurrentBundle);
+
+  // See getInstruction() for the PS_crash / DUPLEX_LOAD_R1R1 rationale.
+  if (Bytes.size() >= HEXAGON_INSTR_SIZE &&
+      support::endian::read32le(Bytes.data()) == DUPLEX_LOAD_R1R1) {
+    MI.setOpcode(Hexagon::BUNDLE);
+    MI.addOperand(MCOperand::createImm(0));
+    MCInst *CrashInst = getContext().createMCInst();
+    CrashInst->setOpcode(Hexagon::PS_crash);
+    MI.addOperand(MCOperand::createInst(CrashInst));
+    Size = HEXAGON_INSTR_SIZE;
+    return MCDisassembler::Success;
+  }
 
   if (!makeBundle(Bytes, Address, BytesToSkip, CS)) {
     Size = BytesToSkip;

--- a/llvm/lib/Target/Hexagon/Disassembler/HexagonDisassembler.cpp
+++ b/llvm/lib/Target/Hexagon/Disassembler/HexagonDisassembler.cpp
@@ -250,13 +250,13 @@ DecodeStatus HexagonDisassembler::getInstruction(MCInst &MI, uint64_t &Size,
   uint64_t BytesToSkip = 0;
 
   if (!CurrentBundle) {
-    // DUPLEX_LOAD_R1R1 is used by PS_crash (__builtin_trap).  It encodes
-    // a duplex where both slots write R1, so the hardware raises a
-    // "multiple writes to register" exception.  Intercept it here because
-    // makeBundle's packet checker would (correctly) reject the duplicate
-    // destination and return a decode failure.
+    // LOAD_MULT_REG_WRITE is used by PS_crash (llvm.trap).  It
+    // encodes R1 = memw(R1++#0) where both the load destination and the
+    // post-increment destination write R1.  Intercept it here so the
+    // disassembler emits PS_crash rather than a raw instruction with a
+    // conflicting register constraint.
     if (Bytes.size() >= HEXAGON_INSTR_SIZE &&
-        support::endian::read32le(Bytes.data()) == DUPLEX_LOAD_R1R1) {
+        support::endian::read32le(Bytes.data()) == LOAD_MULT_REG_WRITE) {
       MI.setOpcode(Hexagon::PS_crash);
       Size = HEXAGON_INSTR_SIZE;
       return MCDisassembler::Success;
@@ -286,9 +286,9 @@ DecodeStatus HexagonDisassembler::getInstructionBundle(MCInst &MI,
   uint64_t BytesToSkip = 0;
   assert(!CurrentBundle);
 
-  // See getInstruction() for the PS_crash / DUPLEX_LOAD_R1R1 rationale.
+  // See getInstruction() for the PS_crash / LOAD_MULT_REG_WRITE rationale.
   if (Bytes.size() >= HEXAGON_INSTR_SIZE &&
-      support::endian::read32le(Bytes.data()) == DUPLEX_LOAD_R1R1) {
+      support::endian::read32le(Bytes.data()) == LOAD_MULT_REG_WRITE) {
     MI.setOpcode(Hexagon::BUNDLE);
     MI.addOperand(MCOperand::createImm(0));
     MCInst *CrashInst = getContext().createMCInst();

--- a/llvm/lib/Target/Hexagon/HexagonAsmPrinter.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonAsmPrinter.cpp
@@ -753,6 +753,15 @@ void HexagonAsmPrinter::emitInstruction(const MachineInstr *MI) {
   Hexagon_MC::verifyInstructionPredicates(MI->getOpcode(),
                                           getSubtargetInfo().getFeatureBits());
 
+  // Crash is emitted as a raw 32-bit zero, which the processor decodes as a
+  // duplex with both slots writing R0 -- an illegal packet that raises a
+  // hardware exception.  We bypass the normal MCInst path because the
+  // assembler would (correctly) reject the duplicate destination.
+  if (MI->getOpcode() == Hexagon::PS_crash) {
+    OutStreamer->emitInt32(0);
+    return;
+  }
+
   MCInst MCB;
   MCB.setOpcode(Hexagon::BUNDLE);
   MCB.addOperand(MCOperand::createImm(0));

--- a/llvm/lib/Target/Hexagon/HexagonAsmPrinter.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonAsmPrinter.cpp
@@ -753,12 +753,13 @@ void HexagonAsmPrinter::emitInstruction(const MachineInstr *MI) {
   Hexagon_MC::verifyInstructionPredicates(MI->getOpcode(),
                                           getSubtargetInfo().getFeatureBits());
 
-  // Crash is emitted as a raw 32-bit zero, which the processor decodes as a
-  // duplex with both slots writing R0 -- an illegal packet that raises a
-  // hardware exception.  We bypass the normal MCInst path because the
-  // assembler would (correctly) reject the duplicate destination.
+  // Crash is emitted as a raw 32-bit word that the processor decodes as a
+  // duplex with both slots writing R1 -- an illegal packet that raises a
+  // "multiple writes to register" hardware exception.  We bypass the normal
+  // MCInst path because the assembler would (correctly) reject the
+  // duplicate destination.
   if (MI->getOpcode() == Hexagon::PS_crash) {
-    OutStreamer->emitInt32(0);
+    OutStreamer->emitInt32(DUPLEX_LOAD_R1R1);
     return;
   }
 

--- a/llvm/lib/Target/Hexagon/HexagonAsmPrinter.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonAsmPrinter.cpp
@@ -753,13 +753,13 @@ void HexagonAsmPrinter::emitInstruction(const MachineInstr *MI) {
   Hexagon_MC::verifyInstructionPredicates(MI->getOpcode(),
                                           getSubtargetInfo().getFeatureBits());
 
-  // Crash is emitted as a raw 32-bit word that the processor decodes as a
-  // duplex with both slots writing R1 -- an illegal packet that raises a
-  // "multiple writes to register" hardware exception.  We bypass the normal
-  // MCInst path because the assembler would (correctly) reject the
-  // duplicate destination.
+  // Crash is emitted as R1 = memw(R1++#0): the load destination and the
+  // post-increment destination both write R1, so the hardware raises a
+  // "multiple writes to register" exception.  We bypass the normal MCInst
+  // path because the assembler would (correctly) reject the duplicate
+  // destination.
   if (MI->getOpcode() == Hexagon::PS_crash) {
-    OutStreamer->emitInt32(DUPLEX_LOAD_R1R1);
+    OutStreamer->emitInt32(LOAD_MULT_REG_WRITE);
     return;
   }
 

--- a/llvm/lib/Target/Hexagon/HexagonInstrInfo.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonInstrInfo.cpp
@@ -1439,38 +1439,12 @@ bool HexagonInstrInfo::expandPostRAPseudo(MachineInstr &MI) const {
       return true;
     }
 
-    case Hexagon::PS_crash: {
-      // Generate a misaligned load that is guaranteed to cause a crash.
-      class CrashPseudoSourceValue : public PseudoSourceValue {
-      public:
-        CrashPseudoSourceValue(const TargetMachine &TM)
-            : PseudoSourceValue(TargetCustom, TM) {}
-
-        bool isConstant(const MachineFrameInfo *) const override {
-          return false;
-        }
-        bool isAliased(const MachineFrameInfo *) const override {
-          return false;
-        }
-        bool mayAlias(const MachineFrameInfo *) const override {
-          return false;
-        }
-        void printCustom(raw_ostream &OS) const override {
-          OS << "MisalignedCrash";
-        }
-      };
-
-      static const CrashPseudoSourceValue CrashPSV(MF.getTarget());
-      MachineMemOperand *MMO = MF.getMachineMemOperand(
-          MachinePointerInfo(&CrashPSV),
-          MachineMemOperand::MOLoad | MachineMemOperand::MOVolatile, 8,
-          Align(1));
-      BuildMI(MBB, MI, DL, get(Hexagon::PS_loadrdabs), Hexagon::D13)
-        .addImm(0xBADC0FEE)  // Misaligned load.
-        .addMemOperand(MMO);
-      MBB.erase(MI);
-      return true;
-    }
+    case Hexagon::PS_crash:
+      // PS_crash is handled directly by HexagonAsmPrinter, which emits
+      // a single word (0x00000000) that decodes as an illegal duplex with
+      // both slots writing R0.  The hardware raises a "multiple writes to
+      // register" exception.
+      return false;
 
     case Hexagon::PS_tailcall_i:
       MI.setDesc(get(Hexagon::J2_jump));

--- a/llvm/lib/Target/Hexagon/HexagonInstrInfo.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonInstrInfo.cpp
@@ -1441,7 +1441,8 @@ bool HexagonInstrInfo::expandPostRAPseudo(MachineInstr &MI) const {
 
     case Hexagon::PS_crash:
       // PS_crash is handled directly by HexagonAsmPrinter, which emits
-      // the word 0x00110011: a duplex where both slots write R1.  The
+      // the word 0x9b810001: R1 = memw(R1++#0) where both the load
+      // destination and the post-increment destination write R1.  The
       // hardware raises a "multiple writes to register" exception.
       return false;
 

--- a/llvm/lib/Target/Hexagon/HexagonInstrInfo.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonInstrInfo.cpp
@@ -1441,9 +1441,8 @@ bool HexagonInstrInfo::expandPostRAPseudo(MachineInstr &MI) const {
 
     case Hexagon::PS_crash:
       // PS_crash is handled directly by HexagonAsmPrinter, which emits
-      // a single word (0x00000000) that decodes as an illegal duplex with
-      // both slots writing R0.  The hardware raises a "multiple writes to
-      // register" exception.
+      // the word 0x00110011: a duplex where both slots write R1.  The
+      // hardware raises a "multiple writes to register" exception.
       return false;
 
     case Hexagon::PS_tailcall_i:

--- a/llvm/lib/Target/Hexagon/HexagonPseudo.td
+++ b/llvm/lib/Target/Hexagon/HexagonPseudo.td
@@ -617,7 +617,9 @@ defm PS_storeri : NewCircularStore<IntRegs, WordAccess>;
 defm PS_storerd : NewCircularStore<DoubleRegs, WordAccess>;
 
 // A pseudo that generates a runtime crash. This is used to implement
-// __builtin_trap.
+// __builtin_trap.  It is emitted directly by the AsmPrinter as a single
+// 32-bit zero word, which decodes as a duplex with both slots writing R0.
+// The hardware raises a "multiple writes to register" exception.
 let hasSideEffects = 1, isPseudo = 1, isCodeGenOnly = 1, isSolo = 1 in
 def PS_crash: InstHexagon<(outs), (ins), "", [], "", PSEUDO, TypePSEUDO>;
 

--- a/llvm/lib/Target/Hexagon/HexagonPseudo.td
+++ b/llvm/lib/Target/Hexagon/HexagonPseudo.td
@@ -617,11 +617,11 @@ defm PS_storeri : NewCircularStore<IntRegs, WordAccess>;
 defm PS_storerd : NewCircularStore<DoubleRegs, WordAccess>;
 
 // A pseudo that generates a runtime crash. This is used to implement
-// __builtin_trap.  It is emitted directly by the AsmPrinter as the 32-bit
-// word 0x00110011, which decodes as the duplex
-//   { R1 = memw(R1+#0); R1 = memw(R1+#0) }
-// Both slots write R1, so the hardware raises a "multiple writes to
-// register" exception.
+// llvm.trap.  It is emitted directly by the AsmPrinter as the 32-bit
+// word 0x9b810001, which encodes R1 = memw(R1++#0) (L2_loadri_pi with
+// Rd==Rx==R1).  The load destination and the post-increment destination
+// both write R1, so the hardware raises a "multiple writes to register"
+// exception.
 let hasSideEffects = 1, isPseudo = 1, isCodeGenOnly = 1, isSolo = 1 in
 def PS_crash: InstHexagon<(outs), (ins), "", [], "", PSEUDO, TypePSEUDO>;
 

--- a/llvm/lib/Target/Hexagon/HexagonPseudo.td
+++ b/llvm/lib/Target/Hexagon/HexagonPseudo.td
@@ -617,9 +617,11 @@ defm PS_storeri : NewCircularStore<IntRegs, WordAccess>;
 defm PS_storerd : NewCircularStore<DoubleRegs, WordAccess>;
 
 // A pseudo that generates a runtime crash. This is used to implement
-// __builtin_trap.  It is emitted directly by the AsmPrinter as a single
-// 32-bit zero word, which decodes as a duplex with both slots writing R0.
-// The hardware raises a "multiple writes to register" exception.
+// __builtin_trap.  It is emitted directly by the AsmPrinter as the 32-bit
+// word 0x00110011, which decodes as the duplex
+//   { R1 = memw(R1+#0); R1 = memw(R1+#0) }
+// Both slots write R1, so the hardware raises a "multiple writes to
+// register" exception.
 let hasSideEffects = 1, isPseudo = 1, isCodeGenOnly = 1, isSolo = 1 in
 def PS_crash: InstHexagon<(outs), (ins), "", [], "", PSEUDO, TypePSEUDO>;
 

--- a/llvm/lib/Target/Hexagon/MCTargetDesc/HexagonInstPrinter.cpp
+++ b/llvm/lib/Target/Hexagon/MCTargetDesc/HexagonInstPrinter.cpp
@@ -33,13 +33,11 @@ void HexagonInstPrinter::printRegName(raw_ostream &O, MCRegister Reg) {
 void HexagonInstPrinter::printInst(const MCInst *MI, uint64_t Address,
                                    StringRef Annot, const MCSubtargetInfo &STI,
                                    raw_ostream &OS) {
-  // PS_crash is emitted as 0x00110011 for __builtin_trap.  It encodes
-  // the duplex { R1 = memw(R1+#0); R1 = memw(R1+#0) } -- both slots
-  // write R1, triggering a hardware exception.  The \v separator signals
-  // the HexagonPrettyPrinter in llvm-objdump that this is a duplex so
-  // it closes the packet braces correctly.
+  // PS_crash is emitted as R1 = memw(R1++#0) -- the load destination and
+  // the post-increment destination both write R1, triggering a hardware
+  // "multiple writes to register" exception.
   if (MI->getOpcode() == Hexagon::PS_crash) {
-    OS << "mult_reg_write_fail" << '\v' << "mult_reg_write_fail";
+    OS << "r1 = memw(r1++#0) // llvm.trap";
     return;
   }
   if (HexagonMCInstrInfo::isDuplex(MII, *MI)) {

--- a/llvm/lib/Target/Hexagon/MCTargetDesc/HexagonInstPrinter.cpp
+++ b/llvm/lib/Target/Hexagon/MCTargetDesc/HexagonInstPrinter.cpp
@@ -33,6 +33,15 @@ void HexagonInstPrinter::printRegName(raw_ostream &O, MCRegister Reg) {
 void HexagonInstPrinter::printInst(const MCInst *MI, uint64_t Address,
                                    StringRef Annot, const MCSubtargetInfo &STI,
                                    raw_ostream &OS) {
+  // PS_crash is emitted as 0x00110011 for __builtin_trap.  It encodes
+  // the duplex { R1 = memw(R1+#0); R1 = memw(R1+#0) } -- both slots
+  // write R1, triggering a hardware exception.  The \v separator signals
+  // the HexagonPrettyPrinter in llvm-objdump that this is a duplex so
+  // it closes the packet braces correctly.
+  if (MI->getOpcode() == Hexagon::PS_crash) {
+    OS << "mult_reg_write_fail" << '\v' << "mult_reg_write_fail";
+    return;
+  }
   if (HexagonMCInstrInfo::isDuplex(MII, *MI)) {
     printInstruction(MI->getOperand(1).getInst(), Address, OS);
     OS << '\v';

--- a/llvm/lib/Target/Hexagon/MCTargetDesc/HexagonMCTargetDesc.h
+++ b/llvm/lib/Target/Hexagon/MCTargetDesc/HexagonMCTargetDesc.h
@@ -101,6 +101,11 @@ createHexagonELFObjectWriter(uint8_t OSABI, StringRef CPU);
 unsigned HexagonGetLastSlot();
 unsigned HexagonConvertUnits(unsigned ItinUnits, unsigned *Lanes);
 
+// Raw encoding of the duplex { R1 = memw(R1+#0); R1 = memw(R1+#0) }.
+// Both slots write R1, so the hardware raises a "multiple writes to
+// register" exception.  Used by PS_crash / __builtin_trap.
+constexpr uint32_t DUPLEX_LOAD_R1R1 = 0x00110011;
+
 } // End llvm namespace
 
 // Define symbolic names for Hexagon registers.  This defines a mapping from

--- a/llvm/lib/Target/Hexagon/MCTargetDesc/HexagonMCTargetDesc.h
+++ b/llvm/lib/Target/Hexagon/MCTargetDesc/HexagonMCTargetDesc.h
@@ -101,10 +101,11 @@ createHexagonELFObjectWriter(uint8_t OSABI, StringRef CPU);
 unsigned HexagonGetLastSlot();
 unsigned HexagonConvertUnits(unsigned ItinUnits, unsigned *Lanes);
 
-// Raw encoding of the duplex { R1 = memw(R1+#0); R1 = memw(R1+#0) }.
-// Both slots write R1, so the hardware raises a "multiple writes to
-// register" exception.  Used by PS_crash / __builtin_trap.
-constexpr uint32_t DUPLEX_LOAD_R1R1 = 0x00110011;
+// Raw encoding of R1 = memw(R1++#0) (L2_loadri_pi with Rd==Rx==R1).
+// The load destination and the post-increment destination both write R1,
+// so the hardware raises a "multiple writes to register" exception.
+// Used by PS_crash / llvm.trap.
+constexpr uint32_t LOAD_MULT_REG_WRITE = 0x9b810001;
 
 } // End llvm namespace
 

--- a/llvm/test/CodeGen/Hexagon/trap-crash.ll
+++ b/llvm/test/CodeGen/Hexagon/trap-crash.ll
@@ -1,9 +1,10 @@
 ; RUN: llc -mtriple=hexagon --verify-machineinstrs < %s | FileCheck %s
 
-; Generate code that is guaranteed to crash. At the moment, it's a
-; misaligned load.
+; Generate code that is guaranteed to crash.  The trap is a 32-bit zero word
+; that decodes as a duplex writing R0 from both slots, which triggers a
+; hardware exception.
 ; CHECK-LABEL: f0
-; CHECK: memd(##3134984174)
+; CHECK: .word 0
 
 target triple = "hexagon"
 

--- a/llvm/test/CodeGen/Hexagon/trap-crash.ll
+++ b/llvm/test/CodeGen/Hexagon/trap-crash.ll
@@ -1,10 +1,10 @@
 ; RUN: llc -mtriple=hexagon --verify-machineinstrs < %s | FileCheck %s
 
-; Generate code that is guaranteed to crash.  The trap is a 32-bit zero word
-; that decodes as a duplex writing R0 from both slots, which triggers a
-; hardware exception.
+; Generate code that is guaranteed to crash.  The trap is the 32-bit word
+; 0x00110011 which decodes as a duplex writing R1 from both slots,
+; triggering a hardware exception.
 ; CHECK-LABEL: f0
-; CHECK: .word 0
+; CHECK: .word 1114129
 
 target triple = "hexagon"
 

--- a/llvm/test/CodeGen/Hexagon/trap-crash.ll
+++ b/llvm/test/CodeGen/Hexagon/trap-crash.ll
@@ -1,10 +1,11 @@
 ; RUN: llc -mtriple=hexagon --verify-machineinstrs < %s | FileCheck %s
 
 ; Generate code that is guaranteed to crash.  The trap is the 32-bit word
-; 0x00110011 which decodes as a duplex writing R1 from both slots,
-; triggering a hardware exception.
+; 0x9b810001 which encodes R1 = memw(R1++#0) -- both the load destination
+; and the post-increment destination write R1, triggering a hardware
+; "multiple writes to register" exception.
 ; CHECK-LABEL: f0
-; CHECK: .word 1114129
+; CHECK: .word 2608922625
 
 target triple = "hexagon"
 

--- a/llvm/test/CodeGen/Hexagon/trap-unreachable.ll
+++ b/llvm/test/CodeGen/Hexagon/trap-unreachable.ll
@@ -1,7 +1,7 @@
 ; RUN: llc -mtriple=hexagon -trap-unreachable < %s | FileCheck %s
 
-; Trap is implemented via a misaligned load.
-; CHECK: memd(##3134984174)
+; Trap is a 32-bit zero word that the processor decodes as an illegal duplex.
+; CHECK: .word 0
 
 define void @fred() #0 {
   unreachable

--- a/llvm/test/CodeGen/Hexagon/trap-unreachable.ll
+++ b/llvm/test/CodeGen/Hexagon/trap-unreachable.ll
@@ -1,7 +1,7 @@
 ; RUN: llc -mtriple=hexagon -trap-unreachable < %s | FileCheck %s
 
-; Trap is a 32-bit zero word that the processor decodes as an illegal duplex.
-; CHECK: .word 0
+; Trap is the word 0x00110011, a duplex where both slots write R1.
+; CHECK: .word 1114129
 
 define void @fred() #0 {
   unreachable

--- a/llvm/test/CodeGen/Hexagon/trap-unreachable.ll
+++ b/llvm/test/CodeGen/Hexagon/trap-unreachable.ll
@@ -1,7 +1,7 @@
 ; RUN: llc -mtriple=hexagon -trap-unreachable < %s | FileCheck %s
 
-; Trap is the word 0x00110011, a duplex where both slots write R1.
-; CHECK: .word 1114129
+; Trap is the word 0x9b810001: R1 = memw(R1++#0) with both outputs writing R1.
+; CHECK: .word 2608922625
 
 define void @fred() #0 {
   unreachable

--- a/llvm/test/MC/Disassembler/Hexagon/trap.txt
+++ b/llvm/test/MC/Disassembler/Hexagon/trap.txt
@@ -1,0 +1,7 @@
+# RUN: llvm-mc -triple hexagon -disassemble < %s | FileCheck %s
+
+## 0x00110011 is used by __builtin_trap.  It encodes the duplex
+## { R1 = memw(R1+#0); R1 = memw(R1+#0) } -- both slots write R1,
+## triggering a hardware exception.
+0x11 0x00 0x11 0x00
+# CHECK: mult_reg_write_fail

--- a/llvm/test/MC/Disassembler/Hexagon/trap.txt
+++ b/llvm/test/MC/Disassembler/Hexagon/trap.txt
@@ -1,7 +1,7 @@
 # RUN: llvm-mc -triple hexagon -disassemble < %s | FileCheck %s
 
-## 0x00110011 is used by __builtin_trap.  It encodes the duplex
-## { R1 = memw(R1+#0); R1 = memw(R1+#0) } -- both slots write R1,
-## triggering a hardware exception.
-0x11 0x00 0x11 0x00
-# CHECK: mult_reg_write_fail
+## 0x9b810001 is used by llvm.trap.  It encodes R1 = memw(R1++#0)
+## where both the load destination and the post-increment destination
+## write R1, triggering a hardware "multiple writes to register" exception.
+0x01 0x00 0x81 0x9b
+# CHECK: r1 = memw(r1++#0) // llvm.trap


### PR DESCRIPTION
Replace the two-word misaligned load (PS_loadrdabs + constant extender for 0xBADC0FEE) with a single 32-bit zero word emitted directly by the AsmPrinter.  The zero word decodes as a duplex with both slots writing R0, which is an illegal packet -- the hardware raises a "multiple writes to register" exception.

This halves the code size of every __builtin_trap / unreachable-with- trap-unreachable from 8 bytes to 4 bytes.

With libc++'s hardening mode https://libcxx.llvm.org/Hardening.html, we see many __builtin_trap()s inlined into call sites to C++ library functionality, so the overhead of this pseudo-instruction is very signficant and creates a barrier to its deployment.