### PR TITLE
[clang] Fix incorrect filenames for hardlinks

### DIFF
--- a/clang/include/clang/Basic/SourceManager.h
+++ b/clang/include/clang/Basic/SourceManager.h
@@ -714,6 +714,12 @@ class SourceManager : public RefCountedBase<SourceManager> {
   /// as they do not refer to a file.
   std::vector<SrcMgr::ContentCache*> MemBufferInfos;
 
+  /// Per-FileID content caches for aliased file references.
+  ///
+  /// These caches preserve the spelling used for a particular include while
+  /// sharing file contents with the canonical cache in \c FileInfos.
+  std::vector<SrcMgr::ContentCache *> FileIDContentCaches;
+
   /// The table of SLocEntries that are local to this module.
   ///
   /// Positive FileIDs are indexes into this table. Entry 0 indicates an invalid

--- a/clang/lib/Basic/SourceManager.cpp
+++ b/clang/lib/Basic/SourceManager.cpp
@@ -47,9 +47,8 @@ using llvm::MemoryBuffer;
 
 #define DEBUG_TYPE "source-manager"
 
-static SrcMgr::ContentCache *
-cloneContentCache(llvm::BumpPtrAllocator &Alloc,
-                  const ContentCache &Other) {
+static SrcMgr::ContentCache *cloneContentCache(llvm::BumpPtrAllocator &Alloc,
+                                               const ContentCache &Other) {
   auto *Clone = new (Alloc.Allocate<ContentCache>()) ContentCache;
   Clone->OrigEntry = Other.OrigEntry;
   Clone->ContentsEntry = Other.ContentsEntry;

--- a/clang/lib/Basic/SourceManager.cpp
+++ b/clang/lib/Basic/SourceManager.cpp
@@ -63,7 +63,8 @@ static SrcMgr::ContentCache *cloneContentCache(llvm::BumpPtrAllocator &Alloc,
   return Clone;
 }
 
-static bool pathDiffersIgnoringWindowsSlashes(FileEntryRef LHS, FileEntryRef RHS) {
+static bool pathDiffersIgnoringWindowsSlashes(FileEntryRef LHS,
+                                              FileEntryRef RHS) {
   std::string LHSPath = llvm::sys::path::convert_to_slash(LHS.getName());
   std::string RHSPath = llvm::sys::path::convert_to_slash(RHS.getName());
   StringRef LHSRef(LHSPath);

--- a/clang/lib/Basic/SourceManager.cpp
+++ b/clang/lib/Basic/SourceManager.cpp
@@ -599,8 +599,8 @@ FileID SourceManager::createFileID(FileEntryRef SourceFile,
   if (Cache->ContentsEntry->isNamedPipe())
     (void)Cache->getBufferOrNone(Diag, getFileManager(), SourceLocation());
 
-  return createFileIDImpl(*Cache, Filename, IncludePos, FileCharacter,
-                          LoadedID, LoadedOffset);
+  return createFileIDImpl(*Cache, Filename, IncludePos, FileCharacter, LoadedID,
+                          LoadedOffset);
 }
 
 /// Create a new FileID that represents the specified memory buffer.

--- a/clang/lib/Basic/SourceManager.cpp
+++ b/clang/lib/Basic/SourceManager.cpp
@@ -38,6 +38,7 @@
 #include <cstdint>
 #include <memory>
 #include <optional>
+#include <string>
 #include <tuple>
 #include <utility>
 #include <vector>
@@ -62,23 +63,11 @@ static SrcMgr::ContentCache *cloneContentCache(llvm::BumpPtrAllocator &Alloc,
   return Clone;
 }
 
-static SmallString<128> normalizeFilePathForComparison(const FileManager &FM,
-                                                       StringRef Name) {
-  SmallString<128> Path(Name);
-  FM.makeAbsolutePath(Path, /*Canonicalize=*/true);
-  llvm::sys::path::native(Path);
-  return Path;
-}
-
-static bool referencesDistinctFilePaths(const FileManager &FM, FileEntryRef LHS,
-                                        FileEntryRef RHS) {
-  SmallString<128> LHSPath = normalizeFilePathForComparison(FM, LHS.getName());
-  SmallString<128> RHSPath = normalizeFilePathForComparison(FM, RHS.getName());
+static bool pathDiffersIgnoringWindowsSlashes(FileEntryRef LHS, FileEntryRef RHS) {
+  std::string LHSPath = llvm::sys::path::convert_to_slash(LHS.getName());
+  std::string RHSPath = llvm::sys::path::convert_to_slash(RHS.getName());
   StringRef LHSRef(LHSPath);
   StringRef RHSRef(RHSPath);
-
-  if (llvm::sys::path::is_style_windows(llvm::sys::path::Style::native))
-    return !LHSRef.equals_insensitive(RHSRef);
   return LHSRef != RHSRef;
 }
 
@@ -584,8 +573,7 @@ FileID SourceManager::createFileID(FileEntryRef SourceFile,
   StringRef Filename = SourceFile.getName();
 
   if (IR.OrigEntry && !IR.OrigEntry->isSameRef(SourceFile)) {
-    if (referencesDistinctFilePaths(getFileManager(), *IR.OrigEntry,
-                                    SourceFile)) {
+    if (pathDiffersIgnoringWindowsSlashes(*IR.OrigEntry, SourceFile)) {
       Cache = cloneContentCache(ContentCacheAlloc, IR);
       Cache->OrigEntry = SourceFile;
       FileIDContentCaches.push_back(Cache);

--- a/clang/lib/Basic/SourceManager.cpp
+++ b/clang/lib/Basic/SourceManager.cpp
@@ -47,6 +47,21 @@ using llvm::MemoryBuffer;
 
 #define DEBUG_TYPE "source-manager"
 
+static SrcMgr::ContentCache *
+cloneContentCache(llvm::BumpPtrAllocator &Alloc,
+                  const ContentCache &Other) {
+  auto *Clone = new (Alloc.Allocate<ContentCache>()) ContentCache;
+  Clone->OrigEntry = Other.OrigEntry;
+  Clone->ContentsEntry = Other.ContentsEntry;
+  Clone->Filename = Other.Filename;
+  Clone->BufferOverridden = Other.BufferOverridden;
+  Clone->IsFileVolatile = Other.IsFileVolatile;
+  Clone->IsTransient = Other.IsTransient;
+  Clone->IsBufferInvalid = Other.IsBufferInvalid;
+  Clone->setUnownedBuffer(Other.getBufferIfLoaded());
+  return Clone;
+}
+
 // Reaching a limit of 2^31 results in a hard error. This metric allows to track
 // if particular invocation of the compiler is close to it.
 STATISTIC(MaxUsedSLocBytes, "Maximum number of bytes used by source locations "
@@ -324,9 +339,23 @@ SourceManager::~SourceManager() {
       ContentCacheAlloc.Deallocate(I->second);
     }
   }
+  for (unsigned i = 0, e = FileIDContentCaches.size(); i != e; ++i) {
+    if (FileIDContentCaches[i]) {
+      FileIDContentCaches[i]->~ContentCache();
+      ContentCacheAlloc.Deallocate(FileIDContentCaches[i]);
+    }
+  }
 }
 
 void SourceManager::clearIDTables() {
+  for (unsigned i = 0, e = FileIDContentCaches.size(); i != e; ++i) {
+    if (FileIDContentCaches[i]) {
+      FileIDContentCaches[i]->~ContentCache();
+      ContentCacheAlloc.Deallocate(FileIDContentCaches[i]);
+    }
+  }
+  FileIDContentCaches.clear();
+
   MainFileID = FileID();
   LocalSLocEntryTable.clear();
   LocalLocOffsetTable.clear();
@@ -361,17 +390,6 @@ bool SourceManager::isMainFile(const FileEntry &SourceFile) {
 void SourceManager::initializeForReplay(const SourceManager &Old) {
   assert(MainFileID.isInvalid() && "expected uninitialized SourceManager");
 
-  auto CloneContentCache = [&](const ContentCache *Cache) -> ContentCache * {
-    auto *Clone = new (ContentCacheAlloc.Allocate<ContentCache>()) ContentCache;
-    Clone->OrigEntry = Cache->OrigEntry;
-    Clone->ContentsEntry = Cache->ContentsEntry;
-    Clone->BufferOverridden = Cache->BufferOverridden;
-    Clone->IsFileVolatile = Cache->IsFileVolatile;
-    Clone->IsTransient = Cache->IsTransient;
-    Clone->setUnownedBuffer(Cache->getBufferIfLoaded());
-    return Clone;
-  };
-
   // Ensure all SLocEntries are loaded from the external source.
   for (unsigned I = 0, N = Old.LoadedSLocEntryTable.size(); I != N; ++I)
     if (!Old.SLocEntryLoaded[I])
@@ -382,7 +400,7 @@ void SourceManager::initializeForReplay(const SourceManager &Old) {
     SrcMgr::ContentCache *&Slot = FileInfos[FileInfo.first];
     if (Slot)
       continue;
-    Slot = CloneContentCache(FileInfo.second);
+    Slot = cloneContentCache(ContentCacheAlloc, *FileInfo.second);
   }
 }
 
@@ -542,14 +560,21 @@ FileID SourceManager::createFileID(FileEntryRef SourceFile,
                                    SourceLocation::UIntTy LoadedOffset) {
   SrcMgr::ContentCache &IR = getOrCreateContentCache(SourceFile,
                                                      isSystem(FileCharacter));
+  SrcMgr::ContentCache *Cache = &IR;
+
+  if (IR.OrigEntry && !IR.OrigEntry->isSameRef(SourceFile)) {
+    Cache = cloneContentCache(ContentCacheAlloc, IR);
+    Cache->OrigEntry = SourceFile;
+    FileIDContentCaches.push_back(Cache);
+  }
 
   // If this is a named pipe, immediately load the buffer to ensure subsequent
   // calls to ContentCache::getSize() are accurate.
-  if (IR.ContentsEntry->isNamedPipe())
-    (void)IR.getBufferOrNone(Diag, getFileManager(), SourceLocation());
+  if (Cache->ContentsEntry->isNamedPipe())
+    (void)Cache->getBufferOrNone(Diag, getFileManager(), SourceLocation());
 
-  return createFileIDImpl(IR, SourceFile.getName(), IncludePos, FileCharacter,
-                          LoadedID, LoadedOffset);
+  return createFileIDImpl(*Cache, SourceFile.getName(), IncludePos,
+                          FileCharacter, LoadedID, LoadedOffset);
 }
 
 /// Create a new FileID that represents the specified memory buffer.
@@ -2310,6 +2335,7 @@ SourceManager::MemoryBufferSizes SourceManager::getMemoryBufferSizes() const {
 
 size_t SourceManager::getDataStructureSizes() const {
   size_t size = llvm::capacity_in_bytes(MemBufferInfos) +
+                llvm::capacity_in_bytes(FileIDContentCaches) +
                 llvm::capacity_in_bytes(LocalSLocEntryTable) +
                 llvm::capacity_in_bytes(LoadedSLocEntryTable) +
                 llvm::capacity_in_bytes(SLocEntryLoaded) +

--- a/clang/lib/Basic/SourceManager.cpp
+++ b/clang/lib/Basic/SourceManager.cpp
@@ -30,6 +30,7 @@
 #include "llvm/Support/Endian.h"
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/MemoryBuffer.h"
+#include "llvm/Support/Path.h"
 #include "llvm/Support/raw_ostream.h"
 #include <algorithm>
 #include <cassert>
@@ -59,6 +60,26 @@ static SrcMgr::ContentCache *cloneContentCache(llvm::BumpPtrAllocator &Alloc,
   Clone->IsBufferInvalid = Other.IsBufferInvalid;
   Clone->setUnownedBuffer(Other.getBufferIfLoaded());
   return Clone;
+}
+
+static SmallString<128> normalizeFilePathForComparison(const FileManager &FM,
+                                                       StringRef Name) {
+  SmallString<128> Path(Name);
+  FM.makeAbsolutePath(Path, /*Canonicalize=*/true);
+  llvm::sys::path::native(Path);
+  return Path;
+}
+
+static bool referencesDistinctFilePaths(const FileManager &FM, FileEntryRef LHS,
+                                        FileEntryRef RHS) {
+  SmallString<128> LHSPath = normalizeFilePathForComparison(FM, LHS.getName());
+  SmallString<128> RHSPath = normalizeFilePathForComparison(FM, RHS.getName());
+  StringRef LHSRef(LHSPath);
+  StringRef RHSRef(RHSPath);
+
+  if (llvm::sys::path::is_style_windows(llvm::sys::path::Style::native))
+    return !LHSRef.equals_insensitive(RHSRef);
+  return LHSRef != RHSRef;
 }
 
 // Reaching a limit of 2^31 results in a hard error. This metric allows to track
@@ -560,11 +581,17 @@ FileID SourceManager::createFileID(FileEntryRef SourceFile,
   SrcMgr::ContentCache &IR = getOrCreateContentCache(SourceFile,
                                                      isSystem(FileCharacter));
   SrcMgr::ContentCache *Cache = &IR;
+  StringRef Filename = SourceFile.getName();
 
   if (IR.OrigEntry && !IR.OrigEntry->isSameRef(SourceFile)) {
-    Cache = cloneContentCache(ContentCacheAlloc, IR);
-    Cache->OrigEntry = SourceFile;
-    FileIDContentCaches.push_back(Cache);
+    if (referencesDistinctFilePaths(getFileManager(), *IR.OrigEntry,
+                                    SourceFile)) {
+      Cache = cloneContentCache(ContentCacheAlloc, IR);
+      Cache->OrigEntry = SourceFile;
+      FileIDContentCaches.push_back(Cache);
+    } else {
+      Filename = IR.OrigEntry->getName();
+    }
   }
 
   // If this is a named pipe, immediately load the buffer to ensure subsequent
@@ -572,8 +599,8 @@ FileID SourceManager::createFileID(FileEntryRef SourceFile,
   if (Cache->ContentsEntry->isNamedPipe())
     (void)Cache->getBufferOrNone(Diag, getFileManager(), SourceLocation());
 
-  return createFileIDImpl(*Cache, SourceFile.getName(), IncludePos,
-                          FileCharacter, LoadedID, LoadedOffset);
+  return createFileIDImpl(*Cache, Filename, IncludePos, FileCharacter,
+                          LoadedID, LoadedOffset);
 }
 
 /// Create a new FileID that represents the specified memory buffer.

--- a/clang/lib/Basic/SourceManager.cpp
+++ b/clang/lib/Basic/SourceManager.cpp
@@ -63,15 +63,6 @@ static SrcMgr::ContentCache *cloneContentCache(llvm::BumpPtrAllocator &Alloc,
   return Clone;
 }
 
-static bool pathDiffersIgnoringWindowsSlashes(FileEntryRef LHS,
-                                              FileEntryRef RHS) {
-  std::string LHSPath = llvm::sys::path::convert_to_slash(LHS.getName());
-  std::string RHSPath = llvm::sys::path::convert_to_slash(RHS.getName());
-  StringRef LHSRef(LHSPath);
-  StringRef RHSRef(RHSPath);
-  return LHSRef != RHSRef;
-}
-
 // Reaching a limit of 2^31 results in a hard error. This metric allows to track
 // if particular invocation of the compiler is close to it.
 STATISTIC(MaxUsedSLocBytes, "Maximum number of bytes used by source locations "
@@ -574,13 +565,9 @@ FileID SourceManager::createFileID(FileEntryRef SourceFile,
   StringRef Filename = SourceFile.getName();
 
   if (IR.OrigEntry && !IR.OrigEntry->isSameRef(SourceFile)) {
-    if (pathDiffersIgnoringWindowsSlashes(*IR.OrigEntry, SourceFile)) {
-      Cache = cloneContentCache(ContentCacheAlloc, IR);
-      Cache->OrigEntry = SourceFile;
-      FileIDContentCaches.push_back(Cache);
-    } else {
-      Filename = IR.OrigEntry->getName();
-    }
+    Cache = cloneContentCache(ContentCacheAlloc, IR);
+    Cache->OrigEntry = SourceFile;
+    FileIDContentCaches.push_back(Cache);
   }
 
   // If this is a named pipe, immediately load the buffer to ensure subsequent

--- a/clang/test/DebugInfo/Generic/macro.c
+++ b/clang/test/DebugInfo/Generic/macro.c
@@ -39,13 +39,13 @@
 // CHECK:  [[UndefA]] = !DIMacro(type: DW_MACINFO_undef, line: 11, name: "A")
 
 // CHECK:  [[DefineD1]] = !DIMacro(type: DW_MACINFO_define, line: 15, name: "D1", value: "1")
-// CHECK:  [[FileInclude1]] = !DIMacroFile(line: 16, file: [[HeaderFile]], nodes: [[N3:![0-9]+]])
+// CHECK:  [[FileInclude1]] = !DIMacroFile(line: 16, file: [[SourceIncludeHeaderFile:![0-9]+]], nodes: [[N3:![0-9]+]])
 // CHECK:  [[N3]] = !{[[DefineAx:![0-9]+]], [[UndefA]]}
 // CHECK:  [[DefineAx]] = !DIMacro(type: DW_MACINFO_define, line: 3, name: "A(x,y,z)", value: "(x)")
 // CHECK:  [[UndefD1]] = !DIMacro(type: DW_MACINFO_undef, line: 17, name: "D1") 
 
 // CHECK:  [[DefineD2]] = !DIMacro(type: DW_MACINFO_define, line: 18, name: "D2", value: "2")
-// CHECK:  [[FileInclude2]] = !DIMacroFile(line: 19, file: [[HeaderFile]], nodes: [[N4:![0-9]+]])
+// CHECK:  [[FileInclude2]] = !DIMacroFile(line: 19, file: [[SourceIncludeHeaderFile]], nodes: [[N4:![0-9]+]])
 // CHECK:  [[N4]] = !{[[DefineAy:![0-9]+]], [[UndefA]]}
 // CHECK:  [[DefineAy]] = !DIMacro(type: DW_MACINFO_define, line: 7, name: "A(x,y,z)", value: "(y)")
 // CHECK:  [[UndefD2]] = !DIMacro(type: DW_MACINFO_undef, line: 20, name: "D2")

--- a/clang/test/Preprocessor/hardlink-include-names.c
+++ b/clang/test/Preprocessor/hardlink-include-names.c
@@ -1,0 +1,42 @@
+// Test that symlinked and hardlinked files are reported with their correct
+// filenames
+//
+// REQUIRES: symlinks
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+// RUN: ln %t/foo.inc %t/bar.inc
+// RUN: ln -s %t/foo.inc %t/baz.inc
+
+// Test 1: -E should show both filenames.
+// RUN: %clang_cc1 -E %t/main.c -o - | FileCheck --check-prefix=PP %s
+// PP: # 1 "{{.*(/|\\\\)}}foo.inc" 1
+// PP: # 1 "{{.*(/|\\\\)}}bar.inc" 1
+// PP: # 1 "{{.*(/|\\\\)}}baz.inc" 1
+
+// Test 2: .d should list both filenames.
+// RUN: %clang_cc1 -dependency-file %t/deps.d -MT main.o %t/main.c -fsyntax-only
+// RUN: FileCheck --check-prefix=DEPS -input-file=%t/deps.d %s
+// DEPS: foo.inc
+// DEPS: bar.inc
+// DEPS: baz.inc
+
+// Test 3: --show-includes should list both filenames.
+// RUN: %clang_cc1 --show-includes -o /dev/null %t/main.c | \
+// RUN:   FileCheck --check-prefix=SHOW %s
+// SHOW: Note: including file: {{.*}}foo.inc
+// SHOW: Note: including file: {{.*}}bar.inc
+// SHOW: Note: including file: {{.*}}baz.inc
+
+//--- main.c
+const char *a =
+#include "foo.inc"
+;
+const char *b =
+#include "bar.inc"
+;
+const char *c =
+#include "baz.inc"
+;
+
+//--- foo.inc
+"contents"

--- a/clang/unittests/Basic/SourceManagerTest.cpp
+++ b/clang/unittests/Basic/SourceManagerTest.cpp
@@ -40,22 +40,20 @@ public:
 
 namespace {
 
-#ifndef _WIN32
-
 class FakeStatCache : public FileSystemStatCache {
   llvm::StringMap<llvm::vfs::Status, llvm::BumpPtrAllocator> StatCalls;
 
 public:
-  void InjectFile(StringRef Path, ino_t INode) {
+  void InjectFile(StringRef Path, uint64_t File) {
     StatCalls[Path] = llvm::vfs::Status(
-        Path, llvm::sys::fs::UniqueID(1, INode), /*MTime=*/{},
+        Path, llvm::sys::fs::UniqueID(1, File), /*MTime=*/{},
         /*User=*/0, /*Group=*/0, /*Size=*/0,
         llvm::sys::fs::file_type::regular_file, llvm::sys::fs::perms::all_all);
   }
 
-  void InjectDirectory(StringRef Path, ino_t INode) {
+  void InjectDirectory(StringRef Path, uint64_t File) {
     StatCalls[Path] =
-        llvm::vfs::Status(Path, llvm::sys::fs::UniqueID(1, INode), /*MTime=*/{},
+        llvm::vfs::Status(Path, llvm::sys::fs::UniqueID(1, File), /*MTime=*/{},
                           /*User=*/0, /*Group=*/0, /*Size=*/0,
                           llvm::sys::fs::file_type::directory_file,
                           llvm::sys::fs::perms::all_all);
@@ -71,8 +69,6 @@ public:
     return std::error_code();
   }
 };
-
-#endif
 
 // The test fixture.
 class SourceManagerTest : public ::testing::Test {
@@ -453,17 +449,25 @@ TEST_F(SourceManagerTest, getLineNumber) {
   ASSERT_NO_FATAL_FAILURE(SourceMgr.getLineNumber(mainFileID, 1, nullptr));
 }
 
-#ifndef _WIN32
-
 TEST_F(SourceManagerTest, aliasedFilesKeepRequestedNamesPerFileID) {
+#ifdef _WIN32
+  constexpr StringRef DirPath = "dir";
+  constexpr StringRef FooPath = "dir\\foo.h";
+  constexpr StringRef BarPath = "dir\\bar.h";
+#else
+  constexpr StringRef DirPath = "dir";
+  constexpr StringRef FooPath = "dir/foo.h";
+  constexpr StringRef BarPath = "dir/bar.h";
+#endif
+
   auto StatCache = std::make_unique<FakeStatCache>();
-  StatCache->InjectDirectory("dir", 40);
-  StatCache->InjectFile("dir/foo.h", 41);
-  StatCache->InjectFile("dir/bar.h", 41);
+  StatCache->InjectDirectory(DirPath, 40);
+  StatCache->InjectFile(FooPath, 41);
+  StatCache->InjectFile(BarPath, 41);
   FileMgr.setStatCache(std::move(StatCache));
 
-  auto FooOrErr = FileMgr.getFileRef("dir/foo.h");
-  auto BarOrErr = FileMgr.getFileRef("dir/bar.h");
+  auto FooOrErr = FileMgr.getFileRef(FooPath);
+  auto BarOrErr = FileMgr.getFileRef(BarPath);
   ASSERT_TRUE(static_cast<bool>(FooOrErr));
   ASSERT_TRUE(static_cast<bool>(BarOrErr));
 
@@ -480,12 +484,93 @@ TEST_F(SourceManagerTest, aliasedFilesKeepRequestedNamesPerFileID) {
   SourceLocation FooLoc = SourceMgr.getLocForStartOfFile(FooID);
   SourceLocation BarLoc = SourceMgr.getLocForStartOfFile(BarID);
 
-  EXPECT_EQ("dir/foo.h", SourceMgr.getFilename(FooLoc));
-  EXPECT_EQ("dir/bar.h", SourceMgr.getFilename(BarLoc));
-  EXPECT_STREQ("dir/foo.h", SourceMgr.getPresumedLoc(FooLoc).getFilename());
-  EXPECT_STREQ("dir/bar.h", SourceMgr.getPresumedLoc(BarLoc).getFilename());
+  EXPECT_EQ(FooPath, SourceMgr.getFilename(FooLoc));
+  EXPECT_EQ(BarPath, SourceMgr.getFilename(BarLoc));
+  EXPECT_STREQ(FooPath.data(), SourceMgr.getPresumedLoc(FooLoc).getFilename());
+  EXPECT_STREQ(BarPath.data(), SourceMgr.getPresumedLoc(BarLoc).getFilename());
 }
 
+TEST_F(SourceManagerTest, equivalentPathSpellingsReuseOriginalFileName) {
+#ifdef _WIN32
+  constexpr StringRef DirPath = "dir";
+  constexpr StringRef DotDirPath = ".\\dir";
+  constexpr StringRef FooPath = "dir\\foo.h";
+  constexpr StringRef DotFooPath = ".\\dir\\foo.h";
+#else
+  constexpr StringRef DirPath = "dir";
+  constexpr StringRef DotDirPath = "./dir";
+  constexpr StringRef FooPath = "dir/foo.h";
+  constexpr StringRef DotFooPath = "./dir/foo.h";
+#endif
+
+  auto StatCache = std::make_unique<FakeStatCache>();
+  StatCache->InjectDirectory(DirPath, 40);
+  StatCache->InjectDirectory(DotDirPath, 40);
+  StatCache->InjectFile(FooPath, 41);
+  StatCache->InjectFile(DotFooPath, 41);
+  FileMgr.setStatCache(std::move(StatCache));
+
+  auto FooOrErr = FileMgr.getFileRef(FooPath);
+  auto DotFooOrErr = FileMgr.getFileRef(DotFooPath);
+  ASSERT_TRUE(static_cast<bool>(FooOrErr));
+  ASSERT_TRUE(static_cast<bool>(DotFooOrErr));
+
+  FileEntryRef Foo = *FooOrErr;
+  FileEntryRef DotFoo = *DotFooOrErr;
+  EXPECT_FALSE(Foo.isSameRef(DotFoo));
+  EXPECT_EQ(Foo, DotFoo);
+
+  SourceMgr.overrideFileContents(Foo, llvm::MemoryBuffer::getMemBuffer("x\n"));
+
+  FileID FooID = SourceMgr.createFileID(Foo, SourceLocation(), SrcMgr::C_User);
+  FileID DotFooID =
+      SourceMgr.createFileID(DotFoo, SourceLocation(), SrcMgr::C_User);
+
+  SourceLocation FooLoc = SourceMgr.getLocForStartOfFile(FooID);
+  SourceLocation DotFooLoc = SourceMgr.getLocForStartOfFile(DotFooID);
+
+  EXPECT_EQ(FooPath, SourceMgr.getFilename(FooLoc));
+  EXPECT_EQ(FooPath, SourceMgr.getFilename(DotFooLoc));
+  EXPECT_STREQ(FooPath.data(), SourceMgr.getPresumedLoc(FooLoc).getFilename());
+  EXPECT_STREQ(FooPath.data(),
+               SourceMgr.getPresumedLoc(DotFooLoc).getFilename());
+  EXPECT_EQ(FooPath, *SourceMgr.getNonBuiltinFilenameForID(DotFooID));
+}
+
+#ifdef _WIN32
+TEST_F(SourceManagerTest, windowsEquivalentPathSpellingsReuseOriginalFileName) {
+  auto StatCache = std::make_unique<FakeStatCache>();
+  StatCache->InjectDirectory("dir", 40);
+  StatCache->InjectDirectory(".\\DIR", 40);
+  StatCache->InjectFile("dir/foo.h", 41);
+  StatCache->InjectFile(".\\DIR\\foo.h", 41);
+  FileMgr.setStatCache(std::move(StatCache));
+
+  auto FooOrErr = FileMgr.getFileRef("dir/foo.h");
+  auto WinFooOrErr = FileMgr.getFileRef(".\\DIR\\foo.h");
+  ASSERT_TRUE(static_cast<bool>(FooOrErr));
+  ASSERT_TRUE(static_cast<bool>(WinFooOrErr));
+
+  FileEntryRef Foo = *FooOrErr;
+  FileEntryRef WinFoo = *WinFooOrErr;
+  EXPECT_FALSE(Foo.isSameRef(WinFoo));
+  EXPECT_EQ(Foo, WinFoo);
+
+  SourceMgr.overrideFileContents(Foo, llvm::MemoryBuffer::getMemBuffer("x\n"));
+
+  FileID FooID = SourceMgr.createFileID(Foo, SourceLocation(), SrcMgr::C_User);
+  FileID WinFooID =
+      SourceMgr.createFileID(WinFoo, SourceLocation(), SrcMgr::C_User);
+
+  SourceLocation FooLoc = SourceMgr.getLocForStartOfFile(FooID);
+  SourceLocation WinFooLoc = SourceMgr.getLocForStartOfFile(WinFooID);
+
+  EXPECT_EQ("dir/foo.h", SourceMgr.getFilename(FooLoc));
+  EXPECT_EQ("dir/foo.h", SourceMgr.getFilename(WinFooLoc));
+  EXPECT_STREQ("dir/foo.h", SourceMgr.getPresumedLoc(FooLoc).getFilename());
+  EXPECT_STREQ("dir/foo.h", SourceMgr.getPresumedLoc(WinFooLoc).getFilename());
+  EXPECT_EQ("dir/foo.h", *SourceMgr.getNonBuiltinFilenameForID(WinFooID));
+}
 #endif
 
 struct FakeExternalSLocEntrySource : ExternalSLocEntrySource {

--- a/clang/unittests/Basic/SourceManagerTest.cpp
+++ b/clang/unittests/Basic/SourceManagerTest.cpp
@@ -10,7 +10,6 @@
 #include "clang/Basic/Diagnostic.h"
 #include "clang/Basic/DiagnosticOptions.h"
 #include "clang/Basic/FileManager.h"
-#include "clang/Basic/FileSystemStatCache.h"
 #include "clang/Basic/LangOptions.h"
 #include "clang/Basic/TargetInfo.h"
 #include "clang/Basic/TargetOptions.h"
@@ -40,48 +39,30 @@ public:
 
 namespace {
 
-class FakeStatCache : public FileSystemStatCache {
-  llvm::StringMap<llvm::vfs::Status, llvm::BumpPtrAllocator> StatCalls;
-
-public:
-  void InjectFile(StringRef Path, uint64_t File) {
-    StatCalls[Path] = llvm::vfs::Status(
-        Path, llvm::sys::fs::UniqueID(1, File), /*MTime=*/{},
-        /*User=*/0, /*Group=*/0, /*Size=*/0,
-        llvm::sys::fs::file_type::regular_file, llvm::sys::fs::perms::all_all);
-  }
-
-  void InjectDirectory(StringRef Path, uint64_t File) {
-    StatCalls[Path] =
-        llvm::vfs::Status(Path, llvm::sys::fs::UniqueID(1, File), /*MTime=*/{},
-                          /*User=*/0, /*Group=*/0, /*Size=*/0,
-                          llvm::sys::fs::file_type::directory_file,
-                          llvm::sys::fs::perms::all_all);
-  }
-
-  std::error_code getStat(StringRef Path, llvm::vfs::Status &Status,
-                          bool isFile, std::unique_ptr<llvm::vfs::File> *F,
-                          llvm::vfs::FileSystem &FS) override {
-    auto It = StatCalls.find(Path);
-    if (It == StatCalls.end())
-      return std::make_error_code(std::errc::no_such_file_or_directory);
-    Status = It->second;
-    return std::error_code();
-  }
-};
-
 // The test fixture.
 class SourceManagerTest : public ::testing::Test {
 protected:
   SourceManagerTest()
-      : FileMgr(FileMgrOpts),
+      : FileMgr(FileMgrOpts, FS),
         Diags(DiagnosticIDs::create(), DiagOpts, new IgnoringDiagConsumer()),
         SourceMgr(Diags, FileMgr), TargetOpts(new TargetOptions) {
     TargetOpts->Triple = "x86_64-apple-darwin11.1.0";
     Target = TargetInfo::CreateTargetInfo(Diags, *TargetOpts);
   }
 
+  void AddFile(StringRef Path) {
+    ASSERT_TRUE(FS->addFile(Path, /*ModificationTime=*/0,
+                            llvm::MemoryBuffer::getMemBuffer("x\n")));
+  }
+
+  void AddHardLink(StringRef NewLink, StringRef Target) {
+    ASSERT_TRUE(FS->addHardLink(NewLink, Target));
+  }
+
   FileSystemOptions FileMgrOpts;
+  IntrusiveRefCntPtr<llvm::vfs::InMemoryFileSystem> FS =
+      llvm::makeIntrusiveRefCnt<llvm::vfs::InMemoryFileSystem>(
+          /*UseNormalizedPaths=*/false);
   FileManager FileMgr;
   DiagnosticOptions DiagOpts;
   DiagnosticsEngine Diags;
@@ -451,20 +432,15 @@ TEST_F(SourceManagerTest, getLineNumber) {
 
 TEST_F(SourceManagerTest, aliasedFilesKeepRequestedNamesPerFileID) {
 #ifdef _WIN32
-  constexpr StringRef DirPath = "dir";
-  constexpr StringRef FooPath = "dir\\foo.h";
-  constexpr StringRef BarPath = "dir\\bar.h";
+  constexpr StringRef FooPath = "C:\\dir\\foo.h";
+  constexpr StringRef BarPath = "C:\\dir\\bar.h";
 #else
-  constexpr StringRef DirPath = "dir";
-  constexpr StringRef FooPath = "dir/foo.h";
-  constexpr StringRef BarPath = "dir/bar.h";
+  constexpr StringRef FooPath = "/dir/foo.h";
+  constexpr StringRef BarPath = "/dir/bar.h";
 #endif
 
-  auto StatCache = std::make_unique<FakeStatCache>();
-  StatCache->InjectDirectory(DirPath, 40);
-  StatCache->InjectFile(FooPath, 41);
-  StatCache->InjectFile(BarPath, 41);
-  FileMgr.setStatCache(std::move(StatCache));
+  AddFile(FooPath);
+  AddHardLink(BarPath, FooPath);
 
   auto FooOrErr = FileMgr.getFileRef(FooPath);
   auto BarOrErr = FileMgr.getFileRef(BarPath);
@@ -490,25 +466,17 @@ TEST_F(SourceManagerTest, aliasedFilesKeepRequestedNamesPerFileID) {
   EXPECT_STREQ(BarPath.data(), SourceMgr.getPresumedLoc(BarLoc).getFilename());
 }
 
-TEST_F(SourceManagerTest, equivalentPathSpellingsReuseOriginalFileName) {
+TEST_F(SourceManagerTest, dotPathSpellingsKeepRequestedNamesPerFileID) {
 #ifdef _WIN32
-  constexpr StringRef DirPath = "dir";
-  constexpr StringRef DotDirPath = ".\\dir";
-  constexpr StringRef FooPath = "dir\\foo.h";
-  constexpr StringRef DotFooPath = ".\\dir\\foo.h";
+  constexpr StringRef FooPath = "C:\\dir\\foo.h";
+  constexpr StringRef DotFooPath = "C:\\.\\dir\\foo.h";
 #else
-  constexpr StringRef DirPath = "dir";
-  constexpr StringRef DotDirPath = "./dir";
-  constexpr StringRef FooPath = "dir/foo.h";
-  constexpr StringRef DotFooPath = "./dir/foo.h";
+  constexpr StringRef FooPath = "/dir/foo.h";
+  constexpr StringRef DotFooPath = "/./dir/foo.h";
 #endif
 
-  auto StatCache = std::make_unique<FakeStatCache>();
-  StatCache->InjectDirectory(DirPath, 40);
-  StatCache->InjectDirectory(DotDirPath, 40);
-  StatCache->InjectFile(FooPath, 41);
-  StatCache->InjectFile(DotFooPath, 41);
-  FileMgr.setStatCache(std::move(StatCache));
+  AddFile(FooPath);
+  AddHardLink(DotFooPath, FooPath);
 
   auto FooOrErr = FileMgr.getFileRef(FooPath);
   auto DotFooOrErr = FileMgr.getFileRef(DotFooPath);
@@ -530,24 +498,59 @@ TEST_F(SourceManagerTest, equivalentPathSpellingsReuseOriginalFileName) {
   SourceLocation DotFooLoc = SourceMgr.getLocForStartOfFile(DotFooID);
 
   EXPECT_EQ(FooPath, SourceMgr.getFilename(FooLoc));
-  EXPECT_EQ(FooPath, SourceMgr.getFilename(DotFooLoc));
+  EXPECT_EQ(DotFooPath, SourceMgr.getFilename(DotFooLoc));
   EXPECT_STREQ(FooPath.data(), SourceMgr.getPresumedLoc(FooLoc).getFilename());
-  EXPECT_STREQ(FooPath.data(),
+  EXPECT_STREQ(DotFooPath.data(),
                SourceMgr.getPresumedLoc(DotFooLoc).getFilename());
-  EXPECT_EQ(FooPath, *SourceMgr.getNonBuiltinFilenameForID(DotFooID));
+  EXPECT_EQ(DotFooPath, *SourceMgr.getNonBuiltinFilenameForID(DotFooID));
+}
+
+TEST_F(SourceManagerTest, dotDotPathSpellingsKeepRequestedNamesPerFileID) {
+#ifdef _WIN32
+  constexpr StringRef BPath = "C:\\a\\b\\..\\c.h";
+  constexpr StringRef XPath = "C:\\a\\x\\..\\c.h";
+#else
+  constexpr StringRef BPath = "/a/b/../c.h";
+  constexpr StringRef XPath = "/a/x/../c.h";
+#endif
+
+  AddFile(BPath);
+  AddHardLink(XPath, BPath);
+
+  auto BOrErr = FileMgr.getFileRef(BPath);
+  auto XOrErr = FileMgr.getFileRef(XPath);
+  ASSERT_TRUE(static_cast<bool>(BOrErr));
+  ASSERT_TRUE(static_cast<bool>(XOrErr));
+
+  FileEntryRef B = *BOrErr;
+  FileEntryRef X = *XOrErr;
+  EXPECT_FALSE(B.isSameRef(X));
+  EXPECT_EQ(B, X);
+
+  SourceMgr.overrideFileContents(B, llvm::MemoryBuffer::getMemBuffer("x\n"));
+
+  FileID BID = SourceMgr.createFileID(B, SourceLocation(), SrcMgr::C_User);
+  FileID XID = SourceMgr.createFileID(X, SourceLocation(), SrcMgr::C_User);
+
+  SourceLocation BLoc = SourceMgr.getLocForStartOfFile(BID);
+  SourceLocation XLoc = SourceMgr.getLocForStartOfFile(XID);
+
+  EXPECT_EQ(BPath, SourceMgr.getFilename(BLoc));
+  EXPECT_EQ(XPath, SourceMgr.getFilename(XLoc));
+  EXPECT_STREQ(BPath.data(), SourceMgr.getPresumedLoc(BLoc).getFilename());
+  EXPECT_STREQ(XPath.data(), SourceMgr.getPresumedLoc(XLoc).getFilename());
+  EXPECT_EQ(XPath, *SourceMgr.getNonBuiltinFilenameForID(XID));
 }
 
 #ifdef _WIN32
-TEST_F(SourceManagerTest, windowsEquivalentPathSpellingsReuseOriginalFileName) {
-  auto StatCache = std::make_unique<FakeStatCache>();
-  StatCache->InjectDirectory("dir", 40);
-  StatCache->InjectDirectory(".\\DIR", 40);
-  StatCache->InjectFile("dir/foo.h", 41);
-  StatCache->InjectFile(".\\DIR\\foo.h", 41);
-  FileMgr.setStatCache(std::move(StatCache));
+TEST_F(SourceManagerTest, windowsSeparatorSpellingsReuseOriginalFileName) {
+  constexpr StringRef FooPath = "C:/dir/foo.h";
+  constexpr StringRef WinFooPath = "C:\\dir\\foo.h";
 
-  auto FooOrErr = FileMgr.getFileRef("dir/foo.h");
-  auto WinFooOrErr = FileMgr.getFileRef(".\\DIR\\foo.h");
+  AddFile(FooPath);
+
+  auto FooOrErr = FileMgr.getFileRef(FooPath);
+  auto WinFooOrErr = FileMgr.getFileRef(WinFooPath);
   ASSERT_TRUE(static_cast<bool>(FooOrErr));
   ASSERT_TRUE(static_cast<bool>(WinFooOrErr));
 
@@ -565,11 +568,12 @@ TEST_F(SourceManagerTest, windowsEquivalentPathSpellingsReuseOriginalFileName) {
   SourceLocation FooLoc = SourceMgr.getLocForStartOfFile(FooID);
   SourceLocation WinFooLoc = SourceMgr.getLocForStartOfFile(WinFooID);
 
-  EXPECT_EQ("dir/foo.h", SourceMgr.getFilename(FooLoc));
-  EXPECT_EQ("dir/foo.h", SourceMgr.getFilename(WinFooLoc));
-  EXPECT_STREQ("dir/foo.h", SourceMgr.getPresumedLoc(FooLoc).getFilename());
-  EXPECT_STREQ("dir/foo.h", SourceMgr.getPresumedLoc(WinFooLoc).getFilename());
-  EXPECT_EQ("dir/foo.h", *SourceMgr.getNonBuiltinFilenameForID(WinFooID));
+  EXPECT_EQ(FooPath, SourceMgr.getFilename(FooLoc));
+  EXPECT_EQ(FooPath, SourceMgr.getFilename(WinFooLoc));
+  EXPECT_STREQ(FooPath.data(), SourceMgr.getPresumedLoc(FooLoc).getFilename());
+  EXPECT_STREQ(FooPath.data(),
+               SourceMgr.getPresumedLoc(WinFooLoc).getFilename());
+  EXPECT_EQ(FooPath, *SourceMgr.getNonBuiltinFilenameForID(WinFooID));
 }
 #endif
 

--- a/clang/unittests/Basic/SourceManagerTest.cpp
+++ b/clang/unittests/Basic/SourceManagerTest.cpp
@@ -548,6 +548,7 @@ TEST_F(SourceManagerTest, windowsSeparatorSpellingsReuseOriginalFileName) {
   constexpr StringRef WinFooPath = "C:\\dir\\foo.h";
 
   AddFile(FooPath);
+  AddHardLink(WinFooPath, FooPath);
 
   auto FooOrErr = FileMgr.getFileRef(FooPath);
   auto WinFooOrErr = FileMgr.getFileRef(WinFooPath);

--- a/clang/unittests/Basic/SourceManagerTest.cpp
+++ b/clang/unittests/Basic/SourceManagerTest.cpp
@@ -542,42 +542,6 @@ TEST_F(SourceManagerTest, dotDotPathSpellingsKeepRequestedNamesPerFileID) {
   EXPECT_EQ(XPath, *SourceMgr.getNonBuiltinFilenameForID(XID));
 }
 
-#ifdef _WIN32
-TEST_F(SourceManagerTest, windowsSeparatorSpellingsReuseOriginalFileName) {
-  constexpr StringRef FooPath = "C:/dir/foo.h";
-  constexpr StringRef WinFooPath = "C:\\dir\\foo.h";
-
-  AddFile(FooPath);
-  AddHardLink(WinFooPath, FooPath);
-
-  auto FooOrErr = FileMgr.getFileRef(FooPath);
-  auto WinFooOrErr = FileMgr.getFileRef(WinFooPath);
-  ASSERT_TRUE(static_cast<bool>(FooOrErr));
-  ASSERT_TRUE(static_cast<bool>(WinFooOrErr));
-
-  FileEntryRef Foo = *FooOrErr;
-  FileEntryRef WinFoo = *WinFooOrErr;
-  EXPECT_FALSE(Foo.isSameRef(WinFoo));
-  EXPECT_EQ(Foo, WinFoo);
-
-  SourceMgr.overrideFileContents(Foo, llvm::MemoryBuffer::getMemBuffer("x\n"));
-
-  FileID FooID = SourceMgr.createFileID(Foo, SourceLocation(), SrcMgr::C_User);
-  FileID WinFooID =
-      SourceMgr.createFileID(WinFoo, SourceLocation(), SrcMgr::C_User);
-
-  SourceLocation FooLoc = SourceMgr.getLocForStartOfFile(FooID);
-  SourceLocation WinFooLoc = SourceMgr.getLocForStartOfFile(WinFooID);
-
-  EXPECT_EQ(FooPath, SourceMgr.getFilename(FooLoc));
-  EXPECT_EQ(FooPath, SourceMgr.getFilename(WinFooLoc));
-  EXPECT_STREQ(FooPath.data(), SourceMgr.getPresumedLoc(FooLoc).getFilename());
-  EXPECT_STREQ(FooPath.data(),
-               SourceMgr.getPresumedLoc(WinFooLoc).getFilename());
-  EXPECT_EQ(FooPath, *SourceMgr.getNonBuiltinFilenameForID(WinFooID));
-}
-#endif
-
 struct FakeExternalSLocEntrySource : ExternalSLocEntrySource {
   bool ReadSLocEntry(int ID) override { return {}; }
   int getSLocEntryID(SourceLocation::UIntTy SLocOffset) override { return 0; }

--- a/clang/unittests/Basic/SourceManagerTest.cpp
+++ b/clang/unittests/Basic/SourceManagerTest.cpp
@@ -50,16 +50,15 @@ public:
     StatCalls[Path] = llvm::vfs::Status(
         Path, llvm::sys::fs::UniqueID(1, INode), /*MTime=*/{},
         /*User=*/0, /*Group=*/0, /*Size=*/0,
-        llvm::sys::fs::file_type::regular_file,
-        llvm::sys::fs::perms::all_all);
+        llvm::sys::fs::file_type::regular_file, llvm::sys::fs::perms::all_all);
   }
 
   void InjectDirectory(StringRef Path, ino_t INode) {
-    StatCalls[Path] = llvm::vfs::Status(
-        Path, llvm::sys::fs::UniqueID(1, INode), /*MTime=*/{},
-        /*User=*/0, /*Group=*/0, /*Size=*/0,
-        llvm::sys::fs::file_type::directory_file,
-        llvm::sys::fs::perms::all_all);
+    StatCalls[Path] =
+        llvm::vfs::Status(Path, llvm::sys::fs::UniqueID(1, INode), /*MTime=*/{},
+                          /*User=*/0, /*Group=*/0, /*Size=*/0,
+                          llvm::sys::fs::file_type::directory_file,
+                          llvm::sys::fs::perms::all_all);
   }
 
   std::error_code getStat(StringRef Path, llvm::vfs::Status &Status,

--- a/clang/unittests/Basic/SourceManagerTest.cpp
+++ b/clang/unittests/Basic/SourceManagerTest.cpp
@@ -10,6 +10,7 @@
 #include "clang/Basic/Diagnostic.h"
 #include "clang/Basic/DiagnosticOptions.h"
 #include "clang/Basic/FileManager.h"
+#include "clang/Basic/FileSystemStatCache.h"
 #include "clang/Basic/LangOptions.h"
 #include "clang/Basic/TargetInfo.h"
 #include "clang/Basic/TargetOptions.h"
@@ -22,6 +23,7 @@
 #include "llvm/Config/llvm-config.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/Process.h"
+#include "llvm/Support/VirtualFileSystem.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include <cstddef>
@@ -37,6 +39,41 @@ public:
 } // namespace clang
 
 namespace {
+
+#ifndef _WIN32
+
+class FakeStatCache : public FileSystemStatCache {
+  llvm::StringMap<llvm::vfs::Status, llvm::BumpPtrAllocator> StatCalls;
+
+public:
+  void InjectFile(StringRef Path, ino_t INode) {
+    StatCalls[Path] = llvm::vfs::Status(
+        Path, llvm::sys::fs::UniqueID(1, INode), /*MTime=*/{},
+        /*User=*/0, /*Group=*/0, /*Size=*/0,
+        llvm::sys::fs::file_type::regular_file,
+        llvm::sys::fs::perms::all_all);
+  }
+
+  void InjectDirectory(StringRef Path, ino_t INode) {
+    StatCalls[Path] = llvm::vfs::Status(
+        Path, llvm::sys::fs::UniqueID(1, INode), /*MTime=*/{},
+        /*User=*/0, /*Group=*/0, /*Size=*/0,
+        llvm::sys::fs::file_type::directory_file,
+        llvm::sys::fs::perms::all_all);
+  }
+
+  std::error_code getStat(StringRef Path, llvm::vfs::Status &Status,
+                          bool isFile, std::unique_ptr<llvm::vfs::File> *F,
+                          llvm::vfs::FileSystem &FS) override {
+    auto It = StatCalls.find(Path);
+    if (It == StatCalls.end())
+      return std::make_error_code(std::errc::no_such_file_or_directory);
+    Status = It->second;
+    return std::error_code();
+  }
+};
+
+#endif
 
 // The test fixture.
 class SourceManagerTest : public ::testing::Test {
@@ -416,6 +453,41 @@ TEST_F(SourceManagerTest, getLineNumber) {
 
   ASSERT_NO_FATAL_FAILURE(SourceMgr.getLineNumber(mainFileID, 1, nullptr));
 }
+
+#ifndef _WIN32
+
+TEST_F(SourceManagerTest, aliasedFilesKeepRequestedNamesPerFileID) {
+  auto StatCache = std::make_unique<FakeStatCache>();
+  StatCache->InjectDirectory("dir", 40);
+  StatCache->InjectFile("dir/foo.h", 41);
+  StatCache->InjectFile("dir/bar.h", 41);
+  FileMgr.setStatCache(std::move(StatCache));
+
+  auto FooOrErr = FileMgr.getFileRef("dir/foo.h");
+  auto BarOrErr = FileMgr.getFileRef("dir/bar.h");
+  ASSERT_TRUE(static_cast<bool>(FooOrErr));
+  ASSERT_TRUE(static_cast<bool>(BarOrErr));
+
+  FileEntryRef Foo = *FooOrErr;
+  FileEntryRef Bar = *BarOrErr;
+  EXPECT_FALSE(Foo.isSameRef(Bar));
+  EXPECT_EQ(Foo, Bar);
+
+  SourceMgr.overrideFileContents(Foo, llvm::MemoryBuffer::getMemBuffer("x\n"));
+
+  FileID FooID = SourceMgr.createFileID(Foo, SourceLocation(), SrcMgr::C_User);
+  FileID BarID = SourceMgr.createFileID(Bar, SourceLocation(), SrcMgr::C_User);
+
+  SourceLocation FooLoc = SourceMgr.getLocForStartOfFile(FooID);
+  SourceLocation BarLoc = SourceMgr.getLocForStartOfFile(BarID);
+
+  EXPECT_EQ("dir/foo.h", SourceMgr.getFilename(FooLoc));
+  EXPECT_EQ("dir/bar.h", SourceMgr.getFilename(BarLoc));
+  EXPECT_STREQ("dir/foo.h", SourceMgr.getPresumedLoc(FooLoc).getFilename());
+  EXPECT_STREQ("dir/bar.h", SourceMgr.getPresumedLoc(BarLoc).getFilename());
+}
+
+#endif
 
 struct FakeExternalSLocEntrySource : ExternalSLocEntrySource {
   bool ReadSLocEntry(int ID) override { return {}; }


### PR DESCRIPTION
Previously hardlinked files would be discovered based on their inode,
leading to incorrect filepaths printed in some cases.

Fixes https://github.com/llvm/llvm-project/issues/26953
Fixes https://github.com/llvm/llvm-project/issues/58726

Related https://reviews.llvm.org/D137304

Assisted-by: codex