### PR TITLE
[mlir][ods] resolve the wrong indent issue

### DIFF
--- a/mlir/tools/mlir-tblgen/CppGenUtilities.cpp
+++ b/mlir/tools/mlir-tblgen/CppGenUtilities.cpp
@@ -18,8 +18,8 @@ void mlir::tblgen::emitSummaryAndDescComments(llvm::raw_ostream &os,
                                               llvm::StringRef summary,
                                               llvm::StringRef description,
                                               bool terminateComment) {
-  StringRef trimmedSummary = summary.trim();
-  StringRef trimmedDesc = description.trim();
+  StringRef trimmedSummary = summary.rtrim();
+  StringRef trimmedDesc = description.rtrim();
   raw_indented_ostream ros(os);
 
   bool empty = true;


### PR DESCRIPTION
The `emitSummaryAndDescComments` is used to generate summary and description for tablegen generated classes and structs such as Dialects and Interfaces. The generated summary and description is indented incorrectly in the output generated file. For example `NVGPUDialect.h.inc ` looks like the following:
```cpp
namespace mlir::nvgpu {

/// The `NVGPU` dialect provides a bridge between higher-level target-agnostic
///     dialects (GPU and Vector) and the lower-level target-specific dialect
///     (LLVM IR based NVVM dialect) for NVIDIA GPUs. This allow representing PTX
///     specific operations while using MLIR high level dialects such as Memref
///     and Vector for memory and target-specific register operands, respectively.
class NVGPUDialect : public ::mlir::Dialect {
    ...
  };

} // namespace mlir::nvgpu
```

This is because the `emitSummaryAndDescComments` trims the summary and description from both sides, rendering the re-indentation useless. This PR resolves this bug.