### PR TITLE
[Flang][OpenMP] Fix implicit symbol resolution for USE-renamed arrays

### DIFF
--- a/flang/lib/Semantics/resolve-directives.cpp
+++ b/flang/lib/Semantics/resolve-directives.cpp
@@ -169,6 +169,8 @@ protected:
   const parser::DoConstruct *GetDoConstructIf(
       const parser::ExecutionPartConstruct &);
   Symbol *DeclareNewAccessEntity(const Symbol &, Symbol::Flag, Scope &);
+  Symbol *DeclareNewAccessEntity(
+      const SourceName &, const Symbol &, Symbol::Flag, Scope &);
   Symbol *DeclareAccessEntity(const parser::Name &, Symbol::Flag, Scope &);
   Symbol *DeclareAccessEntity(Symbol &, Symbol::Flag, Scope &);
 
@@ -1127,8 +1129,21 @@ const parser::DoConstruct *DirectiveAttributeVisitor<T>::GetDoConstructIf(
 
 template <typename T>
 Symbol *DirectiveAttributeVisitor<T>::DeclareNewAccessEntity(
-    const Symbol &object, Symbol::Flag flag, Scope &scope) {
+    const SourceName &name, const Symbol &object, Symbol::Flag flag,
+    Scope &scope) {
   assert(object.owner() != currScope());
+  auto &symbol{MakeAssocSymbol(name, object, scope)};
+  symbol.set(flag);
+  if (flag == Symbol::Flag::OmpCopyIn) {
+    // The symbol in copyin clause must be threadprivate entity.
+    symbol.set(Symbol::Flag::OmpThreadprivate);
+  }
+  return &symbol;
+}
+
+template <typename T>
+Symbol *DirectiveAttributeVisitor<T>::DeclareNewAccessEntity(
+    const Symbol &object, Symbol::Flag flag, Scope &scope) {
   auto &symbol{MakeAssocSymbol(object.name(), object, scope)};
   symbol.set(flag);
   if (flag == Symbol::Flag::OmpCopyIn) {
@@ -2564,8 +2579,8 @@ void OmpAttributeVisitor::CreateImplicitSymbols(
           lastDeclSymbol ? lastDeclSymbol : &symbol->GetUltimate();
       assert(flags.LeastElement());
       Symbol::Flag flag = *flags.LeastElement();
-      lastDeclSymbol = DeclareNewAccessEntity(
-          *hostSymbol, flag, context_.FindScope(dirContext.directiveSource));
+      lastDeclSymbol = DeclareNewAccessEntity(symbol->name(), *hostSymbol, flag,
+          context_.FindScope(dirContext.directiveSource));
       lastDeclSymbol->flags() |= flags;
       return lastDeclSymbol;
     };
@@ -2573,7 +2588,7 @@ void OmpAttributeVisitor::CreateImplicitSymbols(
       if (lastDeclSymbol) {
         const Symbol *hostSymbol =
             lastDeclSymbol ? lastDeclSymbol : &symbol->GetUltimate();
-        MakeAssocSymbol(symbol->name(), *hostSymbol,
+        MakeAssocSymbol(hostSymbol->name(), *hostSymbol,
             context_.FindScope(dirContext.directiveSource));
       }
     };

--- a/flang/lib/Semantics/resolve-directives.cpp
+++ b/flang/lib/Semantics/resolve-directives.cpp
@@ -1131,7 +1131,6 @@ template <typename T>
 Symbol *DirectiveAttributeVisitor<T>::DeclareNewAccessEntity(
     const SourceName &name, const Symbol &object, Symbol::Flag flag,
     Scope &scope) {
-  assert(object.owner() != currScope());
   auto &symbol{MakeAssocSymbol(name, object, scope)};
   symbol.set(flag);
   if (flag == Symbol::Flag::OmpCopyIn) {
@@ -1144,13 +1143,7 @@ Symbol *DirectiveAttributeVisitor<T>::DeclareNewAccessEntity(
 template <typename T>
 Symbol *DirectiveAttributeVisitor<T>::DeclareNewAccessEntity(
     const Symbol &object, Symbol::Flag flag, Scope &scope) {
-  auto &symbol{MakeAssocSymbol(object.name(), object, scope)};
-  symbol.set(flag);
-  if (flag == Symbol::Flag::OmpCopyIn) {
-    // The symbol in copyin clause must be threadprivate entity.
-    symbol.set(Symbol::Flag::OmpThreadprivate);
-  }
-  return &symbol;
+  return DeclareNewAccessEntity(object.name(), object, flag, scope);
 }
 
 template <typename T>

--- a/flang/lib/Semantics/resolve-directives.cpp
+++ b/flang/lib/Semantics/resolve-directives.cpp
@@ -174,6 +174,8 @@ protected:
   const parser::DoConstruct *GetDoConstructIf(
       const parser::ExecutionPartConstruct &);
   Symbol *DeclareNewAccessEntity(const Symbol &, Symbol::Flag, Scope &);
+  Symbol *DeclareNewAccessEntity(
+      const SourceName &, const Symbol &, Symbol::Flag, Scope &);
   Symbol *DeclareAccessEntity(const parser::Name &, Symbol::Flag, Scope &);
   Symbol *DeclareAccessEntity(Symbol &, Symbol::Flag, Scope &);
   Symbol *DeclareOrMarkOtherAccessEntity(const parser::Name &, Symbol::Flag);
@@ -1209,15 +1211,22 @@ const parser::DoConstruct *DirectiveAttributeVisitor<T>::GetDoConstructIf(
 
 template <typename T>
 Symbol *DirectiveAttributeVisitor<T>::DeclareNewAccessEntity(
-    const Symbol &object, Symbol::Flag flag, Scope &scope) {
+    const SourceName &name, const Symbol &object, Symbol::Flag flag,
+    Scope &scope) {
   assert(object.owner() != currScope());
-  auto &symbol{MakeAssocSymbol(object.name(), object, scope)};
+  auto &symbol{MakeAssocSymbol(name, object, scope)};
   symbol.set(flag);
   if (flag == Symbol::Flag::OmpCopyIn) {
     // The symbol in copyin clause must be threadprivate entity.
     symbol.set(Symbol::Flag::OmpThreadprivate);
   }
   return &symbol;
+}
+
+template <typename T>
+Symbol *DirectiveAttributeVisitor<T>::DeclareNewAccessEntity(
+    const Symbol &object, Symbol::Flag flag, Scope &scope) {
+  return DeclareNewAccessEntity(object.name(), object, flag, scope);
 }
 
 template <typename T>
@@ -2736,12 +2745,15 @@ void OmpAttributeVisitor::CreateImplicitSymbols(
     // This would make x appear to be defined in p2, causing it to be
     // privatized in p2 and its privatization in p1 to be skipped.
     auto makeSymbol = [&](Symbol::Flags flags) {
-      const Symbol *hostSymbol =
-          lastDeclSymbol ? lastDeclSymbol : &symbol->GetUltimate();
+      const Symbol *hostSymbol = lastDeclSymbol ? lastDeclSymbol : &symbol->GetUltimate();
+      const SourceName &name =
+          (symbol->name().ToString() != hostSymbol->name().ToString())
+          ? symbol->name()
+          : hostSymbol->name();
       assert(flags.LeastElement());
       Symbol::Flag flag = *flags.LeastElement();
       lastDeclSymbol = DeclareNewAccessEntity(
-          *hostSymbol, flag, context_.FindScope(dirContext.directiveSource));
+          name, *hostSymbol, flag, context_.FindScope(dirContext.directiveSource));
       lastDeclSymbol->flags() |= flags;
       return lastDeclSymbol;
     };

--- a/flang/test/Semantics/OpenMP/use-rename-array-dsa.f90
+++ b/flang/test/Semantics/OpenMP/use-rename-array-dsa.f90
@@ -1,0 +1,32 @@
+! RUN: %flang_fc1 -fdebug-dump-symbols -fopenmp %s | FileCheck %s
+
+! Verify that a USE-renamed array (s_ary => ary) is correctly associated in an
+! OpenMP region under the alias name, not the original module name.
+! Regression test for https://github.com/llvm/llvm-project/issues/185344
+
+module use_rename_mod1
+  implicit none
+  real(8), allocatable :: ary(:,:,:)
+end module
+
+module use_rename_mod2
+  implicit none
+  real(8), allocatable :: ary(:,:,:,:,:)
+end module
+
+program test
+  use use_rename_mod1, only: s_ary => ary
+  use use_rename_mod2, only: ary
+  implicit none
+  integer(4) :: i
+
+  !$omp parallel do
+    do i = 1, 10
+      s_ary(i,1,1) = ary(i,1,1,1,1)
+    end do
+  !$omp end parallel do
+end program
+! The loop variable is private and predetermined.
+! CHECK: i (OmpPrivate, OmpPreDetermined): HostAssoc
+! The OMP region must create a host-association for s_ary under its alias name.
+! CHECK: s_ary (OmpShared): HostAssoc

--- a/flang/test/Semantics/OpenMP/use-rename-array-dsa.f90
+++ b/flang/test/Semantics/OpenMP/use-rename-array-dsa.f90
@@ -26,7 +26,9 @@ program test
     end do
   !$omp end parallel do
 end program
-! The loop variable is private and predetermined.
-! CHECK: i (OmpPrivate, OmpPreDetermined): HostAssoc
 ! The OMP region must create a host-association for s_ary under its alias name.
-! CHECK: s_ary (OmpShared): HostAssoc
+! CHECK:  MainProgram scope: TEST
+! CHECK:    OtherConstruct scope:
+! CHECK:      ary (OmpShared): HostAssoc => ary
+! CHECK:      i (OmpPrivate, OmpPreDetermined): HostAssoc => i
+! CHECK:      s_ary (OmpShared): HostAssoc => ary

--- a/flang/test/Semantics/OpenMP/use-rename-array-dsa.f90
+++ b/flang/test/Semantics/OpenMP/use-rename-array-dsa.f90
@@ -1,0 +1,40 @@
+! RUN: %python %S/../test_errors.py %s %flang_fc1 -fopenmp
+
+! Check that compiling a USE-renamed array inside an OpenMP construct
+! does not trigger a dimension mismatch error against the original symbol name.
+! Also serves as a check that host-association for implicitly scoped variables
+! links against the local 'use' alias symbol correctly.
+
+module mod1
+  implicit none
+  real(8), allocatable :: ary(:,:,:)
+end module mod1
+
+module mod2
+  implicit none
+  real(8), allocatable :: ary(:,:,:,:,:)
+end module mod2
+
+module mod3
+  implicit none
+contains
+  subroutine sub(arg)
+    use mod1, only: s_ary => ary
+    use mod2, only: ary
+    implicit none
+    integer(4), intent(in) :: arg
+    integer(4) :: i, j, k
+    integer(4) :: xx, yy, zs, ze, mm
+
+    !$omp parallel do
+    do j = 0, yy+1
+      do i = 0, xx+1
+        do k = zs, ze
+          s_ary(k,i,j) = s_ary(k,i,j) + ary(k,-1,i,j,mm)
+          ary(k,-1,i,j,mm) = 0._8
+        end do
+      end do
+    end do
+    !$omp end parallel do
+  end subroutine sub
+end module mod3


### PR DESCRIPTION
 [Flang][OpenMP] Fix USE-renamed array DSA in OpenMP regions

  Problem: for a USE-renamed symbol (e.g. USE mod, ONLY: s_ary => ary),
  the HostAssoc in the OMP scope was created under the original name
  "ary" instead of the local alias "s_ary".

  Fix: add a DeclareNewAccessEntity overload that takes an explicit
  SourceName, and call it with symbol->name() (the alias) rather than
  the ultimate symbol's name, so the HostAssoc is created under the
  name the user wrote.

  Fixes #185344

  Assisted-by: Claude Sonnet 4.6