### PR TITLE
[lldb] Fix copy-paste error in SetPrivateRunLockToRunning

### DIFF
--- a/lldb/include/lldb/Target/Process.h
+++ b/lldb/include/lldb/Target/Process.h
@@ -3291,7 +3291,7 @@ protected:
   bool SetPrivateRunLockToRunning() {
     assert(m_current_private_state_thread_sp);
     if (m_current_private_state_thread_sp)
-      return m_current_private_state_thread_sp->SetPrivateRunLockToStopped();
+      return m_current_private_state_thread_sp->SetPrivateRunLockToRunning();
     return false;
   }
   bool SetPublicRunLockToStopped() {


### PR DESCRIPTION
SetPrivateRunLockToRunning incorrectly delegated to SetPrivateRunLockToStopped instead of SetPrivateRunLockToRunning, causing the private run lock to never transition to the running state on process resume.