### PR TITLE
[clang-repl] Fix C89 incompatible keywords

### DIFF
--- a/clang/lib/Interpreter/Interpreter.cpp
+++ b/clang/lib/Interpreter/Interpreter.cpp
@@ -337,9 +337,16 @@ const char *const Runtimes = R"(
       __clang_Interpreter_SetValueCopyArr(Src[0], Placement, Size);
     }
 #else
+    #if __STDC_VERSION__ < 199901L
+      #define CI_RESTRICT
+      #define CI_INLINE
+    #else
+      #define CI_RESTRICT restrict
+      #define CI_INLINE inline
+    #endif
     #define EXTERN_C extern
-    EXTERN_C void *memcpy(void *restrict dst, const void *restrict src, __SIZE_TYPE__ n);
-    EXTERN_C inline void __clang_Interpreter_SetValueCopyArr(const void* Src, void* Placement, unsigned long Size) {
+    EXTERN_C void *memcpy(void *CI_RESTRICT dst, const void *CI_RESTRICT src, __SIZE_TYPE__ n);
+    EXTERN_C CI_INLINE void __clang_Interpreter_SetValueCopyArr(const void* Src, void* Placement, unsigned long Size) {
       memcpy(Placement, Src, Size);
     }
 #endif // __cplusplus

--- a/clang/test/Interpreter/pretty-print.c
+++ b/clang/test/Interpreter/pretty-print.c
@@ -1,6 +1,7 @@
 // REQUIRES: host-supports-jit
 // RUN: cat %s | clang-repl -Xcc -xc  | FileCheck %s
 // RUN: cat %s | clang-repl -Xcc -std=c++11 | FileCheck %s
+// RUN: cat %s | clang-repl -Xcc -xc -Xcc -std=c89 | FileCheck %s
 
 // UNSUPPORTED: hwasan, msan
 


### PR DESCRIPTION
Restrict and inline keywords are removed for C89 interpreter since these keywords caused fail at runtime preamble.

Links to https://github.com/llvm/llvm-project/issues/189088

@vgvassilev 