### PR TITLE
[NFC][LLVM] Rename `IITDescriptor` fields to confirm to LLVM CS

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenBuiltin.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuiltin.cpp
@@ -839,17 +839,17 @@ decodeFixedType(CIRGenFunction &cgf,
   // If the intrinsic expects unsigned integers, the signedness is corrected in
   // correctIntegerSignedness()
   case IITDescriptor::Integer:
-    return cir::IntType::get(context, descriptor.Integer_Width,
+    return cir::IntType::get(context, descriptor.IntegerWidth,
                              /*isSigned=*/true);
   case IITDescriptor::Vector: {
     mlir::Type elementType = decodeFixedType(cgf, infos, context);
-    unsigned numElements = descriptor.Vector_Width.getFixedValue();
+    unsigned numElements = descriptor.VectorWidth.getFixedValue();
     return cir::VectorType::get(elementType, numElements);
   }
   case IITDescriptor::Pointer: {
     mlir::Builder builder(context);
     auto addrSpace = cir::TargetAddressSpaceAttr::get(
-        context, descriptor.Pointer_AddressSpace);
+        context, descriptor.PointerAddressSpace);
     return cir::PointerType::get(cir::VoidType::get(context), addrSpace);
   }
   default:

--- a/llvm/include/llvm/IR/Intrinsics.h
+++ b/llvm/include/llvm/IR/Intrinsics.h
@@ -183,11 +183,11 @@ namespace Intrinsic {
     } Kind;
 
     union {
-      unsigned Integer_Width;
-      unsigned Pointer_AddressSpace;
-      unsigned Struct_NumElements;
-      unsigned Argument_Info;
-      ElementCount Vector_Width;
+      unsigned IntegerWidth;
+      unsigned PointerAddressSpace;
+      unsigned StructNumElements;
+      unsigned ArgumentInfo;
+      ElementCount VectorWidth;
     };
 
     // AK_% : Defined in Intrinsics.td
@@ -201,31 +201,31 @@ namespace Intrinsic {
              Kind == TruncArgument || Kind == SameVecWidthArgument ||
              Kind == VecElementArgument || Kind == Subdivide2Argument ||
              Kind == Subdivide4Argument || Kind == VecOfBitcastsToInt);
-      return Argument_Info >> 3;
+      return ArgumentInfo >> 3;
     }
     ArgKind getArgumentKind() const {
       assert(Kind == Argument || Kind == ExtendArgument ||
              Kind == TruncArgument || Kind == SameVecWidthArgument ||
              Kind == VecElementArgument || Kind == Subdivide2Argument ||
              Kind == Subdivide4Argument || Kind == VecOfBitcastsToInt);
-      return (ArgKind)(Argument_Info & 7);
+      return (ArgKind)(ArgumentInfo & 7);
     }
 
     // VecOfAnyPtrsToElt uses both an overloaded argument (for address space)
     // and a reference argument (for matching vector width and element types)
     unsigned getOverloadArgNumber() const {
       assert(Kind == VecOfAnyPtrsToElt);
-      return Argument_Info >> 16;
+      return ArgumentInfo >> 16;
     }
     // OneNthEltsVecArguments uses both a divisor N and a reference argument for
     // the full-width vector to match
     unsigned getVectorDivisor() const {
       assert(Kind == OneNthEltsVecArgument);
-      return Argument_Info >> 16;
+      return ArgumentInfo >> 16;
     }
     unsigned getRefArgNumber() const {
       assert(Kind == VecOfAnyPtrsToElt || Kind == OneNthEltsVecArgument);
-      return Argument_Info & 0xFFFF;
+      return ArgumentInfo & 0xFFFF;
     }
 
     static IITDescriptor get(IITDescriptorKind K, unsigned Field) {
@@ -242,7 +242,7 @@ namespace Intrinsic {
 
     static IITDescriptor getVector(unsigned Width, bool IsScalable) {
       IITDescriptor Result = {Vector, {0}};
-      Result.Vector_Width = ElementCount::get(Width, IsScalable);
+      Result.VectorWidth = ElementCount::get(Width, IsScalable);
       return Result;
     }
   };

--- a/llvm/lib/IR/Intrinsics.cpp
+++ b/llvm/lib/IR/Intrinsics.cpp
@@ -517,15 +517,14 @@ static Type *DecodeFixedType(ArrayRef<Intrinsic::IITDescriptor> &Infos,
     return TargetExtType::get(Context, "aarch64.svcount");
 
   case IITDescriptor::Integer:
-    return IntegerType::get(Context, D.Integer_Width);
+    return IntegerType::get(Context, D.IntegerWidth);
   case IITDescriptor::Vector:
-    return VectorType::get(DecodeFixedType(Infos, Tys, Context),
-                           D.Vector_Width);
+    return VectorType::get(DecodeFixedType(Infos, Tys, Context), D.VectorWidth);
   case IITDescriptor::Pointer:
-    return PointerType::get(Context, D.Pointer_AddressSpace);
+    return PointerType::get(Context, D.PointerAddressSpace);
   case IITDescriptor::Struct: {
     SmallVector<Type *, 8> Elts;
-    for (unsigned i = 0, e = D.Struct_NumElements; i != e; ++i)
+    for (unsigned i = 0, e = D.StructNumElements; i != e; ++i)
       Elts.push_back(DecodeFixedType(Infos, Tys, Context));
     return StructType::get(Context, Elts);
   }
@@ -890,28 +889,28 @@ matchIntrinsicType(Type *Ty, ArrayRef<Intrinsic::IITDescriptor> &Infos,
   case IITDescriptor::PPCQuad:
     return !Ty->isPPC_FP128Ty();
   case IITDescriptor::Integer:
-    return !Ty->isIntegerTy(D.Integer_Width);
+    return !Ty->isIntegerTy(D.IntegerWidth);
   case IITDescriptor::AArch64Svcount:
     return !isa<TargetExtType>(Ty) ||
            cast<TargetExtType>(Ty)->getName() != "aarch64.svcount";
   case IITDescriptor::Vector: {
     VectorType *VT = dyn_cast<VectorType>(Ty);
-    return !VT || VT->getElementCount() != D.Vector_Width ||
+    return !VT || VT->getElementCount() != D.VectorWidth ||
            matchIntrinsicType(VT->getElementType(), Infos, ArgTys,
                               DeferredChecks, IsDeferredCheck);
   }
   case IITDescriptor::Pointer: {
     PointerType *PT = dyn_cast<PointerType>(Ty);
-    return !PT || PT->getAddressSpace() != D.Pointer_AddressSpace;
+    return !PT || PT->getAddressSpace() != D.PointerAddressSpace;
   }
 
   case IITDescriptor::Struct: {
     StructType *ST = dyn_cast<StructType>(Ty);
     if (!ST || !ST->isLiteral() || ST->isPacked() ||
-        ST->getNumElements() != D.Struct_NumElements)
+        ST->getNumElements() != D.StructNumElements)
       return true;
 
-    for (unsigned i = 0, e = D.Struct_NumElements; i != e; ++i)
+    for (unsigned i = 0, e = D.StructNumElements; i != e; ++i)
       if (matchIntrinsicType(ST->getElementType(i), Infos, ArgTys,
                              DeferredChecks, IsDeferredCheck))
         return true;


### PR DESCRIPTION
Rename fields of `IITDescriptor` to conform to LLVM coding standards naming conventions.