### PR TITLE
[BOLT] Fix the inaccurate profile data check

### DIFF
--- a/bolt/lib/Core/BinaryFunction.cpp
+++ b/bolt/lib/Core/BinaryFunction.cpp
@@ -4745,10 +4745,21 @@ MCInst *BinaryFunction::getInstructionAtOffset(uint64_t Offset) {
     if (!BB)
       return nullptr;
 
+    MCInst *PreInst = nullptr;
     for (MCInst &Inst : *BB) {
       constexpr uint32_t InvalidOffset = std::numeric_limits<uint32_t>::max();
-      if (Offset == BC.MIB->getOffsetWithDefault(Inst, InvalidOffset))
+      uint32_t InstOffset = BC.MIB->getOffsetWithDefault(Inst, InvalidOffset);
+
+      if (Offset == InstOffset)
         return &Inst;
+
+      // If it's a RISCV PseudoCALL - fix it
+      if (PreInst != nullptr && Offset == InstOffset - 4) {
+        if (BC.MIB->isRISCVCall(PreInst, Inst))
+          return &Inst;
+      }
+
+      PreInst = &Inst;
     }
 
     if (MCInst *LastInstr = BB->getLastNonPseudoInstr()) {


### PR DESCRIPTION
The error is caused by the fact that when acquiring the profile data, the instruction at offset is PseudoCALL, but when performing profile verification, PseudoCALL is converted to AUIPC and JALR instructions, and the offset obtained is JALR; therefore, the profile data is considered invalid.