### PR TITLE
[offload][lit] Disable tests failing on Intel GPU

### DIFF
--- a/offload/test/api/omp_host_call.c
+++ b/offload/test/api/omp_host_call.c
@@ -1,5 +1,5 @@
 // RUN: %libomptarget-compile-run-and-check-generic
-// XFAIL: intelgpu
+// UNSUPPORTED: intelgpu
 
 #include <assert.h>
 #include <omp.h>

--- a/offload/test/env/base_ptr_ref_count.c
+++ b/offload/test/env/base_ptr_ref_count.c
@@ -1,7 +1,6 @@
 // clang-format off
 // RUN: %libomptarget-compile-generic && env LIBOMPTARGET_DEBUG=1 %libomptarget-run-generic 2>&1 | %fcheck-generic
 // REQUIRES: libomptarget-debug
-// XFAIL: intelgpu
 // clang-format on
 
 #include <stdio.h>

--- a/offload/test/libc/malloc_parallel.c
+++ b/offload/test/libc/malloc_parallel.c
@@ -1,6 +1,6 @@
 // RUN: %libomptarget-compile-run-and-check-generic
 // RUN: %libomptarget-compileopt-run-and-check-generic
-// XFAIL: intelgpu
+// UNSUPPORTED: intelgpu
 
 #include <omp.h>
 #include <stdio.h>

--- a/offload/test/mapping/device_ptr_update.c
+++ b/offload/test/mapping/device_ptr_update.c
@@ -2,7 +2,6 @@
 // RUN: env LIBOMPTARGET_DEBUG=1 %libomptarget-run-generic 2>&1 \
 // RUN: | %fcheck-generic -check-prefix=DEBUG -check-prefix=CHECK
 // REQUIRES: libomptarget-debug
-// XFAIL: intelgpu
 
 #include <stdio.h>
 

--- a/offload/test/mapping/map_ordering_ptee_tgt_alloc_mapper_alloc_from_to.c
+++ b/offload/test/mapping/map_ordering_ptee_tgt_alloc_mapper_alloc_from_to.c
@@ -4,7 +4,6 @@
 // RUN: env LIBOMPTARGET_DEBUG=1 %libomptarget-run-generic 2>&1 \
 // RUN: | %fcheck-generic -check-prefix=DEBUG
 // REQUIRES: libomptarget-debug
-// XFAIL: intelgpu
 
 // Since the allocation of the pointee happens on the "target" construct (1),
 // the "to" transfer requested as part of the mapper (2) should also happen.

--- a/offload/test/mapping/map_ordering_tgt_alloc_from_to.c
+++ b/offload/test/mapping/map_ordering_tgt_alloc_from_to.c
@@ -2,7 +2,6 @@
 // RUN: env LIBOMPTARGET_DEBUG=1 %libomptarget-run-generic 2>&1 \
 // RUN: | %fcheck-generic -check-prefix=DEBUG -check-prefix=CHECK
 // REQUIRES: libomptarget-debug
-// XFAIL: intelgpu
 
 #include <stdio.h>
 

--- a/offload/test/mapping/map_ordering_tgt_exit_data_always_always.c
+++ b/offload/test/mapping/map_ordering_tgt_exit_data_always_always.c
@@ -2,7 +2,6 @@
 // RUN: env LIBOMPTARGET_DEBUG=1 %libomptarget-run-generic 2>&1 \
 // RUN: | %fcheck-generic -check-prefix=DEBUG -check-prefix=CHECK
 // REQUIRES: libomptarget-debug
-// XFAIL: intelgpu
 
 // There should only be one "from" data-transfer, despite the two duplicate
 // maps.

--- a/offload/test/mapping/map_ordering_tgt_exit_data_delete_from_assumedsize.c
+++ b/offload/test/mapping/map_ordering_tgt_exit_data_delete_from_assumedsize.c
@@ -4,7 +4,6 @@
 // RUN: env LIBOMPTARGET_DEBUG=1 %libomptarget-run-generic 2>&1 \
 // RUN: | %fcheck-generic -check-prefix=DEBUG
 // REQUIRES: libomptarget-debug
-// XFAIL: intelgpu
 
 // The from on target_exit_data should result in a data-transfer of 4 bytes,
 // even if when "from" is honored, the ref-count hasn't gone down to 0.

--- a/offload/test/mapping/map_ordering_tgt_exit_data_from_delete_assumedsize.c
+++ b/offload/test/mapping/map_ordering_tgt_exit_data_from_delete_assumedsize.c
@@ -4,7 +4,6 @@
 // RUN: env LIBOMPTARGET_DEBUG=1 %libomptarget-run-generic 2>&1 \
 // RUN: | %fcheck-generic -check-prefix=DEBUG
 // REQUIRES: libomptarget-debug
-// XFAIL: intelgpu
 
 // The from on target_exit_data should result in a data-transfer of 4 bytes,
 // even if when "delete" is honored first, and by the time "from" is

--- a/offload/test/mapping/map_ordering_tgt_exit_data_from_mapper_overlap.c
+++ b/offload/test/mapping/map_ordering_tgt_exit_data_from_mapper_overlap.c
@@ -4,7 +4,6 @@
 // RUN: env LIBOMPTARGET_DEBUG=1 %libomptarget-run-generic 2>&1 \
 // RUN: | %fcheck-generic -check-prefix=DEBUG
 // REQUIRES: libomptarget-debug
-// XFAIL: intelgpu
 
 // The test ensures that the FROM transfer for the full "s1" is performed, and
 // not just the FROM done via the mapper of s1.s2.

--- a/offload/test/mapping/reduction_implicit_map.cpp
+++ b/offload/test/mapping/reduction_implicit_map.cpp
@@ -1,5 +1,5 @@
 // RUN: %libomptarget-compilexx-run-and-check-generic
-// XFAIL: intelgpu
+// UNSUPPORTED: intelgpu
 
 #include <stdio.h>
 

--- a/offload/test/mapping/target_derefence_array_pointrs.cpp
+++ b/offload/test/mapping/target_derefence_array_pointrs.cpp
@@ -6,7 +6,7 @@
 // UNSUPPORTED: amdgcn-amd-amdhsa
 // UNSUPPORTED: nvptx64-nvidia-cuda
 // UNSUPPORTED: nvptx64-nvidia-cuda-LTO
-// XFAIL: intelgpu
+// UNSUPPORTED: intelgpu
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/offload/test/mapping/target_has_device_addr.c
+++ b/offload/test/mapping/target_has_device_addr.c
@@ -3,7 +3,7 @@
 // RUN: | %fcheck-generic
 
 // UNSUPPORTED: amdgcn-amd-amdhsa
-// XFAIL: intelgpu
+// UNSUPPORTED: intelgpu
 
 #include <omp.h>
 #include <stdio.h>

--- a/offload/test/offloading/bug49779.cpp
+++ b/offload/test/offloading/bug49779.cpp
@@ -5,7 +5,7 @@
 
 // We need malloc/global_alloc support
 // UNSUPPORTED: amdgcn-amd-amdhsa
-// XFAIL: intelgpu
+// UNSUPPORTED: intelgpu
 
 #include <cassert>
 #include <iostream>

--- a/offload/test/offloading/bug64959.c
+++ b/offload/test/offloading/bug64959.c
@@ -6,7 +6,7 @@
 // UNSUPPORTED: amdgcn-amd-amdhsa
 // UNSUPPORTED: nvptx64-nvidia-cuda
 // UNSUPPORTED: nvptx64-nvidia-cuda-LTO
-// XFAIL: intelgpu
+// UNSUPPORTED: intelgpu
 
 #include <omp.h>
 #include <stdio.h>

--- a/offload/test/offloading/bug64959_compile_only.c
+++ b/offload/test/offloading/bug64959_compile_only.c
@@ -1,5 +1,6 @@
 // RUN: %libomptarget-compile-generic
 // RUN: %libomptarget-compileopt-generic
+// XFAIL: intelgpu
 
 #include <stdio.h>
 #define N 10

--- a/offload/test/offloading/force-usm.cpp
+++ b/offload/test/offloading/force-usm.cpp
@@ -10,7 +10,7 @@
 //
 // UNSUPPORTED: nvptx64-nvidia-cuda
 // UNSUPPORTED: nvptx64-nvidia-cuda-LTO
-// XFAIL: intelgpu
+// UNSUPPORTED: intelgpu
 // clang-format on
 
 #include <cassert>

--- a/offload/test/offloading/malloc.c
+++ b/offload/test/offloading/malloc.c
@@ -1,6 +1,6 @@
 // RUN: %libomptarget-compile-generic && %libomptarget-run-generic
 // RUN: %libomptarget-compileopt-generic && %libomptarget-run-generic
-// XFAIL: intelgpu
+// UNSUPPORTED: intelgpu
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/offload/test/offloading/multiple_reductions_simple.c
+++ b/offload/test/offloading/multiple_reductions_simple.c
@@ -1,6 +1,6 @@
 // RUN: %libomptarget-compile-run-and-check-generic
 // RUN: %libomptarget-compileopt-run-and-check-generic
-// XFAIL: intelgpu
+// UNSUPPORTED: intelgpu
 
 #include <stdio.h>
 

--- a/offload/test/offloading/parallel_target_teams_reduction.cpp
+++ b/offload/test/offloading/parallel_target_teams_reduction.cpp
@@ -3,7 +3,7 @@
 
 // FIXME: This is a bug in host offload, this should run fine.
 // REQUIRES: gpu
-// XFAIL: intelgpu
+// UNSUPPORTED: intelgpu
 
 #include <iostream>
 #include <vector>

--- a/offload/test/offloading/parallel_target_teams_reduction_max.cpp
+++ b/offload/test/offloading/parallel_target_teams_reduction_max.cpp
@@ -3,7 +3,7 @@
 
 // FIXME: This is a bug in host offload, this should run fine.
 // REQUIRES: gpu
-// XFAIL: intelgpu
+// UNSUPPORTED: intelgpu
 
 // This test validates that the OpenMP target reductions to find a maximum work
 // as intended for a few common data types.

--- a/offload/test/offloading/parallel_target_teams_reduction_min.cpp
+++ b/offload/test/offloading/parallel_target_teams_reduction_min.cpp
@@ -3,7 +3,7 @@
 
 // FIXME: This is a bug in host offload, this should run fine.
 // REQUIRES: gpu
-// XFAIL: intelgpu
+// UNSUPPORTED: intelgpu
 
 // This test validates that the OpenMP target reductions to find a minimum work
 // as intended for a few common data types.

--- a/offload/test/offloading/std_complex_arithmetic.cpp
+++ b/offload/test/offloading/std_complex_arithmetic.cpp
@@ -7,7 +7,7 @@
 //        needed math functions in the GPU `libm` and require the GPU C library.
 // UNSUPPORTED: amdgcn-amd-amdhsa
 // UNSUPPORTED: nvptx64-nvidia-cuda-LTO
-// XFAIL: intelgpu
+// UNSUPPORTED: intelgpu
 
 #include <cassert>
 #include <complex>

--- a/offload/test/offloading/strided_offset_multidim_update.c
+++ b/offload/test/offloading/strided_offset_multidim_update.c
@@ -1,5 +1,5 @@
 // RUN: %libomptarget-compile-run-and-check-generic
-// XFAIL: intelgpu
+// UNSUPPORTED: intelgpu
 // Make sure multi-dimensional strided offset update works correctly.
 
 #include <stdio.h>

--- a/offload/test/offloading/struct_mapping_with_pointers.cpp
+++ b/offload/test/offloading/struct_mapping_with_pointers.cpp
@@ -6,7 +6,6 @@
 
 // UNSUPPORTED: nvptx64-nvidia-cuda
 // UNSUPPORTED: nvptx64-nvidia-cuda-LTO
-// XFAIL: intelgpu
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/offload/test/offloading/target_critical_region.cpp
+++ b/offload/test/offloading/target_critical_region.cpp
@@ -4,7 +4,6 @@
 // UNSUPPORTED: nvptx64-nvidia-cuda
 // UNSUPPORTED: nvptx64-nvidia-cuda-LTO
 // UNSUPPORTED: amdgcn-amd-amdhsa
-// XFAIL: intelgpu
 
 #include <omp.h>
 #include <stdio.h>

--- a/offload/test/offloading/test_libc.cpp
+++ b/offload/test/offloading/test_libc.cpp
@@ -1,5 +1,5 @@
 // RUN: %libomptarget-compilexx-run-and-check-generic
-// XFAIL: intelgpu
+// UNSUPPORTED: intelgpu
 
 #include <algorithm>
 

--- a/offload/test/sanitizer/kernel_crash_single.c
+++ b/offload/test/sanitizer/kernel_crash_single.c
@@ -12,7 +12,7 @@
 // UNSUPPORTED: aarch64-unknown-linux-gnu
 // UNSUPPORTED: x86_64-unknown-linux-gnu
 // UNSUPPORTED: s390x-ibm-linux-gnu
-// XFAIL: intelgpu
+// UNSUPPORTED: intelgpu
 
 #include <omp.h>
 

--- a/offload/test/sanitizer/ptr_outside_alloc_1.c
+++ b/offload/test/sanitizer/ptr_outside_alloc_1.c
@@ -9,7 +9,7 @@
 // UNSUPPORTED: nvidiagpu
 //
 // REQUIRES: gpu
-// XFAIL: intelgpu
+// UNSUPPORTED: intelgpu
 
 #include <omp.h>
 

--- a/offload/test/sanitizer/ptr_outside_alloc_2.c
+++ b/offload/test/sanitizer/ptr_outside_alloc_2.c
@@ -7,7 +7,7 @@
 // UNSUPPORTED: nvidiagpu
 //
 // REQUIRES: gpu
-// XFAIL: intelgpu
+// UNSUPPORTED: intelgpu
 
 #include <omp.h>
 

--- a/offload/test/sanitizer/use_after_free_1.c
+++ b/offload/test/sanitizer/use_after_free_1.c
@@ -9,7 +9,7 @@
 // UNSUPPORTED: nvidiagpu
 //
 // REQUIRES: gpu
-// XFAIL: intelgpu
+// UNSUPPORTED: intelgpu
 
 #include <omp.h>
 

--- a/offload/test/sanitizer/use_after_free_2.c
+++ b/offload/test/sanitizer/use_after_free_2.c
@@ -7,7 +7,7 @@
 // UNSUPPORTED: nvidiagpu
 //
 // REQUIRES: gpu
-// XFAIL: intelgpu
+// UNSUPPORTED: intelgpu
 
 // If offload memory pooling is enabled for a large allocation, reuse error is
 // not detected. UNSUPPORTED: large_allocation_memory_pool

--- a/offload/test/unified_shared_memory/api.c
+++ b/offload/test/unified_shared_memory/api.c
@@ -3,7 +3,7 @@
 // RUN: %libomptarget-run-generic | %fcheck-generic
 
 // REQUIRES: unified_shared_memory
-// XFAIL: intelgpu
+// UNSUPPORTED: intelgpu
 
 #include <omp.h>
 #include <stdio.h>

--- a/offload/test/unified_shared_memory/close_enter_exit.c
+++ b/offload/test/unified_shared_memory/close_enter_exit.c
@@ -5,7 +5,7 @@
 // REQUIRES: unified_shared_memory
 // UNSUPPORTED: clang-6, clang-7, clang-8, clang-9
 
-// XFAIL: intelgpu
+// UNSUPPORTED: intelgpu
 
 #include <omp.h>
 #include <stdio.h>

--- a/offload/test/unified_shared_memory/close_modifier.c
+++ b/offload/test/unified_shared_memory/close_modifier.c
@@ -8,7 +8,7 @@
 // UNSUPPORTED: amdgcn-amd-amdhsa
 // UNSUPPORTED: nvptx64-nvidia-cuda
 // UNSUPPORTED: nvptx64-nvidia-cuda-LTO
-// XFAIL: intelgpu
+// UNSUPPORTED: intelgpu
 
 #include <omp.h>
 #include <stdio.h>

--- a/offload/test/unified_shared_memory/shared_update.c
+++ b/offload/test/unified_shared_memory/shared_update.c
@@ -7,7 +7,7 @@
 // UNSUPPORTED: amdgcn-amd-amdhsa
 // UNSUPPORTED: nvptx64-nvidia-cuda
 // UNSUPPORTED: nvptx64-nvidia-cuda-LTO
-// XFAIL: intelgpu
+// UNSUPPORTED: intelgpu
 
 #include <omp.h>
 #include <stdio.h>


### PR DESCRIPTION
Fix some tests causing hangs, one fail, and a few XPASSing. We are seeing new passes/fails because of the named barrier changes being merged.