### PR TITLE
[MCA] Use LLVM_DEBUG instead of direct NDEBUG check (NFC)

### DIFF
--- a/llvm/lib/MCA/Support.cpp
+++ b/llvm/lib/MCA/Support.cpp
@@ -68,16 +68,14 @@ void computeProcResourceMasks(const MCSchedModel &SM,
     ProcResourceID++;
   }
 
-#ifndef NDEBUG
-  LLVM_DEBUG(dbgs() << "\nProcessor resource masks:"
-                    << "\n");
-  for (unsigned I = 0, E = SM.getNumProcResourceKinds(); I < E; ++I) {
-    const MCProcResourceDesc &Desc = *SM.getProcResource(I);
-    LLVM_DEBUG(dbgs() << '[' << format_decimal(I,2) << "] " << " - "
-                      << format_hex(Masks[I],16) << " - "
-                      << Desc.Name << '\n');
-  }
-#endif
+  LLVM_DEBUG({
+    dbgs() << "\nProcessor resource masks:\n";
+    for (unsigned I = 0, E = SM.getNumProcResourceKinds(); I < E; ++I) {
+      const MCProcResourceDesc &Desc = *SM.getProcResource(I);
+      dbgs() << '[' << format_decimal(I, 2) << "] " << " - "
+             << format_hex(Masks[I], 16) << " - " << Desc.Name << '\n';
+    }
+  });
 }
 
 double computeBlockRThroughput(const MCSchedModel &SM, unsigned DispatchWidth,


### PR DESCRIPTION
Use the conventional multiline `LLVM_DEBUG` macro for a debug-printing-only code block, instead of unwrapping a direct `NDEBUG` check.