### PR TITLE
[Hexagon] Use trap0(#0xDB) for debugtrap instead of brkpt

### DIFF
--- a/llvm/lib/Target/Hexagon/HexagonPatterns.td
+++ b/llvm/lib/Target/Hexagon/HexagonPatterns.td
@@ -3461,7 +3461,7 @@ def HexagonBARRIER: SDNode<"HexagonISD::BARRIER", SDTNone, [SDNPHasChain]>;
 def: Pat<(HexagonBARRIER), (Y2_barrier)>;
 
 def: Pat<(trap), (PS_crash)>;
-def: Pat<(debugtrap), (Y2_break)>;
+def: Pat<(debugtrap), (J2_trap0 0xDB)>;
 
 // Read cycle counter.
 def : Pat<(i64 (readcyclecounter)), (PS_readcr64 UPCYCLE)>;

--- a/llvm/test/CodeGen/Hexagon/trap-crash.ll
+++ b/llvm/test/CodeGen/Hexagon/trap-crash.ll
@@ -14,7 +14,7 @@ entry:
 }
 
 ; CHECK-LABEL: f1
-; CHECK: brkpt
+; CHECK: trap0(#219)
 define i32 @f1() noreturn nounwind {
 entry:
   tail call void @llvm.debugtrap()


### PR DESCRIPTION
The brkpt instruction is intended for the in-silicon debugger (ISDB). When ISDB is not enabled, brkpt is treated as a NOP, so __builtin_debugtrap() would silently do nothing in user-mode Linux processes.

Use trap0(#0xDB) instead.