### PR TITLE
clang: Fix warnings with multiple offload arch args

### DIFF
--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -1015,7 +1015,10 @@ static TripleSet inferOffloadToolchains(Compilation &C,
     A->claim();
     C.getArgs().append(A);
     C.getArgs().AddSynthesizedArg(A);
-    Triples.insert(Triple);
+
+    auto It = Triples.lower_bound(Triple);
+    if (It == Triples.end() || *It != Triple)
+      Triples.insert(It, Triple);
   }
 
   // Infer the default target triple if no specific architectures are given.

--- a/clang/test/Driver/hip-binding.hip
+++ b/clang/test/Driver/hip-binding.hip
@@ -1,4 +1,4 @@
-// RUN: %clang -ccc-print-bindings --target=x86_64-linux-gnu \
+// RUN: %clang -Werror=openmp-target -ccc-print-bindings --target=x86_64-linux-gnu \
 // RUN:   --cuda-gpu-arch=gfx803 --cuda-gpu-arch=gfx900 %s \
 // RUN:   --no-offload-new-driver -c 2>&1 | FileCheck -check-prefix=NRDCS %s
 // RUN: %clang -ccc-print-bindings --target=x86_64-linux-gnu --offload-new-driver \


### PR DESCRIPTION
Fix regression after ab885fdf5f67726ef564c34087e813f2ca861f5c.
Apparently driver tests do not enforce there are no warnings.
Oddly, I need to use -Werror for the specific error. If I use
just -Werror, I get an error that the -Werror is unused.