### PR TITLE
[Flang][OpenMP] Data-sharing restrictions on assumed-size arrays

### DIFF
--- a/flang/lib/Semantics/check-omp-loop.cpp
+++ b/flang/lib/Semantics/check-omp-loop.cpp
@@ -648,6 +648,7 @@ void OmpStructureChecker::Enter(const parser::OmpClause::Linear &x) {
   auto &objects{std::get<parser::OmpObjectList>(x.v.t)};
   CheckCrayPointee(objects, "LINEAR", false);
   GetSymbolsInObjectList(objects, symbols);
+  CheckAssumedSizeArray(symbols, llvm::omp::Clause::OMPC_linear);
 
   auto CheckIntegerNoRef{[&](const Symbol *symbol, parser::CharBlock source) {
     if (!symbol->GetType()->IsNumeric(TypeCategory::Integer)) {

--- a/flang/lib/Semantics/check-omp-structure.cpp
+++ b/flang/lib/Semantics/check-omp-structure.cpp
@@ -3982,6 +3982,7 @@ void OmpStructureChecker::Enter(const parser::OmpClause::Private &x) {
   CheckVarIsNotPartOfAnotherVar(GetContext().clauseSource, x.v, "PRIVATE");
   CheckIntentInPointer(symbols, llvm::omp::Clause::OMPC_private);
   CheckCrayPointee(x.v, "PRIVATE");
+  CheckAssumedSizeArray(symbols, llvm::omp::Clause::OMPC_private);
 }
 
 void OmpStructureChecker::Enter(const parser::OmpClause::Nowait &x) {
@@ -4060,6 +4061,7 @@ void OmpStructureChecker::Enter(const parser::OmpClause::Firstprivate &x) {
   GetSymbolsInObjectList(x.v, currSymbols);
   CheckCopyingPolymorphicAllocatable(
       currSymbols, llvm::omp::Clause::OMPC_firstprivate);
+  CheckAssumedSizeArray(currSymbols, llvm::omp::Clause::OMPC_firstprivate);
 
   DirectivesClauseTriple dirClauseTriple;
   // Check firstprivate variables in worksharing constructs
@@ -4731,6 +4733,7 @@ void OmpStructureChecker::Enter(const parser::OmpClause::Lastprivate &x) {
   CheckIntentInPointer(currSymbols, llvm::omp::Clause::OMPC_lastprivate);
   CheckCopyingPolymorphicAllocatable(
       currSymbols, llvm::omp::Clause::OMPC_lastprivate);
+  CheckAssumedSizeArray(currSymbols, llvm::omp::Clause::OMPC_lastprivate);
 
   // Check lastprivate variables in worksharing constructs
   dirClauseTriple.emplace(llvm::omp::Directive::OMPD_do,
@@ -5198,6 +5201,18 @@ void OmpStructureChecker::CheckIntentInPointer(
     if (IsPointer(*symbol) && IsIntentIn(*symbol)) {
       context_.Say(source,
           "Pointer '%s' with the INTENT(IN) attribute may not appear in a %s clause"_err_en_US,
+          symbol->name(), parser::omp::GetUpperName(clauseId, version));
+    }
+  }
+}
+
+void OmpStructureChecker::CheckAssumedSizeArray(
+    SymbolSourceMap &symbols, llvm::omp::Clause clauseId) {
+  unsigned version{context_.langOptions().OpenMPVersion};
+  for (auto &[symbol, source] : symbols) {
+    if (IsAssumedSizeArray(*symbol)) {
+      context_.Say(source,
+          "Assumed-size array '%s' may not appear in a %s clause"_err_en_US,
           symbol->name(), parser::omp::GetUpperName(clauseId, version));
     }
   }

--- a/flang/lib/Semantics/check-omp-structure.h
+++ b/flang/lib/Semantics/check-omp-structure.h
@@ -259,6 +259,7 @@ private:
   void CheckSymbolNames(
       const parser::CharBlock &source, const parser::OmpObjectList &objList);
   void CheckIntentInPointer(SymbolSourceMap &, const llvm::omp::Clause);
+  void CheckAssumedSizeArray(SymbolSourceMap &, const llvm::omp::Clause);
   void CheckProcedurePointer(SymbolSourceMap &, const llvm::omp::Clause);
   void CheckCrayPointee(const parser::OmpObjectList &objectList,
       llvm::StringRef clause, bool suggestToUseCrayPointer = true);

--- a/flang/test/Semantics/OpenMP/assumed-size-array-dsa.f90
+++ b/flang/test/Semantics/OpenMP/assumed-size-array-dsa.f90
@@ -1,0 +1,48 @@
+!RUN: %python %S/../test_errors.py %s %flang -fopenmp
+
+! Assumed-size arrays are predetermined shared and may only appear in a SHARED clause
+subroutine test_assumed_size_array_dsa( arr, N )
+  implicit none
+  integer :: arr(*)
+  integer :: i, N
+
+  !$omp parallel
+
+  !$omp task shared(arr)
+  do i = 1, N
+    print *, arr(i)
+  end do
+  !$omp end task
+
+  ! ERROR: Assumed-size array 'arr' may not appear in a PRIVATE clause
+  !$omp task private(arr)
+  do i = 1, N
+    print *, arr(i)
+  end do
+  !$omp end task
+
+  ! ERROR: Assumed-size array 'arr' may not appear in a FIRSTPRIVATE clause
+  !$omp task firstprivate(arr)
+  do i = 1, N
+    print *, arr(i)
+  end do
+  !$omp end task
+
+  ! ERROR: Assumed-size array 'arr' may not appear in a LASTPRIVATE clause
+  !$omp do lastprivate(arr)
+  do i = 1, N
+    print *, arr(i)
+  end do
+  !$omp end do
+
+  ! ERROR: Assumed-size array 'arr' may not appear in a LINEAR clause
+  ! ERROR: List item 'arr' in LINEAR clause must be a scalar variable
+  !$omp do linear(arr)
+  do i = 1, N
+    print *, arr(i)
+  end do
+  !$omp end do
+
+  !$omp end parallel
+
+end subroutine

--- a/flang/test/Semantics/OpenMP/cray-pointer-usage.f90
+++ b/flang/test/Semantics/OpenMP/cray-pointer-usage.f90
@@ -8,6 +8,7 @@ subroutine test_cray_pointer_usage
   ! ERROR: List item 'var' in LINEAR clause must be a scalar variable
   ! ERROR: The list item 'var' specified without the REF 'linear-modifier' must be of INTEGER type
   ! ERROR: The list item `var` must be a dummy argument
+  ! ERROR: Assumed-size array 'var' may not appear in a LINEAR clause
   !$omp declare simd linear(var)
 
   pointee = 42.0
@@ -19,6 +20,7 @@ subroutine test_cray_pointer_usage
   !$omp end parallel
 
   ! ERROR: Cray Pointee 'var' may not appear in PRIVATE clause, use Cray Pointer 'ivar' instead
+  ! ERROR: Assumed-size array 'var' may not appear in a PRIVATE clause
   !$omp parallel num_threads(2) default(none) private(var)
     print *, var(1)
   !$omp end parallel
@@ -29,6 +31,7 @@ subroutine test_cray_pointer_usage
   !$omp end parallel
 
   ! ERROR: Cray Pointee 'var' may not appear in LASTPRIVATE clause, use Cray Pointer 'ivar' instead
+  ! ERROR: Assumed-size array 'var' may not appear in a LASTPRIVATE clause
   !$omp do lastprivate(var)
     do i = 1, 10
       print *, var(1)


### PR DESCRIPTION
Per `OpenMP 5.0 2.19.1 Data-Sharing Attribute Rules`, assumed-size arrays are predetermined shared and may not appear in a data-sharing clause besides `shared`.

Patch adds a semantics check for assumed-size arrays appearing in clauses where they aren't allowed.