### PR TITLE
[AMDGPU] Added a debug counter to Rewrite AGPR-Copy-MFMA pass

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPURewriteAGPRCopyMFMA.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPURewriteAGPRCopyMFMA.cpp
@@ -70,7 +70,6 @@ class AMDGPURewriteAGPRCopyMFMAImpl {
   LiveIntervals &LIS;
   LiveStacks &LSS;
   const RegisterClassInfo &RegClassInfo;
-  mutable unsigned NumRewritesPerformed = 0;
 
   bool attemptReassignmentsToAGPR(SmallSetVector<Register, 4> &InterferingRegs,
                                   MCPhysReg PrefPhysReg) const;
@@ -279,7 +278,7 @@ bool AMDGPURewriteAGPRCopyMFMAImpl::tryReassigningMFMAChain(
     LRM.unassign(LI);
   }
 
-  if (NumRewritesPerformed + RewriteCandidates.size() >
+  if (NumMFMAsRewrittenToAGPR + RewriteCandidates.size() >
           RewriteAGPRCopyMFMALimit ||
       !attemptReassignmentsToAGPR(RewriteRegs, PhysRegHint)) {
     // Roll back the register assignments to the original state.
@@ -305,7 +304,6 @@ bool AMDGPURewriteAGPRCopyMFMAImpl::tryReassigningMFMAChain(
         AMDGPU::getMFMASrcCVDstAGPROp(RewriteCandidate->getOpcode());
     RewriteCandidate->setDesc(TII.get(NewMFMAOp));
     ++NumMFMAsRewrittenToAGPR;
-    ++NumRewritesPerformed;
   }
 
   return true;
@@ -602,11 +600,8 @@ bool AMDGPURewriteAGPRCopyMFMAImpl::run(MachineFunction &MF) const {
   // If we've successfully rewritten some MFMAs, we've alleviated some VGPR
   // pressure. See if we can eliminate some spills now that those registers are
   // more available.
-  if (MadeChange) {
-    LLVM_DEBUG(dbgs() << "Number of MFMA instructions rewritten to AGPR form: "
-                      << NumRewritesPerformed << '\n');
+  if (MadeChange)
     eliminateSpillsOfReassignedVGPRs();
-  }
 
   return MadeChange;
 }

--- a/llvm/lib/Target/AMDGPU/AMDGPURewriteAGPRCopyMFMA.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPURewriteAGPRCopyMFMA.cpp
@@ -41,11 +41,6 @@ using namespace llvm;
 
 #define DEBUG_TYPE "amdgpu-rewrite-agpr-copy-mfma"
 
-static cl::opt<bool> DisableRewriteAGPRCopyMFMA(
-    "amdgpu-disable-rewrite-agpr-copy-mfma", cl::Hidden,
-    cl::desc("Disable the post-RA AGPR copy MFMA rewriting pass."),
-    cl::init(false));
-
 static cl::opt<unsigned> RewriteAGPRCopyMFMALimit(
     "amdgpu-rewrite-agpr-copy-mfma-limit", cl::Hidden,
     cl::desc("Maximum number of MFMA instructions to rewrite to AGPR form."),
@@ -569,9 +564,6 @@ void AMDGPURewriteAGPRCopyMFMAImpl::eliminateSpillsOfReassignedVGPRs() const {
 }
 
 bool AMDGPURewriteAGPRCopyMFMAImpl::run(MachineFunction &MF) const {
-  if (DisableRewriteAGPRCopyMFMA)
-    return false;
-
   // This only applies on subtargets that have a configurable AGPR vs. VGPR
   // allocation.
   if (!ST.hasGFX90AInsts())

--- a/llvm/lib/Target/AMDGPU/AMDGPURewriteAGPRCopyMFMA.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPURewriteAGPRCopyMFMA.cpp
@@ -35,16 +35,14 @@
 #include "llvm/CodeGen/SlotIndexes.h"
 #include "llvm/CodeGen/VirtRegMap.h"
 #include "llvm/InitializePasses.h"
-#include "llvm/Support/CommandLine.h"
+#include "llvm/Support/DebugCounter.h"
 
 using namespace llvm;
 
 #define DEBUG_TYPE "amdgpu-rewrite-agpr-copy-mfma"
 
-static cl::opt<unsigned> RewriteAGPRCopyMFMALimit(
-    "amdgpu-rewrite-agpr-copy-mfma-limit", cl::Hidden,
-    cl::desc("Maximum number of MFMA instructions to rewrite to AGPR form."),
-    cl::init(~0U));
+DEBUG_COUNTER(RewriteAGPRCopyMFMACounter, DEBUG_TYPE,
+              "Controls which MFMA chains are rewritten to AGPR form");
 
 namespace {
 
@@ -273,8 +271,7 @@ bool AMDGPURewriteAGPRCopyMFMAImpl::tryReassigningMFMAChain(
     LRM.unassign(LI);
   }
 
-  if (NumMFMAsRewrittenToAGPR + RewriteCandidates.size() >
-          RewriteAGPRCopyMFMALimit ||
+  if (!DebugCounter::shouldExecute(RewriteAGPRCopyMFMACounter) ||
       !attemptReassignmentsToAGPR(RewriteRegs, PhysRegHint)) {
     // Roll back the register assignments to the original state.
     for (auto [LI, OldAssign] : TentativeReassignments) {

--- a/llvm/lib/Target/AMDGPU/AMDGPURewriteAGPRCopyMFMA.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPURewriteAGPRCopyMFMA.cpp
@@ -35,10 +35,21 @@
 #include "llvm/CodeGen/SlotIndexes.h"
 #include "llvm/CodeGen/VirtRegMap.h"
 #include "llvm/InitializePasses.h"
+#include "llvm/Support/CommandLine.h"
 
 using namespace llvm;
 
 #define DEBUG_TYPE "amdgpu-rewrite-agpr-copy-mfma"
+
+static cl::opt<bool> DisableRewriteAGPRCopyMFMA(
+    "amdgpu-disable-rewrite-agpr-copy-mfma", cl::Hidden,
+    cl::desc("Disable the post-RA AGPR copy MFMA rewriting pass."),
+    cl::init(false));
+
+static cl::opt<unsigned> RewriteAGPRCopyMFMALimit(
+    "amdgpu-rewrite-agpr-copy-mfma-limit", cl::Hidden,
+    cl::desc("Maximum number of MFMA instructions to rewrite to AGPR form."),
+    cl::init(~0U));
 
 namespace {
 
@@ -59,6 +70,7 @@ class AMDGPURewriteAGPRCopyMFMAImpl {
   LiveIntervals &LIS;
   LiveStacks &LSS;
   const RegisterClassInfo &RegClassInfo;
+  mutable unsigned NumRewritesPerformed = 0;
 
   bool attemptReassignmentsToAGPR(SmallSetVector<Register, 4> &InterferingRegs,
                                   MCPhysReg PrefPhysReg) const;
@@ -267,7 +279,9 @@ bool AMDGPURewriteAGPRCopyMFMAImpl::tryReassigningMFMAChain(
     LRM.unassign(LI);
   }
 
-  if (!attemptReassignmentsToAGPR(RewriteRegs, PhysRegHint)) {
+  if (NumRewritesPerformed + RewriteCandidates.size() >
+          RewriteAGPRCopyMFMALimit ||
+      !attemptReassignmentsToAGPR(RewriteRegs, PhysRegHint)) {
     // Roll back the register assignments to the original state.
     for (auto [LI, OldAssign] : TentativeReassignments) {
       if (VRM.hasPhys(LI->reg()))
@@ -291,6 +305,7 @@ bool AMDGPURewriteAGPRCopyMFMAImpl::tryReassigningMFMAChain(
         AMDGPU::getMFMASrcCVDstAGPROp(RewriteCandidate->getOpcode());
     RewriteCandidate->setDesc(TII.get(NewMFMAOp));
     ++NumMFMAsRewrittenToAGPR;
+    ++NumRewritesPerformed;
   }
 
   return true;
@@ -556,6 +571,9 @@ void AMDGPURewriteAGPRCopyMFMAImpl::eliminateSpillsOfReassignedVGPRs() const {
 }
 
 bool AMDGPURewriteAGPRCopyMFMAImpl::run(MachineFunction &MF) const {
+  if (DisableRewriteAGPRCopyMFMA)
+    return false;
+
   // This only applies on subtargets that have a configurable AGPR vs. VGPR
   // allocation.
   if (!ST.hasGFX90AInsts())
@@ -584,8 +602,11 @@ bool AMDGPURewriteAGPRCopyMFMAImpl::run(MachineFunction &MF) const {
   // If we've successfully rewritten some MFMAs, we've alleviated some VGPR
   // pressure. See if we can eliminate some spills now that those registers are
   // more available.
-  if (MadeChange)
+  if (MadeChange) {
+    LLVM_DEBUG(dbgs() << "Number of MFMA instructions rewritten to AGPR form: "
+                      << NumRewritesPerformed << '\n');
     eliminateSpillsOfReassignedVGPRs();
+  }
 
   return MadeChange;
 }


### PR DESCRIPTION
The debug counter can be used to control the MFMA chains rewritten to AGPR form.