### PR TITLE
[mlir][OpenACC] Fold acc_on_device in device-specialized routines

### DIFF
--- a/mlir/lib/Dialect/OpenACC/Transforms/ACCSpecializeForDevice.cpp
+++ b/mlir/lib/Dialect/OpenACC/Transforms/ACCSpecializeForDevice.cpp
@@ -57,6 +57,7 @@
 
 #include "mlir/Dialect/OpenACC/Transforms/Passes.h"
 
+#include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/OpenACC/OpenACC.h"
 #include "mlir/Dialect/OpenACC/Transforms/ACCSpecializePatterns.h"
@@ -74,6 +75,100 @@ using namespace mlir;
 using namespace mlir::acc;
 
 namespace {
+
+// acc_device_t values used by acc_on_device.
+// The numeric values match the openacc.h convention.
+enum AccDeviceType {
+  ACC_DEVICE_HOST = 2,
+  ACC_DEVICE_NOT_HOST = 3,
+  ACC_DEVICE_NVIDIA = 4,
+};
+
+/// Return true if the given function declaration is `acc_on_device`.
+static bool isAccOnDeviceDecl(func::FuncOp funcDecl) {
+  if (!funcDecl || !funcDecl.isDeclaration())
+    return false;
+  auto bindcName = funcDecl->getAttrOfType<StringAttr>("fir.bindc_name");
+  if (bindcName && bindcName.getValue() == "acc_on_device")
+    return true;
+  return funcDecl.getSymName() == "acc_on_device";
+}
+
+/// Return true if `op` is a call to acc_on_device (by checking properties).
+static bool isAccOnDeviceCall(Operation *op) {
+  if (op->getNumOperands() != 1 || op->getNumResults() != 1)
+    return false;
+  auto mod = op->getParentOfType<ModuleOp>();
+  if (!mod)
+    return false;
+  Attribute props = op->getPropertiesAsAttribute();
+  if (!props)
+    return false;
+  auto dict = dyn_cast<DictionaryAttr>(props);
+  if (!dict)
+    return false;
+  auto callee = dict.getAs<SymbolRefAttr>("callee");
+  if (!callee)
+    return false;
+  auto *decl = mod.lookupSymbol(callee);
+  return decl && isAccOnDeviceDecl(dyn_cast<func::FuncOp>(decl));
+}
+
+/// Fold a call to acc_on_device with a constant argument in device code.
+/// On the device, acc_on_device(acc_device_host) is false, and
+/// acc_on_device(acc_device_not_host/acc_device_nvidia) is true.
+/// The call result (which may be a dialect-specific logical type) is typically
+/// converted to i1; we replace that i1 value with a constant so that
+/// dead-code elimination can remove the guarded host code.
+class FoldAccOnDeviceConversion : public RewritePattern {
+public:
+  FoldAccOnDeviceConversion(MLIRContext *context)
+      : RewritePattern(MatchAnyOpTypeTag(), /*benefit=*/1, context) {}
+
+  LogicalResult matchAndRewrite(Operation *op,
+                                PatternRewriter &rewriter) const override {
+    if (!isAccOnDeviceCall(op))
+      return failure();
+
+    Value arg = op->getOperand(0);
+    APInt constVal;
+    if (!matchPattern(arg, m_ConstantInt(&constVal)))
+      return failure();
+
+    int64_t deviceType = constVal.getSExtValue();
+    bool result;
+    switch (deviceType) {
+    case ACC_DEVICE_HOST:
+      result = false;
+      break;
+    case ACC_DEVICE_NOT_HOST:
+    case ACC_DEVICE_NVIDIA:
+      result = true;
+      break;
+    default:
+      return failure();
+    }
+
+    Value callResult = op->getResult(0);
+    bool changed = false;
+    for (Operation *user : llvm::make_early_inc_range(callResult.getUsers())) {
+      if (user->getNumResults() == 1 &&
+          user->getResult(0).getType().isInteger(1)) {
+        rewriter.setInsertionPoint(user);
+        Value i1Const = arith::ConstantOp::create(
+            rewriter, user->getLoc(), rewriter.getI1Type(),
+            rewriter.getIntegerAttr(rewriter.getI1Type(), result ? 1 : 0));
+        rewriter.replaceOp(user, i1Const);
+        changed = true;
+      }
+    }
+    if (callResult.use_empty()) {
+      rewriter.eraseOp(op);
+      return success();
+    }
+    return success(changed);
+  }
+};
 
 class ACCSpecializeForDevice
     : public acc::impl::ACCSpecializeForDeviceBase<ACCSpecializeForDevice> {
@@ -94,7 +189,8 @@ public:
       (void)applyPatternsGreedily(func, std::move(patterns), config);
     } else {
       // For non-specialized functions, apply patterns only to ACC operations
-      // inside compute constructs (not to the compute constructs themselves).
+      // and acc_on_device calls inside compute constructs (not to the compute
+      // constructs themselves).
       // Use ExistingOps strictness so the greedy driver does not expand the
       // worklist to parent ops, which would accidentally unwrap the compute
       // construct (e.g. after inlining acc routines with their own data
@@ -104,11 +200,13 @@ public:
       func.walk([&](Operation *op) {
         if (isa<ACC_COMPUTE_CONSTRUCT_OPS>(op)) {
           // Walk inside the compute construct and collect ACC ops
+          // and acc_on_device calls
           op->walk([&](Operation *innerOp) {
             // Skip the compute construct itself
             if (innerOp == op)
               return;
-            if (isa<acc::OpenACCDialect>(innerOp->getDialect()))
+            if (isa<acc::OpenACCDialect>(innerOp->getDialect()) ||
+                isAccOnDeviceCall(innerOp))
               opsToTransform.push_back(innerOp);
           });
         }
@@ -174,4 +272,8 @@ void mlir::acc::populateACCSpecializeForDevicePatterns(
       ACCOpEraseConversion<acc::InitOp>, ACCOpEraseConversion<acc::ShutdownOp>,
       ACCOpEraseConversion<acc::SetOp>, ACCOpEraseConversion<acc::WaitOp>>(
       context);
+
+  // Fold acc_on_device calls so dead-code elimination can remove
+  // host-only code paths in device code.
+  patterns.insert<FoldAccOnDeviceConversion>(context);
 }

--- a/mlir/test/Dialect/OpenACC/acc-specialize-for-device.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-specialize-for-device.mlir
@@ -230,3 +230,67 @@ func.func @dev_routine_declare() attributes {acc.specialized_routine = #acc.spec
   acc.declare_exit token(%t) dataOperands(%c : memref<f32>)
   return
 }
+
+//===----------------------------------------------------------------------===//
+// acc_on_device folding in specialized routines
+//===----------------------------------------------------------------------===//
+
+func.func private @acc_on_device(i32) -> i32 attributes {fir.bindc_name = "acc_on_device"}
+acc.routine @acc_routine_on_device_decl func(@acc_on_device) seq
+
+acc.routine @acc_routine_on_device_host func(@on_device_host) seq
+// CHECK-LABEL: func.func @on_device_host
+// CHECK-NOT:   call @acc_on_device
+// CHECK:       %[[FALSE:.*]] = arith.constant false
+// CHECK:       return %[[FALSE]] : i1
+func.func @on_device_host() -> i1 attributes {acc.specialized_routine = #acc.specialized_routine<@acc_routine_on_device_host, <seq>, "on_device_host">} {
+  %c2 = arith.constant 2 : i32
+  %0 = func.call @acc_on_device(%c2) : (i32) -> i32
+  %1 = arith.trunci %0 : i32 to i1
+  return %1 : i1
+}
+
+acc.routine @acc_routine_on_device_not_host func(@on_device_not_host) seq
+// CHECK-LABEL: func.func @on_device_not_host
+// CHECK-NOT:   call @acc_on_device
+// CHECK:       %[[TRUE:.*]] = arith.constant true
+// CHECK:       return %[[TRUE]] : i1
+func.func @on_device_not_host() -> i1 attributes {acc.specialized_routine = #acc.specialized_routine<@acc_routine_on_device_not_host, <seq>, "on_device_not_host">} {
+  %c3 = arith.constant 3 : i32
+  %0 = func.call @acc_on_device(%c3) : (i32) -> i32
+  %1 = arith.trunci %0 : i32 to i1
+  return %1 : i1
+}
+
+acc.routine @acc_routine_on_device_nvidia func(@on_device_nvidia) seq
+// CHECK-LABEL: func.func @on_device_nvidia
+// CHECK-NOT:   call @acc_on_device
+// CHECK:       %[[TRUE:.*]] = arith.constant true
+// CHECK:       return %[[TRUE]] : i1
+func.func @on_device_nvidia() -> i1 attributes {acc.specialized_routine = #acc.specialized_routine<@acc_routine_on_device_nvidia, <seq>, "on_device_nvidia">} {
+  %c4 = arith.constant 4 : i32
+  %0 = func.call @acc_on_device(%c4) : (i32) -> i32
+  %1 = arith.trunci %0 : i32 to i1
+  return %1 : i1
+}
+
+//===----------------------------------------------------------------------===//
+// acc_on_device folding inside compute constructs
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: func.func @on_device_in_kernels
+// CHECK:       acc.kernels
+// CHECK-NOT:   call @acc_on_device
+// CHECK:       %[[FALSE:.*]] = arith.constant false
+// CHECK:       arith.select %[[FALSE]]
+func.func @on_device_in_kernels(%arg0 : memref<i32>) {
+  %c2 = arith.constant 2 : i32
+  acc.kernels {
+    %0 = func.call @acc_on_device(%c2) : (i32) -> i32
+    %1 = arith.trunci %0 : i32 to i1
+    %2 = arith.select %1, %c2, %c2 : i32
+    memref.store %2, %arg0[] : memref<i32>
+    acc.terminator
+  }
+  return
+}


### PR DESCRIPTION
In device-specialized acc routines, `acc_on_device(acc_device_host)` is always false. Without folding, the guarded host-only code (e.g. string operations with malloc/free) survives into the GPU kernel because `PrivatizeKernelAllocations` hoists the temporaries before LLVM can eliminate the dead branch, resulting in illegal instruction errors at runtime.

Fold `acc_on_device` calls with constant arguments in the `acc-specialize-for-device` pass so that DCE can remove the dead code before kernel privatization.
