### PR TITLE
[libc][NFC] Guard long double type in shared_math_tests.

### DIFF
--- a/libc/shared/math/nexttoward.h
+++ b/libc/shared/math/nexttoward.h
@@ -10,6 +10,10 @@
 #define LLVM_LIBC_SHARED_MATH_NEXTTOWARD_H
 
 #include "shared/libc_common.h"
+#include "src/__support/macros/properties/types.h"
+
+#ifndef LIBC_TYPES_LONG_DOUBLE_IS_DOUBLE_DOUBLE
+
 #include "src/__support/math/nexttoward.h"
 
 namespace LIBC_NAMESPACE_DECL {
@@ -19,5 +23,7 @@ using math::nexttoward;
 
 } // namespace shared
 } // namespace LIBC_NAMESPACE_DECL
+
+#endif // LIBC_TYPES_LONG_DOUBLE_IS_DOUBLE_DOUBLE
 
 #endif // LLVM_LIBC_SHARED_MATH_NEXTTOWARD_H

--- a/libc/shared/math/nexttowardbf16.h
+++ b/libc/shared/math/nexttowardbf16.h
@@ -10,6 +10,10 @@
 #define LLVM_LIBC_SHARED_MATH_NEXTTOWARDBF16_H
 
 #include "shared/libc_common.h"
+#include "src/__support/macros/properties/types.h"
+
+#ifndef LIBC_TYPES_LONG_DOUBLE_IS_DOUBLE_DOUBLE
+
 #include "src/__support/math/nexttowardbf16.h"
 
 namespace LIBC_NAMESPACE_DECL {
@@ -19,5 +23,7 @@ using math::nexttowardbf16;
 
 } // namespace shared
 } // namespace LIBC_NAMESPACE_DECL
+
+#endif // LIBC_TYPES_LONG_DOUBLE_IS_DOUBLE_DOUBLE
 
 #endif // LLVM_LIBC_SHARED_MATH_NEXTTOWARDBF16_H

--- a/libc/shared/math/nexttowardf.h
+++ b/libc/shared/math/nexttowardf.h
@@ -10,6 +10,10 @@
 #define LLVM_LIBC_SHARED_MATH_NEXTTOWARDF_H
 
 #include "shared/libc_common.h"
+#include "src/__support/macros/properties/types.h"
+
+#ifndef LIBC_TYPES_LONG_DOUBLE_IS_DOUBLE_DOUBLE
+
 #include "src/__support/math/nexttowardf.h"
 
 namespace LIBC_NAMESPACE_DECL {
@@ -19,5 +23,7 @@ using math::nexttowardf;
 
 } // namespace shared
 } // namespace LIBC_NAMESPACE_DECL
+
+#endif // LIBC_TYPES_LONG_DOUBLE_IS_DOUBLE_DOUBLE
 
 #endif // LLVM_LIBC_SHARED_MATH_NEXTTOWARDF_H

--- a/libc/shared/math/nexttowardf16.h
+++ b/libc/shared/math/nexttowardf16.h
@@ -10,10 +10,12 @@
 #define LLVM_LIBC_SHARED_MATH_NEXTTOWARDF16_H
 
 #include "include/llvm-libc-macros/float16-macros.h"
-
-#ifdef LIBC_TYPES_HAS_FLOAT16
-
 #include "shared/libc_common.h"
+#include "src/__support/macros/properties/types.h"
+
+#if defined(LIBC_TYPES_HAS_FLOAT16) &&                                         \
+    !defined(LIBC_TYPES_LONG_DOUBLE_IS_DOUBLE_DOUBLE)
+
 #include "src/__support/math/nexttowardf16.h"
 
 namespace LIBC_NAMESPACE_DECL {

--- a/libc/test/shared/shared_math_constexpr_test.cpp
+++ b/libc/test/shared/shared_math_constexpr_test.cpp
@@ -14,14 +14,14 @@
 //                       Double Tests
 //===----------------------------------------------------------------------===//
 
-static_assert(0x0p+0 == LIBC_NAMESPACE::shared::ceil(0.0));
-static_assert(0x0p+0 == LIBC_NAMESPACE::shared::log(1.0));
+static_assert(0.0 == LIBC_NAMESPACE::shared::ceil(0.0));
+static_assert(0.0 == LIBC_NAMESPACE::shared::log(1.0));
 
 //===----------------------------------------------------------------------===//
 //                       Float Tests
 //===----------------------------------------------------------------------===//
 
-static_assert(0x0p+0f == LIBC_NAMESPACE::shared::ceilf(0.0f));
+static_assert(0.0f == LIBC_NAMESPACE::shared::ceilf(0.0f));
 
 //===----------------------------------------------------------------------===//
 //                       Float16 Tests
@@ -29,7 +29,7 @@ static_assert(0x0p+0f == LIBC_NAMESPACE::shared::ceilf(0.0f));
 
 #ifdef LIBC_TYPES_HAS_FLOAT16
 
-static_assert(0x0p+0f16 == LIBC_NAMESPACE::shared::ceilf16(0.0f16));
+static_assert(0.0f16 == LIBC_NAMESPACE::shared::ceilf16(0.0f16));
 
 #endif // LIBC_TYPES_HAS_FLOAT16
 
@@ -40,7 +40,7 @@ static_assert(0x0p+0f16 == LIBC_NAMESPACE::shared::ceilf16(0.0f16));
 // TODO(issue#185232): Mark as constexpr once the refactor is done.
 #if 0 // Temporarily disable long double tests
 
-static_assert(0x0p+0L == LIBC_NAMESPACE::shared::ceill(0.0L));
+static_assert(0.0L == LIBC_NAMESPACE::shared::ceill(0.0L));
 
 #endif
 
@@ -50,8 +50,7 @@ static_assert(0x0p+0L == LIBC_NAMESPACE::shared::ceill(0.0L));
 
 #ifdef LIBC_TYPES_HAS_FLOAT128
 
-static_assert(float128(0x0p+0) ==
-              LIBC_NAMESPACE::shared::ceilf128(float128(0.0)));
+static_assert(float128(0.0) == LIBC_NAMESPACE::shared::ceilf128(float128(0.0)));
 
 #endif // LIBC_TYPES_HAS_FLOAT128
 
@@ -59,5 +58,4 @@ static_assert(float128(0x0p+0) ==
 //                       BFloat16 Tests
 //===----------------------------------------------------------------------===//
 
-static_assert(bfloat16(0x0p+0) ==
-              LIBC_NAMESPACE::shared::ceilbf16(bfloat16(0.0)));
+static_assert(bfloat16(0.0) == LIBC_NAMESPACE::shared::ceilbf16(bfloat16(0.0)));

--- a/libc/test/shared/shared_math_test.cpp
+++ b/libc/test/shared/shared_math_test.cpp
@@ -16,81 +16,33 @@ TEST(LlvmLibcSharedMathTest, AllFloat16) {
   using FPBits = LIBC_NAMESPACE::fputil::FPBits<float16>;
 
   int exponent;
-  EXPECT_FP_EQ(0x0p+0f16, LIBC_NAMESPACE::shared::acoshf16(1.0f16));
-  EXPECT_FP_EQ(0x0p+0f16, LIBC_NAMESPACE::shared::acospif16(1.0f16));
-  EXPECT_FP_EQ(0x1p+0f16, LIBC_NAMESPACE::shared::rsqrtf16(1.0f16));
-  EXPECT_FP_EQ(0x1p+0f16, LIBC_NAMESPACE::shared::sqrtf16(1.0f16));
+  EXPECT_FP_EQ(0.0f16, LIBC_NAMESPACE::shared::acoshf16(1.0f16));
+  EXPECT_FP_EQ(0.0f16, LIBC_NAMESPACE::shared::acospif16(1.0f16));
+  EXPECT_FP_EQ(1.0f16, LIBC_NAMESPACE::shared::rsqrtf16(1.0f16));
+  EXPECT_FP_EQ(1.0f16, LIBC_NAMESPACE::shared::sqrtf16(1.0f16));
 
-  EXPECT_FP_EQ(0x0p+0f16, LIBC_NAMESPACE::shared::asinf16(0.0f16));
-  EXPECT_FP_EQ(0x0p+0f16, LIBC_NAMESPACE::shared::asinhf16(0.0f16));
-  EXPECT_FP_EQ(0x0p+0f16, LIBC_NAMESPACE::shared::asinpif16(0.0f16));
-  EXPECT_FP_EQ(0x0p+0f16, LIBC_NAMESPACE::shared::atan2f16(0.0f16, 0.0f16));
-  EXPECT_FP_EQ(0x0p+0f16, LIBC_NAMESPACE::shared::atanf16(0.0f16));
-  EXPECT_FP_EQ(0x0p+0f16, LIBC_NAMESPACE::shared::atanhf16(0.0f16));
-  EXPECT_FP_EQ(0x0p+0f16, LIBC_NAMESPACE::shared::atanpif16(0.0f16));
-  EXPECT_FP_EQ(0x1p+0f16, LIBC_NAMESPACE::shared::cosf16(0.0f16));
-  EXPECT_FP_EQ(0x1p+0f16, LIBC_NAMESPACE::shared::coshf16(0.0f16));
-  EXPECT_FP_EQ(0x1p+0f16, LIBC_NAMESPACE::shared::cospif16(0.0f16));
-  EXPECT_FP_EQ(0x0p+0f16, LIBC_NAMESPACE::shared::erff16(0.0f16));
-  EXPECT_FP_EQ(0x1p+0f16, LIBC_NAMESPACE::shared::erfcf16(0.0f));
-  EXPECT_FP_EQ(0x1p+0f16, LIBC_NAMESPACE::shared::exp10f16(0.0f16));
-  EXPECT_FP_EQ(0x0p+0f16, LIBC_NAMESPACE::shared::exp10m1f16(0.0f16));
-  EXPECT_FP_EQ(0x1p+0f16, LIBC_NAMESPACE::shared::exp2f16(0.0f16));
-  EXPECT_FP_EQ(0x0p+0f16, LIBC_NAMESPACE::shared::exp2m1f16(0.0f16));
-  EXPECT_FP_EQ(0x1p+0f16, LIBC_NAMESPACE::shared::expf16(0.0f16));
-  EXPECT_FP_EQ(0x0p+0f16, LIBC_NAMESPACE::shared::expm1f16(0.0f16));
-  EXPECT_FP_EQ(0x0p+0f16,
-               LIBC_NAMESPACE::shared::fmaf16(0.0f16, 0.0f16, 0.0f16));
-  EXPECT_FP_EQ(0x0p+0f16, LIBC_NAMESPACE::shared::hypotf16(0.0f16, 0.0f16));
-  EXPECT_FP_EQ(0x0p+0f16, LIBC_NAMESPACE::shared::logf16(1.0f16));
-  EXPECT_FP_EQ(0x0p+0f16, LIBC_NAMESPACE::shared::sinhf16(0.0f16));
-
-  EXPECT_FP_EQ(float16(10.0), LIBC_NAMESPACE::shared::f16fma(2.0, 3.0, 4.0));
-
-  EXPECT_FP_EQ(float16(10.0),
-               LIBC_NAMESPACE::shared::f16fmaf(2.0f, 3.0f, 4.0f));
-
-#ifdef LIBC_TYPES_HAS_FLOAT128
-
-  EXPECT_FP_EQ(10.0f16, LIBC_NAMESPACE::shared::f16fmaf128(
-                            float128(2.0), float128(3.0), float128(4.0)));
-  EXPECT_FP_EQ(
-      5.0f16, LIBC_NAMESPACE::shared::f16addf128(float128(2.0), float128(3.0)));
-  EXPECT_FP_EQ(float128(0.0), LIBC_NAMESPACE::shared::f16divf128(
-                                  float128(0.0), float128(1.0)));
-
-  EXPECT_FP_EQ(float128(0.0), LIBC_NAMESPACE::shared::f16mulf128(
-                                  float128(0.0), float128(0.0)));
-
-  EXPECT_FP_EQ(float128(0.0), LIBC_NAMESPACE::shared::f16subf128(
-                                  float128(0.0), float128(0.0)));
-#endif // LIBC_TYPES_HAS_FLOAT128
-
-  EXPECT_FP_EQ(0.0, LIBC_NAMESPACE::shared::f16div(0.0, 1.0));
-  EXPECT_FP_EQ(0x0p+0L, LIBC_NAMESPACE::shared::f16divl(0.0L, 1.0L));
-  EXPECT_FP_EQ(0x0p+0f, LIBC_NAMESPACE::shared::f16divf(0.0f, 1.0f));
-  EXPECT_FP_EQ(0x0p+0L, LIBC_NAMESPACE::shared::f16mul(0.0L, 0.0L));
-  EXPECT_FP_EQ(0x0p+0L, LIBC_NAMESPACE::shared::f16mull(0.0L, 0.0L));
-  EXPECT_FP_EQ(0x0p+0f, LIBC_NAMESPACE::shared::f16mulf(0.0f, 0.0f));
-  EXPECT_FP_EQ(0.0, LIBC_NAMESPACE::shared::f16sub(0.0, 0.0));
-  EXPECT_FP_EQ(0x0p+0L, LIBC_NAMESPACE::shared::f16subl(0.0L, 0.0L));
-  EXPECT_FP_EQ(0x0p+0f, LIBC_NAMESPACE::shared::f16subf(0.0f, 0.0f));
-
-  EXPECT_FP_EQ(5.0f16, LIBC_NAMESPACE::shared::f16add(2.0, 3.0));
-  EXPECT_FP_EQ(5.0f16, LIBC_NAMESPACE::shared::f16addf(2.0f, 3.0f));
-  EXPECT_FP_EQ(5.0f16, LIBC_NAMESPACE::shared::f16addl(2.0L, 3.0L));
-  EXPECT_FP_EQ(0x0p+0f16, LIBC_NAMESPACE::shared::f16sqrt(0.0));
-
-  EXPECT_FP_EQ(0x0p+0f16, LIBC_NAMESPACE::shared::f16sqrtf(0.0f));
-
-#ifdef LIBC_TYPES_HAS_FLOAT128
-
-  EXPECT_FP_EQ(0x0p+0f16, LIBC_NAMESPACE::shared::f16sqrtf128(float128(0.0)));
-
-#endif // LIBC_TYPES_HAS_FLOAT128
-
-  EXPECT_FP_EQ(float16(10.0),
-               LIBC_NAMESPACE::shared::f16fmal(2.0L, 3.0L, 4.0L));
+  EXPECT_FP_EQ(0.0f16, LIBC_NAMESPACE::shared::asinf16(0.0f16));
+  EXPECT_FP_EQ(0.0f16, LIBC_NAMESPACE::shared::asinhf16(0.0f16));
+  EXPECT_FP_EQ(0.0f16, LIBC_NAMESPACE::shared::asinpif16(0.0f16));
+  EXPECT_FP_EQ(0.0f16, LIBC_NAMESPACE::shared::atan2f16(0.0f16, 0.0f16));
+  EXPECT_FP_EQ(0.0f16, LIBC_NAMESPACE::shared::atanf16(0.0f16));
+  EXPECT_FP_EQ(0.0f16, LIBC_NAMESPACE::shared::atanhf16(0.0f16));
+  EXPECT_FP_EQ(0.0f16, LIBC_NAMESPACE::shared::atanpif16(0.0f16));
+  EXPECT_FP_EQ(1.0f16, LIBC_NAMESPACE::shared::cosf16(0.0f16));
+  EXPECT_FP_EQ(1.0f16, LIBC_NAMESPACE::shared::coshf16(0.0f16));
+  EXPECT_FP_EQ(1.0f16, LIBC_NAMESPACE::shared::cospif16(0.0f16));
+  EXPECT_FP_EQ(0.0f16, LIBC_NAMESPACE::shared::erff16(0.0f16));
+  EXPECT_FP_EQ(1.0f16, LIBC_NAMESPACE::shared::erfcf16(0.0f));
+  EXPECT_FP_EQ(1.0f16, LIBC_NAMESPACE::shared::exp10f16(0.0f16));
+  EXPECT_FP_EQ(0.0f16, LIBC_NAMESPACE::shared::exp10m1f16(0.0f16));
+  EXPECT_FP_EQ(1.0f16, LIBC_NAMESPACE::shared::exp2f16(0.0f16));
+  EXPECT_FP_EQ(0.0f16, LIBC_NAMESPACE::shared::exp2m1f16(0.0f16));
+  EXPECT_FP_EQ(1.0f16, LIBC_NAMESPACE::shared::expf16(0.0f16));
+  EXPECT_FP_EQ(0.0f16, LIBC_NAMESPACE::shared::expm1f16(0.0f16));
+  EXPECT_FP_EQ(0.0f16, LIBC_NAMESPACE::shared::fmaf16(0.0f16, 0.0f16, 0.0f16));
+  EXPECT_FP_EQ(0.0f16, LIBC_NAMESPACE::shared::hypotf16(0.0f16, 0.0f16));
+  EXPECT_FP_EQ(0.0f16, LIBC_NAMESPACE::shared::logf16(1.0f16));
+  EXPECT_FP_EQ(0.0f16, LIBC_NAMESPACE::shared::sinhf16(0.0f16));
 
   ASSERT_FP_EQ(float16(8 << 5), LIBC_NAMESPACE::shared::ldexpf16(8.0f16, 5));
   ASSERT_FP_EQ(float16(-1 * (8 << 5)),
@@ -101,31 +53,30 @@ TEST(LlvmLibcSharedMathTest, AllFloat16) {
   EXPECT_EQ(exponent, 5);
 
   EXPECT_EQ(0, LIBC_NAMESPACE::shared::ilogbf16(1.0f16));
-  EXPECT_FP_EQ(0x1p+0f16, LIBC_NAMESPACE::shared::log10f16(10.0f16));
-  EXPECT_FP_EQ(0x1p+0f16, LIBC_NAMESPACE::shared::log2f16(2.0f16));
-  EXPECT_FP_EQ(0x0p+0f16, LIBC_NAMESPACE::shared::logbf16(1.0f16));
+  EXPECT_FP_EQ(1.0f16, LIBC_NAMESPACE::shared::log10f16(10.0f16));
+  EXPECT_FP_EQ(1.0f16, LIBC_NAMESPACE::shared::log2f16(2.0f16));
+  EXPECT_FP_EQ(0.0f16, LIBC_NAMESPACE::shared::logbf16(1.0f16));
   EXPECT_EQ(0L, LIBC_NAMESPACE::shared::llogbf16(1.0f16));
 
   EXPECT_FP_EQ(0x1.921fb6p+0f16, LIBC_NAMESPACE::shared::acosf16(0.0f16));
-  EXPECT_FP_EQ(0x1p+0f16, LIBC_NAMESPACE::shared::f16sqrtl(1.0L));
   EXPECT_FP_EQ(0.0f16, LIBC_NAMESPACE::shared::sinf16(0.0f16));
   EXPECT_FP_EQ(0.0f16, LIBC_NAMESPACE::shared::tanf16(0.0f16));
-  EXPECT_FP_EQ(0x0p+0f16, LIBC_NAMESPACE::shared::sinpif16(0.0f16));
+  EXPECT_FP_EQ(0.0f16, LIBC_NAMESPACE::shared::sinpif16(0.0f16));
   EXPECT_FP_EQ(0.0f16, LIBC_NAMESPACE::shared::tanhf16(0.0f16));
-  EXPECT_FP_EQ(0x0p+0f16, LIBC_NAMESPACE::shared::tanpif16(0.0f16));
+  EXPECT_FP_EQ(0.0f16, LIBC_NAMESPACE::shared::tanpif16(0.0f16));
 
   float16 canonicalizef16_cx = 0.0f16;
   float16 canonicalizef16_x = 0.0f16;
   EXPECT_EQ(0, LIBC_NAMESPACE::shared::canonicalizef16(&canonicalizef16_cx,
                                                        &canonicalizef16_x));
-  EXPECT_FP_EQ(0x0p+0f16, canonicalizef16_cx);
+  EXPECT_FP_EQ(0.0f16, canonicalizef16_cx);
 
-  EXPECT_FP_EQ(0x0p+0f16, LIBC_NAMESPACE::shared::ceilf16(0.0f16));
-  EXPECT_FP_EQ(0x0p+0f16, LIBC_NAMESPACE::shared::fdimf16(0.0f16, 0.0f16));
-  EXPECT_FP_EQ(0x0p+0f16, LIBC_NAMESPACE::shared::floorf16(0.0f16));
-  EXPECT_FP_EQ(0x0p+0f16, LIBC_NAMESPACE::shared::fmaxf16(0.0f16, 0.0f16));
+  EXPECT_FP_EQ(0.0f16, LIBC_NAMESPACE::shared::ceilf16(0.0f16));
+  EXPECT_FP_EQ(0.0f16, LIBC_NAMESPACE::shared::fdimf16(0.0f16, 0.0f16));
+  EXPECT_FP_EQ(0.0f16, LIBC_NAMESPACE::shared::floorf16(0.0f16));
+  EXPECT_FP_EQ(0.0f16, LIBC_NAMESPACE::shared::fmaxf16(0.0f16, 0.0f16));
   float16 getpayloadf16_x = 0.0f16;
-  EXPECT_FP_EQ(-0x1p+0f16,
+  EXPECT_FP_EQ(-1.0f16,
                LIBC_NAMESPACE::shared::getpayloadf16(&getpayloadf16_x));
 
   float16 setpayloadf16_res = 0.0f16;
@@ -135,14 +86,17 @@ TEST(LlvmLibcSharedMathTest, AllFloat16) {
   float16 setpayloadsigf16_res = 0.0f16;
   EXPECT_EQ(1, LIBC_NAMESPACE::shared::setpayloadsigf16(&setpayloadsigf16_res,
                                                         0.0f16));
-  EXPECT_FP_EQ(0x0p+0f16, setpayloadsigf16_res);
+  EXPECT_FP_EQ(0.0f16, setpayloadsigf16_res);
   float16 neg_min_denormal = FPBits::min_subnormal(Sign::NEG).get_val();
   EXPECT_FP_EQ(neg_min_denormal, LIBC_NAMESPACE::shared::nextdownf16(0.0f16));
   float16 min_denormal = FPBits::min_subnormal(Sign ::POS).get_val();
   EXPECT_FP_EQ(min_denormal, LIBC_NAMESPACE::shared::nextupf16(0.0f16));
-  EXPECT_FP_EQ(0x0p+0f16,
-               LIBC_NAMESPACE::shared::nexttowardf16(0.0f16, 0.0f16));
-  EXPECT_FP_EQ(0x0p+0f16, LIBC_NAMESPACE::shared::nextafterf16(0.0f16, 0.0f16));
+
+  EXPECT_FP_EQ(0.0f16, LIBC_NAMESPACE::shared::nextafterf16(0.0f16, 0.0f16));
+
+#ifndef LIBC_TYPES_LONG_DOUBLE_IS_DOUBLE_DOUBLE
+  EXPECT_FP_EQ(0.0f16, LIBC_NAMESPACE::shared::nexttowardf16(0.0f16, 0.0L));
+#endif // LIBC_TYPES_LONG_DOUBLE_IS_DOUBLE_DOUBLE
 }
 
 #endif // LIBC_TYPES_HAS_FLOAT16
@@ -150,32 +104,31 @@ TEST(LlvmLibcSharedMathTest, AllFloat16) {
 TEST(LlvmLibcSharedMathTest, AllFloat) {
   using FPBits = LIBC_NAMESPACE::fputil::FPBits<float>;
   int exponent;
-  float sin, cos;
 
   EXPECT_FP_EQ(0x1.921fb6p+0, LIBC_NAMESPACE::shared::acosf(0.0f));
-  EXPECT_FP_EQ(0x0p+0f, LIBC_NAMESPACE::shared::acoshf(1.0f));
-  EXPECT_FP_EQ(0x0p+0f, LIBC_NAMESPACE::shared::acospif(1.0f));
-  EXPECT_FP_EQ(0x0p+0f, LIBC_NAMESPACE::shared::asinf(0.0f));
-  EXPECT_FP_EQ(0x0p+0f, LIBC_NAMESPACE::shared::asinhf(0.0f));
-  EXPECT_FP_EQ(0x0p+0f, LIBC_NAMESPACE::shared::asinpif(0.0f));
-  EXPECT_FP_EQ(0x0p+0f, LIBC_NAMESPACE::shared::atan2f(0.0f, 0.0f));
-  EXPECT_FP_EQ(0x0p+0f, LIBC_NAMESPACE::shared::atanf(0.0f));
-  EXPECT_FP_EQ(0x0p+0f, LIBC_NAMESPACE::shared::atanhf(0.0f));
-  EXPECT_FP_EQ(0x0p+0f, LIBC_NAMESPACE::shared::cbrtf(0.0f));
-  EXPECT_FP_EQ(0x1p+0f, LIBC_NAMESPACE::shared::cosf(0.0f));
-  EXPECT_FP_EQ(0x1p+0f, LIBC_NAMESPACE::shared::coshf(0.0f));
-  EXPECT_FP_EQ(0x1p+0f, LIBC_NAMESPACE::shared::cospif(0.0f));
-  EXPECT_FP_EQ(0x0p+0f, LIBC_NAMESPACE::shared::exp10m1f(0.0f));
-  EXPECT_FP_EQ(0x0p+0f, LIBC_NAMESPACE::shared::erff(0.0f));
-  EXPECT_FP_EQ(0x1p+0f, LIBC_NAMESPACE::shared::exp10f(0.0f));
-  EXPECT_FP_EQ(0x0p+0f, LIBC_NAMESPACE::shared::exp2m1f(0.0f));
-  EXPECT_FP_EQ(0x1p+0f, LIBC_NAMESPACE::shared::expf(0.0f));
-  EXPECT_FP_EQ(0x1p+0f, LIBC_NAMESPACE::shared::exp2f(0.0f));
-  EXPECT_FP_EQ(0x0p+0f, LIBC_NAMESPACE::shared::expm1f(0.0f));
-  EXPECT_FP_EQ(0x0p+0f, LIBC_NAMESPACE::shared::fmaf(0.0f, 0.0f, 0.0f));
-  EXPECT_FP_EQ(0x0p+0f, LIBC_NAMESPACE::shared::hypotf(0.0f, 0.0f));
-  EXPECT_FP_EQ(0x0p+0f, LIBC_NAMESPACE::shared::logf(1.0f));
-  EXPECT_FP_EQ(0x0p+0f, LIBC_NAMESPACE::shared::sinhf(0.0f));
+  EXPECT_FP_EQ(0.0f, LIBC_NAMESPACE::shared::acoshf(1.0f));
+  EXPECT_FP_EQ(0.0f, LIBC_NAMESPACE::shared::acospif(1.0f));
+  EXPECT_FP_EQ(0.0f, LIBC_NAMESPACE::shared::asinf(0.0f));
+  EXPECT_FP_EQ(0.0f, LIBC_NAMESPACE::shared::asinhf(0.0f));
+  EXPECT_FP_EQ(0.0f, LIBC_NAMESPACE::shared::asinpif(0.0f));
+  EXPECT_FP_EQ(0.0f, LIBC_NAMESPACE::shared::atan2f(0.0f, 0.0f));
+  EXPECT_FP_EQ(0.0f, LIBC_NAMESPACE::shared::atanf(0.0f));
+  EXPECT_FP_EQ(0.0f, LIBC_NAMESPACE::shared::atanhf(0.0f));
+  EXPECT_FP_EQ(0.0f, LIBC_NAMESPACE::shared::cbrtf(0.0f));
+  EXPECT_FP_EQ(1.0f, LIBC_NAMESPACE::shared::cosf(0.0f));
+  EXPECT_FP_EQ(1.0f, LIBC_NAMESPACE::shared::coshf(0.0f));
+  EXPECT_FP_EQ(1.0f, LIBC_NAMESPACE::shared::cospif(0.0f));
+  EXPECT_FP_EQ(0.0f, LIBC_NAMESPACE::shared::exp10m1f(0.0f));
+  EXPECT_FP_EQ(0.0f, LIBC_NAMESPACE::shared::erff(0.0f));
+  EXPECT_FP_EQ(1.0f, LIBC_NAMESPACE::shared::exp10f(0.0f));
+  EXPECT_FP_EQ(0.0f, LIBC_NAMESPACE::shared::exp2m1f(0.0f));
+  EXPECT_FP_EQ(1.0f, LIBC_NAMESPACE::shared::expf(0.0f));
+  EXPECT_FP_EQ(1.0f, LIBC_NAMESPACE::shared::exp2f(0.0f));
+  EXPECT_FP_EQ(0.0f, LIBC_NAMESPACE::shared::expm1f(0.0f));
+  EXPECT_FP_EQ(0.0f, LIBC_NAMESPACE::shared::fmaf(0.0f, 0.0f, 0.0f));
+  EXPECT_FP_EQ(0.0f, LIBC_NAMESPACE::shared::hypotf(0.0f, 0.0f));
+  EXPECT_FP_EQ(0.0f, LIBC_NAMESPACE::shared::logf(1.0f));
+  EXPECT_FP_EQ(0.0f, LIBC_NAMESPACE::shared::sinhf(0.0f));
 
   EXPECT_FP_EQ_ALL_ROUNDING(0.75f,
                             LIBC_NAMESPACE::shared::frexpf(24.0f, &exponent));
@@ -186,18 +139,19 @@ TEST(LlvmLibcSharedMathTest, AllFloat) {
   ASSERT_FP_EQ(float(8 << 5), LIBC_NAMESPACE::shared::ldexpf(8.0f, 5));
   ASSERT_FP_EQ(float(-1 * (8 << 5)), LIBC_NAMESPACE::shared::ldexpf(-8.0f, 5));
 
-  EXPECT_EQ(long(0), LIBC_NAMESPACE::shared::llogbf(1.0f));
-  EXPECT_FP_EQ(0x0p+0f, LIBC_NAMESPACE::shared::log1pf(0.0f));
-  EXPECT_FP_EQ(0x1p+0f, LIBC_NAMESPACE::shared::log10f(10.0f));
-  EXPECT_FP_EQ(0x1p+0f, LIBC_NAMESPACE::shared::log2f(2.0f));
-  EXPECT_FP_EQ(0x0p+0f, LIBC_NAMESPACE::shared::logbf(1.0f));
-  EXPECT_FP_EQ(0x1p+0f, LIBC_NAMESPACE::shared::powf(0.0f, 0.0f));
-  EXPECT_FP_EQ(0x1p+0f, LIBC_NAMESPACE::shared::rsqrtf(1.0f));
+  EXPECT_EQ(0L, LIBC_NAMESPACE::shared::llogbf(1.0f));
+  EXPECT_FP_EQ(0.0f, LIBC_NAMESPACE::shared::log1pf(0.0f));
+  EXPECT_FP_EQ(1.0f, LIBC_NAMESPACE::shared::log10f(10.0f));
+  EXPECT_FP_EQ(1.0f, LIBC_NAMESPACE::shared::log2f(2.0f));
+  EXPECT_FP_EQ(0.0f, LIBC_NAMESPACE::shared::logbf(1.0f));
+  EXPECT_FP_EQ(1.0f, LIBC_NAMESPACE::shared::powf(0.0f, 0.0f));
+  EXPECT_FP_EQ(1.0f, LIBC_NAMESPACE::shared::rsqrtf(1.0f));
 
-  LIBC_NAMESPACE::shared::sincosf(0.0f, &sin, &cos);
-  ASSERT_FP_EQ(1.0f, cos);
-  ASSERT_FP_EQ(0.0f, sin);
-  EXPECT_FP_EQ(0x0p+0f, LIBC_NAMESPACE::shared::sinpif(0.0f));
+  float s, c;
+  LIBC_NAMESPACE::shared::sincosf(0.0f, &s, &c);
+  ASSERT_FP_EQ(1.0f, c);
+  ASSERT_FP_EQ(0.0f, s);
+  EXPECT_FP_EQ(0.0f, LIBC_NAMESPACE::shared::sinpif(0.0f));
   EXPECT_FP_EQ(0.0f, LIBC_NAMESPACE::shared::sinf(0.0f));
   EXPECT_FP_EQ(0.0f, LIBC_NAMESPACE::shared::sqrtf(0.0f));
   EXPECT_FP_EQ(0.0f, LIBC_NAMESPACE::shared::tanf(0.0f));
@@ -208,16 +162,21 @@ TEST(LlvmLibcSharedMathTest, AllFloat) {
   float canonicalizef_x = 0.0f;
   EXPECT_EQ(0, LIBC_NAMESPACE::shared::canonicalizef(&canonicalizef_cx,
                                                      &canonicalizef_x));
-  EXPECT_FP_EQ(0x0p+0f, canonicalizef_cx);
+  EXPECT_FP_EQ(0.0f, canonicalizef_cx);
 
-  EXPECT_FP_EQ(bfloat16(0.0), LIBC_NAMESPACE::shared::bf16mulf(0.0f, 0.0f));
-  EXPECT_FP_EQ(bfloat16(0.0), LIBC_NAMESPACE::shared::bf16subf(0.0f, 0.0f));
-  EXPECT_FP_EQ(0x0p+0f, LIBC_NAMESPACE::shared::ceilf(0.0f));
-  EXPECT_FP_EQ(0x0p+0f, LIBC_NAMESPACE::shared::fdimf(0.0f, 0.0f));
-  EXPECT_FP_EQ(0x0p+0f, LIBC_NAMESPACE::shared::floorf(0.0f));
-  EXPECT_FP_EQ(0x0p+0f, LIBC_NAMESPACE::shared::fmaxf(0.0f, 0.0f));
+  EXPECT_FP_EQ(bfloat16(5.0f), LIBC_NAMESPACE::shared::bf16addf(2.0f, 3.0f));
+  EXPECT_FP_EQ(bfloat16(2.0f), LIBC_NAMESPACE::shared::bf16divf(4.0f, 2.0f));
+  EXPECT_FP_EQ(bfloat16(0.0f), LIBC_NAMESPACE::shared::bf16mulf(0.0f, 0.0f));
+  EXPECT_FP_EQ(bfloat16(0.0f), LIBC_NAMESPACE::shared::bf16subf(0.0f, 0.0f));
+  EXPECT_FP_EQ(bfloat16(10.0f),
+               LIBC_NAMESPACE::shared::bf16fmaf(2.0f, 3.0f, 4.0f));
+
+  EXPECT_FP_EQ(0.0f, LIBC_NAMESPACE::shared::ceilf(0.0f));
+  EXPECT_FP_EQ(0.0f, LIBC_NAMESPACE::shared::fdimf(0.0f, 0.0f));
+  EXPECT_FP_EQ(0.0f, LIBC_NAMESPACE::shared::floorf(0.0f));
+  EXPECT_FP_EQ(0.0f, LIBC_NAMESPACE::shared::fmaxf(0.0f, 0.0f));
   float getpayloadf_x = 0.0f;
-  EXPECT_FP_EQ(-0x1p+0f, LIBC_NAMESPACE::shared::getpayloadf(&getpayloadf_x));
+  EXPECT_FP_EQ(-1.0f, LIBC_NAMESPACE::shared::getpayloadf(&getpayloadf_x));
 
   float setpayloadf_res = 0.0f;
   EXPECT_EQ(0, LIBC_NAMESPACE::shared::setpayloadf(&setpayloadf_res, 0.0f));
@@ -225,13 +184,25 @@ TEST(LlvmLibcSharedMathTest, AllFloat) {
   float setpayloadsigf_res = 0.0f;
   EXPECT_EQ(1,
             LIBC_NAMESPACE::shared::setpayloadsigf(&setpayloadsigf_res, 0.0f));
-  EXPECT_FP_EQ(0x0p+0f, setpayloadsigf_res);
+  EXPECT_FP_EQ(0.0f, setpayloadsigf_res);
   float neg_min_denormal = FPBits::min_subnormal(Sign::NEG).get_val();
   EXPECT_FP_EQ(neg_min_denormal, LIBC_NAMESPACE::shared::nextdownf(0.0f));
   float min_denormal = FPBits::min_subnormal(Sign ::POS).get_val();
   EXPECT_FP_EQ(min_denormal, LIBC_NAMESPACE::shared::nextupf(0.0f));
-  EXPECT_FP_EQ(0x0p+0f, LIBC_NAMESPACE::shared::nexttowardf(0.0f, 0.0f));
-  EXPECT_FP_EQ(0x0p+0f, LIBC_NAMESPACE::shared::nextafterf(0.0f, 0.0f));
+  EXPECT_FP_EQ(0.0f, LIBC_NAMESPACE::shared::nextafterf(0.0f, 0.0f));
+
+#ifndef LIBC_TYPES_LONG_DOUBLE_IS_DOUBLE_DOUBLE
+  EXPECT_FP_EQ(0.0f, LIBC_NAMESPACE::shared::nexttowardf(0.0f, 0.0L));
+#endif // LIBC_TYPES_LONG_DOUBLE_IS_DOUBLE_DOUBLE
+
+#ifdef LIBC_TYPES_HAS_FLOAT16
+  EXPECT_FP_EQ(5.0f16, LIBC_NAMESPACE::shared::f16addf(2.0f, 3.0f));
+  EXPECT_FP_EQ(0.0f16, LIBC_NAMESPACE::shared::f16divf(0.0f, 1.0f));
+  EXPECT_FP_EQ(0.0f16, LIBC_NAMESPACE::shared::f16mulf(0.0f, 0.0f));
+  EXPECT_FP_EQ(0.0f16, LIBC_NAMESPACE::shared::f16subf(0.0f, 0.0f));
+  EXPECT_FP_EQ(0.0f16, LIBC_NAMESPACE::shared::f16sqrtf(0.0f));
+  EXPECT_FP_EQ(10.0f16, LIBC_NAMESPACE::shared::f16fmaf(2.0f, 3.0f, 4.0f));
+#endif // LIBC_TYPES_HAS_FLOAT16
 }
 
 TEST(LlvmLibcSharedMathTest, AllDouble) {
@@ -241,30 +212,30 @@ TEST(LlvmLibcSharedMathTest, AllDouble) {
   LIBC_NAMESPACE::shared::sincos(0.0, &sin, &cos);
 
   EXPECT_FP_EQ(0x1.921fb54442d18p+0, LIBC_NAMESPACE::shared::acos(0.0));
-  EXPECT_FP_EQ(0x0p+0, LIBC_NAMESPACE::shared::asin(0.0));
-  EXPECT_FP_EQ(0x0p+0, LIBC_NAMESPACE::shared::asinpi(0.0));
-  EXPECT_FP_EQ(0x0p+0, LIBC_NAMESPACE::shared::atan(0.0));
-  EXPECT_FP_EQ(0x0p+0, LIBC_NAMESPACE::shared::atan2(0.0, 0.0));
-  EXPECT_FP_EQ(0x0p+0, LIBC_NAMESPACE::shared::cbrt(0.0));
-  EXPECT_FP_EQ(0x1p+0, LIBC_NAMESPACE::shared::cos(0.0));
-  EXPECT_FP_EQ(0x0p+0, LIBC_NAMESPACE::shared::dsqrtl(0.0));
-  EXPECT_FP_EQ(0x1p+0, LIBC_NAMESPACE::shared::exp(0.0));
-  EXPECT_FP_EQ(0x1p+0, LIBC_NAMESPACE::shared::exp2(0.0));
-  EXPECT_FP_EQ(0x1p+0, LIBC_NAMESPACE::shared::exp10(0.0));
-  EXPECT_FP_EQ(0x0p+0, LIBC_NAMESPACE::shared::expm1(0.0));
-  EXPECT_FP_EQ(0x0p+0, LIBC_NAMESPACE::shared::fma(0.0, 0.0, 0.0));
-  EXPECT_FP_EQ(0x0p+0f, LIBC_NAMESPACE::shared::ffma(0.0, 0.0, 0.0));
+  EXPECT_FP_EQ(0., LIBC_NAMESPACE::shared::asin(0.0));
+  EXPECT_FP_EQ(0.0, LIBC_NAMESPACE::shared::asinpi(0.0));
+  EXPECT_FP_EQ(0.0, LIBC_NAMESPACE::shared::atan(0.0));
+  EXPECT_FP_EQ(0.0, LIBC_NAMESPACE::shared::atan2(0.0, 0.0));
+  EXPECT_FP_EQ(0.0, LIBC_NAMESPACE::shared::cbrt(0.0));
+  EXPECT_FP_EQ(1.0, LIBC_NAMESPACE::shared::cos(0.0));
+  EXPECT_FP_EQ(0.0, LIBC_NAMESPACE::shared::dsqrtl(0.0));
+  EXPECT_FP_EQ(1.0, LIBC_NAMESPACE::shared::exp(0.0));
+  EXPECT_FP_EQ(1.0, LIBC_NAMESPACE::shared::exp2(0.0));
+  EXPECT_FP_EQ(1.0, LIBC_NAMESPACE::shared::exp10(0.0));
+  EXPECT_FP_EQ(0.0, LIBC_NAMESPACE::shared::expm1(0.0));
+  EXPECT_FP_EQ(0.0, LIBC_NAMESPACE::shared::fma(0.0, 0.0, 0.0));
+  EXPECT_FP_EQ(0.0f, LIBC_NAMESPACE::shared::ffma(0.0, 0.0, 0.0));
   EXPECT_FP_EQ(0.0, LIBC_NAMESPACE::shared::hypot(0.0, 0.0));
-  EXPECT_FP_EQ(0x0p+0, LIBC_NAMESPACE::shared::fsqrt(0.0));
-  EXPECT_FP_EQ(0x0p+0, LIBC_NAMESPACE::shared::log(1.0));
-  EXPECT_FP_EQ(0x0p+0, LIBC_NAMESPACE::shared::log10(1.0));
-  EXPECT_FP_EQ(0x0p+0, LIBC_NAMESPACE::shared::log1p(0.0));
-  EXPECT_FP_EQ(0x0p+0, LIBC_NAMESPACE::shared::log2(1.0));
+  EXPECT_FP_EQ(0.0, LIBC_NAMESPACE::shared::fsqrt(0.0));
+  EXPECT_FP_EQ(0.0, LIBC_NAMESPACE::shared::log(1.0));
+  EXPECT_FP_EQ(0.0, LIBC_NAMESPACE::shared::log10(1.0));
+  EXPECT_FP_EQ(0.0, LIBC_NAMESPACE::shared::log1p(0.0));
+  EXPECT_FP_EQ(0.0, LIBC_NAMESPACE::shared::log2(1.0));
   EXPECT_FP_EQ(1.0, LIBC_NAMESPACE::shared::pow(0.0, 0.0));
   EXPECT_FP_EQ(0.0, LIBC_NAMESPACE::shared::sin(0.0));
   EXPECT_FP_EQ(1.0, cos);
   EXPECT_FP_EQ(0.0, sin);
-  EXPECT_FP_EQ(0x0p+0, LIBC_NAMESPACE::shared::sqrt(0.0));
+  EXPECT_FP_EQ(0.0, LIBC_NAMESPACE::shared::sqrt(0.0));
   EXPECT_FP_EQ(0.0, LIBC_NAMESPACE::shared::tan(0.0));
   EXPECT_EQ(0, LIBC_NAMESPACE::shared::ilogb(1.0));
   EXPECT_EQ(0L, LIBC_NAMESPACE::shared::llogb(1.0));
@@ -276,9 +247,13 @@ TEST(LlvmLibcSharedMathTest, AllDouble) {
                                                     &canonicalize_x));
   EXPECT_FP_EQ(0.0, canonicalize_cx);
 
+  EXPECT_FP_EQ(bfloat16(5.0), LIBC_NAMESPACE::shared::bf16add(2.0, 3.0));
+  EXPECT_FP_EQ(bfloat16(2.0), LIBC_NAMESPACE::shared::bf16div(4.0, 2.0));
   EXPECT_FP_EQ(bfloat16(0.0), LIBC_NAMESPACE::shared::bf16mul(0.0, 0.0));
   EXPECT_FP_EQ(bfloat16(0.0), LIBC_NAMESPACE::shared::bf16sub(0.0, 0.0));
-  EXPECT_FP_EQ(0x0p+0, LIBC_NAMESPACE::shared::ceil(0.0));
+  EXPECT_FP_EQ(bfloat16(10.0), LIBC_NAMESPACE::shared::bf16fma(2.0, 3.0, 4.0));
+
+  EXPECT_FP_EQ(0.0, LIBC_NAMESPACE::shared::ceil(0.0));
   EXPECT_FP_EQ(0.0, LIBC_NAMESPACE::shared::fadd(0.0, 0.0));
   EXPECT_FP_EQ(0.0, LIBC_NAMESPACE::shared::fdim(0.0, 0.0));
   EXPECT_FP_EQ(0.0, LIBC_NAMESPACE::shared::floor(0.0));
@@ -296,35 +271,54 @@ TEST(LlvmLibcSharedMathTest, AllDouble) {
   EXPECT_FP_EQ(neg_min_denormal, LIBC_NAMESPACE::shared::nextdown(0.0));
   double min_denormal = FPBits::min_subnormal(Sign ::POS).get_val();
   EXPECT_FP_EQ(min_denormal, LIBC_NAMESPACE::shared::nextup(0.0));
-  EXPECT_FP_EQ(0.0, LIBC_NAMESPACE::shared::nexttoward(0.0, 0.0));
   EXPECT_FP_EQ(0.0, LIBC_NAMESPACE::shared::nextafter(0.0, 0.0));
+
+#ifndef LIBC_TYPES_LONG_DOUBLE_IS_DOUBLE_DOUBLE
+  EXPECT_FP_EQ(0.0, LIBC_NAMESPACE::shared::nexttoward(0.0, 0.0L));
+#endif // LIBC_TYPES_LONG_DOUBLE_IS_DOUBLE_DOUBLE
+
+#ifdef LIBC_TYPES_HAS_FLOAT16
+  EXPECT_FP_EQ(5.0f16, LIBC_NAMESPACE::shared::f16add(2.0, 3.0));
+  EXPECT_FP_EQ(0.0f16, LIBC_NAMESPACE::shared::f16div(0.0, 1.0));
+  EXPECT_FP_EQ(0.0f16, LIBC_NAMESPACE::shared::f16mul(0.0, 0.0));
+  EXPECT_FP_EQ(0.0f16, LIBC_NAMESPACE::shared::f16sub(0.0, 0.0));
+  EXPECT_FP_EQ(0.0f16, LIBC_NAMESPACE::shared::f16sqrt(0.0));
+  EXPECT_FP_EQ(10.0f16, LIBC_NAMESPACE::shared::f16fma(2.0, 3.0, 4.0));
+#endif // LIBC_TYPES_HAS_FLOAT16
 }
+
+// TODO: Enable the tests when double-double type is supported.
+#ifndef LIBC_TYPES_LONG_DOUBLE_IS_DOUBLE_DOUBLE
 
 TEST(LlvmLibcSharedMathTest, AllLongDouble) {
   using FPBits = LIBC_NAMESPACE::fputil::FPBits<long double>;
-  EXPECT_FP_EQ(0x0p+0L,
-               LIBC_NAMESPACE::shared::dfmal(0x0.p+0L, 0x0.p+0L, 0x0.p+0L));
-  EXPECT_FP_EQ(0x0p+0f, LIBC_NAMESPACE::shared::fsqrtl(0.0L));
-  EXPECT_EQ(0, LIBC_NAMESPACE::shared::ilogbl(0x1.p+0L));
+  EXPECT_FP_EQ(0.0L, LIBC_NAMESPACE::shared::dfmal(0.0L, 0.0L, 0.0L));
+  EXPECT_FP_EQ(0.0f, LIBC_NAMESPACE::shared::fsqrtl(0.0L));
+  EXPECT_EQ(0, LIBC_NAMESPACE::shared::ilogbl(1.0L));
   EXPECT_EQ(0L, LIBC_NAMESPACE::shared::llogbl(1.0L));
-  EXPECT_FP_EQ(0x0p+0L, LIBC_NAMESPACE::shared::logbl(1.0L));
+  EXPECT_FP_EQ(0.0L, LIBC_NAMESPACE::shared::logbl(1.0L));
   EXPECT_FP_EQ(10.0f, LIBC_NAMESPACE::shared::ffmal(2.0L, 3.0, 4.0L));
 
   long double canonicalizel_cx = 0.0L;
   long double canonicalizel_x = 0.0L;
   EXPECT_EQ(0, LIBC_NAMESPACE::shared::canonicalizel(&canonicalizel_cx,
                                                      &canonicalizel_x));
-  EXPECT_FP_EQ(0x0p+0L, canonicalizel_cx);
+  EXPECT_FP_EQ(0.0L, canonicalizel_cx);
 
+  EXPECT_FP_EQ(bfloat16(5.0), LIBC_NAMESPACE::shared::bf16addl(2.0L, 3.0L));
+  EXPECT_FP_EQ(bfloat16(2.0), LIBC_NAMESPACE::shared::bf16divl(6.0L, 3.0L));
   EXPECT_FP_EQ(bfloat16(0.0), LIBC_NAMESPACE::shared::bf16mull(0.0L, 0.0L));
-  EXPECT_FP_EQ(0x0p+0L, LIBC_NAMESPACE::shared::ceill(0.0L));
-  EXPECT_FP_EQ(0x0p+0L, LIBC_NAMESPACE::shared::daddl(0.0L, 0.0L));
-  EXPECT_FP_EQ(0x0p+0L, LIBC_NAMESPACE::shared::faddl(0.0L, 0.0L));
-  EXPECT_FP_EQ(0x0p+0L, LIBC_NAMESPACE::shared::fdiml(0.0L, 0.0L));
-  EXPECT_FP_EQ(0x0p+0L, LIBC_NAMESPACE::shared::floorl(0.0L));
-  EXPECT_FP_EQ(0x0p+0L, LIBC_NAMESPACE::shared::fmaxl(0.0L, 0.0L));
+  EXPECT_FP_EQ(bfloat16(10.0),
+               LIBC_NAMESPACE::shared::bf16fmal(2.0L, 3.0L, 4.0L));
+
+  EXPECT_FP_EQ(0.0L, LIBC_NAMESPACE::shared::ceill(0.0L));
+  EXPECT_FP_EQ(0.0L, LIBC_NAMESPACE::shared::daddl(0.0L, 0.0L));
+  EXPECT_FP_EQ(0.0L, LIBC_NAMESPACE::shared::faddl(0.0L, 0.0L));
+  EXPECT_FP_EQ(0.0L, LIBC_NAMESPACE::shared::fdiml(0.0L, 0.0L));
+  EXPECT_FP_EQ(0.0L, LIBC_NAMESPACE::shared::floorl(0.0L));
+  EXPECT_FP_EQ(0.0L, LIBC_NAMESPACE::shared::fmaxl(0.0L, 0.0L));
   long double getpayloadl_x = 0.0L;
-  EXPECT_FP_EQ(-0x1p+0L, LIBC_NAMESPACE::shared::getpayloadl(&getpayloadl_x));
+  EXPECT_FP_EQ(-1.0L, LIBC_NAMESPACE::shared::getpayloadl(&getpayloadl_x));
 
   long double setpayloadl_res = 0.0L;
   EXPECT_EQ(0, LIBC_NAMESPACE::shared::setpayloadl(&setpayloadl_res, 0.0L));
@@ -332,15 +326,26 @@ TEST(LlvmLibcSharedMathTest, AllLongDouble) {
   long double setpayloadsigl_res = 0.0L;
   EXPECT_EQ(1,
             LIBC_NAMESPACE::shared::setpayloadsigl(&setpayloadsigl_res, 0.0L));
-  EXPECT_FP_EQ(0x0p+0L, setpayloadsigl_res);
+  EXPECT_FP_EQ(0.0L, setpayloadsigl_res);
 
   long double neg_min_denormal = FPBits::min_subnormal(Sign::NEG).get_val();
   EXPECT_FP_EQ(neg_min_denormal, LIBC_NAMESPACE::shared::nextdownl(0.0L));
   long double min_denormal = FPBits::min_subnormal(Sign ::POS).get_val();
   EXPECT_FP_EQ(min_denormal, LIBC_NAMESPACE::shared::nextupl(0.0L));
-  EXPECT_FP_EQ(0x0p+0L, LIBC_NAMESPACE::shared::nexttowardl(0.0L, 0.0L));
-  EXPECT_FP_EQ(0x0p+0L, LIBC_NAMESPACE::shared::nextafterl(0.0L, 0.0L));
+  EXPECT_FP_EQ(0.0L, LIBC_NAMESPACE::shared::nexttowardl(0.0L, 0.0L));
+  EXPECT_FP_EQ(0.0L, LIBC_NAMESPACE::shared::nextafterl(0.0L, 0.0L));
+
+#ifdef LIBC_TYPES_HAS_FLOAT16
+  EXPECT_FP_EQ(5.0f16, LIBC_NAMESPACE::shared::f16addl(2.0L, 3.0L));
+  EXPECT_FP_EQ(0.0f16, LIBC_NAMESPACE::shared::f16divl(0.0L, 1.0L));
+  EXPECT_FP_EQ(0.0f16, LIBC_NAMESPACE::shared::f16mull(0.0L, 0.0L));
+  EXPECT_FP_EQ(0.0f16, LIBC_NAMESPACE::shared::f16subl(0.0L, 0.0L));
+  EXPECT_FP_EQ(1.0f16, LIBC_NAMESPACE::shared::f16sqrtl(1.0L));
+  EXPECT_FP_EQ(10.0f16, LIBC_NAMESPACE::shared::f16fmal(2.0L, 3.0L, 4.0L));
+#endif // LIBC_TYPES_HAS_FLOAT16
 }
+
+#endif // LIBC_TYPES_LONG_DOUBLE_IS_DOUBLE_DOUBLE
 
 #ifdef LIBC_TYPES_HAS_FLOAT128
 
@@ -348,11 +353,11 @@ TEST(LlvmLibcSharedMathTest, AllFloat128) {
   using FPBits = LIBC_NAMESPACE::fputil::FPBits<float128>;
   int exponent;
 
-  EXPECT_FP_EQ(float128(0x0p+0),
+  EXPECT_FP_EQ(float128(0.0),
                LIBC_NAMESPACE::shared::atan2f128(float128(0.0), float128(0.0)));
-  EXPECT_FP_EQ(0x0p+0f, LIBC_NAMESPACE::shared::ffmaf128(
-                            float128(0.0), float128(0.0), float128(0.0)));
-  EXPECT_FP_EQ(0x1p+0f, LIBC_NAMESPACE::shared::fsqrtf128(float128(1.0f)));
+  EXPECT_FP_EQ(0.0f, LIBC_NAMESPACE::shared::ffmaf128(
+                         float128(0.0), float128(0.0), float128(0.0)));
+  EXPECT_FP_EQ(1.0f, LIBC_NAMESPACE::shared::fsqrtf128(float128(1.0f)));
   EXPECT_FP_EQ_ALL_ROUNDING(float128(0.75), LIBC_NAMESPACE::shared::frexpf128(
                                                 float128(24), &exponent));
   EXPECT_EQ(exponent, 5);
@@ -365,8 +370,7 @@ TEST(LlvmLibcSharedMathTest, AllFloat128) {
   EXPECT_FP_EQ(float128(0.0), LIBC_NAMESPACE::shared::logbf128(float128(1.0)));
   EXPECT_FP_EQ(0.0, LIBC_NAMESPACE::shared::dfmaf128(
                         float128(0.0), float128(0.0), float128(0.0)));
-  EXPECT_FP_EQ(float128(0x1p+0),
-               LIBC_NAMESPACE::shared::sqrtf128(float128(1.0)));
+  EXPECT_FP_EQ(float128(1.0), LIBC_NAMESPACE::shared::sqrtf128(float128(1.0)));
 
   EXPECT_EQ(0L, LIBC_NAMESPACE::shared::llogbf128(float128(1.0)));
 
@@ -418,6 +422,22 @@ TEST(LlvmLibcSharedMathTest, AllFloat128) {
   EXPECT_FP_EQ(min_denormal, LIBC_NAMESPACE::shared::nextupf128(float128(0.0)));
   EXPECT_FP_EQ(float128(0.0), LIBC_NAMESPACE::shared::nextafterf128(
                                   float128(0.0), float128(0.0)));
+
+#ifdef LIBC_TYPES_HAS_FLOAT16
+  EXPECT_FP_EQ(10.0f16, LIBC_NAMESPACE::shared::f16fmaf128(
+                            float128(2.0), float128(3.0), float128(4.0)));
+  EXPECT_FP_EQ(
+      5.0f16, LIBC_NAMESPACE::shared::f16addf128(float128(2.0), float128(3.0)));
+  EXPECT_FP_EQ(
+      0.0f16, LIBC_NAMESPACE::shared::f16divf128(float128(0.0), float128(1.0)));
+
+  EXPECT_FP_EQ(
+      0.0f16, LIBC_NAMESPACE::shared::f16mulf128(float128(0.0), float128(0.0)));
+
+  EXPECT_FP_EQ(
+      0.0f16, LIBC_NAMESPACE::shared::f16subf128(float128(0.0), float128(0.0)));
+  EXPECT_FP_EQ(0.0f16, LIBC_NAMESPACE::shared::f16sqrtf128(float128(0.0)));
+#endif // LIBC_TYPES_HAS_FLOAT16
 }
 
 #endif // LIBC_TYPES_HAS_FLOAT128
@@ -425,22 +445,12 @@ TEST(LlvmLibcSharedMathTest, AllFloat128) {
 TEST(LlvmLibcSharedMathTest, AllBFloat16) {
   using FPBits = LIBC_NAMESPACE::fputil::FPBits<bfloat16>;
   EXPECT_FP_EQ(bfloat16(0.0), LIBC_NAMESPACE::shared::atanbf16(bfloat16(0.0)));
-  EXPECT_FP_EQ(bfloat16(5.0), LIBC_NAMESPACE::shared::bf16add(2.0, 3.0));
-  EXPECT_FP_EQ(bfloat16(2.0f), LIBC_NAMESPACE::shared::bf16divf(4.0f, 2.0f));
-  EXPECT_FP_EQ(bfloat16(2.0), LIBC_NAMESPACE::shared::bf16divl(6.0L, 3.0L));
-  EXPECT_FP_EQ(bfloat16(2.0), LIBC_NAMESPACE::shared::bf16div(4.0, 2.0));
-  EXPECT_FP_EQ(bfloat16(10.0),
-               LIBC_NAMESPACE::shared::bf16fmal(2.0L, 3.0L, 4.0L));
 
   bfloat16 canonicalizebf16_cx = bfloat16(0.0);
   bfloat16 canonicalizebf16_x = bfloat16(0.0);
   EXPECT_EQ(0, LIBC_NAMESPACE::shared::canonicalizebf16(&canonicalizebf16_cx,
                                                         &canonicalizebf16_x));
   EXPECT_FP_EQ(bfloat16(0.0), canonicalizebf16_cx);
-  EXPECT_FP_EQ(bfloat16(5.0), LIBC_NAMESPACE::shared::bf16addf(2.0f, 3.0f));
-  EXPECT_FP_EQ(bfloat16(5.0), LIBC_NAMESPACE::shared::bf16addl(2L, 3L));
-  EXPECT_FP_EQ(bfloat16(10.0),
-               LIBC_NAMESPACE::shared::bf16fmaf(2.0f, 3.0f, 4.0f));
   EXPECT_FP_EQ(bfloat16(0.0), LIBC_NAMESPACE::shared::ceilbf16(bfloat16(0.0)));
   EXPECT_FP_EQ(bfloat16(0.0), LIBC_NAMESPACE::shared::floorbf16(bfloat16(0.0)));
   EXPECT_FP_EQ(bfloat16(0.0),
@@ -450,8 +460,6 @@ TEST(LlvmLibcSharedMathTest, AllBFloat16) {
                                                bfloat16(4.0)));
   EXPECT_FP_EQ(bfloat16(0.0),
                LIBC_NAMESPACE::shared::fmaxbf16(bfloat16(0.0), bfloat16(0.0)));
-
-  EXPECT_FP_EQ(bfloat16(10.0), LIBC_NAMESPACE::shared::bf16fma(2.0, 3.0, 4.0));
 
   bfloat16 getpayloadbf16_x = bfloat16(0.0);
   EXPECT_FP_EQ(bfloat16(-1.0),


### PR DESCRIPTION
Skip long double tests when long double is double-double.
Also adjust constant literals.