### PR TITLE
[lldb] Only create RegisterTypeBuilderClang plugin once

### DIFF
--- a/lldb/include/lldb/Target/Target.h
+++ b/lldb/include/lldb/Target/Target.h
@@ -1842,6 +1842,8 @@ protected:
   /// signals you will have.
   llvm::StringMap<DummySignalValues> m_dummy_signals;
 
+  lldb::RegisterTypeBuilderSP m_register_type_builder_sp;
+
   static void ImageSearchPathsChanged(const PathMappingList &path_list,
                                       void *baton);
 

--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -2637,9 +2637,10 @@ Target::GetScratchTypeSystemForLanguage(lldb::LanguageType language,
 CompilerType Target::GetRegisterType(const std::string &name,
                                      const lldb_private::RegisterFlags &flags,
                                      uint32_t byte_size) {
-  RegisterTypeBuilderSP provider = PluginManager::GetRegisterTypeBuilder(*this);
-  assert(provider);
-  return provider->GetRegisterType(name, flags, byte_size);
+  if (!m_register_type_builder_sp)
+    m_register_type_builder_sp = PluginManager::GetRegisterTypeBuilder(*this);
+  assert(m_register_type_builder_sp);
+  return m_register_type_builder_sp->GetRegisterType(name, flags, byte_size);
 }
 
 std::vector<lldb::TypeSystemSP>


### PR DESCRIPTION
This plugin creates types based on information from target XML, which is parsed only once per session. It has internal logic to reuse created types, but the plugin itself was being remade every time a type was requested.