### PR TITLE
[flang][DoConcurrent] Map reduction variables as tofrom ByRef for device offloading

### DIFF
--- a/flang/lib/Optimizer/OpenMP/DoConcurrentConversion.cpp
+++ b/flang/lib/Optimizer/OpenMP/DoConcurrentConversion.cpp
@@ -313,8 +313,10 @@ public:
           fir::getKindMapping(doLoop->getParentOfType<mlir::ModuleOp>()));
 
       for (mlir::Value liveIn : loopNestLiveIns) {
+        bool isReductionVar = llvm::find(loop.getReduceVars(), liveIn) !=
+                              loop.getReduceVars().end();
         targetClauseOps.mapVars.push_back(
-            genMapInfoOpForLiveIn(builder, liveIn));
+            genMapInfoOpForLiveIn(builder, liveIn, isReductionVar));
         liveInShapeInfoMap.insert(
             {liveIn, TargetDeclareShapeCreationInfo(liveIn)});
       }
@@ -540,8 +542,9 @@ private:
         /*dataExvIsAssumedSize=*/false, rawAddr.getLoc());
   }
 
-  mlir::omp::MapInfoOp genMapInfoOpForLiveIn(fir::FirOpBuilder &builder,
-                                             mlir::Value liveIn) const {
+  mlir::omp::MapInfoOp
+  genMapInfoOpForLiveIn(fir::FirOpBuilder &builder, mlir::Value liveIn,
+                        bool isReductionVar = false) const {
     mlir::Value rawAddr = liveIn;
     llvm::StringRef name;
 
@@ -574,7 +577,10 @@ private:
     mlir::omp::VariableCaptureKind captureKind =
         mlir::omp::VariableCaptureKind::ByRef;
 
-    if (fir::isa_trivial(eleType) || fir::isa_char(eleType)) {
+    if (isReductionVar) {
+      mapFlag |= mlir::omp::ClauseMapFlags::to;
+      mapFlag |= mlir::omp::ClauseMapFlags::from;
+    } else if (fir::isa_trivial(eleType) || fir::isa_char(eleType)) {
       captureKind = mlir::omp::VariableCaptureKind::ByCopy;
     } else if (!fir::isa_builtin_cptr_type(eleType)) {
       mapFlag |= mlir::omp::ClauseMapFlags::to;

--- a/flang/test/Transforms/DoConcurrent/reduce_device.mlir
+++ b/flang/test/Transforms/DoConcurrent/reduce_device.mlir
@@ -36,6 +36,7 @@ func.func @_QPfoo() {
 
 // CHECK: %[[S_DECL:.*]]:2 = hlfir.declare %6 {uniq_name = "_QFfooEs"}
 // CHECK: %[[S_MAP:.*]] = omp.map.info var_ptr(%[[S_DECL]]#1
+// CHECK-SAME: map_clauses(implicit, tofrom) capture(ByRef)
 
 // CHECK: omp.target host_eval({{.*}}) map_entries({{.*}}, %[[S_MAP]] -> %[[S_TARGET_ARG:.*]] : {{.*}}) {
 // CHECK:   %[[S_DEV_DECL:.*]]:2 = hlfir.declare %[[S_TARGET_ARG]]

--- a/flang/test/Transforms/DoConcurrent/reduce_device_min.f90
+++ b/flang/test/Transforms/DoConcurrent/reduce_device_min.f90
@@ -1,0 +1,45 @@
+! Tests that a `do concurrent reduce(min:...)` on a scalar maps the reduction
+! variable as `tofrom ByRef` (not `ByCopy`) when targeting a device. This is
+! needed so the reduced result is written back from the device to the host.
+
+! RUN: %flang_fc1 -emit-hlfir -fopenmp -fdo-concurrent-to-openmp=device %s -o - \
+! RUN:   | FileCheck %s
+! RUN: bbc -emit-hlfir -fopenmp -fdo-concurrent-to-openmp=device %s -o - \
+! RUN:   | FileCheck %s
+
+subroutine min_reduce(arr, n, min_val)
+    implicit none
+    integer, intent(in) :: n
+    real, intent(in) :: arr(n)
+    real :: min_val
+    integer :: i
+
+    do concurrent (i=1:n) reduce(min:min_val)
+        min_val = min(min_val, arr(i))
+    end do
+end subroutine min_reduce
+
+! CHECK-DAG: omp.declare_reduction @[[RED_SYM:.*\.omp]] : f32 init
+
+! CHECK-LABEL: func.func @_QPmin_reduce
+
+! CHECK: %[[MIN_VAL_DECL:.*]]:2 = hlfir.declare %{{.*}} dummy_scope %{{.*}} {uniq_name = "_QFmin_reduceEmin_val"}
+
+! Verify the reduction variable is mapped tofrom + ByRef (not implicit + ByCopy).
+! CHECK: %[[MIN_VAL_MAP:.*]] = omp.map.info var_ptr(%[[MIN_VAL_DECL]]#1
+! CHECK-SAME: map_clauses(implicit, tofrom) capture(ByRef)
+! CHECK-SAME: -> !fir.ref<f32> {name = "_QFmin_reduceEmin_val"}
+
+! CHECK: omp.target
+! CHECK-SAME: map_entries({{.*}}%[[MIN_VAL_MAP]] -> %[[MIN_VAL_ARG:[[:alnum:]]+]]{{.*}})
+
+! CHECK: %[[MIN_VAL_DEV:.*]]:2 = hlfir.declare %[[MIN_VAL_ARG]] {{.*}} "_QFmin_reduceEmin_val"
+! CHECK: omp.teams reduction(@[[RED_SYM]] %[[MIN_VAL_DEV]]#0 -> %[[RED_TEAMS:.*]] : !fir.ref<f32>) {
+! CHECK:   omp.parallel {
+! CHECK:     omp.distribute {
+! CHECK:       omp.wsloop reduction(@[[RED_SYM]] %[[RED_TEAMS]] -> %[[RED_WS:.*]] : !fir.ref<f32>) {
+! CHECK:         omp.loop_nest
+! CHECK:       } {omp.composite}
+! CHECK:     } {omp.composite}
+! CHECK:   } {omp.composite}
+! CHECK: }

--- a/offload/test/offloading/fortran/do-concurrent-to-omp-min-reduce.f90
+++ b/offload/test/offloading/fortran/do-concurrent-to-omp-min-reduce.f90
@@ -1,0 +1,48 @@
+! REQUIRES: flang, amdgpu
+
+! RUN: %libomptarget-compile-fortran-generic -fdo-concurrent-to-openmp=device
+! RUN: env LIBOMPTARGET_INFO=16 %libomptarget-run-generic 2>&1 | %fcheck-generic
+
+module min_reduce_mod
+   implicit none
+   public :: min_reduce
+contains
+
+subroutine min_reduce(arr, min_val, n)
+   implicit none
+   integer, intent(in) :: n
+   real, dimension(:), intent(in) :: arr
+   real :: min_val
+   integer :: i
+
+   do concurrent(i=1:n) reduce(min:min_val)
+       min_val = min(min_val, arr(i))
+   end do
+
+   print *, 'min_val after reduction =', min_val
+end subroutine min_reduce
+
+end module min_reduce_mod
+
+program main
+   use min_reduce_mod, only: min_reduce
+   implicit none
+
+   integer, parameter :: n = 10
+   real :: arr(n)
+   real :: min_val
+
+   arr = (/ 200.0, 150.0, 80.0, 50.0, 300.0, 25.0, 175.0, 60.0, 400.0, 90.0 /)
+   min_val = 100.0
+
+   call min_reduce(arr, min_val, n)
+
+   if (min_val == 25.0) then
+       print *, 'PASS'
+   else
+       print *, 'FAIL: expected 25.0, got', min_val
+   end if
+end program main
+
+! CHECK:  PluginInterface device {{[0-9]+}} info: Launching kernel {{.*}}
+! CHECK:  PASS


### PR DESCRIPTION
Scalar reduction variables in `do concurrent reduce(...)` were being mapped with `implicit ByCopy` when offloaded to device, because `genMapInfoOpForLiveIn` treated all trivial types uniformly. This caused the reduction result to be silently dropped — the device-side reduction would compute the correct value but never write it back to the host.

Fix by detecting reduction variables and forcing `implicit tofrom ByRef` mapping, matching the behavior of explicit
`!$omp target teams distribute parallel do reduction(...)`.

Co-authored-by: ergawy <kareem.ergawy@amd.com>
Co-authored-by: Claude <noreply@anthropic.com>
Made-with: Cursor

Fixes: https://github.com/ROCm/llvm-project/issues/1844