### PR TITLE
[compiler-rt][ARM] Rename endian.h to crt_endian.h

### DIFF
--- a/compiler-rt/lib/builtins/arm/crt_endian.h
+++ b/compiler-rt/lib/builtins/arm/crt_endian.h
@@ -1,4 +1,4 @@
-//===-- endian.h - make double-prec software FP work in both endiannesses -===//
+//===-- crt_endian.h - make double-prec software FP work both BE and LE ---===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.


### PR DESCRIPTION
Apparently on macOS there's a system header file also called arm/endian.h, and another system header #includes it with "" rather than <>, so that this compiler-rt header accidentally shadows it. Worked around by prefixing "crt" to the name.

No changes are needed except the rename, because the planned functions that use this header are still under review.