### PR TITLE
[LLVMABI] avoid Align Align member shadowing llvm::Align type

### DIFF
--- a/llvm/include/llvm/ABI/FunctionInfo.h
+++ b/llvm/include/llvm/ABI/FunctionInfo.h
@@ -52,7 +52,7 @@ private:
   };
 
   struct IndirectAttrInfo {
-    Align Alignment;
+    Align RequiredAlign;
     unsigned AddrSpace;
   };
 
@@ -112,7 +112,7 @@ public:
   static ArgInfo getIndirect(Align Align, bool ByVal, unsigned AddrSpace = 0,
                              bool Realign = false) {
     ArgInfo AI(Indirect);
-    AI.IndirectAttr.Alignment = Align;
+    AI.IndirectAttr.RequiredAlign = Align;
     AI.IndirectAttr.AddrSpace = AddrSpace;
     AI.IndirectByVal = ByVal;
     AI.IndirectRealign = Realign;
@@ -153,7 +153,7 @@ public:
 
   Align getIndirectAlign() const {
     assert(isIndirect() && "Invalid Kind!");
-    return IndirectAttr.Alignment;
+    return IndirectAttr.RequiredAlign;
   }
 
   unsigned getIndirectAddrSpace() const {


### PR DESCRIPTION
`IndirectAttrInfo::Align` shadowed the `llvm::Align` type, causing a build failure with GCC (`-fpermissive`). Rename the field to `RequiredAlign` and `DirectAttrInfo::Align` to `Alignment`.

This was introduced as part of https://github.com/llvm/llvm-project/pull/185105.