### PR TITLE
[BOLT][AArch64] Optimize the mov-imm-to-reg operation

### DIFF
--- a/bolt/lib/Target/AArch64/AArch64MCPlusBuilder.cpp
+++ b/bolt/lib/Target/AArch64/AArch64MCPlusBuilder.cpp
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "AArch64ExpandImm.h"
 #include "AArch64InstrInfo.h"
 #include "AArch64MCSymbolizer.h"
 #include "MCTargetDesc/AArch64AddressingModes.h"
@@ -141,6 +142,65 @@ static InstructionListType createIncMemory(MCPhysReg RegTo, MCPhysReg RegTmp) {
   createMovz(Insts.back(), RegTmp, 1);
   Insts.emplace_back();
   atomicAdd(Insts.back(), RegTo, RegTmp);
+  return Insts;
+}
+
+static InstructionListType createMOVImm(MCPhysReg DstReg, unsigned BitSize,
+                                        uint64_t Imm) {
+  SmallVector<AArch64_IMM::ImmInsnModel> Insn;
+  AArch64_IMM::expandMOVImm(Imm, BitSize, Insn);
+  assert(Insn.size() != 0);
+
+  InstructionListType Insts;
+  for (auto I = Insn.begin(), E = Insn.end(); I != E; ++I) {
+    switch (I->Opcode) {
+    case AArch64::ORRWri:
+    case AArch64::ORRXri:
+    case AArch64::ANDXri:
+    case AArch64::EORXri:
+      if (I->Op1 == 0)
+        Insts.emplace_back(MCInstBuilder(I->Opcode)
+                               .addReg(DstReg)
+                               .addReg(BitSize == 32 ? AArch64::WZR
+                                                     : AArch64::XZR)
+                               .addImm(I->Op2));
+      else
+        Insts.emplace_back(MCInstBuilder(I->Opcode)
+                               .addReg(DstReg)
+                               .addReg(DstReg)
+                               .addImm(I->Op2));
+      break;
+    case AArch64::EORXrs:
+    case AArch64::EONXrs:
+    case AArch64::ORRWrs:
+    case AArch64::ORRXrs:
+      Insts.emplace_back(MCInstBuilder(I->Opcode)
+                             .addReg(DstReg)
+                             .addReg(DstReg)
+                             .addReg(DstReg)
+                             .addImm(I->Op2));
+      break;
+    case AArch64::MOVNWi:
+    case AArch64::MOVNXi:
+    case AArch64::MOVZWi:
+    case AArch64::MOVZXi:
+      Insts.emplace_back(MCInstBuilder(I->Opcode)
+                             .addReg(DstReg)
+                             .addImm(I->Op1)
+                             .addImm(I->Op2));
+      break;
+    case AArch64::MOVKWi:
+    case AArch64::MOVKXi:
+      Insts.emplace_back(MCInstBuilder(I->Opcode)
+                             .addReg(DstReg)
+                             .addReg(DstReg)
+                             .addImm(I->Op1)
+                             .addImm(I->Op2));
+      break;
+    default:
+      llvm_unreachable("Unhandled! Please refer to expandMOVImm in llvm");
+    }
+  }
   return Insts;
 }
 
@@ -2867,30 +2927,7 @@ public:
 
   InstructionListType createLoadImmediate(const MCPhysReg Dest,
                                           uint64_t Imm) const override {
-    InstructionListType Insts;
-
-    Insts.emplace_back();
-    MCInst &Inst = Insts.back();
-    Inst.clear();
-    Inst.setOpcode(AArch64::MOVZXi);
-    Inst.addOperand(MCOperand::createReg(Dest));
-    Inst.addOperand(MCOperand::createImm(Imm & 0xFFFF));
-    Inst.addOperand(MCOperand::createImm(0));
-
-    int Shift = 16;
-    for (int I = 0; I < 3; I++, Shift += 16) {
-      const uint64_t ImmVal = (Imm >> Shift) & 0xFFFF;
-      if (!ImmVal)
-        continue;
-      Insts.emplace_back();
-      MCInst &Inst = Insts.back();
-      Inst.setOpcode(AArch64::MOVKXi);
-      Inst.addOperand(MCOperand::createReg(Dest));
-      Inst.addOperand(MCOperand::createReg(Dest));
-      Inst.addOperand(MCOperand::createImm(ImmVal));
-      Inst.addOperand(MCOperand::createImm(Shift));
-    }
-    return Insts;
+    return createMOVImm(Dest, 64, Imm);
   }
 
   void createIndirectCallInst(MCInst &Inst, bool IsTailCall,

--- a/bolt/lib/Target/AArch64/AArch64MCPlusBuilder.cpp
+++ b/bolt/lib/Target/AArch64/AArch64MCPlusBuilder.cpp
@@ -159,16 +159,15 @@ static InstructionListType createMOVImm(MCPhysReg DstReg, unsigned BitSize,
     case AArch64::ANDXri:
     case AArch64::EORXri:
       if (I->Op1 == 0)
-        Insts.emplace_back(MCInstBuilder(I->Opcode)
-                               .addReg(DstReg)
-                               .addReg(BitSize == 32 ? AArch64::WZR
-                                                     : AArch64::XZR)
-                               .addImm(I->Op2));
+        Insts.emplace_back(
+            MCInstBuilder(I->Opcode)
+                .addReg(DstReg)
+                .addReg(BitSize == 32 ? AArch64::WZR : AArch64::XZR)
+                .addImm(I->Op2));
       else
-        Insts.emplace_back(MCInstBuilder(I->Opcode)
-                               .addReg(DstReg)
-                               .addReg(DstReg)
-                               .addImm(I->Op2));
+        Insts.emplace_back(
+            MCInstBuilder(I->Opcode).addReg(DstReg).addReg(DstReg).addImm(
+                I->Op2));
       break;
     case AArch64::EORXrs:
     case AArch64::EONXrs:
@@ -184,10 +183,9 @@ static InstructionListType createMOVImm(MCPhysReg DstReg, unsigned BitSize,
     case AArch64::MOVNXi:
     case AArch64::MOVZWi:
     case AArch64::MOVZXi:
-      Insts.emplace_back(MCInstBuilder(I->Opcode)
-                             .addReg(DstReg)
-                             .addImm(I->Op1)
-                             .addImm(I->Op2));
+      Insts.emplace_back(
+          MCInstBuilder(I->Opcode).addReg(DstReg).addImm(I->Op1).addImm(
+              I->Op2));
       break;
     case AArch64::MOVKWi:
     case AArch64::MOVKXi:
@@ -2927,7 +2925,11 @@ public:
 
   InstructionListType createLoadImmediate(const MCPhysReg Dest,
                                           uint64_t Imm) const override {
-    return createMOVImm(Dest, 64, Imm);
+    if (RegInfo->getRegClass(AArch64::GPR64RegClassID).contains(Dest))
+      return createMOVImm(Dest, 64, Imm);
+    if (RegInfo->getRegClass(AArch64::GPR32RegClassID).contains(Dest))
+      return createMOVImm(Dest, 32, Imm);
+    llvm_unreachable("Unexpected RegClass");
   }
 
   void createIndirectCallInst(MCInst &Inst, bool IsTailCall,

--- a/bolt/lib/Target/AArch64/CMakeLists.txt
+++ b/bolt/lib/Target/AArch64/CMakeLists.txt
@@ -2,6 +2,7 @@ set(LLVM_LINK_COMPONENTS
   MC
   MCDisassembler
   Support
+  AArch64CodeGen
   AArch64Desc
   )
 

--- a/bolt/unittests/Core/MCPlusBuilder.cpp
+++ b/bolt/unittests/Core/MCPlusBuilder.cpp
@@ -119,6 +119,103 @@ TEST_P(MCPlusBuilderTester, AliasSmallerX0) {
                  /*OnlySmaller=*/true);
 }
 
+TEST_P(MCPlusBuilderTester, AArch64_createLoadImmediate) {
+  if (GetParam() != Triple::aarch64)
+    GTEST_SKIP();
+
+  // mov  x0, 0x0001000100010001 --> orr x0, xzr, 0x0001000100010001
+  auto Insts1 = BC->MIB->createLoadImmediate(AArch64::X0, 0x0001000100010001);
+  ASSERT_EQ(Insts1.size(), 1U);
+  ASSERT_EQ(Insts1[0].getOpcode(), AArch64::ORRXri);
+  ASSERT_EQ(Insts1[0].getOperand(0).getReg(), AArch64::X0);
+  ASSERT_EQ(Insts1[0].getOperand(1).getReg(), AArch64::XZR);
+  ASSERT_EQ(Insts1[0].getOperand(2).getImm(), 32);
+
+  // mov  w0, #0x00030003 --> orr w0, wzr, 0x00030003
+  auto Insts2 = BC->MIB->createLoadImmediate(AArch64::W0, 0x00030003);
+  ASSERT_EQ(Insts2.size(), 1U);
+  ASSERT_EQ(Insts2[0].getOpcode(), AArch64::ORRWri);
+  ASSERT_EQ(Insts2[0].getOperand(0).getReg(), AArch64::W0);
+  ASSERT_EQ(Insts2[0].getOperand(1).getReg(), AArch64::WZR);
+  ASSERT_EQ(Insts2[0].getOperand(2).getImm(), 33);
+
+  // mov  x0, #-16  --> movn x0, #15
+  auto Insts3 = BC->MIB->createLoadImmediate(AArch64::X0, 0xfffffffffffffff0);
+  ASSERT_EQ(Insts3.size(), 1U);
+  ASSERT_EQ(Insts3[0].getOpcode(), AArch64::MOVNXi);
+  ASSERT_EQ(Insts3[0].getOperand(0).getReg(), AArch64::X0);
+  ASSERT_EQ(Insts3[0].getOperand(1).getImm(), 15);
+  ASSERT_EQ(Insts3[0].getOperand(2).getImm(), 0);
+
+  // mov  w0, #-1 --> movn  w0, #0
+  auto Insts4 = BC->MIB->createLoadImmediate(AArch64::W0, 0xffffffff);
+  ASSERT_EQ(Insts4.size(), 1U);
+  ASSERT_EQ(Insts4[0].getOpcode(), AArch64::MOVNWi);
+  ASSERT_EQ(Insts4[0].getOperand(0).getReg(), AArch64::W0);
+  ASSERT_EQ(Insts4[0].getOperand(1).getImm(), 0);
+  ASSERT_EQ(Insts4[0].getOperand(2).getImm(), 0);
+
+  // mov    x0, #0x1
+  // movk   x0, #0x2, lsl #16
+  auto Insts5 = BC->MIB->createLoadImmediate(AArch64::X0, 0x00020001);
+  ASSERT_EQ(Insts5.size(), 2U);
+  ASSERT_EQ(Insts5[0].getOpcode(), AArch64::MOVZXi);
+  ASSERT_EQ(Insts5[0].getOperand(0).getReg(), AArch64::X0);
+  ASSERT_EQ(Insts5[0].getOperand(1).getImm(), 1);
+  ASSERT_EQ(Insts5[0].getOperand(2).getImm(), 0);
+  ASSERT_EQ(Insts5[1].getOpcode(), AArch64::MOVKXi);
+  ASSERT_EQ(Insts5[1].getOperand(0).getReg(), AArch64::X0);
+  ASSERT_EQ(Insts5[1].getOperand(1).getReg(), AArch64::X0);
+  ASSERT_EQ(Insts5[1].getOperand(2).getImm(), 2);
+  ASSERT_EQ(Insts5[1].getOperand(3).getImm(), 16);
+
+  // mov    x0, #0x1
+  // movk   x0, #0x2, lsl #16
+  // movk   x0, #0x3, lsl #32
+  auto Insts6 = BC->MIB->createLoadImmediate(AArch64::X0, 0x000300020001);
+  ASSERT_EQ(Insts6.size(), 3U);
+  ASSERT_EQ(Insts6[0].getOpcode(), AArch64::MOVZXi);
+  ASSERT_EQ(Insts6[0].getOperand(0).getReg(), AArch64::X0);
+  ASSERT_EQ(Insts6[0].getOperand(1).getImm(), 1);
+  ASSERT_EQ(Insts6[0].getOperand(2).getImm(), 0);
+  ASSERT_EQ(Insts6[1].getOpcode(), AArch64::MOVKXi);
+  ASSERT_EQ(Insts6[1].getOperand(0).getReg(), AArch64::X0);
+  ASSERT_EQ(Insts6[1].getOperand(1).getReg(), AArch64::X0);
+  ASSERT_EQ(Insts6[1].getOperand(2).getImm(), 2);
+  ASSERT_EQ(Insts6[1].getOperand(3).getImm(), 16);
+  ASSERT_EQ(Insts6[2].getOpcode(), AArch64::MOVKXi);
+  ASSERT_EQ(Insts6[2].getOperand(0).getReg(), AArch64::X0);
+  ASSERT_EQ(Insts6[2].getOperand(1).getReg(), AArch64::X0);
+  ASSERT_EQ(Insts6[2].getOperand(2).getImm(), 3);
+  ASSERT_EQ(Insts6[2].getOperand(3).getImm(), 32);
+
+  // mov    x0, #0x1
+  // movk   x0, #0x2, lsl #16
+  // movk   x0, #0x3, lsl #32
+  // movk   x0, #0x4, lsl #48
+  auto Insts7 = BC->MIB->createLoadImmediate(AArch64::X0, 0x0004000300020001);
+  ASSERT_EQ(Insts7.size(), 4U);
+  ASSERT_EQ(Insts7[0].getOpcode(), AArch64::MOVZXi);
+  ASSERT_EQ(Insts7[0].getOperand(0).getReg(), AArch64::X0);
+  ASSERT_EQ(Insts7[0].getOperand(1).getImm(), 1);
+  ASSERT_EQ(Insts7[0].getOperand(2).getImm(), 0);
+  ASSERT_EQ(Insts7[1].getOpcode(), AArch64::MOVKXi);
+  ASSERT_EQ(Insts7[1].getOperand(0).getReg(), AArch64::X0);
+  ASSERT_EQ(Insts7[1].getOperand(1).getReg(), AArch64::X0);
+  ASSERT_EQ(Insts7[1].getOperand(2).getImm(), 2);
+  ASSERT_EQ(Insts7[1].getOperand(3).getImm(), 16);
+  ASSERT_EQ(Insts7[2].getOpcode(), AArch64::MOVKXi);
+  ASSERT_EQ(Insts7[2].getOperand(0).getReg(), AArch64::X0);
+  ASSERT_EQ(Insts7[2].getOperand(1).getReg(), AArch64::X0);
+  ASSERT_EQ(Insts7[2].getOperand(2).getImm(), 3);
+  ASSERT_EQ(Insts7[2].getOperand(3).getImm(), 32);
+  ASSERT_EQ(Insts7[3].getOpcode(), AArch64::MOVKXi);
+  ASSERT_EQ(Insts7[3].getOperand(0).getReg(), AArch64::X0);
+  ASSERT_EQ(Insts7[3].getOperand(1).getReg(), AArch64::X0);
+  ASSERT_EQ(Insts7[3].getOperand(2).getImm(), 4);
+  ASSERT_EQ(Insts7[3].getOperand(3).getImm(), 48);
+}
+
 TEST_P(MCPlusBuilderTester, AArch64_ReverseCompAndBranch) {
   if (GetParam() != Triple::aarch64)
     GTEST_SKIP();


### PR DESCRIPTION
On AArch64, logical immediate instructions are used to encode some special immediate values. And even at `-O0` level, the AArch64 backend would not choose to generate 4 instructions (movz, movk, movk, movk) for moving such a special value to a 64-bit regiter.

For example, to move the 64-bit value `0x0001000100010001` to `x0`, the AArch64 backend would not choose a 4-instruction-sequence like
```
movz x0, 0x0001
movk x0, 0x0001, lsl 16
movk x0, 0x0001, lsl 32
movk x0, 0x0001, lsl 48
```
Actually, the AArch64 backend would choose to generate one instruction
```
mov x0, 0x0001000100010001
```
which is essentially
```
orr x1, xzr, 0x0001000100010001
```

We could refer to `AArch64ExpandPseudoImpl::expandMOVImm` and `AArch64_IMM::expandMOVImm` for related implementation.

Therefore, maybe we could consider to leverage `expandMOVImm` in llvm to optimize the mov-imm-to-reg operation in BOLT, which would help to speed up the BOLT-instrumented binary.