### PR TITLE
[clang-format] fix aligning inheritance lists  and binary operator operands with UT_AlignWithSpaces

### DIFF
--- a/clang/lib/Format/ContinuationIndenter.cpp
+++ b/clang/lib/Format/ContinuationIndenter.cpp
@@ -1238,6 +1238,25 @@ unsigned ContinuationIndenter::addTokenOnNewLine(LineState &State,
     }
   }
 
+  switch (Style.BreakInheritanceList) {
+  case FormatStyle::BILS_BeforeColon:
+  case FormatStyle::BILS_AfterComma:
+    CurrentState.IsAligned = CurrentState.IsAligned ||
+                             Current.is(TT_InheritanceColon) ||
+                             Previous.is(TT_InheritanceComma);
+    break;
+  case FormatStyle::BILS_BeforeComma:
+    CurrentState.IsAligned =
+        CurrentState.IsAligned ||
+        Current.isOneOf(TT_InheritanceColon, TT_InheritanceComma);
+    break;
+  case FormatStyle::BILS_AfterColon:
+    CurrentState.IsAligned =
+        CurrentState.IsAligned ||
+        Previous.isOneOf(TT_InheritanceColon, TT_InheritanceComma);
+    break;
+  }
+
   if ((PreviousNonComment &&
        PreviousNonComment->isOneOf(tok::comma, tok::semi) &&
        !CurrentState.AvoidBinPacking) ||

--- a/clang/lib/Format/ContinuationIndenter.cpp
+++ b/clang/lib/Format/ContinuationIndenter.cpp
@@ -1273,8 +1273,10 @@ unsigned ContinuationIndenter::addTokenOnNewLine(LineState &State,
       (PreviousNonComment && PreviousNonComment->is(tok::question))) {
     CurrentState.BreakBeforeParameter = true;
   }
-  if (Current.is(TT_BinaryOperator) && Current.CanBreakBefore)
+  if (Current.is(TT_BinaryOperator) && Current.CanBreakBefore) {
     CurrentState.BreakBeforeParameter = false;
+    CurrentState.IsAligned = true;
+  }
 
   if (!DryRun) {
     unsigned MaxEmptyLinesToKeep = Style.MaxEmptyLinesToKeep + 1;

--- a/clang/unittests/Format/FormatTest.cpp
+++ b/clang/unittests/Format/FormatTest.cpp
@@ -17073,6 +17073,19 @@ TEST_F(FormatTest, ConfigurableUseOfTab) {
                "\t}\n"
                "};",
                Tab);
+  verifyFormat("aStreamObject << aaaaaaaaaaaaa\n"
+               "              << bbbbbbbbb;\n",
+               Tab);
+  verifyFormat("result = aaaaaaaaaaaaaaaaaaaaaaaa +\n"
+               "         bbbbbbbbbbbbbbbbbbbb;",
+               Tab);
+  verifyFormat("class C {\n"
+               "\tvoid foo() {\n"
+               "\t\taStreamObject << aaaaaaaaaaaaa\n"
+               "\t\t              << bbbbbbbbb;\n"
+               "\t}\n"
+               "};",
+               Tab);
   Tab.TabWidth = 8;
   Tab.IndentWidth = 4;
   verifyFormat("class TabWidth8Indent4 {\n"

--- a/clang/unittests/Format/FormatTest.cpp
+++ b/clang/unittests/Format/FormatTest.cpp
@@ -8435,6 +8435,52 @@ TEST_F(FormatTest, BreakConstructorInitializersAfterColon) {
       "  : public aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,\n"
       "    public bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb {};",
       Style);
+
+  FormatStyle Tabbed = getLLVMStyle();
+  Tabbed.IndentWidth = 4;
+  Tabbed.TabWidth = 4;
+  Tabbed.UseTab = FormatStyle::UT_AlignWithSpaces;
+  Tabbed.BreakInheritanceList = FormatStyle::BILS_BeforeColon;
+  verifyFormat(
+      "class BeforeColonTabbed\n"
+      "    : public aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,\n"
+      "      protected bbbbbbbbbbbbbbbbbb,\n"
+      "      private cccccccccccccccccccccc,\n"
+      "      dddddddddd {};",
+      Tabbed);
+  Tabbed.BreakInheritanceList = FormatStyle::BILS_BeforeComma;
+  verifyFormat(
+      "class BeforeCommaTabbed\n"
+      "    : public aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n"
+      "    , protected bbbbbbbbb\n"
+      "    , private cccccccccc\n"
+      "    , dddddddddd {};",
+      Tabbed);
+  Tabbed.BreakInheritanceList = FormatStyle::BILS_AfterColon;
+  verifyFormat(
+      "class AfterColonTabbed :\n"
+      "    public aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,\n"
+      "    protected bbbbbbbbb,\n"
+      "    private cccccccccc,\n"
+      "    dddddddddd {};",
+      Tabbed);
+  Tabbed.BreakInheritanceList = FormatStyle::BILS_AfterComma;
+  verifyFormat("class AfterCommaTabbed : public aaaaaaaaa,\n"
+               "                         protected bbbbbbbbb,\n"
+               "                         private cccccccccc,\n"
+               "                         ddddddddd {};",
+               Tabbed);
+  verifyFormat(
+      "class SomeClass\n"
+      "    : public aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,\n"
+      "      public bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb {};",
+      Tabbed);
+  Tabbed.ColumnLimit = 42;
+  verifyFormat("struct S {\n"
+               "\tclass Foo : public aaaaaaaaa,\n"
+               "\t            private bbbbbbbbb {};\n"
+               "};",
+               Tabbed);
 }
 
 TEST_F(FormatTest, BreakConstructorInitializersAfterComma) {


### PR DESCRIPTION
fix aligning inheritance lists with UT_AlignWithSpaces
fix aligning binary operator operands
