### PR TITLE
[DA] Consolidate the logic for checking overlap at the boundary (NFCI)

### DIFF
--- a/llvm/lib/Analysis/DependenceAnalysis.cpp
+++ b/llvm/lib/Analysis/DependenceAnalysis.cpp
@@ -1386,17 +1386,6 @@ bool DependenceInfo::weakCrossingSIVtest(const SCEVAddRecExpr *Src,
   Level--;
   const SCEV *Delta = SE->getMinusSCEV(DstConst, SrcConst);
   LLVM_DEBUG(dbgs() << "\t    Delta = " << *Delta << "\n");
-  if (Delta->isZero() && SE->isKnownNonZero(Coeff)) {
-    Result.DV[Level].Direction &= ~Dependence::DVEntry::LT;
-    Result.DV[Level].Direction &= ~Dependence::DVEntry::GT;
-    ++WeakCrossingSIVsuccesses;
-    if (!Result.DV[Level].Direction) {
-      ++WeakCrossingSIVindependence;
-      return true;
-    }
-    Result.DV[Level].Distance = Delta; // = 0
-    return false;
-  }
   const SCEVConstant *ConstCoeff = dyn_cast<SCEVConstant>(Coeff);
   if (!ConstCoeff)
     return false;
@@ -1429,7 +1418,7 @@ bool DependenceInfo::weakCrossingSIVtest(const SCEVAddRecExpr *Src,
   LLVM_DEBUG(dbgs() << "\t    SrcRange = " << SrcRange << "\n");
   LLVM_DEBUG(dbgs() << "\t    DstRange = " << DstRange << "\n");
   if (SrcRange.intersectWith(DstRange).isSingleElement()) {
-    // The ranges touch at exactly one value (i = i' = BTC).
+    // The ranges touch at exactly one value (i = i' = 0 or i = i' = BTC).
     Result.DV[Level].Direction &= ~Dependence::DVEntry::LT;
     Result.DV[Level].Direction &= ~Dependence::DVEntry::GT;
     ++WeakCrossingSIVsuccesses;


### PR DESCRIPTION
In the Weak Crossing SIV test, there were two places where we checked the dependency at the boundary, one is at the first iteration, and the other is at the last iteration. Now the former can be merged into the latter. There used to be an edge case when the coefficient is zero, and we had an explicit check for that. This patch removes that check as well, by moving the boundary check after the assertion that ensures the (maybe negated) coefficient is positive.