### PR TITLE
[clang][bytecode] Disable preservenone attribute on clang19+asan

### DIFF
--- a/clang/lib/AST/ByteCode/Interp.h
+++ b/clang/lib/AST/ByteCode/Interp.h
@@ -38,7 +38,10 @@
 
 // preserve_none is supported on aarch64, but causes problems when asan is
 // enabled. See https://github.com/llvm/llvm-project/issues/177519.
+// preserve_none also causes problems on clang <= 19 if asan is enabled.
 #if !defined(__aarch64__) && !defined(__i386__) &&                             \
+    !(defined(__clang_major__) && __clang_major__ <= 19 &&                     \
+      __has_feature(address_sanitizer)) &&                                     \
     __has_cpp_attribute(clang::preserve_none)
 #define PRESERVE_NONE [[clang::preserve_none]]
 #else


### PR DESCRIPTION
This better not break anything else.