### PR TITLE
[clang][bytecode] Disable tailcalls on i386

### DIFF
--- a/clang/lib/AST/ByteCode/Interp.cpp
+++ b/clang/lib/AST/ByteCode/Interp.cpp
@@ -40,7 +40,8 @@ using namespace clang::interp;
 // We disable it on MSVC generally since it doesn't seem to be able
 // to handle the way we use tailcalls.
 // PPC can't tail-call external calls, which is a problem for InterpNext.
-#if defined(_MSC_VER) || defined(__powerpc__) || !defined(MUSTTAIL)
+#if defined(_MSC_VER) || defined(__powerpc__) || !defined(MUSTTAIL) ||         \
+    defined(__i386__)
 #undef MUSTTAIL
 #define MUSTTAIL
 #define USE_TAILCALLS 0


### PR DESCRIPTION
Works around a build problem with GCC 15 reported in https://github.com/llvm/llvm-project/pull/188419#issuecomment-4148497506