### PR TITLE
[llvm][docs] Add release note for LLDB AArch64 Linux SME only support

### DIFF
--- a/llvm/docs/ReleaseNotes.md
+++ b/llvm/docs/ReleaseNotes.md
@@ -269,6 +269,15 @@ Changes to LLDB
 
 * On Arm Linux, the tpidruro register can now be read. Writing to this register is not supported.
 * Thread local variables are now supported on Arm Linux if the program being debugged is using glibc.
+* LLDB now supports AArch64 Linux systems that only have SME (as opposed to
+  SVE and SME). Prior to this version of LLDB, there was a bug that caused LLDB
+  to crash on startup on these systems
+  ([#138717](https://github.com/llvm/llvm-project/issues/138717)).
+  This affected LLDB versions 18, 19, 20 and 21. 17 and below are not affected.
+  If you are using such a system and cannot change LLDB version, or want to package
+  an affected version in a way that is compatible with these systems, the issue
+  contains details of backports that could be done to fix the affected versions.
+
 
 Changes to BOLT
 ---------------

--- a/llvm/docs/ReleaseNotes.md
+++ b/llvm/docs/ReleaseNotes.md
@@ -273,7 +273,7 @@ Changes to LLDB
   SVE and SME). Prior to this version of LLDB, there was a bug that caused LLDB
   to crash on startup on these systems
   ([#138717](https://github.com/llvm/llvm-project/issues/138717)).
-  This affected LLDB versions 18, 19, 20 and 21. 17 and below are not affected.
+  This affected LLDB versions from 18 up to and including 22. 17 and below are not affected.
   If you are using such a system and cannot change LLDB version, or want to package
   an affected version in a way that is compatible with these systems, the issue
   contains details of backports that could be done to fix the affected versions.


### PR DESCRIPTION
And highlights that some earlier versions have a critical issue on such systems. This is not something we are able to fix (because the branches are closed), but users and packagers have some options which are listed in the issue.

Relates to #138717.