### PR TITLE
clang: Return Triple from OffloadArchToTriple instead of a string

### DIFF
--- a/clang/include/clang/Basic/OffloadArch.h
+++ b/clang/include/clang/Basic/OffloadArch.h
@@ -152,8 +152,8 @@ const char *OffloadArchToVirtualArchString(OffloadArch A);
 // OffloadArch::Unknown if the string is not recognized.
 OffloadArch StringToOffloadArch(llvm::StringRef S);
 
-llvm::StringRef OffloadArchToTriple(const llvm::Triple &DefaultToolchainTriple,
-                                    OffloadArch ID);
+llvm::Triple OffloadArchToTriple(const llvm::Triple &DefaultToolchainTriple,
+                                 OffloadArch ID);
 
 } // namespace clang
 

--- a/clang/lib/Basic/OffloadArch.cpp
+++ b/clang/lib/Basic/OffloadArch.cpp
@@ -147,19 +147,20 @@ OffloadArch StringToOffloadArch(llvm::StringRef S) {
   return Result->Arch;
 }
 
-llvm::StringRef OffloadArchToTriple(const llvm::Triple &DefaultToolchainTriple,
-                                    OffloadArch ID) {
+llvm::Triple OffloadArchToTriple(const llvm::Triple &DefaultToolchainTriple,
+                                 OffloadArch ID) {
   if (ID == OffloadArch::AMDGCNSPIRV)
-    return "spirv64-amd-amdhsa";
+    return llvm::Triple("spirv64-amd-amdhsa");
 
   if (IsNVIDIAOffloadArch(ID))
-    return DefaultToolchainTriple.isArch64Bit() ? "nvptx64-nvidia-cuda"
-                                                : "nvptx-nvidia-cuda";
+    return DefaultToolchainTriple.isArch64Bit()
+               ? llvm::Triple("nvptx64-nvidia-cuda")
+               : llvm::Triple("nvptx-nvidia-cuda");
 
   if (IsAMDOffloadArch(ID))
-    return "amdgcn-amd-amdhsa";
+    return llvm::Triple("amdgcn-amd-amdhsa");
 
-  return "";
+  return {};
 }
 
 } // namespace clang

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -997,12 +997,8 @@ static TripleSet inferOffloadToolchains(Compilation &C,
       return {};
     }
 
-    llvm::StringRef TripleStr =
+    llvm::Triple Triple =
         OffloadArchToTriple(C.getDefaultToolChain().getTriple(), ID);
-    if (TripleStr.empty())
-      continue;
-
-    llvm::Triple Triple = ToolChain::normalizeOffloadTriple(TripleStr);
 
     // Make a new argument that dispatches this argument to the appropriate
     // toolchain. This is required when we infer it and create potentially


### PR DESCRIPTION
Also stop bothering to call normalizeOffloadTriple. This was
produced by code which should always produce normalized triples.