### PR TITLE
[lldb] Increase timeout on lldbutil.wait_for_file_on_target

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/lldbutil.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbutil.py
@@ -1688,8 +1688,8 @@ def read_file_from_process_wd(test, name):
 def wait_for_file_on_target(testcase, file_path):
     import time
 
-    MAX_ATTEMPTS = 10
-    timeout_seconds = 10 if "ASAN_OPTIONS" in os.environ else 5
+    MAX_ATTEMPTS = 60
+    timeout_seconds = 20 if "ASAN_OPTIONS" in os.environ else 2
     for i in range(MAX_ATTEMPTS):
         command = f"ls {file_path}"
         err, retcode, msg = testcase.run_platform_command(command)

--- a/lldb/packages/Python/lldbsuite/test/lldbutil.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbutil.py
@@ -1689,19 +1689,13 @@ def wait_for_file_on_target(testcase, file_path, max_attempts=6):
     for i in range(max_attempts):
         command = f"ls {file_path}"
         err, retcode, msg = testcase.run_platform_command(command)
-        if testcase.TraceOn():
-            testcase.trace(f"Ran command: {command}")
-            testcase.trace(f"Retcode: {retcode}")
-            testcase.trace(f"Output: {msg}")
-            testcase.trace(f"Error: {err.description}")
-
         if err.Success() and retcode == 0:
             break
         if i < max_attempts:
             # Exponential backoff!
             import time
 
-            time.sleep(pow(2, i) * 0.25)
+            time.sleep(pow(2, i))
     else:
         testcase.fail(
             "File %s not found even after %d attempts." % (file_path, max_attempts)

--- a/lldb/packages/Python/lldbsuite/test/lldbutil.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbutil.py
@@ -1685,17 +1685,18 @@ def read_file_from_process_wd(test, name):
     return read_file_on_target(test, path)
 
 
-def wait_for_file_on_target(testcase, file_path, max_attempts=6):
-    for i in range(max_attempts):
+def wait_for_file_on_target(testcase, file_path):
+    import time
+
+    MAX_ATTEMPTS = 10
+    timeout_seconds = 10 if "ASAN_OPTIONS" in os.environ else 5
+    for i in range(MAX_ATTEMPTS):
         command = f"ls {file_path}"
         err, retcode, msg = testcase.run_platform_command(command)
         if err.Success() and retcode == 0:
             break
-        if i < max_attempts:
-            # Exponential backoff!
-            import time
 
-            time.sleep(pow(2, i))
+        time.sleep(timeout_seconds)
     else:
         testcase.fail(
             "File %s not found even after %d attempts." % (file_path, max_attempts)


### PR DESCRIPTION
I've been tracking sporadic timeouts waiting for a file to appear on macOS buildbots (and occasionally local development environments). I believe I've tracked it down to a regression in process launch performance in macOS.

What I noticed is that running multiple test suites simultaneously almost always triggered these failures and that the tests were always waiting on files created by the inferior. Increasing this timeout no longer triggers the failures on my loaded machine locally.

This timeout moves from about 16 seconds of total wait time to about 127 seconds of total wait time. This may feel a bit extreme, but this is a performance issue. While I was here, I cleaned up logging code I was using to investigate the test failures.

rdar://172122213