### PR TITLE
[Support] Use namespace qualifiers in Parallel.cpp. NFC

### DIFF
--- a/llvm/lib/Support/Parallel.cpp
+++ b/llvm/lib/Support/Parallel.cpp
@@ -21,21 +21,20 @@
 #include <thread>
 #include <vector>
 
-llvm::ThreadPoolStrategy llvm::parallel::strategy;
+using namespace llvm;
+using namespace llvm::parallel;
 
-namespace llvm {
-namespace parallel {
+llvm::ThreadPoolStrategy parallel::strategy;
+
 #if LLVM_ENABLE_THREADS
 
 #ifdef _WIN32
 static thread_local unsigned threadIndex = UINT_MAX;
 
-unsigned getThreadIndex() { GET_THREAD_INDEX_IMPL; }
+unsigned parallel::getThreadIndex() { GET_THREAD_INDEX_IMPL; }
 #else
-thread_local unsigned threadIndex = UINT_MAX;
+thread_local unsigned parallel::threadIndex = UINT_MAX;
 #endif
-
-namespace detail {
 
 namespace {
 
@@ -211,10 +210,9 @@ Executor *Executor::getDefaultExecutor() {
 #endif
 }
 } // namespace
-} // namespace detail
 
-size_t getThreadCount() {
-  return detail::Executor::getDefaultExecutor()->getThreadCount();
+size_t parallel::getThreadCount() {
+  return Executor::getDefaultExecutor()->getThreadCount();
 }
 #endif
 
@@ -223,12 +221,14 @@ size_t getThreadCount() {
 // lock, only allow the root TaskGroup to run tasks parallelly. In the scenario
 // of nested parallel_for_each(), only the outermost one runs parallelly.
 TaskGroup::TaskGroup()
+    : Parallel(
 #if LLVM_ENABLE_THREADS
-    : Parallel((parallel::strategy.ThreadsRequested != 1) &&
-               (threadIndex == UINT_MAX)) {}
+          strategy.ThreadsRequested != 1 && threadIndex == UINT_MAX
 #else
-    : Parallel(false) {}
+          false
 #endif
+      ) {
+}
 TaskGroup::~TaskGroup() {
   // We must ensure that all the workloads have finished before decrementing the
   // instances count.
@@ -239,7 +239,7 @@ void TaskGroup::spawn(std::function<void()> F) {
 #if LLVM_ENABLE_THREADS
   if (Parallel) {
     L.inc();
-    detail::Executor::getDefaultExecutor()->add([&, F = std::move(F)] {
+    Executor::getDefaultExecutor()->add([&, F = std::move(F)] {
       F();
       L.dec();
     });
@@ -249,13 +249,10 @@ void TaskGroup::spawn(std::function<void()> F) {
   F();
 }
 
-} // namespace parallel
-} // namespace llvm
-
 void llvm::parallelFor(size_t Begin, size_t End,
-                       llvm::function_ref<void(size_t)> Fn) {
+                       function_ref<void(size_t)> Fn) {
 #if LLVM_ENABLE_THREADS
-  if (parallel::strategy.ThreadsRequested != 1) {
+  if (strategy.ThreadsRequested != 1) {
     size_t NumItems = End - Begin;
     if (NumItems == 0)
       return;
@@ -264,7 +261,7 @@ void llvm::parallelFor(size_t Begin, size_t End,
     // For lld, per-file work is somewhat uneven, so a multipler > 1 is safer.
     // While 2 vs 4 vs 8 makes no measurable difference, 4 is used as a
     // reasonable default.
-    size_t NumWorkers = std::min<size_t>(NumItems, parallel::getThreadCount());
+    size_t NumWorkers = std::min<size_t>(NumItems, getThreadCount());
     size_t ChunkSize = std::max(size_t(1), NumItems / (NumWorkers * 4));
     std::atomic<size_t> Idx{Begin};
     auto Worker = [&] {
@@ -278,7 +275,7 @@ void llvm::parallelFor(size_t Begin, size_t End,
       }
     };
 
-    parallel::TaskGroup TG;
+    TaskGroup TG;
     for (size_t I = 0; I != NumWorkers; ++I)
       TG.spawn(Worker);
     return;


### PR DESCRIPTION
Replace `namespace llvm { namespace parallel { ... } }` blocks with
`using namespace` and qualified definitions per
https://llvm.org/docs/CodingStandards.html#use-namespace-qualifiers-to-define-previously-declared-symbols

Also reformat the TaskGroup constructor to avoid clang-format issues
with #if/#endif split across the initializer list.