### PR TITLE
[flang] Preserve UseErrorDetails in module files

### DIFF
--- a/flang/lib/Semantics/mod-file.cpp
+++ b/flang/lib/Semantics/mod-file.cpp
@@ -528,7 +528,15 @@ void ModFileWriter::PutSymbol(
             }
           },
           [&](const UseDetails &) { PutUse(symbol); },
-          [](const UseErrorDetails &) {},
+          [&](const UseErrorDetails &x) {
+            for (const auto &[at, symptr] : x.occurrences()) {
+              if (symptr) {
+                UseDetails details{at, *symptr};
+                PutUseDetails(details);
+                uses_ << symbol.name() << "=>" << symptr->name() << '\n';
+              }
+            }
+          },
           [&](const ProcBindingDetails &x) {
             bool deferred{symbol.attrs().test(Attr::DEFERRED)};
             typeBindings << "procedure";
@@ -852,8 +860,7 @@ void ModFileWriter::PutGeneric(const Symbol &symbol) {
   }
 }
 
-void ModFileWriter::PutUse(const Symbol &symbol) {
-  auto &details{symbol.get<UseDetails>()};
+void ModFileWriter::PutUseDetails(const UseDetails &details) {
   auto &use{details.symbol()};
   const Symbol &module{GetUsedModule(details)};
   if (use.owner().parent().IsIntrinsicModules()) {
@@ -863,9 +870,15 @@ void ModFileWriter::PutUse(const Symbol &symbol) {
     usedNonIntrinsicModules_.insert(module);
   }
   uses_ << module.name() << ",only:";
+}
+
+void ModFileWriter::PutUse(const Symbol &symbol) {
+  const auto &details{symbol.get<UseDetails>()};
+  PutUseDetails(details);
   PutGenericName(uses_, symbol);
   // Can have intrinsic op with different local-name and use-name
   // (e.g. `operator(<)` and `operator(.lt.)`) but rename is not allowed
+  auto &use{details.symbol()};
   if (!IsIntrinsicOp(symbol) && use.name() != symbol.name()) {
     PutGenericName(uses_ << "=>", use);
   }

--- a/flang/lib/Semantics/mod-file.h
+++ b/flang/lib/Semantics/mod-file.h
@@ -83,6 +83,7 @@ private:
   void PutUserReduction(llvm::raw_ostream &, const Symbol &);
   void PutSubprogram(const Symbol &);
   void PutGeneric(const Symbol &);
+  void PutUseDetails(const UseDetails &);
   void PutUse(const Symbol &);
   void PutUseExtraAttr(Attr, const Symbol &, const Symbol &);
   llvm::raw_ostream &PutAttrs(llvm::raw_ostream &, Attrs,

--- a/flang/lib/Semantics/resolve-names.cpp
+++ b/flang/lib/Semantics/resolve-names.cpp
@@ -9534,7 +9534,7 @@ void ResolveNamesVisitor::HandleProcedureName(
     } else if (symbol->test(Symbol::Flag::Implicit)) {
       Say(name,
           "Use of '%s' as a procedure conflicts with its implicit definition"_err_en_US);
-    } else {
+    } else if (!HadUseError(context(), name.source, symbol)) {
       SayWithDecl(name, *symbol,
           "Use of '%s' as a procedure conflicts with its declaration"_err_en_US);
     }

--- a/flang/test/Semantics/Inputs/modfile84.f90
+++ b/flang/test/Semantics/Inputs/modfile84.f90
@@ -1,0 +1,14 @@
+module modfile84A
+ contains
+  subroutine foo()
+  end subroutine
+end
+module modfile84B
+ contains
+  subroutine foo()
+  end
+end
+module modfile84AB
+  use modfile84A, only: foo, bar=>foo
+  use modfile84B, only: foo, bar=>foo
+end

--- a/flang/test/Semantics/modfile84.f90
+++ b/flang/test/Semantics/modfile84.f90
@@ -1,0 +1,19 @@
+!RUN: rm -rf %t && mkdir -p %t
+!RUN: %flang_fc1 -fsyntax-only -J%t %S/Inputs/modfile84.f90
+!RUN: not %flang_fc1 -fsyntax-only -J%t %s 2>&1 | FileCheck %s
+
+!CHECK: error: Reference to 'foo' is ambiguous
+!CHECK: 'foo' was use-associated from module 'modfile84a'
+!CHECK: 'foo' was use-associated from module 'modfile84b'
+!CHECK: error: 'foo' is not a callable procedure
+!CHECK: 'foo' is USE-associated with 'foo' in module 'modfile84ab'
+!CHECK: error: Reference to 'bar' is ambiguous
+!CHECK: 'bar' was use-associated from module 'modfile84a'
+!CHECK: 'bar' was use-associated from module 'modfile84b'
+!CHECK: error: 'bar' is not a callable procedure
+!CHECK: 'bar' is USE-associated with 'bar' in module 'modfile84ab'
+
+use modfile84AB
+call foo()
+call bar()
+end


### PR DESCRIPTION
When the same name is USE-associated with two or more distinct ultimate symbols, and they are not both generic procedure interfaces, it's not an error unless the name is actually referenced in the scope.  But when the scope is itself a module or submodule, our module files don't preserve the error for later diagnosis -- instead, the UseErrorDetails symbol that serves as a "poison pill" in case of later use is discarded when the module file is generated.  So emit additional USE statements to the module file so that a UseErrorDetails symbol is created anew when the module file is read.