### PR TITLE
[mlir][reducer] Add opt-pass-file option to opt-reduction pass

### DIFF
--- a/mlir/include/mlir/Reducer/Passes.td
+++ b/mlir/include/mlir/Reducer/Passes.td
@@ -40,6 +40,8 @@ def OptReductionPass : Pass<"opt-reduction-pass"> {
   let options = [
     Option<"optPass", "opt-pass", "std::string", /* default */"",
            "The optimization passes used for reduction, e.g., symbol-dce">,
+    Option<"optPassFile", "opt-pass-file", "std::string", /* default */"",
+           "The file path containing the optimization pipeline definition">,
   ] # CommonReductionPassOptions.options;
 }
 

--- a/mlir/lib/Reducer/OptReductionPass.cpp
+++ b/mlir/lib/Reducer/OptReductionPass.cpp
@@ -18,6 +18,7 @@
 #include "mlir/Reducer/Tester.h"
 
 #include "llvm/Support/DebugLog.h"
+#include "llvm/Support/MemoryBuffer.h"
 
 namespace mlir {
 #define GEN_PASS_DEF_OPTREDUCTIONPASS
@@ -47,8 +48,21 @@ void OptReductionPass::runOnOperation() {
   Tester test(testerName, testerArgs);
   Operation *topOp = this->getOperation();
 
+  std::string pipelineStr = optPass;
+  if (pipelineStr.empty()) {
+    if (!optPassFile.empty()) {
+      auto fileOrErr = llvm::MemoryBuffer::getFile(optPassFile);
+      if (std::error_code ec = fileOrErr.getError()) {
+        topOp->emitError() << "Could not open pass pipeline file: "
+                           << optPassFile << " (" << ec.message() << ")";
+        return signalPassFailure();
+      }
+      pipelineStr = fileOrErr.get()->getBuffer().trim().str();
+    }
+  }
+
   PassManager passManager(topOp->getName());
-  if (failed(parsePassPipeline(optPass, passManager))) {
+  if (failed(parsePassPipeline(pipelineStr, passManager))) {
     topOp->emitError() << "\nfailed to parse pass pipeline";
     return signalPassFailure();
   }

--- a/mlir/test/mlir-reduce/opt-reduction/dce-pipeline
+++ b/mlir/test/mlir-reduce/opt-reduction/dce-pipeline
@@ -1,0 +1,1 @@
+symbol-dce

--- a/mlir/test/mlir-reduce/opt-reduction/dce-test.mlir
+++ b/mlir/test/mlir-reduce/opt-reduction/dce-test.mlir
@@ -1,16 +1,20 @@
 // UNSUPPORTED: system-windows
 // RUN: mlir-reduce %s -opt-reduction-pass='opt-pass=symbol-dce test=%S/../failure-test.sh' | FileCheck %s
+// RUN: mlir-reduce %s -opt-reduction-pass='opt-pass-file=%S/dce-pipeline test=%S/../failure-test.sh' | FileCheck %s  --check-prefix=CHECK-OPT-FILE
 // This input should be reduced by the pass pipeline so that only
 // the @simple1 function remains as the other functions should be
 // removed by the dead code elimination pass.
 
 // CHECK-NOT: func private @dead_private_function
+// CHECK-OPT-FILE-NOT: func private @dead_private_function
 func.func private @dead_private_function()
 
 // CHECK-NOT: func nested @dead_nested_function
+// CHECK-OPT-FILE-NOT: funcnested @dead_nested_function
 func.func nested @dead_nested_function()
 
 // CHECK-LABEL: func @simple1(%arg0: i1, %arg1: memref<2xf32>, %arg2: memref<2xf32>) {
+// CHECK-OPT-FILE-LABEL: func @simple1(%arg0: i1, %arg1: memref<2xf32>, %arg2: memref<2xf32>) {
 func.func @simple1(%arg0: i1, %arg1: memref<2xf32>, %arg2: memref<2xf32>) {
   "test.op_crash" () : () -> ()
   return


### PR DESCRIPTION
Currently, the opt-reduction-pass only supports inputting the optimization pipeline via the command line, which becomes cumbersome when the pipeline is long. To address this, this PR introduces the opt-pass-file option. This allows users to save the pipeline in a file and provide the filename to parse the pipeline.