### PR TITLE
[Flang] Fix statement-function shadowing to avoid false unresolved-symbol internal error

### DIFF
--- a/flang/lib/Semantics/resolve-names.cpp
+++ b/flang/lib/Semantics/resolve-names.cpp
@@ -4657,6 +4657,9 @@ bool SubprogramVisitor::HandleStmtFunction(const parser::StmtFunctionStmt &x) {
           "Name '%s' from host scope should have a type declaration before its local statement function definition"_port_en_US,
           name.source);
       MakeSymbol(name, Attrs{}, UnknownDetails{});
+      // 'name' may still point to a host-associated SubprogramNameDetails
+      // symbol. Reset it so statement-function processing
+      //  re-resolves to the new local SubprogramDetails.
       name.symbol = nullptr;
     } else if (auto *entity{ultimate.detailsIf<EntityDetails>()};
                entity && !ultimate.has<ProcEntityDetails>()) {

--- a/flang/lib/Semantics/resolve-names.cpp
+++ b/flang/lib/Semantics/resolve-names.cpp
@@ -4659,7 +4659,7 @@ bool SubprogramVisitor::HandleStmtFunction(const parser::StmtFunctionStmt &x) {
       MakeSymbol(name, Attrs{}, UnknownDetails{});
       // 'name' may still point to a host-associated SubprogramNameDetails
       // symbol. Reset it so statement-function processing
-      //  re-resolves to the new local SubprogramDetails.
+      // re-resolves to the new local SubprogramDetails.
       name.symbol = nullptr;
     } else if (auto *entity{ultimate.detailsIf<EntityDetails>()};
                entity && !ultimate.has<ProcEntityDetails>()) {

--- a/flang/lib/Semantics/resolve-names.cpp
+++ b/flang/lib/Semantics/resolve-names.cpp
@@ -4657,6 +4657,7 @@ bool SubprogramVisitor::HandleStmtFunction(const parser::StmtFunctionStmt &x) {
           "Name '%s' from host scope should have a type declaration before its local statement function definition"_port_en_US,
           name.source);
       MakeSymbol(name, Attrs{}, UnknownDetails{});
+      name.symbol = nullptr;
     } else if (auto *entity{ultimate.detailsIf<EntityDetails>()};
                entity && !ultimate.has<ProcEntityDetails>()) {
       resultType = entity->type();

--- a/flang/test/Semantics/stmt-func02.f90
+++ b/flang/test/Semantics/stmt-func02.f90
@@ -25,10 +25,12 @@ module m2
   end
   subroutine test2
     !PORTABILITY: Name 'rf' from host scope should have a type declaration before its local statement function definition [-Wstatement-function-extensions]
+    !PORTABILITY: An implicitly typed statement function should not appear when the same symbol is available in its host scope [-Wstatement-function-extensions]
     rf(x) = 1.
   end
   subroutine test2b
     !PORTABILITY: Name 'rf2' from host scope should have a type declaration before its local statement function definition [-Wstatement-function-extensions]
+    !PORTABILITY: An implicitly typed statement function should not appear when the same symbol is available in its host scope [-Wstatement-function-extensions]
     rf2(x) = 1.
   end
   subroutine test3

--- a/flang/test/Semantics/stmt-func03.f90
+++ b/flang/test/Semantics/stmt-func03.f90
@@ -2,11 +2,6 @@
 ! CHECK-NOT: error:
 ! CHECK-NOT: Internal:
 program main
-  integer :: passed, failed
-  passed = 0
-  failed = 0
-  call internal_sub()
-  call exit(failed)
 contains
   subroutine internal_sub()
     integer :: i, result
@@ -15,11 +10,6 @@ contains
     stmt_function(i) = i * 2
     i = 1
     result = stmt_function(i)
-    if (result .eq. 2) then
-      passed = passed + 1
-    else
-      failed = failed + 1
-    end if
   end subroutine internal_sub
   integer function stmt_function(arg)
     integer :: arg

--- a/flang/test/Semantics/stmt-func03.f90
+++ b/flang/test/Semantics/stmt-func03.f90
@@ -1,0 +1,28 @@
+! RUN: %flang_fc1 -fsyntax-only -pedantic %s 2>&1 | FileCheck %s
+! CHECK-NOT: error:
+! CHECK-NOT: Internal:
+program main
+  integer :: passed, failed
+  passed = 0
+  failed = 0
+  call internal_sub()
+  call exit(failed)
+contains
+  subroutine internal_sub()
+    integer :: i, result
+    ! Host-associated sibling internal function name should be shadowed
+    ! by this statement function definition.
+    stmt_function(i) = i * 2
+    i = 1
+    result = stmt_function(i)
+    if (result .eq. 2) then
+      passed = passed + 1
+    else
+      failed = failed + 1
+    end if
+  end subroutine internal_sub
+  integer function stmt_function(arg)
+    integer :: arg
+    stmt_function = arg * 3
+  end function stmt_function
+end program main


### PR DESCRIPTION
When a statement function shadows a host-associated internal procedure name, HandleStmtFunction creates a local symbol but leaves name.symbol pointing to the host SubprogramNameDetails.

Because of that stale pointer, AnalyzeStmtFunctionStmt exits early (it expects SubprogramDetails), so the RHS is never resolved and flang emits a false `internal error: "Internal: no symbol found".` Clearing name.symbol after creating the local shadow symbol lets it re-resolve correctly and fixes the issue.
