### PR TITLE
[Support] Move `KnownFPClass` inference from `KnownBits` to Support

### DIFF
--- a/llvm/include/llvm/Support/KnownFPClass.h
+++ b/llvm/include/llvm/Support/KnownFPClass.h
@@ -15,6 +15,7 @@
 #define LLVM_SUPPORT_KNOWNFPCLASS_H
 
 #include "llvm/ADT/FloatingPointMode.h"
+#include "llvm/IR/Type.h"
 #include "llvm/Support/Compiler.h"
 #include <optional>
 
@@ -224,6 +225,10 @@ struct KnownFPClass {
   LLVM_ABI static KnownFPClass
   canonicalize(const KnownFPClass &Src,
                DenormalMode DenormMode = DenormalMode::getDynamic());
+
+  /// Report known values for a bitcast into a float with provided semantics.
+  LLVM_ABI static KnownFPClass bitcast(const Type *EltTy,
+                                       const KnownBits &Bits);
 
   /// Report known values for fadd
   LLVM_ABI static KnownFPClass

--- a/llvm/include/llvm/Support/KnownFPClass.h
+++ b/llvm/include/llvm/Support/KnownFPClass.h
@@ -226,10 +226,7 @@ struct KnownFPClass {
                DenormalMode DenormMode = DenormalMode::getDynamic());
 
   /// Report known values for a bitcast into a float with provided semantics.
-  /// Set \p IsIEEELikeFP if the FP type has IEEE-compatible layout, and does
-  /// not have non-IEEE values, such as x86_fp80's unnormal values.
   LLVM_ABI static KnownFPClass bitcast(const fltSemantics &FltSemantics,
-                                       bool IsIEEELikeFP,
                                        const KnownBits &Bits);
 
   /// Report known values for fadd

--- a/llvm/include/llvm/Support/KnownFPClass.h
+++ b/llvm/include/llvm/Support/KnownFPClass.h
@@ -15,7 +15,6 @@
 #define LLVM_SUPPORT_KNOWNFPCLASS_H
 
 #include "llvm/ADT/FloatingPointMode.h"
-#include "llvm/IR/Type.h"
 #include "llvm/Support/Compiler.h"
 #include <optional>
 
@@ -227,7 +226,10 @@ struct KnownFPClass {
                DenormalMode DenormMode = DenormalMode::getDynamic());
 
   /// Report known values for a bitcast into a float with provided semantics.
-  LLVM_ABI static KnownFPClass bitcast(const Type *EltTy,
+  /// Set \p IsIEEELikeFP if the FP type has IEEE-compatible layout, and does
+  /// not have non-IEEE values, such as x86_fp80's unnormal values.
+  LLVM_ABI static KnownFPClass bitcast(const fltSemantics &FltSemantics,
+                                       bool IsIEEELikeFP,
                                        const KnownBits &Bits);
 
   /// Report known values for fadd

--- a/llvm/lib/Analysis/ValueTracking.cpp
+++ b/llvm/lib/Analysis/ValueTracking.cpp
@@ -6045,50 +6045,7 @@ void computeKnownFPClass(const Value *V, const APInt &DemandedElts,
     KnownBits Bits(EltTy->getPrimitiveSizeInBits());
     computeKnownBits(Src, DemandedElts, Bits, Q, Depth + 1);
 
-    // Transfer information from the sign bit.
-    if (Bits.isNonNegative())
-      Known.signBitMustBeZero();
-    else if (Bits.isNegative())
-      Known.signBitMustBeOne();
-
-    if (EltTy->isIEEELikeFPTy()) {
-      // IEEE floats are NaN when all bits of the exponent plus at least one of
-      // the fraction bits are 1. This means:
-      //   - If we assume unknown bits are 0 and the value is NaN, it will
-      //     always be NaN
-      //   - If we assume unknown bits are 1 and the value is not NaN, it can
-      //     never be NaN
-      // Note: They do not hold for x86_fp80 format.
-      if (APFloat(EltTy->getFltSemantics(), Bits.One).isNaN())
-        Known.KnownFPClasses = fcNan;
-      else if (!APFloat(EltTy->getFltSemantics(), ~Bits.Zero).isNaN())
-        Known.knownNot(fcNan);
-
-      // Build KnownBits representing Inf and check if it must be equal or
-      // unequal to this value.
-      auto InfKB = KnownBits::makeConstant(
-          APFloat::getInf(EltTy->getFltSemantics()).bitcastToAPInt());
-      InfKB.Zero.clearSignBit();
-      if (const auto InfResult = KnownBits::eq(Bits, InfKB)) {
-        assert(!InfResult.value());
-        Known.knownNot(fcInf);
-      } else if (Bits == InfKB) {
-        Known.KnownFPClasses = fcInf;
-      }
-
-      // Build KnownBits representing Zero and check if it must be equal or
-      // unequal to this value.
-      auto ZeroKB = KnownBits::makeConstant(
-          APFloat::getZero(EltTy->getFltSemantics()).bitcastToAPInt());
-      ZeroKB.Zero.clearSignBit();
-      if (const auto ZeroResult = KnownBits::eq(Bits, ZeroKB)) {
-        assert(!ZeroResult.value());
-        Known.knownNot(fcZero);
-      } else if (Bits == ZeroKB) {
-        Known.KnownFPClasses = fcZero;
-      }
-    }
-
+    Known = KnownFPClass::bitcast(EltTy, Bits);
     break;
   }
   default:

--- a/llvm/lib/Analysis/ValueTracking.cpp
+++ b/llvm/lib/Analysis/ValueTracking.cpp
@@ -6045,7 +6045,8 @@ void computeKnownFPClass(const Value *V, const APInt &DemandedElts,
     KnownBits Bits(EltTy->getPrimitiveSizeInBits());
     computeKnownBits(Src, DemandedElts, Bits, Q, Depth + 1);
 
-    Known = KnownFPClass::bitcast(EltTy, Bits);
+    Known = KnownFPClass::bitcast(EltTy->getFltSemantics(),
+                                  EltTy->isIEEELikeFPTy(), Bits);
     break;
   }
   default:

--- a/llvm/lib/Analysis/ValueTracking.cpp
+++ b/llvm/lib/Analysis/ValueTracking.cpp
@@ -6045,8 +6045,7 @@ void computeKnownFPClass(const Value *V, const APInt &DemandedElts,
     KnownBits Bits(EltTy->getPrimitiveSizeInBits());
     computeKnownBits(Src, DemandedElts, Bits, Q, Depth + 1);
 
-    Known = KnownFPClass::bitcast(EltTy->getFltSemantics(),
-                                  EltTy->isIEEELikeFPTy(), Bits);
+    Known = KnownFPClass::bitcast(EltTy->getFltSemantics(), Bits);
     break;
   }
   default:

--- a/llvm/lib/Support/KnownFPClass.cpp
+++ b/llvm/lib/Support/KnownFPClass.cpp
@@ -13,6 +13,7 @@
 
 #include "llvm/Support/KnownFPClass.h"
 #include "llvm/ADT/APFloat.h"
+#include "llvm/ADT/FloatingPointMode.h"
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/KnownBits.h"
 
@@ -230,6 +231,58 @@ KnownFPClass KnownFPClass::canonicalize(const KnownFPClass &KnownSrc,
       (DenormMode.Output == DenormalMode::PositiveZero &&
        DenormMode.Input == DenormalMode::IEEE))
     Known.knownNot(fcNegZero);
+
+  return Known;
+}
+
+KnownFPClass KnownFPClass::bitcast(const Type *EltTy, const KnownBits &Bits) {
+  assert(EltTy->getPrimitiveSizeInBits() == Bits.getBitWidth() &&
+         "Bitcast operand has incorrect bit width");
+  KnownFPClass Known;
+
+  // Transfer information from the sign bit.
+  if (Bits.isNonNegative())
+    Known.signBitMustBeZero();
+  else if (Bits.isNegative())
+    Known.signBitMustBeOne();
+
+  if (EltTy->isIEEELikeFPTy()) {
+    // IEEE floats are NaN when all bits of the exponent plus at least one of
+    // the fraction bits are 1. This means:
+    //   - If we assume unknown bits are 0 and the value is NaN, it will
+    //     always be NaN
+    //   - If we assume unknown bits are 1 and the value is not NaN, it can
+    //     never be NaN
+    // Note: They do not hold for x86_fp80 format.
+    if (APFloat(EltTy->getFltSemantics(), Bits.One).isNaN())
+      Known.KnownFPClasses = fcNan;
+    else if (!APFloat(EltTy->getFltSemantics(), ~Bits.Zero).isNaN())
+      Known.knownNot(fcNan);
+
+    // Build KnownBits representing Inf and check if it must be equal or
+    // unequal to this value.
+    auto InfKB = KnownBits::makeConstant(
+        APFloat::getInf(EltTy->getFltSemantics()).bitcastToAPInt());
+    InfKB.Zero.clearSignBit();
+    if (const auto InfResult = KnownBits::eq(Bits, InfKB)) {
+      assert(!InfResult.value());
+      Known.knownNot(fcInf);
+    } else if (Bits == InfKB) {
+      Known.KnownFPClasses = fcInf;
+    }
+
+    // Build KnownBits representing Zero and check if it must be equal or
+    // unequal to this value.
+    auto ZeroKB = KnownBits::makeConstant(
+        APFloat::getZero(EltTy->getFltSemantics()).bitcastToAPInt());
+    ZeroKB.Zero.clearSignBit();
+    if (const auto ZeroResult = KnownBits::eq(Bits, ZeroKB)) {
+      assert(!ZeroResult.value());
+      Known.knownNot(fcZero);
+    } else if (Bits == ZeroKB) {
+      Known.KnownFPClasses = fcZero;
+    }
+  }
 
   return Known;
 }

--- a/llvm/lib/Support/KnownFPClass.cpp
+++ b/llvm/lib/Support/KnownFPClass.cpp
@@ -13,7 +13,6 @@
 
 #include "llvm/Support/KnownFPClass.h"
 #include "llvm/ADT/APFloat.h"
-#include "llvm/ADT/FloatingPointMode.h"
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/KnownBits.h"
 

--- a/llvm/lib/Support/KnownFPClass.cpp
+++ b/llvm/lib/Support/KnownFPClass.cpp
@@ -234,8 +234,9 @@ KnownFPClass KnownFPClass::canonicalize(const KnownFPClass &KnownSrc,
   return Known;
 }
 
-KnownFPClass KnownFPClass::bitcast(const Type *EltTy, const KnownBits &Bits) {
-  assert(EltTy->getPrimitiveSizeInBits() == Bits.getBitWidth() &&
+KnownFPClass KnownFPClass::bitcast(const fltSemantics &FltSemantics,
+                                   bool IsIEEELikeFP, const KnownBits &Bits) {
+  assert(FltSemantics.sizeInBits == Bits.getBitWidth() &&
          "Bitcast operand has incorrect bit width");
   KnownFPClass Known;
 
@@ -245,7 +246,7 @@ KnownFPClass KnownFPClass::bitcast(const Type *EltTy, const KnownBits &Bits) {
   else if (Bits.isNegative())
     Known.signBitMustBeOne();
 
-  if (EltTy->isIEEELikeFPTy()) {
+  if (IsIEEELikeFP) {
     // IEEE floats are NaN when all bits of the exponent plus at least one of
     // the fraction bits are 1. This means:
     //   - If we assume unknown bits are 0 and the value is NaN, it will
@@ -253,15 +254,15 @@ KnownFPClass KnownFPClass::bitcast(const Type *EltTy, const KnownBits &Bits) {
     //   - If we assume unknown bits are 1 and the value is not NaN, it can
     //     never be NaN
     // Note: They do not hold for x86_fp80 format.
-    if (APFloat(EltTy->getFltSemantics(), Bits.One).isNaN())
+    if (APFloat(FltSemantics, Bits.One).isNaN())
       Known.KnownFPClasses = fcNan;
-    else if (!APFloat(EltTy->getFltSemantics(), ~Bits.Zero).isNaN())
+    else if (!APFloat(FltSemantics, ~Bits.Zero).isNaN())
       Known.knownNot(fcNan);
 
     // Build KnownBits representing Inf and check if it must be equal or
     // unequal to this value.
-    auto InfKB = KnownBits::makeConstant(
-        APFloat::getInf(EltTy->getFltSemantics()).bitcastToAPInt());
+    auto InfKB =
+        KnownBits::makeConstant(APFloat::getInf(FltSemantics).bitcastToAPInt());
     InfKB.Zero.clearSignBit();
     if (const auto InfResult = KnownBits::eq(Bits, InfKB)) {
       assert(!InfResult.value());
@@ -273,7 +274,7 @@ KnownFPClass KnownFPClass::bitcast(const Type *EltTy, const KnownBits &Bits) {
     // Build KnownBits representing Zero and check if it must be equal or
     // unequal to this value.
     auto ZeroKB = KnownBits::makeConstant(
-        APFloat::getZero(EltTy->getFltSemantics()).bitcastToAPInt());
+        APFloat::getZero(FltSemantics).bitcastToAPInt());
     ZeroKB.Zero.clearSignBit();
     if (const auto ZeroResult = KnownBits::eq(Bits, ZeroKB)) {
       assert(!ZeroResult.value());

--- a/llvm/lib/Support/KnownFPClass.cpp
+++ b/llvm/lib/Support/KnownFPClass.cpp
@@ -235,7 +235,7 @@ KnownFPClass KnownFPClass::canonicalize(const KnownFPClass &KnownSrc,
 }
 
 KnownFPClass KnownFPClass::bitcast(const fltSemantics &FltSemantics,
-                                   bool IsIEEELikeFP, const KnownBits &Bits) {
+                                   const KnownBits &Bits) {
   assert(FltSemantics.sizeInBits == Bits.getBitWidth() &&
          "Bitcast operand has incorrect bit width");
   KnownFPClass Known;
@@ -246,7 +246,7 @@ KnownFPClass KnownFPClass::bitcast(const fltSemantics &FltSemantics,
   else if (Bits.isNegative())
     Known.signBitMustBeOne();
 
-  if (IsIEEELikeFP) {
+  if (APFloat::isIEEELikeFP(FltSemantics)) {
     // IEEE floats are NaN when all bits of the exponent plus at least one of
     // the fraction bits are 1. This means:
     //   - If we assume unknown bits are 0 and the value is NaN, it will


### PR DESCRIPTION
Move logic for inferring `KnownFPClass` from known bits into the Support library so the logic may be used e.g., for analogous value tracking functions in SelectionDAG.