### PR TITLE
[TargetLowering] Add support for more constants to expandDIVREMByConstant.

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/TargetLowering.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/TargetLowering.cpp
@@ -8215,27 +8215,32 @@ bool TargetLowering::expandDIVREMByConstant(SDNode *N,
   }
 
   // Look for the largest chunk width W such that (1 << W) % Divisor == 1.
-  unsigned BestChunkWidth = 0;
+  unsigned BestChunkWidth = 0, AltChunkWidth = 0;
   for (unsigned I = HBitWidth, E = HBitWidth / 2; I > E; --I) {
-    APInt Mod = APInt::getOneBitSet(Divisor.getBitWidth(), I).urem(Divisor);
-
-    if (!Mod.isOne())
+    // Skip HBitWidth-1, it doesn't have enough bits for carries.
+    if (I == HBitWidth - 1)
       continue;
 
-    // If best chunk is HBitWidth, we can use it and handle the carry out.
-    // Otherwise, ensure the sum won't overflow HiLoVT (HBitWidth).
-    // Summing N chunks adds ceil(log2(N)) extra carry bits to the width.
-    // Safety check: Base Chunk Width (I) + Carry Bits <= Register Width.
-    unsigned NumChunks = divideCeil(BitWidth, I);
-    if (I == HBitWidth || I + llvm::bit_width(NumChunks - 1) <= HBitWidth) {
+    APInt Mod = APInt::getOneBitSet(Divisor.getBitWidth(), I).urem(Divisor);
+
+    if (Mod.isOne()) {
       BestChunkWidth = I;
       break;
     }
+
+    // We have an alternate strategy for Remainder == Divisor - 1.
+    // FIXME: Support HBitWidth.
+    if (I != HBitWidth && Mod == Divisor - 1)
+      AltChunkWidth = I;
   }
 
-  // If we didn't find a chunk size, exit.
-  if (!BestChunkWidth)
-    return false;
+  bool Alternate = false;
+  if (!BestChunkWidth) {
+    if (!AltChunkWidth)
+      return false;
+    Alternate = true;
+    BestChunkWidth = AltChunkWidth;
+  }
 
   SDLoc dl(N);
 
@@ -8273,6 +8278,7 @@ bool TargetLowering::expandDIVREMByConstant(SDNode *N,
   // If BestChunkWidth is HBitWidth add low and high half. If there is a carry
   // out, add that to the final sum.
   if (BestChunkWidth == HBitWidth) {
+    assert(!Alternate);
     // Shift LH:LL right if there were trailing zeros in the divisor.
     if (TrailingZeros) {
       LL = GetFSHR(LL, LH, TrailingZeros);
@@ -8322,10 +8328,32 @@ bool TargetLowering::expandDIVREMByConstant(SDNode *N,
       // If we're on the last chunk, we don't need an AND.
       if (I + BestChunkWidth < BitWidth - TrailingZeros)
         Chunk = DAG.getNode(ISD::AND, dl, HiLoVT, Chunk, Mask);
-      if (!Sum)
+      if (!Sum) {
         Sum = Chunk;
-      else
-        Sum = DAG.getNode(ISD::ADD, dl, HiLoVT, Sum, Chunk);
+      } else {
+        // For Alternate, we need to subtract odd chunks.
+        unsigned Opc = (Alternate && (I % 2) != 0) ? ISD::SUB : ISD::ADD;
+        Sum = DAG.getNode(Opc, dl, HiLoVT, Sum, Chunk);
+      }
+    }
+
+    // For Alternate, the sum may be negative, but we need a positive sum. We
+    // can increase it by a multiple of the divisor to make it positive. For 3
+    // chunks the largest negative value is -(2^BestChunkWidth - 1). For 4
+    // chunks, it's 2*-(2^BestChunkWidth - 1). We know that 2^BestChunkWidth + 1
+    // is a multiple of the divisor. Add that 1 or 2 times to make the sum
+    // positive.
+    if (Alternate) {
+      unsigned NumChunks = divideCeil(BitWidth - TrailingZeros, BestChunkWidth);
+      assert(NumChunks <= 4);
+
+      APInt Adjust = APInt::getOneBitSet(HBitWidth, BestChunkWidth);
+      Adjust.setBit(0);
+      // If there are 4 chunks, we need to adjust twice.
+      if (NumChunks == 4)
+        Adjust <<= 1;
+      Sum = DAG.getNode(ISD::ADD, dl, HiLoVT, Sum,
+                        DAG.getConstant(Adjust, dl, HiLoVT));
     }
   }
 

--- a/llvm/lib/CodeGen/SelectionDAG/TargetLowering.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/TargetLowering.cpp
@@ -8214,7 +8214,8 @@ bool TargetLowering::expandDIVREMByConstant(SDNode *N,
     Divisor.lshrInPlace(TrailingZeros);
   }
 
-  // Look for the largest chunk width W such that (1 << W) % Divisor == 1.
+  // Look for the largest chunk width W such that (1 << W) % Divisor == 1 or
+  // (1 << W) % Divisor == -1.
   unsigned BestChunkWidth = 0, AltChunkWidth = 0;
   for (unsigned I = HBitWidth, E = HBitWidth / 2; I > E; --I) {
     // Skip HBitWidth-1, it doesn't have enough bits for carries.
@@ -8332,7 +8333,8 @@ bool TargetLowering::expandDIVREMByConstant(SDNode *N,
         Sum = Chunk;
       } else {
         // For Alternate, we need to subtract odd chunks.
-        unsigned Opc = (Alternate && (I % 2) != 0) ? ISD::SUB : ISD::ADD;
+        unsigned ChunkNum = I / BestChunkWidth;
+        unsigned Opc = (Alternate && (ChunkNum % 2) != 0) ? ISD::SUB : ISD::ADD;
         Sum = DAG.getNode(Opc, dl, HiLoVT, Sum, Chunk);
       }
     }

--- a/llvm/test/CodeGen/ARM/funnel-shift.ll
+++ b/llvm/test/CodeGen/ARM/funnel-shift.ll
@@ -47,67 +47,81 @@ declare i37 @llvm.fshl.i37(i37, i37, i37)
 define i37 @fshl_i37(i37 %x, i37 %y, i37 %z) {
 ; SCALAR-LABEL: fshl_i37:
 ; SCALAR:       @ %bb.0:
-; SCALAR-NEXT:    .save {r4, r5, r6, r7, r8, lr}
-; SCALAR-NEXT:    push {r4, r5, r6, r7, r8, lr}
-; SCALAR-NEXT:    mov r8, r0
-; SCALAR-NEXT:    ldr r0, [sp, #28]
-; SCALAR-NEXT:    mov r4, r1
-; SCALAR-NEXT:    mov r5, r3
-; SCALAR-NEXT:    and r1, r0, #31
-; SCALAR-NEXT:    ldr r0, [sp, #24]
-; SCALAR-NEXT:    mov r6, r2
-; SCALAR-NEXT:    mov r2, #37
-; SCALAR-NEXT:    mov r3, #0
-; SCALAR-NEXT:    bl __aeabi_uldivmod
-; SCALAR-NEXT:    lsl r0, r5, #27
-; SCALAR-NEXT:    tst r2, #32
-; SCALAR-NEXT:    orr r0, r0, r6, lsr #5
-; SCALAR-NEXT:    mov r1, r8
-; SCALAR-NEXT:    and r3, r2, #31
-; SCALAR-NEXT:    mov r7, #31
+; SCALAR-NEXT:    .save {r4, r5, r6, lr}
+; SCALAR-NEXT:    push {r4, r5, r6, lr}
+; SCALAR-NEXT:    ldr r12, [sp, #16]
+; SCALAR-NEXT:    lsl r3, r3, #27
+; SCALAR-NEXT:    ldr r5, [sp, #20]
+; SCALAR-NEXT:    orr r3, r3, r2, lsr #5
+; SCALAR-NEXT:    mov r6, #31
+; SCALAR-NEXT:    lsr lr, r12, #18
+; SCALAR-NEXT:    bfc r12, #18, #14
+; SCALAR-NEXT:    orr r4, lr, r5, lsl #14
+; SCALAR-NEXT:    and r5, r5, #16
+; SCALAR-NEXT:    bfc r4, #18, #14
+; SCALAR-NEXT:    add r4, r12, r4
+; SCALAR-NEXT:    add r5, r4, r5, lsr #4
+; SCALAR-NEXT:    movw r4, #15942
+; SCALAR-NEXT:    add r5, r5, #2
+; SCALAR-NEXT:    movt r4, #1771
+; SCALAR-NEXT:    add r5, r5, #524288
+; SCALAR-NEXT:    umull r4, r12, r5, r4
+; SCALAR-NEXT:    mov r4, #37
+; SCALAR-NEXT:    mls r5, r12, r4, r5
+; SCALAR-NEXT:    mov r4, r0
+; SCALAR-NEXT:    tst r5, #32
+; SCALAR-NEXT:    and r12, r5, #31
+; SCALAR-NEXT:    movne r4, r3
+; SCALAR-NEXT:    lslne r3, r2, #27
+; SCALAR-NEXT:    bic r5, r6, r5
 ; SCALAR-NEXT:    movne r1, r0
-; SCALAR-NEXT:    lslne r0, r6, #27
-; SCALAR-NEXT:    bic r2, r7, r2
-; SCALAR-NEXT:    lsl r5, r1, r3
-; SCALAR-NEXT:    lsr r0, r0, #1
-; SCALAR-NEXT:    movne r4, r8
-; SCALAR-NEXT:    lsr r1, r1, #1
-; SCALAR-NEXT:    lsl r3, r4, r3
-; SCALAR-NEXT:    orr r0, r5, r0, lsr r2
-; SCALAR-NEXT:    orr r1, r3, r1, lsr r2
-; SCALAR-NEXT:    pop {r4, r5, r6, r7, r8, pc}
+; SCALAR-NEXT:    lsr r2, r3, #1
+; SCALAR-NEXT:    lsl lr, r4, r12
+; SCALAR-NEXT:    lsl r0, r1, r12
+; SCALAR-NEXT:    lsr r1, r4, #1
+; SCALAR-NEXT:    orr r2, lr, r2, lsr r5
+; SCALAR-NEXT:    orr r1, r0, r1, lsr r5
+; SCALAR-NEXT:    mov r0, r2
+; SCALAR-NEXT:    pop {r4, r5, r6, pc}
 ;
 ; NEON-LABEL: fshl_i37:
 ; NEON:       @ %bb.0:
-; NEON-NEXT:    .save {r4, r5, r6, r7, r8, lr}
-; NEON-NEXT:    push {r4, r5, r6, r7, r8, lr}
-; NEON-NEXT:    mov r4, r1
-; NEON-NEXT:    ldr r1, [sp, #28]
-; NEON-NEXT:    mov r8, r0
-; NEON-NEXT:    ldr r0, [sp, #24]
-; NEON-NEXT:    and r1, r1, #31
-; NEON-NEXT:    mov r5, r3
-; NEON-NEXT:    mov r6, r2
-; NEON-NEXT:    mov r2, #37
-; NEON-NEXT:    mov r3, #0
-; NEON-NEXT:    bl __aeabi_uldivmod
-; NEON-NEXT:    lsl r0, r5, #27
-; NEON-NEXT:    tst r2, #32
-; NEON-NEXT:    orr r0, r0, r6, lsr #5
-; NEON-NEXT:    mov r1, r8
-; NEON-NEXT:    and r3, r2, #31
-; NEON-NEXT:    mov r7, #31
+; NEON-NEXT:    .save {r4, r5, r6, lr}
+; NEON-NEXT:    push {r4, r5, r6, lr}
+; NEON-NEXT:    ldr r12, [sp, #16]
+; NEON-NEXT:    lsl r3, r3, #27
+; NEON-NEXT:    ldr lr, [sp, #20]
+; NEON-NEXT:    orr r3, r3, r2, lsr #5
+; NEON-NEXT:    mov r6, #31
+; NEON-NEXT:    lsr r4, r12, #18
+; NEON-NEXT:    bfc r12, #18, #14
+; NEON-NEXT:    orr r4, r4, lr, lsl #14
+; NEON-NEXT:    bfc r4, #18, #14
+; NEON-NEXT:    add r12, r12, r4
+; NEON-NEXT:    and r4, lr, #16
+; NEON-NEXT:    add r4, r12, r4, lsr #4
+; NEON-NEXT:    add r4, r4, #2
+; NEON-NEXT:    add r12, r4, #524288
+; NEON-NEXT:    movw r4, #15942
+; NEON-NEXT:    movt r4, #1771
+; NEON-NEXT:    umull r4, lr, r12, r4
+; NEON-NEXT:    mov r4, #37
+; NEON-NEXT:    mls r12, lr, r4, r12
+; NEON-NEXT:    mov r4, r0
+; NEON-NEXT:    tst r12, #32
+; NEON-NEXT:    and lr, r12, #31
+; NEON-NEXT:    movne r4, r3
+; NEON-NEXT:    lslne r3, r2, #27
+; NEON-NEXT:    bic r6, r6, r12
 ; NEON-NEXT:    movne r1, r0
-; NEON-NEXT:    lslne r0, r6, #27
-; NEON-NEXT:    bic r2, r7, r2
-; NEON-NEXT:    lsl r5, r1, r3
-; NEON-NEXT:    lsr r0, r0, #1
-; NEON-NEXT:    movne r4, r8
-; NEON-NEXT:    lsr r1, r1, #1
-; NEON-NEXT:    lsl r3, r4, r3
-; NEON-NEXT:    orr r0, r5, r0, lsr r2
-; NEON-NEXT:    orr r1, r3, r1, lsr r2
-; NEON-NEXT:    pop {r4, r5, r6, r7, r8, pc}
+; NEON-NEXT:    lsr r2, r3, #1
+; NEON-NEXT:    lsl r5, r4, lr
+; NEON-NEXT:    lsl r0, r1, lr
+; NEON-NEXT:    lsr r1, r4, #1
+; NEON-NEXT:    orr r2, r5, r2, lsr r6
+; NEON-NEXT:    orr r1, r0, r1, lsr r6
+; NEON-NEXT:    mov r0, r2
+; NEON-NEXT:    pop {r4, r5, r6, pc}
   %f = call i37 @llvm.fshl.i37(i37 %x, i37 %y, i37 %z)
   ret i37 %f
 }
@@ -235,69 +249,83 @@ declare i37 @llvm.fshr.i37(i37, i37, i37)
 define i37 @fshr_i37(i37 %x, i37 %y, i37 %z) {
 ; SCALAR-LABEL: fshr_i37:
 ; SCALAR:       @ %bb.0:
-; SCALAR-NEXT:    .save {r4, r5, r6, r7, r11, lr}
-; SCALAR-NEXT:    push {r4, r5, r6, r7, r11, lr}
-; SCALAR-NEXT:    mov r5, r0
-; SCALAR-NEXT:    ldr r0, [sp, #28]
-; SCALAR-NEXT:    mov r4, r1
-; SCALAR-NEXT:    mov r6, r3
-; SCALAR-NEXT:    and r1, r0, #31
-; SCALAR-NEXT:    ldr r0, [sp, #24]
-; SCALAR-NEXT:    mov r7, r2
-; SCALAR-NEXT:    mov r2, #37
-; SCALAR-NEXT:    mov r3, #0
-; SCALAR-NEXT:    bl __aeabi_uldivmod
-; SCALAR-NEXT:    add r0, r2, #27
-; SCALAR-NEXT:    lsl r2, r6, #27
-; SCALAR-NEXT:    orr r2, r2, r7, lsr #5
-; SCALAR-NEXT:    mov r1, #31
-; SCALAR-NEXT:    tst r0, #32
-; SCALAR-NEXT:    mov r3, r5
-; SCALAR-NEXT:    moveq r3, r2
-; SCALAR-NEXT:    lsleq r2, r7, #27
-; SCALAR-NEXT:    bic r1, r1, r0
-; SCALAR-NEXT:    and r7, r0, #31
-; SCALAR-NEXT:    lsl r6, r3, #1
-; SCALAR-NEXT:    moveq r4, r5
-; SCALAR-NEXT:    lsl r6, r6, r1
-; SCALAR-NEXT:    orr r0, r6, r2, lsr r7
-; SCALAR-NEXT:    lsl r2, r4, #1
-; SCALAR-NEXT:    lsl r1, r2, r1
-; SCALAR-NEXT:    orr r1, r1, r3, lsr r7
-; SCALAR-NEXT:    pop {r4, r5, r6, r7, r11, pc}
+; SCALAR-NEXT:    .save {r4, r5, r11, lr}
+; SCALAR-NEXT:    push {r4, r5, r11, lr}
+; SCALAR-NEXT:    ldr r12, [sp, #16]
+; SCALAR-NEXT:    lsl r3, r3, #27
+; SCALAR-NEXT:    ldr r5, [sp, #20]
+; SCALAR-NEXT:    orr r3, r3, r2, lsr #5
+; SCALAR-NEXT:    lsr lr, r12, #18
+; SCALAR-NEXT:    bfc r12, #18, #14
+; SCALAR-NEXT:    orr r4, lr, r5, lsl #14
+; SCALAR-NEXT:    and r5, r5, #16
+; SCALAR-NEXT:    bfc r4, #18, #14
+; SCALAR-NEXT:    add r4, r12, r4
+; SCALAR-NEXT:    add r5, r4, r5, lsr #4
+; SCALAR-NEXT:    movw r4, #15942
+; SCALAR-NEXT:    add r5, r5, #2
+; SCALAR-NEXT:    movt r4, #1771
+; SCALAR-NEXT:    add r5, r5, #524288
+; SCALAR-NEXT:    umull r4, r12, r5, r4
+; SCALAR-NEXT:    mov r4, #37
+; SCALAR-NEXT:    mls r5, r12, r4, r5
+; SCALAR-NEXT:    mov r4, #31
+; SCALAR-NEXT:    add lr, r5, #27
+; SCALAR-NEXT:    bic r12, r4, lr
+; SCALAR-NEXT:    tst lr, #32
+; SCALAR-NEXT:    mov r4, r0
+; SCALAR-NEXT:    moveq r1, r0
+; SCALAR-NEXT:    moveq r4, r3
+; SCALAR-NEXT:    lsleq r3, r2, #27
+; SCALAR-NEXT:    and r2, lr, #31
+; SCALAR-NEXT:    lsl r5, r4, #1
+; SCALAR-NEXT:    lsl r0, r1, #1
+; SCALAR-NEXT:    lsl r5, r5, r12
+; SCALAR-NEXT:    orr r3, r5, r3, lsr r2
+; SCALAR-NEXT:    lsl r0, r0, r12
+; SCALAR-NEXT:    orr r1, r0, r4, lsr r2
+; SCALAR-NEXT:    mov r0, r3
+; SCALAR-NEXT:    pop {r4, r5, r11, pc}
 ;
 ; NEON-LABEL: fshr_i37:
 ; NEON:       @ %bb.0:
-; NEON-NEXT:    .save {r4, r5, r6, r7, r11, lr}
-; NEON-NEXT:    push {r4, r5, r6, r7, r11, lr}
-; NEON-NEXT:    mov r4, r1
-; NEON-NEXT:    ldr r1, [sp, #28]
-; NEON-NEXT:    mov r5, r0
-; NEON-NEXT:    ldr r0, [sp, #24]
-; NEON-NEXT:    and r1, r1, #31
-; NEON-NEXT:    mov r6, r3
-; NEON-NEXT:    mov r7, r2
-; NEON-NEXT:    mov r2, #37
-; NEON-NEXT:    mov r3, #0
-; NEON-NEXT:    bl __aeabi_uldivmod
-; NEON-NEXT:    add r0, r2, #27
-; NEON-NEXT:    lsl r2, r6, #27
-; NEON-NEXT:    orr r2, r2, r7, lsr #5
-; NEON-NEXT:    mov r1, #31
-; NEON-NEXT:    tst r0, #32
-; NEON-NEXT:    mov r3, r5
-; NEON-NEXT:    moveq r3, r2
-; NEON-NEXT:    lsleq r2, r7, #27
-; NEON-NEXT:    bic r1, r1, r0
-; NEON-NEXT:    and r7, r0, #31
-; NEON-NEXT:    lsl r6, r3, #1
-; NEON-NEXT:    moveq r4, r5
-; NEON-NEXT:    lsl r6, r6, r1
-; NEON-NEXT:    orr r0, r6, r2, lsr r7
-; NEON-NEXT:    lsl r2, r4, #1
-; NEON-NEXT:    lsl r1, r2, r1
-; NEON-NEXT:    orr r1, r1, r3, lsr r7
-; NEON-NEXT:    pop {r4, r5, r6, r7, r11, pc}
+; NEON-NEXT:    .save {r4, r5, r11, lr}
+; NEON-NEXT:    push {r4, r5, r11, lr}
+; NEON-NEXT:    ldr r12, [sp, #16]
+; NEON-NEXT:    lsl r3, r3, #27
+; NEON-NEXT:    ldr lr, [sp, #20]
+; NEON-NEXT:    orr r3, r3, r2, lsr #5
+; NEON-NEXT:    lsr r4, r12, #18
+; NEON-NEXT:    bfc r12, #18, #14
+; NEON-NEXT:    orr r4, r4, lr, lsl #14
+; NEON-NEXT:    bfc r4, #18, #14
+; NEON-NEXT:    add r12, r12, r4
+; NEON-NEXT:    and r4, lr, #16
+; NEON-NEXT:    add r4, r12, r4, lsr #4
+; NEON-NEXT:    add r4, r4, #2
+; NEON-NEXT:    add r12, r4, #524288
+; NEON-NEXT:    movw r4, #15942
+; NEON-NEXT:    movt r4, #1771
+; NEON-NEXT:    umull r4, lr, r12, r4
+; NEON-NEXT:    mov r4, #37
+; NEON-NEXT:    mls r4, lr, r4, r12
+; NEON-NEXT:    add r12, r4, #27
+; NEON-NEXT:    mov r4, #31
+; NEON-NEXT:    bic lr, r4, r12
+; NEON-NEXT:    tst r12, #32
+; NEON-NEXT:    mov r4, r0
+; NEON-NEXT:    moveq r1, r0
+; NEON-NEXT:    moveq r4, r3
+; NEON-NEXT:    lsleq r3, r2, #27
+; NEON-NEXT:    and r2, r12, #31
+; NEON-NEXT:    lsl r5, r4, #1
+; NEON-NEXT:    lsl r0, r1, #1
+; NEON-NEXT:    lsl r5, r5, lr
+; NEON-NEXT:    orr r3, r5, r3, lsr r2
+; NEON-NEXT:    lsl r0, r0, lr
+; NEON-NEXT:    orr r1, r0, r4, lsr r2
+; NEON-NEXT:    mov r0, r3
+; NEON-NEXT:    pop {r4, r5, r11, pc}
   %f = call i37 @llvm.fshr.i37(i37 %x, i37 %y, i37 %z)
   ret i37 %f
 }

--- a/llvm/test/CodeGen/ARM/funnel-shift.ll
+++ b/llvm/test/CodeGen/ARM/funnel-shift.ll
@@ -59,13 +59,16 @@ define i37 @fshl_i37(i37 %x, i37 %y, i37 %z) {
 ; SCALAR-NEXT:    orr r4, lr, r5, lsl #14
 ; SCALAR-NEXT:    and r5, r5, #16
 ; SCALAR-NEXT:    bfc r4, #18, #14
-; SCALAR-NEXT:    add r4, r12, r4
+; SCALAR-NEXT:    sub r4, r12, r4
 ; SCALAR-NEXT:    add r5, r4, r5, lsr #4
-; SCALAR-NEXT:    movw r4, #15942
+; SCALAR-NEXT:    movw r4, #37197
 ; SCALAR-NEXT:    add r5, r5, #2
-; SCALAR-NEXT:    movt r4, #1771
+; SCALAR-NEXT:    movt r4, #47823
 ; SCALAR-NEXT:    add r5, r5, #524288
 ; SCALAR-NEXT:    umull r4, r12, r5, r4
+; SCALAR-NEXT:    sub r4, r5, r12
+; SCALAR-NEXT:    add r4, r12, r4, lsr #1
+; SCALAR-NEXT:    lsr r12, r4, #5
 ; SCALAR-NEXT:    mov r4, #37
 ; SCALAR-NEXT:    mls r5, r12, r4, r5
 ; SCALAR-NEXT:    mov r4, r0
@@ -97,14 +100,17 @@ define i37 @fshl_i37(i37 %x, i37 %y, i37 %z) {
 ; NEON-NEXT:    bfc r12, #18, #14
 ; NEON-NEXT:    orr r4, r4, lr, lsl #14
 ; NEON-NEXT:    bfc r4, #18, #14
-; NEON-NEXT:    add r12, r12, r4
+; NEON-NEXT:    sub r12, r12, r4
 ; NEON-NEXT:    and r4, lr, #16
 ; NEON-NEXT:    add r4, r12, r4, lsr #4
 ; NEON-NEXT:    add r4, r4, #2
 ; NEON-NEXT:    add r12, r4, #524288
-; NEON-NEXT:    movw r4, #15942
-; NEON-NEXT:    movt r4, #1771
+; NEON-NEXT:    movw r4, #37197
+; NEON-NEXT:    movt r4, #47823
 ; NEON-NEXT:    umull r4, lr, r12, r4
+; NEON-NEXT:    sub r4, r12, lr
+; NEON-NEXT:    add r4, lr, r4, lsr #1
+; NEON-NEXT:    lsr lr, r4, #5
 ; NEON-NEXT:    mov r4, #37
 ; NEON-NEXT:    mls r12, lr, r4, r12
 ; NEON-NEXT:    mov r4, r0
@@ -260,13 +266,16 @@ define i37 @fshr_i37(i37 %x, i37 %y, i37 %z) {
 ; SCALAR-NEXT:    orr r4, lr, r5, lsl #14
 ; SCALAR-NEXT:    and r5, r5, #16
 ; SCALAR-NEXT:    bfc r4, #18, #14
-; SCALAR-NEXT:    add r4, r12, r4
+; SCALAR-NEXT:    sub r4, r12, r4
 ; SCALAR-NEXT:    add r5, r4, r5, lsr #4
-; SCALAR-NEXT:    movw r4, #15942
+; SCALAR-NEXT:    movw r4, #37197
 ; SCALAR-NEXT:    add r5, r5, #2
-; SCALAR-NEXT:    movt r4, #1771
+; SCALAR-NEXT:    movt r4, #47823
 ; SCALAR-NEXT:    add r5, r5, #524288
 ; SCALAR-NEXT:    umull r4, r12, r5, r4
+; SCALAR-NEXT:    sub r4, r5, r12
+; SCALAR-NEXT:    add r4, r12, r4, lsr #1
+; SCALAR-NEXT:    lsr r12, r4, #5
 ; SCALAR-NEXT:    mov r4, #37
 ; SCALAR-NEXT:    mls r5, r12, r4, r5
 ; SCALAR-NEXT:    mov r4, #31
@@ -299,14 +308,17 @@ define i37 @fshr_i37(i37 %x, i37 %y, i37 %z) {
 ; NEON-NEXT:    bfc r12, #18, #14
 ; NEON-NEXT:    orr r4, r4, lr, lsl #14
 ; NEON-NEXT:    bfc r4, #18, #14
-; NEON-NEXT:    add r12, r12, r4
+; NEON-NEXT:    sub r12, r12, r4
 ; NEON-NEXT:    and r4, lr, #16
 ; NEON-NEXT:    add r4, r12, r4, lsr #4
 ; NEON-NEXT:    add r4, r4, #2
 ; NEON-NEXT:    add r12, r4, #524288
-; NEON-NEXT:    movw r4, #15942
-; NEON-NEXT:    movt r4, #1771
+; NEON-NEXT:    movw r4, #37197
+; NEON-NEXT:    movt r4, #47823
 ; NEON-NEXT:    umull r4, lr, r12, r4
+; NEON-NEXT:    sub r4, r12, lr
+; NEON-NEXT:    add r4, lr, r4, lsr #1
+; NEON-NEXT:    lsr lr, r4, #5
 ; NEON-NEXT:    mov r4, #37
 ; NEON-NEXT:    mls r4, lr, r4, r12
 ; NEON-NEXT:    add r12, r4, #27

--- a/llvm/test/CodeGen/Mips/funnel-shift.ll
+++ b/llvm/test/CodeGen/Mips/funnel-shift.ll
@@ -48,105 +48,96 @@ declare i37 @llvm.fshl.i37(i37, i37, i37)
 define i37 @fshl_i37(i37 %x, i37 %y, i37 %z) {
 ; CHECK-BE-LABEL: fshl_i37:
 ; CHECK-BE:       # %bb.0:
-; CHECK-BE-NEXT:    addiu $sp, $sp, -40
-; CHECK-BE-NEXT:    .cfi_def_cfa_offset 40
-; CHECK-BE-NEXT:    sw $ra, 36($sp) # 4-byte Folded Spill
-; CHECK-BE-NEXT:    sw $19, 32($sp) # 4-byte Folded Spill
-; CHECK-BE-NEXT:    sw $18, 28($sp) # 4-byte Folded Spill
-; CHECK-BE-NEXT:    sw $17, 24($sp) # 4-byte Folded Spill
-; CHECK-BE-NEXT:    sw $16, 20($sp) # 4-byte Folded Spill
-; CHECK-BE-NEXT:    .cfi_offset 31, -4
-; CHECK-BE-NEXT:    .cfi_offset 19, -8
-; CHECK-BE-NEXT:    .cfi_offset 18, -12
-; CHECK-BE-NEXT:    .cfi_offset 17, -16
-; CHECK-BE-NEXT:    .cfi_offset 16, -20
-; CHECK-BE-NEXT:    move $16, $7
-; CHECK-BE-NEXT:    move $17, $6
-; CHECK-BE-NEXT:    move $18, $5
-; CHECK-BE-NEXT:    move $19, $4
-; CHECK-BE-NEXT:    lw $1, 56($sp)
-; CHECK-BE-NEXT:    andi $4, $1, 31
-; CHECK-BE-NEXT:    lw $5, 60($sp)
-; CHECK-BE-NEXT:    addiu $6, $zero, 0
-; CHECK-BE-NEXT:    jal __umoddi3
-; CHECK-BE-NEXT:    addiu $7, $zero, 37
-; CHECK-BE-NEXT:    srl $1, $3, 5
-; CHECK-BE-NEXT:    andi $1, $1, 1
-; CHECK-BE-NEXT:    movn $19, $18, $1
-; CHECK-BE-NEXT:    sllv $2, $19, $3
-; CHECK-BE-NEXT:    not $4, $3
-; CHECK-BE-NEXT:    srl $5, $16, 5
-; CHECK-BE-NEXT:    sll $6, $17, 27
-; CHECK-BE-NEXT:    or $5, $6, $5
-; CHECK-BE-NEXT:    movn $18, $5, $1
-; CHECK-BE-NEXT:    srl $6, $18, 1
-; CHECK-BE-NEXT:    srlv $6, $6, $4
-; CHECK-BE-NEXT:    or $2, $2, $6
-; CHECK-BE-NEXT:    sllv $3, $18, $3
-; CHECK-BE-NEXT:    sll $6, $16, 27
-; CHECK-BE-NEXT:    movn $5, $6, $1
-; CHECK-BE-NEXT:    srl $1, $5, 1
-; CHECK-BE-NEXT:    srlv $1, $1, $4
-; CHECK-BE-NEXT:    or $3, $3, $1
-; CHECK-BE-NEXT:    lw $16, 20($sp) # 4-byte Folded Reload
-; CHECK-BE-NEXT:    lw $17, 24($sp) # 4-byte Folded Reload
-; CHECK-BE-NEXT:    lw $18, 28($sp) # 4-byte Folded Reload
-; CHECK-BE-NEXT:    lw $19, 32($sp) # 4-byte Folded Reload
-; CHECK-BE-NEXT:    lw $ra, 36($sp) # 4-byte Folded Reload
+; CHECK-BE-NEXT:    lui $1, 3
+; CHECK-BE-NEXT:    ori $1, $1, 65535
+; CHECK-BE-NEXT:    lw $2, 20($sp)
+; CHECK-BE-NEXT:    and $3, $2, $1
+; CHECK-BE-NEXT:    lw $8, 16($sp)
+; CHECK-BE-NEXT:    sll $9, $8, 14
+; CHECK-BE-NEXT:    srl $2, $2, 18
+; CHECK-BE-NEXT:    or $2, $2, $9
+; CHECK-BE-NEXT:    and $1, $2, $1
+; CHECK-BE-NEXT:    addu $1, $3, $1
+; CHECK-BE-NEXT:    andi $2, $8, 16
+; CHECK-BE-NEXT:    srl $2, $2, 4
+; CHECK-BE-NEXT:    addu $1, $1, $2
+; CHECK-BE-NEXT:    lui $2, 8
+; CHECK-BE-NEXT:    ori $2, $2, 2
+; CHECK-BE-NEXT:    addu $1, $1, $2
+; CHECK-BE-NEXT:    lui $2, 1771
+; CHECK-BE-NEXT:    ori $2, $2, 15942
+; CHECK-BE-NEXT:    multu $1, $2
+; CHECK-BE-NEXT:    mfhi $2
+; CHECK-BE-NEXT:    srl $3, $7, 5
+; CHECK-BE-NEXT:    sll $6, $6, 27
+; CHECK-BE-NEXT:    or $3, $6, $3
+; CHECK-BE-NEXT:    sll $6, $7, 27
+; CHECK-BE-NEXT:    sll $7, $2, 2
+; CHECK-BE-NEXT:    addu $7, $7, $2
+; CHECK-BE-NEXT:    sll $2, $2, 5
+; CHECK-BE-NEXT:    addu $2, $2, $7
+; CHECK-BE-NEXT:    subu $1, $1, $2
+; CHECK-BE-NEXT:    srl $7, $1, 5
+; CHECK-BE-NEXT:    movn $4, $5, $7
+; CHECK-BE-NEXT:    sllv $2, $4, $1
+; CHECK-BE-NEXT:    not $4, $1
+; CHECK-BE-NEXT:    movn $5, $3, $7
+; CHECK-BE-NEXT:    srl $8, $5, 1
+; CHECK-BE-NEXT:    srlv $8, $8, $4
+; CHECK-BE-NEXT:    or $2, $2, $8
+; CHECK-BE-NEXT:    sllv $1, $5, $1
+; CHECK-BE-NEXT:    movn $3, $6, $7
+; CHECK-BE-NEXT:    srl $3, $3, 1
+; CHECK-BE-NEXT:    srlv $3, $3, $4
 ; CHECK-BE-NEXT:    jr $ra
-; CHECK-BE-NEXT:    addiu $sp, $sp, 40
+; CHECK-BE-NEXT:    or $3, $1, $3
 ;
 ; CHECK-LE-LABEL: fshl_i37:
 ; CHECK-LE:       # %bb.0:
-; CHECK-LE-NEXT:    addiu $sp, $sp, -40
-; CHECK-LE-NEXT:    .cfi_def_cfa_offset 40
-; CHECK-LE-NEXT:    sw $ra, 36($sp) # 4-byte Folded Spill
-; CHECK-LE-NEXT:    sw $19, 32($sp) # 4-byte Folded Spill
-; CHECK-LE-NEXT:    sw $18, 28($sp) # 4-byte Folded Spill
-; CHECK-LE-NEXT:    sw $17, 24($sp) # 4-byte Folded Spill
-; CHECK-LE-NEXT:    sw $16, 20($sp) # 4-byte Folded Spill
-; CHECK-LE-NEXT:    .cfi_offset 31, -4
-; CHECK-LE-NEXT:    .cfi_offset 19, -8
-; CHECK-LE-NEXT:    .cfi_offset 18, -12
-; CHECK-LE-NEXT:    .cfi_offset 17, -16
-; CHECK-LE-NEXT:    .cfi_offset 16, -20
-; CHECK-LE-NEXT:    move $16, $7
-; CHECK-LE-NEXT:    move $17, $6
-; CHECK-LE-NEXT:    move $18, $5
-; CHECK-LE-NEXT:    move $19, $4
-; CHECK-LE-NEXT:    lw $1, 60($sp)
-; CHECK-LE-NEXT:    andi $5, $1, 31
-; CHECK-LE-NEXT:    lw $4, 56($sp)
-; CHECK-LE-NEXT:    addiu $6, $zero, 37
-; CHECK-LE-NEXT:    jal __umoddi3
-; CHECK-LE-NEXT:    addiu $7, $zero, 0
-; CHECK-LE-NEXT:    srl $1, $2, 5
-; CHECK-LE-NEXT:    andi $3, $1, 1
-; CHECK-LE-NEXT:    srl $1, $17, 5
-; CHECK-LE-NEXT:    sll $4, $16, 27
-; CHECK-LE-NEXT:    or $1, $4, $1
-; CHECK-LE-NEXT:    move $4, $19
-; CHECK-LE-NEXT:    movn $4, $1, $3
-; CHECK-LE-NEXT:    sllv $5, $4, $2
-; CHECK-LE-NEXT:    not $6, $2
-; CHECK-LE-NEXT:    sll $7, $17, 27
-; CHECK-LE-NEXT:    movn $1, $7, $3
-; CHECK-LE-NEXT:    srl $1, $1, 1
-; CHECK-LE-NEXT:    srlv $1, $1, $6
-; CHECK-LE-NEXT:    or $1, $5, $1
-; CHECK-LE-NEXT:    movn $18, $19, $3
-; CHECK-LE-NEXT:    sllv $2, $18, $2
-; CHECK-LE-NEXT:    srl $3, $4, 1
-; CHECK-LE-NEXT:    srlv $3, $3, $6
-; CHECK-LE-NEXT:    or $3, $2, $3
-; CHECK-LE-NEXT:    move $2, $1
-; CHECK-LE-NEXT:    lw $16, 20($sp) # 4-byte Folded Reload
-; CHECK-LE-NEXT:    lw $17, 24($sp) # 4-byte Folded Reload
-; CHECK-LE-NEXT:    lw $18, 28($sp) # 4-byte Folded Reload
-; CHECK-LE-NEXT:    lw $19, 32($sp) # 4-byte Folded Reload
-; CHECK-LE-NEXT:    lw $ra, 36($sp) # 4-byte Folded Reload
+; CHECK-LE-NEXT:    lui $1, 3
+; CHECK-LE-NEXT:    ori $1, $1, 65535
+; CHECK-LE-NEXT:    lw $2, 16($sp)
+; CHECK-LE-NEXT:    and $3, $2, $1
+; CHECK-LE-NEXT:    lw $8, 20($sp)
+; CHECK-LE-NEXT:    sll $9, $8, 14
+; CHECK-LE-NEXT:    srl $2, $2, 18
+; CHECK-LE-NEXT:    or $2, $2, $9
+; CHECK-LE-NEXT:    and $1, $2, $1
+; CHECK-LE-NEXT:    addu $1, $3, $1
+; CHECK-LE-NEXT:    andi $2, $8, 16
+; CHECK-LE-NEXT:    srl $2, $2, 4
+; CHECK-LE-NEXT:    addu $1, $1, $2
+; CHECK-LE-NEXT:    lui $2, 8
+; CHECK-LE-NEXT:    ori $2, $2, 2
+; CHECK-LE-NEXT:    addu $1, $1, $2
+; CHECK-LE-NEXT:    lui $2, 1771
+; CHECK-LE-NEXT:    ori $2, $2, 15942
+; CHECK-LE-NEXT:    multu $1, $2
+; CHECK-LE-NEXT:    mfhi $2
+; CHECK-LE-NEXT:    srl $3, $6, 5
+; CHECK-LE-NEXT:    sll $7, $7, 27
+; CHECK-LE-NEXT:    or $3, $7, $3
+; CHECK-LE-NEXT:    sll $6, $6, 27
+; CHECK-LE-NEXT:    sll $7, $2, 2
+; CHECK-LE-NEXT:    addu $7, $7, $2
+; CHECK-LE-NEXT:    sll $2, $2, 5
+; CHECK-LE-NEXT:    addu $2, $2, $7
+; CHECK-LE-NEXT:    subu $1, $1, $2
+; CHECK-LE-NEXT:    srl $7, $1, 5
+; CHECK-LE-NEXT:    move $8, $4
+; CHECK-LE-NEXT:    movn $8, $3, $7
+; CHECK-LE-NEXT:    sllv $2, $8, $1
+; CHECK-LE-NEXT:    not $9, $1
+; CHECK-LE-NEXT:    movn $3, $6, $7
+; CHECK-LE-NEXT:    srl $3, $3, 1
+; CHECK-LE-NEXT:    srlv $3, $3, $9
+; CHECK-LE-NEXT:    or $2, $2, $3
+; CHECK-LE-NEXT:    movn $5, $4, $7
+; CHECK-LE-NEXT:    sllv $1, $5, $1
+; CHECK-LE-NEXT:    srl $3, $8, 1
+; CHECK-LE-NEXT:    srlv $3, $3, $9
 ; CHECK-LE-NEXT:    jr $ra
-; CHECK-LE-NEXT:    addiu $sp, $sp, 40
+; CHECK-LE-NEXT:    or $3, $1, $3
   %f = call i37 @llvm.fshl.i37(i37 %x, i37 %y, i37 %z)
   ret i37 %f
 }
@@ -288,104 +279,98 @@ declare i37 @llvm.fshr.i37(i37, i37, i37)
 define i37 @fshr_i37(i37 %x, i37 %y, i37 %z) {
 ; CHECK-BE-LABEL: fshr_i37:
 ; CHECK-BE:       # %bb.0:
-; CHECK-BE-NEXT:    addiu $sp, $sp, -40
-; CHECK-BE-NEXT:    .cfi_def_cfa_offset 40
-; CHECK-BE-NEXT:    sw $ra, 36($sp) # 4-byte Folded Spill
-; CHECK-BE-NEXT:    sw $19, 32($sp) # 4-byte Folded Spill
-; CHECK-BE-NEXT:    sw $18, 28($sp) # 4-byte Folded Spill
-; CHECK-BE-NEXT:    sw $17, 24($sp) # 4-byte Folded Spill
-; CHECK-BE-NEXT:    sw $16, 20($sp) # 4-byte Folded Spill
-; CHECK-BE-NEXT:    .cfi_offset 31, -4
-; CHECK-BE-NEXT:    .cfi_offset 19, -8
-; CHECK-BE-NEXT:    .cfi_offset 18, -12
-; CHECK-BE-NEXT:    .cfi_offset 17, -16
-; CHECK-BE-NEXT:    .cfi_offset 16, -20
-; CHECK-BE-NEXT:    move $16, $7
-; CHECK-BE-NEXT:    move $17, $6
-; CHECK-BE-NEXT:    move $18, $5
-; CHECK-BE-NEXT:    move $19, $4
-; CHECK-BE-NEXT:    lw $1, 56($sp)
-; CHECK-BE-NEXT:    andi $4, $1, 31
-; CHECK-BE-NEXT:    lw $5, 60($sp)
-; CHECK-BE-NEXT:    addiu $6, $zero, 0
-; CHECK-BE-NEXT:    jal __umoddi3
-; CHECK-BE-NEXT:    addiu $7, $zero, 37
-; CHECK-BE-NEXT:    addiu $1, $3, 27
-; CHECK-BE-NEXT:    andi $3, $1, 32
-; CHECK-BE-NEXT:    srl $2, $16, 5
-; CHECK-BE-NEXT:    sll $4, $17, 27
-; CHECK-BE-NEXT:    or $4, $4, $2
-; CHECK-BE-NEXT:    movz $19, $18, $3
-; CHECK-BE-NEXT:    movz $18, $4, $3
-; CHECK-BE-NEXT:    srlv $2, $18, $1
-; CHECK-BE-NEXT:    not $5, $1
-; CHECK-BE-NEXT:    sll $6, $19, 1
-; CHECK-BE-NEXT:    sllv $6, $6, $5
-; CHECK-BE-NEXT:    sll $7, $16, 27
-; CHECK-BE-NEXT:    or $2, $6, $2
-; CHECK-BE-NEXT:    movz $4, $7, $3
-; CHECK-BE-NEXT:    srlv $1, $4, $1
-; CHECK-BE-NEXT:    sll $3, $18, 1
-; CHECK-BE-NEXT:    sllv $3, $3, $5
-; CHECK-BE-NEXT:    or $3, $3, $1
-; CHECK-BE-NEXT:    lw $16, 20($sp) # 4-byte Folded Reload
-; CHECK-BE-NEXT:    lw $17, 24($sp) # 4-byte Folded Reload
-; CHECK-BE-NEXT:    lw $18, 28($sp) # 4-byte Folded Reload
-; CHECK-BE-NEXT:    lw $19, 32($sp) # 4-byte Folded Reload
-; CHECK-BE-NEXT:    lw $ra, 36($sp) # 4-byte Folded Reload
+; CHECK-BE-NEXT:    lui $1, 3
+; CHECK-BE-NEXT:    ori $1, $1, 65535
+; CHECK-BE-NEXT:    lw $2, 20($sp)
+; CHECK-BE-NEXT:    and $3, $2, $1
+; CHECK-BE-NEXT:    lw $8, 16($sp)
+; CHECK-BE-NEXT:    sll $9, $8, 14
+; CHECK-BE-NEXT:    srl $2, $2, 18
+; CHECK-BE-NEXT:    or $2, $2, $9
+; CHECK-BE-NEXT:    and $1, $2, $1
+; CHECK-BE-NEXT:    addu $1, $3, $1
+; CHECK-BE-NEXT:    andi $2, $8, 16
+; CHECK-BE-NEXT:    srl $2, $2, 4
+; CHECK-BE-NEXT:    addu $1, $1, $2
+; CHECK-BE-NEXT:    lui $2, 8
+; CHECK-BE-NEXT:    ori $2, $2, 2
+; CHECK-BE-NEXT:    addu $1, $1, $2
+; CHECK-BE-NEXT:    lui $2, 1771
+; CHECK-BE-NEXT:    ori $2, $2, 15942
+; CHECK-BE-NEXT:    multu $1, $2
+; CHECK-BE-NEXT:    mfhi $2
+; CHECK-BE-NEXT:    srl $3, $7, 5
+; CHECK-BE-NEXT:    sll $6, $6, 27
+; CHECK-BE-NEXT:    or $3, $6, $3
+; CHECK-BE-NEXT:    sll $6, $7, 27
+; CHECK-BE-NEXT:    sll $7, $2, 2
+; CHECK-BE-NEXT:    addu $7, $7, $2
+; CHECK-BE-NEXT:    sll $2, $2, 5
+; CHECK-BE-NEXT:    addu $2, $2, $7
+; CHECK-BE-NEXT:    subu $1, $1, $2
+; CHECK-BE-NEXT:    addiu $1, $1, 27
+; CHECK-BE-NEXT:    andi $7, $1, 32
+; CHECK-BE-NEXT:    movz $4, $5, $7
+; CHECK-BE-NEXT:    movz $5, $3, $7
+; CHECK-BE-NEXT:    srlv $2, $5, $1
+; CHECK-BE-NEXT:    not $8, $1
+; CHECK-BE-NEXT:    sll $4, $4, 1
+; CHECK-BE-NEXT:    sllv $4, $4, $8
+; CHECK-BE-NEXT:    or $2, $4, $2
+; CHECK-BE-NEXT:    movz $3, $6, $7
+; CHECK-BE-NEXT:    srlv $1, $3, $1
+; CHECK-BE-NEXT:    sll $3, $5, 1
+; CHECK-BE-NEXT:    sllv $3, $3, $8
 ; CHECK-BE-NEXT:    jr $ra
-; CHECK-BE-NEXT:    addiu $sp, $sp, 40
+; CHECK-BE-NEXT:    or $3, $3, $1
 ;
 ; CHECK-LE-LABEL: fshr_i37:
 ; CHECK-LE:       # %bb.0:
-; CHECK-LE-NEXT:    addiu $sp, $sp, -40
-; CHECK-LE-NEXT:    .cfi_def_cfa_offset 40
-; CHECK-LE-NEXT:    sw $ra, 36($sp) # 4-byte Folded Spill
-; CHECK-LE-NEXT:    sw $19, 32($sp) # 4-byte Folded Spill
-; CHECK-LE-NEXT:    sw $18, 28($sp) # 4-byte Folded Spill
-; CHECK-LE-NEXT:    sw $17, 24($sp) # 4-byte Folded Spill
-; CHECK-LE-NEXT:    sw $16, 20($sp) # 4-byte Folded Spill
-; CHECK-LE-NEXT:    .cfi_offset 31, -4
-; CHECK-LE-NEXT:    .cfi_offset 19, -8
-; CHECK-LE-NEXT:    .cfi_offset 18, -12
-; CHECK-LE-NEXT:    .cfi_offset 17, -16
-; CHECK-LE-NEXT:    .cfi_offset 16, -20
-; CHECK-LE-NEXT:    move $16, $7
-; CHECK-LE-NEXT:    move $17, $6
-; CHECK-LE-NEXT:    move $18, $5
-; CHECK-LE-NEXT:    move $19, $4
-; CHECK-LE-NEXT:    lw $1, 60($sp)
-; CHECK-LE-NEXT:    andi $5, $1, 31
-; CHECK-LE-NEXT:    lw $4, 56($sp)
-; CHECK-LE-NEXT:    addiu $6, $zero, 37
-; CHECK-LE-NEXT:    jal __umoddi3
-; CHECK-LE-NEXT:    addiu $7, $zero, 0
-; CHECK-LE-NEXT:    addiu $1, $2, 27
-; CHECK-LE-NEXT:    andi $3, $1, 32
-; CHECK-LE-NEXT:    srl $2, $17, 5
-; CHECK-LE-NEXT:    sll $4, $16, 27
-; CHECK-LE-NEXT:    or $2, $4, $2
-; CHECK-LE-NEXT:    sll $4, $17, 27
-; CHECK-LE-NEXT:    move $5, $19
-; CHECK-LE-NEXT:    movz $5, $2, $3
-; CHECK-LE-NEXT:    movz $2, $4, $3
-; CHECK-LE-NEXT:    srlv $2, $2, $1
-; CHECK-LE-NEXT:    not $4, $1
-; CHECK-LE-NEXT:    sll $6, $5, 1
-; CHECK-LE-NEXT:    sllv $6, $6, $4
+; CHECK-LE-NEXT:    lui $1, 3
+; CHECK-LE-NEXT:    ori $1, $1, 65535
+; CHECK-LE-NEXT:    lw $2, 16($sp)
+; CHECK-LE-NEXT:    and $3, $2, $1
+; CHECK-LE-NEXT:    lw $8, 20($sp)
+; CHECK-LE-NEXT:    sll $9, $8, 14
+; CHECK-LE-NEXT:    srl $2, $2, 18
+; CHECK-LE-NEXT:    or $2, $2, $9
+; CHECK-LE-NEXT:    and $1, $2, $1
+; CHECK-LE-NEXT:    addu $1, $3, $1
+; CHECK-LE-NEXT:    andi $2, $8, 16
+; CHECK-LE-NEXT:    srl $2, $2, 4
+; CHECK-LE-NEXT:    addu $1, $1, $2
+; CHECK-LE-NEXT:    lui $2, 8
+; CHECK-LE-NEXT:    ori $2, $2, 2
+; CHECK-LE-NEXT:    addu $1, $1, $2
+; CHECK-LE-NEXT:    lui $2, 1771
+; CHECK-LE-NEXT:    ori $2, $2, 15942
+; CHECK-LE-NEXT:    multu $1, $2
+; CHECK-LE-NEXT:    mfhi $2
+; CHECK-LE-NEXT:    srl $3, $6, 5
+; CHECK-LE-NEXT:    sll $7, $7, 27
+; CHECK-LE-NEXT:    or $3, $7, $3
+; CHECK-LE-NEXT:    sll $6, $6, 27
+; CHECK-LE-NEXT:    sll $7, $2, 2
+; CHECK-LE-NEXT:    addu $7, $7, $2
+; CHECK-LE-NEXT:    sll $2, $2, 5
+; CHECK-LE-NEXT:    addu $2, $2, $7
+; CHECK-LE-NEXT:    subu $1, $1, $2
+; CHECK-LE-NEXT:    addiu $1, $1, 27
+; CHECK-LE-NEXT:    andi $7, $1, 32
+; CHECK-LE-NEXT:    move $8, $4
+; CHECK-LE-NEXT:    movz $8, $3, $7
+; CHECK-LE-NEXT:    movz $3, $6, $7
+; CHECK-LE-NEXT:    srlv $2, $3, $1
+; CHECK-LE-NEXT:    not $3, $1
+; CHECK-LE-NEXT:    sll $6, $8, 1
+; CHECK-LE-NEXT:    sllv $6, $6, $3
 ; CHECK-LE-NEXT:    or $2, $6, $2
-; CHECK-LE-NEXT:    srlv $1, $5, $1
-; CHECK-LE-NEXT:    movz $18, $19, $3
-; CHECK-LE-NEXT:    sll $3, $18, 1
-; CHECK-LE-NEXT:    sllv $3, $3, $4
-; CHECK-LE-NEXT:    or $3, $3, $1
-; CHECK-LE-NEXT:    lw $16, 20($sp) # 4-byte Folded Reload
-; CHECK-LE-NEXT:    lw $17, 24($sp) # 4-byte Folded Reload
-; CHECK-LE-NEXT:    lw $18, 28($sp) # 4-byte Folded Reload
-; CHECK-LE-NEXT:    lw $19, 32($sp) # 4-byte Folded Reload
-; CHECK-LE-NEXT:    lw $ra, 36($sp) # 4-byte Folded Reload
+; CHECK-LE-NEXT:    srlv $1, $8, $1
+; CHECK-LE-NEXT:    movz $5, $4, $7
+; CHECK-LE-NEXT:    sll $4, $5, 1
+; CHECK-LE-NEXT:    sllv $3, $4, $3
 ; CHECK-LE-NEXT:    jr $ra
-; CHECK-LE-NEXT:    addiu $sp, $sp, 40
+; CHECK-LE-NEXT:    or $3, $3, $1
   %f = call i37 @llvm.fshr.i37(i37 %x, i37 %y, i37 %z)
   ret i37 %f
 }

--- a/llvm/test/CodeGen/Mips/funnel-shift.ll
+++ b/llvm/test/CodeGen/Mips/funnel-shift.ll
@@ -57,36 +57,41 @@ define i37 @fshl_i37(i37 %x, i37 %y, i37 %z) {
 ; CHECK-BE-NEXT:    srl $2, $2, 18
 ; CHECK-BE-NEXT:    or $2, $2, $9
 ; CHECK-BE-NEXT:    and $1, $2, $1
-; CHECK-BE-NEXT:    addu $1, $3, $1
+; CHECK-BE-NEXT:    subu $1, $3, $1
 ; CHECK-BE-NEXT:    andi $2, $8, 16
 ; CHECK-BE-NEXT:    srl $2, $2, 4
 ; CHECK-BE-NEXT:    addu $1, $1, $2
 ; CHECK-BE-NEXT:    lui $2, 8
 ; CHECK-BE-NEXT:    ori $2, $2, 2
 ; CHECK-BE-NEXT:    addu $1, $1, $2
-; CHECK-BE-NEXT:    lui $2, 1771
-; CHECK-BE-NEXT:    ori $2, $2, 15942
+; CHECK-BE-NEXT:    lui $2, 47823
+; CHECK-BE-NEXT:    ori $2, $2, 37197
 ; CHECK-BE-NEXT:    multu $1, $2
 ; CHECK-BE-NEXT:    mfhi $2
 ; CHECK-BE-NEXT:    srl $3, $7, 5
 ; CHECK-BE-NEXT:    sll $6, $6, 27
 ; CHECK-BE-NEXT:    or $3, $6, $3
-; CHECK-BE-NEXT:    sll $6, $7, 27
-; CHECK-BE-NEXT:    sll $7, $2, 2
-; CHECK-BE-NEXT:    addu $7, $7, $2
-; CHECK-BE-NEXT:    sll $2, $2, 5
-; CHECK-BE-NEXT:    addu $2, $2, $7
+; CHECK-BE-NEXT:    addiu $6, $zero, -32
+; CHECK-BE-NEXT:    sll $7, $7, 27
+; CHECK-BE-NEXT:    subu $8, $1, $2
+; CHECK-BE-NEXT:    srl $8, $8, 1
+; CHECK-BE-NEXT:    addu $2, $8, $2
+; CHECK-BE-NEXT:    srl $8, $2, 5
+; CHECK-BE-NEXT:    sll $9, $8, 2
+; CHECK-BE-NEXT:    addu $8, $9, $8
+; CHECK-BE-NEXT:    and $2, $2, $6
+; CHECK-BE-NEXT:    addu $2, $2, $8
 ; CHECK-BE-NEXT:    subu $1, $1, $2
-; CHECK-BE-NEXT:    srl $7, $1, 5
-; CHECK-BE-NEXT:    movn $4, $5, $7
+; CHECK-BE-NEXT:    srl $6, $1, 5
+; CHECK-BE-NEXT:    movn $4, $5, $6
 ; CHECK-BE-NEXT:    sllv $2, $4, $1
 ; CHECK-BE-NEXT:    not $4, $1
-; CHECK-BE-NEXT:    movn $5, $3, $7
+; CHECK-BE-NEXT:    movn $5, $3, $6
 ; CHECK-BE-NEXT:    srl $8, $5, 1
 ; CHECK-BE-NEXT:    srlv $8, $8, $4
 ; CHECK-BE-NEXT:    or $2, $2, $8
 ; CHECK-BE-NEXT:    sllv $1, $5, $1
-; CHECK-BE-NEXT:    movn $3, $6, $7
+; CHECK-BE-NEXT:    movn $3, $7, $6
 ; CHECK-BE-NEXT:    srl $3, $3, 1
 ; CHECK-BE-NEXT:    srlv $3, $3, $4
 ; CHECK-BE-NEXT:    jr $ra
@@ -103,25 +108,30 @@ define i37 @fshl_i37(i37 %x, i37 %y, i37 %z) {
 ; CHECK-LE-NEXT:    srl $2, $2, 18
 ; CHECK-LE-NEXT:    or $2, $2, $9
 ; CHECK-LE-NEXT:    and $1, $2, $1
-; CHECK-LE-NEXT:    addu $1, $3, $1
+; CHECK-LE-NEXT:    subu $1, $3, $1
 ; CHECK-LE-NEXT:    andi $2, $8, 16
 ; CHECK-LE-NEXT:    srl $2, $2, 4
 ; CHECK-LE-NEXT:    addu $1, $1, $2
 ; CHECK-LE-NEXT:    lui $2, 8
 ; CHECK-LE-NEXT:    ori $2, $2, 2
 ; CHECK-LE-NEXT:    addu $1, $1, $2
-; CHECK-LE-NEXT:    lui $2, 1771
-; CHECK-LE-NEXT:    ori $2, $2, 15942
+; CHECK-LE-NEXT:    lui $2, 47823
+; CHECK-LE-NEXT:    ori $2, $2, 37197
 ; CHECK-LE-NEXT:    multu $1, $2
 ; CHECK-LE-NEXT:    mfhi $2
 ; CHECK-LE-NEXT:    srl $3, $6, 5
 ; CHECK-LE-NEXT:    sll $7, $7, 27
 ; CHECK-LE-NEXT:    or $3, $7, $3
 ; CHECK-LE-NEXT:    sll $6, $6, 27
-; CHECK-LE-NEXT:    sll $7, $2, 2
-; CHECK-LE-NEXT:    addu $7, $7, $2
-; CHECK-LE-NEXT:    sll $2, $2, 5
-; CHECK-LE-NEXT:    addu $2, $2, $7
+; CHECK-LE-NEXT:    addiu $7, $zero, -32
+; CHECK-LE-NEXT:    subu $8, $1, $2
+; CHECK-LE-NEXT:    srl $8, $8, 1
+; CHECK-LE-NEXT:    addu $2, $8, $2
+; CHECK-LE-NEXT:    srl $8, $2, 5
+; CHECK-LE-NEXT:    sll $9, $8, 2
+; CHECK-LE-NEXT:    addu $8, $9, $8
+; CHECK-LE-NEXT:    and $2, $2, $7
+; CHECK-LE-NEXT:    addu $2, $2, $8
 ; CHECK-LE-NEXT:    subu $1, $1, $2
 ; CHECK-LE-NEXT:    srl $7, $1, 5
 ; CHECK-LE-NEXT:    move $8, $4
@@ -288,25 +298,30 @@ define i37 @fshr_i37(i37 %x, i37 %y, i37 %z) {
 ; CHECK-BE-NEXT:    srl $2, $2, 18
 ; CHECK-BE-NEXT:    or $2, $2, $9
 ; CHECK-BE-NEXT:    and $1, $2, $1
-; CHECK-BE-NEXT:    addu $1, $3, $1
+; CHECK-BE-NEXT:    subu $1, $3, $1
 ; CHECK-BE-NEXT:    andi $2, $8, 16
 ; CHECK-BE-NEXT:    srl $2, $2, 4
 ; CHECK-BE-NEXT:    addu $1, $1, $2
 ; CHECK-BE-NEXT:    lui $2, 8
 ; CHECK-BE-NEXT:    ori $2, $2, 2
 ; CHECK-BE-NEXT:    addu $1, $1, $2
-; CHECK-BE-NEXT:    lui $2, 1771
-; CHECK-BE-NEXT:    ori $2, $2, 15942
+; CHECK-BE-NEXT:    lui $2, 47823
+; CHECK-BE-NEXT:    ori $2, $2, 37197
 ; CHECK-BE-NEXT:    multu $1, $2
 ; CHECK-BE-NEXT:    mfhi $2
 ; CHECK-BE-NEXT:    srl $3, $7, 5
 ; CHECK-BE-NEXT:    sll $6, $6, 27
 ; CHECK-BE-NEXT:    or $3, $6, $3
 ; CHECK-BE-NEXT:    sll $6, $7, 27
-; CHECK-BE-NEXT:    sll $7, $2, 2
-; CHECK-BE-NEXT:    addu $7, $7, $2
-; CHECK-BE-NEXT:    sll $2, $2, 5
-; CHECK-BE-NEXT:    addu $2, $2, $7
+; CHECK-BE-NEXT:    addiu $7, $zero, -32
+; CHECK-BE-NEXT:    subu $8, $1, $2
+; CHECK-BE-NEXT:    srl $8, $8, 1
+; CHECK-BE-NEXT:    addu $2, $8, $2
+; CHECK-BE-NEXT:    srl $8, $2, 5
+; CHECK-BE-NEXT:    sll $9, $8, 2
+; CHECK-BE-NEXT:    addu $8, $9, $8
+; CHECK-BE-NEXT:    and $2, $2, $7
+; CHECK-BE-NEXT:    addu $2, $2, $8
 ; CHECK-BE-NEXT:    subu $1, $1, $2
 ; CHECK-BE-NEXT:    addiu $1, $1, 27
 ; CHECK-BE-NEXT:    andi $7, $1, 32
@@ -335,25 +350,30 @@ define i37 @fshr_i37(i37 %x, i37 %y, i37 %z) {
 ; CHECK-LE-NEXT:    srl $2, $2, 18
 ; CHECK-LE-NEXT:    or $2, $2, $9
 ; CHECK-LE-NEXT:    and $1, $2, $1
-; CHECK-LE-NEXT:    addu $1, $3, $1
+; CHECK-LE-NEXT:    subu $1, $3, $1
 ; CHECK-LE-NEXT:    andi $2, $8, 16
 ; CHECK-LE-NEXT:    srl $2, $2, 4
 ; CHECK-LE-NEXT:    addu $1, $1, $2
 ; CHECK-LE-NEXT:    lui $2, 8
 ; CHECK-LE-NEXT:    ori $2, $2, 2
 ; CHECK-LE-NEXT:    addu $1, $1, $2
-; CHECK-LE-NEXT:    lui $2, 1771
-; CHECK-LE-NEXT:    ori $2, $2, 15942
+; CHECK-LE-NEXT:    lui $2, 47823
+; CHECK-LE-NEXT:    ori $2, $2, 37197
 ; CHECK-LE-NEXT:    multu $1, $2
 ; CHECK-LE-NEXT:    mfhi $2
 ; CHECK-LE-NEXT:    srl $3, $6, 5
 ; CHECK-LE-NEXT:    sll $7, $7, 27
 ; CHECK-LE-NEXT:    or $3, $7, $3
 ; CHECK-LE-NEXT:    sll $6, $6, 27
-; CHECK-LE-NEXT:    sll $7, $2, 2
-; CHECK-LE-NEXT:    addu $7, $7, $2
-; CHECK-LE-NEXT:    sll $2, $2, 5
-; CHECK-LE-NEXT:    addu $2, $2, $7
+; CHECK-LE-NEXT:    addiu $7, $zero, -32
+; CHECK-LE-NEXT:    subu $8, $1, $2
+; CHECK-LE-NEXT:    srl $8, $8, 1
+; CHECK-LE-NEXT:    addu $2, $8, $2
+; CHECK-LE-NEXT:    srl $8, $2, 5
+; CHECK-LE-NEXT:    sll $9, $8, 2
+; CHECK-LE-NEXT:    addu $8, $9, $8
+; CHECK-LE-NEXT:    and $2, $2, $7
+; CHECK-LE-NEXT:    addu $2, $2, $8
 ; CHECK-LE-NEXT:    subu $1, $1, $2
 ; CHECK-LE-NEXT:    addiu $1, $1, 27
 ; CHECK-LE-NEXT:    andi $7, $1, 32

--- a/llvm/test/CodeGen/PowerPC/funnel-shift.ll
+++ b/llvm/test/CodeGen/PowerPC/funnel-shift.ll
@@ -270,116 +270,84 @@ declare i37 @llvm.fshl.i37(i37, i37, i37)
 define i37 @fshl_i37(i37 %x, i37 %y, i37 %z) {
 ; CHECK32_32-LABEL: fshl_i37:
 ; CHECK32_32:       # %bb.0:
-; CHECK32_32-NEXT:    mflr 0
-; CHECK32_32-NEXT:    stwu 1, -32(1)
-; CHECK32_32-NEXT:    stw 0, 36(1)
-; CHECK32_32-NEXT:    .cfi_def_cfa_offset 32
-; CHECK32_32-NEXT:    .cfi_offset lr, 4
-; CHECK32_32-NEXT:    .cfi_offset r27, -20
-; CHECK32_32-NEXT:    .cfi_offset r28, -16
-; CHECK32_32-NEXT:    .cfi_offset r29, -12
-; CHECK32_32-NEXT:    .cfi_offset r30, -8
-; CHECK32_32-NEXT:    stw 27, 12(1) # 4-byte Folded Spill
-; CHECK32_32-NEXT:    mr 27, 5
-; CHECK32_32-NEXT:    stw 28, 16(1) # 4-byte Folded Spill
-; CHECK32_32-NEXT:    mr 28, 3
-; CHECK32_32-NEXT:    stw 29, 20(1) # 4-byte Folded Spill
-; CHECK32_32-NEXT:    mr 29, 4
-; CHECK32_32-NEXT:    stw 30, 24(1) # 4-byte Folded Spill
-; CHECK32_32-NEXT:    mr 30, 6
-; CHECK32_32-NEXT:    clrlwi 3, 7, 27
-; CHECK32_32-NEXT:    mr 4, 8
-; CHECK32_32-NEXT:    li 5, 0
-; CHECK32_32-NEXT:    li 6, 37
-; CHECK32_32-NEXT:    bl __umoddi3
-; CHECK32_32-NEXT:    rotlwi 5, 30, 27
-; CHECK32_32-NEXT:    rlwimi 5, 27, 27, 0, 4
-; CHECK32_32-NEXT:    andi. 3, 4, 32
-; CHECK32_32-NEXT:    mr 6, 5
+; CHECK32_32-NEXT:    srwi 10, 8, 18
+; CHECK32_32-NEXT:    clrlwi 8, 8, 14
+; CHECK32_32-NEXT:    rlwimi 10, 7, 14, 14, 17
+; CHECK32_32-NEXT:    add 8, 8, 10
+; CHECK32_32-NEXT:    rlwinm 7, 7, 28, 31, 31
+; CHECK32_32-NEXT:    add 7, 8, 7
+; CHECK32_32-NEXT:    lis 9, 1771
+; CHECK32_32-NEXT:    addi 7, 7, 2
+; CHECK32_32-NEXT:    ori 9, 9, 15942
+; CHECK32_32-NEXT:    addis 7, 7, 8
+; CHECK32_32-NEXT:    mulhwu 8, 7, 9
+; CHECK32_32-NEXT:    mulli 8, 8, 37
+; CHECK32_32-NEXT:    sub 8, 7, 8
+; CHECK32_32-NEXT:    andi. 7, 8, 32
+; CHECK32_32-NEXT:    rotlwi 7, 6, 27
+; CHECK32_32-NEXT:    rlwimi 7, 5, 27, 0, 4
+; CHECK32_32-NEXT:    mr 5, 7
 ; CHECK32_32-NEXT:    bne 0, .LBB3_2
 ; CHECK32_32-NEXT:  # %bb.1:
-; CHECK32_32-NEXT:    mr 6, 29
+; CHECK32_32-NEXT:    mr 5, 4
 ; CHECK32_32-NEXT:  .LBB3_2:
-; CHECK32_32-NEXT:    clrlwi 4, 4, 27
-; CHECK32_32-NEXT:    subfic 7, 4, 32
-; CHECK32_32-NEXT:    srw 3, 6, 7
+; CHECK32_32-NEXT:    clrlwi 8, 8, 27
+; CHECK32_32-NEXT:    subfic 9, 8, 32
+; CHECK32_32-NEXT:    srw 10, 5, 9
 ; CHECK32_32-NEXT:    bne 0, .LBB3_4
 ; CHECK32_32-NEXT:  # %bb.3:
-; CHECK32_32-NEXT:    mr 29, 28
+; CHECK32_32-NEXT:    mr 4, 3
 ; CHECK32_32-NEXT:  .LBB3_4:
-; CHECK32_32-NEXT:    slw 8, 29, 4
-; CHECK32_32-NEXT:    or 3, 8, 3
+; CHECK32_32-NEXT:    slw 3, 4, 8
+; CHECK32_32-NEXT:    or 3, 3, 10
 ; CHECK32_32-NEXT:    beq 0, .LBB3_6
 ; CHECK32_32-NEXT:  # %bb.5:
-; CHECK32_32-NEXT:    slwi 5, 30, 27
+; CHECK32_32-NEXT:    slwi 7, 6, 27
 ; CHECK32_32-NEXT:  .LBB3_6:
-; CHECK32_32-NEXT:    srw 5, 5, 7
-; CHECK32_32-NEXT:    slw 4, 6, 4
-; CHECK32_32-NEXT:    or 4, 4, 5
-; CHECK32_32-NEXT:    lwz 30, 24(1) # 4-byte Folded Reload
-; CHECK32_32-NEXT:    lwz 29, 20(1) # 4-byte Folded Reload
-; CHECK32_32-NEXT:    lwz 28, 16(1) # 4-byte Folded Reload
-; CHECK32_32-NEXT:    lwz 27, 12(1) # 4-byte Folded Reload
-; CHECK32_32-NEXT:    lwz 0, 36(1)
-; CHECK32_32-NEXT:    addi 1, 1, 32
-; CHECK32_32-NEXT:    mtlr 0
+; CHECK32_32-NEXT:    srw 4, 7, 9
+; CHECK32_32-NEXT:    slw 5, 5, 8
+; CHECK32_32-NEXT:    or 4, 5, 4
 ; CHECK32_32-NEXT:    blr
 ;
 ; CHECK32_64-LABEL: fshl_i37:
 ; CHECK32_64:       # %bb.0:
-; CHECK32_64-NEXT:    mflr 0
-; CHECK32_64-NEXT:    stwu 1, -32(1)
-; CHECK32_64-NEXT:    stw 0, 36(1)
-; CHECK32_64-NEXT:    .cfi_def_cfa_offset 32
-; CHECK32_64-NEXT:    .cfi_offset lr, 4
-; CHECK32_64-NEXT:    .cfi_offset r27, -20
-; CHECK32_64-NEXT:    .cfi_offset r28, -16
-; CHECK32_64-NEXT:    .cfi_offset r29, -12
-; CHECK32_64-NEXT:    .cfi_offset r30, -8
-; CHECK32_64-NEXT:    stw 27, 12(1) # 4-byte Folded Spill
-; CHECK32_64-NEXT:    mr 27, 5
-; CHECK32_64-NEXT:    li 5, 0
-; CHECK32_64-NEXT:    stw 28, 16(1) # 4-byte Folded Spill
-; CHECK32_64-NEXT:    mr 28, 3
-; CHECK32_64-NEXT:    clrlwi 3, 7, 27
-; CHECK32_64-NEXT:    stw 29, 20(1) # 4-byte Folded Spill
-; CHECK32_64-NEXT:    mr 29, 4
-; CHECK32_64-NEXT:    mr 4, 8
-; CHECK32_64-NEXT:    stw 30, 24(1) # 4-byte Folded Spill
-; CHECK32_64-NEXT:    mr 30, 6
-; CHECK32_64-NEXT:    li 6, 37
-; CHECK32_64-NEXT:    bl __umoddi3
-; CHECK32_64-NEXT:    rotlwi 5, 30, 27
-; CHECK32_64-NEXT:    andi. 3, 4, 32
-; CHECK32_64-NEXT:    rlwimi 5, 27, 27, 0, 4
-; CHECK32_64-NEXT:    mr 6, 5
+; CHECK32_64-NEXT:    srwi 10, 8, 18
+; CHECK32_64-NEXT:    clrlwi 8, 8, 14
+; CHECK32_64-NEXT:    rlwimi 10, 7, 14, 14, 17
+; CHECK32_64-NEXT:    rlwinm 7, 7, 28, 31, 31
+; CHECK32_64-NEXT:    add 8, 8, 10
+; CHECK32_64-NEXT:    add 7, 8, 7
+; CHECK32_64-NEXT:    lis 9, 1771
+; CHECK32_64-NEXT:    addi 7, 7, 2
+; CHECK32_64-NEXT:    ori 9, 9, 15942
+; CHECK32_64-NEXT:    addis 7, 7, 8
+; CHECK32_64-NEXT:    mulhwu 8, 7, 9
+; CHECK32_64-NEXT:    mulli 8, 8, 37
+; CHECK32_64-NEXT:    sub 8, 7, 8
+; CHECK32_64-NEXT:    andi. 7, 8, 32
+; CHECK32_64-NEXT:    rotlwi 7, 6, 27
+; CHECK32_64-NEXT:    rlwimi 7, 5, 27, 0, 4
+; CHECK32_64-NEXT:    mr 5, 7
 ; CHECK32_64-NEXT:    bne 0, .LBB3_2
 ; CHECK32_64-NEXT:  # %bb.1:
-; CHECK32_64-NEXT:    mr 6, 29
+; CHECK32_64-NEXT:    mr 5, 4
 ; CHECK32_64-NEXT:  .LBB3_2:
-; CHECK32_64-NEXT:    clrlwi 4, 4, 27
-; CHECK32_64-NEXT:    subfic 7, 4, 32
-; CHECK32_64-NEXT:    srw 3, 6, 7
+; CHECK32_64-NEXT:    clrlwi 8, 8, 27
+; CHECK32_64-NEXT:    subfic 9, 8, 32
+; CHECK32_64-NEXT:    srw 10, 5, 9
 ; CHECK32_64-NEXT:    bne 0, .LBB3_4
 ; CHECK32_64-NEXT:  # %bb.3:
-; CHECK32_64-NEXT:    mr 29, 28
+; CHECK32_64-NEXT:    mr 4, 3
 ; CHECK32_64-NEXT:  .LBB3_4:
-; CHECK32_64-NEXT:    slw 8, 29, 4
-; CHECK32_64-NEXT:    or 3, 8, 3
+; CHECK32_64-NEXT:    slw 3, 4, 8
+; CHECK32_64-NEXT:    or 3, 3, 10
 ; CHECK32_64-NEXT:    beq 0, .LBB3_6
 ; CHECK32_64-NEXT:  # %bb.5:
-; CHECK32_64-NEXT:    slwi 5, 30, 27
+; CHECK32_64-NEXT:    slwi 7, 6, 27
 ; CHECK32_64-NEXT:  .LBB3_6:
-; CHECK32_64-NEXT:    srw 5, 5, 7
-; CHECK32_64-NEXT:    slw 4, 6, 4
-; CHECK32_64-NEXT:    lwz 30, 24(1) # 4-byte Folded Reload
-; CHECK32_64-NEXT:    or 4, 4, 5
-; CHECK32_64-NEXT:    lwz 29, 20(1) # 4-byte Folded Reload
-; CHECK32_64-NEXT:    lwz 28, 16(1) # 4-byte Folded Reload
-; CHECK32_64-NEXT:    lwz 27, 12(1) # 4-byte Folded Reload
-; CHECK32_64-NEXT:    lwz 0, 36(1)
-; CHECK32_64-NEXT:    addi 1, 1, 32
-; CHECK32_64-NEXT:    mtlr 0
+; CHECK32_64-NEXT:    srw 4, 7, 9
+; CHECK32_64-NEXT:    slw 5, 5, 8
+; CHECK32_64-NEXT:    or 4, 5, 4
 ; CHECK32_64-NEXT:    blr
 ;
 ; CHECK64-LABEL: fshl_i37:
@@ -536,118 +504,86 @@ declare i37 @llvm.fshr.i37(i37, i37, i37)
 define i37 @fshr_i37(i37 %x, i37 %y, i37 %z) {
 ; CHECK32_32-LABEL: fshr_i37:
 ; CHECK32_32:       # %bb.0:
-; CHECK32_32-NEXT:    mflr 0
-; CHECK32_32-NEXT:    stwu 1, -32(1)
-; CHECK32_32-NEXT:    stw 0, 36(1)
-; CHECK32_32-NEXT:    .cfi_def_cfa_offset 32
-; CHECK32_32-NEXT:    .cfi_offset lr, 4
-; CHECK32_32-NEXT:    .cfi_offset r27, -20
-; CHECK32_32-NEXT:    .cfi_offset r28, -16
-; CHECK32_32-NEXT:    .cfi_offset r29, -12
-; CHECK32_32-NEXT:    .cfi_offset r30, -8
-; CHECK32_32-NEXT:    stw 27, 12(1) # 4-byte Folded Spill
-; CHECK32_32-NEXT:    mr 27, 5
-; CHECK32_32-NEXT:    stw 28, 16(1) # 4-byte Folded Spill
-; CHECK32_32-NEXT:    mr 28, 3
-; CHECK32_32-NEXT:    stw 29, 20(1) # 4-byte Folded Spill
-; CHECK32_32-NEXT:    mr 29, 4
-; CHECK32_32-NEXT:    stw 30, 24(1) # 4-byte Folded Spill
-; CHECK32_32-NEXT:    mr 30, 6
-; CHECK32_32-NEXT:    clrlwi 3, 7, 27
-; CHECK32_32-NEXT:    mr 4, 8
-; CHECK32_32-NEXT:    li 5, 0
-; CHECK32_32-NEXT:    li 6, 37
-; CHECK32_32-NEXT:    bl __umoddi3
-; CHECK32_32-NEXT:    rotlwi 5, 30, 27
-; CHECK32_32-NEXT:    addi 3, 4, 27
-; CHECK32_32-NEXT:    andi. 4, 3, 32
-; CHECK32_32-NEXT:    rlwimi 5, 27, 27, 0, 4
-; CHECK32_32-NEXT:    mr 4, 5
+; CHECK32_32-NEXT:    srwi 10, 8, 18
+; CHECK32_32-NEXT:    clrlwi 8, 8, 14
+; CHECK32_32-NEXT:    rlwimi 10, 7, 14, 14, 17
+; CHECK32_32-NEXT:    add 8, 8, 10
+; CHECK32_32-NEXT:    rlwinm 7, 7, 28, 31, 31
+; CHECK32_32-NEXT:    add 7, 8, 7
+; CHECK32_32-NEXT:    lis 9, 1771
+; CHECK32_32-NEXT:    addi 7, 7, 2
+; CHECK32_32-NEXT:    ori 9, 9, 15942
+; CHECK32_32-NEXT:    addis 7, 7, 8
+; CHECK32_32-NEXT:    mulhwu 8, 7, 9
+; CHECK32_32-NEXT:    mulli 8, 8, 37
+; CHECK32_32-NEXT:    sub 7, 7, 8
+; CHECK32_32-NEXT:    addi 8, 7, 27
+; CHECK32_32-NEXT:    andi. 7, 8, 32
+; CHECK32_32-NEXT:    rotlwi 7, 6, 27
+; CHECK32_32-NEXT:    rlwimi 7, 5, 27, 0, 4
+; CHECK32_32-NEXT:    mr 5, 7
 ; CHECK32_32-NEXT:    beq 0, .LBB11_2
 ; CHECK32_32-NEXT:  # %bb.1:
-; CHECK32_32-NEXT:    mr 4, 29
+; CHECK32_32-NEXT:    mr 5, 4
 ; CHECK32_32-NEXT:  .LBB11_2:
-; CHECK32_32-NEXT:    clrlwi 6, 3, 27
-; CHECK32_32-NEXT:    srw 3, 4, 6
+; CHECK32_32-NEXT:    clrlwi 8, 8, 27
+; CHECK32_32-NEXT:    srw 10, 5, 8
 ; CHECK32_32-NEXT:    beq 0, .LBB11_4
 ; CHECK32_32-NEXT:  # %bb.3:
-; CHECK32_32-NEXT:    mr 29, 28
+; CHECK32_32-NEXT:    mr 4, 3
 ; CHECK32_32-NEXT:  .LBB11_4:
-; CHECK32_32-NEXT:    subfic 7, 6, 32
-; CHECK32_32-NEXT:    slw 8, 29, 7
-; CHECK32_32-NEXT:    or 3, 8, 3
+; CHECK32_32-NEXT:    subfic 9, 8, 32
+; CHECK32_32-NEXT:    slw 3, 4, 9
+; CHECK32_32-NEXT:    or 3, 3, 10
 ; CHECK32_32-NEXT:    bne 0, .LBB11_6
 ; CHECK32_32-NEXT:  # %bb.5:
-; CHECK32_32-NEXT:    slwi 5, 30, 27
+; CHECK32_32-NEXT:    slwi 7, 6, 27
 ; CHECK32_32-NEXT:  .LBB11_6:
-; CHECK32_32-NEXT:    srw 5, 5, 6
-; CHECK32_32-NEXT:    slw 4, 4, 7
-; CHECK32_32-NEXT:    or 4, 4, 5
-; CHECK32_32-NEXT:    lwz 30, 24(1) # 4-byte Folded Reload
-; CHECK32_32-NEXT:    lwz 29, 20(1) # 4-byte Folded Reload
-; CHECK32_32-NEXT:    lwz 28, 16(1) # 4-byte Folded Reload
-; CHECK32_32-NEXT:    lwz 27, 12(1) # 4-byte Folded Reload
-; CHECK32_32-NEXT:    lwz 0, 36(1)
-; CHECK32_32-NEXT:    addi 1, 1, 32
-; CHECK32_32-NEXT:    mtlr 0
+; CHECK32_32-NEXT:    srw 4, 7, 8
+; CHECK32_32-NEXT:    slw 5, 5, 9
+; CHECK32_32-NEXT:    or 4, 5, 4
 ; CHECK32_32-NEXT:    blr
 ;
 ; CHECK32_64-LABEL: fshr_i37:
 ; CHECK32_64:       # %bb.0:
-; CHECK32_64-NEXT:    mflr 0
-; CHECK32_64-NEXT:    stwu 1, -32(1)
-; CHECK32_64-NEXT:    stw 0, 36(1)
-; CHECK32_64-NEXT:    .cfi_def_cfa_offset 32
-; CHECK32_64-NEXT:    .cfi_offset lr, 4
-; CHECK32_64-NEXT:    .cfi_offset r27, -20
-; CHECK32_64-NEXT:    .cfi_offset r28, -16
-; CHECK32_64-NEXT:    .cfi_offset r29, -12
-; CHECK32_64-NEXT:    .cfi_offset r30, -8
-; CHECK32_64-NEXT:    stw 27, 12(1) # 4-byte Folded Spill
-; CHECK32_64-NEXT:    mr 27, 5
-; CHECK32_64-NEXT:    li 5, 0
-; CHECK32_64-NEXT:    stw 28, 16(1) # 4-byte Folded Spill
-; CHECK32_64-NEXT:    mr 28, 3
-; CHECK32_64-NEXT:    clrlwi 3, 7, 27
-; CHECK32_64-NEXT:    stw 29, 20(1) # 4-byte Folded Spill
-; CHECK32_64-NEXT:    mr 29, 4
-; CHECK32_64-NEXT:    mr 4, 8
-; CHECK32_64-NEXT:    stw 30, 24(1) # 4-byte Folded Spill
-; CHECK32_64-NEXT:    mr 30, 6
-; CHECK32_64-NEXT:    li 6, 37
-; CHECK32_64-NEXT:    bl __umoddi3
-; CHECK32_64-NEXT:    rotlwi 5, 30, 27
-; CHECK32_64-NEXT:    addi 3, 4, 27
-; CHECK32_64-NEXT:    andi. 4, 3, 32
-; CHECK32_64-NEXT:    rlwimi 5, 27, 27, 0, 4
-; CHECK32_64-NEXT:    mr 4, 5
+; CHECK32_64-NEXT:    srwi 10, 8, 18
+; CHECK32_64-NEXT:    clrlwi 8, 8, 14
+; CHECK32_64-NEXT:    rlwimi 10, 7, 14, 14, 17
+; CHECK32_64-NEXT:    rlwinm 7, 7, 28, 31, 31
+; CHECK32_64-NEXT:    add 8, 8, 10
+; CHECK32_64-NEXT:    add 7, 8, 7
+; CHECK32_64-NEXT:    lis 9, 1771
+; CHECK32_64-NEXT:    addi 7, 7, 2
+; CHECK32_64-NEXT:    ori 9, 9, 15942
+; CHECK32_64-NEXT:    addis 7, 7, 8
+; CHECK32_64-NEXT:    mulhwu 8, 7, 9
+; CHECK32_64-NEXT:    mulli 8, 8, 37
+; CHECK32_64-NEXT:    sub 7, 7, 8
+; CHECK32_64-NEXT:    addi 8, 7, 27
+; CHECK32_64-NEXT:    andi. 7, 8, 32
+; CHECK32_64-NEXT:    rotlwi 7, 6, 27
+; CHECK32_64-NEXT:    rlwimi 7, 5, 27, 0, 4
+; CHECK32_64-NEXT:    mr 5, 7
 ; CHECK32_64-NEXT:    beq 0, .LBB11_2
 ; CHECK32_64-NEXT:  # %bb.1:
-; CHECK32_64-NEXT:    mr 4, 29
+; CHECK32_64-NEXT:    mr 5, 4
 ; CHECK32_64-NEXT:  .LBB11_2:
-; CHECK32_64-NEXT:    clrlwi 6, 3, 27
-; CHECK32_64-NEXT:    srw 3, 4, 6
+; CHECK32_64-NEXT:    clrlwi 8, 8, 27
+; CHECK32_64-NEXT:    srw 10, 5, 8
 ; CHECK32_64-NEXT:    beq 0, .LBB11_4
 ; CHECK32_64-NEXT:  # %bb.3:
-; CHECK32_64-NEXT:    mr 29, 28
+; CHECK32_64-NEXT:    mr 4, 3
 ; CHECK32_64-NEXT:  .LBB11_4:
-; CHECK32_64-NEXT:    subfic 7, 6, 32
-; CHECK32_64-NEXT:    slw 8, 29, 7
-; CHECK32_64-NEXT:    or 3, 8, 3
+; CHECK32_64-NEXT:    subfic 9, 8, 32
+; CHECK32_64-NEXT:    slw 3, 4, 9
+; CHECK32_64-NEXT:    or 3, 3, 10
 ; CHECK32_64-NEXT:    bne 0, .LBB11_6
 ; CHECK32_64-NEXT:  # %bb.5:
-; CHECK32_64-NEXT:    slwi 5, 30, 27
+; CHECK32_64-NEXT:    slwi 7, 6, 27
 ; CHECK32_64-NEXT:  .LBB11_6:
-; CHECK32_64-NEXT:    srw 5, 5, 6
-; CHECK32_64-NEXT:    slw 4, 4, 7
-; CHECK32_64-NEXT:    lwz 30, 24(1) # 4-byte Folded Reload
-; CHECK32_64-NEXT:    or 4, 4, 5
-; CHECK32_64-NEXT:    lwz 29, 20(1) # 4-byte Folded Reload
-; CHECK32_64-NEXT:    lwz 28, 16(1) # 4-byte Folded Reload
-; CHECK32_64-NEXT:    lwz 27, 12(1) # 4-byte Folded Reload
-; CHECK32_64-NEXT:    lwz 0, 36(1)
-; CHECK32_64-NEXT:    addi 1, 1, 32
-; CHECK32_64-NEXT:    mtlr 0
+; CHECK32_64-NEXT:    srw 4, 7, 8
+; CHECK32_64-NEXT:    slw 5, 5, 9
+; CHECK32_64-NEXT:    or 4, 5, 4
 ; CHECK32_64-NEXT:    blr
 ;
 ; CHECK64-LABEL: fshr_i37:

--- a/llvm/test/CodeGen/PowerPC/funnel-shift.ll
+++ b/llvm/test/CodeGen/PowerPC/funnel-shift.ll
@@ -273,14 +273,18 @@ define i37 @fshl_i37(i37 %x, i37 %y, i37 %z) {
 ; CHECK32_32-NEXT:    srwi 10, 8, 18
 ; CHECK32_32-NEXT:    clrlwi 8, 8, 14
 ; CHECK32_32-NEXT:    rlwimi 10, 7, 14, 14, 17
-; CHECK32_32-NEXT:    add 8, 8, 10
+; CHECK32_32-NEXT:    sub 8, 8, 10
 ; CHECK32_32-NEXT:    rlwinm 7, 7, 28, 31, 31
 ; CHECK32_32-NEXT:    add 7, 8, 7
-; CHECK32_32-NEXT:    lis 9, 1771
+; CHECK32_32-NEXT:    lis 9, -17713
 ; CHECK32_32-NEXT:    addi 7, 7, 2
-; CHECK32_32-NEXT:    ori 9, 9, 15942
+; CHECK32_32-NEXT:    ori 9, 9, 37197
 ; CHECK32_32-NEXT:    addis 7, 7, 8
 ; CHECK32_32-NEXT:    mulhwu 8, 7, 9
+; CHECK32_32-NEXT:    sub 9, 7, 8
+; CHECK32_32-NEXT:    srwi 9, 9, 1
+; CHECK32_32-NEXT:    add 8, 9, 8
+; CHECK32_32-NEXT:    srwi 8, 8, 5
 ; CHECK32_32-NEXT:    mulli 8, 8, 37
 ; CHECK32_32-NEXT:    sub 8, 7, 8
 ; CHECK32_32-NEXT:    andi. 7, 8, 32
@@ -315,13 +319,17 @@ define i37 @fshl_i37(i37 %x, i37 %y, i37 %z) {
 ; CHECK32_64-NEXT:    clrlwi 8, 8, 14
 ; CHECK32_64-NEXT:    rlwimi 10, 7, 14, 14, 17
 ; CHECK32_64-NEXT:    rlwinm 7, 7, 28, 31, 31
-; CHECK32_64-NEXT:    add 8, 8, 10
+; CHECK32_64-NEXT:    sub 8, 8, 10
 ; CHECK32_64-NEXT:    add 7, 8, 7
-; CHECK32_64-NEXT:    lis 9, 1771
+; CHECK32_64-NEXT:    lis 9, -17713
 ; CHECK32_64-NEXT:    addi 7, 7, 2
-; CHECK32_64-NEXT:    ori 9, 9, 15942
+; CHECK32_64-NEXT:    ori 9, 9, 37197
 ; CHECK32_64-NEXT:    addis 7, 7, 8
 ; CHECK32_64-NEXT:    mulhwu 8, 7, 9
+; CHECK32_64-NEXT:    sub 9, 7, 8
+; CHECK32_64-NEXT:    srwi 9, 9, 1
+; CHECK32_64-NEXT:    add 8, 9, 8
+; CHECK32_64-NEXT:    srwi 8, 8, 5
 ; CHECK32_64-NEXT:    mulli 8, 8, 37
 ; CHECK32_64-NEXT:    sub 8, 7, 8
 ; CHECK32_64-NEXT:    andi. 7, 8, 32
@@ -507,14 +515,18 @@ define i37 @fshr_i37(i37 %x, i37 %y, i37 %z) {
 ; CHECK32_32-NEXT:    srwi 10, 8, 18
 ; CHECK32_32-NEXT:    clrlwi 8, 8, 14
 ; CHECK32_32-NEXT:    rlwimi 10, 7, 14, 14, 17
-; CHECK32_32-NEXT:    add 8, 8, 10
+; CHECK32_32-NEXT:    sub 8, 8, 10
 ; CHECK32_32-NEXT:    rlwinm 7, 7, 28, 31, 31
 ; CHECK32_32-NEXT:    add 7, 8, 7
-; CHECK32_32-NEXT:    lis 9, 1771
+; CHECK32_32-NEXT:    lis 9, -17713
 ; CHECK32_32-NEXT:    addi 7, 7, 2
-; CHECK32_32-NEXT:    ori 9, 9, 15942
+; CHECK32_32-NEXT:    ori 9, 9, 37197
 ; CHECK32_32-NEXT:    addis 7, 7, 8
 ; CHECK32_32-NEXT:    mulhwu 8, 7, 9
+; CHECK32_32-NEXT:    sub 9, 7, 8
+; CHECK32_32-NEXT:    srwi 9, 9, 1
+; CHECK32_32-NEXT:    add 8, 9, 8
+; CHECK32_32-NEXT:    srwi 8, 8, 5
 ; CHECK32_32-NEXT:    mulli 8, 8, 37
 ; CHECK32_32-NEXT:    sub 7, 7, 8
 ; CHECK32_32-NEXT:    addi 8, 7, 27
@@ -550,13 +562,17 @@ define i37 @fshr_i37(i37 %x, i37 %y, i37 %z) {
 ; CHECK32_64-NEXT:    clrlwi 8, 8, 14
 ; CHECK32_64-NEXT:    rlwimi 10, 7, 14, 14, 17
 ; CHECK32_64-NEXT:    rlwinm 7, 7, 28, 31, 31
-; CHECK32_64-NEXT:    add 8, 8, 10
+; CHECK32_64-NEXT:    sub 8, 8, 10
 ; CHECK32_64-NEXT:    add 7, 8, 7
-; CHECK32_64-NEXT:    lis 9, 1771
+; CHECK32_64-NEXT:    lis 9, -17713
 ; CHECK32_64-NEXT:    addi 7, 7, 2
-; CHECK32_64-NEXT:    ori 9, 9, 15942
+; CHECK32_64-NEXT:    ori 9, 9, 37197
 ; CHECK32_64-NEXT:    addis 7, 7, 8
 ; CHECK32_64-NEXT:    mulhwu 8, 7, 9
+; CHECK32_64-NEXT:    sub 9, 7, 8
+; CHECK32_64-NEXT:    srwi 9, 9, 1
+; CHECK32_64-NEXT:    add 8, 9, 8
+; CHECK32_64-NEXT:    srwi 8, 8, 5
 ; CHECK32_64-NEXT:    mulli 8, 8, 37
 ; CHECK32_64-NEXT:    sub 7, 7, 8
 ; CHECK32_64-NEXT:    addi 8, 7, 27

--- a/llvm/test/CodeGen/X86/funnel-shift.ll
+++ b/llvm/test/CodeGen/X86/funnel-shift.ll
@@ -156,33 +156,42 @@ define i37 @fshl_i37(i37 %x, i37 %y, i37 %z) nounwind {
 ; X86-SSE2-NEXT:    pushl %edi
 ; X86-SSE2-NEXT:    pushl %esi
 ; X86-SSE2-NEXT:    movl {{[0-9]+}}(%esp), %eax
-; X86-SSE2-NEXT:    andl $31, %eax
-; X86-SSE2-NEXT:    movl {{[0-9]+}}(%esp), %esi
+; X86-SSE2-NEXT:    movl {{[0-9]+}}(%esp), %ecx
 ; X86-SSE2-NEXT:    movl {{[0-9]+}}(%esp), %ebx
 ; X86-SSE2-NEXT:    movl {{[0-9]+}}(%esp), %edi
-; X86-SSE2-NEXT:    shldl $27, %ebx, %edi
-; X86-SSE2-NEXT:    pushl $0
-; X86-SSE2-NEXT:    pushl $37
-; X86-SSE2-NEXT:    pushl %eax
-; X86-SSE2-NEXT:    pushl {{[0-9]+}}(%esp)
-; X86-SSE2-NEXT:    calll __umoddi3
-; X86-SSE2-NEXT:    addl $16, %esp
-; X86-SSE2-NEXT:    movl %eax, %ecx
-; X86-SSE2-NEXT:    testb $32, %cl
+; X86-SSE2-NEXT:    movl {{[0-9]+}}(%esp), %esi
+; X86-SSE2-NEXT:    movl %eax, %edx
+; X86-SSE2-NEXT:    andl $262143, %edx # imm = 0x3FFFF
+; X86-SSE2-NEXT:    shrdl $18, %ecx, %eax
+; X86-SSE2-NEXT:    andl $16, %ecx
+; X86-SSE2-NEXT:    andl $262143, %eax # imm = 0x3FFFF
+; X86-SSE2-NEXT:    addl %edx, %eax
+; X86-SSE2-NEXT:    shrl $4, %ecx
+; X86-SSE2-NEXT:    leal 524290(%ecx,%eax), %ecx
+; X86-SSE2-NEXT:    movl $116080198, %edx # imm = 0x6EB3E46
+; X86-SSE2-NEXT:    movl %ecx, %eax
+; X86-SSE2-NEXT:    mull %edx
+; X86-SSE2-NEXT:    leal (%edx,%edx,8), %eax
+; X86-SSE2-NEXT:    leal (%edx,%eax,4), %eax
+; X86-SSE2-NEXT:    subl %eax, %ecx
+; X86-SSE2-NEXT:    movl %ecx, %eax
+; X86-SSE2-NEXT:    shrl $5, %eax
+; X86-SSE2-NEXT:    shldl $27, %edi, %esi
+; X86-SSE2-NEXT:    testb %al, %al
 ; X86-SSE2-NEXT:    jne .LBB3_1
 ; X86-SSE2-NEXT:  # %bb.2:
-; X86-SSE2-NEXT:    movl %edi, %ebx
+; X86-SSE2-NEXT:    movl {{[0-9]+}}(%esp), %edx
 ; X86-SSE2-NEXT:    movl %esi, %edi
-; X86-SSE2-NEXT:    movl {{[0-9]+}}(%esp), %esi
+; X86-SSE2-NEXT:    movl %ebx, %esi
 ; X86-SSE2-NEXT:    jmp .LBB3_3
 ; X86-SSE2-NEXT:  .LBB3_1:
-; X86-SSE2-NEXT:    shll $27, %ebx
+; X86-SSE2-NEXT:    shll $27, %edi
+; X86-SSE2-NEXT:    movl %ebx, %edx
 ; X86-SSE2-NEXT:  .LBB3_3:
-; X86-SSE2-NEXT:    movl %edi, %eax
-; X86-SSE2-NEXT:    shldl %cl, %ebx, %eax
+; X86-SSE2-NEXT:    movl %esi, %eax
+; X86-SSE2-NEXT:    shldl %cl, %edi, %eax
 ; X86-SSE2-NEXT:    # kill: def $cl killed $cl killed $ecx
-; X86-SSE2-NEXT:    shldl %cl, %edi, %esi
-; X86-SSE2-NEXT:    movl %esi, %edx
+; X86-SSE2-NEXT:    shldl %cl, %esi, %edx
 ; X86-SSE2-NEXT:    popl %esi
 ; X86-SSE2-NEXT:    popl %edi
 ; X86-SSE2-NEXT:    popl %ebx
@@ -322,34 +331,42 @@ define i37 @fshr_i37(i37 %x, i37 %y, i37 %z) nounwind {
 ; X86-SSE2-NEXT:    pushl %edi
 ; X86-SSE2-NEXT:    pushl %esi
 ; X86-SSE2-NEXT:    movl {{[0-9]+}}(%esp), %eax
-; X86-SSE2-NEXT:    andl $31, %eax
-; X86-SSE2-NEXT:    movl {{[0-9]+}}(%esp), %edi
-; X86-SSE2-NEXT:    movl {{[0-9]+}}(%esp), %ebx
+; X86-SSE2-NEXT:    movl {{[0-9]+}}(%esp), %ecx
 ; X86-SSE2-NEXT:    movl {{[0-9]+}}(%esp), %esi
-; X86-SSE2-NEXT:    shldl $27, %ebx, %esi
-; X86-SSE2-NEXT:    pushl $0
-; X86-SSE2-NEXT:    pushl $37
-; X86-SSE2-NEXT:    pushl %eax
-; X86-SSE2-NEXT:    pushl {{[0-9]+}}(%esp)
-; X86-SSE2-NEXT:    calll __umoddi3
-; X86-SSE2-NEXT:    addl $16, %esp
-; X86-SSE2-NEXT:    movl %eax, %ecx
+; X86-SSE2-NEXT:    movl {{[0-9]+}}(%esp), %ebx
+; X86-SSE2-NEXT:    movl {{[0-9]+}}(%esp), %edi
+; X86-SSE2-NEXT:    movl %eax, %edx
+; X86-SSE2-NEXT:    andl $262143, %edx # imm = 0x3FFFF
+; X86-SSE2-NEXT:    shrdl $18, %ecx, %eax
+; X86-SSE2-NEXT:    andl $16, %ecx
+; X86-SSE2-NEXT:    andl $262143, %eax # imm = 0x3FFFF
+; X86-SSE2-NEXT:    addl %edx, %eax
+; X86-SSE2-NEXT:    shrl $4, %ecx
+; X86-SSE2-NEXT:    leal 524290(%ecx,%eax), %ecx
+; X86-SSE2-NEXT:    movl $116080198, %edx # imm = 0x6EB3E46
+; X86-SSE2-NEXT:    movl %ecx, %eax
+; X86-SSE2-NEXT:    mull %edx
+; X86-SSE2-NEXT:    leal (%edx,%edx,8), %eax
+; X86-SSE2-NEXT:    leal (%edx,%eax,4), %eax
+; X86-SSE2-NEXT:    subl %eax, %ecx
 ; X86-SSE2-NEXT:    addl $27, %ecx
+; X86-SSE2-NEXT:    shldl $27, %ebx, %edi
 ; X86-SSE2-NEXT:    testb $32, %cl
 ; X86-SSE2-NEXT:    je .LBB10_1
 ; X86-SSE2-NEXT:  # %bb.2:
-; X86-SSE2-NEXT:    movl %edi, %edx
-; X86-SSE2-NEXT:    movl {{[0-9]+}}(%esp), %edi
+; X86-SSE2-NEXT:    movl {{[0-9]+}}(%esp), %eax
 ; X86-SSE2-NEXT:    jmp .LBB10_3
 ; X86-SSE2-NEXT:  .LBB10_1:
 ; X86-SSE2-NEXT:    shll $27, %ebx
-; X86-SSE2-NEXT:    movl %esi, %edx
-; X86-SSE2-NEXT:    movl %ebx, %esi
-; X86-SSE2-NEXT:  .LBB10_3:
-; X86-SSE2-NEXT:    shrdl %cl, %edx, %esi
-; X86-SSE2-NEXT:    # kill: def $cl killed $cl killed $ecx
-; X86-SSE2-NEXT:    shrdl %cl, %edi, %edx
 ; X86-SSE2-NEXT:    movl %esi, %eax
+; X86-SSE2-NEXT:    movl %edi, %esi
+; X86-SSE2-NEXT:    movl %ebx, %edi
+; X86-SSE2-NEXT:  .LBB10_3:
+; X86-SSE2-NEXT:    shrdl %cl, %esi, %edi
+; X86-SSE2-NEXT:    # kill: def $cl killed $cl killed $ecx
+; X86-SSE2-NEXT:    shrdl %cl, %eax, %esi
+; X86-SSE2-NEXT:    movl %edi, %eax
+; X86-SSE2-NEXT:    movl %esi, %edx
 ; X86-SSE2-NEXT:    popl %esi
 ; X86-SSE2-NEXT:    popl %edi
 ; X86-SSE2-NEXT:    popl %ebx

--- a/llvm/test/CodeGen/X86/funnel-shift.ll
+++ b/llvm/test/CodeGen/X86/funnel-shift.ll
@@ -155,24 +155,29 @@ define i37 @fshl_i37(i37 %x, i37 %y, i37 %z) nounwind {
 ; X86-SSE2-NEXT:    pushl %ebx
 ; X86-SSE2-NEXT:    pushl %edi
 ; X86-SSE2-NEXT:    pushl %esi
-; X86-SSE2-NEXT:    movl {{[0-9]+}}(%esp), %eax
 ; X86-SSE2-NEXT:    movl {{[0-9]+}}(%esp), %ecx
+; X86-SSE2-NEXT:    movl {{[0-9]+}}(%esp), %eax
 ; X86-SSE2-NEXT:    movl {{[0-9]+}}(%esp), %ebx
 ; X86-SSE2-NEXT:    movl {{[0-9]+}}(%esp), %edi
 ; X86-SSE2-NEXT:    movl {{[0-9]+}}(%esp), %esi
-; X86-SSE2-NEXT:    movl %eax, %edx
+; X86-SSE2-NEXT:    movl %ecx, %edx
 ; X86-SSE2-NEXT:    andl $262143, %edx # imm = 0x3FFFF
-; X86-SSE2-NEXT:    shrdl $18, %ecx, %eax
-; X86-SSE2-NEXT:    andl $16, %ecx
-; X86-SSE2-NEXT:    andl $262143, %eax # imm = 0x3FFFF
-; X86-SSE2-NEXT:    addl %edx, %eax
-; X86-SSE2-NEXT:    shrl $4, %ecx
-; X86-SSE2-NEXT:    leal 524290(%ecx,%eax), %ecx
-; X86-SSE2-NEXT:    movl $116080198, %edx # imm = 0x6EB3E46
+; X86-SSE2-NEXT:    shrdl $18, %eax, %ecx
+; X86-SSE2-NEXT:    andl $16, %eax
+; X86-SSE2-NEXT:    andl $262143, %ecx # imm = 0x3FFFF
+; X86-SSE2-NEXT:    subl %ecx, %edx
+; X86-SSE2-NEXT:    shrl $4, %eax
+; X86-SSE2-NEXT:    leal 524290(%edx,%eax), %ecx
+; X86-SSE2-NEXT:    movl $-1160801971, %edx # imm = 0xBACF914D
 ; X86-SSE2-NEXT:    movl %ecx, %eax
 ; X86-SSE2-NEXT:    mull %edx
-; X86-SSE2-NEXT:    leal (%edx,%edx,8), %eax
-; X86-SSE2-NEXT:    leal (%edx,%eax,4), %eax
+; X86-SSE2-NEXT:    movl %ecx, %eax
+; X86-SSE2-NEXT:    subl %edx, %eax
+; X86-SSE2-NEXT:    shrl %eax
+; X86-SSE2-NEXT:    addl %edx, %eax
+; X86-SSE2-NEXT:    shrl $5, %eax
+; X86-SSE2-NEXT:    leal (%eax,%eax,8), %edx
+; X86-SSE2-NEXT:    leal (%eax,%edx,4), %eax
 ; X86-SSE2-NEXT:    subl %eax, %ecx
 ; X86-SSE2-NEXT:    movl %ecx, %eax
 ; X86-SSE2-NEXT:    shrl $5, %eax
@@ -330,24 +335,29 @@ define i37 @fshr_i37(i37 %x, i37 %y, i37 %z) nounwind {
 ; X86-SSE2-NEXT:    pushl %ebx
 ; X86-SSE2-NEXT:    pushl %edi
 ; X86-SSE2-NEXT:    pushl %esi
-; X86-SSE2-NEXT:    movl {{[0-9]+}}(%esp), %eax
 ; X86-SSE2-NEXT:    movl {{[0-9]+}}(%esp), %ecx
+; X86-SSE2-NEXT:    movl {{[0-9]+}}(%esp), %eax
 ; X86-SSE2-NEXT:    movl {{[0-9]+}}(%esp), %esi
 ; X86-SSE2-NEXT:    movl {{[0-9]+}}(%esp), %ebx
 ; X86-SSE2-NEXT:    movl {{[0-9]+}}(%esp), %edi
-; X86-SSE2-NEXT:    movl %eax, %edx
+; X86-SSE2-NEXT:    movl %ecx, %edx
 ; X86-SSE2-NEXT:    andl $262143, %edx # imm = 0x3FFFF
-; X86-SSE2-NEXT:    shrdl $18, %ecx, %eax
-; X86-SSE2-NEXT:    andl $16, %ecx
-; X86-SSE2-NEXT:    andl $262143, %eax # imm = 0x3FFFF
-; X86-SSE2-NEXT:    addl %edx, %eax
-; X86-SSE2-NEXT:    shrl $4, %ecx
-; X86-SSE2-NEXT:    leal 524290(%ecx,%eax), %ecx
-; X86-SSE2-NEXT:    movl $116080198, %edx # imm = 0x6EB3E46
+; X86-SSE2-NEXT:    shrdl $18, %eax, %ecx
+; X86-SSE2-NEXT:    andl $16, %eax
+; X86-SSE2-NEXT:    andl $262143, %ecx # imm = 0x3FFFF
+; X86-SSE2-NEXT:    subl %ecx, %edx
+; X86-SSE2-NEXT:    shrl $4, %eax
+; X86-SSE2-NEXT:    leal 524290(%edx,%eax), %ecx
+; X86-SSE2-NEXT:    movl $-1160801971, %edx # imm = 0xBACF914D
 ; X86-SSE2-NEXT:    movl %ecx, %eax
 ; X86-SSE2-NEXT:    mull %edx
-; X86-SSE2-NEXT:    leal (%edx,%edx,8), %eax
-; X86-SSE2-NEXT:    leal (%edx,%eax,4), %eax
+; X86-SSE2-NEXT:    movl %ecx, %eax
+; X86-SSE2-NEXT:    subl %edx, %eax
+; X86-SSE2-NEXT:    shrl %eax
+; X86-SSE2-NEXT:    addl %edx, %eax
+; X86-SSE2-NEXT:    shrl $5, %eax
+; X86-SSE2-NEXT:    leal (%eax,%eax,8), %edx
+; X86-SSE2-NEXT:    leal (%eax,%edx,4), %eax
 ; X86-SSE2-NEXT:    subl %eax, %ecx
 ; X86-SSE2-NEXT:    addl $27, %ecx
 ; X86-SSE2-NEXT:    shldl $27, %ebx, %edi

--- a/llvm/test/CodeGen/X86/i128-udiv.ll
+++ b/llvm/test/CodeGen/X86/i128-udiv.ll
@@ -2907,11 +2907,38 @@ define i128 @div_by_67(i128 %x) nounwind {
 ;
 ; X64-LABEL: div_by_67:
 ; X64:       # %bb.0: # %entry
-; X64-NEXT:    pushq %rax
-; X64-NEXT:    movl $67, %edx
-; X64-NEXT:    xorl %ecx, %ecx
-; X64-NEXT:    callq __udivti3@PLT
-; X64-NEXT:    popq %rcx
+; X64-NEXT:    movabsq $8589934591, %rax # imm = 0x1FFFFFFFF
+; X64-NEXT:    movq %rdi, %rcx
+; X64-NEXT:    andq %rax, %rcx
+; X64-NEXT:    movq %rdi, %rdx
+; X64-NEXT:    shrdq $33, %rsi, %rdx
+; X64-NEXT:    andq %rax, %rdx
+; X64-NEXT:    subq %rdx, %rcx
+; X64-NEXT:    movq %rsi, %rdx
+; X64-NEXT:    shrq $2, %rdx
+; X64-NEXT:    andq %rax, %rdx
+; X64-NEXT:    addq %rcx, %rdx
+; X64-NEXT:    movq %rsi, %rax
+; X64-NEXT:    shrq $35, %rax
+; X64-NEXT:    subq %rax, %rdx
+; X64-NEXT:    movabsq $17179869186, %rcx # imm = 0x400000002
+; X64-NEXT:    addq %rdx, %rcx
+; X64-NEXT:    movabsq $-825973615240726191, %rdx # imm = 0xF4898D5F85BB3951
+; X64-NEXT:    movq %rcx, %rax
+; X64-NEXT:    mulq %rdx
+; X64-NEXT:    shrq $6, %rdx
+; X64-NEXT:    imulq $67, %rdx, %rax
+; X64-NEXT:    subq %rax, %rcx
+; X64-NEXT:    subq %rcx, %rdi
+; X64-NEXT:    sbbq $0, %rsi
+; X64-NEXT:    movabsq $-4405192614617206357, %rcx # imm = 0xC2DD9CA81E9131AB
+; X64-NEXT:    imulq %rdi, %rcx
+; X64-NEXT:    movabsq $-1101298153654301589, %r8 # imm = 0xF0B7672A07A44C6B
+; X64-NEXT:    movq %rdi, %rax
+; X64-NEXT:    mulq %r8
+; X64-NEXT:    addq %rcx, %rdx
+; X64-NEXT:    imulq %rsi, %r8
+; X64-NEXT:    addq %r8, %rdx
 ; X64-NEXT:    retq
 entry:
   %div = udiv i128 %x, 67


### PR DESCRIPTION
If we can find a chunk size k where 2^k mod divisor == -1, we can add the even chunks and subtract the odd chunks. The resulting sum may be negative, so we need to add 2^k + 1 (a multiple of divisor) for each odd chunk to ensure the result is positive. We have enough extra bits between the chunk size and HBitWidth to avoid overflow.

The idea here is similar to checking if a decimal number is divisible by 10. You can add the even digits and subtract the odd digits. If the resulting sum is divisible by 11 the original number is divisible by 11.