### PR TITLE
[include-cleaner][NFC] expose and test `normalizePath` helper

### DIFF
--- a/clang-tools-extra/include-cleaner/lib/Types.cpp
+++ b/clang-tools-extra/include-cleaner/lib/Types.cpp
@@ -100,14 +100,12 @@ std::string Include::quote() const {
       .str();
 }
 
-static llvm::SmallString<128> normalizePath(llvm::StringRef Path) {
+llvm::SmallString<128> normalizePath(llvm::StringRef Path) {
   namespace path = llvm::sys::path;
 
   llvm::SmallString<128> P = Path;
   path::remove_dots(P, /*remove_dot_dot=*/true);
   path::native(P, path::Style::posix);
-  while (!P.empty() && P.back() == '/')
-    P.pop_back();
   return P;
 }
 

--- a/clang-tools-extra/include-cleaner/lib/TypesInternal.h
+++ b/clang-tools-extra/include-cleaner/lib/TypesInternal.h
@@ -96,6 +96,8 @@ template <typename T> struct Hinted : public T {
   }
 };
 
+llvm::SmallString<128> normalizePath(llvm::StringRef Path);
+
 } // namespace clang::include_cleaner
 
 #endif

--- a/clang-tools-extra/include-cleaner/unittests/TypesTest.cpp
+++ b/clang-tools-extra/include-cleaner/unittests/TypesTest.cpp
@@ -1,4 +1,4 @@
-//===-- RecordTest.cpp ----------------------------------------------------===//
+//===-- TypesTest.cpp -----------------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "clang-include-cleaner/Types.h"
+#include "TypesInternal.h"
 #include "clang/Basic/FileManager.h"
 #include "clang/Basic/FileSystemOptions.h"
 #include "clang/Tooling/Inclusions/StandardLibrary.h"
@@ -96,6 +97,19 @@ TEST(RecordedIncludesTest, MatchVerbatimMixedAbsoluteRelative) {
   Inc.addSearchDirectory("/working/rel1/rel2");
   Inc.add(Include{"rel2/bar.h", Bar, SourceLocation(), 1});
   EXPECT_THAT(Inc.match(Header("<bar.h>")), IsEmpty());
+}
+
+TEST(NormalizePathTest, RemovesDotSegments) {
+  EXPECT_EQ(normalizePath("foo/./bar/../baz").str(), "foo/baz");
+  EXPECT_EQ(normalizePath("foo/bar/").str(), "foo/bar");
+}
+
+TEST(NormalizePathTest, CanonicalizesSeparators) {
+  EXPECT_EQ(normalizePath("foo\\bar").str(), "foo/bar");
+}
+
+TEST(NormalizePathTest, PreservesRootPath) {
+  EXPECT_EQ(normalizePath("/").str(), "/");
 }
 
 } // namespace

--- a/clang-tools-extra/include-cleaner/unittests/TypesTest.cpp
+++ b/clang-tools-extra/include-cleaner/unittests/TypesTest.cpp
@@ -101,6 +101,8 @@ TEST(RecordedIncludesTest, MatchVerbatimMixedAbsoluteRelative) {
 
 TEST(NormalizePathTest, RemovesDotSegments) {
   EXPECT_EQ(normalizePath("foo/./bar/../baz").str(), "foo/baz");
+  EXPECT_EQ(normalizePath("/foo/./bar").str(), "/foo/bar");
+  EXPECT_EQ(normalizePath("/foo/../bar").str(), "/bar");
   EXPECT_EQ(normalizePath("foo/bar/").str(), "foo/bar");
 }
 


### PR DESCRIPTION
Also fixes a bug where the root `/` path would become an empty string.