### PR TITLE
[CHERI] Establish addrspace(200) as the CHERI capability address space.

### DIFF
--- a/clang/include/clang/Basic/AddressSpaces.h
+++ b/clang/include/clang/Basic/AddressSpaces.h
@@ -71,7 +71,10 @@ enum class LangAS : unsigned {
   // This denotes the count of language-specific address spaces and also
   // the offset added to the target-specific address spaces, which are usually
   // specified by address space attributes __attribute__(address_space(n))).
-  FirstTargetAddressSpace
+  FirstTargetAddressSpace,
+
+  // 200 is used for CHERI capabilities on all targets.
+  cheri_capability = FirstTargetAddressSpace + 200,
 };
 
 /// The type of a lookup table which maps from language-specific address spaces

--- a/llvm/include/llvm/IR/Intrinsics.td
+++ b/llvm/include/llvm/IR/Intrinsics.td
@@ -430,8 +430,8 @@ class LLVMAnyType<ValueType vt> : LLVMType<vt> {
   assert isAny, "LLVMAnyType.VT should have isOverloaded";
 }
 
-class LLVMQualPointerType<int addrspace>
-  : LLVMType<iPTR> {
+class LLVMQualPointerType<int addrspace, ValueType vt = iPTR>
+  : LLVMType<vt> {
   assert !and(!le(0, addrspace), !le(addrspace, 255)),
     "Address space exceeds 255";
 
@@ -446,6 +446,10 @@ class LLVMQualPointerType<int addrspace>
 
 class LLVMAnyPointerType : LLVMAnyType<pAny> {
   assert isAny, "pAny should have isOverloaded";
+}
+
+class LLVMCapabilityType : LLVMQualPointerType<200, cPTR> {
+  let isAny = false;
 }
 
 // Match the type of another intrinsic parameter.  Number is an index into the
@@ -540,6 +544,7 @@ def llvm_f128_ty       : LLVMType<f128>;
 def llvm_ppcf128_ty    : LLVMType<ppcf128>;
 def llvm_ptr_ty        : LLVMQualPointerType<0>; // ptr
 def llvm_anyptr_ty     : LLVMAnyPointerType;     // ptr addrspace(N)
+def llvm_cap_ty        : LLVMCapabilityType;     // ptr addrspace(200), CHERI
 def llvm_empty_ty      : LLVMType<OtherVT>;      // { }
 def llvm_metadata_ty   : LLVMType<MetadataVT>;   // !{...}
 def llvm_token_ty      : LLVMType<token>;        // token


### PR DESCRIPTION
This has a long precedent in the CHERI downstreams, including in the large corpus of test cases. It was originally chosen to minimize the likelihood of conflict with other use cases, and to be reusable across all backends implementing CHERI. It also enables support for "hybrid" CHERI mode (not planned for upstream at this time, but is supported downstream) in which addrspace(0) represents conventional pointers while addrspace(200) represents CHERI capabilities.
