### PR TITLE
[llvm-libgcc] pass target to preprocessor command

### DIFF
--- a/llvm-libgcc/CMakeLists.txt
+++ b/llvm-libgcc/CMakeLists.txt
@@ -102,6 +102,7 @@ add_subdirectory(${LLVM_LIBGCC_LIBUNWIND_PATH} ${LLVM_LIBGCC_LIBUNWIND_BINARY_DI
 add_custom_target(gcc_s.ver
   SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/gcc_s.ver.in
   COMMAND ${CMAKE_C_COMPILER} -E
+  $<$<C_COMPILER_ID:Clang,AppleClang>:--target=${CMAKE_C_COMPILER_TARGET}>
     -xc ${CMAKE_CURRENT_SOURCE_DIR}/gcc_s.ver.in
     -o ${CMAKE_CURRENT_BINARY_DIR}/gcc_s.ver
 )


### PR DESCRIPTION
The target must be passed to the C preprocessor for it to recognize target-specific preprocessor symbols (eg `__ARM_EABI`), as otherwise the default target is used which may not be appropriate when crosscompiling.