### PR TITLE
[mlir][reducer] make opt-reduction pass clone topOp after check (NFC)

### DIFF
--- a/mlir/lib/Reducer/OptReductionPass.cpp
+++ b/mlir/lib/Reducer/OptReductionPass.cpp
@@ -45,9 +45,7 @@ void OptReductionPass::runOnOperation() {
   LDBG() << "\nOptimization Reduction pass: ";
 
   Tester test(testerName, testerArgs);
-
   Operation *topOp = this->getOperation();
-  Operation *topOpVariant = topOp->clone();
 
   PassManager passManager(topOp->getName());
   if (failed(parsePassPipeline(optPass, passManager))) {
@@ -60,6 +58,7 @@ void OptReductionPass::runOnOperation() {
     topOp->emitError() << "\nthe original input is not interested";
     return signalPassFailure();
   }
+  Operation *topOpVariant = topOp->clone();
 
   LogicalResult pipelineResult = passManager.run(topOpVariant);
   if (failed(pipelineResult)) {


### PR DESCRIPTION
To avoid potential memory leaks, this PR defers the ModuleOp cloning until after the verification check. If the check fails, the moduleVariant might not be properly deallocated(original implementation), leading to a memory leak. Therefore, this PR ensures that the clone operation is only performed after a successful check. It is part of https://github.com/llvm/llvm-project/pull/189353.