### PR TITLE
[llvm-otool] Add -a option to print archive headers

### DIFF
--- a/llvm/docs/CommandGuide/llvm-otool.rst
+++ b/llvm/docs/CommandGuide/llvm-otool.rst
@@ -19,6 +19,10 @@ It attempts to be command-line-compatible and output-compatible with macOS's
 OPTIONS
 -------
 
+.. option:: -a
+
+ Print archive header.
+
 .. option:: -arch <value>
 
  Select slice of universal Mach-O file.

--- a/llvm/test/tools/llvm-objdump/MachO/archive-headers.test
+++ b/llvm/test/tools/llvm-objdump/MachO/archive-headers.test
@@ -5,6 +5,18 @@ RUN: | FileCheck %s -check-prefix=OFFSETS
 RUN: llvm-objdump %p/Inputs/macho-universal-archive.x86_64.i386 --macho --archive-headers --arch all --non-verbose \
 RUN: | FileCheck %s -check-prefix=NON-VERBOSE
 
+# llvm-otool -a shows all architectures by default.
+RUN: llvm-otool -a %p/Inputs/macho-universal-archive.x86_64.i386 \
+RUN: | FileCheck %s -check-prefix=NON-VERBOSE
+
+# llvm-otool -a -arch filters to one slice.
+RUN: llvm-otool -a -arch x86_64 %p/Inputs/macho-universal-archive.x86_64.i386 \
+RUN: | FileCheck %s -check-prefix=OTOOL-ARCH
+OTOOL-ARCH:     Archive : {{.*}}macho-universal-archive.x86_64.i386
+OTOOL-ARCH:     0100644 124/11     44
+OTOOL-ARCH:     0100644 124/0     860
+OTOOL-ARCH-NOT: (architecture i386)
+
 # Note the date as printed by ctime(3) is time zone dependent and not checked.
 CHECK: Archive : {{.*}}/macho-universal-archive.x86_64.i386 (architecture x86_64)
 CHECK: -rw-r--r--124/11     44 {{.*}} __.SYMDEF SORTED

--- a/llvm/test/tools/llvm-objdump/MachO/archive-headers.test
+++ b/llvm/test/tools/llvm-objdump/MachO/archive-headers.test
@@ -11,11 +11,10 @@ RUN: | FileCheck %s -check-prefix=NON-VERBOSE
 
 # llvm-otool -a -arch filters to one slice.
 RUN: llvm-otool -a -arch x86_64 %p/Inputs/macho-universal-archive.x86_64.i386 \
-RUN: | FileCheck %s -check-prefix=OTOOL-ARCH
-OTOOL-ARCH:     Archive : {{.*}}macho-universal-archive.x86_64.i386
-OTOOL-ARCH:     0100644 124/11     44
-OTOOL-ARCH:     0100644 124/0     860
-OTOOL-ARCH-NOT: (architecture i386)
+RUN: | FileCheck %s -check-prefix=OTOOL-ARCH --implicit-check-not="(architecture i386)"
+OTOOL-ARCH: Archive : {{.*}}macho-universal-archive.x86_64.i386
+OTOOL-ARCH: 0100644 124/11     44
+OTOOL-ARCH: 0100644 124/0     860
 
 # Note the date as printed by ctime(3) is time zone dependent and not checked.
 CHECK: Archive : {{.*}}/macho-universal-archive.x86_64.i386 (architecture x86_64)

--- a/llvm/test/tools/llvm-objdump/MachO/archive-headers.test
+++ b/llvm/test/tools/llvm-objdump/MachO/archive-headers.test
@@ -12,9 +12,6 @@ RUN: | FileCheck %s -check-prefix=NON-VERBOSE
 # llvm-otool -a -arch filters to one slice.
 RUN: llvm-otool -a -arch x86_64 %p/Inputs/macho-universal-archive.x86_64.i386 \
 RUN: | FileCheck %s -check-prefix=OTOOL-ARCH --implicit-check-not="(architecture i386)"
-OTOOL-ARCH: Archive : {{.*}}macho-universal-archive.x86_64.i386
-OTOOL-ARCH: 0100644 124/11     44
-OTOOL-ARCH: 0100644 124/0     860
 
 # Note the date as printed by ctime(3) is time zone dependent and not checked.
 CHECK: Archive : {{.*}}/macho-universal-archive.x86_64.i386 (architecture x86_64)
@@ -37,3 +34,7 @@ NON-VERBOSE: 0100644 124/0     860 1399501499 #1/12
 NON-VERBOSE: Archive : {{.*}}/macho-universal-archive.x86_64.i386 (architecture i386)
 NON-VERBOSE: 0100644 124/11     60 1399572709 #1/20
 NON-VERBOSE: 0100644 124/0     388 1399572697 #1/12
+
+OTOOL-ARCH:      Archive : {{.*}}macho-universal-archive.x86_64.i386
+OTOOL-ARCH-NEXT: 0100644 124/11     44
+OTOOL-ARCH-NEXT: 0100644 124/0     860

--- a/llvm/tools/llvm-objdump/MachODump.cpp
+++ b/llvm/tools/llvm-objdump/MachODump.cpp
@@ -2676,7 +2676,7 @@ void objdump::parseInputMachO(MachOUniversalBinary *UB) {
   }
   // No architecture flags were specified so if this contains a slice that
   // matches the host architecture dump only that.
-  if (!ArchAll) {
+  if (!ArchAll && !(IsOtool && ArchiveHeaders)) {
     for (MachOUniversalBinary::object_iterator I = UB->begin_objects(),
                                                 E = UB->end_objects();
           I != E; ++I) {

--- a/llvm/tools/llvm-objdump/MachODump.cpp
+++ b/llvm/tools/llvm-objdump/MachODump.cpp
@@ -2675,7 +2675,8 @@ void objdump::parseInputMachO(MachOUniversalBinary *UB) {
     return;
   }
   // No architecture flags were specified so if this contains a slice that
-  // matches the host architecture dump only that.
+  // matches the host architecture dump only that. For otool -a dump all
+  // architectures to match classic otool behaviour.
   if (!ArchAll && !(IsOtool && ArchiveHeaders)) {
     for (MachOUniversalBinary::object_iterator I = UB->begin_objects(),
                                                 E = UB->end_objects();

--- a/llvm/tools/llvm-objdump/OtoolOpts.td
+++ b/llvm/tools/llvm-objdump/OtoolOpts.td
@@ -4,6 +4,7 @@ def help : Flag<["--"], "help">, HelpText<"print help">;
 def help_hidden : Flag<["--"], "help-hidden">,
   HelpText<"print help for hidden flags">;
 
+def a : Flag<["-"], "a">, HelpText<"print archive header">;
 def arch : Separate<["-"], "arch">,
   HelpText<"select slice of universal Mach-O file">;
 def C : Flag<["-"], "C">, HelpText<"print linker optimization hints">;
@@ -43,7 +44,6 @@ def dyld_info : Flag<["-"], "dyld_info">,
   HelpText<"print bind and rebase information">;
 
 // Not (yet?) implemented:
-// def a : Flag<["-"], "a">, HelpText<"print archive header">;
 // -c print argument strings of a core file
 // -m don't use archive(member) syntax
 // -dyld_opcodes

--- a/llvm/tools/llvm-objdump/llvm-objdump.cpp
+++ b/llvm/tools/llvm-objdump/llvm-objdump.cpp
@@ -3661,6 +3661,7 @@ static void parseOtoolOptions(const llvm::opt::InputArgList &InputArgs) {
   ArchName = InputArgs.getLastArgValue(OTOOL_arch).str();
   if (!ArchName.empty())
     ArchFlags.push_back(ArchName);
+  ArchiveHeaders = InputArgs.hasArg(OTOOL_a);
   LinkOptHints = InputArgs.hasArg(OTOOL_C);
   if (InputArgs.hasArg(OTOOL_d))
     FilterSections.push_back("__DATA,__data");


### PR DESCRIPTION
Wire up llvm-otool's -a to the existing --archive-headers machinery with a default of displaying all architectures to match classic otool behaviour.
