### PR TITLE
clang: Use isAMDGPU triple helper

### DIFF
--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -4467,7 +4467,7 @@ shouldBundleHIPAsmWithNewDriver(const Compilation &C,
     if (!TC)
       continue;
     const llvm::Triple &Tr = TC->getTriple();
-    if (Tr.isSPIRV() || Tr.getArch() != llvm::Triple::amdgcn)
+    if (!Tr.isAMDGPU())
       return false;
     HasAMDGCNHIPDevice = true;
   }


### PR DESCRIPTION
Also remove redundant SPIRV check.