### PR TITLE
[VPlan] Strip VPDT-assert forbidding replicate regions

### DIFF
--- a/llvm/lib/Transforms/Vectorize/VPlanAnalysis.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanAnalysis.cpp
@@ -391,24 +391,6 @@ bool VPDominatorTree::properlyDominates(const VPRecipeBase *A,
   if (ParentA == ParentB)
     return LocalComesBefore(A, B);
 
-#ifndef NDEBUG
-  auto GetReplicateRegion = [](VPRecipeBase *R) -> VPRegionBlock * {
-    VPRegionBlock *Region = R->getRegion();
-    if (Region && Region->isReplicator()) {
-      assert(Region->getNumSuccessors() == 1 &&
-             Region->getNumPredecessors() == 1 && "Expected SESE region!");
-      assert(R->getParent()->size() == 1 &&
-             "A recipe in an original replicator region must be the only "
-             "recipe in its block");
-      return Region;
-    }
-    return nullptr;
-  };
-  assert(!GetReplicateRegion(const_cast<VPRecipeBase *>(A)) &&
-         "No replicate regions expected at this point");
-  assert(!GetReplicateRegion(const_cast<VPRecipeBase *>(B)) &&
-         "No replicate regions expected at this point");
-#endif
   return Base::properlyDominates(ParentA, ParentB);
 }
 

--- a/llvm/unittests/Transforms/Vectorize/VPDomTreeTest.cpp
+++ b/llvm/unittests/Transforms/Vectorize/VPDomTreeTest.cpp
@@ -237,8 +237,14 @@ TEST_F(VPDominatorTreeTest, DominanceRegionsTest) {
     VPRegionBlock *R1 = Plan.createReplicateRegion(R1BB1, R1BB3, "R1");
 
     VPBasicBlock *R2BB1 = Plan.createVPBasicBlock("R2BB1");
+    VPInstruction *R2BB1I = new VPInstruction(VPInstruction::VScale, {});
+    R1BB1->appendRecipe(R2BB1I);
     VPBasicBlock *R2BB2 = Plan.createVPBasicBlock("R2BB2");
+    VPInstruction *R2BB2I = new VPInstruction(VPInstruction::VScale, {});
+    R2BB2->appendRecipe(R2BB2I);
     VPBasicBlock *R2BB3 = Plan.createVPBasicBlock("R2BB3");
+    VPInstruction *R2BB3I = new VPInstruction(VPInstruction::VScale, {});
+    R2BB3->appendRecipe(R2BB3I);
     VPRegionBlock *R2 = Plan.createReplicateRegion(R2BB1, R2BB3, "R2");
     R2BB2->setParent(R2);
     VPBlockUtils::connectBlocks(R2BB1, R2BB2);
@@ -260,28 +266,10 @@ TEST_F(VPDominatorTreeTest, DominanceRegionsTest) {
     VPBlockUtils::connectBlocks(VPBB2, Plan.getScalarHeader());
     VPDominatorTree VPDT(Plan);
 
-    checkDomChildren(VPDT, VPBB1, {R1});
-    checkDomChildren(VPDT, R1, {R1BB1});
-    checkDomChildren(VPDT, R1BB1, {R2, R1BB3, R1BB2});
-    checkDomChildren(VPDT, R1BB2, {});
-    checkDomChildren(VPDT, R2, {R2BB1});
-    checkDomChildren(VPDT, R2BB1, {R2BB2});
-    checkDomChildren(VPDT, R2BB2, {R2BB3});
-    checkDomChildren(VPDT, R2BB3, {});
-    checkDomChildren(VPDT, R1BB3, {VPBB2});
-    checkDomChildren(VPDT, VPBB2, {Plan.getScalarHeader()});
-
-    EXPECT_FALSE(VPDT.properlyDominates(R1BB1, R1BB1));
-    EXPECT_FALSE(VPDT.properlyDominates(R2, R1BB3));
-    EXPECT_FALSE(VPDT.properlyDominates(R2, R1BB2));
-    EXPECT_TRUE(VPDT.properlyDominates(R1BB1, R2));
-    EXPECT_TRUE(VPDT.properlyDominates(R1BB1, R1BB2));
-    EXPECT_TRUE(VPDT.properlyDominates(R1BB1, R1BB3));
-    EXPECT_TRUE(VPDT.properlyDominates(R2, R2BB1));
-    EXPECT_TRUE(VPDT.properlyDominates(R2, R2BB2));
-    EXPECT_TRUE(VPDT.properlyDominates(R2, R2BB3));
-    EXPECT_TRUE(VPDT.properlyDominates(R2BB1, R2BB2));
-    EXPECT_TRUE(VPDT.properlyDominates(R2BB1, R2BB3));
+    EXPECT_TRUE(VPDT.properlyDominates(R2BB1I, R2BB2I));
+    EXPECT_TRUE(VPDT.properlyDominates(R2BB1I, R2BB3I));
+    EXPECT_FALSE(VPDT.properlyDominates(R2BB3I, R2BB2I));
+    EXPECT_FALSE(VPDT.properlyDominates(R2BB1I, R2BB1I));
   }
 }
 

--- a/llvm/unittests/Transforms/Vectorize/VPDomTreeTest.cpp
+++ b/llvm/unittests/Transforms/Vectorize/VPDomTreeTest.cpp
@@ -151,12 +151,12 @@ TEST_F(VPDominatorTreeTest, DominanceRegionsTest) {
     //  VPBB1
     //    |
     //  R1 {
-    //         R1BB1 <-+
-    //       /         |
+    //         R1BB1
+    //       /        \
     //   R2 {          |
     //     \           |
-    //     R2BB1<-+    |
-    //       |    |   R1BB2
+    //     R2BB1       |
+    //       |   \    R1BB2
     //     R2BB2-/     |
     //        \        |
     //         R2BB3   |
@@ -214,12 +214,12 @@ TEST_F(VPDominatorTreeTest, DominanceRegionsTest) {
     //  VPBB1
     //    |
     //  R1 {
-    //         R1BB1 <-+
-    //       /         |
+    //         R1BB1
+    //       /        \
     //   R2 {          |
     //     \           |
-    //     R2BB1<-+    |
-    //       |    |   R1BB2
+    //     R2BB1       |
+    //       |   \    R1BB2
     //     R2BB2-/     |
     //        \        |
     //         R2BB3   |

--- a/llvm/unittests/Transforms/Vectorize/VPDomTreeTest.cpp
+++ b/llvm/unittests/Transforms/Vectorize/VPDomTreeTest.cpp
@@ -232,13 +232,19 @@ TEST_F(VPDominatorTreeTest, DominanceRegionsTest) {
     //
     VPlan &Plan = getPlan();
     VPBasicBlock *R1BB1 = Plan.createVPBasicBlock("R1BB1");
+    VPInstruction *R1BB1I = new VPInstruction(VPInstruction::VScale, {});
+    R1BB1->appendRecipe(R1BB1I);
     VPBasicBlock *R1BB2 = Plan.createVPBasicBlock("R1BB2");
+    VPInstruction *R1BB2I = new VPInstruction(VPInstruction::VScale, {});
+    R1BB2->appendRecipe(R1BB2I);
     VPBasicBlock *R1BB3 = Plan.createVPBasicBlock("R1BB3");
+    VPInstruction *R1BB3I = new VPInstruction(VPInstruction::VScale, {});
+    R1BB3->appendRecipe(R1BB3I);
     VPRegionBlock *R1 = Plan.createReplicateRegion(R1BB1, R1BB3, "R1");
 
     VPBasicBlock *R2BB1 = Plan.createVPBasicBlock("R2BB1");
     VPInstruction *R2BB1I = new VPInstruction(VPInstruction::VScale, {});
-    R1BB1->appendRecipe(R2BB1I);
+    R2BB1->appendRecipe(R2BB1I);
     VPBasicBlock *R2BB2 = Plan.createVPBasicBlock("R2BB2");
     VPInstruction *R2BB2I = new VPInstruction(VPInstruction::VScale, {});
     R2BB2->appendRecipe(R2BB2I);
@@ -266,8 +272,14 @@ TEST_F(VPDominatorTreeTest, DominanceRegionsTest) {
     VPBlockUtils::connectBlocks(VPBB2, Plan.getScalarHeader());
     VPDominatorTree VPDT(Plan);
 
+    EXPECT_TRUE(VPDT.properlyDominates(R1BB1I, R2BB1I));
+    EXPECT_TRUE(VPDT.properlyDominates(R1BB1I, R2BB2I));
+    EXPECT_TRUE(VPDT.properlyDominates(R1BB1I, R2BB3I));
+    EXPECT_TRUE(VPDT.properlyDominates(R1BB1I, R1BB3I));
+    EXPECT_FALSE(VPDT.properlyDominates(R1BB2I, R1BB3I));
     EXPECT_TRUE(VPDT.properlyDominates(R2BB1I, R2BB2I));
     EXPECT_TRUE(VPDT.properlyDominates(R2BB1I, R2BB3I));
+    EXPECT_FALSE(VPDT.properlyDominates(R2BB1I, R1BB3I));
     EXPECT_FALSE(VPDT.properlyDominates(R2BB3I, R2BB2I));
     EXPECT_FALSE(VPDT.properlyDominates(R2BB1I, R2BB1I));
   }

--- a/llvm/unittests/Transforms/Vectorize/VPDomTreeTest.cpp
+++ b/llvm/unittests/Transforms/Vectorize/VPDomTreeTest.cpp
@@ -175,8 +175,71 @@ TEST_F(VPDominatorTreeTest, DominanceRegionsTest) {
 
     VPBasicBlock *R2BB1 = Plan.createVPBasicBlock("R2BB1");
     VPBasicBlock *R2BB2 = Plan.createVPBasicBlock("R2BB2");
-    VPBasicBlock *R2BB3 = Plan.createVPBasicBlock("R2BB#");
+    VPBasicBlock *R2BB3 = Plan.createVPBasicBlock("R2BB3");
     VPRegionBlock *R2 = Plan.createLoopRegion("R2", R2BB1, R2BB3);
+    R2BB2->setParent(R2);
+    VPBlockUtils::connectBlocks(R2BB1, R2BB2);
+    VPBlockUtils::connectBlocks(R2BB2, R2BB1);
+    VPBlockUtils::connectBlocks(R2BB2, R2BB3);
+
+    R2->setParent(R1);
+    VPBlockUtils::connectBlocks(R1BB1, R2);
+    R1BB2->setParent(R1);
+    VPBlockUtils::connectBlocks(R1BB1, R1BB2);
+    VPBlockUtils::connectBlocks(R1BB2, R1BB3);
+    VPBlockUtils::connectBlocks(R2, R1BB3);
+
+    VPBasicBlock *VPBB1 = Plan.getEntry();
+    VPBlockUtils::connectBlocks(VPBB1, R1);
+    VPBasicBlock *VPBB2 = Plan.createVPBasicBlock("VPBB2");
+    VPBlockUtils::connectBlocks(R1, VPBB2);
+
+    VPBlockUtils::connectBlocks(VPBB2, Plan.getScalarHeader());
+    VPDominatorTree VPDT(Plan);
+
+    checkDomChildren(VPDT, VPBB1, {R1});
+    checkDomChildren(VPDT, R1, {R1BB1});
+    checkDomChildren(VPDT, R1BB1, {R2, R1BB3, R1BB2});
+    checkDomChildren(VPDT, R1BB2, {});
+    checkDomChildren(VPDT, R2, {R2BB1});
+    checkDomChildren(VPDT, R2BB1, {R2BB2});
+    checkDomChildren(VPDT, R2BB2, {R2BB3});
+    checkDomChildren(VPDT, R2BB3, {});
+    checkDomChildren(VPDT, R1BB3, {VPBB2});
+    checkDomChildren(VPDT, VPBB2, {Plan.getScalarHeader()});
+  }
+
+  {
+    // 2 nested replicate regions.
+    //  VPBB1
+    //    |
+    //  R1 {
+    //         R1BB1
+    //       /        \
+    //   R2 {          |
+    //     \           |
+    //     R2BB1       |
+    //       |   \    R1BB2
+    //     R2BB2-/     |
+    //        \        |
+    //         R2BB3   |
+    //   }            /
+    //      \        /
+    //        R1BB3
+    //  }
+    //   |
+    //  VPBB2
+    //
+    VPlan &Plan = getPlan();
+    VPBasicBlock *R1BB1 = Plan.createVPBasicBlock("R1BB1");
+    VPBasicBlock *R1BB2 = Plan.createVPBasicBlock("R1BB2");
+    VPBasicBlock *R1BB3 = Plan.createVPBasicBlock("R1BB3");
+    VPRegionBlock *R1 = Plan.createReplicateRegion(R1BB1, R1BB3, "R1");
+
+    VPBasicBlock *R2BB1 = Plan.createVPBasicBlock("R2BB1");
+    VPBasicBlock *R2BB2 = Plan.createVPBasicBlock("R2BB2");
+    VPBasicBlock *R2BB3 = Plan.createVPBasicBlock("R2BB3");
+    VPRegionBlock *R2 = Plan.createReplicateRegion(R2BB1, R2BB3, "R2");
     R2BB2->setParent(R2);
     VPBlockUtils::connectBlocks(R2BB1, R2BB2);
     VPBlockUtils::connectBlocks(R2BB2, R2BB1);

--- a/llvm/unittests/Transforms/Vectorize/VPDomTreeTest.cpp
+++ b/llvm/unittests/Transforms/Vectorize/VPDomTreeTest.cpp
@@ -151,12 +151,12 @@ TEST_F(VPDominatorTreeTest, DominanceRegionsTest) {
     //  VPBB1
     //    |
     //  R1 {
-    //         R1BB1
-    //       /        \
+    //         R1BB1 <-+
+    //       /         |
     //   R2 {          |
     //     \           |
-    //     R2BB1       |
-    //       |   \    R1BB2
+    //     R2BB1<-+    |
+    //       |    |   R1BB2
     //     R2BB2-/     |
     //        \        |
     //         R2BB3   |
@@ -214,12 +214,12 @@ TEST_F(VPDominatorTreeTest, DominanceRegionsTest) {
     //  VPBB1
     //    |
     //  R1 {
-    //         R1BB1
-    //       /        \
+    //         R1BB1 <-+
+    //       /         |
     //   R2 {          |
     //     \           |
-    //     R2BB1       |
-    //       |   \    R1BB2
+    //     R2BB1<-+    |
+    //       |    |   R1BB2
     //     R2BB2-/     |
     //        \        |
     //         R2BB3   |

--- a/llvm/unittests/Transforms/Vectorize/VPDomTreeTest.cpp
+++ b/llvm/unittests/Transforms/Vectorize/VPDomTreeTest.cpp
@@ -270,6 +270,18 @@ TEST_F(VPDominatorTreeTest, DominanceRegionsTest) {
     checkDomChildren(VPDT, R2BB3, {});
     checkDomChildren(VPDT, R1BB3, {VPBB2});
     checkDomChildren(VPDT, VPBB2, {Plan.getScalarHeader()});
+
+    EXPECT_FALSE(VPDT.properlyDominates(R1BB1, R1BB1));
+    EXPECT_FALSE(VPDT.properlyDominates(R2, R1BB3));
+    EXPECT_FALSE(VPDT.properlyDominates(R2, R1BB2));
+    EXPECT_TRUE(VPDT.properlyDominates(R1BB1, R2));
+    EXPECT_TRUE(VPDT.properlyDominates(R1BB1, R1BB2));
+    EXPECT_TRUE(VPDT.properlyDominates(R1BB1, R1BB3));
+    EXPECT_TRUE(VPDT.properlyDominates(R2, R2BB1));
+    EXPECT_TRUE(VPDT.properlyDominates(R2, R2BB2));
+    EXPECT_TRUE(VPDT.properlyDominates(R2, R2BB3));
+    EXPECT_TRUE(VPDT.properlyDominates(R2BB1, R2BB2));
+    EXPECT_TRUE(VPDT.properlyDominates(R2BB1, R2BB3));
   }
 }
 


### PR DESCRIPTION
VPDominatorTree::properlyDominates currently unnecessarily forbids replicate regions, as there is no such limitation either in the parent DominatorTree, or in VPlanCFG. Strip the assert entirely.