### PR TITLE
[AArch64] Add error handling for unsupported bases in lowerConstantPtrAuth

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64AsmPrinter.cpp
+++ b/llvm/lib/Target/AArch64/AArch64AsmPrinter.cpp
@@ -2680,9 +2680,13 @@ AArch64AsmPrinter::lowerConstantPtrAuth(const ConstantPtrAuth &CPA) {
   MCContext &Ctx = OutContext;
 
   // Figure out the base symbol and the addend, if any.
+  // LookThroughIntToPtr handles Swift patterns like:
+  //   inttoptr (i64 add (i64 ptrtoint (ptr @global to i64), i64 2) to ptr)
   APInt Offset(64, 0);
   const Value *BaseGV = CPA.getPointer()->stripAndAccumulateConstantOffsets(
-      getDataLayout(), Offset, /*AllowNonInbounds=*/true);
+      getDataLayout(), Offset, /*AllowNonInbounds=*/true,
+      /*AllowInvariantGroup=*/false, /*ExternalAnalysis=*/nullptr,
+      /*LookThroughIntToPtr=*/true);
 
   auto *BaseGVB = dyn_cast<GlobalValue>(BaseGV);
 

--- a/llvm/lib/Target/AArch64/AArch64AsmPrinter.cpp
+++ b/llvm/lib/Target/AArch64/AArch64AsmPrinter.cpp
@@ -2680,13 +2680,9 @@ AArch64AsmPrinter::lowerConstantPtrAuth(const ConstantPtrAuth &CPA) {
   MCContext &Ctx = OutContext;
 
   // Figure out the base symbol and the addend, if any.
-  // LookThroughIntToPtr is needed to handle patterns like:
-  //   inttoptr (i64 add (i64 ptrtoint (ptr @global to i64), i64 2) to ptr)
   APInt Offset(64, 0);
   const Value *BaseGV = CPA.getPointer()->stripAndAccumulateConstantOffsets(
-      getDataLayout(), Offset, /*AllowNonInbounds=*/true,
-      /*AllowInvariantGroup=*/false, /*ExternalAnalysis=*/nullptr,
-      /*LookThroughIntToPtr=*/true);
+      getDataLayout(), Offset, /*AllowNonInbounds=*/true);
 
   auto *BaseGVB = dyn_cast<GlobalValue>(BaseGV);
 

--- a/llvm/lib/Target/AArch64/AArch64AsmPrinter.cpp
+++ b/llvm/lib/Target/AArch64/AArch64AsmPrinter.cpp
@@ -2680,7 +2680,7 @@ AArch64AsmPrinter::lowerConstantPtrAuth(const ConstantPtrAuth &CPA) {
   MCContext &Ctx = OutContext;
 
   // Figure out the base symbol and the addend, if any.
-  // LookThroughIntToPtr handles Swift patterns like:
+  // LookThroughIntToPtr is needed to handle patterns like:
   //   inttoptr (i64 add (i64 ptrtoint (ptr @global to i64), i64 2) to ptr)
   APInt Offset(64, 0);
   const Value *BaseGV = CPA.getPointer()->stripAndAccumulateConstantOffsets(

--- a/llvm/lib/Target/AArch64/AArch64AsmPrinter.cpp
+++ b/llvm/lib/Target/AArch64/AArch64AsmPrinter.cpp
@@ -2700,8 +2700,10 @@ AArch64AsmPrinter::lowerConstantPtrAuth(const ConstantPtrAuth &CPA) {
     else if (Offset.slt(0))
       Sym = MCBinaryExpr::createSub(
           Sym, MCConstantExpr::create((-Offset).getSExtValue(), Ctx), Ctx);
-  } else {
+  } else if (isa<ConstantExpr>(BaseGV)) {
     reportFatalUsageError("unsupported constant expression in ptrauth pointer");
+  } else {
+    Sym = MCConstantExpr::create(Offset.getSExtValue(), Ctx);
   }
 
   const MCExpr *DSExpr = nullptr;

--- a/llvm/lib/Target/AArch64/AArch64AsmPrinter.cpp
+++ b/llvm/lib/Target/AArch64/AArch64AsmPrinter.cpp
@@ -2680,9 +2680,13 @@ AArch64AsmPrinter::lowerConstantPtrAuth(const ConstantPtrAuth &CPA) {
   MCContext &Ctx = OutContext;
 
   // Figure out the base symbol and the addend, if any.
+  // LookThroughIntToPtr handles Swift patterns like:
+  //   inttoptr (i64 add (i64 ptrtoint (ptr @global to i64), i64 2) to ptr)
   APInt Offset(64, 0);
   const Value *BaseGV = CPA.getPointer()->stripAndAccumulateConstantOffsets(
-      getDataLayout(), Offset, /*AllowNonInbounds=*/true);
+      getDataLayout(), Offset, /*AllowNonInbounds=*/true,
+      /*AllowInvariantGroup=*/false, /*ExternalAnalysis=*/nullptr,
+      /*LookThroughIntToPtr=*/true);
 
   auto *BaseGVB = dyn_cast<GlobalValue>(BaseGV);
 
@@ -2697,7 +2701,7 @@ AArch64AsmPrinter::lowerConstantPtrAuth(const ConstantPtrAuth &CPA) {
       Sym = MCBinaryExpr::createSub(
           Sym, MCConstantExpr::create((-Offset).getSExtValue(), Ctx), Ctx);
   } else {
-    Sym = MCConstantExpr::create(Offset.getSExtValue(), Ctx);
+    reportFatalUsageError("unsupported constant expression in ptrauth pointer");
   }
 
   const MCExpr *DSExpr = nullptr;

--- a/llvm/lib/Target/AArch64/AArch64AsmPrinter.cpp
+++ b/llvm/lib/Target/AArch64/AArch64AsmPrinter.cpp
@@ -2700,10 +2700,10 @@ AArch64AsmPrinter::lowerConstantPtrAuth(const ConstantPtrAuth &CPA) {
     else if (Offset.slt(0))
       Sym = MCBinaryExpr::createSub(
           Sym, MCConstantExpr::create((-Offset).getSExtValue(), Ctx), Ctx);
-  } else if (isa<ConstantExpr>(BaseGV)) {
-    reportFatalUsageError("unsupported constant expression in ptrauth pointer");
-  } else {
+  } else if (isa<ConstantPointerNull>(BaseGV)) {
     Sym = MCConstantExpr::create(Offset.getSExtValue(), Ctx);
+  } else {
+    reportFatalUsageError("unsupported constant expression in ptrauth pointer");
   }
 
   const MCExpr *DSExpr = nullptr;

--- a/llvm/test/CodeGen/AArch64/ptrauth-reloc.ll
+++ b/llvm/test/CodeGen/AArch64/ptrauth-reloc.ll
@@ -113,6 +113,20 @@
 
 @g.weird_ref.da.0 = constant i64 ptrtoint (ptr inttoptr (i64 ptrtoint (ptr ptrauth (ptr getelementptr (i8, ptr @g, i64 16), i32 2) to i64) to ptr) to i64)
 
+; Swift generates inttoptr(add(ptrtoint(@global), offset)) inside ptrauth.
+
+; CHECK-ELF-LABEL:     .globl g.inttoptr_add.da.0
+; CHECK-ELF-NEXT:      .p2align 3
+; CHECK-ELF-NEXT:    g.inttoptr_add.da.0:
+; CHECK-ELF-NEXT:      .xword (g+2)@AUTH(da,0)
+
+; CHECK-MACHO-LABEL:   .globl _g.inttoptr_add.da.0
+; CHECK-MACHO-NEXT:    .p2align 3
+; CHECK-MACHO-NEXT:  _g.inttoptr_add.da.0:
+; CHECK-MACHO-NEXT:    .quad (_g+2)@AUTH(da,0)
+
+@g.inttoptr_add.da.0 = constant ptr ptrauth (ptr inttoptr (i64 add (i64 ptrtoint (ptr @g to i64), i64 2) to ptr), i32 2)
+
 ; CHECK-ELF-LABEL:     .globl g_weak.ref.ia.42
 ; CHECK-ELF-NEXT:      .p2align 3
 ; CHECK-ELF-NEXT:    g_weak.ref.ia.42:

--- a/llvm/test/CodeGen/AArch64/ptrauth-reloc.ll
+++ b/llvm/test/CodeGen/AArch64/ptrauth-reloc.ll
@@ -113,7 +113,7 @@
 
 @g.weird_ref.da.0 = constant i64 ptrtoint (ptr inttoptr (i64 ptrtoint (ptr ptrauth (ptr getelementptr (i8, ptr @g, i64 16), i32 2) to i64) to ptr) to i64)
 
-; Swift generates inttoptr(add(ptrtoint(@global), offset)) inside ptrauth.
+; inttoptr(add(ptrtoint(@global), offset)) inside ptrauth.
 
 ; CHECK-ELF-LABEL:     .globl g.inttoptr_add.da.0
 ; CHECK-ELF-NEXT:      .p2align 3

--- a/llvm/test/CodeGen/AArch64/ptrauth-reloc.ll
+++ b/llvm/test/CodeGen/AArch64/ptrauth-reloc.ll
@@ -113,20 +113,6 @@
 
 @g.weird_ref.da.0 = constant i64 ptrtoint (ptr inttoptr (i64 ptrtoint (ptr ptrauth (ptr getelementptr (i8, ptr @g, i64 16), i32 2) to i64) to ptr) to i64)
 
-; inttoptr(add(ptrtoint(@global), offset)) inside ptrauth.
-
-; CHECK-ELF-LABEL:     .globl g.inttoptr_add.da.0
-; CHECK-ELF-NEXT:      .p2align 3
-; CHECK-ELF-NEXT:    g.inttoptr_add.da.0:
-; CHECK-ELF-NEXT:      .xword (g+2)@AUTH(da,0)
-
-; CHECK-MACHO-LABEL:   .globl _g.inttoptr_add.da.0
-; CHECK-MACHO-NEXT:    .p2align 3
-; CHECK-MACHO-NEXT:  _g.inttoptr_add.da.0:
-; CHECK-MACHO-NEXT:    .quad (_g+2)@AUTH(da,0)
-
-@g.inttoptr_add.da.0 = constant ptr ptrauth (ptr inttoptr (i64 add (i64 ptrtoint (ptr @g to i64), i64 2) to ptr), i32 2)
-
 ; Null pointer inside ptrauth is valid (e.g. ptrauth-irelative.ll).
 
 ; CHECK-ELF-LABEL:     .globl g.null_ref.da.0

--- a/llvm/test/CodeGen/AArch64/ptrauth-reloc.ll
+++ b/llvm/test/CodeGen/AArch64/ptrauth-reloc.ll
@@ -127,6 +127,20 @@
 
 @g.inttoptr_add.da.0 = constant ptr ptrauth (ptr inttoptr (i64 add (i64 ptrtoint (ptr @g to i64), i64 2) to ptr), i32 2)
 
+; Null pointer inside ptrauth is valid (e.g. ptrauth-irelative.ll).
+
+; CHECK-ELF-LABEL:     .globl g.null_ref.da.0
+; CHECK-ELF-NEXT:      .p2align 3
+; CHECK-ELF-NEXT:    g.null_ref.da.0:
+; CHECK-ELF-NEXT:      .xword (0)@AUTH(da,0)
+
+; CHECK-MACHO-LABEL:   .globl _g.null_ref.da.0
+; CHECK-MACHO-NEXT:    .p2align 3
+; CHECK-MACHO-NEXT:  _g.null_ref.da.0:
+; CHECK-MACHO-NEXT:    .quad (0)@AUTH(da,0)
+
+@g.null_ref.da.0 = constant ptr ptrauth (ptr null, i32 2)
+
 ; CHECK-ELF-LABEL:     .globl g_weak.ref.ia.42
 ; CHECK-ELF-NEXT:      .p2align 3
 ; CHECK-ELF-NEXT:    g_weak.ref.ia.42:
@@ -206,3 +220,15 @@
 
 ; CHECK-ERR-DISC-GNU: error: AArch64 PAC Discriminator '65538' out of range [0, 0xFFFF]
 @g.ref.da.65538 = constant ptr ptrauth (ptr @g, i32 2, i64 65538, ptr null, ptr @ds)
+
+;--- err-unsupported-base.ll
+
+; RUN: not llc < err-unsupported-base.ll -mtriple arm64e-apple-darwin 2>&1 \
+; RUN:   | FileCheck %s --check-prefix=CHECK-ERR-BASE
+; RUN: not llc < err-unsupported-base.ll -mtriple aarch64-elf -mattr=+pauth 2>&1 \
+; RUN:   | FileCheck %s --check-prefix=CHECK-ERR-BASE
+
+; CHECK-ERR-BASE: unsupported constant expression in ptrauth pointer
+
+@g = external global i32
+@g.nested_ptrauth = constant ptr ptrauth (ptr ptrauth (ptr @g, i32 0), i32 2)


### PR DESCRIPTION
This is part of work being done in #188378 and #188638, split out from #188650.

`lowerConstantPtrAuth` silently miscompiled `ConstantPtrAuth` constants with non-`GlobalValue` pointer bases — emitting `0@AUTH(da,0)` instead of erroring.

Changes:
- Handle `ConstantPointerNull` bases explicitly
- Error via `reportFatalUsageError` on any remaining unresolved base (e.g. nested ptrauth) instead of silently miscompiling

This PR was mostly developed with LLM assistance