### PR TITLE
[clang] Enable part of CWG2598 test in C++20 mode

### DIFF
--- a/clang/test/CXX/drs/cwg25xx.cpp
+++ b/clang/test/CXX/drs/cwg25xx.cpp
@@ -378,7 +378,7 @@ struct Literal { constexpr Literal() {} };
 union union6 { NonLiteral NL; Literal L; };
 static_assert(__is_literal(union6), "");
 
-#if __cplusplus >= 202003L
+#if __cplusplus >= 202002L
 struct A { A(); };
 union U {
   A a;


### PR DESCRIPTION
This is a small fix for `#if __cplusplus >= 202002L` condition, which accidentally disabled this part of the test in C++20 mode.