### PR TITLE
[GlobalISel][LegalizeTypes] Expand UDIV/UREM by constant via chunk summation

### DIFF
--- a/llvm/include/llvm/CodeGen/GlobalISel/CombinerHelper.h
+++ b/llvm/include/llvm/CodeGen/GlobalISel/CombinerHelper.h
@@ -722,6 +722,13 @@ public:
   bool matchNarrowBinopFeedingAnd(MachineInstr &MI, BuildFnTy &MatchInfo) const;
 
   /// Given an G_UDIV \p MI or G_UREM \p MI expressing a divide by constant,
+  /// return an expression that implements chunk summation where constant Div
+  /// satisfies the condition (2^W % D)) == 1. Ref: "Hacker's Delight" or "The
+  /// PowerPC Compiler Writer's Guide", 10-19 Remainder by Summing Digite,
+  /// FIGURE 10–28, Unsigned remainder modulo 7.
+  MachineInstr *buildUDivOrRemUsingChunkSummation(MachineInstr &MI) const;
+
+  /// Given an G_UDIV \p MI or G_UREM \p MI expressing a divide by constant,
   /// return an expression that implements it by multiplying by a magic number.
   /// Ref: "Hacker's Delight" or "The PowerPC Compiler Writer's Guide".
   MachineInstr *buildUDivOrURemUsingMul(MachineInstr &MI) const;

--- a/llvm/lib/CodeGen/GlobalISel/CombinerHelper.cpp
+++ b/llvm/lib/CodeGen/GlobalISel/CombinerHelper.cpp
@@ -5575,6 +5575,229 @@ bool CombinerHelper::matchSubAddSameReg(MachineInstr &MI,
   return false;
 }
 
+static unsigned getSumOfDigitsChunkWidth(const APInt &Divisor,
+                                         unsigned BitWidth) {
+  if (Divisor.isZero())
+    return 0;
+
+  unsigned HBitWidth = BitWidth / 2;
+
+  // Search for a ChunkWidth (I) where (2^I) % D == 1.
+  // This allows us to use the "Sum of Digits" property in base 2^I.
+  for (unsigned I = HBitWidth, E = HBitWidth / 2; I > E; --I) {
+    APInt Mod = APInt::getOneBitSet(BitWidth, I).urem(Divisor);
+
+    if (Mod.isOne()) {
+      unsigned NumChunks = divideCeil(BitWidth, I);
+
+      // Safety check: Ensure the sum of chunks won't overflow the
+      // width of the registers we are using for the summation (HBitWidth).
+      if (I == HBitWidth || I + llvm::bit_width(NumChunks - 1) <= HBitWidth)
+        return I;
+    }
+  }
+
+  return 0;
+}
+
+// Optimize unsigned division or remainder by constants for types twice as large
+// as a legal VT.
+//
+// If (1 << (BitWidth / 2)) % Constant == 1, then the remainder
+// can be computed
+// as:
+//   Sum = __builtin_uadd_overflow(Lo, High, &Sum);
+//   Remainder = Sum % Constant;
+//
+// If (1 << (BitWidth / 2)) % Constant != 1, we can search for a smaller value
+// W such that W != (BitWidth / 2) and (1 << W) % Constant == 1. We can break
+// High:Low into 3 chunks of W bits and compute remainder as
+//   Sum = Chunk0 + Chunk1 + Chunk2;
+//   Remainder = Sum % Constant;
+//
+// This is based on "Remainder by Summing Digits" from Hacker's Delight.
+//
+// For division, we can compute the remainder using the algorithm described
+// above, subtract it from the dividend to get an exact multiple of Constant.
+// Then multiply that exact multiply by the multiplicative inverse modulo
+// (1 << (BitWidth / 2)) to get the quotient.
+
+// If Constant is even, we can shift right the dividend and the divisor by the
+// number of trailing zeros in Constant before applying the remainder algorithm.
+// If we're after the quotient, we can subtract this value from the shifted
+// dividend and multiply by the multiplicative inverse of the shifted divisor.
+// If we want the remainder, we shift the value left by the number of trailing
+// zeros and add the bits that were shifted out of the dividend.
+MachineInstr *
+CombinerHelper::buildUDivOrRemUsingChunkSummation(MachineInstr &MI) const {
+  // Only handle unsigned operations.
+  unsigned Opcode = MI.getOpcode();
+  if (Opcode == TargetOpcode::G_SREM || Opcode == TargetOpcode::G_SDIV)
+    return nullptr;
+  assert((Opcode == TargetOpcode::G_UREM || Opcode == TargetOpcode::G_UDIV) &&
+         "Unexpected opcode");
+
+  Register DivReg = MI.getOperand(2).getReg();
+  auto VRegAndVal = getIConstantVRegValWithLookThrough(DivReg, MRI);
+  if (!VRegAndVal)
+    return nullptr;
+
+  // Don't expand if optimizing for size.
+  const auto &MF = *MI.getMF();
+  if (MF.getFunction().hasMinSize() || MF.getFunction().hasOptSize())
+    return nullptr;
+
+  // Only apply to wide types (e.g., i128).
+  Register DstReg = MI.getOperand(0).getReg();
+  LLT Ty = MRI.getType(DstReg);
+  unsigned BitWidth = Ty.getSizeInBits();
+  if (BitWidth < 128)
+    return nullptr;
+
+  // Early out for 0 or 1 divisors.
+  APInt Divisor = VRegAndVal->Value;
+  if (Divisor.ule(1))
+    return nullptr;
+
+  // Divisor must be less than (1 << (BitWidth / 2)).
+  unsigned HBitWidth = BitWidth / 2;
+  if (Divisor.uge(APInt::getOneBitSet(BitWidth, HBitWidth)))
+    return nullptr;
+
+  LLT HiLoTy = LLT::scalar(HBitWidth);
+  assert(Ty.getScalarSizeInBits() == BitWidth &&
+         HiLoTy.getScalarSizeInBits() == HBitWidth && "Unexpected VTs");
+
+  // If the divisor is even, shift it until it becomes odd.
+  unsigned TZ = Divisor.countr_zero();
+  if (TZ > 0) {
+    Divisor.lshrInPlace(TZ);
+  }
+
+  // Find the best chunk width W where (2^W % D) == 1.
+  unsigned BestW = getSumOfDigitsChunkWidth(Divisor, BitWidth);
+  if (!BestW)
+    return nullptr;
+
+  Builder.setInstrAndDebugLoc(MI);
+
+  // Split input into LL and LH
+  Register SrcReg = MI.getOperand(1).getReg();
+  auto Unmerge = Builder.buildUnmerge(HiLoTy, SrcReg);
+  Register LL = Unmerge.getReg(0);
+  Register LH = Unmerge.getReg(1);
+
+  bool HasFSHR =
+      isLegalOrBeforeLegalizer({TargetOpcode::G_FSHR, {HiLoTy, HiLoTy}});
+
+  auto GetFSHR = [&](Register Lo, Register Hi, unsigned ShiftAmt) {
+    assert(ShiftAmt > 0 && ShiftAmt < HBitWidth);
+
+    if (HasFSHR) {
+      auto Amt = Builder.buildConstant(HiLoTy, ShiftAmt);
+      return Builder.buildInstr(TargetOpcode::G_FSHR, {HiLoTy}, {Hi, Lo, Amt})
+          .getReg(0);
+    }
+
+    // Fallback: (Lo >> ShiftAmt) | (Hi << (HBitWidth - ShiftAmt))
+    auto ShAmt = Builder.buildConstant(HiLoTy, ShiftAmt);
+    auto InvShAmt = Builder.buildConstant(HiLoTy, HBitWidth - ShiftAmt);
+
+    auto Part1 = Builder.buildLShr(HiLoTy, Lo, ShAmt);
+    auto Part2 = Builder.buildShl(HiLoTy, Hi, InvShAmt);
+
+    return Builder.buildOr(HiLoTy, Part1, Part2).getReg(0);
+  };
+
+  Register PartialRem = Builder.buildConstant(HiLoTy, 0).getReg(0);
+  if (TZ > 0) {
+    if (Opcode != TargetOpcode::G_UDIV) {
+      auto Mask =
+          Builder.buildConstant(HiLoTy, APInt::getLowBitsSet(HBitWidth, TZ));
+      PartialRem = Builder.buildAnd(HiLoTy, LL, Mask).getReg(0);
+    }
+    auto ShiftAmt = Builder.buildConstant(HiLoTy, TZ);
+    Register NewLL =
+        Builder.buildInstr(TargetOpcode::G_FSHR, {HiLoTy}, {LH, LL, ShiftAmt})
+            .getReg(0);
+    Register NewLH = Builder.buildLShr(HiLoTy, LH, ShiftAmt).getReg(0);
+    LL = NewLL;
+    LH = NewLH;
+  }
+
+  Register Sum = Register();
+  if (BestW == HBitWidth) {
+    // Specialized path: (1 << 64) % D == 1. Sum = LL + LH + Carry
+    auto Add = Builder.buildUAddo(HiLoTy, LLT::scalar(1), LL, LH);
+    auto Zero = Builder.buildConstant(HiLoTy, 0);
+    Sum = Builder
+              .buildUAdde(HiLoTy, LLT::scalar(1), Add.getReg(0), Zero,
+                          Add.getReg(1))
+              .getReg(0);
+  } else {
+    // General path for smaller chunk widths
+    Sum = Builder.buildConstant(HiLoTy, 0).getReg(0);
+    auto Mask =
+        Builder.buildConstant(HiLoTy, APInt::getLowBitsSet(HBitWidth, BestW));
+
+    for (unsigned I = 0; I < BitWidth - TZ; I += BestW) {
+      Register Chunk;
+      if (I == 0) {
+        Chunk = LL;
+      } else if (I >= HBitWidth) {
+        auto ShiftAmt = Builder.buildConstant(HiLoTy, I - HBitWidth);
+        Chunk = Builder.buildLShr(HiLoTy, LH, ShiftAmt).getReg(0);
+      } else {
+        Chunk = GetFSHR(LL, LH, I);
+      }
+      auto Masked = Builder.buildAnd(HiLoTy, Chunk, Mask);
+      Sum = Builder.buildAdd(HiLoTy, Sum, Masked).getReg(0);
+    }
+  }
+
+  // RemL = Sum % Divisor
+  auto RemL =
+      Builder
+          .buildURem(HiLoTy, Sum,
+                     Builder.buildConstant(HiLoTy, Divisor.trunc(HBitWidth)))
+          .getReg(0);
+
+  MachineInstr *Res = nullptr;
+
+  if (Opcode != TargetOpcode::G_UREM) {
+    // Quotient Calculation
+    Register ZExtLL = Builder.buildZExt(Ty, LL).getReg(0);
+    Register ZExtLH = Builder.buildZExt(Ty, LH).getReg(0);
+
+    Register ShiftedLH =
+        Builder
+            .buildShl(Ty, ZExtLH,
+                      Builder.buildConstant(Ty, HBitWidth).getReg(0))
+            .getReg(0);
+
+    Register Dividend = Builder.buildOr(Ty, ZExtLL, ShiftedLH).getReg(0);
+    Register ZExtRemL = Builder.buildZExt(Ty, RemL).getReg(0);
+    Register Sub = Builder.buildSub(Ty, Dividend, ZExtRemL).getReg(0);
+
+    APInt InvVal = Divisor.multiplicativeInverse();
+    Register Inv = Builder.buildConstant(Ty, InvVal).getReg(0);
+    Res = Builder.buildMul(Ty, Sub, Inv);
+  }
+
+  if (Opcode != TargetOpcode::G_UDIV) {
+    // Remainder Calculation
+    if (TZ > 0) {
+      auto Shl =
+          Builder.buildShl(HiLoTy, RemL, Builder.buildConstant(HiLoTy, TZ));
+      RemL = Builder.buildOr(HiLoTy, Shl, PartialRem).getReg(0);
+    }
+
+    Res = Builder.buildZExt(Ty, RemL);
+  }
+
+  return Res;
+}
+
 MachineInstr *CombinerHelper::buildUDivOrURemUsingMul(MachineInstr &MI) const {
   unsigned Opcode = MI.getOpcode();
   assert(Opcode == TargetOpcode::G_UDIV || Opcode == TargetOpcode::G_UREM);
@@ -5794,7 +6017,12 @@ bool CombinerHelper::matchUDivOrURemByConst(MachineInstr &MI) const {
 }
 
 void CombinerHelper::applyUDivOrURemByConst(MachineInstr &MI) const {
-  auto *NewMI = buildUDivOrURemUsingMul(MI);
+  // Try to build UDIV/UREM by Hacker's Delight's Remainder by Summing Digits.
+  auto *NewMI = buildUDivOrRemUsingChunkSummation(MI);
+
+  // If chunk summation didn't apply, try the multiplier fallback.
+  if (!NewMI)
+    NewMI = buildUDivOrURemUsingMul(MI);
   replaceSingleDefInstWithReg(MI, NewMI->getOperand(0).getReg());
 }
 

--- a/llvm/test/CodeGen/AArch64/rem-by-const.ll
+++ b/llvm/test/CodeGen/AArch64/rem-by-const.ll
@@ -518,65 +518,21 @@ define i128 @ui128_7(i128 %a, i128 %b) {
 ;
 ; CHECK-GI-LABEL: ui128_7:
 ; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    mov x8, #18725 // =0x4925
-; CHECK-GI-NEXT:    mov x10, #9362 // =0x2492
-; CHECK-GI-NEXT:    movk x8, #9362, lsl #16
-; CHECK-GI-NEXT:    movk x10, #37449, lsl #16
-; CHECK-GI-NEXT:    movk x8, #37449, lsl #32
-; CHECK-GI-NEXT:    movk x10, #18724, lsl #32
-; CHECK-GI-NEXT:    movk x8, #18724, lsl #48
-; CHECK-GI-NEXT:    movk x10, #9362, lsl #48
-; CHECK-GI-NEXT:    mul x9, x1, x8
-; CHECK-GI-NEXT:    mul x11, x0, x10
-; CHECK-GI-NEXT:    umulh x12, x0, x8
-; CHECK-GI-NEXT:    mul x13, x1, x10
-; CHECK-GI-NEXT:    adds x9, x9, x11
-; CHECK-GI-NEXT:    umulh x14, x1, x8
-; CHECK-GI-NEXT:    cset w11, hs
-; CHECK-GI-NEXT:    cmn x9, x12
-; CHECK-GI-NEXT:    and x11, x11, #0x1
-; CHECK-GI-NEXT:    and x12, xzr, #0x1
-; CHECK-GI-NEXT:    umulh x15, x0, x10
-; CHECK-GI-NEXT:    cset w9, hs
-; CHECK-GI-NEXT:    and x9, x9, #0x1
-; CHECK-GI-NEXT:    umulh x8, xzr, x8
-; CHECK-GI-NEXT:    add x9, x11, x9
-; CHECK-GI-NEXT:    and x11, xzr, #0x1
-; CHECK-GI-NEXT:    adds x13, x13, x14
-; CHECK-GI-NEXT:    add x11, x11, x12
-; CHECK-GI-NEXT:    umulh x10, x1, x10
-; CHECK-GI-NEXT:    cset w12, hs
-; CHECK-GI-NEXT:    adds x13, x13, x15
-; CHECK-GI-NEXT:    and x12, x12, #0x1
-; CHECK-GI-NEXT:    umulh x14, x0, xzr
-; CHECK-GI-NEXT:    cset w15, hs
-; CHECK-GI-NEXT:    adds x9, x13, x9
-; CHECK-GI-NEXT:    add x11, x11, x12
-; CHECK-GI-NEXT:    and x12, x15, #0x1
-; CHECK-GI-NEXT:    cset w13, hs
-; CHECK-GI-NEXT:    add x11, x11, x12
-; CHECK-GI-NEXT:    and x12, x13, #0x1
-; CHECK-GI-NEXT:    add x8, x8, x10
-; CHECK-GI-NEXT:    add x10, x11, x12
-; CHECK-GI-NEXT:    add x8, x8, x14
-; CHECK-GI-NEXT:    add x8, x8, x10
-; CHECK-GI-NEXT:    subs x10, x0, x9
-; CHECK-GI-NEXT:    sbc x11, x1, x8
-; CHECK-GI-NEXT:    extr x10, x11, x10, #1
-; CHECK-GI-NEXT:    lsr x11, x11, #1
-; CHECK-GI-NEXT:    adds x9, x10, x9
-; CHECK-GI-NEXT:    mov w10, #7 // =0x7
-; CHECK-GI-NEXT:    adc x8, x11, x8
-; CHECK-GI-NEXT:    extr x9, x8, x9, #2
-; CHECK-GI-NEXT:    lsr x8, x8, #2
-; CHECK-GI-NEXT:    umulh x10, x9, x10
-; CHECK-GI-NEXT:    lsl x11, x9, #3
-; CHECK-GI-NEXT:    lsl x12, x8, #3
-; CHECK-GI-NEXT:    sub x9, x11, x9
-; CHECK-GI-NEXT:    sub x8, x12, x8
-; CHECK-GI-NEXT:    subs x0, x0, x9
-; CHECK-GI-NEXT:    add x8, x8, x10
-; CHECK-GI-NEXT:    sbc x1, x1, x8
+; CHECK-GI-NEXT:    extr x8, x1, x0, #60
+; CHECK-GI-NEXT:    and x9, x0, #0xfffffffffffffff
+; CHECK-GI-NEXT:    and x8, x8, #0xfffffffffffffff
+; CHECK-GI-NEXT:    add x8, x9, x8
+; CHECK-GI-NEXT:    mov x9, #18725 // =0x4925
+; CHECK-GI-NEXT:    movk x9, #9362, lsl #16
+; CHECK-GI-NEXT:    add x8, x8, x1, lsr #56
+; CHECK-GI-NEXT:    mov x1, xzr
+; CHECK-GI-NEXT:    movk x9, #37449, lsl #32
+; CHECK-GI-NEXT:    movk x9, #18724, lsl #48
+; CHECK-GI-NEXT:    umulh x9, x8, x9
+; CHECK-GI-NEXT:    lsr x9, x9, #1
+; CHECK-GI-NEXT:    lsl x10, x9, #3
+; CHECK-GI-NEXT:    sub x9, x10, x9
+; CHECK-GI-NEXT:    sub x0, x8, x9
 ; CHECK-GI-NEXT:    ret
 entry:
   %s = urem i128 %a, 7
@@ -605,14 +561,370 @@ define i128 @ui128_100(i128 %a, i128 %b) {
 ;
 ; CHECK-GI-LABEL: ui128_100:
 ; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    mov x8, #23593 // =0x5c29
+; CHECK-GI-NEXT:    extr x8, x1, x0, #2
+; CHECK-GI-NEXT:    lsr x9, x1, #2
+; CHECK-GI-NEXT:    mov w10, #25 // =0x19
+; CHECK-GI-NEXT:    extr x9, x9, x8, #60
+; CHECK-GI-NEXT:    and x8, x8, #0xfffffffffffffff
+; CHECK-GI-NEXT:    and x9, x9, #0xfffffffffffffff
+; CHECK-GI-NEXT:    add x8, x8, x9
+; CHECK-GI-NEXT:    mov x9, #62915 // =0xf5c3
+; CHECK-GI-NEXT:    movk x9, #23592, lsl #16
+; CHECK-GI-NEXT:    add x8, x8, x1, lsr #58
+; CHECK-GI-NEXT:    mov x1, xzr
+; CHECK-GI-NEXT:    movk x9, #49807, lsl #32
+; CHECK-GI-NEXT:    movk x9, #10485, lsl #48
+; CHECK-GI-NEXT:    umulh x9, x8, x9
+; CHECK-GI-NEXT:    lsr x9, x9, #2
+; CHECK-GI-NEXT:    msub x8, x9, x10, x8
+; CHECK-GI-NEXT:    bfi x0, x8, #2, #62
+; CHECK-GI-NEXT:    ret
+entry:
+  %s = urem i128 %a, 100
+  ret i128 %s
+}
+
+define i128 @ui128_35(i128 %a, i128 %b) {
+; CHECK-LABEL: ui128_35:
+; CHECK:       // %bb.0: // %entry
+; CHECK-NEXT:    extr x8, x1, x0, #60
+; CHECK-NEXT:    and x9, x0, #0xfffffffffffffff
+; CHECK-NEXT:    mov w10, #35 // =0x23
+; CHECK-NEXT:    and x8, x8, #0xfffffffffffffff
+; CHECK-NEXT:    add x8, x9, x8
+; CHECK-NEXT:    mov x9, #3745 // =0xea1
+; CHECK-NEXT:    movk x9, #41194, lsl #16
+; CHECK-NEXT:    add x8, x8, x1, lsr #56
+; CHECK-NEXT:    mov x1, xzr
+; CHECK-NEXT:    movk x9, #59918, lsl #32
+; CHECK-NEXT:    movk x9, #3744, lsl #48
+; CHECK-NEXT:    umulh x9, x8, x9
+; CHECK-NEXT:    lsr x9, x9, #1
+; CHECK-NEXT:    msub x0, x9, x10, x8
+; CHECK-NEXT:    ret
+entry:
+  %s = urem i128 %a, 35
+  ret i128 %s
+}
+
+define i128 @ui128_14(i128 %a, i128 %b) {
+; CHECK-SD-LABEL: ui128_14:
+; CHECK-SD:       // %bb.0: // %entry
+; CHECK-SD-NEXT:    extr x8, x1, x0, #61
+; CHECK-SD-NEXT:    ubfx x9, x0, #1, #60
+; CHECK-SD-NEXT:    and x8, x8, #0xfffffffffffffff
+; CHECK-SD-NEXT:    add x8, x9, x8
+; CHECK-SD-NEXT:    mov x9, #18725 // =0x4925
+; CHECK-SD-NEXT:    movk x9, #9362, lsl #16
+; CHECK-SD-NEXT:    add x8, x8, x1, lsr #57
+; CHECK-SD-NEXT:    mov x1, xzr
+; CHECK-SD-NEXT:    movk x9, #37449, lsl #32
+; CHECK-SD-NEXT:    movk x9, #18724, lsl #48
+; CHECK-SD-NEXT:    umulh x9, x8, x9
+; CHECK-SD-NEXT:    lsr x9, x9, #1
+; CHECK-SD-NEXT:    sub x9, x9, x9, lsl #3
+; CHECK-SD-NEXT:    add x8, x8, x9
+; CHECK-SD-NEXT:    bfi x0, x8, #1, #63
+; CHECK-SD-NEXT:    ret
+;
+; CHECK-GI-LABEL: ui128_14:
+; CHECK-GI:       // %bb.0: // %entry
+; CHECK-GI-NEXT:    extr x8, x1, x0, #1
+; CHECK-GI-NEXT:    lsr x9, x1, #1
+; CHECK-GI-NEXT:    extr x9, x9, x8, #60
+; CHECK-GI-NEXT:    and x8, x8, #0xfffffffffffffff
+; CHECK-GI-NEXT:    and x9, x9, #0xfffffffffffffff
+; CHECK-GI-NEXT:    add x8, x8, x9
+; CHECK-GI-NEXT:    mov x9, #18725 // =0x4925
+; CHECK-GI-NEXT:    movk x9, #9362, lsl #16
+; CHECK-GI-NEXT:    add x8, x8, x1, lsr #57
+; CHECK-GI-NEXT:    mov x1, xzr
+; CHECK-GI-NEXT:    movk x9, #37449, lsl #32
+; CHECK-GI-NEXT:    movk x9, #18724, lsl #48
+; CHECK-GI-NEXT:    umulh x9, x8, x9
+; CHECK-GI-NEXT:    lsr x9, x9, #1
+; CHECK-GI-NEXT:    lsl x10, x9, #3
+; CHECK-GI-NEXT:    sub x9, x10, x9
+; CHECK-GI-NEXT:    sub x8, x8, x9
+; CHECK-GI-NEXT:    bfi x0, x8, #1, #63
+; CHECK-GI-NEXT:    ret
+entry:
+  %s = urem i128 %a, 14
+  ret i128 %s
+}
+
+define i128 @ui128_56(i128 %a, i128 %b) {
+; CHECK-SD-LABEL: ui128_56:
+; CHECK-SD:       // %bb.0: // %entry
+; CHECK-SD-NEXT:    extr x8, x1, x0, #63
+; CHECK-SD-NEXT:    ubfx x9, x0, #3, #60
+; CHECK-SD-NEXT:    and x8, x8, #0xfffffffffffffff
+; CHECK-SD-NEXT:    add x8, x9, x8
+; CHECK-SD-NEXT:    mov x9, #18725 // =0x4925
+; CHECK-SD-NEXT:    movk x9, #9362, lsl #16
+; CHECK-SD-NEXT:    add x8, x8, x1, lsr #59
+; CHECK-SD-NEXT:    mov x1, xzr
+; CHECK-SD-NEXT:    movk x9, #37449, lsl #32
+; CHECK-SD-NEXT:    movk x9, #18724, lsl #48
+; CHECK-SD-NEXT:    umulh x9, x8, x9
+; CHECK-SD-NEXT:    lsr x9, x9, #1
+; CHECK-SD-NEXT:    sub x9, x9, x9, lsl #3
+; CHECK-SD-NEXT:    add x8, x8, x9
+; CHECK-SD-NEXT:    bfi x0, x8, #3, #61
+; CHECK-SD-NEXT:    ret
+;
+; CHECK-GI-LABEL: ui128_56:
+; CHECK-GI:       // %bb.0: // %entry
+; CHECK-GI-NEXT:    extr x8, x1, x0, #3
+; CHECK-GI-NEXT:    lsr x9, x1, #3
+; CHECK-GI-NEXT:    extr x9, x9, x8, #60
+; CHECK-GI-NEXT:    and x8, x8, #0xfffffffffffffff
+; CHECK-GI-NEXT:    and x9, x9, #0xfffffffffffffff
+; CHECK-GI-NEXT:    add x8, x8, x9
+; CHECK-GI-NEXT:    mov x9, #18725 // =0x4925
+; CHECK-GI-NEXT:    movk x9, #9362, lsl #16
+; CHECK-GI-NEXT:    add x8, x8, x1, lsr #59
+; CHECK-GI-NEXT:    mov x1, xzr
+; CHECK-GI-NEXT:    movk x9, #37449, lsl #32
+; CHECK-GI-NEXT:    movk x9, #18724, lsl #48
+; CHECK-GI-NEXT:    umulh x9, x8, x9
+; CHECK-GI-NEXT:    lsr x9, x9, #1
+; CHECK-GI-NEXT:    lsl x10, x9, #3
+; CHECK-GI-NEXT:    sub x9, x10, x9
+; CHECK-GI-NEXT:    sub x8, x8, x9
+; CHECK-GI-NEXT:    bfi x0, x8, #3, #61
+; CHECK-GI-NEXT:    ret
+entry:
+  %s = urem i128 %a, 56
+  ret i128 %s
+}
+
+define i128 @udi128_7(i128 %a, i128 %b) {
+; CHECK-SD-LABEL: udi128_7:
+; CHECK-SD:       // %bb.0: // %entry
+; CHECK-SD-NEXT:    extr x8, x1, x0, #60
+; CHECK-SD-NEXT:    and x9, x0, #0xfffffffffffffff
+; CHECK-SD-NEXT:    mov x11, #46811 // =0xb6db
+; CHECK-SD-NEXT:    movk x11, #56173, lsl #16
+; CHECK-SD-NEXT:    and x8, x8, #0xfffffffffffffff
+; CHECK-SD-NEXT:    movk x11, #28086, lsl #32
+; CHECK-SD-NEXT:    add x8, x9, x8
+; CHECK-SD-NEXT:    mov x9, #18725 // =0x4925
+; CHECK-SD-NEXT:    movk x11, #46811, lsl #48
+; CHECK-SD-NEXT:    movk x9, #9362, lsl #16
+; CHECK-SD-NEXT:    add x8, x8, x1, lsr #56
+; CHECK-SD-NEXT:    movk x9, #37449, lsl #32
+; CHECK-SD-NEXT:    movk x9, #18724, lsl #48
+; CHECK-SD-NEXT:    umulh x9, x8, x9
+; CHECK-SD-NEXT:    lsr x9, x9, #1
+; CHECK-SD-NEXT:    sub x9, x9, x9, lsl #3
+; CHECK-SD-NEXT:    add x8, x8, x9
+; CHECK-SD-NEXT:    mov x9, #28087 // =0x6db7
+; CHECK-SD-NEXT:    movk x9, #46811, lsl #16
+; CHECK-SD-NEXT:    subs x8, x0, x8
+; CHECK-SD-NEXT:    movk x9, #56173, lsl #32
+; CHECK-SD-NEXT:    movk x9, #28086, lsl #48
+; CHECK-SD-NEXT:    umulh x10, x8, x9
+; CHECK-SD-NEXT:    mul x0, x8, x9
+; CHECK-SD-NEXT:    madd x10, x8, x11, x10
+; CHECK-SD-NEXT:    sbc x11, x1, xzr
+; CHECK-SD-NEXT:    madd x1, x11, x9, x10
+; CHECK-SD-NEXT:    ret
+;
+; CHECK-GI-LABEL: udi128_7:
+; CHECK-GI:       // %bb.0: // %entry
+; CHECK-GI-NEXT:    extr x8, x1, x0, #60
+; CHECK-GI-NEXT:    and x9, x0, #0xfffffffffffffff
+; CHECK-GI-NEXT:    and x8, x8, #0xfffffffffffffff
+; CHECK-GI-NEXT:    add x8, x9, x8
+; CHECK-GI-NEXT:    mov x9, #18725 // =0x4925
+; CHECK-GI-NEXT:    movk x9, #9362, lsl #16
+; CHECK-GI-NEXT:    add x8, x8, x1, lsr #56
+; CHECK-GI-NEXT:    movk x9, #37449, lsl #32
+; CHECK-GI-NEXT:    movk x9, #18724, lsl #48
+; CHECK-GI-NEXT:    umulh x9, x8, x9
+; CHECK-GI-NEXT:    lsr x9, x9, #1
+; CHECK-GI-NEXT:    lsl x10, x9, #3
+; CHECK-GI-NEXT:    sub x9, x10, x9
+; CHECK-GI-NEXT:    mov x10, #46811 // =0xb6db
+; CHECK-GI-NEXT:    movk x10, #56173, lsl #16
+; CHECK-GI-NEXT:    sub x8, x8, x9
+; CHECK-GI-NEXT:    mov x9, #28087 // =0x6db7
+; CHECK-GI-NEXT:    movk x10, #28086, lsl #32
+; CHECK-GI-NEXT:    subs x8, x0, x8
+; CHECK-GI-NEXT:    movk x9, #46811, lsl #16
+; CHECK-GI-NEXT:    movk x10, #46811, lsl #48
+; CHECK-GI-NEXT:    movk x9, #56173, lsl #32
+; CHECK-GI-NEXT:    sbc x11, x1, xzr
+; CHECK-GI-NEXT:    mul x10, x8, x10
+; CHECK-GI-NEXT:    movk x9, #28086, lsl #48
+; CHECK-GI-NEXT:    mul x0, x8, x9
+; CHECK-GI-NEXT:    umulh x8, x8, x9
+; CHECK-GI-NEXT:    madd x9, x11, x9, x10
+; CHECK-GI-NEXT:    add x1, x9, x8
+; CHECK-GI-NEXT:    ret
+entry:
+  %s = udiv i128 %a, 7
+  ret i128 %s
+}
+
+define i128 @udi128_22(i128 %a, i128 %b) {
+; CHECK-SD-LABEL: udi128_22:
+; CHECK-SD:       // %bb.0: // %entry
+; CHECK-SD-NEXT:    extr x8, x1, x0, #61
+; CHECK-SD-NEXT:    extr x9, x1, x0, #1
+; CHECK-SD-NEXT:    mov w12, #11 // =0xb
+; CHECK-SD-NEXT:    and x8, x8, #0xfffffffffffffff
+; CHECK-SD-NEXT:    and x10, x9, #0xfffffffffffffff
+; CHECK-SD-NEXT:    add x8, x10, x8
+; CHECK-SD-NEXT:    mov x10, #35747 // =0x8ba3
+; CHECK-SD-NEXT:    movk x10, #47662, lsl #16
+; CHECK-SD-NEXT:    add x8, x8, x1, lsr #57
+; CHECK-SD-NEXT:    movk x10, #41704, lsl #32
+; CHECK-SD-NEXT:    movk x10, #11915, lsl #48
+; CHECK-SD-NEXT:    umulh x11, x8, x10
+; CHECK-SD-NEXT:    lsr x11, x11, #1
+; CHECK-SD-NEXT:    msub x8, x11, x12, x8
+; CHECK-SD-NEXT:    mov x11, #59578 // =0xe8ba
+; CHECK-SD-NEXT:    lsr x12, x1, #1
+; CHECK-SD-NEXT:    movk x11, #35746, lsl #16
+; CHECK-SD-NEXT:    movk x11, #47662, lsl #32
+; CHECK-SD-NEXT:    movk x11, #41704, lsl #48
+; CHECK-SD-NEXT:    subs x8, x9, x8
+; CHECK-SD-NEXT:    umulh x9, x8, x10
+; CHECK-SD-NEXT:    mul x0, x8, x10
+; CHECK-SD-NEXT:    madd x9, x8, x11, x9
+; CHECK-SD-NEXT:    sbc x11, x12, xzr
+; CHECK-SD-NEXT:    madd x1, x11, x10, x9
+; CHECK-SD-NEXT:    ret
+;
+; CHECK-GI-LABEL: udi128_22:
+; CHECK-GI:       // %bb.0: // %entry
+; CHECK-GI-NEXT:    extr x8, x1, x0, #1
+; CHECK-GI-NEXT:    lsr x9, x1, #1
+; CHECK-GI-NEXT:    mov w13, #11 // =0xb
+; CHECK-GI-NEXT:    extr x10, x9, x8, #60
+; CHECK-GI-NEXT:    and x11, x8, #0xfffffffffffffff
+; CHECK-GI-NEXT:    and x10, x10, #0xfffffffffffffff
+; CHECK-GI-NEXT:    add x10, x11, x10
+; CHECK-GI-NEXT:    mov x11, #35747 // =0x8ba3
+; CHECK-GI-NEXT:    movk x11, #47662, lsl #16
+; CHECK-GI-NEXT:    add x10, x10, x1, lsr #57
+; CHECK-GI-NEXT:    movk x11, #41704, lsl #32
+; CHECK-GI-NEXT:    movk x11, #11915, lsl #48
+; CHECK-GI-NEXT:    umulh x12, x10, x11
+; CHECK-GI-NEXT:    lsr x12, x12, #1
+; CHECK-GI-NEXT:    msub x10, x12, x13, x10
+; CHECK-GI-NEXT:    subs x8, x8, x10
+; CHECK-GI-NEXT:    mov x10, #59578 // =0xe8ba
+; CHECK-GI-NEXT:    movk x10, #35746, lsl #16
+; CHECK-GI-NEXT:    sbc x9, x9, xzr
+; CHECK-GI-NEXT:    mul x0, x8, x11
+; CHECK-GI-NEXT:    movk x10, #47662, lsl #32
+; CHECK-GI-NEXT:    movk x10, #41704, lsl #48
+; CHECK-GI-NEXT:    mul x10, x8, x10
+; CHECK-GI-NEXT:    umulh x8, x8, x11
+; CHECK-GI-NEXT:    madd x9, x9, x11, x10
+; CHECK-GI-NEXT:    add x1, x9, x8
+; CHECK-GI-NEXT:    ret
+entry:
+  %s = udiv i128 %a, 22
+  ret i128 %s
+}
+
+define i128 @udi128_100(i128 %a, i128 %b) {
+; CHECK-SD-LABEL: udi128_100:
+; CHECK-SD:       // %bb.0: // %entry
+; CHECK-SD-NEXT:    extr x8, x1, x0, #62
+; CHECK-SD-NEXT:    extr x9, x1, x0, #2
+; CHECK-SD-NEXT:    mov w11, #25 // =0x19
+; CHECK-SD-NEXT:    lsr x12, x1, #2
+; CHECK-SD-NEXT:    and x8, x8, #0xfffffffffffffff
+; CHECK-SD-NEXT:    and x10, x9, #0xfffffffffffffff
+; CHECK-SD-NEXT:    add x8, x10, x8
+; CHECK-SD-NEXT:    mov x10, #62915 // =0xf5c3
+; CHECK-SD-NEXT:    movk x10, #23592, lsl #16
+; CHECK-SD-NEXT:    add x8, x8, x1, lsr #58
+; CHECK-SD-NEXT:    movk x10, #49807, lsl #32
+; CHECK-SD-NEXT:    movk x10, #10485, lsl #48
+; CHECK-SD-NEXT:    umulh x10, x8, x10
+; CHECK-SD-NEXT:    lsr x10, x10, #2
+; CHECK-SD-NEXT:    msub x8, x10, x11, x8
+; CHECK-SD-NEXT:    mov x10, #23593 // =0x5c29
+; CHECK-SD-NEXT:    mov x11, #62914 // =0xf5c2
+; CHECK-SD-NEXT:    movk x10, #49807, lsl #16
+; CHECK-SD-NEXT:    movk x11, #23592, lsl #16
+; CHECK-SD-NEXT:    movk x10, #10485, lsl #32
+; CHECK-SD-NEXT:    movk x11, #49807, lsl #32
+; CHECK-SD-NEXT:    movk x10, #36700, lsl #48
+; CHECK-SD-NEXT:    movk x11, #10485, lsl #48
+; CHECK-SD-NEXT:    subs x8, x9, x8
+; CHECK-SD-NEXT:    umulh x9, x8, x10
+; CHECK-SD-NEXT:    mul x0, x8, x10
+; CHECK-SD-NEXT:    madd x9, x8, x11, x9
+; CHECK-SD-NEXT:    sbc x11, x12, xzr
+; CHECK-SD-NEXT:    madd x1, x11, x10, x9
+; CHECK-SD-NEXT:    ret
+;
+; CHECK-GI-LABEL: udi128_100:
+; CHECK-GI:       // %bb.0: // %entry
+; CHECK-GI-NEXT:    extr x8, x1, x0, #2
+; CHECK-GI-NEXT:    lsr x9, x1, #2
+; CHECK-GI-NEXT:    mov w12, #25 // =0x19
+; CHECK-GI-NEXT:    extr x10, x9, x8, #60
+; CHECK-GI-NEXT:    and x11, x8, #0xfffffffffffffff
+; CHECK-GI-NEXT:    and x10, x10, #0xfffffffffffffff
+; CHECK-GI-NEXT:    add x10, x11, x10
+; CHECK-GI-NEXT:    mov x11, #62915 // =0xf5c3
+; CHECK-GI-NEXT:    movk x11, #23592, lsl #16
+; CHECK-GI-NEXT:    add x10, x10, x1, lsr #58
+; CHECK-GI-NEXT:    movk x11, #49807, lsl #32
+; CHECK-GI-NEXT:    movk x11, #10485, lsl #48
+; CHECK-GI-NEXT:    umulh x11, x10, x11
+; CHECK-GI-NEXT:    lsr x11, x11, #2
+; CHECK-GI-NEXT:    msub x10, x11, x12, x10
+; CHECK-GI-NEXT:    mov x11, #23593 // =0x5c29
+; CHECK-GI-NEXT:    movk x11, #49807, lsl #16
+; CHECK-GI-NEXT:    movk x11, #10485, lsl #32
+; CHECK-GI-NEXT:    movk x11, #36700, lsl #48
+; CHECK-GI-NEXT:    subs x8, x8, x10
 ; CHECK-GI-NEXT:    mov x10, #62914 // =0xf5c2
-; CHECK-GI-NEXT:    movk x8, #49807, lsl #16
 ; CHECK-GI-NEXT:    movk x10, #23592, lsl #16
-; CHECK-GI-NEXT:    movk x8, #10485, lsl #32
+; CHECK-GI-NEXT:    sbc x9, x9, xzr
+; CHECK-GI-NEXT:    mul x0, x8, x11
 ; CHECK-GI-NEXT:    movk x10, #49807, lsl #32
-; CHECK-GI-NEXT:    movk x8, #36700, lsl #48
 ; CHECK-GI-NEXT:    movk x10, #10485, lsl #48
+; CHECK-GI-NEXT:    mul x10, x8, x10
+; CHECK-GI-NEXT:    umulh x8, x8, x11
+; CHECK-GI-NEXT:    madd x9, x9, x11, x10
+; CHECK-GI-NEXT:    add x1, x9, x8
+; CHECK-GI-NEXT:    ret
+entry:
+  %s = udiv i128 %a, 100
+  ret i128 %s
+}
+
+define i128 @udi128_67(i128 %a, i128 %b) {
+; CHECK-SD-LABEL: udi128_67:
+; CHECK-SD:       // %bb.0: // %entry
+; CHECK-SD-NEXT:    str x30, [sp, #-16]! // 8-byte Folded Spill
+; CHECK-SD-NEXT:    .cfi_def_cfa_offset 16
+; CHECK-SD-NEXT:    .cfi_offset w30, -16
+; CHECK-SD-NEXT:    mov w2, #67 // =0x43
+; CHECK-SD-NEXT:    mov x3, xzr
+; CHECK-SD-NEXT:    bl __udivti3
+; CHECK-SD-NEXT:    ldr x30, [sp], #16 // 8-byte Folded Reload
+; CHECK-SD-NEXT:    ret
+;
+; CHECK-GI-LABEL: udi128_67:
+; CHECK-GI:       // %bb.0: // %entry
+; CHECK-GI-NEXT:    mov x8, #52821 // =0xce55
+; CHECK-GI-NEXT:    mov x10, #-50864 // =0xffffffffffff3950
+; CHECK-GI-NEXT:    movk x8, #57710, lsl #16
+; CHECK-GI-NEXT:    movk x10, #34235, lsl #16
+; CHECK-GI-NEXT:    movk x8, #25431, lsl #32
+; CHECK-GI-NEXT:    eor x10, x10, x10, lsl #33
+; CHECK-GI-NEXT:    movk x8, #15650, lsl #48
 ; CHECK-GI-NEXT:    mul x9, x1, x8
 ; CHECK-GI-NEXT:    mul x11, x0, x10
 ; CHECK-GI-NEXT:    umulh x12, x0, x8
@@ -647,17 +959,71 @@ define i128 @ui128_100(i128 %a, i128 %b) {
 ; CHECK-GI-NEXT:    add x10, x11, x12
 ; CHECK-GI-NEXT:    add x8, x8, x14
 ; CHECK-GI-NEXT:    add x8, x8, x10
-; CHECK-GI-NEXT:    mov w10, #100 // =0x64
-; CHECK-GI-NEXT:    extr x9, x8, x9, #4
-; CHECK-GI-NEXT:    lsr x8, x8, #4
-; CHECK-GI-NEXT:    umulh x11, x9, x10
-; CHECK-GI-NEXT:    mul x9, x9, x10
-; CHECK-GI-NEXT:    madd x8, x8, x10, x11
-; CHECK-GI-NEXT:    subs x0, x0, x9
-; CHECK-GI-NEXT:    sbc x1, x1, x8
+; CHECK-GI-NEXT:    extr x0, x8, x9, #6
+; CHECK-GI-NEXT:    lsr x1, x8, #6
 ; CHECK-GI-NEXT:    ret
 entry:
-  %s = urem i128 %a, 100
+  %s = udiv i128 %a, 67
+  ret i128 %s
+}
+
+define i128 @udi128_large_const(i128 %a, i128 %b) {
+; CHECK-LABEL: udi128_large_const:
+; CHECK:       // %bb.0: // %entry
+; CHECK-NEXT:    mov x8, x1
+; CHECK-NEXT:    mov x1, xzr
+; CHECK-NEXT:    lsr x0, x8, #2
+; CHECK-NEXT:    ret
+entry:
+  %s = udiv i128 %a, 73786976294838206464
+  ret i128 %s
+}
+
+define i128 @udi128_large_const_wrapped(i128 %a, i128 %b) {
+; CHECK-SD-LABEL: udi128_large_const_wrapped:
+; CHECK-SD:       // %bb.0: // %entry
+; CHECK-SD-NEXT:    str x30, [sp, #-16]! // 8-byte Folded Spill
+; CHECK-SD-NEXT:    .cfi_def_cfa_offset 16
+; CHECK-SD-NEXT:    .cfi_offset w30, -16
+; CHECK-SD-NEXT:    mov x2, xzr
+; CHECK-SD-NEXT:    mov x3, #-4 // =0xfffffffffffffffc
+; CHECK-SD-NEXT:    bl __udivti3
+; CHECK-SD-NEXT:    ldr x30, [sp], #16 // 8-byte Folded Reload
+; CHECK-SD-NEXT:    ret
+;
+; CHECK-GI-LABEL: udi128_large_const_wrapped:
+; CHECK-GI:       // %bb.0: // %entry
+; CHECK-GI-NEXT:    lsr x8, x1, #2
+; CHECK-GI-NEXT:    mov w9, #4 // =0x4
+; CHECK-GI-NEXT:    mov w11, #17 // =0x11
+; CHECK-GI-NEXT:    and x14, xzr, #0x1
+; CHECK-GI-NEXT:    and x15, xzr, #0x1
+; CHECK-GI-NEXT:    mul x10, x8, x9
+; CHECK-GI-NEXT:    add x14, x14, x15
+; CHECK-GI-NEXT:    and x15, xzr, #0x1
+; CHECK-GI-NEXT:    umulh x12, x8, x11
+; CHECK-GI-NEXT:    umulh x11, xzr, x11
+; CHECK-GI-NEXT:    umulh x13, x8, x9
+; CHECK-GI-NEXT:    cmn x10, x12
+; CHECK-GI-NEXT:    and x10, xzr, #0x1
+; CHECK-GI-NEXT:    and x12, xzr, #0x1
+; CHECK-GI-NEXT:    umulh x9, xzr, x9
+; CHECK-GI-NEXT:    add x10, x10, x12
+; CHECK-GI-NEXT:    cset w12, hs
+; CHECK-GI-NEXT:    and x12, x12, #0x1
+; CHECK-GI-NEXT:    add x10, x10, x14
+; CHECK-GI-NEXT:    and x14, xzr, #0x1
+; CHECK-GI-NEXT:    umulh x8, x8, xzr
+; CHECK-GI-NEXT:    add x12, x15, x12
+; CHECK-GI-NEXT:    add x10, x10, x14
+; CHECK-GI-NEXT:    add x9, x11, x9
+; CHECK-GI-NEXT:    add x11, x11, x13
+; CHECK-GI-NEXT:    add x0, x11, x12
+; CHECK-GI-NEXT:    add x8, x9, x8
+; CHECK-GI-NEXT:    add x1, x8, x10
+; CHECK-GI-NEXT:    ret
+entry:
+  %s = udiv i128 %a, -73786976294838206464
   ret i128 %s
 }
 
@@ -1797,9 +2163,9 @@ define <4 x i16> @sv4i16_7(<4 x i16> %d, <4 x i16> %e) {
 ;
 ; CHECK-GI-LABEL: sv4i16_7:
 ; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    adrp x8, .LCPI44_0
+; CHECK-GI-NEXT:    adrp x8, .LCPI53_0
 ; CHECK-GI-NEXT:    movi v3.4h, #7
-; CHECK-GI-NEXT:    ldr d1, [x8, :lo12:.LCPI44_0]
+; CHECK-GI-NEXT:    ldr d1, [x8, :lo12:.LCPI53_0]
 ; CHECK-GI-NEXT:    smull v1.4s, v0.4h, v1.4h
 ; CHECK-GI-NEXT:    shrn v1.4h, v1.4s, #16
 ; CHECK-GI-NEXT:    sshr v2.4h, v1.4h, #1
@@ -1827,9 +2193,9 @@ define <4 x i16> @sv4i16_100(<4 x i16> %d, <4 x i16> %e) {
 ;
 ; CHECK-GI-LABEL: sv4i16_100:
 ; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    adrp x8, .LCPI45_0
+; CHECK-GI-NEXT:    adrp x8, .LCPI54_0
 ; CHECK-GI-NEXT:    movi v3.4h, #100
-; CHECK-GI-NEXT:    ldr d1, [x8, :lo12:.LCPI45_0]
+; CHECK-GI-NEXT:    ldr d1, [x8, :lo12:.LCPI54_0]
 ; CHECK-GI-NEXT:    smull v1.4s, v0.4h, v1.4h
 ; CHECK-GI-NEXT:    shrn v1.4h, v1.4s, #16
 ; CHECK-GI-NEXT:    sshr v2.4h, v1.4h, #3
@@ -1858,9 +2224,9 @@ define <8 x i16> @sv8i16_7(<8 x i16> %d, <8 x i16> %e) {
 ;
 ; CHECK-GI-LABEL: sv8i16_7:
 ; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    adrp x8, .LCPI46_0
+; CHECK-GI-NEXT:    adrp x8, .LCPI55_0
 ; CHECK-GI-NEXT:    movi v3.8h, #7
-; CHECK-GI-NEXT:    ldr q1, [x8, :lo12:.LCPI46_0]
+; CHECK-GI-NEXT:    ldr q1, [x8, :lo12:.LCPI55_0]
 ; CHECK-GI-NEXT:    smull2 v2.4s, v0.8h, v1.8h
 ; CHECK-GI-NEXT:    smull v1.4s, v0.4h, v1.4h
 ; CHECK-GI-NEXT:    uzp2 v1.8h, v1.8h, v2.8h
@@ -1890,9 +2256,9 @@ define <8 x i16> @sv8i16_100(<8 x i16> %d, <8 x i16> %e) {
 ;
 ; CHECK-GI-LABEL: sv8i16_100:
 ; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    adrp x8, .LCPI47_0
+; CHECK-GI-NEXT:    adrp x8, .LCPI56_0
 ; CHECK-GI-NEXT:    movi v3.8h, #100
-; CHECK-GI-NEXT:    ldr q1, [x8, :lo12:.LCPI47_0]
+; CHECK-GI-NEXT:    ldr q1, [x8, :lo12:.LCPI56_0]
 ; CHECK-GI-NEXT:    smull2 v2.4s, v0.8h, v1.8h
 ; CHECK-GI-NEXT:    smull v1.4s, v0.4h, v1.4h
 ; CHECK-GI-NEXT:    uzp2 v1.8h, v1.8h, v2.8h
@@ -2158,8 +2524,8 @@ define <4 x i16> @uv4i16_7(<4 x i16> %d, <4 x i16> %e) {
 ;
 ; CHECK-GI-LABEL: uv4i16_7:
 ; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    adrp x8, .LCPI52_0
-; CHECK-GI-NEXT:    ldr d1, [x8, :lo12:.LCPI52_0]
+; CHECK-GI-NEXT:    adrp x8, .LCPI61_0
+; CHECK-GI-NEXT:    ldr d1, [x8, :lo12:.LCPI61_0]
 ; CHECK-GI-NEXT:    umull v1.4s, v0.4h, v1.4h
 ; CHECK-GI-NEXT:    shrn v1.4h, v1.4s, #16
 ; CHECK-GI-NEXT:    sub v2.4h, v0.4h, v1.4h
@@ -2188,9 +2554,9 @@ define <4 x i16> @uv4i16_100(<4 x i16> %d, <4 x i16> %e) {
 ;
 ; CHECK-GI-LABEL: uv4i16_100:
 ; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    adrp x8, .LCPI53_0
+; CHECK-GI-NEXT:    adrp x8, .LCPI62_0
 ; CHECK-GI-NEXT:    ushr v1.4h, v0.4h, #2
-; CHECK-GI-NEXT:    ldr d2, [x8, :lo12:.LCPI53_0]
+; CHECK-GI-NEXT:    ldr d2, [x8, :lo12:.LCPI62_0]
 ; CHECK-GI-NEXT:    umull v1.4s, v1.4h, v2.4h
 ; CHECK-GI-NEXT:    movi v2.4h, #100
 ; CHECK-GI-NEXT:    ushr v1.4s, v1.4s, #17
@@ -2219,8 +2585,8 @@ define <8 x i16> @uv8i16_7(<8 x i16> %d, <8 x i16> %e) {
 ;
 ; CHECK-GI-LABEL: uv8i16_7:
 ; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    adrp x8, .LCPI54_0
-; CHECK-GI-NEXT:    ldr q1, [x8, :lo12:.LCPI54_0]
+; CHECK-GI-NEXT:    adrp x8, .LCPI63_0
+; CHECK-GI-NEXT:    ldr q1, [x8, :lo12:.LCPI63_0]
 ; CHECK-GI-NEXT:    umull2 v2.4s, v0.8h, v1.8h
 ; CHECK-GI-NEXT:    umull v1.4s, v0.4h, v1.4h
 ; CHECK-GI-NEXT:    uzp2 v1.8h, v1.8h, v2.8h
@@ -2251,9 +2617,9 @@ define <8 x i16> @uv8i16_100(<8 x i16> %d, <8 x i16> %e) {
 ;
 ; CHECK-GI-LABEL: uv8i16_100:
 ; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    adrp x8, .LCPI55_0
+; CHECK-GI-NEXT:    adrp x8, .LCPI64_0
 ; CHECK-GI-NEXT:    ushr v1.8h, v0.8h, #2
-; CHECK-GI-NEXT:    ldr q2, [x8, :lo12:.LCPI55_0]
+; CHECK-GI-NEXT:    ldr q2, [x8, :lo12:.LCPI64_0]
 ; CHECK-GI-NEXT:    umull2 v3.4s, v1.8h, v2.8h
 ; CHECK-GI-NEXT:    umull v1.4s, v1.4h, v2.4h
 ; CHECK-GI-NEXT:    movi v2.8h, #100
@@ -2283,9 +2649,9 @@ define <2 x i32> @sv2i32_7(<2 x i32> %d, <2 x i32> %e) {
 ;
 ; CHECK-GI-LABEL: sv2i32_7:
 ; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    adrp x8, .LCPI56_0
+; CHECK-GI-NEXT:    adrp x8, .LCPI65_0
 ; CHECK-GI-NEXT:    movi v3.2s, #7
-; CHECK-GI-NEXT:    ldr d1, [x8, :lo12:.LCPI56_0]
+; CHECK-GI-NEXT:    ldr d1, [x8, :lo12:.LCPI65_0]
 ; CHECK-GI-NEXT:    smull v1.2d, v0.2s, v1.2s
 ; CHECK-GI-NEXT:    shrn v1.2s, v1.2d, #32
 ; CHECK-GI-NEXT:    add v1.2s, v1.2s, v0.2s
@@ -2315,9 +2681,9 @@ define <2 x i32> @sv2i32_100(<2 x i32> %d, <2 x i32> %e) {
 ;
 ; CHECK-GI-LABEL: sv2i32_100:
 ; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    adrp x8, .LCPI57_0
+; CHECK-GI-NEXT:    adrp x8, .LCPI66_0
 ; CHECK-GI-NEXT:    movi v3.2s, #100
-; CHECK-GI-NEXT:    ldr d1, [x8, :lo12:.LCPI57_0]
+; CHECK-GI-NEXT:    ldr d1, [x8, :lo12:.LCPI66_0]
 ; CHECK-GI-NEXT:    smull v1.2d, v0.2s, v1.2s
 ; CHECK-GI-NEXT:    shrn v1.2s, v1.2d, #32
 ; CHECK-GI-NEXT:    sshr v2.2s, v1.2s, #5
@@ -2431,9 +2797,9 @@ define <4 x i32> @sv4i32_7(<4 x i32> %d, <4 x i32> %e) {
 ;
 ; CHECK-GI-LABEL: sv4i32_7:
 ; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    adrp x8, .LCPI60_0
+; CHECK-GI-NEXT:    adrp x8, .LCPI69_0
 ; CHECK-GI-NEXT:    movi v3.4s, #7
-; CHECK-GI-NEXT:    ldr q1, [x8, :lo12:.LCPI60_0]
+; CHECK-GI-NEXT:    ldr q1, [x8, :lo12:.LCPI69_0]
 ; CHECK-GI-NEXT:    smull2 v2.2d, v0.4s, v1.4s
 ; CHECK-GI-NEXT:    smull v1.2d, v0.2s, v1.2s
 ; CHECK-GI-NEXT:    uzp2 v1.4s, v1.4s, v2.4s
@@ -2465,9 +2831,9 @@ define <4 x i32> @sv4i32_100(<4 x i32> %d, <4 x i32> %e) {
 ;
 ; CHECK-GI-LABEL: sv4i32_100:
 ; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    adrp x8, .LCPI61_0
+; CHECK-GI-NEXT:    adrp x8, .LCPI70_0
 ; CHECK-GI-NEXT:    movi v3.4s, #100
-; CHECK-GI-NEXT:    ldr q1, [x8, :lo12:.LCPI61_0]
+; CHECK-GI-NEXT:    ldr q1, [x8, :lo12:.LCPI70_0]
 ; CHECK-GI-NEXT:    smull2 v2.2d, v0.4s, v1.4s
 ; CHECK-GI-NEXT:    smull v1.2d, v0.2s, v1.2s
 ; CHECK-GI-NEXT:    uzp2 v1.4s, v1.4s, v2.4s
@@ -2500,8 +2866,8 @@ define <2 x i32> @uv2i32_7(<2 x i32> %d, <2 x i32> %e) {
 ;
 ; CHECK-GI-LABEL: uv2i32_7:
 ; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    adrp x8, .LCPI62_0
-; CHECK-GI-NEXT:    ldr d1, [x8, :lo12:.LCPI62_0]
+; CHECK-GI-NEXT:    adrp x8, .LCPI71_0
+; CHECK-GI-NEXT:    ldr d1, [x8, :lo12:.LCPI71_0]
 ; CHECK-GI-NEXT:    umull v1.2d, v0.2s, v1.2s
 ; CHECK-GI-NEXT:    shrn v1.2s, v1.2d, #32
 ; CHECK-GI-NEXT:    sub v2.2s, v0.2s, v1.2s
@@ -2530,9 +2896,9 @@ define <2 x i32> @uv2i32_100(<2 x i32> %d, <2 x i32> %e) {
 ;
 ; CHECK-GI-LABEL: uv2i32_100:
 ; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    adrp x8, .LCPI63_0
+; CHECK-GI-NEXT:    adrp x8, .LCPI72_0
 ; CHECK-GI-NEXT:    movi v2.2s, #100
-; CHECK-GI-NEXT:    ldr d1, [x8, :lo12:.LCPI63_0]
+; CHECK-GI-NEXT:    ldr d1, [x8, :lo12:.LCPI72_0]
 ; CHECK-GI-NEXT:    umull v1.2d, v0.2s, v1.2s
 ; CHECK-GI-NEXT:    ushr v1.2d, v1.2d, #37
 ; CHECK-GI-NEXT:    xtn v1.2s, v1.2d
@@ -2562,9 +2928,9 @@ define <3 x i32> @uv3i32_7(<3 x i32> %d, <3 x i32> %e) {
 ; CHECK-GI-LABEL: uv3i32_7:
 ; CHECK-GI:       // %bb.0: // %entry
 ; CHECK-GI-NEXT:    mov v1.s[0], v0.s[0]
-; CHECK-GI-NEXT:    adrp x8, .LCPI64_0
+; CHECK-GI-NEXT:    adrp x8, .LCPI73_0
 ; CHECK-GI-NEXT:    mov w9, #18725 // =0x4925
-; CHECK-GI-NEXT:    ldr d2, [x8, :lo12:.LCPI64_0]
+; CHECK-GI-NEXT:    ldr d2, [x8, :lo12:.LCPI73_0]
 ; CHECK-GI-NEXT:    mov w8, v0.s[2]
 ; CHECK-GI-NEXT:    movk w9, #9362, lsl #16
 ; CHECK-GI-NEXT:    mov w10, #1 // =0x1
@@ -2620,9 +2986,9 @@ define <3 x i32> @uv3i32_100(<3 x i32> %d, <3 x i32> %e) {
 ; CHECK-GI-LABEL: uv3i32_100:
 ; CHECK-GI:       // %bb.0: // %entry
 ; CHECK-GI-NEXT:    mov v1.s[0], v0.s[0]
-; CHECK-GI-NEXT:    adrp x8, .LCPI65_0
+; CHECK-GI-NEXT:    adrp x8, .LCPI74_0
 ; CHECK-GI-NEXT:    mov w9, v0.s[2]
-; CHECK-GI-NEXT:    ldr d2, [x8, :lo12:.LCPI65_0]
+; CHECK-GI-NEXT:    ldr d2, [x8, :lo12:.LCPI74_0]
 ; CHECK-GI-NEXT:    mov w8, #5 // =0x5
 ; CHECK-GI-NEXT:    mov w10, #34079 // =0x851f
 ; CHECK-GI-NEXT:    fmov s3, w8
@@ -2671,8 +3037,8 @@ define <4 x i32> @uv4i32_7(<4 x i32> %d, <4 x i32> %e) {
 ;
 ; CHECK-GI-LABEL: uv4i32_7:
 ; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    adrp x8, .LCPI66_0
-; CHECK-GI-NEXT:    ldr q1, [x8, :lo12:.LCPI66_0]
+; CHECK-GI-NEXT:    adrp x8, .LCPI75_0
+; CHECK-GI-NEXT:    ldr q1, [x8, :lo12:.LCPI75_0]
 ; CHECK-GI-NEXT:    umull2 v2.2d, v0.4s, v1.4s
 ; CHECK-GI-NEXT:    umull v1.2d, v0.2s, v1.2s
 ; CHECK-GI-NEXT:    uzp2 v1.4s, v1.4s, v2.4s
@@ -2703,8 +3069,8 @@ define <4 x i32> @uv4i32_100(<4 x i32> %d, <4 x i32> %e) {
 ;
 ; CHECK-GI-LABEL: uv4i32_100:
 ; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    adrp x8, .LCPI67_0
-; CHECK-GI-NEXT:    ldr q1, [x8, :lo12:.LCPI67_0]
+; CHECK-GI-NEXT:    adrp x8, .LCPI76_0
+; CHECK-GI-NEXT:    ldr q1, [x8, :lo12:.LCPI76_0]
 ; CHECK-GI-NEXT:    umull2 v2.2d, v0.4s, v1.4s
 ; CHECK-GI-NEXT:    umull v1.2d, v0.2s, v1.2s
 ; CHECK-GI-NEXT:    uzp2 v1.4s, v1.4s, v2.4s
@@ -2749,8 +3115,8 @@ define <2 x i64> @sv2i64_7(<2 x i64> %d, <2 x i64> %e) {
 ; CHECK-GI-NEXT:    sdiv x8, x10, x8
 ; CHECK-GI-NEXT:    fmov d1, x9
 ; CHECK-GI-NEXT:    mov v1.d[1], x8
-; CHECK-GI-NEXT:    adrp x8, .LCPI68_0
-; CHECK-GI-NEXT:    ldr q2, [x8, :lo12:.LCPI68_0]
+; CHECK-GI-NEXT:    adrp x8, .LCPI77_0
+; CHECK-GI-NEXT:    ldr q2, [x8, :lo12:.LCPI77_0]
 ; CHECK-GI-NEXT:    fmov x11, d2
 ; CHECK-GI-NEXT:    mov x9, v2.d[1]
 ; CHECK-GI-NEXT:    fmov x10, d1
@@ -2799,8 +3165,8 @@ define <2 x i64> @sv2i64_100(<2 x i64> %d, <2 x i64> %e) {
 ; CHECK-GI-NEXT:    sdiv x8, x10, x8
 ; CHECK-GI-NEXT:    fmov d1, x9
 ; CHECK-GI-NEXT:    mov v1.d[1], x8
-; CHECK-GI-NEXT:    adrp x8, .LCPI69_0
-; CHECK-GI-NEXT:    ldr q2, [x8, :lo12:.LCPI69_0]
+; CHECK-GI-NEXT:    adrp x8, .LCPI78_0
+; CHECK-GI-NEXT:    ldr q2, [x8, :lo12:.LCPI78_0]
 ; CHECK-GI-NEXT:    fmov x11, d2
 ; CHECK-GI-NEXT:    mov x9, v2.d[1]
 ; CHECK-GI-NEXT:    fmov x10, d1
@@ -2853,10 +3219,10 @@ define <2 x i64> @uv2i64_7(<2 x i64> %d, <2 x i64> %e) {
 ; CHECK-GI-NEXT:    umulh x8, x9, x8
 ; CHECK-GI-NEXT:    fmov d1, x10
 ; CHECK-GI-NEXT:    mov v1.d[1], x8
-; CHECK-GI-NEXT:    adrp x8, .LCPI70_0
+; CHECK-GI-NEXT:    adrp x8, .LCPI79_0
 ; CHECK-GI-NEXT:    sub v2.2d, v0.2d, v1.2d
 ; CHECK-GI-NEXT:    usra v1.2d, v2.2d, #1
-; CHECK-GI-NEXT:    ldr q2, [x8, :lo12:.LCPI70_0]
+; CHECK-GI-NEXT:    ldr q2, [x8, :lo12:.LCPI79_0]
 ; CHECK-GI-NEXT:    fmov x11, d2
 ; CHECK-GI-NEXT:    mov x9, v2.d[1]
 ; CHECK-GI-NEXT:    ushr v1.2d, v1.2d, #2
@@ -2908,8 +3274,8 @@ define <2 x i64> @uv2i64_100(<2 x i64> %d, <2 x i64> %e) {
 ; CHECK-GI-NEXT:    umulh x8, x9, x8
 ; CHECK-GI-NEXT:    fmov d1, x10
 ; CHECK-GI-NEXT:    mov v1.d[1], x8
-; CHECK-GI-NEXT:    adrp x8, .LCPI71_0
-; CHECK-GI-NEXT:    ldr q2, [x8, :lo12:.LCPI71_0]
+; CHECK-GI-NEXT:    adrp x8, .LCPI80_0
+; CHECK-GI-NEXT:    ldr q2, [x8, :lo12:.LCPI80_0]
 ; CHECK-GI-NEXT:    fmov x11, d2
 ; CHECK-GI-NEXT:    mov x9, v2.d[1]
 ; CHECK-GI-NEXT:    ushr v1.2d, v1.2d, #2


### PR DESCRIPTION
This patch improves the lowering of 128-bit unsigned division and remainder by constants (UDIV/UREM) by avoiding  buildUDivOrURemUsingMul or a fallback to libcall (__udivti3/uremti3) for specific divisors.

When a divisor D satisfies the condition (1 << ChunkWidth) % D == 1, the 128-bit value is split into fixed-width chunks (e.g., 30-bit) and summed before applying a smaller UDIV/UREM. This transformation is based on the "remainder by summing digits" trick described in Hacker’s Delight.

This is a porting of SelectionDAG's TargetLowering::expandDIVREMByConstant.